### PR TITLE
fix: increase DeepSeek context window 12K→64K

### DIFF
--- a/.github/workflows/models-security-review.yml
+++ b/.github/workflows/models-security-review.yml
@@ -62,7 +62,7 @@ jobs:
           script: |
             const fs = require('fs');
             const { jsonrepair } = require('./node_modules/jsonrepair');
-            const diff = fs.readFileSync('pr-diff.txt', 'utf8').slice(0, 12000);
+            const diff = fs.readFileSync('pr-diff.txt', 'utf8').slice(0, 64000);
 
             const systemPrompt = [
               'You are a HOSTILE protocol security auditor for the RUBIN blockchain protocol.',
@@ -99,6 +99,8 @@ jobs:
               '- If cryptographic code changed: verify parameter sizes, check for timing side-channels.',
               '- NEVER say "looks good" or "no issues found" if you have not verified every line.',
               '- If the diff is too large to fully verify, say so explicitly and flag unreviewed sections.',
+              '- If a function/module is CALLED in the diff but its DEFINITION is not visible, classify it as UNREVIEWED, NOT as CRITICAL. The definition may be beyond the context window or in a pre-existing file.',
+              '- NEVER flag "function not defined in diff" as CRITICAL — functions can exist in files not touched by the PR.',
               '',
               'OUTPUT FORMAT — strict JSON only, no markdown, no commentary:',
               '{',


### PR DESCRIPTION
## Summary
- Increase diff character limit from 12K to 64K for DeepSeek R1 security review
- Add prompt guidance: functions called but not visible = UNREVIEWED, not CRITICAL

## Problem
PR#861 (832-line p2p_service.rs) was truncated at 12K chars. DeepSeek correctly reported "function not in diff" as CRITICAL — but the functions WERE in the diff, just past the truncation point. Result: 3 false positive CRITICALs blocking a valid PR.

## Test plan
- [ ] Rerun security-review on PR#861 after this merges to main
- [ ] Verify DeepSeek sees full diff and doesn't flag visible functions as "missing"

🤖 Generated with [Claude Code](https://claude.com/claude-code)