### PR TITLE
docs: fix Phase1 plan CV-CHAINSTATE-STORE naming

### DIFF
--- a/operational/RUBIN_PHASE1_CONFORMANCE_PLAN_v1.1.md
+++ b/operational/RUBIN_PHASE1_CONFORMANCE_PLAN_v1.1.md
@@ -140,9 +140,9 @@ Vector types:
 - orphan blocks
 - blocks with invalid ancestry
 
-### 5.3 CV-CHAINSTATE (required)
+### 5.3 CV-CHAINSTATE-STORE (required)
 
-Goal: cross-client parity on applied chainstate snapshot:
+Goal: cross-client parity on persisted chainstate snapshot via node CLI:
 `(tip_hash, tip_height, utxo_set_hash)` MUST match between Go and Rust after each test sequence.
 
 Minimum required vectors:
@@ -166,10 +166,10 @@ Minimum checks:
 
 ## 6. Runner Implementation Plan (non-normative)
 
-- Add new Python runners:
+- Add new Python runners (planned):
   - `conformance/runner/run_cv_storage.py`
   - `conformance/runner/run_cv_import.py`
-  - `conformance/runner/run_cv_chainstate.py`
   - `conformance/runner/run_cv_crash_recovery.py`
-- Integrate into `conformance/runner/run_cv_bundle.py` under new gate names.
+- CV-CHAINSTATE-STORE is implemented in `conformance/runner/run_cv_bundle.py` (`run_chainstate_store`) and consumes `conformance/fixtures/CV-CHAINSTATE-STORE.yml`.
+- Integrate remaining planned runners into `conformance/runner/run_cv_bundle.py` under new gate names.
 - Update `spec/RUBIN_L1_CONFORMANCE_MANIFEST_v1.1.md` (or a new Phase 1 manifest) to track PASS/FAIL.

--- a/operational/RUBIN_PHASE1_DOD_v1.1.md
+++ b/operational/RUBIN_PHASE1_DOD_v1.1.md
@@ -114,7 +114,7 @@ This is the core Phase 1 exit gate (datadir-backed parity).
 - [ ] `cargo audit` — no known vulnerabilities
 - [ ] Go consensus package coverage ≥ 80% (currently 82.3% ✅)
 - [ ] Go node/store package coverage ≥ 70% (integration tests for import/reorg)
-- [ ] `gosec G304` fix in `node/main.go:877` (Q-107)
+- [ ] `gosec G304` fix in `clients/go/node/main.go` (Q-107)
 
 ---
 
@@ -146,7 +146,7 @@ Updates to existing documents:
 
 ## 7. Operational minimum
 
-- [ ] `systemd/rubin-node.service` is parameterized (no hardcoded user-specific absolute paths)
+- [ ] `operational/systemd/rubin-node.service` is parameterized (no hardcoded user-specific absolute paths)
 - [ ] `scripts/launch_rubin_node.sh` works with `--datadir` flag for both clients
 - [ ] `RUBIN_WOLFCRYPT_STRICT=1` is enforced in import-block pipeline (not dev-std)
 


### PR DESCRIPTION
Fix Phase 1 docs inconsistency: the plan uses CV-CHAINSTATE-STORE in the table/text, but a later section still says CV-CHAINSTATE.

- Rename the section heading to CV-CHAINSTATE-STORE and clarify goal text.
- Update runner plan notes to match current implementation.

Validation:
- tools/qa_pre_push.sh PASS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated conformance testing specifications with clarified gate naming and goals for improved cross-client verification standards.
  * Corrected file path references in operational documentation to ensure accurate implementation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->