### PR TITLE
test: add Go fuzz state helper coverage

### DIFF
--- a/clients/go/consensus/fuzz_state_helpers_test.go
+++ b/clients/go/consensus/fuzz_state_helpers_test.go
@@ -1,0 +1,250 @@
+package consensus
+
+import (
+	"bytes"
+	"encoding/binary"
+	"reflect"
+	"testing"
+)
+
+type fuzzTxContextOutputSnapshot struct {
+	Value      uint64
+	ExtPayload []byte
+}
+
+type fuzzTxContextBundleSnapshot struct {
+	Present      bool
+	TotalIn      Uint128
+	TotalOut     Uint128
+	Height       uint64
+	OrderedExtID []uint16
+	Continuing   map[uint16][]fuzzTxContextOutputSnapshot
+}
+
+type fuzzUtxoSetHashEntry struct {
+	op    Outpoint
+	entry UtxoEntry
+}
+
+func seedBuildTxContextFuzzBytes() []byte {
+	tx := &Tx{
+		Version: 1,
+		TxKind:  0x00,
+		TxNonce: 1,
+		Inputs: []TxInput{
+			{
+				PrevTxid: [32]byte{0x07, 0x00, 0x02, 0xAA, 0xBB},
+				PrevVout: 0,
+				Sequence: 0,
+			},
+		},
+		Outputs: []TxOutput{
+			{
+				Value:        90,
+				CovenantType: COV_TYPE_CORE_EXT,
+				CovenantData: makeCoreExtCovenantDataWithPayload(7, []byte{0x10, 0x20}),
+			},
+			{
+				Value:        10,
+				CovenantType: COV_TYPE_P2PK,
+				CovenantData: validP2PKCovenantData(),
+			},
+		},
+		Locktime: 0,
+	}
+	raw, err := MarshalTx(tx)
+	if err != nil {
+		panic(err)
+	}
+	return raw
+}
+
+func buildFuzzTxContextResolvedInputs(tx *Tx) ([]UtxoEntry, *staticMapCoreExtProfileProvider) {
+	profiles := make(map[uint16]CoreExtProfile)
+	resolved := make([]UtxoEntry, 0, len(tx.Inputs))
+	for i, in := range tx.Inputs {
+		value := uint64(i + 1)
+		useCoreExt := i == 0 || (in.PrevTxid[0]&0x01) == 0
+		if useCoreExt {
+			extID := binary.LittleEndian.Uint16(in.PrevTxid[:2])
+			if extID == 0 {
+				extID = uint16(i + 1)
+			}
+			payloadLen := int(in.PrevTxid[2] & 0x03)
+			payload := append([]byte(nil), in.PrevTxid[3:3+payloadLen]...)
+			resolved = append(resolved, UtxoEntry{
+				Value:        value,
+				CovenantType: COV_TYPE_CORE_EXT,
+				CovenantData: makeCoreExtCovenantDataWithPayload(extID, payload),
+			})
+			profiles[extID] = CoreExtProfile{Active: true, TxContextEnabled: true}
+			continue
+		}
+		resolved = append(resolved, UtxoEntry{
+			Value:        value,
+			CovenantType: COV_TYPE_P2PK,
+			CovenantData: validP2PKCovenantData(),
+		})
+	}
+	return resolved, &staticMapCoreExtProfileProvider{profiles: profiles}
+}
+
+func snapshotTxContextBundle(bundle *TxContextBundle) fuzzTxContextBundleSnapshot {
+	if bundle == nil {
+		return fuzzTxContextBundleSnapshot{}
+	}
+	snapshot := fuzzTxContextBundleSnapshot{
+		Present:      true,
+		OrderedExtID: append([]uint16(nil), bundle.OrderedExtIDs()...),
+		Continuing:   make(map[uint16][]fuzzTxContextOutputSnapshot),
+	}
+	if bundle.Base != nil {
+		snapshot.TotalIn = bundle.Base.TotalIn
+		snapshot.TotalOut = bundle.Base.TotalOut
+		snapshot.Height = bundle.Base.Height
+	}
+	for extID, continuing := range bundle.ContinuingByExt {
+		if continuing == nil {
+			snapshot.Continuing[extID] = nil
+			continue
+		}
+		count := int(continuing.ContinuingOutputCount)
+		if count > len(continuing.ContinuingOutputs) {
+			count = len(continuing.ContinuingOutputs)
+		}
+		outputs := make([]fuzzTxContextOutputSnapshot, 0, count)
+		for i := 0; i < count; i++ {
+			out := continuing.ContinuingOutputs[i]
+			outputs = append(outputs, fuzzTxContextOutputSnapshot{
+				Value:      out.Value,
+				ExtPayload: append([]byte(nil), out.ExtPayload...),
+			})
+		}
+		snapshot.Continuing[extID] = outputs
+	}
+	return snapshot
+}
+
+func decodeUtxoSetHashEntries(data []byte) []fuzzUtxoSetHashEntry {
+	const stride = 72
+	count := len(data) / stride
+	if count > 32 {
+		count = 32
+	}
+	out := make([]fuzzUtxoSetHashEntry, 0, count)
+	for i := 0; i < count; i++ {
+		chunk := data[i*stride : (i+1)*stride]
+		var op Outpoint
+		copy(op.Txid[:], chunk[:32])
+		op.Vout = binary.LittleEndian.Uint32(chunk[32:36])
+		payloadLen := int(chunk[55] % 17)
+		out = append(out, fuzzUtxoSetHashEntry{
+			op: op,
+			entry: UtxoEntry{
+				Value:             binary.LittleEndian.Uint64(chunk[36:44]),
+				CreationHeight:    binary.LittleEndian.Uint64(chunk[44:52]),
+				CovenantType:      binary.LittleEndian.Uint16(chunk[52:54]),
+				CreatedByCoinbase: (chunk[54] & 0x01) != 0,
+				CovenantData:      append([]byte(nil), chunk[56:56+payloadLen]...),
+			},
+		})
+	}
+	return out
+}
+
+func canonicalizeUtxoSetHashEntries(entries []fuzzUtxoSetHashEntry) []fuzzUtxoSetHashEntry {
+	lastByOutpoint := make(map[Outpoint]UtxoEntry, len(entries))
+	order := make([]Outpoint, 0, len(entries))
+	seen := make(map[Outpoint]struct{}, len(entries))
+	for _, item := range entries {
+		if _, ok := seen[item.op]; !ok {
+			order = append(order, item.op)
+			seen[item.op] = struct{}{}
+		}
+		lastByOutpoint[item.op] = item.entry
+	}
+	out := make([]fuzzUtxoSetHashEntry, 0, len(lastByOutpoint))
+	for _, op := range order {
+		entry, ok := lastByOutpoint[op]
+		if !ok {
+			continue
+		}
+		out = append(out, fuzzUtxoSetHashEntry{op: op, entry: entry})
+		delete(lastByOutpoint, op)
+	}
+	return out
+}
+
+func FuzzBuildTxContext(f *testing.F) {
+	f.Add(seedBuildTxContextFuzzBytes(), uint64(55))
+	f.Add(minimalTxBytesForFuzz(), uint64(1))
+
+	f.Fuzz(func(t *testing.T, txBytes []byte, blockHeight uint64) {
+		if len(txBytes) > 1<<20 {
+			return
+		}
+		tx, _, _, _, err := ParseTx(txBytes)
+		if err != nil {
+			return
+		}
+		cache, err := BuildTxContextOutputExtIDCache(tx)
+		if err != nil {
+			return
+		}
+
+		resolvedInputs, profiles := buildFuzzTxContextResolvedInputs(tx)
+		bundle1, err1 := BuildTxContext(tx, resolvedInputs, cache, blockHeight, profiles)
+		bundle2, err2 := BuildTxContext(tx, resolvedInputs, cache, blockHeight, profiles)
+
+		if (err1 == nil) != (err2 == nil) {
+			t.Fatalf("BuildTxContext error presence mismatch: %v vs %v", err1, err2)
+		}
+		if err1 != nil {
+			if err1.Error() != err2.Error() {
+				t.Fatalf("BuildTxContext error text mismatch: %q vs %q", err1, err2)
+			}
+			return
+		}
+
+		snap1 := snapshotTxContextBundle(bundle1)
+		snap2 := snapshotTxContextBundle(bundle2)
+		if !reflect.DeepEqual(snap1, snap2) {
+			t.Fatalf("BuildTxContext non-deterministic snapshot")
+		}
+		if bundle1 != nil && bundle1.Base != nil && bundle1.Base.Height != blockHeight {
+			t.Fatalf("bundle height=%d want %d", bundle1.Base.Height, blockHeight)
+		}
+	})
+}
+
+func FuzzUtxoSetHashDeterminism(f *testing.F) {
+	f.Add(bytes.Repeat([]byte{0x11}, 72))
+	f.Add(append(bytes.Repeat([]byte{0x22}, 72), bytes.Repeat([]byte{0x33}, 72)...))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > 72*32 {
+			return
+		}
+		entries := canonicalizeUtxoSetHashEntries(decodeUtxoSetHashEntries(data))
+
+		forward := make(map[Outpoint]UtxoEntry, len(entries))
+		reverse := make(map[Outpoint]UtxoEntry, len(entries))
+		for _, item := range entries {
+			forward[item.op] = item.entry
+		}
+		for i := len(entries) - 1; i >= 0; i-- {
+			reverse[entries[i].op] = entries[i].entry
+		}
+
+		hash1 := UtxoSetHash(forward)
+		hash2 := UtxoSetHash(reverse)
+		hash3 := UtxoSetHash(forward)
+
+		if hash1 != hash2 {
+			t.Fatalf("UtxoSetHash map-order mismatch: %x vs %x", hash1, hash2)
+		}
+		if hash1 != hash3 {
+			t.Fatalf("UtxoSetHash non-deterministic repeat: %x vs %x", hash1, hash3)
+		}
+	})
+}

