### PR TITLE
feat: devnet live mining POST /mine_next + coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ output/
 tmp/
 .claude/
 .codex/
+.cursor/
 artifacts/
 .worktrees/
 

--- a/clients/go/cmd/rubin-node/http_rpc.go
+++ b/clients/go/cmd/rubin-node/http_rpc.go
@@ -449,16 +449,20 @@ func handleSubmitTx(state *devnetRPCState, w http.ResponseWriter, r *http.Reques
 		return
 	}
 	state.rpcMut.Lock()
-	defer state.rpcMut.Unlock()
-	if err := state.mempool.AddTx(raw); err != nil {
-		status, result := classifySubmitErr(err)
+	admitErr := state.mempool.AddTx(raw)
+	state.rpcMut.Unlock()
+	if admitErr != nil {
+		status, result := classifySubmitErr(admitErr)
 		state.metrics.noteSubmit(result)
 		writeJSONResponse(state, route, w, status, submitTxResponse{
 			Accepted: false,
-			Error:    err.Error(),
+			Error:    admitErr.Error(),
 		})
 		return
 	}
+	// Announce runs outside rpcMut: it is p2p broadcast, not chain/mempool
+	// mutation, so serializing with /mine_next under the rpc op lock would
+	// block mine_next on a potentially slow network callback for no benefit.
 	if state.announceTx != nil {
 		if err := state.announceTx(raw); err != nil {
 			_, _ = fmt.Fprintf(state.stderr, "rpc: announce-tx: %v\n", err)

--- a/clients/go/cmd/rubin-node/http_rpc.go
+++ b/clients/go/cmd/rubin-node/http_rpc.go
@@ -449,8 +449,9 @@ func handleSubmitTx(state *devnetRPCState, w http.ResponseWriter, r *http.Reques
 		return
 	}
 	state.rpcMut.Lock()
-	defer state.rpcMut.Unlock()
-	if err := state.mempool.AddTx(raw); err != nil {
+	err = state.mempool.AddTx(raw)
+	state.rpcMut.Unlock()
+	if err != nil {
 		status, result := classifySubmitErr(err)
 		state.metrics.noteSubmit(result)
 		writeJSONResponse(state, route, w, status, submitTxResponse{

--- a/clients/go/cmd/rubin-node/http_rpc.go
+++ b/clients/go/cmd/rubin-node/http_rpc.go
@@ -449,9 +449,8 @@ func handleSubmitTx(state *devnetRPCState, w http.ResponseWriter, r *http.Reques
 		return
 	}
 	state.rpcMut.Lock()
-	err = state.mempool.AddTx(raw)
-	state.rpcMut.Unlock()
-	if err != nil {
+	defer state.rpcMut.Unlock()
+	if err := state.mempool.AddTx(raw); err != nil {
 		status, result := classifySubmitErr(err)
 		state.metrics.noteSubmit(result)
 		writeJSONResponse(state, route, w, status, submitTxResponse{

--- a/clients/go/cmd/rubin-node/http_rpc.go
+++ b/clients/go/cmd/rubin-node/http_rpc.go
@@ -109,8 +109,15 @@ func newDevnetRPCState(
 // for devnet-only live mining RPC (loopback only). Non-loopback binds disable
 // live mining even when network=devnet.
 func rpcBindHostIsLoopback(bindAddr string) bool {
-	host, _, err := net.SplitHostPort(strings.TrimSpace(bindAddr))
+	host, port, err := net.SplitHostPort(strings.TrimSpace(bindAddr))
 	if err != nil {
+		return false
+	}
+	port = strings.TrimSpace(port)
+	if port == "" {
+		return false
+	}
+	if _, err := strconv.ParseUint(port, 10, 16); err != nil {
 		return false
 	}
 	host = strings.TrimSpace(host)
@@ -480,8 +487,6 @@ func handleMineNext(state *devnetRPCState, w http.ResponseWriter, r *http.Reques
 		})
 		return
 	}
-	state.rpcMut.Lock()
-	defer state.rpcMut.Unlock()
 	if state.miner == nil {
 		writeJSONResponse(state, route, w, http.StatusServiceUnavailable, mineNextResponse{
 			Mined: false,
@@ -489,6 +494,8 @@ func handleMineNext(state *devnetRPCState, w http.ResponseWriter, r *http.Reques
 		})
 		return
 	}
+	state.rpcMut.Lock()
+	defer state.rpcMut.Unlock()
 	mb, err := state.miner.MineOne(r.Context(), nil)
 	if err != nil {
 		writeJSONResponse(state, route, w, http.StatusUnprocessableEntity, mineNextResponse{

--- a/clients/go/cmd/rubin-node/http_rpc.go
+++ b/clients/go/cmd/rubin-node/http_rpc.go
@@ -28,6 +28,10 @@ type devnetRPCState struct {
 	stderr      io.Writer
 	nowUnix     func() uint64
 	metrics     *rpcMetrics
+	// rpcMut serializes mutating devnet RPC work (mempool admits + live mining)
+	// so concurrent HTTP handlers cannot interleave chain/mempool updates.
+	rpcMut sync.Mutex
+	miner  *node.Miner // devnet live mining for POST /mine_next; nil disables the route
 }
 
 type runningDevnetRPCServer struct {
@@ -66,6 +70,16 @@ type submitTxResponse struct {
 	Error    string `json:"error,omitempty"`
 }
 
+type mineNextResponse struct {
+	Mined     bool    `json:"mined"`
+	Height    *uint64 `json:"height,omitempty"`
+	BlockHash *string `json:"block_hash,omitempty"`
+	Timestamp *uint64 `json:"timestamp,omitempty"`
+	Nonce     *uint64 `json:"nonce,omitempty"`
+	TxCount   *int    `json:"tx_count,omitempty"`
+	Error     string  `json:"error,omitempty"`
+}
+
 func newDevnetRPCState(
 	syncEngine *node.SyncEngine,
 	blockStore *node.BlockStore,
@@ -73,6 +87,7 @@ func newDevnetRPCState(
 	peerManager *node.PeerManager,
 	announceTx func([]byte) error,
 	stderr io.Writer,
+	liveMiner *node.Miner,
 ) *devnetRPCState {
 	if stderr == nil {
 		stderr = io.Discard
@@ -86,7 +101,24 @@ func newDevnetRPCState(
 		stderr:      stderr,
 		nowUnix:     nowUnixU64,
 		metrics:     newRPCMetrics(),
+		miner:       liveMiner,
 	}
+}
+
+// rpcBindHostIsLoopback reports whether the host part of host:port is suitable
+// for devnet-only live mining RPC (loopback only). Non-loopback binds disable
+// live mining even when network=devnet.
+func rpcBindHostIsLoopback(bindAddr string) bool {
+	host, _, err := net.SplitHostPort(strings.TrimSpace(bindAddr))
+	if err != nil {
+		return false
+	}
+	host = strings.TrimSpace(host)
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }
 
 func newRPCMetrics() *rpcMetrics {
@@ -188,6 +220,9 @@ func newDevnetRPCHandler(state *devnetRPCState) http.Handler {
 	})
 	mux.HandleFunc("/submit_tx", func(w http.ResponseWriter, r *http.Request) {
 		handleSubmitTx(state, w, r)
+	})
+	mux.HandleFunc("/mine_next", func(w http.ResponseWriter, r *http.Request) {
+		handleMineNext(state, w, r)
 	})
 	mux.HandleFunc("/metrics", func(w http.ResponseWriter, r *http.Request) {
 		handleMetrics(state, w, r)
@@ -406,6 +441,8 @@ func handleSubmitTx(state *devnetRPCState, w http.ResponseWriter, r *http.Reques
 		})
 		return
 	}
+	state.rpcMut.Lock()
+	defer state.rpcMut.Unlock()
 	if err := state.mempool.AddTx(raw); err != nil {
 		status, result := classifySubmitErr(err)
 		state.metrics.noteSubmit(result)
@@ -424,6 +461,54 @@ func handleSubmitTx(state *devnetRPCState, w http.ResponseWriter, r *http.Reques
 	writeJSONResponse(state, route, w, http.StatusOK, submitTxResponse{
 		Accepted: true,
 		TxID:     hex.EncodeToString(txid[:]),
+	})
+}
+
+func handleMineNext(state *devnetRPCState, w http.ResponseWriter, r *http.Request) {
+	const route = "/mine_next"
+	if r.Method != http.MethodPost {
+		writeJSONResponse(state, route, w, http.StatusBadRequest, mineNextResponse{
+			Mined: false,
+			Error: "POST required",
+		})
+		return
+	}
+	if state == nil {
+		writeJSONResponse(state, route, w, http.StatusServiceUnavailable, mineNextResponse{
+			Mined: false,
+			Error: "rpc unavailable",
+		})
+		return
+	}
+	state.rpcMut.Lock()
+	defer state.rpcMut.Unlock()
+	if state.miner == nil {
+		writeJSONResponse(state, route, w, http.StatusServiceUnavailable, mineNextResponse{
+			Mined: false,
+			Error: "live mining unavailable",
+		})
+		return
+	}
+	mb, err := state.miner.MineOne(r.Context(), nil)
+	if err != nil {
+		writeJSONResponse(state, route, w, http.StatusUnprocessableEntity, mineNextResponse{
+			Mined: false,
+			Error: err.Error(),
+		})
+		return
+	}
+	height := mb.Height
+	ts := mb.Timestamp
+	nonce := mb.Nonce
+	txCount := mb.TxCount
+	hash := hex.EncodeToString(mb.Hash[:])
+	writeJSONResponse(state, route, w, http.StatusOK, mineNextResponse{
+		Mined:     true,
+		Height:    &height,
+		BlockHash: &hash,
+		Timestamp: &ts,
+		Nonce:     &nonce,
+		TxCount:   &txCount,
 	})
 }
 

--- a/clients/go/cmd/rubin-node/http_rpc_test.go
+++ b/clients/go/cmd/rubin-node/http_rpc_test.go
@@ -51,8 +51,9 @@ func mustRPCStateAtDir(t *testing.T, dir string, withGenesis bool) *devnetRPCSta
 	if err != nil {
 		t.Fatalf("NewMempool: %v", err)
 	}
+	syncEngine.SetMempool(mempool)
 	peerManager := node.NewPeerManager(node.DefaultPeerRuntimeConfig("devnet", 8))
-	state := newDevnetRPCState(syncEngine, blockStore, mempool, peerManager, nil, io.Discard)
+	state := newDevnetRPCState(syncEngine, blockStore, mempool, peerManager, nil, io.Discard, nil)
 	state.nowUnix = func() uint64 { return 0 }
 	return state
 }
@@ -105,8 +106,9 @@ func mustRPCStateWithSpendableUTXO(
 	if err != nil {
 		t.Fatalf("NewMempool: %v", err)
 	}
+	syncEngine.SetMempool(mempool)
 	peerManager := node.NewPeerManager(node.DefaultPeerRuntimeConfig("devnet", 8))
-	state := newDevnetRPCState(syncEngine, blockStore, mempool, peerManager, announceTx, io.Discard)
+	state := newDevnetRPCState(syncEngine, blockStore, mempool, peerManager, announceTx, io.Discard, nil)
 	state.nowUnix = func() uint64 { return 0 }
 	return state, outpoint, chainState.Utxos
 }
@@ -884,8 +886,105 @@ func TestDevnetRPCSubmitTxLogsAnnounceTxError(t *testing.T) {
 }
 
 func TestNewDevnetRPCStateNilStderrFallsBackToDiscard(t *testing.T) {
-	state := newDevnetRPCState(nil, nil, nil, nil, nil, nil)
+	state := newDevnetRPCState(nil, nil, nil, nil, nil, nil, nil)
 	if state.stderr != io.Discard {
 		t.Fatal("expected io.Discard for nil stderr")
+	}
+}
+
+func TestRPCBindHostIsLoopback(t *testing.T) {
+	if !rpcBindHostIsLoopback("127.0.0.1:19112") {
+		t.Fatal("expected loopback for 127.0.0.1")
+	}
+	if !rpcBindHostIsLoopback("[::1]:19112") {
+		t.Fatal("expected loopback for ::1")
+	}
+	if !rpcBindHostIsLoopback("localhost:19112") {
+		t.Fatal("expected loopback for localhost")
+	}
+	if rpcBindHostIsLoopback("0.0.0.0:19112") {
+		t.Fatal("expected non-loopback for 0.0.0.0")
+	}
+	if rpcBindHostIsLoopback("example.com:19112") {
+		t.Fatal("expected non-loopback for example.com")
+	}
+}
+
+func TestDevnetRPCMineNextRejectsGet(t *testing.T) {
+	server := httptest.NewServer(newDevnetRPCHandler(mustRPCState(t, true)))
+	t.Cleanup(server.Close)
+	resp, err := http.Get(server.URL + "/mine_next")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status=%d want 400", resp.StatusCode)
+	}
+}
+
+func TestDevnetRPCMineNextUnavailableWithoutMiner(t *testing.T) {
+	server := httptest.NewServer(newDevnetRPCHandler(mustRPCState(t, true)))
+	t.Cleanup(server.Close)
+	resp, err := http.Post(server.URL+"/mine_next", "application/json", bytes.NewReader([]byte("{}")))
+	if err != nil {
+		t.Fatalf("Post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d want 503", resp.StatusCode)
+	}
+}
+
+func TestDevnetRPCMineNextMinesAfterGenesis(t *testing.T) {
+	dir := t.TempDir()
+	chainStatePath := node.ChainStatePath(dir)
+	chainState := node.NewChainState()
+	if err := chainState.Save(chainStatePath); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	blockStore, err := node.OpenBlockStore(node.BlockStorePath(dir))
+	if err != nil {
+		t.Fatalf("OpenBlockStore: %v", err)
+	}
+	syncCfg := node.DefaultSyncConfig(nil, node.DevnetGenesisChainID(), chainStatePath)
+	syncEngine, err := node.NewSyncEngine(chainState, blockStore, syncCfg)
+	if err != nil {
+		t.Fatalf("NewSyncEngine: %v", err)
+	}
+	if _, err := syncEngine.ApplyBlock(node.DevnetGenesisBlockBytes(), nil); err != nil {
+		t.Fatalf("ApplyBlock(genesis): %v", err)
+	}
+	mempool, err := node.NewMempool(chainState, blockStore, node.DevnetGenesisChainID())
+	if err != nil {
+		t.Fatalf("NewMempool: %v", err)
+	}
+	syncEngine.SetMempool(mempool)
+	peerManager := node.NewPeerManager(node.DefaultPeerRuntimeConfig("devnet", 8))
+	miner, err := node.NewMiner(chainState, blockStore, syncEngine, node.DefaultMinerConfig())
+	if err != nil {
+		t.Fatalf("NewMiner: %v", err)
+	}
+	state := newDevnetRPCState(syncEngine, blockStore, mempool, peerManager, nil, io.Discard, miner)
+	state.nowUnix = func() uint64 { return 0 }
+	server := httptest.NewServer(newDevnetRPCHandler(state))
+	t.Cleanup(server.Close)
+	resp, err := http.Post(server.URL+"/mine_next", "application/json", bytes.NewReader([]byte("{}")))
+	if err != nil {
+		t.Fatalf("Post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d want 200", resp.StatusCode)
+	}
+	var got mineNextResponse
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if !got.Mined || got.Height == nil || *got.Height != 1 || got.TxCount == nil || *got.TxCount < 1 {
+		t.Fatalf("unexpected response: %+v", got)
+	}
+	if got.Nonce == nil {
+		t.Fatalf("want nonce field in JSON for Go/Rust RPC parity, got %+v", got)
 	}
 }

--- a/clients/go/cmd/rubin-node/http_rpc_test.go
+++ b/clients/go/cmd/rubin-node/http_rpc_test.go
@@ -908,6 +908,80 @@ func TestRPCBindHostIsLoopback(t *testing.T) {
 	if rpcBindHostIsLoopback("example.com:19112") {
 		t.Fatal("expected non-loopback for example.com")
 	}
+	if rpcBindHostIsLoopback("127.0.0.1") {
+		t.Fatal("missing port must be rejected")
+	}
+	if rpcBindHostIsLoopback("not-a-host:19112") {
+		t.Fatal("invalid host:port must be rejected")
+	}
+}
+
+func TestHandleMineNextNilState(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/mine_next", nil)
+	handleMineNext(nil, rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d want 503", rec.Code)
+	}
+	var got mineNextResponse
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if got.Error != "rpc unavailable" {
+		t.Fatalf("error=%q want rpc unavailable", got.Error)
+	}
+}
+
+func TestDevnetRPCMineNextMineOneError(t *testing.T) {
+	dir := t.TempDir()
+	chainStatePath := node.ChainStatePath(dir)
+	chainState := node.NewChainState()
+	if err := chainState.Save(chainStatePath); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	blockStore, err := node.OpenBlockStore(node.BlockStorePath(dir))
+	if err != nil {
+		t.Fatalf("OpenBlockStore: %v", err)
+	}
+	syncCfg := node.DefaultSyncConfig(nil, node.DevnetGenesisChainID(), chainStatePath)
+	syncEngine, err := node.NewSyncEngine(chainState, blockStore, syncCfg)
+	if err != nil {
+		t.Fatalf("NewSyncEngine: %v", err)
+	}
+	if _, err := syncEngine.ApplyBlock(node.DevnetGenesisBlockBytes(), nil); err != nil {
+		t.Fatalf("ApplyBlock(genesis): %v", err)
+	}
+	mempool, err := node.NewMempool(chainState, blockStore, node.DevnetGenesisChainID())
+	if err != nil {
+		t.Fatalf("NewMempool: %v", err)
+	}
+	syncEngine.SetMempool(mempool)
+	peerManager := node.NewPeerManager(node.DefaultPeerRuntimeConfig("devnet", 8))
+	miner, err := node.NewMiner(chainState, blockStore, syncEngine, node.DefaultMinerConfig())
+	if err != nil {
+		t.Fatalf("NewMiner: %v", err)
+	}
+	state := newDevnetRPCState(syncEngine, blockStore, mempool, peerManager, nil, io.Discard, miner)
+	state.nowUnix = func() uint64 { return 0 }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	req := httptest.NewRequest(http.MethodPost, "/mine_next", nil).WithContext(ctx)
+	rec := httptest.NewRecorder()
+	handleMineNext(state, rec, req)
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status=%d want 422", rec.Code)
+	}
+	var got mineNextResponse
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if got.Mined || got.Error == "" {
+		t.Fatalf("unexpected response: %+v", got)
+	}
+	if !strings.Contains(got.Error, context.Canceled.Error()) {
+		t.Fatalf("error=%q want context canceled", got.Error)
+	}
 }
 
 func TestDevnetRPCMineNextRejectsGet(t *testing.T) {

--- a/clients/go/cmd/rubin-node/http_rpc_test.go
+++ b/clients/go/cmd/rubin-node/http_rpc_test.go
@@ -914,6 +914,21 @@ func TestRPCBindHostIsLoopback(t *testing.T) {
 	if rpcBindHostIsLoopback("not-a-host:19112") {
 		t.Fatal("invalid host:port must be rejected")
 	}
+	if rpcBindHostIsLoopback("127.0.0.1:") {
+		t.Fatal("empty port must be rejected")
+	}
+	if rpcBindHostIsLoopback("localhost:") {
+		t.Fatal("empty port must be rejected for localhost")
+	}
+	if rpcBindHostIsLoopback("[::1]:") {
+		t.Fatal("empty port must be rejected for bracket IPv6")
+	}
+	if rpcBindHostIsLoopback("127.0.0.1:99999") {
+		t.Fatal("out-of-range port must be rejected")
+	}
+	if !rpcBindHostIsLoopback("127.0.0.1:0") {
+		t.Fatal("port 0 is valid for bind addresses")
+	}
 }
 
 func TestHandleMineNextNilState(t *testing.T) {

--- a/clients/go/cmd/rubin-node/main.go
+++ b/clients/go/cmd/rubin-node/main.go
@@ -453,7 +453,30 @@ func run(args []string, stdout, stderr io.Writer) int {
 		return 2
 	}
 	defer p2pService.Close()
-	rpcState := newDevnetRPCState(syncEngine, blockStore, mempool, peerManager, p2pService.AnnounceTx, stderr)
+	var liveMiner *node.Miner
+	if cfg.Network == "devnet" && strings.TrimSpace(cfg.RPCBindAddr) != "" && rpcBindHostIsLoopback(cfg.RPCBindAddr) {
+		minerCfg := node.DefaultMinerConfig()
+		var mineAddrErr error
+		if cfg.MineAddress != "" {
+			addrBytes, addrErr := node.ParseMineAddress(cfg.MineAddress)
+			if addrErr != nil {
+				mineAddrErr = addrErr
+				_, _ = fmt.Fprintf(stderr, "rpc: live mining disabled (invalid --mine-address): %v\n", addrErr)
+			} else {
+				minerCfg.MineAddress = addrBytes
+			}
+		}
+		if mineAddrErr == nil {
+			minerCfg.CoreExtProfiles = genesisCfg.CoreExtProfiles
+			var err error
+			liveMiner, err = newMinerFn(chainState, blockStore, syncEngine, minerCfg)
+			if err != nil {
+				_, _ = fmt.Fprintf(stderr, "rpc: live mining disabled: %v\n", err)
+				liveMiner = nil
+			}
+		}
+	}
+	rpcState := newDevnetRPCState(syncEngine, blockStore, mempool, peerManager, p2pService.AnnounceTx, stderr, liveMiner)
 	rpcServer, err := startDevnetRPCServer(ctx, cfg.RPCBindAddr, rpcState, stdout, stderr)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "rpc start failed: %v\n", err)

--- a/clients/go/cmd/rubin-node/main.go
+++ b/clients/go/cmd/rubin-node/main.go
@@ -469,11 +469,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 		if mineAddrErr == nil {
 			minerCfg.CoreExtProfiles = genesisCfg.CoreExtProfiles
 			var err error
-			if os.Getenv("RUBIN_TEST_FORCE_LIVE_MINER_INIT_ERROR") == "1" {
-				liveMiner, err = nil, fmt.Errorf("test miner init failed")
-			} else {
-				liveMiner, err = newMinerFn(chainState, blockStore, syncEngine, minerCfg)
-			}
+			liveMiner, err = newMinerFn(chainState, blockStore, syncEngine, minerCfg)
 			if err != nil {
 				_, _ = fmt.Fprintf(stderr, "rpc: live mining disabled: %v\n", err)
 				liveMiner = nil

--- a/clients/go/cmd/rubin-node/main.go
+++ b/clients/go/cmd/rubin-node/main.go
@@ -469,7 +469,11 @@ func run(args []string, stdout, stderr io.Writer) int {
 		if mineAddrErr == nil {
 			minerCfg.CoreExtProfiles = genesisCfg.CoreExtProfiles
 			var err error
-			liveMiner, err = newMinerFn(chainState, blockStore, syncEngine, minerCfg)
+			if os.Getenv("RUBIN_TEST_FORCE_LIVE_MINER_INIT_ERROR") == "1" {
+				liveMiner, err = nil, fmt.Errorf("test miner init failed")
+			} else {
+				liveMiner, err = newMinerFn(chainState, blockStore, syncEngine, minerCfg)
+			}
 			if err != nil {
 				_, _ = fmt.Fprintf(stderr, "rpc: live mining disabled: %v\n", err)
 				liveMiner = nil

--- a/clients/go/cmd/rubin-node/main_test.go
+++ b/clients/go/cmd/rubin-node/main_test.go
@@ -2008,3 +2008,87 @@ func TestRunNonDryRunWithRPCBindExitsOnSignal(t *testing.T) {
 		t.Fatalf("stdout=%q, want stopped banner", stdout.String())
 	}
 }
+
+func TestRunDevnetWithRPCBindInvalidMineAddressLogsStderr(t *testing.T) {
+	if os.Getenv("RUBIN_NODE_TEST_INVALID_MINE_ADDR_CHILD") == "1" {
+		dir := t.TempDir()
+		go func() {
+			time.Sleep(200 * time.Millisecond)
+			p, _ := os.FindProcess(os.Getpid())
+			_ = p.Signal(syscall.SIGINT)
+		}()
+		badSuiteMineAddr := "00" + strings.Repeat("00", 32)
+		code := run(
+			[]string{
+				"--datadir", dir,
+				"--bind", "127.0.0.1:0",
+				"--rpc-bind", "127.0.0.1:0",
+				"--mine-address", badSuiteMineAddr,
+			},
+			io.Discard,
+			os.Stderr,
+		)
+		os.Exit(code)
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestRunDevnetWithRPCBindInvalidMineAddressLogsStderr")
+	cmd.Env = append(os.Environ(), "RUBIN_NODE_TEST_INVALID_MINE_ADDR_CHILD=1")
+	var stderr bytes.Buffer
+	cmd.Stdout = io.Discard
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		ee, ok := err.(*exec.ExitError)
+		if ok {
+			t.Fatalf("exit code=%d, want 0 (stderr=%s)", ee.ExitCode(), stderr.String())
+		}
+		t.Fatalf("unexpected error: %v", err)
+	}
+	s := stderr.String()
+	if !strings.Contains(s, "rpc: live mining disabled (invalid --mine-address)") {
+		t.Fatalf("stderr=%q, want invalid mine-address log", s)
+	}
+}
+
+func TestRunDevnetWithRPCBindLiveMinerInitErrorLogsStderr(t *testing.T) {
+	if os.Getenv("RUBIN_NODE_TEST_LIVE_MINER_INIT_ERR_CHILD") == "1" {
+		dir := t.TempDir()
+		go func() {
+			time.Sleep(200 * time.Millisecond)
+			p, _ := os.FindProcess(os.Getpid())
+			_ = p.Signal(syscall.SIGINT)
+		}()
+		code := run(
+			[]string{
+				"--datadir", dir,
+				"--bind", "127.0.0.1:0",
+				"--rpc-bind", "127.0.0.1:0",
+				"--mine-address", strings.Repeat("11", 32),
+			},
+			io.Discard,
+			os.Stderr,
+		)
+		os.Exit(code)
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestRunDevnetWithRPCBindLiveMinerInitErrorLogsStderr")
+	cmd.Env = append(os.Environ(),
+		"RUBIN_NODE_TEST_LIVE_MINER_INIT_ERR_CHILD=1",
+		"RUBIN_TEST_FORCE_LIVE_MINER_INIT_ERROR=1",
+	)
+	var stderr bytes.Buffer
+	cmd.Stdout = io.Discard
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		ee, ok := err.(*exec.ExitError)
+		if ok {
+			t.Fatalf("exit code=%d, want 0 (stderr=%s)", ee.ExitCode(), stderr.String())
+		}
+		t.Fatalf("unexpected error: %v", err)
+	}
+	s := stderr.String()
+	if !strings.Contains(s, "rpc: live mining disabled:") || !strings.Contains(s, "test miner init failed") {
+		t.Fatalf("stderr=%q, want live mining disabled + test miner init failed", s)
+	}
+}

--- a/clients/go/cmd/rubin-node/main_test.go
+++ b/clients/go/cmd/rubin-node/main_test.go
@@ -2052,6 +2052,10 @@ func TestRunDevnetWithRPCBindInvalidMineAddressLogsStderr(t *testing.T) {
 
 func TestRunDevnetWithRPCBindLiveMinerInitErrorLogsStderr(t *testing.T) {
 	if os.Getenv("RUBIN_NODE_TEST_LIVE_MINER_INIT_ERR_CHILD") == "1" {
+		prev := newMinerFn
+		newMinerFn = func(*node.ChainState, *node.BlockStore, *node.SyncEngine, node.MinerConfig) (*node.Miner, error) {
+			return nil, errors.New("test miner init failed")
+		}
 		dir := t.TempDir()
 		go func() {
 			time.Sleep(200 * time.Millisecond)
@@ -2068,14 +2072,12 @@ func TestRunDevnetWithRPCBindLiveMinerInitErrorLogsStderr(t *testing.T) {
 			io.Discard,
 			os.Stderr,
 		)
+		newMinerFn = prev
 		os.Exit(code)
 	}
 
 	cmd := exec.Command(os.Args[0], "-test.run=TestRunDevnetWithRPCBindLiveMinerInitErrorLogsStderr")
-	cmd.Env = append(os.Environ(),
-		"RUBIN_NODE_TEST_LIVE_MINER_INIT_ERR_CHILD=1",
-		"RUBIN_TEST_FORCE_LIVE_MINER_INIT_ERROR=1",
-	)
+	cmd.Env = append(os.Environ(), "RUBIN_NODE_TEST_LIVE_MINER_INIT_ERR_CHILD=1")
 	var stderr bytes.Buffer
 	cmd.Stdout = io.Discard
 	cmd.Stderr = &stderr

--- a/clients/rust/crates/rubin-node/src/devnet_rpc.rs
+++ b/clients/rust/crates/rubin-node/src/devnet_rpc.rs
@@ -8,6 +8,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 
+use crate::miner::{Miner, MinerConfig};
 use crate::p2p_runtime::PeerManager;
 use crate::{BlockStore, SyncEngine, TxPool, TxPoolAdmitErrorKind, TxPoolConfig};
 
@@ -27,6 +28,10 @@ pub struct DevnetRPCState {
     metrics: Arc<RpcMetrics>,
     now_unix: fn() -> u64,
     announce_tx: Option<AnnounceTxFn>,
+    /// Serializes mutating devnet RPC (submit_tx + mine_next).
+    rpc_op_lock: Arc<Mutex<()>>,
+    /// When set, POST `/mine_next` mines one block using this config (devnet + loopback RPC only).
+    live_mining_cfg: Option<MinerConfig>,
 }
 
 pub struct RunningDevnetRPCServer {
@@ -84,6 +89,53 @@ struct SubmitTxRequest {
     tx_hex: String,
 }
 
+#[derive(Serialize)]
+struct MineNextResponse {
+    mined: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    height: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    block_hash: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    timestamp: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    nonce: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tx_count: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+}
+
+/// True when the host in `host:port` is loopback-only (safe for devnet live mining RPC).
+pub fn rpc_bind_host_is_loopback(bind_addr: &str) -> bool {
+    let addr = bind_addr.trim();
+    if addr.is_empty() {
+        return false;
+    }
+    let host = if addr.starts_with('[') {
+        let Some(bracket_end) = addr.find("]:") else {
+            return false;
+        };
+        &addr[1..bracket_end]
+    } else if let Some(colon_pos) = addr.rfind(':') {
+        let host = &addr[..colon_pos];
+        if host.contains(':') {
+            return false;
+        }
+        host
+    } else {
+        return false;
+    };
+    let host = host.trim();
+    if host.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+    host
+        .parse::<std::net::IpAddr>()
+        .ok()
+        .is_some_and(|ip| ip.is_loopback())
+}
+
 pub fn new_devnet_rpc_state(
     sync_engine: Arc<Mutex<SyncEngine>>,
     block_store: Option<BlockStore>,
@@ -91,7 +143,14 @@ pub fn new_devnet_rpc_state(
     announce_tx: Option<AnnounceTxFn>,
 ) -> DevnetRPCState {
     let tx_pool = new_shared_runtime_tx_pool(&sync_engine);
-    new_devnet_rpc_state_with_tx_pool(sync_engine, block_store, tx_pool, peer_manager, announce_tx)
+    new_devnet_rpc_state_with_tx_pool(
+        sync_engine,
+        block_store,
+        tx_pool,
+        peer_manager,
+        announce_tx,
+        None,
+    )
 }
 
 pub fn new_devnet_rpc_state_with_tx_pool(
@@ -100,6 +159,7 @@ pub fn new_devnet_rpc_state_with_tx_pool(
     tx_pool: Arc<Mutex<TxPool>>,
     peer_manager: Arc<PeerManager>,
     announce_tx: Option<AnnounceTxFn>,
+    live_mining_cfg: Option<MinerConfig>,
 ) -> DevnetRPCState {
     DevnetRPCState {
         sync_engine,
@@ -109,6 +169,8 @@ pub fn new_devnet_rpc_state_with_tx_pool(
         metrics: Arc::new(RpcMetrics::default()),
         now_unix: current_unix,
         announce_tx,
+        rpc_op_lock: Arc::new(Mutex::new(())),
+        live_mining_cfg,
     }
 }
 
@@ -255,6 +317,7 @@ fn route_request(state: &DevnetRPCState, req: HttpRequest) -> HttpResponse {
         "/get_tip" => handle_get_tip(state, &req.method),
         "/get_block" => handle_get_block(state, &req.method, &query),
         "/submit_tx" => handle_submit_tx(state, &req.method, &req.body),
+        "/mine_next" => handle_mine_next(state, &req.method, &req.body),
         "/metrics" => handle_metrics(state, &req.method),
         _ => json_response(
             state,
@@ -562,6 +625,22 @@ fn handle_submit_tx(state: &DevnetRPCState, method: &str, body: &[u8]) -> HttpRe
             );
         }
     };
+    let _rpc_op = match state.rpc_op_lock.lock() {
+        Ok(guard) => guard,
+        Err(_) => {
+            state.metrics.note_submit("unavailable");
+            return json_response(
+                state,
+                ROUTE,
+                503,
+                &SubmitTxResponse {
+                    accepted: false,
+                    txid: None,
+                    error: Some("rpc unavailable".to_string()),
+                },
+            );
+        }
+    };
     let (chain_state, chain_id) = match state.sync_engine.lock() {
         Ok(engine) => (engine.chain_state_snapshot(), engine.chain_id()),
         Err(_) => {
@@ -644,6 +723,148 @@ fn handle_submit_tx(state: &DevnetRPCState, method: &str, body: &[u8]) -> HttpRe
                 },
             )
         }
+    }
+}
+
+fn handle_mine_next(state: &DevnetRPCState, method: &str, _body: &[u8]) -> HttpResponse {
+    const ROUTE: &str = "/mine_next";
+    if method != "POST" {
+        return json_response(
+            state,
+            ROUTE,
+            400,
+            &MineNextResponse {
+                mined: false,
+                height: None,
+                block_hash: None,
+                timestamp: None,
+                nonce: None,
+                tx_count: None,
+                error: Some("POST required".to_string()),
+            },
+        );
+    }
+    let Some(miner_cfg) = state.live_mining_cfg.as_ref() else {
+        return json_response(
+            state,
+            ROUTE,
+            503,
+            &MineNextResponse {
+                mined: false,
+                height: None,
+                block_hash: None,
+                timestamp: None,
+                nonce: None,
+                tx_count: None,
+                error: Some("live mining unavailable".to_string()),
+            },
+        );
+    };
+    let _rpc_op = match state.rpc_op_lock.lock() {
+        Ok(g) => g,
+        Err(_) => {
+            return json_response(
+                state,
+                ROUTE,
+                503,
+                &MineNextResponse {
+                    mined: false,
+                    height: None,
+                    block_hash: None,
+                    timestamp: None,
+                    nonce: None,
+                    tx_count: None,
+                    error: Some("rpc unavailable".to_string()),
+                },
+            );
+        }
+    };
+    let mut sync_engine = match state.sync_engine.lock() {
+        Ok(g) => g,
+        Err(_) => {
+            return json_response(
+                state,
+                ROUTE,
+                503,
+                &MineNextResponse {
+                    mined: false,
+                    height: None,
+                    block_hash: None,
+                    timestamp: None,
+                    nonce: None,
+                    tx_count: None,
+                    error: Some("sync engine unavailable".to_string()),
+                },
+            );
+        }
+    };
+    let mut pool = match state.tx_pool.lock() {
+        Ok(g) => g,
+        Err(_) => {
+            return json_response(
+                state,
+                ROUTE,
+                503,
+                &MineNextResponse {
+                    mined: false,
+                    height: None,
+                    block_hash: None,
+                    timestamp: None,
+                    nonce: None,
+                    tx_count: None,
+                    error: Some("tx pool unavailable".to_string()),
+                },
+            );
+        }
+    };
+    let mut miner = match Miner::new(&mut sync_engine, Some(&mut pool), miner_cfg.clone()) {
+        Ok(m) => m,
+        Err(err) => {
+            return json_response(
+                state,
+                ROUTE,
+                503,
+                &MineNextResponse {
+                    mined: false,
+                    height: None,
+                    block_hash: None,
+                    timestamp: None,
+                    nonce: None,
+                    tx_count: None,
+                    error: Some(err),
+                },
+            );
+        }
+    };
+    match miner.mine_one(&[]) {
+        Ok(b) => json_response(
+            state,
+            ROUTE,
+            200,
+            &MineNextResponse {
+                mined: true,
+                height: Some(b.height),
+                block_hash: Some(hex::encode(b.hash)),
+                timestamp: Some(b.timestamp),
+                nonce: Some(b.nonce),
+                tx_count: Some(b.tx_count),
+                error: None,
+            },
+        ),
+        Err(err) => json_response(
+            state,
+            ROUTE,
+            422,
+            &MineNextResponse {
+                mined: false,
+                height: None,
+                block_hash: None,
+                timestamp: None,
+                nonce: None,
+                tx_count: None,
+                error: Some(err),
+            },
+        ),
     }
 }
 
@@ -954,12 +1175,13 @@ mod tests {
     use crate::io_utils::unique_temp_path;
     use crate::{
         block_store_path, default_peer_runtime_config, default_sync_config,
-        devnet_genesis_block_bytes, devnet_genesis_chain_id, BlockStore, ChainState, PeerManager,
-        SyncEngine, TxPool,
+        devnet_genesis_block_bytes, devnet_genesis_chain_id, BlockStore, ChainState, MinerConfig,
+        PeerManager, SyncEngine, TxPool,
     };
 
     use super::{
-        decode_hex_payload, new_devnet_rpc_state, parse_hex32, parse_query_map, read_http_request,
+        decode_hex_payload, new_devnet_rpc_state, new_devnet_rpc_state_with_tx_pool,
+        new_shared_runtime_tx_pool, parse_hex32, parse_query_map, read_http_request,
         render_prometheus_metrics, route_request, split_target, start_devnet_rpc_server,
         status_text, HttpRequest,
     };
@@ -985,6 +1207,42 @@ mod tests {
             Some(rpc_block_store),
             Arc::new(PeerManager::new(default_peer_runtime_config("devnet", 8))),
             None,
+        );
+        (state, dir)
+    }
+
+    fn build_state_with_live_mining(with_genesis: bool) -> (super::DevnetRPCState, PathBuf) {
+        let dir = unique_temp_path("rubin-devnet-rpc-live");
+        fs::create_dir_all(&dir).expect("mkdir");
+        let block_store = BlockStore::open(block_store_path(&dir)).expect("blockstore");
+        let mut engine = SyncEngine::new(
+            ChainState::new(),
+            Some(block_store.clone()),
+            default_sync_config(None, devnet_genesis_chain_id(), None),
+        )
+        .expect("sync");
+        if with_genesis {
+            engine
+                .apply_block(&devnet_genesis_block_bytes(), None)
+                .expect("apply genesis");
+        }
+        let rpc_block_store = BlockStore::open(block_store_path(&dir)).expect("reopen blockstore");
+        let sync_engine = Arc::new(Mutex::new(engine));
+        let tx_pool = new_shared_runtime_tx_pool(&sync_engine);
+        let live_cfg = MinerConfig {
+            core_ext_deployments: sync_engine
+                .lock()
+                .expect("lock")
+                .core_ext_deployments(),
+            ..MinerConfig::default()
+        };
+        let state = new_devnet_rpc_state_with_tx_pool(
+            sync_engine,
+            Some(rpc_block_store),
+            tx_pool,
+            Arc::new(PeerManager::new(default_peer_runtime_config("devnet", 8))),
+            None,
+            Some(live_cfg),
         );
         (state, dir)
     }
@@ -1111,6 +1369,8 @@ mod tests {
             metrics: Arc::new(super::RpcMetrics::default()),
             now_unix: super::current_unix,
             announce_tx: None,
+            rpc_op_lock: Arc::new(Mutex::new(())),
+            live_mining_cfg: None,
         }
     }
 
@@ -1148,6 +1408,92 @@ mod tests {
         assert_eq!(json["has_tip"].as_bool(), Some(true));
         assert_eq!(json["height"].as_u64(), Some(0));
         assert_eq!(json["tip_hash"].as_str().map(|s| s.len()), Some(64));
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn rpc_bind_host_is_loopback_accepts_loopback_hosts_only() {
+        assert!(super::rpc_bind_host_is_loopback("127.0.0.1:19112"));
+        assert!(super::rpc_bind_host_is_loopback("[::1]:19112"));
+        assert!(super::rpc_bind_host_is_loopback("localhost:19112"));
+        assert!(!super::rpc_bind_host_is_loopback("0.0.0.0:19112"));
+        assert!(!super::rpc_bind_host_is_loopback("example.com:19112"));
+        assert!(!super::rpc_bind_host_is_loopback(""));
+    }
+
+    #[test]
+    fn mine_next_rejects_get() {
+        let (state, dir) = build_state(true);
+        let response = route_request(
+            &state,
+            HttpRequest {
+                method: "GET".to_string(),
+                target: "/mine_next".to_string(),
+                body: Vec::new(),
+            },
+        );
+        assert_eq!(response.status, 400);
+        assert_eq!(
+            response_json(&response)["error"].as_str(),
+            Some("POST required")
+        );
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn mine_next_unavailable_without_live_cfg() {
+        let (state, dir) = build_state(true);
+        let response = route_request(
+            &state,
+            HttpRequest {
+                method: "POST".to_string(),
+                target: "/mine_next".to_string(),
+                body: b"{}".to_vec(),
+            },
+        );
+        assert_eq!(response.status, 503);
+        assert_eq!(
+            response_json(&response)["error"].as_str(),
+            Some("live mining unavailable")
+        );
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn mine_next_mines_after_genesis() {
+        let (state, dir) = build_state_with_live_mining(true);
+        let response = route_request(
+            &state,
+            HttpRequest {
+                method: "POST".to_string(),
+                target: "/mine_next".to_string(),
+                body: b"{}".to_vec(),
+            },
+        );
+        assert_eq!(
+            response.status,
+            200,
+            "{}",
+            String::from_utf8_lossy(&response.body)
+        );
+        let json = response_json(&response);
+        assert_eq!(json["mined"].as_bool(), Some(true));
+        assert_eq!(json["height"].as_u64(), Some(1));
+        assert!(json["tx_count"].as_u64().is_some_and(|n| n >= 1));
+        assert!(
+            json["nonce"].as_u64().is_some(),
+            "nonce must be present for Go/Rust RPC parity"
+        );
+        assert!(
+            json["block_hash"]
+                .as_str()
+                .is_some_and(|s| s.len() == 64),
+            "block_hash must be 32-byte hex"
+        );
+        assert!(
+            json["timestamp"].as_u64().is_some(),
+            "timestamp must be present"
+        );
         fs::remove_dir_all(dir).expect("cleanup");
     }
 
@@ -1783,6 +2129,8 @@ mod tests {
             metrics: Arc::new(super::RpcMetrics::default()),
             now_unix: || 0,
             announce_tx: None,
+            rpc_op_lock: Arc::new(Mutex::new(())),
+            live_mining_cfg: None,
         };
 
         let body = render_prometheus_metrics(&state);

--- a/clients/rust/crates/rubin-node/src/devnet_rpc.rs
+++ b/clients/rust/crates/rubin-node/src/devnet_rpc.rs
@@ -700,6 +700,11 @@ fn handle_submit_tx(state: &DevnetRPCState, method: &str, body: &[u8]) -> HttpRe
             message: "tx pool unavailable".to_string(),
         }),
     };
+    // Release rpc_op_lock before announce: announce is p2p broadcast, not
+    // chain/tx-pool mutation, so holding the RPC op lock across a slow
+    // network callback would block concurrent /mine_next for no benefit.
+    // Matches the narrowed Go scope in handleSubmitTx (http_rpc.go).
+    drop(_rpc_op);
     match admit_result {
         Ok((txid, relay_meta)) => {
             // Relay tx to peers (fire-and-forget, matches Go behavior).

--- a/clients/rust/crates/rubin-node/src/devnet_rpc.rs
+++ b/clients/rust/crates/rubin-node/src/devnet_rpc.rs
@@ -130,8 +130,7 @@ pub fn rpc_bind_host_is_loopback(bind_addr: &str) -> bool {
     if host.eq_ignore_ascii_case("localhost") {
         return true;
     }
-    host
-        .parse::<std::net::IpAddr>()
+    host.parse::<std::net::IpAddr>()
         .ok()
         .is_some_and(|ip| ip.is_loopback())
 }
@@ -1230,10 +1229,7 @@ mod tests {
         let sync_engine = Arc::new(Mutex::new(engine));
         let tx_pool = new_shared_runtime_tx_pool(&sync_engine);
         let live_cfg = MinerConfig {
-            core_ext_deployments: sync_engine
-                .lock()
-                .expect("lock")
-                .core_ext_deployments(),
+            core_ext_deployments: sync_engine.lock().expect("lock").core_ext_deployments(),
             ..MinerConfig::default()
         };
         let state = new_devnet_rpc_state_with_tx_pool(
@@ -1588,9 +1584,7 @@ mod tests {
             "nonce must be present for Go/Rust RPC parity"
         );
         assert!(
-            json["block_hash"]
-                .as_str()
-                .is_some_and(|s| s.len() == 64),
+            json["block_hash"].as_str().is_some_and(|s| s.len() == 64),
             "block_hash must be 32-byte hex"
         );
         assert!(

--- a/clients/rust/crates/rubin-node/src/devnet_rpc.rs
+++ b/clients/rust/crates/rubin-node/src/devnet_rpc.rs
@@ -107,26 +107,42 @@ struct MineNextResponse {
 }
 
 /// True when the host in `host:port` is loopback-only (safe for devnet live mining RPC).
+/// Requires a non-empty, valid `u16` port (rejects `127.0.0.1:` and similar).
 pub fn rpc_bind_host_is_loopback(bind_addr: &str) -> bool {
     let addr = bind_addr.trim();
     if addr.is_empty() {
         return false;
     }
-    let host = if addr.starts_with('[') {
+    let (host, port) = if addr.starts_with('[') {
         let Some(bracket_end) = addr.find("]:") else {
             return false;
         };
-        &addr[1..bracket_end]
+        if bracket_end < 2 {
+            return false;
+        }
+        let port = &addr[bracket_end + 2..];
+        (&addr[1..bracket_end], port)
     } else if let Some(colon_pos) = addr.rfind(':') {
+        if colon_pos == 0 || colon_pos + 1 == addr.len() {
+            return false;
+        }
         let host = &addr[..colon_pos];
         if host.contains(':') {
             return false;
         }
-        host
+        let port = &addr[(colon_pos + 1)..];
+        (host, port)
     } else {
         return false;
     };
     let host = host.trim();
+    if host.is_empty() {
+        return false;
+    }
+    let port = port.trim();
+    if port.is_empty() || port.parse::<u16>().is_err() {
+        return false;
+    }
     if host.eq_ignore_ascii_case("localhost") {
         return true;
     }
@@ -1418,6 +1434,11 @@ mod tests {
         assert!(!super::rpc_bind_host_is_loopback("[::1]"));
         assert!(!super::rpc_bind_host_is_loopback("abcd::1:19112"));
         assert!(!super::rpc_bind_host_is_loopback("127.0.0.1"));
+        assert!(!super::rpc_bind_host_is_loopback("127.0.0.1:"));
+        assert!(!super::rpc_bind_host_is_loopback("[::1]:"));
+        assert!(!super::rpc_bind_host_is_loopback("localhost:"));
+        assert!(!super::rpc_bind_host_is_loopback("127.0.0.1:99999"));
+        assert!(super::rpc_bind_host_is_loopback("127.0.0.1:0"));
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/devnet_rpc.rs
+++ b/clients/rust/crates/rubin-node/src/devnet_rpc.rs
@@ -1419,6 +1419,109 @@ mod tests {
         assert!(!super::rpc_bind_host_is_loopback("0.0.0.0:19112"));
         assert!(!super::rpc_bind_host_is_loopback("example.com:19112"));
         assert!(!super::rpc_bind_host_is_loopback(""));
+        assert!(!super::rpc_bind_host_is_loopback("[::1]"));
+        assert!(!super::rpc_bind_host_is_loopback("abcd::1:19112"));
+        assert!(!super::rpc_bind_host_is_loopback("127.0.0.1"));
+    }
+
+    #[test]
+    fn submit_tx_reports_unavailable_when_rpc_op_lock_is_poisoned() {
+        let (state, dir) = build_state(true);
+        let rpc_lock = Arc::clone(&state.rpc_op_lock);
+        let _ = std::thread::spawn(move || {
+            let _guard = rpc_lock.lock().expect("lock");
+            panic!("poison rpc op lock");
+        })
+        .join();
+        let response = route_request(
+            &state,
+            HttpRequest {
+                method: "POST".to_string(),
+                target: "/submit_tx".to_string(),
+                body: br#"{"tx_hex":"00"}"#.to_vec(),
+            },
+        );
+        assert_eq!(response.status, 503);
+        assert_eq!(
+            response_json(&response)["error"].as_str(),
+            Some("rpc unavailable")
+        );
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn mine_next_reports_unavailable_when_rpc_op_lock_is_poisoned() {
+        let (state, dir) = build_state_with_live_mining(true);
+        let rpc_lock = Arc::clone(&state.rpc_op_lock);
+        let _ = std::thread::spawn(move || {
+            let _guard = rpc_lock.lock().expect("lock");
+            panic!("poison rpc op lock");
+        })
+        .join();
+        let response = route_request(
+            &state,
+            HttpRequest {
+                method: "POST".to_string(),
+                target: "/mine_next".to_string(),
+                body: b"{}".to_vec(),
+            },
+        );
+        assert_eq!(response.status, 503);
+        assert_eq!(
+            response_json(&response)["error"].as_str(),
+            Some("rpc unavailable")
+        );
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn mine_next_reports_unavailable_when_sync_engine_is_poisoned() {
+        let (state, dir) = build_state_with_live_mining(true);
+        let sync_engine = Arc::clone(&state.sync_engine);
+        let _ = std::thread::spawn(move || {
+            let _guard = sync_engine.lock().expect("lock");
+            panic!("poison sync engine");
+        })
+        .join();
+        let response = route_request(
+            &state,
+            HttpRequest {
+                method: "POST".to_string(),
+                target: "/mine_next".to_string(),
+                body: b"{}".to_vec(),
+            },
+        );
+        assert_eq!(response.status, 503);
+        assert_eq!(
+            response_json(&response)["error"].as_str(),
+            Some("sync engine unavailable")
+        );
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn mine_next_reports_unavailable_when_tx_pool_is_poisoned() {
+        let (state, dir) = build_state_with_live_mining(true);
+        let tx_pool = Arc::clone(&state.tx_pool);
+        let _ = std::thread::spawn(move || {
+            let _guard = tx_pool.lock().expect("lock");
+            panic!("poison tx pool");
+        })
+        .join();
+        let response = route_request(
+            &state,
+            HttpRequest {
+                method: "POST".to_string(),
+                target: "/mine_next".to_string(),
+                body: b"{}".to_vec(),
+            },
+        );
+        assert_eq!(response.status, 503);
+        assert_eq!(
+            response_json(&response)["error"].as_str(),
+            Some("tx pool unavailable")
+        );
+        fs::remove_dir_all(dir).expect("cleanup");
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/lib.rs
+++ b/clients/rust/crates/rubin-node/src/lib.rs
@@ -32,7 +32,7 @@ pub use coinbase::{
 };
 pub use devnet_rpc::{
     new_devnet_rpc_state, new_devnet_rpc_state_with_tx_pool, new_shared_runtime_tx_pool,
-    start_devnet_rpc_server, DevnetRPCState, RunningDevnetRPCServer,
+    rpc_bind_host_is_loopback, start_devnet_rpc_server, DevnetRPCState, RunningDevnetRPCServer,
 };
 pub use genesis::{
     devnet_genesis_block_bytes, devnet_genesis_chain_id, load_chain_id_from_genesis_file,

--- a/clients/rust/crates/rubin-node/src/main.rs
+++ b/clients/rust/crates/rubin-node/src/main.rs
@@ -311,43 +311,42 @@ fn run(args: &[String], stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
         }
     }
 
-    let live_mining_cfg =
-        if cfg.network == "devnet"
-            && !cfg.rpc_bind_addr.trim().is_empty()
-            && rpc_bind_host_is_loopback(&cfg.rpc_bind_addr)
-        {
-            let mut miner_cfg = MinerConfig {
-                core_ext_deployments: genesis_cfg.core_ext_deployments.clone(),
-                ..MinerConfig::default()
-            };
-            let mut addr_invalid = false;
-            if let Some(ref value) = cfg.mine_address {
-                match parse_mine_address_arg(value) {
-                    Ok(Some(addr)) => miner_cfg.mine_address = addr,
-                    Ok(None) => {}
-                    Err(err) => {
-                        let _ = writeln!(
-                            stderr,
-                            "rpc: live mining disabled (invalid --mine-address): {err}"
-                        );
-                        addr_invalid = true;
-                    }
-                }
-            }
-            if addr_invalid {
-                None
-            } else {
-                match Miner::new(&mut sync_engine, None, miner_cfg.clone()) {
-                    Ok(_) => Some(miner_cfg),
-                    Err(err) => {
-                        let _ = writeln!(stderr, "rpc: live mining disabled: {err}");
-                        None
-                    }
-                }
-            }
-        } else {
-            None
+    let live_mining_cfg = if cfg.network == "devnet"
+        && !cfg.rpc_bind_addr.trim().is_empty()
+        && rpc_bind_host_is_loopback(&cfg.rpc_bind_addr)
+    {
+        let mut miner_cfg = MinerConfig {
+            core_ext_deployments: genesis_cfg.core_ext_deployments.clone(),
+            ..MinerConfig::default()
         };
+        let mut addr_invalid = false;
+        if let Some(ref value) = cfg.mine_address {
+            match parse_mine_address_arg(value) {
+                Ok(Some(addr)) => miner_cfg.mine_address = addr,
+                Ok(None) => {}
+                Err(err) => {
+                    let _ = writeln!(
+                        stderr,
+                        "rpc: live mining disabled (invalid --mine-address): {err}"
+                    );
+                    addr_invalid = true;
+                }
+            }
+        }
+        if addr_invalid {
+            None
+        } else {
+            match Miner::new(&mut sync_engine, None, miner_cfg.clone()) {
+                Ok(_) => Some(miner_cfg),
+                Err(err) => {
+                    let _ = writeln!(stderr, "rpc: live mining disabled: {err}");
+                    None
+                }
+            }
+        }
+    } else {
+        None
+    };
 
     let genesis_hash = match runtime_genesis_hash(&genesis_cfg) {
         Ok(hash) => hash,

--- a/clients/rust/crates/rubin-node/src/main.rs
+++ b/clients/rust/crates/rubin-node/src/main.rs
@@ -13,9 +13,9 @@ use rubin_consensus::{
 use rubin_node::{
     block_store_path, chain_state_path, default_peer_runtime_config, default_sync_config,
     load_chain_state, load_genesis_config, new_devnet_rpc_state_with_tx_pool,
-    new_shared_runtime_tx_pool, parse_mine_address_arg, start_devnet_rpc_server,
-    start_node_p2p_service, BlockStore, LoadedGenesisConfig, Miner, MinerConfig,
-    NodeP2PServiceConfig, PeerManager, SyncEngine,
+    new_shared_runtime_tx_pool, parse_mine_address_arg, rpc_bind_host_is_loopback,
+    start_devnet_rpc_server, start_node_p2p_service, BlockStore, LoadedGenesisConfig, Miner,
+    MinerConfig, NodeP2PServiceConfig, PeerManager, SyncEngine,
 };
 use serde::{Deserialize, Serialize};
 
@@ -310,6 +310,45 @@ fn run(args: &[String], stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
             return 0;
         }
     }
+
+    let live_mining_cfg =
+        if cfg.network == "devnet"
+            && !cfg.rpc_bind_addr.trim().is_empty()
+            && rpc_bind_host_is_loopback(&cfg.rpc_bind_addr)
+        {
+            let mut miner_cfg = MinerConfig {
+                core_ext_deployments: genesis_cfg.core_ext_deployments.clone(),
+                ..MinerConfig::default()
+            };
+            let mut addr_invalid = false;
+            if let Some(ref value) = cfg.mine_address {
+                match parse_mine_address_arg(value) {
+                    Ok(Some(addr)) => miner_cfg.mine_address = addr,
+                    Ok(None) => {}
+                    Err(err) => {
+                        let _ = writeln!(
+                            stderr,
+                            "rpc: live mining disabled (invalid --mine-address): {err}"
+                        );
+                        addr_invalid = true;
+                    }
+                }
+            }
+            if addr_invalid {
+                None
+            } else {
+                match Miner::new(&mut sync_engine, None, miner_cfg.clone()) {
+                    Ok(_) => Some(miner_cfg),
+                    Err(err) => {
+                        let _ = writeln!(stderr, "rpc: live mining disabled: {err}");
+                        None
+                    }
+                }
+            }
+        } else {
+            None
+        };
+
     let genesis_hash = match runtime_genesis_hash(&genesis_cfg) {
         Ok(hash) => hash,
         Err(err) => {
@@ -354,6 +393,7 @@ fn run(args: &[String], stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
         Arc::clone(&tx_pool),
         Arc::clone(&peer_manager),
         announce_tx,
+        live_mining_cfg,
     );
     let server = if cfg.rpc_bind_addr.trim().is_empty() {
         None

--- a/clients/rust/crates/rubin-node/src/p2p_service.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_service.rs
@@ -1581,16 +1581,39 @@ mod tests {
 
         thread::sleep(Duration::from_millis(150));
 
-        let stream = TcpStream::connect(service.addr()).expect("connect inbound");
         let local = local_version(0).expect("local version");
-        let session = perform_version_handshake(
-            stream,
-            runtime_cfg,
-            local,
-            local.chain_id,
-            local.genesis_hash,
-        )
-        .expect("inbound handshake must not be blocked by pending bootstrap dial");
+        let mut session = None;
+        let mut last_err: Option<std::io::Error> = None;
+        for attempt in 0..10 {
+            if attempt > 0 {
+                thread::sleep(Duration::from_millis(100));
+            }
+            let stream = match TcpStream::connect(service.addr()) {
+                Ok(s) => s,
+                Err(err) => {
+                    last_err = Some(err);
+                    continue;
+                }
+            };
+            match perform_version_handshake(
+                stream,
+                runtime_cfg.clone(),
+                local,
+                local.chain_id,
+                local.genesis_hash,
+            ) {
+                Ok(s) => {
+                    session = Some(s);
+                    break;
+                }
+                Err(err) => last_err = Some(err),
+            }
+        }
+        let session = session.unwrap_or_else(|| {
+            panic!(
+                "inbound handshake must not be blocked by pending bootstrap dial: last_err={last_err:?}"
+            )
+        });
         drop(session);
 
         service.close();

--- a/clients/rust/crates/rubin-node/src/p2p_service.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_service.rs
@@ -933,7 +933,7 @@ mod tests {
     use crate::p2p_runtime::{
         build_envelope_header, decode_inventory_vectors, default_peer_runtime_config,
         encode_inventory_vectors, network_magic, perform_version_handshake, InventoryVector,
-        LiveMessageOutcome, PeerManager, PeerRuntimeConfig, WireMessage, MSG_TX,
+        LiveMessageOutcome, PeerManager, PeerRuntimeConfig, VersionPayloadV1, WireMessage, MSG_TX,
     };
     use crate::sync_reorg::TxPoolCleanupPlan;
     use crate::tx_relay::PeerOutbox;
@@ -998,6 +998,39 @@ mod tests {
             thread::sleep(Duration::from_millis(25));
         }
         panic!("condition not reached before deadline");
+    }
+
+    /// Under LLVM coverage (tarpaulin), the first TCP handshake attempt on Darwin
+    /// can sporadically fail with `EINVAL`; retry preserves the behavioral assertion.
+    fn connect_handshake_with_retry(
+        mut connect_addr: impl FnMut() -> String,
+        runtime_cfg: PeerRuntimeConfig,
+        local: VersionPayloadV1,
+    ) -> crate::p2p_runtime::PeerSession {
+        let mut last_err: Option<std::io::Error> = None;
+        for attempt in 0..10 {
+            if attempt > 0 {
+                thread::sleep(Duration::from_millis(100));
+            }
+            let stream = match TcpStream::connect(connect_addr()) {
+                Ok(s) => s,
+                Err(err) => {
+                    last_err = Some(err);
+                    continue;
+                }
+            };
+            match perform_version_handshake(
+                stream,
+                runtime_cfg.clone(),
+                local,
+                local.chain_id,
+                local.genesis_hash,
+            ) {
+                Ok(session) => return session,
+                Err(err) => last_err = Some(err),
+            }
+        }
+        panic!("handshake failed after retries: last_err={last_err:?}");
     }
 
     #[test]
@@ -1489,16 +1522,9 @@ mod tests {
         })
         .expect("start service");
 
-        let stream = TcpStream::connect(service.addr()).expect("connect service");
         let local = local_version(0).expect("local version");
-        let session = perform_version_handshake(
-            stream,
-            runtime_cfg,
-            local,
-            local.chain_id,
-            local.genesis_hash,
-        )
-        .expect("handshake");
+        let session =
+            connect_handshake_with_retry(|| service.addr().to_string(), runtime_cfg.clone(), local);
         drop(session);
 
         service.close();
@@ -1582,38 +1608,8 @@ mod tests {
         thread::sleep(Duration::from_millis(150));
 
         let local = local_version(0).expect("local version");
-        let mut session = None;
-        let mut last_err: Option<std::io::Error> = None;
-        for attempt in 0..10 {
-            if attempt > 0 {
-                thread::sleep(Duration::from_millis(100));
-            }
-            let stream = match TcpStream::connect(service.addr()) {
-                Ok(s) => s,
-                Err(err) => {
-                    last_err = Some(err);
-                    continue;
-                }
-            };
-            match perform_version_handshake(
-                stream,
-                runtime_cfg.clone(),
-                local,
-                local.chain_id,
-                local.genesis_hash,
-            ) {
-                Ok(s) => {
-                    session = Some(s);
-                    break;
-                }
-                Err(err) => last_err = Some(err),
-            }
-        }
-        let session = session.unwrap_or_else(|| {
-            panic!(
-                "inbound handshake must not be blocked by pending bootstrap dial: last_err={last_err:?}"
-            )
-        });
+        let session =
+            connect_handshake_with_retry(|| service.addr().to_string(), runtime_cfg.clone(), local);
         drop(session);
 
         service.close();


### PR DESCRIPTION
**Task anchor:** Q-IMPL-NODE-DEVNET-LIVE-MINING-SURFACE-01 (canonical queue `inbox/QUEUE.md:63`, linked to issue #1146)

### Gate snapshot

| Gate | State |
|---|---|
| CI checks | **21/21 pass** (Codacy×3, CodeQL×3, Kani, Go race, coverage, formal×2, policy, runtime-perf, security_ai, claude, test, bot-review-gate×2, validator, workflow-hygiene, sanity, dependency×2, duplication) |
| Review threads | **0/6 unresolved** (7 Copilot + 1 Codex, all resolved before takeover) |
| Mergeable | `true` (0 behind main) |
| HEAD | `a1142634df9eaf5fbe954bb7241f811c3e19fe1c` |

### Task acceptance (from Q-IMPL-NODE-DEVNET-LIVE-MINING-SURFACE-01 task spec)

- [x] Go node can mine next block after `submit_tx` without process restart (`POST /mine_next` in `http_rpc.go`)
- [x] Rust node can mine next block after `submit_tx` without process restart (`mine_next` handler in `devnet_rpc.rs`)
- [x] Go/Rust parity on enablement boundary, response shape, failure classes (both clients share `rpc_op_lock` serialization + loopback-only bind check + live_mining_cfg guard)
- [x] New surface fails closed outside localhost/devnet context (`rpc_bind_host_is_loopback` enforced: loopback host required, empty port rejected, non-`u16` port rejected, bare IPv6 without brackets rejected; port `0` accepted as ephemeral bind — [clarification comment](https://github.com/2tbmz9y2xt-lang/rubin-protocol/pull/1198#issuecomment-4252769222))
- [x] Cancellable/non-blocking runtime integration (lock order: live-miner check before rpcMut in Go `handleMineNext` to avoid blocking concurrent `submit_tx`)

