### PR TITLE
test: raise Codacy sub-80 coverage

### DIFF
--- a/clients/go/consensus/coverage_hotspots_test.go
+++ b/clients/go/consensus/coverage_hotspots_test.go
@@ -1,0 +1,203 @@
+package consensus
+
+import (
+	"math/big"
+	"testing"
+)
+
+func TestCoverage_ParseCoreExtCovenantData(t *testing.T) {
+	t.Run("too short", func(t *testing.T) {
+		if _, err := ParseCoreExtCovenantData([]byte{0x01}); err == nil {
+			t.Fatalf("expected error")
+		}
+	})
+
+	t.Run("payload overflow int", func(t *testing.T) {
+		tooBig := []byte{0x01, 0x00, 0xff}
+		for i := 0; i < 7; i++ {
+			tooBig = append(tooBig, 0xff)
+		}
+		if _, err := ParseCoreExtCovenantData(tooBig); err == nil {
+			t.Fatalf("expected overflow error")
+		}
+	})
+
+	t.Run("payload parse failure", func(t *testing.T) {
+		if _, err := ParseCoreExtCovenantData([]byte{0x34, 0x12, 0x04, 0xaa}); err == nil {
+			t.Fatalf("expected payload parse failure")
+		}
+	})
+
+	t.Run("length mismatch", func(t *testing.T) {
+		if _, err := ParseCoreExtCovenantData([]byte{0x34, 0x12, 0x01, 0xaa, 0xbb}); err == nil {
+			t.Fatalf("expected length mismatch")
+		}
+	})
+
+	t.Run("success", func(t *testing.T) {
+		got, err := ParseCoreExtCovenantData([]byte{0x34, 0x12, 0x02, 0xaa, 0xbb})
+		if err != nil {
+			t.Fatalf("ParseCoreExtCovenantData: %v", err)
+		}
+		if got.ExtID != 0x1234 {
+			t.Fatalf("ext_id=%x", got.ExtID)
+		}
+		if len(got.ExtPayload) != 2 || got.ExtPayload[0] != 0xaa || got.ExtPayload[1] != 0xbb {
+			t.Fatalf("unexpected payload=%x", got.ExtPayload)
+		}
+	})
+}
+
+func TestCoverage_HasSuiteAndBigIntToUint64(t *testing.T) {
+	if hasSuite(nil, SUITE_ID_ML_DSA_87) {
+		t.Fatalf("nil allowed set must reject")
+	}
+	if hasSuite(map[uint8]struct{}{}, SUITE_ID_ML_DSA_87) {
+		t.Fatalf("empty allowed set must reject")
+	}
+	if !hasSuite(map[uint8]struct{}{SUITE_ID_ML_DSA_87: {}}, SUITE_ID_ML_DSA_87) {
+		t.Fatalf("expected suite present")
+	}
+
+	if got, err := bigIntToUint64(nil); err != nil || got != 0 {
+		t.Fatalf("bigIntToUint64(nil)=%d,%v want 0,nil", got, err)
+	}
+	if _, err := bigIntToUint64(big.NewInt(-1)); err == nil {
+		t.Fatalf("expected negative big.Int rejection")
+	}
+	if _, err := bigIntToUint64(new(big.Int).Lsh(big.NewInt(1), 65)); err == nil {
+		t.Fatalf("expected overflow rejection")
+	}
+}
+
+func TestCoverage_ConnectBlockBasicInMemoryAtHeightGuards(t *testing.T) {
+	var target = POW_LIMIT
+	if _, err := ConnectBlockBasicInMemoryAtHeight(nil, nil, &target, 0, nil, nil, [32]byte{}); err == nil {
+		t.Fatalf("expected nil state rejection")
+	}
+
+	state := &InMemoryChainState{AlreadyGenerated: big.NewInt(-1)}
+	if _, err := ConnectBlockBasicInMemoryAtHeight(nil, nil, &target, 0, nil, state, [32]byte{}); err == nil {
+		t.Fatalf("expected unsigned already_generated guard")
+	}
+}
+
+func TestCoverage_SighashBranches(t *testing.T) {
+	if _, err := SighashV1DigestWithType(nil, 0, 0, [32]byte{}, SIGHASH_ALL); err == nil {
+		t.Fatalf("expected nil tx rejection")
+	}
+
+	tx := &Tx{
+		Version: 1,
+		TxKind:  0x00,
+		TxNonce: 7,
+		Inputs: []TxInput{{
+			PrevTxid: [32]byte{0x11},
+			PrevVout: 2,
+			Sequence: 3,
+		}},
+		Outputs: []TxOutput{{
+			Value:        9,
+			CovenantType: COV_TYPE_P2PK,
+			CovenantData: []byte{0x01},
+		}},
+	}
+
+	if _, err := SighashV1DigestWithType(tx, 1, 9, [32]byte{}, SIGHASH_ALL); err == nil {
+		t.Fatalf("expected input index rejection")
+	}
+	if _, err := SighashV1DigestWithType(tx, 0, 9, [32]byte{}, 0x7f); err == nil {
+		t.Fatalf("expected invalid sighash type rejection")
+	}
+	if _, err := SighashV1DigestWithType(tx, 0, 9, [32]byte{}, SIGHASH_SINGLE|SIGHASH_ANYONECANPAY); err != nil {
+		t.Fatalf("SighashV1DigestWithType(anyonecanpay): %v", err)
+	}
+	tx.Outputs = nil
+	if _, err := SighashV1DigestWithType(tx, 0, 9, [32]byte{}, SIGHASH_SINGLE); err != nil {
+		t.Fatalf("SighashV1DigestWithType(single no output): %v", err)
+	}
+}
+
+func TestCoverage_SpendVerifyBranches(t *testing.T) {
+	if _, _, err := extractCryptoSigAndSighash(WitnessItem{}); err == nil {
+		t.Fatalf("expected empty signature rejection")
+	}
+	if _, _, err := extractCryptoSigAndSighash(WitnessItem{Signature: []byte{0x7f}}); err == nil {
+		t.Fatalf("expected invalid sighash rejection")
+	}
+
+	tx := &Tx{
+		Version: 1,
+		TxKind:  0x00,
+		TxNonce: 1,
+		Inputs:  []TxInput{{PrevTxid: [32]byte{0x44}, PrevVout: 0, Sequence: 0}},
+		Outputs: []TxOutput{{Value: 1, CovenantType: COV_TYPE_P2PK, CovenantData: make([]byte, 33)}},
+	}
+
+	keys := [][32]byte{{0x01}, {0x02}}
+	ws := []WitnessItem{{SuiteID: SUITE_ID_SENTINEL}}
+	if err := validateThresholdSigSpend(keys, 1, ws, tx, 0, 1, [32]byte{}, 0, "ctx"); err == nil {
+		t.Fatalf("expected witness slot mismatch")
+	}
+
+	ws = []WitnessItem{
+		{SuiteID: SUITE_ID_SENTINEL, Pubkey: []byte{0x01}},
+		{SuiteID: SUITE_ID_SENTINEL},
+	}
+	if err := validateThresholdSigSpend(keys, 1, ws, tx, 0, 1, [32]byte{}, 0, "ctx"); err == nil {
+		t.Fatalf("expected sentinel keyless guard")
+	}
+
+	ws = []WitnessItem{
+		{SuiteID: SUITE_ID_SENTINEL},
+		{SuiteID: 0x99},
+	}
+	if err := validateThresholdSigSpend(keys, 1, ws, tx, 0, 1, [32]byte{}, 0, "ctx"); err == nil {
+		t.Fatalf("expected unknown suite rejection")
+	}
+}
+
+func TestCoverage_StealthBranches(t *testing.T) {
+	if _, err := ParseStealthCovenantData(nil); err == nil {
+		t.Fatalf("expected nil covenant_data rejection")
+	}
+	if _, err := ParseStealthCovenantData(make([]byte, MAX_STEALTH_COVENANT_DATA-1)); err == nil {
+		t.Fatalf("expected length mismatch")
+	}
+
+	entry := UtxoEntry{
+		Value:        1,
+		CovenantType: COV_TYPE_CORE_STEALTH,
+		CovenantData: make([]byte, MAX_STEALTH_COVENANT_DATA),
+	}
+	tx := &Tx{
+		Version: 1,
+		TxKind:  0x00,
+		TxNonce: 1,
+		Inputs:  []TxInput{{PrevTxid: [32]byte{0x55}, PrevVout: 0, Sequence: 0}},
+		Outputs: []TxOutput{{Value: 1, CovenantType: COV_TYPE_P2PK, CovenantData: make([]byte, 33)}},
+	}
+
+	w := WitnessItem{SuiteID: 0x99}
+	if err := validateCoreStealthSpend(entry, w, tx, 0, 1, [32]byte{}, 0); err == nil {
+		t.Fatalf("expected suite invalid")
+	}
+
+	w = WitnessItem{
+		SuiteID:   SUITE_ID_ML_DSA_87,
+		Pubkey:    make([]byte, ML_DSA_87_PUBKEY_BYTES),
+		Signature: make([]byte, ML_DSA_87_SIG_BYTES+1),
+	}
+	if err := validateCoreStealthSpend(entry, w, tx, 0, 1, [32]byte{}, 0); err == nil {
+		t.Fatalf("expected key binding mismatch")
+	}
+
+	w = WitnessItem{
+		SuiteID:   SUITE_ID_ML_DSA_87,
+		Pubkey:    make([]byte, 1),
+		Signature: make([]byte, 1),
+	}
+	if err := validateCoreStealthSpend(entry, w, tx, 0, 1, [32]byte{}, 0); err == nil {
+		t.Fatalf("expected noncanonical witness rejection")
+	}
+}

