### PR TITLE
ci: add native wolfSSL no-liboqs PQ build smoke check

### DIFF
--- a/.github/workflows/wolfssl-native-pqc.yml
+++ b/.github/workflows/wolfssl-native-pqc.yml
@@ -1,0 +1,43 @@
+name: wolfssl-native-pqc
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches: [ main ]
+    paths:
+      - 'scripts/crypto/wolfssl/**'
+      - '.github/workflows/wolfssl-native-pqc.yml'
+
+jobs:
+  native-pqc-build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential autoconf automake libtool pkg-config git
+
+      - name: Build native wolfSSL (no liboqs)
+        run: |
+          ./scripts/crypto/wolfssl/build-wolfssl-native.sh
+        env:
+          WOLFSSL_REF: v5.8.4-stable
+          WOLFSSL_MLKEM_OPTION: 768,make,encapsulate,decapsulate,ml-kem
+          WOLFSSL_MLDSA_OPTION: 87,make,sign,verify
+
+      - name: Smoke test PQ API
+        run: |
+          ./scripts/crypto/wolfssl/run-smoke.sh
+
+      - name: Upload build log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: wolfssl-native-pqc-build-log
+          path: scripts/crypto/wolfssl/.work/logs/last-build.log

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ spec/RUBIN_IMPLEMENTATION_ROADMAP.md
 # Local orchestration files (must stay local-only)
 scripts/orchestration/
 operational/orchestration/
+
+# Native wolfSSL build artifacts
+scripts/crypto/wolfssl/.work/

