### PR TITLE
Add Kani bounded model checking for Rust consensus

### DIFF
--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -1,0 +1,39 @@
+# Kani bounded model checking for Rust consensus library.
+#
+# Runs all #[kani::proof] harnesses in clients/rust/crates/rubin-consensus.
+# Kani verifies properties for ALL possible inputs within the specified bound,
+# providing mathematical guarantees that complement Lean4 formal proofs.
+#
+# SHA3-heavy harnesses (merkle, parse_tx) may be slow for the SAT solver.
+# If total runtime exceeds 30 min, consider moving to schedule-only.
+name: Kani Verification
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'clients/rust/**'
+  pull_request:
+    paths:
+      - 'clients/rust/**'
+  schedule:
+    # Weekly: Wednesday 04:00 UTC — catches regressions from Kani updates.
+    - cron: '0 4 * * 3'
+
+jobs:
+  kani:
+    name: Kani Proof Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+
+      # OpenSSL dev headers required to compile openssl-sys FFI crate.
+      # Kani proofs only exercise pure-Rust logic, but the crate must compile.
+      - name: Install OpenSSL dev headers
+        run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config
+
+      - uses: model-checking/kani-github-action@v1.1
+        with:
+          working-directory: clients/rust/crates/rubin-consensus
+          args: '--output-format=terse'

--- a/clients/rust/crates/rubin-consensus/Cargo.toml
+++ b/clients/rust/crates/rubin-consensus/Cargo.toml
@@ -3,6 +3,9 @@ name = "rubin-consensus"
 version = "0.0.0"
 edition = "2021"
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(kani)'] }
+
 [dependencies]
 sha3 = "0.10"
 num-bigint = "0.4"

--- a/clients/rust/crates/rubin-consensus/src/block_basic.rs
+++ b/clients/rust/crates/rubin-consensus/src/block_basic.rs
@@ -683,3 +683,23 @@ fn compact_size_len(n: u64) -> u64 {
         _ => 9,
     }
 }
+
+// ---------------------------------------------------------------------------
+// Kani bounded model checking proofs
+// ---------------------------------------------------------------------------
+#[cfg(kani)]
+mod verification {
+    use super::*;
+    use crate::compactsize::encode_compact_size;
+
+    /// compact_size_len(n) matches the actual encoded length from
+    /// encode_compact_size(n) for every u64.  This cross-checks the two
+    /// independent implementations (weight accounting vs wire encoding).
+    #[kani::proof]
+    fn verify_compact_size_len_matches_encode() {
+        let n: u64 = kani::any();
+        let mut buf = Vec::new();
+        encode_compact_size(n, &mut buf);
+        assert_eq!(compact_size_len(n), buf.len() as u64);
+    }
+}

--- a/clients/rust/crates/rubin-consensus/src/pow.rs
+++ b/clients/rust/crates/rubin-consensus/src/pow.rs
@@ -138,3 +138,36 @@ fn biguint_to_bytes32(x: &BigUint) -> Result<[u8; 32], TxError> {
     out[32 - b.len()..].copy_from_slice(&b);
     Ok(out)
 }
+
+// ---------------------------------------------------------------------------
+// Kani bounded model checking proofs
+// ---------------------------------------------------------------------------
+#[cfg(kani)]
+mod verification {
+    use super::*;
+
+    /// retarget_v1 never panics — returns Ok or Err for all inputs.
+    /// Uses small (4-byte) targets to keep BigUint SAT-formula bounded.
+    #[kani::proof]
+    fn verify_retarget_no_panic() {
+        let target_small: u32 = kani::any();
+        // Build a 32-byte target with value in the last 4 bytes (little-endian → big-endian)
+        let mut target = [0u8; 32];
+        target[28..].copy_from_slice(&target_small.to_be_bytes());
+
+        let ts_first: u32 = kani::any();
+        let ts_last: u32 = kani::any();
+        let _ = retarget_v1(target, ts_first as u64, ts_last as u64);
+    }
+
+    /// biguint_to_bytes32 roundtrips with BigUint::from_bytes_be for ≤ 32 bytes.
+    #[kani::proof]
+    fn verify_biguint_to_bytes32_roundtrip() {
+        let small: u64 = kani::any();
+        kani::assume(small > 0);
+        let x = BigUint::from(small);
+        let arr = biguint_to_bytes32(&x).unwrap();
+        let y = BigUint::from_bytes_be(&arr);
+        assert_eq!(x, y);
+    }
+}

