### PR TITLE
feat: add local coder-agent hardening gates

### DIFF
--- a/tools/agent_templates/Q_TEMPLATE.md
+++ b/tools/agent_templates/Q_TEMPLATE.md
@@ -1,0 +1,63 @@
+# Q Template
+
+Use this template for `tools/agent_tasks/<Q-ID>.json` plus the human task brief
+that travels with the branch. Keep one branch/PR on one `Q-*` unless a
+controller-approved bundle says otherwise.
+
+## Q-ID
+
+- `Q-ID:`
+- `Owner area:`
+
+## Allowed Files
+
+- Exact files:
+- Allowed globs:
+
+## Forbidden Files
+
+Default runtime-Q forbidden globs unless the manifest explicitly narrows scope
+for tooling/docs/CI:
+
+- `.cursor/**`
+- `.claude/**`
+- `.github/workflows/**`
+- `tools/**`
+- `docs/**`
+- unrelated Go/Rust files outside the declared runtime slice
+
+## Target Diff
+
+- `target_production_loc:`
+- `hard_production_loc:`
+
+## Acceptance Criteria
+
+- Behavior change:
+- Explicit non-goals:
+- Exact proof boundary:
+
+## Invariant Table
+
+Fill this before the first edit.
+
+- `scope:`
+- `state_ownership:`
+- `lock_io:`
+- `failure_atomicity:`
+- `go_rust_parity:`
+- `caller_fuzz_test_sweep:`
+- `test_stability:`
+
+## Required Commands
+
+- `tools/rubin_q_preflight.sh tools/agent_tasks/<Q-ID>.json`
+- Additional local checks:
+
+## Final Self-Check
+
+- One `Q-*` only:
+- Exact changed files confirmed:
+- Each change mapped to one invariant:
+- No adjacent cleanup:
+- No hidden test knobs / brittle tests / file:line comment anchors:

--- a/tools/agent_templates/coder_prompt.md
+++ b/tools/agent_templates/coder_prompt.md
@@ -1,0 +1,40 @@
+# Local Coder Prompt
+
+You are writing code in `rubin-protocol` under the local coder-agent hardening
+contract.
+
+Before the first edit:
+
+1. Read `AGENTS.md`.
+2. Read the matching `tools/agent_tasks/<Q-ID>.json`.
+3. Run the mandatory pre-write skill `rubin-write-quality` from the sanctioned
+   local skill runtime for this machine.
+4. Print the invariant table with all seven keys:
+   - `scope`
+   - `state_ownership`
+   - `lock_io`
+   - `failure_atomicity`
+   - `go_rust_parity`
+   - `caller_fuzz_test_sweep`
+   - `test_stability`
+
+Execution rules:
+
+- One branch/PR implements one `Q-*` unless a controller-approved bundle says
+  otherwise.
+- State the exact files you will change before editing.
+- Map every change back to at least one invariant.
+- Do not do adjacent cleanup or opportunistic refactors.
+- Respect `target_production_loc` and fail closed at `hard_production_loc`.
+- Do not add hidden test env knobs in production paths.
+- Do not add `.unwrap()` / `.expect()` in long-running runtime paths without an
+  explicit justification in the diff.
+- Do not add panic-like cleanup in `Drop`.
+- Do not add brittle tests via CWD mutation, `/nonexistent`, chmod/read-only,
+  or OS-specific error-string matching.
+- Do not add file:line anchors in code comments.
+
+Before any PR update:
+
+- Run `tools/rubin_q_preflight.sh tools/agent_tasks/<Q-ID>.json`.
+- If it fails, stay `BLOCKED` and fix the diff before pushing.

--- a/tools/agent_templates/local_reviewer_prompt.md
+++ b/tools/agent_templates/local_reviewer_prompt.md
@@ -1,0 +1,25 @@
+# Local Reviewer Prompt
+
+Read-only review for the current `Q-*` diff in `rubin-protocol`.
+
+Review the diff against the task manifest and report only concrete findings.
+
+Check:
+
+- violated invariant from the seven-item invariant table
+- scope drift versus `allowed_files`, `allowed_globs`, and `forbidden_globs`
+- brittle test patterns: CWD mutation, `/nonexistent`, chmod/read-only,
+  OS-error-string matching
+- hidden test knobs in production paths
+- caller/fuzz/test sweep omissions that leave dead-path or false-coverage claims
+- mismatch between acceptance criteria / PR body and what the diff or tests
+  actually prove
+
+Rules:
+
+- Stay read-only.
+- Review only the current changed surface plus direct companions needed to prove
+  a finding.
+- Do not ask for unrelated cleanup.
+- Prefer reviewer-worthy correctness, parity, contract, and drift findings over
+  style feedback.

--- a/tools/agent_templates/q_manifest.schema.json
+++ b/tools/agent_templates/q_manifest.schema.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "rubin-protocol local coder-agent Q manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "q_id",
+    "owner_area",
+    "allowed_files",
+    "required_tests",
+    "hard_production_loc",
+    "required_invariants"
+  ],
+  "properties": {
+    "q_id": {
+      "type": "string",
+      "pattern": "^Q-[A-Z0-9][A-Z0-9-]*$"
+    },
+    "owner_area": {
+      "type": "string",
+      "enum": [
+        "consensus",
+        "node",
+        "p2p",
+        "storage",
+        "rpc",
+        "ci",
+        "formal",
+        "docs",
+        "tooling"
+      ]
+    },
+    "allowed_files": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "allowed_globs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "forbidden_globs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "required_tests": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "target_production_loc": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "hard_production_loc": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "required_invariants": {
+      "type": "array",
+      "minItems": 7,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "enum": [
+          "scope",
+          "state_ownership",
+          "lock_io",
+          "failure_atomicity",
+          "go_rust_parity",
+          "caller_fuzz_test_sweep",
+          "test_stability"
+        ]
+      }
+    }
+  }
+}

