### PR TITLE
ci: add bot-review-gate workflow

### DIFF
--- a/.github/workflows/bot-review-gate.yml
+++ b/.github/workflows/bot-review-gate.yml
@@ -1,0 +1,63 @@
+name: Bot Review Gate
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  pull_request_review:
+    types: [submitted, dismissed]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  bot-review-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check bot reviews are acknowledged
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const MONITORED_BOTS = ['copilot[bot]'];
+            const prNumber = context.payload.pull_request.number;
+
+            const reviews = await github.paginate(
+              github.rest.pulls.listReviews,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber
+              }
+            );
+
+            // Keep only the latest review per monitored bot
+            const latestByBot = {};
+            for (const review of reviews) {
+              const login = review.user?.login || '';
+              if (MONITORED_BOTS.includes(login)) {
+                latestByBot[login] = review;
+              }
+            }
+
+            const blocking = [];
+            for (const [bot, review] of Object.entries(latestByBot)) {
+              // COMMENTED = active review that hasn't been dismissed
+              // DISMISSED = human acknowledged and dismissed → OK
+              if (review.state === 'COMMENTED') {
+                blocking.push(
+                  `  • ${bot} — review #${review.id}`
+                );
+              }
+            }
+
+            if (blocking.length > 0) {
+              core.setFailed(
+                [
+                  `${blocking.length} unacknowledged bot review(s):`,
+                  ...blocking,
+                  '',
+                  'To unblock merge: read the review → click ⋯ → Dismiss review.'
+                ].join('\n')
+              );
+            } else {
+              core.info('All bot reviews acknowledged (dismissed) or none present.');
+            }


### PR DESCRIPTION
## Summary
- Adds `bot-review-gate` GitHub Action that blocks merge until bot reviews (copilot[bot]) are dismissed
- Copilot always submits COMMENTED reviews (never REQUEST_CHANGES), so its summary-only reviews bypass `required_review_thread_resolution`
- This gate requires human to read and dismiss bot review before merge is allowed

## How it works
1. Copilot auto-reviews PR → status check FAILS
2. Human reads review → clicks ⋯ → Dismiss review
3. Status check re-runs → PASSES
4. New push → Copilot re-reviews → cycle repeats

## After merge
Add `bot-review-gate` to required status checks in ruleset.