### PR TITLE
p2p(go): version/verack handshake FSM (Q-121)

### DIFF
--- a/clients/go/node/p2p/compactsize.go
+++ b/clients/go/node/p2p/compactsize.go
@@ -1,0 +1,19 @@
+package p2p
+
+import (
+	"fmt"
+
+	"rubin.dev/node/consensus"
+)
+
+func readCompactSize(b []byte) (uint64, int, error) {
+	n, used, err := consensus.DecodeCompactSize(b)
+	if err != nil {
+		return 0, 0, fmt.Errorf("p2p: compactsize: %w", err)
+	}
+	return uint64(n), used, nil
+}
+
+func encodeCompactSize(n uint64) []byte {
+	return consensus.CompactSize(n).Encode()
+}

--- a/clients/go/node/p2p/handshake.go
+++ b/clients/go/node/p2p/handshake.go
@@ -1,0 +1,122 @@
+package p2p
+
+import (
+	"fmt"
+	"net"
+	"time"
+
+	"rubin.dev/node/crypto"
+)
+
+const (
+	HandshakeTimeout = 10 * time.Second
+)
+
+type HandshakeResult struct {
+	PeerVersion VersionPayload
+	Ready       bool
+}
+
+// Handshake performs the minimum v1.1 P2P handshake:
+// - send version
+// - receive+validate peer version (incl chain_id match)
+// - exchange verack
+//
+// It returns an error for any handshake failure. The caller is responsible for closing conn.
+func Handshake(
+	conn net.Conn,
+	p crypto.CryptoProvider,
+	magic uint32,
+	ourVersion VersionPayload,
+	localChainID [32]byte,
+) (*HandshakeResult, error) {
+	if conn == nil {
+		return nil, fmt.Errorf("p2p: handshake: nil conn")
+	}
+
+	ourVersion.ProtocolVersion = ProtocolVersionV1
+	ourVersion.ChainID = localChainID
+
+	versionPayload, err := EncodeVersionPayload(ourVersion)
+	if err != nil {
+		return nil, err
+	}
+	if err := WriteMessage(conn, p, magic, CmdVersion, versionPayload); err != nil {
+		return nil, err
+	}
+
+	// INIT: expect peer version within 10 seconds.
+	_ = conn.SetReadDeadline(time.Now().Add(HandshakeTimeout))
+
+	var peerVersion *VersionPayload
+	for {
+		msg, rerr := ReadMessage(conn, p, magic)
+		if rerr != nil {
+			// checksum mismatch and similar are surfaced as non-disconnect errors.
+			if !rerr.Disconnect {
+				continue
+			}
+			return nil, rerr
+		}
+		switch msg.Command {
+		case CmdVersion:
+			v, err := DecodeVersionPayload(msg.Payload)
+			if err != nil {
+				return nil, err
+			}
+			// chain_id mismatch: send reject + disconnect, no ban-score.
+			if v.ChainID != localChainID {
+				rp, _ := EncodeRejectPayload(RejectPayload{
+					Message: CmdVersion,
+					Code:    RejectInvalid,
+					Reason:  "chain_id mismatch",
+				})
+				_ = WriteMessage(conn, p, magic, CmdReject, rp)
+				return nil, fmt.Errorf("p2p: handshake: chain_id mismatch")
+			}
+			if v.ProtocolVersion != ProtocolVersionV1 {
+				// Spec doesn't define explicit obsolete behavior yet; treat as malformed.
+				return nil, fmt.Errorf("p2p: handshake: unsupported protocol_version")
+			}
+			peerVersion = v
+			goto gotVersion
+		case CmdVerack:
+			// Early verack should be ignored.
+			continue
+		default:
+			// Ignore unknown/unsolicited; higher layers can apply ban-score if repeated.
+			continue
+		}
+	}
+
+gotVersion:
+	// GOT_VERSION: send verack and require peer verack within 10 seconds.
+	if err := WriteMessage(conn, p, magic, CmdVerack, nil); err != nil {
+		return nil, err
+	}
+	_ = conn.SetReadDeadline(time.Now().Add(HandshakeTimeout))
+
+	for {
+		msg, rerr := ReadMessage(conn, p, magic)
+		if rerr != nil {
+			if !rerr.Disconnect {
+				continue
+			}
+			return nil, rerr
+		}
+		switch msg.Command {
+		case CmdVerack:
+			if len(msg.Payload) != 0 {
+				return nil, fmt.Errorf("p2p: handshake: verack payload must be empty")
+			}
+			_ = conn.SetReadDeadline(time.Time{})
+			return &HandshakeResult{PeerVersion: *peerVersion, Ready: true}, nil
+		case CmdVersion:
+			// A second version after handshake start is malformed; in READY it's +10 ban+disconnect.
+			return nil, fmt.Errorf("p2p: handshake: duplicate version")
+		default:
+			// Ignore until verack arrives.
+			continue
+		}
+	}
+}

