### PR TITLE
Require validator success before auto-approve and auto-merge

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -96,6 +96,12 @@ jobs:
                 per_page: 100
               });
 
+              const validatorRuns = checks.data.check_runs.filter(c => c.name === 'validator');
+              const validator = validatorRuns.sort((a, b) => b.id - a.id)[0];
+              const validatorState = validator
+                ? `${validator.status}/${validator.conclusion ?? 'none'}`
+                : 'missing';
+
               const pending = checks.data.check_runs.filter(
                 c => c.name !== 'auto-approve' && c.status !== 'completed'
               );
@@ -110,10 +116,26 @@ jobs:
                 for (const f of failed) {
                   console.log(`  FAILED: ${f.name} - ${f.conclusion}`);
                 }
+                console.log(`  validator state: ${validatorState}`);
                 return;
               }
 
-              if (pending.length === 0) {
+              if (!validator) {
+                if (attempt === MAX_ATTEMPTS || pending.length === 0) {
+                  console.log(`Validator check is required but ${validatorState}; not approving/merging.`);
+                  return;
+                }
+                console.log(`Attempt ${attempt}: validator is ${validatorState}, waiting ${POLL_INTERVAL/1000}s...`);
+                await new Promise(r => setTimeout(r, POLL_INTERVAL));
+                continue;
+              }
+
+              if (validator.status === 'completed' && validator.conclusion !== 'success') {
+                console.log(`Validator check is ${validatorState}; not approving/merging.`);
+                return;
+              }
+
+              if (pending.length === 0 && validator.conclusion === 'success') {
                 console.log(`All checks passed (attempt ${attempt})`);
                 break;
               }
@@ -123,10 +145,11 @@ jobs:
                 for (const p of pending) {
                   console.log(`  PENDING: ${p.name} - ${p.status}`);
                 }
+                console.log(`  validator state: ${validatorState}`);
                 return;
               }
 
-              console.log(`Attempt ${attempt}: ${pending.length} checks pending, waiting ${POLL_INTERVAL/1000}s...`);
+              console.log(`Attempt ${attempt}: ${pending.length} checks pending, validator=${validatorState}, waiting ${POLL_INTERVAL/1000}s...`);
               await new Promise(r => setTimeout(r, POLL_INTERVAL));
             }
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ The runner requires Go and Rust to return identical `ok/err` behavior and identi
 - Local orchestration/queue files live outside the repository and MUST NOT be committed.
 - CI blocks sensitive assets from entering public repo (`tools/check_sensitive_files.py`).
 - PR merge gate includes `validator` check, which is an aggregate status over `policy` + `security_ai` + `formal` + `test` + `formal_refinement`.
+- Auto-merge is allowed only when the `validator` check-run exists and finishes with `success`.
 
 ## Policy Guardrails (Non-consensus)
 


### PR DESCRIPTION
### Motivation
- Ensure the repository auto-approval/auto-merge workflow only proceeds when the aggregated `validator` check-run explicitly exists and finishes with `success` to avoid merging when validation is absent or non-passing.
- Provide clearer diagnostic logging so maintainers can see the `validator` state when auto-merge is refused.
- Make the requirement explicit in the repository `Notes` to communicate the gate to the team.

### Description
- Updated `.github/workflows/auto-approve.yml` to locate the latest `validator` check-run and compute a `validatorState` (`status/conclusion` or `missing`).
- Changed polling logic to block approve/merge when `validator` is missing, pending, skipped/neutral, or completed with any non-`success` conclusion, and only allow auto-merge when `validator.conclusion === 'success'` and no other pending checks remain.
- Added diagnostic logs printing the `validator` state in failure, missing, timeout, and non-success branches so the reason for refusal is visible in workflow logs.
- Updated `README.md` `Notes` section to state that auto-merge depends on an existing `validator` check-run completing with `success`.

### Testing
- Validated the modified workflow YAML with Ruby using `YAML.load_file('.github/workflows/auto-approve.yml')`, which succeeded.
- Ran `git diff --check` to ensure no whitespace/format issues, which returned clean results.
- Attempted to validate YAML with Python/PyYAML, but the environment lacks the `PyYAML` module (validation with Python failed due to missing dependency).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5cadff0108322a43ad5332e2aaccc)