### PR TITLE
fix: align mempool CORE_EXT policy with miner

### DIFF
--- a/clients/go/cmd/rubin-node/main.go
+++ b/clients/go/cmd/rubin-node/main.go
@@ -27,7 +27,7 @@ var newMinerFn = node.NewMiner
 
 var newSyncEngineFn = node.NewSyncEngine
 
-var newMempoolFn = node.NewMempool
+var newMempoolFn = node.NewMempoolWithConfig
 
 type multiStringFlag []string
 
@@ -122,7 +122,9 @@ func run(args []string, stdout, stderr io.Writer) int {
 		_, _ = fmt.Fprintf(stderr, "sync engine init failed: %v\n", err)
 		return 2
 	}
-	mempool, err := newMempoolFn(chainState, blockStore, chainIDFromGenesis)
+	mempoolCfg := node.DefaultMempoolConfig()
+	mempoolCfg.CoreExtProfiles = genesisCfg.CoreExtProfiles
+	mempool, err := newMempoolFn(chainState, blockStore, chainIDFromGenesis, mempoolCfg)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "mempool init failed: %v\n", err)
 		return 2

--- a/clients/go/cmd/rubin-node/main_test.go
+++ b/clients/go/cmd/rubin-node/main_test.go
@@ -347,6 +347,46 @@ func TestRunDryRunUsesDevnetGenesisChainIDByDefault(t *testing.T) {
 	}
 }
 
