### PR TITLE
fix: increase DeepSeek per-file context to 30k chars

### DIFF
--- a/.github/workflows/models-security-review.yml
+++ b/.github/workflows/models-security-review.yml
@@ -162,7 +162,7 @@ jobs:
               const header = `FILE: ${file}\n`;
               // Reserve space: header + separator (except first entry) + at least 200 chars of content
               const frameSize = header.length + (entries.length > 0 ? SEPARATOR.length : 0);
-              if (usedBytes + frameSize + 200 > TOTAL_FILE_BUDGET) break; // no room for meaningful content
+              if (usedBytes + frameSize + 200 > TOTAL_FILE_BUDGET) continue; // skip this file, try shorter ones
               const remainingBudget = TOTAL_FILE_BUDGET - usedBytes - frameSize;
               const contentBudget = Math.min(PER_FILE_CAP, remainingBudget);
               const entry = header + content.slice(0, contentBudget);


### PR DESCRIPTION
## Summary
- Per-file limit: 8000 → 30000 chars (~900 lines, covers full p2p_runtime.rs)
- Total payload: 64000 → 100000 chars

## Root cause
R1 reported CRITICAL FP "Unvalidated Handshake Allows Chain Split" because
p2p_runtime.rs was truncated at ~150 lines. The `validate_remote_version`
function with chain_id/genesis_hash validation is at line 800 — invisible
to the model with 8k per-file limit.