### PR TITLE
fix: harden Go P2P tx fault handling

### DIFF
--- a/clients/go/node/p2p/handlers_tx.go
+++ b/clients/go/node/p2p/handlers_tx.go
@@ -37,10 +37,10 @@ func (p *peer) handleTx(txBytes []byte) error {
 	}
 	meta, err := p.service.relayTxMetadata(txBytes)
 	if err != nil {
-		if p.bumpBan(10, err.Error()) {
-			return err
-		}
-		return nil
+		// Keep metadata rejections peer-neutral for Go/Rust relay parity:
+		// local policy/runtime state can reject a structurally valid tx, and
+		// Rust surfaces the same branch as non-banworthy MetadataRejected.
+		return nil //nolint:nilerr
 	}
 	if !p.service.cfg.TxPool.Put(txid, txBytes, meta.Fee, meta.Size) {
 		return nil

--- a/clients/go/node/p2p/handlers_tx.go
+++ b/clients/go/node/p2p/handlers_tx.go
@@ -37,6 +37,9 @@ func (p *peer) handleTx(txBytes []byte) error {
 	}
 	meta, err := p.service.relayTxMetadata(txBytes)
 	if err != nil {
+		if p.bumpBan(10, err.Error()) {
+			return err
+		}
 		return nil
 	}
 	if !p.service.cfg.TxPool.Put(txid, txBytes, meta.Fee, meta.Size) {

--- a/clients/go/node/p2p/handlers_tx_test.go
+++ b/clients/go/node/p2p/handlers_tx_test.go
@@ -289,7 +289,7 @@ func TestHandleTxPoolFullMarksSeen(t *testing.T) {
 	}
 }
 
-func TestHandleTxMetadataErrorBumpsBanAndMarksSeen(t *testing.T) {
+func TestHandleTxMetadataErrorIsPeerNeutralAndMarksSeen(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -314,54 +314,17 @@ func TestHandleTxMetadataErrorBumpsBanAndMarksSeen(t *testing.T) {
 	if err := p.handleTx(txBytes); err != nil {
 		t.Fatalf("handleTx metadata error should be swallowed, got %v", err)
 	}
-	if p.state.BanScore != 10 {
-		t.Fatalf("ban score=%d, want 10 after metadata error", p.state.BanScore)
+	if p.state.BanScore != 0 {
+		t.Fatalf("ban score=%d, want 0 for peer-neutral metadata error", p.state.BanScore)
 	}
-	if p.state.LastError != "metadata unavailable" {
-		t.Fatalf("last error=%q, want metadata unavailable", p.state.LastError)
+	if p.state.LastError != "" {
+		t.Fatalf("last error=%q, want empty for peer-neutral metadata error", p.state.LastError)
 	}
 	if h.service.cfg.TxPool.Has(txid) {
 		t.Fatal("metadata failure should not admit tx into relay pool")
 	}
 	if !h.service.txSeen.Has(txid) {
 		t.Fatal("metadata failure should still mark tx as seen to suppress churn")
-	}
-}
-
-func TestHandleTxMetadataErrorReturnsAtBanThreshold(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	h := newTestHarness(t, 1, "127.0.0.1:0", nil)
-	h.service.cfg.PeerRuntimeConfig.BanThreshold = 10
-	h.service.cfg.TxMetadataFunc = func([]byte) (node.RelayTxMetadata, error) {
-		return node.RelayTxMetadata{}, errors.New("metadata unavailable")
-	}
-	if err := h.service.Start(ctx); err != nil {
-		t.Fatalf("Start: %v", err)
-	}
-	defer h.service.Close()
-
-	p := &peer{
-		service: h.service,
-		state:   node.PeerState{HandshakeComplete: true},
-	}
-	txBytes := distinctTxBytes(t, 780)
-	txid, err := canonicalTxID(txBytes)
-	if err != nil {
-		t.Fatalf("canonicalTxID: %v", err)
-	}
-	if err := p.handleTx(txBytes); err == nil {
-		t.Fatal("handleTx metadata error should return error at ban threshold")
-	}
-	if p.state.BanScore != 10 {
-		t.Fatalf("ban score=%d, want 10 after metadata error", p.state.BanScore)
-	}
-	if h.service.cfg.TxPool.Has(txid) {
-		t.Fatal("metadata failure should not admit tx into relay pool")
-	}
-	if !h.service.txSeen.Has(txid) {
-		t.Fatal("metadata failure should still mark tx as seen before threshold return")
 	}
 }
 

--- a/clients/go/node/p2p/handlers_tx_test.go
+++ b/clients/go/node/p2p/handlers_tx_test.go
@@ -289,7 +289,7 @@ func TestHandleTxPoolFullMarksSeen(t *testing.T) {
 	}
 }
 
-func TestHandleTxMetadataErrorStillMarksSeen(t *testing.T) {
+func TestHandleTxMetadataErrorBumpsBanAndMarksSeen(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -314,11 +314,54 @@ func TestHandleTxMetadataErrorStillMarksSeen(t *testing.T) {
 	if err := p.handleTx(txBytes); err != nil {
 		t.Fatalf("handleTx metadata error should be swallowed, got %v", err)
 	}
+	if p.state.BanScore != 10 {
+		t.Fatalf("ban score=%d, want 10 after metadata error", p.state.BanScore)
+	}
+	if p.state.LastError != "metadata unavailable" {
+		t.Fatalf("last error=%q, want metadata unavailable", p.state.LastError)
+	}
 	if h.service.cfg.TxPool.Has(txid) {
 		t.Fatal("metadata failure should not admit tx into relay pool")
 	}
 	if !h.service.txSeen.Has(txid) {
 		t.Fatal("metadata failure should still mark tx as seen to suppress churn")
+	}
+}
+
+func TestHandleTxMetadataErrorReturnsAtBanThreshold(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	h := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	h.service.cfg.PeerRuntimeConfig.BanThreshold = 10
+	h.service.cfg.TxMetadataFunc = func([]byte) (node.RelayTxMetadata, error) {
+		return node.RelayTxMetadata{}, errors.New("metadata unavailable")
+	}
+	if err := h.service.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer h.service.Close()
+
+	p := &peer{
+		service: h.service,
+		state:   node.PeerState{HandshakeComplete: true},
+	}
+	txBytes := distinctTxBytes(t, 780)
+	txid, err := canonicalTxID(txBytes)
+	if err != nil {
+		t.Fatalf("canonicalTxID: %v", err)
+	}
+	if err := p.handleTx(txBytes); err == nil {
+		t.Fatal("handleTx metadata error should return error at ban threshold")
+	}
+	if p.state.BanScore != 10 {
+		t.Fatalf("ban score=%d, want 10 after metadata error", p.state.BanScore)
+	}
+	if h.service.cfg.TxPool.Has(txid) {
+		t.Fatal("metadata failure should not admit tx into relay pool")
+	}
+	if !h.service.txSeen.Has(txid) {
+		t.Fatal("metadata failure should still mark tx as seen before threshold return")
 	}
 }
 

--- a/clients/go/node/p2p/reconnect_test.go
+++ b/clients/go/node/p2p/reconnect_test.go
@@ -147,6 +147,11 @@ func TestDialPeerFailureRecordsReconnect(t *testing.T) {
 	}
 }
 
+func TestDialPeerNilReceiverReturnsBeforeDefers(t *testing.T) {
+	var service *Service
+	service.dialPeer("127.0.0.1:1")
+}
+
 func TestReconnectDuePeersSkipsConnectedAndNotDue(t *testing.T) {
 	restore := overrideReconnectTiming(50*time.Millisecond, 50*time.Millisecond, 200*time.Millisecond)
 	defer restore()

--- a/clients/go/node/p2p/service_listener.go
+++ b/clients/go/node/p2p/service_listener.go
@@ -299,11 +299,11 @@ func (s *Service) sleepOrStop(d time.Duration) bool {
 }
 
 func (s *Service) dialPeer(addr string) {
-	defer s.loopWG.Done()
-	defer s.finishDialPeer(addr)
 	if s == nil {
 		return
 	}
+	defer s.loopWG.Done()
+	defer s.finishDialPeer(addr)
 	dialer := &net.Dialer{Timeout: s.cfg.PeerRuntimeConfig.HandshakeTimeout}
 	conn, err := dialer.DialContext(s.ctx, "tcp", addr)
 	if err != nil {


### PR DESCRIPTION
## Architecture class
A = local patch

## System boundary
Go P2P peer fault handling in `clients/go/node/p2p`.

## Single invariant
Close two static-analysis issue reports without changing wire format, Rust behavior, TxPool policy, or peer lifecycle architecture:
- `dialPeer` nil receiver guard must execute before any nil receiver dereference.
- `handleTx` relay metadata rejection must stay explicit, lint-clean, and peer-neutral for Go/Rust parity.

Closes #1258.
Closes #1262.

## Non-goals
- No Rust changes.
- No TxPool interface or pool-full/duplicate semantics redesign.
- No wire format or message policy changes.
- No mechanical cleanup for #1263.

## What this PR is NOT allowed to redesign
Peer lifecycle, reconnect scheduling, mempool admission, relay fanout, or cross-client parity contracts.

## Validation
- `python3 inbox/operational/tools/session_doctor.py --repo-root /Users/gpt/Documents/rubin-protocol-codex-1258-1262 --require-claude-review`
- `cd clients/go && ../../scripts/dev-env.sh -- go test ./node/p2p -run 'Test(DialPeerNilReceiverReturnsBeforeDefers|DialPeerFailureRecordsReconnect|HandleTxMetadataErrorIsPeerNeutralAndMarksSeen|HandleTxPoolFullMarksSeen|HandleTxMalformed|HandleTxValid|HandleTxNonCanonical)$'`
- `cd clients/go && ../../scripts/dev-env.sh -- go test ./node/p2p`
- `cd clients/go && ../../scripts/dev-env.sh -- go test ./...`
- `TOOLING_NEW_ONLY=1 bash /Users/gpt/rubin-tool-scaffolding/scripts/tooling-check.sh fast --repo /Users/gpt/Documents/rubin-protocol-codex-1258-1262`
- `/Users/gpt/.codex/bin/rubin-quality-gate ...` final receipt PASS
- `cl push` PASS, including local security review and Codacy coverage preflight

## Bot review disposition
- Initial metadata-ban policy was rejected by Codex/Copilot as valid Go/Rust parity risk.
- Fixed in `b35b67a`: metadata rejection remains peer-neutral, `nilerr` is suppressed with explicit parity rationale, and tests assert `BanScore=0` / empty `LastError` while preserving `txSeen` churn suppression.
