### PR TITLE
fix(p2p/node): bounded backoff + diagnostics for Accept errors

### DIFF
--- a/clients/go/node/p2p/service_listener.go
+++ b/clients/go/node/p2p/service_listener.go
@@ -3,9 +3,51 @@ package p2p
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
+	"os"
 	"strings"
+	"time"
 )
+
+// Non-terminal Accept errors (e.g. EMFILE on transient file-descriptor
+// exhaustion) are retried with an exponential backoff capped at
+// acceptErrorBackoffCap. The constants mirror rubin-node Rust
+// ACCEPT_ERROR_BACKOFF_INIT / ACCEPT_ERROR_BACKOFF_CAP for cross-client
+// behavioural parity; see
+// clients/rust/crates/rubin-node/src/p2p_service.rs.
+const (
+	acceptErrorBackoffInit = 100 * time.Millisecond
+	acceptErrorBackoffCap  = 5 * time.Second
+)
+
+// nextAcceptErrorBackoff doubles current, capped at acceptErrorBackoffCap.
+// A non-positive current resets to acceptErrorBackoffInit. The helper is
+// pure so tests can exhaustively verify the progression without touching a
+// real listener.
+func nextAcceptErrorBackoff(current time.Duration) time.Duration {
+	if current <= 0 {
+		return acceptErrorBackoffInit
+	}
+	next := current * 2
+	if next > acceptErrorBackoffCap {
+		return acceptErrorBackoffCap
+	}
+	return next
+}
+
+// isAcceptLoopTerminal reports whether an Accept error should exit the
+// accept loop. Terminal conditions are: the service context has been
+// cancelled (Close path), or the listener has been closed.
+func isAcceptLoopTerminal(ctx context.Context, err error) bool {
+	if ctx != nil && ctx.Err() != nil {
+		return true
+	}
+	if errors.Is(err, net.ErrClosed) {
+		return true
+	}
+	return false
+}
 
 func (s *Service) Start(ctx context.Context) error {
 	if s == nil {
@@ -81,23 +123,58 @@ func (s *Service) Addr() string {
 
 func (s *Service) acceptLoop() {
 	defer s.loopWG.Done()
+	errorBackoff := acceptErrorBackoffInit
 	for {
 		conn, err := s.listener.Accept()
 		if err != nil {
-			if s.ctx != nil && s.ctx.Err() != nil {
+			if isAcceptLoopTerminal(s.ctx, err) {
 				return
 			}
-			if errors.Is(err, net.ErrClosed) {
+			// Non-terminal Accept error (e.g. EMFILE, ENFILE, transient
+			// socket failure). Log a diagnostic, sleep with the current
+			// backoff, then double it for the next occurrence (capped at
+			// acceptErrorBackoffCap). Mirrors rubin-node Rust
+			// run_accept_loop; prevents a hot-loop that previously would
+			// spin on a bare `continue` and drown the process.
+			fmt.Fprintf(os.Stderr,
+				"p2p: accept error on %s: %v (sleeping %s before retry)\n",
+				s.cfg.BindAddr, err, errorBackoff)
+			if !s.sleepOrStop(errorBackoff) {
 				return
 			}
+			errorBackoff = nextAcceptErrorBackoff(errorBackoff)
 			continue
 		}
+		errorBackoff = acceptErrorBackoffInit
 		if !s.tryAcquireHandshakeSlot() {
 			_ = conn.Close()
 			continue
 		}
 		s.loopWG.Add(1)
 		go s.runConn(conn, true)
+	}
+}
+
+// sleepOrStop sleeps for d unless the service context is cancelled first.
+// Returns true if the full sleep elapsed, false if cancellation unblocked
+// the sleep (callers treat false as "exit the loop"). A non-positive d or
+// nil receiver/context falls back to the obvious no-op or unconditional
+// time.Sleep respectively so callers never need to branch themselves.
+func (s *Service) sleepOrStop(d time.Duration) bool {
+	if d <= 0 {
+		return true
+	}
+	if s == nil || s.ctx == nil {
+		time.Sleep(d)
+		return true
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return true
+	case <-s.ctx.Done():
+		return false
 	}
 }
 

--- a/clients/go/node/p2p/service_listener_test.go
+++ b/clients/go/node/p2p/service_listener_test.go
@@ -1,0 +1,122 @@
+package p2p
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestNextAcceptErrorBackoff(t *testing.T) {
+	cases := []struct {
+		name    string
+		current time.Duration
+		want    time.Duration
+	}{
+		{"zero resets to init", 0, acceptErrorBackoffInit},
+		{"negative resets to init", -1 * time.Millisecond, acceptErrorBackoffInit},
+		{"init doubles to 200ms", acceptErrorBackoffInit, 200 * time.Millisecond},
+		{"200ms doubles to 400ms", 200 * time.Millisecond, 400 * time.Millisecond},
+		{"400ms doubles to 800ms", 400 * time.Millisecond, 800 * time.Millisecond},
+		{"800ms doubles to 1600ms", 800 * time.Millisecond, 1600 * time.Millisecond},
+		{"1600ms doubles to 3200ms", 1600 * time.Millisecond, 3200 * time.Millisecond},
+		{"3200ms clamps to cap", 3200 * time.Millisecond, acceptErrorBackoffCap},
+		{"cap stays at cap", acceptErrorBackoffCap, acceptErrorBackoffCap},
+		{"overshoot clamps to cap", 10 * time.Second, acceptErrorBackoffCap},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := nextAcceptErrorBackoff(tc.current)
+			if got != tc.want {
+				t.Fatalf("nextAcceptErrorBackoff(%s)=%s want %s", tc.current, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsAcceptLoopTerminalCtxCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	someErr := errors.New("temporary accept failure")
+	if !isAcceptLoopTerminal(ctx, someErr) {
+		t.Fatalf("cancelled ctx should make error terminal")
+	}
+}
+
+func TestIsAcceptLoopTerminalErrClosed(t *testing.T) {
+	// Plain net.ErrClosed returned by a closed listener.
+	if !isAcceptLoopTerminal(context.Background(), net.ErrClosed) {
+		t.Fatalf("net.ErrClosed should be terminal with live ctx")
+	}
+	// Wrapped net.ErrClosed (e.g. OpError wrapping) still unwraps to terminal.
+	wrapped := fmt.Errorf("accept: %w", net.ErrClosed)
+	if !isAcceptLoopTerminal(context.Background(), wrapped) {
+		t.Fatalf("wrapped net.ErrClosed should be terminal")
+	}
+}
+
+func TestIsAcceptLoopTerminalNonTerminal(t *testing.T) {
+	if isAcceptLoopTerminal(context.Background(), errors.New("EMFILE")) {
+		t.Fatalf("random error with live ctx should not be terminal")
+	}
+	// Nil context with a transient error is also non-terminal — Start() sets
+	// s.ctx before acceptLoop runs, but the helper must tolerate a nil ctx.
+	if isAcceptLoopTerminal(nil, errors.New("transient")) {
+		t.Fatalf("nil ctx with transient error should not be terminal")
+	}
+}
+
+func TestSleepOrStopZeroDuration(t *testing.T) {
+	s := &Service{}
+	if !s.sleepOrStop(0) {
+		t.Fatalf("sleepOrStop(0) must return true")
+	}
+	if !s.sleepOrStop(-1 * time.Second) {
+		t.Fatalf("sleepOrStop(-1s) must return true")
+	}
+}
+
+func TestSleepOrStopCancelledCtx(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	s := &Service{ctx: ctx}
+	start := time.Now()
+	if s.sleepOrStop(5 * time.Second) {
+		t.Fatalf("sleepOrStop with cancelled ctx must return false")
+	}
+	if elapsed := time.Since(start); elapsed >= 1*time.Second {
+		t.Fatalf("sleepOrStop should return promptly on cancelled ctx, elapsed=%s", elapsed)
+	}
+}
+
+func TestSleepOrStopLiveCtxElapses(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s := &Service{ctx: ctx}
+	start := time.Now()
+	if !s.sleepOrStop(5 * time.Millisecond) {
+		t.Fatalf("sleepOrStop(5ms) with live ctx must return true")
+	}
+	if elapsed := time.Since(start); elapsed < 5*time.Millisecond {
+		t.Fatalf("sleepOrStop(5ms) returned too early: %s", elapsed)
+	}
+}
+
+func TestSleepOrStopNilReceiver(t *testing.T) {
+	var s *Service
+	if !s.sleepOrStop(0) {
+		t.Fatalf("sleepOrStop on nil service with d=0 must return true")
+	}
+	// Non-zero duration on nil receiver falls back to plain time.Sleep; use a
+	// short duration to keep the test fast but still exercise the branch.
+	start := time.Now()
+	if !s.sleepOrStop(2 * time.Millisecond) {
+		t.Fatalf("sleepOrStop(2ms) on nil service must return true")
+	}
+	if elapsed := time.Since(start); elapsed < 2*time.Millisecond {
+		t.Fatalf("sleepOrStop(2ms) on nil service returned too early: %s", elapsed)
+	}
+}


### PR DESCRIPTION
## Summary

Go p2p `Service.acceptLoop` previously treated every non-terminal
`listener.Accept` error as a silent bare `continue`, producing a tight
hot-loop when the underlying condition was persistent (EMFILE on fd
exhaustion, ENFILE, transient socket failures). Under those conditions the
node spun at 100% CPU with no log and no retry pacing.

Mirror `clients/rust/crates/rubin-node/src/p2p_service.rs` `run_accept_loop`:

- Exponential backoff starting at `acceptErrorBackoffInit = 100 * time.Millisecond`, capped at `acceptErrorBackoffCap = 5 * time.Second`. Values match Rust `ACCEPT_ERROR_BACKOFF_INIT` / `ACCEPT_ERROR_BACKOFF_CAP` exactly.
- Reset backoff to init on every successful `Accept`.
- On non-terminal error: log a single-line diagnostic to `os.Stderr` (bind addr, error, current sleep) and sleep via a ctx-aware helper so `Close()` unblocks a backing-off loop immediately instead of waiting up to 5s.
- Terminal conditions (service `ctx.Err() != nil`, `errors.Is(err, net.ErrClosed)`) still exit the loop without backoff or log noise.

The backoff math and terminal classification live in pure helpers
(`nextAcceptErrorBackoff`, `isAcceptLoopTerminal`), so they can be unit-tested
exhaustively without a fake listener; `sleepOrStop` is also exercised directly.

## Changes

- `clients/go/node/p2p/service_listener.go`: add constants, add helpers `nextAcceptErrorBackoff`, `isAcceptLoopTerminal`, `sleepOrStop`; update `acceptLoop` to use them. +79 / -2
- `clients/go/node/p2p/service_listener_test.go` (new, 122 LOC): table-driven progression test + terminal classification + `sleepOrStop` deterministic paths. +122 / 0

## Go / Rust parity

Matches `clients/rust/crates/rubin-node/src/p2p_service.rs`:

- Lines 34–35: `ACCEPT_ERROR_BACKOFF_INIT: Duration = Duration::from_millis(100)`, `ACCEPT_ERROR_BACKOFF_CAP: Duration = Duration::from_secs(5)`.
- Lines 214–237: `run_accept_loop` — reset-on-success, double-on-error, cap clamp.

Known structural difference (not behavioural): Rust uses a nonblocking listener
+ `AtomicBool stop`, Go uses blocking `Accept()` + ctx cancellation +
`net.ErrClosed` classification. Shutdown and backoff semantics are equivalent
for identical inputs; there is no accept/reject divergence.

Rust side is already guarded by its own unit test
(`p2p_service::tests::accept_error_backoff_constants_valid`) so if the Rust
constants ever drift the test will catch it before parity is silently broken.

## Test plan

- [x] `gofmt -l clients/go/node/p2p/service_listener.go clients/go/node/p2p/service_listener_test.go` — clean
- [x] `go vet ./node/p2p/` — exit 0
- [x] `go build ./...` — exit 0
- [x] `go test ./node/...` — PASS (`node` 34.956s, `node/p2p` 2.854s)
- [x] `go test -race -run 'TestNextAcceptErrorBackoff|TestIsAcceptLoopTerminal|TestSleepOrStop' ./node/p2p/` — PASS (new tests race-clean)
- [x] Coverage: package `github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/node/p2p` 92.4% of statements; new helpers `nextAcceptErrorBackoff`, `isAcceptLoopTerminal`, `sleepOrStop` are at 100%. The four remaining uncovered statements live in the non-terminal error branch of `acceptLoop`, which can only be exercised by real fd-exhaustion fault injection and is classified as `UNREACHABLE_FROM_PUBLIC_SURFACE` per CLAUDE.md coverage policy. The actual logic inside that branch is fully delegated to the 100%-covered helpers.
- [x] Local `cl push` security review: PASS with `NO_FINDINGS=true` across active lenses (`code-review`, `diff-scan`, `combined-security-scan`, `semgrep-scan`, `gosec-scan`, `security-best-practices`, `rubin-coverage`).
- [x] Local Codacy coverage preflight: PASS (`tracked_worktree_clean: true` receipt written).
- [ ] CI green
- [ ] Copilot / Codex / Cursor / DeepSeek review threads resolved

## Race note

`go test -race ./node/p2p/` surfaces a pre-existing race in
`TestReconnectDuePeersDialsDuePeer` between `reconnect.go:135/146`
(`reconnectBackoff()`) and `reconnect_test.go:231/232`
(`overrideReconnectTiming` test helper). Verified by stashing the patch and
re-running on clean `origin/main@4cc279f`: the race reproduces identically
without any of my changes. It is **not** in the files touched by this PR and
is out of scope for #1130.

Fixes #1130.


<!-- rubin-agent-meta actor=claude action=pr-create via=cl branch=claude/q-p2p-accept-backoff-01 wt=rubin-protocol utc=2026-04-11T15:17:14Z -->
