### PR TITLE
refactor: deduplicate CORE_EXT sig/digest and u128 addition

### DIFF
--- a/clients/go/consensus/block_basic_coinbase.go
+++ b/clients/go/consensus/block_basic_coinbase.go
@@ -3,7 +3,6 @@ package consensus
 import (
 	"bytes"
 	"math/big"
-	"math/bits"
 )
 
 func validateCoinbaseStructure(pb *ParsedBlock, blockHeight uint64) error {
@@ -67,12 +66,7 @@ func validateCoinbaseApplyOutputs(coinbase *Tx) error {
 }
 
 func addU64ToU128Block(x u128, v uint64) (u128, error) {
-	lo, carry := bits.Add64(x.lo, v, 0)
-	hi, carry2 := bits.Add64(x.hi, 0, carry)
-	if carry2 != 0 {
-		return u128{}, txerr(BLOCK_ERR_PARSE, "u128 overflow")
-	}
-	return u128{hi: hi, lo: lo}, nil
+	return addU64ToU128WithCode(x, v, BLOCK_ERR_PARSE)
 }
 
 func validateCoinbaseWitnessCommitment(pb *ParsedBlock) error {

--- a/clients/go/consensus/spend_verify.go
+++ b/clients/go/consensus/spend_verify.go
@@ -11,6 +11,21 @@ func extractCryptoSigAndSighash(w WitnessItem) ([]byte, uint8, error) {
 	return w.Signature[:len(w.Signature)-1], sighashType, nil
 }
 
+// extractSigAndDigest extracts the cryptographic signature bytes and computes
+// the sighash digest from a witness item. This is the common preamble shared
+// by all signature verification paths (ML-DSA-87 core and CORE_EXT profiles).
+func extractSigAndDigest(w WitnessItem, tx *Tx, inputIndex uint32, inputValue uint64, chainID [32]byte) ([]byte, [32]byte, error) {
+	cryptoSig, sighashType, err := extractCryptoSigAndSighash(w)
+	if err != nil {
+		return nil, [32]byte{}, err
+	}
+	digest, err := SighashV1DigestWithType(tx, inputIndex, inputValue, chainID, sighashType)
+	if err != nil {
+		return nil, [32]byte{}, err
+	}
+	return cryptoSig, digest, nil
+}
+
 // verifyMLDSAKeyAndSig verifies an ML-DSA-87 witness item's key binding and
 // cryptographic signature. The caller must validate witness item lengths and
 // suite ID before calling this function.
@@ -18,11 +33,7 @@ func verifyMLDSAKeyAndSig(w WitnessItem, expectedKeyID [32]byte, tx *Tx, inputIn
 	if sha3_256(w.Pubkey) != expectedKeyID {
 		return txerr(TX_ERR_SIG_INVALID, context+" key binding mismatch")
 	}
-	cryptoSig, sighashType, err := extractCryptoSigAndSighash(w)
-	if err != nil {
-		return err
-	}
-	digest, err := SighashV1DigestWithType(tx, inputIndex, inputValue, chainID, sighashType)
+	cryptoSig, digest, err := extractSigAndDigest(w, tx, inputIndex, inputValue, chainID)
 	if err != nil {
 		return err
 	}

--- a/clients/go/consensus/utxo_basic.go
+++ b/clients/go/consensus/utxo_basic.go
@@ -296,11 +296,7 @@ func applyNonCoinbaseTxBasicWork(
 				if len(w.Pubkey) != ML_DSA_87_PUBKEY_BYTES || len(w.Signature) != ML_DSA_87_SIG_BYTES+1 {
 					return nil, 0, txerr(TX_ERR_SIG_NONCANONICAL, "non-canonical ML-DSA witness item lengths")
 				}
-				cryptoSig, sighashType, err := extractCryptoSigAndSighash(w)
-				if err != nil {
-					return nil, 0, err
-				}
-				digest, err := SighashV1DigestWithType(tx, uint32(inputIndex), entry.Value, chainID, sighashType)
+				cryptoSig, digest, err := extractSigAndDigest(w, tx, uint32(inputIndex), entry.Value, chainID)
 				if err != nil {
 					return nil, 0, err
 				}
@@ -315,11 +311,7 @@ func applyNonCoinbaseTxBasicWork(
 				if verifySigExtFn == nil {
 					return nil, 0, txerr(TX_ERR_SIG_ALG_INVALID, "CORE_EXT verify_sig_ext unsupported")
 				}
-				cryptoSig, sighashType, err := extractCryptoSigAndSighash(w)
-				if err != nil {
-					return nil, 0, err
-				}
-				digest, err := SighashV1DigestWithType(tx, uint32(inputIndex), entry.Value, chainID, sighashType)
+				cryptoSig, digest, err := extractSigAndDigest(w, tx, uint32(inputIndex), entry.Value, chainID)
 				if err != nil {
 					return nil, 0, err
 				}
@@ -552,10 +544,14 @@ type u128 struct {
 }
 
 func addU64ToU128(x u128, v uint64) (u128, error) {
+	return addU64ToU128WithCode(x, v, TX_ERR_PARSE)
+}
+
+func addU64ToU128WithCode(x u128, v uint64, code ErrorCode) (u128, error) {
 	lo, carry := bits.Add64(x.lo, v, 0)
 	hi, carry2 := bits.Add64(x.hi, 0, carry)
 	if carry2 != 0 {
-		return u128{}, txerr(TX_ERR_PARSE, "u128 overflow")
+		return u128{}, txerr(code, "u128 overflow")
 	}
 	return u128{hi: hi, lo: lo}, nil
 }


### PR DESCRIPTION
## Summary
- Extract `extractSigAndDigest` helper into `spend_verify.go` to eliminate duplicated `extractCryptoSigAndSighash` + `SighashV1DigestWithType` blocks in the CORE_EXT `ML_DSA_87` and `default` switch cases of `utxo_basic.go`
- Unify `addU64ToU128` / `addU64ToU128Block` via a shared `addU64ToU128WithCode` core parameterized by `ErrorCode`, keeping thin wrappers to preserve call-site signatures
- No behavioral change: error ordering at each call site is preserved exactly

Addresses Codacy duplication flags on `utxo_basic.go` (3 clones / 27 duplicated lines → 0).

## Test plan
- [x] All consensus tests pass (`go test ./consensus/... -count=1`)
- [x] `gofmt` clean
- [x] Verified error ordering preserved via diff inspection

🤖 Generated with [Claude Code](https://claude.com/claude-code)