### PR TITLE
spec: apply critical audit fixes for canonical and compact

### DIFF
--- a/spec/RUBIN_COMPACT_BLOCKS.md
+++ b/spec/RUBIN_COMPACT_BLOCKS.md
@@ -32,7 +32,7 @@ Note for hardware provisioning: 18.05 TiB raw data requires a disk marketed as ~
 | `MAX_DA_BYTES_PER_BLOCK` | 32_000_000 bytes (= 30.5 MiB) | |
 | `WINDOW_SIZE` | 10_080 blocks | retarget = 14 days |
 | `MIN_DA_RETENTION_BLOCKS` | 15_120 blocks | DA pruning window = 21 days |
-| `MAX_RELAY_MSG_BYTES` | 96_000_000 bytes (= 91.6 MiB) | |
+| `MAX_RELAY_MSG_BYTES` | 100_663_296 bytes (= 96 MiB) | |
 | `DA_MEMPOOL_SIZE` | 512 MiB | minimum for high-bandwidth relay |
 | `DA_MEMPOOL_PINNED_PAYLOAD_MAX` | 96_000_000 bytes | 3 full DA blocks (payload bytes only) |
 | `DA_ORPHAN_POOL_SIZE` | 64 MiB | = 2 x MAX_DA_BYTES_PER_BLOCK |

--- a/spec/RUBIN_NETWORK_PARAMS.md
+++ b/spec/RUBIN_NETWORK_PARAMS.md
@@ -17,8 +17,9 @@ In case of conflict, RUBIN_L1_CANONICAL.md takes precedence.
 |-----------|-------|--------|
 | `TARGET_BLOCK_INTERVAL` | 120 s | CANONICAL §4 |
 | `MAX_BLOCK_WEIGHT` | 68,000,000 wu | CANONICAL §4 |
-| `MAX_BLOCK_BYTES` | 75,497,472 bytes (72 MiB) | CANONICAL §4 |
+| `MAX_BLOCK_BYTES` | 75,497,472 bytes (72 MiB) | COMPACT §1 (operational cap) |
 | `MAX_DA_BYTES_PER_BLOCK` | 32,000,000 bytes (30.5 MiB) | CANONICAL §4 |
+| `MAX_RELAY_MSG_BYTES` | 100,663,296 bytes (96 MiB) | CANONICAL §4 / COMPACT §1 |
 | `WINDOW_SIZE` (retarget) | 10,080 blocks (14 days) | CANONICAL §4 |
 | `MIN_DA_RETENTION_BLOCKS` | 15,120 blocks (21 days) | COMPACT §1 |
 | `COINBASE_MATURITY` | 100 blocks | CANONICAL §4 |


### PR DESCRIPTION
## Summary
This patch applies a targeted fix set from the latest consensus/P2P audit.

### In CANONICAL
- Added non-coinbase structural rule: `input_count >= 1` (with deterministic order in Section 16).
- Added explicit witness commitment model (coinbase anchor commitment over witness merkle root) and corresponding block error code.
- Clarified sighash serialization details (`TxOutputBytes`) and `input_index` binding to current input.
- Clarified `tx_nonce` scope: per-block uniqueness only; not a global nonce replay mechanism.
- Added `POW_LIMIT` bounds to difficulty retarget semantics and target range requirements.
- Aligned `CORE_DA_COMMIT` semantics with Section 21.4 payload commitment rules.
- Fixed section numbering drift and block validation order references.

### Cross-file sync
- Unified `MAX_RELAY_MSG_BYTES` to `100_663_296` bytes (96 MiB) in COMPACT/CANONICAL/NETWORK_PARAMS.
- Updated NETWORK_PARAMS source note for `MAX_BLOCK_BYTES` as operational cap from COMPACT.

## Note
`npm run spec:all` could not be executed in repo root because `/Users/gpt/Documents/rubin-protocol/package.json` is absent in this checkout.
