### PR TITLE
fix: switch claude-review to OAuth token from subscription

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -29,7 +29,7 @@ jobs:
         env:
           ANTHROPIC_MODEL: claude-sonnet-4-6
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: "--max-turns 15"
           prompt: |
             You are the primary consensus security reviewer for the RUBIN blockchain protocol.


### PR DESCRIPTION
## Summary

<!-- What does this PR do? -->

## Scope

- [ ] Documentation-only
- [ ] Implementation-only change (no consensus change)
- [ ] Consensus-affecting change (requires explicit process)

**Consensus boundary (required):**

- Consensus rules unchanged: YES/NO
- `SECTION_HASHES.json` unchanged: YES/NO
- Wire format unchanged: YES/NO

## Evidence / Gates

<!-- Required for PV/CORE_EXT/consensus-sensitive areas -->

- CI links:
  - test:
  - coverage:
  - policy/validator:
- Conformance:
  - `run_cv_bundle.py`:
- Replay / determinism:
  - seq vs par equality (verdict/error/digests):

## Rollout / Flags (if applicable)

```text
pv-mode=off|shadow|on
pv-shadow-max=N
```

Refs: Q-XXX-YY-ZZ

