### PR TITLE
chore: strengthen self-audit prompt replay

### DIFF
--- a/tools/prepush_review_contract.json
+++ b/tools/prepush_review_contract.json
@@ -1,8 +1,61 @@
 {
-  "schema_version": 4,
+  "schema_version": 5,
   "note": "rubin-protocol local pre-push review contract",
   "default_profile": "diff_only",
   "fullscan_mode": "skill-backed",
+  "self_audit": {
+    "prompt_pack_version": "self-audit-v1",
+    "required_pattern_families": [
+      {
+        "id": "exact-native-suite-params",
+        "title": "Exact native-suite parameter binding",
+        "checks": [
+          "Reject empty or alias algorithm strings that silently collapse into ML-DSA-87.",
+          "If a staged change touches native suite bootstrap or registry parsing, verify exact ML-DSA-87 pubkey_len, sig_len, and verify_cost enforcement on every path."
+        ]
+      },
+      {
+        "id": "bounded-bootstrap-surface",
+        "title": "Bounded bootstrap and allocation surface",
+        "checks": [
+          "Look for new unbounded loops, registry item counts, or large allocation surfaces introduced by config or genesis parsing.",
+          "Require explicit fail-closed caps for item count, pubkey_len, sig_len, and related resource knobs."
+        ]
+      },
+      {
+        "id": "cross-client-int-parity",
+        "title": "Cross-client integer and cast parity",
+        "checks": [
+          "Replay Go vs Rust type parity for every changed numeric field, especially casts between uint64/u64, int/usize, and length checks.",
+          "Reject any path where one client accepts values that the other rejects or panics on."
+        ]
+      },
+      {
+        "id": "bootstrap-default-registry-parity",
+        "title": "Bootstrap/default registry parity",
+        "checks": [
+          "If staged changes touch suite registry construction, confirm both clients preserve the same default ML-DSA-87 entry and initialization semantics.",
+          "Check registry-only bootstrap paths, descriptor+registry paths, and missing-registry fallback paths for identical behavior."
+        ]
+      },
+      {
+        "id": "reviewer-raised-ordering-and-redundancy",
+        "title": "Ordering, redundancy, and reviewer-raised sharp edges",
+        "checks": [
+          "Remove redundant validation if a stronger network-aware validator already covers the same surface.",
+          "Re-read staged diffs for the exact bot-review smells already seen on this track before declaring self-audit complete."
+        ]
+      },
+      {
+        "id": "hostile-regression-tests",
+        "title": "Hostile regression test replay",
+        "checks": [
+          "For every new fail-closed guard, add or update a negative test that proves the guard actually fires.",
+          "If a reviewer-raised pattern changes behavior, add a targeted regression test covering that exact pattern."
+        ]
+      }
+    ]
+  },
   "profiles": {
     "consensus_critical": {
       "combine_review_units_when_at_most": 4,

--- a/tools/self_audit_prompt_pack.py
+++ b/tools/self_audit_prompt_pack.py
@@ -125,27 +125,46 @@ def staged_changed_files(repo_root: Path) -> list[str]:
     return [line.strip() for line in raw.splitlines() if line.strip()]
 
 
-def staged_bundle(repo_root: Path) -> str:
-    paths = staged_changed_files(repo_root)
+def head_changed_files(repo_root: Path) -> list[str]:
+    raw = run_git(repo_root, "show", "--pretty=format:", "--name-only", "--find-renames", "HEAD", "--", *REVIEWABLE_PATHS)
+    return [line.strip() for line in raw.splitlines() if line.strip()]
+
+
+def build_bundle(repo_root: Path, *, mode: str, paths: list[str]) -> str:
     if not paths:
-        raise ValueError("no staged reviewable diff")
-    stat = run_git(repo_root, "diff", "--cached", "--stat=160", "--find-renames", "--", *paths)
-    patch = run_git(repo_root, "diff", "--cached", "--no-color", "--unified=3", "--find-renames", "--", *paths)
+        raise ValueError(f"no {mode} reviewable diff")
+    if mode == "staged":
+        stat = run_git(repo_root, "diff", "--cached", "--stat=160", "--find-renames", "--", *paths)
+        patch = run_git(repo_root, "diff", "--cached", "--no-color", "--unified=3", "--find-renames", "--", *paths)
+    else:
+        stat = run_git(repo_root, "show", "--stat=160", "--format=medium", "--find-renames", "--no-color", "HEAD", "--", *paths)
+        patch = run_git(repo_root, "show", "--format=medium", "--find-renames", "--no-color", "--unified=3", "HEAD", "--", *paths)
     head = run_git(repo_root, "rev-parse", "--short", "HEAD").strip()
     lines = [
+        f"MODE={mode}",
         f"HEAD={head}",
         "",
-        "--- STAGED CHANGED FILES ---",
+        "--- REVIEW CHANGED FILES ---",
         *paths,
         "",
-        "--- STAGED DIFF STAT ---",
+        "--- REVIEW DIFF STAT ---",
         stat.rstrip(),
         "",
-        "--- STAGED PATCH ---",
+        "--- REVIEW PATCH ---",
         patch.rstrip(),
         "",
     ]
     return "\n".join(lines)
+
+
+def staged_bundle(repo_root: Path) -> str:
+    paths = staged_changed_files(repo_root)
+    if paths:
+        return build_bundle(repo_root, mode="staged", paths=paths)
+    head_paths = head_changed_files(repo_root)
+    if head_paths:
+        return build_bundle(repo_root, mode="head", paths=head_paths)
+    raise ValueError("no staged or HEAD reviewable diff")
 
 
 def compose_prompt(*, contract: dict[str, object], bundle_text: str) -> str:

--- a/tools/self_audit_prompt_pack.py
+++ b/tools/self_audit_prompt_pack.py
@@ -137,6 +137,11 @@ def staged_changed_files(repo_root: Path) -> list[str]:
     return [line.strip() for line in raw.splitlines() if line.strip()]
 
 
+def has_any_staged_changes(repo_root: Path) -> bool:
+    raw = run_git(repo_root, "diff", "--cached", "--name-only", "--find-renames")
+    return any(line.strip() for line in raw.splitlines())
+
+
 def head_changed_files(repo_root: Path) -> list[str]:
     raw = run_git(repo_root, "show", "--pretty=format:", "--name-only", "--find-renames", "HEAD", "--", *REVIEWABLE_PATHS)
     return [line.strip() for line in raw.splitlines() if line.strip()]
@@ -191,6 +196,8 @@ def staged_bundle(repo_root: Path) -> str:
     paths = staged_changed_files(repo_root)
     if paths:
         return build_bundle(repo_root, mode="staged", paths=paths)
+    if has_any_staged_changes(repo_root):
+        raise ValueError("no staged reviewable diff")
     head_paths = head_changed_files(repo_root)
     if head_paths:
         return build_bundle(repo_root, mode="head", paths=head_paths)

--- a/tools/self_audit_prompt_pack.py
+++ b/tools/self_audit_prompt_pack.py
@@ -142,6 +142,13 @@ def head_changed_files(repo_root: Path) -> list[str]:
     return [line.strip() for line in raw.splitlines() if line.strip()]
 
 
+def render_head_label(repo_root: Path) -> str:
+    try:
+        return run_git(repo_root, "rev-parse", "--short", "HEAD").strip()
+    except RuntimeError:
+        return "(unborn)"
+
+
 def build_bundle(repo_root: Path, *, mode: str, paths: list[str]) -> str:
     if not paths:
         raise ValueError(f"no {mode} reviewable diff")
@@ -149,9 +156,20 @@ def build_bundle(repo_root: Path, *, mode: str, paths: list[str]) -> str:
         stat = run_git(repo_root, "diff", "--cached", "--stat=160", "--find-renames", "--", *paths)
         patch = run_git(repo_root, "diff", "--cached", "--no-color", "--unified=3", "--find-renames", "--", *paths)
     else:
-        stat = run_git(repo_root, "show", "--stat=160", "--format=medium", "--find-renames", "--no-color", "HEAD", "--", *paths)
+        stat = run_git(
+            repo_root,
+            "show",
+            "--stat=160",
+            "--no-patch",
+            "--format=medium",
+            "--find-renames",
+            "--no-color",
+            "HEAD",
+            "--",
+            *paths,
+        )
         patch = run_git(repo_root, "show", "--format=medium", "--find-renames", "--no-color", "--unified=3", "HEAD", "--", *paths)
-    head = run_git(repo_root, "rev-parse", "--short", "HEAD").strip()
+    head = render_head_label(repo_root)
     lines = [
         f"MODE={mode}",
         f"HEAD={head}",

--- a/tools/self_audit_prompt_pack.py
+++ b/tools/self_audit_prompt_pack.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+
+CONTRACT_PATH = Path(__file__).resolve().with_name("prepush_review_contract.json")
+REVIEWABLE_PATHS = (
+    "*.go",
+    "*.rs",
+    "*.lean",
+    "*.sh",
+    "*.py",
+    "*.yml",
+    "*.yaml",
+    "*.json",
+    "*.toml",
+    "*.md",
+)
+
+BASE_PROMPT = """You are running RUBIN local self-audit before commit in FAIL-CLOSED mode.
+
+INPUT BOUNDARY:
+- Review ONLY the current staged diff and the changed-file list included below.
+- Do not rationalize away known bot-review patterns.
+- If a known pattern is touched by the staged diff, treat it as unresolved until you can point to the exact staged lines and the exact regression test that covers it.
+
+SELF-AUDIT CONTRACT:
+- Before writing a fresh self-audit receipt, replay every required pattern family below.
+- For each family, decide one of:
+  1) covered by exact staged guard + exact test,
+  2) not applicable to this diff,
+  3) still unresolved and must block commit.
+- If any family is unresolved, do not refresh the receipt.
+
+REVIEWER MINDSET:
+- Think like the hostile PR bots that already flagged this repo: DeepSeek, Copilot, Claude, Codex.
+- Prefer concrete adversarial cases: malformed config/genesis input, resource exhaustion, Go/Rust divergence, exact parameter drift, redundant validation ordering, and missing regression tests.
+"""
+
+
+def run_git(repo_root: Path, *args: str) -> str:
+    proc = subprocess.run(
+        ["git", "-C", str(repo_root), *args],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        msg = proc.stderr.strip() or proc.stdout.strip() or "unknown git error"
+        raise RuntimeError(f"git {' '.join(args)} :: {msg}")
+    return proc.stdout
+
+
+def load_self_audit_contract(path: Path = CONTRACT_PATH) -> dict[str, object]:
+    if not path.exists():
+        raise FileNotFoundError(f"self-audit contract missing: {path}")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"self-audit contract at {path} must decode to an object")
+    section = data.get("self_audit")
+    if not isinstance(section, dict):
+        raise ValueError(f"self-audit contract at {path} must define self_audit object")
+    version = str(section.get("prompt_pack_version") or "").strip()
+    families = section.get("required_pattern_families")
+    if not version:
+        raise ValueError(f"self-audit contract at {path} must define prompt_pack_version")
+    if not isinstance(families, list) or not families:
+        raise ValueError(f"self-audit contract at {path} must define non-empty required_pattern_families")
+    normalized: list[dict[str, object]] = []
+    for raw in families:
+        if not isinstance(raw, dict):
+            raise ValueError(f"self-audit contract at {path} has non-object pattern family")
+        family_id = str(raw.get("id") or "").strip()
+        title = str(raw.get("title") or "").strip()
+        checks_raw = raw.get("checks")
+        if not family_id or not title or not isinstance(checks_raw, list) or not checks_raw:
+            raise ValueError(f"self-audit contract at {path} has malformed pattern family")
+        checks = [str(item).strip() for item in checks_raw if str(item).strip()]
+        if not checks:
+            raise ValueError(f"self-audit contract at {path} pattern family {family_id!r} has empty checks")
+        normalized.append({"id": family_id, "title": title, "checks": checks})
+    return {"prompt_pack_version": version, "required_pattern_families": normalized}
+
+
+def staged_changed_files(repo_root: Path) -> list[str]:
+    raw = run_git(repo_root, "diff", "--cached", "--name-only", "--find-renames", "--", *REVIEWABLE_PATHS)
+    return [line.strip() for line in raw.splitlines() if line.strip()]
+
+
+def staged_bundle(repo_root: Path) -> str:
+    paths = staged_changed_files(repo_root)
+    if not paths:
+        raise ValueError("no staged reviewable diff")
+    stat = run_git(repo_root, "diff", "--cached", "--stat=160", "--find-renames", "--", *paths)
+    patch = run_git(repo_root, "diff", "--cached", "--no-color", "--unified=3", "--find-renames", "--", *paths)
+    head = run_git(repo_root, "rev-parse", "--short", "HEAD").strip()
+    lines = [
+        f"HEAD={head}",
+        "",
+        "--- STAGED CHANGED FILES ---",
+        *paths,
+        "",
+        "--- STAGED DIFF STAT ---",
+        stat.rstrip(),
+        "",
+        "--- STAGED PATCH ---",
+        patch.rstrip(),
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def compose_prompt(*, contract: dict[str, object], bundle_text: str) -> str:
+    version = str(contract["prompt_pack_version"])
+    families = contract["required_pattern_families"]
+    lines = [
+        f"Prompt Pack: {version}",
+        "",
+        BASE_PROMPT.strip(),
+        "",
+        "Required pattern replay:",
+    ]
+    for family in families:
+        lines.append(f"- {family['title']} [{family['id']}]")
+        for check in family["checks"]:
+            lines.append(f"  - {check}")
+    lines.extend(
+        [
+            "",
+            "Mandatory self-audit output before receipt refresh:",
+            "- exact changed lines reviewed for each applicable pattern family",
+            "- exact tests covering each new fail-closed guard",
+            "- explicit note if a family is not applicable",
+            "",
+            "Staged diff bundle follows.",
+            "",
+            bundle_text.rstrip(),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Build RUBIN local self-audit prompt pack from staged diff.")
+    parser.add_argument("--repo-root", required=True)
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+
+    repo_root = Path(args.repo_root).resolve()
+    output_path = Path(args.output).resolve()
+    contract = load_self_audit_contract()
+    prompt = compose_prompt(contract=contract, bundle_text=staged_bundle(repo_root))
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(prompt, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/self_audit_prompt_pack.py
+++ b/tools/self_audit_prompt_pack.py
@@ -4,13 +4,21 @@ from __future__ import annotations
 import argparse
 import json
 import subprocess
+import tempfile
 from pathlib import Path
 
 CONTRACT_PATH = Path(__file__).resolve().with_name("prepush_review_contract.json")
+MAX_GIT_OUTPUT_BYTES = 10 * 1024 * 1024
 REVIEWABLE_PATHS = (
     "*.go",
     "*.rs",
+    "*.c",
+    "*.cc",
+    "*.cpp",
+    "*.h",
+    "*.hpp",
     "*.lean",
+    "*.proto",
     "*.sh",
     "*.py",
     "*.yml",
@@ -41,18 +49,44 @@ REVIEWER MINDSET:
 """
 
 
+def normalize_repo_root(repo_root: Path) -> Path:
+    normalized = repo_root.resolve()
+    if not normalized.is_absolute():
+        raise ValueError("repo_root must be absolute")
+    if not normalized.exists() or not normalized.is_dir():
+        raise ValueError(f"repo_root must be an existing directory: {normalized}")
+    if normalized.name.startswith("-"):
+        raise ValueError(f"repo_root must not start with '-': {normalized}")
+    git_marker = normalized / ".git"
+    if not git_marker.exists():
+        raise ValueError(f"repo_root is not a git worktree: {normalized}")
+    return normalized
+
+
+def _read_limited(handle: tempfile.TemporaryFile[bytes], *, label: str) -> str:
+    handle.flush()
+    size = handle.tell()
+    if size > MAX_GIT_OUTPUT_BYTES:
+        raise ValueError(f"{label} exceeds {MAX_GIT_OUTPUT_BYTES} bytes")
+    handle.seek(0)
+    return handle.read().decode("utf-8", errors="replace")
+
+
 def run_git(repo_root: Path, *args: str) -> str:
-    proc = subprocess.run(
-        ["git", "-C", str(repo_root), *args],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-        check=False,
-    )
+    repo_root = normalize_repo_root(repo_root)
+    with tempfile.TemporaryFile() as stdout, tempfile.TemporaryFile() as stderr:
+        proc = subprocess.run(
+            ["git", "-C", str(repo_root), *args],
+            stdout=stdout,
+            stderr=stderr,
+            check=False,
+        )
+        stdout_text = _read_limited(stdout, label=f"git {' '.join(args)} stdout")
+        stderr_text = _read_limited(stderr, label=f"git {' '.join(args)} stderr")
     if proc.returncode != 0:
-        msg = proc.stderr.strip() or proc.stdout.strip() or "unknown git error"
+        msg = stderr_text.strip() or stdout_text.strip() or "unknown git error"
         raise RuntimeError(f"git {' '.join(args)} :: {msg}")
-    return proc.stdout
+    return stdout_text
 
 
 def load_self_audit_contract(path: Path = CONTRACT_PATH) -> dict[str, object]:
@@ -151,7 +185,7 @@ def main() -> int:
     parser.add_argument("--output", required=True)
     args = parser.parse_args()
 
-    repo_root = Path(args.repo_root).resolve()
+    repo_root = normalize_repo_root(Path(args.repo_root))
     output_path = Path(args.output).resolve()
     contract = load_self_audit_contract()
     prompt = compose_prompt(contract=contract, bundle_text=staged_bundle(repo_root))

--- a/tools/self_audit_prompt_pack.py
+++ b/tools/self_audit_prompt_pack.py
@@ -10,22 +10,22 @@ from pathlib import Path
 CONTRACT_PATH = Path(__file__).resolve().with_name("prepush_review_contract.json")
 MAX_GIT_OUTPUT_BYTES = 10 * 1024 * 1024
 REVIEWABLE_PATHS = (
-    "*.go",
-    "*.rs",
-    "*.c",
-    "*.cc",
-    "*.cpp",
-    "*.h",
-    "*.hpp",
-    "*.lean",
-    "*.proto",
-    "*.sh",
-    "*.py",
-    "*.yml",
-    "*.yaml",
-    "*.json",
-    "*.toml",
-    "*.md",
+    ":(glob)**/*.go",
+    ":(glob)**/*.rs",
+    ":(glob)**/*.c",
+    ":(glob)**/*.cc",
+    ":(glob)**/*.cpp",
+    ":(glob)**/*.h",
+    ":(glob)**/*.hpp",
+    ":(glob)**/*.lean",
+    ":(glob)**/*.proto",
+    ":(glob)**/*.sh",
+    ":(glob)**/*.py",
+    ":(glob)**/*.yml",
+    ":(glob)**/*.yaml",
+    ":(glob)**/*.json",
+    ":(glob)**/*.toml",
+    ":(glob)**/*.md",
 )
 
 BASE_PROMPT = """You are running RUBIN local self-audit before commit in FAIL-CLOSED mode.
@@ -89,6 +89,15 @@ def run_git(repo_root: Path, *args: str) -> str:
     return stdout_text
 
 
+def required_string(value: object, *, label: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{label} must be a string")
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{label} must be non-empty")
+    return normalized
+
+
 def load_self_audit_contract(path: Path = CONTRACT_PATH) -> dict[str, object]:
     if not path.exists():
         raise FileNotFoundError(f"self-audit contract missing: {path}")
@@ -98,24 +107,27 @@ def load_self_audit_contract(path: Path = CONTRACT_PATH) -> dict[str, object]:
     section = data.get("self_audit")
     if not isinstance(section, dict):
         raise ValueError(f"self-audit contract at {path} must define self_audit object")
-    version = str(section.get("prompt_pack_version") or "").strip()
+    version = required_string(section.get("prompt_pack_version"), label=f"{path} self_audit.prompt_pack_version")
     families = section.get("required_pattern_families")
-    if not version:
-        raise ValueError(f"self-audit contract at {path} must define prompt_pack_version")
     if not isinstance(families, list) or not families:
         raise ValueError(f"self-audit contract at {path} must define non-empty required_pattern_families")
     normalized: list[dict[str, object]] = []
-    for raw in families:
+    for idx, raw in enumerate(families):
         if not isinstance(raw, dict):
             raise ValueError(f"self-audit contract at {path} has non-object pattern family")
-        family_id = str(raw.get("id") or "").strip()
-        title = str(raw.get("title") or "").strip()
+        family_id = required_string(raw.get("id"), label=f"{path} required_pattern_families[{idx}].id")
+        title = required_string(raw.get("title"), label=f"{path} required_pattern_families[{idx}].title")
         checks_raw = raw.get("checks")
-        if not family_id or not title or not isinstance(checks_raw, list) or not checks_raw:
+        if not isinstance(checks_raw, list) or not checks_raw:
             raise ValueError(f"self-audit contract at {path} has malformed pattern family")
-        checks = [str(item).strip() for item in checks_raw if str(item).strip()]
-        if not checks:
-            raise ValueError(f"self-audit contract at {path} pattern family {family_id!r} has empty checks")
+        checks: list[str] = []
+        for check_idx, item in enumerate(checks_raw):
+            checks.append(
+                required_string(
+                    item,
+                    label=f"{path} required_pattern_families[{idx}].checks[{check_idx}]",
+                )
+            )
         normalized.append({"id": family_id, "title": title, "checks": checks})
     return {"prompt_pack_version": version, "required_pattern_families": normalized}
 

--- a/tools/self_audit_receipt.py
+++ b/tools/self_audit_receipt.py
@@ -168,10 +168,10 @@ def read_receipt(repo_root: Path) -> tuple[dict[str, object], dict[str, object] 
         schema_version = int(payload.get("schema_version") or 0)
     except (TypeError, ValueError):
         result["reason"] = "schema-malformed"
-        return result, payload
+        return result, None
     if schema_version != SCHEMA_VERSION:
         result["reason"] = "schema-mismatch"
-        return result, payload
+        return result, None
     return result, payload
 
 

--- a/tools/self_audit_receipt.py
+++ b/tools/self_audit_receipt.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+STATE_SUBDIR = "local-security-review"
+RECEIPT_NAME = "self-audit-receipt.json"
+PROMPT_NAME = "self-audit-prompt.txt"
+SCHEMA_VERSION = 2
+
+
+def run_git(repo_root: Path, *args: str) -> str:
+    proc = subprocess.run(
+        ["git", "-C", str(repo_root), *args],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        msg = proc.stderr.strip() or proc.stdout.strip() or "unknown git error"
+        raise RuntimeError(f"git {' '.join(args)} :: {msg}")
+    return proc.stdout.strip()
+
+
+def git_dir(repo_root: Path) -> Path:
+    raw = run_git(repo_root, "rev-parse", "--git-dir")
+    path = Path(raw)
+    if not path.is_absolute():
+        path = (repo_root / path).resolve()
+    return path
+
+
+def state_dir(repo_root: Path) -> Path:
+    return git_dir(repo_root) / STATE_SUBDIR
+
+
+def receipt_path(repo_root: Path) -> Path:
+    return state_dir(repo_root) / RECEIPT_NAME
+
+
+def prompt_path(repo_root: Path) -> Path:
+    return state_dir(repo_root) / PROMPT_NAME
+
+
+def prompt_tool_path(repo_root: Path) -> Path:
+    return repo_root / "tools" / "self_audit_prompt_pack.py"
+
+
+def review_contract_path(repo_root: Path) -> Path:
+    return repo_root / "tools" / "prepush_review_contract.json"
+
+
+def now_utc_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def current_branch(repo_root: Path) -> str:
+    try:
+        return run_git(repo_root, "symbolic-ref", "--quiet", "--short", "HEAD")
+    except RuntimeError:
+        return run_git(repo_root, "rev-parse", "--short", "HEAD")
+
+
+def maybe_head(repo_root: Path) -> str:
+    proc = subprocess.run(
+        ["git", "-C", str(repo_root), "rev-parse", "--verify", "HEAD"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    return proc.stdout.strip() if proc.returncode == 0 else ""
+
+
+def maybe_head_tree(repo_root: Path) -> str:
+    head = maybe_head(repo_root)
+    if not head:
+        return ""
+    return run_git(repo_root, "rev-parse", "HEAD^{tree}")
+
+
+def current_index_tree(repo_root: Path) -> str:
+    return run_git(repo_root, "write-tree")
+
+
+def tracked_worktree_clean(repo_root: Path) -> bool:
+    return run_git(repo_root, "status", "--short", "--untracked-files=no") == ""
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def file_sha256(path: Path) -> str:
+    return sha256_bytes(path.read_bytes())
+
+
+def ensure_self_audit_prompt(repo_root: Path) -> Path:
+    tool = prompt_tool_path(repo_root)
+    if not tool.exists():
+        raise RuntimeError(f"missing self-audit prompt tool: {tool}")
+    path = prompt_path(repo_root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    proc = subprocess.run(
+        ["python3", str(tool), "--repo-root", str(repo_root), "--output", str(path)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        msg = proc.stderr.strip() or proc.stdout.strip() or "unknown prompt-pack error"
+        raise RuntimeError(f"self-audit prompt build failed :: {msg}")
+    return path
+
+
+def build_payload(repo_root: Path, *, source: str) -> dict[str, object]:
+    built_prompt_path = ensure_self_audit_prompt(repo_root)
+    contract = review_contract_path(repo_root)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "note": "rubin-protocol local self-audit receipt",
+        "source": source,
+        "repo_root": str(repo_root),
+        "git_dir": str(git_dir(repo_root)),
+        "branch": current_branch(repo_root),
+        "head_at_write": maybe_head(repo_root),
+        "staged_tree": current_index_tree(repo_root),
+        "tracked_worktree_clean": tracked_worktree_clean(repo_root),
+        "prompt_path": str(built_prompt_path),
+        "prompt_sha256": file_sha256(built_prompt_path),
+        "review_contract_path": str(contract),
+        "review_contract_sha256": file_sha256(contract),
+        "generated_at": now_utc_iso(),
+    }
+
+
+def write_receipt(repo_root: Path, *, source: str) -> dict[str, object]:
+    payload = build_payload(repo_root, source=source)
+    path = receipt_path(repo_root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return {"fresh": True, "reason": "written", "receipt_path": str(path), "receipt": payload}
+
+
+def read_receipt(repo_root: Path) -> tuple[dict[str, object], dict[str, object] | None]:
+    path = receipt_path(repo_root)
+    result: dict[str, object] = {"fresh": False, "reason": "missing", "receipt_path": str(path)}
+    if not path.exists():
+        return result, None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        result["reason"] = f"malformed:{exc.__class__.__name__}"
+        return result, None
+    if not isinstance(payload, dict):
+        result["reason"] = "malformed:non-object"
+        return result, None
+    result["receipt"] = payload
+    try:
+        schema_version = int(payload.get("schema_version") or 0)
+    except (TypeError, ValueError):
+        result["reason"] = "schema-malformed"
+        return result, payload
+    if schema_version != SCHEMA_VERSION:
+        result["reason"] = "schema-mismatch"
+        return result, payload
+    return result, payload
+
+
+def check_commit(repo_root: Path) -> dict[str, object]:
+    result, payload = read_receipt(repo_root)
+    if payload is None:
+        return result
+    branch = current_branch(repo_root)
+    if str(payload.get("branch") or "") != branch:
+        result["reason"] = "branch-mismatch"
+        result["current_branch"] = branch
+        return result
+    head = maybe_head(repo_root)
+    if str(payload.get("head_at_write") or "") != head:
+        result["reason"] = "head-mismatch"
+        result["current_head"] = head
+        return result
+    staged_tree = current_index_tree(repo_root)
+    if str(payload.get("staged_tree") or "") != staged_tree:
+        result["reason"] = "staged-tree-mismatch"
+        result["current_staged_tree"] = staged_tree
+        return result
+    current_contract = review_contract_path(repo_root)
+    if not current_contract.exists():
+        result["reason"] = "missing-review-contract"
+        return result
+    if str(payload.get("review_contract_sha256") or "") != file_sha256(current_contract):
+        result["reason"] = "review-contract-mismatch"
+        return result
+    current_prompt = prompt_path(repo_root)
+    if not current_prompt.exists():
+        result["reason"] = "missing-self-audit-prompt"
+        result["prompt_path"] = str(current_prompt)
+        return result
+    if str(payload.get("prompt_sha256") or "") != file_sha256(current_prompt):
+        result["reason"] = "self-audit-prompt-mismatch"
+        result["prompt_path"] = str(current_prompt)
+        return result
+    result["fresh"] = True
+    result["reason"] = "fresh"
+    result["current_branch"] = branch
+    result["current_head"] = head
+    result["current_staged_tree"] = staged_tree
+    return result
+
+
+def check_push(repo_root: Path) -> dict[str, object]:
+    result, payload = read_receipt(repo_root)
+    if payload is None:
+        return result
+    branch = current_branch(repo_root)
+    if str(payload.get("branch") or "") != branch:
+        result["reason"] = "branch-mismatch"
+        result["current_branch"] = branch
+        return result
+    if not tracked_worktree_clean(repo_root):
+        result["reason"] = "dirty-worktree"
+        return result
+    head = maybe_head(repo_root)
+    if not head:
+        result["reason"] = "missing-head"
+        return result
+    head_tree = maybe_head_tree(repo_root)
+    if str(payload.get("staged_tree") or "") != head_tree:
+        result["reason"] = "head-tree-mismatch"
+        result["current_head"] = head
+        result["current_head_tree"] = head_tree
+        return result
+    current_contract = review_contract_path(repo_root)
+    if not current_contract.exists():
+        result["reason"] = "missing-review-contract"
+        return result
+    if str(payload.get("review_contract_sha256") or "") != file_sha256(current_contract):
+        result["reason"] = "review-contract-mismatch"
+        return result
+    current_prompt = prompt_path(repo_root)
+    if not current_prompt.exists():
+        result["reason"] = "missing-self-audit-prompt"
+        result["prompt_path"] = str(current_prompt)
+        return result
+    if str(payload.get("prompt_sha256") or "") != file_sha256(current_prompt):
+        result["reason"] = "self-audit-prompt-mismatch"
+        result["prompt_path"] = str(current_prompt)
+        return result
+    result["fresh"] = True
+    result["reason"] = "fresh"
+    result["current_branch"] = branch
+    result["current_head"] = head
+    result["current_head_tree"] = head_tree
+    return result
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Read/write local rubin-protocol self-audit receipts")
+    sub = ap.add_subparsers(dest="command", required=True)
+
+    write_ap = sub.add_parser("write")
+    write_ap.add_argument("--repo-root", required=True)
+    write_ap.add_argument("--source", default="self-audit")
+
+    check_commit_ap = sub.add_parser("check-commit")
+    check_commit_ap.add_argument("--repo-root", required=True)
+
+    check_push_ap = sub.add_parser("check-push")
+    check_push_ap.add_argument("--repo-root", required=True)
+
+    args = ap.parse_args()
+    repo_root = Path(args.repo_root).resolve()
+    if args.command == "write":
+        payload = write_receipt(repo_root, source=args.source)
+    elif args.command == "check-commit":
+        payload = check_commit(repo_root)
+    else:
+        payload = check_push(repo_root)
+    print(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_self_audit_prompt_pack.py
+++ b/tools/tests/test_self_audit_prompt_pack.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import json
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -50,7 +52,7 @@ class SelfAuditPromptPackTests(unittest.TestCase):
                 m.normalize_repo_root(Path(tmp))
 
     def test_reviewable_paths_include_native_extensions(self):
-        for pattern in ("*.proto", "*.cpp", "*.h"):
+        for pattern in (":(glob)**/*.proto", ":(glob)**/*.cpp", ":(glob)**/*.h"):
             self.assertIn(pattern, m.REVIEWABLE_PATHS)
 
     def test_staged_bundle_falls_back_to_head_bundle(self):
@@ -66,6 +68,78 @@ class SelfAuditPromptPackTests(unittest.TestCase):
         self.assertIn("MODE=head", bundle)
         self.assertIn("--- REVIEW CHANGED FILES ---", bundle)
         self.assertIn("tools/self_audit_prompt_pack.py", bundle)
+
+    def test_staged_changed_files_captures_subdirectory_paths(self):
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            subprocess.run(["git", "init", "-b", "main"], cwd=repo_root, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+            subprocess.run(["git", "config", "user.name", "Test User"], cwd=repo_root, check=True)
+            subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo_root, check=True)
+            nested = repo_root / "clients" / "go" / "node"
+            nested.mkdir(parents=True)
+            tracked = nested / "config.go"
+            tracked.write_text("package node\n", encoding="utf-8")
+            subprocess.run(["git", "add", "."], cwd=repo_root, check=True)
+            subprocess.run(["git", "commit", "-m", "init"], cwd=repo_root, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+            tracked.write_text("package node\n\nconst x = 1\n", encoding="utf-8")
+            subprocess.run(["git", "add", str(tracked.relative_to(repo_root))], cwd=repo_root, check=True)
+            files = m.staged_changed_files(repo_root)
+            self.assertEqual(files, ["clients/go/node/config.go"])
+            bundle = m.staged_bundle(repo_root)
+            self.assertIn("clients/go/node/config.go", bundle)
+            self.assertIn("+const x = 1", bundle)
+
+    def test_load_contract_rejects_non_string_family_fields(self):
+        with tempfile.TemporaryDirectory() as td:
+            contract_path = Path(td) / "contract.json"
+            contract_path.write_text(
+                json.dumps(
+                    {
+                        "self_audit": {
+                            "prompt_pack_version": "self-audit-v1",
+                            "required_pattern_families": [
+                                {
+                                    "id": 7,
+                                    "title": "Family",
+                                    "checks": ["ok"],
+                                }
+                            ],
+                        }
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            with self.assertRaises(ValueError):
+                m.load_self_audit_contract(contract_path)
+
+    def test_load_contract_rejects_non_string_checks(self):
+        with tempfile.TemporaryDirectory() as td:
+            contract_path = Path(td) / "contract.json"
+            contract_path.write_text(
+                json.dumps(
+                    {
+                        "self_audit": {
+                            "prompt_pack_version": "self-audit-v1",
+                            "required_pattern_families": [
+                                {
+                                    "id": "family",
+                                    "title": "Family",
+                                    "checks": ["ok", {"bad": True}],
+                                }
+                            ],
+                        }
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            with self.assertRaises(ValueError):
+                m.load_self_audit_contract(contract_path)
 
 
 if __name__ == "__main__":

--- a/tools/tests/test_self_audit_prompt_pack.py
+++ b/tools/tests/test_self_audit_prompt_pack.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -41,6 +42,15 @@ class SelfAuditPromptPackTests(unittest.TestCase):
         contract = m.load_self_audit_contract()
         self.assertEqual(contract["prompt_pack_version"], "self-audit-v1")
         self.assertTrue(contract["required_pattern_families"])
+
+    def test_normalize_repo_root_requires_git_worktree(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaises(ValueError):
+                m.normalize_repo_root(Path(tmp))
+
+    def test_reviewable_paths_include_native_extensions(self):
+        for pattern in ("*.proto", "*.cpp", "*.h"):
+            self.assertIn(pattern, m.REVIEWABLE_PATHS)
 
 
 if __name__ == "__main__":

--- a/tools/tests/test_self_audit_prompt_pack.py
+++ b/tools/tests/test_self_audit_prompt_pack.py
@@ -57,6 +57,8 @@ class SelfAuditPromptPackTests(unittest.TestCase):
 
     def test_staged_bundle_falls_back_to_head_bundle(self):
         with mock.patch.object(m, "staged_changed_files", return_value=[]), mock.patch.object(
+            m, "has_any_staged_changes", return_value=False
+        ), mock.patch.object(
             m, "head_changed_files", return_value=["tools/self_audit_prompt_pack.py"]
         ), mock.patch.object(m, "run_git") as run_git:
             run_git.side_effect = [
@@ -158,6 +160,20 @@ class SelfAuditPromptPackTests(unittest.TestCase):
             self.assertIn("HEAD=(unborn)", bundle)
             self.assertIn("clients/go/node/config.go", bundle)
             self.assertIn("+const x = 1", bundle)
+
+    def test_staged_bundle_rejects_non_reviewable_staged_changes(self):
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            subprocess.run(["git", "init", "-b", "main"], cwd=repo_root, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+            subprocess.run(["git", "config", "user.name", "Test User"], cwd=repo_root, check=True)
+            subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo_root, check=True)
+            (repo_root / "README.md").write_text("hello\n", encoding="utf-8")
+            subprocess.run(["git", "add", "README.md"], cwd=repo_root, check=True)
+            subprocess.run(["git", "commit", "-m", "init"], cwd=repo_root, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+            (repo_root / "Dockerfile").write_text("FROM scratch\n", encoding="utf-8")
+            subprocess.run(["git", "add", "Dockerfile"], cwd=repo_root, check=True)
+            with self.assertRaisesRegex(ValueError, "no staged reviewable diff"):
+                m.staged_bundle(repo_root)
 
 
 if __name__ == "__main__":

--- a/tools/tests/test_self_audit_prompt_pack.py
+++ b/tools/tests/test_self_audit_prompt_pack.py
@@ -5,6 +5,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 TOOLS_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(TOOLS_DIR))
@@ -51,6 +52,20 @@ class SelfAuditPromptPackTests(unittest.TestCase):
     def test_reviewable_paths_include_native_extensions(self):
         for pattern in ("*.proto", "*.cpp", "*.h"):
             self.assertIn(pattern, m.REVIEWABLE_PATHS)
+
+    def test_staged_bundle_falls_back_to_head_bundle(self):
+        with mock.patch.object(m, "staged_changed_files", return_value=[]), mock.patch.object(
+            m, "head_changed_files", return_value=["tools/self_audit_prompt_pack.py"]
+        ), mock.patch.object(m, "run_git") as run_git:
+            run_git.side_effect = [
+                "stat-output",
+                "patch-output",
+                "03b3e85",
+            ]
+            bundle = m.staged_bundle(Path("/tmp/repo"))
+        self.assertIn("MODE=head", bundle)
+        self.assertIn("--- REVIEW CHANGED FILES ---", bundle)
+        self.assertIn("tools/self_audit_prompt_pack.py", bundle)
 
 
 if __name__ == "__main__":

--- a/tools/tests/test_self_audit_prompt_pack.py
+++ b/tools/tests/test_self_audit_prompt_pack.py
@@ -68,6 +68,7 @@ class SelfAuditPromptPackTests(unittest.TestCase):
         self.assertIn("MODE=head", bundle)
         self.assertIn("--- REVIEW CHANGED FILES ---", bundle)
         self.assertIn("tools/self_audit_prompt_pack.py", bundle)
+        self.assertIn("--no-patch", run_git.call_args_list[0].args[1:])
 
     def test_staged_changed_files_captures_subdirectory_paths(self):
         with tempfile.TemporaryDirectory() as td:
@@ -140,6 +141,23 @@ class SelfAuditPromptPackTests(unittest.TestCase):
             )
             with self.assertRaises(ValueError):
                 m.load_self_audit_contract(contract_path)
+
+    def test_staged_bundle_handles_unborn_head(self):
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            subprocess.run(["git", "init"], cwd=repo_root, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+            subprocess.run(["git", "config", "user.name", "Test User"], cwd=repo_root, check=True)
+            subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo_root, check=True)
+            nested = repo_root / "clients" / "go" / "node"
+            nested.mkdir(parents=True)
+            tracked = nested / "config.go"
+            tracked.write_text("package node\n\nconst x = 1\n", encoding="utf-8")
+            subprocess.run(["git", "add", str(tracked.relative_to(repo_root))], cwd=repo_root, check=True)
+            bundle = m.staged_bundle(repo_root)
+            self.assertIn("MODE=staged", bundle)
+            self.assertIn("HEAD=(unborn)", bundle)
+            self.assertIn("clients/go/node/config.go", bundle)
+            self.assertIn("+const x = 1", bundle)
 
 
 if __name__ == "__main__":

--- a/tools/tests/test_self_audit_prompt_pack.py
+++ b/tools/tests/test_self_audit_prompt_pack.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+TOOLS_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(TOOLS_DIR))
+
+import self_audit_prompt_pack as m
+
+
+class SelfAuditPromptPackTests(unittest.TestCase):
+    def test_compose_prompt_includes_pattern_replay(self):
+        contract = {
+            "prompt_pack_version": "self-audit-v1",
+            "required_pattern_families": [
+                {
+                    "id": "exact-native-suite-params",
+                    "title": "Exact native-suite parameter binding",
+                    "checks": [
+                        "Reject empty alias strings.",
+                        "Enforce exact ML-DSA-87 lengths.",
+                    ],
+                }
+            ],
+        }
+        prompt = m.compose_prompt(
+            contract=contract,
+            bundle_text="--- STAGED PATCH ---\n+new line",
+        )
+        self.assertIn("Prompt Pack: self-audit-v1", prompt)
+        self.assertIn("Required pattern replay:", prompt)
+        self.assertIn("Exact native-suite parameter binding [exact-native-suite-params]", prompt)
+        self.assertIn("Reject empty alias strings.", prompt)
+        self.assertIn("Mandatory self-audit output before receipt refresh:", prompt)
+        self.assertIn("Staged diff bundle follows.", prompt)
+
+    def test_load_contract_reads_self_audit_section(self):
+        contract = m.load_self_audit_contract()
+        self.assertEqual(contract["prompt_pack_version"], "self-audit-v1")
+        self.assertTrue(contract["required_pattern_families"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_self_audit_receipt.py
+++ b/tools/tests/test_self_audit_receipt.py
@@ -99,6 +99,19 @@ class SelfAuditReceiptTests(unittest.TestCase):
             self.assertFalse(checked["fresh"])
             self.assertEqual(checked["reason"], "self-audit-prompt-mismatch")
 
+    def test_check_rejects_schema_mismatch_fail_closed(self):
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            self.init_repo(repo_root)
+            payload = m.write_receipt(repo_root, source="test")
+            receipt_path = Path(payload["receipt_path"])
+            data = json.loads(receipt_path.read_text(encoding="utf-8"))
+            data["schema_version"] = 999
+            receipt_path.write_text(json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+            checked = m.check_commit(repo_root)
+            self.assertFalse(checked["fresh"])
+            self.assertEqual(checked["reason"], "schema-mismatch")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/tests/test_self_audit_receipt.py
+++ b/tools/tests/test_self_audit_receipt.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+TOOLS_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(TOOLS_DIR))
+
+import self_audit_receipt as m
+
+
+class SelfAuditReceiptTests(unittest.TestCase):
+    def init_repo(self, root: Path) -> None:
+        subprocess.run(["git", "init", "-b", "main"], cwd=root, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        subprocess.run(["git", "config", "user.name", "Test User"], cwd=root, check=True)
+        subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=root, check=True)
+        (root / "tools").mkdir()
+        (root / "tools" / "prepush_review_contract.json").write_text(
+            json.dumps(
+                {
+                    "self_audit": {
+                        "prompt_pack_version": "self-audit-v1",
+                        "required_pattern_families": [
+                            {
+                                "id": "family",
+                                "title": "Family",
+                                "checks": ["check one"],
+                            }
+                        ],
+                    }
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        (root / "tools" / "self_audit_prompt_pack.py").write_text(
+            "#!/usr/bin/env python3\n"
+            "from pathlib import Path\n"
+            "import argparse\n"
+            "ap = argparse.ArgumentParser()\n"
+            "ap.add_argument('--repo-root', required=True)\n"
+            "ap.add_argument('--output', required=True)\n"
+            "args = ap.parse_args()\n"
+            "Path(args.output).write_text('prompt', encoding='utf-8')\n",
+            encoding="utf-8",
+        )
+        (root / "README.md").write_text("hello\n", encoding="utf-8")
+        subprocess.run(["git", "add", "."], cwd=root, check=True)
+        subprocess.run(["git", "commit", "-m", "init"], cwd=root, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+
+    def test_write_and_check_fresh_receipt(self):
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            self.init_repo(repo_root)
+            result = m.write_receipt(repo_root, source="test")
+            self.assertTrue(result["fresh"])
+            checked = m.check_commit(repo_root)
+            self.assertTrue(checked["fresh"])
+            self.assertEqual(checked["reason"], "fresh")
+
+    def test_check_detects_contract_hash_mismatch(self):
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            self.init_repo(repo_root)
+            m.write_receipt(repo_root, source="test")
+            (repo_root / "tools" / "prepush_review_contract.json").write_text(
+                json.dumps(
+                    {
+                        "self_audit": {
+                            "prompt_pack_version": "self-audit-v2",
+                            "required_pattern_families": [{"id": "family", "title": "Family", "checks": ["changed"]}],
+                        }
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            checked = m.check_commit(repo_root)
+            self.assertFalse(checked["fresh"])
+            self.assertEqual(checked["reason"], "review-contract-mismatch")
+
+    def test_check_detects_prompt_hash_mismatch(self):
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            self.init_repo(repo_root)
+            payload = m.write_receipt(repo_root, source="test")
+            Path(payload["receipt"]["prompt_path"]).write_text("different", encoding="utf-8")
+            checked = m.check_commit(repo_root)
+            self.assertFalse(checked["fresh"])
+            self.assertEqual(checked["reason"], "self-audit-prompt-mismatch")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a tracked self-audit prompt-pack builder for staged diffs
- bind self-audit receipt freshness to prompt hash plus review-contract hash
- replay recent bot-review pattern families in the tracked review contract and add tests

## Validation
- `python3 -m unittest tools.tests.test_prepush_prompt_pack tools.tests.test_self_audit_prompt_pack`
- `python3 -m py_compile tools/self_audit_prompt_pack.py`
- `python3 /Users/gpt/Documents/rubin-orchestration-private/inbox/operational/tools/run_pr_lifecycle.py pre-pr --target-repo rubin-protocol --repo-root /Users/gpt/Documents/rubin-protocol-wt-self-audit --skip-execution-drift --skip-coverage`

Closes #1102.
