### PR TITLE
spec: close audit doc-tail items

### DIFF
--- a/spec/AUDIT_CONTEXT.md
+++ b/spec/AUDIT_CONTEXT.md
@@ -61,8 +61,8 @@
 | 1 | DA bytes cap маппится на `BLOCK_ERR_WEIGHT_EXCEEDED` | INTENTIONAL | ALREADY_FIXED | Так задано в CANONICAL: `sum_da_bytes(B) ... иначе BLOCK_ERR_WEIGHT_EXCEEDED`. (`spec/RUBIN_L1_CANONICAL.md:419`) |
 | 2 | HTLC claim допускает `preimage_len = 0` (нет нижней границы) | REAL | OPEN | В HTLC spec есть только `<= MAX`; в Go/Rust проверок `>= 1` нет. (`spec/RUBIN_CORE_HTLC_SPEC.md:115`, `clients/go/consensus/htlc.go:75`) **Консенсусное ужесточение ⇒ НУЖНО ОДОБРЕНИЕ КОНТРОЛЕРА.** |
 | 3 | HTLC refund: `lock_value = 0` при HEIGHT делает refund немедленным | REAL | OPEN | Правило `block_height >= lock_value` делает `0` тривиально истинным. (`spec/RUBIN_CORE_HTLC_SPEC.md:161`, `clients/go/consensus/htlc.go:100`) **Консенсусное ужесточение ⇒ НУЖНО ОДОБРЕНИЕ КОНТРОЛЕРА.** |
-| 4 | Witness cursor model не имеет formal proof-pack в репо | REAL | DEFERRED | В спеке есть нормативный алгоритм, но proof-pack заявлен out-of-tree (`rubin-formal/`). (`spec/README.md:37`, `spec/AUDIT_CONTEXT.md:23`) |
-| 5 | SLH-DSA плохо сочетается с multisig из-за лимита witness bytes | REAL | DOC_FIX | Лимиты зафиксированы (`MAX_WITNESS_BYTES_PER_TX`, `MAX_SLH_DSA_SIG_BYTES`). Нужно явно описать эксплуатационное ограничение для SLH fallback. (`spec/RUBIN_L1_CANONICAL.md:68`, `:116`) |
+| 4 | Witness cursor model не имеет formal proof-pack в репо | FALSE | ALREADY_FIXED | Proof-pack baseline вендорится в `rubin-formal/` и синхронизирован через `tools/check_formal_coverage.py` + CI job `formal`. (`spec/README.md`, `.github/workflows/ci.yml`) |
+| 5 | SLH-DSA плохо сочетается с multisig из-за лимита witness bytes | REAL | ALREADY_FIXED | Ограничение явно зафиксировано operational note в `CORE_MULTISIG` semantics (non-consensus), с рекомендацией ML-DSA default и SLH как fallback. (`spec/RUBIN_L1_CANONICAL.md` §14.2) |
 | 6 | `batch_sig` до 64KB — unverified blob (DoS) | INTENTIONAL | ALREADY_FIXED | CANONICAL прямо запрещает L1 проверять `batch_sig`; размер ограничен 65,536. (`spec/RUBIN_L1_CANONICAL.md:205`, `:225`) |
 | 7 | CORE_VAULT fee-preservation может требовать non-VAULT input | INTENTIONAL | ALREADY_FIXED | Это нормативно описано как “fee must be funded by non-VAULT inputs”. (`spec/RUBIN_L1_CANONICAL.md:880`) |
 | 8 | В BlockHeader нет height | INTENTIONAL | ALREADY_FIXED | Height — функция положения в цепи; есть coinbase height-commitment (`locktime = h`). (`spec/RUBIN_L1_CANONICAL.md:426`, `:1054`) |
@@ -72,8 +72,8 @@
 | 12 | `output_count = 0` не запрещён | INTENTIONAL | ALREADY_FIXED | Sighash задаёт `SHA3-256(\"\")` для `output_count=0`. (`spec/RUBIN_L1_CANONICAL.md:604`) |
 | 13 | Feature-bit framework не полностью специфицирован | FALSE | ALREADY_FIXED | FSM `DEFINED→STARTED→LOCKED_IN→ACTIVE/FAILED` описан. (`spec/RUBIN_L1_CANONICAL.md:1402`, `:1425`) |
 | 14 | SLH suite до активации может “залочить” funds | FALSE | ALREADY_FIXED | Creation rules гейтят `suite_id=0x02` по высоте. (`spec/RUBIN_NETWORK_PARAMS.md:132`, `clients/go/consensus/covenant_genesis.go:21`) |
