### PR TITLE
fix(rust/node): atomic canonical block commit matching Go ordering (E.4)

### DIFF
--- a/clients/rust/crates/rubin-node/src/blockstore.rs
+++ b/clients/rust/crates/rubin-node/src/blockstore.rs
@@ -141,28 +141,44 @@ impl BlockStore {
                 undo.block_height
             ));
         }
-        // 0a. Strict append-only invariant guard. `commit_canonical_block`
-        //     is the canonical APPEND path; non-append canonical
-        //     rewrites go through `rollback_canonical` /
-        //     `truncate_canonical` / explicit reorg APIs. A stale
-        //     `height < canonical_len` — even with a matching hash —
-        //     would cause `put_undo` to overwrite the historical
-        //     undo file at that height via `write_file_atomic`'s
-        //     tmp+rename, which is a sharp edge for future callers.
-        //     A future-height gap (`height > canonical_len`) would
-        //     leak orphan block/header/undo files before
-        //     `set_canonical_tip` rejects the gap. Both cases are
-        //     rejected up front, before any disk write. Only the
-        //     strict `height == canonical_len` append is accepted;
-        //     retry after a crashed commit is handled by the
-        //     `set_canonical_tip` reload path, which restores the
-        //     pre-commit `canonical_len` so the retry lands as a
-        //     normal append rather than a mid-chain rewrite.
+        // 0a. Append-only invariant guard with an idempotent same-hash
+        //     replay carve-out for crash recovery.
+        //
+        //     `commit_canonical_block` is the canonical APPEND path; real
+        //     non-append rewrites go through `rollback_canonical` /
+        //     `truncate_canonical` / explicit reorg APIs. A future-height
+        //     gap (`height > canonical_len`) would leak orphan
+        //     block/header/undo files before `set_canonical_tip` rejects
+        //     the gap and is rejected up front.
+        //
+        //     `height < canonical_len` is the crash-recovery case:
+        //     `commit_canonical_block` persisted block/undo and advanced
+        //     the tip, then `chain_state.save` crashed, so on restart the
+        //     chain state lags the blockstore by one or more blocks and
+        //     `SyncEngine::apply_block` replays the already-persisted
+        //     block at its original height. That replay MUST succeed to
+        //     unblock recovery, but MUST NOT rewrite the historical
+        //     block/header/undo files — `put_undo` via `write_file_atomic`
+        //     would otherwise clobber the historical undo on disk. The
+        //     same-hash path therefore returns `Ok(())` as a pure no-op:
+        //     no `persist_block_bytes`, no `put_undo`, no tip mutation.
+        //     Different-hash replay at a historical height is still a
+        //     real reorg and goes through the rollback/truncate APIs.
         let current_len = self.canonical_len() as u64;
