### PR TITLE
Q-090: Chain-instance profile schema fields

### DIFF
--- a/spec/RUBIN_L1_CANONICAL_v1.1.md
+++ b/spec/RUBIN_L1_CANONICAL_v1.1.md
@@ -41,7 +41,7 @@ Constraints:
 Development status note (non-normative):
 
 - During early development, the spec defines the genesis serialization function but does not fix concrete genesis bytes.
-- Any concrete network (devnet/testnet/mainnet) MUST publish a chain-instance profile that fixes the exact genesis bytes (or genesis header/tx bytes) so all clients derive the same `chain_id`.
+- Any concrete network (devnet/testnet/mainnet) MUST publish a chain-instance profile that fixes the exact genesis bytes (or genesis header/tx bytes) so all clients derive the same `chain_id`. Recommended publication format: `spec/RUBIN_L1_CHAIN_INSTANCE_PROFILE_TEMPLATE_v1.1.md` (non-consensus).
 
 ### 1.2 Consensus constants
 

--- a/spec/RUBIN_L1_CHAIN_INSTANCE_PROFILE_TEMPLATE_v1.1.md
+++ b/spec/RUBIN_L1_CHAIN_INSTANCE_PROFILE_TEMPLATE_v1.1.md
@@ -31,3 +31,22 @@ Derived fields (must be recomputed from the published bytes):
 Link the corresponding deployments registry:
 
 - `spec/RUBIN_L1_DEPLOYMENTS_<network>_v1.1.md`
+
+This deployments file is the chain-instance specific VERSION_BITS activation schedule (§8 in CANONICAL).
+If the deployments file is absent or empty, nodes MUST treat all deployments as `DEFINED` / not ACTIVE
+(and any deployment-gated spends will return `TX_ERR_DEPLOYMENT_INACTIVE`).
+
+## 4. Premine / Initial Distribution (Non-consensus, required disclosure)
+
+The initial distribution is committed to by `genesis_tx_bytes`. This section is a required disclosure
+for operator and tooling interoperability. It MUST be consistent with the published `genesis_tx_bytes`.
+
+Recommended fields:
+
+- premine_total: `<u64>` (coins, not base-units)
+- premine_outputs: `<text summary>` (how many outputs, what covenant types, any vesting/spend_delay)
+- premine_security_posture: `<string>` (e.g., unspendable placeholder for devnet/testnet; or vault-based vesting for mainnet)
+
+Mainnet note:
+- If the premine requires key material (e.g., `CORE_VAULT_V1` owner/recovery keys), it MUST be produced
+  as part of the genesis ceremony, not generated ad-hoc by operators after launch.


### PR DESCRIPTION
Spec docs: extend chain-instance profile template to include VERSION_BITS deployment schedule linkage and premine/initial distribution disclosure fields; add reference from CANONICAL §1.1.

Local check:
- npm run spec:all (OK)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation
- Clarified that chain-instance profile publication format is recommended rather than consensus-critical.
- Added guidance on deployments file handling and VERSION_BITS activation schedules, including behavior when deployment files are absent or empty.
- Introduced new Premine/Initial Distribution section with required disclosure requirements and recommendations for genesis ceremony documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->