### PR TITLE
node: persistent chainstate and blockstore for devnet

### DIFF
--- a/clients/go/node/blockstore.go
+++ b/clients/go/node/blockstore.go
@@ -1,0 +1,229 @@
+package node
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+)
+
+const (
+	blockStoreIndexVersion = 1
+	blockStoreDirName      = "blockstore"
+)
+
+type BlockStore struct {
+	rootPath   string
+	indexPath  string
+	blocksDir  string
+	headersDir string
+	index      blockStoreIndexDisk
+}
+
+type blockStoreIndexDisk struct {
+	Version   uint32   `json:"version"`
+	Canonical []string `json:"canonical"`
+}
+
+func BlockStorePath(dataDir string) string {
+	return filepath.Join(dataDir, blockStoreDirName)
+}
+
+func OpenBlockStore(rootPath string) (*BlockStore, error) {
+	indexPath := filepath.Join(rootPath, "index.json")
+	blocksDir := filepath.Join(rootPath, "blocks")
+	headersDir := filepath.Join(rootPath, "headers")
+
+	if err := os.MkdirAll(blocksDir, 0o755); err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(headersDir, 0o755); err != nil {
+		return nil, err
+	}
+
+	index, err := loadBlockStoreIndex(indexPath)
+	if err != nil {
+		return nil, err
+	}
+
+	bs := &BlockStore{
+		rootPath:   rootPath,
+		indexPath:  indexPath,
+		blocksDir:  blocksDir,
+		headersDir: headersDir,
+		index:      index,
+	}
+	return bs, nil
+}
+
+func (bs *BlockStore) PutBlock(height uint64, blockHash [32]byte, headerBytes []byte, blockBytes []byte) error {
+	if bs == nil {
+		return errors.New("nil blockstore")
+	}
+	if len(headerBytes) != consensus.BLOCK_HEADER_BYTES {
+		return fmt.Errorf("invalid header length: %d", len(headerBytes))
+	}
+	computedHash, err := consensus.BlockHash(headerBytes)
+	if err != nil {
+		return err
+	}
+	if computedHash != blockHash {
+		return errors.New("header hash mismatch")
+	}
+
+	hashHex := hex.EncodeToString(blockHash[:])
+	if err := writeFileIfAbsent(filepath.Join(bs.blocksDir, hashHex+".bin"), blockBytes); err != nil {
+		return err
+	}
+	if err := writeFileIfAbsent(filepath.Join(bs.headersDir, hashHex+".bin"), headerBytes); err != nil {
+		return err
+	}
+	return bs.SetCanonicalTip(height, blockHash)
+}
+
+func (bs *BlockStore) SetCanonicalTip(height uint64, blockHash [32]byte) error {
+	if bs == nil {
+		return errors.New("nil blockstore")
+	}
+	hashHex := hex.EncodeToString(blockHash[:])
+	currentLen := uint64(len(bs.index.Canonical))
+	switch {
+	case height > currentLen:
+		return fmt.Errorf("height gap: got %d, expected <= %d", height, currentLen)
+	case height == currentLen:
+		bs.index.Canonical = append(bs.index.Canonical, hashHex)
+	default:
+		if bs.index.Canonical[height] == hashHex {
+			return saveBlockStoreIndex(bs.indexPath, bs.index)
+		}
+		bs.index.Canonical = append(bs.index.Canonical[:height], hashHex)
+	}
+	return saveBlockStoreIndex(bs.indexPath, bs.index)
+}
+
+func (bs *BlockStore) RewindToHeight(height uint64) error {
+	if bs == nil {
+		return errors.New("nil blockstore")
+	}
+	if len(bs.index.Canonical) == 0 {
+		return nil
+	}
+	if height >= uint64(len(bs.index.Canonical)) {
+		return fmt.Errorf("rewind height out of range: %d", height)
+	}
+	bs.index.Canonical = append([]string(nil), bs.index.Canonical[:height+1]...)
+	return saveBlockStoreIndex(bs.indexPath, bs.index)
+}
+
+func (bs *BlockStore) CanonicalHash(height uint64) ([32]byte, bool, error) {
+	var out [32]byte
+	if bs == nil {
+		return out, false, errors.New("nil blockstore")
+	}
+	if height >= uint64(len(bs.index.Canonical)) {
+		return out, false, nil
+	}
+	hash, err := parseHex32("canonical hash", bs.index.Canonical[height])
+	if err != nil {
+		return out, false, err
+	}
+	return hash, true, nil
+}
+
+func (bs *BlockStore) Tip() (uint64, [32]byte, bool, error) {
+	var out [32]byte
+	if bs == nil {
+		return 0, out, false, errors.New("nil blockstore")
+	}
+	if len(bs.index.Canonical) == 0 {
+		return 0, out, false, nil
+	}
+	height := uint64(len(bs.index.Canonical) - 1)
+	hash, err := parseHex32("tip hash", bs.index.Canonical[height])
+	if err != nil {
+		return 0, out, false, err
+	}
+	return height, hash, true, nil
+}
+
+func (bs *BlockStore) GetBlockByHash(blockHash [32]byte) ([]byte, error) {
+	if bs == nil {
+		return nil, errors.New("nil blockstore")
+	}
+	return os.ReadFile(filepath.Join(bs.blocksDir, hex.EncodeToString(blockHash[:])+".bin"))
+}
+
+func (bs *BlockStore) GetHeaderByHash(blockHash [32]byte) ([]byte, error) {
+	if bs == nil {
+		return nil, errors.New("nil blockstore")
+	}
+	return os.ReadFile(filepath.Join(bs.headersDir, hex.EncodeToString(blockHash[:])+".bin"))
+}
+
+func loadBlockStoreIndex(path string) (blockStoreIndexDisk, error) {
+	raw, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return blockStoreIndexDisk{
+			Version:   blockStoreIndexVersion,
+			Canonical: []string{},
+		}, nil
+	}
+	if err != nil {
+		return blockStoreIndexDisk{}, err
+	}
+	var index blockStoreIndexDisk
+	if err := json.Unmarshal(raw, &index); err != nil {
+		return blockStoreIndexDisk{}, fmt.Errorf("decode blockstore index: %w", err)
+	}
+	if index.Version != blockStoreIndexVersion {
+		return blockStoreIndexDisk{}, fmt.Errorf("unsupported blockstore index version: %d", index.Version)
+	}
+	for i, hashHex := range index.Canonical {
+		if _, err := parseHex32(fmt.Sprintf("canonical[%d]", i), hashHex); err != nil {
+			return blockStoreIndexDisk{}, err
+		}
+	}
+	return index, nil
+}
+
+func saveBlockStoreIndex(path string, index blockStoreIndexDisk) error {
+	raw, err := json.MarshalIndent(index, "", "  ")
+	if err != nil {
+		return err
+	}
+	raw = append(raw, '\n')
+	return writeFileAtomic(path, raw, 0o644)
+}
+
+func writeFileIfAbsent(path string, content []byte) error {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	if err == nil {
+		_, writeErr := f.Write(content)
+		closeErr := f.Close()
+		if writeErr != nil {
+			_ = os.Remove(path)
+			return writeErr
+		}
+		if closeErr != nil {
+			_ = os.Remove(path)
+			return closeErr
+		}
+		return nil
+	}
+	if !errors.Is(err, os.ErrExist) {
+		return err
+	}
+	existing, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(existing, content) {
+		return fmt.Errorf("file already exists with different content: %s", path)
+	}
+	return nil
+}

