### PR TITLE
fix: deduplicate DeepSeek review findings across runs

### DIFF
--- a/.github/workflows/models-security-review.yml
+++ b/.github/workflows/models-security-review.yml
@@ -100,7 +100,13 @@ jobs:
                     try {
                       const parsed = JSON.parse(jsonMatch[1]);
                       for (const f of (parsed.findings || [])) {
-                        titles.push(`[${f.severity}] ${f.title}`);
+                        // Sanitize: strip newlines, limit length, allow only printable ASCII
+                        const sev = String(f.severity || '').replace(/[^A-Z]/g, '').slice(0, 10);
+                        const title = String(f.title || '')
+                          .replace(/[\r\n]+/g, ' ')
+                          .replace(/[^\x20-\x7E]/g, '')
+                          .slice(0, 120);
+                        if (sev && title) titles.push(`[${sev}] ${title}`);
                       }
                     } catch {}
                   }


### PR DESCRIPTION
## Summary
R1 re-reports same findings on every push (even after fixes), because each
run starts from scratch without context about previous reviews.

- Fetch last 3 review comments, extract finding titles
- Include as PREVIOUSLY REPORTED in user message
- Add DEDUPLICATION prompt rule to skip already-tracked findings

## Test plan
- [ ] Push to PR#861 → verify findings count decreases
- [ ] Fixed issues no longer re-reported