### PR TITLE
ci: raise claude review max turns

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -31,7 +31,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
             --model claude-opus-4-6
-            --max-turns 18
+            --max-turns 64
           prompt: |
             You are the first-pass consensus/code reviewer for RUBIN.
 


### PR DESCRIPTION
## Summary
- raise the advisory Claude review turn cap in rubin-protocol
- keep the existing v1/Opus 4.6 configuration path unchanged
- preempt the same max-turn exhaustion seen in the formal workflow

## Testing
- python3 - <<'PY'\nimport yaml, pathlib\npath = pathlib.Path(".github/workflows/claude-review.yml")\nyaml.safe_load(path.read_text())\nprint("YAML OK")\nPY\n- git diff --check\n- /Users/gpt/bin/cl push -u origin codex/q-ci-claude-review-max-turns-protocol\n\nQ-ID: Q-CI-CLAUDE-REVIEW-V1-OPUS46-CROSSREPO-01