### PR TITLE
build(deps): bump anchore/sbom-action from 0.23.1 to 0.24.0

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           egress-policy: audit
       - name: Generate SBOM
-        uses: anchore/sbom-action@57aae528053a48a3f6235f2d9461b05fbcb7366d # v0.23.1
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           format: spdx-json
           artifact-name: rubin-protocol-sbom.spdx.json


### PR DESCRIPTION
Replacement for closed #845 after the workflow-only ruleset blocker was removed and the original Dependabot source branch had already been deleted.\n\nScope: exact one-line SHA bump in .github/workflows/sbom.yml only.\n\nTesting:\n- git diff --check\n- /Users/gpt/bin/cl push -u origin codex/dependabot-845-recreate