### PR TITLE
ci: calibrate DeepSeek security review and expand parity context

### DIFF
--- a/.github/workflows/models-security-review.yml
+++ b/.github/workflows/models-security-review.yml
@@ -394,6 +394,8 @@ jobs:
               ['clients/go/node/p2p/mempool.go', 'clients/rust/crates/rubin-node/src/txpool.rs'],
               ['clients/go/node/p2p/tx_metadata.go', 'clients/rust/crates/rubin-node/src/txpool.rs'],
             ];
+            const parityIntro =
+              '\n\n---\nPARITY CONTEXT (counterpart files from the other client — use to verify cross-client consistency BEFORE reporting divergence):\n\n';
             const parityEntries = [];
             let parityUsed = 0;
             const parityCounterpartsSeen = new Set();
@@ -410,19 +412,20 @@ jobs:
                 if (!content) continue;
                 const header = `PARITY FILE: ${counterpart} (counterpart of changed ${file})\n`;
                 const separatorOverhead = parityEntries.length > 0 ? SEPARATOR.length : 0;
+                const introOverhead = parityEntries.length === 0 ? parityIntro.length : 0;
                 const cap = Math.min(
-                  PARITY_BUDGET - parityUsed - separatorOverhead - header.length,
+                  PARITY_BUDGET - parityUsed - separatorOverhead - introOverhead - header.length,
                   PER_FILE_CAP
                 );
                 if (cap < 200) continue;
                 const entry = header + content.slice(0, cap);
                 parityCounterpartsSeen.add(counterpart);
                 parityEntries.push(entry);
-                parityUsed += separatorOverhead + entry.length;
+                parityUsed += separatorOverhead + introOverhead + entry.length;
               }
             }
             const parityContext = parityEntries.length > 0
