### PR TITLE
Spec: add MAINNET deployments stub (v1.1)

### DIFF
--- a/spec/RUBIN_L1_DEPLOYMENTS_MAINNET_v1.1.md
+++ b/spec/RUBIN_L1_DEPLOYMENTS_MAINNET_v1.1.md
@@ -1,0 +1,14 @@
+# RUBIN L1 Deployments — MAINNET v1.1
+
+Status: DRAFT (NON-CONSENSUS)  
+Date: 2026-02-16  
+Network: mainnet
+
+This file publishes the VERSION_BITS deployment schedule and activation states for the RUBIN v1.1 MAINNET chain instance.
+
+## v1.1 deployments
+
+No consensus deployments are scheduled for v1.1 MAINNET at this stage.
+
+All `deployment_bit` slots are `UNUSED` for MAINNET until an explicit governance decision publishes a non-empty deployment table.
+


### PR DESCRIPTION
Adds  as an explicit MAINNET deployment table placeholder (no deployments scheduled for v1.1). This matches the reference from the MAINNET chain-instance profile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added RUBIN v1.1 MAINNET deployment specification documenting the deployment schedule and confirming that no consensus deployments are scheduled for this release phase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->