### PR TITLE
tools: support allowlisted multi-source section hashes

### DIFF
--- a/rubin-formal/proof_coverage.json
+++ b/rubin-formal/proof_coverage.json
@@ -4,7 +4,7 @@
   "claim_level": "refined",
   "spec_source_file": "spec/RUBIN_L1_CANONICAL.md",
   "spec_section_hashes_file": "spec/SECTION_HASHES.json",
-  "spec_section_hashes_sha3_256": "e65824e8882c5c29b76430fe9783838caa0a4101f3874fffa028f60701b388c7",
+  "spec_section_hashes_sha3_256": "a63ae948ca8f710ff98d2203f8dff3319c4e90784e51404a7a3948677d81e1e1",
   "lean_toolchain_file": "rubin-formal/lean-toolchain",
   "refinement_bridge_file": "rubin-formal/refinement_bridge.json",
   "coverage": [

--- a/scripts/check-section-hashes.mjs
+++ b/scripts/check-section-hashes.mjs
@@ -98,7 +98,39 @@ if (!defaultSourceFile) {
   console.error("FAIL [meta] source_file missing in SECTION_HASHES.json");
   process.exit(1);
 }
-const sectionSources = expectedDoc.section_sources || {};
+const allowedSourceFiles = expectedDoc.allowed_source_files;
+if (
+  allowedSourceFiles !== undefined &&
+  (!Array.isArray(allowedSourceFiles) ||
+    allowedSourceFiles.some((value) => typeof value !== "string" || value.length === 0))
+) {
+  console.error("FAIL [meta] invalid allowed_source_files in SECTION_HASHES.json");
+  process.exit(1);
+}
+const allowedSourceSet = new Set(allowedSourceFiles || [defaultSourceFile]);
+if (!allowedSourceSet.has(defaultSourceFile)) {
+  console.error("FAIL [meta] source_file must be present in allowed_source_files");
+  process.exit(1);
+}
+const rawSectionSources = expectedDoc.section_sources;
+if (
+  rawSectionSources !== undefined &&
+  (rawSectionSources === null || Array.isArray(rawSectionSources) || typeof rawSectionSources !== "object")
+) {
+  console.error("FAIL [meta] invalid section_sources in SECTION_HASHES.json");
+  process.exit(1);
+}
+const sectionSources = rawSectionSources || {};
+for (const [key, srcRel] of Object.entries(sectionSources)) {
+  if (typeof srcRel !== "string" || srcRel.length === 0) {
+    console.error(`FAIL [meta] invalid section_sources value for ${key}`);
+    process.exit(1);
+  }
+  if (!allowedSourceSet.has(srcRel)) {
+    console.error(`FAIL [meta] section source for ${key} is not allowlisted: ${srcRel}`);
+    process.exit(1);
+  }
+}
 const sourceCache = new Map();
 
 function loadSource(srcRel) {

--- a/scripts/gen-section-hashes.mjs
+++ b/scripts/gen-section-hashes.mjs
@@ -11,6 +11,7 @@ const sectionSources = {
   replay_domain_checks: "spec/RUBIN_CONSENSUS_STATE_MACHINE.md",
   utxo_state_model: "spec/RUBIN_CONSENSUS_STATE_MACHINE.md",
 };
+const allowedSourceFiles = [defaultSourceFile, ...new Set(Object.values(sectionSources))];
 
 const sectionHeadings = {
   transaction_wire: "## 5. Transaction Wire",
@@ -72,6 +73,7 @@ const doc = {
   source_file: defaultSourceFile,
   canonicalization:
     "LF normalization; extract markdown from exact section heading to next heading of same/higher level; trim; append trailing LF",
+  allowed_source_files: allowedSourceFiles,
   section_sources: sectionSources,
   section_headings: sectionHeadings,
   sections: hashes,

--- a/tools/check_section_hashes.py
+++ b/tools/check_section_hashes.py
@@ -90,13 +90,42 @@ def main() -> int:
 
     headings = data.get("section_headings", {})
     expected = data.get("sections", {})
-    section_sources = data.get("section_sources", {})
+    allowed_source_files = data.get("allowed_source_files")
+    if allowed_source_files is None:
+        allowed_source_files = [default_src_rel]
+    if (
+        not isinstance(allowed_source_files, list)
+        or not allowed_source_files
+        or any(not isinstance(src, str) or not src.strip() for src in allowed_source_files)
+    ):
+        print("ERROR: invalid allowed_source_files in SECTION_HASHES.json", file=sys.stderr)
+        return 2
+    allowed_source_set = set(allowed_source_files)
+    if default_src_rel not in allowed_source_set:
+        print("ERROR: source_file must be present in allowed_source_files", file=sys.stderr)
+        return 2
+
+    raw_section_sources = data.get("section_sources")
+    if raw_section_sources is None:
+        section_sources = {}
+    else:
+        section_sources = raw_section_sources
     if not isinstance(headings, dict) or not isinstance(expected, dict):
         print("ERROR: invalid SECTION_HASHES.json structure", file=sys.stderr)
         return 2
-    if section_sources and not isinstance(section_sources, dict):
+    if not isinstance(section_sources, dict):
         print("ERROR: invalid section_sources in SECTION_HASHES.json", file=sys.stderr)
         return 2
+    for key, src_rel in section_sources.items():
+        if not isinstance(src_rel, str) or not src_rel.strip():
+            print(f"ERROR: invalid section_sources value for {key}", file=sys.stderr)
+            return 2
+        if src_rel not in allowed_source_set:
+            print(
+                f"ERROR: source_file not allowlisted for {key}: {src_rel}",
+                file=sys.stderr,
+            )
+            return 2
 
     source_cache: dict[str, str] = {
         default_src_rel: default_src_path.read_text(encoding="utf-8", errors="strict")


### PR DESCRIPTION
Summary:
- teach section-hash tooling to read per-section source overrides
- enforce explicit allowed_source_files for multi-source pinning
- sync mirrored proof_coverage.json to the new spec digest

Context:
- required downstream for rubin-spec state-machine extraction batch
- keeps spec-ci and formal-disposition gates aligned with standalone state-machine pinning

Refs:
- Q-SPEC-BOUNDARY-01
- Q-SPEC-CONSENSUS-STATE-MACHINE-01
- Q-SPEC-CONSENSUS-STATE-MACHINE-04