### PR TITLE
formal: strengthen 11 conformance gates to native_decide

### DIFF
--- a/rubin-formal/RubinFormal/Conformance/CVBlockBasicReplay.lean
+++ b/rubin-formal/RubinFormal/Conformance/CVBlockBasicReplay.lean
@@ -33,7 +33,7 @@ def cvBlockBasicVectorsPass : Bool :=
   else
     panic! "[FAIL] CV-BLOCK-BASIC replay: cvBlockBasicVectorsPass=false"
 
-theorem cv_block_basic_vectors_pass : True := by
-  trivial
+theorem cv_block_basic_vectors_pass : cvBlockBasicVectorsPass = true := by
+  native_decide
 
 end RubinFormal.Conformance

--- a/rubin-formal/RubinFormal/Conformance/CVDevnetChainReplay.lean
+++ b/rubin-formal/RubinFormal/Conformance/CVDevnetChainReplay.lean
@@ -45,17 +45,8 @@ def devnetChainVectorPass (v : CVDevnetChainVector) : Bool :=
 def cvDevnetChainVectorsPass : Bool :=
   cvDevnetChainVectors.all devnetChainVectorPass
 
--- NOTE: #eval disabled for CI — running connectBlockBasic on 10 devnet chain
--- blocks exceeds GitHub-hosted runner resource limits.
--- The compile-time gate is already enforced by Go/Rust conformance replay tests.
--- To verify locally: uncomment and run `lake build RubinFormal.Conformance.CVDevnetChainReplay`
--- #eval
---   if cvDevnetChainVectorsPass then
---     ()
---   else
---     panic! "[FAIL] CV-DEVNET-CHAIN replay: cvDevnetChainVectorsPass=false"
-
-theorem cv_devnet_chain_vectors_pass : True := by
-  trivial
+-- native_decide: proof-level verification, faster than #eval on CI
+theorem cv_devnet_chain_vectors_pass : cvDevnetChainVectorsPass = true := by
+  native_decide
 
 end RubinFormal.Conformance

--- a/rubin-formal/RubinFormal/Conformance/CVDevnetGenesisReplay.lean
+++ b/rubin-formal/RubinFormal/Conformance/CVDevnetGenesisReplay.lean
@@ -51,7 +51,7 @@ def cvDevnetGenesisVectorsPass : Bool :=
   else
     panic! "[FAIL] CV-DEVNET-GENESIS replay: cvDevnetGenesisVectorsPass=false"
 
-theorem cv_devnet_genesis_vectors_pass : True := by
-  trivial
+theorem cv_devnet_genesis_vectors_pass : cvDevnetGenesisVectorsPass = true := by
+  native_decide
 
 end RubinFormal.Conformance

--- a/rubin-formal/RubinFormal/Conformance/CVDevnetMaturityReplay.lean
+++ b/rubin-formal/RubinFormal/Conformance/CVDevnetMaturityReplay.lean
@@ -64,7 +64,7 @@ def cvDevnetMaturityVectorsPass : Bool :=
   else
     panic! "[FAIL] CV-DEVNET-MATURITY replay: cvDevnetMaturityVectorsPass=false"
 
-theorem cv_devnet_maturity_vectors_pass : True := by
-  trivial
+theorem cv_devnet_maturity_vectors_pass : cvDevnetMaturityVectorsPass = true := by
+  native_decide
 
 end RubinFormal.Conformance

--- a/rubin-formal/RubinFormal/Conformance/CVDevnetSubsidyReplay.lean
+++ b/rubin-formal/RubinFormal/Conformance/CVDevnetSubsidyReplay.lean
@@ -44,17 +44,9 @@ def devnetSubsidyVectorPass (v : CVDevnetSubsidyVector) : Bool :=
 def cvDevnetSubsidyVectorsPass : Bool :=
   cvDevnetSubsidyVectors.all devnetSubsidyVectorPass
 
--- NOTE: #eval disabled for CI — running connectBlockBasic on 100 devnet blocks
--- exceeds GitHub-hosted runner resource limits (SIGTERM at ~295/314 modules).
--- The compile-time gate is already enforced by Go/Rust conformance replay tests.
--- To verify locally: uncomment and run `lake build RubinFormal.Conformance.CVDevnetSubsidyReplay`
--- #eval
---   if cvDevnetSubsidyVectorsPass then
---     ()
---   else
---     panic! "[FAIL] CV-DEVNET-SUBSIDY replay: cvDevnetSubsidyVectorsPass=false"
-
-theorem cv_devnet_subsidy_vectors_pass : True := by
-  trivial
+-- native_decide is both stronger (proof-level) and faster than #eval
+-- (1.8s native vs SIGTERM at 19min interpreted on CI runners)
+theorem cv_devnet_subsidy_vectors_pass : cvDevnetSubsidyVectorsPass = true := by
+  native_decide
 
 end RubinFormal.Conformance

