### PR TITLE
ci: add bot-review-gate workflow

### DIFF
--- a/.github/workflows/bot-review-gate.yml
+++ b/.github/workflows/bot-review-gate.yml
@@ -33,9 +33,9 @@ jobs:
                 }
               );
             } catch (err) {
-              core.warning(
+              core.setFailed(
                 `Failed to fetch reviews: ${err.message}. ` +
-                `Skipping bot-review-gate (will not block merge).`
+                `Bot-review-gate blocked (fail-closed). Re-run this check to retry.`
               );
               return;
             }


### PR DESCRIPTION
## Summary
- Adds `bot-review-gate` status check that blocks merge until bot reviews (copilot[bot]) are dismissed
- Copilot always submits COMMENTED reviews (never REQUEST_CHANGES), so summary-only reviews bypass `required_review_thread_resolution`
- This gate requires human to dismiss bot review before merge

## Flow
1. Copilot auto-reviews PR → `bot-review-gate` FAILS
2. Human reads review → ⋯ → Dismiss review → PASSES
3. New push → Copilot re-reviews → cycle repeats

## After merge
Add `bot-review-gate` to required status checks in ruleset.