### PR TITLE
test: harden local non-ci protocol gates

### DIFF
--- a/tools/check_local_prepush_skill_gates.py
+++ b/tools/check_local_prepush_skill_gates.py
@@ -12,8 +12,55 @@ from pathlib import Path
 MAX_RENDERED_CHANGED_PATHS = 25
 MAX_RENDERED_PATH_CHARS = 160
 CONTRACT_PATH = Path(__file__).resolve().with_name("prepush_review_contract.json")
+TOOLS_REPO_ROOT = Path(__file__).resolve().parents[1]
 ALLOWED_REASONING = {"low", "medium", "high", "xhigh"}
 ALLOWED_CHECK_TYPES = {"auto", "consensus_critical", "formal_lean", "code_noncritical", "diff_only"}
+
+RUST_FUZZ_TARGET_PREFIX = "clients/rust/fuzz/fuzz_targets/"
+RUST_FUZZ_CARGO_PATH = "clients/rust/fuzz/Cargo.toml"
+RUST_BENCH_PREFIX = "clients/rust/crates/rubin-consensus/benches/"
+RUST_CONSENSUS_CARGO_PATH = "clients/rust/crates/rubin-consensus/Cargo.toml"
+
+RUST_FUZZ_RUNTIME_MAP: dict[str, tuple[str, ...]] = {
+    "clients/rust/crates/rubin-consensus/src/block.rs": ("parse_block_bytes", "block_header_surface"),
+    "clients/rust/crates/rubin-consensus/src/block_basic.rs": ("validate_block_basic",),
+    "clients/rust/crates/rubin-consensus/src/compact_relay.rs": ("compact_shortid",),
+    "clients/rust/crates/rubin-consensus/src/compactsize.rs": ("compactsize",),
+    "clients/rust/crates/rubin-consensus/src/connect_block_inmem.rs": ("connect_block_inmem",),
+    "clients/rust/crates/rubin-consensus/src/connect_block_parallel.rs": (
+        "connect_block_parallel_determinism",
+        "connect_block_parallel_worker_parity",
+    ),
+    "clients/rust/crates/rubin-consensus/src/covenant_genesis.rs": ("covenant_genesis",),
+    "clients/rust/crates/rubin-consensus/src/da_chunk_hash.rs": ("da_chunk_hash_verify",),
+    "clients/rust/crates/rubin-consensus/src/da_payload_commit.rs": ("da_payload_commit_verify",),
+    "clients/rust/crates/rubin-consensus/src/featurebits.rs": ("featurebits_state",),
+    "clients/rust/crates/rubin-consensus/src/flagday.rs": ("flagday_helpers",),
+    "clients/rust/crates/rubin-consensus/src/fork_choice.rs": ("fork_work",),
+    "clients/rust/crates/rubin-consensus/src/pow.rs": ("pow_check",),
+    "clients/rust/crates/rubin-consensus/src/sig_cache.rs": ("sig_cache_structural", "sig_cache_concurrent"),
+    "clients/rust/crates/rubin-consensus/src/sighash.rs": ("sighash",),
+    "clients/rust/crates/rubin-consensus/src/spend_verify.rs": ("spend_dispatch_structural",),
+    "clients/rust/crates/rubin-consensus/src/suite_registry.rs": ("suite_registry_surface",),
+    "clients/rust/crates/rubin-consensus/src/tx.rs": ("parse_tx", "parse_tx_determinism", "marshal_tx_roundtrip"),
+    "clients/rust/crates/rubin-consensus/src/tx_dep_graph.rs": ("tx_dep_graph",),
+    "clients/rust/crates/rubin-consensus/src/txcontext.rs": ("txcontext_bundle",),
+    "clients/rust/crates/rubin-consensus/src/tx_validate_worker.rs": ("validate_tx_local",),
+    "clients/rust/crates/rubin-consensus/src/verify_sig_openssl.rs": ("sig_verify_openssl",),
+    "clients/rust/crates/rubin-node/src/p2p/relay.rs": ("tx_relay_announce", "tx_relay_receive"),
+    "clients/rust/crates/rubin-node/src/p2p/version.rs": ("p2p_version_payload",),
+    "clients/rust/crates/rubin-node/src/p2p/wire.rs": ("p2p_wire_message",),
+}
+
+RUST_BENCH_RUNTIME_MAP: dict[str, tuple[str, ...]] = {
+    "clients/rust/crates/rubin-consensus/src/sig_cache.rs": ("sig_cache",),
+    "clients/rust/crates/rubin-consensus/src/connect_block_parallel.rs": ("connect_block_parallel",),
+    "clients/rust/crates/rubin-consensus/src/sig_queue.rs": ("connect_block_parallel",),
+    "clients/rust/crates/rubin-consensus/src/spend_verify.rs": ("connect_block_parallel", "combined_load"),
+    "clients/rust/crates/rubin-consensus/src/verify_sig_openssl.rs": ("connect_block_parallel",),
+    "clients/rust/crates/rubin-consensus/src/da_verify_parallel.rs": ("combined_load",),
+    "clients/rust/crates/rubin-consensus/src/da_rules.rs": ("combined_load",),
+}
 
 
 @dataclass(frozen=True)