--- a/clients/go/node/blockstore_test.go
+++ b/clients/go/node/blockstore_test.go
@@ -1,0 +1,167 @@
+package node
+
+import (
+	"bytes"
+	"encoding/binary"
+	"path/filepath"
+	"testing"
+
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+)
+
+func TestBlockStorePutGetAndTip(t *testing.T) {
+	store, err := OpenBlockStore(filepath.Join(t.TempDir(), "blockstore"))
+	if err != nil {
+		t.Fatalf("open blockstore: %v", err)
+	}
+
+	header0 := testHeaderBytes(1, 11)
+	hash0, err := consensus.BlockHash(header0)
+	if err != nil {
+		t.Fatalf("block hash 0: %v", err)
+	}
+	block0 := []byte("block-0")
+	if err := store.PutBlock(0, hash0, header0, block0); err != nil {
+		t.Fatalf("put block 0: %v", err)
+	}
+
+	header1 := testHeaderBytes(2, 22)
+	hash1, err := consensus.BlockHash(header1)
+	if err != nil {
+		t.Fatalf("block hash 1: %v", err)
+	}
+	block1 := []byte("block-1")
+	if err := store.PutBlock(1, hash1, header1, block1); err != nil {
+		t.Fatalf("put block 1: %v", err)
+	}
+
+	gotHeader1, err := store.GetHeaderByHash(hash1)
+	if err != nil {
+		t.Fatalf("get header by hash: %v", err)
+	}
+	if !bytes.Equal(gotHeader1, header1) {
+		t.Fatalf("header bytes mismatch")
+	}
+
+	gotBlock1, err := store.GetBlockByHash(hash1)
+	if err != nil {
+		t.Fatalf("get block by hash: %v", err)
+	}
+	if !bytes.Equal(gotBlock1, block1) {
+		t.Fatalf("block bytes mismatch")
+	}
+
+	tipHeight, tipHash, ok, err := store.Tip()
+	if err != nil {
+		t.Fatalf("tip: %v", err)
+	}
+	if !ok || tipHeight != 1 || tipHash != hash1 {
+		t.Fatalf("unexpected tip: ok=%v height=%d hash=%x", ok, tipHeight, tipHash)
+	}
+
+	h0, ok, err := store.CanonicalHash(0)
+	if err != nil {
+		t.Fatalf("canonical hash height 0: %v", err)
+	}
+	if !ok || h0 != hash0 {
+		t.Fatalf("canonical hash height 0 mismatch")
+	}
+}
+
+func TestBlockStoreReorgAndRewindHooks(t *testing.T) {
+	store, err := OpenBlockStore(filepath.Join(t.TempDir(), "blockstore"))
+	if err != nil {
+		t.Fatalf("open blockstore: %v", err)
+	}
+
+	header0 := testHeaderBytes(10, 1)
+	hash0, _ := consensus.BlockHash(header0)
+	if err := store.PutBlock(0, hash0, header0, []byte("b0")); err != nil {
+		t.Fatalf("put b0: %v", err)
+	}
+
+	header1a := testHeaderBytes(11, 2)
+	hash1a, _ := consensus.BlockHash(header1a)
+	if err := store.PutBlock(1, hash1a, header1a, []byte("b1a")); err != nil {
+		t.Fatalf("put b1a: %v", err)
+	}
+
+	header1b := testHeaderBytes(12, 3)
+	hash1b, _ := consensus.BlockHash(header1b)
+	if err := store.PutBlock(1, hash1b, header1b, []byte("b1b")); err != nil {
+		t.Fatalf("put b1b (reorg): %v", err)
+	}
+
+	tipHeight, tipHash, ok, err := store.Tip()
+	if err != nil {
+		t.Fatalf("tip after reorg: %v", err)
+	}
+	if !ok || tipHeight != 1 || tipHash != hash1b {
+		t.Fatalf("unexpected tip after reorg: ok=%v height=%d hash=%x", ok, tipHeight, tipHash)
+	}
+
+	if err := store.RewindToHeight(0); err != nil {
+		t.Fatalf("rewind to height 0: %v", err)
+	}
+	tipHeight, tipHash, ok, err = store.Tip()
+	if err != nil {
+		t.Fatalf("tip after rewind: %v", err)
+	}
+	if !ok || tipHeight != 0 || tipHash != hash0 {
+		t.Fatalf("unexpected tip after rewind: ok=%v height=%d hash=%x", ok, tipHeight, tipHash)
+	}
+}
+
+func TestBlockStoreRejectsHeightGap(t *testing.T) {
+	store, err := OpenBlockStore(filepath.Join(t.TempDir(), "blockstore"))
+	if err != nil {
+		t.Fatalf("open blockstore: %v", err)
+	}
+	header := testHeaderBytes(3, 33)
+	hash, _ := consensus.BlockHash(header)
+	if err := store.PutBlock(2, hash, header, []byte("gapped")); err == nil {
+		t.Fatalf("expected height gap error")
+	}
+}
+
+func TestBlockStorePersistsIndex(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "blockstore")
+	store, err := OpenBlockStore(root)
+	if err != nil {
+		t.Fatalf("open blockstore: %v", err)
+	}
+	header := testHeaderBytes(7, 77)
+	hash, _ := consensus.BlockHash(header)
+	if err := store.PutBlock(0, hash, header, []byte("persist")); err != nil {
+		t.Fatalf("put block: %v", err)
+	}
+
+	reopened, err := OpenBlockStore(root)
+	if err != nil {
+		t.Fatalf("reopen blockstore: %v", err)
+	}
+	height, gotHash, ok, err := reopened.Tip()
+	if err != nil {
+		t.Fatalf("tip after reopen: %v", err)
+	}
+	if !ok || height != 0 || gotHash != hash {
+		t.Fatalf("unexpected tip after reopen: ok=%v height=%d hash=%x", ok, height, gotHash)
+	}
+}
+
+func testHeaderBytes(seed byte, nonce uint64) []byte {
+	header := make([]byte, consensus.BLOCK_HEADER_BYTES)
+	binary.LittleEndian.PutUint32(header[0:4], 1)
+	for i := 4; i < 36; i++ {
+		header[i] = seed
+	}
+	for i := 36; i < 68; i++ {
+		header[i] = seed + 1
+	}
+	binary.LittleEndian.PutUint64(header[68:76], 123)
+	for i := 76; i < 108; i++ {
+		header[i] = 0xff
+	}
+	binary.LittleEndian.PutUint64(header[108:116], nonce)
+	return header
+}

