### PR TITLE
wolfcrypt: fix verify_shim_cosign dev-skip and nested path matching

### DIFF
--- a/crypto/wolfcrypt/tests/test_verify_shim_cosign_nested_paths.sh
+++ b/crypto/wolfcrypt/tests/test_verify_shim_cosign_nested_paths.sh
@@ -23,7 +23,13 @@ sums="${tmp}/out/shim/SHA3SUMS.txt"
 # Nested path in sums (matches basename).
 echo "${hash}  shim/$(basename "${shim}")" > "${sums}"
 
-# Should pass (skip cosign; still enforces hash membership).
+# Without dev-skip, missing .sig/.crt must fail.
+if "${script}" "${sums}" "${shim}" >/dev/null 2>/dev/null; then
+  echo "expected failure without cosign artifacts, but verify succeeded" >&2
+  exit 1
+fi
+
+# Should pass in dev-skip mode (still enforces hash membership).
 RUBIN_WOLFCRYPT_DEV_SKIP_COSIGN=1 "${script}" "${sums}" "${shim}" >/dev/null
 
 # Negative: wrong name in sums should fail.
@@ -34,4 +40,3 @@ if RUBIN_WOLFCRYPT_DEV_SKIP_COSIGN=1 "${script}" "${sums}" "${shim}" >/dev/null 
 fi
 
 echo "OK"
-

--- a/crypto/wolfcrypt/verify_shim_cosign.sh
+++ b/crypto/wolfcrypt/verify_shim_cosign.sh
@@ -5,15 +5,24 @@ set -euo pipefail
 # Optional: verify a specific shim binary and emit export commands.
 # Usage:
 #   ./crypto/wolfcrypt/verify_shim_cosign.sh /path/to/SHA3SUMS.txt [/path/to/librubin_wc_shim.*] [--export-env]
+# Dev mode:
+#   RUBIN_WOLFCRYPT_DEV_SKIP_COSIGN=1
+#   - skip cosign/.sig/.crt verification, keep hash membership verification.
 # If --export-env is set, prints export lines for:
 #   RUBIN_WOLFCRYPT_SHIM_PATH
 #   RUBIN_WOLFCRYPT_SHIM_SHA3_256
 #   RUBIN_WOLFCRYPT_STRICT=1
 
-if ! command -v cosign >/dev/null 2>&1; then
-  echo "cosign not found in PATH" >&2
-  exit 1
-fi
+DEV_SKIP_RAW="${RUBIN_WOLFCRYPT_DEV_SKIP_COSIGN:-0}"
+DEV_SKIP_NORM="$(printf '%s' "${DEV_SKIP_RAW}" | tr '[:upper:]' '[:lower:]')"
+case "${DEV_SKIP_NORM}" in
+  1|true|yes) DEV_SKIP_COSIGN=1 ;;
+  0|false|no|"") DEV_SKIP_COSIGN=0 ;;
+  *)
+    echo "invalid RUBIN_WOLFCRYPT_DEV_SKIP_COSIGN=${DEV_SKIP_RAW} (expected 0/1/true/false)" >&2
+    exit 1
+    ;;
+esac
 
 SUMS="${1:-}"
 SHIM=""
@@ -36,19 +45,28 @@ fi
 SIG="${SUMS}.sig"
 CRT="${SUMS}.crt"
 
