### PR TITLE
tooling: accept explicit verifier binding path in crypto policy lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,10 @@ jobs:
         run: |
           python3 tools/check_openssl_cve_response.py --code-root .
 
+      - name: Crypto backend policy tooling tests
+        run: |
+          python3 -m unittest tools.tests.test_check_crypto_backend_policy
+
       - name: Consensus OpenSSL isolation policy
         run: |
           set -euo pipefail

--- a/tools/check_crypto_backend_policy.py
+++ b/tools/check_crypto_backend_policy.py
@@ -79,6 +79,24 @@ GO_VERIFY_ML_DSA_BINDING_HANDOFF_SNIPPET = (
     "return verifySigWithBinding(binding, pubkey, signature, digest32)"
 )
 
+GO_VERIFY_ML_DSA_DIRECT_DISPATCH_PATTERNS = [
+    re.compile(
+        r'return\s+opensslVerifySigOneShot\s*\(\s*,\s*pubkey\s*,\s*signature\s*,\s*digest32\[:\]\s*,?\s*\)'
+    ),
+    re.compile(
+        r'return\s+opensslVerifySigMessage\s*\(\s*,\s*pubkey\s*,\s*signature\s*,\s*digest32\[:\]\s*,?\s*\)'
+    ),
+    re.compile(r'return\s+verifyWithMapping\s*\(\s*\)'),
+]
+
+GO_VERIFY_ML_DSA_BINDING_RESOLUTION_PATTERN = re.compile(
+    r'binding\s*,\s*err\s*:=\s*resolveSuiteVerifierBinding\s*\(\s*,\s*ML_DSA_87_PUBKEY_BYTES\s*,\s*ML_DSA_87_SIG_BYTES\s*,?\s*\)'
+)
+
+GO_VERIFY_ML_DSA_BINDING_HANDOFF_PATTERN = re.compile(
+    r'return\s+verifySigWithBinding\s*\(\s*binding\s*,\s*pubkey\s*,\s*signature\s*,\s*digest32\s*,?\s*\)'
+)
+
 RUST_VERIFY_REQUIRED_SNIPPETS = [
     "pub fn verify_sig(",
     'SUITE_ID_ML_DSA_87 => Ok(c"ML-DSA-87")',
@@ -184,10 +202,6 @@ def check_required_snippet_groups(
 
 def normalize_for_match(text: str) -> str:
     return " ".join(text.split())
-
-
-def normalize_go_code_for_match(text: str) -> str:
-    return normalize_for_match(sanitize_go_source(text, strip_strings=True))
 
 
 def check_required_snippet_groups_normalized(
@@ -395,17 +409,15 @@ def check_go_verify_required_snippets(path: Path, text: str) -> list[str]:
         return errors
     normalized_case_body = normalize_for_match(case_body)
     has_direct_dispatch = any(
-        normalize_go_code_for_match(snippet) in normalized_case_body
-        for snippet in GO_VERIFY_ML_DSA_DIRECT_DISPATCH_SNIPPETS
+        pattern.search(normalized_case_body)
+        for pattern in GO_VERIFY_ML_DSA_DIRECT_DISPATCH_PATTERNS
     )
-    has_binding_resolution = (
-        normalize_go_code_for_match(GO_VERIFY_ML_DSA_BINDING_RESOLUTION_SNIPPET)
-        in normalized_case_body
-    )
-    has_binding_handoff = (
-        normalize_go_code_for_match(GO_VERIFY_ML_DSA_BINDING_HANDOFF_SNIPPET)
-        in normalized_case_body
-    )
+    has_binding_resolution = GO_VERIFY_ML_DSA_BINDING_RESOLUTION_PATTERN.search(
+        normalized_case_body
+    ) is not None
+    has_binding_handoff = GO_VERIFY_ML_DSA_BINDING_HANDOFF_PATTERN.search(
+        normalized_case_body
+    ) is not None
 
     if not (has_direct_dispatch or has_binding_resolution or has_binding_handoff):
         errors.append(

--- a/tools/check_crypto_backend_policy.py
+++ b/tools/check_crypto_backend_policy.py
@@ -359,6 +359,13 @@ def sanitize_go_source(text: str, *, strip_strings: bool) -> str:
     return "".join(out)
 
 
+def extract_go_cgo_preamble(path: Path, text: str) -> tuple[str | None, list[str]]:
+    match = re.search(r"/\*(?P<body>[\s\S]*?)\*/\s*import\s+\"C\"", text)
+    if match is None:
+        return None, [f"{path}: missing cgo preamble before import \"C\" for policy checks"]
+    return match.group("body"), []
+
+
 def extract_go_verify_mldsa_case(path: Path, text: str) -> tuple[str | None, list[str]]:
     errors: list[str] = []
     lines = text.splitlines()
@@ -420,12 +427,17 @@ def extract_go_verify_mldsa_case(path: Path, text: str) -> tuple[str | None, lis
 def check_go_verify_required_snippets(path: Path, text: str) -> list[str]:
     structure_text = sanitize_go_source(text, strip_strings=True)
     comment_stripped_text = sanitize_go_source(text, strip_strings=False)
+    cgo_preamble, cgo_errors = extract_go_cgo_preamble(path, text)
     errors = check_required_snippet_groups_normalized(
         path, structure_text, GO_VERIFY_GO_REQUIRED_SNIPPET_GROUPS
     )
+    errors.extend(cgo_errors)
+    if cgo_preamble is None:
+        return errors
+    cgo_structure_text = sanitize_go_source(cgo_preamble, strip_strings=True)
     errors.extend(
         check_required_snippet_groups_normalized(
-            path, text, GO_VERIFY_CGO_REQUIRED_SNIPPET_GROUPS
+            path, cgo_structure_text, GO_VERIFY_CGO_REQUIRED_SNIPPET_GROUPS
         )
     )
     case_body, case_errors = extract_go_verify_mldsa_case(path, structure_text)

--- a/tools/check_crypto_backend_policy.py
+++ b/tools/check_crypto_backend_policy.py
@@ -92,29 +92,18 @@ GO_VERIFY_ML_DSA_DIRECT_DISPATCH_PATTERNS = [
     re.compile(r'return\s+verifyWithMapping\s*\(\s*\)'),
 ]
 
-GO_VERIFY_ML_DSA_DIRECT_DISPATCH_EXACT_PATTERNS = [
-    re.compile(
-        r'(^|[^`"\\])return\s+opensslVerifySigOneShot\s*\(\s*"ML-DSA-87"\s*,\s*pubkey\s*,\s*signature\s*,\s*digest32\[:\]\s*,?\s*\)'
-    ),
-    re.compile(
-        r'(^|[^`"\\])return\s+opensslVerifySigMessage\s*\(\s*"ML-DSA-87"\s*,\s*pubkey\s*,\s*signature\s*,\s*digest32\[:\]\s*,?\s*\)'
-    ),
-    re.compile(
-        r'(^|[^`"\\])return\s+verifyWithMapping\s*\(\s*"ML-DSA-87"\s*,?\s*\)'
-    ),
-]
-
 GO_VERIFY_ML_DSA_BINDING_RESOLUTION_PATTERN = re.compile(
     r'binding\s*,\s*err\s*:=\s*resolveSuiteVerifierBinding\s*\(\s*,\s*ML_DSA_87_PUBKEY_BYTES\s*,\s*ML_DSA_87_SIG_BYTES\s*,?\s*\)'
-)
-
-GO_VERIFY_ML_DSA_BINDING_RESOLUTION_EXACT_PATTERN = re.compile(
-    r'(^|[^`"\\])binding\s*,\s*err\s*:=\s*resolveSuiteVerifierBinding\s*\(\s*"ML-DSA-87"\s*,\s*ML_DSA_87_PUBKEY_BYTES\s*,\s*ML_DSA_87_SIG_BYTES\s*,?\s*\)'
 )
 
 GO_VERIFY_ML_DSA_BINDING_HANDOFF_PATTERN = re.compile(
     r'return\s+verifySigWithBinding\s*\(\s*binding\s*,\s*pubkey\s*,\s*signature\s*,\s*digest32\s*,?\s*\)'
 )
+
+GO_VERIFY_FUNC_PATTERN = re.compile(r"^\s*func\s+verifySig\s*\(")
+GO_VERIFY_SWITCH_PATTERN = re.compile(r"^\s*switch\s+suiteID\s*\{")
+GO_VERIFY_CASE_PATTERN = re.compile(r"^\s*case SUITE_ID_ML_DSA_87:")
+GO_VERIFY_NEXT_ARM_PATTERN = re.compile(r"^\s*(case |default:)")
 
 RUST_VERIFY_REQUIRED_SNIPPETS = [
     "pub fn verify_sig(",
@@ -360,34 +349,54 @@ def sanitize_go_source(text: str, *, strip_strings: bool) -> str:
 
 
 def extract_go_cgo_preamble(path: Path, text: str) -> tuple[str | None, list[str]]:
-    match = re.search(r"/\*(?P<body>[\s\S]*?)\*/\s*import\s+\"C\"", text)
-    if match is None:
-        return None, [f"{path}: missing cgo preamble before import \"C\" for policy checks"]
-    return match.group("body"), []
+    block_match = re.search(r"/\*(?P<body>[\s\S]*?)\*/\s*import\s+\"C\"", text)
+    if block_match is not None:
+        return block_match.group("body"), []
+
+    line_match = re.search(
+        r"(?P<body>(?:^[ \t]*//[^\n]*(?:\n|$))+)[ \t]*import\s+\"C\"",
+        text,
+        re.MULTILINE,
+    )
+    if line_match is not None:
+        body_lines: list[str] = []
+        for line in line_match.group("body").splitlines():
+            stripped = line.lstrip()
+            if not stripped.startswith("//"):
+                continue
+            body = stripped[2:]
+            if body.startswith(" "):
+                body = body[1:]
+            body_lines.append(body)
+        return "\n".join(body_lines), []
+
+    return None, [f"{path}: missing cgo preamble before import \"C\" for policy checks"]
 
 
-def extract_go_verify_mldsa_case(path: Path, text: str) -> tuple[str | None, list[str]]:
+def extract_go_verify_mldsa_case_line_range(
+    path: Path, text: str
+) -> tuple[tuple[int, int] | None, list[str]]:
     errors: list[str] = []
     lines = text.splitlines()
     in_verify_sig = False
     verify_sig_depth = 0
     switch_depth: int | None = None
     collecting_case = False
-    collected_lines: list[str] = []
+    case_start: int | None = None
 
-    for line in lines:
+    for line_no, line in enumerate(lines):
         current_depth = verify_sig_depth
         next_depth = current_depth + line.count("{") - line.count("}")
         stripped = line.lstrip()
 
         if not in_verify_sig:
-            if "func verifySig(" in line:
+            if GO_VERIFY_FUNC_PATTERN.match(line):
                 in_verify_sig = True
                 verify_sig_depth = next_depth
             continue
 
         if switch_depth is None:
-            if re.match(r"^\s*switch\s+suiteID\s*\{", line):
+            if GO_VERIFY_SWITCH_PATTERN.match(line):
                 switch_depth = next_depth
             verify_sig_depth = next_depth
             if verify_sig_depth <= 0:
@@ -396,20 +405,17 @@ def extract_go_verify_mldsa_case(path: Path, text: str) -> tuple[str | None, lis
 
         if collecting_case:
             if current_depth < switch_depth:
-                return "\n".join(collected_lines), errors
-            if current_depth == switch_depth and re.match(r"^\s*(case |default:)", stripped):
-                return "\n".join(collected_lines), errors
-            collected_lines.append(line)
+                return (case_start if case_start is not None else line_no, line_no), errors
+            if current_depth == switch_depth and GO_VERIFY_NEXT_ARM_PATTERN.match(stripped):
+                return (case_start if case_start is not None else line_no, line_no), errors
             verify_sig_depth = next_depth
             if verify_sig_depth <= 0:
                 break
             continue
 
-        if current_depth == switch_depth and stripped.startswith("case SUITE_ID_ML_DSA_87:"):
+        if current_depth == switch_depth and GO_VERIFY_CASE_PATTERN.match(stripped):
             collecting_case = True
-            _, _, same_line_tail = line.partition("case SUITE_ID_ML_DSA_87:")
-            if same_line_tail.strip():
-                collected_lines.append(same_line_tail)
+            case_start = line_no
             verify_sig_depth = next_depth
             continue
 
@@ -418,15 +424,37 @@ def extract_go_verify_mldsa_case(path: Path, text: str) -> tuple[str | None, lis
             break
 
     if collecting_case:
-        return "\n".join(collected_lines), errors
+        return (
+            case_start if case_start is not None else len(lines),
+            len(lines),
+        ), errors
 
     errors.append(f"{path}: missing verifySig ML-DSA-87 case body for policy checks")
     return None, errors
 
 
+def slice_go_verify_case_body(text: str, line_range: tuple[int, int]) -> str:
+    start, end = line_range
+    lines = text.splitlines()
+    selected = lines[start:end]
+    if not selected:
+        return ""
+    head = selected[0]
+    _, _, same_line_tail = head.partition("case SUITE_ID_ML_DSA_87:")
+    selected[0] = same_line_tail
+    return "\n".join(selected)
+
+
+def find_first_match(patterns: list[re.Pattern[str]], text: str) -> re.Match[str] | None:
+    for pattern in patterns:
+        match = pattern.search(text)
+        if match is not None:
+            return match
+    return None
+
+
 def check_go_verify_required_snippets(path: Path, text: str) -> list[str]:
     structure_text = sanitize_go_source(text, strip_strings=True)
-    comment_stripped_text = sanitize_go_source(text, strip_strings=False)
     cgo_preamble, cgo_errors = extract_go_cgo_preamble(path, text)
     errors = check_required_snippet_groups_normalized(
         path, structure_text, GO_VERIFY_GO_REQUIRED_SNIPPET_GROUPS
@@ -440,33 +468,27 @@ def check_go_verify_required_snippets(path: Path, text: str) -> list[str]:
             path, cgo_structure_text, GO_VERIFY_CGO_REQUIRED_SNIPPET_GROUPS
         )
     )
-    case_body, case_errors = extract_go_verify_mldsa_case(path, structure_text)
+    case_line_range, case_errors = extract_go_verify_mldsa_case_line_range(path, structure_text)
     errors.extend(case_errors)
-    if case_body is None:
+    if case_line_range is None:
         return errors
-    comment_case_body, comment_case_errors = extract_go_verify_mldsa_case(
-        path, comment_stripped_text
+    case_body = slice_go_verify_case_body(structure_text, case_line_range)
+    raw_case_body = slice_go_verify_case_body(text, case_line_range)
+    direct_dispatch_match = find_first_match(GO_VERIFY_ML_DSA_DIRECT_DISPATCH_PATTERNS, case_body)
+    has_direct_dispatch = (
+        direct_dispatch_match is not None
+        and '"ML-DSA-87"' in raw_case_body[
+            direct_dispatch_match.start() : direct_dispatch_match.end()
+        ]
     )
-    if comment_case_body is None:
-        errors.extend(comment_case_errors)
-        return errors
-    normalized_case_body = normalize_for_match(case_body)
-    normalized_comment_case_body = normalize_for_match(comment_case_body)
-    has_direct_dispatch = any(
-        pattern.search(normalized_case_body)
-        for pattern in GO_VERIFY_ML_DSA_DIRECT_DISPATCH_PATTERNS
-    ) and any(
-        pattern.search(normalized_comment_case_body)
-        for pattern in GO_VERIFY_ML_DSA_DIRECT_DISPATCH_EXACT_PATTERNS
+    binding_resolution_match = GO_VERIFY_ML_DSA_BINDING_RESOLUTION_PATTERN.search(case_body)
+    has_binding_resolution = (
+        binding_resolution_match is not None
+        and '"ML-DSA-87"' in raw_case_body[
+            binding_resolution_match.start() : binding_resolution_match.end()
+        ]
     )
-    has_binding_resolution = GO_VERIFY_ML_DSA_BINDING_RESOLUTION_PATTERN.search(
-        normalized_case_body
-    ) is not None and GO_VERIFY_ML_DSA_BINDING_RESOLUTION_EXACT_PATTERN.search(
-        normalized_comment_case_body
-    ) is not None
-    has_binding_handoff = GO_VERIFY_ML_DSA_BINDING_HANDOFF_PATTERN.search(
-        normalized_case_body
-    ) is not None
+    has_binding_handoff = GO_VERIFY_ML_DSA_BINDING_HANDOFF_PATTERN.search(case_body) is not None
 
     if not (has_direct_dispatch or has_binding_resolution or has_binding_handoff):
         errors.append(

--- a/tools/check_crypto_backend_policy.py
+++ b/tools/check_crypto_backend_policy.py
@@ -182,6 +182,146 @@ def check_required_snippet_groups(
     return errors
 
 
+def normalize_for_match(text: str) -> str:
+    return " ".join(text.split())
+
+
+def check_required_snippet_groups_normalized(
+    path: Path, text: str, snippet_groups: list[list[str]]
+) -> list[str]:
+    errors: list[str] = []
+    normalized_text = normalize_for_match(text)
+    for group in snippet_groups:
+        if not any(normalize_for_match(snippet) in normalized_text for snippet in group):
+            errors.append(
+                f"{path}: missing required snippet group (any-of): {group!r}"
+            )
+    return errors
+
+
+def sanitize_go_source(text: str, *, strip_strings: bool) -> str:
+    out: list[str] = []
+    i = 0
+    state = "normal"
+    while i < len(text):
+        ch = text[i]
+        nxt = text[i + 1] if i + 1 < len(text) else ""
+
+        if state == "normal":
+            if ch == "/" and nxt == "/":
+                out.extend("  ")
+                i += 2
+                state = "line_comment"
+                continue
+            if ch == "/" and nxt == "*":
+                out.extend("  ")
+                i += 2
+                state = "block_comment"
+                continue
+            if ch == '"':
+                out.append(" " if strip_strings else ch)
+                i += 1
+                state = "string"
+                continue
+            if ch == "`":
+                out.append(" " if strip_strings else ch)
+                i += 1
+                state = "raw_string"
+                continue
+            if ch == "'":
+                out.append(" " if strip_strings else ch)
+                i += 1
+                state = "rune"
+                continue
+            out.append(ch)
+            i += 1
+            continue
+
+        if state == "line_comment":
+            if ch == "\n":
+                out.append("\n")
+                i += 1
+                state = "normal"
+            else:
+                out.append(" ")
+                i += 1
+            continue
+
+        if state == "block_comment":
+            if ch == "*" and nxt == "/":
+                out.extend("  ")
+                i += 2
+                state = "normal"
+            elif ch == "\n":
+                out.append("\n")
+                i += 1
+            else:
+                out.append(" ")
+                i += 1
+            continue
+
+        if state == "string":
+            if ch == "\\":
+                out.append(" " if strip_strings else ch)
+                i += 1
+                if i < len(text):
+                    if strip_strings:
+                        out.append("\n" if text[i] == "\n" else " ")
+                    else:
+                        out.append(text[i])
+                    i += 1
+                continue
+            if ch == '"':
+                out.append(" " if strip_strings else ch)
+                i += 1
+                state = "normal"
+            elif ch == "\n":
+                out.append("\n")
+                i += 1
+            else:
+                out.append(" " if strip_strings else ch)
+                i += 1
+            continue
+
+        if state == "raw_string":
+            if ch == "`":
+                out.append(" " if strip_strings else ch)
+                i += 1
+                state = "normal"
+            elif ch == "\n":
+                out.append("\n")
+                i += 1
+            else:
+                out.append(" " if strip_strings else ch)
+                i += 1
+            continue
+
+        if state == "rune":
+            if ch == "\\":
+                out.append(" " if strip_strings else ch)
+                i += 1
+                if i < len(text):
+                    if strip_strings:
+                        out.append("\n" if text[i] == "\n" else " ")
+                    else:
+                        out.append(text[i])
+                    i += 1
+                continue
+            if ch == "'":
+                out.append(" " if strip_strings else ch)
+                i += 1
+                state = "normal"
+            elif ch == "\n":
+                out.append("\n")
+                i += 1
+            else:
+                out.append(" " if strip_strings else ch)
+                i += 1
+            continue
+
+    return "".join(out)
+
+
 def extract_go_verify_mldsa_case(path: Path, text: str) -> tuple[str | None, list[str]]:
     errors: list[str] = []
     lines = text.splitlines()
@@ -241,17 +381,31 @@ def extract_go_verify_mldsa_case(path: Path, text: str) -> tuple[str | None, lis
 
 
 def check_go_verify_required_snippets(path: Path, text: str) -> list[str]:
-    errors = check_required_snippet_groups(path, text, GO_VERIFY_GLOBAL_REQUIRED_SNIPPET_GROUPS)
-    case_body, case_errors = extract_go_verify_mldsa_case(path, text)
+    comment_stripped_text = sanitize_go_source(text, strip_strings=False)
+    structure_text = sanitize_go_source(text, strip_strings=True)
+    errors = check_required_snippet_groups_normalized(
+        path, text, GO_VERIFY_GLOBAL_REQUIRED_SNIPPET_GROUPS
+    )
+    case_body, case_errors = extract_go_verify_mldsa_case(path, structure_text)
     errors.extend(case_errors)
     if case_body is None:
         return errors
-
+    match_case_body, _ = extract_go_verify_mldsa_case(path, comment_stripped_text)
+    if match_case_body is None:
+        return errors
+    normalized_case_body = normalize_for_match(match_case_body)
     has_direct_dispatch = any(
-        snippet in case_body for snippet in GO_VERIFY_ML_DSA_DIRECT_DISPATCH_SNIPPETS
+        normalize_for_match(snippet) in normalized_case_body
+        for snippet in GO_VERIFY_ML_DSA_DIRECT_DISPATCH_SNIPPETS
     )
-    has_binding_resolution = GO_VERIFY_ML_DSA_BINDING_RESOLUTION_SNIPPET in case_body
-    has_binding_handoff = GO_VERIFY_ML_DSA_BINDING_HANDOFF_SNIPPET in case_body
+    has_binding_resolution = (
+        normalize_for_match(GO_VERIFY_ML_DSA_BINDING_RESOLUTION_SNIPPET)
+        in normalized_case_body
+    )
+    has_binding_handoff = (
+        normalize_for_match(GO_VERIFY_ML_DSA_BINDING_HANDOFF_SNIPPET)
+        in normalized_case_body
+    )
 
     if not (has_direct_dispatch or has_binding_resolution or has_binding_handoff):
         errors.append(

--- a/tools/check_crypto_backend_policy.py
+++ b/tools/check_crypto_backend_policy.py
@@ -186,6 +186,10 @@ def normalize_for_match(text: str) -> str:
     return " ".join(text.split())
 
 
+def normalize_go_code_for_match(text: str) -> str:
+    return normalize_for_match(sanitize_go_source(text, strip_strings=True))
+
+
 def check_required_snippet_groups_normalized(
     path: Path, text: str, snippet_groups: list[list[str]]
 ) -> list[str]:
@@ -381,7 +385,6 @@ def extract_go_verify_mldsa_case(path: Path, text: str) -> tuple[str | None, lis
 
 
 def check_go_verify_required_snippets(path: Path, text: str) -> list[str]:
-    comment_stripped_text = sanitize_go_source(text, strip_strings=False)
     structure_text = sanitize_go_source(text, strip_strings=True)
     errors = check_required_snippet_groups_normalized(
         path, text, GO_VERIFY_GLOBAL_REQUIRED_SNIPPET_GROUPS
@@ -390,20 +393,17 @@ def check_go_verify_required_snippets(path: Path, text: str) -> list[str]:
     errors.extend(case_errors)
     if case_body is None:
         return errors
-    match_case_body, _ = extract_go_verify_mldsa_case(path, comment_stripped_text)
-    if match_case_body is None:
-        return errors
-    normalized_case_body = normalize_for_match(match_case_body)
+    normalized_case_body = normalize_for_match(case_body)
     has_direct_dispatch = any(
-        normalize_for_match(snippet) in normalized_case_body
+        normalize_go_code_for_match(snippet) in normalized_case_body
         for snippet in GO_VERIFY_ML_DSA_DIRECT_DISPATCH_SNIPPETS
     )
     has_binding_resolution = (
-        normalize_for_match(GO_VERIFY_ML_DSA_BINDING_RESOLUTION_SNIPPET)
+        normalize_go_code_for_match(GO_VERIFY_ML_DSA_BINDING_RESOLUTION_SNIPPET)
         in normalized_case_body
     )
     has_binding_handoff = (
-        normalize_for_match(GO_VERIFY_ML_DSA_BINDING_HANDOFF_SNIPPET)
+        normalize_go_code_for_match(GO_VERIFY_ML_DSA_BINDING_HANDOFF_SNIPPET)
         in normalized_case_body
     )
 

--- a/tools/check_crypto_backend_policy.py
+++ b/tools/check_crypto_backend_policy.py
@@ -52,7 +52,7 @@ DOC_OPS_REQUIRED_PHRASES = [
     "not automatic production FIPS compliance",
 ]
 
-GO_VERIFY_GLOBAL_REQUIRED_SNIPPET_GROUPS = [
+GO_VERIFY_GO_REQUIRED_SNIPPET_GROUPS = [
     ["func verifySig("],
     ["case SUITE_ID_ML_DSA_87:"],
     [
@@ -60,6 +60,9 @@ GO_VERIFY_GLOBAL_REQUIRED_SNIPPET_GROUPS = [
         "func opensslVerifySigDigestOneShot(",
         "func opensslVerifySigMessage(",
     ],
+]
+
+GO_VERIFY_CGO_REQUIRED_SNIPPET_GROUPS = [
     ["EVP_DigestVerifyInit_ex(mctx, NULL, NULL, NULL, NULL, pkey, NULL)"],
     ["EVP_DigestVerify(mctx, sig, sig_len, msg, msg_len)"],
 ]
@@ -89,8 +92,24 @@ GO_VERIFY_ML_DSA_DIRECT_DISPATCH_PATTERNS = [
     re.compile(r'return\s+verifyWithMapping\s*\(\s*\)'),
 ]
 
+GO_VERIFY_ML_DSA_DIRECT_DISPATCH_EXACT_PATTERNS = [
+    re.compile(
+        r'(^|[^`"\\])return\s+opensslVerifySigOneShot\s*\(\s*"ML-DSA-87"\s*,\s*pubkey\s*,\s*signature\s*,\s*digest32\[:\]\s*,?\s*\)'
+    ),
+    re.compile(
+        r'(^|[^`"\\])return\s+opensslVerifySigMessage\s*\(\s*"ML-DSA-87"\s*,\s*pubkey\s*,\s*signature\s*,\s*digest32\[:\]\s*,?\s*\)'
+    ),
+    re.compile(
+        r'(^|[^`"\\])return\s+verifyWithMapping\s*\(\s*"ML-DSA-87"\s*,?\s*\)'
+    ),
+]
+
 GO_VERIFY_ML_DSA_BINDING_RESOLUTION_PATTERN = re.compile(
     r'binding\s*,\s*err\s*:=\s*resolveSuiteVerifierBinding\s*\(\s*,\s*ML_DSA_87_PUBKEY_BYTES\s*,\s*ML_DSA_87_SIG_BYTES\s*,?\s*\)'
+)
+
+GO_VERIFY_ML_DSA_BINDING_RESOLUTION_EXACT_PATTERN = re.compile(
+    r'(^|[^`"\\])binding\s*,\s*err\s*:=\s*resolveSuiteVerifierBinding\s*\(\s*"ML-DSA-87"\s*,\s*ML_DSA_87_PUBKEY_BYTES\s*,\s*ML_DSA_87_SIG_BYTES\s*,?\s*\)'
 )
 
 GO_VERIFY_ML_DSA_BINDING_HANDOFF_PATTERN = re.compile(
@@ -400,20 +419,38 @@ def extract_go_verify_mldsa_case(path: Path, text: str) -> tuple[str | None, lis
 
 def check_go_verify_required_snippets(path: Path, text: str) -> list[str]:
     structure_text = sanitize_go_source(text, strip_strings=True)
+    comment_stripped_text = sanitize_go_source(text, strip_strings=False)
     errors = check_required_snippet_groups_normalized(
-        path, text, GO_VERIFY_GLOBAL_REQUIRED_SNIPPET_GROUPS
+        path, structure_text, GO_VERIFY_GO_REQUIRED_SNIPPET_GROUPS
+    )
+    errors.extend(
+        check_required_snippet_groups_normalized(
+            path, text, GO_VERIFY_CGO_REQUIRED_SNIPPET_GROUPS
+        )
     )
     case_body, case_errors = extract_go_verify_mldsa_case(path, structure_text)
     errors.extend(case_errors)
     if case_body is None:
         return errors
+    comment_case_body, comment_case_errors = extract_go_verify_mldsa_case(
+        path, comment_stripped_text
+    )
+    if comment_case_body is None:
+        errors.extend(comment_case_errors)
+        return errors
     normalized_case_body = normalize_for_match(case_body)
+    normalized_comment_case_body = normalize_for_match(comment_case_body)
     has_direct_dispatch = any(
         pattern.search(normalized_case_body)
         for pattern in GO_VERIFY_ML_DSA_DIRECT_DISPATCH_PATTERNS
+    ) and any(
+        pattern.search(normalized_comment_case_body)
+        for pattern in GO_VERIFY_ML_DSA_DIRECT_DISPATCH_EXACT_PATTERNS
     )
     has_binding_resolution = GO_VERIFY_ML_DSA_BINDING_RESOLUTION_PATTERN.search(
         normalized_case_body
+    ) is not None and GO_VERIFY_ML_DSA_BINDING_RESOLUTION_EXACT_PATTERN.search(
+        normalized_comment_case_body
     ) is not None
     has_binding_handoff = GO_VERIFY_ML_DSA_BINDING_HANDOFF_PATTERN.search(
         normalized_case_body

--- a/tools/check_crypto_backend_policy.py
+++ b/tools/check_crypto_backend_policy.py
@@ -52,21 +52,9 @@ DOC_OPS_REQUIRED_PHRASES = [
     "not automatic production FIPS compliance",
 ]
 
-GO_VERIFY_REQUIRED_SNIPPET_GROUPS = [
+GO_VERIFY_GLOBAL_REQUIRED_SNIPPET_GROUPS = [
     ["func verifySig("],
     ["case SUITE_ID_ML_DSA_87:"],
-    [
-        'return opensslVerifySigOneShot("ML-DSA-87", pubkey, signature, digest32[:])',
-        'return opensslVerifySigMessage("ML-DSA-87", pubkey, signature, digest32[:])',
-        'return verifyWithMapping("ML-DSA-87")',
-        'binding, err := resolveSuiteVerifierBinding("ML-DSA-87", ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES)',
-    ],
-    [
-        'return opensslVerifySigOneShot("ML-DSA-87", pubkey, signature, digest32[:])',
-        'return opensslVerifySigMessage("ML-DSA-87", pubkey, signature, digest32[:])',
-        'return verifyWithMapping("ML-DSA-87")',
-        "return verifySigWithBinding(binding, pubkey, signature, digest32)",
-    ],
     [
         "func opensslVerifySigOneShot(",
         "func opensslVerifySigDigestOneShot(",
@@ -75,6 +63,31 @@ GO_VERIFY_REQUIRED_SNIPPET_GROUPS = [
     ["EVP_DigestVerifyInit_ex(mctx, NULL, NULL, NULL, NULL, pkey, NULL)"],
     ["EVP_DigestVerify(mctx, sig, sig_len, msg, msg_len)"],
 ]
+
+GO_VERIFY_ML_DSA_DIRECT_DISPATCH_SNIPPETS = [
+    'return opensslVerifySigOneShot("ML-DSA-87", pubkey, signature, digest32[:])',
+    'return opensslVerifySigMessage("ML-DSA-87", pubkey, signature, digest32[:])',
+    'return verifyWithMapping("ML-DSA-87")',
+]
+
+GO_VERIFY_ML_DSA_BINDING_RESOLUTION_SNIPPET = (
+    'binding, err := resolveSuiteVerifierBinding("ML-DSA-87", '
+    "ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES)"
+)
+
+GO_VERIFY_ML_DSA_BINDING_HANDOFF_SNIPPET = (
+    "return verifySigWithBinding(binding, pubkey, signature, digest32)"
+)
+
+GO_VERIFY_SIG_FUNC_RE = re.compile(
+    r"func verifySig\([^)]*\)\s*\([^)]*\)\s*\{(?P<body>.*?)^\}",
+    re.DOTALL | re.MULTILINE,
+)
+
+GO_VERIFY_ML_DSA_CASE_RE = re.compile(
+    r"^\s*case SUITE_ID_ML_DSA_87:\s*(?P<body>.*?)(?=^\s*(?:case |default:))",
+    re.DOTALL | re.MULTILINE,
+)
 
 RUST_VERIFY_REQUIRED_SNIPPETS = [
     "pub fn verify_sig(",
@@ -179,6 +192,54 @@ def check_required_snippet_groups(
     return errors
 
 
+def extract_go_verify_mldsa_case(path: Path, text: str) -> tuple[str | None, list[str]]:
+    errors: list[str] = []
+    func_match = GO_VERIFY_SIG_FUNC_RE.search(text)
+    if not func_match:
+        errors.append(f"{path}: missing verifySig function body for ML-DSA-87 policy checks")
+        return None, errors
+
+    case_match = GO_VERIFY_ML_DSA_CASE_RE.search(func_match.group("body"))
+    if not case_match:
+        errors.append(f"{path}: missing verifySig ML-DSA-87 case body for policy checks")
+        return None, errors
+
+    return case_match.group("body"), errors
+
+
+def check_go_verify_required_snippets(path: Path, text: str) -> list[str]:
+    errors = check_required_snippet_groups(path, text, GO_VERIFY_GLOBAL_REQUIRED_SNIPPET_GROUPS)
+    case_body, case_errors = extract_go_verify_mldsa_case(path, text)
+    errors.extend(case_errors)
+    if case_body is None:
+        return errors
+
+    has_direct_dispatch = any(
+        snippet in case_body for snippet in GO_VERIFY_ML_DSA_DIRECT_DISPATCH_SNIPPETS
+    )
+    has_binding_resolution = GO_VERIFY_ML_DSA_BINDING_RESOLUTION_SNIPPET in case_body
+    has_binding_handoff = GO_VERIFY_ML_DSA_BINDING_HANDOFF_SNIPPET in case_body
+
+    if not (has_direct_dispatch or has_binding_resolution or has_binding_handoff):
+        errors.append(
+            f"{path}: verifySig ML-DSA-87 case missing required dispatch group (any-of): "
+            f"{GO_VERIFY_ML_DSA_DIRECT_DISPATCH_SNIPPETS + [GO_VERIFY_ML_DSA_BINDING_RESOLUTION_SNIPPET]!r}"
+        )
+
+    if has_binding_resolution and not has_binding_handoff:
+        errors.append(
+            f"{path}: verifySig ML-DSA-87 case missing required binding handoff snippet: "
+            f"{GO_VERIFY_ML_DSA_BINDING_HANDOFF_SNIPPET!r}"
+        )
+    if has_binding_handoff and not has_binding_resolution:
+        errors.append(
+            f"{path}: verifySig ML-DSA-87 case missing required binding resolution snippet: "
+            f"{GO_VERIFY_ML_DSA_BINDING_RESOLUTION_SNIPPET!r}"
+        )
+
+    return errors
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description="Crypto backend policy lint (docs + OpenSSL binding invariants)."
@@ -275,11 +336,7 @@ def main() -> int:
 
         if go_verify.exists():
             go_text = read_text(go_verify)
-            errors.extend(
-                check_required_snippet_groups(
-                    go_verify, go_text, GO_VERIFY_REQUIRED_SNIPPET_GROUPS
-                )
-            )
+            errors.extend(check_go_verify_required_snippets(go_verify, go_text))
         if rust_verify.exists():
             rust_text = read_text(rust_verify)
             errors.extend(

--- a/tools/check_crypto_backend_policy.py
+++ b/tools/check_crypto_backend_policy.py
@@ -59,6 +59,13 @@ GO_VERIFY_REQUIRED_SNIPPET_GROUPS = [
         'return opensslVerifySigOneShot("ML-DSA-87", pubkey, signature, digest32[:])',
         'return opensslVerifySigMessage("ML-DSA-87", pubkey, signature, digest32[:])',
         'return verifyWithMapping("ML-DSA-87")',
+        'binding, err := resolveSuiteVerifierBinding("ML-DSA-87", ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES)',
+    ],
+    [
+        'return opensslVerifySigOneShot("ML-DSA-87", pubkey, signature, digest32[:])',
+        'return opensslVerifySigMessage("ML-DSA-87", pubkey, signature, digest32[:])',
+        'return verifyWithMapping("ML-DSA-87")',
+        "return verifySigWithBinding(binding, pubkey, signature, digest32)",
     ],
     [
         "func opensslVerifySigOneShot(",

--- a/tools/check_crypto_backend_policy.py
+++ b/tools/check_crypto_backend_policy.py
@@ -79,16 +79,6 @@ GO_VERIFY_ML_DSA_BINDING_HANDOFF_SNIPPET = (
     "return verifySigWithBinding(binding, pubkey, signature, digest32)"
 )
 
-GO_VERIFY_SIG_FUNC_RE = re.compile(
-    r"func verifySig\([^)]*\)\s*\([^)]*\)\s*\{(?P<body>.*?)^\}",
-    re.DOTALL | re.MULTILINE,
-)
-
-GO_VERIFY_ML_DSA_CASE_RE = re.compile(
-    r"^\s*case SUITE_ID_ML_DSA_87:\s*(?P<body>.*?)(?=^\s*(?:case |default:))",
-    re.DOTALL | re.MULTILINE,
-)
-
 RUST_VERIFY_REQUIRED_SNIPPETS = [
     "pub fn verify_sig(",
     'SUITE_ID_ML_DSA_87 => Ok(c"ML-DSA-87")',
@@ -194,17 +184,60 @@ def check_required_snippet_groups(
 
 def extract_go_verify_mldsa_case(path: Path, text: str) -> tuple[str | None, list[str]]:
     errors: list[str] = []
-    func_match = GO_VERIFY_SIG_FUNC_RE.search(text)
-    if not func_match:
-        errors.append(f"{path}: missing verifySig function body for ML-DSA-87 policy checks")
-        return None, errors
+    lines = text.splitlines()
+    in_verify_sig = False
+    verify_sig_depth = 0
+    switch_depth: int | None = None
+    collecting_case = False
+    collected_lines: list[str] = []
 
-    case_match = GO_VERIFY_ML_DSA_CASE_RE.search(func_match.group("body"))
-    if not case_match:
-        errors.append(f"{path}: missing verifySig ML-DSA-87 case body for policy checks")
-        return None, errors
+    for line in lines:
+        current_depth = verify_sig_depth
+        next_depth = current_depth + line.count("{") - line.count("}")
+        stripped = line.lstrip()
 
-    return case_match.group("body"), errors
+        if not in_verify_sig:
+            if "func verifySig(" in line:
+                in_verify_sig = True
+                verify_sig_depth = next_depth
+            continue
+
+        if switch_depth is None:
+            if re.match(r"^\s*switch\s+suiteID\s*\{", line):
+                switch_depth = next_depth
+            verify_sig_depth = next_depth
+            if verify_sig_depth <= 0:
+                break
+            continue
+
+        if collecting_case:
+            if current_depth < switch_depth:
+                return "\n".join(collected_lines), errors
+            if current_depth == switch_depth and re.match(r"^\s*(case |default:)", stripped):
+                return "\n".join(collected_lines), errors
+            collected_lines.append(line)
+            verify_sig_depth = next_depth
+            if verify_sig_depth <= 0:
+                break
+            continue
+
+        if current_depth == switch_depth and stripped.startswith("case SUITE_ID_ML_DSA_87:"):
+            collecting_case = True
+            _, _, same_line_tail = line.partition("case SUITE_ID_ML_DSA_87:")
+            if same_line_tail.strip():
+                collected_lines.append(same_line_tail)
+            verify_sig_depth = next_depth
+            continue
+
+        verify_sig_depth = next_depth
+        if verify_sig_depth <= 0:
+            break
+
+    if collecting_case:
+        return "\n".join(collected_lines), errors
+
+    errors.append(f"{path}: missing verifySig ML-DSA-87 case body for policy checks")
+    return None, errors
 
 
 def check_go_verify_required_snippets(path: Path, text: str) -> list[str]:

--- a/tools/check_local_prepush_skill_gates.py
+++ b/tools/check_local_prepush_skill_gates.py
@@ -435,6 +435,8 @@ def build_plan(
             exact=(
                 ".github/workflows/ci.yml",
                 "tools/check_consensus_openssl_isolation.py",
+                "tools/check_crypto_backend_policy.py",
+                "tools/tests/test_check_crypto_backend_policy.py",
                 "scripts/dev-env.sh",
                 "clients/go/consensus/verify_sig_openssl.go",
                 "clients/go/consensus/verify_sig_openssl_bootstrap_test.go",
@@ -461,6 +463,14 @@ def build_plan(
             add_check(
                 "consensus_openssl_source_policy",
                 ["python3", "tools/check_consensus_openssl_isolation.py", *consensus_openssl_sources],
+            )
+        if any(
+            path in {"tools/check_crypto_backend_policy.py", "tools/tests/test_check_crypto_backend_policy.py"}
+            for path in changed
+        ):
+            add_check(
+                "crypto_backend_policy_tooling_tests",
+                ["python3", "-m", "unittest", "tools.tests.test_check_crypto_backend_policy"],
             )
         if any(
             path in {".github/workflows/ci.yml", "tools/check_consensus_openssl_isolation.py"}

--- a/tools/tests/test_check_crypto_backend_policy.py
+++ b/tools/tests/test_check_crypto_backend_policy.py
@@ -241,6 +241,36 @@ func opensslVerifySigOneShot(alg string, pubkey []byte, signature []byte, msg []
             any("missing required binding handoff snippet" in err for err in errors)
         )
 
+    def test_go_string_literal_spoofed_handoff_does_not_count(self):
+        text = """
+func verifySig(suiteID uint8, pubkey []byte, signature []byte, digest32 [32]byte) (bool, error) {
+    switch suiteID {
+    case SUITE_ID_ML_DSA_87:
+        binding, err := resolveSuiteVerifierBinding("ML-DSA-87", ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES)
+        if err != nil {
+            return false, err
+        }
+        _ = "return verifySigWithBinding(binding, pubkey, signature, digest32)"
+        return false, err
+    default:
+        return false, nil
+    }
+}
+
+func opensslVerifySigOneShot(alg string, pubkey []byte, signature []byte, msg []byte) (bool, error) {
+    EVP_DigestVerifyInit_ex(mctx, NULL, NULL, NULL, NULL, pkey, NULL)
+    EVP_DigestVerify(mctx, sig, sig_len, msg, msg_len)
+    return true, nil
+}
+"""
+        errors = m.check_go_verify_required_snippets(
+            Path("clients/go/consensus/verify_sig_openssl.go"),
+            text,
+        )
+        self.assertTrue(
+            any("missing required binding handoff snippet" in err for err in errors)
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/tests/test_check_crypto_backend_policy.py
+++ b/tools/tests/test_check_crypto_backend_policy.py
@@ -31,10 +31,9 @@ func opensslVerifySigOneShot(alg string, pubkey []byte, signature []byte, msg []
 }
 """
         self.assertEqual(
-            m.check_required_snippet_groups(
+            m.check_go_verify_required_snippets(
                 Path("clients/go/consensus/verify_sig_openssl.go"),
                 text,
-                m.GO_VERIFY_REQUIRED_SNIPPET_GROUPS,
             ),
             [],
         )
@@ -61,12 +60,65 @@ func opensslVerifySigOneShot(alg string, pubkey []byte, signature []byte, msg []
 }
 """
         self.assertEqual(
-            m.check_required_snippet_groups(
+            m.check_go_verify_required_snippets(
                 Path("clients/go/consensus/verify_sig_openssl.go"),
                 text,
-                m.GO_VERIFY_REQUIRED_SNIPPET_GROUPS,
             ),
             [],
+        )
+
+    def test_go_binding_resolution_without_handoff_fails(self):
+        text = """
+func verifySig(suiteID uint8, pubkey []byte, signature []byte, digest32 [32]byte) (bool, error) {
+    switch suiteID {
+    case SUITE_ID_ML_DSA_87:
+        binding, err := resolveSuiteVerifierBinding("ML-DSA-87", ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES)
+        if err != nil {
+            return false, err
+        }
+        return false, err
+    default:
+        return false, nil
+    }
+}
+
+func opensslVerifySigOneShot(alg string, pubkey []byte, signature []byte, msg []byte) (bool, error) {
+    EVP_DigestVerifyInit_ex(mctx, NULL, NULL, NULL, NULL, pkey, NULL)
+    EVP_DigestVerify(mctx, sig, sig_len, msg, msg_len)
+    return true, nil
+}
+"""
+        errors = m.check_go_verify_required_snippets(
+            Path("clients/go/consensus/verify_sig_openssl.go"),
+            text,
+        )
+        self.assertTrue(
+            any("missing required binding handoff snippet" in err for err in errors)
+        )
+
+    def test_go_binding_handoff_without_resolution_fails(self):
+        text = """
+func verifySig(suiteID uint8, pubkey []byte, signature []byte, digest32 [32]byte) (bool, error) {
+    switch suiteID {
+    case SUITE_ID_ML_DSA_87:
+        return verifySigWithBinding(binding, pubkey, signature, digest32)
+    default:
+        return false, nil
+    }
+}
+
+func opensslVerifySigOneShot(alg string, pubkey []byte, signature []byte, msg []byte) (bool, error) {
+    EVP_DigestVerifyInit_ex(mctx, NULL, NULL, NULL, NULL, pkey, NULL)
+    EVP_DigestVerify(mctx, sig, sig_len, msg, msg_len)
+    return true, nil
+}
+"""
+        errors = m.check_go_verify_required_snippets(
+            Path("clients/go/consensus/verify_sig_openssl.go"),
+            text,
+        )
+        self.assertTrue(
+            any("missing required binding resolution snippet" in err for err in errors)
         )
 
 

--- a/tools/tests/test_check_crypto_backend_policy.py
+++ b/tools/tests/test_check_crypto_backend_policy.py
@@ -271,6 +271,44 @@ func opensslVerifySigOneShot(alg string, pubkey []byte, signature []byte, msg []
             any("missing required binding handoff snippet" in err for err in errors)
         )
 
+    def test_go_multiline_binding_resolution_and_handoff_are_accepted(self):
+        text = """
+func verifySig(suiteID uint8, pubkey []byte, signature []byte, digest32 [32]byte) (bool, error) {
+    switch suiteID {
+    case SUITE_ID_ML_DSA_87:
+        binding, err := resolveSuiteVerifierBinding(
+            "ML-DSA-87",
+            ML_DSA_87_PUBKEY_BYTES,
+            ML_DSA_87_SIG_BYTES,
+        )
+        if err != nil {
+            return false, err
+        }
+        return verifySigWithBinding(
+            binding,
+            pubkey,
+            signature,
+            digest32,
+        )
+    default:
+        return false, nil
+    }
+}
+
+func opensslVerifySigOneShot(alg string, pubkey []byte, signature []byte, msg []byte) (bool, error) {
+    EVP_DigestVerifyInit_ex(mctx, NULL, NULL, NULL, NULL, pkey, NULL)
+    EVP_DigestVerify(mctx, sig, sig_len, msg, msg_len)
+    return true, nil
+}
+"""
+        self.assertEqual(
+            m.check_go_verify_required_snippets(
+                Path("clients/go/consensus/verify_sig_openssl.go"),
+                text,
+            ),
+            [],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/tests/test_check_crypto_backend_policy.py
+++ b/tools/tests/test_check_crypto_backend_policy.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+
+TOOLS_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(TOOLS_DIR))
+
+import check_crypto_backend_policy as m
+
+
+class CryptoBackendPolicyTests(unittest.TestCase):
+    def test_go_required_snippet_groups_accept_legacy_direct_dispatch(self):
+        text = """
+func verifySig(suiteID uint8, pubkey []byte, signature []byte, digest32 [32]byte) (bool, error) {
+    switch suiteID {
+    case SUITE_ID_ML_DSA_87:
+        return opensslVerifySigOneShot("ML-DSA-87", pubkey, signature, digest32[:])
+    default:
+        return false, nil
+    }
+}
+
+func opensslVerifySigOneShot(alg string, pubkey []byte, signature []byte, msg []byte) (bool, error) {
+    EVP_DigestVerifyInit_ex(mctx, NULL, NULL, NULL, NULL, pkey, NULL)
+    EVP_DigestVerify(mctx, sig, sig_len, msg, msg_len)
+    return true, nil
+}
+"""
+        self.assertEqual(
+            m.check_required_snippet_groups(
+                Path("clients/go/consensus/verify_sig_openssl.go"),
+                text,
+                m.GO_VERIFY_REQUIRED_SNIPPET_GROUPS,
+            ),
+            [],
+        )
+
+    def test_go_required_snippet_groups_accept_binding_resolution_path(self):
+        text = """
+func verifySig(suiteID uint8, pubkey []byte, signature []byte, digest32 [32]byte) (bool, error) {
+    switch suiteID {
+    case SUITE_ID_ML_DSA_87:
+        binding, err := resolveSuiteVerifierBinding("ML-DSA-87", ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES)
+        if err != nil {
+            return false, err
+        }
+        return verifySigWithBinding(binding, pubkey, signature, digest32)
+    default:
+        return false, nil
+    }
+}
+
+func opensslVerifySigOneShot(alg string, pubkey []byte, signature []byte, msg []byte) (bool, error) {
+    EVP_DigestVerifyInit_ex(mctx, NULL, NULL, NULL, NULL, pkey, NULL)
+    EVP_DigestVerify(mctx, sig, sig_len, msg, msg_len)
+    return true, nil
+}
+"""
+        self.assertEqual(
+            m.check_required_snippet_groups(
+                Path("clients/go/consensus/verify_sig_openssl.go"),
+                text,
+                m.GO_VERIFY_REQUIRED_SNIPPET_GROUPS,
+            ),
+            [],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_check_crypto_backend_policy.py
+++ b/tools/tests/test_check_crypto_backend_policy.py
@@ -23,6 +23,15 @@ import "C"
 """
 
 
+CGO_LINE_PREAMBLE = """
+// static int rubin_verify_sig_oneshot() {
+//     EVP_DigestVerifyInit_ex(mctx, NULL, NULL, NULL, NULL, pkey, NULL);
+//     return EVP_DigestVerify(mctx, sig, sig_len, msg, msg_len);
+// }
+import "C"
+"""
+
+
 def go_fixture(text: str) -> str:
     return CGO_PREAMBLE + "\n" + text
 
@@ -375,6 +384,64 @@ func opensslVerifySigOneShot(alg string, pubkey []byte, signature []byte, msg []
             Path("clients/go/consensus/verify_sig_openssl.go"),
             go_fixture(text),
         )
+        self.assertTrue(
+            any("missing required binding resolution snippet" in err for err in errors)
+        )
+
+    def test_go_direct_dispatch_requires_exact_alg_literal(self):
+        text = """
+func verifySig(suiteID uint8, pubkey []byte, signature []byte, digest32 [32]byte) (bool, error) {
+    switch suiteID {
+    case SUITE_ID_ML_DSA_87:
+        return opensslVerifySigOneShot("WRONG-ALG", pubkey, signature, digest32[:])
+    default:
+        return false, nil
+    }
+}
+
+func opensslVerifySigOneShot(alg string, pubkey []byte, signature []byte, msg []byte) (bool, error) {
+    EVP_DigestVerifyInit_ex(mctx, NULL, NULL, NULL, NULL, pkey, NULL)
+    EVP_DigestVerify(mctx, sig, sig_len, msg, msg_len)
+    return true, nil
+}
+"""
+        errors = m.check_go_verify_required_snippets(
+            Path("clients/go/consensus/verify_sig_openssl.go"),
+            go_fixture(text),
+        )
+        self.assertTrue(
+            any("missing required dispatch group" in err for err in errors)
+        )
+
+    def test_go_raw_string_binding_snippet_does_not_spoof_exact_literal(self):
+        text = """
+func verifySig(suiteID uint8, pubkey []byte, signature []byte, digest32 [32]byte) (bool, error) {
+    switch suiteID {
+    case SUITE_ID_ML_DSA_87:
+        _ = `binding, err := resolveSuiteVerifierBinding("ML-DSA-87", ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES)`
+        binding, err := resolveSuiteVerifierBinding("WRONG-ALG", ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES)
+        if err != nil {
+            return false, err
+        }
+        return verifySigWithBinding(binding, pubkey, signature, digest32)
+    default:
+        return false, nil
+    }
+}
+
+func opensslVerifySigOneShot(alg string, pubkey []byte, signature []byte, msg []byte) (bool, error) {
+    EVP_DigestVerifyInit_ex(mctx, NULL, NULL, NULL, NULL, pkey, NULL)
+    EVP_DigestVerify(mctx, sig, sig_len, msg, msg_len)
+    return true, nil
+}
+"""
+        errors = m.check_go_verify_required_snippets(
+            Path("clients/go/consensus/verify_sig_openssl.go"),
+            go_fixture(text),
+        )
+        self.assertTrue(
+            any("missing required binding resolution snippet" in err for err in errors)
+        )
 
     def test_go_cgo_required_snippet_in_go_string_does_not_count(self):
         text = """
@@ -398,6 +465,60 @@ var spoof = "EVP_DigestVerifyInit_ex(mctx, NULL, NULL, NULL, NULL, pkey, NULL) E
         )
         self.assertTrue(
             any("missing required snippet group" in err for err in errors)
+        )
+
+    def test_go_line_comment_cgo_preamble_is_accepted(self):
+        text = """
+func verifySig(suiteID uint8, pubkey []byte, signature []byte, digest32 [32]byte) (bool, error) {
+    switch suiteID {
+    case SUITE_ID_ML_DSA_87:
+        return opensslVerifySigOneShot("ML-DSA-87", pubkey, signature, digest32[:])
+    default:
+        return false, nil
+    }
+}
+
+func opensslVerifySigOneShot(alg string, pubkey []byte, signature []byte, msg []byte) (bool, error) {
+    return true, nil
+}
+"""
+        self.assertEqual(
+            m.check_go_verify_required_snippets(
+                Path("clients/go/consensus/verify_sig_openssl.go"),
+                CGO_LINE_PREAMBLE + "\n" + text,
+            ),
+            [],
+        )
+
+    def test_go_string_literal_func_verify_sig_does_not_confuse_parser(self):
+        text = '''
+var banner = "func verifySig("
+
+func verifySig(suiteID uint8, pubkey []byte, signature []byte, digest32 [32]byte) (bool, error) {
+    switch suiteID {
+    case SUITE_ID_ML_DSA_87:
+        binding, err := resolveSuiteVerifierBinding("ML-DSA-87", ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES)
+        if err != nil {
+            return false, err
+        }
+        return verifySigWithBinding(binding, pubkey, signature, digest32)
+    default:
+        return false, nil
+    }
+}
+
+func opensslVerifySigOneShot(alg string, pubkey []byte, signature []byte, msg []byte) (bool, error) {
+    EVP_DigestVerifyInit_ex(mctx, NULL, NULL, NULL, NULL, pkey, NULL)
+    EVP_DigestVerify(mctx, sig, sig_len, msg, msg_len)
+    return true, nil
+}
+'''
+        self.assertEqual(
+            m.check_go_verify_required_snippets(
+                Path("clients/go/consensus/verify_sig_openssl.go"),
+                go_fixture(text),
+            ),
+            [],
         )
 
 

--- a/tools/tests/test_check_crypto_backend_policy.py
+++ b/tools/tests/test_check_crypto_backend_policy.py
@@ -309,6 +309,61 @@ func opensslVerifySigOneShot(alg string, pubkey []byte, signature []byte, msg []
             [],
         )
 
+    def test_go_global_verify_helper_snippet_in_string_does_not_count(self):
+        text = """
+func verifySig(suiteID uint8, pubkey []byte, signature []byte, digest32 [32]byte) (bool, error) {
+    switch suiteID {
+    case SUITE_ID_ML_DSA_87:
+        return opensslVerifySigOneShot("ML-DSA-87", pubkey, signature, digest32[:])
+    default:
+        return false, nil
+    }
+}
+
+var spoof = "func opensslVerifySigOneShot("
+
+/*
+EVP_DigestVerifyInit_ex(mctx, NULL, NULL, NULL, NULL, pkey, NULL)
+EVP_DigestVerify(mctx, sig, sig_len, msg, msg_len)
+*/
+"""
+        errors = m.check_go_verify_required_snippets(
+            Path("clients/go/consensus/verify_sig_openssl.go"),
+            text,
+        )
+        self.assertTrue(
+            any("missing required snippet group" in err for err in errors)
+        )
+
+    def test_go_binding_resolution_requires_exact_alg_literal(self):
+        text = """
+func verifySig(suiteID uint8, pubkey []byte, signature []byte, digest32 [32]byte) (bool, error) {
+    switch suiteID {
+    case SUITE_ID_ML_DSA_87:
+        binding, err := resolveSuiteVerifierBinding("WRONG-ALG", ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES)
+        if err != nil {
+            return false, err
+        }
+        return verifySigWithBinding(binding, pubkey, signature, digest32)
+    default:
+        return false, nil
+    }
+}
+
+func opensslVerifySigOneShot(alg string, pubkey []byte, signature []byte, msg []byte) (bool, error) {
+    EVP_DigestVerifyInit_ex(mctx, NULL, NULL, NULL, NULL, pkey, NULL)
+    EVP_DigestVerify(mctx, sig, sig_len, msg, msg_len)
+    return true, nil
+}
+"""
+        errors = m.check_go_verify_required_snippets(
+            Path("clients/go/consensus/verify_sig_openssl.go"),
+            text,
+        )
+        self.assertTrue(
+            any("missing required binding resolution snippet" in err for err in errors)
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/tests/test_check_crypto_backend_policy.py
+++ b/tools/tests/test_check_crypto_backend_policy.py
@@ -121,6 +121,66 @@ func opensslVerifySigOneShot(alg string, pubkey []byte, signature []byte, msg []
             any("missing required binding resolution snippet" in err for err in errors)
         )
 
+    def test_go_binding_resolution_path_accepts_last_switch_arm(self):
+        text = """
+func verifySig(suiteID uint8, pubkey []byte, signature []byte, digest32 [32]byte) (bool, error) {
+    switch suiteID {
+    case SUITE_ID_ML_DSA_87:
+        binding, err := resolveSuiteVerifierBinding("ML-DSA-87", ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES)
+        if err != nil {
+            return false, err
+        }
+        return verifySigWithBinding(binding, pubkey, signature, digest32)
+    }
+    return false, nil
+}
+
+func opensslVerifySigOneShot(alg string, pubkey []byte, signature []byte, msg []byte) (bool, error) {
+    EVP_DigestVerifyInit_ex(mctx, NULL, NULL, NULL, NULL, pkey, NULL)
+    EVP_DigestVerify(mctx, sig, sig_len, msg, msg_len)
+    return true, nil
+}
+"""
+        self.assertEqual(
+            m.check_go_verify_required_snippets(
+                Path("clients/go/consensus/verify_sig_openssl.go"),
+                text,
+            ),
+            [],
+        )
+
+    def test_go_binding_resolution_path_ignores_nested_default(self):
+        text = """
+func verifySig(suiteID uint8, pubkey []byte, signature []byte, digest32 [32]byte) (bool, error) {
+    switch suiteID {
+    case SUITE_ID_ML_DSA_87:
+        switch len(signature) {
+        default:
+            binding, err := resolveSuiteVerifierBinding("ML-DSA-87", ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES)
+            if err != nil {
+                return false, err
+            }
+            return verifySigWithBinding(binding, pubkey, signature, digest32)
+        }
+    default:
+        return false, nil
+    }
+}
+
+func opensslVerifySigOneShot(alg string, pubkey []byte, signature []byte, msg []byte) (bool, error) {
+    EVP_DigestVerifyInit_ex(mctx, NULL, NULL, NULL, NULL, pkey, NULL)
+    EVP_DigestVerify(mctx, sig, sig_len, msg, msg_len)
+    return true, nil
+}
+"""
+        self.assertEqual(
+            m.check_go_verify_required_snippets(
+                Path("clients/go/consensus/verify_sig_openssl.go"),
+                text,
+            ),
+            [],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/tests/test_check_crypto_backend_policy.py
+++ b/tools/tests/test_check_crypto_backend_policy.py
@@ -181,6 +181,66 @@ func opensslVerifySigOneShot(alg string, pubkey []byte, signature []byte, msg []
             [],
         )
 
+    def test_go_comment_braces_do_not_break_case_extraction(self):
+        text = """
+func verifySig(suiteID uint8, pubkey []byte, signature []byte, digest32 [32]byte) (bool, error) {
+    switch suiteID {
+    case SUITE_ID_ML_DSA_87:
+        // } comment-only brace must not terminate the function early
+        binding, err := resolveSuiteVerifierBinding("ML-DSA-87", ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES)
+        if err != nil {
+            return false, err
+        }
+        return verifySigWithBinding(binding, pubkey, signature, digest32)
+    default:
+        return false, nil
+    }
+}
+
+func opensslVerifySigOneShot(alg string, pubkey []byte, signature []byte, msg []byte) (bool, error) {
+    EVP_DigestVerifyInit_ex(mctx, NULL, NULL, NULL, NULL, pkey, NULL)
+    EVP_DigestVerify(mctx, sig, sig_len, msg, msg_len)
+    return true, nil
+}
+"""
+        self.assertEqual(
+            m.check_go_verify_required_snippets(
+                Path("clients/go/consensus/verify_sig_openssl.go"),
+                text,
+            ),
+            [],
+        )
+
+    def test_go_comment_spoofed_handoff_does_not_count(self):
+        text = """
+func verifySig(suiteID uint8, pubkey []byte, signature []byte, digest32 [32]byte) (bool, error) {
+    switch suiteID {
+    case SUITE_ID_ML_DSA_87:
+        binding, err := resolveSuiteVerifierBinding("ML-DSA-87", ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES)
+        if err != nil {
+            return false, err
+        }
+        // return verifySigWithBinding(binding, pubkey, signature, digest32)
+        return false, err
+    default:
+        return false, nil
+    }
+}
+
+func opensslVerifySigOneShot(alg string, pubkey []byte, signature []byte, msg []byte) (bool, error) {
+    EVP_DigestVerifyInit_ex(mctx, NULL, NULL, NULL, NULL, pkey, NULL)
+    EVP_DigestVerify(mctx, sig, sig_len, msg, msg_len)
+    return true, nil
+}
+"""
+        errors = m.check_go_verify_required_snippets(
+            Path("clients/go/consensus/verify_sig_openssl.go"),
+            text,
+        )
+        self.assertTrue(
+            any("missing required binding handoff snippet" in err for err in errors)
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/tests/test_check_crypto_backend_policy.py
+++ b/tools/tests/test_check_crypto_backend_policy.py
@@ -12,6 +12,21 @@ sys.path.insert(0, str(TOOLS_DIR))
 import check_crypto_backend_policy as m
 
 
+CGO_PREAMBLE = """
+/*
+static int rubin_verify_sig_oneshot() {
+    EVP_DigestVerifyInit_ex(mctx, NULL, NULL, NULL, NULL, pkey, NULL);
+    return EVP_DigestVerify(mctx, sig, sig_len, msg, msg_len);
+}
+*/
+import "C"
+"""
+
+
+def go_fixture(text: str) -> str:
+    return CGO_PREAMBLE + "\n" + text
+
+
 class CryptoBackendPolicyTests(unittest.TestCase):
     def test_go_required_snippet_groups_accept_legacy_direct_dispatch(self):
         text = """
@@ -31,12 +46,12 @@ func opensslVerifySigOneShot(alg string, pubkey []byte, signature []byte, msg []
 }
 """
         self.assertEqual(
-            m.check_go_verify_required_snippets(
-                Path("clients/go/consensus/verify_sig_openssl.go"),
-                text,
-            ),
-            [],
-        )
+                m.check_go_verify_required_snippets(
+                    Path("clients/go/consensus/verify_sig_openssl.go"),
+                    go_fixture(text),
+                ),
+                [],
+            )
 
     def test_go_required_snippet_groups_accept_binding_resolution_path(self):
         text = """
@@ -62,7 +77,7 @@ func opensslVerifySigOneShot(alg string, pubkey []byte, signature []byte, msg []
         self.assertEqual(
             m.check_go_verify_required_snippets(
                 Path("clients/go/consensus/verify_sig_openssl.go"),
-                text,
+                go_fixture(text),
             ),
             [],
         )
@@ -90,7 +105,7 @@ func opensslVerifySigOneShot(alg string, pubkey []byte, signature []byte, msg []
 """
         errors = m.check_go_verify_required_snippets(
             Path("clients/go/consensus/verify_sig_openssl.go"),
-            text,
+            go_fixture(text),
         )
         self.assertTrue(
             any("missing required binding handoff snippet" in err for err in errors)
@@ -115,7 +130,7 @@ func opensslVerifySigOneShot(alg string, pubkey []byte, signature []byte, msg []
 """
         errors = m.check_go_verify_required_snippets(
             Path("clients/go/consensus/verify_sig_openssl.go"),
-            text,
+            go_fixture(text),
         )
         self.assertTrue(
             any("missing required binding resolution snippet" in err for err in errors)
@@ -142,12 +157,12 @@ func opensslVerifySigOneShot(alg string, pubkey []byte, signature []byte, msg []
 }
 """
         self.assertEqual(
-            m.check_go_verify_required_snippets(
-                Path("clients/go/consensus/verify_sig_openssl.go"),
-                text,
-            ),
-            [],
-        )
+                m.check_go_verify_required_snippets(
+                    Path("clients/go/consensus/verify_sig_openssl.go"),
+                    go_fixture(text),
+                ),
+                [],
+            )
 
     def test_go_binding_resolution_path_ignores_nested_default(self):
         text = """
@@ -174,12 +189,12 @@ func opensslVerifySigOneShot(alg string, pubkey []byte, signature []byte, msg []
 }
 """
         self.assertEqual(
-            m.check_go_verify_required_snippets(
-                Path("clients/go/consensus/verify_sig_openssl.go"),
-                text,
-            ),
-            [],
-        )
+                m.check_go_verify_required_snippets(
+                    Path("clients/go/consensus/verify_sig_openssl.go"),
+                    go_fixture(text),
+                ),
+                [],
+            )
 
     def test_go_comment_braces_do_not_break_case_extraction(self):
         text = """
@@ -204,12 +219,12 @@ func opensslVerifySigOneShot(alg string, pubkey []byte, signature []byte, msg []
 }
 """
         self.assertEqual(
-            m.check_go_verify_required_snippets(
-                Path("clients/go/consensus/verify_sig_openssl.go"),
-                text,
-            ),
-            [],
-        )
+                m.check_go_verify_required_snippets(
+                    Path("clients/go/consensus/verify_sig_openssl.go"),
+                    go_fixture(text),
+                ),
+                [],
+            )
 
     def test_go_comment_spoofed_handoff_does_not_count(self):
         text = """
@@ -235,7 +250,7 @@ func opensslVerifySigOneShot(alg string, pubkey []byte, signature []byte, msg []
 """
         errors = m.check_go_verify_required_snippets(
             Path("clients/go/consensus/verify_sig_openssl.go"),
-            text,
+            go_fixture(text),
         )
         self.assertTrue(
             any("missing required binding handoff snippet" in err for err in errors)
@@ -265,7 +280,7 @@ func opensslVerifySigOneShot(alg string, pubkey []byte, signature []byte, msg []
 """
         errors = m.check_go_verify_required_snippets(
             Path("clients/go/consensus/verify_sig_openssl.go"),
-            text,
+            go_fixture(text),
         )
         self.assertTrue(
             any("missing required binding handoff snippet" in err for err in errors)
@@ -302,12 +317,12 @@ func opensslVerifySigOneShot(alg string, pubkey []byte, signature []byte, msg []
 }
 """
         self.assertEqual(
-            m.check_go_verify_required_snippets(
-                Path("clients/go/consensus/verify_sig_openssl.go"),
-                text,
-            ),
-            [],
-        )
+                m.check_go_verify_required_snippets(
+                    Path("clients/go/consensus/verify_sig_openssl.go"),
+                    go_fixture(text),
+                ),
+                [],
+            )
 
     def test_go_global_verify_helper_snippet_in_string_does_not_count(self):
         text = """
@@ -329,7 +344,7 @@ EVP_DigestVerify(mctx, sig, sig_len, msg, msg_len)
 """
         errors = m.check_go_verify_required_snippets(
             Path("clients/go/consensus/verify_sig_openssl.go"),
-            text,
+            go_fixture(text),
         )
         self.assertTrue(
             any("missing required snippet group" in err for err in errors)
@@ -358,10 +373,31 @@ func opensslVerifySigOneShot(alg string, pubkey []byte, signature []byte, msg []
 """
         errors = m.check_go_verify_required_snippets(
             Path("clients/go/consensus/verify_sig_openssl.go"),
+            go_fixture(text),
+        )
+
+    def test_go_cgo_required_snippet_in_go_string_does_not_count(self):
+        text = """
+func verifySig(suiteID uint8, pubkey []byte, signature []byte, digest32 [32]byte) (bool, error) {
+    switch suiteID {
+    case SUITE_ID_ML_DSA_87:
+        return opensslVerifySigOneShot("ML-DSA-87", pubkey, signature, digest32[:])
+    default:
+        return false, nil
+    }
+}
+
+var spoof = "EVP_DigestVerifyInit_ex(mctx, NULL, NULL, NULL, NULL, pkey, NULL) EVP_DigestVerify(mctx, sig, sig_len, msg, msg_len)"
+"""
+        errors = m.check_go_verify_required_snippets(
+            Path("clients/go/consensus/verify_sig_openssl.go"),
             text,
         )
         self.assertTrue(
-            any("missing required binding resolution snippet" in err for err in errors)
+            any("missing cgo preamble" in err for err in errors)
+        )
+        self.assertTrue(
+            any("missing required snippet group" in err for err in errors)
         )
 
 

--- a/tools/tests/test_local_prepush_skill_gates.py
+++ b/tools/tests/test_local_prepush_skill_gates.py
@@ -51,6 +51,21 @@ class LocalPrepushSkillGateTests(unittest.TestCase):
         self.assertIn("internal-tools", active_lenses)
         self.assertNotIn("cargo-audit-scan", active_lenses)
 
+    def test_build_plan_adds_crypto_backend_policy_tooling_tests(self):
+        changed = {
+            "tools/check_crypto_backend_policy.py",
+            "tools/tests/test_check_crypto_backend_policy.py",
+        }
+
+        checks, focuses, lenses, profile = m.build_plan(changed)
+        check_names = {name for name, _cmd in checks}
+        active_lenses = {lens.name for lens in lenses if lens.active}
+
+        self.assertIn("crypto_backend_policy_tooling_tests", check_names)
+        self.assertTrue(any("OpenSSL isolation" in focus for focus in focuses))
+        self.assertEqual(profile.name, "consensus_critical")
+        self.assertIn("internal-tools", active_lenses)
+
     def test_render_fullscan_reports_active_and_standby_lenses(self):
         changed = {"docs/README.md"}
         checks, focuses, lenses, profile = m.build_plan(changed)


### PR DESCRIPTION
## Summary
- teach  to accept the current Go explicit verifier-binding path
- keep the lint fail-closed by requiring both binding resolution and the  handoff
- add a unit test covering both the legacy direct-dispatch path and the current explicit-binding path

## Why
 validate is currently red on  because the policy checker still only recognizes the legacy direct OpenSSL dispatch shape, while  main already routes the Go verifier through  and .

This PR is tooling-only. It does not change runtime verification behavior.

## Validation
- 
- OK: crypto backend doc-policy + binding-policy checks passed.
- 
- 

Companion for: 2tbmz9y2xt-lang/rubin-spec#235