### PR TITLE
ci: skip jscpd duplication check on push events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
   cpd-check:
     name: "Duplication check (jscpd)"
     runs-on: ubuntu-latest
-        if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request' }}
     continue-on-error: true    # non-blocking, informational
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
The `getunlatch/jscpd-github-action@v1.2` only works on `pull_request` events.
On `push` to main it fails with: "This action only works on pull_request events".

This adds `if: github.event_name == 'pull_request'` to skip the job on push.