--- a/clients/go/node/p2p/handshake_test.go
+++ b/clients/go/node/p2p/handshake_test.go
@@ -1,0 +1,169 @@
+package p2p
+
+import (
+	"encoding/hex"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"rubin.dev/node/crypto"
+)
+
+func TestHandshakeRoundTripTCP(t *testing.T) {
+	p := crypto.DevStdCryptoProvider{}
+	magic := uint32(0x11223344)
+
+	var chainID [32]byte
+	chainID[0] = 0xaa
+	chainID[31] = 0xbb
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	serverErr := make(chan error, 1)
+	go func() {
+		c, err := ln.Accept()
+		if err != nil {
+			serverErr <- err
+			return
+		}
+		defer c.Close()
+		res, err := Handshake(c, p, magic, VersionPayload{
+			Timestamp:   uint64(time.Now().Unix()),
+			Nonce:       2,
+			UserAgent:   "S",
+			StartHeight: 11,
+			Relay:       false,
+		}, chainID)
+		if err != nil {
+			serverErr <- err
+			return
+		}
+		if !res.Ready {
+			serverErr <- fmt.Errorf("server not ready")
+			return
+		}
+		serverErr <- nil
+	}()
+
+	clientConn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer clientConn.Close()
+
+	res, err := Handshake(clientConn, p, magic, VersionPayload{
+		Timestamp:   uint64(time.Now().Unix()),
+		Nonce:       1,
+		UserAgent:   "C",
+		StartHeight: 10,
+		Relay:       true,
+	}, chainID)
+	if err != nil {
+		t.Fatalf("client handshake: %v", err)
+	}
+	if !res.Ready {
+		t.Fatalf("client not ready")
+	}
+	if err := <-serverErr; err != nil {
+		t.Fatalf("server handshake: %v", err)
+	}
+}
+
+func TestChainIDMismatchSendsReject(t *testing.T) {
+	p := crypto.DevStdCryptoProvider{}
+	magic := uint32(0x11223344)
+
+	var chainA [32]byte
+	var chainB [32]byte
+	chainA[0] = 0x01
+	chainB[0] = 0x02
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	// Server runs handshake expecting chainB; client sends a version with chainA.
+	done := make(chan error, 1)
+	go func() {
+		c, err := ln.Accept()
+		if err != nil {
+			done <- err
+			return
+		}
+		defer c.Close()
+		_, err = Handshake(c, p, magic, VersionPayload{
+			Timestamp:   1,
+			Nonce:       2,
+			UserAgent:   "S",
+			StartHeight: 0,
+			Relay:       false,
+		}, chainB)
+		done <- err
+	}()
+
+	clientConn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer clientConn.Close()
+
+	// Client writes a single version message with wrong chain_id and reads server reject.
+	vp := VersionPayload{
+		ProtocolVersion: ProtocolVersionV1,
+		ChainID:         chainA,
+		PeerServices:    0,
+		Timestamp:       1,
+		Nonce:           1,
+		UserAgent:       "C",
+		StartHeight:     0,
+		Relay:           false,
+	}
+	payload, err := EncodeVersionPayload(vp)
+	if err != nil {
+		t.Fatalf("encode version: %v", err)
+	}
+	if err := WriteMessage(clientConn, p, magic, CmdVersion, payload); err != nil {
+		t.Fatalf("write version: %v", err)
+	}
+
+	// Server is allowed (and recommended) to send its own version promptly after connect,
+	// even if it will later reject the peer's version due to chain_id mismatch.
+	msg, rerr := ReadMessage(clientConn, p, magic)
+	if rerr != nil {
+		t.Fatalf("read first msg: %v", rerr)
+	}
+	if msg.Command == CmdVersion {
+		// ok, ignore
+	} else if msg.Command == CmdReject {
+		// Some implementations might reject before sending their own version; accept.
+	} else {
+		t.Fatalf("expected version or reject, got %q", msg.Command)
+	}
+
+	if msg.Command != CmdReject {
+		msg, rerr = ReadMessage(clientConn, p, magic)
+		if rerr != nil {
+			t.Fatalf("read reject: %v", rerr)
+		}
+	}
+	if msg.Command != CmdReject {
+		t.Fatalf("expected reject, got %q", msg.Command)
+	}
+
+	rp, err := DecodeRejectPayload(msg.Payload)
+	if err != nil {
+		t.Fatalf("decode reject: %v (payload=%s)", err, hex.EncodeToString(msg.Payload))
+	}
+	if rp.Message != CmdVersion || rp.Code != RejectInvalid {
+		t.Fatalf("unexpected reject: message=%q code=%x", rp.Message, rp.Code)
+	}
+
+	_ = <-done
+}

