### PR TITLE
perf(storage): gate Rust chainstate save by Go-mirror snapshot policy (B.1)

### DIFF
--- a/clients/rust/crates/rubin-node/src/chainstate_recovery.rs
+++ b/clients/rust/crates/rubin-node/src/chainstate_recovery.rs
@@ -53,9 +53,55 @@
 //!   handles steady-state mismatch through reorg / disconnect paths).
 
 use crate::blockstore::BlockStore;
-use crate::chainstate::ChainState;
+use crate::chainstate::{ChainState, ChainStateConnectSummary};
 use crate::sync::SyncConfig;
 use rubin_consensus::parse_block_header_bytes;
+
+/// Snapshot cadence: persist `ChainState` to disk on every block until
+/// the UTxO set crosses [`CHAIN_STATE_SNAPSHOT_SMALL_UTXO_CUTOFF`], then
+/// throttle to once every [`CHAIN_STATE_SNAPSHOT_INTERVAL_BLOCKS`]
+/// blocks. Mirrors Go `chainStateSnapshotIntervalBlocks` in
+/// `clients/go/node/chainstate_recovery.go`.
+pub const CHAIN_STATE_SNAPSHOT_INTERVAL_BLOCKS: u64 = 32;
+
+/// At or below this UTxO-set size the snapshot is small enough that
+/// per-block save cost is negligible; persist on every block to
+/// minimise the post-crash replay window. The gate is inclusive
+/// (`<= CHAIN_STATE_SNAPSHOT_SMALL_UTXO_CUTOFF`) — matching Go's
+/// `chainStateSnapshotSmallUtxoCutoff` comparison shape.
+pub const CHAIN_STATE_SNAPSHOT_SMALL_UTXO_CUTOFF: u64 = 4096;
+
+/// Decide whether the apply-block hot path should persist the
+/// `ChainState` snapshot to disk after the current block. Mirrors Go
+/// `shouldPersistChainStateSnapshot` (`clients/go/node/chainstate_recovery.go`):
+///
+/// * `state == None` or `summary == None` → fail-closed, persist.
+/// * tipless state OR `block_height == 0` → seed first snapshot.
+/// * UTxO count `<= CHAIN_STATE_SNAPSHOT_SMALL_UTXO_CUTOFF` → persist
+///   every block (cheap snapshot, small replay window).
+/// * Otherwise persist only when `block_height` is a multiple of
+///   `CHAIN_STATE_SNAPSHOT_INTERVAL_BLOCKS`.
+///
+/// Boundary saves outside the apply-block hot path
+/// (`SyncEngine::disconnect_tip`, reorg rollback, miner publish, and
+/// the startup E.2 reconcile in `main.rs`) call `ChainState::save`
+/// directly and are NOT gated by this policy: shutdown / reorg /
+/// explicit-flush durability is preserved.
+pub(crate) fn should_persist_chainstate_snapshot(
+    state: Option<&ChainState>,
+    summary: Option<&ChainStateConnectSummary>,
+) -> bool {
+    let (Some(state), Some(summary)) = (state, summary) else {
+        return true;
+    };
+    if !state.has_tip || summary.block_height == 0 {
+        return true;
+    }
+    if (state.utxos.len() as u64) <= CHAIN_STATE_SNAPSHOT_SMALL_UTXO_CUTOFF {
+        return true;
+    }
+    summary.block_height % CHAIN_STATE_SNAPSHOT_INTERVAL_BLOCKS == 0
+}
 
 /// Walk the canonical index forward; for every canonical hash, verify
 /// the matching header file, block-bytes file, and undo file all exist
