### PR TITLE
feat: implement devnet p2p backlog

### DIFF
--- a/clients/go/node/blockstore.go
+++ b/clients/go/node/blockstore.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/big"
 	"os"
 	"path/filepath"
 
@@ -87,6 +88,16 @@ func (bs *BlockStore) PutBlock(height uint64, blockHash [32]byte, headerBytes []
 		return err
 	}
 	return bs.SetCanonicalTip(height, blockHash)
+}
+
+func (bs *BlockStore) StoreBlock(blockHash [32]byte, headerBytes []byte, blockBytes []byte) error {
+	if bs == nil {
+		return errors.New("nil blockstore")
+	}
+	if err := validateBlockHeaderHash(headerBytes, blockHash); err != nil {
+		return err
+	}
+	return bs.persistBlockBytes(blockHash, headerBytes, blockBytes)
 }
 
 func (bs *BlockStore) SetCanonicalTip(height uint64, blockHash [32]byte) error {
@@ -171,6 +182,37 @@ func (bs *BlockStore) GetHeaderByHash(blockHash [32]byte) ([]byte, error) {
 		return nil, errors.New("nil blockstore")
 	}
 	return readFileFromDir(bs.headersDir, hex.EncodeToString(blockHash[:])+".bin")
+}
+
+func (bs *BlockStore) ChainWork(tipHash [32]byte) (*big.Int, error) {
+	if bs == nil {
+		return nil, errors.New("nil blockstore")
+	}
+	var zero [32]byte
+	if tipHash == zero {
+		return big.NewInt(0), nil
+	}
+
+	targets := make([][32]byte, 0, 16)
+	seen := make(map[[32]byte]struct{})
+	current := tipHash
+	for current != zero {
+		if _, exists := seen[current]; exists {
+			return nil, errors.New("blockstore parent cycle")
+		}
+		seen[current] = struct{}{}
+		headerBytes, err := bs.GetHeaderByHash(current)
+		if err != nil {
+			return nil, err
+		}
+		header, err := consensus.ParseBlockHeaderBytes(headerBytes)
+		if err != nil {
+			return nil, err
+		}
+		targets = append(targets, header.Target)
+		current = header.PrevBlockHash
+	}
+	return consensus.ChainWorkFromTargets(targets)
 }
 
 func (bs *BlockStore) PutUndo(blockHash [32]byte, undo *BlockUndo) error {

--- a/clients/go/node/p2p/addr_manager.go
+++ b/clients/go/node/p2p/addr_manager.go
@@ -1,0 +1,166 @@
+package p2p
+
+import (
+	"bytes"
+	"crypto/sha3"
+	"net"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	maxKnownAddrs    = 1000
+	maxAddrAdvertise = 25
+)
+
+type addrEntry struct {
+	addr     string
+	lastSeen time.Time
+	attempts int
+}
+
+type addrManager struct {
+	mu    sync.Mutex
+	addrs map[string]addrEntry
+	now   func() time.Time
+	salt  [32]byte
+}
+
+func newAddrManager(now func() time.Time) *addrManager {
+	if now == nil {
+		now = time.Now
+	}
+	var salt [32]byte
+	sum := sha3.Sum256([]byte(now().UTC().Format(time.RFC3339Nano)))
+	copy(salt[:], sum[:])
+	return &addrManager{
+		addrs: make(map[string]addrEntry),
+		now:   now,
+		salt:  salt,
+	}
+}
+
+func (m *addrManager) AddAddrs(addrs []string) {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	now := m.now()
+	for _, addr := range addrs {
+		addr = normalizeNetAddr(addr)
+		if addr == "" {
+			continue
+		}
+		entry := m.addrs[addr]
+		entry.addr = addr
+		entry.lastSeen = now
+		m.addrs[addr] = entry
+	}
+	m.evictLocked()
+}
+
+func (m *addrManager) GetAddrs(max int) []string {
+	if m == nil || max == 0 {
+		return nil
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if max < 0 || max > len(m.addrs) {
+		max = len(m.addrs)
+	}
+	if max == 0 {
+		return nil
+	}
+	entries := make([]addrEntry, 0, len(m.addrs))
+	for _, entry := range m.addrs {
+		entries = append(entries, entry)
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		left := addrSelectionScore(m.salt, entries[i].addr)
+		right := addrSelectionScore(m.salt, entries[j].addr)
+		if cmp := bytes.Compare(left[:], right[:]); cmp != 0 {
+			return cmp < 0
+		}
+		return entries[i].addr < entries[j].addr
+	})
+	out := make([]string, 0, max)
+	for _, entry := range entries[:max] {
+		out = append(out, entry.addr)
+	}
+	return out
+}
+
+func (m *addrManager) MarkAttempted(addr string) {
+	if m == nil {
+		return
+	}
+	addr = normalizeNetAddr(addr)
+	if addr == "" {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	entry := m.addrs[addr]
+	entry.addr = addr
+	entry.attempts++
+	m.addrs[addr] = entry
+}
+
+func (m *addrManager) Len() int {
+	if m == nil {
+		return 0
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.addrs)
+}
+
+func (m *addrManager) evictLocked() {
+	for len(m.addrs) > maxKnownAddrs {
+		var oldest addrEntry
+		first := true
+		for _, entry := range m.addrs {
+			if first || entry.lastSeen.Before(oldest.lastSeen) || (entry.lastSeen.Equal(oldest.lastSeen) && entry.addr < oldest.addr) {
+				oldest = entry
+				first = false
+			}
+		}
+		if first {
+			return
+		}
+		delete(m.addrs, oldest.addr)
+	}
+}
+
+func addrSelectionScore(salt [32]byte, addr string) [32]byte {
+	h := sha3.New256()
+	_, _ = h.Write(salt[:])
+	_, _ = h.Write([]byte(addr))
+	var out [32]byte
+	copy(out[:], h.Sum(nil))
+	return out
+}
+
+func normalizeNetAddr(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	host, portStr, err := net.SplitHostPort(raw)
+	if err != nil {
+		return ""
+	}
+	ip := net.ParseIP(strings.Trim(host, "[]"))
+	if ip == nil {
+		return ""
+	}
+	port, err := strconv.ParseUint(portStr, 10, 16)
+	if err != nil || port == 0 {
+		return ""
+	}
+	return net.JoinHostPort(ip.String(), strconv.FormatUint(port, 10))
+}

--- a/clients/go/node/p2p/addr_test.go
+++ b/clients/go/node/p2p/addr_test.go
@@ -1,0 +1,74 @@
+package p2p
+
+import (
+	"context"
+	"slices"
+	"testing"
+	"time"
+)
+
+func TestAddrPayloadRoundTrip(t *testing.T) {
+	addrs := []string{"127.0.0.1:18444", "[::1]:18445"}
+	encoded, err := encodeAddrPayload(addrs)
+	if err != nil {
+		t.Fatalf("encodeAddrPayload: %v", err)
+	}
+	decoded, err := decodeAddrPayload(encoded)
+	if err != nil {
+		t.Fatalf("decodeAddrPayload: %v", err)
+	}
+	if !slices.Equal(decoded, []string{"127.0.0.1:18444", "[::1]:18445"}) {
+		t.Fatalf("decoded=%v", decoded)
+	}
+}
+
+func TestAddrExchange(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sink := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	sink.service.addrMgr.AddAddrs([]string{"127.0.0.1:18501"})
+	if err := sink.service.Start(ctx); err != nil {
+		t.Fatalf("sink.Start: %v", err)
+	}
+	defer sink.service.Close()
+
+	source := newTestHarness(t, 1, "127.0.0.1:0", []string{sink.service.Addr()})
+	source.service.cfg.PeerRuntimeConfig.MaxPeers = 1
+	if err := source.service.Start(ctx); err != nil {
+		t.Fatalf("source.Start: %v", err)
+	}
+	defer source.service.Close()
+
+	waitFor(t, 5*time.Second, func() bool {
+		return slices.Contains(source.service.addrMgr.GetAddrs(8), "127.0.0.1:18501")
+	})
+}
+
+func TestAddrPropagation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	nodeC := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	if err := nodeC.service.Start(ctx); err != nil {
+		t.Fatalf("nodeC.Start: %v", err)
+	}
+	defer nodeC.service.Close()
+
+	nodeB := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	nodeB.service.addrMgr.AddAddrs([]string{nodeC.service.Addr()})
+	if err := nodeB.service.Start(ctx); err != nil {
+		t.Fatalf("nodeB.Start: %v", err)
+	}
+	defer nodeB.service.Close()
+
+	nodeA := newTestHarness(t, 1, "127.0.0.1:0", []string{nodeB.service.Addr()})
+	if err := nodeA.service.Start(ctx); err != nil {
+		t.Fatalf("nodeA.Start: %v", err)
+	}
+	defer nodeA.service.Close()
+
+	waitFor(t, 5*time.Second, func() bool {
+		return nodeA.peerManager.Count() == 2 && nodeC.peerManager.Count() >= 1
+	})
+}

--- a/clients/go/node/p2p/handlers_addr.go
+++ b/clients/go/node/p2p/handlers_addr.go
@@ -1,0 +1,98 @@
+package p2p
+
+func (p *peer) handleGetAddr(payload []byte) error {
+	if len(payload) != 0 {
+		return nil
+	}
+	addrs := p.service.discoverableAddrs(maxAddrAdvertise)
+	encoded, err := encodeAddrPayload(addrs)
+	if err != nil {
+		return err
+	}
+	return p.send(messageAddr, encoded)
+}
+
+func (p *peer) handleAddr(payload []byte) error {
+	addrs, err := decodeAddrPayload(payload)
+	if err != nil {
+		return err
+	}
+	p.service.addrMgr.AddAddrs(addrs)
+	p.service.connectDiscoveredAddrs(addrs)
+	return nil
+}
+
+func (s *Service) discoverableAddrs(max int) []string {
+	if s == nil {
+		return nil
+	}
+	candidates := s.addrMgr.GetAddrs(maxKnownAddrs)
+	banned := s.bannedPeerSet()
+	connected := s.connectedPeerSet()
+	self := normalizeNetAddr(s.Addr())
+	out := make([]string, 0, max)
+	for _, addr := range candidates {
+		if addr == "" || addr == self {
+			continue
+		}
+		if _, ok := connected[addr]; ok {
+			continue
+		}
+		if _, ok := banned[addr]; ok {
+			continue
+		}
+		out = append(out, addr)
+		if max > 0 && len(out) >= max {
+			break
+		}
+	}
+	return out
+}
+
+func (s *Service) connectDiscoveredAddrs(addrs []string) {
+	if s == nil {
+		return
+	}
+	for _, addr := range addrs {
+		addr = normalizeNetAddr(addr)
+		if addr == "" || s.isConnected(addr) || s.connectedPeerCount() >= s.cfg.PeerRuntimeConfig.MaxPeers {
+			continue
+		}
+		s.ensureOutboundAddr(addr)
+		s.addrMgr.MarkAttempted(addr)
+		s.loopWG.Add(1)
+		go s.dialPeer(addr)
+	}
+}
+
+func (s *Service) connectedPeerCount() int {
+	if s == nil {
+		return 0
+	}
+	s.peersMu.RLock()
+	defer s.peersMu.RUnlock()
+	return len(s.peers)
+}
+
+func (s *Service) connectedPeerSet() map[string]struct{} {
+	s.peersMu.RLock()
+	defer s.peersMu.RUnlock()
+	out := make(map[string]struct{}, len(s.peers))
+	for addr := range s.peers {
+		out[normalizeNetAddr(addr)] = struct{}{}
+	}
+	return out
+}
+
+func (s *Service) bannedPeerSet() map[string]struct{} {
+	out := make(map[string]struct{})
+	if s == nil || s.cfg.PeerManager == nil {
+		return out
+	}
+	for _, state := range s.cfg.PeerManager.Snapshot() {
+		if state.BanScore >= s.cfg.PeerRuntimeConfig.BanThreshold {
+			out[normalizeNetAddr(state.Addr)] = struct{}{}
+		}
+	}
+	return out
+}

--- a/clients/go/node/p2p/handlers_block.go
+++ b/clients/go/node/p2p/handlers_block.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/node"
 )
 
 func (p *peer) handleGetBlocks(payload []byte) error {
@@ -41,31 +42,43 @@ func (p *peer) blockInventoryAfterLocators(req GetBlocksPayload) ([]InventoryVec
 }
 
 func (p *peer) handleBlock(blockBytes []byte) error {
+	summary, err := p.processRelayedBlock(blockBytes)
+	if err != nil {
+		return err
+	}
+	if summary == nil {
+		return nil
+	}
+	return p.service.requestBlocksIfBehind(p)
+}
+
+func (p *peer) processRelayedBlock(blockBytes []byte) (*node.ChainStateConnectSummary, error) {
 	pb, blockHash, err := parseRelayedBlock(blockBytes)
 	if err != nil {
 		p.bumpBan(10, err.Error())
-		return err
+		return nil, err
 	}
 	if pb == nil {
-		return errors.New("nil parsed block")
+		return nil, errors.New("nil parsed block")
 	}
 	have, err := p.service.hasBlock(blockHash)
 	if err != nil || have {
-		return err
+		return nil, err
 	}
 
 	p.service.chainMu.Lock()
-	summary, err := p.service.cfg.SyncEngine.ApplyBlock(blockBytes, nil)
+	summary, err := p.service.cfg.SyncEngine.ApplyBlockWithReorg(blockBytes, nil)
 	p.service.chainMu.Unlock()
 	if err != nil {
+		if errors.Is(err, node.ErrParentNotFound) {
+			p.service.orphans.Add(blockHash, pb.Header.PrevBlockHash, blockBytes)
+			return nil, nil
+		}
 		p.bumpBan(100, err.Error())
-		return err
+		return nil, err
 	}
-	p.service.cfg.SyncEngine.RecordBestKnownHeight(summary.BlockHeight)
-	if p.service.blockSeen.Add(blockHash) {
-		_ = p.service.broadcastInventory(p, []InventoryVector{{Type: MSG_BLOCK, Hash: blockHash}})
-	}
-	return p.service.requestBlocksIfBehind(p)
+	p.acceptedRelayedBlock(blockHash, summary)
+	return summary, nil
 }
 
 func parseRelayedBlock(blockBytes []byte) (*consensus.ParsedBlock, [32]byte, error) {
@@ -78,4 +91,36 @@ func parseRelayedBlock(blockBytes []byte) (*consensus.ParsedBlock, [32]byte, err
 		return nil, [32]byte{}, err
 	}
 	return pb, blockHash, nil
+}
+
+func (p *peer) acceptedRelayedBlock(blockHash [32]byte, summary *node.ChainStateConnectSummary) {
+	p.service.cfg.SyncEngine.RecordBestKnownHeight(summary.BlockHeight)
+	if p.service.blockSeen.Add(blockHash) {
+		_ = p.service.broadcastInventory(p, []InventoryVector{{Type: MSG_BLOCK, Hash: blockHash}})
+	}
+	p.service.resolveOrphans(p, blockHash)
+}
+
+func (s *Service) resolveOrphans(skip *peer, blockHash [32]byte) {
+	children := s.orphans.TakeChildren(blockHash)
+	for _, child := range children {
+		pb, childHash, err := parseRelayedBlock(child.blockBytes)
+		if err != nil {
+			continue
+		}
+		s.chainMu.Lock()
+		summary, applyErr := s.cfg.SyncEngine.ApplyBlockWithReorg(child.blockBytes, nil)
+		s.chainMu.Unlock()
+		if applyErr != nil {
+			if errors.Is(applyErr, node.ErrParentNotFound) {
+				s.orphans.Add(childHash, pb.Header.PrevBlockHash, child.blockBytes)
+			}
+			continue
+		}
+		s.cfg.SyncEngine.RecordBestKnownHeight(summary.BlockHeight)
+		if s.blockSeen.Add(childHash) {
+			_ = s.broadcastInventory(skip, []InventoryVector{{Type: MSG_BLOCK, Hash: childHash}})
+		}
+		s.resolveOrphans(skip, childHash)
+	}
 }

--- a/clients/go/node/p2p/handshake.go
+++ b/clients/go/node/p2p/handshake.go
@@ -91,6 +91,10 @@ func preHandshakePayloadCap(command string) uint32 {
 		return versionPayloadBytes
 	case messageVerAck:
 		return 0
+	case messageGetAddr:
+		return 0
+	case messageAddr:
+		return 0
 	default:
 		return 0
 	}

--- a/clients/go/node/p2p/orphan_pool.go
+++ b/clients/go/node/p2p/orphan_pool.go
@@ -1,0 +1,104 @@
+package p2p
+
+import "sync"
+
+type orphanEntry struct {
+	blockHash  [32]byte
+	parentHash [32]byte
+	blockBytes []byte
+}
+
+type orphanMeta struct {
+	parentHash [32]byte
+}
+
+type orphanPool struct {
+	mu     sync.Mutex
+	limit  int
+	pool   map[[32]byte][]orphanEntry
+	byHash map[[32]byte]orphanMeta
+	fifo   [][32]byte
+}
+
+func newOrphanPool(limit int) *orphanPool {
+	if limit <= 0 {
+		limit = 500
+	}
+	return &orphanPool{
+		limit:  limit,
+		pool:   make(map[[32]byte][]orphanEntry),
+		byHash: make(map[[32]byte]orphanMeta),
+	}
+}
+
+func (o *orphanPool) Add(blockHash, parentHash [32]byte, blockBytes []byte) bool {
+	if o == nil {
+		return false
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if _, exists := o.byHash[blockHash]; exists {
+		return false
+	}
+	entry := orphanEntry{
+		blockHash:  blockHash,
+		parentHash: parentHash,
+		blockBytes: append([]byte(nil), blockBytes...),
+	}
+	o.pool[parentHash] = append(o.pool[parentHash], entry)
+	o.byHash[blockHash] = orphanMeta{parentHash: parentHash}
+	o.fifo = append(o.fifo, blockHash)
+	for len(o.byHash) > o.limit {
+		o.evictOldest()
+	}
+	return true
+}
+
+func (o *orphanPool) TakeChildren(parentHash [32]byte) []orphanEntry {
+	if o == nil {
+		return nil
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	children := append([]orphanEntry(nil), o.pool[parentHash]...)
+	delete(o.pool, parentHash)
+	for _, child := range children {
+		delete(o.byHash, child.blockHash)
+	}
+	return children
+}
+
+func (o *orphanPool) Len() int {
+	if o == nil {
+		return 0
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return len(o.byHash)
+}
+
+func (o *orphanPool) evictOldest() {
+	for len(o.fifo) > 0 {
+		oldest := o.fifo[0]
+		o.fifo = o.fifo[1:]
+		meta, exists := o.byHash[oldest]
+		if !exists {
+			continue
+		}
+		delete(o.byHash, oldest)
+		children := o.pool[meta.parentHash]
+		for index, child := range children {
+			if child.blockHash != oldest {
+				continue
+			}
+			children = append(children[:index], children[index+1:]...)
+			break
+		}
+		if len(children) == 0 {
+			delete(o.pool, meta.parentHash)
+		} else {
+			o.pool[meta.parentHash] = children
+		}
+		return
+	}
+}

--- a/clients/go/node/p2p/orphan_pool_test.go
+++ b/clients/go/node/p2p/orphan_pool_test.go
@@ -1,0 +1,31 @@
+package p2p
+
+import "testing"
+
+func TestOrphanEviction(t *testing.T) {
+	pool := newOrphanPool(500)
+	var sharedParent [32]byte
+	sharedParent[31] = 0x99
+	var oldestHash [32]byte
+	oldestHash[31] = 1
+	for i := 0; i < 501; i++ {
+		var blockHash [32]byte
+		blockHash[30] = byte((i + 1) >> 8)
+		blockHash[31] = byte(i + 1)
+		if !pool.Add(blockHash, sharedParent, []byte{byte(i)}) {
+			t.Fatalf("Add(%d) unexpectedly rejected", i)
+		}
+	}
+	if got := pool.Len(); got != 500 {
+		t.Fatalf("Len()=%d, want 500", got)
+	}
+	children := pool.TakeChildren(sharedParent)
+	if len(children) != 500 {
+		t.Fatalf("children=%d, want 500", len(children))
+	}
+	for _, child := range children {
+		if child.blockHash == oldestHash {
+			t.Fatalf("oldest orphan was not evicted")
+		}
+	}
+}

--- a/clients/go/node/p2p/peer_runtime.go
+++ b/clients/go/node/p2p/peer_runtime.go
@@ -65,6 +65,10 @@ func (p *peer) handleMessage(frame message) error {
 		return p.handleTx(frame.Payload)
 	case messageGetBlk:
 		return p.handleGetBlocks(frame.Payload)
+	case messageGetAddr:
+		return p.handleGetAddr(frame.Payload)
+	case messageAddr:
+		return p.handleAddr(frame.Payload)
 	case messagePing, messagePong, messageHeaders:
 		return nil
 	case messageVersion:

--- a/clients/go/node/p2p/reconnect.go
+++ b/clients/go/node/p2p/reconnect.go
@@ -1,0 +1,191 @@
+package p2p
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"time"
+)
+
+var (
+	reconnectLoopInterval = 5 * time.Second
+	reconnectBaseDelay    = 5 * time.Second
+	reconnectMaxDelay     = 5 * time.Minute
+)
+
+type reconnectEntry struct {
+	failures  int
+	nextRetry time.Time
+}
+
+func (s *Service) reconnectLoop(ctx context.Context) {
+	defer s.loopWG.Done()
+	ticker := time.NewTicker(reconnectLoopInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.reconnectDuePeers()
+		}
+	}
+}
+
+func (s *Service) reconnectDuePeers() {
+	if s == nil {
+		return
+	}
+	now := s.cfg.Now()
+	for _, addr := range s.outboundAddrsSnapshot() {
+		if s.isConnected(addr) {
+			continue
+		}
+		if !s.isReconnectDue(addr, now) {
+			continue
+		}
+		s.scheduleNextReconnectAttempt(addr, now)
+		s.loopWG.Add(1)
+		go s.dialPeer(addr)
+	}
+}
+
+func (s *Service) outboundAddrsSnapshot() []string {
+	s.reconnectMu.Lock()
+	defer s.reconnectMu.Unlock()
+	return append([]string(nil), s.outboundAddrs...)
+}
+
+func (s *Service) ensureOutboundAddr(addr string) {
+	addr = strings.TrimSpace(addr)
+	if addr == "" {
+		return
+	}
+	s.reconnectMu.Lock()
+	defer s.reconnectMu.Unlock()
+	if slices.Contains(s.outboundAddrs, addr) {
+		return
+	}
+	s.outboundAddrs = append(s.outboundAddrs, addr)
+}
+
+func (s *Service) resetReconnect(addr string) {
+	addr = strings.TrimSpace(addr)
+	if addr == "" {
+		return
+	}
+	s.reconnectMu.Lock()
+	defer s.reconnectMu.Unlock()
+	delete(s.reconnectState, addr)
+}
+
+func (s *Service) recordDialFailure(addr string) {
+	addr = strings.TrimSpace(addr)
+	if addr == "" {
+		return
+	}
+	s.reconnectMu.Lock()
+	defer s.reconnectMu.Unlock()
+	entry := s.reconnectState[addr]
+	if entry == nil {
+		entry = &reconnectEntry{}
+		s.reconnectState[addr] = entry
+	}
+	entry.nextRetry = s.cfg.Now().Add(reconnectBackoff(entry.failures))
+	entry.failures++
+}
+
+func (s *Service) scheduleReconnect(addr string) {
+	addr = strings.TrimSpace(addr)
+	if addr == "" {
+		return
+	}
+	s.reconnectMu.Lock()
+	defer s.reconnectMu.Unlock()
+	entry := s.reconnectState[addr]
+	if entry == nil {
+		entry = &reconnectEntry{}
+		s.reconnectState[addr] = entry
+	}
+	entry.nextRetry = s.cfg.Now().Add(reconnectBackoff(entry.failures))
+}
+
+func (s *Service) scheduleNextReconnectAttempt(addr string, now time.Time) {
+	s.reconnectMu.Lock()
+	defer s.reconnectMu.Unlock()
+	entry := s.reconnectState[addr]
+	if entry == nil {
+		entry = &reconnectEntry{}
+		s.reconnectState[addr] = entry
+	}
+	entry.nextRetry = now.Add(reconnectBackoff(entry.failures))
+}
+
+func (s *Service) isReconnectDue(addr string, now time.Time) bool {
+	s.reconnectMu.Lock()
+	defer s.reconnectMu.Unlock()
+	entry := s.reconnectState[addr]
+	if entry == nil {
+		entry = &reconnectEntry{}
+		s.reconnectState[addr] = entry
+	}
+	return !entry.nextRetry.After(now)
+}
+
+func (s *Service) reconnectSnapshot(addr string) reconnectEntry {
+	s.reconnectMu.Lock()
+	defer s.reconnectMu.Unlock()
+	entry := s.reconnectState[addr]
+	if entry == nil {
+		return reconnectEntry{}
+	}
+	return *entry
+}
+
+func reconnectBackoff(failures int) time.Duration {
+	if failures < 0 {
+		failures = 0
+	}
+	delay := reconnectBaseDelay
+	for i := 0; i < failures; i++ {
+		if delay >= reconnectMaxDelay {
+			return reconnectMaxDelay
+		}
+		next := delay * 2
+		if next < delay || next > reconnectMaxDelay {
+			return reconnectMaxDelay
+		}
+		delay = next
+	}
+	if delay > reconnectMaxDelay {
+		return reconnectMaxDelay
+	}
+	return delay
+}
+
+func (s *Service) isConnected(addr string) bool {
+	if s == nil {
+		return false
+	}
+	s.peersMu.RLock()
+	defer s.peersMu.RUnlock()
+	_, ok := s.peers[addr]
+	return ok
+}
+
+func normalizePeerAddrs(addrs []string) []string {
+	seen := make(map[string]struct{}, len(addrs))
+	out := make([]string, 0, len(addrs))
+	for _, addr := range addrs {
+		addr = strings.TrimSpace(addr)
+		if addr == "" {
+			continue
+		}
+		if _, ok := seen[addr]; ok {
+			continue
+		}
+		seen[addr] = struct{}{}
+		out = append(out, addr)
+	}
+	return out
+}

--- a/clients/go/node/p2p/reconnect_test.go
+++ b/clients/go/node/p2p/reconnect_test.go
@@ -1,0 +1,98 @@
+package p2p
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/node"
+)
+
+func TestAutoReconnect(t *testing.T) {
+	restore := overrideReconnectTiming(50*time.Millisecond, 50*time.Millisecond, 400*time.Millisecond)
+	defer restore()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer listener.Close()
+
+	h := newTestHarness(t, 1, "127.0.0.1:0", []string{listener.Addr().String()})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := h.service.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer h.service.Close()
+
+	accepted := make(chan struct{}, 2)
+	go func() {
+		conn, err := listener.Accept()
+		if err == nil {
+			accepted <- struct{}{}
+			_ = conn.Close()
+		}
+		conn, err = listener.Accept()
+		if err != nil {
+			return
+		}
+		accepted <- struct{}{}
+		_ = completeRemoteHandshake(conn, node.DefaultPeerRuntimeConfig("devnet", 8), testVersionPayload(node.DevnetGenesisChainID(), node.DevnetGenesisBlockHash(), "remote", 1))
+		time.Sleep(250 * time.Millisecond)
+		_ = conn.Close()
+	}()
+
+	waitFor(t, 5*time.Second, func() bool {
+		return len(accepted) >= 2 && h.peerManager.Count() == 1
+	})
+	if snap := h.service.reconnectSnapshot(listener.Addr().String()); snap.failures != 0 {
+		t.Fatalf("failures=%d, want reset to 0", snap.failures)
+	}
+}
+
+func TestReconnectBackoff(t *testing.T) {
+	restore := overrideReconnectTiming(50*time.Millisecond, 50*time.Millisecond, 400*time.Millisecond)
+	defer restore()
+
+	currentTime := time.Unix(1_777_000_000, 0)
+	h := newTestHarness(t, 0, "127.0.0.1:0", nil)
+	h.service.cfg.Now = func() time.Time { return currentTime }
+	h.service.addrMgr = newAddrManager(h.service.cfg.Now)
+
+	addr := "127.0.0.1:19001"
+	h.service.recordDialFailure(addr)
+	first := h.service.reconnectSnapshot(addr)
+	if got := first.nextRetry.Sub(currentTime); got != 50*time.Millisecond {
+		t.Fatalf("first backoff=%s, want 50ms", got)
+	}
+
+	currentTime = currentTime.Add(50 * time.Millisecond)
+	h.service.recordDialFailure(addr)
+	second := h.service.reconnectSnapshot(addr)
+	if got := second.nextRetry.Sub(currentTime); got != 100*time.Millisecond {
+		t.Fatalf("second backoff=%s, want 100ms", got)
+	}
+
+	currentTime = currentTime.Add(100 * time.Millisecond)
+	h.service.recordDialFailure(addr)
+	third := h.service.reconnectSnapshot(addr)
+	if got := third.nextRetry.Sub(currentTime); got != 200*time.Millisecond {
+		t.Fatalf("third backoff=%s, want 200ms", got)
+	}
+}
+
+func overrideReconnectTiming(loopInterval, baseDelay, maxDelay time.Duration) func() {
+	prevLoop := reconnectLoopInterval
+	prevBase := reconnectBaseDelay
+	prevMax := reconnectMaxDelay
+	reconnectLoopInterval = loopInterval
+	reconnectBaseDelay = baseDelay
+	reconnectMaxDelay = maxDelay
+	return func() {
+		reconnectLoopInterval = prevLoop
+		reconnectBaseDelay = prevBase
+		reconnectMaxDelay = prevMax
+	}
+}

--- a/clients/go/node/p2p/rust_interop_test.go
+++ b/clients/go/node/p2p/rust_interop_test.go
@@ -142,6 +142,24 @@ func TestRustInterop_RustClientReceivesTxFromGo(t *testing.T) {
 	waitRustInterop(t, cmd, logs)
 }
 
+func TestRustInterop_RustClientSyncsFiveBlocksFromGo(t *testing.T) {
+	bin := requireRustInterop(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	source := newTestHarness(t, 6, "127.0.0.1:0", nil)
+	if err := source.service.Start(ctx); err != nil {
+		t.Fatalf("source.Start: %v", err)
+	}
+	defer source.service.Close()
+
+	cmd, logs := startRustInteropClient(t, bin, source.service.Addr(), "sync-blocks")
+	defer terminateHelper(cmd)
+
+	waitRustInterop(t, cmd, logs)
+}
+
 func requireRustInterop(t *testing.T) string {
 	t.Helper()
 	if os.Getenv("RUBIN_P2P_INTEROP") != "1" {

--- a/clients/go/node/p2p/service.go
+++ b/clients/go/node/p2p/service.go
@@ -46,9 +46,15 @@ type Service struct {
 	peers   map[string]*peer
 	loopWG  sync.WaitGroup
 
+	reconnectMu    sync.Mutex
+	reconnectState map[string]*reconnectEntry
+	outboundAddrs  []string
+	addrMgr        *addrManager
+
 	chainMu   sync.Mutex
 	blockSeen *boundedHashSet
 	txSeen    *boundedHashSet
+	orphans   *orphanPool
 }
 
 type peer struct {
@@ -104,11 +110,16 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 	if cfg.TxRelayFanout <= 0 {
 		cfg.TxRelayFanout = defaultTxRelayFanout
 	}
+	outboundAddrs := normalizePeerAddrs(cfg.BootstrapPeers)
 	return &Service{
-		cfg:       cfg,
-		peers:     make(map[string]*peer),
-		blockSeen: newBoundedHashSet(defaultBlockSeenCapacity),
-		txSeen:    newBoundedHashSet(defaultTxSeenCapacity),
+		cfg:            cfg,
+		peers:          make(map[string]*peer),
+		reconnectState: make(map[string]*reconnectEntry),
+		outboundAddrs:  outboundAddrs,
+		addrMgr:        newAddrManager(cfg.Now),
+		blockSeen:      newBoundedHashSet(defaultBlockSeenCapacity),
+		txSeen:         newBoundedHashSet(defaultTxSeenCapacity),
+		orphans:        newOrphanPool(500),
 	}, nil
 }
 

--- a/clients/go/node/p2p/service_listener.go
+++ b/clients/go/node/p2p/service_listener.go
@@ -26,11 +26,14 @@ func (s *Service) Start(ctx context.Context) error {
 
 	s.loopWG.Add(1)
 	go s.acceptLoop()
-	for _, peerAddr := range s.cfg.BootstrapPeers {
+	s.loopWG.Add(1)
+	go s.reconnectLoop(s.ctx)
+	for _, peerAddr := range s.outboundAddrs {
 		peerAddr = strings.TrimSpace(peerAddr)
 		if peerAddr == "" {
 			continue
 		}
+		s.addrMgr.MarkAttempted(peerAddr)
 		s.loopWG.Add(1)
 		go s.dialPeer(peerAddr)
 	}
@@ -90,10 +93,17 @@ func (s *Service) acceptLoop() {
 
 func (s *Service) dialPeer(addr string) {
 	defer s.loopWG.Done()
+	if s == nil {
+		return
+	}
+	s.addrMgr.MarkAttempted(addr)
 	dialer := &net.Dialer{Timeout: s.cfg.PeerRuntimeConfig.HandshakeTimeout}
 	conn, err := dialer.DialContext(s.ctx, "tcp", addr)
 	if err != nil {
+		s.recordDialFailure(addr)
 		return
 	}
-	s.handleConn(conn)
+	if err := s.handleConn(conn); err != nil && s.ctx != nil && s.ctx.Err() == nil {
+		s.recordDialFailure(addr)
+	}
 }

--- a/clients/go/node/p2p/service_peer_lifecycle.go
+++ b/clients/go/node/p2p/service_peer_lifecycle.go
@@ -2,16 +2,18 @@ package p2p
 
 import (
 	"net"
+	"slices"
+	"strings"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/node"
 )
 
 func (s *Service) runConn(conn net.Conn) {
 	defer s.loopWG.Done()
-	s.handleConn(conn)
+	_ = s.handleConn(conn)
 }
 
-func (s *Service) handleConn(conn net.Conn) {
+func (s *Service) handleConn(conn net.Conn) error {
 	defer func() {
 		if conn != nil {
 			_ = conn.Close()
@@ -20,7 +22,7 @@ func (s *Service) handleConn(conn net.Conn) {
 
 	localVersion, err := s.localVersion()
 	if err != nil {
-		return
+		return err
 	}
 	state, err := performHandshake(
 		s.ctx,
@@ -31,7 +33,7 @@ func (s *Service) handleConn(conn net.Conn) {
 		s.cfg.GenesisHash,
 	)
 	if err != nil {
-		return
+		return err
 	}
 
 	current := &peer{
@@ -40,19 +42,24 @@ func (s *Service) handleConn(conn net.Conn) {
 		state:   state,
 	}
 	if err := s.registerPeer(current); err != nil {
-		return
+		return err
 	}
 	defer s.unregisterPeer(current.addr())
+	if err := s.requestPeerAddrs(current); err != nil {
+		current.setLastError(err.Error())
+		return err
+	}
 
 	s.cfg.SyncEngine.RecordBestKnownHeight(state.RemoteVersion.BestHeight)
 	if err := s.requestBlocksIfBehind(current); err != nil {
 		current.setLastError(err.Error())
-		return
+		return err
 	}
 	if err := current.run(s.ctx); err != nil && s.ctx.Err() == nil {
 		current.setLastError(err.Error())
-		return
+		return err
 	}
+	return nil
 }
 
 func (s *Service) registerPeer(p *peer) error {
@@ -60,8 +67,10 @@ func (s *Service) registerPeer(p *peer) error {
 		return err
 	}
 	s.peersMu.Lock()
-	defer s.peersMu.Unlock()
 	s.peers[p.addr()] = p
+	s.peersMu.Unlock()
+	s.addrMgr.AddAddrs([]string{p.addr()})
+	s.resetReconnect(p.addr())
 	return nil
 }
 
@@ -70,6 +79,9 @@ func (s *Service) unregisterPeer(addr string) {
 	delete(s.peers, addr)
 	s.peersMu.Unlock()
 	s.cfg.PeerManager.RemovePeer(addr)
+	if s.isOutboundAddr(addr) {
+		s.scheduleReconnect(addr)
+	}
 }
 
 func (s *Service) localVersion() (node.VersionPayloadV1, error) {
@@ -90,4 +102,21 @@ func (s *Service) localVersion() (node.VersionPayloadV1, error) {
 		BestHeight:        bestHeight,
 		UserAgent:         s.cfg.UserAgent,
 	}, nil
+}
+
+func (s *Service) requestPeerAddrs(p *peer) error {
+	if p == nil {
+		return nil
+	}
+	return p.send(messageGetAddr, nil)
+}
+
+func (s *Service) isOutboundAddr(addr string) bool {
+	addr = strings.TrimSpace(addr)
+	if addr == "" {
+		return false
+	}
+	s.reconnectMu.Lock()
+	defer s.reconnectMu.Unlock()
+	return slices.Contains(s.outboundAddrs, addr)
 }

--- a/clients/go/node/p2p/service_test.go
+++ b/clients/go/node/p2p/service_test.go
@@ -252,6 +252,71 @@ func TestIBDSync(t *testing.T) {
 	}
 }
 
+func TestOrphanResolution(t *testing.T) {
+	source := newTestHarness(t, 3, "127.0.0.1:0", nil)
+	sink := newTestHarness(t, 0, "127.0.0.1:0", nil)
+
+	genesisBytes := node.DevnetGenesisBlockBytes()
+	height1Hash, ok, err := source.blockStore.CanonicalHash(1)
+	if err != nil || !ok {
+		t.Fatalf("CanonicalHash(1): ok=%v err=%v", ok, err)
+	}
+	height2Hash, ok, err := source.blockStore.CanonicalHash(2)
+	if err != nil || !ok {
+		t.Fatalf("CanonicalHash(2): ok=%v err=%v", ok, err)
+	}
+	block1Bytes, err := source.blockStore.GetBlockByHash(height1Hash)
+	if err != nil {
+		t.Fatalf("GetBlockByHash(height1): %v", err)
+	}
+	block2Bytes, err := source.blockStore.GetBlockByHash(height2Hash)
+	if err != nil {
+		t.Fatalf("GetBlockByHash(height2): %v", err)
+	}
+
+	peer := &peer{
+		service: sink.service,
+		state: node.PeerState{
+			RemoteVersion: testVersionPayload(node.DevnetGenesisChainID(), node.DevnetGenesisBlockHash(), "remote", 2),
+		},
+	}
+
+	if summary, err := peer.processRelayedBlock(block2Bytes); err != nil {
+		t.Fatalf("processRelayedBlock(block2): %v", err)
+	} else if summary != nil {
+		t.Fatalf("expected nil summary for orphan block2")
+	}
+	if summary, err := peer.processRelayedBlock(block1Bytes); err != nil {
+		t.Fatalf("processRelayedBlock(block1): %v", err)
+	} else if summary != nil {
+		t.Fatalf("expected nil summary for orphan block1")
+	}
+	if got := sink.service.orphans.Len(); got != 2 {
+		t.Fatalf("orphans.Len()=%d, want 2", got)
+	}
+
+	summary, err := peer.processRelayedBlock(genesisBytes)
+	if err != nil {
+		t.Fatalf("processRelayedBlock(genesis): %v", err)
+	}
+	if summary == nil || summary.BlockHeight != 0 {
+		t.Fatalf("genesis summary=%v, want height 0", summary)
+	}
+	if got := sink.service.orphans.Len(); got != 0 {
+		t.Fatalf("orphans.Len()=%d, want 0 after resolve", got)
+	}
+	height, tipHash, ok, err := sink.blockStore.Tip()
+	if err != nil {
+		t.Fatalf("sink tip: %v", err)
+	}
+	if !ok || height != 2 {
+		t.Fatalf("sink height=%d ok=%v, want 2/true", height, ok)
+	}
+	if tipHash != height2Hash {
+		t.Fatalf("sink tip hash=%x, want %x", tipHash, height2Hash)
+	}
+}
+
 func newTestHarness(t *testing.T, blockCount int, bindAddr string, bootstrapPeers []string) *testHarness {
 	t.Helper()
 

--- a/clients/go/node/p2p/wire.go
+++ b/clients/go/node/p2p/wire.go
@@ -8,7 +8,10 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"net"
+	"strconv"
 
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/node"
 )
 
@@ -22,6 +25,8 @@ const (
 	messageBlock   = "block"
 	messageTx      = "tx"
 	messageGetBlk  = "getblocks"
+	messageGetAddr = "getaddr"
+	messageAddr    = "addr"
 	messagePing    = "ping"
 	messagePong    = "pong"
 	messageHeaders = "headers"
@@ -30,6 +35,7 @@ const (
 	MSG_TX    byte = 0x02
 
 	inventoryVectorSize     = 33
+	addrPayloadEntrySize    = 18
 	wireHeaderSize          = 24
 	wireCommandSize         = 12
 	versionPayloadBaseBytes = 17
@@ -362,5 +368,61 @@ func decodeGetBlocksPayload(payload []byte) (GetBlocksPayload, error) {
 		offset += 32
 	}
 	copy(out.StopHash[:], payload[offset:offset+32])
+	return out, nil
+}
+
+func encodeAddrPayload(addrs []string) ([]byte, error) {
+	var buf bytes.Buffer
+	buf.Write(consensus.EncodeCompactSize(uint64(len(addrs))))
+	for _, addr := range addrs {
+		host, portStr, err := net.SplitHostPort(addr)
+		if err != nil {
+			return nil, err
+		}
+		ip := net.ParseIP(host)
+		if ip == nil {
+			return nil, fmt.Errorf("invalid addr host: %s", host)
+		}
+		port, err := strconv.ParseUint(portStr, 10, 16)
+		if err != nil || port == 0 {
+			return nil, fmt.Errorf("invalid addr port: %s", portStr)
+		}
+		ip = ip.To16()
+		if ip == nil {
+			return nil, fmt.Errorf("invalid addr ip width: %s", host)
+		}
+		buf.Write(ip)
+		var portBytes [2]byte
+		binary.BigEndian.PutUint16(portBytes[:], uint16(port))
+		buf.Write(portBytes[:])
+	}
+	return buf.Bytes(), nil
+}
+
+func decodeAddrPayload(payload []byte) ([]string, error) {
+	if len(payload) == 0 {
+		return nil, nil
+	}
+	count, consumed, err := consensus.DecodeCompactSize(payload)
+	if err != nil {
+		return nil, err
+	}
+	needed := consumed + int(count)*addrPayloadEntrySize
+	if len(payload) != needed {
+		return nil, errors.New("addr payload width mismatch")
+	}
+	out := make([]string, 0, int(count))
+	offset := consumed
+	for i := uint64(0); i < count; i++ {
+		ip := net.IP(payload[offset : offset+16])
+		offset += 16
+		port := binary.BigEndian.Uint16(payload[offset : offset+2])
+		offset += 2
+		addr := normalizeNetAddr(net.JoinHostPort(ip.String(), strconv.FormatUint(uint64(port), 10)))
+		if addr == "" {
+			return nil, errors.New("invalid addr payload entry")
+		}
+		out = append(out, addr)
+	}
 	return out, nil
 }

--- a/clients/go/node/sync.go
+++ b/clients/go/node/sync.go
@@ -3,6 +3,7 @@ package node
 import (
 	"errors"
 	"fmt"
+	"math/big"
 	"strings"
 	"sync"
 
@@ -10,6 +11,8 @@ import (
 )
 
 const defaultIBDLagSeconds = 24 * 60 * 60
+
+var ErrParentNotFound = errors.New("parent block not found")
 
 type SyncConfig struct {
 	ExpectedTarget   *[32]byte
@@ -34,6 +37,8 @@ type SyncEngine struct {
 	mu              sync.RWMutex
 	tipTimestamp    uint64
 	bestKnownHeight uint64
+	lastReorgDepth  uint64
+	reorgCount      uint64
 }
 
 func DefaultSyncConfig(expectedTarget *[32]byte, chainID [32]byte, chainStatePath string) SyncConfig {
@@ -122,6 +127,24 @@ func (s *SyncEngine) BestKnownHeight() uint64 {
 	return s.bestKnownHeight
 }
 
+func (s *SyncEngine) LastReorgDepth() uint64 {
+	if s == nil {
+		return 0
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.lastReorgDepth
+}
+
+func (s *SyncEngine) ReorgCount() uint64 {
+	if s == nil {
+		return 0
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.reorgCount
+}
+
 func (s *SyncEngine) IsInIBD(nowUnix uint64) bool {
 	if s == nil || s.chainState == nil {
 		return true
@@ -137,6 +160,14 @@ func (s *SyncEngine) IsInIBD(nowUnix uint64) bool {
 }
 
 func (s *SyncEngine) ApplyBlock(blockBytes []byte, prevTimestamps []uint64) (*ChainStateConnectSummary, error) {
+	pb, err := consensus.ParseBlockBytes(blockBytes)
+	if err != nil {
+		return nil, err
+	}
+	return s.applyCanonicalParsedBlock(pb, blockBytes, prevTimestamps)
+}
+
+func (s *SyncEngine) ApplyBlockWithReorg(blockBytes []byte, prevTimestamps []uint64) (*ChainStateConnectSummary, error) {
 	if s == nil || s.chainState == nil {
 		return nil, errors.New("sync engine is not initialized")
 	}
@@ -144,39 +175,82 @@ func (s *SyncEngine) ApplyBlock(blockBytes []byte, prevTimestamps []uint64) (*Ch
 	if err != nil {
 		return nil, err
 	}
-	blockHeight, _, err := nextBlockContext(s.chainState)
-	if err != nil {
-		return nil, err
-	}
-	if err := validateIncomingChainID(blockHeight, s.cfg.ChainID); err != nil {
-		return nil, err
-	}
 	blockHash, err := consensus.BlockHash(pb.HeaderBytes)
 	if err != nil {
 		return nil, err
+	}
+
+	var zero [32]byte
+	if !s.chainState.HasTip {
+		if pb.Header.PrevBlockHash != zero {
+			return nil, ErrParentNotFound
+		}
+		return s.applyCanonicalParsedBlock(pb, blockBytes, prevTimestamps)
+	}
+	if pb.Header.PrevBlockHash == s.chainState.TipHash {
+		return s.applyCanonicalParsedBlock(pb, blockBytes, prevTimestamps)
+	}
+	if s.blockStore == nil {
+		return nil, &consensus.TxError{Code: consensus.BLOCK_ERR_LINKAGE_INVALID, Msg: "missing blockstore for side-chain block"}
+	}
+
+	branch, commonAncestorHash, commonAncestorHeight, err := s.collectBranchToCanonical(blockHash, blockBytes, pb)
+	if err != nil {
+		return nil, err
+	}
+	currentTipHeight, currentTipHash, ok, err := s.blockStore.Tip()
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, errors.New("blockstore has no canonical tip")
+	}
+
+	currentWork, err := s.blockStore.ChainWork(currentTipHash)
+	if err != nil {
+		return nil, err
+	}
+	ancestorWork, err := s.blockStore.ChainWork(commonAncestorHash)
+	if err != nil {
+		return nil, err
+	}
+	branchTargets := make([][32]byte, 0, len(branch))
+	for _, item := range branch {
+		branchTargets = append(branchTargets, item.header.Target)
+	}
+	branchWork, err := consensus.ChainWorkFromTargets(branchTargets)
+	if err != nil {
+		return nil, err
+	}
+	candidateWork := new(big.Int).Add(new(big.Int).Set(ancestorWork), branchWork)
+	candidateHeight := commonAncestorHeight + uint64(len(branch))
+	if candidateWork.Cmp(currentWork) <= 0 {
+		if err := s.blockStore.StoreBlock(blockHash, pb.HeaderBytes, blockBytes); err != nil {
+			return nil, err
+		}
+		return s.syntheticSideChainSummary(candidateHeight, blockHash), nil
 	}
 
 	rollbackState, err := s.captureRollbackState()
 	if err != nil {
 		return nil, err
 	}
-	prevState, err := chainStateFromDisk(rollbackState.chainState)
-	if err != nil {
-		return nil, err
-	}
-	summary, err := s.chainState.ConnectBlock(blockBytes, s.cfg.ExpectedTarget, prevTimestamps, s.cfg.ChainID)
-	if err != nil {
-		return nil, err
-	}
-	if err := s.persistAppliedBlock(summary, blockHash, pb, blockBytes, prevState); err != nil {
-		return nil, s.rollbackApplyBlock(err, rollbackState)
+	reorgDepth := currentTipHeight - commonAncestorHeight
+	for currentTipHeight > commonAncestorHeight {
+		if _, err := s.DisconnectTip(); err != nil {
+			return nil, s.rollbackApplyBlock(err, rollbackState)
+		}
+		currentTipHeight--
 	}
 
-	s.recordAppliedBlock(summary.BlockHeight, pb.Header.Timestamp)
-	if s.mempool != nil {
-		_ = s.mempool.EvictConfirmed(blockBytes)
-		_ = s.mempool.RemoveConflicting(blockBytes)
+	var summary *ChainStateConnectSummary
+	for _, item := range branch {
+		summary, err = s.applyCanonicalParsedBlock(item.parsed, item.blockBytes, prevTimestamps)
+		if err != nil {
+			return nil, s.rollbackApplyBlock(err, rollbackState)
+		}
 	}
+	s.noteReorg(reorgDepth)
 	return summary, nil
 }
 
@@ -255,6 +329,15 @@ type syncRollbackState struct {
 	canonicalCount  uint64
 	tipTimestamp    uint64
 	bestKnownHeight uint64
+	lastReorgDepth  uint64
+	reorgCount      uint64
+}
+
+type reorgBranchBlock struct {
+	hash       [32]byte
+	blockBytes []byte
+	parsed     *consensus.ParsedBlock
+	header     consensus.BlockHeader
 }
 
 func headerSyncRequest(chainState *ChainState, limit uint64) HeaderRequest {
@@ -291,6 +374,8 @@ func (s *SyncEngine) captureRollbackState() (syncRollbackState, error) {
 		canonicalCount:  canonicalCount,
 		tipTimestamp:    s.tipTimestamp,
 		bestKnownHeight: s.bestKnownHeight,
+		lastReorgDepth:  s.lastReorgDepth,
+		reorgCount:      s.reorgCount,
 	}, nil
 }
 
@@ -304,11 +389,115 @@ func (s *SyncEngine) rollbackApplyBlock(cause error, state syncRollbackState) er
 	s.mu.Lock()
 	s.tipTimestamp = state.tipTimestamp
 	s.bestKnownHeight = state.bestKnownHeight
+	s.lastReorgDepth = state.lastReorgDepth
+	s.reorgCount = state.reorgCount
 	s.mu.Unlock()
 	if restoreErr != nil {
 		return fmt.Errorf("%w (rollback failed: %v)", cause, restoreErr)
 	}
 	return cause
+}
+
+func (s *SyncEngine) applyCanonicalParsedBlock(
+	pb *consensus.ParsedBlock,
+	blockBytes []byte,
+	prevTimestamps []uint64,
+) (*ChainStateConnectSummary, error) {
+	if s == nil || s.chainState == nil {
+		return nil, errors.New("sync engine is not initialized")
+	}
+	if pb == nil {
+		return nil, errors.New("nil parsed block")
+	}
+	blockHeight, _, err := nextBlockContext(s.chainState)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateIncomingChainID(blockHeight, s.cfg.ChainID); err != nil {
+		return nil, err
+	}
+	blockHash, err := consensus.BlockHash(pb.HeaderBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	rollbackState, err := s.captureRollbackState()
+	if err != nil {
+		return nil, err
+	}
+	prevState, err := chainStateFromDisk(rollbackState.chainState)
+	if err != nil {
+		return nil, err
+	}
+	summary, err := s.chainState.ConnectBlock(blockBytes, s.cfg.ExpectedTarget, prevTimestamps, s.cfg.ChainID)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.persistAppliedBlock(summary, blockHash, pb, blockBytes, prevState); err != nil {
+		return nil, s.rollbackApplyBlock(err, rollbackState)
+	}
+
+	s.recordAppliedBlock(summary.BlockHeight, pb.Header.Timestamp)
+	if s.mempool != nil {
+		_ = s.mempool.EvictConfirmed(blockBytes)
+		_ = s.mempool.RemoveConflicting(blockBytes)
+	}
+	return summary, nil
+}
+
+func (s *SyncEngine) collectBranchToCanonical(
+	blockHash [32]byte,
+	blockBytes []byte,
+	pb *consensus.ParsedBlock,
+) ([]reorgBranchBlock, [32]byte, uint64, error) {
+	branch := []reorgBranchBlock{{
+		hash:       blockHash,
+		blockBytes: append([]byte(nil), blockBytes...),
+		parsed:     pb,
+		header:     pb.Header,
+	}}
+	parentHash := pb.Header.PrevBlockHash
+	for {
+		height, found, err := s.blockStore.FindCanonicalHeight(parentHash)
+		if err != nil {
+			return nil, [32]byte{}, 0, err
+		}
+		if found {
+			reverseBranchBlocks(branch)
+			return branch, parentHash, height, nil
+		}
+		parentBlockBytes, err := s.blockStore.GetBlockByHash(parentHash)
+		if err != nil {
+			return nil, [32]byte{}, 0, ErrParentNotFound
+		}
+		parentParsed, err := consensus.ParseBlockBytes(parentBlockBytes)
+		if err != nil {
+			return nil, [32]byte{}, 0, err
+		}
+		branch = append(branch, reorgBranchBlock{
+			hash:       parentHash,
+			blockBytes: parentBlockBytes,
+			parsed:     parentParsed,
+			header:     parentParsed.Header,
+		})
+		parentHash = parentParsed.Header.PrevBlockHash
+	}
+}
+
+func (s *SyncEngine) syntheticSideChainSummary(height uint64, blockHash [32]byte) *ChainStateConnectSummary {
+	utxoCount := uint64(0)
+	alreadyGenerated := uint64(0)
+	if s != nil && s.chainState != nil {
+		utxoCount = uint64(len(s.chainState.Utxos))
+		alreadyGenerated = s.chainState.AlreadyGenerated
+	}
+	return &ChainStateConnectSummary{
+		BlockHeight:        height,
+		BlockHash:          blockHash,
+		AlreadyGenerated:   alreadyGenerated,
+		AlreadyGeneratedN1: alreadyGenerated,
+		UtxoCount:          utxoCount,
+	}
 }
 
 func (s *SyncEngine) persistAppliedBlock(summary *ChainStateConnectSummary, blockHash [32]byte, pb *consensus.ParsedBlock, blockBytes []byte, prevState *ChainState) error {
@@ -338,6 +527,19 @@ func (s *SyncEngine) recordAppliedBlock(height uint64, timestamp uint64) {
 	s.tipTimestamp = timestamp
 	if height > s.bestKnownHeight {
 		s.bestKnownHeight = height
+	}
+	s.lastReorgDepth = 0
+}
+
+func (s *SyncEngine) noteReorg(depth uint64) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.lastReorgDepth = depth
+	if depth > 0 {
+		s.reorgCount++
 	}
 }
 
@@ -390,4 +592,10 @@ func parentTipTimestamp(store *BlockStore, tipHeight uint64, prevBlockHash [32]b
 		return 0, err
 	}
 	return parentHeader.Timestamp, nil
+}
+
+func reverseBranchBlocks(branch []reorgBranchBlock) {
+	for left, right := 0, len(branch)-1; left < right; left, right = left+1, right-1 {
+		branch[left], branch[right] = branch[right], branch[left]
+	}
 }

--- a/clients/go/node/sync_reorg_test.go
+++ b/clients/go/node/sync_reorg_test.go
@@ -1,0 +1,171 @@
+package node
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+)
+
+func TestReorgTwoMiners(t *testing.T) {
+	dir := t.TempDir()
+	store, err := OpenBlockStore(BlockStorePath(dir))
+	if err != nil {
+		t.Fatalf("OpenBlockStore: %v", err)
+	}
+	target := consensus.POW_LIMIT
+	engine, err := NewSyncEngine(NewChainState(), store, DefaultSyncConfig(&target, devnetGenesisChainID, ChainStatePath(dir)))
+	if err != nil {
+		t.Fatalf("NewSyncEngine: %v", err)
+	}
+	if _, err := engine.ApplyBlock(devnetGenesisBlockBytes, nil); err != nil {
+		t.Fatalf("ApplyBlock(genesis): %v", err)
+	}
+
+	subsidy1 := consensus.BlockSubsidy(1, 0)
+	blockA1 := buildSingleTxBlock(t, devnetGenesisBlockHash, target, 2, coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 1, subsidy1))
+	summaryA1, err := engine.ApplyBlock(blockA1, nil)
+	if err != nil {
+		t.Fatalf("ApplyBlock(A1): %v", err)
+	}
+	if summaryA1.BlockHeight != 1 {
+		t.Fatalf("A1 height=%d, want 1", summaryA1.BlockHeight)
+	}
+
+	blockB1 := buildSingleTxBlock(t, devnetGenesisBlockHash, target, 3, coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 1, subsidy1))
+	summaryB1, err := engine.ApplyBlockWithReorg(blockB1, nil)
+	if err != nil {
+		t.Fatalf("ApplyBlockWithReorg(B1): %v", err)
+	}
+	if summaryB1.BlockHeight != 1 {
+		t.Fatalf("B1 height=%d, want 1", summaryB1.BlockHeight)
+	}
+	if engine.chainState.Height != 1 || engine.chainState.TipHash != summaryA1.BlockHash {
+		t.Fatalf("canonical tip changed before heavier branch")
+	}
+
+	subsidy2 := consensus.BlockSubsidy(2, subsidy1)
+	blockB1Hash, err := consensus.BlockHash(blockHeaderBytes(t, blockB1))
+	if err != nil {
+		t.Fatalf("BlockHash(B1): %v", err)
+	}
+	blockB2 := buildSingleTxBlock(t, blockB1Hash, target, 4, coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 2, subsidy2))
+	summaryB2, err := engine.ApplyBlockWithReorg(blockB2, nil)
+	if err != nil {
+		t.Fatalf("ApplyBlockWithReorg(B2): %v", err)
+	}
+	if summaryB2.BlockHeight != 2 {
+		t.Fatalf("B2 height=%d, want 2", summaryB2.BlockHeight)
+	}
+	if depth := engine.LastReorgDepth(); depth != 1 {
+		t.Fatalf("LastReorgDepth()=%d, want 1", depth)
+	}
+	if count := engine.ReorgCount(); count != 1 {
+		t.Fatalf("ReorgCount()=%d, want 1", count)
+	}
+
+	b1CanonicalHash, ok, err := store.CanonicalHash(1)
+	if err != nil || !ok {
+		t.Fatalf("CanonicalHash(1): ok=%v err=%v", ok, err)
+	}
+	b2CanonicalHash, ok, err := store.CanonicalHash(2)
+	if err != nil || !ok {
+		t.Fatalf("CanonicalHash(2): ok=%v err=%v", ok, err)
+	}
+	if b1CanonicalHash != blockB1Hash {
+		t.Fatalf("height 1 canonical hash=%x, want %x", b1CanonicalHash, blockB1Hash)
+	}
+	if b2CanonicalHash != summaryB2.BlockHash {
+		t.Fatalf("height 2 canonical hash=%x, want %x", b2CanonicalHash, summaryB2.BlockHash)
+	}
+}
+
+func TestDeepReorg10(t *testing.T) {
+	dir := t.TempDir()
+	store, err := OpenBlockStore(BlockStorePath(dir))
+	if err != nil {
+		t.Fatalf("OpenBlockStore: %v", err)
+	}
+	target := consensus.POW_LIMIT
+	engine, err := NewSyncEngine(NewChainState(), store, DefaultSyncConfig(&target, devnetGenesisChainID, ChainStatePath(dir)))
+	if err != nil {
+		t.Fatalf("NewSyncEngine: %v", err)
+	}
+	if _, err := engine.ApplyBlock(devnetGenesisBlockBytes, nil); err != nil {
+		t.Fatalf("ApplyBlock(genesis): %v", err)
+	}
+
+	mainPrev := devnetGenesisBlockHash
+	mainAlreadyGenerated := uint64(0)
+	for height := uint64(1); height <= 10; height++ {
+		subsidy := consensus.BlockSubsidy(height, mainAlreadyGenerated)
+		block := buildSingleTxBlock(t, mainPrev, target, height+1, coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, height, subsidy))
+		summary, err := engine.ApplyBlock(block, nil)
+		if err != nil {
+			t.Fatalf("ApplyBlock(A%d): %v", height, err)
+		}
+		mainPrev = summary.BlockHash
+		mainAlreadyGenerated += subsidy
+	}
+
+	sidePrev := devnetGenesisBlockHash
+	sideAlreadyGenerated := uint64(0)
+	sideBlocks := make([][]byte, 0, 11)
+	for height := uint64(1); height <= 11; height++ {
+		subsidy := consensus.BlockSubsidy(height, sideAlreadyGenerated)
+		block := buildSingleTxBlock(t, sidePrev, target, 100+height, coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, height, subsidy))
+		sideBlocks = append(sideBlocks, block)
+		sidePrev, err = consensus.BlockHash(blockHeaderBytes(t, block))
+		if err != nil {
+			t.Fatalf("BlockHash(B%d): %v", height, err)
+		}
+		sideAlreadyGenerated += subsidy
+	}
+	for index, block := range sideBlocks {
+		if _, err := engine.ApplyBlockWithReorg(block, nil); err != nil {
+			t.Fatalf("ApplyBlockWithReorg(B%d): %v", index+1, err)
+		}
+	}
+	if depth := engine.LastReorgDepth(); depth != 10 {
+		t.Fatalf("LastReorgDepth()=%d, want 10", depth)
+	}
+
+	referenceStore, err := OpenBlockStore(BlockStorePath(t.TempDir()))
+	if err != nil {
+		t.Fatalf("OpenBlockStore(reference): %v", err)
+	}
+	referenceState := NewChainState()
+	referenceEngine, err := NewSyncEngine(referenceState, referenceStore, DefaultSyncConfig(&target, devnetGenesisChainID, ""))
+	if err != nil {
+		t.Fatalf("NewSyncEngine(reference): %v", err)
+	}
+	if _, err := referenceEngine.ApplyBlock(devnetGenesisBlockBytes, nil); err != nil {
+		t.Fatalf("ApplyBlock(reference genesis): %v", err)
+	}
+	for index, block := range sideBlocks {
+		if _, err := referenceEngine.ApplyBlock(block, nil); err != nil {
+			t.Fatalf("ApplyBlock(reference B%d): %v", index+1, err)
+		}
+	}
+
+	gotDisk, err := stateToDisk(engine.chainState)
+	if err != nil {
+		t.Fatalf("stateToDisk(got): %v", err)
+	}
+	wantDisk, err := stateToDisk(referenceState)
+	if err != nil {
+		t.Fatalf("stateToDisk(want): %v", err)
+	}
+	if !reflect.DeepEqual(gotDisk, wantDisk) {
+		t.Fatalf("reorged chainstate does not match canonical replay")
+	}
+}
+
+func blockHeaderBytes(t *testing.T, blockBytes []byte) []byte {
+	t.Helper()
+	pb, err := consensus.ParseBlockBytes(blockBytes)
+	if err != nil {
+		t.Fatalf("ParseBlockBytes: %v", err)
+	}
+	return pb.HeaderBytes
+}

--- a/clients/rust/crates/rubin-node/src/blockstore.rs
+++ b/clients/rust/crates/rubin-node/src/blockstore.rs
@@ -143,6 +143,86 @@ impl BlockStore {
             .join(format!("{}.bin", hex::encode(block_hash_bytes)));
         fs::read(&path).map_err(|e| format!("read header {}: {e}", path.display()))
     }
+
+    pub fn has_block(&self, block_hash_bytes: [u8; 32]) -> bool {
+        self.headers_dir
+            .join(format!("{}.bin", hex::encode(block_hash_bytes)))
+            .exists()
+    }
+
+    pub fn find_canonical_height(&self, block_hash_bytes: [u8; 32]) -> Result<Option<u64>, String> {
+        let Some((tip_height, _)) = self.tip()? else {
+            return Ok(None);
+        };
+        for height in (0..=tip_height).rev() {
+            if self.canonical_hash(height)? == Some(block_hash_bytes) {
+                return Ok(Some(height));
+            }
+        }
+        Ok(None)
+    }
+
+    pub fn locator_hashes(&self, limit: usize) -> Result<Vec<[u8; 32]>, String> {
+        let limit = if limit == 0 { 32 } else { limit };
+        let Some((mut tip_height, _)) = self.tip()? else {
+            return Ok(Vec::new());
+        };
+        let mut out = Vec::with_capacity(limit);
+        let mut step = 1u64;
+        let mut appended = 0usize;
+        loop {
+            let Some(hash) = self.canonical_hash(tip_height)? else {
+                break;
+            };
+            out.push(hash);
+            appended += 1;
+            if appended >= limit || tip_height == 0 {
+                break;
+            }
+            if appended >= 10 {
+                step = step.saturating_mul(2);
+            }
+            if tip_height <= step {
+                tip_height = 0;
+            } else {
+                tip_height -= step;
+            }
+        }
+        Ok(out)
+    }
+
+    pub fn hashes_after_locators(
+        &self,
+        locator_hashes: &[[u8; 32]],
+        stop_hash: [u8; 32],
+        limit: u64,
+    ) -> Result<Vec<[u8; 32]>, String> {
+        let limit = if limit == 0 { 128 } else { limit };
+        let Some((tip_height, _)) = self.tip()? else {
+            return Ok(Vec::new());
+        };
+        let mut start_height = 0u64;
+        for locator in locator_hashes {
+            if let Some(height) = self.find_canonical_height(*locator)? {
+                start_height = height.saturating_add(1);
+                break;
+            }
+        }
+        let mut out = Vec::with_capacity(limit as usize);
+        for height in start_height..=tip_height {
+            if out.len() as u64 >= limit {
+                break;
+            }
+            let Some(hash) = self.canonical_hash(height)? else {
+                break;
+            };
+            out.push(hash);
+            if stop_hash != [0u8; 32] && hash == stop_hash {
+                break;
+            }
+        }
+        Ok(out)
+    }
 }
 
 pub fn block_store_path<P: AsRef<Path>>(data_dir: P) -> PathBuf {

--- a/clients/rust/crates/rubin-node/src/interop/mod.rs
+++ b/clients/rust/crates/rubin-node/src/interop/mod.rs
@@ -1,12 +1,18 @@
+use std::fs;
 use std::io;
 use std::net::{TcpListener, TcpStream};
+use std::path::PathBuf;
 use std::time::Duration;
 
 use rubin_consensus::block_hash;
+use rubin_consensus::constants::POW_LIMIT;
 
 use crate::p2p_runtime::{
     default_peer_runtime_config, perform_version_handshake, PeerSession, VersionPayloadV1,
     WireMessage,
+};
+use crate::{
+    block_store_path, chain_state_path, default_sync_config, BlockStore, ChainState, SyncEngine,
 };
 use crate::{devnet_genesis_block_bytes, devnet_genesis_chain_id};
 
@@ -23,6 +29,7 @@ pub enum Action {
     Idle,
     SendPingExpectPong,
     ExpectTx { payload: Vec<u8> },
+    SyncBlocks,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -113,6 +120,7 @@ pub fn parse_args(args: &[String]) -> Result<CliConfig, String> {
         "expect-tx" => Action::ExpectTx {
             payload: decode_hex(&payload_hex)?,
         },
+        "sync-blocks" => Action::SyncBlocks,
         other => return Err(format!("unknown action: {other}")),
     };
 
@@ -223,6 +231,33 @@ pub fn run_action(session: &mut PeerSession, action: &Action) -> io::Result<()> 
             }
             Ok(())
         }
+        Action::SyncBlocks => {
+            let mut data_dir = unique_interop_temp_dir();
+            let block_store =
+                BlockStore::open(block_store_path(&data_dir)).map_err(io::Error::other)?;
+            let chain_state_path = chain_state_path(&data_dir);
+            let mut cfg = default_sync_config(
+                Some(POW_LIMIT),
+                devnet_genesis_chain_id(),
+                Some(chain_state_path),
+            );
+            cfg.network = "devnet".to_string();
+            let mut engine = SyncEngine::new(ChainState::new(), Some(block_store), cfg)
+                .map_err(io::Error::other)?;
+            let synced_height = session.run_block_sync_loop(&mut engine)?;
+            if synced_height != session.state().remote_version.best_height {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "sync height mismatch: got {} want {}",
+                        synced_height,
+                        session.state().remote_version.best_height
+                    ),
+                ));
+            }
+            let _ = fs::remove_dir_all(&mut data_dir);
+            Ok(())
+        }
     }
 }
 
@@ -245,6 +280,17 @@ pub fn decode_hex(raw: &str) -> Result<Vec<u8>, String> {
         return Ok(Vec::new());
     }
     hex::decode(raw).map_err(|err| format!("invalid hex: {err}"))
+}
+
+fn unique_interop_temp_dir() -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "rubin-rust-p2p-interop-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("time")
+            .as_nanos()
+    ))
 }
 
 #[cfg(test)]

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -7,17 +7,41 @@ use std::time::Duration;
 use rubin_consensus::constants::MAX_RELAY_MSG_BYTES;
 use sha3::{Digest, Sha3_256};
 
+use crate::sync::SyncEngine;
+
 const DEFAULT_READ_DEADLINE: Duration = Duration::from_secs(15);
 const DEFAULT_WRITE_DEADLINE: Duration = Duration::from_secs(15);
 const DEFAULT_BAN_THRESHOLD: i32 = 100;
 const WIRE_HEADER_SIZE: usize = 24;
 const WIRE_COMMAND_SIZE: usize = 12;
 const FUZZ_MAX_P2P_PAYLOAD_BYTES: u64 = 1 << 20;
+const MESSAGE_INV: &str = "inv";
+const MESSAGE_GETDATA: &str = "getdata";
+const MESSAGE_BLOCK: &str = "block";
+const MESSAGE_TX: &str = "tx";
+const MESSAGE_GETBLOCKS: &str = "getblocks";
+const MESSAGE_GETADDR: &str = "getaddr";
+const MESSAGE_ADDR: &str = "addr";
+pub const MSG_BLOCK: u8 = 0x01;
+pub const MSG_TX: u8 = 0x02;
+const INVENTORY_VECTOR_SIZE: usize = 33;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct WireMessage {
     pub command: String,
     pub payload: Vec<u8>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct InventoryVector {
+    pub kind: u8,
+    pub hash: [u8; 32],
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+pub struct GetBlocksPayload {
+    pub locator_hashes: Vec<[u8; 32]>,
+    pub stop_hash: [u8; 32],
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
@@ -190,7 +214,7 @@ impl PeerSession {
                     };
                     self.write_message(&pong)?;
                 }
-                "tx" | "block" | "headers" => {
+                "tx" | "block" | "headers" | "getaddr" | "addr" => {
                     // accepted runtime commands (stub)
                 }
                 other => {
@@ -204,6 +228,143 @@ impl PeerSession {
                 }
             }
         }
+    }
+
+    pub fn run_block_sync_loop(&mut self, sync_engine: &mut SyncEngine) -> io::Result<u64> {
+        self.request_blocks(sync_engine)?;
+        loop {
+            if let Some((height, _)) = sync_engine.tip().map_err(io::Error::other)? {
+                if height >= self.peer.remote_version.best_height {
+                    return Ok(height);
+                }
+            }
+            let msg = self.read_message()?;
+            match msg.command.as_str() {
+                MESSAGE_INV => {
+                    let requests = self.handle_inv(&msg.payload, sync_engine)?;
+                    if !requests.is_empty() {
+                        let payload = encode_inventory_vectors(&requests)?;
+                        self.write_message(&WireMessage {
+                            command: MESSAGE_GETDATA.to_string(),
+                            payload,
+                        })?;
+                    }
+                }
+                MESSAGE_GETDATA => {
+                    for item in decode_inventory_vectors(&msg.payload)? {
+                        if item.kind != MSG_BLOCK {
+                            continue;
+                        }
+                        let block = sync_engine
+                            .get_block_by_hash(item.hash)
+                            .map_err(io::Error::other)?;
+                        self.write_message(&WireMessage {
+                            command: MESSAGE_BLOCK.to_string(),
+                            payload: block,
+                        })?;
+                    }
+                }
+                MESSAGE_GETBLOCKS => {
+                    let items = self.handle_getblocks(&msg.payload, sync_engine)?;
+                    if items.is_empty() {
+                        continue;
+                    }
+                    self.write_message(&WireMessage {
+                        command: MESSAGE_INV.to_string(),
+                        payload: encode_inventory_vectors(&items)?,
+                    })?;
+                }
+                MESSAGE_BLOCK => {
+                    self.handle_block(&msg.payload, sync_engine)?;
+                }
+                MESSAGE_TX | "headers" | "pong" => {}
+                "ping" => {
+                    self.write_message(&WireMessage {
+                        command: "pong".to_string(),
+                        payload: Vec::new(),
+                    })?;
+                }
+                MESSAGE_GETADDR => {
+                    self.write_message(&WireMessage {
+                        command: MESSAGE_ADDR.to_string(),
+                        payload: marshal_empty_addr_payload(),
+                    })?;
+                }
+                MESSAGE_ADDR => {
+                    let _ = unmarshal_addr_payload(&msg.payload)?;
+                }
+                other => {
+                    self.bump_ban(1, &format!("unknown command: {other}"));
+                    if self.peer.ban_score >= self.cfg.ban_threshold {
+                        return Err(io::Error::new(
+                            io::ErrorKind::PermissionDenied,
+                            "peer banned",
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn request_blocks(&mut self, sync_engine: &SyncEngine) -> io::Result<()> {
+        let payload = encode_getblocks_payload(GetBlocksPayload {
+            locator_hashes: sync_engine.locator_hashes(32).map_err(io::Error::other)?,
+            stop_hash: [0u8; 32],
+        })?;
+        self.write_message(&WireMessage {
+            command: MESSAGE_GETBLOCKS.to_string(),
+            payload,
+        })
+    }
+
+    pub fn handle_getblocks(
+        &mut self,
+        payload: &[u8],
+        sync_engine: &SyncEngine,
+    ) -> io::Result<Vec<InventoryVector>> {
+        let req = decode_getblocks_payload(payload)?;
+        let hashes = sync_engine
+            .hashes_after_locators(&req.locator_hashes, req.stop_hash, 128)
+            .map_err(io::Error::other)?;
+        Ok(hashes
+            .into_iter()
+            .map(|hash| InventoryVector {
+                kind: MSG_BLOCK,
+                hash,
+            })
+            .collect())
+    }
+
+    pub fn handle_inv(
+        &mut self,
+        payload: &[u8],
+        sync_engine: &SyncEngine,
+    ) -> io::Result<Vec<InventoryVector>> {
+        let vectors = decode_inventory_vectors(payload)?;
+        let mut requests = Vec::new();
+        for vector in vectors {
+            if vector.kind != MSG_BLOCK {
+                continue;
+            }
+            if !sync_engine
+                .has_block(vector.hash)
+                .map_err(io::Error::other)?
+            {
+                requests.push(vector);
+            }
+        }
+        Ok(requests)
+    }
+
+    pub fn handle_block(
+        &mut self,
+        block_bytes: &[u8],
+        sync_engine: &mut SyncEngine,
+    ) -> io::Result<()> {
+        sync_engine
+            .apply_block(block_bytes, None)
+            .map_err(io::Error::other)?;
+        Ok(())
     }
 }
 
@@ -351,6 +512,176 @@ fn protocol_versions_compatible(local: u32, remote: u32) -> bool {
         return local - remote <= 1;
     }
     remote - local <= 1
+}
+
+pub fn encode_inventory_vectors(items: &[InventoryVector]) -> io::Result<Vec<u8>> {
+    let mut out = Vec::with_capacity(items.len() * INVENTORY_VECTOR_SIZE);
+    for item in items {
+        if item.kind != MSG_BLOCK && item.kind != MSG_TX {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("unsupported inventory type: {}", item.kind),
+            ));
+        }
+        out.push(item.kind);
+        out.extend_from_slice(&item.hash);
+    }
+    Ok(out)
+}
+
+pub fn decode_inventory_vectors(payload: &[u8]) -> io::Result<Vec<InventoryVector>> {
+    if payload.is_empty() {
+        return Ok(Vec::new());
+    }
+    if payload.len() % INVENTORY_VECTOR_SIZE != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "inventory payload width mismatch",
+        ));
+    }
+    let mut out = Vec::with_capacity(payload.len() / INVENTORY_VECTOR_SIZE);
+    for chunk in payload.chunks_exact(INVENTORY_VECTOR_SIZE) {
+        let kind = chunk[0];
+        if kind != MSG_BLOCK && kind != MSG_TX {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("unsupported inventory type: {kind}"),
+            ));
+        }
+        let mut hash = [0u8; 32];
+        hash.copy_from_slice(&chunk[1..33]);
+        out.push(InventoryVector { kind, hash });
+    }
+    Ok(out)
+}
+
+pub fn encode_getblocks_payload(req: GetBlocksPayload) -> io::Result<Vec<u8>> {
+    let count = u16::try_from(req.locator_hashes.len()).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("too many locator hashes: {}", req.locator_hashes.len()),
+        )
+    })?;
+    let mut out = Vec::with_capacity(2 + req.locator_hashes.len() * 32 + 32);
+    out.extend_from_slice(&count.to_be_bytes());
+    for locator in req.locator_hashes {
+        out.extend_from_slice(&locator);
+    }
+    out.extend_from_slice(&req.stop_hash);
+    Ok(out)
+}
+
+pub fn decode_getblocks_payload(payload: &[u8]) -> io::Result<GetBlocksPayload> {
+    if payload.len() < 34 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "getblocks payload too short",
+        ));
+    }
+    let count = u16::from_be_bytes(payload[0..2].try_into().expect("count")) as usize;
+    let want = 2 + count * 32 + 32;
+    if payload.len() != want {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "getblocks payload width mismatch",
+        ));
+    }
+    let mut locator_hashes = Vec::with_capacity(count);
+    let mut offset = 2usize;
+    for _ in 0..count {
+        let mut locator = [0u8; 32];
+        locator.copy_from_slice(&payload[offset..offset + 32]);
+        locator_hashes.push(locator);
+        offset += 32;
+    }
+    let mut stop_hash = [0u8; 32];
+    stop_hash.copy_from_slice(&payload[offset..offset + 32]);
+    Ok(GetBlocksPayload {
+        locator_hashes,
+        stop_hash,
+    })
+}
+
+fn marshal_empty_addr_payload() -> Vec<u8> {
+    vec![0u8]
+}
+
+fn unmarshal_addr_payload(payload: &[u8]) -> io::Result<Vec<String>> {
+    let (count, consumed) = decode_compact_size(payload)?;
+    let needed = consumed
+        .checked_add(
+            usize::try_from(count)
+                .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "addr count overflow"))?
+                .saturating_mul(18),
+        )
+        .ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidData, "addr payload length overflow")
+        })?;
+    if payload.len() != needed {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "addr payload width mismatch",
+        ));
+    }
+    let mut out = Vec::with_capacity(count as usize);
+    let mut offset = consumed;
+    for _ in 0..count {
+        let ip = std::net::Ipv6Addr::from(
+            <[u8; 16]>::try_from(&payload[offset..offset + 16]).expect("ip"),
+        );
+        offset += 16;
+        let port = u16::from_be_bytes(payload[offset..offset + 2].try_into().expect("port"));
+        offset += 2;
+        out.push(std::net::SocketAddr::new(ip.into(), port).to_string());
+    }
+    Ok(out)
+}
+
+fn decode_compact_size(payload: &[u8]) -> io::Result<(u64, usize)> {
+    let Some(first) = payload.first().copied() else {
+        return Err(io::Error::new(
+            io::ErrorKind::UnexpectedEof,
+            "compactsize truncated",
+        ));
+    };
+    match first {
+        0x00..=0xfc => Ok((u64::from(first), 1)),
+        0xfd => {
+            if payload.len() < 3 {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "compactsize truncated",
+                ));
+            }
+            Ok((u64::from(u16::from_le_bytes([payload[1], payload[2]])), 3))
+        }
+        0xfe => {
+            if payload.len() < 5 {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "compactsize truncated",
+                ));
+            }
+            Ok((
+                u64::from(u32::from_le_bytes(
+                    payload[1..5].try_into().expect("u32 compactsize"),
+                )),
+                5,
+            ))
+        }
+        0xff => {
+            if payload.len() < 9 {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "compactsize truncated",
+                ));
+            }
+            Ok((
+                u64::from_le_bytes(payload[1..9].try_into().expect("u64 compactsize")),
+                9,
+            ))
+        }
+    }
 }
 
 fn marshal_version_payload_v1(v: VersionPayloadV1) -> Vec<u8> {

--- a/clients/rust/crates/rubin-node/src/sync.rs
+++ b/clients/rust/crates/rubin-node/src/sync.rs
@@ -97,6 +97,51 @@ impl SyncEngine {
         self.best_known_height
     }
 
+    pub fn tip(&self) -> Result<Option<(u64, [u8; 32])>, String> {
+        if let Some(block_store) = self.block_store.as_ref() {
+            return block_store.tip();
+        }
+        if !self.chain_state.has_tip {
+            return Ok(None);
+        }
+        Ok(Some((self.chain_state.height, self.chain_state.tip_hash)))
+    }
+
+    pub fn locator_hashes(&self, limit: usize) -> Result<Vec<[u8; 32]>, String> {
+        match self.block_store.as_ref() {
+            Some(block_store) => block_store.locator_hashes(limit),
+            None => Ok(Vec::new()),
+        }
+    }
+
+    pub fn hashes_after_locators(
+        &self,
+        locator_hashes: &[[u8; 32]],
+        stop_hash: [u8; 32],
+        limit: u64,
+    ) -> Result<Vec<[u8; 32]>, String> {
+        match self.block_store.as_ref() {
+            Some(block_store) => {
+                block_store.hashes_after_locators(locator_hashes, stop_hash, limit)
+            }
+            None => Ok(Vec::new()),
+        }
+    }
+
+    pub fn get_block_by_hash(&self, block_hash_bytes: [u8; 32]) -> Result<Vec<u8>, String> {
+        let Some(block_store) = self.block_store.as_ref() else {
+            return Err("sync engine missing blockstore".to_string());
+        };
+        block_store.get_block_by_hash(block_hash_bytes)
+    }
+
+    pub fn has_block(&self, block_hash_bytes: [u8; 32]) -> Result<bool, String> {
+        let Some(block_store) = self.block_store.as_ref() else {
+            return Ok(false);
+        };
+        Ok(block_store.has_block(block_hash_bytes))
+    }
+
     pub fn is_in_ibd(&self, now_unix: u64) -> bool {
         if !self.chain_state.has_tip {
             return true;


### PR DESCRIPTION
Implements Q-DEVNET-P2P-01, Q-DEVNET-P2P-02, Q-DEVNET-P2P-03, Q-DEVNET-P2P-04, and Q-DEVNET-P2P-05.

Summary:
- Go reorg + chainwork fork choice
- Go orphan block pool + recursive resolve
- Go auto-reconnect with exponential backoff
- Go GETADDR/ADDR peer discovery
- Rust block relay + IBD parity with Go interop test

Validation:
- `scripts/dev-env.sh -- bash -lc "cd clients/go && RUBIN_P2P_INTEROP=1 go test ./node ./node/p2p -count=1"`
- `scripts/dev-env.sh -- bash -lc "cd clients/rust && cargo test -p rubin-node"`