--- a/clients/go/node/p2p/messages.go
+++ b/clients/go/node/p2p/messages.go
@@ -1,0 +1,18 @@
+package p2p
+
+const (
+	CmdVersion = "version"
+	CmdVerack  = "verack"
+	CmdReject  = "reject"
+)
+
+const (
+	RejectMalformed       = 0x01
+	RejectInvalid         = 0x10
+	RejectObsolete        = 0x11
+	RejectDuplicate       = 0x12
+	RejectNonstandard     = 0x40
+	RejectDust            = 0x41
+	RejectInsufficientFee = 0x42
+	RejectCheckpoint      = 0x43
+)

--- a/clients/go/node/p2p/reject.go
+++ b/clients/go/node/p2p/reject.go
@@ -1,0 +1,80 @@
+package p2p
+
+import (
+	"fmt"
+	"unicode/utf8"
+)
+
+const (
+	MaxRejectReasonBytes = 111
+)
+
+type RejectPayload struct {
+	Message string
+	Code    byte
+	Reason  string
+}
+
+func EncodeRejectPayload(r RejectPayload) ([]byte, error) {
+	if r.Message == "" {
+		return nil, fmt.Errorf("p2p: reject: empty message")
+	}
+	if len(r.Message) > CommandBytes {
+		// The spec uses an arbitrary string length, but for v1.1 we keep it bounded.
+		return nil, fmt.Errorf("p2p: reject: message too long")
+	}
+	if len(r.Reason) > MaxRejectReasonBytes {
+		return nil, fmt.Errorf("p2p: reject: reason too long")
+	}
+	if !utf8.ValidString(r.Reason) {
+		return nil, fmt.Errorf("p2p: reject: reason must be UTF-8")
+	}
+	out := make([]byte, 0, 9+len(r.Message)+1+9+len(r.Reason))
+	out = append(out, encodeCompactSize(uint64(len(r.Message)))...)
+	out = append(out, []byte(r.Message)...)
+	out = append(out, r.Code)
+	out = append(out, encodeCompactSize(uint64(len(r.Reason)))...)
+	out = append(out, []byte(r.Reason)...)
+	return out, nil
+}
+
+func DecodeRejectPayload(b []byte) (*RejectPayload, error) {
+	off := 0
+	msgLenU64, used, err := readCompactSize(b)
+	if err != nil {
+		return nil, err
+	}
+	off += used
+	if msgLenU64 > CommandBytes {
+		return nil, fmt.Errorf("p2p: reject: message_len too large")
+	}
+	msgLen := int(msgLenU64)
+	if len(b) < off+msgLen+1 {
+		return nil, fmt.Errorf("p2p: reject: truncated message")
+	}
+	msg := string(b[off : off+msgLen])
+	off += msgLen
+	code := b[off]
+	off++
+	reasonLenU64, used, err := readCompactSize(b[off:])
+	if err != nil {
+		return nil, err
+	}
+	off += used
+	if reasonLenU64 > MaxRejectReasonBytes {
+		return nil, fmt.Errorf("p2p: reject: reason_len too large")
+	}
+	reasonLen := int(reasonLenU64)
+	if len(b) < off+reasonLen {
+		return nil, fmt.Errorf("p2p: reject: truncated reason")
+	}
+	reasonBytes := b[off : off+reasonLen]
+	off += reasonLen
+	if off != len(b) {
+		return nil, fmt.Errorf("p2p: reject: trailing bytes")
+	}
+	if !utf8.Valid(reasonBytes) {
+		return nil, fmt.Errorf("p2p: reject: reason must be UTF-8")
+	}
+	return &RejectPayload{Message: msg, Code: code, Reason: string(reasonBytes)}, nil
+}

