### PR TITLE
p2p(go): transport envelope + streaming parser (Q-120)

### DIFF
--- a/clients/go/node/p2p/envelope.go
+++ b/clients/go/node/p2p/envelope.go
@@ -188,4 +188,3 @@ func ReadMessage(r io.Reader, p crypto.CryptoProvider, expectedMagic uint32) (*M
 
 	return &Message{Magic: magic, Command: cmd, Payload: payload}, nil
 }
-

--- a/clients/go/node/p2p/envelope_test.go
+++ b/clients/go/node/p2p/envelope_test.go
@@ -147,4 +147,3 @@ func TestChecksumMismatchBan10NoDisconnect(t *testing.T) {
 		t.Fatalf("expected no disconnect +10 ban, got disconnect=%v ban=%d", rerr.Disconnect, rerr.BanScoreDelta)
 	}
 }
-


### PR DESCRIPTION
Implements Phase 2 (Go primary) P2P transport envelope and streaming parser.

Spec: `spec/RUBIN_L1_P2P_PROTOCOL_v1.1.md` §1.

Changes:
- New package: `clients/go/node/p2p`
- Envelope prefix (24 bytes): magic (u32be), command (12 bytes ASCII + NUL padding), payload_length (u32le), checksum (SHA3-256(payload)[0:4])
- Message-size enforcement: reject payload_length > 8 MiB with disconnect (no payload read)
- Checksum mismatch: drop message (+10 ban) without disconnect
- Magic mismatch: disconnect (not ban-worthy)
- Truncation: disconnect (+20 ban)

Tests:
- Empty payload checksum matches spec (`a7ffc6f8`)
- Round-trip write/read with 1-byte-at-a-time reader (partial reads)
- Oversize disconnect behavior
- Magic mismatch disconnect/no-ban
- Checksum mismatch ban/no-disconnect
