### PR TITLE
feat: reuse protocol pre-push receipts

### DIFF
--- a/tools/prepush_receipt.py
+++ b/tools/prepush_receipt.py
@@ -114,7 +114,12 @@ def check_receipt(repo_root: Path, *, base_ref: str) -> dict[str, object]:
         result["reason"] = "head-mismatch"
         result["current_head"] = head
         return result
-    merge_base = current_merge_base(repo_root, base_ref)
+    try:
+        merge_base = current_merge_base(repo_root, base_ref)
+    except RuntimeError as exc:
+        result["reason"] = "merge-base-unavailable"
+        result["merge_base_error"] = str(exc)
+        return result
     if str(payload.get("merge_base") or "") != merge_base:
         result["reason"] = "merge-base-mismatch"
         result["current_merge_base"] = merge_base

--- a/tools/tests/test_prepush_receipt.py
+++ b/tools/tests/test_prepush_receipt.py
@@ -93,6 +93,17 @@ class PrepushReceiptTests(unittest.TestCase):
             self.assertFalse(checked["fresh"])
             self.assertEqual(checked["reason"], "receipt-dirty-worktree")
 
+    def test_check_handles_missing_base_ref_as_stale(self):
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            self.init_repo(repo_root)
+            m.write_receipt(repo_root, base_ref="origin/main", source="test")
+            subprocess.run(["git", "update-ref", "-d", "refs/remotes/origin/main"], cwd=repo_root, check=True)
+            checked = m.check_receipt(repo_root, base_ref="origin/main")
+            self.assertFalse(checked["fresh"])
+            self.assertEqual(checked["reason"], "merge-base-unavailable")
+            self.assertIn("git merge-base", checked["merge_base_error"])
+
     def test_write_outputs_json_serializable_payload(self):
         with tempfile.TemporaryDirectory() as td:
             repo_root = Path(td)


### PR DESCRIPTION
## Summary
- add a local reusable pre-push receipt for rubin-protocol coverage preflight
- keep the receipt tied to the same clean HEAD and merge-base
- add unit coverage for fresh/stale receipt behavior

## Testing
- python3 -m unittest tools.tests.test_prepush_receipt
- python3 /Users/gpt/Documents/rubin-orchestration-private/inbox/operational/tools/run_pr_lifecycle.py pre-pr --target-repo rubin-protocol
- /Users/gpt/bin/cl push -u origin codex/q-orch-prepush-preflight-chain-01 (cache-hit verified)

## Queue
- Q-ORCH-PREPUSH-PREFLIGHT-CHAIN-01