### PR TITLE
docs: add parallel validation implementation and agent TZ pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ Quick references:
 - Architecture & change path map: `./ARCHITECTURE_MAP.md`
 - Conformance harness overview: `./conformance/README.md`
 - Combined-load benchmark SLO/evidence lane: `./scripts/benchmarks/COMBINED_LOAD_SLO.md`
+- Parallel validation implementation plan: `./RUBIN_PARALLEL_VALIDATION_IMPLEMENTATION_PLAN.md`
+- Parallel validation agent TZ: `./RUBIN_PARALLEL_VALIDATION_AGENT_TZ.md`
+- Parallel validation operator runbook: `./RUBIN_PARALLEL_VALIDATION_OPERATOR_RUNBOOK.md`
+- Parallel validation shadow mode: `./RUBIN_PARALLEL_VALIDATION_SHADOW_MODE.md`
+- Parallel validation fixtures spec: `./RUBIN_PARALLEL_VALIDATION_FIXTURES.md`
+- Parallel validation benchmark plan: `./RUBIN_PARALLEL_VALIDATION_BENCHMARK_PLAN.md`
+- Parallel validation security notes: `./RUBIN_PARALLEL_VALIDATION_SECURITY_NOTES.md`
 
 ## Quick Start (Local)
 

--- a/RUBIN_PARALLEL_VALIDATION_AGENT_TZ.md
+++ b/RUBIN_PARALLEL_VALIDATION_AGENT_TZ.md
@@ -1,0 +1,149 @@
+# RUBIN Parallel Validation — Extended Agent TZ
+
+This document is an execution contract for agents implementing `Q-PV-*` tasks.
+
+## 1. Mission and Hard Boundaries
+
+Mission:
+
+- deliver deterministic parallel validation acceleration;
+- preserve consensus-equivalent behavior bit-for-bit.
+
+Hard boundaries:
+
+- no consensus semantics changes;
+- no new canonical error paths;
+- no concurrent state mutation;
+- no shortcuts that treat policy hints as consensus truth.
+
+## 2. Execution Model
+
+Each agent works on one `Q-PV-*` task at a time.
+
+Required flow:
+
+1. read queue row and dependency rows;
+2. validate baseline (`origin/main`) and referenced files;
+3. implement only task-local scope;
+4. run task-local tests + parity checks;
+5. provide evidence package in PR description;
+6. hand off to next dependency-ready task.
+
+## 3. Mandatory Inputs Before Coding
+
+For every `Q-PV-*` task:
+
+- queue row ID and dependency list (`depends=...`);
+- linked issue body and acceptance list;
+- current `origin/main` SHA for `rubin-protocol`;
+- relevant invariants from:
+  - `ARCHITECTURE_MAP.md`
+  - `README.md`
+  - `RUBIN_PARALLEL_VALIDATION_IMPLEMENTATION_PLAN.md`
+
+## 4. Required Deliverables per Task
+
+Every task output must include:
+
+- code changes (Go and/or Rust as scoped);
+- tests tied to acceptance criteria;
+- fixture or formal updates when required;
+- short evidence block:
+  - commands run
+  - PASS/FAIL summary
+  - parity result
+  - known limitations.
+
+## 5. Determinism Checklist (Must Pass)
+
+Before declaring task complete:
+
+1. parallel and sequential paths return same verdict;
+2. first canonical error matches;
+3. witness digest matches;
+4. post-state digest matches;
+5. result independent of worker scheduling perturbation.
+
+If any check fails: task is `BLOCKED`, not `DONE`.
+
+## 6. Testing Contract
+
+### Minimum
+
+- task-local unit tests;
+- integration parity test for touched path;
+- deterministic replay check.
+
+### Program-level
+
+- full Go and Rust suites for merged stacks;
+- conformance bundle checks;
+- race/sanitizer checks for concurrent paths;
+- fuzz smoke for newly introduced reducers/graph logic.
+
+Coverage requirement for new parallel-validation code:
+
+- floor: `>=80%`
+- target: `>=95%`
+
+## 7. Fixture Contract
+
+For fixture-related tasks (`Q-PV-16`, plus dependent tasks):
+
+- add deterministic fixture IDs with stable expected outputs;
+- verify fixture runs on both clients;
+- ensure no wall-clock/randomness dependence in expected results.
+
+## 8. Formal Contract
+
+For formal-related tasks (`Q-PV-19`, plus dependent tasks):
+
+- add/refresh theorems in `rubin-formal/RubinFormal/Refinement/`;
+- update `rubin-formal/proof_coverage.json`;
+- include theorem artifact evidence in PR notes.
+
+No "proof placeholder" completion without executable artifacts.
+
+## 9. Telemetry and Shadow Rollout Contract
+
+For `Q-PV-12..Q-PV-13` and rollout tasks:
+
+- `shadow` mode must not alter node truth path;
+- mismatch logs must be bounded;
+- telemetry must avoid sensitive payload leakage;
+- rollback to `off` must be straightforward and documented.
+
+## 10. Agent Handoff Template
+
+Use this exact handoff structure:
+
+```text
+QID: Q-PV-XX
+Scope completed:
+- ...
+
+Evidence:
+- command: ...
+- result: PASS/FAIL
+
+Parity:
+- seq_vs_parallel verdict: ...
+- first_error: ...
+- witness_digest: ...
+- post_state_digest: ...
+
+Open risks:
+- ...
+
+Next dependency-ready tasks:
+- Q-PV-YY
+```
+
+## 11. Completion Rule
+
+A `Q-PV-*` task can be marked complete only when:
+
+- acceptance criteria are demonstrably met;
+- required tests for the touched scope are green;
+- evidence is attached to issue/PR;
+- dependency chain remains logically consistent in queue.

