### PR TITLE
fix(fips-preflight): remove <unset> placeholder for Opengrep

### DIFF
--- a/scripts/crypto/openssl/fips-preflight.sh
+++ b/scripts/crypto/openssl/fips-preflight.sh
@@ -31,8 +31,8 @@ fi
 
 echo "[fips-preflight] mode=${MODE}"
 echo "[fips-preflight] openssl=$(command -v openssl || echo missing)"
-echo "[fips-preflight] OPENSSL_MODULES=${OPENSSL_MODULES:-<unset>}"
-echo "[fips-preflight] OPENSSL_CONF=${OPENSSL_CONF:-<unset>}"
+echo "[fips-preflight] OPENSSL_MODULES=${OPENSSL_MODULES:-(unset)}"
+echo "[fips-preflight] OPENSSL_CONF=${OPENSSL_CONF:-(unset)}"
 openssl version -a | sed -n '1,20p' || true
 echo
 


### PR DESCRIPTION
## Summary
- replace `<unset>` placeholders in `scripts/crypto/openssl/fips-preflight.sh`
- use `(unset)` fallback text to avoid Opengrep parser failure on shell interpolation
- no behavior change for runtime checks

## Validation
- `bash -n scripts/crypto/openssl/fips-preflight.sh`
- `/Users/gpt/Documents/rubin-protocol/scripts/dev-env.sh -- bash -lc 'cd /Users/gpt/Documents/rubin-protocol && RUBIN_OPENSSL_FIPS_MODE=off scripts/crypto/openssl/fips-preflight.sh >/tmp/fips-preflight.out && head -n 6 /tmp/fips-preflight.out'`

Closes #206
