### PR TITLE
fix(consensus): correct VAULT validation order and remove whitelist re-check (§24.1)

### DIFF
--- a/clients/go/consensus/utxo_basic.go
+++ b/clients/go/consensus/utxo_basic.go
@@ -173,6 +173,13 @@ func applyNonCoinbaseTxBasicWork(
 			return nil, 0, txerr(TX_ERR_COINBASE_IMMATURE, "coinbase immature")
 		}
 
+		if entry.CovenantType == COV_TYPE_VAULT {
+			vaultInputCount++
+			if vaultInputCount > 1 {
+				return nil, 0, txerr(TX_ERR_VAULT_MULTI_INPUT_FORBIDDEN, "multiple CORE_VAULT inputs forbidden")
+			}
+		}
+
 		if err := checkSpendCovenant(entry.CovenantType, entry.CovenantData); err != nil {
 			return nil, 0, err
 		}
@@ -216,7 +223,7 @@ func applyNonCoinbaseTxBasicWork(
 				return nil, 0, err
 			}
 		case COV_TYPE_VAULT:
-			v, err := ParseVaultCovenantData(entry.CovenantData)
+			v, err := ParseVaultCovenantDataForSpend(entry.CovenantData)
 			if err != nil {
 				return nil, 0, err
 			}
@@ -227,6 +234,8 @@ func applyNonCoinbaseTxBasicWork(
 			vaultSigWitness = append([]WitnessItem(nil), assigned...)
 			vaultSigInputIndex = uint32(inputIndex)
 			vaultSigInputValue = entry.Value
+			vaultWhitelist = v.Whitelist
+			vaultOwnerLockID = v.OwnerLockID
 			haveVaultSig = true
 		case COV_TYPE_HTLC:
 			if slots != 2 {
@@ -344,16 +353,6 @@ func applyNonCoinbaseTxBasicWork(
 			return nil, 0, err
 		}
 		if entry.CovenantType == COV_TYPE_VAULT {
-			vaultInputCount++
-			if vaultInputCount > 1 {
-				return nil, 0, txerr(TX_ERR_VAULT_MULTI_INPUT_FORBIDDEN, "multiple CORE_VAULT inputs forbidden")
-			}
-			v, err := ParseVaultCovenantData(entry.CovenantData)
-			if err != nil {
-				return nil, 0, err
-			}
-			vaultWhitelist = v.Whitelist
-			vaultOwnerLockID = v.OwnerLockID
 			sumInVault, err = addU64ToU128(sumInVault, entry.Value)
 			if err != nil {
 				return nil, 0, err
@@ -510,7 +509,7 @@ func checkSpendCovenant(
 		return nil
 	}
 	if covType == COV_TYPE_VAULT {
-		v, err := ParseVaultCovenantData(covData)
+		v, err := ParseVaultCovenantDataForSpend(covData)
 		if err != nil {
 			return err
 		}

--- a/clients/go/consensus/vault.go
+++ b/clients/go/consensus/vault.go
@@ -22,6 +22,14 @@ type MultisigCovenant struct {
 }
 
 func ParseVaultCovenantData(covData []byte) (*VaultCovenant, error) {
+	return parseVaultCovenantData(covData, true)
+}
+
+func ParseVaultCovenantDataForSpend(covData []byte) (*VaultCovenant, error) {
+	return parseVaultCovenantData(covData, false)
+}
+
+func parseVaultCovenantData(covData []byte, enforceWhitelistCanonical bool) (*VaultCovenant, error) {
 	if covData == nil {
 		return nil, txerr(TX_ERR_VAULT_MALFORMED, "nil CORE_VAULT covenant_data")
 	}
@@ -72,11 +80,13 @@ func ParseVaultCovenantData(covData []byte) (*VaultCovenant, error) {
 		copy(v.Whitelist[i][:], covData[offset:offset+32])
 		offset += 32
 	}
-	if !strictlySortedUnique32(v.Whitelist) {
-		return nil, txerr(TX_ERR_VAULT_WHITELIST_NOT_CANONICAL, "CORE_VAULT whitelist not strictly sorted")
-	}
-	if HashInSorted32(v.Whitelist, v.OwnerLockID) {
-		return nil, txerr(TX_ERR_VAULT_OWNER_DESTINATION_FORBIDDEN, "CORE_VAULT whitelist contains owner_lock_id")
+	if enforceWhitelistCanonical {
+		if !strictlySortedUnique32(v.Whitelist) {
+			return nil, txerr(TX_ERR_VAULT_WHITELIST_NOT_CANONICAL, "CORE_VAULT whitelist not strictly sorted")
+		}
+		if HashInSorted32(v.Whitelist, v.OwnerLockID) {
+			return nil, txerr(TX_ERR_VAULT_OWNER_DESTINATION_FORBIDDEN, "CORE_VAULT whitelist contains owner_lock_id")
+		}
 	}
 	return &v, nil
 }

--- a/clients/rust/crates/rubin-consensus/src/utxo_basic.rs
+++ b/clients/rust/crates/rubin-consensus/src/utxo_basic.rs
@@ -14,7 +14,7 @@ use crate::stealth::{parse_stealth_covenant_data, validate_stealth_spend};
 use crate::tx::Tx;
 use crate::vault::{
     hash_in_sorted_32, output_descriptor_bytes, parse_multisig_covenant_data,
-    parse_vault_covenant_data, witness_slots,
+    parse_vault_covenant_data, parse_vault_covenant_data_for_spend, witness_slots,
 };
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -171,6 +171,15 @@ pub fn apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles(
                 "coinbase immature",
             ));
         }
+        if entry.covenant_type == COV_TYPE_VAULT {
+            vault_input_count += 1;
+            if vault_input_count > 1 {
+                return Err(TxError::new(
+                    ErrorCode::TxErrVaultMultiInputForbidden,
+                    "multiple CORE_VAULT inputs forbidden",
+                ));
+            }
+        }
         check_spend_covenant(entry.covenant_type, &entry.covenant_data)?;
         let slots = witness_slots(entry.covenant_type, &entry.covenant_data)?;
         if slots == 0 {
@@ -214,7 +223,7 @@ pub fn apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles(
                 )?;
             }
             COV_TYPE_VAULT => {
-                let v = parse_vault_covenant_data(&entry.covenant_data)?;
+                let v = parse_vault_covenant_data_for_spend(&entry.covenant_data)?;
                 // CORE_VAULT signature threshold is checked later (CANONICAL §24.1),
                 // after owner-authorization and no-fee-sponsorship checks.
                 vault_sig_keys = v.keys.clone();
@@ -222,6 +231,8 @@ pub fn apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles(
                 vault_sig_witness = assigned.to_vec();
                 vault_sig_input_index = input_index as u32;
                 vault_sig_input_value = entry.value;
+                vault_owner_lock_id = v.owner_lock_id;
+                vault_whitelist = v.whitelist;
                 have_vault_sig = true;
             }
             COV_TYPE_HTLC => {
@@ -290,16 +301,6 @@ pub fn apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles(
             .checked_add(entry.value as u128)
             .ok_or_else(|| TxError::new(ErrorCode::TxErrParse, "u128 overflow"))?;
         if entry.covenant_type == COV_TYPE_VAULT {
-            vault_input_count += 1;
-            if vault_input_count > 1 {
-                return Err(TxError::new(
-                    ErrorCode::TxErrVaultMultiInputForbidden,
-                    "multiple CORE_VAULT inputs forbidden",
-                ));
-            }
-            let v = parse_vault_covenant_data(&entry.covenant_data)?;
-            vault_owner_lock_id = v.owner_lock_id;
-            vault_whitelist = v.whitelist;
             sum_in_vault = sum_in_vault
                 .checked_add(entry.value as u128)
                 .ok_or_else(|| TxError::new(ErrorCode::TxErrParse, "u128 overflow"))?;
@@ -538,7 +539,7 @@ fn check_spend_covenant(covenant_type: u16, covenant_data: &[u8]) -> Result<(), 
         return Ok(());
     }
     if covenant_type == COV_TYPE_VAULT {
-        parse_vault_covenant_data(covenant_data)?;
+        parse_vault_covenant_data_for_spend(covenant_data)?;
         return Ok(());
     }
     if covenant_type == COV_TYPE_MULTISIG {

--- a/clients/rust/crates/rubin-consensus/src/vault.rs
+++ b/clients/rust/crates/rubin-consensus/src/vault.rs
@@ -24,6 +24,17 @@ pub struct MultisigCovenant {
 }
 
 pub fn parse_vault_covenant_data(covenant_data: &[u8]) -> Result<VaultCovenant, TxError> {
+    parse_vault_covenant_data_inner(covenant_data, true)
+}
+
+pub fn parse_vault_covenant_data_for_spend(covenant_data: &[u8]) -> Result<VaultCovenant, TxError> {
+    parse_vault_covenant_data_inner(covenant_data, false)
+}
+
+fn parse_vault_covenant_data_inner(
+    covenant_data: &[u8],
+    enforce_whitelist_canonical: bool,
+) -> Result<VaultCovenant, TxError> {
     if covenant_data.len() < 34 {
         return Err(TxError::new(
             ErrorCode::TxErrVaultMalformed,
@@ -99,17 +110,19 @@ pub fn parse_vault_covenant_data(covenant_data: &[u8]) -> Result<VaultCovenant, 
         offset += 32;
         whitelist.push(h);
     }
-    if !strictly_sorted_unique_32(&whitelist) {
-        return Err(TxError::new(
-            ErrorCode::TxErrVaultWhitelistNotCanonical,
-            "CORE_VAULT whitelist not strictly sorted",
-        ));
-    }
-    if hash_in_sorted_32(&whitelist, &owner_lock_id) {
-        return Err(TxError::new(
-            ErrorCode::TxErrVaultOwnerDestinationForbidden,
-            "CORE_VAULT whitelist contains owner_lock_id",
-        ));
+    if enforce_whitelist_canonical {
+        if !strictly_sorted_unique_32(&whitelist) {
+            return Err(TxError::new(
+                ErrorCode::TxErrVaultWhitelistNotCanonical,
+                "CORE_VAULT whitelist not strictly sorted",
+            ));
+        }
+        if hash_in_sorted_32(&whitelist, &owner_lock_id) {
+            return Err(TxError::new(
+                ErrorCode::TxErrVaultOwnerDestinationForbidden,
+                "CORE_VAULT whitelist contains owner_lock_id",
+            ));
+        }
     }
 
     Ok(VaultCovenant {


### PR DESCRIPTION
## Summary
- Move multi-input check before covenant_data parse per §24.1 step ordering
- Remove whitelist re-check at spend time (spec: MUST NOT re-check at spend)
- Symmetric fix in Go and Rust

## Task
Q-AUDIT-POST-03 — Architect findings A4 (MEDIUM), A9 (LOW-MED)

## Test plan
- [x] Go tests: \`go test ./consensus/...\` — PASS
- [x] Rust tests: \`cargo test -p rubin-consensus\` — 114/114 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)