### PR TITLE
Hygiene: ban absolute home paths in repo

### DIFF
--- a/.github/workflows/spec_checks.yml
+++ b/.github/workflows/spec_checks.yml
@@ -27,3 +27,6 @@ jobs:
 
       - name: Check formal coverage baseline
         run: python3 tools/check_formal_coverage.py
+
+      - name: Hygiene: no absolute home paths
+        run: python3 tools/check_no_absolute_paths.py

--- a/scripts/crypto/openssl/README.md
+++ b/scripts/crypto/openssl/README.md
@@ -3,24 +3,24 @@
 ## Build local bundle (OpenSSL 3.5+)
 
 ```bash
-cd /Users/gpt/Documents/rubin-protocol
+cd <REPO_ROOT>
 chmod +x scripts/crypto/openssl/build-openssl-bundle.sh
 OPENSSL_VERSION=3.5.5 scripts/crypto/openssl/build-openssl-bundle.sh
 ```
 
 Default install prefix:
 
-`/Users/gpt/.cache/rubin-openssl/bundle-<version>`
+`$HOME/.cache/rubin-openssl/bundle-<version>`
 
 ## Run PQ benchmark (OpenSSL `speed`, primary)
 
 ```bash
-cd /Users/gpt/Documents/rubin-protocol
+cd <REPO_ROOT>
 chmod +x scripts/crypto/openssl/bench-pq-speed.py
 scripts/crypto/openssl/bench-pq-speed.py \
-  --openssl-bin /Users/gpt/.cache/rubin-openssl/bundle-3.5.5/bin/openssl \
+  --openssl-bin "$HOME/.cache/rubin-openssl/bundle-<version>/bin/openssl" \
   --seconds 5 \
-  --output-json /Users/gpt/Documents/inbox/reports/openssl_pq_bench_latest.json
+  --output-json <OUTPUT_JSON_PATH>
 ```
 
 Notes:
@@ -32,7 +32,7 @@ Notes:
 Reference command:
 
 ```bash
-/Users/gpt/.cache/rubin-openssl/bundle-3.5.5/bin/openssl speed \
+"$HOME/.cache/rubin-openssl/bundle-<version>/bin/openssl" speed \
   -elapsed -multi 16 -seconds 30 \
   -signature-algorithms ML-DSA-87 SLH-DSA-SHAKE-256f
 ```
@@ -53,6 +53,6 @@ Interpretation:
 ```bash
 chmod +x scripts/crypto/openssl/bench-pq-pkeyutl.py
 scripts/crypto/openssl/bench-pq-pkeyutl.py \
-  --openssl-bin /Users/gpt/.cache/rubin-openssl/bundle-3.5.5/bin/openssl \
-  --output-json /Users/gpt/Documents/inbox/reports/openssl_pq_bench_pkeyutl_latest.json
+  --openssl-bin "$HOME/.cache/rubin-openssl/bundle-<version>/bin/openssl" \
+  --output-json <OUTPUT_JSON_PATH>
 ```

--- a/spec/DEVNET_GENESIS_PUBLISH.md
+++ b/spec/DEVNET_GENESIS_PUBLISH.md
@@ -1,0 +1,47 @@
+# RUBIN Phase‑0 Devnet — genesis publish (v1)
+
+Status: non-consensus / operational spec adjunct.
+
+Goal: publish **byte-exact genesis** for the Phase‑0 devnet so that:
+- all implementations derive the same `chain_id`;
+- audits and test runs are reproducible (byte-for-byte);
+- any genesis changes are explicit (diffable hex changes).
+
+This is **not mainnet ceremony**. For Phase‑0 devnet, engineering keys and simple allocations are acceptable.
+
+## Required artifacts
+
+1) `genesis_header_bytes_hex`
+2) `genesis_tx_bytes_hex`:
+   - `TxBytes(genesis_txs[0]) || ... || TxBytes(genesis_txs[n-1])`
+3) Derived:
+   - `chain_id_hex` (CANONICAL §11)
+   - `genesis_block_hash_hex` (CANONICAL §10.3)
+
+## Where to publish (recommended)
+
+Publish pack (in-repo):
+- `spec/DEVNET_GENESIS_BYTES.json` (hex + minimal metadata)
+- `spec/DEVNET_CHAIN_ID.txt` (single-line hex)
+
+## Change policy
+
+- Any change to genesis bytes changes consensus identity (`chain_id`) and is a **devnet reset**.
+- While Phase‑0 is in active development, resets are allowed, but each reset MUST:
+  - update the publish pack,
+  - document the reason,
+  - communicate the new `chain_id` clearly.
+
+## Minimal procedure
+
+1) Construct the genesis candidate:
+   - header fields (version/prev_hash/merkle_root/timestamp/target/nonce)
+   - genesis txs in exact `TxBytes` form
+2) Compute:
+   - `chain_id` per CANONICAL §11
+   - `genesis_block_hash` per CANONICAL §10.3
+3) Save artifacts in the publish pack.
+4) Run sanity:
+   - `python3 conformance/runner/run_cv_bundle.py` (should not depend on devnet genesis)
+   - tooling (if present) to derive `chain_id` from the published bytes and compare against the published value.
+

