### PR TITLE
fix: compile production activation schedule

### DIFF
--- a/clients/go/cmd/rubin-node/main_test.go
+++ b/clients/go/cmd/rubin-node/main_test.go
@@ -47,22 +47,61 @@ type legacyExposureReportJSON struct {
 	} `json:"legacy_suite_reports"`
 }
 
+type legacyExposureHookVectorJSON struct {
+	Name                string `json:"name"`
+	HasChainstateTip    bool   `json:"has_chainstate_tip"`
+	LegacyExposureTotal uint64 `json:"legacy_exposure_total"`
+	SunsetReadiness     string `json:"sunset_readiness"`
+	WarningHook         string `json:"warning_hook"`
+	GraceHook           string `json:"grace_hook"`
+}
+
 type legacyExposureHookVectorsJSON struct {
-	ContractVersion uint64 `json:"contract_version"`
-	FixtureKind     string `json:"fixture_kind"`
-	Cases           []struct {
-		Name                string `json:"name"`
-		HasChainstateTip    bool   `json:"has_chainstate_tip"`
-		LegacyExposureTotal uint64 `json:"legacy_exposure_total"`
-		SunsetReadiness     string `json:"sunset_readiness"`
-		WarningHook         string `json:"warning_hook"`
-		GraceHook           string `json:"grace_hook"`
-	} `json:"cases"`
+	ContractVersion uint64                         `json:"contract_version"`
+	FixtureKind     string                         `json:"fixture_kind"`
+	Cases           []legacyExposureHookVectorJSON `json:"cases"`
 }
 
 func legacyExposureContractRepoPath(parts ...string) string {
 	segments := append([]string{"..", "..", "..", ".."}, parts...)
 	return filepath.Join(segments...)
+}
+
+func canonicalLegacyExposureHookVectors() []legacyExposureHookVectorJSON {
+	return []legacyExposureHookVectorJSON{
+		{
+			Name:                "no_chainstate_tip_zero_total",
+			HasChainstateTip:    false,
+			LegacyExposureTotal: 0,
+			SunsetReadiness:     "invalid_no_chainstate_tip",
+			WarningHook:         "none",
+			GraceHook:           "not_applicable_no_chainstate_tip",
+		},
+		{
+			Name:                "no_chainstate_tip_nonzero_total",
+			HasChainstateTip:    false,
+			LegacyExposureTotal: 5,
+			SunsetReadiness:     "invalid_no_chainstate_tip",
+			WarningHook:         "none",
+			GraceHook:           "not_applicable_no_chainstate_tip",
+		},
+		{
+			Name:                "tipped_chain_zero_exposure",
+			HasChainstateTip:    true,
+			LegacyExposureTotal: 0,
+			SunsetReadiness:     "ready_for_operator_defined_grace_window",
+			WarningHook:         "none",
+			GraceHook:           "start_operator_defined_grace_window",
+		},
+		{
+			Name:                "tipped_chain_nonzero_exposure",
+			HasChainstateTip:    true,
+			LegacyExposureTotal: 3,
+			SunsetReadiness:     "not_ready_legacy_exposure_present",
+			WarningHook:         "legacy_exposure_present_notify_operator_and_council",
+			GraceHook:           "not_applicable_legacy_exposure_present",
+		},
+	}
 }
 
 func mustCoreExtOpenSSLDigest32DescriptorHex(t *testing.T) string {
@@ -181,8 +220,9 @@ func TestLegacyExposureHookVectorsFixtureParity(t *testing.T) {
 	if doc.FixtureKind != "legacy_exposure_hook_vectors" {
 		t.Fatalf("fixture_kind=%q, want legacy_exposure_hook_vectors", doc.FixtureKind)
 	}
-	if len(doc.Cases) == 0 {
-		t.Fatalf("expected at least one hook vector")
+	expected := canonicalLegacyExposureHookVectors()
+	if !reflect.DeepEqual(doc.Cases, expected) {
+		t.Fatalf("hook vectors=%+v, want %+v", doc.Cases, expected)
 	}
 	for _, c := range doc.Cases {
 		t.Run(c.Name, func(t *testing.T) {

--- a/clients/go/node/config.go
+++ b/clients/go/node/config.go
@@ -329,7 +329,8 @@ func ValidateConfig(cfg Config) error {
 	if strings.TrimSpace(cfg.Network) == "" {
 		return errors.New("network is required")
 	}
-	if _, err := canonicalConfigNetworkName(cfg.Network); err != nil {
+	network, err := canonicalConfigNetworkName(cfg.Network)
+	if err != nil {
 		return err
 	}
 	if strings.TrimSpace(cfg.DataDir) == "" {
@@ -366,10 +367,6 @@ func ValidateConfig(cfg Config) error {
 		if len(raw) != 32 && len(raw) != 33 {
 			return fmt.Errorf("mine_address must be 32 (key_id) or 33 (suite_id||key_id) bytes, got %d", len(raw))
 		}
-	}
-	network, err := canonicalConfigNetworkName(cfg.Network)
-	if err != nil {
-		return err
 	}
 	if network == "mainnet" || network == "testnet" {
 		if cfg.RotationDescriptor != nil {

--- a/clients/go/node/config.go
+++ b/clients/go/node/config.go
@@ -375,9 +375,18 @@ func ValidateConfig(cfg Config) error {
 		if cfg.RotationDescriptor != nil {
 			return errors.New(productionLocalRotationDescriptorErr)
 		}
-		// Production validation checks only the compiled schedule artifact.
-		if _, _, err := productionRotationDescriptorForNetwork(network); err != nil {
+		// Production validation checks only the compiled schedule artifact and
+		// requires the helper to supply the canonical registry that matches the
+		// compiled activation state.
+		desc, registry, err := productionRotationDescriptorForNetwork(network)
+		if err != nil {
 			return err
+		}
+		if registry == nil {
+			return errors.New("production_rotation_schedule: missing registry")
+		}
+		if desc == nil && !registry.IsCanonicalDefaultLiveManifest() {
+			return errors.New("production_rotation_schedule: invalid empty-slot registry")
 		}
 		return nil
 	}

--- a/clients/go/node/config.go
+++ b/clients/go/node/config.go
@@ -29,8 +29,9 @@ type Config struct {
 }
 
 // RotationConfigJSON is the JSON-serializable rotation descriptor for node config.
-// When present, the node constructs a DescriptorRotationProvider from it.
-// When absent (nil), DefaultRotationProvider is used (ML-DSA-87 at all heights).
+// When present on non-production networks, the node constructs a
+// DescriptorRotationProvider from it. Production networks derive activation
+// only from the compiled schedule artifact.
 type RotationConfigJSON struct {
 	Name         string `json:"name"`
 	OldSuiteID   uint8  `json:"old_suite_id"`
@@ -213,11 +214,12 @@ func (cfg Config) buildSuiteRegistry() (*consensus.SuiteRegistry, error) {
 	return consensus.NewSuiteRegistryFromParams(params), nil
 }
 
-// BuildRotationProvider constructs rotation state from config.
-// Returns (nil, nil) when neither rotation_descriptor nor suite_registry is configured.
-// Returns DefaultRotationProvider with a non-nil registry for suite_registry-only bootstrap.
+// BuildRotationProvider constructs node startup rotation state.
+// On mainnet/testnet, activation authority comes only from the compiled
+// production schedule artifact; local suite_registry remains validated input
+// but never becomes a live activation or live binding source by itself.
 func (cfg Config) BuildRotationProvider() (consensus.RotationProvider, *consensus.SuiteRegistry, error) {
-	registry, err := cfg.buildSuiteRegistry()
+	explicitRegistry, err := cfg.buildSuiteRegistry()
 	if err != nil {
 		return nil, nil, fmt.Errorf("suite_registry: %w", err)
 	}
@@ -231,13 +233,24 @@ func (cfg Config) BuildRotationProvider() (consensus.RotationProvider, *consensu
 	if cfg.RotationDescriptor != nil && (network == "mainnet" || network == "testnet") {
 		return nil, nil, errors.New(productionLocalRotationDescriptorErr)
 	}
-	if cfg.RotationDescriptor == nil {
-		if registry == nil {
+	if network == "mainnet" || network == "testnet" {
+		desc, registry, err := productionRotationDescriptorForNetwork(network)
+		if err != nil {
+			return nil, nil, err
+		}
+		if desc == nil {
 			return nil, nil, nil
 		}
-		return consensus.DefaultRotationProvider{}, registry, nil
+		return consensus.DescriptorRotationProvider{Descriptor: *desc}, registry, nil
+	}
+	if cfg.RotationDescriptor == nil {
+		if explicitRegistry == nil {
+			return nil, nil, nil
+		}
+		return consensus.DefaultRotationProvider{}, explicitRegistry, nil
 	}
 	rd := cfg.RotationDescriptor
+	registry := explicitRegistry
 	if registry == nil {
 		registry = consensus.DefaultSuiteRegistry()
 	}
@@ -346,7 +359,11 @@ func ValidateConfig(cfg Config) error {
 	if _, err := cfg.buildSuiteRegistry(); err != nil {
 		return fmt.Errorf("suite_registry: %w", err)
 	}
-	if cfg.RotationDescriptor != nil {
+	network, err := canonicalConfigNetworkName(cfg.Network)
+	if err != nil {
+		return err
+	}
+	if cfg.RotationDescriptor != nil || network == "mainnet" || network == "testnet" {
 		if _, _, err := cfg.BuildRotationProvider(); err != nil {
 			return err
 		}

--- a/clients/go/node/config.go
+++ b/clients/go/node/config.go
@@ -216,8 +216,8 @@ func (cfg Config) buildSuiteRegistry() (*consensus.SuiteRegistry, error) {
 
 // BuildRotationProvider constructs node startup rotation state.
 // On mainnet/testnet, activation authority comes only from the compiled
-// production schedule artifact; local suite_registry remains validated input
-// but never becomes a live activation or live binding source by itself.
+// production schedule artifact; local suite_registry is ignored there and
+// never becomes a live activation or live binding source.
 func (cfg Config) BuildRotationProvider() (consensus.RotationProvider, *consensus.SuiteRegistry, error) {
 	return cfg.buildRotationProviderWithProductionLookup(productionRotationDescriptorForNetwork)
 }
@@ -225,10 +225,6 @@ func (cfg Config) BuildRotationProvider() (consensus.RotationProvider, *consensu
 func (cfg Config) buildRotationProviderWithProductionLookup(
 	productionLookup func(string) (*consensus.CryptoRotationDescriptor, *consensus.SuiteRegistry, error),
 ) (consensus.RotationProvider, *consensus.SuiteRegistry, error) {
-	explicitRegistry, err := cfg.buildSuiteRegistry()
-	if err != nil {
-		return nil, nil, fmt.Errorf("suite_registry: %w", err)
-	}
 	if strings.TrimSpace(cfg.Network) == "" {
 		return nil, nil, errors.New("network is required")
 	}
@@ -245,9 +241,18 @@ func (cfg Config) buildRotationProviderWithProductionLookup(
 			return nil, nil, err
 		}
 		if desc == nil {
-			return nil, registry, nil
+			// Production empty slots use an explicit default pre-rotation runtime
+			// and must ignore any local suite_registry override entirely.
+			if registry == nil {
+				registry = consensus.DefaultSuiteRegistry()
+			}
+			return consensus.DefaultRotationProvider{}, registry, nil
 		}
 		return consensus.DescriptorRotationProvider{Descriptor: *desc}, registry, nil
+	}
+	explicitRegistry, err := cfg.buildSuiteRegistry()
+	if err != nil {
+		return nil, nil, fmt.Errorf("suite_registry: %w", err)
 	}
 	if cfg.RotationDescriptor == nil {
 		if explicitRegistry == nil {
@@ -362,14 +367,24 @@ func ValidateConfig(cfg Config) error {
 			return fmt.Errorf("mine_address must be 32 (key_id) or 33 (suite_id||key_id) bytes, got %d", len(raw))
 		}
 	}
-	if _, err := cfg.buildSuiteRegistry(); err != nil {
-		return fmt.Errorf("suite_registry: %w", err)
-	}
 	network, err := canonicalConfigNetworkName(cfg.Network)
 	if err != nil {
 		return err
 	}
-	if cfg.RotationDescriptor != nil || network == "mainnet" || network == "testnet" {
+	if network == "mainnet" || network == "testnet" {
+		if cfg.RotationDescriptor != nil {
+			return errors.New(productionLocalRotationDescriptorErr)
+		}
+		// Production validation checks only the compiled schedule artifact.
+		if _, _, err := productionRotationDescriptorForNetwork(network); err != nil {
+			return err
+		}
+		return nil
+	}
+	if _, err := cfg.buildSuiteRegistry(); err != nil {
+		return fmt.Errorf("suite_registry: %w", err)
+	}
+	if cfg.RotationDescriptor != nil {
 		if _, _, err := cfg.BuildRotationProvider(); err != nil {
 			return err
 		}

--- a/clients/go/node/config.go
+++ b/clients/go/node/config.go
@@ -227,13 +227,14 @@ func resolveProductionRotationState(
 	localDescriptor *RotationConfigJSON,
 	productionLookup func(string) (*consensus.CryptoRotationDescriptor, *consensus.SuiteRegistry, error),
 ) (*consensus.CryptoRotationDescriptor, *consensus.SuiteRegistry, bool, error) {
-	if network != "mainnet" && network != "testnet" {
+	canonicalNetwork, ok := CanonicalNetworkName(network)
+	if !ok || (canonicalNetwork != "mainnet" && canonicalNetwork != "testnet") {
 		return nil, nil, false, nil
 	}
 	if localDescriptor != nil {
 		return nil, nil, true, errors.New(productionLocalRotationDescriptorErr)
 	}
-	desc, registry, err := productionLookup(network)
+	desc, registry, err := productionLookup(canonicalNetwork)
 	if err != nil {
 		return nil, nil, true, err
 	}

--- a/clients/go/node/config.go
+++ b/clients/go/node/config.go
@@ -222,6 +222,36 @@ func (cfg Config) BuildRotationProvider() (consensus.RotationProvider, *consensu
 	return cfg.buildRotationProviderWithProductionLookup(productionRotationDescriptorForNetwork)
 }
 
+func resolveProductionRotationState(
+	network string,
+	localDescriptor *RotationConfigJSON,
+	productionLookup func(string) (*consensus.CryptoRotationDescriptor, *consensus.SuiteRegistry, error),
+) (*consensus.CryptoRotationDescriptor, *consensus.SuiteRegistry, bool, error) {
+	if network != "mainnet" && network != "testnet" {
+		return nil, nil, false, nil
+	}
+	if localDescriptor != nil {
+		return nil, nil, true, errors.New(productionLocalRotationDescriptorErr)
+	}
+	desc, registry, err := productionLookup(network)
+	if err != nil {
+		return nil, nil, true, err
+	}
+	if desc == nil {
+		if registry == nil {
+			registry = consensus.DefaultSuiteRegistry()
+		}
+		if !registry.IsCanonicalDefaultLiveManifest() {
+			return nil, nil, true, errors.New("production_rotation_schedule: invalid empty-slot registry")
+		}
+		return nil, registry, true, nil
+	}
+	if registry == nil {
+		return nil, nil, true, errors.New("production_rotation_schedule: missing registry")
+	}
+	return desc, registry, true, nil
+}
+
 func (cfg Config) buildRotationProviderWithProductionLookup(
 	productionLookup func(string) (*consensus.CryptoRotationDescriptor, *consensus.SuiteRegistry, error),
 ) (consensus.RotationProvider, *consensus.SuiteRegistry, error) {
@@ -232,23 +262,21 @@ func (cfg Config) buildRotationProviderWithProductionLookup(
 	if err != nil {
 		return nil, nil, err
 	}
-	if cfg.RotationDescriptor != nil && (network == "mainnet" || network == "testnet") {
-		return nil, nil, errors.New(productionLocalRotationDescriptorErr)
+	productionDesc, productionRegistry, productionHandled, err := resolveProductionRotationState(
+		network,
+		cfg.RotationDescriptor,
+		productionLookup,
+	)
+	if err != nil {
+		return nil, nil, err
 	}
-	if network == "mainnet" || network == "testnet" {
-		desc, registry, err := productionLookup(network)
-		if err != nil {
-			return nil, nil, err
-		}
-		if desc == nil {
+	if productionHandled {
+		if productionDesc == nil {
 			// Production empty slots use an explicit default pre-rotation runtime
 			// and must ignore any local suite_registry override entirely.
-			if registry == nil {
-				registry = consensus.DefaultSuiteRegistry()
-			}
-			return consensus.DefaultRotationProvider{}, registry, nil
+			return consensus.DefaultRotationProvider{}, productionRegistry, nil
 		}
-		return consensus.DescriptorRotationProvider{Descriptor: *desc}, registry, nil
+		return consensus.DescriptorRotationProvider{Descriptor: *productionDesc}, productionRegistry, nil
 	}
 	explicitRegistry, err := cfg.buildSuiteRegistry()
 	if err != nil {
@@ -368,23 +396,13 @@ func ValidateConfig(cfg Config) error {
 			return fmt.Errorf("mine_address must be 32 (key_id) or 33 (suite_id||key_id) bytes, got %d", len(raw))
 		}
 	}
-	if network == "mainnet" || network == "testnet" {
-		if cfg.RotationDescriptor != nil {
-			return errors.New(productionLocalRotationDescriptorErr)
-		}
-		// Production validation checks only the compiled schedule artifact and
-		// requires the helper to supply the canonical registry that matches the
-		// compiled activation state.
-		desc, registry, err := productionRotationDescriptorForNetwork(network)
-		if err != nil {
-			return err
-		}
-		if registry == nil {
-			return errors.New("production_rotation_schedule: missing registry")
-		}
-		if desc == nil && !registry.IsCanonicalDefaultLiveManifest() {
-			return errors.New("production_rotation_schedule: invalid empty-slot registry")
-		}
+	if _, _, productionHandled, err := resolveProductionRotationState(
+		network,
+		cfg.RotationDescriptor,
+		productionRotationDescriptorForNetwork,
+	); err != nil {
+		return err
+	} else if productionHandled {
 		return nil
 	}
 	if _, err := cfg.buildSuiteRegistry(); err != nil {

--- a/clients/go/node/config.go
+++ b/clients/go/node/config.go
@@ -245,7 +245,7 @@ func (cfg Config) buildRotationProviderWithProductionLookup(
 			return nil, nil, err
 		}
 		if desc == nil {
-			return nil, nil, nil
+			return nil, registry, nil
 		}
 		return consensus.DescriptorRotationProvider{Descriptor: *desc}, registry, nil
 	}

--- a/clients/go/node/config.go
+++ b/clients/go/node/config.go
@@ -219,6 +219,12 @@ func (cfg Config) buildSuiteRegistry() (*consensus.SuiteRegistry, error) {
 // production schedule artifact; local suite_registry remains validated input
 // but never becomes a live activation or live binding source by itself.
 func (cfg Config) BuildRotationProvider() (consensus.RotationProvider, *consensus.SuiteRegistry, error) {
+	return cfg.buildRotationProviderWithProductionLookup(productionRotationDescriptorForNetwork)
+}
+
+func (cfg Config) buildRotationProviderWithProductionLookup(
+	productionLookup func(string) (*consensus.CryptoRotationDescriptor, *consensus.SuiteRegistry, error),
+) (consensus.RotationProvider, *consensus.SuiteRegistry, error) {
 	explicitRegistry, err := cfg.buildSuiteRegistry()
 	if err != nil {
 		return nil, nil, fmt.Errorf("suite_registry: %w", err)
@@ -234,7 +240,7 @@ func (cfg Config) BuildRotationProvider() (consensus.RotationProvider, *consensu
 		return nil, nil, errors.New(productionLocalRotationDescriptorErr)
 	}
 	if network == "mainnet" || network == "testnet" {
-		desc, registry, err := productionRotationDescriptorForNetwork(network)
+		desc, registry, err := productionLookup(network)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/clients/go/node/config_rotation_test.go
+++ b/clients/go/node/config_rotation_test.go
@@ -557,6 +557,44 @@ func TestValidateConfig_ProductionIgnoresBadSuiteRegistryWithoutDescriptor(t *te
 	}
 }
 
+func TestBuildRotationProvider_ProductionLookupNoneRejectsNoncanonicalRegistry(t *testing.T) {
+	for _, network := range productionRotationNetworks {
+		t.Run(quotedSubtestName(network), func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.Network = network
+			_, _, err := cfg.buildRotationProviderWithProductionLookup(
+				func(gotNetwork string) (*consensus.CryptoRotationDescriptor, *consensus.SuiteRegistry, error) {
+					if gotNetwork != strings.ToLower(strings.TrimSpace(network)) {
+						t.Fatalf("lookup network=%q, want %q", gotNetwork, strings.ToLower(strings.TrimSpace(network)))
+					}
+					return nil, consensus.NewSuiteRegistryFromParams([]consensus.SuiteParams{
+						{
+							SuiteID:    consensus.SUITE_ID_ML_DSA_87,
+							PubkeyLen:  consensus.ML_DSA_87_PUBKEY_BYTES,
+							SigLen:     consensus.ML_DSA_87_SIG_BYTES,
+							VerifyCost: consensus.VERIFY_COST_ML_DSA_87,
+							AlgName:    "ML-DSA-87",
+						},
+						{
+							SuiteID:    0x77,
+							PubkeyLen:  consensus.ML_DSA_87_PUBKEY_BYTES,
+							SigLen:     consensus.ML_DSA_87_SIG_BYTES,
+							VerifyCost: consensus.VERIFY_COST_ML_DSA_87,
+							AlgName:    "ML-DSA-87",
+						},
+					}), nil
+				},
+			)
+			if err == nil {
+				t.Fatal("expected invalid empty-slot registry rejection")
+			}
+			if got, want := err.Error(), "production_rotation_schedule: invalid empty-slot registry"; got != want {
+				t.Fatalf("error=%q, want %q", got, want)
+			}
+		})
+	}
+}
+
 func TestBuildRotationProvider_RejectsUnknownNetworkWithoutSeparateValidateConfig(t *testing.T) {
 	cfg := DefaultConfig()
 	cfg.Network = " not-a-network "

--- a/clients/go/node/config_rotation_test.go
+++ b/clients/go/node/config_rotation_test.go
@@ -309,8 +309,14 @@ func TestBuildRotationProvider_ProductionExplicitSuiteRegistryWithoutDescriptorD
 			if rot != nil {
 				t.Fatal("expected compiled empty production schedule to leave rotation nil")
 			}
-			if reg != nil {
-				t.Fatal("expected production suite_registry-only bootstrap to remain non-authoritative")
+			if reg == nil {
+				t.Fatal("expected canonical default registry for explicit empty production schedule")
+			}
+			if !reg.IsCanonicalDefaultLiveManifest() {
+				t.Fatal("expected canonical default live manifest registry")
+			}
+			if _, ok := reg.Lookup(0x42); ok {
+				t.Fatal("unexpected local suite_registry authority leak into empty production schedule")
 			}
 		})
 	}
@@ -480,7 +486,7 @@ func TestBuildRotationProvider_ProductionLookupNoneKeepsSuiteRegistryNonAuthorit
 					if gotNetwork != strings.ToLower(strings.TrimSpace(network)) {
 						t.Fatalf("lookup network=%q, want %q", gotNetwork, strings.ToLower(strings.TrimSpace(network)))
 					}
-					return nil, nil, nil
+					return nil, consensus.DefaultSuiteRegistry(), nil
 				},
 			)
 			if err != nil {
@@ -489,7 +495,13 @@ func TestBuildRotationProvider_ProductionLookupNoneKeepsSuiteRegistryNonAuthorit
 			if rot != nil {
 				t.Fatal("expected nil rotation when compiled production schedule is empty")
 			}
-			if reg != nil {
+			if reg == nil {
+				t.Fatal("expected canonical default registry when production lookup is empty")
+			}
+			if !reg.IsCanonicalDefaultLiveManifest() {
+				t.Fatal("expected canonical default live manifest registry")
+			}
+			if _, ok := reg.Lookup(0x77); ok {
 				t.Fatal("expected local suite_registry to remain non-authoritative on production lookup none")
 			}
 		})

--- a/clients/go/node/config_rotation_test.go
+++ b/clients/go/node/config_rotation_test.go
@@ -288,7 +288,7 @@ func TestBuildRotationProvider_ExplicitSuiteRegistryWithoutDescriptor(t *testing
 	}
 }
 
-func TestBuildRotationProvider_ProductionExplicitSuiteRegistryWithoutDescriptorDoesNotActivateRotation(t *testing.T) {
+func TestBuildRotationProvider_ProductionExplicitSuiteRegistryWithoutDescriptorUsesDefaultPreRotationRuntime(t *testing.T) {
 	for _, network := range productionRotationNetworks {
 		t.Run(quotedSubtestName(network), func(t *testing.T) {
 			cfg := DefaultConfig()
@@ -306,8 +306,8 @@ func TestBuildRotationProvider_ProductionExplicitSuiteRegistryWithoutDescriptorD
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if rot != nil {
-				t.Fatal("expected compiled empty production schedule to leave rotation nil")
+			if rot == nil {
+				t.Fatal("expected explicit default rotation for empty production schedule")
 			}
 			if reg == nil {
 				t.Fatal("expected canonical default registry for explicit empty production schedule")
@@ -317,6 +317,12 @@ func TestBuildRotationProvider_ProductionExplicitSuiteRegistryWithoutDescriptorD
 			}
 			if _, ok := reg.Lookup(0x42); ok {
 				t.Fatal("unexpected local suite_registry authority leak into empty production schedule")
+			}
+			if !rot.NativeSpendSuites(0).Contains(consensus.SUITE_ID_ML_DSA_87) {
+				t.Fatal("expected default pre-rotation runtime to expose ML-DSA-87")
+			}
+			if rot.NativeSpendSuites(0).Contains(0x42) {
+				t.Fatal("unexpected local suite_registry leak into production default rotation")
 			}
 		})
 	}
@@ -467,7 +473,7 @@ func TestBuildRotationProvider_ProductionHelperRejectsLocalRotationDescriptor(t 
 	}
 }
 
-func TestBuildRotationProvider_ProductionLookupNoneKeepsSuiteRegistryNonAuthoritative(t *testing.T) {
+func TestBuildRotationProvider_ProductionLookupNoneUsesDefaultPreRotationRuntime(t *testing.T) {
 	for _, network := range productionRotationNetworks {
 		t.Run(quotedSubtestName(network), func(t *testing.T) {
 			cfg := DefaultConfig()
@@ -492,8 +498,8 @@ func TestBuildRotationProvider_ProductionLookupNoneKeepsSuiteRegistryNonAuthorit
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if rot != nil {
-				t.Fatal("expected nil rotation when compiled production schedule is empty")
+			if rot == nil {
+				t.Fatal("expected explicit default rotation when compiled production schedule is empty")
 			}
 			if reg == nil {
 				t.Fatal("expected canonical default registry when production lookup is empty")
@@ -503,6 +509,49 @@ func TestBuildRotationProvider_ProductionLookupNoneKeepsSuiteRegistryNonAuthorit
 			}
 			if _, ok := reg.Lookup(0x77); ok {
 				t.Fatal("expected local suite_registry to remain non-authoritative on production lookup none")
+			}
+			if !rot.NativeSpendSuites(0).Contains(consensus.SUITE_ID_ML_DSA_87) {
+				t.Fatal("expected default pre-rotation runtime to expose ML-DSA-87")
+			}
+			if rot.NativeSpendSuites(0).Contains(0x77) {
+				t.Fatal("unexpected local suite_registry leak into production default rotation")
+			}
+		})
+	}
+}
+
+func TestValidateConfig_ProductionIgnoresBadSuiteRegistryWithoutDescriptor(t *testing.T) {
+	for _, network := range productionRotationNetworks {
+		t.Run(quotedSubtestName(network), func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.Network = network
+			cfg.SuiteRegistry = []SuiteParamsJSON{
+				{
+					SuiteID:    0x42,
+					PubkeyLen:  consensus.ML_DSA_87_PUBKEY_BYTES,
+					SigLen:     consensus.ML_DSA_87_SIG_BYTES,
+					VerifyCost: 0,
+					AlgName:    stringPtr("ML-DSA-87"),
+				},
+			}
+			if err := ValidateConfig(cfg); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			rot, reg, err := cfg.BuildRotationProvider()
+			if err != nil {
+				t.Fatalf("build rotation provider: %v", err)
+			}
+			if rot == nil {
+				t.Fatal("expected explicit default rotation on production empty schedule")
+			}
+			if reg == nil || !reg.IsCanonicalDefaultLiveManifest() {
+				t.Fatal("expected canonical default production registry")
+			}
+			if _, ok := reg.Lookup(0x42); ok {
+				t.Fatal("unexpected malformed local suite_registry leak into production registry")
+			}
+			if rot.NativeSpendSuites(0).Contains(0x42) {
+				t.Fatal("unexpected malformed local suite_registry leak into production rotation")
 			}
 		})
 	}

--- a/clients/go/node/config_rotation_test.go
+++ b/clients/go/node/config_rotation_test.go
@@ -316,6 +316,186 @@ func TestBuildRotationProvider_ProductionExplicitSuiteRegistryWithoutDescriptorD
 	}
 }
 
+func TestBuildRotationProvider_ProductionCompiledDescriptorActivatesRotation(t *testing.T) {
+	for _, network := range productionRotationNetworks {
+		t.Run(quotedSubtestName(network), func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.Network = network
+			cfg.SuiteRegistry = []SuiteParamsJSON{
+				{
+					SuiteID:    0x77,
+					PubkeyLen:  consensus.ML_DSA_87_PUBKEY_BYTES,
+					SigLen:     consensus.ML_DSA_87_SIG_BYTES,
+					VerifyCost: consensus.VERIFY_COST_ML_DSA_87,
+					AlgName:    stringPtr("ML-DSA-87"),
+				},
+			}
+			rot, reg, err := cfg.buildRotationProviderWithProductionLookup(
+				func(gotNetwork string) (*consensus.CryptoRotationDescriptor, *consensus.SuiteRegistry, error) {
+					if gotNetwork != strings.ToLower(strings.TrimSpace(network)) {
+						t.Fatalf("lookup network=%q, want %q", gotNetwork, strings.ToLower(strings.TrimSpace(network)))
+					}
+					registry := canonicalProductionScheduleRegistry()
+					return &consensus.CryptoRotationDescriptor{
+						Name:         "rotation-v1",
+						OldSuiteID:   consensus.SUITE_ID_ML_DSA_87,
+						NewSuiteID:   0x42,
+						CreateHeight: 10,
+						SpendHeight:  20,
+						SunsetHeight: 30,
+					}, registry, nil
+				},
+			)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if rot == nil {
+				t.Fatal("expected descriptor-backed production rotation")
+			}
+			if reg == nil {
+				t.Fatal("expected compiled production registry")
+			}
+			if _, ok := reg.Lookup(consensus.SUITE_ID_ML_DSA_87); !ok {
+				t.Fatal("expected compiled production registry to retain ML-DSA-87")
+			}
+			if _, ok := reg.Lookup(0x77); ok {
+				t.Fatal("unexpected local suite_registry authority leak into production registry")
+			}
+			if _, ok := reg.Lookup(0x42); !ok {
+				t.Fatal("expected compiled production registry to include suite 0x42")
+			}
+			if rot.NativeSpendSuites(9).Contains(0x42) {
+				t.Fatal("expected new suite to remain inactive before create_height")
+			}
+			if !rot.NativeSpendSuites(10).Contains(0x42) {
+				t.Fatal("expected new suite to activate at create_height")
+			}
+		})
+	}
+}
+
+func TestBuildRotationProvider_ProductionLookupNormalizesNetworkVariants(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		input   string
+		wantNet string
+	}{
+		{name: "mainnet", input: "mainnet", wantNet: "mainnet"},
+		{name: "testnet", input: "testnet", wantNet: "testnet"},
+		{name: "trimmed-mainnet", input: " MAINNET ", wantNet: "mainnet"},
+		{name: "trimmed-testnet", input: "\tTestNet\t", wantNet: "testnet"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.Network = tc.input
+			rot, reg, err := cfg.buildRotationProviderWithProductionLookup(
+				func(gotNetwork string) (*consensus.CryptoRotationDescriptor, *consensus.SuiteRegistry, error) {
+					if gotNetwork != tc.wantNet {
+						t.Fatalf("lookup network=%q, want %q", gotNetwork, tc.wantNet)
+					}
+					registry := canonicalProductionScheduleRegistry()
+					return &consensus.CryptoRotationDescriptor{
+						Name:         "rotation-v1",
+						OldSuiteID:   consensus.SUITE_ID_ML_DSA_87,
+						NewSuiteID:   0x42,
+						CreateHeight: 10,
+						SpendHeight:  20,
+						SunsetHeight: 30,
+					}, registry, nil
+				},
+			)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if rot == nil {
+				t.Fatal("expected compiled production rotation")
+			}
+			if reg == nil {
+				t.Fatal("expected compiled production registry")
+			}
+			if _, ok := reg.Lookup(consensus.SUITE_ID_ML_DSA_87); !ok {
+				t.Fatal("expected compiled production registry to retain ML-DSA-87")
+			}
+		})
+	}
+}
+
+func TestBuildRotationProvider_ProductionHelperRejectsLocalRotationDescriptor(t *testing.T) {
+	if got, want := productionLocalRotationDescriptorErr, "rotation_descriptor: production networks forbid local rotation_descriptor"; got != want {
+		t.Fatalf("production guard=%q, want %q", got, want)
+	}
+	for _, network := range productionRotationNetworks {
+		t.Run(quotedSubtestName(network), func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.Network = network
+			cfg.SuiteRegistry = []SuiteParamsJSON{
+				{
+					SuiteID:    0x42,
+					PubkeyLen:  consensus.ML_DSA_87_PUBKEY_BYTES,
+					SigLen:     consensus.ML_DSA_87_SIG_BYTES,
+					VerifyCost: consensus.VERIFY_COST_ML_DSA_87,
+					AlgName:    stringPtr("ML-DSA-87"),
+				},
+			}
+			cfg.RotationDescriptor = &RotationConfigJSON{
+				Name:         "prod-rotation",
+				OldSuiteID:   consensus.SUITE_ID_ML_DSA_87,
+				NewSuiteID:   0x42,
+				CreateHeight: 10,
+				SpendHeight:  20,
+				SunsetHeight: 30,
+			}
+			_, _, err := cfg.buildRotationProviderWithProductionLookup(
+				func(string) (*consensus.CryptoRotationDescriptor, *consensus.SuiteRegistry, error) {
+					t.Fatal("production lookup must not run after local production rotation_descriptor reject")
+					return nil, nil, nil
+				},
+			)
+			if err == nil {
+				t.Fatal("expected production local rotation_descriptor rejection")
+			}
+			if got, want := err.Error(), productionLocalRotationDescriptorErr; got != want {
+				t.Fatalf("error=%q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestBuildRotationProvider_ProductionLookupNoneKeepsSuiteRegistryNonAuthoritative(t *testing.T) {
+	for _, network := range productionRotationNetworks {
+		t.Run(quotedSubtestName(network), func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.Network = network
+			cfg.SuiteRegistry = []SuiteParamsJSON{
+				{
+					SuiteID:    0x77,
+					PubkeyLen:  consensus.ML_DSA_87_PUBKEY_BYTES,
+					SigLen:     consensus.ML_DSA_87_SIG_BYTES,
+					VerifyCost: consensus.VERIFY_COST_ML_DSA_87,
+					AlgName:    stringPtr("ML-DSA-87"),
+				},
+			}
+			rot, reg, err := cfg.buildRotationProviderWithProductionLookup(
+				func(gotNetwork string) (*consensus.CryptoRotationDescriptor, *consensus.SuiteRegistry, error) {
+					if gotNetwork != strings.ToLower(strings.TrimSpace(network)) {
+						t.Fatalf("lookup network=%q, want %q", gotNetwork, strings.ToLower(strings.TrimSpace(network)))
+					}
+					return nil, nil, nil
+				},
+			)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if rot != nil {
+				t.Fatal("expected nil rotation when compiled production schedule is empty")
+			}
+			if reg != nil {
+				t.Fatal("expected local suite_registry to remain non-authoritative on production lookup none")
+			}
+		})
+	}
+}
+
 func TestBuildRotationProvider_RejectsUnknownNetworkWithoutSeparateValidateConfig(t *testing.T) {
 	cfg := DefaultConfig()
 	cfg.Network = " not-a-network "

--- a/clients/go/node/config_rotation_test.go
+++ b/clients/go/node/config_rotation_test.go
@@ -288,7 +288,7 @@ func TestBuildRotationProvider_ExplicitSuiteRegistryWithoutDescriptor(t *testing
 	}
 }
 
-func TestBuildRotationProvider_ProductionExplicitSuiteRegistryWithoutDescriptor(t *testing.T) {
+func TestBuildRotationProvider_ProductionExplicitSuiteRegistryWithoutDescriptorDoesNotActivateRotation(t *testing.T) {
 	for _, network := range productionRotationNetworks {
 		t.Run(quotedSubtestName(network), func(t *testing.T) {
 			cfg := DefaultConfig()
@@ -306,11 +306,11 @@ func TestBuildRotationProvider_ProductionExplicitSuiteRegistryWithoutDescriptor(
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if rot == nil || reg == nil {
-				t.Fatal("expected production suite_registry-only bootstrap to remain available")
+			if rot != nil {
+				t.Fatal("expected compiled empty production schedule to leave rotation nil")
 			}
-			if _, ok := reg.Lookup(0x42); !ok {
-				t.Fatal("expected suite 0x42 in production registry")
+			if reg != nil {
+				t.Fatal("expected production suite_registry-only bootstrap to remain non-authoritative")
 			}
 		})
 	}

--- a/clients/go/node/production_rotation_schedule.go
+++ b/clients/go/node/production_rotation_schedule.go
@@ -14,8 +14,8 @@ const productionRotationScheduleVersion = 1
 const productionRotationScheduleErrStem = "production_rotation_schedule"
 
 // Derived runtime copy of conformance/fixtures/protocol/production_rotation_schedule_v1.json.
-// Go embed cannot read a parent-path artifact directly, so tests keep this byte-equivalent
-// to the canonical protocol fixture.
+// Go embed cannot read a parent-path artifact directly, so tests keep this JSON-equivalent
+// to the canonical protocol fixture (ignoring insignificant whitespace differences).
 //
 //go:embed production_rotation_schedule_v1_embedded.json
 var embeddedProductionRotationScheduleV1 []byte
@@ -28,6 +28,15 @@ type productionRotationSchedule struct {
 type productionRotationScheduleWire struct {
 	Version  uint64                     `json:"version"`
 	Networks map[string]json.RawMessage `json:"networks"`
+}
+
+type productionRotationDescriptorWire struct {
+	Name         *string `json:"name"`
+	OldSuiteID   *uint8  `json:"old_suite_id"`
+	NewSuiteID   *uint8  `json:"new_suite_id"`
+	CreateHeight *uint64 `json:"create_height"`
+	SpendHeight  *uint64 `json:"spend_height"`
+	SunsetHeight *uint64 `json:"sunset_height,omitempty"`
 }
 
 func productionRotationScheduleError(format string, args ...any) error {
@@ -66,7 +75,7 @@ func loadCompiledProductionRotationScheduleFromJSONWithRegistry(
 	}
 	var wire productionRotationScheduleWire
 	if err := decodeSingleJSONValue(raw, &wire); err != nil {
-		return nil, nil, productionRotationScheduleError("parse embedded artifact: %v", err)
+		return nil, nil, productionRotationScheduleError("parse embedded artifact: %w", err)
 	}
 	if wire.Version != productionRotationScheduleVersion {
 		return nil, nil, productionRotationScheduleError(
@@ -112,9 +121,13 @@ func parseProductionRotationScheduleDescriptor(
 	if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
 		return nil, nil
 	}
-	var descriptorJSON RotationConfigJSON
-	if err := decodeSingleJSONValue(raw, &descriptorJSON); err != nil {
-		return nil, productionRotationScheduleError("networks.%s: %v", network, err)
+	var wire productionRotationDescriptorWire
+	if err := decodeSingleJSONValue(raw, &wire); err != nil {
+		return nil, productionRotationScheduleError("networks.%s: %w", network, err)
+	}
+	descriptorJSON, err := wire.toRotationConfigJSON()
+	if err != nil {
+		return nil, productionRotationScheduleError("networks.%s: %w", network, err)
 	}
 	descriptor := consensus.CryptoRotationDescriptor{
 		Name:         descriptorJSON.Name,
@@ -132,6 +145,48 @@ func parseProductionRotationScheduleDescriptor(
 		)
 	}
 	return &descriptor, nil
+}
+
+func (wire productionRotationDescriptorWire) toRotationConfigJSON() (RotationConfigJSON, error) {
+	name, err := requireProductionRotationScheduleField("name", wire.Name)
+	if err != nil {
+		return RotationConfigJSON{}, err
+	}
+	oldSuiteID, err := requireProductionRotationScheduleField("old_suite_id", wire.OldSuiteID)
+	if err != nil {
+		return RotationConfigJSON{}, err
+	}
+	newSuiteID, err := requireProductionRotationScheduleField("new_suite_id", wire.NewSuiteID)
+	if err != nil {
+		return RotationConfigJSON{}, err
+	}
+	createHeight, err := requireProductionRotationScheduleField("create_height", wire.CreateHeight)
+	if err != nil {
+		return RotationConfigJSON{}, err
+	}
+	spendHeight, err := requireProductionRotationScheduleField("spend_height", wire.SpendHeight)
+	if err != nil {
+		return RotationConfigJSON{}, err
+	}
+	var sunsetHeight uint64
+	if wire.SunsetHeight != nil {
+		sunsetHeight = *wire.SunsetHeight
+	}
+	return RotationConfigJSON{
+		Name:         *name,
+		OldSuiteID:   *oldSuiteID,
+		NewSuiteID:   *newSuiteID,
+		CreateHeight: *createHeight,
+		SpendHeight:  *spendHeight,
+		SunsetHeight: sunsetHeight,
+	}, nil
+}
+
+func requireProductionRotationScheduleField[T any](name string, value *T) (*T, error) {
+	if value == nil {
+		return nil, fmt.Errorf("missing required field %q", name)
+	}
+	return value, nil
 }
 
 func productionRotationDescriptorForNetwork(

--- a/clients/go/node/production_rotation_schedule.go
+++ b/clients/go/node/production_rotation_schedule.go
@@ -1,0 +1,155 @@
+package node
+
+import (
+	"bytes"
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+)
+
+const productionRotationScheduleVersion = 1
+const productionRotationScheduleErrStem = "production_rotation_schedule"
+
+// Derived runtime copy of conformance/fixtures/protocol/production_rotation_schedule_v1.json.
+// Go embed cannot read a parent-path artifact directly, so tests keep this byte-equivalent
+// to the canonical protocol fixture.
+//
+//go:embed production_rotation_schedule_v1_embedded.json
+var embeddedProductionRotationScheduleV1 []byte
+
+type productionRotationSchedule struct {
+	Version  uint64
+	Networks map[string]*consensus.CryptoRotationDescriptor
+}
+
+type productionRotationScheduleWire struct {
+	Version  uint64                     `json:"version"`
+	Networks map[string]json.RawMessage `json:"networks"`
+}
+
+func productionRotationScheduleError(format string, args ...any) error {
+	return fmt.Errorf(productionRotationScheduleErrStem+": "+format, args...)
+}
+
+func decodeSingleJSONValue(data []byte, dest any) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(dest); err != nil {
+		return err
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("trailing JSON tokens")
+		}
+		return err
+	}
+	return nil
+}
+
+func loadCompiledProductionRotationSchedule() (*productionRotationSchedule, *consensus.SuiteRegistry, error) {
+	return loadCompiledProductionRotationScheduleFromJSONWithRegistry(
+		embeddedProductionRotationScheduleV1,
+		consensus.DefaultSuiteRegistry(),
+	)
+}
+
+func loadCompiledProductionRotationScheduleFromJSONWithRegistry(
+	raw []byte,
+	registry *consensus.SuiteRegistry,
+) (*productionRotationSchedule, *consensus.SuiteRegistry, error) {
+	if registry == nil {
+		registry = consensus.DefaultSuiteRegistry()
+	}
+	var wire productionRotationScheduleWire
+	if err := decodeSingleJSONValue(raw, &wire); err != nil {
+		return nil, nil, productionRotationScheduleError("parse embedded artifact: %v", err)
+	}
+	if wire.Version != productionRotationScheduleVersion {
+		return nil, nil, productionRotationScheduleError(
+			"unsupported version %d (want %d)",
+			wire.Version,
+			productionRotationScheduleVersion,
+		)
+	}
+	for key := range wire.Networks {
+		if key != "mainnet" && key != "testnet" {
+			return nil, nil, productionRotationScheduleError(
+				"unknown networks.%s entry",
+				key,
+			)
+		}
+	}
+	schedule := &productionRotationSchedule{
+		Version:  wire.Version,
+		Networks: make(map[string]*consensus.CryptoRotationDescriptor, len(wire.Networks)),
+	}
+	for _, network := range []string{"mainnet", "testnet"} {
+		raw, ok := wire.Networks[network]
+		if !ok {
+			return nil, nil, productionRotationScheduleError(
+				"networks.%s missing",
+				network,
+			)
+		}
+		desc, err := parseProductionRotationScheduleDescriptor(raw, network, registry)
+		if err != nil {
+			return nil, nil, err
+		}
+		schedule.Networks[network] = desc
+	}
+	return schedule, registry, nil
+}
+
+func parseProductionRotationScheduleDescriptor(
+	raw json.RawMessage,
+	network string,
+	registry *consensus.SuiteRegistry,
+) (*consensus.CryptoRotationDescriptor, error) {
+	if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return nil, nil
+	}
+	var descriptorJSON RotationConfigJSON
+	if err := decodeSingleJSONValue(raw, &descriptorJSON); err != nil {
+		return nil, productionRotationScheduleError("networks.%s: %v", network, err)
+	}
+	descriptor := consensus.CryptoRotationDescriptor{
+		Name:         descriptorJSON.Name,
+		OldSuiteID:   descriptorJSON.OldSuiteID,
+		NewSuiteID:   descriptorJSON.NewSuiteID,
+		CreateHeight: descriptorJSON.CreateHeight,
+		SpendHeight:  descriptorJSON.SpendHeight,
+		SunsetHeight: descriptorJSON.SunsetHeight,
+	}
+	if err := consensus.ValidateRotationDescriptorForNetwork(network, descriptor, registry); err != nil {
+		return nil, productionRotationScheduleError(
+			"networks.%s: rotation_descriptor: %v",
+			network,
+			err,
+		)
+	}
+	return &descriptor, nil
+}
+
+func productionRotationDescriptorForNetwork(
+	network string,
+) (*consensus.CryptoRotationDescriptor, *consensus.SuiteRegistry, error) {
+	schedule, registry, err := loadCompiledProductionRotationSchedule()
+	if err != nil {
+		return nil, nil, err
+	}
+	if network != "mainnet" && network != "testnet" {
+		return nil, nil, productionRotationScheduleError(
+			"network %q is not a production schedule caller",
+			network,
+		)
+	}
+	descriptor := schedule.Networks[network]
+	if descriptor == nil {
+		return nil, nil, nil
+	}
+	return descriptor, registry, nil
+}

--- a/clients/go/node/production_rotation_schedule.go
+++ b/clients/go/node/production_rotation_schedule.go
@@ -218,6 +218,12 @@ func (wire productionRotationDescriptorWire) toRotationConfigJSON() (RotationCon
 	if err != nil {
 		return RotationConfigJSON{}, err
 	}
+	if err := rejectReservedProductionRotationScheduleSuiteID("old_suite_id", oldSuiteID); err != nil {
+		return RotationConfigJSON{}, err
+	}
+	if err := rejectReservedProductionRotationScheduleSuiteID("new_suite_id", newSuiteID); err != nil {
+		return RotationConfigJSON{}, err
+	}
 	createHeight, err := requireProductionRotationScheduleField("create_height", wire.CreateHeight)
 	if err != nil {
 		return RotationConfigJSON{}, err
@@ -238,6 +244,13 @@ func (wire productionRotationDescriptorWire) toRotationConfigJSON() (RotationCon
 		SpendHeight:  spendHeight,
 		SunsetHeight: sunsetHeight,
 	}, nil
+}
+
+func rejectReservedProductionRotationScheduleSuiteID(field string, suiteID uint8) error {
+	if suiteID == consensus.SUITE_ID_SENTINEL {
+		return fmt.Errorf("%s 0x%02x reserved", field, suiteID)
+	}
+	return nil
 }
 
 func requireProductionRotationScheduleField[T any](name string, value *T) (T, error) {

--- a/clients/go/node/production_rotation_schedule.go
+++ b/clients/go/node/production_rotation_schedule.go
@@ -277,9 +277,9 @@ func productionRotationDescriptorForNetwork(
 	descriptor := schedule.Networks[network]
 	if descriptor == nil {
 		// A null slot means this network has no authoritative production activation state.
-		// The compiled registry is derived across schedule entries, so returning it here
-		// would leak foreign-network suites into an empty-slot caller.
-		return nil, nil, nil
+		// Pre-rotation production callers still need the canonical default registry,
+		// but must not inherit foreign-network suites from the compiled schedule.
+		return nil, consensus.DefaultSuiteRegistry(), nil
 	}
 	return descriptor, registry, nil
 }

--- a/clients/go/node/production_rotation_schedule.go
+++ b/clients/go/node/production_rotation_schedule.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"sort"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
 )
@@ -62,7 +63,7 @@ func decodeSingleJSONValue(data []byte, dest any) error {
 func loadCompiledProductionRotationSchedule() (*productionRotationSchedule, *consensus.SuiteRegistry, error) {
 	return loadCompiledProductionRotationScheduleFromJSONWithRegistry(
 		embeddedProductionRotationScheduleV1,
-		consensus.DefaultSuiteRegistry(),
+		nil,
 	)
 }
 
@@ -70,9 +71,6 @@ func loadCompiledProductionRotationScheduleFromJSONWithRegistry(
 	raw []byte,
 	registry *consensus.SuiteRegistry,
 ) (*productionRotationSchedule, *consensus.SuiteRegistry, error) {
-	if registry == nil {
-		registry = consensus.DefaultSuiteRegistry()
-	}
 	var wire productionRotationScheduleWire
 	if err := decodeSingleJSONValue(raw, &wire); err != nil {
 		return nil, nil, productionRotationScheduleError("parse embedded artifact: %w", err)
@@ -96,6 +94,7 @@ func loadCompiledProductionRotationScheduleFromJSONWithRegistry(
 		Version:  wire.Version,
 		Networks: make(map[string]*consensus.CryptoRotationDescriptor, len(wire.Networks)),
 	}
+	parsedDescriptors := make(map[string]*RotationConfigJSON, len(wire.Networks))
 	for _, network := range []string{"mainnet", "testnet"} {
 		raw, ok := wire.Networks[network]
 		if !ok {
@@ -104,7 +103,21 @@ func loadCompiledProductionRotationScheduleFromJSONWithRegistry(
 				network,
 			)
 		}
-		desc, err := parseProductionRotationScheduleDescriptor(raw, network, registry)
+		descriptorJSON, err := parseProductionRotationScheduleDescriptorJSON(raw, network)
+		if err != nil {
+			return nil, nil, err
+		}
+		parsedDescriptors[network] = descriptorJSON
+	}
+	if registry == nil {
+		registry = canonicalProductionScheduleRegistryFromDescriptors(parsedDescriptors)
+	}
+	for _, network := range []string{"mainnet", "testnet"} {
+		desc, err := buildProductionRotationScheduleDescriptor(
+			parsedDescriptors[network],
+			network,
+			registry,
+		)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -113,11 +126,10 @@ func loadCompiledProductionRotationScheduleFromJSONWithRegistry(
 	return schedule, registry, nil
 }
 
-func parseProductionRotationScheduleDescriptor(
+func parseProductionRotationScheduleDescriptorJSON(
 	raw json.RawMessage,
 	network string,
-	registry *consensus.SuiteRegistry,
-) (*consensus.CryptoRotationDescriptor, error) {
+) (*RotationConfigJSON, error) {
 	if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
 		return nil, nil
 	}
@@ -128,6 +140,17 @@ func parseProductionRotationScheduleDescriptor(
 	descriptorJSON, err := wire.toRotationConfigJSON()
 	if err != nil {
 		return nil, productionRotationScheduleError("networks.%s: %w", network, err)
+	}
+	return &descriptorJSON, nil
+}
+
+func buildProductionRotationScheduleDescriptor(
+	descriptorJSON *RotationConfigJSON,
+	network string,
+	registry *consensus.SuiteRegistry,
+) (*consensus.CryptoRotationDescriptor, error) {
+	if descriptorJSON == nil {
+		return nil, nil
 	}
 	descriptor := consensus.CryptoRotationDescriptor{
 		Name:         descriptorJSON.Name,
@@ -145,6 +168,41 @@ func parseProductionRotationScheduleDescriptor(
 		)
 	}
 	return &descriptor, nil
+}
+
+func canonicalProductionScheduleRegistryFromDescriptors(
+	descriptors map[string]*RotationConfigJSON,
+) *consensus.SuiteRegistry {
+	paramsByID := map[uint8]consensus.SuiteParams{
+		consensus.SUITE_ID_ML_DSA_87: defaultSuiteRegistryParams(),
+	}
+	for _, descriptor := range descriptors {
+		if descriptor == nil {
+			continue
+		}
+		paramsByID[descriptor.OldSuiteID] = canonicalProductionScheduleSuiteParams(descriptor.OldSuiteID)
+		paramsByID[descriptor.NewSuiteID] = canonicalProductionScheduleSuiteParams(descriptor.NewSuiteID)
+	}
+	params := make([]consensus.SuiteParams, 0, len(paramsByID))
+	for _, suiteID := range sortedSuiteIDs(paramsByID) {
+		params = append(params, paramsByID[suiteID])
+	}
+	return consensus.NewSuiteRegistryFromParams(params)
+}
+
+func canonicalProductionScheduleSuiteParams(suiteID uint8) consensus.SuiteParams {
+	params := defaultSuiteRegistryParams()
+	params.SuiteID = suiteID
+	return params
+}
+
+func sortedSuiteIDs(paramsByID map[uint8]consensus.SuiteParams) []uint8 {
+	ids := make([]uint8, 0, len(paramsByID))
+	for suiteID := range paramsByID {
+		ids = append(ids, suiteID)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	return ids
 }
 
 func (wire productionRotationDescriptorWire) toRotationConfigJSON() (RotationConfigJSON, error) {
@@ -173,20 +231,21 @@ func (wire productionRotationDescriptorWire) toRotationConfigJSON() (RotationCon
 		sunsetHeight = *wire.SunsetHeight
 	}
 	return RotationConfigJSON{
-		Name:         *name,
-		OldSuiteID:   *oldSuiteID,
-		NewSuiteID:   *newSuiteID,
-		CreateHeight: *createHeight,
-		SpendHeight:  *spendHeight,
+		Name:         name,
+		OldSuiteID:   oldSuiteID,
+		NewSuiteID:   newSuiteID,
+		CreateHeight: createHeight,
+		SpendHeight:  spendHeight,
 		SunsetHeight: sunsetHeight,
 	}, nil
 }
 
-func requireProductionRotationScheduleField[T any](name string, value *T) (*T, error) {
+func requireProductionRotationScheduleField[T any](name string, value *T) (T, error) {
 	if value == nil {
-		return nil, fmt.Errorf("missing required field %q", name)
+		var zero T
+		return zero, fmt.Errorf("missing required field %q", name)
 	}
-	return value, nil
+	return *value, nil
 }
 
 func productionRotationDescriptorForNetwork(

--- a/clients/go/node/production_rotation_schedule.go
+++ b/clients/go/node/production_rotation_schedule.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"sort"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
 )
@@ -63,7 +62,7 @@ func decodeSingleJSONValue(data []byte, dest any) error {
 func loadCompiledProductionRotationSchedule() (*productionRotationSchedule, *consensus.SuiteRegistry, error) {
 	return loadCompiledProductionRotationScheduleFromJSONWithRegistry(
 		embeddedProductionRotationScheduleV1,
-		nil,
+		consensus.DefaultSuiteRegistry(),
 	)
 }
 
@@ -109,8 +108,12 @@ func loadCompiledProductionRotationScheduleFromJSONWithRegistry(
 		}
 		parsedDescriptors[network] = descriptorJSON
 	}
+	// The compiled production schedule is activation-only authority. When the
+	// caller does not supply an explicit canonical registry contract, fail
+	// closed to the default live manifest instead of synthesizing suite params
+	// from schedule IDs.
 	if registry == nil {
-		registry = canonicalProductionScheduleRegistryFromDescriptors(parsedDescriptors)
+		registry = consensus.DefaultSuiteRegistry()
 	}
 	for _, network := range []string{"mainnet", "testnet"} {
 		desc, err := buildProductionRotationScheduleDescriptor(
@@ -168,41 +171,6 @@ func buildProductionRotationScheduleDescriptor(
 		)
 	}
 	return &descriptor, nil
-}
-
-func canonicalProductionScheduleRegistryFromDescriptors(
-	descriptors map[string]*RotationConfigJSON,
-) *consensus.SuiteRegistry {
-	paramsByID := map[uint8]consensus.SuiteParams{
-		consensus.SUITE_ID_ML_DSA_87: canonicalProductionScheduleSuiteParams(consensus.SUITE_ID_ML_DSA_87),
-	}
-	for _, descriptor := range descriptors {
-		if descriptor == nil {
-			continue
-		}
-		paramsByID[descriptor.OldSuiteID] = canonicalProductionScheduleSuiteParams(descriptor.OldSuiteID)
-		paramsByID[descriptor.NewSuiteID] = canonicalProductionScheduleSuiteParams(descriptor.NewSuiteID)
-	}
-	params := make([]consensus.SuiteParams, 0, len(paramsByID))
-	for _, suiteID := range sortedSuiteIDs(paramsByID) {
-		params = append(params, paramsByID[suiteID])
-	}
-	return consensus.NewSuiteRegistryFromParams(params)
-}
-
-func canonicalProductionScheduleSuiteParams(suiteID uint8) consensus.SuiteParams {
-	params := defaultSuiteRegistryParams()
-	params.SuiteID = suiteID
-	return params
-}
-
-func sortedSuiteIDs(paramsByID map[uint8]consensus.SuiteParams) []uint8 {
-	ids := make([]uint8, 0, len(paramsByID))
-	for suiteID := range paramsByID {
-		ids = append(ids, suiteID)
-	}
-	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
-	return ids
 }
 
 func (wire productionRotationDescriptorWire) toRotationConfigJSON() (RotationConfigJSON, error) {

--- a/clients/go/node/production_rotation_schedule.go
+++ b/clients/go/node/production_rotation_schedule.go
@@ -96,14 +96,14 @@ func loadCompiledProductionRotationScheduleFromJSONWithRegistry(
 	}
 	parsedDescriptors := make(map[string]*RotationConfigJSON, len(wire.Networks))
 	for _, network := range []string{"mainnet", "testnet"} {
-		raw, ok := wire.Networks[network]
+		entryRaw, ok := wire.Networks[network]
 		if !ok {
 			return nil, nil, productionRotationScheduleError(
 				"networks.%s missing",
 				network,
 			)
 		}
-		descriptorJSON, err := parseProductionRotationScheduleDescriptorJSON(raw, network)
+		descriptorJSON, err := parseProductionRotationScheduleDescriptorJSON(entryRaw, network)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/clients/go/node/production_rotation_schedule.go
+++ b/clients/go/node/production_rotation_schedule.go
@@ -186,10 +186,10 @@ func (wire productionRotationDescriptorWire) toRotationConfigJSON() (RotationCon
 	if err != nil {
 		return RotationConfigJSON{}, err
 	}
-	if err := rejectReservedProductionRotationScheduleSuiteID("old_suite_id", oldSuiteID); err != nil {
+	if err := rejectSentinelProductionRotationScheduleSuiteID("old_suite_id", oldSuiteID); err != nil {
 		return RotationConfigJSON{}, err
 	}
-	if err := rejectReservedProductionRotationScheduleSuiteID("new_suite_id", newSuiteID); err != nil {
+	if err := rejectSentinelProductionRotationScheduleSuiteID("new_suite_id", newSuiteID); err != nil {
 		return RotationConfigJSON{}, err
 	}
 	createHeight, err := requireProductionRotationScheduleField("create_height", wire.CreateHeight)
@@ -214,9 +214,9 @@ func (wire productionRotationDescriptorWire) toRotationConfigJSON() (RotationCon
 	}, nil
 }
 
-func rejectReservedProductionRotationScheduleSuiteID(field string, suiteID uint8) error {
+func rejectSentinelProductionRotationScheduleSuiteID(field string, suiteID uint8) error {
 	if suiteID == consensus.SUITE_ID_SENTINEL {
-		return fmt.Errorf("%s 0x%02x reserved", field, suiteID)
+		return fmt.Errorf("%s 0x%02x is the sentinel suite_id", field, suiteID)
 	}
 	return nil
 }

--- a/clients/go/node/production_rotation_schedule.go
+++ b/clients/go/node/production_rotation_schedule.go
@@ -263,6 +263,9 @@ func productionRotationDescriptorForNetwork(
 	}
 	descriptor := schedule.Networks[network]
 	if descriptor == nil {
+		// A null slot means this network has no authoritative production activation state.
+		// The compiled registry is derived across schedule entries, so returning it here
+		// would leak foreign-network suites into an empty-slot caller.
 		return nil, nil, nil
 	}
 	return descriptor, registry, nil

--- a/clients/go/node/production_rotation_schedule.go
+++ b/clients/go/node/production_rotation_schedule.go
@@ -174,7 +174,7 @@ func canonicalProductionScheduleRegistryFromDescriptors(
 	descriptors map[string]*RotationConfigJSON,
 ) *consensus.SuiteRegistry {
 	paramsByID := map[uint8]consensus.SuiteParams{
-		consensus.SUITE_ID_ML_DSA_87: defaultSuiteRegistryParams(),
+		consensus.SUITE_ID_ML_DSA_87: canonicalProductionScheduleSuiteParams(consensus.SUITE_ID_ML_DSA_87),
 	}
 	for _, descriptor := range descriptors {
 		if descriptor == nil {

--- a/clients/go/node/production_rotation_schedule_test.go
+++ b/clients/go/node/production_rotation_schedule_test.go
@@ -1,0 +1,205 @@
+package node
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+)
+
+func productionRotationScheduleRepoPath(parts ...string) string {
+	segments := append([]string{"..", "..", ".."}, parts...)
+	return filepath.Join(segments...)
+}
+
+func canonicalProductionScheduleRegistry() *consensus.SuiteRegistry {
+	return consensus.NewSuiteRegistryFromParams([]consensus.SuiteParams{
+		{
+			SuiteID:    consensus.SUITE_ID_ML_DSA_87,
+			PubkeyLen:  consensus.ML_DSA_87_PUBKEY_BYTES,
+			SigLen:     consensus.ML_DSA_87_SIG_BYTES,
+			VerifyCost: consensus.VERIFY_COST_ML_DSA_87,
+			AlgName:    "ML-DSA-87",
+		},
+		{
+			SuiteID:    0x42,
+			PubkeyLen:  consensus.ML_DSA_87_PUBKEY_BYTES,
+			SigLen:     consensus.ML_DSA_87_SIG_BYTES,
+			VerifyCost: consensus.VERIFY_COST_ML_DSA_87,
+			AlgName:    "ML-DSA-87",
+		},
+	})
+}
+
+func compactJSONBytes(t *testing.T, raw []byte) []byte {
+	t.Helper()
+	var out bytes.Buffer
+	if err := json.Compact(&out, raw); err != nil {
+		t.Fatalf("json.Compact: %v", err)
+	}
+	return out.Bytes()
+}
+
+func TestEmbeddedProductionRotationScheduleMatchesCanonicalFixture(t *testing.T) {
+	raw, err := os.ReadFile(productionRotationScheduleRepoPath(
+		"conformance",
+		"fixtures",
+		"protocol",
+		"production_rotation_schedule_v1.json",
+	))
+	if err != nil {
+		t.Fatalf("ReadFile(canonical fixture): %v", err)
+	}
+	if !bytes.Equal(
+		compactJSONBytes(t, raw),
+		compactJSONBytes(t, embeddedProductionRotationScheduleV1),
+	) {
+		t.Fatal("embedded production schedule drifted from canonical fixture")
+	}
+}
+
+func TestLoadCompiledProductionRotationScheduleAcceptsExplicitEmptySchedule(t *testing.T) {
+	schedule, registry, err := loadCompiledProductionRotationSchedule()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if schedule.Version != productionRotationScheduleVersion {
+		t.Fatalf("version=%d, want %d", schedule.Version, productionRotationScheduleVersion)
+	}
+	if schedule.Networks["mainnet"] != nil {
+		t.Fatal("expected mainnet schedule to be explicitly empty")
+	}
+	if schedule.Networks["testnet"] != nil {
+		t.Fatal("expected testnet schedule to be explicitly empty")
+	}
+	if !registry.IsCanonicalDefaultLiveManifest() {
+		t.Fatal("expected canonical default live manifest registry")
+	}
+}
+
+func TestLoadCompiledProductionRotationScheduleRejectsUnsupportedVersion(t *testing.T) {
+	_, _, err := loadCompiledProductionRotationScheduleFromJSONWithRegistry([]byte(`{
+		"version": 2,
+		"networks": {"mainnet": null, "testnet": null}
+	}`), consensus.DefaultSuiteRegistry())
+	if err == nil {
+		t.Fatal("expected unsupported version rejection")
+	}
+	if got, want := err.Error(), `production_rotation_schedule: unsupported version 2 (want 1)`; got != want {
+		t.Fatalf("error=%q, want %q", got, want)
+	}
+}
+
+func TestLoadCompiledProductionRotationScheduleRejectsMissingNetworkKey(t *testing.T) {
+	_, _, err := loadCompiledProductionRotationScheduleFromJSONWithRegistry([]byte(`{
+		"version": 1,
+		"networks": {"mainnet": null}
+	}`), consensus.DefaultSuiteRegistry())
+	if err == nil {
+		t.Fatal("expected missing network key rejection")
+	}
+	if got, want := err.Error(), `production_rotation_schedule: networks.testnet missing`; got != want {
+		t.Fatalf("error=%q, want %q", got, want)
+	}
+}
+
+func TestLoadCompiledProductionRotationScheduleRejectsUnknownNetworkKey(t *testing.T) {
+	_, _, err := loadCompiledProductionRotationScheduleFromJSONWithRegistry([]byte(`{
+		"version": 1,
+		"networks": {"mainnet": null, "devnet": null}
+	}`), consensus.DefaultSuiteRegistry())
+	if err == nil {
+		t.Fatal("expected unknown network key rejection")
+	}
+	if got, want := err.Error(), `production_rotation_schedule: unknown networks.devnet entry`; got != want {
+		t.Fatalf("error=%q, want %q", got, want)
+	}
+}
+
+func TestLoadCompiledProductionRotationScheduleRejectsMalformedDescriptorShape(t *testing.T) {
+	_, _, err := loadCompiledProductionRotationScheduleFromJSONWithRegistry([]byte(`{
+		"version": 1,
+		"networks": {"mainnet": [], "testnet": null}
+	}`), consensus.DefaultSuiteRegistry())
+	if err == nil {
+		t.Fatal("expected malformed descriptor rejection")
+	}
+	if got, want := err.Error(), `production_rotation_schedule: networks.mainnet: json: cannot unmarshal array into Go value of type node.RotationConfigJSON`; got != want {
+		t.Fatalf("error=%q, want %q", got, want)
+	}
+}
+
+func TestLoadCompiledProductionRotationScheduleParsesSingleDescriptorWithCanonicalRegistry(t *testing.T) {
+	schedule, registry, err := loadCompiledProductionRotationScheduleFromJSONWithRegistry([]byte(`{
+		"version": 1,
+		"networks": {
+			"mainnet": {
+				"name": "rotation-v1",
+				"old_suite_id": 1,
+				"new_suite_id": 66,
+				"create_height": 10,
+				"spend_height": 20,
+				"sunset_height": 30
+			},
+			"testnet": null
+		}
+	}`), canonicalProductionScheduleRegistry())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	desc := schedule.Networks["mainnet"]
+	if desc == nil {
+		t.Fatal("expected mainnet descriptor")
+	}
+	if desc.NewSuiteID != 0x42 {
+		t.Fatalf("new_suite_id=0x%02x, want 0x42", desc.NewSuiteID)
+	}
+	if schedule.Networks["testnet"] != nil {
+		t.Fatal("expected testnet schedule to remain empty")
+	}
+	if _, ok := registry.Lookup(0x42); !ok {
+		t.Fatal("expected custom canonical registry to retain suite 0x42")
+	}
+}
+
+func TestLoadCompiledProductionRotationScheduleRejectsTrailingJSONTokens(t *testing.T) {
+	_, _, err := loadCompiledProductionRotationScheduleFromJSONWithRegistry([]byte(`{
+		"version": 1,
+		"networks": {"mainnet": null, "testnet": null}
+	} true`), consensus.DefaultSuiteRegistry())
+	if err == nil {
+		t.Fatal("expected trailing token rejection")
+	}
+	if got, want := err.Error(), `production_rotation_schedule: parse embedded artifact: trailing JSON tokens`; got != want {
+		t.Fatalf("error=%q, want %q", got, want)
+	}
+}
+
+func TestLoadCompiledProductionRotationScheduleNilRegistryFallsBackToCanonicalDefault(t *testing.T) {
+	schedule, registry, err := loadCompiledProductionRotationScheduleFromJSONWithRegistry([]byte(`{
+		"version": 1,
+		"networks": {"mainnet": null, "testnet": null}
+	}`), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if schedule.Networks["mainnet"] != nil || schedule.Networks["testnet"] != nil {
+		t.Fatal("expected explicit empty schedule")
+	}
+	if !registry.IsCanonicalDefaultLiveManifest() {
+		t.Fatal("expected nil registry to fall back to canonical default live manifest")
+	}
+}
+
+func TestProductionRotationDescriptorForNetworkRejectsNonProductionCaller(t *testing.T) {
+	_, _, err := productionRotationDescriptorForNetwork("devnet")
+	if err == nil {
+		t.Fatal("expected non-production caller rejection")
+	}
+	if got, want := err.Error(), `production_rotation_schedule: network "devnet" is not a production schedule caller`; got != want {
+		t.Fatalf("error=%q, want %q", got, want)
+	}
+}

--- a/clients/go/node/production_rotation_schedule_test.go
+++ b/clients/go/node/production_rotation_schedule_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -171,6 +172,59 @@ func TestLoadCompiledProductionRotationScheduleRejectsMissingRequiredDescriptorF
 	}
 	if got, want := err.Error(), `production_rotation_schedule: networks.mainnet: missing required field "create_height"`; got != want {
 		t.Fatalf("error=%q, want %q", got, want)
+	}
+}
+
+func TestLoadCompiledProductionRotationScheduleRejectsReservedSentinelSuiteID(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		field      string
+		oldSuiteID int
+		newSuiteID int
+		want       string
+	}{
+		{
+			name:       "old_suite_id",
+			field:      "old_suite_id",
+			oldSuiteID: 0,
+			newSuiteID: 66,
+			want:       `production_rotation_schedule: networks.mainnet: old_suite_id 0x00 reserved`,
+		},
+		{
+			name:       "new_suite_id",
+			field:      "new_suite_id",
+			oldSuiteID: 1,
+			newSuiteID: 0,
+			want:       `production_rotation_schedule: networks.mainnet: new_suite_id 0x00 reserved`,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := loadCompiledProductionRotationScheduleFromJSONWithRegistry([]byte(`{
+				"version": 1,
+				"networks": {
+					"mainnet": {
+						"name": "rotation-v1",
+						"old_suite_id": `+strconv.Itoa(tc.oldSuiteID)+`,
+						"new_suite_id": `+strconv.Itoa(tc.newSuiteID)+`,
+						"create_height": 10,
+						"spend_height": 20,
+						"sunset_height": 30
+					},
+					"testnet": null
+				}
+			}`), canonicalProductionScheduleRegistry())
+			if err == nil {
+				t.Fatalf("expected reserved %s rejection", tc.field)
+			}
+			if got := err.Error(); got != tc.want {
+				t.Fatalf("error=%q, want %q", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/clients/go/node/production_rotation_schedule_test.go
+++ b/clients/go/node/production_rotation_schedule_test.go
@@ -261,8 +261,8 @@ func TestLoadCompiledProductionRotationScheduleParsesSingleDescriptorWithCanonic
 	}
 }
 
-func TestLoadCompiledProductionRotationScheduleNilRegistryDerivesScheduledSuites(t *testing.T) {
-	schedule, registry, err := loadCompiledProductionRotationScheduleFromJSONWithRegistry([]byte(`{
+func TestLoadCompiledProductionRotationScheduleNilRegistryRejectsUnsanctionedScheduledSuite(t *testing.T) {
+	_, _, err := loadCompiledProductionRotationScheduleFromJSONWithRegistry([]byte(`{
 		"version": 1,
 		"networks": {
 			"mainnet": {
@@ -276,22 +276,11 @@ func TestLoadCompiledProductionRotationScheduleNilRegistryDerivesScheduledSuites
 			"testnet": null
 		}
 	}`), nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if err == nil {
+		t.Fatal("expected compiled schedule to reject unsanctioned suite ID without explicit canonical registry")
 	}
-	desc := schedule.Networks["mainnet"]
-	if desc == nil {
-		t.Fatal("expected mainnet descriptor")
-	}
-	params, ok := registry.Lookup(0x42)
-	if !ok {
-		t.Fatal("expected derived production registry to include suite 0x42")
-	}
-	if params.PubkeyLen != consensus.ML_DSA_87_PUBKEY_BYTES ||
-		params.SigLen != consensus.ML_DSA_87_SIG_BYTES ||
-		params.VerifyCost != consensus.VERIFY_COST_ML_DSA_87 ||
-		params.AlgName != "ML-DSA-87" {
-		t.Fatalf("suite 0x42 params=%+v, want canonical production schedule params", params)
+	if got, want := err.Error(), `production_rotation_schedule: networks.mainnet: rotation_descriptor: rotation: new suite 0x42 not registered`; got != want {
+		t.Fatalf("error=%q, want %q", got, want)
 	}
 }
 
@@ -337,8 +326,8 @@ func TestLoadCompiledProductionRotationScheduleNilRegistryFallsBackToCanonicalDe
 	}
 }
 
-func TestLoadCompiledProductionRotationScheduleNullNetworkDoesNotEraseForeignSlotSuites(t *testing.T) {
-	schedule, registry, err := loadCompiledProductionRotationScheduleFromJSONWithRegistry([]byte(`{
+func TestLoadCompiledProductionRotationScheduleNilRegistryRejectsForeignSlotSuiteIDs(t *testing.T) {
+	_, _, err := loadCompiledProductionRotationScheduleFromJSONWithRegistry([]byte(`{
 		"version": 1,
 		"networks": {
 			"mainnet": null,
@@ -352,17 +341,11 @@ func TestLoadCompiledProductionRotationScheduleNullNetworkDoesNotEraseForeignSlo
 			}
 		}
 	}`), nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if err == nil {
+		t.Fatal("expected compiled schedule to reject foreign-slot suite ID without explicit canonical registry")
 	}
-	if schedule.Networks["mainnet"] != nil {
-		t.Fatal("expected mainnet slot to remain empty")
-	}
-	if schedule.Networks["testnet"] == nil {
-		t.Fatal("expected testnet descriptor")
-	}
-	if _, ok := registry.Lookup(66); !ok {
-		t.Fatal("expected derived registry to retain foreign-slot suite 66")
+	if got, want := err.Error(), `production_rotation_schedule: networks.testnet: rotation_descriptor: rotation: new suite 0x42 not registered`; got != want {
+		t.Fatalf("error=%q, want %q", got, want)
 	}
 }
 

--- a/clients/go/node/production_rotation_schedule_test.go
+++ b/clients/go/node/production_rotation_schedule_test.go
@@ -366,6 +366,25 @@ func TestLoadCompiledProductionRotationScheduleNullNetworkDoesNotEraseForeignSlo
 	}
 }
 
+func TestProductionRotationDescriptorForNetworkEmptySlotReturnsCanonicalDefaultRegistry(t *testing.T) {
+	desc, registry, err := productionRotationDescriptorForNetwork("mainnet")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if desc != nil {
+		t.Fatal("expected explicit empty production slot to keep descriptor nil")
+	}
+	if registry == nil {
+		t.Fatal("expected canonical default registry for empty production slot")
+	}
+	if !registry.IsCanonicalDefaultLiveManifest() {
+		t.Fatal("expected canonical default live manifest registry")
+	}
+	if _, ok := registry.Lookup(66); ok {
+		t.Fatal("unexpected foreign-slot suite leak into empty production caller")
+	}
+}
+
 func TestProductionRotationDescriptorForNetworkRejectsNonProductionCaller(t *testing.T) {
 	_, _, err := productionRotationDescriptorForNetwork("devnet")
 	if err == nil {

--- a/clients/go/node/production_rotation_schedule_test.go
+++ b/clients/go/node/production_rotation_schedule_test.go
@@ -261,6 +261,54 @@ func TestLoadCompiledProductionRotationScheduleParsesSingleDescriptorWithCanonic
 	}
 }
 
+func TestLoadCompiledProductionRotationScheduleRejectsNonFiniteSunsetHeightOnProductionProfile(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name          string
+		sunsetField   string
+		expectedError string
+	}{
+		{
+			name:        "null",
+			sunsetField: `"sunset_height": null`,
+		},
+		{
+			name:        "missing",
+			sunsetField: ``,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			sunsetField := ""
+			if tc.sunsetField != "" {
+				sunsetField = ",\n\t\t\t\t" + tc.sunsetField
+			}
+			_, _, err := loadCompiledProductionRotationScheduleFromJSONWithRegistry([]byte(`{
+				"version": 1,
+				"networks": {
+					"mainnet": {
+						"name": "rotation-v1",
+						"old_suite_id": 1,
+						"new_suite_id": 66,
+						"create_height": 10,
+						"spend_height": 20`+sunsetField+`
+					},
+					"testnet": null
+				}
+			}`), canonicalProductionScheduleRegistry())
+			if err == nil {
+				t.Fatalf("expected %s sunset_height rejection", tc.name)
+			}
+			if got, want := err.Error(), `production_rotation_schedule: networks.mainnet: rotation_descriptor: rotation: v1 production profile requires finite sunset_height (H4)`; got != want {
+				t.Fatalf("error=%q, want %q", got, want)
+			}
+		})
+	}
+}
+
 func TestLoadCompiledProductionRotationScheduleNilRegistryRejectsUnsanctionedScheduledSuite(t *testing.T) {
 	_, _, err := loadCompiledProductionRotationScheduleFromJSONWithRegistry([]byte(`{
 		"version": 1,

--- a/clients/go/node/production_rotation_schedule_test.go
+++ b/clients/go/node/production_rotation_schedule_test.go
@@ -283,6 +283,35 @@ func TestLoadCompiledProductionRotationScheduleNilRegistryFallsBackToCanonicalDe
 	}
 }
 
+func TestLoadCompiledProductionRotationScheduleNullNetworkDoesNotEraseForeignSlotSuites(t *testing.T) {
+	schedule, registry, err := loadCompiledProductionRotationScheduleFromJSONWithRegistry([]byte(`{
+		"version": 1,
+		"networks": {
+			"mainnet": null,
+			"testnet": {
+				"name": "rotation-v1",
+				"old_suite_id": 1,
+				"new_suite_id": 66,
+				"create_height": 10,
+				"spend_height": 20,
+				"sunset_height": 30
+			}
+		}
+	}`), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if schedule.Networks["mainnet"] != nil {
+		t.Fatal("expected mainnet slot to remain empty")
+	}
+	if schedule.Networks["testnet"] == nil {
+		t.Fatal("expected testnet descriptor")
+	}
+	if _, ok := registry.Lookup(66); !ok {
+		t.Fatal("expected derived registry to retain foreign-slot suite 66")
+	}
+}
+
 func TestProductionRotationDescriptorForNetworkRejectsNonProductionCaller(t *testing.T) {
 	_, _, err := productionRotationDescriptorForNetwork("devnet")
 	if err == nil {

--- a/clients/go/node/production_rotation_schedule_test.go
+++ b/clients/go/node/production_rotation_schedule_test.go
@@ -207,6 +207,40 @@ func TestLoadCompiledProductionRotationScheduleParsesSingleDescriptorWithCanonic
 	}
 }
 
+func TestLoadCompiledProductionRotationScheduleNilRegistryDerivesScheduledSuites(t *testing.T) {
+	schedule, registry, err := loadCompiledProductionRotationScheduleFromJSONWithRegistry([]byte(`{
+		"version": 1,
+		"networks": {
+			"mainnet": {
+				"name": "rotation-v1",
+				"old_suite_id": 1,
+				"new_suite_id": 66,
+				"create_height": 10,
+				"spend_height": 20,
+				"sunset_height": 30
+			},
+			"testnet": null
+		}
+	}`), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	desc := schedule.Networks["mainnet"]
+	if desc == nil {
+		t.Fatal("expected mainnet descriptor")
+	}
+	params, ok := registry.Lookup(0x42)
+	if !ok {
+		t.Fatal("expected derived production registry to include suite 0x42")
+	}
+	if params.PubkeyLen != consensus.ML_DSA_87_PUBKEY_BYTES ||
+		params.SigLen != consensus.ML_DSA_87_SIG_BYTES ||
+		params.VerifyCost != consensus.VERIFY_COST_ML_DSA_87 ||
+		params.AlgName != "ML-DSA-87" {
+		t.Fatalf("suite 0x42 params=%+v, want canonical production schedule params", params)
+	}
+}
+
 func TestLoadCompiledProductionRotationScheduleRejectsTrailingJSONTokens(t *testing.T) {
 	_, _, err := loadCompiledProductionRotationScheduleFromJSONWithRegistry([]byte(`{
 		"version": 1,

--- a/clients/go/node/production_rotation_schedule_test.go
+++ b/clients/go/node/production_rotation_schedule_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -13,8 +14,12 @@ import (
 )
 
 func productionRotationScheduleRepoPath(parts ...string) string {
-	segments := append([]string{"..", "..", ".."}, parts...)
-	return filepath.Join(segments...)
+	_, currentFile, _, ok := runtime.Caller(0)
+	if !ok {
+		return ""
+	}
+	segments := append([]string{filepath.Dir(currentFile), "..", "..", ".."}, parts...)
+	return filepath.Clean(filepath.Join(segments...))
 }
 
 func canonicalProductionScheduleRegistry() *consensus.SuiteRegistry {
@@ -46,14 +51,21 @@ func compactJSONBytes(t *testing.T, raw []byte) []byte {
 }
 
 func TestEmbeddedProductionRotationScheduleMatchesCanonicalFixture(t *testing.T) {
-	raw, err := os.ReadFile(productionRotationScheduleRepoPath(
+	path := productionRotationScheduleRepoPath(
 		"conformance",
 		"fixtures",
 		"protocol",
 		"production_rotation_schedule_v1.json",
-	))
+	)
+	if path == "" {
+		t.Fatal("runtime.Caller failed")
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("Stat(%s): %v", path, err)
+	}
+	raw, err := os.ReadFile(path)
 	if err != nil {
-		t.Fatalf("ReadFile(canonical fixture): %v", err)
+		t.Fatalf("ReadFile(%s): %v", path, err)
 	}
 	if !bytes.Equal(
 		compactJSONBytes(t, raw),
@@ -202,6 +214,19 @@ func TestLoadCompiledProductionRotationScheduleRejectsTrailingJSONTokens(t *test
 	} true`), consensus.DefaultSuiteRegistry())
 	if err == nil {
 		t.Fatal("expected trailing token rejection")
+	}
+	if got, want := err.Error(), `production_rotation_schedule: parse embedded artifact: trailing JSON tokens`; got != want {
+		t.Fatalf("error=%q, want %q", got, want)
+	}
+}
+
+func TestLoadCompiledProductionRotationScheduleRejectsSecondJSONValue(t *testing.T) {
+	_, _, err := loadCompiledProductionRotationScheduleFromJSONWithRegistry([]byte(`{
+		"version": 1,
+		"networks": {"mainnet": null, "testnet": null}
+	} {"version":1,"networks":{"mainnet":null,"testnet":null}}`), consensus.DefaultSuiteRegistry())
+	if err == nil {
+		t.Fatal("expected second JSON value rejection")
 	}
 	if got, want := err.Error(), `production_rotation_schedule: parse embedded artifact: trailing JSON tokens`; got != want {
 		t.Fatalf("error=%q, want %q", got, want)

--- a/clients/go/node/production_rotation_schedule_test.go
+++ b/clients/go/node/production_rotation_schedule_test.go
@@ -190,14 +190,14 @@ func TestLoadCompiledProductionRotationScheduleRejectsReservedSentinelSuiteID(t 
 			field:      "old_suite_id",
 			oldSuiteID: 0,
 			newSuiteID: 66,
-			want:       `production_rotation_schedule: networks.mainnet: old_suite_id 0x00 reserved`,
+			want:       `production_rotation_schedule: networks.mainnet: old_suite_id 0x00 is the sentinel suite_id`,
 		},
 		{
 			name:       "new_suite_id",
 			field:      "new_suite_id",
 			oldSuiteID: 1,
 			newSuiteID: 0,
-			want:       `production_rotation_schedule: networks.mainnet: new_suite_id 0x00 reserved`,
+			want:       `production_rotation_schedule: networks.mainnet: new_suite_id 0x00 is the sentinel suite_id`,
 		},
 	}
 

--- a/clients/go/node/production_rotation_schedule_test.go
+++ b/clients/go/node/production_rotation_schedule_test.go
@@ -3,8 +3,10 @@ package node
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
@@ -127,7 +129,35 @@ func TestLoadCompiledProductionRotationScheduleRejectsMalformedDescriptorShape(t
 	if err == nil {
 		t.Fatal("expected malformed descriptor rejection")
 	}
-	if got, want := err.Error(), `production_rotation_schedule: networks.mainnet: json: cannot unmarshal array into Go value of type node.RotationConfigJSON`; got != want {
+	if !strings.Contains(err.Error(), `production_rotation_schedule: networks.mainnet:`) {
+		t.Fatalf("error=%q, want production schedule stem + mainnet path", err)
+	}
+	var typeErr *json.UnmarshalTypeError
+	if !errors.As(err, &typeErr) {
+		t.Fatalf("error=%q, want wrapped *json.UnmarshalTypeError", err)
+	}
+	if got, want := typeErr.Value, "array"; got != want {
+		t.Fatalf("unmarshal value=%q, want %q", got, want)
+	}
+}
+
+func TestLoadCompiledProductionRotationScheduleRejectsMissingRequiredDescriptorField(t *testing.T) {
+	_, _, err := loadCompiledProductionRotationScheduleFromJSONWithRegistry([]byte(`{
+		"version": 1,
+		"networks": {
+			"mainnet": {
+				"name": "rotation-v1",
+				"old_suite_id": 1,
+				"new_suite_id": 66,
+				"spend_height": 20
+			},
+			"testnet": null
+		}
+	}`), canonicalProductionScheduleRegistry())
+	if err == nil {
+		t.Fatal("expected missing required descriptor field rejection")
+	}
+	if got, want := err.Error(), `production_rotation_schedule: networks.mainnet: missing required field "create_height"`; got != want {
 		t.Fatalf("error=%q, want %q", got, want)
 	}
 }

--- a/clients/go/node/production_rotation_schedule_v1_embedded.json
+++ b/clients/go/node/production_rotation_schedule_v1_embedded.json
@@ -1,0 +1,7 @@
+{
+  "version": 1,
+  "networks": {
+    "mainnet": null,
+    "testnet": null
+  }
+}

--- a/clients/rust/crates/rubin-node/src/genesis.rs
+++ b/clients/rust/crates/rubin-node/src/genesis.rs
@@ -315,10 +315,15 @@ where
                 rotation: Arc::new(DescriptorRotationProvider { descriptor }),
                 registry: Arc::new(registry),
             })),
-            None => Ok(Some(crate::sync::SuiteContext {
-                rotation: Arc::new(DefaultRotationProvider),
-                registry: Arc::new(registry),
-            })),
+            None => {
+                if !registry.is_canonical_default_live_manifest() {
+                    return Err("production_rotation_schedule: invalid empty-slot registry".into());
+                }
+                Ok(Some(crate::sync::SuiteContext {
+                    rotation: Arc::new(DefaultRotationProvider),
+                    registry: Arc::new(registry),
+                }))
+            }
         };
     }
     let explicit_registry = build_suite_registry_from_json(suite_registry)?;
@@ -1029,6 +1034,47 @@ mod tests {
             .rotation
             .native_spend_suites(0)
             .contains(SUITE_ID_ML_DSA_87));
+    }
+
+    #[test]
+    fn build_suite_context_from_descriptor_production_lookup_none_rejects_noncanonical_registry() {
+        let err = build_suite_context_from_descriptor_with_production_lookup(
+            &None,
+            &[],
+            "mainnet",
+            |_| {
+                Ok((
+                    None,
+                    rubin_consensus::SuiteRegistry::with_suites(BTreeMap::from([
+                        (
+                            SUITE_ID_ML_DSA_87,
+                            rubin_consensus::SuiteParams {
+                                suite_id: SUITE_ID_ML_DSA_87,
+                                pubkey_len: ML_DSA_87_PUBKEY_BYTES,
+                                sig_len: ML_DSA_87_SIG_BYTES,
+                                verify_cost: VERIFY_COST_ML_DSA_87,
+                                alg_name: "ML-DSA-87",
+                            },
+                        ),
+                        (
+                            77,
+                            rubin_consensus::SuiteParams {
+                                suite_id: 77,
+                                pubkey_len: ML_DSA_87_PUBKEY_BYTES,
+                                sig_len: ML_DSA_87_SIG_BYTES,
+                                verify_cost: VERIFY_COST_ML_DSA_87,
+                                alg_name: "ML-DSA-87",
+                            },
+                        ),
+                    ])),
+                ))
+            },
+        )
+        .expect_err("must reject");
+        assert_eq!(
+            err,
+            "production_rotation_schedule: invalid empty-slot registry"
+        );
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/genesis.rs
+++ b/clients/rust/crates/rubin-node/src/genesis.rs
@@ -124,8 +124,9 @@ pub struct LoadedGenesisConfig {
     pub genesis_hash: Option<[u8; 32]>,
     pub core_ext_deployments: CoreExtDeploymentProfiles,
     /// Optional SuiteContext built from non-production config or the compiled
-    /// production activation schedule. None means use the implicit default
-    /// registry/provider with no explicit suite overlay.
+    /// production activation schedule. Non-production callers without an
+    /// explicit overlay keep this as None; production empty slots use an
+    /// explicit default pre-rotation context.
     pub suite_context: Option<crate::sync::SuiteContext>,
 }
 
@@ -310,7 +311,6 @@ where
             normalized_network, SUPPORTED_ROTATION_NETWORK_NAMES_CSV,
         )
     })?;
-    let explicit_registry = build_suite_registry_from_json(suite_registry)?;
     if is_v1_production_rotation_network_normalized(normalized_network.as_ref()) {
         if desc.is_some() {
             return Err(PRODUCTION_LOCAL_ROTATION_DESCRIPTOR_ERR.to_string());
@@ -320,9 +320,15 @@ where
                 rotation: Arc::new(DescriptorRotationProvider { descriptor }),
                 registry: Arc::new(registry),
             })),
-            None => Ok(None),
+            // Production empty slots use an explicit default pre-rotation
+            // context and never consult local suite_registry input.
+            None => Ok(Some(crate::sync::SuiteContext {
+                rotation: Arc::new(DefaultRotationProvider),
+                registry: Arc::new(SuiteRegistry::default_registry()),
+            })),
         };
     }
+    let explicit_registry = build_suite_registry_from_json(suite_registry)?;
     let registry = explicit_registry.unwrap_or_else(SuiteRegistry::default_registry);
     let registry = Arc::new(registry);
     let rotation: Arc<dyn rubin_consensus::RotationProvider + Send + Sync> = match desc {
@@ -495,7 +501,6 @@ mod tests {
     use rubin_consensus::constants::{
         ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES, SUITE_ID_ML_DSA_87, VERIFY_COST_ML_DSA_87,
     };
-    use rubin_consensus::RotationProvider;
     use rubin_consensus::{
         core_ext_profile_set_anchor_v1, CoreExtDeploymentProfile, CoreExtVerificationBinding,
     };
@@ -773,8 +778,8 @@ mod tests {
     }
 
     #[test]
-    fn load_genesis_config_production_suite_registry_without_rotation_descriptor_does_not_activate()
-    {
+    fn load_genesis_config_production_suite_registry_without_descriptor_uses_default_pre_rotation_runtime(
+    ) {
         for (case_idx, network) in production_rotation_networks().into_iter().enumerate() {
             let dir = std::env::temp_dir().join(format!(
                 "rubin-node-genesis-suite-registry-production-{}-{}",
@@ -799,10 +804,55 @@ mod tests {
             .expect("write");
 
             let cfg = load_genesis_config(Some(&path), network).expect("load");
-            assert!(
-                cfg.suite_context.is_none(),
-                "expected explicit empty production schedule to keep suite_context=None for {network}"
-            );
+            let suite_context = cfg
+                .suite_context
+                .expect("expected explicit default production suite_context");
+            assert!(suite_context.registry.is_canonical_default_live_manifest());
+            assert!(suite_context.registry.lookup(SUITE_ID_ML_DSA_87).is_some());
+            assert!(suite_context.registry.lookup(66).is_none());
+            assert!(suite_context
+                .rotation
+                .native_spend_suites(0)
+                .contains(SUITE_ID_ML_DSA_87));
+            assert!(!suite_context.rotation.native_spend_suites(0).contains(66));
+
+            std::fs::remove_dir_all(&dir).expect("cleanup");
+        }
+    }
+
+    #[test]
+    fn load_genesis_config_production_ignores_bad_local_suite_registry() {
+        for (case_idx, network) in production_rotation_networks().into_iter().enumerate() {
+            let dir = std::env::temp_dir().join(format!(
+                "rubin-node-genesis-bad-suite-registry-production-{}-{}",
+                case_idx,
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .expect("time")
+                    .as_nanos()
+            ));
+            std::fs::create_dir_all(&dir).expect("mkdir");
+            let path = dir.join("genesis.json");
+            std::fs::write(
+                &path,
+                "{\
+                  \"chain_id_hex\":\"0x88f8a9acdeeb902e27aa2fdcb8c46ecf818bf68dec5273ec1bcc5084e2333103\",\
+                  \"suite_registry\":[{\"suite_id\":77,\"pubkey_len\":2592,\"sig_len\":4627,\"verify_cost\":0,\"alg_name\":\"ML-DSA-87\"}]\
+                }",
+            )
+            .expect("write");
+
+            let cfg = load_genesis_config(Some(&path), network).expect("load");
+            let suite_context = cfg
+                .suite_context
+                .expect("expected explicit default production suite_context");
+            assert!(suite_context.registry.is_canonical_default_live_manifest());
+            assert!(suite_context.registry.lookup(77).is_none());
+            assert!(suite_context
+                .rotation
+                .native_spend_suites(0)
+                .contains(SUITE_ID_ML_DSA_87));
+            assert!(!suite_context.rotation.native_spend_suites(0).contains(77));
 
             std::fs::remove_dir_all(&dir).expect("cleanup");
         }
@@ -910,7 +960,7 @@ mod tests {
     }
 
     #[test]
-    fn build_suite_context_from_descriptor_production_lookup_none_keeps_suite_registry_non_authoritative(
+    fn build_suite_context_from_descriptor_production_lookup_none_uses_default_pre_rotation_runtime(
     ) {
         let local_suite_registry = vec![GenesisSuiteParams {
             suite_id: 77,
@@ -934,16 +984,21 @@ mod tests {
                     Ok(None)
                 },
             )
-            .expect("must load");
-            assert!(
-                suite_context.is_none(),
-                "expected empty production schedule to keep suite_context=None for {input}"
-            );
+            .expect("must load")
+            .expect("suite context");
+            assert!(suite_context.registry.is_canonical_default_live_manifest());
+            assert!(suite_context.registry.lookup(SUITE_ID_ML_DSA_87).is_some());
+            assert!(suite_context.registry.lookup(77).is_none());
+            assert!(suite_context
+                .rotation
+                .native_spend_suites(0)
+                .contains(SUITE_ID_ML_DSA_87));
+            assert!(!suite_context.rotation.native_spend_suites(0).contains(77));
         }
     }
 
     #[test]
-    fn build_suite_context_from_descriptor_production_lookup_none_defers_to_default_pre_rotation_semantics(
+    fn build_suite_context_from_descriptor_production_lookup_none_returns_explicit_default_pre_rotation_semantics(
     ) {
         let suite_context = build_suite_context_from_descriptor_with_production_lookup(
             &None,
@@ -951,15 +1006,40 @@ mod tests {
             "testnet",
             |_| Ok(None),
         )
-        .expect("must load");
-        assert!(suite_context.is_none());
-        let default_registry = rubin_consensus::SuiteRegistry::default_registry();
-        assert!(default_registry.is_canonical_default_live_manifest());
-        assert!(default_registry.lookup(SUITE_ID_ML_DSA_87).is_some());
-        let default_rotation = rubin_consensus::DefaultRotationProvider;
-        assert!(default_rotation
+        .expect("must load")
+        .expect("suite context");
+        assert!(suite_context.registry.is_canonical_default_live_manifest());
+        assert!(suite_context.registry.lookup(SUITE_ID_ML_DSA_87).is_some());
+        assert!(suite_context
+            .rotation
             .native_spend_suites(0)
             .contains(SUITE_ID_ML_DSA_87));
+    }
+
+    #[test]
+    fn build_suite_context_from_descriptor_production_ignores_bad_local_suite_registry() {
+        let local_suite_registry = vec![GenesisSuiteParams {
+            suite_id: 77,
+            pubkey_len: ML_DSA_87_PUBKEY_BYTES,
+            sig_len: ML_DSA_87_SIG_BYTES,
+            verify_cost: 0,
+            alg_name: "ML-DSA-87".to_string(),
+        }];
+        let suite_context = build_suite_context_from_descriptor_with_production_lookup(
+            &None,
+            &local_suite_registry,
+            "mainnet",
+            |_| Ok(None),
+        )
+        .expect("must load")
+        .expect("suite context");
+        assert!(suite_context.registry.is_canonical_default_live_manifest());
+        assert!(suite_context.registry.lookup(77).is_none());
+        assert!(suite_context
+            .rotation
+            .native_spend_suites(0)
+            .contains(SUITE_ID_ML_DSA_87));
+        assert!(!suite_context.rotation.native_spend_suites(0).contains(77));
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/genesis.rs
+++ b/clients/rust/crates/rubin-node/src/genesis.rs
@@ -1,6 +1,7 @@
 use std::fs;
 use std::path::Path;
 
+use crate::production_rotation_schedule::production_rotation_descriptor_for_network;
 use rubin_consensus::constants::{
     MAX_WITNESS_BYTES_PER_TX, ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES, SUITE_ID_ML_DSA_87,
     SUITE_ID_SENTINEL, VERIFY_COST_ML_DSA_87,
@@ -43,8 +44,9 @@ struct GenesisPack {
 }
 
 /// JSON-serializable rotation descriptor for genesis/config.
-/// When present, constructs a DescriptorRotationProvider.
-/// When absent, DefaultRotationProvider is used (ML-DSA-87 at all heights).
+/// When present on non-production networks, constructs a
+/// DescriptorRotationProvider. Production networks derive activation only from
+/// the compiled schedule artifact.
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 struct GenesisRotationDescriptor {
     name: String,
@@ -121,8 +123,9 @@ pub struct LoadedGenesisConfig {
     pub chain_id: [u8; 32],
     pub genesis_hash: Option<[u8; 32]>,
     pub core_ext_deployments: CoreExtDeploymentProfiles,
-    /// Optional SuiteContext built from rotation_descriptor or suite_registry config.
-    /// None means use the implicit default registry/provider with no explicit suite overlay.
+    /// Optional SuiteContext built from non-production config or the compiled
+    /// production activation schedule. None means use the implicit default
+    /// registry/provider with no explicit suite overlay.
     pub suite_context: Option<crate::sync::SuiteContext>,
 }
 
@@ -290,14 +293,23 @@ fn build_suite_context_from_descriptor(
             normalized_network, SUPPORTED_ROTATION_NETWORK_NAMES_CSV,
         )
     })?;
-    let registry = build_suite_registry_from_json(suite_registry)?
-        .unwrap_or_else(SuiteRegistry::default_registry);
+    let explicit_registry = build_suite_registry_from_json(suite_registry)?;
+    if is_v1_production_rotation_network_normalized(normalized_network.as_ref()) {
+        if desc.is_some() {
+            return Err(PRODUCTION_LOCAL_ROTATION_DESCRIPTOR_ERR.to_string());
+        }
+        return match production_rotation_descriptor_for_network(normalized_network.as_ref())? {
+            Some((descriptor, registry)) => Ok(Some(crate::sync::SuiteContext {
+                rotation: Arc::new(DescriptorRotationProvider { descriptor }),
+                registry: Arc::new(registry),
+            })),
+            None => Ok(None),
+        };
+    }
+    let registry = explicit_registry.unwrap_or_else(SuiteRegistry::default_registry);
     let registry = Arc::new(registry);
     let rotation: Arc<dyn rubin_consensus::RotationProvider + Send + Sync> = match desc {
         Some(rd) => {
-            if is_v1_production_rotation_network_normalized(normalized_network.as_ref()) {
-                return Err(PRODUCTION_LOCAL_ROTATION_DESCRIPTOR_ERR.to_string());
-            }
             let descriptor = CryptoRotationDescriptor {
                 name: rd.name.clone(),
                 old_suite_id: rd.old_suite_id,
@@ -715,7 +727,8 @@ mod tests {
     }
 
     #[test]
-    fn load_genesis_config_accepts_production_suite_registry_without_rotation_descriptor() {
+    fn load_genesis_config_production_suite_registry_without_rotation_descriptor_does_not_activate()
+    {
         for (case_idx, network) in production_rotation_networks().into_iter().enumerate() {
             let dir = std::env::temp_dir().join(format!(
                 "rubin-node-genesis-suite-registry-production-{}-{}",
@@ -740,9 +753,10 @@ mod tests {
             .expect("write");
 
             let cfg = load_genesis_config(Some(&path), network).expect("load");
-            let suite_context = cfg.suite_context.expect("suite context");
-            assert!(suite_context.registry.lookup(SUITE_ID_ML_DSA_87).is_some());
-            assert!(suite_context.registry.lookup(66).is_some());
+            assert!(
+                cfg.suite_context.is_none(),
+                "expected explicit empty production schedule to keep suite_context=None for {network}"
+            );
 
             std::fs::remove_dir_all(&dir).expect("cleanup");
         }

--- a/clients/rust/crates/rubin-node/src/genesis.rs
+++ b/clients/rust/crates/rubin-node/src/genesis.rs
@@ -298,7 +298,7 @@ fn build_suite_context_from_descriptor_with_production_lookup<F>(
     production_lookup: F,
 ) -> Result<Option<crate::sync::SuiteContext>, String>
 where
-    F: FnOnce(&str) -> Result<Option<(CryptoRotationDescriptor, SuiteRegistry)>, String>,
+    F: FnOnce(&str) -> Result<(Option<CryptoRotationDescriptor>, SuiteRegistry), String>,
 {
     use std::sync::Arc;
     if network.trim().is_empty() {
@@ -315,16 +315,15 @@ where
         if desc.is_some() {
             return Err(PRODUCTION_LOCAL_ROTATION_DESCRIPTOR_ERR.to_string());
         }
-        return match production_lookup(normalized_network.as_ref())? {
-            Some((descriptor, registry)) => Ok(Some(crate::sync::SuiteContext {
+        let (descriptor, registry) = production_lookup(normalized_network.as_ref())?;
+        return match descriptor {
+            Some(descriptor) => Ok(Some(crate::sync::SuiteContext {
                 rotation: Arc::new(DescriptorRotationProvider { descriptor }),
                 registry: Arc::new(registry),
             })),
-            // Production empty slots use an explicit default pre-rotation
-            // context and never consult local suite_registry input.
             None => Ok(Some(crate::sync::SuiteContext {
                 rotation: Arc::new(DefaultRotationProvider),
-                registry: Arc::new(SuiteRegistry::default_registry()),
+                registry: Arc::new(registry),
             })),
         };
     }
@@ -503,6 +502,7 @@ mod tests {
     };
     use rubin_consensus::{
         core_ext_profile_set_anchor_v1, CoreExtDeploymentProfile, CoreExtVerificationBinding,
+        SuiteRegistry,
     };
 
     use super::{
@@ -873,17 +873,17 @@ mod tests {
             " mainnet ",
             |network| {
                 assert_eq!(network, "mainnet");
-                Ok(Some((
-                    CryptoRotationDescriptor {
+                Ok((
+                    Some(CryptoRotationDescriptor {
                         name: "rotation-v1".to_string(),
                         old_suite_id: SUITE_ID_ML_DSA_87,
                         new_suite_id: 66,
                         create_height: 10,
                         spend_height: 20,
                         sunset_height: 30,
-                    },
+                    }),
                     canonical_production_schedule_registry(),
-                )))
+                ))
             },
         )
         .expect("must load")
@@ -909,17 +909,17 @@ mod tests {
                 input,
                 |network| {
                     assert_eq!(network, expected);
-                    Ok(Some((
-                        CryptoRotationDescriptor {
+                    Ok((
+                        Some(CryptoRotationDescriptor {
                             name: "rotation-v1".to_string(),
                             old_suite_id: SUITE_ID_ML_DSA_87,
                             new_suite_id: 66,
                             create_height: 10,
                             spend_height: 20,
                             sunset_height: 30,
-                        },
+                        }),
                         canonical_production_schedule_registry(),
-                    )))
+                    ))
                 },
             )
             .expect("must load")
@@ -981,7 +981,7 @@ mod tests {
                 input,
                 |network| {
                     assert_eq!(network, expected);
-                    Ok(None)
+                    Ok((None, SuiteRegistry::default_registry()))
                 },
             )
             .expect("must load")
@@ -1004,7 +1004,7 @@ mod tests {
             &None,
             &[],
             "testnet",
-            |_| Ok(None),
+            |_| Ok((None, SuiteRegistry::default_registry())),
         )
         .expect("must load")
         .expect("suite context");
@@ -1029,7 +1029,7 @@ mod tests {
             &None,
             &local_suite_registry,
             "mainnet",
-            |_| Ok(None),
+            |_| Ok((None, SuiteRegistry::default_registry())),
         )
         .expect("must load")
         .expect("suite context");

--- a/clients/rust/crates/rubin-node/src/genesis.rs
+++ b/clients/rust/crates/rubin-node/src/genesis.rs
@@ -282,6 +282,23 @@ fn build_suite_context_from_descriptor(
     suite_registry: &[GenesisSuiteParams],
     network: &str,
 ) -> Result<Option<crate::sync::SuiteContext>, String> {
+    build_suite_context_from_descriptor_with_production_lookup(
+        desc,
+        suite_registry,
+        network,
+        production_rotation_descriptor_for_network,
+    )
+}
+
+fn build_suite_context_from_descriptor_with_production_lookup<F>(
+    desc: &Option<GenesisRotationDescriptor>,
+    suite_registry: &[GenesisSuiteParams],
+    network: &str,
+    production_lookup: F,
+) -> Result<Option<crate::sync::SuiteContext>, String>
+where
+    F: FnOnce(&str) -> Result<Option<(CryptoRotationDescriptor, SuiteRegistry)>, String>,
+{
     use std::sync::Arc;
     if network.trim().is_empty() {
         return Err("network is required".to_string());
@@ -298,7 +315,7 @@ fn build_suite_context_from_descriptor(
         if desc.is_some() {
             return Err(PRODUCTION_LOCAL_ROTATION_DESCRIPTOR_ERR.to_string());
         }
-        return match production_rotation_descriptor_for_network(normalized_network.as_ref())? {
+        return match production_lookup(normalized_network.as_ref())? {
             Some((descriptor, registry)) => Ok(Some(crate::sync::SuiteContext {
                 rotation: Arc::new(DescriptorRotationProvider { descriptor }),
                 registry: Arc::new(registry),
@@ -478,15 +495,19 @@ mod tests {
     use rubin_consensus::constants::{
         ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES, SUITE_ID_ML_DSA_87, VERIFY_COST_ML_DSA_87,
     };
+    use rubin_consensus::RotationProvider;
     use rubin_consensus::{
         core_ext_profile_set_anchor_v1, CoreExtDeploymentProfile, CoreExtVerificationBinding,
     };
 
     use super::{
-        derive_devnet_genesis_chain_id, devnet_genesis_block_bytes, devnet_genesis_chain_id,
-        devnet_genesis_hash, load_chain_id_from_genesis_file, load_genesis_config,
-        validate_incoming_chain_id, PRODUCTION_LOCAL_ROTATION_DESCRIPTOR_ERR,
+        build_suite_context_from_descriptor_with_production_lookup, derive_devnet_genesis_chain_id,
+        devnet_genesis_block_bytes, devnet_genesis_chain_id, devnet_genesis_hash,
+        load_chain_id_from_genesis_file, load_genesis_config, validate_incoming_chain_id,
+        CryptoRotationDescriptor, GenesisRotationDescriptor, GenesisSuiteParams,
+        PRODUCTION_LOCAL_ROTATION_DESCRIPTOR_ERR,
     };
+    use std::collections::BTreeMap;
 
     fn suite_registry_entry_json(
         suite_id: u8,
@@ -508,6 +529,31 @@ mod tests {
             VERIFY_COST_ML_DSA_87,
             "ML-DSA-87",
         )
+    }
+
+    fn canonical_production_schedule_registry() -> rubin_consensus::SuiteRegistry {
+        let mut suites = BTreeMap::new();
+        suites.insert(
+            SUITE_ID_ML_DSA_87,
+            rubin_consensus::SuiteParams {
+                suite_id: SUITE_ID_ML_DSA_87,
+                pubkey_len: ML_DSA_87_PUBKEY_BYTES,
+                sig_len: ML_DSA_87_SIG_BYTES,
+                verify_cost: VERIFY_COST_ML_DSA_87,
+                alg_name: "ML-DSA-87",
+            },
+        );
+        suites.insert(
+            66,
+            rubin_consensus::SuiteParams {
+                suite_id: 66,
+                pubkey_len: ML_DSA_87_PUBKEY_BYTES,
+                sig_len: ML_DSA_87_SIG_BYTES,
+                verify_cost: VERIFY_COST_ML_DSA_87,
+                alg_name: "ML-DSA-87",
+            },
+        );
+        rubin_consensus::SuiteRegistry::with_suites(suites)
     }
 
     fn production_rotation_networks() -> [&'static str; 4] {
@@ -760,6 +806,160 @@ mod tests {
 
             std::fs::remove_dir_all(&dir).expect("cleanup");
         }
+    }
+
+    #[test]
+    fn build_suite_context_from_descriptor_production_lookup_activates_rotation() {
+        let local_suite_registry = vec![GenesisSuiteParams {
+            suite_id: 77,
+            pubkey_len: ML_DSA_87_PUBKEY_BYTES,
+            sig_len: ML_DSA_87_SIG_BYTES,
+            verify_cost: VERIFY_COST_ML_DSA_87,
+            alg_name: "ML-DSA-87".to_string(),
+        }];
+        let suite_context = build_suite_context_from_descriptor_with_production_lookup(
+            &None,
+            &local_suite_registry,
+            " mainnet ",
+            |network| {
+                assert_eq!(network, "mainnet");
+                Ok(Some((
+                    CryptoRotationDescriptor {
+                        name: "rotation-v1".to_string(),
+                        old_suite_id: SUITE_ID_ML_DSA_87,
+                        new_suite_id: 66,
+                        create_height: 10,
+                        spend_height: 20,
+                        sunset_height: 30,
+                    },
+                    canonical_production_schedule_registry(),
+                )))
+            },
+        )
+        .expect("must load")
+        .expect("suite context");
+        assert!(suite_context.registry.lookup(SUITE_ID_ML_DSA_87).is_some());
+        assert!(suite_context.registry.lookup(66).is_some());
+        assert!(suite_context.registry.lookup(77).is_none());
+        assert!(!suite_context.rotation.native_spend_suites(9).contains(66));
+        assert!(suite_context.rotation.native_spend_suites(10).contains(66));
+    }
+
+    #[test]
+    fn build_suite_context_from_descriptor_production_lookup_normalizes_network_variants() {
+        for (input, expected) in [
+            ("mainnet", "mainnet"),
+            ("testnet", "testnet"),
+            (" MAINNET ", "mainnet"),
+            ("\tTestNet\t", "testnet"),
+        ] {
+            let suite_context = build_suite_context_from_descriptor_with_production_lookup(
+                &None,
+                &[],
+                input,
+                |network| {
+                    assert_eq!(network, expected);
+                    Ok(Some((
+                        CryptoRotationDescriptor {
+                            name: "rotation-v1".to_string(),
+                            old_suite_id: SUITE_ID_ML_DSA_87,
+                            new_suite_id: 66,
+                            create_height: 10,
+                            spend_height: 20,
+                            sunset_height: 30,
+                        },
+                        canonical_production_schedule_registry(),
+                    )))
+                },
+            )
+            .expect("must load")
+            .expect("suite context");
+            assert!(suite_context.registry.lookup(SUITE_ID_ML_DSA_87).is_some());
+            assert!(suite_context.registry.lookup(66).is_some());
+            assert!(!suite_context.rotation.native_spend_suites(9).contains(66));
+            assert!(suite_context.rotation.native_spend_suites(10).contains(66));
+        }
+    }
+
+    #[test]
+    fn build_suite_context_from_descriptor_production_lookup_rejects_local_descriptor() {
+        const WANT_PRODUCTION_GUARD: &str =
+            "rotation_descriptor: production networks forbid local rotation_descriptor";
+        let descriptor = Some(GenesisRotationDescriptor {
+            name: "prod-rotation".to_string(),
+            old_suite_id: SUITE_ID_ML_DSA_87,
+            new_suite_id: 66,
+            create_height: 10,
+            spend_height: 20,
+            sunset_height: 30,
+        });
+        for network in production_rotation_networks() {
+            let err = build_suite_context_from_descriptor_with_production_lookup(
+                &descriptor,
+                &[],
+                network,
+                |_| {
+                    panic!(
+                        "production lookup must not run after local production rotation_descriptor reject"
+                    )
+                },
+            )
+            .expect_err("must reject");
+            assert_eq!(err, WANT_PRODUCTION_GUARD);
+        }
+    }
+
+    #[test]
+    fn build_suite_context_from_descriptor_production_lookup_none_keeps_suite_registry_non_authoritative(
+    ) {
+        let local_suite_registry = vec![GenesisSuiteParams {
+            suite_id: 77,
+            pubkey_len: ML_DSA_87_PUBKEY_BYTES,
+            sig_len: ML_DSA_87_SIG_BYTES,
+            verify_cost: VERIFY_COST_ML_DSA_87,
+            alg_name: "ML-DSA-87".to_string(),
+        }];
+        for (input, expected) in [
+            ("mainnet", "mainnet"),
+            ("testnet", "testnet"),
+            (" MAINNET ", "mainnet"),
+            ("\tTestNet\t", "testnet"),
+        ] {
+            let suite_context = build_suite_context_from_descriptor_with_production_lookup(
+                &None,
+                &local_suite_registry,
+                input,
+                |network| {
+                    assert_eq!(network, expected);
+                    Ok(None)
+                },
+            )
+            .expect("must load");
+            assert!(
+                suite_context.is_none(),
+                "expected empty production schedule to keep suite_context=None for {input}"
+            );
+        }
+    }
+
+    #[test]
+    fn build_suite_context_from_descriptor_production_lookup_none_defers_to_default_pre_rotation_semantics(
+    ) {
+        let suite_context = build_suite_context_from_descriptor_with_production_lookup(
+            &None,
+            &[],
+            "testnet",
+            |_| Ok(None),
+        )
+        .expect("must load");
+        assert!(suite_context.is_none());
+        let default_registry = rubin_consensus::SuiteRegistry::default_registry();
+        assert!(default_registry.is_canonical_default_live_manifest());
+        assert!(default_registry.lookup(SUITE_ID_ML_DSA_87).is_some());
+        let default_rotation = rubin_consensus::DefaultRotationProvider;
+        assert!(default_rotation
+            .native_spend_suites(0)
+            .contains(SUITE_ID_ML_DSA_87));
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/genesis.rs
+++ b/clients/rust/crates/rubin-node/src/genesis.rs
@@ -9,7 +9,7 @@ use rubin_consensus::constants::{
 use rubin_consensus::encode_compact_size;
 use rubin_consensus::{
     block_hash, canonical_rotation_network_name_normalized, core_ext_profile_set_anchor_v1,
-    is_v1_production_rotation_network_normalized, normalized_rotation_network_name,
+    is_v1_production_rotation_network_normalized,
     validate_rotation_descriptor_for_normalized_network, CoreExtDeploymentProfile,
     CoreExtDeploymentProfiles, CryptoRotationDescriptor, DefaultRotationProvider,
     DescriptorRotationProvider, SuiteParams, SuiteRegistry, BLOCK_HEADER_BYTES,
@@ -305,11 +305,11 @@ where
         return Err("network is required".to_string());
     }
     let normalized_network = canonical_config_network_name(network)?;
-    if is_v1_production_rotation_network_normalized(normalized_network.as_ref()) {
+    if is_v1_production_rotation_network_normalized(normalized_network.as_str()) {
         if desc.is_some() {
             return Err(PRODUCTION_LOCAL_ROTATION_DESCRIPTOR_ERR.to_string());
         }
-        let (descriptor, registry) = production_lookup(normalized_network.as_ref())?;
+        let (descriptor, registry) = production_lookup(normalized_network.as_str())?;
         return match descriptor {
             Some(descriptor) => Ok(Some(crate::sync::SuiteContext {
                 rotation: Arc::new(DescriptorRotationProvider { descriptor }),
@@ -335,7 +335,7 @@ where
                 sunset_height: rd.sunset_height,
             };
             validate_rotation_descriptor_for_normalized_network(
-                normalized_network.as_ref(),
+                normalized_network.as_str(),
                 &descriptor,
                 &registry,
             )
@@ -348,9 +348,9 @@ where
     Ok(Some(crate::sync::SuiteContext { rotation, registry }))
 }
 
-fn canonical_config_network_name(network: &str) -> Result<std::borrow::Cow<'_, str>, String> {
-    let normalized = normalized_rotation_network_name(network);
-    if canonical_rotation_network_name_normalized(normalized.as_ref()).is_some() {
+fn canonical_config_network_name(network: &str) -> Result<String, String> {
+    let normalized = network.trim().to_ascii_lowercase();
+    if canonical_rotation_network_name_normalized(normalized.as_str()).is_some() {
         Ok(normalized)
     } else {
         Err(format!(

--- a/clients/rust/crates/rubin-node/src/genesis.rs
+++ b/clients/rust/crates/rubin-node/src/genesis.rs
@@ -835,10 +835,19 @@ mod tests {
             let path = dir.join("genesis.json");
             std::fs::write(
                 &path,
-                "{\
-                  \"chain_id_hex\":\"0x88f8a9acdeeb902e27aa2fdcb8c46ecf818bf68dec5273ec1bcc5084e2333103\",\
-                  \"suite_registry\":[{\"suite_id\":77,\"pubkey_len\":2592,\"sig_len\":4627,\"verify_cost\":0,\"alg_name\":\"ML-DSA-87\"}]\
-                }",
+                format!(
+                    "{{\
+                      \"chain_id_hex\":\"0x88f8a9acdeeb902e27aa2fdcb8c46ecf818bf68dec5273ec1bcc5084e2333103\",\
+                      \"suite_registry\":[{}]\
+                    }}",
+                    suite_registry_entry_json(
+                        77,
+                        ML_DSA_87_PUBKEY_BYTES,
+                        ML_DSA_87_SIG_BYTES,
+                        0,
+                        "ML-DSA-87",
+                    )
+                ),
             )
             .expect("write");
 

--- a/clients/rust/crates/rubin-node/src/genesis.rs
+++ b/clients/rust/crates/rubin-node/src/genesis.rs
@@ -8,7 +8,7 @@ use rubin_consensus::constants::{
 };
 use rubin_consensus::encode_compact_size;
 use rubin_consensus::{
-    block_hash, canonical_rotation_network_name_normalized, core_ext_profile_set_anchor_v1,
+    block_hash, canonical_rotation_network_name, core_ext_profile_set_anchor_v1,
     is_v1_production_rotation_network_normalized, normalized_rotation_network_name,
     validate_rotation_descriptor_for_normalized_network, CoreExtDeploymentProfile,
     CoreExtDeploymentProfiles, CryptoRotationDescriptor, DefaultRotationProvider,
@@ -304,11 +304,11 @@ where
     if network.trim().is_empty() {
         return Err("network is required".to_string());
     }
-    let normalized_network = normalized_rotation_network_name(network);
-    canonical_rotation_network_name_normalized(normalized_network.as_ref()).ok_or_else(|| {
+    let normalized_network = canonical_rotation_network_name(network).ok_or_else(|| {
         format!(
             "unknown network '{}' (expected: {})",
-            normalized_network, SUPPORTED_ROTATION_NETWORK_NAMES_CSV,
+            normalized_rotation_network_name(network),
+            SUPPORTED_ROTATION_NETWORK_NAMES_CSV,
         )
     })?;
     if is_v1_production_rotation_network_normalized(normalized_network.as_ref()) {

--- a/clients/rust/crates/rubin-node/src/genesis.rs
+++ b/clients/rust/crates/rubin-node/src/genesis.rs
@@ -8,7 +8,7 @@ use rubin_consensus::constants::{
 };
 use rubin_consensus::encode_compact_size;
 use rubin_consensus::{
-    block_hash, canonical_rotation_network_name, core_ext_profile_set_anchor_v1,
+    block_hash, canonical_rotation_network_name_normalized, core_ext_profile_set_anchor_v1,
     is_v1_production_rotation_network_normalized, normalized_rotation_network_name,
     validate_rotation_descriptor_for_normalized_network, CoreExtDeploymentProfile,
     CoreExtDeploymentProfiles, CryptoRotationDescriptor, DefaultRotationProvider,
@@ -304,13 +304,7 @@ where
     if network.trim().is_empty() {
         return Err("network is required".to_string());
     }
-    let normalized_network = canonical_rotation_network_name(network).ok_or_else(|| {
-        format!(
-            "unknown network '{}' (expected: {})",
-            normalized_rotation_network_name(network),
-            SUPPORTED_ROTATION_NETWORK_NAMES_CSV,
-        )
-    })?;
+    let normalized_network = canonical_config_network_name(network)?;
     if is_v1_production_rotation_network_normalized(normalized_network.as_ref()) {
         if desc.is_some() {
             return Err(PRODUCTION_LOCAL_ROTATION_DESCRIPTOR_ERR.to_string());
@@ -352,6 +346,18 @@ where
         None => return Ok(None),
     };
     Ok(Some(crate::sync::SuiteContext { rotation, registry }))
+}
+
+fn canonical_config_network_name(network: &str) -> Result<std::borrow::Cow<'_, str>, String> {
+    let normalized = normalized_rotation_network_name(network);
+    if canonical_rotation_network_name_normalized(normalized.as_ref()).is_some() {
+        Ok(normalized)
+    } else {
+        Err(format!(
+            "unknown network '{}' (expected: {})",
+            normalized, SUPPORTED_ROTATION_NETWORK_NAMES_CSV,
+        ))
+    }
 }
 
 pub fn load_chain_id_from_genesis_file(path: Option<&Path>) -> Result<[u8; 32], String> {

--- a/clients/rust/crates/rubin-node/src/lib.rs
+++ b/clients/rust/crates/rubin-node/src/lib.rs
@@ -8,6 +8,7 @@ mod io_utils;
 pub mod miner;
 pub mod p2p_runtime;
 pub mod p2p_service;
+mod production_rotation_schedule;
 pub mod relay_pool;
 pub mod sync;
 pub mod sync_disconnect;

--- a/clients/rust/crates/rubin-node/src/main.rs
+++ b/clients/rust/crates/rubin-node/src/main.rs
@@ -853,7 +853,7 @@ mod tests {
         cases: Vec<LegacyExposureHookVectorCase>,
     }
 
-    #[derive(serde::Deserialize)]
+    #[derive(Debug, PartialEq, Eq, serde::Deserialize)]
     struct LegacyExposureHookVectorCase {
         name: String,
         has_chainstate_tip: bool,
@@ -861,6 +861,43 @@ mod tests {
         sunset_readiness: String,
         warning_hook: String,
         grace_hook: String,
+    }
+
+    fn canonical_legacy_exposure_hook_vectors() -> Vec<LegacyExposureHookVectorCase> {
+        vec![
+            LegacyExposureHookVectorCase {
+                name: "no_chainstate_tip_zero_total".to_string(),
+                has_chainstate_tip: false,
+                legacy_exposure_total: 0,
+                sunset_readiness: "invalid_no_chainstate_tip".to_string(),
+                warning_hook: "none".to_string(),
+                grace_hook: "not_applicable_no_chainstate_tip".to_string(),
+            },
+            LegacyExposureHookVectorCase {
+                name: "no_chainstate_tip_nonzero_total".to_string(),
+                has_chainstate_tip: false,
+                legacy_exposure_total: 5,
+                sunset_readiness: "invalid_no_chainstate_tip".to_string(),
+                warning_hook: "none".to_string(),
+                grace_hook: "not_applicable_no_chainstate_tip".to_string(),
+            },
+            LegacyExposureHookVectorCase {
+                name: "tipped_chain_zero_exposure".to_string(),
+                has_chainstate_tip: true,
+                legacy_exposure_total: 0,
+                sunset_readiness: "ready_for_operator_defined_grace_window".to_string(),
+                warning_hook: "none".to_string(),
+                grace_hook: "start_operator_defined_grace_window".to_string(),
+            },
+            LegacyExposureHookVectorCase {
+                name: "tipped_chain_nonzero_exposure".to_string(),
+                has_chainstate_tip: true,
+                legacy_exposure_total: 3,
+                sunset_readiness: "not_ready_legacy_exposure_present".to_string(),
+                warning_hook: "legacy_exposure_present_notify_operator_and_council".to_string(),
+                grace_hook: "not_applicable_legacy_exposure_present".to_string(),
+            },
+        ]
     }
 
     struct FailingWriter;
@@ -952,8 +989,8 @@ mod tests {
             serde_json::from_str(&raw).expect("parse hook vectors");
         assert_eq!(doc.contract_version, super::LEGACY_EXPOSURE_REPORT_VERSION);
         assert_eq!(doc.fixture_kind, "legacy_exposure_hook_vectors");
-        assert!(!doc.cases.is_empty(), "expected at least one hook vector");
-        for vector in doc.cases {
+        assert_eq!(doc.cases, canonical_legacy_exposure_hook_vectors());
+        for vector in &doc.cases {
             let (readiness, warning, grace) =
                 legacy_exposure_hooks(vector.has_chainstate_tip, vector.legacy_exposure_total);
             assert_eq!(readiness, vector.sunset_readiness, "{}", vector.name);

--- a/clients/rust/crates/rubin-node/src/production_rotation_schedule.rs
+++ b/clients/rust/crates/rubin-node/src/production_rotation_schedule.rs
@@ -5,7 +5,7 @@ use rubin_consensus::{
     validate_rotation_descriptor_for_normalized_network, CryptoRotationDescriptor, SuiteParams,
     SuiteRegistry,
 };
-use serde::de::{DeserializeOwned, IgnoredAny};
+use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use serde_json::Value;
 use std::collections::BTreeMap;
@@ -54,11 +54,10 @@ fn production_rotation_schedule_error(message: impl Into<String>) -> String {
 fn decode_single_json_value<T: DeserializeOwned>(raw: &str) -> Result<T, String> {
     let mut deserializer = serde_json::Deserializer::from_str(raw);
     let value = T::deserialize(&mut deserializer).map_err(|err| err.to_string())?;
-    match IgnoredAny::deserialize(&mut deserializer) {
-        Ok(_) => Err("trailing JSON tokens".to_owned()),
-        Err(err) if err.classify() == serde_json::error::Category::Eof => Ok(value),
-        Err(err) => Err(err.to_string()),
-    }
+    deserializer
+        .end()
+        .map_err(|_| "trailing JSON tokens".to_owned())?;
+    Ok(value)
 }
 
 fn parse_descriptor_slot_wire(

--- a/clients/rust/crates/rubin-node/src/production_rotation_schedule.rs
+++ b/clients/rust/crates/rubin-node/src/production_rotation_schedule.rs
@@ -55,9 +55,11 @@ fn production_rotation_schedule_error(message: impl Into<String>) -> String {
 fn decode_single_json_value<T: DeserializeOwned>(raw: &str) -> Result<T, String> {
     let mut deserializer = serde_json::Deserializer::from_str(raw);
     let value = T::deserialize(&mut deserializer).map_err(|err| err.to_string())?;
-    deserializer
-        .end()
-        .map_err(|_| "trailing JSON tokens".to_owned())?;
+    match Value::deserialize(&mut deserializer) {
+        Ok(_) => return Err("trailing JSON tokens".to_owned()),
+        Err(err) if err.is_eof() => {}
+        Err(err) => return Err(err.to_string()),
+    }
     Ok(value)
 }
 
@@ -189,7 +191,7 @@ pub(crate) fn load_compiled_production_rotation_schedule(
 
 pub(crate) fn production_rotation_descriptor_for_network(
     network: &str,
-) -> Result<Option<(CryptoRotationDescriptor, SuiteRegistry)>, String> {
+) -> Result<(Option<CryptoRotationDescriptor>, SuiteRegistry), String> {
     let (schedule, registry) = load_compiled_production_rotation_schedule()?;
     let descriptor = match network {
         "mainnet" => schedule.mainnet,
@@ -200,10 +202,13 @@ pub(crate) fn production_rotation_descriptor_for_network(
             )))
         }
     };
-    // A null slot means this network has no authoritative production activation state.
-    // The compiled registry is derived across schedule entries, so returning it here
-    // would leak foreign-network suites into an empty-slot caller.
-    Ok(descriptor.map(|descriptor| (descriptor, registry)))
+    if descriptor.is_none() {
+        // A null slot means this network has no authoritative production activation state.
+        // Empty-slot callers must use the canonical default pre-rotation registry and must
+        // not inherit foreign-network suites from the compiled schedule.
+        return Ok((None, SuiteRegistry::default_registry()));
+    }
+    Ok((descriptor, registry))
 }
 
 #[cfg(test)]
@@ -211,7 +216,7 @@ pub(crate) fn production_rotation_descriptor_for_network_with_registry_for_test(
     raw: &str,
     network: &str,
     registry: SuiteRegistry,
-) -> Result<Option<(CryptoRotationDescriptor, SuiteRegistry)>, String> {
+) -> Result<(Option<CryptoRotationDescriptor>, SuiteRegistry), String> {
     let (schedule, registry) = parse_schedule_with_registry(raw, Some(registry))?;
     let descriptor = match network {
         "mainnet" => schedule.mainnet,
@@ -222,7 +227,10 @@ pub(crate) fn production_rotation_descriptor_for_network_with_registry_for_test(
             )))
         }
     };
-    Ok(descriptor.map(|descriptor| (descriptor, registry)))
+    if descriptor.is_none() {
+        return Ok((None, SuiteRegistry::default_registry()));
+    }
+    Ok((descriptor, registry))
 }
 
 impl ProductionRotationDescriptorWire {
@@ -288,13 +296,19 @@ mod tests {
     }
 
     #[test]
-    fn production_rotation_descriptor_for_network_returns_none_for_explicit_empty_schedule() {
-        assert!(production_rotation_descriptor_for_network("mainnet")
-            .expect("mainnet schedule")
-            .is_none());
-        assert!(production_rotation_descriptor_for_network("testnet")
-            .expect("testnet schedule")
-            .is_none());
+    fn production_rotation_descriptor_for_network_returns_default_registry_for_explicit_empty_schedule(
+    ) {
+        let (mainnet_desc, mainnet_registry) =
+            production_rotation_descriptor_for_network("mainnet").expect("mainnet schedule");
+        assert!(mainnet_desc.is_none());
+        assert!(mainnet_registry.is_canonical_default_live_manifest());
+        assert!(mainnet_registry.lookup(66).is_none());
+
+        let (testnet_desc, testnet_registry) =
+            production_rotation_descriptor_for_network("testnet").expect("testnet schedule");
+        assert!(testnet_desc.is_none());
+        assert!(testnet_registry.is_canonical_default_live_manifest());
+        assert!(testnet_registry.lookup(66).is_none());
     }
 
     #[test]
@@ -424,9 +438,9 @@ mod tests {
             "mainnet",
             canonical_production_schedule_registry(),
         )
-        .expect("must load")
-        .expect("descriptor");
-        let (descriptor, registry) = loaded;
+        .expect("must load");
+        let descriptor = loaded.0.expect("descriptor");
+        let registry = loaded.1;
         assert_eq!(descriptor.old_suite_id, 1);
         assert_eq!(descriptor.new_suite_id, 66);
         assert!(registry.lookup(66).is_some());

--- a/clients/rust/crates/rubin-node/src/production_rotation_schedule.rs
+++ b/clients/rust/crates/rubin-node/src/production_rotation_schedule.rs
@@ -69,16 +69,16 @@ fn parse_descriptor_slot_wire(
     }
     let descriptor_wire: ProductionRotationDescriptorWire = serde_json::from_value(value)
         .map_err(|err| production_rotation_schedule_error(format!("networks.{network}: {err}")))?;
-    reject_reserved_suite_id("old_suite_id", descriptor_wire.old_suite_id)
+    reject_sentinel_suite_id("old_suite_id", descriptor_wire.old_suite_id)
         .map_err(|err| production_rotation_schedule_error(format!("networks.{network}: {err}")))?;
-    reject_reserved_suite_id("new_suite_id", descriptor_wire.new_suite_id)
+    reject_sentinel_suite_id("new_suite_id", descriptor_wire.new_suite_id)
         .map_err(|err| production_rotation_schedule_error(format!("networks.{network}: {err}")))?;
     Ok(Some(descriptor_wire))
 }
 
-fn reject_reserved_suite_id(field: &str, suite_id: u8) -> Result<(), String> {
+fn reject_sentinel_suite_id(field: &str, suite_id: u8) -> Result<(), String> {
     if suite_id == SUITE_ID_SENTINEL {
-        return Err(format!("{field} 0x{suite_id:02x} reserved"));
+        return Err(format!("{field} 0x{suite_id:02x} is the sentinel suite_id"));
     }
     Ok(())
 }
@@ -348,19 +348,19 @@ mod tests {
     }
 
     #[test]
-    fn production_rotation_schedule_rejects_reserved_sentinel_suite_id() {
+    fn production_rotation_schedule_rejects_sentinel_suite_id() {
         for (field_name, old_suite_id, new_suite_id, want) in [
             (
                 "old_suite_id",
                 0,
                 66,
-                "production_rotation_schedule: networks.mainnet: old_suite_id 0x00 reserved",
+                "production_rotation_schedule: networks.mainnet: old_suite_id 0x00 is the sentinel suite_id",
             ),
             (
                 "new_suite_id",
                 1,
                 0,
-                "production_rotation_schedule: networks.mainnet: new_suite_id 0x00 reserved",
+                "production_rotation_schedule: networks.mainnet: new_suite_id 0x00 is the sentinel suite_id",
             ),
         ] {
             let err = production_rotation_descriptor_for_network_with_registry_for_test(

--- a/clients/rust/crates/rubin-node/src/production_rotation_schedule.rs
+++ b/clients/rust/crates/rubin-node/src/production_rotation_schedule.rs
@@ -1,10 +1,6 @@
-use rubin_consensus::constants::{
-    ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES, SUITE_ID_ML_DSA_87, SUITE_ID_SENTINEL,
-    VERIFY_COST_ML_DSA_87,
-};
+use rubin_consensus::constants::SUITE_ID_SENTINEL;
 use rubin_consensus::{
-    validate_rotation_descriptor_for_normalized_network, CryptoRotationDescriptor, SuiteParams,
-    SuiteRegistry,
+    validate_rotation_descriptor_for_normalized_network, CryptoRotationDescriptor, SuiteRegistry,
 };
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
@@ -14,12 +10,11 @@ use std::collections::BTreeMap;
 pub(crate) const PRODUCTION_ROTATION_SCHEDULE_VERSION: u64 = 1;
 pub(crate) const PRODUCTION_ROTATION_SCHEDULE_ERR_STEM: &str = "production_rotation_schedule";
 
-// Rust embeds the canonical protocol fixture directly; there is no client-local
-// copy of the production schedule artifact to keep in sync.
-const PRODUCTION_ROTATION_SCHEDULE_V1_JSON: &str = include_str!(concat!(
-    env!("CARGO_MANIFEST_DIR"),
-    "/../../../../conformance/fixtures/protocol/production_rotation_schedule_v1.json"
-));
+// Derived runtime copy of conformance/fixtures/protocol/production_rotation_schedule_v1.json.
+// Rust keeps a client-local embed, and tests pin JSON-equivalence to the
+// canonical protocol fixture so Go/Rust update through the same rebuild path.
+const PRODUCTION_ROTATION_SCHEDULE_V1_JSON: &str =
+    include_str!("production_rotation_schedule_v1_embedded.json");
 
 #[derive(Debug)]
 pub(crate) struct ProductionRotationSchedule {
@@ -88,38 +83,6 @@ fn reject_reserved_suite_id(field: &str, suite_id: u8) -> Result<(), String> {
     Ok(())
 }
 
-fn canonical_production_schedule_suite_params(suite_id: u8) -> SuiteParams {
-    SuiteParams {
-        suite_id,
-        pubkey_len: ML_DSA_87_PUBKEY_BYTES,
-        sig_len: ML_DSA_87_SIG_BYTES,
-        verify_cost: VERIFY_COST_ML_DSA_87,
-        alg_name: "ML-DSA-87",
-    }
-}
-
-fn derived_production_schedule_registry(
-    mainnet: &Option<ProductionRotationDescriptorWire>,
-    testnet: &Option<ProductionRotationDescriptorWire>,
-) -> SuiteRegistry {
-    let mut suites = BTreeMap::new();
-    suites.insert(
-        SUITE_ID_ML_DSA_87,
-        canonical_production_schedule_suite_params(SUITE_ID_ML_DSA_87),
-    );
-    for descriptor in [mainnet.as_ref(), testnet.as_ref()].into_iter().flatten() {
-        suites.insert(
-            descriptor.old_suite_id,
-            canonical_production_schedule_suite_params(descriptor.old_suite_id),
-        );
-        suites.insert(
-            descriptor.new_suite_id,
-            canonical_production_schedule_suite_params(descriptor.new_suite_id),
-        );
-    }
-    SuiteRegistry::with_suites(suites)
-}
-
 fn validate_descriptor_wire(
     descriptor_wire: Option<ProductionRotationDescriptorWire>,
     network: &str,
@@ -172,8 +135,11 @@ fn parse_schedule_with_registry(
             .ok_or_else(|| production_rotation_schedule_error("networks.testnet missing"))?,
         "testnet",
     )?;
-    let registry = registry
-        .unwrap_or_else(|| derived_production_schedule_registry(&mainnet_wire, &testnet_wire));
+    // The compiled production schedule is activation-only authority. Without an
+    // explicit canonical registry contract from the caller, fail closed to the
+    // default live manifest instead of synthesizing suite params from schedule
+    // IDs.
+    let registry = registry.unwrap_or_else(SuiteRegistry::default_registry);
     let mainnet = validate_descriptor_wire(mainnet_wire, "mainnet", &registry)?;
     let testnet = validate_descriptor_wire(testnet_wire, "testnet", &registry)?;
     Ok((
@@ -483,8 +449,8 @@ mod tests {
     }
 
     #[test]
-    fn production_rotation_schedule_derives_scheduled_suites_when_registry_is_implicit() {
-        let (schedule, registry) = parse_schedule_with_registry(
+    fn production_rotation_schedule_implicit_registry_rejects_unsanctioned_scheduled_suite() {
+        let err = parse_schedule_with_registry(
             r#"{
                 "version": 1,
                 "networks": {
@@ -501,19 +467,16 @@ mod tests {
             }"#,
             None,
         )
-        .expect("must load");
-        let descriptor = schedule.mainnet.expect("mainnet descriptor");
-        assert_eq!(descriptor.new_suite_id, 66);
-        let params = registry.lookup(66).expect("suite 66");
-        assert_eq!(params.pubkey_len, ML_DSA_87_PUBKEY_BYTES);
-        assert_eq!(params.sig_len, ML_DSA_87_SIG_BYTES);
-        assert_eq!(params.verify_cost, VERIFY_COST_ML_DSA_87);
-        assert_eq!(params.alg_name, "ML-DSA-87");
+        .expect_err("must reject");
+        assert_eq!(
+            err,
+            "production_rotation_schedule: networks.mainnet: rotation_descriptor: rotation: new suite 0x42 not registered"
+        );
     }
 
     #[test]
-    fn production_rotation_schedule_empty_slot_does_not_erase_foreign_slot_suites() {
-        let (schedule, registry) = parse_schedule_with_registry(
+    fn production_rotation_schedule_implicit_registry_rejects_foreign_slot_suite_ids() {
+        let err = parse_schedule_with_registry(
             r#"{
                 "version": 1,
                 "networks": {
@@ -530,10 +493,11 @@ mod tests {
             }"#,
             None,
         )
-        .expect("must load");
-        assert!(schedule.mainnet.is_none());
-        assert!(schedule.testnet.is_some());
-        assert!(registry.lookup(66).is_some());
+        .expect_err("must reject");
+        assert_eq!(
+            err,
+            "production_rotation_schedule: networks.testnet: rotation_descriptor: rotation: new suite 0x42 not registered"
+        );
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/production_rotation_schedule.rs
+++ b/clients/rust/crates/rubin-node/src/production_rotation_schedule.rs
@@ -1,5 +1,6 @@
 use rubin_consensus::constants::{
-    ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES, SUITE_ID_ML_DSA_87, VERIFY_COST_ML_DSA_87,
+    ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES, SUITE_ID_ML_DSA_87, SUITE_ID_SENTINEL,
+    VERIFY_COST_ML_DSA_87,
 };
 use rubin_consensus::{
     validate_rotation_descriptor_for_normalized_network, CryptoRotationDescriptor, SuiteParams,
@@ -69,7 +70,18 @@ fn parse_descriptor_slot_wire(
     }
     let descriptor_wire: ProductionRotationDescriptorWire = serde_json::from_value(value)
         .map_err(|err| production_rotation_schedule_error(format!("networks.{network}: {err}")))?;
+    reject_reserved_suite_id("old_suite_id", descriptor_wire.old_suite_id)
+        .map_err(|err| production_rotation_schedule_error(format!("networks.{network}: {err}")))?;
+    reject_reserved_suite_id("new_suite_id", descriptor_wire.new_suite_id)
+        .map_err(|err| production_rotation_schedule_error(format!("networks.{network}: {err}")))?;
     Ok(Some(descriptor_wire))
+}
+
+fn reject_reserved_suite_id(field: &str, suite_id: u8) -> Result<(), String> {
+    if suite_id == SUITE_ID_SENTINEL {
+        return Err(format!("{field} 0x{suite_id:02x} reserved"));
+    }
+    Ok(())
 }
 
 fn canonical_production_schedule_suite_params(suite_id: u8) -> SuiteParams {
@@ -317,6 +329,47 @@ mod tests {
             err,
             "production_rotation_schedule: networks.testnet missing"
         );
+    }
+
+    #[test]
+    fn production_rotation_schedule_rejects_reserved_sentinel_suite_id() {
+        for (field_name, old_suite_id, new_suite_id, want) in [
+            (
+                "old_suite_id",
+                0,
+                66,
+                "production_rotation_schedule: networks.mainnet: old_suite_id 0x00 reserved",
+            ),
+            (
+                "new_suite_id",
+                1,
+                0,
+                "production_rotation_schedule: networks.mainnet: new_suite_id 0x00 reserved",
+            ),
+        ] {
+            let err = production_rotation_descriptor_for_network_with_registry_for_test(
+                &format!(
+                    r#"{{
+                        "version": 1,
+                        "networks": {{
+                            "mainnet": {{
+                                "name": "rotation-v1",
+                                "old_suite_id": {old_suite_id},
+                                "new_suite_id": {new_suite_id},
+                                "create_height": 10,
+                                "spend_height": 20,
+                                "sunset_height": 30
+                            }},
+                            "testnet": null
+                        }}
+                    }}"#
+                ),
+                "mainnet",
+                canonical_production_schedule_registry(),
+            )
+            .expect_err("must reject");
+            assert_eq!(err, want, "field {field_name}");
+        }
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/production_rotation_schedule.rs
+++ b/clients/rust/crates/rubin-node/src/production_rotation_schedule.rs
@@ -501,30 +501,35 @@ mod tests {
     }
 
     #[test]
-    fn production_rotation_schedule_rejects_null_sunset_height_on_production_profile() {
-        let err = production_rotation_descriptor_for_network_with_registry_for_test(
-            r#"{
+    fn production_rotation_schedule_rejects_non_finite_sunset_height_on_production_profile() {
+        for (name, sunset_field) in [("null", r#","sunset_height": null"#), ("missing", "")] {
+            let err = production_rotation_descriptor_for_network_with_registry_for_test(
+                &format!(
+                    r#"{{
                 "version": 1,
-                "networks": {
-                    "mainnet": {
+                "networks": {{
+                    "mainnet": {{
                         "name": "rotation-v1",
                         "old_suite_id": 1,
                         "new_suite_id": 66,
                         "create_height": 10,
-                        "spend_height": 20,
-                        "sunset_height": null
-                    },
+                        "spend_height": 20{}
+                    }},
                     "testnet": null
-                }
-            }"#,
-            "mainnet",
-            canonical_production_schedule_registry(),
-        )
-        .expect_err("must reject");
-        assert_eq!(
-            err,
-            "production_rotation_schedule: networks.mainnet: rotation_descriptor: rotation: v1 production profile requires finite sunset_height (H4)"
-        );
+                }}
+            }}"#,
+                    sunset_field
+                ),
+                "mainnet",
+                canonical_production_schedule_registry(),
+            )
+            .expect_err("must reject");
+            assert_eq!(
+                err,
+                "production_rotation_schedule: networks.mainnet: rotation_descriptor: rotation: v1 production profile requires finite sunset_height (H4)",
+                "{name}"
+            );
+        }
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/production_rotation_schedule.rs
+++ b/clients/rust/crates/rubin-node/src/production_rotation_schedule.rs
@@ -1,0 +1,355 @@
+use rubin_consensus::{
+    validate_rotation_descriptor_for_normalized_network, CryptoRotationDescriptor, SuiteRegistry,
+};
+use serde::Deserialize;
+use serde_json::Value;
+use std::collections::BTreeMap;
+
+pub(crate) const PRODUCTION_ROTATION_SCHEDULE_VERSION: u64 = 1;
+pub(crate) const PRODUCTION_ROTATION_SCHEDULE_ERR_STEM: &str = "production_rotation_schedule";
+
+const PRODUCTION_ROTATION_SCHEDULE_V1_JSON: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../../../conformance/fixtures/protocol/production_rotation_schedule_v1.json"
+));
+
+#[derive(Debug)]
+pub(crate) struct ProductionRotationSchedule {
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) version: u64,
+    pub(crate) mainnet: Option<CryptoRotationDescriptor>,
+    pub(crate) testnet: Option<CryptoRotationDescriptor>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ProductionRotationScheduleWire {
+    version: u64,
+    networks: BTreeMap<String, Value>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ProductionRotationDescriptorWire {
+    name: String,
+    old_suite_id: u8,
+    new_suite_id: u8,
+    create_height: u64,
+    spend_height: u64,
+    #[serde(default)]
+    sunset_height: u64,
+}
+
+fn production_rotation_schedule_error(message: impl Into<String>) -> String {
+    format!(
+        "{PRODUCTION_ROTATION_SCHEDULE_ERR_STEM}: {}",
+        message.into()
+    )
+}
+
+fn parse_descriptor_slot(
+    value: Value,
+    network: &str,
+    registry: &SuiteRegistry,
+) -> Result<Option<CryptoRotationDescriptor>, String> {
+    if value.is_null() {
+        return Ok(None);
+    }
+    let descriptor_wire: ProductionRotationDescriptorWire = serde_json::from_value(value)
+        .map_err(|err| production_rotation_schedule_error(format!("networks.{network}: {err}")))?;
+    let descriptor = CryptoRotationDescriptor {
+        name: descriptor_wire.name,
+        old_suite_id: descriptor_wire.old_suite_id,
+        new_suite_id: descriptor_wire.new_suite_id,
+        create_height: descriptor_wire.create_height,
+        spend_height: descriptor_wire.spend_height,
+        sunset_height: descriptor_wire.sunset_height,
+    };
+    validate_rotation_descriptor_for_normalized_network(network, &descriptor, registry).map_err(
+        |err| {
+            production_rotation_schedule_error(format!(
+                "networks.{network}: rotation_descriptor: {err}"
+            ))
+        },
+    )?;
+    Ok(Some(descriptor))
+}
+
+fn parse_schedule_with_registry(
+    raw: &str,
+    registry: SuiteRegistry,
+) -> Result<(ProductionRotationSchedule, SuiteRegistry), String> {
+    let wire: ProductionRotationScheduleWire = serde_json::from_str(raw).map_err(|err| {
+        production_rotation_schedule_error(format!("parse embedded artifact: {err}"))
+    })?;
+    if wire.version != PRODUCTION_ROTATION_SCHEDULE_VERSION {
+        return Err(production_rotation_schedule_error(format!(
+            "unsupported version {} (want {})",
+            wire.version, PRODUCTION_ROTATION_SCHEDULE_VERSION
+        )));
+    }
+    let mut networks = wire.networks;
+    for key in networks.keys() {
+        if key != "mainnet" && key != "testnet" {
+            return Err(production_rotation_schedule_error(format!(
+                "unknown networks.{key} entry"
+            )));
+        }
+    }
+    let mainnet = parse_descriptor_slot(
+        networks
+            .remove("mainnet")
+            .ok_or_else(|| production_rotation_schedule_error("networks.mainnet missing"))?,
+        "mainnet",
+        &registry,
+    )?;
+    let testnet = parse_descriptor_slot(
+        networks
+            .remove("testnet")
+            .ok_or_else(|| production_rotation_schedule_error("networks.testnet missing"))?,
+        "testnet",
+        &registry,
+    )?;
+    Ok((
+        ProductionRotationSchedule {
+            version: wire.version,
+            mainnet,
+            testnet,
+        },
+        registry,
+    ))
+}
+
+pub(crate) fn load_compiled_production_rotation_schedule(
+) -> Result<(ProductionRotationSchedule, SuiteRegistry), String> {
+    parse_schedule_with_registry(
+        PRODUCTION_ROTATION_SCHEDULE_V1_JSON,
+        SuiteRegistry::default_registry(),
+    )
+}
+
+pub(crate) fn production_rotation_descriptor_for_network(
+    network: &str,
+) -> Result<Option<(CryptoRotationDescriptor, SuiteRegistry)>, String> {
+    let (schedule, registry) = load_compiled_production_rotation_schedule()?;
+    let descriptor = match network {
+        "mainnet" => schedule.mainnet,
+        "testnet" => schedule.testnet,
+        _ => {
+            return Err(production_rotation_schedule_error(format!(
+                "network '{network}' is not a production schedule caller"
+            )))
+        }
+    };
+    Ok(descriptor.map(|descriptor| (descriptor, registry)))
+}
+
+#[cfg(test)]
+pub(crate) fn production_rotation_descriptor_for_network_with_registry_for_test(
+    raw: &str,
+    network: &str,
+    registry: SuiteRegistry,
+) -> Result<Option<(CryptoRotationDescriptor, SuiteRegistry)>, String> {
+    let (schedule, registry) = parse_schedule_with_registry(raw, registry)?;
+    let descriptor = match network {
+        "mainnet" => schedule.mainnet,
+        "testnet" => schedule.testnet,
+        _ => {
+            return Err(production_rotation_schedule_error(format!(
+                "network '{network}' is not a production schedule caller"
+            )))
+        }
+    };
+    Ok(descriptor.map(|descriptor| (descriptor, registry)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        load_compiled_production_rotation_schedule, production_rotation_descriptor_for_network,
+        production_rotation_descriptor_for_network_with_registry_for_test,
+        PRODUCTION_ROTATION_SCHEDULE_ERR_STEM, PRODUCTION_ROTATION_SCHEDULE_VERSION,
+    };
+    use rubin_consensus::constants::{
+        ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES, SUITE_ID_ML_DSA_87, VERIFY_COST_ML_DSA_87,
+    };
+    use rubin_consensus::{SuiteParams, SuiteRegistry};
+    use std::collections::BTreeMap;
+
+    fn canonical_production_schedule_registry() -> SuiteRegistry {
+        let mut suites = BTreeMap::new();
+        suites.insert(
+            SUITE_ID_ML_DSA_87,
+            SuiteParams {
+                suite_id: SUITE_ID_ML_DSA_87,
+                pubkey_len: ML_DSA_87_PUBKEY_BYTES,
+                sig_len: ML_DSA_87_SIG_BYTES,
+                verify_cost: VERIFY_COST_ML_DSA_87,
+                alg_name: "ML-DSA-87",
+            },
+        );
+        suites.insert(
+            66,
+            SuiteParams {
+                suite_id: 66,
+                pubkey_len: ML_DSA_87_PUBKEY_BYTES,
+                sig_len: ML_DSA_87_SIG_BYTES,
+                verify_cost: VERIFY_COST_ML_DSA_87,
+                alg_name: "ML-DSA-87",
+            },
+        );
+        SuiteRegistry::with_suites(suites)
+    }
+
+    #[test]
+    fn load_compiled_production_rotation_schedule_accepts_explicit_empty_schedule() {
+        let (schedule, registry) =
+            load_compiled_production_rotation_schedule().expect("load compiled schedule");
+        assert_eq!(schedule.version, PRODUCTION_ROTATION_SCHEDULE_VERSION);
+        assert!(schedule.mainnet.is_none());
+        assert!(schedule.testnet.is_none());
+        assert!(registry.is_canonical_default_live_manifest());
+    }
+
+    #[test]
+    fn production_rotation_descriptor_for_network_returns_none_for_explicit_empty_schedule() {
+        assert!(production_rotation_descriptor_for_network("mainnet")
+            .expect("mainnet schedule")
+            .is_none());
+        assert!(production_rotation_descriptor_for_network("testnet")
+            .expect("testnet schedule")
+            .is_none());
+    }
+
+    #[test]
+    fn production_rotation_schedule_rejects_unsupported_version() {
+        let err = production_rotation_descriptor_for_network_with_registry_for_test(
+            r#"{
+                "version": 2,
+                "networks": {"mainnet": null, "testnet": null}
+            }"#,
+            "mainnet",
+            SuiteRegistry::default_registry(),
+        )
+        .expect_err("must reject");
+        assert_eq!(
+            err,
+            "production_rotation_schedule: unsupported version 2 (want 1)"
+        );
+    }
+
+    #[test]
+    fn production_rotation_schedule_rejects_missing_network_key() {
+        let err = production_rotation_descriptor_for_network_with_registry_for_test(
+            r#"{
+                "version": 1,
+                "networks": {"mainnet": null}
+            }"#,
+            "mainnet",
+            SuiteRegistry::default_registry(),
+        )
+        .expect_err("must reject");
+        assert_eq!(
+            err,
+            "production_rotation_schedule: networks.testnet missing"
+        );
+    }
+
+    #[test]
+    fn production_rotation_schedule_rejects_unknown_network_key() {
+        let err = production_rotation_descriptor_for_network_with_registry_for_test(
+            r#"{
+                "version": 1,
+                "networks": {"mainnet": null, "devnet": null}
+            }"#,
+            "mainnet",
+            SuiteRegistry::default_registry(),
+        )
+        .expect_err("must reject");
+        assert_eq!(
+            err,
+            "production_rotation_schedule: unknown networks.devnet entry"
+        );
+    }
+
+    #[test]
+    fn production_rotation_schedule_rejects_malformed_descriptor_shape() {
+        let err = production_rotation_descriptor_for_network_with_registry_for_test(
+            r#"{
+                "version": 1,
+                "networks": {"mainnet": [], "testnet": null}
+            }"#,
+            "mainnet",
+            SuiteRegistry::default_registry(),
+        )
+        .expect_err("must reject");
+        assert!(err.contains("networks.mainnet"), "unexpected error: {err}");
+        assert!(err.contains(PRODUCTION_ROTATION_SCHEDULE_ERR_STEM));
+    }
+
+    #[test]
+    fn production_rotation_schedule_parses_single_descriptor_with_canonical_registry() {
+        let loaded = production_rotation_descriptor_for_network_with_registry_for_test(
+            r#"{
+                "version": 1,
+                "networks": {
+                    "mainnet": {
+                        "name": "rotation-v1",
+                        "old_suite_id": 1,
+                        "new_suite_id": 66,
+                        "create_height": 10,
+                        "spend_height": 20,
+                        "sunset_height": 30
+                    },
+                    "testnet": null
+                }
+            }"#,
+            "mainnet",
+            canonical_production_schedule_registry(),
+        )
+        .expect("must load")
+        .expect("descriptor");
+        let (descriptor, registry) = loaded;
+        assert_eq!(descriptor.old_suite_id, 1);
+        assert_eq!(descriptor.new_suite_id, 66);
+        assert!(registry.lookup(66).is_some());
+    }
+
+    #[test]
+    fn production_rotation_schedule_rejects_trailing_json_tokens() {
+        let err = production_rotation_descriptor_for_network_with_registry_for_test(
+            r#"{
+                "version": 1,
+                "networks": {"mainnet": null, "testnet": null}
+            } true"#,
+            "mainnet",
+            SuiteRegistry::default_registry(),
+        )
+        .expect_err("must reject");
+        assert!(
+            err.contains("parse embedded artifact"),
+            "unexpected error: {err}"
+        );
+        assert!(
+            err.contains("trailing characters"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn production_rotation_descriptor_for_network_rejects_non_production_caller() {
+        let err = production_rotation_descriptor_for_network_with_registry_for_test(
+            r#"{
+                "version": 1,
+                "networks": {"mainnet": null, "testnet": null}
+            }"#,
+            "devnet",
+            SuiteRegistry::default_registry(),
+        )
+        .expect_err("must reject");
+        assert_eq!(
+            err,
+            "production_rotation_schedule: network 'devnet' is not a production schedule caller"
+        );
+    }
+}

--- a/clients/rust/crates/rubin-node/src/production_rotation_schedule.rs
+++ b/clients/rust/crates/rubin-node/src/production_rotation_schedule.rs
@@ -1,5 +1,9 @@
+use rubin_consensus::constants::{
+    ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES, SUITE_ID_ML_DSA_87, VERIFY_COST_ML_DSA_87,
+};
 use rubin_consensus::{
-    validate_rotation_descriptor_for_normalized_network, CryptoRotationDescriptor, SuiteRegistry,
+    validate_rotation_descriptor_for_normalized_network, CryptoRotationDescriptor, SuiteParams,
+    SuiteRegistry,
 };
 use serde::de::{DeserializeOwned, IgnoredAny};
 use serde::Deserialize;
@@ -58,24 +62,59 @@ fn decode_single_json_value<T: DeserializeOwned>(raw: &str) -> Result<T, String>
     }
 }
 
-fn parse_descriptor_slot(
+fn parse_descriptor_slot_wire(
     value: Value,
     network: &str,
-    registry: &SuiteRegistry,
-) -> Result<Option<CryptoRotationDescriptor>, String> {
+) -> Result<Option<ProductionRotationDescriptorWire>, String> {
     if value.is_null() {
         return Ok(None);
     }
     let descriptor_wire: ProductionRotationDescriptorWire = serde_json::from_value(value)
         .map_err(|err| production_rotation_schedule_error(format!("networks.{network}: {err}")))?;
-    let descriptor = CryptoRotationDescriptor {
-        name: descriptor_wire.name,
-        old_suite_id: descriptor_wire.old_suite_id,
-        new_suite_id: descriptor_wire.new_suite_id,
-        create_height: descriptor_wire.create_height,
-        spend_height: descriptor_wire.spend_height,
-        sunset_height: descriptor_wire.sunset_height,
+    Ok(Some(descriptor_wire))
+}
+
+fn canonical_production_schedule_suite_params(suite_id: u8) -> SuiteParams {
+    SuiteParams {
+        suite_id,
+        pubkey_len: ML_DSA_87_PUBKEY_BYTES,
+        sig_len: ML_DSA_87_SIG_BYTES,
+        verify_cost: VERIFY_COST_ML_DSA_87,
+        alg_name: "ML-DSA-87",
+    }
+}
+
+fn derived_production_schedule_registry(
+    mainnet: &Option<ProductionRotationDescriptorWire>,
+    testnet: &Option<ProductionRotationDescriptorWire>,
+) -> SuiteRegistry {
+    let mut suites = BTreeMap::new();
+    suites.insert(
+        SUITE_ID_ML_DSA_87,
+        canonical_production_schedule_suite_params(SUITE_ID_ML_DSA_87),
+    );
+    for descriptor in [mainnet.as_ref(), testnet.as_ref()].into_iter().flatten() {
+        suites.insert(
+            descriptor.old_suite_id,
+            canonical_production_schedule_suite_params(descriptor.old_suite_id),
+        );
+        suites.insert(
+            descriptor.new_suite_id,
+            canonical_production_schedule_suite_params(descriptor.new_suite_id),
+        );
+    }
+    SuiteRegistry::with_suites(suites)
+}
+
+fn validate_descriptor_wire(
+    descriptor_wire: Option<ProductionRotationDescriptorWire>,
+    network: &str,
+    registry: &SuiteRegistry,
+) -> Result<Option<CryptoRotationDescriptor>, String> {
+    let Some(descriptor_wire) = descriptor_wire else {
+        return Ok(None);
     };
+    let descriptor = descriptor_wire.into_descriptor();
     validate_rotation_descriptor_for_normalized_network(network, &descriptor, registry).map_err(
         |err| {
             production_rotation_schedule_error(format!(
@@ -88,7 +127,7 @@ fn parse_descriptor_slot(
 
 fn parse_schedule_with_registry(
     raw: &str,
-    registry: SuiteRegistry,
+    registry: Option<SuiteRegistry>,
 ) -> Result<(ProductionRotationSchedule, SuiteRegistry), String> {
     let wire: ProductionRotationScheduleWire = decode_single_json_value(raw).map_err(|err| {
         production_rotation_schedule_error(format!("parse embedded artifact: {err}"))
@@ -107,20 +146,22 @@ fn parse_schedule_with_registry(
             )));
         }
     }
-    let mainnet = parse_descriptor_slot(
+    let mainnet_wire = parse_descriptor_slot_wire(
         networks
             .remove("mainnet")
             .ok_or_else(|| production_rotation_schedule_error("networks.mainnet missing"))?,
         "mainnet",
-        &registry,
     )?;
-    let testnet = parse_descriptor_slot(
+    let testnet_wire = parse_descriptor_slot_wire(
         networks
             .remove("testnet")
             .ok_or_else(|| production_rotation_schedule_error("networks.testnet missing"))?,
         "testnet",
-        &registry,
     )?;
+    let registry = registry
+        .unwrap_or_else(|| derived_production_schedule_registry(&mainnet_wire, &testnet_wire));
+    let mainnet = validate_descriptor_wire(mainnet_wire, "mainnet", &registry)?;
+    let testnet = validate_descriptor_wire(testnet_wire, "testnet", &registry)?;
     Ok((
         ProductionRotationSchedule {
             version: wire.version,
@@ -133,10 +174,7 @@ fn parse_schedule_with_registry(
 
 pub(crate) fn load_compiled_production_rotation_schedule(
 ) -> Result<(ProductionRotationSchedule, SuiteRegistry), String> {
-    parse_schedule_with_registry(
-        PRODUCTION_ROTATION_SCHEDULE_V1_JSON,
-        SuiteRegistry::default_registry(),
-    )
+    parse_schedule_with_registry(PRODUCTION_ROTATION_SCHEDULE_V1_JSON, None)
 }
 
 pub(crate) fn production_rotation_descriptor_for_network(
@@ -161,7 +199,7 @@ pub(crate) fn production_rotation_descriptor_for_network_with_registry_for_test(
     network: &str,
     registry: SuiteRegistry,
 ) -> Result<Option<(CryptoRotationDescriptor, SuiteRegistry)>, String> {
-    let (schedule, registry) = parse_schedule_with_registry(raw, registry)?;
+    let (schedule, registry) = parse_schedule_with_registry(raw, Some(registry))?;
     let descriptor = match network {
         "mainnet" => schedule.mainnet,
         "testnet" => schedule.testnet,
@@ -174,10 +212,24 @@ pub(crate) fn production_rotation_descriptor_for_network_with_registry_for_test(
     Ok(descriptor.map(|descriptor| (descriptor, registry)))
 }
 
+impl ProductionRotationDescriptorWire {
+    fn into_descriptor(self) -> CryptoRotationDescriptor {
+        CryptoRotationDescriptor {
+            name: self.name,
+            old_suite_id: self.old_suite_id,
+            new_suite_id: self.new_suite_id,
+            create_height: self.create_height,
+            spend_height: self.spend_height,
+            sunset_height: self.sunset_height,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        load_compiled_production_rotation_schedule, production_rotation_descriptor_for_network,
+        load_compiled_production_rotation_schedule, parse_schedule_with_registry,
+        production_rotation_descriptor_for_network,
         production_rotation_descriptor_for_network_with_registry_for_test,
         PRODUCTION_ROTATION_SCHEDULE_ERR_STEM, PRODUCTION_ROTATION_SCHEDULE_VERSION,
     };
@@ -324,6 +376,35 @@ mod tests {
         assert_eq!(descriptor.old_suite_id, 1);
         assert_eq!(descriptor.new_suite_id, 66);
         assert!(registry.lookup(66).is_some());
+    }
+
+    #[test]
+    fn production_rotation_schedule_derives_scheduled_suites_when_registry_is_implicit() {
+        let (schedule, registry) = parse_schedule_with_registry(
+            r#"{
+                "version": 1,
+                "networks": {
+                    "mainnet": {
+                        "name": "rotation-v1",
+                        "old_suite_id": 1,
+                        "new_suite_id": 66,
+                        "create_height": 10,
+                        "spend_height": 20,
+                        "sunset_height": 30
+                    },
+                    "testnet": null
+                }
+            }"#,
+            None,
+        )
+        .expect("must load");
+        let descriptor = schedule.mainnet.expect("mainnet descriptor");
+        assert_eq!(descriptor.new_suite_id, 66);
+        let params = registry.lookup(66).expect("suite 66");
+        assert_eq!(params.pubkey_len, ML_DSA_87_PUBKEY_BYTES);
+        assert_eq!(params.sig_len, ML_DSA_87_SIG_BYTES);
+        assert_eq!(params.verify_cost, VERIFY_COST_ML_DSA_87);
+        assert_eq!(params.alg_name, "ML-DSA-87");
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/production_rotation_schedule.rs
+++ b/clients/rust/crates/rubin-node/src/production_rotation_schedule.rs
@@ -41,8 +41,7 @@ struct ProductionRotationDescriptorWire {
     new_suite_id: u8,
     create_height: u64,
     spend_height: u64,
-    #[serde(default)]
-    sunset_height: u64,
+    sunset_height: Option<u64>,
 }
 
 fn production_rotation_schedule_error(message: impl Into<String>) -> String {
@@ -190,6 +189,9 @@ pub(crate) fn production_rotation_descriptor_for_network(
             )))
         }
     };
+    // A null slot means this network has no authoritative production activation state.
+    // The compiled registry is derived across schedule entries, so returning it here
+    // would leak foreign-network suites into an empty-slot caller.
     Ok(descriptor.map(|descriptor| (descriptor, registry)))
 }
 
@@ -220,7 +222,7 @@ impl ProductionRotationDescriptorWire {
             new_suite_id: self.new_suite_id,
             create_height: self.create_height,
             spend_height: self.spend_height,
-            sunset_height: self.sunset_height,
+            sunset_height: self.sunset_height.unwrap_or_default(),
         }
     }
 }
@@ -405,6 +407,58 @@ mod tests {
         assert_eq!(params.sig_len, ML_DSA_87_SIG_BYTES);
         assert_eq!(params.verify_cost, VERIFY_COST_ML_DSA_87);
         assert_eq!(params.alg_name, "ML-DSA-87");
+    }
+
+    #[test]
+    fn production_rotation_schedule_empty_slot_does_not_erase_foreign_slot_suites() {
+        let (schedule, registry) = parse_schedule_with_registry(
+            r#"{
+                "version": 1,
+                "networks": {
+                    "mainnet": null,
+                    "testnet": {
+                        "name": "rotation-v1",
+                        "old_suite_id": 1,
+                        "new_suite_id": 66,
+                        "create_height": 10,
+                        "spend_height": 20,
+                        "sunset_height": 30
+                    }
+                }
+            }"#,
+            None,
+        )
+        .expect("must load");
+        assert!(schedule.mainnet.is_none());
+        assert!(schedule.testnet.is_some());
+        assert!(registry.lookup(66).is_some());
+    }
+
+    #[test]
+    fn production_rotation_schedule_rejects_null_sunset_height_on_production_profile() {
+        let err = production_rotation_descriptor_for_network_with_registry_for_test(
+            r#"{
+                "version": 1,
+                "networks": {
+                    "mainnet": {
+                        "name": "rotation-v1",
+                        "old_suite_id": 1,
+                        "new_suite_id": 66,
+                        "create_height": 10,
+                        "spend_height": 20,
+                        "sunset_height": null
+                    },
+                    "testnet": null
+                }
+            }"#,
+            "mainnet",
+            canonical_production_schedule_registry(),
+        )
+        .expect_err("must reject");
+        assert_eq!(
+            err,
+            "production_rotation_schedule: networks.mainnet: rotation_descriptor: rotation: v1 production profile requires finite sunset_height (H4)"
+        );
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/production_rotation_schedule.rs
+++ b/clients/rust/crates/rubin-node/src/production_rotation_schedule.rs
@@ -14,6 +14,8 @@ use std::collections::BTreeMap;
 pub(crate) const PRODUCTION_ROTATION_SCHEDULE_VERSION: u64 = 1;
 pub(crate) const PRODUCTION_ROTATION_SCHEDULE_ERR_STEM: &str = "production_rotation_schedule";
 
+// Rust embeds the canonical protocol fixture directly; there is no client-local
+// copy of the production schedule artifact to keep in sync.
 const PRODUCTION_ROTATION_SCHEDULE_V1_JSON: &str = include_str!(concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/../../../../conformance/fixtures/protocol/production_rotation_schedule_v1.json"
@@ -252,13 +254,31 @@ mod tests {
         load_compiled_production_rotation_schedule, parse_schedule_with_registry,
         production_rotation_descriptor_for_network,
         production_rotation_descriptor_for_network_with_registry_for_test,
-        PRODUCTION_ROTATION_SCHEDULE_ERR_STEM, PRODUCTION_ROTATION_SCHEDULE_VERSION,
+        PRODUCTION_ROTATION_SCHEDULE_ERR_STEM, PRODUCTION_ROTATION_SCHEDULE_V1_JSON,
+        PRODUCTION_ROTATION_SCHEDULE_VERSION,
     };
     use rubin_consensus::constants::{
         ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES, SUITE_ID_ML_DSA_87, VERIFY_COST_ML_DSA_87,
     };
     use rubin_consensus::{SuiteParams, SuiteRegistry};
+    use serde_json::Value;
     use std::collections::BTreeMap;
+    use std::fs;
+    use std::path::PathBuf;
+
+    fn production_rotation_schedule_repo_path(parts: &[&str]) -> PathBuf {
+        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        path.push("../../../../");
+        for part in parts {
+            path.push(part);
+        }
+        path
+    }
+
+    fn compact_json_bytes(raw: &str) -> Vec<u8> {
+        serde_json::to_vec(&serde_json::from_str::<Value>(raw).expect("compact json"))
+            .expect("serialize compact json")
+    }
 
     fn canonical_production_schedule_registry() -> SuiteRegistry {
         let mut suites = BTreeMap::new();
@@ -293,6 +313,22 @@ mod tests {
         assert!(schedule.mainnet.is_none());
         assert!(schedule.testnet.is_none());
         assert!(registry.is_canonical_default_live_manifest());
+    }
+
+    #[test]
+    fn embedded_production_rotation_schedule_matches_canonical_fixture() {
+        let path = production_rotation_schedule_repo_path(&[
+            "conformance",
+            "fixtures",
+            "protocol",
+            "production_rotation_schedule_v1.json",
+        ]);
+        let raw = fs::read_to_string(&path).expect("read canonical production schedule fixture");
+        assert_eq!(
+            compact_json_bytes(&raw),
+            compact_json_bytes(PRODUCTION_ROTATION_SCHEDULE_V1_JSON),
+            "embedded production schedule drifted from canonical fixture"
+        );
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/production_rotation_schedule.rs
+++ b/clients/rust/crates/rubin-node/src/production_rotation_schedule.rs
@@ -1,6 +1,7 @@
 use rubin_consensus::{
     validate_rotation_descriptor_for_normalized_network, CryptoRotationDescriptor, SuiteRegistry,
 };
+use serde::de::{DeserializeOwned, IgnoredAny};
 use serde::Deserialize;
 use serde_json::Value;
 use std::collections::BTreeMap;
@@ -47,6 +48,16 @@ fn production_rotation_schedule_error(message: impl Into<String>) -> String {
     )
 }
 
+fn decode_single_json_value<T: DeserializeOwned>(raw: &str) -> Result<T, String> {
+    let mut deserializer = serde_json::Deserializer::from_str(raw);
+    let value = T::deserialize(&mut deserializer).map_err(|err| err.to_string())?;
+    match IgnoredAny::deserialize(&mut deserializer) {
+        Ok(_) => Err("trailing JSON tokens".to_owned()),
+        Err(err) if err.classify() == serde_json::error::Category::Eof => Ok(value),
+        Err(err) => Err(err.to_string()),
+    }
+}
+
 fn parse_descriptor_slot(
     value: Value,
     network: &str,
@@ -79,7 +90,7 @@ fn parse_schedule_with_registry(
     raw: &str,
     registry: SuiteRegistry,
 ) -> Result<(ProductionRotationSchedule, SuiteRegistry), String> {
-    let wire: ProductionRotationScheduleWire = serde_json::from_str(raw).map_err(|err| {
+    let wire: ProductionRotationScheduleWire = decode_single_json_value(raw).map_err(|err| {
         production_rotation_schedule_error(format!("parse embedded artifact: {err}"))
     })?;
     if wire.version != PRODUCTION_ROTATION_SCHEDULE_VERSION {
@@ -326,13 +337,26 @@ mod tests {
             SuiteRegistry::default_registry(),
         )
         .expect_err("must reject");
-        assert!(
-            err.contains("parse embedded artifact"),
-            "unexpected error: {err}"
+        assert_eq!(
+            err,
+            "production_rotation_schedule: parse embedded artifact: trailing JSON tokens"
         );
-        assert!(
-            err.contains("trailing characters"),
-            "unexpected error: {err}"
+    }
+
+    #[test]
+    fn production_rotation_schedule_rejects_second_json_value() {
+        let err = production_rotation_descriptor_for_network_with_registry_for_test(
+            r#"{
+                "version": 1,
+                "networks": {"mainnet": null, "testnet": null}
+            } {"version":1,"networks":{"mainnet":null,"testnet":null}}"#,
+            "mainnet",
+            SuiteRegistry::default_registry(),
+        )
+        .expect_err("must reject");
+        assert_eq!(
+            err,
+            "production_rotation_schedule: parse embedded artifact: trailing JSON tokens"
         );
     }
 

--- a/clients/rust/crates/rubin-node/src/production_rotation_schedule_v1_embedded.json
+++ b/clients/rust/crates/rubin-node/src/production_rotation_schedule_v1_embedded.json
@@ -1,0 +1,7 @@
+{
+  "version": 1,
+  "networks": {
+    "mainnet": null,
+    "testnet": null
+  }
+}

--- a/conformance/fixtures/CHANGELOG.md
+++ b/conformance/fixtures/CHANGELOG.md
@@ -9,6 +9,21 @@ Policy:
 
 ---
 
+## 2026-04-10 — Production activation schedule fixture (Q-IMPL-ROTATION-PRODUCTION-ACTIVATION-SCHEDULE-01)
+
+Причина:
+- production node startup больше не должен выводить activation state из local `suite_registry` bootstrap;
+- нужен один compiled authoritative per-network schedule artifact с явным empty-schedule поведением для `mainnet/testnet`;
+- локальный `rotation_descriptor` остаётся non-production only, а production activation authority теперь идёт из общего protocol fixture.
+
+Инструменты:
+- новый protocol fixture `conformance/fixtures/protocol/production_rotation_schedule_v1.json`,
+- Go/Rust node loader tests,
+- проверка через `go test ./node ./cmd/rubin-node` и `cargo test -p rubin-node`.
+
+Изменённые fixtures:
+- `protocol/production_rotation_schedule_v1.json` (new)
+
 ## 2026-04-10 — Live CORE_EXT manifest binding normalization (Q-IMPL-ROTATION-MANIFEST-ARCHIVAL-RUNTIME-SPLIT-01)
 
 Причина:

--- a/conformance/fixtures/CHANGELOG.md
+++ b/conformance/fixtures/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Conformance Fixtures Changelog
 
-Этот файл фиксирует **осознанные** изменения `conformance/fixtures/CV-*.json`.
+Этот файл фиксирует **осознанные** изменения `conformance/fixtures/CV-*.json`
+и shared protocol artifacts под `conformance/fixtures/protocol/*.json`.
 
 Policy:
 - при любом изменении `CV-*.json` обновление этого файла обязательно;
+- при любом изменении `conformance/fixtures/protocol/*.json` обновление этого файла обязательно;
 - указывать причину, инструмент регенерации и список изменённых fixtures;
 - генератор `clients/go/cmd/gen-conformance-fixtures` используется только вручную (не CI).
 

--- a/conformance/fixtures/protocol/production_rotation_schedule_v1.json
+++ b/conformance/fixtures/protocol/production_rotation_schedule_v1.json
@@ -1,0 +1,7 @@
+{
+  "version": 1,
+  "networks": {
+    "mainnet": null,
+    "testnet": null
+  }
+}

--- a/tools/check_legacy_exposure_report_contract.py
+++ b/tools/check_legacy_exposure_report_contract.py
@@ -14,6 +14,41 @@ SCHEMA = REPO_ROOT / "conformance" / "schemas" / "legacy_exposure_report_v1.json
 EXAMPLE = REPO_ROOT / "conformance" / "fixtures" / "protocol" / "legacy_exposure_report_v1_example.json"
 HOOK_VECTORS = REPO_ROOT / "conformance" / "fixtures" / "protocol" / "legacy_exposure_hook_vectors.json"
 
+CANONICAL_HOOK_CASES: list[tuple[str, bool, int, str, str, str]] = [
+    (
+        "no_chainstate_tip_zero_total",
+        False,
+        0,
+        "invalid_no_chainstate_tip",
+        "none",
+        "not_applicable_no_chainstate_tip",
+    ),
+    (
+        "no_chainstate_tip_nonzero_total",
+        False,
+        5,
+        "invalid_no_chainstate_tip",
+        "none",
+        "not_applicable_no_chainstate_tip",
+    ),
+    (
+        "tipped_chain_zero_exposure",
+        True,
+        0,
+        "ready_for_operator_defined_grace_window",
+        "none",
+        "start_operator_defined_grace_window",
+    ),
+    (
+        "tipped_chain_nonzero_exposure",
+        True,
+        3,
+        "not_ready_legacy_exposure_present",
+        "legacy_exposure_present_notify_operator_and_council",
+        "not_applicable_legacy_exposure_present",
+    ),
+]
+
 
 def _fail(msg: str) -> None:
     print(f"FAIL: {msg}", file=sys.stderr)
@@ -64,6 +99,7 @@ def _validate_hook_vectors_structure(
     if sr_enum is None or wh_enum is None or gh_enum is None:
         errors.append("hook vectors: schema missing enum lists for hook fields")
         return errors
+    normalized_cases: list[tuple[str, bool, int, str, str, str]] = []
     for i, c in enumerate(cases):
         if not isinstance(c, dict):
             errors.append(f"cases[{i}]: expected object")
@@ -96,6 +132,124 @@ def _validate_hook_vectors_structure(
                 errors.append(
                     f"cases[{i}]: {label}={val!r} not in schema enum for {label}"
                 )
+        if all(k in c for k in required):
+            normalized_cases.append(
+                (
+                    c["name"],
+                    c["has_chainstate_tip"],
+                    c["legacy_exposure_total"],
+                    c["sunset_readiness"],
+                    c["warning_hook"],
+                    c["grace_hook"],
+                )
+            )
+    if errors:
+        return errors
+    if normalized_cases != CANONICAL_HOOK_CASES:
+        errors.append(
+            f"hook vectors: cases drifted from frozen canonical truth table: {normalized_cases!r}"
+        )
+    return errors
+
+
+def _legacy_exposure_hooks(has_tip: bool, total: int) -> tuple[str, str, str]:
+    if not has_tip:
+        return (
+            "invalid_no_chainstate_tip",
+            "none",
+            "not_applicable_no_chainstate_tip",
+        )
+    if total == 0:
+        return (
+            "ready_for_operator_defined_grace_window",
+            "none",
+            "start_operator_defined_grace_window",
+        )
+    return (
+        "not_ready_legacy_exposure_present",
+        "legacy_exposure_present_notify_operator_and_council",
+        "not_applicable_legacy_exposure_present",
+    )
+
+
+def _validate_example_semantics(example: object) -> list[str]:
+    if not isinstance(example, dict):
+        return ["example fixture: top-level must be an object"]
+    errors: list[str] = []
+    if example.get("chainstate_has_tip") is not True:
+        errors.append("example fixture: chainstate_has_tip must be true for emitted scanner JSON")
+    watched = example.get("watched_legacy_suite_ids")
+    if not isinstance(watched, list) or not all(isinstance(x, int) for x in watched):
+        return errors + ["example fixture: watched_legacy_suite_ids must be an integer array"]
+    reports = example.get("legacy_suite_reports")
+    if not isinstance(reports, list) or not all(isinstance(x, dict) for x in reports):
+        return errors + ["example fixture: legacy_suite_reports must be an array of objects"]
+    if len(reports) != len(watched):
+        errors.append(
+            "example fixture: legacy_suite_reports must contain exactly one row per watched_legacy_suite_id"
+        )
+    report_suite_ids: list[int] = []
+    total = 0
+    include_outpoints = example.get("include_outpoints")
+    for idx, report in enumerate(reports):
+        suite_id = report.get("suite_id")
+        utxo_exposure_count = report.get("utxo_exposure_count")
+        outpoint_count = report.get("outpoint_count")
+        if not isinstance(suite_id, int):
+            errors.append(f"example fixture: legacy_suite_reports[{idx}].suite_id must be an integer")
+            continue
+        report_suite_ids.append(suite_id)
+        if not isinstance(utxo_exposure_count, int):
+            errors.append(
+                f"example fixture: legacy_suite_reports[{idx}].utxo_exposure_count must be an integer"
+            )
+            continue
+        if not isinstance(outpoint_count, int):
+            errors.append(
+                f"example fixture: legacy_suite_reports[{idx}].outpoint_count must be an integer"
+            )
+            continue
+        if outpoint_count != utxo_exposure_count:
+            errors.append(
+                f"example fixture: legacy_suite_reports[{idx}] outpoint_count must equal utxo_exposure_count"
+            )
+        total += utxo_exposure_count
+        outpoints = report.get("outpoints")
+        if include_outpoints is True:
+            if not isinstance(outpoints, list):
+                errors.append(
+                    f"example fixture: legacy_suite_reports[{idx}].outpoints must be present when include_outpoints=true"
+                )
+            elif len(outpoints) != outpoint_count:
+                errors.append(
+                    f"example fixture: legacy_suite_reports[{idx}] outpoints length must equal outpoint_count"
+                )
+        elif "outpoints" in report:
+            errors.append(
+                f"example fixture: legacy_suite_reports[{idx}].outpoints must be absent when include_outpoints=false"
+            )
+    if report_suite_ids != watched:
+        errors.append(
+            f"example fixture: legacy_suite_reports suite_id order {report_suite_ids!r} must match watched_legacy_suite_ids {watched!r}"
+        )
+    legacy_exposure_total = example.get("legacy_exposure_total")
+    if not isinstance(legacy_exposure_total, int):
+        errors.append("example fixture: legacy_exposure_total must be an integer")
+        return errors
+    if legacy_exposure_total != total:
+        errors.append(
+            f"example fixture: legacy_exposure_total={legacy_exposure_total} must equal summed utxo_exposure_count={total}"
+        )
+    expected_hooks = _legacy_exposure_hooks(True, legacy_exposure_total)
+    for field, expected in (
+        ("sunset_readiness", expected_hooks[0]),
+        ("warning_hook", expected_hooks[1]),
+        ("grace_hook", expected_hooks[2]),
+    ):
+        if example.get(field) != expected:
+            errors.append(
+                f"example fixture: {field}={example.get(field)!r} must equal canonical hook output {expected!r}"
+            )
     return errors
 
 
@@ -141,6 +295,11 @@ def main() -> int:
         for e in schema_errors:
             path = ".".join(str(p) for p in e.absolute_path)
             print(f"FAIL: example JSON at {path}: {e.message}", file=sys.stderr)
+        return 1
+    example_errors = _validate_example_semantics(example)
+    if example_errors:
+        for msg in example_errors:
+            _fail(msg)
         return 1
 
     try:


### PR DESCRIPTION
## Pull request overview

Makes production rotation activation derive only from a compiled per-network schedule artifact, so `mainnet`/`testnet` no longer bootstrap activation state from local `suite_registry` alone.

This PR also carries a small legacy-exposure contract hardening follow-up that landed while tightening the same review wave: the frozen hook-vector truth table is now asserted exactly in Go/Rust tests, and the Python contract checker now enforces the example fixture's cross-field semantics instead of only schema shape.

**Changes:**
- add canonical `production_rotation_schedule_v1.json` with explicit empty schedule entries for `mainnet` and `testnet`
- wire Go and Rust node startup to use the compiled schedule as the only production activation authority
- keep production local `rotation_descriptor` rejected and ignore local `suite_registry` entirely on production
- add matched Go/Rust loader and startup tests for empty schedule, malformed schedule, missing keys, unknown keys, non-finite `sunset_height`, and non-production caller misuse
- harden frozen legacy-exposure contract checks by pinning the exact canonical hook truth table in Go/Rust parity tests and by validating `legacy_exposure_total` / `watched_legacy_suite_ids` / `legacy_suite_reports` consistency in `tools/check_legacy_exposure_report_contract.py`
- update fixture changelog for the new protocol artifact

**Verification:**
- `go test ./node ./cmd/rubin-node`
- `cargo test --manifest-path clients/rust/Cargo.toml -p rubin-node`
- `python3 tools/check_legacy_exposure_report_contract.py`
- `gofmt -w clients/go/node/config.go clients/go/node/production_rotation_schedule_test.go clients/go/cmd/rubin-node/main_test.go`
- `cargo fmt --manifest-path clients/rust/Cargo.toml --all`
- `git diff --check`

Refs: #1114
