### PR TITLE
docs: record rust txpool miner perf verdict

### DIFF
--- a/evidence/runtime-perf/2026-03-31_rust_txpool_miner_followup_negative_result.md
+++ b/evidence/runtime-perf/2026-03-31_rust_txpool_miner_followup_negative_result.md
@@ -17,8 +17,7 @@ optimization slice right now.
 ## Benchmark Command
 
 ```bash
-cd /Users/gpt/Documents/rubin-protocol/clients/rust
-cargo bench -p rubin-node --bench runtime_baseline -- --noplot --sample-size 10 --measurement-time 2
+cargo bench --manifest-path clients/rust/Cargo.toml -p rubin-node --bench runtime_baseline -- --noplot --sample-size 10 --measurement-time 2
 ```
 
 ## Observed Results


### PR DESCRIPTION
Summary:
- record the benchmark evidence for the rust txpool/miner follow-up slice
- make the negative result explicit instead of silently dropping the task
- keep the track honest: no code change is justified by the observed numbers yet

Validation:
- python3 /Users/gpt/Documents/rubin-orchestration-private/inbox/operational/tools/run_pr_lifecycle.py pre-pr --target-repo rubin-protocol --repo-root /Users/gpt/Documents/.codex/worktrees/rubin-rust-txpool-followup-pr-01 --skip-execution-drift
- cd /Users/gpt/Documents/rubin-protocol/clients/rust && cargo bench -p rubin-node --bench runtime_baseline -- --noplot --sample-size 10 --measurement-time 2

Queue:
- Q-PERF-RUST-TXPOOL-MINER-FOLLOWUP-01

Track:
- Part of [TRK] Go/Rust runtime perf mini-TZ #1041

Closes:
- #1049
