### PR TITLE
conformance: close audit #11 retarget boundary coverage

### DIFF
--- a/conformance/fixtures/CV-POW.json
+++ b/conformance/fixtures/CV-POW.json
@@ -47,6 +47,24 @@
       "expect_err": "TX_ERR_PARSE"
     },
     {
+      "id": "POW-03C",
+      "op": "retarget_v1",
+      "expect_ok": true,
+      "target_old": "0000000000000000000000000000000000000000000000000000000000001000",
+      "timestamp_first": 0,
+      "timestamp_last": 1209599,
+      "expect_target_new": "0000000000000000000000000000000000000000000000000000000000000fff"
+    },
+    {
+      "id": "POW-03D",
+      "op": "retarget_v1",
+      "expect_ok": true,
+      "target_old": "0000000000000000000000000000000000000000000000000000000000001000",
+      "timestamp_first": 0,
+      "timestamp_last": 1209900,
+      "expect_target_new": "0000000000000000000000000000000000000000000000000000000000001001"
+    },
+    {
       "id": "POW-08",
       "op": "retarget_v1",
       "expect_ok": true,
@@ -61,6 +79,22 @@
         "last_jump": 1000000
       },
       "expect_target_new": "0000000000000000000000000000000000000000000000000000000000001003"
+    },
+    {
+      "id": "POW-08A",
+      "op": "retarget_v1",
+      "expect_ok": false,
+      "target_old": "0000000000000000000000000000000000000000000000000000000000001000",
+      "timestamp_first": 0,
+      "timestamp_last": 1209600,
+      "window_pattern": {
+        "mode": "step_with_last_jump",
+        "window_size": 10080,
+        "start": 18446744073709551615,
+        "step": 0,
+        "last_jump": 0
+      },
+      "expect_err": "TX_ERR_PARSE"
     },
     {
       "id": "POW-04",

--- a/spec/AUDIT_CONTEXT.md
+++ b/spec/AUDIT_CONTEXT.md
@@ -68,7 +68,7 @@
 | 8 | В BlockHeader нет height | INTENTIONAL | ALREADY_FIXED | Height — функция положения в цепи; есть coinbase height-commitment (`locktime = h`). (`spec/RUBIN_L1_CANONICAL.md:426`, `:1054`) |
 | 9 | MTP-only timestamp манипулируем (multi-window) | INTENTIONAL | ACCEPTED_RISK | Зафиксировано как `ACCEPTED_RISK_TS_MTP_MULTIWINDOW`. (`spec/RUBIN_L1_CANONICAL.md:1347`, `spec/AUDIT_CONTEXT.md:67`) |
 | 10 | Термины DA set/batch/payload непоследовательны | FALSE | ALREADY_FIXED | CANONICAL даёт явные определения и норму “используем DA set для консенсуса”. (`spec/RUBIN_L1_CANONICAL.md:30`) |
-| 11 | Ретаргет требует 320-bit/arb-precision, но нет coverage на overflow-края | REAL | OPEN | Требование есть, но conformance требует расширения на boundary-продукты/транкейт. (`spec/RUBIN_L1_CANONICAL.md:997`, `conformance/fixtures/CV-POW.json:1`) |
+| 11 | Ретаргет требует 320-bit/arb-precision, но нет coverage на overflow-края | REAL | ALREADY_FIXED | CV-POW расширен boundary-векторами для floor/truncation и clamp-overflow (`POW-03C`, `POW-03D`, `POW-08A`), выполняется в Go↔Rust parity через `retarget_v1` op. (`conformance/fixtures/CV-POW.json`) |
 | 12 | `output_count = 0` не запрещён | INTENTIONAL | ALREADY_FIXED | Sighash задаёт `SHA3-256(\"\")` для `output_count=0`. (`spec/RUBIN_L1_CANONICAL.md:604`) |
 | 13 | Feature-bit framework не полностью специфицирован | FALSE | ALREADY_FIXED | FSM `DEFINED→STARTED→LOCKED_IN→ACTIVE/FAILED` описан. (`spec/RUBIN_L1_CANONICAL.md:1402`, `:1425`) |
 | 14 | SLH suite до активации может “залочить” funds | FALSE | ALREADY_FIXED | Creation rules гейтят `suite_id=0x02` по высоте. (`spec/RUBIN_NETWORK_PARAMS.md:132`, `clients/go/consensus/covenant_genesis.go:21`) |


### PR DESCRIPTION
## Scope
Close audit backlog item #11 (retarget boundary/overflow conformance coverage).

## Changes
- `conformance/fixtures/CV-POW.json`
  - added `POW-03C` (floor/truncation at `T_actual = T_expected - 1`)
  - added `POW-03D` (threshold +1 increment at near-boundary)
  - added `POW-08A` (clamped-window overflow path -> `TX_ERR_PARSE`)
- `spec/AUDIT_CONTEXT.md`
  - item #11 moved from `OPEN` to `ALREADY_FIXED` with vector references

## Validation
- `python3 conformance/runner/run_cv_bundle.py` → `PASS: 133 vectors`
- `npm run spec:check` → PASS

## Consensus impact
No consensus-rule change. Coverage and audit triage only.
