### PR TITLE
go(consensus): add Phase1-oriented unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,11 +16,16 @@ clients/go/semgrep_output.json
 **/gosec_output.json
 **/semgrep_output.json
 
+# Go local coverage artifacts
+clients/go/coverage*.out
+clients/go/coverage*.txt
+
 # Rust scan artifacts
 clients/rust/cargo_audit.json
 **/cargo_audit.json
 
 # Local analysis outputs (generated, not source)
+analysis/
 analysis/spec/spec-diff.json
 analysis/spec/spec-explainer.json
 
@@ -44,6 +49,12 @@ rubin-ui/
 
 # Local scratch docs
 IMPLEMENTATION_ROADMAP.md
+
+# Local scratch crypto notes
+clients/go/_manual_SHA3/
+
+# Stray local file created by tooling
+=
 
 # Security scan artifacts
 clients/go/gosec_output.json

--- a/clients/go/consensus/P1apply_block_test.go
+++ b/clients/go/consensus/P1apply_block_test.go
@@ -1,0 +1,406 @@
+package consensus
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"rubin.dev/node/crypto"
+)
+
+func repeatByte(value byte, n int) []byte {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = value
+	}
+	return b
+}
+
+func mustSHA3ForTest(t *testing.T, p crypto.CryptoProvider, input []byte) [32]byte {
+	t.Helper()
+	out, err := p.SHA3_256(input)
+	if err != nil {
+		t.Fatalf("SHA3_256 failed: %v", err)
+	}
+	return out
+}
+
+func makeP2PKOutputForKeyID(keyID [32]byte, value uint64) TxOutput {
+	covenantData := make([]byte, 33)
+	covenantData[0] = SUITE_ID_ML_DSA
+	copy(covenantData[1:], keyID[:])
+	return TxOutput{
+		Value:        value,
+		CovenantType: CORE_P2PK,
+		CovenantData: covenantData,
+	}
+}
+
+func sha3NoErr(p crypto.CryptoProvider, input []byte) [32]byte {
+	out, err := p.SHA3_256(input)
+	if err != nil {
+		panic(err)
+	}
+	return out
+}
+
+func makeApplyCoinbaseTx(height uint64, outputs []TxOutput) Tx {
+	if len(outputs) == 0 {
+		outputs = []TxOutput{
+			{
+				Value:        0,
+				CovenantType: CORE_P2PK,
+				CovenantData: make([]byte, 33),
+			},
+		}
+	}
+	return Tx{
+		Version: 1,
+		TxNonce: 0,
+		Inputs: []TxInput{
+			{
+				PrevTxid:  [32]byte{},
+				PrevVout:  TX_COINBASE_PREVOUT_VOUT,
+				Sequence:  TX_COINBASE_PREVOUT_VOUT,
+				ScriptSig: nil,
+			},
+		},
+		Outputs:  outputs,
+		Locktime: uint32(height),
+		Witness:  WitnessSection{},
+	}
+}
+
+func makeHTLCV1RefundCovenant(refundKeyID [32]byte) TxOutput {
+	data := make([]byte, 105)
+	data[32] = TIMELOCK_MODE_HEIGHT
+	binary.LittleEndian.PutUint64(data[33:41], 1)
+	copy(data[41:73], make([]byte, 32))
+	copy(data[73:105], refundKeyID[:])
+	return TxOutput{
+		CovenantType: CORE_HTLC_V1,
+		Value:        10,
+		CovenantData: data,
+	}
+}
+
+func makeHTLCSpendBundle(
+	p crypto.CryptoProvider,
+	inputCount int,
+	chainHeight uint64,
+) (Tx, map[TxOutPoint]UtxoEntry) {
+	witnessPub := repeatByte(0x11, ML_DSA_PUBKEY_BYTES)
+	refundID := sha3NoErr(p, witnessPub)
+	covenant := makeHTLCV1RefundCovenant(refundID)
+
+	utxo := make(map[TxOutPoint]UtxoEntry, inputCount)
+	var totalIn uint64
+	for i := 0; i < inputCount; i++ {
+		point := TxOutPoint{
+			TxID: [32]byte{byte(i)},
+			Vout: 0,
+		}
+		utxo[point] = UtxoEntry{
+			Output:            covenant,
+			CreationHeight:    0,
+			CreatedByCoinbase: false,
+		}
+		totalIn += covenant.Value
+	}
+
+	inputs := make([]TxInput, 0, len(utxo))
+	witnesses := make([]WitnessItem, 0, len(utxo))
+	for point := range utxo {
+		_ = point
+		inputs = append(inputs, TxInput{
+			PrevTxid:  point.TxID,
+			PrevVout:  point.Vout,
+			ScriptSig: nil,
+			Sequence:  1,
+		})
+		witnesses = append(witnesses, WitnessItem{
+			SuiteID:   SUITE_ID_ML_DSA,
+			Pubkey:    append([]byte(nil), witnessPub...),
+			Signature: make([]byte, ML_DSA_SIG_BYTES),
+		})
+	}
+
+	return Tx{
+		Version: 1,
+		TxNonce: 1,
+		Inputs:  inputs,
+		Outputs: []TxOutput{
+			makeP2PKOutputForKeyID(refundID, totalIn-1),
+		},
+		Locktime: uint32(chainHeight),
+		Witness: WitnessSection{
+			Witnesses: witnesses,
+		},
+	}, utxo
+}
+
+func makeApplyBlock(height uint64, ancestor BlockHeader, ts uint64, txs []Tx) Block {
+	header := BlockHeader{
+		Version:       1,
+		Timestamp:     ts,
+		Target:        ancestor.Target,
+		Nonce:         1,
+		MerkleRoot:    [32]byte{},
+		PrevBlockHash: [32]byte{},
+	}
+	if height > 0 {
+		parentHash, _ := BlockHeaderHash(applyTxStubProvider{}, ancestor)
+		header.PrevBlockHash = parentHash
+	}
+	if len(txs) > 0 {
+		ptrs := make([]*Tx, len(txs))
+		for i := range txs {
+			ptrs[i] = &txs[i]
+		}
+		header.MerkleRoot, _ = merkleRootTxIDs(applyTxStubProvider{}, ptrs)
+	}
+	return Block{Header: header, Transactions: txs}
+}
+
+func makeParentHeader(target [32]byte, ts uint64) BlockHeader {
+	return BlockHeader{
+		Version:       1,
+		PrevBlockHash: [32]byte{},
+		MerkleRoot:    [32]byte{},
+		Timestamp:     ts,
+		Target:        target,
+		Nonce:         7,
+	}
+}
+
+func TestApplyBlock(t *testing.T) {
+	p := applyTxStubProvider{}
+	key := mustSHA3ForTest(t, p, repeatByte(0x11, ML_DSA_PUBKEY_BYTES))
+	cbOut := makeP2PKOutputForKeyID(key, 0)
+
+	t.Run("минимальный valid block (coinbase только)", func(t *testing.T) {
+		parent := makeParentHeader([32]byte{0xff}, 1)
+		cb := makeApplyCoinbaseTx(0, []TxOutput{cbOut})
+		block := makeApplyBlock(0, parent, 2, []Tx{cb})
+		utxo := map[TxOutPoint]UtxoEntry{}
+		if err := ApplyBlock(p, [32]byte{}, &block, utxo, BlockValidationContext{Height: 0}); err != nil {
+			t.Fatalf("expected valid block, got %v", err)
+		}
+		if len(utxo) != 1 {
+			t.Fatalf("expected 1 utxo, got %d", len(utxo))
+		}
+	})
+
+	t.Run("merkle root invalid", func(t *testing.T) {
+		parent := makeParentHeader([32]byte{0xff}, 10)
+		cb := makeApplyCoinbaseTx(1, []TxOutput{cbOut})
+		block := makeApplyBlock(1, parent, 11, []Tx{cb})
+		block.Header.MerkleRoot[0] ^= 0x01
+		err := ApplyBlock(p, [32]byte{}, &block, map[TxOutPoint]UtxoEntry{}, BlockValidationContext{Height: 1, AncestorHeaders: []BlockHeader{parent}})
+		if err == nil || err.Error() != BLOCK_ERR_MERKLE_INVALID {
+			t.Fatalf("expected BLOCK_ERR_MERKLE_INVALID, got %v", err)
+		}
+	})
+
+	t.Run("pow invalid", func(t *testing.T) {
+		parent := makeParentHeader([32]byte{}, 10)
+		cb := makeApplyCoinbaseTx(1, []TxOutput{cbOut})
+		block := makeApplyBlock(1, parent, 11, []Tx{cb})
+		block.Header.Target = [32]byte{}
+		err := ApplyBlock(p, [32]byte{}, &block, map[TxOutPoint]UtxoEntry{}, BlockValidationContext{Height: 1, AncestorHeaders: []BlockHeader{parent}})
+		if err == nil || err.Error() != BLOCK_ERR_POW_INVALID {
+			t.Fatalf("expected BLOCK_ERR_POW_INVALID, got %v", err)
+		}
+	})
+
+	t.Run("timestamp old", func(t *testing.T) {
+		parent := makeParentHeader([32]byte{0xff}, 10)
+		cb := makeApplyCoinbaseTx(1, []TxOutput{cbOut})
+		block := makeApplyBlock(1, parent, 10, []Tx{cb})
+		err := ApplyBlock(p, [32]byte{}, &block, map[TxOutPoint]UtxoEntry{}, BlockValidationContext{Height: 1, AncestorHeaders: []BlockHeader{parent}})
+		if err == nil || err.Error() != BLOCK_ERR_TIMESTAMP_OLD {
+			t.Fatalf("expected BLOCK_ERR_TIMESTAMP_OLD, got %v", err)
+		}
+	})
+
+	t.Run("timestamp future", func(t *testing.T) {
+		parent := makeParentHeader([32]byte{0xff}, 100)
+		cb := makeApplyCoinbaseTx(1, []TxOutput{cbOut})
+		block := makeApplyBlock(1, parent, 100+MAX_FUTURE_DRIFT+1, []Tx{cb})
+		err := ApplyBlock(p, [32]byte{}, &block, map[TxOutPoint]UtxoEntry{}, BlockValidationContext{
+			Height:          1,
+			AncestorHeaders: []BlockHeader{parent},
+			LocalTimeSet:    true,
+			LocalTime:       100,
+		})
+		if err == nil || err.Error() != BLOCK_ERR_TIMESTAMP_FUTURE {
+			t.Fatalf("expected BLOCK_ERR_TIMESTAMP_FUTURE, got %v", err)
+		}
+	})
+
+	t.Run("weight exceeded", func(t *testing.T) {
+		parent := makeParentHeader([32]byte{0xff}, 10)
+		heavyTx, utxo := makeHTLCSpendBundle(p, MAX_TX_INPUTS, 1)
+		cb := makeApplyCoinbaseTx(1, []TxOutput{cbOut})
+		block := makeApplyBlock(1, parent, 11, []Tx{cb, heavyTx})
+		err := ApplyBlock(p, [32]byte{}, &block, utxo, BlockValidationContext{Height: 1, AncestorHeaders: []BlockHeader{parent}})
+		if err == nil || err.Error() != TX_ERR_WITNESS_OVERFLOW {
+			t.Fatalf("expected TX_ERR_WITNESS_OVERFLOW, got %v", err)
+		}
+	})
+
+	t.Run("subsidy exceeded", func(t *testing.T) {
+		parent := makeParentHeader([32]byte{0xff}, 10)
+		cb := makeApplyCoinbaseTx(1, []TxOutput{makeP2PKOutputForKeyID(key, 10_000_000_000_000)})
+		block := makeApplyBlock(1, parent, 11, []Tx{cb})
+		err := ApplyBlock(p, [32]byte{}, &block, map[TxOutPoint]UtxoEntry{}, BlockValidationContext{Height: 1, AncestorHeaders: []BlockHeader{parent}})
+		if err == nil || err.Error() != BLOCK_ERR_SUBSIDY_EXCEEDED {
+			t.Fatalf("expected BLOCK_ERR_SUBSIDY_EXCEEDED, got %v", err)
+		}
+	})
+
+	t.Run("double spend in one block", func(t *testing.T) {
+		parent := makeParentHeader([32]byte{0xff}, 10)
+		spendKey := repeatByte(0x22, ML_DSA_PUBKEY_BYTES)
+		spendKeyID := mustSHA3ForTest(t, p, spendKey)
+		point := TxOutPoint{TxID: [32]byte{0x01}, Vout: 0}
+		utxo := map[TxOutPoint]UtxoEntry{
+			point: {Output: makeP2PKOutputForKeyID(spendKeyID, 20), CreationHeight: 0},
+		}
+		spend := Tx{
+			Version: 1,
+			TxNonce: 1,
+			Inputs: []TxInput{{
+				PrevTxid: point.TxID, PrevVout: point.Vout, Sequence: 1, ScriptSig: nil,
+			}},
+			Outputs:  []TxOutput{makeP2PKOutputForKeyID(spendKeyID, 10)},
+			Locktime: 1,
+			Witness: WitnessSection{
+				Witnesses: []WitnessItem{{
+					SuiteID:   SUITE_ID_ML_DSA,
+					Pubkey:    spendKey,
+					Signature: make([]byte, ML_DSA_SIG_BYTES),
+				}},
+			},
+		}
+		spendCopy := spend
+		spendCopy.TxNonce = 2
+		cb := makeApplyCoinbaseTx(1, []TxOutput{cbOut})
+		block := makeApplyBlock(1, parent, 11, []Tx{cb, spend, spendCopy})
+		err := ApplyBlock(p, [32]byte{}, &block, utxo, BlockValidationContext{Height: 1, AncestorHeaders: []BlockHeader{parent}})
+		if err == nil || err.Error() != TX_ERR_MISSING_UTXO {
+			t.Fatalf("expected TX_ERR_MISSING_UTXO, got %v", err)
+		}
+	})
+
+	t.Run("utxo updated after apply", func(t *testing.T) {
+		parent := makeParentHeader([32]byte{0xff}, 10)
+		spendKey := repeatByte(0x33, ML_DSA_PUBKEY_BYTES)
+		spendKeyID := mustSHA3ForTest(t, p, spendKey)
+		point := TxOutPoint{TxID: [32]byte{0x02}, Vout: 0}
+		utxo := map[TxOutPoint]UtxoEntry{
+			point: {
+				Output:            makeP2PKOutputForKeyID(spendKeyID, 20),
+				CreationHeight:    0,
+				CreatedByCoinbase: false,
+			},
+		}
+		spend := Tx{
+			Version: 1,
+			TxNonce: 1,
+			Inputs: []TxInput{{
+				PrevTxid: point.TxID, PrevVout: point.Vout, Sequence: 1, ScriptSig: nil,
+			}},
+			Outputs:  []TxOutput{makeP2PKOutputForKeyID(spendKeyID, 10)},
+			Locktime: 1,
+			Witness: WitnessSection{
+				Witnesses: []WitnessItem{{
+					SuiteID:   SUITE_ID_ML_DSA,
+					Pubkey:    spendKey,
+					Signature: make([]byte, ML_DSA_SIG_BYTES),
+				}},
+			},
+		}
+		cb := makeApplyCoinbaseTx(1, []TxOutput{cbOut})
+		block := makeApplyBlock(1, parent, 11, []Tx{cb, spend})
+		if err := ApplyBlock(p, [32]byte{}, &block, utxo, BlockValidationContext{Height: 1, AncestorHeaders: []BlockHeader{parent}}); err != nil {
+			t.Fatalf("expected valid block, got %v", err)
+		}
+		if _, ok := utxo[point]; ok {
+			t.Fatalf("expected input utxo to be deleted")
+		}
+		if len(utxo) != 2 {
+			t.Fatalf("expected 2 utxos (coinbase + spend output), got %d", len(utxo))
+		}
+		spendTxID, err := TxID(p, &spend)
+		if err != nil {
+			t.Fatalf("tx id calc failed: %v", err)
+		}
+		found := false
+		for u := range utxo {
+			if bytes.Equal(u.TxID[:], spendTxID[:]) && u.Vout == 0 {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("expected spend output with txid %x", spendTxID)
+		}
+	})
+}
+
+func TestValidateCoinbaseTxInputs(t *testing.T) {
+	t.Run("txNonce!=0", func(t *testing.T) {
+		tx := makeApplyCoinbaseTx(0, nil)
+		tx.TxNonce = 1
+		err := validateCoinbaseTxInputs(&tx)
+		if err == nil || err.Error() != BLOCK_ERR_COINBASE_INVALID {
+			t.Fatalf("expected BLOCK_ERR_COINBASE_INVALID, got %v", err)
+		}
+	})
+
+	t.Run("len(inputs)!=1", func(t *testing.T) {
+		tx := makeApplyCoinbaseTx(0, nil)
+		tx.Inputs = nil
+		err := validateCoinbaseTxInputs(&tx)
+		if err == nil || err.Error() != BLOCK_ERR_COINBASE_INVALID {
+			t.Fatalf("expected BLOCK_ERR_COINBASE_INVALID, got %v", err)
+		}
+	})
+
+	t.Run("sequence!=0xFFFFFFFF", func(t *testing.T) {
+		tx := makeApplyCoinbaseTx(0, nil)
+		tx.Inputs[0].Sequence = 1
+		err := validateCoinbaseTxInputs(&tx)
+		if err == nil || err.Error() != BLOCK_ERR_COINBASE_INVALID {
+			t.Fatalf("expected BLOCK_ERR_COINBASE_INVALID, got %v", err)
+		}
+	})
+
+	t.Run("prevTxid!=zero", func(t *testing.T) {
+		tx := makeApplyCoinbaseTx(0, nil)
+		tx.Inputs[0].PrevTxid = [32]byte{1}
+		err := validateCoinbaseTxInputs(&tx)
+		if err == nil || err.Error() != BLOCK_ERR_COINBASE_INVALID {
+			t.Fatalf("expected BLOCK_ERR_COINBASE_INVALID, got %v", err)
+		}
+	})
+
+	t.Run("scriptSig не пуст", func(t *testing.T) {
+		tx := makeApplyCoinbaseTx(0, nil)
+		tx.Inputs[0].ScriptSig = []byte{1}
+		err := validateCoinbaseTxInputs(&tx)
+		if err == nil || err.Error() != BLOCK_ERR_COINBASE_INVALID {
+			t.Fatalf("expected BLOCK_ERR_COINBASE_INVALID, got %v", err)
+		}
+	})
+
+	t.Run("witnesses не пуст", func(t *testing.T) {
+		tx := makeApplyCoinbaseTx(0, nil)
+		tx.Witness.Witnesses = []WitnessItem{{SuiteID: SUITE_ID_ML_DSA}}
+		err := validateCoinbaseTxInputs(&tx)
+		if err == nil || err.Error() != BLOCK_ERR_COINBASE_INVALID {
+			t.Fatalf("expected BLOCK_ERR_COINBASE_INVALID, got %v", err)
+		}
+	})
+}

--- a/clients/go/consensus/P1chainstate_hash_test.go
+++ b/clients/go/consensus/P1chainstate_hash_test.go
@@ -1,0 +1,190 @@
+package consensus
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+func makeUtxoSetOutput(t *testing.T, suiteID byte, value uint64) TxOutput {
+	t.Helper()
+	key := bytes.Repeat([]byte{byte(suiteID)}, ML_DSA_PUBKEY_BYTES)
+	keyID := mustSHA3ForTest(t, applyTxStubProvider{}, key)
+	return TxOutput{
+		Value:        value,
+		CovenantType: CORE_P2PK,
+		CovenantData: append([]byte{SUITE_ID_ML_DSA}, keyID[:]...),
+	}
+}
+
+func makeTestUtxoEntry(value uint64, createdByCoinbase bool) map[TxOutPoint]UtxoEntry {
+	key := [32]byte{1, 2, 3, 4}
+	point := TxOutPoint{TxID: key, Vout: 7}
+	return map[TxOutPoint]UtxoEntry{
+		point: {
+			Output: TxOutput{
+				Value:        value,
+				CovenantType: CORE_P2PK,
+				CovenantData: make([]byte, 33),
+			},
+			CreationHeight:    4,
+			CreatedByCoinbase: createdByCoinbase,
+		},
+	}
+}
+
+func TestUtxoSetHash(t *testing.T) {
+	t.Run("empty utxo -> deterministic non-zero hash", func(t *testing.T) {
+		h1, err := UtxoSetHash(applyTxStubProvider{}, map[TxOutPoint]UtxoEntry{})
+		if err != nil {
+			t.Fatalf("empty hash failed: %v", err)
+		}
+		h2, err := UtxoSetHash(applyTxStubProvider{}, map[TxOutPoint]UtxoEntry{})
+		if err != nil {
+			t.Fatalf("empty hash failed: %v", err)
+		}
+		var zero [32]byte
+		if h1 == zero {
+			t.Fatalf("expected non-zero hash for empty set")
+		}
+		if h1 != h2 {
+			t.Fatalf("empty-set hash not deterministic: %x != %x", h1, h2)
+		}
+	})
+
+	t.Run("1 entry -> manual SHA3", func(t *testing.T) {
+		point := TxOutPoint{
+			TxID: [32]byte{0x99, 0x88, 0x77},
+			Vout: 3,
+		}
+		entry := UtxoEntry{
+			Output: TxOutput{
+				Value:        12345,
+				CovenantType: CORE_P2PK,
+				CovenantData: make([]byte, 33),
+			},
+			CreationHeight:    55,
+			CreatedByCoinbase: true,
+		}
+		utxo := map[TxOutPoint]UtxoEntry{
+			point: entry,
+		}
+		got, err := UtxoSetHash(applyTxStubProvider{}, utxo)
+		if err != nil {
+			t.Fatalf("UtxoSetHash failed: %v", err)
+		}
+
+		var payload []byte
+		payload = append(payload, []byte(utxoSetHashDST)...)
+		payload = append(payload, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00)
+
+		keyBytes := outpointKeyBytes(point)
+		payload = append(payload, keyBytes[:]...)
+
+		var u64b [8]byte
+		binary.LittleEndian.PutUint64(u64b[:], entry.Output.Value)
+		payload = append(payload, u64b[:]...)
+		var u16b [2]byte
+		binary.LittleEndian.PutUint16(u16b[:], entry.Output.CovenantType)
+		payload = append(payload, u16b[:]...)
+		payload = append(payload, CompactSize(uint64(len(entry.Output.CovenantData))).Encode()...)
+
+		payload = append(payload, entry.Output.CovenantData...)
+		binary.LittleEndian.PutUint64(u64b[:], entry.CreationHeight)
+		payload = append(payload, u64b[:]...)
+		payload = append(payload, 0x01)
+
+		expected, err := applyTxStubProvider{}.SHA3_256(payload)
+		if err != nil {
+			t.Fatalf("SHA3_256 failed: %v", err)
+		}
+		if got != expected {
+			t.Fatalf("hash mismatch: got %x expected %x payload=%x", got, expected, payload)
+		}
+	})
+
+	t.Run("order of map insertion does not change hash", func(t *testing.T) {
+		pointA := TxOutPoint{TxID: [32]byte{0x01}, Vout: 0}
+		pointB := TxOutPoint{TxID: [32]byte{0x02}, Vout: 1}
+		utxo1 := map[TxOutPoint]UtxoEntry{
+			pointA: {
+				Output:         makeUtxoSetOutput(t, 0x11, 10),
+				CreationHeight: 1,
+			},
+			pointB: {
+				Output:         makeUtxoSetOutput(t, 0x22, 20),
+				CreationHeight: 2,
+			},
+		}
+		utxo2 := map[TxOutPoint]UtxoEntry{
+			pointB: {
+				Output:         makeUtxoSetOutput(t, 0x22, 20),
+				CreationHeight: 2,
+			},
+			pointA: {
+				Output:         makeUtxoSetOutput(t, 0x11, 10),
+				CreationHeight: 1,
+			},
+		}
+
+		h1, err := UtxoSetHash(applyTxStubProvider{}, utxo1)
+		if err != nil {
+			t.Fatalf("UtxoSetHash 1 failed: %v", err)
+		}
+		h2, err := UtxoSetHash(applyTxStubProvider{}, utxo2)
+		if err != nil {
+			t.Fatalf("UtxoSetHash 2 failed: %v", err)
+		}
+		if h1 != h2 {
+			t.Fatalf("order-dependent hash: %x != %x", h1, h2)
+		}
+	})
+
+	t.Run("different utxo set -> different hash", func(t *testing.T) {
+		base := map[TxOutPoint]UtxoEntry{
+			{TxID: [32]byte{0x01}, Vout: 0}: {
+				Output: TxOutput{
+					Value:        1,
+					CovenantType: CORE_P2PK,
+					CovenantData: make([]byte, 33),
+				},
+				CreationHeight: 1,
+			},
+		}
+		other := map[TxOutPoint]UtxoEntry{
+			{TxID: [32]byte{0x01}, Vout: 0}: {
+				Output: TxOutput{
+					Value:        2,
+					CovenantType: CORE_P2PK,
+					CovenantData: make([]byte, 33),
+				},
+				CreationHeight: 1,
+			},
+		}
+		h1, err := UtxoSetHash(applyTxStubProvider{}, base)
+		if err != nil {
+			t.Fatalf("UtxoSetHash base failed: %v", err)
+		}
+		h2, err := UtxoSetHash(applyTxStubProvider{}, other)
+		if err != nil {
+			t.Fatalf("UtxoSetHash other failed: %v", err)
+		}
+		if h1 == h2 {
+			t.Fatalf("different utxo sets produced same hash")
+		}
+	})
+}
+
+func TestOutpointKeyBytes(t *testing.T) {
+	point := TxOutPoint{
+		TxID: [32]byte{0x01, 0x02, 0x03, 0x04},
+		Vout: 0x01020304,
+	}
+	expected := make([]byte, 36)
+	copy(expected[:32], point.TxID[:])
+	binary.LittleEndian.PutUint32(expected[32:36], point.Vout)
+	got := outpointKeyBytes(point)
+	if !bytes.Equal(got[:], expected) {
+		t.Fatalf("expected %x got %x", expected, got[:])
+	}
+}

--- a/clients/go/consensus/P1parse_test.go
+++ b/clients/go/consensus/P1parse_test.go
@@ -1,0 +1,293 @@
+package consensus
+
+import (
+	"bytes"
+	"testing"
+)
+
+func makeParseCoinbaseTx(height uint32) Tx {
+	return Tx{
+		Version: 1,
+		TxNonce: 0,
+		Inputs: []TxInput{
+			{
+				PrevTxid: [32]byte{},
+				PrevVout: TX_COINBASE_PREVOUT_VOUT,
+				Sequence: TX_COINBASE_PREVOUT_VOUT,
+			},
+		},
+		Outputs: []TxOutput{
+			{
+				Value:        0,
+				CovenantType: CORE_P2PK,
+				CovenantData: bytes.Repeat([]byte{0x11}, 33),
+			},
+		},
+		Locktime: uint32(height),
+		Witness:  WitnessSection{},
+	}
+}
+
+func makeParseTxFixture() Tx {
+	return Tx{
+		Version: 1,
+		TxNonce: 1,
+		Inputs: []TxInput{
+			{
+				PrevTxid:  [32]byte{0x11},
+				PrevVout:  0,
+				ScriptSig: nil,
+				Sequence:  9,
+			},
+		},
+		Outputs: []TxOutput{
+			{
+				Value:        100,
+				CovenantType: CORE_P2PK,
+				CovenantData: bytes.Repeat([]byte{0xaa}, 33),
+			},
+		},
+		Locktime: 12345,
+		Witness: WitnessSection{
+			Witnesses: []WitnessItem{{
+				SuiteID:   SUITE_ID_ML_DSA,
+				Pubkey:    bytes.Repeat([]byte{0x11}, ML_DSA_PUBKEY_BYTES),
+				Signature: bytes.Repeat([]byte{0x22}, ML_DSA_SIG_BYTES),
+			}},
+		},
+	}
+}
+
+func TestParseTxBytes(t *testing.T) {
+	t.Run("valid tx (1 input + 1 output + ML-DSA witness)", func(t *testing.T) {
+		tx := makeParseTxFixture()
+		raw := TxBytes(&tx)
+		parsed, err := ParseTxBytes(raw)
+		if err != nil {
+			t.Fatalf("expected parse success: %v", err)
+		}
+		if parsed.TxNonce != tx.TxNonce || parsed.Locktime != tx.Locktime {
+			t.Fatalf("parsed tx mismatch: got %#v want %#v", parsed, tx)
+		}
+	})
+
+	t.Run("trailing bytes -> parse: trailing bytes", func(t *testing.T) {
+		tx := makeParseTxFixture()
+		raw := append(TxBytes(&tx), 0x00)
+		if _, err := ParseTxBytes(raw); err == nil || err.Error() != "parse: trailing bytes" {
+			t.Fatalf("expected trailing bytes parse error, got %v", err)
+		}
+	})
+
+	t.Run("truncated на каждом поле", func(t *testing.T) {
+		tx := makeParseTxFixture()
+		full := TxBytes(&tx)
+		for i := 0; i < len(full); i++ {
+			if _, err := ParseTxBytes(full[:i]); err == nil {
+				t.Fatalf("expected truncation error at len=%d", i)
+			}
+		}
+	})
+
+	t.Run("compactsize overflow в input_count", func(t *testing.T) {
+		raw := make([]byte, 0, 12+9)
+		raw = append(raw, []byte{0x01, 0x00, 0x00, 0x00}...)
+		raw = append(raw, []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}...)
+		raw = append(raw, 0xff)
+		raw = append(raw, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80)
+		if _, err := ParseTxBytes(raw); err == nil {
+			t.Fatal("expected compactsize overflow to fail")
+		}
+	})
+}
+
+func TestParseBlockBytes(t *testing.T) {
+	header := BlockHeader{
+		Version:       1,
+		PrevBlockHash: [32]byte{},
+		MerkleRoot:    [32]byte{0x11},
+		Timestamp:     100,
+		Target:        [32]byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+		Nonce:         7,
+	}
+
+	t.Run("coinbase-only block", func(t *testing.T) {
+		cb := makeParseCoinbaseTx(0)
+		block := Block{Header: header, Transactions: []Tx{cb}}
+		block.Header.MerkleRoot, _ = merkleRootTxIDs(applyTxStubProvider{}, []*Tx{&block.Transactions[0]})
+		raw := BlockBytes(&block)
+		parsed, err := ParseBlockBytes(raw)
+		if err != nil {
+			t.Fatalf("expected parse success: %v", err)
+		}
+		if len(parsed.Transactions) != 1 {
+			t.Fatalf("unexpected tx count: %d", len(parsed.Transactions))
+		}
+	})
+
+	t.Run("coinbase + 2 tx", func(t *testing.T) {
+		cb := makeParseCoinbaseTx(0)
+		spend := makeParseTxFixture()
+		block := Block{Header: header, Transactions: []Tx{cb, spend}}
+		block.Header.MerkleRoot, _ = merkleRootTxIDs(applyTxStubProvider{}, []*Tx{&block.Transactions[0], &block.Transactions[1]})
+		raw := BlockBytes(&block)
+		if _, err := ParseBlockBytes(raw); err != nil {
+			t.Fatalf("expected parse success: %v", err)
+		}
+	})
+
+	t.Run("trailing bytes -> BLOCK_ERR_PARSE", func(t *testing.T) {
+		cb := makeParseCoinbaseTx(0)
+		block := Block{Header: header, Transactions: []Tx{cb}}
+		block.Header.MerkleRoot, _ = merkleRootTxIDs(applyTxStubProvider{}, []*Tx{&block.Transactions[0]})
+		raw := append(BlockBytes(&block), 0x00, 0x11, 0x22)
+		if _, err := ParseBlockBytes(raw); err == nil || err.Error() != "BLOCK_ERR_PARSE" {
+			t.Fatalf("expected BLOCK_ERR_PARSE, got %v", err)
+		}
+	})
+}
+
+func TestParseBlockHeader(t *testing.T) {
+	header := BlockHeader{
+		Version:   4,
+		Timestamp: 0x1122334455667788,
+		Nonce:     0x99aabbccddeeff00,
+		Target:    [32]byte{0x01, 0x02, 0x03},
+	}
+	copy(header.PrevBlockHash[:], bytes.Repeat([]byte{0xaa}, 32))
+	copy(header.MerkleRoot[:], bytes.Repeat([]byte{0xbb}, 32))
+
+	t.Run("correct 116-байтовый header", func(t *testing.T) {
+		raw := BlockHeaderBytes(header)
+		parsed, err := ParseBlockHeader(newCursor(raw))
+		if err != nil {
+			t.Fatalf("expected parse success: %v", err)
+		}
+		if parsed != header {
+			t.Fatalf("header mismatch: got %#v want %#v", parsed, header)
+		}
+	})
+
+	t.Run("truncated header", func(t *testing.T) {
+		raw := BlockHeaderBytes(header)
+		for i := 0; i < len(raw); i++ {
+			if _, err := ParseBlockHeader(newCursor(raw[:i])); err == nil {
+				t.Fatalf("expected truncation parse error at len=%d", i)
+			}
+		}
+	})
+}
+
+func TestParseOutput(t *testing.T) {
+	t.Run("CORE_P2PK", func(t *testing.T) {
+		out := TxOutput{Value: 1, CovenantType: CORE_P2PK, CovenantData: make([]byte, 33)}
+		raw := TxOutputBytes(out)
+		parsed, err := parseOutput(newCursor(raw))
+		if err != nil {
+			t.Fatalf("parse p2pk output: %v", err)
+		}
+		if parsed.CovenantType != CORE_P2PK || parsed.Value != out.Value || len(parsed.CovenantData) != len(out.CovenantData) {
+			t.Fatalf("unexpected output: %#v", parsed)
+		}
+	})
+
+	t.Run("CORE_TIMELOCK_V1", func(t *testing.T) {
+		out := TxOutput{Value: 1, CovenantType: CORE_TIMELOCK_V1, CovenantData: make([]byte, 9)}
+		raw := TxOutputBytes(out)
+		parsed, err := parseOutput(newCursor(raw))
+		if err != nil {
+			t.Fatalf("parse timelock output: %v", err)
+		}
+		if parsed.CovenantType != CORE_TIMELOCK_V1 || len(parsed.CovenantData) != 9 {
+			t.Fatalf("unexpected output: %#v", parsed)
+		}
+	})
+
+	t.Run("CORE_HTLC_V1", func(t *testing.T) {
+		out := TxOutput{Value: 1, CovenantType: CORE_HTLC_V1, CovenantData: make([]byte, 105)}
+		raw := TxOutputBytes(out)
+		parsed, err := parseOutput(newCursor(raw))
+		if err != nil {
+			t.Fatalf("parse htlc_v1 output: %v", err)
+		}
+		if parsed.CovenantType != CORE_HTLC_V1 || len(parsed.CovenantData) != 105 {
+			t.Fatalf("unexpected output: %#v", parsed)
+		}
+	})
+
+	t.Run("CORE_VAULT_V1", func(t *testing.T) {
+		out := TxOutput{Value: 1, CovenantType: CORE_VAULT_V1, CovenantData: make([]byte, 73)}
+		raw := TxOutputBytes(out)
+		parsed, err := parseOutput(newCursor(raw))
+		if err != nil {
+			t.Fatalf("parse vault output: %v", err)
+		}
+		if parsed.CovenantType != CORE_VAULT_V1 || len(parsed.CovenantData) != 73 {
+			t.Fatalf("unexpected output: %#v", parsed)
+		}
+	})
+}
+
+func TestParseWitnessItem(t *testing.T) {
+	t.Run("SENTINEL", func(t *testing.T) {
+		item := WitnessItem{SuiteID: SUITE_ID_SENTINEL}
+		raw := WitnessItemBytes(item)
+		parsed, err := parseWitnessItem(newCursor(raw))
+		if err != nil {
+			t.Fatalf("parse sentinel witness: %v", err)
+		}
+		if parsed.SuiteID != SUITE_ID_SENTINEL || len(parsed.Pubkey) != 0 || len(parsed.Signature) != 0 {
+			t.Fatalf("unexpected witness: %#v", parsed)
+		}
+	})
+
+	t.Run("ML-DSA", func(t *testing.T) {
+		item := WitnessItem{
+			SuiteID:   SUITE_ID_ML_DSA,
+			Pubkey:    bytes.Repeat([]byte{0x01}, ML_DSA_PUBKEY_BYTES),
+			Signature: bytes.Repeat([]byte{0x02}, ML_DSA_SIG_BYTES),
+		}
+		raw := WitnessItemBytes(item)
+		parsed, err := parseWitnessItem(newCursor(raw))
+		if err != nil {
+			t.Fatalf("parse ml-dsa witness: %v", err)
+		}
+		if parsed.SuiteID != SUITE_ID_ML_DSA ||
+			len(parsed.Pubkey) != ML_DSA_PUBKEY_BYTES ||
+			len(parsed.Signature) != ML_DSA_SIG_BYTES {
+			t.Fatalf("unexpected witness: %#v", parsed)
+		}
+	})
+
+	t.Run("SLH-DSA", func(t *testing.T) {
+		item := WitnessItem{
+			SuiteID:   SUITE_ID_SLH_DSA,
+			Pubkey:    bytes.Repeat([]byte{0x03}, SLH_DSA_PUBKEY_BYTES),
+			Signature: bytes.Repeat([]byte{0x04}, 128),
+		}
+		raw := WitnessItemBytes(item)
+		parsed, err := parseWitnessItem(newCursor(raw))
+		if err != nil {
+			t.Fatalf("parse slh-dsa witness: %v", err)
+		}
+		if parsed.SuiteID != SUITE_ID_SLH_DSA || len(parsed.Pubkey) != SLH_DSA_PUBKEY_BYTES || len(parsed.Signature) != 128 {
+			t.Fatalf("unexpected witness: %#v", parsed)
+		}
+	})
+
+	t.Run("unknown suite", func(t *testing.T) {
+		item := WitnessItem{
+			SuiteID:   0x99,
+			Pubkey:    []byte{1, 2, 3},
+			Signature: []byte{4, 5},
+		}
+		raw := WitnessItemBytes(item)
+		parsed, err := parseWitnessItem(newCursor(raw))
+		if err != nil {
+			t.Fatalf("parse unknown witness: %v", err)
+		}
+		if parsed.SuiteID != 0x99 || !bytes.Equal(parsed.Pubkey, item.Pubkey) || !bytes.Equal(parsed.Signature, item.Signature) {
+			t.Fatalf("unexpected parsed values: %#v", parsed)
+		}
+	})
+}

