### PR TITLE
[codex] Q-SKILL docs: governance + migration + crypto ops

### DIFF
--- a/.github/workflows/spec_checks.yml
+++ b/.github/workflows/spec_checks.yml
@@ -28,5 +28,8 @@ jobs:
       - name: Check formal coverage baseline
         run: python3 tools/check_formal_coverage.py
 
+      - name: Check conformance fixtures IDs + changelog presence
+        run: python3 tools/check_conformance_ids.py
+
       - name: Hygiene: no absolute home paths
         run: python3 tools/check_no_absolute_paths.py

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ output/
 tmp/
 .claude/
 .codex/
+artifacts/
 
 # Local UI tooling (not part of genesis rewrite)
 rubin-ui/

--- a/spec/README.md
+++ b/spec/README.md
@@ -58,9 +58,18 @@ Integrity:
 - `./RUBIN_L1_P2P_AUX.md` — non-consensus P2P notes
   - Envelope format, peer scoring; defers to COMPACT_BLOCKS for relay policy.
 
+- `./RUBIN_SPEC_GOVERNANCE.md` — non-consensus governance rules
+  - Registry lifecycle, SECTION_HASHES discipline, conformance ID rules (CI lint).
+
 - `./RUBIN_SLH_FALLBACK_PLAYBOOK.md` — operational runbook
   - Activation/rollback procedure for SLH-DSA fallback mode
   - Non-normative; consensus gate is `SLH_DSA_ACTIVATION_HEIGHT` in CANONICAL.
+
+- `./RUBIN_PROTOCOL_MIGRATION_PLAYBOOK.md` — non-consensus migration playbook
+  - Rollout/rollback sequence (spec → fixtures → Go → Rust → CI → audit pack).
+
+- `./RUBIN_CRYPTO_BACKEND_OPS.md` — non-consensus crypto ops
+  - KPI/perf + parity acceptance policy for OpenSSL/PQC stack.
 
 ## Audit
 

--- a/spec/RUBIN_CRYPTO_BACKEND_OPS.md
+++ b/spec/RUBIN_CRYPTO_BACKEND_OPS.md
@@ -1,0 +1,38 @@
+# RUBIN Crypto Backend Ops (NON-CONSENSUS)
+
+Статус: **NON-CONSENSUS / operational**.
+
+Назначение: операционные правила для crypto backend (OpenSSL) в клиентах/CI:
+
+- KPI/перф-метрики;
+- interop контроль (Go reference ↔ Rust parity);
+- acceptance policy для изменений PQC stack и fallback процедур.
+
+## 1) Source-of-truth документы
+
+- `spec/RUBIN_CRYPTO_BACKEND_PROFILE.md` — **normative** профиль: OpenSSL-only, запреты зависимостей.
+- `spec/RUBIN_SLH_FALLBACK_PLAYBOOK.md` — operational activation/rollback для SLH fallback (процедура).
+
+## 2) KPI (baseline)
+
+Рекомендуемый минимум KPI:
+
+- verify throughput (ops/s) для ML-DSA и SLH-DSA;
+- p99 latency batch verify (если используется);
+- peak RSS при прогоне conformance bundle.
+
+Политика: ухудшение >10% throughput или >20% p99 требует явного объяснения в PR.
+
+## 3) Interop / acceptance
+
+- `python3 conformance/runner/run_cv_bundle.py` MUST pass (Go↔Rust parity).
+- Никаких “тихих” fallback путей без conformance coverage.
+
+## 4) Рекомендованные команды
+
+```bash
+scripts/dev-env.sh -- python3 conformance/runner/run_cv_bundle.py
+scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./...'
+scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test --workspace'
+```
+

