### PR TITLE
docs: tail emission rationale — VERSION_BITS as deferred consensus decision

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,23 @@ Status: development. Not a production readiness claim.
 2. **Determinism as a release gate**: txid/sighash/error codes must match across independent clients.
 3. **Compliance-oriented supply chain**: keep consensus crypto behind a stable provider/shim ABI to enable controlled builds and future validated-module workflows.
 
+## Economics and long-term security budget
+
+**v1.1 default**: hard cap of 100,000,000 RBN. 99M mined over ~25 years via a linear decay schedule (not halving). After block `N`, `block_subsidy() = 0` and miners are sustained by transaction fees alone.
+
+**The unsolved problem**: fee-only security is an open research question. Bitcoin will face this after ~2140; no major PoW chain has operated in that regime yet. Monero's answer is a hardcoded perpetual tail emission (~0.6 XMR/block forever) — which solves miner incentive but makes supply permanently inflationary by design, with no community override.
+
+**RUBIN's answer**: neither hardcode inflation nor rule it out. VERSION_BITS (§8 of the canonical spec) gives the live network a **consensus-grade activation mechanism**. If, after the emission window closes, the community determines that fee revenue is insufficient to maintain an adequate security budget, they can propose a `tail_emission_v1` deployment:
+
+- a deployment entry is published with a bit assignment and activation window,
+- miners signal in block headers,
+- at 75% threshold over a 2016-block window: `LOCKED_IN → ACTIVE`,
+- `block_subsidy()` returns a `TAIL_CONSTANT` instead of 0 for all future blocks.
+
+This is a coordinated hardfork — all nodes must upgrade — but the signaling, threshold, and activation height are transparent and measurable on-chain, not a surprise flag day.
+
+The default (v1.1) is a clean hard cap. Tail emission is an option the network can exercise through its own governance mechanism, not a parameter set by the founding team. That distinction matters.
+
 ## Cryptography (v1.1)
 
 Consensus primitives (normative in `spec/RUBIN_L1_CANONICAL_v1.1.md`):

--- a/spec/RUBIN_L1_COINBASE_AND_REWARDS_v1.1.md
+++ b/spec/RUBIN_L1_COINBASE_AND_REWARDS_v1.1.md
@@ -3,7 +3,7 @@
 Status: NON-CONSENSUS (auxiliary notes)  
 Date: 2026-02-16
 
-This document collects auxiliary notes about coinbase construction and subsidy schedule.
+This document collects auxiliary notes about coinbase construction, subsidy schedule, and long-term security budget design.
 
 Normative consensus rules remain in:
 - `spec/RUBIN_L1_CANONICAL_v1.1.md`
@@ -11,6 +11,43 @@ Normative consensus rules remain in:
 ## Subsidy schedule
 
 RUBIN v1.1 uses the subsidy function defined in CANONICAL (§4.5). Implementations MUST match the canonical definition and its integer arithmetic behavior at epoch boundaries.
+
+## Long-term security budget: design rationale
+
+### The problem
+
+After block `N` (`SUBSIDY_DURATION_BLOCKS`), `block_subsidy() = 0` and miner revenue consists entirely of transaction fees. Whether fee revenue alone can sustain an adequate security budget is an open question — no major PoW chain has operated in this regime at scale.
+
+Two prior approaches:
+
+| Chain   | Approach | Tradeoff |
+|---------|----------|----------|
+| Bitcoin | Hard cap, fee-only after ~2140 | Clean supply guarantee; fee-security viability unproven |
+| Monero  | Hardcoded perpetual tail emission (~0.6 XMR/block) | Guaranteed miner incentive; permanently inflationary, no community override |
+
+### RUBIN's approach: deferred consensus decision
+
+RUBIN v1.1 ships with a hard cap (`MAX_SUPPLY = 100,000,000 RBN`). Tail emission is not hardcoded — it is an option the network can activate through its standard governance mechanism.
+
+If, after the emission window closes, the community determines that fee revenue is insufficient, a `tail_emission_v1` deployment can be proposed under VERSION_BITS (CANONICAL §8):
+
+```
+deployment_id:   tail_emission_v1
+bit:             <assigned at proposal time>
+start_height:    <any height ≥ N>
+threshold:       1512  # 75% of WINDOW_SIZE=2016
+feature_summary: "tail emission: block_subsidy() returns TAIL_CONSTANT after height N"
+```
+
+Activation flow: miners signal in block headers → 75% threshold over a 2016-block window → `LOCKED_IN` → next window `ACTIVE` → `block_subsidy()` returns `TAIL_CONSTANT` instead of 0.
+
+This is a hardfork — all nodes must upgrade to follow the new subsidy rule. But the signaling threshold, activation height, and `TAIL_CONSTANT` value are published and measurable on-chain before activation, not a surprise flag day.
+
+### Key distinction
+
+Bitcoin cannot do this without an uncoordinated hardfork. Monero does not need to because the decision was made at launch. RUBIN makes the decision available to the network at the time it becomes relevant, using the same VERSION_BITS mechanism already present in v1.1 for all other consensus upgrades.
+
+The founding team does not preset the answer. The default is a clean hard cap.
 
 ## Coinbase transaction
 


### PR DESCRIPTION
## Summary

Add explanation of long-term security budget design to README and `spec/RUBIN_L1_COINBASE_AND_REWARDS_v1.1.md`.

### What

- **README**: new section "Economics and long-term security budget" — readable comparison of Bitcoin (hard cap, fee-only), Monero (hardcoded tail emission), and RUBIN (hard cap default + VERSION_BITS activation path)
- **COINBASE_AND_REWARDS**: full technical rationale with deployment entry example, activation flow, and governance distinction

### Key point

No committee can unilaterally activate tail emission. Requires: public proposal → 75% miner signaling → node operator adoption. Default remains clean hard cap (100M RBN). The decision is deferred to the live network with real fee market data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Economics and long-term security budget section explaining the v1.1 default hard cap and proposed tail emission mechanism.
  * Updated specification documentation to detail long-term security budget design rationale, including governance-driven consensus activation process and comparison with alternative approaches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->