### PR TITLE
[Q-FORMAL-TRACE-01] tighten Go→Lean trace coverage + public sanity gate

### DIFF
--- a/.github/workflows/spec-checks.yml
+++ b/.github/workflows/spec-checks.yml
@@ -16,5 +16,7 @@ jobs:
           node-version-file: '.node-version'
       - name: Conformance fixtures policy check
         run: python3 tools/check_conformance_fixtures_policy.py
+      - name: Conformance edge-pack coverage check
+        run: python3 tools/check_conformance_edge_pack.py
       - name: Conformance matrix check
         run: python3 tools/gen_conformance_matrix.py --check

--- a/clients/go/cmd/formal-trace/main.go
+++ b/clients/go/cmd/formal-trace/main.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha3"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -190,6 +191,59 @@ type blockBasicVector struct {
 	ExpectOk       bool   `json:"expect_ok"`
 }
 
+type weightFixture struct {
+	Gate    string         `json:"gate"`
+	Vectors []weightVector `json:"vectors"`
+}
+
+type weightVector struct {
+	ID                string `json:"id"`
+	Op                string `json:"op"`
+	TxHex             string `json:"tx_hex"`
+	ExpectErr         string `json:"expect_err"`
+	ExpectWeight      uint64 `json:"expect_weight"`
+	ExpectDaBytes     uint64 `json:"expect_da_bytes"`
+	ExpectAnchorBytes uint64 `json:"expect_anchor_bytes"`
+	ExpectOk          bool   `json:"expect_ok"`
+}
+
+type validationOrderFixture struct {
+	Gate    string                  `json:"gate"`
+	Vectors []validationOrderVector `json:"vectors"`
+}
+
+type validationOrderVector struct {
+	ID              string                `json:"id"`
+	Op              string                `json:"op"`
+	Checks          []validationCheckJSON `json:"checks"`
+	ExpectFirstErr  string                `json:"expect_first_err"`
+	ExpectEvaluated []string              `json:"expect_evaluated"`
+	ExpectOk        bool                  `json:"expect_ok"`
+}
+
+type validationCheckJSON struct {
+	Name  string `json:"name"`
+	Fails bool   `json:"fails"`
+	Err   string `json:"err"`
+}
+
+type daIntegrityFixture struct {
+	Gate    string              `json:"gate"`
+	Vectors []daIntegrityVector `json:"vectors"`
+}
+
+type daIntegrityVector struct {
+	PrevTimestamps []uint64 `json:"prev_timestamps"`
+	ID             string   `json:"id"`
+	Op             string   `json:"op"`
+	BlockHex       string   `json:"block_hex"`
+	ExpectedPrev   string   `json:"expected_prev_hash"`
+	ExpectedTarget string   `json:"expected_target"`
+	ExpectErr      string   `json:"expect_err"`
+	Height         uint64   `json:"height"`
+	ExpectOk       bool     `json:"expect_ok"`
+}
+
 var writeJSONFn = writeJSON
 
 func mustGitCommit() string {
@@ -214,19 +268,27 @@ func sha3hex(b []byte) string {
 }
 
 func listFixtureNames(dir string) ([]string, error) {
-	entries, err := os.ReadDir(dir)
+	info, err := os.Stat(dir)
 	if err != nil {
 		return nil, err
 	}
-	names := make([]string, 0, len(entries))
-	for _, entry := range entries {
-		if entry.IsDir() {
+	if !info.IsDir() {
+		return nil, fmt.Errorf("not a directory: %s", dir)
+	}
+	matches, err := filepath.Glob(filepath.Join(dir, "CV-*.json"))
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(matches))
+	for _, match := range matches {
+		info, err := os.Stat(match)
+		if err != nil {
+			return nil, err
+		}
+		if info.IsDir() {
 			continue
 		}
-		name := entry.Name()
-		if strings.HasPrefix(name, "CV-") && strings.HasSuffix(name, ".json") {
-			names = append(names, entry.Name())
-		}
+		names = append(names, filepath.Base(match))
 	}
 	sort.Strings(names)
 	return names, nil
@@ -310,6 +372,20 @@ func writeTraceEntry(buf *bytes.Buffer, gate string, vectorID string, op string,
 		return fmt.Errorf("write entry: %w", err)
 	}
 	return nil
+}
+
+func evalValidationOrder(checks []validationCheckJSON) (string, []string, error) {
+	if len(checks) == 0 {
+		return "", nil, fmt.Errorf("bad checks")
+	}
+	evaluated := make([]string, 0, len(checks))
+	for _, check := range checks {
+		evaluated = append(evaluated, check.Name)
+		if check.Fails {
+			return check.Err, evaluated, errors.New(check.Err)
+		}
+	}
+	return "", evaluated, nil
 }
 
 func run(fixturesDir, outPath string) error {
@@ -619,6 +695,110 @@ func run(fixturesDir, outPath string) error {
 						"expected_target":           v.ExpectedTarget,
 					},
 					outputs,
+				); err != nil {
+					return err
+				}
+			}
+
+		case "CV-WEIGHT":
+			var fx weightFixture
+			if err := json.Unmarshal(b, &fx); err != nil {
+				return fmt.Errorf("unmarshal %s: %w", filepath.Join(fixturesDir, name), err)
+			}
+			for _, v := range fx.Vectors {
+				if !v.ExpectOk {
+					continue
+				}
+				txBytes, _ := hex.DecodeString(v.TxHex)
+				tx, _, _, _, perr := consensus.ParseTx(txBytes)
+				var runErr error
+				outputs := map[string]any{}
+				if perr != nil {
+					runErr = perr
+				} else {
+					weight, daBytes, anchorBytes, err := consensus.TxWeightAndStats(tx)
+					runErr = err
+					outputs["weight"] = weight
+					outputs["da_bytes"] = daBytes
+					outputs["anchor_bytes"] = anchorBytes
+				}
+				if err := writeTraceEntry(
+					&traceBuf,
+					fx.Gate,
+					v.ID,
+					v.Op,
+					runErr,
+					map[string]any{"tx_hex": v.TxHex},
+					outputs,
+				); err != nil {
+					return err
+				}
+			}
+
+		case "CV-VALIDATION-ORDER":
+			var fx validationOrderFixture
+			if err := json.Unmarshal(b, &fx); err != nil {
+				return fmt.Errorf("unmarshal %s: %w", filepath.Join(fixturesDir, name), err)
+			}
+			for _, v := range fx.Vectors {
+				firstErr, evaluated, runErr := evalValidationOrder(v.Checks)
+				outputs := map[string]any{
+					"evaluated": evaluated,
+				}
+				if firstErr != "" {
+					outputs["first_err"] = firstErr
+				}
+				if err := writeTraceEntry(
+					&traceBuf,
+					fx.Gate,
+					v.ID,
+					v.Op,
+					runErr,
+					map[string]any{"checks_len": len(v.Checks)},
+					outputs,
+				); err != nil {
+					return err
+				}
+			}
+
+		case "CV-DA-INTEGRITY":
+			var fx daIntegrityFixture
+			if err := json.Unmarshal(b, &fx); err != nil {
+				return fmt.Errorf("unmarshal %s: %w", filepath.Join(fixturesDir, name), err)
+			}
+			for _, v := range fx.Vectors {
+				blockBytes, _ := hex.DecodeString(v.BlockHex)
+				prevPtr, prevErr := parseHex32Ptr("expected_prev_hash", v.ExpectedPrev)
+				tgtPtr, tgtErr := parseHex32Ptr("expected_target", v.ExpectedTarget)
+				var runErr error
+				if prevErr != nil {
+					runErr = prevErr
+				}
+				if runErr == nil && tgtErr != nil {
+					runErr = tgtErr
+				}
+				if runErr == nil {
+					_, runErr = consensus.ValidateBlockBasicWithContextAtHeight(
+						blockBytes,
+						prevPtr,
+						tgtPtr,
+						v.Height,
+						v.PrevTimestamps,
+					)
+				}
+				if err := writeTraceEntry(
+					&traceBuf,
+					fx.Gate,
+					v.ID,
+					v.Op,
+					runErr,
+					map[string]any{
+						"block_hex_digest_sha3_256": sha3hex(blockBytes),
+						"expected_prev_hash":        v.ExpectedPrev,
+						"expected_target":           v.ExpectedTarget,
+						"prev_timestamps":           v.PrevTimestamps,
+					},
+					map[string]any{},
 				); err != nil {
 					return err
 				}

--- a/rubin-formal/RubinFormal/Refinement/GoTraceV1.lean
+++ b/rubin-formal/RubinFormal/Refinement/GoTraceV1.lean
@@ -40,6 +40,26 @@ structure BlockBasicOut where
   sumWeight : Option Nat
   sumDa : Option Nat
 
+structure WeightOut where
+  id : String
+  ok : Bool
+  err : String
+  weight : Option Nat
+  daBytes : Option Nat
+  anchorBytes : Option Nat
+
+structure ValidationOrderOut where
+  id : String
+  ok : Bool
+  err : String
+  firstErr : Option String
+  evaluated : List String
+
+structure DaIntegrityOut where
+  id : String
+  ok : Bool
+  err : String
+
 def goTraceFixturesDigestSHA3_256 : String := "acb7a1752bddb3c4f9106d199370858141d6b63c5ed13c39b9c77d469f0123a5"
 
 def parseOuts : List ParseOut := [
@@ -130,6 +150,31 @@ def blockBasicOuts : List BlockBasicOut := [
   { id := "CV-B-11", ok := false, err := "BLOCK_ERR_ANCHOR_BYTES_EXCEEDED", blockHashHex := none, sumWeight := none, sumDa := none },
   { id := "CV-B-12", ok := false, err := "BLOCK_ERR_DA_BATCH_EXCEEDED", blockHashHex := none, sumWeight := none, sumDa := none },
   { id := "CV-B-13", ok := false, err := "BLOCK_ERR_COINBASE_INVALID", blockHashHex := none, sumWeight := none, sumDa := none }
+]
+
+def weightOuts : List WeightOut := [
+  { id := "WEIGHT-01", ok := true, err := "", weight := some 242, daBytes := some 0, anchorBytes := some 0 },
+  { id := "WEIGHT-03", ok := true, err := "", weight := some 374, daBytes := some 0, anchorBytes := some 0 },
+  { id := "WEIGHT-04", ok := true, err := "", weight := some 1107, daBytes := some 1, anchorBytes := some 32 },
+  { id := "WEIGHT-05", ok := true, err := "", weight := some 507, daBytes := some 1, anchorBytes := some 0 }
+]
+
+def validationOrderOuts : List ValidationOrderOut := [
+  { id := "CV-VO-01", ok := false, err := "BLOCK_ERR_PARSE", firstErr := some "BLOCK_ERR_PARSE", evaluated := ["parse"] },
+  { id := "CV-VO-02", ok := false, err := "BLOCK_ERR_TARGET_INVALID", firstErr := some "BLOCK_ERR_TARGET_INVALID", evaluated := ["parse", "target_range"] },
+  { id := "CV-VO-03", ok := false, err := "BLOCK_ERR_WEIGHT_EXCEEDED", firstErr := some "BLOCK_ERR_WEIGHT_EXCEEDED", evaluated := ["parse", "target_range", "pow", "expected_target", "linkage", "merkle", "witness_commitment", "timestamp", "weight"] },
+  { id := "CV-VO-04", ok := false, err := "TX_ERR_SIG_INVALID", firstErr := some "TX_ERR_SIG_INVALID", evaluated := ["cursor_p2pk", "cursor_htlc", "cursor_vault", "sig_threshold_vault"] },
+  { id := "CV-VO-05", ok := false, err := "BLOCK_ERR_WEIGHT_EXCEEDED", firstErr := some "BLOCK_ERR_WEIGHT_EXCEEDED", evaluated := ["parse", "target_range", "pow", "expected_target", "linkage", "merkle", "witness_commitment", "timestamp", "weight"] }
+]
+
+def daIntegrityOuts : List DaIntegrityOut := [
+  { id := "CV-DA-01", ok := true, err := "" },
+  { id := "CV-DA-02", ok := false, err := "BLOCK_ERR_DA_CHUNK_HASH_INVALID" },
+  { id := "CV-DA-03", ok := false, err := "BLOCK_ERR_DA_INCOMPLETE" },
+  { id := "CV-DA-04", ok := false, err := "BLOCK_ERR_DA_PAYLOAD_COMMIT_INVALID" },
+  { id := "CV-DA-05", ok := false, err := "BLOCK_ERR_DA_SET_INVALID" },
+  { id := "CV-DA-06", ok := false, err := "TX_ERR_PARSE" },
+  { id := "CV-DA-CHUNK-COUNT-ZERO", ok := false, err := "TX_ERR_PARSE" }
 ]
 
 end RubinFormal.Refinement

--- a/rubin-formal/RubinFormal/Refinement/GoTraceV1Check.lean
+++ b/rubin-formal/RubinFormal/Refinement/GoTraceV1Check.lean
@@ -6,6 +6,7 @@ import RubinFormal.PowV1
 import RubinFormal.TxWeightV2
 import RubinFormal.UtxoBasicV1
 import RubinFormal.BlockBasicV1
+import RubinFormal.DaIntegrityV1
 import RubinFormal.Refinement.GoTraceV1
 
 import RubinFormal.Conformance.CVParseVectors
@@ -13,6 +14,9 @@ import RubinFormal.Conformance.CVSighashVectors
 import RubinFormal.Conformance.CVPowVectors
 import RubinFormal.Conformance.CVUtxoBasicVectors
 import RubinFormal.Conformance.CVBlockBasicVectors
+import RubinFormal.Conformance.CVWeightVectors
+import RubinFormal.Conformance.CVValidationOrderVectors
+import RubinFormal.Conformance.CVDaIntegrityVectors
 
 set_option maxHeartbeats 10000000
 set_option maxRecDepth 50000
@@ -69,9 +73,7 @@ private def isKnownUtxoAcceptDrift (id expectedErr : String) : Bool :=
 
 private def checkParse (o : ParseOut) : Bool :=
   match findById? o.id RubinFormal.Conformance.cvParseVectors (fun v => v.id) with
-  -- Vector not in Lean model scope (toy-model phase0): skip rather than fail.
-  -- Ensures refinement only fails when the model has a prediction that disagrees with Go.
-  | none => true
+  | none => false
   | some v =>
       match RubinFormal.decodeHex? v.txHex with
       | none => false
@@ -170,7 +172,7 @@ private def toUtxoPairs? (us : List RubinFormal.Conformance.CVUtxoEntry) : Optio
 
 private def checkUtxoBasic (o : UtxoBasicOut) : Bool :=
   match findById? o.id RubinFormal.Conformance.cvUtxoBasicVectors (fun v => v.id) with
-  | none => true
+  | none => false
   | some v =>
       match RubinFormal.decodeHex? v.txHex, toUtxoPairs? v.utxos with
       | some tx, some utxos =>
@@ -214,7 +216,7 @@ private def isKnownBlockDrift (id _gotErr expectedErr : String) : Bool :=
 
 private def checkBlockBasic (o : BlockBasicOut) : Bool :=
   match findById? o.id RubinFormal.Conformance.cvBlockBasicVectors (fun v => v.id) with
-  | none => true
+  | none => false
   | some v =>
       match RubinFormal.decodeHex? v.blockHex with
       | none => false
@@ -238,12 +240,67 @@ private def checkBlockBasic (o : BlockBasicOut) : Bool :=
           | .error e =>
               (!o.ok) && (o.err == e || isKnownBlockDrift o.id e o.err)
 
+private def checkWeight (o : WeightOut) : Bool :=
+  match findById? o.id RubinFormal.Conformance.cvWeightVectors (fun v => v.id) with
+  | none => false
+  | some v =>
+      match RubinFormal.decodeHex? v.txHex with
+      | none => false
+      | some tx =>
+          match TxWeightV2.txWeightAndStats tx with
+          | .ok st =>
+              o.ok &&
+              o.weight == some st.weight &&
+              o.daBytes == some st.daBytes &&
+              o.anchorBytes == some st.anchorBytes
+          | .error e =>
+              (!o.ok) && (o.err == e)
+
+private def evalOrder (checks : List RubinFormal.Conformance.ValidationCheck) : (Option String) × (List String) :=
+  let rec go (rest : List RubinFormal.Conformance.ValidationCheck) (evaluated : List String) : (Option String) × (List String) :=
+    match rest with
+    | [] => (none, evaluated)
+    | c :: cs =>
+        let evaluated' := evaluated ++ [c.name]
+        if c.fails then
+          (some c.err, evaluated')
+        else
+          go cs evaluated'
+  go checks []
+
+private def checkValidationOrder (o : ValidationOrderOut) : Bool :=
+  match findById? o.id RubinFormal.Conformance.cvValidationOrderVectors (fun v => v.id) with
+  | none => false
+  | some v =>
+      let (firstErr, evaluated) := evalOrder v.checks
+      let ok := firstErr.isNone
+      (o.ok == ok) &&
+      (o.firstErr == firstErr) &&
+      (o.evaluated == evaluated) &&
+      (if ok then o.err == "" else o.err == firstErr.getD "")
+
+private def checkDaIntegrity (o : DaIntegrityOut) : Bool :=
+  match findById? o.id RubinFormal.Conformance.cvDaIntegrityVectors (fun v => v.id) with
+  | none => false
+  | some v =>
+      match RubinFormal.decodeHex? v.blockHex with
+      | none => false
+      | some blockBytes =>
+          let ph := decodeHexOpt? v.expectedPrevHashHex
+          let tgt := decodeHexOpt? v.expectedTargetHex
+          match RubinFormal.DaIntegrityV1.validateDaIntegrityGate blockBytes ph tgt with
+          | .ok _ => o.ok
+          | .error e => (!o.ok) && (o.err == e)
+
 def allGoTraceV1Ok : Bool :=
   parseOuts.all checkParse &&
   sighashOuts.all checkSighash &&
   powOuts.all checkPow &&
   utxoBasicOuts.all checkUtxoBasic &&
-  blockBasicOuts.all checkBlockBasic
+  blockBasicOuts.all checkBlockBasic &&
+  weightOuts.all checkWeight &&
+  validationOrderOuts.all checkValidationOrder &&
+  daIntegrityOuts.all checkDaIntegrity
 
 def firstGoTraceV1Mismatch : Option String :=
   let mk (gate : String) (id : String) : Option String := some (gate ++ ":" ++ id)
@@ -261,6 +318,15 @@ def firstGoTraceV1Mismatch : Option String :=
               | none =>
                   match blockBasicOuts.find? (fun o => !checkBlockBasic o) with
                   | some o => mk "CV-BLOCK-BASIC" o.id
-                  | none => none
+                  | none =>
+                      match weightOuts.find? (fun o => !checkWeight o) with
+                      | some o => mk "CV-WEIGHT" o.id
+                      | none =>
+                          match validationOrderOuts.find? (fun o => !checkValidationOrder o) with
+                          | some o => mk "CV-VALIDATION-ORDER" o.id
+                          | none =>
+                              match daIntegrityOuts.find? (fun o => !checkDaIntegrity o) with
+                              | some o => mk "CV-DA-INTEGRITY" o.id
+                              | none => none
 
 end RubinFormal.Refinement

--- a/tools/formal/gen_lean_refinement_from_traces.py
+++ b/tools/formal/gen_lean_refinement_from_traces.py
@@ -83,6 +83,25 @@ def _lean_opt_hex(x: Any) -> str:
     return f"some ({_lean_str(_hex0x(x))})"
 
 
+def _lean_opt_str(x: Any) -> str:
+    if x is None:
+        return "none"
+    if not isinstance(x, str):
+        _fail(f"expected string, got: {type(x)}")
+    return f"some {_lean_str(x)}"
+
+
+def _lean_str_list(x: Any) -> str:
+    if not isinstance(x, list):
+        _fail(f"expected list[str], got: {type(x)}")
+    out: list[str] = []
+    for item in x:
+        if not isinstance(item, str):
+            _fail(f"expected string element, got: {type(item)}")
+        out.append(_lean_str(item))
+    return "[" + ", ".join(out) + "]"
+
+
 def _require_keys(obj: dict[str, Any], keys: list[str], ctx: str) -> None:
     for k in keys:
         if k not in obj:
@@ -95,6 +114,9 @@ def _emit_go_trace_v1(header: Header, entries: list[dict[str, Any]]) -> str:
     pow_rows: list[tuple[str, str]] = []
     utxo_rows: list[tuple[str, str]] = []
     block_rows: list[tuple[str, str]] = []
+    weight_rows: list[tuple[str, str]] = []
+    validation_order_rows: list[tuple[str, str]] = []
+    da_integrity_rows: list[tuple[str, str]] = []
 
     for e in entries:
         gate = str(e.get("gate", ""))
@@ -190,6 +212,49 @@ def _emit_go_trace_v1(header: Header, entries: list[dict[str, Any]]) -> str:
                 + _lean_opt_nat(outputs.get("sum_da"))
                 + " }"
             ))
+        elif gate == "CV-WEIGHT":
+            weight_rows.append((
+                vector_id,
+                "{ id := "
+                + _lean_str(vector_id)
+                + ", ok := "
+                + ("true" if ok else "false")
+                + ", err := "
+                + _lean_str(err)
+                + ", weight := "
+                + _lean_opt_nat(outputs.get("weight"))
+                + ", daBytes := "
+                + _lean_opt_nat(outputs.get("da_bytes"))
+                + ", anchorBytes := "
+                + _lean_opt_nat(outputs.get("anchor_bytes"))
+                + " }"
+            ))
+        elif gate == "CV-VALIDATION-ORDER":
+            validation_order_rows.append((
+                vector_id,
+                "{ id := "
+                + _lean_str(vector_id)
+                + ", ok := "
+                + ("true" if ok else "false")
+                + ", err := "
+                + _lean_str(err)
+                + ", firstErr := "
+                + _lean_opt_str(outputs.get("first_err"))
+                + ", evaluated := "
+                + _lean_str_list(outputs.get("evaluated", []))
+                + " }"
+            ))
+        elif gate == "CV-DA-INTEGRITY":
+            da_integrity_rows.append((
+                vector_id,
+                "{ id := "
+                + _lean_str(vector_id)
+                + ", ok := "
+                + ("true" if ok else "false")
+                + ", err := "
+                + _lean_str(err)
+                + " }"
+            ))
         else:
             # non-critical gate for refinement: ignore
             continue
@@ -245,6 +310,26 @@ def _emit_go_trace_v1(header: Header, entries: list[dict[str, Any]]) -> str:
     out.append("  sumWeight : Option Nat")
     out.append("  sumDa : Option Nat")
     out.append("")
+    out.append("structure WeightOut where")
+    out.append("  id : String")
+    out.append("  ok : Bool")
+    out.append("  err : String")
+    out.append("  weight : Option Nat")
+    out.append("  daBytes : Option Nat")
+    out.append("  anchorBytes : Option Nat")
+    out.append("")
+    out.append("structure ValidationOrderOut where")
+    out.append("  id : String")
+    out.append("  ok : Bool")
+    out.append("  err : String")
+    out.append("  firstErr : Option String")
+    out.append("  evaluated : List String")
+    out.append("")
+    out.append("structure DaIntegrityOut where")
+    out.append("  id : String")
+    out.append("  ok : Bool")
+    out.append("  err : String")
+    out.append("")
     # Do not embed current repo commit into generated Lean module.
     # Otherwise `git diff --exit-code` in CI would fail on every commit
     # even when trace semantics are unchanged.
@@ -255,6 +340,9 @@ def _emit_go_trace_v1(header: Header, entries: list[dict[str, Any]]) -> str:
     out.append(list_block("powOuts", "PowOut", pow_rows))
     out.append(list_block("utxoBasicOuts", "UtxoBasicOut", utxo_rows))
     out.append(list_block("blockBasicOuts", "BlockBasicOut", block_rows))
+    out.append(list_block("weightOuts", "WeightOut", weight_rows))
+    out.append(list_block("validationOrderOuts", "ValidationOrderOut", validation_order_rows))
+    out.append(list_block("daIntegrityOuts", "DaIntegrityOut", da_integrity_rows))
     out.append("end RubinFormal.Refinement")
     out.append("")
     return "\n".join(out)


### PR DESCRIPTION
## Summary
- add edge-pack enforcement to `public-sanity`
- extend Go formal-trace + generated `GoTraceV1.lean` for `CV-WEIGHT`, `CV-VALIDATION-ORDER`, `CV-DA-INTEGRITY`
- tighten embedded `GoTraceV1Check.lean` so missing vectors fail instead of being silently accepted

## Validation
- `python3 tools/check_conformance_fixtures_policy.py`
- `python3 tools/check_conformance_edge_pack.py`
- `python3 tools/gen_conformance_matrix.py --check`
- `go run ./clients/go/cmd/formal-trace --fixtures-dir ./conformance/fixtures --out ./rubin-formal/traces/go_trace_v1.jsonl`
- `python3 tools/formal/gen_lean_refinement_from_traces.py --traces rubin-formal/traces/go_trace_v1.jsonl --out rubin-formal/RubinFormal/Refinement/GoTraceV1.lean`
- `cd rubin-formal && lake build RubinFormal.Refinement.GoTraceV1Check`
- `cd rubin-formal && lake env lean --run RubinFormal/Refinement/Main.lean`

Closes #470
