### PR TITLE
feat: devnet RPC tx lifecycle visibility (get_mempool, get_tx, tx_status)

### DIFF
--- a/clients/go/cmd/rubin-node/http_rpc.go
+++ b/clients/go/cmd/rubin-node/http_rpc.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/hex"
 	"encoding/json"
@@ -78,6 +79,25 @@ type mineNextResponse struct {
 	Nonce     *uint64 `json:"nonce,omitempty"`
 	TxCount   *int    `json:"tx_count,omitempty"`
 	Error     string  `json:"error,omitempty"`
+}
+
+type getMempoolResponse struct {
+	Count int      `json:"count"`
+	TxIDs []string `json:"txids"`
+	Error string   `json:"error,omitempty"`
+}
+
+type getTxResponse struct {
+	Found  bool    `json:"found"`
+	TxID   string  `json:"txid,omitempty"`
+	RawHex *string `json:"raw_hex,omitempty"`
+	Error  string  `json:"error,omitempty"`
+}
+
+type txStatusResponse struct {
+	Status string `json:"status"`
+	TxID   string `json:"txid,omitempty"`
+	Error  string `json:"error,omitempty"`
 }
 
 func newDevnetRPCState(
@@ -230,6 +250,15 @@ func newDevnetRPCHandler(state *devnetRPCState) http.Handler {
 	})
 	mux.HandleFunc("/mine_next", func(w http.ResponseWriter, r *http.Request) {
 		handleMineNext(state, w, r)
+	})
+	mux.HandleFunc("/get_mempool", func(w http.ResponseWriter, r *http.Request) {
+		handleGetMempool(state, w, r)
+	})
+	mux.HandleFunc("/get_tx", func(w http.ResponseWriter, r *http.Request) {
+		handleGetTx(state, w, r)
+	})
+	mux.HandleFunc("/tx_status", func(w http.ResponseWriter, r *http.Request) {
+		handleTxStatus(state, w, r)
 	})
 	mux.HandleFunc("/metrics", func(w http.ResponseWriter, r *http.Request) {
 		handleMetrics(state, w, r)
@@ -520,6 +549,134 @@ func handleMineNext(state *devnetRPCState, w http.ResponseWriter, r *http.Reques
 		Timestamp: &ts,
 		Nonce:     &nonce,
 		TxCount:   &txCount,
+	})
+}
+
+// parseTxIDQuery decodes a 64-hex-char "txid" query parameter into a [32]byte.
+// Returns an error if the parameter is missing, has wrong length, or decodes
+// to non-hex bytes.
+func parseTxIDQuery(r *http.Request) ([32]byte, error) {
+	var txid [32]byte
+	raw := r.URL.Query().Get("txid")
+	if raw == "" {
+		return txid, fmt.Errorf("missing required query parameter: txid")
+	}
+	if len(raw) != 64 {
+		return txid, fmt.Errorf("txid must be 64 hex characters (got %d)", len(raw))
+	}
+	decoded, err := hex.DecodeString(raw)
+	if err != nil {
+		return txid, fmt.Errorf("txid is not valid hex: %w", err)
+	}
+	copy(txid[:], decoded)
+	return txid, nil
+}
+
+func handleGetMempool(state *devnetRPCState, w http.ResponseWriter, r *http.Request) {
+	const route = "/get_mempool"
+	if r.Method != http.MethodGet {
+		writeJSONResponse(state, route, w, http.StatusBadRequest, getMempoolResponse{
+			Count: 0,
+			TxIDs: []string{},
+			Error: "GET required",
+		})
+		return
+	}
+	if state == nil || state.mempool == nil {
+		writeJSONResponse(state, route, w, http.StatusServiceUnavailable, getMempoolResponse{
+			Count: 0,
+			TxIDs: []string{},
+			Error: "mempool unavailable",
+		})
+		return
+	}
+	ids := state.mempool.AllTxIDs()
+	// Sort for deterministic response ordering (AllTxIDs order is not stable
+	// because the underlying map iteration is randomized).
+	sort.Slice(ids, func(i, j int) bool { return bytes.Compare(ids[i][:], ids[j][:]) < 0 })
+	txids := make([]string, 0, len(ids))
+	for _, id := range ids {
+		txids = append(txids, hex.EncodeToString(id[:]))
+	}
+	writeJSONResponse(state, route, w, http.StatusOK, getMempoolResponse{
+		Count: len(txids),
+		TxIDs: txids,
+	})
+}
+
+func handleGetTx(state *devnetRPCState, w http.ResponseWriter, r *http.Request) {
+	const route = "/get_tx"
+	if r.Method != http.MethodGet {
+		writeJSONResponse(state, route, w, http.StatusBadRequest, getTxResponse{
+			Found: false,
+			Error: "GET required",
+		})
+		return
+	}
+	txid, err := parseTxIDQuery(r)
+	if err != nil {
+		writeJSONResponse(state, route, w, http.StatusBadRequest, getTxResponse{
+			Found: false,
+			Error: err.Error(),
+		})
+		return
+	}
+	if state == nil || state.mempool == nil {
+		writeJSONResponse(state, route, w, http.StatusServiceUnavailable, getTxResponse{
+			Found: false,
+			TxID:  hex.EncodeToString(txid[:]),
+			Error: "mempool unavailable",
+		})
+		return
+	}
+	raw, ok := state.mempool.TxByID(txid)
+	if !ok {
+		writeJSONResponse(state, route, w, http.StatusOK, getTxResponse{
+			Found: false,
+			TxID:  hex.EncodeToString(txid[:]),
+		})
+		return
+	}
+	rawHex := hex.EncodeToString(raw)
+	writeJSONResponse(state, route, w, http.StatusOK, getTxResponse{
+		Found:  true,
+		TxID:   hex.EncodeToString(txid[:]),
+		RawHex: &rawHex,
+	})
+}
+
+func handleTxStatus(state *devnetRPCState, w http.ResponseWriter, r *http.Request) {
+	const route = "/tx_status"
+	if r.Method != http.MethodGet {
+		writeJSONResponse(state, route, w, http.StatusBadRequest, txStatusResponse{
+			Status: "missing",
+			Error:  "GET required",
+		})
+		return
+	}
+	txid, err := parseTxIDQuery(r)
+	if err != nil {
+		writeJSONResponse(state, route, w, http.StatusBadRequest, txStatusResponse{
+			Status: "missing",
+			Error:  err.Error(),
+		})
+		return
+	}
+	if state == nil || state.mempool == nil {
+		writeJSONResponse(state, route, w, http.StatusServiceUnavailable, txStatusResponse{
+			Status: "missing",
+			TxID:   hex.EncodeToString(txid[:]),
+			Error:  "mempool unavailable",
+		})
+		return
+	}
+	status := "missing"
+	if state.mempool.Contains(txid) {
+		status = "pending"
+	}
+	writeJSONResponse(state, route, w, http.StatusOK, txStatusResponse{
+		Status: status,
+		TxID:   hex.EncodeToString(txid[:]),
 	})
 }
 

--- a/clients/go/cmd/rubin-node/http_rpc.go
+++ b/clients/go/cmd/rubin-node/http_rpc.go
@@ -613,19 +613,22 @@ func handleGetTx(state *devnetRPCState, w http.ResponseWriter, r *http.Request) 
 		})
 		return
 	}
+	// Fail closed on mempool unavailability BEFORE parsing query parameters,
+	// so an invalid/missing txid on an unavailable mempool still surfaces as
+	// 503 (matching the contract shared by /get_block, /submit_tx, and other
+	// handlers). Parsing first would mask unavailability behind a 400.
+	if state == nil || state.mempool == nil {
+		writeJSONResponse(state, route, w, http.StatusServiceUnavailable, getTxResponse{
+			Found: false,
+			Error: "mempool unavailable",
+		})
+		return
+	}
 	txid, err := parseTxIDQuery(r)
 	if err != nil {
 		writeJSONResponse(state, route, w, http.StatusBadRequest, getTxResponse{
 			Found: false,
 			Error: err.Error(),
-		})
-		return
-	}
-	if state == nil || state.mempool == nil {
-		writeJSONResponse(state, route, w, http.StatusServiceUnavailable, getTxResponse{
-			Found: false,
-			TxID:  hex.EncodeToString(txid[:]),
-			Error: "mempool unavailable",
 		})
 		return
 	}
@@ -654,19 +657,20 @@ func handleTxStatus(state *devnetRPCState, w http.ResponseWriter, r *http.Reques
 		})
 		return
 	}
+	// Fail closed on mempool unavailability BEFORE parsing query parameters
+	// (matches handleGetTx and the contract of /get_block, /submit_tx).
+	if state == nil || state.mempool == nil {
+		writeJSONResponse(state, route, w, http.StatusServiceUnavailable, txStatusResponse{
+			Status: "missing",
+			Error:  "mempool unavailable",
+		})
+		return
+	}
 	txid, err := parseTxIDQuery(r)
 	if err != nil {
 		writeJSONResponse(state, route, w, http.StatusBadRequest, txStatusResponse{
 			Status: "missing",
 			Error:  err.Error(),
-		})
-		return
-	}
-	if state == nil || state.mempool == nil {
-		writeJSONResponse(state, route, w, http.StatusServiceUnavailable, txStatusResponse{
-			Status: "missing",
-			TxID:   hex.EncodeToString(txid[:]),
-			Error:  "mempool unavailable",
 		})
 		return
 	}

--- a/clients/go/cmd/rubin-node/http_rpc_test.go
+++ b/clients/go/cmd/rubin-node/http_rpc_test.go
@@ -1348,3 +1348,38 @@ func TestDevnetRPCTxStatusUnavailableOnNilState(t *testing.T) {
 	}
 }
 
+
+func TestDevnetRPCGetTxEmptyTxIDValueIsClassifiedAsMissing(t *testing.T) {
+	// Go/Rust parity regression: ?txid= (present but empty value) must be
+	// classified as missing parameter in BOTH clients.
+	req := httptest.NewRequest(http.MethodGet, "/get_tx?txid=", nil)
+	rec := httptest.NewRecorder()
+	handleGetTx(mustRPCState(t, true), rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d, want 400", rec.Code)
+	}
+	var got getTxResponse
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if !strings.Contains(got.Error, "missing required query parameter") {
+		t.Fatalf("Error=%q, want 'missing required query parameter' to match Rust parity", got.Error)
+	}
+}
+
+func TestDevnetRPCTxStatusEmptyTxIDValueIsClassifiedAsMissing(t *testing.T) {
+	// Parity sibling for tx_status.
+	req := httptest.NewRequest(http.MethodGet, "/tx_status?txid=", nil)
+	rec := httptest.NewRecorder()
+	handleTxStatus(mustRPCState(t, true), rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d, want 400", rec.Code)
+	}
+	var got txStatusResponse
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if !strings.Contains(got.Error, "missing required query parameter") {
+		t.Fatalf("Error=%q, want 'missing required query parameter' to match Rust parity", got.Error)
+	}
+}

--- a/clients/go/cmd/rubin-node/http_rpc_test.go
+++ b/clients/go/cmd/rubin-node/http_rpc_test.go
@@ -1414,3 +1414,42 @@ func TestDevnetRPCGetTxValuelessTxIDKeyClassifiedAsMissing(t *testing.T) {
 		t.Fatalf("Error=%q, want 'missing required query parameter' (first-match semantic)", got.Error)
 	}
 }
+
+func TestDevnetRPCGetTxFailsClosedOn503BeforeParsingInvalidTxID(t *testing.T) {
+	// Contract: mempool unavailability is a 503 fail-closed regardless of
+	// query-string validity. A nil mempool + invalid txid MUST return 503
+	// (not 400). Previously handleGetTx parsed first and returned 400 on
+	// bad query, masking the unavailability. Copilot thread
+	// PRRT_kwDORQ3qGs57N-UC flagged this ordering bug.
+	req := httptest.NewRequest(http.MethodGet, "/get_tx?txid=invalid-not-hex", nil)
+	rec := httptest.NewRecorder()
+	handleGetTx(nil, rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d, want 503 (mempool unavailable fail-closed takes precedence over 400 parse-error)", rec.Code)
+	}
+	var got getTxResponse
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if !strings.Contains(got.Error, "mempool unavailable") {
+		t.Fatalf("Error=%q, want 'mempool unavailable'", got.Error)
+	}
+}
+
+func TestDevnetRPCTxStatusFailsClosedOn503BeforeParsingInvalidTxID(t *testing.T) {
+	// Parity sibling of the handleGetTx ordering fix. Copilot thread
+	// PRRT_kwDORQ3qGs57N-UX.
+	req := httptest.NewRequest(http.MethodGet, "/tx_status?txid=invalid-not-hex", nil)
+	rec := httptest.NewRecorder()
+	handleTxStatus(nil, rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d, want 503", rec.Code)
+	}
+	var got txStatusResponse
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if !strings.Contains(got.Error, "mempool unavailable") {
+		t.Fatalf("Error=%q, want 'mempool unavailable'", got.Error)
+	}
+}

--- a/clients/go/cmd/rubin-node/http_rpc_test.go
+++ b/clients/go/cmd/rubin-node/http_rpc_test.go
@@ -1348,7 +1348,6 @@ func TestDevnetRPCTxStatusUnavailableOnNilState(t *testing.T) {
 	}
 }
 
-
 func TestDevnetRPCGetTxEmptyTxIDValueIsClassifiedAsMissing(t *testing.T) {
 	// Go/Rust parity regression: ?txid= (present but empty value) must be
 	// classified as missing parameter in BOTH clients.

--- a/clients/go/cmd/rubin-node/http_rpc_test.go
+++ b/clients/go/cmd/rubin-node/http_rpc_test.go
@@ -12,7 +12,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -1112,40 +1111,6 @@ func TestDevnetRPCGetMempoolRejectsBadMethod(t *testing.T) {
 	handleGetMempool(mustRPCState(t, true), rec, req)
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("status=%d, want 400", rec.Code)
-	}
-}
-
-func TestDevnetRPCGetMempoolSortedMultiTx(t *testing.T) {
-	state := mustRPCState(t, true)
-	// Inject 3 txids in reverse-lex order to exercise handler sort.
-	ids := [][32]byte{{}, {}, {}}
-	for i := range ids[0] {
-		ids[0][i] = 0xcc
-	}
-	for i := range ids[1] {
-		ids[1][i] = 0xaa
-	}
-	for i := range ids[2] {
-		ids[2][i] = 0xbb
-	}
-	for _, id := range ids {
-		state.mempool.InjectTestEntryRaw(id, []byte{0x00})
-	}
-	req := httptest.NewRequest(http.MethodGet, "/get_mempool", nil)
-	rec := httptest.NewRecorder()
-	handleGetMempool(state, rec, req)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status=%d, want 200", rec.Code)
-	}
-	var got getMempoolResponse
-	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
-		t.Fatalf("Decode: %v", err)
-	}
-	if got.Count != 3 {
-		t.Fatalf("Count=%d, want 3", got.Count)
-	}
-	if !sort.StringsAreSorted(got.TxIDs) {
-		t.Fatalf("TxIDs not sorted: %v", got.TxIDs)
 	}
 }
 

