### PR TITLE
fix(ci): restore nightly toolchain in fuzz-nightly (Q-FUZZ-RUST-02)

### DIFF
--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -56,7 +56,14 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Rust nightly
-        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # nightly
+        # NOTE: This MUST pin the `nightly` branch SHA, not `stable`.
+        # Dependabot treats all branches as one dependency—verify the SHA
+        # belongs to the nightly branch before merging Dependabot PRs.
+        # Current nightly branch: 0f1b44df7e9cbb178d781a242338dfa5e243ad7f
+        # Current stable branch:  631a55b12751854ce901bb631d5902ceb48146f7
+        uses: dtolnay/rust-toolchain@0f1b44df7e9cbb178d781a242338dfa5e243ad7f # nightly
+        with:
+          toolchain: nightly
 
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz --locked


### PR DESCRIPTION
## Summary

- Dependabot PR #532 updated `dtolnay/rust-toolchain` SHA to `631a55b` (the **stable** branch), but `fuzz-nightly.yml` requires the **nightly** branch for `-Zsanitizer=address`
- Restores the correct nightly branch SHA (`0f1b44d`)
- Adds explicit `with: toolchain: nightly` as defense-in-depth against future Dependabot SHA swaps
- Adds inline comments documenting the branch/SHA mapping

**Root cause:** `dtolnay/rust-toolchain` uses separate git branches per channel (`stable`, `nightly`, `master`). Dependabot treats all branches as a single dependency and unified both SHAs to the stable branch.

**Impact:** 4 of last 5 fuzz-nightly runs failed (since PR #532 merge on 2026-03-09T08:41Z).

**Queue:** Q-FUZZ-RUST-02

## Test plan

- [ ] CI checks pass (test, coverage, sanity, policy, CodeQL, etc.)
- [ ] After merge, trigger `fuzz-nightly` workflow manually and verify fuzz-rust job succeeds with nightly toolchain
- [ ] Verify CI logs show `rustup toolchain install nightly` (not `stable`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)