### PR TITLE
CI: auto-request CodeRabbit review on PRs

### DIFF
--- a/.github/workflows/coderabbit-autoreview.yml
+++ b/.github/workflows/coderabbit-autoreview.yml
@@ -1,0 +1,55 @@
+name: CodeRabbit Auto Review
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+concurrency:
+  group: coderabbit-autoreview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  request-review:
+    if: ${{ github.event.pull_request.draft == false }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Request CodeRabbit review (idempotent)
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.payload.pull_request.number;
+            const marker = '@coderabbitai review';
+
+            // Avoid spamming: only post once per PR, by this workflow.
+            const { data: comments } = await github.rest.issues.listComments({
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+
+            const already = comments.some(c =>
+              c.user?.login === 'github-actions[bot]' &&
+              typeof c.body === 'string' &&
+              c.body.includes(marker)
+            );
+
+            if (already) {
+              core.info('Marker comment already present; skipping.');
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number,
+              body: marker,
+            });
+            core.info('Posted CodeRabbit review request marker.');
+


### PR DESCRIPTION
Adds a small workflow that posts a single '@coderabbitai review' marker comment on PR open/reopen/sync (idempotent) to trigger CodeRabbit reviews automatically. Uses pull_request_target with minimal permissions and does not checkout PR code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated workflow to request CodeRabbit code reviews on pull requests. The system intelligently prevents duplicate review requests by checking for existing comments before posting new ones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->