### PR TITLE
docs: align formal proof surface narrative

### DIFF
--- a/ARCHITECTURE_MAP.md
+++ b/ARCHITECTURE_MAP.md
@@ -75,7 +75,7 @@ rubin-spec (private) /*
 
 - `scripts/` contains spec integrity tooling and reproducible env helpers.
 - `tools/` contains policy and integrity checks used by CI and local validation.
-- `rubin-formal/` maintains a toy/model formal baseline and risk-gate metadata.
+- `rubin-formal/` maintains the Lean formal proof surface and risk-gate metadata used by CI and public coverage claims.
 
 ## 6) Practical Change Path (Recommended)
 

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ There is no delayed wire-activation mechanism.
 - `./clients/go/cmd/rubin-node/` Go node skeleton entrypoint (daemon bootstrap)
 - `./clients/rust/` Rust reference consensus library + CLI
 - `./conformance/` fixtures + runner (Go↔Rust parity)
-- `./rubin-formal/` Lean4 proof-pack **mirror/bootstrap** (for CI and local replay)
-  - Authoritative formal baseline lives in the standalone repository: `https://github.com/2tbmz9y2xt-lang/rubin-formal`
+- `./rubin-formal/` Lean4 formal proof surface used by CI and local replay
+  - Authoritative standalone repository: `https://github.com/2tbmz9y2xt-lang/rubin-formal`
 - `./ARCHITECTURE_MAP.md` architecture map (spec → fixtures → clients → CI)
 
 Quick references:


### PR DESCRIPTION
## Summary
- align the public formal-proof description in `README.md` with the actual post-uplift proof surface
- remove stale bootstrap/toy-baseline wording from `ARCHITECTURE_MAP.md`
- keep this PR narrative-only; theorem and registry truth live in rubin-formal companion PR

## Context
- companion formal PR: 2tbmz9y2xt-lang/rubin-formal#405
- supports rubin-formal#374

## Validation
- hostile grep self-audit for stale wording
- sanctioned local self-audit receipt / `cl push` path