### PR TITLE
fix(subsidy): add explicit u64 overflow guard matching Go IsUint64 contract

### DIFF
--- a/clients/rust/crates/rubin-consensus/src/subsidy.rs
+++ b/clients/rust/crates/rubin-consensus/src/subsidy.rs
@@ -17,9 +17,23 @@ pub fn block_subsidy(height: u64, already_generated: u128) -> u64 {
     let remaining = mineable_cap - already_generated;
     let base_reward = remaining >> EMISSION_SPEED_FACTOR;
     if base_reward < u128::from(TAIL_EMISSION_PER_BLOCK) {
-        TAIL_EMISSION_PER_BLOCK
-    } else {
-        base_reward as u64
+        return TAIL_EMISSION_PER_BLOCK;
+    }
+    clamp_base_reward_to_u64(base_reward)
+}
+
+/// Narrow `base_reward` from the u128 subsidy arithmetic into `u64` with
+/// an explicit overflow guard — the Rust equivalent of Go's
+/// `baseReward.IsUint64()` check (clients/go/consensus/subsidy.go:43-47).
+///
+/// Unreachable for current constants (MINEABLE_CAP fits in u64 and the
+/// right shift by EMISSION_SPEED_FACTOR only reduces the value), but
+/// the guard preserves deterministic behavior for malformed caller
+/// state and prevents silent truncation via `as u64`.
+fn clamp_base_reward_to_u64(base_reward: u128) -> u64 {
+    match u64::try_from(base_reward) {
+        Ok(v) => v,
+        Err(_) => TAIL_EMISSION_PER_BLOCK,
     }
 }
 
@@ -67,6 +81,31 @@ mod tests {
     }
 
     #[test]