--- a/clients/go/consensus/P1pow_test.go
+++ b/clients/go/consensus/P1pow_test.go
@@ -1,0 +1,214 @@
+package consensus
+
+import (
+	"math/big"
+	"testing"
+)
+
+func makePowHeader(timestamp uint64) BlockHeader {
+	return BlockHeader{
+		Version:   1,
+		Timestamp: timestamp,
+		Target:    [32]byte{0x01},
+	}
+}
+
+func makeWindowHeaders(count int, step uint64) []BlockHeader {
+	headers := make([]BlockHeader, 0, count)
+	for i := 0; i < count; i++ {
+		headers = append(headers, makePowHeader(uint64(i)*step))
+	}
+	return headers
+}
+
+func TestBlockRewardForHeight(t *testing.T) {
+	base := uint64(SUBSIDY_TOTAL_MINED / SUBSIDY_DURATION_BLOCKS)
+	rem := uint64(SUBSIDY_TOTAL_MINED % SUBSIDY_DURATION_BLOCKS)
+
+	t.Run("height=0 -> base+1 (pre-mint remainder)", func(t *testing.T) {
+		if got := blockRewardForHeight(0); got != base+1 {
+			t.Fatalf("expected %d, got %d", base, got)
+		}
+	})
+
+	t.Run("height<rem -> base+1", func(t *testing.T) {
+		if got := blockRewardForHeight(rem - 1); got != base+1 {
+			t.Fatalf("expected %d, got %d", base+1, got)
+		}
+	})
+
+	t.Run("height>=SUBSIDY_DURATION_BLOCKS -> 0", func(t *testing.T) {
+		if got := blockRewardForHeight(SUBSIDY_DURATION_BLOCKS); got != 0 {
+			t.Fatalf("expected 0, got %d", got)
+		}
+	})
+}
+
+func TestMedianPastTimestamp(t *testing.T) {
+	t.Run("height=0 -> BLOCK_ERR_TIMESTAMP_OLD", func(t *testing.T) {
+		_, err := medianPastTimestamp([]BlockHeader{}, 0)
+		if err == nil || err.Error() != BLOCK_ERR_TIMESTAMP_OLD {
+			t.Fatalf("expected %s, got %v", BLOCK_ERR_TIMESTAMP_OLD, err)
+		}
+	})
+
+	t.Run("headers=[] -> BLOCK_ERR_TIMESTAMP_OLD", func(t *testing.T) {
+		_, err := medianPastTimestamp([]BlockHeader{}, 1)
+		if err == nil || err.Error() != BLOCK_ERR_TIMESTAMP_OLD {
+			t.Fatalf("expected %s, got %v", BLOCK_ERR_TIMESTAMP_OLD, err)
+		}
+	})
+
+	t.Run("1 header -> its timestamp", func(t *testing.T) {
+		headers := []BlockHeader{{Timestamp: 12345}}
+		got, err := medianPastTimestamp(headers, 1)
+		if err != nil {
+			t.Fatalf("medianPastTimestamp failed: %v", err)
+		}
+		if got != 12345 {
+			t.Fatalf("expected 12345, got %d", got)
+		}
+	})
+
+	t.Run("5 headers -> median of 5", func(t *testing.T) {
+		headers := []BlockHeader{
+			{Timestamp: 20},
+			{Timestamp: 10},
+			{Timestamp: 40},
+			{Timestamp: 30},
+			{Timestamp: 50},
+		}
+		got, err := medianPastTimestamp(headers, 5)
+		if err != nil {
+			t.Fatalf("medianPastTimestamp failed: %v", err)
+		}
+		if got != 30 {
+			t.Fatalf("expected median 30, got %d", got)
+		}
+	})
+
+	t.Run("20 headers -> median of 11 latest", func(t *testing.T) {
+		headers := makeWindowHeaders(20, 10)
+		got, err := medianPastTimestamp(headers, 20)
+		if err != nil {
+			t.Fatalf("medianPastTimestamp failed: %v", err)
+		}
+		if got != 140 {
+			t.Fatalf("expected median 140, got %d", got)
+		}
+	})
+}
+
+func TestBlockExpectedTarget(t *testing.T) {
+	targetIn := [32]byte{}
+	targetIn[31] = 1
+
+	t.Run("height=0 -> target_in", func(t *testing.T) {
+		got, err := blockExpectedTarget([]BlockHeader{}, 0, targetIn)
+		if err != nil {
+			t.Fatalf("blockExpectedTarget failed: %v", err)
+		}
+		if got != targetIn {
+			t.Fatalf("expected target_in on height 0")
+		}
+	})
+
+	t.Run("height != WINDOW_SIZE -> old target", func(t *testing.T) {
+		targetIn := makeWindowHeaders(1, 0)[0].Target
+		targetIn = [32]byte{0x01}
+		headers := makeWindowHeaders(10, 60)
+		for i := range headers {
+			headers[i].Target = targetIn
+		}
+		got, err := blockExpectedTarget(headers, 1, targetIn)
+		if err != nil {
+			t.Fatalf("blockExpectedTarget failed: %v", err)
+		}
+		if got != targetIn {
+			t.Fatalf("expected old target when not at retarget boundary")
+		}
+	})
+
+	t.Run("height==WINDOW_SIZE, len<WINDOW_SIZE -> BLOCK_ERR_TARGET_INVALID", func(t *testing.T) {
+		headers := makeWindowHeaders(WINDOW_SIZE-1, 60)
+		for i := range headers {
+			headers[i].Target = targetIn
+		}
+		_, err := blockExpectedTarget(headers, WINDOW_SIZE, targetIn)
+		if err == nil || err.Error() != BLOCK_ERR_TARGET_INVALID {
+			t.Fatalf("expected %s, got %v", BLOCK_ERR_TARGET_INVALID, err)
+		}
+	})
+
+	t.Run("retarget clamp ×4", func(t *testing.T) {
+		headers := makeWindowHeaders(WINDOW_SIZE, 3000)
+		for i := range headers {
+			headers[i].Target = targetIn
+		}
+		got, err := blockExpectedTarget(headers, WINDOW_SIZE, targetIn)
+		if err != nil {
+			t.Fatalf("blockExpectedTarget failed: %v", err)
+		}
+		targetOld := new(big.Int).SetBytes(headers[WINDOW_SIZE-1].Target[:])
+		expectedMul := new(big.Int).Set(targetOld)
+		expectedMul.Mul(expectedMul, big.NewInt(4))
+		var expected [32]byte
+		expectedMul.FillBytes(expected[:])
+		if got != expected {
+			t.Fatalf("expected 4x clamp target, got %x", got)
+		}
+	})
+
+	t.Run("retarget clamp ÷4", func(t *testing.T) {
+		headers := makeWindowHeaders(WINDOW_SIZE, 100)
+		for i := range headers {
+			headers[i].Target = targetIn
+		}
+		got, err := blockExpectedTarget(headers, WINDOW_SIZE, targetIn)
+		if err != nil {
+			t.Fatalf("blockExpectedTarget failed: %v", err)
+		}
+		targetOld := new(big.Int).SetBytes(headers[WINDOW_SIZE-1].Target[:])
+		expectedDiv := new(big.Int).Quo(targetOld, big.NewInt(4))
+		if expectedDiv.Sign() == 0 {
+			expectedDiv = big.NewInt(1)
+		}
+		var expected [32]byte
+		expectedDiv.FillBytes(expected[:])
+		if got != expected {
+			t.Fatalf("expected 1/4 clamp target, got %x", got)
+		}
+	})
+}
+
+func TestBlockHeaderHashRoundtrip(t *testing.T) {
+	header := BlockHeader{
+		Version:       1,
+		PrevBlockHash: [32]byte{0x11},
+		MerkleRoot:    [32]byte{0x22},
+		Timestamp:     12345,
+		Target:        [32]byte{0x99},
+		Nonce:         0x1234,
+	}
+
+	encoded := BlockHeaderBytes(header)
+	decoded, err := ParseBlockHeader(newCursor(encoded))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	if decoded != header {
+		t.Fatalf("decode mismatch: got %#v want %#v", decoded, header)
+	}
+
+	hashA, err := BlockHeaderHash(applyTxStubProvider{}, header)
+	if err != nil {
+		t.Fatalf("hash failed: %v", err)
+	}
+	hashB, err := BlockHeaderHash(applyTxStubProvider{}, decoded)
+	if err != nil {
+		t.Fatalf("hash failed: %v", err)
+	}
+	if hashA != hashB {
+		t.Fatalf("hash mismatch: %x != %x", hashA, hashB)
+	}
+}

