### PR TITLE
consensus: enforce VAULT owner_key_id != recovery_key_id

### DIFF
--- a/clients/go/consensus/P2validate_extended_test.go
+++ b/clients/go/consensus/P2validate_extended_test.go
@@ -63,14 +63,34 @@ func TestValidateOutputCovenantConstraintsExtended(t *testing.T) {
 	})
 
 	t.Run("VAULT_V1 len=73 OK", func(t *testing.T) {
-		if err := validateOutputCovenantConstraints(TxOutput{CovenantType: CORE_VAULT_V1, CovenantData: make([]byte, 73)}); err != nil {
+		var owner [32]byte
+		var recovery [32]byte
+		owner[0] = 0x11
+		recovery[0] = 0x22
+		data := makeVaultV1Data(t, owner, recovery, 0, TIMELOCK_MODE_HEIGHT, 0, false)
+		if err := validateOutputCovenantConstraints(TxOutput{CovenantType: CORE_VAULT_V1, CovenantData: data}); err != nil {
 			t.Fatalf("expected OK, got %v", err)
 		}
 	})
 
 	t.Run("VAULT_V1 len=81 OK", func(t *testing.T) {
-		if err := validateOutputCovenantConstraints(TxOutput{CovenantType: CORE_VAULT_V1, CovenantData: make([]byte, 81)}); err != nil {
+		var owner [32]byte
+		var recovery [32]byte
+		owner[0] = 0x11
+		recovery[0] = 0x22
+		data := makeVaultV1Data(t, owner, recovery, 1, TIMELOCK_MODE_HEIGHT, 0, true)
+		if err := validateOutputCovenantConstraints(TxOutput{CovenantType: CORE_VAULT_V1, CovenantData: data}); err != nil {
 			t.Fatalf("expected OK, got %v", err)
+		}
+	})
+
+	t.Run("VAULT_V1 owner==recovery parse", func(t *testing.T) {
+		var owner [32]byte
+		owner[0] = 0x11
+		data := makeVaultV1Data(t, owner, owner, 0, TIMELOCK_MODE_HEIGHT, 0, false)
+		err := validateOutputCovenantConstraints(TxOutput{CovenantType: CORE_VAULT_V1, CovenantData: data})
+		if err == nil || err.Error() != "TX_ERR_PARSE" {
+			t.Fatalf("expected parse, got %v", err)
 		}
 	})
 

--- a/clients/go/consensus/validate.go
+++ b/clients/go/consensus/validate.go
@@ -209,6 +209,16 @@ func validateOutputCovenantConstraints(output TxOutput) error {
 		if len(output.CovenantData) != 73 && len(output.CovenantData) != 81 {
 			return fmt.Errorf("TX_ERR_PARSE")
 		}
+		ownerKeyID := output.CovenantData[:32]
+		var recoveryKeyID []byte
+		if len(output.CovenantData) == 73 {
+			recoveryKeyID = output.CovenantData[41:73]
+		} else {
+			recoveryKeyID = output.CovenantData[49:81]
+		}
+		if bytes.Equal(ownerKeyID, recoveryKeyID) {
+			return fmt.Errorf("TX_ERR_PARSE")
+		}
 	case CORE_RESERVED_FUTURE:
 		return fmt.Errorf("TX_ERR_COVENANT_TYPE_INVALID")
 	default:

--- a/spec/RUBIN_L1_CANONICAL_v1.1.md
+++ b/spec/RUBIN_L1_CANONICAL_v1.1.md
@@ -473,6 +473,7 @@ Semantics:
   - `covenant_data` has two encodings (backward compatible):
     - Legacy: `owner_key_id:bytes32 || lock_mode:u8 || lock_value:u64le || recovery_key_id:bytes32` (73 bytes).
     - Extended: `owner_key_id:bytes32 || spend_delay:u64le || lock_mode:u8 || lock_value:u64le || recovery_key_id:bytes32` (81 bytes).
+  - `owner_key_id != recovery_key_id` MUST be enforced; equal values MUST be rejected as `TX_ERR_PARSE`.
   - `spend_delay` is a relative height delay (in blocks) for the owner path, computed from the output's `creation_height` stored in the spendable UTXO set:
     - If `spend_delay = 0`, owner path is immediate (legacy behavior).
     - If `spend_delay > 0`, owner path is forbidden until `height(B) ≥ o.creation_height + spend_delay`.
@@ -566,6 +567,7 @@ For each non-coinbase input spending output `o`:
    - parse `owner_key_id || spend_delay || lock_mode || lock_value || recovery_key_id` with backward compatibility:
      - `covenant_data_len = 73`: parse legacy form and set `spend_delay = 0`.
      - `covenant_data_len = 81`: parse extended form.
+   - If `owner_key_id = recovery_key_id`, reject as `TX_ERR_PARSE`.
    - any other `lock_mode` MUST be `TX_ERR_PARSE`;
    - If witness public key hash equals `owner_key_id` (owner path):
      - If `spend_delay = 0`: accept (legacy behavior).


### PR DESCRIPTION
Fix consensus footgun: forbid CORE_VAULT_V1 outputs where owner_key_id == recovery_key_id (TX_ERR_PARSE).\n\nChanges:\n- Spec: CORE_VAULT_V1 now requires distinct owner/recovery key_ids\n- Go + Rust consensus enforce the invariant\n- Go unit test added for the parse reject case\n\nValidation:\n- go test ./... (clients/go)\n- cargo test (clients/rust)\n- python3 conformance/runner/run_cv_bundle.py (PASS)\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for Vault V1 covenants to reject transactions when owner and recovery key identifiers are identical, preventing invalid transaction processing.

* **Specification Updates**
  * Updated specification to document the requirement that owner and recovery keys must be distinct in Vault V1 covenants across both standard and extended covenant data formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->