### PR TITLE
operational: genesis ceremony runbook tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,11 @@ node_modules/
 # Local runtime env files
 operational/systemd/rubin-node.env
 
+# Mainnet ceremony inputs (private; do not commit)
+operational/dev_fund_schedule.csv
+**/*dev_fund_schedule*.csv
+**/*.dev-fund-schedule.csv
+
 # Local UI / task tracker workspace
 rubin-ui/
 

--- a/operational/RUBIN_MAINNET_GENESIS_CEREMONY_v1.1.md
+++ b/operational/RUBIN_MAINNET_GENESIS_CEREMONY_v1.1.md
@@ -61,9 +61,19 @@ python3 scripts/genesis/build_genesis_v1_1.py \
 ```
 
 Notes:
-- If you use a premine/dev-fund schedule, it is an *input artifact* only; do not publish private keys. See:
-  - `operational/RUBIN_GENESIS_DEV_FUND_SCHEDULE_TEMPLATE_v1.1.md`
-  - `scripts/genesis/README.md`
+- If you use a premine/dev-fund schedule, it is an *input artifact* only.
+  - The filled `--schedule-csv` file MUST NOT be committed to the repo and MUST NOT be included in GitHub Release assets.
+  - Store filled schedules only in private, out-of-repo storage before/throughout the ceremony.
+  - Template/schema: `operational/RUBIN_GENESIS_DEV_FUND_SCHEDULE_TEMPLATE_v1.1.md` and `scripts/genesis/README.md`.
+- Recommended local ignore patterns (to reduce accidental commits):
+
+```gitignore
+operational/dev_fund_schedule.csv
+**/*dev_fund_schedule*.csv
+**/*.dev-fund-schedule.csv
+```
+
+- Optional hardening: add a pre-commit/CI rule that rejects committed schedule CSVs (fail-fast before publication).
 - After updating the profile, commit the changes. The resulting commit hash is the `SPEC_COMMIT` you must tag/release.
 
 ## 2. Deterministic derivations (must match spec)


### PR DESCRIPTION
Non-consensus runbook hardening:

- Clarify that `SPEC_COMMIT` must include the final mainnet profile genesis bytes.
- Add deterministic tooling commands using `scripts/genesis/build_genesis_v1_1.py` for verify/update flows.
- Add an explicit "commit changes => SPEC_COMMIT" step to reduce operator confusion.

No consensus rules changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated mainnet genesis ceremony to require final profile values (including concrete genesis bytes) and recompute derived identifiers before recording SPEC_COMMIT.
  * Added a recommended deterministic genesis builder with verification, in-place profile update commands, premine/dev-fund schedule guidance, and explicit commit-and-record steps.
  * Expanded operational guidance on schedule artifacts, storage, and release-security practices.
* **Chores**
  * Added ignore rules for ceremony input schedule files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->