+func TestRunPassesGenesisCoreExtProfilesToMempool(t *testing.T) {
+	prev := newMempoolFn
+	var captured node.MempoolConfig
+	newMempoolFn = func(st *node.ChainState, store *node.BlockStore, chainID [32]byte, cfg node.MempoolConfig) (*node.Mempool, error) {
+		captured = cfg
+		return node.NewMempoolWithConfig(st, store, chainID, cfg)
+	}
+	t.Cleanup(func() { newMempoolFn = prev })
+
+	dir := t.TempDir()
+	genesisPath := filepath.Join(dir, "genesis.json")
+	if err := os.WriteFile(genesisPath, []byte(`{
+		"chain_id_hex":"0x88f8a9acdeeb902e27aa2fdcb8c46ecf818bf68dec5273ec1bcc5084e2333103",
+		"genesis_hash_hex":"0x8d48b863805b96e5fcb79ee9652cd6257ae352b2f52088af921212039f9e8aff",
+		"core_ext_profiles":[{"ext_id":7,"activation_height":12,"allowed_suite_ids":[1],"binding":"verify_sig_ext_accept"}]
+	}`), 0o600); err != nil {
+		t.Fatalf("write genesis file: %v", err)
+	}
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	code := run([]string{"--dry-run", "--datadir", dir, "--genesis-file", genesisPath}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("expected exit code 0, got %d (stderr=%q)", code, errOut.String())
+	}
+	if !captured.PolicyRejectCoreExtPreActivation {
+		t.Fatalf("expected CORE_EXT mempool policy enabled by default")
+	}
+	if captured.CoreExtProfiles == nil {
+		t.Fatalf("expected mempool core_ext profiles")
+	}
+	profile, ok, err := captured.CoreExtProfiles.LookupCoreExtProfile(7, 12)
+	if err != nil {
+		t.Fatalf("LookupCoreExtProfile: %v", err)
+	}
+	if !ok || !profile.Active {
+		t.Fatalf("expected active core_ext profile at activation height")
+	}
+}
+
 func TestRunDryRunShowsTipWhenBlockstoreHasTip(t *testing.T) {
 	dir := t.TempDir()
 

--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -36,6 +36,8 @@ type Mempool struct {
 type MempoolConfig struct {
 	PolicyDaSurchargePerByte             uint64
 	PolicyRejectNonCoinbaseAnchorOutputs bool
+	PolicyRejectCoreExtPreActivation     bool
+	CoreExtProfiles                      consensus.CoreExtProfileProvider
 }
 
 type RelayTxMetadata struct {
@@ -52,6 +54,7 @@ func DefaultMempoolConfig() MempoolConfig {
 	return MempoolConfig{
 		PolicyDaSurchargePerByte:             minerDefaults.PolicyDaSurchargePerByte,
 		PolicyRejectNonCoinbaseAnchorOutputs: minerDefaults.PolicyRejectNonCoinbaseAnchorOutputs,
+		PolicyRejectCoreExtPreActivation:     minerDefaults.PolicyRejectCoreExtPreActivation,
 	}
 }
 
@@ -179,7 +182,7 @@ func (m *Mempool) checkTransactionLocked(txBytes []byte) (*consensus.CheckedTran
 	if err != nil {
 		return nil, nil, err
 	}
-	if err := m.applyPolicyLocked(checked); err != nil {
+	if err := m.applyPolicyLocked(checked, nextHeight); err != nil {
 		return nil, nil, err
 	}
 	inputs := make([]consensus.Outpoint, 0, len(checked.Tx.Inputs))
@@ -189,7 +192,7 @@ func (m *Mempool) checkTransactionLocked(txBytes []byte) (*consensus.CheckedTran
 	return checked, inputs, nil
 }
 
-func (m *Mempool) applyPolicyLocked(checked *consensus.CheckedTransaction) error {
+func (m *Mempool) applyPolicyLocked(checked *consensus.CheckedTransaction, nextHeight uint64) error {
 	if checked == nil || checked.Tx == nil {
 		return errors.New("nil checked transaction")
 	}
@@ -208,6 +211,15 @@ func (m *Mempool) applyPolicyLocked(checked *consensus.CheckedTransaction) error
 	}
 	if reject {
 		return errors.New(reason)
+	}
+	if m.policy.PolicyRejectCoreExtPreActivation {
+		reject, reason, err := RejectCoreExtTxPreActivation(checked.Tx, m.chainState.Utxos, nextHeight, m.policy.CoreExtProfiles)
+		if err != nil {
+			return err
+		}
+		if reject {
+			return errors.New(reason)
+		}
 	}
 	return nil
 }

--- a/clients/go/node/mempool_test.go
+++ b/clients/go/node/mempool_test.go
@@ -126,12 +126,91 @@ func TestMempoolPolicyAllowsSufficientFeeDaCommit(t *testing.T) {
 	}
 }
 
+func TestMempoolPolicyRejectsCoreExtOutputPreActivation(t *testing.T) {
+	fromKey := mustNodeMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{100})
+
+	mp, err := NewMempoolWithConfig(st, nil, devnetGenesisChainID, MempoolConfig{
+		PolicyRejectCoreExtPreActivation: true,
+	})
+	if err != nil {
+		t.Fatalf("new mempool: %v", err)
+	}
+
+	txBytes := mustBuildSignedCoreExtOutputTx(t, st.Utxos, outpoints[0], 90, 1, 1, fromKey, fromAddress, 7)
+	if err := mp.AddTx(txBytes); err == nil || !strings.Contains(err.Error(), "CORE_EXT output pre-ACTIVE ext_id=7") {
+		t.Fatalf("expected CORE_EXT output rejection, got %v", err)
+	}
+	if _, err := mp.RelayMetadata(txBytes); err == nil || !strings.Contains(err.Error(), "CORE_EXT output pre-ACTIVE ext_id=7") {
+		t.Fatalf("expected relay CORE_EXT output rejection, got %v", err)
+	}
+}
+
+func TestMempoolPolicyRejectsCoreExtSpendPreActivation(t *testing.T) {
+	toKey := mustNodeMLDSA87Keypair(t)
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+
+	var prev [32]byte
+	prev[0] = 0x55
+	st := NewChainState()
+	st.HasTip = true
+	st.Height = 100
+	st.TipHash[0] = 0x11
+	st.Utxos[consensus.Outpoint{Txid: prev, Vout: 0}] = consensus.UtxoEntry{
+		Value:        100,
+		CovenantType: consensus.COV_TYPE_CORE_EXT,
+		CovenantData: coreExtCovenantDataForNodeTest(7, nil),
+	}
+
+	mp, err := NewMempoolWithConfig(st, nil, devnetGenesisChainID, MempoolConfig{
+		PolicyRejectCoreExtPreActivation: true,
+	})
+	if err != nil {
+		t.Fatalf("new mempool: %v", err)
+	}
+
+	txBytes := mustBuildCoreExtSpendTx(t, prev, 99, 1, 1, toAddress)
+	if err := mp.AddTx(txBytes); err == nil || !strings.Contains(err.Error(), "CORE_EXT spend pre-ACTIVE ext_id=7") {
+		t.Fatalf("expected CORE_EXT spend rejection, got %v", err)
+	}
+	if _, err := mp.RelayMetadata(txBytes); err == nil || !strings.Contains(err.Error(), "CORE_EXT spend pre-ACTIVE ext_id=7") {
+		t.Fatalf("expected relay CORE_EXT spend rejection, got %v", err)
+	}
+}
+
+func TestMempoolPolicyAllowsCoreExtWhenProfileActive(t *testing.T) {
+	fromKey := mustNodeMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{100})
+
+	mp, err := NewMempoolWithConfig(st, nil, devnetGenesisChainID, MempoolConfig{
+		PolicyRejectCoreExtPreActivation: true,
+		CoreExtProfiles:                  testCoreExtProfiles{activeByExtID: map[uint16]bool{7: true}},
+	})
+	if err != nil {
+		t.Fatalf("new mempool: %v", err)
+	}
+
+	txBytes := mustBuildSignedCoreExtOutputTx(t, st.Utxos, outpoints[0], 90, 1, 1, fromKey, fromAddress, 7)
+	if err := mp.AddTx(txBytes); err != nil {
+		t.Fatalf("expected CORE_EXT tx admission, got %v", err)
+	}
+	meta, err := mp.RelayMetadata(txBytes)
+	if err != nil {
+		t.Fatalf("expected relay metadata success, got %v", err)
+	}
+	if meta.Fee != 1 {
+		t.Fatalf("relay fee=%d, want 1", meta.Fee)
+	}
+}
+
 func TestMempoolPolicyRejectsNilCheckedTransaction(t *testing.T) {
 	mp := &Mempool{}
-	if err := mp.applyPolicyLocked(nil); err == nil || !strings.Contains(err.Error(), "nil checked transaction") {
+	if err := mp.applyPolicyLocked(nil, 0); err == nil || !strings.Contains(err.Error(), "nil checked transaction") {
 		t.Fatalf("expected nil checked transaction rejection, got %v", err)
 	}
-	if err := mp.applyPolicyLocked(&consensus.CheckedTransaction{}); err == nil || !strings.Contains(err.Error(), "nil checked transaction") {
+	if err := mp.applyPolicyLocked(&consensus.CheckedTransaction{}, 0); err == nil || !strings.Contains(err.Error(), "nil checked transaction") {
 		t.Fatalf("expected nil checked tx rejection, got %v", err)
 	}
 }
@@ -154,7 +233,7 @@ func TestMempoolPolicyPropagatesDaFeeComputationErrors(t *testing.T) {
 			PolicyDaSurchargePerByte: 1,
 		},
 	}
-	if err := mp.applyPolicyLocked(&consensus.CheckedTransaction{Tx: tx}); err == nil || !strings.Contains(err.Error(), "nil utxo set") {
+	if err := mp.applyPolicyLocked(&consensus.CheckedTransaction{Tx: tx}, 101); err == nil || !strings.Contains(err.Error(), "nil utxo set") {
 		t.Fatalf("expected DA fee computation error, got %v", err)
 	}
 }
@@ -469,6 +548,83 @@ func mustBuildSignedDaCommitTx(
 	txBytes, err := consensus.MarshalTx(tx)
 	if err != nil {
 		t.Fatalf("MarshalTx(da): %v", err)
+	}
+	return txBytes
+}
+
+func mustBuildSignedCoreExtOutputTx(
+	t *testing.T,
+	utxos map[consensus.Outpoint]consensus.UtxoEntry,
+	input consensus.Outpoint,
+	amount uint64,
+	fee uint64,
+	nonce uint64,
+	signer *consensus.MLDSA87Keypair,
+	changeAddress []byte,
+	extID uint16,
+) []byte {
+	t.Helper()
+	entry, ok := utxos[input]
+	if !ok {
+		t.Fatalf("missing utxo for %x:%d", input.Txid, input.Vout)
+	}
+	tx := &consensus.Tx{
+		Version: 1,
+		TxKind:  0x00,
+		TxNonce: nonce,
+		Inputs: []consensus.TxInput{{
+			PrevTxid: input.Txid,
+			PrevVout: input.Vout,
+			Sequence: 0,
+		}},
+		Outputs: []consensus.TxOutput{
+			{Value: amount, CovenantType: consensus.COV_TYPE_CORE_EXT, CovenantData: coreExtCovenantDataForNodeTest(extID, nil)},
+			{Value: entry.Value - amount - fee, CovenantType: consensus.COV_TYPE_P2PK, CovenantData: append([]byte(nil), changeAddress...)},
+		},
+		Locktime: 0,
+	}
+	if err := consensus.SignTransaction(tx, utxos, devnetGenesisChainID, signer); err != nil {
+		t.Fatalf("SignTransaction(core_ext output): %v", err)
+	}
+	txBytes, err := consensus.MarshalTx(tx)
+	if err != nil {
+		t.Fatalf("MarshalTx(core_ext output): %v", err)
+	}
+	return txBytes
+}
+
+func mustBuildCoreExtSpendTx(
+	t *testing.T,
+	prev [32]byte,
+	amount uint64,
+	fee uint64,
+	nonce uint64,
+	toAddress []byte,
+) []byte {
+	t.Helper()
+	tx := &consensus.Tx{
+		Version: 1,
+		TxKind:  0x00,
+		TxNonce: nonce,
+		Inputs: []consensus.TxInput{{
+			PrevTxid: prev,
+			PrevVout: 0,
+			Sequence: 0,
+		}},
+		Outputs: []consensus.TxOutput{{
+			Value:        amount,
+			CovenantType: consensus.COV_TYPE_P2PK,
+			CovenantData: append([]byte(nil), toAddress...),
+		}},
+		Locktime: 0,
+		Witness:  []consensus.WitnessItem{{SuiteID: consensus.SUITE_ID_SENTINEL}},
+	}
+	txBytes, err := consensus.MarshalTx(tx)
+	if err != nil {
+		t.Fatalf("MarshalTx(core_ext spend): %v", err)
+	}
+	if gotFee := uint64(100) - amount; gotFee != fee {
+		t.Fatalf("fee mismatch: implied=%d declared=%d", gotFee, fee)
 	}
 	return txBytes
 }

--- a/clients/go/node/policy_core_ext_test.go
+++ b/clients/go/node/policy_core_ext_test.go
@@ -122,3 +122,26 @@ func TestRejectCoreExtTxPreActivation_RejectsSpendWhenProfileMissing(t *testing.
 		t.Fatalf("expected reject")
 	}
 }
+
+func TestRejectCoreExtTxPreActivation_AllowsSpendWhenProfileActive(t *testing.T) {
+	var prev [32]byte
+	prev[0] = 0x14
+	raw := txWithOneInputOneOutput(prev, 0, 1, consensus.COV_TYPE_P2PK, make([]byte, consensus.MAX_P2PK_COVENANT_DATA), []consensus.WitnessItem{{SuiteID: consensus.SUITE_ID_SENTINEL}})
+	tx := mustParseTx(t, raw)
+
+	utxos := map[consensus.Outpoint]consensus.UtxoEntry{
+		{Txid: prev, Vout: 0}: {
+			Value:        10,
+			CovenantType: consensus.COV_TYPE_CORE_EXT,
+			CovenantData: coreExtCovenantData(9, nil),
+		},
+	}
+	profiles := testCoreExtProfiles{activeByExtID: map[uint16]bool{9: true}}
+	reject, _, err := RejectCoreExtTxPreActivation(tx, utxos, 0, profiles)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if reject {
+		t.Fatalf("expected allow")
+	}
+}


### PR DESCRIPTION
Closes #518

Refs: Q-COUNCIL-H21

Summary:
- apply CORE_EXT pre-ACTIVE policy in Go mempool admission and relay paths
- pass genesis CORE_EXT profiles into mempool runtime config
- add mempool, helper, and runtime wiring regressions

Validation:
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node ./cmd/rubin-node'\n- scripts/dev-env.sh -- ./scripts/preflight-codacy-coverage.sh