### PR TITLE
fix: trigger codacy coverage after bot merge

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -8,6 +8,8 @@ on:
     types: [completed]
 
 permissions:
+  administration: read
+  actions: write
   pull-requests: write
   contents: write
 
@@ -199,6 +201,18 @@ jobs:
             } catch (mergeError) {
               console.log(`Merge failed: ${mergeError.message}`);
               return;
+            }
+
+            try {
+              await github.rest.actions.createWorkflowDispatch({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'codacy-coverage.yml',
+                ref: pr.base.ref
+              });
+              console.log(`Triggered codacy-coverage workflow_dispatch on ${pr.base.ref}`);
+            } catch (dispatchError) {
+              console.log(`Codacy coverage dispatch failed (non-blocking): ${dispatchError.message}`);
             }
 
             // --- Delete branch ---


### PR DESCRIPTION
## Summary\n- trigger `codacy-coverage.yml` explicitly after successful bot merge\n- add `actions: write` so auto-approve can dispatch the workflow\n- keep dispatch failure non-blocking so merge behavior is unchanged\n\n## Why\nBot merges performed by the auto-approve workflow can advance `main` without creating the normal `push` run for `codacy-coverage`, which leaves Codacy coverage stale for the new HEAD commit.\n\n## Validation\n- YAML parse succeeds for \.github/workflows/auto-approve.yml\n- diff verified against `origin/main` (7c8b4b0e9e33bdd5782a835bf93d3c8c83104dcd)\n