### PR TITLE
docs: add parallel validation review templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Quick references:
 - Parallel validation fixtures spec: `./RUBIN_PARALLEL_VALIDATION_FIXTURES.md`
 - Parallel validation benchmark plan: `./RUBIN_PARALLEL_VALIDATION_BENCHMARK_PLAN.md`
 - Parallel validation security notes: `./RUBIN_PARALLEL_VALIDATION_SECURITY_NOTES.md`
+- Parallel validation PR review template: `./RUBIN_PARALLEL_VALIDATION_PR_REVIEW_TEMPLATE.md`
+- Parallel validation security review template: `./RUBIN_PARALLEL_VALIDATION_SECURITY_REVIEW_TEMPLATE.md`
 
 ## Quick Start (Local)
 

--- a/RUBIN_PARALLEL_VALIDATION_PR_REVIEW_TEMPLATE.md
+++ b/RUBIN_PARALLEL_VALIDATION_PR_REVIEW_TEMPLATE.md
@@ -1,0 +1,314 @@
+# PR Review Template — Parallel Validation (Rubin)
+
+Use this template only for PRs that implement or modify **implementation-only parallel validation**.
+Do not use it for PRs that change consensus rules, wire format, or canonical validation order.
+
+---
+
+## 1) PR Classification
+
+- [ ] This PR does **not** change consensus rules
+- [ ] This PR does **not** change wire format
+- [ ] This PR does **not** change `SECTION_HASHES.json`
+- [ ] This PR is strictly implementation-layer parallel validation
+- [ ] The PR uses the term **parallel validation** (not misleading "parallel execution")
+
+If any item above is false, split the PR or move it to a consensus-track process.
+
+---
+
+## 2) Reviewer Summary
+
+### What this PR does
+
+<!-- short module/path summary -->
+
+### What this PR does NOT do
+
+- [ ] Does not change `ApplyBlock(State, Block)` semantics
+- [ ] Does not change block validity rules
+- [ ] Does not change covenant semantics
+- [ ] Does not change canonical error mapping
+- [ ] Does not claim protocol TPS increase
+
+### Feature flags / rollout mode
+
+- [ ] `off`
+- [ ] `shadow`
+- [ ] `on`
+
+Flags/config:
+
+```text
+<flags here>
+```
+
+---
+
+## 3) Canonical Boundary Checklist
+
+### Validation order
+
+- [ ] Canonical block validation order is preserved
+- [ ] No new consensus error-producing steps inserted between canonical steps
+- [ ] Parallel path does not alter deterministic error precedence
+
+### Sequential-only stages
+
+- [ ] Parse and canonical checks remain sequential
+- [ ] Witness cursor assignment is sequential
+- [ ] Replay-domain / `tx_nonce` checks preserve block-order semantics
+- [ ] Commit stage remains single-threaded
+- [ ] State update remains in block order
+
+### Worker restrictions
+
+- [ ] Workers do not mutate UTXO state
+- [ ] Workers do not mutate DA state
+- [ ] Workers do not mutate shared consensus accumulators
+- [ ] Workers never choose final block error
+
+---
+
+## 4) Witness / Cursor Review
+
+- [ ] Witness cursor is computed exactly once before worker dispatch
+- [ ] Workers use precomputed witness spans/slots
+- [ ] Unknown covenant during cursor precompute rejects deterministically
+- [ ] Bounds checks exist before witness indexing
+- [ ] Tests cover HTLC / VAULT / MULTISIG / STEALTH / CORE_EXT
+
+---
+
+## 5) Dependency Graph Review
+
+- [ ] Graph includes same-prevout conflicts
+- [ ] Graph includes same-block producer -> consumer dependencies
+- [ ] No false parallelization for same-block dependent tx
+- [ ] Adversarial parent-child test exists
+- [ ] Mixed workload dependency test exists
+
+---
+
+## 6) Deterministic Reducer Review
+
+- [ ] Not using "first worker error wins"
+- [ ] Reducer selects smallest invalid `tx_index` in block order
+- [ ] Intra-tx canonical error priority is preserved
+- [ ] Sequential vs parallel match on:
+  - [ ] validity
+  - [ ] first invalid tx index
+  - [ ] first error code
+
+---
+
+## 7) Immutable Snapshot / State Safety
+
+- [ ] Validation uses immutable snapshot inputs
+- [ ] No lazy write-back from workers
+- [ ] Shared caches/refs are read-only or thread-safe
+- [ ] UTXO sharding function is deterministic
+- [ ] Commit phase is the only state mutation phase
+
+---
+
+## 8) Signature Verification Invariants
+
+- [ ] OpenSSL EVP path is preserved
+- [ ] No silent fallback to alternative PQ backends
+- [ ] `digest32` semantics unchanged
+- [ ] No extra pre-hash / wrapping / custom context drift
+- [ ] `pubkey` / `signature` lengths validated before verify calls
+
+---
+
+## 9) Signature Cache Review
+
+- [ ] Cache is bounded
+- [ ] Eviction policy is explicit
+- [ ] Cache key is cryptographically sound
+- [ ] Flood/poisoning scenarios reviewed
+- [ ] Cache hit path does not alter consensus semantics
+
+---
+
+## 10) Compact Block Path Review
+
+- [ ] Compact reconstruction path remains separated from normal full-block path
+- [ ] Batch verify path and individual fallback are preserved
+- [ ] `CV-COMPACT` coverage is preserved/extended
+
+---
+
+## 11) Resource / Policy Separation
+
+- [ ] No policy-only rejects are introduced into consensus-equivalent path
+- [ ] Block-level limits are not transformed into per-tx consensus rules
+- [ ] Mempool pre-validation is only hint/cache-warming, never final truth
+
+---
+
+## 12) Worker Pool / Scheduler Review
+
+- [ ] Worker pool is bounded
+- [ ] Queue is bounded
+- [ ] Backpressure exists
+- [ ] No unbounded memory growth path
+- [ ] Scheduler perturbation/starvation tests exist
+- [ ] `workers=1` path remains sequential-equivalent
+
+---
+
+## 13) Testing Checklist
+
+### Unit tests
+
+- [ ] witness cursor
+- [ ] reducer
+- [ ] dependency graph
+- [ ] snapshot purity
+- [ ] cache
+- [ ] scheduler
+- [ ] DA parallel jobs
+
+### Integration tests
+
+- [ ] sequential vs parallel on valid blocks
+- [ ] sequential vs parallel on invalid blocks
+- [ ] mixed covenant workloads
+- [ ] compact reconstruction path
+- [ ] same-block parent-child dependency
+
+### Adversarial / fuzz / replay
+
+- [ ] deterministic replay harness
+- [ ] race detection
+- [ ] fuzz with parallel mode enabled
+- [ ] injected-delay scheduler perturbation
+- [ ] mismatch tests for first error and state digest
+
+---
+
+## 14) Cross-client Parity
+
+- [ ] Go sequential == Go parallel
+- [ ] Rust sequential == Rust parallel
+- [ ] Go == Rust on parity fixtures
+- [ ] `run_cv_bundle.py` PASS
+
+CI evidence links:
+
+```text
+<CI links here>
+```
+
+---
+
+## 15) Telemetry / Logging
+
+- [ ] Shadow mismatch counters exist (`count`, `first_error`, `state_digest`)
+- [ ] Worker pool metrics exist (`queue_depth`, `active_workers`, `wait_time`)
+- [ ] Validation/commit latency metrics exist
+- [ ] Logs distinguish normal/compact/shadow paths
+- [ ] No sensitive payload leakage in telemetry/logs
+
+---
+
+## 16) Rollout / Fail-closed
+
+- [ ] `shadow` mode exists
+- [ ] Sequential remains truth path in `shadow`
+- [ ] Mismatch triggers fail-closed fallback to sequential
+- [ ] Internal panic triggers fail-closed fallback
+- [ ] Rollback procedure is documented for operators
+
+Rollback command/knob:
+
+```text
+<rollback procedure here>
+```
+
+---
+
+## 17) Benchmarks
+
+### Correctness gates
+
+- [ ] zero replay mismatches
+- [ ] zero race failures
+- [ ] zero parity mismatches
+
+### Performance evidence
+
+- [ ] 1-worker mode regression <= 5%
+- [ ] mixed workload improvement measured
+- [ ] signature-heavy workload improvement measured
+- [ ] benchmark datasets reproducible
+- [ ] hardware matrix included (e.g. 4/8/16/32 cores)
+
+Benchmark summary:
+
+```text
+<benchmark summary here>
+```
+
+---
+
+## 18) Reviewer Decision
+
+### Reviewer A
+
+- [ ] GO
+- [ ] GO with follow-ups
+- [ ] REWORK
+- [ ] REJECT
+
+```text
+<notes>
+```
+
+### Reviewer B
+
+- [ ] GO
+- [ ] GO with follow-ups
+- [ ] REWORK
+- [ ] REJECT
+
+```text
+<notes>
+```
+
+### Security Reviewer
+
+- [ ] GO
+- [ ] GO with follow-ups
+- [ ] REWORK
+- [ ] REJECT
+
+```text
+<notes>
+```
+
+---
+
+## 19) Final Merge Gate
+
+Merge is allowed only if all are true:
+
+- [ ] Consensus boundary preserved
+- [ ] Deterministic reducer verified
+- [ ] Witness cursor precompute verified
+- [ ] Immutable snapshot + sequential commit verified
+- [ ] OpenSSL verifier invariants preserved
+- [ ] Replay/race/fuzz/parity are green
+- [ ] Shadow soak evidence attached
+- [ ] Documentation aligned
+
+Explicit no-go conditions:
+
+- [ ] Worker mutates consensus state
+- [ ] Worker chooses final block error
+- [ ] Witness slicing performed lazily inside workers
+- [ ] Mempool validation substituted for block validation
+- [ ] Crypto backend drift introduced without parity coverage
+- [ ] Any mismatch remains unresolved

