### PR TITLE
Q-109: CV-CHAINSTATE-STORE (persistent store parity)

### DIFF
--- a/clients/rust/crates/rubin-store/src/db.rs
+++ b/clients/rust/crates/rubin-store/src/db.rs
@@ -154,7 +154,7 @@ impl Store {
     /// Calls `f(outpoint_key_bytes, utxo_entry_bytes)` for each entry.
     pub fn iter_utxos<F>(&self, mut f: F) -> Result<(), String>
     where
-        F: FnMut(&[u8], &[u8]),
+        F: FnMut(&[u8], &[u8]) -> Result<(), String>,
     {
         let tx = self
             .db
@@ -166,7 +166,7 @@ impl Store {
         let iter = table.iter().map_err(|e| format!("utxo iter: {e}"))?;
         for result in iter {
             let (key_guard, val_guard) = result.map_err(|e| format!("utxo next: {e}"))?;
-            f(key_guard.value(), val_guard.value());
+            f(key_guard.value(), val_guard.value())?;
         }
         Ok(())
     }

--- a/clients/rust/crates/rubin-store/src/manifest.rs
+++ b/clients/rust/crates/rubin-store/src/manifest.rs
@@ -25,6 +25,23 @@ pub struct Manifest {
 }
 
 impl Manifest {
+    /// Create an initial manifest for an uninitialized (empty) chain store.
+    ///
+    /// This is used by `node init` before importing genesis via the normal import pipeline.
+    /// Tip fields are set to zero/empty so that genesis is always selected as the first tip.
+    pub fn empty(chain_id_hex: &str) -> Self {
+        let zero_hash_hex = "00".repeat(32);
+        Self {
+            schema_version: CURRENT_SCHEMA_VERSION,
+            chain_id_hex: chain_id_hex.to_string(),
+            tip_hash: zero_hash_hex.clone(),
+            tip_height: 0,
+            tip_cumulative_work: "0".to_string(),
+            last_applied_block_hash: zero_hash_hex,
+            last_applied_height: 0,
+        }
+    }
+
     /// Create an initial manifest for genesis state.
     pub fn genesis(chain_id_hex: &str, genesis_hash_hex: &str, genesis_work: u128) -> Self {
         Self {

--- a/conformance/fixtures/CV-CHAINSTATE-STORE.yml
+++ b/conformance/fixtures/CV-CHAINSTATE-STORE.yml
@@ -1,0 +1,34 @@
+version: "1.1"
+gate: CV-CHAINSTATE-STORE
+status: PASS
+description: "Phase 1: persistent-store chainstate parity via init/import-block/utxo-set-hash (Go bbolt vs Rust redb)"
+tests:
+  - id: CS-01
+    title: "Linear chain N=10 (coinbase-only blocks) yields identical utxo_set_hash"
+    profile: "spec/RUBIN_L1_CHAIN_INSTANCE_PROFILE_DEVNET_v1.1.md"
+    plan:
+      kind: linear
+      blocks: 10
+    expected_code: PASS
+
+  - id: CS-02
+    title: "2-block reorg: fork wins by higher cumulative work"
+    profile: "spec/RUBIN_L1_CHAIN_INSTANCE_PROFILE_DEVNET_v1.1.md"
+    plan:
+      kind: reorg
+      # Import A1..A3, then B2..B4 where fork point is height 1.
+      main_len: 3
+      fork_point: 1
+      fork_len: 4
+    expected_code: PASS
+
+  - id: CS-03
+    title: "Deep reorg (depth=25): fork wins by higher cumulative work"
+    profile: "spec/RUBIN_L1_CHAIN_INSTANCE_PROFILE_DEVNET_v1.1.md"
+    plan:
+      kind: reorg
+      main_len: 30
+      fork_point: 5
+      fork_len: 35
+    expected_code: PASS
+

--- a/conformance/fixtures/RUBIN_L1_CONFORMANCE_BUNDLE_v1.1.yaml
+++ b/conformance/fixtures/RUBIN_L1_CONFORMANCE_BUNDLE_v1.1.yaml
@@ -47,6 +47,12 @@ mandatory_gates:
   status: PASS
   description: Cross-client chainstate parity after applying block sequences (2 vectors)
   note: consensus (node-layer integration)
+- name: CV-CHAINSTATE-STORE
+  file: conformance/fixtures/CV-CHAINSTATE-STORE.yml
+  required: false
+  status: PASS
+  description: Phase 1 persistent-store chainstate parity via init/import-block/utxo-set-hash (Go bbolt vs Rust redb)
+  note: phase1 (storage/import/reorg), not a pure consensus gate
 - name: CV-FEES
   file: conformance/fixtures/CV-FEES.yml
   required: true


### PR DESCRIPTION
Adds a datadir-based conformance gate (CV-CHAINSTATE-STORE) that initializes a fresh store, imports deterministic coinbase-only blocks, performs reorg scenarios, and compares (tip_height, tip_hash_hex, utxo_set_hash_hex) between Go and Rust.

Also fixes Rust init to start from an empty manifest, makes Rust utxo-set-hash emit JSON matching Go, and canonicalizes Rust utxo_set_hash encoding to match Go byte-for-byte.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * UTXO set hash output now provided in structured JSON format, including tip height, tip hash, UTXO count, and hash values

* **Improvements**
  * Genesis block initialization workflow streamlined
  * Conformance tests expanded for storage layer validation

* **Tests**
  * New tests added for chainstate consistency verification
<!-- end of auto-generated comment: release notes by coderabbit.ai -->