### PR TITLE
docs: canonize local codex exec push contract

### DIFF
--- a/tools/LOCAL_CODEX_EXEC_REVIEW.md
+++ b/tools/LOCAL_CODEX_EXEC_REVIEW.md
@@ -10,11 +10,11 @@ This machine's sanctioned `rubin-protocol` push path is:
 
 ## Runtime contract
 
-- Entry command: `/Users/gpt/bin/cl push ...`
-- Hook: `/Users/gpt/Documents/rubin-protocol/.git/hooks-disabled/pre-push`
-- Review contract: `/Users/gpt/Documents/rubin-protocol/tools/prepush_review_contract.json`
-- Prompt builder: `/Users/gpt/Documents/rubin-protocol/tools/prepush_prompt_pack.py`
-- Skill-gate planner: `/Users/gpt/Documents/rubin-protocol/tools/check_local_prepush_skill_gates.py`
+- Entry command: `cl push ...`
+- Hook: `$(git rev-parse --git-path hooks-disabled/pre-push)`
+- Review contract: `tools/prepush_review_contract.json`
+- Prompt builder: `tools/prepush_prompt_pack.py`
+- Skill-gate planner: `tools/check_local_prepush_skill_gates.py`
 
 The hook launches `codex exec` in an isolated ephemeral `CODEX_HOME`, with a
 read-only sandbox and JSON-schema output. The model/reasoning profile is picked

--- a/tools/LOCAL_CODEX_EXEC_REVIEW.md
+++ b/tools/LOCAL_CODEX_EXEC_REVIEW.md
@@ -1,0 +1,63 @@
+# Local Codex Exec Pre-Push Review
+
+This machine's sanctioned `rubin-protocol` push path is:
+
+1. run local stack checks and `pre-pr` coverage preflight
+2. call `cl push ...`
+3. let `rubin-protocol/.git/hooks-disabled/pre-push` build the review bundle
+4. let the hook run deterministic local gates plus isolated local `codex exec`
+5. allow the network push only if there are no blocking findings
+
+## Runtime contract
+
+- Entry command: `/Users/gpt/bin/cl push ...`
+- Hook: `/Users/gpt/Documents/rubin-protocol/.git/hooks-disabled/pre-push`
+- Review contract: `/Users/gpt/Documents/rubin-protocol/tools/prepush_review_contract.json`
+- Prompt builder: `/Users/gpt/Documents/rubin-protocol/tools/prepush_prompt_pack.py`
+- Skill-gate planner: `/Users/gpt/Documents/rubin-protocol/tools/check_local_prepush_skill_gates.py`
+
+The hook launches `codex exec` in an isolated ephemeral `CODEX_HOME`, with a
+read-only sandbox and JSON-schema output. The model/reasoning profile is picked
+from `prepush_review_contract.json`; it is not a hardcoded one-size-fits-all
+prompt.
+
+## Runtime profiles
+
+- `consensus_critical` -> `gpt-5.4` `xhigh`
+- `formal_lean` -> `gpt-5.4` `xhigh`
+- `code_noncritical` -> `gpt-5.4-mini` `xhigh`
+- `diff_only` -> `gpt-5.4-mini` `xhigh`
+
+The hook may clamp `diff_only` reasoning down when needed to avoid local stall
+loops, but the sanctioned path remains the same: `cl push` -> `pre-push` ->
+`codex exec` review.
+
+If a local run hits a `no-json stall`, the hook may retry inside the same
+sanctioned path with reduced reasoning for the affected review unit before it
+gives up and blocks the push.
+
+## Blocking policy
+
+- Blocking severities: `CRITICAL`, `HIGH`, `MEDIUM`, `LOW`, `PERF`
+- Advisory only: `INFO`, `STYLE`
+
+If the hook reports blocking findings, push stays blocked. If it reports only
+advisory findings or no findings, the wrapper may continue to the real network
+push.
+
+## Evidence files
+
+The live worktree-local review artifacts are written under the current git-dir
+state directory:
+
+- `last-run-id`
+- `last-run-status`
+- `last-run-meta.txt`
+- `last-review-bundle.txt`
+- `last-prompt.txt`
+- `last-codex.log`
+- `last-result-raw.json`
+- `last-result.json`
+
+There is no separate sanctioned helper script in the
+current path. The review is part of the hook itself.

--- a/tools/LOCAL_CODEX_EXEC_REVIEW.md
+++ b/tools/LOCAL_CODEX_EXEC_REVIEW.md
@@ -29,12 +29,16 @@ prompt.
 - `diff_only` -> `gpt-5.4-mini` `xhigh`
 
 The hook may clamp `diff_only` reasoning down when needed to avoid local stall
-loops, but the sanctioned path remains the same: `cl push` -> `pre-push` ->
-`codex exec` review.
+loops, but that clamp is current hook-implementation behavior rather than part
+of the tracked `tools/prepush_review_contract.json` or
+`tools/check_local_prepush_skill_gates.py` contract. The sanctioned path
+remains the same: `cl push` -> `pre-push` -> `codex exec` review.
 
-If a local run hits a `no-json stall`, the hook may retry inside the same
-sanctioned path with reduced reasoning for the affected review unit before it
-gives up and blocks the push.
+If a local run hits a `no-json stall`, the current hook implementation may
+retry inside the same sanctioned path with reduced reasoning for the affected
+review unit before it gives up and blocks the push. That retry behavior is not
+specified by the JSON contract and may change independently of the tracked
+contract/tools.
 
 ## Blocking policy
 
@@ -46,6 +50,11 @@ advisory findings or no findings, the wrapper may continue to the real network
 push.
 
 ## Evidence files
+
+The tracked `pre-pr` receipt is written under the current git common-dir state
+directory:
+
+- `$(git rev-parse --git-common-dir)/local-security-review/pre-pr-receipt.json`
 
 The live worktree-local review artifacts are written under the current git-dir
 state directory:

--- a/tools/LOCAL_CODEX_EXEC_REVIEW.md
+++ b/tools/LOCAL_CODEX_EXEC_REVIEW.md
@@ -4,7 +4,7 @@ This machine's sanctioned `rubin-protocol` push path is:
 
 1. run local stack checks and `pre-pr` coverage preflight
 2. call `cl push ...`
-3. let `rubin-protocol/.git/hooks-disabled/pre-push` build the review bundle
+3. let `$(git rev-parse --git-path hooks-disabled/pre-push)` build the review bundle
 4. let the hook run deterministic local gates plus isolated local `codex exec`
 5. allow the network push only if there are no blocking findings
 


### PR DESCRIPTION
Task: controller-directed local pre-push contract canonization (no queue task).

Scope:
- add a repo-tracked README for the sanctioned local codex-exec pre-push path
- document the active runtime profiles, blocking policy, evidence files, and no-json-stall retry behavior
- align the human-readable contract layer with the already tracked prepush_review_contract.json tooling

Verification:
- python3 README contract check for referenced tooling files
- cl push -u origin codex/canonize-protocol-codex-exec-contract

<!-- rubin-agent-meta actor=Codex action=pr-create via=cl branch=codex/canonize-protocol-codex-exec-contract wt=rubin-protocol-canonize-codex-exec-contract utc=2026-04-11T17:03:57Z -->
