### PR TITLE
spec: fix NETWORK_PARAMS authority wording

### DIFF
--- a/spec/RUBIN_NETWORK_PARAMS.md
+++ b/spec/RUBIN_NETWORK_PARAMS.md
@@ -3,7 +3,7 @@
 **Status:** Approved v1.0
 **Date:** 2026-02-21
 
-This document is the authoritative reference for RUBIN network parameters,
+This document is the reference summary for RUBIN network parameters,
 node requirements, and technical characteristics. It is derived from and
 must remain consistent with RUBIN_L1_CANONICAL.md and RUBIN_COMPACT_BLOCKS.md.
 


### PR DESCRIPTION
## Summary
- replace "authoritative reference" with "reference summary" in NETWORK_PARAMS
- keep canonical precedence explicit (CANONICAL wins on conflicts)

## Validation
- npm run spec:check