### PR TITLE
feat: add devnet orphan block pool resolution

### DIFF
--- a/clients/go/node/p2p/handlers_block.go
+++ b/clients/go/node/p2p/handlers_block.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/node"
 )
 
 func (p *peer) handleGetBlocks(payload []byte) error {
@@ -41,28 +42,43 @@ func (p *peer) blockInventoryAfterLocators(req GetBlocksPayload) ([]InventoryVec
 }
 
 func (p *peer) handleBlock(blockBytes []byte) error {
+	summary, err := p.processRelayedBlock(blockBytes)
+	if err != nil {
+		return err
+	}
+	if summary == nil {
+		return nil
+	}
+	return p.service.requestBlocksIfBehind(p)
+}
+
+func (p *peer) processRelayedBlock(blockBytes []byte) (*node.ChainStateConnectSummary, error) {
 	pb, blockHash, err := parseRelayedBlock(blockBytes)
 	if err != nil {
 		p.bumpBan(10, err.Error())
-		return err
+		return nil, err
 	}
 	if pb == nil {
-		return errors.New("nil parsed block")
+		return nil, errors.New("nil parsed block")
 	}
 	have, err := p.service.hasBlock(blockHash)
 	if err != nil || have {
-		return err
+		return nil, err
 	}
 
 	p.service.chainMu.Lock()
 	summary, err := p.service.cfg.SyncEngine.ApplyBlockWithReorg(blockBytes, nil)
 	p.service.chainMu.Unlock()
 	if err != nil {
+		if errors.Is(err, node.ErrParentNotFound) {
+			p.service.orphans.Add(blockHash, pb.Header.PrevBlockHash, blockBytes)
+			return nil, nil
+		}
 		p.bumpBan(100, err.Error())
-		return err
+		return nil, err
 	}
-	p.acceptedRelayedBlock(blockHash, summary.BlockHeight)
-	return p.service.requestBlocksIfBehind(p)
+	p.acceptedRelayedBlock(blockHash, summary)
+	return summary, nil
 }
 
 func parseRelayedBlock(blockBytes []byte) (*consensus.ParsedBlock, [32]byte, error) {
@@ -77,9 +93,34 @@ func parseRelayedBlock(blockBytes []byte) (*consensus.ParsedBlock, [32]byte, err
 	return pb, blockHash, nil
 }
 
-func (p *peer) acceptedRelayedBlock(blockHash [32]byte, height uint64) {
-	p.service.cfg.SyncEngine.RecordBestKnownHeight(height)
+func (p *peer) acceptedRelayedBlock(blockHash [32]byte, summary *node.ChainStateConnectSummary) {
+	p.service.cfg.SyncEngine.RecordBestKnownHeight(summary.BlockHeight)
 	if p.service.blockSeen.Add(blockHash) {
 		_ = p.service.broadcastInventory(p, []InventoryVector{{Type: MSG_BLOCK, Hash: blockHash}})
+	}
+	p.service.resolveOrphans(p, blockHash)
+}
+
+func (s *Service) resolveOrphans(skip *peer, blockHash [32]byte) {
+	children := s.orphans.TakeChildren(blockHash)
+	for _, child := range children {
+		pb, childHash, err := parseRelayedBlock(child.blockBytes)
+		if err != nil {
+			continue
+		}
+		s.chainMu.Lock()
+		summary, applyErr := s.cfg.SyncEngine.ApplyBlockWithReorg(child.blockBytes, nil)
+		s.chainMu.Unlock()
+		if applyErr != nil {
+			if errors.Is(applyErr, node.ErrParentNotFound) {
+				s.orphans.Add(childHash, pb.Header.PrevBlockHash, child.blockBytes)
+			}
+			continue
+		}
+		s.cfg.SyncEngine.RecordBestKnownHeight(summary.BlockHeight)
+		if s.blockSeen.Add(childHash) {
+			_ = s.broadcastInventory(skip, []InventoryVector{{Type: MSG_BLOCK, Hash: childHash}})
+		}
+		s.resolveOrphans(skip, childHash)
 	}
 }

--- a/clients/go/node/p2p/orphan_pool.go
+++ b/clients/go/node/p2p/orphan_pool.go
@@ -1,0 +1,137 @@
+package p2p
+
+import "sync"
+
+const defaultOrphanByteLimit = 64 << 20
+
+type orphanEntry struct {
+	blockHash  [32]byte
+	parentHash [32]byte
+	blockBytes []byte
+}
+
+type orphanMeta struct {
+	parentHash [32]byte
+	size       int
+}
+
+type orphanPool struct {
+	mu         sync.Mutex
+	limit      int
+	byteLimit  int
+	totalBytes int
+	pool       map[[32]byte][]orphanEntry
+	byHash     map[[32]byte]orphanMeta
+	fifo       [][32]byte
+}
+
+func newOrphanPool(limit int) *orphanPool {
+	if limit <= 0 {
+		limit = 500
+	}
+	return &orphanPool{
+		limit:     limit,
+		byteLimit: defaultOrphanByteLimit,
+		pool:      make(map[[32]byte][]orphanEntry),
+		byHash:    make(map[[32]byte]orphanMeta),
+	}
+}
+
+func (o *orphanPool) Add(blockHash, parentHash [32]byte, blockBytes []byte) bool {
+	if o == nil {
+		return false
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if _, exists := o.byHash[blockHash]; exists {
+		return false
+	}
+	if o.byteLimit > 0 && len(blockBytes) > o.byteLimit {
+		return false
+	}
+	entry := orphanEntry{
+		blockHash:  blockHash,
+		parentHash: parentHash,
+		blockBytes: append([]byte(nil), blockBytes...),
+	}
+	o.pool[parentHash] = append(o.pool[parentHash], entry)
+	o.byHash[blockHash] = orphanMeta{parentHash: parentHash, size: len(entry.blockBytes)}
+	o.fifo = append(o.fifo, blockHash)
+	o.totalBytes += len(entry.blockBytes)
+	for len(o.byHash) > o.limit || (o.byteLimit > 0 && o.totalBytes > o.byteLimit) {
+		o.evictOldest()
+	}
+	return true
+}
+
+func (o *orphanPool) TakeChildren(parentHash [32]byte) []orphanEntry {
+	if o == nil {
+		return nil
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	children := append([]orphanEntry(nil), o.pool[parentHash]...)
+	delete(o.pool, parentHash)
+	removed := make(map[[32]byte]struct{}, len(children))
+	for _, child := range children {
+		if meta, ok := o.byHash[child.blockHash]; ok {
+			o.totalBytes -= meta.size
+			delete(o.byHash, child.blockHash)
+		}
+		removed[child.blockHash] = struct{}{}
+	}
+	if len(removed) > 0 {
+		o.pruneFIFO(removed)
+	}
+	return children
+}
+
+func (o *orphanPool) Len() int {
+	if o == nil {
+		return 0
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return len(o.byHash)
+}
+
+func (o *orphanPool) evictOldest() {
+	for len(o.fifo) > 0 {
+		oldest := o.fifo[0]
+		o.fifo = o.fifo[1:]
+		meta, exists := o.byHash[oldest]
+		if !exists {
+			continue
+		}
+		delete(o.byHash, oldest)
+		o.totalBytes -= meta.size
+		children := o.pool[meta.parentHash]
+		for index, child := range children {
+			if child.blockHash != oldest {
+				continue
+			}
+			children = append(children[:index], children[index+1:]...)
+			break
+		}
+		if len(children) == 0 {
+			delete(o.pool, meta.parentHash)
+		} else {
+			o.pool[meta.parentHash] = children
+		}
+		return
+	}
+}
+
+func (o *orphanPool) pruneFIFO(removed map[[32]byte]struct{}) {
+	if len(o.fifo) == 0 || len(removed) == 0 {
+		return
+	}
+	filtered := o.fifo[:0]
+	for _, blockHash := range o.fifo {
+		if _, drop := removed[blockHash]; drop {
+			continue
+		}
+		filtered = append(filtered, blockHash)
+	}
+	o.fifo = filtered
+}

--- a/clients/go/node/p2p/orphan_pool_test.go
+++ b/clients/go/node/p2p/orphan_pool_test.go
@@ -1,0 +1,96 @@
+package p2p
+
+import "testing"
+
+func TestOrphanPoolDefaultLimitAndDedup(t *testing.T) {
+	pool := newOrphanPool(0)
+	if pool.limit != 500 {
+		t.Fatalf("limit=%d, want 500", pool.limit)
+	}
+	if pool.byteLimit != defaultOrphanByteLimit {
+		t.Fatalf("byteLimit=%d, want %d", pool.byteLimit, defaultOrphanByteLimit)
+	}
+	var parent [32]byte
+	parent[31] = 0x55
+	var blockHash [32]byte
+	blockHash[31] = 0x77
+	if !pool.Add(blockHash, parent, []byte{0x01, 0x02}) {
+		t.Fatalf("expected first add to succeed")
+	}
+	if pool.Add(blockHash, parent, []byte{0x03}) {
+		t.Fatalf("expected duplicate add to be rejected")
+	}
+	children := pool.TakeChildren(parent)
+	if len(children) != 1 {
+		t.Fatalf("children=%d, want 1", len(children))
+	}
+	if got := pool.Len(); got != 0 {
+		t.Fatalf("Len()=%d, want 0", got)
+	}
+	if got := len(pool.fifo); got != 0 {
+		t.Fatalf("fifo_len=%d, want 0", got)
+	}
+	if got := pool.totalBytes; got != 0 {
+		t.Fatalf("totalBytes=%d, want 0", got)
+	}
+}
+
+func TestOrphanEviction(t *testing.T) {
+	pool := newOrphanPool(500)
+	var sharedParent [32]byte
+	sharedParent[31] = 0x99
+	var oldestHash [32]byte
+	oldestHash[31] = 1
+	for i := 0; i < 501; i++ {
+		var blockHash [32]byte
+		blockHash[30] = byte((i + 1) >> 8)
+		blockHash[31] = byte(i + 1)
+		if !pool.Add(blockHash, sharedParent, []byte{byte(i)}) {
+			t.Fatalf("Add(%d) unexpectedly rejected", i)
+		}
+	}
+	if got := pool.Len(); got != 500 {
+		t.Fatalf("Len()=%d, want 500", got)
+	}
+	children := pool.TakeChildren(sharedParent)
+	if len(children) != 500 {
+		t.Fatalf("children=%d, want 500", len(children))
+	}
+	for _, child := range children {
+		if child.blockHash == oldestHash {
+			t.Fatalf("oldest orphan was not evicted")
+		}
+	}
+}
+
+func TestOrphanPoolRejectsOversizedBlocksAndCapsBytes(t *testing.T) {
+	pool := newOrphanPool(500)
+	pool.byteLimit = 8
+
+	var parent [32]byte
+	parent[31] = 0x01
+	var first [32]byte
+	first[31] = 0x02
+	var second [32]byte
+	second[31] = 0x03
+
+	if pool.Add(first, parent, make([]byte, 9)) {
+		t.Fatalf("expected oversized orphan rejection")
+	}
+	if !pool.Add(first, parent, []byte{1, 2, 3, 4, 5}) {
+		t.Fatalf("expected first orphan add")
+	}
+	if !pool.Add(second, parent, []byte{6, 7, 8, 9, 10}) {
+		t.Fatalf("expected second orphan add")
+	}
+	if got := pool.Len(); got != 1 {
+		t.Fatalf("Len()=%d, want 1 after byte-budget eviction", got)
+	}
+	children := pool.TakeChildren(parent)
+	if len(children) != 1 || children[0].blockHash != second {
+		t.Fatalf("children=%v, want only newest surviving orphan", children)
+	}
+	if got := pool.totalBytes; got != 0 {
+		t.Fatalf("totalBytes=%d, want 0 after draining pool", got)
+	}
+}

--- a/clients/go/node/p2p/service.go
+++ b/clients/go/node/p2p/service.go
@@ -54,6 +54,7 @@ type Service struct {
 	chainMu   sync.Mutex
 	blockSeen *boundedHashSet
 	txSeen    *boundedHashSet
+	orphans   *orphanPool
 }
 
 type peer struct {
@@ -120,6 +121,7 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 		addrMgr:        addrMgr,
 		blockSeen:      newBoundedHashSet(defaultBlockSeenCapacity),
 		txSeen:         newBoundedHashSet(defaultTxSeenCapacity),
+		orphans:        newOrphanPool(500),
 	}, nil
 }
 

--- a/clients/go/node/p2p/service_test.go
+++ b/clients/go/node/p2p/service_test.go
@@ -252,6 +252,71 @@ func TestIBDSync(t *testing.T) {
 	}
 }
 
+func TestOrphanResolution(t *testing.T) {
+	source := newTestHarness(t, 3, "127.0.0.1:0", nil)
+	sink := newTestHarness(t, 0, "127.0.0.1:0", nil)
+
+	genesisBytes := node.DevnetGenesisBlockBytes()
+	height1Hash, ok, err := source.blockStore.CanonicalHash(1)
+	if err != nil || !ok {
+		t.Fatalf("CanonicalHash(1): ok=%v err=%v", ok, err)
+	}
+	height2Hash, ok, err := source.blockStore.CanonicalHash(2)
+	if err != nil || !ok {
+		t.Fatalf("CanonicalHash(2): ok=%v err=%v", ok, err)
+	}
+	block1Bytes, err := source.blockStore.GetBlockByHash(height1Hash)
+	if err != nil {
+		t.Fatalf("GetBlockByHash(height1): %v", err)
+	}
+	block2Bytes, err := source.blockStore.GetBlockByHash(height2Hash)
+	if err != nil {
+		t.Fatalf("GetBlockByHash(height2): %v", err)
+	}
+
+	peer := &peer{
+		service: sink.service,
+		state: node.PeerState{
+			RemoteVersion: testVersionPayload(node.DevnetGenesisChainID(), node.DevnetGenesisBlockHash(), "remote", 2),
+		},
+	}
+
+	if summary, err := peer.processRelayedBlock(block2Bytes); err != nil {
+		t.Fatalf("processRelayedBlock(block2): %v", err)
+	} else if summary != nil {
+		t.Fatalf("expected nil summary for orphan block2")
+	}
+	if summary, err := peer.processRelayedBlock(block1Bytes); err != nil {
+		t.Fatalf("processRelayedBlock(block1): %v", err)
+	} else if summary != nil {
+		t.Fatalf("expected nil summary for orphan block1")
+	}
+	if got := sink.service.orphans.Len(); got != 2 {
+		t.Fatalf("orphans.Len()=%d, want 2", got)
+	}
+
+	summary, err := peer.processRelayedBlock(genesisBytes)
+	if err != nil {
+		t.Fatalf("processRelayedBlock(genesis): %v", err)
+	}
+	if summary == nil || summary.BlockHeight != 0 {
+		t.Fatalf("genesis summary=%v, want height 0", summary)
+	}
+	if got := sink.service.orphans.Len(); got != 0 {
+		t.Fatalf("orphans.Len()=%d, want 0 after resolve", got)
+	}
+	height, tipHash, ok, err := sink.blockStore.Tip()
+	if err != nil {
+		t.Fatalf("sink tip: %v", err)
+	}
+	if !ok || height != 2 {
+		t.Fatalf("sink height=%d ok=%v, want 2/true", height, ok)
+	}
+	if tipHash != height2Hash {
+		t.Fatalf("sink tip hash=%x, want %x", tipHash, height2Hash)
+	}
+}
+
 func newTestHarness(t *testing.T, blockCount int, bindAddr string, bootstrapPeers []string) *testHarness {
 	t.Helper()
 


### PR DESCRIPTION
Refs Q-DEVNET-P2P-02

## Summary
- add bounded in-memory orphan block pool with dedup and eviction
- keep orphaned relayed blocks instead of banning peers on missing parents
- recursively resolve orphan descendants after parent acceptance

## Testing
- scripts/dev-env.sh -- bash -lc "cd clients/go && go test ./node ./node/p2p -count=1 -timeout 300s"