### PR TITLE
fix(reorg): derive fresh prev_timestamps per block in multi-block reorg

### DIFF
--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -838,7 +838,7 @@ func prevTimestampsFromStore(store *BlockStore, nextHeight uint64) ([]uint64, er
 			return nil, err
 		}
 		if !ok {
-			return nil, errors.New("missing canonical header for timestamp context")
+			return nil, fmt.Errorf("missing canonical hash at height %d for timestamp context (next_height=%d)", height, nextHeight)
 		}
 		headerBytes, err := store.GetHeaderByHash(hash)
 		if err != nil {

--- a/clients/go/node/sync_reorg.go
+++ b/clients/go/node/sync_reorg.go
@@ -53,7 +53,7 @@ func (s *SyncEngine) ApplyBlockWithReorg(blockBytes []byte, prevTimestamps []uin
 		}
 		return s.syntheticSideChainSummary(candidateHeight, blockHash), nil
 	}
-	return s.applyHeavierBranch(branch, commonAncestorHeight, prevTimestamps)
+	return s.applyHeavierBranch(branch, commonAncestorHeight)
 }
 
 func (s *SyncEngine) applyDirectBlockIfPossible(
@@ -112,13 +112,12 @@ func (s *SyncEngine) shouldSwitchToBranch(
 func (s *SyncEngine) applyHeavierBranch(
 	branch []reorgBranchBlock,
 	commonAncestorHeight uint64,
-	prevTimestamps []uint64,
 ) (*ChainStateConnectSummary, error) {
 	rollbackState, err := s.captureRollbackState()
 	if err != nil {
 		return nil, err
 	}
-	disconnectedBlocks, reorgDepth, err := s.prepareHeavierBranch(branch, commonAncestorHeight, prevTimestamps, rollbackState)
+	disconnectedBlocks, reorgDepth, err := s.prepareHeavierBranch(branch, commonAncestorHeight, rollbackState)
 	if err != nil {
 		return nil, err
 	}
@@ -127,8 +126,17 @@ func (s *SyncEngine) applyHeavierBranch(
 	}
 
 	var summary *ChainStateConnectSummary
-	for _, item := range branch {
-		summary, err = s.applyCanonicalParsedBlock(item.parsed, item.blockBytes, prevTimestamps)
+	for i, item := range branch {
+		// Derive fresh timestamps from the (updated) canonical index for
+		// each block in the branch.  The stale caller prevTimestamps was
+		// computed for height commonAncestorHeight+1 and is wrong for
+		// blocks 2+ (finding B.9, issue #1166).
+		nextHeight := commonAncestorHeight + 1 + uint64(i)
+		freshTs, tsErr := prevTimestampsFromStore(s.blockStore, nextHeight)
+		if tsErr != nil {
+			return nil, s.rollbackApplyBlock(tsErr, rollbackState)
+		}
+		summary, err = s.applyCanonicalParsedBlock(item.parsed, item.blockBytes, freshTs)
 		if err != nil {
 			return nil, s.rollbackApplyBlock(err, rollbackState)
 		}
@@ -141,7 +149,6 @@ func (s *SyncEngine) applyHeavierBranch(
 func (s *SyncEngine) prepareHeavierBranch(
 	branch []reorgBranchBlock,
 	commonAncestorHeight uint64,
-	prevTimestamps []uint64,
 	rollbackState syncRollbackState,
 ) ([][]byte, uint64, error) {
 	previewState := cloneChainState(rollbackState.chainState)
@@ -153,11 +160,19 @@ func (s *SyncEngine) prepareHeavierBranch(
 	if err != nil {
 		return nil, 0, err
 	}
+	// Build a sliding MTP window: start from pre-fork timestamps, advance
+	// after each block.  The blockstore index is NOT updated during preview,
+	// so per-block advancement uses a sliding window instead of
+	// re-deriving from the store each iteration (B.9 fix).
+	slidingTs, err := prevTimestampsFromStore(s.blockStore, commonAncestorHeight+1)
+	if err != nil {
+		return nil, 0, err
+	}
 	for _, item := range branch {
 		if _, err := previewState.ConnectBlockWithCoreExtProfilesAndSuiteContext(
 			item.blockBytes,
 			s.cfg.ExpectedTarget,
-			prevTimestamps,
+			slidingTs,
 			s.cfg.ChainID,
 			s.cfg.CoreExtProfiles,
 			s.cfg.RotationProvider,
@@ -165,8 +180,24 @@ func (s *SyncEngine) prepareHeavierBranch(
 		); err != nil {
 			return nil, 0, err
 		}
+		slidingTs = advancePrevTimestamps(slidingTs, item.header.Timestamp)
 	}
 	return disconnectedBlocks, reorgDepth, nil
+}
+
+// advancePrevTimestamps prepends newTs to prev and keeps at most 11 entries,
+// sliding the MTP window forward by one block.
+func advancePrevTimestamps(prev []uint64, newTs uint64) []uint64 {
+	const maxWindow = 11
+	out := make([]uint64, 0, maxWindow)
+	out = append(out, newTs)
+	for _, ts := range prev {
+		if len(out) >= maxWindow {
+			break
+		}
+		out = append(out, ts)
+	}
+	return out
 }
 
 func (s *SyncEngine) collectBranchToCanonical(

--- a/clients/go/node/sync_reorg_test.go
+++ b/clients/go/node/sync_reorg_test.go
@@ -12,11 +12,22 @@ import (
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
 )
 
+// reorgTestTimestamp returns a valid MTP-passing timestamp for reorg test
+// blocks.  Genesis timestamp is ~1772020800; adding n ensures each block
+// stays monotonic and above MTP median.
+func reorgTestTimestamp(n uint64) uint64 {
+	genesisParsed, err := consensus.ParseBlockBytes(devnetGenesisBlockBytes)
+	if err != nil {
+		panic("ParseBlockBytes(genesis): " + err.Error())
+	}
+	return genesisParsed.Header.Timestamp + n
+}
+
 func TestReorgTwoMiners(t *testing.T) {
 	engine, store, target := newReorgTestEngine(t)
 
 	subsidy1 := consensus.BlockSubsidy(1, 0)
-	blockA1 := buildSingleTxBlock(t, devnetGenesisBlockHash, target, 2, coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 1, subsidy1))
+	blockA1 := buildSingleTxBlock(t, devnetGenesisBlockHash, target, reorgTestTimestamp(1), coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 1, subsidy1))
 	summaryA1, err := engine.ApplyBlock(blockA1, nil)
 	if err != nil {
 		t.Fatalf("ApplyBlock(A1): %v", err)
@@ -25,7 +36,7 @@ func TestReorgTwoMiners(t *testing.T) {
 		t.Fatalf("A1 height=%d, want 1", summaryA1.BlockHeight)
 	}
 
-	blockB1 := buildSingleTxBlock(t, devnetGenesisBlockHash, target, 3, coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 1, subsidy1))
+	blockB1 := buildSingleTxBlock(t, devnetGenesisBlockHash, target, reorgTestTimestamp(2), coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 1, subsidy1))
 	summaryB1, err := engine.ApplyBlockWithReorg(blockB1, nil)
 	if err != nil {
 		t.Fatalf("ApplyBlockWithReorg(B1): %v", err)
@@ -50,7 +61,7 @@ func TestReorgTwoMiners(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BlockHash(B1): %v", err)
 	}
-	blockB2 := buildSingleTxBlock(t, blockB1Hash, target, 4, coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 2, subsidy2))
+	blockB2 := buildSingleTxBlock(t, blockB1Hash, target, reorgTestTimestamp(3), coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 2, subsidy2))
 	summaryB2, err := engine.ApplyBlockWithReorg(blockB2, nil)
 	if err != nil {
 		t.Fatalf("ApplyBlockWithReorg(B2): %v", err)
@@ -88,7 +99,7 @@ func TestDeepReorg10(t *testing.T) {
 	mainAlreadyGenerated := uint64(0)
 	for height := uint64(1); height <= 10; height++ {
 		subsidy := consensus.BlockSubsidy(height, mainAlreadyGenerated)
-		block := buildSingleTxBlock(t, mainPrev, target, height+1, coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, height, subsidy))
+		block := buildSingleTxBlock(t, mainPrev, target, reorgTestTimestamp(height), coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, height, subsidy))
 		summary, err := engine.ApplyBlock(block, nil)
 		if err != nil {
 			t.Fatalf("ApplyBlock(A%d): %v", height, err)
@@ -103,7 +114,7 @@ func TestDeepReorg10(t *testing.T) {
 	var err error
 	for height := uint64(1); height <= 11; height++ {
 		subsidy := consensus.BlockSubsidy(height, sideAlreadyGenerated)
-		block := buildSingleTxBlock(t, sidePrev, target, 100+height, coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, height, subsidy))
+		block := buildSingleTxBlock(t, sidePrev, target, reorgTestTimestamp(100+height), coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, height, subsidy))
 		sideBlocks = append(sideBlocks, block)
 		sidePrev, err = consensus.BlockHash(blockHeaderBytes(t, block))
 		if err != nil {
@@ -643,7 +654,7 @@ func TestNativeSuitesCacheInvalidatedOnReorg(t *testing.T) {
 		t,
 		devnetGenesisBlockHash,
 		target,
-		2,
+		reorgTestTimestamp(1),
 		reorgTestCoinbaseForWtxids(t, 1, subsidy1+50, sourceAddressA, [][32]byte{{}, blockASpendWtxid}),
 		blockASpend,
 	)
@@ -660,7 +671,7 @@ func TestNativeSuitesCacheInvalidatedOnReorg(t *testing.T) {
 		t,
 		devnetGenesisBlockHash,
 		target,
-		3,
+		reorgTestTimestamp(2),
 		reorgTestCoinbaseForWtxids(t, 1, subsidy1+50, destAddressB, [][32]byte{{}, blockBSpendWtxid}),
 		blockBSpend,
 	)
@@ -677,7 +688,7 @@ func TestNativeSuitesCacheInvalidatedOnReorg(t *testing.T) {
 		t,
 		blockB1Hash,
 		target,
-		4,
+		reorgTestTimestamp(3),
 		reorgTestCoinbaseForAddress(t, 2, subsidy2, destAddressB),
 	)
 	if _, err := engine.ApplyBlockWithReorg(blockB2, nil); err != nil {
@@ -1169,6 +1180,29 @@ func testRestoreChainState(dst *ChainState, snapshot chainStateDisk) error {
 	}
 	dst.replaceFrom(recovered)
 	return nil
+}
+
+func TestAdvancePrevTimestampsSliding(t *testing.T) {
+	// Empty input → single entry.
+	got := advancePrevTimestamps(nil, 100)
+	if len(got) != 1 || got[0] != 100 {
+		t.Fatalf("empty: got %v, want [100]", got)
+	}
+	// Partial window (5 entries) → prepend, len=6.
+	prev := []uint64{90, 80, 70, 60, 50}
+	got = advancePrevTimestamps(prev, 100)
+	if len(got) != 6 || got[0] != 100 || got[5] != 50 {
+		t.Fatalf("partial: got %v, want [100 90 80 70 60 50]", got)
+	}
+	// Full window (11 entries) → prepend, truncate, len=11.
+	full := make([]uint64, 11)
+	for i := range full {
+		full[i] = uint64(110 - i*10)
+	}
+	got = advancePrevTimestamps(full, 200)
+	if len(got) != 11 || got[0] != 200 || got[10] != 20 {
+		t.Fatalf("full: got %v, want [200 110 100 ... 20]", got)
+	}
 }
 
 func testParentTipTimestamp(store *BlockStore, tipHeight uint64, prevBlockHash [32]byte) (uint64, error) {

--- a/clients/rust/crates/rubin-node/src/sync.rs
+++ b/clients/rust/crates/rubin-node/src/sync.rs
@@ -756,7 +756,38 @@ impl SyncEngine {
         for offset in 0..window_len {
             let height = next_height - 1 - offset;
             let Some(hash) = block_store.canonical_hash(height)? else {
-                return Err("missing canonical header for timestamp context".to_string());
+                return Err(format!(
+                    "missing canonical hash at height {height} for timestamp context (next_height={next_height})"
+                ));
+            };
+            let header_bytes = block_store.get_header_by_hash(hash)?;
+            let header = parse_block_header_bytes(&header_bytes).map_err(|e| e.to_string())?;
+            out.push(header.timestamp);
+        }
+        Ok(Some(out))
+    }
+
+    /// Derive prev_timestamps for a given `next_height` from the blockstore.
+    /// Used by the reorg preview loop which needs timestamps at arbitrary
+    /// heights (not just `self.chain_state.height + 1`).
+    pub(crate) fn prev_timestamps_for_height(
+        &self,
+        next_height: u64,
+    ) -> Result<Option<Vec<u64>>, String> {
+        if next_height == 0 {
+            return Ok(None);
+        }
+        let Some(block_store) = self.block_store.as_ref() else {
+            return Err("sync engine missing blockstore for timestamp context".to_string());
+        };
+        let window_len = next_height.min(11);
+        let mut out = Vec::with_capacity(window_len as usize);
+        for offset in 0..window_len {
+            let height = next_height - 1 - offset;
+            let Some(hash) = block_store.canonical_hash(height)? else {
+                return Err(format!(
+                    "missing canonical hash at height {height} for timestamp context (next_height={next_height})"
+                ));
             };
             let header_bytes = block_store.get_header_by_hash(hash)?;
             let header = parse_block_header_bytes(&header_bytes).map_err(|e| e.to_string())?;

--- a/clients/rust/crates/rubin-node/src/sync_reorg.rs
+++ b/clients/rust/crates/rubin-node/src/sync_reorg.rs
@@ -11,6 +11,20 @@ use crate::txpool::TxPool;
 
 pub(crate) const PARENT_BLOCK_NOT_FOUND_ERR: &str = "parent block not found";
 
+/// Slide the MTP window forward by one block: prepend `new_ts` and keep at
+/// most 11 entries.  Mirrors Go `advancePrevTimestamps`.
+fn advance_prev_timestamps(prev: Option<&[u64]>, new_ts: u64) -> Vec<u64> {
+    const MAX_WINDOW: usize = 11;
+    let mut out = Vec::with_capacity(MAX_WINDOW);
+    out.push(new_ts);
+    if let Some(prev) = prev {
+        for &ts in prev.iter().take(MAX_WINDOW - 1) {
+            out.push(ts);
+        }
+    }
+    out
+}
+
 /// A block on a candidate side-chain branch, collected while walking
 /// parent pointers back to a common ancestor on the canonical chain.
 struct ReorgBranchBlock {
@@ -18,6 +32,9 @@ struct ReorgBranchBlock {
     hash: [u8; 32],
     block_bytes: Vec<u8>,
     target: [u8; 32],
+    /// Header timestamp — used to advance the MTP sliding window during
+    /// preview validation (B.9 fix).
+    timestamp: u64,
     /// Cached txids from block parse — avoids re-parsing during mempool eviction.
     txids: Vec<[u8; 32]>,
 }
@@ -173,7 +190,7 @@ impl SyncEngine {
         }
 
         // Execute the reorg.
-        self.apply_heavier_branch(branch, common_ancestor_height, prev_timestamps)
+        self.apply_heavier_branch(branch, common_ancestor_height)
     }
 
     /// Fast path: apply the block directly if it extends the current tip
@@ -239,13 +256,11 @@ impl SyncEngine {
         &mut self,
         branch: Vec<ReorgBranchBlock>,
         common_ancestor_height: u64,
-        prev_timestamps: Option<&[u64]>,
     ) -> Result<ApplyBlockWithReorgOutcome, String> {
         let rollback = self.capture_reorg_rollback_state(common_ancestor_height);
 
         // Dry-run: preview the disconnect + reconnect on a cloned state.
-        let disconnected_blocks =
-            self.prepare_heavier_branch(&branch, common_ancestor_height, prev_timestamps)?;
+        let disconnected_blocks = self.prepare_heavier_branch(&branch, common_ancestor_height)?;
 
         // Disconnect canonical chain back to the common ancestor.
         if let Err(err) = self.disconnect_canonical_to_ancestor(common_ancestor_height) {
@@ -255,10 +270,12 @@ impl SyncEngine {
             ));
         }
 
-        // Connect the heavier branch.
+        // Connect the heavier branch.  Pass None so apply_block derives
+        // fresh timestamps from the (updated) canonical index for each block,
+        // instead of reusing the stale caller value (B.9 fix, issue #1166).
         let mut last_summary = None;
         for item in &branch {
-            match self.apply_block(&item.block_bytes, prev_timestamps) {
+            match self.apply_block(&item.block_bytes, None) {
                 Ok(summary) => last_summary = Some(summary),
                 Err(err) => {
                     return Err(Self::err_with_rollback(
@@ -298,25 +315,32 @@ impl SyncEngine {
         &self,
         branch: &[ReorgBranchBlock],
         common_ancestor_height: u64,
-        prev_timestamps: Option<&[u64]>,
     ) -> Result<Vec<Vec<u8>>, String> {
         let mut preview_state = self.chain_state.clone();
 
         let disconnected_blocks = self
             .preview_disconnect_canonical_to_ancestor(&mut preview_state, common_ancestor_height)?;
 
-        // Connect each branch block on the preview state.
+        // Build a sliding MTP window: start from pre-fork timestamps, advance
+        // after each block.  The blockstore index is NOT updated during preview,
+        // so per-block advancement uses a sliding window instead of
+        // re-deriving from the store each iteration (B.9 fix, issue #1166).
+        let mut sliding_ts = self.prev_timestamps_for_height(common_ancestor_height + 1)?;
         let (rotation, registry) = self.suite_context();
         for item in branch {
             preview_state.connect_block_with_core_ext_deployments_and_suite_context(
                 &item.block_bytes,
                 self.cfg.expected_target,
-                prev_timestamps,
+                sliding_ts.as_deref(),
                 self.cfg.chain_id,
                 &self.cfg.core_ext_deployments,
                 rotation,
                 registry,
             )?;
+            sliding_ts = Some(advance_prev_timestamps(
+                sliding_ts.as_deref(),
+                item.timestamp,
+            ));
         }
 
         Ok(disconnected_blocks)
@@ -340,6 +364,7 @@ impl SyncEngine {
             hash: block_hash_bytes,
             block_bytes: block_bytes.to_vec(),
             target: parsed.header.target,
+            timestamp: parsed.header.timestamp,
             txids: parsed.txids.clone(),
         }];
 
@@ -362,6 +387,7 @@ impl SyncEngine {
                 hash: parent_hash,
                 block_bytes: parent_bytes,
                 target: parent_parsed.header.target,
+                timestamp: parent_parsed.header.timestamp,
                 txids: parent_parsed.txids.clone(),
             });
 
@@ -1078,5 +1104,24 @@ mod tests {
         );
 
         std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    #[test]
+    fn advance_prev_timestamps_sliding_window() {
+        // Empty input → single entry.
+        let got = super::advance_prev_timestamps(None, 100);
+        assert_eq!(got, vec![100]);
+
+        // Partial window (5 entries) → prepend, len=6.
+        let prev = vec![90, 80, 70, 60, 50];
+        let got = super::advance_prev_timestamps(Some(&prev), 100);
+        assert_eq!(got, vec![100, 90, 80, 70, 60, 50]);
+
+        // Full window (11 entries) → prepend + truncate, len=11.
+        let full: Vec<u64> = (0..11).map(|i| 110 - i * 10).collect();
+        let got = super::advance_prev_timestamps(Some(&full), 200);
+        assert_eq!(got.len(), 11);
+        assert_eq!(got[0], 200);
+        assert_eq!(got[10], 20);
     }
 }


### PR DESCRIPTION
## Summary

Fix the shared `prev_timestamps` carryover bug across reorg preview/apply loops (finding B.9, issue #1166). Both Go and Rust passed the same stale MTP window to every block in a multi-block branch.

**Apply loops:** Go derives fresh timestamps from `prevTimestampsFromStore(blockStore, blockHeight)` per iteration (same pattern as `chainstate_recovery.go:154`). Rust passes `None` to `apply_block` to trigger auto-derivation from the updated canonical index.

**Preview loops:** Build a sliding window from pre-fork timestamps, advance with `advancePrevTimestamps` / `advance_prev_timestamps` per block (blockstore index not updated during dry-run).

## Changes

- `clients/go/node/sync_reorg.go`: fix apply + preview loops, add `advancePrevTimestamps`
- `clients/go/node/sync_reorg_test.go`: `reorgTestTimestamp` helper for MTP-valid timestamps, `TestAdvancePrevTimestampsSliding`
- `clients/rust/crates/rubin-node/src/sync_reorg.rs`: fix apply + preview loops, add `advance_prev_timestamps`, add `timestamp` to `ReorgBranchBlock`
- `clients/rust/crates/rubin-node/src/sync.rs`: add `prev_timestamps_for_height` method

## Verification

- `go test ./node/` — all pass (including 3 previously-buggy reorg tests with fixed timestamps)
- `cargo test -p rubin-node --lib sync_reorg` — 14/14 pass
- `cargo fmt --check` / `gofmt` / `clippy -D warnings` — clean
- `claude-review-sync` branch scope — PASS

Closes #1166