--- a/spec/RUBIN_PROTOCOL_MIGRATION_PLAYBOOK.md
+++ b/spec/RUBIN_PROTOCOL_MIGRATION_PLAYBOOK.md
@@ -1,0 +1,49 @@
+# RUBIN Protocol Migration Playbook (NON-CONSENSUS)
+
+Статус: **NON-CONSENSUS / operational playbook**.
+
+Назначение: единая процедура rollout/rollback для изменений протокола и клиентов
+в Phase‑0/devnet режиме.
+
+## 1) Когда нужно одобрение контроллера
+
+**НУЖНО ОДОБРЕНИЕ КОНТРОЛЕРА**, если изменение:
+
+- меняет `valid/invalid` для tx/blocks;
+- меняет validation order/priority/error mapping;
+- меняет лимиты, suite gating, activation boundaries;
+- вводит/меняет новые error codes;
+- меняет wire/serialization, TXID/WTXID preimage, sighash.
+
+## 2) Release train (обязательный порядок)
+
+1) Spec (`spec/*`) + SECTION_HASHES (если менялись pinned секции CANONICAL).
+2) Fixtures (`conformance/fixtures/*`) — фиксируем поведение машинно.
+3) Go reference (`clients/go/*`).
+4) Rust parity (`clients/rust/*`) — ровняется к Go.
+5) CI green (Actions).
+6) Audit pack (если нужно freeze-ready).
+
+## 3) Минимальный локальный чеклист (перед push/PR)
+
+Все команды запускать только через `scripts/dev-env.sh`:
+
+```bash
+scripts/dev-env.sh -- python3 tools/check_readme_index.py
+scripts/dev-env.sh -- python3 tools/check_section_hashes.py
+scripts/dev-env.sh -- python3 tools/check_conformance_ids.py
+scripts/dev-env.sh -- node scripts/check-spec-invariants.mjs
+scripts/dev-env.sh -- node scripts/check-section-hashes.mjs
+scripts/dev-env.sh -- python3 conformance/runner/run_cv_bundle.py
+scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./...'
+scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test --workspace'
+```
+
+## 4) Rollback policy (Phase‑0/devnet)
+
+- До запуска сети rollback = git revert + обновление fixtures/conformance.
+- После поднятия devnet:
+  - consensus-critical rollback делается только через согласованное governance-решение
+    (новая активация или перезапуск devnet с новым genesis), иначе риск split.
+  - non-consensus rollback допускается обычным revert PR.
+

--- a/spec/RUBIN_SPEC_GOVERNANCE.md
+++ b/spec/RUBIN_SPEC_GOVERNANCE.md
@@ -1,0 +1,81 @@
+# RUBIN Spec Governance (NON-CONSENSUS)
+
+Статус: **NON-CONSENSUS / governance artifact**.
+
+Цель: правила сопровождения спеки/реестров/fixtures, чтобы обеспечить:
+
+- стабильность публичных ID (error codes, covenant registry, conformance gates/vectors);
+- воспроизводимость аудита (freeze-ready дисциплина);
+- отсутствие “тихих” breaking-изменений.
+
+Нормативное первенство не меняется: source-of-truth для консенсуса — `RUBIN_L1_CANONICAL.md`.
+
+## 1) Неподвижность ID (stability contract)
+
+### 1.1 Error codes (`TX_ERR_*`, `BLOCK_ERR_*`)
+
+- Любой error code — публичный контракт.
+- Запрещено:
+  - переиспользовать код с другой семантикой;
+  - “тихо” менять приоритет/порядок валидации так, чтобы менялся код ошибки.
+- Разрешено:
+  - добавлять новые коды (через CANONICAL + conformance coverage + Go/Rust parity);
+  - deprecate (не удаляя и не переиспользуя).
+
+### 1.2 Covenant registry (`covenant_type`)
+
+- Значения и смысл фиксируются в CANONICAL.
+- Запрещено менять смысл уже занятых значений.
+- Расширение registry — только через spec + fixtures + Go + Rust.
+
+## 2) SECTION_HASHES discipline
+
+- Любое изменение pinned-секций CANONICAL **MUST** сопровождаться rehash:
+
+```bash
+scripts/dev-env.sh -- node scripts/gen-section-hashes.mjs
+scripts/dev-env.sh -- node scripts/check-section-hashes.mjs
+```
+
+- Изменение pinned scope/canonicalization — это breaking для audit-pack и требует записи в changelog.
+
+## 3) Conformance fixtures governance
+
+Для каждого `conformance/fixtures/<GATE>.json`:
+
+- поле `gate` **MUST** совпадать с именем файла без расширения;
+- внутри `vectors[]` каждый `vector.id` **MUST** быть уникален;
+- gate ID и vector IDs считаются частью публичного контракта; rename = breaking.
+
+Политика breaking:
+
+- вместо rename/удаления: добавляем новый вектор с новым ID;
+- старый ID не переиспользуем;
+- все breaking изменения фиксируем в `spec/SPEC_CHANGELOG.md`.
+
+## 4) Changelog policy
+
+Файл: `spec/SPEC_CHANGELOG.md` (**NON-CONSENSUS**).
+
+Требуется для:
+
+- изменений registry (error codes / covenant types);
+- изменений SECTION_HASHES (scope/canonicalization);
+- любых изменений conformance ID (gate/vector) и их semantics.
+
+## 5) Lints
+
+Инструмент: `tools/check_conformance_ids.py`
+
+Запуск:
+
+```bash
+scripts/dev-env.sh -- python3 tools/check_conformance_ids.py
+```
+
+Проверяет:
+
+- корректность `gate` (совпадает с именем файла),
+- уникальность gate/vector ID,
+- наличие changelog с датированным заголовком.
+

