### PR TITLE
chore: ignore local whitepaper pdf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ rubin-ui/
 
 # Local scratch docs
 IMPLEMENTATION_ROADMAP.md
+RUBIN_WHITEPAPER_*.pdf
 
 # Local scratch crypto notes
 clients/go/_manual_SHA3/


### PR DESCRIPTION
Ignore untracked local file RUBIN_WHITEPAPER_*.pdf to keep working tree clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration to expand file exclusion patterns.

**Note:** This update contains no user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->