### PR TITLE
ci: disable irrelevant Codacy analyzers

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -46,3 +46,20 @@ engines:
       - "clients/rust/crates/rubin-consensus-cli/**"
     config:
       minLines: 25
+
+languages:
+  # Product code lives in Go/Rust. Everything below is docs/tooling/fixtures or
+  # workflow metadata already excluded above, so running language analyzers only
+  # adds noise on PRs that do not touch executable code.
+  javascript:
+    enabled: false
+  typescript:
+    enabled: false
+  python:
+    enabled: false
+  json:
+    enabled: false
+  yaml:
+    enabled: false
+  markdown:
+    enabled: false


### PR DESCRIPTION
Summary:
- disable non-product Codacy language analyzers for JS/TS/Python/JSON/YAML/Markdown
- keep Go/Rust analysis intact
- reduce analysis noise on workflow/docs-only PRs

Validation:
- python3 YAML parse of .codacy.yml

Context:
- follow-up to Codacy noise on workflow-only commits and PR auto-merge troubleshooting