### PR TITLE
chore: disable CodeRabbit auto-generated PRs (docstrings/unit tests)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -9,6 +9,12 @@ reviews:
   high_level_summary: true
   review_status: true
   commit_status: true
+  # Disable PR-generating "finishing touches" (docstrings/unit tests). We only want review comments.
+  finishing_touches:
+    docstrings:
+      enabled: false
+    unit_tests:
+      enabled: false
   path_instructions:
     - path: "**/*"
       instructions: |


### PR DESCRIPTION
Context: CodeRabbit opened an unsolicited PR (e.g. #99) via branch pattern `coderabbitai/docstrings/*` and it introduced build failures.

This change disables PR-generating finishing touches in repo config:
- `reviews.finishing_touches.docstrings.enabled = false`
- `reviews.finishing_touches.unit_tests.enabled = false`

We keep CodeRabbit review comments enabled (workflow `CodeRabbit Auto Review`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added configuration option to customize PR review behavior, enabling users to disable automatic docstring and unit test suggestions while focusing exclusively on review comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->