### PR TITLE
fix(storage): add fsync + parent dir-sync durability contract (E.1)

### DIFF
--- a/clients/go/node/chainstate.go
+++ b/clients/go/node/chainstate.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"math"
 	"math/big"
 	"os"
@@ -848,9 +849,22 @@ func writeAndSyncTemp(tmpPath string, data []byte, mode os.FileMode) error {
 // Sync and Close errors are combined via errors.Join so a Close error after
 // a successful Sync still surfaces (Copilot review feedback on PR #1218,
 // mirrors the writeAndSyncTemp pattern).
+//
+// Best-effort on permission-denied open: a parent directory with mode
+// 0300 (write+execute, no read) permits create/rename but blocks
+// os.Open(dir) for reading (Codex review feedback on PR #1218). The
+// rename has already succeeded by the time we get here, so returning
+// an error would make the caller treat committed state as failed on
+// hardened directory-permission setups. Return nil instead — the
+// destination bytes are already on disk via the temp file's Sync; only
+// the directory-entry fsync is degraded to best-effort. Any other open
+// error (ENOENT, EIO, etc) still propagates as a real anomaly.
 func syncDir(dir string) error {
 	d, err := os.Open(dir)
 	if err != nil {
+		if errors.Is(err, fs.ErrPermission) {
+			return nil
+		}
 		return err
 	}
 	serr := d.Sync()

--- a/clients/go/node/chainstate.go
+++ b/clients/go/node/chainstate.go
@@ -763,18 +763,23 @@ func parseHex32(name, value string) ([32]byte, error) {
 }
 
 // writeFileAtomic writes data to path via a temp+rename pattern with an
-// honest fsync durability contract (E.1):
-//  1. open the temp file with O_TRUNC|O_CREATE|O_WRONLY, write the bytes,
-//  2. Sync the temp file (fdatasync-equivalent on the file's data + inode),
-//  3. close the temp file,
-//  4. Rename temp -> destination,
-//  5. open the parent directory and Sync it so the rename itself is durable.
+// honest fsync durability contract (E.1). The actual file IO lives in the
+// helpers writeAndSyncTemp and syncDir — see their doc comments for the
+// short-write loop, errors.Join semantics, and Close error handling.
 //
-// Without step 5 the destination's bytes are on disk after step 2, but the
-// directory entry mapping `path` to the new inode may still live only in the
-// kernel page cache and be lost on crash. Mirrors the Rust
-// `clients/rust/crates/rubin-node/src/io_utils.rs` `write_file_atomic` for
-// cross-client storage parity.
+// Sequence (any failure removes the temp file before returning):
+//  1. delegate to writeAndSyncTemp: open temp with O_TRUNC|O_CREATE|O_WRONLY,
+//     loop Write until all bytes are persisted, Sync (fdatasync-equivalent
+//     on data + inode), Close, return joined errors;
+//  2. Rename temp -> destination (atomic on the same filesystem);
+//  3. delegate to syncDir on the parent directory so the rename itself is
+//     durable (without this the destination's bytes are on disk after
+//     step 1's Sync, but the directory entry mapping `path` to the new
+//     inode may still live only in the kernel page cache and be lost on
+//     crash).
+//
+// Mirrors the Rust `clients/rust/crates/rubin-node/src/io_utils.rs`
+// `write_file_atomic` for cross-client storage parity.
 func writeFileAtomic(path string, data []byte, mode os.FileMode) error {
 	tmpPath := fmt.Sprintf("%s.tmp.%d", path, os.Getpid())
 	if err := writeAndSyncTemp(tmpPath, data, mode); err != nil {

--- a/clients/go/node/chainstate.go
+++ b/clients/go/node/chainstate.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"math"
 	"math/big"
 	"os"
@@ -791,14 +792,21 @@ func writeFileAtomic(path string, data []byte, mode os.FileMode) error {
 // and inode metadata to stable storage, and closes it. Splitting this out
 // keeps writeFileAtomic linear and lets the rename + dir-sync stay readable.
 //
+// Write is looped until all bytes are persisted, matching Rust's
+// `Write::write_all` contract: io.Writer is allowed to return a short
+// write without an error, and treating that as success would let us
+// sync+rename a truncated file (Copilot review feedback on PR #1218).
+// A zero-byte short write is reported as io.ErrShortWrite to avoid an
+// infinite loop on a well-behaved-but-stuck writer.
+//
 // We always run Write, Sync and Close, then combine their errors with
 // errors.Join (Go 1.20+). This guarantees:
 //  1. the Close error is NOT silently dropped — it surfaces in the joined
-//     error and reaches the caller (Copilot review feedback on PR #1218);
+//     error and reaches the caller;
 //  2. the FD is always released, even when Write or Sync fail, without
 //     duplicating cleanup branches that would otherwise be unreachable
 //     from a unit test (no realistic way to provoke a Write or Sync
-//     failure on an already-opened file in CI).
+//     failure on an already-opened regular file in CI).
 //
 // On error the outer writeFileAtomic removes the temp file, so a partial
 // Sync after a failed Write does not leak state to the destination — the
@@ -808,7 +816,19 @@ func writeAndSyncTemp(tmpPath string, data []byte, mode os.FileMode) error {
 	if err != nil {
 		return err
 	}
-	_, werr := tmp.Write(data)
+	var werr error
+	for written := 0; written < len(data); {
+		n, e := tmp.Write(data[written:])
+		if e != nil {
+			werr = e
+			break
+		}
+		if n == 0 {
+			werr = io.ErrShortWrite
+			break
+		}
+		written += n
+	}
 	serr := tmp.Sync()
 	cerr := tmp.Close()
 	return errors.Join(werr, serr, cerr)

--- a/clients/go/node/chainstate.go
+++ b/clients/go/node/chainstate.go
@@ -761,14 +761,56 @@ func parseHex32(name, value string) ([32]byte, error) {
 	return out, nil
 }
 
+// writeFileAtomic writes data to path via a temp+rename pattern with an
+// honest fsync durability contract (E.1):
+//  1. open the temp file with O_TRUNC|O_CREATE|O_WRONLY, write the bytes,
+//  2. Sync the temp file (fdatasync-equivalent on the file's data + inode),
+//  3. close the temp file,
+//  4. Rename temp -> destination,
+//  5. open the parent directory and Sync it so the rename itself is durable.
+//
+// Without step 5 the destination's bytes are on disk after step 2, but the
+// directory entry mapping `path` to the new inode may still live only in the
+// kernel page cache and be lost on crash. Mirrors the Rust
+// `clients/rust/crates/rubin-node/src/io_utils.rs` `write_file_atomic` for
+// cross-client storage parity.
 func writeFileAtomic(path string, data []byte, mode os.FileMode) error {
 	tmpPath := fmt.Sprintf("%s.tmp.%d", path, os.Getpid())
-	if err := os.WriteFile(tmpPath, data, mode); err != nil {
+	if err := writeAndSyncTemp(tmpPath, data, mode); err != nil {
+		_ = os.Remove(tmpPath)
 		return err
 	}
 	if err := os.Rename(tmpPath, path); err != nil {
 		_ = os.Remove(tmpPath)
 		return err
 	}
-	return nil
+	return syncDir(filepath.Dir(path))
+}
+
+// writeAndSyncTemp writes data to a fresh temp path, syncs the file's bytes
+// and inode metadata to stable storage, and closes it. Splitting this out
+// keeps writeFileAtomic linear and lets the rename + dir-sync stay readable.
+func writeAndSyncTemp(tmpPath string, data []byte, mode os.FileMode) error {
+	tmp, err := os.OpenFile(tmpPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+	defer tmp.Close()
+	if _, err := tmp.Write(data); err != nil {
+		return err
+	}
+	return tmp.Sync()
+}
+
+// syncDir opens the directory and calls Sync so any rename or unlink
+// performed in it is itself durable. Unix-only: directory Sync is the
+// portable way to flush the parent's directory entry on Linux/macOS;
+// Windows lacks an equivalent and is not a Rubin production target.
+func syncDir(dir string) error {
+	d, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer d.Close()
+	return d.Sync()
 }

--- a/clients/go/node/chainstate.go
+++ b/clients/go/node/chainstate.go
@@ -790,16 +790,28 @@ func writeFileAtomic(path string, data []byte, mode os.FileMode) error {
 // writeAndSyncTemp writes data to a fresh temp path, syncs the file's bytes
 // and inode metadata to stable storage, and closes it. Splitting this out
 // keeps writeFileAtomic linear and lets the rename + dir-sync stay readable.
+//
+// We always run Write, Sync and Close, then combine their errors with
+// errors.Join (Go 1.20+). This guarantees:
+//  1. the Close error is NOT silently dropped — it surfaces in the joined
+//     error and reaches the caller (Copilot review feedback on PR #1218);
+//  2. the FD is always released, even when Write or Sync fail, without
+//     duplicating cleanup branches that would otherwise be unreachable
+//     from a unit test (no realistic way to provoke a Write or Sync
+//     failure on an already-opened file in CI).
+//
+// On error the outer writeFileAtomic removes the temp file, so a partial
+// Sync after a failed Write does not leak state to the destination — the
+// rename never runs.
 func writeAndSyncTemp(tmpPath string, data []byte, mode os.FileMode) error {
 	tmp, err := os.OpenFile(tmpPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
 	if err != nil {
 		return err
 	}
-	defer tmp.Close()
-	if _, err := tmp.Write(data); err != nil {
-		return err
-	}
-	return tmp.Sync()
+	_, werr := tmp.Write(data)
+	serr := tmp.Sync()
+	cerr := tmp.Close()
+	return errors.Join(werr, serr, cerr)
 }
 
 // syncDir opens the directory and calls Sync so any rename or unlink

--- a/clients/go/node/chainstate.go
+++ b/clients/go/node/chainstate.go
@@ -769,8 +769,9 @@ func parseHex32(name, value string) ([32]byte, error) {
 //
 // Sequence (any failure removes the temp file before returning):
 //  1. delegate to writeAndSyncTemp: open temp with O_TRUNC|O_CREATE|O_WRONLY,
-//     loop Write until all bytes are persisted, Sync (fdatasync-equivalent
-//     on data + inode), Close, return joined errors;
+//     loop Write until all bytes are persisted, Sync (fsync-equivalent:
+//     flushes file data + metadata to stable storage), Close, return joined
+//     errors;
 //  2. Rename temp -> destination (atomic on the same filesystem);
 //  3. delegate to syncDir on the parent directory so the rename itself is
 //     durable (without this the destination's bytes are on disk after

--- a/clients/go/node/chainstate.go
+++ b/clients/go/node/chainstate.go
@@ -818,11 +818,16 @@ func writeAndSyncTemp(tmpPath string, data []byte, mode os.FileMode) error {
 // performed in it is itself durable. Unix-only: directory Sync is the
 // portable way to flush the parent's directory entry on Linux/macOS;
 // Windows lacks an equivalent and is not a Rubin production target.
+//
+// Sync and Close errors are combined via errors.Join so a Close error after
+// a successful Sync still surfaces (Copilot review feedback on PR #1218,
+// mirrors the writeAndSyncTemp pattern).
 func syncDir(dir string) error {
 	d, err := os.Open(dir)
 	if err != nil {
 		return err
 	}
-	defer d.Close()
-	return d.Sync()
+	serr := d.Sync()
+	cerr := d.Close()
+	return errors.Join(serr, cerr)
 }

--- a/clients/go/node/chainstate_fsync_unix_test.go
+++ b/clients/go/node/chainstate_fsync_unix_test.go
@@ -1,0 +1,93 @@
+//go:build unix
+
+package node
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestWriteFileAtomicFailsWhenParentNotWritable exercises the OpenFile
+// error path of writeAndSyncTemp by chmod'ing the parent dir read-only
+// before the temp file can be created. Skipped when running as root since
+// root bypasses the mode check on most filesystems.
+//
+// Lives in a `//go:build unix` file because os.Geteuid() is Unix-only and
+// would prevent the chainstate_test.go file from compiling under
+// GOOS=windows (Copilot review feedback on PR #1218).
+func TestWriteFileAtomicFailsWhenParentNotWritable(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: chmod-based permission check does not apply")
+	}
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatalf("chmod parent read-only: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+	path := filepath.Join(dir, "denied.bin")
+	if err := writeFileAtomic(path, []byte("nope"), 0o600); err == nil {
+		t.Fatalf("writeFileAtomic to read-only parent: expected error, got nil")
+	}
+
+	// Tmp file must NOT remain on the filesystem either way (writeFileAtomic
+	// either failed before creating it or cleaned it up via os.Remove).
+	if err := os.Chmod(dir, 0o700); err != nil {
+		t.Fatalf("chmod parent restore: %v", err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if strings.Contains(name, ".tmp.") {
+			t.Fatalf("stale tmp file remained after open failure: %s", name)
+		}
+	}
+}
+
+// TestWriteAndSyncTempFailsOnUnwritableParent exercises writeAndSyncTemp's
+// OpenFile error path directly, ensuring the helper is honestly testable
+// without going through the full writeFileAtomic + Rename + syncDir chain.
+//
+// Lives in a `//go:build unix` file for the same reason as
+// TestWriteFileAtomicFailsWhenParentNotWritable.
+func TestWriteAndSyncTempFailsOnUnwritableParent(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: chmod-based permission check does not apply")
+	}
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatalf("chmod parent read-only: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+	tmpPath := filepath.Join(dir, "x.tmp.1")
+	if err := writeAndSyncTemp(tmpPath, []byte("nope"), 0o600); err == nil {
+		t.Fatalf("writeAndSyncTemp into read-only parent: expected error, got nil")
+	}
+}
+
+// TestSyncDirIsBestEffortOnExecuteOnlyParent — exercises the Codex P2 fix
+// from PR #1218. A parent directory with mode 0300 (write+execute, no read)
+// permits create/rename but blocks os.Open(dir) for reading. Before the
+// fix, syncDir returned EACCES after the rename had already succeeded,
+// making callers treat committed state as failed. After the fix, syncDir
+// silently returns nil on EACCES so the rename is reported as successful.
+func TestSyncDirIsBestEffortOnExecuteOnlyParent(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: chmod-based permission check does not apply")
+	}
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o300); err != nil {
+		t.Fatalf("chmod parent execute-only: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+	if err := syncDir(dir); err != nil {
+		t.Fatalf("syncDir on execute-only dir: expected nil (best-effort), got %v", err)
+	}
+}

--- a/clients/go/node/chainstate_test.go
+++ b/clients/go/node/chainstate_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
@@ -609,5 +610,140 @@ func TestChainState_ConnectBlock_DefaultRotation_StillWorks(t *testing.T) {
 	}
 	if !st.HasTip || st.Height != 0 {
 		t.Fatalf("unexpected state after genesis: has_tip=%v height=%d", st.HasTip, st.Height)
+	}
+}
+
+// TestWriteFileAtomicDurablyPersistsFreshFile is the Go-side smoke test for
+// the E.1 durability contract: a fresh write goes through OpenFile + Sync +
+// Rename + parent dir Sync without surfacing an error on a real filesystem,
+// and the resulting bytes are exactly what we wrote. We cannot directly
+// observe the fsync syscall from a unit test, but this DOES regression-guard
+// the OpenFile/Sync/Rename chain returning an error on the platforms that
+// run CI (Linux/macOS).
+func TestWriteFileAtomicDurablyPersistsFreshFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "payload.bin")
+	data := []byte("E.1 fsync contract: bytes + dir entry must both be durable")
+
+	if err := writeFileAtomic(path, data, 0o600); err != nil {
+		t.Fatalf("writeFileAtomic: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Fatalf("payload mismatch: got %q want %q", got, data)
+	}
+}
+
+// TestWriteFileAtomicReplacesExistingFileWithNewDurableBytes verifies the
+// dominant chainstate/blockstore path: rewriting the index file on every
+// commit must atomically replace it AND leave no stale .tmp.* sibling
+// behind once the rename succeeds.
+func TestWriteFileAtomicReplacesExistingFileWithNewDurableBytes(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "index.json")
+
+	if err := writeFileAtomic(path, []byte("first"), 0o600); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	if err := writeFileAtomic(path, []byte("second"), 0o600); err != nil {
+		t.Fatalf("second write: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if !bytes.Equal(got, []byte("second")) {
+		t.Fatalf("payload mismatch: got %q want %q", got, "second")
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if strings.Contains(name, ".tmp.") {
+			t.Fatalf("stale tmp file remained after rename: %s", name)
+		}
+	}
+}
+
+// TestSyncDirSucceedsOnExistingDirectory pins the standalone helper:
+// storage callers may want to fsync ad-hoc directory mutations (for example
+// after deleting a stale undo file) without going through writeFileAtomic.
+func TestSyncDirSucceedsOnExistingDirectory(t *testing.T) {
+	dir := t.TempDir()
+	if err := syncDir(dir); err != nil {
+		t.Fatalf("syncDir on existing directory: %v", err)
+	}
+}
+
+// TestSyncDirFailsOnMissingDirectory exercises the error path of syncDir
+// (os.Open returns an error). Without this the durability helper's failure
+// mode is silent under coverage.
+func TestSyncDirFailsOnMissingDirectory(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "no-such-subdir")
+	if err := syncDir(missing); err == nil {
+		t.Fatalf("syncDir on missing dir: expected error, got nil")
+	}
+}
+
+// TestWriteFileAtomicFailsWhenParentNotWritable exercises the OpenFile
+// error path of writeAndSyncTemp by chmod'ing the parent dir read-only
+// before the temp file can be created. Skipped when running as root since
+// root bypasses the mode check on most filesystems.
+func TestWriteFileAtomicFailsWhenParentNotWritable(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: chmod-based permission check does not apply")
+	}
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatalf("chmod parent read-only: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+	path := filepath.Join(dir, "denied.bin")
+	if err := writeFileAtomic(path, []byte("nope"), 0o600); err == nil {
+		t.Fatalf("writeFileAtomic to read-only parent: expected error, got nil")
+	}
+
+	// Tmp file must NOT remain on the filesystem either way (writeFileAtomic
+	// either failed before creating it or cleaned it up via os.Remove).
+	if err := os.Chmod(dir, 0o700); err != nil {
+		t.Fatalf("chmod parent restore: %v", err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if strings.Contains(name, ".tmp.") {
+			t.Fatalf("stale tmp file remained after open failure: %s", name)
+		}
+	}
+}
+
+// TestWriteAndSyncTempFailsOnUnwritableParent exercises writeAndSyncTemp's
+// OpenFile error path directly, ensuring the helper is honestly testable
+// without going through the full writeFileAtomic + Rename + syncDir chain.
+func TestWriteAndSyncTempFailsOnUnwritableParent(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: chmod-based permission check does not apply")
+	}
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatalf("chmod parent read-only: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+	tmpPath := filepath.Join(dir, "x.tmp.1")
+	if err := writeAndSyncTemp(tmpPath, []byte("nope"), 0o600); err == nil {
+		t.Fatalf("writeAndSyncTemp into read-only parent: expected error, got nil")
 	}
 }

--- a/clients/go/node/chainstate_test.go
+++ b/clients/go/node/chainstate_test.go
@@ -693,57 +693,7 @@ func TestSyncDirFailsOnMissingDirectory(t *testing.T) {
 	}
 }
 
-// TestWriteFileAtomicFailsWhenParentNotWritable exercises the OpenFile
-// error path of writeAndSyncTemp by chmod'ing the parent dir read-only
-// before the temp file can be created. Skipped when running as root since
-// root bypasses the mode check on most filesystems.
-func TestWriteFileAtomicFailsWhenParentNotWritable(t *testing.T) {
-	if os.Geteuid() == 0 {
-		t.Skip("running as root: chmod-based permission check does not apply")
-	}
-	dir := t.TempDir()
-	if err := os.Chmod(dir, 0o500); err != nil {
-		t.Fatalf("chmod parent read-only: %v", err)
-	}
-	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
-
-	path := filepath.Join(dir, "denied.bin")
-	if err := writeFileAtomic(path, []byte("nope"), 0o600); err == nil {
-		t.Fatalf("writeFileAtomic to read-only parent: expected error, got nil")
-	}
-
-	// Tmp file must NOT remain on the filesystem either way (writeFileAtomic
-	// either failed before creating it or cleaned it up via os.Remove).
-	if err := os.Chmod(dir, 0o700); err != nil {
-		t.Fatalf("chmod parent restore: %v", err)
-	}
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		t.Fatalf("read dir: %v", err)
-	}
-	for _, entry := range entries {
-		name := entry.Name()
-		if strings.Contains(name, ".tmp.") {
-			t.Fatalf("stale tmp file remained after open failure: %s", name)
-		}
-	}
-}
-
-// TestWriteAndSyncTempFailsOnUnwritableParent exercises writeAndSyncTemp's
-// OpenFile error path directly, ensuring the helper is honestly testable
-// without going through the full writeFileAtomic + Rename + syncDir chain.
-func TestWriteAndSyncTempFailsOnUnwritableParent(t *testing.T) {
-	if os.Geteuid() == 0 {
-		t.Skip("running as root: chmod-based permission check does not apply")
-	}
-	dir := t.TempDir()
-	if err := os.Chmod(dir, 0o500); err != nil {
-		t.Fatalf("chmod parent read-only: %v", err)
-	}
-	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
-
-	tmpPath := filepath.Join(dir, "x.tmp.1")
-	if err := writeAndSyncTemp(tmpPath, []byte("nope"), 0o600); err == nil {
-		t.Fatalf("writeAndSyncTemp into read-only parent: expected error, got nil")
-	}
-}
+// Permission-based tests that rely on os.Geteuid() (Unix-only) live in
+// chainstate_fsync_unix_test.go behind a `//go:build unix` tag so this
+// file still compiles under GOOS=windows (Copilot review feedback on
+// PR #1218).

--- a/clients/rust/crates/rubin-node/src/io_utils.rs
+++ b/clients/rust/crates/rubin-node/src/io_utils.rs
@@ -110,13 +110,26 @@ fn effective_parent(path: &Path) -> Option<&Path> {
 /// is honestly reported; only the rare close-after-successful-sync error
 /// is silently absorbed by Drop. This is an accepted Rust stdlib
 /// limitation, not a missing fix.
+///
+/// Best-effort on permission-denied open: a parent directory with mode
+/// `0300` (write+execute, no read) permits create/rename but blocks
+/// `OpenOptions::new().read(true).open(dir)` (Codex review feedback on
+/// PR #1218). The rename has already succeeded by the time `sync_dir`
+/// runs, so returning an error would make the caller treat committed
+/// state as failed on hardened directory-permission setups. Return
+/// `Ok(())` instead — the destination bytes are already on disk via
+/// the temp file's `sync_all()`; only the directory-entry fsync is
+/// degraded to best-effort. Any other open error (`NotFound`, `Other`,
+/// etc) still propagates as a real anomaly.
 pub fn sync_dir(dir: &Path) -> Result<(), String> {
-    fs::OpenOptions::new()
-        .read(true)
-        .open(dir)
-        .map_err(|e| format!("open dir {}: {e}", dir.display()))?
-        .sync_all()
-        .map_err(|e| format!("sync dir {}: {e}", dir.display()))
+    use std::io::ErrorKind;
+    match fs::OpenOptions::new().read(true).open(dir) {
+        Ok(file) => file
+            .sync_all()
+            .map_err(|e| format!("sync dir {}: {e}", dir.display())),
+        Err(e) if e.kind() == ErrorKind::PermissionDenied => Ok(()),
+        Err(e) => Err(format!("open dir {}: {e}", dir.display())),
+    }
 }
 
 #[cfg(test)]
@@ -207,6 +220,46 @@ mod tests {
         sync_dir(&dir).expect("sync_dir on existing directory");
 
         let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// Codex P2 fix from PR #1218: `sync_dir` on an execute-only parent
+    /// (mode `0300` — write+execute, no read) must return `Ok(())`
+    /// instead of surfacing `EACCES`, because the rename has already
+    /// succeeded by the time we call it. Without this, hardened
+    /// directory-permission setups would see writes reported as failed
+    /// even though the destination bytes are durably on disk.
+    #[cfg(unix)]
+    #[test]
+    fn sync_dir_is_best_effort_on_execute_only_parent() {
+        use std::os::unix::fs::PermissionsExt;
+        // Skip when running as root — the chmod-based permission check
+        // does not apply (CAP_DAC_READ_SEARCH bypasses it). Detected via
+        // `id -u` (no extra crate dependency on `libc` or `users`).
+        let is_root = std::process::Command::new("id")
+            .arg("-u")
+            .output()
+            .ok()
+            .and_then(|o| String::from_utf8(o.stdout).ok())
+            .map(|s| s.trim() == "0")
+            .unwrap_or(false);
+        if is_root {
+            return;
+        }
+        let dir = unique_temp_path("rubin-io-utils-syncdir-eaccess");
+        fs::create_dir_all(&dir).expect("create test dir");
+        let mut perms = fs::metadata(&dir).expect("stat").permissions();
+        perms.set_mode(0o300);
+        fs::set_permissions(&dir, perms).expect("chmod 0o300");
+
+        let result = sync_dir(&dir);
+
+        // Restore writable mode before any remove call so cleanup works.
+        let mut restore = fs::metadata(&dir).expect("stat").permissions();
+        restore.set_mode(0o700);
+        let _ = fs::set_permissions(&dir, restore);
+        let _ = fs::remove_dir_all(&dir);
+
+        result.expect("sync_dir on execute-only dir must be best-effort (Ok)");
     }
 
     /// Pure-helper unit test for the `path.parent()` edge case: a relative

--- a/clients/rust/crates/rubin-node/src/io_utils.rs
+++ b/clients/rust/crates/rubin-node/src/io_utils.rs
@@ -16,16 +16,7 @@ pub fn parse_hex32(name: &str, value: &str) -> Result<[u8; 32], String> {
 }
 
 pub fn write_file_atomic(path: &Path, data: &[u8]) -> Result<(), String> {
-    // For relative paths like `Path::new("foo")` the standard library returns
-    // `Some(Path::new(""))` rather than `None`. An empty path can neither be
-    // created via `create_dir_all` nor opened via `OpenOptions::open` for
-    // `sync_dir`. Treat empty as the current directory so behaviour matches
-    // the previous `fs::write` semantics for bare-name targets.
-    let parent = match path.parent() {
-        Some(p) if !p.as_os_str().is_empty() => Some(p),
-        Some(_) => Some(Path::new(".")),
-        None => None,
-    };
+    let parent = effective_parent(path);
     if let Some(parent) = parent {
         fs::create_dir_all(parent)
             .map_err(|e| format!("create parent {}: {e}", parent.display()))?;
@@ -38,7 +29,12 @@ pub fn write_file_atomic(path: &Path, data: &[u8]) -> Result<(), String> {
     // explicitly so we control flush ordering: write all bytes, then
     // `sync_all()` (data + metadata), then close, then rename, then sync the
     // parent directory so the rename itself is durable.
-    {
+    //
+    // Mirrors the Go helper: any failure between `open temp` and the rename
+    // removes the partially-written `<dest>.tmp.<pid>` so we do not strand
+    // a large file on disk under realistic I/O fault conditions
+    // (e.g. ENOSPC/EIO after the data write).
+    let write_result: Result<(), String> = (|| {
         use std::io::Write;
         let mut tmp = fs::OpenOptions::new()
             .write(true)
@@ -49,7 +45,11 @@ pub fn write_file_atomic(path: &Path, data: &[u8]) -> Result<(), String> {
         tmp.write_all(data)
             .map_err(|e| format!("write temp {}: {e}", tmp_path))?;
         tmp.sync_all()
-            .map_err(|e| format!("sync temp {}: {e}", tmp_path))?;
+            .map_err(|e| format!("sync temp {}: {e}", tmp_path))
+    })();
+    if let Err(e) = write_result {
+        let _ = fs::remove_file(&tmp_path);
+        return Err(e);
     }
     fs::rename(&tmp_path, path).map_err(|e| {
         let _ = fs::remove_file(&tmp_path);
@@ -65,6 +65,20 @@ pub fn write_file_atomic(path: &Path, data: &[u8]) -> Result<(), String> {
         sync_dir(parent)?;
     }
     Ok(())
+}
+
+/// Compute the directory whose existence we must ensure (and whose entry we
+/// must fsync) for a target path. For relative bare-name targets like
+/// `Path::new("foo")` the standard library returns `Some(Path::new(""))`,
+/// not `None`. An empty path can neither be created via `create_dir_all`
+/// nor opened via `OpenOptions::open` for `sync_dir`, so map empty to `.`
+/// (current directory) — matches the previous `fs::write` semantics.
+fn effective_parent(path: &Path) -> Option<&Path> {
+    match path.parent() {
+        Some(p) if !p.as_os_str().is_empty() => Some(p),
+        Some(_) => Some(Path::new(".")),
+        None => None,
+    }
 }
 
 /// Open the parent directory and call `sync_all()` so any rename or unlink
@@ -170,34 +184,76 @@ mod tests {
         let _ = fs::remove_dir_all(&dir);
     }
 
-    /// Regression for the `path.parent()` edge case: a relative bare-name
-    /// target like `Path::new("relative.bin")` returns `Some(Path::new(""))`
-    /// from `parent()`, not `None`. The previous `fs::write` implementation
-    /// silently no-op'd the parent, so callers in tests/CWD-relative paths
-    /// kept working. Make sure the new implementation maps the empty parent
-    /// to `.` and does not surface `create_dir_all("")` / `sync_dir("")`
-    /// errors.
+    /// Pure-helper unit test for the `path.parent()` edge case: a relative
+    /// bare-name target like `Path::new("relative.bin")` returns
+    /// `Some(Path::new(""))` from `parent()`, not `None`. The previous
+    /// `fs::write` implementation silently no-op'd the parent, so callers
+    /// in CWD-relative paths kept working. The internal `effective_parent`
+    /// helper maps the empty parent to `.` so `create_dir_all` and
+    /// `sync_dir` both get a usable path.
+    ///
+    /// We test the helper directly rather than mutating the process-wide
+    /// CWD with `std::env::set_current_dir`, which would race other tests
+    /// running in parallel (Rust tests are concurrent by default).
     #[test]
-    fn write_file_atomic_handles_relative_bare_name_target() {
+    fn effective_parent_maps_empty_parent_to_current_directory() {
+        use super::effective_parent;
         use std::path::Path;
 
-        // Run with a private CWD to avoid polluting wherever the test runner
-        // happens to be.
-        let cwd = unique_temp_path("rubin-io-utils-cwd");
-        fs::create_dir_all(&cwd).expect("create cwd");
-        let prev_cwd = std::env::current_dir().expect("getcwd");
-        std::env::set_current_dir(&cwd).expect("chdir into test cwd");
+        // Bare relative target: parent is "" -> mapped to "."
+        assert_eq!(
+            effective_parent(Path::new("relative.bin")),
+            Some(Path::new("."))
+        );
+        // Absolute target with explicit parent: returned as-is
+        assert_eq!(
+            effective_parent(Path::new("/tmp/sub/file")),
+            Some(Path::new("/tmp/sub"))
+        );
+        // Filesystem root: no parent at all
+        assert_eq!(effective_parent(Path::new("/")), None);
+        // Multi-segment relative target: parent retained
+        assert_eq!(
+            effective_parent(Path::new("sub/file")),
+            Some(Path::new("sub"))
+        );
+    }
 
-        let bare = Path::new("relative.bin");
-        let result = write_file_atomic(bare, b"relative-target");
+    /// On a sync_all/write_all failure before rename the temp file MUST be
+    /// removed, otherwise a real I/O fault (ENOSPC/EIO after data write)
+    /// would strand large `<dest>.tmp.<pid>` siblings on disk while the
+    /// caller sees an error.
+    ///
+    /// We exercise the path indirectly: provoke a `create_parent` failure
+    /// by passing a destination whose parent path component is an existing
+    /// regular file (not a directory). The early-exit must NOT leave any
+    /// unrelated file behind in the surrounding temp directory.
+    #[test]
+    fn write_file_atomic_does_not_strand_temp_when_create_parent_fails() {
+        let dir = unique_temp_path("rubin-io-utils-strand");
+        fs::create_dir_all(&dir).expect("create test dir");
+        let blocker = dir.join("not-a-dir");
+        fs::write(&blocker, b"existing file masquerading as parent").expect("write blocker");
+        // Path whose parent (`blocker`) is a regular file, so create_dir_all
+        // will fail before any temp open/write happens.
+        let bad_target = blocker.join("payload");
 
-        // Restore CWD before any assertion so a panic does not leak it.
-        std::env::set_current_dir(&prev_cwd).expect("chdir back");
+        let result = write_file_atomic(&bad_target, b"never-written");
+        assert!(result.is_err(), "expected create_parent failure");
 
-        result.expect("write_file_atomic on bare relative target");
-        let read_back = fs::read(cwd.join("relative.bin")).expect("read back");
-        assert_eq!(read_back, b"relative-target");
+        // The directory must contain only the blocker file; no `.tmp.*`
+        // sibling was created by this failed call.
+        let entries: Vec<_> = fs::read_dir(&dir)
+            .expect("list dir")
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(
+            entries,
+            vec!["not-a-dir".to_string()],
+            "stranded files present"
+        );
 
-        let _ = fs::remove_dir_all(&cwd);
+        let _ = fs::remove_dir_all(&dir);
     }
 }

--- a/clients/rust/crates/rubin-node/src/io_utils.rs
+++ b/clients/rust/crates/rubin-node/src/io_utils.rs
@@ -37,7 +37,7 @@ pub fn write_file_atomic(path: &Path, data: &[u8]) -> Result<(), String> {
         fs::create_dir_all(parent)
             .map_err(|e| format!("create parent {}: {e}", parent.display()))?;
     }
-    let tmp_path = format!("{}.tmp.{}", path.display(), std::process::id());
+    let tmp_path = temp_path_for(path, std::process::id());
     // Durability contract (E.1): the temp file's bytes AND its inode metadata
     // must hit stable storage before the rename, otherwise a crash between
     // rename and the next implicit flush can leave the destination pointing
@@ -57,11 +57,11 @@ pub fn write_file_atomic(path: &Path, data: &[u8]) -> Result<(), String> {
             .create(true)
             .truncate(true)
             .open(&tmp_path)
-            .map_err(|e| format!("open temp {}: {e}", tmp_path))?;
+            .map_err(|e| format!("open temp {}: {e}", tmp_path.display()))?;
         tmp.write_all(data)
-            .map_err(|e| format!("write temp {}: {e}", tmp_path))?;
+            .map_err(|e| format!("write temp {}: {e}", tmp_path.display()))?;
         tmp.sync_all()
-            .map_err(|e| format!("sync temp {}: {e}", tmp_path))
+            .map_err(|e| format!("sync temp {}: {e}", tmp_path.display()))
     })();
     if let Err(e) = write_result {
         let _ = fs::remove_file(&tmp_path);
@@ -69,7 +69,11 @@ pub fn write_file_atomic(path: &Path, data: &[u8]) -> Result<(), String> {
     }
     fs::rename(&tmp_path, path).map_err(|e| {
         let _ = fs::remove_file(&tmp_path);
-        format!("rename temp {} -> {}: {e}", tmp_path, path.display())
+        format!(
+            "rename temp {} -> {}: {e}",
+            tmp_path.display(),
+            path.display()
+        )
     })?;
     // Directory fsync makes the rename itself durable. Without this the
     // destination file's bytes are on disk after the temp `sync_all()` above,
@@ -81,6 +85,24 @@ pub fn write_file_atomic(path: &Path, data: &[u8]) -> Result<(), String> {
         sync_dir(parent)?;
     }
     Ok(())
+}
+
+/// Build the `<dest>.tmp.<pid>` companion path for a target `path`
+/// without going through lossy `Path::display()`. `display()` replaces
+/// non-UTF-8 bytes with `U+FFFD`; on Unix a `PathBuf` can contain any
+/// byte sequence other than `/` and `\0`, so a lossy conversion would
+/// produce a temp at a different location than the caller's actual
+/// target — breaking both the atomic rename and the failure cleanup.
+/// `OsString::push` preserves the original bytes exactly. Split into
+/// its own helper so the byte-preservation contract is independently
+/// testable without going through the filesystem (APFS on macOS
+/// rejects non-UTF-8 filenames with EILSEQ, so a filesystem-level
+/// round-trip test is not portable). Copilot review feedback on PR #1218.
+fn temp_path_for(path: &Path, pid: u32) -> std::path::PathBuf {
+    let mut tmp_os = path.as_os_str().to_os_string();
+    tmp_os.push(".tmp.");
+    tmp_os.push(pid.to_string());
+    std::path::PathBuf::from(tmp_os)
 }
 
 /// Compute the directory whose existence we must ensure (and whose entry we
@@ -294,6 +316,48 @@ mod tests {
         assert_eq!(
             effective_parent(Path::new("sub/file")),
             Some(Path::new("sub"))
+        );
+    }
+
+    /// Copilot P1 regression from PR #1218: the temp path must be built
+    /// via byte-level `OsString::push`, NOT via lossy
+    /// `format!("{}.tmp.{}", path.display(), pid)`. `path.display()`
+    /// replaces non-UTF-8 bytes with `U+FFFD`, so a `PathBuf` containing
+    /// any non-UTF-8 byte would round-trip to a DIFFERENT temp path
+    /// than the caller's actual target.
+    ///
+    /// Tested on the pure helper because APFS on macOS rejects non-UTF-8
+    /// filenames at the syscall layer with `EILSEQ`, which makes a
+    /// filesystem-level round-trip test non-portable. `temp_path_for`
+    /// is the only place where the lossy-vs-exact decision lives, so
+    /// byte-level verification here pins the fix completely.
+    #[cfg(unix)]
+    #[test]
+    fn temp_path_for_preserves_non_utf8_bytes() {
+        use super::temp_path_for;
+        use std::ffi::OsString;
+        use std::os::unix::ffi::{OsStrExt, OsStringExt};
+        use std::path::PathBuf;
+
+        let mut bytes = b"/tmp/bad-".to_vec();
+        bytes.push(0xff);
+        bytes.extend_from_slice(b"-name.bin");
+        let path = PathBuf::from(OsString::from_vec(bytes.clone()));
+
+        let tmp = temp_path_for(&path, 12345);
+
+        let mut expected = bytes.clone();
+        expected.extend_from_slice(b".tmp.12345");
+        assert_eq!(tmp.as_os_str().as_bytes(), expected.as_slice());
+
+        // Negative: lossy `format!("{}.tmp.{}", path.display(), 12345)`
+        // would replace the 0xff byte with U+FFFD (three bytes
+        // 0xef 0xbf 0xbd), producing DIFFERENT bytes.
+        let lossy = format!("{}.tmp.12345", path.display());
+        assert_ne!(
+            tmp.as_os_str().as_bytes(),
+            lossy.as_bytes(),
+            "temp_path_for must not agree with lossy display() on non-UTF-8 input"
         );
     }
 

--- a/clients/rust/crates/rubin-node/src/io_utils.rs
+++ b/clients/rust/crates/rubin-node/src/io_utils.rs
@@ -16,7 +16,17 @@ pub fn parse_hex32(name: &str, value: &str) -> Result<[u8; 32], String> {
 }
 
 pub fn write_file_atomic(path: &Path, data: &[u8]) -> Result<(), String> {
-    if let Some(parent) = path.parent() {
+    // For relative paths like `Path::new("foo")` the standard library returns
+    // `Some(Path::new(""))` rather than `None`. An empty path can neither be
+    // created via `create_dir_all` nor opened via `OpenOptions::open` for
+    // `sync_dir`. Treat empty as the current directory so behaviour matches
+    // the previous `fs::write` semantics for bare-name targets.
+    let parent = match path.parent() {
+        Some(p) if !p.as_os_str().is_empty() => Some(p),
+        Some(_) => Some(Path::new(".")),
+        None => None,
+    };
+    if let Some(parent) = parent {
         fs::create_dir_all(parent)
             .map_err(|e| format!("create parent {}: {e}", parent.display()))?;
     }
@@ -51,7 +61,7 @@ pub fn write_file_atomic(path: &Path, data: &[u8]) -> Result<(), String> {
     // inode may still live only in the kernel page cache and be lost on
     // crash. Mirrors the Go `writeFileAtomic` `Sync` on parent directory
     // for cross-client parity.
-    if let Some(parent) = path.parent() {
+    if let Some(parent) = parent {
         sync_dir(parent)?;
     }
     Ok(())
@@ -158,5 +168,36 @@ mod tests {
         sync_dir(&dir).expect("sync_dir on existing directory");
 
         let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// Regression for the `path.parent()` edge case: a relative bare-name
+    /// target like `Path::new("relative.bin")` returns `Some(Path::new(""))`
+    /// from `parent()`, not `None`. The previous `fs::write` implementation
+    /// silently no-op'd the parent, so callers in tests/CWD-relative paths
+    /// kept working. Make sure the new implementation maps the empty parent
+    /// to `.` and does not surface `create_dir_all("")` / `sync_dir("")`
+    /// errors.
+    #[test]
+    fn write_file_atomic_handles_relative_bare_name_target() {
+        use std::path::Path;
+
+        // Run with a private CWD to avoid polluting wherever the test runner
+        // happens to be.
+        let cwd = unique_temp_path("rubin-io-utils-cwd");
+        fs::create_dir_all(&cwd).expect("create cwd");
+        let prev_cwd = std::env::current_dir().expect("getcwd");
+        std::env::set_current_dir(&cwd).expect("chdir into test cwd");
+
+        let bare = Path::new("relative.bin");
+        let result = write_file_atomic(bare, b"relative-target");
+
+        // Restore CWD before any assertion so a panic does not leak it.
+        std::env::set_current_dir(&prev_cwd).expect("chdir back");
+
+        result.expect("write_file_atomic on bare relative target");
+        let read_back = fs::read(cwd.join("relative.bin")).expect("read back");
+        assert_eq!(read_back, b"relative-target");
+
+        let _ = fs::remove_dir_all(&cwd);
     }
 }

--- a/clients/rust/crates/rubin-node/src/io_utils.rs
+++ b/clients/rust/crates/rubin-node/src/io_utils.rs
@@ -15,6 +15,22 @@ pub fn parse_hex32(name: &str, value: &str) -> Result<[u8; 32], String> {
     Ok(out)
 }
 
+/// Atomically write `data` to `path` with an honest fsync durability
+/// contract (audit `E.1`). Sequence (any failure between open and rename
+/// removes the partially-written `<dest>.tmp.<pid>`):
+///
+/// 1. resolve the target's effective parent (see `effective_parent`),
+///    `create_dir_all` it if missing;
+/// 2. open `<path>.tmp.<pid>` with `O_TRUNC|O_CREATE|O_WRONLY`;
+/// 3. `write_all` (loops on short writes per stdlib contract);
+/// 4. `sync_all` — flushes data + inode metadata to disk;
+/// 5. close (implicit on scope exit; see `sync_dir` doc on Rust File close
+///    error semantics);
+/// 6. `fs::rename` temp -> destination (atomic on the same filesystem);
+/// 7. `sync_dir` on the effective parent so the rename itself is durable.
+///
+/// Mirrors the Go `clients/go/node/chainstate.go` `writeFileAtomic` for
+/// cross-client storage parity.
 pub fn write_file_atomic(path: &Path, data: &[u8]) -> Result<(), String> {
     let parent = effective_parent(path);
     if let Some(parent) = parent {
@@ -85,6 +101,15 @@ fn effective_parent(path: &Path) -> Option<&Path> {
 /// performed in it is itself durable. Splitting this out keeps
 /// `write_file_atomic` linear and lets storage callers fsync ad-hoc
 /// directory mutations later if they need to.
+///
+/// Cross-client note: the Go counterpart `syncDir` uses
+/// `errors.Join(serr, cerr)` to surface a Close error after a successful
+/// Sync. Rust cannot easily mirror that — `std::fs::File::drop` discards
+/// the close error by design, and there is no stable safe API to surface
+/// it. The Sync error itself is returned, so a kernel-level flush failure
+/// is honestly reported; only the rare close-after-successful-sync error
+/// is silently absorbed by Drop. This is an accepted Rust stdlib
+/// limitation, not a missing fix.
 pub fn sync_dir(dir: &Path) -> Result<(), String> {
     fs::OpenOptions::new()
         .read(true)

--- a/clients/rust/crates/rubin-node/src/io_utils.rs
+++ b/clients/rust/crates/rubin-node/src/io_utils.rs
@@ -21,11 +21,53 @@ pub fn write_file_atomic(path: &Path, data: &[u8]) -> Result<(), String> {
             .map_err(|e| format!("create parent {}: {e}", parent.display()))?;
     }
     let tmp_path = format!("{}.tmp.{}", path.display(), std::process::id());
-    fs::write(&tmp_path, data).map_err(|e| format!("write temp {}: {e}", tmp_path))?;
+    // Durability contract (E.1): the temp file's bytes AND its inode metadata
+    // must hit stable storage before the rename, otherwise a crash between
+    // rename and the next implicit flush can leave the destination pointing
+    // at a zero-length / partially-written file. Using `OpenOptions` here
+    // explicitly so we control flush ordering: write all bytes, then
+    // `sync_all()` (data + metadata), then close, then rename, then sync the
+    // parent directory so the rename itself is durable.
+    {
+        use std::io::Write;
+        let mut tmp = fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&tmp_path)
+            .map_err(|e| format!("open temp {}: {e}", tmp_path))?;
+        tmp.write_all(data)
+            .map_err(|e| format!("write temp {}: {e}", tmp_path))?;
+        tmp.sync_all()
+            .map_err(|e| format!("sync temp {}: {e}", tmp_path))?;
+    }
     fs::rename(&tmp_path, path).map_err(|e| {
         let _ = fs::remove_file(&tmp_path);
         format!("rename temp {} -> {}: {e}", tmp_path, path.display())
-    })
+    })?;
+    // Directory fsync makes the rename itself durable. Without this the
+    // destination file's bytes are on disk after the temp `sync_all()` above,
+    // but the directory entry that points the destination name at the new
+    // inode may still live only in the kernel page cache and be lost on
+    // crash. Mirrors the Go `writeFileAtomic` `Sync` on parent directory
+    // for cross-client parity.
+    if let Some(parent) = path.parent() {
+        sync_dir(parent)?;
+    }
+    Ok(())
+}
+
+/// Open the parent directory and call `sync_all()` so any rename or unlink
+/// performed in it is itself durable. Splitting this out keeps
+/// `write_file_atomic` linear and lets storage callers fsync ad-hoc
+/// directory mutations later if they need to.
+pub fn sync_dir(dir: &Path) -> Result<(), String> {
+    fs::OpenOptions::new()
+        .read(true)
+        .open(dir)
+        .map_err(|e| format!("open dir {}: {e}", dir.display()))?
+        .sync_all()
+        .map_err(|e| format!("sync dir {}: {e}", dir.display()))
 }
 
 #[cfg(test)]
@@ -40,4 +82,81 @@ pub fn unique_temp_path(prefix: &str) -> PathBuf {
             .as_nanos(),
         NEXT_UNIQUE_TEMP_ID.fetch_add(1, Ordering::Relaxed),
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{sync_dir, unique_temp_path, write_file_atomic};
+    use std::fs;
+
+    /// Smoke test for the E.1 durability contract: a fresh write goes
+    /// through OpenOptions + sync_all + rename + parent dir-sync without
+    /// surfacing an error on a real filesystem, and the resulting bytes
+    /// are exactly what we wrote. We cannot directly observe the fsync
+    /// syscall from a unit test, but we DO want a regression that
+    /// notices if the `OpenOptions`/`sync_all` chain ever returns an
+    /// error on the platforms that run CI (Linux/macOS).
+    #[test]
+    fn write_file_atomic_durably_persists_fresh_file() {
+        let dir = unique_temp_path("rubin-io-utils-fresh");
+        fs::create_dir_all(&dir).expect("create test dir");
+        let path = dir.join("payload.bin");
+        let data = b"E.1 fsync contract: bytes + dir entry must both be durable";
+
+        write_file_atomic(&path, data).expect("write_file_atomic");
+
+        let read_back = fs::read(&path).expect("read back");
+        assert_eq!(read_back, data);
+
+        // Cleanup
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// Replace path: existing destination is overwritten with new bytes.
+    /// Verifies sync_all + rename idempotency on top of an existing inode
+    /// (this is the dominant chainstate/blockstore path: rewrite the
+    /// index file every commit).
+    #[test]
+    fn write_file_atomic_replaces_existing_file_with_new_durable_bytes() {
+        let dir = unique_temp_path("rubin-io-utils-replace");
+        fs::create_dir_all(&dir).expect("create test dir");
+        let path = dir.join("index.json");
+
+        write_file_atomic(&path, b"first").expect("first write");
+        write_file_atomic(&path, b"second").expect("second write");
+
+        let read_back = fs::read(&path).expect("read back");
+        assert_eq!(read_back, b"second");
+
+        // No leftover .tmp.* sibling — temp must have been renamed away.
+        let leftover_tmps: Vec<_> = fs::read_dir(&dir)
+            .expect("list dir")
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| entry.file_name().to_string_lossy().contains(".tmp."))
+            .collect();
+        assert!(
+            leftover_tmps.is_empty(),
+            "stale .tmp.* file remained after rename: {:?}",
+            leftover_tmps
+                .iter()
+                .map(|e| e.file_name())
+                .collect::<Vec<_>>()
+        );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// Standalone `sync_dir` helper accepts an existing directory and
+    /// returns Ok. Storage callers may want to fsync ad-hoc directory
+    /// mutations (e.g. after deleting a stale undo file) without going
+    /// through `write_file_atomic`.
+    #[test]
+    fn sync_dir_succeeds_on_existing_directory() {
+        let dir = unique_temp_path("rubin-io-utils-syncdir");
+        fs::create_dir_all(&dir).expect("create test dir");
+
+        sync_dir(&dir).expect("sync_dir on existing directory");
+
+        let _ = fs::remove_dir_all(&dir);
+    }
 }


### PR DESCRIPTION
## Summary

Closes **Q-IMPL-NODE-STORAGE-FSYNC-DURABILITY-01** (refs #1172; finding `E.1`).

Both Go and Rust storage write paths went through a single helper that did temp-write + rename, but never `fsync`'d the temp file before the rename or the parent directory after it. A crash between rename and the next implicit flush could leave the destination pointing at a zero-length / partially-written file, OR leave the destination's bytes on disk with the directory entry still only in the kernel page cache and lost on reboot.

Fix touches the base helpers, so every storage persistence path inherits durability without per-caller changes:

- Rust: `clients/rust/crates/rubin-node/src/io_utils.rs` `write_file_atomic`
- Go: `clients/go/node/chainstate.go` `writeFileAtomic`

## Contract (mirrored in both clients)

1. open temp with `O_TRUNC|O_CREATE|O_WRONLY`
2. write all bytes
3. `sync_all()` / `file.Sync()` — temp data + inode metadata to disk
4. close
5. rename temp → dest
6. open parent directory and `sync_all()` / `dir.Sync()` — directory entry to disk

A new standalone helper (Rust `pub sync_dir`, Go `syncDir`) is exposed so storage callers can fsync ad-hoc directory mutations (e.g. after deleting a stale undo file) without going through the temp+rename helper.

## Audit chain-trace

> `E.1` — Ни Go, ни Rust не fsync'ят file/dir при chainstate/block/undo persistence.

Source: `inbox/reports/AUDIT_GAPS_2026-04-14_origin_main_revalidated.md` in `rubin-orchestration-private`. Baseline: `rubin-protocol@4fa5c618fb8b0b503c8c5ebd6b211fd5b3c0d4c7`.

## Out of scope (per task spec)

- Startup reconcile / repair work — `Q-IMPL-RUST-STORAGE-STARTUP-RECONCILE-01` (`E.2`, issue #1173)
- Write-if-absent race / TOCTOU hardening — `Q-IMPL-NODE-STORAGE-WRITE-IF-ABSENT-RACE-HARDENING-01` (`E.3`, issue #1174)
- Atomic canonical commit — `Q-IMPL-RUST-STORAGE-ATOMIC-CANONICAL-COMMIT-01` (`E.4`, already merged via #1211)
- Broad storage redesign

## Tests

- Rust `io_utils::tests::write_file_atomic_durably_persists_fresh_file` — fresh-write smoke
- Rust `io_utils::tests::write_file_atomic_replaces_existing_file_with_new_durable_bytes` — overwrite + no `.tmp.*` leftover
- Rust `io_utils::tests::sync_dir_succeeds_on_existing_directory` — standalone helper
- Go `TestWriteFileAtomicDurablyPersistsFreshFile` / `TestWriteFileAtomicReplacesExistingFileWithNewDurableBytes` / `TestSyncDirSucceedsOnExistingDirectory` — same surface
- Go `TestSyncDirFailsOnMissingDirectory` / `TestWriteFileAtomicFailsWhenParentNotWritable` / `TestWriteAndSyncTempFailsOnUnwritableParent` — error-path coverage (skipped under root)

The `fsync` syscall itself cannot be observed from a unit test; these tests pin the `OpenOptions`/`Sync`/`Rename` chain returning Ok on real CI fs (Linux/macOS), and that no `.tmp.*` sibling remains after a successful replace.

## Test plan

- [x] `cargo test -p rubin-node --lib -- blockstore chainstate io_utils` — 29 passed
- [x] `go test ./node/ -run TestWriteFileAtomic|TestSyncDir|TestChainState|TestBlockStore` — passed
- [x] `cargo clippy -p rubin-node --lib --tests -- -D warnings` — clean
- [x] `cargo fmt --check`, `gofmt -l` — clean
- [ ] CI green (Codacy diff coverage ≥ 85%, all required checks)
- [ ] Bot review (`@codex review` + `@copilot review` separately)


<!-- rubin-agent-meta actor=claude action=pr-create via=cl branch=claude/q-impl-node-storage-fsync-durability-01 wt=rubin-protocol utc=2026-04-18T09:27:19Z -->
