### PR TITLE
feat: CORE_EXT spend semantics in Go (Q-SF-EXT-03)

### DIFF
--- a/clients/go/consensus/block_basic.go
+++ b/clients/go/consensus/block_basic.go
@@ -578,6 +578,7 @@ func txWeightAndStats(tx *Tx) (uint64, uint64, uint64, error) {
 	witnessSize = compactSizeLen(uint64(len(tx.Witness)))
 	var mlCount uint64
 	var slhCount uint64
+	var unknownSuiteCount uint64
 	for _, w := range tx.Witness {
 		var err error
 		witnessSize, err = addU64(witnessSize, 1) // suite_id
@@ -609,6 +610,10 @@ func txWeightAndStats(tx *Tx) (uint64, uint64, uint64, error) {
 			if len(w.Pubkey) == SLH_DSA_SHAKE_256F_PUBKEY_BYTES && len(w.Signature) == MAX_SLH_DSA_SIG_BYTES {
 				slhCount++
 			}
+		case SUITE_ID_SENTINEL:
+			// Sentinel does not contribute sig_cost.
+		default:
+			unknownSuiteCount++
 		}
 	}
 
@@ -631,6 +636,14 @@ func txWeightAndStats(tx *Tx) (uint64, uint64, uint64, error) {
 		return 0, 0, 0, err
 	}
 	sigCost, err := addU64(mlCost, slhCost)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	unknownCost, err := mulU64(unknownSuiteCount, VERIFY_COST_UNKNOWN_SUITE)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	sigCost, err = addU64(sigCost, unknownCost)
 	if err != nil {
 		return 0, 0, 0, err
 	}

--- a/clients/go/consensus/constants.go
+++ b/clients/go/consensus/constants.go
@@ -57,6 +57,7 @@ const (
 	COV_TYPE_RESERVED_FUTURE = 0x00FF
 	COV_TYPE_HTLC            = 0x0100
 	COV_TYPE_VAULT           = 0x0101
+	COV_TYPE_CORE_EXT        = 0x0102
 	COV_TYPE_DA_COMMIT       = 0x0103
 	COV_TYPE_MULTISIG        = 0x0104
 
@@ -71,6 +72,9 @@ const (
 
 	VERIFY_COST_ML_DSA_87          = 8
 	VERIFY_COST_SLH_DSA_SHAKE_256F = 64
+	VERIFY_COST_UNKNOWN_SUITE      = 64 // conservative floor for non-native suites (CANONICAL §9)
+
+	CORE_EXT_WITNESS_SLOTS = 1
 
 	SIGNAL_WINDOW    = 2016
 	SIGNAL_THRESHOLD = 1815

--- a/clients/go/consensus/core_ext.go
+++ b/clients/go/consensus/core_ext.go
@@ -1,0 +1,71 @@
+package consensus
+
+import (
+	"encoding/binary"
+	"math"
+)
+
+type CoreExtVerifySigExtFunc func(extID uint16, suiteID uint8, pubkey []byte, signature []byte, digest32 [32]byte, extPayload []byte) (bool, error)
+
+type CoreExtProfile struct {
+	Active         bool
+	AllowedSuites  map[uint8]struct{}
+	VerifySigExtFn CoreExtVerifySigExtFunc
+}
+
+type CoreExtProfileProvider interface {
+	LookupCoreExtProfile(extID uint16, height uint64) (CoreExtProfile, bool, error)
+}
+
+type CoreExtCovenantData struct {
+	ExtID      uint16
+	ExtPayload []byte
+}
+
+func ParseCoreExtCovenantData(covenantData []byte) (*CoreExtCovenantData, error) {
+	if len(covenantData) < 2 {
+		return nil, txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_EXT covenant_data too short")
+	}
+	if len(covenantData) > MAX_COVENANT_DATA_PER_OUTPUT {
+		return nil, txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_EXT covenant_data too large")
+	}
+
+	off := 0
+	extIDBytes, err := readBytes(covenantData, &off, 2)
+	if err != nil {
+		return nil, txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_EXT covenant_data ext_id parse failure")
+	}
+	extID := binary.LittleEndian.Uint16(extIDBytes)
+
+	payloadLenU64, payloadLenVarintBytes, err := readCompactSize(covenantData, &off)
+	if err != nil {
+		return nil, txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_EXT covenant_data ext_payload_len parse failure")
+	}
+	if payloadLenU64 > uint64(math.MaxInt) {
+		return nil, txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_EXT ext_payload_len overflows int")
+	}
+	payloadLen := int(payloadLenU64)
+
+	payload, err := readBytes(covenantData, &off, payloadLen)
+	if err != nil {
+		return nil, txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_EXT covenant_data ext_payload parse failure")
+	}
+
+	expectedLen := 2 + payloadLenVarintBytes + payloadLen
+	if len(covenantData) != expectedLen {
+		return nil, txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_EXT covenant_data length mismatch")
+	}
+
+	return &CoreExtCovenantData{
+		ExtID:      extID,
+		ExtPayload: payload,
+	}, nil
+}
+
+func hasSuite(allowed map[uint8]struct{}, suiteID uint8) bool {
+	if len(allowed) == 0 {
+		return false
+	}
+	_, ok := allowed[suiteID]
+	return ok
+}

--- a/clients/go/consensus/core_ext_test.go
+++ b/clients/go/consensus/core_ext_test.go
@@ -1,0 +1,181 @@
+package consensus
+
+import "testing"
+
+type staticCoreExtProfiles map[uint16]CoreExtProfile
+
+func (m staticCoreExtProfiles) LookupCoreExtProfile(extID uint16, _ uint64) (CoreExtProfile, bool, error) {
+	p, ok := m[extID]
+	return p, ok, nil
+}
+
+func coreExtCovenantData(extID uint16, payload []byte) []byte {
+	out := AppendU16le(nil, extID)
+	out = AppendCompactSize(out, uint64(len(payload)))
+	out = append(out, payload...)
+	return out
+}
+
+func TestParseTx_UnknownSuiteAcceptedAndCharged(t *testing.T) {
+	var prev [32]byte
+	prev[0] = 0xaa
+
+	sentinelTxBytes := txWithOneInputOneOutputWithWitness(prev, 0, 1, COV_TYPE_P2PK, validP2PKCovenantData(), []WitnessItem{
+		{SuiteID: SUITE_ID_SENTINEL},
+	})
+	sentinelTx, _, _, _, err := ParseTx(sentinelTxBytes)
+	if err != nil {
+		t.Fatalf("ParseTx(sentinel): %v", err)
+	}
+	wSentinel, _, _, err := TxWeightAndStats(sentinelTx)
+	if err != nil {
+		t.Fatalf("TxWeightAndStats(sentinel): %v", err)
+	}
+
+	unknownTxBytes := txWithOneInputOneOutputWithWitness(prev, 0, 1, COV_TYPE_P2PK, validP2PKCovenantData(), []WitnessItem{
+		{SuiteID: 0x09},
+	})
+	unknownTx, _, _, _, err := ParseTx(unknownTxBytes)
+	if err != nil {
+		t.Fatalf("ParseTx(unknown): %v", err)
+	}
+	if got := len(unknownTx.Witness); got != 1 || unknownTx.Witness[0].SuiteID != 0x09 {
+		t.Fatalf("witness=%v, want suite_id=0x09", unknownTx.Witness)
+	}
+	wUnknown, _, _, err := TxWeightAndStats(unknownTx)
+	if err != nil {
+		t.Fatalf("TxWeightAndStats(unknown): %v", err)
+	}
+	if wUnknown != wSentinel+VERIFY_COST_UNKNOWN_SUITE {
+		t.Fatalf("weight_unknown=%d, want %d", wUnknown, wSentinel+VERIFY_COST_UNKNOWN_SUITE)
+	}
+}
+
+func TestApplyNonCoinbaseTxBasic_CORE_EXT_PreActiveKeylessSentinelOnly(t *testing.T) {
+	var chainID [32]byte
+	var prev [32]byte
+	prev[0] = 0xa1
+
+	txBytes := txWithOneInputOneOutput(prev, 0, 90, COV_TYPE_P2PK, validP2PKCovenantData())
+	tx, txid := mustParseTxForUtxo(t, txBytes)
+	tx.Witness = []WitnessItem{{SuiteID: SUITE_ID_SENTINEL}}
+
+	utxos := map[Outpoint]UtxoEntry{
+		{Txid: prev, Vout: 0}: {
+			Value:        100,
+			CovenantType: COV_TYPE_CORE_EXT,
+			CovenantData: coreExtCovenantData(1, nil),
+		},
+	}
+	if _, _, err := ApplyNonCoinbaseTxBasicUpdate(tx, txid, utxos, 0, 0, chainID); err != nil {
+		t.Fatalf("ApplyNonCoinbaseTxBasicUpdate: %v", err)
+	}
+}
+
+func TestApplyNonCoinbaseTxBasic_CORE_EXT_PreActiveRejectsNonKeylessSentinel(t *testing.T) {
+	var chainID [32]byte
+	var prev [32]byte
+	prev[0] = 0xa2
+
+	txBytes := txWithOneInputOneOutput(prev, 0, 90, COV_TYPE_P2PK, validP2PKCovenantData())
+	tx, txid := mustParseTxForUtxo(t, txBytes)
+	tx.Witness = []WitnessItem{{SuiteID: SUITE_ID_SENTINEL, Pubkey: make([]byte, 32), Signature: []byte{0x01}}}
+
+	utxos := map[Outpoint]UtxoEntry{
+		{Txid: prev, Vout: 0}: {
+			Value:        100,
+			CovenantType: COV_TYPE_CORE_EXT,
+			CovenantData: coreExtCovenantData(1, nil),
+		},
+	}
+	_, _, err := ApplyNonCoinbaseTxBasicUpdate(tx, txid, utxos, 0, 0, chainID)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if got := mustTxErrCode(t, err); got != TX_ERR_PARSE {
+		t.Fatalf("code=%s, want %s", got, TX_ERR_PARSE)
+	}
+}
+
+func TestApplyNonCoinbaseTxBasic_CORE_EXT_DeterministicCovenantDataParseFirst(t *testing.T) {
+	var chainID [32]byte
+	var prev [32]byte
+	prev[0] = 0xa3
+
+	txBytes := txWithOneInputOneOutput(prev, 0, 90, COV_TYPE_P2PK, validP2PKCovenantData())
+	tx, txid := mustParseTxForUtxo(t, txBytes)
+	tx.Witness = []WitnessItem{{SuiteID: SUITE_ID_SENTINEL, Pubkey: make([]byte, 32), Signature: []byte{0x01}}}
+
+	utxos := map[Outpoint]UtxoEntry{
+		{Txid: prev, Vout: 0}: {
+			Value:        100,
+			CovenantType: COV_TYPE_CORE_EXT,
+			CovenantData: []byte{0x01}, // malformed, must map to TX_ERR_COVENANT_TYPE_INVALID before witness checks
+		},
+	}
+	_, _, err := ApplyNonCoinbaseTxBasicUpdate(tx, txid, utxos, 0, 0, chainID)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if got := mustTxErrCode(t, err); got != TX_ERR_COVENANT_TYPE_INVALID {
+		t.Fatalf("code=%s, want %s", got, TX_ERR_COVENANT_TYPE_INVALID)
+	}
+}
+
+func TestApplyNonCoinbaseTxBasic_CORE_EXT_ActiveSuiteRulesAndVerifySig(t *testing.T) {
+	var chainID [32]byte
+	var prev [32]byte
+	prev[0] = 0xa4
+
+	kp := mustMLDSA87Keypair(t)
+
+	txBytes := txWithOneInputOneOutput(prev, 0, 90, COV_TYPE_P2PK, validP2PKCovenantData())
+	tx, txid := mustParseTxForUtxo(t, txBytes)
+	tx.Witness = []WitnessItem{{SuiteID: SUITE_ID_SENTINEL}}
+
+	utxos := map[Outpoint]UtxoEntry{
+		{Txid: prev, Vout: 0}: {
+			Value:        100,
+			CovenantType: COV_TYPE_CORE_EXT,
+			CovenantData: coreExtCovenantData(7, []byte{0x01}),
+		},
+	}
+
+	profiles := staticCoreExtProfiles{
+		7: {
+			Active: true,
+			AllowedSuites: map[uint8]struct{}{
+				SUITE_ID_SENTINEL:  {},
+				SUITE_ID_ML_DSA_87: {},
+			},
+		},
+	}
+
+	// Sentinel is explicitly forbidden under ACTIVE.
+	_, _, err := ApplyNonCoinbaseTxBasicUpdateWithMTPAndCoreExtProfiles(tx, txid, utxos, 0, 0, 0, chainID, profiles)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if got := mustTxErrCode(t, err); got != TX_ERR_SIG_ALG_INVALID {
+		t.Fatalf("code=%s, want %s", got, TX_ERR_SIG_ALG_INVALID)
+	}
+
+	// Valid ML-DSA signature succeeds under ACTIVE.
+	tx.Witness = []WitnessItem{signP2PKInputWitness(t, tx, 0, 100, chainID, kp)}
+	if _, _, err := ApplyNonCoinbaseTxBasicUpdateWithMTPAndCoreExtProfiles(tx, txid, utxos, 0, 0, 0, chainID, profiles); err != nil {
+		t.Fatalf("ApplyNonCoinbaseTxBasicUpdateWithMTPAndCoreExtProfiles(valid sig): %v", err)
+	}
+
+	// Same-length mutated signature must deterministically reject as TX_ERR_SIG_INVALID.
+	bad := tx.Witness[0]
+	bad.Signature = append([]byte(nil), bad.Signature...)
+	bad.Signature[len(bad.Signature)-1] ^= 0x01
+	tx.Witness = []WitnessItem{bad}
+	_, _, err = ApplyNonCoinbaseTxBasicUpdateWithMTPAndCoreExtProfiles(tx, txid, utxos, 0, 0, 0, chainID, profiles)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if got := mustTxErrCode(t, err); got != TX_ERR_SIG_INVALID {
+		t.Fatalf("code=%s, want %s", got, TX_ERR_SIG_INVALID)
+	}
+}

--- a/clients/go/consensus/covenant_genesis.go
+++ b/clients/go/consensus/covenant_genesis.go
@@ -53,6 +53,14 @@ func ValidateTxCovenantsGenesis(tx *Tx, blockHeight uint64) error {
 				return err
 			}
 
+		case COV_TYPE_CORE_EXT:
+			if out.Value == 0 {
+				return txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_EXT value must be > 0")
+			}
+			if _, err := ParseCoreExtCovenantData(out.CovenantData); err != nil {
+				return err
+			}
+
 		case COV_TYPE_DA_COMMIT:
 			if tx.TxKind != 0x01 {
 				return txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_DA_COMMIT allowed only in tx_kind=0x01")

--- a/clients/go/consensus/spend_verify.go
+++ b/clients/go/consensus/spend_verify.go
@@ -70,7 +70,8 @@ func validateThresholdSigSpend(keys [][32]byte, threshold uint8, ws []WitnessIte
 			}
 			valid++
 		default:
-			// Should be unreachable: wire parser rejects unknown suite_id.
+			// Unknown suites are accepted at parse stage (CANONICAL §12.2 / CV-SIG-05);
+			// non-CORE_EXT spend paths must reject them deterministically here.
 			return txerr(TX_ERR_SIG_ALG_INVALID, context+" suite invalid")
 		}
 	}

--- a/clients/go/consensus/tx_parse.go
+++ b/clients/go/consensus/tx_parse.go
@@ -365,7 +365,8 @@ func ParseTx(b []byte) (*Tx, [32]byte, [32]byte, int, error) {
 			// available; activation must be checked before lengths to preserve
 			// deterministic error-priority (Q-CF-18).
 		default:
-			return nil, zero, zero, 0, txerr(TX_ERR_SIG_ALG_INVALID, "unknown suite_id")
+			// Unknown suites are accepted at parse stage (CANONICAL §12.2 / CV-SIG-05).
+			// Semantic suite authorization is enforced at the spend path.
 		}
 
 		witness = append(witness, WitnessItem{

--- a/clients/go/consensus/tx_parse_test.go
+++ b/clients/go/consensus/tx_parse_test.go
@@ -128,7 +128,7 @@ func TestParseTx_WitnessItem_Canonicalization(t *testing.T) {
 		},
 		{
 			name:    "unknown_suite",
-			wantErr: TX_ERR_SIG_ALG_INVALID,
+			wantErr: "",
 			section: func() []byte {
 				var w bytes.Buffer
 				w.WriteByte(0x01) // witness_count
@@ -164,6 +164,16 @@ func TestParseTx_WitnessItem_Canonicalization(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			if tc.wantErr == "" {
+				tx, _, _, _, err := ParseTx(txWithWitnessSection(tc.section()))
+				if err != nil {
+					t.Fatalf("ParseTx: %v", err)
+				}
+				if len(tx.Witness) != 1 || tx.Witness[0].SuiteID != 0x03 {
+					t.Fatalf("witness=%v, want suite_id=0x03", tx.Witness)
+				}
+				return
+			}
 			expectParseErrCode(t, txWithWitnessSection(tc.section()), tc.wantErr)
 		})
 	}

--- a/clients/go/consensus/utxo_basic_additional_test.go
+++ b/clients/go/consensus/utxo_basic_additional_test.go
@@ -42,6 +42,12 @@ func TestCheckSpendCovenant_SupportedTypes(t *testing.T) {
 	if err := checkSpendCovenant(COV_TYPE_HTLC, htlcData); err != nil {
 		t.Fatalf("CORE_HTLC: %v", err)
 	}
+
+	coreExtData := AppendU16le(nil, 1)
+	coreExtData = AppendCompactSize(coreExtData, 0)
+	if err := checkSpendCovenant(COV_TYPE_CORE_EXT, coreExtData); err != nil {
+		t.Fatalf("CORE_EXT: %v", err)
+	}
 }
 
 func TestCheckSpendCovenant_Errors(t *testing.T) {
@@ -53,6 +59,9 @@ func TestCheckSpendCovenant_Errors(t *testing.T) {
 	}
 	if err := checkSpendCovenant(COV_TYPE_HTLC, nil); err == nil {
 		t.Fatalf("expected error for invalid CORE_HTLC covenant_data")
+	}
+	if err := checkSpendCovenant(COV_TYPE_CORE_EXT, nil); err == nil {
+		t.Fatalf("expected error for invalid CORE_EXT covenant_data")
 	}
 
 	err := checkSpendCovenant(0x9999, []byte{0x01})

--- a/clients/go/consensus/vault.go
+++ b/clients/go/consensus/vault.go
@@ -143,6 +143,8 @@ func WitnessSlots(covenantType uint16, covenantData []byte) (int, error) {
 		return 1, nil
 	case COV_TYPE_HTLC:
 		return 2, nil
+	case COV_TYPE_CORE_EXT:
+		return CORE_EXT_WITNESS_SLOTS, nil
 	default:
 		return 0, txerr(TX_ERR_COVENANT_TYPE_INVALID, "unsupported covenant in witness_slots")
 	}


### PR DESCRIPTION
Implements CORE_EXT (covenant_type 0x0102) spend semantics in Go per CANONICAL §18.2(5) + related rules.

Key points:
- Adds CORE_EXT covenant type + fixed witness slots=1.
- Parses covenant_data as ext_id||CompactSize(len)||payload; parse/length failures -> TX_ERR_COVENANT_TYPE_INVALID.
- Pre-ACTIVE: requires keyless sentinel witness, else TX_ERR_PARSE.
- ACTIVE: enforces allowed_suite_ids + sentinel forbidden + SLH activation + verify_sig for native suites; non-native requires injected verify_sig_ext, else TX_ERR_SIG_ALG_INVALID.
- tx_parse now accepts unknown suite_id (CV-SIG-05) and weight accounting charges VERIFY_COST_UNKNOWN_SUITE.

Validation:
- scripts/dev-env.sh -- bash -lc "cd clients/go && go test ./... && go vet ./..." (PASS)

Queue: Q-SF-EXT-03 (Go slice only; no conformance changes).