--- a/clients/go/consensus/P2validate_extended_test.go
+++ b/clients/go/consensus/P2validate_extended_test.go
@@ -1,0 +1,340 @@
+package consensus
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+func makeVaultV1Data(t *testing.T, owner, recovery [32]byte, spendDelay uint64, mode byte, lockValue uint64, useExtended bool) []byte {
+	t.Helper()
+	if useExtended {
+		data := make([]byte, 81)
+		copy(data[:32], owner[:])
+		binary.LittleEndian.PutUint64(data[32:40], spendDelay)
+		data[40] = mode
+		binary.LittleEndian.PutUint64(data[41:49], lockValue)
+		copy(data[49:81], recovery[:])
+		return data
+	}
+	data := make([]byte, 73)
+	copy(data[:32], owner[:])
+	data[32] = mode
+	binary.LittleEndian.PutUint64(data[33:41], lockValue)
+	copy(data[41:73], recovery[:])
+	return data
+}
+
+func makeP2PKSpendTx(prevTxID [32]byte, prevout TxOutput, inputScriptSig []byte, witnessPub, witnessSig []byte, outputs ...TxOutput) Tx {
+	return Tx{
+		Version:  1,
+		TxNonce:  7,
+		Inputs:   []TxInput{{PrevTxid: prevTxID, PrevVout: 0, ScriptSig: inputScriptSig}},
+		Outputs:  outputs,
+		Locktime: 0,
+		Witness: WitnessSection{
+			Witnesses: []WitnessItem{{
+				SuiteID:   SUITE_ID_ML_DSA,
+				Pubkey:    witnessPub,
+				Signature: witnessSig,
+			}},
+		},
+	}
+}
+
+func validP2PKCovenantData(t *testing.T, p []byte) []byte {
+	t.Helper()
+	id := mustSHA3ForTest(t, applyTxStubProvider{}, p)
+	return append([]byte{SUITE_ID_ML_DSA}, id[:]...)
+}
+
+func TestValidateOutputCovenantConstraintsExtended(t *testing.T) {
+	p := applyTxStubProvider{}
+
+	t.Run("HTLC_V2 claimKey==refundKey -> TX_ERR_PARSE", func(t *testing.T) {
+		key := make([]byte, ML_DSA_PUBKEY_BYTES)
+		keyID := mustSHA3ForTest(t, p, key)
+		data := make([]byte, 105)
+		copy(data[41:73], keyID[:])
+		copy(data[73:105], keyID[:])
+		err := validateOutputCovenantConstraints(TxOutput{CovenantType: CORE_HTLC_V2, CovenantData: data})
+		if err == nil || err.Error() != "TX_ERR_PARSE" {
+			t.Fatalf("expected parse, got %v", err)
+		}
+	})
+
+	t.Run("VAULT_V1 len=73 OK", func(t *testing.T) {
+		if err := validateOutputCovenantConstraints(TxOutput{CovenantType: CORE_VAULT_V1, CovenantData: make([]byte, 73)}); err != nil {
+			t.Fatalf("expected OK, got %v", err)
+		}
+	})
+
+	t.Run("VAULT_V1 len=81 OK", func(t *testing.T) {
+		if err := validateOutputCovenantConstraints(TxOutput{CovenantType: CORE_VAULT_V1, CovenantData: make([]byte, 81)}); err != nil {
+			t.Fatalf("expected OK, got %v", err)
+		}
+	})
+
+	t.Run("VAULT_V1 len=74 parse", func(t *testing.T) {
+		err := validateOutputCovenantConstraints(TxOutput{CovenantType: CORE_VAULT_V1, CovenantData: make([]byte, 74)})
+		if err == nil || err.Error() != "TX_ERR_PARSE" {
+			t.Fatalf("expected parse, got %v", err)
+		}
+	})
+
+	t.Run("CORE_RESERVED_FUTURE -> TX_ERR_COVENANT_TYPE_INVALID", func(t *testing.T) {
+		err := validateOutputCovenantConstraints(TxOutput{CovenantType: CORE_RESERVED_FUTURE, CovenantData: []byte{}})
+		if err == nil || err.Error() != "TX_ERR_COVENANT_TYPE_INVALID" {
+			t.Fatalf("expected TX_ERR_COVENANT_TYPE_INVALID, got %v", err)
+		}
+	})
+
+	t.Run("unknown type -> TX_ERR_COVENANT_TYPE_INVALID", func(t *testing.T) {
+		err := validateOutputCovenantConstraints(TxOutput{CovenantType: 0x9999, CovenantData: []byte{}})
+		if err == nil || err.Error() != "TX_ERR_COVENANT_TYPE_INVALID" {
+			t.Fatalf("expected TX_ERR_COVENANT_TYPE_INVALID, got %v", err)
+		}
+	})
+
+	t.Run("CORE_ANCHOR value!=0 -> TX_ERR_COVENANT_TYPE_INVALID", func(t *testing.T) {
+		err := validateOutputCovenantConstraints(TxOutput{
+			CovenantType: CORE_ANCHOR,
+			Value:        1,
+			CovenantData: []byte{1, 2, 3},
+		})
+		if err == nil || err.Error() != "TX_ERR_COVENANT_TYPE_INVALID" {
+			t.Fatalf("expected TX_ERR_COVENANT_TYPE_INVALID, got %v", err)
+		}
+	})
+
+	t.Run("CORE_ANCHOR data=[] -> TX_ERR_COVENANT_TYPE_INVALID", func(t *testing.T) {
+		err := validateOutputCovenantConstraints(TxOutput{
+			CovenantType: CORE_ANCHOR,
+			Value:        0,
+			CovenantData: []byte{},
+		})
+		if err == nil || err.Error() != "TX_ERR_COVENANT_TYPE_INVALID" {
+			t.Fatalf("expected TX_ERR_COVENANT_TYPE_INVALID, got %v", err)
+		}
+	})
+}
+
+func TestValidateInputAuthorizationExtended(t *testing.T) {
+	p := applyTxStubProvider{}
+
+	t.Run("CORE_TIMELOCK_V1 height not met -> TX_ERR_TIMELOCK_NOT_MET", func(t *testing.T) {
+		var lockVal [8]byte
+		binary.LittleEndian.PutUint64(lockVal[:], 10)
+		prev := TxOutput{
+			CovenantType: CORE_TIMELOCK_V1,
+			CovenantData: append([]byte{TIMELOCK_MODE_HEIGHT}, lockVal[:]...),
+		}
+		tx := Tx{
+			Inputs: []TxInput{{
+				PrevTxid: [32]byte{1},
+				PrevVout: 0,
+			}},
+			Witness: WitnessSection{
+				Witnesses: []WitnessItem{{SuiteID: SUITE_ID_SENTINEL}},
+			},
+		}
+		err := ValidateInputAuthorization(p, [32]byte{}, &tx, 0, 7, &prev, 0, 9, 0, false, false)
+		if err == nil || err.Error() != "TX_ERR_TIMELOCK_NOT_MET" {
+			t.Fatalf("expected TX_ERR_TIMELOCK_NOT_MET, got %v", err)
+		}
+	})
+
+	t.Run("CORE_TIMELOCK_V1 timestamp path", func(t *testing.T) {
+		var lockVal [8]byte
+		binary.LittleEndian.PutUint64(lockVal[:], 55)
+		prev := TxOutput{
+			CovenantType: CORE_TIMELOCK_V1,
+			CovenantData: append([]byte{TIMELOCK_MODE_TIMESTAMP}, lockVal[:]...),
+		}
+		tx := Tx{
+			Inputs: []TxInput{{
+				PrevTxid: [32]byte{2},
+				PrevVout: 0,
+			}},
+			Witness: WitnessSection{
+				Witnesses: []WitnessItem{{SuiteID: SUITE_ID_SENTINEL}},
+			},
+		}
+		if err := ValidateInputAuthorization(p, [32]byte{}, &tx, 0, 7, &prev, 0, 0, 55, false, false); err != nil {
+			t.Fatalf("expected lock satisfied, got %v", err)
+		}
+	})
+
+	t.Run("CORE_VAULT_V1 owner path -> OK", func(t *testing.T) {
+		ownerKey := bytesRepeat(ML_DSA_PUBKEY_BYTES, 0x11)
+		ownerID := mustSHA3ForTest(t, p, ownerKey)
+		recoveryID := mustSHA3ForTest(t, p, bytesRepeat(ML_DSA_PUBKEY_BYTES, 0x22))
+		data := makeVaultV1Data(t, ownerID, recoveryID, 0, TIMELOCK_MODE_HEIGHT, 0, false)
+		prev := TxOutput{CovenantType: CORE_VAULT_V1, CovenantData: data}
+		prevValue := uint64(100)
+		tx := makeP2PKSpendTx([32]byte{3}, prev, nil, ownerKey, make([]byte, ML_DSA_SIG_BYTES), TxOutput{Value: prevValue - 1, CovenantType: CORE_P2PK, CovenantData: append([]byte{SUITE_ID_ML_DSA}, ownerID[:]...)})
+		if err := ValidateInputAuthorization(p, [32]byte{}, &tx, 0, prevValue, &prev, 0, 10, 0, false, false); err != nil {
+			t.Fatalf("expected owner path OK, got %v", err)
+		}
+	})
+
+	t.Run("CORE_VAULT_V1 recovery path + spend delay", func(t *testing.T) {
+		ownerKey := bytesRepeat(ML_DSA_PUBKEY_BYTES, 0x11)
+		ownerID := mustSHA3ForTest(t, p, ownerKey)
+		recoveryKey := bytesRepeat(ML_DSA_PUBKEY_BYTES, 0x22)
+		recoveryID := mustSHA3ForTest(t, p, recoveryKey)
+		data := makeVaultV1Data(t, ownerID, recoveryID, 100, TIMELOCK_MODE_HEIGHT, 10, true)
+		prev := TxOutput{CovenantType: CORE_VAULT_V1, CovenantData: data}
+		tx := makeP2PKSpendTx([32]byte{4}, prev, nil, recoveryKey, make([]byte, ML_DSA_SIG_BYTES), TxOutput{Value: 99, CovenantType: CORE_P2PK, CovenantData: append([]byte{SUITE_ID_ML_DSA}, ownerID[:]...)})
+		if err := ValidateInputAuthorization(p, [32]byte{}, &tx, 0, 100, &prev, 0, 20, 0, false, false); err != nil {
+			t.Fatalf("expected recovery path OK, got %v", err)
+		}
+	})
+
+	t.Run("CORE_VAULT_V1 spend_delay not executed -> TX_ERR_TIMELOCK_NOT_MET", func(t *testing.T) {
+		ownerKey := bytesRepeat(ML_DSA_PUBKEY_BYTES, 0x11)
+		ownerID := mustSHA3ForTest(t, p, ownerKey)
+		recoveryKey := bytesRepeat(ML_DSA_PUBKEY_BYTES, 0x22)
+		recoveryID := mustSHA3ForTest(t, p, recoveryKey)
+		data := makeVaultV1Data(t, ownerID, recoveryID, 1000, TIMELOCK_MODE_HEIGHT, 0, true)
+		prev := TxOutput{CovenantType: CORE_VAULT_V1, CovenantData: data}
+		tx := makeP2PKSpendTx([32]byte{5}, prev, nil, ownerKey, make([]byte, ML_DSA_SIG_BYTES), TxOutput{Value: 1, CovenantType: CORE_P2PK, CovenantData: append([]byte{SUITE_ID_ML_DSA}, ownerID[:]...)})
+		err := ValidateInputAuthorization(p, [32]byte{}, &tx, 0, 100, &prev, 0, 5, 0, false, false)
+		if err == nil || err.Error() != "TX_ERR_TIMELOCK_NOT_MET" {
+			t.Fatalf("expected TX_ERR_TIMELOCK_NOT_MET, got %v", err)
+		}
+	})
+
+	t.Run("CORE_ANCHOR as input -> TX_ERR_MISSING_UTXO", func(t *testing.T) {
+		prev := TxOutput{
+			CovenantType: CORE_ANCHOR,
+			Value:        0,
+			CovenantData: []byte{1, 2, 3},
+		}
+		witnessPub := bytesRepeat(ML_DSA_PUBKEY_BYTES, 0x11)
+		tx := makeP2PKSpendTx([32]byte{6}, prev, nil, witnessPub, make([]byte, ML_DSA_SIG_BYTES),
+			TxOutput{
+				Value:        10,
+				CovenantType: CORE_P2PK,
+				CovenantData: validP2PKCovenantData(t, witnessPub),
+			})
+		err := ValidateInputAuthorization(p, [32]byte{}, &tx, 0, 10, &prev, 0, 10, 0, false, false)
+		if err == nil || err.Error() != "TX_ERR_MISSING_UTXO" {
+			t.Fatalf("expected TX_ERR_MISSING_UTXO, got %v", err)
+		}
+	})
+}
+
+func TestApplyTxExtended(t *testing.T) {
+	p := applyTxStubProvider{}
+
+	t.Run("outputSum > inputSum -> TX_ERR_VALUE_CONSERVATION", func(t *testing.T) {
+		witnessKey := bytesRepeat(ML_DSA_PUBKEY_BYTES, 0x11)
+		witnessID := mustSHA3ForTest(t, p, witnessKey)
+		prevout := TxOutPoint{TxID: [32]byte{1}, Vout: 0}
+		utxo := map[TxOutPoint]UtxoEntry{
+			prevout: {
+				Output: TxOutput{
+					Value:        100,
+					CovenantType: CORE_P2PK,
+					CovenantData: append([]byte{SUITE_ID_ML_DSA}, witnessID[:]...),
+				},
+				CreatedByCoinbase: false,
+			},
+		}
+		tx := Tx{
+			Version: 1,
+			TxNonce: 10,
+			Inputs:  []TxInput{{PrevTxid: prevout.TxID, PrevVout: 0}},
+			Outputs: []TxOutput{
+				{Value: 90, CovenantType: CORE_P2PK, CovenantData: append([]byte{SUITE_ID_ML_DSA}, witnessID[:]...)},
+				{Value: 20, CovenantType: CORE_P2PK, CovenantData: append([]byte{SUITE_ID_ML_DSA}, witnessID[:]...)},
+			},
+			Locktime: 0,
+			Witness: WitnessSection{
+				Witnesses: []WitnessItem{{
+					SuiteID:   SUITE_ID_ML_DSA,
+					Pubkey:    witnessKey,
+					Signature: make([]byte, ML_DSA_SIG_BYTES),
+				}},
+			},
+		}
+		err := ApplyTx(p, [32]byte{}, &tx, utxo, 10, 0, false, true)
+		if err == nil || err.Error() != "TX_ERR_VALUE_CONSERVATION" {
+			t.Fatalf("expected TX_ERR_VALUE_CONSERVATION, got %v", err)
+		}
+	})
+
+	t.Run("missing utxo -> TX_ERR_MISSING_UTXO", func(t *testing.T) {
+		witnessPub := bytesRepeat(ML_DSA_PUBKEY_BYTES, 0x22)
+		witnessData := validP2PKCovenantData(t, witnessPub)
+		tx := Tx{
+			Version:  1,
+			TxNonce:  11,
+			Inputs:   []TxInput{{PrevTxid: [32]byte{2}, PrevVout: 1}},
+			Outputs:  []TxOutput{{Value: 0, CovenantType: CORE_P2PK, CovenantData: witnessData}},
+			Witness:  WitnessSection{Witnesses: []WitnessItem{{SuiteID: SUITE_ID_ML_DSA, Pubkey: witnessPub, Signature: make([]byte, ML_DSA_SIG_BYTES)}}},
+			Locktime: 0,
+		}
+		err := ApplyTx(p, [32]byte{}, &tx, map[TxOutPoint]UtxoEntry{}, 1, 0, false, true)
+		if err == nil || err.Error() != "TX_ERR_MISSING_UTXO" {
+			t.Fatalf("expected TX_ERR_MISSING_UTXO, got %v", err)
+		}
+	})
+
+	t.Run("coinbase maturity not executed -> TX_ERR_COINBASE_IMMATURE", func(t *testing.T) {
+		witnessKey := bytesRepeat(ML_DSA_PUBKEY_BYTES, 0x11)
+		witnessID := mustSHA3ForTest(t, p, witnessKey)
+		prevout := TxOutPoint{TxID: [32]byte{3}, Vout: 0}
+		utxo := map[TxOutPoint]UtxoEntry{
+			prevout: {
+				Output: TxOutput{
+					Value:        1000,
+					CovenantType: CORE_P2PK,
+					CovenantData: append([]byte{SUITE_ID_ML_DSA}, witnessID[:]...),
+				},
+				CreationHeight:    0,
+				CreatedByCoinbase: true,
+			},
+		}
+		tx := makeP2PKSpendTx(prevout.TxID, utxo[prevout].Output, nil, witnessKey, make([]byte, ML_DSA_SIG_BYTES), TxOutput{Value: 900, CovenantType: CORE_P2PK, CovenantData: append([]byte{SUITE_ID_ML_DSA}, witnessID[:]...)})
+		tx.Inputs[0].PrevVout = 0
+		err := ApplyTx(p, [32]byte{}, &tx, utxo, 50, 0, false, true)
+		if err == nil || err.Error() != "TX_ERR_COINBASE_IMMATURE" {
+			t.Fatalf("expected TX_ERR_COINBASE_IMMATURE, got %v", err)
+		}
+	})
+
+	t.Run("ApplyTx: ANCHOR output в не-coinbase tx", func(t *testing.T) {
+		witnessKey := bytesRepeat(ML_DSA_PUBKEY_BYTES, 0x11)
+		witnessID := mustSHA3ForTest(t, p, witnessKey)
+		prevout := TxOutPoint{TxID: [32]byte{4}, Vout: 0}
+		utxo := map[TxOutPoint]UtxoEntry{
+			prevout: {
+				Output: TxOutput{
+					Value:        100,
+					CovenantType: CORE_P2PK,
+					CovenantData: append([]byte{SUITE_ID_ML_DSA}, witnessID[:]...),
+				},
+			},
+		}
+		tx := makeP2PKSpendTx(prevout.TxID, utxo[prevout].Output, nil, witnessKey, make([]byte, ML_DSA_SIG_BYTES),
+			TxOutput{
+				Value:        0,
+				CovenantType: CORE_ANCHOR,
+				CovenantData: []byte{1, 2, 3, 4},
+			},
+		)
+		err := ApplyTx(p, [32]byte{}, &tx, utxo, 1, 0, false, true)
+		if err != nil {
+			t.Fatalf("expected anchor in non-coinbase tx to pass validation, got %v", err)
+		}
+	})
+}
+
+func bytesRepeat(size int, b byte) []byte {
+	out := make([]byte, size)
+	for i := range out {
+		out[i] = b
+	}
+	return out
+}

