### PR TITLE
[Q-FORMAL-PROOF-COVERAGE-SYNC-01] align proof coverage summary with TXCTX baseline

### DIFF
--- a/rubin-formal/PROOF_COVERAGE.md
+++ b/rubin-formal/PROOF_COVERAGE.md
@@ -1,29 +1,41 @@
-# Proof Coverage (bootstrap)
+# Proof Coverage (bootstrap summary)
 
 Источник: `spec/SECTION_HASHES.json`  
-Машинный реестр: `rubin-formal/proof_coverage.json`
+Authoritative machine-readable source: standalone `rubin-formal/proof_coverage.json`  
+In-repo summary: `rubin-protocol/rubin-formal/proof_coverage.json`
 
-Текущее состояние: pinned секции заведены со статусом `stated` в рамках `proof_level=byte-model`,
-а conformance-фикстуры `conformance/fixtures/CV-*.json` полностью покрыты Lean replay-слоем.
+Текущее состояние: authoritative standalone source-of-truth фиксирует `proof_level=refinement`,
+`claim_level=refined`, полный registry по 17 pinned section keys и явные `notes` / `limitations`
+для thin или partial entries. Файл в `rubin-protocol` — это summary subset для local CI/tooling;
+он не должен расходиться по top-level claim boundary и hash baseline, но может не содержать полный registry.
 
 ## Термины (важно)
 
-- `proof_level=byte-model` означает: в репо есть исполняемый (native_decide) Lean replay-слой,
-  который проверяет byte-level свойства на наборе conformance-векторов (CV-*.json).
+- `proof_level=refinement` означает: в репо есть исполняемый Lean replay-слой и trace-based
+  Go(reference) → Lean refinement checks для критических ops на conformance-наборе.
 - `claim_level` фиксирует допустимый публичный уровень заявлений:
   - `toy` (только model-baseline),
   - `byte` (byte-accurate слой),
   - `refined` (refinement to executable path).
 - `status=proved/stated/deferred` относится к конкретной pinned-секции **в рамках указанного `proof_level`**.
 
-Внешний аудит / freeze-ready коммуникации **НЕ ДОЛЖНЫ** трактовать `proof_level=byte-model`
-как “formal verification of CANONICAL”.
+Внешний аудит / freeze-ready коммуникации **НЕ ДОЛЖНЫ** трактовать `proof_level=refinement`
+как “formal verification of CANONICAL for all inputs/sections”.
+
+Связка с hash-pinning:
+
+- `spec/SECTION_HASHES.json` сейчас содержит 17 pinned section keys.
+- summary `proof_coverage.json` обязан совпадать с authoritative standalone файлом по
+  `proof_level`, `claim_level`, `spec_section_hashes_sha3_256` и по смысловой границе claims
+  для тех секций, которые он перечисляет.
+- Если standalone registry ослабляет секционный claim до `stated`, summary не имеет права
+  оставлять для той же секции более сильный статус.
 
 ## Путь к freeze-ready
 
-1. Углубить доказательства до байтовой эквивалентности формул из CANONICAL.
-2. Для consensus-critical safety-инвариантов добавить refinement-слой (model → executable path).
-3. Держать матрицу покрытия в синхроне с hash-pinning CANONICAL.
+1. Держать summary в синхроне с standalone `rubin-formal` реестром и с hash-pinning CANONICAL.
+2. Расширить protocol tooling так, чтобы summary всё меньше отличался от authoritative registry.
+3. Для consensus-critical safety-инвариантов добавлять более сильный beyond-fixtures proof surface.
 
 ## Risk scoring / gates
 

--- a/rubin-formal/README.md
+++ b/rubin-formal/README.md
@@ -10,11 +10,21 @@
 - воспроизводимый “пин” для replay/refinement поверх conformance fixtures,
 - удобная точка входа для разработчиков, но **не** как canonical formal SOT.
 
