### PR TITLE
Q-PARITY-01: unify Rust coinbase bound on u128 path

### DIFF
--- a/clients/rust/crates/rubin-consensus/src/block_basic.rs
+++ b/clients/rust/crates/rubin-consensus/src/block_basic.rs
@@ -296,7 +296,7 @@ fn validate_coinbase_structure(pb: &ParsedBlock, block_height: u64) -> Result<()
     Ok(())
 }
 
-fn validate_coinbase_value_bound(
+pub(crate) fn validate_coinbase_value_bound(
     pb: &ParsedBlock,
     block_height: u64,
     already_generated: u64,


### PR DESCRIPTION
Closes 2tbmz9y2xt-lang/rubin-spec#23

Queue: Q-PARITY-01 (P0)

Problem:
- `connect_block_inmem.rs` had a duplicate `validate_coinbase_value_bound` using `u64` math.
- `block_basic.rs` already had the correct `u128` implementation.

Fix:
- make `block_basic::validate_coinbase_value_bound` `pub(crate)`
- remove duplicate from `connect_block_inmem.rs`
- import and reuse shared helper in in-memory connect path

Validation:
- `cargo test -p rubin-consensus` PASS
- `conformance/runner/run_cv_bundle.py` PASS (191 vectors)
