### PR TITLE
fix(consensus): close rust helper hygiene backlog

### DIFF
--- a/clients/rust/crates/rubin-consensus/src/core_ext.rs
+++ b/clients/rust/crates/rubin-consensus/src/core_ext.rs
@@ -1,5 +1,7 @@
 use crate::compactsize::{encode_compact_size, read_compact_size_bytes};
-use crate::constants::{ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES, SUITE_ID_SENTINEL};
+use crate::constants::{
+    MAX_COVENANT_DATA_PER_OUTPUT, ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES, SUITE_ID_SENTINEL,
+};
 use crate::error::{ErrorCode, TxError};
 use crate::hash::sha3_256;
 use crate::sig_queue::{queue_or_verify_signature, SigCheckQueue};
@@ -557,6 +559,12 @@ fn verify_core_ext_openssl_digest32_binding(
 }
 
 pub fn parse_core_ext_covenant_data(cov_data: &[u8]) -> Result<CoreExtCovenant<'_>, TxError> {
+    if cov_data.len() as u64 > MAX_COVENANT_DATA_PER_OUTPUT {
+        return Err(TxError::new(
+            ErrorCode::TxErrCovenantTypeInvalid,
+            "CORE_EXT covenant_data length exceeds MAX_COVENANT_DATA_PER_OUTPUT",
+        ));
+    }
     if cov_data.len() < 2 {
         return Err(TxError::new(
             ErrorCode::TxErrCovenantTypeInvalid,
@@ -2317,6 +2325,19 @@ mod tests {
         let err = parse_core_ext_covenant_data(&cov_data).unwrap_err();
         assert_eq!(err.code, ErrorCode::TxErrCovenantTypeInvalid);
         assert_eq!(err.msg, "CORE_EXT covenant_data length mismatch");
+    }
+
+    #[test]
+    fn parse_core_ext_covenant_data_rejects_oversized_buffer() {
+        let mut cov_data = vec![0x34, 0x12, 0x00];
+        cov_data.resize(MAX_COVENANT_DATA_PER_OUTPUT as usize + 1, 0x00);
+
+        let err = parse_core_ext_covenant_data(&cov_data).unwrap_err();
+        assert_eq!(err.code, ErrorCode::TxErrCovenantTypeInvalid);
+        assert_eq!(
+            err.msg,
+            "CORE_EXT covenant_data length exceeds MAX_COVENANT_DATA_PER_OUTPUT"
+        );
     }
 }
 

--- a/clients/rust/crates/rubin-consensus/src/tx.rs
+++ b/clients/rust/crates/rubin-consensus/src/tx.rs
@@ -60,6 +60,10 @@ pub struct DaChunkCore {
     pub chunk_hash: [u8; 32],
 }
 
+/// Internal split parser used by `parse_tx` and helper/property tests.
+///
+/// Callers that need stable identifiers must hash `b[..core_end]` for `txid`
+/// and `b[..total_end]` for `wtxid`; this helper only parses wire structure.
 pub(crate) fn parse_tx_without_hashes(b: &[u8]) -> Result<(Tx, usize, usize), TxError> {
     let mut r = Reader::new(b);
 

--- a/clients/rust/crates/rubin-consensus/src/tx_dep_graph.rs
+++ b/clients/rust/crates/rubin-consensus/src/tx_dep_graph.rs
@@ -56,6 +56,12 @@ fn sort_tx_dep_edges(edges: &mut [TxDepEdge]) {
 }
 
 fn compute_tx_dep_levels(tx_count: usize, edges: &[TxDepEdge]) -> (Vec<usize>, usize) {
+    debug_assert!(
+        edges
+            .iter()
+            .all(|edge| { edge.producer_idx < edge.consumer_idx && edge.consumer_idx < tx_count }),
+        "tx_dep_graph edges must reference earlier in-range producers and in-range consumers",
+    );
     let mut levels = vec![0usize; tx_count];
     for edge in edges {
         levels[edge.consumer_idx] = levels[edge.consumer_idx].max(levels[edge.producer_idx] + 1);
@@ -73,6 +79,11 @@ fn tx_dep_level_order_key(
 }
 
 fn compute_tx_dep_level_order(contexts: &[TxValidationContext], levels: &[usize]) -> Vec<usize> {
+    debug_assert_eq!(
+        contexts.len(),
+        levels.len(),
+        "tx_dep_graph level_order requires one level per validation context",
+    );
     let mut order: Vec<usize> = (0..contexts.len()).collect();
     order.sort_by_key(|idx| tx_dep_level_order_key(contexts, levels, *idx));
     order


### PR DESCRIPTION
Refs: Q-IMPL-PROTOCOL-BATCH-926-937-HYGIENE-BACKLOG-01

## Summary
- add a local `MAX_COVENANT_DATA_PER_OUTPUT` guard to the Rust `CORE_EXT` helper parser
- document the caller hash contract on `parse_tx_without_hashes`
- add debug assertions for `tx_dep_graph` internal helper invariants

## Scope
- Rust helper hygiene only inside `rubin-consensus`
- no Go behavior changes
- no spec, fixture, or activation changes

Consensus rules unchanged: YES
SECTION_HASHES.json unchanged: YES

## Testing
- `cargo test -p rubin-consensus oversized_buffer -- --nocapture`
- `cargo test -p rubin-consensus build_tx_dep_graph -- --nocapture`
- `bash scripts/local-codacy-coverage-check.sh origin/main`
- `/Users/gpt/bin/cl push` (job `20260328T185438Z-22165-787d4355`)

Closes #940