+Machine-readable summary contract:
+
+- `rubin-formal/proof_coverage.json` в standalone repo — authoritative source of truth;
+- `rubin-protocol/rubin-formal/proof_coverage.json` — documented in-repo summary subset для CI и
+  tooling в `rubin-protocol`;
+- summary MUST carry the same `proof_level`, `claim_level`, and `spec_section_hashes_sha3_256` as
+  authoritative standalone file, but MAY omit entries that the in-repo tooling does not model.
+
 ## Что есть сейчас
 
 - Lean4-пакет `RubinFormal`
-- `proof_coverage.json` с machine-readable coverage registry (текущая явная формальная матрица: 13 pinned section keys)
-- модельные теоремы (`status=proved`) для pinned секций в `RubinFormal/PinnedSections.lean`
+- `proof_coverage.json` с machine-readable summary registry для pinned section keys, которые
+  текущее protocol tooling реально моделирует
+- summary entries со статусами `proved` / `stated` и явными `notes` / `limitations`, если
+  authoritative standalone registry уже ограничивает claim scope
 
 ## Граница claims (критично)
 
@@ -34,7 +44,8 @@
 - "bit-exact wire/serialization proven"
 - "universal mechanized equivalence between spec text and Go/Rust implementations"
 
-Источник истины по границе claims — `rubin-formal/proof_coverage.json` (`proof_level`, `claims`).
+Источник истины по границе claims — standalone `rubin-formal/proof_coverage.json`.
+Summary в этом каталоге не является отдельным formal SOT и не должен overclaim-ить по отношению к standalone файлу.
 Дополнительно используется `claim_level` (`toy|byte|refined`) с CI-валидацией консистентности относительно `proof_level`.
 
 ## Risk model / CI gate
@@ -50,8 +61,10 @@
 
 - Это **не** полный freeze-ready пакет уровня "универсальная байтовая модель wire + state transition для всех секций".
 - Консенсусные правила не меняются.
-- Формальный coverage registry сейчас явно отражает 13 pinned section keys; остальные pinned keys
-  покрываются conformance/CI и должны коммуницироваться как такой coverage (без overclaim).
+- In-repo summary registry покрывает тот поднабор pinned section keys, который текущее tooling
+  `rubin-protocol` реально валидирует.
+- Если standalone `rubin-formal` усиливает или ослабляет claim boundary, summary обязан обновиться
+  так, чтобы не противоречить authoritative файлу.
 
 ## Локальный запуск
 
@@ -62,6 +75,6 @@ scripts/dev-env.sh -- bash -lc 'cd rubin-formal && lake build'
 
 ## Дальше
 
-1. Расширить формальный coverage registry с 13 до полного набора pinned section keys.
-2. Углубить универсальные теоремы beyond-fixtures поверх текущего refinement слоя.
-3. Поддерживать `proof_coverage.json` в синхроне со `spec/SECTION_HASHES.json` и narrative в `rubin-spec`.
+1. Держать summary `proof_coverage.json` в синхроне с authoritative standalone файлом по `proof_level`, `claim_level`, `spec_section_hashes_sha3_256` и смысловой границе claims.
+2. Расширить protocol tooling так, чтобы summary можно было сужать всё меньше, а не держать вечный split-brain.
+3. Углубить универсальные теоремы beyond-fixtures поверх текущего refinement слоя.

--- a/rubin-formal/proof_coverage.json
+++ b/rubin-formal/proof_coverage.json
@@ -4,7 +4,7 @@
   "claim_level": "refined",
   "spec_source_file": "spec/RUBIN_L1_CANONICAL.md",
   "spec_section_hashes_file": "spec/SECTION_HASHES.json",
