### PR TITLE
formal: sync rotation CUTOFF+SUNSET filled stubs from rubin-formal#156

### DIFF
--- a/rubin-formal/RubinFormal/Conformance/CVNativeRotationCutoffReplay.lean
+++ b/rubin-formal/RubinFormal/Conformance/CVNativeRotationCutoffReplay.lean
@@ -1,4 +1,33 @@
+-- CV-NATIVE-ROTATION-CUTOFF structural replay checks.
 import RubinFormal.Conformance.CVNativeRotationCutoffVectors
+
 namespace RubinFormal.Conformance
-theorem cv_native_rotation_cutoff_vectors_pass : True := trivial
+
+/-- All 6 vectors present. -/
+theorem cv_native_rotation_cutoff_vector_count :
+    cvNativeRotationCutoffVectors.length = 6 := by native_decide
+
+/-- IDs are distinct. -/
+private def allDistinctCutoffIds (vs : List CVNativeRotationCutoffVector) : Bool :=
+  let ids := vs.map (·.id)
+  ids.length == ids.eraseDups.length
+
+theorem cv_native_rotation_cutoff_ids_distinct :
+    allDistinctCutoffIds cvNativeRotationCutoffVectors = true := by native_decide
+
+/-- Every reject vector has non-empty expect_err. -/
+private def allCutoffRejectsHaveErr (vs : List CVNativeRotationCutoffVector) : Bool :=
+  vs.all fun v =>
+    if v.expectOk then true
+    else match v.expectErr with
+      | some e => e.length > 0
+      | none => false
+
+theorem cv_native_rotation_cutoff_rejects_have_err :
+    allCutoffRejectsHaveErr cvNativeRotationCutoffVectors = true := by native_decide
+
+/-- Gate-mandated alias. -/
+theorem cv_native_rotation_cutoff_vectors_pass :
+    cvNativeRotationCutoffVectors.length = 6 := cv_native_rotation_cutoff_vector_count
+
 end RubinFormal.Conformance

--- a/rubin-formal/RubinFormal/Conformance/CVNativeRotationCutoffVectors.lean
+++ b/rubin-formal/RubinFormal/Conformance/CVNativeRotationCutoffVectors.lean
@@ -1,7 +1,23 @@
--- Placeholder for CV-NATIVE-ROTATION-CUTOFF conformance vectors.
+-- Generated from conformance/fixtures/CV-NATIVE-ROTATION-CUTOFF.json
+-- CUTOFF: H1/H2 boundary vectors for NATIVE_CREATE_SUITES/NATIVE_SPEND_SUITES transitions.
+
 namespace RubinFormal.Conformance
+
 structure CVNativeRotationCutoffVector where
   id : String
+  op : String
+  height : Nat
+  suiteId : Nat
   expectOk : Bool
-def cvNativeRotationCutoffVectors : List CVNativeRotationCutoffVector := []
+  expectErr : Option String
+
+def cvNativeRotationCutoffVectors : List CVNativeRotationCutoffVector := [
+  { id := "NATIVE-ROT-CUTOFF-01", op := "rotation_create_suite_check", height := 199, suiteId := 1, expectOk := true, expectErr := none },
+  { id := "NATIVE-ROT-CUTOFF-02", op := "rotation_create_suite_check", height := 200, suiteId := 1, expectOk := true, expectErr := none },
+  { id := "NATIVE-ROT-CUTOFF-03", op := "rotation_create_suite_check", height := 200, suiteId := 2, expectOk := true, expectErr := none },
+  { id := "NATIVE-ROT-CUTOFF-04", op := "rotation_create_suite_check", height := 99, suiteId := 2, expectOk := false, expectErr := some "TX_ERR_SIG_ALG_INVALID" },
+  { id := "NATIVE-ROT-CUTOFF-05", op := "rotation_create_suite_check", height := 100, suiteId := 2, expectOk := true, expectErr := none },
+  { id := "NATIVE-ROT-CUTOFF-06", op := "rotation_spend_suite_check", height := 200, suiteId := 1, expectOk := true, expectErr := none }
+]
+
 end RubinFormal.Conformance

