### PR TITLE
ci: harden Kani workflow flags

### DIFF
--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -53,7 +53,9 @@ jobs:
             clients/rust/crates/rubin-consensus/target
           key: kani-cargo-${{ runner.os }}-${{ hashFiles('clients/rust/crates/rubin-consensus/Cargo.toml') }}
 
+      # Keep the current proof surface, but turn on UB diagnostics and cap
+      # per-harness solver time so one pathological proof cannot stall CI.
       - uses: model-checking/kani-github-action@f838096619a707b0f6b2118cf435eaccfa33e51f # v1.1
         with:
           working-directory: clients/rust/crates/rubin-consensus
-          args: '--output-format=terse'
+          args: '--output-format=terse --ub-check --harness-timeout 120'


### PR DESCRIPTION
## Summary
- add the validated --ub-check and --harness-timeout 120 flags to the live Kani workflow
- keep the existing proof surface and unwind strategy unchanged
- document the intent inline so the CI-only hardening does not get widened into a generic Kani refactor

## Task
- Q-CI-VERIFY-KANI-GATE-HARDENING-01
- rubin-protocol#917

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/kani.yml"); puts "yaml-ok"'
- git diff --check -- .github/workflows/kani.yml
- python3 /Users/gpt/Documents/rubin-orchestration-private/inbox/operational/tools/run_pr_lifecycle.py pre-pr --target-repo rubin-protocol
- /Users/gpt/bin/cl push