### PR TITLE
spec: note clamp behavior in error-codes section

### DIFF
--- a/spec/RUBIN_L1_CANONICAL.md
+++ b/spec/RUBIN_L1_CANONICAL.md
@@ -705,6 +705,9 @@ implementations for the described failure classes:
 Note: Value conservation overflow (`sum_in` or `sum_out` exceeding unsigned u128 range)
 MUST be reported as `TX_ERR_PARSE`. This mapping is intentional and consensus-critical.
 
+Note: `MAX_TIMESTAMP_STEP_PER_BLOCK` is enforced via clamping in Section 15 and does not
+produce a dedicated error code.
+
 Error priority (short-circuit):
 
 - Implementations MUST apply checks in the validation order and return the first applicable error code.

--- a/spec/SECTION_HASHES.json
+++ b/spec/SECTION_HASHES.json
@@ -19,7 +19,7 @@
     "weight_accounting": "28b82c09a53f60c7506294f709aee710528b85d84e205cf744a88c59254590da",
     "witness_commitment": "cd0e55b16f47b6e35414a13e699b47f638519e23fe6cad6a8801d27792393bc9",
     "sighash_v1": "e3aac16f46dd80792b2c08ddfdc9e514491137e86ada16acb3fd520414140b05",
-    "consensus_error_codes": "a864aa7b1bec72a78b3df4f9c6a935810a9bf1c7bfb785a6dfee2c435e41b736",
+    "consensus_error_codes": "aa93a01534020021944089472064bddee52ce680b44f23e15e0d01ac0a7d9368",
     "covenant_registry": "08dc1fdbb27fac15d257b891e8d21b0615b0713e0cbcba01ebd4cc0a77475cda",
     "difficulty_update": "c7c1acb11958bb034d8a89c9c4e43ed39e4daa5bfde2eb1f4fd673c56302e298",
     "value_conservation": "ee3b046749d68f52ac800ed17a485cb94cca31287251b51aa9abfd2275b636c2",


### PR DESCRIPTION
## Summary
- add explicit note in CANONICAL §13 that MAX_TIMESTAMP_STEP_PER_BLOCK is clamped per §15
- clarify that this path does not emit a dedicated error code
- refresh SECTION_HASHES for updated consensus_error_codes section

## Validation
- npm run spec:rehash
- npm run spec:check