### PR TITLE
test(consensus): cover HTLC paths (issue #215)

### DIFF
--- a/clients/go/consensus/htlc_test.go
+++ b/clients/go/consensus/htlc_test.go
@@ -201,3 +201,449 @@ func TestApplyNonCoinbaseTxBasic_HTLCUnknownPath(t *testing.T) {
 		t.Fatalf("code=%s, want %s", got, TX_ERR_PARSE)
 	}
 }
+
+func TestParseHTLCCovenantData_Nil(t *testing.T) {
+	_, err := ParseHTLCCovenantData(nil)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if got := mustTxErrCode(t, err); got != TX_ERR_COVENANT_TYPE_INVALID {
+		t.Fatalf("code=%s, want %s", got, TX_ERR_COVENANT_TYPE_INVALID)
+	}
+}
+
+func TestParseHTLCCovenantData_LengthMismatch(t *testing.T) {
+	_, err := ParseHTLCCovenantData(make([]byte, MAX_HTLC_COVENANT_DATA-1))
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if got := mustTxErrCode(t, err); got != TX_ERR_COVENANT_TYPE_INVALID {
+		t.Fatalf("code=%s, want %s", got, TX_ERR_COVENANT_TYPE_INVALID)
+	}
+}
+
+func TestParseHTLCCovenantData_LockValueZero(t *testing.T) {
+	hash := sha3_256([]byte("x"))
+	claim := sha3_256([]byte("claim"))
+	refund := sha3_256([]byte("refund"))
+	cov := encodeHTLCCovenantData(hash, LOCK_MODE_HEIGHT, 0, claim, refund)
+
+	_, err := ParseHTLCCovenantData(cov)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if got := mustTxErrCode(t, err); got != TX_ERR_COVENANT_TYPE_INVALID {
+		t.Fatalf("code=%s, want %s", got, TX_ERR_COVENANT_TYPE_INVALID)
+	}
+}
+
+func TestParseHTLCCovenantData_ClaimRefundKeyIDMustDiffer(t *testing.T) {
+	hash := sha3_256([]byte("x"))
+	keyID := sha3_256([]byte("same"))
+	cov := encodeHTLCCovenantData(hash, LOCK_MODE_HEIGHT, 1, keyID, keyID)
+
+	_, err := ParseHTLCCovenantData(cov)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if got := mustTxErrCode(t, err); got != TX_ERR_PARSE {
+		t.Fatalf("code=%s, want %s", got, TX_ERR_PARSE)
+	}
+}
+
+func TestValidateHTLCSpend_SelectorSuiteIDInvalid(t *testing.T) {
+	var digest [32]byte
+	claimPub, _, claimKeyID, refundKeyID := makeSLHKeyMaterial(0x55)
+	entry := makeHTLCEntry(sha3_256([]byte("x")), LOCK_MODE_HEIGHT, 1, claimKeyID, refundKeyID)
+
+	path := WitnessItem{
+		SuiteID:   SUITE_ID_ML_DSA_87,
+		Pubkey:    claimKeyID[:],
+		Signature: []byte{0x00},
+	}
+	sig := WitnessItem{SuiteID: SUITE_ID_SLH_DSA_SHAKE_256F, Pubkey: claimPub, Signature: []byte{0x01}}
+
+	err := ValidateHTLCSpend(entry, path, sig, digest, SLH_DSA_ACTIVATION_HEIGHT, 0)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if got := mustTxErrCode(t, err); got != TX_ERR_PARSE {
+		t.Fatalf("code=%s, want %s", got, TX_ERR_PARSE)
+	}
+}
+
+func TestValidateHTLCSpend_SelectorKeyIDLenInvalid(t *testing.T) {
+	var digest [32]byte
+	claimPub, _, claimKeyID, refundKeyID := makeSLHKeyMaterial(0x56)
+	entry := makeHTLCEntry(sha3_256([]byte("x")), LOCK_MODE_HEIGHT, 1, claimKeyID, refundKeyID)
+
+	path := WitnessItem{
+		SuiteID:   SUITE_ID_SENTINEL,
+		Pubkey:    claimKeyID[:31],
+		Signature: []byte{0x00},
+	}
+	sig := WitnessItem{SuiteID: SUITE_ID_SLH_DSA_SHAKE_256F, Pubkey: claimPub, Signature: []byte{0x01}}
+
+	err := ValidateHTLCSpend(entry, path, sig, digest, SLH_DSA_ACTIVATION_HEIGHT, 0)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if got := mustTxErrCode(t, err); got != TX_ERR_PARSE {
+		t.Fatalf("code=%s, want %s", got, TX_ERR_PARSE)
+	}
+}
+
+func TestValidateHTLCSpend_SelectorPayloadTooShort(t *testing.T) {
+	var digest [32]byte
+	claimPub, _, claimKeyID, refundKeyID := makeSLHKeyMaterial(0x57)
+	entry := makeHTLCEntry(sha3_256([]byte("x")), LOCK_MODE_HEIGHT, 1, claimKeyID, refundKeyID)
+
+	path := WitnessItem{
+		SuiteID:   SUITE_ID_SENTINEL,
+		Pubkey:    claimKeyID[:],
+		Signature: nil,
+	}
+	sig := WitnessItem{SuiteID: SUITE_ID_SLH_DSA_SHAKE_256F, Pubkey: claimPub, Signature: []byte{0x01}}
+
+	err := ValidateHTLCSpend(entry, path, sig, digest, SLH_DSA_ACTIVATION_HEIGHT, 0)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if got := mustTxErrCode(t, err); got != TX_ERR_PARSE {
+		t.Fatalf("code=%s, want %s", got, TX_ERR_PARSE)
+	}
+}
+
+func TestValidateHTLCSpend_ClaimKeyIDMismatch(t *testing.T) {
+	var digest [32]byte
+	claimPub, _, claimKeyID, refundKeyID := makeSLHKeyMaterial(0x58)
+	entry := makeHTLCEntry(sha3_256([]byte("x")), LOCK_MODE_HEIGHT, 1, claimKeyID, refundKeyID)
+
+	var otherKeyID [32]byte
+	otherKeyID[0] = 0xff
+	path := WitnessItem{
+		SuiteID:   SUITE_ID_SENTINEL,
+		Pubkey:    otherKeyID[:],
+		Signature: []byte{0x00, 0x00, 0x00}, // claim path + preimage_len=0 (won't be reached)
+	}
+	sig := WitnessItem{SuiteID: SUITE_ID_SLH_DSA_SHAKE_256F, Pubkey: claimPub, Signature: []byte{0x01}}
+
+	err := ValidateHTLCSpend(entry, path, sig, digest, SLH_DSA_ACTIVATION_HEIGHT, 0)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if got := mustTxErrCode(t, err); got != TX_ERR_SIG_INVALID {
+		t.Fatalf("code=%s, want %s", got, TX_ERR_SIG_INVALID)
+	}
+}
+
+func TestValidateHTLCSpend_ClaimPayloadTooShort(t *testing.T) {
+	var digest [32]byte
+	claimPub, _, claimKeyID, refundKeyID := makeSLHKeyMaterial(0x59)
+	entry := makeHTLCEntry(sha3_256([]byte("x")), LOCK_MODE_HEIGHT, 1, claimKeyID, refundKeyID)
+
+	path := WitnessItem{
+		SuiteID:   SUITE_ID_SENTINEL,
+		Pubkey:    claimKeyID[:],
+		Signature: []byte{0x00, 0x01}, // too short for claim payload
+	}
+	sig := WitnessItem{SuiteID: SUITE_ID_SLH_DSA_SHAKE_256F, Pubkey: claimPub, Signature: []byte{0x01}}
+
+	err := ValidateHTLCSpend(entry, path, sig, digest, SLH_DSA_ACTIVATION_HEIGHT, 0)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if got := mustTxErrCode(t, err); got != TX_ERR_PARSE {
+		t.Fatalf("code=%s, want %s", got, TX_ERR_PARSE)
+	}
+}
+
+func TestValidateHTLCSpend_ClaimPreimageLenZero(t *testing.T) {
+	var digest [32]byte
+	claimPub, _, claimKeyID, refundKeyID := makeSLHKeyMaterial(0x5a)
+	entry := makeHTLCEntry(sha3_256([]byte("x")), LOCK_MODE_HEIGHT, 1, claimKeyID, refundKeyID)
+
+	path := WitnessItem{
+		SuiteID:   SUITE_ID_SENTINEL,
+		Pubkey:    claimKeyID[:],
+		Signature: []byte{0x00, 0x00, 0x00}, // claim + preimage_len=0
+	}
+	sig := WitnessItem{SuiteID: SUITE_ID_SLH_DSA_SHAKE_256F, Pubkey: claimPub, Signature: []byte{0x01}}
+
+	err := ValidateHTLCSpend(entry, path, sig, digest, SLH_DSA_ACTIVATION_HEIGHT, 0)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if got := mustTxErrCode(t, err); got != TX_ERR_PARSE {
+		t.Fatalf("code=%s, want %s", got, TX_ERR_PARSE)
+	}
+}
+
+func TestValidateHTLCSpend_ClaimPreimageLenOverflow(t *testing.T) {
+	var digest [32]byte
+	claimPub, _, claimKeyID, refundKeyID := makeSLHKeyMaterial(0x5b)
+	entry := makeHTLCEntry(sha3_256([]byte("x")), LOCK_MODE_HEIGHT, 1, claimKeyID, refundKeyID)
+
+	tooBig := uint16(MAX_HTLC_PREIMAGE_BYTES + 1)
+	path := WitnessItem{
+		SuiteID: SUITE_ID_SENTINEL,
+		Pubkey:  claimKeyID[:],
+		Signature: []byte{
+			0x00,
+			byte(tooBig),
+			byte(tooBig >> 8),
+		},
+	}
+	sig := WitnessItem{SuiteID: SUITE_ID_SLH_DSA_SHAKE_256F, Pubkey: claimPub, Signature: []byte{0x01}}
+
+	err := ValidateHTLCSpend(entry, path, sig, digest, SLH_DSA_ACTIVATION_HEIGHT, 0)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if got := mustTxErrCode(t, err); got != TX_ERR_PARSE {
+		t.Fatalf("code=%s, want %s", got, TX_ERR_PARSE)
+	}
+}
+
+func TestValidateHTLCSpend_ClaimPayloadLenMismatch(t *testing.T) {
+	var digest [32]byte
+	claimPub, _, claimKeyID, refundKeyID := makeSLHKeyMaterial(0x5c)
+	entry := makeHTLCEntry(sha3_256([]byte("x")), LOCK_MODE_HEIGHT, 1, claimKeyID, refundKeyID)
+
+	// preimage_len=2 but only 1 byte provided.
+	path := WitnessItem{
+		SuiteID:   SUITE_ID_SENTINEL,
+		Pubkey:    claimKeyID[:],
+		Signature: []byte{0x00, 0x02, 0x00, 0xaa},
+	}
+	sig := WitnessItem{SuiteID: SUITE_ID_SLH_DSA_SHAKE_256F, Pubkey: claimPub, Signature: []byte{0x01}}
+
+	err := ValidateHTLCSpend(entry, path, sig, digest, SLH_DSA_ACTIVATION_HEIGHT, 0)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if got := mustTxErrCode(t, err); got != TX_ERR_PARSE {
+		t.Fatalf("code=%s, want %s", got, TX_ERR_PARSE)
+	}
+}
+
+func TestValidateHTLCSpend_RefundPayloadLenMismatch(t *testing.T) {
+	var digest [32]byte
+	claimPub, refundPub, claimKeyID, refundKeyID := makeSLHKeyMaterial(0x5d)
+	entry := makeHTLCEntry(sha3_256([]byte("x")), LOCK_MODE_HEIGHT, 1, claimKeyID, refundKeyID)
+
+	path := WitnessItem{
+		SuiteID:   SUITE_ID_SENTINEL,
+		Pubkey:    refundKeyID[:],
+		Signature: []byte{0x01, 0x00},
+	}
+	sig := WitnessItem{SuiteID: SUITE_ID_SLH_DSA_SHAKE_256F, Pubkey: refundPub, Signature: []byte{0x01}}
+
+	err := ValidateHTLCSpend(entry, path, sig, digest, SLH_DSA_ACTIVATION_HEIGHT, 0)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if got := mustTxErrCode(t, err); got != TX_ERR_PARSE {
+		t.Fatalf("code=%s, want %s", got, TX_ERR_PARSE)
+	}
+
+	_ = claimPub
+}
+
+func TestValidateHTLCSpend_RefundKeyIDMismatch(t *testing.T) {
+	var digest [32]byte
+	claimPub, refundPub, claimKeyID, refundKeyID := makeSLHKeyMaterial(0x5e)
+	entry := makeHTLCEntry(sha3_256([]byte("x")), LOCK_MODE_HEIGHT, 1, claimKeyID, refundKeyID)
+
+	var otherKeyID [32]byte
+	otherKeyID[0] = 0xee
+	path := WitnessItem{
+		SuiteID:   SUITE_ID_SENTINEL,
+		Pubkey:    otherKeyID[:],
+		Signature: []byte{0x01},
+	}
+	sig := WitnessItem{SuiteID: SUITE_ID_SLH_DSA_SHAKE_256F, Pubkey: refundPub, Signature: []byte{0x01}}
+
+	err := ValidateHTLCSpend(entry, path, sig, digest, SLH_DSA_ACTIVATION_HEIGHT, 0)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if got := mustTxErrCode(t, err); got != TX_ERR_SIG_INVALID {
+		t.Fatalf("code=%s, want %s", got, TX_ERR_SIG_INVALID)
+	}
+
+	_ = claimPub
+	_ = refundKeyID
+}
+
+func TestValidateHTLCSpend_SigSuiteInvalid(t *testing.T) {
+	var digest [32]byte
+	claimPub, refundPub, claimKeyID, refundKeyID := makeSLHKeyMaterial(0x5f)
+	entry := makeHTLCEntry(sha3_256([]byte("x")), LOCK_MODE_HEIGHT, 1, claimKeyID, refundKeyID)
+	path := WitnessItem{SuiteID: SUITE_ID_SENTINEL, Pubkey: refundKeyID[:], Signature: []byte{0x01}}
+
+	sig := WitnessItem{SuiteID: 0x09, Pubkey: claimPub, Signature: []byte{0x01}}
+	err := ValidateHTLCSpend(entry, path, sig, digest, SLH_DSA_ACTIVATION_HEIGHT, 0)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if got := mustTxErrCode(t, err); got != TX_ERR_SIG_ALG_INVALID {
+		t.Fatalf("code=%s, want %s", got, TX_ERR_SIG_ALG_INVALID)
+	}
+
+	_ = refundPub
+}
+
+func TestValidateHTLCSpend_MLDSANonCanonicalWitnessItemLengths(t *testing.T) {
+	var digest [32]byte
+	claimPub, refundPub, claimKeyID, refundKeyID := makeSLHKeyMaterial(0x60)
+	entry := makeHTLCEntry(sha3_256([]byte("x")), LOCK_MODE_HEIGHT, 1, claimKeyID, refundKeyID)
+	path := WitnessItem{SuiteID: SUITE_ID_SENTINEL, Pubkey: refundKeyID[:], Signature: []byte{0x01}}
+
+	sig := WitnessItem{SuiteID: SUITE_ID_ML_DSA_87, Pubkey: []byte{0x01}, Signature: []byte{0x02}}
+	err := ValidateHTLCSpend(entry, path, sig, digest, SLH_DSA_ACTIVATION_HEIGHT, 0)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if got := mustTxErrCode(t, err); got != TX_ERR_SIG_NONCANONICAL {
+		t.Fatalf("code=%s, want %s", got, TX_ERR_SIG_NONCANONICAL)
+	}
+
+	_ = claimPub
+	_ = refundPub
+}
+
+func TestValidateHTLCSpend_SLHInactiveAtHeight(t *testing.T) {
+	var digest [32]byte
+	claimPub, refundPub, claimKeyID, refundKeyID := makeSLHKeyMaterial(0x61)
+	entry := makeHTLCEntry(sha3_256([]byte("x")), LOCK_MODE_HEIGHT, 1, claimKeyID, refundKeyID)
+	path := WitnessItem{SuiteID: SUITE_ID_SENTINEL, Pubkey: refundKeyID[:], Signature: []byte{0x01}}
+
+	sig := WitnessItem{SuiteID: SUITE_ID_SLH_DSA_SHAKE_256F, Pubkey: refundPub, Signature: []byte{0x01}}
+	err := ValidateHTLCSpend(entry, path, sig, digest, SLH_DSA_ACTIVATION_HEIGHT-1, 0)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if got := mustTxErrCode(t, err); got != TX_ERR_SIG_ALG_INVALID {
+		t.Fatalf("code=%s, want %s", got, TX_ERR_SIG_ALG_INVALID)
+	}
+
+	_ = claimPub
+}
+
+func TestValidateHTLCSpend_SLHNonCanonicalWitnessItemLengths(t *testing.T) {
+	var digest [32]byte
+	claimPub, refundPub, claimKeyID, refundKeyID := makeSLHKeyMaterial(0x62)
+	entry := makeHTLCEntry(sha3_256([]byte("x")), LOCK_MODE_HEIGHT, 1, claimKeyID, refundKeyID)
+	path := WitnessItem{SuiteID: SUITE_ID_SENTINEL, Pubkey: refundKeyID[:], Signature: []byte{0x01}}
+
+	sig := WitnessItem{SuiteID: SUITE_ID_SLH_DSA_SHAKE_256F, Pubkey: refundPub, Signature: nil}
+	err := ValidateHTLCSpend(entry, path, sig, digest, SLH_DSA_ACTIVATION_HEIGHT, 0)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if got := mustTxErrCode(t, err); got != TX_ERR_SIG_NONCANONICAL {
+		t.Fatalf("code=%s, want %s", got, TX_ERR_SIG_NONCANONICAL)
+	}
+
+	_ = claimPub
+}
+
+func TestValidateHTLCSpend_SigKeyBindingMismatch(t *testing.T) {
+	var digest [32]byte
+
+	// Covenant binds to claimKP but signature pubkey is from otherKP.
+	claimKP := mustMLDSA87Keypair(t)
+	otherKP := mustMLDSA87Keypair(t)
+	claimPub := claimKP.PubkeyBytes()
+	otherPub := otherKP.PubkeyBytes()
+	claimKeyID := sha3_256(claimPub)
+	refundKeyID := sha3_256([]byte("refund"))
+
+	entry := makeHTLCEntry(sha3_256([]byte("p")), LOCK_MODE_HEIGHT, 1, claimKeyID, refundKeyID)
+
+	path := WitnessItem{
+		SuiteID:   SUITE_ID_SENTINEL,
+		Pubkey:    claimKeyID[:],
+		Signature: encodeHTLCClaimPayload([]byte("p")),
+	}
+	sig := WitnessItem{
+		SuiteID:   SUITE_ID_ML_DSA_87,
+		Pubkey:    otherPub,
+		Signature: make([]byte, ML_DSA_87_SIG_BYTES),
+	}
+
+	err := ValidateHTLCSpend(entry, path, sig, digest, 0, 0)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if got := mustTxErrCode(t, err); got != TX_ERR_SIG_INVALID {
+		t.Fatalf("code=%s, want %s", got, TX_ERR_SIG_INVALID)
+	}
+}
+
+func TestValidateHTLCSpend_SignatureInvalid(t *testing.T) {
+	var digest [32]byte
+	digest[0] = 0x01
+
+	claimKP := mustMLDSA87Keypair(t)
+	claimPub := claimKP.PubkeyBytes()
+	claimKeyID := sha3_256(claimPub)
+	refundKeyID := sha3_256([]byte("refund"))
+
+	preimage := []byte("rubin-htlc-claim")
+	entry := makeHTLCEntry(sha3_256(preimage), LOCK_MODE_HEIGHT, 1, claimKeyID, refundKeyID)
+
+	path := WitnessItem{
+		SuiteID:   SUITE_ID_SENTINEL,
+		Pubkey:    claimKeyID[:],
+		Signature: encodeHTLCClaimPayload(preimage),
+	}
+	sig := WitnessItem{
+		SuiteID:   SUITE_ID_ML_DSA_87,
+		Pubkey:    claimPub,
+		Signature: make([]byte, ML_DSA_87_SIG_BYTES), // wrong signature but correct length
+	}
+
+	err := ValidateHTLCSpend(entry, path, sig, digest, 0, 0)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if got := mustTxErrCode(t, err); got != TX_ERR_SIG_INVALID {
+		t.Fatalf("code=%s, want %s", got, TX_ERR_SIG_INVALID)
+	}
+}
+
+func TestValidateHTLCSpend_ClaimOK(t *testing.T) {
+	var digest [32]byte
+	digest[0] = 0x99
+
+	claimKP := mustMLDSA87Keypair(t)
+	refundKP := mustMLDSA87Keypair(t)
+	claimPub := claimKP.PubkeyBytes()
+	refundPub := refundKP.PubkeyBytes()
+	claimKeyID := sha3_256(claimPub)
+	refundKeyID := sha3_256(refundPub)
+
+	preimage := []byte("rubin-htlc-claim-ok")
+	entry := makeHTLCEntry(sha3_256(preimage), LOCK_MODE_HEIGHT, 1, claimKeyID, refundKeyID)
+
+	path := WitnessItem{
+		SuiteID:   SUITE_ID_SENTINEL,
+		Pubkey:    claimKeyID[:],
+		Signature: encodeHTLCClaimPayload(preimage),
+	}
+	claimSig, err := claimKP.SignDigest32(digest)
+	if err != nil {
+		t.Fatalf("SignDigest32: %v", err)
+	}
+	sig := WitnessItem{
+		SuiteID:   SUITE_ID_ML_DSA_87,
+		Pubkey:    claimPub,
+		Signature: claimSig,
+	}
+
+	if err := ValidateHTLCSpend(entry, path, sig, digest, 0, 0); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
Raises Go consensus HTLC coverage.

- ParseHTLCCovenantData: 100%
- ValidateHTLCSpend: 93.7%

Part of #215.