### PR TITLE
ci: upgrade to DeepSeek-R1-0528 with hostile security reviewer

### DIFF
--- a/.github/workflows/models-security-review.yml
+++ b/.github/workflows/models-security-review.yml
@@ -36,7 +36,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
       - name: Upload diff artifact
         if: steps.diff.outputs.skip != 'true'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
           name: pr-diff
           path: pr-diff.txt
@@ -49,43 +49,84 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
       - name: Download diff artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v4
         with:
           name: pr-diff
       - name: Install jsonrepair
         run: npm install jsonrepair@3.12.0
+
       - name: Run security review
         id: review
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v7
         with:
           script: |
             const fs = require('fs');
             const { jsonrepair } = require('./node_modules/jsonrepair');
             const diff = fs.readFileSync('pr-diff.txt', 'utf8').slice(0, 12000);
+
             const systemPrompt = [
-              'You are the main protocol security reviewer for the RUBIN protocol. Context:',
+              'You are a HOSTILE protocol security auditor for the RUBIN blockchain protocol.',
+              'Your job is NOT to help the author — it is to BREAK their code and find every exploitable flaw.',
+              '',
+              'PROTOCOL CONTEXT:',
               '- Bitcoin-like UTXO chain with dual reference clients (Go + Rust) and Lean4 formal verification',
-              '- Cryptography: ML-DSA-87 (native signature scheme)',
-              '- Covenant-typed covenant system (P2PK, HTLC, anchor, DA-commit, CORE_EXT, vault, multisig)',
+              '- Cryptography: ML-DSA-87 (FIPS 204) as native signature scheme, post-quantum',
+              '- Covenant-typed system: P2PK, HTLC, anchor, DA-commit, CORE_EXT, vault, multisig',
               '- Soft-fork deployment mechanism for protocol upgrades',
               '- Canonical chain: RUBIN_L1_CANONICAL.md -> fixtures -> Go -> Rust -> conformance tests',
-              'Review the diff for security issues, ordered by severity:',
-              'CRITICAL: double-spend, inflation, signature bypass, fork-choice errors, reorg safety failures',
-              'HIGH: nonce reuse, weak entropy, PQ parameter misuse, hash collision paths',
-              'MEDIUM: integer overflow/underflow, slice bounds, unchecked casts, panic paths in consensus',
-              'LOW: incorrect state transitions, disconnect/reconnect correctness, undo record integrity',
-              'INFO: behavioral divergence causing chain splits, spec/code/fixture drift',
-              'PERF: unbounded allocations, CPU-intensive hot paths, disk exhaustion paths',
-              'Rules:',
-              '- Review only what is visible in the provided diff bundle.',
-              '- Do not invent files, lines, or behavior not evidenced by the diff.',
-              '- If no findings, return empty findings array and explain why in summary.',
-              '- Output ONLY valid JSON. No markdown, no commentary, no trailing commas.',
-              '- Schema: {"model":"string","findings":[{"severity":"string","file":"string","line":0,"title":"string","details":"string","suggestion":"string"}],"summary":"string"}',
+              '- Consensus-critical code: ANY divergence between Go and Rust = chain split = CRITICAL',
+              '',
+              'SEVERITY CLASSIFICATION:',
+              'CRITICAL: double-spend, inflation bug, signature bypass, fork-choice error, reorg safety failure,',
+              '  consensus divergence between Go/Rust clients, covenant type confusion allowing unauthorized spend',
+              'HIGH: nonce reuse, weak entropy, PQ parameter misuse (ML-DSA wrong security level),',
+              '  hash collision paths, missing signature validation on any code path',
+              'MEDIUM: integer overflow/underflow, slice bounds, unchecked casts, panic in consensus path,',
+              '  missing error propagation that silently accepts invalid state',
+              'LOW: incorrect state transitions, disconnect/reconnect bugs, undo record integrity,',
+              '  non-canonical serialization that could cause hash mismatch',
+              'INFO: spec/code/fixture drift, behavioral divergence risk, missing test coverage for edge cases',
+              'PERF: unbounded allocations, O(n^2) in hot paths, disk exhaustion, memory exhaustion under load',
+              '',
+              'HOSTILE REVIEW RULES:',
+              '- Assume every change is guilty until proven safe.',
+              '- Check EVERY arithmetic operation for overflow/underflow.',
+              '- Check EVERY slice/array access for bounds.',
+              '- Check EVERY type cast for truncation or sign errors.',
+              '- Check EVERY error path: does it fail-closed or fail-open?',
+              '- If Go code changed: would the same logic in Rust produce identical results? Flag if uncertain.',
+              '- If Rust code changed: would the same logic in Go produce identical results? Flag if uncertain.',
+              '- If cryptographic code changed: verify parameter sizes, check for timing side-channels.',
+              '- NEVER say "looks good" or "no issues found" if you have not verified every line.',
+              '- If the diff is too large to fully verify, say so explicitly and flag unreviewed sections.',
+              '',
+              'OUTPUT FORMAT — strict JSON only, no markdown, no commentary:',
+              '{',
+              '  "model": "deepseek/DeepSeek-R1-0528",',
+              '  "verdict": "BLOCK" | "WARN" | "PASS",',
+              '  "findings": [{',
+              '    "severity": "CRITICAL|HIGH|MEDIUM|LOW|INFO|PERF",',
+              '    "file": "path/to/file",',
+              '    "line": 0,',
+              '    "title": "short title",',
+              '    "details": "what is wrong and why it is exploitable",',
+              '    "suggestion": "concrete fix"',
+              '  }],',
+              '  "unreviewed_sections": ["list files/ranges not fully checked"],',
+              '  "summary": "one paragraph hostile summary"',
+              '}',
+              '',
+              'VERDICT RULES:',
+              '- BLOCK if any CRITICAL or HIGH finding exists.',
+              '- WARN if any MEDIUM finding exists.',
+              '- PASS only if all findings are LOW/INFO/PERF or no findings.',
+              '- If diff is too large to fully review, verdict MUST be WARN with explanation.',
             ].join('\n');
