### PR TITLE
fix(consensus): align block validation order with §25 strict sequence

### DIFF
--- a/clients/go/consensus/block_basic.go
+++ b/clients/go/consensus/block_basic.go
@@ -152,12 +152,21 @@ func validateParsedBlockBasicWithContextAtHeight(
 	if root != pb.Header.MerkleRoot {
 		return nil, txerr(BLOCK_ERR_MERKLE_INVALID, "merkle_root mismatch")
 	}
+	if err := validateCoinbaseWitnessCommitment(pb); err != nil {
+		return nil, err
+	}
+	if err := validateTimestampRules(pb.Header.Timestamp, blockHeight, prevTimestamps); err != nil {
+		return nil, err
+	}
 
 	var sumWeight uint64
 	var sumDa uint64
 	var sumAnchor uint64
 	if len(pb.Txs) == 0 || !isCoinbaseTx(pb.Txs[0]) {
 		return nil, txerr(BLOCK_ERR_COINBASE_INVALID, "first tx must be canonical coinbase")
+	}
+	if len(pb.Txs[0].Outputs) == 0 {
+		return nil, txerr(BLOCK_ERR_COINBASE_INVALID, "coinbase must have at least one output")
 	}
 	if blockHeight > uint64(^uint32(0)) {
 		return nil, txerr(BLOCK_ERR_COINBASE_INVALID, "block height exceeds coinbase locktime range")
@@ -200,20 +209,14 @@ func validateParsedBlockBasicWithContextAtHeight(
 			return nil, err
 		}
 	}
-	if err := validateCoinbaseWitnessCommitment(pb); err != nil {
-		return nil, err
-	}
-	if err := validateTimestampRules(pb.Header.Timestamp, blockHeight, prevTimestamps); err != nil {
-		return nil, err
-	}
 	if sumWeight > MAX_BLOCK_WEIGHT {
 		return nil, txerr(BLOCK_ERR_WEIGHT_EXCEEDED, "block weight exceeded")
 	}
-	if sumAnchor > MAX_ANCHOR_BYTES_PER_BLOCK {
-		return nil, txerr(BLOCK_ERR_ANCHOR_BYTES_EXCEEDED, "anchor bytes exceeded")
-	}
 	if sumDa > MAX_DA_BYTES_PER_BLOCK {
 		return nil, txerr(BLOCK_ERR_WEIGHT_EXCEEDED, "DA bytes exceeded")
+	}
+	if sumAnchor > MAX_ANCHOR_BYTES_PER_BLOCK {
+		return nil, txerr(BLOCK_ERR_ANCHOR_BYTES_EXCEEDED, "anchor bytes exceeded")
 	}
 	if err := validateDASetIntegrity(pb.Txs); err != nil {
 		return nil, err

--- a/clients/go/consensus/block_basic_rules_test.go
+++ b/clients/go/consensus/block_basic_rules_test.go
@@ -218,7 +218,7 @@ func TestValidateBlockBasic_CovenantInvalid(t *testing.T) {
 	prev := hashWithPrefix(0x88)
 	target := filledHash(0xff)
 	block := buildBlockBytes(t, prev, root, target, 21, [][]byte{tx})
-	expectValidateBlockBasicErr(t, block, &prev, &target, TX_ERR_COVENANT_TYPE_INVALID)
+	expectValidateBlockBasicErr(t, block, &prev, &target, BLOCK_ERR_WITNESS_COMMITMENT)
 }
 
 func TestValidateBlockBasic_SubsidyExceeded(t *testing.T) {
@@ -512,12 +512,14 @@ func TestValidateBlockBasic_CoinbaseRuleErrors(t *testing.T) {
 		nonce   uint64
 		height  uint64
 		prev    [32]byte
+		want    ErrorCode
 	}{
 		{
 			name:   "first_tx_must_be_coinbase",
 			prev:   hashWithPrefix(0x8a),
 			nonce:  24,
 			height: 0,
+			want:   BLOCK_ERR_WITNESS_COMMITMENT,
 			blockFn: func(t *testing.T, prev [32]byte, target [32]byte, nonce uint64) []byte {
 				tx := txWithOneOutput(0, COV_TYPE_ANCHOR, make([]byte, 32))
 				root, err := MerkleRootTxids([][32]byte{testTxID(t, tx)})
@@ -532,6 +534,7 @@ func TestValidateBlockBasic_CoinbaseRuleErrors(t *testing.T) {
 			prev:   hashWithPrefix(0x8b),
 			nonce:  25,
 			height: 7,
+			want:   BLOCK_ERR_COINBASE_INVALID,
 			blockFn: func(t *testing.T, prev [32]byte, target [32]byte, nonce uint64) []byte {
 				coinbase := coinbaseWithWitnessCommitmentAtHeight(t, 6)
 				root, err := MerkleRootTxids([][32]byte{testTxID(t, coinbase)})
@@ -546,6 +549,7 @@ func TestValidateBlockBasic_CoinbaseRuleErrors(t *testing.T) {
 			prev:   hashWithPrefix(0x8c),
 			nonce:  26,
 			height: 0,
+			want:   BLOCK_ERR_COINBASE_INVALID,
 			blockFn: func(t *testing.T, prev [32]byte, target [32]byte, nonce uint64) []byte {
 				coinbaseLike := coinbaseTxWithOutputs(0, []testOutput{
 					{value: 1, covenantType: COV_TYPE_P2PK, covenantData: validP2PKCovenantData()},
@@ -567,8 +571,8 @@ func TestValidateBlockBasic_CoinbaseRuleErrors(t *testing.T) {
 			if err == nil {
 				t.Fatalf("expected error")
 			}
-			if got := mustTxErrCode(t, err); got != BLOCK_ERR_COINBASE_INVALID {
-				t.Fatalf("code=%s, want %s", got, BLOCK_ERR_COINBASE_INVALID)
+			if got := mustTxErrCode(t, err); got != tc.want {
+				t.Fatalf("code=%s, want %s", got, tc.want)
 			}
 		})
 	}

--- a/clients/rust/crates/rubin-consensus/src/block_basic.rs
+++ b/clients/rust/crates/rubin-consensus/src/block_basic.rs
@@ -157,6 +157,8 @@ pub fn validate_block_basic_with_context_at_height(
             "merkle_root mismatch",
         ));
     }
+    validate_coinbase_witness_commitment(&pb)?;
+    validate_timestamp_rules(pb.header.timestamp, block_height, prev_timestamps)?;
 
     validate_coinbase_structure(&pb, block_height)?;
 
@@ -198,8 +200,6 @@ pub fn validate_block_basic_with_context_at_height(
             .checked_add(anchor_bytes)
             .ok_or_else(|| TxError::new(ErrorCode::TxErrParse, "u64 overflow"))?;
     }
-    validate_coinbase_witness_commitment(&pb)?;
-    validate_timestamp_rules(pb.header.timestamp, block_height, prev_timestamps)?;
 
     if sum_weight > MAX_BLOCK_WEIGHT {
         return Err(TxError::new(
@@ -207,16 +207,16 @@ pub fn validate_block_basic_with_context_at_height(
             "block weight exceeded",
         ));
     }
-    if sum_anchor > MAX_ANCHOR_BYTES_PER_BLOCK {
-        return Err(TxError::new(
-            ErrorCode::BlockErrAnchorBytesExceeded,
-            "anchor bytes exceeded",
-        ));
-    }
     if sum_da > MAX_DA_BYTES_PER_BLOCK {
         return Err(TxError::new(
             ErrorCode::BlockErrWeightExceeded,
             "DA bytes exceeded",
+        ));
+    }
+    if sum_anchor > MAX_ANCHOR_BYTES_PER_BLOCK {
+        return Err(TxError::new(
+            ErrorCode::BlockErrAnchorBytesExceeded,
+            "anchor bytes exceeded",
         ));
     }
 
@@ -280,6 +280,12 @@ fn validate_coinbase_structure(pb: &ParsedBlock, block_height: u64) -> Result<()
         return Err(TxError::new(
             ErrorCode::BlockErrCoinbaseInvalid,
             "first tx is not canonical coinbase",
+        ));
+    }
+    if coinbase.outputs.is_empty() {
+        return Err(TxError::new(
+            ErrorCode::BlockErrCoinbaseInvalid,
+            "coinbase must have at least one output",
         ));
     }
 

--- a/clients/rust/crates/rubin-consensus/src/tests.rs
+++ b/clients/rust/crates/rubin-consensus/src/tests.rs
@@ -961,7 +961,7 @@ fn validate_block_basic_covenant_invalid() {
     let block = build_block_bytes(prev, root, target, 21, &[tx]);
 
     let err = validate_block_basic(&block, Some(prev), Some(target)).unwrap_err();
-    assert_eq!(err.code, ErrorCode::TxErrCovenantTypeInvalid);
+    assert_eq!(err.code, ErrorCode::BlockErrWitnessCommitment);
 }
 
 #[test]
@@ -992,7 +992,7 @@ fn validate_block_basic_first_tx_must_be_coinbase() {
     let block = build_block_bytes(prev, root, target, 24, &[tx]);
 
     let err = validate_block_basic(&block, Some(prev), Some(target)).unwrap_err();
-    assert_eq!(err.code, ErrorCode::BlockErrCoinbaseInvalid);
+    assert_eq!(err.code, ErrorCode::BlockErrWitnessCommitment);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Move witness commitment validation (step 6) and timestamp validation (step 7) to correct positions per §25
- Swap DA bytes check before anchor bytes check (steps 8/9 per spec)
- Add coinbase output_count >= 1 check per §10.5
- Symmetric fix in Go and Rust with updated tests

## Task
Q-AUDIT-POST-02 — Architect findings A2 (HIGH), A3 (MEDIUM), A7 (LOW-MED)

## Test plan
- [x] Go tests: \`go test ./consensus/...\` — PASS
- [x] Rust tests: \`cargo test -p rubin-consensus\` — 114/114 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)