### PR TITLE
ci: pin all GitHub Actions to commit SHA (security hardening)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@b8af2aac9666eb9921246e2d2b46a8e8fcfabc88 # v1
         env:
           ANTHROPIC_MODEL: claude-sonnet-4-6
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,18 +23,18 @@ jobs:
         # 'rust' — add when CodeQL Rust exits experimental
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4
         with:
           languages: ${{ matrix.language }}
           # queries: security-extended — uncomment for extended rule set
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/combined-load-nightly.yml
+++ b/.github/workflows/combined-load-nightly.yml
@@ -13,10 +13,10 @@ jobs:
   combined-load:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Cache OpenSSL 3.5 bundle
-        uses: actions/cache@v5
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
         with:
           path: |
             ~/.cache/rubin-openssl/bundle-3.5.5
@@ -76,7 +76,7 @@ jobs:
 
       - name: Upload combined-load artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: combined-load-benchmark
           path: artifacts/combined-load

--- a/.github/workflows/fips-only-nightly.yml
+++ b/.github/workflows/fips-only-nightly.yml
@@ -13,10 +13,10 @@ jobs:
   fips-only-smoke:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Cache OpenSSL 3.5 bundle
-        uses: actions/cache@v5
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
         with:
           path: |
             ~/.cache/rubin-openssl/bundle-3.5.5
@@ -145,7 +145,7 @@ jobs:
 
       - name: Upload FIPS-only nightly artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: fips-only-nightly
           path: artifacts/fips-nightly

--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       # OpenSSL dev headers required to compile openssl-sys FFI crate.
       # Kani proofs only exercise pure-Rust logic, but the crate must compile.
@@ -38,14 +38,14 @@ jobs:
 
       # Cache Kani toolchain to avoid re-downloading CBMC (~200 MB) every run.
       - name: Cache Kani toolchain
-        uses: actions/cache@v5
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
         with:
           path: ~/.kani
           key: kani-toolchain-${{ runner.os }}-${{ hashFiles('.github/workflows/kani.yml') }}
 
       # Cache Cargo build artifacts for faster recompilation.
       - name: Cache Cargo registry + target
-        uses: actions/cache@v5
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
         with:
           path: |
             ~/.cargo/registry
@@ -53,7 +53,7 @@ jobs:
             clients/rust/crates/rubin-consensus/target
           key: kani-cargo-${{ runner.os }}-${{ hashFiles('clients/rust/crates/rubin-consensus/Cargo.toml') }}
 
-      - uses: model-checking/kani-github-action@v1.1
+      - uses: model-checking/kani-github-action@f838096619a707b0f6b2118cf435eaccfa33e51f # v1.1
         with:
           working-directory: clients/rust/crates/rubin-consensus
           args: '--output-format=terse'

--- a/.github/workflows/models-security-review.yml
+++ b/.github/workflows/models-security-review.yml
@@ -36,7 +36,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
       - name: Upload diff artifact
         if: steps.diff.outputs.skip != 'true'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: pr-diff
           path: pr-diff.txt
@@ -49,14 +49,14 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
       - name: Download diff artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: pr-diff
       - name: Install jsonrepair
         run: npm install jsonrepair
       - name: Run security review
         id: review
-        uses: actions/github-script@v8
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         with:
           script: |
             const fs = require('fs');
@@ -142,14 +142,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload raw review output
         if: always() && hashFiles('raw-review-output.txt') != ''
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: raw-review-output
           path: raw-review-output.txt
           retention-days: 3
       - name: Post review comment
         if: steps.review.outputs.review
-        uses: actions/github-script@v8
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         with:
           script: |
             const review = ${{ toJSON(steps.review.outputs.review) }};
@@ -162,7 +162,7 @@ jobs:
             });
       - name: Block on critical findings
         if: steps.review.outputs.review
-        uses: actions/github-script@v8
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         with:
           script: |
             const raw = ${{ toJSON(steps.review.outputs.review) }};

--- a/.github/workflows/spec-checks.yml
+++ b/.github/workflows/spec-checks.yml
@@ -10,8 +10,8 @@ jobs:
   sanity:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
         with:
           node-version-file: '.node-version'
       - name: Conformance fixtures policy check


### PR DESCRIPTION
**7 workflow files, 19 substitutions.**

All `@vN` tag references replaced with commit SHA + comment.

| Action | Was | Now |
|---|---|---|
| `actions/checkout` | `@v6` | `@de0fac2e` |
| `actions/cache` | `@v5` | `@cdf6c1fa` |
| `actions/setup-node` | `@v6` | `@6044e13b` |
| `github/codeql-action/{init,autobuild,analyze}` | `@v4` | `@b1bff819` |
| `actions/upload-artifact` | `@v7` | `@ea165f8d` |
| `actions/download-artifact` | `@v8` | `@d3f86a10` |
| `actions/github-script` | `@v8` | `@60a0d830` |
| `anthropics/claude-code-action` | `@v1` | `@b8af2aac` |
| `model-checking/kani-github-action` | `@v1.1` | `@f838096` |

After merge: zero unpinned `@vN` references remain in `.github/workflows/`.