-| 15 | Непоследовательный стиль перекрёстных ссылок | REAL | DOC_FIX | Смешаны форматы `spec/... §` и `CANONICAL §...`. (`spec/RUBIN_L1_CANONICAL.md:1137`, `spec/RUBIN_CORE_HTLC_SPEC.md:93`) |
-| 16 | CV-HTLC-10 описан как “unknown spend path (suite_id=0x02)” | REAL | DOC_FIX | Текст путает `suite_id` и `path_id`. (`spec/RUBIN_CORE_HTLC_SPEC.md:243`, `conformance/fixtures/CV-HTLC.json:150`) |
+| 15 | Непоследовательный стиль перекрёстных ссылок | REAL | ALREADY_FIXED | HTLC spec нормализован на единый формат ссылок `RUBIN_L1_CANONICAL.md §N`; смешанный стиль в audit-critical участках устранён. (`spec/RUBIN_CORE_HTLC_SPEC.md`) |
+| 16 | CV-HTLC-10 описан как “unknown spend path (suite_id=0x02)” | REAL | ALREADY_FIXED | Формулировка исправлена на корректную семантику `path_id ∉ {0x00,0x01}` без изменения fixture semantics. (`spec/RUBIN_CORE_HTLC_SPEC.md` §8) |
 | 17 | `da_id` uniqueness только per-block, reuse across blocks разрешён | INTENTIONAL | ALREADY_FIXED | Явно задано в CANONICAL. (`spec/RUBIN_L1_CANONICAL.md:1309`) |
 | 18 | Нет опубликованных точных genesis bytes/allocations | REAL | OPEN | Спека требует, чтобы сеть опубликовала exact genesis bytes для derivation `chain_id`, но репо не содержит chain-instance genesis pack. (`spec/RUBIN_L1_CANONICAL.md:587`, `spec/RUBIN_NETWORK_PARAMS.md:101`) |
 

--- a/spec/RUBIN_CORE_HTLC_SPEC.md
+++ b/spec/RUBIN_CORE_HTLC_SPEC.md
@@ -22,7 +22,7 @@ It consumes **2 WitnessItems** from the witness cursor: a spend-path selector an
 the signature for the selected path.
 It has no
 destination whitelist — output routing is unrestricted, subject to standard
-value conservation rules (Section 20, RUBIN_L1_CANONICAL.md).
+value conservation rules (`RUBIN_L1_CANONICAL.md` §20).
 
 ---
 
@@ -80,8 +80,8 @@ When a transaction output has `covenant_type = 0x0100 (CORE_HTLC)`:
 
 ### 5.1 Witness Structure
 