-  "spec_section_hashes_sha3_256": "f442b73983a7e6e2769c3f6d6c2f4a302720be5b505be4f48bac47a38093d594",
+  "spec_section_hashes_sha3_256": "e6f6daf93926eb0fb4a1e7db68dff7803f0796cb8af70f03e9238398fcd3c602",
   "lean_toolchain_file": "rubin-formal/lean-toolchain",
   "refinement_bridge_file": "rubin-formal/refinement_bridge.json",
   "coverage": [
@@ -58,20 +58,30 @@
     {
       "section_key": "sighash_v1",
       "section_heading": "## 12. Sighash v1 (Normative)",
-      "status": "proved",
+      "status": "stated",
       "theorems": [
         "RubinFormal.Conformance.cv_sighash_vectors_pass"
       ],
-      "file": "rubin-formal/RubinFormal/PinnedSections.lean"
+      "file": "rubin-formal/RubinFormal/PinnedSections.lean",
+      "notes": "Protocol mirror summary: TXCTX broadens the pinned sighash surface through the TxContext-aware verify_sig_ext path and allowed_sighash_set policy. The section remains intentionally stated.",
+      "limitations": [
+        "This in-repo summary does not claim universal proof for the TXCTX-expanded sighash surface.",
+        "See standalone rubin-formal/proof_coverage.json for the authoritative detailed limitations."
+      ]
     },
     {
       "section_key": "consensus_error_codes",
       "section_heading": "## 13. Consensus Error Codes (Normative)",
-      "status": "proved",
+      "status": "stated",
       "theorems": [
         "RubinFormal.Conformance.cv_validation_order_vectors_pass"
       ],
-      "file": "rubin-formal/RubinFormal/PinnedSections.lean"
+      "file": "rubin-formal/RubinFormal/PinnedSections.lean",
+      "notes": "Protocol mirror summary: pre-existing validation-order evidence remains, but TXCTX adds new Section 13.1 source mappings and reject paths not yet fully covered by a dedicated formal theorem.",
+      "limitations": [
+        "This in-repo summary does not claim formal closure for the new TXCTX-specific Section 13.1 mappings.",
+        "See standalone rubin-formal/proof_coverage.json for the authoritative claim boundary."
+      ]
     },
     {
       "section_key": "covenant_registry",
@@ -112,11 +122,16 @@
     {
       "section_key": "utxo_state_model",
       "section_heading": "## 2. UTXO State Model (Normative)",
-      "status": "proved",
+      "status": "stated",
       "theorems": [
         "RubinFormal.Conformance.cv_utxo_basic_vectors_pass"
       ],
-      "file": "rubin-formal/RubinFormal/PinnedSections.lean"
+      "file": "rubin-formal/RubinFormal/PinnedSections.lean",
+      "notes": "Protocol mirror summary: legacy UTXO/value/vault replay coverage remains intact, but the pinned section now also includes TXCTX step 3c semantics that are not yet formally closed.",
+      "limitations": [
+        "This in-repo summary does not claim formal closure for SpendTx step 3c TxContext construction.",
+        "The authoritative detailed limitations live in standalone rubin-formal/proof_coverage.json."
+      ]
     },
     {
       "section_key": "coinbase_and_subsidy",


### PR DESCRIPTION
## Summary
- align the in-repo proof coverage summary with the TXCTX section-hash baseline
- document that `rubin-protocol/rubin-formal/proof_coverage.json` is a tooling-facing summary subset
- keep overlapping section claims conservative until the TXCTX formal batch lands

## Why
`rubin-spec` CI validates `spec/SECTION_HASHES.json` against the protocol-side proof coverage summary on `main`. The TXCTX spec amendments need the protocol summary updated first so the spec PR can verify against the new baseline without overclaiming coverage.

## Validation
- `python3 tools/check_formal_claims_lint.py`
- `python3 tools/check_formal_coverage.py`
- `python3 tools/check_formal_refinement_bridge.py`
- `python3 /Users/gpt/Documents/rubin-orchestration-private/inbox/operational/tools/run_pr_lifecycle.py pre-pr --target-repo rubin-protocol`

## Queue
- Q-FORMAL-PROOF-COVERAGE-SYNC-01
- Q-SPEC-TXCTX-CANONICAL-AMEND-01
- Q-SPEC-TXCTX-HASHES-PINS-01
