### PR TITLE
ci: enable rust CodeQL analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,8 +19,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ['go']
-        # 'rust' — add when CodeQL Rust exits experimental
+        include:
+          - language: go
+            build-mode: autobuild
+          - language: rust
+            # GitHub CodeQL now supports Rust with build-mode none.
+            # Keep workflow-wide execution unconditional so the Rust check
+            # can be linked into required status checks without path-filter drift.
+            build-mode: none
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -29,9 +35,11 @@ jobs:
         uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4
         with:
           languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
           # queries: security-extended — uncomment for extended rule set
 
       - name: Autobuild
+        if: matrix.build-mode == 'autobuild'
         uses: github/codeql-action/autobuild@c10b8064de6f491fea524254123dbe5e09572f13 # v4
 
       - name: Perform CodeQL Analysis


### PR DESCRIPTION
## Summary
- enable a Rust CodeQL lane alongside the existing Go lane
- switch CodeQL to an explicit language/build-mode matrix
- keep the Rust lane unconditional so it can be linked into required checks without path-filter drift

## Why
- closes Q-CI-RUST-STATIC-ANALYSIS-HARDENING-01
- refs #1070

## Notes
- Go keeps `autobuild`
- Rust uses `build-mode: none`
- required-ruleset linkage will be updated after this workflow lands on `main`, so the required check exists for future PR heads

## Validation
- sanctioned pre-pr on clean worktree passed
- yaml parse passed
