### PR TITLE
fix(ci): repair CircleCI config — correct paths, Go 1.25, add Rust job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,48 +1,71 @@
-# Use the latest 2.1 version of CircleCI pipeline process engine.
-# See: https://circleci.com/docs/reference/configuration-reference
-
-# For a detailed guide to building and testing with Go, read the docs:
-# https://circleci.com/docs/language-go/ for more details
 version: 2.1
 
-# Define a job to be invoked later in a workflow.
-# See: https://circleci.com/docs/guides/orchestrate/jobs-steps/#jobs-overview & https://circleci.com/docs/reference/configuration-reference/#jobs
 jobs:
-  build:
-    # Specify the execution environment. You can specify an image from Docker Hub or use one of our convenience images from CircleCI's Developer Hub.
-    # See: https://circleci.com/docs/guides/execution-managed/executor-intro/ & https://circleci.com/docs/reference/configuration-reference/#executor-job
+  build-go:
     docker:
-      # Specify the version you desire here
-      # See: https://circleci.com/developer/images/image/cimg/go
-      - image: cimg/go:1.21
-
-    # Add steps to the job
-    # See: https://circleci.com/docs/guides/orchestrate/jobs-steps/#steps-overview & https://circleci.com/docs/reference/configuration-reference/#steps
+      - image: cimg/go:1.25
     steps:
-      # Checkout the code as the first step.
       - checkout
       - restore_cache:
           keys:
-            - go-mod-v4-{{ checksum "go.sum" }}
+            - go-mod-v1-{{ checksum "clients/go/go.sum" }}
       - run:
-          name: Install Dependencies
+          name: Install dependencies
+          working_directory: clients/go
           command: go mod download
       - save_cache:
-          key: go-mod-v4-{{ checksum "go.sum" }}
+          key: go-mod-v1-{{ checksum "clients/go/go.sum" }}
           paths:
-            - "/go/pkg/mod"
+            - "/home/circleci/go/pkg/mod"
+      - run:
+          name: Build
+          working_directory: clients/go
+          command: go build ./...
       - run:
           name: Run tests
+          working_directory: clients/go
           command: |
             mkdir -p /tmp/test-reports
-            gotestsum --junitfile /tmp/test-reports/unit-tests.xml
+            go test -v -count=1 ./... 2>&1 | tee /tmp/test-reports/go-test.log
       - store_test_results:
           path: /tmp/test-reports
 
-# Orchestrate jobs using workflows
-# See: https://circleci.com/docs/guides/orchestrate/workflows/ & https://circleci.com/docs/reference/configuration-reference/#workflows
+  build-rust:
+    docker:
+      - image: cimg/rust:1.84
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - cargo-v1-{{ checksum "clients/rust/Cargo.lock" }}
+            - cargo-v1-
+      - run:
+          name: Build
+          working_directory: clients/rust
+          command: cargo build --release
+      - save_cache:
+          key: cargo-v1-{{ checksum "clients/rust/Cargo.lock" }}
+          paths:
+            - "~/.cargo/registry"
+            - "clients/rust/target"
+      - run:
+          name: Run tests
+          working_directory: clients/rust
+          command: cargo test --release
+
+  lint-conformance:
+    docker:
+      - image: cimg/python:3.12
+    steps:
+      - checkout
+      - run:
+          name: Lint conformance runners
+          working_directory: conformance/runner
+          command: python3 -m py_compile run_cv_sighash.py
+
 workflows:
-  sample: # This is the name of the workflow, feel free to change it to better match your workflow.
-    # Inside the workflow, you define the jobs you want to run.
+  ci:
     jobs:
-      - build
+      - build-go
+      - build-rust
+      - lint-conformance


### PR DESCRIPTION
## Проблема
Коммит 2508163 добавил шаблонный CircleCI конфиг, который не работает:

- `checksum "go.sum"` — файл в `clients/go/go.sum`, не в корне
- Образ `cimg/go:1.21` — проект требует Go 1.25
- `go mod download` / `go test` запускались из корня, а не из `clients/go/`
- `gotestsum` не установлен в образе
- Нет сборки Rust (`clients/rust/`)
- Workflow назван «sample»

## Исправления
- **build-go**: `working_directory: clients/go`, образ `cimg/go:1.25`, кэш по `clients/go/go.sum`
- **build-rust**: `cimg/rust:1.84`, `cargo build --release && cargo test --release`, кэш `Cargo.lock`
- **lint-conformance**: `py_compile` проверка conformance runners
- Workflow → `ci`, все 3 джоба параллельно