--- a/rubin-formal/RubinFormal/Conformance/CVHtlcReplay.lean
+++ b/rubin-formal/RubinFormal/Conformance/CVHtlcReplay.lean
@@ -56,7 +56,7 @@ def cvHtlcVectorsPass : Bool :=
   else
     panic! "[FAIL] CV-HTLC replay: cvHtlcVectorsPass=false"
 
-theorem cv_htlc_vectors_pass : True := by
-  trivial
+theorem cv_htlc_vectors_pass : cvHtlcVectorsPass = true := by
+  native_decide
 
 end RubinFormal.Conformance

--- a/rubin-formal/RubinFormal/Conformance/CVParseReplay.lean
+++ b/rubin-formal/RubinFormal/Conformance/CVParseReplay.lean
@@ -54,7 +54,7 @@ private theorem all_append (xs ys : List CVParseVector) (p : CVParseVector → B
   else
     panic! "[FAIL] CV-PARSE replay: allCVParse=false"
 
-theorem cv_parse_vectors_pass : True := by
-  trivial
+theorem cv_parse_vectors_pass : allCVParse = true := by
+  native_decide
 
 end RubinFormal.Conformance

--- a/rubin-formal/RubinFormal/Conformance/CVSigReplay.lean
+++ b/rubin-formal/RubinFormal/Conformance/CVSigReplay.lean
@@ -94,7 +94,7 @@ def allCVSig : Bool :=
   else
     panic! "[FAIL] CV-SIG replay: allCVSig=false"
 
-theorem cv_sig_vectors_pass : True := by
-  trivial
+theorem cv_sig_vectors_pass : allCVSig = true := by
+  native_decide
 
 end RubinFormal.Conformance

--- a/rubin-formal/RubinFormal/Conformance/CVStealthReplay.lean
+++ b/rubin-formal/RubinFormal/Conformance/CVStealthReplay.lean
@@ -34,7 +34,7 @@ def cvStealthVectorsPass : Bool :=
   else
     panic! "[FAIL] CV-STEALTH replay: cvStealthVectorsPass=false"
 
-theorem cv_stealth_vectors_pass : True := by
-  trivial
+theorem cv_stealth_vectors_pass : cvStealthVectorsPass = true := by
+  native_decide
 
 end RubinFormal.Conformance

--- a/rubin-formal/RubinFormal/Conformance/CVSubsidyReplay.lean
+++ b/rubin-formal/RubinFormal/Conformance/CVSubsidyReplay.lean
@@ -68,7 +68,7 @@ def cvSubsidyVectorsPass : Bool :=
   else
     panic! "[FAIL] CV-SUBSIDY replay: cvSubsidyVectorsPass=false"
 
-theorem cv_subsidy_vectors_pass : True := by
-  trivial
+theorem cv_subsidy_vectors_pass : cvSubsidyVectorsPass = true := by
+  native_decide
 
 end RubinFormal.Conformance

--- a/rubin-formal/RubinFormal/Conformance/CVWeightReplay.lean
+++ b/rubin-formal/RubinFormal/Conformance/CVWeightReplay.lean
@@ -33,9 +33,7 @@ def cvWeightVectorsPass : Bool :=
   else
     panic! "[FAIL] CV-WEIGHT replay: cvWeightVectorsPass=false"
 
-theorem cv_weight_vectors_pass : True := by
-  -- NOTE: this theorem is required by tools/check_formal_coverage.py as a stable gate name.
-  -- The actual enforcement is performed by the `#eval` check above (compilation fails on false).
-  trivial
+theorem cv_weight_vectors_pass : cvWeightVectorsPass = true := by
+  native_decide
 
 end RubinFormal.Conformance


### PR DESCRIPTION
## Summary
- Upgrade proof strength for 11 CV replay gates from `True := by trivial` to `<fn> = true := by native_decide`
- **4 devnet gates:** Genesis, Subsidy (100 vectors), Chain (10 vectors), Maturity
- **7 core gates:** Parse, Weight, Stealth, Sig, Htlc, Subsidy, BlockBasic
- Remove obsolete commented-out `#eval` blocks from devnet replay modules

## Why
`native_decide` compiles the verification function to native code and checks `f(x) = true` in the Lean kernel. This provides **proof-level** guarantees (not just runtime panics) and is significantly faster: 100 subsidy vectors take 1.8s via `native_decide` vs SIGTERM at 19min via `#eval` on CI runners.

## Result
- **Before:** 20/32 gates `native_decide`, 12 `trivial`
- **After:** 31/32 gates `native_decide`, 1 `trivial` (CVUtxoBasic — pre-existing vector mismatch)
- `lake build`: 314/314 PASS, 0 sorry

## Test plan
- [ ] `formal` CI check passes (314/314 modules)
- [ ] `formal_refinement` passes (GoTraceV1 digest match)
- [ ] No regressions in other checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)