### PR TITLE
docs: raise PV coverage floor minimum to 85%

### DIFF
--- a/RUBIN_PARALLEL_VALIDATION_AGENT_TZ.md
+++ b/RUBIN_PARALLEL_VALIDATION_AGENT_TZ.md
@@ -83,7 +83,7 @@ If any check fails: task is `BLOCKED`, not `DONE`.
 
 Coverage requirement for new parallel-validation code:
 
-- floor: `>=80%`
+- floor: `>=85%`
 - target: `>=95%`
 
 ## 7. Fixture Contract

--- a/RUBIN_PARALLEL_VALIDATION_IMPLEMENTATION_PLAN.md
+++ b/RUBIN_PARALLEL_VALIDATION_IMPLEMENTATION_PLAN.md
@@ -138,7 +138,7 @@ Mandatory per-stack gates:
 
 Coverage policy for new parallel-validation code:
 
-- hard floor: `>= 80%`
+- hard floor: `>= 85%`
 - target: `>= 95%`
 - if branch is unreachable from public/runtime surface, annotate explicitly with rationale.
 


### PR DESCRIPTION
## Summary
- update parallel validation documentation to require a minimum coverage floor of `>=85%`
- keep the existing stretch target of `>=95%` unchanged
- align policy wording with Codacy minimum checker behavior

## Test plan
- [x] verify `RUBIN_PARALLEL_VALIDATION_IMPLEMENTATION_PLAN.md` now says `>= 85%`
- [x] verify `RUBIN_PARALLEL_VALIDATION_AGENT_TZ.md` now says `>=85%`

Made with [Cursor](https://cursor.com)