--- a/RUBIN_PARALLEL_VALIDATION_BENCHMARK_PLAN.md
+++ b/RUBIN_PARALLEL_VALIDATION_BENCHMARK_PLAN.md
@@ -1,0 +1,49 @@
+# RUBIN Parallel Validation — Benchmark Plan
+
+## Goal
+
+Measure practical performance gain while preserving deterministic correctness.
+
+## Workload Classes
+
+1. signature-heavy
+2. UTXO-heavy
+3. covenant-heavy
+4. DA-heavy
+5. mixed realistic
+6. adversarial flood
+
+## Hardware Profiles
+
+- 4 core / 16 GB
+- 8 core / 32 GB
+- 16 core / 64 GB
+- 32 core / 128 GB
+
+## Required Artifacts
+
+- `benchmark_results.json`
+- `benchmark_summary.md`
+- `benchmark_env.json`
+
+## Required Metrics
+
+- throughput (`tx/s`)
+- block validation latency
+- signature verification throughput
+- UTXO lookup latency
+- CPU and memory envelope
+- commit stage latency
+
+## Merge Gate Thresholds
+
+- 1-worker mode regression <= 5%
+- positive gain on 8-core mixed workload
+- positive gain on 16-core signature-heavy workload
+- deterministic replay equality remains 100%
+
+## Reporting Rules
+
+- separate cold-cache and warm-cache runs;
+- pin dataset IDs and git SHA;
+- record runtime flags and worker count in `benchmark_env.json`.

--- a/RUBIN_PARALLEL_VALIDATION_FIXTURES.md
+++ b/RUBIN_PARALLEL_VALIDATION_FIXTURES.md
@@ -1,0 +1,53 @@
+# RUBIN Parallel Validation — Fixture Specification
+
+## 1. Fixture Families
+
+Parallel-validation fixtures use `CV-PV-*` namespaces:
+
+- `CV-PV-CURSOR-*`
+- `CV-PV-DAG-*`
+- `CV-PV-ERR-*`
+- `CV-PV-DA-*`
+- `CV-PV-CACHE-*`
+- `CV-PV-MIXED-*`
+- `CV-PV-STRESS-*`
+
+## 2. Minimal Vector Schema
+
+Each vector must include deterministic expected values:
+
+```json
+{
+  "id": "CV-PV-ERR-01",
+  "block_hex": "...",
+  "utxo_snapshot_id": "...",
+  "expect_valid": false,
+  "expect_err": "TX_ERR_PARSE",
+  "expect_first_invalid_tx_index": 2,
+  "expect_witness_digest": "...",
+  "expect_state_digest": "..."
+}
+```
+
+## 3. Determinism Rules
+
+- no wall-clock or random expected outputs;
+- fixture IDs and dataset references are stable;
+- vector outcome is invariant to worker scheduling perturbations.
+
+## 4. Runner Contract
+
+Fixture bundle execution must prove:
+
+1. Go matches fixture expectations;
+2. Rust matches Go behavior (parity);
+3. sequential and parallel digests are equal for required vectors.
+
+## 5. Coverage Expectations
+
+The fixture set must collectively cover:
+
+- first-error election edge cases;
+- witness cursor boundary cases;
+- parent-child DAG dependencies;
+- DA-heavy and signature-heavy stress profiles.

