### PR TITLE
Go consensus: in-process OpenSSL FIPS bootstrap

### DIFF
--- a/clients/go/consensus/openssl_signer.go
+++ b/clients/go/consensus/openssl_signer.go
@@ -116,6 +116,10 @@ import (
 )
 
 func newOpenSSLRawKeypair(alg string, expectedPubkeyLen int) (*C.EVP_PKEY, []byte, error) {
+	if err := ensureOpenSSLBootstrap(); err != nil {
+		return nil, nil, err
+	}
+
 	errBuf := make([]byte, 512)
 	cAlg := C.CString(alg)
 	defer C.free(unsafe.Pointer(cAlg))
@@ -147,6 +151,10 @@ func newOpenSSLRawKeypair(alg string, expectedPubkeyLen int) (*C.EVP_PKEY, []byt
 }
 
 func signOpenSSLDigest32(pkey *C.EVP_PKEY, digest [32]byte, maxSigBytes int, exactSigBytes int, oneShot bool) ([]byte, error) {
+	if err := ensureOpenSSLBootstrap(); err != nil {
+		return nil, err
+	}
+
 	errBuf := make([]byte, 512)
 	signature := make([]byte, maxSigBytes)
 	var signatureLen C.size_t

--- a/clients/go/consensus/verify_sig_openssl.go
+++ b/clients/go/consensus/verify_sig_openssl.go
@@ -7,6 +7,8 @@ package consensus
 
 #include <openssl/evp.h>
 #include <openssl/err.h>
+#include <openssl/provider.h>
+#include <openssl/crypto.h>
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -24,6 +26,83 @@ static void rubin_err(char* out, size_t out_len, const char* prefix) {
 	char buf[256];
 	ERR_error_string_n(e, buf, sizeof(buf));
 	snprintf(out, out_len, "%s: %s", prefix, buf);
+}
+
+static OSSL_PROVIDER* rubin_fips_provider = NULL;
+
+static int rubin_set_env_if_empty(const char* key, const char* value, char* err_buf, size_t err_buf_len) {
+	if (value == NULL || value[0] == '\0') {
+		return 1;
+	}
+	const char* current = getenv(key);
+	if (current != NULL && current[0] != '\0') {
+		return 1;
+	}
+	if (setenv(key, value, 1) != 0) {
+		rubin_err(err_buf, err_buf_len, "setenv failed");
+		return 0;
+	}
+	return 1;
+}
+
+static int rubin_check_sigalg(const char* alg, const char* props, char* err_buf, size_t err_buf_len) {
+	EVP_SIGNATURE* sig = EVP_SIGNATURE_fetch(NULL, alg, props);
+	if (sig == NULL) {
+		rubin_err(err_buf, err_buf_len, "EVP_SIGNATURE_fetch failed");
+		return 0;
+	}
+	EVP_SIGNATURE_free(sig);
+	return 1;
+}
+
+// Returns:
+//  1  -> bootstrap success
+// -1  -> bootstrap failure (err_buf populated)
+static int rubin_openssl_bootstrap(
+	int require_fips,
+	const char* rubin_conf,
+	const char* rubin_modules,
+	char* err_buf,
+	size_t err_buf_len
+) {
+	ERR_clear_error();
+
+	if (!rubin_set_env_if_empty("OPENSSL_CONF", rubin_conf, err_buf, err_buf_len)) {
+		return -1;
+	}
+	if (!rubin_set_env_if_empty("OPENSSL_MODULES", rubin_modules, err_buf, err_buf_len)) {
+		return -1;
+	}
+
+	if (OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL) != 1) {
+		rubin_err(err_buf, err_buf_len, "OPENSSL_init_crypto failed");
+		return -1;
+	}
+
+	if (!require_fips) {
+		return 1;
+	}
+
+	if (rubin_fips_provider == NULL) {
+		rubin_fips_provider = OSSL_PROVIDER_load(NULL, "fips");
+		if (rubin_fips_provider == NULL) {
+			rubin_err(err_buf, err_buf_len, "OSSL_PROVIDER_load(fips) failed");
+			return -1;
+		}
+	}
+
+	if (EVP_set_default_properties(NULL, "fips=yes") != 1) {
+		rubin_err(err_buf, err_buf_len, "EVP_set_default_properties(fips=yes) failed");
+		return -1;
+	}
+
+	if (!rubin_check_sigalg("ML-DSA-87", "provider=fips", err_buf, err_buf_len)) {
+		return -1;
+	}
+	if (!rubin_check_sigalg("SLH-DSA-SHAKE-256f", "provider=fips", err_buf, err_buf_len)) {
+		return -1;
+	}
+	return 1;
 }
 
 // Returns:
@@ -138,8 +217,81 @@ import "C"
 
 import (
 	"fmt"
+	"os"
+	"strings"
+	"sync"
 	"unsafe"
 )
+
+var (
+	opensslBootstrapOnce sync.Once
+	opensslBootstrapErr  error
+)
+
+func resetOpenSSLBootstrapStateForTests() {
+	opensslBootstrapOnce = sync.Once{}
+	opensslBootstrapErr = nil
+}
+
+func ensureOpenSSLBootstrap() error {
+	mode := strings.ToLower(strings.TrimSpace(os.Getenv("RUBIN_OPENSSL_FIPS_MODE")))
+	switch mode {
+	case "", "off":
+		return nil
+	case "ready", "only":
+	default:
+		return txerr(TX_ERR_PARSE, "openssl bootstrap: invalid RUBIN_OPENSSL_FIPS_MODE")
+	}
+
+	requireFIPS := mode == "only"
+	rubinConf := strings.TrimSpace(os.Getenv("RUBIN_OPENSSL_CONF"))
+	rubinModules := strings.TrimSpace(os.Getenv("RUBIN_OPENSSL_MODULES"))
+
+	opensslBootstrapOnce.Do(func() {
+		if err := opensslBootstrap(requireFIPS, rubinConf, rubinModules); err != nil {
+			opensslBootstrapErr = txerr(TX_ERR_PARSE, fmt.Sprintf("openssl bootstrap: %v", err))
+		}
+	})
+	return opensslBootstrapErr
+}
+
+func opensslBootstrap(requireFIPS bool, rubinConf string, rubinModules string) error {
+	var cConf *C.char
+	var cModules *C.char
+	if rubinConf != "" {
+		cConf = C.CString(rubinConf)
+		defer C.free(unsafe.Pointer(cConf))
+	}
+	if rubinModules != "" {
+		cModules = C.CString(rubinModules)
+		defer C.free(unsafe.Pointer(cModules))
+	}
+
+	errBuf := make([]byte, 512)
+	required := C.int(0)
+	if requireFIPS {
+		required = 1
+	}
+
+	rc := C.rubin_openssl_bootstrap(
+		required,
+		cConf,
+		cModules,
+		(*C.char)(unsafe.Pointer(&errBuf[0])),
+		C.size_t(len(errBuf)),
+	)
+	if int(rc) == 1 {
+		return nil
+	}
+	n := 0
+	for n < len(errBuf) && errBuf[n] != 0 {
+		n++
+	}
+	if n == 0 {
+		return fmt.Errorf("unknown bootstrap failure")
+	}
+	return fmt.Errorf("%s", string(errBuf[:n]))
+}
 
 func opensslVerifySigMessage(alg string, pubkey []byte, signature []byte, msg []byte) (bool, error) {
 	if alg == "" {
@@ -231,11 +383,17 @@ func opensslVerifySigDigestOneShot(alg string, pubkey []byte, signature []byte, 
 func verifySig(suiteID uint8, pubkey []byte, signature []byte, digest32 [32]byte) (bool, error) {
 	switch suiteID {
 	case SUITE_ID_ML_DSA_87:
+		if err := ensureOpenSSLBootstrap(); err != nil {
+			return false, err
+		}
 		if len(pubkey) != ML_DSA_87_PUBKEY_BYTES || len(signature) != ML_DSA_87_SIG_BYTES {
 			return false, nil
 		}
 		return opensslVerifySigMessage("ML-DSA-87", pubkey, signature, digest32[:])
 	case SUITE_ID_SLH_DSA_SHAKE_256F:
+		if err := ensureOpenSSLBootstrap(); err != nil {
+			return false, err
+		}
 		if len(pubkey) != SLH_DSA_SHAKE_256F_PUBKEY_BYTES || len(signature) == 0 || len(signature) > MAX_SLH_DSA_SIG_BYTES {
 			return false, nil
 		}

--- a/clients/go/consensus/verify_sig_openssl_bootstrap_test.go
+++ b/clients/go/consensus/verify_sig_openssl_bootstrap_test.go
@@ -1,0 +1,37 @@
+//go:build cgo
+
+package consensus
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestVerifySig_InvalidFIPSModeRejected(t *testing.T) {
+	resetOpenSSLBootstrapStateForTests()
+	t.Cleanup(resetOpenSSLBootstrapStateForTests)
+
+	kp := mustMLDSA87Keypair(t)
+	var digest [32]byte
+	digest[0] = 0x42
+	signature, err := kp.SignDigest32(digest)
+	if err != nil {
+		t.Fatalf("SignDigest32: %v", err)
+	}
+
+	t.Setenv("RUBIN_OPENSSL_FIPS_MODE", "definitely-invalid")
+
+	ok, verifyErr := verifySig(SUITE_ID_ML_DSA_87, kp.PubkeyBytes(), signature, digest)
+	if verifyErr == nil {
+		t.Fatalf("expected bootstrap mode error, got nil")
+	}
+	if ok {
+		t.Fatalf("expected verifySig=false on bootstrap mode error")
+	}
+	if got := mustTxErrCode(t, verifyErr); got != TX_ERR_PARSE {
+		t.Fatalf("code=%s, want %s", got, TX_ERR_PARSE)
+	}
+	if !strings.Contains(verifyErr.Error(), "invalid RUBIN_OPENSSL_FIPS_MODE") {
+		t.Fatalf("expected invalid mode context, got: %v", verifyErr)
+	}
+}


### PR DESCRIPTION
## What
- add one-time OpenSSL bootstrap in Go consensus path
- load config + FIPS provider in-process when `RUBIN_OPENSSL_FIPS_MODE=only`
- enforce `fips=yes` default properties and verify required PQ signature algs in provider
- wire optional `RUBIN_OPENSSL_CONF` / `RUBIN_OPENSSL_MODULES` env fallback
- call bootstrap from verify and signer/keygen paths
- add cgo test that hard-fails bootstrap when FIPS provider path is missing

## Validation
- `/Users/gpt/Documents/rubin-protocol/scripts/dev-env.sh -- bash -lc "cd /Users/gpt/Documents/rubin-protocol/clients/go && go test ./consensus"`
