### PR TITLE
tooling: restore root spec scripts (spec:all/spec:watch)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ python3 conformance/runner/run_cv_bundle.py
 python3 conformance/runner/run_cv_bundle.py --only-gates CV-COMPACT
 ```
 
+Optional spec tooling (HTML + diff + explainer):
+
+```bash
+npm install
+npm run spec:all
+```
+
 ## Adding Conformance Vectors
 
 1. Add a new fixture file: `./conformance/fixtures/CV-<GATE>.json`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,27 @@
+{
+  "name": "rubin-protocol-tooling",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "rubin-protocol-tooling",
+      "version": "0.0.0",
+      "dependencies": {
+        "marked": "^17.0.3"
+      }
+    },
+    "node_modules/marked": {
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.3.tgz",
+      "integrity": "sha512-jt1v2ObpyOKR8p4XaUJVk3YWRJ5n+i4+rjQopxvV32rSndTJXvIzuUdWWIy/1pFQMkQmvTXawzDNqOH/CUmx6A==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "rubin-protocol-tooling",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "spec:html": "node scripts/spec/build-spec-html.mjs",
+    "spec:diff": "node scripts/spec/gen-spec-diff.mjs",
+    "spec:explain": "node scripts/spec/spec-explainer.mjs",
+    "spec:watch": "node scripts/spec/watch-spec.mjs",
+    "spec:all": "npm run spec:html && npm run spec:diff && npm run spec:explain"
+  },
+  "dependencies": {
+    "marked": "^17.0.3"
+  }
+}

--- a/scripts/spec/build-spec-html.mjs
+++ b/scripts/spec/build-spec-html.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+/**
+ * Convert all spec/*.md files to HTML.
+ *
+ * Input:  spec/*.md
+ * Output: analysis/spec/html/*.html
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+import { marked } from 'marked'
+
+const repoRoot = process.cwd()
+const srcDir = path.join(repoRoot, 'spec')
+const outDir = path.join(repoRoot, 'analysis', 'spec', 'html')
+
+if (!fs.existsSync(srcDir)) {
+  console.error(`spec:html: missing directory: ${srcDir}`)
+  process.exit(1)
+}
+
+const files = fs
+  .readdirSync(srcDir)
+  .filter((f) => f.endsWith('.md'))
+  .sort((a, b) => a.localeCompare(b))
+
+if (files.length === 0) {
+  console.error('spec:html: no markdown files found in ./spec')
+  process.exit(1)
+}
+
+fs.mkdirSync(outDir, { recursive: true })
+
+function render(title, body) {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${title}</title>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 1024px; margin: 32px auto; padding: 0 18px; line-height: 1.6; color: #0f172a; background:#fff; }
+    code { background: #f1f5f9; padding: 2px 5px; border-radius: 4px; }
+    pre { background: #0b0d14; color: #f4f6fb; padding: 12px; border-radius: 8px; overflow-x: auto; }
+    table { border-collapse: collapse; width: 100%; margin: 12px 0; }
+    th, td { border: 1px solid #e2e8f0; padding: 6px 8px; }
+    th { background: #f8fafc; }
+    tr:nth-child(even) { background: #f8fafc; }
+    a { color: #0ea5e9; }
+  </style>
+</head>
+<body>
+${body}
+</body>
+</html>`
+}
+
+const generated = []
+for (const file of files) {
+  const src = path.join(srcDir, file)
+  const md = fs.readFileSync(src, 'utf8')
+  const htmlBody = marked.parse(md)
+  const name = file.replace(/\.md$/, '')
+  const dst = path.join(outDir, `${name}.html`)
+  fs.writeFileSync(dst, render(name, htmlBody), 'utf8')
+  generated.push(dst)
+}
+
+console.log(`spec:html: generated ${generated.length} file(s)`)
+for (const f of generated) console.log(` - ${f}`)

