### PR TITLE
feat: add devnet process harness helpers

### DIFF
--- a/scripts/devnet-process-common.sh
+++ b/scripts/devnet-process-common.sh
@@ -7,13 +7,23 @@
 : "${RUBIN_PROCESS_ARTIFACT_PARENT:=}"
 : "${RUBIN_PROCESS_KEEP_ARTIFACTS:=${KEEP_TMP:-0}}"
 : "${RUBIN_PROCESS_STOP_GRACE_SECONDS:=5}"
-declare -p RUBIN_PROCESS_PIDS >/dev/null 2>&1 || RUBIN_PROCESS_PIDS=()
-declare -p RUBIN_PROCESS_LOGS >/dev/null 2>&1 || RUBIN_PROCESS_LOGS=()
-: "${RUBIN_PROCESS_LAST_PID:=}"
-: "${_RUBIN_PROCESS_CREATED_PARENT:=}"
-: "${_RUBIN_PROCESS_CREATED_ROOT:=}"
-: "${_RUBIN_PROCESS_CREATED_ROOT_REAL:=}"
-: "${_RUBIN_PROCESS_STOP_GRACE_SECONDS_DECIMAL:=}"
+_rubin_process_existing_exit_trap="$(trap -p EXIT || true)"
+if [[ "${_rubin_process_existing_exit_trap}" == *"rubin_process_exit_trap"* ]]; then
+  echo "refusing to re-source devnet process helper after rubin_process_init" >&2
+  unset _rubin_process_existing_exit_trap
+  if ! return 1 2>/dev/null; then
+    # shellcheck disable=SC2317 # reachable only when the helper is executed instead of sourced.
+    exit 1
+  fi
+fi
+unset _rubin_process_existing_exit_trap
+RUBIN_PROCESS_PIDS=()
+RUBIN_PROCESS_LOGS=()
+RUBIN_PROCESS_LAST_PID=""
+_RUBIN_PROCESS_CREATED_PARENT=""
+_RUBIN_PROCESS_CREATED_ROOT=""
+_RUBIN_PROCESS_CREATED_ROOT_REAL=""
+_RUBIN_PROCESS_STOP_GRACE_SECONDS_DECIMAL=""
 
 _rubin_process_error() { echo "$*" >&2; }
 

--- a/scripts/devnet-process-common.sh
+++ b/scripts/devnet-process-common.sh
@@ -20,6 +20,8 @@ _rubin_process_uint() {
 
 _rubin_process_pid() { [[ "${1:-}" =~ ^[1-9][0-9]*$ ]]; }
 
+_rubin_process_has_parent_ref() { case "/${1:-}/" in *"/../"*) return 0 ;; *) return 1 ;; esac; }
+
 _rubin_process_require_init() {
   [[ -n "${RUBIN_PROCESS_ARTIFACT_ROOT}" && -d "${RUBIN_PROCESS_ARTIFACT_ROOT}" ]] || { _rubin_process_error "rubin_process_init must run before process helpers"; return 1; }
 }
