### PR TITLE
refactor: split mirrored block_basic helpers (Q-DUPLICATION-03)

### DIFF
--- a/clients/go/consensus/block_basic.go
+++ b/clients/go/consensus/block_basic.go
@@ -23,6 +23,12 @@ type BlockBasicSummary struct {
 	BlockHash [32]byte
 }
 
+type blockTxStats struct {
+	sumWeight uint64
+	sumDa     uint64
+	sumAnchor uint64
+}
+
 func isCoinbasePrevout(in TxInput) bool {
 	var zero [32]byte
 	return in.PrevTxid == zero && in.PrevVout == ^uint32(0)
@@ -134,24 +140,8 @@ func validateParsedBlockBasicWithContextAtHeight(
 		return nil, txerr(BLOCK_ERR_PARSE, "nil parsed block")
 	}
 
-	if err := PowCheck(pb.HeaderBytes, pb.Header.Target); err != nil {
+	if err := validateHeaderCommitments(pb, expectedPrevHash, expectedTarget); err != nil {
 		return nil, err
-	}
-
-	if expectedTarget != nil && pb.Header.Target != *expectedTarget {
-		return nil, txerr(BLOCK_ERR_TARGET_INVALID, "target mismatch")
-	}
-
-	if expectedPrevHash != nil && pb.Header.PrevBlockHash != *expectedPrevHash {
-		return nil, txerr(BLOCK_ERR_LINKAGE_INVALID, "prev_block_hash mismatch")
-	}
-
-	root, err := MerkleRootTxids(pb.Txids)
-	if err != nil {
-		return nil, txerr(BLOCK_ERR_MERKLE_INVALID, "failed to compute merkle root")
-	}
-	if root != pb.Header.MerkleRoot {
-		return nil, txerr(BLOCK_ERR_MERKLE_INVALID, "merkle_root mismatch")
 	}
 	if err := validateCoinbaseWitnessCommitment(pb); err != nil {
 		return nil, err
@@ -159,65 +149,15 @@ func validateParsedBlockBasicWithContextAtHeight(
 	if err := validateTimestampRules(pb.Header.Timestamp, blockHeight, prevTimestamps); err != nil {
 		return nil, err
 	}
-
-	var sumWeight uint64
-	var sumDa uint64
-	var sumAnchor uint64
-	if len(pb.Txs) == 0 || !isCoinbaseTx(pb.Txs[0]) {
-		return nil, txerr(BLOCK_ERR_COINBASE_INVALID, "first tx must be canonical coinbase")
+	if err := validateCoinbaseStructure(pb, blockHeight); err != nil {
+		return nil, err
 	}
-	if len(pb.Txs[0].Outputs) == 0 {
-		return nil, txerr(BLOCK_ERR_COINBASE_INVALID, "coinbase must have at least one output")
+	stats, err := accumulateBlockTxStats(pb, blockHeight)
+	if err != nil {
+		return nil, err
 	}
-	if blockHeight > uint64(^uint32(0)) {
-		return nil, txerr(BLOCK_ERR_COINBASE_INVALID, "block height exceeds coinbase locktime range")
-	}
-	if pb.Txs[0].Locktime != uint32(blockHeight) {
-		return nil, txerr(BLOCK_ERR_COINBASE_INVALID, "coinbase locktime must equal block height")
-	}
-	seenNonces := make(map[uint64]struct{}, len(pb.Txs))
-	for i, tx := range pb.Txs {
-		if i > 0 && isCoinbaseTx(tx) {
-			return nil, txerr(BLOCK_ERR_COINBASE_INVALID, "coinbase-like tx is only allowed at index 0")
-		}
-		// Non-coinbase transactions must carry at least one input.
-		if i > 0 && len(tx.Inputs) == 0 {
-			return nil, txerr(TX_ERR_PARSE, "non-coinbase must have at least one input")
-		}
-		if i > 0 {
-			if _, exists := seenNonces[tx.TxNonce]; exists {
-				return nil, txerr(TX_ERR_NONCE_REPLAY, "duplicate tx_nonce in block")
-			}
-			seenNonces[tx.TxNonce] = struct{}{}
-		}
-		if err := ValidateTxCovenantsGenesis(tx, blockHeight); err != nil {
-			return nil, err
-		}
-		w, da, anchorBytes, err := txWeightAndStats(tx)
-		if err != nil {
-			return nil, err
-		}
-		sumWeight, err = addU64(sumWeight, w)
-		if err != nil {
-			return nil, err
-		}
-		sumDa, err = addU64(sumDa, da)
-		if err != nil {
-			return nil, err
-		}
-		sumAnchor, err = addU64(sumAnchor, anchorBytes)
-		if err != nil {
-			return nil, err
-		}
-	}
-	if sumWeight > MAX_BLOCK_WEIGHT {
-		return nil, txerr(BLOCK_ERR_WEIGHT_EXCEEDED, "block weight exceeded")
-	}
-	if sumDa > MAX_DA_BYTES_PER_BLOCK {
-		return nil, txerr(BLOCK_ERR_WEIGHT_EXCEEDED, "DA bytes exceeded")
-	}
-	if sumAnchor > MAX_ANCHOR_BYTES_PER_BLOCK {
-		return nil, txerr(BLOCK_ERR_ANCHOR_BYTES_EXCEEDED, "anchor bytes exceeded")
+	if err := validateBlockResourceLimits(stats); err != nil {
+		return nil, err
 	}
 	if err := validateDASetIntegrity(pb.Txs); err != nil {
 		return nil, err
@@ -230,8 +170,8 @@ func validateParsedBlockBasicWithContextAtHeight(
 
 	return &BlockBasicSummary{
 		TxCount:   pb.TxCount,
-		SumWeight: sumWeight,
-		SumDa:     sumDa,
+		SumWeight: stats.sumWeight,
+		SumDa:     stats.sumDa,
 		BlockHash: blockHash,
 	}, nil
 }
@@ -264,6 +204,97 @@ func ValidateBlockBasicWithContextAndFeesAtHeight(
 		return nil, err
 	}
 	return s, nil
+}
+
+func validateHeaderCommitments(pb *ParsedBlock, expectedPrevHash *[32]byte, expectedTarget *[32]byte) error {
+	if err := PowCheck(pb.HeaderBytes, pb.Header.Target); err != nil {
+		return err
+	}
+
+	if expectedTarget != nil && pb.Header.Target != *expectedTarget {
+		return txerr(BLOCK_ERR_TARGET_INVALID, "target mismatch")
+	}
+
+	if expectedPrevHash != nil && pb.Header.PrevBlockHash != *expectedPrevHash {
+		return txerr(BLOCK_ERR_LINKAGE_INVALID, "prev_block_hash mismatch")
+	}
+
+	root, err := MerkleRootTxids(pb.Txids)
+	if err != nil {
+		return txerr(BLOCK_ERR_MERKLE_INVALID, "failed to compute merkle root")
+	}
+	if root != pb.Header.MerkleRoot {
+		return txerr(BLOCK_ERR_MERKLE_INVALID, "merkle_root mismatch")
+	}
+	return nil
+}
+
+func validateCoinbaseStructure(pb *ParsedBlock, blockHeight uint64) error {
+	if len(pb.Txs) == 0 || !isCoinbaseTx(pb.Txs[0]) {
+		return txerr(BLOCK_ERR_COINBASE_INVALID, "first tx must be canonical coinbase")
+	}
+	if len(pb.Txs[0].Outputs) == 0 {
+		return txerr(BLOCK_ERR_COINBASE_INVALID, "coinbase must have at least one output")
+	}
+	if blockHeight > uint64(^uint32(0)) {
+		return txerr(BLOCK_ERR_COINBASE_INVALID, "block height exceeds coinbase locktime range")
+	}
+	if pb.Txs[0].Locktime != uint32(blockHeight) {
+		return txerr(BLOCK_ERR_COINBASE_INVALID, "coinbase locktime must equal block height")
+	}
+	return nil
+}
+
+func accumulateBlockTxStats(pb *ParsedBlock, blockHeight uint64) (*blockTxStats, error) {
+	stats := &blockTxStats{}
+	seenNonces := make(map[uint64]struct{}, len(pb.Txs))
+	for i, tx := range pb.Txs {
+		if i > 0 && isCoinbaseTx(tx) {
+			return nil, txerr(BLOCK_ERR_COINBASE_INVALID, "coinbase-like tx is only allowed at index 0")
+		}
+		if i > 0 && len(tx.Inputs) == 0 {
+			return nil, txerr(TX_ERR_PARSE, "non-coinbase must have at least one input")
+		}
+		if i > 0 {
+			if _, exists := seenNonces[tx.TxNonce]; exists {
+				return nil, txerr(TX_ERR_NONCE_REPLAY, "duplicate tx_nonce in block")
+			}
+			seenNonces[tx.TxNonce] = struct{}{}
+		}
+		if err := ValidateTxCovenantsGenesis(tx, blockHeight); err != nil {
+			return nil, err
+		}
+		w, da, anchorBytes, err := txWeightAndStats(tx)
+		if err != nil {
+			return nil, err
+		}
+		stats.sumWeight, err = addU64(stats.sumWeight, w)
+		if err != nil {
+			return nil, err
+		}
+		stats.sumDa, err = addU64(stats.sumDa, da)
+		if err != nil {
+			return nil, err
+		}
+		stats.sumAnchor, err = addU64(stats.sumAnchor, anchorBytes)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return stats, nil
+}
+
+func validateBlockResourceLimits(stats *blockTxStats) error {
+	if stats.sumWeight > MAX_BLOCK_WEIGHT {
+		return txerr(BLOCK_ERR_WEIGHT_EXCEEDED, "block weight exceeded")
+	}
+	if stats.sumDa > MAX_DA_BYTES_PER_BLOCK {
+		return txerr(BLOCK_ERR_WEIGHT_EXCEEDED, "DA bytes exceeded")
+	}
+	if stats.sumAnchor > MAX_ANCHOR_BYTES_PER_BLOCK {
+		return txerr(BLOCK_ERR_ANCHOR_BYTES_EXCEEDED, "anchor bytes exceeded")
+	}
+	return nil
 }
 
 func validateCoinbaseValueBound(pb *ParsedBlock, blockHeight uint64, alreadyGenerated *big.Int, sumFees uint64) error {

--- a/clients/rust/crates/rubin-consensus/src/block_basic.rs
+++ b/clients/rust/crates/rubin-consensus/src/block_basic.rs
@@ -34,6 +34,13 @@ pub struct BlockBasicSummary {
     pub block_hash: [u8; 32],
 }
 
+#[derive(Clone, Copy, Debug)]
+struct BlockTxStats {
+    sum_weight: u64,
+    sum_da: u64,
+    sum_anchor: u64,
+}
+
 pub fn parse_block_bytes(block_bytes: &[u8]) -> Result<ParsedBlock, TxError> {
     if block_bytes.len() < BLOCK_HEADER_BYTES + 1 {
         return Err(TxError::new(ErrorCode::BlockErrParse, "block too short"));
@@ -129,96 +136,13 @@ pub fn validate_block_basic_with_context_at_height(
 ) -> Result<BlockBasicSummary, TxError> {
     let pb = parse_block_bytes(block_bytes)?;
 
-    pow_check(&pb.header_bytes, pb.header.target)?;
-
-    if let Some(target) = expected_target {
-        if pb.header.target != target {
-            return Err(TxError::new(
-                ErrorCode::BlockErrTargetInvalid,
-                "target mismatch",
-            ));
-        }
-    }
-
-    if let Some(prev) = expected_prev_hash {
-        if pb.header.prev_block_hash != prev {
-            return Err(TxError::new(
-                ErrorCode::BlockErrLinkageInvalid,
-                "prev_block_hash mismatch",
-            ));
-        }
-    }
-
-    let root = merkle_root_txids(&pb.txids)
-        .map_err(|_| TxError::new(ErrorCode::BlockErrMerkleInvalid, "failed to compute merkle"))?;
-    if root != pb.header.merkle_root {
-        return Err(TxError::new(
-            ErrorCode::BlockErrMerkleInvalid,
-            "merkle_root mismatch",
-        ));
-    }
+    validate_header_commitments(&pb, expected_prev_hash, expected_target)?;
     validate_coinbase_witness_commitment(&pb)?;
     validate_timestamp_rules(pb.header.timestamp, block_height, prev_timestamps)?;
 
     validate_coinbase_structure(&pb, block_height)?;
-
-    let mut sum_weight: u64 = 0;
-    let mut sum_da: u64 = 0;
-    let mut sum_anchor: u64 = 0;
-    let mut seen_nonces: HashMap<u64, ()> = HashMap::with_capacity(pb.txs.len());
-    for (i, tx) in pb.txs.iter().enumerate() {
-        if i > 0 {
-            if is_coinbase_tx(tx) {
-                return Err(TxError::new(
-                    ErrorCode::BlockErrCoinbaseInvalid,
-                    "coinbase-like tx found at index > 0",
-                ));
-            }
-            // Non-coinbase transactions must carry at least one input.
-            if tx.inputs.is_empty() {
-                return Err(TxError::new(
-                    ErrorCode::TxErrParse,
-                    "non-coinbase must have at least one input",
-                ));
-            }
-            if seen_nonces.insert(tx.tx_nonce, ()).is_some() {
-                return Err(TxError::new(
-                    ErrorCode::TxErrNonceReplay,
-                    "duplicate tx_nonce in block",
-                ));
-            }
-        }
-        validate_tx_covenants_genesis(tx, block_height)?;
-        let (w, da, anchor_bytes) = tx_weight_and_stats(tx)?;
-        sum_weight = sum_weight
-            .checked_add(w)
-            .ok_or_else(|| TxError::new(ErrorCode::TxErrParse, "u64 overflow"))?;
-        sum_da = sum_da
-            .checked_add(da)
-            .ok_or_else(|| TxError::new(ErrorCode::TxErrParse, "u64 overflow"))?;
-        sum_anchor = sum_anchor
-            .checked_add(anchor_bytes)
-            .ok_or_else(|| TxError::new(ErrorCode::TxErrParse, "u64 overflow"))?;
-    }
-
-    if sum_weight > MAX_BLOCK_WEIGHT {
-        return Err(TxError::new(
-            ErrorCode::BlockErrWeightExceeded,
-            "block weight exceeded",
-        ));
-    }
-    if sum_da > MAX_DA_BYTES_PER_BLOCK {
-        return Err(TxError::new(
-            ErrorCode::BlockErrWeightExceeded,
-            "DA bytes exceeded",
-        ));
-    }
-    if sum_anchor > MAX_ANCHOR_BYTES_PER_BLOCK {
-        return Err(TxError::new(
-            ErrorCode::BlockErrAnchorBytesExceeded,
-            "anchor bytes exceeded",
-        ));
-    }
+    let stats = accumulate_block_tx_stats(&pb, block_height)?;
+    validate_block_resource_limits(stats)?;
 
     validate_da_set_integrity(&pb.txs)?;
 
@@ -227,8 +151,8 @@ pub fn validate_block_basic_with_context_at_height(
 
     Ok(BlockBasicSummary {
         tx_count: pb.tx_count,
-        sum_weight,
-        sum_da,
+        sum_weight: stats.sum_weight,
+        sum_da: stats.sum_da,
         block_hash: h,
     })
 }
@@ -270,6 +194,42 @@ fn is_coinbase_tx(tx: &Tx) -> bool {
         && input.sequence == u32::MAX
 }
 
+fn validate_header_commitments(
+    pb: &ParsedBlock,
+    expected_prev_hash: Option<[u8; 32]>,
+    expected_target: Option<[u8; 32]>,
+) -> Result<(), TxError> {
+    pow_check(&pb.header_bytes, pb.header.target)?;
+
+    if let Some(target) = expected_target {
+        if pb.header.target != target {
+            return Err(TxError::new(
+                ErrorCode::BlockErrTargetInvalid,
+                "target mismatch",
+            ));
+        }
+    }
+
+    if let Some(prev) = expected_prev_hash {
+        if pb.header.prev_block_hash != prev {
+            return Err(TxError::new(
+                ErrorCode::BlockErrLinkageInvalid,
+                "prev_block_hash mismatch",
+            ));
+        }
+    }
+
+    let root = merkle_root_txids(&pb.txids)
+        .map_err(|_| TxError::new(ErrorCode::BlockErrMerkleInvalid, "failed to compute merkle"))?;
+    if root != pb.header.merkle_root {
+        return Err(TxError::new(
+            ErrorCode::BlockErrMerkleInvalid,
+            "merkle_root mismatch",
+        ));
+    }
+    Ok(())
+}
+
 fn validate_coinbase_structure(pb: &ParsedBlock, block_height: u64) -> Result<(), TxError> {
     let coinbase = pb
         .txs
@@ -295,6 +255,74 @@ fn validate_coinbase_structure(pb: &ParsedBlock, block_height: u64) -> Result<()
         return Err(TxError::new(
             ErrorCode::BlockErrCoinbaseInvalid,
             "coinbase locktime must equal block height",
+        ));
+    }
+    Ok(())
+}
+
+fn accumulate_block_tx_stats(pb: &ParsedBlock, block_height: u64) -> Result<BlockTxStats, TxError> {
+    let mut stats = BlockTxStats {
+        sum_weight: 0,
+        sum_da: 0,
+        sum_anchor: 0,
+    };
+    let mut seen_nonces: HashMap<u64, ()> = HashMap::with_capacity(pb.txs.len());
+    for (i, tx) in pb.txs.iter().enumerate() {
+        if i > 0 {
+            if is_coinbase_tx(tx) {
+                return Err(TxError::new(
+                    ErrorCode::BlockErrCoinbaseInvalid,
+                    "coinbase-like tx found at index > 0",
+                ));
+            }
+            if tx.inputs.is_empty() {
+                return Err(TxError::new(
+                    ErrorCode::TxErrParse,
+                    "non-coinbase must have at least one input",
+                ));
+            }
+            if seen_nonces.insert(tx.tx_nonce, ()).is_some() {
+                return Err(TxError::new(
+                    ErrorCode::TxErrNonceReplay,
+                    "duplicate tx_nonce in block",
+                ));
+            }
+        }
+        validate_tx_covenants_genesis(tx, block_height)?;
+        let (w, da, anchor_bytes) = tx_weight_and_stats(tx)?;
+        stats.sum_weight = stats
+            .sum_weight
+            .checked_add(w)
+            .ok_or_else(|| TxError::new(ErrorCode::TxErrParse, "u64 overflow"))?;
+        stats.sum_da = stats
+            .sum_da
+            .checked_add(da)
+            .ok_or_else(|| TxError::new(ErrorCode::TxErrParse, "u64 overflow"))?;
+        stats.sum_anchor = stats
+            .sum_anchor
+            .checked_add(anchor_bytes)
+            .ok_or_else(|| TxError::new(ErrorCode::TxErrParse, "u64 overflow"))?;
+    }
+    Ok(stats)
+}
+
+fn validate_block_resource_limits(stats: BlockTxStats) -> Result<(), TxError> {
+    if stats.sum_weight > MAX_BLOCK_WEIGHT {
+        return Err(TxError::new(
+            ErrorCode::BlockErrWeightExceeded,
+            "block weight exceeded",
+        ));
+    }
+    if stats.sum_da > MAX_DA_BYTES_PER_BLOCK {
+        return Err(TxError::new(
+            ErrorCode::BlockErrWeightExceeded,
+            "DA bytes exceeded",
+        ));
+    }
+    if stats.sum_anchor > MAX_ANCHOR_BYTES_PER_BLOCK {
+        return Err(TxError::new(
+            ErrorCode::BlockErrAnchorBytesExceeded,
+            "anchor bytes exceeded",
         ));
     }
     Ok(())


### PR DESCRIPTION
## Summary
- extract mirrored helper-only validation phases in Go and Rust `block_basic`
- preserve block validation order, error mapping, and accept/reject behavior
- keep scope limited to helper extraction and stats/resource-limit plumbing

## Validation
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./consensus'`\n- `scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test -p rubin-consensus'`\n\nRefs: Q-DUPLICATION-03, #453, #454