### PR TITLE
fix(disconnect): align Rust truncate/save ordering with Go

### DIFF
--- a/clients/rust/crates/rubin-consensus/src/connect_block_inmem.rs
+++ b/clients/rust/crates/rubin-consensus/src/connect_block_inmem.rs
@@ -378,7 +378,7 @@ pub(crate) fn utxo_set_hash(utxos: &HashMap<Outpoint, UtxoEntry>) -> [u8; 32] {
         key[32..].copy_from_slice(&outpoint.vout.to_le_bytes());
         items.push((key, entry));
     }
-    items.sort_by(|a, b| a.0.cmp(&b.0));
+    items.sort_by_key(|a| a.0);
 
     let mut buf = Vec::with_capacity(UTXO_SET_HASH_DST.len() + 8 + items.len() * 64);
     buf.extend_from_slice(UTXO_SET_HASH_DST);

--- a/clients/rust/crates/rubin-consensus/src/connect_block_inmem.rs
+++ b/clients/rust/crates/rubin-consensus/src/connect_block_inmem.rs
@@ -378,7 +378,11 @@ pub(crate) fn utxo_set_hash(utxos: &HashMap<Outpoint, UtxoEntry>) -> [u8; 32] {
         key[32..].copy_from_slice(&outpoint.vout.to_le_bytes());
         items.push((key, entry));
     }
-    items.sort_by_key(|a| a.0);
+    // sort_unstable_by avoids decorate/sort/undecorate copies of the
+    // [u8; 36] key that sort_by_key/sort_unstable_by_key would do —
+    // important on the consensus digest path with large UTXO sets.
+    #[allow(clippy::unnecessary_sort_by)]
+    items.sort_unstable_by(|a, b| a.0.cmp(&b.0));
 
     let mut buf = Vec::with_capacity(UTXO_SET_HASH_DST.len() + 8 + items.len() * 64);
     buf.extend_from_slice(UTXO_SET_HASH_DST);

--- a/clients/rust/crates/rubin-consensus/src/tx.rs
+++ b/clients/rust/crates/rubin-consensus/src/tx.rs
@@ -332,16 +332,16 @@ pub(crate) fn parse_tx_without_hashes(b: &[u8]) -> Result<(Tx, usize, usize), Tx
                     ));
                 }
             }
-            SUITE_ID_ML_DSA_87 => {
+            SUITE_ID_ML_DSA_87
                 if !(pub_len_u64 == ML_DSA_87_PUBKEY_BYTES
-                    && sig_len_u64 == ML_DSA_87_SIG_BYTES + 1)
-                {
-                    return Err(TxError::new(
-                        ErrorCode::TxErrSigNoncanonical,
-                        "non-canonical ML-DSA witness item lengths",
-                    ));
-                }
+                    && sig_len_u64 == ML_DSA_87_SIG_BYTES + 1) =>
+            {
+                return Err(TxError::new(
+                    ErrorCode::TxErrSigNoncanonical,
+                    "non-canonical ML-DSA witness item lengths",
+                ));
             }
+            SUITE_ID_ML_DSA_87 => {}
             _ => {}
         }
 

--- a/clients/rust/crates/rubin-node/src/blockstore.rs
+++ b/clients/rust/crates/rubin-node/src/blockstore.rs
@@ -100,6 +100,9 @@ impl BlockStore {
         self.set_canonical_tip(height, block_hash_bytes)
     }
 
+    /// Set or replace the canonical tip at `height`.  Atomic: in-memory
+    /// canonical is updated only after the disk write succeeds, so a
+    /// failed call leaves the in-memory state unchanged.
     pub fn set_canonical_tip(
         &mut self,
         height: u64,
@@ -112,15 +115,25 @@ impl BlockStore {
                 "height gap: got {height}, expected <= {current_len}"
             ));
         }
-        if height == current_len {
-            self.index.canonical.push(hash_hex);
-        } else if self.index.canonical[height as usize] != hash_hex {
-            self.index.canonical.truncate(height as usize);
-            self.index.canonical.push(hash_hex);
+        // Skip the disk write if the in-memory slot already holds the
+        // exact same hash.  Otherwise build the next index out-of-place.
+        if height < current_len && self.index.canonical[height as usize] == hash_hex {
+            return Ok(());
         }
-        save_blockstore_index(&self.index_path, &self.index)
+        let mut next_index = self.index.clone();
+        if height == current_len {
+            next_index.canonical.push(hash_hex);
+        } else {
+            next_index.canonical.truncate(height as usize);
+            next_index.canonical.push(hash_hex);
+        }
+        save_blockstore_index(&self.index_path, &next_index)?;
+        self.index = next_index;
+        Ok(())
     }
 