--- a/clients/go/node/p2p/version.go
+++ b/clients/go/node/p2p/version.go
@@ -1,0 +1,120 @@
+package p2p
+
+import (
+	"encoding/binary"
+	"fmt"
+	"unicode/utf8"
+)
+
+const (
+	ProtocolVersionV1 = 1
+	MaxUserAgentBytes = 256
+)
+
+type VersionPayload struct {
+	ProtocolVersion uint32
+	ChainID         [32]byte
+	PeerServices    uint64
+	Timestamp       uint64
+	Nonce           uint64
+	UserAgent       string
+	StartHeight     uint32
+	Relay           bool
+}
+
+func EncodeVersionPayload(v VersionPayload) ([]byte, error) {
+	if v.ProtocolVersion != ProtocolVersionV1 {
+		return nil, fmt.Errorf("p2p: version: unsupported protocol_version")
+	}
+	if len(v.UserAgent) > MaxUserAgentBytes {
+		return nil, fmt.Errorf("p2p: version: user_agent too long")
+	}
+	if !utf8.ValidString(v.UserAgent) {
+		return nil, fmt.Errorf("p2p: version: user_agent must be UTF-8")
+	}
+
+	out := make([]byte, 0, 4+32+8+8+8+9+len(v.UserAgent)+4+1)
+	var tmp8 [8]byte
+	var tmp4 [4]byte
+
+	binary.LittleEndian.PutUint32(tmp4[:], v.ProtocolVersion)
+	out = append(out, tmp4[:]...)
+	out = append(out, v.ChainID[:]...)
+	binary.LittleEndian.PutUint64(tmp8[:], v.PeerServices)
+	out = append(out, tmp8[:]...)
+	binary.LittleEndian.PutUint64(tmp8[:], v.Timestamp)
+	out = append(out, tmp8[:]...)
+	binary.LittleEndian.PutUint64(tmp8[:], v.Nonce)
+	out = append(out, tmp8[:]...)
+
+	out = append(out, encodeCompactSize(uint64(len(v.UserAgent)))...)
+	out = append(out, []byte(v.UserAgent)...)
+
+	binary.LittleEndian.PutUint32(tmp4[:], v.StartHeight)
+	out = append(out, tmp4[:]...)
+
+	if v.Relay {
+		out = append(out, 1)
+	} else {
+		out = append(out, 0)
+	}
+
+	return out, nil
+}
+
+func DecodeVersionPayload(b []byte) (*VersionPayload, error) {
+	if len(b) < 4+32+8+8+8+4+1 {
+		return nil, fmt.Errorf("p2p: version: truncated")
+	}
+	off := 0
+	proto := binary.LittleEndian.Uint32(b[off : off+4])
+	off += 4
+	var chainID [32]byte
+	copy(chainID[:], b[off:off+32])
+	off += 32
+	peerServices := binary.LittleEndian.Uint64(b[off : off+8])
+	off += 8
+	timestamp := binary.LittleEndian.Uint64(b[off : off+8])
+	off += 8
+	nonce := binary.LittleEndian.Uint64(b[off : off+8])
+	off += 8
+
+	uaLenU64, used, err := readCompactSize(b[off:])
+	if err != nil {
+		return nil, err
+	}
+	off += used
+	if uaLenU64 > MaxUserAgentBytes {
+		return nil, fmt.Errorf("p2p: version: user_agent_len exceeds MAX_USER_AGENT_BYTES")
+	}
+	uaLen := int(uaLenU64)
+	if len(b) < off+uaLen+4+1 {
+		return nil, fmt.Errorf("p2p: version: truncated user_agent")
+	}
+	uaBytes := b[off : off+uaLen]
+	off += uaLen
+	if !utf8.Valid(uaBytes) {
+		return nil, fmt.Errorf("p2p: version: user_agent must be UTF-8")
+	}
+	startHeight := binary.LittleEndian.Uint32(b[off : off+4])
+	off += 4
+	relayByte := b[off]
+	off++
+	if relayByte != 0 && relayByte != 1 {
+		return nil, fmt.Errorf("p2p: version: relay must be 0 or 1")
+	}
+	if off != len(b) {
+		return nil, fmt.Errorf("p2p: version: trailing bytes")
+	}
+
+	return &VersionPayload{
+		ProtocolVersion: proto,
+		ChainID:         chainID,
+		PeerServices:    peerServices,
+		Timestamp:       timestamp,
+		Nonce:           nonce,
+		UserAgent:       string(uaBytes),
+		StartHeight:     startHeight,
+		Relay:           relayByte == 1,
+	}, nil
+}


### PR DESCRIPTION
Implements Go P2P handshake FSM per spec v1.1: version/verack, chain_id gating, timeouts, and reject message encoding/decoding.\n\nQA: tools/qa_pre_push.sh PASS; conformance bundle PASS (140).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Implemented P2P peer handshake protocol with version negotiation, chain ID validation, and strict deadline handling
  * Added support for peer rejection messages with standardized reason codes and message encoding
  * Introduced protocol message constants and binary payload encoding/decoding for version exchange and rejection flows with comprehensive validation

* **Tests**
  * Added comprehensive handshake tests covering successful peer exchanges and chain ID mismatch rejection scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->