### PR TITLE
ci: add shared security-ai precheck gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,37 @@ jobs:
       - name: Sensitive files/content gate
         run: python3 tools/check_sensitive_files.py
 
+  security_ai:
+    needs: policy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.24.13'
+          cache: true
+          cache-dependency-path: clients/go/go.mod
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Semgrep
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install semgrep
+
+      - name: Install gosec + govulncheck
+        run: |
+          go install github.com/securego/gosec/v2/cmd/gosec@latest
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+
+      - name: Security precheck gate
+        run: scripts/security/precheck.sh --ci
+
   formal:
     needs: policy
     runs-on: ubuntu-latest
@@ -292,7 +323,7 @@ jobs:
 
   validator:
     name: validator
-    needs: [policy, formal, test, formal_refinement]
+    needs: [policy, security_ai, formal, test, formal_refinement]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
@@ -300,12 +331,13 @@ jobs:
         run: |
           declare -A results=(
             [policy]="${{ needs.policy.result }}"
+            [security_ai]="${{ needs.security_ai.result }}"
             [formal]="${{ needs.formal.result }}"
             [test]="${{ needs.test.result }}"
             [formal_refinement]="${{ needs.formal_refinement.result }}"
           )
           failed=0
-          for key in policy formal test formal_refinement; do
+          for key in policy security_ai formal test formal_refinement; do
             value="${results[$key]}"
             echo "$key=$value"
             if [ "$value" != "success" ]; then

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ cd rubin-protocol
 
 scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./...'
 scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test --workspace'
+scripts/dev-env.sh -- scripts/security/precheck.sh --local
 ```
 
 Run cross-client conformance (builds local CLIs into `./conformance/bin/`):
@@ -69,4 +70,4 @@ The runner requires Go and Rust to return identical `ok/err` behavior and identi
 
 - Local orchestration/queue files live outside the repository and MUST NOT be committed.
 - CI blocks sensitive assets from entering public repo (`tools/check_sensitive_files.py`).
-- PR merge gate includes `validator` check, which is an aggregate status over `policy` + `formal` + `test` + `formal_refinement`.
+- PR merge gate includes `validator` check, which is an aggregate status over `policy` + `security_ai` + `formal` + `test` + `formal_refinement`.

--- a/scripts/security/precheck.sh
+++ b/scripts/security/precheck.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+MODE="${1:---local}"
+export PATH="$(go env GOPATH)/bin:$HOME/.cargo/bin:$HOME/.local/bin:$PATH"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/security/precheck.sh [--local|--ci]
+
+Description:
+  Runs a shared security precheck pipeline for local runs and GitHub Actions:
+    - semgrep (ERROR severity only)
+    - gosec (high severity + high confidence)
+    - govulncheck (Go)
+    - cargo audit (Rust)
+EOF
+}
+
+require_cmd() {
+  local command_name="$1"
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    echo "ERROR: required command not found: $command_name" >&2
+    exit 1
+  fi
+}
+
+ensure_semgrep() {
+  if command -v semgrep >/dev/null 2>&1; then
+    return 0
+  fi
+  echo "semgrep not found; installing with pip --user"
+  python3 -m pip install --user semgrep
+  export PATH="$HOME/.local/bin:$PATH"
+  require_cmd semgrep
+}
+
+ensure_go_tool() {
+  local tool_name="$1"
+  local module_path="$2"
+  if command -v "$tool_name" >/dev/null 2>&1; then
+    return 0
+  fi
+  echo "$tool_name not found; installing via go install $module_path"
+  go install "$module_path"
+  export PATH="$(go env GOPATH)/bin:$PATH"
+  require_cmd "$tool_name"
+}
+
+ensure_cargo_tool() {
+  local tool_name="$1"
+  local install_name="$2"
+  if command -v "$tool_name" >/dev/null 2>&1; then
+    return 0
+  fi
+  echo "$tool_name not found; installing via cargo install $install_name"
+  cargo install "$install_name" --locked
+  require_cmd "$tool_name"
+}
+
+log_step() {
+  echo
+  echo "==> $1"
+}
+
+case "$MODE" in
+  --local|--ci) ;;
+  --help|-h)
+    usage
+    exit 0
+    ;;
+  *)
+    echo "ERROR: unknown mode: $MODE" >&2
+    usage
+    exit 1
+    ;;
+esac
+
+require_cmd go
+require_cmd cargo
+ensure_semgrep
+ensure_go_tool gosec github.com/securego/gosec/v2/cmd/gosec@latest
+ensure_go_tool govulncheck golang.org/x/vuln/cmd/govulncheck@latest
+ensure_cargo_tool cargo-audit cargo-audit
+
+log_step "Semgrep (ERROR severity)"
+SEMGREP_RULES="$ROOT_DIR/tools/security/semgrep-rules.yml"
+if [[ ! -f "$SEMGREP_RULES" ]]; then
+  echo "ERROR: semgrep rules file not found: $SEMGREP_RULES" >&2
+  exit 1
+fi
+semgrep scan \
+  --config "$SEMGREP_RULES" \
+  --error \
+  --metrics=off \
+  "$ROOT_DIR/clients/go" \
+  "$ROOT_DIR/clients/rust"
+
+log_step "gosec (high/high)"
+(
+  cd "$ROOT_DIR/clients/go"
+  gosec -severity high -confidence high -fmt text ./...
+)
+
+log_step "govulncheck"
+(
+  cd "$ROOT_DIR/clients/go"
+  govulncheck ./...
+)
+
+log_step "cargo audit"
+(
+  cd "$ROOT_DIR/clients/rust"
+  cargo audit --deny warnings
+)
+
+echo
+echo "security precheck: PASS"

--- a/tools/security/semgrep-rules.yml
+++ b/tools/security/semgrep-rules.yml
@@ -1,0 +1,24 @@
+rules:
+  - id: rubin.go.no-crypto-md5
+    message: "MD5 is forbidden in consensus/security code."
+    severity: ERROR
+    languages: [go]
+    pattern: "crypto/md5"
+
+  - id: rubin.go.no-crypto-sha1
+    message: "SHA-1 is forbidden in consensus/security code."
+    severity: ERROR
+    languages: [go]
+    pattern: "crypto/sha1"
+
+  - id: rubin.rust.no-md5
+    message: "MD5 crate usage is forbidden in consensus/security code."
+    severity: ERROR
+    languages: [rust]
+    pattern-regex: "\\bmd5::"
+
+  - id: rubin.rust.no-sha1
+    message: "SHA-1 crate usage is forbidden in consensus/security code."
+    severity: ERROR
+    languages: [rust]
+    pattern-regex: "\\bsha1::"


### PR DESCRIPTION
## Summary
- add shared `scripts/security/precheck.sh` used locally and in CI
- add local Semgrep rules at `tools/security/semgrep-rules.yml`
- add new CI job `security_ai` and wire it into `validator` aggregate gate
- document local security precheck command in README

## Validation
- `scripts/dev-env.sh -- scripts/security/precheck.sh --local` (PASS)
- `bash -n scripts/security/precheck.sh` (PASS)