--- a/spec/RUBIN_NETWORK_PARAMS.md
+++ b/spec/RUBIN_NETWORK_PARAMS.md
@@ -104,7 +104,7 @@ Phase‑0 devnet status (spec-only stage):
 - **Genesis bytes are not published yet**; therefore `chain_id` for Phase‑0 devnet is **TBD**.
 - Implementations MUST NOT “auto-generate defaults” for genesis bytes locally (that would split the network).
 - Before devnet bring‑up, the project MUST publish a byte‑exact devnet genesis pack (see:
-  `/Users/gpt/Documents/inbox/operational/RUBIN_DEVNET_GENESIS_PUBLISH_v1.md`, tasks `B-01..B-03` in inbox queue).
+  `spec/DEVNET_GENESIS_PUBLISH.md`, tasks `B-01..B-03` in the project queue).
 
 ---
 

--- a/tools/check_no_absolute_paths.py
+++ b/tools/check_no_absolute_paths.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+DISALLOWED_SUBSTRINGS = [
+    "/Users/",
+    "\\Users\\",
+]
+
+
+def iter_tracked_files() -> list[Path]:
+    out = subprocess.check_output(["git", "ls-files"], cwd=str(REPO_ROOT), text=True)
+    paths: list[Path] = []
+    for line in out.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        paths.append(REPO_ROOT / line)
+    return paths
+
+
+def should_scan(p: Path) -> bool:
+    if not p.is_file():
+        return False
+    try:
+        if p.stat().st_size > 2_000_000:
+            return False
+    except OSError:
+        return False
+    if p.suffix.lower() in {".png", ".jpg", ".jpeg", ".gif", ".pdf", ".zip"}:
+        return False
+    return True
+
+
+def main() -> int:
+    bad: list[str] = []
+    for p in iter_tracked_files():
+        rel = str(p.relative_to(REPO_ROOT))
+        if not should_scan(p):
+            continue
+        try:
+            data = p.read_bytes()
+        except OSError as e:
+            bad.append(f"READ_FAIL {rel}: {e}")
+            continue
+
+        try:
+            s = data.decode("utf-8")
+        except UnicodeDecodeError:
+            continue
+
+        for needle in DISALLOWED_SUBSTRINGS:
+            if needle in s:
+                bad.append(f"ABS_PATH {rel}: contains {needle!r}")
+                break
+
+    if bad:
+        print("ERROR: absolute home paths are not allowed in tracked files:")
+        for line in bad:
+            print(" -", line)
+        print()
+        print("Fix: replace with repo-relative paths or environment variables.")
+        return 1
+
+    print("OK: no disallowed absolute home paths found.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+


### PR DESCRIPTION
Fixes repo hygiene: remove hardcoded absolute home paths (e.g. /Users/...) from tracked docs and enforce via CI.\n\n- Add tools/check_no_absolute_paths.py and run it in spec-checks workflow\n- Replace absolute paths in scripts/crypto/openssl/README.md examples with <REPO_ROOT>//Users/gpt placeholders\n- Replace spec reference to local inbox path with repo-relative spec/DEVNET_GENESIS_PUBLISH.md\n\nThis prevents leaking local workstation paths into GitHub.