### PR TITLE
spec(p2p): compact block relay (sendcmpct/cmpctblock)

### DIFF
--- a/spec/RUBIN_L1_P2P_CONFORMANCE_PLAN_v1.1.md
+++ b/spec/RUBIN_L1_P2P_CONFORMANCE_PLAN_v1.1.md
@@ -130,6 +130,15 @@ Light-client helpers:
 - anchorproof: depth > 32 (malformed)
 - getanchorproof: reserved flags bits set (malformed)
 
+Compact blocks (if implemented):
+
+- sendcmpct: announce=2 (malformed) -> drop + ban-score
+- sendcmpct: version != 1 -> ignore (no ban-score)
+- cmpctblock: missing prefilled coinbase at index 0 (malformed)
+- cmpctblock: shortid derivation determinism (same header/nonce => same shortids)
+- getblocktxn: delta decoding monotonicity; out-of-range index (malformed)
+- blocktxn: tx_count mismatch vs requested indexes (malformed)
+
 Peer management:
 
 - addr relay drops IPv6 link-local (`fe80::/10`) and IPv4-mapped link-local (`::ffff:169.254.0.0/112`)
@@ -140,4 +149,3 @@ Peer management:
 
 - This plan does not define encrypted transport / hybrid key exchange.
   If added later, it should be validated as a separate gate (e.g., CV-P2P-CRYPTO) and remain non-consensus.
-


### PR DESCRIPTION
Adds a draft compact block relay spec to the P2P protocol doc (sendcmpct/cmpctblock/getblocktxn/blocktxn) and extends the P2P conformance plan inventory.

Notes:
- Uses wtxid and SHA3-256 for shortid derivation.
- Updates pre-freeze checklist to track compact-block interop validation work.

Tests:
- npm run spec:all

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive specification for Compact blocks protocol messaging, including negotiation, transaction binding, shortID derivation, and fallback mechanisms.
  * Expanded conformance testing plan with detailed test cases for Compact blocks validation.
  * Updated pre-freeze status checklist to reflect pending compact block relay interoperability validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->