### PR TITLE
docs: clarify protocol push-contract boundary wording

### DIFF
--- a/tools/LOCAL_CODEX_EXEC_REVIEW.md
+++ b/tools/LOCAL_CODEX_EXEC_REVIEW.md
@@ -13,8 +13,9 @@ This machine's sanctioned `rubin-protocol` push path is:
 - Entry command: `cl push ...`
 - Hook: `$(git rev-parse --git-path hooks-disabled/pre-push)`
 - Public repo contract stops here on purpose.
-- This repository keeps only this README as the repo-facing pointer for the
-  local push contract.
+- This repository keeps only this README as the repo-facing pointer for this
+  local push contract; unrelated repository tooling remains outside this
+  contract boundary.
 - The actual machine-local runtime assets live in the private orchestration
   repository under `inbox/operational/local_push_gate/protocol/`.
 - That private path owns:


### PR DESCRIPTION
## Summary
- clarify that `tools/LOCAL_CODEX_EXEC_REVIEW.md` is the public pointer for this local push contract only
- state explicitly that unrelated public tooling remains outside this contract boundary
- keep the change scoped to wording only

## Why
- avoids future review churn from reading the README as a claim that `rubin-protocol` should contain no other public tools at all
- preserves the intended boundary: local push-contract runtime stays private, unrelated repo tooling stays public

## Verification
- `git diff --check origin/main...HEAD`
- local `cl push` review PASS on this head
- branch pushed via sanctioned `cl push`

<!-- rubin-agent-meta actor=Codex action=pr-create via=cl branch=codex/protocol-readme-boundary-followup wt=rubin-protocol-readme-boundary-followup utc=2026-04-11T22:34:29Z -->
