### PR TITLE
fix(rust-p2p): enforce global orphan block memory cap across peer sessions

### DIFF
--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -1401,6 +1401,7 @@ mod tests {
     use std::net::{TcpListener, TcpStream};
     use std::path::PathBuf;
     use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::Mutex;
     use std::thread;
     use std::time::Duration;
 
@@ -1417,6 +1418,8 @@ mod tests {
         BLOCK_HEADER_BYTES,
     };
     use serde::Deserialize;
+
+    static ORPHAN_POOL_TEST_LOCK: Mutex<()> = Mutex::new(());
 
     static NEXT_TEST_ROOT_ID: AtomicU64 = AtomicU64::new(1);
 
@@ -2087,6 +2090,7 @@ mod tests {
 
     #[test]
     fn orphan_pool_replaces_local_oldest_when_global_limit_reached() {
+        let _guard = ORPHAN_POOL_TEST_LOCK.lock().expect("lock orphan tests");
         GLOBAL_ORPHAN_TOTAL_BYTES.store(0, Ordering::SeqCst);
         GLOBAL_ORPHAN_BYTE_LIMIT_OVERRIDE.store(1024, Ordering::SeqCst);
 
@@ -2115,6 +2119,7 @@ mod tests {
 
     #[test]
     fn orphan_pool_enforces_global_byte_limit_across_sessions() {
+        let _guard = ORPHAN_POOL_TEST_LOCK.lock().expect("lock orphan tests");
         GLOBAL_ORPHAN_TOTAL_BYTES.store(0, Ordering::SeqCst);
         GLOBAL_ORPHAN_BYTE_LIMIT_OVERRIDE.store(1024, Ordering::SeqCst);
 


### PR DESCRIPTION
### Motivation
- The runtime previously allocated an independent orphan block byte pool per `PeerSession` (default 64 MiB), which allows memory usage to scale linearly with the number of peers and enables remote OOM attacks. 
- A single peer swarm can therefore exhaust node RAM by sending large orphan blocks to many sessions, causing availability loss. 

### Description
- Introduce a global orphan-byte budget constant `DEFAULT_GLOBAL_ORPHAN_BYTE_LIMIT` and an atomic counter `GLOBAL_ORPHAN_TOTAL_BYTES` to account for retained orphan bytes across all sessions. 
- Modify `OrphanBlockPool::add` to take a `global_byte_limit` argument and atomically reserve bytes from the global budget before cloning `block_bytes`, returning early if the global budget would be exceeded. 
- Decrement the global counter when orphan bytes are removed (in `take_children`, `evict_oldest`) and on pool drop via an `impl Drop for OrphanBlockPool`. 
- Wire calls that retain or re-enqueue orphans (`retain_or_resolve_orphan` and the requeue path in `resolve_orphans`) to pass `global_orphan_byte_limit()` so the global cap is enforced; preserve per-session `limit` and `byte_limit` logic. 
- Add a focused unit test `orphan_pool_enforces_global_byte_limit_across_sessions` demonstrating that one pool can consume the global budget and a second pool is then prevented from admitting more orphan bytes. 

### Testing
- Ran `cargo test -p rubin-node orphan_pool_enforces_global_byte_limit_across_sessions -- --nocapture` and the test passed. 
- Ran `cargo test -p rubin-node handle_block_retains_orphan_until_parent_arrives -- --nocapture` and the existing behavior remained correct (test passed). 
- Ran `cargo fmt` to format the modified file successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b41533d5888322b642ea41299733ba)