### PR TITLE
feat(consensus): port batched ML-DSA verification to Rust (#885)

### DIFF
--- a/clients/rust/crates/rubin-consensus/src/sig_queue.rs
+++ b/clients/rust/crates/rubin-consensus/src/sig_queue.rs
@@ -242,12 +242,8 @@ fn verify_queued_tasks_batch(
 ) -> Result<(), TxError> {
     let token = WorkerCancellationToken::new();
     let max_tasks = tasks.len();
-    let results = run_worker_pool(&token, workers, max_tasks, tasks, |cancel, task| {
-        let result = verify_queued_task(task, registry);
-        if result.is_err() {
-            cancel.cancel();
-        }
-        result
+    let results = run_worker_pool(&token, workers, max_tasks, tasks, |_cancel, task| {
+        verify_queued_task(task, registry)
     })
     .map_err(sigcheck_batch_run_error_to_tx_error)?;
 
@@ -305,10 +301,9 @@ fn verify_signatures_batch_with_limit(
 }
 
 fn reduce_queued_task_results(results: Vec<WorkerResult<(), TxError>>) -> Result<(), TxError> {
-    // WorkerPool preserves submission order in its result vector. We ignore
-    // cancellation markers here so the reduction still returns the earliest
-    // actual verification failure, while late tasks can stop spending CPU once
-    // another worker has already proven the block invalid.
+    // WorkerPool preserves submission order in its result vector. We reduce
+    // the batch strictly in that order so the queue returns the same earliest
+    // failing signature it would have surfaced sequentially.
     for result in results {
         match result.error {
             Some(WorkerPoolError::Task(err)) => return Err(err),


### PR DESCRIPTION
## Summary

- batch `SigCheckQueue::flush()` through the bounded worker-pool substrate while preserving deterministic first-error reduction
- add a Rust `verify_signatures_batch` executor matching the Go batch helper surface for mixed pass/fail ML-DSA requests
- cover zero-worker normalization and aligned batch-result tests so the executor is production-ready before connect-block wiring

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy -p rubin-consensus --all-targets -- -D warnings`
- [x] `cargo test -p rubin-consensus -- --test-threads=1`

Refs: #885