### PR TITLE
Q-CI-03: add go vet and clippy CI gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           cache-dependency-path: clients/go/go.mod
       - uses: dtolnay/rust-toolchain@stable
         with:
-          components: rustfmt
+          components: rustfmt, clippy
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.node-version'
@@ -87,6 +87,11 @@ jobs:
           cd clients/go
           go test ./...
 
+      - name: Go vet
+        run: |
+          cd clients/go
+          go vet ./...
+
       - name: Rust fmt
         run: |
           cd clients/rust
@@ -96,6 +101,11 @@ jobs:
         run: |
           cd clients/rust
           cargo test --workspace
+
+      - name: Rust clippy
+        run: |
+          cd clients/rust
+          cargo clippy --workspace --all-targets -- -D warnings
 
       - name: Spec invariants check
         run: node scripts/check-spec-invariants.mjs

--- a/clients/rust/crates/rubin-consensus-cli/src/main.rs
+++ b/clients/rust/crates/rubin-consensus-cli/src/main.rs
@@ -167,7 +167,6 @@ fn main() {
                 sum_fees: None,
                 already_generated: None,
                 already_generated_n1: None,
-                ..Default::default()
             };
             let _ = serde_json::to_writer(std::io::stdout(), &resp);
             return;

--- a/clients/rust/crates/rubin-consensus/src/compact_relay.rs
+++ b/clients/rust/crates/rubin-consensus/src/compact_relay.rs
@@ -74,7 +74,7 @@ pub(crate) fn siphash24(msg: &[u8], k0: u64, k1: u64) -> u64 {
 /// Computes a 6-byte compact short ID from WTXID using SipHash-2-4.
 /// The 64-bit SipHash result is truncated to lower 48 bits (little-endian bytes).
 pub fn compact_shortid(wtxid: [u8; 32], nonce1: u64, nonce2: u64) -> [u8; 6] {
-    let h = siphash24(&wtxid, nonce1, nonce2) & 0x0000ffff_ffff_ffff;
+    let h = siphash24(&wtxid, nonce1, nonce2) & 0x0000_ffff_ffff_ffff;
     let b = h.to_le_bytes();
     let mut out = [0u8; 6];
     out.copy_from_slice(&b[..6]);

--- a/clients/rust/crates/rubin-consensus/src/merkle.rs
+++ b/clients/rust/crates/rubin-consensus/src/merkle.rs
@@ -41,7 +41,7 @@ fn merkle_root_tagged(ids: &[[u8; 32]], leaf_tag: u8, node_tag: u8) -> Result<[u
     let mut node_preimage = [0u8; 1 + 32 + 32];
     node_preimage[0] = node_tag;
     while level.len() > 1 {
-        let mut next: Vec<[u8; 32]> = Vec::with_capacity((level.len() + 1) / 2);
+        let mut next: Vec<[u8; 32]> = Vec::with_capacity(level.len().div_ceil(2));
         let mut i = 0usize;
         while i < level.len() {
             if i == level.len() - 1 {

--- a/clients/rust/crates/rubin-consensus/src/tests.rs
+++ b/clients/rust/crates/rubin-consensus/src/tests.rs
@@ -175,7 +175,7 @@ fn parse_tx_witness_item_canonicalization() {
     tx4.push(0x01);
     tx4.push(SUITE_ID_SLH_DSA_SHAKE_256F);
     tx4.push(0x40); // pubkey_length = 64
-    tx4.extend_from_slice(&vec![0u8; 64]);
+    tx4.extend_from_slice(&[0u8; 64]);
     tx4.push(0x00); // sig_length = 0
     tx4.push(0x00); // da_payload_len
     let err = parse_tx(&tx4).unwrap_err();
@@ -191,7 +191,7 @@ fn parse_tx_witness_bytes_overflow() {
     for _ in 0..3 {
         tx.push(SUITE_ID_SLH_DSA_SHAKE_256F);
         tx.push(0x40); // pubkey_length=64
-        tx.extend_from_slice(&vec![0u8; 64]);
+        tx.extend_from_slice(&[0u8; 64]);
         tx.extend_from_slice(&[0xfd, 0xc0, 0xc2]); // sig_length=49856 (0xC2C0)
         tx.extend_from_slice(&vec![0u8; 49_856]);
     }
@@ -1078,6 +1078,7 @@ fn tx_with_one_input_one_output(
     b
 }
 
+#[allow(clippy::too_many_arguments)]
 fn tx_with_one_input_one_output_with_witness(
     prev_txid: [u8; 32],
     prev_vout: u32,

--- a/clients/rust/crates/rubin-consensus/src/tx.rs
+++ b/clients/rust/crates/rubin-consensus/src/tx.rs
@@ -244,9 +244,9 @@ pub fn parse_tx(b: &[u8]) -> Result<(Tx, [u8; 32], [u8; 32], usize), TxError> {
                     true
                 } else if pub_len == 32 {
                     if sig_len == 1 {
-                        signature.get(0) == Some(&0x01)
+                        signature.first() == Some(&0x01)
                     } else if sig_len >= 3 {
-                        if signature.get(0) != Some(&0x00) {
+                        if signature.first() != Some(&0x00) {
                             false
                         } else {
                             let pre_len = u16::from_le_bytes(


### PR DESCRIPTION
- Add `go vet ./...` (clients/go) to CI.
- Add `cargo clippy --workspace --all-targets -- -D warnings` (clients/rust) to CI.
- Fix existing clippy warnings so the new gate is green.

Non-consensus; Phase-0 freeze hardening.
