### PR TITLE
feat(storage): Rust startup reconcile/repair (E.2)

### DIFF
--- a/clients/go/cmd/rubin-node/main.go
+++ b/clients/go/cmd/rubin-node/main.go
@@ -340,6 +340,41 @@ func run(args []string, stdout, stderr io.Writer) int {
 	applySuiteContextToSyncConfig(&syncCfg, rotation, registry)
 	syncCfg.ParallelValidationMode = *pvMode
 	syncCfg.PVShadowMaxSamples = *pvShadowMax
+	// Mainnet target / genesis guard runs BEFORE any reconcile-driven
+	// state mutation (truncate_canonical / chainstate replay). MkdirAll,
+	// LoadChainState, and OpenBlockStore above are read/open-only
+	// operations that do not rewrite canonical or chainstate contents;
+	// the authoritative boundary we care about is reconcile + save +
+	// sync engine start, and the guard must run before that boundary.
+	// Mirror of Rust main.rs validate_mainnet_genesis_guard pre-reconcile
+	// call. NewSyncEngine also runs the same guard internally (see
+	// sync.go validateMainnetGenesisGuard) so tests / embedded callers
+	// that construct an engine directly still get the check.
+	// Devnet / test networks no-op.
+	if err := node.ValidateMainnetGenesisGuard(syncCfg); err != nil {
+		_, _ = fmt.Fprintf(stderr, "mainnet genesis guard failed: %v\n", err)
+		return 2
+	}
+	// Reconcile + save BEFORE constructing the sync engine. Rust mirror
+	// in clients/rust/crates/rubin-node/src/main.rs: the contract is
+	// that chainstate is persisted to disk BEFORE any sync / P2P / RPC /
+	// miner thread can observe it, so a post-reconcile crash cannot
+	// expose a chainstate whose claimed tip exceeds the truncated
+	// canonical index. If chainState.Save fails after a successful
+	// reconcile, the canonical index on disk is already truncated
+	// (atomic via write_file_atomic) but the chainstate snapshot may be
+	// stale; the next startup will detect this via height/tip mismatch
+	// and reset+replay from height 0 — correct, just wasteful on large
+	// chains. If the sync engine constructor itself fails later, the
+	// already-repaired chainstate is durable on disk.
+	if _, err := node.ReconcileChainStateWithBlockStore(chainState, blockStore, syncCfg); err != nil {
+		_, _ = fmt.Fprintf(stderr, "chainstate reconcile failed: %v\n", err)
+		return 2
+	}
+	if err := chainState.Save(chainStatePath); err != nil {
+		_, _ = fmt.Fprintf(stderr, "chainstate save failed: %v\n", err)
+		return 2
+	}
 	syncEngine, err := newSyncEngineFn(
 		chainState,
 		blockStore,
@@ -347,14 +382,6 @@ func run(args []string, stdout, stderr io.Writer) int {
 	)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "sync engine init failed: %v\n", err)
-		return 2
-	}
-	if _, err := node.ReconcileChainStateWithBlockStore(chainState, blockStore, syncCfg); err != nil {
-		_, _ = fmt.Fprintf(stderr, "chainstate reconcile failed: %v\n", err)
-		return 2
-	}
-	if err := chainState.Save(chainStatePath); err != nil {
-		_, _ = fmt.Fprintf(stderr, "chainstate save failed: %v\n", err)
 		return 2
 	}
 	mempoolCfg := node.DefaultMempoolConfig()

--- a/clients/go/node/chainstate_recovery.go
+++ b/clients/go/node/chainstate_recovery.go
@@ -2,7 +2,10 @@ package node
 
 import (
 	"errors"
+	"fmt"
 	"os"
+
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
 )
 
 const (
@@ -145,11 +148,46 @@ func ReconcileChainStateWithBlockStore(state *ChainState, store *BlockStore, cfg
 			return false, err
 		}
 		if !ok {
-			return false, errors.New("missing canonical block hash during chainstate replay")
+			// Suffix `at height N (tip_height=N')` is part of the
+			// cross-client error literal — Rust mirror in
+			// `clients/rust/crates/rubin-node/src/chainstate_recovery.rs`
+			// emits the bit-identical wording. Operators searching
+			// logs for canonical-index corruption get the exact
+			// height instead of having to reconstruct the loop state.
+			return false, fmt.Errorf("missing canonical block hash during chainstate replay at height %d (tip_height=%d)", height, tipHeight)
 		}
 		blockBytes, err := store.GetBlockByHash(blockHash)
 		if err != nil {
 			return false, err
+		}
+		// Defence-in-depth: re-hash the loaded block's header and
+		// confirm it matches the canonical-index entry BEFORE
+		// delegating to ConnectBlockWithCoreExtProfilesAndSuiteContext.
+		// A parseable-but-swapped <hash>.bin (bit-rot, manual disk
+		// repair gone wrong, adversarial replacement that happens to
+		// link to the current tip's prev_hash) would otherwise be
+		// accepted by ConnectBlock, leaving ChainState with a tip
+		// that no longer corresponds to its canonical-index entry.
+		// The prev_hash chain-integrity check inside ConnectBlock
+		// catches some of this class but NOT the same-prev-hash
+		// adversarial case. One hash per replay block is recovery-
+		// path-only cost (N rows, not steady state). Cross-client
+		// symmetric: Rust `clients/rust/crates/rubin-node/src/chainstate_recovery.rs`
+		// reconcile_chain_state_with_block_store performs the
+		// bit-identical check with the same error literal.
+		parsed, err := consensus.ParseBlockBytes(blockBytes)
+		if err != nil {
+			return false, fmt.Errorf("parse block bytes during chainstate replay at height %d: %w", height, err)
+		}
+		observedHash, err := consensus.BlockHash(parsed.HeaderBytes)
+		if err != nil {
+			return false, fmt.Errorf("hash header during chainstate replay at height %d: %w", height, err)
+		}
+		if observedHash != blockHash {
+			return false, fmt.Errorf(
+				"canonical artifact corruption during chainstate replay at height %d: expected %x, on-disk header hashes to %x",
+				height, blockHash, observedHash,
+			)
 		}
 		prevTimestamps, err := prevTimestampsFromStore(store, height)
 		if err != nil {

--- a/clients/go/node/chainstate_recovery_test.go
+++ b/clients/go/node/chainstate_recovery_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
@@ -456,5 +457,77 @@ func TestReconcileChainStateWithBlockStore_ResetsDirtyTiplessSnapshotBeforeRepla
 	}
 	if len(dirty.Utxos) != len(expected.Utxos) {
 		t.Fatalf("unexpected utxo count after dirty replay: got=%d want=%d", len(dirty.Utxos), len(expected.Utxos))
+	}
+}
+
+// TestReconcileChainStateWithBlockStore_PropagatesCorruptBlockBytesSwap
+// pins the cross-client re-hash defence: a parseable-but-wrong
+// <hash>.bin (block 1's payload overwritten with block 2's bytes,
+// which still link to b1_hash as prev_hash so chain-integrity
+// inside ConnectBlock would PASS) MUST be rejected by reconcile's
+// pre-replay re-hash check. Mirror of Rust
+// `reconcile_propagates_corrupt_canonical_block_artifact`.
+func TestReconcileChainStateWithBlockStore_PropagatesCorruptBlockBytesSwap(t *testing.T) {
+	dir := t.TempDir()
+	chainStatePath := ChainStatePath(dir)
+	store, err := OpenBlockStore(BlockStorePath(dir))
+	if err != nil {
+		t.Fatalf("OpenBlockStore: %v", err)
+	}
+
+	target := consensus.POW_LIMIT
+	cfg := DefaultSyncConfig(&target, devnetGenesisChainID, chainStatePath)
+	liveState := NewChainState()
+	engine, err := NewSyncEngine(liveState, store, cfg)
+	if err != nil {
+		t.Fatalf("NewSyncEngine: %v", err)
+	}
+	if _, err := engine.ApplyBlock(devnetGenesisBlockBytes, nil); err != nil {
+		t.Fatalf("ApplyBlock(genesis): %v", err)
+	}
+	genesisParsed, err := consensus.ParseBlockBytes(devnetGenesisBlockBytes)
+	if err != nil {
+		t.Fatalf("ParseBlockBytes(genesis): %v", err)
+	}
+	block1Coinbase := coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 1, 1)
+	block1 := buildSingleTxBlock(t, devnetGenesisBlockHash, target, genesisParsed.Header.Timestamp+1, block1Coinbase)
+	if _, err := engine.ApplyBlock(block1, nil); err != nil {
+		t.Fatalf("ApplyBlock(block1): %v", err)
+	}
+	block1Parsed, err := consensus.ParseBlockBytes(block1)
+	if err != nil {
+		t.Fatalf("ParseBlockBytes(block1): %v", err)
+	}
+	block1Hash, err := consensus.BlockHash(block1Parsed.HeaderBytes)
+	if err != nil {
+		t.Fatalf("BlockHash(block1): %v", err)
+	}
+	// Build a second valid block at height 2 whose prev_hash is
+	// block1Hash. Overwrite block 1's <hash>.bin with block 2's
+	// bytes so the file is parseable, prev_hash links to the
+	// current canonical tip (passes connect_block prev-hash
+	// integrity), but its header hashes to block2_hash, NOT
+	// block1_hash — only the re-hash check catches the swap.
+	block2Coinbase := coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 2, 2)
+	block2 := buildSingleTxBlock(t, block1Hash, target, block1Parsed.Header.Timestamp+1, block2Coinbase)
+	block1Path := filepath.Join(store.blocksDir, hex.EncodeToString(block1Hash[:])+".bin")
+	if err := os.WriteFile(block1Path, block2, 0o600); err != nil {
+		t.Fatalf("overwrite block1 bytes: %v", err)
+	}
+
+	state := NewChainState()
+	if _, err := state.ConnectBlockWithCoreExtProfilesAndSuiteContext(
+		devnetGenesisBlockBytes, &target, nil, devnetGenesisChainID,
+		cfg.CoreExtProfiles, cfg.RotationProvider, cfg.SuiteRegistry,
+	); err != nil {
+		t.Fatalf("seed genesis state: %v", err)
+	}
+	_, err = ReconcileChainStateWithBlockStore(state, store, cfg)
+	if err == nil {
+		t.Fatalf("expected canonical-artifact-corruption error, got nil")
+	}
+	want := "canonical artifact corruption during chainstate replay at height 1"
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("expected error containing %q, got %v", want, err)
 	}
 }