@@ -29,6 +31,7 @@ _rubin_process_resolve_log() {
   _rubin_process_require_init || return 1
   [[ -n "${log_file}" ]] || { _rubin_process_error "log path must not be empty"; return 1; }
   [[ "${log_file}" == /* ]] || log_file="${RUBIN_PROCESS_ARTIFACT_ROOT}/${log_file}"
+  ! _rubin_process_has_parent_ref "${log_file}" || { _rubin_process_error "log path must not contain '..': ${log_file}"; return 1; }
   case "${log_file}" in
     "${RUBIN_PROCESS_ARTIFACT_ROOT}"/*) printf '%s\n' "${log_file}" ;;
     *) _rubin_process_error "log path must stay under artifact root: ${log_file}"; return 1 ;;
@@ -45,7 +48,7 @@ rubin_process_init() {
     return 1
   }
   [[ -n "${safe_prefix}" && "${safe_prefix}" != "." && "${safe_prefix}" != ".." ]] || safe_prefix="rubin-devnet-process"
-  [[ "${parent}" == /* && "${parent}" != "/" && "${parent}" != "." && "${parent}" != ".." ]] || {
+  [[ "${parent}" == /* && "${parent}" != "/" && "${parent}" != "." && "${parent}" != ".." ]] && ! _rubin_process_has_parent_ref "${parent}" || {
     _rubin_process_error "unsafe artifact parent: ${parent:-<empty>}"
     return 1
   }
@@ -118,10 +121,8 @@ rubin_process_stop_all() {
 
 rubin_process_wait_for_log() {
   local file="${1:-}" needle="${2:-}" timeout="${3:-}" pid="${4:-}" deadline
-  [[ -n "${file}" && -n "${needle}" ]] || {
-    _rubin_process_error "rubin_process_wait_for_log requires file, needle, timeout"
-    return 1
-  }
+  [[ -n "${file}" && -n "${needle}" ]] || { _rubin_process_error "rubin_process_wait_for_log requires file, needle, timeout"; return 1; }
+  file="$(_rubin_process_resolve_log "${file}")" || return 1
   _rubin_process_uint "timeout" "${timeout}" || return 1
   deadline=$((SECONDS + timeout))
   while (( SECONDS < deadline )); do
@@ -138,6 +139,7 @@ rubin_process_wait_for_log() {
 
 rubin_process_extract_rpc_addr() {
   local file="${1:-}" addr
+  file="$(_rubin_process_resolve_log "${file}")" || return 1
   [[ -r "${file}" ]] || { _rubin_process_error "rpc log file is missing or unreadable: ${file:-<empty>}"; return 1; }
   if ! addr="$(sed -n 's/.*rpc: listening=//p' "${file}" | tail -n 1 | tr -d '[:space:]')"; then
     _rubin_process_error "failed to extract rpc listening banner from ${file}"
@@ -182,8 +184,8 @@ rubin_process_cleanup() {
     echo "OK: artifacts preserved at ${RUBIN_PROCESS_ARTIFACT_ROOT}"
     return "${cleanup_status}"
   }
-  [[ -n "${_RUBIN_PROCESS_CREATED_PARENT}" && -n "${RUBIN_PROCESS_ARTIFACT_ROOT}" ]] || {
-    _rubin_process_error "refusing cleanup without initialized artifact paths"
+  [[ -n "${_RUBIN_PROCESS_CREATED_PARENT}" && -n "${RUBIN_PROCESS_ARTIFACT_ROOT}" ]] && ! _rubin_process_has_parent_ref "${RUBIN_PROCESS_ARTIFACT_ROOT}" || {
+    _rubin_process_error "refusing cleanup without initialized artifact paths or with parent traversal"
     return 1
   }
   case "${RUBIN_PROCESS_ARTIFACT_ROOT}" in

--- a/scripts/devnet-process-common.sh
+++ b/scripts/devnet-process-common.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+
+# Shared fail-closed process helpers for devnet evidence scripts.
+# Source this file from scenario scripts, then call rubin_process_init.
+
+RUBIN_PROCESS_ARTIFACT_ROOT="${RUBIN_PROCESS_ARTIFACT_ROOT:-}"
+RUBIN_PROCESS_KEEP_ARTIFACTS="${RUBIN_PROCESS_KEEP_ARTIFACTS:-${KEEP_TMP:-0}}"
+RUBIN_PROCESS_STOP_GRACE_SECONDS="${RUBIN_PROCESS_STOP_GRACE_SECONDS:-5}"
+RUBIN_PROCESS_PIDS=()
+RUBIN_PROCESS_LOGS=()
+RUBIN_PROCESS_LAST_PID=""
+
+rubin_process_init() {
+  local prefix="${1:-rubin-devnet-process}"
+
+  if [[ -z "${RUBIN_PROCESS_ARTIFACT_ROOT}" ]]; then
+    RUBIN_PROCESS_ARTIFACT_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/${prefix}.XXXXXX")"
+  else
+    mkdir -p "${RUBIN_PROCESS_ARTIFACT_ROOT}"
+  fi
+
+  RUBIN_PROCESS_PIDS=()
+  RUBIN_PROCESS_LOGS=()
+  RUBIN_PROCESS_LAST_PID=""
+  trap rubin_process_exit_trap EXIT
+}
+
+rubin_process_register_log() {
+  local log_file="$1"
+  RUBIN_PROCESS_LOGS+=("${log_file}")
+}
+
+rubin_process_start() {
+  local log_file="$1"
+  shift
+
+  mkdir -p "$(dirname "${log_file}")"
+  rubin_process_register_log "${log_file}"
+  "$@" >"${log_file}" 2>&1 &
+  RUBIN_PROCESS_LAST_PID="$!"
+  RUBIN_PROCESS_PIDS+=("${RUBIN_PROCESS_LAST_PID}")
+}
+
+rubin_process_is_alive() {
+  local pid="$1"
+  kill -0 "${pid}" >/dev/null 2>&1
+}
+
+rubin_process_stop_pid() {
+  local pid="$1"
+
+  if rubin_process_is_alive "${pid}"; then
+    kill "${pid}" >/dev/null 2>&1 || true
+    local deadline=$((SECONDS + RUBIN_PROCESS_STOP_GRACE_SECONDS))
+    while rubin_process_is_alive "${pid}" && (( SECONDS < deadline )); do
+      sleep 1
+    done
+  fi
+  if rubin_process_is_alive "${pid}"; then
+    kill -KILL "${pid}" >/dev/null 2>&1 || true
+  fi
+  wait "${pid}" >/dev/null 2>&1 || true
+}
+
+rubin_process_stop_all() {
+  local pid
+  for pid in "${RUBIN_PROCESS_PIDS[@]:-}"; do
+    rubin_process_stop_pid "${pid}"
+  done
+}
+
+rubin_process_wait_for_log() {
+  local file="$1"
+  local pattern="$2"
+  local timeout="$3"
+  local pid="${4:-}"
+  local deadline=$((SECONDS + timeout))
+
+  while (( SECONDS < deadline )); do
+    if [[ -f "${file}" ]] && grep -q "${pattern}" "${file}"; then
+      return 0
+    fi
+    if [[ -n "${pid}" ]] && ! rubin_process_is_alive "${pid}"; then
+      echo "process ${pid} exited before ${pattern} appeared in ${file}" >&2
+      return 1
+    fi
+    sleep 1
+  done
+
+  echo "timeout waiting for ${pattern} in ${file}" >&2
+  return 1
+}
+
+rubin_process_extract_rpc_addr() {
+  local file="$1"
+  local addr
+
+  addr="$(awk -F= '/rpc: listening=/{print $2}' "${file}" | tail -n 1 | tr -d '[:space:]')"
+  if [[ -z "${addr}" ]]; then
+    echo "missing rpc listening banner in ${file}" >&2
+    return 1
+  fi
+  printf '%s\n' "${addr}"
+}
+
+rubin_process_wait_for_rpc_ready() {
+  local rpc_addr="$1"
+  local timeout="$2"
+  local deadline=$((SECONDS + timeout))
+
+  while (( SECONDS < deadline )); do
+    if python3 - "${rpc_addr}" 2>/dev/null <<'PY'
+import json
+import sys
+import urllib.request
+
+rpc_addr = sys.argv[1]
+with urllib.request.urlopen(f"http://{rpc_addr}/get_tip", timeout=2) as resp:
+    if resp.status != 200:
+        raise SystemExit(1)
+    json.load(resp)
+PY
+    then
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "timeout waiting for /get_tip on ${rpc_addr}" >&2
+  return 1
+}
+
+rubin_process_dump_artifacts() {
+  local log_file
+
+  echo "FAIL: artifacts preserved at ${RUBIN_PROCESS_ARTIFACT_ROOT}" >&2
+  for log_file in "${RUBIN_PROCESS_LOGS[@]:-}"; do
+    if [[ -f "${log_file}" ]]; then
+      echo "----- $(basename "${log_file}") -----" >&2
+      tail -n 80 "${log_file}" >&2 || true
+    fi
+  done
+}
+
+rubin_process_cleanup() {
+  local status="$1"
+
+  rubin_process_stop_all
+  if [[ "${status}" != "0" ]]; then
+    rubin_process_dump_artifacts
+    return "${status}"
+  fi
+  if [[ "${RUBIN_PROCESS_KEEP_ARTIFACTS}" == "1" ]]; then
+    echo "OK: artifacts preserved at ${RUBIN_PROCESS_ARTIFACT_ROOT}"
+    return 0
+  fi
+  rm -rf "${RUBIN_PROCESS_ARTIFACT_ROOT}"
+}
+
+rubin_process_exit_trap() {
+  local status=$?
+  rubin_process_cleanup "${status}"
+  exit "${status}"
+}
+
+rubin_process_self_test() {
+  set -euo pipefail
+
+  rubin_process_init "rubin-devnet-process-selftest"
+  local log_file="${RUBIN_PROCESS_ARTIFACT_ROOT}/selftest.log"
+  local pid
+  rubin_process_start "${log_file}" bash -c 'trap "exit 0" TERM; echo "rpc: listening=127.0.0.1:12345"; while :; do sleep 1; done'
+  pid="${RUBIN_PROCESS_LAST_PID}"
+  rubin_process_wait_for_log "${log_file}" "rpc: listening=" 5 "${pid}"
+
+  local addr
+  addr="$(rubin_process_extract_rpc_addr "${log_file}")"
+  if [[ "${addr}" != "127.0.0.1:12345" ]]; then
+    echo "unexpected rpc addr: ${addr}" >&2
+    return 1
+  fi
+
+  rubin_process_stop_pid "${pid}"
+  echo "PASS: devnet process common self-test"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  case "${1:-}" in
+    --self-test)
+      rubin_process_self_test
+      ;;
+    *)
+      echo "usage: $0 --self-test" >&2
+      exit 2
+      ;;
+  esac
+fi

--- a/scripts/devnet-process-common.sh
+++ b/scripts/devnet-process-common.sh
@@ -12,12 +12,20 @@ RUBIN_PROCESS_LAST_PID=""
 
 rubin_process_init() {
   local prefix="${1:-rubin-devnet-process}"
+  local safe_prefix="${prefix//\//_}"
+  safe_prefix="${safe_prefix//\\/_}"
+  local artifact_parent="${RUBIN_PROCESS_ARTIFACT_ROOT:-${TMPDIR:-/tmp}}"
 
-  if [[ -z "${RUBIN_PROCESS_ARTIFACT_ROOT}" ]]; then
-    RUBIN_PROCESS_ARTIFACT_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/${prefix}.XXXXXX")"
-  else
-    mkdir -p "${RUBIN_PROCESS_ARTIFACT_ROOT}"
+  if [[ -z "${safe_prefix}" || "${safe_prefix}" == "." || "${safe_prefix}" == ".." ]]; then
+    safe_prefix="rubin-devnet-process"
   fi
+  if [[ -z "${artifact_parent}" || "${artifact_parent}" == "/" || "${artifact_parent}" == "." ]]; then
+    echo "unsafe artifact parent: ${artifact_parent:-<empty>}" >&2
+    return 1
+  fi
+
+  mkdir -p "${artifact_parent}"
+  RUBIN_PROCESS_ARTIFACT_ROOT="$(mktemp -d "${artifact_parent%/}/${safe_prefix}.XXXXXX")"
 
   RUBIN_PROCESS_PIDS=()
   RUBIN_PROCESS_LOGS=()
@@ -71,23 +79,23 @@ rubin_process_stop_all() {
 
 rubin_process_wait_for_log() {
   local file="$1"
-  local pattern="$2"
+  local needle="$2"
   local timeout="$3"
   local pid="${4:-}"
   local deadline=$((SECONDS + timeout))
 
   while (( SECONDS < deadline )); do
-    if [[ -f "${file}" ]] && grep -q "${pattern}" "${file}"; then
+    if [[ -f "${file}" ]] && grep -F -q -- "${needle}" "${file}"; then
       return 0
     fi
     if [[ -n "${pid}" ]] && ! rubin_process_is_alive "${pid}"; then
-      echo "process ${pid} exited before ${pattern} appeared in ${file}" >&2
+      echo "process ${pid} exited before ${needle} appeared in ${file}" >&2
       return 1
     fi
     sleep 1
   done
 
-  echo "timeout waiting for ${pattern} in ${file}" >&2
+  echo "timeout waiting for ${needle} in ${file}" >&2
   return 1
 }
 
@@ -95,7 +103,14 @@ rubin_process_extract_rpc_addr() {
   local file="$1"
   local addr
 
-  addr="$(awk -F= '/rpc: listening=/{print $2}' "${file}" | tail -n 1 | tr -d '[:space:]')"
+  if [[ ! -r "${file}" ]]; then
+    echo "rpc log file is missing or unreadable: ${file}" >&2
+    return 1
+  fi
+  if ! addr="$(awk -F= '/rpc: listening=/{print $2}' "${file}" | tail -n 1 | tr -d '[:space:]')"; then
+    echo "failed to extract rpc listening banner from ${file}" >&2
+    return 1
+  fi
   if [[ -z "${addr}" ]]; then
     echo "missing rpc listening banner in ${file}" >&2
     return 1
@@ -107,6 +122,11 @@ rubin_process_wait_for_rpc_ready() {
   local rpc_addr="$1"
   local timeout="$2"
   local deadline=$((SECONDS + timeout))
+
+  if ! command -v python3 >/dev/null 2>&1; then
+    echo "python3 is required to poll /get_tip" >&2
+    return 1
+  fi
 
   while (( SECONDS < deadline )); do
     if python3 - "${rpc_addr}" 2>/dev/null <<'PY'
@@ -154,7 +174,13 @@ rubin_process_cleanup() {
     echo "OK: artifacts preserved at ${RUBIN_PROCESS_ARTIFACT_ROOT}"
     return 0
   fi
-  rm -rf "${RUBIN_PROCESS_ARTIFACT_ROOT}"
+  if [[ -z "${RUBIN_PROCESS_ARTIFACT_ROOT}" ||
+        "${RUBIN_PROCESS_ARTIFACT_ROOT}" == "/" ||
+        "${RUBIN_PROCESS_ARTIFACT_ROOT}" == "." ]]; then
+    echo "refusing to remove unsafe artifact root: ${RUBIN_PROCESS_ARTIFACT_ROOT:-<empty>}" >&2
+    return 1
+  fi
+  rm -rf -- "${RUBIN_PROCESS_ARTIFACT_ROOT}"
 }
 
 rubin_process_exit_trap() {
@@ -165,6 +191,24 @@ rubin_process_exit_trap() {
 
 rubin_process_self_test() {
   set -euo pipefail
+
+  local parent_root
+  parent_root="$(mktemp -d "${TMPDIR:-/tmp}/rubin-devnet-process-parent.XXXXXX")"
+  RUBIN_PROCESS_ARTIFACT_ROOT="${parent_root}"
+  rubin_process_init "unsafe/prefix"
+  if [[ "${RUBIN_PROCESS_ARTIFACT_ROOT}" == "${parent_root}" ||
+        "${RUBIN_PROCESS_ARTIFACT_ROOT}" != "${parent_root}/"* ]]; then
+    echo "custom artifact parent was not isolated: ${RUBIN_PROCESS_ARTIFACT_ROOT}" >&2
+    return 1
+  fi
+  rubin_process_cleanup 0
+  trap - EXIT
+  if [[ ! -d "${parent_root}" ]]; then
+    echo "custom artifact parent was removed: ${parent_root}" >&2
+    return 1
+  fi
+  rm -rf -- "${parent_root}"
+  RUBIN_PROCESS_ARTIFACT_ROOT=""
 
   rubin_process_init "rubin-devnet-process-selftest"
   local log_file="${RUBIN_PROCESS_ARTIFACT_ROOT}/selftest.log"

--- a/scripts/devnet-process-common.sh
+++ b/scripts/devnet-process-common.sh
@@ -10,11 +10,39 @@ RUBIN_PROCESS_PIDS=()
 RUBIN_PROCESS_LOGS=()
 RUBIN_PROCESS_LAST_PID=""
 
+rubin_process_require_uint() {
+  local name="$1"
+  local value="$2"
+
+  if [[ ! "${value}" =~ ^[0-9]+$ ]]; then
+    echo "${name} must be a non-negative integer: ${value}" >&2
+    return 1
+  fi
+}
+
+rubin_process_require_args() {
+  local name="$1"
+  local minimum="$2"
+  local actual="$3"
+
+  if (( actual < minimum )); then
+    echo "${name} requires at least ${minimum} argument(s), got ${actual}" >&2
+    return 1
+  fi
+}
+
 rubin_process_init() {
   local prefix="${1:-rubin-devnet-process}"
   local safe_prefix="${prefix//\//_}"
   safe_prefix="${safe_prefix//\\/_}"
   local artifact_parent="${RUBIN_PROCESS_ARTIFACT_ROOT:-${TMPDIR:-/tmp}}"
+  local existing_exit_trap
+
+  existing_exit_trap="$(trap -p EXIT || true)"
+  if [[ -n "${existing_exit_trap}" ]]; then
+    echo "refusing to overwrite existing EXIT trap" >&2
+    return 1
+  fi
 
   if [[ -z "${safe_prefix}" || "${safe_prefix}" == "." || "${safe_prefix}" == ".." ]]; then
     safe_prefix="rubin-devnet-process"
@@ -23,10 +51,20 @@ rubin_process_init() {
     echo "unsafe artifact parent: ${artifact_parent:-<empty>}" >&2
     return 1
   fi
+  rubin_process_require_uint "RUBIN_PROCESS_STOP_GRACE_SECONDS" "${RUBIN_PROCESS_STOP_GRACE_SECONDS}" || return 1
 
-  mkdir -p "${artifact_parent}"
+  if ! mkdir -p "${artifact_parent}"; then
+    echo "failed to create artifact parent: ${artifact_parent}" >&2
+    return 1
+  fi
   if ! RUBIN_PROCESS_ARTIFACT_ROOT="$(mktemp -d "${artifact_parent%/}/${safe_prefix}.XXXXXX")"; then
     echo "failed to create artifact root under ${artifact_parent}" >&2
+    RUBIN_PROCESS_ARTIFACT_ROOT=""
+    return 1
+  fi
+  if [[ ! -d "${RUBIN_PROCESS_ARTIFACT_ROOT}" ]]; then
+    echo "artifact root is not a directory: ${RUBIN_PROCESS_ARTIFACT_ROOT}" >&2
+    RUBIN_PROCESS_ARTIFACT_ROOT=""
     return 1
   fi
 
@@ -37,31 +75,54 @@ rubin_process_init() {
 }
 
 rubin_process_register_log() {
+  rubin_process_require_args "rubin_process_register_log" 1 "$#" || return 1
   local log_file="$1"
   RUBIN_PROCESS_LOGS+=("${log_file}")
 }
 
 rubin_process_start() {
+  rubin_process_require_args "rubin_process_start" 2 "$#" || return 1
   local log_file="$1"
   shift
+  local log_dir
+  local started_pid
 
-  mkdir -p "$(dirname "${log_file}")"
+  log_dir="$(dirname "${log_file}")"
+  if ! mkdir -p "${log_dir}"; then
+    echo "failed to create log directory: ${log_dir}" >&2
+    RUBIN_PROCESS_LAST_PID=""
+    return 1
+  fi
   rubin_process_register_log "${log_file}"
+  RUBIN_PROCESS_LAST_PID=""
   "$@" >"${log_file}" 2>&1 &
-  RUBIN_PROCESS_LAST_PID="$!"
+  started_pid="$!"
+  if [[ -z "${started_pid}" ]]; then
+    echo "failed to start background command for log: ${log_file}" >&2
+    return 1
+  fi
+  RUBIN_PROCESS_LAST_PID="${started_pid}"
+  if ! rubin_process_is_alive "${RUBIN_PROCESS_LAST_PID}"; then
+    echo "background command exited before registration: ${log_file}" >&2
+    RUBIN_PROCESS_LAST_PID=""
+    return 1
+  fi
   RUBIN_PROCESS_PIDS+=("${RUBIN_PROCESS_LAST_PID}")
 }
 
 rubin_process_is_alive() {
+  rubin_process_require_args "rubin_process_is_alive" 1 "$#" || return 1
   local pid="$1"
   kill -0 "${pid}" >/dev/null 2>&1
 }
 
 rubin_process_stop_pid() {
+  rubin_process_require_args "rubin_process_stop_pid" 1 "$#" || return 1
   local pid="$1"
 
   if rubin_process_is_alive "${pid}"; then
     kill "${pid}" >/dev/null 2>&1 || true
+    rubin_process_require_uint "RUBIN_PROCESS_STOP_GRACE_SECONDS" "${RUBIN_PROCESS_STOP_GRACE_SECONDS}" || return 1
     local deadline=$((SECONDS + RUBIN_PROCESS_STOP_GRACE_SECONDS))
     while rubin_process_is_alive "${pid}" && (( SECONDS < deadline )); do
       sleep 1
@@ -81,12 +142,15 @@ rubin_process_stop_all() {
 }
 
 rubin_process_wait_for_log() {
+  rubin_process_require_args "rubin_process_wait_for_log" 3 "$#" || return 1
   local file="$1"
   local needle="$2"
   local timeout="$3"
   local pid="${4:-}"
-  local deadline=$((SECONDS + timeout))
+  local deadline
 
+  rubin_process_require_uint "timeout" "${timeout}" || return 1
+  deadline=$((SECONDS + timeout))
   while (( SECONDS < deadline )); do
     if [[ -f "${file}" ]] && grep -F -q -- "${needle}" "${file}"; then
       return 0
@@ -103,6 +167,7 @@ rubin_process_wait_for_log() {
 }
 
 rubin_process_extract_rpc_addr() {
+  rubin_process_require_args "rubin_process_extract_rpc_addr" 1 "$#" || return 1
   local file="$1"
   local addr
 
@@ -122,10 +187,13 @@ rubin_process_extract_rpc_addr() {
 }
 
 rubin_process_wait_for_rpc_ready() {
+  rubin_process_require_args "rubin_process_wait_for_rpc_ready" 2 "$#" || return 1
   local rpc_addr="$1"
   local timeout="$2"
-  local deadline=$((SECONDS + timeout))
+  local deadline
 
+  rubin_process_require_uint "timeout" "${timeout}" || return 1
+  deadline=$((SECONDS + timeout))
   if ! command -v python3 >/dev/null 2>&1; then
     echo "python3 is required to poll /get_tip" >&2
     return 1
@@ -196,7 +264,7 @@ rubin_process_exit_trap() {
   exit "${cleanup_status}"
 }
 
-rubin_process_self_test() {
+rubin_process_self_test() (
   set -euo pipefail
 
   local parent_root
@@ -232,6 +300,11 @@ rubin_process_self_test() {
     return 1
   fi
 
+  if bash -c 'source "$1"; trap "echo caller trap >&2" EXIT; rubin_process_init trap-clobber' bash "${BASH_SOURCE[0]}" >/dev/null 2>&1; then
+    echo "existing EXIT trap was overwritten" >&2
+    return 1
+  fi
+
   rubin_process_init "rubin-devnet-process-selftest"
   local log_file="${RUBIN_PROCESS_ARTIFACT_ROOT}/selftest.log"
   local pid
@@ -248,7 +321,7 @@ rubin_process_self_test() {
 
   rubin_process_stop_pid "${pid}"
   echo "PASS: devnet process common self-test"
-}
+)
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
   case "${1:-}" in

--- a/scripts/devnet-process-common.sh
+++ b/scripts/devnet-process-common.sh
@@ -3,17 +3,17 @@
 # Shared fail-closed process helpers for devnet evidence scripts.
 # Source this file, then call rubin_process_init before using helpers.
 
-RUBIN_PROCESS_ARTIFACT_ROOT="${RUBIN_PROCESS_ARTIFACT_ROOT:-}"
-RUBIN_PROCESS_ARTIFACT_PARENT="${RUBIN_PROCESS_ARTIFACT_PARENT:-}"
-RUBIN_PROCESS_KEEP_ARTIFACTS="${RUBIN_PROCESS_KEEP_ARTIFACTS:-${KEEP_TMP:-0}}"
-RUBIN_PROCESS_STOP_GRACE_SECONDS="${RUBIN_PROCESS_STOP_GRACE_SECONDS:-5}"
-RUBIN_PROCESS_PIDS=()
-RUBIN_PROCESS_LOGS=()
-RUBIN_PROCESS_LAST_PID=""
-_RUBIN_PROCESS_CREATED_PARENT=""
-_RUBIN_PROCESS_CREATED_ROOT=""
-_RUBIN_PROCESS_CREATED_ROOT_REAL=""
-_RUBIN_PROCESS_STOP_GRACE_SECONDS_DECIMAL=""
+: "${RUBIN_PROCESS_ARTIFACT_ROOT:=}"
+: "${RUBIN_PROCESS_ARTIFACT_PARENT:=}"
+: "${RUBIN_PROCESS_KEEP_ARTIFACTS:=${KEEP_TMP:-0}}"
+: "${RUBIN_PROCESS_STOP_GRACE_SECONDS:=5}"
+declare -p RUBIN_PROCESS_PIDS >/dev/null 2>&1 || RUBIN_PROCESS_PIDS=()
+declare -p RUBIN_PROCESS_LOGS >/dev/null 2>&1 || RUBIN_PROCESS_LOGS=()
+: "${RUBIN_PROCESS_LAST_PID:=}"
+: "${_RUBIN_PROCESS_CREATED_PARENT:=}"
+: "${_RUBIN_PROCESS_CREATED_ROOT:=}"
+: "${_RUBIN_PROCESS_CREATED_ROOT_REAL:=}"
+: "${_RUBIN_PROCESS_STOP_GRACE_SECONDS_DECIMAL:=}"
 
 _rubin_process_error() { echo "$*" >&2; }
 
@@ -22,8 +22,15 @@ _rubin_process_uint() {
 }
 
 _rubin_process_uint_decimal() {
+  local value max=2147483647
   _rubin_process_uint "$1" "$2" || return 1
-  printf '%s\n' "$((10#$2))"
+  value="$2"
+  while [[ "${#value}" -gt 1 && "${value:0:1}" == "0" ]]; do value="${value:1}"; done
+  if (( ${#value} > ${#max} )) || { (( ${#value} == ${#max} )) && (( 10#${value} > max )); }; then
+    _rubin_process_error "$1 is too large: $2"
+    return 1
+  fi
+  printf '%s\n' "$((10#${value}))"
 }
 
 _rubin_process_pid() { [[ "${1:-}" =~ ^[1-9][0-9]*$ ]]; }
@@ -87,6 +94,17 @@ _rubin_process_require_artifact_parent() {
     "${root_real}"|"${root_real}"/*) ;;
     *) _rubin_process_error "log directory must stay under artifact root: ${dir}"; return 1 ;;
   esac
+}
+
+_rubin_process_clear_state() {
+  trap - EXIT
+  RUBIN_PROCESS_PIDS=()
+  RUBIN_PROCESS_LOGS=()
+  RUBIN_PROCESS_LAST_PID=""
+  RUBIN_PROCESS_ARTIFACT_ROOT=""
+  _RUBIN_PROCESS_CREATED_PARENT=""
+  _RUBIN_PROCESS_CREATED_ROOT=""
+  _RUBIN_PROCESS_CREATED_ROOT_REAL=""
 }
 
 _rubin_process_mkdir_under_artifact_root() {
@@ -163,9 +181,10 @@ rubin_process_start() {
   log_dir="$(dirname "${log_file}")"
   _rubin_process_mkdir_under_artifact_root "${log_dir}" || return 1
   _rubin_process_require_artifact_parent "${log_file}" || return 1
+  command -v perl >/dev/null 2>&1 || { _rubin_process_error "perl is required to launch managed process groups"; return 1; }
 
   RUBIN_PROCESS_LAST_PID=""
-  "$@" >"${log_file}" 2>&1 &
+  perl -e 'setpgrp(0, 0) or die "setpgrp failed: $!"; exec @ARGV or die "exec failed: $!"' -- "$@" >"${log_file}" 2>&1 &
   launch_status=$?
   if (( launch_status != 0 )); then
     _rubin_process_error "failed to launch background command for ${log_file}"
@@ -175,6 +194,7 @@ rubin_process_start() {
   _rubin_process_pid "${started_pid}" || { _rubin_process_error "failed to capture background pid for ${log_file}"; return 1; }
   sleep 0.2
   if ! rubin_process_is_alive "${started_pid}"; then
+    kill -- "-${started_pid}" >/dev/null 2>&1 || true
     wait "${started_pid}" >/dev/null 2>&1 || true
     _rubin_process_error "background command exited before registration: ${log_file}"
     return 1
@@ -183,6 +203,7 @@ rubin_process_start() {
   RUBIN_PROCESS_LAST_PID="${started_pid}"
   RUBIN_PROCESS_PIDS+=("${started_pid}")
   RUBIN_PROCESS_LOGS+=("${log_file}")
+  disown "${started_pid}" 2>/dev/null || true
 }
 
 rubin_process_stop_pid() {
@@ -191,11 +212,13 @@ rubin_process_stop_pid() {
   grace_seconds="${_RUBIN_PROCESS_STOP_GRACE_SECONDS_DECIMAL:-}"
   [[ -n "${grace_seconds}" ]] || grace_seconds="$(_rubin_process_uint_decimal "RUBIN_PROCESS_STOP_GRACE_SECONDS" "${RUBIN_PROCESS_STOP_GRACE_SECONDS}")" || return 1
   if rubin_process_is_alive "${pid}"; then
-    kill "${pid}" >/dev/null 2>&1 || true
+    kill -- "-${pid}" >/dev/null 2>&1 || kill "${pid}" >/dev/null 2>&1 || true
     deadline=$((SECONDS + grace_seconds))
     while rubin_process_is_alive "${pid}" && (( SECONDS < deadline )); do sleep 1; done
   fi
-  rubin_process_is_alive "${pid}" && kill -KILL "${pid}" >/dev/null 2>&1 || true
+  if rubin_process_is_alive "${pid}"; then
+    kill -KILL -- "-${pid}" >/dev/null 2>&1 || kill -KILL "${pid}" >/dev/null 2>&1 || true
+  fi
   wait "${pid}" >/dev/null 2>&1 || true
 }
 
@@ -276,10 +299,15 @@ rubin_process_dump_artifacts() {
 rubin_process_cleanup() {
   local status="${1:-0}" cleanup_status=0
   _rubin_process_uint "status" "${status}" || return 1
+  if [[ -z "${RUBIN_PROCESS_ARTIFACT_ROOT}" && -z "${_RUBIN_PROCESS_CREATED_ROOT}" && ${#RUBIN_PROCESS_PIDS[@]} -eq 0 ]]; then
+    _rubin_process_clear_state
+    return 0
+  fi
   rubin_process_stop_all || cleanup_status=$?
   if [[ "${status}" != "0" ]]; then rubin_process_dump_artifacts; return "${status}"; fi
   [[ "${RUBIN_PROCESS_KEEP_ARTIFACTS}" == "1" ]] && {
     echo "OK: artifacts preserved at ${RUBIN_PROCESS_ARTIFACT_ROOT}"
+    _rubin_process_clear_state
     return "${cleanup_status}"
   }
   if [[ -z "${_RUBIN_PROCESS_CREATED_PARENT}" || -z "${_RUBIN_PROCESS_CREATED_ROOT}" || -z "${_RUBIN_PROCESS_CREATED_ROOT_REAL}" || -z "${RUBIN_PROCESS_ARTIFACT_ROOT}" ]] || _rubin_process_has_parent_ref "${RUBIN_PROCESS_ARTIFACT_ROOT}"; then
@@ -296,6 +324,7 @@ rubin_process_cleanup() {
     *) _rubin_process_error "refusing to remove unsafe artifact root: ${RUBIN_PROCESS_ARTIFACT_ROOT}"; return 1 ;;
   esac
   rm -rf -- "${_RUBIN_PROCESS_CREATED_ROOT_REAL}" || cleanup_status=$?
+  _rubin_process_clear_state
   return "${cleanup_status}"
 }
 

--- a/scripts/devnet-process-common.sh
+++ b/scripts/devnet-process-common.sh
@@ -25,7 +25,7 @@ _RUBIN_PROCESS_CREATED_ROOT=""
 _RUBIN_PROCESS_CREATED_ROOT_REAL=""
 _RUBIN_PROCESS_STOP_GRACE_SECONDS_DECIMAL=""
 
-_rubin_process_error() { echo "$*" >&2; }
+_rubin_process_error() { printf '%s\n' "$*" >&2; }
 
 _rubin_process_uint() {
   [[ "${2:-}" =~ ^[0-9]+$ ]] || { _rubin_process_error "$1 must be a non-negative integer: ${2:-<empty>}"; return 1; }
@@ -298,6 +298,7 @@ rubin_process_wait_for_rpc_ready() {
 rubin_process_dump_artifacts() {
   local log_file
   _rubin_process_error "FAIL: artifacts preserved at ${RUBIN_PROCESS_ARTIFACT_ROOT:-<unset>}"
+  ((${#RUBIN_PROCESS_LOGS[@]} > 0)) || return 0
   for log_file in "${RUBIN_PROCESS_LOGS[@]}"; do
     _rubin_process_require_artifact_parent "${log_file}" || { _rubin_process_error "skipping unsafe log file: ${log_file}"; continue; }
     [[ -f "${log_file}" ]] || continue
@@ -314,7 +315,11 @@ rubin_process_cleanup() {
     return 0
   fi
   rubin_process_stop_all || cleanup_status=$?
-  if [[ "${status}" != "0" ]]; then rubin_process_dump_artifacts; return "${status}"; fi
+  if [[ "${status}" != "0" ]]; then
+    rubin_process_dump_artifacts
+    _rubin_process_clear_state
+    return "${status}"
+  fi
   [[ "${RUBIN_PROCESS_KEEP_ARTIFACTS}" == "1" ]] && {
     echo "OK: artifacts preserved at ${RUBIN_PROCESS_ARTIFACT_ROOT}"
     _rubin_process_clear_state

--- a/scripts/devnet-process-common.sh
+++ b/scripts/devnet-process-common.sh
@@ -11,11 +11,18 @@ RUBIN_PROCESS_PIDS=()
 RUBIN_PROCESS_LOGS=()
 RUBIN_PROCESS_LAST_PID=""
 _RUBIN_PROCESS_CREATED_PARENT=""
+_RUBIN_PROCESS_CREATED_ROOT=""
+_RUBIN_PROCESS_STOP_GRACE_SECONDS_DECIMAL=""
 
 _rubin_process_error() { echo "$*" >&2; }
 
 _rubin_process_uint() {
   [[ "${2:-}" =~ ^[0-9]+$ ]] || { _rubin_process_error "$1 must be a non-negative integer: ${2:-<empty>}"; return 1; }
+}
+
+_rubin_process_uint_decimal() {
+  _rubin_process_uint "$1" "$2" || return 1
+  printf '%s\n' "$((10#$2))"
 }
 
 _rubin_process_pid() { [[ "${1:-}" =~ ^[1-9][0-9]*$ ]]; }
@@ -24,6 +31,7 @@ _rubin_process_has_parent_ref() { case "/${1:-}/" in *"/../"*) return 0 ;; *) re
 
 _rubin_process_require_init() {
   [[ -n "${RUBIN_PROCESS_ARTIFACT_ROOT}" && -d "${RUBIN_PROCESS_ARTIFACT_ROOT}" ]] || { _rubin_process_error "rubin_process_init must run before process helpers"; return 1; }
+  [[ ! -L "${RUBIN_PROCESS_ARTIFACT_ROOT}" ]] || { _rubin_process_error "artifact root must not be a symlink: ${RUBIN_PROCESS_ARTIFACT_ROOT}"; return 1; }
 }
 
 _rubin_process_resolve_log() {
@@ -38,6 +46,61 @@ _rubin_process_resolve_log() {
   esac
 }
 
+_rubin_process_reject_symlink_components() {
+  local path="${1:-}" relative current component old_ifs
+  case "${path}" in
+    "${RUBIN_PROCESS_ARTIFACT_ROOT}") return 0 ;;
+    "${RUBIN_PROCESS_ARTIFACT_ROOT}"/*) relative="${path#"${RUBIN_PROCESS_ARTIFACT_ROOT}"/}" ;;
+    *) _rubin_process_error "path must stay under artifact root: ${path}"; return 1 ;;
+  esac
+
+  current="${RUBIN_PROCESS_ARTIFACT_ROOT}"
+  old_ifs="${IFS}"
+  IFS="/"
+  read -r -a components <<< "${relative}"
+  IFS="${old_ifs}"
+  for component in "${components[@]}"; do
+    [[ -n "${component}" && "${component}" != "." ]] || continue
+    current="${current}/${component}"
+    [[ ! -L "${current}" ]] || { _rubin_process_error "path component must not be a symlink: ${current}"; return 1; }
+  done
+}
+
+_rubin_process_require_artifact_parent() {
+  local file="${1:-}" dir root_real dir_real
+  _rubin_process_reject_symlink_components "${file}" || return 1
+  dir="$(dirname "${file}")"
+  [[ -d "${dir}" ]] || return 0
+  root_real="$(cd "${RUBIN_PROCESS_ARTIFACT_ROOT}" && pwd -P)" || { _rubin_process_error "failed to resolve artifact root: ${RUBIN_PROCESS_ARTIFACT_ROOT}"; return 1; }
+  dir_real="$(cd "${dir}" && pwd -P)" || { _rubin_process_error "failed to resolve log directory: ${dir}"; return 1; }
+  case "${dir_real}" in
+    "${root_real}"|"${root_real}"/*) ;;
+    *) _rubin_process_error "log directory must stay under artifact root: ${dir}"; return 1 ;;
+  esac
+}
+
+_rubin_process_mkdir_under_artifact_root() {
+  local dir="${1:-}" relative current component old_ifs
+  case "${dir}" in
+    "${RUBIN_PROCESS_ARTIFACT_ROOT}") return 0 ;;
+    "${RUBIN_PROCESS_ARTIFACT_ROOT}"/*) relative="${dir#"${RUBIN_PROCESS_ARTIFACT_ROOT}"/}" ;;
+    *) _rubin_process_error "directory must stay under artifact root: ${dir}"; return 1 ;;
+  esac
+
+  current="${RUBIN_PROCESS_ARTIFACT_ROOT}"
+  old_ifs="${IFS}"
+  IFS="/"
+  read -r -a components <<< "${relative}"
+  IFS="${old_ifs}"
+  for component in "${components[@]}"; do
+    [[ -n "${component}" && "${component}" != "." ]] || continue
+    current="${current}/${component}"
+    [[ ! -L "${current}" ]] || { _rubin_process_error "directory component must not be a symlink: ${current}"; return 1; }
+    [[ ! -e "${current}" || -d "${current}" ]] || { _rubin_process_error "directory component is not a directory: ${current}"; return 1; }
+    [[ -d "${current}" ]] || mkdir "${current}" || { _rubin_process_error "failed to create log directory: ${current}"; return 1; }
+  done
+}
+
 rubin_process_init() {
   local prefix="${1:-rubin-devnet-process}"
   local safe_prefix="${prefix//[^[:alnum:]._-]/_}"
@@ -48,11 +111,11 @@ rubin_process_init() {
     return 1
   }
   [[ -n "${safe_prefix}" && "${safe_prefix}" != "." && "${safe_prefix}" != ".." ]] || safe_prefix="rubin-devnet-process"
-  [[ "${parent}" == /* && "${parent}" != "/" && "${parent}" != "." && "${parent}" != ".." ]] && ! _rubin_process_has_parent_ref "${parent}" || {
+  if [[ "${parent}" != /* || "${parent}" == "/" || "${parent}" == "." || "${parent}" == ".." ]] || _rubin_process_has_parent_ref "${parent}"; then
     _rubin_process_error "unsafe artifact parent: ${parent:-<empty>}"
     return 1
-  }
-  _rubin_process_uint "RUBIN_PROCESS_STOP_GRACE_SECONDS" "${RUBIN_PROCESS_STOP_GRACE_SECONDS}" || return 1
+  fi
+  _RUBIN_PROCESS_STOP_GRACE_SECONDS_DECIMAL="$(_rubin_process_uint_decimal "RUBIN_PROCESS_STOP_GRACE_SECONDS" "${RUBIN_PROCESS_STOP_GRACE_SECONDS}")" || return 1
   mkdir -p "${parent}" || { _rubin_process_error "failed to create artifact parent: ${parent}"; return 1; }
 
   _RUBIN_PROCESS_CREATED_PARENT="${parent%/}"
@@ -66,6 +129,7 @@ rubin_process_init() {
     RUBIN_PROCESS_ARTIFACT_ROOT=""
     return 1
   }
+  _RUBIN_PROCESS_CREATED_ROOT="${RUBIN_PROCESS_ARTIFACT_ROOT}"
   RUBIN_PROCESS_PIDS=()
   RUBIN_PROCESS_LOGS=()
   RUBIN_PROCESS_LAST_PID=""
@@ -78,34 +142,43 @@ rubin_process_is_alive() {
 }
 
 rubin_process_start() {
-  local log_file log_dir started_pid
+  local log_file log_dir launch_status started_pid
   (( $# >= 2 )) || { _rubin_process_error "rubin_process_start requires a log path and command"; return 1; }
   log_file="$(_rubin_process_resolve_log "$1")" || return 1
   shift
   log_dir="$(dirname "${log_file}")"
-  mkdir -p "${log_dir}" || { _rubin_process_error "failed to create log directory: ${log_dir}"; return 1; }
+  _rubin_process_mkdir_under_artifact_root "${log_dir}" || return 1
+  _rubin_process_require_artifact_parent "${log_file}" || return 1
 
   RUBIN_PROCESS_LAST_PID=""
   "$@" >"${log_file}" 2>&1 &
+  launch_status=$?
+  if (( launch_status != 0 )); then
+    _rubin_process_error "failed to launch background command for ${log_file}"
+    return "${launch_status}"
+  fi
   started_pid="$!"
+  _rubin_process_pid "${started_pid}" || { _rubin_process_error "failed to capture background pid for ${log_file}"; return 1; }
   sleep 0.2
   if ! rubin_process_is_alive "${started_pid}"; then
     wait "${started_pid}" >/dev/null 2>&1 || true
     _rubin_process_error "background command exited before registration: ${log_file}"
     return 1
   fi
+  # shellcheck disable=SC2034 # caller scripts read this state after sourcing.
   RUBIN_PROCESS_LAST_PID="${started_pid}"
   RUBIN_PROCESS_PIDS+=("${started_pid}")
   RUBIN_PROCESS_LOGS+=("${log_file}")
 }
 
 rubin_process_stop_pid() {
-  local pid="${1:-}" deadline
+  local pid="${1:-}" grace_seconds deadline
   _rubin_process_pid "${pid}" || return 1
+  grace_seconds="${_RUBIN_PROCESS_STOP_GRACE_SECONDS_DECIMAL:-}"
+  [[ -n "${grace_seconds}" ]] || grace_seconds="$(_rubin_process_uint_decimal "RUBIN_PROCESS_STOP_GRACE_SECONDS" "${RUBIN_PROCESS_STOP_GRACE_SECONDS}")" || return 1
   if rubin_process_is_alive "${pid}"; then
     kill "${pid}" >/dev/null 2>&1 || true
-    _rubin_process_uint "RUBIN_PROCESS_STOP_GRACE_SECONDS" "${RUBIN_PROCESS_STOP_GRACE_SECONDS}" || return 1
-    deadline=$((SECONDS + RUBIN_PROCESS_STOP_GRACE_SECONDS))
+    deadline=$((SECONDS + grace_seconds))
     while rubin_process_is_alive "${pid}" && (( SECONDS < deadline )); do sleep 1; done
   fi
   rubin_process_is_alive "${pid}" && kill -KILL "${pid}" >/dev/null 2>&1 || true
@@ -120,13 +193,18 @@ rubin_process_stop_all() {
 }
 
 rubin_process_wait_for_log() {
-  local file="${1:-}" needle="${2:-}" timeout="${3:-}" pid="${4:-}" deadline
+  local file="${1:-}" needle="${2:-}" timeout="${3:-}" pid="${4:-}" timeout_seconds deadline
   [[ -n "${file}" && -n "${needle}" ]] || { _rubin_process_error "rubin_process_wait_for_log requires file, needle, timeout"; return 1; }
   file="$(_rubin_process_resolve_log "${file}")" || return 1
-  _rubin_process_uint "timeout" "${timeout}" || return 1
-  deadline=$((SECONDS + timeout))
+  _rubin_process_require_artifact_parent "${file}" || return 1
+  timeout_seconds="$(_rubin_process_uint_decimal "timeout" "${timeout}")" || return 1
+  [[ -z "${pid}" ]] || _rubin_process_pid "${pid}" || { _rubin_process_error "invalid pid: ${pid}"; return 1; }
+  deadline=$((SECONDS + timeout_seconds))
   while (( SECONDS < deadline )); do
-    [[ -f "${file}" ]] && grep -F -q -- "${needle}" "${file}" && return 0
+    if [[ -f "${file}" ]]; then
+      _rubin_process_require_artifact_parent "${file}" || return 1
+      grep -F -q -- "${needle}" "${file}" && return 0
+    fi
     if [[ -n "${pid}" ]] && ! rubin_process_is_alive "${pid}"; then
       _rubin_process_error "process ${pid} exited before ${needle} appeared in ${file}"
       return 1
@@ -140,6 +218,7 @@ rubin_process_wait_for_log() {
 rubin_process_extract_rpc_addr() {
   local file="${1:-}" addr
   file="$(_rubin_process_resolve_log "${file}")" || return 1
+  _rubin_process_require_artifact_parent "${file}" || return 1
   [[ -r "${file}" ]] || { _rubin_process_error "rpc log file is missing or unreadable: ${file:-<empty>}"; return 1; }
   if ! addr="$(sed -n 's/.*rpc: listening=//p' "${file}" | tail -n 1 | tr -d '[:space:]')"; then
     _rubin_process_error "failed to extract rpc listening banner from ${file}"
@@ -150,11 +229,11 @@ rubin_process_extract_rpc_addr() {
 }
 
 rubin_process_wait_for_rpc_ready() {
-  local rpc_addr="${1:-}" timeout="${2:-}" deadline
+  local rpc_addr="${1:-}" timeout="${2:-}" timeout_seconds deadline
   [[ -n "${rpc_addr}" && "${rpc_addr}" != *[[:space:]/]* ]] || { _rubin_process_error "invalid rpc address: ${rpc_addr:-<empty>}"; return 1; }
-  _rubin_process_uint "timeout" "${timeout}" || return 1
+  timeout_seconds="$(_rubin_process_uint_decimal "timeout" "${timeout}")" || return 1
   command -v python3 >/dev/null 2>&1 || { _rubin_process_error "python3 is required to poll /get_tip"; return 1; }
-  deadline=$((SECONDS + timeout))
+  deadline=$((SECONDS + timeout_seconds))
   while (( SECONDS < deadline )); do
     if python3 -c 'import json,sys,urllib.request as u; r=u.urlopen(f"http://{sys.argv[1]}/get_tip", timeout=2); json.load(r); sys.exit(0 if r.status == 200 else 1)' "${rpc_addr}" 2>/dev/null; then
       return 0
@@ -184,8 +263,12 @@ rubin_process_cleanup() {
     echo "OK: artifacts preserved at ${RUBIN_PROCESS_ARTIFACT_ROOT}"
     return "${cleanup_status}"
   }
-  [[ -n "${_RUBIN_PROCESS_CREATED_PARENT}" && -n "${RUBIN_PROCESS_ARTIFACT_ROOT}" ]] && ! _rubin_process_has_parent_ref "${RUBIN_PROCESS_ARTIFACT_ROOT}" || {
+  if [[ -z "${_RUBIN_PROCESS_CREATED_PARENT}" || -z "${_RUBIN_PROCESS_CREATED_ROOT}" || -z "${RUBIN_PROCESS_ARTIFACT_ROOT}" ]] || _rubin_process_has_parent_ref "${RUBIN_PROCESS_ARTIFACT_ROOT}"; then
     _rubin_process_error "refusing cleanup without initialized artifact paths or with parent traversal"
+    return 1
+  fi
+  [[ "${RUBIN_PROCESS_ARTIFACT_ROOT}" == "${_RUBIN_PROCESS_CREATED_ROOT}" ]] || {
+    _rubin_process_error "refusing to remove artifact root not created by rubin_process_init: ${RUBIN_PROCESS_ARTIFACT_ROOT}"
     return 1
   }
   case "${RUBIN_PROCESS_ARTIFACT_ROOT}" in

--- a/scripts/devnet-process-common.sh
+++ b/scripts/devnet-process-common.sh
@@ -1,336 +1,202 @@
 #!/usr/bin/env bash
 
 # Shared fail-closed process helpers for devnet evidence scripts.
-# Source this file from scenario scripts, then call rubin_process_init.
+# Source this file, then call rubin_process_init before using helpers.
 
 RUBIN_PROCESS_ARTIFACT_ROOT="${RUBIN_PROCESS_ARTIFACT_ROOT:-}"
+RUBIN_PROCESS_ARTIFACT_PARENT="${RUBIN_PROCESS_ARTIFACT_PARENT:-}"
 RUBIN_PROCESS_KEEP_ARTIFACTS="${RUBIN_PROCESS_KEEP_ARTIFACTS:-${KEEP_TMP:-0}}"
 RUBIN_PROCESS_STOP_GRACE_SECONDS="${RUBIN_PROCESS_STOP_GRACE_SECONDS:-5}"
 RUBIN_PROCESS_PIDS=()
 RUBIN_PROCESS_LOGS=()
 RUBIN_PROCESS_LAST_PID=""
+_RUBIN_PROCESS_CREATED_PARENT=""
 
-rubin_process_require_uint() {
-  local name="$1"
-  local value="$2"
+_rubin_process_error() { echo "$*" >&2; }
 
-  if [[ ! "${value}" =~ ^[0-9]+$ ]]; then
-    echo "${name} must be a non-negative integer: ${value}" >&2
-    return 1
-  fi
+_rubin_process_uint() {
+  [[ "${2:-}" =~ ^[0-9]+$ ]] || { _rubin_process_error "$1 must be a non-negative integer: ${2:-<empty>}"; return 1; }
 }
 
-rubin_process_require_args() {
-  local name="$1"
-  local minimum="$2"
-  local actual="$3"
+_rubin_process_pid() { [[ "${1:-}" =~ ^[1-9][0-9]*$ ]]; }
 
-  if (( actual < minimum )); then
-    echo "${name} requires at least ${minimum} argument(s), got ${actual}" >&2
-    return 1
-  fi
+_rubin_process_require_init() {
+  [[ -n "${RUBIN_PROCESS_ARTIFACT_ROOT}" && -d "${RUBIN_PROCESS_ARTIFACT_ROOT}" ]] || { _rubin_process_error "rubin_process_init must run before process helpers"; return 1; }
+}
+
+_rubin_process_resolve_log() {
+  local log_file="${1:-}"
+  _rubin_process_require_init || return 1
+  [[ -n "${log_file}" ]] || { _rubin_process_error "log path must not be empty"; return 1; }
+  [[ "${log_file}" == /* ]] || log_file="${RUBIN_PROCESS_ARTIFACT_ROOT}/${log_file}"
+  case "${log_file}" in
+    "${RUBIN_PROCESS_ARTIFACT_ROOT}"/*) printf '%s\n' "${log_file}" ;;
+    *) _rubin_process_error "log path must stay under artifact root: ${log_file}"; return 1 ;;
+  esac
 }
 
 rubin_process_init() {
   local prefix="${1:-rubin-devnet-process}"
-  local safe_prefix="${prefix//\//_}"
-  safe_prefix="${safe_prefix//\\/_}"
-  local artifact_parent="${RUBIN_PROCESS_ARTIFACT_ROOT:-${TMPDIR:-/tmp}}"
-  local existing_exit_trap
+  local safe_prefix="${prefix//[^[:alnum:]._-]/_}"
+  local parent="${RUBIN_PROCESS_ARTIFACT_PARENT:-${RUBIN_PROCESS_ARTIFACT_ROOT:-${TMPDIR:-/tmp}}}"
 
-  existing_exit_trap="$(trap -p EXIT || true)"
-  if [[ -n "${existing_exit_trap}" ]]; then
-    echo "refusing to overwrite existing EXIT trap" >&2
+  [[ -z "$(trap -p EXIT || true)" ]] || {
+    _rubin_process_error "refusing to overwrite existing EXIT trap"
+    return 1
+  }
+  [[ -n "${safe_prefix}" && "${safe_prefix}" != "." && "${safe_prefix}" != ".." ]] || safe_prefix="rubin-devnet-process"
+  [[ "${parent}" == /* && "${parent}" != "/" && "${parent}" != "." && "${parent}" != ".." ]] || {
+    _rubin_process_error "unsafe artifact parent: ${parent:-<empty>}"
+    return 1
+  }
+  _rubin_process_uint "RUBIN_PROCESS_STOP_GRACE_SECONDS" "${RUBIN_PROCESS_STOP_GRACE_SECONDS}" || return 1
+  mkdir -p "${parent}" || { _rubin_process_error "failed to create artifact parent: ${parent}"; return 1; }
+
+  _RUBIN_PROCESS_CREATED_PARENT="${parent%/}"
+  if ! RUBIN_PROCESS_ARTIFACT_ROOT="$(mktemp -d "${_RUBIN_PROCESS_CREATED_PARENT}/${safe_prefix}.XXXXXX")"; then
+    RUBIN_PROCESS_ARTIFACT_ROOT=""
+    _rubin_process_error "failed to create artifact root under ${_RUBIN_PROCESS_CREATED_PARENT}"
     return 1
   fi
-
-  if [[ -z "${safe_prefix}" || "${safe_prefix}" == "." || "${safe_prefix}" == ".." ]]; then
-    safe_prefix="rubin-devnet-process"
-  fi
-  if [[ -z "${artifact_parent}" || "${artifact_parent}" == "/" || "${artifact_parent}" == "." ]]; then
-    echo "unsafe artifact parent: ${artifact_parent:-<empty>}" >&2
-    return 1
-  fi
-  rubin_process_require_uint "RUBIN_PROCESS_STOP_GRACE_SECONDS" "${RUBIN_PROCESS_STOP_GRACE_SECONDS}" || return 1
-
-  if ! mkdir -p "${artifact_parent}"; then
-    echo "failed to create artifact parent: ${artifact_parent}" >&2
-    return 1
-  fi
-  if ! RUBIN_PROCESS_ARTIFACT_ROOT="$(mktemp -d "${artifact_parent%/}/${safe_prefix}.XXXXXX")"; then
-    echo "failed to create artifact root under ${artifact_parent}" >&2
+  [[ -d "${RUBIN_PROCESS_ARTIFACT_ROOT}" ]] || {
+    _rubin_process_error "artifact root is not a directory: ${RUBIN_PROCESS_ARTIFACT_ROOT}"
     RUBIN_PROCESS_ARTIFACT_ROOT=""
     return 1
-  fi
-  if [[ ! -d "${RUBIN_PROCESS_ARTIFACT_ROOT}" ]]; then
-    echo "artifact root is not a directory: ${RUBIN_PROCESS_ARTIFACT_ROOT}" >&2
-    RUBIN_PROCESS_ARTIFACT_ROOT=""
-    return 1
-  fi
-
+  }
   RUBIN_PROCESS_PIDS=()
   RUBIN_PROCESS_LOGS=()
   RUBIN_PROCESS_LAST_PID=""
   trap rubin_process_exit_trap EXIT
 }
 
-rubin_process_register_log() {
-  rubin_process_require_args "rubin_process_register_log" 1 "$#" || return 1
-  local log_file="$1"
-  RUBIN_PROCESS_LOGS+=("${log_file}")
+rubin_process_is_alive() {
+  _rubin_process_pid "${1:-}" || return 1
+  kill -0 "$1" >/dev/null 2>&1
 }
 
 rubin_process_start() {
-  rubin_process_require_args "rubin_process_start" 2 "$#" || return 1
-  local log_file="$1"
+  local log_file log_dir started_pid
+  (( $# >= 2 )) || { _rubin_process_error "rubin_process_start requires a log path and command"; return 1; }
+  log_file="$(_rubin_process_resolve_log "$1")" || return 1
   shift
-  local log_dir
-  local started_pid
-
   log_dir="$(dirname "${log_file}")"
-  if ! mkdir -p "${log_dir}"; then
-    echo "failed to create log directory: ${log_dir}" >&2
-    RUBIN_PROCESS_LAST_PID=""
-    return 1
-  fi
-  rubin_process_register_log "${log_file}"
+  mkdir -p "${log_dir}" || { _rubin_process_error "failed to create log directory: ${log_dir}"; return 1; }
+
   RUBIN_PROCESS_LAST_PID=""
   "$@" >"${log_file}" 2>&1 &
   started_pid="$!"
-  if [[ -z "${started_pid}" ]]; then
-    echo "failed to start background command for log: ${log_file}" >&2
+  sleep 0.2
+  if ! rubin_process_is_alive "${started_pid}"; then
+    wait "${started_pid}" >/dev/null 2>&1 || true
+    _rubin_process_error "background command exited before registration: ${log_file}"
     return 1
   fi
   RUBIN_PROCESS_LAST_PID="${started_pid}"
-  if ! rubin_process_is_alive "${RUBIN_PROCESS_LAST_PID}"; then
-    echo "background command exited before registration: ${log_file}" >&2
-    RUBIN_PROCESS_LAST_PID=""
-    return 1
-  fi
-  RUBIN_PROCESS_PIDS+=("${RUBIN_PROCESS_LAST_PID}")
-}
-
-rubin_process_is_alive() {
-  rubin_process_require_args "rubin_process_is_alive" 1 "$#" || return 1
-  local pid="$1"
-  kill -0 "${pid}" >/dev/null 2>&1
+  RUBIN_PROCESS_PIDS+=("${started_pid}")
+  RUBIN_PROCESS_LOGS+=("${log_file}")
 }
 
 rubin_process_stop_pid() {
-  rubin_process_require_args "rubin_process_stop_pid" 1 "$#" || return 1
-  local pid="$1"
-
+  local pid="${1:-}" deadline
+  _rubin_process_pid "${pid}" || return 1
   if rubin_process_is_alive "${pid}"; then
     kill "${pid}" >/dev/null 2>&1 || true
-    rubin_process_require_uint "RUBIN_PROCESS_STOP_GRACE_SECONDS" "${RUBIN_PROCESS_STOP_GRACE_SECONDS}" || return 1
-    local deadline=$((SECONDS + RUBIN_PROCESS_STOP_GRACE_SECONDS))
-    while rubin_process_is_alive "${pid}" && (( SECONDS < deadline )); do
-      sleep 1
-    done
+    _rubin_process_uint "RUBIN_PROCESS_STOP_GRACE_SECONDS" "${RUBIN_PROCESS_STOP_GRACE_SECONDS}" || return 1
+    deadline=$((SECONDS + RUBIN_PROCESS_STOP_GRACE_SECONDS))
+    while rubin_process_is_alive "${pid}" && (( SECONDS < deadline )); do sleep 1; done
   fi
-  if rubin_process_is_alive "${pid}"; then
-    kill -KILL "${pid}" >/dev/null 2>&1 || true
-  fi
+  rubin_process_is_alive "${pid}" && kill -KILL "${pid}" >/dev/null 2>&1 || true
   wait "${pid}" >/dev/null 2>&1 || true
 }
 
 rubin_process_stop_all() {
-  local pid
-  for pid in "${RUBIN_PROCESS_PIDS[@]:-}"; do
-    rubin_process_stop_pid "${pid}"
+  local i
+  for ((i=${#RUBIN_PROCESS_PIDS[@]} - 1; i >= 0; i--)); do
+    rubin_process_stop_pid "${RUBIN_PROCESS_PIDS[$i]}" || return 1
   done
 }
 
 rubin_process_wait_for_log() {
-  rubin_process_require_args "rubin_process_wait_for_log" 3 "$#" || return 1
-  local file="$1"
-  local needle="$2"
-  local timeout="$3"
-  local pid="${4:-}"
-  local deadline
-
-  rubin_process_require_uint "timeout" "${timeout}" || return 1
+  local file="${1:-}" needle="${2:-}" timeout="${3:-}" pid="${4:-}" deadline
+  [[ -n "${file}" && -n "${needle}" ]] || {
+    _rubin_process_error "rubin_process_wait_for_log requires file, needle, timeout"
+    return 1
+  }
+  _rubin_process_uint "timeout" "${timeout}" || return 1
   deadline=$((SECONDS + timeout))
   while (( SECONDS < deadline )); do
-    if [[ -f "${file}" ]] && grep -F -q -- "${needle}" "${file}"; then
-      return 0
-    fi
+    [[ -f "${file}" ]] && grep -F -q -- "${needle}" "${file}" && return 0
     if [[ -n "${pid}" ]] && ! rubin_process_is_alive "${pid}"; then
-      echo "process ${pid} exited before ${needle} appeared in ${file}" >&2
+      _rubin_process_error "process ${pid} exited before ${needle} appeared in ${file}"
       return 1
     fi
     sleep 1
   done
-
-  echo "timeout waiting for ${needle} in ${file}" >&2
+  _rubin_process_error "timeout waiting for ${needle} in ${file}"
   return 1
 }
 
 rubin_process_extract_rpc_addr() {
-  rubin_process_require_args "rubin_process_extract_rpc_addr" 1 "$#" || return 1
-  local file="$1"
-  local addr
-
-  if [[ ! -r "${file}" ]]; then
-    echo "rpc log file is missing or unreadable: ${file}" >&2
+  local file="${1:-}" addr
+  [[ -r "${file}" ]] || { _rubin_process_error "rpc log file is missing or unreadable: ${file:-<empty>}"; return 1; }
+  if ! addr="$(sed -n 's/.*rpc: listening=//p' "${file}" | tail -n 1 | tr -d '[:space:]')"; then
+    _rubin_process_error "failed to extract rpc listening banner from ${file}"
     return 1
   fi
-  if ! addr="$(awk -F= '/rpc: listening=/{print $2}' "${file}" | tail -n 1 | tr -d '[:space:]')"; then
-    echo "failed to extract rpc listening banner from ${file}" >&2
-    return 1
-  fi
-  if [[ -z "${addr}" ]]; then
-    echo "missing rpc listening banner in ${file}" >&2
-    return 1
-  fi
+  [[ -n "${addr}" ]] || { _rubin_process_error "missing rpc listening banner in ${file}"; return 1; }
   printf '%s\n' "${addr}"
 }
 
 rubin_process_wait_for_rpc_ready() {
-  rubin_process_require_args "rubin_process_wait_for_rpc_ready" 2 "$#" || return 1
-  local rpc_addr="$1"
-  local timeout="$2"
-  local deadline
-
-  rubin_process_require_uint "timeout" "${timeout}" || return 1
+  local rpc_addr="${1:-}" timeout="${2:-}" deadline
+  [[ -n "${rpc_addr}" && "${rpc_addr}" != *[[:space:]/]* ]] || { _rubin_process_error "invalid rpc address: ${rpc_addr:-<empty>}"; return 1; }
+  _rubin_process_uint "timeout" "${timeout}" || return 1
+  command -v python3 >/dev/null 2>&1 || { _rubin_process_error "python3 is required to poll /get_tip"; return 1; }
   deadline=$((SECONDS + timeout))
-  if ! command -v python3 >/dev/null 2>&1; then
-    echo "python3 is required to poll /get_tip" >&2
-    return 1
-  fi
-
   while (( SECONDS < deadline )); do
-    if python3 - "${rpc_addr}" 2>/dev/null <<'PY'
-import json
-import sys
-import urllib.request
-
-rpc_addr = sys.argv[1]
-with urllib.request.urlopen(f"http://{rpc_addr}/get_tip", timeout=2) as resp:
-    if resp.status != 200:
-        raise SystemExit(1)
-    json.load(resp)
-PY
-    then
+    if python3 -c 'import json,sys,urllib.request as u; r=u.urlopen(f"http://{sys.argv[1]}/get_tip", timeout=2); json.load(r); sys.exit(0 if r.status == 200 else 1)' "${rpc_addr}" 2>/dev/null; then
       return 0
     fi
     sleep 1
   done
-
-  echo "timeout waiting for /get_tip on ${rpc_addr}" >&2
+  _rubin_process_error "timeout waiting for /get_tip on ${rpc_addr}"
   return 1
 }
 
 rubin_process_dump_artifacts() {
   local log_file
-
-  echo "FAIL: artifacts preserved at ${RUBIN_PROCESS_ARTIFACT_ROOT}" >&2
+  _rubin_process_error "FAIL: artifacts preserved at ${RUBIN_PROCESS_ARTIFACT_ROOT:-<unset>}"
   for log_file in "${RUBIN_PROCESS_LOGS[@]:-}"; do
-    if [[ -f "${log_file}" ]]; then
-      echo "----- $(basename "${log_file}") -----" >&2
-      tail -n 80 "${log_file}" >&2 || true
-    fi
+    [[ -f "${log_file}" ]] || continue
+    _rubin_process_error "----- $(basename "${log_file}") -----"
+    tail -n 80 "${log_file}" >&2 || true
   done
 }
 
 rubin_process_cleanup() {
-  local status="$1"
-
-  rubin_process_stop_all
-  if [[ "${status}" != "0" ]]; then
-    rubin_process_dump_artifacts
-    return "${status}"
-  fi
-  if [[ "${RUBIN_PROCESS_KEEP_ARTIFACTS}" == "1" ]]; then
+  local status="${1:-0}" cleanup_status=0
+  _rubin_process_uint "status" "${status}" || return 1
+  rubin_process_stop_all || cleanup_status=$?
+  if [[ "${status}" != "0" ]]; then rubin_process_dump_artifacts; return "${status}"; fi
+  [[ "${RUBIN_PROCESS_KEEP_ARTIFACTS}" == "1" ]] && {
     echo "OK: artifacts preserved at ${RUBIN_PROCESS_ARTIFACT_ROOT}"
-    return 0
-  fi
-  if [[ -z "${RUBIN_PROCESS_ARTIFACT_ROOT}" ||
-        "${RUBIN_PROCESS_ARTIFACT_ROOT}" == "/" ||
-        "${RUBIN_PROCESS_ARTIFACT_ROOT}" == "." ]]; then
-    echo "refusing to remove unsafe artifact root: ${RUBIN_PROCESS_ARTIFACT_ROOT:-<empty>}" >&2
+    return "${cleanup_status}"
+  }
+  [[ -n "${_RUBIN_PROCESS_CREATED_PARENT}" && -n "${RUBIN_PROCESS_ARTIFACT_ROOT}" ]] || {
+    _rubin_process_error "refusing cleanup without initialized artifact paths"
     return 1
-  fi
-  rm -rf -- "${RUBIN_PROCESS_ARTIFACT_ROOT}"
+  }
+  case "${RUBIN_PROCESS_ARTIFACT_ROOT}" in
+    "${_RUBIN_PROCESS_CREATED_PARENT}"/*) ;;
+    *) _rubin_process_error "refusing to remove unsafe artifact root: ${RUBIN_PROCESS_ARTIFACT_ROOT}"; return 1 ;;
+  esac
+  rm -rf -- "${RUBIN_PROCESS_ARTIFACT_ROOT}" || cleanup_status=$?
+  return "${cleanup_status}"
 }
 
 rubin_process_exit_trap() {
-  local status=$?
-  local cleanup_status=0
+  local status=$? cleanup_status=0
   rubin_process_cleanup "${status}" || cleanup_status=$?
-  if [[ "${status}" != "0" ]]; then
-    exit "${status}"
-  fi
+  [[ "${status}" != "0" ]] && exit "${status}"
   exit "${cleanup_status}"
 }
-
-rubin_process_self_test() (
-  set -euo pipefail
-
-  local parent_root
-  parent_root="$(mktemp -d "${TMPDIR:-/tmp}/rubin-devnet-process-parent.XXXXXX")"
-  RUBIN_PROCESS_ARTIFACT_ROOT="${parent_root}"
-  rubin_process_init "unsafe/prefix"
-  if [[ "${RUBIN_PROCESS_ARTIFACT_ROOT}" == "${parent_root}" ||
-        "${RUBIN_PROCESS_ARTIFACT_ROOT}" != "${parent_root}/"* ]]; then
-    echo "custom artifact parent was not isolated: ${RUBIN_PROCESS_ARTIFACT_ROOT}" >&2
-    return 1
-  fi
-  rubin_process_cleanup 0
-  trap - EXIT
-  if [[ ! -d "${parent_root}" ]]; then
-    echo "custom artifact parent was removed: ${parent_root}" >&2
-    return 1
-  fi
-  rm -rf -- "${parent_root}"
-  RUBIN_PROCESS_ARTIFACT_ROOT=""
-
-  local parent_file
-  parent_file="$(mktemp "${TMPDIR:-/tmp}/rubin-devnet-process-parent-file.XXXXXX")"
-  RUBIN_PROCESS_ARTIFACT_ROOT="${parent_file}"
-  if rubin_process_init "bad-parent" 2>"${parent_file}.err"; then
-    echo "artifact root creation unexpectedly succeeded under file parent" >&2
-    return 1
-  fi
-  rm -f -- "${parent_file}" "${parent_file}.err"
-  RUBIN_PROCESS_ARTIFACT_ROOT=""
-
-  if bash -c 'source "$1"; rubin_process_init trap-fail; RUBIN_PROCESS_ARTIFACT_ROOT=/; exit 0' bash "${BASH_SOURCE[0]}" >/dev/null 2>&1; then
-    echo "exit trap ignored cleanup failure" >&2
-    return 1
-  fi
-
-  if bash -c 'source "$1"; trap "echo caller trap >&2" EXIT; rubin_process_init trap-clobber' bash "${BASH_SOURCE[0]}" >/dev/null 2>&1; then
-    echo "existing EXIT trap was overwritten" >&2
-    return 1
-  fi
-
-  rubin_process_init "rubin-devnet-process-selftest"
-  local log_file="${RUBIN_PROCESS_ARTIFACT_ROOT}/selftest.log"
-  local pid
-  rubin_process_start "${log_file}" bash -c 'trap "exit 0" TERM; echo "rpc: listening=127.0.0.1:12345"; while :; do sleep 1; done'
-  pid="${RUBIN_PROCESS_LAST_PID}"
-  rubin_process_wait_for_log "${log_file}" "rpc: listening=" 5 "${pid}"
-
-  local addr
-  addr="$(rubin_process_extract_rpc_addr "${log_file}")"
-  if [[ "${addr}" != "127.0.0.1:12345" ]]; then
-    echo "unexpected rpc addr: ${addr}" >&2
-    return 1
-  fi
-
-  rubin_process_stop_pid "${pid}"
-  echo "PASS: devnet process common self-test"
-)
-
-if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
-  case "${1:-}" in
-    --self-test)
-      rubin_process_self_test
-      ;;
-    *)
-      echo "usage: $0 --self-test" >&2
-      exit 2
-      ;;
-  esac
-fi

--- a/scripts/devnet-process-common.sh
+++ b/scripts/devnet-process-common.sh
@@ -25,7 +25,10 @@ rubin_process_init() {
   fi
 
   mkdir -p "${artifact_parent}"
-  RUBIN_PROCESS_ARTIFACT_ROOT="$(mktemp -d "${artifact_parent%/}/${safe_prefix}.XXXXXX")"
+  if ! RUBIN_PROCESS_ARTIFACT_ROOT="$(mktemp -d "${artifact_parent%/}/${safe_prefix}.XXXXXX")"; then
+    echo "failed to create artifact root under ${artifact_parent}" >&2
+    return 1
+  fi
 
   RUBIN_PROCESS_PIDS=()
   RUBIN_PROCESS_LOGS=()
@@ -185,8 +188,12 @@ rubin_process_cleanup() {
 
 rubin_process_exit_trap() {
   local status=$?
-  rubin_process_cleanup "${status}"
-  exit "${status}"
+  local cleanup_status=0
+  rubin_process_cleanup "${status}" || cleanup_status=$?
+  if [[ "${status}" != "0" ]]; then
+    exit "${status}"
+  fi
+  exit "${cleanup_status}"
 }
 
 rubin_process_self_test() {
@@ -209,6 +216,21 @@ rubin_process_self_test() {
   fi
   rm -rf -- "${parent_root}"
   RUBIN_PROCESS_ARTIFACT_ROOT=""
+
+  local parent_file
+  parent_file="$(mktemp "${TMPDIR:-/tmp}/rubin-devnet-process-parent-file.XXXXXX")"
+  RUBIN_PROCESS_ARTIFACT_ROOT="${parent_file}"
+  if rubin_process_init "bad-parent" 2>"${parent_file}.err"; then
+    echo "artifact root creation unexpectedly succeeded under file parent" >&2
+    return 1
+  fi
+  rm -f -- "${parent_file}" "${parent_file}.err"
+  RUBIN_PROCESS_ARTIFACT_ROOT=""
+
+  if bash -c 'source "$1"; rubin_process_init trap-fail; RUBIN_PROCESS_ARTIFACT_ROOT=/; exit 0' bash "${BASH_SOURCE[0]}" >/dev/null 2>&1; then
+    echo "exit trap ignored cleanup failure" >&2
+    return 1
+  fi
 
   rubin_process_init "rubin-devnet-process-selftest"
   local log_file="${RUBIN_PROCESS_ARTIFACT_ROOT}/selftest.log"

--- a/scripts/devnet-process-common.sh
+++ b/scripts/devnet-process-common.sh
@@ -12,6 +12,7 @@ RUBIN_PROCESS_LOGS=()
 RUBIN_PROCESS_LAST_PID=""
 _RUBIN_PROCESS_CREATED_PARENT=""
 _RUBIN_PROCESS_CREATED_ROOT=""
+_RUBIN_PROCESS_CREATED_ROOT_REAL=""
 _RUBIN_PROCESS_STOP_GRACE_SECONDS_DECIMAL=""
 
 _rubin_process_error() { echo "$*" >&2; }
@@ -29,8 +30,16 @@ _rubin_process_pid() { [[ "${1:-}" =~ ^[1-9][0-9]*$ ]]; }
 
 _rubin_process_has_parent_ref() { case "/${1:-}/" in *"/../"*) return 0 ;; *) return 1 ;; esac; }
 
+_rubin_process_physical_dir() {
+  local dir="${1:-}"
+  [[ -n "${dir}" && -d "${dir}" ]] || { _rubin_process_error "directory does not exist: ${dir:-<empty>}"; return 1; }
+  (cd "${dir}" && pwd -P) || { _rubin_process_error "failed to resolve directory: ${dir}"; return 1; }
+}
+
 _rubin_process_require_init() {
   [[ -n "${RUBIN_PROCESS_ARTIFACT_ROOT}" && -d "${RUBIN_PROCESS_ARTIFACT_ROOT}" ]] || { _rubin_process_error "rubin_process_init must run before process helpers"; return 1; }
+  [[ -n "${_RUBIN_PROCESS_CREATED_ROOT}" && "${RUBIN_PROCESS_ARTIFACT_ROOT}" == "${_RUBIN_PROCESS_CREATED_ROOT}" ]] || { _rubin_process_error "rubin_process_init must complete successfully before process helpers"; return 1; }
+  [[ -n "${_RUBIN_PROCESS_CREATED_ROOT_REAL}" && "$(_rubin_process_physical_dir "${RUBIN_PROCESS_ARTIFACT_ROOT}")" == "${_RUBIN_PROCESS_CREATED_ROOT_REAL}" ]] || { _rubin_process_error "artifact root no longer resolves to the helper-created directory: ${RUBIN_PROCESS_ARTIFACT_ROOT}"; return 1; }
   [[ ! -L "${RUBIN_PROCESS_ARTIFACT_ROOT}" ]] || { _rubin_process_error "artifact root must not be a symlink: ${RUBIN_PROCESS_ARTIFACT_ROOT}"; return 1; }
 }
 
@@ -68,11 +77,12 @@ _rubin_process_reject_symlink_components() {
 
 _rubin_process_require_artifact_parent() {
   local file="${1:-}" dir root_real dir_real
+  _rubin_process_require_init || return 1
   _rubin_process_reject_symlink_components "${file}" || return 1
   dir="$(dirname "${file}")"
   [[ -d "${dir}" ]] || return 0
-  root_real="$(cd "${RUBIN_PROCESS_ARTIFACT_ROOT}" && pwd -P)" || { _rubin_process_error "failed to resolve artifact root: ${RUBIN_PROCESS_ARTIFACT_ROOT}"; return 1; }
-  dir_real="$(cd "${dir}" && pwd -P)" || { _rubin_process_error "failed to resolve log directory: ${dir}"; return 1; }
+  root_real="$(_rubin_process_physical_dir "${RUBIN_PROCESS_ARTIFACT_ROOT}")" || return 1
+  dir_real="$(_rubin_process_physical_dir "${dir}")" || return 1
   case "${dir_real}" in
     "${root_real}"|"${root_real}"/*) ;;
     *) _rubin_process_error "log directory must stay under artifact root: ${dir}"; return 1 ;;
@@ -130,6 +140,10 @@ rubin_process_init() {
     return 1
   }
   _RUBIN_PROCESS_CREATED_ROOT="${RUBIN_PROCESS_ARTIFACT_ROOT}"
+  _RUBIN_PROCESS_CREATED_ROOT_REAL="$(_rubin_process_physical_dir "${RUBIN_PROCESS_ARTIFACT_ROOT}")" || {
+    RUBIN_PROCESS_ARTIFACT_ROOT=""
+    return 1
+  }
   RUBIN_PROCESS_PIDS=()
   RUBIN_PROCESS_LOGS=()
   RUBIN_PROCESS_LAST_PID=""
@@ -186,15 +200,18 @@ rubin_process_stop_pid() {
 }
 
 rubin_process_stop_all() {
-  local i
+  local i rc status=0
   for ((i=${#RUBIN_PROCESS_PIDS[@]} - 1; i >= 0; i--)); do
-    rubin_process_stop_pid "${RUBIN_PROCESS_PIDS[$i]}" || return 1
+    rc=0
+    rubin_process_stop_pid "${RUBIN_PROCESS_PIDS[$i]}" || rc=$?
+    (( rc == 0 )) || { (( status == 0 )) && status="${rc}"; }
   done
+  return "${status}"
 }
 
 rubin_process_wait_for_log() {
   local file="${1:-}" needle="${2:-}" timeout="${3:-}" pid="${4:-}" timeout_seconds deadline
-  [[ -n "${file}" && -n "${needle}" ]] || { _rubin_process_error "rubin_process_wait_for_log requires file, needle, timeout"; return 1; }
+  [[ -n "${file}" && -n "${needle}" && -n "${timeout}" ]] || { _rubin_process_error "rubin_process_wait_for_log requires file, needle, timeout"; return 1; }
   file="$(_rubin_process_resolve_log "${file}")" || return 1
   _rubin_process_require_artifact_parent "${file}" || return 1
   timeout_seconds="$(_rubin_process_uint_decimal "timeout" "${timeout}")" || return 1
@@ -230,7 +247,8 @@ rubin_process_extract_rpc_addr() {
 
 rubin_process_wait_for_rpc_ready() {
   local rpc_addr="${1:-}" timeout="${2:-}" timeout_seconds deadline
-  [[ -n "${rpc_addr}" && "${rpc_addr}" != *[[:space:]/]* ]] || { _rubin_process_error "invalid rpc address: ${rpc_addr:-<empty>}"; return 1; }
+  [[ -n "${rpc_addr}" && -n "${timeout}" ]] || { _rubin_process_error "rubin_process_wait_for_rpc_ready requires rpc address and timeout"; return 1; }
+  [[ "${rpc_addr}" != *[[:space:]/]* ]] || { _rubin_process_error "invalid rpc address: ${rpc_addr:-<empty>}"; return 1; }
   timeout_seconds="$(_rubin_process_uint_decimal "timeout" "${timeout}")" || return 1
   command -v python3 >/dev/null 2>&1 || { _rubin_process_error "python3 is required to poll /get_tip"; return 1; }
   deadline=$((SECONDS + timeout_seconds))
@@ -247,7 +265,8 @@ rubin_process_wait_for_rpc_ready() {
 rubin_process_dump_artifacts() {
   local log_file
   _rubin_process_error "FAIL: artifacts preserved at ${RUBIN_PROCESS_ARTIFACT_ROOT:-<unset>}"
-  for log_file in "${RUBIN_PROCESS_LOGS[@]:-}"; do
+  for log_file in "${RUBIN_PROCESS_LOGS[@]}"; do
+    _rubin_process_require_artifact_parent "${log_file}" || { _rubin_process_error "skipping unsafe log file: ${log_file}"; continue; }
     [[ -f "${log_file}" ]] || continue
     _rubin_process_error "----- $(basename "${log_file}") -----"
     tail -n 80 "${log_file}" >&2 || true
@@ -263,10 +282,11 @@ rubin_process_cleanup() {
     echo "OK: artifacts preserved at ${RUBIN_PROCESS_ARTIFACT_ROOT}"
     return "${cleanup_status}"
   }
-  if [[ -z "${_RUBIN_PROCESS_CREATED_PARENT}" || -z "${_RUBIN_PROCESS_CREATED_ROOT}" || -z "${RUBIN_PROCESS_ARTIFACT_ROOT}" ]] || _rubin_process_has_parent_ref "${RUBIN_PROCESS_ARTIFACT_ROOT}"; then
+  if [[ -z "${_RUBIN_PROCESS_CREATED_PARENT}" || -z "${_RUBIN_PROCESS_CREATED_ROOT}" || -z "${_RUBIN_PROCESS_CREATED_ROOT_REAL}" || -z "${RUBIN_PROCESS_ARTIFACT_ROOT}" ]] || _rubin_process_has_parent_ref "${RUBIN_PROCESS_ARTIFACT_ROOT}"; then
     _rubin_process_error "refusing cleanup without initialized artifact paths or with parent traversal"
     return 1
   fi
+  _rubin_process_require_init || return 1
   [[ "${RUBIN_PROCESS_ARTIFACT_ROOT}" == "${_RUBIN_PROCESS_CREATED_ROOT}" ]] || {
     _rubin_process_error "refusing to remove artifact root not created by rubin_process_init: ${RUBIN_PROCESS_ARTIFACT_ROOT}"
     return 1
@@ -275,7 +295,7 @@ rubin_process_cleanup() {
     "${_RUBIN_PROCESS_CREATED_PARENT}"/*) ;;
     *) _rubin_process_error "refusing to remove unsafe artifact root: ${RUBIN_PROCESS_ARTIFACT_ROOT}"; return 1 ;;
   esac
-  rm -rf -- "${RUBIN_PROCESS_ARTIFACT_ROOT}" || cleanup_status=$?
+  rm -rf -- "${_RUBIN_PROCESS_CREATED_ROOT_REAL}" || cleanup_status=$?
   return "${cleanup_status}"
 }
 


### PR DESCRIPTION
## Q
Q-ID: Q-IMPL-NODE-DEVNET-PROCESS-HARNESS-COMMON-01
Issue: #1222

## Architecture class
C = lifecycle helper boundary.

Controller-approved continuation: review found lifecycle-helper/process-containment defects after the helper existed; controller instruction was to finish this PR and not split into a new PR.

## System boundary
`rubin-protocol` devnet process harness only.

## Single invariant
Later devnet process scripts share one fail-closed lifecycle helper surface instead of duplicating fragile process control.

## Scope
- Add one source-able Bash helper: `scripts/devnet-process-common.sh`.
- Provide temp/artifact child-root setup, PID/process-group tracking, bounded cleanup, failure log preservation, RPC banner extraction, log waiting, and `/get_tip` readiness polling.
- Keep the helper scenario-neutral; no binary soak or topology logic is added in this slice.

## Non-goals
- No Go runtime changes.
- No Rust runtime changes.
- No new RPC endpoints.
- No tx submission, topology, mixed-client, reorg, or report-schema scenario logic.

## What this PR is NOT allowed to redesign
- Node lifecycle semantics.
- RPC behavior or route shape.
- Devnet process-soak scenario architecture.
- Cross-client parity behavior.

## Budget waiver
- Changed files: 1.
- Helper file size at current head `374c721130d969ae883689b68ef310c37f45e223`: 351 total lines, 316 non-comment/nonblank structural lines.
- Issue budget `<=180 executable lines` was exceeded because review required fail-closed containment, process-group cleanup, idempotent cleanup, re-source/forged-state protection, and overflow guards inside the one helper boundary.
- No built-in test harness is kept in the diff.

## Validation
- `shellcheck scripts/devnet-process-common.sh` PASS.
- `bash -n scripts/devnet-process-common.sh` PASS.
- `git diff --check` PASS.
- Hostile local source-path smoke matrix PASS:
  - pre-exported forged internal state without trap cannot authorize start/cleanup;
  - forged helper-looking EXIT trap is rejected on source;
  - failed init does not authorize stale pre-set root cleanup;
  - parent symlink replacement fails closed and preserves outside target;
  - root/log symlink replacement before dump does not read outside logs;
  - symlink log-dir start/wait rejected without outside mkdir side effects;
  - process-group cleanup kills wrapper children without Bash job-status noise;
  - re-source after real init fails closed and cleanup still kills existing PID;
  - manual cleanup is idempotent and clears EXIT trap state;
  - nonzero manual cleanup returns the original status, clears EXIT trap/state, and the second cleanup is idempotent;
  - empty-log artifact dump is safe under `set -u`;
  - diagnostics use `printf` and preserve leading `-n`;
  - integer overflow, invalid PID, parent traversal, and leading-zero timeout guards pass.
- `TOOLING_NEW_ONLY=1 bash /Users/gpt/rubin-tool-scaffolding/scripts/tooling-check.sh --mode fast --repo /Users/gpt/Documents/rubin-protocol` PASS.
- Read-only adversarial reviewer-agent final verdict: `approve` on postimage `15a6c9d61a48de42f0438defbb290e9480311c37`, diff hash `dd350bed30fa13a4c4692a559efc2245e0c1a2e90cbc4bdf6746217dc9d76c14`.
- `python3 /Users/gpt/Documents/rubin-orchestration-private/inbox/operational/tools/run_pr_lifecycle.py pre-pr --target-repo rubin-protocol` PASS at head `374c721130d969ae883689b68ef310c37f45e223` with `tracked_worktree_clean=true`.
- `cl push` local security review PASS and pushed `5699c29..374c721`.

## Stop rule
If review requires runtime behavior changes, new RPC surface, scenario-specific submit/mine/reorg logic, or another harness redesign outside this helper boundary, stop and split instead of widening this PR.

<!-- rubin-agent-meta actor=codex action=pr-update via=gh branch=codex/q-impl-node-devnet-process-harness-common-01 wt=rubin-protocol utc=2026-04-22T18:40:00Z -->
