### PR TITLE
ci: show Claude review report summary

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -32,6 +32,7 @@ jobs:
           claude_args: |
             --model claude-opus-4-6
             --max-turns 64
+          display_report: true
           prompt: |
             You are the first-pass consensus/code reviewer for RUBIN.
 


### PR DESCRIPTION
## Summary\n- enable Claude action report display in the protocol review workflow\n- keep the existing Opus 4.6 model selection, turn cap, prompt, and action pin unchanged\n- make successful no-inline-finding runs leave visible step-summary evidence\n\n## Testing\n- YAML parse\n- minimal diff review\n- sanctioned local pre-push review via cl push\n\nRefs: Q-CI-CLAUDE-REVIEW-REPORT-VISIBILITY-01