-if [ ! -f "${SIG}" ] || [ ! -f "${CRT}" ]; then
-  echo "expected ${SIG} and ${CRT} next to SHA3SUMS.txt" >&2
-  exit 1
+if [ "${DEV_SKIP_COSIGN}" -eq 0 ]; then
+  if ! command -v cosign >/dev/null 2>&1; then
+    echo "cosign not found in PATH" >&2
+    exit 1
+  fi
+
+  if [ ! -f "${SIG}" ] || [ ! -f "${CRT}" ]; then
+    echo "expected ${SIG} and ${CRT} next to SHA3SUMS.txt" >&2
+    exit 1
+  fi
+
+  COSIGN_EXPERIMENTAL=1 COSIGN_YES=true cosign verify-blob \
+    --certificate "${CRT}" \
+    --signature "${SIG}" \
+    --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+    --certificate-identity-regexp '^https://github.com/2tbmz9y2xt-lang/rubin-protocol/.+@refs/(heads/.+|pull/.+/.+|tags/.+)$' \
+    "${SUMS}"
+
+  echo "cosign verification OK for ${SUMS}" >&2
+else
+  echo "dev mode: skipping cosign verification for ${SUMS}" >&2
 fi
-
-COSIGN_EXPERIMENTAL=1 COSIGN_YES=true cosign verify-blob \
-  --certificate "${CRT}" \
-  --signature "${SIG}" \
-  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-  --certificate-identity-regexp '^https://github.com/2tbmz9y2xt-lang/rubin-protocol/.+@refs/(heads/.+|pull/.+/.+|tags/.+)$' \
-  "${SUMS}"
-
-echo "cosign verification OK for ${SUMS}" >&2
 
 if [ -n "${SHIM}" ]; then
   if [ ! -f "${SHIM}" ]; then
@@ -57,8 +75,18 @@ if [ -n "${SHIM}" ]; then
   fi
   HASH=$(python3 -c 'import hashlib, sys; print(hashlib.sha3_256(open(sys.argv[1], "rb").read()).hexdigest())' "${SHIM}")
   name=$(basename "${SHIM}")
-  if ! grep -q "${HASH}  ${name}" "${SUMS}"; then
-    echo "hash mismatch for ${name}: ${HASH} not in ${SUMS}" >&2
+  if ! awk -v want_hash="${HASH}" -v want_name="${name}" '
+    {
+      if (tolower($1) != tolower(want_hash)) next
+      path = $2
+      sub(/^\*/, "", path)    # support checksum style with leading "*"
+      n = split(path, parts, "/")
+      base = parts[n]
+      if (base == want_name) { found = 1; exit 0 }
+    }
+    END { exit(found ? 0 : 1) }
+  ' "${SUMS}"; then
+    echo "hash mismatch for ${name}: ${HASH} not in ${SUMS} (basename-aware)" >&2
     exit 1
   fi
   echo "hash match: ${name} ${HASH}" >&2


### PR DESCRIPTION
## What
- fix `crypto/wolfcrypt/verify_shim_cosign.sh` to support documented dev mode via `RUBIN_WOLFCRYPT_DEV_SKIP_COSIGN=1`
- keep strict production behavior by default (`cosign` + `.sig/.crt` still mandatory when dev-skip is off)
- make SHA3SUMS matching basename-aware so entries like `shim/librubin_wc_shim.so` are accepted
- update regression test `crypto/wolfcrypt/tests/test_verify_shim_cosign_nested_paths.sh` to assert both modes:
  - fail without dev-skip when `.sig/.crt` are missing
  - pass with dev-skip and nested path

## Why
`test_verify_shim_cosign_nested_paths.sh` was failing because the script ignored the documented dev-skip flag and required `.sig/.crt` unconditionally.
Additionally, nested-path SHA3SUMS entries were not matched.

## Validation
- `bash crypto/wolfcrypt/tests/test_verify_shim_cosign_nested_paths.sh` => PASS
- manual smoke:
  - `RUBIN_WOLFCRYPT_DEV_SKIP_COSIGN=1 bash crypto/wolfcrypt/verify_shim_cosign.sh ... --export-env` => PASS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added environment variable to conditionally skip cosign verification during development.

* **Bug Fixes**
  * Enhanced hash verification logic with improved case-insensitive, basename-aware matching.
  * Refined error messages for hash mismatch scenarios.

* **Tests**
  * Strengthened verification tests to enforce stricter artifact validation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->