### PR TITLE
spec: fix SHA3 Keccak markdown + vault rule + POW_LIMIT

### DIFF
--- a/spec/RUBIN_L1_CANONICAL.md
+++ b/spec/RUBIN_L1_CANONICAL.md
@@ -307,7 +307,7 @@ RUBIN uses `SHA3-256` (FIPS 202) as the consensus hash function.
 
 ### 8.1.1 SHA3-256 Security Properties (Informative)
 
-`SHA3-256` (FIPS 202, Keccak[512](M, 256)) provides the following asymptotic security properties:
+`SHA3-256` (FIPS 202, `Keccak[512](M, 256)`) provides the following asymptotic security properties:
 
 - **Preimage resistance:** ~256-bit (classical), ~128-bit (quantum; Grover)
 - **Second-preimage resistance:** ~256-bit (classical), ~128-bit (quantum; Grover)
@@ -1306,7 +1306,7 @@ For each non-coinbase transaction `T`:
 2. Let `sum_out` be the sum of `T.outputs[j].value` over all outputs `j`.
 3. Let `sum_in_vault` be the sum of referenced input values whose UTXO covenant type is `CORE_VAULT`.
 4. If `sum_out > sum_in`, reject as `TX_ERR_VALUE_CONSERVATION`.
-5. If `T` spends at least one `CORE_VAULT` input and `sum_out != sum_in_vault`,
+5. If `T` spends at least one `CORE_VAULT` input and `sum_out < sum_in_vault`,
    reject as `TX_ERR_VALUE_CONSERVATION`.
 6. Arithmetic MUST be exact and MUST be computed in at least 128-bit unsigned integer arithmetic.
    Any overflow MUST be rejected as `TX_ERR_PARSE`.

--- a/spec/RUBIN_NETWORK_PARAMS.md
+++ b/spec/RUBIN_NETWORK_PARAMS.md
@@ -23,7 +23,7 @@ Operational defaults and relay policy defaults MUST NOT be treated as validity r
 | Parameter | Value | Class | Source |
 |-----------|-------|-------|--------|
 | `TARGET_BLOCK_INTERVAL` | 120 s | Consensus-critical | CANONICAL §4 |
-| `POW_LIMIT` | 0xffff..ffff (bytes32 max) | Consensus-critical | CANONICAL §4, §15 |
+| `POW_LIMIT` | 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff (bytes32) | Consensus-critical | CANONICAL §4, §15 |
 | `MAX_BLOCK_WEIGHT` | 68,000,000 wu | Consensus-critical | CANONICAL §4 |
 | `MAX_DA_BYTES_PER_BLOCK` | 32,000,000 bytes (30.5 MiB) | Consensus-critical | CANONICAL §4 |
 | `WINDOW_SIZE` (retarget) | 10,080 blocks (14 days) | Consensus-critical | CANONICAL §4 |

--- a/spec/SECTION_HASHES.json
+++ b/spec/SECTION_HASHES.json
@@ -20,7 +20,7 @@
   },
   "sections": {
     "transaction_wire": "1c9afdad12da2a6d869b0495709f54a7296a4186be303aad15b88492306462bc",
-    "transaction_identifiers": "4ef9d9777bb3f0a2e3c145d6578738c1a18134a192f63e66ff3b343f996377d4",
+    "transaction_identifiers": "abc38661d94a5113dfe2bc0fe2ba3626c6828538b615bea033080a9a8bff9086",
     "weight_accounting": "2ad57571c7ac1239ebbee6889b99be9f507d4b904346a79d3cfa4eef36dcf755",
     "witness_commitment": "10a0e0b289df6023e6c6589d575e0f25b37025c0b84ba404dae5738ad50abf3d",
     "sighash_v1": "e20b0bcae92ec4a9549150f1d6b7dc9f29e888c1e6d56341e6beb6062e4a7d1f",
@@ -30,7 +30,7 @@
     "transaction_structural_rules": "c5b268dab7a7e8e036bc62a0cba877d5994a7bfb47966201c5d71473b18ee965",
     "replay_domain_checks": "f65201c5b65cdc4c53286074806cb189eaaf5909a007ea0079102e3cb616f115",
     "utxo_state_model": "f3f96f3dd27ee8d7d3725502cc4afcbd6cc301cd03c49fa2e1b7e6417ee2ba42",
-    "value_conservation": "e48278b5318dc1bc68712430febebfe37a7ce6e68e02349ca657261eb5c34962",
+    "value_conservation": "6aee9b8a883467c413ba37c32d404de5a75db0ed0026df6d712b6148fe643226",
     "da_set_integrity": "3e71e5f27c3c33997564d5bc7bc36f63467a345ab0ed4b2d40c5c1ff9a94c244"
   }
 }


### PR DESCRIPTION
Audit hygiene + spec consistency fixes:

- Avoid broken Markdown link parsing for Keccak[512](M, 256).
- Align Value Conservation vault rule with the normative vault spend rule (sum_out < sum_in_vault is invalid; owner top-up allowed).
- Make POW_LIMIT byte-exact in RUBIN_NETWORK_PARAMS.
- Regenerate SECTION_HASHES for affected pinned sections.
