### PR TITLE
sec: pin workflow action refs

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -19,7 +19,7 @@ jobs:
     if: github.event.pull_request || github.event.workflow_run
     steps:
       - name: Wait for all checks, approve and merge
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -23,9 +23,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           go-version: '1.24.13'
           cache: true
@@ -40,7 +40,7 @@ jobs:
 
       - name: Upload fuzz artifacts (crashes/regressions)
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: fuzz-stage2-${{ github.run_id }}
           path: |
@@ -53,10 +53,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Rust nightly
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@0f1b44df7e9cbb178d781a242338dfa5e243ad7f # nightly
 
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz --locked
@@ -85,7 +85,7 @@ jobs:
 
       - name: Upload Rust fuzz artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: fuzz-rust-${{ github.run_id }}
           path: clients/rust/fuzz/artifacts/


### PR DESCRIPTION
Q-SECAUDIT-F09
Q-SECAUDIT-F11

## Summary
- pin actions/github-script in auto-approve.yml to an exact SHA
- pin checkout/setup-go/upload-artifact/rust-toolchain refs in fuzz-nightly.yml
- keep workflow behavior unchanged while removing mutable action tags

## Validation
- python3: YAML parse for .github/workflows/auto-approve.yml and .github/workflows/fuzz-nightly.yml
- grep confirms mutable action tags removed from both workflows