### PR TITLE
chore: disable CodeRabbit PR checks

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,17 @@
+# CodeRabbit config
+# цель: полностью убрать CodeRabbit из CI/PR checks (не постить commit status)
+# и выключить авто-ревью.
+
+language: en-US
+
+enable_free_tier: false
+
+early_access: false
+
+reviews:
+  auto_review:
+    enabled: false
+  auto_incremental_review: false
+  commit_status: false
+  fail_commit_status: false
+  review_status: false


### PR DESCRIPTION
Disables CodeRabbit auto-review and commit status checks via .coderabbit.yaml.\n\nRationale: CodeRabbit is intermittently failing with rate-limit errors and is not a required gate for this repo.