-        if height != current_len {
+        if height > current_len {
             return Err(format!(
-                "commit_canonical_block is append-only: height={height} != canonical_len={current_len}; \
-                 use rollback/truncate/rewind APIs for non-append commits"
+                "commit_canonical_block height gap: height={height} > canonical_len={current_len}"
+            ));
+        }
+        if height < current_len {
+            let existing = self.canonical_hash(height)?;
+            if existing == Some(block_hash_bytes) {
+                // Idempotent same-hash replay: skip all disk writes.
+                return Ok(());
+            }
+            return Err(format!(
+                "commit_canonical_block is append-only: height={height} < canonical_len={current_len} \
+                 with a different hash; use rollback/truncate for reorg commits"
             ));
         }
         // 1. Persist block + header bytes (idempotent `write_file_if_absent`).
@@ -967,8 +983,8 @@ mod tests {
             .commit_canonical_block(5, hash, header, &genesis, &undo)
             .unwrap_err();
         assert!(
-            err.contains("append-only") && err.contains("height=5"),
-            "expected append-only rejection on future-height gap, got {err:?}"
+            err.contains("height gap") && err.contains("height=5"),
+            "expected height-gap rejection, got {err:?}"
         );
 
         // No disk writes: block/header/undo files must NOT exist.
@@ -982,44 +998,71 @@ mod tests {
     /// canonical height must be rejected, because the undo file
     /// would be overwritten at a historical height (sharp edge for
     /// future callers).
+    /// Crash-recovery path (GPT-5 review P1): after a successful
+    /// `commit_canonical_block` that advanced the blockstore tip, if
+    /// `chain_state.save` crashes the chain state lags the blockstore
+    /// by one or more blocks. On restart `SyncEngine::apply_block`
+    /// replays the already-persisted block at its original height and
+    /// MUST succeed so recovery can proceed; it MUST NOT rewrite the
+    /// historical block/header/undo files because `put_undo` via
+    /// `write_file_atomic` would clobber the historical undo on disk.
+    /// The same-hash replay is therefore handled as a no-op: no disk
+    /// writes, no tip mutation, `Ok(())` returned.
     #[test]
-    fn commit_canonical_block_rejects_same_hash_at_historical_height() {
+    fn commit_canonical_block_same_hash_replay_is_idempotent_noop() {
+        use crate::genesis::devnet_genesis_block_bytes;
         use crate::undo::{BlockUndo, TxUndo};
-        use rubin_consensus::BLOCK_HEADER_BYTES;
+        use rubin_consensus::{block_hash, BLOCK_HEADER_BYTES};
 
-        let dir = unique_temp_path("rubin-blockstore-commit-same-hash");
+        let dir = unique_temp_path("rubin-blockstore-same-hash-replay");
         let root = block_store_path(&dir);
         let mut store = BlockStore::open(&root).expect("open");
 
-        let hash0 = [0x11; 32];
-        let hash1 = [0x22; 32];
-        store.set_canonical_tip(0, hash0).expect("seed 0");
-        store.set_canonical_tip(1, hash1).expect("seed 1");
-        assert_eq!(store.canonical_len(), 2);
-
-        let undo0 = BlockUndo {
+        let genesis = devnet_genesis_block_bytes();
+        let header = &genesis[..BLOCK_HEADER_BYTES];
+        let hash = block_hash(header).expect("hash");
+        let undo = BlockUndo {
             block_height: 0,
             previous_already_generated: 0,
             txs: vec![TxUndo { spent: vec![] }],
         };
-        let fake_header = [0u8; BLOCK_HEADER_BYTES];
 
-        // Same hash at a historical height must be rejected to avoid
-        // rewriting the historical undo file.
-        let err = store
-            .commit_canonical_block(0, hash0, &fake_header, &fake_header, &undo0)
-            .unwrap_err();
-        assert!(
-            err.contains("append-only")
-                && err.contains("height=0")
-                && err.contains("canonical_len=2"),
-            "expected strict append-only rejection, got {err:?}"
-        );
+        // First commit lands normally.
+        store
+            .commit_canonical_block(0, hash, header, &genesis, &undo)
+            .expect("first commit");
+        assert_eq!(store.canonical_len(), 1);
+        assert_eq!(store.tip().expect("tip").expect("some"), (0, hash));
+
+        // Capture undo file mtime so we can assert the replay does NOT
+        // rewrite it.
+        let undo_path = root
+            .join("undo")
+            .join(format!("{}.json", hex::encode(hash)));
+        let mtime_before = std::fs::metadata(&undo_path)
+            .expect("undo metadata")
+            .modified()
+            .expect("mtime");
+
+        // Simulate a crash-recovery replay: same hash at height 0 after
+        // blockstore already advanced to canonical_len == 1. Must succeed
+        // as a no-op.
+        store
+            .commit_canonical_block(0, hash, header, &genesis, &undo)
+            .expect("replay same-hash commit must succeed");
 
         // Canonical index unchanged.
-        assert_eq!(store.canonical_len(), 2);
-        assert_eq!(store.canonical_hash(0).expect("h0"), Some(hash0));
-        assert_eq!(store.canonical_hash(1).expect("h1"), Some(hash1));
+        assert_eq!(store.canonical_len(), 1);
+        assert_eq!(store.tip().expect("tip").expect("some"), (0, hash));
+        // Undo file NOT rewritten — mtime stable.
+        let mtime_after = std::fs::metadata(&undo_path)
+            .expect("undo metadata after replay")
+            .modified()
+            .expect("mtime after");
+        assert_eq!(
+            mtime_before, mtime_after,
+            "same-hash replay must not rewrite the historical undo file"
+        );
 
         std::fs::remove_dir_all(&dir).expect("cleanup");
     }

--- a/clients/rust/crates/rubin-node/src/blockstore.rs
+++ b/clients/rust/crates/rubin-node/src/blockstore.rs
@@ -179,18 +179,27 @@ impl BlockStore {
         if height < current_len {
             let existing = self.canonical_hash(height)?;
             if existing == Some(block_hash_bytes) {
-                // Idempotent same-hash replay: validate header, verify
-                // the undo file is actually on disk (guards against
-                // pre-E.4 state or corruption where a canonical entry
-                // lost its undo — silently accepting here would leave
-                // the node with a broken `disconnect_tip` path), then
-                // short-circuit with no disk writes.
+                // Idempotent same-hash replay. Two sub-cases:
+                //
+                //  (a) Undo file already on disk — pure no-op: don't
+                //      rewrite the historical undo (matches the
+                //      Copilot earlier-round concern that
+                //      `write_file_atomic` would clobber the historical
+                //      bytes even on a same-hash retry).
+                //
+                //  (b) Undo file missing — pre-E.4 / partial-commit
+                //      recovery case: crash between block persist and
+                //      undo write left a canonical entry with no undo.
+                //      Heal by writing the caller-supplied undo via
+                //      `put_undo`; this is the path that made
+                //      `SyncEngine::apply_block` replay able to repair
+                //      the node on restart before the atomic API
+                //      existed. Do NOT error here — the canonical
+                //      entry is already on disk, the undo is simply
+                //      being back-filled.
                 self.validate_header_matches_hash(header_bytes, block_hash_bytes)?;
                 if !self.has_undo(block_hash_bytes) {
-                    return Err(format!(
-                        "commit_canonical_block same-hash replay: undo file missing for canonical \
-                         entry at height={height}; blockstore requires repair"
-                    ));
+                    self.put_undo(block_hash_bytes, undo)?;
                 }
                 return Ok(());
             }
@@ -945,6 +954,59 @@ mod tests {
             !store.has_block(hash),
             "block/header files must not be written before the mismatch check"
         );
+
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    /// Same-hash replay heals a pre-E.4 partial-commit state: a
+    /// canonical entry present on disk but with its undo missing
+    /// (crash between block persist and undo write on the old
+    /// non-atomic path). `SyncEngine::apply_block` replays the block
+    /// on restart, and the replay must back-fill the undo so recovery
+    /// proceeds — not error out. If the undo IS on disk, the replay
+    /// stays a no-op (doesn't rewrite historical bytes).
+    #[test]
+    fn commit_canonical_block_same_hash_replay_back_fills_missing_undo() {
+        use crate::genesis::devnet_genesis_block_bytes;
+        use crate::undo::{BlockUndo, TxUndo};
+        use rubin_consensus::{block_hash, BLOCK_HEADER_BYTES};
+
+        let dir = unique_temp_path("rubin-blockstore-replay-backfill");
+        let root = block_store_path(&dir);
+        let mut store = BlockStore::open(&root).expect("open");
+
+        let genesis = devnet_genesis_block_bytes();
+        let header = &genesis[..BLOCK_HEADER_BYTES];
+        let hash = block_hash(header).expect("hash");
+
+        // Simulate pre-E.4 partial-commit state: block + canonical tip
+        // landed via the non-atomic `put_block`, but the undo file was
+        // never written (crash between the two steps in the old code).
+        store
+            .put_block(0, hash, header, &genesis)
+            .expect("put_block (seed)");
+        assert_eq!(store.canonical_len(), 1);
+        assert!(!store.has_undo(hash), "seeded state must have no undo");
+
+        let undo = BlockUndo {
+            block_height: 0,
+            previous_already_generated: 0,
+            txs: vec![TxUndo { spent: vec![] }],
+        };
+
+        // Replay the same block. Canonical entry already matches, undo
+        // is missing — API must heal by writing undo and returning Ok.
+        store
+            .commit_canonical_block(0, hash, header, &genesis, &undo)
+            .expect("same-hash replay must back-fill missing undo");
+
+        // Canonical index unchanged; undo now present and matches.
+        assert_eq!(store.canonical_len(), 1);
+        assert!(
+            store.has_undo(hash),
+            "undo file must be written during healing"
+        );
+        assert_eq!(store.get_undo(hash).expect("get_undo"), undo);
 
         std::fs::remove_dir_all(&dir).expect("cleanup");
     }

--- a/clients/rust/crates/rubin-node/src/blockstore.rs
+++ b/clients/rust/crates/rubin-node/src/blockstore.rs
@@ -145,11 +145,20 @@ impl BlockStore {
         //     canonical APPEND path; non-append canonical rewrites go
         //     through `rollback_canonical` / `truncate_canonical` /
         //     explicit reorg APIs. Without this guard a caller mistake
-        //     could pass a stale height and silently truncate live
+        //     could (a) pass a stale height and silently truncate live
         //     canonical entries inside `set_canonical_tip` (which allows
-        //     mid-chain rewrite when the hash differs). Idempotent retry
-        //     at the same `(height, hash)` stays accepted.
+        //     mid-chain rewrite when the hash differs), or (b) pass a
+        //     future-height gap and produce orphan block/header/undo
+        //     files before `set_canonical_tip` rejects the gap. Both
+        //     cases are rejected up front, before any disk write.
+        //     Idempotent retry at the same `(height, hash)` stays
+        //     accepted (same-hash path below returns Ok without mutation).
         let current_len = self.canonical_len() as u64;
+        if height > current_len {
+            return Err(format!(
+                "commit_canonical_block height gap: height={height} > canonical_len={current_len}"
+            ));
+        }
         if height < current_len {
             let existing = self.canonical_hash(height)?;
             if existing != Some(block_hash_bytes) {
@@ -930,6 +939,44 @@ mod tests {
         // is intact.
         assert_eq!(store.canonical_len(), 2);
         assert_eq!(store.canonical_hash(1).expect("h1"), Some([0x22; 32]));
+
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    /// `commit_canonical_block` rejects future-height gaps BEFORE any
+    /// disk write, so orphan block/header/undo files never accumulate
+    /// when a caller accidentally skips a height.
+    #[test]
+    fn commit_canonical_block_rejects_height_gap_without_orphan_files() {
+        use crate::genesis::devnet_genesis_block_bytes;
+        use crate::undo::{BlockUndo, TxUndo};
+        use rubin_consensus::{block_hash, BLOCK_HEADER_BYTES};
+
+        let dir = unique_temp_path("rubin-blockstore-commit-gap");
+        let root = block_store_path(&dir);
+        let mut store = BlockStore::open(&root).expect("open");
+
+        let genesis = devnet_genesis_block_bytes();
+        let header = &genesis[..BLOCK_HEADER_BYTES];
+        let hash = block_hash(header).expect("hash");
+        // canonical_len starts at 0; passing height=5 is a gap.
+        let undo = BlockUndo {
+            block_height: 5,
+            previous_already_generated: 0,
+            txs: vec![TxUndo { spent: vec![] }],
+        };
+
+        let err = store
+            .commit_canonical_block(5, hash, header, &genesis, &undo)
+            .unwrap_err();
+        assert!(
+            err.contains("height gap"),
+            "expected height-gap rejection, got {err:?}"
+        );
+
+        // No disk writes: block/header/undo files must NOT exist.
+        assert_eq!(store.canonical_len(), 0);
+        assert!(!store.has_block(hash));
 
         std::fs::remove_dir_all(&dir).expect("cleanup");
     }

--- a/clients/rust/crates/rubin-node/src/blockstore.rs
+++ b/clients/rust/crates/rubin-node/src/blockstore.rs
@@ -105,6 +105,11 @@ impl BlockStore {
     /// sequence in `sync.rs`, this API shrinks the failure surface: the
     /// tip never advances before undo durability, so no post-hoc
     /// `truncate_canonical` rewind is needed on undo-write failure.
+    /// Note: a subsequent `chain_state.save` failure AFTER a successful
+    /// `commit_canonical_block` still requires the caller to call
+    /// `truncate_canonical(canonical_len_before)` because the tip has
+    /// already advanced; that rewind is outside the atomic boundary of
+    /// this API (see `sync.rs` main commit callsite).
     ///
     /// **Orphan semantics on retry.** A failure at any step before the
     /// tip advance may leave block/header/undo files on disk without a
@@ -135,6 +140,24 @@ impl BlockStore {
                 "undo block_height mismatch: commit height={height}, undo.block_height={}",
                 undo.block_height
             ));
+        }
+        // 0a. Append-only invariant guard. `commit_canonical_block` is the
+        //     canonical APPEND path; non-append canonical rewrites go
+        //     through `rollback_canonical` / `truncate_canonical` /
+        //     explicit reorg APIs. Without this guard a caller mistake
+        //     could pass a stale height and silently truncate live
+        //     canonical entries inside `set_canonical_tip` (which allows
+        //     mid-chain rewrite when the hash differs). Idempotent retry
+        //     at the same `(height, hash)` stays accepted.
+        let current_len = self.canonical_len() as u64;
+        if height < current_len {
+            let existing = self.canonical_hash(height)?;
+            if existing != Some(block_hash_bytes) {
+                return Err(format!(
+                    "commit_canonical_block is append-only: height={height} < canonical_len={current_len} \
+                     with a different hash; use rollback/truncate for reorg commits"
+                ));
+            }
         }
         // 1. Persist block + header bytes (idempotent `write_file_if_absent`).
         self.persist_block_bytes(block_hash_bytes, header_bytes, block_bytes)?;
@@ -859,6 +882,54 @@ mod tests {
             !store.has_block(hash),
             "block/header files must not be written before the mismatch check"
         );
+
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    /// `commit_canonical_block` is append-only. A caller passing a height
+    /// below the current canonical length with a DIFFERENT hash must be
+    /// rejected before any disk write — otherwise `set_canonical_tip`
+    /// would silently truncate live canonical entries and destroy the
+    /// chain view whose undo records are still on disk. Reorg /
+    /// truncation paths must go through the dedicated
+    /// `rollback_canonical` / `truncate_canonical` APIs.
+    #[test]
+    fn commit_canonical_block_rejects_non_append_rewrite() {
+        use crate::undo::{BlockUndo, TxUndo};
+        use rubin_consensus::BLOCK_HEADER_BYTES;
+
+        let dir = unique_temp_path("rubin-blockstore-commit-non-append");
+        let root = block_store_path(&dir);
+        let mut store = BlockStore::open(&root).expect("open");
+
+        // Seed two canonical entries without going through the atomic
+        // commit (the test targets the guard, not the happy path).
+        store.set_canonical_tip(0, [0x11; 32]).expect("seed 0");
+        store.set_canonical_tip(1, [0x22; 32]).expect("seed 1");
+        assert_eq!(store.canonical_len(), 2);
+
+        // Different hash at an existing height must be rejected.
+        let different_hash = [0x33; 32];
+        let undo = BlockUndo {
+            block_height: 1,
+            previous_already_generated: 0,
+            txs: vec![TxUndo { spent: vec![] }],
+        };
+        // Header bytes / block bytes irrelevant here: the append guard
+        // fires before `persist_block_bytes` runs.
+        let fake_header = [0u8; BLOCK_HEADER_BYTES];
+        let err = store
+            .commit_canonical_block(1, different_hash, &fake_header, &fake_header, &undo)
+            .unwrap_err();
+        assert!(
+            err.contains("append-only"),
+            "expected append-only rejection, got {err:?}"
+        );
+
+        // Canonical length stays at 2 and the prior hash at height 1
+        // is intact.
+        assert_eq!(store.canonical_len(), 2);
+        assert_eq!(store.canonical_hash(1).expect("h1"), Some([0x22; 32]));
 
         std::fs::remove_dir_all(&dir).expect("cleanup");
     }

--- a/clients/rust/crates/rubin-node/src/blockstore.rs
+++ b/clients/rust/crates/rubin-node/src/blockstore.rs
@@ -150,19 +150,20 @@ impl BlockStore {
         //       accumulate in the "skipped future height" case.
         //
         //     - `height < canonical_len` with the SAME hash is an
-        //       idempotent replay (the crash-recovery path where
-        //       `commit_canonical_block` advanced the blockstore tip but
-        //       `chain_state.save` crashed; on restart
+        //       idempotent replay (crash-recovery path where
+        //       `commit_canonical_block` advanced the blockstore tip
+        //       but `chain_state.save` crashed; on restart
         //       `SyncEngine::apply_block` replays the already-persisted
-        //       block at its original height). Header bytes are still
-        //       validated so replay matches the append path's header/hash
-        //       consistency contract. If the block's undo is already
-        //       present, this is a no-op: return `Ok(())` with no
-        //       `persist_block_bytes`, no `put_undo`, and no tip
-        //       mutation. If the undo file is missing (the pre-E.4
-        //       recovery/backfill case), replay may call `put_undo` to
-        //       restore the missing undo data before returning `Ok(())`;
-        //       tip/canonical state still remain unchanged.
+        //       block at its original height). Replay ALWAYS calls
+        //       `persist_block_bytes` for symmetric self-healing of
+        //       block + header files (idempotent: `write_file_if_absent`
+        //       is a no-op when the file already exists and never
+        //       overwrites existing bytes; header hash is still
+        //       validated against `block_hash_bytes`). Undo is
+        //       conditionally back-filled via `put_undo` only when the
+        //       undo file is missing on disk (pre-E.4 partial-commit
+        //       case); an existing undo file is NOT rewritten. Tip /
+        //       canonical index remain unchanged on both sub-paths.
         //
         //     - `height < canonical_len` with a DIFFERENT hash is a real
         //       reorg on the canonical index (same parent, different
@@ -964,11 +965,17 @@ mod tests {
         );
 
         // Canonical state must be untouched — no files, no tip advance.
+        // Check block and header files explicitly (`has_block` only
+        // checks the header directory).
         assert_eq!(store.canonical_len(), 0);
         assert!(store.tip().expect("tip").is_none());
         assert!(
-            !store.has_block(hash),
-            "block/header files must not be written before the mismatch check"
+            store.get_header_by_hash(hash).is_err(),
+            "header file must not exist before the mismatch check"
+        );
+        assert!(
+            store.get_block_by_hash(hash).is_err(),
+            "block file must not exist before the mismatch check"
         );
 
         std::fs::remove_dir_all(&dir).expect("cleanup");
@@ -1058,9 +1065,17 @@ mod tests {
             "expected height-gap rejection, got {err:?}"
         );
 
-        // No disk writes: block/header/undo files must NOT exist.
+        // No disk writes: block AND header files must NOT exist (check
+        // both explicitly — `has_block` only inspects the header dir).
         assert_eq!(store.canonical_len(), 0);
-        assert!(!store.has_block(hash));
+        assert!(
+            store.get_header_by_hash(hash).is_err(),
+            "header file must not exist on height-gap rejection"
+        );
+        assert!(
+            store.get_block_by_hash(hash).is_err(),
+            "block file must not exist on height-gap rejection"
+        );
 
         std::fs::remove_dir_all(&dir).expect("cleanup");
     }
@@ -1071,11 +1086,14 @@ mod tests {
     /// by one or more blocks. On restart `SyncEngine::apply_block`
     /// replays the already-persisted block at its original height and
     /// MUST succeed so recovery can proceed; it MUST NOT rewrite the
-    /// historical block/header/undo files because `put_undo` via
-    /// `write_file_atomic` would clobber the historical undo on disk.
-    /// The same-hash replay is therefore handled as a no-op: no disk
-    /// writes, no tip mutation, `Ok(())` returned (header bytes are
-    /// still validated for consistency with the append path).
+    /// historical undo file (`put_undo` via `write_file_atomic` would
+    /// otherwise clobber the historical bytes on disk). The same-hash
+    /// replay validates the header, runs the idempotent
+    /// `persist_block_bytes` (no-op when block/header already exist,
+    /// self-heals if missing), and only calls `put_undo` when the undo
+    /// file is absent; canonical index / tip stay unchanged.
+    /// This test covers the already-present-undo sub-case: byte
+    /// equality before/after replay proves no rewrite happened.
     #[test]
     fn commit_canonical_block_same_hash_replay_is_idempotent_noop() {
         use crate::genesis::devnet_genesis_block_bytes;

--- a/clients/rust/crates/rubin-node/src/blockstore.rs
+++ b/clients/rust/crates/rubin-node/src/blockstore.rs
@@ -183,25 +183,28 @@ impl BlockStore {
         if height < current_len {
             let existing = self.canonical_hash(height)?;
             if existing == Some(block_hash_bytes) {
-                // Idempotent same-hash replay. Two sub-cases:
+                // Idempotent same-hash replay with symmetric healing.
                 //
-                //  (a) Undo file already on disk — pure no-op: don't
-                //      rewrite the historical undo (matches the
-                //      Copilot earlier-round concern that
-                //      `write_file_atomic` would clobber the historical
-                //      bytes even on a same-hash retry).
+                //  - `persist_block_bytes` runs header validation and
+                //    then writes block + header via
+                //    `write_file_if_absent` (idempotent no-op if the
+                //    file already exists, same pre-existing behavior
+                //    as the non-atomic `put_block` path). A replay
+                //    after a pre-E.4 partial-commit crash can
+                //    re-create missing block/header files without
+                //    clobbering existing ones.
                 //
-                //  (b) Undo file missing — pre-E.4 / partial-commit
-                //      recovery case: crash between block persist and
-                //      undo write left a canonical entry with no undo.
-                //      Heal by writing the caller-supplied undo via
-                //      `put_undo`; this is the path that made
-                //      `SyncEngine::apply_block` replay able to repair
-                //      the node on restart before the atomic API
-                //      existed. Do NOT error here — the canonical
-                //      entry is already on disk, the undo is simply
-                //      being back-filled.
-                self.validate_header_matches_hash(header_bytes, block_hash_bytes)?;
+                //  - Undo is then conditionally back-filled only when
+                //    absent: if the undo file is already on disk the
+                //    historical bytes are NOT rewritten (matches the
+                //    earlier Copilot concern that `write_file_atomic`
+                //    would clobber the historical undo even on a
+                //    same-hash retry); if the undo file is missing
+                //    (pre-E.4 crash between block persist and undo
+                //    write), `put_undo` back-fills it.
+                //
+                //  Canonical index / tip remain unchanged regardless.
+                self.persist_block_bytes(block_hash_bytes, header_bytes, block_bytes)?;
                 if !self.has_undo(block_hash_bytes) {
                     self.put_undo(block_hash_bytes, undo)?;
                 }

--- a/clients/rust/crates/rubin-node/src/blockstore.rs
+++ b/clients/rust/crates/rubin-node/src/blockstore.rs
@@ -124,6 +124,18 @@ impl BlockStore {
         block_bytes: &[u8],
         undo: &BlockUndo,
     ) -> Result<(), String> {
+        // 0. Reject mismatched undo up front. If `undo.block_height` does
+        //    not match the canonical height being committed, a later
+        //    `ChainState::disconnect_block` would trip its height invariant
+        //    and the tip would already have advanced — exactly the
+        //    non-atomic failure mode this API is closing. Rejecting before
+        //    any disk write keeps the canonical state untouched.
+        if undo.block_height != height {
+            return Err(format!(
+                "undo block_height mismatch: commit height={height}, undo.block_height={}",
+                undo.block_height
+            ));
+        }
         // 1. Persist block + header bytes (idempotent `write_file_if_absent`).
         self.persist_block_bytes(block_hash_bytes, header_bytes, block_bytes)?;
         // 2. Persist undo BEFORE any tip advance. Matches Go ordering in
@@ -378,12 +390,17 @@ impl BlockStore {
 
     // ----- Undo storage -----
 
-    /// Persist a single undo record. Crate-private so that all canonical
-    /// commit paths go through `commit_canonical_block`, which enforces
-    /// the `block -> header -> undo -> tip` ordering contract (see
-    /// `commit_canonical_block` docstring). A standalone `put_undo`
-    /// paired with `set_canonical_tip` in the opposite order would
-    /// reintroduce the E.4 atomicity gap this task is closing.
+    /// Persist a single undo record. Crate-private so that any in-crate
+    /// canonical-commit path that needs an undo goes through
+    /// `commit_canonical_block`, which enforces the
+    /// `block -> header -> undo -> tip` ordering contract (see that
+    /// docstring). `put_block` and `set_canonical_tip` remain `pub` for
+    /// the no-undo paths (genesis / interop bootstrap, rollback, index
+    /// truncate) where persisting an undo record is either unnecessary
+    /// or inverted; they are NOT part of the E.4 atomicity lane.
+    /// A standalone `put_undo` paired with `set_canonical_tip` in the
+    /// opposite order would reintroduce the E.4 atomicity gap this task
+    /// is closing.
     pub(crate) fn put_undo(
         &self,
         block_hash_bytes: [u8; 32],
@@ -799,6 +816,49 @@ mod tests {
         assert_eq!(store.canonical_len(), 1);
         assert_eq!(store.tip().expect("tip").expect("some"), (0, hash));
         assert_eq!(store.get_undo(hash).expect("get_undo"), undo);
+
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    /// `commit_canonical_block` must reject a mismatched undo before any
+    /// disk write, otherwise a later `disconnect_block` would trip its
+    /// height invariant while the canonical tip has already advanced —
+    /// exactly the non-atomic failure mode this API closes.
+    #[test]
+    fn commit_canonical_block_rejects_mismatched_undo_height() {
+        use crate::genesis::devnet_genesis_block_bytes;
+        use crate::undo::{BlockUndo, TxUndo};
+        use rubin_consensus::{block_hash, BLOCK_HEADER_BYTES};
+
+        let dir = unique_temp_path("rubin-blockstore-commit-undo-mismatch");
+        let root = block_store_path(&dir);
+        let mut store = BlockStore::open(&root).expect("open");
+
+        let genesis = devnet_genesis_block_bytes();
+        let header = &genesis[..BLOCK_HEADER_BYTES];
+        let hash = block_hash(header).expect("hash");
+        // Deliberately mismatched undo: commit height 0 but undo claims height 7.
+        let bad_undo = BlockUndo {
+            block_height: 7,
+            previous_already_generated: 0,
+            txs: vec![TxUndo { spent: vec![] }],
+        };
+
+        let err = store
+            .commit_canonical_block(0, hash, header, &genesis, &bad_undo)
+            .unwrap_err();
+        assert!(
+            err.contains("undo block_height mismatch"),
+            "expected mismatch error, got {err:?}"
+        );
+
+        // Canonical state must be untouched — no files, no tip advance.
+        assert_eq!(store.canonical_len(), 0);
+        assert!(store.tip().expect("tip").is_none());
+        assert!(
+            !store.has_block(hash),
+            "block/header files must not be written before the mismatch check"
+        );
 
         std::fs::remove_dir_all(&dir).expect("cleanup");
     }

--- a/clients/rust/crates/rubin-node/src/blockstore.rs
+++ b/clients/rust/crates/rubin-node/src/blockstore.rs
@@ -154,11 +154,15 @@ impl BlockStore {
         //       `commit_canonical_block` advanced the blockstore tip but
         //       `chain_state.save` crashed; on restart
         //       `SyncEngine::apply_block` replays the already-persisted
-        //       block at its original height). Handle as a pure no-op:
-        //       return `Ok(())` with no `persist_block_bytes`, no
-        //       `put_undo`, no tip mutation. Header bytes are still
+        //       block at its original height). Header bytes are still
         //       validated so replay matches the append path's header/hash
-        //       consistency contract.
+        //       consistency contract. If the block's undo is already
+        //       present, this is a no-op: return `Ok(())` with no
+        //       `persist_block_bytes`, no `put_undo`, and no tip
+        //       mutation. If the undo file is missing (the pre-E.4
+        //       recovery/backfill case), replay may call `put_undo` to
+        //       restore the missing undo data before returning `Ok(())`;
+        //       tip/canonical state still remain unchanged.
         //
         //     - `height < canonical_len` with a DIFFERENT hash is a real
         //       reorg on the canonical index (same parent, different
@@ -895,10 +899,19 @@ mod tests {
         // Tip MUST NOT have advanced past the prior height.
         assert_eq!(store.canonical_len(), canonical_len_before);
         assert!(store.tip().expect("tip").is_none());
-        // Block/header files land before the undo step fires, which is
-        // safe because `write_file_if_absent` is idempotent on retry and
-        // no canonical entry references them until the tip advances.
-        assert!(store.has_block(hash));
+        // Block AND header files landed on disk before the undo step
+        // fired, which is safe because `write_file_if_absent` is
+        // idempotent on retry and no canonical entry references them
+        // until the tip advances. Assert both explicitly rather than
+        // relying on `has_block` (which only checks the header file).
+        assert_eq!(
+            store.get_header_by_hash(hash).expect("get_header_by_hash"),
+            header
+        );
+        assert_eq!(
+            store.get_block_by_hash(hash).expect("get_block_by_hash"),
+            genesis
+        );
 
         // Retry contract: once the transient undo failure clears, calling
         // commit_canonical_block again with the same arguments must

--- a/clients/rust/crates/rubin-node/src/blockstore.rs
+++ b/clients/rust/crates/rubin-node/src/blockstore.rs
@@ -141,32 +141,29 @@ impl BlockStore {
                 undo.block_height
             ));
         }
-        // 0a. Append-only invariant guard. `commit_canonical_block` is the
-        //     canonical APPEND path; non-append canonical rewrites go
-        //     through `rollback_canonical` / `truncate_canonical` /
-        //     explicit reorg APIs. Without this guard a caller mistake
-        //     could (a) pass a stale height and silently truncate live
-        //     canonical entries inside `set_canonical_tip` (which allows
-        //     mid-chain rewrite when the hash differs), or (b) pass a
-        //     future-height gap and produce orphan block/header/undo
-        //     files before `set_canonical_tip` rejects the gap. Both
-        //     cases are rejected up front, before any disk write.
-        //     Idempotent retry at the same `(height, hash)` stays
-        //     accepted (same-hash path below returns Ok without mutation).
+        // 0a. Strict append-only invariant guard. `commit_canonical_block`
+        //     is the canonical APPEND path; non-append canonical
+        //     rewrites go through `rollback_canonical` /
+        //     `truncate_canonical` / explicit reorg APIs. A stale
+        //     `height < canonical_len` — even with a matching hash —
+        //     would cause `put_undo` to overwrite the historical
+        //     undo file at that height via `write_file_atomic`'s
+        //     tmp+rename, which is a sharp edge for future callers.
+        //     A future-height gap (`height > canonical_len`) would
+        //     leak orphan block/header/undo files before
+        //     `set_canonical_tip` rejects the gap. Both cases are
+        //     rejected up front, before any disk write. Only the
+        //     strict `height == canonical_len` append is accepted;
+        //     retry after a crashed commit is handled by the
+        //     `set_canonical_tip` reload path, which restores the
+        //     pre-commit `canonical_len` so the retry lands as a
+        //     normal append rather than a mid-chain rewrite.
         let current_len = self.canonical_len() as u64;
-        if height > current_len {
+        if height != current_len {
             return Err(format!(
-                "commit_canonical_block height gap: height={height} > canonical_len={current_len}"
+                "commit_canonical_block is append-only: height={height} != canonical_len={current_len}; \
+                 use rollback/truncate/rewind APIs for non-append commits"
             ));
-        }
-        if height < current_len {
-            let existing = self.canonical_hash(height)?;
-            if existing != Some(block_hash_bytes) {
-                return Err(format!(
-                    "commit_canonical_block is append-only: height={height} < canonical_len={current_len} \
-                     with a different hash; use rollback/truncate for reorg commits"
-                ));
-            }
         }
         // 1. Persist block + header bytes (idempotent `write_file_if_absent`).
         self.persist_block_bytes(block_hash_bytes, header_bytes, block_bytes)?;
@@ -970,13 +967,59 @@ mod tests {
             .commit_canonical_block(5, hash, header, &genesis, &undo)
             .unwrap_err();
         assert!(
-            err.contains("height gap"),
-            "expected height-gap rejection, got {err:?}"
+            err.contains("append-only") && err.contains("height=5"),
+            "expected append-only rejection on future-height gap, got {err:?}"
         );
 
         // No disk writes: block/header/undo files must NOT exist.
         assert_eq!(store.canonical_len(), 0);
         assert!(!store.has_block(hash));
+
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    /// Strict append-only: even a same-hash call at an existing
+    /// canonical height must be rejected, because the undo file
+    /// would be overwritten at a historical height (sharp edge for
+    /// future callers).
+    #[test]
+    fn commit_canonical_block_rejects_same_hash_at_historical_height() {
+        use crate::undo::{BlockUndo, TxUndo};
+        use rubin_consensus::BLOCK_HEADER_BYTES;
+
+        let dir = unique_temp_path("rubin-blockstore-commit-same-hash");
+        let root = block_store_path(&dir);
+        let mut store = BlockStore::open(&root).expect("open");
+
+        let hash0 = [0x11; 32];
+        let hash1 = [0x22; 32];
+        store.set_canonical_tip(0, hash0).expect("seed 0");
+        store.set_canonical_tip(1, hash1).expect("seed 1");
+        assert_eq!(store.canonical_len(), 2);
+
+        let undo0 = BlockUndo {
+            block_height: 0,
+            previous_already_generated: 0,
+            txs: vec![TxUndo { spent: vec![] }],
+        };
+        let fake_header = [0u8; BLOCK_HEADER_BYTES];
+
+        // Same hash at a historical height must be rejected to avoid
+        // rewriting the historical undo file.
+        let err = store
+            .commit_canonical_block(0, hash0, &fake_header, &fake_header, &undo0)
+            .unwrap_err();
+        assert!(
+            err.contains("append-only")
+                && err.contains("height=0")
+                && err.contains("canonical_len=2"),
+            "expected strict append-only rejection, got {err:?}"
+        );
+
+        // Canonical index unchanged.
+        assert_eq!(store.canonical_len(), 2);
+        assert_eq!(store.canonical_hash(0).expect("h0"), Some(hash0));
+        assert_eq!(store.canonical_hash(1).expect("h1"), Some(hash1));
 
         std::fs::remove_dir_all(&dir).expect("cleanup");
     }

--- a/clients/rust/crates/rubin-node/src/blockstore.rs
+++ b/clients/rust/crates/rubin-node/src/blockstore.rs
@@ -224,10 +224,11 @@ impl BlockStore {
     }
 
     /// Cheap header consistency check — length + computed hash equals
-    /// the caller-supplied hash. Shared by `persist_block_bytes` (as the
-    /// precondition for any disk write) and by the same-hash no-op branch
-    /// of `commit_canonical_block` (so replay/no-op behavior matches the
-    /// append path's validation contract even when no write happens).
+    /// the caller-supplied hash. Called from `persist_block_bytes` as
+    /// the precondition for any block/header write; every canonical
+    /// entry point (`put_block`, `commit_canonical_block`,
+    /// `store_block`) reaches this check through that helper, so
+    /// header validation cannot drift between paths.
     fn validate_header_matches_hash(
         &self,
         header_bytes: &[u8],
@@ -243,10 +244,11 @@ impl BlockStore {
         Ok(())
     }
 
-    /// Block/header persistence shared by `put_block` and
-    /// `commit_canonical_block`. Validates header length + hash, then
-    /// writes block and header files via `write_file_if_absent`
-    /// (idempotent across retries).
+    /// Block/header persistence shared by `put_block`,
+    /// `commit_canonical_block`, and `store_block`. Validates header
+    /// length + hash, then writes block and header files via
+    /// `write_file_if_absent` (idempotent across retries — no-op when
+    /// the file already exists; errors if existing bytes differ).
     fn persist_block_bytes(
         &self,
         block_hash_bytes: [u8; 32],
@@ -439,22 +441,11 @@ impl BlockStore {
         header_bytes: &[u8],
         block_bytes: &[u8],
     ) -> Result<(), String> {
-        if header_bytes.len() != BLOCK_HEADER_BYTES {
-            return Err(format!("invalid header length: {}", header_bytes.len()));
-        }
-        let computed_hash = block_hash(header_bytes).map_err(|e| e.to_string())?;
-        if computed_hash != block_hash_bytes {
-            return Err("header hash mismatch".to_string());
-        }
-        let hash_hex = hex::encode(block_hash_bytes);
-        write_file_if_absent(
-            &self.blocks_dir.join(format!("{hash_hex}.bin")),
-            block_bytes,
-        )?;
-        write_file_if_absent(
-            &self.headers_dir.join(format!("{hash_hex}.bin")),
-            header_bytes,
-        )
+        // Delegate to the shared helper so header validation and
+        // block/header file writes stay in one place across all
+        // entry points (`put_block`, `commit_canonical_block`,
+        // `store_block`).
+        self.persist_block_bytes(block_hash_bytes, header_bytes, block_bytes)
     }
 
     // ----- Chain work -----

--- a/clients/rust/crates/rubin-node/src/blockstore.rs
+++ b/clients/rust/crates/rubin-node/src/blockstore.rs
@@ -27,6 +27,10 @@ pub struct BlockStore {
     /// Test-only: force `rollback_canonical` to return an error.
     #[cfg(test)]
     pub(crate) force_rollback_error: bool,
+    /// Test-only: force `put_undo` to return an error. Used to exercise
+    /// the crash-style atomicity contract of `commit_canonical_block`.
+    #[cfg(test)]
+    pub(crate) force_undo_error: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -66,6 +70,8 @@ impl BlockStore {
             force_truncate_error: false,
             #[cfg(test)]
             force_rollback_error: false,
+            #[cfg(test)]
+            force_undo_error: false,
         })
     }
 
@@ -80,6 +86,51 @@ impl BlockStore {
         header_bytes: &[u8],
         block_bytes: &[u8],
     ) -> Result<(), String> {
+        self.persist_block_bytes(block_hash_bytes, header_bytes, block_bytes)?;
+        self.set_canonical_tip(height, block_hash_bytes)
+    }
+
+    /// Atomic canonical block commit — Go parity
+    /// (`clients/go/node/blockstore.go`, `CommitCanonicalBlock`).
+    ///
+    /// Persists block bytes, header bytes, and the undo record BEFORE
+    /// advancing the canonical tip. The tip update is the explicit
+    /// commit point: if any earlier step (block/header/undo write) fails,
+    /// the canonical tip remains at its prior height, so a crash leaves
+    /// the chain with no orphaned canonical block missing its undo —
+    /// which would otherwise break `disconnect_tip` on the next reorg.
+    ///
+    /// Compared to the previous `put_block` + separate `put_undo`
+    /// sequence in `sync.rs`, this API shrinks the failure surface: the
+    /// tip never advances before undo durability, so no post-hoc
+    /// `truncate_canonical` rewind is needed on undo-write failure.
+    pub fn commit_canonical_block(
+        &mut self,
+        height: u64,
+        block_hash_bytes: [u8; 32],
+        header_bytes: &[u8],
+        block_bytes: &[u8],
+        undo: &BlockUndo,
+    ) -> Result<(), String> {
+        // 1. Persist block + header bytes (idempotent `write_file_if_absent`).
+        self.persist_block_bytes(block_hash_bytes, header_bytes, block_bytes)?;
+        // 2. Persist undo BEFORE any tip advance. Matches Go ordering in
+        //    `CommitCanonicalBlock` (StoreBlock → PutUndo → SetCanonicalTip).
+        self.put_undo(block_hash_bytes, undo)?;
+        // 3. Advance canonical tip LAST — this is the atomic commit point.
+        self.set_canonical_tip(height, block_hash_bytes)
+    }
+
+    /// Block/header persistence shared by `put_block` and
+    /// `commit_canonical_block`. Validates header length + hash, then
+    /// writes block and header files via `write_file_if_absent`
+    /// (idempotent across retries).
+    fn persist_block_bytes(
+        &self,
+        block_hash_bytes: [u8; 32],
+        header_bytes: &[u8],
+        block_bytes: &[u8],
+    ) -> Result<(), String> {
         if header_bytes.len() != BLOCK_HEADER_BYTES {
             return Err(format!("invalid header length: {}", header_bytes.len()));
         }
@@ -87,7 +138,6 @@ impl BlockStore {
         if computed_hash != block_hash_bytes {
             return Err("header hash mismatch".to_string());
         }
-
         let hash_hex = hex::encode(block_hash_bytes);
         write_file_if_absent(
             &self.blocks_dir.join(format!("{hash_hex}.bin")),
@@ -96,8 +146,7 @@ impl BlockStore {
         write_file_if_absent(
             &self.headers_dir.join(format!("{hash_hex}.bin")),
             header_bytes,
-        )?;
-        self.set_canonical_tip(height, block_hash_bytes)
+        )
     }
 
     /// Set or replace the canonical tip at `height`.
@@ -318,6 +367,10 @@ impl BlockStore {
     // ----- Undo storage -----
 
     pub fn put_undo(&self, block_hash_bytes: [u8; 32], undo: &BlockUndo) -> Result<(), String> {
+        #[cfg(test)]
+        if self.force_undo_error {
+            return Err("forced undo error (test)".to_string());
+        }
         let raw = marshal_block_undo(undo)?;
         let path = self
             .undo_dir
@@ -630,6 +683,88 @@ mod tests {
 
         let err = store.truncate_canonical(5).unwrap_err();
         assert!(err.contains("truncate_canonical"));
+
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    /// Go parity / crash-safety for Q-IMPL-RUST-STORAGE-ATOMIC-CANONICAL-COMMIT-01:
+    /// `commit_canonical_block` persists block/header/undo BEFORE
+    /// advancing the canonical tip. The happy-path roundtrip confirms
+    /// all three pieces land and the tip moves to the new height.
+    #[test]
+    fn commit_canonical_block_happy_path_advances_tip_and_persists_undo() {
+        use crate::genesis::devnet_genesis_block_bytes;
+        use crate::undo::{BlockUndo, TxUndo};
+        use rubin_consensus::{block_hash, BLOCK_HEADER_BYTES};
+
+        let dir = unique_temp_path("rubin-blockstore-commit-happy");
+        let root = block_store_path(&dir);
+        let mut store = BlockStore::open(&root).expect("open");
+
+        let genesis = devnet_genesis_block_bytes();
+        let header = &genesis[..BLOCK_HEADER_BYTES];
+        let hash = block_hash(header).expect("hash");
+        let undo = BlockUndo {
+            block_height: 0,
+            previous_already_generated: 0,
+            txs: vec![TxUndo { spent: vec![] }],
+        };
+
+        store
+            .commit_canonical_block(0, hash, header, &genesis, &undo)
+            .expect("commit_canonical_block");
+
+        assert_eq!(store.canonical_len(), 1);
+        let tip = store.tip().expect("tip").expect("some");
+        assert_eq!(tip, (0, hash));
+        assert_eq!(store.get_undo(hash).expect("get_undo"), undo);
+        assert_eq!(store.get_block_by_hash(hash).expect("block"), genesis);
+
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    /// Crash-style atomicity evidence for E.4: if undo persistence fails
+    /// (simulated here via `force_undo_error`), the canonical tip MUST
+    /// remain at its prior height. Before this change the tip was
+    /// advanced by `put_block` before the undo write, so a crash at the
+    /// same point would leave a canonical block with no recoverable undo.
+    #[test]
+    fn commit_canonical_block_leaves_tip_unchanged_when_undo_fails() {
+        use crate::genesis::devnet_genesis_block_bytes;
+        use crate::undo::{BlockUndo, TxUndo};
+        use rubin_consensus::{block_hash, BLOCK_HEADER_BYTES};
+
+        let dir = unique_temp_path("rubin-blockstore-commit-undo-fail");
+        let root = block_store_path(&dir);
+        let mut store = BlockStore::open(&root).expect("open");
+
+        let genesis = devnet_genesis_block_bytes();
+        let header = &genesis[..BLOCK_HEADER_BYTES];
+        let hash = block_hash(header).expect("hash");
+        let undo = BlockUndo {
+            block_height: 0,
+            previous_already_generated: 0,
+            txs: vec![TxUndo { spent: vec![] }],
+        };
+
+        let canonical_len_before = store.canonical_len();
+        store.force_undo_error = true;
+
+        let err = store
+            .commit_canonical_block(0, hash, header, &genesis, &undo)
+            .unwrap_err();
+        assert!(
+            err.contains("forced undo error"),
+            "expected forced undo error, got {err:?}"
+        );
+
+        // Tip MUST NOT have advanced past the prior height.
+        assert_eq!(store.canonical_len(), canonical_len_before);
+        assert!(store.tip().expect("tip").is_none());
+        // Block/header files land before the undo step fires, which is
+        // safe because `write_file_if_absent` is idempotent on retry and
+        // no canonical entry references them until the tip advances.
+        assert!(store.has_block(hash));
 
         std::fs::remove_dir_all(&dir).expect("cleanup");
     }

--- a/clients/rust/crates/rubin-node/src/blockstore.rs
+++ b/clients/rust/crates/rubin-node/src/blockstore.rs
@@ -91,7 +91,8 @@ impl BlockStore {
     }
 
     /// Atomic canonical block commit — Go parity
-    /// (`clients/go/node/blockstore.go`, `CommitCanonicalBlock`).
+    /// (`clients/go/node/blockstore.go:100-114`, `CommitCanonicalBlock`:
+    /// `StoreBlock` -> `PutUndo` -> `SetCanonicalTip`).
     ///
     /// Persists block bytes, header bytes, and the undo record BEFORE
     /// advancing the canonical tip. The tip update is the explicit
@@ -104,6 +105,17 @@ impl BlockStore {
     /// sequence in `sync.rs`, this API shrinks the failure surface: the
     /// tip never advances before undo durability, so no post-hoc
     /// `truncate_canonical` rewind is needed on undo-write failure.
+    ///
+    /// **Orphan semantics on retry.** A failure at any step before the
+    /// tip advance may leave block/header/undo files on disk without a
+    /// canonical reference. These are safe and self-healing: block and
+    /// header files are written via `write_file_if_absent` (idempotent
+    /// no-op if the exact contents already exist on retry), and the
+    /// undo file is written via `write_file_atomic`, whose tmp+rename
+    /// idempotently overwrites at the same path on a subsequent retry
+    /// with the same block hash. No canonical entry references these
+    /// files until the tip advances, so they neither contaminate the
+    /// chain nor leak unboundedly across same-hash retries.
     pub fn commit_canonical_block(
         &mut self,
         height: u64,
@@ -366,7 +378,17 @@ impl BlockStore {
 
     // ----- Undo storage -----
 
-    pub fn put_undo(&self, block_hash_bytes: [u8; 32], undo: &BlockUndo) -> Result<(), String> {
+    /// Persist a single undo record. Crate-private so that all canonical
+    /// commit paths go through `commit_canonical_block`, which enforces
+    /// the `block -> header -> undo -> tip` ordering contract (see
+    /// `commit_canonical_block` docstring). A standalone `put_undo`
+    /// paired with `set_canonical_tip` in the opposite order would
+    /// reintroduce the E.4 atomicity gap this task is closing.
+    pub(crate) fn put_undo(
+        &self,
+        block_hash_bytes: [u8; 32],
+        undo: &BlockUndo,
+    ) -> Result<(), String> {
         #[cfg(test)]
         if self.force_undo_error {
             return Err("forced undo error (test)".to_string());
@@ -765,6 +787,18 @@ mod tests {
         // safe because `write_file_if_absent` is idempotent on retry and
         // no canonical entry references them until the tip advances.
         assert!(store.has_block(hash));
+
+        // Retry contract: once the transient undo failure clears, calling
+        // commit_canonical_block again with the same arguments must
+        // succeed (no "already exists" error from block/header writes,
+        // no stale-state corruption) and the tip must finally advance.
+        store.force_undo_error = false;
+        store
+            .commit_canonical_block(0, hash, header, &genesis, &undo)
+            .expect("retry commit_canonical_block");
+        assert_eq!(store.canonical_len(), 1);
+        assert_eq!(store.tip().expect("tip").expect("some"), (0, hash));
+        assert_eq!(store.get_undo(hash).expect("get_undo"), undo);
 
         std::fs::remove_dir_all(&dir).expect("cleanup");
     }

--- a/clients/rust/crates/rubin-node/src/blockstore.rs
+++ b/clients/rust/crates/rubin-node/src/blockstore.rs
@@ -141,29 +141,35 @@ impl BlockStore {
                 undo.block_height
             ));
         }
-        // 0a. Append-only invariant guard with an idempotent same-hash
-        //     replay carve-out for crash recovery.
+        // 0a. Height-range + idempotent same-hash no-op guards. Semantics
+        //     mirror Go's `CommitCanonicalBlock` -> `SetCanonicalTip`
+        //     (`clients/go/node/blockstore.go:126-153`):
         //
-        //     `commit_canonical_block` is the canonical APPEND path; real
-        //     non-append rewrites go through `rollback_canonical` /
-        //     `truncate_canonical` / explicit reorg APIs. A future-height
-        //     gap (`height > canonical_len`) would leak orphan
-        //     block/header/undo files before `set_canonical_tip` rejects
-        //     the gap and is rejected up front.
+        //     - `height > canonical_len` is an illegal gap; reject BEFORE
+        //       any disk write so orphan block/header/undo files never
+        //       accumulate in the "skipped future height" case.
         //
-        //     `height < canonical_len` is the crash-recovery case:
-        //     `commit_canonical_block` persisted block/undo and advanced
-        //     the tip, then `chain_state.save` crashed, so on restart the
-        //     chain state lags the blockstore by one or more blocks and
-        //     `SyncEngine::apply_block` replays the already-persisted
-        //     block at its original height. That replay MUST succeed to
-        //     unblock recovery, but MUST NOT rewrite the historical
-        //     block/header/undo files — `put_undo` via `write_file_atomic`
-        //     would otherwise clobber the historical undo on disk. The
-        //     same-hash path therefore returns `Ok(())` as a pure no-op:
-        //     no `persist_block_bytes`, no `put_undo`, no tip mutation.
-        //     Different-hash replay at a historical height is still a
-        //     real reorg and goes through the rollback/truncate APIs.
+        //     - `height < canonical_len` with the SAME hash is an
+        //       idempotent replay (the crash-recovery path where
+        //       `commit_canonical_block` advanced the blockstore tip but
+        //       `chain_state.save` crashed; on restart
+        //       `SyncEngine::apply_block` replays the already-persisted
+        //       block at its original height). Handle as a pure no-op:
+        //       return `Ok(())` with no `persist_block_bytes`, no
+        //       `put_undo`, no tip mutation. Header bytes are still
+        //       validated so replay matches the append path's header/hash
+        //       consistency contract.
+        //
+        //     - `height < canonical_len` with a DIFFERENT hash is a real
+        //       reorg on the canonical index (same parent, different
+        //       block at this height). Fall through to the normal
+        //       persist -> `set_canonical_tip` path, which truncates
+        //       `canonical[height..]` and pushes the new hash — matching
+        //       Go. The prior block's files stay on disk as orphans (no
+        //       canonical reference); this is the standard blockstore
+        //       behavior for non-canonical blocks.
+        //
+        //     - `height == canonical_len` is the normal append.
         let current_len = self.canonical_len() as u64;
         if height > current_len {
             return Err(format!(
@@ -173,13 +179,13 @@ impl BlockStore {
         if height < current_len {
             let existing = self.canonical_hash(height)?;
             if existing == Some(block_hash_bytes) {
-                // Idempotent same-hash replay: skip all disk writes.
+                // Idempotent same-hash replay: validate header, then
+                // short-circuit with no disk writes.
+                self.validate_header_matches_hash(header_bytes, block_hash_bytes)?;
                 return Ok(());
             }
-            return Err(format!(
-                "commit_canonical_block is append-only: height={height} < canonical_len={current_len} \
-                 with a different hash; use rollback/truncate for reorg commits"
-            ));
+            // Different hash at historical height: real reorg; fall
+            // through to persist + tip replace.
         }
         // 1. Persist block + header bytes (idempotent `write_file_if_absent`).
         self.persist_block_bytes(block_hash_bytes, header_bytes, block_bytes)?;
@@ -188,6 +194,26 @@ impl BlockStore {
         self.put_undo(block_hash_bytes, undo)?;
         // 3. Advance canonical tip LAST — this is the atomic commit point.
         self.set_canonical_tip(height, block_hash_bytes)
+    }
+
+    /// Cheap header consistency check — length + computed hash equals
+    /// the caller-supplied hash. Shared by `persist_block_bytes` (as the
+    /// precondition for any disk write) and by the same-hash no-op branch
+    /// of `commit_canonical_block` (so replay/no-op behavior matches the
+    /// append path's validation contract even when no write happens).
+    fn validate_header_matches_hash(
+        &self,
+        header_bytes: &[u8],
+        block_hash_bytes: [u8; 32],
+    ) -> Result<(), String> {
+        if header_bytes.len() != BLOCK_HEADER_BYTES {
+            return Err(format!("invalid header length: {}", header_bytes.len()));
+        }
+        let computed_hash = block_hash(header_bytes).map_err(|e| e.to_string())?;
+        if computed_hash != block_hash_bytes {
+            return Err("header hash mismatch".to_string());
+        }
+        Ok(())
     }
 
     /// Block/header persistence shared by `put_block` and
@@ -200,13 +226,7 @@ impl BlockStore {
         header_bytes: &[u8],
         block_bytes: &[u8],
     ) -> Result<(), String> {
-        if header_bytes.len() != BLOCK_HEADER_BYTES {
-            return Err(format!("invalid header length: {}", header_bytes.len()));
-        }
-        let computed_hash = block_hash(header_bytes).map_err(|e| e.to_string())?;
-        if computed_hash != block_hash_bytes {
-            return Err("header hash mismatch".to_string());
-        }
+        self.validate_header_matches_hash(header_bytes, block_hash_bytes)?;
         let hash_hex = hex::encode(block_hash_bytes);
         write_file_if_absent(
             &self.blocks_dir.join(format!("{hash_hex}.bin")),
@@ -908,54 +928,6 @@ mod tests {
         std::fs::remove_dir_all(&dir).expect("cleanup");
     }
 
-    /// `commit_canonical_block` is append-only. A caller passing a height
-    /// below the current canonical length with a DIFFERENT hash must be
-    /// rejected before any disk write — otherwise `set_canonical_tip`
-    /// would silently truncate live canonical entries and destroy the
-    /// chain view whose undo records are still on disk. Reorg /
-    /// truncation paths must go through the dedicated
-    /// `rollback_canonical` / `truncate_canonical` APIs.
-    #[test]
-    fn commit_canonical_block_rejects_non_append_rewrite() {
-        use crate::undo::{BlockUndo, TxUndo};
-        use rubin_consensus::BLOCK_HEADER_BYTES;
-
-        let dir = unique_temp_path("rubin-blockstore-commit-non-append");
-        let root = block_store_path(&dir);
-        let mut store = BlockStore::open(&root).expect("open");
-
-        // Seed two canonical entries without going through the atomic
-        // commit (the test targets the guard, not the happy path).
-        store.set_canonical_tip(0, [0x11; 32]).expect("seed 0");
-        store.set_canonical_tip(1, [0x22; 32]).expect("seed 1");
-        assert_eq!(store.canonical_len(), 2);
-
-        // Different hash at an existing height must be rejected.
-        let different_hash = [0x33; 32];
-        let undo = BlockUndo {
-            block_height: 1,
-            previous_already_generated: 0,
-            txs: vec![TxUndo { spent: vec![] }],
-        };
-        // Header bytes / block bytes irrelevant here: the append guard
-        // fires before `persist_block_bytes` runs.
-        let fake_header = [0u8; BLOCK_HEADER_BYTES];
-        let err = store
-            .commit_canonical_block(1, different_hash, &fake_header, &fake_header, &undo)
-            .unwrap_err();
-        assert!(
-            err.contains("append-only"),
-            "expected append-only rejection, got {err:?}"
-        );
-
-        // Canonical length stays at 2 and the prior hash at height 1
-        // is intact.
-        assert_eq!(store.canonical_len(), 2);
-        assert_eq!(store.canonical_hash(1).expect("h1"), Some([0x22; 32]));
-
-        std::fs::remove_dir_all(&dir).expect("cleanup");
-    }
-
     /// `commit_canonical_block` rejects future-height gaps BEFORE any
     /// disk write, so orphan block/header/undo files never accumulate
     /// when a caller accidentally skips a height.
@@ -994,10 +966,6 @@ mod tests {
         std::fs::remove_dir_all(&dir).expect("cleanup");
     }
 
-    /// Strict append-only: even a same-hash call at an existing
-    /// canonical height must be rejected, because the undo file
-    /// would be overwritten at a historical height (sharp edge for
-    /// future callers).
     /// Crash-recovery path (GPT-5 review P1): after a successful
     /// `commit_canonical_block` that advanced the blockstore tip, if
     /// `chain_state.save` crashes the chain state lags the blockstore
@@ -1007,7 +975,8 @@ mod tests {
     /// historical block/header/undo files because `put_undo` via
     /// `write_file_atomic` would clobber the historical undo on disk.
     /// The same-hash replay is therefore handled as a no-op: no disk
-    /// writes, no tip mutation, `Ok(())` returned.
+    /// writes, no tip mutation, `Ok(())` returned (header bytes are
+    /// still validated for consistency with the append path).
     #[test]
     fn commit_canonical_block_same_hash_replay_is_idempotent_noop() {
         use crate::genesis::devnet_genesis_block_bytes;

--- a/clients/rust/crates/rubin-node/src/blockstore.rs
+++ b/clients/rust/crates/rubin-node/src/blockstore.rs
@@ -179,9 +179,19 @@ impl BlockStore {
         if height < current_len {
             let existing = self.canonical_hash(height)?;
             if existing == Some(block_hash_bytes) {
-                // Idempotent same-hash replay: validate header, then
+                // Idempotent same-hash replay: validate header, verify
+                // the undo file is actually on disk (guards against
+                // pre-E.4 state or corruption where a canonical entry
+                // lost its undo — silently accepting here would leave
+                // the node with a broken `disconnect_tip` path), then
                 // short-circuit with no disk writes.
                 self.validate_header_matches_hash(header_bytes, block_hash_bytes)?;
+                if !self.has_undo(block_hash_bytes) {
+                    return Err(format!(
+                        "commit_canonical_block same-hash replay: undo file missing for canonical \
+                         entry at height={height}; blockstore requires repair"
+                    ));
+                }
                 return Ok(());
             }
             // Different hash at historical height: real reorg; fall
@@ -488,6 +498,17 @@ impl BlockStore {
             .join(format!("{}.json", hex::encode(block_hash_bytes)));
         let raw = fs::read(&path).map_err(|e| format!("read undo {}: {e}", path.display()))?;
         unmarshal_block_undo(&raw)
+    }
+
+    /// Cheap undo-presence check used by the same-hash replay branch of
+    /// `commit_canonical_block` to verify that a canonical entry
+    /// inherited from pre-E.4 disk state (or corrupted in some other
+    /// way) actually has its undo file on disk before accepting the
+    /// replay as a no-op.
+    fn has_undo(&self, block_hash_bytes: [u8; 32]) -> bool {
+        self.undo_dir
+            .join(format!("{}.json", hex::encode(block_hash_bytes)))
+            .is_file()
     }
 
     // ----- Canonical index helpers -----
@@ -1003,15 +1024,14 @@ mod tests {
         assert_eq!(store.canonical_len(), 1);
         assert_eq!(store.tip().expect("tip").expect("some"), (0, hash));
 
-        // Capture undo file mtime so we can assert the replay does NOT
-        // rewrite it.
+        // Capture undo file bytes so we can assert the replay does NOT
+        // rewrite them. Content comparison is more robust than mtime:
+        // filesystem timestamp resolution and update semantics vary by
+        // platform and may not change on a same-bytes rewrite.
         let undo_path = root
             .join("undo")
             .join(format!("{}.json", hex::encode(hash)));
-        let mtime_before = std::fs::metadata(&undo_path)
-            .expect("undo metadata")
-            .modified()
-            .expect("mtime");
+        let undo_bytes_before = std::fs::read(&undo_path).expect("undo bytes before");
 
         // Simulate a crash-recovery replay: same hash at height 0 after
         // blockstore already advanced to canonical_len == 1. Must succeed
@@ -1023,13 +1043,10 @@ mod tests {
         // Canonical index unchanged.
         assert_eq!(store.canonical_len(), 1);
         assert_eq!(store.tip().expect("tip").expect("some"), (0, hash));
-        // Undo file NOT rewritten — mtime stable.
-        let mtime_after = std::fs::metadata(&undo_path)
-            .expect("undo metadata after replay")
-            .modified()
-            .expect("mtime after");
+        // Undo file bytes unchanged — no rewrite happened.
+        let undo_bytes_after = std::fs::read(&undo_path).expect("undo bytes after");
         assert_eq!(
-            mtime_before, mtime_after,
+            undo_bytes_before, undo_bytes_after,
             "same-hash replay must not rewrite the historical undo file"
         );
 

--- a/clients/rust/crates/rubin-node/src/sync.rs
+++ b/clients/rust/crates/rubin-node/src/sync.rs
@@ -609,6 +609,14 @@ impl SyncEngine {
         }
 
         let commit_start = Instant::now();
+        // `canonical_len_before` is the rewind target for the ONLY remaining
+        // post-commit failure point: `chain_state.save` below. If
+        // `commit_canonical_block` itself returns `Err`, the tip has not
+        // advanced (the tip write is the last step inside the atomic API;
+        // an earlier failure leaves the prior tip in place, and a save
+        // failure inside `set_canonical_tip` triggers
+        // `reload_index_from_disk` which restores the on-disk length), so
+        // no rewind is needed on that path.
         let canonical_len_before = self.block_store.as_ref().map_or(0, |bs| bs.canonical_len());
         if let Some(block_store) = self.block_store.as_mut() {
             // Atomic canonical commit — Go parity

--- a/clients/rust/crates/rubin-node/src/sync.rs
+++ b/clients/rust/crates/rubin-node/src/sync.rs
@@ -611,36 +611,30 @@ impl SyncEngine {
         let commit_start = Instant::now();
         let canonical_len_before = self.block_store.as_ref().map_or(0, |bs| bs.canonical_len());
         if let Some(block_store) = self.block_store.as_mut() {
-            if let Err(err) = block_store.put_block(
+            // Atomic canonical commit — Go parity
+            // (`clients/go/node/blockstore.go`, `CommitCanonicalBlock`).
+            // Order inside the call: block bytes -> header bytes -> undo
+            // -> canonical tip (last). A failure before the tip advance
+            // leaves the canonical tip at its prior height, so no rewind
+            // is required on block/header/undo write failure.
+            if let Err(err) = block_store.commit_canonical_block(
                 summary.block_height,
                 block_hash_bytes,
                 &parsed.header_bytes,
                 block_bytes,
+                &undo,
             ) {
                 self.chain_state = snapshot;
                 self.tip_timestamp = old_tip_timestamp;
                 self.best_known_height = old_best_known_height;
                 return Err(err);
             }
-            // Persist the undo record alongside the block.
-            if let Err(err) = block_store.put_undo(block_hash_bytes, &undo) {
-                // Rewind canonical to the length captured before put_block.
-                let rewind_err = block_store.truncate_canonical(canonical_len_before).err();
-                self.chain_state = snapshot;
-                self.tip_timestamp = old_tip_timestamp;
-                self.best_known_height = old_best_known_height;
-                if let Some(rewind_err) = rewind_err {
-                    return Err(format!(
-                        "{err}; failed to rewind canonical index after undo write failure: {rewind_err}; blockstore may require repair"
-                    ));
-                }
-                return Err(err);
-            }
         }
 
         if let Some(chain_state_path) = self.cfg.chain_state_path.as_ref() {
             if let Err(err) = self.chain_state.save(chain_state_path) {
-                // Rewind canonical index to the length captured before put_block.
+                // Canonical commit already advanced the tip; unwind it so
+                // in-memory state and on-disk canonical index stay paired.
                 if let Some(bs) = self.block_store.as_mut() {
                     let _ = bs.truncate_canonical(canonical_len_before);
                 }

--- a/clients/rust/crates/rubin-node/src/sync.rs
+++ b/clients/rust/crates/rubin-node/src/sync.rs
@@ -645,10 +645,11 @@ impl SyncEngine {
         if let Some(chain_state_path) = self.cfg.chain_state_path.as_ref() {
             if let Err(err) = self.chain_state.save(chain_state_path) {
                 // Canonical commit MAY have advanced the tip. The
-                // same-hash replay path returns Ok(()) as a pure no-op
-                // and leaves the tip unchanged, so only rewind when the
-                // canonical length actually grew past the pre-commit
-                // snapshot.
+                // same-hash replay path returns Ok(()) without advancing
+                // the canonical index/tip (canonical_len unchanged),
+                // though it may still back-fill missing undo data on
+                // disk, so only rewind when the canonical length
+                // actually grew past the pre-commit snapshot.
                 let rewind_err = self.block_store.as_mut().and_then(|bs| {
                     if bs.canonical_len() > canonical_len_before {
                         bs.truncate_canonical(canonical_len_before).err()

--- a/clients/rust/crates/rubin-node/src/sync.rs
+++ b/clients/rust/crates/rubin-node/src/sync.rs
@@ -635,12 +635,18 @@ impl SyncEngine {
             if let Err(err) = self.chain_state.save(chain_state_path) {
                 // Canonical commit already advanced the tip; unwind it so
                 // in-memory state and on-disk canonical index stay paired.
-                if let Some(bs) = self.block_store.as_mut() {
-                    let _ = bs.truncate_canonical(canonical_len_before);
-                }
+                let rewind_err = self
+                    .block_store
+                    .as_mut()
+                    .and_then(|bs| bs.truncate_canonical(canonical_len_before).err());
                 self.chain_state = snapshot;
                 self.tip_timestamp = old_tip_timestamp;
                 self.best_known_height = old_best_known_height;
+                if let Some(rewind_err) = rewind_err {
+                    return Err(format!(
+                        "{err}; failed to rewind canonical index after chain_state save failure: {rewind_err}; blockstore may require repair"
+                    ));
+                }
                 return Err(err);
             }
         }

--- a/clients/rust/crates/rubin-node/src/sync.rs
+++ b/clients/rust/crates/rubin-node/src/sync.rs
@@ -611,14 +611,15 @@ impl SyncEngine {
         let commit_start = Instant::now();
         // `canonical_len_before` is the rewind target for the ONLY remaining
         // post-commit failure point: `chain_state.save` below. If
-        // `commit_canonical_block` itself returns `Err`, the tip has not
-        // advanced (the tip write is the last step inside the atomic API;
-        // an earlier failure leaves the prior tip in place, and a save
-        // failure inside `set_canonical_tip` best-effort reloads the
-        // on-disk length — a double failure there would leave the
-        // in-memory length ahead of disk and the blockstore would require
-        // repair), so no rewind is needed on that path in the happy
-        // save-failure case.
+        // `commit_canonical_block` itself returns `Err`, the persisted
+        // canonical tip has not advanced: the tip write is the last step
+        // inside the atomic API, so an earlier failure leaves the prior
+        // on-disk tip in place. Note that a save failure inside
+        // `set_canonical_tip` mutates in-memory state before a best-effort
+        // reload of the on-disk length; if that reload also fails, the
+        // in-memory length may still be ahead of disk and the blockstore
+        // would require repair. No rewind is needed here for the normal
+        // `commit_canonical_block` error path.
         let canonical_len_before = self.block_store.as_ref().map_or(0, |bs| bs.canonical_len());
         if let Some(block_store) = self.block_store.as_mut() {
             // Atomic canonical commit — Go parity

--- a/clients/rust/crates/rubin-node/src/sync.rs
+++ b/clients/rust/crates/rubin-node/src/sync.rs
@@ -644,12 +644,18 @@ impl SyncEngine {
 
         if let Some(chain_state_path) = self.cfg.chain_state_path.as_ref() {
             if let Err(err) = self.chain_state.save(chain_state_path) {
-                // Canonical commit already advanced the tip; unwind it so
-                // in-memory state and on-disk canonical index stay paired.
-                let rewind_err = self
-                    .block_store
-                    .as_mut()
-                    .and_then(|bs| bs.truncate_canonical(canonical_len_before).err());
+                // Canonical commit MAY have advanced the tip. The
+                // same-hash replay path returns Ok(()) as a pure no-op
+                // and leaves the tip unchanged, so only rewind when the
+                // canonical length actually grew past the pre-commit
+                // snapshot.
+                let rewind_err = self.block_store.as_mut().and_then(|bs| {
+                    if bs.canonical_len() > canonical_len_before {
+                        bs.truncate_canonical(canonical_len_before).err()
+                    } else {
+                        None
+                    }
+                });
                 self.chain_state = snapshot;
                 self.tip_timestamp = old_tip_timestamp;
                 self.best_known_height = old_best_known_height;

--- a/clients/rust/crates/rubin-node/src/sync.rs
+++ b/clients/rust/crates/rubin-node/src/sync.rs
@@ -614,9 +614,11 @@ impl SyncEngine {
         // `commit_canonical_block` itself returns `Err`, the tip has not
         // advanced (the tip write is the last step inside the atomic API;
         // an earlier failure leaves the prior tip in place, and a save
-        // failure inside `set_canonical_tip` triggers
-        // `reload_index_from_disk` which restores the on-disk length), so
-        // no rewind is needed on that path.
+        // failure inside `set_canonical_tip` best-effort reloads the
+        // on-disk length — a double failure there would leave the
+        // in-memory length ahead of disk and the blockstore would require
+        // repair), so no rewind is needed on that path in the happy
+        // save-failure case.
         let canonical_len_before = self.block_store.as_ref().map_or(0, |bs| bs.canonical_len());
         if let Some(block_store) = self.block_store.as_mut() {
             // Atomic canonical commit — Go parity


### PR DESCRIPTION
## Summary

Closes **Q-IMPL-RUST-STORAGE-ATOMIC-CANONICAL-COMMIT-01** (refs #1175).

The Rust canonical block commit path in `sync.rs` used a split sequence: `BlockStore::put_block` advanced the canonical tip internally (via `set_canonical_tip`), then the caller persisted the undo separately via `put_undo`. A crash between tip-advance and undo-write would leave a canonical block with no recoverable undo, breaking `disconnect_tip` on the next reorg.

Go (`clients/go/node/blockstore.go:100-114`, `CommitCanonicalBlock`) has a single API with strict ordering: `StoreBlock` → `PutUndo` → `SetCanonicalTip`. The tip advance is the explicit commit point.

This PR aligns the Rust path.

## Changes

### `clients/rust/crates/rubin-node/src/blockstore.rs`
- New `BlockStore::commit_canonical_block(height, hash, header_bytes, block_bytes, undo)` API. Order: block bytes → header bytes → undo → canonical tip (last).
- Extracted `persist_block_bytes()` private helper shared by `put_block` and `commit_canonical_block` (avoids duplicating header validation + file writes).
- `put_undo` narrowed from `pub` to `pub(crate)` so every in-crate caller goes through the atomic API; no external callers existed.
- Docstring cites exact Go file:line + explains orphan-file retry semantics (`write_file_if_absent` idempotent for block/header; `write_file_atomic` tmp+rename idempotent for undo).

### `clients/rust/crates/rubin-node/src/sync.rs`
- Main commit callsite now uses `commit_canonical_block` as a single atomic call.
- `chain_state.save` failure path composes rewind error if `truncate_canonical` itself fails (matches the prior rewind-error-chain pattern).
- Added clarifying comment explaining `canonical_len_before`'s narrowed purpose (only for the post-commit `chain_state.save` rewind).

## Tests

- `commit_canonical_block_happy_path_advances_tip_and_persists_undo` — all three pieces land and tip moves.
- `commit_canonical_block_leaves_tip_unchanged_when_undo_fails` — crash-style evidence per task acceptance criteria. Uses test-only `force_undo_error` to simulate undo-persist failure; asserts `canonical_len()` unchanged + tip not advanced. Then clears the flag and retries, proving the same-hash retry contract succeeds and tip advances.

## Out of scope (per task spec)

- fsync durability (E.1)
- startup reconcile (E.2)
- write-if-absent race (E.3)
- broader storage architecture redesign

## Verification

- [x] `cargo test -p rubin-node` — 406 + 49 + 3 tests green (incl. 2 new crash-safety tests)
- [x] `cargo clippy -p rubin-node --all-targets -- -D warnings` clean
- [x] Coverage preflight: variation within gate, diff coverage OK
- [x] Claude-review (branch scope, Opus 4.7, max effort) — 2 rounds of findings addressed
- [x] Local security review PASS (ci-deferred, consensus_critical lenses)

## Test plan

- [x] CI green (Go/Rust/Kani/Codacy/bot-review-gate)
- [x] Bot reviewers — no structural findings expected
- [ ] Controller approval (no consensus semantics change; storage atomicity contract tightened)