### PR TITLE
feat: generic bounded worker pool (Q-PV-05)

### DIFF
--- a/clients/go/consensus/worker_pool.go
+++ b/clients/go/consensus/worker_pool.go
@@ -1,0 +1,154 @@
+package consensus
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"sync"
+)
+
+// WorkerPool executes a batch of typed tasks in parallel using a bounded
+// goroutine pool. Results are returned in submission order regardless of
+// scheduling, ensuring deterministic output for consensus-critical pipelines.
+//
+// The pool is single-use: call Run once. For repeated batches, create a new
+// pool each time.
+//
+// Design properties:
+//   - Bounded: at most MaxWorkers goroutines are active simultaneously.
+//   - Deterministic: result[i] corresponds to task[i].
+//   - Panic-safe: a panicking task produces an error result, does not crash
+//     the process, and does not prevent other tasks from completing.
+//   - Cancellable: if the context is cancelled, unstarted tasks are skipped
+//     and their results are set to the context error.
+type WorkerPool[T any, R any] struct {
+	// MaxWorkers is the maximum number of concurrent goroutines.
+	// If <= 0, defaults to GOMAXPROCS.
+	MaxWorkers int
+
+	// Func is the work function applied to each task. It receives a context
+	// (for cancellation) and the task value, and returns a result or error.
+	Func func(ctx context.Context, task T) (R, error)
+}
+
+// WorkerResult holds the outcome of a single task execution.
+type WorkerResult[R any] struct {
+	Value R
+	Err   error
+}
+
+// Run executes all tasks in parallel and returns results in submission order.
+// The returned slice has the same length as tasks.
+//
+// If ctx is cancelled, unstarted tasks receive ctx.Err() as their error.
+// Already-running tasks continue to completion (Go goroutines cannot be
+// forcibly stopped).
+//
+// If a task panics, the panic is recovered and converted to an error result.
+// Other tasks are unaffected.
+func (p *WorkerPool[T, R]) Run(ctx context.Context, tasks []T) []WorkerResult[R] {
+	n := len(tasks)
+	if n == 0 {
+		return nil
+	}
+
+	workers := p.MaxWorkers
+	if workers <= 0 {
+		workers = runtime.GOMAXPROCS(0)
+		if workers < 1 {
+			workers = 1
+		}
+	}
+	if workers > n {
+		workers = n
+	}
+
+	results := make([]WorkerResult[R], n)
+
+	// Single task: run inline to avoid goroutine overhead.
+	if n == 1 {
+		results[0] = p.execTask(ctx, tasks[0])
+		return results
+	}
+
+	// Fan out via buffered channel of indices.
+	taskCh := make(chan int, n)
+	for i := 0; i < n; i++ {
+		taskCh <- i
+	}
+	close(taskCh)
+
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for idx := range taskCh {
+				results[idx] = p.execTask(ctx, tasks[idx])
+			}
+		}()
+	}
+
+	wg.Wait()
+	return results
+}
+
+// execTask runs a single task with panic recovery and context check.
+func (p *WorkerPool[T, R]) execTask(ctx context.Context, task T) (result WorkerResult[R]) {
+	// Check context before starting expensive work.
+	if err := ctx.Err(); err != nil {
+		result.Err = err
+		return
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			result.Err = fmt.Errorf("worker panic: %v", r)
+		}
+	}()
+
+	val, err := p.Func(ctx, task)
+	result.Value = val
+	result.Err = err
+	return
+}
+
+// RunFunc is a convenience function that creates a WorkerPool and runs tasks
+// in a single call. Useful when pool reuse is not needed.
+func RunFunc[T any, R any](
+	ctx context.Context,
+	maxWorkers int,
+	tasks []T,
+	fn func(ctx context.Context, task T) (R, error),
+) []WorkerResult[R] {
+	pool := &WorkerPool[T, R]{
+		MaxWorkers: maxWorkers,
+		Func:       fn,
+	}
+	return pool.Run(ctx, tasks)
+}
+
+// FirstError returns the first error (by index) from a slice of WorkerResults,
+// or nil if all succeeded. This is useful for fail-fast consensus pipelines
+// where the lowest-index error is canonical.
+func FirstError[R any](results []WorkerResult[R]) error {
+	for _, r := range results {
+		if r.Err != nil {
+			return r.Err
+		}
+	}
+	return nil
+}
+
+// CollectValues extracts the Value fields from results into a flat slice.
+// If any result has an error, returns that error immediately (first by index).
+func CollectValues[R any](results []WorkerResult[R]) ([]R, error) {
+	values := make([]R, len(results))
+	for i, r := range results {
+		if r.Err != nil {
+			return nil, r.Err
+		}
+		values[i] = r.Value
+	}
+	return values, nil
+}

