### PR TITLE
cleanup: misspell + copyloopvar auto-fixes (Go linter baseline)

### DIFF
--- a/clients/go/consensus/covenant_genesis.go
+++ b/clients/go/consensus/covenant_genesis.go
@@ -3,7 +3,7 @@ package consensus
 // ValidateTxCovenantsGenesis checks that every output's covenant is well-formed
 // at creation time. The rotation parameter controls which signature suites are
 // valid for native covenant creation at the given block height. Pass nil for
-// the default pre-rotation behaviour ({ML-DSA-87} only).
+// the default pre-rotation behavior ({ML-DSA-87} only).
 func ValidateTxCovenantsGenesis(tx *Tx, blockHeight uint64, rotation RotationProvider) error {
 	if tx == nil {
 		return txerr(TX_ERR_PARSE, "nil tx")

--- a/clients/go/consensus/da_verify_parallel_test.go
+++ b/clients/go/consensus/da_verify_parallel_test.go
@@ -72,7 +72,7 @@ func TestVerifyDAChunkHashes_CancelledContext(t *testing.T) {
 	}
 	err := VerifyDAChunkHashesParallel(ctx, tasks, 1)
 	if err == nil {
-		t.Fatalf("expected error from cancelled context")
+		t.Fatalf("expected error from canceled context")
 	}
 }
 

--- a/clients/go/consensus/tx_marshal.go
+++ b/clients/go/consensus/tx_marshal.go
@@ -2,7 +2,7 @@ package consensus
 
 import "fmt"
 
-// MarshalTx serialises a Tx into its canonical wire-format bytes.
+// MarshalTx serializes a Tx into its canonical wire-format bytes.
 // The output is the exact inverse of ParseTx (roundtrip property).
 func MarshalTx(tx *Tx) ([]byte, error) {
 	if tx == nil {

--- a/clients/go/consensus/tx_validate_worker_test.go
+++ b/clients/go/consensus/tx_validate_worker_test.go
@@ -437,7 +437,7 @@ func TestRunTxValidationWorkers_CancelledContext(t *testing.T) {
 	}}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	cancel() // already cancelled
+	cancel() // already canceled
 
 	results, err := RunTxValidationWorkers(ctx, 2, txcs, [32]byte{}, 1, 0, nil, nil)
 	if err != nil {
@@ -447,7 +447,7 @@ func TestRunTxValidationWorkers_CancelledContext(t *testing.T) {
 		t.Fatalf("expected 1 result, got %d", len(results))
 	}
 	if results[0].Err == nil {
-		t.Fatalf("expected error from cancelled context")
+		t.Fatalf("expected error from canceled context")
 	}
 }
 

--- a/clients/go/consensus/wire_read_test.go
+++ b/clients/go/consensus/wire_read_test.go
@@ -9,7 +9,7 @@ func TestReadBytes_RejectsInvalidOffsets(t *testing.T) {
 	buf := []byte{0x01, 0x02, 0x03}
 
 	for _, off := range []int{-1, len(buf) + 1, int(^uint(0) >> 1)} {
-		off := off
+
 		t.Run("off", func(t *testing.T) {
 			_, err := readBytes(buf, &off, 1)
 			if err == nil {

--- a/clients/go/consensus/worker_pool.go
+++ b/clients/go/consensus/worker_pool.go
@@ -37,7 +37,7 @@ func (e *WorkerPoolRunError) Error() string {
 //   - Deterministic: result[i] corresponds to task[i].
 //   - Panic-safe: a panicking task produces an error result, does not crash
 //     the process, and does not prevent other tasks from completing.
-//   - Cancellable: if the context is cancelled, unstarted tasks are skipped
+//   - Cancellable: if the context is canceled, unstarted tasks are skipped
 //     and their results are set to the context error.
 type WorkerPool[T any, R any] struct {
 	// MaxWorkers is the maximum number of concurrent goroutines.
@@ -62,7 +62,7 @@ type WorkerResult[R any] struct {
 // Run executes all tasks in parallel and returns results in submission order.
 // The returned slice has the same length as tasks.
 //
-// If ctx is cancelled, unstarted tasks receive ctx.Err() as their error.
+// If ctx is canceled, unstarted tasks receive ctx.Err() as their error.
 // Already-running tasks continue to completion (Go goroutines cannot be
 // forcibly stopped).
 //

--- a/clients/go/consensus/worker_pool_test.go
+++ b/clients/go/consensus/worker_pool_test.go
@@ -263,7 +263,7 @@ func TestWorkerPool_ContextCancellation(t *testing.T) {
 
 func TestWorkerPool_AlreadyCancelledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	cancel() // already cancelled
+	cancel() // already canceled
 
 	pool := &WorkerPool[int, int]{MaxWorkers: 4, MaxTasks: 8, Func: intIdentity}
 	tasks := []int{1, 2, 3}

--- a/clients/go/node/blockstore.go
+++ b/clients/go/node/blockstore.go
@@ -543,7 +543,7 @@ func canonicalTipHeight(canonical []string) (uint64, bool) {
 //	                    fast-path on retry re-runs syncDir and
 //	                    propagates its error so durability is surfaced.
 //	cross-platform:     Unix (Linux, macOS): os.Link, O_EXCL, dir Sync
-//	                    all semantically honoured. Windows: Sync on
+//	                    all semantically honored. Windows: Sync on
 //	                    directories is a no-op in stdlib; Rubin does
 //	                    not ship Windows as a production target.
 //	                    Test surfaces that rely on os.Geteuid()/chmod
@@ -573,7 +573,7 @@ func canonicalTipHeight(canonical []string) (uint64, bool) {
 //	                    PR #1220).
 func writeFileIfAbsent(path string, content []byte) error {
 	// Fast path: destination already exists. Read once and verify match
-	// before attempting any writes. Same behaviour as the Rust helper
+	// before attempting any writes. Same behavior as the Rust helper
 	// via `write_file_exclusive` + EEXIST branch, but short-circuited
 	// here to avoid a useless temp write when the file is already
 	// present with the right bytes (dominant case during idempotent

--- a/clients/go/node/chainstate_recovery.go
+++ b/clients/go/node/chainstate_recovery.go
@@ -160,7 +160,7 @@ func ReconcileChainStateWithBlockStore(state *ChainState, store *BlockStore, cfg
 		if err != nil {
 			return false, err
 		}
-		// Defence-in-depth: re-hash the loaded block's header and
+		// Defense-in-depth: re-hash the loaded block's header and
 		// confirm it matches the canonical-index entry BEFORE
 		// delegating to ConnectBlockWithCoreExtProfilesAndSuiteContext.
 		// A parseable-but-swapped <hash>.bin (bit-rot, manual disk

--- a/clients/go/node/chainstate_recovery_test.go
+++ b/clients/go/node/chainstate_recovery_test.go
@@ -461,7 +461,7 @@ func TestReconcileChainStateWithBlockStore_ResetsDirtyTiplessSnapshotBeforeRepla
 }
 
 // TestReconcileChainStateWithBlockStore_PropagatesCorruptBlockBytesSwap
-// pins the cross-client re-hash defence: a parseable-but-wrong
+// pins the cross-client re-hash defense: a parseable-but-wrong
 // <hash>.bin (block 1's payload overwritten with block 2's bytes,
 // which still link to b1_hash as prev_hash so chain-integrity
 // inside ConnectBlock would PASS) MUST be rejected by reconcile's

--- a/clients/go/node/miner_additional_test.go
+++ b/clients/go/node/miner_additional_test.go
@@ -386,7 +386,7 @@ func TestCanonicalCoinbaseWeightMatchesLegacyWeight(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/clients/go/node/p2p/service_listener.go
+++ b/clients/go/node/p2p/service_listener.go
@@ -14,7 +14,7 @@ import (
 // exhaustion) are retried with an exponential backoff capped at
 // acceptErrorBackoffCap. The constants mirror rubin-node Rust
 // ACCEPT_ERROR_BACKOFF_INIT / ACCEPT_ERROR_BACKOFF_CAP for cross-client
-// behavioural parity; see
+// behavioral parity; see
 // clients/rust/crates/rubin-node/src/p2p_service.rs.
 const (
 	acceptErrorBackoffInit = 100 * time.Millisecond
@@ -44,7 +44,7 @@ func nextAcceptErrorBackoff(current time.Duration) time.Duration {
 
 // isAcceptLoopTerminal reports whether an Accept error should exit the
 // accept loop. Terminal conditions are: the service context has been
-// cancelled (Close path), or the listener has been closed.
+// canceled (Close path), or the listener has been closed.
 func isAcceptLoopTerminal(ctx context.Context, err error) bool {
 	if ctx != nil && ctx.Err() != nil {
 		return true
@@ -275,7 +275,7 @@ func (s *Service) acceptLoop() {
 	}
 }
 
-// sleepOrStop sleeps for d unless the service context is cancelled first.
+// sleepOrStop sleeps for d unless the service context is canceled first.
 // Returns true if the full sleep elapsed, false if cancellation unblocked
 // the sleep (callers treat false as "exit the loop"). A non-positive d or
 // nil receiver/context falls back to the obvious no-op or unconditional

--- a/clients/go/node/p2p/service_listener_test.go
+++ b/clients/go/node/p2p/service_listener_test.go
@@ -30,7 +30,7 @@ func TestNextAcceptErrorBackoff(t *testing.T) {
 		{"overshoot clamps to cap", 10 * time.Second, acceptErrorBackoffCap},
 	}
 	for _, tc := range cases {
-		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			got := nextAcceptErrorBackoff(tc.current)
 			if got != tc.want {
@@ -45,7 +45,7 @@ func TestIsAcceptLoopTerminalCtxCancelled(t *testing.T) {
 	cancel()
 	someErr := errors.New("temporary accept failure")
 	if !isAcceptLoopTerminal(ctx, someErr) {
-		t.Fatalf("cancelled ctx should make error terminal")
+		t.Fatalf("canceled ctx should make error terminal")
 	}
 }
 
@@ -88,10 +88,10 @@ func TestSleepOrStopCancelledCtx(t *testing.T) {
 	s := &Service{ctx: ctx}
 	start := time.Now()
 	if s.sleepOrStop(5 * time.Second) {
-		t.Fatalf("sleepOrStop with cancelled ctx must return false")
+		t.Fatalf("sleepOrStop with canceled ctx must return false")
 	}
 	if elapsed := time.Since(start); elapsed >= 1*time.Second {
-		t.Fatalf("sleepOrStop should return promptly on cancelled ctx, elapsed=%s", elapsed)
+		t.Fatalf("sleepOrStop should return promptly on canceled ctx, elapsed=%s", elapsed)
 	}
 }
 

--- a/clients/go/node/production_rotation_schedule_test.go
+++ b/clients/go/node/production_rotation_schedule_test.go
@@ -202,7 +202,7 @@ func TestLoadCompiledProductionRotationScheduleRejectsReservedSentinelSuiteID(t 
 	}
 
 	for _, tc := range cases {
-		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			_, _, err := loadCompiledProductionRotationScheduleFromJSONWithRegistry([]byte(`{
 				"version": 1,
@@ -280,7 +280,7 @@ func TestLoadCompiledProductionRotationScheduleRejectsNonFiniteSunsetHeightOnPro
 	}
 
 	for _, tc := range cases {
-		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			sunsetField := ""
 			if tc.sunsetField != "" {

--- a/clients/go/node/sync.go
+++ b/clients/go/node/sync.go
@@ -182,7 +182,7 @@ func normalizedNetworkName(network string) string {
 // ValidateMainnetGenesisGuard exposes the mainnet genesis / target
 // guard so cmd/rubin-node/main.go can run it BEFORE reconcile (mirror
 // of Rust main.rs validate_mainnet_genesis_guard call). Devnet / test
-// networks no-op. Defence-in-depth: NewSyncEngine still runs the same
+// networks no-op. Defense-in-depth: NewSyncEngine still runs the same
 // guard internally for callers that construct an engine directly
 // (tests, embedded uses).
 func ValidateMainnetGenesisGuard(cfg SyncConfig) error {
@@ -551,7 +551,7 @@ func (s *SyncEngine) applyCanonicalParsedBlock(
 }
 
 // txErrCode extracts the consensus.TxError code string from err for
-// telemetry and event labelling. It uses errors.As so that a wrapped
+// telemetry and event labeling. It uses errors.As so that a wrapped
 // *consensus.TxError (e.g. produced by fmt.Errorf("...: %w", inner)) is
 // still classified correctly instead of falling through to "ERR". A nil
 // error reports "OK"; any non-TxError reports "ERR".


### PR DESCRIPTION
## Summary

Pure mechanical cleanup surfaced by `golangci-lint` baseline on the current Go
module. **No semantic behavior change**, 25 findings auto-fixed via `--fix`.

Part of tracking umbrella #1261.

Refs: Q-TOOLING-CLEANUP-MISSPELL-COPYLOOPVAR-01
Consensus rules unchanged: YES
SECTION_HASHES.json unchanged: YES

## Scope

| Class | Count | Fix |
|---|---|---|
| `misspell` | 20 | US English replacements |
| `copyloopvar` | 5 | Remove redundant `tc := tc` / `off := off` (Go 1.22+ captures correctly per-iteration) |

### misspell replacements (20 occurrences)

- `cancelled` → `canceled` (×11)
- `behaviour` → `behavior` (×2)
- `Defence` / `defence` → `Defense` / `defense` (×2)
- `serialises` → `serializes`
- `labelling` → `labeling`
- `honoured` → `honored`
- `behavioural` → `behavioral`

All occurrences are in comments / error messages / test strings. No public
identifiers renamed.

### copyloopvar deletions (5 occurrences)

Removed redundant loop-variable re-binding in 5 test sites:

- `clients/go/consensus/wire_read_test.go:12`
- `clients/go/node/miner_additional_test.go:389`
- `clients/go/node/p2p/service_listener_test.go:33`
- `clients/go/node/production_rotation_schedule_test.go:205`
- `clients/go/node/production_rotation_schedule_test.go:283`

Go 1.22+ loop-variable capture semantics make the explicit copy unnecessary.

## Verification

- `go build ./...` → ok
- `go test ./consensus` → pass
- `go test ./node/p2p` → pass
- `go test ./node` → pre-existing flakiness on `service_listener` goroutine
  leak (`go test -timeout 60s ./node` on clean `origin/main` also fails);
  not introduced by this change
- `golangci-lint run --new-from-rev=origin/main` → 0 new findings
- local pre-push review gate passed (all active lenses ok)

## Files changed

15 files, +25 / -25. All changes are string-literal swaps or line deletions —
no control-flow modification.

## Out of scope

- `errorlint` (21), `SA1006` (21), `gocritic filepathJoin` (7) — require
  manual per-site edits; separate follow-up PR.
- Real bug fixes tracked in issues #1258 #1262 #1263 — separate PRs.
- `nilnil` (11), `errcheck` type-assertion (16), `contextcheck` (2), G602
  false positives (7) — deserve `//nolint` annotations with rationale in a
  follow-up PR, not silent code changes.
- G115 integer-overflow cluster (9 sites) — per-site invariant audit,
  tracked as follow-up.