--- a/RUBIN_PARALLEL_VALIDATION_IMPLEMENTATION_PLAN.md
+++ b/RUBIN_PARALLEL_VALIDATION_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,190 @@
+# RUBIN Parallel Validation — Implementation Plan (Deterministic, Implementation-Only)
+
+## 1. Purpose
+
+This plan defines how to implement deterministic parallel block validation in `rubin-protocol`
+without changing consensus semantics.
+
+Core contract:
+
+- parallelize only read-only validation work;
+- keep final block verdict election deterministic;
+- keep commit/state mutation strictly sequential in canonical block order;
+- preserve canonical first-error behavior;
+- preserve witness assignment determinism.
+
+## 2. Scope and Non-Goals
+
+### In scope
+
+- deterministic tx-context precompute;
+- deterministic dependency graph for same-block relations;
+- read-only validation worker pool;
+- deterministic reducer for final error election;
+- sequential commit stage;
+- shadow-mode rollout (`off|shadow|on`);
+- parity fixtures and replay harness;
+- formal refinement package;
+- benchmark evidence and promotion gates.
+
+### Out of scope
+
+- consensus rule changes;
+- wire format changes;
+- new covenant semantics;
+- policy-as-consensus behavior;
+- speculative concurrent state mutation.
+
+## 3. Repository-Accurate Placement
+
+This section replaces draft path assumptions like `internal/parallel` and `tests/parallel`.
+
+### Go implementation
+
+- `clients/go/consensus/connect_block_parallel.go` (orchestrator, reducer hooks)
+- `clients/go/consensus/connect_block_parallel_*.go` (new modules by concern)
+- `clients/go/consensus/*_test.go` (unit/integration parity tests)
+- `clients/go/cmd/rubin-node/` (runtime flags and shadow mode wiring)
+
+### Rust implementation (parity path)
+
+- `clients/rust/crates/rubin-consensus/src/` (parallel parity modules)
+- `clients/rust/crates/rubin-consensus/src/tests/` (determinism/parity tests)
+- `clients/rust/crates/rubin-node/src/` (runtime flags and shadow mode wiring)
+
+### Conformance and fixtures
+
+- `conformance/fixtures/CV-PV-*.json` (parallel-validation fixture families)
+- `conformance/runner/run_cv_bundle.py` (routing + checks)
+- `tools/gen_conformance_matrix.py` (matrix coverage updates)
+
+### Formal package
+
+- `rubin-formal/RubinFormal/Refinement/` (refinement theorems)
+- `rubin-formal/proof_coverage.json` (coverage updates)
+- `rubin-formal/PROOF_COVERAGE.md` (human-readable summary)
+
+### Documentation
+
+- repository root markdowns:
+  - `RUBIN_PARALLEL_VALIDATION_IMPLEMENTATION_PLAN.md` (this file)
+  - `RUBIN_PARALLEL_VALIDATION_AGENT_TZ.md` (agent execution contract)
+  - `RUBIN_PARALLEL_VALIDATION_OPERATOR_RUNBOOK.md` (operational rollout)
+  - `RUBIN_PARALLEL_VALIDATION_SECURITY_NOTES.md` (risk and controls)
+  - `RUBIN_PARALLEL_VALIDATION_BENCHMARK_PLAN.md` (benchmark protocol)
+
+## 4. Work Breakdown (Q-PV Program)
+
+Program track: `Q-PV-01..Q-PV-20`.
+
+Execution order is dependency-driven (not pure numeric order). The queue rows define exact
+`depends=` constraints.
+
+### Foundation
+
+- `Q-PV-01`: scope lock + wording hardening (parallel validation, not parallel execution)
+- `Q-PV-02`: tx-context precompute
+- `Q-PV-03`: witness cursor module extraction
+- `Q-PV-04`: dependency graph v2
+- `Q-PV-05`: bounded worker pool skeleton
+- `Q-PV-06`: immutable UTXO snapshot read layer
+
+### Validation pipeline
+
+- `Q-PV-07`: parallel ML-DSA verification pool
+- `Q-PV-08`: parallel DA jobs
+- `Q-PV-09`: tx-local validation workers
+- `Q-PV-10`: deterministic reducer
+- `Q-PV-11`: sequential commit stage
+
+### Rollout and observability
+
+- `Q-PV-12`: shadow mode (`off|shadow|on`)
+- `Q-PV-13`: telemetry contract + counters
+
+### Verification completeness
+
+- `Q-PV-14`: unit tests (coverage floor/target policy)
+- `Q-PV-15`: integration parity suite
+- `Q-PV-16`: fixtures package (full)
+- `Q-PV-17`: fuzz + race harness
+- `Q-PV-18`: benchmark evidence package
+- `Q-PV-19`: formal refinement package (full)
+- `Q-PV-20`: promotion gates and staged rollout
+
+## 5. Determinism and Safety Invariants
+
+The following MUST hold for every Q-PV implementation PR:
+
+1. Canonical validity behavior is unchanged.
+2. First applicable error remains canonical.
+3. Witness digest equality holds (sequential vs parallel).
+4. Post-state digest equality holds (sequential vs parallel).
+5. No worker mutates consensus state.
+6. No reducer rule depends on scheduling order.
+7. Shadow mismatches never affect node verdict.
+
+## 6. Validation Gates
+
+Mandatory per-stack gates:
+
+- Go tests: `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./...'`
+- Rust tests: `scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test --workspace'`
+- Conformance: `scripts/dev-env.sh -- python3 conformance/runner/run_cv_bundle.py`
+- Determinism replay (sequential == parallel verdict/error/state/witness)
+- Race/sanitizer suites
+- Fuzz smoke gate
+- Formal artifact presence + theorem checks
+
+Coverage policy for new parallel-validation code:
+
+- hard floor: `>= 80%`
+- target: `>= 95%`
+- if branch is unreachable from public/runtime surface, annotate explicitly with rationale.
+
+## 7. Fixture Completeness Contract
+
+Required fixture families:
+
+- `CV-PV-CURSOR-*`
+- `CV-PV-DAG-*`
+- `CV-PV-ERR-*`
+- `CV-PV-DA-*`
+- `CV-PV-CACHE-*`
+- `CV-PV-MIXED-*`
+- `CV-PV-STRESS-*`
+
+Each vector must pin:
+
+- expected validity
+- expected canonical error
+- first invalid tx index (if invalid)
+- witness digest
+- post-state digest
+
+All vectors must run on Go and Rust with parity.
+
+## 8. Formal Completeness Contract
+
+Minimum theorem/artifact set:
+
+- witness cursor determinism
+- dependency graph soundness (`same-prevout`, `parent-child`)
+- validation purity (worker side effects forbidden)
+- reducer returns canonical first invalid tx
+- reject/accept equivalence vs sequential
+- commit equivalence vs sequential
+
+Formal artifacts must be committed in the same stack as the implementation changes they validate.
+
+## 9. Merge/Promotion Contract
+
+A parallel-validation stack is merge-ready only when:
+
+- all correctness gates are green;
+- no canonical/spec integrity drift is introduced;
+- deterministic parity is 100%;
+- fixture and formal packages are complete for the delivered scope;
+- benchmark evidence shows non-negative practical benefit for target hardware profiles.
+
+Promotion to broader rollout follows staged shadow evidence and operator readiness.

