### PR TITLE
fix: bound txSeen/blockSeen to prevent unbounded memory growth (Q-AUDIT-P2-SEEN)

### DIFF
--- a/clients/go/node/p2p/seen.go
+++ b/clients/go/node/p2p/seen.go
@@ -2,30 +2,74 @@ package p2p
 
 import "sync"
 
-type hashSet struct {
-	mu    sync.RWMutex
+const (
+	// defaultBlockSeenCapacity is the maximum number of block hashes to
+	// remember for relay deduplication.  10 000 blocks at ~10 min/block
+	// covers roughly 70 days of chain history.
+	defaultBlockSeenCapacity = 10_000
+
+	// defaultTxSeenCapacity is the maximum number of transaction hashes
+	// to remember.  50 000 txids covers more than a full day at peak
+	// throughput and is sufficient to break inv/getdata relay loops.
+	defaultTxSeenCapacity = 50_000
+)
+
+// boundedHashSet is a thread-safe bounded FIFO set of [32]byte hashes.
+// When the set reaches capacity, the oldest entry is evicted to make room.
+// This prevents unbounded memory growth for long-running nodes.
+//
+// Implementation: map for O(1) lookup + fixed-size ring buffer for FIFO
+// eviction order.  All operations are O(1) amortized.
+type boundedHashSet struct {
+	mu   sync.RWMutex
+	cap  int
+	ring [][32]byte
+	next int
+	// items provides O(1) membership tests.
 	items map[[32]byte]struct{}
 }
 
-func newHashSet() *hashSet {
-	return &hashSet{
-		items: make(map[[32]byte]struct{}),
+func newBoundedHashSet(capacity int) *boundedHashSet {
+	if capacity <= 0 {
+		capacity = defaultTxSeenCapacity
+	}
+	return &boundedHashSet{
+		cap:   capacity,
+		ring:  make([][32]byte, capacity),
+		items: make(map[[32]byte]struct{}, capacity),
 	}
 }
 
-func (s *hashSet) Add(hash [32]byte) bool {
+// Add inserts hash into the set.  Returns true if the hash was newly
+// added, false if it was already present.  When the set is at capacity
+// the oldest entry is evicted (FIFO) before the new one is stored.
+func (s *boundedHashSet) Add(hash [32]byte) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if _, exists := s.items[hash]; exists {
 		return false
 	}
+	// Evict the oldest entry when the set is full.
+	if len(s.items) >= s.cap {
+		delete(s.items, s.ring[s.next])
+	}
+	s.ring[s.next] = hash
 	s.items[hash] = struct{}{}
+	s.next = (s.next + 1) % s.cap
 	return true
 }
 
-func (s *hashSet) Has(hash [32]byte) bool {
+// Has returns true if hash is in the set.
+func (s *boundedHashSet) Has(hash [32]byte) bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	_, exists := s.items[hash]
 	return exists
+}
+
+// Len returns the current number of entries in the set.
+func (s *boundedHashSet) Len() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.items)
 }

--- a/clients/go/node/p2p/seen_test.go
+++ b/clients/go/node/p2p/seen_test.go
@@ -5,18 +5,18 @@ import (
 	"testing"
 )
 
-func TestHashSet_AddAndHas(t *testing.T) {
-	s := newHashSet()
+func TestBoundedHashSet_AddAndHas(t *testing.T) {
+	s := newBoundedHashSet(100)
 
 	var h1, h2 [32]byte
 	h1[0] = 0x01
 	h2[0] = 0x02
 
-	// First add returns true
+	// First add returns true.
 	if !s.Add(h1) {
 		t.Fatal("first Add should return true")
 	}
-	// Duplicate returns false
+	// Duplicate returns false.
 	if s.Add(h1) {
 		t.Fatal("duplicate Add should return false")
 	}
@@ -26,10 +26,13 @@ func TestHashSet_AddAndHas(t *testing.T) {
 	if s.Has(h2) {
 		t.Fatal("Has should return false for unknown hash")
 	}
+	if s.Len() != 1 {
+		t.Fatalf("Len should be 1, got %d", s.Len())
+	}
 }
 
-func TestHashSet_ConcurrentSafe(t *testing.T) {
-	s := newHashSet()
+func TestBoundedHashSet_ConcurrentSafe(t *testing.T) {
+	s := newBoundedHashSet(200)
 	var wg sync.WaitGroup
 	for i := 0; i < 100; i++ {
 		wg.Add(1)
@@ -42,4 +45,136 @@ func TestHashSet_ConcurrentSafe(t *testing.T) {
 		}(i)
 	}
 	wg.Wait()
+}
+
+func TestBoundedHashSet_EvictsOldest(t *testing.T) {
+	const cap = 5
+	s := newBoundedHashSet(cap)
+
+	hashes := make([][32]byte, cap+3)
+	for i := range hashes {
+		hashes[i][0] = byte(i + 1)
+	}
+
+	// Fill to capacity.
+	for i := 0; i < cap; i++ {
+		if !s.Add(hashes[i]) {
+			t.Fatalf("Add(%d) should succeed", i)
+		}
+	}
+	if s.Len() != cap {
+		t.Fatalf("expected Len=%d, got %d", cap, s.Len())
+	}
+
+	// All entries present.
+	for i := 0; i < cap; i++ {
+		if !s.Has(hashes[i]) {
+			t.Fatalf("hash %d should be present before eviction", i)
+		}
+	}
+
+	// Add one more — oldest (index 0) should be evicted.
+	if !s.Add(hashes[cap]) {
+		t.Fatal("Add beyond capacity should succeed (evicts oldest)")
+	}
+	if s.Len() != cap {
+		t.Fatalf("Len should remain %d after eviction, got %d", cap, s.Len())
+	}
+	if s.Has(hashes[0]) {
+		t.Fatal("oldest hash (index 0) should have been evicted")
+	}
+	if !s.Has(hashes[cap]) {
+		t.Fatal("newly added hash should be present")
+	}
+	// Entries 1..cap-1 should still be present.
+	for i := 1; i < cap; i++ {
+		if !s.Has(hashes[i]) {
+			t.Fatalf("hash %d should still be present", i)
+		}
+	}
+
+	// Add two more — evict indices 1 and 2.
+	if !s.Add(hashes[cap+1]) {
+		t.Fatal("Add should succeed")
+	}
+	if !s.Add(hashes[cap+2]) {
+		t.Fatal("Add should succeed")
+	}
+	if s.Has(hashes[1]) {
+		t.Fatal("hash 1 should have been evicted")
+	}
+	if s.Has(hashes[2]) {
+		t.Fatal("hash 2 should have been evicted")
+	}
+	if s.Len() != cap {
+		t.Fatalf("Len should be %d, got %d", cap, s.Len())
+	}
+}
+
+func TestBoundedHashSet_DuplicateAfterEviction(t *testing.T) {
+	const cap = 3
+	s := newBoundedHashSet(cap)
+
+	var a, b, c, d [32]byte
+	a[0] = 0x0A
+	b[0] = 0x0B
+	c[0] = 0x0C
+	d[0] = 0x0D
+
+	s.Add(a) // ring: [A, _, _]
+	s.Add(b) // ring: [A, B, _]
+	s.Add(c) // ring: [A, B, C]  — full
+	s.Add(d) // ring: [D, B, C]  — A evicted
+
+	// A was evicted, re-adding should succeed.
+	if !s.Add(a) {
+		t.Fatal("re-adding evicted hash should return true")
+	}
+	if !s.Has(a) {
+		t.Fatal("re-added hash should be present")
+	}
+	// B was evicted to make room for A.
+	if s.Has(b) {
+		t.Fatal("hash B should have been evicted when A was re-added")
+	}
+	if s.Len() != cap {
+		t.Fatalf("Len should be %d, got %d", cap, s.Len())
+	}
+}
+
+func TestBoundedHashSet_ZeroCapacityUsesDefault(t *testing.T) {
+	s := newBoundedHashSet(0)
+	if s.cap != defaultTxSeenCapacity {
+		t.Fatalf("cap(0) should default to %d, got %d", defaultTxSeenCapacity, s.cap)
+	}
+	neg := newBoundedHashSet(-5)
+	if neg.cap != defaultTxSeenCapacity {
+		t.Fatalf("cap(-5) should default to %d, got %d", defaultTxSeenCapacity, neg.cap)
+	}
+}
+
+func TestBoundedHashSet_CapacityOne(t *testing.T) {
+	s := newBoundedHashSet(1)
+	var a, b [32]byte
+	a[0] = 0x01
+	b[0] = 0x02
+
+	if !s.Add(a) {
+		t.Fatal("Add A should succeed")
+	}
+	if s.Len() != 1 {
+		t.Fatalf("expected Len=1, got %d", s.Len())
+	}
+	if !s.Add(b) {
+		t.Fatal("Add B should succeed (evicts A)")
+	}
+	if s.Has(a) {
+		t.Fatal("A should be evicted")
+	}
+	if !s.Has(b) {
+		t.Fatal("B should be present")
+	}
+	if s.Len() != 1 {
+		t.Fatalf("expected Len=1 after eviction, got %d", s.Len())
+	}
 }

--- a/clients/go/node/p2p/service.go
+++ b/clients/go/node/p2p/service.go
@@ -43,8 +43,8 @@ type Service struct {
 	peers   map[string]*peer
 
 	chainMu   sync.Mutex
-	blockSeen *hashSet
-	txSeen    *hashSet
+	blockSeen *boundedHashSet
+	txSeen    *boundedHashSet
 }
 
 type peer struct {
@@ -100,8 +100,8 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 	return &Service{
 		cfg:       cfg,
 		peers:     make(map[string]*peer),
-		blockSeen: newHashSet(),
-		txSeen:    newHashSet(),
+		blockSeen: newBoundedHashSet(defaultBlockSeenCapacity),
+		txSeen:    newBoundedHashSet(defaultTxSeenCapacity),
 	}, nil
 }
 


### PR DESCRIPTION
## Summary

- Replace unbounded `hashSet` (map-only, grows forever) with `boundedHashSet` (ring buffer + map, FIFO eviction at capacity)
- `blockSeen`: capped at 10,000 entries (~70 days of block relay dedup)
- `txSeen`: capped at 50,000 entries (~1 day at peak tx throughput)
- Memory usage now constant O(capacity) regardless of node uptime

## Finding

P2-1 from Q-AUDIT-P0P1 closeout report: `txSeen/blockSeen unbounded hashSet growth` — long-running nodes accumulate every seen txid/blockhash in memory with no eviction, leading to OOM risk.

## Design

Ring buffer FIFO: simpler than LRU for this use case. Seen sets are relay-only dedup — a false negative (evicted hash re-requested) costs one extra `getdata`, not a consensus error. FIFO is O(1), cache-friendly, and doesn't require a doubly-linked list.

## Test plan

- [x] `TestBoundedHashSet_AddAndHas` — basic add/has/len
- [x] `TestBoundedHashSet_ConcurrentSafe` — 100 goroutines
- [x] `TestBoundedHashSet_EvictsOldest` — FIFO eviction order verified
- [x] `TestBoundedHashSet_DuplicateAfterEviction` — re-add after eviction
- [x] `TestBoundedHashSet_ZeroCapacityUsesDefault` — fallback for 0/-5
- [x] `TestBoundedHashSet_CapacityOne` — edge case cap=1
- [x] All existing p2p tests pass (handleTx, handleBlock, etc.)
- [x] Full Go test suite: 8/8 packages PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)