--- a/RUBIN_PARALLEL_VALIDATION_SECURITY_REVIEW_TEMPLATE.md
+++ b/RUBIN_PARALLEL_VALIDATION_SECURITY_REVIEW_TEMPLATE.md
@@ -1,0 +1,289 @@
+# Rubin Parallel Validation — Security Review Template
+
+Purpose: security review template for PRs and release gates in the
+**parallel validation** track.
+
+Scope: implementation acceleration only; consensus rules are unchanged.
+
+---
+
+## 1) Change Identification
+
+- [ ] PR / commit range is specified
+- [ ] Go implementation scope is listed
+- [ ] Rust implementation scope is listed
+- [ ] Benchmark evidence is linked
+- [ ] Parity evidence is linked
+- [ ] Race / sanitizer evidence is linked
+- [ ] Shadow rollout evidence is linked
+
+Reviewer:
+
+- Security reviewer:
+- Date:
+- Target branch / release train:
+- Related issues:
+
+---
+
+## 2) Scope Lock
+
+### Hard blocker checks
+
+- [ ] No consensus rule change
+- [ ] No `ApplyBlock(State, Block)` semantic change
+- [ ] No block/tx/covenant semantic change
+- [ ] `SECTION_HASHES.json` unchanged
+- [ ] PR uses term **parallel validation** (not concurrent state execution)
+
+Reviewer notes:
+
+- Any sign of hidden consensus drift?
+- Any policy optimization being smuggled into validity logic?
+
+---
+
+## 3) Determinism Boundary
+
+### Hard blocker checks
+
+- [ ] Validation stage is side-effect free
+- [ ] Commit stage is single-threaded
+- [ ] Commit stage remains strict block order
+- [ ] Worker results never decide final block validity directly
+- [ ] Reducer chooses canonical first error deterministically
+- [ ] Sequential vs parallel match on:
+  - [ ] valid / invalid
+  - [ ] first invalid tx index
+  - [ ] first error code
+  - [ ] post-state digest
+
+### Evidence required
+
+- [ ] deterministic replay logs
+- [ ] reducer tests
+- [ ] scheduling perturbation tests
+
+---
+
+## 4) Witness / Tx-context Safety
+
+### Hard blocker checks
+
+- [ ] Witness cursor is computed sequentially before workers
+- [ ] Workers use precomputed witness spans (no dynamic slicing)
+- [ ] Unknown covenant during cursor/precompute rejects deterministically
+- [ ] Witness bounds checks are covered by tests
+- [ ] `VAULT` / `MULTISIG` key-count-dependent spans covered by tests
+
+### Evidence required
+
+- [ ] witness cursor unit tests
+- [ ] malformed witness fixture set
+- [ ] mixed-covenant fixture set
+
+---
+
+## 5) Shared-state Safety
+
+### Hard blocker checks
+
+- [ ] Validation uses immutable snapshot inputs
+- [ ] Workers have no mutable access to consensus state
+- [ ] Shared caches/references are read-only or thread-safe
+- [ ] No lazy write-back from workers
+- [ ] Snapshot identity is deterministic and explicit
+
+### Evidence required
+
+- [ ] architecture note / code pointers
+- [ ] race detector output
+- [ ] snapshot purity tests
+
+---
+
+## 6) Dependency Graph Safety
+
+### Hard blocker checks
+
+- [ ] DAG models same-prevout conflicts
+- [ ] DAG models same-block producer -> consumer dependencies
+- [ ] No false independence for same-block dependent tx
+- [ ] Scheduler respects graph barriers deterministically
+
+### Evidence required
+
+- [ ] DAG unit tests
+- [ ] parent-child fixture
+- [ ] adversarial mixed-block fixture
+
+---
+
+## 7) Crypto Backend Invariants
+
+### Hard blocker checks
+
+- [ ] OpenSSL EVP path is preserved
+- [ ] No silent fallback to alternate PQ backends
+- [ ] `digest32` semantics unchanged
+- [ ] No extra pre-hash / domain wrapping / provider drift
+- [ ] `pubkey` / `signature` length checks run before verify calls
+
+### Evidence required
+
+- [ ] Go tests
+- [ ] Rust tests
+- [ ] OpenSSL preflight output
+- [ ] parity evidence (`run_cv_bundle.py`)
+
+---
+
+## 8) Signature Cache Review
+
+### Strong requirements
+
+- [ ] Cache is bounded
+- [ ] Cache key uses cryptographic tuple
+- [ ] Eviction policy is explicit
+- [ ] Flood / poisoning scenario reviewed
+- [ ] Cache hit path cannot alter consensus semantics
+
+### Evidence required
+
+- [ ] cache tests
+- [ ] cache flood benchmark
+- [ ] cache poisoning analysis
+
+---
+
+## 9) Compact-block Path Review
+
+### Hard blocker checks
+
+- [ ] Compact reconstruction path is separated from normal full-block path
+- [ ] Batch verify path follows canonical compact procedure
+- [ ] Batch-fail -> individual-fallback path covered
+- [ ] Parallel optimization does not alter compact error handling
+- [ ] Compact telemetry / peer-quality signals preserved
+
+### Evidence required
+
+- [ ] `CV-COMPACT` results
+- [ ] compact fallback tests
+- [ ] compact telemetry sample
+
+---
+
+## 10) DA Parallelism Review
+
+### Hard blocker checks
+
+- [ ] DA jobs do not alter commitment semantics
+- [ ] Chunk ordering validation remains deterministic
+- [ ] Malformed/incomplete DA yields same errors as sequential path
+- [ ] DA workers do not bypass canonical block-order checks
+
+### Evidence required
+
+- [ ] DA fixtures
+- [ ] DA replay equality results
+
+---
+
+## 11) Fault Handling / Fail-closed
+
+### Hard blocker checks
+
+- [ ] Worker panic/internal error cannot silently continue acceptance
+- [ ] Parallel mismatch triggers fail-closed fallback to sequential truth path
+- [ ] Resource guardrail breach triggers fail-closed behavior
+- [ ] Race/sanitizer failure blocks release
+- [ ] No partial-success ambiguous mode
+
+### Evidence required
+
+- [ ] panic injection test
+- [ ] mismatch injection test
+- [ ] fallback test
+
+---
+
+## 12) Test Evidence
+
+### Hard blocker checks
+
+- [ ] Unit tests complete
+- [ ] Integration tests complete
+- [ ] Fuzz tests complete
+- [ ] Replay tests complete
+- [ ] Go `-race` complete
+- [ ] Rust sanitizer/concurrency tests complete
+- [ ] Cross-client parity complete
+
+---
+
+## 13) Rollout Security
+
+### Hard blocker checks
+
+- [ ] Modes `off / shadow / on` documented
+- [ ] `shadow` uses sequential as truth path
+- [ ] Shadow mismatch telemetry is present
+- [ ] Operator rollback path documented
+- [ ] Soak evidence is present before default-on decision
+
+### Evidence required
+
+- [ ] operator SOP/runbook
+- [ ] shadow soak metrics
+- [ ] rollback drill result
+
+---
+
+## 14) Documentation / Claims Review
+
+### Hard blocker checks
+
+- [ ] Documentation does not claim protocol TPS increase
+- [ ] Documentation does not present this as consensus change
+- [ ] Security claims are evidence-backed
+- [ ] README / PR body / runbook language is aligned
+
+---
+
+## 15) Final Decision
+
+### Merge decision
+
+- [ ] APPROVE
+- [ ] APPROVE WITH REQUIRED FIXES
+- [ ] REJECT / REWORK REQUIRED
+
+Blocking findings:
+
+1.
+2.
+3.
+
+Non-blocking findings:
+
+1.
+2.
+3.
+
+Required follow-up issues:
+
+- [ ] deferred hardening
+- [ ] benchmark debt
+- [ ] operator telemetry/alerts
+- [ ] formal refinement extension
+
+---
+
+## 16) Reviewer Summary
+
+Security verdict:
+
+Rationale:
+
+Conditions for production enablement:


### PR DESCRIPTION
## Summary
- Add `RUBIN_PARALLEL_VALIDATION_PR_REVIEW_TEMPLATE.md`.
- Add `RUBIN_PARALLEL_VALIDATION_SECURITY_REVIEW_TEMPLATE.md`.
- Update README quick references to include both template docs.

## Scope
- Documentation-only change.
- No consensus semantics changes.


Made with [Cursor](https://cursor.com)