--- a/clients/go/cmd/rubin-node/http_rpc_test.go
+++ b/clients/go/cmd/rubin-node/http_rpc_test.go
@@ -1382,3 +1382,35 @@ func TestDevnetRPCTxStatusEmptyTxIDValueIsClassifiedAsMissing(t *testing.T) {
 		t.Fatalf("Error=%q, want 'missing required query parameter' to match Rust parity", got.Error)
 	}
 }
+
+func TestDevnetRPCGetTxValuelessTxIDKeyClassifiedAsMissing(t *testing.T) {
+	// Go/Rust parity regression (Codex thread PRRT_kwDORQ3qGs57NpSB):
+	// ?txid (key without `=`) or ?txid&txid=<hex> — Go's net/url parses a
+	// key without `=` into url.Values{"txid":[""]}, so Query().Get returns
+	// "" (missing). Rust parser must match: treat key without `=` as
+	// present-with-empty, classify as missing, first-match semantic (never
+	// accept a later duplicate-key value).
+	validHex := strings.Repeat("ab", 32)
+	// Case 1: ?txid (no value, no duplicate)
+	req := httptest.NewRequest(http.MethodGet, "/get_tx?txid", nil)
+	rec := httptest.NewRecorder()
+	handleGetTx(mustRPCState(t, true), rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("case ?txid status=%d, want 400", rec.Code)
+	}
+	// Case 2: ?txid&txid=<valid hex> — first key is valueless, Rust must
+	// reject as missing (not accept the second key's hex).
+	req2 := httptest.NewRequest(http.MethodGet, "/get_tx?txid&txid="+validHex, nil)
+	rec2 := httptest.NewRecorder()
+	handleGetTx(mustRPCState(t, true), rec2, req2)
+	if rec2.Code != http.StatusBadRequest {
+		t.Fatalf("case ?txid&txid=<hex> status=%d, want 400 (first-match semantic)", rec2.Code)
+	}
+	var got getTxResponse
+	if err := json.NewDecoder(rec2.Body).Decode(&got); err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if !strings.Contains(got.Error, "missing required query parameter") {
+		t.Fatalf("Error=%q, want 'missing required query parameter' (first-match semantic)", got.Error)
+	}
+}

--- a/clients/go/cmd/rubin-node/http_rpc_test.go
+++ b/clients/go/cmd/rubin-node/http_rpc_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -1111,6 +1112,40 @@ func TestDevnetRPCGetMempoolRejectsBadMethod(t *testing.T) {
 	handleGetMempool(mustRPCState(t, true), rec, req)
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("status=%d, want 400", rec.Code)
+	}
+}
+
+func TestDevnetRPCGetMempoolSortedMultiTx(t *testing.T) {
+	state := mustRPCState(t, true)
+	// Inject 3 txids in reverse-lex order to exercise handler sort.
+	ids := [][32]byte{{}, {}, {}}
+	for i := range ids[0] {
+		ids[0][i] = 0xcc
+	}
+	for i := range ids[1] {
+		ids[1][i] = 0xaa
+	}
+	for i := range ids[2] {
+		ids[2][i] = 0xbb
+	}
+	for _, id := range ids {
+		state.mempool.InjectTestEntryRaw(id, []byte{0x00})
+	}
+	req := httptest.NewRequest(http.MethodGet, "/get_mempool", nil)
+	rec := httptest.NewRecorder()
+	handleGetMempool(state, rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d, want 200", rec.Code)
+	}
+	var got getMempoolResponse
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if got.Count != 3 {
+		t.Fatalf("Count=%d, want 3", got.Count)
+	}
+	if !sort.StringsAreSorted(got.TxIDs) {
+		t.Fatalf("TxIDs not sorted: %v", got.TxIDs)
 	}
 }
 

--- a/clients/go/cmd/rubin-node/http_rpc_test.go
+++ b/clients/go/cmd/rubin-node/http_rpc_test.go
@@ -1348,34 +1348,3 @@ func TestDevnetRPCTxStatusUnavailableOnNilState(t *testing.T) {
 	}
 }
 
-func TestDevnetRPCGetMempoolSortedDeterministic(t *testing.T) {
-	fromKey := mustRPCMLDSA87Keypair(t)
-	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
-	state, _, _ := mustRPCStateWithSpendableUTXO(t, fromAddress, nil)
-
-	// Inject txids directly to bypass mempool admission (cheap test for sort
-	// behavior; does not need real tx bytes since AllTxIDs just returns keys).
-	// Use three synthetic txids in non-sorted order.
-	type withRaw interface{ Len() int }
-	_ = withRaw(state.mempool) // ensure interface compiles
-
-	req := httptest.NewRequest(http.MethodGet, "/get_mempool", nil)
-	rec := httptest.NewRecorder()
-	handleGetMempool(state, rec, req)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status=%d, want 200", rec.Code)
-	}
-	var got getMempoolResponse
-	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
-		t.Fatalf("Decode: %v", err)
-	}
-	// empty mempool → empty txids, trivially sorted
-	if got.TxIDs == nil {
-		t.Fatalf("TxIDs=nil, want empty slice")
-	}
-	for i := 1; i < len(got.TxIDs); i++ {
-		if got.TxIDs[i-1] >= got.TxIDs[i] {
-			t.Fatalf("TxIDs not strictly sorted: %v", got.TxIDs)
-		}
-	}
-}

--- a/clients/go/cmd/rubin-node/http_rpc_test.go
+++ b/clients/go/cmd/rubin-node/http_rpc_test.go
@@ -1077,3 +1077,157 @@ func TestDevnetRPCMineNextMinesAfterGenesis(t *testing.T) {
 		t.Fatalf("want nonce field in JSON for Go/Rust RPC parity, got %+v", got)
 	}
 }
+
+func TestDevnetRPCGetMempoolEmpty(t *testing.T) {
+	server := httptest.NewServer(newDevnetRPCHandler(mustRPCState(t, true)))
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/get_mempool")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d, want 200", resp.StatusCode)
+	}
+	var got getMempoolResponse
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if got.Count != 0 {
+		t.Fatalf("Count=%d, want 0", got.Count)
+	}
+	if got.TxIDs == nil {
+		t.Fatalf("TxIDs=nil, want empty slice (must serialize as [] not null)")
+	}
+	if len(got.TxIDs) != 0 {
+		t.Fatalf("TxIDs=%v, want empty", got.TxIDs)
+	}
+}
+
+func TestDevnetRPCGetMempoolRejectsBadMethod(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/get_mempool", nil)
+	rec := httptest.NewRecorder()
+	handleGetMempool(mustRPCState(t, true), rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d, want 400", rec.Code)
+	}
+}
+
+func TestDevnetRPCGetMempoolUnavailableOnNilState(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/get_mempool", nil)
+	rec := httptest.NewRecorder()
+	handleGetMempool(nil, rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d, want 503", rec.Code)
+	}
+}
+
+func TestDevnetRPCGetTxRejectsMissingTxIDParam(t *testing.T) {
+	server := httptest.NewServer(newDevnetRPCHandler(mustRPCState(t, true)))
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/get_tx")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status=%d, want 400", resp.StatusCode)
+	}
+	var got getTxResponse
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if got.Found {
+		t.Fatalf("Found=true, want false for missing txid param")
+	}
+	if got.Error == "" {
+		t.Fatalf("Error empty, want missing-txid message")
+	}
+}
+
+func TestDevnetRPCGetTxRejectsInvalidLength(t *testing.T) {
+	server := httptest.NewServer(newDevnetRPCHandler(mustRPCState(t, true)))
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/get_tx?txid=deadbeef")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status=%d, want 400", resp.StatusCode)
+	}
+}
+
+func TestDevnetRPCGetTxRejectsNonHex(t *testing.T) {
+	server := httptest.NewServer(newDevnetRPCHandler(mustRPCState(t, true)))
+	defer server.Close()
+
+	badTxid := strings.Repeat("z", 64)
+	resp, err := http.Get(server.URL + "/get_tx?txid=" + badTxid)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status=%d, want 400", resp.StatusCode)
+	}
+}
+
+func TestDevnetRPCGetTxMissingReturnsFoundFalse(t *testing.T) {
+	server := httptest.NewServer(newDevnetRPCHandler(mustRPCState(t, true)))
+	defer server.Close()
+
+	unknownTxid := strings.Repeat("11", 32)
+	resp, err := http.Get(server.URL + "/get_tx?txid=" + unknownTxid)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d, want 200", resp.StatusCode)
+	}
+	var got getTxResponse
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if got.Found {
+		t.Fatalf("Found=true, want false for unknown txid")
+	}
+	if got.TxID != unknownTxid {
+		t.Fatalf("TxID=%q, want echoed input", got.TxID)
+	}
+}
+
+func TestDevnetRPCTxStatusMissingReturnsMissing(t *testing.T) {
+	server := httptest.NewServer(newDevnetRPCHandler(mustRPCState(t, true)))
+	defer server.Close()
+
+	unknownTxid := strings.Repeat("22", 32)
+	resp, err := http.Get(server.URL + "/tx_status?txid=" + unknownTxid)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d, want 200", resp.StatusCode)
+	}
+	var got txStatusResponse
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if got.Status != "missing" {
+		t.Fatalf("Status=%q, want missing", got.Status)
+	}
+}
+
+func TestDevnetRPCTxStatusRejectsInvalidTxID(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/tx_status?txid=not-hex", nil)
+	rec := httptest.NewRecorder()
+	handleTxStatus(mustRPCState(t, true), rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d, want 400", rec.Code)
+	}
+}

--- a/clients/go/cmd/rubin-node/http_rpc_test.go
+++ b/clients/go/cmd/rubin-node/http_rpc_test.go
@@ -1231,3 +1231,151 @@ func TestDevnetRPCTxStatusRejectsInvalidTxID(t *testing.T) {
 		t.Fatalf("status=%d, want 400", rec.Code)
 	}
 }
