### PR TITLE
protocol: coinbase invalid mapping + CV-BLOCK vectors

### DIFF
--- a/clients/go/consensus/tx.go
+++ b/clients/go/consensus/tx.go
@@ -1194,23 +1194,23 @@ func validateOutputCovenantConstraints(output TxOutput) error {
 
 func validateCoinbaseTxInputs(tx *Tx) error {
 	if tx.TxNonce != 0 {
-		return fmt.Errorf("TX_ERR_COINBASE_INVALID")
+		return fmt.Errorf(BLOCK_ERR_COINBASE_INVALID)
 	}
 	if len(tx.Inputs) != 1 {
-		return fmt.Errorf("TX_ERR_COINBASE_INVALID")
+		return fmt.Errorf(BLOCK_ERR_COINBASE_INVALID)
 	}
 	in := tx.Inputs[0]
 	if in.Sequence != TX_COINBASE_PREVOUT_VOUT {
-		return fmt.Errorf("TX_ERR_COINBASE_INVALID")
+		return fmt.Errorf(BLOCK_ERR_COINBASE_INVALID)
 	}
 	if in.PrevTxid != ([32]byte{}) || in.PrevVout != TX_COINBASE_PREVOUT_VOUT {
-		return fmt.Errorf("TX_ERR_COINBASE_INVALID")
+		return fmt.Errorf(BLOCK_ERR_COINBASE_INVALID)
 	}
 	if len(in.ScriptSig) != 0 {
-		return fmt.Errorf("TX_ERR_COINBASE_INVALID")
+		return fmt.Errorf(BLOCK_ERR_COINBASE_INVALID)
 	}
 	if len(tx.Witness.Witnesses) != 0 {
-		return fmt.Errorf("TX_ERR_COINBASE_INVALID")
+		return fmt.Errorf(BLOCK_ERR_COINBASE_INVALID)
 	}
 	return nil
 }

--- a/clients/rust/crates/rubin-consensus/src/lib.rs
+++ b/clients/rust/crates/rubin-consensus/src/lib.rs
@@ -535,23 +535,23 @@ fn is_coinbase_tx(tx: &Tx, block_height: u64) -> bool {
 
 fn validate_coinbase_tx_inputs(tx: &Tx) -> Result<(), String> {
     if tx.tx_nonce != 0 {
-        return Err("TX_ERR_COINBASE_INVALID".into());
+        return Err(BLOCK_ERR_COINBASE_INVALID.into());
     }
     if tx.inputs.len() != 1 {
-        return Err("TX_ERR_COINBASE_INVALID".into());
+        return Err(BLOCK_ERR_COINBASE_INVALID.into());
     }
     let input = &tx.inputs[0];
     if input.sequence != TX_COINBASE_PREVOUT_VOUT {
-        return Err("TX_ERR_COINBASE_INVALID".into());
+        return Err(BLOCK_ERR_COINBASE_INVALID.into());
     }
     if !is_zero_outpoint(&input.prev_txid, input.prev_vout) {
-        return Err("TX_ERR_COINBASE_INVALID".into());
+        return Err(BLOCK_ERR_COINBASE_INVALID.into());
     }
     if !input.script_sig.is_empty() {
-        return Err("TX_ERR_COINBASE_INVALID".into());
+        return Err(BLOCK_ERR_COINBASE_INVALID.into());
     }
     if !tx.witness.witnesses.is_empty() {
-        return Err("TX_ERR_COINBASE_INVALID".into());
+        return Err(BLOCK_ERR_COINBASE_INVALID.into());
     }
     Ok(())
 }

--- a/conformance/fixtures/CV-BLOCK.yml
+++ b/conformance/fixtures/CV-BLOCK.yml
@@ -39,6 +39,36 @@ tests:
     expected_error: BLOCK_ERR_COINBASE_INVALID
     consensus: true
 
+  - id: BLOCK-06A
+    title: "Coinbase invalid: tx_nonce != 0 on coinbase-shaped tx => BLOCK_ERR_COINBASE_INVALID"
+    context: { case: COINBASE_INVALID_TX_NONCE }
+    expected_error: BLOCK_ERR_COINBASE_INVALID
+    consensus: true
+
+  - id: BLOCK-06B
+    title: "Coinbase invalid: script_sig_len != 0 on coinbase-shaped tx => BLOCK_ERR_COINBASE_INVALID"
+    context: { case: COINBASE_INVALID_SCRIPT_SIG }
+    expected_error: BLOCK_ERR_COINBASE_INVALID
+    consensus: true
+
+  - id: BLOCK-06C
+    title: "Coinbase invalid: sequence != 0xffffffff on coinbase-shaped tx => BLOCK_ERR_COINBASE_INVALID"
+    context: { case: COINBASE_INVALID_SEQUENCE }
+    expected_error: BLOCK_ERR_COINBASE_INVALID
+    consensus: true
+
+  - id: BLOCK-06D
+    title: "Coinbase invalid: locktime != height(B) on coinbase-shaped tx => BLOCK_ERR_COINBASE_INVALID"
+    context: { case: COINBASE_INVALID_LOCKTIME }
+    expected_error: BLOCK_ERR_COINBASE_INVALID
+    consensus: true
+
+  - id: BLOCK-06E
+    title: "Coinbase invalid: witness_count != 0 on coinbase-shaped tx => BLOCK_ERR_COINBASE_INVALID"
+    context: { case: COINBASE_INVALID_WITNESS }
+    expected_error: BLOCK_ERR_COINBASE_INVALID
+    consensus: true
+
   - id: BLOCK-07
     title: "Median-time-vs-timestamp old bound violation => BLOCK_ERR_TIMESTAMP_OLD"
     context: { case: TIMESTAMP_OLD }


### PR DESCRIPTION
Closes queue items Q-061/Q-062.

- Removes/avoids `TX_ERR_COINBASE_INVALID` by mapping coinbase tx-field violations to the block-level code `BLOCK_ERR_COINBASE_INVALID` (matches CANONICAL §3.3 mapping).
  - Go: `validateCoinbaseTxInputs` now returns `BLOCK_ERR_COINBASE_INVALID`
  - Rust: `validate_coinbase_tx_inputs` now returns `BLOCK_ERR_COINBASE_INVALID`
- Adds explicit CV-BLOCK vectors for coinbase tx-field violations:
  - tx_nonce != 0
  - script_sig_len != 0
  - sequence != 0xffffffff
  - locktime != height(B)
  - witness_count != 0
- Extends the CV-BLOCK context builder to synthesize these malformed coinbase transactions.

Local checks:
- python3 conformance/runner/run_cv_bundle.py --only-gates CV-BLOCK
- python3 conformance/runner/run_cv_bundle.py (full bundle)
- (clients/go) go test ./...
- (clients/rust) cargo test
