### PR TITLE
Q-CRYPTO-OPS-01: one-time in-process OpenSSL bootstrap for Rust

### DIFF
--- a/scripts/crypto/openssl/README.md
+++ b/scripts/crypto/openssl/README.md
@@ -31,6 +31,8 @@ Runtime enforcement in `RUBIN_OPENSSL_FIPS_MODE=only`:
 
 - `scripts/dev-env.sh -- <cmd>` now runs the same preflight automatically and hard-fails when
   `provider=fips`/required PQ signatures are unavailable.
+- In-process bootstrap is enforced once per process in both Go and Rust consensus verify paths
+  (`OPENSSL_CONF`/`OPENSSL_MODULES` from `RUBIN_OPENSSL_*` are applied before provider checks).
 - Temporary bypass (for bootstrap/debug only): set `RUBIN_OPENSSL_SKIP_FIPS_GUARD=1`.
 
 ## Thread-safety assumptions (verify/sign paths)

--- a/tools/check_crypto_backend_policy.py
+++ b/tools/check_crypto_backend_policy.py
@@ -58,11 +58,13 @@ GO_VERIFY_REQUIRED_SNIPPET_GROUPS = [
     [
         'return opensslVerifySigOneShot("ML-DSA-87", pubkey, signature, digest32[:])',
         'return opensslVerifySigMessage("ML-DSA-87", pubkey, signature, digest32[:])',
+        'return verifyWithMapping("ML-DSA-87")',
     ],
     ["case SUITE_ID_SLH_DSA_SHAKE_256F:"],
     [
         'return opensslVerifySigOneShot("SLH-DSA-SHAKE-256f", pubkey, signature, digest32[:])',
         'return opensslVerifySigDigestOneShot("SLH-DSA-SHAKE-256f", pubkey, signature, digest32[:])',
+        'return verifyWithMapping("SLH-DSA-SHAKE-256f")',
     ],
     [
         "func opensslVerifySigOneShot(",
@@ -77,6 +79,11 @@ RUST_VERIFY_REQUIRED_SNIPPETS = [
     "pub fn verify_sig(",
     'SUITE_ID_ML_DSA_87 => Ok(c"ML-DSA-87")',
     'SUITE_ID_SLH_DSA_SHAKE_256F => Ok(c"SLH-DSA-SHAKE-256f")',
+    "fn parse_openssl_fips_mode(",
+    "fn ensure_openssl_bootstrap()",
+    "OPENSSL_init_crypto(",
+    "OSSL_PROVIDER_load(",
+    "EVP_set_default_properties(",
     "fn openssl_verify_sig_digest_oneshot(",
     "EVP_DigestVerifyInit_ex(",
     "core::ptr::null()",


### PR DESCRIPTION
## Summary
- add Rust in-process OpenSSL bootstrap with one-time initialization controlled by `RUBIN_OPENSSL_FIPS_MODE`
- apply `RUBIN_OPENSSL_CONF` / `RUBIN_OPENSSL_MODULES` to process env before provider checks
- enforce `fips=yes` + provider algorithm fetch checks in `only` mode
- update crypto backend policy lint invariants for current Go mapping and Rust bootstrap invariants
- document once-only in-process bootstrap behavior in OpenSSL README

## Validation
- `scripts/dev-env.sh -- bash -lc 'cd /Users/gpt/Documents/rubin-protocol/clients/go && go test ./consensus'`
- `scripts/dev-env.sh -- bash -lc 'cd /Users/gpt/Documents/rubin-protocol/clients/rust && cargo test -p rubin-consensus'`
- `scripts/dev-env.sh -- python3 /Users/gpt/Documents/rubin-protocol/tools/check_crypto_backend_policy.py --context-root /Users/gpt/Documents/rubin-spec-private --code-root /Users/gpt/Documents/rubin-protocol`