+
+func TestDevnetRPCTxLifecyclePendingHappyPath(t *testing.T) {
+	fromKey := mustRPCMLDSA87Keypair(t)
+	toKey := mustRPCMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+
+	state, input, utxos := mustRPCStateWithSpendableUTXO(t, fromAddress, nil)
+	txBytes, wantTxID := mustRPCSignedTransferTx(t, utxos, input, fromKey, toAddress)
+	server := httptest.NewServer(newDevnetRPCHandler(state))
+	defer server.Close()
+
+	// submit
+	body, err := json.Marshal(submitTxRequest{TxHex: hex.EncodeToString(txBytes)})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	resp, err := http.Post(server.URL+"/submit_tx", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("Post: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("submit status=%d, want 200", resp.StatusCode)
+	}
+
+	// get_mempool — count=1 with the submitted txid
+	mpResp, err := http.Get(server.URL + "/get_mempool")
+	if err != nil {
+		t.Fatalf("Get mempool: %v", err)
+	}
+	defer mpResp.Body.Close()
+	var mp getMempoolResponse
+	if err := json.NewDecoder(mpResp.Body).Decode(&mp); err != nil {
+		t.Fatalf("Decode mempool: %v", err)
+	}
+	if mp.Count != 1 {
+		t.Fatalf("mempool count=%d, want 1", mp.Count)
+	}
+	if len(mp.TxIDs) != 1 || mp.TxIDs[0] != wantTxID {
+		t.Fatalf("mempool txids=%v, want [%q]", mp.TxIDs, wantTxID)
+	}
+
+	// get_tx — found=true, raw_hex matches
+	txResp, err := http.Get(server.URL + "/get_tx?txid=" + wantTxID)
+	if err != nil {
+		t.Fatalf("Get tx: %v", err)
+	}
+	defer txResp.Body.Close()
+	var gx getTxResponse
+	if err := json.NewDecoder(txResp.Body).Decode(&gx); err != nil {
+		t.Fatalf("Decode tx: %v", err)
+	}
+	if !gx.Found {
+		t.Fatalf("Found=false, want true")
+	}
+	if gx.TxID != wantTxID {
+		t.Fatalf("TxID=%q, want %q", gx.TxID, wantTxID)
+	}
+	if gx.RawHex == nil || *gx.RawHex != hex.EncodeToString(txBytes) {
+		t.Fatalf("RawHex mismatch: got=%v want=%q", gx.RawHex, hex.EncodeToString(txBytes))
+	}
+
+	// tx_status — pending
+	stResp, err := http.Get(server.URL + "/tx_status?txid=" + wantTxID)
+	if err != nil {
+		t.Fatalf("Get tx_status: %v", err)
+	}
+	defer stResp.Body.Close()
+	var st txStatusResponse
+	if err := json.NewDecoder(stResp.Body).Decode(&st); err != nil {
+		t.Fatalf("Decode tx_status: %v", err)
+	}
+	if st.Status != "pending" {
+		t.Fatalf("Status=%q, want pending", st.Status)
+	}
+	if st.TxID != wantTxID {
+		t.Fatalf("TxID=%q, want %q", st.TxID, wantTxID)
+	}
+}
+
+func TestDevnetRPCGetTxRejectsBadMethod(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/get_tx?txid="+strings.Repeat("1", 64), nil)
+	rec := httptest.NewRecorder()
+	handleGetTx(mustRPCState(t, true), rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d, want 400", rec.Code)
+	}
+}
+
+func TestDevnetRPCGetTxUnavailableOnNilState(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/get_tx?txid="+strings.Repeat("1", 64), nil)
+	rec := httptest.NewRecorder()
+	handleGetTx(nil, rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d, want 503", rec.Code)
+	}
+}
+
+func TestDevnetRPCTxStatusRejectsBadMethod(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/tx_status?txid="+strings.Repeat("1", 64), nil)
+	rec := httptest.NewRecorder()
+	handleTxStatus(mustRPCState(t, true), rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d, want 400", rec.Code)
+	}
+}
+
+func TestDevnetRPCTxStatusUnavailableOnNilState(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/tx_status?txid="+strings.Repeat("1", 64), nil)
+	rec := httptest.NewRecorder()
+	handleTxStatus(nil, rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d, want 503", rec.Code)
+	}
+}
+
+func TestDevnetRPCGetMempoolSortedDeterministic(t *testing.T) {
+	fromKey := mustRPCMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	state, _, _ := mustRPCStateWithSpendableUTXO(t, fromAddress, nil)
+
+	// Inject txids directly to bypass mempool admission (cheap test for sort
+	// behavior; does not need real tx bytes since AllTxIDs just returns keys).
+	// Use three synthetic txids in non-sorted order.
+	type withRaw interface{ Len() int }
+	_ = withRaw(state.mempool) // ensure interface compiles
+
+	req := httptest.NewRequest(http.MethodGet, "/get_mempool", nil)
+	rec := httptest.NewRecorder()
+	handleGetMempool(state, rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d, want 200", rec.Code)
+	}
+	var got getMempoolResponse
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	// empty mempool → empty txids, trivially sorted
+	if got.TxIDs == nil {
+		t.Fatalf("TxIDs=nil, want empty slice")
+	}
+	for i := 1; i < len(got.TxIDs); i++ {
+		if got.TxIDs[i-1] >= got.TxIDs[i] {
+			t.Fatalf("TxIDs not strictly sorted: %v", got.TxIDs)
+		}
+	}
+}

--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -214,19 +214,6 @@ func (m *Mempool) Contains(txid [32]byte) bool {
 	return ok
 }
 
-// InjectTestEntryRaw inserts a minimal entry into the mempool without
-// transaction validation.  Exported for cross-package handler tests that
-// need a populated pool without constructing valid signed transactions.
-func (m *Mempool) InjectTestEntryRaw(txid [32]byte, raw []byte) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.txs[txid] = &mempoolEntry{
-		raw:  append([]byte(nil), raw...),
-		txid: txid,
-		size: len(raw),
-	}
-}
-
 func (m *Mempool) AddTx(txBytes []byte) error {
 	if m == nil {
 		return txAdmitUnavailable("nil mempool")

--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -214,6 +214,19 @@ func (m *Mempool) Contains(txid [32]byte) bool {
 	return ok
 }
 
+// InjectTestEntryRaw inserts a minimal entry into the mempool without
+// transaction validation.  Exported for cross-package handler tests that
+// need a populated pool without constructing valid signed transactions.
+func (m *Mempool) InjectTestEntryRaw(txid [32]byte, raw []byte) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.txs[txid] = &mempoolEntry{
+		raw:  append([]byte(nil), raw...),
+		txid: txid,
+		size: len(raw),
+	}
+}
+
 func (m *Mempool) AddTx(txBytes []byte) error {
 	if m == nil {
 		return txAdmitUnavailable("nil mempool")

--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -169,6 +169,51 @@ func (m *Mempool) Len() int {
 	return len(m.txs)
 }
 
+// AllTxIDs returns the txids of every transaction currently in the mempool.
+// The slice ordering is not guaranteed to be stable between calls.
+func (m *Mempool) AllTxIDs() [][32]byte {
+	if m == nil {
+		return nil
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	ids := make([][32]byte, 0, len(m.txs))
+	for txid := range m.txs {
+		ids = append(ids, txid)
+	}
+	return ids
+}
+
+// TxByID returns the raw transaction bytes of a mempool entry with the given
+// txid. The returned slice is a defensive copy and safe for the caller to
+// retain or mutate. Returns (nil, false) if no matching entry is present.
+func (m *Mempool) TxByID(txid [32]byte) ([]byte, bool) {
+	if m == nil {
+		return nil, false
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	entry, ok := m.txs[txid]
+	if !ok {
+		return nil, false
+	}
+	raw := make([]byte, len(entry.raw))
+	copy(raw, entry.raw)
+	return raw, true
+}
+
+// Contains reports whether a transaction with the given txid is currently
+// present in the mempool.
+func (m *Mempool) Contains(txid [32]byte) bool {
+	if m == nil {
+		return false
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	_, ok := m.txs[txid]
+	return ok
+}
+
 func (m *Mempool) AddTx(txBytes []byte) error {
 	if m == nil {
 		return txAdmitUnavailable("nil mempool")

--- a/clients/go/node/mempool_test.go
+++ b/clients/go/node/mempool_test.go
@@ -3,9 +3,11 @@ package node
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"reflect"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -1403,6 +1405,50 @@ func TestMempoolAllTxIDsReturnsEveryEntry(t *testing.T) {
 	for _, id := range got {
 		if _, ok := want[id]; !ok {
 			t.Fatalf("AllTxIDs returned unexpected txid %x", id)
+		}
+	}
+}
+
+func TestMempoolAllTxIDsSortedDeterministic(t *testing.T) {
+	// Copilot thread on PR #1199: verify that sorting AllTxIDs produces
+	// deterministic lexicographic order (handler sorts; this test proves
+	// the data is sortable and the result matches expectation).
+	fromKey := mustNodeMLDSA87Keypair(t)
+	toKey := mustNodeMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{100, 100, 100})
+
+	mp, err := NewMempool(st, nil, devnetGenesisChainID)
+	if err != nil {
+		t.Fatalf("new mempool: %v", err)
+	}
+	var ids [][32]byte
+	for i := 0; i < 3; i++ {
+		txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[i]}, 90, 1, 1, fromKey, fromAddress, toAddress)
+		if err := mp.AddTx(txBytes); err != nil {
+			t.Fatalf("AddTx[%d]: %v", i, err)
+		}
+		_, txid, _, _, err := consensus.ParseTx(txBytes)
+		if err != nil {
+			t.Fatalf("ParseTx[%d]: %v", i, err)
+		}
+		ids = append(ids, txid)
+	}
+	got := mp.AllTxIDs()
+	if len(got) != 3 {
+		t.Fatalf("AllTxIDs len=%d, want 3", len(got))
+	}
+	// Replicate handler sort: lexicographic on hex-encoded txid.
+	sort.Slice(got, func(i, j int) bool {
+		return hex.EncodeToString(got[i][:]) < hex.EncodeToString(got[j][:])
+	})
+	sort.Slice(ids, func(i, j int) bool {
+		return hex.EncodeToString(ids[i][:]) < hex.EncodeToString(ids[j][:])
+	})
+	for i := range ids {
+		if got[i] != ids[i] {
+			t.Fatalf("sorted[%d]: got %x, want %x", i, got[i], ids[i])
 		}
 	}
 }

--- a/clients/go/node/mempool_test.go
+++ b/clients/go/node/mempool_test.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -1367,5 +1368,165 @@ func TestTxAdmitErrorMessage(t *testing.T) {
 	err := &TxAdmitError{Kind: TxAdmitConflict, Message: "tx already in mempool"}
 	if err.Error() != "tx already in mempool" {
 		t.Fatalf("Error()=%q, want %q", err.Error(), "tx already in mempool")
+	}
+}
+
+func TestMempoolAllTxIDsReturnsEveryEntry(t *testing.T) {
+	fromKey := mustNodeMLDSA87Keypair(t)
+	toKey := mustNodeMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{100, 100, 100})
+
+	mp, err := NewMempool(st, nil, devnetGenesisChainID)
+	if err != nil {
+		t.Fatalf("new mempool: %v", err)
+	}
+
+	want := make(map[[32]byte]struct{})
+	for i := 0; i < 3; i++ {
+		txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[i]}, 90, 1, 1, fromKey, fromAddress, toAddress)
+		if err := mp.AddTx(txBytes); err != nil {
+			t.Fatalf("AddTx[%d]: %v", i, err)
+		}
+		_, txid, _, _, err := consensus.ParseTx(txBytes)
+		if err != nil {
+			t.Fatalf("ParseTx[%d]: %v", i, err)
+		}
+		want[txid] = struct{}{}
+	}
+
+	got := mp.AllTxIDs()
+	if len(got) != 3 {
+		t.Fatalf("AllTxIDs len=%d, want 3", len(got))
+	}
+	for _, id := range got {
+		if _, ok := want[id]; !ok {
+			t.Fatalf("AllTxIDs returned unexpected txid %x", id)
+		}
+	}
+}
+
+func TestMempoolAllTxIDsEmpty(t *testing.T) {
+	fromKey := mustNodeMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	st, _ := testSpendableChainState(fromAddress, []uint64{100})
+	mp, err := NewMempool(st, nil, devnetGenesisChainID)
+	if err != nil {
+		t.Fatalf("new mempool: %v", err)
+	}
+	if got := mp.AllTxIDs(); len(got) != 0 {
+		t.Fatalf("AllTxIDs on empty mempool returned %d entries, want 0", len(got))
+	}
+}
+
+func TestMempoolAllTxIDsNilReceiver(t *testing.T) {
+	var mp *Mempool
+	if got := mp.AllTxIDs(); got != nil {
+		t.Fatalf("AllTxIDs on nil receiver=%v, want nil", got)
+	}
+}
+
+func TestMempoolTxByIDReturnsRawAndDefensiveCopy(t *testing.T) {
+	fromKey := mustNodeMLDSA87Keypair(t)
+	toKey := mustNodeMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{100})
+
+	mp, err := NewMempool(st, nil, devnetGenesisChainID)
+	if err != nil {
+		t.Fatalf("new mempool: %v", err)
+	}
+	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 1, 1, fromKey, fromAddress, toAddress)
+	if err := mp.AddTx(txBytes); err != nil {
+		t.Fatalf("AddTx: %v", err)
+	}
+	_, txid, _, _, err := consensus.ParseTx(txBytes)
+	if err != nil {
+		t.Fatalf("ParseTx: %v", err)
+	}
+
+	got, ok := mp.TxByID(txid)
+	if !ok {
+		t.Fatalf("TxByID ok=false, want true")
+	}
+	if !bytes.Equal(got, txBytes) {
+		t.Fatalf("TxByID raw mismatch")
+	}
+
+	// Defensive-copy invariant: mutate the returned slice and verify the
+	// mempool entry remains intact via a second TxByID call.
+	got[0] ^= 0xff
+	got2, ok2 := mp.TxByID(txid)
+	if !ok2 {
+		t.Fatalf("TxByID second call ok=false")
+	}
+	if !bytes.Equal(got2, txBytes) {
+		t.Fatalf("mempool entry mutated by caller — defensive copy broken")
+	}
+}
+
+func TestMempoolTxByIDMissing(t *testing.T) {
+	fromKey := mustNodeMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	st, _ := testSpendableChainState(fromAddress, []uint64{100})
+	mp, err := NewMempool(st, nil, devnetGenesisChainID)
+	if err != nil {
+		t.Fatalf("new mempool: %v", err)
+	}
+	var unknown [32]byte
+	raw, ok := mp.TxByID(unknown)
+	if ok || raw != nil {
+		t.Fatalf("TxByID on unknown txid returned raw=%v ok=%v, want nil,false", raw, ok)
+	}
+}
+
+func TestMempoolTxByIDNilReceiver(t *testing.T) {
+	var mp *Mempool
+	var id [32]byte
+	raw, ok := mp.TxByID(id)
+	if ok || raw != nil {
+		t.Fatalf("TxByID on nil receiver returned raw=%v ok=%v, want nil,false", raw, ok)
+	}
+}
+
+func TestMempoolContainsReflectsAdmission(t *testing.T) {
+	fromKey := mustNodeMLDSA87Keypair(t)
+	toKey := mustNodeMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{100})
+
+	mp, err := NewMempool(st, nil, devnetGenesisChainID)
+	if err != nil {
+		t.Fatalf("new mempool: %v", err)
+	}
+	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 1, 1, fromKey, fromAddress, toAddress)
+	_, txid, _, _, err := consensus.ParseTx(txBytes)
+	if err != nil {
+		t.Fatalf("ParseTx: %v", err)
+	}
+
+	if mp.Contains(txid) {
+		t.Fatalf("Contains before admit=true, want false")
+	}
+	if err := mp.AddTx(txBytes); err != nil {
+		t.Fatalf("AddTx: %v", err)
+	}
+	if !mp.Contains(txid) {
+		t.Fatalf("Contains after admit=false, want true")
+	}
+	var other [32]byte
+	if mp.Contains(other) {
+		t.Fatalf("Contains for unrelated txid=true, want false")
+	}
+}
+
+func TestMempoolContainsNilReceiver(t *testing.T) {
+	var mp *Mempool
+	var id [32]byte
+	if mp.Contains(id) {
+		t.Fatalf("Contains on nil receiver=true, want false")
 	}
 }

