### PR TITLE
perf: optimize go miner build context

### DIFF
--- a/clients/go/node/miner.go
+++ b/clients/go/node/miner.go
@@ -314,7 +314,7 @@ func canonicalCoinbaseWeight(height uint64, alreadyGenerated uint64, mineAddress
 	}
 
 	outputCount := uint64(1)
-	baseSize := uint64(4 + 1 + 8) // version + tx_kind + tx_nonce
+	strippedSize := uint64(4 + 1 + 8) // version + tx_kind + tx_nonce
 	parts := []uint64{
 		compactSizeLenForMiner(1),
 		32 + 4 + compactSizeLenForMiner(0) + 4,
@@ -329,11 +329,15 @@ func canonicalCoinbaseWeight(height uint64, alreadyGenerated uint64, mineAddress
 		8+2+compactSizeLenForMiner(32)+32,
 		4,
 	)
-	if err := addCoinbaseBaseSize(&baseSize, parts...); err != nil {
+	if err := addCoinbaseBaseSize(&strippedSize, parts...); err != nil {
 		return 0, err
 	}
 
-	return finalizeCoinbaseWeight(baseSize)
+	// Canonical coinbase carries zero witness items and no DA payload, so the
+	// discounted trailer still contributes one CompactSize byte for each field.
+	witnessSize := compactSizeLenForMiner(0)
+	daSize := compactSizeLenForMiner(0)
+	return finalizeCoinbaseWeight(strippedSize, witnessSize, daSize)
 }
 
 func addU64NoOverflow(dst *uint64, value uint64) error {
@@ -353,11 +357,15 @@ func addCoinbaseBaseSize(dst *uint64, values ...uint64) error {
 	return nil
 }
 
-func finalizeCoinbaseWeight(baseSize uint64) (uint64, error) {
-	if baseSize > (math.MaxUint64-2)/consensus.WITNESS_DISCOUNT_DIVISOR {
+func finalizeCoinbaseWeight(strippedSize uint64, witnessSize uint64, daSize uint64) (uint64, error) {
+	extraWeight, err := addU64NoOverflowValue(witnessSize, daSize)
+	if err != nil {
 		return 0, errors.New("coinbase weight overflow")
 	}
-	return consensus.WITNESS_DISCOUNT_DIVISOR*baseSize + 2, nil
+	if strippedSize > (math.MaxUint64-extraWeight)/consensus.WITNESS_DISCOUNT_DIVISOR {
+		return 0, errors.New("coinbase weight overflow")
+	}
+	return uint64(consensus.WITNESS_DISCOUNT_DIVISOR)*strippedSize + extraWeight, nil
 }
 
 func remainingWeightFromCoinbase(coinbaseWeight uint64) (uint64, error) {
@@ -365,6 +373,13 @@ func remainingWeightFromCoinbase(coinbaseWeight uint64) (uint64, error) {
 		return 0, errors.New("coinbase weight exceeds max block weight")
 	}
 	return consensus.MAX_BLOCK_WEIGHT - coinbaseWeight, nil
+}
+
+func addU64NoOverflowValue(left uint64, right uint64) (uint64, error) {
+	if right > math.MaxUint64-left {
+		return 0, errors.New("u64 overflow")
+	}
+	return left + right, nil
 }
 
 func compactSizeLenForMiner(n uint64) uint64 {

--- a/clients/go/node/miner_additional_test.go
+++ b/clients/go/node/miner_additional_test.go
@@ -631,17 +631,19 @@ func TestAddCoinbaseBaseSize(t *testing.T) {
 func TestFinalizeCoinbaseWeight(t *testing.T) {
 	t.Parallel()
 
-	const maxBaseSize = (math.MaxUint64 - 2) / consensus.WITNESS_DISCOUNT_DIVISOR
-	got, err := finalizeCoinbaseWeight(maxBaseSize)
+	const witnessSize = uint64(1)
+	const daSize = uint64(1)
+	const maxBaseSize = (math.MaxUint64 - witnessSize - daSize) / consensus.WITNESS_DISCOUNT_DIVISOR
+	got, err := finalizeCoinbaseWeight(maxBaseSize, witnessSize, daSize)
 	if err != nil {
 		t.Fatalf("unexpected finalize error: %v", err)
 	}
-	want := uint64(consensus.WITNESS_DISCOUNT_DIVISOR)*maxBaseSize + 2
+	want := uint64(consensus.WITNESS_DISCOUNT_DIVISOR)*maxBaseSize + witnessSize + daSize
 	if got != want {
 		t.Fatalf("weight=%d, want %d", got, want)
 	}
 
-	if _, err := finalizeCoinbaseWeight(maxBaseSize + 1); err == nil {
+	if _, err := finalizeCoinbaseWeight(maxBaseSize+1, witnessSize, daSize); err == nil {
 		t.Fatal("expected overflow error")
 	}
 }
@@ -659,6 +661,22 @@ func TestRemainingWeightFromCoinbase(t *testing.T) {
 
 	if _, err := remainingWeightFromCoinbase(consensus.MAX_BLOCK_WEIGHT + 1); err == nil {
 		t.Fatal("expected oversize coinbase error")
+	}
+}
+
+func TestAddU64NoOverflowValue(t *testing.T) {
+	t.Parallel()
+
+	got, err := addU64NoOverflowValue(3, 4)
+	if err != nil {
+		t.Fatalf("unexpected add error: %v", err)
+	}
+	if got != 7 {
+		t.Fatalf("sum=%d, want 7", got)
+	}
+
+	if _, err := addU64NoOverflowValue(math.MaxUint64, 1); err == nil {
+		t.Fatal("expected overflow error")
 	}
 }
 


### PR DESCRIPTION
Summary:
- avoid redundant miner build-context work on the hot path
- cover readonly snapshot and coinbase-weight branches so local gates stay green
- keep semantics unchanged while tightening hot-path allocations

Validation:
- python3 /Users/gpt/Documents/rubin-orchestration-private/inbox/operational/tools/run_pr_lifecycle.py pre-pr --target-repo rubin-protocol --repo-root /Users/gpt/Documents/.codex/worktrees/rubin-go-miner-pr-01 --skip-execution-drift
- bash ./scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node -run "^(TestMiner|TestBuildCoinbase|TestCanonicalCoinbaseWeightMatchesLegacyWeight|TestCanonicalCoinbaseWeightRejectsOverflowAndInvalidAddress|TestCompactSizeLenForMinerCoversAllBranches|TestPolicyNeedsReadonlyUtxoSnapshotMatrix|TestSnapshotBuildContextStateHandlesNilAndNoPolicyPaths|TestMinerBuildContextUtxoMapDoesNotAliasChainStateMap)$" -count=1 && go test ./node -run "^$" -bench "^BenchmarkMinerBuildContext$" -benchmem -count=3'

Queue:
- Q-PERF-GO-MINER-PATH-01

Track:
- Part of [TRK] Go/Rust runtime perf mini-TZ #1041

Closes:
- #1047
