### PR TITLE
fix: clean conflicting rust mempool spends after block accept

### DIFF
--- a/clients/rust/crates/rubin-node/src/miner.rs
+++ b/clients/rust/crates/rubin-node/src/miner.rs
@@ -178,6 +178,11 @@ impl<'a> Miner<'a> {
         };
         let txids: Vec<[u8; 32]> = parsed.iter().map(|candidate| candidate.txid).collect();
         pool.evict_txids(&txids);
+        let block_txs: Vec<Tx> = parsed
+            .iter()
+            .map(|candidate| candidate.tx.clone())
+            .collect();
+        pool.remove_conflicting_inputs(&block_txs);
     }
 
     fn remaining_weight_budget(&self, next_height: u64) -> Result<u64, String> {
@@ -386,16 +391,13 @@ mod tests {
     use std::fs;
     use std::path::PathBuf;
 
-    use rubin_consensus::constants::{COV_TYPE_P2PK, MAX_BLOCK_WEIGHT, TX_WIRE_VERSION};
+    use rubin_consensus::constants::MAX_BLOCK_WEIGHT;
     use rubin_consensus::merkle::{witness_commitment_hash, witness_merkle_root_wtxids};
-    use rubin_consensus::{
-        marshal_tx, p2pk_covenant_data_for_pubkey, sign_transaction, Mldsa87Keypair, Outpoint,
-        TxInput, TxOutput, UtxoEntry,
-    };
 
     use crate::{
         block_store_path, chain_state_path, default_sync_config, devnet_genesis_chain_id,
-        BlockStore, ChainState, SyncEngine, TxPool,
+        test_helpers::signed_conflicting_p2pk_state_and_txs, BlockStore, ChainState, SyncEngine,
+        TxPool,
     };
 
     use super::{
@@ -607,48 +609,8 @@ mod tests {
     }
 
     fn signed_p2pk_state_and_tx(input_value: u64, output_value: u64) -> (ChainState, Vec<u8>) {
-        let keypair = Mldsa87Keypair::generate().expect("OpenSSL signer unavailable");
-        let pubkey = keypair.pubkey_bytes();
-        let outpoint = Outpoint {
-            txid: [0x11; 32],
-            vout: 0,
-        };
-        let mut state = ChainState::new();
-        state.utxos.insert(
-            outpoint.clone(),
-            UtxoEntry {
-                value: input_value,
-                covenant_type: COV_TYPE_P2PK,
-                covenant_data: p2pk_covenant_data_for_pubkey(&pubkey),
-                creation_height: 0,
-                created_by_coinbase: false,
-            },
-        );
-
-        let mut tx = rubin_consensus::Tx {
-            version: TX_WIRE_VERSION,
-            tx_kind: 0x00,
-            tx_nonce: 7,
-            inputs: vec![TxInput {
-                prev_txid: outpoint.txid,
-                prev_vout: outpoint.vout,
-                script_sig: Vec::new(),
-                sequence: 0,
-            }],
-            outputs: vec![TxOutput {
-                value: output_value,
-                covenant_type: COV_TYPE_P2PK,
-                covenant_data: p2pk_covenant_data_for_pubkey(&vec![0x22; 2592]),
-            }],
-            locktime: 0,
-            da_commit_core: None,
-            da_chunk_core: None,
-            witness: Vec::new(),
-            da_payload: Vec::new(),
-        };
-        sign_transaction(&mut tx, &state.utxos, devnet_genesis_chain_id(), &keypair)
-            .expect("sign tx");
-        let raw = marshal_tx(&tx).expect("marshal tx");
+        let (state, raw, _conflict) =
+            signed_conflicting_p2pk_state_and_txs(input_value, output_value, output_value - 1);
         (state, raw)
     }
 
@@ -692,6 +654,36 @@ mod tests {
         assert_eq!(mined.len(), 2);
         assert_eq!(mined[0].tx_count, 2);
         assert_eq!(mined[1].tx_count, 1);
+        assert!(pool.is_empty());
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn mine_one_evicts_conflicting_pool_transaction_for_explicit_candidate() {
+        let (dir, _block_store, mut sync) = test_sync("rubin-rust-miner-explicit-conflict");
+        let (state, explicit_raw, conflicting_raw) =
+            signed_conflicting_p2pk_state_and_txs(20, 10, 9);
+        sync.chain_state.utxos = state.utxos.clone();
+
+        let mut pool = TxPool::new();
+        pool.admit(
+            &conflicting_raw,
+            &sync.chain_state,
+            None,
+            devnet_genesis_chain_id(),
+        )
+        .expect("admit conflict");
+
+        {
+            let cfg = MinerConfig {
+                timestamp_source: || 1_777_000_555,
+                ..MinerConfig::default()
+            };
+            let mut miner = Miner::new(&mut sync, Some(&mut pool), cfg).expect("miner");
+            let mined = miner.mine_one(&[explicit_raw]).expect("mine explicit");
+            assert_eq!(mined.tx_count, 2);
+        }
+
         assert!(pool.is_empty());
         let _ = fs::remove_dir_all(&dir);
     }

--- a/clients/rust/crates/rubin-node/src/sync_reorg.rs
+++ b/clients/rust/crates/rubin-node/src/sync_reorg.rs
@@ -1,6 +1,6 @@
 use rubin_consensus::{
     block_hash, parse_block_bytes, parse_tx, read_compact_size_bytes,
-    validate_block_basic_with_context_at_height, BLOCK_HEADER_BYTES,
+    validate_block_basic_with_context_at_height, ParsedBlock, BLOCK_HEADER_BYTES,
 };
 
 use crate::chainstate::ChainStateConnectSummary;
@@ -36,6 +36,7 @@ impl SyncEngine {
         if let Some(summary) = self.apply_direct_if_possible(block_bytes, prev_timestamps)? {
             if let Some(pool) = tx_pool {
                 evict_confirmed_from_pool(pool, block_bytes);
+                remove_conflicting_from_pool(pool, &parsed);
             }
             return Ok(summary);
         }
@@ -318,6 +319,13 @@ fn evict_confirmed_from_pool(pool: &mut TxPool, block_bytes: &[u8]) {
     pool.evict_txids(&parsed.txids);
 }
 
+fn remove_conflicting_from_pool(pool: &mut TxPool, parsed: &ParsedBlock) {
+    if parsed.txs.len() <= 1 {
+        return;
+    }
+    pool.remove_conflicting_inputs(&parsed.txs[1..]);
+}
+
 /// Extract raw bytes for each non-coinbase transaction in a block.
 /// This avoids needing a marshal_tx function — we slice directly from
 /// the block bytes using parse_tx consumed lengths.
@@ -351,11 +359,12 @@ mod tests {
     use super::*;
     use crate::blockstore::{block_store_path, BlockStore};
     use crate::chainstate::{chain_state_path, ChainState};
+    use crate::devnet_genesis_chain_id;
     use crate::io_utils::unique_temp_path;
     use crate::sync::{default_sync_config, SyncEngine};
     use crate::test_helpers::{
-        coinbase_only_block, coinbase_only_block_with_gen, genesis_info,
-        height_one_coinbase_only_block,
+        block_with_txs, coinbase_only_block, coinbase_only_block_with_gen, genesis_info,
+        height_one_coinbase_only_block, signed_conflicting_p2pk_state_and_txs,
     };
 
     #[test]
@@ -409,6 +418,36 @@ mod tests {
             .expect("block 1");
         assert_eq!(summary.block_height, 1);
 
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    #[test]
+    fn apply_block_with_reorg_tip_extension_removes_conflicting_pool_spends() {
+        let (mut engine, dir) = engine_with_store("rubin-reorg-tip-conflict");
+        let (genesis, genesis_hash, gen_ts) = genesis_info();
+        engine
+            .apply_block_with_reorg(&genesis, None, None)
+            .expect("genesis");
+        engine.cfg.chain_id = devnet_genesis_chain_id();
+
+        let (state, admitted_raw, block_raw) = signed_conflicting_p2pk_state_and_txs(20, 10, 9);
+        engine.chain_state.utxos = state.utxos.clone();
+
+        let mut pool = TxPool::new();
+        pool.admit(
+            &admitted_raw,
+            &engine.chain_state,
+            engine.block_store.as_ref(),
+            engine.cfg.chain_id,
+        )
+        .expect("admit");
+
+        let block1 = block_with_txs(1, 0, genesis_hash, gen_ts + 1, &[block_raw]);
+        engine
+            .apply_block_with_reorg(&block1, None, Some(&mut pool))
+            .expect("block 1");
+
+        assert!(pool.is_empty());
         std::fs::remove_dir_all(&dir).expect("cleanup");
     }
 

--- a/clients/rust/crates/rubin-node/src/test_helpers.rs
+++ b/clients/rust/crates/rubin-node/src/test_helpers.rs
@@ -3,12 +3,15 @@
 use rubin_consensus::constants::POW_LIMIT;
 use rubin_consensus::merkle::{witness_commitment_hash, witness_merkle_root_wtxids};
 use rubin_consensus::{
-    block_hash, encode_compact_size, merkle_root_txids, parse_block_bytes, parse_tx,
-    BLOCK_HEADER_BYTES,
+    block_hash, encode_compact_size, marshal_tx, merkle_root_txids, p2pk_covenant_data_for_pubkey,
+    parse_block_bytes, parse_tx, sign_transaction, Mldsa87Keypair, Outpoint, Tx, TxInput, TxOutput,
+    UtxoEntry, BLOCK_HEADER_BYTES,
 };
 
 use crate::coinbase::{build_coinbase_tx, default_mine_address};
+use crate::devnet_genesis_chain_id;
 use crate::genesis::devnet_genesis_block_bytes;
+use crate::ChainState;
 
 pub fn build_block_bytes(
     prev_hash: [u8; 32],
@@ -62,6 +65,102 @@ pub fn coinbase_only_block_with_gen(
     assert_eq!(consumed, coinbase.len());
     let merkle_root = merkle_root_txids(&[coinbase_txid]).expect("merkle root");
     build_block_bytes(prev_hash, merkle_root, POW_LIMIT, timestamp, &[coinbase])
+}
+
+pub fn block_with_txs(
+    height: u64,
+    already_generated: u64,
+    prev_hash: [u8; 32],
+    timestamp: u64,
+    txs: &[Vec<u8>],
+) -> Vec<u8> {
+    let mut txids = Vec::with_capacity(1 + txs.len());
+    let mut wtxids = Vec::with_capacity(1 + txs.len());
+    wtxids.push([0u8; 32]);
+    for tx_bytes in txs {
+        let (_tx, txid, wtxid, consumed) = parse_tx(tx_bytes).expect("parse tx");
+        assert_eq!(consumed, tx_bytes.len());
+        txids.push(txid);
+        wtxids.push(wtxid);
+    }
+
+    let witness_root = witness_merkle_root_wtxids(&wtxids).expect("witness root");
+    let witness_commitment = witness_commitment_hash(witness_root);
+    let coinbase = build_coinbase_tx(
+        height,
+        already_generated,
+        &default_mine_address(),
+        witness_commitment,
+    )
+    .expect("coinbase");
+    let (_, coinbase_txid, _, consumed) = parse_tx(&coinbase).expect("parse coinbase");
+    assert_eq!(consumed, coinbase.len());
+
+    let mut all_txids = Vec::with_capacity(1 + txids.len());
+    all_txids.push(coinbase_txid);
+    all_txids.extend_from_slice(&txids);
+    let merkle_root = merkle_root_txids(&all_txids).expect("merkle root");
+
+    let mut block_txs = Vec::with_capacity(1 + txs.len());
+    block_txs.push(coinbase);
+    block_txs.extend(txs.iter().cloned());
+    build_block_bytes(prev_hash, merkle_root, POW_LIMIT, timestamp, &block_txs)
+}
+
+pub fn signed_conflicting_p2pk_state_and_txs(
+    input_value: u64,
+    first_output_value: u64,
+    second_output_value: u64,
+) -> (ChainState, Vec<u8>, Vec<u8>) {
+    let keypair = Mldsa87Keypair::generate().expect("OpenSSL signer unavailable");
+    let pubkey = keypair.pubkey_bytes();
+    let outpoint = Outpoint {
+        txid: [0x11; 32],
+        vout: 0,
+    };
+
+    let mut state = ChainState::new();
+    state.utxos.insert(
+        outpoint.clone(),
+        UtxoEntry {
+            value: input_value,
+            covenant_type: rubin_consensus::constants::COV_TYPE_P2PK,
+            covenant_data: p2pk_covenant_data_for_pubkey(&pubkey),
+            creation_height: 0,
+            created_by_coinbase: false,
+        },
+    );
+
+    let build_tx = |tx_nonce: u64, output_value: u64| -> Vec<u8> {
+        let mut tx = Tx {
+            version: rubin_consensus::constants::TX_WIRE_VERSION,
+            tx_kind: 0x00,
+            tx_nonce,
+            inputs: vec![TxInput {
+                prev_txid: outpoint.txid,
+                prev_vout: outpoint.vout,
+                script_sig: Vec::new(),
+                sequence: 0,
+            }],
+            outputs: vec![TxOutput {
+                value: output_value,
+                covenant_type: rubin_consensus::constants::COV_TYPE_P2PK,
+                covenant_data: p2pk_covenant_data_for_pubkey(&vec![tx_nonce as u8; 2592]),
+            }],
+            locktime: 0,
+            da_commit_core: None,
+            da_chunk_core: None,
+            witness: Vec::new(),
+            da_payload: Vec::new(),
+        };
+        sign_transaction(&mut tx, &state.utxos, devnet_genesis_chain_id(), &keypair)
+            .expect("sign tx");
+        marshal_tx(&tx).expect("marshal tx")
+    };
+
+    let first = build_tx(7, first_output_value);
+    let second = build_tx(8, second_output_value);
+    (state, first, second)
 }
 
 /// Build a valid coinbase-only block at a given height (already_generated = 0).

--- a/clients/rust/crates/rubin-node/src/txpool.rs
+++ b/clients/rust/crates/rubin-node/src/txpool.rs
@@ -1,5 +1,5 @@
 use std::cmp::Ordering;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use rubin_consensus::{
     apply_non_coinbase_tx_basic_with_mtp, parse_block_header_bytes, parse_core_ext_covenant_data,
@@ -177,6 +177,26 @@ impl TxPool {
                 }
             }
         }
+    }
+
+    pub fn remove_conflicting_inputs(&mut self, txs: &[rubin_consensus::Tx]) {
+        let mut conflicting = HashSet::new();
+        for tx in txs {
+            for input in &tx.inputs {
+                let outpoint = Outpoint {
+                    txid: input.prev_txid,
+                    vout: input.prev_vout,
+                };
+                if let Some(txid) = self.spenders.get(&outpoint) {
+                    conflicting.insert(*txid);
+                }
+            }
+        }
+        if conflicting.is_empty() {
+            return;
+        }
+        let txids: Vec<[u8; 32]> = conflicting.into_iter().collect();
+        self.evict_txids(&txids);
     }
 }
 
@@ -453,7 +473,7 @@ mod tests {
     };
     use crate::{
         block_store_path, default_sync_config, devnet_genesis_block_bytes, devnet_genesis_chain_id,
-        BlockStore, ChainState, SyncEngine,
+        test_helpers::signed_conflicting_p2pk_state_and_txs, BlockStore, ChainState, SyncEngine,
     };
 
     #[derive(serde::Deserialize)]
@@ -950,6 +970,22 @@ mod tests {
 
         let selected = pool.select_transactions(1, 2);
         assert_eq!(selected, vec![vec![0x44, 0x44]]);
+    }
+
+    #[test]
+    fn remove_conflicting_inputs_evicts_conflicting_mempool_entries() {
+        let (state, admitted_raw, block_raw) = signed_conflicting_p2pk_state_and_txs(20, 10, 9);
+        let mut pool = TxPool::new();
+        let admitted_txid = pool
+            .admit(&admitted_raw, &state, None, devnet_genesis_chain_id())
+            .expect("admit");
+        let (block_tx, _txid, _wtxid, consumed) = parse_tx(&block_raw).expect("parse tx");
+        assert_eq!(consumed, block_raw.len());
+
+        pool.remove_conflicting_inputs(&[block_tx]);
+
+        assert!(!pool.txs.contains_key(&admitted_txid));
+        assert!(pool.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- remove non-confirmed mempool transactions that conflict with newly consumed inputs after Rust tip-extension apply
- mirror the same cleanup in miner explicit-candidate flow so conflicting spends are dropped after mined block assembly
- add regression helpers and tests covering txpool, sync_reorg, and miner paths

## Validation
- `/Users/gpt/Documents/rubin-protocol/scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test -p rubin-node'`
- `/Users/gpt/Documents/rubin-protocol/scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo clippy -p rubin-node --all-targets -- -D warnings'`
- `/Users/gpt/Documents/rubin-protocol/scripts/dev-env.sh -- ./scripts/preflight-codacy-coverage.sh`

## Queue
- Q-RUST-PARITY-MEMPOOL-CONFLICT-CLEANUP-01