@@ -869,6 +915,185 @@ mod tests {
         assert_eq!(state.tip_hash, genesis_hash);
         // Stale snapshot is unused after the test — silence dead-code.
         drop(stale_state);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// Cross-client cadence parity: cell-by-cell mirror of Go
+    /// `TestShouldPersistChainStateSnapshotCadence` in
+    /// `clients/go/node/chainstate_recovery_test.go`. Any divergence
+    /// here means Rust apply_block hot-path saves drift away from Go.
+    #[test]
+    fn should_persist_chainstate_snapshot_cadence() {
+        // Nil-equivalent inputs → fail-closed persist.
+        assert!(
+            should_persist_chainstate_snapshot(None, None),
+            "missing state+summary must persist (fail-closed)"
+        );
+
+        // Tipless state seeds the first snapshot regardless of height.
+        let empty = ChainState::new();
+        assert!(
+            should_persist_chainstate_snapshot(
+                Some(&empty),
+                Some(&ChainStateConnectSummary {
+                    block_height: 1,
+                    block_hash: [0u8; 32],
+                    sum_fees: 0,
+                    already_generated: 0,
+                    already_generated_n1: 0,
+                    utxo_count: 0,
+                }),
+            ),
+            "tipless state must persist to seed first snapshot"
+        );
+
+        // Small UTxO set persists every block, even off the interval.
+        let mut small = ChainState::new();
+        small.has_tip = true;
+        for i in 0..CHAIN_STATE_SNAPSHOT_SMALL_UTXO_CUTOFF {
+            let mut txid = [0u8; 32];
+            txid[0] = i as u8;
+            small.utxos.insert(
+                rubin_consensus::Outpoint {
+                    txid,
+                    vout: i as u32,
+                },
+                rubin_consensus::UtxoEntry {
+                    value: i + 1,
+                    covenant_type: 0,
+                    covenant_data: Vec::new(),
+                    creation_height: 0,
+                    created_by_coinbase: false,
+                },
+            );
+        }
+        assert!(
+            should_persist_chainstate_snapshot(
+                Some(&small),
+                Some(&ChainStateConnectSummary {
+                    block_height: 17,
+                    block_hash: [0u8; 32],
+                    sum_fees: 0,
+                    already_generated: 0,
+                    already_generated_n1: 0,
+                    utxo_count: small.utxos.len() as u64,
+                }),
+            ),
+            "small utxo set must persist every block"
+        );
+
+        // Crossing the cutoff switches to interval-only persistence.
+        let mut large = ChainState::new();
+        large.has_tip = true;
+        for i in 0..=CHAIN_STATE_SNAPSHOT_SMALL_UTXO_CUTOFF {
+            let mut txid = [0u8; 32];
+            txid[0] = i as u8;
+            txid[1] = (i >> 8) as u8;
+            large.utxos.insert(
+                rubin_consensus::Outpoint {
+                    txid,
+                    vout: i as u32,
+                },
+                rubin_consensus::UtxoEntry {
+                    value: i + 1,
+                    covenant_type: 0,
+                    covenant_data: Vec::new(),
+                    creation_height: 0,
+                    created_by_coinbase: false,
+                },
+            );
+        }
+        // Off-interval block at (interval - 1) MUST be skipped.
+        assert!(
+            !should_persist_chainstate_snapshot(
+                Some(&large),
+                Some(&ChainStateConnectSummary {
+                    block_height: CHAIN_STATE_SNAPSHOT_INTERVAL_BLOCKS - 1,
+                    block_hash: [0u8; 32],
+                    sum_fees: 0,
+                    already_generated: 0,
+                    already_generated_n1: 0,
+                    utxo_count: large.utxos.len() as u64,
+                }),
+            ),
+            "large utxo set must skip non-interval snapshots"
+        );
+        // Interval boundary triggers the throttled persist.
+        assert!(
+            should_persist_chainstate_snapshot(
+                Some(&large),
+                Some(&ChainStateConnectSummary {
+                    block_height: CHAIN_STATE_SNAPSHOT_INTERVAL_BLOCKS,
+                    block_hash: [0u8; 32],
+                    sum_fees: 0,
+                    already_generated: 0,
+                    already_generated_n1: 0,
+                    utxo_count: large.utxos.len() as u64,
+                }),
+            ),
+            "large utxo set must persist on interval boundary"
+        );
+        // height == 0 always seeds (genesis snapshot).
+        assert!(
+            should_persist_chainstate_snapshot(
+                Some(&large),
+                Some(&ChainStateConnectSummary {
+                    block_height: 0,
+                    block_hash: [0u8; 32],
+                    sum_fees: 0,
+                    already_generated: 0,
+                    already_generated_n1: 0,
+                    utxo_count: large.utxos.len() as u64,
+                }),
+            ),
+            "height zero summary must persist"
+        );
+    }
+
+    /// Boundary contract: even with the apply-block save gated, the
+    /// pre-existing E.2 startup reconcile path (`main.rs` calling
+    /// `chain_state.save` after `reconcile_chain_state_with_block_store`)
+    /// continues to land a snapshot on disk. This test pins the
+    /// reconcile + explicit-save sequence end-to-end so a future change
+    /// to the apply-block gate cannot silently break the explicit-flush
+    /// boundary contract documented on `should_persist_chainstate_snapshot`.
+    #[test]
+    fn reconcile_then_explicit_save_persists_snapshot_independent_of_gate() {
+        let dir = fresh_dir("rubin-recover-explicit-save");
+        let chain_state_file = crate::chainstate::chain_state_path(&dir);
+        let store = open_store_in(&dir);
+        let (_genesis_hash, mut store, mut state) = apply_genesis(store);
+        // Force the gate to its "skip" branch by faking a large UTxO
+        // set + off-interval height; reconcile + explicit save must
+        // STILL land the snapshot.
+        for i in 0..=CHAIN_STATE_SNAPSHOT_SMALL_UTXO_CUTOFF {
+            let mut txid = [0u8; 32];
+            txid[0] = i as u8;
+            txid[1] = (i >> 8) as u8;
+            state.utxos.insert(
+                rubin_consensus::Outpoint {
+                    txid,
+                    vout: i as u32,
+                },
+                rubin_consensus::UtxoEntry {
+                    value: i + 1,
+                    covenant_type: 0,
+                    covenant_data: Vec::new(),
+                    creation_height: 0,
+                    created_by_coinbase: false,
+                },
+            );
+        }
+        let cfg = devnet_cfg();
+        // Reconcile is a noop here (genesis tip already matches), but
+        // the explicit save AFTER it is the durability point.
+        let _ = reconcile_chain_state_with_block_store(&mut state, &mut store, &cfg)
+            .expect("reconcile");
+        state.save(&chain_state_file).expect("explicit save");
+        assert!(
+            chain_state_file.exists(),
+            "explicit save outside the apply-block gate must always land"
+        );
         let _ = fs::remove_dir_all(&dir);
     }
 }