--- a/scripts/spec/gen-spec-diff.mjs
+++ b/scripts/spec/gen-spec-diff.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+/**
+ * Generate git diff for ./spec and write to analysis/spec/spec-diff.json.
+ *
+ * Input:  git diff -- spec/
+ * Output: analysis/spec/spec-diff.json
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+import { execSync } from 'node:child_process'
+
+const repoRoot = process.cwd()
+const outPath = path.join(repoRoot, 'analysis', 'spec', 'spec-diff.json')
+const updated = new Date().toISOString().replace('T', ' ').slice(0, 19)
+
+let diff = ''
+let changedFiles = []
+
+try {
+  diff = execSync('git diff --unified=3 -- spec/', {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim()
+  changedFiles = execSync('git diff --name-only -- spec/', {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+    .split('\n')
+    .map((s) => s.trim())
+    .filter(Boolean)
+  if (!diff) diff = 'No spec changes relative to current HEAD.'
+} catch (e) {
+  diff = `Failed to collect diff: ${e.message}`
+}
+
+fs.mkdirSync(path.dirname(outPath), { recursive: true })
+fs.writeFileSync(
+  outPath,
+  JSON.stringify({ updated, changed_files: changedFiles, diff }, null, 2),
+  'utf8',
+)
+console.log(`[${updated}] spec-diff saved -> ${outPath}`)

--- a/scripts/spec/spec-explainer.mjs
+++ b/scripts/spec/spec-explainer.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+/**
+ * Produce an offline heuristic explainer for analysis/spec/spec-diff.json.
+ *
+ * Input:  analysis/spec/spec-diff.json
+ * Output: analysis/spec/spec-explainer.json
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+
+const repoRoot = process.cwd()
+const diffPath = path.join(repoRoot, 'analysis', 'spec', 'spec-diff.json')
+const outPath = path.join(repoRoot, 'analysis', 'spec', 'spec-explainer.json')
+
+if (!fs.existsSync(diffPath)) {
+  console.error('spec:explain: missing analysis/spec/spec-diff.json; run spec:diff first')
+  process.exit(1)
+}
+
+const input = JSON.parse(fs.readFileSync(diffPath, 'utf8'))
+const diff = String(input.diff || '')
+const changedFiles = Array.isArray(input.changed_files) ? input.changed_files : []
+const updated = new Date().toISOString().replace('T', ' ').slice(0, 19)
+
+function classify(text) {
+  const lower = text.toLowerCase()
+  const findings = []
+
+  const touchesConsensus =
+    /\b(must|normative|consensus|block_err_|tx_err_|sighash|pow|utxo|covenant)\b/i.test(text)
+  const touchesWeight = /weight|max_block_weight|witness_discount/i.test(lower)
+  const touchesP2P = /compact|shortid|relay|mempool|orphan|cmpctblock/i.test(lower)
+  const touchesDA = /\bda_|payload|chunk|commit\b/i.test(lower)
+  const touchesEconomics = /subsidy|max_supply|coinbase|fee/i.test(lower)
+
+  if (text.includes('No spec changes')) {
+    return [
+      {
+        area: 'No-op',
+        impact: 'docs',
+        summary: 'No spec changes detected.',
+        action: 'No action required.',
+        risk: 'low',
+      },
+    ]
+  }
+
+  if (touchesConsensus) {
+    findings.push({
+      area: 'Consensus semantics',
+      impact: 'consensus',
+      summary: 'Normative consensus sections were changed.',
+      action: 'Run cross-client conformance and parity checks before merge.',
+      risk: 'high',
+    })
+  }
+  if (touchesWeight) {
+    findings.push({
+      area: 'Weight / throughput',
+      impact: 'consensus',
+      summary: 'Weight or witness accounting related text changed.',
+      action: 'Recompute TPS/weight examples and confirm code constants.',
+      risk: 'medium',
+    })
+  }
+  if (touchesDA || touchesP2P) {
+    findings.push({
+      area: 'DA / relay',
+      impact: touchesConsensus ? 'consensus+p2p' : 'p2p',
+      summary: 'DA payload or compact relay behavior changed.',
+      action: 'Re-run CV-COMPACT and verify block/data commitment consistency.',
+      risk: 'medium',
+    })
+  }
+  if (touchesEconomics) {
+    findings.push({
+      area: 'Economics',
+      impact: 'consensus',
+      summary: 'Subsidy/coinbase/economic parameters changed.',
+      action: 'Re-validate emission tables and coinbase constraints.',
+      risk: 'medium',
+    })
+  }
+  if (findings.length === 0) {
+    findings.push({
+      area: 'Documentation',
+      impact: 'docs',
+      summary: 'No critical keyword clusters detected; likely wording/structure updates.',
+      action: 'Perform quick manual review for references and numbering.',
+      risk: 'low',
+    })
+  }
+
+  return findings
+}
+
+const output = {
+  updated,
+  changed_files: changedFiles,
+  note: 'Heuristic offline explainer.',
+  findings: classify(diff),
+}
+
+fs.mkdirSync(path.dirname(outPath), { recursive: true })
+fs.writeFileSync(outPath, JSON.stringify(output, null, 2), 'utf8')
+console.log(`[${updated}] spec-explainer saved -> ${outPath} (${output.findings.length} finding(s))`)

--- a/scripts/spec/watch-spec.mjs
+++ b/scripts/spec/watch-spec.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+/**
+ * Watch ./spec for markdown changes and run spec pipeline.
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+import { execSync } from 'node:child_process'
+
+const repoRoot = process.cwd()
+const specDir = path.join(repoRoot, 'spec')
+
+if (!fs.existsSync(specDir)) {
+  console.error(`spec:watch: missing directory: ${specDir}`)
+  process.exit(1)
+}
+
+let queued = false
+function run(reason) {
+  if (queued) return
+  queued = true
+  setTimeout(() => {
+    queued = false
+    const ts = new Date().toISOString().replace('T', ' ').slice(0, 19)
+    try {
+      execSync('npm run -s spec:all', { stdio: 'inherit', cwd: repoRoot })
+      console.log(`[${ts}] spec pipeline done (${reason})`)
+    } catch (e) {
+      console.error(`[${ts}] spec pipeline failed (${reason}): ${e.message}`)
+    }
+  }, 250)
+}
+
+run('initial')
+fs.watch(specDir, { persistent: true }, (_event, filename) => {
+  if (!filename || !filename.endsWith('.md')) return
+  run(`change:${filename}`)
+})


### PR DESCRIPTION
## Summary
Restore root-level spec tooling in this clean-slate repo line.

- add root `package.json` and `package-lock.json`
- add `scripts/spec/*` pipeline:
  - `spec:html` (render all `spec/*.md` to `analysis/spec/html/*.html`)
  - `spec:diff` (write `analysis/spec/spec-diff.json`)
  - `spec:explain` (write `analysis/spec/spec-explainer.json`)
  - `spec:watch`
- document usage in root `README.md`

## Validation
Executed locally:

```bash
npm install
npm run spec:all
```

Result: PASS; generated HTML + diff + explainer artifacts under `analysis/spec/`.