--- a/clients/go/node/fuzz_disconnect_test.go
+++ b/clients/go/node/fuzz_disconnect_test.go
@@ -1,0 +1,261 @@
+package node
+
+import (
+	"bytes"
+	"crypto/sha3"
+	"encoding/hex"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+)
+
+func cloneChainStateForDisconnectFuzz(src *ChainState) *ChainState {
+	if src == nil {
+		return nil
+	}
+	utxos := make(map[consensus.Outpoint]consensus.UtxoEntry, len(src.Utxos))
+	for op, entry := range src.Utxos {
+		utxos[op] = copyUtxoEntry(entry)
+	}
+	out := &ChainState{
+		Utxos:            utxos,
+		Height:           src.Height,
+		AlreadyGenerated: src.AlreadyGenerated,
+		TipHash:          src.TipHash,
+		HasTip:           src.HasTip,
+		Rotation:         src.Rotation,
+		Registry:         src.Registry,
+	}
+	return out
+}
+
+func buildSignedTransferTxForDisconnectFuzz(
+	utxos map[consensus.Outpoint]consensus.UtxoEntry,
+	inputs []consensus.Outpoint,
+	amount uint64,
+	fee uint64,
+	nonce uint64,
+	signer *consensus.MLDSA87Keypair,
+	changeAddress []byte,
+	toAddress []byte,
+) ([]byte, error) {
+	txInputs := make([]consensus.TxInput, 0, len(inputs))
+	var totalIn uint64
+	for _, op := range inputs {
+		entry, ok := utxos[op]
+		if !ok {
+			return nil, errors.New("missing utxo")
+		}
+		totalIn += entry.Value
+		txInputs = append(txInputs, consensus.TxInput{
+			PrevTxid: op.Txid,
+			PrevVout: op.Vout,
+			Sequence: 0,
+		})
+	}
+
+	change := totalIn - amount - fee
+	outputs := []consensus.TxOutput{{
+		Value:        amount,
+		CovenantType: consensus.COV_TYPE_P2PK,
+		CovenantData: append([]byte(nil), toAddress...),
+	}}
+	if change > 0 {
+		outputs = append(outputs, consensus.TxOutput{
+			Value:        change,
+			CovenantType: consensus.COV_TYPE_P2PK,
+			CovenantData: append([]byte(nil), changeAddress...),
+		})
+	}
+
+	tx := &consensus.Tx{
+		Version:  1,
+		TxKind:   0x00,
+		TxNonce:  nonce,
+		Inputs:   txInputs,
+		Outputs:  outputs,
+		Locktime: 0,
+	}
+	if err := consensus.SignTransaction(tx, utxos, devnetGenesisChainID, signer); err != nil {
+		return nil, err
+	}
+	return consensus.MarshalTx(tx)
+}
+
+func buildMultiTxBlockForDisconnectFuzz(prevHash [32]byte, target [32]byte, timestamp uint64, txs ...[]byte) ([]byte, error) {
+	txids := make([][32]byte, 0, len(txs))
+	totalLen := consensus.BLOCK_HEADER_BYTES + 8
+	for _, txBytes := range txs {
+		_, txid, _, _, err := consensus.ParseTx(txBytes)
+		if err != nil {
+			return nil, err
+		}
+		txids = append(txids, txid)
+		totalLen += len(txBytes)
+	}
+	root, err := consensus.MerkleRootTxids(txids)
+	if err != nil {
+		return nil, err
+	}
+	header := make([]byte, 0, consensus.BLOCK_HEADER_BYTES)
+	header = consensus.AppendU32le(header, 1)
+	header = append(header, prevHash[:]...)
+	header = append(header, root[:]...)
+	header = consensus.AppendU64le(header, timestamp)
+	header = append(header, target[:]...)
+	header = consensus.AppendU64le(header, 7)
+
+	block := make([]byte, 0, totalLen)
+	block = append(block, header...)
+	block = consensus.AppendCompactSize(block, uint64(len(txs)))
+	for _, txBytes := range txs {
+		block = append(block, txBytes...)
+	}
+	return block, nil
+}
+
+func coinbaseWithWitnessCommitmentForDisconnectFuzz(height uint64, value uint64, wtxids [][32]byte) ([]byte, error) {
+	wroot, err := consensus.WitnessMerkleRootWtxids(wtxids)
+	if err != nil {
+		return nil, err
+	}
+	commitment := consensus.WitnessCommitmentHash(wroot)
+	return coinbaseTxWithOutputs(uint32(height), []testOutput{
+		{value: value, covenantType: consensus.COV_TYPE_P2PK, covenantData: testP2PKCovenantData(0x11)},
+		{value: 0, covenantType: consensus.COV_TYPE_ANCHOR, covenantData: commitment[:]},
+	}), nil
+}
+
+func mustDisconnectFuzzFixture(tb testing.TB) ([]byte, []byte, *ChainState, *ChainState) {
+	tb.Helper()
+
+	signer, err := consensus.NewMLDSA87Keypair()
+	if err != nil {
+		if strings.Contains(strings.ToLower(err.Error()), "unsupported") {
+			tb.Skipf("ML-DSA backend unavailable: %v", err)
+		}
+		tb.Fatalf("NewMLDSA87Keypair: %v", err)
+	}
+	defer signer.Close()
+
+	keyID := sha3.Sum256(signer.PubkeyBytes())
+	fromAddr, err := ParseMineAddress(hex.EncodeToString(keyID[:]))
+	if err != nil {
+		tb.Fatalf("ParseMineAddress: %v", err)
+	}
+
+	prevState, ops := testSpendableChainState(fromAddr, []uint64{100})
+	preDisconnectState := cloneChainStateForDisconnectFuzz(prevState)
+	target := consensus.POW_LIMIT
+	height := prevState.Height + 1
+
+	spendTx, err := buildSignedTransferTxForDisconnectFuzz(prevState.Utxos, []consensus.Outpoint{ops[0]}, 90, 1, 1, signer, fromAddr, fromAddr)
+	if err != nil {
+		tb.Fatalf("buildSignedTransferTx: %v", err)
+	}
+	_, _, spendWTxID, _, err := consensus.ParseTx(spendTx)
+	if err != nil {
+		tb.Fatalf("ParseTx(spend): %v", err)
+	}
+
+	subsidy := consensus.BlockSubsidy(height, prevState.AlreadyGenerated)
+	coinbase, err := coinbaseWithWitnessCommitmentForDisconnectFuzz(height, subsidy, [][32]byte{{}, spendWTxID})
+	if err != nil {
+		tb.Fatalf("coinbaseWithWitnessCommitment: %v", err)
+	}
+	blockBytes, err := buildMultiTxBlockForDisconnectFuzz(prevState.TipHash, target, 2, coinbase, spendTx)
+	if err != nil {
+		tb.Fatalf("buildMultiTxBlock: %v", err)
+	}
+
+	pb, err := consensus.ParseBlockBytes(blockBytes)
+	if err != nil {
+		tb.Fatalf("ParseBlockBytes: %v", err)
+	}
+	undo, err := buildBlockUndo(preDisconnectState, pb, height)
+	if err != nil {
+		tb.Fatalf("buildBlockUndo: %v", err)
+	}
+	rawUndo, err := marshalBlockUndo(undo)
+	if err != nil {
+		tb.Fatalf("marshalBlockUndo: %v", err)
+	}
+
+	postDisconnectState := cloneChainStateForDisconnectFuzz(preDisconnectState)
+	if _, err := postDisconnectState.ConnectBlock(blockBytes, &target, nil, devnetGenesisChainID); err != nil {
+		tb.Fatalf("ConnectBlock: %v", err)
+	}
+
+	return blockBytes, rawUndo, postDisconnectState, preDisconnectState
+}
+
+func FuzzDisconnectBlock(f *testing.F) {
+	blockSeed, undoSeed, postStateSeed, preStateSeed := mustDisconnectFuzzFixture(f)
+	f.Add(blockSeed, undoSeed)
+	f.Add([]byte{0x01, 0x02}, undoSeed)
+
+	f.Fuzz(func(t *testing.T, blockBytes []byte, rawUndo []byte) {
+		if len(blockBytes) > 2<<20 || len(rawUndo) > 1<<20 {
+			return
+		}
+		undo, err := unmarshalBlockUndo(rawUndo)
+		if err != nil {
+			return
+		}
+
+		st1 := cloneChainStateForDisconnectFuzz(postStateSeed)
+		st2 := cloneChainStateForDisconnectFuzz(postStateSeed)
+		beforeHash := consensus.UtxoSetHash(postStateSeed.Utxos)
+		beforeHeight := postStateSeed.Height
+		beforeTip := postStateSeed.TipHash
+		beforeAlreadyGenerated := postStateSeed.AlreadyGenerated
+		beforeHasTip := postStateSeed.HasTip
+
+		summary1, err1 := st1.DisconnectBlock(blockBytes, undo)
+		summary2, err2 := st2.DisconnectBlock(blockBytes, undo)
+
+		if (err1 == nil) != (err2 == nil) {
+			t.Fatalf("DisconnectBlock error presence mismatch: %v vs %v", err1, err2)
+		}
+		if err1 != nil {
+			if err1.Error() != err2.Error() {
+				t.Fatalf("DisconnectBlock error text mismatch: %q vs %q", err1, err2)
+			}
+			if consensus.UtxoSetHash(st1.Utxos) != beforeHash || consensus.UtxoSetHash(st2.Utxos) != beforeHash {
+				t.Fatalf("DisconnectBlock mutated state on error")
+			}
+			if st1.Height != beforeHeight || st2.Height != beforeHeight {
+				t.Fatalf("DisconnectBlock changed height on error")
+			}
+			if st1.TipHash != beforeTip || st2.TipHash != beforeTip {
+				t.Fatalf("DisconnectBlock changed tip on error")
+			}
+			if st1.AlreadyGenerated != beforeAlreadyGenerated || st2.AlreadyGenerated != beforeAlreadyGenerated {
+				t.Fatalf("DisconnectBlock changed already_generated on error")
+			}
+			if st1.HasTip != beforeHasTip || st2.HasTip != beforeHasTip {
+				t.Fatalf("DisconnectBlock changed has_tip on error")
+			}
+			return
+		}
+
+		if !reflect.DeepEqual(summary1, summary2) {
+			t.Fatalf("DisconnectBlock summary mismatch: %+v vs %+v", summary1, summary2)
+		}
+		if consensus.UtxoSetHash(st1.Utxos) != consensus.UtxoSetHash(st2.Utxos) {
+			t.Fatalf("DisconnectBlock final state digest mismatch")
+		}
+
+		if bytes.Equal(blockBytes, blockSeed) && bytes.Equal(rawUndo, undoSeed) {
+			if consensus.UtxoSetHash(st1.Utxos) != consensus.UtxoSetHash(preStateSeed.Utxos) {
+				t.Fatalf("valid disconnect did not restore pre-state digest")
+			}
+			if st1.Height != preStateSeed.Height || st1.TipHash != preStateSeed.TipHash || st1.HasTip != preStateSeed.HasTip {
+				t.Fatalf("valid disconnect did not restore chainstate tip metadata")
+			}
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- add Go native fuzz coverage for `BuildTxContext` helper determinism
- add Go native fuzz coverage for `UtxoSetHash` map-order determinism
- add Go native fuzz coverage for live `node.ChainState.DisconnectBlock` fail-closed / reorg-state handling

## Scope

- [ ] Documentation-only
- [x] Implementation-only change (no consensus change)
- [ ] Consensus-affecting change (requires explicit process)

**Consensus boundary (required):**

- Consensus rules unchanged: YES
- `SECTION_HASHES.json` unchanged: YES
- Wire format unchanged: YES

## Evidence / Gates

- Local:
  - `go test ./consensus ./node`: PASS
  - `go test ./consensus -run=^$ -fuzz=FuzzBuildTxContext -fuzztime=60s`: PASS
  - `go test ./consensus -run=^$ -fuzz=FuzzUtxoSetHashDeterminism -fuzztime=60s`: PASS
  - `go test ./node -run=^$ -fuzz=FuzzDisconnectBlock -fuzztime=60s`: PASS
  - `run_pr_lifecycle.py pre-pr --target-repo rubin-protocol --skip-execution-drift`: PASS
- CI links:
  - test:
  - coverage:
  - policy/validator:
- Conformance:
  - not applicable (no spec / vector change)
- Replay / determinism:
  - `BuildTxContext` deterministic projection checked under fuzz
  - `UtxoSetHash` map-order independence checked under fuzz
  - `DisconnectBlock` deterministic success/error surface and fail-closed state preservation checked under fuzz

## Notes

- There is no live `DisconnectBlock` entrypoint in `clients/go/consensus`; the real reorg-state helper lives in `clients/go/node/undo.go`, so the bundle is intentionally split across `consensus` and `node`.
- The `UtxoSetHash` fuzz target canonicalizes duplicate outpoints before comparing insertion-order variants so the target measures digest determinism, not Go map overwrite semantics.

Refs: Q-VERIFY-GO-FUZZ-STATE-HELPERS-01
Closes #925
