### PR TITLE
Reduce duplication in CLI tests + fixture generator

### DIFF
--- a/clients/go/cmd/gen-conformance-fixtures/runtime.go
+++ b/clients/go/cmd/gen-conformance-fixtures/runtime.go
@@ -438,13 +438,7 @@ func updateVaultSpendVectorsUTXO(
 			{SuiteID: consensus.SUITE_ID_ML_DSA_87, Pubkey: ownerPub, Signature: ownerSig},
 		}
 
-		b, err := txBytes(tx)
-		if err != nil {
-			fatalf("%s: txBytes: %v", id, err)
-		}
-		if _, _, _, n, err := consensus.ParseTx(b); err != nil || n != len(b) {
-			fatalf("%s: ParseTx sanity failed: err=%v consumed=%d len=%d", id, err, n, len(b))
-		}
+		b := mustTxBytes(tx)
 
 		v["tx_hex"] = hex.EncodeToString(b)
 		v["utxos"] = utxos
@@ -511,13 +505,7 @@ func updateVaultCreateVectors(
 			fatalf("%s: sign: %v", id, err)
 		}
 		tx.Witness = []consensus.WitnessItem{{SuiteID: consensus.SUITE_ID_ML_DSA_87, Pubkey: nonOwnerPub, Signature: sig}}
-		b, err := txBytes(tx)
-		if err != nil {
-			fatalf("%s: txBytes: %v", id, err)
-		}
-		if _, _, _, n, err := consensus.ParseTx(b); err != nil || n != len(b) {
-			fatalf("%s: ParseTx sanity failed: err=%v consumed=%d len=%d", id, err, n, len(b))
-		}
+		b := mustTxBytes(tx)
 		v["tx_hex"] = hex.EncodeToString(b)
 		v["utxos"] = utxos
 	}
@@ -552,13 +540,7 @@ func updateVaultCreateVectors(
 			fatalf("%s: sign: %v", id, err)
 		}
 		tx.Witness = []consensus.WitnessItem{{SuiteID: consensus.SUITE_ID_ML_DSA_87, Pubkey: ownerPub, Signature: sig}}
-		b, err := txBytes(tx)
-		if err != nil {
-			fatalf("%s: txBytes: %v", id, err)
-		}
-		if _, _, _, n, err := consensus.ParseTx(b); err != nil || n != len(b) {
-			fatalf("%s: ParseTx sanity failed: err=%v consumed=%d len=%d", id, err, n, len(b))
-		}
+		b := mustTxBytes(tx)
 		v["tx_hex"] = hex.EncodeToString(b)
 		v["utxos"] = utxos
 	}
@@ -648,13 +630,7 @@ func updateVaultSpendVectorsVaultFixture(
 			{SuiteID: consensus.SUITE_ID_ML_DSA_87, Pubkey: sponsorPub, Signature: sponsorSig},
 		}
 
-		b, err := txBytes(tx)
-		if err != nil {
-			fatalf("%s: txBytes: %v", id, err)
-		}
-		if _, _, _, n, err := consensus.ParseTx(b); err != nil || n != len(b) {
-			fatalf("%s: ParseTx sanity failed: err=%v consumed=%d len=%d", id, err, n, len(b))
-		}
+		b := mustTxBytes(tx)
 		v["tx_hex"] = hex.EncodeToString(b)
 		v["utxos"] = utxos
 	}
@@ -711,13 +687,7 @@ func updateVaultSpendVectorsVaultFixture(
 			{SuiteID: consensus.SUITE_ID_ML_DSA_87, Pubkey: ownerPub, Signature: ownerSig},
 		}
 
-		b, err := txBytes(tx)
-		if err != nil {
-			fatalf("%s: txBytes: %v", id, err)
-		}
-		if _, _, _, n, err := consensus.ParseTx(b); err != nil || n != len(b) {
-			fatalf("%s: ParseTx sanity failed: err=%v consumed=%d len=%d", id, err, n, len(b))
-		}
+		b := mustTxBytes(tx)
 		v["tx_hex"] = hex.EncodeToString(b)
 		v["utxos"] = utxos
 	}
@@ -802,13 +772,7 @@ func updateHTLCVector(
 		{SuiteID: consensus.SUITE_ID_ML_DSA_87, Pubkey: claimPub, Signature: sig},
 	}
 
-	b, err := txBytes(tx)
-	if err != nil {
-		fatalf("%s: txBytes: %v", id, err)
-	}
-	if _, _, _, n, err := consensus.ParseTx(b); err != nil || n != len(b) {
-		fatalf("%s: ParseTx sanity failed: err=%v consumed=%d len=%d", id, err, n, len(b))
-	}
+	b := mustTxBytes(tx)
 
 	v["tx_hex"] = hex.EncodeToString(b)
 	v["utxos"] = utxos


### PR DESCRIPTION
Fixes #230.\n\n- Deduplicate tx-bytes + ParseTx sanity blocks in gen-conformance-fixtures.\n- Deduplicate CLI runtime tests via helpers + shared telemetry key list.\n\nLocal: gofmt + ok  	github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/cmd/formal-trace	0.384s
ok  	github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/cmd/gen-conformance-fixtures	0.539s
ok  	github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/cmd/rubin-consensus-cli	0.603s
ok  	github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/cmd/rubin-node	0.989s
ok  	github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus	1.375s
ok  	github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/node	1.156s PASS.