--- a/clients/go/node/sync.go
+++ b/clients/go/node/sync.go
@@ -179,6 +179,16 @@ func normalizedNetworkName(network string) string {
 	return network
 }
 
+// ValidateMainnetGenesisGuard exposes the mainnet genesis / target
+// guard so cmd/rubin-node/main.go can run it BEFORE reconcile (mirror
+// of Rust main.rs validate_mainnet_genesis_guard call). Devnet / test
+// networks no-op. Defence-in-depth: NewSyncEngine still runs the same
+// guard internally for callers that construct an engine directly
+// (tests, embedded uses).
+func ValidateMainnetGenesisGuard(cfg SyncConfig) error {
+	return validateMainnetGenesisGuard(cfg)
+}
+
 func validateMainnetGenesisGuard(cfg SyncConfig) error {
 	if normalizedNetworkName(cfg.Network) != "mainnet" {
 		return nil

--- a/clients/go/node/sync_test.go
+++ b/clients/go/node/sync_test.go
@@ -938,3 +938,35 @@ func TestTxErrCode(t *testing.T) {
 		}
 	})
 }
+
+func TestValidateMainnetGenesisGuard_ExportedWrapperParity(t *testing.T) {
+	// The exported wrapper is the entry point used by cmd/rubin-node/main.go
+	// to run the guard BEFORE reconcile (mirror of Rust main.rs ordering).
+	// It must produce identical results to the unexported form used inside
+	// NewSyncEngine — same pass on devnet, same reject on misconfigured
+	// mainnet. Cross-client parity: matches Rust validate_mainnet_genesis_guard
+	// re-export (clients/rust/crates/rubin-node/src/lib.rs).
+
+	t.Run("devnet_passes", func(t *testing.T) {
+		cfg := SyncConfig{Network: "devnet"}
+		if err := ValidateMainnetGenesisGuard(cfg); err != nil {
+			t.Fatalf("devnet: ValidateMainnetGenesisGuard returned %v, want nil", err)
+		}
+		// Wrapper and inner must agree.
+		if inner := validateMainnetGenesisGuard(cfg); inner != nil {
+			t.Fatalf("devnet: validateMainnetGenesisGuard returned %v, want nil", inner)
+		}
+	})
+
+	t.Run("mainnet_without_expected_target_rejects", func(t *testing.T) {
+		cfg := SyncConfig{Network: "mainnet"} // ExpectedTarget==nil
+		err := ValidateMainnetGenesisGuard(cfg)
+		if err == nil {
+			t.Fatal("mainnet without ExpectedTarget: ValidateMainnetGenesisGuard returned nil, want error")
+		}
+		inner := validateMainnetGenesisGuard(cfg)
+		if inner == nil || inner.Error() != err.Error() {
+			t.Fatalf("wrapper/inner divergence: wrapper=%v inner=%v", err, inner)
+		}
+	})
+}

--- a/clients/rust/crates/rubin-node/src/blockstore.rs
+++ b/clients/rust/crates/rubin-node/src/blockstore.rs
@@ -360,6 +360,46 @@ impl BlockStore {
             .exists()
     }
 