--- a/scripts/crypto/wolfssl/README.md
+++ b/scripts/crypto/wolfssl/README.md
@@ -1,0 +1,172 @@
+# wolfSSL Native PQC Build + FFI (No liboqs)
+
+Этот набор используется только для разработки/CI. Он целенаправленно собирает **native wolfCrypt** с PQ-поддержкой без `liboqs`.
+
+## 1) Что нужно собрать
+
+- `ML-KEM` (native `ML-KEM`/Kyber)
+- `ML-DSA` (native Dilithium)
+- `XMSS`
+- `LMS`
+
+Важно: не использовать `--with-liboqs` и любые PQ-флаги, которые тянут OQS интеграцию.
+
+## 2) Быстрый запуск локально
+
+```bash
+cd /path/to/rubin-protocol
+./scripts/crypto/wolfssl/build-wolfssl-native.sh
+```
+
+По умолчанию будет сделан клон `https://github.com/wolfSSL/wolfssl` в `.work/wolfssl`, сборка с
+`--enable-kyber=768,make,encapsulate,decapsulate,ml-kem --enable-dilithium=87,make,sign,verify --enable-experimental --enable-xmss --enable-lms`,
+и затем проверка Smoke-теста.
+
+Дополнительно можно задать:
+
+- `WOLFSSL_REPO` — URL репозитория
+- `WOLFSSL_REF` — commit/tag/branch
+- `WOLFSSL_WORKDIR` — рабочая директория (по умолчанию `scripts/crypto/wolfssl/.work`)
+- `WOLFSSL_INSTALL_DIR` — prefix инсталляции (по умолчанию `.../.work/prefix`)
+- `WOLFSSL_MLKEM_VARIANTS` — профиль KYBER, напр. `768,make,encapsulate,decapsulate,ml-kem`
+- `WOLFSSL_MLDSA_VARIANTS` — профиль ML-DSA, напр. `87,make,sign,verify`
+- `WOLFSSL_EXTRA_CFLAGS` поддерживает `-Wno-error=...` для подавления сборочных предупреждений в средах с `-Werror`
+- `WOLFSSL_EXTRA_CFLAGS` — доп. флаги компилятора (по умолчанию `-Wno-error=unused-function -Wno-error`)
+- `WOLFSSL_EXTRA_CONFIGURE_ARGS` — доп. флаги для `./configure` (если нужны)
+
+## 3) Почему это соответствует требованию «без liboqs»
+
+После конфигурации скрипт проверяет:
+
+- `config.h` не содержит `WOLFSSL_WITH_LIBOQS`
+- `config.status` не включает включение `liboqs`
+- `wc_MlKem*`, `wc_dilithium*`, `wc_XmssKey_*`, `wc_LmsKey_*` доступны при линковке
+
+## 4) API (Go/C) — FFI сигнатуры под Rust/Go
+
+### C/PQ функции (core)
+
+```c
+// ML-KEM
+MlKemKey* wc_MlKemKey_New(int type, void* heap, int devId);
+int       wc_MlKemKey_Delete(MlKemKey* key, MlKemKey** key_p);
+int       wc_MlKemKey_Init(MlKemKey* key, int type, void* heap, int devId);
+void      wc_MlKemKey_Free(MlKemKey* key);
+int       wc_MlKemKey_MakeKey(MlKemKey* key, WC_RNG* rng);
+int       wc_MlKemKey_Encapsulate(MlKemKey* key, unsigned char* ct,
+           word32* ctLen, unsigned char* ss, word32* ssLen, WC_RNG* rng);
+int       wc_MlKemKey_Decapsulate(MlKemKey* key, const unsigned char* ct,
+           word32 ctLen, unsigned char* ss, word32* ssLen);
+int       wc_MlKemKey_PublicKeySize(MlKemKey* key, word32* len);
+int       wc_MlKemKey_PrivateKeySize(MlKemKey* key, word32* len);
+
+// ML-DSA (Dilithium/ML-DSA, native wolfCrypt)
+int       wc_dilithium_init(dilithium_key* key);
+dilithium_key* wc_dilithium_new(void* heap, int devId);
+int       wc_dilithium_delete(dilithium_key* key, dilithium_key** key_p);
+void      wc_dilithium_free(dilithium_key* key);
+int       wc_dilithium_make_key(dilithium_key* key, WC_RNG* rng);
+int       wc_dilithium_sign_msg(const byte* msg, word32 msgLen, byte* sig,
+           word32* sigLen, dilithium_key* key, WC_RNG* rng);
+int       wc_dilithium_verify_msg(const byte* sig, word32 sigLen,
+           const byte* msg, word32 msgLen, int* ret, dilithium_key* key);
+int       wc_MlDsaSignMsg(int level, const byte* msg, word32 msgLen, byte* sig,
+           word32* sigLen, dilithium_key* key, WC_RNG* rng);
+int       wc_MlDsaVerifyMsg(int level, const byte* sig, word32 sigLen,
+           const byte* msg, word32 msgLen, int* ret, dilithium_key* key);
+
+// XMSS/LMS
+int       wc_XmssKey_Init(XmssKey* key, void* heap, int devId);
+void      wc_XmssKey_Free(XmssKey* key);
+int       wc_LmsKey_Init(LmsKey* key, void* heap, int devId);
+void      wc_LmsKey_Free(LmsKey* key);
+```
+
+### Go (cgo)
+
+```go
+// #cgo CFLAGS: -I${SRCDIR}/.work/prefix/include
+// #cgo LDFLAGS: -L${SRCDIR}/.work/prefix/lib -lwolfssl
+//
+// #include <wolfssl/wolfcrypt/mlkem.h>
+// #include <wolfssl/wolfcrypt/dilithium.h>
+// #include <wolfssl/wolfcrypt/xmss.h>
+// #include <wolfssl/wolfcrypt/lms.h>
+import "C"
+
+// use opaque pointers as raw C structs
+func mlKemNew(keyType C.int) *C.MlKemKey {
+    return C.wc_MlKemKey_New(keyType, nil, -1)
+}
+
+func mlKemPublicKeySize(key *C.MlKemKey) (C.int, C.uint) {
+    var n C.uint
+    rc := C.wc_MlKemKey_PublicKeySize(key, &n)
+    return rc, n
+}
+
+func dilithiumInit(level C.uchar) (*C.struct_dilithium_key, C.int) {
+    k := C.wc_dilithium_new(nil, -1)
+    rc := C.wc_dilithium_init(k)
+    return k, rc
+}
+```
+
+### Rust (FFI)
+
+```rust
+#[repr(C)]
+pub struct MlKemKey { _private: [u8; 0] }
+#[repr(C)]
+pub struct DilithiumKey { _private: [u8; 0] }
+#[repr(C)]
+pub struct XmssKey { _private: [u8; 0] }
+#[repr(C)]
+pub struct LmsKey { _private: [u8; 0] }
+#[repr(C)]
+pub struct WC_RNG { _private: [u8; 0] }
+
+extern "C" {
+    pub fn wc_MlKemKey_New(key_type: i32, heap: *mut core::ffi::c_void, dev_id: i32) -> *mut MlKemKey;
+    pub fn wc_MlKemKey_Delete(key: *mut MlKemKey, key_p: *mut *mut MlKemKey) -> i32;
+    pub fn wc_MlKemKey_Init(key: *mut MlKemKey, key_type: i32, heap: *mut core::ffi::c_void, dev_id: i32) -> i32;
+    pub fn wc_MlKemKey_Free(key: *mut MlKemKey);
+    pub fn wc_MlKemKey_MakeKey(key: *mut MlKemKey, rng: *mut WC_RNG) -> i32;
+    pub fn wc_MlKemKey_PublicKeySize(key: *mut MlKemKey, len: *mut u32) -> i32;
+
+    pub fn wc_dilithium_new(heap: *mut core::ffi::c_void, dev_id: i32) -> *mut DilithiumKey;
+    pub fn wc_dilithium_init(key: *mut DilithiumKey) -> i32;
+    pub fn wc_dilithium_free(key: *mut DilithiumKey);
+    pub fn wc_dilithium_delete(key: *mut DilithiumKey, key_p: *mut *mut DilithiumKey) -> i32;
+    pub fn wc_dilithium_sign_msg(msg: *const u8, msg_len: u32, sig: *mut u8, sig_len: *mut u32,
+        key: *mut DilithiumKey, rng: *mut WC_RNG) -> i32;
+    pub fn wc_dilithium_verify_msg(sig: *const u8, sig_len: u32, msg: *const u8, msg_len: u32, ret: *mut i32,
+        key: *mut DilithiumKey) -> i32;
+    pub fn wc_MlDsaSignMsg(level: u8, msg: *const u8, msg_len: u32, sig: *mut u8, sig_len: *mut u32,
+        key: *mut DilithiumKey, rng: *mut WC_RNG) -> i32;
+    pub fn wc_MlDsaVerifyMsg(level: u8, sig: *const u8, sig_len: u32, msg: *const u8, msg_len: u32, ret: *mut i32,
+        key: *mut DilithiumKey) -> i32;
+
+    pub fn wc_XmssKey_Init(key: *mut XmssKey, heap: *mut core::ffi::c_void, dev_id: i32) -> i32;
+    pub fn wc_XmssKey_Free(key: *mut XmssKey);
+    pub fn wc_LmsKey_Init(key: *mut LmsKey, heap: *mut core::ffi::c_void, dev_id: i32) -> i32;
+    pub fn wc_LmsKey_Free(key: *mut LmsKey);
+}
+```
+
+## 5) Smoke test API coverage (C)
+
+Скрипт `run-smoke.sh` компилирует и запускает `smoke_mlkem_dilithium.c`, который:
+
+- инициализирует и освобождает ML-KEM/Dilithium контексты
+- дёргает символы/функции XMSS/LMS
+- завершается с non-zero кодом при ошибки линковки или несовместимости API
+
+## 6) CI job
+
+В репозитории добавлен `.github/workflows/wolfssl-native-pqc.yml`, который:
+
+1. Собирает native wolfSSL с нужными флагами PQ,
+2. Проверяет отсутствие `liboqs`,
+3. Держит `pkg-config`-пути/`LD_LIBRARY_PATH`,
+4. Запускает C smoke.

