### PR TITLE
[Q-IMPL-ROTATION-LEGACY-EXPOSURE-CONTRACT-TYPING-01] Freeze typed legacy exposure report contract

### DIFF
--- a/clients/go/cmd/rubin-node/main_test.go
+++ b/clients/go/cmd/rubin-node/main_test.go
@@ -47,6 +47,24 @@ type legacyExposureReportJSON struct {
 	} `json:"legacy_suite_reports"`
 }
 
+type legacyExposureHookVectorsJSON struct {
+	ContractVersion uint64 `json:"contract_version"`
+	FixtureKind     string `json:"fixture_kind"`
+	Cases           []struct {
+		Name                string `json:"name"`
+		HasChainstateTip    bool   `json:"has_chainstate_tip"`
+		LegacyExposureTotal uint64 `json:"legacy_exposure_total"`
+		SunsetReadiness     string `json:"sunset_readiness"`
+		WarningHook         string `json:"warning_hook"`
+		GraceHook           string `json:"grace_hook"`
+	} `json:"cases"`
+}
+
+func legacyExposureContractRepoPath(parts ...string) string {
+	segments := append([]string{"..", "..", "..", ".."}, parts...)
+	return filepath.Join(segments...)
+}
+
 func mustCoreExtOpenSSLDigest32DescriptorHex(t *testing.T) string {
 	t.Helper()
 	descriptor, err := consensus.CoreExtOpenSSLDigest32BindingDescriptorBytes("ML-DSA-87", consensus.ML_DSA_87_PUBKEY_BYTES, consensus.ML_DSA_87_SIG_BYTES)
@@ -149,31 +167,22 @@ func TestLegacyExposureHooksWithTipNonZeroTotalReturnsNotReady(t *testing.T) {
 }
 
 func TestLegacyExposureHookVectorsFixtureParity(t *testing.T) {
-	fixturePath := filepath.Join("..", "..", "..", "..", "conformance", "fixtures", "protocol", "legacy_exposure_hook_vectors.json")
-	raw, err := os.ReadFile(fixturePath)
+	raw, err := os.ReadFile(legacyExposureContractRepoPath("conformance", "fixtures", "protocol", "legacy_exposure_hook_vectors.json"))
 	if err != nil {
-		t.Fatalf("hook vectors fixture required for parity lock (read %s: %v)", fixturePath, err)
+		t.Fatalf("ReadFile(hook vectors): %v", err)
 	}
-	var doc struct {
-		ContractVersion int    `json:"contract_version"`
-		FixtureKind     string `json:"fixture_kind"`
-		Cases           []struct {
-			Name                string `json:"name"`
-			HasChainstateTip    bool   `json:"has_chainstate_tip"`
-			LegacyExposureTotal uint64 `json:"legacy_exposure_total"`
-			SunsetReadiness     string `json:"sunset_readiness"`
-			WarningHook         string `json:"warning_hook"`
-			GraceHook           string `json:"grace_hook"`
-		} `json:"cases"`
-	}
+	var doc legacyExposureHookVectorsJSON
 	if err := json.Unmarshal(raw, &doc); err != nil {
-		t.Fatalf("unmarshal hook vectors: %v", err)
+		t.Fatalf("json.Unmarshal(hook vectors): %v", err)
 	}
-	if doc.ContractVersion != 1 {
-		t.Fatalf("contract_version=%d, want 1", doc.ContractVersion)
+	if doc.ContractVersion != legacyExposureReportVersion {
+		t.Fatalf("contract_version=%d, want %d", doc.ContractVersion, legacyExposureReportVersion)
 	}
 	if doc.FixtureKind != "legacy_exposure_hook_vectors" {
 		t.Fatalf("fixture_kind=%q, want legacy_exposure_hook_vectors", doc.FixtureKind)
+	}
+	if len(doc.Cases) == 0 {
+		t.Fatalf("expected at least one hook vector")
 	}
 	for _, c := range doc.Cases {
 		t.Run(c.Name, func(t *testing.T) {
@@ -188,6 +197,54 @@ func TestLegacyExposureHookVectorsFixtureParity(t *testing.T) {
 				t.Fatalf("grace_hook=%q, want %q", g, c.GraceHook)
 			}
 		})
+	}
+}
+
+func TestLegacyExposureExampleFixtureMatchesFrozenContract(t *testing.T) {
+	raw, err := os.ReadFile(legacyExposureContractRepoPath("conformance", "fixtures", "protocol", "legacy_exposure_report_v1_example.json"))
+	if err != nil {
+		t.Fatalf("ReadFile(example fixture): %v", err)
+	}
+	var report legacyExposureReportJSON
+	if err := json.Unmarshal(raw, &report); err != nil {
+		t.Fatalf("json.Unmarshal(example fixture): %v", err)
+	}
+	if report.ReportVersion != legacyExposureReportVersion {
+		t.Fatalf("report_version=%d, want %d", report.ReportVersion, legacyExposureReportVersion)
+	}
+	if report.MeasurementScope != "explicit_suite_id_utxos" {
+		t.Fatalf("measurement_scope=%q", report.MeasurementScope)
+	}
+	if report.Network != "devnet" {
+		t.Fatalf("network=%q, want devnet", report.Network)
+	}
+	if !report.ChainstateHasTip {
+		t.Fatalf("expected chainstate_has_tip=true")
+	}
+	if report.LegacyExposureTotal != 3 {
+		t.Fatalf("legacy_exposure_total=%d, want 3", report.LegacyExposureTotal)
+	}
+	if report.IncludeOutpoints {
+		t.Fatalf("expected include_outpoints=false")
+	}
+	if !reflect.DeepEqual(report.IndexedSuiteIDs, []uint8{consensus.SUITE_ID_ML_DSA_87, 0x42}) {
+		t.Fatalf("indexed_suite_ids=%v", report.IndexedSuiteIDs)
+	}
+	if !reflect.DeepEqual(report.WatchedLegacySuiteIDs, []uint8{consensus.SUITE_ID_ML_DSA_87, 0x42}) {
+		t.Fatalf("watched_legacy_suite_ids=%v", report.WatchedLegacySuiteIDs)
+	}
+	if len(report.LegacySuiteReports) != 2 {
+		t.Fatalf("legacy_suite_reports=%d, want 2", len(report.LegacySuiteReports))
+	}
+	readiness, warning, grace := legacyExposureHooks(report.ChainstateHasTip, report.LegacyExposureTotal)
+	if report.SunsetReadiness != readiness {
+		t.Fatalf("sunset_readiness=%q, want %q", report.SunsetReadiness, readiness)
+	}
+	if report.WarningHook != warning {
+		t.Fatalf("warning_hook=%q, want %q", report.WarningHook, warning)
+	}
+	if report.GraceHook != grace {
+		t.Fatalf("grace_hook=%q, want %q", report.GraceHook, grace)
 	}
 }
 

--- a/clients/rust/crates/rubin-node/src/main.rs
+++ b/clients/rust/crates/rubin-node/src/main.rs
@@ -17,7 +17,7 @@ use rubin_node::{
     start_node_p2p_service, BlockStore, LoadedGenesisConfig, Miner, MinerConfig,
     NodeP2PServiceConfig, PeerManager, SyncEngine,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct CliConfig {
@@ -56,7 +56,7 @@ struct EffectiveConfig {
     pv_shadow_max: u64,
 }
 
-#[derive(Serialize)]
+#[derive(Deserialize, Serialize)]
 struct LegacyExposureSuiteReport {
     suite_id: u64,
     utxo_exposure_count: u64,
@@ -65,7 +65,7 @@ struct LegacyExposureSuiteReport {
     outpoints: Option<Vec<String>>,
 }
 
-#[derive(Serialize)]
+#[derive(Deserialize, Serialize)]
 struct LegacyExposureReport {
     report_version: u64,
     measurement_scope: String,
@@ -839,10 +839,25 @@ mod tests {
     use rubin_consensus::constants::{
         ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES, VERIFY_COST_ML_DSA_87,
     };
-    use serde_json::Value;
-
     use super::{legacy_exposure_hooks, parse_args, run, runtime_genesis_hash, validate_config};
     use rubin_node::{load_genesis_config, PRODUCTION_LOCAL_ROTATION_DESCRIPTOR_ERR};
+
+    #[derive(serde::Deserialize)]
+    struct LegacyExposureHookVectorsDoc {
+        contract_version: u64,
+        fixture_kind: String,
+        cases: Vec<LegacyExposureHookVectorCase>,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct LegacyExposureHookVectorCase {
+        name: String,
+        has_chainstate_tip: bool,
+        legacy_exposure_total: u64,
+        sunset_readiness: String,
+        warning_hook: String,
+        grace_hook: String,
+    }
 
     struct FailingWriter;
 
@@ -864,6 +879,12 @@ mod tests {
                 .expect("time")
                 .as_nanos()
         ))
+    }
+
+    fn legacy_exposure_contract_repo_path(rel: &str) -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../../../")
+            .join(rel)
     }
 
     fn canonical_suite_registry_entry_json(suite_id: u8) -> String {
@@ -919,49 +940,46 @@ mod tests {
 
     #[test]
     fn legacy_exposure_hook_vectors_fixture_parity() {
-        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .join("../../../../conformance/fixtures/protocol/legacy_exposure_hook_vectors.json");
-        let raw =
-            fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
-        let doc: Value = serde_json::from_str(&raw).expect("hook vectors json");
-        assert_eq!(
-            doc["contract_version"].as_u64(),
-            Some(1),
-            "unexpected contract_version in {}",
-            path.display()
+        let path = legacy_exposure_contract_repo_path(
+            "conformance/fixtures/protocol/legacy_exposure_hook_vectors.json",
         );
-        assert_eq!(
-            doc["fixture_kind"].as_str(),
-            Some("legacy_exposure_hook_vectors"),
-            "unexpected fixture_kind in {}",
-            path.display()
-        );
-        let cases = doc["cases"].as_array().expect("cases array");
-        for c in cases {
-            let name = c["name"].as_str().expect("case name");
-            let has_tip = c["has_chainstate_tip"]
-                .as_bool()
-                .expect("has_chainstate_tip");
-            let total = c["legacy_exposure_total"]
-                .as_u64()
-                .expect("legacy_exposure_total");
-            let (r, w, g) = legacy_exposure_hooks(has_tip, total);
-            assert_eq!(
-                r,
-                c["sunset_readiness"].as_str().expect("sunset_readiness"),
-                "case {name}"
-            );
-            assert_eq!(
-                w,
-                c["warning_hook"].as_str().expect("warning_hook"),
-                "case {name}"
-            );
-            assert_eq!(
-                g,
-                c["grace_hook"].as_str().expect("grace_hook"),
-                "case {name}"
-            );
+        let raw = fs::read_to_string(&path).expect("read hook vectors");
+        let doc: LegacyExposureHookVectorsDoc =
+            serde_json::from_str(&raw).expect("parse hook vectors");
+        assert_eq!(doc.contract_version, super::LEGACY_EXPOSURE_REPORT_VERSION);
+        assert_eq!(doc.fixture_kind, "legacy_exposure_hook_vectors");
+        assert!(!doc.cases.is_empty(), "expected at least one hook vector");
+        for vector in doc.cases {
+            let (readiness, warning, grace) =
+                legacy_exposure_hooks(vector.has_chainstate_tip, vector.legacy_exposure_total);
+            assert_eq!(readiness, vector.sunset_readiness, "{}", vector.name);
+            assert_eq!(warning, vector.warning_hook, "{}", vector.name);
+            assert_eq!(grace, vector.grace_hook, "{}", vector.name);
         }
+    }
+
+    #[test]
+    fn legacy_exposure_example_fixture_matches_frozen_contract() {
+        let path = legacy_exposure_contract_repo_path(
+            "conformance/fixtures/protocol/legacy_exposure_report_v1_example.json",
+        );
+        let raw = fs::read(&path).expect("read example fixture");
+        let report: LegacyExposureReport =
+            serde_json::from_slice(&raw).expect("parse example fixture");
+        assert_eq!(report.report_version, super::LEGACY_EXPOSURE_REPORT_VERSION);
+        assert_eq!(report.measurement_scope, "explicit_suite_id_utxos");
+        assert_eq!(report.network, "devnet");
+        assert!(report.chainstate_has_tip);
+        assert_eq!(report.legacy_exposure_total, 3);
+        assert!(!report.include_outpoints);
+        assert_eq!(report.indexed_suite_ids, vec![1, 66]);
+        assert_eq!(report.watched_legacy_suite_ids, vec![1, 66]);
+        assert_eq!(report.legacy_suite_reports.len(), 2);
+        let (readiness, warning, grace) =
+            legacy_exposure_hooks(report.chainstate_has_tip, report.legacy_exposure_total);
+        assert_eq!(report.sunset_readiness, readiness);
+        assert_eq!(report.warning_hook, warning);
+        assert_eq!(report.grace_hook, grace);
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/main.rs
+++ b/clients/rust/crates/rubin-node/src/main.rs
@@ -836,11 +836,15 @@ mod tests {
     use std::io;
     use std::path::PathBuf;
 
+    use super::{
+        legacy_exposure_hooks, parse_args, run, runtime_genesis_hash, validate_config,
+        LegacyExposureReport,
+    };
     use rubin_consensus::constants::{
         ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES, VERIFY_COST_ML_DSA_87,
     };
-    use super::{legacy_exposure_hooks, parse_args, run, runtime_genesis_hash, validate_config};
     use rubin_node::{load_genesis_config, PRODUCTION_LOCAL_ROTATION_DESCRIPTOR_ERR};
+    use serde_json::Value;
 
     #[derive(serde::Deserialize)]
     struct LegacyExposureHookVectorsDoc {

--- a/clients/rust/crates/rubin-node/src/main.rs
+++ b/clients/rust/crates/rubin-node/src/main.rs
@@ -841,7 +841,7 @@ mod tests {
         LegacyExposureReport,
     };
     use rubin_consensus::constants::{
-        ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES, VERIFY_COST_ML_DSA_87,
+        ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES, SUITE_ID_ML_DSA_87, VERIFY_COST_ML_DSA_87,
     };
     use rubin_node::{load_genesis_config, PRODUCTION_LOCAL_ROTATION_DESCRIPTOR_ERR};
     use serde_json::Value;
@@ -976,8 +976,14 @@ mod tests {
         assert!(report.chainstate_has_tip);
         assert_eq!(report.legacy_exposure_total, 3);
         assert!(!report.include_outpoints);
-        assert_eq!(report.indexed_suite_ids, vec![1, 66]);
-        assert_eq!(report.watched_legacy_suite_ids, vec![1, 66]);
+        assert_eq!(
+            report.indexed_suite_ids,
+            vec![u64::from(SUITE_ID_ML_DSA_87), 66]
+        );
+        assert_eq!(
+            report.watched_legacy_suite_ids,
+            vec![u64::from(SUITE_ID_ML_DSA_87), 66]
+        );
         assert_eq!(report.legacy_suite_reports.len(), 2);
         let (readiness, warning, grace) =
             legacy_exposure_hooks(report.chainstate_has_tip, report.legacy_exposure_total);

--- a/conformance/fixtures/protocol/legacy_exposure_report_v1_example.json
+++ b/conformance/fixtures/protocol/legacy_exposure_report_v1_example.json
@@ -2,21 +2,26 @@
   "report_version": 1,
   "measurement_scope": "explicit_suite_id_utxos",
   "network": "devnet",
-  "data_dir": "/tmp/example-datadir",
-  "chainstate_height": 1,
+  "data_dir": "/var/lib/rubin/devnet",
+  "chainstate_height": 42,
   "chainstate_has_tip": true,
   "indexed_suite_ids": [1, 66],
-  "watched_legacy_suite_ids": [1],
-  "legacy_exposure_total": 0,
-  "sunset_readiness": "ready_for_operator_defined_grace_window",
-  "warning_hook": "none",
-  "grace_hook": "start_operator_defined_grace_window",
+  "watched_legacy_suite_ids": [1, 66],
+  "legacy_exposure_total": 3,
+  "sunset_readiness": "not_ready_legacy_exposure_present",
+  "warning_hook": "legacy_exposure_present_notify_operator_and_council",
+  "grace_hook": "not_applicable_legacy_exposure_present",
   "include_outpoints": false,
   "legacy_suite_reports": [
     {
       "suite_id": 1,
-      "utxo_exposure_count": 0,
-      "outpoint_count": 0
+      "utxo_exposure_count": 1,
+      "outpoint_count": 1
+    },
+    {
+      "suite_id": 66,
+      "utxo_exposure_count": 2,
+      "outpoint_count": 2
     }
   ]
 }

--- a/conformance/schemas/legacy_exposure_report_v1.json
+++ b/conformance/schemas/legacy_exposure_report_v1.json
@@ -30,27 +30,48 @@
       "type": "string",
       "const": "explicit_suite_id_utxos"
     },
-    "network": { "type": "string" },
+    "network": {
+      "type": "string",
+      "minLength": 1
+    },
     "data_dir": {
       "type": "string",
+      "minLength": 1,
       "description": "CLI --datadir as passed to the scanner (verbatim; may be relative; not canonicalized in current implementations)"
     },
-    "chainstate_height": { "type": "integer", "minimum": 0 },
-    "chainstate_has_tip": { "type": "boolean" },
+    "chainstate_height": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "chainstate_has_tip": {
+      "type": "boolean",
+      "description": "Successful scanner runs emit true; false is retained only for hook-helper/conformance parity."
+    },
     "indexed_suite_ids": {
       "type": "array",
-      "description": "Set-like list of indexed suite IDs (no duplicates); order is implementation-defined.",
-      "items": { "type": "integer", "minimum": 0, "maximum": 255 },
+      "description": "Set-like list of indexed suite IDs serialized as JSON integers in the range 0..255.",
+      "items": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 255
+      },
       "uniqueItems": true
     },
     "watched_legacy_suite_ids": {
       "type": "array",
       "description": "Non-empty deduplicated sorted suite IDs from CLI --legacy-suite-id (scanner requires at least one).",
       "minItems": 1,
-      "uniqueItems": true,
-      "items": { "type": "integer", "minimum": 0, "maximum": 255 }
+      "items": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 255
+      },
+      "uniqueItems": true
     },
-    "legacy_exposure_total": { "type": "integer", "minimum": 0 },
+    "legacy_exposure_total": {
+      "type": "integer",
+      "minimum": 0
+    },
     "sunset_readiness": {
       "type": "string",
       "enum": [
@@ -61,7 +82,10 @@
     },
     "warning_hook": {
       "type": "string",
-      "enum": ["none", "legacy_exposure_present_notify_operator_and_council"]
+      "enum": [
+        "none",
+        "legacy_exposure_present_notify_operator_and_council"
+      ]
     },
     "grace_hook": {
       "type": "string",
@@ -71,7 +95,9 @@
         "not_applicable_legacy_exposure_present"
       ]
     },
-    "include_outpoints": { "type": "boolean" },
+    "include_outpoints": {
+      "type": "boolean"
+    },
     "legacy_suite_reports": {
       "type": "array",
       "minItems": 1,
@@ -80,7 +106,13 @@
   },
   "allOf": [
     {
-      "if": { "properties": { "include_outpoints": { "const": false } } },
+      "if": {
+        "properties": {
+          "include_outpoints": {
+            "const": false
+          }
+        }
+      },
       "then": {
         "properties": {
           "legacy_suite_reports": {
@@ -89,11 +121,37 @@
             "items": {
               "type": "object",
               "additionalProperties": false,
-              "required": ["suite_id", "utxo_exposure_count", "outpoint_count"],
+              "required": [
+                "suite_id",
+                "utxo_exposure_count",
+                "outpoint_count"
+              ],
               "properties": {
-                "suite_id": { "type": "integer", "minimum": 0, "maximum": 255 },
-                "utxo_exposure_count": { "type": "integer", "minimum": 0 },
-                "outpoint_count": { "type": "integer", "minimum": 0 }
+                "suite_id": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 255
+                },
+                "utxo_exposure_count": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "outpoint_count": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "outpoints": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "pattern": "^[0-9a-f]{64}:[0-9]+$"
+                  }
+                }
+              },
+              "not": {
+                "required": [
+                  "outpoints"
+                ]
               }
             }
           }
@@ -101,7 +159,13 @@
       }
     },
     {
-      "if": { "properties": { "include_outpoints": { "const": true } } },
+      "if": {
+        "properties": {
+          "include_outpoints": {
+            "const": true
+          }
+        }
+      },
       "then": {
         "properties": {
           "legacy_suite_reports": {
@@ -110,11 +174,26 @@
             "items": {
               "type": "object",
               "additionalProperties": false,
-              "required": ["suite_id", "utxo_exposure_count", "outpoint_count", "outpoints"],
+              "required": [
+                "suite_id",
+                "utxo_exposure_count",
+                "outpoint_count",
+                "outpoints"
+              ],
               "properties": {
-                "suite_id": { "type": "integer", "minimum": 0, "maximum": 255 },
-                "utxo_exposure_count": { "type": "integer", "minimum": 0 },
-                "outpoint_count": { "type": "integer", "minimum": 0 },
+                "suite_id": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 255
+                },
+                "utxo_exposure_count": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "outpoint_count": {
+                  "type": "integer",
+                  "minimum": 0
+                },
                 "outpoints": {
                   "type": "array",
                   "items": {

--- a/conformance/schemas/legacy_exposure_report_v1.json
+++ b/conformance/schemas/legacy_exposure_report_v1.json
@@ -49,7 +49,7 @@
     },
     "indexed_suite_ids": {
       "type": "array",
-      "description": "Set-like list of indexed suite IDs serialized as JSON integers in the range 0..255.",
+      "description": "Unique indexed suite IDs serialized as JSON integers in the range 0..255 and emitted in ascending numeric order.",
       "items": {
         "type": "integer",
         "minimum": 0,

--- a/scripts/rotation/LEGACY_EXPOSURE_REPORT_CONTRACT_V1.md
+++ b/scripts/rotation/LEGACY_EXPOSURE_REPORT_CONTRACT_V1.md
@@ -34,7 +34,7 @@ All top-level keys are required in emitted output (pretty-printed deterministic 
 | `data_dir` | string | `--datadir` value as passed to the CLI for this scan (verbatim; not canonicalized to an absolute path and may be relative) |
 | `chainstate_height` | integer | Height from loaded chainstate |
 | `chainstate_has_tip` | boolean | Whether chainstate reports a tip. Successful scanner runs that emit JSON reports use `true`; the `false` row is retained only for shared hook-helper and conformance parity |
-| `indexed_suite_ids` | array of JSON integers | Suite IDs present in explicit UTXO index; values are byte-sized suite ids in the range `0..255`; no duplicates (set-like) |
+| `indexed_suite_ids` | array of JSON integers | Suite IDs present in explicit UTXO index; values are byte-sized suite ids in the range `0..255`; unique and emitted in ascending numeric order |
 | `watched_legacy_suite_ids` | array of JSON integers | Non-empty sorted unique `--legacy-suite-id` values; values are byte-sized suite ids in the range `0..255` and the scanner requires at least one id |
 | `legacy_exposure_total` | integer | Sum of exposure counts across watched legacy suite IDs |
 | `sunset_readiness` | string | Advisory readiness label (see hooks below) |

--- a/scripts/rotation/LEGACY_EXPOSURE_REPORT_CONTRACT_V1.md
+++ b/scripts/rotation/LEGACY_EXPOSURE_REPORT_CONTRACT_V1.md
@@ -17,14 +17,14 @@ CI (`tools/check_legacy_exposure_report_contract.py`) validates the example agai
 
 Any change to top-level keys, hook string values, or `measurement_scope`/`report_version` semantics requires:
 
-1. Bumping `report_version` in Go (`legacyExposureReportVersion`) and Rust (`LEGACY_EXPOSURE_REPORT_VERSION`) together  
-2. Updating the JSON Schema and example fixture  
-3. Updating this document and `scripts/rotation/LEGACY_EXPOSURE_RUNBOOK.md`  
+1. Bumping `report_version` in Go (`legacyExposureReportVersion`) and Rust (`LEGACY_EXPOSURE_REPORT_VERSION`) together
+2. Updating the JSON Schema and example fixture
+3. Updating this document and `scripts/rotation/LEGACY_EXPOSURE_RUNBOOK.md`
 4. Refreshing the orchestration evidence pointer under `rubin-orchestration-private` (see that repo)
 
 ## Top-level JSON fields (v1)
 
-All keys are required in emitted output (pretty-printed deterministic JSON).
+All top-level keys are required in emitted output (pretty-printed deterministic JSON).
 
 | JSON key | Type | Meaning |
 |----------|------|---------|
@@ -33,21 +33,21 @@ All keys are required in emitted output (pretty-printed deterministic JSON).
 | `network` | string | CLI `--network` value used for the scan |
 | `data_dir` | string | `--datadir` value as passed to the CLI for this scan (verbatim; not canonicalized to an absolute path and may be relative) |
 | `chainstate_height` | integer | Height from loaded chainstate |
-| `chainstate_has_tip` | boolean | Whether chainstate reports a tip |
-| `indexed_suite_ids` | array of integers | Suite IDs present in explicit UTXO index (0–255); no duplicates (set-like) |
-| `watched_legacy_suite_ids` | integer array | Non-empty sorted unique `--legacy-suite-id` values (0–255); scanner requires ≥1 id |
+| `chainstate_has_tip` | boolean | Whether chainstate reports a tip. Successful scanner runs that emit JSON reports use `true`; the `false` row is retained only for shared hook-helper and conformance parity |
+| `indexed_suite_ids` | array of JSON integers | Suite IDs present in explicit UTXO index; values are byte-sized suite ids in the range `0..255`; no duplicates (set-like) |
+| `watched_legacy_suite_ids` | array of JSON integers | Non-empty sorted unique `--legacy-suite-id` values; values are byte-sized suite ids in the range `0..255` and the scanner requires at least one id |
 | `legacy_exposure_total` | integer | Sum of exposure counts across watched legacy suite IDs |
 | `sunset_readiness` | string | Advisory readiness label (see hooks below) |
 | `warning_hook` | string | Advisory warning hook (see hooks below) |
 | `grace_hook` | string | Advisory grace-process hook (see hooks below) |
 | `include_outpoints` | boolean | Whether `--legacy-exposure-include-outpoints` was set |
-| `legacy_suite_reports` | array | Per-suite breakdown (non-empty: one entry per watched legacy suite id; see below) |
+| `legacy_suite_reports` | array | Non-empty per-suite breakdown (one object per watched legacy suite id; see below) |
 
 Per-suite objects:
 
 | Key | Type | Meaning |
 |-----|------|---------|
-| `suite_id` | integer | Watched legacy suite id |
+| `suite_id` | integer | Watched legacy suite id serialized as a JSON integer in the range `0..255` |
 | `utxo_exposure_count` | integer | Matching UTXO count for that suite |
 | `outpoint_count` | integer | Same as exposure count in current implementations |
 | `outpoints` | array of strings | Required when `include_outpoints` is true (may be empty); must be absent when false; each string is lowercase 64-hex txid, `:`, decimal vout (matches `formatLegacyExposureOutpoint` / Rust equivalent) |
@@ -58,7 +58,7 @@ Hooks are **advisory strings** for operators and council workflows. They do not 
 
 The implementation function is `legacyExposureHooks(has_chainstate_tip, legacy_exposure_total)` in Go and `legacy_exposure_hooks` in Rust. Inputs are:
 
-- `has_chainstate_tip`: from loaded chainstate (`chainstate_has_tip` in JSON)  
+- `has_chainstate_tip`: from loaded chainstate (`chainstate_has_tip` in JSON)
 - `legacy_exposure_total`: the scalar total in the report
 
 Canonical outputs are frozen in `conformance/fixtures/protocol/legacy_exposure_hook_vectors.json`. Go and Rust tests must stay aligned with that file.
@@ -66,14 +66,14 @@ Canonical outputs are frozen in `conformance/fixtures/protocol/legacy_exposure_h
 ### Truth table
 
 | `has_chainstate_tip` | `legacy_exposure_total` | `sunset_readiness` | `warning_hook` | `grace_hook` |
-|---------------------|-------------------------|--------------------|------------------|--------------|
+|---------------------|-------------------------|--------------------|----------------|--------------|
 | false | any | `invalid_no_chainstate_tip` | `none` | `not_applicable_no_chainstate_tip` |
 | true | 0 | `ready_for_operator_defined_grace_window` | `none` | `start_operator_defined_grace_window` |
 | true | > 0 | `not_ready_legacy_exposure_present` | `legacy_exposure_present_notify_operator_and_council` | `not_applicable_legacy_exposure_present` |
 
 ### Emitted JSON vs invalid scans
 
-Successful CLI runs that print JSON use a chainstate snapshot **with a tip**; scans without a tip or without chainstate exit with an error and do not emit this report. The `invalid_no_chainstate_tip` hook row exists for parity with the shared hook helper and for tests; operators should treat **successful** JSON as having `chainstate_has_tip == true` when following the runbook.
+Successful CLI runs that print JSON use a chainstate snapshot **with a tip**; scans without a tip or without chainstate exit with an error and do not emit this report. The `invalid_no_chainstate_tip` hook row exists only for parity with the shared hook helper and for conformance/tests; it is not an emitted scanner report state. Operators should therefore treat **successful** JSON as having `chainstate_has_tip == true` when following the runbook.
 
 ## Advisory disclaimer
 


### PR DESCRIPTION
## Summary
Freeze the missing legacy-exposure report contract package that orchestration already points at.

## Scope
- add the canonical human contract for `rubin-node --legacy-exposure-scan`
- add the v1 JSON schema, example report, and shared hook vectors
- add Go and Rust parity tests that replay the shared hook vocabulary
- keep the surface advisory-only; no governance threshold engine and no H4 redesign

## Checks
- go test ./cmd/rubin-node
- cargo test -p rubin-node legacy_exposure
- python3 JSON parse checks for schema/example/vectors
- local self-audit receipt PASS