### PR TITLE
ci: add cargo-tarpaulin + Codacy coverage upload to test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,6 +235,17 @@ jobs:
         run: |
           cd clients/rust
           cargo test --workspace
+        - name: Install cargo-tarpaulin
+          run: cargo install cargo-tarpaulin --locked
+        - name: Rust coverage (tarpaulin)
+          run: |
+            cd clients/rust
+            cargo tarpaulin --workspace --out Lcov --output-dir ../../coverage/
+        - name: Upload coverage to Codacy
+          uses: codacy/codacy-coverage-reporter-action@v1
+          with:
+            project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+            coverage-reports: coverage/lcov.info                                                                                                              
 
       - name: Rust clippy
         run: |


### PR DESCRIPTION
## What

Adds Rust coverage reporting via `cargo-tarpaulin` and uploads results to Codacy.

## Why

Codacy Coverage page shows `-` (no data) because CI never generated or uploaded a coverage report. Only `Kani Proof Check` was running — it performs formal verification, not `cargo test` with instrumentation.

## Changes

- Added step: **Install cargo-tarpaulin** (`cargo install cargo-tarpaulin --locked`)
- Added step: **Rust coverage (tarpaulin)** — generates `coverage/lcov.info`
- Added step: **Upload coverage to Codacy** — uses `codacy/codacy-coverage-reporter-action@v1` with `CODACY_PROJECT_TOKEN`

## Prerequisites

- `CODACY_PROJECT_TOKEN` has been added to GitHub Actions Secrets

## Closes

Resolves coverage gap reported in Codacy dashboard (`-` on all metrics).