### PR TITLE
fix: parameterize spec-root in validation tooling (Q-XDOC-003)

### DIFF
--- a/SPEC_LOCATION.md
+++ b/SPEC_LOCATION.md
@@ -6,3 +6,26 @@ Canonical RUBIN specifications were moved to a private repository:
 
 This public repository contains implementation code, conformance fixtures/runner,
 and formal verification toolchain only.
+
+## Tooling with external spec root
+
+Some tooling checks need canonical spec files (`RUBIN_L1_CANONICAL.md`, `SECTION_HASHES.json`,
+`SPEC_CHANGELOG.md`) from the private spec repository.
+
+Supported methods:
+
+1) environment variable:
+
+```bash
+RUBIN_SPEC_ROOT=../rubin-spec-private/spec node scripts/check-section-hashes.mjs
+RUBIN_SPEC_ROOT=../rubin-spec-private/spec node scripts/check-spec-invariants.mjs
+RUBIN_SPEC_ROOT=../rubin-spec-private/spec python3 tools/check_conformance_ids.py
+```
+
+2) explicit flag:
+
+```bash
+node scripts/check-section-hashes.mjs --spec-root ../rubin-spec-private/spec
+node scripts/check-spec-invariants.mjs --spec-root ../rubin-spec-private/spec
+python3 tools/check_conformance_ids.py --spec-root ../rubin-spec-private/spec
+```

--- a/tools/check_conformance_ids.py
+++ b/tools/check_conformance_ids.py
@@ -1,20 +1,14 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import argparse
 import json
+import os
 import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
 
-
-ROOT = Path(".")
-FIXTURES_DIR = ROOT / "conformance" / "fixtures"
-
-CHANGELOG_CANDIDATES = [
-    ROOT / "spec" / "SPEC_CHANGELOG.md",
-    ROOT / "spec" / "CHANGES.md",
-]
 
 DATE_HDR_RE = re.compile(r"(?m)^##\s+\d{4}-\d{2}-\d{2}\b")
 
@@ -29,8 +23,62 @@ def load_json(path: Path) -> object:
     return json.loads(path.read_text(encoding="utf-8", errors="strict"))
 
 
-def pick_changelog() -> Path | None:
-    for p in CHANGELOG_CANDIDATES:
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate conformance gate/vector IDs and changelog presence."
+    )
+    parser.add_argument(
+        "--code-root",
+        default=".",
+        help="Path to code repository root (default: .)",
+    )
+    parser.add_argument(
+        "--spec-root",
+        default="",
+        help=(
+            "Optional path to spec directory containing SPEC_CHANGELOG.md. "
+            "If omitted, auto-detection checks code-root/spec and sibling rubin-spec* repos."
+        ),
+    )
+    return parser.parse_args()
+
+
+def detect_spec_roots(code_root: Path, explicit_spec_root: str) -> list[Path]:
+    candidates: list[Path] = []
+    if explicit_spec_root:
+        candidates.append(Path(explicit_spec_root))
+    env_raw = os.environ.get("RUBIN_SPEC_ROOT", "")
+    if env_raw:
+        candidates.append(Path(env_raw))
+    candidates.extend(
+        [
+            code_root / "spec",
+            code_root.parent / "rubin-spec-private" / "spec",
+            code_root.parent / "rubin-spec" / "spec",
+        ]
+    )
+
+    unique: list[Path] = []
+    seen: set[Path] = set()
+    for candidate in candidates:
+        resolved = candidate.expanduser().resolve()
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        unique.append(resolved)
+    return unique
+
+
+def changelog_candidates(spec_roots: list[Path]) -> list[Path]:
+    out: list[Path] = []
+    for root in spec_roots:
+        out.append(root / "SPEC_CHANGELOG.md")
+        out.append(root / "CHANGES.md")
+    return out
+
+
+def pick_changelog(candidates: list[Path]) -> Path | None:
+    for p in candidates:
         if p.exists():
             return p
     return None
@@ -53,11 +101,17 @@ def validate_changelog(path: Path) -> list[str]:
 
 
 def main() -> int:
-    if not FIXTURES_DIR.exists():
+    args = parse_args()
+    code_root = Path(args.code_root).expanduser().resolve()
+    fixtures_dir = code_root / "conformance" / "fixtures"
+    spec_roots = detect_spec_roots(code_root, args.spec_root)
+    candidates = changelog_candidates(spec_roots)
+
+    if not fixtures_dir.exists():
         print("ERROR: conformance/fixtures directory not found", file=sys.stderr)
         return 2
 
-    fixture_paths = sorted(FIXTURES_DIR.glob("*.json"))
+    fixture_paths = sorted(fixtures_dir.glob("*.json"))
     if not fixture_paths:
         print("ERROR: no conformance fixtures found in conformance/fixtures/*.json", file=sys.stderr)
         return 2
@@ -139,10 +193,14 @@ def main() -> int:
             else:
                 vector_seen[vid] = IdLoc(vid, path)
 
-    changelog = pick_changelog()
+    changelog = pick_changelog(candidates)
     if not changelog:
         print(
-            "ERROR: missing spec changelog file (expected spec/SPEC_CHANGELOG.md or spec/CHANGES.md)",
+            "ERROR: missing spec changelog file (expected SPEC_CHANGELOG.md/CHANGES.md under configured spec roots)",
+            file=sys.stderr,
+        )
+        print(
+            f"       searched roots: {', '.join(str(p) for p in spec_roots)}",
             file=sys.stderr,
         )
         failed = True
@@ -164,4 +222,3 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-


### PR DESCRIPTION
## Summary
- add configurable spec-root discovery (`--spec-root` / `RUBIN_SPEC_ROOT`) for invariant/hash/changelog tooling
- support private spec checkout (`../rubin-spec-private/spec`) without hardcoded `rubin-protocol/spec/*`
- update `SPEC_LOCATION.md` with explicit run commands

## Validation
- `node scripts/check-spec-invariants.mjs`
- `node scripts/check-section-hashes.mjs`
- `python3 tools/check_conformance_ids.py`

Closes #335
