### PR TITLE
fix: strip markdown code fences from model output before JSON parsing

### DIFF
--- a/.github/workflows/models-security-review.yml
+++ b/.github/workflows/models-security-review.yml
@@ -179,6 +179,8 @@ jobs:
             }
 
             core.info(`Used model: ${usedModel}`);
+                          // Strip markdown code fences that models sometimes wrap around JSON
+              result = result.replace(/^\s*```(?:json)?\s*\n?/, '').replace(/\n?\s*```\s*$/, '').trim();
             core.setOutput('review', result);
             core.setOutput('used_model', usedModel);
         env:


### PR DESCRIPTION
Models (deepseek-v3, llama-4-maverick) sometimes return JSON wrapped in markdown code fences (```json...```). The workflow's post-review step then wraps this again in ```json...```, creating double fences. The resolve job's regex extracts the inner fence marker instead of actual JSON, causing parse failures.

This fix strips leading/trailing markdown code fences from model output before saving it as a step output.