### PR TITLE
fix(go/node): resolve spec profile paths from repo root

### DIFF
--- a/clients/go/node/README.md
+++ b/clients/go/node/README.md
@@ -6,7 +6,7 @@ Status: development tooling (non-production).
 
 ## Build / Run
 
-From repo root:
+You can run from repo root or from inside `clients/go` (both work).
 
 ```bash
 cd clients/go
@@ -35,6 +35,10 @@ Devnet default profile (as wired in code):
 - `spec/RUBIN_L1_CHAIN_INSTANCE_PROFILE_DEVNET_v1.1.md`
 
 You can override it with `--profile <path>`.
+
+Note: profile paths are **repo-relative** and constrained to `spec/` for safety.
+The CLI resolves them relative to the repo root (it searches upwards from the current working directory),
+so `--profile spec/...` works even when running from `clients/go`.
 
 ## Phase 1 Commands (datadir + persistence)
 


### PR DESCRIPTION
This removes the need for a git symlink like clients/go/spec.

- Profile paths remain constrained to spec/ (safety)
- Resolution is done against the repo root (searching upwards from current working directory)
- Works when running from clients/go as documented

Supersedes #86.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Go node README with enhanced guidance on executing commands from different working directories. Documentation now clarifies that commands can be run from either the repository root or the clients/go directory, and explains how profile paths are resolved consistently across these locations.

* **New Features**
  * Go node CLI now supports flexible execution from both the repository root and the clients/go directory with consistent profile path resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->