### PR TITLE
docs: remove chmod +x from OpenSSL examples

### DIFF
--- a/scripts/crypto/openssl/README.md
+++ b/scripts/crypto/openssl/README.md
@@ -65,6 +65,7 @@ Interpretation:
 ## Optional fallback benchmark (`pkeyutl` loop)
 
 ```bash
+cd <REPO_ROOT>
 scripts/dev-env.sh -- python3 scripts/crypto/openssl/bench-pq-pkeyutl.py \
   --openssl-bin "$HOME/.cache/rubin-openssl/bundle-<version>/bin/openssl" \
   --output-json <OUTPUT_JSON_PATH>


### PR DESCRIPTION
Removes runtime chmod from docs and invokes scripts via bash/python3 through scripts/dev-env.sh.