### PR TITLE
feat: add tx-local validation workers for parallel block validation (Q-PV-09)

### DIFF
--- a/clients/go/consensus/tx_validate_worker.go
+++ b/clients/go/consensus/tx_validate_worker.go
@@ -1,0 +1,298 @@
+package consensus
+
+import "context"
+
+// TxValidationResult holds the outcome of validating a single non-coinbase
+// transaction in a parallel worker. Workers perform read-only checks against
+// precomputed TxValidationContext and do NOT mutate UTXO or consensus state.
+type TxValidationResult struct {
+	// TxIndex is the block-level index of this transaction (1-based).
+	TxIndex int
+
+	// Valid is true if all input-level spend checks and signature
+	// verifications passed.
+	Valid bool
+
+	// Err is non-nil if validation failed. The error is a canonical
+	// TX_ERR_* error suitable for deterministic error reporting.
+	Err error
+
+	// SigCount is the number of signature verification operations that
+	// were executed (including deferred+flushed).
+	SigCount int
+
+	// Fee is the precomputed transaction fee, copied from TxValidationContext.
+	Fee uint64
+}
+
+// ValidateTxLocal validates a single non-coinbase transaction using read-only
+// precomputed context. It creates a per-worker SigCheckQueue to batch ML-DSA-87
+// verifications, calls the existing Q-variant spend validators for each input,
+// and flushes the queue at the end.
+//
+// This function does NOT modify any UTXO set or consensus state. It is safe
+// to call concurrently from multiple goroutines.
+//
+// Vault inputs: only the threshold signature is verified here. Full vault
+// policy (whitelist, owner lock, output rules) is enforced in the sequential
+// commit stage, which has access to block-level context.
+func ValidateTxLocal(
+	tvc TxValidationContext,
+	chainID [32]byte,
+	blockHeight uint64,
+	blockMTP uint64,
+	coreExtProfiles CoreExtProfileProvider,
+	sigCache *SigCache,
+) TxValidationResult {
+	result := TxValidationResult{
+		TxIndex: tvc.TxIndex,
+		Fee:     tvc.Fee,
+	}
+
+	tx := tvc.Tx
+	if tx == nil {
+		result.Err = txerr(TX_ERR_PARSE, "nil tx in TxValidationContext")
+		return result
+	}
+
+	// Create per-worker sig queue. Workers=1 since this runs inside a
+	// pool worker already — no need for nested parallelism.
+	sigQueue := NewSigCheckQueue(1)
+	if sigCache != nil {
+		sigQueue.WithCache(sigCache)
+	}
+
+	witnessCursor := tvc.WitnessStart
+	for inputIndex, entry := range tvc.ResolvedInputs {
+		slots, err := WitnessSlots(entry.CovenantType, entry.CovenantData)
+		if err != nil {
+			result.Err = err
+			return result
+		}
+		if witnessCursor+slots > tvc.WitnessEnd {
+			result.Err = txerr(TX_ERR_PARSE, "witness underflow in worker")
+			return result
+		}
+		assigned := tx.Witness[witnessCursor : witnessCursor+slots]
+
+		if err := validateInputSpendQ(
+			entry, assigned, tx, uint32(inputIndex), entry.Value,
+			chainID, blockHeight, blockMTP, tvc.SighashCache,
+			coreExtProfiles, sigQueue,
+		); err != nil {
+			result.Err = err
+			return result
+		}
+
+		witnessCursor += slots
+	}
+
+	result.SigCount = sigQueue.Len()
+
+	// Flush deferred signature verifications.
+	if err := sigQueue.Flush(); err != nil {
+		result.Err = err
+		return result
+	}
+
+	result.Valid = true
+	return result
+}
+
+// validateInputSpendQ dispatches a single input to the appropriate Q-variant
+// spend validator based on covenant type. This mirrors the switch in
+// applyNonCoinbaseTxBasicWorkQ but without UTXO mutations.
+func validateInputSpendQ(
+	entry UtxoEntry,
+	assigned []WitnessItem,
+	tx *Tx,
+	inputIndex uint32,
+	inputValue uint64,
+	chainID [32]byte,
+	blockHeight uint64,
+	blockMTP uint64,
+	sighashCache *SighashV1PrehashCache,
+	coreExtProfiles CoreExtProfileProvider,
+	sigQueue *SigCheckQueue,
+) error {
+	switch entry.CovenantType {
+	case COV_TYPE_P2PK:
+		if len(assigned) != 1 {
+			return txerr(TX_ERR_PARSE, "CORE_P2PK witness_slots must be 1")
+		}
+		return validateP2PKSpendQ(entry, assigned[0], tx, inputIndex, inputValue, chainID, blockHeight, sighashCache, sigQueue)
+
+	case COV_TYPE_MULTISIG:
+		m, err := ParseMultisigCovenantData(entry.CovenantData)
+		if err != nil {
+			return err
+		}
+		return validateThresholdSigSpendQ(
+			m.Keys, m.Threshold, assigned, tx, inputIndex, inputValue,
+			chainID, blockHeight, sighashCache, sigQueue, "CORE_MULTISIG",
+		)
+
+	case COV_TYPE_VAULT:
+		// Vault: only verify threshold signature in the worker.
+		// Full vault policy (whitelist, owner lock, output checks)
+		// is enforced in the sequential commit stage.
+		v, err := ParseVaultCovenantDataForSpend(entry.CovenantData)
+		if err != nil {
+			return err
+		}
+		return validateThresholdSigSpendQ(
+			v.Keys, v.Threshold, assigned, tx, inputIndex, inputValue,
+			chainID, blockHeight, sighashCache, sigQueue, "CORE_VAULT",
+		)
+
+	case COV_TYPE_HTLC:
+		if len(assigned) != 2 {
+			return txerr(TX_ERR_PARSE, "CORE_HTLC witness_slots must be 2")
+		}
+		return validateHTLCSpendQ(
+			entry, assigned[0], assigned[1], tx, inputIndex, inputValue,
+			chainID, blockHeight, blockMTP, sighashCache, sigQueue,
+		)
+
+	case COV_TYPE_CORE_EXT:
+		if len(assigned) != CORE_EXT_WITNESS_SLOTS {
+			return txerr(TX_ERR_PARSE, "CORE_EXT witness_slots must be 1")
+		}
+		return validateCoreExtSpendQ(
+			entry, assigned[0], tx, inputIndex, inputValue,
+			chainID, blockHeight, sighashCache, coreExtProfiles, sigQueue,
+		)
+
+	case COV_TYPE_CORE_STEALTH:
+		if len(assigned) != CORE_STEALTH_WITNESS_SLOTS {
+			return txerr(TX_ERR_PARSE, "CORE_STEALTH witness_slots must be 1")
+		}
+		return validateCoreStealthSpendQ(entry, assigned[0], tx, inputIndex, inputValue, chainID, blockHeight, sighashCache, sigQueue)
+
+	default:
+		// Other covenant types have no spend-time checks in the genesis set.
+		return nil
+	}
+}
+
+// validateCoreExtSpendQ is the queue-aware CORE_EXT spend validator, extracted
+// from the inline logic in applyNonCoinbaseTxBasicWorkQ. ML-DSA-87 signatures
+// are deferred to sigQueue; external verifiers (non-ML-DSA suites) are called
+// inline because they may not be thread-safe.
+func validateCoreExtSpendQ(
+	entry UtxoEntry,
+	w WitnessItem,
+	tx *Tx,
+	inputIndex uint32,
+	inputValue uint64,
+	chainID [32]byte,
+	blockHeight uint64,
+	sighashCache *SighashV1PrehashCache,
+	coreExtProfiles CoreExtProfileProvider,
+	sigQueue *SigCheckQueue,
+) error {
+	cd, err := ParseCoreExtCovenantData(entry.CovenantData)
+	if err != nil {
+		return err
+	}
+
+	active := false
+	allowedSuites := map[uint8]struct{}(nil)
+	verifySigExtFn := CoreExtVerifySigExtFunc(nil)
+
+	if coreExtProfiles != nil {
+		profile, ok, err := coreExtProfiles.LookupCoreExtProfile(cd.ExtID, blockHeight)
+		if err != nil {
+			return txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_EXT profile lookup failure")
+		}
+		if ok && profile.Active {
+			active = true
+			allowedSuites = profile.AllowedSuites
+			verifySigExtFn = profile.VerifySigExtFn
+		}
+	}
+
+	if !active {
+		return nil
+	}
+
+	if !hasSuite(allowedSuites, w.SuiteID) {
+		return txerr(TX_ERR_SIG_ALG_INVALID, "CORE_EXT suite disallowed under ACTIVE profile")
+	}
+	if w.SuiteID == SUITE_ID_SENTINEL {
+		return txerr(TX_ERR_SIG_ALG_INVALID, "CORE_EXT sentinel forbidden under ACTIVE profile")
+	}
+
+	extractSigDigest := func() ([]byte, [32]byte, error) {
+		return extractSigAndDigestWithCache(w, tx, inputIndex, inputValue, chainID, sighashCache)
+	}
+
+	switch w.SuiteID {
+	case SUITE_ID_ML_DSA_87:
+		if len(w.Pubkey) != ML_DSA_87_PUBKEY_BYTES || len(w.Signature) != ML_DSA_87_SIG_BYTES+1 {
+			return txerr(TX_ERR_SIG_NONCANONICAL, "non-canonical ML-DSA witness item lengths")
+		}
+		cryptoSig, digest, err := extractSigDigest()
+		if err != nil {
+			return err
+		}
+		if sigQueue != nil {
+			sigQueue.Push(w.SuiteID, w.Pubkey, cryptoSig, digest, txerr(TX_ERR_SIG_INVALID, "CORE_EXT signature invalid"))
+		} else {
+			ok, err := verifySig(w.SuiteID, w.Pubkey, cryptoSig, digest)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return txerr(TX_ERR_SIG_INVALID, "CORE_EXT signature invalid")
+			}
+		}
+	default:
+		// External verifiers are NOT deferred to the queue — they may not
+		// be thread-safe.
+		if verifySigExtFn == nil {
+			return txerr(TX_ERR_SIG_ALG_INVALID, "CORE_EXT verify_sig_ext unsupported")
+		}
+		cryptoSig, digest, err := extractSigDigest()
+		if err != nil {
+			return err
+		}
+		ok, err := verifySigExtFn(cd.ExtID, w.SuiteID, w.Pubkey, cryptoSig, digest, cd.ExtPayload)
+		if err != nil {
+			return txerr(TX_ERR_SIG_ALG_INVALID, "CORE_EXT verify_sig_ext error")
+		}
+		if !ok {
+			return txerr(TX_ERR_SIG_INVALID, "CORE_EXT signature invalid")
+		}
+	}
+
+	return nil
+}
+
+// RunTxValidationWorkers validates multiple transactions in parallel using
+// WorkerPool. Returns results in submission order; use FirstTxError to get
+// the first failing transaction.
+func RunTxValidationWorkers(
+	ctx context.Context,
+	maxWorkers int,
+	txcs []TxValidationContext,
+	chainID [32]byte,
+	blockHeight uint64,
+	blockMTP uint64,
+	coreExtProfiles CoreExtProfileProvider,
+	sigCache *SigCache,
+) []WorkerResult[TxValidationResult] {
+	return RunFunc(ctx, maxWorkers, txcs, func(ctx context.Context, tvc TxValidationContext) (TxValidationResult, error) {
+		r := ValidateTxLocal(tvc, chainID, blockHeight, blockMTP, coreExtProfiles, sigCache)
+		if r.Err != nil {
+			return r, r.Err
+		}
+		return r, nil
+	})
+}
+
+// FirstTxError returns the first error by transaction index from validation
+// results, or nil if all transactions are valid.
+func FirstTxError(results []WorkerResult[TxValidationResult]) error {
+	return FirstError(results)
+}