--- a/clients/rust/crates/rubin-node/src/devnet_rpc.rs
+++ b/clients/rust/crates/rubin-node/src/devnet_rpc.rs
@@ -955,36 +955,45 @@ fn percent_decode(s: &str) -> Option<String> {
 
 /// Decode a 64-hex-char "txid" query parameter to a [u8; 32]. Returns Err with
 /// an operator-facing message on missing, wrong length, or non-hex input.
-/// An empty value (e.g. `?txid=` or `?txid` without `=`) is classified as
-/// missing to preserve parity with the Go `parseTxIDQuery` contract. Go's
-/// `r.URL.Query()` parses both `?txid=` and `?txid` into `url.Values{"txid":
-/// [""]}`; `Query().Get("txid")` returns "" in both cases and the Go parser
-/// classifies that as "missing required query parameter". The first-match
-/// semantic is preserved via `break`: if multiple `txid` keys appear (e.g.
-/// `?txid&txid=<hex>`), only the first is considered, matching Go's
-/// `Values.Get` which returns `values[0]`.
-/// The value is percent-decoded before length/hex validation to match Go's
-/// net/url.QueryUnescape behavior (e.g. `?txid=%61b...` is decoded to
-/// `?txid=ab...` before hex-decode, so clients that percent-escape query
-/// values see identical accept/reject behavior across Go and Rust).
+/// Parity contract with Go `r.URL.Query().Get("txid")`:
+///   - A key without `=` (e.g. `?txid`) or with empty value (e.g. `?txid=`)
+///     is classified as missing; Go's parseQuery stores `url.Values{"txid":
+///     [""]}` and `Get` returns `""`, which the Go parser maps to
+///     "missing required query parameter".
+///   - First-match semantic via `break` mirrors Go's `Values.Get` returning
+///     `values[0]`.
+///   - Both key and value are percent-decoded; pairs that fail to decode
+///     (malformed `%XX`) are silently skipped and the loop continues,
+///     matching Go's `parseQuery` which `continue`s on either
+///     `QueryUnescape` error and never stores the pair. This means
+///     `?txid=%ZZ&txid=<hex>` resolves to the valid second occurrence on
+///     BOTH clients, and `?%74%78%69%64=<hex>` (encoded "txid" key) is
+///     accepted on BOTH clients.
 fn parse_txid_query(query: &str) -> Result<[u8; 32], String> {
-    let mut txid_hex: Option<&str> = None;
+    let mut txid_value: Option<String> = None;
     for pair in query.split('&') {
         // Treat a key without `=` as present-with-empty-value, matching
         // net/url's Values parsing (key alone → values=[""]).
-        let (k, v) = pair.split_once('=').unwrap_or((pair, ""));
-        if k == "txid" {
-            txid_hex = Some(v);
-            break;
+        let (k_raw, v_raw) = pair.split_once('=').unwrap_or((pair, ""));
+        // Go `parseQuery` calls `QueryUnescape` on BOTH the key and value
+        // and `continue`s on either failure (the pair never lands in the
+        // Values map). Replicate that: if either decode fails, skip the
+        // pair and keep scanning for a later valid `txid`.
+        let Some(k) = percent_decode(k_raw) else {
+            continue;
+        };
+        if k != "txid" {
+            continue;
         }
+        let Some(v) = percent_decode(v_raw) else {
+            continue;
+        };
+        txid_value = Some(v);
+        break;
     }
-    let raw_encoded = txid_hex
+    let raw = txid_value
         .filter(|v| !v.is_empty())
         .ok_or_else(|| "missing required query parameter: txid".to_string())?;
-    // Percent-decode before length/hex validation so clients that encode
-    // legitimate hex characters (e.g. `%61` == 'a') still validate correctly.
-    let raw = percent_decode(raw_encoded)
-        .ok_or_else(|| "txid contains malformed percent-escape".to_string())?;
     if raw.len() != 64 {
         return Err(format!(
             "txid must be 64 hex characters (got {})",
@@ -1059,6 +1068,22 @@ fn handle_get_tx(state: &DevnetRPCState, method: &str, query: &str) -> HttpRespo
             },
         );
     }
+    // Fail-closed on tx pool unavailability BEFORE parsing the query, so a
+    // poisoned pool + invalid/missing txid surfaces as 503 rather than 400.
+    // Mirrors the Go handleGetTx contract (nil-mempool check runs first).
+    if state.tx_pool.is_poisoned() {
+        return json_response(
+            state,
+            ROUTE,
+            503,
+            &GetTxResponse {
+                found: false,
+                txid: None,
+                raw_hex: None,
+                error: Some("tx pool unavailable".to_string()),
+            },
+        );
+    }
     let txid = match parse_txid_query(query) {
         Ok(txid) => txid,
         Err(err) => {
@@ -1078,6 +1103,8 @@ fn handle_get_tx(state: &DevnetRPCState, method: &str, query: &str) -> HttpRespo
     let pool = match state.tx_pool.lock() {
         Ok(guard) => guard,
         Err(_) => {
+            // Race: pool became poisoned between is_poisoned() and lock().
+            // Still fail-closed with 503.
             return json_response(
                 state,
                 ROUTE,
@@ -1133,6 +1160,20 @@ fn handle_tx_status(state: &DevnetRPCState, method: &str, query: &str) -> HttpRe
             },
         );
     }
+    // Fail-closed on tx pool unavailability BEFORE parsing the query
+    // (mirrors handle_get_tx and the Go handleTxStatus contract).
+    if state.tx_pool.is_poisoned() {
+        return json_response(
+            state,
+            ROUTE,
+            503,
+            &TxStatusResponse {
+                status: "missing".to_string(),
+                txid: None,
+                error: Some("tx pool unavailable".to_string()),
+            },
+        );
+    }
     let txid = match parse_txid_query(query) {
         Ok(txid) => txid,
         Err(err) => {
@@ -1151,6 +1192,8 @@ fn handle_tx_status(state: &DevnetRPCState, method: &str, query: &str) -> HttpRe
     let pool = match state.tx_pool.lock() {
         Ok(guard) => guard,
         Err(_) => {
+            // Race: pool became poisoned between is_poisoned() and lock().
+            // Still fail-closed with 503.
             return json_response(
                 state,
                 ROUTE,
@@ -3192,9 +3235,14 @@ mod tests {
     }
 
     #[test]
-    fn get_tx_rejects_malformed_percent_escape() {
-        // `?txid=%XY` — `%` followed by non-hex digits — decoding MUST fail
-        // rather than silently pass raw bytes through.
+    fn get_tx_malformed_percent_escape_classified_as_missing() {
+        // Codex thread PRRT_kwDORQ3qGs57OTOf: Go's net/url.parseQuery
+        // `continue`s on percent-decode failure (key OR value) and NEVER
+        // stores the pair in `Values`. So `?txid=%ZZ` alone has no stored
+        // txid, and `Values.Get("txid")` returns "" → Go handler classifies
+        // that as "missing required query parameter". Rust must match:
+        // skip the malformed pair and report missing (NOT "malformed
+        // percent-escape", which was the prior divergent behavior).
         let (state, dir) = build_state(true);
         let response = route_request(
             &state,
@@ -3209,7 +3257,115 @@ mod tests {
         assert!(body["error"]
             .as_str()
             .unwrap_or_default()
-            .contains("malformed percent-escape"));
+            .contains("missing required query parameter"));
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn get_tx_malformed_first_pair_falls_through_to_valid_second() {
+        // Go parseQuery drops the first pair (value unescape fails on %ZZ)
+        // and stores the second (`txid=<hex>`). `Values.Get` then returns
+        // the valid hex. Rust must match.
+        let (state, dir) = build_state(true);
+        let valid_hex = "cd".repeat(32);
+        let target = format!("/get_tx?txid=%ZZ&txid={valid_hex}");
+        let response = route_request(
+            &state,
+            HttpRequest {
+                method: "GET".to_string(),
+                target,
+                body: Vec::new(),
+            },
+        );
+        assert_eq!(
+            response.status, 200,
+            "expected 200 found-false: malformed first pair should be skipped, second pair's valid hex should parse"
+        );
+        let body = response_json(&response);
+        assert_eq!(body["found"].as_bool(), Some(false));
+        assert_eq!(body["txid"].as_str(), Some(valid_hex.as_str()));
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn get_tx_percent_encoded_key_txid_is_accepted() {
+        // Go parseQuery percent-decodes BOTH keys and values before
+        // comparison/storage. So `?%74%78%69%64=<hex>` (the key "txid"
+        // percent-encoded) is stored as `Values{"txid": [<hex>]}`. Rust
+        // must match — percent-decode the key before comparing to "txid".
+        let (state, dir) = build_state(true);
+        let valid_hex = "ef".repeat(32);
+        // "%74%78%69%64" decodes to "txid"
+        let target = format!("/get_tx?%74%78%69%64={valid_hex}");
+        let response = route_request(
+            &state,
+            HttpRequest {
+                method: "GET".to_string(),
+                target,
+                body: Vec::new(),
+            },
+        );
+        assert_eq!(
+            response.status, 200,
+            "expected 200: percent-encoded 'txid' key should decode and match"
+        );
+        let body = response_json(&response);
+        assert_eq!(body["found"].as_bool(), Some(false));
+        assert_eq!(body["txid"].as_str(), Some(valid_hex.as_str()));
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn get_tx_reports_unavailable_when_tx_pool_is_poisoned_before_parse() {
+        // Codex thread PRRT_kwDORQ3qGs57OTOW: handle_get_tx must check
+        // tx_pool availability BEFORE parse_txid_query, so a poisoned pool
+        // + invalid/missing txid returns 503, not 400. Parity with Go
+        // handleGetTx (which checks state.mempool == nil first).
+        let (state, dir) = build_state(true);
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = state.tx_pool.lock().expect("tx_pool lock");
+            panic!("forced to poison tx_pool");
+        }));
+        // Deliberately malformed txid — if the old order still ran, this
+        // would surface as 400 rather than the contract's 503.
+        let response = route_request(
+            &state,
+            HttpRequest {
+                method: "GET".to_string(),
+                target: "/get_tx?txid=not-hex-and-wrong-length".to_string(),
+                body: Vec::new(),
+            },
+        );
+        assert_eq!(response.status, 503);
+        assert_eq!(
+            response_json(&response)["error"].as_str(),
+            Some("tx pool unavailable")
+        );
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn tx_status_reports_unavailable_when_tx_pool_is_poisoned_before_parse() {
+        // Codex thread PRRT_kwDORQ3qGs57OTOb — parity sibling of the
+        // handle_get_tx ordering fix.
+        let (state, dir) = build_state(true);
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = state.tx_pool.lock().expect("tx_pool lock");
+            panic!("forced to poison tx_pool");
+        }));
+        let response = route_request(
+            &state,
+            HttpRequest {
+                method: "GET".to_string(),
+                target: "/tx_status?txid=not-hex".to_string(),
+                body: Vec::new(),
+            },
+        );
+        assert_eq!(response.status, 503);
+        assert_eq!(
+            response_json(&response)["error"].as_str(),
+            Some("tx pool unavailable")
+        );
         fs::remove_dir_all(dir).expect("cleanup");
     }
 

--- a/clients/rust/crates/rubin-node/src/devnet_rpc.rs
+++ b/clients/rust/crates/rubin-node/src/devnet_rpc.rs
@@ -921,6 +921,10 @@ fn handle_mine_next(state: &DevnetRPCState, method: &str, _body: &[u8]) -> HttpR
 
 /// Decode a 64-hex-char "txid" query parameter to a [u8; 32]. Returns Err with
 /// an operator-facing message on missing, wrong length, or non-hex input.
+/// An empty value (e.g. `?txid=`) is classified as missing to preserve parity
+/// with the Go `parseTxIDQuery` contract (Go's `r.URL.Query().Get("txid")`
+/// returns "" for both absent and present-but-empty, and the Go parser
+/// classifies that as "missing required query parameter").
 fn parse_txid_query(query: &str) -> Result<[u8; 32], String> {
     let mut txid_hex: Option<&str> = None;
     for pair in query.split('&') {
@@ -931,7 +935,9 @@ fn parse_txid_query(query: &str) -> Result<[u8; 32], String> {
             }
         }
     }
-    let raw = txid_hex.ok_or_else(|| "missing required query parameter: txid".to_string())?;
+    let raw = txid_hex
+        .filter(|v| !v.is_empty())
+        .ok_or_else(|| "missing required query parameter: txid".to_string())?;
     if raw.len() != 64 {
         return Err(format!(
             "txid must be 64 hex characters (got {})",
@@ -3008,6 +3014,49 @@ mod tests {
             },
         );
         assert_eq!(response.status, 400);
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn get_tx_empty_txid_value_is_classified_as_missing() {
+        // Go/Rust parity: ?txid= (present but empty value) must classify as
+        // missing parameter, not length=0, to match Go parseTxIDQuery which
+        // uses Query().Get returning "" for both absent and present-empty.
+        let (state, dir) = build_state(true);
+        let response = route_request(
+            &state,
+            HttpRequest {
+                method: "GET".to_string(),
+                target: "/get_tx?txid=".to_string(),
+                body: Vec::new(),
+            },
+        );
+        assert_eq!(response.status, 400);
+        let body = response_json(&response);
+        assert!(body["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("missing required query parameter"));
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn tx_status_empty_txid_value_is_classified_as_missing() {
+        let (state, dir) = build_state(true);
+        let response = route_request(
+            &state,
+            HttpRequest {
+                method: "GET".to_string(),
+                target: "/tx_status?txid=".to_string(),
+                body: Vec::new(),
+            },
+        );
+        assert_eq!(response.status, 400);
+        let body = response_json(&response);
+        assert!(body["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("missing required query parameter"));
         fs::remove_dir_all(dir).expect("cleanup");
     }
 }

--- a/clients/rust/crates/rubin-node/src/devnet_rpc.rs
+++ b/clients/rust/crates/rubin-node/src/devnet_rpc.rs
@@ -950,7 +950,12 @@ fn percent_decode(s: &str) -> Option<String> {
             }
         }
     }
-    String::from_utf8(out).ok()
+    // Go strings are byte sequences — QueryUnescape never rejects valid %XX
+    // on UTF-8 grounds.  Use lossy conversion so non-UTF-8 decoded bytes
+    // (e.g. %ff) survive as replacement chars and reach the length/hex check
+    // instead of being silently discarded (which would misclassify the error
+    // as "missing" rather than "wrong length" — Codex thread PRRT_kwDORQ3qGs57PGFx).
+    Some(String::from_utf8_lossy(&out).into_owned())
 }
 
 /// Decode a 64-hex-char "txid" query parameter to a [u8; 32]. Returns Err with
@@ -3316,6 +3321,33 @@ mod tests {
     }
 
     #[test]
+    fn get_tx_non_utf8_percent_value_reaches_length_check() {
+        // Codex thread PRRT_kwDORQ3qGs57PGFx: %ff decodes to a non-UTF-8
+        // byte.  percent_decode must NOT discard it (which would
+        // misclassify as "missing"); instead the decoded value reaches the
+        // length/hex check and returns 400 "wrong length" — parity with
+        // Go where QueryUnescape keeps the byte.
+        let (state, dir) = build_state(true);
+        let response = route_request(
+            &state,
+            HttpRequest {
+                method: "GET".to_string(),
+                target: "/get_tx?txid=%ff".to_string(),
+                body: Vec::new(),
+            },
+        );
+        assert_eq!(response.status, 400);
+        let body = response_json(&response);
+        let err = body["error"].as_str().unwrap_or("");
+        // Must say "wrong length", NOT "missing required query parameter".
+        assert!(
+            err.contains("64 hex characters"),
+            "expected length error, got: {err}"
+        );
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
     fn get_tx_reports_unavailable_when_tx_pool_is_poisoned_before_parse() {
         // Codex thread PRRT_kwDORQ3qGs57OTOW: handle_get_tx must check
         // tx_pool availability BEFORE parse_txid_query, so a poisoned pool
@@ -3382,5 +3414,10 @@ mod tests {
         // Malformed — incomplete escape at end
         assert_eq!(super::percent_decode("%a"), None);
         assert_eq!(super::percent_decode("%"), None);
+        // Non-UTF-8 decoded byte — Go keeps it, Rust uses lossy replacement.
+        // Must return Some (not None!) so the value reaches the length/hex
+        // check rather than being silently dropped (Codex PRRT_kwDORQ3qGs57PGFx).
+        assert!(super::percent_decode("%ff").is_some());
+        assert!(super::percent_decode("%c3%28").is_some());
     }
 }

--- a/clients/rust/crates/rubin-node/src/devnet_rpc.rs
+++ b/clients/rust/crates/rubin-node/src/devnet_rpc.rs
@@ -923,7 +923,16 @@ fn handle_mine_next(state: &DevnetRPCState, method: &str, _body: &[u8]) -> HttpR
 /// None on malformed escapes (incomplete or non-hex digits). Mirrors Go's
 /// net/url.QueryUnescape used internally by Values.Get, which decodes the
 /// value before returning it to the handler.
-fn percent_decode(s: &str) -> Option<String> {
+/// Percent-decode a query component to raw bytes.  Returns `None` only on
+/// malformed `%XX` escapes (truncated or non-hex digits), matching the
+/// error-returns-continue semantics of Go `net/url.QueryUnescape`.
+///
+/// Returns `Vec<u8>` (not `String`) because Go strings are arbitrary byte
+/// sequences — `QueryUnescape` never rejects on UTF-8 grounds.  Keeping
+/// raw bytes ensures `len()` matches Go's `len()` for the downstream
+/// length check in `parse_txid_query` (Codex threads PRRT_kwDORQ3qGs57PGFx,
+/// PRRT_kwDORQ3qGs57RCc0).
+fn percent_decode(s: &str) -> Option<Vec<u8>> {
     let bytes = s.as_bytes();
     let mut out = Vec::with_capacity(bytes.len());
     let mut i = 0;
@@ -939,8 +948,6 @@ fn percent_decode(s: &str) -> Option<String> {
                 i += 3;
             }
             b'+' => {
-                // application/x-www-form-urlencoded: '+' decodes to space.
-                // Go's Query().Get treats '+' as space in values.
                 out.push(b' ');
                 i += 1;
             }
@@ -950,12 +957,7 @@ fn percent_decode(s: &str) -> Option<String> {
             }
         }
     }
-    // Go strings are byte sequences — QueryUnescape never rejects valid %XX
-    // on UTF-8 grounds.  Use lossy conversion so non-UTF-8 decoded bytes
-    // (e.g. %ff) survive as replacement chars and reach the length check
-    // in parse_txid_query rather than being silently discarded and
-    // misclassified as "missing" (Codex thread PRRT_kwDORQ3qGs57PGFx).
-    Some(String::from_utf8_lossy(&out).into_owned())
+    Some(out)
 }
 
 /// Decode a 64-hex-char "txid" query parameter to a [u8; 32]. Returns Err with
@@ -975,52 +977,44 @@ fn percent_decode(s: &str) -> Option<String> {
 ///     BOTH clients, and `?%74%78%69%64=<hex>` (encoded "txid" key) is
 ///     accepted on BOTH clients.
 fn parse_txid_query(query: &str) -> Result<[u8; 32], String> {
-    let mut txid_value: Option<String> = None;
+    let mut txid_bytes: Option<Vec<u8>> = None;
     for pair in query.split('&') {
         // Go 1.17+ (CVE-2021-44716): parseQuery rejects pairs containing
-        // an unescaped semicolon with "invalid semicolon separator in query"
-        // and `continue`s.  Match that behavior so e.g.
-        // `?txid=<64hex>;foo=1` is classified as "missing txid" on both
-        // clients (Codex thread PRRT_kwDORQ3qGs57PkNn).
+        // an unescaped semicolon.
         if pair.contains(';') {
             continue;
         }
-        // Treat a key without `=` as present-with-empty-value, matching
-        // net/url's Values parsing (key alone → values=[""]).
         let (k_raw, v_raw) = pair.split_once('=').unwrap_or((pair, ""));
-        // Go `parseQuery` calls `QueryUnescape` on BOTH the key and value
-        // and `continue`s on either failure (the pair never lands in the
-        // Values map). Replicate that: if either decode fails, skip the
-        // pair and keep scanning for a later valid `txid`.
         let Some(k) = percent_decode(k_raw) else {
             continue;
         };
-        if k != "txid" {
+        // Key comparison on raw bytes — "txid" is ASCII so this is exact.
+        if k != b"txid" {
             continue;
         }
         let Some(v) = percent_decode(v_raw) else {
             continue;
         };
-        txid_value = Some(v);
+        txid_bytes = Some(v);
         break;
     }
-    let raw = txid_value
+    let raw = txid_bytes
         .filter(|v| !v.is_empty())
         .ok_or_else(|| "missing required query parameter: txid".to_string())?;
+    // Length check on raw decoded bytes — matches Go's len(raw) which
+    // counts bytes, not UTF-8 characters.
     if raw.len() != 64 {
         return Err(format!(
             "txid must be 64 hex characters (got {})",
             raw.len()
         ));
     }
-    // After length check: non-ASCII means lossy-replaced non-UTF-8 bytes
-    // (e.g. %ff → U+FFFD).  Go's hex.DecodeString would also reject them.
-    // Guard here so the length error class matches Go for wrong-length
-    // non-ASCII input (reviewer finding on 6a58db7).
-    if !raw.is_ascii() {
-        return Err("txid is not valid hex: contains non-ASCII decoded bytes".to_string());
-    }
-    let decoded = hex::decode(&raw).map_err(|err| format!("txid is not valid hex: {err}"))?;
+    // Convert to UTF-8 string for hex::decode.  Valid hex is always ASCII,
+    // so non-UTF-8 bytes (e.g. %ff decoded to 0xFF) fail here with the
+    // same error class as Go's hex.DecodeString.
+    let raw_str = std::str::from_utf8(&raw)
+        .map_err(|_| "txid is not valid hex: contains non-ASCII decoded bytes".to_string())?;
+    let decoded = hex::decode(raw_str).map_err(|err| format!("txid is not valid hex: {err}"))?;
     let mut txid = [0u8; 32];
     txid.copy_from_slice(&decoded);
     Ok(txid)
@@ -3375,12 +3369,9 @@ mod tests {
 
     #[test]
     fn get_tx_non_utf8_percent_value_not_classified_as_missing() {
-        // Codex thread PRRT_kwDORQ3qGs57PGFx: %ff decodes to a non-UTF-8
-        // byte.  percent_decode must NOT discard it (which would
-        // misclassify as "missing").  The decoded lossy value (3 chars)
-        // reaches the length check first → "got 3" (Go: "got 1" on raw
-        // byte). Both are 400 + length-class error, matching the Go
-        // error class for wrong-length non-hex input.
+        // Codex thread PRRT_kwDORQ3qGs57PGFx: %ff decodes to 1 raw byte.
+        // With Vec<u8> percent_decode, length check sees "got 1" — same as
+        // Go where len(raw) counts raw decoded bytes.
         let (state, dir) = build_state(true);
         let response = route_request(
             &state,
@@ -3393,15 +3384,41 @@ mod tests {
         assert_eq!(response.status, 400);
         let body = response_json(&response);
         let err = body["error"].as_str().unwrap_or("");
-        // Must NOT say "missing" — the value was decoded, not dropped.
         assert!(
             !err.contains("missing"),
             "non-UTF-8 decoded value must not be classified as missing, got: {err}"
         );
-        // Length-class error (same class as Go).
+        // Length error with raw byte count: "got 1" (matches Go).
         assert!(
-            err.contains("64 hex characters"),
-            "expected length error, got: {err}"
+            err.contains("(got 1)"),
+            "expected raw byte length 1, got: {err}"
+        );
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn get_tx_non_utf8_64_raw_bytes_reaches_hex_check() {
+        // Codex thread PRRT_kwDORQ3qGs57RCc0: 62 hex chars + %c3%28 = 64
+        // raw decoded bytes.  Go: len==64 → hex.DecodeString → hex error.
+        // Rust (with Vec<u8>): len==64 → from_utf8 → hex-class error.
+        // Both: 400, hex-class error.  NOT length error.
+        let (state, dir) = build_state(true);
+        let hex62 = "a".repeat(62);
+        let target = format!("/get_tx?txid={hex62}%c3%28");
+        let response = route_request(
+            &state,
+            HttpRequest {
+                method: "GET".to_string(),
+                target,
+                body: Vec::new(),
+            },
+        );
+        assert_eq!(response.status, 400);
+        let body = response_json(&response);
+        let err = body["error"].as_str().unwrap_or("");
+        assert!(
+            err.contains("not valid hex"),
+            "64 raw bytes with non-UTF-8 must get hex error, got: {err}"
         );
         fs::remove_dir_all(dir).expect("cleanup");
     }
@@ -3488,21 +3505,19 @@ mod tests {
 
     #[test]
     fn percent_decode_basic_cases() {
-        // Unit coverage for the helper.
-        assert_eq!(super::percent_decode("abc"), Some("abc".to_string()));
-        assert_eq!(super::percent_decode("%61"), Some("a".to_string()));
-        assert_eq!(super::percent_decode("%41%42"), Some("AB".to_string()));
-        assert_eq!(super::percent_decode("a+b"), Some("a b".to_string()));
-        assert_eq!(super::percent_decode(""), Some(String::new()));
+        // Returns Vec<u8> — raw decoded bytes.
+        assert_eq!(super::percent_decode("abc"), Some(b"abc".to_vec()));
+        assert_eq!(super::percent_decode("%61"), Some(vec![0x61]));
+        assert_eq!(super::percent_decode("%41%42"), Some(vec![0x41, 0x42]));
+        assert_eq!(super::percent_decode("a+b"), Some(b"a b".to_vec()));
+        assert_eq!(super::percent_decode(""), Some(vec![]));
         // Malformed — non-hex digit in escape
         assert_eq!(super::percent_decode("%ZZ"), None);
         // Malformed — incomplete escape at end
         assert_eq!(super::percent_decode("%a"), None);
         assert_eq!(super::percent_decode("%"), None);
-        // Non-UTF-8 decoded byte — Go keeps it, Rust uses lossy replacement.
-        // Must return Some (not None!) so the value reaches the length/hex
-        // check rather than being silently dropped (Codex PRRT_kwDORQ3qGs57PGFx).
-        assert!(super::percent_decode("%ff").is_some());
-        assert!(super::percent_decode("%c3%28").is_some());
+        // Non-UTF-8 decoded bytes — preserved as raw bytes (Go parity).
+        assert_eq!(super::percent_decode("%ff"), Some(vec![0xff]));
+        assert_eq!(super::percent_decode("%c3%28"), Some(vec![0xc3, 0x28]));
     }
 }

--- a/clients/rust/crates/rubin-node/src/devnet_rpc.rs
+++ b/clients/rust/crates/rubin-node/src/devnet_rpc.rs
@@ -919,6 +919,40 @@ fn handle_mine_next(state: &DevnetRPCState, method: &str, _body: &[u8]) -> HttpR
     }
 }
 
+/// Percent-decode a query-string fragment ("%XX" pairs → byte values). Returns
+/// None on malformed escapes (incomplete or non-hex digits). Mirrors Go's
+/// net/url.QueryUnescape used internally by Values.Get, which decodes the
+/// value before returning it to the handler.
+fn percent_decode(s: &str) -> Option<String> {
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'%' => {
+                if i + 2 >= bytes.len() {
+                    return None;
+                }
+                let hi = (bytes[i + 1] as char).to_digit(16)?;
+                let lo = (bytes[i + 2] as char).to_digit(16)?;
+                out.push(((hi << 4) | lo) as u8);
+                i += 3;
+            }
+            b'+' => {
+                // application/x-www-form-urlencoded: '+' decodes to space.
+                // Go's Query().Get treats '+' as space in values.
+                out.push(b' ');
+                i += 1;
+            }
+            other => {
+                out.push(other);
+                i += 1;
+            }
+        }
+    }
+    String::from_utf8(out).ok()
+}
+
 /// Decode a 64-hex-char "txid" query parameter to a [u8; 32]. Returns Err with
 /// an operator-facing message on missing, wrong length, or non-hex input.
 /// An empty value (e.g. `?txid=` or `?txid` without `=`) is classified as
@@ -929,6 +963,10 @@ fn handle_mine_next(state: &DevnetRPCState, method: &str, _body: &[u8]) -> HttpR
 /// semantic is preserved via `break`: if multiple `txid` keys appear (e.g.
 /// `?txid&txid=<hex>`), only the first is considered, matching Go's
 /// `Values.Get` which returns `values[0]`.
+/// The value is percent-decoded before length/hex validation to match Go's
+/// net/url.QueryUnescape behavior (e.g. `?txid=%61b...` is decoded to
+/// `?txid=ab...` before hex-decode, so clients that percent-escape query
+/// values see identical accept/reject behavior across Go and Rust).
 fn parse_txid_query(query: &str) -> Result<[u8; 32], String> {
     let mut txid_hex: Option<&str> = None;
     for pair in query.split('&') {
@@ -940,17 +978,20 @@ fn parse_txid_query(query: &str) -> Result<[u8; 32], String> {
             break;
         }
     }
-    let raw = txid_hex
+    let raw_encoded = txid_hex
         .filter(|v| !v.is_empty())
         .ok_or_else(|| "missing required query parameter: txid".to_string())?;
+    // Percent-decode before length/hex validation so clients that encode
+    // legitimate hex characters (e.g. `%61` == 'a') still validate correctly.
+    let raw = percent_decode(raw_encoded)
+        .ok_or_else(|| "txid contains malformed percent-escape".to_string())?;
     if raw.len() != 64 {
         return Err(format!(
             "txid must be 64 hex characters (got {})",
             raw.len()
         ));
     }
-    let decoded =
-        hex::decode(raw).map_err(|err| format!("txid is not valid hex: {err}"))?;
+    let decoded = hex::decode(&raw).map_err(|err| format!("txid is not valid hex: {err}"))?;
     let mut txid = [0u8; 32];
     txid.copy_from_slice(&decoded);
     Ok(txid)
@@ -3114,5 +3155,76 @@ mod tests {
             .unwrap_or_default()
             .contains("missing required query parameter"));
         fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn get_tx_accepts_percent_encoded_hex_value() {
+        // Codex thread PRRT_kwDORQ3qGs57N_wu: Go's Query().Get percent-decodes
+        // the value before returning it, so `?txid=%61b...` becomes `ab...`
+        // and validates as valid hex. Rust must match: percent-decode before
+        // length/hex checks. A missing-but-syntactically-valid txid returns
+        // 200 + found=false, which proves the parser accepted the
+        // percent-encoded input (the parse-reject paths would return 400).
+        let (state, dir) = build_state(true);
+
+        let encoded_prefix = "%61%62"; // == "ab"
+        let literal_rest = "cd".repeat(31); // 62 chars → total 64 after decode
+        let target = format!("/get_tx?txid={encoded_prefix}{literal_rest}");
+        let response = route_request(
+            &state,
+            HttpRequest {
+                method: "GET".to_string(),
+                target,
+                body: Vec::new(),
+            },
+        );
+        assert_eq!(
+            response.status, 200,
+            "percent-encoded valid hex must parse, got status={}",
+            response.status
+        );
+        let body = response_json(&response);
+        assert_eq!(body["found"].as_bool(), Some(false));
+        // Echoed txid should be the decoded form (lower-case hex 'ab' + rest)
+        let expected = format!("ab{literal_rest}");
+        assert_eq!(body["txid"].as_str(), Some(expected.as_str()));
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn get_tx_rejects_malformed_percent_escape() {
+        // `?txid=%XY` — `%` followed by non-hex digits — decoding MUST fail
+        // rather than silently pass raw bytes through.
+        let (state, dir) = build_state(true);
+        let response = route_request(
+            &state,
+            HttpRequest {
+                method: "GET".to_string(),
+                target: "/get_tx?txid=%ZZ".to_string(),
+                body: Vec::new(),
+            },
+        );
+        assert_eq!(response.status, 400);
+        let body = response_json(&response);
+        assert!(body["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("malformed percent-escape"));
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn percent_decode_basic_cases() {
+        // Unit coverage for the helper.
+        assert_eq!(super::percent_decode("abc"), Some("abc".to_string()));
+        assert_eq!(super::percent_decode("%61"), Some("a".to_string()));
+        assert_eq!(super::percent_decode("%41%42"), Some("AB".to_string()));
+        assert_eq!(super::percent_decode("a+b"), Some("a b".to_string()));
+        assert_eq!(super::percent_decode(""), Some(String::new()));
+        // Malformed — non-hex digit in escape
+        assert_eq!(super::percent_decode("%ZZ"), None);
+        // Malformed — incomplete escape at end
+        assert_eq!(super::percent_decode("%a"), None);
+        assert_eq!(super::percent_decode("%"), None);
     }
 }

--- a/clients/rust/crates/rubin-node/src/devnet_rpc.rs
+++ b/clients/rust/crates/rubin-node/src/devnet_rpc.rs
@@ -977,6 +977,14 @@ fn percent_decode(s: &str) -> Option<String> {
 fn parse_txid_query(query: &str) -> Result<[u8; 32], String> {
     let mut txid_value: Option<String> = None;
     for pair in query.split('&') {
+        // Go 1.17+ (CVE-2021-44716): parseQuery rejects pairs containing
+        // an unescaped semicolon with "invalid semicolon separator in query"
+        // and `continue`s.  Match that behavior so e.g.
+        // `?txid=<64hex>;foo=1` is classified as "missing txid" on both
+        // clients (Codex thread PRRT_kwDORQ3qGs57PkNn).
+        if pair.contains(';') {
+            continue;
+        }
         // Treat a key without `=` as present-with-empty-value, matching
         // net/url's Values parsing (key alone → values=[""]).
         let (k_raw, v_raw) = pair.split_once('=').unwrap_or((pair, ""));
@@ -3356,6 +3364,32 @@ mod tests {
         assert!(
             err.contains("64 hex characters"),
             "expected length error, got: {err}"
+        );
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn get_tx_semicolon_in_pair_is_dropped_like_go() {
+        // Codex thread PRRT_kwDORQ3qGs57PkNn: Go parseQuery (1.17+,
+        // CVE-2021-44716) skips pairs containing `;`.  So
+        // `?txid=<64hex>;foo=1` → pair dropped → "missing txid".
+        let (state, dir) = build_state(true);
+        let valid_hex = "a".repeat(64);
+        let target = format!("/get_tx?txid={valid_hex};foo=1");
+        let response = route_request(
+            &state,
+            HttpRequest {
+                method: "GET".to_string(),
+                target,
+                body: Vec::new(),
+            },
+        );
+        assert_eq!(response.status, 400);
+        let body = response_json(&response);
+        let err = body["error"].as_str().unwrap_or("");
+        assert!(
+            err.contains("missing"),
+            "pair with semicolon must be dropped (Go parity), got: {err}"
         );
         fs::remove_dir_all(dir).expect("cleanup");
     }

--- a/clients/rust/crates/rubin-node/src/devnet_rpc.rs
+++ b/clients/rust/crates/rubin-node/src/devnet_rpc.rs
@@ -2951,9 +2951,8 @@ mod tests {
 
     #[test]
     fn get_mempool_returns_sorted_txids() {
-        // Copilot thread PRRT_kwDORQ3qGs57Qgs6/QgtE: verify that
-        // /get_mempool returns txids in lexicographic order regardless
-        // of HashMap iteration order.
+        // Verify /get_mempool returns txids in lexicographic order
+        // regardless of HashMap iteration order.
         let (state, dir) = build_state(true);
         // Inject 3 txids in reverse-lex order to guarantee the sort
         // in handle_get_mempool is exercised.
@@ -3197,7 +3196,6 @@ mod tests {
 
     #[test]
     fn get_tx_valueless_txid_key_classified_as_missing() {
-        // Go/Rust parity regression (Codex thread PRRT_kwDORQ3qGs57NpSB):
         // ?txid (key without `=`) must classify as missing, matching Go's
         // net/url which parses a valueless key into values=[""].
         let (state, dir) = build_state(true);
@@ -3248,10 +3246,10 @@ mod tests {
 
     #[test]
     fn get_tx_accepts_percent_encoded_hex_value() {
-        // Codex thread PRRT_kwDORQ3qGs57N_wu: Go's Query().Get percent-decodes
-        // the value before returning it, so `?txid=%61b...` becomes `ab...`
-        // and validates as valid hex. Rust must match: percent-decode before
-        // length/hex checks. A missing-but-syntactically-valid txid returns
+        // Go's Query().Get percent-decodes the value before returning it,
+        // so `?txid=%61b...` becomes `ab...` and validates as valid hex.
+        // Rust must match: percent-decode before length/hex checks. A
+        // missing-but-syntactically-valid txid returns
         // 200 + found=false, which proves the parser accepted the
         // percent-encoded input (the parse-reject paths would return 400).
         let (state, dir) = build_state(true);
@@ -3282,9 +3280,9 @@ mod tests {
 
     #[test]
     fn get_tx_malformed_percent_escape_classified_as_missing() {
-        // Codex thread PRRT_kwDORQ3qGs57OTOf: Go's net/url.parseQuery
-        // `continue`s on percent-decode failure (key OR value) and NEVER
-        // stores the pair in `Values`. So `?txid=%ZZ` alone has no stored
+        // Go's net/url.parseQuery `continue`s on percent-decode failure
+        // (key OR value) and never stores the pair. So `?txid=%ZZ` alone
+        // has no stored
         // txid, and `Values.Get("txid")` returns "" → Go handler classifies
         // that as "missing required query parameter". Rust must match:
         // skip the malformed pair and report missing (NOT "malformed
@@ -3363,9 +3361,8 @@ mod tests {
 
     #[test]
     fn get_tx_non_utf8_percent_value_not_classified_as_missing() {
-        // Codex thread PRRT_kwDORQ3qGs57PGFx: %ff decodes to 1 raw byte.
-        // With Vec<u8> percent_decode, length check sees "got 1" — same as
-        // Go where len(raw) counts raw decoded bytes.
+        // %ff decodes to 1 raw byte (0xFF). Length check sees "got 1" —
+        // same as Go where len(raw) counts raw decoded bytes.
         let (state, dir) = build_state(true);
         let response = route_request(
             &state,
@@ -3392,10 +3389,10 @@ mod tests {
 
     #[test]
     fn get_tx_non_utf8_64_raw_bytes_reaches_hex_check() {
-        // Codex thread PRRT_kwDORQ3qGs57RCc0: 62 hex chars + %c3%28 = 64
-        // raw decoded bytes.  Go: len==64 → hex.DecodeString → hex error.
-        // Rust (with Vec<u8>): len==64 → from_utf8 → hex-class error.
-        // Both: 400, hex-class error.  NOT length error.
+        // 62 hex chars + %c3%28 = 64 raw decoded bytes.
+        // Go: len==64 → hex.DecodeString → hex error.
+        // Rust: len==64 → from_utf8 fails → hex-class error.
+        // Both: 400, hex-class error — NOT length error.
         let (state, dir) = build_state(true);
         let hex62 = "a".repeat(62);
         let target = format!("/get_tx?txid={hex62}%c3%28");
@@ -3419,9 +3416,8 @@ mod tests {
 
     #[test]
     fn get_tx_semicolon_in_pair_is_dropped_like_go() {
-        // Codex thread PRRT_kwDORQ3qGs57PkNn: Go parseQuery (1.17+,
-        // CVE-2021-44716) skips pairs containing `;`.  So
-        // `?txid=<64hex>;foo=1` → pair dropped → "missing txid".
+        // Go parseQuery (1.17+, CVE-2021-44716) skips pairs containing
+        // `;`.  `?txid=<64hex>;foo=1` → pair dropped → "missing txid".
         let (state, dir) = build_state(true);
         let valid_hex = "a".repeat(64);
         let target = format!("/get_tx?txid={valid_hex};foo=1");
@@ -3445,10 +3441,10 @@ mod tests {
 
     #[test]
     fn get_tx_reports_unavailable_when_tx_pool_is_poisoned_before_parse() {
-        // Codex thread PRRT_kwDORQ3qGs57OTOW: handle_get_tx must check
-        // tx_pool availability BEFORE parse_txid_query, so a poisoned pool
-        // + invalid/missing txid returns 503, not 400. Parity with Go
-        // handleGetTx (which checks state.mempool == nil first).
+        // handle_get_tx must check tx_pool availability BEFORE
+        // parse_txid_query, so a poisoned pool + invalid/missing txid
+        // returns 503, not 400.  Parity with Go handleGetTx which
+        // checks state.mempool == nil first.
         let (state, dir) = build_state(true);
         let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let _guard = state.tx_pool.lock().expect("tx_pool lock");
@@ -3474,8 +3470,8 @@ mod tests {
 
     #[test]
     fn tx_status_reports_unavailable_when_tx_pool_is_poisoned_before_parse() {
-        // Codex thread PRRT_kwDORQ3qGs57OTOb — parity sibling of the
-        // handle_get_tx ordering fix.
+        // Parity sibling of the handle_get_tx ordering fix:
+        // tx_pool availability check BEFORE parse.
         let (state, dir) = build_state(true);
         let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let _guard = state.tx_pool.lock().expect("tx_pool lock");

--- a/clients/rust/crates/rubin-node/src/devnet_rpc.rs
+++ b/clients/rust/crates/rubin-node/src/devnet_rpc.rs
@@ -952,9 +952,9 @@ fn percent_decode(s: &str) -> Option<String> {
     }
     // Go strings are byte sequences — QueryUnescape never rejects valid %XX
     // on UTF-8 grounds.  Use lossy conversion so non-UTF-8 decoded bytes
-    // (e.g. %ff) survive as replacement chars and reach the length/hex check
-    // instead of being silently discarded (which would misclassify the error
-    // as "missing" rather than "wrong length" — Codex thread PRRT_kwDORQ3qGs57PGFx).
+    // (e.g. %ff) survive as replacement chars and reach the length check
+    // in parse_txid_query rather than being silently discarded and
+    // misclassified as "missing" (Codex thread PRRT_kwDORQ3qGs57PGFx).
     Some(String::from_utf8_lossy(&out).into_owned())
 }
 
@@ -1004,6 +1004,13 @@ fn parse_txid_query(query: &str) -> Result<[u8; 32], String> {
             "txid must be 64 hex characters (got {})",
             raw.len()
         ));
+    }
+    // After length check: non-ASCII means lossy-replaced non-UTF-8 bytes
+    // (e.g. %ff → U+FFFD).  Go's hex.DecodeString would also reject them.
+    // Guard here so the length error class matches Go for wrong-length
+    // non-ASCII input (reviewer finding on 6a58db7).
+    if !raw.is_ascii() {
+        return Err("txid is not valid hex: contains non-ASCII decoded bytes".to_string());
     }
     let decoded = hex::decode(&raw).map_err(|err| format!("txid is not valid hex: {err}"))?;
     let mut txid = [0u8; 32];
@@ -3321,12 +3328,13 @@ mod tests {
     }
 
     #[test]
-    fn get_tx_non_utf8_percent_value_reaches_length_check() {
+    fn get_tx_non_utf8_percent_value_not_classified_as_missing() {
         // Codex thread PRRT_kwDORQ3qGs57PGFx: %ff decodes to a non-UTF-8
         // byte.  percent_decode must NOT discard it (which would
-        // misclassify as "missing"); instead the decoded value reaches the
-        // length/hex check and returns 400 "wrong length" — parity with
-        // Go where QueryUnescape keeps the byte.
+        // misclassify as "missing").  The decoded lossy value (3 chars)
+        // reaches the length check first → "got 3" (Go: "got 1" on raw
+        // byte). Both are 400 + length-class error, matching the Go
+        // error class for wrong-length non-hex input.
         let (state, dir) = build_state(true);
         let response = route_request(
             &state,
@@ -3339,7 +3347,12 @@ mod tests {
         assert_eq!(response.status, 400);
         let body = response_json(&response);
         let err = body["error"].as_str().unwrap_or("");
-        // Must say "wrong length", NOT "missing required query parameter".
+        // Must NOT say "missing" — the value was decoded, not dropped.
+        assert!(
+            !err.contains("missing"),
+            "non-UTF-8 decoded value must not be classified as missing, got: {err}"
+        );
+        // Length-class error (same class as Go).
         assert!(
             err.contains("64 hex characters"),
             "expected length error, got: {err}"

--- a/clients/rust/crates/rubin-node/src/devnet_rpc.rs
+++ b/clients/rust/crates/rubin-node/src/devnet_rpc.rs
@@ -2962,6 +2962,44 @@ mod tests {
     }
 
     #[test]
+    fn get_mempool_returns_sorted_txids() {
+        // Copilot thread PRRT_kwDORQ3qGs57Qgs6/QgtE: verify that
+        // /get_mempool returns txids in lexicographic order regardless
+        // of HashMap iteration order.
+        let (state, dir) = build_state(true);
+        // Inject 3 txids in reverse-lex order to guarantee the sort
+        // in handle_get_mempool is exercised.
+        let mut ids: Vec<[u8; 32]> = vec![[0xcc; 32], [0xaa; 32], [0xbb; 32]];
+        {
+            let mut pool = state.tx_pool.lock().expect("pool lock");
+            for id in &ids {
+                pool.inject_test_entry(*id, vec![0x00]);
+            }
+        }
+        let response = route_request(
+            &state,
+            HttpRequest {
+                method: "GET".to_string(),
+                target: "/get_mempool".to_string(),
+                body: Vec::new(),
+            },
+        );
+        assert_eq!(response.status, 200);
+        let body = response_json(&response);
+        assert_eq!(body["count"].as_u64(), Some(3));
+        let txids: Vec<String> = body["txids"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap().to_string())
+            .collect();
+        ids.sort();
+        let expected: Vec<String> = ids.iter().map(hex::encode).collect();
+        assert_eq!(txids, expected, "txids must be lexicographically sorted");
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
     fn get_mempool_rejects_post() {
         let (state, dir) = build_state(true);
         let response = route_request(

--- a/clients/rust/crates/rubin-node/src/devnet_rpc.rs
+++ b/clients/rust/crates/rubin-node/src/devnet_rpc.rs
@@ -1030,7 +1030,7 @@ fn handle_get_mempool(state: &DevnetRPCState, method: &str) -> HttpResponse {
                 &GetMempoolResponse {
                     count: 0,
                     txids: Vec::new(),
-                    error: Some("tx pool unavailable".to_string()),
+                    error: Some("mempool unavailable".to_string()),
                 },
             );
         }
@@ -1080,7 +1080,7 @@ fn handle_get_tx(state: &DevnetRPCState, method: &str, query: &str) -> HttpRespo
                 found: false,
                 txid: None,
                 raw_hex: None,
-                error: Some("tx pool unavailable".to_string()),
+                error: Some("mempool unavailable".to_string()),
             },
         );
     }
@@ -1111,9 +1111,9 @@ fn handle_get_tx(state: &DevnetRPCState, method: &str, query: &str) -> HttpRespo
                 503,
                 &GetTxResponse {
                     found: false,
-                    txid: Some(hex::encode(txid)),
+                    txid: None,
                     raw_hex: None,
-                    error: Some("tx pool unavailable".to_string()),
+                    error: Some("mempool unavailable".to_string()),
                 },
             );
         }
@@ -1170,7 +1170,7 @@ fn handle_tx_status(state: &DevnetRPCState, method: &str, query: &str) -> HttpRe
             &TxStatusResponse {
                 status: "missing".to_string(),
                 txid: None,
-                error: Some("tx pool unavailable".to_string()),
+                error: Some("mempool unavailable".to_string()),
             },
         );
     }
@@ -1200,8 +1200,8 @@ fn handle_tx_status(state: &DevnetRPCState, method: &str, query: &str) -> HttpRe
                 503,
                 &TxStatusResponse {
                     status: "missing".to_string(),
-                    txid: Some(hex::encode(txid)),
-                    error: Some("tx pool unavailable".to_string()),
+                    txid: None,
+                    error: Some("mempool unavailable".to_string()),
                 },
             );
         }
@@ -2978,7 +2978,7 @@ mod tests {
         assert_eq!(response.status, 503);
         assert_eq!(
             response_json(&response)["error"].as_str(),
-            Some("tx pool unavailable")
+            Some("mempool unavailable")
         );
         fs::remove_dir_all(dir).expect("cleanup");
     }
@@ -3339,7 +3339,7 @@ mod tests {
         assert_eq!(response.status, 503);
         assert_eq!(
             response_json(&response)["error"].as_str(),
-            Some("tx pool unavailable")
+            Some("mempool unavailable")
         );
         fs::remove_dir_all(dir).expect("cleanup");
     }
@@ -3364,7 +3364,7 @@ mod tests {
         assert_eq!(response.status, 503);
         assert_eq!(
             response_json(&response)["error"].as_str(),
-            Some("tx pool unavailable")
+            Some("mempool unavailable")
         );
         fs::remove_dir_all(dir).expect("cleanup");
     }

--- a/clients/rust/crates/rubin-node/src/devnet_rpc.rs
+++ b/clients/rust/crates/rubin-node/src/devnet_rpc.rs
@@ -106,6 +106,34 @@ struct MineNextResponse {
     error: Option<String>,
 }
 
+#[derive(Serialize)]
+struct GetMempoolResponse {
+    count: usize,
+    txids: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+}
+
+#[derive(Serialize)]
+struct GetTxResponse {
+    found: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    txid: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    raw_hex: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+}
+
+#[derive(Serialize)]
+struct TxStatusResponse {
+    status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    txid: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+}
+
 /// True when the host in `host:port` is loopback-only (safe for devnet live mining RPC).
 /// Requires a non-empty, valid `u16` port (rejects `127.0.0.1:` and similar).
 pub fn rpc_bind_host_is_loopback(bind_addr: &str) -> bool {
@@ -333,6 +361,9 @@ fn route_request(state: &DevnetRPCState, req: HttpRequest) -> HttpResponse {
         "/get_block" => handle_get_block(state, &req.method, &query),
         "/submit_tx" => handle_submit_tx(state, &req.method, &req.body),
         "/mine_next" => handle_mine_next(state, &req.method, &req.body),
+        "/get_mempool" => handle_get_mempool(state, &req.method),
+        "/get_tx" => handle_get_tx(state, &req.method, &query),
+        "/tx_status" => handle_tx_status(state, &req.method, &query),
         "/metrics" => handle_metrics(state, &req.method),
         _ => json_response(
             state,
@@ -886,6 +917,216 @@ fn handle_mine_next(state: &DevnetRPCState, method: &str, _body: &[u8]) -> HttpR
             },
         ),
     }
+}
+
+/// Decode a 64-hex-char "txid" query parameter to a [u8; 32]. Returns Err with
+/// an operator-facing message on missing, wrong length, or non-hex input.
+fn parse_txid_query(query: &str) -> Result<[u8; 32], String> {
+    let mut txid_hex: Option<&str> = None;
+    for pair in query.split('&') {
+        if let Some((k, v)) = pair.split_once('=') {
+            if k == "txid" {
+                txid_hex = Some(v);
+                break;
+            }
+        }
+    }
+    let raw = txid_hex.ok_or_else(|| "missing required query parameter: txid".to_string())?;
+    if raw.len() != 64 {
+        return Err(format!(
+            "txid must be 64 hex characters (got {})",
+            raw.len()
+        ));
+    }
+    let decoded =
+        hex::decode(raw).map_err(|err| format!("txid is not valid hex: {err}"))?;
+    let mut txid = [0u8; 32];
+    txid.copy_from_slice(&decoded);
+    Ok(txid)
+}
+
+fn handle_get_mempool(state: &DevnetRPCState, method: &str) -> HttpResponse {
+    const ROUTE: &str = "/get_mempool";
+    if method != "GET" {
+        return json_response(
+            state,
+            ROUTE,
+            400,
+            &GetMempoolResponse {
+                count: 0,
+                txids: Vec::new(),
+                error: Some("GET required".to_string()),
+            },
+        );
+    }
+    let pool = match state.tx_pool.lock() {
+        Ok(guard) => guard,
+        Err(_) => {
+            return json_response(
+                state,
+                ROUTE,
+                503,
+                &GetMempoolResponse {
+                    count: 0,
+                    txids: Vec::new(),
+                    error: Some("tx pool unavailable".to_string()),
+                },
+            );
+        }
+    };
+    let mut ids = pool.all_txids();
+    drop(pool);
+    // Sort for deterministic response ordering; HashMap iteration is not
+    // stable across calls.
+    ids.sort();
+    let txids: Vec<String> = ids.iter().map(hex::encode).collect();
+    json_response(
+        state,
+        ROUTE,
+        200,
+        &GetMempoolResponse {
+            count: txids.len(),
+            txids,
+            error: None,
+        },
+    )
+}
+
+fn handle_get_tx(state: &DevnetRPCState, method: &str, query: &str) -> HttpResponse {
+    const ROUTE: &str = "/get_tx";
+    if method != "GET" {
+        return json_response(
+            state,
+            ROUTE,
+            400,
+            &GetTxResponse {
+                found: false,
+                txid: None,
+                raw_hex: None,
+                error: Some("GET required".to_string()),
+            },
+        );
+    }
+    let txid = match parse_txid_query(query) {
+        Ok(txid) => txid,
+        Err(err) => {
+            return json_response(
+                state,
+                ROUTE,
+                400,
+                &GetTxResponse {
+                    found: false,
+                    txid: None,
+                    raw_hex: None,
+                    error: Some(err),
+                },
+            );
+        }
+    };
+    let pool = match state.tx_pool.lock() {
+        Ok(guard) => guard,
+        Err(_) => {
+            return json_response(
+                state,
+                ROUTE,
+                503,
+                &GetTxResponse {
+                    found: false,
+                    txid: Some(hex::encode(txid)),
+                    raw_hex: None,
+                    error: Some("tx pool unavailable".to_string()),
+                },
+            );
+        }
+    };
+    let raw = pool.tx_by_id(&txid);
+    drop(pool);
+    match raw {
+        Some(bytes) => json_response(
+            state,
+            ROUTE,
+            200,
+            &GetTxResponse {
+                found: true,
+                txid: Some(hex::encode(txid)),
+                raw_hex: Some(hex::encode(bytes)),
+                error: None,
+            },
+        ),
+        None => json_response(
+            state,
+            ROUTE,
+            200,
+            &GetTxResponse {
+                found: false,
+                txid: Some(hex::encode(txid)),
+                raw_hex: None,
+                error: None,
+            },
+        ),
+    }
+}
+
+fn handle_tx_status(state: &DevnetRPCState, method: &str, query: &str) -> HttpResponse {
+    const ROUTE: &str = "/tx_status";
+    if method != "GET" {
+        return json_response(
+            state,
+            ROUTE,
+            400,
+            &TxStatusResponse {
+                status: "missing".to_string(),
+                txid: None,
+                error: Some("GET required".to_string()),
+            },
+        );
+    }
+    let txid = match parse_txid_query(query) {
+        Ok(txid) => txid,
+        Err(err) => {
+            return json_response(
+                state,
+                ROUTE,
+                400,
+                &TxStatusResponse {
+                    status: "missing".to_string(),
+                    txid: None,
+                    error: Some(err),
+                },
+            );
+        }
+    };
+    let pool = match state.tx_pool.lock() {
+        Ok(guard) => guard,
+        Err(_) => {
+            return json_response(
+                state,
+                ROUTE,
+                503,
+                &TxStatusResponse {
+                    status: "missing".to_string(),
+                    txid: Some(hex::encode(txid)),
+                    error: Some("tx pool unavailable".to_string()),
+                },
+            );
+        }
+    };
+    let status = if pool.contains(&txid) {
+        "pending"
+    } else {
+        "missing"
+    };
+    drop(pool);
+    json_response(
+        state,
+        ROUTE,
+        200,
+        &TxStatusResponse {
+            status: status.to_string(),
+            txid: Some(hex::encode(txid)),
+            error: None,
+        },
+    )
 }
 
 fn handle_metrics(state: &DevnetRPCState, method: &str) -> HttpResponse {
@@ -2583,6 +2824,190 @@ mod tests {
             let _ = h.join();
         }
         drop(server);
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn get_mempool_returns_empty_for_fresh_state() {
+        let (state, dir) = build_state(true);
+        let response = route_request(
+            &state,
+            HttpRequest {
+                method: "GET".to_string(),
+                target: "/get_mempool".to_string(),
+                body: Vec::new(),
+            },
+        );
+        assert_eq!(response.status, 200);
+        let body = response_json(&response);
+        assert_eq!(body["count"].as_u64(), Some(0));
+        assert!(body["txids"].is_array());
+        assert_eq!(body["txids"].as_array().unwrap().len(), 0);
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn get_mempool_rejects_post() {
+        let (state, dir) = build_state(true);
+        let response = route_request(
+            &state,
+            HttpRequest {
+                method: "POST".to_string(),
+                target: "/get_mempool".to_string(),
+                body: Vec::new(),
+            },
+        );
+        assert_eq!(response.status, 400);
+        assert_eq!(
+            response_json(&response)["error"].as_str(),
+            Some("GET required")
+        );
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn get_mempool_reports_unavailable_when_tx_pool_is_poisoned() {
+        let (state, dir) = build_state(true);
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = state.tx_pool.lock().expect("tx_pool lock");
+            panic!("forced to poison tx_pool");
+        }));
+        let response = route_request(
+            &state,
+            HttpRequest {
+                method: "GET".to_string(),
+                target: "/get_mempool".to_string(),
+                body: Vec::new(),
+            },
+        );
+        assert_eq!(response.status, 503);
+        assert_eq!(
+            response_json(&response)["error"].as_str(),
+            Some("tx pool unavailable")
+        );
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn get_tx_rejects_missing_txid_param() {
+        let (state, dir) = build_state(true);
+        let response = route_request(
+            &state,
+            HttpRequest {
+                method: "GET".to_string(),
+                target: "/get_tx".to_string(),
+                body: Vec::new(),
+            },
+        );
+        assert_eq!(response.status, 400);
+        let body = response_json(&response);
+        assert_eq!(body["found"].as_bool(), Some(false));
+        assert!(body["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("missing required query parameter"));
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn get_tx_rejects_invalid_length() {
+        let (state, dir) = build_state(true);
+        let response = route_request(
+            &state,
+            HttpRequest {
+                method: "GET".to_string(),
+                target: "/get_tx?txid=deadbeef".to_string(),
+                body: Vec::new(),
+            },
+        );
+        assert_eq!(response.status, 400);
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn get_tx_rejects_non_hex() {
+        let (state, dir) = build_state(true);
+        let target = format!("/get_tx?txid={}", "z".repeat(64));
+        let response = route_request(
+            &state,
+            HttpRequest {
+                method: "GET".to_string(),
+                target,
+                body: Vec::new(),
+            },
+        );
+        assert_eq!(response.status, 400);
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn get_tx_missing_returns_found_false_with_200() {
+        let (state, dir) = build_state(true);
+        let unknown = "11".repeat(32);
+        let target = format!("/get_tx?txid={unknown}");
+        let response = route_request(
+            &state,
+            HttpRequest {
+                method: "GET".to_string(),
+                target,
+                body: Vec::new(),
+            },
+        );
+        assert_eq!(response.status, 200);
+        let body = response_json(&response);
+        assert_eq!(body["found"].as_bool(), Some(false));
+        assert_eq!(body["txid"].as_str(), Some(unknown.as_str()));
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn tx_status_missing_returns_missing() {
+        let (state, dir) = build_state(true);
+        let unknown = "22".repeat(32);
+        let target = format!("/tx_status?txid={unknown}");
+        let response = route_request(
+            &state,
+            HttpRequest {
+                method: "GET".to_string(),
+                target,
+                body: Vec::new(),
+            },
+        );
+        assert_eq!(response.status, 200);
+        let body = response_json(&response);
+        assert_eq!(body["status"].as_str(), Some("missing"));
+        assert_eq!(body["txid"].as_str(), Some(unknown.as_str()));
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn tx_status_rejects_invalid_txid() {
+        let (state, dir) = build_state(true);
+        let response = route_request(
+            &state,
+            HttpRequest {
+                method: "GET".to_string(),
+                target: "/tx_status?txid=not-hex".to_string(),
+                body: Vec::new(),
+            },
+        );
+        assert_eq!(response.status, 400);
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn tx_status_rejects_post() {
+        let (state, dir) = build_state(true);
+        let target = format!("/tx_status?txid={}", "33".repeat(32));
+        let response = route_request(
+            &state,
+            HttpRequest {
+                method: "POST".to_string(),
+                target,
+                body: Vec::new(),
+            },
+        );
+        assert_eq!(response.status, 400);
         fs::remove_dir_all(dir).expect("cleanup");
     }
 }

--- a/clients/rust/crates/rubin-node/src/devnet_rpc.rs
+++ b/clients/rust/crates/rubin-node/src/devnet_rpc.rs
@@ -919,19 +919,13 @@ fn handle_mine_next(state: &DevnetRPCState, method: &str, _body: &[u8]) -> HttpR
     }
 }
 
-/// Percent-decode a query-string fragment ("%XX" pairs → byte values). Returns
-/// None on malformed escapes (incomplete or non-hex digits). Mirrors Go's
-/// net/url.QueryUnescape used internally by Values.Get, which decodes the
-/// value before returning it to the handler.
 /// Percent-decode a query component to raw bytes.  Returns `None` only on
-/// malformed `%XX` escapes (truncated or non-hex digits), matching the
-/// error-returns-continue semantics of Go `net/url.QueryUnescape`.
-///
-/// Returns `Vec<u8>` (not `String`) because Go strings are arbitrary byte
-/// sequences — `QueryUnescape` never rejects on UTF-8 grounds.  Keeping
-/// raw bytes ensures `len()` matches Go's `len()` for the downstream
-/// length check in `parse_txid_query` (Codex threads PRRT_kwDORQ3qGs57PGFx,
-/// PRRT_kwDORQ3qGs57RCc0).
+/// malformed `%XX` escapes (truncated or non-hex digits), matching Go
+/// `net/url.QueryUnescape` error semantics.  Returns `Vec<u8>` (not
+/// `String`) because Go strings are arbitrary byte sequences and
+/// `QueryUnescape` never rejects on UTF-8 grounds — keeping raw bytes
+/// ensures `len()` matches Go's `len()` for the downstream length check
+/// in `parse_txid_query`.
 fn percent_decode(s: &str) -> Option<Vec<u8>> {
     let bytes = s.as_bytes();
     let mut out = Vec::with_capacity(bytes.len());

--- a/clients/rust/crates/rubin-node/src/devnet_rpc.rs
+++ b/clients/rust/crates/rubin-node/src/devnet_rpc.rs
@@ -921,18 +921,23 @@ fn handle_mine_next(state: &DevnetRPCState, method: &str, _body: &[u8]) -> HttpR
 
 /// Decode a 64-hex-char "txid" query parameter to a [u8; 32]. Returns Err with
 /// an operator-facing message on missing, wrong length, or non-hex input.
-/// An empty value (e.g. `?txid=`) is classified as missing to preserve parity
-/// with the Go `parseTxIDQuery` contract (Go's `r.URL.Query().Get("txid")`
-/// returns "" for both absent and present-but-empty, and the Go parser
-/// classifies that as "missing required query parameter").
+/// An empty value (e.g. `?txid=` or `?txid` without `=`) is classified as
+/// missing to preserve parity with the Go `parseTxIDQuery` contract. Go's
+/// `r.URL.Query()` parses both `?txid=` and `?txid` into `url.Values{"txid":
+/// [""]}`; `Query().Get("txid")` returns "" in both cases and the Go parser
+/// classifies that as "missing required query parameter". The first-match
+/// semantic is preserved via `break`: if multiple `txid` keys appear (e.g.
+/// `?txid&txid=<hex>`), only the first is considered, matching Go's
+/// `Values.Get` which returns `values[0]`.
 fn parse_txid_query(query: &str) -> Result<[u8; 32], String> {
     let mut txid_hex: Option<&str> = None;
     for pair in query.split('&') {
-        if let Some((k, v)) = pair.split_once('=') {
-            if k == "txid" {
-                txid_hex = Some(v);
-                break;
-            }
+        // Treat a key without `=` as present-with-empty-value, matching
+        // net/url's Values parsing (key alone → values=[""]).
+        let (k, v) = pair.split_once('=').unwrap_or((pair, ""));
+        if k == "txid" {
+            txid_hex = Some(v);
+            break;
         }
     }
     let raw = txid_hex
@@ -3052,6 +3057,57 @@ mod tests {
             },
         );
         assert_eq!(response.status, 400);
+        let body = response_json(&response);
+        assert!(body["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("missing required query parameter"));
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn get_tx_valueless_txid_key_classified_as_missing() {
+        // Go/Rust parity regression (Codex thread PRRT_kwDORQ3qGs57NpSB):
+        // ?txid (key without `=`) must classify as missing, matching Go's
+        // net/url which parses a valueless key into values=[""].
+        let (state, dir) = build_state(true);
+        let response = route_request(
+            &state,
+            HttpRequest {
+                method: "GET".to_string(),
+                target: "/get_tx?txid".to_string(),
+                body: Vec::new(),
+            },
+        );
+        assert_eq!(response.status, 400);
+        let body = response_json(&response);
+        assert!(body["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("missing required query parameter"));
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn get_tx_valueless_first_key_never_accepts_later_hex_duplicate() {
+        // First-match semantic (mirrors Go's Values.Get = values[0]):
+        // ?txid&txid=<valid hex> — first key is valueless → missing;
+        // Rust must NOT fall through to accept the later duplicate's hex.
+        let (state, dir) = build_state(true);
+        let valid_hex = "ab".repeat(32);
+        let target = format!("/get_tx?txid&txid={valid_hex}");
+        let response = route_request(
+            &state,
+            HttpRequest {
+                method: "GET".to_string(),
+                target,
+                body: Vec::new(),
+            },
+        );
+        assert_eq!(
+            response.status, 400,
+            "first-match semantic violated: accepted duplicate-key hex value"
+        );
         let body = response_json(&response);
         assert!(body["error"]
             .as_str()

--- a/clients/rust/crates/rubin-node/src/txpool.rs
+++ b/clients/rust/crates/rubin-node/src/txpool.rs
@@ -149,14 +149,15 @@ impl TxPool {
     /// Inject a raw entry for testing without full transaction validation.
     #[cfg(test)]
     pub fn inject_test_entry(&mut self, txid: [u8; 32], raw: Vec<u8>) {
+        let size = raw.len();
         self.insert_entry(
             txid,
             TxPoolEntry {
                 raw,
                 inputs: Vec::new(),
                 fee: 0,
-                weight: 0,
-                size: 0,
+                weight: size as u64,
+                size,
             },
         );
     }

--- a/clients/rust/crates/rubin-node/src/txpool.rs
+++ b/clients/rust/crates/rubin-node/src/txpool.rs
@@ -146,6 +146,21 @@ impl TxPool {
         self.txs.get(txid).map(|entry| entry.raw.clone())
     }
 
+    /// Inject a raw entry for testing without full transaction validation.
+    #[cfg(test)]
+    pub fn inject_test_entry(&mut self, txid: [u8; 32], raw: Vec<u8>) {
+        self.insert_entry(
+            txid,
+            TxPoolEntry {
+                raw,
+                inputs: Vec::new(),
+                fee: 0,
+                weight: 0,
+                size: 0,
+            },
+        );
+    }
+
     /// Reports whether a transaction with the given txid is currently present
     /// in the pool.
     pub fn contains(&self, txid: &[u8; 32]) -> bool {

--- a/clients/rust/crates/rubin-node/src/txpool.rs
+++ b/clients/rust/crates/rubin-node/src/txpool.rs
@@ -133,6 +133,25 @@ impl TxPool {
         self.txs.is_empty()
     }
 
+    /// Returns the txids of every transaction currently in the pool.
+    /// The ordering of the returned vector is not guaranteed to be stable
+    /// between calls; callers that require a deterministic order must sort.
+    pub fn all_txids(&self) -> Vec<[u8; 32]> {
+        self.txs.keys().copied().collect()
+    }
+
+    /// Returns a defensive clone of the raw transaction bytes for a pool entry
+    /// with the given txid. Returns `None` if no matching entry is present.
+    pub fn tx_by_id(&self, txid: &[u8; 32]) -> Option<Vec<u8>> {
+        self.txs.get(txid).map(|entry| entry.raw.clone())
+    }
+
+    /// Reports whether a transaction with the given txid is currently present
+    /// in the pool.
+    pub fn contains(&self, txid: &[u8; 32]) -> bool {
+        self.txs.contains_key(txid)
+    }
+
     pub fn select_transactions(&self, max_count: usize, max_bytes: usize) -> Vec<Vec<u8>> {
         if max_count == 0 || max_bytes == 0 {
             return Vec::new();


### PR DESCRIPTION
**Task anchor:** Q-IMPL-NODE-DEVNET-TX-LIFECYCLE-VISIBILITY-01 (canonical `inbox/QUEUE.md:64`, issue #1147). Follow-up to merged #1198.

## Summary

Adds three devnet-only read-only RPC endpoints with Go/Rust parity:

| Endpoint | Method | Query | 200 Response |
|---|---|---|---|
| `/get_mempool` | GET | — | `{count, txids: [hex...]}` |
| `/get_tx` | GET | `txid=<64-hex>` | `{found: bool, txid, raw_hex?: string}` |
| `/tx_status` | GET | `txid=<64-hex>` | `{status: "pending" or "missing", txid}` |

**Error contract (Go/Rust parity):**
- Wrong method → 400 with `"GET required"`
- Missing `txid` parameter → 400 with `"missing required query parameter: txid"`
- `txid` length != 64 → 400 with length-specific message
- Non-hex `txid` → 400 with hex-decode error
- Pool lock poisoned / nil state → 503 (Go `"mempool unavailable"`, Rust `"tx pool unavailable"` — pre-existing Go/Rust string split in `submit_tx`; not introduced by this PR)

## Scope boundary

Covers **pending/missing** only. Post-inclusion `"included"` status is out-of-scope — requires block-store scan, deferred to a separate lane.

No consensus/policy changes. No live-mining changes. No wait-style helpers introduced (kept narrow per task spec).

## Implementation notes

- **Lock-scope discipline** (MXI-1): all Rust handlers acquire `state.tx_pool.lock()`, read, and call `drop(pool)` explicitly BEFORE `json_response(...)`. Go pub methods wrap reads in deferred `RUnlock` with no network I/O in the critical section.
- **Deterministic response ordering**: `/get_mempool` sorts txids lexicographically. HashMap iteration in both clients is randomized; explicit sort in handlers guarantees stable output across calls.
- **Defensive copy**: Go `TxByID` returns `make+copy`; Rust `tx_by_id` returns `entry.raw.clone()`. Callers cannot mutate pool state through the returned slice. Covered by `TestMempoolTxByIDReturnsRawAndDefensiveCopy`.

## Commits (4)

1. `76b5593` feat — 3 endpoints + Go/Rust pub methods + initial tests
2. `ea88972` test — +6 Go tests closing handler-path coverage
3. `cd366d8` test — drop redundant `TestDevnetRPCGetMempoolSortedDeterministic` (stale comment caught by local reviewer; empty-path already covered by `TestDevnetRPCGetMempoolEmpty`)
4. `06e9106` test — 8 direct unit tests for `AllTxIDs/TxByID/Contains` in `clients/go/node/mempool_test.go` (coverage measured per-package)

## Local verification

- `go build ./cmd/rubin-node && go build ./node/...` → OK
- `go test -run 'TestDevnetRPC(GetMempool|GetTx|TxStatus|TxLifecycle)' ./cmd/rubin-node/...` → **PASS 14/14**
- `go test -run 'TestMempool(AllTxIDs|TxByID|Contains)' ./node/...` → **PASS 8/8**
- `cargo build -p rubin-node` → OK
- `cargo test -p rubin-node --lib -- get_mempool get_tx tx_status` → **PASS 10/10**
- `cl push` local Codacy preflight: `7/7 lenses ok, NO_FINDINGS=true, LOCAL SECURITY REVIEW PASS`

## Task acceptance

- [x] After `submit_tx`, operators can distinguish **missing**, **pending**, and (via `get_mempool`) **known** transaction cases on the devnet surface
- [x] Go and Rust expose the same minimal tx lifecycle visibility contract: endpoints, payload shape, and status/error semantics
- [x] No wait-style helper introduced (task spec marked optional — explicitly not added)
- [x] Localhost bring-up no longer requires custom helper code to inspect tx lifecycle after submission

Closes: #1147