--- a/clients/go/node/coverage_hotspots_test.go
+++ b/clients/go/node/coverage_hotspots_test.go
@@ -1,0 +1,159 @@
+package node
+
+import (
+	"testing"
+
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+)
+
+func TestCoverage_DaAnchorPolicyGuards(t *testing.T) {
+	if reject, _, _, err := RejectDaAnchorTxPolicy(nil, nil, 1); !reject || err == nil {
+		t.Fatalf("expected nil tx rejection")
+	}
+	if reject, reason, err := RejectNonCoinbaseAnchorOutputs(nil); !reject || err == nil || reason == "" {
+		t.Fatalf("expected nil tx rejection for anchor outputs")
+	}
+
+	tx := &consensus.Tx{
+		Inputs: []consensus.TxInput{{PrevTxid: [32]byte{0x11}, PrevVout: 0}},
+		Outputs: []consensus.TxOutput{{
+			Value:        1,
+			CovenantType: consensus.COV_TYPE_ANCHOR,
+		}},
+	}
+	if reject, reason, err := RejectNonCoinbaseAnchorOutputs(tx); !reject || err != nil || reason == "" {
+		t.Fatalf("expected anchor policy reject")
+	}
+	if _, err := mulU64NoOverflow(^uint64(0), 2); err == nil {
+		t.Fatalf("expected mul overflow")
+	}
+}
+
+func TestCoverage_ComputeFeeNoVerifyGuards(t *testing.T) {
+	if _, err := computeFeeNoVerify(nil, nil); err == nil {
+		t.Fatalf("expected nil tx rejection")
+	}
+	if _, err := computeFeeNoVerify(&consensus.Tx{}, nil); err == nil {
+		t.Fatalf("expected missing inputs rejection")
+	}
+	tx := &consensus.Tx{
+		Inputs:  []consensus.TxInput{{PrevTxid: [32]byte{0x01}, PrevVout: 0}},
+		Outputs: []consensus.TxOutput{{Value: 1}},
+	}
+	if _, err := computeFeeNoVerify(tx, nil); err == nil {
+		t.Fatalf("expected nil utxo set rejection")
+	}
+	if _, err := computeFeeNoVerify(tx, map[consensus.Outpoint]consensus.UtxoEntry{}); err == nil {
+		t.Fatalf("expected missing utxo rejection")
+	}
+	utxos := map[consensus.Outpoint]consensus.UtxoEntry{
+		{Txid: [32]byte{0x01}, Vout: 0}: {Value: ^uint64(0)},
+	}
+	tx.Inputs = append(tx.Inputs, consensus.TxInput{PrevTxid: [32]byte{0x01}, PrevVout: 0})
+	if _, err := computeFeeNoVerify(tx, utxos); err == nil {
+		t.Fatalf("expected sum_in overflow")
+	}
+	tx.Inputs = tx.Inputs[:1]
+	tx.Outputs = []consensus.TxOutput{{Value: ^uint64(0)}, {Value: 1}}
+	utxos = map[consensus.Outpoint]consensus.UtxoEntry{
+		{Txid: [32]byte{0x01}, Vout: 0}: {Value: 10},
+	}
+	if _, err := computeFeeNoVerify(tx, utxos); err == nil {
+		t.Fatalf("expected sum_out overflow")
+	}
+	tx.Outputs = []consensus.TxOutput{{Value: 11}}
+	if _, err := computeFeeNoVerify(tx, utxos); err == nil {
+		t.Fatalf("expected overspend")
+	}
+}
+
+func TestCoverage_MempoolHelpers(t *testing.T) {
+	if got := (*Mempool)(nil).Len(); got != 0 {
+		t.Fatalf("nil Len=%d", got)
+	}
+	if err := (*Mempool)(nil).AddTx(nil); err == nil {
+		t.Fatalf("expected nil mempool add rejection")
+	}
+	if selected := (*Mempool)(nil).SelectTransactions(1, 1); selected != nil {
+		t.Fatalf("expected nil select result")
+	}
+
+	fromKey := mustNodeMLDSA87Keypair(t)
+	toKey := mustNodeMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{100, 100})
+
+	mp, err := NewMempool(st, nil, devnetGenesisChainID)
+	if err != nil {
+		t.Fatalf("NewMempool: %v", err)
+	}
+	tx1 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 1, 1, fromKey, fromAddress, toAddress)
+	tx2 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[1]}, 90, 2, 2, fromKey, fromAddress, toAddress)
+	if err := mp.AddTx(tx1); err != nil {
+		t.Fatalf("AddTx(tx1): %v", err)
+	}
+	if err := mp.AddTx(tx2); err != nil {
+		t.Fatalf("AddTx(tx2): %v", err)
+	}
+	var existingTxID [32]byte
+	for txid := range mp.txs {
+		existingTxID = txid
+		break
+	}
+	if err := mp.validateAdmissionLocked(existingTxID, nil); err == nil {
+		t.Fatalf("expected duplicate tx rejection")
+	}
+	mp.maxTxs = len(mp.txs)
+	if err := mp.validateAdmissionLocked([32]byte{0xaa}, nil); err == nil {
+		t.Fatalf("expected mempool full")
+	}
+	if got := pickEntries(mp.snapshotEntries(), 1, 1<<20); len(got) != 1 {
+		t.Fatalf("pickEntries count=%d, want 1", len(got))
+	}
+}
+
+func TestCoverage_BuildBlockUndoGuards(t *testing.T) {
+	if _, err := buildBlockUndo(nil, nil, 0); err == nil {
+		t.Fatalf("expected nil previous chainstate")
+	}
+	if _, err := buildBlockUndo(NewChainState(), nil, 0); err == nil {
+		t.Fatalf("expected nil parsed block")
+	}
+	pb := &consensus.ParsedBlock{Txs: []*consensus.Tx{{}}, Txids: nil}
+	if _, err := buildBlockUndo(NewChainState(), pb, 0); err == nil {
+		t.Fatalf("expected txid length mismatch")
+	}
+	pb = &consensus.ParsedBlock{Txs: []*consensus.Tx{nil}, Txids: [][32]byte{{}}}
+	if _, err := buildBlockUndo(NewChainState(), pb, 0); err == nil {
+		t.Fatalf("expected nil tx rejection")
+	}
+}
+
+func TestCoverage_DisconnectBlockGuards(t *testing.T) {
+	if _, err := (*ChainState)(nil).DisconnectBlock(nil, nil); err == nil {
+		t.Fatalf("expected nil chainstate rejection")
+	}
+	st := NewChainState()
+	if _, err := st.DisconnectBlock(nil, &BlockUndo{}); err == nil {
+		t.Fatalf("expected no tip rejection")
+	}
+	st.HasTip = true
+	if _, err := st.DisconnectBlock(nil, nil); err == nil {
+		t.Fatalf("expected nil undo rejection")
+	}
+}
+
+func TestCoverage_BlockUndoCodecGuards(t *testing.T) {
+	if _, err := marshalBlockUndo(nil); err == nil {
+		t.Fatalf("expected marshal nil undo rejection")
+	}
+	if _, err := unmarshalBlockUndo([]byte("{")); err == nil {
+		t.Fatalf("expected decode failure")
+	}
+	if _, err := blockUndoFromDisk(blockUndoDisk{
+		Txs: []txUndoDisk{{Spent: []spentUndoDisk{{Txid: "zz"}}}},
+	}); err == nil {
+		t.Fatalf("expected invalid hex txid rejection")
+	}
+}

