### PR TITLE
consensus: fix double-parse hot path + HTLC dead guards (Q-CF-15/16)

### DIFF
--- a/clients/go/consensus/block_basic.go
+++ b/clients/go/consensus/block_basic.go
@@ -119,6 +119,19 @@ func ValidateBlockBasicWithContextAtHeight(
 	if err != nil {
 		return nil, err
 	}
+	return validateParsedBlockBasicWithContextAtHeight(pb, expectedPrevHash, expectedTarget, blockHeight, prevTimestamps)
+}
+
+func validateParsedBlockBasicWithContextAtHeight(
+	pb *ParsedBlock,
+	expectedPrevHash *[32]byte,
+	expectedTarget *[32]byte,
+	blockHeight uint64,
+	prevTimestamps []uint64,
+) (*BlockBasicSummary, error) {
+	if pb == nil {
+		return nil, txerr(BLOCK_ERR_PARSE, "nil parsed block")
+	}
 
 	if expectedPrevHash != nil && pb.Header.PrevBlockHash != *expectedPrevHash {
 		return nil, txerr(BLOCK_ERR_LINKAGE_INVALID, "prev_block_hash mismatch")
@@ -239,11 +252,11 @@ func ValidateBlockBasicWithContextAndFeesAtHeight(
 	alreadyGenerated uint64,
 	sumFees uint64,
 ) (*BlockBasicSummary, error) {
-	s, err := ValidateBlockBasicWithContextAtHeight(blockBytes, expectedPrevHash, expectedTarget, blockHeight, prevTimestamps)
+	pb, err := ParseBlockBytes(blockBytes)
 	if err != nil {
 		return nil, err
 	}
-	pb, err := ParseBlockBytes(blockBytes)
+	s, err := validateParsedBlockBasicWithContextAtHeight(pb, expectedPrevHash, expectedTarget, blockHeight, prevTimestamps)
 	if err != nil {
 		return nil, err
 	}

--- a/clients/go/consensus/htlc.go
+++ b/clients/go/consensus/htlc.go
@@ -65,9 +65,6 @@ func ValidateHTLCSpend(
 	pathID := pathSig[0]
 	switch pathID {
 	case 0x00: // claim
-		if len(pathItem.Pubkey) != 32 {
-			return txerr(TX_ERR_PARSE, "CORE_HTLC claim path key_id length invalid")
-		}
 		var pathKeyID [32]byte
 		copy(pathKeyID[:], pathItem.Pubkey)
 		if pathKeyID != c.ClaimKeyID {
@@ -93,9 +90,6 @@ func ValidateHTLCSpend(
 		expectedKeyID = c.ClaimKeyID
 
 	case 0x01: // refund
-		if len(pathItem.Pubkey) != 32 {
-			return txerr(TX_ERR_PARSE, "CORE_HTLC refund path key_id length invalid")
-		}
 		if len(pathSig) != 1 {
 			return txerr(TX_ERR_PARSE, "CORE_HTLC refund payload length mismatch")
 		}


### PR DESCRIPTION
## Summary
- remove duplicate block parsing in `ValidateBlockBasicWithContextAndFeesAtHeight` by reusing one parsed block for both basic checks and coinbase bound
- keep existing validation order and error mapping, but avoid redundant `ParseBlockBytes` hot-path work
- remove unreachable duplicated HTLC key-length guards in `ValidateHTLCSpend` claim/refund branches; keep single selector-level guard

## Validation
- `scripts/dev-env.sh -- bash -lc "cd /Users/gpt/Documents/rubin-protocol-cf-15-16/clients/go && go test ./consensus"`

## Queue
- Q-CF-15
- Q-CF-16

Closes #267
Closes #268
