### PR TITLE
feat(rust): add tx helper, signer, and txpool policy parity

### DIFF
--- a/clients/rust/crates/rubin-consensus/src/lib.rs
+++ b/clients/rust/crates/rubin-consensus/src/lib.rs
@@ -19,6 +19,7 @@ mod spend_verify;
 mod stealth;
 pub mod subsidy;
 pub mod tx;
+mod tx_helpers;
 mod utxo_basic;
 mod vault;
 mod verify_sig_openssl;
@@ -59,6 +60,7 @@ pub use sighash::{is_valid_sighash_type, sighash_v1_digest, sighash_v1_digest_wi
 pub use stealth::{parse_stealth_covenant_data, validate_stealth_spend, StealthCovenant};
 pub use subsidy::block_subsidy;
 pub use tx::{parse_tx, DaChunkCore, DaCommitCore, Tx, TxInput, TxOutput, WitnessItem};
+pub use tx_helpers::{marshal_tx, p2pk_covenant_data_for_pubkey, sign_transaction, DigestSigner};
 pub use utxo_basic::{
     apply_non_coinbase_tx_basic, apply_non_coinbase_tx_basic_update,
     apply_non_coinbase_tx_basic_update_with_mtp,
@@ -69,6 +71,7 @@ pub use vault::{
     output_descriptor_bytes, parse_multisig_covenant_data, parse_vault_covenant_data,
     witness_slots, MultisigCovenant, VaultCovenant,
 };
+pub use verify_sig_openssl::{verify_sig, Mldsa87Keypair};
 
 #[cfg(test)]
 mod compact_relay_tests;

--- a/clients/rust/crates/rubin-consensus/src/tx_helpers.rs
+++ b/clients/rust/crates/rubin-consensus/src/tx_helpers.rs
@@ -1,0 +1,380 @@
+use std::collections::HashMap;
+
+use crate::compactsize::encode_compact_size;
+use crate::constants::{
+    COV_TYPE_P2PK, MAX_P2PK_COVENANT_DATA, ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES,
+    SIGHASH_ALL, SUITE_ID_ML_DSA_87,
+};
+use crate::error::{ErrorCode, TxError};
+use crate::hash::sha3_256;
+use crate::sighash::sighash_v1_digest_with_type;
+use crate::tx::{da_core_fields_bytes, Tx, WitnessItem};
+use crate::utxo_basic::{Outpoint, UtxoEntry};
+
+pub trait DigestSigner {
+    fn pubkey_bytes(&self) -> Vec<u8>;
+    fn sign_digest32(&self, digest32: [u8; 32]) -> Result<Vec<u8>, TxError>;
+}
+
+pub fn p2pk_covenant_data_for_pubkey(pubkey: &[u8]) -> Vec<u8> {
+    let key_id = sha3_256(pubkey);
+    let mut out = vec![0u8; MAX_P2PK_COVENANT_DATA as usize];
+    out[0] = SUITE_ID_ML_DSA_87;
+    out[1..33].copy_from_slice(&key_id);
+    out
+}
+
+pub fn marshal_tx(tx: &Tx) -> Result<Vec<u8>, TxError> {
+    let mut out = Vec::new();
+
+    out.extend_from_slice(&tx.version.to_le_bytes());
+    out.push(tx.tx_kind);
+    out.extend_from_slice(&tx.tx_nonce.to_le_bytes());
+
+    encode_compact_size(tx.inputs.len() as u64, &mut out);
+    for input in &tx.inputs {
+        out.extend_from_slice(&input.prev_txid);
+        out.extend_from_slice(&input.prev_vout.to_le_bytes());
+        encode_compact_size(input.script_sig.len() as u64, &mut out);
+        out.extend_from_slice(&input.script_sig);
+        out.extend_from_slice(&input.sequence.to_le_bytes());
+    }
+
+    encode_compact_size(tx.outputs.len() as u64, &mut out);
+    for output in &tx.outputs {
+        out.extend_from_slice(&output.value.to_le_bytes());
+        out.extend_from_slice(&output.covenant_type.to_le_bytes());
+        encode_compact_size(output.covenant_data.len() as u64, &mut out);
+        out.extend_from_slice(&output.covenant_data);
+    }
+
+    out.extend_from_slice(&tx.locktime.to_le_bytes());
+    out.extend_from_slice(&da_core_fields_bytes(tx)?);
+
+    encode_compact_size(tx.witness.len() as u64, &mut out);
+    for item in &tx.witness {
+        out.push(item.suite_id);
+        encode_compact_size(item.pubkey.len() as u64, &mut out);
+        out.extend_from_slice(&item.pubkey);
+        encode_compact_size(item.signature.len() as u64, &mut out);
+        out.extend_from_slice(&item.signature);
+    }
+
+    encode_compact_size(tx.da_payload.len() as u64, &mut out);
+    out.extend_from_slice(&tx.da_payload);
+
+    Ok(out)
+}
+
+pub fn sign_transaction(
+    tx: &mut Tx,
+    utxo_set: &HashMap<Outpoint, UtxoEntry>,
+    chain_id: [u8; 32],
+    signer: &impl DigestSigner,
+) -> Result<(), TxError> {
+    if tx.inputs.is_empty() {
+        return Err(TxError::new(
+            ErrorCode::TxErrParse,
+            "non-coinbase must have at least one input",
+        ));
+    }
+
+    let pubkey = signer.pubkey_bytes();
+    if pubkey.len() as u64 != ML_DSA_87_PUBKEY_BYTES {
+        return Err(TxError::new(
+            ErrorCode::TxErrSigNoncanonical,
+            "non-canonical ML-DSA public key length",
+        ));
+    }
+    let key_id = sha3_256(&pubkey);
+
+    let mut witness = Vec::with_capacity(tx.inputs.len());
+    for (idx, input) in tx.inputs.iter().enumerate() {
+        let outpoint = Outpoint {
+            txid: input.prev_txid,
+            vout: input.prev_vout,
+        };
+        let entry = utxo_set.get(&outpoint).ok_or_else(|| {
+            TxError::new(ErrorCode::TxErrMissingUtxo, "utxo not found for signing")
+        })?;
+        if entry.covenant_type != COV_TYPE_P2PK {
+            return Err(TxError::new(
+                ErrorCode::TxErrCovenantTypeInvalid,
+                "unsupported covenant type for signing",
+            ));
+        }
+        if entry.covenant_data.len() as u64 != MAX_P2PK_COVENANT_DATA
+            || entry.covenant_data[0] != SUITE_ID_ML_DSA_87
+        {
+            return Err(TxError::new(
+                ErrorCode::TxErrCovenantTypeInvalid,
+                "CORE_P2PK covenant_data invalid",
+            ));
+        }
+        if entry.covenant_data[1..33] != key_id {
+            return Err(TxError::new(
+                ErrorCode::TxErrSigInvalid,
+                "signer key binding mismatch",
+            ));
+        }
+
+        let digest =
+            sighash_v1_digest_with_type(tx, idx as u32, entry.value, chain_id, SIGHASH_ALL)?;
+        let mut signature = signer.sign_digest32(digest)?;
+        if signature.len() as u64 != ML_DSA_87_SIG_BYTES {
+            return Err(TxError::new(
+                ErrorCode::TxErrSigNoncanonical,
+                "non-canonical ML-DSA signature length",
+            ));
+        }
+        signature.push(SIGHASH_ALL);
+        witness.push(WitnessItem {
+            suite_id: SUITE_ID_ML_DSA_87,
+            pubkey: pubkey.clone(),
+            signature,
+        });
+    }
+
+    tx.witness = witness;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::constants::{ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES, TX_WIRE_VERSION};
+    use crate::tx::{parse_tx, Tx, TxInput, TxOutput};
+
+    struct StubSigner {
+        pubkey: Vec<u8>,
+        signature: Vec<u8>,
+    }
+
+    impl DigestSigner for StubSigner {
+        fn pubkey_bytes(&self) -> Vec<u8> {
+            self.pubkey.clone()
+        }
+
+        fn sign_digest32(&self, _digest32: [u8; 32]) -> Result<Vec<u8>, TxError> {
+            Ok(self.signature.clone())
+        }
+    }
+
+    struct ErrorSigner;
+
+    impl DigestSigner for ErrorSigner {
+        fn pubkey_bytes(&self) -> Vec<u8> {
+            test_pubkey(0x77)
+        }
+
+        fn sign_digest32(&self, _digest32: [u8; 32]) -> Result<Vec<u8>, TxError> {
+            Err(TxError::new(
+                ErrorCode::TxErrSigInvalid,
+                "signer backend failure",
+            ))
+        }
+    }
+
+    fn test_pubkey(byte: u8) -> Vec<u8> {
+        vec![byte; ML_DSA_87_PUBKEY_BYTES as usize]
+    }
+
+    fn test_signature(byte: u8) -> Vec<u8> {
+        vec![byte; ML_DSA_87_SIG_BYTES as usize]
+    }
+
+    fn test_tx() -> Tx {
+        Tx {
+            version: TX_WIRE_VERSION,
+            tx_kind: 0x00,
+            tx_nonce: 7,
+            inputs: vec![TxInput {
+                prev_txid: [0x11; 32],
+                prev_vout: 0,
+                script_sig: Vec::new(),
+                sequence: 0,
+            }],
+            outputs: vec![TxOutput {
+                value: 9,
+                covenant_type: COV_TYPE_P2PK,
+                covenant_data: p2pk_covenant_data_for_pubkey(&test_pubkey(0x22)),
+            }],
+            locktime: 0,
+            da_commit_core: None,
+            da_chunk_core: None,
+            witness: Vec::new(),
+            da_payload: Vec::new(),
+        }
+    }
+
+    fn test_utxos(pubkey: &[u8]) -> HashMap<Outpoint, UtxoEntry> {
+        HashMap::from([(
+            Outpoint {
+                txid: [0x11; 32],
+                vout: 0,
+            },
+            UtxoEntry {
+                value: 10,
+                covenant_type: COV_TYPE_P2PK,
+                covenant_data: p2pk_covenant_data_for_pubkey(pubkey),
+                creation_height: 0,
+                created_by_coinbase: false,
+            },
+        )])
+    }
+
+    #[test]
+    fn marshal_tx_roundtrips_via_parse_tx() {
+        let tx = test_tx();
+        let bytes = marshal_tx(&tx).expect("marshal");
+        let (parsed, _, _, consumed) = parse_tx(&bytes).expect("parse");
+        assert_eq!(consumed, bytes.len());
+        assert_eq!(parsed, tx);
+    }
+
+    #[test]
+    fn sign_transaction_populates_canonical_mldsa_witness() {
+        let pubkey = test_pubkey(0x33);
+        let signer = StubSigner {
+            pubkey: pubkey.clone(),
+            signature: test_signature(0x44),
+        };
+        let mut tx = test_tx();
+        let chain_id = [0x55; 32];
+
+        sign_transaction(&mut tx, &test_utxos(&pubkey), chain_id, &signer).expect("sign");
+
+        assert_eq!(tx.witness.len(), 1);
+        let item = &tx.witness[0];
+        assert_eq!(item.suite_id, SUITE_ID_ML_DSA_87);
+        assert_eq!(item.pubkey, pubkey);
+        assert_eq!(item.signature.len(), (ML_DSA_87_SIG_BYTES + 1) as usize);
+        assert_eq!(item.signature.last(), Some(&SIGHASH_ALL));
+
+        let bytes = marshal_tx(&tx).expect("marshal signed tx");
+        let (parsed, _, _, consumed) = parse_tx(&bytes).expect("parse signed tx");
+        assert_eq!(consumed, bytes.len());
+        assert_eq!(parsed, tx);
+    }
+
+    #[test]
+    fn sign_transaction_rejects_utxo_key_binding_mismatch() {
+        let signer = StubSigner {
+            pubkey: test_pubkey(0x33),
+            signature: test_signature(0x44),
+        };
+        let mut tx = test_tx();
+        let err = sign_transaction(&mut tx, &test_utxos(&test_pubkey(0x22)), [0u8; 32], &signer)
+            .expect_err("key mismatch must fail");
+        assert_eq!(err.code, ErrorCode::TxErrSigInvalid);
+    }
+
+    #[test]
+    fn sign_transaction_rejects_noncanonical_signer_lengths() {
+        let signer = StubSigner {
+            pubkey: vec![0u8; (ML_DSA_87_PUBKEY_BYTES as usize) - 1],
+            signature: test_signature(0x44),
+        };
+        let mut tx = test_tx();
+        let err = sign_transaction(&mut tx, &test_utxos(&test_pubkey(0x33)), [0u8; 32], &signer)
+            .expect_err("bad pubkey len must fail");
+        assert_eq!(err.code, ErrorCode::TxErrSigNoncanonical);
+    }
+
+    #[test]
+    fn sign_transaction_rejects_empty_input_list() {
+        let signer = StubSigner {
+            pubkey: test_pubkey(0x33),
+            signature: test_signature(0x44),
+        };
+        let mut tx = test_tx();
+        tx.inputs.clear();
+        let err =
+            sign_transaction(&mut tx, &HashMap::new(), [0u8; 32], &signer).expect_err("empty");
+        assert_eq!(err.code, ErrorCode::TxErrParse);
+    }
+
+    #[test]
+    fn sign_transaction_rejects_missing_utxo() {
+        let signer = StubSigner {
+            pubkey: test_pubkey(0x33),
+            signature: test_signature(0x44),
+        };
+        let mut tx = test_tx();
+        let err =
+            sign_transaction(&mut tx, &HashMap::new(), [0u8; 32], &signer).expect_err("missing");
+        assert_eq!(err.code, ErrorCode::TxErrMissingUtxo);
+    }
+
+    #[test]
+    fn sign_transaction_rejects_non_p2pk_signing_entry() {
+        let signer = StubSigner {
+            pubkey: test_pubkey(0x33),
+            signature: test_signature(0x44),
+        };
+        let mut tx = test_tx();
+        let utxos = HashMap::from([(
+            Outpoint {
+                txid: [0x11; 32],
+                vout: 0,
+            },
+            UtxoEntry {
+                value: 10,
+                covenant_type: 0x0104,
+                covenant_data: vec![1, 1],
+                creation_height: 0,
+                created_by_coinbase: false,
+            },
+        )]);
+        let err =
+            sign_transaction(&mut tx, &utxos, [0u8; 32], &signer).expect_err("non-p2pk must fail");
+        assert_eq!(err.code, ErrorCode::TxErrCovenantTypeInvalid);
+    }
+
+    #[test]
+    fn sign_transaction_rejects_invalid_p2pk_covenant_data() {
+        let signer = StubSigner {
+            pubkey: test_pubkey(0x33),
+            signature: test_signature(0x44),
+        };
+        let mut tx = test_tx();
+        let utxos = HashMap::from([(
+            Outpoint {
+                txid: [0x11; 32],
+                vout: 0,
+            },
+            UtxoEntry {
+                value: 10,
+                covenant_type: COV_TYPE_P2PK,
+                covenant_data: vec![SUITE_ID_ML_DSA_87; 32],
+                creation_height: 0,
+                created_by_coinbase: false,
+            },
+        )]);
+        let err = sign_transaction(&mut tx, &utxos, [0u8; 32], &signer)
+            .expect_err("invalid covenant data");
+        assert_eq!(err.code, ErrorCode::TxErrCovenantTypeInvalid);
+    }
+
+    #[test]
+    fn sign_transaction_rejects_noncanonical_signature_length() {
+        let pubkey = test_pubkey(0x33);
+        let signer = StubSigner {
+            pubkey: pubkey.clone(),
+            signature: vec![0x44; (ML_DSA_87_SIG_BYTES as usize) - 1],
+        };
+        let mut tx = test_tx();
+        let err =
+            sign_transaction(&mut tx, &test_utxos(&pubkey), [0u8; 32], &signer).expect_err("sig");
+        assert_eq!(err.code, ErrorCode::TxErrSigNoncanonical);
+    }
+
+    #[test]
+    fn sign_transaction_propagates_signer_errors() {
+        let pubkey = test_pubkey(0x77);
+        let mut tx = test_tx();
+        let err = sign_transaction(&mut tx, &test_utxos(&pubkey), [0u8; 32], &ErrorSigner)
+            .expect_err("signer error");
+        assert_eq!(err.code, ErrorCode::TxErrSigInvalid);
+    }
+}

--- a/clients/rust/crates/rubin-consensus/src/verify_sig_openssl.rs
+++ b/clients/rust/crates/rubin-consensus/src/verify_sig_openssl.rs
@@ -1,5 +1,6 @@
 use crate::constants::{ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES, SUITE_ID_ML_DSA_87};
 use crate::error::{ErrorCode, TxError};
+use crate::tx_helpers::DigestSigner;
 use core::ffi::CStr;
 use std::sync::OnceLock;
 
@@ -15,6 +16,12 @@ enum OpenSslFipsMode {
 static OPENSSL_BOOTSTRAP_STATE: OnceLock<Result<(), TxError>> = OnceLock::new();
 
 extern "C" {
+    fn EVP_PKEY_CTX_new_from_name(
+        libctx: *mut core::ffi::c_void,
+        name: *const core::ffi::c_char,
+        propq: *const core::ffi::c_char,
+    ) -> *mut openssl_sys::EVP_PKEY_CTX;
+
     fn EVP_PKEY_new_raw_public_key_ex(
         libctx: *mut core::ffi::c_void,
         keytype: *const core::ffi::c_char,
@@ -44,12 +51,178 @@ extern "C" {
         tbslen: usize,
     ) -> core::ffi::c_int;
 
+    fn EVP_DigestSignInit_ex(
+        ctx: *mut openssl_sys::EVP_MD_CTX,
+        pctx: *mut *mut openssl_sys::EVP_PKEY_CTX,
+        mdname: *const core::ffi::c_char,
+        libctx: *mut core::ffi::c_void,
+        props: *const core::ffi::c_char,
+        pkey: *mut openssl_sys::EVP_PKEY,
+        params: *const core::ffi::c_void,
+    ) -> core::ffi::c_int;
+
+    fn EVP_DigestSign(
+        ctx: *mut openssl_sys::EVP_MD_CTX,
+        sigret: *mut core::ffi::c_uchar,
+        siglen: *mut usize,
+        tbs: *const core::ffi::c_uchar,
+        tbslen: usize,
+    ) -> core::ffi::c_int;
+
     fn OPENSSL_init_crypto(opts: u64, settings: *const core::ffi::c_void) -> core::ffi::c_int;
 
     fn EVP_set_default_properties(
         libctx: *mut core::ffi::c_void,
         propq: *const core::ffi::c_char,
     ) -> core::ffi::c_int;
+
+    fn EVP_PKEY_get_raw_public_key(
+        pkey: *const openssl_sys::EVP_PKEY,
+        pub_: *mut core::ffi::c_uchar,
+        publen: *mut usize,
+    ) -> core::ffi::c_int;
+}
+
+pub struct Mldsa87Keypair {
+    pkey: *mut openssl_sys::EVP_PKEY,
+    pubkey: Vec<u8>,
+}
+
+impl Drop for Mldsa87Keypair {
+    fn drop(&mut self) {
+        unsafe {
+            if !self.pkey.is_null() {
+                openssl_sys::EVP_PKEY_free(self.pkey);
+                self.pkey = core::ptr::null_mut();
+            }
+        }
+    }
+}
+
+impl Mldsa87Keypair {
+    pub fn generate() -> Result<Self, TxError> {
+        ensure_openssl_bootstrap()?;
+        let alg = suite_alg_name(SUITE_ID_ML_DSA_87)?;
+        unsafe {
+            openssl_sys::ERR_clear_error();
+            let ctx =
+                EVP_PKEY_CTX_new_from_name(core::ptr::null_mut(), alg.as_ptr(), core::ptr::null());
+            if ctx.is_null() {
+                return Err(TxError::new(
+                    ErrorCode::TxErrParse,
+                    "openssl: EVP_PKEY_CTX_new_from_name failed",
+                ));
+            }
+            if openssl_sys::EVP_PKEY_keygen_init(ctx) <= 0 {
+                openssl_sys::EVP_PKEY_CTX_free(ctx);
+                return Err(TxError::new(
+                    ErrorCode::TxErrParse,
+                    "openssl: EVP_PKEY_keygen_init failed",
+                ));
+            }
+            let mut pkey: *mut openssl_sys::EVP_PKEY = core::ptr::null_mut();
+            if openssl_sys::EVP_PKEY_keygen(ctx, &mut pkey) <= 0 || pkey.is_null() {
+                openssl_sys::EVP_PKEY_CTX_free(ctx);
+                return Err(TxError::new(
+                    ErrorCode::TxErrParse,
+                    "openssl: EVP_PKEY_keygen failed",
+                ));
+            }
+            openssl_sys::EVP_PKEY_CTX_free(ctx);
+
+            let mut pubkey = vec![0u8; ML_DSA_87_PUBKEY_BYTES as usize];
+            let mut pubkey_len = pubkey.len();
+            if EVP_PKEY_get_raw_public_key(pkey, pubkey.as_mut_ptr(), &mut pubkey_len) <= 0 {
+                openssl_sys::EVP_PKEY_free(pkey);
+                return Err(TxError::new(
+                    ErrorCode::TxErrParse,
+                    "openssl: EVP_PKEY_get_raw_public_key failed",
+                ));
+            }
+            if pubkey_len != ML_DSA_87_PUBKEY_BYTES as usize {
+                openssl_sys::EVP_PKEY_free(pkey);
+                return Err(TxError::new(
+                    ErrorCode::TxErrSigNoncanonical,
+                    "openssl: non-canonical ML-DSA public key length",
+                ));
+            }
+            Ok(Self { pkey, pubkey })
+        }
+    }
+
+    pub fn pubkey_bytes(&self) -> Vec<u8> {
+        self.pubkey.clone()
+    }
+
+    pub fn sign_digest32(&self, digest32: [u8; 32]) -> Result<Vec<u8>, TxError> {
+        if self.pkey.is_null() {
+            return Err(TxError::new(
+                ErrorCode::TxErrParse,
+                "openssl: nil ML-DSA keypair",
+            ));
+        }
+        unsafe {
+            openssl_sys::ERR_clear_error();
+            let mctx = EVP_MD_CTX_new();
+            if mctx.is_null() {
+                return Err(TxError::new(
+                    ErrorCode::TxErrParse,
+                    "openssl: EVP_MD_CTX_new failed",
+                ));
+            }
+            if EVP_DigestSignInit_ex(
+                mctx,
+                core::ptr::null_mut(),
+                core::ptr::null(),
+                core::ptr::null_mut(),
+                core::ptr::null(),
+                self.pkey,
+                core::ptr::null(),
+            ) <= 0
+            {
+                EVP_MD_CTX_free(mctx);
+                return Err(TxError::new(
+                    ErrorCode::TxErrParse,
+                    "openssl: EVP_DigestSignInit_ex failed",
+                ));
+            }
+            let mut signature = vec![0u8; ML_DSA_87_SIG_BYTES as usize];
+            let mut sig_len = signature.len();
+            if EVP_DigestSign(
+                mctx,
+                signature.as_mut_ptr(),
+                &mut sig_len,
+                digest32.as_ptr(),
+                digest32.len(),
+            ) <= 0
+            {
+                EVP_MD_CTX_free(mctx);
+                return Err(TxError::new(
+                    ErrorCode::TxErrSigInvalid,
+                    "openssl: EVP_DigestSign failed",
+                ));
+            }
+            EVP_MD_CTX_free(mctx);
+            if sig_len != ML_DSA_87_SIG_BYTES as usize {
+                return Err(TxError::new(
+                    ErrorCode::TxErrSigNoncanonical,
+                    "openssl: non-canonical ML-DSA signature length",
+                ));
+            }
+            signature.truncate(sig_len);
+            Ok(signature)
+        }
+    }
+}
+
+impl DigestSigner for Mldsa87Keypair {
+    fn pubkey_bytes(&self) -> Vec<u8> {
+        Mldsa87Keypair::pubkey_bytes(self)
+    }
+
+    fn sign_digest32(&self, digest32: [u8; 32]) -> Result<Vec<u8>, TxError> {
+        Mldsa87Keypair::sign_digest32(self, digest32)
+    }
 }
 
 fn suite_alg_name(suite_id: u8) -> Result<&'static CStr, TxError> {
@@ -299,7 +472,8 @@ fn openssl_verify_sig_digest_oneshot(
 #[cfg(test)]
 mod tests {
     use super::{
-        map_digest_verify_rc, openssl_bootstrap, parse_openssl_fips_mode, OpenSslFipsMode,
+        map_digest_verify_rc, openssl_bootstrap, parse_openssl_fips_mode, Mldsa87Keypair,
+        OpenSslFipsMode,
     };
     use crate::error::ErrorCode;
 
@@ -358,5 +532,27 @@ mod tests {
         if let Err(err) = openssl_bootstrap(true) {
             assert_eq!(err.code, ErrorCode::TxErrParse);
         }
+    }
+
+    #[test]
+    fn mldsa87_keypair_generate_sign_and_verify_roundtrip() {
+        let keypair = match Mldsa87Keypair::generate() {
+            Ok(value) => value,
+            Err(err) => {
+                assert_eq!(err.code, ErrorCode::TxErrParse);
+                return;
+            }
+        };
+        let pubkey = keypair.pubkey_bytes();
+        let digest = [0x42; 32];
+        let signature = keypair.sign_digest32(digest).expect("sign digest");
+        let ok = super::verify_sig(
+            crate::constants::SUITE_ID_ML_DSA_87,
+            &pubkey,
+            &signature,
+            &digest,
+        )
+        .expect("verify signature");
+        assert!(ok);
     }
 }

--- a/clients/rust/crates/rubin-node/src/devnet_rpc.rs
+++ b/clients/rust/crates/rubin-node/src/devnet_rpc.rs
@@ -9,7 +9,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use serde::{Deserialize, Serialize};
 
 use crate::p2p_runtime::PeerManager;
-use crate::{BlockStore, SyncEngine, TxPool, TxPoolAdmitErrorKind};
+use crate::{BlockStore, SyncEngine, TxPool, TxPoolAdmitErrorKind, TxPoolConfig};
 
 const MAX_HEADER_BYTES: usize = 64 * 1024;
 const MAX_BODY_BYTES: usize = 2 * 1024 * 1024;
@@ -85,10 +85,17 @@ pub fn new_devnet_rpc_state(
     block_store: Option<BlockStore>,
     peer_manager: Arc<PeerManager>,
 ) -> DevnetRPCState {
+    let core_ext_deployments = sync_engine
+        .lock()
+        .map(|engine| engine.core_ext_deployments())
+        .unwrap_or_default();
     DevnetRPCState {
         sync_engine,
         block_store,
-        tx_pool: Arc::new(Mutex::new(TxPool::new())),
+        tx_pool: Arc::new(Mutex::new(TxPool::new_with_config(TxPoolConfig {
+            core_ext_deployments,
+            ..TxPoolConfig::default()
+        }))),
         peer_manager,
         metrics: Arc::new(RpcMetrics::default()),
         now_unix: current_unix,

--- a/clients/rust/crates/rubin-node/src/lib.rs
+++ b/clients/rust/crates/rubin-node/src/lib.rs
@@ -29,4 +29,4 @@ pub use p2p_runtime::{default_peer_runtime_config, PeerManager};
 pub use sync::{
     default_sync_config, HeaderRequest, SyncConfig, SyncEngine, DEFAULT_IBD_LAG_SECONDS,
 };
-pub use txpool::{TxPool, TxPoolAdmitError, TxPoolAdmitErrorKind};
+pub use txpool::{TxPool, TxPoolAdmitError, TxPoolAdmitErrorKind, TxPoolConfig};

--- a/clients/rust/crates/rubin-node/src/sync.rs
+++ b/clients/rust/crates/rubin-node/src/sync.rs
@@ -109,6 +109,10 @@ impl SyncEngine {
         self.cfg.chain_id
     }
 
+    pub fn core_ext_deployments(&self) -> CoreExtDeploymentProfiles {
+        self.cfg.core_ext_deployments.clone()
+    }
+
     pub fn tip(&self) -> Result<Option<(u64, [u8; 32])>, String> {
         if let Some(block_store) = self.block_store.as_ref() {
             return block_store.tip();

--- a/clients/rust/crates/rubin-node/src/txpool.rs
+++ b/clients/rust/crates/rubin-node/src/txpool.rs
@@ -1,12 +1,21 @@
 use std::collections::HashMap;
 
 use rubin_consensus::{
-    apply_non_coinbase_tx_basic_with_mtp, parse_block_header_bytes, parse_tx, Outpoint,
+    apply_non_coinbase_tx_basic_with_mtp, parse_block_header_bytes, parse_core_ext_covenant_data,
+    parse_tx, tx_weight_and_stats_public, CoreExtDeploymentProfiles, Outpoint,
 };
 
 use crate::{BlockStore, ChainState};
 
 const MAX_TX_POOL_TRANSACTIONS: usize = 300;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TxPoolConfig {
+    pub policy_da_surcharge_per_byte: u64,
+    pub policy_reject_non_coinbase_anchor_outputs: bool,
+    pub policy_reject_core_ext_pre_activation: bool,
+    pub core_ext_deployments: CoreExtDeploymentProfiles,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TxPoolEntry {
@@ -16,6 +25,7 @@ pub struct TxPoolEntry {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TxPool {
+    cfg: TxPoolConfig,
     txs: HashMap<[u8; 32], TxPoolEntry>,
     spenders: HashMap<Outpoint, [u8; 32]>,
 }
@@ -43,7 +53,12 @@ impl std::error::Error for TxPoolAdmitError {}
 
 impl TxPool {
     pub fn new() -> Self {
+        Self::new_with_config(TxPoolConfig::default())
+    }
+
+    pub fn new_with_config(cfg: TxPoolConfig) -> Self {
         Self {
+            cfg,
             txs: HashMap::new(),
             spenders: HashMap::new(),
         }
@@ -105,6 +120,7 @@ impl TxPool {
             chain_id,
         )
         .map_err(|err| rejected(format!("transaction rejected: {err}")))?;
+        apply_policy(&tx, &chain_state.utxos, next_height, &self.cfg).map_err(rejected)?;
 
         self.txs.insert(
             txid,
@@ -123,6 +139,17 @@ impl TxPool {
 impl Default for TxPool {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl Default for TxPoolConfig {
+    fn default() -> Self {
+        Self {
+            policy_da_surcharge_per_byte: 0,
+            policy_reject_non_coinbase_anchor_outputs: true,
+            policy_reject_core_ext_pre_activation: true,
+            core_ext_deployments: CoreExtDeploymentProfiles::empty(),
+        }
     }
 }
 
@@ -208,6 +235,133 @@ fn unavailable(message: impl Into<String>) -> TxPoolAdmitError {
     }
 }
 
+fn apply_policy(
+    tx: &rubin_consensus::Tx,
+    utxos: &HashMap<Outpoint, rubin_consensus::UtxoEntry>,
+    next_height: u64,
+    cfg: &TxPoolConfig,
+) -> Result<(), String> {
+    if cfg.policy_reject_non_coinbase_anchor_outputs {
+        reject_non_coinbase_anchor_outputs(tx)?;
+    }
+    reject_da_anchor_tx_policy(tx, utxos, cfg.policy_da_surcharge_per_byte)?;
+    if cfg.policy_reject_core_ext_pre_activation {
+        reject_core_ext_tx_pre_activation(tx, utxos, next_height, &cfg.core_ext_deployments)?;
+    }
+    Ok(())
+}
+
+fn reject_non_coinbase_anchor_outputs(tx: &rubin_consensus::Tx) -> Result<(), String> {
+    if tx
+        .outputs
+        .iter()
+        .any(|output| output.covenant_type == rubin_consensus::constants::COV_TYPE_ANCHOR)
+    {
+        return Err("non-coinbase CORE_ANCHOR is non-standard (policy)".to_string());
+    }
+    Ok(())
+}
+
+fn reject_da_anchor_tx_policy(
+    tx: &rubin_consensus::Tx,
+    utxos: &HashMap<Outpoint, rubin_consensus::UtxoEntry>,
+    da_surcharge_per_byte: u64,
+) -> Result<(), String> {
+    let (_, da_bytes, _) = tx_weight_and_stats_public(tx).map_err(|err| err.to_string())?;
+    if da_bytes == 0 || da_surcharge_per_byte == 0 {
+        return Ok(());
+    }
+    let min_fee = da_bytes
+        .checked_mul(da_surcharge_per_byte)
+        .ok_or_else(|| "min fee overflow".to_string())?;
+    let fee = compute_fee_no_verify(tx, utxos)?;
+    if fee < min_fee {
+        return Err(format!(
+            "DA fee below policy minimum (fee={fee} min_fee={min_fee})"
+        ));
+    }
+    Ok(())
+}
+
+fn compute_fee_no_verify(
+    tx: &rubin_consensus::Tx,
+    utxos: &HashMap<Outpoint, rubin_consensus::UtxoEntry>,
+) -> Result<u64, String> {
+    if tx.inputs.is_empty() {
+        return Err("missing inputs".to_string());
+    }
+    let mut sum_in = 0u64;
+    for input in &tx.inputs {
+        let outpoint = Outpoint {
+            txid: input.prev_txid,
+            vout: input.prev_vout,
+        };
+        let entry = utxos
+            .get(&outpoint)
+            .ok_or_else(|| "missing utxo".to_string())?;
+        sum_in = sum_in
+            .checked_add(entry.value)
+            .ok_or_else(|| "sum_in overflow".to_string())?;
+    }
+    let mut sum_out = 0u64;
+    for output in &tx.outputs {
+        sum_out = sum_out
+            .checked_add(output.value)
+            .ok_or_else(|| "sum_out overflow".to_string())?;
+    }
+    if sum_out > sum_in {
+        return Err("overspend".to_string());
+    }
+    Ok(sum_in - sum_out)
+}
+
+fn reject_core_ext_tx_pre_activation(
+    tx: &rubin_consensus::Tx,
+    utxos: &HashMap<Outpoint, rubin_consensus::UtxoEntry>,
+    height: u64,
+    deployments: &CoreExtDeploymentProfiles,
+) -> Result<(), String> {
+    let active = deployments
+        .active_profiles_at_height(height)
+        .map_err(|err| err.to_string())?;
+    for output in &tx.outputs {
+        if output.covenant_type != rubin_consensus::constants::COV_TYPE_EXT {
+            continue;
+        }
+        let cov =
+            parse_core_ext_covenant_data(&output.covenant_data).map_err(|err| err.to_string())?;
+        if !active
+            .active
+            .iter()
+            .any(|profile| profile.ext_id == cov.ext_id)
+        {
+            return Err(format!("CORE_EXT output pre-ACTIVE ext_id={}", cov.ext_id));
+        }
+    }
+    for input in &tx.inputs {
+        let outpoint = Outpoint {
+            txid: input.prev_txid,
+            vout: input.prev_vout,
+        };
+        let Some(entry) = utxos.get(&outpoint) else {
+            continue;
+        };
+        if entry.covenant_type != rubin_consensus::constants::COV_TYPE_EXT {
+            continue;
+        }
+        let cov =
+            parse_core_ext_covenant_data(&entry.covenant_data).map_err(|err| err.to_string())?;
+        if !active
+            .active
+            .iter()
+            .any(|profile| profile.ext_id == cov.ext_id)
+        {
+            return Err(format!("CORE_EXT spend pre-ACTIVE ext_id={}", cov.ext_id));
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
@@ -215,11 +369,18 @@ mod tests {
     use std::path::PathBuf;
 
     use rubin_consensus::block::BLOCK_HEADER_BYTES;
-    use rubin_consensus::{parse_tx, Outpoint, UtxoEntry};
+    use rubin_consensus::constants::{
+        COV_TYPE_ANCHOR, COV_TYPE_EXT, COV_TYPE_P2PK, SUITE_ID_SENTINEL, TX_WIRE_VERSION,
+    };
+    use rubin_consensus::{
+        marshal_tx, p2pk_covenant_data_for_pubkey, parse_tx, sign_transaction,
+        CoreExtDeploymentProfile, CoreExtDeploymentProfiles, CoreExtVerificationBinding,
+        DaChunkCore, Mldsa87Keypair, Outpoint, Tx, TxInput, TxOutput, UtxoEntry, WitnessItem,
+    };
 
     use super::{
         conflict, mtp_median, next_block_height, next_block_mtp, rejected, unavailable, TxPool,
-        TxPoolAdmitErrorKind, TxPoolEntry, MAX_TX_POOL_TRANSACTIONS,
+        TxPoolAdmitErrorKind, TxPoolConfig, TxPoolEntry, MAX_TX_POOL_TRANSACTIONS,
     };
     use crate::{
         block_store_path, default_sync_config, devnet_genesis_block_bytes, devnet_genesis_chain_id,
@@ -352,6 +513,108 @@ mod tests {
         state.height = vector.height.saturating_sub(1);
         state.utxos = fixture_utxos_to_map(&vector.utxos);
         state
+    }
+
+    fn empty_core_ext_covenant_data(ext_id: u16) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(&ext_id.to_le_bytes());
+        out.push(0x00);
+        out
+    }
+
+    fn signed_p2pk_state_and_tx(
+        input_value: u64,
+        outputs: Vec<TxOutput>,
+        tx_kind: u8,
+        da_chunk_core: Option<DaChunkCore>,
+        da_payload: Vec<u8>,
+    ) -> (ChainState, Vec<u8>) {
+        let keypair = match Mldsa87Keypair::generate() {
+            Ok(value) => value,
+            Err(err) => panic!("OpenSSL signer unavailable for txpool policy test: {err}"),
+        };
+        let pubkey = keypair.pubkey_bytes();
+        let outpoint = Outpoint {
+            txid: [0x11; 32],
+            vout: 0,
+        };
+        let mut state = ChainState::new();
+        state.utxos.insert(
+            outpoint.clone(),
+            UtxoEntry {
+                value: input_value,
+                covenant_type: COV_TYPE_P2PK,
+                covenant_data: p2pk_covenant_data_for_pubkey(&pubkey),
+                creation_height: 0,
+                created_by_coinbase: false,
+            },
+        );
+
+        let mut tx = Tx {
+            version: TX_WIRE_VERSION,
+            tx_kind,
+            tx_nonce: 7,
+            inputs: vec![TxInput {
+                prev_txid: outpoint.txid,
+                prev_vout: outpoint.vout,
+                script_sig: Vec::new(),
+                sequence: 0,
+            }],
+            outputs,
+            locktime: 0,
+            da_commit_core: None,
+            da_chunk_core,
+            witness: Vec::new(),
+            da_payload,
+        };
+        sign_transaction(&mut tx, &state.utxos, [0u8; 32], &keypair).expect("sign tx");
+        let raw = marshal_tx(&tx).expect("marshal tx");
+        (state, raw)
+    }
+
+    fn core_ext_spend_state_and_tx(ext_id: u16) -> (ChainState, Vec<u8>) {
+        let input = Outpoint {
+            txid: [0x33; 32],
+            vout: 0,
+        };
+        let mut state = ChainState::new();
+        state.utxos.insert(
+            input.clone(),
+            UtxoEntry {
+                value: 10,
+                covenant_type: COV_TYPE_EXT,
+                covenant_data: empty_core_ext_covenant_data(ext_id),
+                creation_height: 0,
+                created_by_coinbase: false,
+            },
+        );
+        let tx = Tx {
+            version: TX_WIRE_VERSION,
+            tx_kind: 0x00,
+            tx_nonce: 9,
+            inputs: vec![TxInput {
+                prev_txid: input.txid,
+                prev_vout: input.vout,
+                script_sig: Vec::new(),
+                sequence: 0,
+            }],
+            outputs: vec![TxOutput {
+                value: 9,
+                covenant_type: COV_TYPE_P2PK,
+                covenant_data: p2pk_covenant_data_for_pubkey(&vec![0x44; 2592]),
+            }],
+            locktime: 0,
+            da_commit_core: None,
+            da_chunk_core: None,
+            witness: vec![WitnessItem {
+                suite_id: SUITE_ID_SENTINEL,
+                pubkey: Vec::new(),
+                signature: Vec::new(),
+            }],
+            da_payload: Vec::new(),
+        };
+        let raw = marshal_tx(&tx).expect("marshal core_ext spend");
+        (state, raw)
     }
 
     #[test]
@@ -612,6 +875,113 @@ mod tests {
             .unwrap_err();
         assert_eq!(err.kind, TxPoolAdmitErrorKind::Rejected);
         assert!(err.message.contains("transaction rejected"));
+    }
+
+    #[test]
+    fn admit_rejects_non_coinbase_anchor_outputs_by_policy() {
+        let (state, raw) = signed_p2pk_state_and_tx(
+            10,
+            vec![
+                TxOutput {
+                    value: 0,
+                    covenant_type: COV_TYPE_ANCHOR,
+                    covenant_data: vec![0x99],
+                },
+                TxOutput {
+                    value: 9,
+                    covenant_type: COV_TYPE_P2PK,
+                    covenant_data: p2pk_covenant_data_for_pubkey(&vec![0x22; 2592]),
+                },
+            ],
+            0x00,
+            None,
+            Vec::new(),
+        );
+        let err = TxPool::new()
+            .admit(&raw, &state, None, [0u8; 32])
+            .unwrap_err();
+        assert_eq!(err.kind, TxPoolAdmitErrorKind::Rejected);
+        assert!(err.message.contains("CORE_ANCHOR"));
+    }
+
+    #[test]
+    fn admit_rejects_da_tx_below_policy_surcharge_minimum() {
+        let (state, raw) = signed_p2pk_state_and_tx(
+            10,
+            vec![TxOutput {
+                value: 9,
+                covenant_type: COV_TYPE_P2PK,
+                covenant_data: p2pk_covenant_data_for_pubkey(&vec![0x23; 2592]),
+            }],
+            0x02,
+            Some(DaChunkCore {
+                da_id: [0x55; 32],
+                chunk_index: 0,
+                chunk_hash: [0x66; 32],
+            }),
+            vec![0x77; 64],
+        );
+        let mut pool = TxPool::new_with_config(TxPoolConfig::default());
+        pool.cfg.policy_da_surcharge_per_byte = 1;
+        let err = pool.admit(&raw, &state, None, [0u8; 32]).unwrap_err();
+        assert_eq!(err.kind, TxPoolAdmitErrorKind::Rejected);
+        assert!(err.message.contains("DA fee below policy minimum"));
+    }
+
+    #[test]
+    fn admit_rejects_core_ext_output_pre_activation_by_policy() {
+        let (state, raw) = signed_p2pk_state_and_tx(
+            10,
+            vec![TxOutput {
+                value: 9,
+                covenant_type: COV_TYPE_EXT,
+                covenant_data: empty_core_ext_covenant_data(7),
+            }],
+            0x00,
+            None,
+            Vec::new(),
+        );
+        let err = TxPool::new()
+            .admit(&raw, &state, None, [0u8; 32])
+            .unwrap_err();
+        assert_eq!(err.kind, TxPoolAdmitErrorKind::Rejected);
+        assert!(err.message.contains("CORE_EXT output pre-ACTIVE"));
+    }
+
+    #[test]
+    fn admit_allows_core_ext_output_when_profile_is_active() {
+        let (state, raw) = signed_p2pk_state_and_tx(
+            10,
+            vec![TxOutput {
+                value: 9,
+                covenant_type: COV_TYPE_EXT,
+                covenant_data: empty_core_ext_covenant_data(7),
+            }],
+            0x00,
+            None,
+            Vec::new(),
+        );
+        let mut pool = TxPool::new_with_config(TxPoolConfig::default());
+        pool.cfg.core_ext_deployments = CoreExtDeploymentProfiles {
+            deployments: vec![CoreExtDeploymentProfile {
+                ext_id: 7,
+                activation_height: 0,
+                allowed_suite_ids: vec![3],
+                verification_binding: CoreExtVerificationBinding::VerifySigExtAccept,
+            }],
+        };
+        let txid = pool.admit(&raw, &state, None, [0u8; 32]).expect("admit");
+        assert!(pool.txs.contains_key(&txid));
+    }
+
+    #[test]
+    fn admit_rejects_core_ext_spend_pre_activation_by_policy() {
+        let (state, raw) = core_ext_spend_state_and_tx(9);
+        let err = TxPool::new()
+            .admit(&raw, &state, None, [0u8; 32])
+            .unwrap_err();
+        assert_eq!(err.kind, TxPoolAdmitErrorKind::Rejected);
+        assert!(err.message.contains("CORE_EXT spend pre-ACTIVE"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- close Q-RUST-PARITY-TX-01 by adding a public Rust marshal/sign helper surface
- close Q-RUST-PARITY-SIGNER-01 by exposing an OpenSSL-backed ML-DSA signer helper
- close Q-RUST-PARITY-POLICY-01 by wiring Go-style non-consensus txpool policy hooks

## Queue
- Q-RUST-PARITY-TX-01
- Q-RUST-PARITY-SIGNER-01
- Q-RUST-PARITY-POLICY-01

Fixes #556
Fixes #560
Fixes #558

## Validation
- cargo test -p rubin-consensus -p rubin-node
- ./scripts/preflight-codacy-coverage.sh