### PR TITLE
[codex] Q-FUZZ-01: fuzz targets (Go+Rust) + runbook

### DIFF
--- a/clients/go/consensus/fuzz_consensus_test.go
+++ b/clients/go/consensus/fuzz_consensus_test.go
@@ -1,0 +1,91 @@
+package consensus
+
+import (
+	"bytes"
+	"testing"
+)
+
+func minimalTxBytesForFuzz() []byte {
+	// version(4) + tx_kind(1) + tx_nonce(8) + input_count(1) + output_count(1) + locktime(4) + witness_count(1) + da_payload_len(1)
+	return []byte{
+		0x01, 0x00, 0x00, 0x00, // version
+		0x00,                                           // tx_kind
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // tx_nonce
+		0x00,                   // input_count
+		0x00,                   // output_count
+		0x00, 0x00, 0x00, 0x00, // locktime
+		0x00, // witness_count
+		0x00, // da_payload_len
+	}
+}
+
+func minimalBlockBytesForFuzz() []byte {
+	var prev [32]byte
+	var target [32]byte
+	for i := range target {
+		target[i] = 0xff
+	}
+	var root [32]byte
+	tx := minimalTxBytesForFuzz()
+
+	header := make([]byte, 0, BLOCK_HEADER_BYTES)
+	header = appendU32le(header, 1) // version
+	header = append(header, prev[:]...)
+	header = append(header, root[:]...)
+	header = appendU64le(header, 1) // timestamp
+	header = append(header, target[:]...)
+	header = appendU64le(header, 1) // nonce
+
+	out := make([]byte, 0, len(header)+1+len(tx))
+	out = append(out, header...)
+	out = appendCompactSize(out, 1) // tx_count
+	out = append(out, tx...)
+	return out
+}
+
+func FuzzReadCompactSize(f *testing.F) {
+	f.Add([]byte{0x00})
+	f.Add([]byte{0xfc})
+	f.Add([]byte{0xfd, 0xfd, 0x00})
+	f.Add([]byte{0xfe, 0x00, 0x00, 0x01, 0x00})
+	f.Fuzz(func(t *testing.T, b []byte) {
+		off := 0
+		n, nbytes, err := readCompactSize(b, &off)
+		if err != nil {
+			return
+		}
+		if nbytes <= 0 || nbytes > len(b) {
+			t.Fatalf("bad nbytes=%d len=%d", nbytes, len(b))
+		}
+		enc := appendCompactSize(nil, n)
+		if !bytes.Equal(enc, b[:nbytes]) {
+			t.Fatalf("non-minimal or mismatch: got=%x want_prefix=%x", enc, b[:nbytes])
+		}
+	})
+}
+
+func FuzzParseTx(f *testing.F) {
+	f.Add(minimalTxBytesForFuzz())
+	f.Fuzz(func(t *testing.T, b []byte) {
+		_, _, _, n, err := ParseTx(b)
+		if err != nil {
+			return
+		}
+		if n != len(b) {
+			t.Fatalf("consumed=%d len=%d", n, len(b))
+		}
+	})
+}
+
+func FuzzParseBlockBytes(f *testing.F) {
+	f.Add(minimalBlockBytesForFuzz())
+	f.Fuzz(func(t *testing.T, b []byte) {
+		pb, err := ParseBlockBytes(b)
+		if err != nil {
+			return
+		}
+		if pb.TxCount != uint64(len(pb.Txs)) || pb.TxCount != uint64(len(pb.Txids)) || pb.TxCount != uint64(len(pb.Wtxids)) {
+			t.Fatalf("inconsistent tx sizes: tx_count=%d txs=%d txids=%d wtxids=%d", pb.TxCount, len(pb.Txs), len(pb.Txids), len(pb.Wtxids))
+		}
+	})
+}

--- a/clients/rust/crates/rubin-consensus/src/compactsize.rs
+++ b/clients/rust/crates/rubin-consensus/src/compactsize.rs
@@ -31,6 +31,11 @@ pub fn read_compact_size(r: &mut Reader<'_>) -> Result<(u64, usize), TxError> {
     Ok((v, r.offset() - start))
 }
 
