### PR TITLE
sec: acknowledge worker pool review false positives

### DIFF
--- a/.github/security-acknowledged.json
+++ b/.github/security-acknowledged.json
@@ -204,6 +204,20 @@
       "reason": "ACCEPTED_RISK: single parse per tx relay path. Optimizing to reuse parsed tx is premature — relay is not hot path.",
       "acknowledged_by": "controller",
       "date": "2026-03-25"
+    },
+    {
+      "title_pattern": "Worker Pool Hanging Causes Node Denial-of-Service",
+      "file_pattern": "worker_pool.rs",
+      "reason": "FALSE_POSITIVE: Go parity — go/consensus/worker_pool.go is the same cooperative primitive with no per-task kill switch. Tasks are internal consensus closures, not attacker-supplied code; adding forceful timeouts would change semantics and is not implementable safely in std threads.",
+      "acknowledged_by": "architect",
+      "date": "2026-03-26"
+    },
+    {
+      "title_pattern": "Unbounded Memory Consumption in Results Buffer",
+      "file_pattern": "worker_pool.rs",
+      "reason": "ACCEPTED_RISK: Go parity — ordered reduction requires one result slot per submitted task just like Go make([]WorkerResult, n). The caller already materializes the task batch; concrete task-count bounds belong at future block-level integration sites, not this infrastructure primitive.",
+      "acknowledged_by": "architect",
+      "date": "2026-03-26"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- acknowledge the validated worker-pool false-positive family from PR #893 in the base DeepSeek suppression list
- mark the generic result-buffer concern as a reviewed accepted risk at the infrastructure-primitive layer

## Scope
- only `.github/security-acknowledged.json`
- no production code changes
- no consensus, wire, or runtime semantics changes
- Documentation-only: NO
- Implementation-only change (no consensus change): YES
- Consensus-affecting change (requires explicit process): NO
- Consensus rules unchanged: YES
- `SECTION_HASHES.json` unchanged: YES
- Wire format unchanged: YES

## Evidence / Gates
- CI links:
  - test:
  - coverage:
  - policy/validator:
- Conformance:
  - `run_cv_bundle.py`: not applicable
- Replay / determinism:
  - seq vs par equality (verdict/error/digests): not applicable

## Threat model
- malformed input adversary: no parser or validator code changes
- Byzantine peer: no peer-facing behavior changes
- DoS / resource exhaustion: no runtime execution-path changes; this only updates base suppression metadata for validated false positives
- implementation divergence: no Go/Rust behavior changes
- consensus split: none; merge affects reviewer gating only
- PQ adversary: no cryptographic behavior changes
