### PR TITLE
ops: OpenSSL CVE response process + CI policy gate (Q-A287-05)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,10 @@ jobs:
             --code-root . \
             --skip-doc-policy
 
+      - name: OpenSSL CVE response policy
+        run: |
+          python3 tools/check_openssl_cve_response.py --code-root .
+
   security_ai:
     needs: policy
     runs-on: ubuntu-latest

--- a/scripts/crypto/openssl/CVE_RESPONSE_RUNBOOK.md
+++ b/scripts/crypto/openssl/CVE_RESPONSE_RUNBOOK.md
@@ -1,0 +1,82 @@
+# OpenSSL CVE Response Runbook
+
+Status: Operational policy (repository enforcement)  
+Scope: `clients/go`, `clients/rust`, OpenSSL bundle pipeline, release packaging
+
+## 1) Intake and Disclosure Channels
+
+Primary intake channels:
+
+1. GitHub Security Advisory (private report for this repository).
+2. OpenSSL upstream security advisories and release notes.
+3. NVD/CVE feed items referencing OpenSSL 3.x.
+
+Internal disclosure path:
+
+1. Open a private incident thread titled `OPENSSL-CVE-<id>`.
+2. Assign one incident owner and one backup owner.
+3. Record first-seen timestamp (UTC) and affected repository refs.
+
+## 2) SLA Targets
+
+The response SLA is measured from first-seen timestamp.
+
+| Severity | Triage start | Impact decision | Patch PR opened | Release evidence complete |
+|---|---:|---:|---:|---:|
+| Critical (RCE/memory corruption in active path) | <= 2h | <= 6h | <= 24h | <= 48h |
+| High | <= 4h | <= 12h | <= 48h | <= 72h |
+| Medium | <= 1 business day | <= 2 business days | <= 5 business days | <= 7 business days |
+| Low | <= 2 business days | <= 5 business days | Planned maintenance window | Planned maintenance window |
+
+If SLA cannot be met, incident owner MUST publish a blocker note with ETA and mitigation status.
+
+## 3) Patch Triage Procedure
+
+1. Confirm whether affected OpenSSL versions intersect:
+   - bundled version in CI/build scripts,
+   - local runtime requirements in `scripts/dev-env.sh`,
+   - production deployment constraints (if applicable).
+2. Classify impact:
+   - **Consensus-impacting**: can alter accept/reject decisions or signature verification outcomes.
+   - **Operational-only**: availability/perf/compliance without consensus drift.
+3. Prepare mitigation:
+   - version bump and bundle rebuild,
+   - temporary runtime guard (if needed),
+   - tests for regression and deterministic behavior.
+4. Open one PR for code/tooling updates and one PR for spec/ops updates when required.
+5. Run mandatory validation gates before merge:
+   - `policy`, `test`, `security_ai`, `formal`, `formal_refinement`, `validator`, `CodeQL`.
+
+## 4) Release Evidence Requirements
+
+A CVE response is not complete until evidence is attached in the release note or incident report.
+
+Required evidence block:
+
+1. CVE identifier(s) and severity.
+2. Affected component list (Go/Rust/bundle/CI).
+3. Fixed OpenSSL version and bundle hash/checksum.
+4. PR links and merge commit SHAs.
+5. CI run IDs for required checks.
+6. `fips-preflight.sh` result for `RUBIN_OPENSSL_FIPS_MODE=only`.
+7. Rollback instruction (previous known-good version + trigger condition).
+
+## 5) Controller Escalation Rule
+
+Mark as **НУЖНО ОДОБРЕНИЕ КОНТРОЛЕРА** when the mitigation requires:
+
+- consensus-rule changes,
+- error-code remapping in consensus paths,
+- wire-format changes,
+- governance-level freeze exceptions.
+
+Operational-only OpenSSL version updates do not require controller approval if consensus behavior is unchanged.
+
+## 6) Closure Criteria
+
+Incident can be closed only when all are true:
+
+1. Patch merged to default branch.
+2. Required CI checks green on merge commit.
+3. Evidence block complete.
+4. Queue task updated to `DONE` with evidence reference.

