### PR TITLE
Dev env: add dev-env.sh wrapper for stable PATH

### DIFF
--- a/spec/README.md
+++ b/spec/README.md
@@ -71,10 +71,19 @@ Integrity:
 
 ### Audit Tooling Repro (operational)
 
-Для воспроизводимых локальных запусков в macOS/Homebrew окружении:
+Для воспроизводимых локальных запусков в macOS/Homebrew окружении используем единый env-wrapper
+(устраняет проблемы с урезанным `PATH` в Codex-сессиях):
 
 ```bash
-export PATH=/opt/homebrew/bin:$PATH
+scripts/dev-env.sh
+```
+
+Для запуска команд:
+
+```bash
+scripts/dev-env.sh -- python3 tools/check_readme_index.py
+scripts/dev-env.sh -- node scripts/check-section-hashes.mjs
+scripts/dev-env.sh -- python3 conformance/runner/run_cv_bundle.py
 ```
 
 Версия Node.js для spec tooling pinned в корне репо:


### PR DESCRIPTION
- Add `scripts/dev-env.sh` to normalize PATH (Homebrew) and check required tools.
- Update `spec/README.md` to require wrapper instead of per-command PATH hacks.

Operational-only; no consensus changes.