--- a/clients/go/consensus/worker_pool_test.go
+++ b/clients/go/consensus/worker_pool_test.go
@@ -1,0 +1,425 @@
+package consensus
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// --------------- helpers ---------------
+
+func intIdentity(_ context.Context, v int) (int, error) {
+	return v, nil
+}
+
+func intDouble(_ context.Context, v int) (int, error) {
+	return v * 2, nil
+}
+
+func intFailOdd(_ context.Context, v int) (int, error) {
+	if v%2 != 0 {
+		return 0, fmt.Errorf("odd: %d", v)
+	}
+	return v, nil
+}
+
+// --------------- basic tests ---------------
+
+func TestWorkerPool_Empty(t *testing.T) {
+	pool := &WorkerPool[int, int]{MaxWorkers: 4, Func: intIdentity}
+	results := pool.Run(context.Background(), nil)
+	if len(results) != 0 {
+		t.Fatalf("expected 0 results, got %d", len(results))
+	}
+}
+
+func TestWorkerPool_SingleTask(t *testing.T) {
+	pool := &WorkerPool[int, int]{MaxWorkers: 4, Func: intDouble}
+	results := pool.Run(context.Background(), []int{21})
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Err != nil {
+		t.Fatalf("unexpected error: %v", results[0].Err)
+	}
+	if results[0].Value != 42 {
+		t.Fatalf("expected 42, got %d", results[0].Value)
+	}
+}
+
+func TestWorkerPool_MultipleTasksOrdered(t *testing.T) {
+	pool := &WorkerPool[int, int]{MaxWorkers: 2, Func: intDouble}
+	tasks := []int{1, 2, 3, 4, 5}
+	results := pool.Run(context.Background(), tasks)
+	if len(results) != 5 {
+		t.Fatalf("expected 5 results, got %d", len(results))
+	}
+	for i, r := range results {
+		if r.Err != nil {
+			t.Fatalf("task %d: unexpected error: %v", i, r.Err)
+		}
+		if r.Value != tasks[i]*2 {
+			t.Fatalf("task %d: expected %d, got %d", i, tasks[i]*2, r.Value)
+		}
+	}
+}
+
+func TestWorkerPool_ErrorPreservesOrder(t *testing.T) {
+	pool := &WorkerPool[int, int]{MaxWorkers: 4, Func: intFailOdd}
+	tasks := []int{2, 3, 4, 5, 6}
+	results := pool.Run(context.Background(), tasks)
+
+	// Task 0 (2): ok, Task 1 (3): error, Task 2 (4): ok, Task 3 (5): error, Task 4 (6): ok
+	if results[0].Err != nil || results[0].Value != 2 {
+		t.Fatalf("task 0: expected (2, nil), got (%d, %v)", results[0].Value, results[0].Err)
+	}
+	if results[1].Err == nil {
+		t.Fatal("task 1: expected error for odd=3")
+	}
+	if results[2].Err != nil || results[2].Value != 4 {
+		t.Fatalf("task 2: expected (4, nil), got (%d, %v)", results[2].Value, results[2].Err)
+	}
+	if results[3].Err == nil {
+		t.Fatal("task 3: expected error for odd=5")
+	}
+	if results[4].Err != nil || results[4].Value != 6 {
+		t.Fatalf("task 4: expected (6, nil), got (%d, %v)", results[4].Value, results[4].Err)
+	}
+}
+
+func TestWorkerPool_DefaultWorkers(t *testing.T) {
+	// MaxWorkers=0 → should default to GOMAXPROCS.
+	pool := &WorkerPool[int, int]{MaxWorkers: 0, Func: intIdentity}
+	tasks := make([]int, 10)
+	for i := range tasks {
+		tasks[i] = i
+	}
+	results := pool.Run(context.Background(), tasks)
+	for i, r := range results {
+		if r.Err != nil {
+			t.Fatalf("task %d: %v", i, r.Err)
+		}
+		if r.Value != i {
+			t.Fatalf("task %d: expected %d, got %d", i, i, r.Value)
+		}
+	}
+}
+
+func TestWorkerPool_WorkersCappedAtTaskCount(t *testing.T) {
+	// 100 workers but only 3 tasks → should use 3 workers.
+	var maxConcurrent atomic.Int32
+	var current atomic.Int32
+
+	pool := &WorkerPool[int, int]{
+		MaxWorkers: 100,
+		Func: func(_ context.Context, v int) (int, error) {
+			c := current.Add(1)
+			for {
+				old := maxConcurrent.Load()
+				if c <= old || maxConcurrent.CompareAndSwap(old, c) {
+					break
+				}
+			}
+			time.Sleep(10 * time.Millisecond)
+			current.Add(-1)
+			return v, nil
+		},
+	}
+	tasks := []int{1, 2, 3}
+	pool.Run(context.Background(), tasks)
+
+	mc := maxConcurrent.Load()
+	if mc > 3 {
+		t.Fatalf("max concurrent %d > 3 (task count)", mc)
+	}
+}
+
+// --------------- panic safety ---------------
+
+func TestWorkerPool_PanicRecovery(t *testing.T) {
+	pool := &WorkerPool[int, int]{
+		MaxWorkers: 2,
+		Func: func(_ context.Context, v int) (int, error) {
+			if v == 3 {
+				panic("task 3 panicked")
+			}
+			return v * 10, nil
+		},
+	}
+	tasks := []int{1, 2, 3, 4, 5}
+	results := pool.Run(context.Background(), tasks)
+
+	// Task 2 (value=3) should have panic error.
+	if results[2].Err == nil {
+		t.Fatal("expected panic error for task[2]")
+	}
+	if results[2].Err.Error() != "worker panic: task 3 panicked" {
+		t.Fatalf("unexpected panic error: %v", results[2].Err)
+	}
+	// Other tasks should succeed.
+	for i, r := range results {
+		if i == 2 {
+			continue
+		}
+		if r.Err != nil {
+			t.Fatalf("task %d: unexpected error: %v", i, r.Err)
+		}
+		if r.Value != tasks[i]*10 {
+			t.Fatalf("task %d: expected %d, got %d", i, tasks[i]*10, r.Value)
+		}
+	}
+}
+
+func TestWorkerPool_PanicDoesNotLeakGoroutines(t *testing.T) {
+	before := runtime.NumGoroutine()
+
+	pool := &WorkerPool[int, int]{
+		MaxWorkers: 4,
+		Func: func(_ context.Context, v int) (int, error) {
+			if v%2 == 0 {
+				panic(fmt.Sprintf("panic at %d", v))
+			}
+			return v, nil
+		},
+	}
+	tasks := []int{1, 2, 3, 4, 5, 6, 7, 8}
+	pool.Run(context.Background(), tasks)
+
+	// Give goroutines time to clean up.
+	time.Sleep(50 * time.Millisecond)
+	after := runtime.NumGoroutine()
+
+	// Allow some slack for test infrastructure goroutines.
+	if after > before+2 {
+		t.Fatalf("goroutine leak: before=%d after=%d", before, after)
+	}
+}
+
+// --------------- cancellation ---------------
+
+func TestWorkerPool_ContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var started atomic.Int32
+	pool := &WorkerPool[int, int]{
+		MaxWorkers: 1, // single worker for deterministic ordering
+		Func: func(ctx context.Context, v int) (int, error) {
+			started.Add(1)
+			if v == 2 {
+				cancel() // cancel after processing task[1] (value=2)
+				return v, nil
+			}
+			// Check context for later tasks.
+			if err := ctx.Err(); err != nil {
+				return 0, err
+			}
+			return v * 10, nil
+		},
+	}
+
+	tasks := []int{1, 2, 3, 4, 5}
+	results := pool.Run(ctx, tasks)
+
+	// Task 0 (value=1): should succeed.
+	if results[0].Err != nil {
+		t.Fatalf("task 0: %v", results[0].Err)
+	}
+	// Task 1 (value=2): should succeed (it's the one that cancels).
+	if results[1].Err != nil {
+		t.Fatalf("task 1: %v", results[1].Err)
+	}
+	// Tasks 2-4: should have context.Canceled errors.
+	for i := 2; i < 5; i++ {
+		if results[i].Err == nil {
+			t.Fatalf("task %d: expected cancellation error", i)
+		}
+		if !errors.Is(results[i].Err, context.Canceled) {
+			t.Fatalf("task %d: expected context.Canceled, got %v", i, results[i].Err)
+		}
+	}
+}
+
+func TestWorkerPool_AlreadyCancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled
+
+	pool := &WorkerPool[int, int]{MaxWorkers: 4, Func: intIdentity}
+	tasks := []int{1, 2, 3}
+	results := pool.Run(ctx, tasks)
+
+	for i, r := range results {
+		if r.Err == nil {
+			t.Fatalf("task %d: expected error", i)
+		}
+		if !errors.Is(r.Err, context.Canceled) {
+			t.Fatalf("task %d: expected context.Canceled, got %v", i, r.Err)
+		}
+	}
+}
+
+// --------------- convenience functions ---------------
+
+func TestRunFunc(t *testing.T) {
+	results := RunFunc(context.Background(), 2, []int{10, 20, 30}, intDouble)
+	if len(results) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(results))
+	}
+	expected := []int{20, 40, 60}
+	for i, r := range results {
+		if r.Err != nil {
+			t.Fatalf("task %d: %v", i, r.Err)
+		}
+		if r.Value != expected[i] {
+			t.Fatalf("task %d: expected %d, got %d", i, expected[i], r.Value)
+		}
+	}
+}
+
+func TestFirstError(t *testing.T) {
+	// No errors.
+	results := []WorkerResult[int]{
+		{Value: 1}, {Value: 2}, {Value: 3},
+	}
+	if err := FirstError(results); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+
+	// Error at index 2.
+	results[2].Err = fmt.Errorf("fail at 2")
+	if err := FirstError(results); err == nil || err.Error() != "fail at 2" {
+		t.Fatalf("expected 'fail at 2', got %v", err)
+	}
+
+	// Error at index 0 takes precedence.
+	results[0].Err = fmt.Errorf("fail at 0")
+	if err := FirstError(results); err == nil || err.Error() != "fail at 0" {
+		t.Fatalf("expected 'fail at 0', got %v", err)
+	}
+}
+
+func TestCollectValues(t *testing.T) {
+	// All success.
+	results := []WorkerResult[int]{
+		{Value: 10}, {Value: 20}, {Value: 30},
+	}
+	vals, err := CollectValues(results)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for i, v := range vals {
+		if v != (i+1)*10 {
+			t.Fatalf("expected %d, got %d", (i+1)*10, v)
+		}
+	}
+
+	// Error at index 1.
+	results[1].Err = fmt.Errorf("bad")
+	_, err = CollectValues(results)
+	if err == nil || err.Error() != "bad" {
+		t.Fatalf("expected 'bad', got %v", err)
+	}
+}
+
+// --------------- determinism ---------------
+
+func TestWorkerPool_DeterministicResultOrder(t *testing.T) {
+	// Run 10 times with random-ish delays to verify order is always preserved.
+	for iter := 0; iter < 10; iter++ {
+		pool := &WorkerPool[int, int]{
+			MaxWorkers: 4,
+			Func: func(_ context.Context, v int) (int, error) {
+				// Vary delay to expose ordering bugs.
+				if v%3 == 0 {
+					time.Sleep(time.Millisecond)
+				}
+				return v * v, nil
+			},
+		}
+		tasks := make([]int, 20)
+		for i := range tasks {
+			tasks[i] = i
+		}
+		results := pool.Run(context.Background(), tasks)
+		for i, r := range results {
+			if r.Err != nil {
+				t.Fatalf("iter %d task %d: %v", iter, i, r.Err)
+			}
+			if r.Value != i*i {
+				t.Fatalf("iter %d task %d: expected %d, got %d", iter, i, i*i, r.Value)
+			}
+		}
+	}
+}
+
+// --------------- bounded concurrency ---------------
+
+func TestWorkerPool_BoundedConcurrency(t *testing.T) {
+	const maxW = 3
+	var current atomic.Int32
+	var maxSeen atomic.Int32
+
+	pool := &WorkerPool[int, int]{
+		MaxWorkers: maxW,
+		Func: func(_ context.Context, v int) (int, error) {
+			c := current.Add(1)
+			for {
+				old := maxSeen.Load()
+				if c <= old || maxSeen.CompareAndSwap(old, c) {
+					break
+				}
+			}
+			time.Sleep(20 * time.Millisecond) // hold slot
+			current.Add(-1)
+			return v, nil
+		},
+	}
+	tasks := make([]int, 20)
+	for i := range tasks {
+		tasks[i] = i
+	}
+	pool.Run(context.Background(), tasks)
+
+	if maxSeen.Load() > maxW {
+		t.Fatalf("max concurrent %d exceeds MaxWorkers %d", maxSeen.Load(), maxW)
+	}
+}
+
+// --------------- large batch ---------------
+
+func TestWorkerPool_LargeBatch(t *testing.T) {
+	const n = 1000
+	pool := &WorkerPool[int, int]{MaxWorkers: 8, Func: intDouble}
+	tasks := make([]int, n)
+	for i := range tasks {
+		tasks[i] = i
+	}
+	results := pool.Run(context.Background(), tasks)
+	if len(results) != n {
+		t.Fatalf("expected %d results, got %d", n, len(results))
+	}
+	for i, r := range results {
+		if r.Err != nil {
+			t.Fatalf("task %d: %v", i, r.Err)
+		}
+		if r.Value != i*2 {
+			t.Fatalf("task %d: expected %d, got %d", i, i*2, r.Value)
+		}
+	}
+}
+
+// --------------- negative workers ---------------
+
+func TestWorkerPool_NegativeWorkers(t *testing.T) {
+	pool := &WorkerPool[int, int]{MaxWorkers: -5, Func: intIdentity}
+	results := pool.Run(context.Background(), []int{42})
+	if results[0].Err != nil {
+		t.Fatalf("unexpected error: %v", results[0].Err)
+	}
+	if results[0].Value != 42 {
+		t.Fatalf("expected 42, got %d", results[0].Value)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `WorkerPool[T, R]` — a generic bounded-concurrency task executor for parallel validation pipelines
- Deterministic result ordering: `result[i]` always corresponds to `task[i]`
- Panic-safe: panicking tasks produce error results without crashing the process
- Context cancellation: unstarted tasks receive `ctx.Err()`
- Helper functions: `RunFunc` (convenience), `FirstError` (fail-fast), `CollectValues` (extract values)
- 14 tests: empty, single, ordered results, error preservation, default workers, worker capping, panic recovery, goroutine leak detection, context cancellation, already-cancelled, deterministic ordering (10 iterations), bounded concurrency, large batch (1000 tasks), negative workers

## Test plan
- [x] `go test ./consensus/ -run TestWorkerPool` — 14/14 PASS
- [x] Full consensus test suite — PASS
- [x] `gofmt` — clean
- [x] Coverage: `worker_pool.go` 96.3%, `execTask` 100%, helpers 100%
- [x] Local Codacy preflight — PASS (diff 97.22%, variation +0.04%)
- [ ] CI checks

Part of Q-PV-05.

🤖 Generated with [Claude Code](https://claude.com/claude-code)