### PR TITLE
chore: disable CodeRabbit automatic PR reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,7 @@
+# CodeRabbit configuration
+# Automatic PR reviews are disabled — use local CLI only:
+#   coderabbit review --plain
+#   coderabbit review --prompt-only
+reviews:
+  auto_review:
+    enabled: false


### PR DESCRIPTION
## Summary
- Adds `.coderabbit.yaml` with `reviews.auto_review.enabled: false`
- Disables automatic CodeRabbit GitHub App reviews on PRs
- Local CLI (`coderabbit review --plain`) remains fully functional

## Test plan
- [ ] Verify CodeRabbit bot does not post automatic review on this PR
- [ ] Verify `coderabbit review --plain` still works locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration for code review processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->