+    /// Rewind canonical to (height + 1) entries.  Atomic: in-memory
+    /// state is updated only after the disk write succeeds.
     pub fn rewind_to_height(&mut self, height: u64) -> Result<(), String> {
         if self.index.canonical.is_empty() {
             return Ok(());
@@ -128,8 +141,11 @@ impl BlockStore {
         if height >= self.index.canonical.len() as u64 {
             return Err(format!("rewind height out of range: {height}"));
         }
-        self.index.canonical.truncate(height as usize + 1);
-        save_blockstore_index(&self.index_path, &self.index)
+        let mut next_index = self.index.clone();
+        next_index.canonical.truncate(height as usize + 1);
+        save_blockstore_index(&self.index_path, &next_index)?;
+        self.index = next_index;
+        Ok(())
     }
 
     pub fn canonical_hash(&self, height: u64) -> Result<Option<[u8; 32]>, String> {
@@ -331,6 +347,11 @@ impl BlockStore {
     ///
     /// Atomic: on disk-write failure the index is reloaded from disk
     /// so in-memory state stays consistent (no temp buffer needed).
+    /// Restore canonical to `base_len` entries from current canonical
+    /// followed by `suffix`.  Atomic: in-memory state is updated ONLY
+    /// after the disk write succeeds, so a failed call leaves the
+    /// in-memory canonical exactly as it was before the call (callers
+    /// can rely on `Err` meaning "no state change").
     pub fn rollback_canonical(
         &mut self,
         base_len: usize,
@@ -340,22 +361,23 @@ impl BlockStore {
         if self.force_rollback_error {
             return Err("forced rollback error (test inject)".into());
         }
-        let mut restored = Vec::with_capacity(base_len + suffix.len());
-        restored
+        let mut next_canonical = Vec::with_capacity(base_len + suffix.len());
+        next_canonical
             .extend_from_slice(&self.index.canonical[..base_len.min(self.index.canonical.len())]);
-        restored.extend(suffix);
-        self.index.canonical = restored;
-        if let Err(e) = save_blockstore_index(&self.index_path, &self.index) {
-            self.reload_index_from_disk();
-            return Err(e);
-        }
+        next_canonical.extend(suffix);
+        let mut next_index = self.index.clone();
+        next_index.canonical = next_canonical;
+        save_blockstore_index(&self.index_path, &next_index)?;
+        self.index = next_index;
         Ok(())
     }
 
     /// Truncate canonical index to exactly `new_len` entries.
     ///
-    /// Atomic: on disk-write failure the index is reloaded from disk
-    /// (the atomic write guarantees the old version is still on disk).
+    /// Atomic: in-memory state is updated ONLY after the disk write
+    /// succeeds.  A failed call leaves the in-memory canonical exactly
+    /// as it was before, so callers can rely on `Err` meaning "no
+    /// state change".
     pub fn truncate_canonical(&mut self, new_len: usize) -> Result<(), String> {
         #[cfg(test)]
         if self.force_truncate_error {
@@ -368,25 +390,11 @@ impl BlockStore {
                 self.index.canonical.len()
             ));
         }
-        self.index.canonical.truncate(new_len);
-        if let Err(e) = save_blockstore_index(&self.index_path, &self.index) {
-            self.reload_index_from_disk();
-            return Err(e);
-        }
+        let mut next_index = self.index.clone();
+        next_index.canonical.truncate(new_len);
+        save_blockstore_index(&self.index_path, &next_index)?;
+        self.index = next_index;
         Ok(())
-    }
-
-    /// Reload the blockstore index from disk to restore consistency
-    /// after a failed save.  Since `save_blockstore_index` uses
-    /// write-to-tmp + rename, the on-disk file is always a valid
-    /// previous version.
-    fn reload_index_from_disk(&mut self) {
-        if let Ok(disk) = load_blockstore_index(&self.index_path) {
-            self.index = disk;
-        }
-        // If reload also fails, in-memory state is stale but we
-        // already returned an error to the caller — the engine will
-        // be marked as needing repair.
     }
 }
 

--- a/clients/rust/crates/rubin-node/src/blockstore.rs
+++ b/clients/rust/crates/rubin-node/src/blockstore.rs
@@ -366,14 +366,20 @@ impl BlockStore {
         if self.force_rollback_error {
             return Err("forced rollback error (test inject)".into());
         }
-        let mut next_canonical = Vec::with_capacity(base_len + suffix.len());
-        next_canonical
-            .extend_from_slice(&self.index.canonical[..base_len.min(self.index.canonical.len())]);
+        // Build the target canonical once (owning only `suffix` + a
+        // slice clone of `base_len` prefix entries).  No clone of the
+        // entries BEYOND `base_len`.
+        let clamped_base = base_len.min(self.index.canonical.len());
+        let mut next_canonical = Vec::with_capacity(clamped_base + suffix.len());
+        next_canonical.extend_from_slice(&self.index.canonical[..clamped_base]);
         next_canonical.extend(suffix);
-        let mut next_index = self.index.clone();
-        next_index.canonical = next_canonical;
-        save_blockstore_index(&self.index_path, &next_index)?;
-        self.index = next_index;
+        let view = BlockStoreIndexView {
+            version: self.index.version,
+            canonical: &next_canonical,
+        };
+        save_blockstore_index_serializable(&self.index_path, &view)?;
+        // Save succeeded — commit to in-memory.
+        self.index.canonical = next_canonical;
         Ok(())
     }
 
@@ -382,23 +388,30 @@ impl BlockStore {
     /// Atomic: in-memory state is updated ONLY after the disk write
     /// succeeds.  A failed call leaves the in-memory canonical exactly
     /// as it was before, so callers can rely on `Err` meaning "no
-    /// state change".
+    /// state change".  Writes a borrowed slice-backed view of the
+    /// target prefix instead of cloning all canonical strings.
     pub fn truncate_canonical(&mut self, new_len: usize) -> Result<(), String> {
         #[cfg(test)]
         if self.force_truncate_error {
             return Err("forced truncate error (test inject)".into());
         }
-        if new_len > self.index.canonical.len() {
+        let current_len = self.index.canonical.len();
+        if new_len > current_len {
             return Err(format!(
-                "truncate_canonical new_len {} > current {}",
-                new_len,
-                self.index.canonical.len()
+                "truncate_canonical new_len {new_len} > current {current_len}"
             ));
         }
-        let mut next_index = self.index.clone();
-        next_index.canonical.truncate(new_len);
-        save_blockstore_index(&self.index_path, &next_index)?;
-        self.index = next_index;
+        // Fast-path: already at target length, skip the disk write.
+        if new_len == current_len {
+            return Ok(());
+        }
+        let view = BlockStoreIndexView {
+            version: self.index.version,
+            canonical: &self.index.canonical[..new_len],
+        };
+        save_blockstore_index_serializable(&self.index_path, &view)?;
+        // Save succeeded — now apply O(1) in-memory truncate.
+        self.index.canonical.truncate(new_len);
         Ok(())
     }
 
@@ -447,10 +460,30 @@ fn load_blockstore_index(path: &Path) -> Result<BlockStoreIndexDisk, String> {
 }
 
 fn save_blockstore_index(path: &Path, index: &BlockStoreIndexDisk) -> Result<(), String> {
+    save_blockstore_index_serializable(path, index)
+}
+
+/// Generic save: accepts any `Serialize` value with the same on-disk
+/// shape as `BlockStoreIndexDisk`.  Lets `truncate_canonical` and
+/// `rollback_canonical` pass a borrowed slice-backed view without
+/// cloning all canonical strings.
+fn save_blockstore_index_serializable<S: serde::Serialize + ?Sized>(
+    path: &Path,
+    index: &S,
+) -> Result<(), String> {
     let mut raw =
         serde_json::to_vec_pretty(index).map_err(|e| format!("encode blockstore index: {e}"))?;
     raw.push(b'\n');
     write_file_atomic(path, &raw)
+}
+
+/// Borrowed view of `BlockStoreIndexDisk` that serializes identically
+/// but holds `&[String]` instead of owning the vector.  Used for
+/// out-of-place writes (truncate/rollback) on the rare disconnect path.
+#[derive(serde::Serialize)]
+struct BlockStoreIndexView<'a> {
+    version: u32,
+    canonical: &'a [String],
 }
 
 fn write_file_if_absent(path: &Path, content: &[u8]) -> Result<(), String> {

--- a/clients/rust/crates/rubin-node/src/blockstore.rs
+++ b/clients/rust/crates/rubin-node/src/blockstore.rs
@@ -24,6 +24,9 @@ pub struct BlockStore {
     /// Test-only: force `truncate_canonical` to return an error.
     #[cfg(test)]
     pub force_truncate_error: bool,
+    /// Test-only: force `rollback_canonical` to return an error.
+    #[cfg(test)]
+    pub force_rollback_error: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -61,6 +64,8 @@ impl BlockStore {
             index,
             #[cfg(test)]
             force_truncate_error: false,
+            #[cfg(test)]
+            force_rollback_error: false,
         })
     }
 
@@ -331,6 +336,10 @@ impl BlockStore {
         base_len: usize,
         suffix: Vec<String>,
     ) -> Result<(), String> {
+        #[cfg(test)]
+        if self.force_rollback_error {
+            return Err("forced rollback error (test inject)".into());
+        }
         let mut restored = Vec::with_capacity(base_len + suffix.len());
         restored
             .extend_from_slice(&self.index.canonical[..base_len.min(self.index.canonical.len())]);

--- a/clients/rust/crates/rubin-node/src/blockstore.rs
+++ b/clients/rust/crates/rubin-node/src/blockstore.rs
@@ -23,10 +23,10 @@ pub struct BlockStore {
     index: BlockStoreIndexDisk,
     /// Test-only: force `truncate_canonical` to return an error.
     #[cfg(test)]
-    pub force_truncate_error: bool,
+    pub(crate) force_truncate_error: bool,
     /// Test-only: force `rollback_canonical` to return an error.
     #[cfg(test)]
-    pub force_rollback_error: bool,
+    pub(crate) force_rollback_error: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/clients/rust/crates/rubin-node/src/blockstore.rs
+++ b/clients/rust/crates/rubin-node/src/blockstore.rs
@@ -21,6 +21,9 @@ pub struct BlockStore {
     headers_dir: PathBuf,
     undo_dir: PathBuf,
     index: BlockStoreIndexDisk,
+    /// Test-only: force `truncate_canonical` to return an error.
+    #[cfg(test)]
+    pub force_truncate_error: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -56,6 +59,8 @@ impl BlockStore {
             headers_dir,
             undo_dir,
             index,
+            #[cfg(test)]
+            force_truncate_error: false,
         })
     }
 
@@ -179,10 +184,7 @@ impl BlockStore {
         let mut out = Vec::with_capacity(limit);
         let mut step = 1u64;
         let mut appended = 0usize;
-        loop {
-            let Some(hash) = self.canonical_hash(tip_height)? else {
-                break;
-            };
+        while let Some(hash) = self.canonical_hash(tip_height)? {
             out.push(hash);
             appended += 1;
             if appended >= limit || tip_height == 0 {
@@ -346,6 +348,10 @@ impl BlockStore {
     /// Atomic: on disk-write failure the index is reloaded from disk
     /// (the atomic write guarantees the old version is still on disk).
     pub fn truncate_canonical(&mut self, new_len: usize) -> Result<(), String> {
+        #[cfg(test)]
+        if self.force_truncate_error {
+            return Err("forced truncate error (test inject)".into());
+        }
         if new_len > self.index.canonical.len() {
             return Err(format!(
                 "truncate_canonical new_len {} > current {}",

--- a/clients/rust/crates/rubin-node/src/blockstore.rs
+++ b/clients/rust/crates/rubin-node/src/blockstore.rs
@@ -100,9 +100,13 @@ impl BlockStore {
         self.set_canonical_tip(height, block_hash_bytes)
     }
 
-    /// Set or replace the canonical tip at `height`.  Atomic: in-memory
-    /// canonical is updated only after the disk write succeeds, so a
-    /// failed call leaves the in-memory state unchanged.
+    /// Set or replace the canonical tip at `height`.
+    ///
+    /// Hot path (called per connected block via `put_block`): mutate
+    /// in-memory then save; on save failure best-effort
+    /// `reload_index_from_disk` to restore in-memory consistency.
+    /// Avoids the O(chain_height) clone that out-of-place transactions
+    /// would cost on every block.
     pub fn set_canonical_tip(
         &mut self,
         height: u64,
@@ -115,25 +119,28 @@ impl BlockStore {
                 "height gap: got {height}, expected <= {current_len}"
             ));
         }
-        // Skip the disk write if the in-memory slot already holds the
-        // exact same hash.  Otherwise build the next index out-of-place.
+        // No-op if in-memory already holds this exact hash at this height.
         if height < current_len && self.index.canonical[height as usize] == hash_hex {
             return Ok(());
         }
-        let mut next_index = self.index.clone();
         if height == current_len {
-            next_index.canonical.push(hash_hex);
+            self.index.canonical.push(hash_hex);
         } else {
-            next_index.canonical.truncate(height as usize);
-            next_index.canonical.push(hash_hex);
+            self.index.canonical.truncate(height as usize);
+            self.index.canonical.push(hash_hex);
         }
-        save_blockstore_index(&self.index_path, &next_index)?;
-        self.index = next_index;
+        if let Err(e) = save_blockstore_index(&self.index_path, &self.index) {
+            self.reload_index_from_disk();
+            return Err(e);
+        }
         Ok(())
     }
 
-    /// Rewind canonical to (height + 1) entries.  Atomic: in-memory
-    /// state is updated only after the disk write succeeds.
+    /// Rewind canonical to (height + 1) entries.
+    ///
+    /// Same hot-path strategy as `set_canonical_tip`: mutate-then-save
+    /// with reload on failure (avoids per-call clone of the canonical
+    /// vector).
     pub fn rewind_to_height(&mut self, height: u64) -> Result<(), String> {
         if self.index.canonical.is_empty() {
             return Ok(());
@@ -141,10 +148,11 @@ impl BlockStore {
         if height >= self.index.canonical.len() as u64 {
             return Err(format!("rewind height out of range: {height}"));
         }
-        let mut next_index = self.index.clone();
-        next_index.canonical.truncate(height as usize + 1);
-        save_blockstore_index(&self.index_path, &next_index)?;
-        self.index = next_index;
+        self.index.canonical.truncate(height as usize + 1);
+        if let Err(e) = save_blockstore_index(&self.index_path, &self.index) {
+            self.reload_index_from_disk();
+            return Err(e);
+        }
         Ok(())
     }
 
@@ -345,13 +353,10 @@ impl BlockStore {
     /// `base_len` (removing entries added during reconnect), then
     /// re-append `suffix` (entries removed during disconnect).
     ///
-    /// Atomic: on disk-write failure the index is reloaded from disk
-    /// so in-memory state stays consistent (no temp buffer needed).
-    /// Restore canonical to `base_len` entries from current canonical
-    /// followed by `suffix`.  Atomic: in-memory state is updated ONLY
-    /// after the disk write succeeds, so a failed call leaves the
-    /// in-memory canonical exactly as it was before the call (callers
-    /// can rely on `Err` meaning "no state change").
+    /// Atomic via out-of-place transaction: build the next index as a
+    /// clone, save to disk, then commit to in-memory only on success.
+    /// A failed call leaves the in-memory canonical exactly as it was
+    /// before, so callers can rely on `Err` meaning "no state change".
     pub fn rollback_canonical(
         &mut self,
         base_len: usize,
@@ -395,6 +400,20 @@ impl BlockStore {
         save_blockstore_index(&self.index_path, &next_index)?;
         self.index = next_index;
         Ok(())
+    }
+
+    /// Reload the blockstore index from disk to restore in-memory
+    /// consistency after a failed save in a hot-path mutator
+    /// (`set_canonical_tip`, `rewind_to_height`).  Best-effort: if the
+    /// reload itself fails the in-memory state is stale, but we have
+    /// already returned the original error to the caller — the engine
+    /// is in an unrecoverable state and needs repair.  Not used by
+    /// `truncate_canonical` / `rollback_canonical`, which use the
+    /// out-of-place transaction pattern instead.
+    fn reload_index_from_disk(&mut self) {
+        if let Ok(disk) = load_blockstore_index(&self.index_path) {
+            self.index = disk;
+        }
     }
 }
 

--- a/clients/rust/crates/rubin-node/src/chainstate.rs
+++ b/clients/rust/crates/rubin-node/src/chainstate.rs
@@ -291,7 +291,11 @@ fn utxo_set_hash(utxos: &HashMap<Outpoint, UtxoEntry>) -> [u8; 32] {
         key[32..].copy_from_slice(&outpoint.vout.to_le_bytes());
         items.push((key, entry));
     }
-    items.sort_by_key(|a| a.0);
+    // sort_unstable_by avoids decorate/sort/undecorate copies of the
+    // [u8; 36] key that sort_by_key/sort_unstable_by_key would do —
+    // important on the consensus digest path with large UTXO sets.
+    #[allow(clippy::unnecessary_sort_by)]
+    items.sort_unstable_by(|a, b| a.0.cmp(&b.0));
 
     let mut buf = Vec::with_capacity(UTXO_SET_HASH_DST.len() + 8 + items.len() * 64);
     buf.extend_from_slice(UTXO_SET_HASH_DST);

--- a/clients/rust/crates/rubin-node/src/chainstate.rs
+++ b/clients/rust/crates/rubin-node/src/chainstate.rs
@@ -291,7 +291,7 @@ fn utxo_set_hash(utxos: &HashMap<Outpoint, UtxoEntry>) -> [u8; 32] {
         key[32..].copy_from_slice(&outpoint.vout.to_le_bytes());
         items.push((key, entry));
     }
-    items.sort_by(|a, b| a.0.cmp(&b.0));
+    items.sort_by_key(|a| a.0);
 
     let mut buf = Vec::with_capacity(UTXO_SET_HASH_DST.len() + 8 + items.len() * 64);
     buf.extend_from_slice(UTXO_SET_HASH_DST);

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -635,14 +635,14 @@ impl PeerSession {
         let mut requests = Vec::new();
         for vector in vectors {
             match vector.kind {
-                MSG_BLOCK => {
+                MSG_BLOCK
                     if !sync_engine
                         .has_block(vector.hash)
-                        .map_err(io::Error::other)?
-                    {
-                        requests.push(vector);
-                    }
+                        .map_err(io::Error::other)? =>
+                {
+                    requests.push(vector);
                 }
+                MSG_BLOCK => {}
                 MSG_TX => {
                     if let Some(rs) = relay_state {
                         if !rs.tx_seen.has(&vector.hash) && !rs.relay_pool.has(&vector.hash) {

--- a/clients/rust/crates/rubin-node/src/sync.rs
+++ b/clients/rust/crates/rubin-node/src/sync.rs
@@ -262,6 +262,12 @@ pub struct SyncEngine {
     pv_shadow_mismatches: u64,
     pv_shadow_samples: Vec<String>,
     pv_telemetry: PVTelemetry,
+    /// Test-only: drop block_store after canonical truncate (between
+    /// truncate and save) to exercise the otherwise-unreachable
+    /// blockstore-missing branch in disconnect_tip's save-failure
+    /// recovery.
+    #[cfg(test)]
+    pub(crate) drop_block_store_after_truncate: bool,
 }
 
 /// Captured state for rollback on failure during reorg.
@@ -342,6 +348,8 @@ impl SyncEngine {
             pv_shadow_mismatches: 0,
             pv_shadow_samples: Vec::new(),
             pv_telemetry: PVTelemetry::new(pv_mode),
+            #[cfg(test)]
+            drop_block_store_after_truncate: false,
         })
     }
 

--- a/clients/rust/crates/rubin-node/src/sync_disconnect.rs
+++ b/clients/rust/crates/rubin-node/src/sync_disconnect.rs
@@ -59,6 +59,13 @@ impl SyncEngine {
             ));
         }
 
+        // Test-only seam to exercise the otherwise-unreachable
+        // blockstore-missing branch in the save-failure recovery below.
+        #[cfg(test)]
+        if self.drop_block_store_after_truncate {
+            self.block_store = None;
+        }
+
         if let Some(path) = self.cfg.chain_state_path.as_ref() {
             if let Err(err) = self.chain_state.save(path) {
                 // Restore canonical tip directly, then restore in-memory
@@ -504,6 +511,47 @@ mod tests {
         assert_eq!(
             engine.tip_timestamp, gen_ts,
             "tip_timestamp must be parent's (genesis) when canonical rollback failed"
+        );
+
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    #[test]
+    fn disconnect_tip_save_failure_with_blockstore_dropped_propagates_error() {
+        // Test-only seam: drop block_store between truncate and save so the
+        // save-failure recovery hits the otherwise-unreachable None branch.
+        // Verifies the branch propagates a normal error (no panic) and
+        // aligns tip_timestamp with the disconnected parent.
+        let (mut engine, dir) = engine_with_store("rubin-disc-bs-dropped");
+        let (genesis, genesis_hash, gen_ts) = genesis_info();
+
+        engine.apply_block(&genesis, None).expect("genesis");
+        let block1 = height_one_coinbase_only_block(genesis_hash, gen_ts + 1);
+        engine.apply_block(&block1, None).expect("block 1");
+
+        // Force save() to fail deterministically (regular file as parent).
+        let cs_parent_file = dir.join("chainstate-parent-file");
+        std::fs::write(&cs_parent_file, b"not a directory").expect("create parent file");
+        engine.cfg.chain_state_path = Some(cs_parent_file.join("state.bin"));
+        // Arm the test seam: drop block_store after the first truncate so the
+        // save-failure recovery cannot re-borrow it.
+        engine.drop_block_store_after_truncate = true;
+
+        let err = engine.disconnect_tip().unwrap_err();
+        // Composite error must mention both the save error and the
+        // blockstore-missing rollback note.
+        assert!(
+            err.contains("rollback failed"),
+            "expected rollback failure note, got: {err}"
+        );
+        assert!(
+            err.contains("blockstore missing after canonical truncate"),
+            "expected blockstore-missing note, got: {err}"
+        );
+        // tip_timestamp must align with the disconnected parent (genesis).
+        assert_eq!(
+            engine.tip_timestamp, gen_ts,
+            "tip_timestamp must be parent's (genesis) on blockstore-missing branch"
         );
 
         std::fs::remove_dir_all(&dir).expect("cleanup");

--- a/clients/rust/crates/rubin-node/src/sync_disconnect.rs
+++ b/clients/rust/crates/rubin-node/src/sync_disconnect.rs
@@ -362,7 +362,10 @@ mod tests {
         );
 
         // In-memory chain_state must also be restored to pre-disconnect tip.
-        assert!(engine.chain_state.has_tip, "chain_state.has_tip not restored");
+        assert!(
+            engine.chain_state.has_tip,
+            "chain_state.has_tip not restored"
+        );
         assert_eq!(
             engine.chain_state.height, tip_before.0,
             "chain_state.height not restored after save failure"

--- a/clients/rust/crates/rubin-node/src/sync_disconnect.rs
+++ b/clients/rust/crates/rubin-node/src/sync_disconnect.rs
@@ -286,8 +286,10 @@ mod tests {
 
     #[test]
     fn disconnect_tip_save_failure_restores_canonical() {
-        // Cover lines 69-71: save fails after truncate, rollback_canonical
-        // restores the truncated entry, rollback_apply_block runs.
+        // Save fails after truncate: rollback_canonical re-appends tip_hash,
+        // then in-memory chain_state is restored inline.  rollback_apply_block
+        // is NOT called here — that path is exercised only on truncate
+        // failure (see disconnect_tip_truncate_error_propagates_with_rollback).
         let (mut engine, dir) = engine_with_store("rubin-disc-save-fail");
         let (genesis, genesis_hash, gen_ts) = genesis_info();
 
@@ -352,7 +354,11 @@ mod tests {
             .expect("some");
         assert_eq!(
             tip_after.0, tip_before.0,
-            "canonical index should be restored after save failure"
+            "canonical index height should be restored after save failure"
+        );
+        assert_eq!(
+            tip_after.1, tip_before.1,
+            "canonical tip hash should be restored after save failure"
         );
 
         // In-memory chain_state must also be restored to pre-disconnect tip.

--- a/clients/rust/crates/rubin-node/src/sync_disconnect.rs
+++ b/clients/rust/crates/rubin-node/src/sync_disconnect.rs
@@ -273,6 +273,11 @@ mod tests {
 
     #[test]
     fn disconnect_tip_truncate_error_propagates_with_rollback() {
+        // Both the initial truncate AND the rollback_apply_block phase-1
+        // truncate fail (force_truncate_error stays armed for both calls),
+        // so the composite error reports both failures.  Engine state ends
+        // up at post-disconnect_block (chain_state.height=0) while canonical
+        // is still untouched ([genesis, block1]) — verified after disarm.
         let (mut engine, dir) = engine_with_store("rubin-disc-trunc-err");
         let (genesis, genesis_hash, gen_ts) = genesis_info();
 
@@ -288,6 +293,29 @@ mod tests {
             err.contains("forced truncate error"),
             "expected forced truncate error, got: {err}"
         );
+        // Composite error must surface BOTH the main error and the
+        // rollback-phase failure (rollback_apply_block also tried to
+        // truncate and got the same injected error).
+        assert!(
+            err.contains("rollback failed"),
+            "expected rollback failure note, got: {err}"
+        );
+
+        // Disarm so cleanup succeeds.
+        engine.block_store.as_mut().unwrap().force_truncate_error = false;
+
+        // Canonical never mutated (both truncate calls failed before write).
+        let tip = engine
+            .block_store
+            .as_ref()
+            .unwrap()
+            .tip()
+            .expect("tip")
+            .expect("some");
+        assert_eq!(
+            tip.0, 1,
+            "canonical should still have block1 after both truncate failures"
+        );
 
         std::fs::remove_dir_all(&dir).expect("cleanup");
     }
@@ -296,8 +324,9 @@ mod tests {
     fn disconnect_tip_save_failure_restores_canonical() {
         // Save fails after truncate: rollback_canonical re-appends tip_hash,
         // then in-memory chain_state is restored inline.  rollback_apply_block
-        // is NOT called here — that path is exercised only on truncate
-        // failure (see disconnect_tip_truncate_error_propagates_with_rollback).
+        // is NOT called in the save-failure branch (it is called only on
+        // truncate failure, but that path tests its own assertions in
+        // disconnect_tip_truncate_error_propagates_with_rollback).
         let (mut engine, dir) = engine_with_store("rubin-disc-save-fail");
         let (genesis, genesis_hash, gen_ts) = genesis_info();
 

--- a/clients/rust/crates/rubin-node/src/sync_disconnect.rs
+++ b/clients/rust/crates/rubin-node/src/sync_disconnect.rs
@@ -67,16 +67,20 @@ impl SyncEngine {
                 // truncate_canonical(rb.canonical_len)) on an already
                 // restored index, which can fail independently and leave
                 // chain_state un-rolled-back.
-                let canonical_rb = if let Some(bs) = self.block_store.as_mut() {
-                    bs.rollback_canonical(
+                //
+                // Blockstore presence is an invariant at this point — the
+                // function-top check (line 14) and the successful
+                // truncate_canonical above both prove block_store is Some.
+                let bs = self.block_store.as_mut().expect(
+                    "disconnect_tip rollback invariant: blockstore missing after canonical truncate",
+                );
+                let canonical_rb = bs
+                    .rollback_canonical(
                         rollback.canonical_len.saturating_sub(1),
                         vec![hex::encode(tip_hash)],
                     )
                     .err()
-                    .map(|e| format!("canonical restore failed: {e}"))
-                } else {
-                    None
-                };
+                    .map(|e| format!("canonical restore failed: {e}"));
                 // Only restore in-memory state if canonical rollback succeeded.
                 // If canonical is still truncated and we restore chain_state to
                 // the pre-disconnect tip, the next operation hits the

--- a/clients/rust/crates/rubin-node/src/sync_disconnect.rs
+++ b/clients/rust/crates/rubin-node/src/sync_disconnect.rs
@@ -59,20 +59,26 @@ impl SyncEngine {
 
         if let Some(path) = self.cfg.chain_state_path.as_ref() {
             if let Err(err) = self.chain_state.save(path) {
-                // Restore the truncated canonical entry so rollback_apply_block
-                // can succeed (truncate_canonical cannot extend).
-                if let Some(bs) = self.block_store.as_mut() {
-                    // Best-effort: if this also fails, err_with_rollback
-                    // will report the compound failure.
-                    let _ = bs.rollback_canonical(
+                // Restore canonical tip directly, then restore in-memory
+                // state inline.  Going through rollback_apply_block here
+                // would trigger a second canonical write (light-rollback
+                // truncate_canonical(rb.canonical_len)) on an already
+                // restored index, which can fail independently and leave
+                // chain_state un-rolled-back.
+                let canonical_rb = if let Some(bs) = self.block_store.as_mut() {
+                    bs.rollback_canonical(
                         rollback.canonical_len.saturating_sub(1),
                         vec![hex::encode(tip_hash)],
-                    );
-                }
-                return Err(SyncEngine::err_with_rollback(
-                    err,
-                    self.rollback_apply_block(rollback),
-                ));
+                    )
+                    .err()
+                    .map(|e| format!("canonical restore failed: {e}"))
+                } else {
+                    None
+                };
+                self.chain_state = rollback.chain_state;
+                self.tip_timestamp = rollback.tip_timestamp;
+                self.best_known_height = rollback.best_known_height;
+                return Err(SyncEngine::err_with_rollback(err, canonical_rb));
             }
         }
 
@@ -347,6 +353,17 @@ mod tests {
         assert_eq!(
             tip_after.0, tip_before.0,
             "canonical index should be restored after save failure"
+        );
+
+        // In-memory chain_state must also be restored to pre-disconnect tip.
+        assert!(engine.chain_state.has_tip, "chain_state.has_tip not restored");
+        assert_eq!(
+            engine.chain_state.height, tip_before.0,
+            "chain_state.height not restored after save failure"
+        );
+        assert_eq!(
+            engine.chain_state.tip_hash, tip_before.1,
+            "chain_state.tip_hash not restored after save failure"
         );
 
         std::fs::remove_dir_all(&dir).expect("cleanup");

--- a/clients/rust/crates/rubin-node/src/sync_disconnect.rs
+++ b/clients/rust/crates/rubin-node/src/sync_disconnect.rs
@@ -75,9 +75,17 @@ impl SyncEngine {
                 } else {
                     None
                 };
-                self.chain_state = rollback.chain_state;
-                self.tip_timestamp = rollback.tip_timestamp;
-                self.best_known_height = rollback.best_known_height;
+                // Only restore in-memory state if canonical rollback succeeded.
+                // If canonical is still truncated and we restore chain_state to
+                // the pre-disconnect tip, the next operation hits the
+                // mismatch guard at the top of disconnect_tip.  Leaving
+                // chain_state in its post-disconnect_block state keeps it
+                // aligned with the truncated canonical (both at parent tip).
+                if canonical_rb.is_none() {
+                    self.chain_state = rollback.chain_state;
+                    self.tip_timestamp = rollback.tip_timestamp;
+                    self.best_known_height = rollback.best_known_height;
+                }
                 return Err(SyncEngine::err_with_rollback(err, canonical_rb));
             }
         }
@@ -373,6 +381,65 @@ mod tests {
         assert_eq!(
             engine.chain_state.tip_hash, tip_before.1,
             "chain_state.tip_hash not restored after save failure"
+        );
+
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    #[test]
+    fn disconnect_tip_save_and_canonical_rollback_both_fail() {
+        // Double-failure case: save() fails AND rollback_canonical() fails.
+        // chain_state must NOT be restored to pre-disconnect tip — that would
+        // create a mismatch with the truncated canonical.  Engine remains in
+        // post-disconnect state (parent tip, canonical missing original tip).
+        let (mut engine, dir) = engine_with_store("rubin-disc-double-fail");
+        let (genesis, genesis_hash, gen_ts) = genesis_info();
+
+        engine.apply_block(&genesis, None).expect("genesis");
+        let block1 = height_one_coinbase_only_block(genesis_hash, gen_ts + 1);
+        engine.apply_block(&block1, None).expect("block 1");
+
+        // Detach chain_state path so save() fails; arm rollback inject so
+        // canonical restore also fails after truncate succeeds.
+        engine.cfg.chain_state_path = Some(std::path::PathBuf::from("/nonexistent/dir/state.bin"));
+        engine.block_store.as_mut().unwrap().force_rollback_error = true;
+
+        let err = engine.disconnect_tip().unwrap_err();
+        // Composite error must mention both failures.
+        assert!(
+            err.contains("rollback failed"),
+            "expected rollback failure note, got: {err}"
+        );
+        assert!(
+            err.contains("canonical restore failed"),
+            "expected canonical restore failure note, got: {err}"
+        );
+
+        // Disarm so cleanup succeeds.
+        engine.block_store.as_mut().unwrap().force_rollback_error = false;
+
+        // Canonical was truncated and rollback failed — tip is now genesis.
+        let tip = engine
+            .block_store
+            .as_ref()
+            .unwrap()
+            .tip()
+            .expect("tip")
+            .expect("some");
+        assert_eq!(
+            tip.0, 0,
+            "canonical should be at genesis after failed rollback"
+        );
+        assert_eq!(tip.1, genesis_hash, "canonical tip should be genesis hash");
+
+        // chain_state must align with truncated canonical (not pre-disconnect).
+        assert_eq!(
+            engine.chain_state.height, 0,
+            "chain_state must NOT be restored when canonical rollback failed"
+        );
+        assert_eq!(
+            engine.chain_state.tip_hash, genesis_hash,
+            "chain_state tip must align with truncated canonical (genesis)"
         );
 
         std::fs::remove_dir_all(&dir).expect("cleanup");

--- a/clients/rust/crates/rubin-node/src/sync_disconnect.rs
+++ b/clients/rust/crates/rubin-node/src/sync_disconnect.rs
@@ -68,19 +68,30 @@ impl SyncEngine {
                 // restored index, which can fail independently and leave
                 // chain_state un-rolled-back.
                 //
-                // Blockstore presence is an invariant at this point — the
-                // function-top check (line 14) and the successful
-                // truncate_canonical above both prove block_store is Some.
-                let bs = self.block_store.as_mut().expect(
-                    "disconnect_tip rollback invariant: blockstore missing after canonical truncate",
-                );
-                let canonical_rb = bs
-                    .rollback_canonical(
-                        rollback.canonical_len.saturating_sub(1),
-                        vec![hex::encode(tip_hash)],
-                    )
-                    .err()
-                    .map(|e| format!("canonical restore failed: {e}"));
+                // Blockstore presence is an invariant at this point (it
+                // was Some at function entry and the successful truncate
+                // above proves it still is), but we propagate a normal
+                // error if it's somehow missing rather than panic in a
+                // sync hot path.
+                let canonical_rb = match self.block_store.as_mut() {
+                    Some(bs) => bs
+                        .rollback_canonical(
+                            rollback.canonical_len.saturating_sub(1),
+                            vec![hex::encode(tip_hash)],
+                        )
+                        .err()
+                        .map(|e| format!("canonical restore failed: {e}")),
+                    None => {
+                        // Canonical restore cannot be attempted; align the
+                        // in-memory tip with the disconnected parent and
+                        // surface both errors via err_with_rollback.
+                        self.tip_timestamp = new_tip_timestamp;
+                        return Err(SyncEngine::err_with_rollback(
+                            err,
+                            Some("blockstore missing after canonical truncate".into()),
+                        ));
+                    }
+                };
                 // Only restore in-memory state if canonical rollback succeeded.
                 // If canonical is still truncated and we restore chain_state to
                 // the pre-disconnect tip, the next operation hits the

--- a/clients/rust/crates/rubin-node/src/sync_disconnect.rs
+++ b/clients/rust/crates/rubin-node/src/sync_disconnect.rs
@@ -48,8 +48,10 @@ impl SyncEngine {
         // truncate and save leaves the canonical index short while chainstate
         // still has the old tip; the mismatch guard at the top of this
         // function detects and rejects this on restart.
-        // block_store presence already checked at top of function.
-        let bs = self.block_store.as_mut().expect("blockstore checked above");
+        let bs = self
+            .block_store
+            .as_mut()
+            .ok_or("sync engine has no blockstore")?;
         if let Err(err) = bs.truncate_canonical(rollback.canonical_len.saturating_sub(1)) {
             return Err(SyncEngine::err_with_rollback(
                 err,

--- a/clients/rust/crates/rubin-node/src/sync_disconnect.rs
+++ b/clients/rust/crates/rubin-node/src/sync_disconnect.rs
@@ -43,26 +43,36 @@ impl SyncEngine {
 
         let summary = self.chain_state.disconnect_block(&block_bytes, &undo)?;
 
-        // Persist chain state BEFORE truncating canonical index so that a
-        // save failure can be rolled back without losing canonical entries.
-        //
-        // Crash-consistency note: a crash between `save` and `truncate_canonical`
-        // leaves persisted chain_state at the parent while the canonical index
-        // still references the old tip.  On restart the mismatch guard at the top
-        // of this function will reject the stale canonical tip, requiring an
-        // index rebuild.  True atomicity would need a write-ahead log.
-        if let Some(path) = self.cfg.chain_state_path.as_ref() {
-            if let Err(err) = self.chain_state.save(path) {
-                self.rollback_apply_block(rollback);
-                return Err(err);
-            }
+        // Truncate canonical index FIRST, then persist chain state — matching
+        // Go DisconnectTip ordering (B.7 fix, issue #1170).  A crash between
+        // truncate and save leaves the canonical index short while chainstate
+        // still has the old tip; the mismatch guard at the top of this
+        // function detects and rejects this on restart.
+        // block_store presence already checked at top of function.
+        let bs = self.block_store.as_mut().expect("blockstore checked above");
+        if let Err(err) = bs.truncate_canonical(rollback.canonical_len.saturating_sub(1)) {
+            return Err(SyncEngine::err_with_rollback(
+                err,
+                self.rollback_apply_block(rollback),
+            ));
         }
 
-        // Truncate canonical index (remove the tip entry).
-        if let Some(bs) = self.block_store.as_mut() {
-            if let Err(err) = bs.truncate_canonical(rollback.canonical_len.saturating_sub(1)) {
-                self.rollback_apply_block(rollback);
-                return Err(err);
+        if let Some(path) = self.cfg.chain_state_path.as_ref() {
+            if let Err(err) = self.chain_state.save(path) {
+                // Restore the truncated canonical entry so rollback_apply_block
+                // can succeed (truncate_canonical cannot extend).
+                if let Some(bs) = self.block_store.as_mut() {
+                    // Best-effort: if this also fails, err_with_rollback
+                    // will report the compound failure.
+                    let _ = bs.rollback_canonical(
+                        rollback.canonical_len.saturating_sub(1),
+                        vec![hex::encode(tip_hash)],
+                    );
+                }
+                return Err(SyncEngine::err_with_rollback(
+                    err,
+                    self.rollback_apply_block(rollback),
+                ));
             }
         }
 
@@ -242,6 +252,101 @@ mod tests {
         assert!(
             err.contains("does not match"),
             "expected mismatch error, got: {err}"
+        );
+
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    #[test]
+    fn disconnect_tip_truncate_error_propagates_with_rollback() {
+        let (mut engine, dir) = engine_with_store("rubin-disc-trunc-err");
+        let (genesis, genesis_hash, gen_ts) = genesis_info();
+
+        engine.apply_block(&genesis, None).expect("genesis");
+        let block1 = height_one_coinbase_only_block(genesis_hash, gen_ts + 1);
+        engine.apply_block(&block1, None).expect("block 1");
+
+        // Inject forced truncate error.
+        engine.block_store.as_mut().unwrap().force_truncate_error = true;
+
+        let err = engine.disconnect_tip().unwrap_err();
+        assert!(
+            err.contains("forced truncate error"),
+            "expected forced truncate error, got: {err}"
+        );
+
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    #[test]
+    fn disconnect_tip_save_failure_restores_canonical() {
+        // Cover lines 69-71: save fails after truncate, rollback_canonical
+        // restores the truncated entry, rollback_apply_block runs.
+        let (mut engine, dir) = engine_with_store("rubin-disc-save-fail");
+        let (genesis, genesis_hash, gen_ts) = genesis_info();
+
+        engine.apply_block(&genesis, None).expect("genesis");
+        let block1 = height_one_coinbase_only_block(genesis_hash, gen_ts + 1);
+        engine.apply_block(&block1, None).expect("block 1");
+
+        // Canonical index should have 2 entries (genesis + block1).
+        let tip_before = engine
+            .block_store
+            .as_ref()
+            .unwrap()
+            .tip()
+            .expect("tip")
+            .expect("some");
+        assert_eq!(tip_before.0, 1);
+
+        // Make chainstate dir read-only so save (atomic write) fails.
+        // Blockstore truncate_canonical operates on its own dir which
+        // remains writable, so truncate succeeds before save fails.
+        let cs_dir = dir.join("chainstate");
+        std::fs::create_dir_all(&cs_dir).ok();
+        // Move chainstate file into its own subdir
+        let cs_path = crate::chainstate::chain_state_path(&dir);
+        let cs_subdir_path = cs_dir.join("state.bin");
+        if cs_path.exists() {
+            std::fs::rename(&cs_path, &cs_subdir_path).expect("move chainstate");
+        }
+        // Point engine at the subdir path
+        engine.cfg.chain_state_path = Some(cs_subdir_path.clone());
+        // Reload from new path
+        engine.chain_state.save(&cs_subdir_path).expect("re-save");
+        // Now make subdir readonly — atomic write creates temp in same dir, fails
+        let mut perms = std::fs::metadata(&cs_dir).expect("meta").permissions();
+        perms.set_readonly(true);
+        std::fs::set_permissions(&cs_dir, perms.clone()).expect("set readonly");
+
+        // disconnect_tip should fail (save error — platform-specific message).
+        let err = engine.disconnect_tip().unwrap_err();
+        assert!(!err.is_empty(), "expected save error, got empty string");
+
+        // Restore permissions for cleanup.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&cs_dir, std::fs::Permissions::from_mode(0o755))
+                .expect("restore perms");
+        }
+        #[cfg(not(unix))]
+        {
+            perms.set_readonly(false);
+            std::fs::set_permissions(&cs_dir, perms).expect("restore perms");
+        }
+
+        // Canonical index should be restored — tip still at block1.
+        let tip_after = engine
+            .block_store
+            .as_ref()
+            .unwrap()
+            .tip()
+            .expect("tip")
+            .expect("some");
+        assert_eq!(
+            tip_after.0, tip_before.0,
+            "canonical index should be restored after save failure"
         );
 
         std::fs::remove_dir_all(&dir).expect("cleanup");

--- a/clients/rust/crates/rubin-node/src/sync_disconnect.rs
+++ b/clients/rust/crates/rubin-node/src/sync_disconnect.rs
@@ -285,6 +285,15 @@ mod tests {
         let block1 = height_one_coinbase_only_block(genesis_hash, gen_ts + 1);
         engine.apply_block(&block1, None).expect("block 1");
 
+        // Capture pre-disconnect state for post-error verification.
+        let tip_before = engine
+            .block_store
+            .as_ref()
+            .unwrap()
+            .tip()
+            .expect("tip")
+            .expect("some");
+
         // Inject forced truncate error.
         engine.block_store.as_mut().unwrap().force_truncate_error = true;
 
@@ -304,7 +313,8 @@ mod tests {
         // Disarm so cleanup succeeds.
         engine.block_store.as_mut().unwrap().force_truncate_error = false;
 
-        // Canonical never mutated (both truncate calls failed before write).
+        // Canonical never mutated — both truncate calls failed before write.
+        // Verify both height AND hash, not just length.
         let tip = engine
             .block_store
             .as_ref()
@@ -313,8 +323,25 @@ mod tests {
             .expect("tip")
             .expect("some");
         assert_eq!(
-            tip.0, 1,
-            "canonical should still have block1 after both truncate failures"
+            tip.0, tip_before.0,
+            "canonical height should be unchanged after both truncate failures"
+        );
+        assert_eq!(
+            tip.1, tip_before.1,
+            "canonical tip hash should be unchanged after both truncate failures"
+        );
+
+        // chain_state was mutated by disconnect_block (height 1 → 0), and
+        // rollback_apply_block phase-1 truncate failed before phase-2 ran,
+        // so the in-memory state remains in the post-disconnect_block state.
+        // Document this asymmetry: canonical at block1, chain_state at genesis.
+        assert_eq!(
+            engine.chain_state.height, 0,
+            "chain_state.height should be 0 (rollback aborted at phase 1)"
+        );
+        assert_eq!(
+            engine.chain_state.tip_hash, genesis_hash,
+            "chain_state.tip_hash should be genesis (rollback aborted at phase 1)"
         );
 
         std::fs::remove_dir_all(&dir).expect("cleanup");

--- a/clients/rust/crates/rubin-node/src/sync_disconnect.rs
+++ b/clients/rust/crates/rubin-node/src/sync_disconnect.rs
@@ -85,6 +85,11 @@ impl SyncEngine {
                     self.chain_state = rollback.chain_state;
                     self.tip_timestamp = rollback.tip_timestamp;
                     self.best_known_height = rollback.best_known_height;
+                } else {
+                    // Canonical stays truncated; align tip_timestamp with the
+                    // disconnected parent so is_in_ibd() and other freshness
+                    // metadata don't keep reporting the old tip.
+                    self.tip_timestamp = new_tip_timestamp;
                 }
                 return Err(SyncEngine::err_with_rollback(err, canonical_rb));
             }
@@ -455,9 +460,13 @@ mod tests {
         let block1 = height_one_coinbase_only_block(genesis_hash, gen_ts + 1);
         engine.apply_block(&block1, None).expect("block 1");
 
-        // Detach chain_state path so save() fails; arm rollback inject so
-        // canonical restore also fails after truncate succeeds.
-        engine.cfg.chain_state_path = Some(std::path::PathBuf::from("/nonexistent/dir/state.bin"));
+        // Point chain_state_path at a child of a regular file so save() fails
+        // deterministically (parent is not a directory — works under any
+        // privileges).  Arm rollback inject so canonical restore also fails
+        // after truncate succeeds.
+        let invalid_parent = dir.join("not-a-dir");
+        std::fs::write(&invalid_parent, b"not a directory").expect("create invalid parent file");
+        engine.cfg.chain_state_path = Some(invalid_parent.join("state.bin"));
         engine.block_store.as_mut().unwrap().force_rollback_error = true;
 
         let err = engine.disconnect_tip().unwrap_err();
@@ -496,6 +505,12 @@ mod tests {
         assert_eq!(
             engine.chain_state.tip_hash, genesis_hash,
             "chain_state tip must align with truncated canonical (genesis)"
+        );
+        // tip_timestamp must also be aligned with the disconnected parent
+        // (genesis) so is_in_ibd() / freshness metadata stay coherent.
+        assert_eq!(
+            engine.tip_timestamp, gen_ts,
+            "tip_timestamp must be parent's (genesis) when canonical rollback failed"
         );
 
         std::fs::remove_dir_all(&dir).expect("cleanup");

--- a/clients/rust/crates/rubin-node/src/sync_disconnect.rs
+++ b/clients/rust/crates/rubin-node/src/sync_disconnect.rs
@@ -53,10 +53,17 @@ impl SyncEngine {
             .as_mut()
             .ok_or("sync engine has no blockstore")?;
         if let Err(err) = bs.truncate_canonical(rollback.canonical_len.saturating_sub(1)) {
-            return Err(SyncEngine::err_with_rollback(
-                err,
-                self.rollback_apply_block(rollback),
-            ));
+            // truncate_canonical failure is expected to leave the canonical
+            // index unchanged (atomic write + reload-on-failure in
+            // BlockStore::truncate_canonical), so restore the captured
+            // in-memory snapshot directly.  Going through rollback_apply_block
+            // would re-call truncate_canonical(rb.canonical_len) which can
+            // fail again under the same root cause and short-circuit before
+            // restoring chain_state, leaving the engine desynced.
+            self.chain_state = rollback.chain_state;
+            self.tip_timestamp = rollback.tip_timestamp;
+            self.best_known_height = rollback.best_known_height;
+            return Err(err);
         }
 
         // Test-only seam to exercise the otherwise-unreachable
@@ -302,11 +309,13 @@ mod tests {
 
     #[test]
     fn disconnect_tip_truncate_error_propagates_with_rollback() {
-        // Both the initial truncate AND the rollback_apply_block phase-1
-        // truncate fail (force_truncate_error stays armed for both calls),
-        // so the composite error reports both failures.  Engine state ends
-        // up at post-disconnect_block (chain_state.height=0) while canonical
-        // is still untouched ([genesis, block1]) — verified after disarm.
+        // truncate_canonical fails (force_truncate_error inject); per
+        // BlockStore::truncate_canonical's atomic-write-and-reload contract
+        // the canonical index stays unchanged on disk.  disconnect_tip
+        // restores the captured in-memory snapshot directly (without going
+        // through rollback_apply_block, whose phase-1 truncate would
+        // re-fail and short-circuit).  After the failure both canonical and
+        // in-memory state are at the pre-disconnect tip — engine usable.
         let (mut engine, dir) = engine_with_store("rubin-disc-trunc-err");
         let (genesis, genesis_hash, gen_ts) = genesis_info();
 
@@ -331,19 +340,12 @@ mod tests {
             err.contains("forced truncate error"),
             "expected forced truncate error, got: {err}"
         );
-        // Composite error must surface BOTH the main error and the
-        // rollback-phase failure (rollback_apply_block also tried to
-        // truncate and got the same injected error).
-        assert!(
-            err.contains("rollback failed"),
-            "expected rollback failure note, got: {err}"
-        );
 
         // Disarm so cleanup succeeds.
         engine.block_store.as_mut().unwrap().force_truncate_error = false;
 
-        // Canonical never mutated — both truncate calls failed before write.
-        // Verify both height AND hash, not just length.
+        // Canonical never mutated — inject returns before the in-memory
+        // truncate happens.  Verify both height AND hash, not just length.
         let tip = engine
             .block_store
             .as_ref()
@@ -353,24 +355,26 @@ mod tests {
             .expect("some");
         assert_eq!(
             tip.0, tip_before.0,
-            "canonical height should be unchanged after both truncate failures"
+            "canonical height should be unchanged after truncate failure"
         );
         assert_eq!(
             tip.1, tip_before.1,
-            "canonical tip hash should be unchanged after both truncate failures"
+            "canonical tip hash should be unchanged after truncate failure"
         );
 
-        // chain_state was mutated by disconnect_block (height 1 → 0), and
-        // rollback_apply_block phase-1 truncate failed before phase-2 ran,
-        // so the in-memory state remains in the post-disconnect_block state.
-        // Document this asymmetry: canonical at block1, chain_state at genesis.
-        assert_eq!(
-            engine.chain_state.height, 0,
-            "chain_state.height should be 0 (rollback aborted at phase 1)"
+        // In-memory chain_state must be restored to the pre-disconnect tip
+        // so the engine stays consistent with the unchanged canonical index.
+        assert!(
+            engine.chain_state.has_tip,
+            "chain_state.has_tip should be restored after truncate failure"
         );
         assert_eq!(
-            engine.chain_state.tip_hash, genesis_hash,
-            "chain_state.tip_hash should be genesis (rollback aborted at phase 1)"
+            engine.chain_state.height, tip_before.0,
+            "chain_state.height should be restored to pre-disconnect tip"
+        );
+        assert_eq!(
+            engine.chain_state.tip_hash, tip_before.1,
+            "chain_state.tip_hash should be restored to pre-disconnect tip"
         );
 
         std::fs::remove_dir_all(&dir).expect("cleanup");

--- a/clients/rust/crates/rubin-node/src/sync_disconnect.rs
+++ b/clients/rust/crates/rubin-node/src/sync_disconnect.rs
@@ -376,42 +376,18 @@ mod tests {
             .expect("some");
         assert_eq!(tip_before.0, 1);
 
-        // Make chainstate dir read-only so save (atomic write) fails.
-        // Blockstore truncate_canonical operates on its own dir which
-        // remains writable, so truncate succeeds before save fails.
-        let cs_dir = dir.join("chainstate");
-        std::fs::create_dir_all(&cs_dir).ok();
-        // Move chainstate file into its own subdir
-        let cs_path = crate::chainstate::chain_state_path(&dir);
-        let cs_subdir_path = cs_dir.join("state.bin");
-        if cs_path.exists() {
-            std::fs::rename(&cs_path, &cs_subdir_path).expect("move chainstate");
-        }
-        // Point engine at the subdir path
-        engine.cfg.chain_state_path = Some(cs_subdir_path.clone());
-        // Reload from new path
-        engine.chain_state.save(&cs_subdir_path).expect("re-save");
-        // Now make subdir readonly — atomic write creates temp in same dir, fails
-        let mut perms = std::fs::metadata(&cs_dir).expect("meta").permissions();
-        perms.set_readonly(true);
-        std::fs::set_permissions(&cs_dir, perms.clone()).expect("set readonly");
+        // Point chain_state_path under a regular file so save() fails
+        // deterministically when atomic write tries to create the temp
+        // file in the parent directory.  Blockstore truncate_canonical
+        // operates on its own writable dir, so truncate succeeds before
+        // save fails — exercising the rollback_canonical recovery path.
+        let cs_parent_file = dir.join("chainstate-parent-file");
+        std::fs::write(&cs_parent_file, b"not a directory").expect("create parent file");
+        engine.cfg.chain_state_path = Some(cs_parent_file.join("state.bin"));
 
         // disconnect_tip should fail (save error — platform-specific message).
         let err = engine.disconnect_tip().unwrap_err();
         assert!(!err.is_empty(), "expected save error, got empty string");
-
-        // Restore permissions for cleanup.
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            std::fs::set_permissions(&cs_dir, std::fs::Permissions::from_mode(0o755))
-                .expect("restore perms");
-        }
-        #[cfg(not(unix))]
-        {
-            perms.set_readonly(false);
-            std::fs::set_permissions(&cs_dir, perms).expect("restore perms");
-        }
 
         // Canonical index should be restored — tip still at block1.
         let tip_after = engine

--- a/clients/rust/crates/rubin-node/src/sync_disconnect.rs
+++ b/clients/rust/crates/rubin-node/src/sync_disconnect.rs
@@ -53,12 +53,13 @@ impl SyncEngine {
             .as_mut()
             .ok_or("sync engine has no blockstore")?;
         if let Err(err) = bs.truncate_canonical(rollback.canonical_len.saturating_sub(1)) {
-            // truncate_canonical failure is expected to leave the canonical
-            // index unchanged (atomic write + reload-on-failure in
-            // BlockStore::truncate_canonical), so restore the captured
-            // in-memory snapshot directly.  Going through rollback_apply_block
-            // would re-call truncate_canonical(rb.canonical_len) which can
-            // fail again under the same root cause and short-circuit before
+            // truncate_canonical leaves the canonical index unchanged on
+            // failure because BlockStore::truncate_canonical updates its
+            // in-memory canonical only after the disk write succeeds.
+            // Restore the captured in-memory snapshot directly.  Going
+            // through rollback_apply_block would re-call
+            // truncate_canonical(rb.canonical_len), which can fail again
+            // under the same root cause and short-circuit before
             // restoring chain_state, leaving the engine desynced.
             self.chain_state = rollback.chain_state;
             self.tip_timestamp = rollback.tip_timestamp;

--- a/tools/check_pre_commit_hygiene.py
+++ b/tools/check_pre_commit_hygiene.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Pre-commit hygiene checks for rubin-protocol.
+
+Catches the top bot-thread patterns BEFORE commit, reducing push→bot→fix cycles.
+Based on 39 real threads from PR #1199 and PR #1203.
+
+Usage:
+    python3 tools/check_pre_commit_hygiene.py [--fix] [--staged-only]
+
+Exit codes: 0 = clean, 1 = violations found, 2 = usage error.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RUST_DIR = REPO_ROOT / "clients" / "rust"
+
+
+def run(cmd: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, capture_output=True, text=True, cwd=cwd or REPO_ROOT)
+
+
+def get_staged_files() -> list[str]:
+    r = run(["git", "diff", "--cached", "--name-only", "--diff-filter=ACMR"])
+    if r.returncode != 0:
+        print("⚠ git diff --cached failed — fail closed", file=sys.stderr)
+        sys.exit(2)
+    return [f for f in r.stdout.splitlines() if f.strip()]
+
+
+def get_changed_files() -> list[str]:
+    """All modified/added files vs origin/main."""
+    base_result = run(["git", "merge-base", "origin/main", "HEAD"])
+    base = base_result.stdout.strip()
+    if not base:
+        print("⚠ Could not determine merge-base with origin/main — falling back to staged files.", file=sys.stderr)
+        return get_staged_files()
+    r = run(["git", "diff", "--name-only", f"{base}...HEAD"])
+    return [f for f in r.stdout.splitlines() if f.strip()]
+
+
+# ── Check 1: Bot thread IDs in code ──────────────────────────────────
+
+BOT_THREAD_RE = re.compile(r"PRRT_\w+|Codex thread|Copilot thread|chatgpt-codex-connector")
+
+
+def check_bot_thread_ids(files: list[str]) -> list[str]:
+    """Bot thread IDs are temporary PR artifacts, not permanent code."""
+    violations = []
+    for f in files:
+        # Skip self — this file contains the pattern as a regex literal.
+        if f.endswith("check_pre_commit_hygiene.py"):
+            continue
+        path = REPO_ROOT / f
+        if not path.is_file():
+            continue
+        for i, line in enumerate(path.read_text(errors="replace").splitlines(), 1):
+            if BOT_THREAD_RE.search(line):
+                violations.append(f"{f}:{i}: bot thread ID in code: {line.strip()[:80]}")
+    return violations
+
+
+# ── Check 2: Exported test helpers in production ─────────────────────
+
+TEST_HELPER_RE = re.compile(r"InjectTestEntry|inject_test_entry")
+
+
+def check_test_helpers_in_production(files: list[str]) -> list[str]:
+    """Test-only helpers must not be exported in production code."""
+    violations = []
+    for f in files:
+        # Skip test files
+        if "_test.go" in f or f.endswith("_test.rs") or "/tests/" in f:
+            continue
+        if not (f.endswith(".go") or f.endswith(".rs")):
+            continue
+        path = REPO_ROOT / f
+        if not path.is_file():
+            continue
+        content = path.read_text(errors="replace")
+        lines = content.splitlines()
+        # Rust: only check lines BEFORE the final `#[cfg(test)] mod tests`
+        # block.  Inline `#[cfg(test)]` on a single function is rare in
+        # this repo; the standard pattern is a trailing test module.
+        prod_end = len(lines)
+        if f.endswith(".rs"):
+            for idx in range(len(lines) - 1, -1, -1):
+                if "#[cfg(test)]" in lines[idx]:
+                    for nxt in range(idx + 1, min(idx + 3, len(lines))):
+                        if "mod tests" in lines[nxt] or "mod test" in lines[nxt]:
+                            prod_end = idx
+                            break
+                    if prod_end < len(lines):
+                        break  # found mod tests block
+        for i, line in enumerate(lines[:prod_end], 1):
+            if TEST_HELPER_RE.search(line):
+                violations.append(f"{f}:{i}: test helper in production: {line.strip()[:80]}")
+    return violations
+
+
+# ── Check 3: RUSTFLAGS=-D warnings ──────────────────────────────────
+
+def check_rust_warnings(files: list[str]) -> list[str]:
+    """CI uses -D warnings. Local clippy may miss what CI catches."""
+    rs_files = [f for f in files if f.endswith(".rs")]
+    if not rs_files:
+        return []
+
+    dev_env = REPO_ROOT / "scripts" / "dev-env.sh"
+    if dev_env.exists():
+        cmd = [str(dev_env), "--", "bash", "-c",
+               "cd clients/rust && RUSTFLAGS='-D warnings' cargo check -p rubin-node -p rubin-consensus 2>&1"]
+    else:
+        cmd = ["bash", "-c",
+               "cd clients/rust && RUSTFLAGS='-D warnings' cargo check -p rubin-node -p rubin-consensus 2>&1"]
+
+    r = run(cmd, cwd=REPO_ROOT)
+    if r.returncode != 0:
+        # Extract error lines
+        errors = [line for line in r.stdout.splitlines()
+                  if "error[" in line or "error:" in line.lower()]
+        if errors:
+            # Strip file paths from cargo output for cleaner messages.
+            return [f"RUSTFLAGS=-D warnings: {re.sub(r' --> .*$', '', e.strip())[:100]}" for e in errors[:5]]
+        raw = re.sub(r"^\s*-->.*$", "", (r.stdout or r.stderr or ""), flags=re.MULTILINE).strip()[:200]
+        return [f"RUSTFLAGS=-D warnings cargo check failed: {raw or '(no output)'}"]
+    return []
+
+
+# ── Check 4: git diff HEAD after amend ───────────────────────────────
+
+def check_amend_completeness(staged_only: bool) -> list[str]:
+    """Check for unstaged modifications in tracked files (not staged vs HEAD).
+
+    In staged-only mode (pre-commit), skip this check — staged diff from
+    HEAD is intentional.  Only run after amend when we expect zero diff.
+    """
+    if staged_only:
+        return []
+    r = run(["git", "diff", "--stat"])  # unstaged only, not vs HEAD
+    if r.stdout.strip():
+        files = r.stdout.strip().splitlines()
+        return [f"unstaged changes in working tree: {f.strip()}" for f in files[:5]]
+    return []
+
+
+# ── Main ─────────────────────────────────────────────────────────────
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--staged-only", action="store_true",
+                        help="Check only staged files (for pre-commit hook)")
+    parser.add_argument("--fix", action="store_true",
+                        help="Reserved for future auto-fix (not yet implemented)")
+    parser.add_argument("--skip-rust-warnings", action="store_true",
+                        help="Skip RUSTFLAGS=-D warnings check (slow)")
+    args = parser.parse_args(argv)
+
+    files = get_staged_files() if args.staged_only else get_changed_files()
+    if not files:
+        print("No changed files to check.")
+        return 0
+
+    all_violations: list[str] = []
+
+    # Fast checks
+    v = check_bot_thread_ids(files)
+    if v:
+        print(f"\n❌ Bot thread IDs in code ({len(v)}):")
+        for line in v:
+            print(f"  {line}")
+        all_violations.extend(v)
+
+    v = check_test_helpers_in_production(files)
+    if v:
+        print(f"\n❌ Test helpers in production ({len(v)}):")
+        for line in v:
+            print(f"  {line}")
+        all_violations.extend(v)
+
+    v = check_amend_completeness(args.staged_only)
+    if v:
+        print(f"\n❌ Unstaged changes after amend ({len(v)}):")
+        for line in v:
+            print(f"  {line}")
+        all_violations.extend(v)
+
+    # Slow check
+    if not args.skip_rust_warnings:
+        v = check_rust_warnings(files)
+        if v:
+            print(f"\n❌ RUSTFLAGS=-D warnings failures ({len(v)}):")
+            for line in v:
+                print(f"  {line}")
+            all_violations.extend(v)
+
+    if all_violations:
+        print(f"\n🛑 {len(all_violations)} violation(s) found. Fix before commit.")
+        return 1
+
+    print("✅ Pre-commit hygiene: clean.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/check_pre_commit_hygiene.py
+++ b/tools/check_pre_commit_hygiene.py
@@ -33,7 +33,16 @@ def _sanitize_paths(text: str) -> str:
 
 
 def run(cmd: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(cmd, capture_output=True, text=True, cwd=cwd or REPO_ROOT)
+    try:
+        return subprocess.run(cmd, capture_output=True, text=True, cwd=cwd or REPO_ROOT)
+    except FileNotFoundError as exc:
+        detail = _sanitize_paths(str(exc)).strip()
+        command = cmd[0] if cmd else "<unknown>"
+        print(
+            f"⚠ failed to execute {command!r} — fail closed: {detail}",
+            file=sys.stderr,
+        )
+        sys.exit(2)
 
 
 def get_staged_files() -> list[str]:
@@ -239,12 +248,21 @@ def check_rust_warnings(files: list[str]) -> list[str]:
 
     # Inherit caller env (no overrides needed; -D warnings is on the
     # cargo arg list, not RUSTFLAGS).
-    r = subprocess.run(
-        cmd,
-        capture_output=True,
-        text=True,
-        cwd=RUST_DIR,
-    )
+    try:
+        r = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            cwd=RUST_DIR,
+        )
+    except FileNotFoundError as exc:
+        detail = _sanitize_paths(str(exc)).strip()
+        command = cmd[0] if cmd else "<unknown>"
+        print(
+            f"⚠ failed to execute {command!r} — fail closed: {detail}",
+            file=sys.stderr,
+        )
+        sys.exit(2)
     if r.returncode != 0:
         combined = (r.stdout or "") + (r.stderr or "")
         errors = [line for line in combined.splitlines()

--- a/tools/check_pre_commit_hygiene.py
+++ b/tools/check_pre_commit_hygiene.py
@@ -56,8 +56,13 @@ _BASE_REF_CANDIDATES = ("origin/main", "upstream/main", "main", "master")
 def get_changed_files() -> list[str]:
     """All changed (added/modified/deleted) files vs the project's base branch.
 
-    `git diff --name-only` includes deletions; downstream check_* helpers
-    individually skip files that no longer exist on disk.
+    Union of:
+      - committed diff `base...HEAD` (commit-to-commit, ignores index)
+      - staged diff (`--cached`, includes index)
+      - unstaged working-tree diff
+    so first-commit / pre-commit / amend workflows all surface their
+    changes.  `git diff --name-only` includes deletions; downstream
+    check_* helpers skip paths that no longer exist on disk.
 
     Tries common base refs in order; falls back to staged-only mode (with
     a loud warning) only when no candidate ref is available locally.
@@ -67,15 +72,27 @@ def get_changed_files() -> list[str]:
         base_result = run(["git", "merge-base", ref, "HEAD"])
         if base_result.returncode == 0 and base_result.stdout.strip():
             base = base_result.stdout.strip()
-            r = run(["git", "diff", "--name-only", f"{base}...HEAD"])
-            if r.returncode != 0:
-                print(
-                    f"⚠ git diff failed (rc={r.returncode}) — fail closed: "
-                    f"{(r.stderr or '').strip()}",
-                    file=sys.stderr,
-                )
-                sys.exit(2)
-            return [f for f in r.stdout.splitlines() if f.strip()]
+            files: list[str] = []
+            seen: set[str] = set()
+            for diff_args in (
+                ["git", "diff", "--name-only", f"{base}...HEAD"],
+                ["git", "diff", "--cached", "--name-only", "--diff-filter=ACMRD"],
+                ["git", "diff", "--name-only", "--diff-filter=ACMRD"],
+            ):
+                r = run(diff_args)
+                if r.returncode != 0:
+                    print(
+                        f"⚠ git {' '.join(diff_args[1:])} failed (rc={r.returncode}) "
+                        f"— fail closed: {(r.stderr or '').strip()}",
+                        file=sys.stderr,
+                    )
+                    sys.exit(2)
+                for line in r.stdout.splitlines():
+                    f = line.strip()
+                    if f and f not in seen:
+                        seen.add(f)
+                        files.append(f)
+            return files
         last_err = (base_result.stderr or "").strip()
     print(
         f"⚠ no base ref found ({', '.join(_BASE_REF_CANDIDATES)}); "
@@ -281,11 +298,24 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     files = get_staged_files() if args.staged_only else get_changed_files()
-    if not files:
-        print("No changed files to check.")
-        return 0
 
     all_violations: list[str] = []
+
+    # Run amend-completeness FIRST so unstaged working-tree changes are
+    # surfaced even if the file-set derivation came back empty.
+    v = check_amend_completeness(args.staged_only)
+    if v:
+        print(f"\n❌ Unstaged changes after amend ({len(v)}):")
+        for line in v:
+            print(f"  {line}")
+        all_violations.extend(v)
+
+    if not files:
+        if all_violations:
+            print(f"\n🛑 {len(all_violations)} violation(s) found. Fix before commit.")
+            return 1
+        print("No changed files to check.")
+        return 0
 
     # Fast checks
     v = check_bot_thread_ids(files)
@@ -298,13 +328,6 @@ def main(argv: list[str] | None = None) -> int:
     v = check_test_helpers_in_production(files)
     if v:
         print(f"\n❌ Test helpers in production ({len(v)}):")
-        for line in v:
-            print(f"  {line}")
-        all_violations.extend(v)
-
-    v = check_amend_completeness(args.staged_only)
-    if v:
-        print(f"\n❌ Unstaged changes after amend ({len(v)}):")
         for line in v:
             print(f"  {line}")
         all_violations.extend(v)

--- a/tools/check_pre_commit_hygiene.py
+++ b/tools/check_pre_commit_hygiene.py
@@ -107,6 +107,14 @@ def check_test_helpers_in_production(files: list[str]) -> list[str]:
 
 # ── Check 3: RUSTFLAGS=-D warnings ──────────────────────────────────
 
+_PATH_RE = re.compile(r"/(?:Users|home|var/folders|tmp|opt/homebrew|private)/[^\s\"']+")
+
+
+def _sanitize_paths(text: str) -> str:
+    """Replace absolute filesystem paths with <path> placeholder."""
+    return _PATH_RE.sub("<path>", text)
+
+
 def check_rust_warnings(files: list[str]) -> list[str]:
     """CI uses -D warnings. Local clippy may miss what CI catches."""
     rs_files = [f for f in files if f.endswith(".rs")]
@@ -135,8 +143,12 @@ def check_rust_warnings(files: list[str]) -> list[str]:
                   if "error[" in line or "error:" in line.lower()]
         if errors:
             # Strip file paths from cargo output for cleaner messages.
-            return [f"RUSTFLAGS=-D warnings: {re.sub(r' --> .*$', '', e.strip())[:100]}" for e in errors[:5]]
-        raw = re.sub(r"^\s*-->.*$", "", combined, flags=re.MULTILINE).strip()[:200]
+            return [
+                f"RUSTFLAGS=-D warnings: {_sanitize_paths(re.sub(r' --> .*$', '', e.strip()))[:100]}"
+                for e in errors[:5]
+            ]
+        raw = re.sub(r"^\s*-->.*$", "", combined, flags=re.MULTILINE).strip()
+        raw = _sanitize_paths(raw)[:200]
         return [f"RUSTFLAGS=-D warnings cargo check failed: {raw or '(no output)'}"]
     return []
 

--- a/tools/check_pre_commit_hygiene.py
+++ b/tools/check_pre_commit_hygiene.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Pre-commit hygiene checks for rubin-protocol.
 
-Catches the top bot-thread patterns BEFORE commit, reducing push→bot→fix cycles.
+Catches the top bot-thread patterns BEFORE commit, reducing push -> bot -> fix cycles.
 Based on 39 real threads from PR #1199 and PR #1203.
 
 Usage:
@@ -39,7 +39,7 @@ def run(cmd: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess[
         detail = _sanitize_paths(str(exc)).strip()
         command = cmd[0] if cmd else "<unknown>"
         print(
-            f"⚠ failed to execute {command!r} — fail closed: {detail}",
+            f"[WARN] failed to execute {command!r} -- fail closed: {detail}",
             file=sys.stderr,
         )
         sys.exit(2)
@@ -53,7 +53,7 @@ def get_staged_files() -> list[str]:
     if r.returncode != 0:
         detail = _sanitize_paths((r.stderr or "").strip())
         print(
-            f"⚠ git diff --cached failed — fail closed: {detail}",
+            f"[WARN] git diff --cached failed -- fail closed: {detail}",
             file=sys.stderr,
         )
         sys.exit(2)
@@ -93,8 +93,8 @@ def get_changed_files() -> list[str]:
                 if r.returncode != 0:
                     detail = _sanitize_paths((r.stderr or "").strip())
                     print(
-                        f"⚠ git {' '.join(diff_args[1:])} failed (rc={r.returncode}) "
-                        f"— fail closed: {detail}",
+                        f"[WARN] git {' '.join(diff_args[1:])} failed (rc={r.returncode}) "
+                        f"-- fail closed: {detail}",
                         file=sys.stderr,
                     )
                     sys.exit(2)
@@ -106,7 +106,7 @@ def get_changed_files() -> list[str]:
             return files
         last_err = _sanitize_paths((base_result.stderr or "").strip())
     print(
-        f"⚠ no base ref found ({', '.join(_BASE_REF_CANDIDATES)}); "
+        f"[WARN] no base ref found ({', '.join(_BASE_REF_CANDIDATES)}); "
         f"falling back to staged files. Last git error: {last_err}",
         file=sys.stderr,
     )
@@ -261,7 +261,7 @@ def check_rust_warnings(files: list[str]) -> list[str]:
         detail = _sanitize_paths(str(exc)).strip()
         command = cmd[0] if cmd else "<unknown>"
         print(
-            f"⚠ failed to execute {command!r} — fail closed: {detail}",
+            f"[WARN] failed to execute {command!r} -- fail closed: {detail}",
             file=sys.stderr,
         )
         sys.exit(2)
@@ -298,7 +298,7 @@ def check_amend_completeness(staged_only: bool) -> list[str]:
     if r.returncode != 0:
         detail = _sanitize_paths((r.stderr or "").strip())
         print(
-            f"⚠ git diff HEAD --stat failed (rc={r.returncode}) — fail closed: "
+            f"[WARN] git diff HEAD --stat failed (rc={r.returncode}) -- fail closed: "
             f"{detail}",
             file=sys.stderr,
         )
@@ -329,14 +329,14 @@ def main(argv: list[str] | None = None) -> int:
     # surfaced even if the file-set derivation came back empty.
     v = check_amend_completeness(args.staged_only)
     if v:
-        print(f"\n❌ Changes vs HEAD after amend ({len(v)}):")
+        print(f"\n[FAIL] Changes vs HEAD after amend ({len(v)}):")
         for line in v:
             print(f"  {line}")
         all_violations.extend(v)
 
     if not files:
         if all_violations:
-            print(f"\n🛑 {len(all_violations)} violation(s) found. Fix before commit.")
+            print(f"\n[STOP] {len(all_violations)} violation(s) found. Fix before commit.")
             return 1
         print("No changed files to check.")
         return 0
@@ -344,14 +344,14 @@ def main(argv: list[str] | None = None) -> int:
     # Fast checks
     v = check_bot_thread_ids(files)
     if v:
-        print(f"\n❌ Bot thread IDs in code ({len(v)}):")
+        print(f"\n[FAIL] Bot thread IDs in code ({len(v)}):")
         for line in v:
             print(f"  {line}")
         all_violations.extend(v)
 
     v = check_test_helpers_in_production(files)
     if v:
-        print(f"\n❌ Test helpers in production ({len(v)}):")
+        print(f"\n[FAIL] Test helpers in production ({len(v)}):")
         for line in v:
             print(f"  {line}")
         all_violations.extend(v)
@@ -360,16 +360,16 @@ def main(argv: list[str] | None = None) -> int:
     if not args.skip_rust_warnings:
         v = check_rust_warnings(files)
         if v:
-            print(f"\n❌ cargo clippy --workspace --all-targets -- -D warnings failures ({len(v)}):")
+            print(f"\n[FAIL] cargo clippy --workspace --all-targets -- -D warnings failures ({len(v)}):")
             for line in v:
                 print(f"  {line}")
             all_violations.extend(v)
 
     if all_violations:
-        print(f"\n🛑 {len(all_violations)} violation(s) found. Fix before commit.")
+        print(f"\n[STOP] {len(all_violations)} violation(s) found. Fix before commit.")
         return 1
 
-    print("✅ Pre-commit hygiene: clean.")
+    print("[OK] Pre-commit hygiene: clean.")
     return 0
 
 

--- a/tools/check_pre_commit_hygiene.py
+++ b/tools/check_pre_commit_hygiene.py
@@ -22,6 +22,15 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 RUST_DIR = REPO_ROOT / "clients" / "rust"
 
+_PATH_RE = re.compile(
+    r"/(?:Users|home|root|workspace|var/folders|tmp|opt/homebrew|private|runner/work)/[^\s\"']+"
+)
+
+
+def _sanitize_paths(text: str) -> str:
+    """Replace absolute filesystem paths with <path> placeholder."""
+    return _PATH_RE.sub("<path>", text)
+
 
 def run(cmd: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
     return subprocess.run(cmd, capture_output=True, text=True, cwd=cwd or REPO_ROOT)
@@ -38,11 +47,17 @@ def get_staged_files() -> list[str]:
 def get_changed_files() -> list[str]:
     """All modified/added files vs origin/main."""
     base_result = run(["git", "merge-base", "origin/main", "HEAD"])
+    if base_result.returncode != 0:
+        print(f"⚠ git merge-base failed (rc={base_result.returncode}) — fail closed", file=sys.stderr)
+        sys.exit(2)
     base = base_result.stdout.strip()
     if not base:
-        print("⚠ Could not determine merge-base with origin/main — falling back to staged files.", file=sys.stderr)
-        return get_staged_files()
+        print("⚠ git merge-base returned empty — fail closed", file=sys.stderr)
+        sys.exit(2)
     r = run(["git", "diff", "--name-only", f"{base}...HEAD"])
+    if r.returncode != 0:
+        print(f"⚠ git diff failed (rc={r.returncode}) — fail closed", file=sys.stderr)
+        sys.exit(2)
     return [f for f in r.stdout.splitlines() if f.strip()]
 
 
@@ -63,7 +78,8 @@ def check_bot_thread_ids(files: list[str]) -> list[str]:
             continue
         for i, line in enumerate(path.read_text(errors="replace").splitlines(), 1):
             if BOT_THREAD_RE.search(line):
-                violations.append(f"{f}:{i}: bot thread ID in code: {line.strip()[:80]}")
+                snippet = _sanitize_paths(line.strip())[:80]
+                violations.append(f"{f}:{i}: bot thread ID in code: {snippet}")
     return violations
 
 
@@ -87,12 +103,17 @@ def check_test_helpers_in_production(files: list[str]) -> list[str]:
         content = path.read_text(errors="replace")
         lines = content.splitlines()
         # Rust: only check lines BEFORE the final `#[cfg(test)] mod tests`
-        # block.  Inline `#[cfg(test)]` on a single function is rare in
-        # this repo; the standard pattern is a trailing test module.
+        # block.  Standard pattern is a trailing test module; also handle
+        # `#[cfg(test)] mod tests {` on a single line.
         prod_end = len(lines)
         if f.endswith(".rs"):
             for idx in range(len(lines) - 1, -1, -1):
                 if "#[cfg(test)]" in lines[idx]:
+                    # Same line: `#[cfg(test)] mod tests {`
+                    if "mod tests" in lines[idx] or "mod test" in lines[idx]:
+                        prod_end = idx
+                        break
+                    # Within next 2 lines
                     for nxt in range(idx + 1, min(idx + 3, len(lines))):
                         if "mod tests" in lines[nxt] or "mod test" in lines[nxt]:
                             prod_end = idx
@@ -101,19 +122,12 @@ def check_test_helpers_in_production(files: list[str]) -> list[str]:
                         break  # found mod tests block
         for i, line in enumerate(lines[:prod_end], 1):
             if TEST_HELPER_RE.search(line):
-                violations.append(f"{f}:{i}: test helper in production: {line.strip()[:80]}")
+                snippet = _sanitize_paths(line.strip())[:80]
+                violations.append(f"{f}:{i}: test helper in production: {snippet}")
     return violations
 
 
 # ── Check 3: RUSTFLAGS=-D warnings ──────────────────────────────────
-
-_PATH_RE = re.compile(r"/(?:Users|home|var/folders|tmp|opt/homebrew|private)/[^\s\"']+")
-
-
-def _sanitize_paths(text: str) -> str:
-    """Replace absolute filesystem paths with <path> placeholder."""
-    return _PATH_RE.sub("<path>", text)
-
 
 def check_rust_warnings(files: list[str]) -> list[str]:
     """CI uses -D warnings. Local clippy may miss what CI catches."""

--- a/tools/check_pre_commit_hygiene.py
+++ b/tools/check_pre_commit_hygiene.py
@@ -51,8 +51,9 @@ def get_staged_files() -> list[str]:
     # Individual check_* helpers skip paths that no longer exist on disk.
     r = run(["git", "diff", "--cached", "--name-only", "--diff-filter=ACMRD"])
     if r.returncode != 0:
+        detail = _sanitize_paths((r.stderr or "").strip())
         print(
-            f"⚠ git diff --cached failed — fail closed: {(r.stderr or '').strip()}",
+            f"⚠ git diff --cached failed — fail closed: {detail}",
             file=sys.stderr,
         )
         sys.exit(2)
@@ -90,9 +91,10 @@ def get_changed_files() -> list[str]:
             ):
                 r = run(diff_args)
                 if r.returncode != 0:
+                    detail = _sanitize_paths((r.stderr or "").strip())
                     print(
                         f"⚠ git {' '.join(diff_args[1:])} failed (rc={r.returncode}) "
-                        f"— fail closed: {(r.stderr or '').strip()}",
+                        f"— fail closed: {detail}",
                         file=sys.stderr,
                     )
                     sys.exit(2)
@@ -102,7 +104,7 @@ def get_changed_files() -> list[str]:
                         seen.add(f)
                         files.append(f)
             return files
-        last_err = (base_result.stderr or "").strip()
+        last_err = _sanitize_paths((base_result.stderr or "").strip())
     print(
         f"⚠ no base ref found ({', '.join(_BASE_REF_CANDIDATES)}); "
         f"falling back to staged files. Last git error: {last_err}",
@@ -282,24 +284,28 @@ def check_rust_warnings(files: list[str]) -> list[str]:
 # ── Check 4: git diff HEAD after amend ───────────────────────────────
 
 def check_amend_completeness(staged_only: bool) -> list[str]:
-    """Check for unstaged modifications in tracked files (not staged vs HEAD).
+    """Check for any working-tree changes (staged + unstaged) vs HEAD.
 
-    In staged-only mode (pre-commit), skip this check — staged diff from
-    HEAD is intentional.  Only run after amend when we expect zero diff.
+    In staged-only mode (pre-commit), skip — staged diff from HEAD is
+    intentional.  Otherwise compare working tree against HEAD: catches
+    BOTH staged-but-not-amended fixes AND unstaged edits, so the
+    after-amend "zero diff" guard actually fires when fixes are still
+    sitting in the index.
     """
     if staged_only:
         return []
-    r = run(["git", "diff", "--stat"])  # unstaged only, not vs HEAD
+    r = run(["git", "diff", "HEAD", "--stat"])  # vs HEAD = staged + unstaged
     if r.returncode != 0:
+        detail = _sanitize_paths((r.stderr or "").strip())
         print(
-            f"⚠ git diff --stat failed (rc={r.returncode}) — fail closed: "
-            f"{(r.stderr or '').strip()}",
+            f"⚠ git diff HEAD --stat failed (rc={r.returncode}) — fail closed: "
+            f"{detail}",
             file=sys.stderr,
         )
         sys.exit(2)
     if r.stdout.strip():
         files = r.stdout.strip().splitlines()
-        return [f"unstaged changes in working tree: {f.strip()}" for f in files[:5]]
+        return [f"changes vs HEAD (staged or unstaged): {f.strip()}" for f in files[:5]]
     return []
 
 
@@ -323,7 +329,7 @@ def main(argv: list[str] | None = None) -> int:
     # surfaced even if the file-set derivation came back empty.
     v = check_amend_completeness(args.staged_only)
     if v:
-        print(f"\n❌ Unstaged changes after amend ({len(v)}):")
+        print(f"\n❌ Changes vs HEAD after amend ({len(v)}):")
         for line in v:
             print(f"  {line}")
         all_violations.extend(v)

--- a/tools/check_pre_commit_hygiene.py
+++ b/tools/check_pre_commit_hygiene.py
@@ -281,31 +281,34 @@ def check_rust_warnings(files: list[str]) -> list[str]:
     return []
 
 
-# ── Check 4: git diff HEAD after amend ───────────────────────────────
+# ── Check 4: working tree clean (git status --porcelain) ────────────
 
 def check_amend_completeness(staged_only: bool) -> list[str]:
-    """Check for any working-tree changes (staged + unstaged) vs HEAD.
+    """Check that the working tree is fully clean vs HEAD.
 
     In staged-only mode (pre-commit), skip — staged diff from HEAD is
-    intentional.  Otherwise compare working tree against HEAD: catches
-    BOTH staged-but-not-amended fixes AND unstaged edits, so the
-    after-amend "zero diff" guard actually fires when fixes are still
-    sitting in the index.
+    intentional.  Otherwise run `git status --porcelain` which reports
+    ALL three classes of pending change in one call:
+      - staged tracked changes  (XY=`M `, `A `, `D `, etc.)
+      - unstaged tracked changes (XY=` M`, ` D`, etc.)
+      - untracked files          (XY=`??`)
+    The previous `git diff HEAD --stat` missed untracked files (e.g.
+    a new test/fix file forgotten during `git commit --amend`).
     """
     if staged_only:
         return []
-    r = run(["git", "diff", "HEAD", "--stat"])  # vs HEAD = staged + unstaged
+    r = run(["git", "status", "--porcelain"])
     if r.returncode != 0:
         detail = _sanitize_paths((r.stderr or "").strip())
         print(
-            f"[WARN] git diff HEAD --stat failed (rc={r.returncode}) -- fail closed: "
+            f"[WARN] git status --porcelain failed (rc={r.returncode}) -- fail closed: "
             f"{detail}",
             file=sys.stderr,
         )
         sys.exit(2)
     if r.stdout.strip():
-        files = r.stdout.strip().splitlines()
-        return [f"changes vs HEAD (staged or unstaged): {f.strip()}" for f in files[:5]]
+        entries = r.stdout.splitlines()
+        return [f"working tree not clean (XY status): {e}" for e in entries[:5]]
     return []
 
 
@@ -329,7 +332,7 @@ def main(argv: list[str] | None = None) -> int:
     # surfaced even if the file-set derivation came back empty.
     v = check_amend_completeness(args.staged_only)
     if v:
-        print(f"\n[FAIL] Changes vs HEAD after amend ({len(v)}):")
+        print(f"\n[FAIL] Working tree not clean ({len(v)}):")
         for line in v:
             print(f"  {line}")
         all_violations.extend(v)

--- a/tools/check_pre_commit_hygiene.py
+++ b/tools/check_pre_commit_hygiene.py
@@ -127,16 +127,27 @@ def check_test_helpers_in_production(files: list[str]) -> list[str]:
     return violations
 
 
-# ── Check 3: RUSTFLAGS=-D warnings ──────────────────────────────────
+# ── Check 3: cargo clippy --workspace --all-targets -- -D warnings ──
 
 def check_rust_warnings(files: list[str]) -> list[str]:
-    """CI uses -D warnings. Local clippy may miss what CI catches."""
+    """Mirror CI's clippy gate: cargo clippy --workspace --all-targets -- -D warnings.
+
+    Slower than `cargo check` but catches clippy lints CI catches.
+    """
     rs_files = [f for f in files if f.endswith(".rs")]
     if not rs_files:
         return []
 
-    cargo_args = ["cargo", "check", "-p", "rubin-node", "-p", "rubin-consensus"]
-    env = {**os.environ, "RUSTFLAGS": "-D warnings"}
+    cargo_args = [
+        "cargo",
+        "clippy",
+        "--workspace",
+        "--all-targets",
+        "--",
+        "-D",
+        "warnings",
+    ]
+    env = {**os.environ}
 
     dev_env = REPO_ROOT / "scripts" / "dev-env.sh"
     if dev_env.exists():
@@ -158,12 +169,12 @@ def check_rust_warnings(files: list[str]) -> list[str]:
         if errors:
             # Strip file paths from cargo output for cleaner messages.
             return [
-                f"RUSTFLAGS=-D warnings: {_sanitize_paths(re.sub(r' --> .*$', '', e.strip()))[:100]}"
+                f"clippy -D warnings: {_sanitize_paths(re.sub(r' --> .*$', '', e.strip()))[:100]}"
                 for e in errors[:5]
             ]
         raw = re.sub(r"^\s*-->.*$", "", combined, flags=re.MULTILINE).strip()
         raw = _sanitize_paths(raw)[:200]
-        return [f"RUSTFLAGS=-D warnings cargo check failed: {raw or '(no output)'}"]
+        return [f"clippy --workspace --all-targets -- -D warnings failed: {raw or '(no output)'}"]
     return []
 
 
@@ -193,7 +204,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--fix", action="store_true",
                         help="Reserved for future auto-fix (not yet implemented)")
     parser.add_argument("--skip-rust-warnings", action="store_true",
-                        help="Skip RUSTFLAGS=-D warnings check (slow)")
+                        help="Skip cargo clippy --workspace --all-targets check (slow)")
     args = parser.parse_args(argv)
 
     files = get_staged_files() if args.staged_only else get_changed_files()
@@ -229,7 +240,7 @@ def main(argv: list[str] | None = None) -> int:
     if not args.skip_rust_warnings:
         v = check_rust_warnings(files)
         if v:
-            print(f"\n❌ RUSTFLAGS=-D warnings failures ({len(v)}):")
+            print(f"\n❌ cargo clippy --workspace --all-targets -- -D warnings failures ({len(v)}):")
             for line in v:
                 print(f"  {line}")
             all_violations.extend(v)

--- a/tools/check_pre_commit_hygiene.py
+++ b/tools/check_pre_commit_hygiene.py
@@ -47,28 +47,36 @@ def get_staged_files() -> list[str]:
     return [f for f in r.stdout.splitlines() if f.strip()]
 
 
+_BASE_REF_CANDIDATES = ("origin/main", "upstream/main", "main", "master")
+
+
 def get_changed_files() -> list[str]:
-    """All modified/added files vs origin/main."""
-    base_result = run(["git", "merge-base", "origin/main", "HEAD"])
-    if base_result.returncode != 0:
-        print(
-            f"⚠ git merge-base failed (rc={base_result.returncode}) — fail closed: "
-            f"{(base_result.stderr or '').strip()}",
-            file=sys.stderr,
-        )
-        sys.exit(2)
-    base = base_result.stdout.strip()
-    if not base:
-        print("⚠ git merge-base returned empty — fail closed", file=sys.stderr)
-        sys.exit(2)
-    r = run(["git", "diff", "--name-only", f"{base}...HEAD"])
-    if r.returncode != 0:
-        print(
-            f"⚠ git diff failed (rc={r.returncode}) — fail closed: {(r.stderr or '').strip()}",
-            file=sys.stderr,
-        )
-        sys.exit(2)
-    return [f for f in r.stdout.splitlines() if f.strip()]
+    """All modified/added files vs the project's base branch.
+
+    Tries common base refs in order; falls back to staged-only mode (with
+    a loud warning) only when no candidate ref is available locally.
+    """
+    last_err = ""
+    for ref in _BASE_REF_CANDIDATES:
+        base_result = run(["git", "merge-base", ref, "HEAD"])
+        if base_result.returncode == 0 and base_result.stdout.strip():
+            base = base_result.stdout.strip()
+            r = run(["git", "diff", "--name-only", f"{base}...HEAD"])
+            if r.returncode != 0:
+                print(
+                    f"⚠ git diff failed (rc={r.returncode}) — fail closed: "
+                    f"{(r.stderr or '').strip()}",
+                    file=sys.stderr,
+                )
+                sys.exit(2)
+            return [f for f in r.stdout.splitlines() if f.strip()]
+        last_err = (base_result.stderr or "").strip()
+    print(
+        f"⚠ no base ref found ({', '.join(_BASE_REF_CANDIDATES)}); "
+        f"falling back to staged files. Last git error: {last_err}",
+        file=sys.stderr,
+    )
+    return get_staged_files()
 
 
 # ── Check 1: Bot thread IDs in code ──────────────────────────────────

--- a/tools/check_pre_commit_hygiene.py
+++ b/tools/check_pre_commit_hygiene.py
@@ -23,7 +23,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 RUST_DIR = REPO_ROOT / "clients" / "rust"
 
 _PATH_RE = re.compile(
-    r"/(?:Users|home|root|workspace|var/folders|tmp|opt/homebrew|private|runner/work)/[^\s\"']+"
+    r"/(?:Users|home|root|workspace|var/folders|tmp|opt|private|runner/work|nix|build|data|run|mnt|srv|proc|usr)/[^\s\"']+"
 )
 
 

--- a/tools/check_pre_commit_hygiene.py
+++ b/tools/check_pre_commit_hygiene.py
@@ -129,6 +129,9 @@ def check_bot_thread_ids(files: list[str]) -> list[str]:
 # ── Check 2: Exported test helpers in production ─────────────────────
 
 TEST_HELPER_RE = re.compile(r"InjectTestEntry|inject_test_entry")
+# Match the conventional trailing test module only: `mod tests`/`mod test`,
+# but NOT siblings like `mod test_helpers`, `mod testing`, etc.
+MOD_TESTS_RE = re.compile(r"\bmod\s+tests?\b")
 
 
 def check_test_helpers_in_production(files: list[str]) -> list[str]:
@@ -147,18 +150,21 @@ def check_test_helpers_in_production(files: list[str]) -> list[str]:
         lines = content.splitlines()
         # Rust: only check lines BEFORE the final `#[cfg(test)] mod tests`
         # block.  Standard pattern is a trailing test module; also handle
-        # `#[cfg(test)] mod tests {` on a single line.
+        # `#[cfg(test)] mod tests {` on a single line.  Match only the
+        # conventional `mod tests` / `mod test` module name with word
+        # boundaries — `mod test_helpers` is a real production module
+        # that must not be treated as the end-of-prod marker.
         prod_end = len(lines)
         if f.endswith(".rs"):
             for idx in range(len(lines) - 1, -1, -1):
                 if "#[cfg(test)]" in lines[idx]:
                     # Same line: `#[cfg(test)] mod tests {`
-                    if "mod tests" in lines[idx] or "mod test" in lines[idx]:
+                    if MOD_TESTS_RE.search(lines[idx]):
                         prod_end = idx
                         break
                     # Within next 2 lines
                     for nxt in range(idx + 1, min(idx + 3, len(lines))):
-                        if "mod tests" in lines[nxt] or "mod test" in lines[nxt]:
+                        if MOD_TESTS_RE.search(lines[nxt]):
                             prod_end = idx
                             break
                     if prod_end < len(lines):

--- a/tools/check_pre_commit_hygiene.py
+++ b/tools/check_pre_commit_hygiene.py
@@ -161,6 +161,14 @@ def check_test_helpers_in_production(files: list[str]) -> list[str]:
                         break  # found mod tests block
         for i, line in enumerate(lines[:prod_end], 1):
             if TEST_HELPER_RE.search(line):
+                # Skip if the previous non-blank line gates this with #[cfg(test)]
+                # (inline test-only function pattern, e.g. txpool.rs:150).
+                if f.endswith(".rs"):
+                    j = i - 2  # zero-based, line before this match
+                    while j >= 0 and not lines[j].strip():
+                        j -= 1
+                    if j >= 0 and "#[cfg(test)]" in lines[j]:
+                        continue
                 snippet = _sanitize_paths(line.strip())[:80]
                 violations.append(f"{f}:{i}: test helper in production: {snippet}")
     return violations

--- a/tools/check_pre_commit_hygiene.py
+++ b/tools/check_pre_commit_hygiene.py
@@ -126,30 +126,50 @@ _BINARY_EXTS = frozenset({
 _MAX_SCAN_BYTES = 1 * 1024 * 1024  # 1 MiB
 
 
-def _should_scan(f: str, path: Path) -> bool:
+def _read_file_for_check(f: str, staged_only: bool) -> str | None:
+    """Return content of `f` for a check.
+
+    In `--staged-only` mode reads the staged blob (`git show :<f>`) so
+    partial-staging workflows (`git add -p` then unstaged edit) cannot
+    hide a violation by reverting it in the working tree only.
+
+    Otherwise reads the working-tree file.
+
+    Returns None if the file is binary by extension, missing, too large,
+    or — in staged_only mode — not present in the index.
+    """
     if Path(f).suffix.lower() in _BINARY_EXTS:
-        return False
+        return None
+    if staged_only:
+        # Read from the index; skip working-tree size check (the staged
+        # blob's size isn't trivially available, and pre-commit content
+        # is bounded by what the user actually staged).
+        r = run(["git", "show", f":{f}"])
+        if r.returncode != 0:
+            return None  # not in index (e.g. removed before staging)
+        return r.stdout
+    path = REPO_ROOT / f
+    if not path.is_file():
+        return None
     try:
         if path.stat().st_size > _MAX_SCAN_BYTES:
-            return False
+            return None
     except OSError:
-        return False
-    return True
+        return None
+    return path.read_text(errors="replace")
 
 
-def check_bot_thread_ids(files: list[str]) -> list[str]:
+def check_bot_thread_ids(files: list[str], staged_only: bool) -> list[str]:
     """Bot thread IDs are temporary PR artifacts, not permanent code."""
     violations = []
     for f in files:
         # Skip self — this file contains the pattern as a regex literal.
         if f.endswith("check_pre_commit_hygiene.py"):
             continue
-        path = REPO_ROOT / f
-        if not path.is_file():
+        content = _read_file_for_check(f, staged_only)
+        if content is None:
             continue
-        if not _should_scan(f, path):
-            continue
-        for i, line in enumerate(path.read_text(errors="replace").splitlines(), 1):
+        for i, line in enumerate(content.splitlines(), 1):
             if BOT_THREAD_RE.search(line):
                 snippet = _sanitize_paths(line.strip())[:80]
                 violations.append(f"{f}:{i}: bot thread ID in code: {snippet}")
@@ -164,7 +184,7 @@ TEST_HELPER_RE = re.compile(r"InjectTestEntry|inject_test_entry")
 MOD_TESTS_RE = re.compile(r"\bmod\s+tests?\b")
 
 
-def check_test_helpers_in_production(files: list[str]) -> list[str]:
+def check_test_helpers_in_production(files: list[str], staged_only: bool) -> list[str]:
     """Test-only helpers must not be exported in production code."""
     violations = []
     for f in files:
@@ -173,10 +193,9 @@ def check_test_helpers_in_production(files: list[str]) -> list[str]:
             continue
         if not (f.endswith(".go") or f.endswith(".rs")):
             continue
-        path = REPO_ROOT / f
-        if not path.is_file():
+        content = _read_file_for_check(f, staged_only)
+        if content is None:
             continue
-        content = path.read_text(errors="replace")
         lines = content.splitlines()
         # Rust: only check lines BEFORE the final `#[cfg(test)] mod tests`
         # block.  Standard pattern is a trailing test module; also handle
@@ -345,14 +364,14 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     # Fast checks
-    v = check_bot_thread_ids(files)
+    v = check_bot_thread_ids(files, args.staged_only)
     if v:
         print(f"\n[FAIL] Bot thread IDs in code ({len(v)}):")
         for line in v:
             print(f"  {line}")
         all_violations.extend(v)
 
-    v = check_test_helpers_in_production(files)
+    v = check_test_helpers_in_production(files, args.staged_only)
     if v:
         print(f"\n[FAIL] Test helpers in production ({len(v)}):")
         for line in v:

--- a/tools/check_pre_commit_hygiene.py
+++ b/tools/check_pre_commit_hygiene.py
@@ -6,8 +6,9 @@ Based on 39 real threads from PR #1199 and PR #1203.
 
 Usage:
     python3 tools/check_pre_commit_hygiene.py [--fix] [--staged-only]
+                                              [--skip-rust-warnings]
 
-Exit codes: 0 = clean, 1 = violations found, 2 = usage error.
+Exit codes: 0 = clean, 1 = violations found, 2 = usage error or git failure.
 """
 from __future__ import annotations
 
@@ -51,7 +52,10 @@ _BASE_REF_CANDIDATES = ("origin/main", "upstream/main", "main", "master")
 
 
 def get_changed_files() -> list[str]:
-    """All modified/added files vs the project's base branch.
+    """All changed (added/modified/deleted) files vs the project's base branch.
+
+    `git diff --name-only` includes deletions; downstream check_* helpers
+    individually skip files that no longer exist on disk.
 
     Tries common base refs in order; falls back to staged-only mode (with
     a loud warning) only when no candidate ref is available locally.
@@ -180,9 +184,16 @@ def check_rust_warnings(files: list[str]) -> list[str]:
     """Mirror CI's clippy gate: cargo clippy --workspace --all-targets -- -D warnings.
 
     Slower than `cargo check` but catches clippy lints CI catches.
+    Fires on .rs changes AND on Cargo.toml/Cargo.lock changes (which
+    can change feature sets or dependency versions and break clippy).
     """
-    rs_files = [f for f in files if f.endswith(".rs")]
-    if not rs_files:
+    triggers = [
+        f for f in files
+        if f.endswith(".rs")
+        or f.endswith("Cargo.toml")
+        or f.endswith("Cargo.lock")
+    ]
+    if not triggers:
         return []
 
     cargo_args = [
@@ -236,6 +247,13 @@ def check_amend_completeness(staged_only: bool) -> list[str]:
     if staged_only:
         return []
     r = run(["git", "diff", "--stat"])  # unstaged only, not vs HEAD
+    if r.returncode != 0:
+        print(
+            f"⚠ git diff --stat failed (rc={r.returncode}) — fail closed: "
+            f"{(r.stderr or '').strip()}",
+            file=sys.stderr,
+        )
+        sys.exit(2)
     if r.stdout.strip():
         files = r.stdout.strip().splitlines()
         return [f"unstaged changes in working tree: {f.strip()}" for f in files[:5]]

--- a/tools/check_pre_commit_hygiene.py
+++ b/tools/check_pre_commit_hygiene.py
@@ -143,11 +143,26 @@ def _read_file_for_check(f: str, staged_only: bool) -> str | None:
     if staged_only:
         # Read from the index; skip working-tree size check (the staged
         # blob's size isn't trivially available, and pre-commit content
-        # is bounded by what the user actually staged).
-        r = run(["git", "show", f":{f}"])
-        if r.returncode != 0:
+        # is bounded by what the user actually staged).  Read as bytes
+        # to avoid UnicodeDecodeError on non-UTF-8 blobs that slip past
+        # the extension filter, then decode with errors="replace" so
+        # binary/non-UTF-8 staged content doesn't crash the script.
+        try:
+            completed = subprocess.run(
+                ["git", "show", f":{f}"],
+                capture_output=True,
+                cwd=REPO_ROOT,
+            )
+        except FileNotFoundError as exc:
+            detail = _sanitize_paths(str(exc)).strip()
+            print(
+                f"[WARN] failed to execute 'git' -- fail closed: {detail}",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        if completed.returncode != 0:
             return None  # not in index (e.g. removed before staging)
-        return r.stdout
+        return completed.stdout.decode("utf-8", errors="replace")
     path = REPO_ROOT / f
     if not path.is_file():
         return None

--- a/tools/check_pre_commit_hygiene.py
+++ b/tools/check_pre_commit_hygiene.py
@@ -13,7 +13,6 @@ Exit codes: 0 = clean, 1 = violations found, 2 = usage error or git failure.
 from __future__ import annotations
 
 import argparse
-import os
 import re
 import subprocess
 import sys
@@ -214,7 +213,6 @@ def check_rust_warnings(files: list[str]) -> list[str]:
         "-D",
         "warnings",
     ]
-    env = {**os.environ}
 
     dev_env = REPO_ROOT / "scripts" / "dev-env.sh"
     if dev_env.exists():
@@ -222,12 +220,13 @@ def check_rust_warnings(files: list[str]) -> list[str]:
     else:
         cmd = cargo_args
 
+    # Inherit caller env (no overrides needed; -D warnings is on the
+    # cargo arg list, not RUSTFLAGS).
     r = subprocess.run(
         cmd,
         capture_output=True,
         text=True,
         cwd=RUST_DIR,
-        env=env,
     )
     if r.returncode != 0:
         combined = (r.stdout or "") + (r.stderr or "")

--- a/tools/check_pre_commit_hygiene.py
+++ b/tools/check_pre_commit_hygiene.py
@@ -12,6 +12,7 @@ Exit codes: 0 = clean, 1 = violations found, 2 = usage error.
 from __future__ import annotations
 
 import argparse
+import os
 import re
 import subprocess
 import sys
@@ -112,23 +113,30 @@ def check_rust_warnings(files: list[str]) -> list[str]:
     if not rs_files:
         return []
 
+    cargo_args = ["cargo", "check", "-p", "rubin-node", "-p", "rubin-consensus"]
+    env = {**os.environ, "RUSTFLAGS": "-D warnings"}
+
     dev_env = REPO_ROOT / "scripts" / "dev-env.sh"
     if dev_env.exists():
-        cmd = [str(dev_env), "--", "bash", "-c",
-               "cd clients/rust && RUSTFLAGS='-D warnings' cargo check -p rubin-node -p rubin-consensus 2>&1"]
+        cmd = [str(dev_env), "--", *cargo_args]
     else:
-        cmd = ["bash", "-c",
-               "cd clients/rust && RUSTFLAGS='-D warnings' cargo check -p rubin-node -p rubin-consensus 2>&1"]
+        cmd = cargo_args
 
-    r = run(cmd, cwd=REPO_ROOT)
+    r = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        cwd=RUST_DIR,
+        env=env,
+    )
     if r.returncode != 0:
-        # Extract error lines
-        errors = [line for line in r.stdout.splitlines()
+        combined = (r.stdout or "") + (r.stderr or "")
+        errors = [line for line in combined.splitlines()
                   if "error[" in line or "error:" in line.lower()]
         if errors:
             # Strip file paths from cargo output for cleaner messages.
             return [f"RUSTFLAGS=-D warnings: {re.sub(r' --> .*$', '', e.strip())[:100]}" for e in errors[:5]]
-        raw = re.sub(r"^\s*-->.*$", "", (r.stdout or r.stderr or ""), flags=re.MULTILINE).strip()[:200]
+        raw = re.sub(r"^\s*-->.*$", "", combined, flags=re.MULTILINE).strip()[:200]
         return [f"RUSTFLAGS=-D warnings cargo check failed: {raw or '(no output)'}"]
     return []
 

--- a/tools/check_pre_commit_hygiene.py
+++ b/tools/check_pre_commit_hygiene.py
@@ -38,7 +38,10 @@ def run(cmd: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess[
 
 
 def get_staged_files() -> list[str]:
-    r = run(["git", "diff", "--cached", "--name-only", "--diff-filter=ACMR"])
+    # Include D (deletions) so commits that only delete files still trigger
+    # downstream checks (clippy on Cargo.toml/lock changes, etc.).
+    # Individual check_* helpers skip paths that no longer exist on disk.
+    r = run(["git", "diff", "--cached", "--name-only", "--diff-filter=ACMRD"])
     if r.returncode != 0:
         print(
             f"⚠ git diff --cached failed — fail closed: {(r.stderr or '').strip()}",

--- a/tools/check_pre_commit_hygiene.py
+++ b/tools/check_pre_commit_hygiene.py
@@ -39,7 +39,10 @@ def run(cmd: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess[
 def get_staged_files() -> list[str]:
     r = run(["git", "diff", "--cached", "--name-only", "--diff-filter=ACMR"])
     if r.returncode != 0:
-        print("⚠ git diff --cached failed — fail closed", file=sys.stderr)
+        print(
+            f"⚠ git diff --cached failed — fail closed: {(r.stderr or '').strip()}",
+            file=sys.stderr,
+        )
         sys.exit(2)
     return [f for f in r.stdout.splitlines() if f.strip()]
 
@@ -48,7 +51,11 @@ def get_changed_files() -> list[str]:
     """All modified/added files vs origin/main."""
     base_result = run(["git", "merge-base", "origin/main", "HEAD"])
     if base_result.returncode != 0:
-        print(f"⚠ git merge-base failed (rc={base_result.returncode}) — fail closed", file=sys.stderr)
+        print(
+            f"⚠ git merge-base failed (rc={base_result.returncode}) — fail closed: "
+            f"{(base_result.stderr or '').strip()}",
+            file=sys.stderr,
+        )
         sys.exit(2)
     base = base_result.stdout.strip()
     if not base:
@@ -56,7 +63,10 @@ def get_changed_files() -> list[str]:
         sys.exit(2)
     r = run(["git", "diff", "--name-only", f"{base}...HEAD"])
     if r.returncode != 0:
-        print(f"⚠ git diff failed (rc={r.returncode}) — fail closed", file=sys.stderr)
+        print(
+            f"⚠ git diff failed (rc={r.returncode}) — fail closed: {(r.stderr or '').strip()}",
+            file=sys.stderr,
+        )
         sys.exit(2)
     return [f for f in r.stdout.splitlines() if f.strip()]
 
@@ -64,6 +74,25 @@ def get_changed_files() -> list[str]:
 # ── Check 1: Bot thread IDs in code ──────────────────────────────────
 
 BOT_THREAD_RE = re.compile(r"PRRT_\w+|Codex thread|Copilot thread|chatgpt-codex-connector")
+_BINARY_EXTS = frozenset({
+    ".png", ".jpg", ".jpeg", ".gif", ".bmp", ".ico", ".webp", ".pdf",
+    ".zip", ".gz", ".tar", ".tgz", ".bz2", ".xz", ".7z", ".rar",
+    ".so", ".dylib", ".dll", ".exe", ".bin", ".o", ".a", ".class",
+    ".jar", ".wasm", ".woff", ".woff2", ".ttf", ".otf", ".eot",
+    ".mp3", ".mp4", ".mov", ".avi", ".mkv", ".webm", ".ogg",
+})
+_MAX_SCAN_BYTES = 1 * 1024 * 1024  # 1 MiB
+
+
+def _should_scan(f: str, path: Path) -> bool:
+    if Path(f).suffix.lower() in _BINARY_EXTS:
+        return False
+    try:
+        if path.stat().st_size > _MAX_SCAN_BYTES:
+            return False
+    except OSError:
+        return False
+    return True
 
 
 def check_bot_thread_ids(files: list[str]) -> list[str]:
@@ -75,6 +104,8 @@ def check_bot_thread_ids(files: list[str]) -> list[str]:
             continue
         path = REPO_ROOT / f
         if not path.is_file():
+            continue
+        if not _should_scan(f, path):
             continue
         for i, line in enumerate(path.read_text(errors="replace").splitlines(), 1):
             if BOT_THREAD_RE.search(line):


### PR DESCRIPTION
## Summary

Fix B.7: Rust `disconnect_tip` persisted chainstate (save) BEFORE truncating the canonical index. Go does truncate FIRST, then save. Aligns Rust with Go `DisconnectTip` ordering.

## Change

### Primary fix
`clients/rust/crates/rubin-node/src/sync_disconnect.rs`: swap `truncate_canonical` and `chain_state.save` — now disconnect → truncate → save (matching Go).

Save-failure recovery: `rollback_canonical` re-appends tip hash, then in-memory state is restored inline only when canonical rollback succeeded (avoids mismatch on double-failure). When canonical restore fails, in-memory state stays in its post-`disconnect_block` state and `tip_timestamp` is aligned with the disconnected parent so freshness metadata stays coherent.

### Supporting refactors required to pass CI clippy 1.95.0
- `clients/rust/crates/rubin-consensus/src/connect_block_inmem.rs`, `clients/rust/crates/rubin-node/src/chainstate.rs`: `sort_by` → `sort_unstable_by(|a,b| a.0.cmp(&b.0))` for `[u8;36]` keys, with `#[allow(clippy::unnecessary_sort_by)]` to opt out of the `sort_unstable_by_key` rewrite (avoids decorate/sort/undecorate copies on the consensus digest hot path).
- `clients/rust/crates/rubin-consensus/src/tx.rs`: ML-DSA-87 match arm restructured to guard pattern (clippy `collapsed_match_arm`)
- `clients/rust/crates/rubin-node/src/p2p_runtime.rs`: `MSG_BLOCK` match arm restructured to guard pattern (clippy `collapsed_match_arm`)
- `clients/rust/crates/rubin-node/src/blockstore.rs`: `loop { let Some(...) = ... else { break } }` → `while let Some(...) = ...` (clippy `while_let_loop`); added `#[cfg(test)] force_truncate_error` and `force_rollback_error` test injects.
- `clients/rust/crates/rubin-node/src/sync.rs`: added `#[cfg(test)] drop_block_store_after_truncate` seam to exercise the otherwise-unreachable blockstore-missing branch in the save-failure recovery.

These are pure syntactic refactors with verified-equivalent semantics (see reviewer notes).

### Pre-commit gate
Adds `tools/check_pre_commit_hygiene.py` — pre-commit Python tool catching bot thread IDs, test helpers in production, unstaged changes, and `cargo clippy --workspace --all-targets -- -D warnings` failures (mirrors CI gate). The script itself is the deliverable here; agents are expected to invoke it manually before committing or to install a per-clone hook (no in-repo hook installer is shipped in this PR — that's intentional, hooks remain local-only).

## Verification

- `cargo test sync_disconnect` — 8/8 pass (incl. double-failure rollback test + blockstore-dropped seam test)
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- Local Codacy preflight — PASS, baseline matches GitHub, diff coverage 100%

Closes #1170