+pub fn read_compact_size_bytes(b: &[u8]) -> Result<(u64, usize), TxError> {
+    let mut r = Reader::new(b);
+    read_compact_size(&mut r)
+}
+
 pub fn encode_compact_size(n: u64, out: &mut Vec<u8>) {
     match n {
         0x00..=0xfc => out.push(n as u8),

--- a/clients/rust/crates/rubin-consensus/src/lib.rs
+++ b/clients/rust/crates/rubin-consensus/src/lib.rs
@@ -25,6 +25,8 @@ pub use block_basic::{
     validate_block_basic_with_context_at_height, BlockBasicSummary, ParsedBlock,
 };
 pub use compact_relay::compact_shortid;
+pub use compactsize::encode_compact_size;
+pub use compactsize::read_compact_size_bytes;
 pub use connect_block_inmem::{
     connect_block_basic_in_memory_at_height, ConnectBlockBasicSummary, InMemoryChainState,
 };

--- a/clients/rust/fuzz/.gitignore
+++ b/clients/rust/fuzz/.gitignore
@@ -1,0 +1,5 @@
+/artifacts/
+/corpus/
+/coverage/
+target/
+

--- a/clients/rust/fuzz/Cargo.toml
+++ b/clients/rust/fuzz/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "rubin-consensus-fuzz"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+rubin-consensus = { path = "../crates/rubin-consensus" }
+
+[[bin]]
+name = "parse_tx"
+path = "fuzz_targets/parse_tx.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "parse_block_bytes"
+path = "fuzz_targets/parse_block_bytes.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "compactsize"
+path = "fuzz_targets/compactsize.rs"
+test = false
+doc = false
+

--- a/clients/rust/fuzz/fuzz_targets/compactsize.rs
+++ b/clients/rust/fuzz/fuzz_targets/compactsize.rs
@@ -1,0 +1,16 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let Ok((n, nbytes)) = rubin_consensus::read_compact_size_bytes(data) else {
+        return;
+    };
+    let prefix = &data[..nbytes];
+    let mut enc = Vec::new();
+    rubin_consensus::encode_compact_size(n, &mut enc);
+    if enc != prefix {
+        panic!("non-minimal or mismatch: got={enc:02x?} want_prefix={prefix:02x?}");
+    }
+});
+

--- a/clients/rust/fuzz/fuzz_targets/parse_block_bytes.rs
+++ b/clients/rust/fuzz/fuzz_targets/parse_block_bytes.rs
@@ -1,0 +1,8 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = rubin_consensus::parse_block_bytes(data);
+});
+

--- a/clients/rust/fuzz/fuzz_targets/parse_tx.rs
+++ b/clients/rust/fuzz/fuzz_targets/parse_tx.rs
@@ -1,0 +1,8 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = rubin_consensus::parse_tx(data);
+});
+

--- a/tools/FUZZING.md
+++ b/tools/FUZZING.md
@@ -1,0 +1,48 @@
+# Fuzzing (Phase‑0 hardening)
+
+This repo keeps fuzzing **out of default CI** (time/cost), but provides deterministic fuzz targets for manual runs.
+
+All commands below should be run via `scripts/dev-env.sh` to avoid local PATH drift.
+
+## Go (native fuzzing)
+
+Targets live in `clients/go/consensus/*_test.go` (Go 1.18+):
+
+- CompactSize: `FuzzReadCompactSize`
+- TX parser: `FuzzParseTx`
+- Block parser: `FuzzParseBlockBytes`
+
+Examples:
+
+```bash
+scripts/dev-env.sh -- bash -lc 'cd clients/go/consensus && go test -fuzz=FuzzReadCompactSize -fuzztime=30s'
+scripts/dev-env.sh -- bash -lc 'cd clients/go/consensus && go test -fuzz=FuzzParseTx -fuzztime=30s'
+scripts/dev-env.sh -- bash -lc 'cd clients/go/consensus && go test -fuzz=FuzzParseBlockBytes -fuzztime=30s'
+```
+
+## Rust (cargo-fuzz / libFuzzer)
+
+Targets live in `clients/rust/fuzz/fuzz_targets/`:
+
+- `parse_tx`
+- `parse_block_bytes`
+- `compactsize`
+
+One-time setup:
+
+```bash
+scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo install cargo-fuzz --locked'
+```
+
+Run examples:
+
+```bash
+scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo fuzz run parse_tx -- -max_total_time=30'
+scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo fuzz run parse_block_bytes -- -max_total_time=30'
+scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo fuzz run compactsize -- -max_total_time=30'
+```
+
+Notes:
+- Fuzz artifacts/corpora are ignored via `clients/rust/fuzz/.gitignore`.
+- Keep fuzz runs bounded (`-max_total_time=...`) for reproducibility during triage.
+


### PR DESCRIPTION
Adds Go native fuzz targets for CompactSize/ParseTx/ParseBlockBytes and a Rust cargo-fuzz harness (parse_tx, parse_block_bytes, compactsize) plus `tools/FUZZING.md` runbook. No consensus semantics change; CI only compiles these files (does not run fuzz by default).

Local: go/rust tests + conformance PASS.