### PR TITLE
fix: overflow-safe coinbase maturity check (Go + Rust)

### DIFF
--- a/clients/go/consensus/utxo_basic.go
+++ b/clients/go/consensus/utxo_basic.go
@@ -213,7 +213,8 @@ func applyNonCoinbaseTxBasicWork(
 			return nil, 0, txerr(TX_ERR_MISSING_UTXO, "attempt to spend non-spendable covenant")
 		}
 
-		if entry.CreatedByCoinbase && height < entry.CreationHeight+COINBASE_MATURITY {
+		// Overflow-safe maturity check: avoid entry.CreationHeight+COINBASE_MATURITY wrapping.
+		if entry.CreatedByCoinbase && (height < entry.CreationHeight || height-entry.CreationHeight < COINBASE_MATURITY) {
 			return nil, 0, txerr(TX_ERR_COINBASE_IMMATURE, "coinbase immature")
 		}
 

--- a/clients/go/consensus/utxo_basic_test.go
+++ b/clients/go/consensus/utxo_basic_test.go
@@ -157,6 +157,39 @@ func TestApplyNonCoinbaseTxBasicUpdate_RejectsImmatureCoinbaseSpend(t *testing.T
 	}
 }
 
+func TestApplyNonCoinbaseTxBasicUpdate_RejectsImmatureCoinbaseSpend_OverflowSafe(t *testing.T) {
+	// Regression: creation_height near MaxUint64 must not wrap around and
+	// falsely pass the maturity check. The overflow-safe form uses
+	// subtraction instead of addition.
+	var prev [32]byte
+	prev[0] = 0xc2
+
+	txBytes := txWithOneInputOneOutput(prev, 0, 90, COV_TYPE_P2PK, validP2PKCovenantData())
+	tx, txid := mustParseTxForUtxo(t, txBytes)
+
+	const nearMax uint64 = ^uint64(0) - 10 // MaxUint64 - 10
+	utxos := map[Outpoint]UtxoEntry{
+		{Txid: prev, Vout: 0}: {
+			Value:             100,
+			CovenantType:      COV_TYPE_P2PK,
+			CovenantData:      validP2PKCovenantData(),
+			CreationHeight:    nearMax,
+			CreatedByCoinbase: true,
+		},
+	}
+
+	// height = nearMax + 5: maturity gap is only 5, well below COINBASE_MATURITY.
+	// With the old overflow-prone check (height < creation+MATURITY), the
+	// addition would wrap and the check would incorrectly pass.
+	_, _, err := ApplyNonCoinbaseTxBasicUpdate(tx, txid, utxos, nearMax+5, 0, [32]byte{})
+	if err == nil {
+		t.Fatalf("expected TX_ERR_COINBASE_IMMATURE for overflow-edge case")
+	}
+	if got := mustTxErrCode(t, err); got != TX_ERR_COINBASE_IMMATURE {
+		t.Fatalf("code=%s, want %s", got, TX_ERR_COINBASE_IMMATURE)
+	}
+}
+
 func TestApplyNonCoinbaseTxBasic_InputValidationErrors(t *testing.T) {
 	cases := []struct {
 		utxosFn   func(prev [32]byte) map[Outpoint]UtxoEntry

--- a/clients/rust/crates/rubin-consensus/src/tests/utxo_apply.rs
+++ b/clients/rust/crates/rubin-consensus/src/tests/utxo_apply.rs
@@ -1454,3 +1454,38 @@ fn sentinel_keyless_enforcement() {
         .expect_err("should reject sentinel with pubkey+sig");
     assert_eq!(err.code, ErrorCode::TxErrParse);
 }
+
+#[test]
+fn apply_non_coinbase_tx_basic_coinbase_maturity_overflow_safe() {
+    // Regression: creation_height near u64::MAX must not wrap around and
+    // falsely pass the maturity check. The overflow-safe form uses
+    // subtraction instead of addition.
+    let mut prev = [0u8; 32];
+    prev[0] = 0xc2;
+    let tx_bytes =
+        tx_with_one_input_one_output(prev, 0, 90, COV_TYPE_P2PK, &valid_p2pk_covenant_data());
+    let (tx, txid, _wtxid, _n) = parse_tx(&tx_bytes).expect("parse");
+
+    let near_max: u64 = u64::MAX - 10;
+    let mut utxos: HashMap<Outpoint, UtxoEntry> = HashMap::new();
+    utxos.insert(
+        Outpoint {
+            txid: prev,
+            vout: 0,
+        },
+        UtxoEntry {
+            value: 100,
+            covenant_type: COV_TYPE_P2PK,
+            covenant_data: valid_p2pk_covenant_data(),
+            creation_height: near_max,
+            created_by_coinbase: true,
+        },
+    );
+
+    // height = near_max + 5: maturity gap is only 5, well below COINBASE_MATURITY.
+    // With the old overflow-prone check (height < creation+MATURITY), the
+    // addition would wrap and the check would incorrectly pass.
+    let err = apply_non_coinbase_tx_basic(&tx, txid, &utxos, near_max + 5, 1000, ZERO_CHAIN_ID)
+        .unwrap_err();
+    assert_eq!(err.code, ErrorCode::TxErrCoinbaseImmature);
+}

--- a/clients/rust/crates/rubin-consensus/src/utxo_basic.rs
+++ b/clients/rust/crates/rubin-consensus/src/utxo_basic.rs
@@ -204,7 +204,11 @@ pub fn apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles_and_sui
             ));
         }
 
-        if entry.created_by_coinbase && height < entry.creation_height + COINBASE_MATURITY {
+        // Overflow-safe maturity check: avoid entry.creation_height + COINBASE_MATURITY wrapping.
+        if entry.created_by_coinbase
+            && (height < entry.creation_height
+                || height - entry.creation_height < COINBASE_MATURITY)
+        {
             return Err(TxError::new(
                 ErrorCode::TxErrCoinbaseImmature,
                 "coinbase immature",


### PR DESCRIPTION
## Summary
- Replace overflow-prone `height < creation_height + COINBASE_MATURITY` with safe subtraction form in both Go and Rust sequential paths
- Aligns sequential path with the already-safe parallel IBD path
- Adds regression tests with `creation_height = u64::MAX - 10`

## Changes
- `clients/go/consensus/utxo_basic.go:216` — overflow-safe form
- `clients/rust/crates/rubin-consensus/src/utxo_basic.rs:207` — overflow-safe form
- Go test: `TestApplyNonCoinbaseTxBasicUpdate_RejectsImmatureCoinbaseSpend_OverflowSafe`
- Rust test: `apply_non_coinbase_tx_basic_coinbase_maturity_overflow_safe`

## Test plan
- [x] Go test PASS
- [x] Rust test PASS
- [x] Local security review PASS

Closes #771
Refs: Q-IMPL-COINBASE-MATURITY-OVERFLOW-01