### PR TITLE
refactor: split block_basic files for Q-DUPLICATION-04

### DIFF
--- a/clients/go/consensus/block_basic.go
+++ b/clients/go/consensus/block_basic.go
@@ -3,7 +3,6 @@ package consensus
 import (
 	"bytes"
 	"math/big"
-	"math/bits"
 	"sort"
 )
 
@@ -206,43 +205,9 @@ func ValidateBlockBasicWithContextAndFeesAtHeight(
 	return s, nil
 }
 
-func validateHeaderCommitments(pb *ParsedBlock, expectedPrevHash *[32]byte, expectedTarget *[32]byte) error {
-	if err := PowCheck(pb.HeaderBytes, pb.Header.Target); err != nil {
-		return err
-	}
-
-	if expectedTarget != nil && pb.Header.Target != *expectedTarget {
-		return txerr(BLOCK_ERR_TARGET_INVALID, "target mismatch")
-	}
-
-	if expectedPrevHash != nil && pb.Header.PrevBlockHash != *expectedPrevHash {
-		return txerr(BLOCK_ERR_LINKAGE_INVALID, "prev_block_hash mismatch")
-	}
-
-	root, err := MerkleRootTxids(pb.Txids)
-	if err != nil {
-		return txerr(BLOCK_ERR_MERKLE_INVALID, "failed to compute merkle root")
-	}
-	if root != pb.Header.MerkleRoot {
-		return txerr(BLOCK_ERR_MERKLE_INVALID, "merkle_root mismatch")
-	}
-	return nil
-}
-
-func validateCoinbaseStructure(pb *ParsedBlock, blockHeight uint64) error {
-	if len(pb.Txs) == 0 || !isCoinbaseTx(pb.Txs[0]) {
-		return txerr(BLOCK_ERR_COINBASE_INVALID, "first tx must be canonical coinbase")
-	}
-	if len(pb.Txs[0].Outputs) == 0 {
-		return txerr(BLOCK_ERR_COINBASE_INVALID, "coinbase must have at least one output")
-	}
-	if blockHeight > uint64(^uint32(0)) {
-		return txerr(BLOCK_ERR_COINBASE_INVALID, "block height exceeds coinbase locktime range")
-	}
-	if pb.Txs[0].Locktime != uint32(blockHeight) {
-		return txerr(BLOCK_ERR_COINBASE_INVALID, "coinbase locktime must equal block height")
-	}
-	return nil
+type daCommitSet struct {
+	tx         *Tx
+	chunkCount uint16
 }
 
 func accumulateBlockTxStats(pb *ParsedBlock, blockHeight uint64) (*blockTxStats, error) {
@@ -295,116 +260,6 @@ func validateBlockResourceLimits(stats *blockTxStats) error {
 		return txerr(BLOCK_ERR_ANCHOR_BYTES_EXCEEDED, "anchor bytes exceeded")
 	}
 	return nil
-}
-
-func validateCoinbaseValueBound(pb *ParsedBlock, blockHeight uint64, alreadyGenerated *big.Int, sumFees uint64) error {
-	if pb == nil || len(pb.Txs) == 0 {
-		return txerr(BLOCK_ERR_COINBASE_INVALID, "missing coinbase")
-	}
-	if blockHeight == 0 {
-		return nil
-	}
-	coinbase := pb.Txs[0]
-	if coinbase == nil {
-		return txerr(BLOCK_ERR_COINBASE_INVALID, "nil coinbase")
-	}
-
-	var sumCoinbase u128
-	for _, out := range coinbase.Outputs {
-		var err error
-		sumCoinbase, err = addU64ToU128Block(sumCoinbase, out.Value)
-		if err != nil {
-			return err
-		}
-	}
-	subsidy := BlockSubsidyBig(blockHeight, alreadyGenerated)
-	limit := u128{hi: 0, lo: subsidy}
-	limit, err := addU64ToU128Block(limit, sumFees)
-	if err != nil {
-		return err
-	}
-	if cmpU128(sumCoinbase, limit) > 0 {
-		return txerr(BLOCK_ERR_SUBSIDY_EXCEEDED, "coinbase outputs exceed subsidy+fees bound")
-	}
-	return nil
-}
-
-func addU64ToU128Block(x u128, v uint64) (u128, error) {
-	lo, carry := bits.Add64(x.lo, v, 0)
-	hi, carry2 := bits.Add64(x.hi, 0, carry)
-	if carry2 != 0 {
-		return u128{}, txerr(BLOCK_ERR_PARSE, "u128 overflow")
-	}
-	return u128{hi: hi, lo: lo}, nil
-}
-
-func validateCoinbaseWitnessCommitment(pb *ParsedBlock) error {
-	if pb == nil || len(pb.Txs) == 0 || len(pb.Wtxids) == 0 {
-		return txerr(BLOCK_ERR_COINBASE_INVALID, "missing coinbase")
-	}
-
-	wroot, err := WitnessMerkleRootWtxids(pb.Wtxids)
-	if err != nil {
-		return txerr(BLOCK_ERR_WITNESS_COMMITMENT, "failed to compute witness merkle root")
-	}
-	expected := WitnessCommitmentHash(wroot)
-
-	matches := 0
-	for _, out := range pb.Txs[0].Outputs {
-		if out.CovenantType != COV_TYPE_ANCHOR || len(out.CovenantData) != 32 {
-			continue
-		}
-		if bytes.Equal(out.CovenantData, expected[:]) {
-			matches++
-		}
-	}
-
-	if matches != 1 {
-		return txerr(BLOCK_ERR_WITNESS_COMMITMENT, "coinbase witness commitment missing or duplicated")
-	}
-	return nil
-}
-
-func validateTimestampRules(headerTimestamp uint64, blockHeight uint64, prevTimestamps []uint64) error {
-	median, ok, err := medianTimePast(blockHeight, prevTimestamps)
-	if err != nil {
-		return err
-	}
-	if !ok {
-		return nil
-	}
-	if headerTimestamp <= median {
-		return txerr(BLOCK_ERR_TIMESTAMP_OLD, "timestamp <= MTP median")
-	}
-	upperBound := median + MAX_FUTURE_DRIFT
-	if upperBound < median {
-		upperBound = ^uint64(0)
-	}
-	if headerTimestamp > upperBound {
-		return txerr(BLOCK_ERR_TIMESTAMP_FUTURE, "timestamp exceeds future drift")
-	}
-	return nil
-}
-
-func medianTimePast(blockHeight uint64, prevTimestamps []uint64) (uint64, bool, error) {
-	if blockHeight == 0 || len(prevTimestamps) == 0 {
-		return 0, false, nil
-	}
-	k := uint64(11)
-	if blockHeight < k {
-		k = blockHeight
-	}
-	if len(prevTimestamps) < int(k) {
-		return 0, false, txerr(BLOCK_ERR_PARSE, "insufficient prev_timestamps context")
-	}
-	window := append([]uint64(nil), prevTimestamps[:int(k)]...)
-	sort.Slice(window, func(i, j int) bool { return window[i] < window[j] })
-	return window[(len(window)-1)/2], true, nil
-}
-
-type daCommitSet struct {
-	tx         *Tx
-	chunkCount uint16
 }
 
 func validateDASetIntegrity(txs []*Tx) error {
@@ -484,8 +339,6 @@ func validateDASetIntegrity(txs []*Tx) error {
 		}
 		payloadCommitment := sha3_256(concat)
 
-		// CANONICAL §21.4: commit tx MUST contain exactly one CORE_DA_COMMIT output whose
-		// covenant_data equals the payload commitment hash (missing/duplicate are invalid).
 		daCommitOutputs := 0
 		var gotCommitment [32]byte
 		for _, out := range commit.tx.Outputs {
@@ -526,14 +379,13 @@ func txWeightAndStats(tx *Tx) (uint64, uint64, uint64, error) {
 
 	var err error
 	var baseSize uint64
-	baseSize = 4 + 1 + 8 // version + tx_kind + tx_nonce
+	baseSize = 4 + 1 + 8
 	baseSize, err = addU64(baseSize, compactSizeLen(uint64(len(tx.Inputs))))
 	if err != nil {
 		return 0, 0, 0, txerr(TX_ERR_PARSE, "tx base size overflow")
 	}
 	for _, in := range tx.Inputs {
-		var err error
-		baseSize, err = addU64(baseSize, 32+4) // prevout
+		baseSize, err = addU64(baseSize, 32+4)
 		if err != nil {
 			return 0, 0, 0, err
 		}
@@ -545,7 +397,7 @@ func txWeightAndStats(tx *Tx) (uint64, uint64, uint64, error) {
 		if err != nil {
 			return 0, 0, 0, err
 		}
-		baseSize, err = addU64(baseSize, 4) // sequence
+		baseSize, err = addU64(baseSize, 4)
 		if err != nil {
 			return 0, 0, 0, err
 		}
@@ -556,8 +408,7 @@ func txWeightAndStats(tx *Tx) (uint64, uint64, uint64, error) {
 	}
 	var anchorBytes uint64
 	for _, out := range tx.Outputs {
-		var err error
-		baseSize, err = addU64(baseSize, 8+2) // value + covenant_type
+		baseSize, err = addU64(baseSize, 8+2)
 		if err != nil {
 			return 0, 0, 0, err
 		}
@@ -577,7 +428,7 @@ func txWeightAndStats(tx *Tx) (uint64, uint64, uint64, error) {
 			}
 		}
 	}
-	baseSize, err = addU64(baseSize, 4) // locktime
+	baseSize, err = addU64(baseSize, 4)
 	if err != nil {
 		return 0, 0, 0, txerr(TX_ERR_PARSE, "tx base size overflow")
 	}
@@ -590,13 +441,11 @@ func txWeightAndStats(tx *Tx) (uint64, uint64, uint64, error) {
 		return 0, 0, 0, err
 	}
 
-	var witnessSize uint64
-	witnessSize = compactSizeLen(uint64(len(tx.Witness)))
+	witnessSize := compactSizeLen(uint64(len(tx.Witness)))
 	var mlCount uint64
 	var unknownSuiteCount uint64
 	for _, w := range tx.Witness {
-		var err error
-		witnessSize, err = addU64(witnessSize, 1) // suite_id
+		witnessSize, err = addU64(witnessSize, 1)
 		if err != nil {
 			return 0, 0, 0, err
 		}
@@ -622,7 +471,6 @@ func txWeightAndStats(tx *Tx) (uint64, uint64, uint64, error) {
 				mlCount++
 			}
 		case SUITE_ID_SENTINEL:
-			// Sentinel does not contribute sig_cost.
 		default:
 			unknownSuiteCount++
 		}
@@ -672,12 +520,6 @@ func txWeightAndStats(tx *Tx) (uint64, uint64, uint64, error) {
 	return weight, daBytes, anchorBytes, nil
 }
 
-// TxWeightAndStats exposes consensus weight accounting for conformance and formal tooling.
-// It is a pure function of a parsed Tx and does not consult chainstate.
-func TxWeightAndStats(tx *Tx) (uint64, uint64, uint64, error) {
-	return txWeightAndStats(tx)
-}
-
 func compactSizeLen(n uint64) uint64 {
 	switch {
 	case n < 0xfd:
@@ -706,4 +548,10 @@ func mulU64(a uint64, b uint64) (uint64, error) {
 		return 0, txerr(TX_ERR_PARSE, "u64 overflow")
 	}
 	return a * b, nil
+}
+
+// TxWeightAndStats exposes consensus weight accounting for conformance and formal tooling.
+// It is a pure function of a parsed Tx and does not consult chainstate.
+func TxWeightAndStats(tx *Tx) (uint64, uint64, uint64, error) {
+	return txWeightAndStats(tx)
 }

--- a/clients/go/consensus/block_basic_coinbase.go
+++ b/clients/go/consensus/block_basic_coinbase.go
@@ -1,0 +1,91 @@
+package consensus
+
+import (
+	"bytes"
+	"math/big"
+	"math/bits"
+)
+
+func validateCoinbaseStructure(pb *ParsedBlock, blockHeight uint64) error {
+	if len(pb.Txs) == 0 || !isCoinbaseTx(pb.Txs[0]) {
+		return txerr(BLOCK_ERR_COINBASE_INVALID, "first tx must be canonical coinbase")
+	}
+	if len(pb.Txs[0].Outputs) == 0 {
+		return txerr(BLOCK_ERR_COINBASE_INVALID, "coinbase must have at least one output")
+	}
+	if blockHeight > uint64(^uint32(0)) {
+		return txerr(BLOCK_ERR_COINBASE_INVALID, "block height exceeds coinbase locktime range")
+	}
+	if pb.Txs[0].Locktime != uint32(blockHeight) {
+		return txerr(BLOCK_ERR_COINBASE_INVALID, "coinbase locktime must equal block height")
+	}
+	return nil
+}
+
+func validateCoinbaseValueBound(pb *ParsedBlock, blockHeight uint64, alreadyGenerated *big.Int, sumFees uint64) error {
+	if pb == nil || len(pb.Txs) == 0 {
+		return txerr(BLOCK_ERR_COINBASE_INVALID, "missing coinbase")
+	}
+	if blockHeight == 0 {
+		return nil
+	}
+	coinbase := pb.Txs[0]
+	if coinbase == nil {
+		return txerr(BLOCK_ERR_COINBASE_INVALID, "nil coinbase")
+	}
+
+	var sumCoinbase u128
+	for _, out := range coinbase.Outputs {
+		var err error
+		sumCoinbase, err = addU64ToU128Block(sumCoinbase, out.Value)
+		if err != nil {
+			return err
+		}
+	}
+	subsidy := BlockSubsidyBig(blockHeight, alreadyGenerated)
+	limit := u128{hi: 0, lo: subsidy}
+	limit, err := addU64ToU128Block(limit, sumFees)
+	if err != nil {
+		return err
+	}
+	if cmpU128(sumCoinbase, limit) > 0 {
+		return txerr(BLOCK_ERR_SUBSIDY_EXCEEDED, "coinbase outputs exceed subsidy+fees bound")
+	}
+	return nil
+}
+
+func addU64ToU128Block(x u128, v uint64) (u128, error) {
+	lo, carry := bits.Add64(x.lo, v, 0)
+	hi, carry2 := bits.Add64(x.hi, 0, carry)
+	if carry2 != 0 {
+		return u128{}, txerr(BLOCK_ERR_PARSE, "u128 overflow")
+	}
+	return u128{hi: hi, lo: lo}, nil
+}
+
+func validateCoinbaseWitnessCommitment(pb *ParsedBlock) error {
+	if pb == nil || len(pb.Txs) == 0 || len(pb.Wtxids) == 0 {
+		return txerr(BLOCK_ERR_COINBASE_INVALID, "missing coinbase")
+	}
+
+	wroot, err := WitnessMerkleRootWtxids(pb.Wtxids)
+	if err != nil {
+		return txerr(BLOCK_ERR_WITNESS_COMMITMENT, "failed to compute witness merkle root")
+	}
+	expected := WitnessCommitmentHash(wroot)
+
+	matches := 0
+	for _, out := range pb.Txs[0].Outputs {
+		if out.CovenantType != COV_TYPE_ANCHOR || len(out.CovenantData) != 32 {
+			continue
+		}
+		if bytes.Equal(out.CovenantData, expected[:]) {
+			matches++
+		}
+	}
+
+	if matches != 1 {
+		return txerr(BLOCK_ERR_WITNESS_COMMITMENT, "coinbase witness commitment missing or duplicated")
+	}
+	return nil
+}

--- a/clients/go/consensus/block_basic_header.go
+++ b/clients/go/consensus/block_basic_header.go
@@ -1,0 +1,63 @@
+package consensus
+
+import "sort"
+
+func validateHeaderCommitments(pb *ParsedBlock, expectedPrevHash *[32]byte, expectedTarget *[32]byte) error {
+	if err := PowCheck(pb.HeaderBytes, pb.Header.Target); err != nil {
+		return err
+	}
+
+	if expectedTarget != nil && pb.Header.Target != *expectedTarget {
+		return txerr(BLOCK_ERR_TARGET_INVALID, "target mismatch")
+	}
+
+	if expectedPrevHash != nil && pb.Header.PrevBlockHash != *expectedPrevHash {
+		return txerr(BLOCK_ERR_LINKAGE_INVALID, "prev_block_hash mismatch")
+	}
+
+	root, err := MerkleRootTxids(pb.Txids)
+	if err != nil {
+		return txerr(BLOCK_ERR_MERKLE_INVALID, "failed to compute merkle root")
+	}
+	if root != pb.Header.MerkleRoot {
+		return txerr(BLOCK_ERR_MERKLE_INVALID, "merkle_root mismatch")
+	}
+	return nil
+}
+
+func validateTimestampRules(headerTimestamp uint64, blockHeight uint64, prevTimestamps []uint64) error {
+	median, ok, err := medianTimePast(blockHeight, prevTimestamps)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+	if headerTimestamp <= median {
+		return txerr(BLOCK_ERR_TIMESTAMP_OLD, "timestamp <= MTP median")
+	}
+	upperBound := median + MAX_FUTURE_DRIFT
+	if upperBound < median {
+		upperBound = ^uint64(0)
+	}
+	if headerTimestamp > upperBound {
+		return txerr(BLOCK_ERR_TIMESTAMP_FUTURE, "timestamp exceeds future drift")
+	}
+	return nil
+}
+
+func medianTimePast(blockHeight uint64, prevTimestamps []uint64) (uint64, bool, error) {
+	if blockHeight == 0 || len(prevTimestamps) == 0 {
+		return 0, false, nil
+	}
+	k := uint64(11)
+	if blockHeight < k {
+		k = blockHeight
+	}
+	if len(prevTimestamps) < int(k) {
+		return 0, false, txerr(BLOCK_ERR_PARSE, "insufficient prev_timestamps context")
+	}
+	window := append([]uint64(nil), prevTimestamps[:int(k)]...)
+	sort.Slice(window, func(i, j int) bool { return window[i] < window[j] })
+	return window[(len(window)-1)/2], true, nil
+}

--- a/clients/rust/crates/rubin-consensus/src/block_basic.rs
+++ b/clients/rust/crates/rubin-consensus/src/block_basic.rs
@@ -1,20 +1,26 @@
 use crate::block::{block_hash, parse_block_header_bytes, BlockHeader, BLOCK_HEADER_BYTES};
 use crate::compactsize::read_compact_size;
 use crate::constants::{
-    COV_TYPE_ANCHOR, COV_TYPE_DA_COMMIT, MAX_ANCHOR_BYTES_PER_BLOCK, MAX_BLOCK_WEIGHT,
-    MAX_DA_BATCHES_PER_BLOCK, MAX_DA_BYTES_PER_BLOCK, MAX_DA_CHUNK_COUNT, MAX_FUTURE_DRIFT,
-    ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES, SUITE_ID_ML_DSA_87, SUITE_ID_SENTINEL,
-    VERIFY_COST_ML_DSA_87, VERIFY_COST_UNKNOWN_SUITE, WITNESS_DISCOUNT_DIVISOR,
+    COV_TYPE_DA_COMMIT, MAX_ANCHOR_BYTES_PER_BLOCK, MAX_BLOCK_WEIGHT, MAX_DA_BATCHES_PER_BLOCK,
+    MAX_DA_BYTES_PER_BLOCK, MAX_DA_CHUNK_COUNT, ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES,
+    SUITE_ID_ML_DSA_87, SUITE_ID_SENTINEL, VERIFY_COST_ML_DSA_87, VERIFY_COST_UNKNOWN_SUITE,
+    WITNESS_DISCOUNT_DIVISOR,
 };
 use crate::covenant_genesis::validate_tx_covenants_genesis;
 use crate::error::{ErrorCode, TxError};
 use crate::hash::sha3_256;
-use crate::merkle::{merkle_root_txids, witness_commitment_hash, witness_merkle_root_wtxids};
-use crate::pow::pow_check;
-use crate::subsidy::block_subsidy;
 use crate::tx::{da_core_fields_bytes, parse_tx, Tx};
 use crate::wire_read::Reader;
 use std::collections::HashMap;
+
+mod coinbase;
+mod header;
+
+use self::coinbase::{validate_coinbase_structure, validate_coinbase_witness_commitment};
+use self::header::{validate_header_commitments, validate_timestamp_rules};
+
+pub(crate) use self::coinbase::validate_coinbase_value_bound;
+pub(crate) use self::header::median_time_past;
 
 #[derive(Clone, Debug)]
 pub struct ParsedBlock {
@@ -39,6 +45,12 @@ struct BlockTxStats {
     sum_weight: u64,
     sum_da: u64,
     sum_anchor: u64,
+}
+
+#[derive(Clone)]
+struct DaCommitSet {
+    tx: Tx,
+    chunk_count: u16,
 }
 
 pub fn parse_block_bytes(block_bytes: &[u8]) -> Result<ParsedBlock, TxError> {
@@ -178,88 +190,6 @@ pub fn validate_block_basic_with_context_and_fees_at_height(
     Ok(s)
 }
 
-fn is_coinbase_tx(tx: &Tx) -> bool {
-    if tx.tx_kind != 0x00
-        || tx.tx_nonce != 0
-        || tx.inputs.len() != 1
-        || !tx.witness.is_empty()
-        || !tx.da_payload.is_empty()
-    {
-        return false;
-    }
-    let input = &tx.inputs[0];
-    input.prev_txid == [0u8; 32]
-        && input.prev_vout == u32::MAX
-        && input.script_sig.is_empty()
-        && input.sequence == u32::MAX
-}
-
-fn validate_header_commitments(
-    pb: &ParsedBlock,
-    expected_prev_hash: Option<[u8; 32]>,
-    expected_target: Option<[u8; 32]>,
-) -> Result<(), TxError> {
-    pow_check(&pb.header_bytes, pb.header.target)?;
-
-    if let Some(target) = expected_target {
-        if pb.header.target != target {
-            return Err(TxError::new(
-                ErrorCode::BlockErrTargetInvalid,
-                "target mismatch",
-            ));
-        }
-    }
-
-    if let Some(prev) = expected_prev_hash {
-        if pb.header.prev_block_hash != prev {
-            return Err(TxError::new(
-                ErrorCode::BlockErrLinkageInvalid,
-                "prev_block_hash mismatch",
-            ));
-        }
-    }
-
-    let root = merkle_root_txids(&pb.txids)
-        .map_err(|_| TxError::new(ErrorCode::BlockErrMerkleInvalid, "failed to compute merkle"))?;
-    if root != pb.header.merkle_root {
-        return Err(TxError::new(
-            ErrorCode::BlockErrMerkleInvalid,
-            "merkle_root mismatch",
-        ));
-    }
-    Ok(())
-}
-
-fn validate_coinbase_structure(pb: &ParsedBlock, block_height: u64) -> Result<(), TxError> {
-    let coinbase = pb
-        .txs
-        .first()
-        .ok_or_else(|| TxError::new(ErrorCode::BlockErrCoinbaseInvalid, "missing coinbase"))?;
-
-    if !is_coinbase_tx(coinbase) {
-        return Err(TxError::new(
-            ErrorCode::BlockErrCoinbaseInvalid,
-            "first tx is not canonical coinbase",
-        ));
-    }
-    if coinbase.outputs.is_empty() {
-        return Err(TxError::new(
-            ErrorCode::BlockErrCoinbaseInvalid,
-            "coinbase must have at least one output",
-        ));
-    }
-
-    let expected_locktime = u32::try_from(block_height)
-        .map_err(|_| TxError::new(ErrorCode::BlockErrCoinbaseInvalid, "height out of range"))?;
-    if coinbase.locktime != expected_locktime {
-        return Err(TxError::new(
-            ErrorCode::BlockErrCoinbaseInvalid,
-            "coinbase locktime must equal block height",
-        ));
-    }
-    Ok(())
-}
-
 fn accumulate_block_tx_stats(pb: &ParsedBlock, block_height: u64) -> Result<BlockTxStats, TxError> {
     let mut stats = BlockTxStats {
         sum_weight: 0,
@@ -269,7 +199,7 @@ fn accumulate_block_tx_stats(pb: &ParsedBlock, block_height: u64) -> Result<Bloc
     let mut seen_nonces: HashMap<u64, ()> = HashMap::with_capacity(pb.txs.len());
     for (i, tx) in pb.txs.iter().enumerate() {
         if i > 0 {
-            if is_coinbase_tx(tx) {
+            if coinbase::is_coinbase_tx(tx) {
                 return Err(TxError::new(
                     ErrorCode::BlockErrCoinbaseInvalid,
                     "coinbase-like tx found at index > 0",
@@ -326,135 +256,6 @@ fn validate_block_resource_limits(stats: BlockTxStats) -> Result<(), TxError> {
         ));
     }
     Ok(())
-}
-
-pub(crate) fn validate_coinbase_value_bound(
-    pb: &ParsedBlock,
-    block_height: u64,
-    already_generated: u128,
-    sum_fees: u64,
-) -> Result<(), TxError> {
-    if block_height == 0 {
-        return Ok(());
-    }
-    if pb.txs.is_empty() {
-        return Err(TxError::new(
-            ErrorCode::BlockErrCoinbaseInvalid,
-            "missing coinbase",
-        ));
-    }
-    let coinbase = &pb.txs[0];
-
-    let mut sum_coinbase: u128 = 0;
-    for out in &coinbase.outputs {
-        sum_coinbase = sum_coinbase
-            .checked_add(out.value as u128)
-            .ok_or_else(|| TxError::new(ErrorCode::BlockErrParse, "u128 overflow"))?;
-    }
-
-    let subsidy = block_subsidy(block_height, already_generated);
-    let limit = (subsidy as u128)
-        .checked_add(sum_fees as u128)
-        .ok_or_else(|| TxError::new(ErrorCode::BlockErrParse, "u128 overflow"))?;
-    if sum_coinbase > limit {
-        return Err(TxError::new(
-            ErrorCode::BlockErrSubsidyExceeded,
-            "coinbase outputs exceed subsidy+fees bound",
-        ));
-    }
-    Ok(())
-}
-
-fn validate_coinbase_witness_commitment(pb: &ParsedBlock) -> Result<(), TxError> {
-    if pb.txs.is_empty() || pb.wtxids.is_empty() {
-        return Err(TxError::new(
-            ErrorCode::BlockErrCoinbaseInvalid,
-            "missing coinbase",
-        ));
-    }
-
-    let wroot = witness_merkle_root_wtxids(&pb.wtxids).map_err(|_| {
-        TxError::new(
-            ErrorCode::BlockErrWitnessCommitment,
-            "failed to compute witness merkle root",
-        )
-    })?;
-    let expected = witness_commitment_hash(wroot);
-
-    let mut matches = 0u64;
-    for out in &pb.txs[0].outputs {
-        if out.covenant_type != COV_TYPE_ANCHOR || out.covenant_data.len() != 32 {
-            continue;
-        }
-        if out.covenant_data.as_slice() == &expected[..] {
-            matches += 1;
-        }
-    }
-
-    if matches != 1 {
-        return Err(TxError::new(
-            ErrorCode::BlockErrWitnessCommitment,
-            "coinbase witness commitment missing or duplicated",
-        ));
-    }
-    Ok(())
-}
-
-fn validate_timestamp_rules(
-    header_timestamp: u64,
-    block_height: u64,
-    prev_timestamps: Option<&[u64]>,
-) -> Result<(), TxError> {
-    let Some(median) = median_time_past(block_height, prev_timestamps)? else {
-        return Ok(());
-    };
-    if header_timestamp <= median {
-        return Err(TxError::new(
-            ErrorCode::BlockErrTimestampOld,
-            "timestamp <= MTP median",
-        ));
-    }
-    let upper_bound = median.saturating_add(MAX_FUTURE_DRIFT);
-    if header_timestamp > upper_bound {
-        return Err(TxError::new(
-            ErrorCode::BlockErrTimestampFuture,
-            "timestamp exceeds future drift",
-        ));
-    }
-    Ok(())
-}
-
-pub(crate) fn median_time_past(
-    block_height: u64,
-    prev_timestamps: Option<&[u64]>,
-) -> Result<Option<u64>, TxError> {
-    if block_height == 0 {
-        return Ok(None);
-    }
-    let Some(prev) = prev_timestamps else {
-        return Ok(None);
-    };
-    if prev.is_empty() {
-        return Ok(None);
-    }
-
-    let k = usize::try_from(block_height.min(11)).unwrap_or(11);
-    if prev.len() < k {
-        return Err(TxError::new(
-            ErrorCode::BlockErrParse,
-            "insufficient prev_timestamps context",
-        ));
-    }
-
-    let mut window = prev[..k].to_vec();
-    window.sort_unstable();
-    Ok(Some(window[(window.len() - 1) / 2]))
-}
-
-#[derive(Clone)]
-struct DaCommitSet {
-    tx: Tx,
-    chunk_count: u16,
 }
 
 fn validate_da_set_integrity(txs: &[Tx]) -> Result<(), TxError> {
@@ -572,8 +373,6 @@ fn validate_da_set_integrity(txs: &[Tx]) -> Result<(), TxError> {
         }
         let payload_commitment = sha3_256(&concat);
 
-        // CANONICAL §21.4: commit tx MUST contain exactly one CORE_DA_COMMIT output whose
-        // covenant_data equals the payload commitment hash (missing/duplicate are invalid).
         let mut da_commit_outputs: u32 = 0;
         let mut got_commitment = [0u8; 32];
         for o in &commit.tx.outputs {
@@ -609,7 +408,7 @@ fn sorted_da_ids<T>(m: &HashMap<[u8; 32], T>) -> Vec<[u8; 32]> {
 }
 
 fn tx_weight_and_stats(tx: &Tx) -> Result<(u64, u64, u64), TxError> {
-    let mut base_size: u64 = 4 + 1 + 8; // version + tx_kind + tx_nonce
+    let mut base_size: u64 = 4 + 1 + 8;
     base_size = base_size
         .checked_add(compact_size_len(tx.inputs.len() as u64))
         .ok_or_else(|| TxError::new(ErrorCode::TxErrParse, "u64 overflow"))?;
@@ -642,7 +441,9 @@ fn tx_weight_and_stats(tx: &Tx) -> Result<(u64, u64, u64), TxError> {
         base_size = base_size
             .checked_add(cov_len)
             .ok_or_else(|| TxError::new(ErrorCode::TxErrParse, "u64 overflow"))?;
-        if o.covenant_type == COV_TYPE_ANCHOR || o.covenant_type == COV_TYPE_DA_COMMIT {
+        if o.covenant_type == crate::constants::COV_TYPE_ANCHOR
+            || o.covenant_type == COV_TYPE_DA_COMMIT
+        {
             anchor_bytes = anchor_bytes
                 .checked_add(cov_len)
                 .ok_or_else(|| TxError::new(ErrorCode::TxErrParse, "u64 overflow"))?;
@@ -650,7 +451,7 @@ fn tx_weight_and_stats(tx: &Tx) -> Result<(u64, u64, u64), TxError> {
     }
     base_size = base_size
         .checked_add(4)
-        .ok_or_else(|| TxError::new(ErrorCode::TxErrParse, "u64 overflow"))?; // locktime
+        .ok_or_else(|| TxError::new(ErrorCode::TxErrParse, "u64 overflow"))?;
     base_size = base_size
         .checked_add(da_core_fields_bytes(tx)?.len() as u64)
         .ok_or_else(|| TxError::new(ErrorCode::TxErrParse, "u64 overflow"))?;
@@ -726,17 +527,11 @@ fn compact_size_len(n: u64) -> u64 {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Kani bounded model checking proofs
-// ---------------------------------------------------------------------------
 #[cfg(kani)]
 mod verification {
-    use super::*;
+    use super::compact_size_len;
     use crate::compactsize::encode_compact_size;
 
-    /// compact_size_len(n) matches the actual encoded length from
-    /// encode_compact_size(n) for every u64.  This cross-checks the two
-    /// independent implementations (weight accounting vs wire encoding).
     #[kani::proof]
     fn verify_compact_size_len_matches_encode() {
         let n: u64 = kani::any();

--- a/clients/rust/crates/rubin-consensus/src/block_basic/coinbase.rs
+++ b/clients/rust/crates/rubin-consensus/src/block_basic/coinbase.rs
@@ -1,0 +1,125 @@
+use super::*;
+use crate::constants::COV_TYPE_ANCHOR;
+use crate::merkle::{witness_commitment_hash, witness_merkle_root_wtxids};
+use crate::subsidy::block_subsidy;
+
+pub(super) fn is_coinbase_tx(tx: &Tx) -> bool {
+    if tx.tx_kind != 0x00
+        || tx.tx_nonce != 0
+        || tx.inputs.len() != 1
+        || !tx.witness.is_empty()
+        || !tx.da_payload.is_empty()
+    {
+        return false;
+    }
+    let input = &tx.inputs[0];
+    input.prev_txid == [0u8; 32]
+        && input.prev_vout == u32::MAX
+        && input.script_sig.is_empty()
+        && input.sequence == u32::MAX
+}
+
+pub(super) fn validate_coinbase_structure(
+    pb: &ParsedBlock,
+    block_height: u64,
+) -> Result<(), TxError> {
+    let coinbase = pb
+        .txs
+        .first()
+        .ok_or_else(|| TxError::new(ErrorCode::BlockErrCoinbaseInvalid, "missing coinbase"))?;
+
+    if !is_coinbase_tx(coinbase) {
+        return Err(TxError::new(
+            ErrorCode::BlockErrCoinbaseInvalid,
+            "first tx is not canonical coinbase",
+        ));
+    }
+    if coinbase.outputs.is_empty() {
+        return Err(TxError::new(
+            ErrorCode::BlockErrCoinbaseInvalid,
+            "coinbase must have at least one output",
+        ));
+    }
+
+    let expected_locktime = u32::try_from(block_height)
+        .map_err(|_| TxError::new(ErrorCode::BlockErrCoinbaseInvalid, "height out of range"))?;
+    if coinbase.locktime != expected_locktime {
+        return Err(TxError::new(
+            ErrorCode::BlockErrCoinbaseInvalid,
+            "coinbase locktime must equal block height",
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_coinbase_value_bound(
+    pb: &ParsedBlock,
+    block_height: u64,
+    already_generated: u128,
+    sum_fees: u64,
+) -> Result<(), TxError> {
+    if block_height == 0 {
+        return Ok(());
+    }
+    if pb.txs.is_empty() {
+        return Err(TxError::new(
+            ErrorCode::BlockErrCoinbaseInvalid,
+            "missing coinbase",
+        ));
+    }
+    let coinbase = &pb.txs[0];
+
+    let mut sum_coinbase: u128 = 0;
+    for out in &coinbase.outputs {
+        sum_coinbase = sum_coinbase
+            .checked_add(out.value as u128)
+            .ok_or_else(|| TxError::new(ErrorCode::BlockErrParse, "u128 overflow"))?;
+    }
+
+    let subsidy = block_subsidy(block_height, already_generated);
+    let limit = (subsidy as u128)
+        .checked_add(sum_fees as u128)
+        .ok_or_else(|| TxError::new(ErrorCode::BlockErrParse, "u128 overflow"))?;
+    if sum_coinbase > limit {
+        return Err(TxError::new(
+            ErrorCode::BlockErrSubsidyExceeded,
+            "coinbase outputs exceed subsidy+fees bound",
+        ));
+    }
+    Ok(())
+}
+
+pub(super) fn validate_coinbase_witness_commitment(pb: &ParsedBlock) -> Result<(), TxError> {
+    if pb.txs.is_empty() || pb.wtxids.is_empty() {
+        return Err(TxError::new(
+            ErrorCode::BlockErrCoinbaseInvalid,
+            "missing coinbase",
+        ));
+    }
+
+    let wroot = witness_merkle_root_wtxids(&pb.wtxids).map_err(|_| {
+        TxError::new(
+            ErrorCode::BlockErrWitnessCommitment,
+            "failed to compute witness merkle root",
+        )
+    })?;
+    let expected = witness_commitment_hash(wroot);
+
+    let mut matches = 0u64;
+    for out in &pb.txs[0].outputs {
+        if out.covenant_type != COV_TYPE_ANCHOR || out.covenant_data.len() != 32 {
+            continue;
+        }
+        if out.covenant_data.as_slice() == &expected[..] {
+            matches += 1;
+        }
+    }
+
+    if matches != 1 {
+        return Err(TxError::new(
+            ErrorCode::BlockErrWitnessCommitment,
+            "coinbase witness commitment missing or duplicated",
+        ));
+    }
+    Ok(())
+}

--- a/clients/rust/crates/rubin-consensus/src/block_basic/header.rs
+++ b/clients/rust/crates/rubin-consensus/src/block_basic/header.rs
@@ -1,0 +1,90 @@
+use super::*;
+use crate::merkle::merkle_root_txids;
+use crate::pow::pow_check;
+
+pub(super) fn validate_header_commitments(
+    pb: &ParsedBlock,
+    expected_prev_hash: Option<[u8; 32]>,
+    expected_target: Option<[u8; 32]>,
+) -> Result<(), TxError> {
+    pow_check(&pb.header_bytes, pb.header.target)?;
+
+    if let Some(target) = expected_target {
+        if pb.header.target != target {
+            return Err(TxError::new(
+                ErrorCode::BlockErrTargetInvalid,
+                "target mismatch",
+            ));
+        }
+    }
+
+    if let Some(prev) = expected_prev_hash {
+        if pb.header.prev_block_hash != prev {
+            return Err(TxError::new(
+                ErrorCode::BlockErrLinkageInvalid,
+                "prev_block_hash mismatch",
+            ));
+        }
+    }
+
+    let root = merkle_root_txids(&pb.txids)
+        .map_err(|_| TxError::new(ErrorCode::BlockErrMerkleInvalid, "failed to compute merkle"))?;
+    if root != pb.header.merkle_root {
+        return Err(TxError::new(
+            ErrorCode::BlockErrMerkleInvalid,
+            "merkle_root mismatch",
+        ));
+    }
+    Ok(())
+}
+
+pub(super) fn validate_timestamp_rules(
+    header_timestamp: u64,
+    block_height: u64,
+    prev_timestamps: Option<&[u64]>,
+) -> Result<(), TxError> {
+    let Some(median) = median_time_past(block_height, prev_timestamps)? else {
+        return Ok(());
+    };
+    if header_timestamp <= median {
+        return Err(TxError::new(
+            ErrorCode::BlockErrTimestampOld,
+            "timestamp <= MTP median",
+        ));
+    }
+    let upper_bound = median.saturating_add(crate::constants::MAX_FUTURE_DRIFT);
+    if header_timestamp > upper_bound {
+        return Err(TxError::new(
+            ErrorCode::BlockErrTimestampFuture,
+            "timestamp exceeds future drift",
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) fn median_time_past(
+    block_height: u64,
+    prev_timestamps: Option<&[u64]>,
+) -> Result<Option<u64>, TxError> {
+    if block_height == 0 {
+        return Ok(None);
+    }
+    let Some(prev) = prev_timestamps else {
+        return Ok(None);
+    };
+    if prev.is_empty() {
+        return Ok(None);
+    }
+
+    let k = usize::try_from(block_height.min(11)).unwrap_or(11);
+    if prev.len() < k {
+        return Err(TxError::new(
+            ErrorCode::BlockErrParse,
+            "insufficient prev_timestamps context",
+        ));
+    }
+
+    let mut window = prev[..k].to_vec();
+    window.sort_unstable();
+    Ok(Some(window[(window.len() - 1) / 2]))
+}


### PR DESCRIPTION
Q-DUPLICATION-04

- mechanically split Go and Rust `block_basic` helpers into separate files/modules
- preserved public API, call order, and validation sequencing
- no intended consensus behavior change

Validation:
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./...'`
- `scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test -p rubin-consensus'`
