### PR TITLE
test(consensus): add rust signature infra coverage batch

### DIFF
--- a/clients/rust/Cargo.lock
+++ b/clients/rust/Cargo.lock
@@ -3,6 +3,27 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16,6 +37,18 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
@@ -34,6 +67,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -41,6 +126,73 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -63,6 +215,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -79,16 +237,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "js-sys"
+version = "0.3.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "keccak"
@@ -140,6 +345,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -156,6 +373,34 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -176,9 +421,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
 name = "rubin-consensus"
 version = "0.0.0"
 dependencies = [
+ "criterion",
  "num-bigint",
  "num-traits",
  "openssl-sys",
@@ -211,6 +506,21 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -295,6 +605,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -317,6 +637,115 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84cde8507f4d7cfcb1185b8cb5890c494ffea65edbe1ba82cfd63661c805ed94"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zmij"

--- a/clients/rust/crates/rubin-consensus/Cargo.toml
+++ b/clients/rust/crates/rubin-consensus/Cargo.toml
@@ -13,5 +13,10 @@ num-traits = "0.2"
 openssl-sys = "0.9"
 
 [dev-dependencies]
+criterion = "0.5"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+
+[[bench]]
+name = "sig_cache"
+harness = false

--- a/clients/rust/crates/rubin-consensus/benches/sig_cache.rs
+++ b/clients/rust/crates/rubin-consensus/benches/sig_cache.rs
@@ -1,0 +1,43 @@
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
+use rubin_consensus::constants::SUITE_ID_ML_DSA_87;
+use rubin_consensus::{Mldsa87Keypair, SigCache};
+
+fn sig_cache_lookup_hit(c: &mut Criterion) {
+    let kp = Mldsa87Keypair::generate().expect("keypair");
+    let digest = [0x42; 32];
+    let sig = kp.sign_digest32(digest).expect("sign");
+    let pubkey = kp.pubkey_bytes();
+    let cache = SigCache::new(64);
+    cache.insert(SUITE_ID_ML_DSA_87, &pubkey, &sig, digest);
+
+    c.bench_function("sig_cache_lookup_hit", |b| {
+        b.iter(|| {
+            black_box(cache.lookup(SUITE_ID_ML_DSA_87, &pubkey, &sig, digest));
+        });
+    });
+}
+
+fn sig_cache_insert_lookup_cycle(c: &mut Criterion) {
+    let kp = Mldsa87Keypair::generate().expect("keypair");
+    let digest = [0x24; 32];
+    let sig = kp.sign_digest32(digest).expect("sign");
+    let pubkey = kp.pubkey_bytes();
+
+    c.bench_function("sig_cache_insert_lookup_cycle", |b| {
+        b.iter_batched(
+            || SigCache::new(64),
+            |cache| {
+                cache.insert(SUITE_ID_ML_DSA_87, &pubkey, &sig, digest);
+                black_box(cache.lookup(SUITE_ID_ML_DSA_87, &pubkey, &sig, digest));
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
+criterion_group!(
+    sig_cache_benches,
+    sig_cache_lookup_hit,
+    sig_cache_insert_lookup_cycle
+);
+criterion_main!(sig_cache_benches);

--- a/clients/rust/crates/rubin-consensus/src/spend_verify.rs
+++ b/clients/rust/crates/rubin-consensus/src/spend_verify.rs
@@ -476,6 +476,41 @@ mod tests {
         }
     }
 
+    #[test]
+    fn extract_crypto_sig_and_sighash_rejects_missing_trailer() {
+        let w = WitnessItem {
+            suite_id: SUITE_ID_ML_DSA_87,
+            pubkey: vec![],
+            signature: vec![],
+        };
+        let err = extract_crypto_sig_and_sighash(&w).expect_err("missing sighash trailer");
+        assert_eq!(err.code, ErrorCode::TxErrParse);
+    }
+
+    #[test]
+    fn extract_crypto_sig_and_sighash_rejects_invalid_type() {
+        let w = WitnessItem {
+            suite_id: SUITE_ID_ML_DSA_87,
+            pubkey: vec![],
+            signature: vec![0xAA, 0xFF],
+        };
+        let err = extract_crypto_sig_and_sighash(&w).expect_err("invalid sighash type");
+        assert_eq!(err.code, ErrorCode::TxErrSighashTypeInvalid);
+    }
+
+    #[test]
+    fn extract_crypto_sig_and_sighash_preserves_crypto_sig_bytes() {
+        let w = WitnessItem {
+            suite_id: SUITE_ID_ML_DSA_87,
+            pubkey: vec![],
+            signature: vec![0xAA, 0xBB, SIGHASH_ALL],
+        };
+        let (crypto_sig, sighash_type) =
+            extract_crypto_sig_and_sighash(&w).expect("valid trailing sighash");
+        assert_eq!(crypto_sig, &[0xAA, 0xBB]);
+        assert_eq!(sighash_type, SIGHASH_ALL);
+    }
+
     // ======== Registry & Lookup Tests (8) ========
 
     #[test]

--- a/clients/rust/fuzz/Cargo.toml
+++ b/clients/rust/fuzz/Cargo.toml
@@ -184,6 +184,18 @@ test = false
 doc = false
 
 [[bin]]
+name = "sig_cache_concurrent"
+path = "fuzz_targets/sig_cache_concurrent.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "suite_registry_surface"
+path = "fuzz_targets/suite_registry_surface.rs"
+test = false
+doc = false
+
+[[bin]]
 name = "connect_block_inmem"
 path = "fuzz_targets/connect_block_inmem.rs"
 test = false

--- a/clients/rust/fuzz/fuzz_targets/sig_cache_concurrent.rs
+++ b/clients/rust/fuzz/fuzz_targets/sig_cache_concurrent.rs
@@ -1,0 +1,54 @@
+#![no_main]
+
+use std::thread;
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    if data.len() < 34 {
+        return;
+    }
+
+    let suite_id = data[0];
+    let pubkey_len = (data[1] as usize).min(64);
+    let sig_len = (data[2] as usize).min(64);
+    if data.len() < 3 + pubkey_len + sig_len + 32 {
+        return;
+    }
+
+    let mut pos = 3;
+    let pubkey = data[pos..pos + pubkey_len].to_vec();
+    pos += pubkey_len;
+    let sig = data[pos..pos + sig_len].to_vec();
+    pos += sig_len;
+
+    let mut base_digest = [0u8; 32];
+    base_digest.copy_from_slice(&data[pos..pos + 32]);
+    let cache = rubin_consensus::SigCache::new(16);
+
+    let mut handles = Vec::new();
+    for i in 0..4u8 {
+        let cache = cache.clone();
+        let pubkey = pubkey.clone();
+        let sig = sig.clone();
+        let mut digest = base_digest;
+        digest[0] ^= i;
+        handles.push(thread::spawn(move || {
+            cache.insert(suite_id, &pubkey, &sig, digest);
+            let _ = cache.lookup(suite_id, &pubkey, &sig, digest);
+        }));
+    }
+
+    for handle in handles {
+        handle.join().expect("sig_cache concurrent worker panicked");
+    }
+
+    if cache.len() > 16 {
+        panic!("cache exceeded configured capacity");
+    }
+
+    cache.reset();
+    if !cache.is_empty() {
+        panic!("cache reset failed");
+    }
+});

--- a/clients/rust/fuzz/fuzz_targets/sighash.rs
+++ b/clients/rust/fuzz/fuzz_targets/sighash.rs
@@ -1,18 +1,39 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
+use rubin_consensus::constants::{
+    SIGHASH_ALL, SIGHASH_ANYONECANPAY, SIGHASH_NONE, SIGHASH_SINGLE,
+};
 
-// Fuzz sighash_v1_digest: parse arbitrary bytes into a Tx, then compute
-// sighash for each input.  Verifies determinism (same tx → same digest)
-// and no-panic for any parseable transaction.
+fn select_sighash_type(raw: u8) -> u8 {
+    match raw % 8 {
+        0 => SIGHASH_ALL,
+        1 => SIGHASH_NONE,
+        2 => SIGHASH_SINGLE,
+        3 => SIGHASH_ALL | SIGHASH_ANYONECANPAY,
+        4 => SIGHASH_NONE | SIGHASH_ANYONECANPAY,
+        5 => SIGHASH_SINGLE | SIGHASH_ANYONECANPAY,
+        6 => 0x00,
+        _ => raw,
+    }
+}
+
+// Fuzz sighash_v1_digest_with_type: parse arbitrary bytes into a Tx, then
+// compute sighash across valid and invalid sighash_type values.
+//
+// Verifies:
+// - wrapper determinism (same tx/type -> same result)
+// - cache determinism (same cache path -> same result)
+// - wrapper/cache parity for the same sighash_type
+// - default wrapper parity for SIGHASH_ALL
 fuzz_target!(|data: &[u8]| {
-    // Need at least some bytes for tx + input_index(4) + input_value(8) + chain_id(32).
-    if data.len() < 44 {
+    // Need at least some bytes for tx + input_index(4) + input_value(8) + chain_id(32) + type(1).
+    if data.len() < 45 {
         return;
     }
 
-    // Split: last 44 bytes are sighash params, rest is tx wire bytes.
-    let tx_end = data.len() - 44;
+    // Split: last 45 bytes are sighash params, rest is tx wire bytes.
+    let tx_end = data.len() - 45;
     let tx_bytes = &data[..tx_end];
     let params = &data[tx_end..];
 
@@ -29,17 +50,52 @@ fuzz_target!(|data: &[u8]| {
     let input_value = u64::from_le_bytes(params[4..12].try_into().unwrap());
     let mut chain_id = [0u8; 32];
     chain_id.copy_from_slice(&params[12..44]);
+    let sighash_type = select_sighash_type(params[44]);
 
-    let r1 = rubin_consensus::sighash_v1_digest(&tx, input_index, input_value, chain_id);
-    let r2 = rubin_consensus::sighash_v1_digest(&tx, input_index, input_value, chain_id);
+    let direct1 =
+        rubin_consensus::sighash_v1_digest_with_type(&tx, input_index, input_value, chain_id, sighash_type);
+    let direct2 =
+        rubin_consensus::sighash_v1_digest_with_type(&tx, input_index, input_value, chain_id, sighash_type);
+    let mut cache = match rubin_consensus::SighashV1PrehashCache::new(&tx) {
+        Ok(cache) => cache,
+        Err(_) => return,
+    };
+    let cached1 = rubin_consensus::sighash_v1_digest_with_cache(
+        &mut cache,
+        input_index,
+        input_value,
+        chain_id,
+        sighash_type,
+    );
+    let cached2 = rubin_consensus::sighash_v1_digest_with_cache(
+        &mut cache,
+        input_index,
+        input_value,
+        chain_id,
+        sighash_type,
+    );
 
-    match (&r1, &r2) {
-        (Ok(a), Ok(b)) => {
+    match (&direct1, &direct2, &cached1, &cached2) {
+        (Ok(a), Ok(b), Ok(c1), Ok(c2)) => {
             if a != b {
-                panic!("sighash_v1_digest non-deterministic");
+                panic!("sighash_v1_digest_with_type wrapper non-deterministic");
+            }
+            if c1 != c2 {
+                panic!("sighash_v1_digest_with_cache non-deterministic");
+            }
+            if a != c1 {
+                panic!("wrapper/cache sighash mismatch");
+            }
+            if sighash_type == SIGHASH_ALL {
+                let default_digest =
+                    rubin_consensus::sighash_v1_digest(&tx, input_index, input_value, chain_id)
+                        .expect("default wrapper");
+                if a != &default_digest {
+                    panic!("SIGHASH_ALL default wrapper diverged");
+                }
             }
         }
-        (Err(_), Err(_)) => {}
-        _ => panic!("sighash_v1_digest non-deterministic error/ok mismatch"),
+        (Err(_), Err(_), Err(_), Err(_)) => {}
+        _ => panic!("sighash wrapper/cache error/ok mismatch"),
     }
 });

--- a/clients/rust/fuzz/fuzz_targets/suite_registry_surface.rs
+++ b/clients/rust/fuzz/fuzz_targets/suite_registry_surface.rs
@@ -1,0 +1,91 @@
+#![no_main]
+
+use std::collections::BTreeMap;
+
+use libfuzzer_sys::fuzz_target;
+use rubin_consensus::constants::{
+    ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES, SUITE_ID_ML_DSA_87, VERIFY_COST_ML_DSA_87,
+};
+use rubin_consensus::{DefaultRotationProvider, RotationProvider, SuiteParams, SuiteRegistry};
+
+fn build_registry(data: &[u8]) -> SuiteRegistry {
+    if data.first().copied().unwrap_or_default() & 1 == 0 {
+        return SuiteRegistry::default_registry();
+    }
+
+    let mut suites = BTreeMap::new();
+    let custom_id = data.get(1).copied().unwrap_or(0x09);
+    let pubkey_len = u64::from(data.get(2).copied().unwrap_or(0)) + 1;
+    let sig_len = u64::from(data.get(3).copied().unwrap_or(0)) + 1;
+    let verify_cost = u64::from(data.get(4).copied().unwrap_or(0)) + 1;
+    suites.insert(
+        custom_id,
+        SuiteParams {
+            suite_id: custom_id,
+            pubkey_len,
+            sig_len,
+            verify_cost,
+            openssl_alg: "ML-DSA-87",
+        },
+    );
+    suites.insert(
+        SUITE_ID_ML_DSA_87,
+        SuiteParams {
+            suite_id: SUITE_ID_ML_DSA_87,
+            pubkey_len: ML_DSA_87_PUBKEY_BYTES,
+            sig_len: ML_DSA_87_SIG_BYTES,
+            verify_cost: VERIFY_COST_ML_DSA_87,
+            openssl_alg: "ML-DSA-87",
+        },
+    );
+    SuiteRegistry::with_suites(suites)
+}
+
+fuzz_target!(|data: &[u8]| {
+    if data.is_empty() {
+        return;
+    }
+
+    let registry = build_registry(data);
+    let suite_id = data[0];
+    let params = registry.lookup(suite_id);
+    let is_registered = registry.is_registered(suite_id);
+
+    if params.is_some() != is_registered {
+        panic!("lookup/is_registered mismatch for suite 0x{suite_id:02x}");
+    }
+
+    if let Some(params) = registry.lookup(SUITE_ID_ML_DSA_87) {
+        if params.pubkey_len != ML_DSA_87_PUBKEY_BYTES {
+            panic!("ml-dsa-87 pubkey len drift");
+        }
+        if params.sig_len != ML_DSA_87_SIG_BYTES {
+            panic!("ml-dsa-87 sig len drift");
+        }
+        if params.verify_cost != VERIFY_COST_ML_DSA_87 {
+            panic!("ml-dsa-87 verify_cost drift");
+        }
+    }
+
+    let min_payload = registry.min_sigcheck_payload_bytes();
+    if let Ok(Some(bytes)) = min_payload {
+        if bytes == 0 {
+            panic!("min_sigcheck_payload_bytes must be positive");
+        }
+    }
+
+    let provider = DefaultRotationProvider;
+    let create = provider.native_create_suites(0);
+    let spend = provider.native_spend_suites(u64::from(data.get(1).copied().unwrap_or(0)));
+    if !create.contains(SUITE_ID_ML_DSA_87) {
+        panic!("default rotation create set lost ml-dsa-87");
+    }
+    if !spend.contains(SUITE_ID_ML_DSA_87) {
+        panic!("default rotation spend set lost ml-dsa-87");
+    }
+
+    let ids = create.suite_ids();
+    if !ids.windows(2).all(|pair| pair[0] < pair[1]) {
+        panic!("suite ids not sorted");
+    }
+});


### PR DESCRIPTION
## Summary
- add direct Rust regression coverage for `spend_verify` trailer parsing so the remaining malformed-witness paths are covered without changing validation semantics
- strengthen the existing Rust `sighash` fuzz target into type-aware wrapper/cache parity coverage across valid and invalid `sighash_type` values
- add native Rust fuzz targets for `suite_registry` and concurrent `sig_cache` access, plus a minimal Rust benchmark harness for `sig_cache`
- keep scope strictly to Q-VERIFY-RUST-SPEND-VERIFY-FUZZ-PARITY-01, Q-VERIFY-RUST-SIG-CACHE-FUZZ-BENCH-PARITY-01, Q-VERIFY-RUST-SIGHASH-FUZZ-PARITY-01, and Q-VERIFY-RUST-SUITE-REGISTRY-FUZZ-01

## Validation
- `./scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test -p rubin-consensus --lib spend_verify -- --nocapture'`
- `./scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo build -p rubin-consensus-fuzz --manifest-path fuzz/Cargo.toml --bin sighash --bin sig_cache_concurrent --bin suite_registry_surface'`
- `./scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo bench -p rubin-consensus --bench sig_cache --no-run'`
- `./scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo clippy -p rubin-consensus --all-targets -- -D warnings'`
- `python3 /Users/gpt/Documents/rubin-orchestration-private/inbox/operational/tools/run_pr_lifecycle.py pre-pr --target-repo rubin-protocol --repo-root /Users/gpt/Documents/.codex/worktrees/rubin-protocol-signature-batch-03 --skip-execution-drift`

Refs: Q-VERIFY-RUST-SPEND-VERIFY-FUZZ-PARITY-01, Q-VERIFY-RUST-SIG-CACHE-FUZZ-BENCH-PARITY-01, Q-VERIFY-RUST-SIGHASH-FUZZ-PARITY-01, Q-VERIFY-RUST-SUITE-REGISTRY-FUZZ-01
