### PR TITLE
ci: upgrade security review Stage 1 from GPT-4.1 to GPT-5

### DIFF
--- a/.github/workflows/models-security-review.yml
+++ b/.github/workflows/models-security-review.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Get PR diff
         id: diff
         run: |
-          DIFF=$(git diff origin/${{ github.base_ref }}...HEAD -- '*.go' '*.rs' '*.lean' | head -c 80000)
+          DIFF=$(git diff origin/${{ github.base_ref }}...HEAD -- '*.go' '*.rs' '*.lean' | head -c 160000)
           echo "diff<<DIFF_EOF" >> $GITHUB_OUTPUT
           echo "$DIFF" >> $GITHUB_OUTPUT
           echo "DIFF_EOF" >> $GITHUB_OUTPUT
@@ -36,7 +36,7 @@ jobs:
     outputs:
       review: ${{ steps.review.outputs.comment }}
     steps:
-      - name: "Stage 1: GPT-4.1 Primary Security Analysis"
+      - name: "Stage 1: gpt-5 Primary Security Analysis"
         id: review
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -44,7 +44,7 @@ jobs:
           BODY=$(jq -n \
             --arg diff "${{ needs.get-diff.outputs.diff }}" \
             '{
-              model: "openai/gpt-4.1",
+              model: "openai/gpt-5",
               messages: [
                 {
                   role: "system",
@@ -56,7 +56,7 @@ jobs:
                 }
               ],
               temperature: 0.1,
-              max_tokens: 4096
+              max_tokens: 16384
             }')
           RESPONSE=$(curl -sL \
             -X POST \
@@ -90,10 +90,10 @@ jobs:
               messages: [
                 {
                   role: "user",
-                  content: ("You are a blockchain security auditor performing a SECOND-PASS review with deep reasoning. Another model (GPT-4.1) already performed a primary analysis. Your job is to:\n\n1) CHALLENGE the primary review - are there false positives? Missed issues?\n2) REASON STEP-BY-STEP about edge cases the primary reviewer may have missed\n3) VERIFY the severity ratings - are they accurate?\n4) IDENTIFY any logical flaws in the primary analysis itself\n5) ADD new findings that require deeper reasoning (state machine analysis, race conditions, mathematical proof gaps)\n\nContext: RUBIN protocol - Bitcoin-like UTXO chain with post-quantum crypto (ML-DSA, SLH-DSA), vault covenants, Lean4 formal verification.\n\n--- PRIMARY REVIEW (GPT-4.1) ---\n" + $stage1 + "\n\n--- ORIGINAL DIFF ---\n" + $diff + "\n\nProvide your second-pass analysis with severity ratings (CRITICAL/HIGH/MEDIUM/LOW/INFO). Clearly mark which findings are NEW vs corrections to the primary review.")
+                  content: ("You are a blockchain security auditor performing a SECOND-PASS review with deep reasoning. Another model (gpt-5) already performed a primary analysis. Your job is to:\n\n1) CHALLENGE the primary review - are there false positives? Missed issues?\n2) REASON STEP-BY-STEP about edge cases the primary reviewer may have missed\n3) VERIFY the severity ratings - are they accurate?\n4) IDENTIFY any logical flaws in the primary analysis itself\n5) ADD new findings that require deeper reasoning (state machine analysis, race conditions, mathematical proof gaps)\n\nContext: RUBIN protocol - Bitcoin-like UTXO chain with post-quantum crypto (ML-DSA, SLH-DSA), vault covenants, Lean4 formal verification.\n\n--- PRIMARY REVIEW (gpt-5) ---\n" + $stage1 + "\n\n--- ORIGINAL DIFF ---\n" + $diff + "\n\nProvide your second-pass analysis with severity ratings (CRITICAL/HIGH/MEDIUM/LOW/INFO). Clearly mark which findings are NEW vs corrections to the primary review.")
                 }
               ],
-              max_tokens: 4096
+              max_tokens: 16384
             }')
           RESPONSE=$(curl -sL \
             -X POST \
@@ -128,15 +128,15 @@ jobs:
               messages: [
                 {
                   role: "system",
-                  content: "You are the FINAL ARBITER in a multi-model security review pipeline for the RUBIN blockchain protocol. Two models have already reviewed this code: GPT-4.1 (primary analysis) and o4-mini (reasoning challenge/second pass). Your job is to SYNTHESIZE their findings into a final actionable report."
+                  content: "You are the FINAL ARBITER in a multi-model security review pipeline for the RUBIN blockchain protocol. Two models have already reviewed this code: gpt-5 (primary analysis) and o4-mini (reasoning challenge/second pass). Your job is to SYNTHESIZE their findings into a final actionable report."
                 },
                 {
                   role: "user",
-                  content: ("Synthesize the following two reviews into a FINAL CONSENSUS REPORT.\n\nRules:\n1) Where both models AGREE - mark as CONFIRMED finding with combined severity\n2) Where models DISAGREE - analyze both arguments and make a final ruling\n3) Flag any FALSE POSITIVES identified by the second reviewer\n4) Produce a FINAL severity-sorted list of all confirmed issues\n5) End with a GO/NO-GO recommendation for merging\n\n--- STAGE 1: GPT-4.1 Primary Analysis ---\n" + $stage1 + "\n\n--- STAGE 2: o4-mini Reasoning Challenge ---\n" + $stage2 + "\n\n--- ORIGINAL DIFF ---\n" + $diff + "\n\nOutput format:\n## Final Consensus Report\n### CONFIRMED Issues (both models agree)\n### DISPUTED Issues (models disagree) + your ruling\n### FALSE POSITIVES (rejected findings)\n### ADDITIONAL Issues (found only by one model, confirmed by you)\n### Merge Recommendation: GO / CAUTION / NO-GO")
+                  content: ("Synthesize the following two reviews into a FINAL CONSENSUS REPORT.\n\nRules:\n1) Where both models AGREE - mark as CONFIRMED finding with combined severity\n2) Where models DISAGREE - analyze both arguments and make a final ruling\n3) Flag any FALSE POSITIVES identified by the second reviewer\n4) Produce a FINAL severity-sorted list of all confirmed issues\n5) End with a GO/NO-GO recommendation for merging\n\n--- STAGE 1: gpt-5 Primary Analysis ---\n" + $stage1 + "\n\n--- STAGE 2: o4-mini Reasoning Challenge ---\n" + $stage2 + "\n\n--- ORIGINAL DIFF ---\n" + $diff + "\n\nOutput format:\n## Final Consensus Report\n### CONFIRMED Issues (both models agree)\n### DISPUTED Issues (models disagree) + your ruling\n### FALSE POSITIVES (rejected findings)\n### ADDITIONAL Issues (found only by one model, confirmed by you)\n### Merge Recommendation: GO / CAUTION / NO-GO")
                 }
               ],
               temperature: 0.1,
-              max_tokens: 4096
+              max_tokens: 16384
             }')
           RESPONSE=$(curl -sL \
             -X POST \
@@ -166,7 +166,7 @@ jobs:
               '## Orchestrated Multi-Model Security Review',
               '',
               '<details>',
-              '<summary>Stage 1: GPT-4.1 Primary Security Analysis</summary>',
+              '<summary>Stage 1: gpt-5 Primary Security Analysis</summary>',
               '',
               stage1,
               '',
@@ -184,7 +184,7 @@ jobs:
               stage3,
               '',
               '---',
-              '_Orchestrated 3-stage review: GPT-4.1 (analysis) -> o4-mini (challenge) -> DeepSeek-V3 (synthesis). Each stage builds on previous results._'
+              '_Orchestrated 3-stage review: gpt-5 (analysis) -> o4-mini (challenge) -> DeepSeek-V3 (synthesis). Each stage builds on previous results._'
             ].join('\n');
             await github.rest.issues.createComment({
               owner: context.repo.owner,


### PR DESCRIPTION
Upgrade Stage 1 primary analysis model from GPT-4.1 to GPT-5 (200k context, 100k output).

Changes:
- model: openai/gpt-4.1 -> openai/gpt-5
- max_tokens: 4096 -> 16384
- diff limit: 80KB -> 160KB
- All GPT-4.1 references updated to GPT-5