### PR TITLE
go(consensus): HTLC_V2 unit tests

### DIFF
--- a/clients/go/consensus/validate_test.go
+++ b/clients/go/consensus/validate_test.go
@@ -299,11 +299,27 @@ func TestValidateInputAuthorizationHTLCV2(t *testing.T) {
 		}
 	})
 
+	t.Run("active claim wrong key", func(t *testing.T) {
+		tx := makeHTLCV2Tx(t, nil, refundPub, refundSig, makeHTLCV2Anchor(t, preimage))
+		err := ValidateInputAuthorization(p, [32]byte{}, &tx, 0, prevout.Value, &prevout, 0, 0, 0, false, true)
+		if err == nil || err.Error() != "TX_ERR_SIG_INVALID" {
+			t.Fatalf("expected sig invalid, got %v", err)
+		}
+	})
+
 	t.Run("active refund path no anchors", func(t *testing.T) {
 		tx := makeHTLCV2Tx(t, nil, refundPub, refundSig)
 		err := ValidateInputAuthorization(p, [32]byte{}, &tx, 0, prevout.Value, &prevout, 0, 150, 0, false, true)
 		if err != nil {
 			t.Fatalf("expected success, got %v", err)
+		}
+	})
+
+	t.Run("active refund wrong key", func(t *testing.T) {
+		tx := makeHTLCV2Tx(t, nil, claimPub, claimSig)
+		err := ValidateInputAuthorization(p, [32]byte{}, &tx, 0, prevout.Value, &prevout, 0, 150, 0, false, true)
+		if err == nil || err.Error() != "TX_ERR_SIG_INVALID" {
+			t.Fatalf("expected sig invalid, got %v", err)
 		}
 	})
 


### PR DESCRIPTION
Adds focused unit coverage for consensus HTLC_V2 validation paths:

- `satisfyLock`, `validateHTLCScriptSigLen`, `checkWitnessFormat`, `validateOutputCovenantConstraints`
- `ValidateInputAuthorization` CORE_HTLC_V2: inactive gate, scriptsig rule, claim/refund, 0/1/2 anchors, timelock fail, hash mismatch

Cross-check: `reports/2026-02-19_report_phase0_test_additions_consensus.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive HTLC v2 validation tests covering timelock enforcement, anchor handling, script-sig length checks, witness format validation, output covenant constraints, and input authorization (claim/refund) paths. Introduces new test scaffolding to simulate transaction contexts and extensive error-path coverage for inactive deployments, parse failures, timelock violations, signature issues, and duplicate/insufficient data scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->