--- a/scripts/crypto/openssl/README.md
+++ b/scripts/crypto/openssl/README.md
@@ -49,6 +49,19 @@ Operational implication:
 - Parallel `verify_sig` is supported, but context lifecycle must remain strictly per-call.
 - Any optimization that introduces shared mutable OpenSSL contexts is out of policy and must be rejected.
 
+## OpenSSL CVE response process
+
+Use the dedicated runbook:
+
+- `scripts/crypto/openssl/CVE_RESPONSE_RUNBOOK.md`
+
+The runbook defines:
+
+- SLA by severity,
+- intake and disclosure channels,
+- patch triage procedure,
+- mandatory release evidence payload.
+
 ## Run PQ benchmark (OpenSSL `speed`, primary)
 
 ```bash

--- a/tools/check_openssl_cve_response.py
+++ b/tools/check_openssl_cve_response.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+REQUIRED_SECTIONS = [
+    "## 1) Intake and Disclosure Channels",
+    "## 2) SLA Targets",
+    "## 3) Patch Triage Procedure",
+    "## 4) Release Evidence Requirements",
+    "## 5) Controller Escalation Rule",
+    "## 6) Closure Criteria",
+]
+
+REQUIRED_PHRASES = [
+    "GitHub Security Advisory",
+    "RUBIN_OPENSSL_FIPS_MODE=only",
+    "Queue task updated to `DONE` with evidence reference",
+    "НУЖНО ОДОБРЕНИЕ КОНТРОЛЕРА",
+]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate OpenSSL CVE response runbook coverage."
+    )
+    parser.add_argument(
+        "--code-root",
+        default=".",
+        help="Path to repository root.",
+    )
+    args = parser.parse_args()
+
+    root = Path(args.code_root).resolve()
+    runbook = root / "scripts" / "crypto" / "openssl" / "CVE_RESPONSE_RUNBOOK.md"
+    readme = root / "scripts" / "crypto" / "openssl" / "README.md"
+
+    errors: list[str] = []
+
+    if not runbook.exists():
+        errors.append(f"missing required file: {runbook}")
+    if not readme.exists():
+        errors.append(f"missing required file: {readme}")
+
+    if errors:
+        for err in errors:
+            print(f"ERROR: {err}", file=sys.stderr)
+        return 1
+
+    runbook_text = runbook.read_text(encoding="utf-8", errors="strict")
+    readme_text = readme.read_text(encoding="utf-8", errors="strict")
+
+    for section in REQUIRED_SECTIONS:
+        if section not in runbook_text:
+            errors.append(f"missing runbook section: {section!r}")
+
+    for phrase in REQUIRED_PHRASES:
+        if phrase not in runbook_text:
+            errors.append(f"missing runbook phrase: {phrase!r}")
+
+    if "CVE_RESPONSE_RUNBOOK.md" not in readme_text:
+        errors.append("README must reference scripts/crypto/openssl/CVE_RESPONSE_RUNBOOK.md")
+
+    if errors:
+        for err in errors:
+            print(f"ERROR: {err}", file=sys.stderr)
+        return 1
+
+    print("OK: OpenSSL CVE response runbook policy checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `scripts/crypto/openssl/CVE_RESPONSE_RUNBOOK.md`
- define OpenSSL CVE intake/disclosure channels, SLA table, triage flow, and closure criteria
- require explicit release evidence payload (CVE id, affected components, fixed version/hash, CI run IDs, FIPS preflight, rollback note)
- add policy lint `tools/check_openssl_cve_response.py` and wire it into CI `policy` job

## Validation
- `python3 tools/check_openssl_cve_response.py --code-root .`
- `python3 tools/check_keygen_security_profile.py --context-root . --code-root . --skip-doc-policy`
- `python3 tools/check_sensitive_files.py`

## Queue
- Q-A287-05
- Closes #292
