### PR TITLE
spec: Q-V02 vault/multisig redesign + witness cursor

### DIFF
--- a/spec/RUBIN_L1_CANONICAL.md
+++ b/spec/RUBIN_L1_CANONICAL.md
@@ -62,6 +62,9 @@ These constants are consensus-critical for this protocol ruleset:
 - `MAX_ANCHOR_BYTES_PER_BLOCK = 131_072` bytes
 - `MAX_P2PK_COVENANT_DATA = 33` bytes
 - `MAX_TIMELOCK_COVENANT_DATA = 9` bytes
+- `MAX_VAULT_KEYS = 16`
+- `MAX_VAULT_WHITELIST_ENTRIES = 1_024`
+- `MAX_MULTISIG_KEYS = 16`
 
 Monetary constants (consensus-critical):
 
@@ -557,6 +560,7 @@ The following `covenant_type` values are valid:
 - `0x0101` `CORE_VAULT`
 - `0x0102` *(unassigned — MUST be rejected as `TX_ERR_COVENANT_TYPE_INVALID`)*
 - `0x0103` `CORE_DA_COMMIT`
+- `0x0104` `CORE_MULTISIG`
 
 Any other unknown or future `covenant_type` MUST be rejected as `TX_ERR_COVENANT_TYPE_INVALID`.
 
@@ -588,17 +592,36 @@ Semantics:
   - Until semantics are ratified in this document, any output with `covenant_type = 0x0100` MUST be
     rejected as `TX_ERR_COVENANT_TYPE_INVALID`.
 - `CORE_VAULT`:
-  - Consensus-native covenant, active from genesis. Full spend semantics defined in Section 14.1.
-  - **Section 14.1 is pending Q-V01 controller approval.** Until ratified, any output with
-    `covenant_type = 0x0101` MUST be rejected as `TX_ERR_COVENANT_TYPE_INVALID`.
-
-### 14.1 CORE_VAULT Semantics (Normative)
-
-> **TODO — pending Q-V01 controller approval.**
-> This section will define the full consensus spend rules for `CORE_VAULT` (0x0101):
-> covenant_data layout, spend_delay, whitelist_root, recovery_key, partial_spend rules,
-> early_close fee, CheckBlock rules, and error codes.
-> Do not implement until this section is populated and approved.
+  - Consensus-native covenant for value storage with mandatory destination whitelist.
+  - Active from genesis block 0.
+  - `covenant_data` format:
+    - `threshold:u8 || key_count:u8 || keys[key_count] || whitelist_count:u16le || whitelist[whitelist_count]`
+    - each `keys[i]` is `bytes32`; each `whitelist[j]` is `bytes32`
+    - `covenant_data_len MUST equal 2 + 32*key_count + 2 + 32*whitelist_count`
+  - Constraints at creation (CheckTx):
+    - `1 <= key_count <= MAX_VAULT_KEYS`; otherwise reject as `TX_ERR_COVENANT_TYPE_INVALID`.
+    - `1 <= threshold <= key_count`; otherwise reject as `TX_ERR_COVENANT_TYPE_INVALID`.
+    - `1 <= whitelist_count <= MAX_VAULT_WHITELIST_ENTRIES`; otherwise reject as `TX_ERR_COVENANT_TYPE_INVALID`.
+    - `whitelist_count = 0` is explicitly forbidden; reject as `TX_ERR_COVENANT_TYPE_INVALID`.
+    - `whitelist[]` MUST be strictly lexicographically sorted (ascending) with no duplicates;
+      otherwise reject as `TX_ERR_COVENANT_TYPE_INVALID`.
+  - `keys[i] = SHA3-256(pubkey_i)`.
+  - `whitelist[j] = SHA3-256(OutputDescriptorBytes(output_j))` (Section 18.3).
+  - Spend semantics: Section 14.1.
+  - Witness consumption: `key_count` WitnessItems (Section 16).
+- `CORE_MULTISIG`:
+  - Operational M-of-N multisig covenant without destination restrictions.
+  - Active from genesis block 0.
+  - `covenant_data` format:
+    - `threshold:u8 || key_count:u8 || keys[key_count]`
+    - each `keys[i]` is `bytes32`
+    - `covenant_data_len MUST equal 2 + 32*key_count`
+  - Constraints at creation (CheckTx):
+    - `1 <= key_count <= MAX_MULTISIG_KEYS`; otherwise reject as `TX_ERR_COVENANT_TYPE_INVALID`.
+    - `1 <= threshold <= key_count`; otherwise reject as `TX_ERR_COVENANT_TYPE_INVALID`.
+  - `keys[i] = SHA3-256(pubkey_i)`.
+  - Spend semantics: Section 14.2.
+  - Witness consumption: `key_count` WitnessItems (Section 16).
 - `CORE_DA_COMMIT`:
   - `covenant_data_len MUST equal 32`. Otherwise reject as `TX_ERR_COVENANT_TYPE_INVALID`.
   - `covenant_data MUST equal SHA3-256(T.da_payload)` where `T` is the containing transaction. Otherwise reject as
