### PR TITLE
fix(storage): add Go state_digest/utxo_set_hash twins to match Rust surface (E.8)

### DIFF
--- a/clients/go/node/chainstate.go
+++ b/clients/go/node/chainstate.go
@@ -438,6 +438,35 @@ func (s *ChainState) ConnectBlockWithCoreExtProfilesAndSuiteContext(
 	}, nil
 }
 
+// UtxoSetHash returns the deterministic SHA3-256 digest over the current UTXO
+// set. It is bit-identical with the Rust node ChainState::utxo_set_hash() and
+// uses the same canonical encoding as consensus.UtxoSetHash (which produces
+// PostStateDigest in ConnectBlock summaries). On a nil receiver returns the
+// digest of an empty UTXO map for definedness.
+//
+// Cost: O(n log n) over the entire UTXO set (sort by outpoint canonical key)
+// plus one SHA3-256 hash + per-entry allocations for the canonical encoding.
+// Intended for low-frequency inspection / parity-vector verification — do
+// NOT call from hot paths or polling loops. If a caller needs incremental
+// digest updates, fold the maintenance into ConnectBlock / DisconnectTip
+// instead of calling this.
+func (s *ChainState) UtxoSetHash() [32]byte {
+	if s == nil {
+		return consensus.UtxoSetHash(nil)
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return consensus.UtxoSetHash(s.Utxos)
+}
+
+// StateDigest is an alias for UtxoSetHash that mirrors the Rust node
+// ChainState::state_digest() surface. Today the chain state digest is exactly
+// the UTXO set hash; the two names are kept in parity with Rust so that
+// inspection callers can reach for either spelling.
+func (s *ChainState) StateDigest() [32]byte {
+	return s.UtxoSetHash()
+}
+
 // ConnectBlockParallelSigs connects a block using parallel signature
 // verification. This is an IBD optimization: pre-checks are sequential,
 // ML-DSA-87 signature verifications are batched and executed across a

--- a/clients/go/node/chainstate_test.go
+++ b/clients/go/node/chainstate_test.go
@@ -155,6 +155,86 @@ func TestChainStateConnectBlockDeterministicUpdate(t *testing.T) {
 	}
 }
 
