### PR TITLE
conformance: add rust parse and pow coverage batch

### DIFF
--- a/clients/rust/crates/rubin-consensus/src/block.rs
+++ b/clients/rust/crates/rubin-consensus/src/block.rs
@@ -51,6 +51,63 @@ pub fn block_hash(header_bytes: &[u8]) -> Result<[u8; 32], TxError> {
     Ok(sha3_256(header_bytes))
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn header_bytes() -> [u8; BLOCK_HEADER_BYTES] {
+        let mut bytes = [0u8; BLOCK_HEADER_BYTES];
+        bytes[0..4].copy_from_slice(&7u32.to_le_bytes());
+        bytes[4..36].fill(0x01);
+        bytes[36..68].fill(0x02);
+        bytes[68..76].copy_from_slice(&11u64.to_le_bytes());
+        bytes[76..108].fill(0xff);
+        bytes[108..116].copy_from_slice(&13u64.to_le_bytes());
+        bytes
+    }
+
+    #[test]
+    fn parse_block_header_bytes_roundtrip_fields() {
+        let bytes = header_bytes();
+        let parsed = parse_block_header_bytes(&bytes).expect("parse block header");
+
+        assert_eq!(parsed.version, 7);
+        assert_eq!(parsed.prev_block_hash, [0x01; 32]);
+        assert_eq!(parsed.merkle_root, [0x02; 32]);
+        assert_eq!(parsed.timestamp, 11);
+        assert_eq!(parsed.target, [0xff; 32]);
+        assert_eq!(parsed.nonce, 13);
+    }
+
+    #[test]
+    fn parse_block_header_bytes_rejects_short_length() {
+        let err = parse_block_header_bytes(&[0u8; BLOCK_HEADER_BYTES - 1]).unwrap_err();
+        assert_eq!(err.code, ErrorCode::TxErrParse);
+    }
+
+    #[test]
+    fn parse_block_header_bytes_rejects_truncation_points() {
+        for len in [0usize, 3, 35, 67, 75, 107, BLOCK_HEADER_BYTES - 1] {
+            let err = parse_block_header_bytes(&vec![0u8; len]).unwrap_err();
+            assert_eq!(err.code, ErrorCode::TxErrParse, "len={len}");
+        }
+    }
+
+    #[test]
+    fn block_hash_rejects_invalid_length() {
+        let err = block_hash(&[]).unwrap_err();
+        assert_eq!(err.code, ErrorCode::TxErrParse);
+    }
+
+    #[test]
+    fn block_hash_matches_sha3() {
+        let mut bytes = [0u8; BLOCK_HEADER_BYTES];
+        bytes[0] = 0x42;
+        let got = block_hash(&bytes).expect("hash");
+        assert_eq!(got, sha3_256(&bytes));
+    }
+}
+
 #[cfg(kani)]
 mod verification {
     use super::*;

--- a/clients/rust/crates/rubin-consensus/src/block_basic/txs.rs
+++ b/clients/rust/crates/rubin-consensus/src/block_basic/txs.rs
@@ -64,3 +64,137 @@ pub(super) fn validate_block_tx_semantics(
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::block::BlockHeader;
+    use crate::constants::{COV_TYPE_ANCHOR, COV_TYPE_DA_COMMIT, COV_TYPE_P2PK, TX_WIRE_VERSION};
+    use crate::tx::{DaChunkCore, TxInput, TxOutput, WitnessItem};
+    use crate::tx_helpers::p2pk_covenant_data_for_pubkey;
+
+    fn coinbase(block_height: u64) -> Tx {
+        Tx {
+            version: TX_WIRE_VERSION,
+            tx_kind: 0x00,
+            tx_nonce: 0,
+            inputs: vec![TxInput {
+                prev_txid: [0u8; 32],
+                prev_vout: u32::MAX,
+                script_sig: Vec::new(),
+                sequence: u32::MAX,
+            }],
+            outputs: vec![TxOutput {
+                value: 1,
+                covenant_type: COV_TYPE_P2PK,
+                covenant_data: p2pk_covenant_data_for_pubkey(&[0x11; 32]),
+            }],
+            locktime: block_height as u32,
+            da_commit_core: None,
+            da_chunk_core: None,
+            witness: Vec::new(),
+            da_payload: Vec::new(),
+        }
+    }
+
+    fn spend(tx_nonce: u64, value: u64) -> Tx {
+        Tx {
+            version: TX_WIRE_VERSION,
+            tx_kind: 0x00,
+            tx_nonce,
+            inputs: vec![TxInput {
+                prev_txid: [0x22; 32],
+                prev_vout: 0,
+                script_sig: vec![0x01],
+                sequence: 1,
+            }],
+            outputs: vec![TxOutput {
+                value,
+                covenant_type: COV_TYPE_P2PK,
+                covenant_data: p2pk_covenant_data_for_pubkey(&[0x33; 32]),
+            }],
+            locktime: 0,
+            da_commit_core: None,
+            da_chunk_core: None,
+            witness: vec![WitnessItem {
+                suite_id: SUITE_ID_SENTINEL,
+                pubkey: Vec::new(),
+                signature: Vec::new(),
+            }],
+            da_payload: Vec::new(),
+        }
+    }
+
+    fn parsed_block(txs: Vec<Tx>) -> ParsedBlock {
+        ParsedBlock {
+            header: BlockHeader {
+                version: 1,
+                prev_block_hash: [0u8; 32],
+                merkle_root: [0u8; 32],
+                timestamp: 0,
+                target: [1u8; 32],
+                nonce: 0,
+            },
+            header_bytes: [0u8; BLOCK_HEADER_BYTES],
+            tx_count: txs.len() as u64,
+            txids: Vec::new(),
+            wtxids: Vec::new(),
+            txs,
+        }
+    }
+
+    #[test]
+    fn accumulate_block_resource_stats_aggregates_da_and_anchor_bytes() {
+        let mut da_chunk = spend(7, 2);
+        da_chunk.tx_kind = 0x02;
+        da_chunk.outputs.push(TxOutput {
+            value: 0,
+            covenant_type: COV_TYPE_ANCHOR,
+            covenant_data: vec![0x44; 32],
+        });
+        da_chunk.da_chunk_core = Some(DaChunkCore {
+            da_id: [0x55; 32],
+            chunk_index: 0,
+            chunk_hash: sha3_256(&[0xaa, 0xbb, 0xcc]),
+        });
+        da_chunk.da_payload = vec![0xaa, 0xbb, 0xcc];
+
+        let pb = parsed_block(vec![coinbase(1), da_chunk]);
+        let stats = accumulate_block_resource_stats(&pb).expect("stats");
+
+        assert!(stats.sum_weight > 0);
+        assert_eq!(stats.sum_da, 3);
+        assert_eq!(stats.sum_anchor, 32);
+    }
+
+    #[test]
+    fn accumulate_block_resource_stats_bubbles_tx_weight_error() {
+        let mut bad_da = spend(8, 2);
+        bad_da.tx_kind = 0x01;
+        bad_da.outputs.push(TxOutput {
+            value: 0,
+            covenant_type: COV_TYPE_DA_COMMIT,
+            covenant_data: vec![0x99; 32],
+        });
+
+        let pb = parsed_block(vec![coinbase(1), bad_da]);
+        let err = accumulate_block_resource_stats(&pb).unwrap_err();
+        assert_eq!(err.code, ErrorCode::TxErrParse);
+    }
+
+    #[test]
+    fn validate_block_tx_semantics_rejects_nonce_replay() {
+        let pb = parsed_block(vec![coinbase(1), spend(42, 1), spend(42, 1)]);
+        let err = validate_block_tx_semantics(&pb, 1).unwrap_err();
+        assert_eq!(err.code, ErrorCode::TxErrNonceReplay);
+    }
+
+    #[test]
+    fn validate_block_tx_semantics_bubbles_covenant_error() {
+        let mut bad = spend(99, 0);
+        bad.outputs[0].value = 0;
+        let pb = parsed_block(vec![coinbase(1), bad]);
+        let err = validate_block_tx_semantics(&pb, 1).unwrap_err();
+        assert_eq!(err.code, ErrorCode::TxErrCovenantTypeInvalid);
+    }
+}

--- a/clients/rust/crates/rubin-consensus/src/pow.rs
+++ b/clients/rust/crates/rubin-consensus/src/pow.rs
@@ -139,6 +139,61 @@ fn biguint_to_bytes32(x: &BigUint) -> Result<[u8; 32], TxError> {
     Ok(out)
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bytes32_u16(value: u16) -> [u8; 32] {
+        let mut out = [0u8; 32];
+        out[30..32].copy_from_slice(&value.to_be_bytes());
+        out
+    }
+
+    #[test]
+    fn retarget_v1_target_old_zero_errors() {
+        let err = retarget_v1([0u8; 32], 1, 2).unwrap_err();
+        assert_eq!(err.code, ErrorCode::TxErrParse);
+    }
+
+    #[test]
+    fn retarget_v1_clamped_clamps_underflow_to_lo() {
+        let target_old = bytes32_u16(0x1000);
+        let first = 10_000u64;
+        let mut window = vec![0u64; WINDOW_SIZE as usize];
+        window[0] = first;
+        let got = retarget_v1_clamped(target_old, &window).expect("retarget");
+        let want = retarget_v1(target_old, 0, WINDOW_SIZE - 1).expect("expected");
+        assert_eq!(got, want);
+    }
+
+    #[test]
+    fn retarget_v1_clamped_timestamp_clamp_overflow_lo() {
+        let mut target_old = [0u8; 32];
+        target_old[31] = 1;
+        let mut window = vec![0u64; WINDOW_SIZE as usize];
+        window[0] = u64::MAX;
+        let err = retarget_v1_clamped(target_old, &window).unwrap_err();
+        assert_eq!(err.code, ErrorCode::TxErrParse);
+    }
+
+    #[test]
+    fn retarget_v1_clamped_timestamp_clamp_overflow_hi() {
+        let mut target_old = [0u8; 32];
+        target_old[31] = 1;
+        let mut window = vec![0u64; WINDOW_SIZE as usize];
+        window[0] = u64::MAX - MAX_TIMESTAMP_STEP_PER_BLOCK + 1;
+        let err = retarget_v1_clamped(target_old, &window).unwrap_err();
+        assert_eq!(err.code, ErrorCode::TxErrParse);
+    }
+
+    #[test]
+    fn biguint_to_bytes32_overflow_errors() {
+        let overflow = BigUint::one() << 256usize;
+        let err = biguint_to_bytes32(&overflow).unwrap_err();
+        assert_eq!(err.code, ErrorCode::TxErrParse);
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Kani bounded model checking proofs
 // ---------------------------------------------------------------------------

--- a/clients/rust/crates/rubin-consensus/src/tests/tx_parse.rs
+++ b/clients/rust/crates/rubin-consensus/src/tests/tx_parse.rs
@@ -10,6 +10,15 @@ fn parse_tx_rejects_unsupported_version() {
 }
 
 #[test]
+fn parse_tx_rejects_unsupported_tx_kind() {
+    let mut tx = minimal_tx_bytes();
+    tx[4] = 0x03;
+
+    let err = parse_tx(&tx).unwrap_err();
+    assert_eq!(err.code, ErrorCode::TxErrParse);
+}
+
+#[test]
 fn parse_tx_minimal_txid_wtxid() {
     let tx_bytes = minimal_tx_bytes();
     let (_tx, txid, wtxid, n) = parse_tx(&tx_bytes).expect("parse");
@@ -70,6 +79,41 @@ fn parse_tx_covenant_data_len_exceeds_cap() {
     crate::compactsize::encode_compact_size(0, &mut b); // da_payload_len
 
     let err = parse_tx(&b).unwrap_err();
+    assert_eq!(err.code, ErrorCode::TxErrParse);
+}
+
+#[test]
+fn parse_tx_input_count_overflow() {
+    let mut b = Vec::new();
+    b.extend_from_slice(&1u32.to_le_bytes());
+    b.push(0x00);
+    b.extend_from_slice(&0u64.to_le_bytes());
+    crate::compactsize::encode_compact_size(MAX_TX_INPUTS + 1, &mut b);
+
+    let err = parse_tx(&b).unwrap_err();
+    assert_eq!(err.code, ErrorCode::TxErrParse);
+}
+
+#[test]
+fn parse_tx_output_count_overflow() {
+    let mut b = Vec::new();
+    b.extend_from_slice(&1u32.to_le_bytes());
+    b.push(0x00);
+    b.extend_from_slice(&0u64.to_le_bytes());
+    crate::compactsize::encode_compact_size(0, &mut b);
+    crate::compactsize::encode_compact_size(MAX_TX_OUTPUTS + 1, &mut b);
+
+    let err = parse_tx(&b).unwrap_err();
+    assert_eq!(err.code, ErrorCode::TxErrParse);
+}
+
+#[test]
+fn parse_tx_tx_kind_zero_rejects_nonzero_da_payload_len() {
+    let mut tx = minimal_tx_bytes();
+    let last = tx.len() - 1;
+    tx[last] = 0x01;
+
+    let err = parse_tx(&tx).unwrap_err();
     assert_eq!(err.code, ErrorCode::TxErrParse);
 }
 
@@ -182,6 +226,37 @@ fn parse_tx_witness_item_canonicalization() {
 }
 
 #[test]
+fn parse_tx_sentinel_empty_witness_is_canonical() {
+    let mut tx = minimal_tx_bytes();
+    tx.truncate(core_end());
+    tx.push(0x01);
+    tx.push(SUITE_ID_SENTINEL);
+    tx.push(0x00);
+    tx.push(0x00);
+    tx.push(0x00);
+
+    let (parsed, _, _, _) = parse_tx(&tx).expect("parse sentinel");
+    assert_eq!(parsed.witness.len(), 1);
+    assert_eq!(parsed.witness[0].suite_id, SUITE_ID_SENTINEL);
+    assert!(parsed.witness[0].pubkey.is_empty());
+    assert!(parsed.witness[0].signature.is_empty());
+}
+
+#[test]
+fn parse_tx_missing_sighash_type_byte_rejected() {
+    let mut tx = minimal_tx_bytes();
+    tx.truncate(core_end());
+    tx.push(0x01);
+    tx.push(0x03);
+    tx.push(0x00);
+    tx.push(0x00);
+    tx.push(0x00);
+
+    let err = parse_tx(&tx).unwrap_err();
+    assert_eq!(err.code, ErrorCode::TxErrParse);
+}
+
+#[test]
 fn parse_tx_witness_bytes_overflow() {
     let mut tx = minimal_tx_bytes();
     tx.truncate(core_end());
@@ -233,6 +308,67 @@ fn parse_tx_unknown_suite_id_accepted() {
     assert_eq!(t.witness[0].suite_id, 0x03);
     assert!(t.witness[0].pubkey.is_empty());
     assert_eq!(t.witness[0].signature, vec![0x01]);
+}
+
+#[test]
+fn parse_tx_da_commit_and_chunk_minimal_ok() {
+    let da_id = [0xa1u8; 32];
+    let payload = b"abc";
+    let payload_commitment = sha3_256(payload);
+
+    let commit = da_commit_tx(da_id, 1, payload_commitment, 1);
+    let parsed_commit = parse_tx(&commit).expect("parse commit").0;
+    assert_eq!(parsed_commit.tx_kind, 0x01);
+    assert!(parsed_commit.da_commit_core.is_some());
+
+    let chunk = da_chunk_tx(da_id, 0, sha3_256(payload), payload, 2);
+    let parsed_chunk = parse_tx(&chunk).expect("parse chunk").0;
+    assert_eq!(parsed_chunk.tx_kind, 0x02);
+    assert!(parsed_chunk.da_chunk_core.is_some());
+}
+
+#[test]
+fn parse_tx_da_commit_rejects_oversize_manifest_payload_len() {
+    let mut b = Vec::new();
+    b.extend_from_slice(&1u32.to_le_bytes());
+    b.push(0x01);
+    b.extend_from_slice(&0u64.to_le_bytes());
+    crate::compactsize::encode_compact_size(0, &mut b);
+    crate::compactsize::encode_compact_size(0, &mut b);
+    b.extend_from_slice(&0u32.to_le_bytes());
+    b.extend_from_slice(&[0xa2; 32]);
+    b.extend_from_slice(&1u16.to_le_bytes());
+    b.extend_from_slice(&[0xa3; 32]);
+    b.extend_from_slice(&1u64.to_le_bytes());
+    b.extend_from_slice(&[0xa4; 32]);
+    b.extend_from_slice(&[0xa5; 32]);
+    b.extend_from_slice(&[0xa6; 32]);
+    b.push(0x00);
+    crate::compactsize::encode_compact_size(0, &mut b);
+    crate::compactsize::encode_compact_size(0, &mut b);
+    crate::compactsize::encode_compact_size(MAX_DA_MANIFEST_BYTES_PER_TX + 1, &mut b);
+
+    let err = parse_tx(&b).unwrap_err();
+    assert_eq!(err.code, ErrorCode::TxErrParse);
+}
+
+#[test]
+fn parse_tx_da_chunk_rejects_zero_payload_len() {
+    let mut b = Vec::new();
+    b.extend_from_slice(&1u32.to_le_bytes());
+    b.push(0x02);
+    b.extend_from_slice(&0u64.to_le_bytes());
+    crate::compactsize::encode_compact_size(0, &mut b);
+    crate::compactsize::encode_compact_size(0, &mut b);
+    b.extend_from_slice(&0u32.to_le_bytes());
+    b.extend_from_slice(&[0xb1; 32]);
+    b.extend_from_slice(&0u16.to_le_bytes());
+    b.extend_from_slice(&[0xb2; 32]);
+    crate::compactsize::encode_compact_size(0, &mut b);
+    crate::compactsize::encode_compact_size(0, &mut b);
+
+    let err = parse_tx(&b).unwrap_err();
+    assert_eq!(err.code, ErrorCode::TxErrParse);
 }
 
 #[test]

--- a/clients/rust/crates/rubin-consensus/src/tx_helpers.rs
+++ b/clients/rust/crates/rubin-consensus/src/tx_helpers.rs
@@ -213,6 +213,58 @@ mod tests {
         }
     }
 
+    fn da_commit_tx() -> Tx {
+        Tx {
+            version: TX_WIRE_VERSION,
+            tx_kind: 0x01,
+            tx_nonce: 7,
+            inputs: Vec::new(),
+            outputs: vec![TxOutput {
+                value: 0,
+                covenant_type: COV_TYPE_P2PK,
+                covenant_data: Vec::new(),
+            }],
+            locktime: 0,
+            da_commit_core: Some(crate::tx::DaCommitCore {
+                da_id: [0x10; 32],
+                chunk_count: 1,
+                retl_domain_id: [0x20; 32],
+                batch_number: 9,
+                tx_data_root: [0x30; 32],
+                state_root: [0x40; 32],
+                withdrawals_root: [0x50; 32],
+                batch_sig_suite: 0x00,
+                batch_sig: vec![0xaa, 0xbb],
+            }),
+            da_chunk_core: None,
+            witness: Vec::new(),
+            da_payload: vec![0xde, 0xad, 0xbe, 0xef],
+        }
+    }
+
+    fn da_chunk_tx() -> Tx {
+        Tx {
+            version: TX_WIRE_VERSION,
+            tx_kind: 0x02,
+            tx_nonce: 9,
+            inputs: Vec::new(),
+            outputs: vec![TxOutput {
+                value: 0,
+                covenant_type: COV_TYPE_P2PK,
+                covenant_data: Vec::new(),
+            }],
+            locktime: 0,
+            da_commit_core: None,
+            da_chunk_core: Some(crate::tx::DaChunkCore {
+                da_id: [0x11; 32],
+                chunk_index: 0,
+                chunk_hash: [0x22; 32],
+            }),
+            witness: Vec::new(),
+            da_payload: vec![0x01],
+        }
+    }
+
     fn test_utxos(pubkey: &[u8]) -> HashMap<Outpoint, UtxoEntry> {
         HashMap::from([(
             Outpoint {
@@ -248,6 +300,112 @@ mod tests {
         let (parsed, _, _, consumed) = parse_tx(&bytes).expect("parse");
         assert_eq!(consumed, bytes.len());
         assert_eq!(parsed, tx);
+    }
+
+    #[test]
+    fn marshal_tx_with_inputs_outputs_roundtrips() {
+        let mut tx = test_tx();
+        tx.tx_nonce = 42;
+        tx.inputs[0].prev_txid[0..3].copy_from_slice(&[0x01, 0x02, 0x03]);
+        tx.inputs[0].prev_vout = 7;
+        tx.inputs[0].script_sig = vec![0xaa, 0xbb];
+        tx.inputs[0].sequence = u32::MAX;
+        tx.outputs = vec![
+            TxOutput {
+                value: 50_000,
+                covenant_type: 0,
+                covenant_data: Vec::new(),
+            },
+            TxOutput {
+                value: 10_000,
+                covenant_type: 1,
+                covenant_data: vec![0xcc],
+            },
+        ];
+        tx.locktime = 100;
+
+        let bytes = marshal_tx(&tx).expect("marshal");
+        let (parsed, _, _, consumed) = parse_tx(&bytes).expect("parse");
+        assert_eq!(consumed, bytes.len());
+        assert_eq!(parsed.inputs.len(), 1);
+        assert_eq!(parsed.inputs[0].prev_txid, tx.inputs[0].prev_txid);
+        assert_eq!(parsed.outputs.len(), 2);
+        assert_eq!(parsed.outputs[0].value, 50_000);
+        assert_eq!(parsed.locktime, 100);
+    }
+
+    #[test]
+    fn marshal_tx_empty_da_payload_roundtrips() {
+        let tx = Tx {
+            version: TX_WIRE_VERSION,
+            tx_kind: 0x00,
+            tx_nonce: 0,
+            inputs: Vec::new(),
+            outputs: Vec::new(),
+            locktime: 0,
+            da_commit_core: None,
+            da_chunk_core: None,
+            witness: Vec::new(),
+            da_payload: Vec::new(),
+        };
+
+        let bytes = marshal_tx(&tx).expect("marshal");
+        let (parsed, _, _, consumed) = parse_tx(&bytes).expect("parse");
+        assert_eq!(consumed, bytes.len());
+        assert!(parsed.da_payload.is_empty());
+    }
+
+    #[test]
+    fn marshal_tx_da_commit_roundtrips() {
+        let tx = da_commit_tx();
+        let bytes = marshal_tx(&tx).expect("marshal commit");
+        let (parsed, _, _, consumed) = parse_tx(&bytes).expect("parse commit");
+        assert_eq!(consumed, bytes.len());
+        assert_eq!(parsed.da_commit_core, tx.da_commit_core);
+        assert_eq!(parsed.da_payload, tx.da_payload);
+    }
+
+    #[test]
+    fn marshal_tx_da_chunk_roundtrips() {
+        let tx = da_chunk_tx();
+        let bytes = marshal_tx(&tx).expect("marshal chunk");
+        let (parsed, _, _, consumed) = parse_tx(&bytes).expect("parse chunk");
+        assert_eq!(consumed, bytes.len());
+        assert_eq!(parsed.da_chunk_core, tx.da_chunk_core);
+        assert_eq!(parsed.da_payload, tx.da_payload);
+    }
+
+    #[test]
+    fn marshal_tx_da_kind_missing_core_errors() {
+        let tx_commit = Tx {
+            version: TX_WIRE_VERSION,
+            tx_kind: 0x01,
+            tx_nonce: 0,
+            inputs: Vec::new(),
+            outputs: Vec::new(),
+            locktime: 0,
+            da_commit_core: None,
+            da_chunk_core: None,
+            witness: Vec::new(),
+            da_payload: vec![0x01],
+        };
+        let err = marshal_tx(&tx_commit).expect_err("missing commit core must fail");
+        assert_eq!(err.code, ErrorCode::TxErrParse);
+
+        let tx_chunk = Tx {
+            version: TX_WIRE_VERSION,
+            tx_kind: 0x02,
+            tx_nonce: 0,
+            inputs: Vec::new(),
+            outputs: Vec::new(),
+            locktime: 0,
+            da_commit_core: None,
+            da_chunk_core: None,
+            witness: Vec::new(),
+            da_payload: vec![0x01],
+        };
+        let err = marshal_tx(&tx_chunk).expect_err("missing chunk core must fail");
+        assert_eq!(err.code, ErrorCode::TxErrParse);
     }
 
     #[test]

--- a/clients/rust/fuzz/Cargo.toml
+++ b/clients/rust/fuzz/Cargo.toml
@@ -22,8 +22,20 @@ test = false
 doc = false
 
 [[bin]]
+name = "parse_tx_determinism"
+path = "fuzz_targets/parse_tx_determinism.rs"
+test = false
+doc = false
+
+[[bin]]
 name = "parse_block_bytes"
 path = "fuzz_targets/parse_block_bytes.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "block_header_surface"
+path = "fuzz_targets/block_header_surface.rs"
 test = false
 doc = false
 
@@ -132,6 +144,12 @@ doc = false
 [[bin]]
 name = "tx_relay_receive"
 path = "fuzz_targets/tx_relay_receive.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "marshal_tx_roundtrip"
+path = "fuzz_targets/marshal_tx_roundtrip.rs"
 test = false
 doc = false
 

--- a/clients/rust/fuzz/fuzz_targets/block_header_surface.rs
+++ b/clients/rust/fuzz/fuzz_targets/block_header_surface.rs
@@ -1,0 +1,21 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use rubin_consensus::{block_hash, parse_block_header_bytes, ErrorCode, BLOCK_HEADER_BYTES};
+
+fuzz_target!(|data: &[u8]| {
+    if data.len() < BLOCK_HEADER_BYTES {
+        let err = parse_block_header_bytes(data).expect_err("short block header must fail");
+        assert_eq!(err.code, ErrorCode::TxErrParse);
+        return;
+    }
+
+    let header_bytes = &data[..BLOCK_HEADER_BYTES];
+    let parsed_a = parse_block_header_bytes(header_bytes).expect("exact header");
+    let parsed_b = parse_block_header_bytes(header_bytes).expect("repeat exact header");
+    assert_eq!(parsed_a, parsed_b, "parse_block_header_bytes drift");
+
+    let hash_a = block_hash(header_bytes).expect("hash exact header");
+    let hash_b = block_hash(header_bytes).expect("rehash exact header");
+    assert_eq!(hash_a, hash_b, "block_hash drift");
+});

--- a/clients/rust/fuzz/fuzz_targets/marshal_tx_roundtrip.rs
+++ b/clients/rust/fuzz/fuzz_targets/marshal_tx_roundtrip.rs
@@ -1,0 +1,18 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let (tx, _, _, _) = match rubin_consensus::parse_tx(data) {
+        Ok(parsed) => parsed,
+        Err(_) => return,
+    };
+
+    let bytes_a = rubin_consensus::marshal_tx(&tx).expect("marshal parsed tx");
+    let (parsed_a, _, _, consumed_a) = rubin_consensus::parse_tx(&bytes_a).expect("reparse");
+    assert_eq!(consumed_a, bytes_a.len(), "marshal consumed drift");
+    assert_eq!(parsed_a, tx, "marshal roundtrip tx drift");
+
+    let bytes_b = rubin_consensus::marshal_tx(&parsed_a).expect("remarshal");
+    assert_eq!(bytes_a, bytes_b, "marshal non-deterministic bytes");
+});

--- a/clients/rust/fuzz/fuzz_targets/parse_tx_determinism.rs
+++ b/clients/rust/fuzz/fuzz_targets/parse_tx_determinism.rs
@@ -1,0 +1,22 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let first = rubin_consensus::parse_tx(data);
+    let second = rubin_consensus::parse_tx(data);
+
+    match (first, second) {
+        (Ok((tx_a, txid_a, wtxid_a, consumed_a)), Ok((tx_b, txid_b, wtxid_b, consumed_b))) => {
+            assert_eq!(tx_a, tx_b, "parse_tx tx drift");
+            assert_eq!(txid_a, txid_b, "parse_tx txid drift");
+            assert_eq!(wtxid_a, wtxid_b, "parse_tx wtxid drift");
+            assert_eq!(consumed_a, consumed_b, "parse_tx consumed drift");
+        }
+        (Err(err_a), Err(err_b)) => {
+            assert_eq!(err_a.code, err_b.code, "parse_tx error code drift");
+            assert_eq!(err_a.msg, err_b.msg, "parse_tx error msg drift");
+        }
+        _ => panic!("parse_tx non-deterministic error/ok mismatch"),
+    }
+});


### PR DESCRIPTION
## Summary
- add Rust direct coverage for block parse, block_basic/txs, tx parse, tx marshal, and pow residuals
- add native Rust fuzz targets for block header surface, tx parse determinism, and marshal roundtrip
- keep scope strictly to coverage/test/fuzz residue for Q-VERIFY-RUST-BLOCK-PARSE-COVERAGE-01, Q-VERIFY-RUST-BLOCK-BASIC-TXS-COVERAGE-01, Q-VERIFY-RUST-TX-PARSE-COVERAGE-01, Q-VERIFY-RUST-TX-MARSHAL-COVERAGE-01, and Q-VERIFY-RUST-POW-COVERAGE-01

## Validation
- `./scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test -p rubin-consensus --lib -- --nocapture'`
- `./scripts/dev-env.sh -- bash -lc 'cd clients/rust/fuzz && cargo build --bin parse_block_bytes --bin block_header_surface --bin parse_tx --bin parse_tx_determinism --bin marshal_tx_roundtrip --bin pow_check --bin retarget_no_panic'`
- `./scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo clippy -p rubin-consensus --all-targets -- -D warnings'`
- `./scripts/dev-env.sh -- ./scripts/preflight-codacy-coverage.sh`
- `python3 /Users/gpt/Documents/rubin-orchestration-private/inbox/operational/tools/run_pr_lifecycle.py pre-pr --target-repo rubin-protocol --repo-root /Users/gpt/Documents/.codex/worktrees/rubin-protocol-parse-pow-batch-03 --skip-execution-drift`

Refs: Q-VERIFY-RUST-BLOCK-PARSE-COVERAGE-01, Q-VERIFY-RUST-BLOCK-BASIC-TXS-COVERAGE-01, Q-VERIFY-RUST-TX-PARSE-COVERAGE-01, Q-VERIFY-RUST-TX-MARSHAL-COVERAGE-01, Q-VERIFY-RUST-POW-COVERAGE-01
