### PR TITLE
fix(go): remove dead tx relay branch

### DIFF
--- a/clients/go/node/p2p/handlers_tx.go
+++ b/clients/go/node/p2p/handlers_tx.go
@@ -27,9 +27,7 @@ func (p *peer) handleTx(txBytes []byte) error {
 	if !p.service.cfg.TxPool.Put(txid, txBytes, meta.Fee, meta.Size) {
 		return nil
 	}
-	if isNew {
-		_ = p.service.broadcastInventory(p, []InventoryVector{{Type: MSG_TX, Hash: txid}})
-	}
+	_ = p.service.broadcastInventory(p, []InventoryVector{{Type: MSG_TX, Hash: txid}})
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- remove the dead `if isNew` relay guard in Go `handleTx`
- keep behavior unchanged because `!isNew` already returns early
- preserve existing tx pool / metadata / relay semantics

## Validation
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node/p2p -run "TestHandleTxValid|TestCoverage_AnnounceTxAndHandleTxBranches|TestHandleTxPoolFullMarksSeen" -count=1'`\n- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node/p2p -count=1'`\n- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node/... -count=1'`\n- sanctioned `claude-review` PASS\n- sanctioned `pre-pr` PASS\n- sanctioned `cl push` PASS\n\n## Queue\n- Q-IMPL-GO-TX-DEAD-BRANCH-CLEANUP-01\n- closes #1180