### PR TITLE
Add sighash fuzz target (CV-SIG)

### DIFF
--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -70,7 +70,7 @@ jobs:
           RUST_FUZZ_TIME: ${{ github.event.inputs.rust_fuzz_time || '60' }}
         run: |
           cd clients/rust
-          TARGETS=(merkle_determinism retarget_no_panic biguint_roundtrip parse_tx parse_block_bytes compactsize)
+          TARGETS=(merkle_determinism retarget_no_panic biguint_roundtrip sighash parse_tx parse_block_bytes compactsize)
           STATUS=0
           for target in "${TARGETS[@]}"; do
             echo "==> fuzzing $target for ${RUST_FUZZ_TIME}s"

--- a/clients/rust/fuzz/Cargo.toml
+++ b/clients/rust/fuzz/Cargo.toml
@@ -48,3 +48,9 @@ name = "biguint_roundtrip"
 path = "fuzz_targets/biguint_roundtrip.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "sighash"
+path = "fuzz_targets/sighash.rs"
+test = false
+doc = false

--- a/clients/rust/fuzz/fuzz_targets/sighash.rs
+++ b/clients/rust/fuzz/fuzz_targets/sighash.rs
@@ -1,0 +1,45 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+// Fuzz sighash_v1_digest: parse arbitrary bytes into a Tx, then compute
+// sighash for each input.  Verifies determinism (same tx → same digest)
+// and no-panic for any parseable transaction.
+fuzz_target!(|data: &[u8]| {
+    // Need at least some bytes for tx + input_index(4) + input_value(8) + chain_id(32).
+    if data.len() < 44 {
+        return;
+    }
+
+    // Split: last 44 bytes are sighash params, rest is tx wire bytes.
+    let tx_end = data.len() - 44;
+    let tx_bytes = &data[..tx_end];
+    let params = &data[tx_end..];
+
+    let tx = match rubin_consensus::parse_tx(tx_bytes) {
+        Ok(t) => t,
+        Err(_) => return,
+    };
+
+    if tx.inputs.is_empty() {
+        return;
+    }
+
+    let input_index = u32::from_le_bytes(params[..4].try_into().unwrap()) % tx.inputs.len() as u32;
+    let input_value = u64::from_le_bytes(params[4..12].try_into().unwrap());
+    let mut chain_id = [0u8; 32];
+    chain_id.copy_from_slice(&params[12..44]);
+
+    let r1 = rubin_consensus::sighash_v1_digest(&tx, input_index, input_value, chain_id);
+    let r2 = rubin_consensus::sighash_v1_digest(&tx, input_index, input_value, chain_id);
+
+    match (&r1, &r2) {
+        (Ok(a), Ok(b)) => {
+            if a != b {
+                panic!("sighash_v1_digest non-deterministic");
+            }
+        }
+        (Err(_), Err(_)) => {}
+        _ => panic!("sighash_v1_digest non-deterministic error/ok mismatch"),
+    }
+});

--- a/proof_coverage.json
+++ b/proof_coverage.json
@@ -126,6 +126,11 @@
       {
         "name": "compactsize",
         "property": "CompactSize decode→encode roundtrip"
+      },
+      {
+        "name": "sighash",
+        "property": "sighash_v1_digest determinism and no-panic for arbitrary parsed transactions",
+        "conformance_gate": "CV-SIG"
       }
     ]
   }


### PR DESCRIPTION
## Summary
- Add `sighash` fuzz target covering `sighash_v1_digest` determinism + no-panic
- Uses structure-aware fuzzing: parse_tx filters invalid bytes, libFuzzer learns valid Tx structure
- Added to fuzz-nightly CI (7 Rust targets total)
- Updated proof_coverage.json with CV-SIG gate mapping

## Test plan
- [ ] All required CI checks pass
- [ ] `fuzz-nightly` workflow runs sighash target without crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)