### PR TITLE
fix: eliminate narrowing cast in featurebits evaluator

### DIFF
--- a/clients/go/consensus/featurebits.go
+++ b/clients/go/consensus/featurebits.go
@@ -83,11 +83,10 @@ func FeatureBitStateAtHeightFromWindowCounts(
 	boundaryHeight := height - (height % SIGNAL_WINDOW)
 	targetBoundaryIndex := boundaryHeight / SIGNAL_WINDOW
 
-	needWindows := int(targetBoundaryIndex)
-	if len(windowSignalCounts) < needWindows {
+	if uint64(len(windowSignalCounts)) < targetBoundaryIndex {
 		return FeatureBitEval{}, fmt.Errorf(
 			"featurebits: need %d window_signal_counts entries, got %d",
-			needWindows,
+			targetBoundaryIndex,
 			len(windowSignalCounts),
 		)
 	}

--- a/clients/go/consensus/featurebits_test.go
+++ b/clients/go/consensus/featurebits_test.go
@@ -114,6 +114,43 @@ func TestFeatureBits_StateBetweenBoundaries(t *testing.T) {
 	}
 }
 
+func TestFeatureBits_LargeHeightNoNarrowingOverflow(t *testing.T) {
+	d := FeatureBitDeployment{
+		Name:          "X",
+		Bit:           0,
+		StartHeight:   0,
+		TimeoutHeight: 1<<63 - 1,
+	}
+	// height that produces targetBoundaryIndex > math.MaxInt32.
+	// boundaryHeight = height - (height % 2016) ≈ height
+	// targetBoundaryIndex = boundaryHeight / 2016 ≈ 2^32
+	// Old code: int(2^32) on 32-bit platform → overflow → wrong comparison.
+	largeHeight := uint64(SIGNAL_WINDOW) * (1<<32 + 1)
+	_, err := FeatureBitStateAtHeightFromWindowCounts(d, largeHeight, nil)
+	if err == nil {
+		t.Fatalf("expected error for large height with insufficient window counts")
+	}
+	expected := "featurebits: need"
+	if got := err.Error(); len(got) < len(expected) || got[:len(expected)] != expected {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestFeatureBits_MaxUint64Height(t *testing.T) {
+	d := FeatureBitDeployment{
+		Name:          "X",
+		Bit:           0,
+		StartHeight:   0,
+		TimeoutHeight: 1<<63 - 1,
+	}
+	// maxHeight aligned to SIGNAL_WINDOW boundary
+	maxHeight := uint64(1<<64-1) - (uint64(1<<64-1) % SIGNAL_WINDOW)
+	_, err := FeatureBitStateAtHeightFromWindowCounts(d, maxHeight, nil)
+	if err == nil {
+		t.Fatalf("expected error for max height with nil counts")
+	}
+}
+
 func TestFeatureBits_BitRange(t *testing.T) {
 	d := FeatureBitDeployment{
 		Name:          "X",

--- a/clients/rust/crates/rubin-consensus/src/featurebits.rs
+++ b/clients/rust/crates/rubin-consensus/src/featurebits.rs
@@ -85,11 +85,10 @@ pub fn featurebit_state_at_height_from_window_counts(
     let boundary_height = height - (height % SIGNAL_WINDOW);
     let target_boundary_index = boundary_height / SIGNAL_WINDOW;
 
-    let need_windows = target_boundary_index as usize;
-    if window_signal_counts.len() < need_windows {
+    if (window_signal_counts.len() as u64) < target_boundary_index {
         return Err(format!(
             "featurebits: need {} window_signal_counts entries, got {}",
-            need_windows,
+            target_boundary_index,
             window_signal_counts.len()
         ));
     }

--- a/clients/rust/crates/rubin-consensus/src/featurebits_tests.rs
+++ b/clients/rust/crates/rubin-consensus/src/featurebits_tests.rs
@@ -87,6 +87,33 @@ fn featurebits_state_between_boundaries() {
 }
 
 #[test]
+fn featurebits_large_height_no_narrowing_overflow() {
+    let d = FeatureBitDeployment {
+        name: "X".to_string(),
+        bit: 0,
+        start_height: 0,
+        timeout_height: i64::MAX as u64,
+    };
+    // height producing target_boundary_index > u32::MAX
+    let large_height: u64 = SIGNAL_WINDOW * ((1u64 << 32) + 1);
+    let err = featurebit_state_at_height_from_window_counts(&d, large_height, &[]).unwrap_err();
+    assert!(err.contains("need"), "expected 'need' in error, got: {err}");
+}
+
+#[test]
+fn featurebits_max_u64_height() {
+    let d = FeatureBitDeployment {
+        name: "X".to_string(),
+        bit: 0,
+        start_height: 0,
+        timeout_height: i64::MAX as u64,
+    };
+    let max_height: u64 = u64::MAX - (u64::MAX % SIGNAL_WINDOW);
+    let err = featurebit_state_at_height_from_window_counts(&d, max_height, &[]).unwrap_err();
+    assert!(err.contains("need"), "expected 'need' in error, got: {err}");
+}
+
+#[test]
 fn featurebits_bit_range() {
     let d = FeatureBitDeployment {
         name: "X".to_string(),


### PR DESCRIPTION
## Summary
- Replace `int(targetBoundaryIndex)` (Go) and `target_boundary_index as usize` (Rust) with width-stable `uint64`/`u64` comparisons
- Eliminates potential integer overflow on 32-bit platforms (WASM, embedded)
- Adds regression tests for boundary index > `MaxInt32` and `MaxUint64` height

## Task
Q-AUDIT-P3-FEATUREBITS-CAST

## Test plan
- [x] Go: 8/8 featurebits tests PASS
- [x] Rust: 10/10 featurebits tests PASS
- [x] Coverage: `FeatureBitStateAtHeightFromWindowCounts` = 100%
- [ ] CI: Go test + Rust test + Codacy

🤖 Generated with [Claude Code](https://claude.com/claude-code)