### PR TITLE
perf(consensus): dedup block parse between validate and connect (Rust, G.9)

### DIFF
--- a/clients/rust/crates/rubin-consensus/src/block_basic.rs
+++ b/clients/rust/crates/rubin-consensus/src/block_basic.rs
@@ -47,7 +47,20 @@ struct DaCommitSet {
     chunk_count: u16,
 }
 
+// G.9 instrumentation: per-thread counter of `parse_block_bytes`
+// invocations under `#[cfg(test)]`, used by `tests/parse_dedup.rs` to
+// assert the one-parse-per-apply_block invariant. Thread-local (not a
+// process-global atomic) so parallel test execution cannot contaminate
+// the count. Not compiled in release builds.
+#[cfg(test)]
+thread_local! {
+    pub(crate) static PARSE_BLOCK_BYTES_CALL_COUNT: std::cell::Cell<u64> =
+        const { std::cell::Cell::new(0) };
+}
+
 pub fn parse_block_bytes(block_bytes: &[u8]) -> Result<ParsedBlock, TxError> {
+    #[cfg(test)]
+    PARSE_BLOCK_BYTES_CALL_COUNT.with(|c| c.set(c.get() + 1));
     if block_bytes.len() < BLOCK_HEADER_BYTES + 1 {
         return Err(TxError::new(ErrorCode::BlockErrParse, "block too short"));
     }
@@ -141,16 +154,36 @@ pub fn validate_block_basic_with_context_at_height(
     prev_timestamps: Option<&[u64]>,
 ) -> Result<BlockBasicSummary, TxError> {
     let pb = parse_block_bytes(block_bytes)?;
+    validate_parsed_block_basic_with_context_at_height(
+        &pb,
+        expected_prev_hash,
+        expected_target,
+        block_height,
+        prev_timestamps,
+    )
+}
 
-    validate_header_commitments(&pb, expected_prev_hash, expected_target)?;
-    validate_coinbase_witness_commitment(&pb)?;
+/// G.9 / Go parity (`clients/go/consensus/block_basic.go`,
+/// `validateParsedBlockBasicWithContextAtHeight`): validation logic against an
+/// already-parsed block. Callers that need both the parsed block and the
+/// summary parse once via `parse_block_bytes` and then call this helper,
+/// instead of re-parsing in both `validate_*` and `connect_*`.
+pub(crate) fn validate_parsed_block_basic_with_context_at_height(
+    pb: &ParsedBlock,
+    expected_prev_hash: Option<[u8; 32]>,
+    expected_target: Option<[u8; 32]>,
+    block_height: u64,
+    prev_timestamps: Option<&[u64]>,
+) -> Result<BlockBasicSummary, TxError> {
+    validate_header_commitments(pb, expected_prev_hash, expected_target)?;
+    validate_coinbase_witness_commitment(pb)?;
     validate_timestamp_rules(pb.header.timestamp, block_height, prev_timestamps)?;
 
-    let stats = accumulate_block_resource_stats(&pb)?;
+    let stats = accumulate_block_resource_stats(pb)?;
     validate_block_resource_limits(stats)?;
 
     validate_da_set_integrity(&pb.txs)?;
-    validate_block_tx_semantics(&pb, block_height)?;
+    validate_block_tx_semantics(pb, block_height)?;
 
     let h = block_hash(&pb.header_bytes)
         .map_err(|_| TxError::new(ErrorCode::BlockErrParse, "failed to hash block header"))?;
@@ -172,14 +205,16 @@ pub fn validate_block_basic_with_context_and_fees_at_height(
     already_generated: u128,
     sum_fees: u64,
 ) -> Result<BlockBasicSummary, TxError> {
-    let s = validate_block_basic_with_context_at_height(
-        block_bytes,
+    // G.9: parse once, share `pb` between basic validation and the
+    // coinbase-value-bound check, instead of parsing twice.
+    let pb = parse_block_bytes(block_bytes)?;
+    let s = validate_parsed_block_basic_with_context_at_height(
+        &pb,
         expected_prev_hash,
         expected_target,
         block_height,
         prev_timestamps,
     )?;
-    let pb = parse_block_bytes(block_bytes)?;
     validate_coinbase_value_bound(&pb, block_height, already_generated, sum_fees)?;
     Ok(s)
 }

--- a/clients/rust/crates/rubin-consensus/src/connect_block_inmem.rs
+++ b/clients/rust/crates/rubin-consensus/src/connect_block_inmem.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 use sha3::{Digest, Sha3_256};
 
 use crate::block_basic::{
-    median_time_past, parse_block_bytes, validate_block_basic_with_context_at_height,
-    validate_coinbase_apply_outputs, validate_coinbase_value_bound,
+    median_time_past, parse_block_bytes, validate_coinbase_apply_outputs,
+    validate_coinbase_value_bound, validate_parsed_block_basic_with_context_at_height,
 };
 use crate::compactsize::encode_compact_size;
 use crate::constants::{COV_TYPE_ANCHOR, COV_TYPE_DA_COMMIT};
@@ -105,16 +105,17 @@ pub fn connect_block_basic_in_memory_at_height_and_core_ext_deployments_with_sui
     rotation: Option<&dyn RotationProvider>,
     registry: Option<&SuiteRegistry>,
 ) -> Result<ConnectBlockBasicSummary, TxError> {
-    // Stateless checks first.
-    validate_block_basic_with_context_at_height(
-        block_bytes,
+    // G.9: parse once, then run stateless checks against the parsed block;
+    // previously this path called validate_*_with_context_at_height (which
+    // parsed internally) and then re-parsed via parse_block_bytes.
+    let pb = parse_block_bytes(block_bytes)?;
+    validate_parsed_block_basic_with_context_at_height(
+        &pb,
         expected_prev_hash,
         expected_target,
         block_height,
         prev_timestamps,
     )?;
-
-    let pb = parse_block_bytes(block_bytes)?;
     if pb.txs.is_empty() || pb.txids.len() != pb.txs.len() {
         return Err(TxError::new(
             ErrorCode::BlockErrParse,
@@ -269,15 +270,16 @@ pub fn connect_block_parallel_sig_verify_and_core_ext_deployments_with_suite_con
     registry: Option<&SuiteRegistry>,
     workers: usize,
 ) -> Result<ConnectBlockBasicSummary, TxError> {
-    validate_block_basic_with_context_at_height(
-        block_bytes,
+    // G.9: parse once and validate against the parsed block, mirroring the
+    // sequential connect path above.
+    let pb = parse_block_bytes(block_bytes)?;
+    validate_parsed_block_basic_with_context_at_height(
+        &pb,
         expected_prev_hash,
         expected_target,
         block_height,
         prev_timestamps,
     )?;
-
-    let pb = parse_block_bytes(block_bytes)?;
     if pb.txs.is_empty() || pb.txids.len() != pb.txs.len() {
         return Err(TxError::new(
             ErrorCode::BlockErrParse,

--- a/clients/rust/crates/rubin-consensus/src/tests/mod.rs
+++ b/clients/rust/crates/rubin-consensus/src/tests/mod.rs
@@ -621,6 +621,7 @@ mod connect_block_parallel_conformance;
 mod connect_block_parallel_integration;
 mod covenant_genesis;
 mod da_verify_parallel;
+mod parse_dedup;
 mod precompute;
 mod tx_parse;
 mod tx_validate_worker;

--- a/clients/rust/crates/rubin-consensus/src/tests/parse_dedup.rs
+++ b/clients/rust/crates/rubin-consensus/src/tests/parse_dedup.rs
@@ -1,0 +1,185 @@
+//! G.9 / sub-issue #1248: assert that the Rust consensus path parses each
+//! block exactly ONCE per `apply_block`-style call (`connect_block_*`),
+//! mirroring the Go single-parse pattern in
+//! `clients/go/consensus/connect_block_inmem.go` (`parseAndValidateBlockBasicWithContextAtHeight`).
+//!
+//! Uses the test-only `PARSE_BLOCK_BYTES_CALL_COUNT` counter in
+//! `block_basic.rs`. The counter is `thread_local!`, so each test runs
+//! against its own isolated counter — no cross-test contamination under
+//! `cargo test`'s default parallel runner. Tests still snapshot the
+//! counter at entry and assert the delta (rather than asserting an
+//! absolute value) so any ambient parse calls earlier in the same
+//! thread (e.g. from helper fixtures) do not affect the assertion.
+
+use super::*;
+
+use crate::block_basic::PARSE_BLOCK_BYTES_CALL_COUNT;
+use crate::connect_block_inmem::InMemoryChainState;
+
+fn parse_count() -> u64 {
+    PARSE_BLOCK_BYTES_CALL_COUNT.with(|c| c.get())
+}
+
+/// Build the same coinbase-only block used by
+/// `connect_block_coinbase_only_at_height0_succeeds` so we have a
+/// happy-path block whose parse cost we can measure.
+fn happy_path_block_bytes() -> (Vec<u8>, [u8; 32], [u8; 32]) {
+    let prev = [0u8; 32];
+    let target = [0xffu8; 32];
+    let coinbase = coinbase_with_witness_commitment(0, &[]);
+    let (_cb, coinbase_txid, _cbw, _cbn) = parse_tx(&coinbase).expect("parse coinbase");
+    let root = merkle_root_txids(&[coinbase_txid]).expect("merkle root");
+    let block = build_block_bytes(prev, root, target, 1, &[coinbase]);
+    (block, prev, target)
+}
+
+/// G.9 happy path: `connect_block_basic_in_memory_at_height` parses the
+/// block exactly once, even though it internally still validates basic
+/// rules (which used to call `parse_block_bytes` a second time).
+#[test]
+fn connect_block_basic_in_memory_parses_once_on_happy_path() {
+    let (block, prev, target) = happy_path_block_bytes();
+    let mut state = InMemoryChainState {
+        utxos: HashMap::new(),
+        already_generated: 0,
+    };
+
+    let before = parse_count();
+    let _summary = crate::connect_block_basic_in_memory_at_height(
+        &block,
+        Some(prev),
+        Some(target),
+        0,
+        None,
+        &mut state,
+        ZERO_CHAIN_ID,
+    )
+    .expect("connect_block_basic_in_memory_at_height happy path");
+    let delta = parse_count() - before;
+
+    assert_eq!(
+        delta, 1,
+        "G.9: connect_block_basic_in_memory_at_height must parse the block \
+         exactly once per apply_block (observed {delta})"
+    );
+}
+
+/// G.9 error path: a connect call that fails inside basic validation must
+/// NOT have parsed the block twice. With the dedup in place the parse
+/// count is exactly 1 (parse, then validate-on-parsed fails); before the
+/// fix it was 1 (validate failed before the second parse) — but the
+/// stricter property the slice-protocol locks is "≤ 1 parse on the error
+/// path", which we still want to assert as a regression guard.
+#[test]
+fn connect_block_basic_in_memory_does_not_double_parse_on_validation_error() {
+    let (block, _prev, target) = happy_path_block_bytes();
+    let mut state = InMemoryChainState {
+        utxos: HashMap::new(),
+        already_generated: 0,
+    };
+
+    // Force a stateless-validation rejection: pass a wrong expected_prev_hash
+    // so validate_header_commitments fails after parse, before connect's
+    // tx-application loop.
+    let wrong_prev = [0xAAu8; 32];
+
+    let before = parse_count();
+    let err = crate::connect_block_basic_in_memory_at_height(
+        &block,
+        Some(wrong_prev),
+        Some(target),
+        0,
+        None,
+        &mut state,
+        ZERO_CHAIN_ID,
+    )
+    .expect_err("expected stateless validation to reject wrong prev_hash");
+    let delta = parse_count() - before;
+
+    // Must be a header / commitment class rejection, not a parse failure
+    // (a parse failure would short-circuit at the very first parse and
+    // hide a regression where a second parse was added later).
+    assert_ne!(
+        err.code,
+        ErrorCode::BlockErrParse,
+        "G.9 setup error: expected non-parse rejection, got BlockErrParse: {err:?}"
+    );
+    assert!(
+        delta <= 1,
+        "G.9: connect_block_basic_in_memory_at_height parsed the block \
+         {delta} times on the error path; must be ≤ 1"
+    );
+}
+
+/// G.9 reorg/disconnect path: applying the same block again (e.g. after a
+/// reorg revert) must still parse exactly once per call, with no leaked
+/// parsed state across calls.
+#[test]
+fn connect_block_basic_in_memory_parses_once_on_reapply() {
+    let (block, prev, target) = happy_path_block_bytes();
+    let mut state1 = InMemoryChainState {
+        utxos: HashMap::new(),
+        already_generated: 0,
+    };
+    let mut state2 = InMemoryChainState {
+        utxos: HashMap::new(),
+        already_generated: 0,
+    };
+
+    let before = parse_count();
+    let _ = crate::connect_block_basic_in_memory_at_height(
+        &block,
+        Some(prev),
+        Some(target),
+        0,
+        None,
+        &mut state1,
+        ZERO_CHAIN_ID,
+    )
+    .expect("first apply");
+    let _ = crate::connect_block_basic_in_memory_at_height(
+        &block,
+        Some(prev),
+        Some(target),
+        0,
+        None,
+        &mut state2,
+        ZERO_CHAIN_ID,
+    )
+    .expect("second apply (reapply / reorg)");
+    let delta = parse_count() - before;
+
+    assert_eq!(
+        delta, 2,
+        "G.9: two consecutive connect_block calls must parse exactly twice \
+         total (1 parse per apply_block); observed {delta}"
+    );
+}
+
+/// G.9 fees variant: `validate_block_basic_with_context_and_fees_at_height`
+/// used to call `validate_block_basic_with_context_at_height` (1 parse)
+/// and then `parse_block_bytes` again (2nd parse) before checking the
+/// coinbase value bound. After the fix it parses exactly once.
+#[test]
+fn validate_block_basic_with_context_and_fees_at_height_parses_once() {
+    let (block, prev, target) = happy_path_block_bytes();
+
+    let before = parse_count();
+    let _ = crate::validate_block_basic_with_context_and_fees_at_height(
+        &block,
+        Some(prev),
+        Some(target),
+        0,
+        None,
+        0,
+        0,
+    )
+    .expect("validate_block_basic_with_context_and_fees_at_height happy path");
+    let delta = parse_count() - before;
+
+    assert_eq!(
+        delta, 1,
+        "G.9: validate_block_basic_with_context_and_fees_at_height must parse \
+         the block exactly once (observed {delta})"
+    );
+}


### PR DESCRIPTION
## Q
Q-ID parent (canonical, OPEN): `Q-PERF-NODE-PERSISTENCE-HOTPATH-01`
Sub-issue: Closes #1248

## One invariant
Rust consensus path parses each block exactly ONCE per `apply_block` call. `validate_parsed_block_basic_with_context_at_height(pb, ...)` extracted as `pub(crate)` helper; public `validate_block_basic_with_context_at_height` keeps signature, parses + delegates. `connect_block_basic_in_memory_*` now parses once via `parse_block_bytes` + calls helper, instead of "validate (parses) + parse again". Mirrors Go `validateParsedBlockBasicWithContextAtHeight` (`clients/go/consensus/block_basic.go:152`).

## Allowed files (4, at budget)
- `clients/rust/crates/rubin-consensus/src/block_basic.rs` (+38 / -7)
- `clients/rust/crates/rubin-consensus/src/connect_block_inmem.rs` (+13 / -9)
- `clients/rust/crates/rubin-consensus/src/tests/mod.rs` (+1)
- `clients/rust/crates/rubin-consensus/src/tests/parse_dedup.rs` (NEW, 182 LoC test)

## Non-scope (per slice-protocol HARD RULE 2026-04-19)
- B.1 chainstate save policy (sub-issue #1246)
- E.7 canonical-height cache (sub-issue #1247)
- consensus rule changes
- error variant / error message changes
- public API signature changes
- broader consensus refactor

## Accepted cases (tested via `PARSE_BLOCK_BYTES_CALL_COUNT` thread-local counter, `#[cfg(test)]` only)
- `apply_block(bytes)` happy path → exactly 1 parse ✓
- `apply_block(bytes)` validation rejection → ≤ 1 parse on error path ✓
- Reapply same block → exactly 2 parses (1 each call) — invariant holds per call ✓
- `_with_fees_` variant → exactly 1 parse ✓

## Validation
- `cargo test -p rubin-consensus`: 694 lib + 285 integration tests PASS
- `cargo test -p rubin-node`: 445 + 49 + 3 tests PASS (consumer of consensus API)
- `cargo clippy -p rubin-consensus --all-targets`: clean
- Existing consensus error vectors byte-for-byte identical (verified)
- `pre-amend-audit` stages 1-10 PASS; stage 11 skipped per /batch dispatch
- Codacy preflight Go skipped (Rust-only diff — per-lang skip)

## Slice-protocol marker
This PR closes ONLY G.9. B.1 (#1246) and E.7 (#1247) are tracked separately and MUST NOT be addressed here.

<!-- rubin-agent-meta actor=claude action=pr-create via=cl branch=worktree-agent-ace46dec wt=agent-ace46dec utc=2026-04-19T18:39:41Z -->
