### PR TITLE
tooling: add specdiff annotator npm scripts (Q-058)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ clients/rust/cargo_audit.json
 # Local analysis outputs
 analysis/
 
+# Node tooling (spec annotator)
+node_modules/
+
 # Local runtime env files
 operational/systemd/rubin-node.env
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,27 @@
+{
+  "name": "rubin-protocol-tooling",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "rubin-protocol-tooling",
+      "version": "0.0.0",
+      "dependencies": {
+        "marked": "^12.0.2"
+      }
+    },
+    "node_modules/marked": {
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
+      "integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "rubin-protocol-tooling",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "spec:html": "node scripts/spec/build-spec-html.mjs",
+    "spec:diff": "node scripts/spec/gen-spec-diff.mjs",
+    "spec:explain": "node scripts/spec/spec-explainer.mjs",
+    "spec:watch": "node scripts/spec/watch-spec.mjs",
+    "spec:all": "npm run spec:html && npm run spec:diff && npm run spec:explain"
+  },
+  "dependencies": {
+    "marked": "^12.0.2"
+  }
+}

--- a/scripts/spec/build-spec-html.mjs
+++ b/scripts/spec/build-spec-html.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+/**
+ * Convert canonical spec Markdown -> HTML.
+ *
+ * Input:  spec/RUBIN_L1_CANONICAL_v1.1.md
+ * Output: analysis/spec/RUBIN_L1_CANONICAL_v1.1.html
+ *
+ * This is tooling-only; output is ignored by git.
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+import { marked } from 'marked'
+
+const repoRoot = process.cwd()
+const src = path.join(repoRoot, 'spec', 'RUBIN_L1_CANONICAL_v1.1.md')
+const dstDir = path.join(repoRoot, 'analysis', 'spec')
+const dst = path.join(dstDir, 'RUBIN_L1_CANONICAL_v1.1.html')
+
+if (!fs.existsSync(src)) {
+  console.error(`spec:html: missing input: ${src}`)
+  process.exit(1)
+}
+
+const md = fs.readFileSync(src, 'utf8')
+const htmlBody = marked.parse(md)
+const template = `<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="utf-8">
+  <title>RUBIN L1 CANONICAL v1.1</title>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 1000px; margin: 32px auto; padding: 0 18px; line-height: 1.6; color: #0f172a; background:#ffffff; }
+    code { background: #f1f5f9; padding: 2px 5px; border-radius: 4px; }
+    pre { background: #0b0d14; color: #f4f6fb; padding: 12px; border-radius: 8px; overflow-x: auto; }
+    table { border-collapse: collapse; width: 100%; margin: 12px 0; }
+    th, td { border: 1px solid #e2e8f0; padding: 6px 8px; }
+    th { background: #f8fafc; }
+    tr:nth-child(even) { background: #f8fafc; }
+    a { color: #0ea5e9; }
+  </style>
+</head>
+<body>
+${htmlBody}
+</body>
+</html>`
+
+fs.mkdirSync(dstDir, { recursive: true })
+fs.writeFileSync(dst, template, 'utf8')
+console.log(`Spec HTML saved -> ${dst}`)
+

--- a/scripts/spec/gen-spec-diff.mjs
+++ b/scripts/spec/gen-spec-diff.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+/**
+ * Generate git diff for canonical spec and write to analysis/spec/spec-diff.json.
+ *
+ * Input:  git diff -- spec/RUBIN_L1_CANONICAL_v1.1.md
+ * Output: analysis/spec/spec-diff.json
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+import { execSync } from 'node:child_process'
+
+const repoRoot = process.cwd()
+const target = path.join(repoRoot, 'analysis', 'spec', 'spec-diff.json')
+const updated = new Date().toISOString().replace('T', ' ').slice(0, 19)
+
+let diff = ''
+try {
+  diff = execSync('git diff --unified=3 -- spec/RUBIN_L1_CANONICAL_v1.1.md', {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim()
+  if (!diff) diff = 'Нет изменений в каноникале относительно текущего HEAD.'
+} catch (e) {
+  diff = `Не удалось получить diff: ${e.message}`
+}
+
+fs.mkdirSync(path.dirname(target), { recursive: true })
+fs.writeFileSync(target, JSON.stringify({ updated, diff }, null, 2), 'utf8')
+console.log(`[${updated}] spec-diff.json saved -> ${target}`)
+

--- a/scripts/spec/spec-explainer.mjs
+++ b/scripts/spec/spec-explainer.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+/**
+ * Produce a lightweight explainer for spec-diff.json without external LLM deps.
+ *
+ * Input:  analysis/spec/spec-diff.json
+ * Output: analysis/spec/spec-explainer.json
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+
+const repoRoot = process.cwd()
+const diffPath = path.join(repoRoot, 'analysis', 'spec', 'spec-diff.json')
+const outPath = path.join(repoRoot, 'analysis', 'spec', 'spec-explainer.json')
+
+if (!fs.existsSync(diffPath)) {
+  console.error('spec:explain: missing analysis/spec/spec-diff.json; run spec:diff first')
+  process.exit(1)
+}
+
+const diffData = JSON.parse(fs.readFileSync(diffPath, 'utf8'))
+const diff = String(diffData.diff || '')
+const updated = new Date().toISOString().replace('T', ' ').slice(0, 19)
+
+function explain(d) {
+  const lower = d.toLowerCase()
+  const findings = []
+
+  const hasConsensus = /\b(consensus|block_err_|tx_err_|must|normative)\b/i.test(d)
+  const touchesWeight = /\bweight\b|max_block_weight|verify_cost/i.test(lower)
+  const touchesWitness = /\bwitness\b|max_witness/i.test(lower)
+  const touchesAnchor = /\banchor\b|max_anchor/i.test(lower)
+  const touchesDeploy = /version_bits|deployment|locked_in|active|failed/i.test(lower)
+  const touchesHtlc = /\bhtlc\b/i.test(lower)
+
+  if (diff.includes('Нет изменений')) {
+    return [
+      {
+        area: 'No-op',
+        impact: 'docs',
+        summary: 'Изменений в каноникале относительно HEAD нет.',
+        action: 'Ничего делать не нужно.',
+        risk: 'low',
+      },
+    ]
+  }
+
+  if (touchesWeight || touchesWitness) {
+    findings.push({
+      area: 'L1 weight/TPS',
+      impact: 'consensus',
+      summary: 'Изменены/затронуты правила веса или witness. Это может менять TPS и DoS-порог.',
+      action: 'Прогнать conformance bundle и пересчитать производные метрики.',
+      risk: 'medium',
+    })
+  }
+  if (touchesAnchor) {
+    findings.push({
+      area: 'ANCHOR limits',
+      impact: 'consensus',
+      summary: 'Затронуты ANCHOR-ограничения/семантика.',
+      action: 'Сверить per-block лимиты, relay-политику и light-client anchorproof протокол.',
+      risk: 'medium',
+    })
+  }
+  if (touchesDeploy) {
+    findings.push({
+      area: 'VERSION_BITS',
+      impact: 'consensus',
+      summary: 'Затронуты deployment/активации (VERSION_BITS).',
+      action: 'Проверить deployment таблицы для devnet/testnet/mainnet и cross-client интерпретацию.',
+      risk: 'medium',
+    })
+  }
+  if (touchesHtlc) {
+    findings.push({
+      area: 'HTLC',
+      impact: hasConsensus ? 'consensus' : 'docs',
+      summary: 'Затронуты HTLC правила/описания.',
+      action: 'Проверить error codes и conformance CV-HTLC/CV-HTLC-ANCHOR.',
+      risk: 'low',
+    })
+  }
+
+  if (findings.length === 0) {
+    findings.push({
+      area: 'Docs/format',
+      impact: hasConsensus ? 'consensus' : 'docs',
+      summary: 'Diff не зацепил типовые ключевые области (weight/witness/anchor/deploy/htlc).',
+      action: 'Просмотреть diff вручную на предмет терминологии и ссылок.',
+      risk: 'low',
+    })
+  }
+  return findings
+}
+
+const findings = explain(diff)
+const output = {
+  updated,
+  note: 'Heuristic explainer (offline).',
+  findings,
+}
+
+fs.mkdirSync(path.dirname(outPath), { recursive: true })
+fs.writeFileSync(outPath, JSON.stringify(output, null, 2), 'utf8')
+console.log(`[${updated}] spec-explainer.json saved -> ${outPath} (${findings.length} findings)`)
+

--- a/scripts/spec/watch-spec.mjs
+++ b/scripts/spec/watch-spec.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+/**
+ * Watch canonical spec and re-run spec pipeline on change.
+ *
+ * Watches: spec/RUBIN_L1_CANONICAL_v1.1.md
+ * Runs:    npm run spec:all
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+import { execSync } from 'node:child_process'
+
+const repoRoot = process.cwd()
+const src = path.join(repoRoot, 'spec', 'RUBIN_L1_CANONICAL_v1.1.md')
+
+if (!fs.existsSync(src)) {
+  console.error(`spec:watch: missing input: ${src}`)
+  process.exit(1)
+}
+
+let queued = false
+function run(reason) {
+  if (queued) return
+  queued = true
+  setTimeout(() => {
+    queued = false
+    const ts = new Date().toISOString().replace('T', ' ').slice(0, 19)
+    try {
+      execSync('npm run -s spec:all', { stdio: 'inherit', cwd: repoRoot })
+      console.log(`[${ts}] spec pipeline done (${reason})`)
+    } catch (e) {
+      console.error(`[${ts}] spec pipeline failed (${reason}):`, e.message)
+    }
+  }, 250)
+}
+
+run('initial')
+fs.watch(src, { persistent: true }, () => run('change'))
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added spec tooling workflow: convert specification markdown to HTML, track specification changes, generate change explanations, and monitor for updates.

* **Chores**
  * Initialized Node.js project configuration and build tooling setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->