--- a/scripts/crypto/wolfssl/build-wolfssl-native.sh
+++ b/scripts/crypto/wolfssl/build-wolfssl-native.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+WORKDIR="${WOLFSSL_WORKDIR:-$(dirname "$0")/.work}"
+WOLFSSL_REPO="${WOLFSSL_REPO:-https://github.com/wolfSSL/wolfssl.git}"
+WOLFSSL_REF="${WOLFSSL_REF:-master}"
+KEEP_SRC="${WOLFSSL_KEEP_SRC:-false}"
+
+# Supported profiles for wolfCrypt-native PQ (no liboqs).
+# See wolfSSL configure help:
+# --enable-kyber=[all,512,768,1024,ml-kem,small,original,yes]
+# --enable-dilithium=[all,44,65,87,small,make,sign,verify,verify-only]
+MLKEM_VARIANTS="${WOLFSSL_MLKEM_VARIANTS:-${WOLFSSL_MLKEM_OPTION:-768,make,encapsulate,decapsulate,ml-kem}}"
+MLDSA_VARIANTS="${WOLFSSL_MLDSA_VARIANTS:-${WOLFSSL_MLDSA_OPTION:-87,make,sign,verify}}"
+WOLFSSL_EXTRA_CONFIGURE_ARGS="${WOLFSSL_EXTRA_CONFIGURE_ARGS:-}"
+WOLFSSL_EXTRA_CFLAGS="${WOLFSSL_EXTRA_CFLAGS:--Wno-error=unused-function -Wno-error}"
+
+THREADS="${WOLFSSL_BUILD_THREADS:-$(sysctl -n hw.ncpu 2>/dev/null || nproc)}"
+
+mkdir -p "$WORKDIR"
+WORKDIR="$(cd "$WORKDIR" && pwd)"
+INSTALL_DIR="${WOLFSSL_INSTALL_DIR:-$WORKDIR/prefix}"
+SRC_DIR="$WORKDIR/wolfssl"
+LOG_FILE="$WORKDIR/build.log"
+
+if [ -d "$SRC_DIR" ]; then
+  if [ "$KEEP_SRC" = "true" ]; then
+    echo "Using existing source at $SRC_DIR"
+    (cd "$SRC_DIR" && git fetch --depth=1 origin "$WOLFSSL_REF")
+    (cd "$SRC_DIR" && git checkout -f "$WOLFSSL_REF")
+  else
+    rm -rf "$SRC_DIR"
+    git clone --depth 1 --branch "$WOLFSSL_REF" "$WOLFSSL_REPO" "$SRC_DIR"
+  fi
+else
+  git clone --depth 1 --branch "$WOLFSSL_REF" "$WOLFSSL_REPO" "$SRC_DIR"
+fi
+
+cd "$SRC_DIR"
+
+if [ -x ./autogen.sh ]; then
+  ./autogen.sh
+fi
+
+./configure \
+  CFLAGS="${WOLFSSL_EXTRA_CFLAGS} ${CFLAGS:-}" \
+  CPPFLAGS="${CPPFLAGS:-}" \
+  --prefix="$INSTALL_DIR" \
+  --enable-static \
+  --disable-shared \
+  --disable-examples \
+  --disable-crypttests \
+  --enable-experimental \
+  --enable-kyber="$MLKEM_VARIANTS" \
+  --enable-dilithium="$MLDSA_VARIANTS" \
+  --enable-xmss \
+  --enable-lms \
+  $WOLFSSL_EXTRA_CONFIGURE_ARGS \
+  >"$LOG_FILE" 2>&1
+
+if [ -f "$SRC_DIR/config.status" ] && grep -Eq "with-liboqs.*(yes|\\\"yes\\\")" "$SRC_DIR/config.status"; then
+  echo "ERROR: config.status indicates liboqs"
+  exit 1
+fi
+if [ -f "$SRC_DIR/config.h" ] && grep -Eq "WOLFSSL_WITH_LIBOQS" "$SRC_DIR/config.h"; then
+  echo "ERROR: config.h contains disallowed liboqs flags"
+  exit 1
+fi
+
+make -j "$THREADS" >>"$LOG_FILE" 2>&1
+make install >>"$LOG_FILE" 2>&1
+
+mkdir -p "$WORKDIR/logs"
+cp "$LOG_FILE" "$WORKDIR/logs/last-build.log"
+
+echo "Built wolfSSL at $INSTALL_DIR"
+echo "Log: $WORKDIR/logs/last-build.log"

