### PR TITLE
feat(rust/node): expose TxPoolCleanupPlan::from_block_bytes for apply-path parity

### DIFF
--- a/clients/rust/crates/rubin-node/src/sync_reorg.rs
+++ b/clients/rust/crates/rubin-node/src/sync_reorg.rs
@@ -98,6 +98,24 @@ impl TxPoolCleanupPlan {
         })
     }
 
+    /// Build a cleanup plan from raw block bytes — high-level
+    /// constructor intended for callers that just finished a successful
+    /// `SyncEngine::apply_block` on the direct (non-reorg) path.
+    ///
+    /// Go parity (`clients/go/node/sync.go` calls
+    /// `s.mempool.EvictConfirmedParsed(pb)` after a successful apply);
+    /// in Rust the reorg path already builds this plan internally, but
+    /// the direct apply path (miner loop, test harnesses) had no
+    /// equivalent constructor. Callers can now run
+    /// `TxPoolCleanupPlan::from_block_bytes(block_bytes)?.apply(&mut
+    /// pool, &chain_state, block_store, chain_id)` to mirror the Go
+    /// post-apply cleanup shape: evict confirmed txids, drop
+    /// conflicting inputs.
+    pub fn from_block_bytes(block_bytes: &[u8]) -> Result<Self, String> {
+        let parsed = parse_block_bytes(block_bytes).map_err(|e| e.to_string())?;
+        Self::from_validated_block(&parsed, block_bytes)
+    }
+
     #[cfg(test)]
     pub fn from_parts_for_test(
         confirmed_txids: Vec<[u8; 32]>,
@@ -526,6 +544,45 @@ mod tests {
         let genesis = crate::devnet_genesis_block_bytes();
         let txs = non_coinbase_tx_bytes(&genesis).expect("parse");
         assert!(txs.is_empty());
+    }
+
+    /// `TxPoolCleanupPlan::from_block_bytes` is the direct-apply-path
+    /// constructor introduced for Q-IMPL-NODE-CONFIRMED-TX-CLEANUP-PARITY-01.
+    /// After a successful `SyncEngine::apply_block`, a direct caller
+    /// (miner, test harness) can build the cleanup plan from the same
+    /// block bytes and call `plan.apply(...)` to evict the now-confirmed
+    /// txids from the pool. This mirrors Go's post-apply call shape
+    /// `s.mempool.EvictConfirmedParsed(pb)` (clients/go/node/sync.go).
+    ///
+    /// The plan's `confirmed_txids` must equal the block's parsed txids
+    /// (coinbase is included in `parsed.txids` just like Go passes the
+    /// whole `ParsedBlock` to `EvictConfirmedParsed`; the pool's
+    /// `evict_txids` is tolerant of non-member txids so the coinbase
+    /// entry is a no-op when absent from the pool).
+    #[test]
+    fn cleanup_plan_from_block_bytes_lists_parsed_txids() {
+        let genesis = crate::devnet_genesis_block_bytes();
+        let parsed =
+            rubin_consensus::parse_block_bytes(&genesis).expect("parse genesis for parity check");
+        let plan = TxPoolCleanupPlan::from_block_bytes(&genesis).expect("from_block_bytes");
+        assert_eq!(
+            plan.confirmed_txids, parsed.txids,
+            "confirmed_txids must mirror parsed block txids"
+        );
+        // Genesis is coinbase-only so there are no non-coinbase inputs to
+        // drop; still, the plan is well-formed (not `is_empty`, since
+        // the coinbase txid is present).
+        assert!(plan.conflicting_inputs.is_empty());
+        assert!(plan.requeue_block_hashes.is_empty());
+    }
+
+    #[test]
+    fn cleanup_plan_from_block_bytes_rejects_short_input() {
+        let err = TxPoolCleanupPlan::from_block_bytes(&[0u8; 10]).unwrap_err();
+        assert!(
+            !err.is_empty(),
+            "short block must surface the underlying parse error"
+        );
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/sync_reorg.rs
+++ b/clients/rust/crates/rubin-node/src/sync_reorg.rs
@@ -90,7 +90,18 @@ impl TxPoolCleanupPlan {
         self
     }
 
-    fn from_validated_block(parsed: &ParsedBlock, block_bytes: &[u8]) -> Result<Self, String> {
+    /// Build a cleanup plan from an already-parsed block. Crate-private
+    /// for the reorg pipeline and hot-path callers that already hold a
+    /// `ParsedBlock` — avoids re-parsing the block bytes. External
+    /// callers use the `pub` [`Self::from_block_bytes`] wrapper.
+    ///
+    /// The caller must guarantee `parsed` was produced from
+    /// `block_bytes` (otherwise `parsed.txids` and
+    /// `non_coinbase_inputs(block_bytes)` would disagree).
+    pub(crate) fn from_validated_block(
+        parsed: &ParsedBlock,
+        block_bytes: &[u8],
+    ) -> Result<Self, String> {
         Ok(Self {
             confirmed_txids: parsed.txids.clone(),
             conflicting_inputs: non_coinbase_inputs(block_bytes)?,
@@ -106,11 +117,20 @@ impl TxPoolCleanupPlan {
     /// `s.mempool.EvictConfirmedParsed(pb)` after a successful apply);
     /// in Rust the reorg path already builds this plan internally, but
     /// the direct apply path (miner loop, test harnesses) had no
-    /// equivalent constructor. Callers can now run
-    /// `TxPoolCleanupPlan::from_block_bytes(block_bytes)?.apply(&mut
-    /// pool, &chain_state, block_store, chain_id)` to mirror the Go
-    /// post-apply cleanup shape: evict confirmed txids, drop
-    /// conflicting inputs.
+    /// equivalent constructor. Usage:
+    ///
+    /// ```ignore
+    /// TxPoolCleanupPlan::from_block_bytes(block_bytes)?
+    ///     .apply(&mut pool, &chain_state, block_store, chain_id);
+    /// ```
+    ///
+    /// Mirrors the Go post-apply cleanup shape: evict confirmed txids,
+    /// drop conflicting inputs.
+    ///
+    /// This constructor re-parses the block. Hot-path in-crate callers
+    /// that already hold a `ParsedBlock` (e.g., the reorg pipeline)
+    /// use the crate-private [`Self::from_validated_block`] directly to
+    /// avoid the second parse.
     pub fn from_block_bytes(block_bytes: &[u8]) -> Result<Self, String> {
         let parsed = parse_block_bytes(block_bytes).map_err(|e| e.to_string())?;
         Self::from_validated_block(&parsed, block_bytes)


### PR DESCRIPTION
## Summary

Closes **Q-IMPL-NODE-CONFIRMED-TX-CLEANUP-PARITY-01** (refs #1164; findings B.8 / C.6 / F.1).

Gap: Go's `sync.go` calls `s.mempool.EvictConfirmedParsed(pb)` right after a successful block apply so confirmed txids and conflicting inputs are dropped from the pool. Rust's reorg path builds `TxPoolCleanupPlan` internally via the private `from_validated_block`, but the direct `SyncEngine::apply_block` path (miner loop, test harnesses) had no public constructor — direct callers could not build the equivalent cleanup plan without duplicating block-parsing logic.

Fix: expose a narrow high-level constructor `TxPoolCleanupPlan::from_block_bytes(block_bytes) -> Result<Self, String>` that parses the block and delegates to the existing `from_validated_block`. Callers can mirror the Go shape:

```rust
sync_engine.apply_block(&block_bytes, prev_timestamps)?;
TxPoolCleanupPlan::from_block_bytes(&block_bytes)?
    .apply(&mut pool, &chain_state, block_store, chain_id);
```

No existing call sites change; this PR only adds the new entry point for the direct apply path.

## Parity
- Go: `clients/go/node/sync.go` → `s.mempool.EvictConfirmedParsed(pb)` after apply.
- Go: `clients/go/node/mempool.go` `EvictConfirmedParsed(block *consensus.ParsedBlock)` — drops confirmed txids + conflicting-input spenders.
- Rust (new): `TxPoolCleanupPlan::from_block_bytes(&block)?.apply(...)`.

## Tests (`sync_reorg::tests`)
- `cleanup_plan_from_block_bytes_lists_parsed_txids`: plan's `confirmed_txids` equals `ParsedBlock::txids`, matching the shape Go's `EvictConfirmedParsed` consumes.
- `cleanup_plan_from_block_bytes_rejects_short_input`: malformed block surfaces the `parse_block_bytes` error rather than panicking or producing an empty plan.

## Out of scope
- Wiring `SyncEngine` to hold a pool reference directly (broader refactor, out per task spec).
- Tx ordering / tie-break (covered by PR #1212).
- Broad reorg redesign.

## Verification
- `cargo test -p rubin-node --lib sync_reorg` 16/16 green
- `cargo clippy -p rubin-node --all-targets -- -D warnings` clean
- Coverage preflight PASS
- Claude-review (branch, Opus 4.7, max effort) PASS, 0 findings
- Local security review PASS (`cl push`)

Refs: rubin-protocol#1164