### PR TITLE
gitignore: keep IMPLEMENTATION_ROADMAP.md as local artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ clients/rust/cargo_audit.json
 # Generated spec analysis artifacts
 analysis/spec/spec-diff.json
 analysis/spec/spec-explainer.json
+IMPLEMENTATION_ROADMAP.md


### PR DESCRIPTION
Roadmap is an agent planning artifact, not part of the protocol.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration to exclude internal files from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->