### PR TITLE
conformance: HTLC2-07 vector + manifest count fix

### DIFF
--- a/conformance/fixtures/CV-HTLC-ANCHOR.yml
+++ b/conformance/fixtures/CV-HTLC-ANCHOR.yml
@@ -111,6 +111,25 @@ tests:
     expected_error: TX_ERR_DEPLOYMENT_INACTIVE
     consensus: true
 
+  - id: HTLC2-07
+    title: "Redeem FAIL: script_sig_len != 0 for CORE_HTLC_V2 => TX_ERR_PARSE"
+    context:
+      chain_id_hex: "7dcf48a266788491e77bbb7b9c97ad6a2c89b882293dfaf3bdebeec62548cc00"
+      chain_height: 600
+      chain_timestamp: 1700000600
+      suite_id_02_active: true
+      htlc_v2_active: true
+      # Same as HTLC2-01, but input script_sig_len=1 with a 1-byte script_sig payload. Must be rejected.
+      tx_hex: "010000000100000000000000010303030303030303030303030303030303030303030303030303030303030303000000000100000000000000000000010240000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000100"
+      utxo_set:
+        - txid: "0303030303030303030303030303030303030303030303030303030303030303"
+          vout: 0
+          value: 1000
+          covenant_type: 258
+          covenant_data: "e2929f80ffdaaa51c427cbf42df6679013fddb1630bc28f234ca48692b35399200f401000000000000070fa1ab6fcc557ed14d42941f1967693048551eb9042a8d0a057afbd75e81e03333333333333333333333333333333333333333333333333333333333333333"
+    expected_error: TX_ERR_PARSE
+    consensus: true
+
   - id: HTLC2-08
     title: "Redeem reaches signature: extra non-matching CORE_ANCHOR present => still TX_ERR_SIG_INVALID (prefix-scoped matching)"
     context:

--- a/spec/RUBIN_L1_CONFORMANCE_MANIFEST_v1.1.md
+++ b/spec/RUBIN_L1_CONFORMANCE_MANIFEST_v1.1.md
@@ -27,7 +27,7 @@ Source of truth for the bundle list:
 | CV-HTLC-ANCHOR | ✓ | PASS | 10 | consensus |
 | CV-VAULT | ✓ | PASS | 9 | consensus |
 | CV-WEIGHT | ✓ | PASS | 3 | consensus |
-| CV-COINBASE | ✓ | PASS | 12 | consensus |
+| CV-COINBASE | ✓ | PASS | 9 | consensus |
 | CV-ANCHOR-RELAY | — | PENDING | 11 | policy-only |
 
 **15 consensus gates — all PASS. 1 policy gate — PENDING (runner support needed).**


### PR DESCRIPTION
Closes queue items Q-066/Q-067.

- Adds missing `HTLC2-07` executable vector to `CV-HTLC-ANCHOR`:
  - `script_sig_len != 0` for CORE_HTLC_V2 => `TX_ERR_PARSE`
  - Verified parity (Go + Rust) via unified conformance runner.
- Fixes `spec/RUBIN_L1_CONFORMANCE_MANIFEST_v1.1.md` vector counts:
  - `CV-COINBASE`: 12 -> 9 (matches current fixture)
  - `CV-HTLC-ANCHOR` remains 10 (now matches fixture after adding HTLC2-07)

Local checks:
- `python3 conformance/runner/run_cv_bundle.py --only-gates CV-HTLC-ANCHOR,CV-COINBASE`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded HTLC validation test coverage by adding a new test case that verifies proper transaction parsing rejection when encountering invalid script signature length parameters. This enhances protocol conformance testing.

* **Chores**
  * Updated conformance specification documentation with revised gate vector count metrics to reflect changes in validation procedures and accuracy improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->