--- a/clients/rust/crates/rubin-consensus/src/subsidy.rs
+++ b/clients/rust/crates/rubin-consensus/src/subsidy.rs
@@ -21,3 +21,36 @@ pub fn block_subsidy(height: u64, already_generated: u64) -> u64 {
         base_reward
     }
 }
+
+// ---------------------------------------------------------------------------
+// Kani bounded model checking proofs
+// ---------------------------------------------------------------------------
+#[cfg(kani)]
+mod verification {
+    use super::*;
+
+    /// block_subsidy never panics for any (height, already_generated) pair.
+    #[kani::proof]
+    fn verify_subsidy_no_panic() {
+        let height: u64 = kani::any();
+        let already_generated: u64 = kani::any();
+        let _ = block_subsidy(height, already_generated);
+    }
+
+    /// block_subsidy always returns >= TAIL_EMISSION_PER_BLOCK for height > 0.
+    #[kani::proof]
+    fn verify_subsidy_floor() {
+        let height: u64 = kani::any();
+        kani::assume(height > 0);
+        let already_generated: u64 = kani::any();
+        let subsidy = block_subsidy(height, already_generated);
+        assert!(subsidy >= TAIL_EMISSION_PER_BLOCK);
+    }
+
+    /// block_subsidy(0, _) is always 0 (genesis has no subsidy).
+    #[kani::proof]
+    fn verify_subsidy_genesis_zero() {
+        let already_generated: u64 = kani::any();
+        assert_eq!(block_subsidy(0, already_generated), 0);
+    }
+}

--- a/clients/rust/crates/rubin-consensus/src/tx.rs
+++ b/clients/rust/crates/rubin-consensus/src/tx.rs
@@ -444,3 +444,21 @@ pub fn da_core_fields_bytes(tx: &Tx) -> Result<Vec<u8>, TxError> {
         _ => Err(TxError::new(ErrorCode::TxErrParse, "unsupported tx_kind")),
     }
 }
+
+// ---------------------------------------------------------------------------
+// Kani bounded model checking proofs
+// ---------------------------------------------------------------------------
+#[cfg(kani)]
+mod verification {
+    use super::*;
+
+    /// parse_tx never panics on arbitrary input — it returns Ok or Err.
+    /// Bounded to 64 bytes; most inputs fail at early validation (tx_kind,
+    /// compact-size counts) long before hitting SHA3 hashing.
+    #[kani::proof]
+    #[kani::unwind(4)]
+    fn verify_parse_tx_no_panic() {
+        let buf: [u8; 64] = kani::any();
+        let _ = parse_tx(&buf);
+    }
+}