--- a/clients/go/consensus/P3util_encode_test.go
+++ b/clients/go/consensus/P3util_encode_test.go
@@ -1,0 +1,136 @@
+package consensus
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestSubUint64(t *testing.T) {
+	t.Run("a>=b -> no error", func(t *testing.T) {
+		got, err := subUint64(7, 3)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != 4 {
+			t.Fatalf("expected 4, got %d", got)
+		}
+	})
+
+	t.Run("b>a -> TX_ERR_VALUE_CONSERVATION", func(t *testing.T) {
+		_, err := subUint64(3, 7)
+		if err == nil || err.Error() != "TX_ERR_VALUE_CONSERVATION" {
+			t.Fatalf("expected TX_ERR_VALUE_CONSERVATION, got %v", err)
+		}
+	})
+}
+
+func TestIsCoinbaseTx(t *testing.T) {
+	t.Run("nil -> false", func(t *testing.T) {
+		if isCoinbaseTx(nil, 0) {
+			t.Fatalf("expected false for nil tx")
+		}
+	})
+
+	t.Run("len(inputs)!=1 -> false", func(t *testing.T) {
+		tx := &Tx{Inputs: []TxInput{}, Outputs: []TxOutput{}, Witness: WitnessSection{}, TxNonce: 0, Locktime: 1}
+		if isCoinbaseTx(tx, 0) {
+			t.Fatalf("expected false for input count not 1")
+		}
+	})
+
+	t.Run("locktime!=height -> false", func(t *testing.T) {
+		tx := &Tx{
+			Inputs:   []TxInput{{PrevTxid: [32]byte{}, PrevVout: TX_COINBASE_PREVOUT_VOUT, ScriptSig: []byte{}, Sequence: TX_COINBASE_PREVOUT_VOUT}},
+			Outputs:  []TxOutput{},
+			TxNonce:  0,
+			Locktime: 2,
+			Witness:  WitnessSection{},
+		}
+		if isCoinbaseTx(tx, 1) {
+			t.Fatalf("expected false when locktime != block height")
+		}
+	})
+
+	t.Run("all conditions OK -> true", func(t *testing.T) {
+		tx := &Tx{
+			Inputs:   []TxInput{{PrevTxid: [32]byte{}, PrevVout: TX_COINBASE_PREVOUT_VOUT, ScriptSig: []byte{}, Sequence: TX_COINBASE_PREVOUT_VOUT}},
+			Outputs:  []TxOutput{},
+			TxNonce:  0,
+			Locktime: 1,
+			Witness:  WitnessSection{},
+		}
+		if !isCoinbaseTx(tx, 1) {
+			t.Fatalf("expected true for coinbase tx shape")
+		}
+	})
+}
+
+func TestEncodingRoundTrips(t *testing.T) {
+	t.Run("BlockHeaderBytes roundtrip", func(t *testing.T) {
+		header := BlockHeader{
+			Version:       9,
+			PrevBlockHash: [32]byte{0x11},
+			MerkleRoot:    [32]byte{0x22},
+			Timestamp:     98765,
+			Target:        [32]byte{0xaa},
+			Nonce:         0x7fff,
+		}
+		parsed, err := ParseBlockHeader(newCursor(BlockHeaderBytes(header)))
+		if err != nil {
+			t.Fatalf("parse header failed: %v", err)
+		}
+		if parsed != header {
+			t.Fatalf("block header mismatch: got %#v want %#v", parsed, header)
+		}
+	})
+
+	t.Run("TxBytes roundtrip", func(t *testing.T) {
+		tx := &Tx{
+			Version:  2,
+			TxNonce:  77,
+			Inputs:   []TxInput{{PrevTxid: [32]byte{0xaa}, PrevVout: 1, ScriptSig: []byte{1, 2}, Sequence: 9}},
+			Outputs:  []TxOutput{{Value: 1, CovenantType: CORE_P2PK, CovenantData: make([]byte, 33)}},
+			Locktime: 10,
+			Witness:  WitnessSection{Witnesses: []WitnessItem{{SuiteID: SUITE_ID_ML_DSA, Pubkey: make([]byte, ML_DSA_PUBKEY_BYTES), Signature: make([]byte, ML_DSA_SIG_BYTES)}}},
+		}
+		parsed, err := ParseTxBytes(TxBytes(tx))
+		if err != nil {
+			t.Fatalf("parse tx failed: %v", err)
+		}
+		if !txsEqual(parsed, tx) {
+			t.Fatalf("tx mismatch: got %#v want %#v", parsed, tx)
+		}
+	})
+}
+
+func txsEqual(a, b *Tx) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	if a.Version != b.Version || a.TxNonce != b.TxNonce || a.Locktime != b.Locktime {
+		return false
+	}
+	if len(a.Inputs) != len(b.Inputs) || len(a.Outputs) != len(b.Outputs) || len(a.Witness.Witnesses) != len(b.Witness.Witnesses) {
+		return false
+	}
+	for i := range a.Inputs {
+		if a.Inputs[i].PrevTxid != b.Inputs[i].PrevTxid || a.Inputs[i].PrevVout != b.Inputs[i].PrevVout ||
+			a.Inputs[i].Sequence != b.Inputs[i].Sequence || !bytes.Equal(a.Inputs[i].ScriptSig, b.Inputs[i].ScriptSig) {
+			return false
+		}
+	}
+	for i := range a.Outputs {
+		if a.Outputs[i].Value != b.Outputs[i].Value || a.Outputs[i].CovenantType != b.Outputs[i].CovenantType ||
+			!bytes.Equal(a.Outputs[i].CovenantData, b.Outputs[i].CovenantData) {
+			return false
+		}
+	}
+	for i := range a.Witness.Witnesses {
+		if a.Witness.Witnesses[i].SuiteID != b.Witness.Witnesses[i].SuiteID ||
+			!bytes.Equal(a.Witness.Witnesses[i].Pubkey, b.Witness.Witnesses[i].Pubkey) ||
+			!bytes.Equal(a.Witness.Witnesses[i].Signature, b.Witness.Witnesses[i].Signature) {
+			return false
+		}
+	}
+	return true
+}