--- a/tools/agent_templates/q_manifest.schema.json
+++ b/tools/agent_templates/q_manifest.schema.json
@@ -57,7 +57,8 @@
       "minItems": 1,
       "items": {
         "type": "string",
-        "minLength": 1
+        "minLength": 1,
+        "pattern": "^[^\\r\\n]+$"
       }
     },
     "target_production_loc": {

--- a/tools/agent_templates/q_manifest.schema.json
+++ b/tools/agent_templates/q_manifest.schema.json
@@ -58,7 +58,7 @@
       "items": {
         "type": "string",
         "minLength": 1,
-        "pattern": "^[^\\r\\n]+$"
+        "pattern": "^(?=.*\\S)[^\\r\\n]+$"
       }
     },
     "target_production_loc": {

--- a/tools/rubin_agent_contract.py
+++ b/tools/rubin_agent_contract.py
@@ -43,7 +43,21 @@ RUNTIME_SENSITIVE_TOKENS = (
 )
 
 PRODUCTION_SUFFIXES = {".go", ".rs", ".lean"}
-COMMENT_PREFIXES = ("//", "#", "/*", "*", "--")
+COMMENT_PREFIXES = ("//", "#", "/*", "*/", "--")
+DEFAULT_RUNTIME_FORBIDDEN_GLOBS = (
+    ".cursor/**",
+    ".claude/**",
+    ".github/workflows/**",
+    "tools/**",
+    "docs/**",
+)
+DEFAULT_FORBIDDEN_OWNER_AREAS = {
+    "consensus",
+    "node",
+    "p2p",
+    "storage",
+    "rpc",
+}
 
 DIFF_HEADER_RE = re.compile(r"^diff --git a/(.+) b/(.+)$")
 HUNK_HEADER_RE = re.compile(
@@ -193,25 +207,43 @@ def _validate_instance(instance: Any, schema: dict[str, Any], pointer: str = "$"
     return errors
 
 
-def validate_manifest_document(document: dict[str, Any]) -> dict[str, Any]:
+def validate_manifest_document(document: Any) -> dict[str, Any]:
     schema = load_json(SCHEMA_PATH)
     errors = _validate_instance(document, schema)
+
+    if not isinstance(document, dict):
+        raise ManifestValidationError(errors or ["$: expected object"])
 
     if "required_invariants" in document:
         observed = document["required_invariants"]
         if isinstance(observed, list):
-            missing = sorted(set(CANONICAL_INVARIANTS) - set(observed))
-            extras = sorted(set(observed) - set(CANONICAL_INVARIANTS))
-            if missing:
+            if all(isinstance(item, str) for item in observed):
+                observed_set = set(observed)
+                missing = sorted(set(CANONICAL_INVARIANTS) - observed_set)
+                extras = sorted(observed_set - set(CANONICAL_INVARIANTS))
+                if missing:
+                    errors.append(
+                        "$.required_invariants: missing canonical invariant(s): "
+                        + ", ".join(missing)
+                    )
+                if extras:
+                    errors.append(
+                        "$.required_invariants: unsupported invariant(s): "
+                        + ", ".join(extras)
+                    )
+            else:
                 errors.append(
-                    "$.required_invariants: missing canonical invariant(s): "
-                    + ", ".join(missing)
+                    "$.required_invariants: entries must all be strings"
                 )
-            if extras:
-                errors.append(
-                    "$.required_invariants: unsupported invariant(s): "
-                    + ", ".join(extras)
-                )
+
+    if "required_tests" in document:
+        observed_tests = document["required_tests"]
+        if isinstance(observed_tests, list):
+            for idx, command in enumerate(observed_tests):
+                if isinstance(command, str) and ("\n" in command or "\r" in command):
+                    errors.append(
+                        f"$.required_tests[{idx}]: required test commands must be single-line"
+                    )
 
     if (
         isinstance(document.get("target_production_loc"), int)
@@ -347,13 +379,47 @@ def parse_diff_patches(repo_root: Path, diff_range: str) -> dict[str, FilePatch]
 
 
 def path_matches_glob(rel_path: str, pattern: str) -> bool:
-    rel = PurePosixPath(normalize_rel_path(rel_path))
     normalized_pattern = normalize_rel_path(pattern)
-    return rel.match(normalized_pattern) or rel.as_posix() == normalized_pattern
+    normalized_path = normalize_rel_path(rel_path)
+    regex_parts = ["^"]
+    idx = 0
+
+    while idx < len(normalized_pattern):
+        char = normalized_pattern[idx]
+        if char == "*":
+            next_is_star = idx + 1 < len(normalized_pattern) and normalized_pattern[idx + 1] == "*"
+            if next_is_star:
+                regex_parts.append(".*")
+                idx += 2
+                continue
+            regex_parts.append("[^/]*")
+            idx += 1
+            continue
+        if char == "?":
+            regex_parts.append("[^/]")
+            idx += 1
+            continue
+        regex_parts.append(re.escape(char))
+        idx += 1
+
+    regex_parts.append("$")
+    return re.fullmatch("".join(regex_parts), normalized_path) is not None
 
 
 def matches_any_glob(rel_path: str, patterns: list[str]) -> bool:
     return any(path_matches_glob(rel_path, pattern) for pattern in patterns)
+
+
+def effective_forbidden_globs(manifest: dict[str, Any]) -> list[str]:
+    configured = manifest.get("forbidden_globs")
+    if isinstance(configured, list):
+        return [normalize_rel_path(pattern) for pattern in configured]
+
+    owner_area = manifest.get("owner_area")
+    if owner_area in DEFAULT_FORBIDDEN_OWNER_AREAS:
+        return list(DEFAULT_RUNTIME_FORBIDDEN_GLOBS)
+
+    return []
 
 
 def is_test_file(rel_path: str) -> bool:

--- a/tools/rubin_agent_contract.py
+++ b/tools/rubin_agent_contract.py
@@ -430,6 +430,11 @@ def path_matches_glob(rel_path: str, pattern: str) -> bool:
         if char == "*":
             next_is_star = idx + 1 < len(normalized_pattern) and normalized_pattern[idx + 1] == "*"
             if next_is_star:
+                slash_after_star = idx + 2 < len(normalized_pattern) and normalized_pattern[idx + 2] == "/"
+                if slash_after_star:
+                    regex_parts.append("(?:[^/]+/)*")
+                    idx += 3
+                    continue
                 regex_parts.append(".*")
                 idx += 2
                 continue
@@ -511,13 +516,19 @@ def find_drop_block_ranges(text: str) -> list[tuple[int, int]]:
     started = False
     start_line = 0
     brace_depth = 0
+    header_lines: list[str] = []
+    drop_header_re = re.compile(r"^\s*impl(?:\s*<[^{}]*>)?\s+Drop\b.*\bfor\b")
 
     for idx, line in enumerate(lines, start=1):
         stripped = line.lstrip()
         comment_like = is_comment_line(line) or stripped.startswith("* ") or stripped == "*"
 
-        if not tracking_header and not comment_like and re.search(r"^\s*impl\b.*\bDrop\b", line):
+        if not tracking_header and not comment_like and re.search(r"^\s*impl\b", line):
             tracking_header = True
+            header_lines = [line.split("{", 1)[0]]
+            start_line = idx
+        elif tracking_header and not started:
+            header_lines.append(line.split("{", 1)[0])
 
         if not tracking_header:
             continue
@@ -526,14 +537,19 @@ def find_drop_block_ranges(text: str) -> list[tuple[int, int]]:
         close_braces = line.count("}")
 
         if not started and open_braces:
+            header_text = " ".join(part.strip() for part in header_lines if part.strip())
+            if not drop_header_re.search(header_text):
+                tracking_header = False
+                header_lines = []
+                continue
             started = True
-            start_line = idx
             brace_depth += open_braces - close_braces
             if brace_depth <= 0:
                 ranges.append((start_line, idx))
                 tracking_header = False
                 started = False
                 brace_depth = 0
+                header_lines = []
             continue
 
         if started:
@@ -543,6 +559,7 @@ def find_drop_block_ranges(text: str) -> list[tuple[int, int]]:
                 tracking_header = False
                 started = False
                 brace_depth = 0
+                header_lines = []
 
     return ranges
 

--- a/tools/rubin_agent_contract.py
+++ b/tools/rubin_agent_contract.py
@@ -135,6 +135,12 @@ def load_json(path: Path) -> Any:
         return json.loads(path.read_text(encoding="utf-8"))
     except FileNotFoundError as exc:
         raise ManifestValidationError([f"{path}: file not found"]) from exc
+    except UnicodeDecodeError as exc:
+        raise ManifestValidationError(
+            [f"{path}: invalid utf-8 at byte {exc.start}"]
+        ) from exc
+    except OSError as exc:
+        raise ManifestValidationError([f"{path}: unable to read file: {exc}"]) from exc
     except json.JSONDecodeError as exc:
         raise ManifestValidationError(
             [f"{path}: invalid json at line {exc.lineno} column {exc.colno}: {exc.msg}"]
@@ -466,16 +472,19 @@ def read_worktree_text(repo_root: Path, rel_path: str) -> str:
 def find_drop_block_ranges(text: str) -> list[tuple[int, int]]:
     lines = text.splitlines()
     ranges: list[tuple[int, int]] = []
-    tracking = False
+    tracking_header = False
     started = False
     start_line = 0
     brace_depth = 0
 
     for idx, line in enumerate(lines, start=1):
-        if not tracking and "Drop for" in line:
-            tracking = True
+        stripped = line.lstrip()
+        comment_like = is_comment_line(line) or stripped.startswith("* ") or stripped == "*"
 
-        if not tracking:
+        if not tracking_header and not comment_like and re.search(r"^\s*impl\b.*\bDrop\b", line):
+            tracking_header = True
+
+        if not tracking_header:
             continue
 
         open_braces = line.count("{")
@@ -487,7 +496,7 @@ def find_drop_block_ranges(text: str) -> list[tuple[int, int]]:
             brace_depth += open_braces - close_braces
             if brace_depth <= 0:
                 ranges.append((start_line, idx))
-                tracking = False
+                tracking_header = False
                 started = False
                 brace_depth = 0
             continue
@@ -496,7 +505,7 @@ def find_drop_block_ranges(text: str) -> list[tuple[int, int]]:
             brace_depth += open_braces - close_braces
             if brace_depth <= 0:
                 ranges.append((start_line, idx))
-                tracking = False
+                tracking_header = False
                 started = False
                 brace_depth = 0
 

--- a/tools/rubin_agent_contract.py
+++ b/tools/rubin_agent_contract.py
@@ -517,7 +517,10 @@ def find_drop_block_ranges(text: str) -> list[tuple[int, int]]:
     start_line = 0
     brace_depth = 0
     header_lines: list[str] = []
-    drop_header_re = re.compile(r"^\s*impl(?:\s*<[^{}]*>)?\s+Drop\b.*\bfor\b")
+    drop_header_re = re.compile(
+        r"^\s*impl(?:\s*<[^{}]*>)?\s+"
+        r"(?:(?:::)?[A-Za-z_][A-Za-z0-9_]*\s*::\s*)*Drop\b\s+for\b"
+    )
 
     for idx, line in enumerate(lines, start=1):
         stripped = line.lstrip()

--- a/tools/rubin_agent_contract.py
+++ b/tools/rubin_agent_contract.py
@@ -1,0 +1,441 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+SCHEMA_PATH = SCRIPT_DIR / "agent_templates" / "q_manifest.schema.json"
+
+OWNER_AREAS = (
+    "consensus",
+    "node",
+    "p2p",
+    "storage",
+    "rpc",
+    "ci",
+    "formal",
+    "docs",
+    "tooling",
+)
+
+CANONICAL_INVARIANTS = (
+    "scope",
+    "state_ownership",
+    "lock_io",
+    "failure_atomicity",
+    "go_rust_parity",
+    "caller_fuzz_test_sweep",
+    "test_stability",
+)
+
+RUNTIME_SENSITIVE_TOKENS = (
+    "p2p",
+    "sync",
+    "rpc",
+    "miner",
+    "reconnect",
+)
+
+PRODUCTION_SUFFIXES = {".go", ".rs", ".lean"}
+COMMENT_PREFIXES = ("//", "#", "/*", "*", "--")
+
+DIFF_HEADER_RE = re.compile(r"^diff --git a/(.+) b/(.+)$")
+HUNK_HEADER_RE = re.compile(
+    r"^@@ -(?P<old_start>\d+)(?:,(?P<old_count>\d+))? "
+    r"\+(?P<new_start>\d+)(?:,(?P<new_count>\d+))? @@"
+)
+
+
+class ContractError(RuntimeError):
+    """Base error for local coder-agent contracts."""
+
+
+class GitCommandError(ContractError):
+    """Raised when a required git command fails."""
+
+
+class ManifestValidationError(ContractError):
+    """Raised when a manifest or schema is invalid."""
+
+    def __init__(self, errors: list[str]):
+        self.errors = errors
+        message = "manifest validation failed:\n- " + "\n- ".join(errors)
+        super().__init__(message)
+
+
+@dataclass(frozen=True)
+class AddedLine:
+    number: int
+    text: str
+
+
+@dataclass
+class FilePatch:
+    path: str
+    added_lines: list[AddedLine] = field(default_factory=list)
+    added_count: int = 0
+    deleted_count: int = 0
+
+
+def normalize_rel_path(path: str) -> str:
+    normalized = path.replace("\\", "/")
+    if normalized.startswith("./"):
+        return normalized[2:]
+    return normalized
+
+
+def resolve_manifest_path(path_arg: str | Path) -> Path:
+    path = Path(path_arg).expanduser()
+    if path.is_absolute():
+        return path
+    cwd_candidate = Path.cwd() / path
+    if cwd_candidate.exists():
+        return cwd_candidate.resolve()
+    return path.resolve()
+
+
+def discover_repo_root(manifest_path: Path) -> Path:
+    result = subprocess.run(
+        ["git", "-C", str(manifest_path.parent), "rev-parse", "--show-toplevel"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or "git rev-parse failed"
+        raise GitCommandError(
+            f"unable to discover repo root for manifest {manifest_path}: {detail}"
+        )
+    return Path(result.stdout.strip()).resolve()
+
+
+def load_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ManifestValidationError([f"{path}: file not found"]) from exc
+    except json.JSONDecodeError as exc:
+        raise ManifestValidationError(
+            [f"{path}: invalid json at line {exc.lineno} column {exc.colno}: {exc.msg}"]
+        ) from exc
+
+
+def _validate_instance(instance: Any, schema: dict[str, Any], pointer: str = "$") -> list[str]:
+    errors: list[str] = []
+    schema_type = schema.get("type")
+
+    if schema_type == "object":
+        if not isinstance(instance, dict):
+            return [f"{pointer}: expected object"]
+        required = schema.get("required", [])
+        for key in required:
+            if key not in instance:
+                errors.append(f"{pointer}: missing required property {key!r}")
+        properties = schema.get("properties", {})
+        if schema.get("additionalProperties") is False:
+            extras = sorted(set(instance.keys()) - set(properties.keys()))
+            for key in extras:
+                errors.append(f"{pointer}: unexpected property {key!r}")
+        for key, value in instance.items():
+            prop_schema = properties.get(key)
+            if prop_schema is not None:
+                errors.extend(_validate_instance(value, prop_schema, f"{pointer}.{key}"))
+        return errors
+
+    if schema_type == "array":
+        if not isinstance(instance, list):
+            return [f"{pointer}: expected array"]
+        min_items = schema.get("minItems")
+        if min_items is not None and len(instance) < min_items:
+            errors.append(f"{pointer}: expected at least {min_items} item(s)")
+        if schema.get("uniqueItems"):
+            try:
+                normalized = [json.dumps(item, sort_keys=True) for item in instance]
+            except TypeError:
+                normalized = [repr(item) for item in instance]
+            if len(normalized) != len(set(normalized)):
+                errors.append(f"{pointer}: array items must be unique")
+        item_schema = schema.get("items")
+        if item_schema is not None:
+            for idx, item in enumerate(instance):
+                errors.extend(_validate_instance(item, item_schema, f"{pointer}[{idx}]"))
+        return errors
+
+    if schema_type == "string":
+        if not isinstance(instance, str):
+            return [f"{pointer}: expected string"]
+        min_length = schema.get("minLength")
+        if min_length is not None and len(instance) < min_length:
+            errors.append(f"{pointer}: expected string length >= {min_length}")
+        enum = schema.get("enum")
+        if enum is not None and instance not in enum:
+            errors.append(f"{pointer}: expected one of {enum!r}")
+        pattern = schema.get("pattern")
+        if pattern is not None and re.fullmatch(pattern, instance) is None:
+            errors.append(f"{pointer}: value does not match pattern {pattern!r}")
+        return errors
+
+    if schema_type == "integer":
+        if not isinstance(instance, int) or isinstance(instance, bool):
+            return [f"{pointer}: expected integer"]
+        minimum = schema.get("minimum")
+        if minimum is not None and instance < minimum:
+            errors.append(f"{pointer}: expected integer >= {minimum}")
+        return errors
+
+    return errors
+
+
+def validate_manifest_document(document: dict[str, Any]) -> dict[str, Any]:
+    schema = load_json(SCHEMA_PATH)
+    errors = _validate_instance(document, schema)
+
+    if "required_invariants" in document:
+        observed = document["required_invariants"]
+        if isinstance(observed, list):
+            missing = sorted(set(CANONICAL_INVARIANTS) - set(observed))
+            extras = sorted(set(observed) - set(CANONICAL_INVARIANTS))
+            if missing:
+                errors.append(
+                    "$.required_invariants: missing canonical invariant(s): "
+                    + ", ".join(missing)
+                )
+            if extras:
+                errors.append(
+                    "$.required_invariants: unsupported invariant(s): "
+                    + ", ".join(extras)
+                )
+
+    if (
+        isinstance(document.get("target_production_loc"), int)
+        and isinstance(document.get("hard_production_loc"), int)
+        and document["target_production_loc"] > document["hard_production_loc"]
+    ):
+        errors.append(
+            "$.target_production_loc: target_production_loc must be <= hard_production_loc"
+        )
+
+    if errors:
+        raise ManifestValidationError(errors)
+    return document
+
+
+def load_manifest(path_arg: str | Path) -> tuple[Path, Path, dict[str, Any]]:
+    manifest_path = resolve_manifest_path(path_arg)
+    repo_root = discover_repo_root(manifest_path)
+    document = load_json(manifest_path)
+    manifest = validate_manifest_document(document)
+    return manifest_path, repo_root, manifest
+
+
+def run_git(repo_root: Path, args: list[str]) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), *args],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "git command failed"
+        raise GitCommandError(f"git {' '.join(args)} failed: {detail}")
+    return result.stdout
+
+
+def default_diff_range(repo_root: Path) -> str:
+    run_git(repo_root, ["rev-parse", "--verify", "origin/main"])
+    merge_base = run_git(repo_root, ["merge-base", "origin/main", "HEAD"]).strip()
+    if not merge_base:
+        raise GitCommandError("git merge-base origin/main HEAD returned empty output")
+    return merge_base
+
+
+def resolve_diff_range(repo_root: Path, diff_range: str | None) -> str:
+    if diff_range:
+        return diff_range
+    return default_diff_range(repo_root)
+
+
+def list_changed_files(repo_root: Path, diff_range: str) -> list[str]:
+    output = run_git(repo_root, ["diff", "--name-only", diff_range, "--"])
+    changed = {normalize_rel_path(line) for line in output.splitlines() if line.strip()}
+    changed.update(list_untracked_files(repo_root))
+    return sorted(changed)
+
+
+def list_untracked_files(repo_root: Path) -> list[str]:
+    output = run_git(repo_root, ["ls-files", "--others", "--exclude-standard"])
+    return [normalize_rel_path(line) for line in output.splitlines() if line.strip()]
+
+
+def parse_diff_patches(repo_root: Path, diff_range: str) -> dict[str, FilePatch]:
+    output = run_git(repo_root, ["diff", "--find-renames", "--unified=0", diff_range, "--"])
+    patches: dict[str, FilePatch] = {}
+    current: FilePatch | None = None
+    new_line = 0
+    old_line = 0
+    in_hunk = False
+
+    for line in output.splitlines():
+        match = DIFF_HEADER_RE.match(line)
+        if match:
+            path = normalize_rel_path(match.group(2))
+            current = patches.setdefault(path, FilePatch(path=path))
+            in_hunk = False
+            continue
+
+        if current is None:
+            continue
+
+        if line.startswith("+++ "):
+            dst = line[4:].strip()
+            if dst != "/dev/null":
+                path = normalize_rel_path(dst.removeprefix("b/"))
+                if path != current.path:
+                    current = patches.setdefault(path, FilePatch(path=path))
+            continue
+
+        hunk = HUNK_HEADER_RE.match(line)
+        if hunk:
+            old_line = int(hunk.group("old_start"))
+            new_line = int(hunk.group("new_start"))
+            in_hunk = True
+            continue
+
+        if not in_hunk:
+            continue
+
+        if line.startswith("+") and not line.startswith("+++"):
+            current.added_count += 1
+            current.added_lines.append(AddedLine(number=new_line, text=line[1:]))
+            new_line += 1
+            continue
+
+        if line.startswith("-") and not line.startswith("---"):
+            current.deleted_count += 1
+            old_line += 1
+            continue
+
+        if line.startswith(" "):
+            old_line += 1
+            new_line += 1
+
+    for rel_path in list_untracked_files(repo_root):
+        path = repo_root / rel_path
+        if not path.is_file():
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        added_lines = [
+            AddedLine(number=idx, text=line)
+            for idx, line in enumerate(text.splitlines(), start=1)
+        ]
+        patch = patches.setdefault(rel_path, FilePatch(path=rel_path))
+        patch.added_lines.extend(added_lines)
+        patch.added_count += len(added_lines)
+
+    return patches
+
+
+def path_matches_glob(rel_path: str, pattern: str) -> bool:
+    rel = PurePosixPath(normalize_rel_path(rel_path))
+    normalized_pattern = normalize_rel_path(pattern)
+    return rel.match(normalized_pattern) or rel.as_posix() == normalized_pattern
+
+
+def matches_any_glob(rel_path: str, patterns: list[str]) -> bool:
+    return any(path_matches_glob(rel_path, pattern) for pattern in patterns)
+
+
+def is_test_file(rel_path: str) -> bool:
+    pure = PurePosixPath(normalize_rel_path(rel_path))
+    if pure.name.endswith("_test.go"):
+        return True
+    return any(part in {"tests", "benches", "fuzz"} for part in pure.parts)
+
+
+def is_production_loc_file(rel_path: str) -> bool:
+    pure = PurePosixPath(normalize_rel_path(rel_path))
+    if pure.suffix not in PRODUCTION_SUFFIXES:
+        return False
+    return not is_test_file(rel_path)
+
+
+def is_runtime_sensitive_path(rel_path: str) -> bool:
+    pure = PurePosixPath(normalize_rel_path(rel_path))
+    lower_parts = [part.lower() for part in pure.parts]
+    return any(
+        token in part
+        for token in RUNTIME_SENSITIVE_TOKENS
+        for part in lower_parts
+    )
+
+
+def count_production_loc(patches: dict[str, FilePatch]) -> int:
+    total = 0
+    for rel_path, patch in patches.items():
+        if is_production_loc_file(rel_path):
+            total += patch.added_count + patch.deleted_count
+    return total
+
+
+def is_comment_line(text: str) -> bool:
+    stripped = text.lstrip()
+    return any(stripped.startswith(prefix) for prefix in COMMENT_PREFIXES)
+
+
+def read_worktree_text(repo_root: Path, rel_path: str) -> str:
+    return (repo_root / rel_path).read_text(encoding="utf-8")
+
+
+def find_drop_block_ranges(text: str) -> list[tuple[int, int]]:
+    lines = text.splitlines()
+    ranges: list[tuple[int, int]] = []
+    tracking = False
+    started = False
+    start_line = 0
+    brace_depth = 0
+
+    for idx, line in enumerate(lines, start=1):
+        if not tracking and "Drop for" in line:
+            tracking = True
+
+        if not tracking:
+            continue
+
+        open_braces = line.count("{")
+        close_braces = line.count("}")
+
+        if not started and open_braces:
+            started = True
+            start_line = idx
+            brace_depth += open_braces - close_braces
+            if brace_depth <= 0:
+                ranges.append((start_line, idx))
+                tracking = False
+                started = False
+                brace_depth = 0
+            continue
+
+        if started:
+            brace_depth += open_braces - close_braces
+            if brace_depth <= 0:
+                ranges.append((start_line, idx))
+                tracking = False
+                started = False
+                brace_depth = 0
+
+    return ranges
+
+
+def line_in_ranges(line_number: int, ranges: list[tuple[int, int]]) -> bool:
+    return any(start <= line_number <= end for start, end in ranges)

--- a/tools/rubin_agent_contract.py
+++ b/tools/rubin_agent_contract.py
@@ -250,6 +250,10 @@ def validate_manifest_document(document: Any) -> dict[str, Any]:
                     errors.append(
                         f"$.required_tests[{idx}]: required test commands must be single-line"
                     )
+                if isinstance(command, str) and not command.strip():
+                    errors.append(
+                        f"$.required_tests[{idx}]: required test commands must contain non-whitespace text"
+                    )
 
     if (
         isinstance(document.get("target_production_loc"), int)
@@ -302,8 +306,39 @@ def resolve_diff_range(repo_root: Path, diff_range: str | None) -> str:
 
 
 def list_changed_files(repo_root: Path, diff_range: str) -> list[str]:
-    output = run_git(repo_root, ["diff", "--name-only", diff_range, "--"])
-    changed = {normalize_rel_path(line) for line in output.splitlines() if line.strip()}
+    output = run_git(
+        repo_root,
+        ["diff", "--name-status", "--find-renames", "-z", diff_range, "--"],
+    )
+    tokens = output.split("\0")
+    if tokens and tokens[-1] == "":
+        tokens.pop()
+    changed: set[str] = set()
+    idx = 0
+
+    while idx < len(tokens):
+        status = tokens[idx]
+        idx += 1
+        if not status:
+            continue
+
+        if status.startswith(("R", "C")):
+            if idx + 1 >= len(tokens):
+                raise GitCommandError(
+                    "git diff --name-status returned malformed rename/copy entry"
+                )
+            changed.add(normalize_rel_path(tokens[idx]))
+            changed.add(normalize_rel_path(tokens[idx + 1]))
+            idx += 2
+            continue
+
+        if idx >= len(tokens):
+            raise GitCommandError(
+                "git diff --name-status returned malformed changed-path entry"
+            )
+        changed.add(normalize_rel_path(tokens[idx]))
+        idx += 1
+
     changed.update(list_untracked_files(repo_root))
     return sorted(changed)
 

--- a/tools/rubin_agent_scope_guard.py
+++ b/tools/rubin_agent_scope_guard.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import sys
+
+from rubin_agent_contract import (
+    count_production_loc,
+    list_changed_files,
+    load_manifest,
+    matches_any_glob,
+    normalize_rel_path,
+    parse_diff_patches,
+    resolve_diff_range,
+)
+
+
+def evaluate_scope(manifest_path: str, diff_range: str | None = None) -> tuple[list[str], list[str]]:
+    manifest_path_resolved, repo_root, manifest = load_manifest(manifest_path)
+    resolved_diff_range = resolve_diff_range(repo_root, diff_range)
+
+    changed_files = list_changed_files(repo_root, resolved_diff_range)
+    allowed_files = {normalize_rel_path(path) for path in manifest["allowed_files"]}
+    manifest_rel = manifest_path_resolved.resolve().relative_to(repo_root.resolve())
+    allowed_files.add(normalize_rel_path(str(manifest_rel)))
+    allowed_globs = [normalize_rel_path(pattern) for pattern in manifest.get("allowed_globs", [])]
+    forbidden_globs = [
+        normalize_rel_path(pattern) for pattern in manifest.get("forbidden_globs", [])
+    ]
+
+    blockers: list[str] = []
+    warnings: list[str] = []
+
+    for rel_path in changed_files:
+        if forbidden_globs and matches_any_glob(rel_path, forbidden_globs):
+            blockers.append(
+                f"{rel_path}: touched forbidden surface declared in forbidden_globs"
+            )
+            continue
+        if rel_path in allowed_files:
+            continue
+        if allowed_globs and matches_any_glob(rel_path, allowed_globs):
+            continue
+        blockers.append(
+            f"{rel_path}: outside allowed_files/allowed_globs for {manifest['q_id']}"
+        )
+
+    production_loc = count_production_loc(parse_diff_patches(repo_root, resolved_diff_range))
+    target_loc = manifest.get("target_production_loc")
+    hard_loc = manifest["hard_production_loc"]
+    if isinstance(target_loc, int) and production_loc > target_loc:
+        warnings.append(
+            f"production diff is {production_loc} LOC, above target_production_loc={target_loc}"
+        )
+    if production_loc > hard_loc:
+        blockers.append(
+            f"production diff is {production_loc} LOC, above hard_production_loc={hard_loc}"
+        )
+
+    return blockers, warnings
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Fail-closed scope guard for repo-local Q manifests."
+    )
+    parser.add_argument("--q-manifest", required=True, help="Path to tools/agent_tasks/<Q-ID>.json")
+    parser.add_argument(
+        "--diff-range",
+        help="Optional git diff range; defaults to the current worktree against git merge-base origin/main HEAD",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        blockers, warnings = evaluate_scope(args.q_manifest, args.diff_range)
+    except Exception as exc:
+        print(f"BLOCKED: scope guard failed: {exc}")
+        return 1
+
+    for warning in warnings:
+        print(f"WARN: {warning}")
+
+    if blockers:
+        print("BLOCKED: scope guard found contract violations")
+        for blocker in blockers:
+            print(f"- {blocker}")
+        return 1
+
+    print("PASS: scope guard")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/rubin_agent_scope_guard.py
+++ b/tools/rubin_agent_scope_guard.py
@@ -6,6 +6,7 @@ import sys
 
 from rubin_agent_contract import (
     count_production_loc,
+    effective_forbidden_globs,
     list_changed_files,
     load_manifest,
     matches_any_glob,
@@ -22,20 +23,19 @@ def evaluate_scope(manifest_path: str, diff_range: str | None = None) -> tuple[l
     changed_files = list_changed_files(repo_root, resolved_diff_range)
     allowed_files = {normalize_rel_path(path) for path in manifest["allowed_files"]}
     manifest_rel = manifest_path_resolved.resolve().relative_to(repo_root.resolve())
-    allowed_files.add(normalize_rel_path(str(manifest_rel)))
+    manifest_rel_str = normalize_rel_path(str(manifest_rel))
+    allowed_files.add(manifest_rel_str)
     allowed_globs = [normalize_rel_path(pattern) for pattern in manifest.get("allowed_globs", [])]
-    forbidden_globs = [
-        normalize_rel_path(pattern) for pattern in manifest.get("forbidden_globs", [])
-    ]
+    forbidden_globs = effective_forbidden_globs(manifest)
 
     blockers: list[str] = []
     warnings: list[str] = []
 
     for rel_path in changed_files:
+        if rel_path == manifest_rel_str:
+            continue
         if forbidden_globs and matches_any_glob(rel_path, forbidden_globs):
-            blockers.append(
-                f"{rel_path}: touched forbidden surface declared in forbidden_globs"
-            )
+            blockers.append(f"{rel_path}: touched forbidden surface")
             continue
         if rel_path in allowed_files:
             continue

--- a/tools/rubin_agent_scope_guard.py
+++ b/tools/rubin_agent_scope_guard.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import argparse
-import sys
+from pathlib import Path
 
 from rubin_agent_contract import (
     count_production_loc,
@@ -16,7 +16,9 @@ from rubin_agent_contract import (
 )
 
 
-def evaluate_scope(manifest_path: str, diff_range: str | None = None) -> tuple[list[str], list[str]]:
+def evaluate_scope(
+    manifest_path: str | Path, diff_range: str | None = None
+) -> tuple[list[str], list[str]]:
     manifest_path_resolved, repo_root, manifest = load_manifest(manifest_path)
     resolved_diff_range = resolve_diff_range(repo_root, diff_range)
 

--- a/tools/rubin_invariant_scan.py
+++ b/tools/rubin_invariant_scan.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 
 import argparse
 import re
-import sys
+from pathlib import Path
 
 from rubin_agent_contract import (
     find_drop_block_ranges,
     is_comment_line,
+    is_production_loc_file,
     is_runtime_sensitive_path,
     is_test_file,
     line_in_ranges,
@@ -70,7 +71,7 @@ def extract_comment_fragments(text: str) -> list[str]:
 
 
 def scan_invariants(
-    manifest_path: str, diff_range: str | None = None, fast: bool = False
+    manifest_path: str | Path, diff_range: str | None = None, fast: bool = False
 ) -> list[str]:
     _, repo_root, _ = load_manifest(manifest_path)
     resolved_diff_range = resolve_diff_range(repo_root, diff_range)
@@ -81,13 +82,18 @@ def scan_invariants(
 
     for rel_path, patch in sorted(patches.items()):
         test_file = is_test_file(rel_path)
-        runtime_sensitive = is_runtime_sensitive_path(rel_path) and not test_file
+        production_file = is_production_loc_file(rel_path)
+        runtime_sensitive = (
+            production_file
+            and rel_path.endswith(".rs")
+            and is_runtime_sensitive_path(rel_path)
+        )
 
         for added in patch.added_lines:
             text = added.text
             location = f"{rel_path}:{added.number}"
 
-            if not test_file:
+            if production_file:
                 for pattern in ENV_KNOB_PATTERNS:
                     if pattern.search(text):
                         blockers.append(
@@ -96,7 +102,9 @@ def scan_invariants(
                         break
 
             comment_fragments = extract_comment_fragments(text)
-            if any(FILE_LINE_ANCHOR_RE.search(fragment) for fragment in comment_fragments):
+            if production_file and any(
+                FILE_LINE_ANCHOR_RE.search(fragment) for fragment in comment_fragments
+            ):
                 blockers.append(f"{location}: file:line anchor in added comment")
 
             if test_file:

--- a/tools/rubin_invariant_scan.py
+++ b/tools/rubin_invariant_scan.py
@@ -36,9 +36,9 @@ TEST_BRITTLE_PATTERNS = (
     re.compile(r"read-only", re.IGNORECASE),
     re.compile(r"\bchmod\s*\("),
 )
-RUNTIME_UNWRAP_RE = re.compile(r"(?:\.|::)(unwrap|expect)\s*\(")
+RUNTIME_UNWRAP_RE = re.compile(r"(?:\.\s*|::\s*)(unwrap|expect)\s*\(")
 DROP_PANIC_RE = re.compile(
-    r"\b(panic|todo|unimplemented)!\s*\(|(?:\.|::)(unwrap|expect)\s*\("
+    r"\b(panic|todo|unimplemented)\s*!\s*\(|(?:\.\s*|::\s*)(unwrap|expect)\s*\("
 )
 INLINE_COMMENT_PATTERNS = (
     re.compile(r"(^|[^:])(?P<comment>//.*)"),
@@ -46,6 +46,12 @@ INLINE_COMMENT_PATTERNS = (
     re.compile(r"(^|\s)(?P<comment>#.*)"),
     re.compile(r"(^|\s)(?P<comment>--.*)"),
 )
+RUST_INLINE_COMMENT_PATTERNS = (
+    re.compile(r"(^|[^:])(?P<comment>//.*)"),
+    re.compile(r"(?P<comment>/\*.*)"),
+)
+RUST_BLOCK_COMMENT_RE = re.compile(r"/\*.*?\*/")
+RUST_LINE_COMMENT_RE = re.compile(r"(^|[^:])//.*")
 
 
 def extract_comment_fragments(text: str) -> list[str]:
@@ -70,6 +76,21 @@ def extract_comment_fragments(text: str) -> list[str]:
     return fragments
 
 
+def strip_inline_comment_suffix(
+    text: str, patterns: tuple[re.Pattern[str], ...]
+) -> str:
+    sanitized = RUST_BLOCK_COMMENT_RE.sub("", text)
+    for pattern in patterns:
+        match = pattern.search(sanitized)
+        if match is None:
+            continue
+        sanitized = sanitized[:match.start("comment")]
+    line_match = RUST_LINE_COMMENT_RE.search(sanitized)
+    if line_match is not None:
+        sanitized = sanitized[: line_match.start()] + line_match.group(1)
+    return sanitized
+
+
 def scan_invariants(
     manifest_path: str | Path, diff_range: str | None = None, fast: bool = False
 ) -> list[str]:
@@ -91,6 +112,7 @@ def scan_invariants(
 
         for added in patch.added_lines:
             text = added.text
+            scan_text = strip_inline_comment_suffix(text, RUST_INLINE_COMMENT_PATTERNS)
             location = f"{rel_path}:{added.number}"
 
             if production_file:
@@ -117,7 +139,7 @@ def scan_invariants(
                         blockers.append(f"{location}: brittle test path or OS-string match")
                         break
 
-            if runtime_sensitive and not is_comment_line(text) and RUNTIME_UNWRAP_RE.search(text):
+            if runtime_sensitive and not is_comment_line(text) and RUNTIME_UNWRAP_RE.search(scan_text):
                 blockers.append(
                     f"{location}: unwrap/expect added in runtime-sensitive non-test path"
                 )
@@ -133,7 +155,8 @@ def scan_invariants(
             continue
 
         for added in patch.added_lines:
-            if line_in_ranges(added.number, drop_ranges) and DROP_PANIC_RE.search(added.text):
+            scan_text = strip_inline_comment_suffix(added.text, RUST_INLINE_COMMENT_PATTERNS)
+            if line_in_ranges(added.number, drop_ranges) and DROP_PANIC_RE.search(scan_text):
                 blockers.append(
                     f"{rel_path}:{added.number}: panic-like cleanup added inside impl Drop"
                 )

--- a/tools/rubin_invariant_scan.py
+++ b/tools/rubin_invariant_scan.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+
+from rubin_agent_contract import (
+    find_drop_block_ranges,
+    is_comment_line,
+    is_runtime_sensitive_path,
+    is_test_file,
+    line_in_ranges,
+    load_manifest,
+    parse_diff_patches,
+    read_worktree_text,
+    resolve_diff_range,
+)
+
+
+ENV_KNOB_PATTERNS = (
+    re.compile(r"\bRUBIN_TEST_[A-Z0-9_]*\b"),
+    re.compile(r"\b[A-Z0-9]+_TEST_[A-Z0-9_]+\b"),
+)
+FILE_LINE_ANCHOR_RE = re.compile(
+    r"\b[\w./-]+\.(?:rs|go|py|sh|ts|js|tsx|jsx|lean):\d+\b"
+)
+TEST_CWD_PATTERNS = (
+    re.compile(r"\bstd::env::set_current_dir\s*\("),
+    re.compile(r"\bos\.Chdir\s*\("),
+)
+TEST_BRITTLE_PATTERNS = (
+    re.compile(r"/nonexistent"),
+    re.compile(r"Permission denied"),
+    re.compile(r"read-only", re.IGNORECASE),
+    re.compile(r"\bchmod\s*\("),
+)
+RUNTIME_UNWRAP_RE = re.compile(r"\.(unwrap|expect)\s*\(")
+DROP_PANIC_RE = re.compile(r"\b(panic|todo|unimplemented)!\s*\(|\.(unwrap|expect)\s*\(")
+
+
+def scan_invariants(
+    manifest_path: str, diff_range: str | None = None, fast: bool = False
+) -> list[str]:
+    _, repo_root, _ = load_manifest(manifest_path)
+    resolved_diff_range = resolve_diff_range(repo_root, diff_range)
+    patches = parse_diff_patches(repo_root, resolved_diff_range)
+
+    blockers: list[str] = []
+    drop_ranges_cache: dict[str, list[tuple[int, int]]] = {}
+
+    for rel_path, patch in sorted(patches.items()):
+        test_file = is_test_file(rel_path)
+        runtime_sensitive = is_runtime_sensitive_path(rel_path) and not test_file
+
+        for added in patch.added_lines:
+            text = added.text
+            location = f"{rel_path}:{added.number}"
+
+            if not test_file:
+                for pattern in ENV_KNOB_PATTERNS:
+                    if pattern.search(text):
+                        blockers.append(
+                            f"{location}: hidden test knob in production path"
+                        )
+                        break
+
+            if is_comment_line(text) and FILE_LINE_ANCHOR_RE.search(text):
+                blockers.append(f"{location}: file:line anchor in added comment")
+
+            if test_file:
+                for pattern in TEST_CWD_PATTERNS:
+                    if pattern.search(text):
+                        blockers.append(f"{location}: brittle test CWD mutation")
+                        break
+                for pattern in TEST_BRITTLE_PATTERNS:
+                    if pattern.search(text):
+                        blockers.append(f"{location}: brittle test path or OS-string match")
+                        break
+
+            if runtime_sensitive and not is_comment_line(text) and RUNTIME_UNWRAP_RE.search(text):
+                blockers.append(
+                    f"{location}: unwrap/expect added in runtime-sensitive non-test path"
+                )
+
+        if fast or test_file or not rel_path.endswith(".rs"):
+            continue
+
+        try:
+            drop_ranges = drop_ranges_cache.setdefault(
+                rel_path, find_drop_block_ranges(read_worktree_text(repo_root, rel_path))
+            )
+        except FileNotFoundError:
+            continue
+
+        for added in patch.added_lines:
+            if line_in_ranges(added.number, drop_ranges) and DROP_PANIC_RE.search(added.text):
+                blockers.append(
+                    f"{rel_path}:{added.number}: panic-like cleanup added inside impl Drop"
+                )
+
+    return blockers
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="High-confidence invariant scan for repo-local Q manifests."
+    )
+    parser.add_argument("--q-manifest", required=True, help="Path to tools/agent_tasks/<Q-ID>.json")
+    parser.add_argument(
+        "--diff-range",
+        help="Optional git diff range; defaults to the current worktree against git merge-base origin/main HEAD",
+    )
+    parser.add_argument(
+        "--fast",
+        action="store_true",
+        help="Skip full-file impl Drop context checks and scan added lines only.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        blockers = scan_invariants(args.q_manifest, args.diff_range, args.fast)
+    except Exception as exc:
+        print(f"BLOCKED: invariant scan failed: {exc}")
+        return 1
+
+    if blockers:
+        print("BLOCKED: invariant scan found violations")
+        for blocker in blockers:
+            print(f"- {blocker}")
+        return 1
+
+    print("PASS: invariant scan")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/rubin_invariant_scan.py
+++ b/tools/rubin_invariant_scan.py
@@ -35,8 +35,10 @@ TEST_BRITTLE_PATTERNS = (
     re.compile(r"read-only", re.IGNORECASE),
     re.compile(r"\bchmod\s*\("),
 )
-RUNTIME_UNWRAP_RE = re.compile(r"\.(unwrap|expect)\s*\(")
-DROP_PANIC_RE = re.compile(r"\b(panic|todo|unimplemented)!\s*\(|\.(unwrap|expect)\s*\(")
+RUNTIME_UNWRAP_RE = re.compile(r"(?:\.|::)(unwrap|expect)\s*\(")
+DROP_PANIC_RE = re.compile(
+    r"\b(panic|todo|unimplemented)!\s*\(|(?:\.|::)(unwrap|expect)\s*\("
+)
 INLINE_COMMENT_PATTERNS = (
     re.compile(r"(^|[^:])(?P<comment>//.*)"),
     re.compile(r"(?P<comment>/\*.*)"),

--- a/tools/rubin_invariant_scan.py
+++ b/tools/rubin_invariant_scan.py
@@ -37,6 +37,34 @@ TEST_BRITTLE_PATTERNS = (
 )
 RUNTIME_UNWRAP_RE = re.compile(r"\.(unwrap|expect)\s*\(")
 DROP_PANIC_RE = re.compile(r"\b(panic|todo|unimplemented)!\s*\(|\.(unwrap|expect)\s*\(")
+INLINE_COMMENT_PATTERNS = (
+    re.compile(r"(^|[^:])(?P<comment>//.*)"),
+    re.compile(r"(?P<comment>/\*.*)"),
+    re.compile(r"(^|\s)(?P<comment>#.*)"),
+    re.compile(r"(^|\s)(?P<comment>--.*)"),
+)
+
+
+def extract_comment_fragments(text: str) -> list[str]:
+    fragments: list[str] = []
+    stripped = text.lstrip()
+
+    if (
+        is_comment_line(text)
+        or stripped.startswith("* ")
+        or stripped == "*"
+    ):
+        fragments.append(stripped)
+
+    for pattern in INLINE_COMMENT_PATTERNS:
+        match = pattern.search(text)
+        if match is None:
+            continue
+        fragment = match.group("comment")
+        if fragment and fragment not in fragments:
+            fragments.append(fragment)
+
+    return fragments
 
 
 def scan_invariants(
@@ -65,7 +93,8 @@ def scan_invariants(
                         )
                         break
 
-            if is_comment_line(text) and FILE_LINE_ANCHOR_RE.search(text):
+            comment_fragments = extract_comment_fragments(text)
+            if any(FILE_LINE_ANCHOR_RE.search(fragment) for fragment in comment_fragments):
                 blockers.append(f"{location}: file:line anchor in added comment")
 
             if test_file:

--- a/tools/rubin_q_preflight.sh
+++ b/tools/rubin_q_preflight.sh
@@ -57,7 +57,12 @@ if ! python3 "$SCRIPT_DIR/rubin_invariant_scan.py" --q-manifest "$MANIFEST_PATH"
   exit 1
 fi
 
-COMMAND_LIST=$(mktemp)
+TMP_ROOT=${TMPDIR:-/tmp}
+TMP_ROOT=${TMP_ROOT%/}
+if [ -z "$TMP_ROOT" ]; then
+  TMP_ROOT=/
+fi
+COMMAND_LIST=$(mktemp "$TMP_ROOT/rubin-q-preflight.XXXXXX")
 trap 'rm -f "$COMMAND_LIST"' EXIT HUP INT TERM
 
 python3 - "$MANIFEST_PATH" > "$COMMAND_LIST" <<'PY'

--- a/tools/rubin_q_preflight.sh
+++ b/tools/rubin_q_preflight.sh
@@ -65,12 +65,15 @@ fi
 COMMAND_LIST=$(mktemp "$TMP_ROOT/rubin-q-preflight.XXXXXX")
 trap 'rm -f "$COMMAND_LIST"' EXIT HUP INT TERM
 
-python3 - "$MANIFEST_PATH" > "$COMMAND_LIST" <<'PY'
-import json
+python3 - "$SCRIPT_DIR" "$MANIFEST_PATH" > "$COMMAND_LIST" <<'PY'
 from pathlib import Path
 import sys
 
-manifest = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+sys.path.insert(0, sys.argv[1])
+
+from rubin_agent_contract import load_manifest
+
+manifest = load_manifest(Path(sys.argv[2]))[2]
 for command in manifest["required_tests"]:
     print(command)
 PY

--- a/tools/rubin_q_preflight.sh
+++ b/tools/rubin_q_preflight.sh
@@ -1,0 +1,85 @@
+#!/bin/sh
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+MANIFEST_ARG=${1:-}
+
+if [ -z "$MANIFEST_ARG" ]; then
+  echo "BLOCKED: usage: tools/rubin_q_preflight.sh tools/agent_tasks/<Q-ID>.json"
+  exit 1
+fi
+
+MANIFEST_PATH=$(python3 - "$MANIFEST_ARG" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1]).expanduser()
+if not path.is_absolute():
+    path = (Path.cwd() / path).resolve()
+print(path)
+PY
+)
+
+if [ ! -f "$MANIFEST_PATH" ]; then
+  echo "BLOCKED: manifest not found: $MANIFEST_PATH"
+  exit 1
+fi
+
+REPO_ROOT=$(git -C "$(dirname "$MANIFEST_PATH")" rev-parse --show-toplevel 2>/dev/null || true)
+if [ -z "$REPO_ROOT" ]; then
+  echo "BLOCKED: unable to discover repo root for manifest $MANIFEST_PATH"
+  exit 1
+fi
+
+if ! python3 - "$SCRIPT_DIR" "$MANIFEST_PATH" <<'PY'
+from pathlib import Path
+import sys
+
+sys.path.insert(0, sys.argv[1])
+
+from rubin_agent_contract import load_manifest
+
+load_manifest(Path(sys.argv[2]))
+print("PASS: manifest schema")
+PY
+then
+  echo "BLOCKED: q preflight"
+  exit 1
+fi
+
+if ! python3 "$SCRIPT_DIR/rubin_agent_scope_guard.py" --q-manifest "$MANIFEST_PATH"; then
+  echo "BLOCKED: q preflight"
+  exit 1
+fi
+
+if ! python3 "$SCRIPT_DIR/rubin_invariant_scan.py" --q-manifest "$MANIFEST_PATH"; then
+  echo "BLOCKED: q preflight"
+  exit 1
+fi
+
+COMMAND_LIST=$(mktemp)
+trap 'rm -f "$COMMAND_LIST"' EXIT HUP INT TERM
+
+python3 - "$MANIFEST_PATH" > "$COMMAND_LIST" <<'PY'
+import json
+from pathlib import Path
+import sys
+
+manifest = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+for command in manifest["required_tests"]:
+    print(command)
+PY
+
+while IFS= read -r command; do
+  [ -n "$command" ] || continue
+  echo "RUN: $command"
+  if ! (cd "$REPO_ROOT" && sh -c "$command"); then
+    echo "BLOCKED: q preflight"
+    exit 1
+  fi
+done < "$COMMAND_LIST"
+
+rm -f "$COMMAND_LIST"
+trap - EXIT HUP INT TERM
+
+echo "PASS: q preflight"

--- a/tools/tests/test_rubin_agent_contract.py
+++ b/tools/tests/test_rubin_agent_contract.py
@@ -67,6 +67,50 @@ class ManifestContractTests(unittest.TestCase):
 
         self.assertIn("missing canonical invariant(s)", str(ctx.exception))
 
+    def test_manifest_rejects_non_object_root(self):
+        with self.assertRaises(m.ManifestValidationError) as ctx:
+            m.validate_manifest_document(["not", "an", "object"])
+
+        self.assertIn("expected object", str(ctx.exception))
+
+    def test_manifest_rejects_multiline_required_test(self):
+        manifest = {
+            "q_id": "Q-IMPL-NODE-TEST-01",
+            "owner_area": "node",
+            "allowed_files": ["clients/go/node/sync.go"],
+            "required_tests": ["printf ok\nprintf nope"],
+            "hard_production_loc": 250,
+            "required_invariants": list(m.CANONICAL_INVARIANTS),
+        }
+
+        with self.assertRaises(m.ManifestValidationError) as ctx:
+            m.validate_manifest_document(manifest)
+
+        self.assertIn("required test commands must be single-line", str(ctx.exception))
+
+    def test_manifest_rejects_non_string_required_invariant_entries(self):
+        manifest = {
+            "q_id": "Q-IMPL-NODE-TEST-01",
+            "owner_area": "node",
+            "allowed_files": ["clients/go/node/sync.go"],
+            "required_tests": ["printf ok"],
+            "hard_production_loc": 250,
+            "required_invariants": list(m.CANONICAL_INVARIANTS[:-1]) + [["bad"]],
+        }
+
+        with self.assertRaises(m.ManifestValidationError) as ctx:
+            m.validate_manifest_document(manifest)
+
+        self.assertIn("entries must all be strings", str(ctx.exception))
+
+    def test_root_anchored_globs_match_only_from_repo_root(self):
+        self.assertTrue(
+            m.path_matches_glob("clients/go/node/sync.go", "clients/**")
+        )
+        self.assertFalse(
+            m.path_matches_glob("vendor/clients/go/node/sync.go", "clients/**")
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/tests/test_rubin_agent_contract.py
+++ b/tools/tests/test_rubin_agent_contract.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import tempfile
 import sys
 import unittest
 
@@ -110,6 +111,16 @@ class ManifestContractTests(unittest.TestCase):
         self.assertFalse(
             m.path_matches_glob("vendor/clients/go/node/sync.go", "clients/**")
         )
+
+    def test_load_json_rejects_invalid_utf8(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "bad.json"
+            path.write_bytes(b"\xff\xfe\x00")
+
+            with self.assertRaises(m.ManifestValidationError) as ctx:
+                m.load_json(path)
+
+        self.assertIn("invalid utf-8", str(ctx.exception))
 
 
 if __name__ == "__main__":

--- a/tools/tests/test_rubin_agent_contract.py
+++ b/tools/tests/test_rubin_agent_contract.py
@@ -153,6 +153,18 @@ class ManifestContractTests(unittest.TestCase):
 
         self.assertIn("malformed changed-path entry", str(ctx.exception))
 
+    def test_find_drop_block_ranges_accepts_qualified_drop_impl(self):
+        text = (
+            "struct Dropper;\n\n"
+            "impl std::ops::Drop for Dropper {\n"
+            "    fn drop(&mut self) {\n"
+            "        panic!(\"boom\");\n"
+            "    }\n"
+            "}\n"
+        )
+
+        self.assertEqual(m.find_drop_block_ranges(text), [(3, 7)])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/tests/test_rubin_agent_contract.py
+++ b/tools/tests/test_rubin_agent_contract.py
@@ -6,6 +6,7 @@ import sys
 import unittest
 
 from pathlib import Path
+from unittest import mock
 
 TOOLS_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(TOOLS_DIR))
@@ -89,6 +90,24 @@ class ManifestContractTests(unittest.TestCase):
 
         self.assertIn("required test commands must be single-line", str(ctx.exception))
 
+    def test_manifest_rejects_whitespace_only_required_test(self):
+        manifest = {
+            "q_id": "Q-IMPL-NODE-TEST-01",
+            "owner_area": "node",
+            "allowed_files": ["clients/go/node/sync.go"],
+            "required_tests": ["   "],
+            "hard_production_loc": 250,
+            "required_invariants": list(m.CANONICAL_INVARIANTS),
+        }
+
+        with self.assertRaises(m.ManifestValidationError) as ctx:
+            m.validate_manifest_document(manifest)
+
+        self.assertIn(
+            "required test commands must contain non-whitespace text",
+            str(ctx.exception),
+        )
+
     def test_manifest_rejects_non_string_required_invariant_entries(self):
         manifest = {
             "q_id": "Q-IMPL-NODE-TEST-01",
@@ -121,6 +140,14 @@ class ManifestContractTests(unittest.TestCase):
                 m.load_json(path)
 
         self.assertIn("invalid utf-8", str(ctx.exception))
+
+    def test_list_changed_files_rejects_truncated_name_status_stream(self):
+        with mock.patch.object(m, "run_git", return_value="M\0"):
+            with mock.patch.object(m, "list_untracked_files", return_value=[]):
+                with self.assertRaises(m.GitCommandError) as ctx:
+                    m.list_changed_files(Path("/tmp/repo"), "HEAD")
+
+        self.assertIn("malformed changed-path entry", str(ctx.exception))
 
 
 if __name__ == "__main__":

--- a/tools/tests/test_rubin_agent_contract.py
+++ b/tools/tests/test_rubin_agent_contract.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+import unittest
+
+from pathlib import Path
+
+TOOLS_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(TOOLS_DIR))
+
+import rubin_agent_contract as m
+
+
+class ManifestContractTests(unittest.TestCase):
+    def test_runtime_manifest_schema_accepts_runtime_q(self):
+        manifest = {
+            "q_id": "Q-IMPL-NODE-TEST-01",
+            "owner_area": "node",
+            "allowed_files": ["clients/go/node/sync.go"],
+            "allowed_globs": ["clients/go/node/**"],
+            "forbidden_globs": [
+                ".cursor/**",
+                ".claude/**",
+                ".github/workflows/**",
+                "tools/**",
+                "docs/**",
+            ],
+            "required_tests": ["printf runtime-ok"],
+            "target_production_loc": 200,
+            "hard_production_loc": 250,
+            "required_invariants": list(m.CANONICAL_INVARIANTS),
+        }
+
+        validated = m.validate_manifest_document(manifest)
+
+        self.assertEqual(validated["owner_area"], "node")
+
+    def test_runtime_manifest_schema_accepts_tooling_q(self):
+        manifest = {
+            "q_id": "Q-TOOLING-LINT-01",
+            "owner_area": "tooling",
+            "allowed_files": ["tools/check_pre_commit_hygiene.py"],
+            "allowed_globs": ["tools/**"],
+            "forbidden_globs": [".cursor/**", ".claude/**"],
+            "required_tests": ["printf tooling-ok"],
+            "hard_production_loc": 80,
+            "required_invariants": list(m.CANONICAL_INVARIANTS),
+        }
+
+        validated = m.validate_manifest_document(manifest)
+
+        self.assertEqual(validated["owner_area"], "tooling")
+
+    def test_manifest_rejects_missing_canonical_invariant(self):
+        manifest = {
+            "q_id": "Q-IMPL-NODE-TEST-01",
+            "owner_area": "node",
+            "allowed_files": ["clients/go/node/sync.go"],
+            "required_tests": ["printf ok"],
+            "hard_production_loc": 250,
+            "required_invariants": list(m.CANONICAL_INVARIANTS[:-1]),
+        }
+
+        with self.assertRaises(m.ManifestValidationError) as ctx:
+            m.validate_manifest_document(manifest)
+
+        self.assertIn("missing canonical invariant(s)", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_rubin_agent_contract.py
+++ b/tools/tests/test_rubin_agent_contract.py
@@ -131,6 +131,10 @@ class ManifestContractTests(unittest.TestCase):
             m.path_matches_glob("vendor/clients/go/node/sync.go", "clients/**")
         )
 
+    def test_double_star_slash_glob_matches_repo_root_files(self):
+        self.assertTrue(m.path_matches_glob("README.md", "**/*.md"))
+        self.assertTrue(m.path_matches_glob("docs/guide.md", "**/*.md"))
+
     def test_load_json_rejects_invalid_utf8(self):
         with tempfile.TemporaryDirectory() as td:
             path = Path(td) / "bad.json"

--- a/tools/tests/test_rubin_agent_scope_guard.py
+++ b/tools/tests/test_rubin_agent_scope_guard.py
@@ -12,7 +12,7 @@ TOOLS_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(TOOLS_DIR))
 
 import rubin_agent_scope_guard as m
-from rubin_agent_contract import CANONICAL_INVARIANTS
+from rubin_agent_contract import CANONICAL_INVARIANTS, GitCommandError
 
 
 def run(cmd: list[str], cwd: Path) -> str:
@@ -33,6 +33,7 @@ def init_repo() -> tuple[tempfile.TemporaryDirectory[str], Path]:
     run(["git", "init"], root)
     run(["git", "config", "user.name", "Test User"], root)
     run(["git", "config", "user.email", "test@example.com"], root)
+    run(["git", "config", "commit.gpgsign", "false"], root)
     run(["git", "branch", "-M", "main"], root)
     (root / "tools" / "agent_tasks").mkdir(parents=True, exist_ok=True)
     (root / "clients" / "go" / "node").mkdir(parents=True, exist_ok=True)
@@ -121,7 +122,7 @@ class ScopeGuardTests(unittest.TestCase):
         manifest = self.write_manifest(self.runtime_manifest())
         run(["git", "update-ref", "-d", "refs/remotes/origin/main"], self.repo_root)
 
-        with self.assertRaises(Exception) as ctx:
+        with self.assertRaises(GitCommandError) as ctx:
             m.evaluate_scope(manifest, None)
 
         self.assertIn("origin/main", str(ctx.exception))
@@ -135,6 +136,28 @@ class ScopeGuardTests(unittest.TestCase):
 
         self.assertFalse(warnings)
         self.assertTrue(any("outside allowed_files/allowed_globs" in item for item in blockers))
+
+    def test_runtime_defaults_enforce_forbidden_globs_when_manifest_omits_them(self):
+        payload = self.runtime_manifest()
+        payload.pop("forbidden_globs")
+        manifest = self.write_manifest(payload)
+        touched = self.repo_root / "docs" / "note.md"
+        touched.write_text("runtime drift\n", encoding="utf-8")
+
+        blockers, warnings = m.evaluate_scope(manifest, None)
+
+        self.assertFalse(warnings)
+        self.assertTrue(any("forbidden surface" in item for item in blockers))
+
+    def test_runtime_defaults_allow_manifest_control_plane_artifact(self):
+        payload = self.runtime_manifest()
+        payload.pop("forbidden_globs")
+        manifest = self.write_manifest(payload)
+
+        blockers, warnings = m.evaluate_scope(manifest, None)
+
+        self.assertFalse(warnings)
+        self.assertFalse(blockers)
 
 
 if __name__ == "__main__":

--- a/tools/tests/test_rubin_agent_scope_guard.py
+++ b/tools/tests/test_rubin_agent_scope_guard.py
@@ -159,6 +159,30 @@ class ScopeGuardTests(unittest.TestCase):
         self.assertFalse(warnings)
         self.assertFalse(blockers)
 
+    def test_fails_on_rename_from_forbidden_source_path(self):
+        payload = self.runtime_manifest()
+        payload["allowed_globs"] = ["clients/go/node/**"]
+        manifest = self.write_manifest(payload)
+        run(
+            ["git", "mv", "docs/note.md", "clients/go/node/note.md"],
+            self.repo_root,
+        )
+        changed_files = m.list_changed_files(self.repo_root, "HEAD")
+
+        blockers, warnings = m.evaluate_scope(manifest, "HEAD")
+
+        self.assertFalse(warnings)
+        self.assertIn("docs/note.md", changed_files)
+        self.assertIn("clients/go/node/note.md", changed_files)
+        self.assertTrue(
+            any("docs/note.md: touched forbidden surface" == item for item in blockers),
+            msg=blockers,
+        )
+        self.assertFalse(
+            any("clients/go/node/note.md" in item for item in blockers),
+            msg=blockers,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/tests/test_rubin_agent_scope_guard.py
+++ b/tools/tests/test_rubin_agent_scope_guard.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+TOOLS_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(TOOLS_DIR))
+
+import rubin_agent_scope_guard as m
+from rubin_agent_contract import CANONICAL_INVARIANTS
+
+
+def run(cmd: list[str], cwd: Path) -> str:
+    result = subprocess.run(
+        cmd,
+        cwd=cwd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def init_repo() -> tuple[tempfile.TemporaryDirectory[str], Path]:
+    td = tempfile.TemporaryDirectory()
+    root = Path(td.name)
+    run(["git", "init"], root)
+    run(["git", "config", "user.name", "Test User"], root)
+    run(["git", "config", "user.email", "test@example.com"], root)
+    run(["git", "branch", "-M", "main"], root)
+    (root / "tools" / "agent_tasks").mkdir(parents=True, exist_ok=True)
+    (root / "clients" / "go" / "node").mkdir(parents=True, exist_ok=True)
+    (root / "clients" / "rust" / "crates" / "rubin-node" / "src").mkdir(parents=True, exist_ok=True)
+    (root / "docs").mkdir(parents=True, exist_ok=True)
+    (root / "clients" / "go" / "node" / "sync.go").write_text("package node\n", encoding="utf-8")
+    (root / "clients" / "rust" / "crates" / "rubin-node" / "src" / "p2p_runtime.rs").write_text(
+        "pub fn relay() {}\n",
+        encoding="utf-8",
+    )
+    (root / "docs" / "note.md").write_text("baseline\n", encoding="utf-8")
+    run(["git", "add", "."], root)
+    run(["git", "commit", "-m", "baseline"], root)
+    head = run(["git", "rev-parse", "HEAD"], root)
+    run(["git", "update-ref", "refs/remotes/origin/main", head], root)
+    return td, root
+
+
+class ScopeGuardTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td, self.repo_root = init_repo()
+        self.addCleanup(self._td.cleanup)
+
+    def write_manifest(self, payload: dict[str, object]) -> Path:
+        path = self.repo_root / "tools" / "agent_tasks" / "Q-TEST.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        return path
+
+    def runtime_manifest(self) -> dict[str, object]:
+        return {
+            "q_id": "Q-IMPL-NODE-TEST-01",
+            "owner_area": "node",
+            "allowed_files": ["clients/go/node/sync.go"],
+            "allowed_globs": [],
+            "forbidden_globs": [
+                ".cursor/**",
+                ".claude/**",
+                ".github/workflows/**",
+                "tools/**",
+                "docs/**",
+            ],
+            "required_tests": ["printf ok"],
+            "target_production_loc": 10,
+            "hard_production_loc": 20,
+            "required_invariants": list(CANONICAL_INVARIANTS),
+        }
+
+    def test_fails_on_file_outside_allowed_files(self):
+        manifest = self.write_manifest(self.runtime_manifest())
+        extra = self.repo_root / "clients" / "rust" / "crates" / "rubin-node" / "src" / "p2p_runtime.rs"
+        extra.write_text("pub fn drift() {\n    let _x = 1;\n}\n", encoding="utf-8")
+
+        blockers, warnings = m.evaluate_scope(manifest, "HEAD")
+
+        self.assertFalse(warnings)
+        self.assertTrue(any("outside allowed_files/allowed_globs" in item for item in blockers))
+
+    def test_fails_on_default_forbidden_glob_touch(self):
+        manifest = self.write_manifest(self.runtime_manifest())
+        touched = self.repo_root / "docs" / "note.md"
+        touched.write_text("drift\nmore drift\n", encoding="utf-8")
+
+        blockers, warnings = m.evaluate_scope(manifest, "HEAD")
+
+        self.assertFalse(warnings)
+        self.assertTrue(any("forbidden surface" in item for item in blockers))
+
+    def test_warns_over_target_loc_and_fails_over_hard_loc(self):
+        manifest = self.write_manifest(self.runtime_manifest())
+        payload = json.loads(manifest.read_text(encoding="utf-8"))
+        payload["target_production_loc"] = 3
+        payload["hard_production_loc"] = 5
+        manifest.write_text(json.dumps(payload), encoding="utf-8")
+        target = self.repo_root / "clients" / "go" / "node" / "sync.go"
+        target.write_text(
+            "package node\n\nfunc A() {}\nfunc B() {}\nfunc C() {}\nfunc D() {}\nfunc E() {}\n",
+            encoding="utf-8",
+        )
+
+        blockers, warnings = m.evaluate_scope(manifest, "HEAD")
+
+        self.assertTrue(any("above target_production_loc" in item for item in warnings))
+        self.assertTrue(any("above hard_production_loc" in item for item in blockers))
+
+    def test_fails_when_origin_main_missing_for_default_diff_range(self):
+        manifest = self.write_manifest(self.runtime_manifest())
+        run(["git", "update-ref", "-d", "refs/remotes/origin/main"], self.repo_root)
+
+        with self.assertRaises(Exception) as ctx:
+            m.evaluate_scope(manifest, None)
+
+        self.assertIn("origin/main", str(ctx.exception))
+
+    def test_default_diff_catches_untracked_file_outside_scope(self):
+        manifest = self.write_manifest(self.runtime_manifest())
+        extra = self.repo_root / "clients" / "rust" / "crates" / "rubin-node" / "src" / "new_sync.rs"
+        extra.write_text("pub fn drift() {}\n", encoding="utf-8")
+
+        blockers, warnings = m.evaluate_scope(manifest, None)
+
+        self.assertFalse(warnings)
+        self.assertTrue(any("outside allowed_files/allowed_globs" in item for item in blockers))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_rubin_invariant_scan.py
+++ b/tools/tests/test_rubin_invariant_scan.py
@@ -33,6 +33,7 @@ def init_repo() -> tuple[tempfile.TemporaryDirectory[str], Path]:
     run(["git", "init"], root)
     run(["git", "config", "user.name", "Test User"], root)
     run(["git", "config", "user.email", "test@example.com"], root)
+    run(["git", "config", "commit.gpgsign", "false"], root)
     run(["git", "branch", "-M", "main"], root)
     (root / "tools" / "agent_tasks").mkdir(parents=True, exist_ok=True)
     (root / "clients" / "go" / "node").mkdir(parents=True, exist_ok=True)
@@ -130,6 +131,17 @@ class InvariantScanTests(unittest.TestCase):
         target = self.repo_root / "clients" / "rust" / "crates" / "rubin-node" / "src" / "p2p_runtime.rs"
         target.write_text(
             "pub fn relay() {\n    let _value = Some(1).unwrap();\n}\n",
+            encoding="utf-8",
+        )
+
+        blockers = self.scan()
+
+        self.assertTrue(any("unwrap/expect added in runtime-sensitive" in item for item in blockers))
+
+    def test_fails_on_dereference_line_with_unwrap(self):
+        target = self.repo_root / "clients" / "rust" / "crates" / "rubin-node" / "src" / "p2p_runtime.rs"
+        target.write_text(
+            "pub fn relay(slot: &mut Option<i32>) {\n    *slot = Some(1).unwrap();\n}\n",
             encoding="utf-8",
         )
 

--- a/tools/tests/test_rubin_invariant_scan.py
+++ b/tools/tests/test_rubin_invariant_scan.py
@@ -40,6 +40,7 @@ def init_repo() -> tuple[tempfile.TemporaryDirectory[str], Path]:
     (root / "clients" / "go" / "node" / "tests").mkdir(parents=True, exist_ok=True)
     (root / "clients" / "rust" / "crates" / "rubin-node" / "src").mkdir(parents=True, exist_ok=True)
     (root / "clients" / "rust" / "crates" / "rubin-node" / "tests").mkdir(parents=True, exist_ok=True)
+    (root / "docs").mkdir(parents=True, exist_ok=True)
     (root / "clients" / "go" / "node" / "sync.go").write_text("package node\n", encoding="utf-8")
     (root / "clients" / "go" / "node" / "tests" / "sync_test.go").write_text(
         "package tests\n",
@@ -61,6 +62,7 @@ def init_repo() -> tuple[tempfile.TemporaryDirectory[str], Path]:
         "#[test]\nfn ok() {}\n",
         encoding="utf-8",
     )
+    (root / "docs" / "sync-guide.md").write_text("# Guide\n", encoding="utf-8")
     run(["git", "add", "."], root)
     run(["git", "commit", "-m", "baseline"], root)
     head = run(["git", "rev-parse", "HEAD"], root)
@@ -225,6 +227,28 @@ class InvariantScanTests(unittest.TestCase):
         blockers = self.scan()
 
         self.assertTrue(any("brittle test path or OS-string match" in item for item in blockers))
+
+    def test_does_not_flag_non_code_docs_examples(self):
+        target = self.repo_root / "docs" / "sync-guide.md"
+        target.write_text(
+            "# see p2p_runtime.rs:123\nRUBIN_TEST_ONLY\nOption::unwrap(value)\n",
+            encoding="utf-8",
+        )
+
+        blockers = self.scan()
+
+        self.assertFalse(blockers)
+
+    def test_does_not_treat_generic_drop_bounds_as_impl_drop(self):
+        target = self.repo_root / "clients" / "rust" / "crates" / "rubin-node" / "src" / "dropper.rs"
+        target.write_text(
+            "struct Wrapper<T>(T);\n\nimpl<T: Drop> Wrapper<T> {\n    fn demo(&self) {\n        let _value = Some(1).unwrap();\n    }\n}\n",
+            encoding="utf-8",
+        )
+
+        blockers = self.scan()
+
+        self.assertFalse(any("panic-like cleanup added inside impl Drop" in item for item in blockers))
 
 
 if __name__ == "__main__":

--- a/tools/tests/test_rubin_invariant_scan.py
+++ b/tools/tests/test_rubin_invariant_scan.py
@@ -184,6 +184,17 @@ class InvariantScanTests(unittest.TestCase):
 
         self.assertTrue(any("unwrap/expect added in runtime-sensitive" in item for item in blockers))
 
+    def test_fails_on_whitespace_separated_unwrap_in_runtime_sensitive_path(self):
+        target = self.repo_root / "clients" / "rust" / "crates" / "rubin-node" / "src" / "p2p_runtime.rs"
+        target.write_text(
+            "pub fn relay(value: Option<i32>) {\n    let _value = Option :: unwrap(value);\n    let _copy = value . expect(\"boom\");\n}\n",
+            encoding="utf-8",
+        )
+
+        blockers = self.scan()
+
+        self.assertTrue(any("unwrap/expect added in runtime-sensitive" in item for item in blockers))
+
     def test_fails_on_panic_in_drop(self):
         target = self.repo_root / "clients" / "rust" / "crates" / "rubin-node" / "src" / "dropper.rs"
         target.write_text(
@@ -194,6 +205,39 @@ class InvariantScanTests(unittest.TestCase):
         blockers = self.scan()
 
         self.assertTrue(any("panic-like cleanup added inside impl Drop" in item for item in blockers))
+
+    def test_fails_on_whitespace_panic_in_qualified_drop_impl(self):
+        target = self.repo_root / "clients" / "rust" / "crates" / "rubin-node" / "src" / "dropper.rs"
+        target.write_text(
+            "struct Dropper;\n\nimpl std::ops::Drop for Dropper {\n    fn drop(&mut self) {\n        panic ! (\"boom\");\n    }\n}\n",
+            encoding="utf-8",
+        )
+
+        blockers = self.scan()
+
+        self.assertTrue(any("panic-like cleanup added inside impl Drop" in item for item in blockers))
+
+    def test_does_not_flag_inline_comment_mentions_of_unwrap(self):
+        target = self.repo_root / "clients" / "rust" / "crates" / "rubin-node" / "src" / "p2p_runtime.rs"
+        target.write_text(
+            "pub fn relay(value: Option<i32>) {\n    let _value = value; // prefer Option :: unwrap(value) avoidance here\n}\n",
+            encoding="utf-8",
+        )
+
+        blockers = self.scan()
+
+        self.assertFalse(any("unwrap/expect added in runtime-sensitive" in item for item in blockers))
+
+    def test_finds_unwrap_after_closed_inline_block_comment(self):
+        target = self.repo_root / "clients" / "rust" / "crates" / "rubin-node" / "src" / "p2p_runtime.rs"
+        target.write_text(
+            "pub fn relay(value: Option<i32>) {\n    let _value = /* note */ Option :: unwrap(value);\n}\n",
+            encoding="utf-8",
+        )
+
+        blockers = self.scan()
+
+        self.assertTrue(any("unwrap/expect added in runtime-sensitive" in item for item in blockers))
 
     def test_fails_on_ufcs_expect_in_multiline_drop_impl(self):
         target = self.repo_root / "clients" / "rust" / "crates" / "rubin-node" / "src" / "dropper.rs"
@@ -243,6 +287,17 @@ class InvariantScanTests(unittest.TestCase):
         target = self.repo_root / "clients" / "rust" / "crates" / "rubin-node" / "src" / "dropper.rs"
         target.write_text(
             "struct Wrapper<T>(T);\n\nimpl<T: Drop> Wrapper<T> {\n    fn demo(&self) {\n        let _value = Some(1).unwrap();\n    }\n}\n",
+            encoding="utf-8",
+        )
+
+        blockers = self.scan()
+
+        self.assertFalse(any("panic-like cleanup added inside impl Drop" in item for item in blockers))
+
+    def test_does_not_treat_qualified_generic_drop_bounds_as_impl_drop(self):
+        target = self.repo_root / "clients" / "rust" / "crates" / "rubin-node" / "src" / "dropper.rs"
+        target.write_text(
+            "struct Wrapper<T>(T);\n\nimpl<T: std::ops::Drop> Wrapper<T> {\n    fn demo(&self) {\n        let _value = Result::<i32, &str> :: expect(Err(\"boom\"), \"boom\");\n    }\n}\n",
             encoding="utf-8",
         )
 

--- a/tools/tests/test_rubin_invariant_scan.py
+++ b/tools/tests/test_rubin_invariant_scan.py
@@ -171,10 +171,32 @@ class InvariantScanTests(unittest.TestCase):
 
         self.assertTrue(any("unwrap/expect added in runtime-sensitive" in item for item in blockers))
 
+    def test_fails_on_ufcs_unwrap_in_runtime_sensitive_path(self):
+        target = self.repo_root / "clients" / "rust" / "crates" / "rubin-node" / "src" / "p2p_runtime.rs"
+        target.write_text(
+            "pub fn relay(value: Option<i32>) {\n    let _value = Option::unwrap(value);\n}\n",
+            encoding="utf-8",
+        )
+
+        blockers = self.scan()
+
+        self.assertTrue(any("unwrap/expect added in runtime-sensitive" in item for item in blockers))
+
     def test_fails_on_panic_in_drop(self):
         target = self.repo_root / "clients" / "rust" / "crates" / "rubin-node" / "src" / "dropper.rs"
         target.write_text(
             "struct Dropper;\n\nimpl Drop for Dropper {\n    fn drop(&mut self) {\n        panic!(\"boom\");\n    }\n}\n",
+            encoding="utf-8",
+        )
+
+        blockers = self.scan()
+
+        self.assertTrue(any("panic-like cleanup added inside impl Drop" in item for item in blockers))
+
+    def test_fails_on_ufcs_expect_in_multiline_drop_impl(self):
+        target = self.repo_root / "clients" / "rust" / "crates" / "rubin-node" / "src" / "dropper.rs"
+        target.write_text(
+            "struct Dropper;\n\nimpl Drop\nfor Dropper\n{\n    fn drop(&mut self) {\n        let _value = Result::<i32, &str>::expect(Err(\"boom\"), \"boom\");\n    }\n}\n",
             encoding="utf-8",
         )
 

--- a/tools/tests/test_rubin_invariant_scan.py
+++ b/tools/tests/test_rubin_invariant_scan.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+TOOLS_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(TOOLS_DIR))
+
+import rubin_invariant_scan as m
+from rubin_agent_contract import CANONICAL_INVARIANTS
+
+
+def run(cmd: list[str], cwd: Path) -> str:
+    result = subprocess.run(
+        cmd,
+        cwd=cwd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def init_repo() -> tuple[tempfile.TemporaryDirectory[str], Path]:
+    td = tempfile.TemporaryDirectory()
+    root = Path(td.name)
+    run(["git", "init"], root)
+    run(["git", "config", "user.name", "Test User"], root)
+    run(["git", "config", "user.email", "test@example.com"], root)
+    run(["git", "branch", "-M", "main"], root)
+    (root / "tools" / "agent_tasks").mkdir(parents=True, exist_ok=True)
+    (root / "clients" / "go" / "node").mkdir(parents=True, exist_ok=True)
+    (root / "clients" / "go" / "node" / "tests").mkdir(parents=True, exist_ok=True)
+    (root / "clients" / "rust" / "crates" / "rubin-node" / "src").mkdir(parents=True, exist_ok=True)
+    (root / "clients" / "rust" / "crates" / "rubin-node" / "tests").mkdir(parents=True, exist_ok=True)
+    (root / "clients" / "go" / "node" / "sync.go").write_text("package node\n", encoding="utf-8")
+    (root / "clients" / "go" / "node" / "tests" / "sync_test.go").write_text(
+        "package tests\n",
+        encoding="utf-8",
+    )
+    (root / "clients" / "rust" / "crates" / "rubin-node" / "src" / "p2p_runtime.rs").write_text(
+        "pub fn relay() {}\n",
+        encoding="utf-8",
+    )
+    (root / "clients" / "rust" / "crates" / "rubin-node" / "src" / "dropper.rs").write_text(
+        "struct Dropper;\n",
+        encoding="utf-8",
+    )
+    (root / "clients" / "rust" / "crates" / "rubin-node" / "tests" / "cwd.rs").write_text(
+        "#[test]\nfn t() {}\n",
+        encoding="utf-8",
+    )
+    (root / "clients" / "rust" / "crates" / "rubin-node" / "tests" / "safe.rs").write_text(
+        "#[test]\nfn ok() {}\n",
+        encoding="utf-8",
+    )
+    run(["git", "add", "."], root)
+    run(["git", "commit", "-m", "baseline"], root)
+    head = run(["git", "rev-parse", "HEAD"], root)
+    run(["git", "update-ref", "refs/remotes/origin/main", head], root)
+    return td, root
+
+
+class InvariantScanTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td, self.repo_root = init_repo()
+        self.addCleanup(self._td.cleanup)
+        manifest_path = self.repo_root / "tools" / "agent_tasks" / "Q-TEST.json"
+        manifest = {
+            "q_id": "Q-IMPL-NODE-TEST-01",
+            "owner_area": "node",
+            "allowed_files": ["clients/go/node/sync.go"],
+            "allowed_globs": ["clients/**"],
+            "forbidden_globs": [],
+            "required_tests": ["printf ok"],
+            "hard_production_loc": 250,
+            "required_invariants": list(CANONICAL_INVARIANTS),
+        }
+        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+        self.manifest_path = manifest_path
+
+    def scan(self) -> list[str]:
+        return m.scan_invariants(self.manifest_path, "HEAD")
+
+    def test_fails_on_hidden_test_knob_in_production_file(self):
+        target = self.repo_root / "clients" / "go" / "node" / "sync.go"
+        target.write_text("package node\nconst knob = \"RUBIN_TEST_ONLY\"\n", encoding="utf-8")
+
+        blockers = self.scan()
+
+        self.assertTrue(any("hidden test knob" in item for item in blockers))
+
+    def test_fails_on_file_line_anchor_comment(self):
+        target = self.repo_root / "clients" / "go" / "node" / "sync.go"
+        target.write_text("package node\n// see p2p_runtime.rs:123 before editing\n", encoding="utf-8")
+
+        blockers = self.scan()
+
+        self.assertTrue(any("file:line anchor" in item for item in blockers))
+
+    def test_fails_on_set_current_dir_in_test(self):
+        target = self.repo_root / "clients" / "rust" / "crates" / "rubin-node" / "tests" / "cwd.rs"
+        target.write_text(
+            "#[test]\nfn t() {\n    std::env::set_current_dir(\"/\").unwrap();\n}\n",
+            encoding="utf-8",
+        )
+
+        blockers = self.scan()
+
+        self.assertTrue(any("CWD mutation" in item for item in blockers))
+
+    def test_fails_on_brittle_test_path_pattern(self):
+        target = self.repo_root / "clients" / "go" / "node" / "tests" / "sync_test.go"
+        target.write_text(
+            "package tests\n\nfunc T() {\n    _ = \"/nonexistent\"\n    chmod(0)\n}\n",
+            encoding="utf-8",
+        )
+
+        blockers = self.scan()
+
+        self.assertTrue(any("brittle test path or OS-string match" in item for item in blockers))
+
+    def test_fails_on_unwrap_in_runtime_sensitive_path(self):
+        target = self.repo_root / "clients" / "rust" / "crates" / "rubin-node" / "src" / "p2p_runtime.rs"
+        target.write_text(
+            "pub fn relay() {\n    let _value = Some(1).unwrap();\n}\n",
+            encoding="utf-8",
+        )
+
+        blockers = self.scan()
+
+        self.assertTrue(any("unwrap/expect added in runtime-sensitive" in item for item in blockers))
+
+    def test_fails_on_panic_in_drop(self):
+        target = self.repo_root / "clients" / "rust" / "crates" / "rubin-node" / "src" / "dropper.rs"
+        target.write_text(
+            "struct Dropper;\n\nimpl Drop for Dropper {\n    fn drop(&mut self) {\n        panic!(\"boom\");\n    }\n}\n",
+            encoding="utf-8",
+        )
+
+        blockers = self.scan()
+
+        self.assertTrue(any("panic-like cleanup added inside impl Drop" in item for item in blockers))
+
+    def test_does_not_flag_test_only_unwrap_in_non_runtime_sensitive_path(self):
+        target = self.repo_root / "clients" / "rust" / "crates" / "rubin-node" / "tests" / "safe.rs"
+        target.write_text(
+            "#[test]\nfn ok() {\n    let _value = Some(1).unwrap();\n}\n",
+            encoding="utf-8",
+        )
+
+        blockers = self.scan()
+
+        self.assertFalse(blockers)
+
+    def test_fails_on_untracked_test_with_brittle_pattern(self):
+        target = self.repo_root / "clients" / "go" / "node" / "tests" / "new_sync_test.go"
+        target.write_text(
+            "package tests\n\nfunc T() {\n    _ = \"Permission denied\"\n}\n",
+            encoding="utf-8",
+        )
+
+        blockers = self.scan()
+
+        self.assertTrue(any("brittle test path or OS-string match" in item for item in blockers))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_rubin_invariant_scan.py
+++ b/tools/tests/test_rubin_invariant_scan.py
@@ -105,6 +105,28 @@ class InvariantScanTests(unittest.TestCase):
 
         self.assertTrue(any("file:line anchor" in item for item in blockers))
 
+    def test_fails_on_inline_file_line_anchor_comment(self):
+        target = self.repo_root / "clients" / "go" / "node" / "sync.go"
+        target.write_text(
+            "package node\nfunc sync() { doWork() // see p2p_runtime.rs:123 before editing\n}\n",
+            encoding="utf-8",
+        )
+
+        blockers = self.scan()
+
+        self.assertTrue(any("file:line anchor" in item for item in blockers))
+
+    def test_fails_on_block_comment_interior_file_line_anchor(self):
+        target = self.repo_root / "clients" / "go" / "node" / "sync.go"
+        target.write_text(
+            "package node\n/*\n * see p2p_runtime.rs:123 before editing\n */\n",
+            encoding="utf-8",
+        )
+
+        blockers = self.scan()
+
+        self.assertTrue(any("file:line anchor" in item for item in blockers))
+
     def test_fails_on_set_current_dir_in_test(self):
         target = self.repo_root / "clients" / "rust" / "crates" / "rubin-node" / "tests" / "cwd.rs"
         target.write_text(

--- a/tools/tests/test_rubin_q_preflight.py
+++ b/tools/tests/test_rubin_q_preflight.py
@@ -108,6 +108,21 @@ class QPreflightTests(unittest.TestCase):
             result.stdout + result.stderr,
         )
 
+    def test_preflight_rejects_whitespace_only_required_test(self):
+        self.write_manifest(["   "])
+
+        result = run(
+            [str(PREFLIGHT), str(self.manifest_path)],
+            self.repo_root,
+            check=False,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "required test commands must contain non-whitespace text",
+            result.stdout + result.stderr,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/tests/test_rubin_q_preflight.py
+++ b/tools/tests/test_rubin_q_preflight.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import json
 import subprocess
-import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -29,6 +28,7 @@ def init_repo() -> tuple[tempfile.TemporaryDirectory[str], Path, Path]:
     run(["git", "init"], root)
     run(["git", "config", "user.name", "Test User"], root)
     run(["git", "config", "user.email", "test@example.com"], root)
+    run(["git", "config", "commit.gpgsign", "false"], root)
     run(["git", "branch", "-M", "main"], root)
     (root / "tools" / "agent_tasks").mkdir(parents=True, exist_ok=True)
     (root / "clients" / "go" / "node").mkdir(parents=True, exist_ok=True)
@@ -92,6 +92,21 @@ class QPreflightTests(unittest.TestCase):
 
         self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
         self.assertIn("PASS: q preflight", result.stdout)
+
+    def test_preflight_rejects_multiline_required_test(self):
+        self.write_manifest(["printf ok\nprintf nope"])
+
+        result = run(
+            [str(PREFLIGHT), str(self.manifest_path)],
+            self.repo_root,
+            check=False,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "required test commands must be single-line",
+            result.stdout + result.stderr,
+        )
 
 
 if __name__ == "__main__":

--- a/tools/tests/test_rubin_q_preflight.py
+++ b/tools/tests/test_rubin_q_preflight.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+TOOLS_DIR = Path(__file__).resolve().parents[1]
+PREFLIGHT = TOOLS_DIR / "rubin_q_preflight.sh"
+
+
+def run(cmd: list[str], cwd: Path, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        cmd,
+        cwd=cwd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=check,
+    )
+
+
+def init_repo() -> tuple[tempfile.TemporaryDirectory[str], Path, Path]:
+    td = tempfile.TemporaryDirectory()
+    root = Path(td.name)
+    run(["git", "init"], root)
+    run(["git", "config", "user.name", "Test User"], root)
+    run(["git", "config", "user.email", "test@example.com"], root)
+    run(["git", "branch", "-M", "main"], root)
+    (root / "tools" / "agent_tasks").mkdir(parents=True, exist_ok=True)
+    (root / "clients" / "go" / "node").mkdir(parents=True, exist_ok=True)
+    (root / "clients" / "go" / "node" / "sync.go").write_text("package node\n", encoding="utf-8")
+    run(["git", "add", "."], root)
+    run(["git", "commit", "-m", "baseline"], root)
+    head = run(["git", "rev-parse", "HEAD"], root).stdout.strip()
+    run(["git", "update-ref", "refs/remotes/origin/main", head], root)
+    manifest_path = root / "tools" / "agent_tasks" / "Q-TEST.json"
+    return td, root, manifest_path
+
+
+class QPreflightTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td, self.repo_root, self.manifest_path = init_repo()
+        self.addCleanup(self._td.cleanup)
+
+    def write_manifest(self, required_tests: list[str]) -> None:
+        payload = {
+            "q_id": "Q-IMPL-NODE-TEST-01",
+            "owner_area": "node",
+            "allowed_files": ["clients/go/node/sync.go"],
+            "allowed_globs": [],
+            "forbidden_globs": [],
+            "required_tests": required_tests,
+            "hard_production_loc": 250,
+            "required_invariants": [
+                "scope",
+                "state_ownership",
+                "lock_io",
+                "failure_atomicity",
+                "go_rust_parity",
+                "caller_fuzz_test_sweep",
+                "test_stability"
+            ],
+        }
+        self.manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    def test_preflight_fails_when_required_test_fails(self):
+        self.write_manifest(["printf ok", "exit 1"])
+
+        result = run(
+            [str(PREFLIGHT), str(self.manifest_path)],
+            self.repo_root,
+            check=False,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("BLOCKED: q preflight", result.stdout)
+
+    def test_preflight_passes_on_clean_manifest(self):
+        self.write_manifest(["printf ok"])
+        target = self.repo_root / "clients" / "go" / "node" / "sync.go"
+        target.write_text("package node\n\nfunc Sync() {}\n", encoding="utf-8")
+
+        result = run(
+            [str(PREFLIGHT), str(self.manifest_path)],
+            self.repo_root,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+        self.assertIn("PASS: q preflight", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a repo-local Q manifest contract for coder-agent work in `tools/agent_templates/`
- add local fail-closed guards for scope, invariant scanning, and deterministic Q preflight
- add synthetic unit coverage for schema validation, scope drift, invariant violations, and preflight behavior

## Validation
- `python3 -m unittest discover -s /Users/gpt/Documents/rubin-protocol/tools/tests`
- `python3 -m py_compile /Users/gpt/Documents/rubin-protocol/tools/rubin_agent_contract.py /Users/gpt/Documents/rubin-protocol/tools/rubin_agent_scope_guard.py /Users/gpt/Documents/rubin-protocol/tools/rubin_invariant_scan.py /Users/gpt/Documents/rubin-protocol/tools/tests/test_rubin_agent_contract.py /Users/gpt/Documents/rubin-protocol/tools/tests/test_rubin_agent_scope_guard.py /Users/gpt/Documents/rubin-protocol/tools/tests/test_rubin_invariant_scan.py /Users/gpt/Documents/rubin-protocol/tools/tests/test_rubin_q_preflight.py`
- `python3 /Users/gpt/Documents/rubin-orchestration-private/inbox/operational/tools/run_pr_lifecycle.py pre-pr --target-repo rubin-protocol --repo-root /Users/gpt/Documents/.Codex/worktrees/rubin-protocol-local-coder-hardening-publish`
