### PR TITLE
fix: bound tx relay fanout

### DIFF
--- a/clients/go/node/p2p/coverage_sub80_followup_test.go
+++ b/clients/go/node/p2p/coverage_sub80_followup_test.go
@@ -1,8 +1,13 @@
 package p2p
 
 import (
+	"bytes"
+	"io"
 	"net"
 	"testing"
+	"time"
+
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/node"
 )
 
 func TestCoverageResidual_ServiceSyncBroadcastBranches(t *testing.T) {
@@ -55,3 +60,186 @@ func TestCoverageResidual_ServiceSyncBroadcastBranches(t *testing.T) {
 		t.Fatalf("expected send failure to record peer2 error")
 	}
 }
+
+func TestSelectTxRelayPeersDeterministic(t *testing.T) {
+	h := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	peers := []*peer{
+		{service: h.service, state: nodePeerState("peer-3")},
+		{service: h.service, state: nodePeerState("peer-1")},
+		{service: h.service, state: nodePeerState("peer-4")},
+		{service: h.service, state: nodePeerState("peer-2")},
+	}
+	var txid [32]byte
+	txid[0] = 0x44
+	first := selectTxRelayPeers(txid, "sender-a", peers, 2)
+	second := selectTxRelayPeers(txid, "sender-a", peers, 2)
+	if len(first) != 2 || len(second) != 2 {
+		t.Fatalf("got %d and %d peers, want 2", len(first), len(second))
+	}
+	if first[0].addr() != second[0].addr() || first[1].addr() != second[1].addr() {
+		t.Fatalf("selection should be deterministic: %q,%q vs %q,%q", first[0].addr(), first[1].addr(), second[0].addr(), second[1].addr())
+	}
+	var otherTxid [32]byte
+	otherTxid[0] = 0x55
+	other := selectTxRelayPeers(otherTxid, "sender-a", peers, 2)
+	if first[0].addr() == other[0].addr() && first[1].addr() == other[1].addr() {
+		t.Fatalf("different txids should not always pick the same relay peers")
+	}
+	otherSender := selectTxRelayPeers(txid, "sender-b", peers, 2)
+	if first[0].addr() == otherSender[0].addr() && first[1].addr() == otherSender[1].addr() {
+		t.Fatalf("different sender salts should not always pick the same relay peers")
+	}
+}
+
+func TestSelectTxRelayPeersLimitFallbacks(t *testing.T) {
+	h := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	peers := []*peer{
+		{service: h.service, state: nodePeerState("peer-1")},
+		{service: h.service, state: nodePeerState("peer-2")},
+	}
+	var txid [32]byte
+	txid[0] = 0x77
+	if got := selectTxRelayPeers(txid, "sender-a", peers, 0); len(got) != len(peers) {
+		t.Fatalf("limit=0 should return all peers, got %d want %d", len(got), len(peers))
+	}
+	if got := selectTxRelayPeers(txid, "sender-a", peers, 8); len(got) != len(peers) {
+		t.Fatalf("oversized limit should return all peers, got %d want %d", len(got), len(peers))
+	}
+}
+
+func TestInventoryRelayKeyMultipleItems(t *testing.T) {
+	items := []InventoryVector{
+		{Type: MSG_TX, Hash: [32]byte{0x01}},
+		{Type: MSG_TX, Hash: [32]byte{0x02}},
+	}
+	first := inventoryRelayKey(items)
+	second := inventoryRelayKey(items)
+	if first != second {
+		t.Fatal("inventoryRelayKey should be deterministic for the same input")
+	}
+	if first == items[0].Hash {
+		t.Fatal("multi-item relay key should not collapse to the first txid")
+	}
+}
+
+func TestBroadcastInventoryTxUsesFanoutLimit(t *testing.T) {
+	h := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	h.service.cfg.TxRelayFanout = 2
+
+	peers := make([]*peer, 0, 4)
+	recorders := make([]*recordingConn, 0, 4)
+	for i := 1; i <= 4; i++ {
+		conn := &recordingConn{}
+		current := &peer{conn: conn, service: h.service, state: nodePeerState("peer-" + string(rune('0'+i)))}
+		peers = append(peers, current)
+		recorders = append(recorders, conn)
+		h.service.peers[current.addr()] = current
+	}
+
+	var txid [32]byte
+	txid[0] = 0x99
+	selected := selectTxRelayPeers(txid, h.service.txRelaySalt(nil), peers, h.service.cfg.TxRelayFanout)
+	selectedSet := make(map[string]struct{}, len(selected))
+	for _, current := range selected {
+		selectedSet[current.addr()] = struct{}{}
+	}
+
+	if err := h.service.broadcastInventory(nil, []InventoryVector{{Type: MSG_TX, Hash: txid}}); err != nil {
+		t.Fatalf("broadcastInventory tx: %v", err)
+	}
+	for idx, conn := range recorders {
+		peerAddr := peers[idx].addr()
+		got := conn.framesWritten() == 1
+		_, shouldReceive := selectedSet[peerAddr]
+		if got != shouldReceive {
+			t.Fatalf("peer %s receive=%v, want %v", peerAddr, got, shouldReceive)
+		}
+	}
+}
+
+func TestBroadcastInventoryMixedKeepsBlocksGlobal(t *testing.T) {
+	h := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	h.service.cfg.TxRelayFanout = 1
+
+	local1, remote1 := net.Pipe()
+	defer local1.Close()
+	defer remote1.Close()
+	peer1 := &peer{conn: local1, service: h.service, state: nodePeerState("peer-a")}
+
+	local2, remote2 := net.Pipe()
+	defer local2.Close()
+	defer remote2.Close()
+	peer2 := &peer{conn: local2, service: h.service, state: nodePeerState("peer-b")}
+
+	h.service.peers[peer1.addr()] = peer1
+	h.service.peers[peer2.addr()] = peer2
+
+	done1 := make(chan int, 1)
+	done2 := make(chan int, 1)
+	go countFrames(remote1, h.service.cfg.PeerRuntimeConfig.MaxMessageSize, 2, done1)
+	go countFrames(remote2, h.service.cfg.PeerRuntimeConfig.MaxMessageSize, 2, done2)
+
+	items := []InventoryVector{
+		{Type: MSG_BLOCK, Hash: [32]byte{0x01}},
+		{Type: MSG_TX, Hash: [32]byte{0x02}},
+	}
+	if err := h.service.broadcastInventory(nil, items); err != nil {
+		t.Fatalf("broadcastInventory mixed: %v", err)
+	}
+
+	got1 := <-done1
+	got2 := <-done2
+	if got1+got2 != 3 {
+		t.Fatalf("expected 3 total frames (2 block + 1 tx), got %d", got1+got2)
+	}
+	if got1 == 0 || got2 == 0 {
+		t.Fatalf("both peers should receive the block inventory")
+	}
+}
+
+func countFrames(conn net.Conn, maxSize uint32, limit int, done chan<- int) {
+	received := 0
+	for received < limit {
+		_ = conn.SetReadDeadline(time.Now().Add(time.Second))
+		if _, err := readFrame(conn, maxSize); err != nil {
+			break
+		}
+		received++
+	}
+	done <- received
+}
+
+func nodePeerState(addr string) node.PeerState {
+	return node.PeerState{Addr: addr, HandshakeComplete: true}
+}
+
+type recordingConn struct {
+	bytes.Buffer
+}
+
+func (c *recordingConn) Read(_ []byte) (int, error)         { return 0, io.EOF }
+func (c *recordingConn) Close() error                       { return nil }
+func (c *recordingConn) LocalAddr() net.Addr                { return stubAddr("local") }
+func (c *recordingConn) RemoteAddr() net.Addr               { return stubAddr("remote") }
+func (c *recordingConn) SetDeadline(_ time.Time) error      { return nil }
+func (c *recordingConn) SetReadDeadline(_ time.Time) error  { return nil }
+func (c *recordingConn) SetWriteDeadline(_ time.Time) error { return nil }
+
+func (c *recordingConn) framesWritten() int {
+	payload := c.Bytes()
+	frames := 0
+	for len(payload) >= 4 {
+		size := int(uint32(payload[0])<<24 | uint32(payload[1])<<16 | uint32(payload[2])<<8 | uint32(payload[3]))
+		if len(payload) < 4+size {
+			break
+		}
+		frames++
+		payload = payload[4+size:]
+	}
+	return frames
+}
+
+type stubAddr string
+
+func (a stubAddr) Network() string { return "test" }
+func (a stubAddr) String() string  { return string(a) }

