### PR TITLE
ci: enforce hard Kani timeout kill-after

### DIFF
--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -87,12 +87,12 @@ jobs:
           fi
 
       # Keep the current proof surface. Step-level timeout fails closed if a
-      # harness or cargo-kani stalls, while the job-level timeout remains a
-      # backstop for cleanup/cache save.
+      # harness or cargo-kani stalls; add a kill-after backstop so a trapped
+      # TERM cannot silently stretch the lane until the job-level timeout.
       - name: Run Kani proofs
         shell: bash
         working-directory: clients/rust/crates/rubin-consensus
         run: |
           set -euo pipefail
           export PATH="$HOME/.cargo/bin:$PATH"
-          timeout --signal=TERM 900 cargo kani --output-format=terse
+          timeout --signal=TERM --kill-after=30s 900 cargo kani --output-format=terse


### PR DESCRIPTION
## Summary
- add a real hard-stop backstop to the Kani timeout with `--kill-after=30s`
- keep the existing TERM-first behavior and current proof surface unchanged
- preserve the cache/install path landed in `#927`

Closes #929.

## Why
`timeout --signal=TERM 900` is not a strict runtime cap because TERM can be trapped or delayed. This follow-up makes the Kani lane fail closed instead of drifting toward the 20-minute job timeout when a solver or cargo-kani run stalls.

## Validation
- local YAML parse check
