### PR TITLE
feat(consensus): port tx_validate_worker Go→Rust (#886)

### DIFF
--- a/clients/rust/crates/rubin-consensus/src/lib.rs
+++ b/clients/rust/crates/rubin-consensus/src/lib.rs
@@ -23,6 +23,7 @@ pub mod suite_registry;
 pub mod tx;
 pub mod tx_dep_graph;
 mod tx_helpers;
+pub mod tx_validate_worker;
 pub mod txcontext;
 mod utxo_basic;
 pub mod utxo_snapshot;
@@ -83,6 +84,9 @@ pub use tx_dep_graph::{
     build_tx_dep_graph, TxDepEdge, TxDepEdgeKind, TxDepGraph, TxValidationContext,
 };
 pub use tx_helpers::{marshal_tx, p2pk_covenant_data_for_pubkey, sign_transaction, DigestSigner};
+pub use tx_validate_worker::{
+    first_tx_error, run_tx_validation_workers, validate_tx_local, TxValidationResult,
+};
 pub use txcontext::{
     build_tx_context, build_tx_context_output_ext_id_cache, ExtIdCacheEntry, TxContextBase,
     TxContextBundle, TxContextContinuing, TxOutputView, Uint128, TXCONTEXT_MAX_CONTINUING_OUTPUTS,

--- a/clients/rust/crates/rubin-consensus/src/tests/mod.rs
+++ b/clients/rust/crates/rubin-consensus/src/tests/mod.rs
@@ -617,4 +617,5 @@ mod block_basic;
 mod covenant_genesis;
 mod precompute;
 mod tx_parse;
+mod tx_validate_worker;
 mod utxo_apply;

--- a/clients/rust/crates/rubin-consensus/src/tests/tx_validate_worker.rs
+++ b/clients/rust/crates/rubin-consensus/src/tests/tx_validate_worker.rs
@@ -1,0 +1,363 @@
+use std::collections::HashMap;
+
+use crate::block::{BlockHeader, BLOCK_HEADER_BYTES};
+use crate::block_basic::ParsedBlock;
+use crate::constants::*;
+use crate::core_ext::CoreExtProfiles;
+use crate::error::ErrorCode;
+use crate::hash::sha3_256;
+use crate::precompute::{precompute_tx_contexts, PrecomputedTxContext};
+use crate::tx::{Tx, TxInput, TxOutput, WitnessItem};
+use crate::tx_validate_worker::{
+    first_tx_error, run_tx_validation_workers, validate_tx_local, TxValidationResult,
+};
+use crate::utxo_basic::{Outpoint, UtxoEntry};
+use crate::worker_pool::{WorkerCancellationToken, WorkerPoolError, WorkerResult};
+
+fn valid_p2pk_covenant_data() -> Vec<u8> {
+    vec![0u8; 32]
+}
+
+fn dummy_witness() -> WitnessItem {
+    WitnessItem {
+        suite_id: SUITE_ID_ML_DSA_87,
+        pubkey: vec![0u8; ML_DSA_87_PUBKEY_BYTES as usize],
+        signature: vec![0u8; (ML_DSA_87_SIG_BYTES + 1) as usize],
+    }
+}
+
+fn make_parsed_block(coinbase: Tx, txs: Vec<Tx>) -> ParsedBlock {
+    let mut all_txs = Vec::with_capacity(1 + txs.len());
+    all_txs.push(coinbase);
+    all_txs.extend(txs);
+
+    let txids: Vec<[u8; 32]> = (0..all_txs.len()).map(|i| sha3_256(&[i as u8])).collect();
+    let wtxids = txids.clone();
+
+    ParsedBlock {
+        header: BlockHeader {
+            version: 1,
+            prev_block_hash: [0u8; 32],
+            merkle_root: [0u8; 32],
+            timestamp: 0,
+            target: [0u8; 32],
+            nonce: 0,
+        },
+        header_bytes: [0u8; BLOCK_HEADER_BYTES],
+        tx_count: all_txs.len() as u64,
+        txs: all_txs,
+        txids,
+        wtxids,
+    }
+}
+
+fn simple_coinbase() -> Tx {
+    Tx {
+        version: 1,
+        tx_kind: 0x00,
+        tx_nonce: 0,
+        inputs: vec![TxInput {
+            prev_txid: [0u8; 32],
+            prev_vout: 0xffff_ffff,
+            script_sig: Vec::new(),
+            sequence: 0,
+        }],
+        outputs: vec![TxOutput {
+            value: 50_000_000,
+            covenant_type: COV_TYPE_P2PK,
+            covenant_data: valid_p2pk_covenant_data(),
+        }],
+        locktime: 0,
+        da_commit_core: None,
+        da_chunk_core: None,
+        witness: Vec::new(),
+        da_payload: Vec::new(),
+    }
+}
+
+fn simple_p2pk_tx(prev_txid_seed: u8) -> Tx {
+    let mut prev_txid = [0u8; 32];
+    prev_txid[0] = prev_txid_seed;
+    Tx {
+        version: 1,
+        tx_kind: 0x00,
+        tx_nonce: 1,
+        inputs: vec![TxInput {
+            prev_txid,
+            prev_vout: 0,
+            script_sig: Vec::new(),
+            sequence: 0,
+        }],
+        outputs: vec![TxOutput {
+            value: 90,
+            covenant_type: COV_TYPE_P2PK,
+            covenant_data: valid_p2pk_covenant_data(),
+        }],
+        locktime: 0,
+        da_commit_core: None,
+        da_chunk_core: None,
+        witness: vec![dummy_witness()],
+        da_payload: Vec::new(),
+    }
+}
+
+fn make_utxo_snapshot_for_tx(
+    tx: &Tx,
+    value: u64,
+) -> HashMap<Outpoint, UtxoEntry> {
+    let mut snap = HashMap::new();
+    for input in &tx.inputs {
+        snap.insert(
+            Outpoint {
+                txid: input.prev_txid,
+                vout: input.prev_vout,
+            },
+            UtxoEntry {
+                value,
+                covenant_type: COV_TYPE_P2PK,
+                covenant_data: valid_p2pk_covenant_data(),
+                creation_height: 1,
+                created_by_coinbase: false,
+            },
+        );
+    }
+    snap
+}
+
+/// Helper: precompute + validate for a single-tx block.
+fn precompute_single_tx(
+    tx: Tx,
+    input_value: u64,
+    block_height: u64,
+) -> (ParsedBlock, Vec<PrecomputedTxContext>, HashMap<Outpoint, UtxoEntry>) {
+    let snapshot = make_utxo_snapshot_for_tx(&tx, input_value);
+    let pb = make_parsed_block(simple_coinbase(), vec![tx]);
+    let ptcs = precompute_tx_contexts(&pb, &snapshot, block_height).unwrap();
+    (pb, ptcs, snapshot)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// validate_tx_local
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn validate_tx_local_witness_underflow() {
+    let tx = simple_p2pk_tx(0x42);
+    let (pb, mut ptcs, _snap) = precompute_single_tx(tx, 100, 100);
+
+    // Corrupt witness_end so the worker sees fewer witness items than needed.
+    ptcs[0].witness_end = ptcs[0].witness_start;
+
+    let profiles = CoreExtProfiles::empty();
+    let r = validate_tx_local(&ptcs[0], &pb, [0u8; 32], 100, 0, &profiles);
+    assert!(!r.valid);
+    assert!(r.err.is_some());
+    let err = r.err.unwrap();
+    assert_eq!(err.code, ErrorCode::TxErrParse);
+    assert!(err.msg.contains("witness underflow"));
+}
+
+#[test]
+fn validate_tx_local_witness_count_mismatch() {
+    // Create a tx with an extra witness item that won't be consumed.
+    let mut tx = simple_p2pk_tx(0x42);
+    tx.witness.push(dummy_witness()); // extra witness
+    let (pb, ptcs, _snap) = precompute_single_tx(tx, 100, 100);
+
+    let profiles = CoreExtProfiles::empty();
+    let r = validate_tx_local(&ptcs[0], &pb, [0u8; 32], 100, 0, &profiles);
+    assert!(!r.valid);
+    assert!(r.err.is_some());
+    let err = r.err.unwrap();
+    assert_eq!(err.code, ErrorCode::TxErrParse);
+    assert!(err.msg.contains("witness_count mismatch"));
+}
+
+#[test]
+fn validate_tx_local_fee_and_index_preserved() {
+    let tx = simple_p2pk_tx(0x42);
+    let (pb, ptcs, _snap) = precompute_single_tx(tx, 100, 100);
+
+    let profiles = CoreExtProfiles::empty();
+    let r = validate_tx_local(&ptcs[0], &pb, [0u8; 32], 100, 0, &profiles);
+    // Note: this test will likely fail at signature verification (dummy witness
+    // won't pass ML-DSA verify) — we're testing that fee/index are set correctly
+    // before any validation error is returned.
+    assert_eq!(r.tx_index, ptcs[0].tx_index);
+    assert_eq!(r.fee, ptcs[0].fee);
+}
+
+#[test]
+fn validate_tx_local_default_covenant_passthrough() {
+    // COV_TYPE_ANCHOR has no spend-time checks — the default match arm returns Ok(()).
+    // However, ANCHOR is non-spendable and filtered by precompute. Test with a
+    // synthetic PrecomputedTxContext that has no resolved inputs (empty block body
+    // after coinbase).
+    let pb = make_parsed_block(simple_coinbase(), vec![simple_p2pk_tx(0x42)]);
+    let ptc = PrecomputedTxContext {
+        tx_index: 1,
+        tx_block_idx: 1,
+        txid: [0u8; 32],
+        resolved_inputs: vec![], // no inputs → zero iterations
+        witness_start: 0,
+        witness_end: 0,
+        input_outpoints: vec![],
+        fee: 0,
+    };
+    let profiles = CoreExtProfiles::empty();
+    let r = validate_tx_local(&ptc, &pb, [0u8; 32], 100, 0, &profiles);
+    assert!(r.valid);
+    assert!(r.err.is_none());
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// run_tx_validation_workers
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn run_tx_validation_workers_empty() {
+    let token = WorkerCancellationToken::new();
+    let profiles = CoreExtProfiles::empty();
+    let pb = make_parsed_block(simple_coinbase(), vec![]);
+    let results =
+        run_tx_validation_workers(&token, 4, vec![], &pb, [0u8; 32], 1, 0, &profiles).unwrap();
+    assert!(results.is_empty());
+}
+
+#[test]
+fn run_tx_validation_workers_cancelled_token() {
+    let tx = simple_p2pk_tx(0x42);
+    let (pb, ptcs, _snap) = precompute_single_tx(tx, 100, 100);
+
+    let token = WorkerCancellationToken::new();
+    token.cancel(); // pre-cancel
+
+    let profiles = CoreExtProfiles::empty();
+    let results =
+        run_tx_validation_workers(&token, 2, ptcs, &pb, [0u8; 32], 100, 0, &profiles).unwrap();
+    assert_eq!(results.len(), 1);
+    assert!(results[0].error.is_some());
+    match &results[0].error {
+        Some(WorkerPoolError::Cancelled) => {}
+        other => panic!("expected Cancelled, got {:?}", other),
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// first_tx_error
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn first_tx_error_all_valid() {
+    let results: Vec<WorkerResult<TxValidationResult, _>> = vec![
+        WorkerResult {
+            value: Some(TxValidationResult {
+                tx_index: 1,
+                valid: true,
+                err: None,
+                sig_count: 1,
+                fee: 10,
+            }),
+            error: None,
+        },
+        WorkerResult {
+            value: Some(TxValidationResult {
+                tx_index: 2,
+                valid: true,
+                err: None,
+                sig_count: 1,
+                fee: 20,
+            }),
+            error: None,
+        },
+    ];
+    assert!(first_tx_error(&results).is_none());
+}
+
+#[test]
+fn first_tx_error_nil() {
+    let results: Vec<WorkerResult<TxValidationResult, _>> = vec![];
+    assert!(first_tx_error(&results).is_none());
+}
+
+#[test]
+fn first_tx_error_picks_smallest_tx_index() {
+    use crate::error::TxError;
+
+    let err3 = TxError::new(ErrorCode::TxErrParse, "tx3");
+    let err1 = TxError::new(ErrorCode::TxErrMissingUtxo, "tx1");
+
+    let results: Vec<WorkerResult<TxValidationResult, _>> = vec![
+        WorkerResult {
+            value: Some(TxValidationResult {
+                tx_index: 3,
+                valid: false,
+                err: Some(err3.clone()),
+                sig_count: 0,
+                fee: 0,
+            }),
+            error: Some(WorkerPoolError::Task(err3)),
+        },
+        WorkerResult {
+            value: Some(TxValidationResult {
+                tx_index: 2,
+                valid: true,
+                err: None,
+                sig_count: 1,
+                fee: 10,
+            }),
+            error: None,
+        },
+        WorkerResult {
+            value: Some(TxValidationResult {
+                tx_index: 1,
+                valid: false,
+                err: Some(err1.clone()),
+                sig_count: 0,
+                fee: 0,
+            }),
+            error: Some(WorkerPoolError::Task(err1.clone())),
+        },
+    ];
+
+    let got = first_tx_error(&results);
+    assert!(got.is_some());
+    let got = got.unwrap();
+    assert_eq!(got.code, ErrorCode::TxErrMissingUtxo);
+    assert!(got.msg.contains("tx1"));
+}
+
+#[test]
+fn first_tx_error_fallback_when_tx_index_zero() {
+    use crate::error::TxError;
+
+    let err_a = TxError::new(ErrorCode::TxErrParse, "missing index A");
+    let err_b = TxError::new(ErrorCode::TxErrParse, "missing index B");
+
+    // Both errors have tx_index=0 (unset). First encountered should be kept.
+    let results: Vec<WorkerResult<TxValidationResult, _>> = vec![
+        WorkerResult {
+            value: Some(TxValidationResult {
+                tx_index: 0,
+                valid: false,
+                err: Some(err_a.clone()),
+                sig_count: 0,
+                fee: 0,
+            }),
+            error: Some(WorkerPoolError::Task(err_a.clone())),
+        },
+        WorkerResult {
+            value: Some(TxValidationResult {
+                tx_index: 0,
+                valid: false,
+                err: Some(err_b.clone()),
+                sig_count: 0,
+                fee: 0,
+            }),
+            error: Some(WorkerPoolError::Task(err_b)),
+        },
+    ];
+
+    let got = first_tx_error(&results).unwrap();
+    assert!(got.msg.contains("missing index A"));
+}

--- a/clients/rust/crates/rubin-consensus/src/tx_validate_worker.rs
+++ b/clients/rust/crates/rubin-consensus/src/tx_validate_worker.rs
@@ -1,0 +1,412 @@
+use crate::block_basic::ParsedBlock;
+use crate::constants::{
+    COV_TYPE_EXT, COV_TYPE_HTLC, COV_TYPE_MULTISIG, COV_TYPE_P2PK, COV_TYPE_STEALTH,
+    COV_TYPE_VAULT, CORE_EXT_WITNESS_SLOTS, CORE_STEALTH_WITNESS_SLOTS,
+};
+use crate::core_ext::{
+    validate_core_ext_spend_with_cache_and_suite_context, CoreExtProfiles,
+};
+use crate::error::{ErrorCode, TxError};
+use crate::htlc::validate_htlc_spend_at_height;
+use crate::precompute::PrecomputedTxContext;
+use crate::sighash::SighashV1PrehashCache;
+use crate::spend_verify::{validate_p2pk_spend_at_height, validate_threshold_sig_spend_at_height};
+use crate::stealth::validate_stealth_spend_at_height;
+use crate::suite_registry::{DefaultRotationProvider, RotationProvider, SuiteRegistry};
+use crate::tx::{Tx, WitnessItem};
+use crate::txcontext::{
+    build_tx_context, build_tx_context_output_ext_id_cache, collect_txcontext_ext_ids,
+    TxContextBundle,
+};
+use crate::utxo_basic::UtxoEntry;
+use crate::vault::{parse_multisig_covenant_data, parse_vault_covenant_data_for_spend, witness_slots};
+use crate::worker_pool::{
+    run_worker_pool, WorkerCancellationToken, WorkerPoolError, WorkerPoolRunError, WorkerResult,
+};
+
+/// Outcome of validating a single non-coinbase transaction in a parallel
+/// worker. Workers perform read-only checks against precomputed
+/// [`PrecomputedTxContext`] and do NOT mutate UTXO or consensus state.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TxValidationResult {
+    /// 1-based block-level index of this transaction.
+    pub tx_index: usize,
+    /// `true` if all input-level spend checks and signature verifications
+    /// passed.
+    pub valid: bool,
+    /// Non-`None` if validation failed. The error is a canonical `TX_ERR_*`
+    /// error suitable for deterministic error reporting.
+    pub err: Option<TxError>,
+    /// Number of signature verification operations executed.
+    pub sig_count: usize,
+    /// Transaction fee, copied from [`PrecomputedTxContext`].
+    pub fee: u64,
+}
+
+/// Validate a single non-coinbase transaction using read-only precomputed
+/// context. Iterates resolved inputs, dispatches per-covenant-type spend
+/// validators, and counts signature verifications.
+///
+/// This function does NOT modify any UTXO set or consensus state. It is safe
+/// to call concurrently from multiple threads.
+///
+/// Vault inputs: only the threshold signature is verified here. Full vault
+/// policy (whitelist, owner lock, output rules) is enforced in the sequential
+/// commit stage, which has access to block-level context.
+#[allow(clippy::too_many_arguments)]
+pub fn validate_tx_local(
+    ptc: &PrecomputedTxContext,
+    pb: &ParsedBlock,
+    chain_id: [u8; 32],
+    block_height: u64,
+    block_mtp: u64,
+    core_ext_profiles: &CoreExtProfiles,
+) -> TxValidationResult {
+    let mut result = TxValidationResult {
+        tx_index: ptc.tx_index,
+        valid: false,
+        err: None,
+        sig_count: 0,
+        fee: ptc.fee,
+    };
+
+    let tx = &pb.txs[ptc.tx_block_idx];
+
+    // Build sighash cache for this transaction.
+    let mut sighash_cache = match SighashV1PrehashCache::new(tx) {
+        Ok(c) => c,
+        Err(e) => {
+            result.err = Some(e);
+            return result;
+        }
+    };
+
+    // Build TxContext if any input requires CORE_EXT context.
+    let tx_context = match build_tx_context_if_needed(
+        tx,
+        &ptc.resolved_inputs,
+        block_height,
+        core_ext_profiles,
+    ) {
+        Ok(ctx) => ctx,
+        Err(e) => {
+            result.err = Some(e);
+            return result;
+        }
+    };
+
+    let rotation = DefaultRotationProvider;
+    let registry = SuiteRegistry::default_registry();
+
+    let mut witness_cursor = ptc.witness_start;
+    for (input_index, entry) in ptc.resolved_inputs.iter().enumerate() {
+        let slots = match witness_slots(entry.covenant_type, &entry.covenant_data) {
+            Ok(s) => s,
+            Err(e) => {
+                result.err = Some(e);
+                return result;
+            }
+        };
+        if witness_cursor + slots > ptc.witness_end {
+            result.err = Some(TxError::new(
+                ErrorCode::TxErrParse,
+                "witness underflow in worker",
+            ));
+            return result;
+        }
+        let assigned = &tx.witness[witness_cursor..witness_cursor + slots];
+
+        if let Err(e) = validate_input_spend(
+            entry,
+            assigned,
+            tx,
+            input_index as u32,
+            entry.value,
+            chain_id,
+            block_height,
+            block_mtp,
+            &mut sighash_cache,
+            core_ext_profiles,
+            &rotation,
+            &registry,
+            tx_context.as_ref(),
+        ) {
+            result.err = Some(e);
+            return result;
+        }
+
+        // Count one sig verification per input that carries a signature.
+        // Covenant types with zero witness slots or no-op validation (anchor,
+        // da_commit) are excluded by the precompute stage.
+        result.sig_count += 1;
+
+        witness_cursor += slots;
+    }
+
+    if witness_cursor != ptc.witness_end {
+        result.err = Some(TxError::new(
+            ErrorCode::TxErrParse,
+            "witness_count mismatch",
+        ));
+        return result;
+    }
+
+    result.valid = true;
+    result
+}
+
+/// Dispatch a single input to the appropriate spend validator based on
+/// covenant type. Mirrors the switch in
+/// `apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles_and_suite_context`
+/// but without UTXO mutations.
+#[allow(clippy::too_many_arguments)]
+fn validate_input_spend(
+    entry: &UtxoEntry,
+    assigned: &[WitnessItem],
+    tx: &Tx,
+    input_index: u32,
+    input_value: u64,
+    chain_id: [u8; 32],
+    block_height: u64,
+    block_mtp: u64,
+    sighash_cache: &mut SighashV1PrehashCache<'_>,
+    core_ext_profiles: &CoreExtProfiles,
+    rotation: &dyn RotationProvider,
+    registry: &SuiteRegistry,
+    tx_context: Option<&TxContextBundle>,
+) -> Result<(), TxError> {
+    match entry.covenant_type {
+        COV_TYPE_P2PK => {
+            if assigned.len() != 1 {
+                return Err(TxError::new(
+                    ErrorCode::TxErrParse,
+                    "CORE_P2PK witness_slots must be 1",
+                ));
+            }
+            validate_p2pk_spend_at_height(
+                entry,
+                &assigned[0],
+                tx,
+                input_index,
+                input_value,
+                chain_id,
+                block_height,
+                sighash_cache,
+                Some(rotation),
+                Some(registry),
+            )
+        }
+
+        COV_TYPE_MULTISIG => {
+            let m = parse_multisig_covenant_data(&entry.covenant_data)?;
+            validate_threshold_sig_spend_at_height(
+                &m.keys,
+                m.threshold,
+                assigned,
+                tx,
+                input_index,
+                input_value,
+                chain_id,
+                block_height,
+                "CORE_MULTISIG",
+                sighash_cache,
+                Some(rotation),
+                Some(registry),
+            )
+        }
+
+        COV_TYPE_VAULT => {
+            // Vault: only verify threshold signature in the worker.
+            // Full vault policy (whitelist, owner lock, output checks) is
+            // enforced in the sequential commit stage.
+            let v = parse_vault_covenant_data_for_spend(&entry.covenant_data)?;
+            validate_threshold_sig_spend_at_height(
+                &v.keys,
+                v.threshold,
+                assigned,
+                tx,
+                input_index,
+                input_value,
+                chain_id,
+                block_height,
+                "CORE_VAULT",
+                sighash_cache,
+                Some(rotation),
+                Some(registry),
+            )
+        }
+
+        COV_TYPE_HTLC => {
+            if assigned.len() != 2 {
+                return Err(TxError::new(
+                    ErrorCode::TxErrParse,
+                    "CORE_HTLC witness_slots must be 2",
+                ));
+            }
+            validate_htlc_spend_at_height(
+                entry,
+                &assigned[0], // path_item
+                &assigned[1], // sig_item
+                tx,
+                input_index,
+                input_value,
+                chain_id,
+                block_height,
+                block_mtp,
+                sighash_cache,
+                Some(rotation),
+                Some(registry),
+            )
+        }
+
+        COV_TYPE_EXT => {
+            if assigned.len() != CORE_EXT_WITNESS_SLOTS as usize {
+                return Err(TxError::new(
+                    ErrorCode::TxErrParse,
+                    "CORE_EXT witness_slots must be 1",
+                ));
+            }
+            validate_core_ext_spend_with_cache_and_suite_context(
+                entry,
+                &assigned[0],
+                tx,
+                input_index,
+                input_value,
+                chain_id,
+                block_height,
+                core_ext_profiles,
+                Some(rotation),
+                Some(registry),
+                tx_context,
+                sighash_cache,
+            )
+        }
+
+        COV_TYPE_STEALTH => {
+            if assigned.len() != CORE_STEALTH_WITNESS_SLOTS as usize {
+                return Err(TxError::new(
+                    ErrorCode::TxErrParse,
+                    "CORE_STEALTH witness_slots must be 1",
+                ));
+            }
+            validate_stealth_spend_at_height(
+                entry,
+                &assigned[0],
+                tx,
+                input_index,
+                input_value,
+                chain_id,
+                block_height,
+                sighash_cache,
+                Some(rotation),
+                Some(registry),
+            )
+        }
+
+        _ => {
+            // Other covenant types have no spend-time checks in the genesis set.
+            Ok(())
+        }
+    }
+}
+
+/// Build [`TxContextBundle`] only when at least one resolved input requires
+/// CORE_EXT context.
+fn build_tx_context_if_needed(
+    tx: &Tx,
+    resolved_inputs: &[UtxoEntry],
+    block_height: u64,
+    core_ext_profiles: &CoreExtProfiles,
+) -> Result<Option<TxContextBundle>, TxError> {
+    let ext_ids = collect_txcontext_ext_ids(resolved_inputs, core_ext_profiles)?;
+    if ext_ids.is_empty() {
+        return Ok(None);
+    }
+    let output_ext_id_cache = build_tx_context_output_ext_id_cache(tx)?;
+    build_tx_context(
+        tx,
+        resolved_inputs,
+        Some(&output_ext_id_cache),
+        block_height,
+        core_ext_profiles,
+    )
+}
+
+/// Validate multiple transactions in parallel using the deterministic
+/// [`WorkerPool`]. Returns results in submission order.
+///
+/// Returns a pool-level error only if the worker-pool substrate itself
+/// rejects the batch before task execution starts.
+#[allow(clippy::too_many_arguments)]
+pub fn run_tx_validation_workers(
+    token: &WorkerCancellationToken,
+    max_workers: usize,
+    ptcs: Vec<PrecomputedTxContext>,
+    pb: &ParsedBlock,
+    chain_id: [u8; 32],
+    block_height: u64,
+    block_mtp: u64,
+    core_ext_profiles: &CoreExtProfiles,
+) -> Result<Vec<WorkerResult<TxValidationResult, TxError>>, WorkerPoolRunError> {
+    let max_tasks = ptcs.len();
+    if max_tasks == 0 {
+        return Ok(Vec::new());
+    }
+    run_worker_pool(
+        token,
+        max_workers,
+        max_tasks,
+        ptcs,
+        |_cancel, ptc| {
+            let r = validate_tx_local(
+                &ptc,
+                pb,
+                chain_id,
+                block_height,
+                block_mtp,
+                core_ext_profiles,
+            );
+            if let Some(ref e) = r.err {
+                Err(e.clone())
+            } else {
+                Ok(r)
+            }
+        },
+    )
+}
+
+/// Return the first error by transaction index from validation results, or
+/// `None` if all transactions are valid. Deterministic: always selects the
+/// smallest positive `tx_index` among failed results.
+pub fn first_tx_error(results: &[WorkerResult<TxValidationResult, TxError>]) -> Option<TxError> {
+    let mut best: Option<(usize, TxError)> = None;
+    for r in results {
+        let err = match &r.error {
+            Some(WorkerPoolError::Task(e)) => e.clone(),
+            Some(WorkerPoolError::Cancelled) => {
+                TxError::new(ErrorCode::TxErrParse, "validation cancelled")
+            }
+            Some(WorkerPoolError::Panic(msg)) => {
+                TxError::new(ErrorCode::TxErrParse, msg.as_str())
+            }
+            None => continue,
+        };
+        let tx_index = r.value.as_ref().map_or(0, |v| v.tx_index);
+        if tx_index == 0 {
+            // Defensive: if tx index is lost (0 = unset), keep the first
+            // such error seen.
+            if best.is_none() {
+                best = Some((tx_index, err));
+            }
+            continue;
+        }
+        match &best {
+            None => best = Some((tx_index, err)),
+            Some((best_idx, _)) if *best_idx == 0 || tx_index < *best_idx => {
+                best = Some((tx_index, err));
+            }
+            _ => {}
+        }
+    }
+    best.map(|(_, e)| e)
+}


### PR DESCRIPTION
Port ValidateTxLocal, validateInputSpend, RunTxValidationWorkers, FirstTxError from Go consensus to Rust. Workers perform read-only parallel validation against PrecomputedTxContext without UTXO mutations. Vault inputs verify threshold signature only (full policy in sequential commit stage).

Covers all covenant types: P2PK, MULTISIG, VAULT, HTLC, EXT, STEALTH. Uses inline sig verification (SIG-QUEUE-01 is separate).

Tests: witness underflow, witness count mismatch, fee/index preserved, default covenant passthrough, empty workers, cancelled token, first_tx_error deterministic selection.

## Summary

<!-- What does this PR do? -->

## Scope

- [ ] Documentation-only
- [ ] Implementation-only change (no consensus change)
- [ ] Consensus-affecting change (requires explicit process)

**Consensus boundary (required):**

- Consensus rules unchanged: YES/NO
- `SECTION_HASHES.json` unchanged: YES/NO
- Wire format unchanged: YES/NO

## Evidence / Gates

<!-- Required for PV/CORE_EXT/consensus-sensitive areas -->

- CI links:
  - test:
  - coverage:
  - policy/validator:
- Conformance:
  - `run_cv_bundle.py`:
- Replay / determinism:
  - seq vs par equality (verdict/error/digests):

## Rollout / Flags (if applicable)

```text
pv-mode=off|shadow|on
pv-shadow-max=N
```

Refs: Q-XXX-YY-ZZ

