### PR TITLE
ci: add mandatory validator aggregate gate for PR merges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,3 +289,31 @@ jobs:
         run: |
           cd rubin-formal
           lake env lean --run RubinFormal/Refinement/Main.lean
+
+  validator:
+    name: validator
+    needs: [policy, formal, test, formal_refinement]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce validator-gate dependencies
+        run: |
+          declare -A results=(
+            [policy]="${{ needs.policy.result }}"
+            [formal]="${{ needs.formal.result }}"
+            [test]="${{ needs.test.result }}"
+            [formal_refinement]="${{ needs.formal_refinement.result }}"
+          )
+          failed=0
+          for key in policy formal test formal_refinement; do
+            value="${results[$key]}"
+            echo "$key=$value"
+            if [ "$value" != "success" ]; then
+              failed=1
+            fi
+          done
+          if [ "$failed" -ne 0 ]; then
+            echo "validator gate failed: one or more prerequisite jobs did not succeed" >&2
+            exit 1
+          fi
+          echo "validator gate passed"

--- a/README.md
+++ b/README.md
@@ -69,3 +69,4 @@ The runner requires Go and Rust to return identical `ok/err` behavior and identi
 
 - Local orchestration/queue files live outside the repository and MUST NOT be committed.
 - CI blocks sensitive assets from entering public repo (`tools/check_sensitive_files.py`).
+- PR merge gate includes `validator` check, which is an aggregate status over `policy` + `formal` + `test` + `formal_refinement`.


### PR DESCRIPTION
## Summary
- add a new `validator` CI job that aggregates and enforces success of `policy`, `formal`, `test`, and `formal_refinement`
- make the aggregate job explicit for branch protection and merge gating
- document the new merge gate in README Notes

## Why
- ensures a single required status check can represent full validator readiness before merge
- avoids ambiguous merge decisions when individual checks are green but no aggregate gate exists

## Validation
- workflow updated in `.github/workflows/ci.yml`
- local sanity checks:
  - `git diff --check`
  - grep verification of new `validator` job and README note


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a validator gate to the continuous integration workflow that aggregates status results from policy, formal, test, and formal_refinement jobs. The gate ensures all prerequisite checks pass successfully before code can be merged.

* **Documentation**
  * Updated README to document the validator check included in the merge gate process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->