@@ -156,6 +203,62 @@ def matches_any(path: str, prefixes: tuple[str, ...], suffixes: tuple[str, ...],
         or any(is_under(path, prefix) for prefix in prefixes)
         or any(path.endswith(suffix) for suffix in suffixes)
     )
+
+
+def available_rust_fuzz_targets(repo_root: Path = TOOLS_REPO_ROOT) -> set[str]:
+    root = repo_root / "clients" / "rust" / "fuzz" / "fuzz_targets"
+    if not root.exists():
+        return set()
+    return {path.stem for path in root.glob("*.rs")}
+
+
+def available_rust_bench_targets(repo_root: Path = TOOLS_REPO_ROOT) -> set[str]:
+    root = repo_root / "clients" / "rust" / "crates" / "rubin-consensus" / "benches"
+    if not root.exists():
+        return set()
+    return {path.stem for path in root.glob("*.rs")}
+
+
+def resolve_rust_fuzz_targets(changed: set[str], repo_root: Path = TOOLS_REPO_ROOT) -> tuple[set[str], bool]:
+    available = available_rust_fuzz_targets(repo_root)
+    if not available:
+        return set(), False
+
+    targets: set[str] = set()
+    build_all = RUST_FUZZ_CARGO_PATH in changed
+    for path in changed:
+        if path.startswith(RUST_FUZZ_TARGET_PREFIX):
+            stem = Path(path).stem
+            if stem in available:
+                targets.add(stem)
+        mapped = RUST_FUZZ_RUNTIME_MAP.get(path)
+        if mapped:
+            targets.update(name for name in mapped if name in available)
+    if build_all:
+        targets = set(available)
+    return targets, build_all
+
+
+def resolve_rust_bench_targets(changed: set[str], repo_root: Path = TOOLS_REPO_ROOT) -> tuple[set[str], set[str], bool]:
+    available = available_rust_bench_targets(repo_root)
+    if not available:
+        return set(), set(), False
+
+    direct_changes: set[str] = set()
+    targets: set[str] = set()
+    build_all = RUST_CONSENSUS_CARGO_PATH in changed
+    for path in changed:
+        if path.startswith(RUST_BENCH_PREFIX):
+            stem = Path(path).stem
+            if stem in available:
+                direct_changes.add(stem)
+                targets.add(stem)
+        mapped = RUST_BENCH_RUNTIME_MAP.get(path)
+        if mapped:
+            targets.update(name for name in mapped if name in available)
+    if build_all:
+        targets = set(available)
+    return targets, direct_changes, build_all
 
 
 def run_check(name: str, cmd: list[str], repo_root: Path) -> int:
@@ -361,6 +464,47 @@ def build_plan(
             "rust_consensus_tests",
             ["scripts/dev-env.sh", "--", "bash", "-lc", "cd clients/rust && cargo test -p rubin-consensus"],
         )
