### PR TITLE
ci: acknowledge da helper output-order false positive

### DIFF
--- a/.github/security-acknowledged.json
+++ b/.github/security-acknowledged.json
@@ -274,6 +274,13 @@
       "reason": "FALSE_POSITIVE for Rust-vs-Go parity: Go already keeps registry-native suites on the native queue path and non-native verify_sig_ext suites inline. Rust mirrors that split; this is not a new divergence.",
       "acknowledged_by": "architect",
       "date": "2026-03-27"
+    },
+    {
+      "title_pattern": "Consensus Divergence Risk Due to Multiple DA Commit Outputs",
+      "file_pattern": "da_verify_parallel.rs",
+      "reason": "FALSE_POSITIVE: Go parity — CollectDAPayloadCommitTasks also scans outputs, takes the first COV_TYPE_DA_COMMIT entry with 32-byte covenant data, and breaks. Structural DA-set integrity is enforced earlier in validateDASetIntegrity / validate_block_basic before this helper is reachable.",
+      "acknowledged_by": "architect",
+      "date": "2026-03-27"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- acknowledge the repeated DeepSeek false positive about multiple DA commit outputs in `da_verify_parallel.rs`
- document the exact Go parity basis: Go also takes the first matching `COV_TYPE_DA_COMMIT` output and breaks
- keep this technical review-noise suppression outside canonical queue work

## Testing
- python3 -m json.tool .github/security-acknowledged.json