### PR TITLE
Q-IMPL-ROTATION-NATIVE-RUNTIME-ALGNAME-RENAME-01: rename native runtime alg_name surface

### DIFF
--- a/clients/go/cmd/rubin-consensus-cli/runtime.go
+++ b/clients/go/cmd/rubin-consensus-cli/runtime.go
@@ -349,6 +349,7 @@ func (item SuiteParamsJSON) MarshalJSON() ([]byte, error) {
 
 const maxExplicitSuiteRegistryItems = 16
 const maxCoreExtHexFieldBytes = 4096
+const canonicalSuiteRegistryAlgName = "ML-DSA-87"
 
 func validateSuiteRegistryParamLen(value int) (int, error) {
 	if value < 0 || value > consensus.MAX_WITNESS_BYTES_PER_TX {
@@ -358,12 +359,11 @@ func validateSuiteRegistryParamLen(value int) (int, error) {
 }
 
 func normalizeSuiteRegistryAlgName(value string) (string, error) {
-	switch strings.TrimSpace(value) {
-	case "ML-DSA-87":
-		return "ML-DSA-87", nil
-	default:
+	trimmed := strings.TrimSpace(value)
+	if trimmed != canonicalSuiteRegistryAlgName {
 		return "", fmt.Errorf("bad suite_registry")
 	}
+	return canonicalSuiteRegistryAlgName, nil
 }
 
 func validateSuiteRegistryItem(item SuiteParamsJSON) (consensus.SuiteParams, error) {

--- a/clients/go/cmd/rubin-consensus-cli/runtime.go
+++ b/clients/go/cmd/rubin-consensus-cli/runtime.go
@@ -310,12 +310,12 @@ type SuiteParamsJSON struct {
 }
 
 type suiteParamsJSONWire struct {
-	SuiteID    uint8  `json:"suite_id"`
-	PubkeyLen  int    `json:"pubkey_len"`
-	SigLen     int    `json:"sig_len"`
-	VerifyCost uint64 `json:"verify_cost"`
-	AlgName    string `json:"alg_name,omitempty"`
-	OpenSSLAlg string `json:"openssl_alg,omitempty"`
+	SuiteID    uint8   `json:"suite_id"`
+	PubkeyLen  int     `json:"pubkey_len"`
+	SigLen     int     `json:"sig_len"`
+	VerifyCost uint64  `json:"verify_cost"`
+	AlgName    *string `json:"alg_name,omitempty"`
+	OpenSSLAlg *string `json:"openssl_alg,omitempty"`
 }
 
 func (item *SuiteParamsJSON) UnmarshalJSON(data []byte) error {
@@ -327,20 +327,23 @@ func (item *SuiteParamsJSON) UnmarshalJSON(data []byte) error {
 	item.PubkeyLen = wire.PubkeyLen
 	item.SigLen = wire.SigLen
 	item.VerifyCost = wire.VerifyCost
-	item.AlgName = wire.AlgName
-	if strings.TrimSpace(item.AlgName) == "" {
-		item.AlgName = wire.OpenSSLAlg
+	item.AlgName = ""
+	if wire.AlgName != nil {
+		item.AlgName = *wire.AlgName
+	} else if wire.OpenSSLAlg != nil {
+		item.AlgName = *wire.OpenSSLAlg
 	}
 	return nil
 }
 
 func (item SuiteParamsJSON) MarshalJSON() ([]byte, error) {
+	algName := item.AlgName
 	return json.Marshal(suiteParamsJSONWire{
 		SuiteID:    item.SuiteID,
 		PubkeyLen:  item.PubkeyLen,
 		SigLen:     item.SigLen,
 		VerifyCost: item.VerifyCost,
-		AlgName:    item.AlgName,
+		AlgName:    &algName,
 	})
 }
 
@@ -348,7 +351,7 @@ const maxExplicitSuiteRegistryItems = 16
 const maxCoreExtHexFieldBytes = 4096
 
 func validateSuiteRegistryParamLen(value int) (int, error) {
-	if value <= 0 || value > consensus.MAX_WITNESS_BYTES_PER_TX {
+	if value < 0 || value > consensus.MAX_WITNESS_BYTES_PER_TX {
 		return 0, fmt.Errorf("bad suite_registry")
 	}
 	return value, nil
@@ -378,11 +381,6 @@ func validateSuiteRegistryItem(item SuiteParamsJSON) (consensus.SuiteParams, err
 	algName, err := normalizeSuiteRegistryAlgName(item.AlgName)
 	if err != nil {
 		return consensus.SuiteParams{}, err
-	}
-	if pubkeyLen != consensus.ML_DSA_87_PUBKEY_BYTES ||
-		sigLen != consensus.ML_DSA_87_SIG_BYTES ||
-		item.VerifyCost != consensus.VERIFY_COST_ML_DSA_87 {
-		return consensus.SuiteParams{}, fmt.Errorf("bad suite_registry")
 	}
 	return consensus.SuiteParams{
 		SuiteID:    item.SuiteID,
@@ -516,6 +514,8 @@ func buildSuiteRegistry(items []SuiteParamsJSON) (*consensus.SuiteRegistry, erro
 	}
 	seen := make(map[uint8]struct{}, len(items))
 	params := make([]consensus.SuiteParams, 0, len(items))
+	// CLI suite_registry is a harness overlay: keep synthetic param shapes for
+	// conformance vectors, but normalize/validate the renamed alg_name surface.
 	for _, it := range items {
 		if _, ok := seen[it.SuiteID]; ok {
 			return nil, fmt.Errorf("bad suite_registry")

--- a/clients/go/cmd/rubin-consensus-cli/runtime.go
+++ b/clients/go/cmd/rubin-consensus-cli/runtime.go
@@ -306,7 +306,42 @@ type SuiteParamsJSON struct {
 	PubkeyLen  int    `json:"pubkey_len"`
 	SigLen     int    `json:"sig_len"`
 	VerifyCost uint64 `json:"verify_cost"`
-	OpenSSLAlg string `json:"openssl_alg"`
+	AlgName    string `json:"-"`
+}
+
+type suiteParamsJSONWire struct {
+	SuiteID    uint8  `json:"suite_id"`
+	PubkeyLen  int    `json:"pubkey_len"`
+	SigLen     int    `json:"sig_len"`
+	VerifyCost uint64 `json:"verify_cost"`
+	AlgName    string `json:"alg_name,omitempty"`
+	OpenSSLAlg string `json:"openssl_alg,omitempty"`
+}
+
+func (item *SuiteParamsJSON) UnmarshalJSON(data []byte) error {
+	var wire suiteParamsJSONWire
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return err
+	}
+	item.SuiteID = wire.SuiteID
+	item.PubkeyLen = wire.PubkeyLen
+	item.SigLen = wire.SigLen
+	item.VerifyCost = wire.VerifyCost
+	item.AlgName = wire.AlgName
+	if strings.TrimSpace(item.AlgName) == "" {
+		item.AlgName = wire.OpenSSLAlg
+	}
+	return nil
+}
+
+func (item SuiteParamsJSON) MarshalJSON() ([]byte, error) {
+	return json.Marshal(suiteParamsJSONWire{
+		SuiteID:    item.SuiteID,
+		PubkeyLen:  item.PubkeyLen,
+		SigLen:     item.SigLen,
+		VerifyCost: item.VerifyCost,
+		AlgName:    item.AlgName,
+	})
 }
 
 const maxCoreExtHexFieldBytes = 4096
@@ -436,7 +471,7 @@ func buildSuiteRegistry(items []SuiteParamsJSON) *consensus.SuiteRegistry {
 			PubkeyLen:  it.PubkeyLen,
 			SigLen:     it.SigLen,
 			VerifyCost: it.VerifyCost,
-			OpenSSLAlg: it.OpenSSLAlg,
+			AlgName:    it.AlgName,
 		})
 	}
 	return consensus.NewSuiteRegistryFromParams(params)

--- a/clients/go/cmd/rubin-consensus-cli/runtime.go
+++ b/clients/go/cmd/rubin-consensus-cli/runtime.go
@@ -311,8 +311,8 @@ type SuiteParamsJSON struct {
 
 type suiteParamsJSONWire struct {
 	SuiteID    *uint8  `json:"suite_id"`
-	PubkeyLen  *int    `json:"pubkey_len"`
-	SigLen     *int    `json:"sig_len"`
+	PubkeyLen  *uint64 `json:"pubkey_len"`
+	SigLen     *uint64 `json:"sig_len"`
 	VerifyCost *uint64 `json:"verify_cost"`
 	AlgName    *string `json:"alg_name,omitempty"`
 	OpenSSLAlg *string `json:"openssl_alg,omitempty"`
@@ -326,9 +326,13 @@ func (item *SuiteParamsJSON) UnmarshalJSON(data []byte) error {
 	if wire.SuiteID == nil || wire.PubkeyLen == nil || wire.SigLen == nil || wire.VerifyCost == nil {
 		return fmt.Errorf("bad suite_registry")
 	}
+	maxInt := int(^uint(0) >> 1)
+	if *wire.PubkeyLen > uint64(maxInt) || *wire.SigLen > uint64(maxInt) {
+		return fmt.Errorf("bad suite_registry")
+	}
 	item.SuiteID = *wire.SuiteID
-	item.PubkeyLen = *wire.PubkeyLen
-	item.SigLen = *wire.SigLen
+	item.PubkeyLen = int(*wire.PubkeyLen)
+	item.SigLen = int(*wire.SigLen)
 	item.VerifyCost = *wire.VerifyCost
 	item.AlgName = ""
 	if wire.AlgName != nil {
@@ -341,8 +345,8 @@ func (item *SuiteParamsJSON) UnmarshalJSON(data []byte) error {
 
 func (item SuiteParamsJSON) MarshalJSON() ([]byte, error) {
 	suiteID := item.SuiteID
-	pubkeyLen := item.PubkeyLen
-	sigLen := item.SigLen
+	pubkeyLen := uint64(item.PubkeyLen)
+	sigLen := uint64(item.SigLen)
 	verifyCost := item.VerifyCost
 	algName := item.AlgName
 	return json.Marshal(suiteParamsJSONWire{
@@ -359,6 +363,9 @@ const maxCoreExtHexFieldBytes = 4096
 const canonicalSuiteRegistryAlgName = "ML-DSA-87"
 
 func validateSuiteRegistryParamLen(value int) (int, error) {
+	// Negative lengths fail closed during JSON decode because the wire surface
+	// uses unsigned lengths. Reaching this helper means the caller provided an
+	// in-range int value, and explicit zero remains reserved for harness vectors.
 	if value < 0 || value > consensus.MAX_WITNESS_BYTES_PER_TX {
 		return 0, fmt.Errorf("bad suite_registry")
 	}
@@ -367,7 +374,7 @@ func validateSuiteRegistryParamLen(value int) (int, error) {
 
 func normalizeSuiteRegistryAlgName(value string) (string, error) {
 	trimmed := strings.TrimSpace(value)
-	if trimmed != canonicalSuiteRegistryAlgName {
+	if !strings.EqualFold(trimmed, canonicalSuiteRegistryAlgName) {
 		return "", fmt.Errorf("bad suite_registry")
 	}
 	return canonicalSuiteRegistryAlgName, nil

--- a/clients/go/cmd/rubin-consensus-cli/runtime.go
+++ b/clients/go/cmd/rubin-consensus-cli/runtime.go
@@ -379,6 +379,11 @@ func validateSuiteRegistryItem(item SuiteParamsJSON) (consensus.SuiteParams, err
 	if err != nil {
 		return consensus.SuiteParams{}, err
 	}
+	if pubkeyLen != consensus.ML_DSA_87_PUBKEY_BYTES ||
+		sigLen != consensus.ML_DSA_87_SIG_BYTES ||
+		item.VerifyCost != consensus.VERIFY_COST_ML_DSA_87 {
+		return consensus.SuiteParams{}, fmt.Errorf("bad suite_registry")
+	}
 	return consensus.SuiteParams{
 		SuiteID:    item.SuiteID,
 		PubkeyLen:  pubkeyLen,

--- a/clients/go/cmd/rubin-consensus-cli/runtime.go
+++ b/clients/go/cmd/rubin-consensus-cli/runtime.go
@@ -344,7 +344,49 @@ func (item SuiteParamsJSON) MarshalJSON() ([]byte, error) {
 	})
 }
 
+const maxExplicitSuiteRegistryItems = 16
 const maxCoreExtHexFieldBytes = 4096
+
+func validateSuiteRegistryParamLen(value int) (int, error) {
+	if value <= 0 || value > consensus.MAX_WITNESS_BYTES_PER_TX {
+		return 0, fmt.Errorf("bad suite_registry")
+	}
+	return value, nil
+}
+
+func normalizeSuiteRegistryAlgName(value string) (string, error) {
+	switch strings.TrimSpace(value) {
+	case "ML-DSA-87":
+		return "ML-DSA-87", nil
+	default:
+		return "", fmt.Errorf("bad suite_registry")
+	}
+}
+
+func validateSuiteRegistryItem(item SuiteParamsJSON) (consensus.SuiteParams, error) {
+	if item.SuiteID == consensus.SUITE_ID_SENTINEL || item.VerifyCost == 0 {
+		return consensus.SuiteParams{}, fmt.Errorf("bad suite_registry")
+	}
+	pubkeyLen, err := validateSuiteRegistryParamLen(item.PubkeyLen)
+	if err != nil {
+		return consensus.SuiteParams{}, err
+	}
+	sigLen, err := validateSuiteRegistryParamLen(item.SigLen)
+	if err != nil {
+		return consensus.SuiteParams{}, err
+	}
+	algName, err := normalizeSuiteRegistryAlgName(item.AlgName)
+	if err != nil {
+		return consensus.SuiteParams{}, err
+	}
+	return consensus.SuiteParams{
+		SuiteID:    item.SuiteID,
+		PubkeyLen:  pubkeyLen,
+		SigLen:     sigLen,
+		VerifyCost: item.VerifyCost,
+		AlgName:    algName,
+	}, nil
+}
 
 func parseOptionalHexBytes(name, value string) ([]byte, error) {
 	value = strings.TrimSpace(value)
@@ -460,25 +502,34 @@ type ForkChoiceChain struct {
 	Targets []string `json:"targets"`
 }
 
-func buildSuiteRegistry(items []SuiteParamsJSON) *consensus.SuiteRegistry {
+func buildSuiteRegistry(items []SuiteParamsJSON) (*consensus.SuiteRegistry, error) {
 	if len(items) == 0 {
-		return nil
+		return nil, nil
 	}
+	if len(items) > maxExplicitSuiteRegistryItems {
+		return nil, fmt.Errorf("bad suite_registry")
+	}
+	seen := make(map[uint8]struct{}, len(items))
 	params := make([]consensus.SuiteParams, 0, len(items))
 	for _, it := range items {
-		params = append(params, consensus.SuiteParams{
-			SuiteID:    it.SuiteID,
-			PubkeyLen:  it.PubkeyLen,
-			SigLen:     it.SigLen,
-			VerifyCost: it.VerifyCost,
-			AlgName:    it.AlgName,
-		})
+		if _, ok := seen[it.SuiteID]; ok {
+			return nil, fmt.Errorf("bad suite_registry")
+		}
+		seen[it.SuiteID] = struct{}{}
+		param, err := validateSuiteRegistryItem(it)
+		if err != nil {
+			return nil, err
+		}
+		params = append(params, param)
 	}
-	return consensus.NewSuiteRegistryFromParams(params)
+	return consensus.NewSuiteRegistryFromParams(params), nil
 }
 
 func buildCoreExtSuiteContext(req Request) (consensus.RotationProvider, *consensus.SuiteRegistry, error) {
-	reg := buildSuiteRegistry(req.SuiteRegistry)
+	reg, err := buildSuiteRegistry(req.SuiteRegistry)
+	if err != nil {
+		return nil, nil, err
+	}
 	if req.RotationDescriptor == nil {
 		return nil, reg, nil
 	}
@@ -1109,7 +1160,11 @@ func runFromStdin() {
 			return
 		}
 		if req.RotationDescriptor != nil && len(req.SuiteRegistry) > 0 {
-			reg := buildSuiteRegistry(req.SuiteRegistry)
+			reg, err := buildSuiteRegistry(req.SuiteRegistry)
+			if err != nil {
+				writeResp(os.Stdout, Response{Ok: false, Err: "bad suite_registry"})
+				return
+			}
 			desc := consensus.CryptoRotationDescriptor{
 				Name:         req.RotationDescriptor.Name,
 				OldSuiteID:   req.RotationDescriptor.OldSuiteID,
@@ -1139,7 +1194,11 @@ func runFromStdin() {
 			writeResp(os.Stdout, Response{Ok: false, Err: "bad rotation_descriptor"})
 			return
 		}
-		reg := buildSuiteRegistry(req.SuiteRegistry)
+		reg, err := buildSuiteRegistry(req.SuiteRegistry)
+		if err != nil {
+			writeResp(os.Stdout, Response{Ok: false, Err: "bad suite_registry"})
+			return
+		}
 		desc := consensus.CryptoRotationDescriptor{
 			Name:         req.RotationDescriptor.Name,
 			OldSuiteID:   req.RotationDescriptor.OldSuiteID,
@@ -1166,7 +1225,11 @@ func runFromStdin() {
 			writeResp(os.Stdout, Response{Ok: false, Err: "bad rotation_descriptor"})
 			return
 		}
-		reg := buildSuiteRegistry(req.SuiteRegistry)
+		reg, err := buildSuiteRegistry(req.SuiteRegistry)
+		if err != nil {
+			writeResp(os.Stdout, Response{Ok: false, Err: "bad suite_registry"})
+			return
+		}
 		desc := consensus.CryptoRotationDescriptor{
 			Name:         req.RotationDescriptor.Name,
 			OldSuiteID:   req.RotationDescriptor.OldSuiteID,
@@ -1188,7 +1251,11 @@ func runFromStdin() {
 			writeResp(os.Stdout, Response{Ok: false, Err: "bad rotation_descriptor"})
 			return
 		}
-		reg := buildSuiteRegistry(req.SuiteRegistry)
+		reg, err := buildSuiteRegistry(req.SuiteRegistry)
+		if err != nil {
+			writeResp(os.Stdout, Response{Ok: false, Err: "bad suite_registry"})
+			return
+		}
 		desc := consensus.CryptoRotationDescriptor{
 			Name:         req.RotationDescriptor.Name,
 			OldSuiteID:   req.RotationDescriptor.OldSuiteID,
@@ -1211,7 +1278,11 @@ func runFromStdin() {
 		return
 
 	case "rotation_descriptor_check":
-		reg := buildSuiteRegistry(req.SuiteRegistry)
+		reg, err := buildSuiteRegistry(req.SuiteRegistry)
+		if err != nil {
+			writeResp(os.Stdout, Response{Ok: false, Err: "bad suite_registry"})
+			return
+		}
 		if len(req.RotationDescriptors) > 0 {
 			ds := make([]consensus.CryptoRotationDescriptor, 0, len(req.RotationDescriptors))
 			for _, rd := range req.RotationDescriptors {

--- a/clients/go/cmd/rubin-consensus-cli/runtime.go
+++ b/clients/go/cmd/rubin-consensus-cli/runtime.go
@@ -310,10 +310,10 @@ type SuiteParamsJSON struct {
 }
 
 type suiteParamsJSONWire struct {
-	SuiteID    uint8   `json:"suite_id"`
-	PubkeyLen  int     `json:"pubkey_len"`
-	SigLen     int     `json:"sig_len"`
-	VerifyCost uint64  `json:"verify_cost"`
+	SuiteID    *uint8  `json:"suite_id"`
+	PubkeyLen  *int    `json:"pubkey_len"`
+	SigLen     *int    `json:"sig_len"`
+	VerifyCost *uint64 `json:"verify_cost"`
 	AlgName    *string `json:"alg_name,omitempty"`
 	OpenSSLAlg *string `json:"openssl_alg,omitempty"`
 }
@@ -323,10 +323,13 @@ func (item *SuiteParamsJSON) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &wire); err != nil {
 		return err
 	}
-	item.SuiteID = wire.SuiteID
-	item.PubkeyLen = wire.PubkeyLen
-	item.SigLen = wire.SigLen
-	item.VerifyCost = wire.VerifyCost
+	if wire.SuiteID == nil || wire.PubkeyLen == nil || wire.SigLen == nil || wire.VerifyCost == nil {
+		return fmt.Errorf("bad suite_registry")
+	}
+	item.SuiteID = *wire.SuiteID
+	item.PubkeyLen = *wire.PubkeyLen
+	item.SigLen = *wire.SigLen
+	item.VerifyCost = *wire.VerifyCost
 	item.AlgName = ""
 	if wire.AlgName != nil {
 		item.AlgName = *wire.AlgName
@@ -337,12 +340,16 @@ func (item *SuiteParamsJSON) UnmarshalJSON(data []byte) error {
 }
 
 func (item SuiteParamsJSON) MarshalJSON() ([]byte, error) {
+	suiteID := item.SuiteID
+	pubkeyLen := item.PubkeyLen
+	sigLen := item.SigLen
+	verifyCost := item.VerifyCost
 	algName := item.AlgName
 	return json.Marshal(suiteParamsJSONWire{
-		SuiteID:    item.SuiteID,
-		PubkeyLen:  item.PubkeyLen,
-		SigLen:     item.SigLen,
-		VerifyCost: item.VerifyCost,
+		SuiteID:    &suiteID,
+		PubkeyLen:  &pubkeyLen,
+		SigLen:     &sigLen,
+		VerifyCost: &verifyCost,
 		AlgName:    &algName,
 	})
 }
@@ -382,6 +389,9 @@ func validateSuiteRegistryItem(item SuiteParamsJSON) (consensus.SuiteParams, err
 	if err != nil {
 		return consensus.SuiteParams{}, err
 	}
+	// Required JSON field presence is enforced in UnmarshalJSON. Reaching this
+	// point means explicit zero values came from the caller intentionally, which
+	// the CLI harness still allows for synthetic conformance vectors.
 	return consensus.SuiteParams{
 		SuiteID:    item.SuiteID,
 		PubkeyLen:  pubkeyLen,

--- a/clients/go/cmd/rubin-consensus-cli/runtime_rotation_production_test.go
+++ b/clients/go/cmd/rubin-consensus-cli/runtime_rotation_production_test.go
@@ -255,6 +255,30 @@ func TestRubinConsensusCLI_RotationDescriptorCheck_AcceptsDualAlgNameAndOpenSSLA
 	mustRunOk(t, req)
 }
 
+func TestRubinConsensusCLI_RotationDescriptorCheck_AcceptsCaseInsensitiveAlgName(t *testing.T) {
+	var req Request
+	payload := fmt.Sprintf(`{
+		"op":"rotation_descriptor_check",
+		"network":"devnet",
+		"suite_registry":[
+			{"suite_id":1,"pubkey_len":%d,"sig_len":%d,"verify_cost":%d,"alg_name":"ml-dsa-87"},
+			{"suite_id":2,"pubkey_len":%d,"sig_len":%d,"verify_cost":%d,"alg_name":"ML-dSa-87"}
+		],
+		"rotation_descriptor":{"name":"r1","old_suite_id":1,"new_suite_id":2,"create_height":10,"spend_height":20,"sunset_height":100}
+	}`,
+		consensus.ML_DSA_87_PUBKEY_BYTES,
+		consensus.ML_DSA_87_SIG_BYTES,
+		consensus.VERIFY_COST_ML_DSA_87,
+		consensus.ML_DSA_87_PUBKEY_BYTES,
+		consensus.ML_DSA_87_SIG_BYTES,
+		consensus.VERIFY_COST_ML_DSA_87,
+	)
+	if err := json.Unmarshal([]byte(payload), &req); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	mustRunOk(t, req)
+}
+
 func TestRubinConsensusCLI_RotationDescriptorCheck_RejectsEmptyAlgNameEvenWithLegacyAlias(t *testing.T) {
 	var req Request
 	payload := fmt.Sprintf(`{
@@ -344,6 +368,50 @@ func TestRubinConsensusCLI_RotationDescriptorCheck_RejectsMissingSuiteRegistrySi
 	)
 	if err := json.Unmarshal([]byte(payload), &req); err == nil {
 		t.Fatal("expected missing sig_len to fail closed during unmarshal")
+	}
+}
+
+func TestRubinConsensusCLI_RotationDescriptorCheck_RejectsNegativeSuiteRegistryPubkeyLen(t *testing.T) {
+	var req Request
+	payload := fmt.Sprintf(`{
+		"op":"rotation_descriptor_check",
+		"network":"devnet",
+		"suite_registry":[
+			{"suite_id":1,"pubkey_len":-1,"sig_len":%d,"verify_cost":%d,"alg_name":"ML-DSA-87"},
+			{"suite_id":2,"pubkey_len":%d,"sig_len":%d,"verify_cost":%d,"alg_name":"ML-DSA-87"}
+		],
+		"rotation_descriptor":{"name":"r1","old_suite_id":1,"new_suite_id":2,"create_height":10,"spend_height":20,"sunset_height":100}
+	}`,
+		consensus.ML_DSA_87_SIG_BYTES,
+		consensus.VERIFY_COST_ML_DSA_87,
+		consensus.ML_DSA_87_PUBKEY_BYTES,
+		consensus.ML_DSA_87_SIG_BYTES,
+		consensus.VERIFY_COST_ML_DSA_87,
+	)
+	if err := json.Unmarshal([]byte(payload), &req); err == nil {
+		t.Fatal("expected negative pubkey_len to fail closed during unmarshal")
+	}
+}
+
+func TestRubinConsensusCLI_RotationDescriptorCheck_RejectsNegativeSuiteRegistrySigLen(t *testing.T) {
+	var req Request
+	payload := fmt.Sprintf(`{
+		"op":"rotation_descriptor_check",
+		"network":"devnet",
+		"suite_registry":[
+			{"suite_id":1,"pubkey_len":%d,"sig_len":-1,"verify_cost":%d,"alg_name":"ML-DSA-87"},
+			{"suite_id":2,"pubkey_len":%d,"sig_len":%d,"verify_cost":%d,"alg_name":"ML-DSA-87"}
+		],
+		"rotation_descriptor":{"name":"r1","old_suite_id":1,"new_suite_id":2,"create_height":10,"spend_height":20,"sunset_height":100}
+	}`,
+		consensus.ML_DSA_87_PUBKEY_BYTES,
+		consensus.VERIFY_COST_ML_DSA_87,
+		consensus.ML_DSA_87_PUBKEY_BYTES,
+		consensus.ML_DSA_87_SIG_BYTES,
+		consensus.VERIFY_COST_ML_DSA_87,
+	)
+	if err := json.Unmarshal([]byte(payload), &req); err == nil {
+		t.Fatal("expected negative sig_len to fail closed during unmarshal")
 	}
 }
 
@@ -490,13 +558,13 @@ func TestRubinConsensusCLI_TxWeightAndStats_RejectsRotationDescriptorWithoutSuit
 	}, "bad suite_registry")
 }
 
-func TestRubinConsensusCLI_RotationDescriptorCheck_RejectsLowercaseSuiteRegistryAlgName(t *testing.T) {
-	mustRunErr(t, Request{
+func TestRubinConsensusCLI_RotationDescriptorCheck_AcceptsCaseInsensitiveSuiteRegistryAlgName(t *testing.T) {
+	mustRunOk(t, Request{
 		Op:      "rotation_descriptor_check",
 		Network: "devnet",
 		SuiteRegistry: []SuiteParamsJSON{
 			{SuiteID: 1, PubkeyLen: consensus.ML_DSA_87_PUBKEY_BYTES, SigLen: consensus.ML_DSA_87_SIG_BYTES, VerifyCost: consensus.VERIFY_COST_ML_DSA_87, AlgName: "ml-dsa-87"},
-			{SuiteID: 2, PubkeyLen: consensus.ML_DSA_87_PUBKEY_BYTES, SigLen: consensus.ML_DSA_87_SIG_BYTES, VerifyCost: consensus.VERIFY_COST_ML_DSA_87, AlgName: "ML-DSA-87"},
+			{SuiteID: 2, PubkeyLen: consensus.ML_DSA_87_PUBKEY_BYTES, SigLen: consensus.ML_DSA_87_SIG_BYTES, VerifyCost: consensus.VERIFY_COST_ML_DSA_87, AlgName: "ML-dSa-87"},
 		},
 		RotationDescriptor: &RotationDescriptorJSON{
 			Name:         "r1",
@@ -506,5 +574,5 @@ func TestRubinConsensusCLI_RotationDescriptorCheck_RejectsLowercaseSuiteRegistry
 			SpendHeight:  20,
 			SunsetHeight: 100,
 		},
-	}, "bad suite_registry")
+	})
 }

--- a/clients/go/cmd/rubin-consensus-cli/runtime_rotation_production_test.go
+++ b/clients/go/cmd/rubin-consensus-cli/runtime_rotation_production_test.go
@@ -218,3 +218,57 @@ func TestRubinConsensusCLI_RotationDescriptorCheck_AcceptsLegacyOpenSSLAlgAlias(
 	}
 	mustRunOk(t, req)
 }
+
+func TestRubinConsensusCLI_RotationDescriptorCheck_RejectsMissingSuiteRegistryAlgName(t *testing.T) {
+	var req Request
+	if err := json.Unmarshal([]byte(`{
+		"op":"rotation_descriptor_check",
+		"network":"devnet",
+		"suite_registry":[
+			{"suite_id":1,"pubkey_len":2592,"sig_len":4627,"verify_cost":8},
+			{"suite_id":2,"pubkey_len":1024,"sig_len":512,"verify_cost":9,"alg_name":"ML-DSA-87"}
+		],
+		"rotation_descriptor":{"name":"r1","old_suite_id":1,"new_suite_id":2,"create_height":10,"spend_height":20,"sunset_height":100}
+	}`), &req); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	mustRunErr(t, req, "bad suite_registry")
+}
+
+func TestRubinConsensusCLI_RotationDescriptorCheck_RejectsDuplicateSuiteID(t *testing.T) {
+	mustRunErr(t, Request{
+		Op:      "rotation_descriptor_check",
+		Network: "devnet",
+		SuiteRegistry: []SuiteParamsJSON{
+			{SuiteID: 1, PubkeyLen: 2592, SigLen: 4627, VerifyCost: 8, AlgName: "ML-DSA-87"},
+			{SuiteID: 1, PubkeyLen: 1024, SigLen: 512, VerifyCost: 9, AlgName: "ML-DSA-87"},
+		},
+		RotationDescriptor: &RotationDescriptorJSON{
+			Name:         "r1",
+			OldSuiteID:   1,
+			NewSuiteID:   2,
+			CreateHeight: 10,
+			SpendHeight:  20,
+			SunsetHeight: 100,
+		},
+	}, "bad suite_registry")
+}
+
+func TestRubinConsensusCLI_RotationDescriptorCheck_RejectsUnknownSuiteRegistryAlgName(t *testing.T) {
+	mustRunErr(t, Request{
+		Op:      "rotation_descriptor_check",
+		Network: "devnet",
+		SuiteRegistry: []SuiteParamsJSON{
+			{SuiteID: 1, PubkeyLen: 2592, SigLen: 4627, VerifyCost: 8, AlgName: "NO_SUCH_ALG"},
+			{SuiteID: 2, PubkeyLen: 1024, SigLen: 512, VerifyCost: 9, AlgName: "ML-DSA-87"},
+		},
+		RotationDescriptor: &RotationDescriptorJSON{
+			Name:         "r1",
+			OldSuiteID:   1,
+			NewSuiteID:   2,
+			CreateHeight: 10,
+			SpendHeight:  20,
+			SunsetHeight: 100,
+		},
+	}, "bad suite_registry")
+}

--- a/clients/go/cmd/rubin-consensus-cli/runtime_rotation_production_test.go
+++ b/clients/go/cmd/rubin-consensus-cli/runtime_rotation_production_test.go
@@ -303,6 +303,50 @@ func TestRubinConsensusCLI_RotationDescriptorCheck_RejectsMissingSuiteRegistryAl
 	mustRunErr(t, req, "bad suite_registry")
 }
 
+func TestRubinConsensusCLI_RotationDescriptorCheck_RejectsMissingSuiteRegistryPubkeyLen(t *testing.T) {
+	var req Request
+	payload := fmt.Sprintf(`{
+		"op":"rotation_descriptor_check",
+		"network":"devnet",
+		"suite_registry":[
+			{"suite_id":1,"sig_len":%d,"verify_cost":%d,"alg_name":"ML-DSA-87"},
+			{"suite_id":2,"pubkey_len":%d,"sig_len":%d,"verify_cost":%d,"alg_name":"ML-DSA-87"}
+		],
+		"rotation_descriptor":{"name":"r1","old_suite_id":1,"new_suite_id":2,"create_height":10,"spend_height":20,"sunset_height":100}
+	}`,
+		consensus.ML_DSA_87_SIG_BYTES,
+		consensus.VERIFY_COST_ML_DSA_87,
+		consensus.ML_DSA_87_PUBKEY_BYTES,
+		consensus.ML_DSA_87_SIG_BYTES,
+		consensus.VERIFY_COST_ML_DSA_87,
+	)
+	if err := json.Unmarshal([]byte(payload), &req); err == nil {
+		t.Fatal("expected missing pubkey_len to fail closed during unmarshal")
+	}
+}
+
+func TestRubinConsensusCLI_RotationDescriptorCheck_RejectsMissingSuiteRegistrySigLen(t *testing.T) {
+	var req Request
+	payload := fmt.Sprintf(`{
+		"op":"rotation_descriptor_check",
+		"network":"devnet",
+		"suite_registry":[
+			{"suite_id":1,"pubkey_len":%d,"verify_cost":%d,"alg_name":"ML-DSA-87"},
+			{"suite_id":2,"pubkey_len":%d,"sig_len":%d,"verify_cost":%d,"alg_name":"ML-DSA-87"}
+		],
+		"rotation_descriptor":{"name":"r1","old_suite_id":1,"new_suite_id":2,"create_height":10,"spend_height":20,"sunset_height":100}
+	}`,
+		consensus.ML_DSA_87_PUBKEY_BYTES,
+		consensus.VERIFY_COST_ML_DSA_87,
+		consensus.ML_DSA_87_PUBKEY_BYTES,
+		consensus.ML_DSA_87_SIG_BYTES,
+		consensus.VERIFY_COST_ML_DSA_87,
+	)
+	if err := json.Unmarshal([]byte(payload), &req); err == nil {
+		t.Fatal("expected missing sig_len to fail closed during unmarshal")
+	}
+}
+
 func TestRubinConsensusCLI_RotationDescriptorCheck_RejectsDuplicateSuiteID(t *testing.T) {
 	mustRunErr(t, Request{
 		Op:      "rotation_descriptor_check",

--- a/clients/go/cmd/rubin-consensus-cli/runtime_rotation_production_test.go
+++ b/clients/go/cmd/rubin-consensus-cli/runtime_rotation_production_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
@@ -202,15 +203,23 @@ func TestSanitizeRotationValidationErr_UsesSharedStems(t *testing.T) {
 
 func TestRubinConsensusCLI_RotationDescriptorCheck_AcceptsLegacyOpenSSLAlgAlias(t *testing.T) {
 	var req Request
-	if err := json.Unmarshal([]byte(`{
+	payload := fmt.Sprintf(`{
 		"op":"rotation_descriptor_check",
 		"network":"devnet",
 		"suite_registry":[
-			{"suite_id":1,"pubkey_len":2592,"sig_len":4627,"verify_cost":8,"openssl_alg":"ML-DSA-87"},
-			{"suite_id":2,"pubkey_len":2592,"sig_len":4627,"verify_cost":8,"openssl_alg":"ML-DSA-87"}
+			{"suite_id":1,"pubkey_len":%d,"sig_len":%d,"verify_cost":%d,"openssl_alg":"ML-DSA-87"},
+			{"suite_id":2,"pubkey_len":%d,"sig_len":%d,"verify_cost":%d,"openssl_alg":"ML-DSA-87"}
 		],
 		"rotation_descriptor":{"name":"r1","old_suite_id":1,"new_suite_id":2,"create_height":10,"spend_height":20,"sunset_height":100}
-	}`), &req); err != nil {
+	}`,
+		consensus.ML_DSA_87_PUBKEY_BYTES,
+		consensus.ML_DSA_87_SIG_BYTES,
+		consensus.VERIFY_COST_ML_DSA_87,
+		consensus.ML_DSA_87_PUBKEY_BYTES,
+		consensus.ML_DSA_87_SIG_BYTES,
+		consensus.VERIFY_COST_ML_DSA_87,
+	)
+	if err := json.Unmarshal([]byte(payload), &req); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	if req.SuiteRegistry[0].AlgName != "ML-DSA-87" || req.SuiteRegistry[1].AlgName != "ML-DSA-87" {
@@ -219,17 +228,76 @@ func TestRubinConsensusCLI_RotationDescriptorCheck_AcceptsLegacyOpenSSLAlgAlias(
 	mustRunOk(t, req)
 }
 
-func TestRubinConsensusCLI_RotationDescriptorCheck_RejectsMissingSuiteRegistryAlgName(t *testing.T) {
+func TestRubinConsensusCLI_RotationDescriptorCheck_AcceptsDualAlgNameAndOpenSSLAlgKeys(t *testing.T) {
 	var req Request
-	if err := json.Unmarshal([]byte(`{
+	payload := fmt.Sprintf(`{
 		"op":"rotation_descriptor_check",
 		"network":"devnet",
 		"suite_registry":[
-			{"suite_id":1,"pubkey_len":2592,"sig_len":4627,"verify_cost":8},
-			{"suite_id":2,"pubkey_len":2592,"sig_len":4627,"verify_cost":8,"alg_name":"ML-DSA-87"}
+			{"suite_id":1,"pubkey_len":%d,"sig_len":%d,"verify_cost":%d,"alg_name":"ML-DSA-87","openssl_alg":"ML-DSA-87"},
+			{"suite_id":2,"pubkey_len":%d,"sig_len":%d,"verify_cost":%d,"alg_name":"ML-DSA-87","openssl_alg":"ML-DSA-87"}
 		],
 		"rotation_descriptor":{"name":"r1","old_suite_id":1,"new_suite_id":2,"create_height":10,"spend_height":20,"sunset_height":100}
-	}`), &req); err != nil {
+	}`,
+		consensus.ML_DSA_87_PUBKEY_BYTES,
+		consensus.ML_DSA_87_SIG_BYTES,
+		consensus.VERIFY_COST_ML_DSA_87,
+		consensus.ML_DSA_87_PUBKEY_BYTES,
+		consensus.ML_DSA_87_SIG_BYTES,
+		consensus.VERIFY_COST_ML_DSA_87,
+	)
+	if err := json.Unmarshal([]byte(payload), &req); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if req.SuiteRegistry[0].AlgName != "ML-DSA-87" || req.SuiteRegistry[1].AlgName != "ML-DSA-87" {
+		t.Fatalf("dual keys failed to preserve alg_name: %+v", req.SuiteRegistry)
+	}
+	mustRunOk(t, req)
+}
+
+func TestRubinConsensusCLI_RotationDescriptorCheck_RejectsEmptyAlgNameEvenWithLegacyAlias(t *testing.T) {
+	var req Request
+	payload := fmt.Sprintf(`{
+		"op":"rotation_descriptor_check",
+		"network":"devnet",
+		"suite_registry":[
+			{"suite_id":1,"pubkey_len":%d,"sig_len":%d,"verify_cost":%d,"alg_name":"","openssl_alg":"ML-DSA-87"},
+			{"suite_id":2,"pubkey_len":%d,"sig_len":%d,"verify_cost":%d,"alg_name":"ML-DSA-87","openssl_alg":"ML-DSA-87"}
+		],
+		"rotation_descriptor":{"name":"r1","old_suite_id":1,"new_suite_id":2,"create_height":10,"spend_height":20,"sunset_height":100}
+	}`,
+		consensus.ML_DSA_87_PUBKEY_BYTES,
+		consensus.ML_DSA_87_SIG_BYTES,
+		consensus.VERIFY_COST_ML_DSA_87,
+		consensus.ML_DSA_87_PUBKEY_BYTES,
+		consensus.ML_DSA_87_SIG_BYTES,
+		consensus.VERIFY_COST_ML_DSA_87,
+	)
+	if err := json.Unmarshal([]byte(payload), &req); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	mustRunErr(t, req, "bad suite_registry")
+}
+
+func TestRubinConsensusCLI_RotationDescriptorCheck_RejectsMissingSuiteRegistryAlgName(t *testing.T) {
+	var req Request
+	payload := fmt.Sprintf(`{
+		"op":"rotation_descriptor_check",
+		"network":"devnet",
+		"suite_registry":[
+			{"suite_id":1,"pubkey_len":%d,"sig_len":%d,"verify_cost":%d},
+			{"suite_id":2,"pubkey_len":%d,"sig_len":%d,"verify_cost":%d,"alg_name":"ML-DSA-87"}
+		],
+		"rotation_descriptor":{"name":"r1","old_suite_id":1,"new_suite_id":2,"create_height":10,"spend_height":20,"sunset_height":100}
+	}`,
+		consensus.ML_DSA_87_PUBKEY_BYTES,
+		consensus.ML_DSA_87_SIG_BYTES,
+		consensus.VERIFY_COST_ML_DSA_87,
+		consensus.ML_DSA_87_PUBKEY_BYTES,
+		consensus.ML_DSA_87_SIG_BYTES,
+		consensus.VERIFY_COST_ML_DSA_87,
+	)
+	if err := json.Unmarshal([]byte(payload), &req); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	mustRunErr(t, req, "bad suite_registry")
@@ -243,6 +311,32 @@ func TestRubinConsensusCLI_RotationDescriptorCheck_RejectsDuplicateSuiteID(t *te
 			{SuiteID: 1, PubkeyLen: 2592, SigLen: 4627, VerifyCost: 8, AlgName: "ML-DSA-87"},
 			{SuiteID: 1, PubkeyLen: 2592, SigLen: 4627, VerifyCost: 8, AlgName: "ML-DSA-87"},
 		},
+		RotationDescriptor: &RotationDescriptorJSON{
+			Name:         "r1",
+			OldSuiteID:   1,
+			NewSuiteID:   2,
+			CreateHeight: 10,
+			SpendHeight:  20,
+			SunsetHeight: 100,
+		},
+	}, "bad suite_registry")
+}
+
+func TestRubinConsensusCLI_RotationDescriptorCheck_RejectsOversizedSuiteRegistry(t *testing.T) {
+	reg := make([]SuiteParamsJSON, 0, maxExplicitSuiteRegistryItems+1)
+	for i := 0; i < maxExplicitSuiteRegistryItems+1; i++ {
+		reg = append(reg, SuiteParamsJSON{
+			SuiteID:    uint8(i + 1),
+			PubkeyLen:  consensus.ML_DSA_87_PUBKEY_BYTES,
+			SigLen:     consensus.ML_DSA_87_SIG_BYTES,
+			VerifyCost: consensus.VERIFY_COST_ML_DSA_87,
+			AlgName:    "ML-DSA-87",
+		})
+	}
+	mustRunErr(t, Request{
+		Op:            "rotation_descriptor_check",
+		Network:       "devnet",
+		SuiteRegistry: reg,
 		RotationDescriptor: &RotationDescriptorJSON{
 			Name:         "r1",
 			OldSuiteID:   1,
@@ -273,12 +367,12 @@ func TestRubinConsensusCLI_RotationDescriptorCheck_RejectsUnknownSuiteRegistryAl
 	}, "bad suite_registry")
 }
 
-func TestRubinConsensusCLI_RotationDescriptorCheck_RejectsNonCanonicalSuiteRegistryParams(t *testing.T) {
+func TestRubinConsensusCLI_RotationDescriptorCheck_RejectsOversizedSuiteRegistryPubkeyLen(t *testing.T) {
 	mustRunErr(t, Request{
 		Op:      "rotation_descriptor_check",
 		Network: "devnet",
 		SuiteRegistry: []SuiteParamsJSON{
-			{SuiteID: 1, PubkeyLen: consensus.ML_DSA_87_PUBKEY_BYTES, SigLen: consensus.ML_DSA_87_SIG_BYTES - 1, VerifyCost: consensus.VERIFY_COST_ML_DSA_87, AlgName: "ML-DSA-87"},
+			{SuiteID: 1, PubkeyLen: consensus.MAX_WITNESS_BYTES_PER_TX + 1, SigLen: consensus.ML_DSA_87_SIG_BYTES, VerifyCost: consensus.VERIFY_COST_ML_DSA_87, AlgName: "ML-DSA-87"},
 			{SuiteID: 2, PubkeyLen: consensus.ML_DSA_87_PUBKEY_BYTES, SigLen: consensus.ML_DSA_87_SIG_BYTES, VerifyCost: consensus.VERIFY_COST_ML_DSA_87, AlgName: "ML-DSA-87"},
 		},
 		RotationDescriptor: &RotationDescriptorJSON{
@@ -289,6 +383,66 @@ func TestRubinConsensusCLI_RotationDescriptorCheck_RejectsNonCanonicalSuiteRegis
 			SpendHeight:  20,
 			SunsetHeight: 100,
 		},
+	}, "bad suite_registry")
+}
+
+func TestRubinConsensusCLI_RotationDescriptorCheck_RejectsZeroSuiteRegistryVerifyCost(t *testing.T) {
+	mustRunErr(t, Request{
+		Op:      "rotation_descriptor_check",
+		Network: "devnet",
+		SuiteRegistry: []SuiteParamsJSON{
+			{SuiteID: 1, PubkeyLen: consensus.ML_DSA_87_PUBKEY_BYTES, SigLen: consensus.ML_DSA_87_SIG_BYTES, VerifyCost: 0, AlgName: "ML-DSA-87"},
+			{SuiteID: 2, PubkeyLen: consensus.ML_DSA_87_PUBKEY_BYTES, SigLen: consensus.ML_DSA_87_SIG_BYTES, VerifyCost: consensus.VERIFY_COST_ML_DSA_87, AlgName: "ML-DSA-87"},
+		},
+		RotationDescriptor: &RotationDescriptorJSON{
+			Name:         "r1",
+			OldSuiteID:   1,
+			NewSuiteID:   2,
+			CreateHeight: 10,
+			SpendHeight:  20,
+			SunsetHeight: 100,
+		},
+	}, "bad suite_registry")
+}
+
+func TestRubinConsensusCLI_TxWeightAndStats_AcceptsSyntheticSuiteRegistryParamsForHarnessVectors(t *testing.T) {
+	resp := mustRunOk(t, Request{
+		Op:      "tx_weight_and_stats",
+		Network: "devnet",
+		Height:  100,
+		RotationDescriptor: &RotationDescriptorJSON{
+			Name:         "rot-weight",
+			OldSuiteID:   1,
+			NewSuiteID:   2,
+			CreateHeight: 50,
+			SpendHeight:  100,
+			SunsetHeight: 0,
+		},
+		SuiteRegistry: []SuiteParamsJSON{
+			{SuiteID: 1, PubkeyLen: consensus.ML_DSA_87_PUBKEY_BYTES, SigLen: consensus.ML_DSA_87_SIG_BYTES, VerifyCost: 8, AlgName: "ML-DSA-87"},
+			{SuiteID: 2, PubkeyLen: 64, SigLen: 0, VerifyCost: 9, AlgName: "ML-DSA-87"},
+		},
+		TxHex: "010000000002000000000000000111111111111111111111111111111111111111111111111111111111111111110000000000000000000000000000010240cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc01dd00",
+	})
+	if resp.Weight != 319 {
+		t.Fatalf("weight=%d, want 319", resp.Weight)
+	}
+}
+
+func TestRubinConsensusCLI_TxWeightAndStats_RejectsRotationDescriptorWithoutSuiteRegistry(t *testing.T) {
+	mustRunErr(t, Request{
+		Op:      "tx_weight_and_stats",
+		Network: "devnet",
+		Height:  100,
+		RotationDescriptor: &RotationDescriptorJSON{
+			Name:         "rot-weight",
+			OldSuiteID:   1,
+			NewSuiteID:   2,
+			CreateHeight: 50,
+			SpendHeight:  100,
+			SunsetHeight: 0,
+		},
+		TxHex: "010000000002000000000000000111111111111111111111111111111111111111111111111111111111111111110000000000000000000000000000010240cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc01dd00",
 	}, "bad suite_registry")
 }
 

--- a/clients/go/cmd/rubin-consensus-cli/runtime_rotation_production_test.go
+++ b/clients/go/cmd/rubin-consensus-cli/runtime_rotation_production_test.go
@@ -19,9 +19,9 @@ func cliTestRotationSuites() []SuiteParamsJSON {
 		},
 		{
 			SuiteID:    2,
-			PubkeyLen:  1024,
-			SigLen:     512,
-			VerifyCost: 9,
+			PubkeyLen:  consensus.ML_DSA_87_PUBKEY_BYTES,
+			SigLen:     consensus.ML_DSA_87_SIG_BYTES,
+			VerifyCost: consensus.VERIFY_COST_ML_DSA_87,
 			AlgName:    "ML-DSA-87",
 		},
 	}
@@ -97,8 +97,8 @@ func TestRubinConsensusCLI_RotationProduction_MainnetSingleDescriptorAndDevnetBa
 func TestRubinConsensusCLI_RotationProduction_MainnetRejectsMultiDescriptorBatch(t *testing.T) {
 	reg := append(
 		cliTestRotationSuites(),
-		SuiteParamsJSON{SuiteID: 3, PubkeyLen: 1024, SigLen: 512, VerifyCost: 9, AlgName: "ML-DSA-87"},
-		SuiteParamsJSON{SuiteID: 4, PubkeyLen: 1024, SigLen: 512, VerifyCost: 9, AlgName: "ML-DSA-87"},
+		SuiteParamsJSON{SuiteID: 3, PubkeyLen: consensus.ML_DSA_87_PUBKEY_BYTES, SigLen: consensus.ML_DSA_87_SIG_BYTES, VerifyCost: consensus.VERIFY_COST_ML_DSA_87, AlgName: "ML-DSA-87"},
+		SuiteParamsJSON{SuiteID: 4, PubkeyLen: consensus.ML_DSA_87_PUBKEY_BYTES, SigLen: consensus.ML_DSA_87_SIG_BYTES, VerifyCost: consensus.VERIFY_COST_ML_DSA_87, AlgName: "ML-DSA-87"},
 	)
 	mustRunErr(t, Request{
 		Op:            "rotation_descriptor_check",
@@ -133,7 +133,7 @@ func TestRubinConsensusCLI_RotationProduction_MainnetRejectsMultiDescriptorBatch
 func TestRubinConsensusCLI_RotationDescriptorCheck_PreservesStableErrAndDiagnostics(t *testing.T) {
 	reg := append(
 		cliTestRotationSuites(),
-		SuiteParamsJSON{SuiteID: 3, PubkeyLen: 1024, SigLen: 512, VerifyCost: 9, AlgName: "ML-DSA-87"},
+		SuiteParamsJSON{SuiteID: 3, PubkeyLen: consensus.ML_DSA_87_PUBKEY_BYTES, SigLen: consensus.ML_DSA_87_SIG_BYTES, VerifyCost: consensus.VERIFY_COST_ML_DSA_87, AlgName: "ML-DSA-87"},
 	)
 	resp := mustRunErr(t, Request{
 		Op:            "rotation_descriptor_check",
@@ -207,7 +207,7 @@ func TestRubinConsensusCLI_RotationDescriptorCheck_AcceptsLegacyOpenSSLAlgAlias(
 		"network":"devnet",
 		"suite_registry":[
 			{"suite_id":1,"pubkey_len":2592,"sig_len":4627,"verify_cost":8,"openssl_alg":"ML-DSA-87"},
-			{"suite_id":2,"pubkey_len":1024,"sig_len":512,"verify_cost":9,"openssl_alg":"ML-DSA-87"}
+			{"suite_id":2,"pubkey_len":2592,"sig_len":4627,"verify_cost":8,"openssl_alg":"ML-DSA-87"}
 		],
 		"rotation_descriptor":{"name":"r1","old_suite_id":1,"new_suite_id":2,"create_height":10,"spend_height":20,"sunset_height":100}
 	}`), &req); err != nil {
@@ -226,7 +226,7 @@ func TestRubinConsensusCLI_RotationDescriptorCheck_RejectsMissingSuiteRegistryAl
 		"network":"devnet",
 		"suite_registry":[
 			{"suite_id":1,"pubkey_len":2592,"sig_len":4627,"verify_cost":8},
-			{"suite_id":2,"pubkey_len":1024,"sig_len":512,"verify_cost":9,"alg_name":"ML-DSA-87"}
+			{"suite_id":2,"pubkey_len":2592,"sig_len":4627,"verify_cost":8,"alg_name":"ML-DSA-87"}
 		],
 		"rotation_descriptor":{"name":"r1","old_suite_id":1,"new_suite_id":2,"create_height":10,"spend_height":20,"sunset_height":100}
 	}`), &req); err != nil {
@@ -241,7 +241,7 @@ func TestRubinConsensusCLI_RotationDescriptorCheck_RejectsDuplicateSuiteID(t *te
 		Network: "devnet",
 		SuiteRegistry: []SuiteParamsJSON{
 			{SuiteID: 1, PubkeyLen: 2592, SigLen: 4627, VerifyCost: 8, AlgName: "ML-DSA-87"},
-			{SuiteID: 1, PubkeyLen: 1024, SigLen: 512, VerifyCost: 9, AlgName: "ML-DSA-87"},
+			{SuiteID: 1, PubkeyLen: 2592, SigLen: 4627, VerifyCost: 8, AlgName: "ML-DSA-87"},
 		},
 		RotationDescriptor: &RotationDescriptorJSON{
 			Name:         "r1",
@@ -260,7 +260,45 @@ func TestRubinConsensusCLI_RotationDescriptorCheck_RejectsUnknownSuiteRegistryAl
 		Network: "devnet",
 		SuiteRegistry: []SuiteParamsJSON{
 			{SuiteID: 1, PubkeyLen: 2592, SigLen: 4627, VerifyCost: 8, AlgName: "NO_SUCH_ALG"},
-			{SuiteID: 2, PubkeyLen: 1024, SigLen: 512, VerifyCost: 9, AlgName: "ML-DSA-87"},
+			{SuiteID: 2, PubkeyLen: 2592, SigLen: 4627, VerifyCost: 8, AlgName: "ML-DSA-87"},
+		},
+		RotationDescriptor: &RotationDescriptorJSON{
+			Name:         "r1",
+			OldSuiteID:   1,
+			NewSuiteID:   2,
+			CreateHeight: 10,
+			SpendHeight:  20,
+			SunsetHeight: 100,
+		},
+	}, "bad suite_registry")
+}
+
+func TestRubinConsensusCLI_RotationDescriptorCheck_RejectsNonCanonicalSuiteRegistryParams(t *testing.T) {
+	mustRunErr(t, Request{
+		Op:      "rotation_descriptor_check",
+		Network: "devnet",
+		SuiteRegistry: []SuiteParamsJSON{
+			{SuiteID: 1, PubkeyLen: consensus.ML_DSA_87_PUBKEY_BYTES, SigLen: consensus.ML_DSA_87_SIG_BYTES - 1, VerifyCost: consensus.VERIFY_COST_ML_DSA_87, AlgName: "ML-DSA-87"},
+			{SuiteID: 2, PubkeyLen: consensus.ML_DSA_87_PUBKEY_BYTES, SigLen: consensus.ML_DSA_87_SIG_BYTES, VerifyCost: consensus.VERIFY_COST_ML_DSA_87, AlgName: "ML-DSA-87"},
+		},
+		RotationDescriptor: &RotationDescriptorJSON{
+			Name:         "r1",
+			OldSuiteID:   1,
+			NewSuiteID:   2,
+			CreateHeight: 10,
+			SpendHeight:  20,
+			SunsetHeight: 100,
+		},
+	}, "bad suite_registry")
+}
+
+func TestRubinConsensusCLI_RotationDescriptorCheck_RejectsLowercaseSuiteRegistryAlgName(t *testing.T) {
+	mustRunErr(t, Request{
+		Op:      "rotation_descriptor_check",
+		Network: "devnet",
+		SuiteRegistry: []SuiteParamsJSON{
+			{SuiteID: 1, PubkeyLen: consensus.ML_DSA_87_PUBKEY_BYTES, SigLen: consensus.ML_DSA_87_SIG_BYTES, VerifyCost: consensus.VERIFY_COST_ML_DSA_87, AlgName: "ml-dsa-87"},
+			{SuiteID: 2, PubkeyLen: consensus.ML_DSA_87_PUBKEY_BYTES, SigLen: consensus.ML_DSA_87_SIG_BYTES, VerifyCost: consensus.VERIFY_COST_ML_DSA_87, AlgName: "ML-DSA-87"},
 		},
 		RotationDescriptor: &RotationDescriptorJSON{
 			Name:         "r1",

--- a/clients/go/cmd/rubin-consensus-cli/runtime_rotation_production_test.go
+++ b/clients/go/cmd/rubin-consensus-cli/runtime_rotation_production_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -14,14 +15,14 @@ func cliTestRotationSuites() []SuiteParamsJSON {
 			PubkeyLen:  consensus.ML_DSA_87_PUBKEY_BYTES,
 			SigLen:     consensus.ML_DSA_87_SIG_BYTES,
 			VerifyCost: consensus.VERIFY_COST_ML_DSA_87,
-			OpenSSLAlg: "ML-DSA-87",
+			AlgName:    "ML-DSA-87",
 		},
 		{
 			SuiteID:    2,
 			PubkeyLen:  1024,
 			SigLen:     512,
 			VerifyCost: 9,
-			OpenSSLAlg: "ML-DSA-87",
+			AlgName:    "ML-DSA-87",
 		},
 	}
 }
@@ -96,8 +97,8 @@ func TestRubinConsensusCLI_RotationProduction_MainnetSingleDescriptorAndDevnetBa
 func TestRubinConsensusCLI_RotationProduction_MainnetRejectsMultiDescriptorBatch(t *testing.T) {
 	reg := append(
 		cliTestRotationSuites(),
-		SuiteParamsJSON{SuiteID: 3, PubkeyLen: 1024, SigLen: 512, VerifyCost: 9, OpenSSLAlg: "ML-DSA-87"},
-		SuiteParamsJSON{SuiteID: 4, PubkeyLen: 1024, SigLen: 512, VerifyCost: 9, OpenSSLAlg: "ML-DSA-87"},
+		SuiteParamsJSON{SuiteID: 3, PubkeyLen: 1024, SigLen: 512, VerifyCost: 9, AlgName: "ML-DSA-87"},
+		SuiteParamsJSON{SuiteID: 4, PubkeyLen: 1024, SigLen: 512, VerifyCost: 9, AlgName: "ML-DSA-87"},
 	)
 	mustRunErr(t, Request{
 		Op:            "rotation_descriptor_check",
@@ -132,7 +133,7 @@ func TestRubinConsensusCLI_RotationProduction_MainnetRejectsMultiDescriptorBatch
 func TestRubinConsensusCLI_RotationDescriptorCheck_PreservesStableErrAndDiagnostics(t *testing.T) {
 	reg := append(
 		cliTestRotationSuites(),
-		SuiteParamsJSON{SuiteID: 3, PubkeyLen: 1024, SigLen: 512, VerifyCost: 9, OpenSSLAlg: "ML-DSA-87"},
+		SuiteParamsJSON{SuiteID: 3, PubkeyLen: 1024, SigLen: 512, VerifyCost: 9, AlgName: "ML-DSA-87"},
 	)
 	resp := mustRunErr(t, Request{
 		Op:            "rotation_descriptor_check",
@@ -197,4 +198,23 @@ func TestSanitizeRotationValidationErr_UsesSharedStems(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRubinConsensusCLI_RotationDescriptorCheck_AcceptsLegacyOpenSSLAlgAlias(t *testing.T) {
+	var req Request
+	if err := json.Unmarshal([]byte(`{
+		"op":"rotation_descriptor_check",
+		"network":"devnet",
+		"suite_registry":[
+			{"suite_id":1,"pubkey_len":2592,"sig_len":4627,"verify_cost":8,"openssl_alg":"ML-DSA-87"},
+			{"suite_id":2,"pubkey_len":1024,"sig_len":512,"verify_cost":9,"openssl_alg":"ML-DSA-87"}
+		],
+		"rotation_descriptor":{"name":"r1","old_suite_id":1,"new_suite_id":2,"create_height":10,"spend_height":20,"sunset_height":100}
+	}`), &req); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if req.SuiteRegistry[0].AlgName != "ML-DSA-87" || req.SuiteRegistry[1].AlgName != "ML-DSA-87" {
+		t.Fatalf("legacy alias failed to populate alg_name: %+v", req.SuiteRegistry)
+	}
+	mustRunOk(t, req)
 }

--- a/clients/go/consensus/core_ext_test.go
+++ b/clients/go/consensus/core_ext_test.go
@@ -477,7 +477,7 @@ func TestValidateCoreExtWitnessAtHeightMixedProfileNativeSuiteUsesNativePath(t *
 		PubkeyLen:  len(w.Pubkey),
 		SigLen:     len(w.Signature) - 1,
 		VerifyCost: 1,
-		OpenSSLAlg: "ML-DSA-87",
+		AlgName:    "ML-DSA-87",
 	}})
 	queue := NewSigCheckQueue(0).WithRegistry(registry)
 	if err := validateCoreExtWitnessAtHeight(
@@ -594,7 +594,7 @@ func TestValidateCoreExtWitnessAtHeightRegisteredNativeSuiteOutsideSpendSetRejec
 			PubkeyLen:  len(w.Pubkey),
 			SigLen:     len(w.Signature) - 1,
 			VerifyCost: 1,
-			OpenSSLAlg: "ML-DSA-87",
+			AlgName:    "ML-DSA-87",
 		}}),
 		nil,
 		nil,
@@ -1118,7 +1118,7 @@ func TestApplyNonCoinbaseTxBasic_CORE_EXT_RotatedNativeSuiteUsesRegistryPath(t *
 		PubkeyLen:  ML_DSA_87_PUBKEY_BYTES,
 		SigLen:     ML_DSA_87_SIG_BYTES,
 		VerifyCost: VERIFY_COST_ML_DSA_87,
-		OpenSSLAlg: "ML-DSA-87",
+		AlgName:    "ML-DSA-87",
 	}})
 	err = nil
 	_, _, err = ApplyNonCoinbaseTxBasicUpdateWithMTPAndCoreExtProfilesAndSuiteContext(

--- a/clients/go/consensus/suite_registry.go
+++ b/clients/go/consensus/suite_registry.go
@@ -8,7 +8,7 @@ type SuiteParams struct {
 	PubkeyLen  int
 	SigLen     int    // crypto sig length (without sighash byte)
 	VerifyCost uint64 // weight units per signature verification
-	OpenSSLAlg string // algorithm name for opensslVerifySigOneShot
+	AlgName    string // semantic algorithm identity for live verifier binding
 }
 
 // SuiteRegistry maps suite IDs to their consensus parameters.
@@ -42,7 +42,7 @@ func DefaultSuiteRegistry() *SuiteRegistry {
 				PubkeyLen:  ML_DSA_87_PUBKEY_BYTES,
 				SigLen:     ML_DSA_87_SIG_BYTES,
 				VerifyCost: VERIFY_COST_ML_DSA_87,
-				OpenSSLAlg: "ML-DSA-87",
+				AlgName:    "ML-DSA-87",
 			},
 		},
 	}

--- a/clients/go/consensus/suite_registry_test.go
+++ b/clients/go/consensus/suite_registry_test.go
@@ -26,8 +26,8 @@ func TestDefaultSuiteRegistry_LookupMLDSA87(t *testing.T) {
 	if p.VerifyCost != VERIFY_COST_ML_DSA_87 {
 		t.Errorf("VerifyCost = %d, want %d", p.VerifyCost, VERIFY_COST_ML_DSA_87)
 	}
-	if p.OpenSSLAlg != "ML-DSA-87" {
-		t.Errorf("OpenSSLAlg = %q, want %q", p.OpenSSLAlg, "ML-DSA-87")
+	if p.AlgName != "ML-DSA-87" {
+		t.Errorf("AlgName = %q, want %q", p.AlgName, "ML-DSA-87")
 	}
 }
 
@@ -73,8 +73,8 @@ func TestSuiteRegistry_NilSafe(t *testing.T) {
 
 func TestNewSuiteRegistryFromParams_BuildsIndependentRegistry(t *testing.T) {
 	params := []SuiteParams{
-		{SuiteID: 0x01, PubkeyLen: 10, SigLen: 20, VerifyCost: 8, OpenSSLAlg: "ML-DSA-87"},
-		{SuiteID: 0x02, PubkeyLen: 11, SigLen: 21, VerifyCost: 9, OpenSSLAlg: "ML-DSA-87"},
+		{SuiteID: 0x01, PubkeyLen: 10, SigLen: 20, VerifyCost: 8, AlgName: "ML-DSA-87"},
+		{SuiteID: 0x02, PubkeyLen: 11, SigLen: 21, VerifyCost: 9, AlgName: "ML-DSA-87"},
 	}
 	reg := NewSuiteRegistryFromParams(params)
 	if reg == nil {
@@ -293,14 +293,14 @@ func TestSuiteRegistry_MultiSuite(t *testing.T) {
 				PubkeyLen:  ML_DSA_87_PUBKEY_BYTES,
 				SigLen:     ML_DSA_87_SIG_BYTES,
 				VerifyCost: VERIFY_COST_ML_DSA_87,
-				OpenSSLAlg: "ML-DSA-87",
+				AlgName:    "ML-DSA-87",
 			},
 			0x02: {
 				SuiteID:    0x02,
 				PubkeyLen:  1312,
 				SigLen:     2420,
 				VerifyCost: 4,
-				OpenSSLAlg: "ML-DSA-65",
+				AlgName:    "ML-DSA-65",
 			},
 		},
 	}

--- a/clients/go/consensus/verify_sig_openssl.go
+++ b/clients/go/consensus/verify_sig_openssl.go
@@ -369,9 +369,9 @@ type suiteVerifierBinding struct {
 
 // v1 keeps the legacy ML-DSA-87 verifier on the OpenSSL archival/runtime path.
 // Runtime dispatch must resolve an explicit binding instead of trusting a raw
-// registry OpenSSLAlg string as an implicit backend switch.
-func resolveSuiteVerifierBinding(opensslAlg string, pubkeyLen int, sigLen int) (suiteVerifierBinding, error) {
-	if opensslAlg == "ML-DSA-87" && pubkeyLen == ML_DSA_87_PUBKEY_BYTES && sigLen == ML_DSA_87_SIG_BYTES {
+// registry AlgName string as an implicit backend switch.
+func resolveSuiteVerifierBinding(algName string, pubkeyLen int, sigLen int) (suiteVerifierBinding, error) {
+	if algName == "ML-DSA-87" && pubkeyLen == ML_DSA_87_PUBKEY_BYTES && sigLen == ML_DSA_87_SIG_BYTES {
 		return suiteVerifierBinding{
 			kind:       suiteVerifierBindingOpenSSLDigest32V1,
 			opensslAlg: "ML-DSA-87",
@@ -403,7 +403,7 @@ func verifySigWithBinding(binding suiteVerifierBinding, pubkey []byte, signature
 // Falls back to legacy verifySig when registry is nil.
 //
 // The registry no longer gets to select the verifier backend implicitly through
-// OpenSSLAlg alone. Runtime verification resolves an explicit v1 binding from
+// AlgName alone. Runtime verification resolves an explicit v1 binding from
 // the suite parameters so existing suites cannot switch backend silently.
 func verifySigWithRegistry(suiteID uint8, pubkey []byte, signature []byte, digest32 [32]byte, registry *SuiteRegistry) (bool, error) {
 	if registry == nil {
@@ -417,7 +417,7 @@ func verifySigWithRegistry(suiteID uint8, pubkey []byte, signature []byte, diges
 	if err := ensureOpenSSLConsensusInit(); err != nil {
 		return false, err
 	}
-	binding, err := resolveSuiteVerifierBinding(params.OpenSSLAlg, params.PubkeyLen, params.SigLen)
+	binding, err := resolveSuiteVerifierBinding(params.AlgName, params.PubkeyLen, params.SigLen)
 	if err != nil {
 		return false, err
 	}

--- a/clients/go/consensus/verify_sig_registry_test.go
+++ b/clients/go/consensus/verify_sig_registry_test.go
@@ -80,7 +80,7 @@ func TestVerifySigWithRegistry_CustomSuite_ExactV1BindingAllowed(t *testing.T) {
 				PubkeyLen:  ML_DSA_87_PUBKEY_BYTES,
 				SigLen:     ML_DSA_87_SIG_BYTES,
 				VerifyCost: VERIFY_COST_ML_DSA_87,
-				OpenSSLAlg: "ML-DSA-87",
+				AlgName:    "ML-DSA-87",
 			},
 		},
 	}
@@ -117,7 +117,7 @@ func TestVerifySigWithRegistry_CustomSuite_UnsupportedBindingRejected(t *testing
 				PubkeyLen:  1312,
 				SigLen:     2420,
 				VerifyCost: 4,
-				OpenSSLAlg: "ML-DSA-65",
+				AlgName:    "ML-DSA-65",
 			},
 		},
 	}

--- a/clients/go/consensus/weight_registry_test.go
+++ b/clients/go/consensus/weight_registry_test.go
@@ -72,11 +72,11 @@ func TestTxWeightAtHeight_NativeNotInSpendSet_UsesFloor(t *testing.T) {
 		suites: map[uint8]SuiteParams{
 			SUITE_ID_ML_DSA_87: {
 				SuiteID: SUITE_ID_ML_DSA_87, PubkeyLen: ML_DSA_87_PUBKEY_BYTES,
-				SigLen: ML_DSA_87_SIG_BYTES, VerifyCost: VERIFY_COST_ML_DSA_87, OpenSSLAlg: "ML-DSA-87",
+				SigLen: ML_DSA_87_SIG_BYTES, VerifyCost: VERIFY_COST_ML_DSA_87, AlgName: "ML-DSA-87",
 			},
 			0x02: {
 				SuiteID: 0x02, PubkeyLen: 1312, SigLen: 2420,
-				VerifyCost: 4, OpenSSLAlg: "ML-DSA-65",
+				VerifyCost: 4, AlgName: "ML-DSA-65",
 			},
 		},
 	}

--- a/clients/go/node/config.go
+++ b/clients/go/node/config.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -46,7 +47,42 @@ type SuiteParamsJSON struct {
 	PubkeyLen  uint32  `json:"pubkey_len"`
 	SigLen     uint32  `json:"sig_len"`
 	VerifyCost uint64  `json:"verify_cost"`
-	OpenSSLAlg *string `json:"openssl_alg"`
+	AlgName    *string `json:"-"`
+}
+
+type suiteParamsJSONWire struct {
+	SuiteID    uint8   `json:"suite_id"`
+	PubkeyLen  uint32  `json:"pubkey_len"`
+	SigLen     uint32  `json:"sig_len"`
+	VerifyCost uint64  `json:"verify_cost"`
+	AlgName    *string `json:"alg_name,omitempty"`
+	OpenSSLAlg *string `json:"openssl_alg,omitempty"`
+}
+
+func (item *SuiteParamsJSON) UnmarshalJSON(data []byte) error {
+	var wire suiteParamsJSONWire
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return err
+	}
+	item.SuiteID = wire.SuiteID
+	item.PubkeyLen = wire.PubkeyLen
+	item.SigLen = wire.SigLen
+	item.VerifyCost = wire.VerifyCost
+	item.AlgName = wire.AlgName
+	if item.AlgName == nil {
+		item.AlgName = wire.OpenSSLAlg
+	}
+	return nil
+}
+
+func (item SuiteParamsJSON) MarshalJSON() ([]byte, error) {
+	return json.Marshal(suiteParamsJSONWire{
+		SuiteID:    item.SuiteID,
+		PubkeyLen:  item.PubkeyLen,
+		SigLen:     item.SigLen,
+		VerifyCost: item.VerifyCost,
+		AlgName:    item.AlgName,
+	})
 }
 
 const maxSuiteRegistryParamLen = consensus.MAX_WITNESS_BYTES_PER_TX
@@ -86,7 +122,7 @@ func validateSuiteRegistryParamLen(value uint32) (int, error) {
 	return int(value), nil
 }
 
-func normalizeSuiteRegistryOpenSSLAlg(value *string) (string, error) {
+func normalizeSuiteRegistryAlgName(value *string) (string, error) {
 	if value == nil {
 		return "", errors.New("bad suite_registry")
 	}
@@ -104,7 +140,7 @@ func defaultSuiteRegistryParams() consensus.SuiteParams {
 		PubkeyLen:  consensus.ML_DSA_87_PUBKEY_BYTES,
 		SigLen:     consensus.ML_DSA_87_SIG_BYTES,
 		VerifyCost: consensus.VERIFY_COST_ML_DSA_87,
-		OpenSSLAlg: "ML-DSA-87",
+		AlgName:    "ML-DSA-87",
 	}
 }
 
@@ -120,7 +156,7 @@ func validateSuiteRegistryItem(item SuiteParamsJSON) (consensus.SuiteParams, err
 	if err != nil {
 		return consensus.SuiteParams{}, err
 	}
-	alg, err := normalizeSuiteRegistryOpenSSLAlg(item.OpenSSLAlg)
+	alg, err := normalizeSuiteRegistryAlgName(item.AlgName)
 	if err != nil {
 		return consensus.SuiteParams{}, err
 	}
@@ -129,7 +165,7 @@ func validateSuiteRegistryItem(item SuiteParamsJSON) (consensus.SuiteParams, err
 		PubkeyLen:  pubkeyLen,
 		SigLen:     sigLen,
 		VerifyCost: item.VerifyCost,
-		OpenSSLAlg: alg,
+		AlgName:    alg,
 	}
 	want := defaultSuiteRegistryParams()
 	if params.PubkeyLen != want.PubkeyLen ||

--- a/clients/go/node/config.go
+++ b/clients/go/node/config.go
@@ -126,8 +126,8 @@ func normalizeSuiteRegistryAlgName(value *string) (string, error) {
 	if value == nil {
 		return "", errors.New("bad suite_registry")
 	}
-	switch strings.TrimSpace(*value) {
-	case "ML-DSA-87":
+	switch trimmed := strings.TrimSpace(*value); {
+	case strings.EqualFold(trimmed, "ML-DSA-87"):
 		return "ML-DSA-87", nil
 	default:
 		return "", errors.New("bad suite_registry")

--- a/clients/go/node/config.go
+++ b/clients/go/node/config.go
@@ -167,6 +167,9 @@ func validateSuiteRegistryItem(item SuiteParamsJSON) (consensus.SuiteParams, err
 		VerifyCost: item.VerifyCost,
 		AlgName:    alg,
 	}
+	// Live node config is canonical-only. Synthetic suite_registry shapes are
+	// reserved for the CLI harness/conformance surface and must never be
+	// accepted here on mainnet/testnet or devnet bootstrap.
 	want := defaultSuiteRegistryParams()
 	if params.PubkeyLen != want.PubkeyLen ||
 		params.SigLen != want.SigLen ||

--- a/clients/go/node/config_rotation_test.go
+++ b/clients/go/node/config_rotation_test.go
@@ -41,7 +41,7 @@ func TestBuildRotationProvider_ValidDescriptorOnNonProductionNetwork(t *testing.
 			PubkeyLen:  consensus.ML_DSA_87_PUBKEY_BYTES,
 			SigLen:     consensus.ML_DSA_87_SIG_BYTES,
 			VerifyCost: consensus.VERIFY_COST_ML_DSA_87,
-			OpenSSLAlg: stringPtr("ML-DSA-87"),
+			AlgName:    stringPtr("ML-DSA-87"),
 		},
 	}
 	cfg.RotationDescriptor = &RotationConfigJSON{
@@ -81,7 +81,7 @@ func TestBuildRotationProvider_RejectsProductionLocalRotationDescriptor(t *testi
 					PubkeyLen:  consensus.ML_DSA_87_PUBKEY_BYTES,
 					SigLen:     consensus.ML_DSA_87_SIG_BYTES,
 					VerifyCost: consensus.VERIFY_COST_ML_DSA_87,
-					OpenSSLAlg: stringPtr("ML-DSA-87"),
+					AlgName:    stringPtr("ML-DSA-87"),
 				},
 			}
 			cfg.RotationDescriptor = &RotationConfigJSON{
@@ -103,25 +103,25 @@ func TestBuildRotationProvider_RejectsProductionLocalRotationDescriptor(t *testi
 	}
 }
 
-func TestBuildRotationProvider_RejectsSuiteRegistryEmptyOpenSSLAlg(t *testing.T) {
+func TestBuildRotationProvider_RejectsSuiteRegistryEmptyAlgName(t *testing.T) {
 	cfg := DefaultConfig()
 	cfg.SuiteRegistry = []SuiteParamsJSON{{
 		SuiteID:    0x42,
 		PubkeyLen:  consensus.ML_DSA_87_PUBKEY_BYTES,
 		SigLen:     consensus.ML_DSA_87_SIG_BYTES,
 		VerifyCost: consensus.VERIFY_COST_ML_DSA_87,
-		OpenSSLAlg: stringPtr(""),
+		AlgName:    stringPtr(""),
 	}}
 	_, _, err := cfg.BuildRotationProvider()
 	if err == nil {
-		t.Fatal("expected suite_registry rejection for empty openssl_alg")
+		t.Fatal("expected suite_registry rejection for empty alg_name")
 	}
 	if got, want := err.Error(), "suite_registry: bad suite_registry"; got != want {
 		t.Fatalf("error=%q, want %q", got, want)
 	}
 }
 
-func TestBuildRotationProvider_RejectsSuiteRegistryAliasOpenSSLAlg(t *testing.T) {
+func TestBuildRotationProvider_RejectsSuiteRegistryAliasAlgName(t *testing.T) {
 	for _, alg := range []string{"ml-dsa-87", "MLDSA87"} {
 		t.Run(alg, func(t *testing.T) {
 			cfg := DefaultConfig()
@@ -130,11 +130,11 @@ func TestBuildRotationProvider_RejectsSuiteRegistryAliasOpenSSLAlg(t *testing.T)
 				PubkeyLen:  consensus.ML_DSA_87_PUBKEY_BYTES,
 				SigLen:     consensus.ML_DSA_87_SIG_BYTES,
 				VerifyCost: consensus.VERIFY_COST_ML_DSA_87,
-				OpenSSLAlg: stringPtr(alg),
+				AlgName:    stringPtr(alg),
 			}}
 			_, _, err := cfg.BuildRotationProvider()
 			if err == nil {
-				t.Fatalf("expected suite_registry rejection for openssl_alg=%q", alg)
+				t.Fatalf("expected suite_registry rejection for alg_name=%q", alg)
 			}
 			if got, want := err.Error(), "suite_registry: bad suite_registry"; got != want {
 				t.Fatalf("error=%q, want %q", got, want)
@@ -150,7 +150,7 @@ func TestBuildRotationProvider_RejectsSuiteRegistryNoncanonicalVerifyCost(t *tes
 		PubkeyLen:  consensus.ML_DSA_87_PUBKEY_BYTES,
 		SigLen:     consensus.ML_DSA_87_SIG_BYTES,
 		VerifyCost: consensus.VERIFY_COST_ML_DSA_87 + 1,
-		OpenSSLAlg: stringPtr("ML-DSA-87"),
+		AlgName:    stringPtr("ML-DSA-87"),
 	}}
 	_, _, err := cfg.BuildRotationProvider()
 	if err == nil {
@@ -220,7 +220,7 @@ func TestBuildRotationProvider_ExplicitSuiteRegistryWithoutDescriptor(t *testing
 			PubkeyLen:  consensus.ML_DSA_87_PUBKEY_BYTES,
 			SigLen:     consensus.ML_DSA_87_SIG_BYTES,
 			VerifyCost: consensus.VERIFY_COST_ML_DSA_87,
-			OpenSSLAlg: stringPtr("ML-DSA-87"),
+			AlgName:    stringPtr("ML-DSA-87"),
 		},
 	}
 	rot, reg, err := cfg.BuildRotationProvider()
@@ -259,7 +259,7 @@ func TestBuildRotationProvider_ProductionExplicitSuiteRegistryWithoutDescriptor(
 					PubkeyLen:  consensus.ML_DSA_87_PUBKEY_BYTES,
 					SigLen:     consensus.ML_DSA_87_SIG_BYTES,
 					VerifyCost: consensus.VERIFY_COST_ML_DSA_87,
-					OpenSSLAlg: stringPtr("ML-DSA-87"),
+					AlgName:    stringPtr("ML-DSA-87"),
 				},
 			}
 			rot, reg, err := cfg.BuildRotationProvider()
@@ -293,7 +293,7 @@ func TestBuildRotationProvider_RejectsUnknownNetworkWithoutSeparateValidateConfi
 			PubkeyLen:  consensus.ML_DSA_87_PUBKEY_BYTES,
 			SigLen:     consensus.ML_DSA_87_SIG_BYTES,
 			VerifyCost: consensus.VERIFY_COST_ML_DSA_87,
-			OpenSSLAlg: stringPtr("ML-DSA-87"),
+			AlgName:    stringPtr("ML-DSA-87"),
 		},
 	}
 
@@ -323,7 +323,7 @@ func TestBuildRotationProvider_RejectsWhitespaceOnlyNetworkWithoutSeparateValida
 			PubkeyLen:  consensus.ML_DSA_87_PUBKEY_BYTES,
 			SigLen:     consensus.ML_DSA_87_SIG_BYTES,
 			VerifyCost: consensus.VERIFY_COST_ML_DSA_87,
-			OpenSSLAlg: stringPtr("ML-DSA-87"),
+			AlgName:    stringPtr("ML-DSA-87"),
 		},
 	}
 
@@ -347,7 +347,7 @@ func TestValidateConfig_RejectsProductionLocalRotationDescriptor(t *testing.T) {
 					PubkeyLen:  consensus.ML_DSA_87_PUBKEY_BYTES,
 					SigLen:     consensus.ML_DSA_87_SIG_BYTES,
 					VerifyCost: consensus.VERIFY_COST_ML_DSA_87,
-					OpenSSLAlg: stringPtr("ML-DSA-87"),
+					AlgName:    stringPtr("ML-DSA-87"),
 				},
 			}
 			cfg.RotationDescriptor = &RotationConfigJSON{
@@ -376,56 +376,56 @@ func TestValidateConfig_RejectsBadSuiteRegistry(t *testing.T) {
 			PubkeyLen:  10,
 			SigLen:     20,
 			VerifyCost: 30,
-			OpenSSLAlg: stringPtr("NO_SUCH_ALG"),
+			AlgName:    stringPtr("NO_SUCH_ALG"),
 		},
 		{
 			SuiteID:    0x42,
 			PubkeyLen:  consensus.ML_DSA_87_PUBKEY_BYTES,
 			SigLen:     consensus.ML_DSA_87_SIG_BYTES,
 			VerifyCost: consensus.VERIFY_COST_ML_DSA_87,
-			OpenSSLAlg: stringPtr(""),
+			AlgName:    stringPtr(""),
 		},
 		{
 			SuiteID:    0x42,
 			PubkeyLen:  64,
 			SigLen:     96,
 			VerifyCost: 30,
-			OpenSSLAlg: stringPtr("ML-DSA-87"),
+			AlgName:    stringPtr("ML-DSA-87"),
 		},
 		{
 			SuiteID:    consensus.SUITE_ID_SENTINEL,
 			PubkeyLen:  64,
 			SigLen:     96,
 			VerifyCost: 30,
-			OpenSSLAlg: stringPtr("ML-DSA-87"),
+			AlgName:    stringPtr("ML-DSA-87"),
 		},
 		{
 			SuiteID:    0x42,
 			PubkeyLen:  64,
 			SigLen:     96,
 			VerifyCost: 0,
-			OpenSSLAlg: stringPtr("ML-DSA-87"),
+			AlgName:    stringPtr("ML-DSA-87"),
 		},
 		{
 			SuiteID:    consensus.SUITE_ID_ML_DSA_87,
 			PubkeyLen:  consensus.ML_DSA_87_PUBKEY_BYTES - 1,
 			SigLen:     consensus.ML_DSA_87_SIG_BYTES,
 			VerifyCost: consensus.VERIFY_COST_ML_DSA_87,
-			OpenSSLAlg: stringPtr("ML-DSA-87"),
+			AlgName:    stringPtr("ML-DSA-87"),
 		},
 		{
 			SuiteID:    0x42,
 			PubkeyLen:  maxSuiteRegistryParamLen + 1,
 			SigLen:     consensus.ML_DSA_87_SIG_BYTES,
 			VerifyCost: 30,
-			OpenSSLAlg: stringPtr("ML-DSA-87"),
+			AlgName:    stringPtr("ML-DSA-87"),
 		},
 		{
 			SuiteID:    0x42,
 			PubkeyLen:  consensus.ML_DSA_87_PUBKEY_BYTES,
 			SigLen:     consensus.ML_DSA_87_SIG_BYTES,
 			VerifyCost: 30,
-			OpenSSLAlg: stringPtr("ML-DSA-87"),
+			AlgName:    stringPtr("ML-DSA-87"),
 		},
 	}
 	for _, tc := range cases {
@@ -467,7 +467,7 @@ func TestValidateConfig_RejectsTooManySuiteRegistryEntries(t *testing.T) {
 			PubkeyLen:  consensus.ML_DSA_87_PUBKEY_BYTES,
 			SigLen:     consensus.ML_DSA_87_SIG_BYTES,
 			VerifyCost: consensus.VERIFY_COST_ML_DSA_87,
-			OpenSSLAlg: stringPtr("ML-DSA-87"),
+			AlgName:    stringPtr("ML-DSA-87"),
 		})
 	}
 	if err := ValidateConfig(cfg); err == nil {
@@ -484,14 +484,14 @@ func TestValidateConfig_RejectsNegativeSuiteRegistryLengthsJSON(t *testing.T) {
 		"log_level":"info",
 		"max_peers":64,
 		"mine_address":"",
-		"suite_registry":[{"suite_id":66,"pubkey_len":-1,"sig_len":4627,"verify_cost":19,"openssl_alg":"ML-DSA-87"}]
+		"suite_registry":[{"suite_id":66,"pubkey_len":-1,"sig_len":4627,"verify_cost":19,"alg_name":"ML-DSA-87"}]
 	}`), &cfg)
 	if err == nil {
 		t.Fatal("expected unmarshal error for negative suite_registry.pubkey_len")
 	}
 }
 
-func TestValidateConfig_RejectsMissingSuiteRegistryOpenSSLAlg(t *testing.T) {
+func TestValidateConfig_RejectsMissingSuiteRegistryAlgName(t *testing.T) {
 	var cfg Config
 	if err := json.Unmarshal([]byte(`{
 		"network":"devnet",
@@ -505,7 +505,7 @@ func TestValidateConfig_RejectsMissingSuiteRegistryOpenSSLAlg(t *testing.T) {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	if err := ValidateConfig(cfg); err == nil {
-		t.Fatal("expected validation error for missing suite_registry.openssl_alg")
+		t.Fatal("expected validation error for missing suite_registry.alg_name")
 	}
 }
 
@@ -530,13 +530,31 @@ func TestRotationConfigJSON_Roundtrip(t *testing.T) {
 				PubkeyLen:  consensus.ML_DSA_87_PUBKEY_BYTES,
 				SigLen:     consensus.ML_DSA_87_SIG_BYTES,
 				VerifyCost: consensus.VERIFY_COST_ML_DSA_87,
-				OpenSSLAlg: stringPtr("ML-DSA-87"),
+				AlgName:    stringPtr("ML-DSA-87"),
 			},
 		},
 	}
 	data, err := json.Marshal(cfg)
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("unmarshal raw: %v", err)
+	}
+	suiteRegistry, ok := raw["suite_registry"].([]any)
+	if !ok || len(suiteRegistry) != 1 {
+		t.Fatalf("suite_registry raw=%#v, want singleton array", raw["suite_registry"])
+	}
+	entry, ok := suiteRegistry[0].(map[string]any)
+	if !ok {
+		t.Fatalf("suite_registry entry raw=%#v, want object", suiteRegistry[0])
+	}
+	if got := entry["alg_name"]; got != "ML-DSA-87" {
+		t.Fatalf("alg_name raw=%#v, want %q", got, "ML-DSA-87")
+	}
+	if _, ok := entry["openssl_alg"]; ok {
+		t.Fatal("marshal should not emit legacy openssl_alg key")
 	}
 	var restored Config
 	if err := json.Unmarshal(data, &restored); err != nil {
@@ -557,8 +575,29 @@ func TestRotationConfigJSON_Roundtrip(t *testing.T) {
 	if restored.SuiteRegistry[0].SuiteID != 0x02 {
 		t.Fatalf("suite_id=0x%02x, want 0x02", restored.SuiteRegistry[0].SuiteID)
 	}
-	if restored.SuiteRegistry[0].OpenSSLAlg == nil || *restored.SuiteRegistry[0].OpenSSLAlg != "ML-DSA-87" {
-		t.Fatal("openssl_alg lost in roundtrip")
+	if restored.SuiteRegistry[0].AlgName == nil || *restored.SuiteRegistry[0].AlgName != "ML-DSA-87" {
+		t.Fatal("alg_name lost in roundtrip")
+	}
+}
+
+func TestValidateConfig_AcceptsLegacySuiteRegistryOpenSSLAlgAlias(t *testing.T) {
+	var cfg Config
+	if err := json.Unmarshal([]byte(`{
+		"network":"devnet",
+		"data_dir":"/tmp/test",
+		"bind_addr":"0.0.0.0:19111",
+		"log_level":"info",
+		"max_peers":64,
+		"mine_address":"",
+		"suite_registry":[{"suite_id":66,"pubkey_len":2592,"sig_len":4627,"verify_cost":8,"openssl_alg":"ML-DSA-87"}]
+	}`), &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if err := ValidateConfig(cfg); err != nil {
+		t.Fatalf("expected legacy openssl_alg alias to remain accepted, got %v", err)
+	}
+	if cfg.SuiteRegistry[0].AlgName == nil || *cfg.SuiteRegistry[0].AlgName != "ML-DSA-87" {
+		t.Fatal("legacy openssl_alg alias did not normalize into alg_name")
 	}
 }
 

--- a/clients/go/node/config_rotation_test.go
+++ b/clients/go/node/config_rotation_test.go
@@ -121,8 +121,8 @@ func TestBuildRotationProvider_RejectsSuiteRegistryEmptyAlgName(t *testing.T) {
 	}
 }
 
-func TestBuildRotationProvider_RejectsSuiteRegistryAliasAlgName(t *testing.T) {
-	for _, alg := range []string{"ml-dsa-87", "MLDSA87"} {
+func TestBuildRotationProvider_AcceptsCaseInsensitiveSuiteRegistryAlgName(t *testing.T) {
+	for _, alg := range []string{"ml-dsa-87", "ML-dSa-87"} {
 		t.Run(alg, func(t *testing.T) {
 			cfg := DefaultConfig()
 			cfg.SuiteRegistry = []SuiteParamsJSON{{
@@ -132,14 +132,36 @@ func TestBuildRotationProvider_RejectsSuiteRegistryAliasAlgName(t *testing.T) {
 				VerifyCost: consensus.VERIFY_COST_ML_DSA_87,
 				AlgName:    stringPtr(alg),
 			}}
-			_, _, err := cfg.BuildRotationProvider()
-			if err == nil {
-				t.Fatalf("expected suite_registry rejection for alg_name=%q", alg)
+			_, reg, err := cfg.BuildRotationProvider()
+			if err != nil {
+				t.Fatalf("unexpected error for alg_name=%q: %v", alg, err)
 			}
-			if got, want := err.Error(), "suite_registry: bad suite_registry"; got != want {
-				t.Fatalf("error=%q, want %q", got, want)
+			params, ok := reg.Lookup(0x42)
+			if !ok {
+				t.Fatalf("missing suite 0x42 for alg_name=%q", alg)
+			}
+			if got, want := params.AlgName, "ML-DSA-87"; got != want {
+				t.Fatalf("alg_name=%q normalized to %q, want %q", alg, got, want)
 			}
 		})
+	}
+}
+
+func TestBuildRotationProvider_RejectsMalformedSuiteRegistryAlgName(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.SuiteRegistry = []SuiteParamsJSON{{
+		SuiteID:    0x42,
+		PubkeyLen:  consensus.ML_DSA_87_PUBKEY_BYTES,
+		SigLen:     consensus.ML_DSA_87_SIG_BYTES,
+		VerifyCost: consensus.VERIFY_COST_ML_DSA_87,
+		AlgName:    stringPtr("MLDSA87"),
+	}}
+	_, _, err := cfg.BuildRotationProvider()
+	if err == nil {
+		t.Fatal("expected suite_registry rejection for malformed alg_name")
+	}
+	if got, want := err.Error(), "suite_registry: bad suite_registry"; got != want {
+		t.Fatalf("error=%q, want %q", got, want)
 	}
 }
 

--- a/clients/go/node/config_rotation_test.go
+++ b/clients/go/node/config_rotation_test.go
@@ -161,6 +161,24 @@ func TestBuildRotationProvider_RejectsSuiteRegistryNoncanonicalVerifyCost(t *tes
 	}
 }
 
+func TestBuildRotationProvider_RejectsSuiteRegistrySyntheticHarnessParams(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.SuiteRegistry = []SuiteParamsJSON{{
+		SuiteID:    0x42,
+		PubkeyLen:  64,
+		SigLen:     0,
+		VerifyCost: 9,
+		AlgName:    stringPtr("ML-DSA-87"),
+	}}
+	_, _, err := cfg.BuildRotationProvider()
+	if err == nil {
+		t.Fatal("expected live node suite_registry to reject synthetic harness params")
+	}
+	if got, want := err.Error(), "suite_registry: bad suite_registry"; got != want {
+		t.Fatalf("error=%q, want %q", got, want)
+	}
+}
+
 func TestBuildRotationProvider_DescriptorRejectsUnregisteredNewSuiteWithoutExplicitRegistry(t *testing.T) {
 	cfg := DefaultConfig()
 	cfg.RotationDescriptor = &RotationConfigJSON{

--- a/clients/go/node/sync_reorg_test.go
+++ b/clients/go/node/sync_reorg_test.go
@@ -1087,14 +1087,14 @@ func reorgTestSuiteRegistry(extraSuiteID uint8) *consensus.SuiteRegistry {
 			PubkeyLen:  consensus.ML_DSA_87_PUBKEY_BYTES,
 			SigLen:     consensus.ML_DSA_87_SIG_BYTES,
 			VerifyCost: consensus.VERIFY_COST_ML_DSA_87,
-			OpenSSLAlg: "ML-DSA-87",
+			AlgName:    "ML-DSA-87",
 		},
 		{
 			SuiteID:    extraSuiteID,
 			PubkeyLen:  consensus.ML_DSA_87_PUBKEY_BYTES,
 			SigLen:     consensus.ML_DSA_87_SIG_BYTES,
 			VerifyCost: consensus.VERIFY_COST_ML_DSA_87,
-			OpenSSLAlg: "ML-DSA-87",
+			AlgName:    "ML-DSA-87",
 		},
 	})
 }

--- a/clients/rust/crates/rubin-consensus-cli/src/main.rs
+++ b/clients/rust/crates/rubin-consensus-cli/src/main.rs
@@ -986,10 +986,12 @@ fn decode_optional_hex_bytes(name: &str, value: &str) -> Result<Vec<u8>, String>
 }
 
 fn normalize_suite_alg_name(value: &str) -> Result<&'static str, String> {
-    match value.trim() {
-        "ML-DSA-87" => Ok("ML-DSA-87"),
-        _ => Err("bad suite_registry".to_string()),
+    const CANONICAL_SUITE_ALG_NAME: &str = "ML-DSA-87";
+    let trimmed = value.trim();
+    if trimmed != CANONICAL_SUITE_ALG_NAME {
+        return Err("bad suite_registry".to_string());
     }
+    Ok(CANONICAL_SUITE_ALG_NAME)
 }
 
 const MAX_EXPLICIT_SUITE_REGISTRY_ITEMS: usize = 16;

--- a/clients/rust/crates/rubin-consensus-cli/src/main.rs
+++ b/clients/rust/crates/rubin-consensus-cli/src/main.rs
@@ -1000,7 +1000,7 @@ fn decode_optional_hex_bytes(name: &str, value: &str) -> Result<Vec<u8>, String>
 fn normalize_suite_alg_name(value: &str) -> Result<&'static str, String> {
     const CANONICAL_SUITE_ALG_NAME: &str = "ML-DSA-87";
     let trimmed = value.trim();
-    if trimmed != CANONICAL_SUITE_ALG_NAME {
+    if !trimmed.eq_ignore_ascii_case(CANONICAL_SUITE_ALG_NAME) {
         return Err("bad suite_registry".to_string());
     }
     Ok(CANONICAL_SUITE_ALG_NAME)
@@ -5246,16 +5246,18 @@ mod tests {
     }
 
     #[test]
-    fn suite_registry_rejects_lowercase_alg_name() {
-        let err = build_suite_registry_from_json(&[SuiteParamsJson {
+    fn suite_registry_accepts_case_insensitive_alg_name() {
+        let registry = build_suite_registry_from_json(&[SuiteParamsJson {
             suite_id: 3,
             pubkey_len: rubin_consensus::constants::ML_DSA_87_PUBKEY_BYTES,
             sig_len: rubin_consensus::constants::ML_DSA_87_SIG_BYTES,
             verify_cost: rubin_consensus::constants::VERIFY_COST_ML_DSA_87,
-            alg_name: "ml-dsa-87".to_string(),
+            alg_name: "mL-dSa-87".to_string(),
         }])
-        .unwrap_err();
-        assert_eq!(err, "bad suite_registry");
+        .expect("registry")
+        .expect("suite registry");
+        let params = registry.lookup(3).expect("suite 3 present");
+        assert_eq!(params.alg_name, "ML-DSA-87");
     }
 
     #[test]

--- a/clients/rust/crates/rubin-consensus-cli/src/main.rs
+++ b/clients/rust/crates/rubin-consensus-cli/src/main.rs
@@ -606,8 +606,17 @@ struct RotationDescriptorJson {
     sunset_height: u64,
 }
 
-#[derive(Deserialize, Default)]
+#[derive(Default)]
 struct SuiteParamsJson {
+    suite_id: u8,
+    pubkey_len: u64,
+    sig_len: u64,
+    verify_cost: u64,
+    alg_name: String,
+}
+
+#[derive(Deserialize, Default)]
+struct SuiteParamsJsonWire {
     #[serde(default)]
     suite_id: u8,
     #[serde(default)]
@@ -616,8 +625,31 @@ struct SuiteParamsJson {
     sig_len: u64,
     #[serde(default)]
     verify_cost: u64,
-    #[serde(default, rename = "alg_name", alias = "openssl_alg")]
-    alg_name: String,
+    #[serde(default)]
+    alg_name: Option<String>,
+    #[serde(default)]
+    openssl_alg: Option<String>,
+}
+
+impl<'de> Deserialize<'de> for SuiteParamsJson {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = SuiteParamsJsonWire::deserialize(deserializer)?;
+        let alg_name = if let Some(value) = wire.alg_name {
+            value
+        } else {
+            wire.openssl_alg.unwrap_or_default()
+        };
+        Ok(Self {
+            suite_id: wire.suite_id,
+            pubkey_len: wire.pubkey_len,
+            sig_len: wire.sig_len,
+            verify_cost: wire.verify_cost,
+            alg_name,
+        })
+    }
 }
 
 #[derive(Deserialize)]
@@ -963,7 +995,7 @@ fn normalize_suite_alg_name(value: &str) -> Result<&'static str, String> {
 const MAX_EXPLICIT_SUITE_REGISTRY_ITEMS: usize = 16;
 
 fn validate_suite_registry_param_len(value: u64) -> Result<u64, String> {
-    if value == 0 || value > MAX_WITNESS_BYTES_PER_TX as u64 {
+    if value > MAX_WITNESS_BYTES_PER_TX as u64 {
         return Err("bad suite_registry".to_string());
     }
     Ok(value)
@@ -987,12 +1019,8 @@ fn build_suite_registry_from_json(
         let pubkey_len = validate_suite_registry_param_len(s.pubkey_len)?;
         let sig_len = validate_suite_registry_param_len(s.sig_len)?;
         let alg = normalize_suite_alg_name(&s.alg_name)?;
-        if pubkey_len != rubin_consensus::constants::ML_DSA_87_PUBKEY_BYTES
-            || sig_len != rubin_consensus::constants::ML_DSA_87_SIG_BYTES
-            || s.verify_cost != rubin_consensus::constants::VERIFY_COST_ML_DSA_87
-        {
-            return Err("bad suite_registry".to_string());
-        }
+        // CLI suite_registry is a harness overlay: keep synthetic param shapes
+        // for conformance vectors, but normalize/validate the renamed alg_name surface.
         if suites
             .insert(
                 s.suite_id,
@@ -5160,16 +5188,46 @@ mod tests {
     }
 
     #[test]
-    fn suite_registry_rejects_noncanonical_params() {
+    fn suite_registry_rejects_oversized_pubkey_len() {
         let err = build_suite_registry_from_json(&[SuiteParamsJson {
             suite_id: 3,
-            pubkey_len: rubin_consensus::constants::ML_DSA_87_PUBKEY_BYTES,
-            sig_len: rubin_consensus::constants::ML_DSA_87_SIG_BYTES - 1,
+            pubkey_len: MAX_WITNESS_BYTES_PER_TX as u64 + 1,
+            sig_len: rubin_consensus::constants::ML_DSA_87_SIG_BYTES,
             verify_cost: rubin_consensus::constants::VERIFY_COST_ML_DSA_87,
             alg_name: "ML-DSA-87".to_string(),
         }])
         .unwrap_err();
         assert_eq!(err, "bad suite_registry");
+    }
+
+    #[test]
+    fn suite_registry_rejects_zero_verify_cost() {
+        let err = build_suite_registry_from_json(&[SuiteParamsJson {
+            suite_id: 3,
+            pubkey_len: rubin_consensus::constants::ML_DSA_87_PUBKEY_BYTES,
+            sig_len: rubin_consensus::constants::ML_DSA_87_SIG_BYTES,
+            verify_cost: 0,
+            alg_name: "ML-DSA-87".to_string(),
+        }])
+        .unwrap_err();
+        assert_eq!(err, "bad suite_registry");
+    }
+
+    #[test]
+    fn suite_registry_accepts_synthetic_params_for_harness_vectors() {
+        let registry = build_suite_registry_from_json(&[SuiteParamsJson {
+            suite_id: 3,
+            pubkey_len: 64,
+            sig_len: 0,
+            verify_cost: 9,
+            alg_name: "ML-DSA-87".to_string(),
+        }])
+        .expect("registry");
+        let registry = registry.expect("suite registry");
+        let params = registry.lookup(3).expect("suite 3 present");
+        assert_eq!(params.pubkey_len, 64);
+        assert_eq!(params.sig_len, 0);
+        assert_eq!(params.verify_cost, 9);
     }
 
     #[test]
@@ -5187,22 +5245,79 @@ mod tests {
 
     #[test]
     fn rotation_descriptor_check_accepts_legacy_openssl_alg_alias() {
-        let req: Request = serde_json::from_str(
-            r#"{
+        let payload = format!(
+            r#"{{
                 "op":"rotation_descriptor_check",
                 "network":"devnet",
                 "suite_registry":[
-                    {"suite_id":1,"pubkey_len":2592,"sig_len":4627,"verify_cost":8,"openssl_alg":"ML-DSA-87"},
-                    {"suite_id":2,"pubkey_len":2592,"sig_len":4627,"verify_cost":8,"openssl_alg":"ML-DSA-87"}
+                    {{"suite_id":1,"pubkey_len":{},"sig_len":{},"verify_cost":{},"openssl_alg":"ML-DSA-87"}},
+                    {{"suite_id":2,"pubkey_len":{},"sig_len":{},"verify_cost":{},"openssl_alg":"ML-DSA-87"}}
                 ],
-                "rotation_descriptor":{"name":"r1","old_suite_id":1,"new_suite_id":2,"create_height":10,"spend_height":20,"sunset_height":100}
-            }"#,
-        )
-        .expect("request");
+                "rotation_descriptor":{{"name":"r1","old_suite_id":1,"new_suite_id":2,"create_height":10,"spend_height":20,"sunset_height":100}}
+            }}"#,
+            rubin_consensus::constants::ML_DSA_87_PUBKEY_BYTES,
+            rubin_consensus::constants::ML_DSA_87_SIG_BYTES,
+            rubin_consensus::constants::VERIFY_COST_ML_DSA_87,
+            rubin_consensus::constants::ML_DSA_87_PUBKEY_BYTES,
+            rubin_consensus::constants::ML_DSA_87_SIG_BYTES,
+            rubin_consensus::constants::VERIFY_COST_ML_DSA_87,
+        );
+        let req: Request = serde_json::from_str(&payload).expect("request");
         assert_eq!(req.suite_registry[0].alg_name, "ML-DSA-87");
         assert_eq!(req.suite_registry[1].alg_name, "ML-DSA-87");
         let resp = op_rotation_descriptor_check(&req);
         assert!(resp.ok, "unexpected err: {:?}", resp.err);
+    }
+
+    #[test]
+    fn rotation_descriptor_check_accepts_dual_alg_name_and_openssl_alg_keys() {
+        let payload = format!(
+            r#"{{
+                "op":"rotation_descriptor_check",
+                "network":"devnet",
+                "suite_registry":[
+                    {{"suite_id":1,"pubkey_len":{},"sig_len":{},"verify_cost":{},"alg_name":"ML-DSA-87","openssl_alg":"ML-DSA-87"}},
+                    {{"suite_id":2,"pubkey_len":{},"sig_len":{},"verify_cost":{},"alg_name":"ML-DSA-87","openssl_alg":"ML-DSA-87"}}
+                ],
+                "rotation_descriptor":{{"name":"r1","old_suite_id":1,"new_suite_id":2,"create_height":10,"spend_height":20,"sunset_height":100}}
+            }}"#,
+            rubin_consensus::constants::ML_DSA_87_PUBKEY_BYTES,
+            rubin_consensus::constants::ML_DSA_87_SIG_BYTES,
+            rubin_consensus::constants::VERIFY_COST_ML_DSA_87,
+            rubin_consensus::constants::ML_DSA_87_PUBKEY_BYTES,
+            rubin_consensus::constants::ML_DSA_87_SIG_BYTES,
+            rubin_consensus::constants::VERIFY_COST_ML_DSA_87,
+        );
+        let req: Request = serde_json::from_str(&payload).expect("request");
+        assert_eq!(req.suite_registry[0].alg_name, "ML-DSA-87");
+        assert_eq!(req.suite_registry[1].alg_name, "ML-DSA-87");
+        let resp = op_rotation_descriptor_check(&req);
+        assert!(resp.ok, "unexpected err: {:?}", resp.err);
+    }
+
+    #[test]
+    fn rotation_descriptor_check_rejects_empty_alg_name_even_with_legacy_alias() {
+        let payload = format!(
+            r#"{{
+                "op":"rotation_descriptor_check",
+                "network":"devnet",
+                "suite_registry":[
+                    {{"suite_id":1,"pubkey_len":{},"sig_len":{},"verify_cost":{},"alg_name":"","openssl_alg":"ML-DSA-87"}},
+                    {{"suite_id":2,"pubkey_len":{},"sig_len":{},"verify_cost":{},"alg_name":"ML-DSA-87","openssl_alg":"ML-DSA-87"}}
+                ],
+                "rotation_descriptor":{{"name":"r1","old_suite_id":1,"new_suite_id":2,"create_height":10,"spend_height":20,"sunset_height":100}}
+            }}"#,
+            rubin_consensus::constants::ML_DSA_87_PUBKEY_BYTES,
+            rubin_consensus::constants::ML_DSA_87_SIG_BYTES,
+            rubin_consensus::constants::VERIFY_COST_ML_DSA_87,
+            rubin_consensus::constants::ML_DSA_87_PUBKEY_BYTES,
+            rubin_consensus::constants::ML_DSA_87_SIG_BYTES,
+            rubin_consensus::constants::VERIFY_COST_ML_DSA_87,
+        );
+        let req: Request = serde_json::from_str(&payload).expect("request");
+        let resp = op_rotation_descriptor_check(&req);
+        assert!(!resp.ok);
+        assert_eq!(resp.err.as_deref(), Some("bad suite_registry"));
     }
 
     #[test]

--- a/clients/rust/crates/rubin-consensus-cli/src/main.rs
+++ b/clients/rust/crates/rubin-consensus-cli/src/main.rs
@@ -3,6 +3,7 @@ mod txctx_harness;
 
 use num_bigint::BigUint;
 use num_traits::Zero;
+use rubin_consensus::constants::MAX_WITNESS_BYTES_PER_TX;
 use rubin_consensus::merkle::witness_merkle_root_wtxids;
 use rubin_consensus::{
     apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles_and_suite_context,
@@ -954,9 +955,18 @@ fn decode_optional_hex_bytes(name: &str, value: &str) -> Result<Vec<u8>, String>
 
 fn normalize_suite_alg_name(value: &str) -> Result<&'static str, String> {
     match value.trim() {
-        "" | "ML-DSA-87" => Ok("ML-DSA-87"),
+        "ML-DSA-87" => Ok("ML-DSA-87"),
         _ => Err("bad suite_registry".to_string()),
     }
+}
+
+const MAX_EXPLICIT_SUITE_REGISTRY_ITEMS: usize = 16;
+
+fn validate_suite_registry_param_len(value: u64) -> Result<u64, String> {
+    if value == 0 || value > MAX_WITNESS_BYTES_PER_TX as u64 {
+        return Err("bad suite_registry".to_string());
+    }
+    Ok(value)
 }
 
 fn build_suite_registry_from_json(
@@ -965,17 +975,25 @@ fn build_suite_registry_from_json(
     if items.is_empty() {
         return Ok(None);
     }
+    if items.len() > MAX_EXPLICIT_SUITE_REGISTRY_ITEMS {
+        return Err("bad suite_registry".to_string());
+    }
 
     let mut suites = std::collections::BTreeMap::new();
     for s in items {
+        if s.suite_id == rubin_consensus::constants::SUITE_ID_SENTINEL || s.verify_cost == 0 {
+            return Err("bad suite_registry".to_string());
+        }
+        let pubkey_len = validate_suite_registry_param_len(s.pubkey_len)?;
+        let sig_len = validate_suite_registry_param_len(s.sig_len)?;
         let alg = normalize_suite_alg_name(&s.alg_name)?;
         if suites
             .insert(
                 s.suite_id,
                 SuiteParams {
                     suite_id: s.suite_id,
-                    pubkey_len: s.pubkey_len,
-                    sig_len: s.sig_len,
+                    pubkey_len,
+                    sig_len,
                     verify_cost: s.verify_cost,
                     alg_name: alg,
                 },
@@ -5086,6 +5104,19 @@ mod tests {
     }
 
     #[test]
+    fn suite_registry_rejects_empty_alg_name() {
+        let err = build_suite_registry_from_json(&[SuiteParamsJson {
+            suite_id: 3,
+            pubkey_len: 2592,
+            sig_len: 4627,
+            verify_cost: 990000,
+            alg_name: "".to_string(),
+        }])
+        .unwrap_err();
+        assert_eq!(err, "bad suite_registry");
+    }
+
+    #[test]
     fn suite_registry_rejects_duplicate_suite_ids() {
         let err = build_suite_registry_from_json(&[
             SuiteParamsJson {
@@ -5104,6 +5135,21 @@ mod tests {
             },
         ])
         .unwrap_err();
+        assert_eq!(err, "bad suite_registry");
+    }
+
+    #[test]
+    fn suite_registry_rejects_oversized_registry() {
+        let items = (0..(MAX_EXPLICIT_SUITE_REGISTRY_ITEMS + 1))
+            .map(|idx| SuiteParamsJson {
+                suite_id: (idx + 1) as u8,
+                pubkey_len: 2592,
+                sig_len: 4627,
+                verify_cost: 990000,
+                alg_name: "ML-DSA-87".to_string(),
+            })
+            .collect::<Vec<_>>();
+        let err = build_suite_registry_from_json(&items).unwrap_err();
         assert_eq!(err, "bad suite_registry");
     }
 

--- a/clients/rust/crates/rubin-consensus-cli/src/main.rs
+++ b/clients/rust/crates/rubin-consensus-cli/src/main.rs
@@ -618,13 +618,13 @@ struct SuiteParamsJson {
 #[derive(Deserialize, Default)]
 struct SuiteParamsJsonWire {
     #[serde(default)]
-    suite_id: u8,
+    suite_id: Option<u8>,
     #[serde(default)]
-    pubkey_len: u64,
+    pubkey_len: Option<u64>,
     #[serde(default)]
-    sig_len: u64,
+    sig_len: Option<u64>,
     #[serde(default)]
-    verify_cost: u64,
+    verify_cost: Option<u64>,
     #[serde(default)]
     alg_name: Option<String>,
     #[serde(default)]
@@ -637,16 +637,28 @@ impl<'de> Deserialize<'de> for SuiteParamsJson {
         D: Deserializer<'de>,
     {
         let wire = SuiteParamsJsonWire::deserialize(deserializer)?;
+        let suite_id = wire
+            .suite_id
+            .ok_or_else(|| serde::de::Error::custom("bad suite_registry"))?;
+        let pubkey_len = wire
+            .pubkey_len
+            .ok_or_else(|| serde::de::Error::custom("bad suite_registry"))?;
+        let sig_len = wire
+            .sig_len
+            .ok_or_else(|| serde::de::Error::custom("bad suite_registry"))?;
+        let verify_cost = wire
+            .verify_cost
+            .ok_or_else(|| serde::de::Error::custom("bad suite_registry"))?;
         let alg_name = if let Some(value) = wire.alg_name {
             value
         } else {
             wire.openssl_alg.unwrap_or_default()
         };
         Ok(Self {
-            suite_id: wire.suite_id,
-            pubkey_len: wire.pubkey_len,
-            sig_len: wire.sig_len,
-            verify_cost: wire.verify_cost,
+            suite_id,
+            pubkey_len,
+            sig_len,
+            verify_cost,
             alg_name,
         })
     }
@@ -1021,8 +1033,9 @@ fn build_suite_registry_from_json(
         let pubkey_len = validate_suite_registry_param_len(s.pubkey_len)?;
         let sig_len = validate_suite_registry_param_len(s.sig_len)?;
         let alg = normalize_suite_alg_name(&s.alg_name)?;
-        // CLI suite_registry is a harness overlay: keep synthetic param shapes
-        // for conformance vectors, but normalize/validate the renamed alg_name surface.
+        // Missing required JSON fields are rejected during Deserialize above.
+        // Reaching this path means zero-valued lengths were explicit, which the
+        // CLI harness still permits for synthetic conformance vectors.
         if suites
             .insert(
                 s.suite_id,
@@ -5320,6 +5333,56 @@ mod tests {
         let resp = op_rotation_descriptor_check(&req);
         assert!(!resp.ok);
         assert_eq!(resp.err.as_deref(), Some("bad suite_registry"));
+    }
+
+    #[test]
+    fn rotation_descriptor_check_rejects_missing_suite_registry_pubkey_len() {
+        let payload = format!(
+            r#"{{
+                "op":"rotation_descriptor_check",
+                "network":"devnet",
+                "suite_registry":[
+                    {{"suite_id":1,"sig_len":{},"verify_cost":{},"alg_name":"ML-DSA-87"}},
+                    {{"suite_id":2,"pubkey_len":{},"sig_len":{},"verify_cost":{},"alg_name":"ML-DSA-87"}}
+                ],
+                "rotation_descriptor":{{"name":"r1","old_suite_id":1,"new_suite_id":2,"create_height":10,"spend_height":20,"sunset_height":100}}
+            }}"#,
+            rubin_consensus::constants::ML_DSA_87_SIG_BYTES,
+            rubin_consensus::constants::VERIFY_COST_ML_DSA_87,
+            rubin_consensus::constants::ML_DSA_87_PUBKEY_BYTES,
+            rubin_consensus::constants::ML_DSA_87_SIG_BYTES,
+            rubin_consensus::constants::VERIFY_COST_ML_DSA_87,
+        );
+        let err = match serde_json::from_str::<Request>(&payload) {
+            Ok(_) => panic!("expected missing pubkey_len to fail closed during deserialize"),
+            Err(err) => err,
+        };
+        assert!(err.to_string().contains("bad suite_registry"));
+    }
+
+    #[test]
+    fn rotation_descriptor_check_rejects_missing_suite_registry_sig_len() {
+        let payload = format!(
+            r#"{{
+                "op":"rotation_descriptor_check",
+                "network":"devnet",
+                "suite_registry":[
+                    {{"suite_id":1,"pubkey_len":{},"verify_cost":{},"alg_name":"ML-DSA-87"}},
+                    {{"suite_id":2,"pubkey_len":{},"sig_len":{},"verify_cost":{},"alg_name":"ML-DSA-87"}}
+                ],
+                "rotation_descriptor":{{"name":"r1","old_suite_id":1,"new_suite_id":2,"create_height":10,"spend_height":20,"sunset_height":100}}
+            }}"#,
+            rubin_consensus::constants::ML_DSA_87_PUBKEY_BYTES,
+            rubin_consensus::constants::VERIFY_COST_ML_DSA_87,
+            rubin_consensus::constants::ML_DSA_87_PUBKEY_BYTES,
+            rubin_consensus::constants::ML_DSA_87_SIG_BYTES,
+            rubin_consensus::constants::VERIFY_COST_ML_DSA_87,
+        );
+        let err = match serde_json::from_str::<Request>(&payload) {
+            Ok(_) => panic!("expected missing sig_len to fail closed during deserialize"),
+            Err(err) => err,
+        };
+        assert!(err.to_string().contains("bad suite_registry"));
     }
 
     #[test]

--- a/clients/rust/crates/rubin-consensus-cli/src/main.rs
+++ b/clients/rust/crates/rubin-consensus-cli/src/main.rs
@@ -5128,9 +5128,9 @@ mod tests {
     fn suite_registry_rejects_unknown_alg_name() {
         let err = build_suite_registry_from_json(&[SuiteParamsJson {
             suite_id: 3,
-            pubkey_len: 2592,
-            sig_len: 4627,
-            verify_cost: 990000,
+            pubkey_len: rubin_consensus::constants::ML_DSA_87_PUBKEY_BYTES,
+            sig_len: rubin_consensus::constants::ML_DSA_87_SIG_BYTES,
+            verify_cost: rubin_consensus::constants::VERIFY_COST_ML_DSA_87,
             alg_name: "SLH-DSA".to_string(),
         }])
         .unwrap_err();
@@ -5141,9 +5141,9 @@ mod tests {
     fn suite_registry_rejects_empty_alg_name() {
         let err = build_suite_registry_from_json(&[SuiteParamsJson {
             suite_id: 3,
-            pubkey_len: 2592,
-            sig_len: 4627,
-            verify_cost: 990000,
+            pubkey_len: rubin_consensus::constants::ML_DSA_87_PUBKEY_BYTES,
+            sig_len: rubin_consensus::constants::ML_DSA_87_SIG_BYTES,
+            verify_cost: rubin_consensus::constants::VERIFY_COST_ML_DSA_87,
             alg_name: "".to_string(),
         }])
         .unwrap_err();
@@ -5155,16 +5155,16 @@ mod tests {
         let err = build_suite_registry_from_json(&[
             SuiteParamsJson {
                 suite_id: 3,
-                pubkey_len: 2592,
-                sig_len: 4627,
-                verify_cost: 990000,
+                pubkey_len: rubin_consensus::constants::ML_DSA_87_PUBKEY_BYTES,
+                sig_len: rubin_consensus::constants::ML_DSA_87_SIG_BYTES,
+                verify_cost: rubin_consensus::constants::VERIFY_COST_ML_DSA_87,
                 alg_name: "ML-DSA-87".to_string(),
             },
             SuiteParamsJson {
                 suite_id: 3,
-                pubkey_len: 2592,
-                sig_len: 4627,
-                verify_cost: 990000,
+                pubkey_len: rubin_consensus::constants::ML_DSA_87_PUBKEY_BYTES,
+                sig_len: rubin_consensus::constants::ML_DSA_87_SIG_BYTES,
+                verify_cost: rubin_consensus::constants::VERIFY_COST_ML_DSA_87,
                 alg_name: "ML-DSA-87".to_string(),
             },
         ])
@@ -5177,9 +5177,9 @@ mod tests {
         let items = (0..(MAX_EXPLICIT_SUITE_REGISTRY_ITEMS + 1))
             .map(|idx| SuiteParamsJson {
                 suite_id: (idx + 1) as u8,
-                pubkey_len: 2592,
-                sig_len: 4627,
-                verify_cost: 990000,
+                pubkey_len: rubin_consensus::constants::ML_DSA_87_PUBKEY_BYTES,
+                sig_len: rubin_consensus::constants::ML_DSA_87_SIG_BYTES,
+                verify_cost: rubin_consensus::constants::VERIFY_COST_ML_DSA_87,
                 alg_name: "ML-DSA-87".to_string(),
             })
             .collect::<Vec<_>>();

--- a/clients/rust/crates/rubin-consensus-cli/src/main.rs
+++ b/clients/rust/crates/rubin-consensus-cli/src/main.rs
@@ -615,8 +615,8 @@ struct SuiteParamsJson {
     sig_len: u64,
     #[serde(default)]
     verify_cost: u64,
-    #[serde(default)]
-    openssl_alg: String,
+    #[serde(default, rename = "alg_name", alias = "openssl_alg")]
+    alg_name: String,
 }
 
 #[derive(Deserialize)]
@@ -952,7 +952,7 @@ fn decode_optional_hex_bytes(name: &str, value: &str) -> Result<Vec<u8>, String>
     hex::decode(trimmed).map_err(|_| format!("bad {name}"))
 }
 
-fn normalize_suite_openssl_alg(value: &str) -> Result<&'static str, String> {
+fn normalize_suite_alg_name(value: &str) -> Result<&'static str, String> {
     match value.trim() {
         "" | "ML-DSA-87" => Ok("ML-DSA-87"),
         _ => Err("bad suite_registry".to_string()),
@@ -968,7 +968,7 @@ fn build_suite_registry_from_json(
 
     let mut suites = std::collections::BTreeMap::new();
     for s in items {
-        let alg = normalize_suite_openssl_alg(&s.openssl_alg)?;
+        let alg = normalize_suite_alg_name(&s.alg_name)?;
         if suites
             .insert(
                 s.suite_id,
@@ -977,7 +977,7 @@ fn build_suite_registry_from_json(
                     pubkey_len: s.pubkey_len,
                     sig_len: s.sig_len,
                     verify_cost: s.verify_cost,
-                    openssl_alg: alg,
+                    alg_name: alg,
                 },
             )
             .is_some()
@@ -4645,21 +4645,21 @@ mod tests {
                 pubkey_len: rubin_consensus::constants::ML_DSA_87_PUBKEY_BYTES,
                 sig_len: rubin_consensus::constants::ML_DSA_87_SIG_BYTES,
                 verify_cost: rubin_consensus::constants::VERIFY_COST_ML_DSA_87,
-                openssl_alg: "ML-DSA-87".to_string(),
+                alg_name: "ML-DSA-87".to_string(),
             },
             SuiteParamsJson {
                 suite_id: 2,
                 pubkey_len: 1024,
                 sig_len: 512,
                 verify_cost: 9,
-                openssl_alg: "ML-DSA-87".to_string(),
+                alg_name: "ML-DSA-87".to_string(),
             },
             SuiteParamsJson {
                 suite_id: 3,
                 pubkey_len: 1024,
                 sig_len: 512,
                 verify_cost: 9,
-                openssl_alg: "ML-DSA-87".to_string(),
+                alg_name: "ML-DSA-87".to_string(),
             },
         ]
     }
@@ -5073,13 +5073,13 @@ mod tests {
     }
 
     #[test]
-    fn suite_registry_rejects_unknown_openssl_alg() {
+    fn suite_registry_rejects_unknown_alg_name() {
         let err = build_suite_registry_from_json(&[SuiteParamsJson {
             suite_id: 3,
             pubkey_len: 2592,
             sig_len: 4627,
             verify_cost: 990000,
-            openssl_alg: "SLH-DSA".to_string(),
+            alg_name: "SLH-DSA".to_string(),
         }])
         .unwrap_err();
         assert_eq!(err, "bad suite_registry");
@@ -5093,18 +5093,38 @@ mod tests {
                 pubkey_len: 2592,
                 sig_len: 4627,
                 verify_cost: 990000,
-                openssl_alg: "ML-DSA-87".to_string(),
+                alg_name: "ML-DSA-87".to_string(),
             },
             SuiteParamsJson {
                 suite_id: 3,
                 pubkey_len: 2592,
                 sig_len: 4627,
                 verify_cost: 990000,
-                openssl_alg: "ML-DSA-87".to_string(),
+                alg_name: "ML-DSA-87".to_string(),
             },
         ])
         .unwrap_err();
         assert_eq!(err, "bad suite_registry");
+    }
+
+    #[test]
+    fn rotation_descriptor_check_accepts_legacy_openssl_alg_alias() {
+        let req: Request = serde_json::from_str(
+            r#"{
+                "op":"rotation_descriptor_check",
+                "network":"devnet",
+                "suite_registry":[
+                    {"suite_id":1,"pubkey_len":2592,"sig_len":4627,"verify_cost":8,"openssl_alg":"ML-DSA-87"},
+                    {"suite_id":2,"pubkey_len":1024,"sig_len":512,"verify_cost":9,"openssl_alg":"ML-DSA-87"}
+                ],
+                "rotation_descriptor":{"name":"r1","old_suite_id":1,"new_suite_id":2,"create_height":10,"spend_height":20,"sunset_height":100}
+            }"#,
+        )
+        .expect("request");
+        assert_eq!(req.suite_registry[0].alg_name, "ML-DSA-87");
+        assert_eq!(req.suite_registry[1].alg_name, "ML-DSA-87");
+        let resp = op_rotation_descriptor_check(&req);
+        assert!(resp.ok, "unexpected err: {:?}", resp.err);
     }
 
     #[test]

--- a/clients/rust/crates/rubin-consensus-cli/src/main.rs
+++ b/clients/rust/crates/rubin-consensus-cli/src/main.rs
@@ -987,6 +987,12 @@ fn build_suite_registry_from_json(
         let pubkey_len = validate_suite_registry_param_len(s.pubkey_len)?;
         let sig_len = validate_suite_registry_param_len(s.sig_len)?;
         let alg = normalize_suite_alg_name(&s.alg_name)?;
+        if pubkey_len != rubin_consensus::constants::ML_DSA_87_PUBKEY_BYTES
+            || sig_len != rubin_consensus::constants::ML_DSA_87_SIG_BYTES
+            || s.verify_cost != rubin_consensus::constants::VERIFY_COST_ML_DSA_87
+        {
+            return Err("bad suite_registry".to_string());
+        }
         if suites
             .insert(
                 s.suite_id,
@@ -4667,16 +4673,16 @@ mod tests {
             },
             SuiteParamsJson {
                 suite_id: 2,
-                pubkey_len: 1024,
-                sig_len: 512,
-                verify_cost: 9,
+                pubkey_len: rubin_consensus::constants::ML_DSA_87_PUBKEY_BYTES,
+                sig_len: rubin_consensus::constants::ML_DSA_87_SIG_BYTES,
+                verify_cost: rubin_consensus::constants::VERIFY_COST_ML_DSA_87,
                 alg_name: "ML-DSA-87".to_string(),
             },
             SuiteParamsJson {
                 suite_id: 3,
-                pubkey_len: 1024,
-                sig_len: 512,
-                verify_cost: 9,
+                pubkey_len: rubin_consensus::constants::ML_DSA_87_PUBKEY_BYTES,
+                sig_len: rubin_consensus::constants::ML_DSA_87_SIG_BYTES,
+                verify_cost: rubin_consensus::constants::VERIFY_COST_ML_DSA_87,
                 alg_name: "ML-DSA-87".to_string(),
             },
         ]
@@ -5154,6 +5160,32 @@ mod tests {
     }
 
     #[test]
+    fn suite_registry_rejects_noncanonical_params() {
+        let err = build_suite_registry_from_json(&[SuiteParamsJson {
+            suite_id: 3,
+            pubkey_len: rubin_consensus::constants::ML_DSA_87_PUBKEY_BYTES,
+            sig_len: rubin_consensus::constants::ML_DSA_87_SIG_BYTES - 1,
+            verify_cost: rubin_consensus::constants::VERIFY_COST_ML_DSA_87,
+            alg_name: "ML-DSA-87".to_string(),
+        }])
+        .unwrap_err();
+        assert_eq!(err, "bad suite_registry");
+    }
+
+    #[test]
+    fn suite_registry_rejects_lowercase_alg_name() {
+        let err = build_suite_registry_from_json(&[SuiteParamsJson {
+            suite_id: 3,
+            pubkey_len: rubin_consensus::constants::ML_DSA_87_PUBKEY_BYTES,
+            sig_len: rubin_consensus::constants::ML_DSA_87_SIG_BYTES,
+            verify_cost: rubin_consensus::constants::VERIFY_COST_ML_DSA_87,
+            alg_name: "ml-dsa-87".to_string(),
+        }])
+        .unwrap_err();
+        assert_eq!(err, "bad suite_registry");
+    }
+
+    #[test]
     fn rotation_descriptor_check_accepts_legacy_openssl_alg_alias() {
         let req: Request = serde_json::from_str(
             r#"{
@@ -5161,7 +5193,7 @@ mod tests {
                 "network":"devnet",
                 "suite_registry":[
                     {"suite_id":1,"pubkey_len":2592,"sig_len":4627,"verify_cost":8,"openssl_alg":"ML-DSA-87"},
-                    {"suite_id":2,"pubkey_len":1024,"sig_len":512,"verify_cost":9,"openssl_alg":"ML-DSA-87"}
+                    {"suite_id":2,"pubkey_len":2592,"sig_len":4627,"verify_cost":8,"openssl_alg":"ML-DSA-87"}
                 ],
                 "rotation_descriptor":{"name":"r1","old_suite_id":1,"new_suite_id":2,"create_height":10,"spend_height":20,"sunset_height":100}
             }"#,

--- a/clients/rust/crates/rubin-consensus/src/core_ext.rs
+++ b/clients/rust/crates/rubin-consensus/src/core_ext.rs
@@ -2205,7 +2205,7 @@ mod tests {
                 pubkey_len: ML_DSA_87_PUBKEY_BYTES,
                 sig_len: ML_DSA_87_SIG_BYTES,
                 verify_cost: VERIFY_COST_ML_DSA_87,
-                openssl_alg: "ML-DSA-87",
+                alg_name: "ML-DSA-87",
             },
         );
         let reg = SuiteRegistry::with_suites(suites);
@@ -2267,7 +2267,7 @@ mod tests {
                 pubkey_len: ML_DSA_87_PUBKEY_BYTES,
                 sig_len: ML_DSA_87_SIG_BYTES,
                 verify_cost: VERIFY_COST_ML_DSA_87,
-                openssl_alg: "ML-DSA-87",
+                alg_name: "ML-DSA-87",
             },
         );
         let reg = SuiteRegistry::with_suites(suites);

--- a/clients/rust/crates/rubin-consensus/src/htlc.rs
+++ b/clients/rust/crates/rubin-consensus/src/htlc.rs
@@ -408,7 +408,7 @@ mod tests {
                 pubkey_len: ML_DSA_87_PUBKEY_BYTES,
                 sig_len: ML_DSA_87_SIG_BYTES,
                 verify_cost: VERIFY_COST_ML_DSA_87,
-                openssl_alg: "ML-DSA-87",
+                alg_name: "ML-DSA-87",
             },
         );
         suites.insert(
@@ -418,7 +418,7 @@ mod tests {
                 pubkey_len: 32,
                 sig_len: 64,
                 verify_cost: 100,
-                openssl_alg: "TEST-SUITE",
+                alg_name: "TEST-SUITE",
             },
         );
         let registry = SuiteRegistry::with_suites(suites);

--- a/clients/rust/crates/rubin-consensus/src/sig_queue.rs
+++ b/clients/rust/crates/rubin-consensus/src/sig_queue.rs
@@ -1025,7 +1025,7 @@ mod tests {
                 pubkey_len: ML_DSA_87_PUBKEY_BYTES,
                 sig_len: ML_DSA_87_SIG_BYTES,
                 verify_cost: VERIFY_COST_ML_DSA_87,
-                openssl_alg: "ML-DSA-87",
+                alg_name: "ML-DSA-87",
             },
         );
         suites.insert(
@@ -1035,7 +1035,7 @@ mod tests {
                 pubkey_len: ML_DSA_87_PUBKEY_BYTES,
                 sig_len: ML_DSA_87_SIG_BYTES,
                 verify_cost: VERIFY_COST_ML_DSA_87,
-                openssl_alg: "ML-DSA-87",
+                alg_name: "ML-DSA-87",
             },
         );
         let mismatched_registry = SuiteRegistry::with_suites(suites);
@@ -1101,7 +1101,7 @@ mod tests {
                 pubkey_len: u64::MAX,
                 sig_len: 0,
                 verify_cost: VERIFY_COST_ML_DSA_87,
-                openssl_alg: "ML-DSA-87",
+                alg_name: "ML-DSA-87",
             },
         );
         let registry = SuiteRegistry::with_suites(suites);
@@ -1145,7 +1145,7 @@ mod tests {
                 pubkey_len: ML_DSA_87_PUBKEY_BYTES,
                 sig_len: ML_DSA_87_SIG_BYTES,
                 verify_cost: VERIFY_COST_ML_DSA_87,
-                openssl_alg: "ML-DSA-87",
+                alg_name: "ML-DSA-87",
             },
         );
         suites.insert(
@@ -1155,7 +1155,7 @@ mod tests {
                 pubkey_len: 64,
                 sig_len: 100,
                 verify_cost: 1,
-                openssl_alg: "ML-DSA-87",
+                alg_name: "ML-DSA-87",
             },
         );
         let registry = SuiteRegistry::with_suites(suites);

--- a/clients/rust/crates/rubin-consensus/src/spend_verify.rs
+++ b/clients/rust/crates/rubin-consensus/src/spend_verify.rs
@@ -610,7 +610,7 @@ mod tests {
                 pubkey_len: ML_DSA_87_PUBKEY_BYTES,
                 sig_len: ML_DSA_87_SIG_BYTES,
                 verify_cost: VERIFY_COST_ML_DSA_87,
-                openssl_alg: "ML-DSA-87",
+                alg_name: "ML-DSA-87",
             },
         );
         let registry = SuiteRegistry::with_suites(suites);
@@ -637,7 +637,7 @@ mod tests {
                 pubkey_len: 1312,
                 sig_len: 2420,
                 verify_cost: 4,
-                openssl_alg: "ML-DSA-65",
+                alg_name: "ML-DSA-65",
             },
         );
         let registry = SuiteRegistry::with_suites(suites);
@@ -890,7 +890,7 @@ mod tests {
                 pubkey_len: ML_DSA_87_PUBKEY_BYTES,
                 sig_len: ML_DSA_87_SIG_BYTES,
                 verify_cost: 8,
-                openssl_alg: "ML-DSA-87",
+                alg_name: "ML-DSA-87",
             },
         );
         let registry = SuiteRegistry::with_suites(suites);
@@ -1209,7 +1209,7 @@ mod tests {
                 pubkey_len: ML_DSA_87_PUBKEY_BYTES,
                 sig_len: ML_DSA_87_SIG_BYTES,
                 verify_cost: 8,
-                openssl_alg: "ML-DSA-87",
+                alg_name: "ML-DSA-87",
             },
         );
         let registry = SuiteRegistry::with_suites(suites);

--- a/clients/rust/crates/rubin-consensus/src/suite_registry.rs
+++ b/clients/rust/crates/rubin-consensus/src/suite_registry.rs
@@ -16,8 +16,8 @@ pub struct SuiteParams {
     pub pubkey_len: u64,
     pub sig_len: u64,
     pub verify_cost: u64,
-    /// OpenSSL algorithm name for verify_sig dispatch (e.g. "ML-DSA-87").
-    pub openssl_alg: &'static str,
+    /// Semantic algorithm identity used to resolve the live verifier binding.
+    pub alg_name: &'static str,
 }
 
 /// Maps suite IDs to their consensus parameters. Single source of truth for
@@ -38,7 +38,7 @@ impl SuiteRegistry {
                 pubkey_len: ML_DSA_87_PUBKEY_BYTES,
                 sig_len: ML_DSA_87_SIG_BYTES,
                 verify_cost: VERIFY_COST_ML_DSA_87,
-                openssl_alg: "ML-DSA-87",
+                alg_name: "ML-DSA-87",
             },
         );
         Self { suites }
@@ -384,7 +384,7 @@ mod tests {
                 pubkey_len: 2592,
                 sig_len: 4627,
                 verify_cost: 8,
-                openssl_alg: "ML-DSA-87",
+                alg_name: "ML-DSA-87",
             },
         );
         suites.insert(
@@ -394,7 +394,7 @@ mod tests {
                 pubkey_len: 1024,
                 sig_len: 512,
                 verify_cost: 4,
-                openssl_alg: "ML-DSA-87",
+                alg_name: "ML-DSA-87",
             },
         );
         SuiteRegistry { suites }
@@ -420,7 +420,7 @@ mod tests {
                 pubkey_len: 100,
                 sig_len: 200,
                 verify_cost: 1,
-                openssl_alg: "ML-DSA-87",
+                alg_name: "ML-DSA-87",
             },
         );
         let reg = SuiteRegistry::with_suites(suites);
@@ -485,7 +485,7 @@ mod tests {
                 pubkey_len: 2592,
                 sig_len: 4627,
                 verify_cost: 8,
-                openssl_alg: "ML-DSA-87",
+                alg_name: "ML-DSA-87",
             },
         );
         suites.insert(
@@ -495,7 +495,7 @@ mod tests {
                 pubkey_len: 64,
                 sig_len: 100,
                 verify_cost: 1,
-                openssl_alg: "ML-DSA-87",
+                alg_name: "ML-DSA-87",
             },
         );
         let reg = SuiteRegistry::with_suites(suites);
@@ -515,7 +515,7 @@ mod tests {
                 pubkey_len: u64::MAX,
                 sig_len: 1,
                 verify_cost: 1,
-                openssl_alg: "ML-DSA-87",
+                alg_name: "ML-DSA-87",
             },
         );
         let reg = SuiteRegistry::with_suites(suites);
@@ -662,7 +662,7 @@ mod tests {
                 pubkey_len: 2592,
                 sig_len: 4627,
                 verify_cost: 8,
-                openssl_alg: "ML-DSA-87",
+                alg_name: "ML-DSA-87",
             },
         );
         suites.insert(
@@ -672,7 +672,7 @@ mod tests {
                 pubkey_len: 1024,
                 sig_len: 512,
                 verify_cost: 4,
-                openssl_alg: "ML-DSA-87",
+                alg_name: "ML-DSA-87",
             },
         );
         suites.insert(
@@ -682,7 +682,7 @@ mod tests {
                 pubkey_len: 1024,
                 sig_len: 512,
                 verify_cost: 4,
-                openssl_alg: "ML-DSA-87",
+                alg_name: "ML-DSA-87",
             },
         );
         SuiteRegistry::with_suites(suites)
@@ -756,7 +756,7 @@ mod tests {
                 pubkey_len: 2592,
                 sig_len: 4627,
                 verify_cost: 8,
-                openssl_alg: "ML-DSA-87",
+                alg_name: "ML-DSA-87",
             },
         );
         for id in [0x02u8, 0x03, 0x04] {
@@ -767,7 +767,7 @@ mod tests {
                     pubkey_len: 1024,
                     sig_len: 512,
                     verify_cost: 4,
-                    openssl_alg: "ML-DSA-87",
+                    alg_name: "ML-DSA-87",
                 },
             );
         }
@@ -978,7 +978,7 @@ mod tests {
         let p = r.lookup(crate::constants::SUITE_ID_ML_DSA_87).unwrap();
         assert_eq!(p.pubkey_len, crate::constants::ML_DSA_87_PUBKEY_BYTES);
         assert_eq!(p.sig_len, crate::constants::ML_DSA_87_SIG_BYTES);
-        assert_eq!(p.openssl_alg, "ML-DSA-87");
+        assert_eq!(p.alg_name, "ML-DSA-87");
         assert_eq!(p.verify_cost, crate::constants::VERIFY_COST_ML_DSA_87);
     }
 

--- a/clients/rust/crates/rubin-consensus/src/tests/block_basic.rs
+++ b/clients/rust/crates/rubin-consensus/src/tests/block_basic.rs
@@ -900,7 +900,7 @@ fn tx_weight_at_height_native_not_in_spend_set_uses_unknown_floor() {
             pubkey_len: ML_DSA_87_PUBKEY_BYTES,
             sig_len: ML_DSA_87_SIG_BYTES,
             verify_cost: VERIFY_COST_ML_DSA_87,
-            openssl_alg: "ML-DSA-87",
+            alg_name: "ML-DSA-87",
         },
     );
     suites.insert(
@@ -910,7 +910,7 @@ fn tx_weight_at_height_native_not_in_spend_set_uses_unknown_floor() {
             pubkey_len: 1312,
             sig_len: 2420,
             verify_cost: 4,
-            openssl_alg: "ML-DSA-65",
+            alg_name: "ML-DSA-65",
         },
     );
     let reg = SuiteRegistry::with_suites(suites);

--- a/clients/rust/crates/rubin-consensus/src/verify_sig_openssl.rs
+++ b/clients/rust/crates/rubin-consensus/src/verify_sig_openssl.rs
@@ -428,13 +428,13 @@ enum SuiteVerifierBinding {
 
 // v1 keeps the legacy ML-DSA-87 verifier on the explicit OpenSSL
 // archival/runtime path. Runtime dispatch must resolve a concrete binding
-// instead of treating registry.openssl_alg as an implicit backend switch.
+// instead of treating registry.alg_name as an implicit backend switch.
 fn resolve_suite_verifier_binding(
-    openssl_alg: &str,
+    alg_name: &str,
     pubkey_len: u64,
     sig_len: u64,
 ) -> Result<SuiteVerifierBinding, TxError> {
-    if openssl_alg == "ML-DSA-87"
+    if alg_name == "ML-DSA-87"
         && pubkey_len == ML_DSA_87_PUBKEY_BYTES
         && sig_len == ML_DSA_87_SIG_BYTES
     {
@@ -480,7 +480,7 @@ fn verify_sig_with_binding(
 /// Registry-aware signature verification. When registry is Some, looks up
 /// the suite's parameters from the registry. When registry is None, falls back
 /// to the hardcoded verify_sig path. The registry no longer selects a backend
-/// implicitly through `openssl_alg`; runtime verification resolves an explicit
+/// implicitly through `alg_name`; runtime verification resolves an explicit
 /// v1 binding from the suite parameters instead. Parity with Go
 /// `verifySigWithRegistry`.
 pub fn verify_sig_with_registry(
@@ -501,7 +501,7 @@ pub fn verify_sig_with_registry(
     };
     ensure_openssl_consensus_init()?;
     let binding =
-        resolve_suite_verifier_binding(params.openssl_alg, params.pubkey_len, params.sig_len)?;
+        resolve_suite_verifier_binding(params.alg_name, params.pubkey_len, params.sig_len)?;
     verify_sig_with_binding(&binding, pubkey, signature, digest32)
 }
 

--- a/clients/rust/crates/rubin-consensus/tests/rotation_descriptor_direct.rs
+++ b/clients/rust/crates/rubin-consensus/tests/rotation_descriptor_direct.rs
@@ -18,7 +18,7 @@ fn two_suite_registry() -> SuiteRegistry {
             pubkey_len: 2592,
             sig_len: 4627,
             verify_cost: 8,
-            openssl_alg: "ML-DSA-87",
+            alg_name: "ML-DSA-87",
         },
     );
     m.insert(
@@ -28,7 +28,7 @@ fn two_suite_registry() -> SuiteRegistry {
             pubkey_len: 1024,
             sig_len: 512,
             verify_cost: 4,
-            openssl_alg: "SLH-DSA-256s",
+            alg_name: "SLH-DSA-256s",
         },
     );
     SuiteRegistry::with_suites(m)
@@ -57,7 +57,7 @@ fn registry_default_has_ml_dsa_87() {
         .lookup(0x01)
         .expect("default registry must contain suite 0x01");
     assert_eq!(p.suite_id, 0x01);
-    assert_eq!(p.openssl_alg, "ML-DSA-87");
+    assert_eq!(p.alg_name, "ML-DSA-87");
 }
 
 #[test]
@@ -90,7 +90,7 @@ fn registry_min_sigcheck_overflow() {
             pubkey_len: u64::MAX,
             sig_len: 1,
             verify_cost: 0,
-            openssl_alg: "overflow",
+            alg_name: "overflow",
         },
     );
     let reg = SuiteRegistry::with_suites(m);

--- a/clients/rust/crates/rubin-node/src/genesis.rs
+++ b/clients/rust/crates/rubin-node/src/genesis.rs
@@ -910,7 +910,7 @@ mod tests {
     #[test]
     fn load_genesis_config_rejects_empty_suite_registry_alg_name() {
         let dir = std::env::temp_dir().join(format!(
-            "rubin-node-genesis-suite-registry-empty-openssl-{}",
+            "rubin-node-genesis-suite-registry-empty-alg-name-{}",
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .expect("time")
@@ -946,7 +946,7 @@ mod tests {
     fn load_genesis_config_rejects_alias_suite_registry_alg_name() {
         for (case_idx, alg) in ["ml-dsa-87", "MLDSA87"].into_iter().enumerate() {
             let dir = std::env::temp_dir().join(format!(
-                "rubin-node-genesis-suite-registry-alias-openssl-{}-{}",
+                "rubin-node-genesis-suite-registry-alg-name-alias-{}-{}",
                 case_idx,
                 std::time::SystemTime::now()
                     .duration_since(std::time::UNIX_EPOCH)

--- a/clients/rust/crates/rubin-node/src/genesis.rs
+++ b/clients/rust/crates/rubin-node/src/genesis.rs
@@ -991,12 +991,17 @@ mod tests {
         let path = dir.join("genesis.json");
         std::fs::write(
             &path,
-            "{\
-              \"chain_id_hex\":\"0x88f8a9acdeeb902e27aa2fdcb8c46ecf818bf68dec5273ec1bcc5084e2333103\",\
-              \"suite_registry\":[\
-                {\"suite_id\":66,\"pubkey_len\":2592,\"sig_len\":4627,\"verify_cost\":8,\"openssl_alg\":\"ML-DSA-87\"}\
-              ]\
-            }",
+            format!(
+                "{{\
+                  \"chain_id_hex\":\"0x88f8a9acdeeb902e27aa2fdcb8c46ecf818bf68dec5273ec1bcc5084e2333103\",\
+                  \"suite_registry\":[\
+                    {{\"suite_id\":66,\"pubkey_len\":{},\"sig_len\":{},\"verify_cost\":{},\"openssl_alg\":\"ML-DSA-87\"}}\
+                  ]\
+                }}",
+                ML_DSA_87_PUBKEY_BYTES,
+                ML_DSA_87_SIG_BYTES,
+                VERIFY_COST_ML_DSA_87
+            ),
         )
         .expect("write");
 

--- a/clients/rust/crates/rubin-node/src/genesis.rs
+++ b/clients/rust/crates/rubin-node/src/genesis.rs
@@ -203,7 +203,7 @@ pub fn load_genesis_config(
 fn normalize_suite_alg_name(value: &str) -> Result<&'static str, String> {
     const CANONICAL_SUITE_ALG_NAME: &str = "ML-DSA-87";
     let trimmed = value.trim();
-    if trimmed != CANONICAL_SUITE_ALG_NAME {
+    if !trimmed.eq_ignore_ascii_case(CANONICAL_SUITE_ALG_NAME) {
         return Err("bad suite_registry".to_string());
     }
     Ok(CANONICAL_SUITE_ALG_NAME)
@@ -945,8 +945,8 @@ mod tests {
     }
 
     #[test]
-    fn load_genesis_config_rejects_alias_suite_registry_alg_name() {
-        for (case_idx, alg) in ["ml-dsa-87", "MLDSA87"].into_iter().enumerate() {
+    fn load_genesis_config_accepts_case_insensitive_suite_registry_alg_name() {
+        for (case_idx, alg) in ["ml-dsa-87", "ML-dSa-87"].into_iter().enumerate() {
             let dir = std::env::temp_dir().join(format!(
                 "rubin-node-genesis-suite-registry-alg-name-alias-{}-{}",
                 case_idx,
@@ -975,11 +975,48 @@ mod tests {
             )
             .expect("write");
 
-            let err = load_genesis_config(Some(&path), "devnet").unwrap_err();
-            assert_eq!(err, "bad suite_registry");
+            let loaded = load_genesis_config(Some(&path), "devnet").expect("must load");
+            let ctx = loaded.suite_context.expect("suite context");
+            let params = ctx.registry.lookup(66).expect("suite 66");
+            assert_eq!(params.alg_name, "ML-DSA-87");
 
             std::fs::remove_dir_all(&dir).expect("cleanup");
         }
+    }
+
+    #[test]
+    fn load_genesis_config_rejects_malformed_suite_registry_alg_name() {
+        let dir = std::env::temp_dir().join(format!(
+            "rubin-node-genesis-suite-registry-bad-alg-name-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("time")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        let path = dir.join("genesis.json");
+        std::fs::write(
+            &path,
+            format!(
+                "{{\
+                  \"chain_id_hex\":\"0x88f8a9acdeeb902e27aa2fdcb8c46ecf818bf68dec5273ec1bcc5084e2333103\",\
+                  \"suite_registry\":[{}]\
+                }}",
+                suite_registry_entry_json(
+                    66,
+                    ML_DSA_87_PUBKEY_BYTES,
+                    ML_DSA_87_SIG_BYTES,
+                    VERIFY_COST_ML_DSA_87,
+                    "MLDSA87",
+                )
+            ),
+        )
+        .expect("write");
+
+        let err = load_genesis_config(Some(&path), "devnet").unwrap_err();
+        assert_eq!(err, "bad suite_registry");
+
+        std::fs::remove_dir_all(&dir).expect("cleanup");
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/genesis.rs
+++ b/clients/rust/crates/rubin-node/src/genesis.rs
@@ -57,14 +57,46 @@ struct GenesisRotationDescriptor {
     sunset_height: u64,
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 struct GenesisSuiteParams {
     suite_id: u8,
     pubkey_len: u64,
     sig_len: u64,
     verify_cost: u64,
-    #[serde(default, rename = "alg_name", alias = "openssl_alg")]
     alg_name: String,
+}
+
+#[derive(Deserialize)]
+struct GenesisSuiteParamsWire {
+    suite_id: u8,
+    pubkey_len: u64,
+    sig_len: u64,
+    verify_cost: u64,
+    #[serde(default)]
+    alg_name: Option<String>,
+    #[serde(default)]
+    openssl_alg: Option<String>,
+}
+
+impl<'de> Deserialize<'de> for GenesisSuiteParams {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let wire = GenesisSuiteParamsWire::deserialize(deserializer)?;
+        let alg_name = if let Some(value) = wire.alg_name {
+            value
+        } else {
+            wire.openssl_alg.unwrap_or_default()
+        };
+        Ok(Self {
+            suite_id: wire.suite_id,
+            pubkey_len: wire.pubkey_len,
+            sig_len: wire.sig_len,
+            verify_cost: wire.verify_cost,
+            alg_name,
+        })
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
@@ -972,6 +1004,70 @@ mod tests {
         let ctx = loaded.suite_context.expect("suite context");
         let params = ctx.registry.lookup(66).expect("suite 66");
         assert_eq!(params.alg_name, "ML-DSA-87");
+
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    #[test]
+    fn load_genesis_config_accepts_dual_suite_registry_keys_with_alg_name_precedence() {
+        let dir = std::env::temp_dir().join(format!(
+            "rubin-node-genesis-suite-registry-dual-keys-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("time")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        let path = dir.join("genesis.json");
+        std::fs::write(
+            &path,
+            format!(
+                "{{\
+                  \"chain_id_hex\":\"0x88f8a9acdeeb902e27aa2fdcb8c46ecf818bf68dec5273ec1bcc5084e2333103\",\
+                  \"suite_registry\":[\
+                    {{\"suite_id\":66,\"pubkey_len\":{},\"sig_len\":{},\"verify_cost\":{},\"alg_name\":\"ML-DSA-87\",\"openssl_alg\":\"ML-DSA-87\"}}\
+                  ]\
+                }}",
+                ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES, VERIFY_COST_ML_DSA_87
+            ),
+        )
+        .expect("write");
+
+        let loaded = load_genesis_config(Some(&path), "devnet").expect("must load");
+        let ctx = loaded.suite_context.expect("suite context");
+        let params = ctx.registry.lookup(66).expect("suite 66");
+        assert_eq!(params.alg_name, "ML-DSA-87");
+
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    #[test]
+    fn load_genesis_config_rejects_empty_alg_name_even_with_legacy_alias() {
+        let dir = std::env::temp_dir().join(format!(
+            "rubin-node-genesis-suite-registry-empty-dual-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("time")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        let path = dir.join("genesis.json");
+        std::fs::write(
+            &path,
+            format!(
+                "{{\
+                  \"chain_id_hex\":\"0x88f8a9acdeeb902e27aa2fdcb8c46ecf818bf68dec5273ec1bcc5084e2333103\",\
+                  \"suite_registry\":[\
+                    {{\"suite_id\":66,\"pubkey_len\":{},\"sig_len\":{},\"verify_cost\":{},\"alg_name\":\"\",\"openssl_alg\":\"ML-DSA-87\"}}\
+                  ]\
+                }}",
+                ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES, VERIFY_COST_ML_DSA_87
+            ),
+        )
+        .expect("write");
+
+        let err = load_genesis_config(Some(&path), "devnet").unwrap_err();
+        assert_eq!(err, "bad suite_registry");
 
         std::fs::remove_dir_all(&dir).expect("cleanup");
     }

--- a/clients/rust/crates/rubin-node/src/genesis.rs
+++ b/clients/rust/crates/rubin-node/src/genesis.rs
@@ -63,7 +63,8 @@ struct GenesisSuiteParams {
     pubkey_len: u64,
     sig_len: u64,
     verify_cost: u64,
-    openssl_alg: String,
+    #[serde(default, rename = "alg_name", alias = "openssl_alg")]
+    alg_name: String,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
@@ -167,7 +168,7 @@ pub fn load_genesis_config(
     })
 }
 
-fn normalize_suite_openssl_alg(value: &str) -> Result<&'static str, String> {
+fn normalize_suite_alg_name(value: &str) -> Result<&'static str, String> {
     match value.trim() {
         "ML-DSA-87" => Ok("ML-DSA-87"),
         _ => Err("bad suite_registry".to_string()),
@@ -180,7 +181,7 @@ fn default_suite_registry_params() -> SuiteParams {
         pubkey_len: ML_DSA_87_PUBKEY_BYTES,
         sig_len: ML_DSA_87_SIG_BYTES,
         verify_cost: VERIFY_COST_ML_DSA_87,
-        openssl_alg: "ML-DSA-87",
+        alg_name: "ML-DSA-87",
     }
 }
 
@@ -204,7 +205,7 @@ fn validate_suite_registry_item(item: &GenesisSuiteParams) -> Result<SuiteParams
         pubkey_len,
         sig_len,
         verify_cost: item.verify_cost,
-        openssl_alg: normalize_suite_openssl_alg(&item.openssl_alg)?,
+        alg_name: normalize_suite_alg_name(&item.alg_name)?,
     };
     let want = default_suite_registry_params();
     if params.pubkey_len != want.pubkey_len
@@ -462,10 +463,10 @@ mod tests {
         pubkey_len: u64,
         sig_len: u64,
         verify_cost: u64,
-        openssl_alg: &str,
+        alg_name: &str,
     ) -> String {
         format!(
-            "{{\"suite_id\":{suite_id},\"pubkey_len\":{pubkey_len},\"sig_len\":{sig_len},\"verify_cost\":{verify_cost},\"openssl_alg\":\"{openssl_alg}\"}}"
+            "{{\"suite_id\":{suite_id},\"pubkey_len\":{pubkey_len},\"sig_len\":{sig_len},\"verify_cost\":{verify_cost},\"alg_name\":\"{alg_name}\"}}"
         )
     }
 
@@ -798,7 +799,7 @@ mod tests {
             "{\
               \"chain_id_hex\":\"0x88f8a9acdeeb902e27aa2fdcb8c46ecf818bf68dec5273ec1bcc5084e2333103\",\
               \"suite_registry\":[\
-                {\"suite_id\":66,\"pubkey_len\":64,\"sig_len\":96,\"openssl_alg\":\"ML-DSA-87\"}\
+                {\"suite_id\":66,\"pubkey_len\":64,\"sig_len\":96,\"alg_name\":\"ML-DSA-87\"}\
               ]\
             }",
         )
@@ -827,7 +828,7 @@ mod tests {
                 "{{\
                   \"chain_id_hex\":\"0x88f8a9acdeeb902e27aa2fdcb8c46ecf818bf68dec5273ec1bcc5084e2333103\",\
                   \"suite_registry\":[\
-                    {{\"suite_id\":{},\"pubkey_len\":{},\"sig_len\":{},\"verify_cost\":{},\"openssl_alg\":\"ML-DSA-87\"}}\
+                    {{\"suite_id\":{},\"pubkey_len\":{},\"sig_len\":{},\"verify_cost\":{},\"alg_name\":\"ML-DSA-87\"}}\
                   ]\
                 }}",
                 SUITE_ID_ML_DSA_87,
@@ -860,7 +861,7 @@ mod tests {
             "{\
               \"chain_id_hex\":\"0x88f8a9acdeeb902e27aa2fdcb8c46ecf818bf68dec5273ec1bcc5084e2333103\",\
               \"suite_registry\":[\
-                {\"suite_id\":66,\"pubkey_len\":1,\"sig_len\":100001,\"verify_cost\":8,\"openssl_alg\":\"ML-DSA-87\"}\
+                {\"suite_id\":66,\"pubkey_len\":1,\"sig_len\":100001,\"verify_cost\":8,\"alg_name\":\"ML-DSA-87\"}\
               ]\
             }",
         )
@@ -873,7 +874,7 @@ mod tests {
     }
 
     #[test]
-    fn load_genesis_config_rejects_empty_suite_registry_openssl_alg() {
+    fn load_genesis_config_rejects_empty_suite_registry_alg_name() {
         let dir = std::env::temp_dir().join(format!(
             "rubin-node-genesis-suite-registry-empty-openssl-{}",
             std::time::SystemTime::now()
@@ -908,7 +909,7 @@ mod tests {
     }
 
     #[test]
-    fn load_genesis_config_rejects_alias_suite_registry_openssl_alg() {
+    fn load_genesis_config_rejects_alias_suite_registry_alg_name() {
         for (case_idx, alg) in ["ml-dsa-87", "MLDSA87"].into_iter().enumerate() {
             let dir = std::env::temp_dir().join(format!(
                 "rubin-node-genesis-suite-registry-alias-openssl-{}-{}",
@@ -946,6 +947,36 @@ mod tests {
     }
 
     #[test]
+    fn load_genesis_config_accepts_legacy_suite_registry_openssl_alg_alias() {
+        let dir = std::env::temp_dir().join(format!(
+            "rubin-node-genesis-suite-registry-legacy-openssl-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("time")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        let path = dir.join("genesis.json");
+        std::fs::write(
+            &path,
+            "{\
+              \"chain_id_hex\":\"0x88f8a9acdeeb902e27aa2fdcb8c46ecf818bf68dec5273ec1bcc5084e2333103\",\
+              \"suite_registry\":[\
+                {\"suite_id\":66,\"pubkey_len\":2592,\"sig_len\":4627,\"verify_cost\":8,\"openssl_alg\":\"ML-DSA-87\"}\
+              ]\
+            }",
+        )
+        .expect("write");
+
+        let loaded = load_genesis_config(Some(&path), "devnet").expect("must load");
+        let ctx = loaded.suite_context.expect("suite context");
+        let params = ctx.registry.lookup(66).expect("suite 66");
+        assert_eq!(params.alg_name, "ML-DSA-87");
+
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    #[test]
     fn load_genesis_config_rejects_noncanonical_ml_dsa_lengths_for_custom_suite() {
         let dir = std::env::temp_dir().join(format!(
             "rubin-node-genesis-suite-registry-noncanonical-{}",
@@ -961,7 +992,7 @@ mod tests {
             "{\
               \"chain_id_hex\":\"0x88f8a9acdeeb902e27aa2fdcb8c46ecf818bf68dec5273ec1bcc5084e2333103\",\
               \"suite_registry\":[\
-                {\"suite_id\":66,\"pubkey_len\":64,\"sig_len\":96,\"verify_cost\":321,\"openssl_alg\":\"ML-DSA-87\"}\
+                {\"suite_id\":66,\"pubkey_len\":64,\"sig_len\":96,\"verify_cost\":321,\"alg_name\":\"ML-DSA-87\"}\
               ]\
             }",
         )

--- a/clients/rust/crates/rubin-node/src/genesis.rs
+++ b/clients/rust/crates/rubin-node/src/genesis.rs
@@ -241,6 +241,8 @@ fn validate_suite_registry_item(item: &GenesisSuiteParams) -> Result<SuiteParams
         verify_cost: item.verify_cost,
         alg_name: normalize_suite_alg_name(&item.alg_name)?,
     };
+    // Live node genesis/config is canonical-only. Synthetic suite_registry
+    // parameter shapes are CLI-harness fixtures and must not enter node boot.
     let want = default_suite_registry_params();
     if params.pubkey_len != want.pubkey_len
         || params.sig_len != want.sig_len
@@ -1132,6 +1134,35 @@ mod tests {
                     321,
                     "ML-DSA-87",
                 )
+            ),
+        )
+        .expect("write");
+
+        let err = load_genesis_config(Some(&path), "devnet").unwrap_err();
+        assert!(err.contains("bad suite_registry"));
+
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    #[test]
+    fn load_genesis_config_rejects_synthetic_harness_suite_params() {
+        let dir = std::env::temp_dir().join(format!(
+            "rubin-node-genesis-suite-registry-synthetic-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("time")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        let path = dir.join("genesis.json");
+        std::fs::write(
+            &path,
+            format!(
+                "{{\
+                  \"chain_id_hex\":\"0x88f8a9acdeeb902e27aa2fdcb8c46ecf818bf68dec5273ec1bcc5084e2333103\",\
+                  \"suite_registry\":[{}]\
+                }}",
+                suite_registry_entry_json(66, 64, 0, 9, "ML-DSA-87")
             ),
         )
         .expect("write");

--- a/clients/rust/crates/rubin-node/src/genesis.rs
+++ b/clients/rust/crates/rubin-node/src/genesis.rs
@@ -201,10 +201,12 @@ pub fn load_genesis_config(
 }
 
 fn normalize_suite_alg_name(value: &str) -> Result<&'static str, String> {
-    match value.trim() {
-        "ML-DSA-87" => Ok("ML-DSA-87"),
-        _ => Err("bad suite_registry".to_string()),
+    const CANONICAL_SUITE_ALG_NAME: &str = "ML-DSA-87";
+    let trimmed = value.trim();
+    if trimmed != CANONICAL_SUITE_ALG_NAME {
+        return Err("bad suite_registry".to_string());
     }
+    Ok(CANONICAL_SUITE_ALG_NAME)
 }
 
 fn default_suite_registry_params() -> SuiteParams {

--- a/clients/rust/crates/rubin-node/src/main.rs
+++ b/clients/rust/crates/rubin-node/src/main.rs
@@ -893,7 +893,7 @@ mod tests {
 
     fn canonical_suite_registry_entry_json(suite_id: u8) -> String {
         format!(
-            "{{\"suite_id\":{suite_id},\"pubkey_len\":{ML_DSA_87_PUBKEY_BYTES},\"sig_len\":{ML_DSA_87_SIG_BYTES},\"verify_cost\":{VERIFY_COST_ML_DSA_87},\"openssl_alg\":\"ML-DSA-87\"}}"
+            "{{\"suite_id\":{suite_id},\"pubkey_len\":{ML_DSA_87_PUBKEY_BYTES},\"sig_len\":{ML_DSA_87_SIG_BYTES},\"verify_cost\":{VERIFY_COST_ML_DSA_87},\"alg_name\":\"ML-DSA-87\"}}"
         )
     }
 

--- a/clients/rust/crates/rubin-node/src/sync_reorg.rs
+++ b/clients/rust/crates/rubin-node/src/sync_reorg.rs
@@ -542,7 +542,7 @@ mod tests {
                 pubkey_len: ML_DSA_87_PUBKEY_BYTES,
                 sig_len: ML_DSA_87_SIG_BYTES,
                 verify_cost: VERIFY_COST_ML_DSA_87,
-                openssl_alg: "ML-DSA-87",
+                alg_name: "ML-DSA-87",
             },
         );
         suites.insert(
@@ -552,7 +552,7 @@ mod tests {
                 pubkey_len: ML_DSA_87_PUBKEY_BYTES,
                 sig_len: ML_DSA_87_SIG_BYTES,
                 verify_cost: VERIFY_COST_ML_DSA_87,
-                openssl_alg: "ML-DSA-87",
+                alg_name: "ML-DSA-87",
             },
         );
         let ctx = SuiteContext {

--- a/clients/rust/fuzz/fuzz_targets/suite_registry_surface.rs
+++ b/clients/rust/fuzz/fuzz_targets/suite_registry_surface.rs
@@ -25,7 +25,7 @@ fn build_registry(data: &[u8]) -> SuiteRegistry {
             pubkey_len,
             sig_len,
             verify_cost,
-            openssl_alg: "ML-DSA-87",
+            alg_name: "ML-DSA-87",
         },
     );
     suites.insert(
@@ -35,7 +35,7 @@ fn build_registry(data: &[u8]) -> SuiteRegistry {
             pubkey_len: ML_DSA_87_PUBKEY_BYTES,
             sig_len: ML_DSA_87_SIG_BYTES,
             verify_cost: VERIFY_COST_ML_DSA_87,
-            openssl_alg: "ML-DSA-87",
+            alg_name: "ML-DSA-87",
         },
     );
     SuiteRegistry::with_suites(suites)


### PR DESCRIPTION
Refs: Q-IMPL-ROTATION-NATIVE-RUNTIME-ALGNAME-RENAME-01

## Summary
- rename the native runtime/config/registry surface from backend-tied `OpenSSLAlg` / `openssl_alg` to semantic `AlgName` / `alg_name`
- preserve legacy input alias support while keeping emitted runtime/config JSON on `alg_name`
- keep CORE_EXT wire bytes, descriptor layout, and `OpenSSLAlg` / `openssl_alg` binding fields untouched
- harden the CLI `suite_registry` bootstrap surface in Go/Rust so malformed explicit registry inputs fail closed before descriptor evaluation
- add Go/Rust parity coverage for the narrowed rename surface and the explicit registry validation path

## Scope
- as-issue: native runtime path only
- runtime/config/registry rename only where backend-tied naming leaked through the native runtime surface
- no CORE_EXT wire-format change
- no spec or consensus semantic expansion

Consensus rules unchanged: YES
SECTION_HASHES.json unchanged: YES

## Validation
- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/go test ./cmd/rubin-consensus-cli ./consensus ./node`
- `cargo fmt --all && cargo test -p rubin-consensus-cli -p rubin-consensus -p rubin-node`
- `git diff --check`
- `python3 /Users/gpt/Documents/rubin-orchestration-private/inbox/operational/tools/run_pr_lifecycle.py pre-pr --target-repo rubin-protocol --repo-root /Users/gpt/Documents/rubin-protocol-q-impl-rotation-native-runtime-algname-rename-01 --skip-execution-drift`
- local self-audit receipt recorded and `cl push` wrapper gates passed

Closes #1112.
