### PR TITLE
fix: defensive clone for NativeSuiteSet shared state

### DIFF
--- a/clients/go/consensus/suite_registry.go
+++ b/clients/go/consensus/suite_registry.go
@@ -105,6 +105,18 @@ func NewNativeSuiteSet(ids ...uint8) *NativeSuiteSet {
 	return &NativeSuiteSet{suites: m}
 }
 
+// Clone returns a deep copy of the suite set so callers cannot mutate shared state.
+func (s *NativeSuiteSet) Clone() *NativeSuiteSet {
+	if s == nil {
+		return nil
+	}
+	m := make(map[uint8]struct{}, len(s.suites))
+	for id := range s.suites {
+		m[id] = struct{}{}
+	}
+	return &NativeSuiteSet{suites: m}
+}
+
 // RotationProvider determines which signature suites are valid for native
 // covenant creation and spending at a given block height. This is the
 // injection point for rotation deployment descriptors.
@@ -130,10 +142,10 @@ var defaultNativeSuiteSet = NewNativeSuiteSet(SUITE_ID_ML_DSA_87)
 
 // NativeCreateSuites implements RotationProvider.
 func (DefaultRotationProvider) NativeCreateSuites(_ uint64) *NativeSuiteSet {
-	return defaultNativeSuiteSet
+	return defaultNativeSuiteSet.Clone()
 }
 
 // NativeSpendSuites implements RotationProvider.
 func (DefaultRotationProvider) NativeSpendSuites(_ uint64) *NativeSuiteSet {
-	return defaultNativeSuiteSet
+	return defaultNativeSuiteSet.Clone()
 }

--- a/clients/go/consensus/suite_registry_test.go
+++ b/clients/go/consensus/suite_registry_test.go
@@ -102,7 +102,7 @@ func TestNativeSuiteSet_SuiteIDs_Sorted(t *testing.T) {
 		t.Fatalf("len = %d, want 3", len(ids))
 	}
 	if ids[0] != SUITE_ID_ML_DSA_87 || ids[1] != 0x02 || ids[2] != 0x03 {
-		t.Errorf("SuiteIDs = %v, want [1 2 3]", ids)
+		t.Errorf("SuiteIDs = %v, want [%d %d %d]", ids, SUITE_ID_ML_DSA_87, 0x02, 0x03)
 	}
 }
 
@@ -136,6 +136,29 @@ func TestNativeSuiteSet_Dedup(t *testing.T) {
 	s := NewNativeSuiteSet(SUITE_ID_ML_DSA_87, SUITE_ID_ML_DSA_87, SUITE_ID_ML_DSA_87)
 	if s.Len() != 1 {
 		t.Errorf("Len = %d, want 1 (dedup)", s.Len())
+	}
+}
+
+func TestNativeSuiteSet_Clone(t *testing.T) {
+	orig := NewNativeSuiteSet(SUITE_ID_ML_DSA_87, 0x02)
+	cloned := orig.Clone()
+	if cloned.Len() != orig.Len() {
+		t.Fatalf("Clone Len = %d, want %d", cloned.Len(), orig.Len())
+	}
+	if !cloned.Contains(SUITE_ID_ML_DSA_87) || !cloned.Contains(0x02) {
+		t.Error("Clone should contain same IDs")
+	}
+	// Mutating clone must not affect original.
+	cloned.suites[0xFF] = struct{}{}
+	if orig.Contains(0xFF) {
+		t.Error("mutating clone must not affect original")
+	}
+}
+
+func TestNativeSuiteSet_Clone_Nil(t *testing.T) {
+	var s *NativeSuiteSet
+	if s.Clone() != nil {
+		t.Error("Clone of nil should return nil")
 	}
 }
 


### PR DESCRIPTION
## Summary
- `DefaultRotationProvider.NativeCreateSuites/NativeSpendSuites` now return `Clone()` instead of shared package-level pointer
- Prevents potential race/mutation if future callers modify the returned `*NativeSuiteSet`
- Fixes test error message to use constants (`SUITE_ID_ML_DSA_87`) instead of hardcoded `[1 2 3]`
- Adds `Clone()` method + 2 tests (`TestNativeSuiteSet_Clone`, `TestNativeSuiteSet_Clone_Nil`)

## Source
CodeRabbit review finding on PR#718 (rotation GO-01..03).

## Test plan
- [x] All 67 consensus tests pass locally
- [ ] CI green (test + coverage + Codacy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Suite registry now provides proper state isolation to prevent unintended data modifications.

* **Tests**
  * Added tests for suite registry cloning behavior and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->