### PR TITLE
docs: clarify P2P protocol location (spec vs operational)

### DIFF
--- a/operational/RUBIN_L1_P2P_PROTOCOL_v1.1.md
+++ b/operational/RUBIN_L1_P2P_PROTOCOL_v1.1.md
@@ -1,0 +1,13 @@
+# RUBIN L1 P2P Protocol v1.1 — Location Note (Operational)
+
+This file is intentionally a pointer.
+
+Authoritative P2P wire protocol for RUBIN v1.1 lives under:
+
+- `spec/RUBIN_L1_P2P_PROTOCOL_v1.1.md`
+
+Rationale:
+
+- The P2P protocol is referenced by CANONICAL §15 and is part of the spec surface (auxiliary, non-consensus).
+- The `operational/` directory is reserved for operator policy/runbooks and non-normative operational guidance.
+


### PR DESCRIPTION
Adds `operational/RUBIN_L1_P2P_PROTOCOL_v1.1.md` as an explicit pointer to the authoritative aux spec `spec/RUBIN_L1_P2P_PROTOCOL_v1.1.md`.

No protocol changes.
