### PR TITLE
Q-FORMAL-03: formal claim-boundary (toy-model baseline)

### DIFF
--- a/rubin-formal/PROOF_COVERAGE.md
+++ b/rubin-formal/PROOF_COVERAGE.md
@@ -3,7 +3,15 @@
 Источник: `spec/SECTION_HASHES.json`  
 Машинный реестр: `rubin-formal/proof_coverage.json`
 
-Текущее состояние: все pinned секции заведены со статусом `proved` (модельный baseline).
+Текущее состояние: все pinned секции заведены со статусом `proved` **в рамках `proof_level=toy-model`**.
+
+## Термины (важно)
+
+- `proof_level=toy-model` означает: доказательства относятся к упрощённой/модельной семантике и служат baseline-слоем,
+  а не байтовой (wire) или исполняемой (Go/Rust) эквивалентности.
+- `status=proved/stated/deferred` относится к конкретной pinned-секции **в рамках указанного `proof_level`**.
+
+Внешний аудит / freeze-ready коммуникации **НЕ ДОЛЖНЫ** трактовать `status=proved` как “formal verification of CANONICAL”.
 
 ## Путь к freeze-ready
 

--- a/rubin-formal/README.md
+++ b/rubin-formal/README.md
@@ -8,6 +8,22 @@
 - `proof_coverage.json` с baseline-покрытием всех pinned секций из `spec/SECTION_HASHES.json`
 - модельные теоремы (`status=proved`) для pinned секций в `RubinFormal/PinnedSections.lean`
 
+## Граница claims (критично)
+
+Этот proof-pack — **toy/model baseline**. Он нужен для воспроизводимого “якоря” и ранних инвариантов,
+но **не** является freeze-ready формальной верификацией CANONICAL.
+
+Разрешённые формулировки (OK):
+- “model-level proved baseline for pinned sections”
+- “toy/model invariants proved; refinement to byte-accurate/executable semantics is pending”
+
+Запрещённые формулировки (NOT OK):
+- “formal verification of RUBIN consensus / CANONICAL”
+- “bit-exact wire/serialization proven”
+- “proved equivalence between spec and Go/Rust implementations”
+
+Источник истины по границе claims — `rubin-formal/proof_coverage.json` (`proof_level`, `claims`).
+
 ## Что это значит
 
 - Это **не** полный formal freeze-ready пакет уровня “бит-в-бит байтовая модель wire + state transition”.

--- a/rubin-formal/proof_coverage.json
+++ b/rubin-formal/proof_coverage.json
@@ -122,5 +122,17 @@
       ],
       "file": "rubin-formal/RubinFormal/PinnedSections.lean"
     }
-  ]
+  ],
+  "proof_level": "toy-model",
+  "claims": {
+    "allowed": [
+      "model-level proved baseline for pinned sections",
+      "toy/model invariants proved; refinement to byte-accurate/executable semantics is pending"
+    ],
+    "forbidden": [
+      "formal verification of RUBIN consensus / CANONICAL",
+      "bit-exact wire/serialization proven",
+      "proved equivalence between spec and Go/Rust implementations"
+    ]
+  }
 }

--- a/spec/AUDIT_CONTEXT.md
+++ b/spec/AUDIT_CONTEXT.md
@@ -20,8 +20,9 @@
 
 ## Formal proof-pack (informational)
 
-- Lean4 proof-pack вендорится в `rubin-formal/` и входит в audit-pack как baseline (`status=proved` на модельном уровне).
+- Lean4 proof-pack вендорится в `rubin-formal/` и входит в audit-pack как baseline (`proof_level=toy-model`; `status=proved` означает “proved in toy/model baseline”, а не байтовую/исполняемую эквивалентность CANONICAL).
 - Freeze-ready claim для formal verification допускается только после byte-accurate/executable refinement поверх модельного baseline.
+- Любые публичные/аудиторские формулировки должны следовать `rubin-formal/proof_coverage.json` (`claims.allowed[]` / `claims.forbidden[]`).
 
 ## Правило дедупликации finding’ов
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -34,7 +34,7 @@ Integrity:
 - `./RUBIN_CORE_HTLC_SPEC.md` — consensus-critical covenant spec
   - `CORE_HTLC` (0x0100), active from genesis block 0
   - Spend rules, witness format, conformance vectors CV-HTLC-01..12
-  - Lean4 proof-pack baseline is vendored in `../rubin-formal/` (`status=proved` on model-level; refinement to byte-accurate/executable semantics is pending)
+  - Lean4 proof-pack baseline is vendored in `../rubin-formal/` (`proof_level=toy-model`; `status=proved` = proved in the toy/model baseline; refinement to byte-accurate/executable semantics is pending)
 
 ## Normative (Non-Consensus)
 


### PR DESCRIPTION
- Define explicit claim boundary for `rubin-formal` toy/model baseline.
- Add machine-readable `proof_level` + `claims.allowed[]` / `claims.forbidden[]` to `rubin-formal/proof_coverage.json`.
- Enforce claim-boundary fields via `tools/check_formal_coverage.py` (CI guardrail).
- Clarify spec docs (`spec/AUDIT_CONTEXT.md`, `spec/README.md`) to prevent overclaim.