@@ -610,6 +633,73 @@ Semantics:
     `tx_kind` values MUST be rejected as `TX_ERR_COVENANT_TYPE_INVALID`.
 - `CORE_RESERVED_FUTURE`:
   - Forbidden; any appearance MUST be rejected as `TX_ERR_COVENANT_TYPE_INVALID`.
+
+### 14.1 CORE_VAULT Semantics (Normative)
+
+For each non-coinbase input spending a `CORE_VAULT` UTXO entry `e`,
+with WitnessItems `witnesses[W .. W+key_count-1]` assigned by the cursor model (Section 16):
+
+#### Signature verification
+
+For each index `i` in `[0..key_count-1]`:
+
+Let `w = witnesses[W+i]`.
+
+If `w.suite_id = SUITE_ID_SENTINEL (0x00)` (non-participating key):
+- `w.pubkey_length MUST equal 0` and `w.sig_length MUST equal 0`. Otherwise reject as `TX_ERR_PARSE`.
+
+If `w.suite_id = SUITE_ID_ML_DSA_87 (0x01)`:
+- Require `SHA3-256(w.pubkey) = keys[i]`. Otherwise reject as `TX_ERR_SIG_INVALID`.
+- Require `verify_sig(w.signature, digest) = true` where `digest` is per Section 12
+  with `input_index` bound to this input's index in the transaction.
+  Otherwise reject as `TX_ERR_SIG_INVALID`.
+- Count as one valid signature.
+
+Any other `suite_id` MUST be rejected as `TX_ERR_SIG_ALG_INVALID`.
+
+Let `valid = count of valid ML_DSA_87 signatures across all key_count WitnessItems`.
+
+If `valid < threshold`: reject as `TX_ERR_SIG_INVALID`.
+
+#### Whitelist verification
+
+For each output `out` in the spending transaction:
+
+Compute `h = SHA3-256(OutputDescriptorBytes(out))` (Section 18.3).
+
+`h` MUST be found in `e.whitelist[]` using binary search
+(whitelist is guaranteed sorted at UTXO creation).
+
+If any output is not found: reject as `TX_ERR_COVENANT_TYPE_INVALID`.
+
+### 14.2 CORE_MULTISIG Semantics (Normative)
+
+For each non-coinbase input spending a `CORE_MULTISIG` UTXO entry `e`,
+with WitnessItems `witnesses[W .. W+key_count-1]` assigned by the cursor model (Section 16):
+
+#### Signature verification
+
+For each index `i` in `[0..key_count-1]`:
+
+Let `w = witnesses[W+i]`.
+
+If `w.suite_id = SUITE_ID_SENTINEL (0x00)`:
+- `w.pubkey_length MUST equal 0` and `w.sig_length MUST equal 0`. Otherwise reject as `TX_ERR_PARSE`.
+
+If `w.suite_id = SUITE_ID_ML_DSA_87 (0x01)`:
+- Require `SHA3-256(w.pubkey) = keys[i]`. Otherwise reject as `TX_ERR_SIG_INVALID`.
+- Require `verify_sig(w.signature, digest) = true` where `digest` is per Section 12
+  with `input_index` bound to this input's index.
+  Otherwise reject as `TX_ERR_SIG_INVALID`.
+- Count as one valid signature.
+
+Any other `suite_id` MUST be rejected as `TX_ERR_SIG_ALG_INVALID`.
+
+Let `valid = count of valid signatures`.
+
+If `valid < threshold`: reject as `TX_ERR_SIG_INVALID`.
+
+No whitelist check is performed for `CORE_MULTISIG`.
 
 ## 15. Difficulty Update (Normative)
 
@@ -664,14 +754,39 @@ Define `is_coinbase_prevout` for an input `I` as:
 For any non-coinbase transaction `T`:
 
 1. `T.tx_nonce` MUST be in `[1, 0xffff_ffff_ffff_ffff]`. Otherwise reject as `TX_ERR_TX_NONCE_INVALID`.
