### PR TITLE
test: add tractable Kani context helper coverage

### DIFF
--- a/clients/rust/crates/rubin-consensus/src/tx_helpers.rs
+++ b/clients/rust/crates/rubin-consensus/src/tx_helpers.rs
@@ -230,6 +230,18 @@ mod tests {
     }
 
     #[test]
+    fn p2pk_covenant_data_for_pubkey_emits_canonical_shape_and_is_deterministic() {
+        let pubkey = b"rubin-p2pk-shape";
+        let covenant_data = p2pk_covenant_data_for_pubkey(pubkey);
+        let repeated = p2pk_covenant_data_for_pubkey(pubkey);
+
+        assert_eq!(covenant_data.len(), MAX_P2PK_COVENANT_DATA as usize);
+        assert_eq!(covenant_data[0], SUITE_ID_ML_DSA_87);
+        assert_eq!(covenant_data[1..33], sha3_256(pubkey));
+        assert_eq!(covenant_data, repeated);
+    }
+
+    #[test]
     fn marshal_tx_roundtrips_via_parse_tx() {
         let tx = test_tx();
         let bytes = marshal_tx(&tx).expect("marshal");

--- a/clients/rust/crates/rubin-consensus/src/txcontext.rs
+++ b/clients/rust/crates/rubin-consensus/src/txcontext.rs
@@ -34,6 +34,44 @@ mod verification {
         let split = Uint128 { lo, hi };
         assert_eq!(Uint128::from_native(split.to_native()), split);
     }
+
+    #[kani::proof]
+    fn verify_txcontext_get_output_checked_accepts_highest_valid_index() {
+        let mut continuing = TxContextContinuing::default();
+        continuing.continuing_output_count = 2;
+        continuing.continuing_outputs[0] = Some(TxOutputView {
+            value: 11,
+            ext_payload: Arc::from(&[0x71][..]),
+        });
+        continuing.continuing_outputs[1] = Some(TxOutputView {
+            value: 12,
+            ext_payload: Arc::from(&[0x72][..]),
+        });
+
+        let output = continuing.get_output_checked(1).expect("index 1");
+        assert_eq!(output.value, 12);
+        assert_eq!(output.ext_payload.as_ref(), &[0x72]);
+    }
+
+    #[kani::proof]
+    fn verify_txcontext_get_output_checked_rejects_count_boundary_index() {
+        let mut continuing = TxContextContinuing::default();
+        continuing.continuing_output_count = 2;
+        continuing.continuing_outputs[0] = Some(TxOutputView {
+            value: 11,
+            ext_payload: Arc::from(&[0x71][..]),
+        });
+        continuing.continuing_outputs[1] = Some(TxOutputView {
+            value: 12,
+            ext_payload: Arc::from(&[0x72][..]),
+        });
+
+        let err = continuing
+            .get_output_checked(TXCONTEXT_MAX_CONTINUING_OUTPUTS)
+            .expect_err("boundary index must fail");
+        assert_eq!(err.code, ErrorCode::TxErrSigInvalid);
+        assert_eq!(err.msg, "txcontext continuing output index out of bounds");
+    }
 }
 
 impl Uint128 {
@@ -329,6 +367,45 @@ mod tests {
         )
         .unwrap();
         assert!(bundle.is_none());
+    }
+
+    #[test]
+    fn collect_txcontext_ext_ids_skips_disabled_profiles_and_deduplicates() {
+        let resolved_inputs = vec![
+            UtxoEntry {
+                value: 11,
+                covenant_type: COV_TYPE_EXT,
+                covenant_data: core_ext_covdata(9, &[0x90]),
+                creation_height: 0,
+                created_by_coinbase: false,
+            },
+            UtxoEntry {
+                value: 12,
+                covenant_type: COV_TYPE_EXT,
+                covenant_data: core_ext_covdata(7, &[0x71]),
+                creation_height: 0,
+                created_by_coinbase: false,
+            },
+            UtxoEntry {
+                value: 13,
+                covenant_type: COV_TYPE_EXT,
+                covenant_data: core_ext_covdata(7, &[0x72]),
+                creation_height: 0,
+                created_by_coinbase: false,
+            },
+            UtxoEntry {
+                value: 14,
+                covenant_type: crate::constants::COV_TYPE_P2PK,
+                covenant_data: vec![],
+                creation_height: 0,
+                created_by_coinbase: false,
+            },
+        ];
+
+        let ext_ids =
+            collect_txcontext_ext_ids(&resolved_inputs, &static_profiles(&[(7, true), (9, false)]))
+                .expect("collect ext_ids");
+        assert_eq!(ext_ids, vec![7]);
     }
 
     #[test]