--- a/RUBIN_PARALLEL_VALIDATION_OPERATOR_RUNBOOK.md
+++ b/RUBIN_PARALLEL_VALIDATION_OPERATOR_RUNBOOK.md
@@ -1,0 +1,54 @@
+# RUBIN Parallel Validation — Operator Runbook
+
+## 1. Runtime Modes
+
+Parallel validation exposes three modes:
+
+- `off`: sequential validation only (default-safe mode)
+- `shadow`: sequential is authoritative, parallel runs for comparison only
+- `on`: parallel validation path enabled with deterministic reducer + sequential commit
+
+## 2. Rollout Order
+
+1. local lab (`off`)
+2. CI parity checks
+3. devnet `shadow`
+4. testnet `shadow`
+5. opt-in testnet `on`
+6. mainnet default remains `off` until evidence threshold is met
+
+## 3. Observability Signals
+
+Monitor:
+
+- mode and worker count
+- shadow mismatch totals (verdict/error/state/witness)
+- scheduler queue depth
+- validation/commit latency
+- signature cache hit ratio
+
+## 4. Mismatch Procedure (Shadow)
+
+If mismatch is detected in `shadow` mode:
+
+1. keep sequential verdict as source of truth;
+2. capture block ID, tx index, error code, digest deltas;
+3. persist diagnostic bundle for replay;
+4. open incident task and block promotion;
+5. investigate reducer/graph/cursor assumptions first.
+
+## 5. Emergency Rollback
+
+Immediate fallback path:
+
+- switch mode to `off`;
+- keep telemetry enabled;
+- resume only after root-cause fix and replay parity confirmation.
+
+## 6. Go/No-Go for Promotion
+
+Promotion to broader rollout is allowed only when:
+
+- zero unresolved shadow mismatches in required soak window;
+- parity fixtures are green;
+- formal and benchmark evidence for current phase is complete.

