### PR TITLE
sec: harden P2P payload streaming reads

### DIFF
--- a/clients/go/node/p2p/wire.go
+++ b/clients/go/node/p2p/wire.go
@@ -43,6 +43,7 @@ const (
 	maxAddrPayloadEntries   = maxKnownAddrs
 	maxInventoryVectors     = 4096
 	maxCompactSizeBytes     = 9
+	streamReadChunkBytes    = 32 * 1024
 )
 
 type message struct {
@@ -83,24 +84,55 @@ func readFrameWithPayloadLimit(r io.Reader, expectedMagic [4]byte, maxMessageSiz
 			return frame, errors.New("message exceeds command cap")
 		}
 	}
-	payload := []byte{}
-	if header.Size > 0 {
-		limited := io.LimitReader(r, int64(header.Size))
-		payload, err = io.ReadAll(limited)
-		if err != nil {
-			return frame, err
-		}
-		if len(payload) != int(header.Size) {
-			return frame, io.ErrUnexpectedEOF
-		}
-	}
-	checksum := wireChecksum(payload)
-	if !bytes.Equal(header.Checksum[:], checksum[:]) {
-		return frame, errors.New("invalid envelope checksum")
+	payload, err := readPayloadWithChecksum(r, header.Size, header.Checksum)
+	if err != nil {
+		return frame, err
 	}
 	frame.Command = header.Command
 	frame.Payload = payload
 	return frame, nil
+}
+
+func readPayloadWithChecksum(r io.Reader, size uint32, wantChecksum [4]byte) ([]byte, error) {
+	if size == 0 {
+		if wantChecksum != wireChecksum(nil) {
+			return nil, errors.New("invalid envelope checksum")
+		}
+		return make([]byte, 0), nil
+	}
+
+	hasher := sha3.New256()
+	initialCap := int(size)
+	if initialCap > streamReadChunkBytes {
+		initialCap = streamReadChunkBytes
+	}
+	payload := make([]byte, 0, initialCap)
+	remaining := int(size)
+	for remaining > 0 {
+		chunkLen := remaining
+		if chunkLen > streamReadChunkBytes {
+			chunkLen = streamReadChunkBytes
+		}
+		chunk := make([]byte, chunkLen)
+		if _, err := io.ReadFull(r, chunk); err != nil {
+			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+				return nil, io.ErrUnexpectedEOF
+			}
+			return nil, err
+		}
+		if _, err := hasher.Write(chunk); err != nil {
+			return nil, err
+		}
+		payload = append(payload, chunk...)
+		remaining -= chunkLen
+	}
+
+	sum := hasher.Sum(nil)
+	if !bytes.Equal(wantChecksum[:], sum[:4]) {
+		return nil, errors.New("invalid envelope checksum")
+	}
+
+	return payload, nil
 }
 
 func readFrameHeader(r io.Reader, expectedMagic [4]byte, maxMessageSize uint32) (frameHeader, error) {

--- a/clients/go/node/p2p/wire_test.go
+++ b/clients/go/node/p2p/wire_test.go
@@ -11,6 +11,14 @@ import (
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/node"
 )
 
+type errReader struct {
+	err error
+}
+
+func (r errReader) Read(_ []byte) (int, error) {
+	return 0, r.err
+}
+
 func TestReadWriteFrameRoundtrip(t *testing.T) {
 	msg := message{Command: messageInv, Payload: []byte{0x01, 0x02, 0x03}}
 	magic := networkMagic("devnet")
@@ -128,6 +136,67 @@ func TestReadFrameWithPayloadLimitReadsTxPayloadExact(t *testing.T) {
 	}
 	if !bytes.Equal(got.Payload, payload) {
 		t.Fatalf("payload mismatch")
+	}
+}
+
+func TestReadPayloadWithChecksumChunkedRoundtrip(t *testing.T) {
+	payload := bytes.Repeat([]byte{0xab}, streamReadChunkBytes+17)
+	checksum := wireChecksum(payload)
+	got, err := readPayloadWithChecksum(bytes.NewReader(payload), uint32(len(payload)), checksum)
+	if err != nil {
+		t.Fatalf("readPayloadWithChecksum: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatal("payload mismatch")
+	}
+}
+
+func TestReadPayloadWithChecksumRejectsBadChecksumAfterChunkedRead(t *testing.T) {
+	payload := bytes.Repeat([]byte{0xcd}, streamReadChunkBytes+9)
+	checksum := wireChecksum(payload)
+	checksum[0] ^= 0xff
+	_, err := readPayloadWithChecksum(bytes.NewReader(payload), uint32(len(payload)), checksum)
+	if err == nil || err.Error() != "invalid envelope checksum" {
+		t.Fatalf("expected invalid envelope checksum, got %v", err)
+	}
+}
+
+func TestReadPayloadWithChecksumNormalizesShortReadToUnexpectedEOF(t *testing.T) {
+	payload := bytes.Repeat([]byte{0xef}, streamReadChunkBytes+5)
+	checksum := wireChecksum(payload)
+	short := payload[:len(payload)-3]
+	_, err := readPayloadWithChecksum(bytes.NewReader(short), uint32(len(payload)), checksum)
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Fatalf("expected unexpected EOF, got %v", err)
+	}
+}
+
+func TestReadPayloadWithChecksumRejectsZeroLengthBadChecksum(t *testing.T) {
+	checksum := wireChecksum(nil)
+	checksum[0] ^= 0xff
+	_, err := readPayloadWithChecksum(bytes.NewReader(nil), 0, checksum)
+	if err == nil || err.Error() != "invalid envelope checksum" {
+		t.Fatalf("expected invalid envelope checksum, got %v", err)
+	}
+}
+
+func TestReadPayloadWithChecksumZeroLengthReturnsEmptySlice(t *testing.T) {
+	got, err := readPayloadWithChecksum(bytes.NewReader(nil), 0, wireChecksum(nil))
+	if err != nil {
+		t.Fatalf("readPayloadWithChecksum: %v", err)
+	}
+	if got == nil || len(got) != 0 {
+		t.Fatalf("expected empty non-nil slice, got %#v", got)
+	}
+}
+
+func TestReadPayloadWithChecksumPropagatesNonEOFReadError(t *testing.T) {
+	payload := bytes.Repeat([]byte{0x11}, streamReadChunkBytes)
+	checksum := wireChecksum(payload)
+	boom := errors.New("boom")
+	_, err := readPayloadWithChecksum(errReader{err: boom}, uint32(len(payload)), checksum)
+	if !errors.Is(err, boom) {
+		t.Fatalf("expected boom, got %v", err)
 	}
 }
 

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -45,6 +45,7 @@ const MAX_ADDR_PAYLOAD_BYTES: u64 = MAX_ADDR_COMPACT_SIZE_BYTES
 const MAX_HEADERS_BATCH: u64 = 2000;
 const MAX_HEADERS_PAYLOAD_BYTES: u64 =
     MAX_HEADERS_BATCH * (rubin_consensus::BLOCK_HEADER_BYTES as u64);
+const STREAM_READ_CHUNK_BYTES: usize = 32 * 1024;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct WireMessage {
@@ -679,22 +680,46 @@ fn read_message_from_with_payload_limit<R: Read>(
     let mut header = [0u8; WIRE_HEADER_SIZE];
     reader.read_exact(&mut header)?;
     let envelope = parse_envelope_header(&header, expected_magic, max_payload_bytes, payload_cap)?;
-    let mut payload = vec![0u8; envelope.payload_len];
-    if envelope.payload_len > 0 {
-        reader.read_exact(&mut payload)?;
+    let payload = read_payload_with_checksum(reader, envelope.payload_len, envelope.checksum)?;
+
+    Ok(WireMessage {
+        command: envelope.command,
+        payload,
+    })
+}
+
+fn read_payload_with_checksum<R: Read>(
+    reader: &mut R,
+    payload_len: usize,
+    want_checksum: [u8; 4],
+) -> io::Result<Vec<u8>> {
+    if payload_len == 0 {
+        if want_checksum != wire_checksum(&[]) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "invalid envelope checksum",
+            ));
+        }
+        return Ok(Vec::new());
     }
-    let checksum = wire_checksum(&payload);
-    if envelope.checksum != checksum {
+
+    let mut hasher = Sha3_256::new();
+    let mut payload = vec![0u8; payload_len];
+    for chunk in payload.chunks_mut(STREAM_READ_CHUNK_BYTES) {
+        reader.read_exact(chunk)?;
+        hasher.update(&*chunk);
+    }
+
+    let digest = hasher.finalize();
+    let checksum = [digest[0], digest[1], digest[2], digest[3]];
+    if want_checksum != checksum {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             "invalid envelope checksum",
         ));
     }
 
