### PR TITLE
fix(rust/consensus): align DA error surface with Go (G.1, G.2)

### DIFF
--- a/clients/rust/crates/rubin-consensus/src/block_basic.rs
+++ b/clients/rust/crates/rubin-consensus/src/block_basic.rs
@@ -676,11 +676,11 @@ mod internal_tests {
 
         let err = validate_da_set_maps(&commits, &chunks).unwrap_err();
         assert_eq!(err.code, ErrorCode::BlockErrDaPayloadCommitInvalid);
-        assert!(
-            err.msg.contains("invalid length"),
-            "expected 'invalid length' surface, got {:?}",
-            err.msg
-        );
+        // Exact-message parity: the Go reference returns this exact string
+        // (`clients/go/consensus/block_basic.go`, `validateDASetIntegrity`).
+        // A substring check would mask future drift that still happens to
+        // contain "invalid length".
+        assert_eq!(err.msg, "DA commitment output has invalid length");
     }
 
     /// Go parity for G.2: the `MAX_DA_BATCHES_PER_BLOCK` guard runs BEFORE the
@@ -692,10 +692,15 @@ mod internal_tests {
     #[test]
     fn validate_da_set_maps_batch_exceeded_fires_before_set_invalid() {
         let mut commits = HashMap::new();
-        for i in 0..=MAX_DA_BATCHES_PER_BLOCK as u16 {
+        // `i` is u32 and we write 4 bytes of `da_id` so the counter stays
+        // injective even if `MAX_DA_BATCHES_PER_BLOCK` is ever raised past
+        // `u16::MAX`. `assert_eq!(commits.len(), MAX+1)` below is the
+        // fail-fast guard; the wider counter keeps that guard meaningful.
+        let limit: u32 = MAX_DA_BATCHES_PER_BLOCK as u32;
+        for i in 0..=limit {
             // commit_count == MAX + 1 triggers the batch-exceeded guard.
             let mut da_id = [0u8; 32];
-            da_id[0..2].copy_from_slice(&i.to_le_bytes());
+            da_id[0..4].copy_from_slice(&i.to_le_bytes());
             commits.insert(
                 da_id,
                 DaCommitSet {

--- a/clients/rust/crates/rubin-consensus/src/block_basic.rs
+++ b/clients/rust/crates/rubin-consensus/src/block_basic.rs
@@ -293,6 +293,18 @@ fn validate_da_set_maps(
     commits: &HashMap<[u8; 32], DaCommitSet>,
     chunks: &HashMap<[u8; 32], HashMap<u16, Tx>>,
 ) -> Result<(), TxError> {
+    // Go parity (clients/go/consensus/block_basic.go, `validateDASetsInBlock`):
+    // the batch-count guard runs BEFORE the sortedDAIDs loops so a block that
+    // exceeds `MAX_DA_BATCHES_PER_BLOCK` surfaces as `BLOCK_ERR_DA_BATCH_EXCEEDED`,
+    // not as `BLOCK_ERR_DA_SET_INVALID` / `BLOCK_ERR_DA_INCOMPLETE` from a
+    // stray chunk or bad chunk_count inside the overflowing set.
+    if commits.len() > MAX_DA_BATCHES_PER_BLOCK as usize {
+        return Err(TxError::new(
+            ErrorCode::BlockErrDaBatchExceeded,
+            "too many DA commits in block",
+        ));
+    }
+
     let commit_ids = sorted_da_ids(commits);
     let chunk_ids = sorted_da_ids(chunks);
 
@@ -325,13 +337,6 @@ fn validate_da_set_maps(
         }
     }
 
-    if commits.len() > MAX_DA_BATCHES_PER_BLOCK as usize {
-        return Err(TxError::new(
-            ErrorCode::BlockErrDaBatchExceeded,
-            "too many DA commits in block",
-        ));
-    }
-
     for da_id in &commit_ids {
         let commit = da_commit_for_id(commits, da_id)?;
         let set = da_chunk_set_for_id(chunks, da_id)?;
@@ -349,9 +354,22 @@ fn validate_da_set_maps(
                 continue;
             }
             da_commit_outputs += 1;
-            if o.covenant_data.len() == 32 {
-                got_commitment.copy_from_slice(&o.covenant_data);
+            // Go parity (clients/go/consensus/block_basic.go,
+            // `validateDASetsInBlock` payload-commitment loop): a DA commit
+            // output whose covenant payload is not exactly 32 bytes is
+            // rejected as `BLOCK_ERR_DA_PAYLOAD_COMMIT_INVALID /
+            // "DA commitment output has invalid length"` BEFORE the
+            // missing/duplicated count check and BEFORE the commitment
+            // mismatch check. Silently zero-filling `got_commitment` would
+            // collapse this case into `payload commitment mismatch`, losing
+            // the dedicated length-classification surface.
+            if o.covenant_data.len() != 32 {
+                return Err(TxError::new(
+                    ErrorCode::BlockErrDaPayloadCommitInvalid,
+                    "DA commitment output has invalid length",
+                ));
             }
+            got_commitment.copy_from_slice(&o.covenant_data);
         }
         if da_commit_outputs != 1 {
             return Err(TxError::new(
@@ -545,12 +563,16 @@ mod internal_tests {
         da_chunk_set_for_id, da_chunk_tx_for_index, da_commit_for_id, validate_da_set_maps,
         DaCommitSet,
     };
-    use crate::constants::COV_TYPE_DA_COMMIT;
+    use crate::constants::{COV_TYPE_DA_COMMIT, MAX_DA_BATCHES_PER_BLOCK};
     use crate::error::ErrorCode;
     use crate::tx::{Tx, TxOutput};
     use std::collections::HashMap;
 
     fn dummy_da_commit_tx(payload_commitment: [u8; 32]) -> Tx {
+        dummy_da_commit_tx_with_covenant_data(payload_commitment.to_vec())
+    }
+
+    fn dummy_da_commit_tx_with_covenant_data(covenant_data: Vec<u8>) -> Tx {
         Tx {
             version: 1,
             tx_kind: 0x01,
@@ -559,7 +581,7 @@ mod internal_tests {
             outputs: vec![TxOutput {
                 value: 0,
                 covenant_type: COV_TYPE_DA_COMMIT,
-                covenant_data: payload_commitment.to_vec(),
+                covenant_data,
             }],
             locktime: 0,
             da_commit_core: None,
@@ -624,6 +646,76 @@ mod internal_tests {
 
         let err = validate_da_set_maps(&commits, &chunks).unwrap_err();
         assert_eq!(err.code, ErrorCode::BlockErrDaIncomplete);
+    }
+
+    /// Go parity for G.1: a DA commit output whose covenant payload is not
+    /// exactly 32 bytes is classified as
+    /// `BLOCK_ERR_DA_PAYLOAD_COMMIT_INVALID / "DA commitment output has
+    /// invalid length"`, not collapsed into the generic
+    /// `"payload commitment mismatch"` surface.
+    #[test]
+    fn validate_da_set_maps_rejects_non_32_covenant_data_as_invalid_length() {
+        let da_id = [0x55; 32];
+        let payload = b"payload-short-covenant".to_vec();
+
+        let mut commits = HashMap::new();
+        // covenant_data deliberately 31 bytes (not 32).
+        let bad_covenant: Vec<u8> = (0..31).collect();
+        commits.insert(
+            da_id,
+            DaCommitSet {
+                tx: dummy_da_commit_tx_with_covenant_data(bad_covenant),
+                chunk_count: 1,
+            },
+        );
+
+        let mut set = HashMap::new();
+        set.insert(0, dummy_da_chunk_tx(&payload));
+        let mut chunks = HashMap::new();
+        chunks.insert(da_id, set);
+
+        let err = validate_da_set_maps(&commits, &chunks).unwrap_err();
+        assert_eq!(err.code, ErrorCode::BlockErrDaPayloadCommitInvalid);
+        assert!(
+            err.msg.contains("invalid length"),
+            "expected 'invalid length' surface, got {:?}",
+            err.msg
+        );
+    }
+
+    /// Go parity for G.2: the `MAX_DA_BATCHES_PER_BLOCK` guard runs BEFORE the
+    /// sortedDAIDs loops, so an oversize block whose excess sets also contain
+    /// structural problems (orphaned chunks, missing chunk index, chunk_count
+    /// OOB) surfaces as `BLOCK_ERR_DA_BATCH_EXCEEDED` rather than the
+    /// downstream `BLOCK_ERR_DA_SET_INVALID` / `BLOCK_ERR_DA_INCOMPLETE`
+    /// classification of an inner set.
+    #[test]
+    fn validate_da_set_maps_batch_exceeded_fires_before_set_invalid() {
+        let mut commits = HashMap::new();
+        for i in 0..=MAX_DA_BATCHES_PER_BLOCK as u16 {
+            // commit_count == MAX + 1 triggers the batch-exceeded guard.
+            let mut da_id = [0u8; 32];
+            da_id[0..2].copy_from_slice(&i.to_le_bytes());
+            commits.insert(
+                da_id,
+                DaCommitSet {
+                    tx: dummy_da_commit_tx([0xAA; 32]),
+                    chunk_count: 1,
+                },
+            );
+        }
+
+        // Seed chunk map with an orphaned DA set (no matching commit) —
+        // without the reorder, this would surface as `BlockErrDaSetInvalid`.
+        let mut orphan_set = HashMap::new();
+        orphan_set.insert(0, dummy_da_chunk_tx(b"orphan"));
+        let mut chunks = HashMap::new();
+        chunks.insert([0xFF; 32], orphan_set);
+
+        assert_eq!(commits.len(), MAX_DA_BATCHES_PER_BLOCK as usize + 1);
+
+        let err = validate_da_set_maps(&commits, &chunks).unwrap_err();
+        assert_eq!(err.code, ErrorCode::BlockErrDaBatchExceeded);
     }
 }
 

--- a/clients/rust/crates/rubin-consensus/src/block_basic.rs
+++ b/clients/rust/crates/rubin-consensus/src/block_basic.rs
@@ -721,6 +721,12 @@ mod internal_tests {
 
         let err = validate_da_set_maps(&commits, &chunks).unwrap_err();
         assert_eq!(err.code, ErrorCode::BlockErrDaBatchExceeded);
+        // Exact-message parity with Go (`clients/go/consensus/block_basic.go`,
+        // `validateDASetIntegrity`): lock the full reject message, not just
+        // the code, so future wording drift is caught alongside the
+        // ordering invariant. Mirrors the same assertion style used by the
+        // G.1 length-reject test above.
+        assert_eq!(err.msg, "too many DA commits in block");
     }
 }
 

--- a/clients/rust/crates/rubin-consensus/src/block_basic.rs
+++ b/clients/rust/crates/rubin-consensus/src/block_basic.rs
@@ -293,7 +293,7 @@ fn validate_da_set_maps(
     commits: &HashMap<[u8; 32], DaCommitSet>,
     chunks: &HashMap<[u8; 32], HashMap<u16, Tx>>,
 ) -> Result<(), TxError> {
-    // Go parity (clients/go/consensus/block_basic.go, `validateDASetsInBlock`):
+    // Go parity (clients/go/consensus/block_basic.go, `validateDASetIntegrity`):
     // the batch-count guard runs BEFORE the sortedDAIDs loops so a block that
     // exceeds `MAX_DA_BATCHES_PER_BLOCK` surfaces as `BLOCK_ERR_DA_BATCH_EXCEEDED`,
     // not as `BLOCK_ERR_DA_SET_INVALID` / `BLOCK_ERR_DA_INCOMPLETE` from a
@@ -355,7 +355,7 @@ fn validate_da_set_maps(
             }
             da_commit_outputs += 1;
             // Go parity (clients/go/consensus/block_basic.go,
-            // `validateDASetsInBlock` payload-commitment loop): a DA commit
+            // `validateDASetIntegrity` payload-commitment loop): a DA commit
             // output whose covenant payload is not exactly 32 bytes is
             // rejected as `BLOCK_ERR_DA_PAYLOAD_COMMIT_INVALID /
             // "DA commitment output has invalid length"` BEFORE the


### PR DESCRIPTION
## Summary

Closes **Q-IMPL-CONSENSUS-DA-ERROR-SURFACE-PARITY-01** (refs #1185).

Two scoped Go↔Rust drifts in `validate_da_set_maps`:

- **G.1 (payload-commitment length classification)** — Rust silently skipped the `covenant_data.len() != 32` case (gated `copy_from_slice` behind `== 32`), so a malformed DA commitment output fell through with `got_commitment` all zeros and surfaced as `BLOCK_ERR_DA_PAYLOAD_COMMIT_INVALID / "payload commitment mismatch"`. Go explicitly rejects with `"DA commitment output has invalid length"` before the missing/duplicated and mismatch checks. Rust now mirrors that path.

- **G.2 (batch-count check ordering)** — Rust ran `commits.len() > MAX_DA_BATCHES_PER_BLOCK` **after** the sortedDAIDs "chunks-without-commit" loop and per-commit chunk-count loops, so oversize blocks whose excess sets also had structural problems surfaced as `BLOCK_ERR_DA_SET_INVALID` / `BLOCK_ERR_DA_INCOMPLETE`. Go runs batch-exceeded **first**. Rust now checks it at the top of `validate_da_set_maps`.

Visible payload: reject code/message surface for the two cases — no consensus-rule change, only classification parity.

## Parity contract

- Both clients reject `covenant_data.len() != 32` with `BLOCK_ERR_DA_PAYLOAD_COMMIT_INVALID / "DA commitment output has invalid length"` before the count/mismatch checks.
- Both clients run the `MAX_DA_BATCHES_PER_BLOCK` guard before the sortedDAIDs loops.

## Tests

New targeted unit tests in `block_basic::internal_tests`:

- `validate_da_set_maps_rejects_non_32_covenant_data_as_invalid_length` — 31-byte covenant ⇒ `BlockErrDaPayloadCommitInvalid` with `"invalid length"` message, not collapsed into `"payload commitment mismatch"`.
- `validate_da_set_maps_batch_exceeded_fires_before_set_invalid` — `MAX_DA_BATCHES_PER_BLOCK + 1` commits + orphan chunk ⇒ `BlockErrDaBatchExceeded`, confirming reorder.

## Out of scope

- `verify_da_payload_commits_parallel` `MAX_DA_BYTES_PER_BLOCK` surface (no Go twin).
- `pow_check` header-length guard (G.3).
- Broader DA pipeline redesign.

## Verification

- [x] `cargo test -p rubin-consensus` all suites green
- [x] `cargo clippy -p rubin-consensus --all-targets -- -D warnings` clean
- [x] Go DA test baseline unchanged (`go test ./consensus/ -run 'DA|Da'`)
- [x] Coverage preflight: +0.01% variation, 100% diff coverage (9/9)
- [x] Local security review PASS (ci-deferred, consensus_critical lenses)
- [x] Claude-review PASS (branch scope, Opus 4.7, max effort), 0 findings

## Test plan

- [ ] CI green across Go/Rust/conformance jobs
- [ ] Bot reviewers (CodeRabbit/Copilot) — no structural findings expected
- [ ] Controller approval (merge semantics unchanged; only reject classification aligned)