### PR TITLE
Phase 1: node storage model spec

### DIFF
--- a/operational/RUBIN_NODE_STORAGE_MODEL_v1.1.md
+++ b/operational/RUBIN_NODE_STORAGE_MODEL_v1.1.md
@@ -167,6 +167,5 @@ This document intentionally defines `utxo_by_outpoint` key encoding as:
 `txid || vout_le` so an ordered iteration is well-defined.
 
 Follow-up:
-- Define `utxo_set_hash` as a canonical hash over lexicographically ordered `(outpoint, utxo_entry_bytes)` pairs.
-- Add `CV-CHAINSTATE` conformance gate to compare Rust vs Go on block sequences.
-
+- Q-076: Define `utxo_set_hash` as a canonical hash over lexicographically ordered `(outpoint, utxo_entry_bytes)` pairs.
+- Q-077: Add `CV-CHAINSTATE` conformance gate to compare Rust vs Go on block sequences.

--- a/spec/RUBIN_L1_CANONICAL_v1.1.md
+++ b/spec/RUBIN_L1_CANONICAL_v1.1.md
@@ -62,7 +62,7 @@ Development status note (non-normative):
 - `MAX_SUPPLY = 10_000_000_000_000_000` base units (100,000,000 RBN)
 - `SUBSIDY_TOTAL_MINED = 9_900_000_000_000_000` base units (99,000,000 RBN)
 - `SUBSIDY_DURATION_BLOCKS = 1_314_900` blocks
-  - Non-normative: `1_314_900 = 2² × 3³ × 5² × 487`; divisible by `COINBASE_MATURITY` (100) and `TARGET_BLOCK_INTERVAL` (600) but not by `SIGNAL_WINDOW` (2016).
+  - Non-normative: `1_314_900 = 2² × 3³ × 5² × 487`; divisible by `COINBASE_MATURITY` (100) but not by `TARGET_BLOCK_INTERVAL` (600) or `SIGNAL_WINDOW` (2016).
 
 Non-normative note (emission schedule and genesis intent):
 - Total supply target is 100,000,000 RBN (`MAX_SUPPLY`) where values in transactions are in base units


### PR DESCRIPTION
Implements Q-073: engineering spec for node storage model (datadir layout, manifest, block store, indexes, UTXO, undo log, atomic apply, schema versioning). Non-consensus doc only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Node Storage Model v1.1 specification defining the persistent storage layout, atomic block application guarantees, crash recovery behavior, schema versioning/migrations, and Phase 1 plan for cross-client comparability.
  * Clarified canonical specification with subsidy duration details and added cryptographic security level mapping for a post-quantum scheme.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->