--- a/rubin-formal/RubinFormal/Conformance/CVNativeRotationSunsetReplay.lean
+++ b/rubin-formal/RubinFormal/Conformance/CVNativeRotationSunsetReplay.lean
@@ -1,4 +1,33 @@
+-- CV-NATIVE-ROTATION-SUNSET structural replay checks.
 import RubinFormal.Conformance.CVNativeRotationSunsetVectors
+
 namespace RubinFormal.Conformance
-theorem cv_native_rotation_sunset_vectors_pass : True := trivial
+
+/-- All 5 vectors present. -/
+theorem cv_native_rotation_sunset_vector_count :
+    cvNativeRotationSunsetVectors.length = 5 := by native_decide
+
+/-- IDs are distinct. -/
+private def allDistinctSunsetIds (vs : List CVNativeRotationSunsetVector) : Bool :=
+  let ids := vs.map (·.id)
+  ids.length == ids.eraseDups.length
+
+theorem cv_native_rotation_sunset_ids_distinct :
+    allDistinctSunsetIds cvNativeRotationSunsetVectors = true := by native_decide
+
+/-- Every reject vector has non-empty expect_err. -/
+private def allSunsetRejectsHaveErr (vs : List CVNativeRotationSunsetVector) : Bool :=
+  vs.all fun v =>
+    if v.expectOk then true
+    else match v.expectErr with
+      | some e => e.length > 0
+      | none => false
+
+theorem cv_native_rotation_sunset_rejects_have_err :
+    allSunsetRejectsHaveErr cvNativeRotationSunsetVectors = true := by native_decide
+
+/-- Gate-mandated alias. -/
+theorem cv_native_rotation_sunset_vectors_pass :
+    cvNativeRotationSunsetVectors.length = 5 := cv_native_rotation_sunset_vector_count
+
 end RubinFormal.Conformance

--- a/rubin-formal/RubinFormal/Conformance/CVNativeRotationSunsetVectors.lean
+++ b/rubin-formal/RubinFormal/Conformance/CVNativeRotationSunsetVectors.lean
@@ -1,7 +1,22 @@
--- Placeholder for CV-NATIVE-ROTATION-SUNSET conformance vectors.
+-- Generated from conformance/fixtures/CV-NATIVE-ROTATION-SUNSET.json
+-- SUNSET: H4 boundary vectors — old suite removal from CREATE set at sunset_height.
+
 namespace RubinFormal.Conformance
+
 structure CVNativeRotationSunsetVector where
   id : String
+  op : String
+  height : Nat
+  suiteId : Nat
   expectOk : Bool
-def cvNativeRotationSunsetVectors : List CVNativeRotationSunsetVector := []
+  expectErr : Option String
+
+def cvNativeRotationSunsetVectors : List CVNativeRotationSunsetVector := [
+  { id := "NATIVE-ROT-SUNSET-01", op := "rotation_spend_suite_check", height := 399, suiteId := 1, expectOk := true, expectErr := none },
+  { id := "NATIVE-ROT-SUNSET-02", op := "rotation_spend_suite_check", height := 400, suiteId := 1, expectOk := true, expectErr := none },
+  { id := "NATIVE-ROT-SUNSET-03", op := "rotation_create_suite_check", height := 399, suiteId := 1, expectOk := true, expectErr := none },
+  { id := "NATIVE-ROT-SUNSET-04", op := "rotation_create_suite_check", height := 400, suiteId := 1, expectOk := false, expectErr := some "TX_ERR_SIG_ALG_INVALID" },
+  { id := "NATIVE-ROT-SUNSET-05", op := "rotation_create_suite_check", height := 999999, suiteId := 1, expectOk := true, expectErr := none }
+]
+
 end RubinFormal.Conformance


### PR DESCRIPTION
## Summary

Mirror sync: filled rotation Lean stubs with real vectors + structural checks.

Refs: rubin-formal#156

Consensus rules unchanged: YES
SECTION_HASHES.json unchanged: YES