### PR TITLE
fix: internalize codacy coverage gating

### DIFF
--- a/.github/workflows/codacy-coverage.yml
+++ b/.github/workflows/codacy-coverage.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
 
       - name: Cache OpenSSL 3.5 bundle
         uses: actions/cache@v5

--- a/scripts/preflight-codacy-coverage.sh
+++ b/scripts/preflight-codacy-coverage.sh
@@ -17,7 +17,11 @@ cleanup() {
 }
 trap cleanup EXIT
 
-git -C "$repo_root" fetch origin
+if [[ "$(git -C "$repo_root" rev-parse --is-shallow-repository)" == "true" ]]; then
+  git -C "$repo_root" fetch --prune --unshallow origin
+else
+  git -C "$repo_root" fetch origin
+fi
 merge_base="$(git -C "$repo_root" merge-base HEAD "$base_ref")"
 git -C "$repo_root" worktree add --detach "$base_worktree" "$merge_base" >/dev/null
 


### PR DESCRIPTION
Fixes the recurring Dependabot/automation merge stall where branch protection requires external Codacy coverage checks that do not reliably materialize on workflow-only or no-code PRs.

This change makes the internal `coverage` workflow enforce the local diff/variation policy on pull requests via `scripts/preflight-codacy-coverage.sh`, so required gating stays deterministic inside GitHub Actions.

Follow-up repo setting change: required statuses on `main` were reduced to internal checks (`coverage` remains required; external Codacy Static/Diff/Variation are no longer required).