### PR TITLE
fix: skip sentinel cost in rotation-aware tx weight

### DIFF
--- a/clients/rust/crates/rubin-consensus/src/block_basic.rs
+++ b/clients/rust/crates/rubin-consensus/src/block_basic.rs
@@ -510,6 +510,9 @@ pub fn tx_weight_and_stats_at_height(
     let native_spend = rotation.native_spend_suites(height);
 
     tx_weight_components(tx, |w| {
+        if w.suite_id == SUITE_ID_SENTINEL {
+            return Ok(0);
+        }
         if native_spend.contains(w.suite_id) {
             if let Some(params) = registry.lookup(w.suite_id) {
                 if w.pubkey.len() as u64 == params.pubkey_len

--- a/clients/rust/crates/rubin-consensus/src/tests/block_basic.rs
+++ b/clients/rust/crates/rubin-consensus/src/tests/block_basic.rs
@@ -770,6 +770,33 @@ fn tx_weight_at_height_with_registry_known_suite() {
 }
 
 #[test]
+fn tx_weight_at_height_sentinel_has_no_cost() {
+    use crate::suite_registry::{DefaultRotationProvider, SuiteRegistry};
+
+    let mut tx_bytes = Vec::new();
+    tx_bytes.extend_from_slice(&1u32.to_le_bytes()); // version
+    tx_bytes.push(0x00); // tx_kind
+    tx_bytes.extend_from_slice(&0u64.to_le_bytes()); // tx_nonce
+    crate::compactsize::encode_compact_size(0, &mut tx_bytes); // inputs
+    crate::compactsize::encode_compact_size(0, &mut tx_bytes); // outputs
+    tx_bytes.extend_from_slice(&0u32.to_le_bytes()); // locktime
+    crate::compactsize::encode_compact_size(1, &mut tx_bytes); // 1 witness item
+    tx_bytes.push(SUITE_ID_SENTINEL);
+    crate::compactsize::encode_compact_size(0, &mut tx_bytes); // pubkey len
+    crate::compactsize::encode_compact_size(0, &mut tx_bytes); // sig len
+    crate::compactsize::encode_compact_size(0, &mut tx_bytes); // da_payload
+
+    let (tx, _, _, _) = parse_tx(&tx_bytes).expect("parse");
+    let rp = DefaultRotationProvider;
+    let reg = SuiteRegistry::default_registry();
+    let (w_reg, _, _) =
+        crate::block_basic::tx_weight_and_stats_at_height(&tx, 0, Some(&rp), Some(&reg))
+            .expect("at_height");
+    let (w_legacy, _, _) = crate::block_basic::tx_weight_and_stats_public(&tx).expect("legacy");
+    assert_eq!(w_reg, w_legacy);
+}
+
+#[test]
 fn tx_weight_at_height_unknown_suite_uses_floor() {
     use crate::suite_registry::{DefaultRotationProvider, SuiteRegistry};
 


### PR DESCRIPTION
### Motivation
- Rotation-aware weight calculation charged `SUITE_ID_SENTINEL` witness items as unknown suites, inflating transaction weights and creating a parity/consensus divergence vs Go and the formal model. 
- The goal is to restore parity with the Go reference and Lean spec by ensuring sentinel witness items are treated as zero-cost in the registry/rotation-aware path.

### Description
- Add an early `SUITE_ID_SENTINEL` check in `tx_weight_and_stats_at_height` to return `Ok(0)` before native-suite/registry handling, ensuring sentinel items are not charged `VERIFY_COST_UNKNOWN_SUITE` (`clients/rust/crates/rubin-consensus/src/block_basic.rs`).
- Add a regression unit test `tx_weight_at_height_sentinel_has_no_cost` that constructs a tx with a sentinel witness and asserts rotation-aware weight equals legacy weight (`clients/rust/crates/rubin-consensus/src/tests/block_basic.rs`).
- Minimal change restricted to Rust consensus crate; behavior now matches existing Go implementation and the Lean weight model without changing semantics for non-sentinel suites.

### Testing
- Ran `cargo fmt --all` in the Rust workspace and it completed successfully.
- Ran `cargo test -p rubin-consensus tx_weight_at_height_sentinel_has_no_cost` and the new test passed (1 passed; 0 failed).
- Ran `cargo clippy -p rubin-consensus -- -D warnings` in the crate and it completed without warnings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba07412c5c83229c7c2eeb36e65d99)