-            const modelId = 'deepseek/DeepSeek-V3-0324';
+
+            const modelId = 'deepseek/DeepSeek-R1-0528';
             let rawContent = '';
             let result = null;
+
             try {
               core.info(`Trying model: ${modelId}`);
               const response = await fetch(
@@ -100,18 +141,20 @@ jobs:
                     model: modelId,
                     messages: [
                       { role: 'system', content: systemPrompt },
-                      { role: 'user', content: `Review this PR diff:\n\n${diff}` }
+                      { role: 'user', content: `Review this PR diff for security vulnerabilities. Be hostile — assume every change is a potential exploit vector:\n\n${diff}` }
                     ],
-                    temperature: 0.2,
-                    response_format: { type: 'json_object' }
+                    temperature: 0.6,
+                    top_p: 0.95
                   })
                 }
               );
+
               if (!response.ok) {
                 const body = await response.text();
                 core.setFailed(`Security review fail-closed: model ${modelId} returned ${response.status}: ${body.slice(0, 200)}`);
                 return;
               }
+
               const data = await response.json();
               if (!data.choices || !data.choices[0] || !data.choices[0].message) {
                 core.setFailed(`Security review fail-closed: model ${modelId} returned unexpected structure: ${JSON.stringify(data).slice(0, 200)}`);
@@ -123,6 +166,9 @@ jobs:
               core.setFailed(`Security review fail-closed: model ${modelId} error: ${err.message}`);
               return;
             }
+
+            // Strip R1 <think> reasoning blocks
+            result = result.replace(/<think>[\s\S]*?<\/think>/g, '').trim();
 
             // Strip markdown fences if present: find first '{' and last '}'
             result = result.replace(/^[\s\S]*?(?=\{)/, '').replace(/\}(?![\s\S]*\})[\s\S]*$/, '}').trim();
@@ -141,32 +187,40 @@ jobs:
                 return;
               }
             }
+
             core.setOutput('review', result);
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Upload raw review output
         if: always() && hashFiles('raw-review-output.txt') != ''
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
           name: raw-review-output
           path: raw-review-output.txt
           retention-days: 3
+
       - name: Post review comment
         if: steps.review.outputs.review
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v7
         with:
           script: |
             const review = ${{ toJSON(steps.review.outputs.review) }};
             if (!review) return;
+            let parsed;
+            try { parsed = JSON.parse(review); } catch(e) { parsed = null; }
+            const verdict = parsed && parsed.verdict ? parsed.verdict : 'UNKNOWN';
+            const emoji = verdict === 'PASS' ? '\u2705' : verdict === 'WARN' ? '\u26a0\ufe0f' : '\ud83d\uded1';
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: `### Security Review: deepseek-v3\n_Model: deepseek/DeepSeek-V3-0324_\n\n\`\`\`json\n${review}\n\`\`\``
+              body: `### ${emoji} Security Review: ${verdict}\n_Model: deepseek/DeepSeek-R1-0528_\n\n\`\`\`json\n${review}\n\`\`\``
             });
-      - name: Block on critical findings
+
+      - name: Block on critical/high findings
         if: steps.review.outputs.review
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v7
         with:
           script: |
             const raw = ${{ toJSON(steps.review.outputs.review) }};
@@ -178,11 +232,14 @@ jobs:
               core.setFailed(`Security review fail-closed: unparseable review JSON: ${e.message}`);
               return;
             }
-            const critical = (parsed.findings || []).filter(f => (f.severity || '').toUpperCase() === 'CRITICAL');
-            if (critical.length > 0) {
-              core.setFailed(`Merge blocked: ${critical.length} CRITICAL finding(s)`);
+            const dominated = (parsed.findings || []).filter(f => {
+              const sev = (f.severity || '').toUpperCase();
+              return sev === 'CRITICAL' || sev === 'HIGH';
+            });
+            if (dominated.length > 0) {
+              core.setFailed(`Merge blocked: ${dominated.length} CRITICAL/HIGH finding(s)`);
             } else {
-              core.info('No CRITICAL findings - review passed');
+              core.info('No CRITICAL/HIGH findings - review passed');
             }
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

<!-- What does this PR do? -->

## Scope

- [ ] Documentation-only
- [ ] Implementation-only change (no consensus change)
- [ ] Consensus-affecting change (requires explicit process)

**Consensus boundary (required):**

- Consensus rules unchanged: YES/NO
- `SECTION_HASHES.json` unchanged: YES/NO
- Wire format unchanged: YES/NO

## Evidence / Gates

<!-- Required for PV/CORE_EXT/consensus-sensitive areas -->

- CI links:
  - test:
  - coverage:
  - policy/validator:
- Conformance:
  - `run_cv_bundle.py`:
- Replay / determinism:
  - seq vs par equality (verdict/error/digests):

## Rollout / Flags (if applicable)

```text
pv-mode=off|shadow|on
pv-shadow-max=N
```

Refs: Q-XXX-YY-ZZ