+    fn clamp_base_reward_within_u64_passes_through() {
+        // Values that fit u64 go through unchanged.
+        assert_eq!(clamp_base_reward_to_u64(0), 0);
+        assert_eq!(clamp_base_reward_to_u64(1), 1);
+        assert_eq!(clamp_base_reward_to_u64(u128::from(u64::MAX)), u64::MAX);
+        assert_eq!(
+            clamp_base_reward_to_u64(u128::from(TAIL_EMISSION_PER_BLOCK)),
+            TAIL_EMISSION_PER_BLOCK
+        );
+    }
+
+    #[test]
+    fn clamp_base_reward_overflow_falls_back_to_tail() {
+        // Overflow branch matches Go `BlockSubsidyBig` `IsUint64()` behavior:
+        // deterministic fallback to TAIL_EMISSION_PER_BLOCK (not a silent
+        // truncation via `as u64`).  Unreachable for current constants but
+        // verifies the guard exists and fires.
+        assert_eq!(
+            clamp_base_reward_to_u64(u128::from(u64::MAX) + 1),
+            TAIL_EMISSION_PER_BLOCK
+        );
+        assert_eq!(clamp_base_reward_to_u64(u128::MAX), TAIL_EMISSION_PER_BLOCK);
+    }
+
+    #[test]
     fn block_subsidy_repeat_is_deterministic() {
         let height = 42;
         let already_generated = 123_456_789u128;
@@ -107,5 +146,22 @@ mod verification {
     fn verify_subsidy_genesis_zero() {
         let already_generated: u128 = kani::any();
         assert_eq!(block_subsidy(0, already_generated), 0);
+    }
+
+    /// `clamp_base_reward_to_u64` never panics, and its result is
+    /// either the input unchanged (when it fits u64) or the
+    /// deterministic `TAIL_EMISSION_PER_BLOCK` fallback (matching Go's
+    /// `IsUint64()` branch).  No silent truncation via `as u64`.
+    #[kani::proof]
+    fn verify_clamp_base_reward_no_overflow() {
+        let base_reward: u128 = kani::any();
+        let clamped = clamp_base_reward_to_u64(base_reward);
+        if base_reward <= u128::from(u64::MAX) {
+            // Fits u64 — identity.
+            assert_eq!(u128::from(clamped), base_reward);
+        } else {
+            // Overflow — deterministic tail fallback.
+            assert_eq!(clamped, TAIL_EMISSION_PER_BLOCK);
+        }
     }
 }

--- a/clients/rust/crates/rubin-consensus/src/subsidy.rs
+++ b/clients/rust/crates/rubin-consensus/src/subsidy.rs
@@ -22,14 +22,17 @@ pub fn block_subsidy(height: u64, already_generated: u128) -> u64 {
     clamp_base_reward_to_u64(base_reward)
 }
 
-/// Narrow `base_reward` from the u128 subsidy arithmetic into `u64` with
-/// an explicit overflow guard — the Rust equivalent of Go's
-/// `baseReward.IsUint64()` check (clients/go/consensus/subsidy.go:43-47).
+/// Narrow `base_reward` from the u128 subsidy arithmetic into `u64`
+/// with an explicit overflow guard — the Rust equivalent of the
+/// `baseReward.IsUint64()` branch in `BlockSubsidyBig`
+/// (`clients/go/consensus/subsidy.go`).
 ///
-/// Unreachable for current constants (MINEABLE_CAP fits in u64 and the
-/// right shift by EMISSION_SPEED_FACTOR only reduces the value), but
-/// the guard preserves deterministic behavior for malformed caller
-/// state and prevents silent truncation via `as u64`.
+/// Unreachable with the current constants and control flow
+/// (`already_generated >= MINEABLE_CAP` returns early, and the right
+/// shift by `EMISSION_SPEED_FACTOR` only reduces the remaining
+/// amount), but the guard preserves explicit Go↔Rust parity,
+/// future-proofs this path if the cap or arithmetic widens later, and
+/// prevents silent truncation via `as u64`.
 fn clamp_base_reward_to_u64(base_reward: u128) -> u64 {
     match u64::try_from(base_reward) {
         Ok(v) => v,


### PR DESCRIPTION
## Summary

Q-IMPL-CONSENSUS-BLOCK-SUBSIDY-OVERFLOW-GUARD-01 (G.14, issue #1193).

Rust \`block_subsidy\` ended its u128 arithmetic with a silent \`base_reward as u64\` truncation. Go's \`BlockSubsidyBig\` ([clients/go/consensus/subsidy.go:43-47](https://github.com/2tbmz9y2xt-lang/rubin-protocol/blob/main/clients/go/consensus/subsidy.go#L43-L47)) guards the same cast with \`!baseReward.IsUint64()\` and falls back to \`TAIL_EMISSION_PER_BLOCK\`.

## Change

Extract the narrowing into a private \`clamp_base_reward_to_u64(u128) -> u64\` helper that uses \`u64::try_from\` with \`TAIL_EMISSION_PER_BLOCK\` as the \`Err\` fallback — the Rust equivalent of Go's \`IsUint64\` branch.

Unreachable for current constants (\`MINEABLE_CAP\` fits u64, right shift by \`EMISSION_SPEED_FACTOR\` only reduces), but the explicit guard preserves deterministic behavior for malformed caller state and eliminates silent truncation.

## Tests

- \`clamp_base_reward_within_u64_passes_through\` — identity for 0, 1, \`u64::MAX\`, \`TAIL_EMISSION_PER_BLOCK\`.
- \`clamp_base_reward_overflow_falls_back_to_tail\` — overflow branch returns TAIL for \`u64::MAX + 1\` and \`u128::MAX\`.

## Kani

- \`verify_clamp_base_reward_no_overflow\` — bi-conditional property for the full u128 domain: identity when input fits u64, deterministic TAIL fallback otherwise. No silent truncation.

## Verification

- \`cargo test -p rubin-consensus subsidy\` — 14/14 pass (6 existing + 2 new unit + 6 module-level)
- \`cargo clippy -p rubin-consensus --all-targets -- -D warnings\` — clean
- \`cargo fmt --check\` — clean
- Local Codacy preflight — PASS (variation -0.00%)
- Pre-push reviewer (Opus 4.7, max effort) — \`VERDICT: PASS, 0 findings\`

Closes #1193.