--- a/spec/SPEC_CHANGELOG.md
+++ b/spec/SPEC_CHANGELOG.md
@@ -1,0 +1,10 @@
+# Spec Changelog (NON-CONSENSUS)
+
+Этот файл — **NON-CONSENSUS** журнал изменений спецификаций/реестров и governance-политик.  
+Он не является нормативным источником валидности блоков/транзакций.
+
+## 2026-02-25
+
+- INIT: добавлен `spec/RUBIN_SPEC_GOVERNANCE.md` (governance, non-consensus).
+- INIT: добавлен `tools/check_conformance_ids.py` (breaking lint: уникальность conformance gate/vector IDs + наличие changelog).
+

--- a/tools/check_conformance_ids.py
+++ b/tools/check_conformance_ids.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+ROOT = Path(".")
+FIXTURES_DIR = ROOT / "conformance" / "fixtures"
+
+CHANGELOG_CANDIDATES = [
+    ROOT / "spec" / "SPEC_CHANGELOG.md",
+    ROOT / "spec" / "CHANGES.md",
+]
+
+DATE_HDR_RE = re.compile(r"(?m)^##\s+\d{4}-\d{2}-\d{2}\b")
+
+
+@dataclass(frozen=True)
+class IdLoc:
+    value: str
+    path: Path
+
+
+def load_json(path: Path) -> object:
+    return json.loads(path.read_text(encoding="utf-8", errors="strict"))
+
+
+def pick_changelog() -> Path | None:
+    for p in CHANGELOG_CANDIDATES:
+        if p.exists():
+            return p
+    return None
+
+
+def validate_changelog(path: Path) -> list[str]:
+    problems: list[str] = []
+    text = path.read_text(encoding="utf-8", errors="strict")
+
+    if not text.lstrip().startswith("#"):
+        problems.append("changelog: missing top-level markdown header (# ...)")
+
+    if "NON-CONSENSUS" not in text:
+        problems.append("changelog: must include 'NON-CONSENSUS' marker")
+
+    if not DATE_HDR_RE.search(text):
+        problems.append("changelog: must contain at least one dated section header: '## YYYY-MM-DD'")
+
+    return problems
+
+
+def main() -> int:
+    if not FIXTURES_DIR.exists():
+        print("ERROR: conformance/fixtures directory not found", file=sys.stderr)
+        return 2
+
+    fixture_paths = sorted(FIXTURES_DIR.glob("*.json"))
+    if not fixture_paths:
+        print("ERROR: no conformance fixtures found in conformance/fixtures/*.json", file=sys.stderr)
+        return 2
+
+    failed = False
+
+    gate_seen: dict[str, IdLoc] = {}
+    vector_seen: dict[str, IdLoc] = {}
+
+    for path in fixture_paths:
+        try:
+            data = load_json(path)
+        except Exception as e:
+            print(f"ERROR: cannot parse json: {path}: {e}", file=sys.stderr)
+            failed = True
+            continue
+
+        if not isinstance(data, dict):
+            print(f"ERROR: fixture root must be object: {path}", file=sys.stderr)
+            failed = True
+            continue
+
+        gate = data.get("gate")
+        if not isinstance(gate, str) or gate.strip() == "":
+            print(f"ERROR: missing/invalid 'gate' string in {path}", file=sys.stderr)
+            failed = True
+            continue
+
+        expected_gate = path.stem
+        if gate != expected_gate:
+            print(
+                f"ERROR: gate must match filename stem in {path}: gate={gate!r} expected={expected_gate!r}",
+                file=sys.stderr,
+            )
+            failed = True
+
+        if gate in gate_seen:
+            prev = gate_seen[gate]
+            print(
+                f"ERROR: duplicate gate id {gate!r} in {path} (already in {prev.path})",
+                file=sys.stderr,
+            )
+            failed = True
+        else:
+            gate_seen[gate] = IdLoc(gate, path)
+
+        vectors = data.get("vectors")
+        if not isinstance(vectors, list):
+            print(f"ERROR: missing/invalid 'vectors' array in {path}", file=sys.stderr)
+            failed = True
+            continue
+
+        local_vectors: set[str] = set()
+        for i, v in enumerate(vectors):
+            if not isinstance(v, dict):
+                print(f"ERROR: vectors[{i}] must be object in {path}", file=sys.stderr)
+                failed = True
+                continue
+
+            vid = v.get("id")
+            if not isinstance(vid, str) or vid.strip() == "":
+                print(f"ERROR: vectors[{i}].id must be non-empty string in {path}", file=sys.stderr)
+                failed = True
+                continue
+
+            if vid in local_vectors:
+                print(f"ERROR: duplicate vector id {vid!r} within {path}", file=sys.stderr)
+                failed = True
+            else:
+                local_vectors.add(vid)
+
+            if vid in vector_seen:
+                prev = vector_seen[vid]
+                print(
+                    f"ERROR: duplicate vector id {vid!r} in {path} (already in {prev.path})",
+                    file=sys.stderr,
+                )
+                failed = True
+            else:
+                vector_seen[vid] = IdLoc(vid, path)
+
+    changelog = pick_changelog()
+    if not changelog:
+        print(
+            "ERROR: missing spec changelog file (expected spec/SPEC_CHANGELOG.md or spec/CHANGES.md)",
+            file=sys.stderr,
+        )
+        failed = True
+    else:
+        problems = validate_changelog(changelog)
+        for p in problems:
+            print(f"ERROR: {p} ({changelog})", file=sys.stderr)
+        if problems:
+            failed = True
+
+    if failed:
+        return 1
+
+    print(
+        f"OK: conformance IDs are unique (gates={len(gate_seen)} vectors={len(vector_seen)}), changelog present."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+


### PR DESCRIPTION
Adds NON-CONSENSUS documentation and guardrails from the skill progression map:

- Spec governance: registries/SECTION_HASHES discipline + conformance ID stability
- Breaking lint: tools/check_conformance_ids.py (gate/vector ID uniqueness + changelog presence)
- Migration playbook: rollout/rollback sequence and controller-approval boundary
- Crypto backend ops: KPI + parity acceptance policy (OpenSSL/PQC)

CI:
- spec-checks workflow now runs tools/check_conformance_ids.py

Inbox closeouts:
- /Users/gpt/Documents/inbox/reports/2026-02-25_report_q-skill-03_spec_governance_done.md
- /Users/gpt/Documents/inbox/reports/2026-02-25_report_q-skill-02_migration_playbooks_done.md
- /Users/gpt/Documents/inbox/reports/2026-02-25_report_q-skill-05_crypto_backend_ops_done.md
