### PR TITLE
node(rust): keymgr keystore wrap/rewrap parity

### DIFF
--- a/clients/rust/Cargo.lock
+++ b/clients/rust/Cargo.lock
@@ -3,6 +3,17 @@
 version = 4
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -28,6 +39,16 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -155,6 +176,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -278,10 +308,12 @@ dependencies = [
 name = "rubin-node"
 version = "0.1.0"
 dependencies = [
+ "aes",
  "rubin-consensus",
  "rubin-crypto",
  "rubin-store",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]

--- a/clients/rust/crates/rubin-node/Cargo.toml
+++ b/clients/rust/crates/rubin-node/Cargo.toml
@@ -13,4 +13,8 @@ wolfcrypt-dylib = ["rubin-crypto/wolfcrypt-dylib"]
 rubin-consensus = { path = "../rubin-consensus" }
 rubin-crypto = { path = "../rubin-crypto" }
 rubin-store = { path = "../rubin-store" }
+aes = "0.8"
 serde_json = "1.0"
+
+[dev-dependencies]
+tempfile = "3"

--- a/clients/rust/crates/rubin-node/src/aeskw.rs
+++ b/clients/rust/crates/rubin-node/src/aeskw.rs
@@ -1,0 +1,132 @@
+// AES-256 Key Wrap (RFC 3394 / NIST SP 800-38F).
+//
+// This is a dev-only fallback for environments without a wolfcrypt shim keywrap
+// implementation. Strict/FIPS deployments must use the shim/HSM path.
+
+use aes::Aes256;
+use aes::cipher::{BlockDecrypt, BlockEncrypt, KeyInit};
+
+const DEFAULT_IV: [u8; 8] = [0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6];
+
+fn xor_u64_be(a: &mut [u8; 8], t: u64) {
+    for (k, v) in a.iter_mut().enumerate().take(8) {
+        *v ^= ((t >> (56 - 8 * k)) & 0xff) as u8;
+    }
+}
+
+pub fn aes_key_wrap_rfc3394(kek: &[u8], key_in: &[u8]) -> Result<Vec<u8>, String> {
+    if kek.len() != 32 {
+        return Err("aeskw: kek must be 32 bytes (AES-256)".into());
+    }
+    if key_in.len() < 16 || key_in.len() > 4096 || !key_in.len().is_multiple_of(8) {
+        return Err("aeskw: keyIn must be 16..4096 bytes and multiple of 8".into());
+    }
+
+    let cipher = Aes256::new_from_slice(kek).map_err(|_| "aeskw: invalid kek".to_string())?;
+    let n = key_in.len() / 8;
+
+    let mut r = vec![[0u8; 8]; n];
+    for i in 0..n {
+        r[i].copy_from_slice(&key_in[i * 8..(i + 1) * 8]);
+    }
+    let mut a = DEFAULT_IV;
+
+    for j in 0..6u64 {
+        for (i, ri) in r.iter_mut().enumerate().take(n) {
+            let mut b = [0u8; 16];
+            b[0..8].copy_from_slice(&a);
+            b[8..16].copy_from_slice(ri);
+
+            let mut block = aes::cipher::generic_array::GenericArray::clone_from_slice(&b);
+            cipher.encrypt_block(&mut block);
+            b.copy_from_slice(&block);
+
+            a.copy_from_slice(&b[0..8]);
+            let t = (n as u64) * j + (i as u64) + 1;
+            xor_u64_be(&mut a, t);
+            ri.copy_from_slice(&b[8..16]);
+        }
+    }
+
+    let mut out = Vec::with_capacity(8 + key_in.len());
+    out.extend_from_slice(&a);
+    for ri in r.iter().take(n) {
+        out.extend_from_slice(ri);
+    }
+    Ok(out)
+}
+
+pub fn aes_key_unwrap_rfc3394(kek: &[u8], wrapped: &[u8]) -> Result<Vec<u8>, String> {
+    if kek.len() != 32 {
+        return Err("aeskw: kek must be 32 bytes (AES-256)".into());
+    }
+    if wrapped.len() < 24 || wrapped.len() > 4104 || !wrapped.len().is_multiple_of(8) {
+        return Err("aeskw: wrapped must be 24..4104 bytes and multiple of 8".into());
+    }
+
+    let cipher = Aes256::new_from_slice(kek).map_err(|_| "aeskw: invalid kek".to_string())?;
+    let n = (wrapped.len() / 8) - 1;
+
+    let mut a = [0u8; 8];
+    a.copy_from_slice(&wrapped[0..8]);
+    let mut r = vec![[0u8; 8]; n];
+    for i in 0..n {
+        r[i].copy_from_slice(&wrapped[(i + 1) * 8..(i + 2) * 8]);
+    }
+
+    for j in (0..6u64).rev() {
+        for i in (0..n).rev() {
+            let t = (n as u64) * j + (i as u64) + 1;
+            let mut a_xor = a;
+            xor_u64_be(&mut a_xor, t);
+
+            let mut b = [0u8; 16];
+            b[0..8].copy_from_slice(&a_xor);
+            b[8..16].copy_from_slice(&r[i]);
+
+            let mut block = aes::cipher::generic_array::GenericArray::clone_from_slice(&b);
+            cipher.decrypt_block(&mut block);
+            b.copy_from_slice(&block);
+
+            a.copy_from_slice(&b[0..8]);
+            r[i].copy_from_slice(&b[8..16]);
+        }
+    }
+
+    if a != DEFAULT_IV {
+        return Err("aeskw: integrity check failed".into());
+    }
+
+    let mut out = Vec::with_capacity(n * 8);
+    for ri in r.iter().take(n) {
+        out.extend_from_slice(ri);
+    }
+    if out.len() % 8 != 0 {
+        return Err("aeskw: unwrap produced non-multiple-of-8 length".into());
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_aeskw_roundtrip() {
+        let kek = [0x11u8; 32];
+        let key_in = [0x22u8; 16];
+        let wrapped = aes_key_wrap_rfc3394(&kek, &key_in).unwrap();
+        let unwrapped = aes_key_unwrap_rfc3394(&kek, &wrapped).unwrap();
+        assert_eq!(unwrapped, key_in);
+    }
+
+    #[test]
+    fn test_aeskw_wrong_kek_fails_integrity() {
+        let kek = [0x11u8; 32];
+        let kek2 = [0x12u8; 32];
+        let key_in = [0x22u8; 16];
+        let wrapped = aes_key_wrap_rfc3394(&kek, &key_in).unwrap();
+        let err = aes_key_unwrap_rfc3394(&kek2, &wrapped).unwrap_err();
+        assert!(err.contains("integrity"));
+    }
+}

--- a/clients/rust/crates/rubin-node/src/keymgr.rs
+++ b/clients/rust/crates/rubin-node/src/keymgr.rs
@@ -1,0 +1,498 @@
+use std::fs;
+
+use crate::aeskw;
+
+trait KeyWrapProvider {
+    fn wrap(&self, kek: &[u8], key_in: &[u8]) -> Result<Vec<u8>, String>;
+    fn unwrap(&self, kek: &[u8], wrapped: &[u8]) -> Result<Vec<u8>, String>;
+}
+
+struct SoftwareKeyWrap;
+
+impl KeyWrapProvider for SoftwareKeyWrap {
+    fn wrap(&self, kek: &[u8], key_in: &[u8]) -> Result<Vec<u8>, String> {
+        aeskw::aes_key_wrap_rfc3394(kek, key_in)
+    }
+
+    fn unwrap(&self, kek: &[u8], wrapped: &[u8]) -> Result<Vec<u8>, String> {
+        aeskw::aes_key_unwrap_rfc3394(kek, wrapped)
+    }
+}
+
+#[cfg(feature = "wolfcrypt-dylib")]
+struct ShimKeyWrap {
+    p: rubin_crypto::WolfcryptDylibProvider,
+}
+
+#[cfg(feature = "wolfcrypt-dylib")]
+impl KeyWrapProvider for ShimKeyWrap {
+    fn wrap(&self, kek: &[u8], key_in: &[u8]) -> Result<Vec<u8>, String> {
+        self.p.key_wrap(kek, key_in)
+    }
+
+    fn unwrap(&self, kek: &[u8], wrapped: &[u8]) -> Result<Vec<u8>, String> {
+        self.p.key_unwrap(kek, wrapped).map_err(|e| e.to_string())
+    }
+}
+
+fn parse_hex_flag(args: &[String], flag: &str) -> Result<Vec<u8>, i32> {
+    match crate::get_flag(args, flag) {
+        Ok(Some(v)) => match rubin_consensus::hex_decode_strict(&v) {
+            Ok(b) => Ok(b),
+            Err(e) => {
+                eprintln!("{flag}: {e}");
+                Err(2)
+            }
+        },
+        Ok(None) => {
+            eprintln!("missing required flag: {flag}");
+            Err(2)
+        }
+        Err(e) => {
+            eprintln!("{e}");
+            Err(2)
+        }
+    }
+}
+
+fn parse_opt_hex_flag(args: &[String], flag: &str) -> Result<Option<Vec<u8>>, i32> {
+    match crate::get_flag(args, flag) {
+        Ok(Some(v)) => match rubin_consensus::hex_decode_strict(&v) {
+            Ok(b) => Ok(Some(b)),
+            Err(e) => {
+                eprintln!("{flag}: {e}");
+                Err(2)
+            }
+        },
+        Ok(None) => Ok(None),
+        Err(e) => {
+            eprintln!("{e}");
+            Err(2)
+        }
+    }
+}
+
+fn parse_u8_flag(args: &[String], flag: &str) -> Result<u8, i32> {
+    match crate::get_flag(args, flag) {
+        Ok(Some(v)) => {
+            let s = v.trim();
+            let parsed = if let Some(hex) = s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")) {
+                u8::from_str_radix(hex, 16)
+            } else {
+                s.parse::<u8>()
+            };
+            parsed.map_err(|e| {
+                eprintln!("{flag}: {e}");
+                2
+            })
+        }
+        Ok(None) => {
+            eprintln!("missing required flag: {flag}");
+            Err(2)
+        }
+        Err(e) => {
+            eprintln!("{e}");
+            Err(2)
+        }
+    }
+}
+
+fn parse_string_flag(args: &[String], flag: &str) -> Result<String, i32> {
+    match crate::get_flag(args, flag) {
+        Ok(Some(v)) => Ok(v),
+        Ok(None) => {
+            eprintln!("missing required flag: {flag}");
+            Err(2)
+        }
+        Err(e) => {
+            eprintln!("{e}");
+            Err(2)
+        }
+    }
+}
+
+fn write_file_0600(path: &str, bytes: &[u8]) -> Result<(), String> {
+    use std::io::Write;
+    #[cfg(unix)]
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let mut opts = std::fs::OpenOptions::new();
+    opts.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    {
+        opts.mode(0o600);
+    }
+    let mut f = opts.open(path).map_err(|e| format!("write {path}: {e}"))?;
+    f.write_all(bytes)
+        .map_err(|e| format!("write {path}: {e}"))?;
+    Ok(())
+}
+
+#[cfg(feature = "wolfcrypt-dylib")]
+fn load_key_wrapper(strict: bool) -> Result<Box<dyn KeyWrapProvider>, String> {
+    let has_shim_path = std::env::var("RUBIN_WOLFCRYPT_SHIM_PATH")
+        .map(|v| !v.trim().is_empty())
+        .unwrap_or(false);
+
+    if !has_shim_path {
+        if strict {
+            return Err("RUBIN_WOLFCRYPT_STRICT=1 requires RUBIN_WOLFCRYPT_SHIM_PATH".into());
+        }
+        return Ok(Box::new(SoftwareKeyWrap));
+    }
+
+    let p = rubin_crypto::WolfcryptDylibProvider::load_from_env()?;
+    if p.has_key_management() {
+        Ok(Box::new(ShimKeyWrap { p }))
+    } else if strict {
+        Err("keymgr requires wolfcrypt shim keywrap symbols in strict mode".into())
+    } else {
+        Ok(Box::new(SoftwareKeyWrap))
+    }
+}
+
+#[cfg(not(feature = "wolfcrypt-dylib"))]
+fn load_key_wrapper(strict: bool) -> Result<Box<dyn KeyWrapProvider>, String> {
+    if strict {
+        return Err("RUBIN_WOLFCRYPT_STRICT=1 requires feature wolfcrypt-dylib".into());
+    }
+    Ok(Box::new(SoftwareKeyWrap))
+}
+
+fn read_keystore(path: &str) -> Result<serde_json::Map<String, serde_json::Value>, String> {
+    let raw = fs::read_to_string(path).map_err(|e| format!("read keystore: {e}"))?;
+    let v: serde_json::Value =
+        serde_json::from_str(&raw).map_err(|e| format!("keystore json: {e}"))?;
+    let obj = v
+        .as_object()
+        .ok_or_else(|| "keystore json: root must be object".to_string())?;
+
+    let version = obj.get("version").and_then(|v| v.as_str()).unwrap_or("");
+    if version != "RBKSv1" {
+        return Err(format!("unsupported keystore version: {version:?}"));
+    }
+    let wrap_alg = obj.get("wrap_alg").and_then(|v| v.as_str()).unwrap_or("");
+    if !wrap_alg.eq_ignore_ascii_case("AES-256-KW") {
+        return Err(format!("unsupported wrap_alg: {wrap_alg:?}"));
+    }
+    Ok(obj.clone())
+}
+
+fn cmd_keymgr_export_wrapped(args: &[String]) -> i32 {
+    let out = match parse_string_flag(args, "--out") {
+        Ok(v) => v,
+        Err(code) => return code,
+    };
+    let suite_id = match parse_u8_flag(args, "--suite-id") {
+        Ok(v) => v,
+        Err(code) => return code,
+    };
+    let pubkey = match parse_hex_flag(args, "--pubkey-hex") {
+        Ok(v) => v,
+        Err(code) => return code,
+    };
+    let sk = match parse_hex_flag(args, "--sk-hex") {
+        Ok(v) => v,
+        Err(code) => return code,
+    };
+    let kek = match parse_hex_flag(args, "--kek-hex") {
+        Ok(v) => v,
+        Err(code) => return code,
+    };
+    if kek.len() != 32 {
+        eprintln!("kek must be 32 bytes (got {})", kek.len());
+        return 2;
+    }
+    if sk.is_empty() || sk.len() % 8 != 0 {
+        eprintln!("sk must be non-zero multiple of 8 bytes (AES-KW requirement)");
+        return 2;
+    }
+
+    let strict = crate::wolfcrypt_strict();
+    let km = match load_key_wrapper(strict) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("{e}");
+            return 1;
+        }
+    };
+
+    // key_id = SHA3-256(pubkey)
+    let provider = match crate::load_crypto_provider() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("{e}");
+            return 1;
+        }
+    };
+    let key_id = match provider.sha3_256(&pubkey) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("{e}");
+            return 1;
+        }
+    };
+
+    let wrapped = match km.wrap(&kek, &sk) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("{e}");
+            return 1;
+        }
+    };
+
+    let mut obj = serde_json::Map::new();
+    obj.insert(
+        "version".to_string(),
+        serde_json::Value::String("RBKSv1".to_string()),
+    );
+    obj.insert(
+        "suite_id".to_string(),
+        serde_json::Value::Number(serde_json::Number::from(suite_id)),
+    );
+    obj.insert(
+        "pubkey_hex".to_string(),
+        serde_json::Value::String(crate::hex_encode(&pubkey)),
+    );
+    obj.insert(
+        "key_id_hex".to_string(),
+        serde_json::Value::String(crate::hex_encode(&key_id)),
+    );
+    obj.insert(
+        "wrap_alg".to_string(),
+        serde_json::Value::String("AES-256-KW".to_string()),
+    );
+    obj.insert(
+        "wrapped_sk_hex".to_string(),
+        serde_json::Value::String(crate::hex_encode(&wrapped)),
+    );
+
+    let mut bytes = serde_json::to_vec(&serde_json::Value::Object(obj))
+        .map_err(|e| format!("json: {e}"))
+        .unwrap();
+    bytes.push(b'\n');
+    if let Err(e) = write_file_0600(&out, &bytes) {
+        eprintln!("{e}");
+        return 1;
+    }
+    0
+}
+
+fn cmd_keymgr_import_wrapped(args: &[String]) -> i32 {
+    let in_path = match parse_string_flag(args, "--in") {
+        Ok(v) => v,
+        Err(code) => return code,
+    };
+    let out_path = match parse_string_flag(args, "--out") {
+        Ok(v) => v,
+        Err(code) => return code,
+    };
+    let old_kek = match parse_hex_flag(args, "--old-kek-hex") {
+        Ok(v) => v,
+        Err(code) => return code,
+    };
+    let new_kek = match parse_hex_flag(args, "--new-kek-hex") {
+        Ok(v) => v,
+        Err(code) => return code,
+    };
+    if old_kek.len() != 32 {
+        eprintln!("old-kek must be 32 bytes (got {})", old_kek.len());
+        return 2;
+    }
+    if new_kek.len() != 32 {
+        eprintln!("new-kek must be 32 bytes (got {})", new_kek.len());
+        return 2;
+    }
+
+    let strict = crate::wolfcrypt_strict();
+    let km = match load_key_wrapper(strict) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("{e}");
+            return 1;
+        }
+    };
+
+    let mut ks = match read_keystore(&in_path) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("{e}");
+            return 1;
+        }
+    };
+    let wrapped_sk_hex = ks
+        .get("wrapped_sk_hex")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let wrapped = match rubin_consensus::hex_decode_strict(wrapped_sk_hex) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("wrapped_sk_hex: {e}");
+            return 1;
+        }
+    };
+
+    let plain = match km.unwrap(&old_kek, &wrapped) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("{e}");
+            return 1;
+        }
+    };
+    let new_wrapped = match km.wrap(&new_kek, &plain) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("{e}");
+            return 1;
+        }
+    };
+    ks.insert(
+        "wrapped_sk_hex".to_string(),
+        serde_json::Value::String(crate::hex_encode(&new_wrapped)),
+    );
+
+    let mut bytes = serde_json::to_vec(&serde_json::Value::Object(ks))
+        .map_err(|e| format!("json: {e}"))
+        .unwrap();
+    bytes.push(b'\n');
+    if let Err(e) = write_file_0600(&out_path, &bytes) {
+        eprintln!("{e}");
+        return 1;
+    }
+    0
+}
+
+fn cmd_keymgr_verify_pubkey(args: &[String]) -> i32 {
+    let in_path = match parse_string_flag(args, "--in") {
+        Ok(v) => v,
+        Err(code) => return code,
+    };
+    let expected = match parse_opt_hex_flag(args, "--expected-key-id-hex") {
+        Ok(v) => v,
+        Err(code) => return code,
+    };
+
+    let ks = match read_keystore(&in_path) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("{e}");
+            return 1;
+        }
+    };
+    let pubkey_hex = ks.get("pubkey_hex").and_then(|v| v.as_str()).unwrap_or("");
+    let pubkey = match rubin_consensus::hex_decode_strict(pubkey_hex) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("pubkey_hex: {e}");
+            return 1;
+        }
+    };
+
+    let provider = match crate::load_crypto_provider() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("{e}");
+            return 1;
+        }
+    };
+    let key_id = match provider.sha3_256(&pubkey) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("{e}");
+            return 1;
+        }
+    };
+    let got_hex = crate::hex_encode(&key_id);
+
+    if let Some(embedded) = ks.get("key_id_hex").and_then(|v| v.as_str())
+        && !embedded.is_empty()
+        && embedded.to_ascii_lowercase() != got_hex
+    {
+        eprintln!("keystore key_id mismatch: embedded={embedded} computed={got_hex}");
+        return 1;
+    }
+    if let Some(exp) = expected {
+        if exp.len() != 32 {
+            eprintln!(
+                "--expected-key-id-hex must decode to 32 bytes (got {})",
+                exp.len()
+            );
+            return 2;
+        }
+        let exp_hex = crate::hex_encode(&exp);
+        if exp_hex != got_hex {
+            eprintln!("expected key_id mismatch: expected={exp_hex} computed={got_hex}");
+            return 1;
+        }
+    }
+
+    println!("{got_hex}");
+    0
+}
+
+pub fn cmd_keymgr_main(args: &[String]) -> i32 {
+    if args.is_empty() {
+        eprintln!("usage: rubin-node keymgr <subcommand> [flags]");
+        return 2;
+    }
+    let sub = args[0].as_str();
+    let sub_args = &args[1..];
+    match sub {
+        "export-wrapped" => {
+            let rc = cmd_keymgr_export_wrapped(sub_args);
+            if rc == 0 {
+                println!("OK");
+            } else if rc == 1 {
+                eprintln!("keymgr export-wrapped error");
+            }
+            rc
+        }
+        "import-wrapped" => {
+            let rc = cmd_keymgr_import_wrapped(sub_args);
+            if rc == 0 {
+                println!("OK");
+            } else if rc == 1 {
+                eprintln!("keymgr import-wrapped error");
+            }
+            rc
+        }
+        "verify-pubkey" => cmd_keymgr_verify_pubkey(sub_args),
+        _ => {
+            eprintln!("unknown keymgr subcommand");
+            2
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_keymgr_verify_pubkey_minimal_keystore() {
+        let td = tempfile::tempdir().unwrap();
+        let ks_path = td.path().join("k.json");
+
+        // Minimal keystore, no wrapped key needed for verify-pubkey.
+        // wrapped_sk_hex may be junk, but verify-pubkey must not crash.
+        write_file_0600(
+            ks_path.to_str().unwrap(),
+            br#"{
+  "version": "RBKSv1",
+  "suite_id": 1,
+  "pubkey_hex": "11",
+  "key_id_hex": "",
+  "wrap_alg": "AES-256-KW",
+  "wrapped_sk_hex": "00"
+}
+"#,
+        )
+        .unwrap();
+
+        let rc = cmd_keymgr_verify_pubkey(&vec![
+            "--in".to_string(),
+            ks_path.to_str().unwrap().to_string(),
+        ]);
+        assert_eq!(rc, 0);
+    }
+}

--- a/clients/rust/crates/rubin-node/src/main.rs
+++ b/clients/rust/crates/rubin-node/src/main.rs
@@ -4,6 +4,9 @@ use std::path::{Component, Path, PathBuf};
 
 use rubin_crypto::CryptoProvider;
 
+mod aeskw;
+mod keymgr;
+
 fn hex_encode(bytes: &[u8]) -> String {
     bytes.iter().map(|byte| format!("{:02x}", byte)).collect()
 }
@@ -999,6 +1002,7 @@ fn usage() {
         "  import-block --datadir <path> (--block-hex <hex> | --block-hex-file <path>) [--profile <path>]"
     );
     eprintln!("  utxo-set-hash --datadir <path> [--profile <path>]");
+    eprintln!("  keymgr <export-wrapped|import-wrapped|verify-pubkey> [flags]");
 }
 
 fn cmd_version() -> i32 {
@@ -1898,6 +1902,7 @@ fn dispatch(cmd: &str, args: &[String]) -> i32 {
         "init" => cmd_init_main(args),
         "import-block" => cmd_import_block_main(args),
         "utxo-set-hash" => cmd_utxo_set_hash_main(args),
+        "keymgr" => keymgr::cmd_keymgr_main(args),
         _ => {
             eprintln!("unknown command: {cmd}");
             2


### PR DESCRIPTION
Rust parity for Go keymgr (RBKSv1 keystore + AES-256-KW wrap/rewrap + verify-pubkey).\n\n- Adds  subcommands: export-wrapped/import-wrapped/verify-pubkey\n- Strict mode: requires wolfcrypt shim keywrap symbols (no fallback)\n- Non-strict: software AES-KW (RFC3394) fallback for dev/test\n\nValidation:\n- tools/qa_pre_push.sh PASS\n- conformance bundle PASS (140)\n- cargo test -p rubin-node PASS\n\nFollow-up: reuse/centralize AES-KW fallback if needed; this is tooling-only (non-FIPS claim).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

- Added `keymgr` CLI command for secure key management operations:
  - `export-wrapped`: Encrypt and export secret keys securely with a key encryption key
  - `import-wrapped`: Import previously encrypted keys and re-wrap them with new encryption parameters
  - `verify-pubkey`: Validate public keys against their computed identifiers to ensure integrity
<!-- end of auto-generated comment: release notes by coderabbit.ai -->