### PR TITLE
ci: submit dependency snapshots for PR heads

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -20,4 +20,6 @@ jobs:
         with:
           fail-on-severity: high
           deny-licenses: AGPL-3.0, GPL-3.0
-          comment-summary-in-pr: always
+          comment-summary-in-pr: on-failure
+          retry-on-snapshot-warnings: true
+          retry-on-snapshot-warnings-timeout: 120

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,26 @@
+name: dependency-submission
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  dependency-submission:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+      - name: Submit dependency snapshot
+        uses: advanced-security/component-detection-dependency-submission-action@9c110eb34dee187cd9eca76a652b9f6a0ed22927 # v0.1.1
+        with:
+          detectorsCategories: Cargo,GoMod
+          correlator: repo-manifests


### PR DESCRIPTION
## Summary
- add dependency snapshot submission for Cargo and GoMod manifests on PR heads and main
- let dependency-review retry while waiting for snapshots
- stop posting success comments on every PR push by limiting summary comments to failures

## Testing
- python3 /Users/gpt/Documents/rubin-orchestration-private/inbox/operational/tools/run_pr_lifecycle.py pre-pr --target-repo rubin-protocol --skip-execution-drift --skip-cascade