### PR TITLE
fix: remove SLH naming tails from tests and CI

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,7 @@
 * @2tbmz9y2xt-lang
 
 # ── Cryptographic modules (consensus-critical, PQ) ────────────
-# Go: OpenSSL signer (ML-DSA-87, SLH-DSA-SHAKE-256f)
+# Go: OpenSSL signer (ML-DSA-87)
 clients/go/consensus/openssl_signer*.go @2tbmz9y2xt-lang
 
 # Rust: hashing, sighash, signature verification

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
       - name: Verify OpenSSL PQ algorithms
         run: |
           openssl version
-          openssl list -signature-algorithms | grep -E 'ML-DSA-87|SLH-DSA-SHAKE-256f'
+          openssl list -signature-algorithms | grep -E 'ML-DSA-87'
 
       - name: FIPS provider preflight (module + PQ visibility)
         env:
@@ -332,7 +332,7 @@ jobs:
           LD_LIBRARY_PATH: ${{ steps.openssl.outputs.ld_library_path }}
         run: |
           openssl version
-          openssl list -signature-algorithms | grep -E 'ML-DSA-87|SLH-DSA-SHAKE-256f'
+          openssl list -signature-algorithms | grep -E 'ML-DSA-87'
 
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:

--- a/.github/workflows/codacy-coverage.yml
+++ b/.github/workflows/codacy-coverage.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Verify OpenSSL PQ algorithms
         run: |
           openssl version
-          openssl list -signature-algorithms | grep -E 'ML-DSA-87|SLH-DSA-SHAKE-256f'
+          openssl list -signature-algorithms | grep -E 'ML-DSA-87'
 
       - uses: actions/setup-go@v6
         with:

--- a/.github/workflows/combined-load-nightly.yml
+++ b/.github/workflows/combined-load-nightly.yml
@@ -57,7 +57,7 @@ jobs:
           LD_LIBRARY_PATH: ${{ steps.openssl.outputs.ld_library_path }}
         run: |
           openssl version
-          openssl list -signature-algorithms | grep -E 'ML-DSA-87|SLH-DSA-SHAKE-256f'
+          openssl list -signature-algorithms | grep -E 'ML-DSA-87'
 
       - name: Run combined-load benchmark
         env:
@@ -67,10 +67,10 @@ jobs:
           PKG_CONFIG_PATH: ${{ steps.openssl.outputs.pkg_config_path }}
           LD_LIBRARY_PATH: ${{ steps.openssl.outputs.ld_library_path }}
           RUBIN_COMBINED_LOAD_BENCH_ITERS: 1
-          RUBIN_COMBINED_LOAD_SLH_TXS: 8
+          RUBIN_COMBINED_LOAD_UNKNOWN_SUITE_TXS: 8
           RUBIN_COMBINED_LOAD_DA_CHUNKS: 32
           RUBIN_COMBINED_LOAD_CHUNK_BYTES: 65536
-          RUBIN_COMBINED_LOAD_SLH_SIG_BYTES: 49856
+          RUBIN_COMBINED_LOAD_UNKNOWN_SUITE_SIG_BYTES: 49856
         run: |
           scripts/benchmarks/run_combined_load_benchmark.sh artifacts/combined-load
 

--- a/.github/workflows/fips-only-nightly.yml
+++ b/.github/workflows/fips-only-nightly.yml
@@ -83,7 +83,7 @@ jobs:
 
           run_check "fips_preflight" scripts/dev-env.sh -- scripts/crypto/openssl/fips-preflight.sh
           run_check "go_verify_sig_smoke" scripts/dev-env.sh -- bash -lc \
-            'cd clients/go && go test ./consensus -run "TestVerifySig_(FIPSOnlyModeValidOrSkip|SLHBranchExecutesBootstrap|OpenSSLBackendErrorMapsToSigInvalid)$" -count=1'
+            'cd clients/go && go test ./consensus -run "TestVerifySig_(FIPSReadyModeValid|FIPSOnlyModeValidOrSkip|OpenSSLBackendErrorMapsToSigInvalid)$" -count=1'
           run_check "rust_verify_sig_smoke" scripts/dev-env.sh -- bash -lc \
             'cd clients/rust && cargo test -p rubin-consensus verify_sig_openssl::tests::'
           run_check "conformance_sig_lane" scripts/dev-env.sh -- python3 \

