### PR TITLE
fix: enforce timestamp validation context in Rust P2P block sync

### DIFF
--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -382,8 +382,11 @@ impl PeerSession {
         {
             return Ok(());
         }
+        let prev_timestamps = sync_engine
+            .prev_timestamps_for_next_block()
+            .map_err(io::Error::other)?;
         sync_engine
-            .apply_block(block_bytes, None)
+            .apply_block(block_bytes, prev_timestamps.as_deref())
             .map_err(io::Error::other)?;
         Ok(())
     }

--- a/clients/rust/crates/rubin-node/src/sync.rs
+++ b/clients/rust/crates/rubin-node/src/sync.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use rubin_consensus::constants::POW_LIMIT;
-use rubin_consensus::{block_hash, parse_block_bytes};
+use rubin_consensus::{block_hash, parse_block_bytes, parse_block_header_bytes};
 
 use crate::blockstore::BlockStore;
 use crate::chainstate::{ChainState, ChainStateConnectSummary};
@@ -209,6 +209,37 @@ impl SyncEngine {
 
         Ok(summary)
     }
+
+    pub fn prev_timestamps_for_next_block(&self) -> Result<Option<Vec<u64>>, String> {
+        if !self.chain_state.has_tip {
+            return Ok(None);
+        }
+        let block_store = self
+            .block_store
+            .as_ref()
+            .ok_or_else(|| "sync engine missing blockstore for timestamp context".to_string())?;
+
+        let next_height = self.chain_state.height.saturating_add(1);
+        let window_len = usize::try_from(next_height.min(11)).unwrap_or(11);
+        let mut out = Vec::with_capacity(window_len);
+
+        for offset in 0..window_len {
+            let offset_u64 = u64::try_from(offset).map_err(|_| "offset overflow".to_string())?;
+            let height = self
+                .chain_state
+                .height
+                .checked_sub(offset_u64)
+                .ok_or_else(|| "height underflow".to_string())?;
+            let hash = block_store
+                .canonical_hash(height)?
+                .ok_or_else(|| format!("missing canonical hash at height {height}"))?;
+            let header_bytes = block_store.get_header_by_hash(hash)?;
+            let header = parse_block_header_bytes(&header_bytes).map_err(|e| e.to_string())?;
+            out.push(header.timestamp);
+        }
+
+        Ok(Some(out))
+    }
 }
 
 fn validate_mainnet_genesis_guard(cfg: &SyncConfig) -> Result<(), String> {
@@ -314,6 +345,30 @@ mod tests {
             .expect("tip")
             .expect("some tip");
         assert_eq!(tip.0, 0);
+
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    #[test]
+    fn prev_timestamps_for_next_block_reads_canonical_headers() {
+        let dir = unique_temp_path("rubin-node-sync-prev-timestamps");
+        let chain_state_file = chain_state_path(&dir);
+        let block_store_root = block_store_path(&dir);
+        let store = BlockStore::open(block_store_root).expect("open blockstore");
+
+        let st = ChainState::new();
+        let cfg = default_sync_config(Some(POW_LIMIT), [0u8; 32], Some(chain_state_file));
+        let mut engine = SyncEngine::new(st, Some(store), cfg).expect("new sync");
+
+        let block = hex_to_bytes(VALID_BLOCK_HEX);
+        let parsed = rubin_consensus::parse_block_bytes(&block).expect("parse block");
+        engine.apply_block(&block, None).expect("apply block");
+
+        let prev = engine
+            .prev_timestamps_for_next_block()
+            .expect("timestamp context")
+            .expect("non-genesis context");
+        assert_eq!(prev, vec![parsed.header.timestamp]);
 
         std::fs::remove_dir_all(&dir).expect("cleanup");
     }


### PR DESCRIPTION
### Motivation
- The P2P `handle_block` path previously called `apply_block(..., None)`, which caused consensus timestamp checks (median-time-past and max future drift) to be skipped for non-genesis blocks and allowed peers to supply blocks with invalid timestamps.

### Description
- Change `PeerSession::handle_block` to obtain timestamp context from the sync engine and pass it into `apply_block` instead of `None` by calling `prev_timestamps_for_next_block()`.
- Add `SyncEngine::prev_timestamps_for_next_block()` which reads canonical header timestamps from `BlockStore` (up to the 11-block window) and returns `Option<Vec<u64>>`, failing if required blockstore or headers are missing so the path is fail-closed.
- Use `parse_block_header_bytes` to extract header timestamps when building the window and preserve the original genesis/no-tip behavior by returning `Ok(None)` when there is no tip.
- Add a unit test `prev_timestamps_for_next_block_reads_canonical_headers` that applies the genesis block into a test `BlockStore` and verifies the helper returns the canonical header timestamp.

### Testing
- Ran `cargo test -p rubin-node prev_timestamps_for_next_block_reads_canonical_headers` and it passed.
- Ran `cargo test -p rubin-node handle_block_ignores_duplicate_frames` and it passed.
- Ran `cargo fmt` to format changes and then re-ran the tests above which continued to pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae0f606f4083228074b9259fce4873)