### PR TITLE
fix: clean network magic fallback

### DIFF
--- a/clients/go/node/p2p/wire.go
+++ b/clients/go/node/p2p/wire.go
@@ -315,8 +315,9 @@ func decodeWireCommand(raw []byte) (string, error) {
 
 func networkMagic(network string) [4]byte {
 	network, _ = node.CanonicalNetworkName(network)
-	// Low-level wire helpers keep a fixed isolation fallback for custom/private
-	// transports; the node config/runtime surface rejects those names before startup.
+	// Low-level wire helpers keep a fixed isolation fallback for unknown or
+	// custom/private transport names. Validated config flows typically reject
+	// unknown names earlier, but runtime normalization is not the rejection point.
 	switch network {
 	case "mainnet":
 		return [4]byte{'R', 'B', 'M', 'N'}

--- a/clients/go/node/p2p/wire.go
+++ b/clients/go/node/p2p/wire.go
@@ -314,13 +314,9 @@ func decodeWireCommand(raw []byte) (string, error) {
 }
 
 func networkMagic(network string) [4]byte {
-	network, ok := node.CanonicalNetworkName(network)
-	if !ok {
-		// Low-level wire helpers still keep a fixed isolation fallback for custom or
-		// private transports, but the node config/runtime surface rejects those names
-		// before startup. Any normalized name outside {mainnet,testnet,devnet} falls
-		// through to the shared non-standard magic below.
-	}
+	network, _ = node.CanonicalNetworkName(network)
+	// Low-level wire helpers keep a fixed isolation fallback for custom/private
+	// transports; the node config/runtime surface rejects those names before startup.
 	switch network {
 	case "mainnet":
 		return [4]byte{'R', 'B', 'M', 'N'}


### PR DESCRIPTION
## Architecture class
A = local patch

## System boundary
Go P2P wire helper `networkMagic` in `clients/go/node/p2p`.

## Single invariant
Remove the staticcheck `SA4006` / `SA9003` trigger from `networkMagic` without changing network magic behavior:
- known network names still map to their existing magic bytes;
- canonicalized known names still work;
- unknown/custom names still fall through to the shared `RBOP` fallback.

Closes #1263.

## Non-goals
- No logging or metrics side effects in the low-level wire helper.
- No config validation or `CanonicalNetworkName` contract changes.
- No wire format or magic byte changes.
- No Rust changes.
- No broader p2p cleanup.

## What this PR is NOT allowed to redesign
Network policy, peer lifecycle, handshake semantics, wire envelope format, or Go/Rust parity contracts.

## Validation
- `python3 inbox/operational/tools/session_doctor.py --repo-root /Users/gpt/Documents/rubin-protocol-codex-1258-1262 --require-claude-review`
- `cd clients/go && ../../scripts/dev-env.sh -- go test ./node/p2p -run 'TestNetworkMagic'`
- `cd clients/go && ../../scripts/dev-env.sh -- go test ./node/p2p`
- `cd clients/go && ../../scripts/dev-env.sh -- go test ./...`
- `TOOLING_NEW_ONLY=1 bash /Users/gpt/rubin-tool-scaffolding/scripts/tooling-check.sh fast --repo /Users/gpt/Documents/rubin-protocol-codex-1258-1262`
- `/Users/gpt/.codex/bin/rubin-quality-gate ...` PASS receipt
- `cl push` PASS, including local security review

## Reviewer notes
Issue #1263 listed logging as a possible option, but this PR intentionally keeps the slice smaller: logging would add a new side effect to a low-level wire helper. The existing tests already cover the relevant behavior boundaries, and the diff only removes the empty branch while preserving the fallback.