-2. `T.witness.witness_count` MUST equal `T.input_count`. Otherwise reject as `TX_ERR_PARSE`.
-3. No input may use the coinbase prevout encoding. If any input satisfies `is_coinbase_prevout`, reject as
+2. `T.input_count` MUST be `>= 1`. Otherwise reject as `TX_ERR_PARSE`.
+3. WitnessItems are consumed by inputs using a cursor model.
+
+   Define `witness_slots(e)` for a referenced UTXO entry `e`:
+   - If `e.covenant_type = CORE_TIMELOCK`: `witness_slots(e) = 0`.
+   - If `e.covenant_type ∈ {CORE_VAULT, CORE_MULTISIG}`: `witness_slots(e) = key_count(e)`,
+     where `key_count(e)` is read from `e.covenant_data` (validated at UTXO creation).
+   - Otherwise: `witness_slots(e) = 1`.
+
+   Future covenant types MUST explicitly declare their `witness_slots` value.
+   Default for undeclared types: `witness_slots = 1`.
+
+   Cursor interpretation:
+
+   Let `W = 0`.
+
+   For each input `i` in transaction order:
+     Let `e` be the referenced UTXO entry. If missing, reject as `TX_ERR_MISSING_UTXO`.
+     Let `slots = witness_slots(e)`.
+     WitnessItems assigned to input `i` are: `T.witness.witnesses[W .. W+slots-1]`.
+     `W := W + slots`.
+
+   After all inputs:
+     `W MUST equal T.witness.witness_count`. Otherwise reject as `TX_ERR_PARSE`.
+4. No input may use the coinbase prevout encoding. If any input satisfies `is_coinbase_prevout`, reject as
    `TX_ERR_PARSE`.
-4. For genesis covenant set (Section 14 only), every input MUST have `script_sig_len = 0`. Otherwise reject as
+5. For genesis covenant set (Section 14 only), every input MUST have `script_sig_len = 0`. Otherwise reject as
    `TX_ERR_PARSE`.
-5. For each input, `sequence` MUST be `<= 0x7fffffff`. Otherwise reject as `TX_ERR_SEQUENCE_INVALID`.
-6. All input outpoints `(prev_txid, prev_vout)` within the transaction MUST be unique. Otherwise reject as
+6. For each input, `sequence` MUST be `<= 0x7fffffff`. Otherwise reject as `TX_ERR_SEQUENCE_INVALID`.
+7. All input outpoints `(prev_txid, prev_vout)` within the transaction MUST be unique. Otherwise reject as
    `TX_ERR_PARSE`.
+
+If multiple failures apply in this section, checks MUST be applied in the numbered order above.
 
 For coinbase transaction `T` (the first transaction in a block at height `h = height(B)`):
 
@@ -729,14 +844,15 @@ reject the spending transaction as `TX_ERR_COINBASE_IMMATURE`.
 
 ### 18.2 Covenant Evaluation (Genesis Covenants) (Normative)
 
-For each non-coinbase input at index `i`, let `w = T.witness.witnesses[i]` be the witness item paired with that input
-(Section 16 requires `witness_count = input_count`).
+For each non-coinbase input at index `i`, WitnessItems assigned to this input are determined
+by the cursor model defined in Section 16.
 
 Let `e = U_work[(prev_txid, prev_vout)]` be the referenced UTXO entry. If missing, reject as `TX_ERR_MISSING_UTXO`.
 
 Then enforce:
 
 1. If `e.covenant_type = CORE_P2PK`:
+   - Let `w` be the single WitnessItem assigned to this input by the cursor model.
    - Require `w.suite_id = SUITE_ID_ML_DSA_87 (0x01)`. Any other suite MUST be rejected as `TX_ERR_SIG_ALG_INVALID`.
    - Require `len(e.covenant_data) = MAX_P2PK_COVENANT_DATA` and the first byte equals `w.suite_id`. Otherwise reject as
      `TX_ERR_COVENANT_TYPE_INVALID`.
@@ -745,16 +861,44 @@ Then enforce:
    - Require signature verification of `w.signature` over `digest` (Section 12) succeeds. Otherwise reject as
      `TX_ERR_SIG_INVALID`.
 2. If `e.covenant_type = CORE_TIMELOCK`:
-   - Require `w.suite_id = SUITE_ID_SENTINEL (0x00)`. Otherwise reject as `TX_ERR_SIG_ALG_INVALID`.
-   - Parse `lock_mode:u8 || lock_value:u64le` from `e.covenant_data` (must be exactly `MAX_TIMELOCK_COVENANT_DATA` bytes).
+   - This covenant is keyless and consumes 0 WitnessItems (Section 16).
+   - No signature is required. Any witness item for this input causes cursor mismatch
+     and is rejected as `TX_ERR_PARSE`.
+   - Parse `lock_mode:u8 || lock_value:u64le` from `e.covenant_data`
+     (MUST be exactly `MAX_TIMELOCK_COVENANT_DATA` bytes).
      Otherwise reject as `TX_ERR_COVENANT_TYPE_INVALID`.
    - If `lock_mode = 0x00` (height lock): require `h >= lock_value`. Otherwise reject as `TX_ERR_TIMELOCK_NOT_MET`.
    - If `lock_mode = 0x01` (timestamp lock): require `timestamp(B_h) >= lock_value`. Otherwise reject as
      `TX_ERR_TIMELOCK_NOT_MET`.
    - Any other `lock_mode` MUST be rejected as `TX_ERR_COVENANT_TYPE_INVALID`.
-3. If `e.covenant_type = CORE_ANCHOR`: this output is non-spendable. Any attempt to spend it MUST be rejected as
+3. If `e.covenant_type = CORE_VAULT`:
+   - Evaluate per Section 14.1 using WitnessItems assigned by the cursor model.
+4. If `e.covenant_type = CORE_MULTISIG`:
+   - Evaluate per Section 14.2 using WitnessItems assigned by the cursor model.
+5. If `e.covenant_type = CORE_ANCHOR`: this output is non-spendable. Any attempt to spend it MUST be rejected as
    `TX_ERR_MISSING_UTXO`.
-4. Any other covenant type MUST be rejected as `TX_ERR_COVENANT_TYPE_INVALID`.
+6. Any other covenant type MUST be rejected as `TX_ERR_COVENANT_TYPE_INVALID`.
+
+### 18.3 OutputDescriptorBytes (Normative)
+
+`OutputDescriptorBytes` is the canonical serialization of a transaction output
+used for `CORE_VAULT` whitelist membership hashing.
+
+```text
+OutputDescriptorBytes(output) =
+    u16le(output.covenant_type) ||
+    CompactSize(output.covenant_data_len) ||
+    output.covenant_data
+```
+
+`output.value` is intentionally excluded so that whitelist entries are
+independent of transfer amounts.
+
+Normative definition for all `CORE_VAULT` whitelist computations:
+
+```text
+whitelist[j] = SHA3-256(OutputDescriptorBytes(output_j))
+```
 
 ## 19. Coinbase and Subsidy (Normative)
 
@@ -916,6 +1060,19 @@ Consensus validity MUST be deterministic given the same chain state and the same
 - Implementations MUST NOT rely on non-deterministic iteration order (for example, hash-map iteration order).
 - If any rule requires iterating over an unordered set/map, the iteration order MUST be defined as lexicographic order
   over the canonical key bytes for that collection.
+
+### 24.1 CORE_VAULT Input Validation Order
+
+For inputs spending `CORE_VAULT` (after standard Section 18 parse):
+
+1. Parse `covenant_data`: verify `threshold`, `key_count`, `whitelist_count`, and data length.
+2. Whitelist canonical order is checked at UTXO creation only and MUST NOT be re-checked at spend.
+3. Assign `key_count` WitnessItems via the cursor model (Section 16).
+4. Signature threshold check: count valid signatures and require `valid >= threshold`.
+5. Whitelist membership check per output using binary search (`O(log W)`).
+6. Value conservation.
+
+Short-circuit on first error.
 
 ## 25. Block Validation Order (Normative)
 


### PR DESCRIPTION
## Summary\n- rewrite CANONICAL for Q-V02\n- replace legacy CORE_VAULT semantics with M-of-N + mandatory whitelist\n- add CORE_MULTISIG (0x0104) semantics\n- replace witness_count=input_count with cursor model\n- make CORE_TIMELOCK keyless (0 witness slots)\n- add OutputDescriptorBytes normative definition\n- add CORE_VAULT validation order subsection\n\n## Validation\n- npm run spec:all (PASS)\n\n## Scope\n- spec-only change in `spec/RUBIN_L1_CANONICAL.md`\n