### PR TITLE
Q-MARSHAL-DA-01: include DA core fields in MarshalTx

### DIFF
--- a/clients/go/consensus/tx_marshal.go
+++ b/clients/go/consensus/tx_marshal.go
@@ -38,6 +38,13 @@ func MarshalTx(tx *Tx) ([]byte, error) {
 	// Locktime
 	b = AppendU32le(b, tx.Locktime)
 
+	// DA core fields (tx_kind-specific, positioned before witness section).
+	daCore, err := daCoreFieldsBytes(tx)
+	if err != nil {
+		return nil, err
+	}
+	b = append(b, daCore...)
+
 	// Witness
 	b = AppendCompactSize(b, uint64(len(tx.Witness)))
 	for _, w := range tx.Witness {


### PR DESCRIPTION
## Summary
- fixes `MarshalTx` to serialize tx-kind specific DA core fields between `locktime` and `witness`
- reuses existing `daCoreFieldsBytes(tx)` canonical encoder
- adds roundtrip tests for `tx_kind=0x01` and `tx_kind=0x02`
- adds missing-core negative tests for DA kinds

## Validation
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./consensus -run TestMarshalTx'`
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./...'`
- `scripts/dev-env.sh -- python3 conformance/runner/run_cv_bundle.py`

Closes #310