--- a/clients/go/node/chainstate.go
+++ b/clients/go/node/chainstate.go
@@ -1,0 +1,301 @@
+package node
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+)
+
+const (
+	chainStateDiskVersion = 1
+	chainStateFileName    = "chainstate.json"
+)
+
+type ChainState struct {
+	HasTip           bool
+	Height           uint64
+	TipHash          [32]byte
+	AlreadyGenerated uint64
+	Utxos            map[consensus.Outpoint]consensus.UtxoEntry
+}
+
+type ChainStateConnectSummary struct {
+	BlockHeight        uint64
+	BlockHash          [32]byte
+	SumFees            uint64
+	AlreadyGenerated   uint64
+	AlreadyGeneratedN1 uint64
+	UtxoCount          uint64
+}
+
+type chainStateDisk struct {
+	Version          uint32          `json:"version"`
+	HasTip           bool            `json:"has_tip"`
+	Height           uint64          `json:"height"`
+	TipHash          string          `json:"tip_hash"`
+	AlreadyGenerated uint64          `json:"already_generated"`
+	Utxos            []utxoDiskEntry `json:"utxos"`
+}
+
+type utxoDiskEntry struct {
+	Txid              string `json:"txid"`
+	Vout              uint32 `json:"vout"`
+	Value             uint64 `json:"value"`
+	CovenantType      uint16 `json:"covenant_type"`
+	CovenantData      string `json:"covenant_data"`
+	CreationHeight    uint64 `json:"creation_height"`
+	CreatedByCoinbase bool   `json:"created_by_coinbase"`
+}
+
+func NewChainState() *ChainState {
+	return &ChainState{
+		Utxos: make(map[consensus.Outpoint]consensus.UtxoEntry),
+	}
+}
+
+func ChainStatePath(dataDir string) string {
+	return filepath.Join(dataDir, chainStateFileName)
+}
+
+func LoadChainState(path string) (*ChainState, error) {
+	raw, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return NewChainState(), nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var disk chainStateDisk
+	if err := json.Unmarshal(raw, &disk); err != nil {
+		return nil, fmt.Errorf("decode chainstate: %w", err)
+	}
+	return chainStateFromDisk(disk)
+}
+
+func (s *ChainState) Save(path string) error {
+	if s == nil {
+		return errors.New("nil chainstate")
+	}
+	disk, err := stateToDisk(s)
+	if err != nil {
+		return err
+	}
+	raw, err := json.MarshalIndent(disk, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode chainstate: %w", err)
+	}
+	raw = append(raw, '\n')
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return writeFileAtomic(path, raw, 0o644)
+}
+
+func (s *ChainState) ConnectBlock(
+	blockBytes []byte,
+	expectedTarget *[32]byte,
+	prevTimestamps []uint64,
+	chainID [32]byte,
+) (*ChainStateConnectSummary, error) {
+	if s == nil {
+		return nil, errors.New("nil chainstate")
+	}
+	if s.Utxos == nil {
+		s.Utxos = make(map[consensus.Outpoint]consensus.UtxoEntry)
+	}
+	blockHeight, expectedPrevHash, err := nextBlockContext(s)
+	if err != nil {
+		return nil, err
+	}
+
+	workState := consensus.InMemoryChainState{
+		Utxos:            copyUtxoSet(s.Utxos),
+		AlreadyGenerated: s.AlreadyGenerated,
+	}
+	summary, err := consensus.ConnectBlockBasicInMemoryAtHeight(
+		blockBytes,
+		expectedPrevHash,
+		expectedTarget,
+		blockHeight,
+		prevTimestamps,
+		&workState,
+		chainID,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	pb, err := consensus.ParseBlockBytes(blockBytes)
+	if err != nil {
+		return nil, err
+	}
+	blockHash, err := consensus.BlockHash(pb.HeaderBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	s.HasTip = true
+	s.Height = blockHeight
+	s.TipHash = blockHash
+	s.AlreadyGenerated = workState.AlreadyGenerated
+	s.Utxos = workState.Utxos
+
+	return &ChainStateConnectSummary{
+		BlockHeight:        blockHeight,
+		BlockHash:          blockHash,
+		SumFees:            summary.SumFees,
+		AlreadyGenerated:   summary.AlreadyGenerated,
+		AlreadyGeneratedN1: summary.AlreadyGeneratedN1,
+		UtxoCount:          summary.UtxoCount,
+	}, nil
+}
+
+func nextBlockContext(s *ChainState) (uint64, *[32]byte, error) {
+	if s == nil {
+		return 0, nil, errors.New("nil chainstate")
+	}
+	if !s.HasTip {
+		return 0, nil, nil
+	}
+	if s.Height == math.MaxUint64 {
+		return 0, nil, errors.New("height overflow")
+	}
+	nextHeight := s.Height + 1
+	prev := s.TipHash
+	return nextHeight, &prev, nil
+}
+
+func copyUtxoSet(src map[consensus.Outpoint]consensus.UtxoEntry) map[consensus.Outpoint]consensus.UtxoEntry {
+	out := make(map[consensus.Outpoint]consensus.UtxoEntry, len(src))
+	for k, v := range src {
+		out[k] = consensus.UtxoEntry{
+			Value:             v.Value,
+			CovenantType:      v.CovenantType,
+			CovenantData:      append([]byte(nil), v.CovenantData...),
+			CreationHeight:    v.CreationHeight,
+			CreatedByCoinbase: v.CreatedByCoinbase,
+		}
+	}
+	return out
+}
+
+func stateToDisk(s *ChainState) (chainStateDisk, error) {
+	if s == nil {
+		return chainStateDisk{}, errors.New("nil chainstate")
+	}
+	utxos := make([]utxoDiskEntry, 0, len(s.Utxos))
+	for op, entry := range s.Utxos {
+		utxos = append(utxos, utxoDiskEntry{
+			Txid:              hex.EncodeToString(op.Txid[:]),
+			Vout:              op.Vout,
+			Value:             entry.Value,
+			CovenantType:      entry.CovenantType,
+			CovenantData:      hex.EncodeToString(entry.CovenantData),
+			CreationHeight:    entry.CreationHeight,
+			CreatedByCoinbase: entry.CreatedByCoinbase,
+		})
+	}
+	sort.Slice(utxos, func(i, j int) bool {
+		if utxos[i].Txid != utxos[j].Txid {
+			return utxos[i].Txid < utxos[j].Txid
+		}
+		return utxos[i].Vout < utxos[j].Vout
+	})
+
+	return chainStateDisk{
+		Version:          chainStateDiskVersion,
+		HasTip:           s.HasTip,
+		Height:           s.Height,
+		TipHash:          hex.EncodeToString(s.TipHash[:]),
+		AlreadyGenerated: s.AlreadyGenerated,
+		Utxos:            utxos,
+	}, nil
+}
+
+func chainStateFromDisk(disk chainStateDisk) (*ChainState, error) {
+	if disk.Version != chainStateDiskVersion {
+		return nil, fmt.Errorf("unsupported chainstate version: %d", disk.Version)
+	}
+
+	tipHash, err := parseHex32("tip_hash", disk.TipHash)
+	if err != nil {
+		return nil, err
+	}
+	utxos := make(map[consensus.Outpoint]consensus.UtxoEntry, len(disk.Utxos))
+	for _, item := range disk.Utxos {
+		txid, err := parseHex32("utxo.txid", item.Txid)
+		if err != nil {
+			return nil, err
+		}
+		covData, err := parseHex("utxo.covenant_data", item.CovenantData)
+		if err != nil {
+			return nil, err
+		}
+		op := consensus.Outpoint{
+			Txid: txid,
+			Vout: item.Vout,
+		}
+		if _, exists := utxos[op]; exists {
+			return nil, fmt.Errorf("duplicate utxo outpoint: %s:%d", item.Txid, item.Vout)
+		}
+		utxos[op] = consensus.UtxoEntry{
+			Value:             item.Value,
+			CovenantType:      item.CovenantType,
+			CovenantData:      covData,
+			CreationHeight:    item.CreationHeight,
+			CreatedByCoinbase: item.CreatedByCoinbase,
+		}
+	}
+	return &ChainState{
+		HasTip:           disk.HasTip,
+		Height:           disk.Height,
+		TipHash:          tipHash,
+		AlreadyGenerated: disk.AlreadyGenerated,
+		Utxos:            utxos,
+	}, nil
+}
+
+func parseHex(name, value string) ([]byte, error) {
+	trimmed := strings.TrimSpace(value)
+	if len(trimmed)%2 != 0 {
+		return nil, fmt.Errorf("%s: odd-length hex", name)
+	}
+	out, err := hex.DecodeString(trimmed)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", name, err)
+	}
+	return out, nil
+}
+
+func parseHex32(name, value string) ([32]byte, error) {
+	var out [32]byte
+	raw, err := parseHex(name, value)
+	if err != nil {
+		return out, err
+	}
+	if len(raw) != 32 {
+		return out, fmt.Errorf("%s: expected 32 bytes, got %d", name, len(raw))
+	}
+	copy(out[:], raw)
+	return out, nil
+}
+
+func writeFileAtomic(path string, data []byte, mode os.FileMode) error {
+	tmpPath := fmt.Sprintf("%s.tmp.%d", path, os.Getpid())
+	if err := os.WriteFile(tmpPath, data, mode); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	return nil
+}

--- a/clients/go/node/chainstate_test.go
+++ b/clients/go/node/chainstate_test.go
@@ -1,0 +1,349 @@
+package node
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"slices"
+	"testing"
+
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+)
+
+func TestChainStateSaveLoadRoundTripDeterministic(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "chainstate.json")
+
+	st := NewChainState()
+	st.HasTip = true
+	st.Height = 42
+	st.AlreadyGenerated = 123_456
+	st.TipHash = mustHash32Hex(t, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+
+	st.Utxos[consensus.Outpoint{
+		Txid: mustHash32Hex(t, "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
+		Vout: 2,
+	}] = consensus.UtxoEntry{
+		Value:             100,
+		CovenantType:      consensus.COV_TYPE_P2PK,
+		CovenantData:      testP2PKCovenantData(0x55),
+		CreationHeight:    8,
+		CreatedByCoinbase: true,
+	}
+	st.Utxos[consensus.Outpoint{
+		Txid: mustHash32Hex(t, "0101010101010101010101010101010101010101010101010101010101010101"),
+		Vout: 0,
+	}] = consensus.UtxoEntry{
+		Value:             7,
+		CovenantType:      consensus.COV_TYPE_MULTISIG,
+		CovenantData:      []byte{0x01, 0x01, 0x01, 0x01},
+		CreationHeight:    3,
+		CreatedByCoinbase: false,
+	}
+
+	if err := st.Save(path); err != nil {
+		t.Fatalf("save chainstate: %v", err)
+	}
+	firstBytes, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read chainstate file: %v", err)
+	}
+
+	if err := st.Save(path); err != nil {
+		t.Fatalf("save chainstate second time: %v", err)
+	}
+	secondBytes, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read chainstate file second time: %v", err)
+	}
+	if !bytes.Equal(firstBytes, secondBytes) {
+		t.Fatalf("chainstate encoding is not deterministic")
+	}
+
+	var disk chainStateDisk
+	if err := json.Unmarshal(firstBytes, &disk); err != nil {
+		t.Fatalf("decode disk chainstate: %v", err)
+	}
+	if len(disk.Utxos) != 2 {
+		t.Fatalf("disk utxos=%d, want 2", len(disk.Utxos))
+	}
+	if !slices.IsSortedFunc(disk.Utxos, func(a, b utxoDiskEntry) int {
+		if a.Txid < b.Txid {
+			return -1
+		}
+		if a.Txid > b.Txid {
+			return 1
+		}
+		if a.Vout < b.Vout {
+			return -1
+		}
+		if a.Vout > b.Vout {
+			return 1
+		}
+		return 0
+	}) {
+		t.Fatalf("disk utxo order is not sorted")
+	}
+
+	loaded, err := LoadChainState(path)
+	if err != nil {
+		t.Fatalf("load chainstate: %v", err)
+	}
+	if !equalChainState(st, loaded) {
+		t.Fatalf("loaded chainstate mismatch")
+	}
+}
+
+func TestChainStateConnectBlockDeterministicUpdate(t *testing.T) {
+	target := consensus.POW_LIMIT
+	var chainID [32]byte
+
+	st := NewChainState()
+	genesisPrev := mustHash32Hex(t, "1111111111111111111111111111111111111111111111111111111111111111")
+	genesisCoinbase := coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 0, 1)
+	genesisBlock := buildSingleTxBlock(t, genesisPrev, target, 1, genesisCoinbase)
+
+	first, err := st.ConnectBlock(genesisBlock, &target, nil, chainID)
+	if err != nil {
+		t.Fatalf("connect genesis-like block: %v", err)
+	}
+	if first.BlockHeight != 0 {
+		t.Fatalf("first block height=%d, want 0", first.BlockHeight)
+	}
+	if !st.HasTip || st.Height != 0 {
+		t.Fatalf("unexpected tip after first block: has_tip=%v height=%d", st.HasTip, st.Height)
+	}
+	if st.AlreadyGenerated != 0 {
+		t.Fatalf("already_generated after height 0=%d, want 0", st.AlreadyGenerated)
+	}
+	if len(st.Utxos) != 1 {
+		t.Fatalf("utxo_count after first block=%d, want 1", len(st.Utxos))
+	}
+
+	subsidy1 := consensus.BlockSubsidy(1, 0)
+	block1Coinbase := coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 1, subsidy1)
+	block1 := buildSingleTxBlock(t, st.TipHash, target, 2, block1Coinbase)
+	second, err := st.ConnectBlock(block1, &target, nil, chainID)
+	if err != nil {
+		t.Fatalf("connect height-1 block: %v", err)
+	}
+	if second.BlockHeight != 1 {
+		t.Fatalf("second block height=%d, want 1", second.BlockHeight)
+	}
+	if st.Height != 1 {
+		t.Fatalf("state height=%d, want 1", st.Height)
+	}
+	if st.AlreadyGenerated != subsidy1 {
+		t.Fatalf("already_generated=%d, want %d", st.AlreadyGenerated, subsidy1)
+	}
+	if len(st.Utxos) != 2 {
+		t.Fatalf("utxo_count=%d, want 2", len(st.Utxos))
+	}
+}
+
+func TestChainStateConnectBlockNoMutationOnFailure(t *testing.T) {
+	st := NewChainState()
+	st.HasTip = true
+	st.Height = 3
+	st.TipHash = mustHash32Hex(t, "2222222222222222222222222222222222222222222222222222222222222222")
+	st.AlreadyGenerated = 77
+	st.Utxos[consensus.Outpoint{
+		Txid: mustHash32Hex(t, "3333333333333333333333333333333333333333333333333333333333333333"),
+		Vout: 1,
+	}] = consensus.UtxoEntry{
+		Value:             9,
+		CovenantType:      consensus.COV_TYPE_P2PK,
+		CovenantData:      testP2PKCovenantData(0x21),
+		CreationHeight:    2,
+		CreatedByCoinbase: false,
+	}
+
+	before, err := stateToDisk(st)
+	if err != nil {
+		t.Fatalf("stateToDisk before: %v", err)
+	}
+
+	var target [32]byte
+	_, err = st.ConnectBlock([]byte{0x00, 0x01, 0x02}, &target, nil, [32]byte{})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+
+	after, err := stateToDisk(st)
+	if err != nil {
+		t.Fatalf("stateToDisk after: %v", err)
+	}
+	if !reflect.DeepEqual(before, after) {
+		t.Fatalf("chainstate mutated on failed connect")
+	}
+}
+
+func TestLoadChainStateNotFoundReturnsEmpty(t *testing.T) {
+	st, err := LoadChainState(filepath.Join(t.TempDir(), "missing.json"))
+	if err != nil {
+		t.Fatalf("load missing chainstate: %v", err)
+	}
+	if st == nil || st.Utxos == nil || len(st.Utxos) != 0 {
+		t.Fatalf("unexpected missing-load state: %+v", st)
+	}
+}
+
+func equalChainState(a, b *ChainState) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	if a.HasTip != b.HasTip ||
+		a.Height != b.Height ||
+		a.TipHash != b.TipHash ||
+		a.AlreadyGenerated != b.AlreadyGenerated ||
+		len(a.Utxos) != len(b.Utxos) {
+		return false
+	}
+	for op, ae := range a.Utxos {
+		be, ok := b.Utxos[op]
+		if !ok {
+			return false
+		}
+		if ae.Value != be.Value ||
+			ae.CovenantType != be.CovenantType ||
+			ae.CreationHeight != be.CreationHeight ||
+			ae.CreatedByCoinbase != be.CreatedByCoinbase ||
+			!bytes.Equal(ae.CovenantData, be.CovenantData) {
+			return false
+		}
+	}
+	return true
+}
+
+type testOutput struct {
+	value        uint64
+	covenantType uint16
+	covenantData []byte
+}
+
+func buildSingleTxBlock(t *testing.T, prevHash [32]byte, target [32]byte, timestamp uint64, tx []byte) []byte {
+	t.Helper()
+	_, txid, _, _, err := consensus.ParseTx(tx)
+	if err != nil {
+		t.Fatalf("parse tx: %v", err)
+	}
+	root, err := consensus.MerkleRootTxids([][32]byte{txid})
+	if err != nil {
+		t.Fatalf("merkle root: %v", err)
+	}
+	header := make([]byte, 0, consensus.BLOCK_HEADER_BYTES)
+	header = appendU32le(header, 1)
+	header = append(header, prevHash[:]...)
+	header = append(header, root[:]...)
+	header = appendU64le(header, timestamp)
+	header = append(header, target[:]...)
+	header = appendU64le(header, 7)
+
+	block := make([]byte, 0, len(header)+len(tx)+4)
+	block = append(block, header...)
+	block = appendCompactSize(block, 1)
+	block = append(block, tx...)
+	return block
+}
+
+func coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t *testing.T, height uint64, value uint64) []byte {
+	t.Helper()
+	wtxids := [][32]byte{{}}
+	wroot, err := consensus.WitnessMerkleRootWtxids(wtxids)
+	if err != nil {
+		t.Fatalf("witness merkle root: %v", err)
+	}
+	commitment := consensus.WitnessCommitmentHash(wroot)
+	return coinbaseTxWithOutputs(uint32(height), []testOutput{
+		{value: value, covenantType: consensus.COV_TYPE_P2PK, covenantData: testP2PKCovenantData(0x11)},
+		{value: 0, covenantType: consensus.COV_TYPE_ANCHOR, covenantData: commitment[:]},
+	})
+}
+
+func coinbaseTxWithOutputs(locktime uint32, outputs []testOutput) []byte {
+	sizeHint := 128
+	for _, out := range outputs {
+		sizeHint += 16 + len(out.covenantData)
+	}
+	b := make([]byte, 0, sizeHint)
+	b = appendU32le(b, 1)
+	b = append(b, 0x00)
+	b = appendU64le(b, 0)
+	b = appendCompactSize(b, 1)
+	b = append(b, make([]byte, 32)...)
+	b = appendU32le(b, ^uint32(0))
+	b = appendCompactSize(b, 0)
+	b = appendU32le(b, ^uint32(0))
+	b = appendCompactSize(b, uint64(len(outputs)))
+	for _, out := range outputs {
+		b = appendU64le(b, out.value)
+		b = appendU16le(b, out.covenantType)
+		b = appendCompactSize(b, uint64(len(out.covenantData)))
+		b = append(b, out.covenantData...)
+	}
+	b = appendU32le(b, locktime)
+	b = appendCompactSize(b, 0)
+	b = appendCompactSize(b, 0)
+	return b
+}
+
+func appendCompactSize(dst []byte, v uint64) []byte {
+	switch {
+	case v < 0xfd:
+		return append(dst, byte(v))
+	case v <= 0xffff:
+		dst = append(dst, 0xfd)
+		return appendU16le(dst, uint16(v))
+	case v <= 0xffff_ffff:
+		dst = append(dst, 0xfe)
+		return appendU32le(dst, uint32(v))
+	default:
+		dst = append(dst, 0xff)
+		return appendU64le(dst, v)
+	}
+}
+
+func appendU16le(dst []byte, v uint16) []byte {
+	var buf [2]byte
+	binary.LittleEndian.PutUint16(buf[:], v)
+	return append(dst, buf[:]...)
+}
+
+func appendU32le(dst []byte, v uint32) []byte {
+	var buf [4]byte
+	binary.LittleEndian.PutUint32(buf[:], v)
+	return append(dst, buf[:]...)
+}
+
+func appendU64le(dst []byte, v uint64) []byte {
+	var buf [8]byte
+	binary.LittleEndian.PutUint64(buf[:], v)
+	return append(dst, buf[:]...)
+}
+
+func testP2PKCovenantData(seed byte) []byte {
+	data := make([]byte, consensus.MAX_P2PK_COVENANT_DATA)
+	data[0] = consensus.SUITE_ID_ML_DSA_87
+	for i := 1; i < len(data); i++ {
+		data[i] = seed + byte(i)
+	}
+	return data
+}
+
+func mustHash32Hex(t *testing.T, s string) [32]byte {
+	t.Helper()
+	var out [32]byte
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		t.Fatalf("decode hash hex: %v", err)
+	}
+	if len(b) != 32 {
+		t.Fatalf("hash length=%d, want 32", len(b))
+	}
+	copy(out[:], b)
+	return out
+}


### PR DESCRIPTION
## What
- add persistent Go chainstate (`clients/go/node/chainstate.go`) with disk load/save
- enforce deterministic state transition: connect on a work-copy, commit only on success
- persist fields: tip hash, height, already_generated, UTXO snapshot
- add minimal Go block/header store (`clients/go/node/blockstore.go`) with canonical index and reorg hooks (`SetCanonicalTip`, `RewindToHeight`)
- wire node startup to initialize/open chainstate and blockstore and print status in dry-run

## Tests
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./...'`
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go run ./cmd/rubin-node --dry-run --datadir /tmp/rubin-node-dryrun-test'`

## Queue linkage
- NODE-CHAINSTATE-01
- NODE-BLOCKSTORE-01