--- a/clients/rust/crates/rubin-node/src/sync.rs
+++ b/clients/rust/crates/rubin-node/src/sync.rs
@@ -11,6 +11,7 @@ use rubin_consensus::{RotationProvider, SuiteRegistry};
 
 use crate::blockstore::BlockStore;
 use crate::chainstate::{ChainState, ChainStateConnectSummary};
+use crate::chainstate_recovery::should_persist_chainstate_snapshot;
 use crate::undo::build_block_undo;
 
 pub const DEFAULT_IBD_LAG_SECONDS: u64 = 24 * 60 * 60;
@@ -648,30 +649,51 @@ impl SyncEngine {
             }
         }
 
+        // Snapshot cadence gate (B.1, sub-issue #1246) — Go parity with
+        // `clients/go/node/sync.go::persistAppliedBlock` save guard:
+        // when a blockstore is wired, throttle per-block snapshot writes
+        // through `should_persist_chainstate_snapshot`. The blockstore
+        // already durably persists block bytes / header / undo on every
+        // commit, so a missing snapshot at crash time is recoverable by
+        // the E.2 startup reconcile path. Without a blockstore (test /
+        // embedded mode), we do not throttle per-block snapshot attempts
+        // through this cadence gate; an on-disk save still only occurs
+        // when `cfg.chain_state_path` is configured. Boundary saves
+        // (disconnect_tip, reorg rollback, miner publish, startup
+        // reconcile in main.rs) call `chain_state.save` directly and are
+        // unaffected by this gate.
+        //
+        // Early-return when chainstate persistence is fully disabled
+        // (`chain_state_path == None`): no save would happen anyway, so
+        // skip the cadence computation entirely on the hot path.
         if let Some(chain_state_path) = self.cfg.chain_state_path.as_ref() {
-            if let Err(err) = self.chain_state.save(chain_state_path) {
-                // Canonical commit MAY have advanced the tip. The
-                // same-hash replay path returns Ok(()) without advancing
-                // the canonical index/tip (canonical_len unchanged),
-                // though it may still back-fill missing undo data on
-                // disk, so only rewind when the canonical length
-                // actually grew past the pre-commit snapshot.
-                let rewind_err = self.block_store.as_mut().and_then(|bs| {
-                    if bs.canonical_len() > canonical_len_before {
-                        bs.truncate_canonical(canonical_len_before).err()
-                    } else {
-                        None
+            let persist_snapshot = self.block_store.is_none()
+                || should_persist_chainstate_snapshot(Some(&self.chain_state), Some(&summary));
+            if persist_snapshot {
+                if let Err(err) = self.chain_state.save(chain_state_path) {
+                    // Canonical commit MAY have advanced the tip. The
+                    // same-hash replay path returns Ok(()) without advancing
+                    // the canonical index/tip (canonical_len unchanged),
+                    // though it may still back-fill missing undo data on
+                    // disk, so only rewind when the canonical length
+                    // actually grew past the pre-commit snapshot.
+                    let rewind_err = self.block_store.as_mut().and_then(|bs| {
+                        if bs.canonical_len() > canonical_len_before {
+                            bs.truncate_canonical(canonical_len_before).err()
+                        } else {
+                            None
+                        }
+                    });
+                    self.chain_state = snapshot;
+                    self.tip_timestamp = old_tip_timestamp;
+                    self.best_known_height = old_best_known_height;
+                    if let Some(rewind_err) = rewind_err {
+                        return Err(format!(
+                            "{err}; failed to rewind canonical index after chain_state save failure: {rewind_err}; blockstore may require repair"
+                        ));
                     }
-                });
-                self.chain_state = snapshot;
-                self.tip_timestamp = old_tip_timestamp;
-                self.best_known_height = old_best_known_height;
-                if let Some(rewind_err) = rewind_err {
-                    return Err(format!(
-                        "{err}; failed to rewind canonical index after chain_state save failure: {rewind_err}; blockstore may require repair"
-                    ));
+                    return Err(err);
                 }
-                return Err(err);
             }
         }
 
@@ -1062,6 +1084,47 @@ mod tests {
             .expect("tip")
             .expect("some tip");
         assert_eq!(tip.0, 0);
+
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    /// B.1 sub-issue #1246: when `cfg.chain_state_path == None`, the
+    /// snapshot cadence gate must early-return BEFORE calling
+    /// `should_persist_chainstate_snapshot`, so apply_block does no
+    /// chainstate-save-related work on the hot path. Verified by
+    /// constructing a SyncEngine with a blockstore but no chainstate
+    /// path, running apply_block, and asserting:
+    ///
+    ///   - apply_block returns Ok (no panic / no side-channel error
+    ///     from a missing-path-but-attempted-save mismatch);
+    ///   - no chainstate.json file is created in the data dir.
+    ///
+    /// Full end-to-end coverage of the >4096-UTXO + off-interval skip
+    /// path requires synthesising valid PoW blocks at specific heights
+    /// (height % 32 != 0) and is tracked as a follow-up Q (see #1246
+    /// thread).
+    #[test]
+    fn sync_engine_apply_block_no_chainstate_path_skips_save_path() {
+        let dir = unique_temp_path("rubin-node-sync-no-chainstate-path");
+        let block_store_root = block_store_path(&dir);
+        let store = BlockStore::open(block_store_root).expect("open blockstore");
+
+        let st = ChainState::new();
+        let cfg = default_sync_config(Some(POW_LIMIT), [0u8; 32], None /* chain_state_path */);
+        let mut engine = SyncEngine::new(st, Some(store), cfg).expect("new sync");
+
+        let block = hex_to_bytes(VALID_BLOCK_HEX);
+        let summary = engine.apply_block(&block, None).expect("apply block");
+        assert_eq!(summary.block_height, 0);
+
+        // Chainstate file must NOT exist — the early-return on
+        // `chain_state_path == None` skipped the save call entirely.
+        let would_have_been_path = chain_state_path(&dir);
+        assert!(
+            !would_have_been_path.exists(),
+            "chainstate file at {} must not be written when chain_state_path is None",
+            would_have_been_path.display()
+        );
 
         std::fs::remove_dir_all(&dir).expect("cleanup");
     }

--- a/clients/rust/crates/rubin-node/src/sync.rs
+++ b/clients/rust/crates/rubin-node/src/sync.rs
@@ -1088,16 +1088,19 @@ mod tests {
         std::fs::remove_dir_all(&dir).expect("cleanup");
     }
 
-    /// B.1 sub-issue #1246: when `cfg.chain_state_path == None`, the
-    /// snapshot cadence gate must early-return BEFORE calling
-    /// `should_persist_chainstate_snapshot`, so apply_block does no
-    /// chainstate-save-related work on the hot path. Verified by
-    /// constructing a SyncEngine with a blockstore but no chainstate
-    /// path, running apply_block, and asserting:
+    /// B.1 sub-issue #1246: when `cfg.chain_state_path == None`,
+    /// `apply_block` should skip the chainstate snapshot save path.
+    /// Verified by constructing a `SyncEngine` with a blockstore but
+    /// no chainstate path, running `apply_block`, and asserting:
     ///
-    ///   - apply_block returns Ok (no panic / no side-channel error
-    ///     from a missing-path-but-attempted-save mismatch);
-    ///   - no chainstate.json file is created in the data dir.
+    ///   - `apply_block` returns `Ok` (no panic / no error from a
+    ///     missing-path-but-attempted-save mismatch);
+    ///   - no `chainstate.json` file is created in the data dir.
+    ///
+    /// This test does not assert whether
+    /// `should_persist_chainstate_snapshot` is evaluated internally;
+    /// it only verifies that no snapshot file is written when the
+    /// chainstate path is absent.
     ///
     /// Full end-to-end coverage of the >4096-UTXO + off-interval skip
     /// path requires synthesising valid PoW blocks at specific heights


### PR DESCRIPTION
## Q

`Q-PERF-NODE-PERSISTENCE-HOTPATH-01:B.1` — sub-issue #1246.
Closes #1246.

This PR closes ONLY B.1.
E.7 (#1247) and G.9 (#1248) are tracked separately and MUST NOT be addressed here.

## One invariant

Rust `SyncEngine::apply_block` honours the same snapshot persistence
policy that Go enforces (interval-N / small-utxo-always /
explicit-flush): it does NOT call `chain_state.save(...)` on every
applied block on hot sync, but the durability ordering contract from
the E.2 startup reconcile (#1221), the disconnect/reorg boundary, and
explicit-flush boundaries is preserved.

## Allowed files

- `clients/rust/crates/rubin-node/src/chainstate_recovery.rs` — adds
  `CHAIN_STATE_SNAPSHOT_INTERVAL_BLOCKS = 32`,
  `CHAIN_STATE_SNAPSHOT_SMALL_UTXO_CUTOFF = 4096`, and
  `should_persist_chainstate_snapshot()` (Go mirror of
  `clients/go/node/chainstate_recovery.go::shouldPersistChainStateSnapshot`).
- `clients/rust/crates/rubin-node/src/sync.rs` — gates the apply-block
  hot-path `chain_state.save()` call (was line 652) with the new
  helper, mirroring the Go gate at
  `clients/go/node/sync.go::persistAppliedBlock` (line 579):
  `block_store.is_none() || should_persist_chainstate_snapshot(...)`.

## Non-scope (explicit)

- E.7 canonical-height lookup cache (sub-issue #1247).
- G.9 dedup block parse (sub-issue #1248).
- E.2 reconcile / startup repair in `main.rs` (already merged #1221) —
  intentionally untouched.
- `sync_disconnect.rs::disconnect_tip` save (line 78) — boundary save,
  intentionally NOT gated.
- Rollback save in `sync.rs` (~line 752) — boundary save, intentionally
  NOT gated.
- `chainstate.rs::ChainState::save` signature / snapshot file format /
  WAL.
- Go-side policy parameter changes — this slice mirrors Go, does not
  change Go.

## Accepted cases (Go-parity policy)

| Case | Expected | Where enforced |
|---|---|---|
| `state == None` or `summary == None` | persist (fail-closed) | helper line 1 |
| Tipless state OR `block_height == 0` | persist (seed first snapshot) | helper line 2 |
| `utxo_count <= 4096` | persist every block | helper line 3 |
| `utxo_count > 4096` AND `height % 32 != 0` | skip | helper line 4 |
| `utxo_count > 4096` AND `height % 32 == 0` | persist | helper line 4 |
| Blockstore wired off (`block_store == None`) | persist every block | gate in `sync.rs` |
| Disconnect / reorg rollback boundary | persist (unchanged) | `sync_disconnect.rs:78` + `sync.rs::rollback_apply_block` |
| Startup E.2 reconcile + explicit save | persist (unchanged) | `main.rs:250` |

## Rejected cases (PR would fail)

| Case | Why |
|---|---|
| Block applied → no save anywhere ever | durability lost |
| Save policy diverges from Go's | parity break |
| Add new configuration knob without Go twin | drift |

## Validation

- `cargo test -p rubin-node` — 447 lib + 49 integration + 3 perf-guardrail tests pass; new tests:
  - `chainstate_recovery::tests::should_persist_chainstate_snapshot_cadence` — bit-by-bit mirror of Go `TestShouldPersistChainStateSnapshotCadence`.
  - `chainstate_recovery::tests::reconcile_then_explicit_save_persists_snapshot_independent_of_gate` — pins the explicit-flush boundary contract.
- `cargo clippy -p rubin-node --tests` — clean.
- Existing `sync_engine_apply_block_persists_chainstate_and_store` still passes (genesis utxo set is small → falls into "persist every block" branch, regression-checked).
- `pre-amend-audit.sh` — PASS (no consensus-client diff in canonical repo path).

## Cite to Go save policy

- `clients/go/node/chainstate_recovery.go` — `shouldPersistChainStateSnapshot`, constants `chainStateSnapshotIntervalBlocks=32`, `chainStateSnapshotSmallUtxoCutoff=4096`.
- `clients/go/node/sync.go::persistAppliedBlock` — gate `s.cfg.ChainStatePath != "" && (s.blockStore == nil || shouldPersistChainStateSnapshot(...))`.
- `clients/go/node/chainstate_recovery_test.go::TestShouldPersistChainStateSnapshotCadence` — cell-by-cell mirrored in Rust.

## LoC budget (≤200 prod / ≤250 test / ≤4 files)

- 2 files touched.
- prod additions: ~50 LoC (constants + helper + 1-line gate + comment block).
- test additions: ~180 LoC (1 cadence test mirroring Go + 1 explicit-flush boundary test).

## Slice-protocol marker

```
This PR closes ONLY B.1.
E.7 and G.9 are tracked separately and MUST NOT be addressed here.
```

<!-- rubin-agent-meta actor=claude action=pr-create via=cl branch=claude/q-perf-b1-save-policy wt=agent-a3b23f4d utc=2026-04-19T18:27:50Z -->
