### PR TITLE
fix(consensus): deduplicate coinbase bound u64→u128

### DIFF
--- a/clients/rust/crates/rubin-consensus/src/block_basic.rs
+++ b/clients/rust/crates/rubin-consensus/src/block_basic.rs
@@ -296,7 +296,7 @@ fn validate_coinbase_structure(pb: &ParsedBlock, block_height: u64) -> Result<()
     Ok(())
 }
 
-fn validate_coinbase_value_bound(
+pub(crate) fn validate_coinbase_value_bound(
     pb: &ParsedBlock,
     block_height: u64,
     already_generated: u64,


### PR DESCRIPTION
## Summary
- Remove duplicated `validate_coinbase_value_bound` from `connect_block_inmem.rs` that used **u64** arithmetic (overflow risk on coinbase output summation)
- Import the canonical **u128** version from `block_basic.rs` (changed to `pub(crate)`)
- Ensures stateless (`validate_block_basic`) and stateful (`connect_block_basic_in_memory`) validation paths use **identical** arithmetic

## Risk
**CRITICAL** — The u64 duplicate could silently overflow when coinbase outputs sum exceeds `u64::MAX`, causing divergent consensus between `block_basic` (u128, correct) and `connect_block_inmem` (u64, buggy).

## Changes
| File | Change |
|------|--------|
| `block_basic.rs` | `fn` → `pub(crate) fn` for `validate_coinbase_value_bound` |
| `connect_block_inmem.rs` | Remove 36-line duplicate function, import from `block_basic` |

## Test plan
- [x] `cargo check` — 0 errors, 0 warnings
- [x] `cargo test --workspace` — all tests pass
- [ ] CI pipeline (13 checks)

Fixes #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)