### PR TITLE
Issue #215: utxo_basic u128 + covenant tests

### DIFF
--- a/clients/go/consensus/utxo_basic_additional_test.go
+++ b/clients/go/consensus/utxo_basic_additional_test.go
@@ -63,4 +63,3 @@ func TestCheckSpendCovenant_Errors(t *testing.T) {
 		t.Fatalf("code=%s, want %s", got, TX_ERR_COVENANT_TYPE_INVALID)
 	}
 }
-


### PR DESCRIPTION
Adds unit tests to cover checkSpendCovenant branches (P2PK/VAULT/MULTISIG/HTLC/unknown) and u128 helper error paths (sub underflow, u64 overflow). No consensus rule changes.