### PR TITLE
test: maximize p2p wire coverage

### DIFF
--- a/clients/go/node/p2p/wire.go
+++ b/clients/go/node/p2p/wire.go
@@ -96,28 +96,35 @@ func encodeVersionPayload(v node.VersionPayloadV1) ([]byte, error) {
 	}
 
 	var buf bytes.Buffer
-	if err := binary.Write(&buf, binary.BigEndian, v.Magic); err != nil {
-		return nil, err
-	}
-	if err := binary.Write(&buf, binary.BigEndian, v.ProtocolVersion); err != nil {
-		return nil, err
-	}
-	if _, err := buf.Write(v.ChainID[:]); err != nil {
-		return nil, err
-	}
-	if _, err := buf.Write(v.GenesisHash[:]); err != nil {
-		return nil, err
-	}
-	if err := binary.Write(&buf, binary.BigEndian, uint16(len(v.UserAgent))); err != nil {
-		return nil, err
-	}
-	if _, err := buf.WriteString(v.UserAgent); err != nil {
-		return nil, err
-	}
-	if err := binary.Write(&buf, binary.BigEndian, v.BestHeight); err != nil {
+	if err := encodeVersionPayloadTo(&buf, v); err != nil {
 		return nil, err
 	}
 	return buf.Bytes(), nil
+}
+
+func encodeVersionPayloadTo(w io.Writer, v node.VersionPayloadV1) error {
+	if err := binary.Write(w, binary.BigEndian, v.Magic); err != nil {
+		return err
+	}
+	if err := binary.Write(w, binary.BigEndian, v.ProtocolVersion); err != nil {
+		return err
+	}
+	if _, err := w.Write(v.ChainID[:]); err != nil {
+		return err
+	}
+	if _, err := w.Write(v.GenesisHash[:]); err != nil {
+		return err
+	}
+	if err := binary.Write(w, binary.BigEndian, uint16(len(v.UserAgent))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, v.UserAgent); err != nil {
+		return err
+	}
+	if err := binary.Write(w, binary.BigEndian, v.BestHeight); err != nil {
+		return err
+	}
+	return nil
 }
 
 func decodeVersionPayload(payload []byte) (node.VersionPayloadV1, error) {
@@ -193,18 +200,25 @@ func encodeGetBlocksPayload(req GetBlocksPayload) ([]byte, error) {
 		return nil, fmt.Errorf("too many locator hashes: %d", len(req.LocatorHashes))
 	}
 	var buf bytes.Buffer
-	if err := binary.Write(&buf, binary.BigEndian, uint16(len(req.LocatorHashes))); err != nil {
-		return nil, err
-	}
-	for _, locator := range req.LocatorHashes {
-		if _, err := buf.Write(locator[:]); err != nil {
-			return nil, err
-		}
-	}
-	if _, err := buf.Write(req.StopHash[:]); err != nil {
+	if err := encodeGetBlocksPayloadTo(&buf, req); err != nil {
 		return nil, err
 	}
 	return buf.Bytes(), nil
+}
+
+func encodeGetBlocksPayloadTo(w io.Writer, req GetBlocksPayload) error {
+	if err := binary.Write(w, binary.BigEndian, uint16(len(req.LocatorHashes))); err != nil {
+		return err
+	}
+	for _, locator := range req.LocatorHashes {
+		if _, err := w.Write(locator[:]); err != nil {
+			return err
+		}
+	}
+	if _, err := w.Write(req.StopHash[:]); err != nil {
+		return err
+	}
+	return nil
 }
 
 func decodeGetBlocksPayload(payload []byte) (GetBlocksPayload, error) {

--- a/clients/go/node/p2p/wire_test.go
+++ b/clients/go/node/p2p/wire_test.go
@@ -3,7 +3,13 @@ package p2p
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
+	"io"
+	"math"
+	"strings"
 	"testing"
+
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/node"
 )
 
 func TestReadWriteFrame_Roundtrip(t *testing.T) {
@@ -97,4 +103,209 @@ func TestEncodeDecodeGetBlocksPayload(t *testing.T) {
 	if decoded.StopHash != p.StopHash {
 		t.Fatal("stop hash mismatch")
 	}
+}
+
+func TestReadFrame_ShortBody(t *testing.T) {
+	var buf bytes.Buffer
+	if err := binary.Write(&buf, binary.BigEndian, uint32(3)); err != nil {
+		t.Fatalf("write length: %v", err)
+	}
+	if _, err := buf.Write([]byte{messageTx, 0x01}); err != nil {
+		t.Fatalf("write body: %v", err)
+	}
+	_, err := readFrame(&buf, 1024)
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Fatalf("expected short body error, got %v", err)
+	}
+}
+
+func TestWriteFrame_EmptyPayloadAllowed(t *testing.T) {
+	var buf bytes.Buffer
+	msg := message{Kind: messageTx}
+	if err := writeFrame(&buf, msg, 1024); err != nil {
+		t.Fatalf("writeFrame: %v", err)
+	}
+	got, err := readFrame(&buf, 1024)
+	if err != nil {
+		t.Fatalf("readFrame: %v", err)
+	}
+	if got.Kind != msg.Kind || len(got.Payload) != 0 {
+		t.Fatalf("unexpected frame: %#v", got)
+	}
+}
+
+func TestWriteFrame_Errors(t *testing.T) {
+	t.Run("cap exceeded", func(t *testing.T) {
+		err := writeFrame(io.Discard, message{Kind: messageInv, Payload: []byte{1, 2}}, 2)
+		if err == nil {
+			t.Fatal("expected cap error")
+		}
+	})
+
+	t.Run("length write fails", func(t *testing.T) {
+		err := writeFrame(&failingWriter{failOnWrite: 1}, message{Kind: messageInv, Payload: []byte{1}}, 1024)
+		if !errors.Is(err, errWriterFailed) {
+			t.Fatalf("expected writer error, got %v", err)
+		}
+	})
+
+	t.Run("kind write fails", func(t *testing.T) {
+		err := writeFrame(&failingWriter{failOnWrite: 2}, message{Kind: messageInv, Payload: []byte{1}}, 1024)
+		if !errors.Is(err, errWriterFailed) {
+			t.Fatalf("expected writer error, got %v", err)
+		}
+	})
+
+	t.Run("payload write fails", func(t *testing.T) {
+		err := writeFrame(&failingWriter{failOnWrite: 3}, message{Kind: messageInv, Payload: []byte{1}}, 1024)
+		if !errors.Is(err, errWriterFailed) {
+			t.Fatalf("expected writer error, got %v", err)
+		}
+	})
+}
+
+func TestEncodeDecodeVersionPayload(t *testing.T) {
+	var chainID [32]byte
+	var genesis [32]byte
+	chainID[0] = 0x11
+	genesis[0] = 0x22
+	in := node.VersionPayloadV1{
+		Magic:           ProtocolMagic,
+		ProtocolVersion: ProtocolVersion,
+		ChainID:         chainID,
+		GenesisHash:     genesis,
+		UserAgent:       "rubin-go/test",
+		BestHeight:      123,
+	}
+	encoded, err := encodeVersionPayload(in)
+	if err != nil {
+		t.Fatalf("encodeVersionPayload: %v", err)
+	}
+	out, err := decodeVersionPayload(encoded)
+	if err != nil {
+		t.Fatalf("decodeVersionPayload: %v", err)
+	}
+	if out != in {
+		t.Fatalf("roundtrip mismatch: %#v vs %#v", out, in)
+	}
+}
+
+func TestEncodeVersionPayload_UserAgentTooLong(t *testing.T) {
+	_, err := encodeVersionPayload(node.VersionPayloadV1{
+		UserAgent: strings.Repeat("a", math.MaxUint16+1),
+	})
+	if err == nil {
+		t.Fatal("expected user agent length error")
+	}
+}
+
+func TestEncodeVersionPayloadTo_WriteErrors(t *testing.T) {
+	base := node.VersionPayloadV1{
+		Magic:           ProtocolMagic,
+		ProtocolVersion: ProtocolVersion,
+		UserAgent:       "ua",
+		BestHeight:      7,
+	}
+	for _, failOn := range []int{1, 2, 3, 4, 5, 6, 7} {
+		err := encodeVersionPayloadTo(&failingWriter{failOnWrite: failOn}, base)
+		if !errors.Is(err, errWriterFailed) {
+			t.Fatalf("failOnWrite=%d: expected writer error, got %v", failOn, err)
+		}
+	}
+}
+
+func TestDecodeVersionPayload_Errors(t *testing.T) {
+	t.Run("too short", func(t *testing.T) {
+		_, err := decodeVersionPayload([]byte{0x01, 0x02})
+		if err == nil {
+			t.Fatal("expected short payload error")
+		}
+	})
+
+	t.Run("trailing bytes", func(t *testing.T) {
+		payload, err := encodeVersionPayload(node.VersionPayloadV1{
+			Magic:           ProtocolMagic,
+			ProtocolVersion: ProtocolVersion,
+			UserAgent:       "ua",
+		})
+		if err != nil {
+			t.Fatalf("encodeVersionPayload: %v", err)
+		}
+		payload = append(payload, 0xFF)
+		_, err = decodeVersionPayload(payload)
+		if err == nil {
+			t.Fatal("expected trailing bytes error")
+		}
+	})
+}
+
+func TestInventoryVectorEdgeCases(t *testing.T) {
+	encoded, err := encodeInventoryVectors(nil)
+	if err != nil {
+		t.Fatalf("encodeInventoryVectors(nil): %v", err)
+	}
+	if len(encoded) != 0 {
+		t.Fatalf("expected empty encoding, got %d bytes", len(encoded))
+	}
+
+	decoded, err := decodeInventoryVectors(nil)
+	if err != nil {
+		t.Fatalf("decodeInventoryVectors(nil): %v", err)
+	}
+	if decoded != nil {
+		t.Fatalf("expected nil decoded slice, got %#v", decoded)
+	}
+
+	if _, err := encodeInventoryVectors([]InventoryVector{{Type: 0x7F}}); err == nil {
+		t.Fatal("expected unsupported type error on encode")
+	}
+
+	payload := make([]byte, inventoryVectorSize)
+	payload[0] = 0x7F
+	if _, err := decodeInventoryVectors(payload); err == nil {
+		t.Fatal("expected unsupported type error on decode")
+	}
+}
+
+func TestGetBlocksPayload_Errors(t *testing.T) {
+	locators := make([][32]byte, math.MaxUint16+1)
+	if _, err := encodeGetBlocksPayload(GetBlocksPayload{LocatorHashes: locators}); err == nil {
+		t.Fatal("expected locator overflow error")
+	}
+
+	if _, err := decodeGetBlocksPayload([]byte{0x00, 0x01}); err == nil {
+		t.Fatal("expected short payload error")
+	}
+
+	if _, err := decodeGetBlocksPayload(make([]byte, 2+31)); err == nil {
+		t.Fatal("expected width mismatch error")
+	}
+}
+
+func TestEncodeGetBlocksPayloadTo_WriteErrors(t *testing.T) {
+	req := GetBlocksPayload{
+		LocatorHashes: [][32]byte{{0xAA}, {0xBB}},
+		StopHash:      [32]byte{0xCC},
+	}
+	for _, failOn := range []int{1, 2, 3, 4} {
+		err := encodeGetBlocksPayloadTo(&failingWriter{failOnWrite: failOn}, req)
+		if !errors.Is(err, errWriterFailed) {
+			t.Fatalf("failOnWrite=%d: expected writer error, got %v", failOn, err)
+		}
+	}
+}
+
+var errWriterFailed = errors.New("writer failed")
+
+type failingWriter struct {
+	writes      int
+	failOnWrite int
+}
+
+func (w *failingWriter) Write(p []byte) (int, error) {
+	w.writes++
+	if w.writes == w.failOnWrite {
+		return 0, errWriterFailed
+	}
+	return len(p), nil
 }


### PR DESCRIPTION
Targets Codacy file coverage hotspot for `clients/go/node/p2p/wire.go`.

What changed:
- added comprehensive edge-case tests for frame, version payload, inventory vectors, and getblocks payload encoding/decoding
- factored writer-based helpers for version/getblocks encoders so error paths are testable without changing wire semantics

Validation:
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node/p2p -coverprofile=/tmp/p2p.cover && go tool cover -func=/tmp/p2p.cover'`
- local file coverage for `clients/go/node/p2p/wire.go`: `92.0%` (was `60.98%` on Codacy page)