--- a/clients/go/node/p2p/service.go
+++ b/clients/go/node/p2p/service.go
@@ -15,6 +15,7 @@ import (
 const (
 	defaultGetBlocksBatchLimit uint64 = 128
 	defaultLocatorLimit               = 32
+	defaultTxRelayFanout              = 8
 )
 
 type ServiceConfig struct {
@@ -24,6 +25,7 @@ type ServiceConfig struct {
 	GenesisHash        [32]byte
 	LocatorLimit       int
 	GetBlocksBatchSize uint64
+	TxRelayFanout      int
 	PeerRuntimeConfig  node.PeerRuntimeConfig
 	PeerManager        *node.PeerManager
 	SyncConfig         node.SyncConfig
@@ -96,6 +98,9 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 	cfg.PeerRuntimeConfig = mergePeerRuntimeConfig(cfg.PeerRuntimeConfig)
 	if cfg.PeerRuntimeConfig.Network == "" {
 		cfg.PeerRuntimeConfig.Network = cfg.SyncConfig.Network
+	}
+	if cfg.TxRelayFanout <= 0 {
+		cfg.TxRelayFanout = defaultTxRelayFanout
 	}
 	return &Service{
 		cfg:       cfg,

--- a/clients/go/node/p2p/service_inventory.go
+++ b/clients/go/node/p2p/service_inventory.go
@@ -1,0 +1,135 @@
+package p2p
+
+import (
+	"bytes"
+	"crypto/sha3"
+	"sort"
+)
+
+func (s *Service) broadcastInventory(skip *peer, items []InventoryVector) error {
+	peers := s.inventoryPeers(skip)
+	if len(peers) == 0 || len(items) == 0 {
+		return nil
+	}
+	blockItems, txItems := splitInventoryVectors(items)
+	if len(blockItems) > 0 {
+		if err := s.broadcastInventoryToPeers(peers, blockItems); err != nil {
+			return err
+		}
+	}
+	if len(txItems) == 0 {
+		return nil
+	}
+	txPeers := selectTxRelayPeers(inventoryRelayKey(txItems), s.txRelaySalt(skip), peers, s.cfg.TxRelayFanout)
+	return s.broadcastInventoryToPeers(txPeers, txItems)
+}
+
+func (s *Service) inventoryPeers(skip *peer) []*peer {
+	s.peersMu.RLock()
+	defer s.peersMu.RUnlock()
+	peers := make([]*peer, 0, len(s.peers))
+	for _, current := range s.peers {
+		if skip != nil && current.addr() == skip.addr() {
+			continue
+		}
+		peers = append(peers, current)
+	}
+	return peers
+}
+
+func splitInventoryVectors(items []InventoryVector) (blockItems []InventoryVector, txItems []InventoryVector) {
+	for _, item := range items {
+		switch item.Type {
+		case MSG_BLOCK:
+			blockItems = append(blockItems, item)
+		case MSG_TX:
+			txItems = append(txItems, item)
+		}
+	}
+	return blockItems, txItems
+}
+
+func (s *Service) broadcastInventoryToPeers(peers []*peer, items []InventoryVector) error {
+	if len(peers) == 0 || len(items) == 0 {
+		return nil
+	}
+	payload, err := encodeInventoryVectors(items)
+	if err != nil {
+		return err
+	}
+	for _, current := range peers {
+		if err := current.send(messageInv, payload); err != nil {
+			current.setLastError(err.Error())
+			_ = current.conn.Close()
+		}
+	}
+	return nil
+}
+
+func selectTxRelayPeers(relayKey [32]byte, relaySalt string, peers []*peer, limit int) []*peer {
+	if len(peers) == 0 {
+		return nil
+	}
+	if limit <= 0 || limit >= len(peers) {
+		return append([]*peer(nil), peers...)
+	}
+	scored := make([]scoredPeer, 0, len(peers))
+	for _, current := range peers {
+		addr := current.addr()
+		scored = append(scored, scoredPeer{
+			score: txRelayScore(relayKey, relaySalt, addr),
+			addr:  addr,
+			peer:  current,
+		})
+	}
+	sort.Slice(scored, func(i, j int) bool {
+		if cmp := bytes.Compare(scored[i].score[:], scored[j].score[:]); cmp != 0 {
+			return cmp < 0
+		}
+		return scored[i].addr < scored[j].addr
+	})
+	selected := make([]*peer, 0, limit)
+	for _, current := range scored[:limit] {
+		selected = append(selected, current.peer)
+	}
+	return selected
+}
+
+func (s *Service) txRelaySalt(skip *peer) string {
+	if skip != nil && skip.addr() != "" {
+		return skip.addr()
+	}
+	if s == nil {
+		return ""
+	}
+	return s.Addr()
+}
+
+func inventoryRelayKey(items []InventoryVector) [32]byte {
+	if len(items) == 1 {
+		return items[0].Hash
+	}
+	h := sha3.New256()
+	for _, item := range items {
+		_, _ = h.Write(item.Hash[:])
+	}
+	var out [32]byte
+	copy(out[:], h.Sum(nil))
+	return out
+}
+
+func txRelayScore(relayKey [32]byte, relaySalt string, addr string) [32]byte {
+	h := sha3.New256()
+	_, _ = h.Write(relayKey[:])
+	_, _ = h.Write([]byte(relaySalt))
+	_, _ = h.Write([]byte(addr))
+	var out [32]byte
+	copy(out[:], h.Sum(nil))
+	return out
+}
+
+type scoredPeer struct {
+	score [32]byte
+	addr  string
+	peer  *peer
+}

--- a/clients/go/node/p2p/service_sync.go
+++ b/clients/go/node/p2p/service_sync.go
@@ -52,26 +52,3 @@ func (s *Service) hasBlock(blockHash [32]byte) (bool, error) {
 	}
 	return false, err
 }
-
-func (s *Service) broadcastInventory(skip *peer, items []InventoryVector) error {
-	payload, err := encodeInventoryVectors(items)
-	if err != nil {
-		return err
-	}
-	s.peersMu.RLock()
-	peers := make([]*peer, 0, len(s.peers))
-	for _, current := range s.peers {
-		if skip != nil && current.addr() == skip.addr() {
-			continue
-		}
-		peers = append(peers, current)
-	}
-	s.peersMu.RUnlock()
-	for _, current := range peers {
-		if err := current.send(messageInv, payload); err != nil {
-			current.setLastError(err.Error())
-			_ = current.conn.Close()
-		}
-	}
-	return nil
-}


### PR DESCRIPTION
Q-AUDIT-P2-FANOUT

## Summary
- bound tx inventory relay to a deterministic hashed peer subset
- keep block inventory on full fanout
- add coverage for deterministic selection and mixed block/tx relay

## Validation
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node/p2p ./node ./cmd/rubin-node'