--- a/clients/go/consensus/TEST_SPEC.md
+++ b/clients/go/consensus/TEST_SPEC.md
@@ -1,0 +1,300 @@
+# ТЗ: тесты для достижения coverage ≥70% (clients/go/consensus)
+
+**Дата:** 2026-02-19  
+**Файл:** `clients/go/consensus/`  
+**Текущее покрытие:** consensus 24.8% / global 14.2%  
+**Цель:** consensus ≥70% / global ≥50%  
+**Файлы тестов:** добавлять в `clients/go/consensus/*_test.go`
+
+---
+
+## Приоритет 1 — критические пробелы (0% → нужно)
+
+### 1.1 `parse.go` — ParseTxBytes / ParseBlockBytes (0%)
+
+Все функции парсинга полностью без тестов. Самый большой вклад в coverage.
+
+**Тест-файл:** `parse_test.go`
+
+```
+TestParseTxBytes_Valid
+  - корректный tx: 1 input + 1 output + 1 witness (ML-DSA)
+  - корректный tx: coinbase (нет inputs, нет witnesses)
+  - trailing bytes → "parse: trailing bytes"
+
+TestParseTxBytes_Truncated
+  - обрезанный на version
+  - обрезанный на input list
+  - обрезанный на output list
+  - обрезанный на witness
+  - compactsize overflow в input_count
+
+TestParseBlockBytes_Valid
+  - блок с 1 coinbase транзакцией
+  - блок с coinbase + 2 обычными tx
+  - trailing bytes → BLOCK_ERR_PARSE
+
+TestParseBlockHeader
+  - корректный 116-байтовый header
+  - короткий header → ошибка
+  - truncated на midfield
+
+TestParseOutput_CovenantTypes
+  - CORE_P2PK output bytes
+  - CORE_TIMELOCK_V1 output bytes
+  - CORE_HTLC_V1 output bytes
+  - CORE_VAULT_V1 output bytes (73 bytes и 81 bytes)
+
+TestParseWitnessItem
+  - SUITE_ID_SENTINEL (suiteID=0, нет pubkey/sig)
+  - SUITE_ID_ML_DSA
+  - SUITE_ID_SLH_DSA
+  - неизвестный suiteID
+```
+
+---
+
+### 1.2 `validate.go` — ApplyBlock (0%)
+
+Самая важная функция — полностью непокрыта.
+
+**Добавить в:** `apply_block_test.go`
+
+```
+TestApplyBlock_Valid
+  - минимальный блок: coinbase tx только
+    input ctx: height=1, ancestors=[genesis_header], utxo={}
+    ожидание: OK, utxo содержит coinbase output
+
+TestApplyBlock_MerkleInvalid
+  - block.Header.MerkleRoot = неправильный хеш
+  - ожидание: BLOCK_ERR_MERKLE_INVALID
+
+TestApplyBlock_PoWInvalid
+  - block.Header.Target = все нули (impossibly hard)
+  - ожидание: BLOCK_ERR_POW_INVALID
+
+TestApplyBlock_TimestampTooOld
+  - block.Timestamp = medianPastTimestamp - 1
+  - ожидание: BLOCK_ERR_TIMESTAMP_OLD
+
+TestApplyBlock_TimestampTooFuture
+  - blockCtx.LocalTimeSet=true, LocalTime = block.Timestamp - MAX_FUTURE_DRIFT - 1
+  - ожидание: BLOCK_ERR_TIMESTAMP_FUTURE
+
+TestApplyBlock_WeightExceeded
+  - блок с tx превышающим MAX_BLOCK_WEIGHT
+  - ожидание: BLOCK_ERR_WEIGHT_EXCEEDED
+
+TestApplyBlock_SubsidyExceeded
+  - coinbase output.Value > blockRewardForHeight(height)
+  - ожидание: BLOCK_ERR_SUBSIDY_EXCEEDED
+
+TestApplyBlock_CoinbaseMissing
+  - блок без coinbase tx (первый tx не является coinbase)
+  - ожидание: BLOCK_ERR_COINBASE_INVALID
+
+TestApplyBlock_DoubleSpend
+  - два tx тратят один и тот же outpoint
+  - ожидание: TX_ERR_MISSING_UTXO (второй tx не найдёт utxo)
+
+TestApplyBlock_UTXOUpdated
+  - после применения блока: spent outpoints удалены, новые добавлены
+  - проверка что utxo map изменилась корректно
+```
+
+---
+
+### 1.3 `validate.go` — validateCoinbaseTxInputs (0%)
+
+```
+TestValidateCoinbaseTxInputs
+  - валидный coinbase input: prevTxid=0x00..00, prevVout=0xFFFFFFFF, sequence=0xFFFFFFFF, scriptSig=[]
+  - txNonce != 0 → BLOCK_ERR_COINBASE_INVALID
+  - len(inputs) != 1 → BLOCK_ERR_COINBASE_INVALID
+  - sequence != TX_COINBASE_PREVOUT_VOUT → BLOCK_ERR_COINBASE_INVALID
+  - prevTxid != zero → BLOCK_ERR_COINBASE_INVALID
+  - len(ScriptSig) != 0 → BLOCK_ERR_COINBASE_INVALID
+  - len(witnesses) != 0 → BLOCK_ERR_COINBASE_INVALID
+```
+
+---
+
+### 1.4 `pow.go` — blockRewardForHeight / medianPastTimestamp / blockExpectedTarget (0%)
+
+**Тест-файл:** `pow_test.go`
+
+```
+TestBlockRewardForHeight
+  - height=0 → base subsidy
+  - height=rem-1 → base+1
+  - height=rem → base
+  - height=SUBSIDY_DURATION_BLOCKS → 0
+  - height=SUBSIDY_DURATION_BLOCKS+1 → 0
+
+TestMedianPastTimestamp
+  - height=0 → BLOCK_ERR_TIMESTAMP_OLD
+  - headers=[] → BLOCK_ERR_TIMESTAMP_OLD
+  - height=1, headers=[{Timestamp:100}] → 100
+  - height=5, headers=[t1..t5] → медиана из 5
+  - height=20, headers=[t1..t20] → медиана из 11 последних
+
+TestBlockExpectedTarget
+  - height=0 → возвращает targetIn как есть
+  - height=1, headers=[h1] → тот же target что у h1 (не окончание окна)
+  - height=WINDOW_SIZE, len(headers)<WINDOW_SIZE → BLOCK_ERR_TARGET_INVALID
+  - height=WINDOW_SIZE, корректные headers → пересчитанный target
+  - retarget clamp: actualTime << targetBlockInterval → maxTarget (×4)
+  - retarget clamp: actualTime >> targetBlockInterval → minTarget (÷4)
+  - нулевой old target → minTarget=1
+```
+
+---
+
+### 1.5 `chainstate_hash.go` — UtxoSetHash / outpointKeyBytes (0%)
+
+**Добавить в:** `chainstate_hash_test.go`
+
+```
+TestUtxoSetHash_Empty
+  - utxo={} → детерминированный хеш (не нулевой — DST + N_le=0)
+
+TestUtxoSetHash_SingleEntry
+  - 1 utxo запись → хеш, вручную сверить с SHA3-256(DST || n_le || pair)
+
+TestUtxoSetHash_Deterministic
+  - один и тот же utxo map, вызвать дважды → одинаковый хеш
+
+TestUtxoSetHash_OrderIndependent
+  - построить utxo map с 3 entries, передать в разном порядке вставки
+  - хеш должен совпадать (сортировка работает корректно)
+
+TestUtxoSetHash_DifferentEntries
+  - два разных utxo set → разные хеши
+
+TestOutpointKeyBytes
+  - txid[0..31] + vout_le[4] → 36 байт, проверить little-endian порядок
+```
+
+---
+
+## Приоритет 2 — частичное покрытие (расширить)
+
+### 2.1 `validate.go` — validateOutputCovenantConstraints (40.9% → цель 80%)
+
+Не покрыты: CORE_HTLC_V2 (claimKey==refundKey), CORE_VAULT_V1 (81 bytes), CORE_RESERVED_FUTURE, default.
+
+```
+TestValidateOutputCovenantConstraints_Missing
+  - CORE_HTLC_V2: claimKeyID == refundKeyID → TX_ERR_PARSE
+  - CORE_VAULT_V1: len=73 → OK
+  - CORE_VAULT_V1: len=81 → OK
+  - CORE_VAULT_V1: len=74 → TX_ERR_PARSE
+  - CORE_RESERVED_FUTURE (0x7FFF) → TX_ERR_COVENANT_TYPE_INVALID
+  - unknown type (0x9999) → TX_ERR_COVENANT_TYPE_INVALID
+  - CORE_ANCHOR: value=1 → TX_ERR_COVENANT_TYPE_INVALID
+  - CORE_ANCHOR: data=[] (empty) → TX_ERR_COVENANT_TYPE_INVALID
+  - CORE_ANCHOR: data len > MAX_ANCHOR_PAYLOAD_SIZE → TX_ERR_COVENANT_TYPE_INVALID
+```
+
+### 2.2 `validate.go` — ValidateInputAuthorization (31.1% → цель 80%)
+
+Не покрыты: CORE_P2PK полный путь, CORE_VAULT_V1 owner/recovery, CORE_TIMELOCK_V1 ветки, CORE_ANCHOR как input.
+
+```
+TestValidateInputAuthorization_P2PK
+  - валидный P2PK (mock CryptoProvider с успешным verify)
+  - неверная подпись → TX_ERR_SIG_INVALID
+  - witness count != 1 → ошибка
+
+TestValidateInputAuthorization_TIMELOCK
+  - lockMode=HEIGHT, height не достигнут → TX_ERR_TIMELOCK_NOT_MET
+  - lockMode=HEIGHT, height достигнут → OK (с валидной подписью)
+  - lockMode=TIMESTAMP, timestamp не достигнут → TX_ERR_TIMELOCK_NOT_MET
+  - data len != 9 → TX_ERR_PARSE
+
+TestValidateInputAuthorization_VAULT_Owner
+  - owner path: witness[0].Pubkey matches ownerKeyID → пройти
+  - recovery path: witness[0].Pubkey matches recoveryKeyID, spend_delay выполнен
+  - spend_delay не выполнен → TX_ERR_TIMELOCK_NOT_MET
+  - ни owner ни recovery → TX_ERR_SIG_KEY_MISMATCH
+
+TestValidateInputAuthorization_ANCHOR
+  - CORE_ANCHOR как input → TX_ERR_COVENANT_TYPE_INVALID (anchor не спендится)
+```
+
+### 2.3 `validate.go` — ApplyTx (66% → цель 90%)
+
+```
+TestApplyTx_ValueConservation
+  - outputSum > inputSum → TX_ERR_VALUE_CONSERVATION
+  - overflow в output sum → TX_ERR_PARSE
+
+TestApplyTx_MissingUTXO
+  - input ссылается на несуществующий outpoint → TX_ERR_MISSING_UTXO
+
+TestApplyTx_CoinbaseMaturity
+  - попытка потратить coinbase output до достижения COINBASE_MATURITY → TX_ERR_COINBASE_IMMATURE
+
+TestApplyTx_HTLC_NonCoinbase
+  - CORE_ANCHOR output в не-coinbase tx → TX_ERR_COVENANT_TYPE_INVALID
+```
+
+---
+
+## Приоритет 3 — util.go / encode.go (smoke)
+
+```
+TestUtil_SubUint64
+  - a >= b → корректный результат
+  - b > a → TX_ERR_VALUE_CONSERVATION
+
+TestUtil_IsCoinbaseTx
+  - nil tx → false
+  - len(inputs) != 1 → false
+  - locktime != blockHeight → false
+  - все условия ок → true
+
+TestEncode_BlockHeaderBytes
+  - encode/decode roundtrip: ParseBlockHeader(BlockHeaderBytes(h)) == h
+
+TestEncode_TxRoundtrip
+  - ParseTxBytes(TxBytes(tx)) == tx (для простого tx)
+```
+
+---
+
+## Вспомогательные структуры для тестов
+
+Добавить в `testhelpers_test.go`:
+
+```go
+// mockCrypto — минимальный CryptoProvider для unit-тестов
+type mockCrypto struct{ verifyResult error }
+func (m *mockCrypto) SHA3_256(data []byte) ([32]byte, error) { ... реальный sha3 ... }
+func (m *mockCrypto) VerifyMLDSA87(...) error { return m.verifyResult }
+func (m *mockCrypto) VerifySLHDSA(...) error  { return m.verifyResult }
+
+// buildMinimalCoinbaseTx(height, outputValue) *Tx
+// buildMinimalBlock(header, txs) Block
+// buildHeader(prevHash, target, timestamp) BlockHeader
+// makeUTXO(txid, vout, value, covenantType, data) map[TxOutPoint]UtxoEntry
+```
+
+---
+
+## Ожидаемые цифры после выполнения
+
+| Файл | До | После |
+|---|---|---|
+| parse.go (все функции) | 0% | ~75% |
+| validate.go (ApplyBlock) | 0% | ~70% |
+| validate.go (validateCoinbaseTxInputs) | 0% | ~100% |
+| pow.go (все) | 0% | ~85% |
+| chainstate_hash.go | 0% | ~90% |
+| validateOutputCovenantConstraints | 40.9% | ~85% |
+| ValidateInputAuthorization | 31.1% | ~75% |
+| **consensus пакет итого** | **24.8%** | **~72%** |
+| **global (./...)** | **14.2%** | **~35%** |
+
+Global ≥50% потребует дополнительно smoke-тестов для `crypto` и `node` пакетов (отдельное ТЗ).


### PR DESCRIPTION
Adds additional Go consensus unit tests (parse/pow/apply_block/validate/util), plus TEST_SPEC.md notes. Also extends .gitignore for local coverage artifacts and analysis scratch. No consensus rule changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for Go consensus components including block application, parsing, proof-of-work validation, chainstate hashing, and extended covenant validation.
  * New test suites validate transaction processing, block rewards, timestamp verification, and UTXO state management.

* **Documentation**
  * Added testing specification outlining coverage targets and test strategy for the consensus client.

* **Chores**
  * Updated ignore patterns for local build artifacts and analysis outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->