### PR TITLE
test(go): raise coverage for subsidy/block_parse/wire_read

### DIFF
--- a/clients/go/consensus/block_parse_test.go
+++ b/clients/go/consensus/block_parse_test.go
@@ -1,0 +1,91 @@
+package consensus
+
+import "testing"
+
+func TestParseBlockHeaderBytes_RoundtripFields(t *testing.T) {
+	prev := hashWithPrefix(0x01)
+	root := hashWithPrefix(0x02)
+	target := filledHash(0xff)
+	version := uint32(7)
+	timestamp := uint64(11)
+	nonce := uint64(13)
+
+	b := make([]byte, 0, BLOCK_HEADER_BYTES)
+	b = appendU32le(b, version)
+	b = append(b, prev[:]...)
+	b = append(b, root[:]...)
+	b = appendU64le(b, timestamp)
+	b = append(b, target[:]...)
+	b = appendU64le(b, nonce)
+	if len(b) != BLOCK_HEADER_BYTES {
+		t.Fatalf("header len=%d", len(b))
+	}
+
+	h, err := ParseBlockHeaderBytes(b)
+	if err != nil {
+		t.Fatalf("ParseBlockHeaderBytes: %v", err)
+	}
+	if h.Version != version || h.PrevBlockHash != prev || h.MerkleRoot != root || h.Timestamp != timestamp || h.Target != target || h.Nonce != nonce {
+		t.Fatalf("parsed mismatch: %#v", h)
+	}
+}
+
+func TestParseBlockHeaderBytes_TooShort(t *testing.T) {
+	_, err := ParseBlockHeaderBytes(make([]byte, BLOCK_HEADER_BYTES-1))
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if got := mustTxErrCode(t, err); got != TX_ERR_PARSE {
+		t.Fatalf("code=%s, want %s", got, TX_ERR_PARSE)
+	}
+}
+
+func TestParseBlockHeaderBytes_TruncationPoints(t *testing.T) {
+	// Exercise each early-return error path from readU32le/readBytes/readU64le.
+	cases := []struct {
+		name string
+		n    int
+	}{
+		{name: "no_version", n: 0},
+		{name: "short_version", n: 3},
+		{name: "short_prev", n: 4 + 31},
+		{name: "short_merkle", n: 4 + 32 + 31},
+		{name: "short_timestamp", n: 4 + 32 + 32 + 7},
+		{name: "short_target", n: 4 + 32 + 32 + 8 + 31},
+		{name: "short_nonce", n: 4 + 32 + 32 + 8 + 32 + 7},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParseBlockHeaderBytes(make([]byte, tc.n))
+			if err == nil {
+				t.Fatalf("expected error")
+			}
+			if got := mustTxErrCode(t, err); got != TX_ERR_PARSE {
+				t.Fatalf("code=%s, want %s", got, TX_ERR_PARSE)
+			}
+		})
+	}
+}
+
+func TestBlockHash_InvalidLen(t *testing.T) {
+	_, err := BlockHash(nil)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if got := mustTxErrCode(t, err); got != TX_ERR_PARSE {
+		t.Fatalf("code=%s, want %s", got, TX_ERR_PARSE)
+	}
+}
+
+func TestBlockHash_HashMatchesSHA3(t *testing.T) {
+	header := make([]byte, BLOCK_HEADER_BYTES)
+	header[0] = 0x42
+	h, err := BlockHash(header)
+	if err != nil {
+		t.Fatalf("BlockHash: %v", err)
+	}
+	want := sha3_256(header)
+	if h != want {
+		t.Fatalf("hash mismatch")
+	}
+}

--- a/clients/go/consensus/subsidy_test.go
+++ b/clients/go/consensus/subsidy_test.go
@@ -1,0 +1,38 @@
+package consensus
+
+import "testing"
+
+func TestBlockSubsidy_Height0IsZero(t *testing.T) {
+	if got := BlockSubsidy(0, 0); got != 0 {
+		t.Fatalf("got=%d, want 0", got)
+	}
+}
+
+func TestBlockSubsidy_TailEmissionAfterCap(t *testing.T) {
+	if got := BlockSubsidy(1, MINEABLE_CAP); got != TAIL_EMISSION_PER_BLOCK {
+		t.Fatalf("got=%d, want %d", got, TAIL_EMISSION_PER_BLOCK)
+	}
+	if got := BlockSubsidy(1, MINEABLE_CAP+1); got != TAIL_EMISSION_PER_BLOCK {
+		t.Fatalf("got=%d, want %d", got, TAIL_EMISSION_PER_BLOCK)
+	}
+}
+
+func TestBlockSubsidy_ClampsToTailEmissionWhenBaseWouldUndercut(t *testing.T) {
+	// Choose alreadyGenerated such that remaining >> EMISSION_SPEED_FACTOR would be
+	// smaller than TAIL_EMISSION_PER_BLOCK, forcing the clamp.
+	alreadyGenerated := MINEABLE_CAP - (uint64(TAIL_EMISSION_PER_BLOCK-1) << EMISSION_SPEED_FACTOR)
+	got := BlockSubsidy(1, alreadyGenerated)
+	if got != TAIL_EMISSION_PER_BLOCK {
+		t.Fatalf("got=%d, want clamp %d", got, TAIL_EMISSION_PER_BLOCK)
+	}
+}
+
+func TestBlockSubsidy_BaseRewardFormula(t *testing.T) {
+	alreadyGenerated := uint64(123)
+	remaining := MINEABLE_CAP - alreadyGenerated
+	want := remaining >> EMISSION_SPEED_FACTOR
+	got := BlockSubsidy(1, alreadyGenerated)
+	if got != want {
+		t.Fatalf("got=%d, want %d", got, want)
+	}
+}

--- a/clients/go/consensus/wire_read_test.go
+++ b/clients/go/consensus/wire_read_test.go
@@ -1,0 +1,25 @@
+package consensus
+
+import "testing"
+
+func TestReadBytes_NegativeLen(t *testing.T) {
+	off := 0
+	_, err := readBytes([]byte{}, &off, -1)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if got := mustTxErrCode(t, err); got != TX_ERR_PARSE {
+		t.Fatalf("code=%s, want %s", got, TX_ERR_PARSE)
+	}
+}
+
+func TestReadBytes_UnexpectedEOF(t *testing.T) {
+	off := 0
+	_, err := readBytes([]byte{0x01, 0x02}, &off, 3)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if got := mustTxErrCode(t, err); got != TX_ERR_PARSE {
+		t.Fatalf("code=%s, want %s", got, TX_ERR_PARSE)
+	}
+}


### PR DESCRIPTION
Part of #215.

Tests-only PR to push remaining low-coverage consensus helpers above 80%:
- `clients/go/consensus/subsidy.go` (BlockSubsidy edge cases + formula)
- `clients/go/consensus/block_parse.go` (ParseBlockHeaderBytes truncation points + BlockHash)
- `clients/go/consensus/wire_read.go` (readBytes negative/EOF)
