### PR TITLE
Q-087: Fix eclipse PoW integrity wording

### DIFF
--- a/spec/RUBIN_L1_CANONICAL_v1.1.md
+++ b/spec/RUBIN_L1_CANONICAL_v1.1.md
@@ -1463,13 +1463,13 @@ to detect UTXO fraud. Its only protections are PoW and Merkle inclusion.
 Even under a complete eclipse (all peers adversarial), the following hold for an honest
 light client that correctly implements RUBIN v1.1:
 
-1. **PoW integrity**: the adversary cannot present a header with less cumulative work than
-   the adversary cannot present a header chain that violates PoW validity rules (§6.2).
-   However, without trusted checkpoints or diverse peers, the adversary can present an
-   alternative valid-PoW chain with equal or greater cumulative work, which the client
-   cannot distinguish from the honest chain.
-   With a trusted checkpoint (known block hash at height `h_c`), the client can reject any
-   presented chain that does not contain that checkpoint.
+1. **PoW integrity**: the adversary cannot present a header chain that violates PoW validity rules (§6.2).
+   That is, an eclipsed light client can still enforce *validity* of the presented header chain.
+   However, without trusted checkpoints or diverse peers, the adversary can present an alternative
+   valid-PoW header chain with equal or greater cumulative work, which the client cannot distinguish
+   from the honest chain.
+   With a trusted checkpoint (known block hash at height `h_c`), the client can reject any presented
+   chain that does not contain that checkpoint.
 2. **Merkle proof integrity**: given a valid `block_header.merkle_root`, a Merkle inclusion
    proof cannot be forged (SHA3-256 collision resistance, T-013). An eclipsed client that
    accepts a fraudulent header may accept a fraudulent Merkle proof — but only against that


### PR DESCRIPTION
Doc-only: fix §14.2.2(1) PoW integrity wording (remove broken duplicated clause, clarify semantics for eclipsed light clients).

Local check:
- npm run spec:all (OK)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Refined specification of eclipse attack mitigation requirements and corresponding security guarantees
  * Clarified integrity properties for transaction validation, signature verification, and covenant binding enforcement
  * Expanded risk analysis framework to address application-layer security implications of anchor-based attacks
<!-- end of auto-generated comment: release notes by coderabbit.ai -->