--- a/clients/rust/crates/rubin-consensus/src/vault.rs
+++ b/clients/rust/crates/rubin-consensus/src/vault.rs
@@ -225,6 +225,25 @@ mod verification {
     use super::*;
 
     #[kani::proof]
+    fn verify_witness_slots_defaults_to_one_for_short_multisig_payload() {
+        let slots = witness_slots(COV_TYPE_MULTISIG, &[]).expect("short multisig");
+        assert_eq!(slots, 1);
+    }
+
+    #[kani::proof]
+    fn verify_witness_slots_defaults_to_one_for_short_vault_payload() {
+        let slots = witness_slots(COV_TYPE_VAULT, &[0u8; 33]).expect("short vault");
+        assert_eq!(slots, 1);
+    }
+
+    #[kani::proof]
+    fn verify_witness_slots_rejects_unknown_covenant_type() {
+        let err = witness_slots(0xffff, &[]).expect_err("unknown covenant must fail");
+        assert_eq!(err.code, ErrorCode::TxErrCovenantTypeInvalid);
+        assert_eq!(err.msg, "unsupported covenant in witness_slots");
+    }
+
+    #[kani::proof]
     fn verify_parse_vault_covenant_data_rejects_zero_key_count() {
         let owner_lock_id = [0u8; 32];
         let mut covenant_data = Vec::with_capacity(34);


### PR DESCRIPTION
## Summary

- add tractable Kani proofs for `TxContextContinuing::get_output_checked`
- add tractable Kani proofs for `witness_slots` covenant helper boundaries
- pin non-tractable `txcontext` dedup and `p2pk` canonical-shape behavior with deterministic unit tests

## Scope

- [ ] Documentation-only
- [x] Implementation-only change (no consensus change)
- [ ] Consensus-affecting change (requires explicit process)

**Consensus boundary (required):**

- Consensus rules unchanged: YES
- `SECTION_HASHES.json` unchanged: YES
- Wire format unchanged: YES

## Evidence / Gates

- Local:
  - `cargo fmt --all`: PASS
  - `cargo test -p rubin-consensus txcontext -- --nocapture`: PASS
  - `cargo test -p rubin-consensus tx_helpers -- --nocapture`: PASS
  - `cargo test -p rubin-consensus vault -- --nocapture`: PASS
  - targeted `cargo kani` harnesses for txcontext/vault helper boundaries: PASS
  - `run_pr_lifecycle.py pre-pr --target-repo rubin-protocol --skip-execution-drift`: PASS
- CI links:
  - test:
  - coverage:
  - policy/validator:
- Conformance:
  - not applicable (no spec / vector change)
- Replay / determinism:
  - deterministic unit test coverage added for helper outputs / dedup behavior

## Notes

- `build_tx_context` / `collect_txcontext_ext_ids` Kani proofs were intentionally not kept because `BTreeMap` / `BTreeSet` internals made the harnesses non-tractable for CI.
- `p2pk_covenant_data_for_pubkey` remains covered by deterministic unit test, not Kani, because the current Kani workflow excludes SHA3-heavy surfaces.

Refs: Q-VERIFY-RUST-KANI-CONTEXT-HELPERS-01
Closes #923
