### PR TITLE
fix(storage): add Rust safe-path traversal guard for BlockStore reads (Go parity)

### DIFF
--- a/clients/rust/crates/rubin-node/src/blockstore.rs
+++ b/clients/rust/crates/rubin-node/src/blockstore.rs
@@ -7,7 +7,9 @@ use rubin_consensus::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::io_utils::{parse_hex32, write_file_atomic, write_file_exclusive, AtomicWriteError};
+use crate::io_utils::{
+    parse_hex32, read_file_from_dir, write_file_atomic, write_file_exclusive, AtomicWriteError,
+};
 use crate::undo::{marshal_block_undo, unmarshal_block_undo, BlockUndo};
 
 pub const BLOCK_STORE_DIR_NAME: &str = "blockstore";
@@ -341,17 +343,26 @@ impl BlockStore {
     }
 
     pub fn get_block_by_hash(&self, block_hash_bytes: [u8; 32]) -> Result<Vec<u8>, String> {
-        let path = self
-            .blocks_dir
-            .join(format!("{}.bin", hex::encode(block_hash_bytes)));
-        fs::read(&path).map_err(|e| format!("read block {}: {e}", path.display()))
+        // E.10: route through `read_file_from_dir` so the leaf name is
+        // validated against the same traversal / absolute-path / empty-name
+        // guard Go enforces in `readFileFromDir`. The synthesized
+        // `<hex>.bin` cannot in practice contain a separator, but the
+        // guard removes the entire class of "leaf name from on-disk
+        // index drift becomes a traversal" without runtime cost.
+        let name = format!("{}.bin", hex::encode(block_hash_bytes));
+        read_file_from_dir(&self.blocks_dir, &name)
+            .map_err(|e| format!("read block {}: {e}", self.blocks_dir.join(&name).display()))
     }
 
     pub fn get_header_by_hash(&self, block_hash_bytes: [u8; 32]) -> Result<Vec<u8>, String> {
-        let path = self
-            .headers_dir
-            .join(format!("{}.bin", hex::encode(block_hash_bytes)));
-        fs::read(&path).map_err(|e| format!("read header {}: {e}", path.display()))
+        // E.10: see `get_block_by_hash` doc.
+        let name = format!("{}.bin", hex::encode(block_hash_bytes));
+        read_file_from_dir(&self.headers_dir, &name).map_err(|e| {
+            format!(
+                "read header {}: {e}",
+                self.headers_dir.join(&name).display()
+            )
+        })
     }
 
     pub fn has_block(&self, block_hash_bytes: [u8; 32]) -> bool {
@@ -541,10 +552,10 @@ impl BlockStore {
     }
 
     pub fn get_undo(&self, block_hash_bytes: [u8; 32]) -> Result<BlockUndo, String> {
-        let path = self
-            .undo_dir
-            .join(format!("{}.json", hex::encode(block_hash_bytes)));
-        let raw = fs::read(&path).map_err(|e| format!("read undo {}: {e}", path.display()))?;
+        // E.10: see `get_block_by_hash` doc.
+        let name = format!("{}.json", hex::encode(block_hash_bytes));
+        let raw = read_file_from_dir(&self.undo_dir, &name)
+            .map_err(|e| format!("read undo {}: {e}", self.undo_dir.join(&name).display()))?;
         unmarshal_block_undo(&raw)
     }
 

--- a/clients/rust/crates/rubin-node/src/blockstore.rs
+++ b/clients/rust/crates/rubin-node/src/blockstore.rs
@@ -8,8 +8,8 @@ use rubin_consensus::{
 use serde::{Deserialize, Serialize};
 
 use crate::io_utils::{
-    parse_hex32, read_file_by_path, read_file_from_dir, write_file_atomic_by_path,
-    write_file_exclusive, AtomicWriteError,
+    parse_hex32, read_file_by_path, read_file_from_dir, write_file_atomic,
+    write_file_atomic_by_path, write_file_exclusive, AtomicWriteError,
 };
 use crate::undo::{marshal_block_undo, unmarshal_block_undo, BlockUndo};
 
@@ -571,7 +571,17 @@ impl BlockStore {
         let path = self
             .undo_dir
             .join(format!("{}.json", hex::encode(block_hash_bytes)));
-        write_file_atomic_by_path(&path, &raw)
+        // Undo files intentionally stay on the raw `write_file_atomic`
+        // path (no `lexical_clean`) so the writer and the readers
+        // (`get_undo` / `has_undo` / `try_has_undo`, which all go
+        // through `self.undo_dir.join(...)` + raw `fs::read` or
+        // `.is_file()`) share one path-resolution strategy. The
+        // symlink-divergence defense matters for the durable
+        // chainstate / blockstore-index surface (startup read vs
+        // later save); undo files are ephemeral, reorg-scoped, and
+        // keep the Go-baseline symmetric raw-OS resolution so a
+        // written undo is always visible to the corresponding read.
+        write_file_atomic(&path, &raw)
     }
 
     pub fn get_undo(&self, block_hash_bytes: [u8; 32]) -> Result<BlockUndo, String> {

--- a/clients/rust/crates/rubin-node/src/blockstore.rs
+++ b/clients/rust/crates/rubin-node/src/blockstore.rs
@@ -8,8 +8,8 @@ use rubin_consensus::{
 use serde::{Deserialize, Serialize};
 
 use crate::io_utils::{
-    parse_hex32, read_file_by_path, read_file_from_dir, write_file_atomic, write_file_exclusive,
-    AtomicWriteError,
+    parse_hex32, read_file_by_path, read_file_from_dir, write_file_atomic_by_path,
+    write_file_exclusive, AtomicWriteError,
 };
 use crate::undo::{marshal_block_undo, unmarshal_block_undo, BlockUndo};
 
@@ -571,7 +571,7 @@ impl BlockStore {
         let path = self
             .undo_dir
             .join(format!("{}.json", hex::encode(block_hash_bytes)));
-        write_file_atomic(&path, &raw)
+        write_file_atomic_by_path(&path, &raw)
     }
 
     pub fn get_undo(&self, block_hash_bytes: [u8; 32]) -> Result<BlockUndo, String> {
@@ -804,7 +804,7 @@ fn save_blockstore_index_serializable<S: serde::Serialize + ?Sized>(
     let mut raw =
         serde_json::to_vec_pretty(index).map_err(|e| format!("encode blockstore index: {e}"))?;
     raw.push(b'\n');
-    write_file_atomic(path, &raw)
+    write_file_atomic_by_path(path, &raw)
 }
 
 /// Borrowed view of `BlockStoreIndexDisk` that serializes identically

--- a/clients/rust/crates/rubin-node/src/blockstore.rs
+++ b/clients/rust/crates/rubin-node/src/blockstore.rs
@@ -11,6 +11,7 @@ use crate::io_utils::{
     parse_hex32, read_file_from_dir, write_file_atomic, write_file_exclusive, AtomicWriteError,
 };
 use crate::undo::{marshal_block_undo, unmarshal_block_undo, BlockUndo};
+use std::ffi::OsStr;
 
 pub const BLOCK_STORE_DIR_NAME: &str = "blockstore";
 const BLOCK_STORE_INDEX_VERSION: u32 = 1;
@@ -774,19 +775,28 @@ fn try_has_file_at(path: &Path) -> Result<bool, String> {
 }
 
 fn load_blockstore_index(path: &Path) -> Result<BlockStoreIndexDisk, String> {
-    // The blockstore reads block / header / undo files via raw
-    // `read_file_from_dir` on `self.*_dir.join(...)` — no
-    // `lexical_clean` on the dir portion. Keep the index on the
-    // same raw resolution strategy so a single operator `--data-dir`
-    // that crosses a symlink combined with `..` lands on one
-    // physical tree for the index AND the block/header/undo files
-    // the index references. Routing the index read through
-    // `read_file_by_path` (which cleans) diverged the two: the
-    // index would load from the cleaned tree while block/header
-    // files resolved via OS symlink traversal to a different
-    // location, so a restart could load an index that points at
-    // hashes whose block/header files live elsewhere.
-    let raw = match fs::read(path) {
+    // Use `read_file_from_dir(parent, file_name)` so the leaf
+    // component still goes through the E.10 leaf-name guard, but
+    // the dir portion is kept AS-IS (no `lexical_clean`) — that
+    // way the index reads from the same physical directory the
+    // block / header / undo readers + writers use when they call
+    // `self.*_dir.join(...)` + raw `fs::read` / `write_file_atomic`.
+    // Operator `--data-dir` is already lexically cleaned once at
+    // the CLI parse site (`normalize_data_dir` in main.rs), so
+    // `path.parent()` here is also pre-cleaned; there is nothing
+    // to clean per-helper and no risk of split persistence between
+    // the index and the block / header / undo files it references.
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let name = match path.file_name().and_then(OsStr::to_str) {
+        Some(s) => s,
+        None => {
+            return Err(format!(
+                "blockstore index path has no valid UTF-8 leaf: {}",
+                path.display()
+            ));
+        }
+    };
+    let raw = match read_file_from_dir(parent, name) {
         Ok(raw) => raw,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             return Ok(BlockStoreIndexDisk {

--- a/clients/rust/crates/rubin-node/src/blockstore.rs
+++ b/clients/rust/crates/rubin-node/src/blockstore.rs
@@ -8,8 +8,7 @@ use rubin_consensus::{
 use serde::{Deserialize, Serialize};
 
 use crate::io_utils::{
-    parse_hex32, read_file_by_path, read_file_from_dir, write_file_atomic,
-    write_file_atomic_by_path, write_file_exclusive, AtomicWriteError,
+    parse_hex32, read_file_from_dir, write_file_atomic, write_file_exclusive, AtomicWriteError,
 };
 use crate::undo::{marshal_block_undo, unmarshal_block_undo, BlockUndo};
 
@@ -775,10 +774,19 @@ fn try_has_file_at(path: &Path) -> Result<bool, String> {
 }
 
 fn load_blockstore_index(path: &Path) -> Result<BlockStoreIndexDisk, String> {
-    // E.10: route through `read_file_by_path` so the index file read
-    // gets the same leaf-name guard Go's `loadBlockStoreIndex` enforces
-    // via its `readFileByPath` call. Mirrors Go cross-client.
-    let raw = match read_file_by_path(path) {
+    // The blockstore reads block / header / undo files via raw
+    // `read_file_from_dir` on `self.*_dir.join(...)` — no
+    // `lexical_clean` on the dir portion. Keep the index on the
+    // same raw resolution strategy so a single operator `--data-dir`
+    // that crosses a symlink combined with `..` lands on one
+    // physical tree for the index AND the block/header/undo files
+    // the index references. Routing the index read through
+    // `read_file_by_path` (which cleans) diverged the two: the
+    // index would load from the cleaned tree while block/header
+    // files resolved via OS symlink traversal to a different
+    // location, so a restart could load an index that points at
+    // hashes whose block/header files live elsewhere.
+    let raw = match fs::read(path) {
         Ok(raw) => raw,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             return Ok(BlockStoreIndexDisk {
@@ -822,7 +830,13 @@ fn save_blockstore_index_serializable<S: serde::Serialize + ?Sized>(
     let mut raw =
         serde_json::to_vec_pretty(index).map_err(|e| format!("encode blockstore index: {e}"))?;
     raw.push(b'\n');
-    write_file_atomic_by_path(path, &raw)
+    // Keep writer on raw `write_file_atomic` (no `lexical_clean`)
+    // so the index file persists to the same physical directory
+    // that block / header / undo writers use and that
+    // `load_blockstore_index` reads back from. See the comment in
+    // `load_blockstore_index` for the full blockstore-wide symmetry
+    // rationale.
+    write_file_atomic(path, &raw)
 }
 
 /// Borrowed view of `BlockStoreIndexDisk` that serializes identically

--- a/clients/rust/crates/rubin-node/src/blockstore.rs
+++ b/clients/rust/crates/rubin-node/src/blockstore.rs
@@ -572,14 +572,22 @@ impl BlockStore {
             .undo_dir
             .join(format!("{}.json", hex::encode(block_hash_bytes)));
         // Undo files intentionally stay on the raw `write_file_atomic`
-        // path (no `lexical_clean`) so the writer and the readers
-        // (`get_undo` / `has_undo` / `try_has_undo`, which all go
-        // through `self.undo_dir.join(...)` + raw `fs::read` or
-        // `.is_file()`) share one path-resolution strategy. The
-        // symlink-divergence defense matters for the durable
-        // chainstate / blockstore-index surface (startup read vs
-        // later save); undo files are ephemeral, reorg-scoped, and
-        // keep the Go-baseline symmetric raw-OS resolution so a
+        // path (no `lexical_clean`). Writer and readers share one
+        // dir-resolution strategy:
+        //   - `get_undo`     → `read_file_from_dir(&self.undo_dir, ...)`
+        //     (E.10 leaf-name guard on the leaf, NO `lexical_clean`
+        //     on `self.undo_dir`)
+        //   - `has_undo`     → `self.undo_dir.join(...).is_file()`
+        //   - `try_has_undo` → `try_has_file_at(&self.undo_dir.join(...))`
+        // None of them apply `lexical_clean` to `self.undo_dir`, so
+        // keeping the writer on raw `write_file_atomic` means a write
+        // that goes to `self.undo_dir.join(<hex>.json)` is the exact
+        // same path the readers probe. The symlink-divergence
+        // defense matters for the durable chainstate /
+        // blockstore-index surface (startup read vs later save
+        // under an operator `--data-dir` that crosses a symlink);
+        // undo files are ephemeral and reorg-scoped, and keep the
+        // Go-baseline symmetric raw-OS resolution so a freshly
         // written undo is always visible to the corresponding read.
         write_file_atomic(&path, &raw)
     }

--- a/clients/rust/crates/rubin-node/src/blockstore.rs
+++ b/clients/rust/crates/rubin-node/src/blockstore.rs
@@ -8,7 +8,8 @@ use rubin_consensus::{
 use serde::{Deserialize, Serialize};
 
 use crate::io_utils::{
-    parse_hex32, read_file_from_dir, write_file_atomic, write_file_exclusive, AtomicWriteError,
+    parse_hex32, read_file_by_path, read_file_from_dir, write_file_atomic, write_file_exclusive,
+    AtomicWriteError,
 };
 use crate::undo::{marshal_block_undo, unmarshal_block_undo, BlockUndo};
 
@@ -756,7 +757,10 @@ fn try_has_file_at(path: &Path) -> Result<bool, String> {
 }
 
 fn load_blockstore_index(path: &Path) -> Result<BlockStoreIndexDisk, String> {
-    let raw = match fs::read(path) {
+    // E.10: route through `read_file_by_path` so the index file read
+    // gets the same leaf-name guard Go's `loadBlockStoreIndex` enforces
+    // via its `readFileByPath` call. Mirrors Go cross-client.
+    let raw = match read_file_by_path(path) {
         Ok(raw) => raw,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             return Ok(BlockStoreIndexDisk {

--- a/clients/rust/crates/rubin-node/src/chainstate.rs
+++ b/clients/rust/crates/rubin-node/src/chainstate.rs
@@ -686,11 +686,19 @@ mod tests {
         let dir = unique_temp_path("rubin-chainstate-bare-filename");
         std::fs::create_dir_all(&dir).expect("mkdir");
 
+        // Rust's test harness `--exact` mode matches against the
+        // FULLY-QUALIFIED test name (`module::path::test_name`). Just
+        // the leaf name would filter to zero tests, the child process
+        // would exit successfully without running anything, and the
+        // parent `assert!(status.success())` would pass — leaving
+        // this regression test as a silent no-op. Pass the full path
+        // so the child actually re-enters this function through the
+        // `CHILD_ENV`-set branch above.
         let status = Command::new(std::env::current_exe().expect("current test binary"))
             .current_dir(&dir)
             .env(CHILD_ENV, "1")
             .arg("--exact")
-            .arg("save_accepts_bare_filename_via_effective_parent")
+            .arg("chainstate::tests::save_accepts_bare_filename_via_effective_parent")
             .status()
             .expect("spawn child test process");
 

--- a/clients/rust/crates/rubin-node/src/chainstate.rs
+++ b/clients/rust/crates/rubin-node/src/chainstate.rs
@@ -643,8 +643,12 @@ mod tests {
     }
 
     /// E.10 wiring lock: pin that `load_chain_state` routes through the
-    /// `read_file_by_path` guard so an invalid leaf component (`.`,
-    /// `..`) returns Err instead of attempting an OS read. Mirrors Go's
+    /// `read_file_by_path` guard so a path whose TRAILING-LEAF component
+    /// is `.` (or another guard-rejected shape) returns Err instead of
+    /// attempting an OS read. The guard validates ONLY the leaf
+    /// component — `..` appearing in PARENT components of an absolute
+    /// path is NOT blocked (e.g. `<dir>/../etc/passwd` has leaf
+    /// `passwd` and would proceed). Mirrors Go's
     /// `TestLoadChainState_InvalidFileName`. Without this test a future
     /// refactor could replace `read_file_by_path` with raw `fs::read`
     /// and the leaf-name guard would silently disappear.

--- a/clients/rust/crates/rubin-node/src/chainstate.rs
+++ b/clients/rust/crates/rubin-node/src/chainstate.rs
@@ -80,16 +80,18 @@ impl ChainState {
             fs::create_dir_all(parent)
                 .map_err(|e| format!("create chainstate parent {}: {e}", parent.display()))?;
         }
-        // Raw `write_file_atomic` — the caller's `path` comes from
-        // `chain_state_path(data_dir)` after `data_dir` was
-        // lexically cleaned at the CLI parse site
-        // (`normalize_data_dir`), so no per-helper
-        // `lexical_clean` step is needed here. Startup reads go
-        // through `load_chain_state` below which uses the same raw
-        // resolution on the same pre-cleaned path, so a symlink+`..`
-        // operator `--data-dir` cannot split persistence across two
-        // files: both read and write resolve through the same
-        // already-cleaned root.
+        // Raw `write_file_atomic`. Paired with `load_chain_state`'s
+        // raw `fs::read` — both use the caller-supplied path
+        // directly, with no per-helper `lexical_clean` step.
+        //
+        // For the node binary, `path` originates from
+        // `chain_state_path(cfg.data_dir)` after `cfg.data_dir` was
+        // cleaned at the CLI parse site, so the startup read and
+        // every subsequent save land on one on-disk file even for
+        // operator `--data-dir` values that cross a symlink
+        // combined with `..`. Other callers of `ChainState::save`
+        // are responsible for their own path hygiene — see
+        // `load_chain_state` for the mirror note.
         write_file_atomic(path, &raw)
     }
 
@@ -291,16 +293,19 @@ pub fn chain_state_path<P: AsRef<Path>>(data_dir: P) -> PathBuf {
 
 pub fn load_chain_state<P: AsRef<Path>>(path: P) -> Result<ChainState, String> {
     let path = path.as_ref();
-    // Raw `fs::read` on a caller-supplied path that originates from
-    // `chain_state_path(data_dir)` where `data_dir` was lexically
-    // cleaned once at the CLI parse site (`normalize_data_dir`).
-    // Writes go through the same raw resolution on the same
-    // pre-cleaned path in `ChainState::save`, so startup reads and
-    // subsequent saves land on exactly one on-disk file regardless
-    // of whether the operator `--data-dir` contained symlink+`..`
-    // segments. Mirrors the Go `LoadChainState` reader in
-    // `clients/go/node/chainstate.go`, which also uses a
-    // caller-supplied path directly.
+    // Raw `fs::read` on a caller-supplied path. Mirrors the Go
+    // `LoadChainState` reader in `clients/go/node/chainstate.go`,
+    // which also uses a caller-supplied path directly.
+    //
+    // For the node binary's own call site, `path` originates from
+    // `chain_state_path(cfg.data_dir)` after `cfg.data_dir` was
+    // lexically cleaned at the CLI parse site (`normalize_data_dir`
+    // in `main.rs`), so the startup read and subsequent
+    // `ChainState::save` writes land on exactly one on-disk file
+    // regardless of whether the operator `--data-dir` contained
+    // symlink+`..` segments. Other callers of this public function
+    // are responsible for their own path hygiene — this helper does
+    // NOT canonicalise or sandbox its input.
     let raw = match fs::read(path) {
         Ok(raw) => raw,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(ChainState::new()),

--- a/clients/rust/crates/rubin-node/src/chainstate.rs
+++ b/clients/rust/crates/rubin-node/src/chainstate.rs
@@ -245,14 +245,17 @@ pub fn chain_state_path<P: AsRef<Path>>(data_dir: P) -> PathBuf {
 
 pub fn load_chain_state<P: AsRef<Path>>(path: P) -> Result<ChainState, String> {
     let path = path.as_ref();
-    // E.10: route through `read_file_by_path` so the LEAF component is
-    // validated against the same `.`/`..`/separator/drive-prefix guard
-    // Go enforces in `readFileByPath` -> `readFileFromDir`. This is a
-    // leaf-name guard, NOT a full-path sandbox: a caller passing an
-    // absolute path like `/etc/passwd` would still read it because the
-    // leaf `"passwd"` passes validation. Full-path sandboxing is the
-    // caller's responsibility (here `path` originates from a trusted
-    // data-dir join). Mirrors the Go `LoadChainState` reader in
+    // E.10: route through `read_file_by_path` so the LEAF component
+    // gets the same `.`/`..`/separator (+ Windows drive-prefix) guard
+    // Go enforces in `readFileByPath` -> `readFileFromDir`. The guard
+    // refuses ONLY trailing-leaf escapes — a path of the shape
+    // `<data_dir>/<leaf>` whose leaf would itself escape (e.g. leaf is
+    // `..` literally, or contains a separator). It does NOT validate
+    // parent components: e.g. `<data_dir>/../etc/passwd` has leaf
+    // `passwd` which passes validation, and the read proceeds against
+    // the resolved parent. Full-path sandboxing is the caller's
+    // responsibility (here `path` originates from a trusted data-dir
+    // join). Mirrors the Go `LoadChainState` reader in
     // `clients/go/node/chainstate.go`.
     let raw = match read_file_by_path(path) {
         Ok(raw) => raw,
@@ -598,6 +601,36 @@ mod tests {
         assert_eq!(got, st);
 
         std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    /// E.10 wiring lock: pin that `load_chain_state` routes through the
+    /// `read_file_by_path` guard so an invalid leaf component (`.`,
+    /// `..`, trailing-separator, etc.) returns Err instead of attempting
+    /// an OS read. Mirrors Go's `TestLoadChainState_InvalidFileName`.
+    /// Without this test a future refactor could replace `read_file_by_path`
+    /// with raw `fs::read` and the guard would silently disappear.
+    #[test]
+    fn load_chain_state_invalid_leaf_name_rejected() {
+        // Leaf == "." — read_file_by_path's guard rejects with
+        // ErrorKind::InvalidInput; load_chain_state propagates as the
+        // operator-facing "read chainstate <path>: ..." error.
+        let result = load_chain_state(std::path::Path::new("."));
+        let err = result.expect_err("expected Err for leaf `.`");
+        assert!(
+            err.contains("invalid file name"),
+            "expected guard error in {err:?}"
+        );
+
+        // Trailing-separator path: `read_file_by_path` rejects with
+        // "ends with a separator" before stripping the trailing slash
+        // would silently change the read target.
+        let trailing = std::path::PathBuf::from("/tmp/");
+        let result = load_chain_state(&trailing);
+        let err = result.expect_err("expected Err for trailing-slash path");
+        assert!(
+            err.contains("ends with a separator"),
+            "expected trailing-separator error in {err:?}"
+        );
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/chainstate.rs
+++ b/clients/rust/crates/rubin-node/src/chainstate.rs
@@ -1,6 +1,5 @@
 use std::cmp::Ordering;
 use std::collections::HashMap;
-use std::fs;
 use std::path::{Path, PathBuf};
 
 use rubin_consensus::{
@@ -77,15 +76,19 @@ impl ChainState {
             serde_json::to_vec_pretty(&disk).map_err(|e| format!("encode chainstate: {e}"))?;
         raw.push(b'\n');
 
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent)
-                .map_err(|e| format!("create chainstate parent {}: {e}", parent.display()))?;
-        }
-        // Use `_by_path` so the write's dir/leaf resolution matches
-        // what `read_file_by_path` does at load time. Without this,
-        // a `--data-dir` that crosses a symlink combined with `..`
-        // segments would read one file on startup and persist to a
-        // different file on subsequent saves.
+        // Parent creation is delegated to `write_file_atomic_by_path`,
+        // which goes through `write_file_atomic::effective_parent` on
+        // the lexically-cleaned target. Creating `path.parent()` here
+        // would operate on the RAW path before cleaning, and for a
+        // `--data-dir` that crosses a symlink combined with `..`
+        // segments it would create or require the wrong directory
+        // (following the symlink out of the intended root) while the
+        // actual write happens at a different, cleaned location.
+        //
+        // Using `_by_path` for the write ensures startup reads and
+        // subsequent saves share the same dir/leaf resolution, so
+        // symlink+`..` operator paths cannot split persistence across
+        // two files.
         write_file_atomic_by_path(path, &raw)
     }
 

--- a/clients/rust/crates/rubin-node/src/chainstate.rs
+++ b/clients/rust/crates/rubin-node/src/chainstate.rs
@@ -76,10 +76,17 @@ impl ChainState {
         let mut raw =
             serde_json::to_vec_pretty(&disk).map_err(|e| format!("encode chainstate: {e}"))?;
         raw.push(b'\n');
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent)
-                .map_err(|e| format!("create chainstate parent {}: {e}", parent.display()))?;
-        }
+        // Parent creation is delegated to `write_file_atomic`, which
+        // runs `fs::create_dir_all(effective_parent(path))` on the
+        // actual write target. `effective_parent` maps a bare-filename
+        // input (`Path::new("chainstate.json").parent() == Some("")`)
+        // to `Some(".")` so the `create_dir_all` call always receives
+        // a non-empty directory. Running an explicit
+        // `fs::create_dir_all(path.parent())` here — as an earlier
+        // version did — instead passed `""` to `create_dir_all` on
+        // bare-filename callers and failed with an I/O error; this
+        // helper's own `effective_parent` is the correct layer.
+        //
         // Raw `write_file_atomic`. Paired with `load_chain_state`'s
         // raw `fs::read` — both use the caller-supplied path
         // directly, with no per-helper `lexical_clean` step.
@@ -649,6 +656,36 @@ mod tests {
         st.save(&path).expect("save");
         let got = load_chain_state(&path).expect("load");
         assert_eq!(got, st);
+
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    /// `ChainState::save` must accept a bare-filename path (e.g.
+    /// `"chainstate.json"`) without the pre-write `create_dir_all`
+    /// running against `""`. An earlier version of `save` called
+    /// `fs::create_dir_all(path.parent())` directly; for a
+    /// bare-filename input `path.parent()` is `Some("")` on Unix,
+    /// and `create_dir_all("")` fails with an I/O error. Parent
+    /// creation is delegated to `write_file_atomic` which uses
+    /// `effective_parent` (maps `""` → `.`), so `save("file.json")`
+    /// from the current working directory succeeds.
+    #[test]
+    fn save_accepts_bare_filename_via_effective_parent() {
+        use std::path::Path;
+        let dir = unique_temp_path("rubin-chainstate-bare-filename");
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        // cd into the temp dir so "chainstate.json" resolves locally.
+        let prev_cwd = std::env::current_dir().expect("get cwd");
+        std::env::set_current_dir(&dir).expect("cd");
+
+        let st = ChainState::new();
+        let result = st.save(Path::new("chainstate.json"));
+
+        // Always restore cwd before asserting so a failing assert
+        // does not leave the process in the temp dir.
+        std::env::set_current_dir(&prev_cwd).expect("restore cwd");
+
+        result.expect("save with bare filename must not error on empty parent");
 
         std::fs::remove_dir_all(&dir).expect("cleanup");
     }

--- a/clients/rust/crates/rubin-node/src/chainstate.rs
+++ b/clients/rust/crates/rubin-node/src/chainstate.rs
@@ -644,10 +644,10 @@ mod tests {
 
     /// E.10 wiring lock: pin that `load_chain_state` routes through the
     /// `read_file_by_path` guard so an invalid leaf component (`.`,
-    /// `..`, trailing-separator, etc.) returns Err instead of attempting
-    /// an OS read. Mirrors Go's `TestLoadChainState_InvalidFileName`.
-    /// Without this test a future refactor could replace `read_file_by_path`
-    /// with raw `fs::read` and the guard would silently disappear.
+    /// `..`) returns Err instead of attempting an OS read. Mirrors Go's
+    /// `TestLoadChainState_InvalidFileName`. Without this test a future
+    /// refactor could replace `read_file_by_path` with raw `fs::read`
+    /// and the leaf-name guard would silently disappear.
     #[test]
     fn load_chain_state_invalid_leaf_name_rejected() {
         // Leaf == "." — read_file_by_path's guard rejects with
@@ -658,17 +658,6 @@ mod tests {
         assert!(
             err.contains("invalid file name"),
             "expected guard error in {err:?}"
-        );
-
-        // Trailing-separator path: `read_file_by_path` rejects with
-        // "ends with a separator" before stripping the trailing slash
-        // would silently change the read target.
-        let trailing = std::path::PathBuf::from("/tmp/");
-        let result = load_chain_state(&trailing);
-        let err = result.expect_err("expected Err for trailing-slash path");
-        assert!(
-            err.contains("ends with a separator"),
-            "expected trailing-separator error in {err:?}"
         );
     }
 

--- a/clients/rust/crates/rubin-node/src/chainstate.rs
+++ b/clients/rust/crates/rubin-node/src/chainstate.rs
@@ -672,21 +672,32 @@ mod tests {
     #[test]
     fn save_accepts_bare_filename_via_effective_parent() {
         use std::path::Path;
+        use std::process::Command;
+
+        const CHILD_ENV: &str = "RUBIN_CHAINSTATE_BARE_FILENAME_CHILD";
+
+        if std::env::var_os(CHILD_ENV).is_some() {
+            let st = ChainState::new();
+            st.save(Path::new("chainstate.json"))
+                .expect("save with bare filename must not error on empty parent");
+            return;
+        }
+
         let dir = unique_temp_path("rubin-chainstate-bare-filename");
         std::fs::create_dir_all(&dir).expect("mkdir");
-        // cd into the temp dir so "chainstate.json" resolves locally.
-        let prev_cwd = std::env::current_dir().expect("get cwd");
-        std::env::set_current_dir(&dir).expect("cd");
 
-        let st = ChainState::new();
-        let result = st.save(Path::new("chainstate.json"));
+        let status = Command::new(std::env::current_exe().expect("current test binary"))
+            .current_dir(&dir)
+            .env(CHILD_ENV, "1")
+            .arg("--exact")
+            .arg("save_accepts_bare_filename_via_effective_parent")
+            .status()
+            .expect("spawn child test process");
 
-        // Always restore cwd before asserting so a failing assert
-        // does not leave the process in the temp dir.
-        std::env::set_current_dir(&prev_cwd).expect("restore cwd");
-
-        result.expect("save with bare filename must not error on empty parent");
-
+        assert!(
+            status.success(),
+            "child test process failed for bare filename save"
+        );
         std::fs::remove_dir_all(&dir).expect("cleanup");
     }
 

--- a/clients/rust/crates/rubin-node/src/chainstate.rs
+++ b/clients/rust/crates/rubin-node/src/chainstate.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 use sha3::{Digest, Sha3_256};
 
 use crate::genesis::validate_incoming_chain_id;
+use crate::io_utils::read_file_by_path;
 use crate::io_utils::{parse_hex32, write_file_atomic};
 
 pub const CHAIN_STATE_FILE_NAME: &str = "chainstate.json";
@@ -244,7 +245,16 @@ pub fn chain_state_path<P: AsRef<Path>>(data_dir: P) -> PathBuf {
 
 pub fn load_chain_state<P: AsRef<Path>>(path: P) -> Result<ChainState, String> {
     let path = path.as_ref();
-    let raw = match fs::read(path) {
+    // E.10: route through `read_file_by_path` so the LEAF component is
+    // validated against the same `.`/`..`/separator/drive-prefix guard
+    // Go enforces in `readFileByPath` -> `readFileFromDir`. This is a
+    // leaf-name guard, NOT a full-path sandbox: a caller passing an
+    // absolute path like `/etc/passwd` would still read it because the
+    // leaf `"passwd"` passes validation. Full-path sandboxing is the
+    // caller's responsibility (here `path` originates from a trusted
+    // data-dir join). Mirrors the Go `LoadChainState` reader in
+    // `clients/go/node/chainstate.go`.
+    let raw = match read_file_by_path(path) {
         Ok(raw) => raw,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(ChainState::new()),
         Err(e) => return Err(format!("read chainstate {}: {e}", path.display())),

--- a/clients/rust/crates/rubin-node/src/chainstate.rs
+++ b/clients/rust/crates/rubin-node/src/chainstate.rs
@@ -14,7 +14,7 @@ use sha3::{Digest, Sha3_256};
 
 use crate::genesis::validate_incoming_chain_id;
 use crate::io_utils::read_file_by_path;
-use crate::io_utils::{parse_hex32, write_file_atomic};
+use crate::io_utils::{parse_hex32, write_file_atomic_by_path};
 
 pub const CHAIN_STATE_FILE_NAME: &str = "chainstate.json";
 const CHAIN_STATE_DISK_VERSION: u32 = 1;
@@ -82,7 +82,12 @@ impl ChainState {
             fs::create_dir_all(parent)
                 .map_err(|e| format!("create chainstate parent {}: {e}", parent.display()))?;
         }
-        write_file_atomic(path, &raw)
+        // Use `_by_path` so the write's dir/leaf resolution matches
+        // what `read_file_by_path` does at load time. Without this,
+        // a `--data-dir` that crosses a symlink combined with `..`
+        // segments would read one file on startup and persist to a
+        // different file on subsequent saves.
+        write_file_atomic_by_path(path, &raw)
     }
 
     pub fn connect_block(

--- a/clients/rust/crates/rubin-node/src/chainstate.rs
+++ b/clients/rust/crates/rubin-node/src/chainstate.rs
@@ -1,5 +1,6 @@
 use std::cmp::Ordering;
 use std::collections::HashMap;
+use std::fs;
 use std::path::{Path, PathBuf};
 
 use rubin_consensus::{
@@ -12,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use sha3::{Digest, Sha3_256};
 
 use crate::genesis::validate_incoming_chain_id;
-use crate::io_utils::{parse_hex32, read_file_by_path, write_file_atomic_by_path};
+use crate::io_utils::{parse_hex32, write_file_atomic};
 
 pub const CHAIN_STATE_FILE_NAME: &str = "chainstate.json";
 const CHAIN_STATE_DISK_VERSION: u32 = 1;
@@ -75,21 +76,21 @@ impl ChainState {
         let mut raw =
             serde_json::to_vec_pretty(&disk).map_err(|e| format!("encode chainstate: {e}"))?;
         raw.push(b'\n');
-
-        // Parent creation is delegated to `write_file_atomic_by_path`,
-        // which goes through `write_file_atomic::effective_parent` on
-        // the lexically-cleaned target. Creating `path.parent()` here
-        // would operate on the RAW path before cleaning, and for a
-        // `--data-dir` that crosses a symlink combined with `..`
-        // segments it would create or require the wrong directory
-        // (following the symlink out of the intended root) while the
-        // actual write happens at a different, cleaned location.
-        //
-        // Using `_by_path` for the write ensures startup reads and
-        // subsequent saves share the same dir/leaf resolution, so
-        // symlink+`..` operator paths cannot split persistence across
-        // two files.
-        write_file_atomic_by_path(path, &raw)
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .map_err(|e| format!("create chainstate parent {}: {e}", parent.display()))?;
+        }
+        // Raw `write_file_atomic` — the caller's `path` comes from
+        // `chain_state_path(data_dir)` after `data_dir` was
+        // lexically cleaned at the CLI parse site
+        // (`normalize_data_dir`), so no per-helper
+        // `lexical_clean` step is needed here. Startup reads go
+        // through `load_chain_state` below which uses the same raw
+        // resolution on the same pre-cleaned path, so a symlink+`..`
+        // operator `--data-dir` cannot split persistence across two
+        // files: both read and write resolve through the same
+        // already-cleaned root.
+        write_file_atomic(path, &raw)
     }
 
     pub fn connect_block(
@@ -290,19 +291,17 @@ pub fn chain_state_path<P: AsRef<Path>>(data_dir: P) -> PathBuf {
 
 pub fn load_chain_state<P: AsRef<Path>>(path: P) -> Result<ChainState, String> {
     let path = path.as_ref();
-    // E.10: route through `read_file_by_path` so the LEAF component
-    // gets the same `.`/`..`/separator (+ Windows drive-prefix) guard
-    // Go enforces in `readFileByPath` -> `readFileFromDir`. The guard
-    // refuses ONLY trailing-leaf escapes — a path of the shape
-    // `<data_dir>/<leaf>` whose leaf would itself escape (e.g. leaf is
-    // `..` literally, or contains a separator). It does NOT validate
-    // parent components: e.g. `<data_dir>/../etc/passwd` has leaf
-    // `passwd` which passes validation, and the read proceeds against
-    // the resolved parent. Full-path sandboxing is the caller's
-    // responsibility (here `path` originates from a trusted data-dir
-    // join). Mirrors the Go `LoadChainState` reader in
-    // `clients/go/node/chainstate.go`.
-    let raw = match read_file_by_path(path) {
+    // Raw `fs::read` on a caller-supplied path that originates from
+    // `chain_state_path(data_dir)` where `data_dir` was lexically
+    // cleaned once at the CLI parse site (`normalize_data_dir`).
+    // Writes go through the same raw resolution on the same
+    // pre-cleaned path in `ChainState::save`, so startup reads and
+    // subsequent saves land on exactly one on-disk file regardless
+    // of whether the operator `--data-dir` contained symlink+`..`
+    // segments. Mirrors the Go `LoadChainState` reader in
+    // `clients/go/node/chainstate.go`, which also uses a
+    // caller-supplied path directly.
+    let raw = match fs::read(path) {
         Ok(raw) => raw,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(ChainState::new()),
         Err(e) => return Err(format!("read chainstate {}: {e}", path.display())),
@@ -647,29 +646,6 @@ mod tests {
         assert_eq!(got, st);
 
         std::fs::remove_dir_all(&dir).expect("cleanup");
-    }
-
-    /// E.10 wiring lock: pin that `load_chain_state` routes through the
-    /// `read_file_by_path` guard so a path whose TRAILING-LEAF component
-    /// is `.` (or another guard-rejected shape) returns Err instead of
-    /// attempting an OS read. The guard validates ONLY the leaf
-    /// component — `..` appearing in PARENT components of an absolute
-    /// path is NOT blocked (e.g. `<dir>/../etc/passwd` has leaf
-    /// `passwd` and would proceed). Mirrors Go's
-    /// `TestLoadChainState_InvalidFileName`. Without this test a future
-    /// refactor could replace `read_file_by_path` with raw `fs::read`
-    /// and the leaf-name guard would silently disappear.
-    #[test]
-    fn load_chain_state_invalid_leaf_name_rejected() {
-        // Leaf == "." — read_file_by_path's guard rejects with
-        // ErrorKind::InvalidInput; load_chain_state propagates as the
-        // operator-facing "read chainstate <path>: ..." error.
-        let result = load_chain_state(std::path::Path::new("."));
-        let err = result.expect_err("expected Err for leaf `.`");
-        assert!(
-            err.contains("invalid file name"),
-            "expected guard error in {err:?}"
-        );
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/chainstate.rs
+++ b/clients/rust/crates/rubin-node/src/chainstate.rs
@@ -13,8 +13,7 @@ use serde::{Deserialize, Serialize};
 use sha3::{Digest, Sha3_256};
 
 use crate::genesis::validate_incoming_chain_id;
-use crate::io_utils::read_file_by_path;
-use crate::io_utils::{parse_hex32, write_file_atomic_by_path};
+use crate::io_utils::{parse_hex32, read_file_by_path, write_file_atomic_by_path};
 
 pub const CHAIN_STATE_FILE_NAME: &str = "chainstate.json";
 const CHAIN_STATE_DISK_VERSION: u32 = 1;

--- a/clients/rust/crates/rubin-node/src/io_utils.rs
+++ b/clients/rust/crates/rubin-node/src/io_utils.rs
@@ -115,8 +115,36 @@ pub fn read_file_from_dir(dir: &Path, name: &str) -> Result<Vec<u8>, std::io::Er
 /// caller's responsibility (see `chainstate.rs` for an example
 /// where the path is constructed from a trusted data-dir).
 pub fn read_file_by_path(path: &Path) -> Result<Vec<u8>, std::io::Error> {
-    let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
-    read_file_from_dir(path.parent().unwrap_or(Path::new("")), name)
+    // Extract leaf via Go's `filepath.Base` semantics (string-based)
+    // rather than `Path::file_name`, which silently SKIPS trailing
+    // `.` components. With `Path::file_name`, an input like
+    // `"/etc/passwd/."` returns `"passwd"` and would silently read
+    // `/etc/passwd`; Go's `filepath.Base` returns `"."` for the same
+    // input and the leaf-name guard then rejects it. This implementation
+    // reproduces Go's behavior: trim trailing `/` (separator-only
+    // suffix), then take everything after the last `/`. The result is
+    // fed to the same `check_safe_file_name` guard.
+    let raw = match path.to_str() {
+        Some(s) => s,
+        None => {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("invalid path: non-UTF8 {path:?}"),
+            ));
+        }
+    };
+    let trimmed = raw.trim_end_matches('/');
+    let leaf = if trimmed.is_empty() {
+        // All-separator input; Go returns "/" — match by passing "/" to
+        // the leaf guard, which rejects it (contains `/`).
+        "/"
+    } else {
+        match trimmed.rfind('/') {
+            Some(idx) => &trimmed[idx + 1..],
+            None => trimmed,
+        }
+    };
+    read_file_from_dir(path.parent().unwrap_or(Path::new("")), leaf)
 }
 
 pub fn parse_hex32(name: &str, value: &str) -> Result<[u8; 32], String> {

--- a/clients/rust/crates/rubin-node/src/io_utils.rs
+++ b/clients/rust/crates/rubin-node/src/io_utils.rs
@@ -284,7 +284,11 @@ fn lexical_clean(input: &str) -> String {
 ///   trailing rooting separator (`"C:\\"`) so `dir.join(leaf)` stays
 ///   drive-rooted rather than collapsing to drive-relative.
 /// - Drive-relative input (`"C:foo"` on Windows): splits as
-///   `("C:", "foo")`, matching Go's drive-relative split.
+///   `("C:.", "foo")` after the `lexical_clean` step — the raw dir
+///   portion is `"C:"`, which Clean normalises to `"C:."` (volume
+///   present, no explicit component) exactly as Go's
+///   `filepath.Dir("C:foo")` does. The subsequent `dir.join(leaf)`
+///   still resolves to `C:foo` on Windows.
 ///
 /// Returns `InvalidInput` if the path is not valid UTF-8 (the helper
 /// relies on byte-level parsing of path separators).

--- a/clients/rust/crates/rubin-node/src/io_utils.rs
+++ b/clients/rust/crates/rubin-node/src/io_utils.rs
@@ -115,6 +115,21 @@ pub fn read_file_from_dir(dir: &Path, name: &str) -> Result<Vec<u8>, std::io::Er
 /// caller's responsibility (see `chainstate.rs` for an example
 /// where the path is constructed from a trusted data-dir).
 pub fn read_file_by_path(path: &Path) -> Result<Vec<u8>, std::io::Error> {
+    // Reject trailing-separator inputs explicitly: `Path::file_name()`
+    // strips a trailing `/` (or `\` on Windows) and `Path::parent()`
+    // returns the parent of the would-be leaf, so without this check
+    // `read_file_by_path("/etc/passwd/")` would silently read
+    // `/etc/passwd` — a different file than the caller passed in.
+    let raw = path.as_os_str().as_encoded_bytes();
+    if let Some(&last) = raw.last() {
+        let is_sep = last == b'/' || (cfg!(windows) && last == b'\\');
+        if is_sep {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("invalid path: {path:?} ends with a separator"),
+            ));
+        }
+    }
     let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
     read_file_from_dir(path.parent().unwrap_or(Path::new("")), name)
 }

--- a/clients/rust/crates/rubin-node/src/io_utils.rs
+++ b/clients/rust/crates/rubin-node/src/io_utils.rs
@@ -213,7 +213,7 @@ fn volume_prefix_len(s: &str) -> usize {
 /// On Windows both `/` and `\` are treated as separators per Go's
 /// `filepath` package; the canonical separator in the returned string
 /// is `std::path::MAIN_SEPARATOR`.
-fn lexical_clean(input: &str) -> String {
+pub(crate) fn lexical_clean(input: &str) -> String {
     #[cfg(windows)]
     let is_sep = |c: char| c == '/' || c == '\\';
     #[cfg(not(windows))]
@@ -263,187 +263,42 @@ fn lexical_clean(input: &str) -> String {
     out
 }
 
-/// Split a full path into `(cleaned_dir, leaf)` using the same
-/// dir/leaf derivation `read_file_by_path` and `write_file_atomic_by_path`
-/// share so read-then-write round-trips on the same input path cannot
-/// drift apart. Mirrors Go's `filepath.Dir` + `filepath.Base` pair,
-/// including Go's `filepath.Dir` internal `Clean` step: rooted `..`
-/// segments are collapsed textually (`lexical_clean`), not resolved
-/// through the OS.
+/// Normalise an operator-supplied `--data-dir` once at the CLI parse
+/// site so every subsystem that derives a path from it
+/// (`ChainState::save` / `load_chain_state`, `BlockStore::open` and
+/// its blocks / headers / undo / index sub-directories, etc.) sees
+/// the same already-cleaned root. With the root normalised once,
+/// internal readers and writers can stay on raw `fs::read` /
+/// `write_file_atomic` and remain symmetric with each other — there
+/// is no per-helper `lexical_clean` step that could diverge between
+/// read and write for operator paths that cross a symlink combined
+/// with `..`.
 ///
-/// Edge-case behaviour (kept identical between the read and write
-/// surfaces so a single operator-supplied path lands on the same file
-/// in both directions):
-/// - All-separator input (`"/"`, `"//"`): returns `("/", "/")`.
-/// - Trailing-separator input (`"/etc/passwd/"`): returns
-///   `("/etc/passwd", "passwd")`, matching Go's Dir/Base pair
-///   exactly. Per Go's own documented `ExampleDir`
-///   (<https://pkg.go.dev/path/filepath#Dir>):
-///
-///   ```text
-///   filepath.Dir("/foo/bar/baz/")  -> "/foo/bar/baz"
-///   filepath.Dir("/foo/bar/baz")   -> "/foo/bar"
-///   ```
-///
-///   The trailing separator changes the result — Go's `Dir` does
-///   NOT strip trailing separators and return the parent-of-parent.
-///   So Go's `readFileByPath("/etc/passwd/")` calls
-///   `readFileFromDir("/etc/passwd", "passwd")` and attempts to
-///   read `"/etc/passwd/passwd"`, which the OS then surfaces as
-///   ENOENT / ENOTDIR. The Rust mirror produces the same path.
-///   This behaviour is deliberate Go-parity — not a divergence —
-///   and is covered by
-///   `read_file_by_path_trailing_separator_does_not_silently_rewrite`.
-/// - Drive-root input (`"C:\\foo"` on Windows): dir preserves the
-///   trailing rooting separator (`"C:\\"`) so `dir.join(leaf)` stays
-///   drive-rooted rather than collapsing to drive-relative.
-/// - Drive-relative input (`"C:foo"` on Windows): splits as
-///   `("C:.", "foo")` after the `lexical_clean` step — the raw dir
-///   portion is `"C:"`, which Clean normalises to `"C:."` (volume
-///   present, no explicit component) exactly as Go's
-///   `filepath.Dir("C:foo")` does. The subsequent `dir.join(leaf)`
-///   still resolves to `C:foo` on Windows.
-///
-/// Returns `InvalidInput` if the path is not valid UTF-8 (the helper
-/// relies on byte-level parsing of path separators).
-fn resolve_io_path_dir_leaf(path: &Path) -> Result<(String, String), std::io::Error> {
-    // `Path::file_name`/`Path::parent` silently skip trailing `.`
-    // components: an input like `"/etc/passwd/."` returns
-    // `file_name = "passwd"`, which would make the read target
-    // `/etc/passwd` and bypass the leaf-name guard. Going through
-    // the raw `&str` and mirroring Go's `filepath.Base` keeps that
-    // vector rejected the same way Go rejects it.
-    //
-    // Per-OS separator parity with Go's `filepath.Base`: on Windows
-    // both `'/'` and `'\\'` are treated as separators; on Unix only
-    // `'/'`. Without the `cfg(windows)` branch, ordinary Windows
-    // paths like `C:\data\chainstate.json` would have no separator
-    // match, the whole string would become the leaf, and
-    // `check_safe_file_name` would reject it (contains `\` / drive
-    // prefix), regressing every Windows read/write through this
-    // helper.
-    let raw = match path.to_str() {
-        Some(s) => s,
-        None => {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                format!("invalid path: non-UTF8 {path:?}"),
-            ));
-        }
-    };
-    #[cfg(windows)]
-    let is_sep = |c: char| c == '/' || c == '\\';
-    #[cfg(not(windows))]
-    let is_sep = |c: char| c == '/';
-
-    // Empty input is distinct from all-separator input. Go's
-    // `filepath.Dir("")` and `filepath.Base("")` both return `"."`,
-    // and the leaf-name guard then rejects `"."` with
-    // `invalid file name: "."`. Without this branch, empty input
-    // would fall into the all-separator arm below and surface as
-    // `invalid file name: "/"` — a confusing error that implies the
-    // operator passed a rooted path when they passed no path at all.
-    if raw.is_empty() {
-        return Ok((".".to_string(), ".".to_string()));
+/// Returns `Err` if `path` is not valid UTF-8 (the lexical cleaner
+/// works on the string form of the path); the practical expectation
+/// is that `--data-dir` is a UTF-8 string since it comes from the
+/// argv vector this binary was launched with, but surfacing an
+/// explicit error keeps the failure mode obvious on unusual setups.
+pub fn normalize_data_dir(path: &Path) -> Result<PathBuf, String> {
+    match path.to_str() {
+        Some(s) => Ok(PathBuf::from(lexical_clean(s))),
+        None => Err(format!("data_dir must be valid UTF-8: {}", path.display())),
     }
-    let had_trailing_sep = raw.chars().next_back().is_some_and(is_sep);
-    let trimmed = raw.trim_end_matches(is_sep);
-    let (dir_str, leaf) = if trimmed.is_empty() {
-        // `raw` is non-empty but all separators (e.g. `"/"`, `"//"`).
-        // Go returns `"/"` for both `Dir` and `Base` here.
-        ("/", "/")
-    } else if had_trailing_sep {
-        // Go parity (see function-level doc for ExampleDir citation):
-        //   filepath.Dir("/foo/bar/baz/")  = "/foo/bar/baz"
-        //   filepath.Base("/foo/bar/baz/") = "baz"
-        // So for trailing-sep input the dir is the TRIMMED path
-        // itself and the leaf is the last component name. The
-        // resulting read/write target is `<trimmed>/<leaf>`, which
-        // surfaces as a real OS error on misuse — identical to Go.
-        let leaf = match trimmed.rfind(is_sep) {
-            Some(idx) => &trimmed[idx + 1..],
-            None => trimmed,
-        };
-        (trimmed, leaf)
-    } else {
-        match trimmed.rfind(is_sep) {
-            Some(idx) => {
-                // Preserve the rooting separator when the last
-                // separator is the path's root marker, otherwise the
-                // dir loses its absolute-root semantics:
-                //   - Unix `/foo`        → idx=0, dir must be `/`
-                //   - Windows `C:\foo`   → idx=2 right after drive
-                //     vol, dir must be `C:\` (NOT `C:`, which would
-                //     be drive-relative on Windows)
-                let vol_len = volume_prefix_len(trimmed);
-                let dir = if idx == 0 {
-                    "/"
-                } else if vol_len > 0 && idx == vol_len {
-                    &trimmed[..idx + 1]
-                } else {
-                    &trimmed[..idx]
-                };
-                (dir, &trimmed[idx + 1..])
-            }
-            None => {
-                let vol_len = volume_prefix_len(trimmed);
-                if vol_len > 0 && trimmed.len() > vol_len {
-                    (&trimmed[..vol_len], &trimmed[vol_len..])
-                } else {
-                    (".", trimmed)
-                }
-            }
-        }
-    };
-    let cleaned_dir = lexical_clean(dir_str);
-    Ok((cleaned_dir, leaf.to_string()))
 }
 
-/// Read a file by full path after validating only the LEAF component
-/// (not the full path) with the same `E.10` guard `read_file_from_dir`
-/// enforces. Mirrors the Go `readFileByPath` helper in
-/// `clients/go/node/safeio.go` for chainstate-style call sites that
-/// already work with a fully-resolved path
-/// (`<data_dir>/chainstate.json`) and need a drop-in safe reader.
-///
-/// This is a leaf-name / traversal guard, NOT a sandbox against
-/// arbitrary full-path input: a caller passing `/etc/passwd` will
-/// still read the absolute path because the leaf `"passwd"` passes
-/// the guard. The guard's job is to refuse names that, when treated
-/// as the trailing component, would escape their directory via
-/// `.`/`..`/separators/drive-prefix; full-path sandboxing is the
-/// caller's responsibility (see `chainstate.rs` for an example where
-/// the path is constructed from a trusted data-dir).
-pub fn read_file_by_path(path: &Path) -> Result<Vec<u8>, std::io::Error> {
-    let (cleaned_dir, leaf) = resolve_io_path_dir_leaf(path)?;
-    read_file_from_dir(Path::new(&cleaned_dir), &leaf)
-}
-
-/// Write `data` atomically to the file identified by `path`, using the
-/// same dir/leaf derivation `read_file_by_path` uses so a round-trip
-/// read-then-write on the same operator-supplied path lands on the
-/// same on-disk file. Without this symmetry, an operator `--data-dir`
-/// that passes through a symlink combined with `..` segments can
-/// cause startup to read one file while subsequent saves persist to
-/// a different file (split persistence / apparent state loss on
-/// symlink-escape paths).
-///
-/// This is deliberately stricter than the Go `safeio.go` twin, which
-/// calls `writeFileAtomic` directly on the original path (Go's read
-/// side applies `filepath.Dir`'s `Clean` step while its write side
-/// does not). Fixing the asymmetry in Go is tracked as a separate
-/// concern; the Rust side converges read and write here.
-///
-/// The `E.10` leaf-name guard still applies: the leaf derived from
-/// `path` must pass `check_safe_file_name`, so writes refuse the
-/// same traversal / absolute-path / drive-prefix vectors reads do.
-pub fn write_file_atomic_by_path(path: &Path, data: &[u8]) -> Result<(), String> {
-    let (cleaned_dir, leaf) =
-        resolve_io_path_dir_leaf(path).map_err(|e| format!("resolve path: {e}"))?;
-    check_safe_file_name(&leaf)?;
-    let target = Path::new(&cleaned_dir).join(&leaf);
-    write_file_atomic(&target, data)
-}
+// Historical helpers `resolve_io_path_dir_leaf`, `read_file_by_path`,
+// and `write_file_atomic_by_path` used to sit here. They applied
+// `lexical_clean` to the dir portion of a caller-supplied full path
+// so that symlink-divergence on an operator `--data-dir` could be
+// defeated at the per-read / per-write site. After adopting
+// CLI-level normalisation via `normalize_data_dir` in `main.rs`,
+// every subsystem now receives a pre-cleaned data-dir and can stay
+// on raw `fs::read` / `write_file_atomic`; the per-helper cleaning
+// step is no longer needed (and having it at some call sites but
+// not others reintroduced asymmetries between chainstate and
+// blockstore surfaces). The removed helpers and their regression
+// tests lived in git history; the CLI-level approach is the single
+// resolution strategy the whole node now uses.
 
 pub fn parse_hex32(name: &str, value: &str) -> Result<[u8; 32], String> {
     let bytes = hex::decode(value).map_err(|e| format!("{name}: {e}"))?;
@@ -808,11 +663,10 @@ pub fn unique_temp_path(prefix: &str) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::{
-        lexical_clean, read_file_by_path, read_file_from_dir, sync_dir, unique_temp_path,
-        volume_prefix_len, write_file_atomic, write_file_atomic_by_path,
+        lexical_clean, read_file_from_dir, sync_dir, unique_temp_path, volume_prefix_len,
+        write_file_atomic,
     };
     use std::fs;
-    use std::path::Path;
 
     /// E.10 parity: `read_file_from_dir` mirrors Go `readFileFromDir`.
     /// Rejected vectors (must surface `InvalidInput`):
@@ -862,45 +716,6 @@ mod tests {
         let _ = fs::remove_dir_all(&dir);
     }
 
-    /// Empty-path parity with Go `filepath.Dir("")` / `filepath.Base("")`
-    /// (both return `"."`): the leaf extraction must produce leaf=`"."`
-    /// and the guard must reject it with the `name == "."` branch of
-    /// `check_safe_file_name`, NOT the all-separator `"/"` rejection
-    /// path. Without this branch the empty-input error surfaces as
-    /// `invalid file name: "/"` — confusing because the operator did
-    /// not pass a rooted path.
-    #[test]
-    fn read_file_by_path_empty_input_rejected_as_dot_not_slash() {
-        let err = read_file_by_path(Path::new("")).expect_err("empty path must be rejected");
-        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
-        let msg = err.to_string();
-        assert!(
-            msg.contains("\".\""),
-            "expected `\".\"` leaf-guard rejection (Go parity), got: {msg}"
-        );
-        assert!(
-            !msg.contains("\"/\""),
-            "must not fall through to all-separator branch, got: {msg}"
-        );
-    }
-
-    /// Matching Go parity for the write side: `write_file_atomic_by_path`
-    /// uses the same leaf-guard error path as reads, so empty input
-    /// produces `invalid file name: "."` there too.
-    #[test]
-    fn write_file_atomic_by_path_empty_input_rejected_as_dot_not_slash() {
-        let err = write_file_atomic_by_path(Path::new(""), b"bytes")
-            .expect_err("empty path must be rejected");
-        assert!(
-            err.contains("\".\""),
-            "expected `\".\"` leaf-guard rejection (Go parity), got: {err}"
-        );
-        assert!(
-            !err.contains("\"/\""),
-            "must not fall through to all-separator branch, got: {err}"
-        );
-    }
-
     /// E.10 happy path: a real leaf name reads back the bytes.
     #[test]
     fn read_file_from_dir_reads_inside_root() {
@@ -911,94 +726,6 @@ mod tests {
 
         let got = read_file_from_dir(&dir, leaf).expect("read leaf");
         assert_eq!(got, b"hi");
-
-        let _ = fs::remove_dir_all(&dir);
-    }
-
-    /// E.10: a TRAILING `..` segment in the FULL path passed to
-    /// `read_file_by_path` becomes the extracted leaf, which the
-    /// leaf-name guard rejects. Covers shapes like `<data_dir>/..`
-    /// (leaf is `..`). It does NOT cover `..` in parent components
-    /// (e.g. `<data_dir>/../etc/passwd` has leaf `passwd` which
-    /// passes the guard) — full-path sandboxing is the caller's
-    /// responsibility, by design.
-    #[test]
-    fn read_file_by_path_rejects_dotdot_leaf() {
-        let dir = unique_temp_path("rubin-io-utils-by-path-dotdot");
-        fs::create_dir_all(&dir).expect("create test dir");
-
-        let bad = dir.join("..");
-        match read_file_by_path(&bad) {
-            Err(e) if e.kind() == std::io::ErrorKind::InvalidInput => {}
-            other => panic!("expected InvalidInput for trailing .., got {other:?}"),
-        }
-
-        let _ = fs::remove_dir_all(&dir);
-    }
-
-    /// E.10 happy path for `read_file_by_path`: full-path readers like
-    /// the chainstate loader read back what they wrote.
-    #[test]
-    fn read_file_by_path_reads_inside_root() {
-        let dir = unique_temp_path("rubin-io-utils-by-path-ok");
-        fs::create_dir_all(&dir).expect("create test dir");
-        let path = dir.join("chainstate.json");
-        fs::write(&path, b"{}").expect("seed");
-
-        let got = read_file_by_path(&path).expect("read by path");
-        assert_eq!(got, b"{}");
-
-        let _ = fs::remove_dir_all(&dir);
-    }
-
-    /// E.10 trailing-separator semantics: a caller passing
-    /// `<dir>/foo/` MUST NOT silently read `<dir>/foo` (which would
-    /// be the result of `Path::parent`/`Path::file_name`-style
-    /// stripping). This mirrors Go's `filepath.Dir` + `filepath.Base`
-    /// exactly — trailing separator changes the result of `Dir`, it
-    /// does NOT strip the trailing sep and return the parent-of-parent.
-    ///
-    /// Go's own `ExampleDir` (<https://pkg.go.dev/path/filepath#Dir>)
-    /// demonstrates this directly:
-    ///
-    ///     filepath.Dir("/foo/bar/baz/")  → "/foo/bar/baz"
-    ///     filepath.Dir("/foo/bar/baz")   → "/foo/bar"
-    ///
-    /// So for `<dir>/foo/` Go returns dir=`<dir>/foo`, leaf=`foo`;
-    /// the subsequent `readFileFromDir` attempt lands on
-    /// `<dir>/foo/foo` and surfaces ENOENT/ENOTDIR. This test pins
-    /// that Go-parity behaviour — it is NOT a divergence from Go
-    /// and MUST NOT be "fixed" by making the Rust side strip the
-    /// trailing separator (that would be the actual divergence).
-    #[test]
-    fn read_file_by_path_trailing_separator_does_not_silently_rewrite() {
-        let dir = unique_temp_path("rubin-io-utils-by-path-trailing-sep");
-        fs::create_dir_all(&dir).expect("create test dir");
-        let real = dir.join("foo");
-        fs::write(&real, b"contents-of-real-foo").expect("seed");
-
-        // Build a trailing-separator path: "<dir>/foo/"
-        let mut trailing = real.clone().into_os_string();
-        trailing.push("/");
-        let trailing_path = std::path::PathBuf::from(trailing);
-
-        let result = read_file_by_path(&trailing_path);
-        match result {
-            Ok(bytes) => panic!(
-                "expected error on trailing-separator input, got Ok({} bytes); \
-                 silent-rewrite-to-{} regression",
-                bytes.len(),
-                real.display()
-            ),
-            Err(e) => {
-                assert_ne!(
-                    e.kind(),
-                    std::io::ErrorKind::InvalidInput,
-                    "trailing-separator input should fall through to OS read \
-                     (NOT be rejected by the leaf-name guard); got {e}"
-                );
-            }
-        }
 
         let _ = fs::remove_dir_all(&dir);
     }
@@ -1033,144 +760,10 @@ mod tests {
         );
     }
 
-    /// E.10 symlink-divergence defence: lexically-clean dir BEFORE OS
-    /// resolution so `<root>/link/../foo` reads `<root>/foo`, not the
-    /// file under wherever `link` resolves. Mirrors Go `filepath.Dir`,
-    /// which Cleans textually and never follows the symlink for `..`
-    /// resolution.
-    ///
-    /// Divergence fixture: `root/foo` exists with bytes A; `link` is a
-    /// symlink pointing at `elsewhere/target/` where `elsewhere/` is
-    /// OUTSIDE `root`, and `elsewhere/foo` holds different bytes B.
-    /// With physical path resolution the kernel follows `link` to
-    /// `elsewhere/target/`, treats `..` as `elsewhere/`, and reads B.
-    /// With lexical cleaning `link/..` collapses textually, the read
-    /// stays under `root/`, and returns A.
-    ///
-    /// A sibling-directory setup (e.g. `link -> root/other`) does NOT
-    /// demonstrate divergence: `root/other`'s parent is `root`, so
-    /// physical and lexical both resolve to `root/foo`. The link target
-    /// must leave `root` for the two resolutions to diverge.
-    #[cfg(unix)]
-    #[test]
-    fn read_file_by_path_lexical_clean_defeats_symlink_divergence() {
-        use std::os::unix::fs as unix_fs;
-
-        let root = unique_temp_path("rubin-io-utils-by-path-symlink-div-root");
-        fs::create_dir_all(&root).expect("create root");
-        fs::write(root.join("foo"), b"local-bytes").expect("seed root/foo");
-
-        // `elsewhere/` is a separate tempdir so that its parent is NOT
-        // `root`. Put `elsewhere/foo` with different bytes, and
-        // `elsewhere/target/` as the symlink's point-to so that
-        // `link/..` physically resolves to `elsewhere/`.
-        let elsewhere = unique_temp_path("rubin-io-utils-by-path-symlink-div-elsewhere");
-        fs::create_dir_all(&elsewhere).expect("create elsewhere");
-        fs::write(elsewhere.join("foo"), b"other-bytes").expect("seed elsewhere/foo");
-        let target = elsewhere.join("target");
-        fs::create_dir_all(&target).expect("create elsewhere/target");
-
-        let link = root.join("link");
-        unix_fs::symlink(&target, &link).expect("symlink link → elsewhere/target");
-
-        // Caller-supplied path: <root>/link/../foo
-        let mut tricky = link.clone().into_os_string();
-        tricky.push("/../foo");
-        let tricky_path = std::path::PathBuf::from(tricky);
-
-        // Sanity: the kernel's physical resolution follows the symlink
-        // out of `root` to `elsewhere/target/`, treats `..` as
-        // `elsewhere/`, and reads `elsewhere/foo` = "other-bytes". This
-        // proves the divergence actually exists for this fixture; if
-        // this assertion ever flips to "local-bytes" the setup has
-        // regressed and the main assertion below is a no-op.
-        let direct = fs::read(&tricky_path).expect("direct fs::read");
-        assert_eq!(
-            direct, b"other-bytes",
-            "kernel physical resolution must follow symlink and read \
-             elsewhere/foo — fixture is broken otherwise"
-        );
-
-        // Main contract: `read_file_by_path` lexically cleans `link/..`
-        // before touching the filesystem, so it reads `root/foo`.
-        let got = read_file_by_path(&tricky_path).expect("read should succeed lexically");
-        assert_eq!(
-            got, b"local-bytes",
-            "lexical clean must collapse `link/..` textually and read \
-             root/foo, NOT follow the symlink to elsewhere/foo"
-        );
-
-        let _ = fs::remove_dir_all(&root);
-        let _ = fs::remove_dir_all(&elsewhere);
-    }
-
-    /// `write_file_atomic_by_path` + `read_file_by_path` must land on
-    /// the same physical file for an operator-supplied path that
-    /// crosses a symlink combined with `..`. Without shared dir/leaf
-    /// resolution between read and write, a `--data-dir` of the shape
-    /// `<real>/link/..` where `link` escapes `<real>` causes startup
-    /// reads to hit `<real>/chainstate.json` (via lexical clean) but
-    /// saves to persist at `<elsewhere>/chainstate.json` (via OS
-    /// symlink resolution), surfacing as apparent state loss after
-    /// restart. This test pins the round-trip on one file.
-    #[cfg(unix)]
-    #[test]
-    fn write_by_path_then_read_by_path_round_trips_through_symlink_escape() {
-        use std::os::unix::fs as unix_fs;
-
-        let root = unique_temp_path("rubin-io-utils-by-path-write-rt-root");
-        fs::create_dir_all(&root).expect("create root");
-
-        let elsewhere = unique_temp_path("rubin-io-utils-by-path-write-rt-elsewhere");
-        fs::create_dir_all(&elsewhere).expect("create elsewhere");
-        let target = elsewhere.join("target");
-        fs::create_dir_all(&target).expect("create elsewhere/target");
-
-        // Seed `elsewhere/foo` so we can tell if the write escaped.
-        fs::write(elsewhere.join("foo"), b"pre-existing-elsewhere").expect("seed elsewhere/foo");
-
-        let link = root.join("link");
-        unix_fs::symlink(&target, &link).expect("symlink link → elsewhere/target");
-
-        // Operator-supplied path: <root>/link/../foo
-        let mut tricky = link.clone().into_os_string();
-        tricky.push("/../foo");
-        let tricky_path = std::path::PathBuf::from(tricky);
-
-        // Write via `_by_path`. With shared resolution, this lands
-        // on `root/foo`, NOT `elsewhere/foo`.
-        write_file_atomic_by_path(&tricky_path, b"round-trip-bytes")
-            .expect("write_file_atomic_by_path");
-
-        // Read via `_by_path`. With shared resolution, this reads
-        // the same `root/foo` that the write produced.
-        let got = read_file_by_path(&tricky_path).expect("read back");
-        assert_eq!(
-            got, b"round-trip-bytes",
-            "read must see the bytes the write produced"
-        );
-
-        // Positive-proof that the write did NOT escape to `elsewhere`:
-        // `elsewhere/foo` keeps its pre-existing bytes.
-        let elsewhere_bytes = fs::read(elsewhere.join("foo")).expect("read elsewhere/foo");
-        assert_eq!(
-            elsewhere_bytes, b"pre-existing-elsewhere",
-            "write must NOT have followed the symlink out of root"
-        );
-
-        // And `root/foo` now holds the round-trip bytes.
-        let root_bytes = fs::read(root.join("foo")).expect("read root/foo");
-        assert_eq!(root_bytes, b"round-trip-bytes");
-
-        let _ = fs::remove_dir_all(&root);
-        let _ = fs::remove_dir_all(&elsewhere);
-    }
-
     /// `volume_prefix_len` must match Go `filepath.VolumeName` length
-    /// on every path shape the `read_file_by_path` /
-    /// `write_file_atomic_by_path` pair may encounter on Windows:
-    /// drive-letter, UNC (`\\HOST\SHARE`), DOS device drive
-    /// (`\\?\C:`, `\\.\C:`), DOS device UNC
+    /// on every path shape the `lexical_clean` helper may encounter
+    /// on Windows: drive-letter, UNC (`\\HOST\SHARE`), DOS device
+    /// drive (`\\?\C:`, `\\.\C:`), DOS device UNC
     /// (`\\?\UNC\HOST\SHARE`), and the malformed-prefix fail-closed
     /// cases. Non-Windows input always returns 0.
     #[test]

--- a/clients/rust/crates/rubin-node/src/io_utils.rs
+++ b/clients/rust/crates/rubin-node/src/io_utils.rs
@@ -432,11 +432,11 @@ pub(crate) fn lexical_clean(input: &str) -> String {
 /// read and write for operator paths that cross a symlink combined
 /// with `..`.
 ///
-/// Returns `Err` if `path` is not valid UTF-8 (the lexical cleaner
-/// works on the string form of the path); the practical expectation
-/// is that `--data-dir` is a UTF-8 string since it comes from the
-/// argv vector this binary was launched with, but surfacing an
-/// explicit error keeps the failure mode obvious on unusual setups.
+/// If `path` is valid UTF-8, applies `lexical_clean` to its string
+/// form and returns the cleaned `PathBuf`. If `path` is not valid
+/// UTF-8, returns it unchanged: `lexical_clean` is string-based, and
+/// preserving the original OS-native path avoids rejecting otherwise
+/// valid non-UTF-8 filesystem paths on unusual setups.
 pub fn normalize_data_dir(path: &Path) -> Result<PathBuf, String> {
     match path.to_str() {
         Some(s) => Ok(PathBuf::from(lexical_clean(s))),

--- a/clients/rust/crates/rubin-node/src/io_utils.rs
+++ b/clients/rust/crates/rubin-node/src/io_utils.rs
@@ -440,7 +440,23 @@ pub(crate) fn lexical_clean(input: &str) -> String {
 pub fn normalize_data_dir(path: &Path) -> Result<PathBuf, String> {
     match path.to_str() {
         Some(s) => Ok(PathBuf::from(lexical_clean(s))),
-        None => Err(format!("data_dir must be valid UTF-8: {}", path.display())),
+        None => {
+            // Non-UTF-8 path: `lexical_clean` is string-based and
+            // cannot run on the raw bytes. Rather than hard-fail
+            // startup for an otherwise valid OS-level path (on Unix
+            // `PathBuf` can hold arbitrary bytes; `default_data_dir`
+            // derives its path from `env::var_os("HOME")` which may
+            // legitimately be non-UTF-8), pass the path through
+            // unchanged. Plain `fs::read` / `fs::write` are
+            // byte-transparent and worked on the pre-CLI-normalize
+            // codebase for these paths, so we preserve that
+            // compatibility. The cost for this edge case is that a
+            // non-UTF-8 operator `--data-dir` with symlink+`..`
+            // shapes bypasses the CLI-level lexical cleanup — rare
+            // enough that we accept the trade-off over breaking
+            // the startup path.
+            Ok(path.to_path_buf())
+        }
     }
 }
 
@@ -894,6 +910,36 @@ mod tests {
         assert_eq!(got, b"hi");
 
         let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// `normalize_data_dir` must pass non-UTF-8 Unix paths through
+    /// unchanged rather than hard-fail. On Unix `PathBuf` can hold
+    /// arbitrary bytes (e.g. when `default_data_dir` derives the
+    /// path from `env::var_os("HOME")` and `$HOME` is not valid
+    /// UTF-8). Hard-failing here would regress startup for
+    /// otherwise-valid OS-level paths that `fs::read` / `fs::write`
+    /// handle correctly. The trade-off: non-UTF-8 operator
+    /// `--data-dir` values bypass the lexical cleanup, which is
+    /// acceptable for this rare edge case.
+    #[cfg(unix)]
+    #[test]
+    fn normalize_data_dir_preserves_non_utf8_unix_path() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+        use std::path::Path;
+
+        // Bytes include a valid-looking prefix followed by an
+        // invalid UTF-8 continuation byte (0xFF).
+        let raw_bytes: &[u8] = b"/tmp/rubin-data-\xFFdir";
+        let os_str = OsStr::from_bytes(raw_bytes);
+        let input = Path::new(os_str);
+        assert!(input.to_str().is_none(), "fixture must be non-UTF-8");
+
+        let cleaned = super::normalize_data_dir(input)
+            .expect("non-UTF-8 path must not hard-fail — falls through to raw");
+        // Raw bytes are preserved verbatim — no `.` appending, no
+        // separator rewriting, no UTF-8-lossy replacement.
+        assert_eq!(cleaned.as_os_str().as_bytes(), raw_bytes);
     }
 
     /// `lexical_clean` mirrors Go `path/filepath::Clean`. Each case

--- a/clients/rust/crates/rubin-node/src/io_utils.rs
+++ b/clients/rust/crates/rubin-node/src/io_utils.rs
@@ -697,6 +697,46 @@ mod tests {
         let _ = fs::remove_dir_all(&dir);
     }
 
+    /// E.10 trailing-separator semantics: a caller passing
+    /// `<dir>/foo/` MUST NOT silently read `<dir>/foo` (which would
+    /// be the result of `Path::parent`/`Path::file_name`-style
+    /// stripping). Mirrors Go's `filepath.Dir` + `filepath.Base`,
+    /// where `<dir>/foo/` resolves to dir=`<dir>/foo` + leaf=`foo`,
+    /// so the read attempts `<dir>/foo/foo` and surfaces an OS error
+    /// instead of returning bytes from `<dir>/foo`.
+    #[test]
+    fn read_file_by_path_trailing_separator_does_not_silently_rewrite() {
+        let dir = unique_temp_path("rubin-io-utils-by-path-trailing-sep");
+        fs::create_dir_all(&dir).expect("create test dir");
+        let real = dir.join("foo");
+        fs::write(&real, b"contents-of-real-foo").expect("seed");
+
+        // Build a trailing-separator path: "<dir>/foo/"
+        let mut trailing = real.clone().into_os_string();
+        trailing.push("/");
+        let trailing_path = std::path::PathBuf::from(trailing);
+
+        let result = read_file_by_path(&trailing_path);
+        match result {
+            Ok(bytes) => panic!(
+                "expected error on trailing-separator input, got Ok({} bytes); \
+                 silent-rewrite-to-{} regression",
+                bytes.len(),
+                real.display()
+            ),
+            Err(e) => {
+                assert_ne!(
+                    e.kind(),
+                    std::io::ErrorKind::InvalidInput,
+                    "trailing-separator input should fall through to OS read \
+                     (NOT be rejected by the leaf-name guard); got {e}"
+                );
+            }
+        }
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
     /// Smoke test for the E.1 durability contract: a fresh write goes
     /// through OpenOptions + sync_all + rename + parent dir-sync without
     /// surfacing an error on a real filesystem, and the resulting bytes

--- a/clients/rust/crates/rubin-node/src/io_utils.rs
+++ b/clients/rust/crates/rubin-node/src/io_utils.rs
@@ -136,6 +136,82 @@ fn volume_prefix_len(s: &str) -> usize {
     }
 }
 
+/// Lexical path cleanup mirroring Go's `path/filepath::Clean` for the
+/// path shapes `read_file_by_path` accepts. Performs no syscalls — `..`
+/// is collapsed against the preceding component textually, NOT through
+/// symlink resolution.
+///
+/// Without this step, a path like `link/../foo` where `link` is a
+/// symlink to another directory would resolve via the symlink at
+/// `stat()` time, reading a file under the symlink target instead of
+/// the local `foo`. Go applies `Clean` inside `filepath.Dir` so its
+/// `readFileByPath` does not exhibit this divergence; mirroring the
+/// lexical cleanup here keeps cross-client behaviour aligned for
+/// operator-supplied paths (notably `--data-dir` values that may
+/// contain `..` segments combined with symlinks anywhere along the
+/// resolved chain).
+///
+/// Rules (per Go `Clean`):
+///   - Drop each `.` element.
+///   - Eliminate each inner `..` element along with the non-`..`
+///     element immediately preceding it.
+///   - For a rooted path, drop a leading `..` (cannot escape root).
+///   - Collapse runs of consecutive separators into a single separator.
+///   - Empty input becomes `.`; an otherwise empty result becomes `.`.
+///
+/// On Windows both `/` and `\` are treated as separators per Go's
+/// `filepath` package; the canonical separator in the returned string
+/// is `std::path::MAIN_SEPARATOR`.
+fn lexical_clean(input: &str) -> String {
+    #[cfg(windows)]
+    let is_sep = |c: char| c == '/' || c == '\\';
+    #[cfg(not(windows))]
+    let is_sep = |c: char| c == '/';
+
+    let vol_len = volume_prefix_len(input);
+    let vol = &input[..vol_len];
+    let rest = &input[vol_len..];
+    let rooted = rest.starts_with(is_sep);
+
+    let mut parts: Vec<&str> = Vec::new();
+    for component in rest.split(is_sep) {
+        match component {
+            "" | "." => continue,
+            ".." => {
+                if let Some(last) = parts.last() {
+                    if *last != ".." {
+                        parts.pop();
+                        continue;
+                    }
+                }
+                if rooted {
+                    // /.. → /  : drop the parent-of-root reference.
+                    continue;
+                }
+                parts.push("..");
+            }
+            other => parts.push(other),
+        }
+    }
+
+    let sep = std::path::MAIN_SEPARATOR;
+    let mut out = String::with_capacity(input.len());
+    out.push_str(vol);
+    if rooted {
+        out.push(sep);
+    }
+    for (i, p) in parts.iter().enumerate() {
+        if i > 0 {
+            out.push(sep);
+        }
+        out.push_str(p);
+    }
+    if out.len() == vol.len() && !rooted {
+        out.push('.');
+    }
+    out
+}
+
 pub fn read_file_by_path(path: &Path) -> Result<Vec<u8>, std::io::Error> {
     // Extract leaf via Go's `filepath.Base` semantics (string-based)
     // rather than `Path::file_name`, which silently SKIPS trailing
@@ -229,7 +305,13 @@ pub fn read_file_by_path(path: &Path) -> Result<Vec<u8>, std::io::Error> {
             }
         }
     };
-    read_file_from_dir(Path::new(dir_str), leaf)
+    // Lexically clean the dir before passing to read_file_from_dir.
+    // This mirrors Go's `filepath.Dir`, which Cleans the result, so
+    // parent-component `..` segments are textually collapsed instead
+    // of resolved through the OS — defending against symlink-divergence
+    // when the path passes through a symlink before a `..`.
+    let cleaned_dir = lexical_clean(dir_str);
+    read_file_from_dir(Path::new(&cleaned_dir), leaf)
 }
 
 pub fn parse_hex32(name: &str, value: &str) -> Result<[u8; 32], String> {
@@ -595,7 +677,8 @@ pub fn unique_temp_path(prefix: &str) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::{
-        read_file_by_path, read_file_from_dir, sync_dir, unique_temp_path, write_file_atomic,
+        lexical_clean, read_file_by_path, read_file_from_dir, sync_dir, unique_temp_path,
+        write_file_atomic,
     };
     use std::fs;
 
@@ -735,6 +818,80 @@ mod tests {
         }
 
         let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// `lexical_clean` mirrors Go `path/filepath::Clean`. Each case
+    /// here is verified against Go's documented behaviour for the path
+    /// shapes the storage helpers accept.
+    #[test]
+    fn lexical_clean_matches_go_filepath_clean() {
+        let sep = std::path::MAIN_SEPARATOR;
+        let join = |parts: &[&str]| parts.join(&sep.to_string());
+
+        assert_eq!(lexical_clean(""), ".");
+        assert_eq!(lexical_clean("."), ".");
+        assert_eq!(lexical_clean(".."), "..");
+        assert_eq!(lexical_clean("../"), "..");
+        assert_eq!(lexical_clean("../.."), join(&["..", ".."]));
+        assert_eq!(lexical_clean("../foo"), join(&["..", "foo"]));
+        assert_eq!(lexical_clean("foo/../bar"), "bar");
+        assert_eq!(lexical_clean("foo/./bar"), join(&["foo", "bar"]));
+        assert_eq!(lexical_clean("foo//bar"), join(&["foo", "bar"]));
+        assert_eq!(lexical_clean("link/../foo"), "foo");
+        assert_eq!(lexical_clean("link/.."), ".");
+
+        // Rooted: leading `..` is dropped (cannot escape root).
+        assert_eq!(lexical_clean("/"), format!("{sep}"));
+        assert_eq!(lexical_clean("/.."), format!("{sep}"));
+        assert_eq!(lexical_clean("/../foo"), format!("{sep}foo"));
+        assert_eq!(
+            lexical_clean("/var/data/link/../chainstate.json"),
+            format!("{sep}var{sep}data{sep}chainstate.json")
+        );
+    }
+
+    /// E.10 symlink-divergence defence: lexically-clean dir BEFORE OS
+    /// resolution so `<dir>/link/../foo` reads `<dir>/foo`, not the
+    /// file under wherever `link` resolves. Mirrors Go `filepath.Dir`,
+    /// which Cleans textually and never follows the symlink for `..`
+    /// resolution.
+    ///
+    /// Concretely: `dir/foo` exists with bytes A, `dir/link` is a
+    /// symlink pointing at a sibling directory `dir/other` (which also
+    /// has a `foo` with different bytes B). A read of
+    /// `dir/link/../foo` MUST return A (lexical resolve to `dir/foo`),
+    /// NOT B (symlink-resolve to `dir/other/foo`).
+    #[cfg(unix)]
+    #[test]
+    fn read_file_by_path_lexical_clean_defeats_symlink_divergence() {
+        use std::os::unix::fs as unix_fs;
+
+        let root = unique_temp_path("rubin-io-utils-by-path-symlink-div");
+        fs::create_dir_all(&root).expect("create root");
+
+        let local_foo = root.join("foo");
+        fs::write(&local_foo, b"local-bytes").expect("seed local foo");
+
+        let other = root.join("other");
+        fs::create_dir_all(&other).expect("create other");
+        fs::write(other.join("foo"), b"other-bytes").expect("seed other/foo");
+
+        let link = root.join("link");
+        unix_fs::symlink(&other, &link).expect("symlink link → other");
+
+        // Caller-supplied path: <root>/link/../foo
+        let mut tricky = link.clone().into_os_string();
+        tricky.push("/../foo");
+        let tricky_path = std::path::PathBuf::from(tricky);
+
+        let got = read_file_by_path(&tricky_path).expect("read should succeed lexically");
+        assert_eq!(
+            got, b"local-bytes",
+            "lexical clean must collapse `link/..` textually and read root/foo, \
+             NOT follow the symlink to other/foo"
+        );
+
+        let _ = fs::remove_dir_all(&root);
     }
 
     /// Smoke test for the E.1 durability contract: a fresh write goes

--- a/clients/rust/crates/rubin-node/src/io_utils.rs
+++ b/clients/rust/crates/rubin-node/src/io_utils.rs
@@ -143,18 +143,40 @@ pub fn read_file_by_path(path: &Path) -> Result<Vec<u8>, std::io::Error> {
     #[cfg(not(windows))]
     let is_sep = |c: char| c == '/';
 
+    let had_trailing_sep = raw.chars().next_back().is_some_and(is_sep);
     let trimmed = raw.trim_end_matches(is_sep);
-    let leaf = if trimmed.is_empty() {
-        // All-separator input; Go returns "/" — match by passing "/" to
-        // the leaf guard, which rejects it (contains `/`).
-        "/"
-    } else {
-        match trimmed.rfind(is_sep) {
+    // Compute (dir, leaf) to match Go's `filepath.Dir`/`filepath.Base`
+    // pair exactly. The notable case is trailing-separator input
+    // `/etc/passwd/`: Go's `Dir` returns `/etc/passwd` (the trimmed
+    // path including the would-be-leaf) and `Base` returns `passwd`,
+    // so Go's `readFileByPath` then attempts `/etc/passwd/passwd`
+    // which surfaces as ENOENT/ENOTDIR — NOT a silent read of
+    // `/etc/passwd`. Mirroring `Path::parent`/`Path::file_name` would
+    // diverge (parent="/etc"+name="passwd" → reads `/etc/passwd`).
+    let (dir_str, leaf) = if trimmed.is_empty() {
+        // All-separator input; Go returns "/" for both `Base` and `Dir`.
+        ("/", "/")
+    } else if had_trailing_sep {
+        // Trailing-separator input. Go: dir = trimmed, leaf = last
+        // path component name. The combined read target is
+        // `<trimmed>/<leaf>` which surfaces a real OS error on
+        // misuse instead of silently rewriting.
+        let leaf = match trimmed.rfind(is_sep) {
             Some(idx) => &trimmed[idx + 1..],
             None => trimmed,
+        };
+        (trimmed, leaf)
+    } else {
+        // No trailing separator. Standard split at last separator.
+        match trimmed.rfind(is_sep) {
+            Some(idx) => {
+                let dir = if idx == 0 { "/" } else { &trimmed[..idx] };
+                (dir, &trimmed[idx + 1..])
+            }
+            None => (".", trimmed),
         }
     };
-    read_file_from_dir(path.parent().unwrap_or(Path::new("")), leaf)
+    read_file_from_dir(Path::new(dir_str), leaf)
 }
 
 pub fn parse_hex32(name: &str, value: &str) -> Result<[u8; 32], String> {

--- a/clients/rust/crates/rubin-node/src/io_utils.rs
+++ b/clients/rust/crates/rubin-node/src/io_utils.rs
@@ -851,47 +851,74 @@ mod tests {
     }
 
     /// E.10 symlink-divergence defence: lexically-clean dir BEFORE OS
-    /// resolution so `<dir>/link/../foo` reads `<dir>/foo`, not the
+    /// resolution so `<root>/link/../foo` reads `<root>/foo`, not the
     /// file under wherever `link` resolves. Mirrors Go `filepath.Dir`,
     /// which Cleans textually and never follows the symlink for `..`
     /// resolution.
     ///
-    /// Concretely: `dir/foo` exists with bytes A, `dir/link` is a
-    /// symlink pointing at a sibling directory `dir/other` (which also
-    /// has a `foo` with different bytes B). A read of
-    /// `dir/link/../foo` MUST return A (lexical resolve to `dir/foo`),
-    /// NOT B (symlink-resolve to `dir/other/foo`).
+    /// Divergence fixture: `root/foo` exists with bytes A; `link` is a
+    /// symlink pointing at `elsewhere/target/` where `elsewhere/` is
+    /// OUTSIDE `root`, and `elsewhere/foo` holds different bytes B.
+    /// With physical path resolution the kernel follows `link` to
+    /// `elsewhere/target/`, treats `..` as `elsewhere/`, and reads B.
+    /// With lexical cleaning `link/..` collapses textually, the read
+    /// stays under `root/`, and returns A.
+    ///
+    /// A sibling-directory setup (e.g. `link -> root/other`) does NOT
+    /// demonstrate divergence: `root/other`'s parent is `root`, so
+    /// physical and lexical both resolve to `root/foo`. The link target
+    /// must leave `root` for the two resolutions to diverge.
     #[cfg(unix)]
     #[test]
     fn read_file_by_path_lexical_clean_defeats_symlink_divergence() {
         use std::os::unix::fs as unix_fs;
 
-        let root = unique_temp_path("rubin-io-utils-by-path-symlink-div");
+        let root = unique_temp_path("rubin-io-utils-by-path-symlink-div-root");
         fs::create_dir_all(&root).expect("create root");
+        fs::write(root.join("foo"), b"local-bytes").expect("seed root/foo");
 
-        let local_foo = root.join("foo");
-        fs::write(&local_foo, b"local-bytes").expect("seed local foo");
-
-        let other = root.join("other");
-        fs::create_dir_all(&other).expect("create other");
-        fs::write(other.join("foo"), b"other-bytes").expect("seed other/foo");
+        // `elsewhere/` is a separate tempdir so that its parent is NOT
+        // `root`. Put `elsewhere/foo` with different bytes, and
+        // `elsewhere/target/` as the symlink's point-to so that
+        // `link/..` physically resolves to `elsewhere/`.
+        let elsewhere = unique_temp_path("rubin-io-utils-by-path-symlink-div-elsewhere");
+        fs::create_dir_all(&elsewhere).expect("create elsewhere");
+        fs::write(elsewhere.join("foo"), b"other-bytes").expect("seed elsewhere/foo");
+        let target = elsewhere.join("target");
+        fs::create_dir_all(&target).expect("create elsewhere/target");
 
         let link = root.join("link");
-        unix_fs::symlink(&other, &link).expect("symlink link → other");
+        unix_fs::symlink(&target, &link).expect("symlink link → elsewhere/target");
 
         // Caller-supplied path: <root>/link/../foo
         let mut tricky = link.clone().into_os_string();
         tricky.push("/../foo");
         let tricky_path = std::path::PathBuf::from(tricky);
 
+        // Sanity: the kernel's physical resolution follows the symlink
+        // out of `root` to `elsewhere/target/`, treats `..` as
+        // `elsewhere/`, and reads `elsewhere/foo` = "other-bytes". This
+        // proves the divergence actually exists for this fixture; if
+        // this assertion ever flips to "local-bytes" the setup has
+        // regressed and the main assertion below is a no-op.
+        let direct = fs::read(&tricky_path).expect("direct fs::read");
+        assert_eq!(
+            direct, b"other-bytes",
+            "kernel physical resolution must follow symlink and read \
+             elsewhere/foo — fixture is broken otherwise"
+        );
+
+        // Main contract: `read_file_by_path` lexically cleans `link/..`
+        // before touching the filesystem, so it reads `root/foo`.
         let got = read_file_by_path(&tricky_path).expect("read should succeed lexically");
         assert_eq!(
             got, b"local-bytes",
-            "lexical clean must collapse `link/..` textually and read root/foo, \
-             NOT follow the symlink to other/foo"
+            "lexical clean must collapse `link/..` textually and read \
+             root/foo, NOT follow the symlink to elsewhere/foo"
         );
 
         let _ = fs::remove_dir_all(&root);
+        let _ = fs::remove_dir_all(&elsewhere);
     }
 
     /// Smoke test for the E.1 durability contract: a fresh write goes

--- a/clients/rust/crates/rubin-node/src/io_utils.rs
+++ b/clients/rust/crates/rubin-node/src/io_utils.rs
@@ -209,7 +209,24 @@ pub fn read_file_by_path(path: &Path) -> Result<Vec<u8>, std::io::Error> {
                 };
                 (dir, &trimmed[idx + 1..])
             }
-            None => (".", trimmed),
+            None => {
+                // No separator inside trimmed. If trimmed starts with
+                // a Windows drive volume prefix and has more after it
+                // (e.g. "C:foo"), Go's filepath.Dir/Base split as
+                // dir = "<vol>" + leaf = "<rest>", giving a drive-
+                // relative read on Windows. Mirror that split here so
+                // callers passing drive-relative paths get the same
+                // resolution as Go (and the leaf-name guard still
+                // validates "<rest>", not the whole drive-prefixed
+                // string). On Unix volume_prefix_len always returns 0
+                // and this branch is a no-op.
+                let vol_len = volume_prefix_len(trimmed);
+                if vol_len > 0 && trimmed.len() > vol_len {
+                    (&trimmed[..vol_len], &trimmed[vol_len..])
+                } else {
+                    (".", trimmed)
+                }
+            }
         }
     };
     read_file_from_dir(Path::new(dir_str), leaf)

--- a/clients/rust/crates/rubin-node/src/io_utils.rs
+++ b/clients/rust/crates/rubin-node/src/io_utils.rs
@@ -114,6 +114,28 @@ pub fn read_file_from_dir(dir: &Path, name: &str) -> Result<Vec<u8>, std::io::Er
 /// `.`/`..`/separators/drive-prefix; full-path sandboxing is the
 /// caller's responsibility (see `chainstate.rs` for an example
 /// where the path is constructed from a trusted data-dir).
+/// Length of the volume prefix at the start of `s`. On Windows, returns
+/// 2 if `s` begins with an ASCII-letter + `:` (drive prefix like `C:`).
+/// On Unix and on Windows non-drive paths, returns 0. Mirrors Go's
+/// `filepath.VolumeName` length contract for the path shapes the
+/// `read_file_by_path` helper accepts (drive-letter paths only — UNC
+/// roots are not exercised by current callers).
+fn volume_prefix_len(s: &str) -> usize {
+    #[cfg(windows)]
+    {
+        let bytes = s.as_bytes();
+        if bytes.len() >= 2 && bytes[1] == b':' && bytes[0].is_ascii_alphabetic() {
+            return 2;
+        }
+        0
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = s;
+        0
+    }
+}
+
 pub fn read_file_by_path(path: &Path) -> Result<Vec<u8>, std::io::Error> {
     // Extract leaf via Go's `filepath.Base` semantics (string-based)
     // rather than `Path::file_name`, which silently SKIPS trailing
@@ -170,7 +192,21 @@ pub fn read_file_by_path(path: &Path) -> Result<Vec<u8>, std::io::Error> {
         // No trailing separator. Standard split at last separator.
         match trimmed.rfind(is_sep) {
             Some(idx) => {
-                let dir = if idx == 0 { "/" } else { &trimmed[..idx] };
+                // Preserve the rooting separator when the last separator
+                // is the path's root marker, otherwise the dir loses its
+                // absolute-root semantics:
+                //   - Unix `/foo`        → idx=0, dir must be `/`
+                //   - Windows `C:\foo`   → idx=2 right after drive vol,
+                //     dir must be `C:\` (NOT `C:`, which would be
+                //     drive-relative on Windows)
+                let vol_len = volume_prefix_len(trimmed);
+                let dir = if idx == 0 {
+                    "/"
+                } else if vol_len > 0 && idx == vol_len {
+                    &trimmed[..idx + 1]
+                } else {
+                    &trimmed[..idx]
+                };
                 (dir, &trimmed[idx + 1..])
             }
             None => (".", trimmed),
@@ -608,11 +644,13 @@ mod tests {
         let _ = fs::remove_dir_all(&dir);
     }
 
-    /// E.10: a `..` segment embedded in the FULL path passed to
-    /// `read_file_by_path` becomes the leaf component after
-    /// `Path::file_name`, which the leaf-name guard rejects. This
-    /// prevents `<data_dir>/..` and `<data_dir>/../etc/passwd` style
-    /// callers from sneaking past via `Path::join`.
+    /// E.10: a TRAILING `..` segment in the FULL path passed to
+    /// `read_file_by_path` becomes the extracted leaf, which the
+    /// leaf-name guard rejects. Covers shapes like `<data_dir>/..`
+    /// (leaf is `..`). It does NOT cover `..` in parent components
+    /// (e.g. `<data_dir>/../etc/passwd` has leaf `passwd` which
+    /// passes the guard) — full-path sandboxing is the caller's
+    /// responsibility, by design.
     #[test]
     fn read_file_by_path_rejects_dotdot_leaf() {
         let dir = unique_temp_path("rubin-io-utils-by-path-dotdot");

--- a/clients/rust/crates/rubin-node/src/io_utils.rs
+++ b/clients/rust/crates/rubin-node/src/io_utils.rs
@@ -280,8 +280,10 @@ fn lexical_clean(input: &str) -> String {
 ///   exactly. Per Go's own documented `ExampleDir`
 ///   (<https://pkg.go.dev/path/filepath#Dir>):
 ///
-///       filepath.Dir("/foo/bar/baz/")  → "/foo/bar/baz"
-///       filepath.Dir("/foo/bar/baz")   → "/foo/bar"
+///   ```text
+///   filepath.Dir("/foo/bar/baz/")  -> "/foo/bar/baz"
+///   filepath.Dir("/foo/bar/baz")   -> "/foo/bar"
+///   ```
 ///
 ///   The trailing separator changes the result — Go's `Dir` does
 ///   NOT strip trailing separators and return the parent-of-parent.

--- a/clients/rust/crates/rubin-node/src/io_utils.rs
+++ b/clients/rust/crates/rubin-node/src/io_utils.rs
@@ -276,10 +276,22 @@ fn lexical_clean(input: &str) -> String {
 /// in both directions):
 /// - All-separator input (`"/"`, `"//"`): returns `("/", "/")`.
 /// - Trailing-separator input (`"/etc/passwd/"`): returns
-///   `("/etc/passwd", "passwd")`, matching Go's Dir/Base pair — the
-///   subsequent join produces `"/etc/passwd/passwd"` and the OS
-///   surfaces ENOENT/ENOTDIR instead of a silent read/write of
-///   `/etc/passwd`.
+///   `("/etc/passwd", "passwd")`, matching Go's Dir/Base pair
+///   exactly. Per Go's own documented `ExampleDir`
+///   (<https://pkg.go.dev/path/filepath#Dir>):
+///
+///       filepath.Dir("/foo/bar/baz/")  → "/foo/bar/baz"
+///       filepath.Dir("/foo/bar/baz")   → "/foo/bar"
+///
+///   The trailing separator changes the result — Go's `Dir` does
+///   NOT strip trailing separators and return the parent-of-parent.
+///   So Go's `readFileByPath("/etc/passwd/")` calls
+///   `readFileFromDir("/etc/passwd", "passwd")` and attempts to
+///   read `"/etc/passwd/passwd"`, which the OS then surfaces as
+///   ENOENT / ENOTDIR. The Rust mirror produces the same path.
+///   This behaviour is deliberate Go-parity — not a divergence —
+///   and is covered by
+///   `read_file_by_path_trailing_separator_does_not_silently_rewrite`.
 /// - Drive-root input (`"C:\\foo"` on Windows): dir preserves the
 ///   trailing rooting separator (`"C:\\"`) so `dir.join(leaf)` stays
 ///   drive-rooted rather than collapsing to drive-relative.
@@ -339,6 +351,13 @@ fn resolve_io_path_dir_leaf(path: &Path) -> Result<(String, String), std::io::Er
         // Go returns `"/"` for both `Dir` and `Base` here.
         ("/", "/")
     } else if had_trailing_sep {
+        // Go parity (see function-level doc for ExampleDir citation):
+        //   filepath.Dir("/foo/bar/baz/")  = "/foo/bar/baz"
+        //   filepath.Base("/foo/bar/baz/") = "baz"
+        // So for trailing-sep input the dir is the TRIMMED path
+        // itself and the leaf is the last component name. The
+        // resulting read/write target is `<trimmed>/<leaf>`, which
+        // surfaces as a real OS error on misuse — identical to Go.
         let leaf = match trimmed.rfind(is_sep) {
             Some(idx) => &trimmed[idx + 1..],
             None => trimmed,
@@ -933,10 +952,22 @@ mod tests {
     /// E.10 trailing-separator semantics: a caller passing
     /// `<dir>/foo/` MUST NOT silently read `<dir>/foo` (which would
     /// be the result of `Path::parent`/`Path::file_name`-style
-    /// stripping). Mirrors Go's `filepath.Dir` + `filepath.Base`,
-    /// where `<dir>/foo/` resolves to dir=`<dir>/foo` + leaf=`foo`,
-    /// so the read attempts `<dir>/foo/foo` and surfaces an OS error
-    /// instead of returning bytes from `<dir>/foo`.
+    /// stripping). This mirrors Go's `filepath.Dir` + `filepath.Base`
+    /// exactly — trailing separator changes the result of `Dir`, it
+    /// does NOT strip the trailing sep and return the parent-of-parent.
+    ///
+    /// Go's own `ExampleDir` (<https://pkg.go.dev/path/filepath#Dir>)
+    /// demonstrates this directly:
+    ///
+    ///     filepath.Dir("/foo/bar/baz/")  → "/foo/bar/baz"
+    ///     filepath.Dir("/foo/bar/baz")   → "/foo/bar"
+    ///
+    /// So for `<dir>/foo/` Go returns dir=`<dir>/foo`, leaf=`foo`;
+    /// the subsequent `readFileFromDir` attempt lands on
+    /// `<dir>/foo/foo` and surfaces ENOENT/ENOTDIR. This test pins
+    /// that Go-parity behaviour — it is NOT a divergence from Go
+    /// and MUST NOT be "fixed" by making the Rust side strip the
+    /// trailing separator (that would be the actual divergence).
     #[test]
     fn read_file_by_path_trailing_separator_does_not_silently_rewrite() {
         let dir = unique_temp_path("rubin-io-utils-by-path-trailing-sep");

--- a/clients/rust/crates/rubin-node/src/io_utils.rs
+++ b/clients/rust/crates/rubin-node/src/io_utils.rs
@@ -192,15 +192,16 @@ fn volume_prefix_len(s: &str) -> usize {
 /// is collapsed against the preceding component textually, NOT through
 /// symlink resolution.
 ///
+/// Called once per node startup from `normalize_data_dir`, which
+/// cleans `cfg.data_dir` at the CLI parse site so every subsystem
+/// that derives a path from it sees an already-normalised root.
 /// Without this step, a path like `link/../foo` where `link` is a
 /// symlink to another directory would resolve via the symlink at
-/// `stat()` time, reading a file under the symlink target instead of
-/// the local `foo`. Go applies `Clean` inside `filepath.Dir` so its
-/// `readFileByPath` does not exhibit this divergence; mirroring the
-/// lexical cleanup here keeps cross-client behaviour aligned for
-/// operator-supplied paths (notably `--data-dir` values that may
-/// contain `..` segments combined with symlinks anywhere along the
-/// resolved chain).
+/// `stat()` time, reading a file under the symlink target instead
+/// of the local `foo`; applying the lexical cleanup once at CLI
+/// keeps cross-client behaviour aligned for operator-supplied
+/// `--data-dir` values that may contain `..` segments combined with
+/// symlinks anywhere along the resolved chain.
 ///
 /// Rules (per Go `Clean`):
 ///   - Drop each `.` element.
@@ -257,7 +258,23 @@ pub(crate) fn lexical_clean(input: &str) -> String {
         }
         out.push_str(p);
     }
-    if out.len() == vol.len() && !rooted {
+    // Append the `.` fallback only for the cases where Go's `Clean`
+    // actually emits one:
+    //   - No volume, no root, no parts: plain relative current-dir.
+    //   - Drive-letter volume (e.g. `C:`) with empty rest: Go's
+    //     `Clean("C:") = "C:."` (drive-relative current on that drive).
+    // UNC / DOS-device volume roots (any prefix starting with two
+    // path separators: `\\HOST\SHARE`, `\\?\UNC\HOST\SHARE`,
+    // `\\?\C:`) must NOT receive the trailing `.` — Go returns the
+    // volume unchanged there (`filepath.Clean("\\\\server\\share")` =
+    // `"\\\\server\\share"`). Without this guard a UNC volume-only
+    // input would be rewritten to `"\\\\server\\share."`, which is a
+    // different (and invalid) path.
+    let starts_with_double_sep = {
+        let bytes = input.as_bytes();
+        bytes.len() >= 2 && is_sep(bytes[0] as char) && is_sep(bytes[1] as char)
+    };
+    if out.len() == vol.len() && !rooted && !starts_with_double_sep {
         out.push('.');
     }
     out
@@ -758,6 +775,35 @@ mod tests {
             lexical_clean("/var/data/link/../chainstate.json"),
             format!("{sep}var{sep}data{sep}chainstate.json")
         );
+    }
+
+    /// Windows UNC and DOS-device volume-only inputs must pass
+    /// through `lexical_clean` unchanged. Go's `filepath.Clean`
+    /// special-cases this: when the volume is the whole path and the
+    /// input starts with two path separators (UNC / DOS device), the
+    /// volume is returned as-is — NOT with a trailing `.` appended
+    /// (that `.` fallback is only for no-volume empty results and for
+    /// drive-letter-only inputs where Go returns `"C:."`).
+    ///
+    /// Without that special case a UNC volume root would be rewritten
+    /// to a different (and invalid) path, e.g.
+    /// `"\\\\server\\share"` → `"\\\\server\\share."`.
+    #[cfg(windows)]
+    #[test]
+    fn lexical_clean_preserves_unc_volume_roots() {
+        // Plain UNC volume root.
+        assert_eq!(lexical_clean("\\\\server\\share"), "\\\\server\\share");
+        // DOS-device UNC volume root.
+        assert_eq!(
+            lexical_clean("\\\\?\\UNC\\server\\share"),
+            "\\\\?\\UNC\\server\\share"
+        );
+        // Drive-letter volume with empty rest still gets the `.`
+        // (Go parity: `filepath.Clean("C:") = "C:."`).
+        assert_eq!(lexical_clean("C:"), "C:.");
+        // UNC volume root with trailing separator collapses the
+        // trailing sep but keeps the volume intact.
+        assert_eq!(lexical_clean("\\\\server\\share\\"), "\\\\server\\share\\");
     }
 
     /// `volume_prefix_len` must match Go `filepath.VolumeName` length

--- a/clients/rust/crates/rubin-node/src/io_utils.rs
+++ b/clients/rust/crates/rubin-node/src/io_utils.rs
@@ -115,21 +115,6 @@ pub fn read_file_from_dir(dir: &Path, name: &str) -> Result<Vec<u8>, std::io::Er
 /// caller's responsibility (see `chainstate.rs` for an example
 /// where the path is constructed from a trusted data-dir).
 pub fn read_file_by_path(path: &Path) -> Result<Vec<u8>, std::io::Error> {
-    // Reject trailing-separator inputs explicitly: `Path::file_name()`
-    // strips a trailing `/` (or `\` on Windows) and `Path::parent()`
-    // returns the parent of the would-be leaf, so without this check
-    // `read_file_by_path("/etc/passwd/")` would silently read
-    // `/etc/passwd` — a different file than the caller passed in.
-    let raw = path.as_os_str().as_encoded_bytes();
-    if let Some(&last) = raw.last() {
-        let is_sep = last == b'/' || (cfg!(windows) && last == b'\\');
-        if is_sep {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                format!("invalid path: {path:?} ends with a separator"),
-            ));
-        }
-    }
     let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
     read_file_from_dir(path.parent().unwrap_or(Path::new("")), name)
 }

--- a/clients/rust/crates/rubin-node/src/io_utils.rs
+++ b/clients/rust/crates/rubin-node/src/io_utils.rs
@@ -318,9 +318,21 @@ fn resolve_io_path_dir_leaf(path: &Path) -> Result<(String, String), std::io::Er
     #[cfg(not(windows))]
     let is_sep = |c: char| c == '/';
 
+    // Empty input is distinct from all-separator input. Go's
+    // `filepath.Dir("")` and `filepath.Base("")` both return `"."`,
+    // and the leaf-name guard then rejects `"."` with
+    // `invalid file name: "."`. Without this branch, empty input
+    // would fall into the all-separator arm below and surface as
+    // `invalid file name: "/"` — a confusing error that implies the
+    // operator passed a rooted path when they passed no path at all.
+    if raw.is_empty() {
+        return Ok((".".to_string(), ".".to_string()));
+    }
     let had_trailing_sep = raw.chars().next_back().is_some_and(is_sep);
     let trimmed = raw.trim_end_matches(is_sep);
     let (dir_str, leaf) = if trimmed.is_empty() {
+        // `raw` is non-empty but all separators (e.g. `"/"`, `"//"`).
+        // Go returns `"/"` for both `Dir` and `Base` here.
         ("/", "/")
     } else if had_trailing_sep {
         let leaf = match trimmed.rfind(is_sep) {
@@ -775,6 +787,7 @@ mod tests {
         volume_prefix_len, write_file_atomic, write_file_atomic_by_path,
     };
     use std::fs;
+    use std::path::Path;
 
     /// E.10 parity: `read_file_from_dir` mirrors Go `readFileFromDir`.
     /// Rejected vectors (must surface `InvalidInput`):
@@ -822,6 +835,45 @@ mod tests {
         }
 
         let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// Empty-path parity with Go `filepath.Dir("")` / `filepath.Base("")`
+    /// (both return `"."`): the leaf extraction must produce leaf=`"."`
+    /// and the guard must reject it with the `name == "."` branch of
+    /// `check_safe_file_name`, NOT the all-separator `"/"` rejection
+    /// path. Without this branch the empty-input error surfaces as
+    /// `invalid file name: "/"` — confusing because the operator did
+    /// not pass a rooted path.
+    #[test]
+    fn read_file_by_path_empty_input_rejected_as_dot_not_slash() {
+        let err = read_file_by_path(Path::new("")).expect_err("empty path must be rejected");
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+        let msg = err.to_string();
+        assert!(
+            msg.contains("\".\""),
+            "expected `\".\"` leaf-guard rejection (Go parity), got: {msg}"
+        );
+        assert!(
+            !msg.contains("\"/\""),
+            "must not fall through to all-separator branch, got: {msg}"
+        );
+    }
+
+    /// Matching Go parity for the write side: `write_file_atomic_by_path`
+    /// uses the same leaf-guard error path as reads, so empty input
+    /// produces `invalid file name: "."` there too.
+    #[test]
+    fn write_file_atomic_by_path_empty_input_rejected_as_dot_not_slash() {
+        let err = write_file_atomic_by_path(Path::new(""), b"bytes")
+            .expect_err("empty path must be rejected");
+        assert!(
+            err.contains("\".\""),
+            "expected `\".\"` leaf-guard rejection (Go parity), got: {err}"
+        );
+        assert!(
+            !err.contains("\"/\""),
+            "must not fall through to all-separator branch, got: {err}"
+        );
     }
 
     /// E.10 happy path: a real leaf name reads back the bytes.

--- a/clients/rust/crates/rubin-node/src/io_utils.rs
+++ b/clients/rust/crates/rubin-node/src/io_utils.rs
@@ -99,92 +99,150 @@ pub fn read_file_from_dir(dir: &Path, name: &str) -> Result<Vec<u8>, std::io::Er
     fs::read(dir.join(name))
 }
 
-/// Length of the volume prefix at the start of `s`. Mirrors Go's
-/// `path/filepath/path_windows.go::volumeNameLen` byte-for-byte for
-/// every path shape that helper accepts:
+/// Length of the volume prefix at the start of `s`. Mirrors Go
+/// `internal/filepathlite/path_windows.go::volumeNameLen` byte-for-byte.
 ///
-/// - drive-letter: `C:` → 2 (`C:foo`, `C:\foo`, bare `C:`)
-/// - UNC: `\\HOST\SHARE` → len of `\\HOST\SHARE`
-/// - DOS device drive: `\\?\C:` / `\\.\C:` → 6
-/// - DOS device UNC: `\\?\UNC\HOST\SHARE` → len of that prefix
+/// Path shapes recognised (each case mirrors Go's switch arm):
+/// - drive letter: `C:` → 2 (`C:foo`, `C:\foo`, bare `C:`, `2:`
+///   — Go does not enforce ASCII-letter range; we follow)
+/// - no leading separator → 0 (relative / Unix-style)
+/// - Local Device UNC forward: `\\.\UNC\HOST\SHARE\...` → uncLen
+///   starting after the `\\.\UNC\` prefix (8 bytes)
+/// - Local Device / Root Local Device: `\\.\X`, `\\?\X`, `\??\X` →
+///   next segment after the 3-char prefix is part of the volume
+///   (matches Go issue #64028: `Clean("\\?\c:\")` must keep trailing
+///   `\` because the `c:` segment is still the volume)
+/// - Two-leading-separator UNC: `\\HOST\SHARE...` → uncLen from pos 2
+/// - anything else → 0
 ///
-/// Malformed path shapes (`\\`, `\\host`, `\\host\`, `\\?\UNC\host`
-/// without a share segment) return the full input length to match
-/// Go's fail-closed behaviour — there is no valid path to split.
-/// Returns 0 on Unix and for non-volume-rooted Windows paths.
+/// Returns 0 on non-Windows builds.
 fn volume_prefix_len(s: &str) -> usize {
     #[cfg(windows)]
     {
         let bytes = s.as_bytes();
-        if bytes.len() < 2 {
-            return 0;
-        }
-        // Drive letter.
-        if bytes[1] == b':' && bytes[0].is_ascii_alphabetic() {
+        // Drive letter — Go matches on `path[1] == ':'` without
+        // enforcing that `path[0]` is a letter. Mirror that.
+        if bytes.len() >= 2 && bytes[1] == b':' {
             return 2;
         }
-        let is_slash = |b: u8| b == b'/' || b == b'\\';
-        // UNC / DOS device paths require two leading separators.
-        if !is_slash(bytes[0]) || !is_slash(bytes[1]) {
+        if bytes.is_empty() || !is_path_separator_byte(bytes[0]) {
             return 0;
         }
-        // Scan for the next separator starting at `start`. Returns
-        // `(segment_end, rest_start)`. `segment_end == bytes.len()`
-        // means no further separator exists.
-        let cut_at = |start: usize| -> (usize, usize) {
-            let mut i = start;
-            while i < bytes.len() && !is_slash(bytes[i]) {
-                i += 1;
-            }
-            if i < bytes.len() {
-                (i, i + 1)
-            } else {
-                (bytes.len(), bytes.len())
-            }
-        };
-        let (p1_end, after_p1_sep) = cut_at(2);
-        if p1_end == bytes.len() {
-            // `\\` or `\\host` — no separator after host. Go returns
-            // `len(path)`; mirror it.
-            return bytes.len();
+        // Local Device UNC forward: `\\.\UNC\...`. Go treats the
+        // HOST and SHARE after `\\.\UNC\` as part of the volume.
+        if path_has_prefix_fold(bytes, br"\\.\UNC") {
+            return unc_len(bytes, br"\\.\UNC\".len());
         }
-        let (p2_end, after_p2_sep) = cut_at(after_p1_sep);
-        if p2_end == bytes.len() {
-            // `\\host\share` with no further separator. Go's
-            // `cutPath` returns `ok=false` here and falls through to
-            // `return len(path)` at the matching `if !ok` branch.
-            return bytes.len();
-        }
-        let p1 = &bytes[2..p1_end];
-        // Regular UNC: `\\HOST\SHARE\...` — volume is through share.
-        if p1 != b"." && p1 != b"?" {
-            return p2_end;
-        }
-        let p2 = &bytes[after_p1_sep..p2_end];
-        // DOS device that forwards to UNC: `\\?\UNC\HOST\SHARE\...`.
-        if p2.len() == 3
-            && p2[0].to_ascii_uppercase() == b'U'
-            && p2[1].to_ascii_uppercase() == b'N'
-            && p2[2].to_ascii_uppercase() == b'C'
+        // Local / Root Local Device: `\\.` / `\\?` / `\??`.
+        // The next component after the 3-byte prefix is part of the
+        // volume, so `\\?\C:` (6) and `\??\C:` (6) both include the
+        // `C:` segment as volume. Exact match (len == 3) returns 3.
+        if path_has_prefix_fold(bytes, br"\\.")
+            || path_has_prefix_fold(bytes, br"\\?")
+            || path_has_prefix_fold(bytes, br"\??")
         {
-            if after_p2_sep >= bytes.len() {
+            if bytes.len() == 3 {
+                return 3;
+            }
+            // Go: `_, rest, ok := cutPath(path[4:])`. Prefix + sep is
+            // 4 bytes (`\\?\`, `\??\`, etc.). If `path[4:]` is empty,
+            // cutPath returns ok=false and Go returns len(path).
+            if 4 >= bytes.len() {
                 return bytes.len();
             }
-            let (_host_end, share_start) = cut_at(after_p2_sep);
-            if share_start == bytes.len() {
-                return bytes.len();
+            let tail = &bytes[4..];
+            match cut_first_separator(tail) {
+                None => bytes.len(),
+                Some((_before_end, after_start_in_tail)) => {
+                    // Go: `return len(path) - len(rest) - 1`.
+                    let rest_len = tail.len() - after_start_in_tail;
+                    bytes.len() - rest_len - 1
+                }
             }
-            let (share_end, _) = cut_at(share_start);
-            return share_end;
+        } else if bytes.len() >= 2 && is_path_separator_byte(bytes[1]) {
+            // Two-leading-separator UNC: `\\HOST\SHARE...`.
+            unc_len(bytes, 2)
+        } else {
+            0
         }
-        // DOS device drive or other DOS device: `\\?\C:` / `\\.\X`.
-        p2_end
     }
     #[cfg(not(windows))]
     {
         let _ = s;
         0
     }
+}
+
+#[cfg(windows)]
+#[inline]
+fn is_path_separator_byte(c: u8) -> bool {
+    c == b'/' || c == b'\\'
+}
+
+#[cfg(windows)]
+#[inline]
+fn ascii_upper(c: u8) -> u8 {
+    if c >= b'a' && c <= b'z' {
+        c - 32
+    } else {
+        c
+    }
+}
+
+/// Mirrors Go `pathHasPrefixFold`: ignore ASCII case on non-separator
+/// bytes; treat any separator in `prefix` as matching any separator
+/// in `s`; require `s[len(prefix)]` to be a separator if `s` is
+/// strictly longer than `prefix`.
+#[cfg(windows)]
+fn path_has_prefix_fold(s: &[u8], prefix: &[u8]) -> bool {
+    if s.len() < prefix.len() {
+        return false;
+    }
+    for i in 0..prefix.len() {
+        if is_path_separator_byte(prefix[i]) {
+            if !is_path_separator_byte(s[i]) {
+                return false;
+            }
+        } else if ascii_upper(prefix[i]) != ascii_upper(s[i]) {
+            return false;
+        }
+    }
+    if s.len() > prefix.len() && !is_path_separator_byte(s[prefix.len()]) {
+        return false;
+    }
+    true
+}
+
+/// Mirrors Go `uncLen`: returns the index of the second path
+/// separator at or after `prefix_len`. If fewer than two separators
+/// remain, returns `path.len()` (matches Go's fall-through).
+#[cfg(windows)]
+fn unc_len(path: &[u8], prefix_len: usize) -> usize {
+    let mut count = 0usize;
+    let mut i = prefix_len;
+    while i < path.len() {
+        if is_path_separator_byte(path[i]) {
+            count += 1;
+            if count == 2 {
+                return i;
+            }
+        }
+        i += 1;
+    }
+    path.len()
+}
+
+/// Mirrors Go `cutPath`: scan for the first separator in `tail`;
+/// return `Some((before_end, after_start))` with slicing indices
+/// into `tail`. `None` means no separator exists in `tail`.
+#[cfg(windows)]
+fn cut_first_separator(tail: &[u8]) -> Option<(usize, usize)> {
+    for (i, &b) in tail.iter().enumerate() {
+        if is_path_separator_byte(b) {
+            return Some((i, i + 1));
+        }
+    }
+    None
 }
 
 /// Lexical path cleanup mirroring Go's `path/filepath::Clean` for the
@@ -276,6 +334,64 @@ pub(crate) fn lexical_clean(input: &str) -> String {
     };
     if out.len() == vol.len() && !rooted && !starts_with_double_sep {
         out.push('.');
+    }
+    // Go `postClean` (path_windows.go:302) — protect against a
+    // relative path being lexically reduced into an absolute /
+    // rooted shape. Only runs when `vol_len == 0` (input had no
+    // recognised volume), mirroring Go's guard
+    // `if out.volLen != 0 || out.buf == nil { return }`.
+    //
+    // Two cases Go defends against:
+    //
+    // 1. First path element contains `:` before any separator —
+    //    e.g. `a/../c:` lexically reduces to `c:` which Windows
+    //    would interpret as a drive-relative reference. Prepend
+    //    `.` + separator so the result stays relative: `.\c:`.
+    //
+    // 2. Output starts with `\??` (Root Local Device prefix) after
+    //    lexical reduction — e.g. `\a\..\??\c:\x` reduces to
+    //    `\??\c:\x`, which would be read as `c:\x` via the NT
+    //    namespace. Prepend separator + `.` so the result is
+    //    `\.\??\c:\x` and the `\??\` is neutralised.
+    //
+    // Both prepends preserve the lexical result bytes intact; they
+    // only neutralise the Windows-specific interpretation. On Unix
+    // these shapes are not meaningful but the prepend is still
+    // harmless for the resulting string.
+    #[cfg(windows)]
+    {
+        if vol_len == 0 && !out.is_empty() {
+            let bytes = out.as_bytes();
+            // Case 1: `:` in first segment before any separator.
+            let mut first_segment_has_colon = false;
+            for &b in bytes.iter() {
+                if is_sep(b as char) {
+                    break;
+                }
+                if b == b':' {
+                    first_segment_has_colon = true;
+                    break;
+                }
+            }
+            if first_segment_has_colon {
+                let mut prepended = String::with_capacity(out.len() + 2);
+                prepended.push('.');
+                prepended.push(sep);
+                prepended.push_str(&out);
+                out = prepended;
+            } else if bytes.len() >= 3
+                && is_sep(bytes[0] as char)
+                && bytes[1] == b'?'
+                && bytes[2] == b'?'
+            {
+                // Case 2: starts with `\??`.
+                let mut prepended = String::with_capacity(out.len() + 2);
+                prepended.push(sep);
+                prepended.push('.');
+                prepended.push_str(&out);
+                out = prepended;
+            }
+        }
     }
     out
 }
@@ -807,11 +923,28 @@ mod tests {
     }
 
     /// `volume_prefix_len` must match Go `filepath.VolumeName` length
-    /// on every path shape the `lexical_clean` helper may encounter
-    /// on Windows: drive-letter, UNC (`\\HOST\SHARE`), DOS device
-    /// drive (`\\?\C:`, `\\.\C:`), DOS device UNC
-    /// (`\\?\UNC\HOST\SHARE`), and the malformed-prefix fail-closed
-    /// cases. Non-Windows input always returns 0.
+    /// on every path shape the `lexical_clean` helper may encounter.
+    /// Reference: Go's own `volumenametests` table in
+    /// `src/path/filepath/path_test.go` + `volumeNameLen` in
+    /// `src/internal/filepathlite/path_windows.go`. Non-Windows input
+    /// always returns 0.
+    ///
+    /// Case classes covered:
+    /// - Drive letter (`C:`) — Go matches `path[1] == ':'` without
+    ///   enforcing ASCII-letter range, so `1:`, `2:`, `:` (len<2) all
+    ///   follow Go's own rule.
+    /// - UNC (`\\HOST\SHARE`) — volume is through share (two seps).
+    /// - Local Device UNC (`\\.\UNC\HOST\SHARE`) — case 3 in Go's
+    ///   switch; UncLen-based, includes host + share.
+    /// - Local / Root Local Device (`\\.\X`, `\\?\X`, `\??\X`) — next
+    ///   segment after the 3-byte prefix is part of the volume. For
+    ///   `\\?\UNC\host\share` this means volume = `\\?\UNC` (7), NOT
+    ///   the full UNC path.
+    /// - `\??\` specifically — Root Local Device; an earlier version
+    ///   of this port missed it because it required two leading
+    ///   separators, but Go's `pathHasPrefixFold` match works with a
+    ///   single leading sep + `??`.
+    /// - Malformed-prefix cases return `len(path)` (Go fail-closed).
     #[test]
     fn volume_prefix_len_matches_go_filepath_volumename() {
         // Unix-style / relative / non-volume input: always 0.
@@ -825,41 +958,89 @@ mod tests {
         // assertions in this block would fail.
         #[cfg(windows)]
         {
-            // Drive-letter: `C:`, `C:foo`, `C:\foo`, `c:\foo`.
+            // Drive-letter family.
             assert_eq!(volume_prefix_len("C:"), 2);
             assert_eq!(volume_prefix_len("C:foo"), 2);
             assert_eq!(volume_prefix_len("C:\\"), 2);
             assert_eq!(volume_prefix_len("C:\\foo"), 2);
             assert_eq!(volume_prefix_len("c:\\foo"), 2);
-            // Non-drive single-colon shapes — not a drive letter.
-            assert_eq!(volume_prefix_len("1:foo"), 0);
+            // Go matches `path[1] == ':'` without enforcing letter,
+            // so `2:` IS a "drive-letter" shape per Go's own test
+            // table (`{"2:", "2:"}`).
+            assert_eq!(volume_prefix_len("2:"), 2);
+            // One-byte / empty / no colon: 0.
             assert_eq!(volume_prefix_len(":foo"), 0);
 
-            // UNC: `\\HOST\SHARE` — volume includes HOST and SHARE.
+            // Plain UNC (case 5: two leading seps + uncLen).
             assert_eq!(volume_prefix_len("\\\\host\\share"), 12);
             assert_eq!(volume_prefix_len("\\\\host\\share\\"), 12);
             assert_eq!(volume_prefix_len("\\\\host\\share\\foo"), 12);
             assert_eq!(volume_prefix_len("//host/share/foo"), 12);
 
-            // Malformed UNC prefixes: Go returns `len(path)`
-            // (fail-closed — no legitimate split). Mirror it.
+            // Malformed UNC prefixes: Go returns `len(path)`.
             assert_eq!(volume_prefix_len("\\\\"), 2);
             assert_eq!(volume_prefix_len("\\\\host"), 6);
             assert_eq!(volume_prefix_len("\\\\host\\"), 7);
 
-            // DOS device drive: `\\?\C:` and `\\.\C:`.
+            // Local Device / Root Local Device (case 4): next
+            // segment after the 3-byte prefix is volume.
             assert_eq!(volume_prefix_len("\\\\?\\C:"), 6);
             assert_eq!(volume_prefix_len("\\\\?\\C:\\foo"), 6);
             assert_eq!(volume_prefix_len("\\\\.\\C:"), 6);
+            assert_eq!(volume_prefix_len("\\\\.\\C:\\foo"), 6);
+            // Root Local Device via `\??\` — ONE leading sep + `??`.
+            // Missed by the previous two-leading-separator-only
+            // detector.
+            assert_eq!(volume_prefix_len("\\??\\C:"), 6);
+            assert_eq!(volume_prefix_len("\\??\\C:\\foo"), 6);
+            assert_eq!(volume_prefix_len("\\??\\NUL"), 7);
+            // Exact prefix length 3 → return 3.
+            assert_eq!(volume_prefix_len("\\\\?"), 3);
+            assert_eq!(volume_prefix_len("\\\\."), 3);
+            assert_eq!(volume_prefix_len("\\??"), 3);
+            // Empty tail after 4-byte prefix → full path length.
+            assert_eq!(volume_prefix_len("\\\\?\\"), 4);
+            assert_eq!(volume_prefix_len("\\??\\"), 4);
 
-            // DOS device UNC: `\\?\UNC\HOST\SHARE`.
-            assert_eq!(volume_prefix_len("\\\\?\\UNC\\host\\share"), 18);
-            assert_eq!(volume_prefix_len("\\\\?\\UNC\\host\\share\\"), 18);
-            assert_eq!(volume_prefix_len("\\\\?\\UNC\\host\\share\\foo"), 18);
-            // Malformed DOS-UNC (no share segment) → full path.
-            assert_eq!(volume_prefix_len("\\\\?\\UNC\\host"), 12);
+            // DOS-device UNC forward (case 3): only `\\.\UNC\` form.
+            // `\\.\UNC\host\share` uses uncLen → full 18 chars.
+            assert_eq!(volume_prefix_len("\\\\.\\UNC\\host\\share"), 18);
+            assert_eq!(volume_prefix_len("\\\\.\\UNC\\host\\share\\foo"), 18);
+            // `\\?\UNC\host\share` falls into case 4 (not case 3),
+            // so volume is just `\\?\UNC` (7). This differs from the
+            // previous port which incorrectly returned the full UNC
+            // length here — Go's switch routes `\\?\UNC...` through
+            // the Root Local Device arm, not the `\\.\UNC` arm.
+            assert_eq!(volume_prefix_len("\\\\?\\UNC\\host\\share"), 7);
+            assert_eq!(volume_prefix_len("\\\\?\\UNC\\host\\share\\foo"), 7);
             assert_eq!(volume_prefix_len("\\\\?\\UNC"), 7);
         }
+    }
+
+    /// `lexical_clean` must apply Go's Windows `postClean` safeguard
+    /// on a build targeting Windows: a relative input that lexically
+    /// reduces into a path whose first segment contains `:` (e.g.
+    /// `a/../C:\node` → `C:\node`) must be prepended with `.\` so the
+    /// result stays relative (`.\C:\node`). Similarly, a path that
+    /// lexically reduces to start with `\??` (Root Local Device
+    /// prefix) must be prepended with `\.` to neutralise the NT
+    /// namespace interpretation.
+    ///
+    /// Reference: Go `internal/filepathlite/path_windows.go::postClean`.
+    /// Non-Windows builds do not run postClean — the result stays as
+    /// the raw lexical reduction.
+    #[cfg(windows)]
+    #[test]
+    fn lexical_clean_postclean_protects_against_drive_and_device_rewrites() {
+        // Case 1: relative path reduces to drive-qualified shape.
+        assert_eq!(lexical_clean("a/../C:\\node"), ".\\C:\\node");
+        assert_eq!(lexical_clean("a\\..\\c:"), ".\\c:");
+        // Case 2: relative path reduces to Root Local Device shape.
+        assert_eq!(lexical_clean("\\a\\..\\??\\c:\\x"), "\\.\\??\\c:\\x");
+        assert_eq!(lexical_clean("\\??\\c:\\x"), "\\??\\c:\\x"); // vol_len != 0
+                                                                 // Sanity: a plain relative path with no colon / `\??` stays
+                                                                 // unchanged by postClean.
+        assert_eq!(lexical_clean("foo/bar"), "foo\\bar");
     }
 
     /// Smoke test for the E.1 durability contract: a fresh write goes

--- a/clients/rust/crates/rubin-node/src/io_utils.rs
+++ b/clients/rust/crates/rubin-node/src/io_utils.rs
@@ -69,13 +69,23 @@ fn check_safe_file_name(name: &str) -> Result<(), String> {
     // Both are no-ops on Unix where `\` is a regular filename byte and
     // `C:` has no path-shape semantics — so gating them on `cfg(windows)`
     // matches Go's `filepath.Base` per-OS behaviour exactly.
+    //
+    // Drive-prefix rejection: Go's guard is
+    // `filepath.Base(name) != name`. On Windows `filepath.Base("X:foo")`
+    // strips the 2-byte volume prefix and returns `"foo"` for ANY
+    // byte at `name[0]` (Go matches `path[1] == ':'` unconditionally
+    // in `volumeNameLen`, no ASCII-letter enforcement). So `"1:foo"`,
+    // `":foo"` (2-byte, first byte is `:` — fails len>=2 + bytes[1]==':'
+    // test below, `bytes[1]` is `f`), and `"_:foo"` all get rejected
+    // by Go's guard. Drop the `is_ascii_alphabetic` narrowing here
+    // so the Rust guard covers the same vector set.
     #[cfg(windows)]
     {
         if name.contains('\\') {
             return Err(format!("invalid file name: {name:?}"));
         }
         let bytes = name.as_bytes();
-        if bytes.len() >= 2 && bytes[1] == b':' && bytes[0].is_ascii_alphabetic() {
+        if bytes.len() >= 2 && bytes[1] == b':' {
             return Err(format!("invalid file name: {name:?}"));
         }
     }
@@ -337,6 +347,19 @@ pub(crate) fn lexical_clean(input: &str) -> String {
     if out.len() == vol.len() && !rooted && !starts_with_double_sep {
         out.push('.');
     }
+    // Mirror Go's `return FromSlash(out.string())` at the end of
+    // Clean: on Windows every `/` is replaced with the OS
+    // separator `\`. This canonicalises Windows inputs whose
+    // volume prefix came in with forward slashes (e.g.
+    // `//host/share/foo` → `\\host\share\foo`) and any `/` that
+    // snuck through inside the vol copy. On Unix `MAIN_SEPARATOR`
+    // is `/` so this pass is a no-op (we still guard it with
+    // `cfg(windows)` to keep the output verbatim on non-Windows).
+    #[cfg(windows)]
+    {
+        out = out.replace('/', "\\");
+    }
+
     // Go `postClean` (path_windows.go:302) — protect against a
     // relative path being lexically reduced into an absolute /
     // rooted shape. Only runs when `vol_len == 0` (input had no
@@ -840,6 +863,14 @@ mod tests {
             "C:foo",     // drive-prefixed leaf — Path::join replaces base on Windows
             "C:",
             "z:bar",
+            // Go's `filepath.Base(name) != name` guard rejects ANY
+            // byte at position 0 paired with `:` at position 1 —
+            // Go's volumeNameLen matches `path[1] == ':'` without
+            // letter enforcement. Cover the non-alphabetic vectors
+            // to pin the same coverage.
+            "1:foo",
+            "_:foo",
+            "0:",
         ] {
             match read_file_from_dir(&dir, bad) {
                 Err(e) if e.kind() == std::io::ErrorKind::InvalidInput => {}
@@ -1017,6 +1048,24 @@ mod tests {
             assert_eq!(volume_prefix_len("\\\\?\\UNC\\host\\share\\foo"), 7);
             assert_eq!(volume_prefix_len("\\\\?\\UNC"), 7);
         }
+    }
+
+    /// `lexical_clean` must canonicalise forward slashes inside the
+    /// VOLUME prefix on Windows — Go's `Clean` ends with
+    /// `FromSlash(out.string())` which replaces every `/` with `\`.
+    /// Inputs like `//host/share/foo` (UNC with forward slashes, a
+    /// shape Windows accepts) must come out as `\\host\share\foo`,
+    /// NOT `//host/share\foo` (which would mix separators and
+    /// diverge from Go).
+    #[cfg(windows)]
+    #[test]
+    fn lexical_clean_canonicalises_forward_slashes_in_volume_prefix() {
+        // UNC with forward slashes in vol → backslash-canonical UNC.
+        assert_eq!(lexical_clean("//host/share/foo"), "\\\\host\\share\\foo");
+        // Trailing / on pure UNC vol stays a single trailing `\`.
+        assert_eq!(lexical_clean("//host/share/"), "\\\\host\\share\\");
+        // Mixed separators inside the path body collapse to `\`.
+        assert_eq!(lexical_clean("C:/foo/bar"), "C:\\foo\\bar");
     }
 
     /// `lexical_clean` must apply Go's Windows `postClean` safeguard

--- a/clients/rust/crates/rubin-node/src/io_utils.rs
+++ b/clients/rust/crates/rubin-node/src/io_utils.rs
@@ -246,9 +246,11 @@ fn cut_first_separator(tail: &[u8]) -> Option<(usize, usize)> {
 }
 
 /// Lexical path cleanup mirroring Go's `path/filepath::Clean` for the
-/// path shapes `read_file_by_path` accepts. Performs no syscalls — `..`
-/// is collapsed against the preceding component textually, NOT through
-/// symlink resolution.
+/// `--data-dir` path shapes `normalize_data_dir` passes in (drive,
+/// UNC, Local Device, Root Local Device, POSIX absolute, and
+/// relative paths with `.` / `..` segments). Performs no syscalls —
+/// `..` is collapsed against the preceding component textually, NOT
+/// through symlink resolution.
 ///
 /// Called once per node startup from `normalize_data_dir`, which
 /// cleans `cfg.data_dir` at the CLI parse site so every subsystem

--- a/clients/rust/crates/rubin-node/src/io_utils.rs
+++ b/clients/rust/crates/rubin-node/src/io_utils.rs
@@ -293,7 +293,7 @@ pub(crate) fn lexical_clean(input: &str) -> String {
     let vol_len = volume_prefix_len(input);
     let vol = &input[..vol_len];
     let rest = &input[vol_len..];
-    let rooted = rest.starts_with(is_sep);
+    let rooted = rest.chars().next().is_some_and(is_sep);
 
     let mut parts: Vec<&str> = Vec::new();
     for component in rest.split(is_sep) {

--- a/clients/rust/crates/rubin-node/src/io_utils.rs
+++ b/clients/rust/crates/rubin-node/src/io_utils.rs
@@ -120,10 +120,15 @@ pub fn read_file_by_path(path: &Path) -> Result<Vec<u8>, std::io::Error> {
     // `.` components. With `Path::file_name`, an input like
     // `"/etc/passwd/."` returns `"passwd"` and would silently read
     // `/etc/passwd`; Go's `filepath.Base` returns `"."` for the same
-    // input and the leaf-name guard then rejects it. This implementation
-    // reproduces Go's behavior: trim trailing `/` (separator-only
-    // suffix), then take everything after the last `/`. The result is
-    // fed to the same `check_safe_file_name` guard.
+    // input and the leaf-name guard then rejects it.
+    //
+    // Per-OS separator parity with Go's `filepath.Base`: on Windows
+    // both `'/'` and `'\\'` are treated as separators; on Unix only
+    // `'/'`. Without the cfg(windows) branch, ordinary Windows paths
+    // like `C:\data\chainstate.json` would have no separator match,
+    // the whole string would become the leaf, and `check_safe_file_name`
+    // would reject it (contains `\` / drive prefix), regressing all
+    // Windows reads through this helper.
     let raw = match path.to_str() {
         Some(s) => s,
         None => {
@@ -133,13 +138,18 @@ pub fn read_file_by_path(path: &Path) -> Result<Vec<u8>, std::io::Error> {
             ));
         }
     };
-    let trimmed = raw.trim_end_matches('/');
+    #[cfg(windows)]
+    let is_sep = |c: char| c == '/' || c == '\\';
+    #[cfg(not(windows))]
+    let is_sep = |c: char| c == '/';
+
+    let trimmed = raw.trim_end_matches(is_sep);
     let leaf = if trimmed.is_empty() {
         // All-separator input; Go returns "/" — match by passing "/" to
         // the leaf guard, which rejects it (contains `/`).
         "/"
     } else {
-        match trimmed.rfind('/') {
+        match trimmed.rfind(is_sep) {
             Some(idx) => &trimmed[idx + 1..],
             None => trimmed,
         }

--- a/clients/rust/crates/rubin-node/src/io_utils.rs
+++ b/clients/rust/crates/rubin-node/src/io_utils.rs
@@ -20,6 +20,105 @@ fn next_temp_seq() -> u64 {
     TEMP_SEQ.fetch_add(1, Ordering::Relaxed) + 1
 }
 
+/// Reject a file name (the leaf component, NOT a full path) that would
+/// escape the directory it is being looked up in (audit `E.10`).
+///
+/// Mirrors the Go `readFileFromDir` guard in
+/// `clients/go/node/safeio.go`:
+///
+/// ```text
+/// if name == "" || name == "." || name == ".." || filepath.Base(name) != name {
+///     return invalid
+/// }
+/// ```
+///
+/// Rejected vectors (cross-platform-uniform unless noted):
+/// - empty name (`""`)
+/// - `"."` and `".."` (parent / current dir refs)
+/// - any name containing a `/` separator (would escape `dir` via
+///   `dir.join("../foo")` becoming a traversal — true on every OS)
+/// - any absolute path (`/etc/passwd` would override `dir.join`)
+///
+/// Windows-only additional vectors (gated by `cfg(windows)` to preserve
+/// strict per-OS Go parity — `filepath.Base` on Unix accepts both of
+/// these unchanged):
+/// - any name containing a `\` separator (path separator on Windows)
+/// - any Windows drive-prefixed leaf (`C:foo`, `C:`) — `Path::join`
+///   on a drive-prefixed component REPLACES the base path on Windows,
+///   defeating the dir-rooted contract; harmless on Unix where `:`
+///   has no path-shape semantics.
+///
+/// This is a per-leaf-name guard, not a canonicalization-based sandbox.
+/// It deliberately does NOT follow symlinks or canonicalize, because:
+///   1. blockstore / chainstate readers always synthesize the leaf name
+///      from `hex::encode(hash)` plus a fixed extension, so a legitimate
+///      leaf can never contain a separator;
+///   2. canonicalization would require disk I/O on every read and would
+///      change error semantics on transient I/O failure.
+fn check_safe_file_name(name: &str) -> Result<(), String> {
+    if name.is_empty() || name == "." || name == ".." {
+        return Err(format!("invalid file name: {name:?}"));
+    }
+    if name.contains('/') {
+        return Err(format!("invalid file name: {name:?}"));
+    }
+    if Path::new(name).is_absolute() {
+        return Err(format!("invalid file name: {name:?}"));
+    }
+    // Windows-only hardening: backslash separator + drive-prefix leaf.
+    // Both are no-ops on Unix where `\` is a regular filename byte and
+    // `C:` has no path-shape semantics — so gating them on `cfg(windows)`
+    // matches Go's `filepath.Base` per-OS behaviour exactly.
+    #[cfg(windows)]
+    {
+        if name.contains('\\') {
+            return Err(format!("invalid file name: {name:?}"));
+        }
+        let bytes = name.as_bytes();
+        if bytes.len() >= 2 && bytes[1] == b':' && bytes[0].is_ascii_alphabetic() {
+            return Err(format!("invalid file name: {name:?}"));
+        }
+    }
+    Ok(())
+}
+
+/// Read `dir/name` after validating `name` is a safe leaf file name
+/// (audit `E.10`). Mirrors the Go `readFileFromDir` helper in
+/// `clients/go/node/safeio.go` so cross-client storage readers refuse
+/// the same set of traversal / absolute-path / empty-name vectors.
+///
+/// Use this instead of raw `fs::read(dir.join(untrusted_name))` for any
+/// reader where the leaf name comes from data that could in principle
+/// be attacker-influenced (block index entries, on-disk headers, etc.)
+/// even when the current call sites synthesize the name from a fixed
+/// `hex::encode(hash) + ".bin"` shape.
+pub fn read_file_from_dir(dir: &Path, name: &str) -> Result<Vec<u8>, std::io::Error> {
+    if let Err(msg) = check_safe_file_name(name) {
+        return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, msg));
+    }
+    fs::read(dir.join(name))
+}
+
+/// Read a file by full path after validating only the LEAF component
+/// (not the full path) with the same `E.10` guard `read_file_from_dir`
+/// enforces. Mirrors the Go `readFileByPath` helper in
+/// `clients/go/node/safeio.go` for chainstate-style call sites that
+/// already work with a fully-resolved path
+/// (`<data_dir>/chainstate.json`) and need a drop-in safe reader.
+///
+/// This is a leaf-name / traversal guard, NOT a sandbox against
+/// arbitrary full-path input: a caller passing `/etc/passwd` will
+/// still read the absolute path because the leaf `"passwd"` passes
+/// the guard. The guard's job is to refuse names that, when treated
+/// as the trailing component, would escape their directory via
+/// `.`/`..`/separators/drive-prefix; full-path sandboxing is the
+/// caller's responsibility (see `chainstate.rs` for an example
+/// where the path is constructed from a trusted data-dir).
+pub fn read_file_by_path(path: &Path) -> Result<Vec<u8>, std::io::Error> {
+    let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+    read_file_from_dir(path.parent().unwrap_or(Path::new("")), name)
+}
+
 pub fn parse_hex32(name: &str, value: &str) -> Result<[u8; 32], String> {
     let bytes = hex::decode(value).map_err(|e| format!("{name}: {e}"))?;
     if bytes.len() != 32 {
@@ -382,8 +481,106 @@ pub fn unique_temp_path(prefix: &str) -> PathBuf {
 
 #[cfg(test)]
 mod tests {
-    use super::{sync_dir, unique_temp_path, write_file_atomic};
+    use super::{
+        read_file_by_path, read_file_from_dir, sync_dir, unique_temp_path, write_file_atomic,
+    };
     use std::fs;
+
+    /// E.10 parity: `read_file_from_dir` mirrors Go `readFileFromDir`.
+    /// Rejected vectors (must surface `InvalidInput`):
+    ///   `""`, `"."`, `".."`, `"../etc/passwd"`, `"sub/file"`,
+    ///   `"/etc/passwd"`.
+    /// Accepted: a real leaf name pointing at a file inside `dir`.
+    #[test]
+    fn read_file_from_dir_rejects_traversal_and_absolute_and_empty() {
+        let dir = unique_temp_path("rubin-io-utils-safe-read");
+        fs::create_dir_all(&dir).expect("create test dir");
+
+        // Cross-platform-uniform rejected vectors (Go-twin parity on
+        // every OS).
+        for bad in [
+            "",
+            ".",
+            "..",
+            "../etc/passwd",
+            "sub/file",
+            "/etc/passwd", // absolute Unix
+        ] {
+            match read_file_from_dir(&dir, bad) {
+                Err(e) if e.kind() == std::io::ErrorKind::InvalidInput => {}
+                Err(e) => panic!("expected InvalidInput for {bad:?}, got {:?}: {e}", e.kind()),
+                Ok(_) => panic!("expected error for {bad:?}, got Ok"),
+            }
+        }
+
+        // Windows-only rejected vectors: backslash separator + drive-
+        // prefix leaf. On Unix these are valid filename bytes (Go's
+        // `filepath.Base` accepts them too) — gating on cfg(windows)
+        // preserves strict per-OS Go parity.
+        #[cfg(windows)]
+        for bad in [
+            "sub\\file", // backslash separator (path separator on Windows)
+            "C:foo",     // drive-prefixed leaf — Path::join replaces base on Windows
+            "C:",
+            "z:bar",
+        ] {
+            match read_file_from_dir(&dir, bad) {
+                Err(e) if e.kind() == std::io::ErrorKind::InvalidInput => {}
+                Err(e) => panic!("expected InvalidInput for {bad:?}, got {:?}: {e}", e.kind()),
+                Ok(_) => panic!("expected error for {bad:?}, got Ok"),
+            }
+        }
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// E.10 happy path: a real leaf name reads back the bytes.
+    #[test]
+    fn read_file_from_dir_reads_inside_root() {
+        let dir = unique_temp_path("rubin-io-utils-safe-read-ok");
+        fs::create_dir_all(&dir).expect("create test dir");
+        let leaf = "ok.bin";
+        fs::write(dir.join(leaf), b"hi").expect("seed");
+
+        let got = read_file_from_dir(&dir, leaf).expect("read leaf");
+        assert_eq!(got, b"hi");
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// E.10: a `..` segment embedded in the FULL path passed to
+    /// `read_file_by_path` becomes the leaf component after
+    /// `Path::file_name`, which the leaf-name guard rejects. This
+    /// prevents `<data_dir>/..` and `<data_dir>/../etc/passwd` style
+    /// callers from sneaking past via `Path::join`.
+    #[test]
+    fn read_file_by_path_rejects_dotdot_leaf() {
+        let dir = unique_temp_path("rubin-io-utils-by-path-dotdot");
+        fs::create_dir_all(&dir).expect("create test dir");
+
+        let bad = dir.join("..");
+        match read_file_by_path(&bad) {
+            Err(e) if e.kind() == std::io::ErrorKind::InvalidInput => {}
+            other => panic!("expected InvalidInput for trailing .., got {other:?}"),
+        }
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// E.10 happy path for `read_file_by_path`: full-path readers like
+    /// the chainstate loader read back what they wrote.
+    #[test]
+    fn read_file_by_path_reads_inside_root() {
+        let dir = unique_temp_path("rubin-io-utils-by-path-ok");
+        fs::create_dir_all(&dir).expect("create test dir");
+        let path = dir.join("chainstate.json");
+        fs::write(&path, b"{}").expect("seed");
+
+        let got = read_file_by_path(&path).expect("read by path");
+        assert_eq!(got, b"{}");
+
+        let _ = fs::remove_dir_all(&dir);
+    }
 
     /// Smoke test for the E.1 durability contract: a fresh write goes
     /// through OpenOptions + sync_all + rename + parent dir-sync without

--- a/clients/rust/crates/rubin-node/src/io_utils.rs
+++ b/clients/rust/crates/rubin-node/src/io_utils.rs
@@ -99,35 +99,86 @@ pub fn read_file_from_dir(dir: &Path, name: &str) -> Result<Vec<u8>, std::io::Er
     fs::read(dir.join(name))
 }
 
-/// Read a file by full path after validating only the LEAF component
-/// (not the full path) with the same `E.10` guard `read_file_from_dir`
-/// enforces. Mirrors the Go `readFileByPath` helper in
-/// `clients/go/node/safeio.go` for chainstate-style call sites that
-/// already work with a fully-resolved path
-/// (`<data_dir>/chainstate.json`) and need a drop-in safe reader.
+/// Length of the volume prefix at the start of `s`. Mirrors Go's
+/// `path/filepath/path_windows.go::volumeNameLen` byte-for-byte for
+/// every path shape that helper accepts:
 ///
-/// This is a leaf-name / traversal guard, NOT a sandbox against
-/// arbitrary full-path input: a caller passing `/etc/passwd` will
-/// still read the absolute path because the leaf `"passwd"` passes
-/// the guard. The guard's job is to refuse names that, when treated
-/// as the trailing component, would escape their directory via
-/// `.`/`..`/separators/drive-prefix; full-path sandboxing is the
-/// caller's responsibility (see `chainstate.rs` for an example
-/// where the path is constructed from a trusted data-dir).
-/// Length of the volume prefix at the start of `s`. On Windows, returns
-/// 2 if `s` begins with an ASCII-letter + `:` (drive prefix like `C:`).
-/// On Unix and on Windows non-drive paths, returns 0. Mirrors Go's
-/// `filepath.VolumeName` length contract for the path shapes the
-/// `read_file_by_path` helper accepts (drive-letter paths only — UNC
-/// roots are not exercised by current callers).
+/// - drive-letter: `C:` → 2 (`C:foo`, `C:\foo`, bare `C:`)
+/// - UNC: `\\HOST\SHARE` → len of `\\HOST\SHARE`
+/// - DOS device drive: `\\?\C:` / `\\.\C:` → 6
+/// - DOS device UNC: `\\?\UNC\HOST\SHARE` → len of that prefix
+///
+/// Malformed path shapes (`\\`, `\\host`, `\\host\`, `\\?\UNC\host`
+/// without a share segment) return the full input length to match
+/// Go's fail-closed behaviour — there is no valid path to split.
+/// Returns 0 on Unix and for non-volume-rooted Windows paths.
 fn volume_prefix_len(s: &str) -> usize {
     #[cfg(windows)]
     {
         let bytes = s.as_bytes();
-        if bytes.len() >= 2 && bytes[1] == b':' && bytes[0].is_ascii_alphabetic() {
+        if bytes.len() < 2 {
+            return 0;
+        }
+        // Drive letter.
+        if bytes[1] == b':' && bytes[0].is_ascii_alphabetic() {
             return 2;
         }
-        0
+        let is_slash = |b: u8| b == b'/' || b == b'\\';
+        // UNC / DOS device paths require two leading separators.
+        if !is_slash(bytes[0]) || !is_slash(bytes[1]) {
+            return 0;
+        }
+        // Scan for the next separator starting at `start`. Returns
+        // `(segment_end, rest_start)`. `segment_end == bytes.len()`
+        // means no further separator exists.
+        let cut_at = |start: usize| -> (usize, usize) {
+            let mut i = start;
+            while i < bytes.len() && !is_slash(bytes[i]) {
+                i += 1;
+            }
+            if i < bytes.len() {
+                (i, i + 1)
+            } else {
+                (bytes.len(), bytes.len())
+            }
+        };
+        let (p1_end, after_p1_sep) = cut_at(2);
+        if p1_end == bytes.len() {
+            // `\\` or `\\host` — no separator after host. Go returns
+            // `len(path)`; mirror it.
+            return bytes.len();
+        }
+        let (p2_end, after_p2_sep) = cut_at(after_p1_sep);
+        if p2_end == bytes.len() {
+            // `\\host\share` with no further separator. Go's
+            // `cutPath` returns `ok=false` here and falls through to
+            // `return len(path)` at the matching `if !ok` branch.
+            return bytes.len();
+        }
+        let p1 = &bytes[2..p1_end];
+        // Regular UNC: `\\HOST\SHARE\...` — volume is through share.
+        if p1 != b"." && p1 != b"?" {
+            return p2_end;
+        }
+        let p2 = &bytes[after_p1_sep..p2_end];
+        // DOS device that forwards to UNC: `\\?\UNC\HOST\SHARE\...`.
+        if p2.len() == 3
+            && p2[0].to_ascii_uppercase() == b'U'
+            && p2[1].to_ascii_uppercase() == b'N'
+            && p2[2].to_ascii_uppercase() == b'C'
+        {
+            if after_p2_sep >= bytes.len() {
+                return bytes.len();
+            }
+            let (_host_end, share_start) = cut_at(after_p2_sep);
+            if share_start == bytes.len() {
+                return bytes.len();
+            }
+            let (share_end, _) = cut_at(share_start);
+            return share_end;
+        }
+        // DOS device drive or other DOS device: `\\?\C:` / `\\.\X`.
+        p2_end
     }
     #[cfg(not(windows))]
     {
@@ -212,21 +263,47 @@ fn lexical_clean(input: &str) -> String {
     out
 }
 
-pub fn read_file_by_path(path: &Path) -> Result<Vec<u8>, std::io::Error> {
-    // Extract leaf via Go's `filepath.Base` semantics (string-based)
-    // rather than `Path::file_name`, which silently SKIPS trailing
-    // `.` components. With `Path::file_name`, an input like
-    // `"/etc/passwd/."` returns `"passwd"` and would silently read
-    // `/etc/passwd`; Go's `filepath.Base` returns `"."` for the same
-    // input and the leaf-name guard then rejects it.
+/// Split a full path into `(cleaned_dir, leaf)` using the same
+/// dir/leaf derivation `read_file_by_path` and `write_file_atomic_by_path`
+/// share so read-then-write round-trips on the same input path cannot
+/// drift apart. Mirrors Go's `filepath.Dir` + `filepath.Base` pair,
+/// including Go's `filepath.Dir` internal `Clean` step: rooted `..`
+/// segments are collapsed textually (`lexical_clean`), not resolved
+/// through the OS.
+///
+/// Edge-case behaviour (kept identical between the read and write
+/// surfaces so a single operator-supplied path lands on the same file
+/// in both directions):
+/// - All-separator input (`"/"`, `"//"`): returns `("/", "/")`.
+/// - Trailing-separator input (`"/etc/passwd/"`): returns
+///   `("/etc/passwd", "passwd")`, matching Go's Dir/Base pair — the
+///   subsequent join produces `"/etc/passwd/passwd"` and the OS
+///   surfaces ENOENT/ENOTDIR instead of a silent read/write of
+///   `/etc/passwd`.
+/// - Drive-root input (`"C:\\foo"` on Windows): dir preserves the
+///   trailing rooting separator (`"C:\\"`) so `dir.join(leaf)` stays
+///   drive-rooted rather than collapsing to drive-relative.
+/// - Drive-relative input (`"C:foo"` on Windows): splits as
+///   `("C:", "foo")`, matching Go's drive-relative split.
+///
+/// Returns `InvalidInput` if the path is not valid UTF-8 (the helper
+/// relies on byte-level parsing of path separators).
+fn resolve_io_path_dir_leaf(path: &Path) -> Result<(String, String), std::io::Error> {
+    // `Path::file_name`/`Path::parent` silently skip trailing `.`
+    // components: an input like `"/etc/passwd/."` returns
+    // `file_name = "passwd"`, which would make the read target
+    // `/etc/passwd` and bypass the leaf-name guard. Going through
+    // the raw `&str` and mirroring Go's `filepath.Base` keeps that
+    // vector rejected the same way Go rejects it.
     //
     // Per-OS separator parity with Go's `filepath.Base`: on Windows
     // both `'/'` and `'\\'` are treated as separators; on Unix only
-    // `'/'`. Without the cfg(windows) branch, ordinary Windows paths
-    // like `C:\data\chainstate.json` would have no separator match,
-    // the whole string would become the leaf, and `check_safe_file_name`
-    // would reject it (contains `\` / drive prefix), regressing all
-    // Windows reads through this helper.
+    // `'/'`. Without the `cfg(windows)` branch, ordinary Windows
+    // paths like `C:\data\chainstate.json` would have no separator
+    // match, the whole string would become the leaf, and
+    // `check_safe_file_name` would reject it (contains `\` / drive
+    // prefix), regressing every Windows read/write through this
+    // helper.
     let raw = match path.to_str() {
         Some(s) => s,
         None => {
@@ -243,38 +320,24 @@ pub fn read_file_by_path(path: &Path) -> Result<Vec<u8>, std::io::Error> {
 
     let had_trailing_sep = raw.chars().next_back().is_some_and(is_sep);
     let trimmed = raw.trim_end_matches(is_sep);
-    // Compute (dir, leaf) to match Go's `filepath.Dir`/`filepath.Base`
-    // pair exactly. The notable case is trailing-separator input
-    // `/etc/passwd/`: Go's `Dir` returns `/etc/passwd` (the trimmed
-    // path including the would-be-leaf) and `Base` returns `passwd`,
-    // so Go's `readFileByPath` then attempts `/etc/passwd/passwd`
-    // which surfaces as ENOENT/ENOTDIR — NOT a silent read of
-    // `/etc/passwd`. Mirroring `Path::parent`/`Path::file_name` would
-    // diverge (parent="/etc"+name="passwd" → reads `/etc/passwd`).
     let (dir_str, leaf) = if trimmed.is_empty() {
-        // All-separator input; Go returns "/" for both `Base` and `Dir`.
         ("/", "/")
     } else if had_trailing_sep {
-        // Trailing-separator input. Go: dir = trimmed, leaf = last
-        // path component name. The combined read target is
-        // `<trimmed>/<leaf>` which surfaces a real OS error on
-        // misuse instead of silently rewriting.
         let leaf = match trimmed.rfind(is_sep) {
             Some(idx) => &trimmed[idx + 1..],
             None => trimmed,
         };
         (trimmed, leaf)
     } else {
-        // No trailing separator. Standard split at last separator.
         match trimmed.rfind(is_sep) {
             Some(idx) => {
-                // Preserve the rooting separator when the last separator
-                // is the path's root marker, otherwise the dir loses its
-                // absolute-root semantics:
+                // Preserve the rooting separator when the last
+                // separator is the path's root marker, otherwise the
+                // dir loses its absolute-root semantics:
                 //   - Unix `/foo`        → idx=0, dir must be `/`
-                //   - Windows `C:\foo`   → idx=2 right after drive vol,
-                //     dir must be `C:\` (NOT `C:`, which would be
-                //     drive-relative on Windows)
+                //   - Windows `C:\foo`   → idx=2 right after drive
+                //     vol, dir must be `C:\` (NOT `C:`, which would
+                //     be drive-relative on Windows)
                 let vol_len = volume_prefix_len(trimmed);
                 let dir = if idx == 0 {
                     "/"
@@ -286,16 +349,6 @@ pub fn read_file_by_path(path: &Path) -> Result<Vec<u8>, std::io::Error> {
                 (dir, &trimmed[idx + 1..])
             }
             None => {
-                // No separator inside trimmed. If trimmed starts with
-                // a Windows drive volume prefix and has more after it
-                // (e.g. "C:foo"), Go's filepath.Dir/Base split as
-                // dir = "<vol>" + leaf = "<rest>", giving a drive-
-                // relative read on Windows. Mirror that split here so
-                // callers passing drive-relative paths get the same
-                // resolution as Go (and the leaf-name guard still
-                // validates "<rest>", not the whole drive-prefixed
-                // string). On Unix volume_prefix_len always returns 0
-                // and this branch is a no-op.
                 let vol_len = volume_prefix_len(trimmed);
                 if vol_len > 0 && trimmed.len() > vol_len {
                     (&trimmed[..vol_len], &trimmed[vol_len..])
@@ -305,13 +358,54 @@ pub fn read_file_by_path(path: &Path) -> Result<Vec<u8>, std::io::Error> {
             }
         }
     };
-    // Lexically clean the dir before passing to read_file_from_dir.
-    // This mirrors Go's `filepath.Dir`, which Cleans the result, so
-    // parent-component `..` segments are textually collapsed instead
-    // of resolved through the OS — defending against symlink-divergence
-    // when the path passes through a symlink before a `..`.
     let cleaned_dir = lexical_clean(dir_str);
-    read_file_from_dir(Path::new(&cleaned_dir), leaf)
+    Ok((cleaned_dir, leaf.to_string()))
+}
+
+/// Read a file by full path after validating only the LEAF component
+/// (not the full path) with the same `E.10` guard `read_file_from_dir`
+/// enforces. Mirrors the Go `readFileByPath` helper in
+/// `clients/go/node/safeio.go` for chainstate-style call sites that
+/// already work with a fully-resolved path
+/// (`<data_dir>/chainstate.json`) and need a drop-in safe reader.
+///
+/// This is a leaf-name / traversal guard, NOT a sandbox against
+/// arbitrary full-path input: a caller passing `/etc/passwd` will
+/// still read the absolute path because the leaf `"passwd"` passes
+/// the guard. The guard's job is to refuse names that, when treated
+/// as the trailing component, would escape their directory via
+/// `.`/`..`/separators/drive-prefix; full-path sandboxing is the
+/// caller's responsibility (see `chainstate.rs` for an example where
+/// the path is constructed from a trusted data-dir).
+pub fn read_file_by_path(path: &Path) -> Result<Vec<u8>, std::io::Error> {
+    let (cleaned_dir, leaf) = resolve_io_path_dir_leaf(path)?;
+    read_file_from_dir(Path::new(&cleaned_dir), &leaf)
+}
+
+/// Write `data` atomically to the file identified by `path`, using the
+/// same dir/leaf derivation `read_file_by_path` uses so a round-trip
+/// read-then-write on the same operator-supplied path lands on the
+/// same on-disk file. Without this symmetry, an operator `--data-dir`
+/// that passes through a symlink combined with `..` segments can
+/// cause startup to read one file while subsequent saves persist to
+/// a different file (split persistence / apparent state loss on
+/// symlink-escape paths).
+///
+/// This is deliberately stricter than the Go `safeio.go` twin, which
+/// calls `writeFileAtomic` directly on the original path (Go's read
+/// side applies `filepath.Dir`'s `Clean` step while its write side
+/// does not). Fixing the asymmetry in Go is tracked as a separate
+/// concern; the Rust side converges read and write here.
+///
+/// The `E.10` leaf-name guard still applies: the leaf derived from
+/// `path` must pass `check_safe_file_name`, so writes refuse the
+/// same traversal / absolute-path / drive-prefix vectors reads do.
+pub fn write_file_atomic_by_path(path: &Path, data: &[u8]) -> Result<(), String> {
+    let (cleaned_dir, leaf) =
+        resolve_io_path_dir_leaf(path).map_err(|e| format!("resolve path: {e}"))?;
+    check_safe_file_name(&leaf)?;
+    let target = Path::new(&cleaned_dir).join(&leaf);
+    write_file_atomic(&target, data)
 }
 
 pub fn parse_hex32(name: &str, value: &str) -> Result<[u8; 32], String> {
@@ -678,7 +772,7 @@ pub fn unique_temp_path(prefix: &str) -> PathBuf {
 mod tests {
     use super::{
         lexical_clean, read_file_by_path, read_file_from_dir, sync_dir, unique_temp_path,
-        write_file_atomic,
+        volume_prefix_len, write_file_atomic, write_file_atomic_by_path,
     };
     use std::fs;
 
@@ -919,6 +1013,125 @@ mod tests {
 
         let _ = fs::remove_dir_all(&root);
         let _ = fs::remove_dir_all(&elsewhere);
+    }
+
+    /// `write_file_atomic_by_path` + `read_file_by_path` must land on
+    /// the same physical file for an operator-supplied path that
+    /// crosses a symlink combined with `..`. Without shared dir/leaf
+    /// resolution between read and write, a `--data-dir` of the shape
+    /// `<real>/link/..` where `link` escapes `<real>` causes startup
+    /// reads to hit `<real>/chainstate.json` (via lexical clean) but
+    /// saves to persist at `<elsewhere>/chainstate.json` (via OS
+    /// symlink resolution), surfacing as apparent state loss after
+    /// restart. This test pins the round-trip on one file.
+    #[cfg(unix)]
+    #[test]
+    fn write_by_path_then_read_by_path_round_trips_through_symlink_escape() {
+        use std::os::unix::fs as unix_fs;
+
+        let root = unique_temp_path("rubin-io-utils-by-path-write-rt-root");
+        fs::create_dir_all(&root).expect("create root");
+
+        let elsewhere = unique_temp_path("rubin-io-utils-by-path-write-rt-elsewhere");
+        fs::create_dir_all(&elsewhere).expect("create elsewhere");
+        let target = elsewhere.join("target");
+        fs::create_dir_all(&target).expect("create elsewhere/target");
+
+        // Seed `elsewhere/foo` so we can tell if the write escaped.
+        fs::write(elsewhere.join("foo"), b"pre-existing-elsewhere").expect("seed elsewhere/foo");
+
+        let link = root.join("link");
+        unix_fs::symlink(&target, &link).expect("symlink link → elsewhere/target");
+
+        // Operator-supplied path: <root>/link/../foo
+        let mut tricky = link.clone().into_os_string();
+        tricky.push("/../foo");
+        let tricky_path = std::path::PathBuf::from(tricky);
+
+        // Write via `_by_path`. With shared resolution, this lands
+        // on `root/foo`, NOT `elsewhere/foo`.
+        write_file_atomic_by_path(&tricky_path, b"round-trip-bytes")
+            .expect("write_file_atomic_by_path");
+
+        // Read via `_by_path`. With shared resolution, this reads
+        // the same `root/foo` that the write produced.
+        let got = read_file_by_path(&tricky_path).expect("read back");
+        assert_eq!(
+            got, b"round-trip-bytes",
+            "read must see the bytes the write produced"
+        );
+
+        // Positive-proof that the write did NOT escape to `elsewhere`:
+        // `elsewhere/foo` keeps its pre-existing bytes.
+        let elsewhere_bytes = fs::read(elsewhere.join("foo")).expect("read elsewhere/foo");
+        assert_eq!(
+            elsewhere_bytes, b"pre-existing-elsewhere",
+            "write must NOT have followed the symlink out of root"
+        );
+
+        // And `root/foo` now holds the round-trip bytes.
+        let root_bytes = fs::read(root.join("foo")).expect("read root/foo");
+        assert_eq!(root_bytes, b"round-trip-bytes");
+
+        let _ = fs::remove_dir_all(&root);
+        let _ = fs::remove_dir_all(&elsewhere);
+    }
+
+    /// `volume_prefix_len` must match Go `filepath.VolumeName` length
+    /// on every path shape the `read_file_by_path` /
+    /// `write_file_atomic_by_path` pair may encounter on Windows:
+    /// drive-letter, UNC (`\\HOST\SHARE`), DOS device drive
+    /// (`\\?\C:`, `\\.\C:`), DOS device UNC
+    /// (`\\?\UNC\HOST\SHARE`), and the malformed-prefix fail-closed
+    /// cases. Non-Windows input always returns 0.
+    #[test]
+    fn volume_prefix_len_matches_go_filepath_volumename() {
+        // Unix-style / relative / non-volume input: always 0.
+        for s in ["", "foo", "/foo", "/foo/bar", "foo/bar", "."] {
+            assert_eq!(volume_prefix_len(s), 0, "non-volume input {s:?}");
+        }
+
+        // Windows-gated cases: the byte-level parser runs only when
+        // this crate is compiled for Windows. Run the full table
+        // there; on non-Windows the function short-circuits to 0 so
+        // assertions in this block would fail.
+        #[cfg(windows)]
+        {
+            // Drive-letter: `C:`, `C:foo`, `C:\foo`, `c:\foo`.
+            assert_eq!(volume_prefix_len("C:"), 2);
+            assert_eq!(volume_prefix_len("C:foo"), 2);
+            assert_eq!(volume_prefix_len("C:\\"), 2);
+            assert_eq!(volume_prefix_len("C:\\foo"), 2);
+            assert_eq!(volume_prefix_len("c:\\foo"), 2);
+            // Non-drive single-colon shapes — not a drive letter.
+            assert_eq!(volume_prefix_len("1:foo"), 0);
+            assert_eq!(volume_prefix_len(":foo"), 0);
+
+            // UNC: `\\HOST\SHARE` — volume includes HOST and SHARE.
+            assert_eq!(volume_prefix_len("\\\\host\\share"), 12);
+            assert_eq!(volume_prefix_len("\\\\host\\share\\"), 12);
+            assert_eq!(volume_prefix_len("\\\\host\\share\\foo"), 12);
+            assert_eq!(volume_prefix_len("//host/share/foo"), 12);
+
+            // Malformed UNC prefixes: Go returns `len(path)`
+            // (fail-closed — no legitimate split). Mirror it.
+            assert_eq!(volume_prefix_len("\\\\"), 2);
+            assert_eq!(volume_prefix_len("\\\\host"), 6);
+            assert_eq!(volume_prefix_len("\\\\host\\"), 7);
+
+            // DOS device drive: `\\?\C:` and `\\.\C:`.
+            assert_eq!(volume_prefix_len("\\\\?\\C:"), 6);
+            assert_eq!(volume_prefix_len("\\\\?\\C:\\foo"), 6);
+            assert_eq!(volume_prefix_len("\\\\.\\C:"), 6);
+
+            // DOS device UNC: `\\?\UNC\HOST\SHARE`.
+            assert_eq!(volume_prefix_len("\\\\?\\UNC\\host\\share"), 18);
+            assert_eq!(volume_prefix_len("\\\\?\\UNC\\host\\share\\"), 18);
+            assert_eq!(volume_prefix_len("\\\\?\\UNC\\host\\share\\foo"), 18);
+            // Malformed DOS-UNC (no share segment) → full path.
+            assert_eq!(volume_prefix_len("\\\\?\\UNC\\host"), 12);
+            assert_eq!(volume_prefix_len("\\\\?\\UNC"), 7);
+        }
     }
 
     /// Smoke test for the E.1 durability contract: a fresh write goes

--- a/clients/rust/crates/rubin-node/src/lib.rs
+++ b/clients/rust/crates/rubin-node/src/lib.rs
@@ -41,6 +41,7 @@ pub use genesis::{
     load_genesis_config, validate_incoming_chain_id, LoadedGenesisConfig,
     PRODUCTION_LOCAL_ROTATION_DESCRIPTOR_ERR,
 };
+pub use io_utils::normalize_data_dir;
 pub use miner::{parse_mine_address_arg, MinedBlock, Miner, MinerConfig};
 pub use p2p_runtime::{default_peer_runtime_config, PeerManager};
 pub use p2p_service::{start_node_p2p_service, NodeP2PServiceConfig, RunningNodeP2PService};

--- a/clients/rust/crates/rubin-node/src/main.rs
+++ b/clients/rust/crates/rubin-node/src/main.rs
@@ -766,6 +766,17 @@ fn validate_config(cfg: &mut CliConfig) -> Result<(), String> {
     if cfg.data_dir.as_os_str().is_empty() {
         return Err("data_dir is required".to_string());
     }
+    // Normalise `--data-dir` once so every subsystem
+    // (`ChainState::save` / `load_chain_state`, `BlockStore::open`
+    // and its block / header / undo / index sub-directories, etc.)
+    // derives paths from a single lexically-cleaned root. Internal
+    // readers and writers then stay on raw `fs::read` /
+    // `write_file_atomic` and remain symmetric with each other
+    // (block + index surface live in the same physical tree, and a
+    // chainstate read lands on exactly the file a prior chainstate
+    // save produced) — even for operator `--data-dir` values that
+    // cross a symlink combined with `..` segments.
+    cfg.data_dir = rubin_node::normalize_data_dir(&cfg.data_dir)?;
     validate_addr_inner("bind_addr", &cfg.bind_addr, true)?;
     if !cfg.rpc_bind_addr.trim().is_empty() {
         validate_addr_inner("rpc_bind_addr", &cfg.rpc_bind_addr, true)?;


### PR DESCRIPTION
## Q
Q-ID parent (canonical, OPEN): `Q-IMPL-NODE-STORAGE-SAFETY-AND-STATE-SURFACE-PARITY-01`
Sub-issue: Closes #1245

## One invariant
Rust BlockStore block / header / undo reads and `load_blockstore_index` refuse `""`, `"."`, `".."`, separators (`/`, `\`), absolute paths, AND Windows drive-prefixed leafs (`C:foo`, `C:`, `1:foo`, `_:foo`) via `check_safe_file_name` used by `read_file_from_dir`. Leaf-name / traversal guard (NOT a full-path sandbox — callers are responsible for full-path trust). Direct twin of Go `clients/go/node/safeio.go`.

`ChainState::save` / `load_chain_state` use raw `write_file_atomic` / `fs::read` on the caller-supplied path; the node binary`s invariant for those helpers is "the operator `--data-dir` has already been lexically cleaned at the CLI parse site" via `normalize_data_dir` in `main.rs`. Other callers of the public `ChainState` helpers are responsible for their own path hygiene.

Operator `--data-dir` is lexically cleaned once at the CLI parse site (`normalize_data_dir` in `main.rs`), so every subsystem that derives a path from it (ChainState, BlockStore blocks/headers/undo/index) inherits a pre-cleaned root and stays on raw `fs::read` / `write_file_atomic`. Reads and writes on each storage surface share one raw resolution, and both surfaces resolve through the same pre-cleaned root — matches the Go `safeio.go` baseline and keeps blockstore files co-located with the index they reference.

## Files touched
- `clients/rust/crates/rubin-node/src/io_utils.rs`: `check_safe_file_name`, `read_file_from_dir`, `volume_prefix_len` (full Go `filepath.VolumeName` port: drive / UNC / DOS-device), `lexical_clean` (Go `filepath.Clean` port), `normalize_data_dir` (CLI-level one-shot cleaner), storage-primitive tests.
- `clients/rust/crates/rubin-node/src/main.rs`: apply `normalize_data_dir` to `cfg.data_dir` after the non-empty validation, before any subsystem reads it.
- `clients/rust/crates/rubin-node/src/chainstate.rs`: `ChainState::save` / `load_chain_state` use raw `write_file_atomic` / `fs::read` on the caller-supplied path (node binary pre-cleans; other callers are responsible for their own hygiene — noted in the doc comments).
- `clients/rust/crates/rubin-node/src/blockstore.rs`: `load_blockstore_index` routes through `read_file_from_dir(parent, file_name)` so the index reader still carries the E.10 leaf-name guard without per-helper cleaning; `save_blockstore_index_serializable` / `put_undo` / block / header writers stay on raw `write_file_atomic` / `write_file_exclusive`.
- `clients/rust/crates/rubin-node/src/lib.rs`: re-export `normalize_data_dir`.

## Non-scope (per slice-protocol HARD RULE 2026-04-19)
- E.8 state-digest / utxo_set_hash twin (sub-issue #1243 → PR #1254)
- E.9 UTXO defensive-copy helper (sub-issue #1244 → PR #1252)
- full-path sandboxing / canonicalization on arbitrary caller input (`load_chain_state` is public; the CLI-level normalization covers the node binary)
- broader admin/RPC surface expansion
- Windows CI job (separate infrastructure PR)

## Accepted cases (all tested)
| Vector | Result |
|---|---|
| empty `""` leaf | Err |
| `.`, `..` leaf | Err |
| `../etc/passwd`, `sub/file` leaf | Err |
| `sub\\file` (Windows-style backslash) leaf | Err |
| `/etc/passwd` (absolute Unix) leaf | Err |
| `C:foo`, `C:`, `z:bar` (Windows drive prefix) leaf | Err |
| relative leaf inside-root | OK |
| `volume_prefix_len` drive / UNC / DOS-device / DOS-device-UNC / malformed | Go parity (cfg(windows)) |
| `lexical_clean` `.`/`..`/rooted/multi-sep/UNC-volume-root | Go parity |

## Validation
- `cargo test -p rubin-node`: 462 + 49 + 3 + doctests PASS
- `cargo fmt -- --check`: clean
- `cargo clippy -p rubin-node --tests --no-deps -- -D warnings`: clean
- `pre-amend-audit` stages 1-10 PASS

## Slice-protocol marker
This PR closes ONLY E.10. E.8 (#1243 → PR #1254) and E.9 (#1244 → PR #1252) are tracked separately and MUST NOT be addressed here.

