### PR TITLE
refactor: split miner helpers without semantic drift (Q-DUPLICATION-01)

### DIFF
--- a/clients/go/node/miner.go
+++ b/clients/go/node/miner.go
@@ -73,6 +73,13 @@ type minedCandidate struct {
 	weight uint64
 }
 
+type miningBuildContext struct {
+	prevHash        [32]byte
+	remainingWeight uint64
+	nextHeight      uint64
+	candidateTxs    [][]byte
+}
+
 func DefaultMinerConfig() MinerConfig {
 	return MinerConfig{
 		Target: consensus.POW_LIMIT,
@@ -163,22 +170,12 @@ func (m *Miner) MineOne(ctx context.Context, txs [][]byte) (*MinedBlock, error) 
 }
 
 func (m *Miner) buildBlock(ctx context.Context, txs [][]byte) ([]byte, []uint64, uint64, uint64, int, error) {
-	nextHeight, expectedPrev, err := nextBlockContext(m.chainState)
-	if err != nil {
-		return nil, nil, 0, 0, 0, err
-	}
-	var prevHash [32]byte
-	if expectedPrev != nil {
-		prevHash = *expectedPrev
-	}
-
-	candidateTxs := m.candidateTransactions(txs)
-	remainingWeight, err := m.remainingWeightBudget(nextHeight)
+	buildCtx, err := m.buildContext(txs)
 	if err != nil {
 		return nil, nil, 0, 0, 0, err
 	}
 
-	parsed, err := m.selectCandidateTransactions(candidateTxs, nextHeight, remainingWeight)
+	parsed, err := m.selectCandidateTransactions(buildCtx.candidateTxs, buildCtx.nextHeight, buildCtx.remainingWeight)
 	if err != nil {
 		return nil, nil, 0, 0, 0, err
 	}
@@ -186,32 +183,37 @@ func (m *Miner) buildBlock(ctx context.Context, txs [][]byte) ([]byte, []uint64,
 	if err != nil {
 		return nil, nil, 0, 0, 0, err
 	}
-	coinbase, merkleRoot, err := m.buildCoinbaseAndMerkleRoot(nextHeight, witnessCommitment, parsed)
+	coinbase, merkleRoot, err := m.buildCoinbaseAndMerkleRoot(buildCtx.nextHeight, witnessCommitment, parsed)
 	if err != nil {
 		return nil, nil, 0, 0, 0, err
 	}
-
-	prevTimestamps, err := m.prevTimestamps(nextHeight)
+	prevTimestamps, timestamp, headerBytes, nonce, err := m.mineHeader(ctx, buildCtx.nextHeight, buildCtx.prevHash, merkleRoot)
 	if err != nil {
 		return nil, nil, 0, 0, 0, err
 	}
-	now := m.cfg.TimestampSource()
-	timestamp := chooseValidTimestamp(nextHeight, prevTimestamps, now)
-
-	blockWithoutNonce := makeHeaderPrefix(prevHash, merkleRoot, timestamp, m.cfg.Target)
-	headerBytes, nonce, err := mineHeaderNonce(ctx, blockWithoutNonce, m.cfg.Target)
-	if err != nil {
-		return nil, nil, 0, 0, 0, err
-	}
-
-	blockBytes := make([]byte, 0, len(headerBytes)+4+len(coinbase))
-	blockBytes = append(blockBytes, headerBytes...)
-	blockBytes = consensus.AppendCompactSize(blockBytes, uint64(1+len(parsed)))
-	blockBytes = append(blockBytes, coinbase...)
-	for _, p := range parsed {
-		blockBytes = append(blockBytes, p.raw...)
-	}
+	blockBytes := assembleBlockBytes(headerBytes, coinbase, parsed)
 	return blockBytes, prevTimestamps, timestamp, nonce, 1 + len(parsed), nil
+}
+
+func (m *Miner) buildContext(txs [][]byte) (miningBuildContext, error) {
+	nextHeight, expectedPrev, err := nextBlockContext(m.chainState)
+	if err != nil {
+		return miningBuildContext{}, err
+	}
+	var prevHash [32]byte
+	if expectedPrev != nil {
+		prevHash = *expectedPrev
+	}
+	remainingWeight, err := m.remainingWeightBudget(nextHeight)
+	if err != nil {
+		return miningBuildContext{}, err
+	}
+	return miningBuildContext{
+		nextHeight:      nextHeight,
+		prevHash:        prevHash,
+		remainingWeight: remainingWeight,
+		candidateTxs:    m.candidateTransactions(txs),
+	}, nil
 }
 
 func (m *Miner) candidateTransactions(txs [][]byte) [][]byte {
@@ -273,12 +275,9 @@ type miningCandidate struct {
 }
 
 func (m *Miner) parseMiningCandidate(raw []byte) (miningCandidate, error) {
-	tx, txid, wtxid, consumed, parseErr := consensus.ParseTx(raw)
-	if parseErr != nil {
-		return miningCandidate{}, parseErr
-	}
-	if consumed != len(raw) {
-		return miningCandidate{}, errors.New("non-canonical tx bytes in miner input")
+	tx, txid, wtxid, err := parseCanonicalTx(raw, "non-canonical tx bytes in miner input")
+	if err != nil {
+		return miningCandidate{}, err
 	}
 	txWeight, _, _, err := consensus.TxWeightAndStats(tx)
 	if err != nil {
@@ -359,12 +358,9 @@ func (m *Miner) buildCoinbaseAndMerkleRoot(nextHeight uint64, witnessCommitment 
 	if err != nil {
 		return nil, [32]byte{}, err
 	}
-	_, coinbaseTxid, _, consumed, err := consensus.ParseTx(coinbase)
+	_, coinbaseTxid, _, err := parseCanonicalTx(coinbase, "coinbase serialization is non-canonical")
 	if err != nil {
 		return nil, [32]byte{}, err
-	}
-	if consumed != len(coinbase) {
-		return nil, [32]byte{}, errors.New("coinbase serialization is non-canonical")
 	}
 	txids := make([][32]byte, 0, 1+len(parsed))
 	txids = append(txids, coinbaseTxid)
@@ -376,6 +372,32 @@ func (m *Miner) buildCoinbaseAndMerkleRoot(nextHeight uint64, witnessCommitment 
 		return nil, [32]byte{}, err
 	}
 	return coinbase, merkleRoot, nil
+}
+
+func (m *Miner) mineHeader(ctx context.Context, nextHeight uint64, prevHash [32]byte, merkleRoot [32]byte) ([]uint64, uint64, []byte, uint64, error) {
+	prevTimestamps, err := m.prevTimestamps(nextHeight)
+	if err != nil {
+		return nil, 0, nil, 0, err
+	}
+	now := m.cfg.TimestampSource()
+	timestamp := chooseValidTimestamp(nextHeight, prevTimestamps, now)
+	blockWithoutNonce := makeHeaderPrefix(prevHash, merkleRoot, timestamp, m.cfg.Target)
+	headerBytes, nonce, err := mineHeaderNonce(ctx, blockWithoutNonce, m.cfg.Target)
+	if err != nil {
+		return nil, 0, nil, 0, err
+	}
+	return prevTimestamps, timestamp, headerBytes, nonce, nil
+}
+
+func assembleBlockBytes(headerBytes []byte, coinbase []byte, parsed []minedCandidate) []byte {
+	blockBytes := make([]byte, 0, len(headerBytes)+4+len(coinbase))
+	blockBytes = append(blockBytes, headerBytes...)
+	blockBytes = consensus.AppendCompactSize(blockBytes, uint64(1+len(parsed)))
+	blockBytes = append(blockBytes, coinbase...)
+	for _, p := range parsed {
+		blockBytes = append(blockBytes, p.raw...)
+	}
+	return blockBytes
 }
 
 func mineHeaderNonce(ctx context.Context, blockWithoutNonce []byte, target [32]byte) ([]byte, uint64, error) {
@@ -397,18 +419,26 @@ func mineHeaderNonce(ctx context.Context, blockWithoutNonce []byte, target [32]b
 }
 
 func canonicalTxWeight(raw []byte, label string) (uint64, error) {
-	tx, _, _, consumed, err := consensus.ParseTx(raw)
+	tx, _, _, err := parseCanonicalTx(raw, label+" serialization is non-canonical")
 	if err != nil {
 		return 0, err
-	}
-	if consumed != len(raw) {
-		return 0, errors.New(label + " serialization is non-canonical")
 	}
 	txWeight, _, _, err := consensus.TxWeightAndStats(tx)
 	if err != nil {
 		return 0, err
 	}
 	return txWeight, nil
+}
+
+func parseCanonicalTx(raw []byte, nonCanonicalMsg string) (*consensus.Tx, [32]byte, [32]byte, error) {
+	tx, txid, wtxid, consumed, err := consensus.ParseTx(raw)
+	if err != nil {
+		return nil, [32]byte{}, [32]byte{}, err
+	}
+	if consumed != len(raw) {
+		return nil, [32]byte{}, [32]byte{}, errors.New(nonCanonicalMsg)
+	}
+	return tx, txid, wtxid, nil
 }
 
 func (m *Miner) prevTimestamps(nextHeight uint64) ([]uint64, error) {

--- a/clients/go/node/miner_additional_test.go
+++ b/clients/go/node/miner_additional_test.go
@@ -292,3 +292,99 @@ func TestAppendCompactSizeMinerEncodesAllWidthBranches(t *testing.T) {
 		t.Fatalf("unexpected 64-bit le: %x", out64)
 	}
 }
+
+func TestUpdatedPolicyDaBytes(t *testing.T) {
+	cases := []struct {
+		current uint64
+		daBytes uint64
+		max     uint64
+		want    uint64
+		ok      bool
+	}{
+		{current: 0, daBytes: 0, max: 10, want: 0, ok: true},
+		{current: 4, daBytes: 3, max: 10, want: 7, ok: true},
+		{current: 4, daBytes: 7, max: 10, want: 4, ok: false},
+		{current: ^uint64(0), daBytes: 1, max: ^uint64(0), want: ^uint64(0), ok: false},
+	}
+	for _, tc := range cases {
+		got, ok := updatedPolicyDaBytes(tc.current, tc.daBytes, tc.max)
+		if got != tc.want || ok != tc.ok {
+			t.Fatalf("updatedPolicyDaBytes(%d,%d,%d)=(%d,%v), want (%d,%v)", tc.current, tc.daBytes, tc.max, got, ok, tc.want, tc.ok)
+		}
+	}
+}
+
+func TestMinerBuildContextAndAssembleBlockBytes(t *testing.T) {
+	dir := t.TempDir()
+	chainStatePath := ChainStatePath(dir)
+
+	chainState := NewChainState()
+	chainState.HasTip = true
+	chainState.Height = 7
+	chainState.TipHash = [32]byte{0x44}
+	blockStore, err := OpenBlockStore(BlockStorePath(dir))
+	if err != nil {
+		t.Fatalf("open blockstore: %v", err)
+	}
+	syncEngine, err := NewSyncEngine(chainState, blockStore, DefaultSyncConfig(nil, [32]byte{}, chainStatePath))
+	if err != nil {
+		t.Fatalf("new sync engine: %v", err)
+	}
+	cfg := DefaultMinerConfig()
+	cfg.MaxTxPerBlock = 2
+	miner, err := NewMiner(chainState, blockStore, syncEngine, cfg)
+	if err != nil {
+		t.Fatalf("new miner: %v", err)
+	}
+
+	txA, err := buildCoinbaseTx(0, 0, nil, [32]byte{})
+	if err != nil {
+		t.Fatalf("build txA: %v", err)
+	}
+	txB := append([]byte(nil), txA...)
+	txC := append([]byte(nil), txA...)
+	buildCtx, err := miner.buildContext([][]byte{txA, txB, txC})
+	if err != nil {
+		t.Fatalf("buildContext: %v", err)
+	}
+	if buildCtx.nextHeight != 8 {
+		t.Fatalf("nextHeight=%d, want 8", buildCtx.nextHeight)
+	}
+	if buildCtx.prevHash != chainState.TipHash {
+		t.Fatalf("prevHash mismatch")
+	}
+	if len(buildCtx.candidateTxs) != 1 {
+		t.Fatalf("candidate count=%d, want 1", len(buildCtx.candidateTxs))
+	}
+	if buildCtx.remainingWeight == 0 {
+		t.Fatalf("expected non-zero remaining weight")
+	}
+
+	header := make([]byte, consensus.BLOCK_HEADER_BYTES)
+	coinbase := []byte{0xaa}
+	parsed := []minedCandidate{{raw: []byte{0xbb}}, {raw: []byte{0xcc}}}
+	block := assembleBlockBytes(header, coinbase, parsed)
+	want := append(append(append(append([]byte{}, header...), 0x03), coinbase...), 0xbb, 0xcc)
+	if string(block) != string(want) {
+		t.Fatalf("assembled block mismatch: got=%x want=%x", block, want)
+	}
+}
+
+func TestParseCanonicalTx(t *testing.T) {
+	raw, err := buildCoinbaseTx(0, 0, nil, [32]byte{})
+	if err != nil {
+		t.Fatalf("buildCoinbaseTx: %v", err)
+	}
+	tx, _, _, err := parseCanonicalTx(raw, "bad")
+	if err != nil {
+		t.Fatalf("parseCanonicalTx(valid): %v", err)
+	}
+	if tx == nil {
+		t.Fatalf("expected parsed tx")
+	}
+
+	raw = append(raw, 0x00)
+	if _, _, _, err := parseCanonicalTx(raw, "bad"); err == nil || err.Error() != "bad" {
+		t.Fatalf("expected non-canonical parse error, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- split `clients/go/node/miner.go` helper flow into smaller non-consensus units
- isolate build context, DA/anchor policy rejection, CORE_EXT policy rejection, and block assembly
- add targeted miner helper tests to lock behavior

## Safety
- no consensus/spec change
- preserves timestamp selection, candidate ordering, policy outcomes, coinbase composition, and nonce search behavior

## Validation
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node ./cmd/rubin-node'`\n\nRefs: Q-DUPLICATION-01, issue #457