### PR TITLE
ci: add retry polling to auto-approve workflow

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -6,6 +6,9 @@ on:
   check_suite:
     types: [completed]
   status:
+  workflow_run:
+    workflows: [ci]
+    types: [completed]
 
 permissions:
   pull-requests: write
@@ -13,44 +16,66 @@ permissions:
 jobs:
   auto-approve:
     runs-on: ubuntu-latest
-    if: github.event.pull_request || github.event.check_suite || github.event.sha
+    if: github.event.pull_request || github.event.check_suite || github.event.sha || github.event.workflow_run
     steps:
-      - name: Wait for all checks
+      - name: Wait for all checks and approve
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            // Get PR number
+            const MAX_ATTEMPTS = 15;
+            const POLL_INTERVAL = 20000; // 20 seconds
+
+            // --- Find PR number ---
             let prNumber;
             if (context.payload.pull_request) {
               prNumber = context.payload.pull_request.number;
-            } else {
-              // Find PR from check_suite or status event
-              const sha = context.payload.check_suite?.head_sha || context.payload.sha;
-              if (!sha) return;
+            } else if (context.payload.workflow_run) {
+              // workflow_run: find PR from head branch
+              const branch = context.payload.workflow_run.head_branch;
               const prs = await github.rest.pulls.list({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 state: 'open',
-                head: `${context.repo.owner}:${sha}`
+                head: `${context.repo.owner}:${branch}`
               });
-              if (prs.data.length === 0) {
-                // Try by commit SHA
-                const pulls = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  commit_sha: sha
-                });
-                const open = pulls.data.filter(p => p.state === 'open');
-                if (open.length === 0) return;
+              if (prs.data.length > 0) prNumber = prs.data[0].number;
+            }
+
+            if (!prNumber) {
+              const sha = context.payload.check_suite?.head_sha || context.payload.sha;
+              if (!sha) { console.log('No SHA found, skipping'); return; }
+
+              // Try by commit SHA
+              const pulls = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: sha
+              });
+              const open = pulls.data.filter(p => p.state === 'open');
+              if (open.length > 0) {
                 prNumber = open[0].number;
               } else {
-                prNumber = prs.data[0].number;
+                // Fallback: list all open PRs and match head SHA
+                const allPrs = await github.rest.pulls.list({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  state: 'open',
+                  per_page: 10
+                });
+                for (const pr of allPrs.data) {
+                  if (pr.head.sha === sha) {
+                    prNumber = pr.number;
+                    break;
+                  }
+                }
               }
             }
-            if (!prNumber) return;
 
-            // Check all status checks
+            if (!prNumber) { console.log('No open PR found, skipping'); return; }
+            console.log(`Found PR #${prNumber}`);
+
+            // --- Poll for checks to complete ---
             const pr = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -58,38 +83,52 @@ jobs:
             });
             const ref = pr.data.head.sha;
 
-            const checks = await github.rest.checks.listForRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: ref,
-              per_page: 100
-            });
+            for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+              const checks = await github.rest.checks.listForRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: ref,
+                per_page: 100
+              });
 
-            const pending = checks.data.check_runs.filter(
-              c => c.name !== 'auto-approve' &&
-                   c.status !== 'completed'
-            );
-            const failed = checks.data.check_runs.filter(
-              c => c.name !== 'auto-approve' &&
-                   c.status === 'completed' &&
-                   c.conclusion !== 'success' &&
-                   c.conclusion !== 'skipped' &&
-                   c.conclusion !== 'neutral'
-            );
+              const pending = checks.data.check_runs.filter(
+                c => c.name !== 'auto-approve' &&
+                     c.status !== 'completed'
+              );
+              const failed = checks.data.check_runs.filter(
+                c => c.name !== 'auto-approve' &&
+                     c.status === 'completed' &&
+                     c.conclusion !== 'success' &&
+                     c.conclusion !== 'skipped' &&
+                     c.conclusion !== 'neutral'
+              );
 
-            if (pending.length > 0) {
-              console.log(`Still ${pending.length} checks pending, skipping`);
-              return;
-            }
-            if (failed.length > 0) {
-              console.log(`${failed.length} checks failed, not approving`);
-              for (const f of failed) {
-                console.log(`  FAILED: ${f.name} - ${f.conclusion}`);
+              if (failed.length > 0) {
+                console.log(`${failed.length} checks failed, not approving:`);
+                for (const f of failed) {
+                  console.log(`  FAILED: ${f.name} - ${f.conclusion}`);
+                }
+                return;
               }
-              return;
+
+              if (pending.length === 0) {
+                console.log(`All checks passed (attempt ${attempt})`);
+                break;
+              }
+
+              if (attempt === MAX_ATTEMPTS) {
+                console.log(`Timeout: still ${pending.length} checks pending after ${MAX_ATTEMPTS} attempts`);
+                for (const p of pending) {
+                  console.log(`  PENDING: ${p.name} - ${p.status}`);
+                }
+                return;
+              }
+
+              console.log(`Attempt ${attempt}: ${pending.length} checks pending, waiting ${POLL_INTERVAL/1000}s...`);
+              await new Promise(r => setTimeout(r, POLL_INTERVAL));
             }
 
-            // Check existing reviews - don't approve twice
+            // --- Check existing reviews ---
             const reviews = await github.rest.pulls.listReviews({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -103,7 +142,7 @@ jobs:
               return;
             }
 
-            // All checks passed - approve
+            // --- Approve ---
             console.log(`All checks passed for PR #${prNumber}, approving...`);
             await github.rest.pulls.createReview({
               owner: context.repo.owner,


### PR DESCRIPTION
Fixes auto-approve workflow that was skipping when checks were still pending.

Changes:
- Add retry polling (15 attempts x 20s = 5 min max wait)
- Add `workflow_run` trigger for `ci` workflow completion
- Improve PR lookup: by branch (workflow_run), commit SHA, and fallback to open PRs list
- Fail fast on check failures, wait on pending