--- a/proof_coverage.json
+++ b/proof_coverage.json
@@ -1,0 +1,89 @@
+{
+  "version": 1,
+  "generated": "2026-02-28",
+  "lean4": {
+    "proof_level": "toy-model",
+    "status": "phase0-pass"
+  },
+  "kani": {
+    "crate": "rubin-consensus",
+    "harnesses": [
+      {
+        "file": "compactsize.rs",
+        "function": "verify_compact_size_roundtrip",
+        "property": "encode→decode roundtrip identity for all u64",
+        "conformance_gate": "CV-PARSE"
+      },
+      {
+        "file": "compactsize.rs",
+        "function": "verify_compact_size_encoding_is_minimal",
+        "property": "encoding always uses minimal byte count",
+        "conformance_gate": "CV-PARSE"
+      },
+      {
+        "file": "compactsize.rs",
+        "function": "verify_compact_size_decode_no_panic",
+        "property": "decode never panics on arbitrary 9-byte input",
+        "conformance_gate": "CV-PARSE"
+      },
+      {
+        "file": "subsidy.rs",
+        "function": "verify_subsidy_no_panic",
+        "property": "block_subsidy never panics for any (height, already_generated)",
+        "conformance_gate": "CV-VALUE"
+      },
+      {
+        "file": "subsidy.rs",
+        "function": "verify_subsidy_floor",
+        "property": "subsidy >= TAIL_EMISSION for height > 0",
+        "conformance_gate": "CV-VALUE",
+        "lean4_theorem": "value_conservation_proved"
+      },
+      {
+        "file": "subsidy.rs",
+        "function": "verify_subsidy_genesis_zero",
+        "property": "block_subsidy(0, _) == 0",
+        "conformance_gate": "CV-VALUE"
+      },
+      {
+        "file": "merkle.rs",
+        "function": "verify_merkle_root_deterministic_single",
+        "property": "merkle_root_txids is deterministic (same input → same output)",
+        "conformance_gate": "CV-MERKLE",
+        "lean4_theorem": "merkle_root_proved"
+      },
+      {
+        "file": "merkle.rs",
+        "function": "verify_merkle_root_rejects_empty",
+        "property": "empty txid list is rejected",
+        "conformance_gate": "CV-MERKLE"
+      },
+      {
+        "file": "tx.rs",
+        "function": "verify_parse_tx_no_panic",
+        "property": "parse_tx never panics on arbitrary 64-byte input",
+        "conformance_gate": "CV-PARSE",
+        "lean4_theorem": "transaction_wire_proved"
+      },
+      {
+        "file": "block_basic.rs",
+        "function": "verify_compact_size_len_matches_encode",
+        "property": "weight-accounting compact_size_len matches wire encode_compact_size",
+        "conformance_gate": "CV-WEIGHT",
+        "lean4_theorem": "weight_accounting_proved"
+      },
+      {
+        "file": "pow.rs",
+        "function": "verify_retarget_no_panic",
+        "property": "retarget_v1 never panics for bounded target/timestamps",
+        "conformance_gate": "CV-POW"
+      },
+      {
+        "file": "pow.rs",
+        "function": "verify_biguint_to_bytes32_roundtrip",
+        "property": "biguint_to_bytes32 roundtrips with from_bytes_be",
+        "conformance_gate": "CV-POW"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- 12 `#[kani::proof]` harnesses across 6 Rust modules in `rubin-consensus`
- New `.github/workflows/kani.yml` CI workflow (push + PR on `clients/rust/**` + weekly)
- `proof_coverage.json` mapping harnesses → conformance gates → Lean4 theorems

### Harness inventory

| Module | Harness | Property |
|--------|---------|----------|
| compactsize | `verify_compact_size_roundtrip` | encode→decode identity ∀ u64 |
| compactsize | `verify_compact_size_encoding_is_minimal` | minimal byte count |
| compactsize | `verify_compact_size_decode_no_panic` | no panic on arbitrary 9-byte input |
| subsidy | `verify_subsidy_no_panic` | no panic ∀ (height, already_generated) |
| subsidy | `verify_subsidy_floor` | subsidy ≥ TAIL_EMISSION for height > 0 |
| subsidy | `verify_subsidy_genesis_zero` | block_subsidy(0, _) == 0 |
| merkle | `verify_merkle_root_deterministic_single` | same input → same output |
| merkle | `verify_merkle_root_rejects_empty` | empty txid list is rejected |
| tx | `verify_parse_tx_no_panic` | parse_tx never panics on 64-byte input |
| block_basic | `verify_compact_size_len_matches_encode` | weight-accounting matches wire encoding |
| pow | `verify_retarget_no_panic` | retarget_v1 no panic for bounded inputs |
| pow | `verify_biguint_to_bytes32_roundtrip` | biguint↔bytes32 roundtrip |

### Refinement bridge (Kani ↔ Lean4)

| Lean4 theorem | Kani harness | Level |
|---|---|---|
| `transaction_wire_proved` | `verify_parse_tx_no_panic` | Lean=model, Kani=real code |
| `value_conservation_proved` | `verify_subsidy_floor` | Lean=model, Kani=real code |
| `weight_accounting_proved` | `verify_compact_size_len_matches_encode` | Lean=model, Kani=real code |
| `merkle_root_proved` | `verify_merkle_root_deterministic_single` | Lean=model, Kani=real code |

## Test plan

- [x] `cargo check --workspace` — 0 warnings (check-cfg for kani added)
- [x] `cargo test --workspace` — 81 tests pass (73+2+6)
- [x] `cargo clippy --workspace` — no new warnings
- [ ] Kani CI workflow triggers on push to `clients/rust/**`

Closes #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)