### PR TITLE
fix: reject malformed ML-DSA lengths before OpenSSL init

### DIFF
--- a/clients/rust/crates/rubin-consensus/src/tests/block_basic.rs
+++ b/clients/rust/crates/rubin-consensus/src/tests/block_basic.rs
@@ -629,6 +629,21 @@ fn verify_sig_rejects_wrong_mldsa_lengths_before_openssl() {
 }
 
 #[test]
+fn verify_sig_with_registry_rejects_wrong_mldsa_lengths_before_openssl() {
+    let digest = [0u8; 32];
+    let registry = crate::suite_registry::SuiteRegistry::default_registry();
+    let ok = crate::verify_sig_openssl::verify_sig_with_registry(
+        SUITE_ID_ML_DSA_87,
+        &vec![0u8; (ML_DSA_87_PUBKEY_BYTES as usize) - 1],
+        &vec![0u8; ML_DSA_87_SIG_BYTES as usize],
+        &digest,
+        Some(&registry),
+    )
+    .expect("verify_sig_with_registry should not return transport error for length mismatch");
+    assert!(!ok);
+}
+
+#[test]
 fn verify_sig_unsupported_suite_rejected_sig_alg_invalid() {
     let digest = [0u8; 32];
     let err = crate::verify_sig_openssl::verify_sig(0x02, &[0x01], &[0x02], &digest).unwrap_err();

--- a/clients/rust/crates/rubin-consensus/src/verify_sig_openssl.rs
+++ b/clients/rust/crates/rubin-consensus/src/verify_sig_openssl.rs
@@ -414,13 +414,14 @@ pub fn verify_sig(
     }
 
     let alg = suite_alg_name(suite_id)?;
-    ensure_openssl_consensus_init()?;
 
     if pubkey.len() != ML_DSA_87_PUBKEY_BYTES as usize
         || signature.len() != ML_DSA_87_SIG_BYTES as usize
     {
         return Ok(false);
     }
+
+    ensure_openssl_consensus_init()?;
 
     openssl_verify_sig_digest_oneshot(alg, pubkey, signature, digest32)
 }
@@ -446,11 +447,11 @@ pub fn verify_sig_with_registry(
         ));
     };
 
-    ensure_openssl_consensus_init()?;
-
     if pubkey.len() as u64 != params.pubkey_len || signature.len() as u64 != params.sig_len {
         return Ok(false);
     }
+
+    ensure_openssl_consensus_init()?;
 
     // Convert the static str to CStr for OpenSSL.
     let alg = match params.openssl_alg {


### PR DESCRIPTION
Refs: Q-IMPL-RUST-VERIFY-SIG-LENGTH-GATE-01
Closes #835

## Summary
- move Rust ML-DSA length rejection ahead of OpenSSL consensus bootstrap in `verify_sig`
- apply the same ordering to `verify_sig_with_registry` so registry-aware native verification stays environment-independent for malformed lengths
- add regression coverage for the direct and registry-aware malformed-length paths

## Scope
- Rust consensus path only
- no spec, formal, fixture, or activation semantics change
- preserve unsupported-suite rejection as `TxErrSigAlgInvalid`

Consensus rules unchanged: YES
`SECTION_HASHES.json` unchanged: YES