--- a/clients/go/consensus/tx_validate_worker_test.go
+++ b/clients/go/consensus/tx_validate_worker_test.go
@@ -1,0 +1,985 @@
+package consensus
+
+import (
+	"context"
+	"testing"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ValidateTxLocal unit tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestValidateTxLocal_P2PK_Valid(t *testing.T) {
+	kp := mustMLDSA87Keypair(t)
+	covData := p2pkCovenantDataForPubkey(kp.PubkeyBytes())
+
+	var prevTxid [32]byte
+	prevTxid[0] = 0x42
+	tx := &Tx{
+		Version: 1,
+		TxKind:  0x00,
+		TxNonce: 1,
+		Inputs:  []TxInput{{PrevTxid: prevTxid, PrevVout: 0, Sequence: 0}},
+		Outputs: []TxOutput{{Value: 90, CovenantType: COV_TYPE_P2PK, CovenantData: covData}},
+	}
+	tx.Witness = []WitnessItem{signP2PKInputWitness(t, tx, 0, 100, [32]byte{}, kp)}
+
+	sighashCache, err := NewSighashV1PrehashCache(tx)
+	if err != nil {
+		t.Fatalf("NewSighashV1PrehashCache: %v", err)
+	}
+
+	tvc := TxValidationContext{
+		TxIndex: 1,
+		Tx:      tx,
+		ResolvedInputs: []UtxoEntry{{
+			Value:        100,
+			CovenantType: COV_TYPE_P2PK,
+			CovenantData: append([]byte(nil), covData...),
+		}},
+		WitnessStart: 0,
+		WitnessEnd:   1,
+		SighashCache: sighashCache,
+		Fee:          10,
+	}
+
+	result := ValidateTxLocal(tvc, [32]byte{}, 1, 0, nil, nil)
+	if !result.Valid {
+		t.Fatalf("expected valid, got err: %v", result.Err)
+	}
+	if result.Fee != 10 {
+		t.Fatalf("expected fee=10, got %d", result.Fee)
+	}
+	if result.TxIndex != 1 {
+		t.Fatalf("expected TxIndex=1, got %d", result.TxIndex)
+	}
+	if result.SigCount != 1 {
+		t.Fatalf("expected SigCount=1, got %d", result.SigCount)
+	}
+}
+
+func TestValidateTxLocal_P2PK_InvalidSig(t *testing.T) {
+	kp := mustMLDSA87Keypair(t)
+	kp2 := mustMLDSA87Keypair(t)
+	covData := p2pkCovenantDataForPubkey(kp.PubkeyBytes())
+
+	var prevTxid [32]byte
+	prevTxid[0] = 0x42
+	tx := &Tx{
+		Version: 1,
+		TxKind:  0x00,
+		TxNonce: 1,
+		Inputs:  []TxInput{{PrevTxid: prevTxid, PrevVout: 0, Sequence: 0}},
+		Outputs: []TxOutput{{Value: 90, CovenantType: COV_TYPE_P2PK, CovenantData: covData}},
+	}
+	// Sign with wrong key — will fail key binding check.
+	tx.Witness = []WitnessItem{signP2PKInputWitness(t, tx, 0, 100, [32]byte{}, kp2)}
+
+	sighashCache, err := NewSighashV1PrehashCache(tx)
+	if err != nil {
+		t.Fatalf("NewSighashV1PrehashCache: %v", err)
+	}
+
+	tvc := TxValidationContext{
+		TxIndex: 1,
+		Tx:      tx,
+		ResolvedInputs: []UtxoEntry{{
+			Value:        100,
+			CovenantType: COV_TYPE_P2PK,
+			CovenantData: append([]byte(nil), covData...),
+		}},
+		WitnessStart: 0,
+		WitnessEnd:   1,
+		SighashCache: sighashCache,
+		Fee:          10,
+	}
+
+	result := ValidateTxLocal(tvc, [32]byte{}, 1, 0, nil, nil)
+	if result.Valid {
+		t.Fatalf("expected invalid, got valid")
+	}
+	if result.Err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+}
+
+func TestValidateTxLocal_NilTx(t *testing.T) {
+	tvc := TxValidationContext{TxIndex: 1, Tx: nil}
+	result := ValidateTxLocal(tvc, [32]byte{}, 1, 0, nil, nil)
+	if result.Valid {
+		t.Fatalf("expected invalid for nil tx")
+	}
+	if result.Err == nil {
+		t.Fatalf("expected error for nil tx")
+	}
+}
+
+func TestValidateTxLocal_WitnessUnderflow(t *testing.T) {
+	kp := mustMLDSA87Keypair(t)
+	covData := p2pkCovenantDataForPubkey(kp.PubkeyBytes())
+
+	tx := &Tx{
+		Version: 1,
+		TxKind:  0x00,
+		TxNonce: 1,
+		Inputs:  []TxInput{{PrevVout: 0, Sequence: 0}},
+		Outputs: []TxOutput{{Value: 90, CovenantType: COV_TYPE_P2PK, CovenantData: covData}},
+		Witness: []WitnessItem{}, // empty — underflow
+	}
+
+	sighashCache, err := NewSighashV1PrehashCache(tx)
+	if err != nil {
+		t.Fatalf("NewSighashV1PrehashCache: %v", err)
+	}
+
+	tvc := TxValidationContext{
+		TxIndex: 1,
+		Tx:      tx,
+		ResolvedInputs: []UtxoEntry{{
+			Value:        100,
+			CovenantType: COV_TYPE_P2PK,
+			CovenantData: covData,
+		}},
+		WitnessStart: 0,
+		WitnessEnd:   0, // no witness available
+		SighashCache: sighashCache,
+		Fee:          10,
+	}
+
+	result := ValidateTxLocal(tvc, [32]byte{}, 1, 0, nil, nil)
+	if result.Valid {
+		t.Fatalf("expected invalid for witness underflow")
+	}
+}
+
+func TestValidateTxLocal_WithSigCache(t *testing.T) {
+	kp := mustMLDSA87Keypair(t)
+	covData := p2pkCovenantDataForPubkey(kp.PubkeyBytes())
+
+	var prevTxid [32]byte
+	prevTxid[0] = 0x42
+	tx := &Tx{
+		Version: 1,
+		TxKind:  0x00,
+		TxNonce: 1,
+		Inputs:  []TxInput{{PrevTxid: prevTxid, PrevVout: 0, Sequence: 0}},
+		Outputs: []TxOutput{{Value: 90, CovenantType: COV_TYPE_P2PK, CovenantData: covData}},
+	}
+	tx.Witness = []WitnessItem{signP2PKInputWitness(t, tx, 0, 100, [32]byte{}, kp)}
+
+	sighashCache, err := NewSighashV1PrehashCache(tx)
+	if err != nil {
+		t.Fatalf("NewSighashV1PrehashCache: %v", err)
+	}
+
+	entry := UtxoEntry{
+		Value:        100,
+		CovenantType: COV_TYPE_P2PK,
+		CovenantData: append([]byte(nil), covData...),
+	}
+
+	sigCache := NewSigCache(100)
+	tvc := TxValidationContext{
+		TxIndex:        1,
+		Tx:             tx,
+		ResolvedInputs: []UtxoEntry{entry},
+		WitnessStart:   0,
+		WitnessEnd:     1,
+		SighashCache:   sighashCache,
+		Fee:            10,
+	}
+
+	// First call populates sig cache.
+	result := ValidateTxLocal(tvc, [32]byte{}, 1, 0, nil, sigCache)
+	if !result.Valid {
+		t.Fatalf("first call: %v", result.Err)
+	}
+	if sigCache.Len() != 1 {
+		t.Fatalf("expected 1 cached sig, got %d", sigCache.Len())
+	}
+
+	// Second call should hit cache.
+	result2 := ValidateTxLocal(tvc, [32]byte{}, 1, 0, nil, sigCache)
+	if !result2.Valid {
+		t.Fatalf("second call (cached): %v", result2.Err)
+	}
+	if sigCache.Hits() < 1 {
+		t.Fatalf("expected cache hit, got %d hits", sigCache.Hits())
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// RunTxValidationWorkers tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestRunTxValidationWorkers_Empty(t *testing.T) {
+	results := RunTxValidationWorkers(
+		context.Background(), 4, nil, [32]byte{}, 1, 0, nil, nil,
+	)
+	if len(results) != 0 {
+		t.Fatalf("expected 0 results, got %d", len(results))
+	}
+}
+
+func TestRunTxValidationWorkers_SingleValid(t *testing.T) {
+	kp := mustMLDSA87Keypair(t)
+	covData := p2pkCovenantDataForPubkey(kp.PubkeyBytes())
+
+	var prevTxid [32]byte
+	prevTxid[0] = 0x42
+	tx := &Tx{
+		Version: 1,
+		TxKind:  0x00,
+		TxNonce: 1,
+		Inputs:  []TxInput{{PrevTxid: prevTxid, PrevVout: 0, Sequence: 0}},
+		Outputs: []TxOutput{{Value: 90, CovenantType: COV_TYPE_P2PK, CovenantData: covData}},
+	}
+	tx.Witness = []WitnessItem{signP2PKInputWitness(t, tx, 0, 100, [32]byte{}, kp)}
+
+	sighashCache, err := NewSighashV1PrehashCache(tx)
+	if err != nil {
+		t.Fatalf("NewSighashV1PrehashCache: %v", err)
+	}
+
+	txcs := []TxValidationContext{{
+		TxIndex: 1,
+		Tx:      tx,
+		ResolvedInputs: []UtxoEntry{{
+			Value:        100,
+			CovenantType: COV_TYPE_P2PK,
+			CovenantData: append([]byte(nil), covData...),
+		}},
+		WitnessStart: 0,
+		WitnessEnd:   1,
+		SighashCache: sighashCache,
+		Fee:          10,
+	}}
+
+	results := RunTxValidationWorkers(
+		context.Background(), 2, txcs, [32]byte{}, 1, 0, nil, nil,
+	)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Err != nil {
+		t.Fatalf("expected valid, got err: %v", results[0].Err)
+	}
+	if !results[0].Value.Valid {
+		t.Fatalf("expected Valid=true")
+	}
+}
+
+func TestRunTxValidationWorkers_MultipleWithOneInvalid(t *testing.T) {
+	kp := mustMLDSA87Keypair(t)
+	kp2 := mustMLDSA87Keypair(t)
+	covData := p2pkCovenantDataForPubkey(kp.PubkeyBytes())
+
+	makeTvc := func(idx int, validSig bool) TxValidationContext {
+		var prevTxid [32]byte
+		prevTxid[0] = byte(idx)
+		tx := &Tx{
+			Version: 1,
+			TxKind:  0x00,
+			TxNonce: 1,
+			Inputs:  []TxInput{{PrevTxid: prevTxid, PrevVout: 0, Sequence: 0}},
+			Outputs: []TxOutput{{Value: 90, CovenantType: COV_TYPE_P2PK, CovenantData: covData}},
+		}
+		signer := kp
+		if !validSig {
+			signer = kp2 // wrong key → key binding mismatch
+		}
+		tx.Witness = []WitnessItem{signP2PKInputWitness(t, tx, 0, 100, [32]byte{}, signer)}
+
+		sighashCache, err := NewSighashV1PrehashCache(tx)
+		if err != nil {
+			t.Fatalf("NewSighashV1PrehashCache: %v", err)
+		}
+
+		return TxValidationContext{
+			TxIndex: idx,
+			Tx:      tx,
+			ResolvedInputs: []UtxoEntry{{
+				Value:        100,
+				CovenantType: COV_TYPE_P2PK,
+				CovenantData: append([]byte(nil), covData...),
+			}},
+			WitnessStart: 0,
+			WitnessEnd:   1,
+			SighashCache: sighashCache,
+			Fee:          10,
+		}
+	}
+
+	txcs := []TxValidationContext{
+		makeTvc(1, true),
+		makeTvc(2, false), // invalid
+		makeTvc(3, true),
+	}
+
+	results := RunTxValidationWorkers(
+		context.Background(), 2, txcs, [32]byte{}, 1, 0, nil, nil,
+	)
+	if len(results) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(results))
+	}
+
+	// First should be valid.
+	if results[0].Err != nil {
+		t.Fatalf("tx[0] expected valid, got err: %v", results[0].Err)
+	}
+
+	// Second should be invalid.
+	if results[1].Err == nil {
+		t.Fatalf("tx[1] expected error, got nil")
+	}
+
+	// Third should be valid.
+	if results[2].Err != nil {
+		t.Fatalf("tx[2] expected valid, got err: %v", results[2].Err)
+	}
+
+	// FirstTxError should return the second tx error.
+	firstErr := FirstTxError(results)
+	if firstErr == nil {
+		t.Fatalf("FirstTxError should return non-nil")
+	}
+}
+
+func TestRunTxValidationWorkers_CancelledContext(t *testing.T) {
+	kp := mustMLDSA87Keypair(t)
+	covData := p2pkCovenantDataForPubkey(kp.PubkeyBytes())
+
+	var prevTxid [32]byte
+	prevTxid[0] = 0x42
+	tx := &Tx{
+		Version: 1,
+		TxKind:  0x00,
+		TxNonce: 1,
+		Inputs:  []TxInput{{PrevTxid: prevTxid, PrevVout: 0, Sequence: 0}},
+		Outputs: []TxOutput{{Value: 90, CovenantType: COV_TYPE_P2PK, CovenantData: covData}},
+	}
+	tx.Witness = []WitnessItem{signP2PKInputWitness(t, tx, 0, 100, [32]byte{}, kp)}
+
+	sighashCache, err := NewSighashV1PrehashCache(tx)
+	if err != nil {
+		t.Fatalf("NewSighashV1PrehashCache: %v", err)
+	}
+
+	txcs := []TxValidationContext{{
+		TxIndex: 1,
+		Tx:      tx,
+		ResolvedInputs: []UtxoEntry{{
+			Value:        100,
+			CovenantType: COV_TYPE_P2PK,
+			CovenantData: append([]byte(nil), covData...),
+		}},
+		WitnessStart: 0,
+		WitnessEnd:   1,
+		SighashCache: sighashCache,
+		Fee:          10,
+	}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled
+
+	results := RunTxValidationWorkers(ctx, 2, txcs, [32]byte{}, 1, 0, nil, nil)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Err == nil {
+		t.Fatalf("expected error from cancelled context")
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// FirstTxError tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestFirstTxError_AllValid(t *testing.T) {
+	results := []WorkerResult[TxValidationResult]{
+		{Value: TxValidationResult{Valid: true}},
+		{Value: TxValidationResult{Valid: true}},
+	}
+	if err := FirstTxError(results); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+}
+
+func TestFirstTxError_Nil(t *testing.T) {
+	if err := FirstTxError(nil); err != nil {
+		t.Fatalf("expected nil for nil results, got %v", err)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// validateInputSpendQ branch coverage
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestValidateInputSpendQ_DefaultCovType(t *testing.T) {
+	// Unknown/unhandled covenant type should return nil (no spend checks).
+	entry := UtxoEntry{
+		CovenantType: 0xFFFF, // unknown type
+		CovenantData: []byte{0x00},
+	}
+	err := validateInputSpendQ(entry, nil, &Tx{}, 0, 100, [32]byte{}, 1, 0, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("expected nil for unknown covenant type, got: %v", err)
+	}
+}
+
+func TestValidateCoreExtSpendQ_InactiveProfile(t *testing.T) {
+	// When no CoreExtProfileProvider is set, CORE_EXT should pass (inactive).
+	entry := UtxoEntry{
+		CovenantType: COV_TYPE_CORE_EXT,
+		CovenantData: makeCoreExtCovenantData(0x01),
+	}
+	w := WitnessItem{SuiteID: SUITE_ID_ML_DSA_87}
+	err := validateCoreExtSpendQ(entry, w, &Tx{}, 0, 100, [32]byte{}, 1, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("expected nil for inactive CORE_EXT, got: %v", err)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ValidateTxLocal — non-P2PK covenant types
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestValidateTxLocal_Multisig_Valid(t *testing.T) {
+	kp := mustMLDSA87Keypair(t)
+	keyID := sha3_256(kp.PubkeyBytes())
+	covData := encodeMultisigCovenantData(1, [][32]byte{keyID})
+
+	var prevTxid [32]byte
+	prevTxid[0] = 0x11
+	tx := &Tx{
+		Version: 1,
+		TxKind:  0x00,
+		TxNonce: 1,
+		Inputs:  []TxInput{{PrevTxid: prevTxid, PrevVout: 0, Sequence: 0}},
+		Outputs: []TxOutput{{Value: 90, CovenantType: COV_TYPE_P2PK, CovenantData: p2pkCovenantDataForPubkey(kp.PubkeyBytes())}},
+	}
+	tx.Witness = []WitnessItem{signP2PKInputWitness(t, tx, 0, 100, [32]byte{}, kp)}
+
+	sighashCache, err := NewSighashV1PrehashCache(tx)
+	if err != nil {
+		t.Fatalf("sighash cache: %v", err)
+	}
+
+	tvc := TxValidationContext{
+		TxIndex: 1,
+		Tx:      tx,
+		ResolvedInputs: []UtxoEntry{{
+			Value:        100,
+			CovenantType: COV_TYPE_MULTISIG,
+			CovenantData: covData,
+		}},
+		WitnessStart: 0,
+		WitnessEnd:   1,
+		SighashCache: sighashCache,
+		Fee:          10,
+	}
+
+	result := ValidateTxLocal(tvc, [32]byte{}, 1, 0, nil, nil)
+	if !result.Valid {
+		t.Fatalf("multisig valid: %v", result.Err)
+	}
+}
+
+func TestValidateTxLocal_HTLC_ClaimValid(t *testing.T) {
+	kp := mustMLDSA87Keypair(t)
+	claimKeyID := sha3_256(kp.PubkeyBytes())
+
+	preimage := make([]byte, 32)
+	preimage[0] = 0xAA
+	hash := sha3_256(preimage)
+
+	var refundKeyID [32]byte
+	refundKeyID[0] = 0xBB
+
+	covData := encodeHTLCCovenantData(hash, LOCK_MODE_HEIGHT, 100, claimKeyID, refundKeyID)
+
+	var prevTxid [32]byte
+	prevTxid[0] = 0x22
+	tx := &Tx{
+		Version: 1,
+		TxKind:  0x00,
+		TxNonce: 1,
+		Inputs:  []TxInput{{PrevTxid: prevTxid, PrevVout: 0, Sequence: 0}},
+		Outputs: []TxOutput{{Value: 90, CovenantType: COV_TYPE_P2PK, CovenantData: p2pkCovenantDataForPubkey(kp.PubkeyBytes())}},
+	}
+
+	// Build HTLC witness: path selector (claim) + signature.
+	claimPayload := encodeHTLCClaimPayload(preimage)
+	pathItem := WitnessItem{
+		SuiteID:   SUITE_ID_SENTINEL,
+		Pubkey:    claimKeyID[:],
+		Signature: claimPayload,
+	}
+	tx.Witness = []WitnessItem{pathItem, signP2PKInputWitness(t, tx, 0, 100, [32]byte{}, kp)}
+
+	sighashCache, err := NewSighashV1PrehashCache(tx)
+	if err != nil {
+		t.Fatalf("sighash cache: %v", err)
+	}
+
+	tvc := TxValidationContext{
+		TxIndex: 1,
+		Tx:      tx,
+		ResolvedInputs: []UtxoEntry{{
+			Value:        100,
+			CovenantType: COV_TYPE_HTLC,
+			CovenantData: covData,
+		}},
+		WitnessStart: 0,
+		WitnessEnd:   2,
+		SighashCache: sighashCache,
+		Fee:          10,
+	}
+
+	result := ValidateTxLocal(tvc, [32]byte{}, 1, 0, nil, nil)
+	if !result.Valid {
+		t.Fatalf("HTLC claim valid: %v", result.Err)
+	}
+}
+
+func TestValidateTxLocal_Vault_SigValid(t *testing.T) {
+	kp := mustMLDSA87Keypair(t)
+	vaultKeyID := sha3_256(kp.PubkeyBytes())
+	var ownerLockID [32]byte
+	ownerLockID[0] = 0xCC
+	var whitelistH [32]byte
+	whitelistH[0] = 0xDD
+
+	covData := encodeVaultCovenantData(ownerLockID, 1, [][32]byte{vaultKeyID}, [][32]byte{whitelistH})
+
+	var prevTxid [32]byte
+	prevTxid[0] = 0x33
+	tx := &Tx{
+		Version: 1,
+		TxKind:  0x00,
+		TxNonce: 1,
+		Inputs:  []TxInput{{PrevTxid: prevTxid, PrevVout: 0, Sequence: 0}},
+		Outputs: []TxOutput{{Value: 90, CovenantType: COV_TYPE_P2PK, CovenantData: p2pkCovenantDataForPubkey(kp.PubkeyBytes())}},
+	}
+	tx.Witness = []WitnessItem{signP2PKInputWitness(t, tx, 0, 100, [32]byte{}, kp)}
+
+	sighashCache, err := NewSighashV1PrehashCache(tx)
+	if err != nil {
+		t.Fatalf("sighash cache: %v", err)
+	}
+
+	tvc := TxValidationContext{
+		TxIndex: 1,
+		Tx:      tx,
+		ResolvedInputs: []UtxoEntry{{
+			Value:        100,
+			CovenantType: COV_TYPE_VAULT,
+			CovenantData: covData,
+		}},
+		WitnessStart: 0,
+		WitnessEnd:   1,
+		SighashCache: sighashCache,
+		Fee:          10,
+	}
+
+	result := ValidateTxLocal(tvc, [32]byte{}, 1, 0, nil, nil)
+	if !result.Valid {
+		t.Fatalf("vault sig valid: %v", result.Err)
+	}
+}
+
+func TestValidateTxLocal_Stealth_Valid(t *testing.T) {
+	kp := mustMLDSA87Keypair(t)
+	oneTimeKeyID := sha3_256(kp.PubkeyBytes())
+	covData := stealthCovenantDataForKeyID(oneTimeKeyID)
+
+	var prevTxid [32]byte
+	prevTxid[0] = 0x44
+	tx := &Tx{
+		Version: 1,
+		TxKind:  0x00,
+		TxNonce: 1,
+		Inputs:  []TxInput{{PrevTxid: prevTxid, PrevVout: 0, Sequence: 0}},
+		Outputs: []TxOutput{{Value: 90, CovenantType: COV_TYPE_P2PK, CovenantData: p2pkCovenantDataForPubkey(kp.PubkeyBytes())}},
+	}
+	tx.Witness = []WitnessItem{signP2PKInputWitness(t, tx, 0, 100, [32]byte{}, kp)}
+
+	sighashCache, err := NewSighashV1PrehashCache(tx)
+	if err != nil {
+		t.Fatalf("sighash cache: %v", err)
+	}
+
+	tvc := TxValidationContext{
+		TxIndex: 1,
+		Tx:      tx,
+		ResolvedInputs: []UtxoEntry{{
+			Value:        100,
+			CovenantType: COV_TYPE_CORE_STEALTH,
+			CovenantData: covData,
+		}},
+		WitnessStart: 0,
+		WitnessEnd:   1,
+		SighashCache: sighashCache,
+		Fee:          10,
+	}
+
+	result := ValidateTxLocal(tvc, [32]byte{}, 1, 0, nil, nil)
+	if !result.Valid {
+		t.Fatalf("stealth valid: %v", result.Err)
+	}
+}
+
+func TestValidateTxLocal_CoreExt_ActiveProfile(t *testing.T) {
+	kp := mustMLDSA87Keypair(t)
+	covData := makeCoreExtCovenantData(0x01)
+
+	var prevTxid [32]byte
+	prevTxid[0] = 0x55
+	tx := &Tx{
+		Version: 1,
+		TxKind:  0x00,
+		TxNonce: 1,
+		Inputs:  []TxInput{{PrevTxid: prevTxid, PrevVout: 0, Sequence: 0}},
+		Outputs: []TxOutput{{Value: 90, CovenantType: COV_TYPE_P2PK, CovenantData: p2pkCovenantDataForPubkey(kp.PubkeyBytes())}},
+	}
+	tx.Witness = []WitnessItem{signP2PKInputWitness(t, tx, 0, 100, [32]byte{}, kp)}
+
+	sighashCache, err := NewSighashV1PrehashCache(tx)
+	if err != nil {
+		t.Fatalf("sighash cache: %v", err)
+	}
+
+	profiles := &testCoreExtProfileProvider{
+		profile: CoreExtProfile{
+			Active:        true,
+			AllowedSuites: map[uint8]struct{}{SUITE_ID_ML_DSA_87: {}},
+		},
+		found: true,
+	}
+
+	tvc := TxValidationContext{
+		TxIndex: 1,
+		Tx:      tx,
+		ResolvedInputs: []UtxoEntry{{
+			Value:        100,
+			CovenantType: COV_TYPE_CORE_EXT,
+			CovenantData: covData,
+		}},
+		WitnessStart: 0,
+		WitnessEnd:   1,
+		SighashCache: sighashCache,
+		Fee:          10,
+	}
+
+	result := ValidateTxLocal(tvc, [32]byte{}, 1, 0, profiles, nil)
+	if !result.Valid {
+		t.Fatalf("CORE_EXT active: %v", result.Err)
+	}
+}
+
+func TestValidateInputSpendQ_P2PKWrongSlots(t *testing.T) {
+	entry := UtxoEntry{
+		CovenantType: COV_TYPE_P2PK,
+		CovenantData: p2pkCovenantDataForPubkey(make([]byte, ML_DSA_87_PUBKEY_BYTES)),
+	}
+	err := validateInputSpendQ(entry, []WitnessItem{{}, {}}, &Tx{}, 0, 100, [32]byte{}, 1, 0, nil, nil, nil)
+	if err == nil {
+		t.Fatalf("expected error for wrong slot count")
+	}
+}
+
+func TestValidateInputSpendQ_HTLCWrongSlots(t *testing.T) {
+	preimage := make([]byte, 32)
+	hash := sha3_256(preimage)
+	covData := encodeHTLCCovenantData(hash, LOCK_MODE_HEIGHT, 100, [32]byte{}, [32]byte{})
+	entry := UtxoEntry{
+		CovenantType: COV_TYPE_HTLC,
+		CovenantData: covData,
+	}
+	// Only 1 witness item instead of 2.
+	err := validateInputSpendQ(entry, []WitnessItem{{}}, &Tx{}, 0, 100, [32]byte{}, 1, 0, nil, nil, nil)
+	if err == nil {
+		t.Fatalf("expected error for HTLC wrong slot count")
+	}
+}
+
+func TestValidateInputSpendQ_CoreExtWrongSlots(t *testing.T) {
+	entry := UtxoEntry{
+		CovenantType: COV_TYPE_CORE_EXT,
+		CovenantData: makeCoreExtCovenantData(0x01),
+	}
+	err := validateInputSpendQ(entry, []WitnessItem{{}, {}}, &Tx{}, 0, 100, [32]byte{}, 1, 0, nil, nil, nil)
+	if err == nil {
+		t.Fatalf("expected error for CORE_EXT wrong slot count")
+	}
+}
+
+func TestValidateInputSpendQ_StealthWrongSlots(t *testing.T) {
+	covData := stealthCovenantDataForKeyID([32]byte{})
+	entry := UtxoEntry{
+		CovenantType: COV_TYPE_CORE_STEALTH,
+		CovenantData: covData,
+	}
+	err := validateInputSpendQ(entry, []WitnessItem{{}, {}}, &Tx{}, 0, 100, [32]byte{}, 1, 0, nil, nil, nil)
+	if err == nil {
+		t.Fatalf("expected error for CORE_STEALTH wrong slot count")
+	}
+}
+
+func TestValidateCoreExtSpendQ_SentinelForbidden(t *testing.T) {
+	entry := UtxoEntry{
+		CovenantType: COV_TYPE_CORE_EXT,
+		CovenantData: makeCoreExtCovenantData(0x01),
+	}
+	profiles := &testCoreExtProfileProvider{
+		profile: CoreExtProfile{
+			Active:        true,
+			AllowedSuites: map[uint8]struct{}{SUITE_ID_SENTINEL: {}},
+		},
+		found: true,
+	}
+	w := WitnessItem{SuiteID: SUITE_ID_SENTINEL}
+	err := validateCoreExtSpendQ(entry, w, &Tx{}, 0, 100, [32]byte{}, 1, nil, profiles, nil)
+	if err == nil {
+		t.Fatalf("expected error for sentinel under active profile")
+	}
+}
+
+func TestValidateCoreExtSpendQ_DisallowedSuite(t *testing.T) {
+	entry := UtxoEntry{
+		CovenantType: COV_TYPE_CORE_EXT,
+		CovenantData: makeCoreExtCovenantData(0x01),
+	}
+	profiles := &testCoreExtProfileProvider{
+		profile: CoreExtProfile{
+			Active:        true,
+			AllowedSuites: map[uint8]struct{}{}, // no suites allowed
+		},
+		found: true,
+	}
+	w := WitnessItem{SuiteID: SUITE_ID_ML_DSA_87}
+	err := validateCoreExtSpendQ(entry, w, &Tx{}, 0, 100, [32]byte{}, 1, nil, profiles, nil)
+	if err == nil {
+		t.Fatalf("expected error for disallowed suite")
+	}
+}
+
+func TestValidateCoreExtSpendQ_ExternalVerifier(t *testing.T) {
+	entry := UtxoEntry{
+		CovenantType: COV_TYPE_CORE_EXT,
+		CovenantData: makeCoreExtCovenantData(0x01),
+	}
+	called := false
+	profiles := &testCoreExtProfileProvider{
+		profile: CoreExtProfile{
+			Active:        true,
+			AllowedSuites: map[uint8]struct{}{0x42: {}},
+			VerifySigExtFn: func(extID uint16, suiteID uint8, pubkey []byte, signature []byte, digest32 [32]byte, extPayload []byte) (bool, error) {
+				called = true
+				return true, nil
+			},
+		},
+		found: true,
+	}
+	// Need a valid Tx for extractSigAndDigestWithCache.
+	var prevTxid [32]byte
+	prevTxid[0] = 0x66
+	tx := &Tx{
+		Version: 1,
+		TxKind:  0x00,
+		TxNonce: 1,
+		Inputs:  []TxInput{{PrevTxid: prevTxid, PrevVout: 0, Sequence: 0}},
+		Outputs: []TxOutput{{Value: 90, CovenantType: COV_TYPE_P2PK, CovenantData: make([]byte, MAX_P2PK_COVENANT_DATA)}},
+	}
+
+	sighashCache, cacheErr := NewSighashV1PrehashCache(tx)
+	if cacheErr != nil {
+		t.Fatalf("sighash: %v", cacheErr)
+	}
+
+	w := WitnessItem{
+		SuiteID:   0x42,
+		Pubkey:    make([]byte, 10),
+		Signature: append(make([]byte, 100), SIGHASH_ALL),
+	}
+	err := validateCoreExtSpendQ(entry, w, tx, 0, 100, [32]byte{}, 1, sighashCache, profiles, nil)
+	if err != nil {
+		t.Fatalf("external verifier: %v", err)
+	}
+	if !called {
+		t.Fatalf("external verifier was not called")
+	}
+}
+
+func TestValidateCoreExtSpendQ_ExternalVerifierRejects(t *testing.T) {
+	entry := UtxoEntry{
+		CovenantType: COV_TYPE_CORE_EXT,
+		CovenantData: makeCoreExtCovenantData(0x01),
+	}
+	profiles := &testCoreExtProfileProvider{
+		profile: CoreExtProfile{
+			Active:        true,
+			AllowedSuites: map[uint8]struct{}{0x42: {}},
+			VerifySigExtFn: func(extID uint16, suiteID uint8, pubkey []byte, signature []byte, digest32 [32]byte, extPayload []byte) (bool, error) {
+				return false, nil // rejected
+			},
+		},
+		found: true,
+	}
+	var prevTxid [32]byte
+	prevTxid[0] = 0x88
+	tx := &Tx{
+		Version: 1, TxKind: 0x00, TxNonce: 1,
+		Inputs:  []TxInput{{PrevTxid: prevTxid, PrevVout: 0, Sequence: 0}},
+		Outputs: []TxOutput{{Value: 90, CovenantType: COV_TYPE_P2PK, CovenantData: make([]byte, MAX_P2PK_COVENANT_DATA)}},
+	}
+	sighashCache, _ := NewSighashV1PrehashCache(tx)
+	w := WitnessItem{
+		SuiteID:   0x42,
+		Pubkey:    make([]byte, 10),
+		Signature: append(make([]byte, 100), SIGHASH_ALL),
+	}
+	err := validateCoreExtSpendQ(entry, w, tx, 0, 100, [32]byte{}, 1, sighashCache, profiles, nil)
+	if err == nil {
+		t.Fatalf("expected error for rejected external verifier")
+	}
+}
+
+func TestValidateCoreExtSpendQ_ExternalVerifierError(t *testing.T) {
+	entry := UtxoEntry{
+		CovenantType: COV_TYPE_CORE_EXT,
+		CovenantData: makeCoreExtCovenantData(0x01),
+	}
+	profiles := &testCoreExtProfileProvider{
+		profile: CoreExtProfile{
+			Active:        true,
+			AllowedSuites: map[uint8]struct{}{0x42: {}},
+			VerifySigExtFn: func(extID uint16, suiteID uint8, pubkey []byte, signature []byte, digest32 [32]byte, extPayload []byte) (bool, error) {
+				return false, txerr(TX_ERR_SIG_ALG_INVALID, "ext error")
+			},
+		},
+		found: true,
+	}
+	var prevTxid [32]byte
+	prevTxid[0] = 0x99
+	tx := &Tx{
+		Version: 1, TxKind: 0x00, TxNonce: 1,
+		Inputs:  []TxInput{{PrevTxid: prevTxid, PrevVout: 0, Sequence: 0}},
+		Outputs: []TxOutput{{Value: 90, CovenantType: COV_TYPE_P2PK, CovenantData: make([]byte, MAX_P2PK_COVENANT_DATA)}},
+	}
+	sighashCache, _ := NewSighashV1PrehashCache(tx)
+	w := WitnessItem{
+		SuiteID:   0x42,
+		Pubkey:    make([]byte, 10),
+		Signature: append(make([]byte, 100), SIGHASH_ALL),
+	}
+	err := validateCoreExtSpendQ(entry, w, tx, 0, 100, [32]byte{}, 1, sighashCache, profiles, nil)
+	if err == nil {
+		t.Fatalf("expected error for ext verifier error")
+	}
+}
+
+func TestValidateCoreExtSpendQ_MLDSA87_NonCanonical(t *testing.T) {
+	entry := UtxoEntry{
+		CovenantType: COV_TYPE_CORE_EXT,
+		CovenantData: makeCoreExtCovenantData(0x01),
+	}
+	profiles := &testCoreExtProfileProvider{
+		profile: CoreExtProfile{
+			Active:        true,
+			AllowedSuites: map[uint8]struct{}{SUITE_ID_ML_DSA_87: {}},
+		},
+		found: true,
+	}
+	w := WitnessItem{
+		SuiteID:   SUITE_ID_ML_DSA_87,
+		Pubkey:    make([]byte, 10), // wrong size
+		Signature: make([]byte, 10), // wrong size
+	}
+	err := validateCoreExtSpendQ(entry, w, &Tx{}, 0, 100, [32]byte{}, 1, nil, profiles, nil)
+	if err == nil {
+		t.Fatalf("expected error for non-canonical ML-DSA lengths")
+	}
+}
+
+func TestValidateCoreExtSpendQ_NilQueue_MLDSA(t *testing.T) {
+	// Test the sigQueue==nil fallback for ML-DSA-87 in CORE_EXT.
+	kp := mustMLDSA87Keypair(t)
+	entry := UtxoEntry{
+		CovenantType: COV_TYPE_CORE_EXT,
+		CovenantData: makeCoreExtCovenantData(0x01),
+	}
+	profiles := &testCoreExtProfileProvider{
+		profile: CoreExtProfile{
+			Active:        true,
+			AllowedSuites: map[uint8]struct{}{SUITE_ID_ML_DSA_87: {}},
+		},
+		found: true,
+	}
+
+	var prevTxid [32]byte
+	prevTxid[0] = 0xAA
+	tx := &Tx{
+		Version: 1, TxKind: 0x00, TxNonce: 1,
+		Inputs:  []TxInput{{PrevTxid: prevTxid, PrevVout: 0, Sequence: 0}},
+		Outputs: []TxOutput{{Value: 90, CovenantType: COV_TYPE_P2PK, CovenantData: p2pkCovenantDataForPubkey(kp.PubkeyBytes())}},
+	}
+	tx.Witness = []WitnessItem{signP2PKInputWitness(t, tx, 0, 100, [32]byte{}, kp)}
+	sighashCache, _ := NewSighashV1PrehashCache(tx)
+
+	// sigQueue=nil → inline verifySig
+	err := validateCoreExtSpendQ(entry, tx.Witness[0], tx, 0, 100, [32]byte{}, 1, sighashCache, profiles, nil)
+	if err != nil {
+		t.Fatalf("nil queue MLDSA: %v", err)
+	}
+}
+
+func TestValidateCoreExtSpendQ_ProfileLookupError(t *testing.T) {
+	entry := UtxoEntry{
+		CovenantType: COV_TYPE_CORE_EXT,
+		CovenantData: makeCoreExtCovenantData(0x01),
+	}
+	profiles := &testCoreExtProfileProvider{
+		err: txerr(TX_ERR_COVENANT_TYPE_INVALID, "lookup fail"),
+	}
+	w := WitnessItem{SuiteID: SUITE_ID_ML_DSA_87}
+	err := validateCoreExtSpendQ(entry, w, &Tx{}, 0, 100, [32]byte{}, 1, nil, profiles, nil)
+	if err == nil {
+		t.Fatalf("expected error for profile lookup failure")
+	}
+}
+
+func TestValidateCoreExtSpendQ_ExternalVerifierNil(t *testing.T) {
+	entry := UtxoEntry{
+		CovenantType: COV_TYPE_CORE_EXT,
+		CovenantData: makeCoreExtCovenantData(0x01),
+	}
+	profiles := &testCoreExtProfileProvider{
+		profile: CoreExtProfile{
+			Active:        true,
+			AllowedSuites: map[uint8]struct{}{0x42: {}},
+			// No VerifySigExtFn → nil
+		},
+		found: true,
+	}
+	var prevTxid [32]byte
+	prevTxid[0] = 0x77
+	tx := &Tx{
+		Version: 1,
+		TxKind:  0x00,
+		TxNonce: 1,
+		Inputs:  []TxInput{{PrevTxid: prevTxid, PrevVout: 0, Sequence: 0}},
+		Outputs: []TxOutput{{Value: 90, CovenantType: COV_TYPE_P2PK, CovenantData: make([]byte, MAX_P2PK_COVENANT_DATA)}},
+	}
+	sighashCache, _ := NewSighashV1PrehashCache(tx)
+
+	w := WitnessItem{
+		SuiteID:   0x42,
+		Pubkey:    make([]byte, 10),
+		Signature: append(make([]byte, 100), SIGHASH_ALL),
+	}
+	err := validateCoreExtSpendQ(entry, w, tx, 0, 100, [32]byte{}, 1, sighashCache, profiles, nil)
+	if err == nil {
+		t.Fatalf("expected error for nil external verifier")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `ValidateTxLocal` — read-only per-tx validation using precomputed `TxValidationContext`
- Per-worker `SigCheckQueue` with optional `SigCache` integration for ML-DSA-87 deferred verification
- `validateInputSpendQ` dispatches to existing Q-variant validators for all 6 spendable covenant types (P2PK, Multisig, HTLC, Vault, CORE_EXT, CORE_STEALTH)
- `validateCoreExtSpendQ` extracted from inline logic; external verifiers called inline (not thread-safe), ML-DSA-87 deferred to queue
- `RunTxValidationWorkers` wraps `WorkerPool` for parallel execution; `FirstTxError` for deterministic error ordering
- Vault: only threshold sig verified in worker; full policy (whitelist, owner lock) deferred to sequential commit stage

## Test plan
- [x] 31 unit tests covering all covenant types, error paths, cache integration
- [x] Coverage: ValidateTxLocal 85.7%, validateInputSpendQ 90.9%, validateCoreExtSpendQ 89.1%, RunTxValidationWorkers+FirstTxError 100%
- [x] Local coverage preflight PASS
- [ ] CI checks green (test, coverage, lint)

Closes Q-PV-09

🤖 Generated with [Claude Code](https://claude.com/claude-code)