### PR TITLE
CI: add SonarCloud analysis

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,28 @@
+name: sonarcloud
+# web-visible: true (see operational/WEB_VISIBLE_POLICY.md)
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  sonarcloud:
+    name: SonarCloud Analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarqube-scan-action@v5
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,34 @@
+sonar.organization=2tbmz9y2xt-lang
+sonar.projectKey=2tbmz9y2xt-lang_rubin-protocol
+sonar.projectName=rubin-protocol
+
+# Source paths
+sonar.sources=clients/rust,clients/go,crypto/wolfcrypt/shim,scripts,conformance/runner
+
+# Spec and docs (informational, no code analysis)
+# sonar.sources.docs=spec,operational,formal
+
+# Exclusions
+sonar.exclusions=\
+  **/target/**,\
+  **/bin/**,\
+  **/vendor/**,\
+  **/*.json,\
+  **/node_modules/**,\
+  **/*_test.go,\
+  **/*_test.rs,\
+  **/testdata/**,\
+  **/gosec_output.json,\
+  **/semgrep_output.json,\
+  **/cargo_audit.json
+
+# Test sources
+sonar.tests=clients/rust,clients/go
+sonar.test.inclusions=**/*_test.go,**/*_test.rs,**/tests/**
+
+# Language-specific
+sonar.go.file.suffixes=.go
+sonar.rust.file.suffixes=.rs
+
+# Encoding
+sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## What
- `sonar-project.properties` — project config (sources, exclusions, test paths)
- `.github/workflows/sonarcloud.yml` — runs on push to main + all PRs

## Setup required
1. Go to https://sonarcloud.io → Sign in with GitHub
2. Import `rubin-protocol` repository
3. Copy SONAR_TOKEN → add to GitHub repo Settings → Secrets → Actions → `SONAR_TOKEN`

## Consensus impact
None. CI-only change.