### PR TITLE
refactor: reduce complexity in mempool and tx helpers (Q-DEVNET-06A)

### DIFF
--- a/clients/go/consensus/openssl_signer.go
+++ b/clients/go/consensus/openssl_signer.go
@@ -140,56 +140,31 @@ var keygenAllowlist = map[string]int{
 	"ML-DSA-87": ML_DSA_87_PUBKEY_BYTES,
 }
 
-func newOpenSSLRawKeypair(alg string, expectedPubkeyLen int) (*C.EVP_PKEY, []byte, error) {
-	if err := ensureOpenSSLBootstrap(); err != nil {
-		return nil, nil, err
-	}
+func validateOpenSSLAlgorithm(alg string, expectedPubkeyLen int, action string) error {
 	requiredLen, ok := keygenAllowlist[alg]
 	if !ok {
-		return nil, nil, fmt.Errorf("openssl keygen algorithm not allowed: %s", alg)
+		return fmt.Errorf("openssl %s algorithm not allowed: %s", action, alg)
 	}
 	if expectedPubkeyLen != requiredLen {
-		return nil, nil, fmt.Errorf(
-			"openssl keygen expected pubkey length mismatch for %s: got %d want %d",
-			alg, expectedPubkeyLen, requiredLen,
+		return fmt.Errorf(
+			"openssl %s expected pubkey length mismatch for %s: got %d want %d",
+			action, alg, expectedPubkeyLen, requiredLen,
 		)
 	}
-
-	errBuf := make([]byte, 512)
-	cAlg := C.CString(alg)
-	defer C.free(unsafe.Pointer(cAlg))
-
-	pkey := C.rubin_keygen(cAlg, (*C.char)(unsafe.Pointer(&errBuf[0])), C.size_t(len(errBuf)))
-	if pkey == nil {
-		return nil, nil, fmt.Errorf("openssl keygen failed: %s", cStringTrim0(errBuf))
-	}
-
-	pubkey := make([]byte, expectedPubkeyLen)
-	var pubLen C.size_t
-	if C.rubin_get_raw_public(
-		pkey,
-		(*C.uchar)(unsafe.Pointer(&pubkey[0])),
-		C.size_t(len(pubkey)),
-		&pubLen,
-		(*C.char)(unsafe.Pointer(&errBuf[0])),
-		C.size_t(len(errBuf)),
-	) != 0 {
-		C.EVP_PKEY_free(pkey)
-		return nil, nil, fmt.Errorf("openssl get_raw_public failed: %s", cStringTrim0(errBuf))
-	}
-	if int(pubLen) != expectedPubkeyLen {
-		C.EVP_PKEY_free(pkey)
-		return nil, nil, fmt.Errorf("openssl pubkey length=%d, want %d", int(pubLen), expectedPubkeyLen)
-	}
-
-	return pkey, pubkey, nil
+	return nil
 }
 
-func openSSLPublicKeyBytes(pkey *C.EVP_PKEY, expectedPubkeyLen int) ([]byte, error) {
+func newOpenSSLErrorBuffer() []byte {
+	return make([]byte, 512)
+}
+
+func openSSLPublicKeyBytesWithErrBuf(pkey *C.EVP_PKEY, expectedPubkeyLen int, errBuf []byte) ([]byte, error) {
 	if pkey == nil {
 		return nil, fmt.Errorf("nil openssl key")
 	}
-	errBuf := make([]byte, 512)
+	if len(errBuf) == 0 {
+		errBuf = newOpenSSLErrorBuffer()
+	}
 	pubkey := make([]byte, expectedPubkeyLen)
 	var pubLen C.size_t
 	if C.rubin_get_raw_public(
@@ -208,25 +183,46 @@ func openSSLPublicKeyBytes(pkey *C.EVP_PKEY, expectedPubkeyLen int) ([]byte, err
 	return pubkey, nil
 }
 
+func newOpenSSLRawKeypair(alg string, expectedPubkeyLen int) (*C.EVP_PKEY, []byte, error) {
+	if err := ensureOpenSSLBootstrap(); err != nil {
+		return nil, nil, err
+	}
+	if err := validateOpenSSLAlgorithm(alg, expectedPubkeyLen, "keygen"); err != nil {
+		return nil, nil, err
+	}
+
+	errBuf := newOpenSSLErrorBuffer()
+	cAlg := C.CString(alg)
+	defer C.free(unsafe.Pointer(cAlg))
+
+	pkey := C.rubin_keygen(cAlg, (*C.char)(unsafe.Pointer(&errBuf[0])), C.size_t(len(errBuf)))
+	if pkey == nil {
+		return nil, nil, fmt.Errorf("openssl keygen failed: %s", cStringTrim0(errBuf))
+	}
+	pubkey, err := openSSLPublicKeyBytesWithErrBuf(pkey, expectedPubkeyLen, errBuf)
+	if err != nil {
+		C.EVP_PKEY_free(pkey)
+		return nil, nil, err
+	}
+	return pkey, pubkey, nil
+}
+
+func openSSLPublicKeyBytes(pkey *C.EVP_PKEY, expectedPubkeyLen int) ([]byte, error) {
+	return openSSLPublicKeyBytesWithErrBuf(pkey, expectedPubkeyLen, nil)
+}
+
 func newOpenSSLRawKeypairFromDER(alg string, der []byte, expectedPubkeyLen int) (*C.EVP_PKEY, []byte, error) {
 	if err := ensureOpenSSLBootstrap(); err != nil {
 		return nil, nil, err
 	}
-	requiredLen, ok := keygenAllowlist[alg]
-	if !ok {
-		return nil, nil, fmt.Errorf("openssl key import algorithm not allowed: %s", alg)
-	}
-	if expectedPubkeyLen != requiredLen {
-		return nil, nil, fmt.Errorf(
-			"openssl key import expected pubkey length mismatch for %s: got %d want %d",
-			alg, expectedPubkeyLen, requiredLen,
-		)
+	if err := validateOpenSSLAlgorithm(alg, expectedPubkeyLen, "key import"); err != nil {
+		return nil, nil, err
 	}
 	if len(der) == 0 {
 		return nil, nil, fmt.Errorf("empty private key DER")
 	}
 
-	errBuf := make([]byte, 512)
+	errBuf := newOpenSSLErrorBuffer()
 	pkey := C.rubin_parse_private_key_der(
 		(*C.uchar)(unsafe.Pointer(&der[0])),
 		C.size_t(len(der)),

--- a/clients/go/consensus/tx_helpers.go
+++ b/clients/go/consensus/tx_helpers.go
@@ -85,45 +85,74 @@ func SignTransaction(tx *Tx, utxoSet map[Outpoint]UtxoEntry, chainID [32]byte, s
 	if signer == nil {
 		return fmt.Errorf("nil signer")
 	}
-	pub := signer.PubkeyBytes()
-	if len(pub) != ML_DSA_87_PUBKEY_BYTES {
-		return txerr(TX_ERR_SIG_NONCANONICAL, "non-canonical ML-DSA public key length")
+	pub, keyID, err := signerBinding(signer)
+	if err != nil {
+		return err
 	}
-	keyID := sha3_256(pub)
 
 	witness := make([]WitnessItem, 0, len(tx.Inputs))
 	for i, in := range tx.Inputs {
-		op := Outpoint{Txid: in.PrevTxid, Vout: in.PrevVout}
-		entry, ok := utxoSet[op]
-		if !ok {
-			return txerr(TX_ERR_MISSING_UTXO, "utxo not found")
-		}
-		if entry.CovenantType != COV_TYPE_P2PK {
-			return fmt.Errorf("unsupported covenant type for signing: 0x%04x", entry.CovenantType)
-		}
-		if len(entry.CovenantData) != MAX_P2PK_COVENANT_DATA || entry.CovenantData[0] != SUITE_ID_ML_DSA_87 {
-			return txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_P2PK covenant_data invalid")
-		}
-		if !bytes.Equal(entry.CovenantData[1:33], keyID[:]) {
-			return txerr(TX_ERR_SIG_INVALID, "signer key binding mismatch")
-		}
-
-		digest, err := SighashV1DigestWithType(tx, uint32(i), entry.Value, chainID, SIGHASH_ALL)
+		entry, err := signableP2PKEntry(utxoSet, in, keyID)
 		if err != nil {
 			return err
 		}
-		signature, err := signer.SignDigest32(digest)
+		witnessItem, err := signWitnessItem(tx, uint32(i), entry.Value, chainID, signer, pub)
 		if err != nil {
 			return err
 		}
-		signature = append(signature, SIGHASH_ALL)
-		witness = append(witness, WitnessItem{
-			SuiteID:   SUITE_ID_ML_DSA_87,
-			Pubkey:    append([]byte(nil), pub...),
-			Signature: signature,
-		})
+		witness = append(witness, witnessItem)
 	}
 
 	tx.Witness = witness
 	return nil
+}
+
+func signerBinding(signer DigestSigner) ([]byte, [32]byte, error) {
+	pub := signer.PubkeyBytes()
+	if len(pub) != ML_DSA_87_PUBKEY_BYTES {
+		return nil, [32]byte{}, txerr(TX_ERR_SIG_NONCANONICAL, "non-canonical ML-DSA public key length")
+	}
+	return pub, sha3_256(pub), nil
+}
+
+func signableP2PKEntry(utxoSet map[Outpoint]UtxoEntry, in TxInput, keyID [32]byte) (UtxoEntry, error) {
+	op := Outpoint{Txid: in.PrevTxid, Vout: in.PrevVout}
+	entry, ok := utxoSet[op]
+	if !ok {
+		return UtxoEntry{}, txerr(TX_ERR_MISSING_UTXO, "utxo not found")
+	}
+	if entry.CovenantType != COV_TYPE_P2PK {
+		return UtxoEntry{}, fmt.Errorf("unsupported covenant type for signing: 0x%04x", entry.CovenantType)
+	}
+	if len(entry.CovenantData) != MAX_P2PK_COVENANT_DATA || entry.CovenantData[0] != SUITE_ID_ML_DSA_87 {
+		return UtxoEntry{}, txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_P2PK covenant_data invalid")
+	}
+	if !bytes.Equal(entry.CovenantData[1:33], keyID[:]) {
+		return UtxoEntry{}, txerr(TX_ERR_SIG_INVALID, "signer key binding mismatch")
+	}
+	return entry, nil
+}
+
+func signWitnessItem(
+	tx *Tx,
+	inputIndex uint32,
+	inputValue uint64,
+	chainID [32]byte,
+	signer DigestSigner,
+	pub []byte,
+) (WitnessItem, error) {
+	digest, err := SighashV1DigestWithType(tx, inputIndex, inputValue, chainID, SIGHASH_ALL)
+	if err != nil {
+		return WitnessItem{}, err
+	}
+	signature, err := signer.SignDigest32(digest)
+	if err != nil {
+		return WitnessItem{}, err
+	}
+	signature = append(signature, SIGHASH_ALL)
+	return WitnessItem{
+		SuiteID:   SUITE_ID_ML_DSA_87,
+		Pubkey:    append([]byte(nil), pub...),
+		Signature: signature,
+	}, nil
 }

--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -67,30 +67,12 @@ func (m *Mempool) AddTx(txBytes []byte) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.txs[checked.TxID]; exists {
-		return fmt.Errorf("tx already in mempool")
-	}
-	if len(m.txs) >= m.maxTxs {
-		return fmt.Errorf("mempool full")
-	}
-	for _, op := range inputs {
-		if existing, ok := m.spenders[op]; ok {
-			return fmt.Errorf("mempool double-spend conflict with %x", existing)
-		}
+	if err := m.validateAdmissionLocked(checked.TxID, inputs); err != nil {
+		return err
 	}
 
-	entry := &mempoolEntry{
-		raw:    append([]byte(nil), checked.Bytes...),
-		txid:   checked.TxID,
-		inputs: append([]consensus.Outpoint(nil), inputs...),
-		fee:    checked.Fee,
-		weight: checked.Weight,
-		size:   checked.SerializedSize,
-	}
-	m.txs[entry.txid] = entry
-	for _, op := range entry.inputs {
-		m.spenders[op] = entry.txid
-	}
+	entry := newMempoolEntry(checked, inputs)
+	m.addEntryLocked(entry)
 	return nil
 }
 
@@ -99,39 +81,9 @@ func (m *Mempool) SelectTransactions(maxCount int, maxBytes int) [][]byte {
 		return nil
 	}
 
-	m.mu.RLock()
-	entries := make([]*mempoolEntry, 0, len(m.txs))
-	for _, entry := range m.txs {
-		entries = append(entries, entry)
-	}
-	m.mu.RUnlock()
-
-	sort.Slice(entries, func(i, j int) bool {
-		if cmp := compareFeeRate(entries[i], entries[j]); cmp != 0 {
-			return cmp > 0
-		}
-		if entries[i].fee != entries[j].fee {
-			return entries[i].fee > entries[j].fee
-		}
-		if entries[i].weight != entries[j].weight {
-			return entries[i].weight < entries[j].weight
-		}
-		return bytes.Compare(entries[i].txid[:], entries[j].txid[:]) < 0
-	})
-
-	selected := make([][]byte, 0, len(entries))
-	usedBytes := 0
-	for _, entry := range entries {
-		if len(selected) >= maxCount {
-			break
-		}
-		if entry.size > maxBytes-usedBytes {
-			continue
-		}
-		selected = append(selected, append([]byte(nil), entry.raw...))
-		usedBytes += entry.size
-	}
-	return selected
+	entries := m.snapshotEntries()
+	sortMempoolEntries(entries)
+	return pickEntries(entries, maxCount, maxBytes)
 }
 
 func (m *Mempool) EvictConfirmed(blockBytes []byte) error {
@@ -163,19 +115,7 @@ func (m *Mempool) RemoveConflicting(blockBytes []byte) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	conflicts := make(map[[32]byte]struct{})
-	for i, tx := range block.Txs {
-		if i == 0 || tx == nil {
-			continue
-		}
-		for _, in := range tx.Inputs {
-			op := consensus.Outpoint{Txid: in.PrevTxid, Vout: in.PrevVout}
-			if txid, ok := m.spenders[op]; ok {
-				conflicts[txid] = struct{}{}
-			}
-		}
-	}
-	for txid := range conflicts {
+	for txid := range m.collectConflictsLocked(block) {
 		m.removeTxLocked(txid)
 	}
 	return nil
@@ -225,6 +165,99 @@ func (m *Mempool) removeTxLocked(txid [32]byte) {
 	for _, op := range entry.inputs {
 		delete(m.spenders, op)
 	}
+}
+
+func (m *Mempool) validateAdmissionLocked(txid [32]byte, inputs []consensus.Outpoint) error {
+	if _, exists := m.txs[txid]; exists {
+		return fmt.Errorf("tx already in mempool")
+	}
+	if len(m.txs) >= m.maxTxs {
+		return fmt.Errorf("mempool full")
+	}
+	for _, op := range inputs {
+		if existing, ok := m.spenders[op]; ok {
+			return fmt.Errorf("mempool double-spend conflict with %x", existing)
+		}
+	}
+	return nil
+}
+
+func newMempoolEntry(checked *consensus.CheckedTransaction, inputs []consensus.Outpoint) *mempoolEntry {
+	return &mempoolEntry{
+		raw:    append([]byte(nil), checked.Bytes...),
+		txid:   checked.TxID,
+		inputs: append([]consensus.Outpoint(nil), inputs...),
+		fee:    checked.Fee,
+		weight: checked.Weight,
+		size:   checked.SerializedSize,
+	}
+}
+
+func (m *Mempool) addEntryLocked(entry *mempoolEntry) {
+	m.txs[entry.txid] = entry
+	for _, op := range entry.inputs {
+		m.spenders[op] = entry.txid
+	}
+}
+
+func (m *Mempool) snapshotEntries() []*mempoolEntry {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	entries := make([]*mempoolEntry, 0, len(m.txs))
+	for _, entry := range m.txs {
+		entries = append(entries, entry)
+	}
+	return entries
+}
+
+func sortMempoolEntries(entries []*mempoolEntry) {
+	sort.Slice(entries, func(i, j int) bool {
+		if cmp := compareFeeRate(entries[i], entries[j]); cmp != 0 {
+			return cmp > 0
+		}
+		if entries[i].fee != entries[j].fee {
+			return entries[i].fee > entries[j].fee
+		}
+		if entries[i].weight != entries[j].weight {
+			return entries[i].weight < entries[j].weight
+		}
+		return bytes.Compare(entries[i].txid[:], entries[j].txid[:]) < 0
+	})
+}
+
+func pickEntries(entries []*mempoolEntry, maxCount int, maxBytes int) [][]byte {
+	selected := make([][]byte, 0, len(entries))
+	usedBytes := 0
+	for _, entry := range entries {
+		if len(selected) >= maxCount {
+			break
+		}
+		if entry.size > maxBytes-usedBytes {
+			continue
+		}
+		selected = append(selected, append([]byte(nil), entry.raw...))
+		usedBytes += entry.size
+	}
+	return selected
+}
+
+func (m *Mempool) collectConflictsLocked(block *consensus.ParsedBlock) map[[32]byte]struct{} {
+	conflicts := make(map[[32]byte]struct{})
+	for i, tx := range block.Txs {
+		if i == 0 || tx == nil {
+			continue
+		}
+		for _, in := range tx.Inputs {
+			if txid, ok := m.spenders[outpointFromInput(in)]; ok {
+				conflicts[txid] = struct{}{}
+			}
+		}
+	}
+	return conflicts
+}
+
+func outpointFromInput(in consensus.TxInput) consensus.Outpoint {
+	return consensus.Outpoint{Txid: in.PrevTxid, Vout: in.PrevVout}
 }
 
 func compareFeeRate(a *mempoolEntry, b *mempoolEntry) int {


### PR DESCRIPTION
## Summary
- split mempool admission and selection into smaller helpers without changing admission/order semantics
- extract signer binding and witness-building helpers in `tx_helpers.go`
- deduplicate OpenSSL key algorithm/public-key helpers in `openssl_signer.go`

## Testing
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node ./consensus ./cmd/rubin-txgen'`

Closes #428
