### PR TITLE
go(node): utxo-set-hash --datadir (Q-104)

### DIFF
--- a/clients/go/node/README.md
+++ b/clients/go/node/README.md
@@ -111,6 +111,21 @@ Decision tokens (stdout):
 - `INVALID_ANCESTRY`
 - `APPLIED_AS_NEW_TIP`
 
+### 4) UTXO set snapshot hash (persisted KV state)
+
+Reads the persisted `utxo_by_outpoint` table from `datadir` and outputs a JSON object:
+- `tip_height`
+- `tip_hash_hex`
+- `utxo_count`
+- `utxo_set_hash_hex`
+
+```bash
+cd clients/go
+go run ./node utxo-set-hash \
+  --datadir /tmp/rubin-data \
+  --profile spec/RUBIN_L1_CHAIN_INSTANCE_PROFILE_DEVNET_v1.1.md
+```
+
 ## Crypto provider selection (dev-std vs wolfCrypt)
 
 The Go node chooses crypto backend at runtime:
@@ -127,4 +142,3 @@ cd clients/go
 RUBIN_WOLFCRYPT_SHIM_PATH=/absolute/path/to/librubin_wc_shim.so \
   go run -tags wolfcrypt_dylib ./node version
 ```
-


### PR DESCRIPTION
Implements Q-104: go-node command utxo-set-hash reads persisted UTXO set from the KV store in datadir and outputs a stable JSON payload including utxo_set_hash_hex.

Also updates clients/go/node/README.md to document the new command.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new CLI command to compute and output the UTXO set snapshot hash with JSON data (tip height, tip hash, UTXO count, hash value).

* **Documentation**
  * Added command documentation and usage examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->