### PR TITLE
fix(ci): resolve fuzz-nightly build failure and combined-load LD_LIBRARY_PATH

### DIFF
--- a/.github/workflows/combined-load-nightly.yml
+++ b/.github/workflows/combined-load-nightly.yml
@@ -54,6 +54,7 @@ jobs:
         env:
           OPENSSL_MODULES: ${{ steps.openssl.outputs.openssl_modules }}
           OPENSSL_CONF: ${{ steps.openssl.outputs.openssl_conf }}
+          LD_LIBRARY_PATH: ${{ steps.openssl.outputs.ld_library_path }}
         run: |
           openssl version
           openssl list -signature-algorithms | grep -E 'ML-DSA-87|SLH-DSA-SHAKE-256f'

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -4,4 +4,5 @@ members = [
     "crates/rubin-consensus-cli",
     "crates/rubin-node",
 ]
+exclude = ["fuzz"]
 resolver = "2"


### PR DESCRIPTION
## Summary

Fixes two nightly CI workflows that have been red for 3+ consecutive runs.

### fuzz-nightly (fuzz-rust job)
**Root cause:** `clients/rust/fuzz/Cargo.toml` is detected as part of the workspace but isn't listed in `workspace.members`. Cargo refuses to build it.

**Fix:** Add `"fuzz"` to `workspace.exclude` in `clients/rust/Cargo.toml`. The fuzz crate must be outside the workspace because `cargo-fuzz` injects its own ASAN/sanitizer RUSTFLAGS that conflict with workspace-level settings.

### combined-load-nightly
**Root cause:** The "Verify OpenSSL PQ algorithms" step runs the cached OpenSSL 3.5.5 binary, which is dynamically linked against `libssl.so.3` / `libcrypto.so.3` (3.2.0+ symbols). The CI runner only ships OpenSSL 3.0.x system libs, so the binary fails with `version OPENSSL_3.4.0 not found`.

**Fix:** Add `LD_LIBRARY_PATH` env (already computed by the build step) to the verify step, matching the benchmark step that already had it.

### Evidence
- fuzz-nightly: https://github.com/2tbmz9y2xt-lang/rubin-protocol/actions/runs/22609004111
- combined-load: https://github.com/2tbmz9y2xt-lang/rubin-protocol/actions/runs/22609464866
