### PR TITLE
ops(fips): hard-fail dev-env when FIPS-only preflight fails

### DIFF
--- a/scripts/crypto/openssl/README.md
+++ b/scripts/crypto/openssl/README.md
@@ -27,6 +27,12 @@ RUBIN_OPENSSL_FIPS_MODE=only \
 scripts/dev-env.sh -- scripts/crypto/openssl/fips-preflight.sh
 ```
 
+Runtime enforcement in `RUBIN_OPENSSL_FIPS_MODE=only`:
+
+- `scripts/dev-env.sh -- <cmd>` now runs the same preflight automatically and hard-fails when
+  `provider=fips`/required PQ signatures are unavailable.
+- Temporary bypass (for bootstrap/debug only): set `RUBIN_OPENSSL_SKIP_FIPS_GUARD=1`.
+
 ## Thread-safety assumptions (verify/sign paths)
 
 OpenSSL usage in this repository relies on the following invariants:


### PR DESCRIPTION
## Summary\n- add mandatory FIPS-only runtime guard to repo_root: /Users/gpt/Documents/rubin-protocol
PATH: /opt/homebrew/opt/openssl@3/bin:/Users/gpt/.elan/bin:/usr/local/bin:/opt/homebrew/bin:/Users/gpt/.cargo/bin:/Users/gpt/.codex/tmp/arg0/codex-arg0Y210l7:/usr/bin:/bin:/usr/sbin:/sbin:/Applications/Codex.app/Contents/Resources
OPENSSL_DIR: /opt/homebrew/opt/openssl@3
OPENSSL_MODULES: /opt/homebrew/opt/openssl@3/lib/ossl-modules
PKG_CONFIG_PATH: /opt/homebrew/opt/openssl@3/lib/pkgconfig

git: git version 2.52.0
python3: Python 3.14.3
node: v25.6.0
npm: 11.8.0
go: go version go1.25.7 darwin/arm64
rustc: rustc 1.93.0 (254b59607 2026-01-19)
cargo: cargo 1.93.0 (083ac5135 2025-12-15)
openssl: OpenSSL 3.6.1 27 Jan 2026 (Library: OpenSSL 3.6.1 27 Jan 2026)
gh: gh version 2.86.0 (2026-01-21)
elan: elan 4.1.2 (58e8d545e 2025-05-26)
lake: Lake version 5.0.0-a5bc901 (Lean version 4.6.0)

OK: dev env looks usable. Tip: scripts/dev-env.sh -- <cmd>\n- when , run [fips-preflight] mode=off
[fips-preflight] openssl=/usr/bin/openssl
[fips-preflight] OPENSSL_MODULES=(unset)
[fips-preflight] OPENSSL_CONF=(unset)
LibreSSL 3.3.6
built on: date not available
platform: information not available
options:  bn(64,64) rc4(ptr,int) des(idx,cisc,16,int) blowfish(idx) 
compiler: information not available
OPENSSLDIR: "/private/etc/ssl"

[fips-preflight] providers(active): before executing command\n- add explicit bypass switch for bootstrap/debug: \n- document guard behavior in OpenSSL README\n\n## Validation\n- \n- \n- DEV_ENV_OK\n- FIPS_GUARD_BYPASSED_OK\n- forced fail check: [dev-env] enforcing FIPS-only runtime guard via fips-preflight.sh
[fips-preflight] mode=only
[fips-preflight] openssl=/opt/homebrew/opt/openssl@3/bin/openssl
[fips-preflight] OPENSSL_MODULES=/tmp/does-not-exist-modules
[fips-preflight] OPENSSL_CONF=/tmp/does-not-exist.cnf
OpenSSL 3.6.1 27 Jan 2026 (Library: OpenSSL 3.6.1 27 Jan 2026)
built on: Tue Jan 27 13:33:54 2026 UTC
platform: darwin64-arm64-cc
options:  bn(64,64)
compiler: clang -fPIC -arch arm64 -O3 -Wall -DL_ENDIAN -DOPENSSL_PIC -D_REENTRANT -DOPENSSL_BUILDING_OPENSSL -DNDEBUG
OPENSSLDIR: "/opt/homebrew/etc/openssl@3"
ENGINESDIR: "/opt/homebrew/Cellar/openssl@3/3.6.1/lib/engines-3"
MODULESDIR: "/opt/homebrew/Cellar/openssl@3/3.6.1/lib/ossl-modules"
Seeding source: os-specific
CPUINFO: OPENSSL_armcap=0x987d

[fips-preflight] providers(active):
Providers:
  default
    name: OpenSSL Default Provider
    version: 3.6.1
    status: active

[fips-preflight] trying to load provider=fips... (expected non-zero)\n\n## Scope\n- non-consensus ops hardening only