### PR TITLE
[codex] Harden CLI numeric coercions (Q-GOSEC-CLI-BOUNDS-01)

### DIFF
--- a/clients/go/cmd/rubin-consensus-cli/runtime.go
+++ b/clients/go/cmd/rubin-consensus-cli/runtime.go
@@ -502,6 +502,7 @@ func asSortedInts(values []int) []int {
 const (
 	platformMaxInt = int(^uint(0) >> 1)
 	platformMinInt = -platformMaxInt - 1
+	maxSafeJSONInt = 1 << 53
 )
 
 func asInt(v any) (int, bool) {
@@ -510,10 +511,14 @@ func asInt(v any) (int, bool) {
 		if math.IsNaN(value) || math.IsInf(value, 0) {
 			return 0, false
 		}
-		if value < float64(platformMinInt) || value > float64(platformMaxInt) || math.Trunc(value) != value {
+		if math.Trunc(value) != value || value < -maxSafeJSONInt || value > maxSafeJSONInt {
 			return 0, false
 		}
-		return int(value), true
+		narrowed := int64(value)
+		if float64(narrowed) != value || narrowed < int64(platformMinInt) || narrowed > int64(platformMaxInt) {
+			return 0, false
+		}
+		return int(narrowed), true
 	case int:
 		return value, true
 	case int64:
@@ -1062,18 +1067,20 @@ func runFromStdin() {
 			writeResp(os.Stdout, Response{Ok: false, Err: err.Error()})
 			return
 		}
-		wireCap, ok := addPositiveInts(1, 9, pubLen, 9, sigLen)
+		pubLenCS := uint64(pubLen) // #nosec G115 -- nonNegativeBoundedInt caps pubLen before conversion
+		sigLenCS := uint64(sigLen) // #nosec G115 -- nonNegativeBoundedInt caps sigLen before conversion
+		pubLenEnc := consensus.EncodeCompactSize(pubLenCS)
+		sigLenEnc := consensus.EncodeCompactSize(sigLenCS)
+		wireCap, ok := addPositiveInts(1, len(pubLenEnc), pubLen, len(sigLenEnc), sigLen)
 		if !ok || wireCap > consensus.MAX_WITNESS_BYTES_PER_TX {
 			writeResp(os.Stdout, Response{Ok: false, Err: "invalid witness lengths"})
 			return
 		}
-		pubLenCS := uint64(pubLen) // #nosec G115 -- nonNegativeBoundedInt caps pubLen before conversion
-		sigLenCS := uint64(sigLen) // #nosec G115 -- nonNegativeBoundedInt caps sigLen before conversion
 		wire := make([]byte, 0, wireCap)
 		wire = append(wire, suiteID)
-		wire = append(wire, consensus.EncodeCompactSize(pubLenCS)...)
+		wire = append(wire, pubLenEnc...)
 		wire = append(wire, bytes.Repeat([]byte{0x11}, pubLen)...)
-		wire = append(wire, consensus.EncodeCompactSize(sigLenCS)...)
+		wire = append(wire, sigLenEnc...)
 		wire = append(wire, bytes.Repeat([]byte{0x22}, sigLen)...)
 		off := 0
 		if len(wire) < 1 {

--- a/clients/go/cmd/rubin-consensus-cli/runtime_test.go
+++ b/clients/go/cmd/rubin-consensus-cli/runtime_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"io"
+	"math"
 	"os"
 	"strings"
 	"testing"
@@ -542,6 +543,13 @@ func TestRubinConsensusCLI_RunFromStdin_CoversErrorPaths(t *testing.T) {
 		)
 	})
 
+	t.Run("compact_witness_roundtrip_near_limit_valid", func(t *testing.T) {
+		resp := mustRunOk(t, Request{Op: "compact_witness_roundtrip", PubkeyLength: 99990, SigLength: 0})
+		if !resp.RoundtripOK || resp.WireBytes != 99997 {
+			t.Fatalf("unexpected resp: %+v", resp)
+		}
+	})
+
 	t.Run("compact_batch_verify_index_oob", func(t *testing.T) {
 		mustRunErr(t, Request{Op: "compact_batch_verify", BatchSize: 2, InvalidIndices: []int{2}}, "invalid index out of range")
 	})
@@ -563,6 +571,11 @@ func TestRubinConsensusCLI_RunFromStdin_CoversErrorPaths(t *testing.T) {
 		mustRunErr(
 			t,
 			Request{Op: "compact_state_machine", ChunkCount: 2, Events: []any{map[string]any{"type": "tick", "blocks": 1.5}}},
+			"invalid blocks",
+		)
+		mustRunErr(
+			t,
+			Request{Op: "compact_state_machine", ChunkCount: 2, Events: []any{map[string]any{"type": "tick", "blocks": math.Exp2(63)}}},
 			"invalid blocks",
 		)
 	})


### PR DESCRIPTION
## Summary

Implements `Q-GOSEC-CLI-BOUNDS-01` by hardening `clients/go/cmd/rubin-consensus-cli` against malformed numeric JSON payloads in compact-block helper operations.

The issue was not a live consensus divergence or remote node exploit. The risk was local CLI / harness instability: unchecked `float64` / `int64` / `uint64` coercions and unchecked witness-size arithmetic could silently truncate extreme values or panic during allocation and decode math.

## Root Cause

`rubin-consensus-cli/runtime.go` accepted untyped JSON numeric values and converted them directly into `int` in helper paths that later fed:

- witness round-trip allocation and CompactSize encoding
- compact state-machine event handling
- compact sendcmpct mode selection
- compact eviction tie-break normalization

That made malformed or out-of-range numeric payloads fail late or behave lossy instead of being rejected deterministically.

## Fix

- add checked integer coercion helpers for untyped JSON values
- reject non-integer / out-of-range values before using them in size or index math
- bound `compact_witness_roundtrip` lengths before allocation and CompactSize conversion
- return explicit errors for malformed numeric fields in compact helper map payloads
- add focused tests for invalid witness lengths and malformed numeric inputs

## Validation

- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./cmd/rubin-consensus-cli'`
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && gosec -fmt=json ./cmd/rubin-consensus-cli'`
- `scripts/dev-env.sh -- ./scripts/preflight-codacy-coverage.sh`

All passed locally.

## Queue

- Q-ID: `Q-GOSEC-CLI-BOUNDS-01`
- Pre-merge validation report recorded in orchestration.
