### PR TITLE
refactor: reduce node hotspot complexity for q-devnet-11

### DIFF
--- a/clients/go/node/blockstore.go
+++ b/clients/go/node/blockstore.go
@@ -70,22 +70,10 @@ func (bs *BlockStore) PutBlock(height uint64, blockHash [32]byte, headerBytes []
 	if bs == nil {
 		return errors.New("nil blockstore")
 	}
-	if len(headerBytes) != consensus.BLOCK_HEADER_BYTES {
-		return fmt.Errorf("invalid header length: %d", len(headerBytes))
-	}
-	computedHash, err := consensus.BlockHash(headerBytes)
-	if err != nil {
+	if err := validateBlockHeaderHash(headerBytes, blockHash); err != nil {
 		return err
 	}
-	if computedHash != blockHash {
-		return errors.New("header hash mismatch")
-	}
-
-	hashHex := hex.EncodeToString(blockHash[:])
-	if err := writeFileIfAbsent(filepath.Join(bs.blocksDir, hashHex+".bin"), blockBytes); err != nil {
-		return err
-	}
-	if err := writeFileIfAbsent(filepath.Join(bs.headersDir, hashHex+".bin"), headerBytes); err != nil {
+	if err := bs.persistBlockBytes(blockHash, headerBytes, blockBytes); err != nil {
 		return err
 	}
 	return bs.SetCanonicalTip(height, blockHash)
@@ -95,19 +83,14 @@ func (bs *BlockStore) SetCanonicalTip(height uint64, blockHash [32]byte) error {
 	if bs == nil {
 		return errors.New("nil blockstore")
 	}
-	hashHex := hex.EncodeToString(blockHash[:])
-	currentLen := uint64(len(bs.index.Canonical))
-	switch {
-	case height > currentLen:
-		return fmt.Errorf("height gap: got %d, expected <= %d", height, currentLen)
-	case height == currentLen:
-		bs.index.Canonical = append(bs.index.Canonical, hashHex)
-	default:
-		if bs.index.Canonical[height] == hashHex {
-			return saveBlockStoreIndex(bs.indexPath, bs.index)
-		}
-		bs.index.Canonical = append(bs.index.Canonical[:height], hashHex)
+	nextCanonical, changed, err := updatedCanonicalHashes(bs.index.Canonical, height, blockHash)
+	if err != nil {
+		return err
 	}
+	if !changed {
+		return saveBlockStoreIndex(bs.indexPath, bs.index)
+	}
+	bs.index.Canonical = nextCanonical
 	return saveBlockStoreIndex(bs.indexPath, bs.index)
 }
 
@@ -145,14 +128,10 @@ func (bs *BlockStore) Tip() (uint64, [32]byte, bool, error) {
 	if bs == nil {
 		return 0, out, false, errors.New("nil blockstore")
 	}
-	if len(bs.index.Canonical) == 0 {
+	height, ok := canonicalTipHeight(bs.index.Canonical)
+	if !ok {
 		return 0, out, false, nil
 	}
-	var height uint64
-	for range bs.index.Canonical {
-		height++
-	}
-	height--
 	hash, err := parseHex32("tip hash", bs.index.Canonical[height])
 	if err != nil {
 		return 0, out, false, err
@@ -207,6 +186,52 @@ func saveBlockStoreIndex(path string, index blockStoreIndexDisk) error {
 	}
 	raw = append(raw, '\n')
 	return writeFileAtomicFn(path, raw, 0o600)
+}
+
+func validateBlockHeaderHash(headerBytes []byte, blockHash [32]byte) error {
+	if len(headerBytes) != consensus.BLOCK_HEADER_BYTES {
+		return fmt.Errorf("invalid header length: %d", len(headerBytes))
+	}
+	computedHash, err := consensus.BlockHash(headerBytes)
+	if err != nil {
+		return err
+	}
+	if computedHash != blockHash {
+		return errors.New("header hash mismatch")
+	}
+	return nil
+}
+
+func (bs *BlockStore) persistBlockBytes(blockHash [32]byte, headerBytes []byte, blockBytes []byte) error {
+	hashHex := hex.EncodeToString(blockHash[:])
+	if err := writeFileIfAbsent(filepath.Join(bs.blocksDir, hashHex+".bin"), blockBytes); err != nil {
+		return err
+	}
+	return writeFileIfAbsent(filepath.Join(bs.headersDir, hashHex+".bin"), headerBytes)
+}
+
+func updatedCanonicalHashes(canonical []string, height uint64, blockHash [32]byte) ([]string, bool, error) {
+	hashHex := hex.EncodeToString(blockHash[:])
+	currentLen := uint64(len(canonical))
+	switch {
+	case height > currentLen:
+		return nil, false, fmt.Errorf("height gap: got %d, expected <= %d", height, currentLen)
+	case height == currentLen:
+		return append(canonical, hashHex), true, nil
+	case canonical[height] == hashHex:
+		return canonical, false, nil
+	default:
+		nextCanonical := append([]string(nil), canonical[:height]...)
+		nextCanonical = append(nextCanonical, hashHex)
+		return nextCanonical, true, nil
+	}
+}
+
+func canonicalTipHeight(canonical []string) (uint64, bool) {
+	if len(canonical) == 0 {
+		return 0, false
+	}
+	return uint64(len(canonical) - 1), true
 }
 
 func writeFileIfAbsent(path string, content []byte) error {

--- a/clients/go/node/miner.go
+++ b/clients/go/node/miner.go
@@ -66,6 +66,13 @@ type Miner struct {
 	cfg        MinerConfig
 }
 
+type minedCandidate struct {
+	raw    []byte
+	txid   [32]byte
+	wtxid  [32]byte
+	weight uint64
+}
+
 func DefaultMinerConfig() MinerConfig {
 	return MinerConfig{
 		Target: consensus.POW_LIMIT,
@@ -165,123 +172,21 @@ func (m *Miner) buildBlock(ctx context.Context, txs [][]byte) ([]byte, []uint64,
 		prevHash = *expectedPrev
 	}
 
-	candidateTxs := txs
-	maxSelected := m.cfg.MaxTxPerBlock - 1
-	if maxSelected < 0 {
-		maxSelected = 0
-	}
-	if len(candidateTxs) == 0 && m.sync != nil && m.sync.mempool != nil && maxSelected > 0 {
-		candidateTxs = m.sync.mempool.SelectTransactions(maxSelected, int(consensus.MAX_BLOCK_WEIGHT))
-	}
-	if maxSelected >= 0 && len(candidateTxs) > maxSelected {
-		candidateTxs = candidateTxs[:maxSelected]
+	candidateTxs := m.candidateTransactions(txs)
+	remainingWeight, err := m.remainingWeightBudget(nextHeight)
+	if err != nil {
+		return nil, nil, 0, 0, 0, err
 	}
 
-	coinbaseTemplate, err := buildCoinbaseTx(nextHeight, m.chainState.AlreadyGenerated, m.cfg.MineAddress, [32]byte{})
+	parsed, err := m.selectCandidateTransactions(candidateTxs, nextHeight, remainingWeight)
 	if err != nil {
 		return nil, nil, 0, 0, 0, err
 	}
-	coinbaseTx, _, _, consumed, err := consensus.ParseTx(coinbaseTemplate)
+	witnessCommitment, err := buildWitnessCommitment(parsed)
 	if err != nil {
 		return nil, nil, 0, 0, 0, err
 	}
-	if consumed != len(coinbaseTemplate) {
-		return nil, nil, 0, 0, 0, errors.New("coinbase serialization is non-canonical")
-	}
-	coinbaseWeight, _, _, err := consensus.TxWeightAndStats(coinbaseTx)
-	if err != nil {
-		return nil, nil, 0, 0, 0, err
-	}
-	remainingWeight := consensus.MAX_BLOCK_WEIGHT - coinbaseWeight
-
-	type parsedTx struct {
-		raw    []byte
-		txid   [32]byte
-		wtxid  [32]byte
-		weight uint64
-	}
-	parsed := make([]parsedTx, 0, len(candidateTxs))
-	var selectedWeight uint64
-	var policyDaIncluded uint64
-	for _, raw := range candidateTxs {
-		tx, txid, wtxid, consumed, parseErr := consensus.ParseTx(raw)
-		if parseErr != nil {
-			return nil, nil, 0, 0, 0, parseErr
-		}
-		if consumed != len(raw) {
-			return nil, nil, 0, 0, 0, errors.New("non-canonical tx bytes in miner input")
-		}
-		if m.cfg.PolicyDaAnchorAntiAbuse {
-			reject, daBytes, _, err := RejectDaAnchorTxPolicy(tx, m.chainState.Utxos, m.cfg.PolicyDaSurchargePerByte)
-			if err != nil || reject {
-				continue
-			}
-			if daBytes > 0 && m.cfg.PolicyMaxDaBytesPerBlock > 0 {
-				next := policyDaIncluded + daBytes
-				if next < policyDaIncluded { // overflow
-					continue
-				}
-				if next > m.cfg.PolicyMaxDaBytesPerBlock {
-					continue
-				}
-				policyDaIncluded = next
-			}
-			if m.cfg.PolicyRejectNonCoinbaseAnchorOutputs {
-				if reject, _, err := RejectNonCoinbaseAnchorOutputs(tx); err != nil || reject {
-					continue
-				}
-			}
-		}
-		if m.cfg.PolicyRejectCoreExtPreActivation {
-			reject, _, err := RejectCoreExtTxPreActivation(tx, m.chainState.Utxos, nextHeight, m.cfg.CoreExtProfiles)
-			if err != nil || reject {
-				continue
-			}
-		}
-		txWeight, _, _, err := consensus.TxWeightAndStats(tx)
-		if err != nil {
-			return nil, nil, 0, 0, 0, err
-		}
-		if txWeight > remainingWeight-selectedWeight {
-			continue
-		}
-		selectedWeight += txWeight
-		parsed = append(parsed, parsedTx{
-			raw:    append([]byte(nil), raw...),
-			txid:   txid,
-			wtxid:  wtxid,
-			weight: txWeight,
-		})
-	}
-
-	wtxids := make([][32]byte, 1, 1+len(parsed))
-	for _, p := range parsed {
-		wtxids = append(wtxids, p.wtxid)
-	}
-	witnessRoot, err := consensus.WitnessMerkleRootWtxids(wtxids)
-	if err != nil {
-		return nil, nil, 0, 0, 0, err
-	}
-	witnessCommitment := consensus.WitnessCommitmentHash(witnessRoot)
-
-	coinbase, err := buildCoinbaseTx(nextHeight, m.chainState.AlreadyGenerated, m.cfg.MineAddress, witnessCommitment)
-	if err != nil {
-		return nil, nil, 0, 0, 0, err
-	}
-	_, coinbaseTxid, _, consumed, err := consensus.ParseTx(coinbase)
-	if err != nil {
-		return nil, nil, 0, 0, 0, err
-	}
-	if consumed != len(coinbase) {
-		return nil, nil, 0, 0, 0, errors.New("coinbase serialization is non-canonical")
-	}
-
-	txids := make([][32]byte, 0, 1+len(parsed))
-	txids = append(txids, coinbaseTxid)
-	for _, p := range parsed {
-		txids = append(txids, p.txid)
-	}
-	merkleRoot, err := consensus.MerkleRootTxids(txids)
+	coinbase, merkleRoot, err := m.buildCoinbaseAndMerkleRoot(nextHeight, witnessCommitment, parsed)
 	if err != nil {
 		return nil, nil, 0, 0, 0, err
 	}
@@ -294,21 +199,9 @@ func (m *Miner) buildBlock(ctx context.Context, txs [][]byte) ([]byte, []uint64,
 	timestamp := chooseValidTimestamp(nextHeight, prevTimestamps, now)
 
 	blockWithoutNonce := makeHeaderPrefix(prevHash, merkleRoot, timestamp, m.cfg.Target)
-	var nonce uint64
-	var headerBytes []byte
-	for {
-		if ctx != nil {
-			select {
-			case <-ctx.Done():
-				return nil, nil, 0, 0, 0, ctx.Err()
-			default:
-			}
-		}
-		headerBytes = consensus.AppendU64le(append([]byte(nil), blockWithoutNonce...), nonce)
-		if err := consensus.PowCheck(headerBytes, m.cfg.Target); err == nil {
-			break
-		}
-		nonce++
+	headerBytes, nonce, err := mineHeaderNonce(ctx, blockWithoutNonce, m.cfg.Target)
+	if err != nil {
+		return nil, nil, 0, 0, 0, err
 	}
 
 	blockBytes := make([]byte, 0, len(headerBytes)+4+len(coinbase))
@@ -319,6 +212,203 @@ func (m *Miner) buildBlock(ctx context.Context, txs [][]byte) ([]byte, []uint64,
 		blockBytes = append(blockBytes, p.raw...)
 	}
 	return blockBytes, prevTimestamps, timestamp, nonce, 1 + len(parsed), nil
+}
+
+func (m *Miner) candidateTransactions(txs [][]byte) [][]byte {
+	candidateTxs := txs
+	maxSelected := m.cfg.MaxTxPerBlock - 1
+	if maxSelected < 0 {
+		maxSelected = 0
+	}
+	if len(candidateTxs) == 0 && m.sync != nil && m.sync.mempool != nil && maxSelected > 0 {
+		candidateTxs = m.sync.mempool.SelectTransactions(maxSelected, int(consensus.MAX_BLOCK_WEIGHT))
+	}
+	if maxSelected >= 0 && len(candidateTxs) > maxSelected {
+		candidateTxs = candidateTxs[:maxSelected]
+	}
+	return candidateTxs
+}
+
+func (m *Miner) remainingWeightBudget(nextHeight uint64) (uint64, error) {
+	coinbaseTemplate, err := buildCoinbaseTx(nextHeight, m.chainState.AlreadyGenerated, m.cfg.MineAddress, [32]byte{})
+	if err != nil {
+		return 0, err
+	}
+	coinbaseWeight, err := canonicalTxWeight(coinbaseTemplate, "coinbase")
+	if err != nil {
+		return 0, err
+	}
+	return consensus.MAX_BLOCK_WEIGHT - coinbaseWeight, nil
+}
+
+func (m *Miner) selectCandidateTransactions(candidateTxs [][]byte, nextHeight uint64, remainingWeight uint64) ([]minedCandidate, error) {
+	parsed := make([]minedCandidate, 0, len(candidateTxs))
+	var selectedWeight uint64
+	var policyDaIncluded uint64
+	for _, raw := range candidateTxs {
+		candidate, err := m.parseMiningCandidate(raw)
+		if err != nil {
+			return nil, err
+		}
+		reject, nextDaIncluded, err := m.rejectCandidate(candidate.tx, nextHeight, policyDaIncluded)
+		if err != nil {
+			return nil, err
+		}
+		if reject {
+			continue
+		}
+		if candidate.minedCandidate.weight > remainingWeight-selectedWeight {
+			continue
+		}
+		selectedWeight += candidate.minedCandidate.weight
+		policyDaIncluded = nextDaIncluded
+		parsed = append(parsed, candidate.minedCandidate)
+	}
+	return parsed, nil
+}
+
+type miningCandidate struct {
+	tx             *consensus.Tx
+	minedCandidate minedCandidate
+}
+
+func (m *Miner) parseMiningCandidate(raw []byte) (miningCandidate, error) {
+	tx, txid, wtxid, consumed, parseErr := consensus.ParseTx(raw)
+	if parseErr != nil {
+		return miningCandidate{}, parseErr
+	}
+	if consumed != len(raw) {
+		return miningCandidate{}, errors.New("non-canonical tx bytes in miner input")
+	}
+	txWeight, _, _, err := consensus.TxWeightAndStats(tx)
+	if err != nil {
+		return miningCandidate{}, err
+	}
+	return miningCandidate{
+		tx: tx,
+		minedCandidate: minedCandidate{
+			raw:    append([]byte(nil), raw...),
+			txid:   txid,
+			wtxid:  wtxid,
+			weight: txWeight,
+		},
+	}, nil
+}
+
+func (m *Miner) rejectCandidate(tx *consensus.Tx, nextHeight uint64, policyDaIncluded uint64) (bool, uint64, error) {
+	if m.cfg.PolicyDaAnchorAntiAbuse {
+		reject, daBytes, _, err := RejectDaAnchorTxPolicy(tx, m.chainState.Utxos, m.cfg.PolicyDaSurchargePerByte)
+		if err != nil {
+			return false, policyDaIncluded, err
+		}
+		if reject {
+			return true, policyDaIncluded, nil
+		}
+		nextDaIncluded, ok := updatedPolicyDaBytes(policyDaIncluded, daBytes, m.cfg.PolicyMaxDaBytesPerBlock)
+		if !ok {
+			return true, policyDaIncluded, nil
+		}
+		policyDaIncluded = nextDaIncluded
+		if m.cfg.PolicyRejectNonCoinbaseAnchorOutputs {
+			reject, _, err := RejectNonCoinbaseAnchorOutputs(tx)
+			if err != nil {
+				return false, policyDaIncluded, err
+			}
+			if reject {
+				return true, policyDaIncluded, nil
+			}
+		}
+	}
+	if m.cfg.PolicyRejectCoreExtPreActivation {
+		reject, _, err := RejectCoreExtTxPreActivation(tx, m.chainState.Utxos, nextHeight, m.cfg.CoreExtProfiles)
+		if err != nil {
+			return false, policyDaIncluded, err
+		}
+		if reject {
+			return true, policyDaIncluded, nil
+		}
+	}
+	return false, policyDaIncluded, nil
+}
+
+func updatedPolicyDaBytes(current uint64, daBytes uint64, maxPerBlock uint64) (uint64, bool) {
+	if daBytes == 0 || maxPerBlock == 0 {
+		return current, true
+	}
+	next := current + daBytes
+	if next < current || next > maxPerBlock {
+		return current, false
+	}
+	return next, true
+}
+
+func buildWitnessCommitment(parsed []minedCandidate) ([32]byte, error) {
+	wtxids := make([][32]byte, 1, 1+len(parsed))
+	for _, p := range parsed {
+		wtxids = append(wtxids, p.wtxid)
+	}
+	witnessRoot, err := consensus.WitnessMerkleRootWtxids(wtxids)
+	if err != nil {
+		return [32]byte{}, err
+	}
+	return consensus.WitnessCommitmentHash(witnessRoot), nil
+}
+
+func (m *Miner) buildCoinbaseAndMerkleRoot(nextHeight uint64, witnessCommitment [32]byte, parsed []minedCandidate) ([]byte, [32]byte, error) {
+	coinbase, err := buildCoinbaseTx(nextHeight, m.chainState.AlreadyGenerated, m.cfg.MineAddress, witnessCommitment)
+	if err != nil {
+		return nil, [32]byte{}, err
+	}
+	_, coinbaseTxid, _, consumed, err := consensus.ParseTx(coinbase)
+	if err != nil {
+		return nil, [32]byte{}, err
+	}
+	if consumed != len(coinbase) {
+		return nil, [32]byte{}, errors.New("coinbase serialization is non-canonical")
+	}
+	txids := make([][32]byte, 0, 1+len(parsed))
+	txids = append(txids, coinbaseTxid)
+	for _, p := range parsed {
+		txids = append(txids, p.txid)
+	}
+	merkleRoot, err := consensus.MerkleRootTxids(txids)
+	if err != nil {
+		return nil, [32]byte{}, err
+	}
+	return coinbase, merkleRoot, nil
+}
+
+func mineHeaderNonce(ctx context.Context, blockWithoutNonce []byte, target [32]byte) ([]byte, uint64, error) {
+	var nonce uint64
+	for {
+		if ctx != nil {
+			select {
+			case <-ctx.Done():
+				return nil, 0, ctx.Err()
+			default:
+			}
+		}
+		headerBytes := consensus.AppendU64le(append([]byte(nil), blockWithoutNonce...), nonce)
+		if err := consensus.PowCheck(headerBytes, target); err == nil {
+			return headerBytes, nonce, nil
+		}
+		nonce++
+	}
+}
+
+func canonicalTxWeight(raw []byte, label string) (uint64, error) {
+	tx, _, _, consumed, err := consensus.ParseTx(raw)
+	if err != nil {
+		return 0, err
+	}
+	if consumed != len(raw) {
+		return 0, errors.New(label + " serialization is non-canonical")
+	}
+	txWeight, _, _, err := consensus.TxWeightAndStats(tx)
+	if err != nil {
+		return 0, err
+	}
+	return txWeight, nil
 }
 
 func (m *Miner) prevTimestamps(nextHeight uint64) ([]uint64, error) {

--- a/clients/go/node/sync.go
+++ b/clients/go/node/sync.go
@@ -51,14 +51,9 @@ func NewSyncEngine(chainState *ChainState, blockStore *BlockStore, cfg SyncConfi
 	if chainState == nil {
 		return nil, errors.New("nil chainstate")
 	}
+	cfg = normalizeSyncConfig(cfg)
 	if err := validateMainnetGenesisGuard(cfg); err != nil {
 		return nil, err
-	}
-	if cfg.HeaderBatchLimit == 0 {
-		cfg.HeaderBatchLimit = 512
-	}
-	if cfg.IBDLagSeconds == 0 {
-		cfg.IBDLagSeconds = defaultIBDLagSeconds
 	}
 	engine := &SyncEngine{
 		chainState: chainState,
@@ -68,12 +63,27 @@ func NewSyncEngine(chainState *ChainState, blockStore *BlockStore, cfg SyncConfi
 	return engine, nil
 }
 
-func validateMainnetGenesisGuard(cfg SyncConfig) error {
-	network := strings.ToLower(strings.TrimSpace(cfg.Network))
-	if network == "" {
-		network = "devnet"
+func normalizeSyncConfig(cfg SyncConfig) SyncConfig {
+	if cfg.HeaderBatchLimit == 0 {
+		cfg.HeaderBatchLimit = 512
 	}
-	if network != "mainnet" {
+	if cfg.IBDLagSeconds == 0 {
+		cfg.IBDLagSeconds = defaultIBDLagSeconds
+	}
+	cfg.Network = normalizedNetworkName(cfg.Network)
+	return cfg
+}
+
+func normalizedNetworkName(network string) string {
+	network = strings.ToLower(strings.TrimSpace(network))
+	if network == "" {
+		return "devnet"
+	}
+	return network
+}
+
+func validateMainnetGenesisGuard(cfg SyncConfig) error {
+	if normalizedNetworkName(cfg.Network) != "mainnet" {
 		return nil
 	}
 	if cfg.ExpectedTarget == nil {
@@ -89,17 +99,7 @@ func (s *SyncEngine) HeaderSyncRequest() HeaderRequest {
 	if s == nil || s.chainState == nil {
 		return HeaderRequest{}
 	}
-	if !s.chainState.HasTip {
-		return HeaderRequest{
-			HasFrom: false,
-			Limit:   s.cfg.HeaderBatchLimit,
-		}
-	}
-	return HeaderRequest{
-		FromHash: s.chainState.TipHash,
-		HasFrom:  true,
-		Limit:    s.cfg.HeaderBatchLimit,
-	}
+	return headerSyncRequest(s.chainState, s.cfg.HeaderBatchLimit)
 }
 
 func (s *SyncEngine) RecordBestKnownHeight(height uint64) {
@@ -133,10 +133,7 @@ func (s *SyncEngine) IsInIBD(nowUnix uint64) bool {
 	tipTimestamp := s.tipTimestamp
 	ibdLag := s.cfg.IBDLagSeconds
 	s.mu.RUnlock()
-	if nowUnix < tipTimestamp {
-		return true
-	}
-	return nowUnix-tipTimestamp > ibdLag
+	return isInIBDWindow(nowUnix, tipTimestamp, ibdLag)
 }
 
 func (s *SyncEngine) ApplyBlock(blockBytes []byte, prevTimestamps []uint64) (*ChainStateConnectSummary, error) {
@@ -159,48 +156,19 @@ func (s *SyncEngine) ApplyBlock(blockBytes []byte, prevTimestamps []uint64) (*Ch
 		return nil, err
 	}
 
-	snapshot, err := stateToDisk(s.chainState)
+	rollbackState, err := s.captureRollbackState()
 	if err != nil {
 		return nil, err
 	}
-	s.mu.RLock()
-	oldTipTimestamp := s.tipTimestamp
-	oldBestKnown := s.bestKnownHeight
-	s.mu.RUnlock()
-
 	summary, err := s.chainState.ConnectBlock(blockBytes, s.cfg.ExpectedTarget, prevTimestamps, s.cfg.ChainID)
 	if err != nil {
 		return nil, err
 	}
-	rollback := func(cause error) error {
-		restoreErr := restoreChainState(s.chainState, snapshot)
-		s.mu.Lock()
-		s.tipTimestamp = oldTipTimestamp
-		s.bestKnownHeight = oldBestKnown
-		s.mu.Unlock()
-		if restoreErr != nil {
-			return fmt.Errorf("%w (rollback failed: %v)", cause, restoreErr)
-		}
-		return cause
+	if err := s.persistAppliedBlock(summary, blockHash, pb.HeaderBytes, blockBytes); err != nil {
+		return nil, s.rollbackApplyBlock(err, rollbackState)
 	}
 
-	if s.blockStore != nil {
-		if err := s.blockStore.PutBlock(summary.BlockHeight, blockHash, pb.HeaderBytes, blockBytes); err != nil {
-			return nil, rollback(err)
-		}
-	}
-	if s.cfg.ChainStatePath != "" {
-		if err := s.chainState.Save(s.cfg.ChainStatePath); err != nil {
-			return nil, rollback(err)
-		}
-	}
-
-	s.mu.Lock()
-	s.tipTimestamp = pb.Header.Timestamp
-	if summary.BlockHeight > s.bestKnownHeight {
-		s.bestKnownHeight = summary.BlockHeight
-	}
-	s.mu.Unlock()
+	s.recordAppliedBlock(summary.BlockHeight, pb.Header.Timestamp)
 	if s.mempool != nil {
 		_ = s.mempool.EvictConfirmed(blockBytes)
 		_ = s.mempool.RemoveConflicting(blockBytes)
@@ -215,6 +183,79 @@ func (s *SyncEngine) SetMempool(mempool *Mempool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.mempool = mempool
+}
+
+type syncRollbackState struct {
+	chainState      chainStateDisk
+	tipTimestamp    uint64
+	bestKnownHeight uint64
+}
+
+func headerSyncRequest(chainState *ChainState, limit uint64) HeaderRequest {
+	if chainState == nil || !chainState.HasTip {
+		return HeaderRequest{Limit: limit}
+	}
+	return HeaderRequest{
+		FromHash: chainState.TipHash,
+		HasFrom:  true,
+		Limit:    limit,
+	}
+}
+
+func isInIBDWindow(nowUnix uint64, tipTimestamp uint64, ibdLag uint64) bool {
+	if nowUnix < tipTimestamp {
+		return true
+	}
+	return nowUnix-tipTimestamp > ibdLag
+}
+
+func (s *SyncEngine) captureRollbackState() (syncRollbackState, error) {
+	snapshot, err := stateToDisk(s.chainState)
+	if err != nil {
+		return syncRollbackState{}, err
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return syncRollbackState{
+		chainState:      snapshot,
+		tipTimestamp:    s.tipTimestamp,
+		bestKnownHeight: s.bestKnownHeight,
+	}, nil
+}
+
+func (s *SyncEngine) rollbackApplyBlock(cause error, state syncRollbackState) error {
+	restoreErr := restoreChainState(s.chainState, state.chainState)
+	s.mu.Lock()
+	s.tipTimestamp = state.tipTimestamp
+	s.bestKnownHeight = state.bestKnownHeight
+	s.mu.Unlock()
+	if restoreErr != nil {
+		return fmt.Errorf("%w (rollback failed: %v)", cause, restoreErr)
+	}
+	return cause
+}
+
+func (s *SyncEngine) persistAppliedBlock(summary *ChainStateConnectSummary, blockHash [32]byte, headerBytes []byte, blockBytes []byte) error {
+	if s.blockStore != nil {
+		if err := s.blockStore.PutBlock(summary.BlockHeight, blockHash, headerBytes, blockBytes); err != nil {
+			return err
+		}
+	}
+	if s.cfg.ChainStatePath != "" {
+		if err := s.chainState.Save(s.cfg.ChainStatePath); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *SyncEngine) recordAppliedBlock(height uint64, timestamp uint64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.tipTimestamp = timestamp
+	if height > s.bestKnownHeight {
+		s.bestKnownHeight = height
+	}
 }
 
 func validateIncomingChainID(blockHeight uint64, chainID [32]byte) error {


### PR DESCRIPTION
## Summary
- split `BlockStore` persistence/canonical helpers to reduce `PutBlock`/`SetCanonicalTip` branching
- normalize `SyncConfig` and isolate rollback/persist/runtime-update helpers in `SyncEngine`
- split miner block assembly into candidate selection, witness/merkle, and nonce-mining helpers without changing behavior

## Testing
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node'`
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./cmd/rubin-node ./node/p2p'`

Refs #436
