### PR TITLE
feat: CORE_EXT spend semantics (rust) (Q-SF-EXT-03)

### DIFF
--- a/clients/rust/crates/rubin-consensus/src/block_basic.rs
+++ b/clients/rust/crates/rubin-consensus/src/block_basic.rs
@@ -4,8 +4,9 @@ use crate::constants::{
     COV_TYPE_ANCHOR, COV_TYPE_DA_COMMIT, MAX_ANCHOR_BYTES_PER_BLOCK, MAX_BLOCK_WEIGHT,
     MAX_DA_BATCHES_PER_BLOCK, MAX_DA_BYTES_PER_BLOCK, MAX_DA_CHUNK_COUNT, MAX_FUTURE_DRIFT,
     MAX_SLH_DSA_SIG_BYTES, ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES, SLH_DSA_ACTIVATION_HEIGHT,
-    SLH_DSA_SHAKE_256F_PUBKEY_BYTES, SUITE_ID_ML_DSA_87, SUITE_ID_SLH_DSA_SHAKE_256F,
-    VERIFY_COST_ML_DSA_87, VERIFY_COST_SLH_DSA_SHAKE_256F, WITNESS_DISCOUNT_DIVISOR,
+    SLH_DSA_SHAKE_256F_PUBKEY_BYTES, SUITE_ID_ML_DSA_87, SUITE_ID_SENTINEL,
+    SUITE_ID_SLH_DSA_SHAKE_256F, VERIFY_COST_ML_DSA_87, VERIFY_COST_SLH_DSA_SHAKE_256F,
+    VERIFY_COST_UNKNOWN_SUITE, WITNESS_DISCOUNT_DIVISOR,
 };
 use crate::covenant_genesis::validate_tx_covenants_genesis;
 use crate::error::{ErrorCode, TxError};