--- a/scripts/crypto/wolfssl/run-smoke.sh
+++ b/scripts/crypto/wolfssl/run-smoke.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+WORKDIR="${WOLFSSL_WORKDIR:-$(dirname "$0")/.work}"
+INSTALL_DIR="${WOLFSSL_INSTALL_DIR:-$WORKDIR/prefix}"
+SRC_DIR="$WORKDIR/wolfssl"
+SMOKE_SRC="$(dirname "$0")/smoke_mlkem_dilithium.c"
+SMOKE_BIN="$WORKDIR/smoke_mlkem_dilithium"
+PLATFORM_LINK_FLAGS=""
+
+if [ "$(uname -s)" = "Darwin" ]; then
+  PLATFORM_LINK_FLAGS="-framework Security -framework CoreFoundation"
+fi
+
+if [ ! -f "$SMOKE_SRC" ]; then
+  echo "Smoke source not found: $SMOKE_SRC"
+  exit 1
+fi
+
+if [ ! -d "$INSTALL_DIR/include/wolfssl" ] || [ ! -f "$INSTALL_DIR/lib/libwolfssl.a" ]; then
+  echo "wolfSSL install not found. run build-wolfssl-native.sh first."
+  exit 1
+fi
+
+cc -std=c11 -I"$INSTALL_DIR/include" -I"$SRC_DIR" "$SMOKE_SRC" \
+  -L"$INSTALL_DIR/lib" -lwolfssl -lm $PLATFORM_LINK_FLAGS -o "$SMOKE_BIN"
+
+"$SMOKE_BIN"
+
+echo "Smoke test OK"

