### PR TITLE
fix: resolve protocol issues 787-790

### DIFF
--- a/clients/go/consensus/block_basic.go
+++ b/clients/go/consensus/block_basic.go
@@ -121,11 +121,32 @@ func ValidateBlockBasicWithContextAtHeight(
 	blockHeight uint64,
 	prevTimestamps []uint64,
 ) (*BlockBasicSummary, error) {
+	_, summary, err := parseAndValidateBlockBasicWithContextAtHeight(
+		blockBytes,
+		expectedPrevHash,
+		expectedTarget,
+		blockHeight,
+		prevTimestamps,
+	)
+	return summary, err
+}
+
+func parseAndValidateBlockBasicWithContextAtHeight(
+	blockBytes []byte,
+	expectedPrevHash *[32]byte,
+	expectedTarget *[32]byte,
+	blockHeight uint64,
+	prevTimestamps []uint64,
+) (*ParsedBlock, *BlockBasicSummary, error) {
 	pb, err := ParseBlockBytes(blockBytes)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return validateParsedBlockBasicWithContextAtHeight(pb, expectedPrevHash, expectedTarget, blockHeight, prevTimestamps)
+	summary, err := validateParsedBlockBasicWithContextAtHeight(pb, expectedPrevHash, expectedTarget, blockHeight, prevTimestamps)
+	if err != nil {
+		return nil, nil, err
+	}
+	return pb, summary, nil
 }
 
 func validateParsedBlockBasicWithContextAtHeight(
@@ -191,11 +212,13 @@ func ValidateBlockBasicWithContextAndFeesAtHeight(
 	alreadyGenerated uint64,
 	sumFees uint64,
 ) (*BlockBasicSummary, error) {
-	pb, err := ParseBlockBytes(blockBytes)
-	if err != nil {
-		return nil, err
-	}
-	s, err := validateParsedBlockBasicWithContextAtHeight(pb, expectedPrevHash, expectedTarget, blockHeight, prevTimestamps)
+	pb, s, err := parseAndValidateBlockBasicWithContextAtHeight(
+		blockBytes,
+		expectedPrevHash,
+		expectedTarget,
+		blockHeight,
+		prevTimestamps,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -257,6 +280,10 @@ func validateDASetIntegrity(txs []*Tx) error {
 		}
 	}
 
+	if len(commits) > MAX_DA_BATCHES_PER_BLOCK {
+		return txerr(BLOCK_ERR_DA_BATCH_EXCEEDED, "too many DA commits in block")
+	}
+
 	commitIDs := sortedDAIDs(commits)
 	chunkIDs := sortedDAIDs(chunks)
 
@@ -287,10 +314,6 @@ func validateDASetIntegrity(txs []*Tx) error {
 		}
 	}
 
-	if len(commits) > MAX_DA_BATCHES_PER_BLOCK {
-		return txerr(BLOCK_ERR_DA_BATCH_EXCEEDED, "too many DA commits in block")
-	}
-
 	for _, daID := range commitIDs {
 		commit := commits[daID]
 		set := chunks[daID]
@@ -307,9 +330,10 @@ func validateDASetIntegrity(txs []*Tx) error {
 				continue
 			}
 			daCommitOutputs++
-			if len(out.CovenantData) == 32 {
-				copy(gotCommitment[:], out.CovenantData)
+			if len(out.CovenantData) != 32 {
+				return txerr(BLOCK_ERR_DA_PAYLOAD_COMMIT_INVALID, "DA commitment output has invalid length")
 			}
+			copy(gotCommitment[:], out.CovenantData)
 		}
 		if daCommitOutputs != 1 {
 			return txerr(BLOCK_ERR_DA_PAYLOAD_COMMIT_INVALID, "DA commitment output missing or duplicated")
@@ -483,6 +507,9 @@ func txWeightAndStats(tx *Tx) (uint64, uint64, uint64, error) {
 			if len(w.Pubkey) == ML_DSA_87_PUBKEY_BYTES && len(w.Signature) == ML_DSA_87_SIG_BYTES+1 {
 				return VERIFY_COST_ML_DSA_87, nil
 			}
+			// Malformed native witness: zero sig_cost because witness bytes still
+			// contribute via wit_size and validation rejects on cheap length checks
+			// without invoking expensive crypto verification.
 			return 0, nil
 		default:
 			return VERIFY_COST_UNKNOWN_SUITE, nil
@@ -551,7 +578,8 @@ func txWeightAndStatsWithRegistry(tx *Tx, height uint64, rotation RotationProvid
 			if params, ok := registry.Lookup(w.SuiteID); ok {
 				// Native registered suite: use registry cost if lengths match,
 				// else zero (matches legacy — malformed native witness items
-				// are not counted as unknown suites).
+				// still pay through wit_size and fail on cheap length checks,
+				// so they are not charged as unknown suites).
 				if len(w.Pubkey) == params.PubkeyLen && len(w.Signature) == params.SigLen+1 {
 					return params.VerifyCost, nil
 				}

--- a/clients/go/consensus/block_basic_additional_test.go
+++ b/clients/go/consensus/block_basic_additional_test.go
@@ -133,6 +133,60 @@ func TestTxWeightAndStats_NonCanonicalWitnessLengths_NoSigCost(t *testing.T) {
 	}
 }
 
+func TestTxWeightAndStats_MalformedNativeWitness_ZeroSigCostIntentional(t *testing.T) {
+	malformedPub := make([]byte, ML_DSA_87_PUBKEY_BYTES-1)
+	malformedSig := make([]byte, ML_DSA_87_SIG_BYTES+1)
+
+	buildTx := func(suiteID uint8) *Tx {
+		return &Tx{
+			Version: 1,
+			TxKind:  0x00,
+			TxNonce: 9,
+			Inputs: []TxInput{
+				{Sequence: 0},
+			},
+			Outputs: []TxOutput{
+				{Value: 1, CovenantType: COV_TYPE_P2PK, CovenantData: validP2PKCovenantData()},
+			},
+			Locktime: 0,
+			Witness: []WitnessItem{
+				{SuiteID: suiteID, Pubkey: malformedPub, Signature: malformedSig},
+			},
+		}
+	}
+
+	malformedTx := buildTx(SUITE_ID_ML_DSA_87)
+	sentinelTx := buildTx(SUITE_ID_SENTINEL)
+
+	legacyWeight, _, _, err := TxWeightAndStats(malformedTx)
+	if err != nil {
+		t.Fatalf("TxWeightAndStats(malformed): %v", err)
+	}
+	sentinelWeight, _, _, err := TxWeightAndStats(sentinelTx)
+	if err != nil {
+		t.Fatalf("TxWeightAndStats(sentinel): %v", err)
+	}
+	if legacyWeight == 0 {
+		t.Fatalf("legacyWeight=0, want > 0 from witness bytes")
+	}
+	if legacyWeight != sentinelWeight {
+		t.Fatalf("legacyWeight=%d, want sentinelWeight=%d", legacyWeight, sentinelWeight)
+	}
+
+	registryWeight, _, _, err := TxWeightAndStatsAtHeight(
+		malformedTx,
+		0,
+		DefaultRotationProvider{},
+		DefaultSuiteRegistry(),
+	)
+	if err != nil {
+		t.Fatalf("TxWeightAndStatsAtHeight(malformed): %v", err)
+	}
+	if registryWeight != sentinelWeight {
+		t.Fatalf("registryWeight=%d, want sentinelWeight=%d", registryWeight, sentinelWeight)
+	}
+}
+
 func TestTxWeightAndStats_TxKind00_DAIgnoredForDaBytes(t *testing.T) {
 	tx := &Tx{
 		Version:  1,

--- a/clients/go/consensus/connect_block_inmem.go
+++ b/clients/go/consensus/connect_block_inmem.go
@@ -112,11 +112,13 @@ func ConnectBlockBasicInMemoryAtHeightAndCoreExtProfilesAndSuiteContext(
 	}
 
 	// Stateless checks first (wire, merkle root, PoW/target, covenant creation, etc).
-	if _, err := ValidateBlockBasicWithContextAtHeight(blockBytes, expectedPrevHash, expectedTarget, blockHeight, prevTimestamps); err != nil {
-		return nil, err
-	}
-
-	pb, err := ParseBlockBytes(blockBytes)
+	pb, _, err := parseAndValidateBlockBasicWithContextAtHeight(
+		blockBytes,
+		expectedPrevHash,
+		expectedTarget,
+		blockHeight,
+		prevTimestamps,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/clients/go/consensus/connect_block_inmem_test.go
+++ b/clients/go/consensus/connect_block_inmem_test.go
@@ -149,6 +149,39 @@ func TestConnectBlockBasicInMemoryAtHeight_NilState(t *testing.T) {
 	}
 }
 
+func TestParseAndValidateBlockBasicWithContextAtHeight_ReturnsParsedBlock(t *testing.T) {
+	height := uint64(0)
+	prev := hashWithPrefix(0x41)
+	target := filledHash(0xff)
+
+	coinbase := coinbaseWithWitnessCommitmentAtHeight(t, height)
+	cbTxid := testTxID(t, coinbase)
+	root, err := MerkleRootTxids([][32]byte{cbTxid})
+	if err != nil {
+		t.Fatalf("MerkleRootTxids: %v", err)
+	}
+	block := buildBlockBytes(t, prev, root, target, 5, [][]byte{coinbase})
+
+	pb, summary, err := parseAndValidateBlockBasicWithContextAtHeight(block, &prev, &target, height, nil)
+	if err != nil {
+		t.Fatalf("parseAndValidateBlockBasicWithContextAtHeight: %v", err)
+	}
+	if pb == nil || len(pb.Txs) != 1 || len(pb.Txids) != 1 {
+		t.Fatalf("unexpected parsed block shape: %#v", pb)
+	}
+	if pb.Txids[0] != cbTxid {
+		t.Fatalf("parsed txid mismatch")
+	}
+
+	want, err := ValidateBlockBasicWithContextAtHeight(block, &prev, &target, height, nil)
+	if err != nil {
+		t.Fatalf("ValidateBlockBasicWithContextAtHeight: %v", err)
+	}
+	if *summary != *want {
+		t.Fatalf("summary mismatch: got %#v want %#v", *summary, *want)
+	}
+}
+
 func TestConnectBlockBasicInMemoryAtHeight_Height0_DoesNotAdvanceAlreadyGenerated(t *testing.T) {
 	height := uint64(0)
 	prev := hashWithPrefix(0x12)

--- a/clients/go/consensus/da_rules_test.go
+++ b/clients/go/consensus/da_rules_test.go
@@ -269,6 +269,41 @@ func daCommitTxBytesDuplicateOutputs(txNonce uint64, daID [32]byte, chunkCount u
 	return b
 }
 
+func daCommitTxBytesWithOutputLen(txNonce uint64, daID [32]byte, chunkCount uint16, payloadCommitment []byte) []byte {
+	b := make([]byte, 0, 320)
+	b = AppendU32le(b, 1)
+	b = append(b, 0x01)
+	b = AppendU64le(b, txNonce)
+	b = AppendCompactSize(b, 1)
+	prevTxid := filled32(byte(txNonce))
+	b = append(b, prevTxid[:]...)
+	b = AppendU32le(b, 0)
+	b = AppendCompactSize(b, 0)
+	b = AppendU32le(b, 0)
+	b = AppendCompactSize(b, 1)
+	b = AppendU64le(b, 0)
+	b = AppendU16le(b, COV_TYPE_DA_COMMIT)
+	b = AppendCompactSize(b, uint64(len(payloadCommitment)))
+	b = append(b, payloadCommitment...)
+	b = AppendU32le(b, 0)
+	b = append(b, daID[:]...)
+	b = AppendU16le(b, chunkCount)
+	retlDomain := filled32(0x10)
+	b = append(b, retlDomain[:]...)
+	b = AppendU64le(b, 1)
+	txDataRoot := filled32(0x11)
+	b = append(b, txDataRoot[:]...)
+	stateRoot := filled32(0x12)
+	b = append(b, stateRoot[:]...)
+	withdrawalsRoot := filled32(0x13)
+	b = append(b, withdrawalsRoot[:]...)
+	b = append(b, 0x00)
+	b = AppendCompactSize(b, 0)
+	b = AppendCompactSize(b, 0)
+	b = AppendCompactSize(b, 0)
+	return b
+}
+
 func TestValidateBlockBasic_DA_DuplicateCommit(t *testing.T) {
 	daID := filled32(0xc1)
 	commitment := filled32(0xc2)
@@ -429,6 +464,50 @@ func TestValidateBlockBasic_DA_CommitOutputMissingOrDuplicated(t *testing.T) {
 			t.Fatalf("code=%s, want %s", got, BLOCK_ERR_DA_PAYLOAD_COMMIT_INVALID)
 		}
 	})
+
+	t.Run("invalid_length", func(t *testing.T) {
+		daID := filled32(0xcc)
+		payload := []byte("abc")
+		badCommitment := bytes.Repeat([]byte{0x44}, 31)
+
+		commit := daCommitTxBytesWithOutputLen(1, daID, 1, badCommitment)
+		chunk := daChunkTxBytes(2, daID, 0, sha3_256(payload), payload)
+		block, prev, target := buildDABlockBytes(t, commit, chunk)
+
+		_, err := ValidateBlockBasic(block, &prev, &target)
+		if err == nil {
+			t.Fatalf("expected error")
+		}
+		if got := mustTxErrCode(t, err); got != BLOCK_ERR_DA_PAYLOAD_COMMIT_INVALID {
+			t.Fatalf("code=%s, want %s", got, BLOCK_ERR_DA_PAYLOAD_COMMIT_INVALID)
+		}
+	})
+}
+
+func TestValidateBlockBasic_DA_BatchExceededPreemptsPayloadChecks(t *testing.T) {
+	txs := make([][]byte, 0, (MAX_DA_BATCHES_PER_BLOCK+1)*2)
+	for i := 0; i < MAX_DA_BATCHES_PER_BLOCK+1; i++ {
+		daID := filled32(byte(i))
+		payload := []byte{byte(i)}
+		chunk := daChunkTxBytes(uint64(10_000+i), daID, 0, sha3_256(payload), payload)
+		if i == 0 {
+			commit := daCommitTxBytesWithOutputLen(uint64(i+1), daID, 1, bytes.Repeat([]byte{0x77}, 31))
+			txs = append(txs, commit, chunk)
+			continue
+		}
+		commitment := sha3_256(payload)
+		commit := daCommitTxBytes(uint64(i+1), daID, 1, commitment)
+		txs = append(txs, commit, chunk)
+	}
+
+	block, prev, target := buildDABlockBytes(t, txs...)
+	_, err := ValidateBlockBasic(block, &prev, &target)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if got := mustTxErrCode(t, err); got != BLOCK_ERR_DA_BATCH_EXCEEDED {
+		t.Fatalf("code=%s, want %s", got, BLOCK_ERR_DA_BATCH_EXCEEDED)
+	}
 }
 
 func TestValidateBlockBasic_DA_CapsBeforeIntegrityChecks(t *testing.T) {

--- a/clients/go/consensus/da_verify_parallel.go
+++ b/clients/go/consensus/da_verify_parallel.go
@@ -98,8 +98,15 @@ func CollectDAChunkHashTasks(txs []*Tx) []DAChunkHashTask {
 // commitment verification tasks. Each task groups all chunks for a single
 // DA ID. Tasks are returned in deterministic order (sorted by DA ID).
 //
-// Precondition: structural validation (duplicate checks, chunk count) has
-// already been performed by the sequential validateDASetIntegrity phase.
+// Precondition: the caller has already enforced DA-set structural integrity
+// for every collected DA ID:
+//  1. no duplicate chunk index exists for the DA ID,
+//  2. len(chunks) == chunkCount for the DA commit,
+//  3. every chunk index in [0, chunkCount-1] is present.
+//
+// Snapshot import, fast-sync, or any other caller that bypasses the
+// sequential validateDASetIntegrity phase MUST re-enforce this contiguity
+// contract independently before calling this helper.
 func CollectDAPayloadCommitTasks(txs []*Tx) []DAPayloadCommitTask {
 	commits := make(map[[32]byte]*Tx)
 	chunks := make(map[[32]byte]map[uint16]*Tx)


### PR DESCRIPTION
## Summary

- strengthen the DA payload task precondition godoc for future non-sequential callers
- fail early on too many DA batches and reject malformed DA commitment output lengths explicitly
- remove the duplicate `ParseBlockBytes` pass from the in-memory connect path via parsed-block reuse
- document and test the intentional zero `sig_cost` behavior for malformed native witnesses

## Scope

- [ ] Documentation-only
- [x] Implementation-only change (no consensus change)
- [ ] Consensus-affecting change (requires explicit process)

**Consensus boundary (required):**

- Consensus rules unchanged: YES
- `SECTION_HASHES.json` unchanged: YES
- Wire format unchanged: YES

## Evidence / Gates

- CI links:
  - test: pending
  - coverage: pending
  - policy/validator: pending
- Conformance:
  - `run_cv_bundle.py`: not run; Go-only hardening/docs/tests with no fixture/spec changes
- Replay / determinism:
  - seq vs par equality (verdict/error/digests): not applicable to this batch

## Rollout / Flags (if applicable)

```text
pv-mode=off
pv-shadow-max=n/a
```

Refs: Q-IMPL-DA-BATCH-LIMIT-HARDENING-01

Related:
- Q-DOC-DA-PAYLOAD-PRECONDITION-01
- Q-IMPL-INMEM-PARSE-DEDUPE-01
- Q-DOC-ZERO-SIG-COST-INTENT-01
- closes #787
- closes #788
- closes #789
- closes #790
