### PR TITLE
test(go): raise coverage for spend_verify and openssl_signer

### DIFF
--- a/clients/go/consensus/openssl_signer_additional_test.go
+++ b/clients/go/consensus/openssl_signer_additional_test.go
@@ -1,0 +1,110 @@
+//go:build cgo
+
+package consensus
+
+import "testing"
+
+func TestCStringTrim0(t *testing.T) {
+	if got := cStringTrim0([]byte("abc\x00def")); got != "abc" {
+		t.Fatalf("got=%q", got)
+	}
+	if got := cStringTrim0([]byte("abc")); got != "abc" {
+		t.Fatalf("got=%q", got)
+	}
+}
+
+func TestMLDSA87Keypair_PubkeyBytesIsCopyAndCloseIdempotent(t *testing.T) {
+	kp := mustMLDSA87Keypair(t)
+
+	p1 := kp.PubkeyBytes()
+	if len(p1) != ML_DSA_87_PUBKEY_BYTES {
+		t.Fatalf("pubkey len=%d", len(p1))
+	}
+	p1[0] ^= 0x01
+
+	p2 := kp.PubkeyBytes()
+	if p2[0] == p1[0] {
+		t.Fatalf("expected PubkeyBytes to return a copy")
+	}
+
+	kp.Close()
+	kp.Close()
+
+	var nilKP *MLDSA87Keypair
+	if got := nilKP.PubkeyBytes(); got != nil {
+		t.Fatalf("expected nil for nil receiver")
+	}
+}
+
+func TestMLDSA87Keypair_SignDigest32_NilKeypairErrors(t *testing.T) {
+	var digest [32]byte
+
+	var kp *MLDSA87Keypair
+	if _, err := kp.SignDigest32(digest); err == nil {
+		t.Fatalf("expected error")
+	}
+	kp = &MLDSA87Keypair{}
+	if _, err := kp.SignDigest32(digest); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestSLHDSAKeypair_NilKeypairErrors(t *testing.T) {
+	var digest [32]byte
+	var kp *SLHDSASHAKE256fKeypair
+	if _, err := kp.SignDigest32(digest); err == nil {
+		t.Fatalf("expected error")
+	}
+	kp = &SLHDSASHAKE256fKeypair{}
+	if _, err := kp.SignDigest32(digest); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestSLHDSAKeypair_RoundtripAndPubkeyBytes(t *testing.T) {
+	kp, err := NewSLHDSASHAKE256fKeypair()
+	if err != nil {
+		t.Fatalf("NewSLHDSASHAKE256fKeypair: %v", err)
+	}
+	t.Cleanup(func() { kp.Close() })
+
+	pub := kp.PubkeyBytes()
+	if len(pub) != SLH_DSA_SHAKE_256F_PUBKEY_BYTES {
+		t.Fatalf("pubkey len=%d", len(pub))
+	}
+	pub[0] ^= 0x01
+	pub2 := kp.PubkeyBytes()
+	if pub2[0] == pub[0] {
+		t.Fatalf("expected PubkeyBytes to return a copy")
+	}
+
+	var digest [32]byte
+	digest[0] = 0x42
+	sig, err := kp.SignDigest32(digest)
+	if err != nil {
+		t.Fatalf("SignDigest32: %v", err)
+	}
+	if len(sig) == 0 {
+		t.Fatalf("expected non-empty signature")
+	}
+
+	ok, err := verifySig(SUITE_ID_SLH_DSA_SHAKE_256F, kp.PubkeyBytes(), sig, digest)
+	if err != nil {
+		t.Fatalf("verifySig: %v", err)
+	}
+	if !ok {
+		t.Fatalf("verifySig=false")
+	}
+
+	var nilKP *SLHDSASHAKE256fKeypair
+	if got := nilKP.PubkeyBytes(); got != nil {
+		t.Fatalf("expected nil for nil receiver")
+	}
+}
+
+func TestNewOpenSSLRawKeypair_RejectsUnknownAlg(t *testing.T) {
+	_, _, err := newOpenSSLRawKeypair("NO_SUCH_ALG", 1)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+}

--- a/clients/go/consensus/spend_verify_test.go
+++ b/clients/go/consensus/spend_verify_test.go
@@ -1,0 +1,117 @@
+package consensus
+
+import (
+	"testing"
+)
+
+func p2pkEntryForPub(t *testing.T, suiteID uint8, pub []byte) UtxoEntry {
+	t.Helper()
+	keyID := sha3_256(pub)
+	cov := make([]byte, MAX_P2PK_COVENANT_DATA)
+	cov[0] = suiteID
+	copy(cov[1:33], keyID[:])
+	return UtxoEntry{
+		Value:             1,
+		CovenantType:      COV_TYPE_P2PK,
+		CovenantData:      cov,
+		CreationHeight:    0,
+		CreatedByCoinbase: false,
+	}
+}
+
+func TestValidateP2PKSpend_OkAndFailureModes(t *testing.T) {
+	kp := mustMLDSA87Keypair(t)
+	pub := kp.PubkeyBytes()
+
+	digest := sha3_256([]byte("x"))
+	sig, err := kp.SignDigest32(digest)
+	if err != nil {
+		t.Fatalf("SignDigest32: %v", err)
+	}
+
+	entry := p2pkEntryForPub(t, SUITE_ID_ML_DSA_87, pub)
+	w := WitnessItem{SuiteID: SUITE_ID_ML_DSA_87, Pubkey: pub, Signature: sig}
+	if err := validateP2PKSpend(entry, w, digest, 0); err != nil {
+		t.Fatalf("expected ok, got %v", err)
+	}
+
+	// suite invalid
+	wBadSuite := w
+	wBadSuite.SuiteID = 0x03
+	if err := validateP2PKSpend(entry, wBadSuite, digest, 0); err == nil || mustTxErrCode(t, err) != TX_ERR_SIG_ALG_INVALID {
+		t.Fatalf("expected TX_ERR_SIG_ALG_INVALID, got %v", err)
+	}
+
+	// SLH suite inactive
+	wSLH := w
+	wSLH.SuiteID = SUITE_ID_SLH_DSA_SHAKE_256F
+	if err := validateP2PKSpend(entry, wSLH, digest, SLH_DSA_ACTIVATION_HEIGHT-1); err == nil || mustTxErrCode(t, err) != TX_ERR_SIG_ALG_INVALID {
+		t.Fatalf("expected TX_ERR_SIG_ALG_INVALID (inactive), got %v", err)
+	}
+
+	// covenant_data invalid (len)
+	entryBad := entry
+	entryBad.CovenantData = entryBad.CovenantData[:32]
+	if err := validateP2PKSpend(entryBad, w, digest, 0); err == nil || mustTxErrCode(t, err) != TX_ERR_COVENANT_TYPE_INVALID {
+		t.Fatalf("expected TX_ERR_COVENANT_TYPE_INVALID, got %v", err)
+	}
+
+	// key binding mismatch
+	entryKeyMismatch := entry
+	entryKeyMismatch.CovenantData = append([]byte(nil), entry.CovenantData...)
+	entryKeyMismatch.CovenantData[1] ^= 0x01
+	if err := validateP2PKSpend(entryKeyMismatch, w, digest, 0); err == nil || mustTxErrCode(t, err) != TX_ERR_SIG_INVALID {
+		t.Fatalf("expected TX_ERR_SIG_INVALID (binding), got %v", err)
+	}
+
+	// signature invalid
+	wBadSig := w
+	wBadSig.Signature = append([]byte(nil), wBadSig.Signature...)
+	wBadSig.Signature[0] ^= 0x01
+	if err := validateP2PKSpend(entry, wBadSig, digest, 0); err == nil || mustTxErrCode(t, err) != TX_ERR_SIG_INVALID {
+		t.Fatalf("expected TX_ERR_SIG_INVALID (sig), got %v", err)
+	}
+}
+
+func TestValidateThresholdSigSpend_MismatchAndThresholdLogic(t *testing.T) {
+	// witness slot assignment mismatch
+	if err := validateThresholdSigSpend([][32]byte{}, 0, []WitnessItem{{SuiteID: SUITE_ID_SENTINEL}}, [32]byte{}, 0, "ctx"); err == nil || mustTxErrCode(t, err) != TX_ERR_PARSE {
+		t.Fatalf("expected TX_ERR_PARSE, got %v", err)
+	}
+
+	// unknown suite id branch (should be unreachable at wire level, but must be deterministic)
+	keys := [][32]byte{hashWithPrefix(0x01)}
+	ws := []WitnessItem{{SuiteID: 0x03, Pubkey: []byte{0x01}, Signature: []byte{0x02}}}
+	if err := validateThresholdSigSpend(keys, 1, ws, [32]byte{}, 0, "ctx"); err == nil || mustTxErrCode(t, err) != TX_ERR_SIG_ALG_INVALID {
+		t.Fatalf("expected TX_ERR_SIG_ALG_INVALID, got %v", err)
+	}
+
+	// sentinel witnesses -> threshold not met
+	keys2 := [][32]byte{hashWithPrefix(0x02), hashWithPrefix(0x03)}
+	ws2 := []WitnessItem{{SuiteID: SUITE_ID_SENTINEL}, {SuiteID: SUITE_ID_SENTINEL}}
+	if err := validateThresholdSigSpend(keys2, 1, ws2, [32]byte{}, 0, "ctx"); err == nil || mustTxErrCode(t, err) != TX_ERR_SIG_INVALID {
+		t.Fatalf("expected TX_ERR_SIG_INVALID (threshold), got %v", err)
+	}
+}
+
+func TestValidateThresholdSigSpend_OkWithOneValidAndOneSentinel(t *testing.T) {
+	kp := mustMLDSA87Keypair(t)
+	pub := kp.PubkeyBytes()
+	digest := sha3_256([]byte("y"))
+
+	sig, err := kp.SignDigest32(digest)
+	if err != nil {
+		t.Fatalf("SignDigest32: %v", err)
+	}
+
+	key0 := sha3_256(pub)
+	keys := [][32]byte{key0, hashWithPrefix(0x99)}
+	ws := []WitnessItem{
+		{SuiteID: SUITE_ID_ML_DSA_87, Pubkey: pub, Signature: sig},
+		{SuiteID: SUITE_ID_SENTINEL},
+	}
+
+	if err := validateThresholdSigSpend(keys, 1, ws, digest, 0, "ctx"); err != nil {
+		t.Fatalf("expected ok, got %v", err)
+	}
+}


### PR DESCRIPTION
Part of #215.

Tests-only PR to raise Go consensus coverage for:
- `clients/go/consensus/spend_verify.go` (P2PK + threshold spend verification paths)
- `clients/go/consensus/openssl_signer.go` (PQC keypair helpers + SLH path + PubkeyBytes copy semantics)

This keeps coverage work focused on consensus before moving to node/CLI modules.