--- a/scripts/crypto/wolfssl/smoke_mlkem_dilithium.c
+++ b/scripts/crypto/wolfssl/smoke_mlkem_dilithium.c
@@ -1,0 +1,56 @@
+#include <stdio.h>
+#include <wolfssl/options.h>
+#include <wolfssl/wolfcrypt/mlkem.h>
+#include <wolfssl/wolfcrypt/dilithium.h>
+#include <wolfssl/wolfcrypt/xmss.h>
+#include <wolfssl/wolfcrypt/lms.h>
+
+int main(void)
+{
+    int ret = 0;
+    MlKemKey* kem = NULL;
+    dilithium_key* d = NULL;
+
+    kem = wc_MlKemKey_New(WC_ML_KEM_768, NULL, -1);
+    if (kem == NULL) {
+        fprintf(stderr, "mlkem new failed\n");
+        return 1;
+    }
+    ret = wc_MlKemKey_Init(kem, WC_ML_KEM_768, NULL, -1);
+    if (ret != 0) {
+        fprintf(stderr, "mlkem init failed: %d\n", ret);
+        wc_MlKemKey_Delete(kem, &kem);
+        return 1;
+    }
+    wc_MlKemKey_Delete(kem, &kem);
+
+    d = wc_dilithium_new(NULL, -1);
+    if (d == NULL) {
+        fprintf(stderr, "dilithium_new failed\n");
+        return 1;
+    }
+    ret = wc_dilithium_init(d);
+    if (ret != 0) {
+        fprintf(stderr, "dilithium_init failed: %d\n", ret);
+        wc_dilithium_delete(d, &d);
+        return 1;
+    }
+    ret = wc_dilithium_set_level(d, 5);
+    if (ret != 0) {
+        fprintf(stderr, "dilithium_set_level failed: %d\n", ret);
+        wc_dilithium_free(d);
+        return 1;
+    }
+    wc_dilithium_free(d);
+
+    /* Keep link-time coverage for XMSS/LMS API as build-time availability probes */
+    (void)wc_XmssKey_Init;
+    (void)wc_XmssKey_Free;
+    (void)wc_LmsKey_Init;
+    (void)wc_LmsKey_Free;
+    (void)wc_MlKemKey_Encapsulate;
+    (void)wc_dilithium_sign_msg;
+    (void)wc_dilithium_verify_msg;
+
+    return 0;
+}


### PR DESCRIPTION
Add native wolfSSL build + smoke scripts for ML-KEM/ML-DSA without liboqs, plus workflow and README.