--- a/RUBIN_PARALLEL_VALIDATION_SECURITY_NOTES.md
+++ b/RUBIN_PARALLEL_VALIDATION_SECURITY_NOTES.md
@@ -1,0 +1,39 @@
+# RUBIN Parallel Validation — Security Notes
+
+## Threat Focus
+
+Parallel validation introduces implementation risk, not new consensus semantics.
+
+Primary hazards:
+
+1. nondeterministic first-error election
+2. witness slice misassignment
+3. incomplete parent-child dependency graph
+4. cache poisoning / false positive cache reuse
+5. policy leakage into consensus-equivalent path
+6. shadow mismatch flood and operator blindness
+
+## Controls
+
+- deterministic reducer with canonical priority table
+- sequential witness precompute and explicit boundary checks
+- explicit DAG edges (`same-prevout`, `producer->consumer`)
+- positive-only bounded cache with canonical keying
+- strict separation of policy checks from consensus-equivalent engine
+- bounded mismatch telemetry and rollback-to-off procedure
+
+## Verification Surfaces
+
+- deterministic replay harness
+- race/sanitizer suites
+- fuzz perturbation on scheduler/reducer paths
+- fixture parity and digest equality checks
+- formal refinement artifacts for reducer/graph/cursor invariants
+
+## Security Review Checklist
+
+- no worker mutates consensus state
+- reducer output is schedule-independent
+- first canonical error preserved
+- mismatch diagnostics do not leak sensitive payloads
+- rollback path is tested and documented

--- a/RUBIN_PARALLEL_VALIDATION_SHADOW_MODE.md
+++ b/RUBIN_PARALLEL_VALIDATION_SHADOW_MODE.md
@@ -1,0 +1,44 @@
+# RUBIN Parallel Validation — Shadow Mode Contract
+
+## Purpose
+
+`shadow` mode validates production safety before enabling parallel verdicts.
+
+In shadow mode:
+
+- sequential path remains authoritative;
+- parallel path computes comparison artifacts;
+- mismatches are telemetry/diagnostic only.
+
+## Comparison Surface
+
+For each validated block compare:
+
+- final verdict
+- first canonical error code
+- first invalid tx index
+- witness digest
+- post-state digest
+
+## Safety Guarantees
+
+Shadow mode MUST guarantee:
+
+- no change to externally observed node verdict;
+- bounded diagnostic logging;
+- deterministic mismatch reproduction input bundle.
+
+## Required Instrumentation
+
+- mismatch counters by category
+- digest-level mismatch detail
+- replay bundle ID and block reference
+- worker/scheduler metadata snapshot
+
+## Exit Criteria
+
+A rollout phase exits shadow only when:
+
+- mismatch count is zero for required soak window;
+- no unresolved deterministic replay discrepancy remains open;
+- promotion checklist (`Q-PV-20`) is satisfied.


### PR DESCRIPTION
## Summary
- add repository-accurate parallel validation implementation plan and agent execution TZ
- add runbook, shadow-mode contract, fixtures spec, benchmark plan, and security notes
- link the new doc pack from `README.md` quick references

## Queue / issue context
- aligns with `Q-PV-01..Q-PV-20` intake and issue set `#681..#700`
- documentation contract includes coverage target (>=95%), fixture completeness, and formal package requirements

## Validation
- docs-only change, no consensus/runtime code touched
- queue/issue mapping already canonicalized in orchestration (`rubin-orchestration-private#319`)

Made with [Cursor](https://cursor.com)