+
+    rust_fuzz_targets, rust_fuzz_all = resolve_rust_fuzz_targets(changed)
+    if rust_fuzz_targets:
+        add_focus("Rust native fuzz companions are mandatory local gates: touched fuzz surfaces must at least build before push, otherwise push is blocked.")
+        if rust_fuzz_all:
+            add_check(
+                "rust_fuzz_build_all",
+                ["scripts/dev-env.sh", "--", "bash", "-lc", "cd clients/rust/fuzz && cargo build --bins"],
+            )
+        else:
+            for target in sorted(rust_fuzz_targets):
+                add_check(
+                    f"rust_fuzz_build:{target}",
+                    ["scripts/dev-env.sh", "--", "bash", "-lc", f"cd clients/rust/fuzz && cargo build --bin {shlex.quote(target)}"],
+                )
+
+    rust_bench_targets, rust_direct_bench_changes, rust_bench_all = resolve_rust_bench_targets(changed)
+    if rust_bench_targets:
+        add_focus("Rust benchmark companions are mandatory local gates: perf-sensitive surfaces with dedicated benches must compile locally before push, and edited bench files must get a tiny smoke run.")
+        if rust_bench_all:
+            add_check(
+                "rust_bench_norun_all",
+                ["scripts/dev-env.sh", "--", "bash", "-lc", "cd clients/rust && cargo bench -p rubin-consensus --benches --no-run"],
+            )
+        else:
+            for target in sorted(rust_bench_targets):
+                add_check(
+                    f"rust_bench_norun:{target}",
+                    ["scripts/dev-env.sh", "--", "bash", "-lc", f"cd clients/rust && cargo bench -p rubin-consensus --bench {shlex.quote(target)} --no-run"],
+                )
+        for target in sorted(rust_direct_bench_changes):
+            add_check(
+                f"rust_bench_smoke:{target}",
+                [
+                    "scripts/dev-env.sh",
+                    "--",
+                    "bash",
+                    "-lc",
+                    f"cd clients/rust && cargo bench -p rubin-consensus --bench {shlex.quote(target)} -- --sample-size 10 --measurement-time 0.01 --warm-up-time 0.01",
+                ],
+            )
 
     formal_bridge_exact_paths = {
         "tools/check_formal_refinement_bridge.py",

--- a/tools/prepush_receipt.py
+++ b/tools/prepush_receipt.py
@@ -54,8 +54,15 @@ def tracked_worktree_clean(repo_root: Path) -> bool:
     return run_git(repo_root, "status", "--short", "--untracked-files=no") == ""
 
 
-def write_receipt(repo_root: Path, *, base_ref: str, source: str) -> dict[str, object]:
+def write_receipt(
+    repo_root: Path,
+    *,
+    base_ref: str,
+    source: str,
+    steps: list[str] | None = None,
+) -> dict[str, object]:
     path = receipt_path(repo_root)
+    receipt_steps = list(steps or ["local-skill-gates", "coverage-preflight"])
     payload = {
         "schema_version": 1,
         "note": "rubin-protocol pre-push preflight receipt",
@@ -67,7 +74,7 @@ def write_receipt(repo_root: Path, *, base_ref: str, source: str) -> dict[str, o
         "merge_base": current_merge_base(repo_root, base_ref),
         "tracked_worktree_clean": tracked_worktree_clean(repo_root),
         "generated_at": now_utc_iso(),
-        "steps": ["coverage-preflight"],
+        "steps": receipt_steps,
     }
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/tools/tests/test_local_prepush_skill_gates.py
+++ b/tools/tests/test_local_prepush_skill_gates.py
@@ -246,6 +246,26 @@ class LocalPrepushSkillGateTests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "expected >= 1"):
                 m.load_profile_contract("diff_only", path=contract_path)
 
+    def test_build_plan_adds_native_fuzz_builds_for_changed_runtime_surface(self):
+        changed = {"clients/rust/crates/rubin-consensus/src/connect_block_parallel.rs"}
+
+        checks, focuses, _lenses, _profile = m.build_plan(changed)
+        check_names = {name for name, _cmd in checks}
+
+        self.assertIn("rust_fuzz_build:connect_block_parallel_determinism", check_names)
+        self.assertIn("rust_fuzz_build:connect_block_parallel_worker_parity", check_names)
+        self.assertTrue(any("native fuzz companions" in focus for focus in focuses))
+
+    def test_build_plan_adds_bench_compile_and_smoke_for_direct_bench_edit(self):
+        changed = {"clients/rust/crates/rubin-consensus/benches/sig_cache.rs"}
+
+        checks, focuses, _lenses, _profile = m.build_plan(changed)
+        check_names = {name for name, _cmd in checks}
+
+        self.assertIn("rust_bench_norun:sig_cache", check_names)
+        self.assertIn("rust_bench_smoke:sig_cache", check_names)
+        self.assertTrue(any("benchmark companions are mandatory local gates" in focus for focus in focuses))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/tests/test_prepush_receipt.py
+++ b/tools/tests/test_prepush_receipt.py
@@ -32,9 +32,22 @@ class PrepushReceiptTests(unittest.TestCase):
             self.init_repo(repo_root)
             result = m.write_receipt(repo_root, base_ref="origin/main", source="test")
             self.assertTrue(result["fresh"])
+            self.assertEqual(result["receipt"]["steps"], ["local-skill-gates", "coverage-preflight"])
             checked = m.check_receipt(repo_root, base_ref="origin/main")
             self.assertTrue(checked["fresh"])
             self.assertEqual(checked["reason"], "fresh")
+
+    def test_write_receipt_accepts_explicit_steps(self):
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            self.init_repo(repo_root)
+            result = m.write_receipt(
+                repo_root,
+                base_ref="origin/main",
+                source="test",
+                steps=["local-skill-gates", "coverage-preflight", "extra-step"],
+            )
+            self.assertEqual(result["receipt"]["steps"], ["local-skill-gates", "coverage-preflight", "extra-step"])
 
     def test_check_detects_dirty_worktree(self):
         with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
## Summary
- make mapped Rust consensus surfaces pull native fuzz build and bench companion gates fail-closed in local pre-push skill gates
- record reusable pre-push receipts as local-skill-gates plus coverage-preflight, not coverage only
- cover the new protocol gate behavior with unit tests

## Validation
- python3 -m unittest tools/tests/test_local_prepush_skill_gates.py tools/tests/test_prepush_receipt.py
- python3 /Users/gpt/Documents/rubin-orchestration-private/inbox/operational/tools/run_pr_lifecycle.py pre-pr --target-repo rubin-protocol --repo-root /Users/gpt/Documents/.codex/worktrees/rubin-protocol-non-ci-gates-01 --skip-execution-drift