### PR TITLE
feat: add rust signature cache parity

### DIFF
--- a/clients/rust/crates/rubin-consensus/src/lib.rs
+++ b/clients/rust/crates/rubin-consensus/src/lib.rs
@@ -16,6 +16,7 @@ mod htlc;
 pub mod merkle;
 pub mod pow;
 pub mod precompute;
+mod sig_cache;
 mod sig_queue;
 pub mod sighash;
 mod spend_verify;
@@ -77,6 +78,7 @@ pub use htlc::{parse_htlc_covenant_data, validate_htlc_spend, HtlcCovenant};
 pub use merkle::merkle_root_txids;
 pub use pow::{pow_check, retarget_v1, retarget_v1_clamped};
 pub use precompute::{precompute_tx_contexts, PrecomputedTxContext};
+pub use sig_cache::SigCache;
 pub use sighash::{
     is_valid_sighash_type, sighash_v1_digest, sighash_v1_digest_with_cache,
     sighash_v1_digest_with_type, SighashV1PrehashCache,

--- a/clients/rust/crates/rubin-consensus/src/sig_cache.rs
+++ b/clients/rust/crates/rubin-consensus/src/sig_cache.rs
@@ -1,0 +1,185 @@
+use crate::hash::sha3_256;
+use std::collections::HashSet;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, RwLock};
+
+#[derive(Debug)]
+struct SigCacheInner {
+    entries: RwLock<HashSet<[u8; 32]>>,
+    capacity: usize,
+    hits: AtomicU64,
+    misses: AtomicU64,
+}
+
+#[derive(Clone, Debug)]
+pub struct SigCache {
+    inner: Arc<SigCacheInner>,
+}
+
+impl SigCache {
+    pub fn new(capacity: usize) -> Self {
+        let capacity = capacity.max(1);
+        Self {
+            inner: Arc::new(SigCacheInner {
+                entries: RwLock::new(HashSet::with_capacity(capacity)),
+                capacity,
+                hits: AtomicU64::new(0),
+                misses: AtomicU64::new(0),
+            }),
+        }
+    }
+
+    pub fn lookup(&self, suite_id: u8, pubkey: &[u8], sig: &[u8], digest: [u8; 32]) -> bool {
+        let key = sig_cache_key(suite_id, pubkey, sig, digest);
+        let ok = self
+            .inner
+            .entries
+            .read()
+            .expect("sig cache poisoned")
+            .contains(&key);
+        if ok {
+            self.inner.hits.fetch_add(1, Ordering::Relaxed);
+        } else {
+            self.inner.misses.fetch_add(1, Ordering::Relaxed);
+        }
+        ok
+    }
+
+    pub fn insert(&self, suite_id: u8, pubkey: &[u8], sig: &[u8], digest: [u8; 32]) {
+        let key = sig_cache_key(suite_id, pubkey, sig, digest);
+        let mut entries = self.inner.entries.write().expect("sig cache poisoned");
+        if entries.len() < self.inner.capacity {
+            entries.insert(key);
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.inner.entries.read().expect("sig cache poisoned").len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn hits(&self) -> u64 {
+        self.inner.hits.load(Ordering::Relaxed)
+    }
+
+    pub fn misses(&self) -> u64 {
+        self.inner.misses.load(Ordering::Relaxed)
+    }
+
+    pub fn reset(&self) {
+        let mut entries = self.inner.entries.write().expect("sig cache poisoned");
+        *entries = HashSet::with_capacity(self.inner.capacity);
+        self.inner.hits.store(0, Ordering::Relaxed);
+        self.inner.misses.store(0, Ordering::Relaxed);
+    }
+}
+
+pub(crate) fn sig_cache_key(suite_id: u8, pubkey: &[u8], sig: &[u8], digest: [u8; 32]) -> [u8; 32] {
+    let mut buf = Vec::with_capacity(1 + 4 + pubkey.len() + 4 + sig.len() + 32);
+    buf.push(suite_id);
+    buf.extend_from_slice(
+        &u32::try_from(pubkey.len())
+            .expect("pubkey length must fit into u32")
+            .to_le_bytes(),
+    );
+    buf.extend_from_slice(pubkey);
+    buf.extend_from_slice(
+        &u32::try_from(sig.len())
+            .expect("signature length must fit into u32")
+            .to_le_bytes(),
+    );
+    buf.extend_from_slice(sig);
+    buf.extend_from_slice(&digest);
+    sha3_256(&buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::constants::SUITE_ID_ML_DSA_87;
+    use crate::verify_sig_openssl::Mldsa87Keypair;
+
+    #[test]
+    fn basic_insert_lookup() {
+        let cache = SigCache::new(100);
+        let keypair = Mldsa87Keypair::generate().expect("keypair");
+        let mut digest = [0u8; 32];
+        digest[0] = 0x42;
+        let sig = keypair.sign_digest32(digest).expect("sign");
+        let pubkey = keypair.pubkey_bytes();
+
+        assert!(!cache.lookup(SUITE_ID_ML_DSA_87, &pubkey, &sig, digest));
+        assert_eq!(cache.hits(), 0);
+        assert_eq!(cache.misses(), 1);
+
+        cache.insert(SUITE_ID_ML_DSA_87, &pubkey, &sig, digest);
+        assert!(cache.lookup(SUITE_ID_ML_DSA_87, &pubkey, &sig, digest));
+        assert_eq!(cache.hits(), 1);
+        assert_eq!(cache.misses(), 1);
+        assert_eq!(cache.len(), 1);
+    }
+
+    #[test]
+    fn bounded_capacity() {
+        let cache = SigCache::new(2);
+        let keypair = Mldsa87Keypair::generate().expect("keypair");
+        let pubkey = keypair.pubkey_bytes();
+        let mut entries = Vec::new();
+        for i in 0..3 {
+            let mut digest = [0u8; 32];
+            digest[0] = i;
+            let sig = keypair.sign_digest32(digest).expect("sign");
+            cache.insert(SUITE_ID_ML_DSA_87, &pubkey, &sig, digest);
+            entries.push((sig, digest));
+        }
+
+        assert_eq!(cache.len(), 2);
+        assert!(cache.lookup(SUITE_ID_ML_DSA_87, &pubkey, &entries[0].0, entries[0].1));
+        assert!(cache.lookup(SUITE_ID_ML_DSA_87, &pubkey, &entries[1].0, entries[1].1));
+        assert!(!cache.lookup(SUITE_ID_ML_DSA_87, &pubkey, &entries[2].0, entries[2].1));
+    }
+
+    #[test]
+    fn reset_clears_entries_and_counters() {
+        let cache = SigCache::new(10);
+        let keypair = Mldsa87Keypair::generate().expect("keypair");
+        let digest = [0u8; 32];
+        let sig = keypair.sign_digest32(digest).expect("sign");
+        let pubkey = keypair.pubkey_bytes();
+
+        cache.insert(SUITE_ID_ML_DSA_87, &pubkey, &sig, digest);
+        assert!(cache.lookup(SUITE_ID_ML_DSA_87, &pubkey, &sig, digest));
+        assert_eq!(cache.len(), 1);
+        assert_eq!(cache.hits(), 1);
+
+        cache.reset();
+        assert_eq!(cache.len(), 0);
+        assert_eq!(cache.hits(), 0);
+        assert_eq!(cache.misses(), 0);
+        assert!(!cache.lookup(SUITE_ID_ML_DSA_87, &pubkey, &sig, digest));
+    }
+
+    #[test]
+    fn canonical_key_determinism() {
+        let pubkey = [1u8, 2, 3];
+        let sig = [4u8, 5, 6];
+        let mut digest = [0u8; 32];
+        digest[0] = 0xff;
+
+        let first = sig_cache_key(0x01, &pubkey, &sig, digest);
+        let second = sig_cache_key(0x01, &pubkey, &sig, digest);
+        let different_suite = sig_cache_key(0x02, &pubkey, &sig, digest);
+
+        assert_eq!(first, second);
+        assert_ne!(first, different_suite);
+    }
+
+    #[test]
+    fn zero_capacity_clamps_to_one() {
+        let cache = SigCache::new(0);
+        assert_eq!(cache.inner.capacity, 1);
+    }
+}

--- a/clients/rust/crates/rubin-consensus/src/sig_queue.rs
+++ b/clients/rust/crates/rubin-consensus/src/sig_queue.rs
@@ -1,5 +1,6 @@
 use crate::constants::{MAX_BLOCK_WEIGHT, ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES};
 use crate::error::{ErrorCode, TxError};
+use crate::sig_cache::SigCache;
 use crate::suite_registry::SuiteRegistry;
 use crate::verify_sig_openssl::{verify_sig, verify_sig_with_registry};
 use crate::worker_pool::{
@@ -57,6 +58,7 @@ pub(crate) struct SigCheckQueue {
     tasks: Vec<SigCheckTask>,
     queued_bytes: usize,
     registry: Option<SuiteRegistry>,
+    cache: Option<SigCache>,
     workers: usize,
 }
 
@@ -66,6 +68,7 @@ impl Default for SigCheckQueue {
             tasks: Vec::new(),
             queued_bytes: 0,
             registry: None,
+            cache: None,
             workers: 1,
         }
     }
@@ -95,12 +98,18 @@ impl SigCheckQueue {
             tasks: Vec::new(),
             queued_bytes: 0,
             registry: None,
+            cache: None,
             workers: workers.max(1),
         }
     }
 
     pub(crate) fn with_registry(mut self, registry: &SuiteRegistry) -> Self {
         self.registry = Some(registry.clone());
+        self
+    }
+
+    pub(crate) fn with_cache(mut self, cache: SigCache) -> Self {
+        self.cache = Some(cache);
         self
     }
 
@@ -144,12 +153,17 @@ impl SigCheckQueue {
         self.queued_bytes = 0;
         if tasks.len() == 1 || self.workers <= 1 {
             for task in tasks {
-                verify_queued_task(task, self.registry.as_ref())?;
+                verify_queued_task(task, self.registry.as_ref(), self.cache.as_ref())?;
             }
             return Ok(());
         }
 
-        verify_queued_tasks_batch(tasks, self.workers, self.registry.as_ref())
+        verify_queued_tasks_batch(
+            tasks,
+            self.workers,
+            self.registry.as_ref(),
+            self.cache.as_ref(),
+        )
     }
 
     pub(crate) fn assert_flushed(&self) -> Result<(), TxError> {
@@ -218,7 +232,17 @@ pub(crate) fn queue_or_verify_signature(
 }
 
 #[cfg_attr(not(test), allow(dead_code))]
-fn verify_queued_task(task: SigCheckTask, registry: Option<&SuiteRegistry>) -> Result<(), TxError> {
+fn verify_queued_task(
+    task: SigCheckTask,
+    registry: Option<&SuiteRegistry>,
+    cache: Option<&SigCache>,
+) -> Result<(), TxError> {
+    if let Some(cache) = cache {
+        if cache.lookup(task.suite_id, &task.pubkey, &task.sig, task.digest) {
+            return Ok(());
+        }
+    }
+
     let ok = match registry {
         Some(registry) => verify_sig_with_registry(
             task.suite_id,
@@ -232,6 +256,9 @@ fn verify_queued_task(task: SigCheckTask, registry: Option<&SuiteRegistry>) -> R
     if !ok {
         return Err(task.err_on_fail);
     }
+    if let Some(cache) = cache {
+        cache.insert(task.suite_id, &task.pubkey, &task.sig, task.digest);
+    }
     Ok(())
 }
 
@@ -239,11 +266,13 @@ fn verify_queued_tasks_batch(
     tasks: Vec<SigCheckTask>,
     workers: usize,
     registry: Option<&SuiteRegistry>,
+    cache: Option<&SigCache>,
 ) -> Result<(), TxError> {
     let token = WorkerCancellationToken::new();
     let max_tasks = tasks.len();
+    let cache = cache.cloned();
     let results = run_worker_pool(&token, workers, max_tasks, tasks, |_cancel, task| {
-        verify_queued_task(task, registry)
+        verify_queued_task(task, registry, cache.as_ref())
     })
     .map_err(sigcheck_batch_run_error_to_tx_error)?;
 
@@ -401,6 +430,7 @@ mod tests {
     use crate::hash::sha3_256;
     use crate::htlc::parse_htlc_covenant_data;
     use crate::htlc::validate_htlc_spend_q;
+    use crate::sig_cache::SigCache;
     use crate::spend_verify::{validate_p2pk_spend_q, validate_threshold_sig_spend_q};
     use crate::stealth::parse_stealth_covenant_data;
     use crate::stealth::validate_stealth_spend_q;
@@ -468,6 +498,58 @@ mod tests {
             pubkey: keypair.pubkey_bytes(),
             signature,
         }
+    }
+
+    #[test]
+    fn sig_check_queue_with_cache_single_hit() {
+        let keypair = Mldsa87Keypair::generate().expect("keypair");
+        let cache = SigCache::new(100);
+        let digest = [0x42; 32];
+        let sig = keypair.sign_digest32(digest).expect("sign");
+        let pubkey = keypair.pubkey_bytes();
+
+        cache.insert(SUITE_ID_ML_DSA_87, &pubkey, &sig, digest);
+
+        let mut queue = SigCheckQueue::new(1).with_cache(cache.clone());
+        queue
+            .push(
+                SUITE_ID_ML_DSA_87,
+                &pubkey,
+                &sig,
+                digest,
+                TxError::new(ErrorCode::TxErrSigInvalid, "test"),
+            )
+            .expect("push");
+        queue.flush().expect("flush");
+
+        assert_eq!(cache.hits(), 1);
+        assert_eq!(cache.len(), 1);
+    }
+
+    #[test]
+    fn sig_check_queue_with_cache_invalid_not_cached() {
+        let keypair = Mldsa87Keypair::generate().expect("keypair");
+        let cache = SigCache::new(100);
+        let digest = [0x42; 32];
+        let sig = keypair.sign_digest32(digest).expect("sign");
+        let pubkey = keypair.pubkey_bytes();
+        let mut bad_digest = digest;
+        bad_digest[0] ^= 0xff;
+
+        let mut queue = SigCheckQueue::new(1).with_cache(cache.clone());
+        queue
+            .push(
+                SUITE_ID_ML_DSA_87,
+                &pubkey,
+                &sig,
+                bad_digest,
+                TxError::new(ErrorCode::TxErrSigInvalid, "invalid"),
+            )
+            .expect("push");
+
+        let err = queue.flush().expect_err("invalid signature must fail");
+        assert_eq!(err.code, ErrorCode::TxErrSigInvalid);
+        assert_eq!(cache.len(), 0);
     }
 
     fn encode_htlc_claim_payload(preimage: &[u8]) -> Vec<u8> {

--- a/clients/rust/crates/rubin-consensus/src/tests/tx_validate_worker.rs
+++ b/clients/rust/crates/rubin-consensus/src/tests/tx_validate_worker.rs
@@ -150,7 +150,7 @@ fn validate_tx_local_witness_underflow() {
     ptcs[0].witness_end = ptcs[0].witness_start;
 
     let profiles = CoreExtProfiles::empty();
-    let r = validate_tx_local(&ptcs[0], &pb, [0u8; 32], 100, 0, &profiles);
+    let r = validate_tx_local(&ptcs[0], &pb, [0u8; 32], 100, 0, &profiles, None);
     assert!(!r.valid);
     assert!(r.err.is_some());
     let err = r.err.unwrap();
@@ -175,7 +175,7 @@ fn validate_tx_local_witness_count_mismatch() {
         fee: 0,
     };
     let profiles = CoreExtProfiles::empty();
-    let r = validate_tx_local(&ptc, &pb, [0u8; 32], 100, 0, &profiles);
+    let r = validate_tx_local(&ptc, &pb, [0u8; 32], 100, 0, &profiles, None);
     assert!(!r.valid);
     assert!(r.err.is_some());
     let err = r.err.unwrap();
@@ -189,7 +189,7 @@ fn validate_tx_local_fee_and_index_preserved() {
     let (pb, ptcs, _snap) = precompute_single_tx(tx, 100, 100);
 
     let profiles = CoreExtProfiles::empty();
-    let r = validate_tx_local(&ptcs[0], &pb, [0u8; 32], 100, 0, &profiles);
+    let r = validate_tx_local(&ptcs[0], &pb, [0u8; 32], 100, 0, &profiles, None);
     // Note: this test will likely fail at signature verification (dummy witness
     // won't pass ML-DSA verify) — we're testing that fee/index are set correctly
     // before any validation error is returned.
@@ -215,7 +215,7 @@ fn validate_tx_local_default_covenant_passthrough() {
         fee: 0,
     };
     let profiles = CoreExtProfiles::empty();
-    let r = validate_tx_local(&ptc, &pb, [0u8; 32], 100, 0, &profiles);
+    let r = validate_tx_local(&ptc, &pb, [0u8; 32], 100, 0, &profiles, None);
     assert!(r.valid);
     assert!(r.err.is_none());
 }
@@ -229,7 +229,7 @@ fn validate_tx_local_p2pk_dispatch_enters_branch() {
     let (pb, ptcs, _snap) = precompute_single_tx(tx, 100, 100);
 
     let profiles = CoreExtProfiles::empty();
-    let r = validate_tx_local(&ptcs[0], &pb, [0u8; 32], 100, 0, &profiles);
+    let r = validate_tx_local(&ptcs[0], &pb, [0u8; 32], 100, 0, &profiles, None);
     // Dummy sig will fail at ML-DSA verify but the P2PK branch was entered.
     // Dummy sig will fail ML-DSA verify but the P2PK branch was entered.
     // We only care that the path was exercised, not that it passed.
@@ -279,7 +279,7 @@ fn validate_tx_local_multisig_dispatch_enters_branch() {
         fee: 10,
     };
     let profiles = CoreExtProfiles::empty();
-    let r = validate_tx_local(&ptc, &pb, [0u8; 32], 100, 0, &profiles);
+    let r = validate_tx_local(&ptc, &pb, [0u8; 32], 100, 0, &profiles, None);
     // Will fail at sig verify but MULTISIG branch was entered.
     assert_eq!(r.tx_index, 1);
     assert_eq!(r.fee, 10);
@@ -327,7 +327,7 @@ fn validate_tx_local_vault_dispatch_enters_branch() {
         fee: 10,
     };
     let profiles = CoreExtProfiles::empty();
-    let r = validate_tx_local(&ptc, &pb, [0u8; 32], 100, 0, &profiles);
+    let r = validate_tx_local(&ptc, &pb, [0u8; 32], 100, 0, &profiles, None);
     assert_eq!(r.tx_index, 1);
 }
 
@@ -363,7 +363,7 @@ fn validate_tx_local_htlc_dispatch_enters_branch() {
         fee: 10,
     };
     let profiles = CoreExtProfiles::empty();
-    let r = validate_tx_local(&ptc, &pb, [0u8; 32], 100, 0, &profiles);
+    let r = validate_tx_local(&ptc, &pb, [0u8; 32], 100, 0, &profiles, None);
     assert_eq!(r.tx_index, 1);
 }
 
@@ -396,7 +396,7 @@ fn validate_tx_local_unknown_covenant_witness_slots_error() {
         fee: 10,
     };
     let profiles = CoreExtProfiles::empty();
-    let r = validate_tx_local(&ptc, &pb, [0u8; 32], 100, 0, &profiles);
+    let r = validate_tx_local(&ptc, &pb, [0u8; 32], 100, 0, &profiles, None);
     assert!(!r.valid);
     assert!(r.err.is_some());
     assert_eq!(r.err.unwrap().code, ErrorCode::TxErrCovenantTypeInvalid);
@@ -450,7 +450,7 @@ fn validate_tx_local_ext_context_build_error() {
         }],
         fee: 10,
     };
-    let r = validate_tx_local(&ptc, &pb, [0u8; 32], 100, 0, &profiles);
+    let r = validate_tx_local(&ptc, &pb, [0u8; 32], 100, 0, &profiles, None);
     assert!(!r.valid);
     assert!(r.err.is_some());
 }
@@ -460,6 +460,7 @@ fn validate_tx_local_ext_context_build_error() {
 /// result.valid = true (line 151), and the complete P2PK branch (lines 183-194).
 #[test]
 fn validate_tx_local_real_signature_full_path() {
+    use crate::sig_cache::SigCache;
     use crate::tx_helpers::{p2pk_covenant_data_for_pubkey, sign_transaction};
     use crate::verify_sig_openssl::Mldsa87Keypair;
 
@@ -516,11 +517,130 @@ fn validate_tx_local_real_signature_full_path() {
     let ptcs = precompute_tx_contexts(&pb, &utxo_map, 100).unwrap();
 
     let profiles = CoreExtProfiles::empty();
-    let r = validate_tx_local(&ptcs[0], &pb, [0u8; 32], 100, 0, &profiles);
+    let r = validate_tx_local(&ptcs[0], &pb, [0u8; 32], 100, 0, &profiles, None);
     assert!(r.valid, "expected valid tx, got err: {:?}", r.err);
     assert!(r.err.is_none());
     assert_eq!(r.sig_count, 1);
     assert_eq!(r.fee, 10); // 100 - 90
+
+    let cache = SigCache::new(100);
+    let cached_first = validate_tx_local(&ptcs[0], &pb, [0u8; 32], 100, 0, &profiles, Some(&cache));
+    assert!(
+        cached_first.valid,
+        "expected cached first run to pass: {:?}",
+        cached_first.err
+    );
+    assert_eq!(cache.hits(), 0);
+
+    let cached_second =
+        validate_tx_local(&ptcs[0], &pb, [0u8; 32], 100, 0, &profiles, Some(&cache));
+    assert!(
+        cached_second.valid,
+        "expected cached second run to pass: {:?}",
+        cached_second.err
+    );
+    assert_eq!(cache.hits(), 1);
+}
+
+#[test]
+fn run_tx_validation_workers_with_sig_cache_reuses_positive_result() {
+    use crate::sig_cache::SigCache;
+    use crate::tx_helpers::{p2pk_covenant_data_for_pubkey, sign_transaction};
+    use crate::verify_sig_openssl::Mldsa87Keypair;
+
+    let keypair = match Mldsa87Keypair::generate() {
+        Ok(kp) => kp,
+        Err(_) => return,
+    };
+    let pubkey = keypair.pubkey_bytes();
+    let cov_data = p2pk_covenant_data_for_pubkey(&pubkey);
+    let prev_txid = [0x24u8; 32];
+    let outpoint = Outpoint {
+        txid: prev_txid,
+        vout: 0,
+    };
+
+    let mut utxo_map = HashMap::new();
+    utxo_map.insert(
+        outpoint,
+        UtxoEntry {
+            value: 100,
+            covenant_type: COV_TYPE_P2PK,
+            covenant_data: cov_data.clone(),
+            creation_height: 1,
+            created_by_coinbase: false,
+        },
+    );
+
+    let mut tx = Tx {
+        version: 1,
+        tx_kind: 0x00,
+        tx_nonce: 2,
+        inputs: vec![TxInput {
+            prev_txid,
+            prev_vout: 0,
+            script_sig: Vec::new(),
+            sequence: 0,
+        }],
+        outputs: vec![TxOutput {
+            value: 90,
+            covenant_type: COV_TYPE_P2PK,
+            covenant_data: cov_data,
+        }],
+        locktime: 0,
+        da_commit_core: None,
+        da_chunk_core: None,
+        witness: Vec::new(),
+        da_payload: Vec::new(),
+    };
+
+    sign_transaction(&mut tx, &utxo_map, [0u8; 32], &keypair).expect("sign tx");
+
+    let pb = make_parsed_block(simple_coinbase(), vec![tx]);
+    let ptcs = precompute_tx_contexts(&pb, &utxo_map, 100).unwrap();
+    let token = WorkerCancellationToken::new();
+    let profiles = CoreExtProfiles::empty();
+    let cache = SigCache::new(100);
+
+    let first = run_tx_validation_workers(
+        &token,
+        1,
+        ptcs.clone(),
+        &pb,
+        [0u8; 32],
+        100,
+        0,
+        &profiles,
+        Some(cache.clone()),
+    )
+    .unwrap();
+    assert_eq!(first.len(), 1);
+    assert!(
+        first[0].error.is_none(),
+        "first run err: {:?}",
+        first[0].error
+    );
+    assert_eq!(cache.hits(), 0);
+
+    let second = run_tx_validation_workers(
+        &token,
+        1,
+        ptcs,
+        &pb,
+        [0u8; 32],
+        100,
+        0,
+        &profiles,
+        Some(cache.clone()),
+    )
+    .unwrap();
+    assert_eq!(second.len(), 1);
+    assert!(
+        second[0].error.is_none(),
+        "second run err: {:?}",
+        second[0].error
+    );
+    assert_eq!(cache.hits(), 1);
 }
 
 /// Exercises run_tx_validation_workers worker closure (lines 351-367).
@@ -532,7 +652,8 @@ fn validate_tx_local_worker_pool_closure() {
     let token = WorkerCancellationToken::new();
     let profiles = CoreExtProfiles::empty();
     let results =
-        run_tx_validation_workers(&token, 2, ptcs, &pb, [0u8; 32], 100, 0, &profiles).unwrap();
+        run_tx_validation_workers(&token, 2, ptcs, &pb, [0u8; 32], 100, 0, &profiles, None)
+            .unwrap();
     assert_eq!(results.len(), 1);
     // The result will have an error (dummy sig) but the worker was exercised.
     assert!(results[0].error.is_some() || results[0].value.is_some());
@@ -548,7 +669,8 @@ fn run_tx_validation_workers_empty() {
     let profiles = CoreExtProfiles::empty();
     let pb = make_parsed_block(simple_coinbase(), vec![]);
     let results =
-        run_tx_validation_workers(&token, 4, vec![], &pb, [0u8; 32], 1, 0, &profiles).unwrap();
+        run_tx_validation_workers(&token, 4, vec![], &pb, [0u8; 32], 1, 0, &profiles, None)
+            .unwrap();
     assert!(results.is_empty());
 }
 
@@ -562,7 +684,8 @@ fn run_tx_validation_workers_cancelled_token() {
 
     let profiles = CoreExtProfiles::empty();
     let results =
-        run_tx_validation_workers(&token, 2, ptcs, &pb, [0u8; 32], 100, 0, &profiles).unwrap();
+        run_tx_validation_workers(&token, 2, ptcs, &pb, [0u8; 32], 100, 0, &profiles, None)
+            .unwrap();
     assert_eq!(results.len(), 1);
     assert!(results[0].error.is_some());
     match &results[0].error {

--- a/clients/rust/crates/rubin-consensus/src/tx_validate_worker.rs
+++ b/clients/rust/crates/rubin-consensus/src/tx_validate_worker.rs
@@ -3,13 +3,15 @@ use crate::constants::{
     CORE_EXT_WITNESS_SLOTS, CORE_STEALTH_WITNESS_SLOTS, COV_TYPE_EXT, COV_TYPE_HTLC,
     COV_TYPE_MULTISIG, COV_TYPE_P2PK, COV_TYPE_STEALTH, COV_TYPE_VAULT,
 };
-use crate::core_ext::{validate_core_ext_spend_with_cache_and_suite_context, CoreExtProfiles};
+use crate::core_ext::{validate_core_ext_spend_with_cache_and_suite_context_q, CoreExtProfiles};
 use crate::error::{ErrorCode, TxError};
-use crate::htlc::validate_htlc_spend_at_height;
+use crate::htlc::validate_htlc_spend_q;
 use crate::precompute::PrecomputedTxContext;
+use crate::sig_cache::SigCache;
+use crate::sig_queue::SigCheckQueue;
 use crate::sighash::SighashV1PrehashCache;
-use crate::spend_verify::{validate_p2pk_spend_at_height, validate_threshold_sig_spend_at_height};
-use crate::stealth::validate_stealth_spend_at_height;
+use crate::spend_verify::{validate_p2pk_spend_q, validate_threshold_sig_spend_q};
+use crate::stealth::validate_stealth_spend_q;
 use crate::suite_registry::{DefaultRotationProvider, RotationProvider, SuiteRegistry};
 use crate::tx::{Tx, WitnessItem};
 use crate::txcontext::{
@@ -61,6 +63,7 @@ pub fn validate_tx_local(
     block_height: u64,
     block_mtp: u64,
     core_ext_profiles: &CoreExtProfiles,
+    sig_cache: Option<&SigCache>,
 ) -> TxValidationResult {
     let mut result = TxValidationResult {
         tx_index: ptc.tx_index,
@@ -94,6 +97,10 @@ pub fn validate_tx_local(
 
     let rotation = DefaultRotationProvider;
     let registry = SuiteRegistry::default_registry();
+    let mut sig_queue = SigCheckQueue::new(1).with_registry(&registry);
+    if let Some(sig_cache) = sig_cache {
+        sig_queue = sig_queue.with_cache(sig_cache.clone());
+    }
 
     let mut witness_cursor = ptc.witness_start;
     for (input_index, entry) in ptc.resolved_inputs.iter().enumerate() {
@@ -116,7 +123,6 @@ pub fn validate_tx_local(
         if let Err(e) = validate_input_spend(
             entry,
             assigned,
-            tx,
             input_index as u32,
             entry.value,
             chain_id,
@@ -127,15 +133,11 @@ pub fn validate_tx_local(
             &rotation,
             &registry,
             tx_context.as_ref(),
+            Some(&mut sig_queue),
         ) {
             result.err = Some(e);
             return result;
         }
-
-        // Count one sig verification per input that carries a signature.
-        // Covenant types with zero witness slots or no-op validation (anchor,
-        // da_commit) are excluded by the precompute stage.
-        result.sig_count += 1;
 
         witness_cursor += slots;
     }
@@ -145,6 +147,12 @@ pub fn validate_tx_local(
             ErrorCode::TxErrParse,
             "witness_count mismatch",
         ));
+        return result;
+    }
+
+    result.sig_count = sig_queue.len();
+    if let Err(e) = sig_queue.flush() {
+        result.err = Some(e);
         return result;
     }
 
@@ -160,7 +168,6 @@ pub fn validate_tx_local(
 fn validate_input_spend(
     entry: &UtxoEntry,
     assigned: &[WitnessItem],
-    tx: &Tx,
     input_index: u32,
     input_value: u64,
     chain_id: [u8; 32],
@@ -171,6 +178,7 @@ fn validate_input_spend(
     rotation: &dyn RotationProvider,
     registry: &SuiteRegistry,
     tx_context: Option<&TxContextBundle>,
+    sig_queue: Option<&mut SigCheckQueue>,
 ) -> Result<(), TxError> {
     match entry.covenant_type {
         COV_TYPE_P2PK => {
@@ -180,15 +188,15 @@ fn validate_input_spend(
                     "CORE_P2PK witness_slots must be 1",
                 ));
             }
-            validate_p2pk_spend_at_height(
+            validate_p2pk_spend_q(
                 entry,
                 &assigned[0],
-                tx,
                 input_index,
                 input_value,
                 chain_id,
                 block_height,
                 sighash_cache,
+                sig_queue,
                 Some(rotation),
                 Some(registry),
             )
@@ -196,17 +204,17 @@ fn validate_input_spend(
 
         COV_TYPE_MULTISIG => {
             let m = parse_multisig_covenant_data(&entry.covenant_data)?;
-            validate_threshold_sig_spend_at_height(
+            validate_threshold_sig_spend_q(
                 &m.keys,
                 m.threshold,
                 assigned,
-                tx,
                 input_index,
                 input_value,
                 chain_id,
                 block_height,
                 "CORE_MULTISIG",
                 sighash_cache,
+                sig_queue,
                 Some(rotation),
                 Some(registry),
             )
@@ -217,17 +225,17 @@ fn validate_input_spend(
             // Full vault policy (whitelist, owner lock, output checks) is
             // enforced in the sequential commit stage.
             let v = parse_vault_covenant_data_for_spend(&entry.covenant_data)?;
-            validate_threshold_sig_spend_at_height(
+            validate_threshold_sig_spend_q(
                 &v.keys,
                 v.threshold,
                 assigned,
-                tx,
                 input_index,
                 input_value,
                 chain_id,
                 block_height,
                 "CORE_VAULT",
                 sighash_cache,
+                sig_queue,
                 Some(rotation),
                 Some(registry),
             )
@@ -240,17 +248,17 @@ fn validate_input_spend(
                     "CORE_HTLC witness_slots must be 2",
                 ));
             }
-            validate_htlc_spend_at_height(
+            validate_htlc_spend_q(
                 entry,
                 &assigned[0], // path_item
                 &assigned[1], // sig_item
-                tx,
                 input_index,
                 input_value,
                 chain_id,
                 block_height,
                 block_mtp,
                 sighash_cache,
+                sig_queue,
                 Some(rotation),
                 Some(registry),
             )
@@ -263,10 +271,9 @@ fn validate_input_spend(
                     "CORE_EXT witness_slots must be 1",
                 ));
             }
-            validate_core_ext_spend_with_cache_and_suite_context(
+            validate_core_ext_spend_with_cache_and_suite_context_q(
                 entry,
                 &assigned[0],
-                tx,
                 input_index,
                 input_value,
                 chain_id,
@@ -275,6 +282,7 @@ fn validate_input_spend(
                 Some(rotation),
                 Some(registry),
                 tx_context,
+                sig_queue,
                 sighash_cache,
             )
         }
@@ -286,15 +294,15 @@ fn validate_input_spend(
                     "CORE_STEALTH witness_slots must be 1",
                 ));
             }
-            validate_stealth_spend_at_height(
+            validate_stealth_spend_q(
                 entry,
                 &assigned[0],
-                tx,
                 input_index,
                 input_value,
                 chain_id,
                 block_height,
                 sighash_cache,
+                sig_queue,
                 Some(rotation),
                 Some(registry),
             )
@@ -344,6 +352,7 @@ pub fn run_tx_validation_workers(
     block_height: u64,
     block_mtp: u64,
     core_ext_profiles: &CoreExtProfiles,
+    sig_cache: Option<SigCache>,
 ) -> Result<Vec<WorkerResult<TxValidationResult, TxError>>, WorkerPoolRunError> {
     let max_tasks = ptcs.len();
     if max_tasks == 0 {
@@ -357,6 +366,7 @@ pub fn run_tx_validation_workers(
             block_height,
             block_mtp,
             core_ext_profiles,
+            sig_cache.as_ref(),
         );
         if let Some(ref e) = r.err {
             Err(e.clone())


### PR DESCRIPTION
## Summary
- add bounded positive-only Rust `SigCache` with canonical Go-parity keys
- wire `SigCheckQueue` to reuse cached positive results without changing accept/reject semantics
- route tx worker validation through queue-aware spend validators and shared cache plumbing

## Testing
- cargo fmt --manifest-path clients/rust/Cargo.toml --all
- cargo clippy --manifest-path clients/rust/Cargo.toml -p rubin-consensus --all-targets -- -D warnings
- cargo test --manifest-path clients/rust/Cargo.toml -p rubin-consensus -- --test-threads=1

Closes #889