--- a/clients/go/consensus/block_basic_additional_test.go
+++ b/clients/go/consensus/block_basic_additional_test.go
@@ -38,7 +38,7 @@ func TestTxWeightAndStats_Nil(t *testing.T) {
 	}
 }
 
-func TestTxWeightAndStats_MLAndSLHCountsAndDAAndAnchor(t *testing.T) {
+func TestTxWeightAndStats_MLAndUnknownSuiteCountsAndDAAndAnchor(t *testing.T) {
 	mlPub := make([]byte, ML_DSA_87_PUBKEY_BYTES)
 	mlSig := make([]byte, ML_DSA_87_SIG_BYTES+1)
 	unknownPub := make([]byte, 64)
@@ -82,7 +82,7 @@ func TestTxWeightAndStats_MLAndSLHCountsAndDAAndAnchor(t *testing.T) {
 	// - base_size = 318 bytes
 	// - witness_size = 57_154 bytes
 	// - da_size = 4 bytes (len varint + payload)
-	// - sig_cost = 8 (ML) + 64 (SLH) = 72
+	// - sig_cost = 8 (ML) + 64 (unknown suite) = 72
 	// - weight = 4*base_size + witness_size + da_size + sig_cost
 	const wantWeight = uint64(58_502)
 	if weight != wantWeight {

--- a/clients/go/consensus/combined_load_benchmark_test.go
+++ b/clients/go/consensus/combined_load_benchmark_test.go
@@ -8,10 +8,10 @@ import (
 )
 
 const (
-	defaultCombinedLoadSLHTxCount   = 8
-	defaultCombinedLoadDAChunkCount = 32
-	defaultCombinedLoadChunkBytes   = 65_536
-	defaultCombinedLoadSLHSigBytes  = 49_856
+	defaultCombinedLoadUnknownSuiteTxCount  = 8
+	defaultCombinedLoadDAChunkCount         = 32
+	defaultCombinedLoadChunkBytes           = 65_536
+	defaultCombinedLoadUnknownSuiteSigBytes = 49_856
 )
 
 func benchmarkEnvInt(tb testing.TB, key string, defaultValue int, minValue int, maxValue int) int {
@@ -128,10 +128,10 @@ func benchBuildBlockBytes(tb testing.TB, txs [][]byte) ([]byte, [32]byte, [32]by
 }
 
 func BenchmarkValidateBlockBasicCombinedLoad(b *testing.B) {
-	slhTxCount := benchmarkEnvInt(
+	unknownSuiteTxCount := benchmarkEnvInt(
 		b,
-		"RUBIN_COMBINED_LOAD_SLH_TXS",
-		defaultCombinedLoadSLHTxCount,
+		"RUBIN_COMBINED_LOAD_UNKNOWN_SUITE_TXS",
+		defaultCombinedLoadUnknownSuiteTxCount,
 		1,
 		64,
 	)
@@ -149,26 +149,26 @@ func BenchmarkValidateBlockBasicCombinedLoad(b *testing.B) {
 		1,
 		MAX_DA_MANIFEST_BYTES_PER_TX,
 	)
-	slhSigBytes := benchmarkEnvInt(
+	unknownSuiteSigBytes := benchmarkEnvInt(
 		b,
-		"RUBIN_COMBINED_LOAD_SLH_SIG_BYTES",
-		defaultCombinedLoadSLHSigBytes,
+		"RUBIN_COMBINED_LOAD_UNKNOWN_SUITE_SIG_BYTES",
+		defaultCombinedLoadUnknownSuiteSigBytes,
 		1,
 		MAX_WITNESS_BYTES_PER_TX,
 	)
 
 	height := uint64(1)
-	slhPub := bytes.Repeat([]byte{0x42}, 64)
-	slhSig := bytes.Repeat([]byte{0x5a}, slhSigBytes)
+	unknownSuitePub := bytes.Repeat([]byte{0x42}, 64)
+	unknownSuiteSig := bytes.Repeat([]byte{0x5a}, unknownSuiteSigBytes)
 
 	nonce := uint64(1)
-	nonCoinbaseTxs := make([][]byte, 0, slhTxCount+1+daChunkCount)
-	for i := 0; i < slhTxCount; i++ {
+	nonCoinbaseTxs := make([][]byte, 0, unknownSuiteTxCount+1+daChunkCount)
+	for i := 0; i < unknownSuiteTxCount; i++ {
 		nonCoinbaseTxs = append(nonCoinbaseTxs, benchTxWithOneInputOneOutputAndWitness(
 			nonce,
 			0x02, // non-native/unknown suite
-			slhPub,
-			slhSig,
+			unknownSuitePub,
+			unknownSuiteSig,
 		))
 		nonce++
 	}
@@ -219,8 +219,8 @@ func BenchmarkValidateBlockBasicCombinedLoad(b *testing.B) {
 	}
 
 	b.Logf(
-		"combined-load fixture: slh_txs=%d da_chunks=%d chunk_bytes=%d total_block_bytes=%d",
-		slhTxCount,
+		"combined-load fixture: unknown_suite_txs=%d da_chunks=%d chunk_bytes=%d total_block_bytes=%d",
+		unknownSuiteTxCount,
 		daChunkCount,
 		chunkPayloadBytes,
 		len(blockBytes),

--- a/clients/go/consensus/covenant_genesis_test.go
+++ b/clients/go/consensus/covenant_genesis_test.go
@@ -190,7 +190,7 @@ func TestValidateTxCovenantsGenesis_MoreBranches(t *testing.T) {
 	invalidP2PKSuite := make([]byte, MAX_P2PK_COVENANT_DATA)
 	invalidP2PKSuite[0] = 0xff
 
-	_, _, claimKeyID, refundKeyID := makeSLHKeyMaterial(0x20)
+	_, _, claimKeyID, refundKeyID := makeMLKeyMaterial(0x20)
 	htlcData := encodeHTLCCovenantData(sha3_256([]byte("x")), LOCK_MODE_HEIGHT, 1, claimKeyID, refundKeyID)
 
 	cases := []struct {

--- a/clients/go/consensus/htlc_test.go
+++ b/clients/go/consensus/htlc_test.go
@@ -26,7 +26,7 @@ func encodeHTLCClaimPayload(preimage []byte) []byte {
 	return b
 }
 
-func makeSLHKeyMaterial(refundTag byte) ([]byte, []byte, [32]byte, [32]byte) {
+func makeMLKeyMaterial(refundTag byte) ([]byte, []byte, [32]byte, [32]byte) {
 	claimPub := make([]byte, ML_DSA_87_PUBKEY_BYTES)
 	refundPub := make([]byte, ML_DSA_87_PUBKEY_BYTES)
 	refundPub[0] = refundTag
@@ -74,7 +74,7 @@ func htlcTestDigest(t *testing.T, sighashType uint8) [32]byte {
 func TestParseHTLCCovenantData_OK(t *testing.T) {
 	preimage := []byte("rubin-htlc")
 	hash := sha3_256(preimage)
-	_, _, claimKeyID, refundKeyID := makeSLHKeyMaterial(0x01)
+	_, _, claimKeyID, refundKeyID := makeMLKeyMaterial(0x01)
 	cov := encodeHTLCCovenantData(hash, LOCK_MODE_HEIGHT, 123, claimKeyID, refundKeyID)
 	parsed, err := ParseHTLCCovenantData(cov)
 	if err != nil {
@@ -103,7 +103,7 @@ func TestParseHTLCCovenantData_InvalidLockMode(t *testing.T) {
 
 func TestValidateHTLCSpend_ClaimHashMismatch(t *testing.T) {
 	var digest [32]byte
-	claimPub, _, claimKeyID, refundKeyID := makeSLHKeyMaterial(0x22)
+	claimPub, _, claimKeyID, refundKeyID := makeMLKeyMaterial(0x22)
 	entry := makeHTLCEntry(sha3_256([]byte("different")), LOCK_MODE_HEIGHT, 50, claimKeyID, refundKeyID)
 
 	path := WitnessItem{
@@ -128,7 +128,7 @@ func TestValidateHTLCSpend_ClaimHashMismatch(t *testing.T) {
 
 func TestValidateHTLCSpend_RefundTimelockNotMet(t *testing.T) {
 	var digest [32]byte
-	_, refundPub, claimKeyID, refundKeyID := makeSLHKeyMaterial(0x33)
+	_, refundPub, claimKeyID, refundKeyID := makeMLKeyMaterial(0x33)
 	entry := makeHTLCEntry(
 		sha3_256([]byte("x")),
 		LOCK_MODE_HEIGHT,
@@ -208,7 +208,7 @@ func TestApplyNonCoinbaseTxBasic_HTLCUnknownPath(t *testing.T) {
 	txBytes := txWithOneInputOneOutput(prev, 0, 90, COV_TYPE_P2PK, validP2PKCovenantData())
 	tx, txid := mustParseTxForUtxo(t, txBytes)
 
-	claimPub, _, claimKeyID, refundKeyID := makeSLHKeyMaterial(0x44)
+	claimPub, _, claimKeyID, refundKeyID := makeMLKeyMaterial(0x44)
 
 	tx.Witness = []WitnessItem{
 		// Unknown spend path for CORE_HTLC.
@@ -281,7 +281,7 @@ func TestParseHTLCCovenantData_ClaimRefundKeyIDMustDiffer(t *testing.T) {
 
 func TestValidateHTLCSpend_SelectorSuiteIDInvalid(t *testing.T) {
 	var digest [32]byte
-	claimPub, _, claimKeyID, refundKeyID := makeSLHKeyMaterial(0x55)
+	claimPub, _, claimKeyID, refundKeyID := makeMLKeyMaterial(0x55)
 	entry := makeHTLCEntry(sha3_256([]byte("x")), LOCK_MODE_HEIGHT, 1, claimKeyID, refundKeyID)
 
 	path := WitnessItem{
@@ -302,7 +302,7 @@ func TestValidateHTLCSpend_SelectorSuiteIDInvalid(t *testing.T) {
 
 func TestValidateHTLCSpend_SelectorKeyIDLenInvalid(t *testing.T) {
 	var digest [32]byte
-	claimPub, _, claimKeyID, refundKeyID := makeSLHKeyMaterial(0x56)
+	claimPub, _, claimKeyID, refundKeyID := makeMLKeyMaterial(0x56)
 	entry := makeHTLCEntry(sha3_256([]byte("x")), LOCK_MODE_HEIGHT, 1, claimKeyID, refundKeyID)
 
 	path := WitnessItem{
@@ -323,7 +323,7 @@ func TestValidateHTLCSpend_SelectorKeyIDLenInvalid(t *testing.T) {
 
 func TestValidateHTLCSpend_SelectorPayloadTooShort(t *testing.T) {
 	var digest [32]byte
-	claimPub, _, claimKeyID, refundKeyID := makeSLHKeyMaterial(0x57)
+	claimPub, _, claimKeyID, refundKeyID := makeMLKeyMaterial(0x57)
 	entry := makeHTLCEntry(sha3_256([]byte("x")), LOCK_MODE_HEIGHT, 1, claimKeyID, refundKeyID)
 
 	path := WitnessItem{
@@ -344,7 +344,7 @@ func TestValidateHTLCSpend_SelectorPayloadTooShort(t *testing.T) {
 
 func TestValidateHTLCSpend_ClaimKeyIDMismatch(t *testing.T) {
 	var digest [32]byte
-	claimPub, _, claimKeyID, refundKeyID := makeSLHKeyMaterial(0x58)
+	claimPub, _, claimKeyID, refundKeyID := makeMLKeyMaterial(0x58)
 	entry := makeHTLCEntry(sha3_256([]byte("x")), LOCK_MODE_HEIGHT, 1, claimKeyID, refundKeyID)
 
 	var otherKeyID [32]byte
@@ -367,7 +367,7 @@ func TestValidateHTLCSpend_ClaimKeyIDMismatch(t *testing.T) {
 
 func TestValidateHTLCSpend_ClaimPayloadTooShort(t *testing.T) {
 	var digest [32]byte
-	claimPub, _, claimKeyID, refundKeyID := makeSLHKeyMaterial(0x59)
+	claimPub, _, claimKeyID, refundKeyID := makeMLKeyMaterial(0x59)
 	entry := makeHTLCEntry(sha3_256([]byte("x")), LOCK_MODE_HEIGHT, 1, claimKeyID, refundKeyID)
 
 	path := WitnessItem{
@@ -388,7 +388,7 @@ func TestValidateHTLCSpend_ClaimPayloadTooShort(t *testing.T) {
 
 func TestValidateHTLCSpend_ClaimPreimageLenZero(t *testing.T) {
 	var digest [32]byte
-	claimPub, _, claimKeyID, refundKeyID := makeSLHKeyMaterial(0x5a)
+	claimPub, _, claimKeyID, refundKeyID := makeMLKeyMaterial(0x5a)
 	entry := makeHTLCEntry(sha3_256([]byte("x")), LOCK_MODE_HEIGHT, 1, claimKeyID, refundKeyID)
 
 	path := WitnessItem{
@@ -409,7 +409,7 @@ func TestValidateHTLCSpend_ClaimPreimageLenZero(t *testing.T) {
 
 func TestValidateHTLCSpend_ClaimPreimageLenOverflow(t *testing.T) {
 	var digest [32]byte
-	claimPub, _, claimKeyID, refundKeyID := makeSLHKeyMaterial(0x5b)
+	claimPub, _, claimKeyID, refundKeyID := makeMLKeyMaterial(0x5b)
 	entry := makeHTLCEntry(sha3_256([]byte("x")), LOCK_MODE_HEIGHT, 1, claimKeyID, refundKeyID)
 
 	tooBig := uint16(MAX_HTLC_PREIMAGE_BYTES + 1)
@@ -435,7 +435,7 @@ func TestValidateHTLCSpend_ClaimPreimageLenOverflow(t *testing.T) {
 
 func TestValidateHTLCSpend_ClaimPayloadLenMismatch(t *testing.T) {
 	var digest [32]byte
-	claimPub, _, claimKeyID, refundKeyID := makeSLHKeyMaterial(0x5c)
+	claimPub, _, claimKeyID, refundKeyID := makeMLKeyMaterial(0x5c)
 	entry := makeHTLCEntry(sha3_256([]byte("x")), LOCK_MODE_HEIGHT, 1, claimKeyID, refundKeyID)
 
 	// preimage_len=2 but only 1 byte provided.
@@ -457,7 +457,7 @@ func TestValidateHTLCSpend_ClaimPayloadLenMismatch(t *testing.T) {
 
 func TestValidateHTLCSpend_RefundPayloadLenMismatch(t *testing.T) {
 	var digest [32]byte
-	claimPub, refundPub, claimKeyID, refundKeyID := makeSLHKeyMaterial(0x5d)
+	claimPub, refundPub, claimKeyID, refundKeyID := makeMLKeyMaterial(0x5d)
 	entry := makeHTLCEntry(sha3_256([]byte("x")), LOCK_MODE_HEIGHT, 1, claimKeyID, refundKeyID)
 
 	path := WitnessItem{
@@ -480,7 +480,7 @@ func TestValidateHTLCSpend_RefundPayloadLenMismatch(t *testing.T) {
 
 func TestValidateHTLCSpend_RefundKeyIDMismatch(t *testing.T) {
 	var digest [32]byte
-	claimPub, refundPub, claimKeyID, refundKeyID := makeSLHKeyMaterial(0x5e)
+	claimPub, refundPub, claimKeyID, refundKeyID := makeMLKeyMaterial(0x5e)
 	entry := makeHTLCEntry(sha3_256([]byte("x")), LOCK_MODE_HEIGHT, 1, claimKeyID, refundKeyID)
 
 	var otherKeyID [32]byte
@@ -506,7 +506,7 @@ func TestValidateHTLCSpend_RefundKeyIDMismatch(t *testing.T) {
 
 func TestValidateHTLCSpend_SigSuiteInvalid(t *testing.T) {
 	var digest [32]byte
-	claimPub, refundPub, claimKeyID, refundKeyID := makeSLHKeyMaterial(0x5f)
+	claimPub, refundPub, claimKeyID, refundKeyID := makeMLKeyMaterial(0x5f)
 	entry := makeHTLCEntry(sha3_256([]byte("x")), LOCK_MODE_HEIGHT, 1, claimKeyID, refundKeyID)
 	path := WitnessItem{SuiteID: SUITE_ID_SENTINEL, Pubkey: refundKeyID[:], Signature: []byte{0x01}}
 
@@ -524,7 +524,7 @@ func TestValidateHTLCSpend_SigSuiteInvalid(t *testing.T) {
 
 func TestValidateHTLCSpend_MLDSANonCanonicalWitnessItemLengths(t *testing.T) {
 	var digest [32]byte
-	claimPub, refundPub, claimKeyID, refundKeyID := makeSLHKeyMaterial(0x60)
+	claimPub, refundPub, claimKeyID, refundKeyID := makeMLKeyMaterial(0x60)
 	entry := makeHTLCEntry(sha3_256([]byte("x")), LOCK_MODE_HEIGHT, 1, claimKeyID, refundKeyID)
 	path := WitnessItem{SuiteID: SUITE_ID_SENTINEL, Pubkey: refundKeyID[:], Signature: []byte{0x01}}
 

--- a/clients/go/consensus/stealth_test.go
+++ b/clients/go/consensus/stealth_test.go
@@ -84,7 +84,7 @@ func TestValidateCoreStealthSpend_ErrorMapping(t *testing.T) {
 	}
 
 	nonNative := validWitness
-	nonNative.SuiteID = 0x02 // Formerly SLH-DSA; now treated as a non-native suite.
+	nonNative.SuiteID = 0x02 // Treated as a non-native suite.
 	err = validateCoreStealthSpend(entry, nonNative, tx, 0, 100, chainID, 0)
 	if err == nil {
 		t.Fatalf("expected non-native suite rejection")

--- a/scripts/benchmarks/COMBINED_LOAD_SLO.md
+++ b/scripts/benchmarks/COMBINED_LOAD_SLO.md
@@ -1,8 +1,8 @@
-# Combined-Load Benchmark (SLH + DA) SLO
+# Combined-Load Benchmark (Unknown Suite + DA) SLO
 
 Purpose: provide a repeatable benchmark/evidence lane for mixed load:
 
-- SLH-heavy witness processing (`SUITE_ID_SLH_DSA_SHAKE_256F`),
+- non-native witness processing (`suite_id=0x02`, unknown suite),
 - DA-filled block parsing/validation (`tx_kind=0x01/0x02` with chunk payloads),
 - block-basic validation path as implemented in Go consensus.
 
@@ -14,10 +14,10 @@ Benchmark target:
 
 Default profile (configurable via environment variables):
 
-- `RUBIN_COMBINED_LOAD_SLH_TXS=8`
+- `RUBIN_COMBINED_LOAD_UNKNOWN_SUITE_TXS=8`
 - `RUBIN_COMBINED_LOAD_DA_CHUNKS=32`
 - `RUBIN_COMBINED_LOAD_CHUNK_BYTES=65536`
-- `RUBIN_COMBINED_LOAD_SLH_SIG_BYTES=49856`
+- `RUBIN_COMBINED_LOAD_UNKNOWN_SUITE_SIG_BYTES=49856`
 
 ## Metrics
 


### PR DESCRIPTION
## Summary\n- remove remaining SLH naming from Go consensus tests/benchmarks and benchmark SLO docs\n- switch combined-load benchmark env names to unknown-suite wording\n- align CI algorithm checks and FIPS nightly test selector with ML-DSA-only native path\n\n## Validation\n- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./consensus -run "TestParseHTLCCovenantData_OK|TestValidateTxCovenantsGenesis_MoreBranches|TestTxWeightAndStats_MLAndUnknownSuiteCountsAndDAAndAnchor|TestValidateCoreStealthSpend_ErrorMapping" -count=1'\n- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./consensus -run "^$" -bench "^BenchmarkValidateBlockBasicCombinedLoad$" -benchtime=1x -count=1'\n\n## Linkage\n- Q-SLH-DEINTEG-02\n