+// E.8 surface-parity: pinned cross-client digest vectors. The genesis-only
+// digest is also pinned in conformance/fixtures/CV-PV-*.json (expect_digest)
+// and in the Rust ChainState test (GENESIS_ONLY_STATE_DIGEST_HEX), so a single
+// hex string here keeps Go bit-identical with Rust. The empty-set digest is
+// the bare SHA3-256 of DST || 0_u64_le and is exercised here to lock in the
+// nil-receiver / fresh-state contract; any encoding drift would change it.
+const (
+	chainStateEmptyDigestHex       = "e0a6004258a669e1c7f1e12c1b249964e31ad956661237162a6d4daa22d39a6f"
+	chainStateGenesisOnlyDigestHex = "8b172fb3a5e70b56de9ae78ce750c04eccbc4dd8b3be55751252e5a1b4f2e752"
+)
+
+func TestChainStateUtxoSetHashEmptyAndNilReceiver(t *testing.T) {
+	emptyDigest := NewChainState().UtxoSetHash()
+	if got := hex.EncodeToString(emptyDigest[:]); got != chainStateEmptyDigestHex {
+		t.Fatalf("empty UTXO digest=%s, want %s", got, chainStateEmptyDigestHex)
+	}
+
+	var nilState *ChainState
+	if nilState.UtxoSetHash() != emptyDigest {
+		t.Fatalf("nil receiver must return empty-set digest")
+	}
+	if nilState.StateDigest() != emptyDigest {
+		t.Fatalf("nil receiver StateDigest must return empty-set digest")
+	}
+
+	st := NewChainState()
+	if st.StateDigest() != st.UtxoSetHash() {
+		t.Fatalf("StateDigest must alias UtxoSetHash")
+	}
+}
+
+func TestChainStateUtxoSetHashMatchesRustGenesisOnlyVector(t *testing.T) {
+	target := consensus.POW_LIMIT
+	st := NewChainState()
+	if _, err := st.ConnectBlock(devnetGenesisBlockBytes, &target, nil, devnetGenesisChainID); err != nil {
+		t.Fatalf("connect genesis block: %v", err)
+	}
+	digest := st.StateDigest()
+	if got := hex.EncodeToString(digest[:]); got != chainStateGenesisOnlyDigestHex {
+		t.Fatalf("genesis-only state_digest=%s, want %s (Rust parity)", got, chainStateGenesisOnlyDigestHex)
+	}
+	if st.UtxoSetHash() != digest {
+		t.Fatalf("UtxoSetHash and StateDigest must agree")
+	}
+}
+
+func TestChainStateUtxoSetHashIsDeterministicAndSensitiveToChange(t *testing.T) {
+	st := NewChainState()
+	st.Utxos[consensus.Outpoint{
+		Txid: mustHash32Hex(t, "1111111111111111111111111111111111111111111111111111111111111111"),
+		Vout: 0,
+	}] = consensus.UtxoEntry{
+		Value:             42,
+		CovenantType:      consensus.COV_TYPE_P2PK,
+		CovenantData:      testP2PKCovenantData(0x11),
+		CreationHeight:    5,
+		CreatedByCoinbase: false,
+	}
+
+	first := st.UtxoSetHash()
+	if first != st.UtxoSetHash() {
+		t.Fatalf("UtxoSetHash must be idempotent on the same state")
+	}
+
+	st.Utxos[consensus.Outpoint{
+		Txid: mustHash32Hex(t, "2222222222222222222222222222222222222222222222222222222222222222"),
+		Vout: 1,
+	}] = consensus.UtxoEntry{
+		Value:             7,
+		CovenantType:      consensus.COV_TYPE_P2PK,
+		CovenantData:      testP2PKCovenantData(0x22),
+		CreationHeight:    6,
+		CreatedByCoinbase: false,
+	}
+	second := st.UtxoSetHash()
+	if first == second {
+		t.Fatalf("adding a UTXO must change the digest")
+	}
+}
+
 func TestChainStateConnectBlockAcceptsLocalGenesisWithConfiguredChainID(t *testing.T) {
 	target := consensus.POW_LIMIT
 	st := NewChainState()


### PR DESCRIPTION
## Q
Q-ID parent (canonical, OPEN): `Q-IMPL-NODE-STORAGE-SAFETY-AND-STATE-SURFACE-PARITY-01`
Sub-issue: Closes #1243

## One invariant
Go gains `(*ChainState).UtxoSetHash()` and `(*ChainState).StateDigest()` accessor methods that delegate to the existing canonical `consensus.UtxoSetHash` encoding under `s.mu.RLock()`. Outputs are bit-identical to Rust's `utxo_set_hash` / `state_digest` for the same UTXO set; nil-receiver definedness mirrored.

## Allowed files (2)
- `clients/go/node/chainstate.go` (+30 — 2 accessor methods + cost doc)
- `clients/go/node/chainstate_test.go` (+80 — 3 tests)

LoC: 30 prod + 80 test, well under 200/200/4 budget.

## Cost (documented in code)
`UtxoSetHash()` is **O(n log n)** over the entire UTXO set (canonical sort) plus a SHA3-256 hash and per-entry allocations. Intended for low-frequency inspection / parity-vector verification — NOT hot paths or polling loops. Doc explicitly tells future callers to fold incremental digest maintenance into ConnectBlock/DisconnectTip if a hot-path use case appears.

## Non-scope (per slice-protocol HARD RULE 2026-04-19)
- E.9 UTXO defensive-copy helper (sub-issue #1244, closed via PR #1252)
- E.10 safe-path traversal guard (sub-issue #1245, closed via PR #1250)
- canonical UTXO encoding redesign
- digest caching / incremental maintenance (would be separate Q if needed)

## Accepted cases (3 tests)
- `TestChainStateUtxoSetHashEmptyAndNilReceiver` — empty digest pinned to canonical formula; nil-receiver = empty; `StateDigest == UtxoSetHash`
- `TestChainStateUtxoSetHashMatchesRustGenesisOnlyVector` — **cross-client parity vector**: `8b172fb3a5e70b56de9ae78ce750c04eccbc4dd8b3be55751252e5a1b4f2e752` matches Rust `GENESIS_ONLY_STATE_DIGEST_HEX` and the value pinned in `conformance/fixtures/CV-PV-*.json`
- `TestChainStateUtxoSetHashIsDeterministicAndSensitiveToChange` — idempotence + change-sensitivity

## Validation
- `gofmt` clean, `go vet ./node/` clean
- `go test ./node/ -count=1`: full suite PASS; all 3 new tests PASS including cross-client parity vector
- `pre-amend-audit` stages 1-10 PASS; stage 11 skipped per /batch dispatch
- Rebased onto current `origin/main` (`mergeStateStatus` was BEHIND prior to this update)

## Slice-protocol marker
This PR closes ONLY E.8. E.9 (#1244 → PR #1252) and E.10 (#1245 → PR #1250) are tracked separately and MUST NOT be addressed here.

<!-- rubin-agent-meta actor=claude action=pr-edit via=cl branch=claude/strange-ramanujan wt=strange-ramanujan utc=2026-04-19T19:18:31Z -->