@@ -646,6 +647,7 @@ fn tx_weight_and_stats(tx: &Tx) -> Result<(u64, u64, u64), TxError> {
     let mut witness_size: u64 = compact_size_len(tx.witness.len() as u64);
     let mut ml_count: u64 = 0;
     let mut slh_count: u64 = 0;
+    let mut unknown_suite_count: u64 = 0;
     for w in &tx.witness {
         witness_size = witness_size
             .checked_add(1)
@@ -664,6 +666,7 @@ fn tx_weight_and_stats(tx: &Tx) -> Result<(u64, u64, u64), TxError> {
             .ok_or_else(|| TxError::new(ErrorCode::TxErrParse, "u64 overflow"))?;
 
         match w.suite_id {
+            SUITE_ID_SENTINEL => {}
             SUITE_ID_ML_DSA_87 => {
                 if w.pubkey.len() as u64 == ML_DSA_87_PUBKEY_BYTES
                     && w.signature.len() as u64 == ML_DSA_87_SIG_BYTES
@@ -678,7 +681,11 @@ fn tx_weight_and_stats(tx: &Tx) -> Result<(u64, u64, u64), TxError> {
                     slh_count += 1;
                 }
             }
-            _ => {}
+            _ => {
+                unknown_suite_count = unknown_suite_count
+                    .checked_add(1)
+                    .ok_or_else(|| TxError::new(ErrorCode::TxErrParse, "u64 overflow"))?;
+            }
         }
     }
 
@@ -691,6 +698,7 @@ fn tx_weight_and_stats(tx: &Tx) -> Result<(u64, u64, u64), TxError> {
     let sig_cost = ml_count
         .checked_mul(VERIFY_COST_ML_DSA_87)
         .and_then(|v| v.checked_add(slh_count.checked_mul(VERIFY_COST_SLH_DSA_SHAKE_256F)?))
+        .and_then(|v| v.checked_add(unknown_suite_count.checked_mul(VERIFY_COST_UNKNOWN_SUITE)?))
         .ok_or_else(|| TxError::new(ErrorCode::TxErrParse, "u64 overflow"))?;
 
     let weight = WITNESS_DISCOUNT_DIVISOR

--- a/clients/rust/crates/rubin-consensus/src/constants.rs
+++ b/clients/rust/crates/rubin-consensus/src/constants.rs
@@ -36,6 +36,8 @@ pub const MAX_VAULT_KEYS: u8 = 12;
 pub const MAX_VAULT_WHITELIST_ENTRIES: u16 = 1024;
 pub const MAX_MULTISIG_KEYS: u8 = 12;
 pub const COV_TYPE_MULTISIG: u16 = 0x0104;
+pub const COV_TYPE_EXT: u16 = 0x0102;
+pub const CORE_EXT_WITNESS_SLOTS: u64 = 1;
 
 pub const MAX_TX_INPUTS: u64 = 1024;
 pub const MAX_TX_OUTPUTS: u64 = 1024;
@@ -67,6 +69,7 @@ pub const MAX_SLH_DSA_SIG_BYTES: u64 = 49_856;
 
 pub const VERIFY_COST_ML_DSA_87: u64 = 8;
 pub const VERIFY_COST_SLH_DSA_SHAKE_256F: u64 = 64;
+pub const VERIFY_COST_UNKNOWN_SUITE: u64 = 64;
 
 pub const SIGNAL_WINDOW: u64 = 2016;
 pub const SIGNAL_THRESHOLD: u32 = 1815;

--- a/clients/rust/crates/rubin-consensus/src/core_ext.rs
+++ b/clients/rust/crates/rubin-consensus/src/core_ext.rs
@@ -1,0 +1,305 @@
+use crate::compactsize::read_compact_size_bytes;
+use crate::constants::{
+    SLH_DSA_ACTIVATION_HEIGHT, SUITE_ID_ML_DSA_87, SUITE_ID_SENTINEL, SUITE_ID_SLH_DSA_SHAKE_256F,
+};
+use crate::error::{ErrorCode, TxError};
+use crate::tx::WitnessItem;
+use crate::utxo_basic::UtxoEntry;
+use crate::verify_sig_openssl::verify_sig;
+
+fn check_slh_canonical(w: &WitnessItem) -> Result<(), TxError> {
+    use crate::constants::{MAX_SLH_DSA_SIG_BYTES, SLH_DSA_SHAKE_256F_PUBKEY_BYTES};
+    if w.suite_id != SUITE_ID_SLH_DSA_SHAKE_256F {
+        return Ok(());
+    }
+    if w.pubkey.len() as u64 != SLH_DSA_SHAKE_256F_PUBKEY_BYTES
+        || w.signature.len() as u64 != MAX_SLH_DSA_SIG_BYTES
+    {
+        return Err(TxError::new(
+            ErrorCode::TxErrSigNoncanonical,
+            "non-canonical SLH-DSA witness item lengths",
+        ));
+    }
+    Ok(())
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CoreExtCovenant<'a> {
+    pub ext_id: u16,
+    pub ext_payload: &'a [u8],
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum CoreExtVerificationBinding {
+    /// Only native suites (0x01/0x02) are supported; non-native suites are rejected even if listed.
+    NativeVerifySig,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CoreExtActiveProfile {
+    pub ext_id: u16,
+    pub allowed_suite_ids: Vec<u8>,
+    pub verification_binding: CoreExtVerificationBinding,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct CoreExtProfiles {
+    pub active: Vec<CoreExtActiveProfile>,
+}
+
+impl CoreExtProfiles {
+    pub fn empty() -> Self {
+        Self { active: Vec::new() }
+    }
+
+    fn lookup_active_profile(&self, ext_id: u16) -> Result<Option<&CoreExtActiveProfile>, TxError> {
+        let mut found: Option<&CoreExtActiveProfile> = None;
+        for p in &self.active {
+            if p.ext_id != ext_id {
+                continue;
+            }
+            if found.is_some() {
+                return Err(TxError::new(
+                    ErrorCode::TxErrCovenantTypeInvalid,
+                    "CORE_EXT multiple ACTIVE profiles for ext_id",
+                ));
+            }
+            found = Some(p);
+        }
+        Ok(found)
+    }
+}
+
+pub fn parse_core_ext_covenant_data(cov_data: &[u8]) -> Result<CoreExtCovenant<'_>, TxError> {
+    if cov_data.len() < 2 {
+        return Err(TxError::new(
+            ErrorCode::TxErrCovenantTypeInvalid,
+            "CORE_EXT covenant_data too short",
+        ));
+    }
+    let ext_id = u16::from_le_bytes(
+        cov_data[0..2]
+            .try_into()
+            .expect("cov_data[0..2] is 2 bytes"),
+    );
+
+    let (ext_payload_len_u64, varint_bytes) =
+        read_compact_size_bytes(&cov_data[2..]).map_err(|_| {
+            TxError::new(
+                ErrorCode::TxErrCovenantTypeInvalid,
+                "CORE_EXT ext_payload_len CompactSize invalid",
+            )
+        })?;
+    if ext_payload_len_u64 > usize::MAX as u64 {
+        return Err(TxError::new(
+            ErrorCode::TxErrCovenantTypeInvalid,
+            "CORE_EXT ext_payload_len overflows usize",
+        ));
+    }
+    let ext_payload_len = ext_payload_len_u64 as usize;
+    let expected_len = 2usize
+        .checked_add(varint_bytes)
+        .and_then(|v| v.checked_add(ext_payload_len))
+        .ok_or_else(|| {
+            TxError::new(
+                ErrorCode::TxErrCovenantTypeInvalid,
+                "CORE_EXT length overflow",
+            )
+        })?;
+    if cov_data.len() != expected_len {
+        return Err(TxError::new(
+            ErrorCode::TxErrCovenantTypeInvalid,
+            "CORE_EXT covenant_data length mismatch",
+        ));
+    }
+    let payload_start = 2 + varint_bytes;
+    let ext_payload = &cov_data[payload_start..payload_start + ext_payload_len];
+
+    Ok(CoreExtCovenant {
+        ext_id,
+        ext_payload,
+    })
+}
+
+pub fn validate_core_ext_spend(
+    entry: &UtxoEntry,
+    w: &WitnessItem,
+    digest: &[u8; 32],
+    block_height: u64,
+    profiles_at_height: &CoreExtProfiles,
+) -> Result<(), TxError> {
+    let cov = parse_core_ext_covenant_data(&entry.covenant_data)?;
+    let _ = cov.ext_payload;
+
+    let active_profile = profiles_at_height.lookup_active_profile(cov.ext_id)?;
+    if active_profile.is_none() {
+        if w.suite_id != SUITE_ID_SENTINEL || !w.pubkey.is_empty() || !w.signature.is_empty() {
+            return Err(TxError::new(
+                ErrorCode::TxErrParse,
+                "CORE_EXT pre-ACTIVE requires keyless sentinel witness",
+            ));
+        }
+        return Ok(());
+    }
+    let p = active_profile.expect("active_profile is Some");
+
+    if !p.allowed_suite_ids.contains(&w.suite_id) {
+        return Err(TxError::new(
+            ErrorCode::TxErrSigAlgInvalid,
+            "CORE_EXT suite disallowed under ACTIVE profile",
+        ));
+    }
+    if w.suite_id == SUITE_ID_SENTINEL {
+        return Err(TxError::new(
+            ErrorCode::TxErrSigAlgInvalid,
+            "CORE_EXT sentinel suite forbidden under ACTIVE profile",
+        ));
+    }
+    if w.suite_id == SUITE_ID_SLH_DSA_SHAKE_256F && block_height < SLH_DSA_ACTIVATION_HEIGHT {
+        return Err(TxError::new(
+            ErrorCode::TxErrSigAlgInvalid,
+            "SLH-DSA suite inactive at this height",
+        ));
+    }
+
+    match p.verification_binding {
+        CoreExtVerificationBinding::NativeVerifySig => match w.suite_id {
+            SUITE_ID_ML_DSA_87 | SUITE_ID_SLH_DSA_SHAKE_256F => {
+                check_slh_canonical(w)?;
+                let ok = verify_sig(w.suite_id, &w.pubkey, &w.signature, digest)?;
+                if !ok {
+                    return Err(TxError::new(
+                        ErrorCode::TxErrSigInvalid,
+                        "CORE_EXT signature invalid",
+                    ));
+                }
+                Ok(())
+            }
+            _ => Err(TxError::new(
+                ErrorCode::TxErrSigAlgInvalid,
+                "CORE_EXT non-native verifier binding unsupported",
+            )),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::compactsize::encode_compact_size;
+    use crate::constants::{COV_TYPE_EXT, ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES};
+
+    fn core_ext_covdata(ext_id: u16, payload: &[u8]) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(&ext_id.to_le_bytes());
+        encode_compact_size(payload.len() as u64, &mut out);
+        out.extend_from_slice(payload);
+        out
+    }
+
+    fn dummy_entry(ext_id: u16) -> UtxoEntry {
+        UtxoEntry {
+            value: 1,
+            covenant_type: COV_TYPE_EXT,
+            covenant_data: core_ext_covdata(ext_id, b""),
+            creation_height: 0,
+            created_by_coinbase: false,
+        }
+    }
+
+    #[test]
+    fn core_ext_pre_active_keyless_sentinel_ok() {
+        let entry = dummy_entry(7);
+        let w = WitnessItem {
+            suite_id: SUITE_ID_SENTINEL,
+            pubkey: vec![],
+            signature: vec![],
+        };
+        validate_core_ext_spend(&entry, &w, &[0u8; 32], 0, &CoreExtProfiles::empty()).unwrap();
+    }
+
+    #[test]
+    fn core_ext_pre_active_non_keyless_sentinel_rejected_parse() {
+        let entry = dummy_entry(7);
+        let w = WitnessItem {
+            suite_id: SUITE_ID_SENTINEL,
+            pubkey: vec![0u8; 32],
+            signature: vec![0x01],
+        };
+        let err = validate_core_ext_spend(&entry, &w, &[0u8; 32], 0, &CoreExtProfiles::empty())
+            .unwrap_err();
+        assert_eq!(err.code, ErrorCode::TxErrParse);
+    }
+
+    #[test]
+    fn core_ext_pre_active_non_sentinel_rejected_parse() {
+        let entry = dummy_entry(7);
+        let w = WitnessItem {
+            suite_id: SUITE_ID_ML_DSA_87,
+            pubkey: vec![0u8; ML_DSA_87_PUBKEY_BYTES as usize],
+            signature: vec![0u8; ML_DSA_87_SIG_BYTES as usize],
+        };
+        let err = validate_core_ext_spend(&entry, &w, &[0u8; 32], 0, &CoreExtProfiles::empty())
+            .unwrap_err();
+        assert_eq!(err.code, ErrorCode::TxErrParse);
+    }
+
+    #[test]
+    fn core_ext_active_disallowed_suite_rejected_sig_alg_invalid() {
+        let entry = dummy_entry(7);
+        let profiles = CoreExtProfiles {
+            active: vec![CoreExtActiveProfile {
+                ext_id: 7,
+                allowed_suite_ids: vec![SUITE_ID_ML_DSA_87],
+                verification_binding: CoreExtVerificationBinding::NativeVerifySig,
+            }],
+        };
+        let w = WitnessItem {
+            suite_id: SUITE_ID_SLH_DSA_SHAKE_256F,
+            pubkey: vec![0u8; 64],
+            signature: vec![0u8; 49_856],
+        };
+        let err =
+            validate_core_ext_spend(&entry, &w, &[0u8; 32], SLH_DSA_ACTIVATION_HEIGHT, &profiles)
+                .unwrap_err();
+        assert_eq!(err.code, ErrorCode::TxErrSigAlgInvalid);
+    }
+
+    #[test]
+    fn core_ext_active_unknown_suite_allowed_but_unsupported_binding_rejected_sig_alg_invalid() {
+        let entry = dummy_entry(7);
+        let profiles = CoreExtProfiles {
+            active: vec![CoreExtActiveProfile {
+                ext_id: 7,
+                allowed_suite_ids: vec![0x03],
+                verification_binding: CoreExtVerificationBinding::NativeVerifySig,
+            }],
+        };
+        let w = WitnessItem {
+            suite_id: 0x03,
+            pubkey: vec![0x01],
+            signature: vec![0x02],
+        };
+        let err = validate_core_ext_spend(&entry, &w, &[0u8; 32], 0, &profiles).unwrap_err();
+        assert_eq!(err.code, ErrorCode::TxErrSigAlgInvalid);
+    }
+
+    #[test]
+    fn core_ext_active_native_suite_invalid_signature_maps_to_sig_invalid() {
+        let entry = dummy_entry(7);
+        let profiles = CoreExtProfiles {
+            active: vec![CoreExtActiveProfile {
+                ext_id: 7,
+                allowed_suite_ids: vec![SUITE_ID_ML_DSA_87],
+                verification_binding: CoreExtVerificationBinding::NativeVerifySig,
+            }],
+        };
+        let w = WitnessItem {
+            suite_id: SUITE_ID_ML_DSA_87,
+            pubkey: vec![0u8; ML_DSA_87_PUBKEY_BYTES as usize],
+            signature: vec![0u8; ML_DSA_87_SIG_BYTES as usize],
+        };
+        let err = validate_core_ext_spend(&entry, &w, &[0u8; 32], 0, &profiles).unwrap_err();
+        assert_eq!(err.code, ErrorCode::TxErrSigInvalid);
+    }
+}

--- a/clients/rust/crates/rubin-consensus/src/covenant_genesis.rs
+++ b/clients/rust/crates/rubin-consensus/src/covenant_genesis.rs
@@ -1,8 +1,10 @@
 use crate::constants::{
-    COV_TYPE_ANCHOR, COV_TYPE_DA_COMMIT, COV_TYPE_HTLC, COV_TYPE_MULTISIG, COV_TYPE_P2PK,
-    COV_TYPE_RESERVED_FUTURE, COV_TYPE_VAULT, MAX_ANCHOR_PAYLOAD_SIZE, MAX_P2PK_COVENANT_DATA,
-    SLH_DSA_ACTIVATION_HEIGHT, SUITE_ID_ML_DSA_87, SUITE_ID_SLH_DSA_SHAKE_256F,
+    COV_TYPE_ANCHOR, COV_TYPE_DA_COMMIT, COV_TYPE_EXT, COV_TYPE_HTLC, COV_TYPE_MULTISIG,
+    COV_TYPE_P2PK, COV_TYPE_RESERVED_FUTURE, COV_TYPE_VAULT, MAX_ANCHOR_PAYLOAD_SIZE,
+    MAX_COVENANT_DATA_PER_OUTPUT, MAX_P2PK_COVENANT_DATA, SLH_DSA_ACTIVATION_HEIGHT,
+    SUITE_ID_ML_DSA_87, SUITE_ID_SLH_DSA_SHAKE_256F,
 };
+use crate::core_ext::parse_core_ext_covenant_data;
 use crate::error::{ErrorCode, TxError};
 use crate::htlc::parse_htlc_covenant_data;
 use crate::tx::Tx;
@@ -81,6 +83,21 @@ pub fn validate_tx_covenants_genesis(tx: &Tx, block_height: u64) -> Result<(), T
                     ));
                 }
                 parse_htlc_covenant_data(&out.covenant_data)?;
+            }
+            COV_TYPE_EXT => {
+                if out.value == 0 {
+                    return Err(TxError::new(
+                        ErrorCode::TxErrCovenantTypeInvalid,
+                        "CORE_EXT value must be > 0",
+                    ));
+                }
+                if out.covenant_data.len() as u64 > MAX_COVENANT_DATA_PER_OUTPUT {
+                    return Err(TxError::new(
+                        ErrorCode::TxErrCovenantTypeInvalid,
+                        "CORE_EXT covenant_data length exceeds MAX_COVENANT_DATA_PER_OUTPUT",
+                    ));
+                }
+                let _ = parse_core_ext_covenant_data(&out.covenant_data)?;
             }
             COV_TYPE_DA_COMMIT => {
                 if tx.tx_kind != 0x01 {

--- a/clients/rust/crates/rubin-consensus/src/lib.rs
+++ b/clients/rust/crates/rubin-consensus/src/lib.rs
@@ -4,6 +4,7 @@ mod compact_relay;
 mod compactsize;
 pub mod connect_block_inmem;
 pub mod constants;
+pub mod core_ext;
 mod covenant_genesis;
 pub mod error;
 pub mod featurebits;
@@ -34,6 +35,10 @@ pub use compactsize::read_compact_size_bytes;
 pub use connect_block_inmem::{
     connect_block_basic_in_memory_at_height, ConnectBlockBasicSummary, InMemoryChainState,
 };
+pub use core_ext::{
+    parse_core_ext_covenant_data, validate_core_ext_spend, CoreExtActiveProfile, CoreExtProfiles,
+    CoreExtVerificationBinding,
+};
 pub use covenant_genesis::validate_tx_covenants_genesis;
 pub use error::{ErrorCode, TxError};
 pub use featurebits::{
@@ -49,8 +54,9 @@ pub use subsidy::block_subsidy;
 pub use tx::{parse_tx, DaChunkCore, DaCommitCore, Tx, TxInput, TxOutput, WitnessItem};
 pub use utxo_basic::{
     apply_non_coinbase_tx_basic, apply_non_coinbase_tx_basic_update,
-    apply_non_coinbase_tx_basic_update_with_mtp, apply_non_coinbase_tx_basic_with_mtp, Outpoint,
-    UtxoApplySummary, UtxoEntry,
+    apply_non_coinbase_tx_basic_update_with_mtp,
+    apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles,
+    apply_non_coinbase_tx_basic_with_mtp, Outpoint, UtxoApplySummary, UtxoEntry,
 };
 pub use vault::{
     output_descriptor_bytes, parse_multisig_covenant_data, parse_vault_covenant_data,

--- a/clients/rust/crates/rubin-consensus/src/tx.rs
+++ b/clients/rust/crates/rubin-consensus/src/tx.rs
@@ -339,12 +339,7 @@ pub fn parse_tx(b: &[u8]) -> Result<(Tx, [u8; 32], [u8; 32], usize), TxError> {
                 // available; activation must be checked before lengths to preserve
                 // deterministic error-priority (Q-CF-18).
             }
-            _ => {
-                return Err(TxError::new(
-                    ErrorCode::TxErrSigAlgInvalid,
-                    "unknown suite_id",
-                ));
-            }
+            _ => {}
         }
 
         witness.push(WitnessItem {

--- a/clients/rust/crates/rubin-consensus/src/vault.rs
+++ b/clients/rust/crates/rubin-consensus/src/vault.rs
@@ -1,7 +1,7 @@
 use crate::compactsize::encode_compact_size;
 use crate::constants::{
-    COV_TYPE_HTLC, COV_TYPE_MULTISIG, COV_TYPE_P2PK, COV_TYPE_VAULT, MAX_MULTISIG_KEYS,
-    MAX_VAULT_KEYS, MAX_VAULT_WHITELIST_ENTRIES,
+    COV_TYPE_EXT, COV_TYPE_HTLC, COV_TYPE_MULTISIG, COV_TYPE_P2PK, COV_TYPE_VAULT,
+    MAX_MULTISIG_KEYS, MAX_VAULT_KEYS, MAX_VAULT_WHITELIST_ENTRIES,
 };
 use crate::error::{ErrorCode, TxError};
 
@@ -185,6 +185,7 @@ pub fn output_descriptor_bytes(covenant_type: u16, covenant_data: &[u8]) -> Vec<
 pub fn witness_slots(covenant_type: u16, covenant_data: &[u8]) -> Result<usize, TxError> {
     match covenant_type {
         COV_TYPE_P2PK => Ok(1),
+        COV_TYPE_EXT => Ok(1),
         COV_TYPE_MULTISIG => Ok(covenant_data.get(1).copied().unwrap_or(1) as usize),
         // CORE_VAULT: owner_lock_id[32] || threshold[1] || key_count[1] || ...
         COV_TYPE_VAULT => Ok(covenant_data.get(33).copied().unwrap_or(1) as usize),


### PR DESCRIPTION
Implements CANONICAL CORE_EXT (covenant_type 0x0102) spend semantics in Rust:
- Adds CORE_EXT covenant_data parsing + creation validation.
- Adds injectable CoreExtProfiles context for ACTIVE profile testing.
- Enforces §18.2(5) pre-ACTIVE keyless sentinel; ACTIVE allowed_suite_ids + verifier binding (native verify_sig only) + SLH activation + SLH canonical lengths.
- Updates tx witness parse to accept unknown suite_id (defer to spend) and weight accounting to charge VERIFY_COST_UNKNOWN_SUITE.

Evidence (local): cargo fmt, cargo test --workspace, cargo clippy -D warnings.

Q-ID: Q-SF-EXT-03 (Rust-only slice).