--- a/clients/go/node/p2p/coverage_hotspots_test.go
+++ b/clients/go/node/p2p/coverage_hotspots_test.go
@@ -1,0 +1,452 @@
+package p2p
+
+import (
+	"context"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/node"
+)
+
+func TestCoverage_NewServiceAndListenerGuards(t *testing.T) {
+	if _, err := NewService(ServiceConfig{}); err == nil {
+		t.Fatalf("expected bind address rejection")
+	}
+	if _, err := NewService(ServiceConfig{BindAddr: "127.0.0.1:0"}); err == nil {
+		t.Fatalf("expected nil peer manager rejection")
+	}
+	if _, err := NewService(ServiceConfig{BindAddr: "127.0.0.1:0", PeerManager: node.NewPeerManager(node.DefaultPeerRuntimeConfig("devnet", 8))}); err == nil {
+		t.Fatalf("expected nil sync engine rejection")
+	}
+	var nilService *Service
+	if err := nilService.Start(context.Background()); err == nil {
+		t.Fatalf("expected nil service start rejection")
+	}
+	if err := nilService.Close(); err != nil {
+		t.Fatalf("nil close: %v", err)
+	}
+	if addr := nilService.Addr(); addr != "" {
+		t.Fatalf("nil addr=%q", addr)
+	}
+
+	h := newTestHarness(t, 0, "127.0.0.1:0", []string{"", "  "})
+	if err := h.service.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer h.service.Close()
+	if err := h.service.Start(context.Background()); err == nil {
+		t.Fatalf("expected already-started rejection")
+	}
+	if !strings.Contains(h.service.Addr(), ":") {
+		t.Fatalf("unexpected addr=%q", h.service.Addr())
+	}
+}
+
+func TestCoverage_NewServiceDefaultsAndAnnounceBlock(t *testing.T) {
+	h := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	svc, err := NewService(ServiceConfig{
+		BindAddr:    "127.0.0.1:0",
+		PeerManager: h.peerManager,
+		SyncConfig:  h.syncCfg,
+		SyncEngine:  h.syncEngine,
+		BlockStore:  h.blockStore,
+	})
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	if svc.cfg.TxPool == nil || svc.cfg.UserAgent == "" || svc.cfg.GenesisHash == ([32]byte{}) || svc.cfg.LocatorLimit == 0 || svc.cfg.GetBlocksBatchSize == 0 {
+		t.Fatalf("expected defaults to be populated: %#v", svc.cfg)
+	}
+	if err := (*Service)(nil).AnnounceBlock(nil); err == nil {
+		t.Fatalf("expected nil service announce block rejection")
+	}
+	if err := svc.AnnounceBlock([]byte{0x00}); err == nil {
+		t.Fatalf("expected invalid block parse")
+	}
+	blockBytes := h.mineNextBlockBytes(t)
+	if err := svc.AnnounceBlock(blockBytes); err != nil {
+		t.Fatalf("AnnounceBlock(valid): %v", err)
+	}
+	if err := svc.AnnounceBlock(blockBytes); err != nil {
+		t.Fatalf("AnnounceBlock(duplicate): %v", err)
+	}
+}
+
+func TestCoverage_HandshakeHelpers(t *testing.T) {
+	localConn, remoteConn := net.Pipe()
+	defer localConn.Close()
+	defer remoteConn.Close()
+
+	cfg := node.DefaultPeerRuntimeConfig("devnet", 8)
+	cfg.HandshakeTimeout = time.Second
+	localVersion := testVersionPayload(node.DevnetGenesisChainID(), node.DevnetGenesisBlockHash(), "local", 0)
+
+	go func() {
+		_, _ = readFrame(remoteConn, cfg.MaxMessageSize)
+		_ = writeFrame(remoteConn, message{Kind: messageInv}, cfg.MaxMessageSize)
+	}()
+	state, err := performHandshake(context.Background(), localConn, cfg, localVersion, localVersion.ChainID, localVersion.GenesisHash)
+	if err == nil || state.LastError != "invalid version message" {
+		t.Fatalf("expected invalid version message, got state=%+v err=%v", state, err)
+	}
+
+	if got := handshakeDeadline(nil, time.Second); got.Before(time.Now()) {
+		t.Fatalf("deadline unexpectedly in the past")
+	}
+	if normalizeDuration(0, time.Second) != time.Second || normalizeDuration(time.Millisecond, time.Second) != time.Millisecond {
+		t.Fatalf("normalizeDuration mismatch")
+	}
+
+	state2 := node.PeerState{}
+	if err := validateRemoteVersion(testVersionPayload([32]byte{}, node.DevnetGenesisBlockHash(), "ua", 0), node.DevnetGenesisChainID(), node.DevnetGenesisBlockHash(), 10, &state2); err == nil {
+		t.Fatalf("expected magic mismatch")
+	}
+}
+
+func TestCoverage_AnnounceTxAndHandleTxBranches(t *testing.T) {
+	h := newTestHarness(t, 0, "127.0.0.1:0", nil)
+	if err := (*Service)(nil).AnnounceTx(nil); err == nil {
+		t.Fatalf("expected nil service reject")
+	}
+	if err := h.service.AnnounceTx([]byte{0x00}); err == nil {
+		t.Fatalf("expected parse reject")
+	}
+
+	fromKey := mustP2PMLDSA87Keypair(t)
+	toKey := mustP2PMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+	utxos, outpoints := testP2PUtxoSet(fromAddress, []uint64{100})
+	txBytes := mustBuildSignedP2PTx(t, utxos, []consensus.Outpoint{outpoints[0]}, 90, 1, 1, fromKey, fromAddress, toAddress)
+
+	p := newPeerRuntimeTestPeer(t)
+	p.service.cfg.PeerRuntimeConfig.BanThreshold = 100
+	if err := p.handleTx(append(txBytes, 0x00)); err != nil {
+		t.Fatalf("expected below-threshold invalid tx to be ignored, got %v", err)
+	}
+	if err := p.handleTx(txBytes); err != nil {
+		t.Fatalf("handleTx(valid): %v", err)
+	}
+	if err := p.handleTx(txBytes); err != nil {
+		t.Fatalf("handleTx(duplicate): %v", err)
+	}
+
+	p2 := newPeerRuntimeTestPeer(t)
+	p2.service.cfg.PeerRuntimeConfig.BanThreshold = 5
+	if err := p2.handleTx([]byte{0x00}); err == nil {
+		t.Fatalf("expected threshold-reaching invalid tx error")
+	}
+}
+
+func TestCoverage_InventoryAndBlockBranches(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	if err := p.handleGetData([]byte{0x00}); err == nil {
+		t.Fatalf("expected decode reject")
+	}
+	if ok, err := p.needsInventory(InventoryVector{Type: 77}); err != nil || ok {
+		t.Fatalf("default inventory path mismatch: ok=%v err=%v", ok, err)
+	}
+	if err := p.respondToInventory(InventoryVector{Type: MSG_BLOCK, Hash: [32]byte{0xaa}}); err != nil {
+		t.Fatalf("missing block should be ignored, got %v", err)
+	}
+	if err := p.respondToInventory(InventoryVector{Type: MSG_TX, Hash: [32]byte{0xbb}}); err != nil {
+		t.Fatalf("missing tx should be ignored, got %v", err)
+	}
+	if err := p.respondToInventory(InventoryVector{Type: 77}); err != nil {
+		t.Fatalf("unknown inventory type should be ignored, got %v", err)
+	}
+	if _, _, err := parseRelayedBlock([]byte{0x00}); err == nil {
+		t.Fatalf("expected invalid block parse")
+	}
+	if _, err := p.blockInventoryAfterLocators(GetBlocksPayload{}); err != nil {
+		t.Fatalf("blockInventoryAfterLocators: %v", err)
+	}
+	if err := p.handleGetBlocks([]byte{0x00}); err == nil {
+		t.Fatalf("expected invalid getblocks payload")
+	}
+	if err := p.handleBlock([]byte{0x00}); err == nil {
+		t.Fatalf("expected invalid relayed block rejection")
+	}
+
+	h := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	p.service = h.service
+	local, remote := net.Pipe()
+	defer local.Close()
+	defer remote.Close()
+	p.conn = local
+	done := make(chan error, 1)
+	go func() {
+		_, err := readFrame(remote, p.service.cfg.PeerRuntimeConfig.MaxMessageSize)
+		done <- err
+	}()
+	if err := p.handleGetBlocks(mustEncodeGetBlocksPayload(t, GetBlocksPayload{})); err != nil {
+		t.Fatalf("handleGetBlocks(empty inventory): %v", err)
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("handleGetBlocks read: %v", err)
+	}
+	blockBytes := h.mineNextBlockBytes(t)
+	if err := p.handleBlock(blockBytes); err != nil {
+		t.Fatalf("handleBlock(existing block): %v", err)
+	}
+}
+
+func TestCoverage_ServiceSyncPaths(t *testing.T) {
+	h := newTestHarness(t, 0, "127.0.0.1:0", nil)
+	p := newPeerRuntimeTestPeer(t)
+	p.service = h.service
+	local, remote := net.Pipe()
+	defer local.Close()
+	defer remote.Close()
+	p.conn = local
+	done := make(chan error, 1)
+	go func() {
+		_, err := readFrame(remote, p.service.cfg.PeerRuntimeConfig.MaxMessageSize)
+		done <- err
+	}()
+
+	if err := h.service.requestBlocksIfBehind(p); err != nil {
+		t.Fatalf("requestBlocksIfBehind without tip: %v", err)
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("requestBlocksIfBehind read: %v", err)
+	}
+
+	h2 := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	p2 := newPeerRuntimeTestPeer(t)
+	p2.service = h2.service
+	p2.state.RemoteVersion.BestHeight = 0
+	if err := h2.service.requestBlocksIfBehind(p2); err != nil {
+		t.Fatalf("requestBlocksIfBehind up-to-date: %v", err)
+	}
+
+	if _, err := h2.service.getBlocksRequestPayload(); err != nil {
+		t.Fatalf("getBlocksRequestPayload: %v", err)
+	}
+	if have, err := h2.service.hasBlock([32]byte{0xff}); err != nil || have {
+		t.Fatalf("hasBlock missing mismatch: have=%v err=%v", have, err)
+	}
+}
+
+func TestCoverage_HandleConnLifecyclePaths(t *testing.T) {
+	h := newTestHarness(t, 0, "127.0.0.1:0", nil)
+	local, remote := net.Pipe()
+	defer local.Close()
+	defer remote.Close()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = readFrame(remote, h.service.cfg.PeerRuntimeConfig.MaxMessageSize)
+		_ = writeFrame(remote, message{Kind: messageVersion, Payload: []byte{0x00}}, h.service.cfg.PeerRuntimeConfig.MaxMessageSize)
+	}()
+	h.service.ctx = context.Background()
+	h.service.handleConn(local)
+	<-done
+}
+
+func TestCoverage_HandleConnSuccessPath(t *testing.T) {
+	h := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h.service.ctx = ctx
+
+	local, remote := net.Pipe()
+	defer local.Close()
+	defer remote.Close()
+
+	remoteDone := make(chan error, 1)
+	go func() {
+		frame, err := readFrame(remote, h.service.cfg.PeerRuntimeConfig.MaxMessageSize)
+		if err != nil {
+			remoteDone <- err
+			return
+		}
+		if frame.Kind != messageVersion {
+			remoteDone <- err
+			return
+		}
+		payload, err := encodeVersionPayload(testVersionPayload(node.DevnetGenesisChainID(), node.DevnetGenesisBlockHash(), "remote", 0))
+		if err != nil {
+			remoteDone <- err
+			return
+		}
+		if err := writeFrame(remote, message{Kind: messageVersion, Payload: payload}, h.service.cfg.PeerRuntimeConfig.MaxMessageSize); err != nil {
+			remoteDone <- err
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+		remoteDone <- nil
+	}()
+
+	h.service.handleConn(local)
+	if err := <-remoteDone; err != nil {
+		t.Fatalf("remote handshake: %v", err)
+	}
+}
+
+func TestCoverage_HandleConnRunErrorPath(t *testing.T) {
+	h := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h.service.ctx = ctx
+
+	local, remote := net.Pipe()
+	defer local.Close()
+	defer remote.Close()
+
+	remoteDone := make(chan error, 1)
+	go func() {
+		frame, err := readFrame(remote, h.service.cfg.PeerRuntimeConfig.MaxMessageSize)
+		if err != nil {
+			remoteDone <- err
+			return
+		}
+		if frame.Kind != messageVersion {
+			remoteDone <- nil
+			return
+		}
+		payload, err := encodeVersionPayload(testVersionPayload(node.DevnetGenesisChainID(), node.DevnetGenesisBlockHash(), "remote", 0))
+		if err != nil {
+			remoteDone <- err
+			return
+		}
+		if err := writeFrame(remote, message{Kind: messageVersion, Payload: payload}, h.service.cfg.PeerRuntimeConfig.MaxMessageSize); err != nil {
+			remoteDone <- err
+			return
+		}
+		remoteDone <- writeFrame(remote, message{Kind: messageVersion, Payload: payload}, h.service.cfg.PeerRuntimeConfig.MaxMessageSize)
+	}()
+
+	h.service.handleConn(local)
+	if err := <-remoteDone; err != nil {
+		t.Fatalf("remote sequence: %v", err)
+	}
+}
+
+func TestCoverage_RegisterPeerAndLocalVersion(t *testing.T) {
+	h := newTestHarness(t, 0, "127.0.0.1:0", nil)
+	pr := &peer{
+		service: h.service,
+		state: node.PeerState{
+			Addr: "peer-register",
+		},
+	}
+	if err := h.service.registerPeer(pr); err != nil {
+		t.Fatalf("registerPeer: %v", err)
+	}
+	if _, ok := h.service.peers["peer-register"]; !ok {
+		t.Fatalf("peer not registered")
+	}
+	h.service.unregisterPeer("peer-register")
+	if _, ok := h.service.peers["peer-register"]; ok {
+		t.Fatalf("peer still registered")
+	}
+
+	version, err := h.service.localVersion()
+	if err != nil {
+		t.Fatalf("localVersion: %v", err)
+	}
+	if version.BestHeight != 0 {
+		t.Fatalf("best_height=%d, want 0", version.BestHeight)
+	}
+}
+
+func mustEncodeGetBlocksPayload(t *testing.T, payload GetBlocksPayload) []byte {
+	t.Helper()
+	raw, err := encodeGetBlocksPayload(payload)
+	if err != nil {
+		t.Fatalf("encodeGetBlocksPayload: %v", err)
+	}
+	return raw
+}
+
+func mustP2PMLDSA87Keypair(t *testing.T) *consensus.MLDSA87Keypair {
+	t.Helper()
+	kp, err := consensus.NewMLDSA87Keypair()
+	if err != nil {
+		t.Fatalf("NewMLDSA87Keypair: %v", err)
+	}
+	t.Cleanup(func() { kp.Close() })
+	return kp
+}
+
+func testP2PUtxoSet(fromAddress []byte, values []uint64) (map[consensus.Outpoint]consensus.UtxoEntry, []consensus.Outpoint) {
+	utxos := make(map[consensus.Outpoint]consensus.UtxoEntry, len(values))
+	outpoints := make([]consensus.Outpoint, 0, len(values))
+	for i, value := range values {
+		var txid [32]byte
+		txid[0] = byte(i + 1)
+		txid[31] = byte(i + 9)
+		op := consensus.Outpoint{Txid: txid, Vout: uint32(i)}
+		utxos[op] = consensus.UtxoEntry{
+			Value:             value,
+			CovenantType:      consensus.COV_TYPE_P2PK,
+			CovenantData:      append([]byte(nil), fromAddress...),
+			CreationHeight:    1,
+			CreatedByCoinbase: true,
+		}
+		outpoints = append(outpoints, op)
+	}
+	return utxos, outpoints
+}
+
+func mustBuildSignedP2PTx(
+	t *testing.T,
+	utxos map[consensus.Outpoint]consensus.UtxoEntry,
+	inputs []consensus.Outpoint,
+	amount uint64,
+	fee uint64,
+	nonce uint64,
+	signer *consensus.MLDSA87Keypair,
+	changeAddress []byte,
+	toAddress []byte,
+) []byte {
+	t.Helper()
+	txInputs := make([]consensus.TxInput, 0, len(inputs))
+	var totalIn uint64
+	for _, op := range inputs {
+		entry, ok := utxos[op]
+		if !ok {
+			t.Fatalf("missing utxo for %x:%d", op.Txid, op.Vout)
+		}
+		totalIn += entry.Value
+		txInputs = append(txInputs, consensus.TxInput{
+			PrevTxid: op.Txid,
+			PrevVout: op.Vout,
+			Sequence: 0,
+		})
+	}
+	change := totalIn - amount - fee
+	outputs := []consensus.TxOutput{{
+		Value:        amount,
+		CovenantType: consensus.COV_TYPE_P2PK,
+		CovenantData: append([]byte(nil), toAddress...),
+	}}
+	if change > 0 {
+		outputs = append(outputs, consensus.TxOutput{
+			Value:        change,
+			CovenantType: consensus.COV_TYPE_P2PK,
+			CovenantData: append([]byte(nil), changeAddress...),
+		})
+	}
+	tx := &consensus.Tx{
+		Version:  1,
+		TxKind:   0x00,
+		TxNonce:  nonce,
+		Inputs:   txInputs,
+		Outputs:  outputs,
+		Locktime: 0,
+	}
+	if err := consensus.SignTransaction(tx, utxos, node.DevnetGenesisChainID(), signer); err != nil {
+		t.Fatalf("SignTransaction: %v", err)
+	}
+	txBytes, err := consensus.MarshalTx(tx)
+	if err != nil {
+		t.Fatalf("MarshalTx: %v", err)
+	}
+	return txBytes
+}

--- a/clients/rust/crates/rubin-consensus/src/coverage_hotspots_tests.rs
+++ b/clients/rust/crates/rubin-consensus/src/coverage_hotspots_tests.rs
@@ -1,0 +1,687 @@
+use std::sync::{Mutex, OnceLock};
+
+use crate::constants::{
+    COV_TYPE_HTLC, COV_TYPE_P2PK, COV_TYPE_STEALTH, LOCK_MODE_HEIGHT, LOCK_MODE_TIMESTAMP,
+    MAX_HTLC_COVENANT_DATA, MAX_STEALTH_COVENANT_DATA, ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES,
+    ML_KEM_1024_CT_BYTES, SIGHASH_ALL, SIGHASH_ANYONECANPAY, SIGHASH_NONE, SIGHASH_SINGLE,
+    SUITE_ID_ML_DSA_87, SUITE_ID_SENTINEL,
+};
+use crate::error::ErrorCode;
+use crate::featurebits::{
+    featurebit_state_at_height_from_window_counts, FeatureBitDeployment, FeatureBitState,
+};
+use crate::htlc::{parse_htlc_covenant_data, validate_htlc_spend};
+use crate::sighash::{is_valid_sighash_type, sighash_v1_digest_with_type};
+use crate::spend_verify::{validate_p2pk_spend, validate_threshold_sig_spend};
+use crate::stealth::{parse_stealth_covenant_data, validate_stealth_spend};
+use crate::tx::{Tx, TxInput, TxOutput, WitnessItem};
+use crate::utxo_basic::UtxoEntry;
+use crate::verify_sig_openssl::{
+    test_ensure_openssl_bootstrap_for_mode, test_openssl_check_sigalg_bad_alg,
+    test_openssl_verify_sig_digest_oneshot_bad_alg,
+    test_openssl_verify_sig_digest_oneshot_empty_input, test_set_env_if_empty, test_suite_alg_name,
+    verify_sig,
+};
+use crate::wire_read::Reader;
+
+fn dummy_chain_id() -> [u8; 32] {
+    [0x11; 32]
+}
+
+fn base_tx() -> Tx {
+    Tx {
+        version: 1,
+        tx_kind: 0x00,
+        tx_nonce: 7,
+        inputs: vec![TxInput {
+            prev_txid: [0x42; 32],
+            prev_vout: 0,
+            script_sig: vec![],
+            sequence: 0,
+        }],
+        outputs: vec![TxOutput {
+            value: 90,
+            covenant_type: COV_TYPE_P2PK,
+            covenant_data: vec![0u8; 33],
+        }],
+        locktime: 0,
+        da_commit_core: None,
+        da_chunk_core: None,
+        witness: vec![],
+        da_payload: vec![],
+    }
+}
+
+fn mldsa_pubkey(fill: u8) -> Vec<u8> {
+    vec![fill; ML_DSA_87_PUBKEY_BYTES as usize]
+}
+
+fn mldsa_signature(fill: u8) -> Vec<u8> {
+    let mut sig = vec![fill; ML_DSA_87_SIG_BYTES as usize];
+    sig.push(SIGHASH_ALL);
+    sig
+}
+
+fn p2pk_entry_for_pubkey(pubkey: &[u8]) -> UtxoEntry {
+    let mut cov = vec![0u8; 33];
+    cov[0] = SUITE_ID_ML_DSA_87;
+    cov[1..33].copy_from_slice(&crate::hash::sha3_256(pubkey));
+    UtxoEntry {
+        value: 100,
+        covenant_type: COV_TYPE_P2PK,
+        covenant_data: cov,
+        creation_height: 0,
+        created_by_coinbase: false,
+    }
+}
+
+fn stealth_entry_for_pubkey(pubkey: &[u8]) -> UtxoEntry {
+    let mut cov = vec![0u8; MAX_STEALTH_COVENANT_DATA as usize];
+    cov[ML_KEM_1024_CT_BYTES as usize..].copy_from_slice(&crate::hash::sha3_256(pubkey));
+    UtxoEntry {
+        value: 100,
+        covenant_type: COV_TYPE_STEALTH,
+        covenant_data: cov,
+        creation_height: 0,
+        created_by_coinbase: false,
+    }
+}
+
+fn htlc_components(lock_mode: u8, lock_value: u64) -> ([u8; 32], [u8; 32], [u8; 32], Vec<u8>) {
+    let preimage = [0x55; 32];
+    let hash = crate::hash::sha3_256(&preimage);
+    let claim_key_id = [0x11; 32];
+    let refund_key_id = [0x22; 32];
+    let mut cov = Vec::with_capacity(MAX_HTLC_COVENANT_DATA as usize);
+    cov.extend_from_slice(&hash);
+    cov.push(lock_mode);
+    cov.extend_from_slice(&lock_value.to_le_bytes());
+    cov.extend_from_slice(&claim_key_id);
+    cov.extend_from_slice(&refund_key_id);
+    (claim_key_id, refund_key_id, preimage, cov)
+}
+
+fn htlc_entry(covenant_data: Vec<u8>) -> UtxoEntry {
+    UtxoEntry {
+        value: 100,
+        covenant_type: COV_TYPE_HTLC,
+        covenant_data,
+        creation_height: 0,
+        created_by_coinbase: false,
+    }
+}
+
+fn htlc_claim_selector(selector_key_id: [u8; 32], preimage: &[u8]) -> WitnessItem {
+    let mut sig = vec![0x00];
+    sig.extend_from_slice(&(preimage.len() as u16).to_le_bytes());
+    sig.extend_from_slice(preimage);
+    WitnessItem {
+        suite_id: SUITE_ID_SENTINEL,
+        pubkey: selector_key_id.to_vec(),
+        signature: sig,
+    }
+}
+
+fn htlc_refund_selector(selector_key_id: [u8; 32]) -> WitnessItem {
+    WitnessItem {
+        suite_id: SUITE_ID_SENTINEL,
+        pubkey: selector_key_id.to_vec(),
+        signature: vec![0x01],
+    }
+}
+
+fn openssl_env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+#[test]
+fn featurebits_strings_and_validation_errors() {
+    assert_eq!(FeatureBitState::Defined.as_str(), "DEFINED");
+    let bad = FeatureBitDeployment {
+        name: String::new(),
+        bit: 0,
+        start_height: 0,
+        timeout_height: 1,
+    };
+    assert!(featurebit_state_at_height_from_window_counts(&bad, 0, &[]).is_err());
+}
+
+#[test]
+fn featurebits_window_requirements_and_defined_state() {
+    let dep = FeatureBitDeployment {
+        name: "x".to_string(),
+        bit: 1,
+        start_height: 100,
+        timeout_height: 200,
+    };
+    let eval = featurebit_state_at_height_from_window_counts(&dep, 0, &[]).expect("eval");
+    assert_eq!(eval.state, FeatureBitState::Defined);
+    assert!(featurebit_state_at_height_from_window_counts(&dep, 2016, &[]).is_err());
+}
+
+#[test]
+fn sighash_rejects_invalid_input_and_type() {
+    let tx = base_tx();
+    assert!(sighash_v1_digest_with_type(&tx, 1, 100, dummy_chain_id(), SIGHASH_ALL).is_err());
+    assert!(sighash_v1_digest_with_type(&tx, 0, 100, dummy_chain_id(), 0x7f).is_err());
+    assert!(is_valid_sighash_type(SIGHASH_SINGLE | SIGHASH_ANYONECANPAY));
+}
+
+#[test]
+fn sighash_modes_cover_anyonecanpay_none_and_single() {
+    let mut tx = base_tx();
+    assert!(sighash_v1_digest_with_type(
+        &tx,
+        0,
+        100,
+        dummy_chain_id(),
+        SIGHASH_NONE | SIGHASH_ANYONECANPAY
+    )
+    .is_ok());
+    tx.outputs.clear();
+    assert!(sighash_v1_digest_with_type(&tx, 0, 100, dummy_chain_id(), SIGHASH_SINGLE).is_ok());
+}
+
+#[test]
+fn reader_reads_sequential_values_and_offsets() {
+    let mut r = Reader::new(&[1, 2, 3, 4, 5, 6, 7, 8]);
+    assert_eq!(r.read_u8().expect("u8"), 1);
+    assert_eq!(r.read_u16_le().expect("u16"), 0x0302);
+    assert_eq!(r.offset(), 3);
+    assert_eq!(r.read_bytes(2).expect("bytes"), &[4, 5]);
+}
+
+#[test]
+fn reader_reports_eof_for_each_read_shape() {
+    let mut r = Reader::new(&[]);
+    assert!(r.read_u8().is_err());
+    let mut r = Reader::new(&[1]);
+    assert!(r.read_u16_le().is_err());
+    let mut r = Reader::new(&[1, 2, 3]);
+    assert!(r.read_u32_le().is_err());
+    let mut r = Reader::new(&[1, 2, 3, 4, 5, 6, 7]);
+    assert!(r.read_u64_le().is_err());
+    let mut r = Reader::new(&[1]);
+    assert!(r.read_bytes(2).is_err());
+}
+
+#[test]
+fn verify_sig_rejects_unsupported_suite_and_bad_lengths() {
+    assert!(verify_sig(0xff, &[], &[], &[0u8; 32]).is_err());
+    let ok = verify_sig(SUITE_ID_ML_DSA_87, &[0u8; 1], &[0u8; 1], &[0u8; 32]).expect("bad lengths");
+    assert!(!ok);
+}
+
+#[test]
+fn verify_sig_testability_wrappers_cover_bootstrap_helpers() {
+    let _guard = openssl_env_lock().lock().expect("env lock");
+    std::env::remove_var("RUBIN_TEST_ENV_COVERAGE");
+    test_set_env_if_empty("RUBIN_TEST_ENV_COVERAGE", Some(" value ".to_string()));
+    assert_eq!(
+        std::env::var("RUBIN_TEST_ENV_COVERAGE").expect("env"),
+        "value"
+    );
+    assert_eq!(
+        test_suite_alg_name(SUITE_ID_ML_DSA_87).expect("alg"),
+        "ML-DSA-87"
+    );
+    assert!(test_suite_alg_name(0xff).is_err());
+    assert!(test_ensure_openssl_bootstrap_for_mode("off").is_ok());
+    assert!(test_ensure_openssl_bootstrap_for_mode("garbage").is_err());
+    assert!(test_openssl_check_sigalg_bad_alg().is_err());
+    assert!(test_openssl_verify_sig_digest_oneshot_empty_input().is_err());
+    assert!(test_openssl_verify_sig_digest_oneshot_bad_alg().is_err());
+}
+
+#[test]
+fn parse_htlc_covenant_data_rejects_invalid_variants() {
+    assert!(parse_htlc_covenant_data(&[]).is_err());
+    let (_, _, _, mut cov) = htlc_components(9, 1);
+    assert!(parse_htlc_covenant_data(&cov).is_err());
+    cov = htlc_components(LOCK_MODE_HEIGHT, 0).3;
+    assert!(parse_htlc_covenant_data(&cov).is_err());
+    let (claim_key_id, refund_key_id, _, cov) = htlc_components(LOCK_MODE_HEIGHT, 5);
+    let parsed = parse_htlc_covenant_data(&cov).expect("valid htlc parse");
+    assert_eq!(parsed.claim_key_id, claim_key_id);
+    assert_eq!(parsed.refund_key_id, refund_key_id);
+}
+
+#[test]
+fn validate_htlc_spend_rejects_selector_shape_errors() {
+    let (claim_key_id, _, _, cov) = htlc_components(LOCK_MODE_HEIGHT, 5);
+    let entry = htlc_entry(cov);
+    let path = WitnessItem {
+        suite_id: 1,
+        pubkey: vec![],
+        signature: vec![],
+    };
+    let sig = WitnessItem {
+        suite_id: SUITE_ID_ML_DSA_87,
+        pubkey: mldsa_pubkey(1),
+        signature: mldsa_signature(2),
+    };
+    let err = validate_htlc_spend(
+        &entry,
+        &path,
+        &sig,
+        &base_tx(),
+        0,
+        100,
+        dummy_chain_id(),
+        0,
+        0,
+    )
+    .unwrap_err();
+    assert_eq!(err.code, ErrorCode::TxErrParse);
+
+    let path = WitnessItem {
+        suite_id: SUITE_ID_SENTINEL,
+        pubkey: claim_key_id.to_vec(),
+        signature: vec![],
+    };
+    let err = validate_htlc_spend(
+        &entry,
+        &path,
+        &sig,
+        &base_tx(),
+        0,
+        100,
+        dummy_chain_id(),
+        0,
+        0,
+    )
+    .unwrap_err();
+    assert_eq!(err.code, ErrorCode::TxErrParse);
+
+    let path = WitnessItem {
+        suite_id: SUITE_ID_SENTINEL,
+        pubkey: vec![1],
+        signature: vec![0],
+    };
+    let err = validate_htlc_spend(
+        &entry,
+        &path,
+        &sig,
+        &base_tx(),
+        0,
+        100,
+        dummy_chain_id(),
+        0,
+        0,
+    )
+    .unwrap_err();
+    assert_eq!(err.code, ErrorCode::TxErrParse);
+}
+
+#[test]
+fn validate_htlc_spend_rejects_claim_path_errors() {
+    let (claim_key_id, _, preimage, cov) = htlc_components(LOCK_MODE_HEIGHT, 5);
+    let entry = htlc_entry(cov);
+    let short = WitnessItem {
+        suite_id: SUITE_ID_SENTINEL,
+        pubkey: claim_key_id.to_vec(),
+        signature: vec![0x00, 0x01],
+    };
+    let sig = WitnessItem {
+        suite_id: SUITE_ID_ML_DSA_87,
+        pubkey: mldsa_pubkey(1),
+        signature: mldsa_signature(2),
+    };
+    let err = validate_htlc_spend(
+        &entry,
+        &short,
+        &sig,
+        &base_tx(),
+        0,
+        100,
+        dummy_chain_id(),
+        0,
+        0,
+    )
+    .unwrap_err();
+    assert_eq!(err.code, ErrorCode::TxErrParse);
+
+    let tiny_preimage = htlc_claim_selector(claim_key_id, &[1; 8]);
+    let err = validate_htlc_spend(
+        &entry,
+        &tiny_preimage,
+        &sig,
+        &base_tx(),
+        0,
+        100,
+        dummy_chain_id(),
+        0,
+        0,
+    )
+    .unwrap_err();
+    assert_eq!(err.code, ErrorCode::TxErrParse);
+
+    let overflow_preimage = WitnessItem {
+        suite_id: SUITE_ID_SENTINEL,
+        pubkey: claim_key_id.to_vec(),
+        signature: {
+            let mut s = vec![0x00];
+            s.extend_from_slice(&257u16.to_le_bytes());
+            s.extend_from_slice(&vec![0u8; 257]);
+            s
+        },
+    };
+    let err = validate_htlc_spend(
+        &entry,
+        &overflow_preimage,
+        &sig,
+        &base_tx(),
+        0,
+        100,
+        dummy_chain_id(),
+        0,
+        0,
+    )
+    .unwrap_err();
+    assert_eq!(err.code, ErrorCode::TxErrParse);
+
+    let mut bad_preimage = preimage;
+    bad_preimage[0] ^= 0xff;
+    let path = htlc_claim_selector(claim_key_id, &bad_preimage);
+    let err = validate_htlc_spend(
+        &entry,
+        &path,
+        &sig,
+        &base_tx(),
+        0,
+        100,
+        dummy_chain_id(),
+        0,
+        0,
+    )
+    .unwrap_err();
+    assert_eq!(err.code, ErrorCode::TxErrSigInvalid);
+
+    let wrong_selector = htlc_claim_selector([0x33; 32], &preimage);
+    let err = validate_htlc_spend(
+        &entry,
+        &wrong_selector,
+        &sig,
+        &base_tx(),
+        0,
+        100,
+        dummy_chain_id(),
+        0,
+        0,
+    )
+    .unwrap_err();
+    assert_eq!(err.code, ErrorCode::TxErrSigInvalid);
+}
+
+#[test]
+fn validate_htlc_spend_rejects_refund_and_signature_errors() {
+    let (_, refund_key_id, _, cov) = htlc_components(LOCK_MODE_TIMESTAMP, 50);
+    let entry = htlc_entry(cov);
+    let path = htlc_refund_selector(refund_key_id);
+    let bad_sig = WitnessItem {
+        suite_id: 0xff,
+        pubkey: vec![],
+        signature: vec![],
+    };
+    let err = validate_htlc_spend(
+        &entry,
+        &path,
+        &bad_sig,
+        &base_tx(),
+        0,
+        100,
+        dummy_chain_id(),
+        0,
+        10,
+    )
+    .unwrap_err();
+    assert_eq!(err.code, ErrorCode::TxErrTimelockNotMet);
+
+    let path = htlc_refund_selector(refund_key_id);
+    let sig = WitnessItem {
+        suite_id: SUITE_ID_ML_DSA_87,
+        pubkey: mldsa_pubkey(1),
+        signature: vec![0],
+    };
+    let err = validate_htlc_spend(
+        &entry,
+        &path,
+        &sig,
+        &base_tx(),
+        0,
+        100,
+        dummy_chain_id(),
+        0,
+        100,
+    )
+    .unwrap_err();
+    assert!(matches!(
+        err.code,
+        ErrorCode::TxErrSigNoncanonical
+            | ErrorCode::TxErrSigInvalid
+            | ErrorCode::TxErrSighashTypeInvalid
+    ));
+
+    let wrong_path = htlc_refund_selector([0x77; 32]);
+    let err = validate_htlc_spend(
+        &entry,
+        &wrong_path,
+        &bad_sig,
+        &base_tx(),
+        0,
+        100,
+        dummy_chain_id(),
+        0,
+        100,
+    )
+    .unwrap_err();
+    assert_eq!(err.code, ErrorCode::TxErrSigInvalid);
+
+    let malformed_refund = WitnessItem {
+        suite_id: SUITE_ID_SENTINEL,
+        pubkey: refund_key_id.to_vec(),
+        signature: vec![0x01, 0x00],
+    };
+    let err = validate_htlc_spend(
+        &entry,
+        &malformed_refund,
+        &bad_sig,
+        &base_tx(),
+        0,
+        100,
+        dummy_chain_id(),
+        0,
+        100,
+    )
+    .unwrap_err();
+    assert_eq!(err.code, ErrorCode::TxErrParse);
+
+    let good_sig_shape = WitnessItem {
+        suite_id: SUITE_ID_ML_DSA_87,
+        pubkey: mldsa_pubkey(9),
+        signature: mldsa_signature(8),
+    };
+    let err = validate_htlc_spend(
+        &entry,
+        &path,
+        &good_sig_shape,
+        &base_tx(),
+        0,
+        100,
+        dummy_chain_id(),
+        0,
+        100,
+    )
+    .unwrap_err();
+    assert_eq!(err.code, ErrorCode::TxErrSigInvalid);
+
+    let wrong_suite = WitnessItem {
+        suite_id: 0xff,
+        pubkey: vec![],
+        signature: vec![],
+    };
+    let err = validate_htlc_spend(
+        &entry,
+        &path,
+        &wrong_suite,
+        &base_tx(),
+        0,
+        100,
+        dummy_chain_id(),
+        0,
+        100,
+    )
+    .unwrap_err();
+    assert_eq!(err.code, ErrorCode::TxErrSigAlgInvalid);
+}
+
+#[test]
+fn validate_p2pk_spend_rejects_canonicality_and_binding_errors() {
+    let tx = base_tx();
+    let pubkey = mldsa_pubkey(1);
+    let entry = p2pk_entry_for_pubkey(&pubkey);
+    let w = WitnessItem {
+        suite_id: 0xff,
+        pubkey: vec![],
+        signature: vec![],
+    };
+    let err = validate_p2pk_spend(&entry, &w, &tx, 0, 100, dummy_chain_id(), 0).unwrap_err();
+    assert_eq!(err.code, ErrorCode::TxErrSigAlgInvalid);
+
+    let w = WitnessItem {
+        suite_id: SUITE_ID_ML_DSA_87,
+        pubkey: vec![1],
+        signature: vec![1],
+    };
+    let err = validate_p2pk_spend(&entry, &w, &tx, 0, 100, dummy_chain_id(), 0).unwrap_err();
+    assert_eq!(err.code, ErrorCode::TxErrSigNoncanonical);
+
+    let w = WitnessItem {
+        suite_id: SUITE_ID_ML_DSA_87,
+        pubkey: mldsa_pubkey(2),
+        signature: mldsa_signature(3),
+    };
+    let err = validate_p2pk_spend(&entry, &w, &tx, 0, 100, dummy_chain_id(), 0).unwrap_err();
+    assert_eq!(err.code, ErrorCode::TxErrSigInvalid);
+}
+
+#[test]
+fn validate_threshold_sig_spend_rejects_assignment_and_threshold_errors() {
+    let tx = base_tx();
+    let keys = vec![[1u8; 32], [2u8; 32]];
+    let ws = vec![WitnessItem {
+        suite_id: SUITE_ID_SENTINEL,
+        pubkey: vec![],
+        signature: vec![],
+    }];
+    let err = validate_threshold_sig_spend(&keys, 1, &ws, &tx, 0, 100, dummy_chain_id(), 0, "ctx")
+        .unwrap_err();
+    assert_eq!(err.code, ErrorCode::TxErrParse);
+
+    let ws = vec![
+        WitnessItem {
+            suite_id: SUITE_ID_SENTINEL,
+            pubkey: vec![1],
+            signature: vec![],
+        },
+        WitnessItem {
+            suite_id: SUITE_ID_SENTINEL,
+            pubkey: vec![],
+            signature: vec![],
+        },
+    ];
+    let err = validate_threshold_sig_spend(&keys, 1, &ws, &tx, 0, 100, dummy_chain_id(), 0, "ctx")
+        .unwrap_err();
+    assert_eq!(err.code, ErrorCode::TxErrParse);
+
+    let ws = vec![
+        WitnessItem {
+            suite_id: SUITE_ID_SENTINEL,
+            pubkey: vec![],
+            signature: vec![],
+        },
+        WitnessItem {
+            suite_id: SUITE_ID_SENTINEL,
+            pubkey: vec![],
+            signature: vec![],
+        },
+    ];
+    let err = validate_threshold_sig_spend(&keys, 1, &ws, &tx, 0, 100, dummy_chain_id(), 0, "ctx")
+        .unwrap_err();
+    assert_eq!(err.code, ErrorCode::TxErrSigInvalid);
+
+    let ws = vec![
+        WitnessItem {
+            suite_id: SUITE_ID_ML_DSA_87,
+            pubkey: vec![1],
+            signature: vec![1],
+        },
+        WitnessItem {
+            suite_id: SUITE_ID_SENTINEL,
+            pubkey: vec![],
+            signature: vec![],
+        },
+    ];
+    let err = validate_threshold_sig_spend(&keys, 1, &ws, &tx, 0, 100, dummy_chain_id(), 0, "ctx")
+        .unwrap_err();
+    assert_eq!(err.code, ErrorCode::TxErrSigNoncanonical);
+
+    let ws = vec![
+        WitnessItem {
+            suite_id: SUITE_ID_ML_DSA_87,
+            pubkey: mldsa_pubkey(1),
+            signature: mldsa_signature(2),
+        },
+        WitnessItem {
+            suite_id: SUITE_ID_SENTINEL,
+            pubkey: vec![],
+            signature: vec![],
+        },
+    ];
+    let err = validate_threshold_sig_spend(&keys, 1, &ws, &tx, 0, 100, dummy_chain_id(), 0, "ctx")
+        .unwrap_err();
+    assert_eq!(err.code, ErrorCode::TxErrSigInvalid);
+}
+
+#[test]
+fn validate_stealth_spend_rejects_noncanonical_and_bad_sighash() {
+    let tx = base_tx();
+    let entry = stealth_entry_for_pubkey(&mldsa_pubkey(1));
+    assert!(parse_stealth_covenant_data(&entry.covenant_data).is_ok());
+    let w = WitnessItem {
+        suite_id: SUITE_ID_ML_DSA_87,
+        pubkey: vec![1],
+        signature: vec![1],
+    };
+    let err = validate_stealth_spend(&entry, &w, &tx, 0, 100, dummy_chain_id(), 0).unwrap_err();
+    assert_eq!(err.code, ErrorCode::TxErrSigNoncanonical);
+
+    let w = WitnessItem {
+        suite_id: SUITE_ID_ML_DSA_87,
+        pubkey: mldsa_pubkey(1),
+        signature: {
+            let mut sig = vec![0x00; ML_DSA_87_SIG_BYTES as usize];
+            sig.push(0x7f);
+            sig
+        },
+    };
+    let err = validate_stealth_spend(&entry, &w, &tx, 0, 100, dummy_chain_id(), 0).unwrap_err();
+    assert_eq!(err.code, ErrorCode::TxErrSighashTypeInvalid);
+}
+
+#[test]
+fn validate_stealth_spend_reaches_digest_and_verify_path() {
+    let tx = base_tx();
+    let pubkey = mldsa_pubkey(1);
+    let entry = stealth_entry_for_pubkey(&pubkey);
+    let mut sig = vec![0x00; ML_DSA_87_SIG_BYTES as usize];
+    sig.push(SIGHASH_ALL);
+    let w = WitnessItem {
+        suite_id: SUITE_ID_ML_DSA_87,
+        pubkey,
+        signature: sig,
+    };
+    let err = validate_stealth_spend(&entry, &w, &tx, 0, 100, dummy_chain_id(), 0).unwrap_err();
+    assert_eq!(err.code, ErrorCode::TxErrSigInvalid);
+}

--- a/clients/rust/crates/rubin-consensus/src/lib.rs
+++ b/clients/rust/crates/rubin-consensus/src/lib.rs
@@ -70,6 +70,8 @@ pub use vault::{
 #[cfg(test)]
 mod compact_relay_tests;
 #[cfg(test)]
+mod coverage_hotspots_tests;
+#[cfg(test)]
 mod featurebits_tests;
 #[cfg(test)]
 mod tests;

--- a/clients/rust/crates/rubin-consensus/src/verify_sig_openssl.rs
+++ b/clients/rust/crates/rubin-consensus/src/verify_sig_openssl.rs
@@ -77,6 +77,10 @@ fn parse_openssl_fips_mode(raw: &str) -> Result<OpenSslFipsMode, TxError> {
 fn ensure_openssl_bootstrap() -> Result<(), TxError> {
     let mode_raw = std::env::var("RUBIN_OPENSSL_FIPS_MODE").unwrap_or_default();
     let mode = parse_openssl_fips_mode(&mode_raw)?;
+    ensure_openssl_bootstrap_for_mode(mode)
+}
+
+fn ensure_openssl_bootstrap_for_mode(mode: OpenSslFipsMode) -> Result<(), TxError> {
     if mode == OpenSslFipsMode::Off {
         return Ok(());
     }
@@ -113,6 +117,37 @@ fn openssl_check_sigalg(alg: &'static CStr, props: &'static CStr) -> Result<(), 
         openssl_sys::EVP_SIGNATURE_free(sig);
     }
     Ok(())
+}
+
+#[cfg(test)]
+pub(crate) fn test_set_env_if_empty(key: &str, value: Option<String>) {
+    set_env_if_empty(key, value);
+}
+
+#[cfg(test)]
+pub(crate) fn test_suite_alg_name(suite_id: u8) -> Result<&'static str, TxError> {
+    suite_alg_name(suite_id).map(|alg| alg.to_str().expect("cstr"))
+}
+
+#[cfg(test)]
+pub(crate) fn test_ensure_openssl_bootstrap_for_mode(mode_raw: &str) -> Result<(), TxError> {
+    let mode = parse_openssl_fips_mode(mode_raw)?;
+    ensure_openssl_bootstrap_for_mode(mode)
+}
+
+#[cfg(test)]
+pub(crate) fn test_openssl_check_sigalg_bad_alg() -> Result<(), TxError> {
+    openssl_check_sigalg(c"NOT-A-REAL-SIGALG", c"")
+}
+
+#[cfg(test)]
+pub(crate) fn test_openssl_verify_sig_digest_oneshot_empty_input() -> Result<bool, TxError> {
+    openssl_verify_sig_digest_oneshot(c"ML-DSA-87", &[], &[], &[])
+}
+
+#[cfg(test)]
+pub(crate) fn test_openssl_verify_sig_digest_oneshot_bad_alg() -> Result<bool, TxError> {
+    openssl_verify_sig_digest_oneshot(c"NOT-A-REAL-SIGALG", &[1], &[1], &[1])
 }
 
 fn openssl_bootstrap(require_fips: bool) -> Result<(), TxError> {


### PR DESCRIPTION
## Summary
- add targeted Go coverage tests for consensus, node, and p2p hotspot files
- add targeted Rust coverage tests plus minimal testability wrappers for OpenSSL bootstrap paths
- lift all files that Codacy currently showed below 80% to local >80% before PR

## Validation
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./consensus ./node ./node/p2p -coverprofile=/tmp/rp-go-sweep.cover'`
- `cd clients/rust && cargo test --package rubin-consensus`
- `cd clients/rust && cargo tarpaulin --engine llvm --lib --package rubin-consensus --out Xml --output-dir /tmp/rp-rust-cov`

Refs: Q-COVERAGE-01