-              ? '\n\n---\nPARITY CONTEXT (counterpart files from the other client — use to verify cross-client consistency BEFORE reporting divergence):\n\n' + parityEntries.join(SEPARATOR)
+              ? parityIntro + parityEntries.join(SEPARATOR)
               : '';
 
             const systemPrompt = [
@@ -565,17 +568,20 @@ jobs:
                 let overflow = userContent.length - maxUserCharsBeforeNotice;
                 core.warning(
                   `User message length ${userContent.length} exceeds cap ${MAX_USER_CHARS}; ` +
-                  'truncating lower-priority sections from the tail first, then appending explicit notice'
+                  'truncating supplementary context first (parity, dependency, full files, dedup list), ' +
+                  'then diff only as last resort; then preamble if still over cap; then appending explicit notice'
                 );
 
-                for (const sectionName of ['changedFiles', 'diff', 'parityContext', 'dependencyContext']) {
+                for (const sectionName of [
+                  'parityContext',
+                  'dependencyContext',
+                  'changedFiles',
+                  'previousFindings',
+                  'diff',
+                ]) {
                   if (overflow <= 0) break;
                   const section = sections.find((c) => c.name === sectionName);
                   overflow -= shrinkSectionToFit(section, overflow);
-                }
-                if (overflow > 0) {
-                  const prevSec = sections.find((c) => c.name === 'previousFindings');
-                  overflow -= shrinkSectionToFit(prevSec, overflow);
                 }
                 if (overflow > 0) {
                   const pre = sections.find((c) => c.name === 'preamble');

--- a/.github/workflows/models-security-review.yml
+++ b/.github/workflows/models-security-review.yml
@@ -302,8 +302,8 @@ jobs:
             // counterpart (and vice versa) so the model can verify parity
             // claims with actual evidence instead of hallucinating.
             // Pairs are symmetric: either path may be the "changed" file.
-            // Multiple entries with the same first path intentionally pull
-            // more than one counterpart (mirrors tools/run_local_hostile_review.py).
+            // Multiple entries with the same left-hand path intentionally pull
+            // more than one counterpart when one side maps to several peers.
             const PARITY_BUDGET = 60000;
             const parityMap = [
               // Consensus reference clients
@@ -344,11 +344,10 @@ jobs:
               ['clients/go/consensus/utxo_snapshot.go', 'clients/rust/crates/rubin-consensus/src/utxo_snapshot.rs'],
               ['clients/go/consensus/compactsize.go', 'clients/rust/crates/rubin-consensus/src/compactsize.rs'],
               ['clients/go/consensus/errors.go', 'clients/rust/crates/rubin-consensus/src/error.rs'],
-              // Node: config / genesis / embedded production schedule (rotation)
+              // Node bootstrap vs consensus rotation (real paths; no separate production_rotation_schedule.* in tree)
               ['clients/go/node/config.go', 'clients/rust/crates/rubin-node/src/genesis.rs'],
-              ['clients/go/node/production_rotation_schedule.go', 'clients/rust/crates/rubin-node/src/production_rotation_schedule.rs'],
-              ['clients/go/node/production_rotation_schedule.go', 'clients/rust/crates/rubin-node/src/genesis.rs'],
-              ['clients/rust/crates/rubin-node/src/production_rotation_schedule.rs', 'clients/go/node/config.go'],
+              ['clients/go/node/config.go', 'clients/rust/crates/rubin-consensus/src/suite_registry.rs'],
+              ['clients/rust/crates/rubin-node/src/genesis.rs', 'clients/go/consensus/rotation_production.go'],
               // Node: core state and sync
               ['clients/go/node/chainstate.go', 'clients/rust/crates/rubin-node/src/chainstate.rs'],
               ['clients/go/node/sync.go', 'clients/rust/crates/rubin-node/src/sync.rs'],
@@ -395,6 +394,7 @@ jobs:
             ];
             const parityEntries = [];
             let parityUsed = 0;
+            const parityCounterpartsSeen = new Set();
             for (const file of changedFiles) {
               if (parityUsed >= PARITY_BUDGET) break;
               // Find the parity counterpart (either direction)
@@ -403,12 +403,14 @@ jobs:
                 if (file === goFile && !changedFiles.includes(rsFile)) counterpart = rsFile;
                 else if (file === rsFile && !changedFiles.includes(goFile)) counterpart = goFile;
                 if (!counterpart) continue;
+                if (parityCounterpartsSeen.has(counterpart)) continue;
                 const content = readChangedFile(counterpart);
                 if (!content) continue;
                 const header = `PARITY FILE: ${counterpart} (counterpart of changed ${file})\n`;
                 const cap = Math.min(PARITY_BUDGET - parityUsed - header.length, PER_FILE_CAP);
                 if (cap < 200) continue;
                 const entry = header + content.slice(0, cap);
+                parityCounterpartsSeen.add(counterpart);
                 parityEntries.push(entry);
                 parityUsed += entry.length;
               }

--- a/.github/workflows/models-security-review.yml
+++ b/.github/workflows/models-security-review.yml
@@ -154,6 +154,7 @@ jobs:
               `git diff --diff-filter=ACMR --name-only ${baseSha} ${headSha}`,
               { maxBuffer: 20 * 1024 * 1024 }
             ).toString().split('\n').map(s => s.trim()).filter(isReviewRelevantFile);
+            const changedFilesSet = new Set(changedFiles);
 
             const readChangedFile = (file) => {
               const fullPath = path.resolve(repoRoot, file);
@@ -262,7 +263,7 @@ jobs:
                 if (!modFile) continue;
                 const modRel = path.relative(repoRoot, modFile);
                 // Skip files already in changedFilePayload
-                if (changedFiles.includes(modRel)) continue;
+                if (changedFilesSet.has(modRel)) continue;
 
                 let modContent;
                 try { modContent = fs.readFileSync(modFile, 'utf8'); } catch { continue; }
@@ -309,8 +310,6 @@ jobs:
               // Consensus reference clients
               ['clients/go/consensus/wire_read.go',   'clients/rust/crates/rubin-consensus/src/wire_read.rs'],
               ['clients/go/consensus/tx_helpers.go',   'clients/rust/crates/rubin-consensus/src/tx_helpers.rs'],
-              ['clients/go/consensus/transaction.go',  'clients/rust/crates/rubin-consensus/src/transaction.rs'],
-              ['clients/go/consensus/block.go',        'clients/rust/crates/rubin-consensus/src/block.rs'],
               ['clients/go/consensus/block_parse.go',   'clients/rust/crates/rubin-consensus/src/block.rs'],
               ['clients/go/consensus/constants.go',    'clients/rust/crates/rubin-consensus/src/constants.rs'],
               ['clients/go/consensus/connect_block_inmem.go', 'clients/rust/crates/rubin-consensus/src/connect_block_inmem.rs'],
@@ -400,8 +399,8 @@ jobs:
               // Find the parity counterpart (either direction)
               for (const [goFile, rsFile] of parityMap) {
                 let counterpart = null;
-                if (file === goFile && !changedFiles.includes(rsFile)) counterpart = rsFile;
-                else if (file === rsFile && !changedFiles.includes(goFile)) counterpart = goFile;
+                if (file === goFile && !changedFilesSet.has(rsFile)) counterpart = rsFile;
+                else if (file === rsFile && !changedFilesSet.has(goFile)) counterpart = goFile;
                 if (!counterpart) continue;
                 if (parityCounterpartsSeen.has(counterpart)) continue;
                 const content = readChangedFile(counterpart);
@@ -523,6 +522,22 @@ jobs:
 
             try {
               core.info(`Trying model: ${modelId}`);
+              const userContentPreamble = 'Review this PR diff for security issues. Be strict and skeptical, but follow the system severity definitions — do not inflate node/bootstrap/API differences to CRITICAL or HIGH without a proven consensus path.\n\nDIFF:\n';
+              let userContent = userContentPreamble + diff +
+                (changedFilePayload ? `\n\n---\nFULL CHANGED FILES (use to verify definitions before claiming anything missing):\n${changedFilePayload}` : '') +
+                dependencyContext + parityContext + previousFindings;
+              const MAX_USER_CHARS = 260000;
+              core.info(
+                `security-review payload sizes: diff=${diff.length} changedFiles=${changedFilePayload.length} ` +
+                `dep=${dependencyContext.length} parity=${parityContext.length} prev=${previousFindings.length} user=${userContent.length}`
+              );
+              if (userContent.length > MAX_USER_CHARS) {
+                core.warning(
+                  `User message length ${userContent.length} exceeds cap ${MAX_USER_CHARS}; truncating with explicit notice`
+                );
+                userContent = userContent.slice(0, MAX_USER_CHARS) +
+                  '\n\n[TRUNCATED: user payload exceeded workflow cap; treat tail sections as unreviewed]\n';
+              }
               const response = await fetch(
                 'https://models.github.ai/inference/chat/completions',
                 {
@@ -535,7 +550,7 @@ jobs:
                     model: modelId,
                     messages: [
                       { role: 'system', content: systemPrompt },
-                      { role: 'user', content: `Review this PR diff for security issues. Be strict and skeptical, but follow the system severity definitions — do not inflate node/bootstrap/API differences to CRITICAL or HIGH without a proven consensus path.\n\nDIFF:\n${diff}${changedFilePayload ? `\n\n---\nFULL CHANGED FILES (use to verify definitions before claiming anything missing):\n${changedFilePayload}` : ''}${dependencyContext}${parityContext}${previousFindings}` }
+                      { role: 'user', content: userContent }
                     ],
                     temperature: 0.2,
                     top_p: 0.9

--- a/.github/workflows/models-security-review.yml
+++ b/.github/workflows/models-security-review.yml
@@ -262,7 +262,7 @@ jobs:
                 }
                 if (!modFile) continue;
                 const modRel = path.relative(repoRoot, modFile);
-                // Skip files already in changedFilePayload
+                // Skip module sources that are already part of the PR file list (not the same as "in changedFilePayload", which can omit files due to TOTAL_FILE_BUDGET).
                 if (changedFilesSet.has(modRel)) continue;
 
                 let modContent;
@@ -397,10 +397,10 @@ jobs:
             for (const file of changedFiles) {
               if (parityUsed >= PARITY_BUDGET) break;
               // Find the parity counterpart (either direction)
-              for (const [goFile, rsFile] of parityMap) {
+              for (const [pathA, pathB] of parityMap) {
                 let counterpart = null;
-                if (file === goFile && !changedFilesSet.has(rsFile)) counterpart = rsFile;
-                else if (file === rsFile && !changedFilesSet.has(goFile)) counterpart = goFile;
+                if (file === pathA && !changedFilesSet.has(pathB)) counterpart = pathB;
+                else if (file === pathB && !changedFilesSet.has(pathA)) counterpart = pathA;
                 if (!counterpart) continue;
                 if (parityCounterpartsSeen.has(counterpart)) continue;
                 const content = readChangedFile(counterpart);
@@ -527,16 +527,19 @@ jobs:
                 (changedFilePayload ? `\n\n---\nFULL CHANGED FILES (use to verify definitions before claiming anything missing):\n${changedFilePayload}` : '') +
                 dependencyContext + parityContext + previousFindings;
               const MAX_USER_CHARS = 260000;
+              const truncationNotice =
+                '\n\n[TRUNCATED: user payload exceeded workflow cap; treat tail sections as unreviewed]\n';
               core.info(
-                `security-review payload sizes: diff=${diff.length} changedFiles=${changedFilePayload.length} ` +
+                `security-review payload sizes: diff=${diff.length} changedFileCount=${changedFiles.length} ` +
+                `changedFilePayloadChars=${changedFilePayload.length} ` +
                 `dep=${dependencyContext.length} parity=${parityContext.length} prev=${previousFindings.length} user=${userContent.length}`
               );
               if (userContent.length > MAX_USER_CHARS) {
+                const maxUserPrefixChars = Math.max(0, MAX_USER_CHARS - truncationNotice.length);
                 core.warning(
                   `User message length ${userContent.length} exceeds cap ${MAX_USER_CHARS}; truncating with explicit notice`
                 );
-                userContent = userContent.slice(0, MAX_USER_CHARS) +
-                  '\n\n[TRUNCATED: user payload exceeded workflow cap; treat tail sections as unreviewed]\n';
+                userContent = userContent.slice(0, maxUserPrefixChars) + truncationNotice;
               }
               const response = await fetch(
                 'https://models.github.ai/inference/chat/completions',

--- a/.github/workflows/models-security-review.yml
+++ b/.github/workflows/models-security-review.yml
@@ -346,7 +346,7 @@ jobs:
               ['clients/go/consensus/utxo_snapshot.go', 'clients/rust/crates/rubin-consensus/src/utxo_snapshot.rs'],
               ['clients/go/consensus/compactsize.go', 'clients/rust/crates/rubin-consensus/src/compactsize.rs'],
               ['clients/go/consensus/errors.go', 'clients/rust/crates/rubin-consensus/src/error.rs'],
-              // Node bootstrap vs consensus rotation (real paths; no separate production_rotation_schedule.* in tree)
+              // Node bootstrap vs consensus rotation (config/genesis + suite_registry; schedule modules when touched)
               ['clients/go/node/config.go', 'clients/rust/crates/rubin-node/src/genesis.rs'],
               ['clients/go/node/config.go', 'clients/rust/crates/rubin-consensus/src/suite_registry.rs'],
               ['clients/rust/crates/rubin-node/src/genesis.rs', 'clients/go/consensus/rotation_production.go'],
@@ -409,12 +409,16 @@ jobs:
                 const content = readChangedFile(counterpart);
                 if (!content) continue;
                 const header = `PARITY FILE: ${counterpart} (counterpart of changed ${file})\n`;
-                const cap = Math.min(PARITY_BUDGET - parityUsed - header.length, PER_FILE_CAP);
+                const separatorOverhead = parityEntries.length > 0 ? SEPARATOR.length : 0;
+                const cap = Math.min(
+                  PARITY_BUDGET - parityUsed - separatorOverhead - header.length,
+                  PER_FILE_CAP
+                );
                 if (cap < 200) continue;
                 const entry = header + content.slice(0, cap);
                 parityCounterpartsSeen.add(counterpart);
                 parityEntries.push(entry);
-                parityUsed += entry.length;
+                parityUsed += separatorOverhead + entry.length;
               }
             }
             const parityContext = parityEntries.length > 0
@@ -526,24 +530,65 @@ jobs:
             try {
               core.info(`Trying model: ${modelId}`);
               const userContentPreamble = 'Review this PR diff for security issues. Be strict and skeptical, but follow the system severity definitions — do not inflate node/bootstrap/API differences to CRITICAL or HIGH without a proven consensus path.\n\nDIFF:\n';
-              let userContent = userContentPreamble + diff +
-                (changedFilePayload ? `\n\n---\nFULL CHANGED FILES (use to verify definitions before claiming anything missing):\n${changedFilePayload}` : '') +
-                dependencyContext + parityContext + previousFindings;
+              const changedFilesSection = changedFilePayload
+                ? `\n\n---\nFULL CHANGED FILES (use to verify definitions before claiming anything missing):\n${changedFilePayload}`
+                : '';
               const MAX_USER_CHARS = 260000;
               const truncationNotice =
                 '\n\n[TRUNCATED: user payload exceeded workflow cap; treat tail sections as unreviewed]\n';
+
+              const buildUserContent = (sections) => sections.map((s) => s.content).join('');
+              const shrinkSectionToFit = (section, overflow) => {
+                if (overflow <= 0 || !section.content) return 0;
+                const removed = Math.min(overflow, section.content.length);
+                section.content = section.content.slice(0, section.content.length - removed);
+                return removed;
+              };
+
+              const sections = [
+                { name: 'preamble', content: userContentPreamble },
+                { name: 'diff', content: diff },
+                { name: 'changedFiles', content: changedFilesSection },
+                { name: 'dependencyContext', content: dependencyContext },
+                { name: 'parityContext', content: parityContext },
+                { name: 'previousFindings', content: previousFindings },
+              ];
+
+              let userContent = buildUserContent(sections);
               core.info(
                 `security-review payload sizes: diff=${diff.length} changedFileCount=${changedFiles.length} ` +
                 `changedFilePayloadChars=${changedFilePayload.length} ` +
                 `dep=${dependencyContext.length} parity=${parityContext.length} prev=${previousFindings.length} user=${userContent.length}`
               );
               if (userContent.length > MAX_USER_CHARS) {
-                const maxUserPrefixChars = Math.max(0, MAX_USER_CHARS - truncationNotice.length);
+                const maxUserCharsBeforeNotice = Math.max(0, MAX_USER_CHARS - truncationNotice.length);
+                let overflow = userContent.length - maxUserCharsBeforeNotice;
                 core.warning(
-                  `User message length ${userContent.length} exceeds cap ${MAX_USER_CHARS}; truncating with explicit notice`
+                  `User message length ${userContent.length} exceeds cap ${MAX_USER_CHARS}; ` +
+                  'truncating lower-priority sections from the tail first, then appending explicit notice'
                 );
-                userContent = userContent.slice(0, maxUserPrefixChars) + truncationNotice;
+
+                for (const sectionName of ['changedFiles', 'diff', 'parityContext', 'dependencyContext']) {
+                  if (overflow <= 0) break;
+                  const section = sections.find((c) => c.name === sectionName);
+                  overflow -= shrinkSectionToFit(section, overflow);
+                }
+                if (overflow > 0) {
+                  const prevSec = sections.find((c) => c.name === 'previousFindings');
+                  overflow -= shrinkSectionToFit(prevSec, overflow);
+                }
+                if (overflow > 0) {
+                  const pre = sections.find((c) => c.name === 'preamble');
+                  overflow -= shrinkSectionToFit(pre, overflow);
+                }
+
+                userContent = buildUserContent(sections) + truncationNotice;
+                if (userContent.length > MAX_USER_CHARS) {
+                  const maxFinal = Math.max(0, MAX_USER_CHARS - truncationNotice.length);
+                  userContent = userContent.slice(0, maxFinal) + truncationNotice;
+                }
               }
+              core.info(`security-review final user message length: ${userContent.length}`);
               const response = await fetch(
                 'https://models.github.ai/inference/chat/completions',
                 {

--- a/.github/workflows/models-security-review.yml
+++ b/.github/workflows/models-security-review.yml
@@ -298,19 +298,100 @@ jobs:
               : '';
 
             // ── Cross-language parity context ────────────────────────────
-            // When consensus-critical Go files change, inject the Rust
+            // When consensus- or node-critical Go files change, inject the Rust
             // counterpart (and vice versa) so the model can verify parity
             // claims with actual evidence instead of hallucinating.
-            const PARITY_BUDGET = 30000;
+            // Pairs are symmetric: either path may be the "changed" file.
+            // Multiple entries with the same first path intentionally pull
+            // more than one counterpart (mirrors tools/run_local_hostile_review.py).
+            const PARITY_BUDGET = 60000;
             const parityMap = [
-              // Go → Rust parity pairs (consensus-critical files)
+              // Consensus reference clients
               ['clients/go/consensus/wire_read.go',   'clients/rust/crates/rubin-consensus/src/wire_read.rs'],
               ['clients/go/consensus/tx_helpers.go',   'clients/rust/crates/rubin-consensus/src/tx_helpers.rs'],
               ['clients/go/consensus/transaction.go',  'clients/rust/crates/rubin-consensus/src/transaction.rs'],
               ['clients/go/consensus/block.go',        'clients/rust/crates/rubin-consensus/src/block.rs'],
-              ['clients/go/consensus/script_engine.go','clients/rust/crates/rubin-consensus/src/script_engine.rs'],
+              ['clients/go/consensus/block_parse.go',   'clients/rust/crates/rubin-consensus/src/block.rs'],
               ['clients/go/consensus/constants.go',    'clients/rust/crates/rubin-consensus/src/constants.rs'],
-              ['clients/go/consensus/covenant.go',     'clients/rust/crates/rubin-consensus/src/covenant.rs'],
+              ['clients/go/consensus/connect_block_inmem.go', 'clients/rust/crates/rubin-consensus/src/connect_block_inmem.rs'],
+              ['clients/go/consensus/suite_registry.go', 'clients/rust/crates/rubin-consensus/src/suite_registry.rs'],
+              ['clients/go/consensus/sighash.go', 'clients/rust/crates/rubin-consensus/src/sighash.rs'],
+              ['clients/go/consensus/core_ext.go', 'clients/rust/crates/rubin-consensus/src/core_ext.rs'],
+              ['clients/go/consensus/fork_choice.go', 'clients/rust/crates/rubin-consensus/src/fork_choice.rs'],
+              ['clients/go/consensus/spend_verify.go', 'clients/rust/crates/rubin-consensus/src/spend_verify.rs'],
+              ['clients/go/consensus/pow.go', 'clients/rust/crates/rubin-consensus/src/pow.rs'],
+              ['clients/go/consensus/merkle.go', 'clients/rust/crates/rubin-consensus/src/merkle.rs'],
+              ['clients/go/consensus/subsidy.go', 'clients/rust/crates/rubin-consensus/src/subsidy.rs'],
+              ['clients/go/consensus/utxo_basic.go', 'clients/rust/crates/rubin-consensus/src/utxo_basic.rs'],
+              ['clients/go/consensus/block_basic.go', 'clients/rust/crates/rubin-consensus/src/block_basic.rs'],
+              ['clients/go/consensus/rotation_descriptor.go', 'clients/rust/crates/rubin-consensus/src/suite_registry.rs'],
+              ['clients/go/consensus/rotation_production.go', 'clients/rust/crates/rubin-consensus/src/suite_registry.rs'],
+              ['clients/go/consensus/featurebits.go', 'clients/rust/crates/rubin-consensus/src/featurebits.rs'],
+              ['clients/go/consensus/flagday.go', 'clients/rust/crates/rubin-consensus/src/flagday.rs'],
+              ['clients/go/consensus/htlc.go', 'clients/rust/crates/rubin-consensus/src/htlc.rs'],
+              ['clients/go/consensus/vault.go', 'clients/rust/crates/rubin-consensus/src/vault.rs'],
+              ['clients/go/consensus/tx_parse.go', 'clients/rust/crates/rubin-consensus/src/tx.rs'],
+              ['clients/go/consensus/tx_marshal.go', 'clients/rust/crates/rubin-consensus/src/tx.rs'],
+              ['clients/go/consensus/hash.go', 'clients/rust/crates/rubin-consensus/src/hash.rs'],
+              ['clients/go/consensus/compact_relay.go', 'clients/rust/crates/rubin-consensus/src/compact_relay.rs'],
+              ['clients/go/consensus/da_verify_parallel.go', 'clients/rust/crates/rubin-consensus/src/da_verify_parallel.rs'],
+              ['clients/go/consensus/verify_sig_openssl.go', 'clients/rust/crates/rubin-consensus/src/verify_sig_openssl.rs'],
+              ['clients/go/consensus/covenant_genesis.go', 'clients/rust/crates/rubin-consensus/src/covenant_genesis.rs'],
+              ['clients/go/consensus/txcontext.go', 'clients/rust/crates/rubin-consensus/src/txcontext.rs'],
+              ['clients/go/consensus/tx_dep_graph.go', 'clients/rust/crates/rubin-consensus/src/tx_dep_graph.rs'],
+              ['clients/go/consensus/core_ext_binding.go', 'clients/rust/crates/rubin-consensus/src/core_ext.rs'],
+              ['clients/go/consensus/stealth.go', 'clients/rust/crates/rubin-consensus/src/stealth.rs'],
+              ['clients/go/consensus/utxo_snapshot.go', 'clients/rust/crates/rubin-consensus/src/utxo_snapshot.rs'],
+              ['clients/go/consensus/compactsize.go', 'clients/rust/crates/rubin-consensus/src/compactsize.rs'],
+              ['clients/go/consensus/errors.go', 'clients/rust/crates/rubin-consensus/src/error.rs'],
+              // Node: config / genesis / embedded production schedule (rotation)
+              ['clients/go/node/config.go', 'clients/rust/crates/rubin-node/src/genesis.rs'],
+              ['clients/go/node/production_rotation_schedule.go', 'clients/rust/crates/rubin-node/src/production_rotation_schedule.rs'],
+              ['clients/go/node/production_rotation_schedule.go', 'clients/rust/crates/rubin-node/src/genesis.rs'],
+              ['clients/rust/crates/rubin-node/src/production_rotation_schedule.rs', 'clients/go/node/config.go'],
+              // Node: core state and sync
+              ['clients/go/node/chainstate.go', 'clients/rust/crates/rubin-node/src/chainstate.rs'],
+              ['clients/go/node/sync.go', 'clients/rust/crates/rubin-node/src/sync.rs'],
+              ['clients/go/node/undo.go', 'clients/rust/crates/rubin-node/src/undo.rs'],
+              ['clients/go/node/blockstore.go', 'clients/rust/crates/rubin-node/src/blockstore.rs'],
+              ['clients/go/node/miner.go', 'clients/rust/crates/rubin-node/src/miner.rs'],
+              ['clients/go/node/mempool.go', 'clients/rust/crates/rubin-node/src/txpool.rs'],
+              ['clients/go/node/sync_reorg.go', 'clients/rust/crates/rubin-node/src/sync_reorg.rs'],
+              ['clients/go/node/sync_disconnect.go', 'clients/rust/crates/rubin-node/src/sync_disconnect.rs'],
+              ['clients/go/node/chainstate_recovery.go', 'clients/rust/crates/rubin-node/src/chainstate.rs'],
+              ['clients/go/node/blockstore_p2p.go', 'clients/rust/crates/rubin-node/src/blockstore.rs'],
+              ['clients/go/node/sync_mempool.go', 'clients/rust/crates/rubin-node/src/txpool.rs'],
+              ['clients/go/node/policy_core_ext.go', 'clients/rust/crates/rubin-node/src/txpool.rs'],
+              ['clients/go/node/policy_core_ext.go', 'clients/rust/crates/rubin-node/src/miner.rs'],
+              ['clients/go/node/policy_da_anchor.go', 'clients/rust/crates/rubin-node/src/txpool.rs'],
+              ['clients/go/node/policy_da_anchor.go', 'clients/rust/crates/rubin-node/src/miner.rs'],
+              ['clients/rust/crates/rubin-node/src/main.rs', 'clients/go/cmd/rubin-node/main.go'],
+              ['clients/go/cmd/rubin-node/main.go', 'clients/rust/crates/rubin-node/src/genesis.rs'],
+              ['clients/go/cmd/rubin-node/http_rpc.go', 'clients/rust/crates/rubin-node/src/devnet_rpc.rs'],
+              ['clients/go/node/p2p/rust_interop_test.go', 'clients/rust/crates/rubin-node/src/interop/mod.rs'],
+              // Node: helpers and P2P (best-effort counterpart mapping)
+              ['clients/go/node/mine_address.go', 'clients/rust/crates/rubin-node/src/coinbase.rs'],
+              ['clients/go/node/safeio.go', 'clients/rust/crates/rubin-node/src/io_utils.rs'],
+              ['clients/go/node/peer_manager.go', 'clients/rust/crates/rubin-node/src/p2p_runtime.rs'],
+              ['clients/go/node/p2p/service.go', 'clients/rust/crates/rubin-node/src/p2p_service.rs'],
+              ['clients/go/node/p2p/wire.go', 'clients/rust/crates/rubin-node/src/p2p_service.rs'],
+              ['clients/go/node/p2p/handlers_tx.go', 'clients/rust/crates/rubin-node/src/tx_relay.rs'],
+              ['clients/go/node/p2p/seen.go', 'clients/rust/crates/rubin-node/src/tx_seen.rs'],
+              ['clients/go/node/p2p/handlers_block.go', 'clients/rust/crates/rubin-node/src/p2p_service.rs'],
+              ['clients/go/node/p2p/handlers_inventory.go', 'clients/rust/crates/rubin-node/src/p2p_runtime.rs'],
+              ['clients/go/node/p2p/handshake.go', 'clients/rust/crates/rubin-node/src/p2p_service.rs'],
+              ['clients/go/node/p2p/reconnect.go', 'clients/rust/crates/rubin-node/src/p2p_runtime.rs'],
+              ['clients/go/node/p2p/peer_runtime.go', 'clients/rust/crates/rubin-node/src/p2p_runtime.rs'],
+              ['clients/go/node/p2p/service_peer_lifecycle.go', 'clients/rust/crates/rubin-node/src/p2p_service.rs'],
+              ['clients/go/node/p2p/service_listener.go', 'clients/rust/crates/rubin-node/src/p2p_service.rs'],
+              ['clients/go/node/p2p/service_sync.go', 'clients/rust/crates/rubin-node/src/sync.rs'],
+              ['clients/go/node/p2p/service_inventory.go', 'clients/rust/crates/rubin-node/src/p2p_runtime.rs'],
+              ['clients/go/node/p2p/addr_manager.go', 'clients/rust/crates/rubin-node/src/p2p_runtime.rs'],
+              ['clients/go/node/p2p/addr_discovery.go', 'clients/rust/crates/rubin-node/src/p2p_runtime.rs'],
+              ['clients/go/node/p2p/handlers_addr.go', 'clients/rust/crates/rubin-node/src/p2p_runtime.rs'],
+              ['clients/go/node/p2p/orphan_pool.go', 'clients/rust/crates/rubin-node/src/relay_pool.rs'],
+              ['clients/go/node/p2p/mempool.go', 'clients/rust/crates/rubin-node/src/txpool.rs'],
+              ['clients/go/node/p2p/tx_metadata.go', 'clients/rust/crates/rubin-node/src/txpool.rs'],
             ];
             const parityEntries = [];
             let parityUsed = 0;
@@ -337,8 +418,8 @@ jobs:
               : '';
 
             const systemPrompt = [
-              'You are a HOSTILE protocol security auditor for the RUBIN blockchain protocol.',
-              'Your job is NOT to help the author — it is to BREAK their code and find every exploitable flaw.',
+              'You are a strict protocol security reviewer for the RUBIN blockchain protocol.',
+              'Your job is to find real vulnerabilities and consensus hazards, with severities calibrated to actual impact.',
               '',
               'PROTOCOL CONTEXT:',
               '- Bitcoin-like UTXO chain with dual reference clients (Go + Rust) and Lean4 formal verification',
@@ -346,11 +427,18 @@ jobs:
               '- Covenant-typed system: P2PK, HTLC, anchor, DA-commit, CORE_EXT, vault, multisig',
               '- Soft-fork deployment mechanism for protocol upgrades',
               '- Canonical chain: RUBIN_L1_CANONICAL.md -> fixtures -> Go -> Rust -> conformance tests',
-              '- Consensus-critical code: ANY divergence between Go and Rust = chain split = CRITICAL',
+              '- Consensus-critical divergence (CRITICAL): ONLY when the same consensus-visible artifact (block header/body,',
+              '  tx wire, script/covenant validation, sighash, weight/fees, state transition) would be ACCEPTed by one',
+              '  reference client and REJECTed by the other, or would commit different consensus state. Name the validation',
+              '  or wire path (function/module). Do not treat node config/bootstrap/API shape alone as CRITICAL unless you',
+              '  prove that difference reaches block/tx validation unchanged.',
+              '- Node/bootstrap/config-only differences (nil vs default wrapper, optional fields, logging, CLI) are NOT',
+              '  CRITICAL by default — cap at MEDIUM unless you prove consensus impact with a concrete call chain.',
               '',
               'SEVERITY CLASSIFICATION:',
               'CRITICAL: double-spend, inflation bug, signature bypass, fork-choice error, reorg safety failure,',
-              '  consensus divergence between Go/Rust clients, covenant type confusion allowing unauthorized spend',
+              '  proven consensus divergence on block/tx validation or wire between Go and Rust reference clients,',
+              '  covenant type confusion allowing unauthorized spend',
               'HIGH: nonce reuse, weak entropy, PQ parameter misuse (ML-DSA wrong security level),',
               '  hash collision paths, missing signature validation on any code path',
               'MEDIUM: integer overflow/underflow, slice bounds, unchecked casts, panic in consensus path,',
@@ -360,18 +448,20 @@ jobs:
               'INFO: spec/code/fixture drift, behavioral divergence risk, missing test coverage for edge cases',
               'PERF: unbounded allocations, O(n^2) in hot paths, disk exhaustion, memory exhaustion under load',
               '',
-              'HOSTILE REVIEW RULES:',
-              '- Assume every change is guilty until proven safe.',
+              'ADVERSARIAL REVIEW RULES (calibrated):',
+              '- Treat changes as untrusted input: look for real bugs and consensus hazards, not maximal scare wording.',
               '- Check EVERY arithmetic operation for overflow/underflow.',
               '- Check EVERY slice/array access for bounds.',
               '- Check EVERY type cast for truncation or sign errors.',
               '- Check EVERY error path: does it fail-closed or fail-open?',
-              '- If Go code changed: would the same logic in Rust produce identical results? Flag if uncertain.',
-              '- If Rust code changed: would the same logic in Go produce identical results? Flag if uncertain.',
-              '- CROSS-CLIENT EVIDENCE RULE (MANDATORY): BEFORE reporting consensus divergence between Go and Rust,',
-              '  you MUST cite concrete evidence from BOTH clients\' code. If you only see one client\'s code in the',
-              '  diff/context, check the PARITY CONTEXT section below. If you have NO evidence from the other client,',
-              '  do NOT report divergence — add it to unreviewed_sections instead.',
+              '- Cross-client parity: if Go and Rust might differ, first decide whether the difference touches',
+              '  consensus validation/wire. If you cannot show that it does, use INFO or unreviewed_sections — not CRITICAL/HIGH.',
+              '- CROSS-CLIENT EVIDENCE RULE (MANDATORY, overrides "sounds risky"): BEFORE reporting CRITICAL or HIGH for',
+              '  Go/Rust divergence, you MUST cite concrete matching logic from BOTH clients (diff, FULL CHANGED FILES, or',
+              '  PARITY CONTEXT). If you lack the other side, do NOT emit CRITICAL/HIGH for divergence — add to',
+              '  unreviewed_sections and keep verdict at WARN at most.',
+              '- Never use CRITICAL for hypothetical chain split: "could cause fork" requires a stated consensus path;',
+              '  otherwise downgrade to MEDIUM or INFO.',
               '- If cryptographic code changed: verify parameter sizes, check for timing side-channels.',
               '- CRYPTO STANDARD ANTI-HALLUCINATION (MANDATORY): NEVER claim a cryptographic standard (FIPS, NIST,',
               '  RFC) allows, requires, or forbids something based on your training knowledge. Crypto standards are',
@@ -415,7 +505,7 @@ jobs:
               '    "suggestion": "concrete fix"',
               '  }],',
               '  "unreviewed_sections": ["list files/ranges not fully checked"],',
-              '  "summary": "one paragraph hostile summary"',
+              '  "summary": "one paragraph summary"',
               '}',
               '',
               'VERDICT RULES:',
@@ -443,10 +533,10 @@ jobs:
                     model: modelId,
                     messages: [
                       { role: 'system', content: systemPrompt },
-                      { role: 'user', content: `Review this PR diff for security vulnerabilities. Be hostile — assume every change is a potential exploit vector.\n\nDIFF:\n${diff}${changedFilePayload ? `\n\n---\nFULL CHANGED FILES (use to verify definitions before claiming anything missing):\n${changedFilePayload}` : ''}${dependencyContext}${parityContext}${previousFindings}` }
+                      { role: 'user', content: `Review this PR diff for security issues. Be strict and skeptical, but follow the system severity definitions — do not inflate node/bootstrap/API differences to CRITICAL or HIGH without a proven consensus path.\n\nDIFF:\n${diff}${changedFilePayload ? `\n\n---\nFULL CHANGED FILES (use to verify definitions before claiming anything missing):\n${changedFilePayload}` : ''}${dependencyContext}${parityContext}${previousFindings}` }
                     ],
-                    temperature: 0.6,
-                    top_p: 0.95
+                    temperature: 0.2,
+                    top_p: 0.9
                   })
                 }
               );

--- a/.github/workflows/models-security-review.yml
+++ b/.github/workflows/models-security-review.yml
@@ -262,11 +262,14 @@ jobs:
                 }
                 if (!modFile) continue;
                 const modRel = path.relative(repoRoot, modFile);
+                if (!modRel || path.isAbsolute(modRel) || modRel === '..' || modRel.startsWith('..' + path.sep)) {
+                  continue;
+                }
                 // Skip module sources that are already part of the PR file list (not the same as "in changedFilePayload", which can omit files due to TOTAL_FILE_BUDGET).
                 if (changedFilesSet.has(modRel)) continue;
 
-                let modContent;
-                try { modContent = fs.readFileSync(modFile, 'utf8'); } catch { continue; }
+                const modContent = readChangedFile(modRel);
+                if (!modContent) continue;
 
                 for (const sym of symbols) {
                   if (depUsed >= DEP_BUDGET) break;

--- a/tools/check_local_prepush_skill_gates.py
+++ b/tools/check_local_prepush_skill_gates.py
@@ -371,6 +371,14 @@ def build_plan(
         )
         add_check("workflow_shell_target_integrity", ["python3", "tools/list_workflow_shell_targets.py"])
 
+    if ".github/workflows/models-security-review.yml" in changed or (
+        "tools/check_models_security_review_workflow.py" in changed
+    ):
+        add_check(
+            "models_security_review_workflow_contract",
+            ["python3", "tools/check_models_security_review_workflow.py"],
+        )
+
     conformance_hygiene_related = fixture_json_changed or any(
         matches_any(
             path,

--- a/tools/check_models_security_review_workflow.py
+++ b/tools/check_models_security_review_workflow.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Fail-closed contract checks for `.github/workflows/models-security-review.yml`.
+
+Catches regressions that tend to produce noisy automated PR review threads:
+stale parity paths, unsafe file reads, O(n) membership in hot loops, and
+payload budget mistakes.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "models-security-review.yml"
+
+PAIR_RE = re.compile(r"\['([^']+)',\s*'([^']+)'\]")
+
+REQUIRED_SUBSTRINGS = [
+    "readChangedFile(modRel)",
+    "separatorOverhead",
+    "introOverhead",
+    "shrinkSectionToFit",
+    "changedFilesSet",
+    "maxUserCharsBeforeNotice",
+    "security-review final user message length",
+]
+
+BANNED_SUBSTRINGS = [
+    "fs.readFileSync(modFile",
+    "changedFiles.includes(",
+]
+
+
+def _fail(msg: str) -> None:
+    print(f"FAIL: {msg}", file=sys.stderr)
+
+
+def load_yaml_module():
+    try:
+        import yaml  # type: ignore
+    except ModuleNotFoundError:
+        return None
+    return yaml
+
+
+def main() -> int:
+    if not WORKFLOW.is_file():
+        _fail(f"missing workflow file: {WORKFLOW}")
+        return 1
+
+    text = WORKFLOW.read_text(encoding="utf-8")
+    errors: list[str] = []
+
+    yaml = load_yaml_module()
+    if yaml is not None:
+        try:
+            yaml.safe_load(text)
+        except yaml.YAMLError as exc:  # type: ignore[attr-defined]
+            errors.append(f"invalid YAML: {exc}")
+
+    for s in REQUIRED_SUBSTRINGS:
+        if s not in text:
+            errors.append(f"missing required invariant substring {s!r}")
+    for s in BANNED_SUBSTRINGS:
+        if s in text:
+            errors.append(f"banned regression substring present: {s!r}")
+
+    pairs = PAIR_RE.findall(text)
+    if len(pairs) < 10:
+        errors.append(f"expected parityMap-style pairs, got only {len(pairs)}")
+
+    missing_files: list[str] = []
+    for a, b in pairs:
+        for p in (a, b):
+            fp = REPO_ROOT / p
+            if not fp.is_file():
+                missing_files.append(p)
+    if missing_files:
+        preview = ", ".join(missing_files[:25])
+        extra = f" (+{len(missing_files) - 25} more)" if len(missing_files) > 25 else ""
+        errors.append(f"parityMap references missing files: {preview}{extra}")
+
+    if errors:
+        for e in errors:
+            _fail(e)
+        return 1
+
+    print(f"OK: models-security-review.yml contract ({len(pairs)} parity pairs)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_check_models_security_review_workflow.py
+++ b/tools/tests/test_check_models_security_review_workflow.py
@@ -1,0 +1,22 @@
+"""Contract tests for tools/check_models_security_review_workflow.py."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+TOOLS_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(TOOLS_DIR))
+
+import check_models_security_review_workflow as m
+
+
+class TestCheckModelsSecurityReviewWorkflow(unittest.TestCase):
+    def test_main_passes_on_repo_workflow(self) -> None:
+        self.assertTrue(m.WORKFLOW.is_file(), f"missing {m.WORKFLOW}")
+        self.assertEqual(m.main(), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_local_prepush_skill_gates.py
+++ b/tools/tests/test_local_prepush_skill_gates.py
@@ -298,6 +298,25 @@ class LocalPrepushSkillGateTests(unittest.TestCase):
         self.assertTrue(any("Workflow hygiene parity" in focus for focus in focuses))
         self.assertTrue(any("Server-only required checks" in focus for focus in focuses))
 
+    def test_build_plan_adds_models_security_review_contract_for_workflow_edit(self):
+        changed = {".github/workflows/models-security-review.yml"}
+
+        checks, _focuses, _lenses, profile = m.build_plan(changed)
+        check_names = {name for name, _cmd in checks}
+
+        self.assertEqual(profile.name, "diff_only")
+        self.assertIn("workflow_yaml_syntax", check_names)
+        self.assertIn("models_security_review_workflow_contract", check_names)
+
+    def test_build_plan_adds_models_contract_when_checker_script_changes(self):
+        changed = {"tools/check_models_security_review_workflow.py"}
+
+        checks, _focuses, _lenses, profile = m.build_plan(changed)
+        check_names = {name for name, _cmd in checks}
+
+        self.assertEqual(profile.name, "diff_only")
+        self.assertIn("models_security_review_workflow_contract", check_names)
+
     def test_build_plan_adds_kani_server_only_focus_for_rust_surfaces(self):
         changed = {"clients/rust/crates/rubin-consensus/src/tx.rs"}
 


### PR DESCRIPTION
## Summary
- Tighten `models-security-review.yml` system/user prompts: CRITICAL only for proven consensus-path divergence; cross-client evidence required before CRITICAL/HIGH; lower model temperature.
- Expand Go/Rust `parityMap`: consensus modules, node/cmd, policy, P2P; fix stale `covenant.go`/`script_engine` pairs; raise `PARITY_BUDGET` to 60k.

## Validation
- `python3 -c "import yaml; yaml.safe_load(open(...))"` → YAML OK
- Local pre-push: `workflow_yaml_syntax` PASS on this workflow file
- `run_pr_lifecycle.py pre-pr` PASS (`--skip-execution-drift` due to external queue drift unrelated to this change)

## Note
Hostile-review receipt blocked on `receipt-dirty-worktree` (untracked local tools files); push used `LOCAL_HOSTILE_REVIEW_BYPASS` with documented reason for this workflow-only PR.

Made with [Cursor](https://cursor.com)