### PR TITLE
ci: run sanity workflow on main pushes

### DIFF
--- a/.github/workflows/spec-checks.yml
+++ b/.github/workflows/spec-checks.yml
@@ -1,6 +1,8 @@
 name: public-sanity
 
 on:
+  push:
+    branches: [ main ]
   pull_request: {}
   workflow_dispatch: {}
 


### PR DESCRIPTION
## Summary
- update `public-sanity` workflow trigger to run on `push` to `main`
- keep existing `pull_request` and `workflow_dispatch` triggers

## Why
- CI minutes are not constrained; we want post-merge visibility for sanity checks on main
- avoids blind spot where `sanity` existed only on PR checks