-    Ok(WireMessage {
-        command: envelope.command,
-        payload,
-    })
+    Ok(payload)
 }
 
 fn protocol_versions_compatible(local: u32, remote: u32) -> bool {
@@ -1639,6 +1664,28 @@ mod tests {
             .unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);
         assert_eq!(err.to_string(), "message exceeds command cap");
+    }
+
+    #[test]
+    fn p2p_read_payload_with_checksum_chunked_roundtrip() {
+        let payload = vec![0xabu8; STREAM_READ_CHUNK_BYTES + 17];
+        let checksum = wire_checksum(&payload);
+        let mut reader = std::io::Cursor::new(payload.clone());
+        let got =
+            read_payload_with_checksum(&mut reader, payload.len(), checksum).expect("payload");
+        assert_eq!(got, payload);
+    }
+
+    #[test]
+    fn p2p_read_payload_with_checksum_rejects_bad_checksum_after_chunked_read() {
+        let payload = vec![0xcdu8; STREAM_READ_CHUNK_BYTES + 9];
+        let mut checksum = wire_checksum(&payload);
+        checksum[0] ^= 0xff;
+        let mut reader = std::io::Cursor::new(payload);
+        let err = read_payload_with_checksum(&mut reader, STREAM_READ_CHUNK_BYTES + 9, checksum)
+            .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert_eq!(err.to_string(), "invalid envelope checksum");
     }
 
     #[test]


### PR DESCRIPTION
Q-P2P-STREAM-READ-HARDENING-01

## Summary
- switch Go and Rust P2P payload reads to chunked checksuming paths
- keep short payload failures normalized and reject zero-length bad checksums explicitly
- add Go and Rust regression tests for chunked reads, bad checksums, short reads, and zero-length frames

## Validation
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node/p2p'\n- scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo fmt --all && cargo test -p rubin-node p2p_read_payload_with_checksum && cargo test -p rubin-node p2p_read_message_rejects_ && cargo clippy -p rubin-node --all-targets -- -D warnings'\n- scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test -p rubin-node'\n- /Users/gpt/bin/cl push origin HEAD (includes local model review + Codacy preflight)