### PR TITLE
ci: fix YAML in spec_checks workflow

### DIFF
--- a/.github/workflows/spec_checks.yml
+++ b/.github/workflows/spec_checks.yml
@@ -28,5 +28,5 @@ jobs:
       - name: Check formal coverage baseline
         run: python3 tools/check_formal_coverage.py
 
-      - name: Hygiene: no absolute home paths
+      - name: "Hygiene: no absolute home paths"
         run: python3 tools/check_no_absolute_paths.py


### PR DESCRIPTION
Fixes invalid YAML in .github/workflows/spec_checks.yml (step name contains ': ' and must be quoted). This restores spec-checks workflow parsing and unblocks main push checks.