+    /// Fallible header-file presence probe used by reconcile. Returns
+    /// `Ok(true)` on present, `Ok(false)` only on `NotFound`, and
+    /// `Err` on any other metadata error (EACCES / EIO / ENOTDIR on
+    /// parent / etc.). Distinct from `has_block` — the boolean
+    /// `has_block` is `Path::exists()` which conflates "missing" with
+    /// metadata errors and is therefore unsafe for the
+    /// reconcile-vs-truncate decision: a transient I/O failure must
+    /// surface as a HARD startup error, not silently look like a
+    /// "missing file → truncate canonical suffix" trigger.
+    pub fn try_has_block(&self, block_hash_bytes: [u8; 32]) -> Result<bool, String> {
+        try_has_file_at(
+            &self
+                .headers_dir
+                .join(format!("{}.bin", hex::encode(block_hash_bytes))),
+        )
+    }
+
+    /// Fallible block-bytes presence probe (in `blocks_dir`). Same
+    /// semantics as `try_has_block`: only `NotFound` returns
+    /// `Ok(false)`, every other metadata failure surfaces as `Err`.
+    pub fn try_has_block_data(&self, block_hash_bytes: [u8; 32]) -> Result<bool, String> {
+        try_has_file_at(
+            &self
+                .blocks_dir
+                .join(format!("{}.bin", hex::encode(block_hash_bytes))),
+        )
+    }
+
+    /// Fallible undo-file presence probe. Same semantics as
+    /// `try_has_block`. Use this in `chainstate_recovery::truncate_
+    /// incomplete_canonical_suffix` and any other path that must
+    /// distinguish "missing" from "present but unreadable".
+    pub fn try_has_undo(&self, block_hash_bytes: [u8; 32]) -> Result<bool, String> {
+        try_has_file_at(
+            &self
+                .undo_dir
+                .join(format!("{}.json", hex::encode(block_hash_bytes))),
+        )
+    }
+
     pub fn find_canonical_height(&self, block_hash_bytes: [u8; 32]) -> Result<Option<u64>, String> {
         let Some((tip_height, _)) = self.tip()? else {
             return Ok(None);
@@ -508,11 +548,13 @@ impl BlockStore {
         unmarshal_block_undo(&raw)
     }
 
-    /// Cheap undo-presence check used by the same-hash replay branch of
-    /// `commit_canonical_block` to verify that a canonical entry
+    /// Cheap undo-presence check used by the same-hash replay branch
+    /// of `commit_canonical_block` to verify that a canonical entry
     /// inherited from pre-E.4 disk state (or corrupted in some other
     /// way) actually has its undo file on disk before accepting the
-    /// replay as a no-op.
+    /// replay as a no-op. Reconcile / truncate paths use the fallible
+    /// `try_has_undo` instead so EACCES / EIO surface as Err rather
+    /// than silently looking like NotFound.
     fn has_undo(&self, block_hash_bytes: [u8; 32]) -> bool {
         self.undo_dir
             .join(format!("{}.json", hex::encode(block_hash_bytes)))
@@ -618,6 +660,21 @@ impl BlockStore {
 
 pub fn block_store_path<P: AsRef<Path>>(data_dir: P) -> PathBuf {
     data_dir.as_ref().join(BLOCK_STORE_DIR_NAME)
+}
+
+/// Fallible existence probe used by the `try_has_*` family. Returns
+/// `Ok(true)` if the file is present and stat'able, `Ok(false)` only
+/// on `ErrorKind::NotFound`, `Err` on every other metadata failure
+/// (EACCES on parent, EIO, ENOTDIR, etc.). Distinct from
+/// `Path::exists()` which silently treats every metadata failure as
+/// "missing" — that is unsafe for paths that gate truncate-vs-error
+/// decisions in startup reconcile.
+fn try_has_file_at(path: &Path) -> Result<bool, String> {
+    match fs::metadata(path) {
+        Ok(_) => Ok(true),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(e) => Err(format!("stat {}: {e}", path.display())),
+    }
 }
 
 fn load_blockstore_index(path: &Path) -> Result<BlockStoreIndexDisk, String> {

--- a/clients/rust/crates/rubin-node/src/chainstate_recovery.rs
+++ b/clients/rust/crates/rubin-node/src/chainstate_recovery.rs
@@ -1,0 +1,874 @@
+//! Startup-time reconcile / repair between the persisted ChainState
+//! snapshot and the on-disk BlockStore (`E.2` of the 2026-04-14 audit).
+//!
+//! Rust mirror of `clients/go/node/chainstate_recovery.go`.
+//!
+//! # What this closes
+//!
+//! Before this module, the Rust node entrypoint (`main.rs`) opened the
+//! chainstate snapshot and the blockstore independently and immediately
+//! constructed a `SyncEngine` from them. If the two diverged — most
+//! commonly after a crash that landed the chainstate snapshot but lost
+//! the matching block / undo file, or vice versa — the sync engine
+//! would happily run with a chainstate tip that no longer points at any
+//! canonical block on disk. Go has had this since the storage
+//! cluster landed: function defined in
+//! `clients/go/node/chainstate_recovery.go::ReconcileChainStateWithBlockStore`,
+//! invoked from `clients/go/cmd/rubin-node/main.go` between
+//! `OpenBlockStore` and the sync engine constructor. Rust did not.
+//!
+//! # Repair contract
+//!
+//! `reconcile_chain_state_with_block_store(state, store, cfg)` performs
+//! two repair steps:
+//!
+//! 1. `truncate_incomplete_canonical_suffix(store)` — walks the
+//!    canonical index from height 0 forward and stops at the first
+//!    height whose header / block-bytes / undo file is missing on
+//!    disk. Truncates the canonical index to that prefix. This is the
+//!    "blockstore lost its tail" repair. A present-but-unparseable
+//!    artifact (e.g. corrupt JSON undo) is propagated as an error and
+//!    no truncate happens — operator must investigate.
+//! 2. Snapshot reconciliation — compares the loaded chainstate snapshot
+//!    against the (possibly truncated) blockstore canonical chain:
+//!      * empty store + dirty snapshot → reset snapshot to empty;
+//!      * empty store + empty snapshot → no-op;
+//!      * snapshot at height H, canonical(H) == snapshot.tip → replay
+//!        canonical blocks from H+1 to tip;
+//!      * canonical(H) ≠ snapshot.tip OR snapshot.height > tip → reset
+//!        snapshot and replay from genesis.
+//!
+//! Replay reuses `ChainState::connect_block_with_core_ext_deployments_
+//! and_suite_context`, the same entry point the live sync engine uses,
+//! so consensus rules during reconcile match consensus rules during
+//! steady-state sync.
+//!
+//! # Out of scope
+//!
+//! - fsync durability (closed by `E.1`, PR #1218)
+//! - atomic canonical commit semantics (closed by `E.4`, already
+//!   merged via PR #1211)
+//! - WAL / snapshot-cadence redesign
+//! - Any non-startup runtime reconciliation (the live sync engine
+//!   handles steady-state mismatch through reorg / disconnect paths).
+
+use crate::blockstore::BlockStore;
+use crate::chainstate::ChainState;
+use crate::sync::SyncConfig;
+use rubin_consensus::parse_block_header_bytes;
+
+/// Walk the canonical index forward; for every canonical hash, verify
+/// the matching header file, block-bytes file, and undo file all exist
+/// on disk and (for undo) parse cleanly. On the first missing
+/// artifact, truncate the canonical index to the prefix that was
+/// fully present. Returns `Ok(true)` if a truncate happened,
+/// `Ok(false)` if the index was already complete.
+///
+/// Errors propagate from (one bullet per `?`-site in the body so the
+/// doc enumeration matches the actual exit set):
+///   * `BlockStore::canonical_hash(height)` propagation, plus the
+///     internal "canonical index hole at height N during truncate
+///     scan" error if the index has a gap below `canonical_len`
+///     (a corrupt `blockstore-index.json`);
+///   * `try_has_block` / `try_has_block_data` / `try_has_undo`
+///     metadata failures — i.e. EACCES / EIO / ENOTDIR on the parent
+///     directory or on the artifact itself, surfaced as
+///     `stat <path>: <err>`. NotFound is intentionally NOT propagated
+///     here: it converts to `Ok(false)` and triggers truncate;
+///   * `get_header_by_hash` / `get_block_by_hash` read failures on
+///     present-but-unreadable artifact files (the follow-up `get_*`
+///     call after `try_has_*` confirms presence — corruption /
+///     EACCES on the file itself surfaces here). The threat-model
+///     assumption (no concurrent reconcile, no external process
+///     mutating BlockStore files mid-call) means a NotFound at this
+///     point is a hard error: it implies an external delete between
+///     `try_has_*` and `get_*_by_hash`, which violates the contract;
+///   * `get_undo` parse failure on a present-and-readable but
+///     unparseable undo JSON (operator must investigate);
+///   * `BlockStore::truncate_canonical` failure when the prefix
+///     write back to the index file fails.
+///
+/// Mirrors the Go `truncateIncompleteCanonicalSuffix` helper.
+pub(crate) fn truncate_incomplete_canonical_suffix(store: &mut BlockStore) -> Result<bool, String> {
+    // Iterate by height instead of cloning the entire canonical
+    // index via `canonical_suffix_from(0)` — that allocation is
+    // O(chain_height) bytes for a one-shot scan that only needs
+    // height-by-height access. `canonical_hash` reads each entry
+    // in place; `canonical_len` gives the bound.
+    let canonical_len = store.canonical_len();
+    let mut valid_count: usize = 0;
+    for height in 0..canonical_len {
+        let block_hash = store.canonical_hash(height as u64)?.ok_or_else(|| {
+            format!("canonical index hole at height {height} during truncate scan")
+        })?;
+        // Use the fallible `try_has_*` probes so a metadata-level
+        // failure (EACCES, EIO, ENOTDIR on parent) propagates as a
+        // HARD startup error instead of silently looking like
+        // "missing file → truncate". The boolean `Path::exists()`
+        // siblings cannot distinguish those classes from NotFound
+        // and would lose canonical suffix on transient I/O —
+        // mismatching Go's `errors.Is(err, os.ErrNotExist)` semantics
+        // and the operator contract documented at the module level.
+        // After existence is confirmed, the follow-up `get_*_by_hash`
+        // read propagates corruption / EACCES on the artifact file
+        // itself.
+        if !store.try_has_block(block_hash)? {
+            break;
+        }
+        store.get_header_by_hash(block_hash)?;
+        if !store.try_has_block_data(block_hash)? {
+            break;
+        }
+        store.get_block_by_hash(block_hash)?;
+        if !store.try_has_undo(block_hash)? {
+            break;
+        }
+        store.get_undo(block_hash)?;
+        valid_count += 1;
+    }
+    if valid_count == canonical_len {
+        return Ok(false);
+    }
+    store.truncate_canonical(valid_count)?;
+    Ok(true)
+}
+
+/// Reconcile the persisted chainstate snapshot against the on-disk
+/// canonical chain in `store`. Returns `Ok(true)` if any repair was
+/// applied (truncate, reset, or replay), `Ok(false)` if both inputs
+/// already agreed.
+///
+/// Repair sequence (mirrors Go `ReconcileChainStateWithBlockStore`):
+///
+/// 1. `truncate_incomplete_canonical_suffix(store)` — drop any tail
+///    of the canonical index that lost its block / undo files.
+/// 2. If the (possibly truncated) blockstore has no tip:
+///       * if `state` is also empty → no-op (`Ok(false)`),
+///       * else reset `state` to empty and return `Ok(true)`.
+/// 3. If `state` has a tip and `state.height <= tip_height`:
+///       * if `canonical(state.height) == state.tip_hash`:
+///           - if `state.height == tip_height` → no-op (caller may
+///             still see `Ok(true)` if step 1 truncated),
+///           - else replay forward from `state.height + 1`.
+///       * else (mismatch) reset `state` and replay from height 0.
+/// 4. If `state.height > tip_height` (snapshot is ahead of blockstore)
+///    → reset `state` and replay from height 0.
+/// 5. If `state` has no tip → reset to empty (idempotent) and replay
+///    from height 0.
+///
+/// Replay reuses
+/// `ChainState::connect_block_with_core_ext_deployments_and_suite_context`
+/// so consensus checks during recovery match steady-state sync.
+///
+/// # Threat model
+///
+/// **Concurrent actors**: This is a startup-only function. Caller
+/// (`main.rs`) holds an exclusive `&mut ChainState` and `&mut
+/// BlockStore` before any sync engine, P2P, RPC, or miner thread
+/// starts. No concurrent reconcile.
+///
+/// **Process crash**: The reconcile makes the disk state self-
+/// consistent before the live engine runs. If the process crashes
+/// mid-reconcile (e.g. between `truncate_canonical` and the replay
+/// loop), the next startup re-runs reconcile from scratch — the truncate
+/// is itself atomic via `write_file_atomic` on the canonical index
+/// file (`E.1`), and the chainstate snapshot is re-saved by the caller
+/// after reconcile returns. Re-entry is idempotent.
+///
+/// **Cross-platform**: All I/O goes through helpers that already abide
+/// by the storage cluster's OS contracts (`O_EXCL` for temp creates,
+/// `drop(fd)` before unlink on Windows in `write_and_sync_temp`,
+/// best-effort `sync_dir` on permission-hardened parents).
+///
+/// **Retry / exhaustion**: No bounded retry inside reconcile — the
+/// caller (`main.rs`) treats a reconcile error as a fatal startup
+/// failure and exits with non-zero, mirroring Go's `chainstate
+/// reconcile failed: %v` exit path.
+///
+/// **Inode / fs-layer**: Reconcile reads only — does not create new
+/// files. `truncate_canonical` rewrites the canonical index via the
+/// existing atomic-write helper (no shared-inode hazards).
+///
+/// **Durability**: After reconcile returns `Ok(true)`, the caller
+/// MUST persist `chain_state.save(...)` BEFORE starting any sync
+/// engine / P2P / RPC / miner thread, so a crash between
+/// `truncate_canonical` (already atomic via `write_file_atomic`) and
+/// the chainstate snapshot rewrite cannot expose a chainstate whose
+/// claimed tip exceeds the truncated canonical index. If the caller
+/// honours this ordering and crashes before save, the next startup
+/// re-runs reconcile from scratch — correct, just wasteful. Mirror
+/// of Go `ReconcileChainStateWithBlockStore` caller-side contract
+/// in `clients/go/cmd/rubin-node/main.go`.
+///
+/// Mirrors the Go `ReconcileChainStateWithBlockStore` for cross-client
+/// storage parity.
+pub fn reconcile_chain_state_with_block_store(
+    state: &mut ChainState,
+    store: &mut BlockStore,
+    cfg: &SyncConfig,
+) -> Result<bool, String> {
+    let truncated = truncate_incomplete_canonical_suffix(store)?;
+    let tip = store.tip()?;
+    let mut changed = truncated;
+
+    let Some((tip_height, _tip_hash)) = tip else {
+        // Empty store. Reset chainstate if it carries any state.
+        if truncated
+            || state.has_tip
+            || state.height != 0
+            || state.tip_hash != [0u8; 32]
+            || state.already_generated != 0
+            || !state.utxos.is_empty()
+        {
+            *state = ChainState::new();
+            return Ok(true);
+        }
+        return Ok(false);
+    };
+
+    let mut replay_from: u64 = 0;
+    if state.has_tip {
+        if state.height <= tip_height {
+            let canonical = store.canonical_hash(state.height)?;
+            match canonical {
+                Some(canonical_hash) if canonical_hash == state.tip_hash => {
+                    if state.height == tip_height {
+                        return Ok(changed);
+                    }
+                    replay_from = state.height + 1;
+                }
+                _ => {
+                    *state = ChainState::new();
+                    changed = true;
+                }
+            }
+        } else {
+            *state = ChainState::new();
+            changed = true;
+        }
+    } else {
+        *state = ChainState::new();
+        changed = true;
+    }
+
+    // Hoist rotation / registry resolution out of the replay loop —
+    // `cfg.suite_context` is immutable for the lifetime of reconcile,
+    // so the per-height re-borrow is wasted work on long replays.
+    // The trait-erasure re-borrow has to stay even at the hoist
+    // point: `SuiteContext.rotation` is stored as
+    // `Arc<dyn RotationProvider + Send + Sync>` while
+    // `connect_block_with_core_ext_deployments_and_suite_context`
+    // takes the bare `Option<&dyn RotationProvider>` (no `+ Send +
+    // Sync` bound). Without the explicit `let r: &(dyn ... + Send +
+    // Sync) = ctx.rotation.as_ref();` step the compiler refuses to
+    // weaken the bound through a single coercion. Same idiom
+    // `SyncEngine` uses internally for the per-call re-borrow.
+    let rotation: Option<&dyn rubin_consensus::RotationProvider> =
+        cfg.suite_context.as_ref().map(|ctx| {
+            let r: &(dyn rubin_consensus::RotationProvider + Send + Sync) = ctx.rotation.as_ref();
+            r as &dyn rubin_consensus::RotationProvider
+        });
+    let registry = cfg.suite_context.as_ref().map(|ctx| ctx.registry.as_ref());
+
+    for height in replay_from..=tip_height {
+        // Error literal stays prefixed `missing canonical block hash
+        // during chainstate replay` for log-scrape parity with Go;
+        // height + tip_height suffix added in BOTH clients in the
+        // same commit so operators can locate the corrupt canonical
+        // entry. See Go `clients/go/node/chainstate_recovery.go`
+        // ReconcileChainStateWithBlockStore for the mirror.
+        let block_hash = store.canonical_hash(height)?.ok_or_else(|| {
+            format!(
+                "missing canonical block hash during chainstate replay at height {height} (tip_height={tip_height})"
+            )
+        })?;
+        let block_bytes = store.get_block_by_hash(block_hash)?;
+        // Defence-in-depth: re-hash the loaded block's header and
+        // confirm it matches the canonical-index entry BEFORE
+        // delegating to `connect_block_*`. A parseable-but-swapped
+        // `<hash>.bin` (bit-rot, manual disk repair gone wrong,
+        // adversarial replacement that happens to point at the
+        // current tip's prev_hash) would otherwise be accepted by
+        // connect_block, leaving ChainState with a tip that no
+        // longer corresponds to its canonical-index entry. The
+        // prev_hash chain-integrity check inside connect_block
+        // catches some of this class but NOT the same-prev-hash
+        // adversarial case. One hash per replay block is recovery-
+        // path-only cost (N rows, not steady state). Cross-client
+        // symmetric: Go `clients/go/node/chainstate_recovery.go`
+        // ReconcileChainStateWithBlockStore replay loop performs
+        // the bit-identical check with the same error literal.
+        let parsed = rubin_consensus::parse_block_bytes(&block_bytes).map_err(|e| {
+            format!("parse block bytes during chainstate replay at height {height}: {e}")
+        })?;
+        let observed_hash = rubin_consensus::block_hash(&parsed.header_bytes)
+            .map_err(|e| format!("hash header during chainstate replay at height {height}: {e}"))?;
+        if observed_hash != block_hash {
+            return Err(format!(
+                "canonical artifact corruption during chainstate replay at height {height}: \
+                 expected {expected}, on-disk header hashes to {observed}",
+                expected = hex::encode(block_hash),
+                observed = hex::encode(observed_hash),
+            ));
+        }
+        let prev_timestamps = prev_timestamps_from_store(store, height)?;
+        state.connect_block_with_core_ext_deployments_and_suite_context(
+            &block_bytes,
+            cfg.expected_target,
+            prev_timestamps.as_deref(),
+            cfg.chain_id,
+            &cfg.core_ext_deployments,
+            rotation,
+            registry,
+        )?;
+        changed = true;
+    }
+    Ok(changed)
+}
+
+/// Build the prev-timestamps window used by `connect_block` consensus
+/// validation during replay. Returns up to 11 timestamps (the BIP-113
+/// MTP window) for the canonical chain ending at `height - 1`. A
+/// `None` return means `height == 0` (genesis), which has no prev
+/// window.
+///
+/// Standalone helper instead of going through `SyncEngine.
+/// prev_timestamps_for_height` because reconcile runs before the
+/// sync engine exists; both implementations are functionally
+/// identical and both will diverge into a shared helper if a third
+/// caller appears.
+fn prev_timestamps_from_store(store: &BlockStore, height: u64) -> Result<Option<Vec<u64>>, String> {
+    if height == 0 {
+        return Ok(None);
+    }
+    let window_len = height.min(11);
+    let mut out = Vec::with_capacity(window_len as usize);
+    for offset in 0..window_len {
+        let h = height - 1 - offset;
+        let hash = store.canonical_hash(h)?.ok_or_else(|| {
+            format!(
+                "missing canonical hash at height {h} for timestamp context (next_height={height})"
+            )
+        })?;
+        let header_bytes = store.get_header_by_hash(hash)?;
+        let header = parse_block_header_bytes(&header_bytes).map_err(|e| e.to_string())?;
+        out.push(header.timestamp);
+    }
+    Ok(Some(out))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::blockstore::block_store_path;
+    use crate::genesis::{devnet_genesis_block_bytes, devnet_genesis_chain_id};
+    use crate::io_utils::unique_temp_path;
+    use crate::sync::{default_sync_config, SyncEngine};
+    use rubin_consensus::constants::POW_LIMIT;
+    use rubin_consensus::{block_hash, parse_block_bytes};
+    use std::fs;
+
+    fn fresh_dir(prefix: &str) -> std::path::PathBuf {
+        let dir = unique_temp_path(prefix);
+        fs::create_dir_all(&dir).expect("create test dir");
+        dir
+    }
+
+    fn open_store_in(dir: &std::path::Path) -> BlockStore {
+        BlockStore::open(block_store_path(dir)).expect("open blockstore")
+    }
+
+    fn devnet_cfg() -> SyncConfig {
+        default_sync_config(Some(POW_LIMIT), devnet_genesis_chain_id(), None)
+    }
+
+    fn apply_genesis(store: BlockStore) -> ([u8; 32], BlockStore, ChainState) {
+        let cfg = devnet_cfg();
+        let mut engine = SyncEngine::new(ChainState::new(), Some(store), cfg).expect("sync engine");
+        engine
+            .apply_block(&devnet_genesis_block_bytes(), None)
+            .expect("apply_block(genesis)");
+        let parsed = parse_block_bytes(&devnet_genesis_block_bytes()).expect("parse genesis bytes");
+        let genesis_hash = block_hash(&parsed.header_bytes).expect("hash genesis");
+        let final_state = engine.chain_state_snapshot();
+        let final_store = engine.block_store_snapshot().expect("blockstore");
+        (genesis_hash, final_store, final_state)
+    }
+
+    /// Input validation: nil-equivalent inputs return errors (Go
+    /// `TestReconcileChainStateWithBlockStore_InputValidation*`).
+    /// Rust enforces non-null via `&mut` references — compile-time
+    /// check, but we still verify the empty-state noop branch and the
+    /// dirty-empty-store reset branch.
+    #[test]
+    fn reconcile_empty_store_empty_state_is_noop() {
+        let dir = fresh_dir("rubin-recover-empty");
+        let mut store = open_store_in(&dir);
+        let mut state = ChainState::new();
+        let cfg = devnet_cfg();
+        let changed =
+            reconcile_chain_state_with_block_store(&mut state, &mut store, &cfg).expect("ok");
+        assert!(!changed, "empty store + empty state must be a noop");
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn reconcile_empty_store_dirty_state_resets_to_empty() {
+        let dir = fresh_dir("rubin-recover-dirty");
+        let mut store = open_store_in(&dir);
+        let mut state = ChainState::new();
+        state.has_tip = true;
+        state.height = 7;
+        state.tip_hash[0] = 0xaa;
+        state.already_generated = 99;
+        let cfg = devnet_cfg();
+        let changed = reconcile_chain_state_with_block_store(&mut state, &mut store, &cfg)
+            .expect("reconcile");
+        assert!(changed, "dirty state with empty store must be reset");
+        assert!(!state.has_tip);
+        assert_eq!(state.height, 0);
+        assert_eq!(state.tip_hash, [0u8; 32]);
+        assert_eq!(state.already_generated, 0);
+        assert!(state.utxos.is_empty());
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn reconcile_noop_when_state_matches_canonical_tip() {
+        let dir = fresh_dir("rubin-recover-noop");
+        let store = open_store_in(&dir);
+        let (_genesis_hash, mut store, mut state) = apply_genesis(store);
+        let cfg = devnet_cfg();
+        let changed = reconcile_chain_state_with_block_store(&mut state, &mut store, &cfg)
+            .expect("reconcile");
+        assert!(!changed, "matching canonical tip must be a noop");
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn reconcile_resets_mismatched_snapshot_at_genesis() {
+        let dir = fresh_dir("rubin-recover-mismatch");
+        let store = open_store_in(&dir);
+        let (genesis_hash, mut store, mut state) = apply_genesis(store);
+        // Corrupt the snapshot's tip hash so canonical(height) != tip.
+        state.tip_hash[0] ^= 0xff;
+        let cfg = devnet_cfg();
+        let changed = reconcile_chain_state_with_block_store(&mut state, &mut store, &cfg)
+            .expect("reconcile");
+        assert!(changed, "mismatched snapshot must be reset and replayed");
+        assert!(state.has_tip);
+        assert_eq!(state.height, 0);
+        assert_eq!(state.tip_hash, genesis_hash);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn reconcile_resets_ahead_snapshot() {
+        let dir = fresh_dir("rubin-recover-ahead");
+        let store = open_store_in(&dir);
+        let (genesis_hash, mut store, mut state) = apply_genesis(store);
+        // Snapshot claims a height the blockstore does not have.
+        state.height = 5;
+        let cfg = devnet_cfg();
+        let changed = reconcile_chain_state_with_block_store(&mut state, &mut store, &cfg)
+            .expect("reconcile");
+        assert!(changed, "ahead snapshot must be reset and replayed");
+        assert_eq!(state.height, 0);
+        assert_eq!(state.tip_hash, genesis_hash);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// Set up a canonical entry at height 1 whose chosen artifact is
+    /// missing while the other two are present on disk. Verifies the
+    /// per-artifact `break` branches inside
+    /// `truncate_incomplete_canonical_suffix` (lines 96-107). `kind`
+    /// selects which file to OMIT: "header" / "block_data" / "undo".
+    fn synth_partial_artifact_at_height_1(
+        dir: &std::path::Path,
+        store: &mut BlockStore,
+        omit: &str,
+    ) -> [u8; 32] {
+        let fake_hash: [u8; 32] = [0xee; 32];
+        let bs_root = block_store_path(dir);
+        let header_path = bs_root
+            .join("headers")
+            .join(format!("{}.bin", hex::encode(fake_hash)));
+        let block_path = bs_root
+            .join("blocks")
+            .join(format!("{}.bin", hex::encode(fake_hash)));
+        let undo_path = bs_root
+            .join("undo")
+            .join(format!("{}.json", hex::encode(fake_hash)));
+        if omit != "header" {
+            fs::write(&header_path, b"fake header bytes").expect("write header");
+        }
+        if omit != "block_data" {
+            fs::write(&block_path, b"fake block bytes").expect("write block");
+        }
+        if omit != "undo" {
+            // Build a real `BlockUndo` and serialise via the
+            // production marshal helper so the on-disk JSON shape
+            // tracks the current `BlockUndoDisk` schema; using a
+            // hand-written JSON literal would silently drift on any
+            // future schema change and pass for the wrong reason.
+            let raw = crate::undo::marshal_block_undo(&crate::undo::BlockUndo {
+                block_height: 1,
+                previous_already_generated: 0,
+                txs: Vec::new(),
+            })
+            .expect("marshal undo");
+            fs::write(&undo_path, &raw).expect("write undo");
+        }
+        store
+            .set_canonical_tip(1, fake_hash)
+            .expect("set_canonical_tip");
+        fake_hash
+    }
+
+    /// Multi-block forward replay: snapshot is at height 1 with the
+    /// matching canonical hash, blockstore has tip at height 2 →
+    /// reconcile replays just block #2 (covers L213
+    /// `replay_from = state.height + 1` and L276-286 prev_timestamps
+    /// body for height >= 2).
+    #[test]
+    fn reconcile_replays_forward_from_matching_lower_height() {
+        use crate::test_helpers::{coinbase_only_block_with_gen, height_one_coinbase_only_block};
+        let dir = fresh_dir("rubin-recover-fwd-replay");
+        let store = open_store_in(&dir);
+        let cfg = devnet_cfg();
+        let mut engine =
+            SyncEngine::new(ChainState::new(), Some(store), cfg.clone()).expect("sync engine");
+        // Apply genesis.
+        engine
+            .apply_block(&devnet_genesis_block_bytes(), None)
+            .expect("apply_block(genesis)");
+        let g_parsed = parse_block_bytes(&devnet_genesis_block_bytes()).expect("parse genesis");
+        let g_hash = block_hash(&g_parsed.header_bytes).expect("hash genesis");
+        let g_ts = g_parsed.header.timestamp;
+        // Apply block 1.
+        let block1 = height_one_coinbase_only_block(g_hash, g_ts + 1);
+        engine.apply_block(&block1, None).expect("apply_block(1)");
+        let b1_parsed = parse_block_bytes(&block1).expect("parse block1");
+        let b1_hash = block_hash(&b1_parsed.header_bytes).expect("hash block1");
+        let b1_ts = b1_parsed.header.timestamp;
+        // Apply block 2 — provide the post-block-1 already_generated
+        // so the coinbase subsidy stays within consensus bounds.
+        let post_b1_already_gen = engine.chain_state_snapshot().already_generated;
+        let block2 = coinbase_only_block_with_gen(2, post_b1_already_gen, b1_hash, b1_ts + 1);
+        engine.apply_block(&block2, None).expect("apply_block(2)");
+        let b2_parsed = parse_block_bytes(&block2).expect("parse block2");
+        let b2_hash = block_hash(&b2_parsed.header_bytes).expect("hash block2");
+
+        let mut store = engine.block_store_snapshot().expect("blockstore");
+        // Build a stale snapshot at height 1 with matching canonical
+        // hash by replaying genesis + block1 onto a fresh ChainState —
+        // mirrors the intermediate state apply_block produced before
+        // block2. Reconcile must keep this state intact and replay
+        // only block 2.
+        let mut state = ChainState::new();
+        state
+            .connect_block_with_core_ext_deployments_and_suite_context(
+                &devnet_genesis_block_bytes(),
+                cfg.expected_target,
+                None,
+                cfg.chain_id,
+                &cfg.core_ext_deployments,
+                None,
+                None,
+            )
+            .expect("seed genesis");
+        state
+            .connect_block_with_core_ext_deployments_and_suite_context(
+                &block1,
+                cfg.expected_target,
+                Some(&[g_ts]),
+                cfg.chain_id,
+                &cfg.core_ext_deployments,
+                None,
+                None,
+            )
+            .expect("seed block1");
+        // Sanity-check the seeded snapshot matches the canonical hash
+        // at height 1 so reconcile takes the forward-replay path
+        // instead of resetting.
+        assert_eq!(state.height, 1);
+        assert_eq!(state.tip_hash, b1_hash);
+
+        let changed = reconcile_chain_state_with_block_store(&mut state, &mut store, &cfg)
+            .expect("reconcile");
+        assert!(changed, "stale-at-1 snapshot must replay block 2");
+        assert_eq!(state.height, 2);
+        assert_eq!(state.tip_hash, b2_hash);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// Bit-rot / file-swap defence: a parseable-but-wrong
+    /// `<hash>.bin` MUST be rejected by reconcile's re-hash check
+    /// before delegating to `connect_block_*`. Replace block 1's
+    /// payload with block 2's bytes (parseable, links to b1_hash as
+    /// prev_hash so chain-integrity passes — only re-hash catches
+    /// the swap), and assert reconcile returns
+    /// `canonical artifact corruption ... at height 1`. Mirror of
+    /// Go `TestReconcileChainStateWithBlockStore_PropagatesCorruptBlockBytesSwap`.
+    #[test]
+    fn reconcile_propagates_corrupt_canonical_block_artifact() {
+        use crate::test_helpers::{coinbase_only_block_with_gen, height_one_coinbase_only_block};
+        let dir = fresh_dir("rubin-recover-corrupt-block");
+        let store = open_store_in(&dir);
+        let cfg = devnet_cfg();
+        let mut engine =
+            SyncEngine::new(ChainState::new(), Some(store), cfg.clone()).expect("sync engine");
+        engine
+            .apply_block(&devnet_genesis_block_bytes(), None)
+            .expect("apply_block(genesis)");
+        let g_parsed = parse_block_bytes(&devnet_genesis_block_bytes()).expect("parse genesis");
+        let g_hash = block_hash(&g_parsed.header_bytes).expect("hash genesis");
+        let g_ts = g_parsed.header.timestamp;
+        let block1 = height_one_coinbase_only_block(g_hash, g_ts + 1);
+        engine.apply_block(&block1, None).expect("apply_block(1)");
+        let b1_parsed = parse_block_bytes(&block1).expect("parse b1");
+        let b1_hash = block_hash(&b1_parsed.header_bytes).expect("hash b1");
+        let post_b1_already_gen = engine.chain_state_snapshot().already_generated;
+        let block2 = coinbase_only_block_with_gen(
+            2,
+            post_b1_already_gen,
+            b1_hash,
+            b1_parsed.header.timestamp + 1,
+        );
+        // Overwrite `<b1_hash>.bin` block-bytes with block2 bytes —
+        // parseable, but header hashes to b2_hash, NOT b1_hash.
+        let bs_root = block_store_path(&dir);
+        let b1_block_path = bs_root
+            .join("blocks")
+            .join(format!("{}.bin", hex::encode(b1_hash)));
+        fs::write(&b1_block_path, &block2).expect("overwrite b1 block bytes");
+
+        let mut store = engine.block_store_snapshot().expect("blockstore");
+        let mut state = ChainState::new();
+        state
+            .connect_block_with_core_ext_deployments_and_suite_context(
+                &devnet_genesis_block_bytes(),
+                cfg.expected_target,
+                None,
+                cfg.chain_id,
+                &cfg.core_ext_deployments,
+                None,
+                None,
+            )
+            .expect("seed genesis");
+        let result = reconcile_chain_state_with_block_store(&mut state, &mut store, &cfg);
+        match result {
+            Err(msg) => assert!(
+                msg.contains("canonical artifact corruption") && msg.contains("at height 1"),
+                "expected corruption error mentioning height 1, got {msg}"
+            ),
+            Ok(_) => panic!("expected reconcile to reject corrupt block-bytes file"),
+        }
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// Pin `prev_timestamps_from_store` against `SyncEngine::
+    /// prev_timestamps_for_height` so the two implementations stay
+    /// in lockstep. Builds 4 blocks (genesis + 3) so window_len
+    /// reaches 3 (still below the 11-cap, but exercises the loop
+    /// body more than once) and asserts both functions produce
+    /// byte-identical `Vec<u64>` for the same `(store, height)`.
+    #[test]
+    fn prev_timestamps_from_store_matches_sync_engine() {
+        use crate::test_helpers::{coinbase_only_block_with_gen, height_one_coinbase_only_block};
+        let dir = fresh_dir("rubin-recover-prev-ts-parity");
+        let store = open_store_in(&dir);
+        let cfg = devnet_cfg();
+        let mut engine =
+            SyncEngine::new(ChainState::new(), Some(store), cfg.clone()).expect("sync engine");
+        engine
+            .apply_block(&devnet_genesis_block_bytes(), None)
+            .expect("apply_block(genesis)");
+        let g_parsed = parse_block_bytes(&devnet_genesis_block_bytes()).expect("parse genesis");
+        let g_hash = block_hash(&g_parsed.header_bytes).expect("hash genesis");
+        let g_ts = g_parsed.header.timestamp;
+        let block1 = height_one_coinbase_only_block(g_hash, g_ts + 1);
+        engine.apply_block(&block1, None).expect("apply_block(1)");
+        let b1_parsed = parse_block_bytes(&block1).expect("parse b1");
+        let b1_hash = block_hash(&b1_parsed.header_bytes).expect("hash b1");
+        let post_b1_gen = engine.chain_state_snapshot().already_generated;
+        let block2 =
+            coinbase_only_block_with_gen(2, post_b1_gen, b1_hash, b1_parsed.header.timestamp + 1);
+        engine.apply_block(&block2, None).expect("apply_block(2)");
+        let b2_parsed = parse_block_bytes(&block2).expect("parse b2");
+        let b2_hash = block_hash(&b2_parsed.header_bytes).expect("hash b2");
+        let post_b2_gen = engine.chain_state_snapshot().already_generated;
+        let block3 =
+            coinbase_only_block_with_gen(3, post_b2_gen, b2_hash, b2_parsed.header.timestamp + 1);
+        engine.apply_block(&block3, None).expect("apply_block(3)");
+
+        let store = engine.block_store_snapshot().expect("blockstore");
+        // Compare both helpers at every reachable height.
+        for h in 0..=3u64 {
+            let ours = prev_timestamps_from_store(&store, h).expect("ours");
+            let theirs = engine.prev_timestamps_for_height(h).expect("theirs");
+            assert_eq!(ours, theirs, "prev_timestamps mismatch at height {h}");
+        }
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn reconcile_truncates_when_block_data_missing() {
+        let dir = fresh_dir("rubin-recover-trunc-block");
+        let store = open_store_in(&dir);
+        let (genesis_hash, mut store, mut state) = apply_genesis(store);
+        // Header + undo present, block_data missing → truncate at L101.
+        let _fake = synth_partial_artifact_at_height_1(&dir, &mut store, "block_data");
+        state.height = 0;
+        state.tip_hash = genesis_hash;
+        let cfg = devnet_cfg();
+        let changed = reconcile_chain_state_with_block_store(&mut state, &mut store, &cfg)
+            .expect("reconcile");
+        assert!(changed);
+        let tip = store.tip().expect("tip").expect("has tip");
+        assert_eq!(tip.0, 0);
+        assert_eq!(tip.1, genesis_hash);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn reconcile_truncates_when_undo_missing() {
+        let dir = fresh_dir("rubin-recover-trunc-undo");
+        let store = open_store_in(&dir);
+        let (genesis_hash, mut store, mut state) = apply_genesis(store);
+        // Header + block_data present, undo missing → truncate at L105.
+        let _fake = synth_partial_artifact_at_height_1(&dir, &mut store, "undo");
+        state.height = 0;
+        state.tip_hash = genesis_hash;
+        let cfg = devnet_cfg();
+        let changed = reconcile_chain_state_with_block_store(&mut state, &mut store, &cfg)
+            .expect("reconcile");
+        assert!(changed);
+        let tip = store.tip().expect("tip").expect("has tip");
+        assert_eq!(tip.0, 0);
+        assert_eq!(tip.1, genesis_hash);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn reconcile_resets_tipless_dirty_state_with_canonical_chain() {
+        let dir = fresh_dir("rubin-recover-tipless");
+        let store = open_store_in(&dir);
+        let (genesis_hash, mut store, _) = apply_genesis(store);
+        // Build a fresh dirty-but-tipless state: has_tip=false but
+        // utxos non-empty (the "stale dirty snapshot" residue path).
+        // This forces the `else` branch at lines 224-226 (reset to
+        // empty + replay from 0).
+        let mut state = ChainState::new();
+        state.utxos.insert(
+            rubin_consensus::Outpoint {
+                txid: [0x33; 32],
+                vout: 0,
+            },
+            rubin_consensus::UtxoEntry {
+                value: 1,
+                covenant_type: 0,
+                covenant_data: Vec::new(),
+                creation_height: 0,
+                created_by_coinbase: false,
+            },
+        );
+        let cfg = devnet_cfg();
+        let changed = reconcile_chain_state_with_block_store(&mut state, &mut store, &cfg)
+            .expect("reconcile");
+        assert!(changed, "tipless dirty state must be reset and replayed");
+        assert!(state.has_tip);
+        assert_eq!(state.tip_hash, genesis_hash);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// Regression for the Codex P1 + Copilot P0 wave on PR #1221:
+    /// a metadata-level error on the canonical artifact (EACCES on
+    /// parent dir) MUST propagate as `Err(...)` from
+    /// `truncate_incomplete_canonical_suffix`, NOT silently be
+    /// interpreted as "missing → truncate". Unix-only because the
+    /// repro uses chmod 0; skipped under root.
+    #[cfg(unix)]
+    #[test]
+    fn truncate_propagates_metadata_eacces_instead_of_silent_truncate() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = fresh_dir("rubin-recover-eacces");
+        let store = open_store_in(&dir);
+        let (_genesis_hash, mut store, _state) = apply_genesis(store);
+        // Promote canonical to a fake height-1 entry whose artifact
+        // dir we will chmod 0o000 to force EACCES on metadata().
+        let fake_hash: [u8; 32] = [0x77; 32];
+        let bs_root = block_store_path(&dir);
+        let header_path = bs_root
+            .join("headers")
+            .join(format!("{}.bin", hex::encode(fake_hash)));
+        fs::write(&header_path, b"fake header").expect("write header");
+        store
+            .set_canonical_tip(1, fake_hash)
+            .expect("set_canonical_tip");
+        let headers_dir = bs_root.join("headers");
+        let original_perm = fs::metadata(&headers_dir).expect("stat dir").permissions();
+        fs::set_permissions(&headers_dir, fs::Permissions::from_mode(0o000)).expect("chmod 0");
+        // Detect root (or any environment that bypasses chmod) by
+        // checking whether metadata still succeeds — if it does, the
+        // test cannot reproduce EACCES, so skip the assertion to
+        // avoid a false negative under sudo / CI containers.
+        if fs::metadata(&header_path).is_ok() {
+            let _ = fs::set_permissions(&headers_dir, original_perm);
+            let _ = fs::remove_dir_all(&dir);
+            return;
+        }
+        let result = truncate_incomplete_canonical_suffix(&mut store);
+        // Restore perms before any panic so cleanup works.
+        let _ = fs::set_permissions(&headers_dir, original_perm);
+        match result {
+            Err(msg) => {
+                assert!(
+                    msg.contains("stat ") || msg.contains("Permission") || msg.contains("denied"),
+                    "expected propagated metadata error, got {msg}"
+                );
+            }
+            Ok(truncated) => panic!(
+                "EACCES on metadata MUST propagate, not silent truncate (got Ok({truncated}))"
+            ),
+        }
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn reconcile_truncates_incomplete_canonical_suffix() {
+        let dir = fresh_dir("rubin-recover-truncate");
+        let store = open_store_in(&dir);
+        let (genesis_hash, mut store, mut state) = apply_genesis(store);
+        // Synthesise a canonical entry at height 1 whose artifacts are
+        // missing. We use `BlockStore::set_canonical_tip` with a hash
+        // that has no header / block / undo files on disk — exactly
+        // the residue a crash between artifact write and tip advance
+        // would leave.
+        let fake_hash: [u8; 32] = [0x99; 32];
+        store
+            .set_canonical_tip(1, fake_hash)
+            .expect("set_canonical_tip");
+        // Reset the snapshot so reconcile must repair the truncation.
+        let stale_state = state.clone();
+        state.height = 0;
+        state.tip_hash = genesis_hash;
+        let cfg = devnet_cfg();
+        let changed = reconcile_chain_state_with_block_store(&mut state, &mut store, &cfg)
+            .expect("reconcile");
+        assert!(
+            changed,
+            "incomplete canonical suffix must trigger truncate + change report"
+        );
+        // After truncate, blockstore tip falls back to genesis.
+        let tip = store.tip().expect("tip").expect("has tip");
+        assert_eq!(tip.0, 0);
+        assert_eq!(tip.1, genesis_hash);
+        // Snapshot ends at genesis, identical to pre-set-canonical.
+        assert_eq!(state.height, 0);
+        assert_eq!(state.tip_hash, genesis_hash);
+        // Stale snapshot is unused after the test — silence dead-code.
+        drop(stale_state);
+        let _ = fs::remove_dir_all(&dir);
+    }
+}

--- a/clients/rust/crates/rubin-node/src/lib.rs
+++ b/clients/rust/crates/rubin-node/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod blockstore;
 pub mod chainstate;
+mod chainstate_recovery;
 pub mod coinbase;
 pub mod devnet_rpc;
 pub mod genesis;
@@ -26,6 +27,7 @@ pub use chainstate::{
     chain_state_path, load_chain_state, ChainState, ChainStateConnectSummary,
     CHAIN_STATE_FILE_NAME, UTXO_SET_HASH_DST,
 };
+pub use chainstate_recovery::reconcile_chain_state_with_block_store;
 pub use coinbase::{
     build_coinbase_tx, default_mine_address, normalize_mine_address, parse_mine_address,
     validate_mine_address,
@@ -43,7 +45,7 @@ pub use miner::{parse_mine_address_arg, MinedBlock, Miner, MinerConfig};
 pub use p2p_runtime::{default_peer_runtime_config, PeerManager};
 pub use p2p_service::{start_node_p2p_service, NodeP2PServiceConfig, RunningNodeP2PService};
 pub use sync::{
-    default_sync_config, HeaderRequest, PVTelemetrySnapshot, SyncConfig, SyncEngine,
-    DEFAULT_IBD_LAG_SECONDS,
+    default_sync_config, validate_mainnet_genesis_guard, HeaderRequest, PVTelemetrySnapshot,
+    SyncConfig, SyncEngine, DEFAULT_IBD_LAG_SECONDS,
 };
 pub use txpool::{TxPool, TxPoolAdmitError, TxPoolAdmitErrorKind, TxPoolConfig};

--- a/clients/rust/crates/rubin-node/src/main.rs
+++ b/clients/rust/crates/rubin-node/src/main.rs
@@ -13,9 +13,10 @@ use rubin_consensus::{
 use rubin_node::{
     block_store_path, chain_state_path, default_peer_runtime_config, default_sync_config,
     load_chain_state, load_genesis_config, new_devnet_rpc_state_with_tx_pool,
-    new_shared_runtime_tx_pool, parse_mine_address_arg, rpc_bind_host_is_loopback,
-    start_devnet_rpc_server, start_node_p2p_service, BlockStore, LoadedGenesisConfig, Miner,
-    MinerConfig, NodeP2PServiceConfig, PeerManager, SyncEngine,
+    new_shared_runtime_tx_pool, parse_mine_address_arg, reconcile_chain_state_with_block_store,
+    rpc_bind_host_is_loopback, start_devnet_rpc_server, start_node_p2p_service,
+    validate_mainnet_genesis_guard, BlockStore, LoadedGenesisConfig, Miner, MinerConfig,
+    NodeP2PServiceConfig, PeerManager, SyncEngine,
 };
 use serde::{Deserialize, Serialize};
 
@@ -188,7 +189,7 @@ fn run(args: &[String], stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
         );
         return 2;
     }
-    let chain_state = match load_chain_state(&chain_state_file) {
+    let mut chain_state = match load_chain_state(&chain_state_file) {
         Ok(chain_state) => chain_state,
         Err(err) => {
             let _ = writeln!(
@@ -200,16 +201,8 @@ fn run(args: &[String], stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
         }
     };
     let chain_id = genesis_cfg.chain_id;
-    if let Err(err) = chain_state.save(&chain_state_file) {
-        let _ = writeln!(
-            stderr,
-            "chainstate save failed ({}): {err}",
-            chain_state_file.display()
-        );
-        return 2;
-    }
 
-    let block_store = match BlockStore::open(block_store_path(&cfg.data_dir)) {
+    let mut block_store = match BlockStore::open(block_store_path(&cfg.data_dir)) {
         Ok(block_store) => block_store,
         Err(err) => {
             let _ = writeln!(stderr, "blockstore open failed: {err}");
@@ -223,6 +216,58 @@ fn run(args: &[String], stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
     sync_cfg.suite_context = genesis_cfg.suite_context.clone();
     sync_cfg.parallel_validation_mode = cfg.pv_mode.clone();
     sync_cfg.pv_shadow_max_samples = cfg.pv_shadow_max;
+
+    // Mainnet target / genesis guard runs BEFORE reconcile so a
+    // misconfigured `--network mainnet` startup is rejected before
+    // any reconcile-driven state mutation: reconcile may rewrite
+    // chainstate via truncate / replay, and we must not touch persisted
+    // state when the network config itself is invalid. `SyncEngine::new`
+    // runs the same guard internally as defence-in-depth: it re-validates
+    // the final `SyncConfig` actually passed to the engine, catching any
+    // mutation between this early call and engine construction. For
+    // callers that construct `SyncEngine` directly (tests, embedded uses)
+    // it is the ONLY guard. Do not remove the inner call as a perceived
+    // duplicate. Devnet / test networks no-op.
+    if let Err(err) = validate_mainnet_genesis_guard(&sync_cfg) {
+        let _ = writeln!(stderr, "mainnet genesis guard failed: {err}");
+        return 2;
+    }
+
+    // Startup reconcile (E.2): repair any chainstate ↔ blockstore
+    // mismatch left by a crash (incomplete canonical suffix, stale
+    // snapshot, ahead snapshot, mismatched tip hash) BEFORE the live
+    // sync engine, P2P, RPC, or miner start. Mirrors the Go
+    // `ReconcileChainStateWithBlockStore` call in `cmd/rubin-node/main.go`.
+    // A reconcile error is fatal: continuing would let the engine run
+    // with a chainstate tip that no longer points at any canonical
+    // block on disk.
+    if let Err(err) =
+        reconcile_chain_state_with_block_store(&mut chain_state, &mut block_store, &sync_cfg)
+    {
+        let _ = writeln!(stderr, "chainstate reconcile failed: {err}");
+        return 2;
+    }
+    if let Err(err) = chain_state.save(&chain_state_file) {
+        let _ = writeln!(
+            stderr,
+            "chainstate save failed ({}): {err}",
+            chain_state_file.display()
+        );
+        return 2;
+    }
+
+    // NOTE: `block_store.clone()` here mirrors the pre-existing
+    // pattern in `main.rs` (the RPC handoff at `Some(block_store)`
+    // below also moves an independent copy). After reconcile the
+    // clone captures the post-truncate snapshot, so the engine
+    // starts from the repaired index. The RPC vs SyncEngine
+    // BlockStore-divergence (their independent clones do NOT track
+    // each other's post-startup canonical advances) is a
+    // pre-existing main.rs gap, NOT introduced by E.2 reconcile,
+    // and is out of scope for this PR — see the Q-IMPL-RUST-RPC-
+    // BLOCKSTORE-SHARING follow-up for the proper Arc<BlockStore>
+    // fix that touches both `SyncEngine::new` and
+    // `new_devnet_rpc_state_with_tx_pool` signatures.
     let mut sync_engine = match SyncEngine::new(chain_state, Some(block_store.clone()), sync_cfg) {
         Ok(engine) => engine,
         Err(err) => {

--- a/clients/rust/crates/rubin-node/src/sync.rs
+++ b/clients/rust/crates/rubin-node/src/sync.rs
@@ -316,6 +316,12 @@ impl SyncEngine {
         block_store: Option<BlockStore>,
         mut cfg: SyncConfig,
     ) -> Result<Self, String> {
+        // Defence-in-depth re-check on the final `SyncConfig` actually
+        // used to construct the engine — catches any mutation of cfg
+        // between the authoritative early guard in `main.rs` (run BEFORE
+        // reconcile) and engine construction. For callers that construct
+        // `SyncEngine` directly (tests, embedded uses) this is the ONLY
+        // guard. Devnet / test networks no-op; guard itself is idempotent.
         validate_mainnet_genesis_guard(&cfg)?;
         if cfg.header_batch_limit == 0 {
             cfg.header_batch_limit = DEFAULT_HEADER_BATCH_LIMIT;
@@ -823,7 +829,7 @@ impl SyncEngine {
     }
 }
 
-fn validate_mainnet_genesis_guard(cfg: &SyncConfig) -> Result<(), String> {
+pub fn validate_mainnet_genesis_guard(cfg: &SyncConfig) -> Result<(), String> {
     let network = cfg.network.trim().to_ascii_lowercase();
     let network = if network.is_empty() {
         "devnet".to_string()


### PR DESCRIPTION
Closes Q-IMPL-RUST-STORAGE-STARTUP-RECONCILE-01 (refs #1173; finding `E.2`). Last P1 in storage-durability cluster (E.1 #1218 merged, E.3 #1220 merged, E.4 #1211 merged).

**Cross-client:** Both Rust (new) and Go (existing reconcile path) are touched in this PR — Rust adds the missing reconcile entry point, Go gains the symmetric replay re-hash defence + matching error literal so log-scrape parity holds.

## What this closes

Before this PR, `clients/rust/crates/rubin-node/src/main.rs` opened chainstate and blockstore independently and immediately constructed `SyncEngine`. If a crash had landed the chainstate snapshot but lost the matching block / undo file (or vice versa), the engine would run with a chainstate tip that no longer points at any canonical block on disk. Go has had this since the storage cluster landed; Rust did not.

## Repair contract (mirror Go)

`reconcile_chain_state_with_block_store(state, store, cfg)`:

1. `truncate_incomplete_canonical_suffix(store)` — iterate by height (`canonical_len()` + `canonical_hash(h)`, no full-vec clone); on the first height whose header / block-bytes / undo file is missing, truncate the index. Uses fallible `try_has_*` probes (`fs::metadata`-based) so EACCES / EIO / ENOTDIR propagate as fatal startup errors instead of silently triggering truncate.
2. Snapshot reconciliation:
   - empty store + dirty snapshot → reset snapshot to empty;
   - empty store + empty snapshot → no-op;
   - snapshot at height H, canonical(H) == snapshot.tip → replay canonical blocks from H+1 to tip;
   - canonical(H) ≠ snapshot.tip OR snapshot.height > tip → reset snapshot and replay from genesis.

Replay re-hashes each loaded `<hash>.bin`'s header against the canonical-index entry before delegating to `connect_block_*` (defence-in-depth against bit-rot / parseable-but-swapped block files). **Cross-client symmetric**: same check landed in Go `clients/go/node/chainstate_recovery.go::ReconcileChainStateWithBlockStore` in the same commit with the bit-identical error literal `canonical artifact corruption during chainstate replay at height N: expected <hex>, on-disk header hashes to <hex>`.

## Files

**Rust (new behaviour):**
- **NEW** `clients/rust/crates/rubin-node/src/chainstate_recovery.rs` — `reconcile_chain_state_with_block_store` (pub) + `truncate_incomplete_canonical_suffix` (pub(crate)) + `prev_timestamps_from_store` + full `# Threat model` doc + 13 tests.
- `clients/rust/crates/rubin-node/src/blockstore.rs` — fallible `try_has_block` / `try_has_block_data` / `try_has_undo` (`Result<bool, String>`); `try_has_file_at` private helper.
- `clients/rust/crates/rubin-node/src/lib.rs` — `mod chainstate_recovery;` (private), re-export only `reconcile_chain_state_with_block_store`.
- `clients/rust/crates/rubin-node/src/sync.rs` — `validate_mainnet_genesis_guard` promoted to `pub fn`, defence-in-depth duplicate noted.
- `clients/rust/crates/rubin-node/src/main.rs` — `validate_mainnet_genesis_guard` runs BEFORE reconcile; `reconcile_chain_state_with_block_store` between `BlockStore::open` and `SyncEngine::new`; save chainstate after reconcile. Reconcile errors are fatal (exit 2).

**Go (cross-client mirror):**
- `clients/go/node/chainstate_recovery.go` — replay loop adds bit-identical re-hash check; `missing canonical block hash during chainstate replay` enriched with `at height N (tip_height=N')` suffix matching the Rust literal.
- `clients/go/node/chainstate_recovery_test.go` — `TestReconcileChainStateWithBlockStore_PropagatesCorruptBlockBytesSwap` regression for the corrupt-block-bytes-swap case.

## Out of scope

- fsync durability (closed by `E.1`, PR #1218).
- atomic canonical commit semantics (closed by `E.4`, PR #1211).
- WAL / snapshot-cadence redesign.
- Non-startup runtime reconciliation (live sync engine handles via reorg / disconnect paths).
- RPC-vs-SyncEngine `BlockStore` clone divergence — pre-existing main.rs gap, tracked under Q-IMPL-RUST-RPC-BLOCKSTORE-SHARING follow-up.

## Tests

`cargo test -p rubin-node --lib -- chainstate_recovery` — 13/13 pass.
`go test ./node/ -run TestReconcileChainStateWithBlockStore` — pass.
`cargo clippy -D warnings` clean. `cargo fmt --check` clean. `gofmt -l` clean.
`preflight-codacy-coverage.sh` — diff coverage ≥85% PASS.

Pre-amend audit pipeline (11 stages: fmt, clippy, gofmt, cargo test, go test, vocab-grep, doc-enum scanner, threat-model scanner, cross-client parity, test-thread-safety, claude-review-sync) — verdict PASS.

## Test plan

- [x] `cargo test -p rubin-node --lib -- chainstate_recovery` — 13/13
- [x] `go test ./node/` — pass
- [x] `cargo clippy -p rubin-node --lib --tests -- -D warnings` — clean
- [x] `cargo fmt --check` + `gofmt -l` — clean
- [x] `preflight-codacy-coverage.sh` — PASS
- [ ] CI green
- [ ] Bot review (`@codex review` only; Copilot SWE-agent disabled repo-wide)
