### PR TITLE
ci: scope OpenSSL env in formal_refinement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,7 @@ jobs:
           key: openssl-bundle-${{ runner.os }}-3.5.5-v2
 
       - name: Build OpenSSL 3.5.5 bundle
+        id: openssl
         run: |
           set -euo pipefail
           PREFIX="$HOME/.cache/rubin-openssl/bundle-3.5.5"
@@ -239,13 +240,19 @@ jobs:
             exit 1
           fi
           echo "$PREFIX/bin" >> "$GITHUB_PATH"
-          echo "OPENSSL_DIR=$PREFIX" >> "$GITHUB_ENV"
-          echo "PKG_CONFIG_PATH=$PREFIX/lib64/pkgconfig:$PREFIX/lib/pkgconfig" >> "$GITHUB_ENV"
-          echo "LD_LIBRARY_PATH=$PREFIX/lib64:$PREFIX/lib" >> "$GITHUB_ENV"
-          echo "OPENSSL_MODULES=$MODULES_DIR" >> "$GITHUB_ENV"
-          echo "OPENSSL_CONF=$PREFIX/ssl/openssl-fips.cnf" >> "$GITHUB_ENV"
+          echo "openssl_dir=$PREFIX" >> "$GITHUB_OUTPUT"
+          echo "openssl_modules=$MODULES_DIR" >> "$GITHUB_OUTPUT"
+          echo "openssl_conf=$PREFIX/ssl/openssl-fips.cnf" >> "$GITHUB_OUTPUT"
+          echo "pkg_config_path=$PREFIX/lib64/pkgconfig:$PREFIX/lib/pkgconfig" >> "$GITHUB_OUTPUT"
+          echo "ld_library_path=$PREFIX/lib64:$PREFIX/lib" >> "$GITHUB_OUTPUT"
 
       - name: Verify OpenSSL PQ algorithms
+        env:
+          OPENSSL_DIR: ${{ steps.openssl.outputs.openssl_dir }}
+          OPENSSL_MODULES: ${{ steps.openssl.outputs.openssl_modules }}
+          OPENSSL_CONF: ${{ steps.openssl.outputs.openssl_conf }}
+          PKG_CONFIG_PATH: ${{ steps.openssl.outputs.pkg_config_path }}
+          LD_LIBRARY_PATH: ${{ steps.openssl.outputs.ld_library_path }}
         run: |
           openssl version
           openssl list -signature-algorithms | grep -E 'ML-DSA-87|SLH-DSA-SHAKE-256f'


### PR DESCRIPTION
Hardens CI job `formal_refinement`: OpenSSL/FIPS env is now scoped to only the steps that need it (openssl list + Go trace), and is no longer written into `$GITHUB_ENV`.

This removes global environment coupling and avoids Lean/elan/lake networking breakage from OpenSSL/FIPS overrides.
