### PR TITLE
codacy: configure duplication thresholds for dual-client architecture

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,3 +1,12 @@
+# ──────────────────────────────────────────────────────────
+# Codacy configuration for Rubin Protocol
+# ──────────────────────────────────────────────────────────
+# Duplication thresholds:
+#   clients/go/   — target < 5% (security-critical, duplication preferred over abstraction)
+#   clients/rust/ — target < 5% (same rationale)
+#   Cross-client Go↔Rust duplication is architectural (dual-client) and ignored.
+#   conformance/, rubin-formal/, tools/, scripts/, analysis/ — excluded entirely.
+# ──────────────────────────────────────────────────────────
 ---
 
 exclude_paths:
@@ -11,14 +20,25 @@ exclude_paths:
   - "conformance/**"
   - "rubin-formal/**"
   - "tools/**"
+  # Normative specs (Markdown documents, not code).
+  - "spec/**"
+  # Shell/JS utility scripts and spec analysis tooling.
+  - "scripts/**"
+  - "analysis/**"
+  # Generated files — deterministic output, not human-authored.
+  - "**/*.gen.go"
+  - "**/*_generated.rs"
+  # Dependency lockfiles.
+  - "package-lock.json"
 
 engines:
   duplication:
     # CLI dispatchers and fixture generators contain inherent structural
     # repetition (dispatch boilerplate, tx-building templates) that cannot be
-    # eliminated without sacrificing readability. Raise the minimum clone
+    # eliminated without sacrificing readability.  Raise the minimum clone
     # threshold so only substantive duplications (>25 lines) are reported.
     exclude_paths:
       - "clients/go/cmd/**"
+      - "clients/rust/crates/rubin-consensus-cli/**"
     config:
       minLines: 25


### PR DESCRIPTION
## Summary
Configure `.codacy.yml` with differentiated duplication thresholds aligned with the project's dual-client PQ-blockchain architecture.

- Add `spec/**`, `scripts/**`, `analysis/**` to `exclude_paths` (non-code artifacts)
- Add generated file globs (`*.gen.go`, `*_generated.rs`) and `package-lock.json`
- Exclude Rust CLI dispatcher (`clients/rust/crates/rubin-consensus-cli/**`) from duplication engine — same inherent dispatch pattern as Go CLI
- Add header comment documenting per-layer duplication targets (`< 5%`)
- Cross-client Go↔Rust duplication is architectural (dual-client parallel implementation) and already ignored by Codacy (PMD-CPD is per-language)

**Note:** `spec/**` path added as safety net — specs are currently in a private repo but the exclude prevents false positives if they return.

Closes #279
Queue: Q-TOOLING-08

## Test plan
- [x] Go tests 6/6 PASS (config-only change)
- [ ] CI pipeline (policy, test, formal, security_ai, validator)
- [ ] Codacy checks (Coverage Variation, Diff Coverage, Static Code Analysis)

🤖 Generated with [Claude Code](https://claude.com/claude-code)