-`CORE_HTLC` consumes exactly **2 WitnessItems** from the witness cursor (Section 16,
-RUBIN_L1_CANONICAL.md):
+`CORE_HTLC` consumes exactly **2 WitnessItems** from the witness cursor
+(`RUBIN_L1_CANONICAL.md` §16):
 
 ```
 WitnessItem[W+0] : spend_path_item  -- encodes which path is taken
@@ -146,7 +146,7 @@ When `spend_path_item.signature[0] = 0x00`:
 
 4. **Signature verification:**
    `verify_sig(sig_item.suite_id, sig_item.pubkey, sig_item.signature, digest) MUST be true`
-   where `digest` is the sighash v1 digest (Section 12, RUBIN_L1_CANONICAL.md)
+   where `digest` is the sighash v1 digest (`RUBIN_L1_CANONICAL.md` §12)
    with `input_index` bound to this input's position in the transaction.
    Otherwise reject as `TX_ERR_SIG_INVALID`.
 
@@ -178,7 +178,7 @@ When `spend_path_item.signature[0] = 0x01`:
 
 4. **Signature verification:**
    `verify_sig(sig_item.suite_id, sig_item.pubkey, sig_item.signature, digest) MUST be true`
-   where `digest` is per Section 12, RUBIN_L1_CANONICAL.md.
+   where `digest` is per `RUBIN_L1_CANONICAL.md` §12.
    Otherwise reject as `TX_ERR_SIG_INVALID`.
 
 5. **SLH-DSA gate:** same as claim path rule 5 above.
@@ -214,7 +214,7 @@ Structural/parse errors MUST be returned before signature verification is attemp
 ## 7. Value Conservation
 
 `CORE_HTLC` inputs are subject to standard value conservation rules
-(Section 20, RUBIN_L1_CANONICAL.md): `sum_out <= sum_in` for any
+(`RUBIN_L1_CANONICAL.md` §20): `sum_out <= sum_in` for any
 transaction spending one or more HTLC inputs (along with any other input types).
 
 There is no fee-preservation rule (unlike `CORE_VAULT`). The spender may
@@ -240,7 +240,7 @@ See `conformance/fixtures/CV-HTLC.json`. Required coverage:
 | CV-HTLC-07 | refund | locktime not met (height mode) | `TX_ERR_TIMELOCK_NOT_MET` |
 | CV-HTLC-08 | refund | locktime not met (timestamp mode) | `TX_ERR_TIMELOCK_NOT_MET` |
 | CV-HTLC-09 | claim | `preimage_len > 256` | `TX_ERR_PARSE` |
-| CV-HTLC-10 | spend | unknown spend path (`suite_id = 0x02`) | `TX_ERR_PARSE` |
+| CV-HTLC-10 | spend | unknown spend path (`path_id ∉ {0x00, 0x01}`) | `TX_ERR_PARSE` |
 
 ---
 

--- a/spec/RUBIN_L1_CANONICAL.md
+++ b/spec/RUBIN_L1_CANONICAL.md
@@ -923,6 +923,14 @@ If `valid < threshold`: reject as `TX_ERR_SIG_INVALID`.
 
 No whitelist check is performed for `CORE_MULTISIG`.
 
+Operational note (non-consensus):
+
+- SLH-DSA signatures are bounded by `MAX_SLH_DSA_SIG_BYTES = 49_856` and transaction witness by
+  `MAX_WITNESS_BYTES_PER_TX = 100_000`.
+- For `CORE_MULTISIG`, this means SLH fallback can materially reduce the feasible number of participating
+  signers per transaction under witness-byte limits (even when `threshold` is lower than `key_count`).
+- Implementations SHOULD prefer ML-DSA-87 as default multisig path and reserve SLH-DSA for fallback/incident mode.
+
 ## 15. Difficulty Update (Normative)
 
 Let:

--- a/spec/SECTION_HASHES.json
+++ b/spec/SECTION_HASHES.json
@@ -25,7 +25,7 @@
     "witness_commitment": "10a0e0b289df6023e6c6589d575e0f25b37025c0b84ba404dae5738ad50abf3d",
     "sighash_v1": "e20b0bcae92ec4a9549150f1d6b7dc9f29e888c1e6d56341e6beb6062e4a7d1f",
     "consensus_error_codes": "8a45d187ea0523c29fc1fff3298f4bbaab3bce4e7f2fb67ea737a5858e2d78e1",
-    "covenant_registry": "b43922371de9a212b77ccc54539ec0772f7cf4a842ea5a4b68832a3fdbd92842",
+    "covenant_registry": "2a95eafaae6b79d74f66bacef27cd817edcb1cedd4ef2c8c5045f9f346b0871e",
     "difficulty_update": "1b755c3a6e65add9e1f92e382d171acea87763145929978fea5a6e54a51b969d",
     "transaction_structural_rules": "cda940d89f17467ae803d5504d9d7f11725b44593a9487ccf4ab829dfcf3b5d7",
     "replay_domain_checks": "f65201c5b65cdc4c53286074806cb189eaaf5909a007ea0079102e3cb616f115",


### PR DESCRIPTION
## Scope
Documentation-only closeout for remaining audit doc-tail items from external multi-model pack.

## Changes
- `spec/RUBIN_CORE_HTLC_SPEC.md`
  - normalized cross-references to `RUBIN_L1_CANONICAL.md §N`
  - fixed `CV-HTLC-10` wording: unknown spend path now correctly defined by `path_id`, not `suite_id`
- `spec/RUBIN_L1_CANONICAL.md`
  - added non-consensus operational note in `CORE_MULTISIG` semantics about SLH-DSA witness-size constraints
- `spec/AUDIT_CONTEXT.md`
  - updated audit rows #4/#5/#15/#16 to `ALREADY_FIXED` (or `FALSE/ALREADY_FIXED` for #4)
- `spec/SECTION_HASHES.json`
  - deterministic rehash after covenant-registry section text update

## Validation
- `npm run spec:rehash`
- `npm run spec:check` (PASS)
- `python3 tools/check_formal_coverage.py` (PASS)

## Consensus impact
No consensus-rule change; doc/governance alignment only.
