### PR TITLE
feat: add Go binary soak skeleton

### DIFF
--- a/scripts/devnet-go-binary-soak.sh
+++ b/scripts/devnet-go-binary-soak.sh
@@ -52,7 +52,6 @@ A_LOG="node-a.log"
 B_LOG="node-b.log"
 C_LOG="node-c.log"
 MINE_LOG="${RUBIN_PROCESS_ARTIFACT_ROOT}/mine-base.log"
-A_P2P_ADDR="127.0.0.1:$((29110 + ($$ % 1000)))"
 
 rpc_json() {
   local method="$1" addr="$2" path="$3" body="${4:-}"
@@ -125,25 +124,24 @@ cp -R "${A_DIR}/." "${B_DIR}/"
 cp -R "${A_DIR}/." "${C_DIR}/"
 
 echo "Starting three Go rubin-node processes"
-rubin_process_start "${A_LOG}" "${NODE_BIN}" --datadir "${A_DIR}" --bind "${A_P2P_ADDR}" --rpc-bind 127.0.0.1:0 --mine-address "${MINE_ADDRESS_HEX}"
-A_PID="${RUBIN_PROCESS_LAST_PID}"
+A_PID=""
+for _ in 1 2 3; do
+  A_P2P_ADDR="$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(f"127.0.0.1:{s.getsockname()[1]}"); s.close()')"
+  if rubin_process_start "${A_LOG}" "${NODE_BIN}" --datadir "${A_DIR}" --bind "${A_P2P_ADDR}" --rpc-bind 127.0.0.1:0 --mine-address "${MINE_ADDRESS_HEX}" && rubin_process_wait_for_log "${A_LOG}" "rpc: listening=" 30 "${RUBIN_PROCESS_LAST_PID}"; then A_PID="${RUBIN_PROCESS_LAST_PID}"; A_RPC_ADDR="$(rubin_process_extract_rpc_addr "${A_LOG}")"; break; fi
+  [[ -z "${RUBIN_PROCESS_LAST_PID}" ]] || rubin_process_stop_pid "${RUBIN_PROCESS_LAST_PID}" || true
+done
+[[ -n "${A_PID}" ]] || { echo "failed to start node-a after retrying loopback bind ports" >&2; exit 1; }
 rubin_process_start "${B_LOG}" "${NODE_BIN}" --datadir "${B_DIR}" --bind 127.0.0.1:0 --rpc-bind 127.0.0.1:0 --peers "${A_P2P_ADDR}" --mine-address "${MINE_ADDRESS_HEX}"
 B_PID="${RUBIN_PROCESS_LAST_PID}"
 rubin_process_start "${C_LOG}" "${NODE_BIN}" --datadir "${C_DIR}" --bind 127.0.0.1:0 --rpc-bind 127.0.0.1:0 --peers "${A_P2P_ADDR}" --mine-address "${MINE_ADDRESS_HEX}"
 C_PID="${RUBIN_PROCESS_LAST_PID}"
 
-rubin_process_wait_for_log "${A_LOG}" "rpc: listening=" 30 "${A_PID}"
-A_RPC_ADDR="$(rubin_process_extract_rpc_addr "${A_LOG}")"
 rubin_process_wait_for_log "${B_LOG}" "rpc: listening=" 30 "${B_PID}"
 B_RPC_ADDR="$(rubin_process_extract_rpc_addr "${B_LOG}")"
 rubin_process_wait_for_log "${C_LOG}" "rpc: listening=" 30 "${C_PID}"
 C_RPC_ADDR="$(rubin_process_extract_rpc_addr "${C_LOG}")"
-rubin_process_wait_for_rpc_ready "${A_RPC_ADDR}" 30
-rubin_process_wait_for_rpc_ready "${B_RPC_ADDR}" 30
-rubin_process_wait_for_rpc_ready "${C_RPC_ADDR}" 30
-wait_height "${A_RPC_ADDR}" "${BASE_HEIGHT}" 30
-wait_height "${B_RPC_ADDR}" "${BASE_HEIGHT}" 30
-wait_height "${C_RPC_ADDR}" "${BASE_HEIGHT}" 30
+for addr in "${A_RPC_ADDR}" "${B_RPC_ADDR}" "${C_RPC_ADDR}"; do rubin_process_wait_for_rpc_ready "${addr}" 30; done
+for addr in "${A_RPC_ADDR}" "${B_RPC_ADDR}" "${C_RPC_ADDR}"; do wait_height "${addr}" "${BASE_HEIGHT}" 30; done
 
 echo "Submitting tx through Go RPC and mining it through /mine_next"
 TX_HEX="$("${TXGEN_BIN}" --datadir "${A_DIR}" --from-key "${FROM_DER_HEX}" --to-key "${TO_ADDRESS_HEX}" --amount 1 --fee 1 --submit-to "${A_RPC_ADDR}")"

--- a/scripts/devnet-go-binary-soak.sh
+++ b/scripts/devnet-go-binary-soak.sh
@@ -55,8 +55,9 @@ if body:
 try:
     resp = urllib.request.urlopen(req, timeout=5)
 except urllib.error.HTTPError as exc:
-    print(exc.read().decode("utf-8"), end="")
-    sys.exit(22)
+    print(exc.read().decode("utf-8"), end=""); sys.exit(22)
+except (urllib.error.URLError, TimeoutError) as exc:
+    print(f"request failed: {getattr(exc, 'reason', exc)}", end=""); sys.exit(1)
 with resp:
     print(resp.read().decode("utf-8"), end="")
 PY

--- a/scripts/devnet-go-binary-soak.sh
+++ b/scripts/devnet-go-binary-soak.sh
@@ -25,8 +25,8 @@ while (($#)); do
       ;;
   esac
 done
-# Runtime txgen needs base height >=100; target 100 has no mature spend.
-[[ "${TARGET_HEIGHT}" =~ ^[0-9]+$ && "${TARGET_HEIGHT}" -ge 101 ]] || { echo "--target-height must be an integer >= 101" >&2; exit 2; }
+# Runtime txgen needs base height >=100; bound height to keep the soak finite.
+TARGET_HEIGHT="$(python3 -c 'import sys; s=sys.argv[1]; n=int(s) if s.isdecimal() else -1; 101 <= n <= 10000 or sys.exit(2); print(n)' "${TARGET_HEIGHT}")" || { echo "--target-height must be an integer in [101, 10000]" >&2; exit 2; }
 # shellcheck source=scripts/devnet-process-common.sh disable=SC1091
 source "${HELPER}"
 rubin_process_init go-binary-soak

--- a/scripts/devnet-go-binary-soak.sh
+++ b/scripts/devnet-go-binary-soak.sh
@@ -46,20 +46,19 @@ RUBIN_PROCESS_LOGS+=("${MINE_LOG}")
 rpc_json() {
   local method="$1" addr="$2" path="$3" body="${4:-}"
   python3 - "${method}" "${addr}" "${path}" "${body}" <<'PY'
-import sys, urllib.error, urllib.request
+import socket, sys, urllib.error, urllib.request
 method, addr, path, body = sys.argv[1:5]
 data = body.encode() if body else None
 req = urllib.request.Request(f"http://{addr}{path}", data=data, method=method)
 if body:
     req.add_header("Content-Type", "application/json")
 try:
-    resp = urllib.request.urlopen(req, timeout=5)
+    with urllib.request.urlopen(req, timeout=5) as resp:
+        print(resp.read().decode("utf-8"), end="")
 except urllib.error.HTTPError as exc:
     print(exc.read().decode("utf-8"), end=""); sys.exit(22)
-except (urllib.error.URLError, TimeoutError) as exc:
+except (urllib.error.URLError, TimeoutError, socket.timeout) as exc:
     print(f"request failed: {getattr(exc, 'reason', exc)}", end=""); sys.exit(1)
-with resp:
-    print(resp.read().decode("utf-8"), end="")
 PY
 }
 tip_tsv() {

--- a/scripts/devnet-go-binary-soak.sh
+++ b/scripts/devnet-go-binary-soak.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEV_ENV="${REPO_ROOT}/scripts/dev-env.sh"
+GO_MODULE_ROOT="${REPO_ROOT}/clients/go"
+HELPER="${REPO_ROOT}/scripts/devnet-process-common.sh"
+TARGET_HEIGHT=120
+
+usage() {
+  echo "usage: $0 [--target-height N]" >&2
+}
+
+while (($#)); do
+  case "$1" in
+    --target-height)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      TARGET_HEIGHT="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+[[ "${TARGET_HEIGHT}" =~ ^[0-9]+$ && "${TARGET_HEIGHT}" -ge 102 ]] || {
+  echo "--target-height must be an integer >= 102" >&2
+  exit 2
+}
+
+# shellcheck source=scripts/devnet-process-common.sh disable=SC1091
+source "${HELPER}"
+rubin_process_init go-binary-soak
+
+NODE_BIN="${RUBIN_PROCESS_ARTIFACT_ROOT}/rubin-node-go"
+TXGEN_BIN="${RUBIN_PROCESS_ARTIFACT_ROOT}/rubin-txgen"
+KEYGEN_GO="${RUBIN_PROCESS_ARTIFACT_ROOT}/keygen.go"
+KEYGEN_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/keygen.json"
+REPORT_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/go-binary-soak-report.json"
+BASE_HEIGHT=$((TARGET_HEIGHT - 1))
+BASE_MINE_BLOCKS="${TARGET_HEIGHT}"
+A_DIR="${RUBIN_PROCESS_ARTIFACT_ROOT}/node-a"
+B_DIR="${RUBIN_PROCESS_ARTIFACT_ROOT}/node-b"
+C_DIR="${RUBIN_PROCESS_ARTIFACT_ROOT}/node-c"
+A_LOG="node-a.log"
+B_LOG="node-b.log"
+C_LOG="node-c.log"
+MINE_LOG="${RUBIN_PROCESS_ARTIFACT_ROOT}/mine-base.log"
+A_P2P_ADDR="127.0.0.1:$((29110 + ($$ % 1000)))"
+
+rpc_json() {
+  local method="$1" addr="$2" path="$3" body="${4:-}"
+  python3 - "${method}" "${addr}" "${path}" "${body}" <<'PY'
+import json, sys, urllib.request
+method, addr, path, body = sys.argv[1:5]
+data = body.encode() if body else None
+req = urllib.request.Request(f"http://{addr}{path}", data=data, method=method)
+if body:
+    req.add_header("Content-Type", "application/json")
+with urllib.request.urlopen(req, timeout=5) as resp:
+    print(resp.read().decode("utf-8"), end="")
+PY
+}
+
+json_key() {
+  python3 -c 'import json,sys; d=json.load(sys.stdin)
+for p in sys.argv[1].split("."): d=d[p]
+print(d)' "$1"
+}
+
+tip_tsv() {
+  rpc_json GET "$1" /get_tip | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d["height"], d["tip_hash"], sep="\t")'
+}
+
+wait_height() {
+  local addr="$1" want="$2" timeout="$3" height hash
+  local deadline=$((SECONDS + timeout))
+  while ((SECONDS < deadline)); do
+    if IFS=$'\t' read -r height hash < <(tip_tsv "${addr}" 2>/dev/null) && [[ "${height}" == "${want}" && -n "${hash}" ]]; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "timeout waiting for ${addr} height=${want}" >&2
+  return 1
+}
+
+write_keygen() {
+  cat >"${KEYGEN_GO}" <<'EOF'
+package main
+import ("encoding/hex"; "encoding/json"; "os"; "github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus")
+func main() {
+  from, err := consensus.NewMLDSA87Keypair(); if err != nil { panic(err) }; defer from.Close()
+  to, err := consensus.NewMLDSA87Keypair(); if err != nil { panic(err) }; defer to.Close()
+  der, err := from.PrivateKeyDER(); if err != nil { panic(err) }
+  out := map[string]string{
+    "from_der_hex": hex.EncodeToString(der),
+    "mine_address_hex": hex.EncodeToString(consensus.P2PKCovenantDataForPubkey(from.PubkeyBytes())),
+    "to_address_hex": hex.EncodeToString(consensus.P2PKCovenantDataForPubkey(to.PubkeyBytes())),
+  }
+  if err := json.NewEncoder(os.Stdout).Encode(out); err != nil { panic(err) }
+}
+EOF
+}
+
+echo "Building Go rubin-node and rubin-txgen"
+"${DEV_ENV}" -- go -C "${GO_MODULE_ROOT}" build -o "${NODE_BIN}" ./cmd/rubin-node
+"${DEV_ENV}" -- go -C "${GO_MODULE_ROOT}" build -o "${TXGEN_BIN}" ./cmd/rubin-txgen
+write_keygen
+"${DEV_ENV}" -- go -C "${GO_MODULE_ROOT}" run "${KEYGEN_GO}" >"${KEYGEN_JSON}"
+FROM_DER_HEX="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["from_der_hex"])' "${KEYGEN_JSON}")"
+MINE_ADDRESS_HEX="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["mine_address_hex"])' "${KEYGEN_JSON}")"
+TO_ADDRESS_HEX="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["to_address_hex"])' "${KEYGEN_JSON}")"
+
+mkdir -p "${A_DIR}" "${B_DIR}" "${C_DIR}"
+echo "Mining mature Go chain to height ${BASE_HEIGHT}"
+"${NODE_BIN}" --datadir "${A_DIR}" --mine-address "${MINE_ADDRESS_HEX}" --mine-blocks "${BASE_MINE_BLOCKS}" --mine-exit >"${MINE_LOG}" 2>&1
+cp -R "${A_DIR}/." "${B_DIR}/"
+cp -R "${A_DIR}/." "${C_DIR}/"
+
+echo "Starting three Go rubin-node processes"
+rubin_process_start "${A_LOG}" "${NODE_BIN}" --datadir "${A_DIR}" --bind "${A_P2P_ADDR}" --rpc-bind 127.0.0.1:0 --mine-address "${MINE_ADDRESS_HEX}"
+A_PID="${RUBIN_PROCESS_LAST_PID}"
+rubin_process_start "${B_LOG}" "${NODE_BIN}" --datadir "${B_DIR}" --bind 127.0.0.1:0 --rpc-bind 127.0.0.1:0 --peers "${A_P2P_ADDR}" --mine-address "${MINE_ADDRESS_HEX}"
+B_PID="${RUBIN_PROCESS_LAST_PID}"
+rubin_process_start "${C_LOG}" "${NODE_BIN}" --datadir "${C_DIR}" --bind 127.0.0.1:0 --rpc-bind 127.0.0.1:0 --peers "${A_P2P_ADDR}" --mine-address "${MINE_ADDRESS_HEX}"
+C_PID="${RUBIN_PROCESS_LAST_PID}"
+
+rubin_process_wait_for_log "${A_LOG}" "rpc: listening=" 30 "${A_PID}"
+A_RPC_ADDR="$(rubin_process_extract_rpc_addr "${A_LOG}")"
+rubin_process_wait_for_log "${B_LOG}" "rpc: listening=" 30 "${B_PID}"
+B_RPC_ADDR="$(rubin_process_extract_rpc_addr "${B_LOG}")"
+rubin_process_wait_for_log "${C_LOG}" "rpc: listening=" 30 "${C_PID}"
+C_RPC_ADDR="$(rubin_process_extract_rpc_addr "${C_LOG}")"
+rubin_process_wait_for_rpc_ready "${A_RPC_ADDR}" 30
+rubin_process_wait_for_rpc_ready "${B_RPC_ADDR}" 30
+rubin_process_wait_for_rpc_ready "${C_RPC_ADDR}" 30
+wait_height "${A_RPC_ADDR}" "${BASE_HEIGHT}" 30
+wait_height "${B_RPC_ADDR}" "${BASE_HEIGHT}" 30
+wait_height "${C_RPC_ADDR}" "${BASE_HEIGHT}" 30
+
+echo "Submitting tx through Go RPC and mining it through /mine_next"
+TX_HEX="$("${TXGEN_BIN}" --datadir "${A_DIR}" --from-key "${FROM_DER_HEX}" --to-key "${TO_ADDRESS_HEX}" --amount 1 --fee 1 --submit-to "${A_RPC_ADDR}")"
+MEMPOOL_JSON="$(rpc_json GET "${A_RPC_ADDR}" /get_mempool)"
+TX_ID="$(printf '%s' "${MEMPOOL_JSON}" | python3 -c 'import json,sys; d=json.load(sys.stdin); assert d["count"] == 1; print(d["txids"][0])')"
+MINE_JSON="$(rpc_json POST "${A_RPC_ADDR}" /mine_next '{}')"
+FINAL_HEIGHT="$(printf '%s' "${MINE_JSON}" | json_key height)"
+FINAL_HASH="$(printf '%s' "${MINE_JSON}" | json_key block_hash)"
+TX_COUNT="$(printf '%s' "${MINE_JSON}" | json_key tx_count)"
+[[ "${FINAL_HEIGHT}" == "${TARGET_HEIGHT}" && "${TX_COUNT}" -ge 2 ]] || {
+  echo "unexpected mine_next result height=${FINAL_HEIGHT} tx_count=${TX_COUNT}" >&2
+  exit 1
+}
+wait_height "${A_RPC_ADDR}" "${TARGET_HEIGHT}" 30
+IFS=$'\t' read -r _ A_TIP < <(tip_tsv "${A_RPC_ADDR}")
+IFS=$'\t' read -r B_HEIGHT _ < <(tip_tsv "${B_RPC_ADDR}")
+IFS=$'\t' read -r C_HEIGHT _ < <(tip_tsv "${C_RPC_ADDR}")
+[[ "${A_TIP}" == "${FINAL_HASH}" && "${B_HEIGHT}" == "${BASE_HEIGHT}" && "${C_HEIGHT}" == "${BASE_HEIGHT}" ]] || {
+  echo "unexpected checkpoints final=${FINAL_HASH} a=${A_TIP} b_height=${B_HEIGHT} c_height=${C_HEIGHT}" >&2
+  exit 1
+}
+BLOCK_JSON="$(rpc_json GET "${A_RPC_ADDR}" "/get_block?height=${TARGET_HEIGHT}")"
+printf '%s' "${BLOCK_JSON}" | python3 -c 'import json,sys; d=json.load(sys.stdin); assert sys.argv[1].lower() in d["block_hex"].lower()' "${TX_HEX}"
+
+export REPORT_JSON TARGET_HEIGHT BASE_HEIGHT B_HEIGHT C_HEIGHT A_PID B_PID C_PID A_RPC_ADDR B_RPC_ADDR C_RPC_ADDR TX_ID FINAL_HASH TX_COUNT
+python3 - <<'PY'
+import json, os
+report = {
+  "scenario": "go_binary_soak_skeleton",
+  "target_height": int(os.environ["TARGET_HEIGHT"]),
+  "base_height": int(os.environ["BASE_HEIGHT"]),
+  "participants": [
+    {"name": "node-a", "pid": int(os.environ["A_PID"]), "rpc": os.environ["A_RPC_ADDR"], "checkpoint_height": int(os.environ["TARGET_HEIGHT"])},
+    {"name": "node-b", "pid": int(os.environ["B_PID"]), "rpc": os.environ["B_RPC_ADDR"], "checkpoint_height": int(os.environ["B_HEIGHT"])},
+    {"name": "node-c", "pid": int(os.environ["C_PID"]), "rpc": os.environ["C_RPC_ADDR"], "checkpoint_height": int(os.environ["C_HEIGHT"])},
+  ],
+  "tx": {"id": os.environ["TX_ID"], "submission": "rpc:/submit_tx"},
+  "final": {"height": int(os.environ["TARGET_HEIGHT"]), "tip_hash": os.environ["FINAL_HASH"], "tx_count": int(os.environ["TX_COUNT"])},
+  "verdict": "PASS",
+}
+with open(os.environ["REPORT_JSON"], "w", encoding="utf-8") as f:
+    json.dump(report, f, indent=2, sort_keys=True)
+    f.write("\n")
+PY
+echo "PASS: Go binary soak reached height ${TARGET_HEIGHT} with tx ${TX_ID}; report=${REPORT_JSON}"

--- a/scripts/devnet-go-binary-soak.sh
+++ b/scripts/devnet-go-binary-soak.sh
@@ -158,17 +158,25 @@ TX_COUNT="$(printf '%s' "${MINE_JSON}" | json_key tx_count)"
   exit 1
 }
 wait_height "${A_RPC_ADDR}" "${TARGET_HEIGHT}" 30
-IFS=$'\t' read -r _ A_TIP < <(tip_tsv "${A_RPC_ADDR}")
-IFS=$'\t' read -r B_HEIGHT _ < <(tip_tsv "${B_RPC_ADDR}")
-IFS=$'\t' read -r C_HEIGHT _ < <(tip_tsv "${C_RPC_ADDR}")
-[[ "${A_TIP}" == "${FINAL_HASH}" && "${B_HEIGHT}" == "${BASE_HEIGHT}" && "${C_HEIGHT}" == "${BASE_HEIGHT}" ]] || {
-  echo "unexpected checkpoints final=${FINAL_HASH} a=${A_TIP} b_height=${B_HEIGHT} c_height=${C_HEIGHT}" >&2
+IFS=$'\t' read -r A_HEIGHT A_TIP < <(tip_tsv "${A_RPC_ADDR}")
+IFS=$'\t' read -r B_HEIGHT B_TIP < <(tip_tsv "${B_RPC_ADDR}")
+IFS=$'\t' read -r C_HEIGHT C_TIP < <(tip_tsv "${C_RPC_ADDR}")
+[[ "${A_HEIGHT}" == "${TARGET_HEIGHT}" && "${A_TIP}" == "${FINAL_HASH}" ]] || {
+  echo "unexpected node-a checkpoint final=${FINAL_HASH} a_height=${A_HEIGHT} a_tip=${A_TIP}" >&2
+  exit 1
+}
+[[ ("${B_HEIGHT}" == "${BASE_HEIGHT}" && -n "${B_TIP}") || ("${B_HEIGHT}" == "${TARGET_HEIGHT}" && "${B_TIP}" == "${FINAL_HASH}") ]] || {
+  echo "unexpected node-b checkpoint final=${FINAL_HASH} b_height=${B_HEIGHT} b_tip=${B_TIP}" >&2
+  exit 1
+}
+[[ ("${C_HEIGHT}" == "${BASE_HEIGHT}" && -n "${C_TIP}") || ("${C_HEIGHT}" == "${TARGET_HEIGHT}" && "${C_TIP}" == "${FINAL_HASH}") ]] || {
+  echo "unexpected node-c checkpoint final=${FINAL_HASH} c_height=${C_HEIGHT} c_tip=${C_TIP}" >&2
   exit 1
 }
 BLOCK_JSON="$(rpc_json GET "${A_RPC_ADDR}" "/get_block?height=${TARGET_HEIGHT}")"
 printf '%s' "${BLOCK_JSON}" | python3 -c 'import json,sys; d=json.load(sys.stdin); assert sys.argv[1].lower() in d["block_hex"].lower()' "${TX_HEX}"
 
-export REPORT_JSON TARGET_HEIGHT BASE_HEIGHT B_HEIGHT C_HEIGHT A_PID B_PID C_PID A_RPC_ADDR B_RPC_ADDR C_RPC_ADDR TX_ID FINAL_HASH TX_COUNT
+export REPORT_JSON TARGET_HEIGHT BASE_HEIGHT A_HEIGHT B_HEIGHT C_HEIGHT A_TIP B_TIP C_TIP A_PID B_PID C_PID A_RPC_ADDR B_RPC_ADDR C_RPC_ADDR TX_ID FINAL_HASH TX_COUNT
 python3 - <<'PY'
 import json, os
 report = {
@@ -176,9 +184,9 @@ report = {
   "target_height": int(os.environ["TARGET_HEIGHT"]),
   "base_height": int(os.environ["BASE_HEIGHT"]),
   "participants": [
-    {"name": "node-a", "pid": int(os.environ["A_PID"]), "rpc": os.environ["A_RPC_ADDR"], "checkpoint_height": int(os.environ["TARGET_HEIGHT"])},
-    {"name": "node-b", "pid": int(os.environ["B_PID"]), "rpc": os.environ["B_RPC_ADDR"], "checkpoint_height": int(os.environ["B_HEIGHT"])},
-    {"name": "node-c", "pid": int(os.environ["C_PID"]), "rpc": os.environ["C_RPC_ADDR"], "checkpoint_height": int(os.environ["C_HEIGHT"])},
+    {"name": "node-a", "pid": int(os.environ["A_PID"]), "rpc": os.environ["A_RPC_ADDR"], "checkpoint_height": int(os.environ["A_HEIGHT"]), "tip_hash": os.environ["A_TIP"]},
+    {"name": "node-b", "pid": int(os.environ["B_PID"]), "rpc": os.environ["B_RPC_ADDR"], "checkpoint_height": int(os.environ["B_HEIGHT"]), "tip_hash": os.environ["B_TIP"]},
+    {"name": "node-c", "pid": int(os.environ["C_PID"]), "rpc": os.environ["C_RPC_ADDR"], "checkpoint_height": int(os.environ["C_HEIGHT"]), "tip_hash": os.environ["C_TIP"]},
   ],
   "tx": {"id": os.environ["TX_ID"], "submission": "rpc:/submit_tx"},
   "final": {"height": int(os.environ["TARGET_HEIGHT"]), "tip_hash": os.environ["FINAL_HASH"], "tx_count": int(os.environ["TX_COUNT"])},

--- a/scripts/devnet-go-binary-soak.sh
+++ b/scripts/devnet-go-binary-soak.sh
@@ -54,25 +54,28 @@ MINE_LOG="${RUBIN_PROCESS_ARTIFACT_ROOT}/mine-base.log"
 rpc_json() {
   local method="$1" addr="$2" path="$3" body="${4:-}"
   python3 - "${method}" "${addr}" "${path}" "${body}" <<'PY'
-import json, sys, urllib.request
+import sys, urllib.error, urllib.request
 method, addr, path, body = sys.argv[1:5]
 data = body.encode() if body else None
 req = urllib.request.Request(f"http://{addr}{path}", data=data, method=method)
 if body:
     req.add_header("Content-Type", "application/json")
-with urllib.request.urlopen(req, timeout=5) as resp:
+try:
+    resp = urllib.request.urlopen(req, timeout=5)
+except urllib.error.HTTPError as exc:
+    print(exc.read().decode("utf-8"), end="")
+    sys.exit(22)
+with resp:
     print(resp.read().decode("utf-8"), end="")
 PY
 }
 
-json_key() {
-  python3 -c 'import json,sys; d=json.load(sys.stdin)
-for p in sys.argv[1].split("."): d=d[p]
-print(d)' "$1"
-}
-
 tip_tsv() {
   rpc_json GET "$1" /get_tip | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d["height"], d["tip_hash"], sep="\t")'
+}
+
+metric_value() {
+  rpc_json GET "$1" /metrics | awk -v name="$2" '$1 == name {print int($2); found=1} END {exit !found}'
 }
 
 wait_height() {
@@ -145,10 +148,8 @@ echo "Submitting tx through Go RPC and mining it through /mine_next"
 TX_HEX="$("${TXGEN_BIN}" --datadir "${A_DIR}" --from-key "${FROM_DER_HEX}" --to-key "${TO_ADDRESS_HEX}" --amount 1 --fee 1 --submit-to "${A_RPC_ADDR}")"
 MEMPOOL_JSON="$(rpc_json GET "${A_RPC_ADDR}" /get_mempool)"
 TX_ID="$(printf '%s' "${MEMPOOL_JSON}" | python3 -c 'import json,sys; d=json.load(sys.stdin); assert d["count"] == 1; print(d["txids"][0])')"
-MINE_JSON="$(rpc_json POST "${A_RPC_ADDR}" /mine_next '{}')"
-FINAL_HEIGHT="$(printf '%s' "${MINE_JSON}" | json_key height)"
-FINAL_HASH="$(printf '%s' "${MINE_JSON}" | json_key block_hash)"
-TX_COUNT="$(printf '%s' "${MINE_JSON}" | json_key tx_count)"
+if ! MINE_JSON="$(rpc_json POST "${A_RPC_ADDR}" /mine_next '{}')"; then echo "mine_next request failed: ${MINE_JSON}" >&2; exit 1; fi
+IFS=$'\t' read -r FINAL_HEIGHT FINAL_HASH TX_COUNT < <(printf '%s' "${MINE_JSON}" | python3 -c 'import json,sys; d=json.load(sys.stdin); (d.get("mined") is True) or sys.exit("mine_next failed: "+str(d.get("error","missing mined result"))); print(d["height"], d["block_hash"], d["tx_count"], sep="\t")')
 [[ "${FINAL_HEIGHT}" == "${TARGET_HEIGHT}" && "${TX_COUNT}" -ge 2 ]] || {
   echo "unexpected mine_next result height=${FINAL_HEIGHT} tx_count=${TX_COUNT}" >&2
   exit 1
@@ -157,22 +158,19 @@ wait_height "${A_RPC_ADDR}" "${TARGET_HEIGHT}" 30
 IFS=$'\t' read -r A_HEIGHT A_TIP < <(tip_tsv "${A_RPC_ADDR}")
 IFS=$'\t' read -r B_HEIGHT B_TIP < <(tip_tsv "${B_RPC_ADDR}")
 IFS=$'\t' read -r C_HEIGHT C_TIP < <(tip_tsv "${C_RPC_ADDR}")
+A_PEERS="$(metric_value "${A_RPC_ADDR}" rubin_node_peer_count)" B_PEERS="$(metric_value "${B_RPC_ADDR}" rubin_node_peer_count)" C_PEERS="$(metric_value "${C_RPC_ADDR}" rubin_node_peer_count)"
 [[ "${A_HEIGHT}" == "${TARGET_HEIGHT}" && "${A_TIP}" == "${FINAL_HASH}" ]] || {
   echo "unexpected node-a checkpoint final=${FINAL_HASH} a_height=${A_HEIGHT} a_tip=${A_TIP}" >&2
   exit 1
 }
-[[ ("${B_HEIGHT}" == "${BASE_HEIGHT}" && -n "${B_TIP}") || ("${B_HEIGHT}" == "${TARGET_HEIGHT}" && "${B_TIP}" == "${FINAL_HASH}") ]] || {
-  echo "unexpected node-b checkpoint final=${FINAL_HASH} b_height=${B_HEIGHT} b_tip=${B_TIP}" >&2
-  exit 1
-}
-[[ ("${C_HEIGHT}" == "${BASE_HEIGHT}" && -n "${C_TIP}") || ("${C_HEIGHT}" == "${TARGET_HEIGHT}" && "${C_TIP}" == "${FINAL_HASH}") ]] || {
-  echo "unexpected node-c checkpoint final=${FINAL_HASH} c_height=${C_HEIGHT} c_tip=${C_TIP}" >&2
+[[ (("${B_HEIGHT}" == "${BASE_HEIGHT}" && -n "${B_TIP}") || ("${B_HEIGHT}" == "${TARGET_HEIGHT}" && "${B_TIP}" == "${FINAL_HASH}")) && (("${C_HEIGHT}" == "${BASE_HEIGHT}" && -n "${C_TIP}") || ("${C_HEIGHT}" == "${TARGET_HEIGHT}" && "${C_TIP}" == "${FINAL_HASH}")) && "${A_PEERS}" -ge 2 && "${B_PEERS}" -ge 1 && "${C_PEERS}" -ge 1 ]] || {
+  echo "unexpected peer checkpoint/connectivity final=${FINAL_HASH} b_height=${B_HEIGHT} c_height=${C_HEIGHT} peers=${A_PEERS}/${B_PEERS}/${C_PEERS}" >&2
   exit 1
 }
 BLOCK_JSON="$(rpc_json GET "${A_RPC_ADDR}" "/get_block?height=${TARGET_HEIGHT}")"
 printf '%s' "${BLOCK_JSON}" | python3 -c 'import json,sys; d=json.load(sys.stdin); assert sys.argv[1].lower() in d["block_hex"].lower()' "${TX_HEX}"
 
-export REPORT_JSON TARGET_HEIGHT BASE_HEIGHT A_HEIGHT B_HEIGHT C_HEIGHT A_TIP B_TIP C_TIP A_PID B_PID C_PID A_RPC_ADDR B_RPC_ADDR C_RPC_ADDR TX_ID FINAL_HASH TX_COUNT
+export REPORT_JSON TARGET_HEIGHT BASE_HEIGHT A_HEIGHT B_HEIGHT C_HEIGHT A_TIP B_TIP C_TIP A_PID B_PID C_PID A_RPC_ADDR B_RPC_ADDR C_RPC_ADDR A_PEERS B_PEERS C_PEERS TX_ID FINAL_HASH TX_COUNT
 python3 - <<'PY'
 import json, os
 report = {
@@ -180,9 +178,9 @@ report = {
   "target_height": int(os.environ["TARGET_HEIGHT"]),
   "base_height": int(os.environ["BASE_HEIGHT"]),
   "participants": [
-    {"name": "node-a", "pid": int(os.environ["A_PID"]), "rpc": os.environ["A_RPC_ADDR"], "checkpoint_height": int(os.environ["A_HEIGHT"]), "tip_hash": os.environ["A_TIP"]},
-    {"name": "node-b", "pid": int(os.environ["B_PID"]), "rpc": os.environ["B_RPC_ADDR"], "checkpoint_height": int(os.environ["B_HEIGHT"]), "tip_hash": os.environ["B_TIP"]},
-    {"name": "node-c", "pid": int(os.environ["C_PID"]), "rpc": os.environ["C_RPC_ADDR"], "checkpoint_height": int(os.environ["C_HEIGHT"]), "tip_hash": os.environ["C_TIP"]},
+    {"name": "node-a", "pid": int(os.environ["A_PID"]), "rpc": os.environ["A_RPC_ADDR"], "checkpoint_height": int(os.environ["A_HEIGHT"]), "tip_hash": os.environ["A_TIP"], "peer_count": int(os.environ["A_PEERS"])},
+    {"name": "node-b", "pid": int(os.environ["B_PID"]), "rpc": os.environ["B_RPC_ADDR"], "checkpoint_height": int(os.environ["B_HEIGHT"]), "tip_hash": os.environ["B_TIP"], "peer_count": int(os.environ["B_PEERS"])},
+    {"name": "node-c", "pid": int(os.environ["C_PID"]), "rpc": os.environ["C_RPC_ADDR"], "checkpoint_height": int(os.environ["C_HEIGHT"]), "tip_hash": os.environ["C_TIP"], "peer_count": int(os.environ["C_PEERS"])},
   ],
   "tx": {"id": os.environ["TX_ID"], "submission": "rpc:/submit_tx"},
   "final": {"height": int(os.environ["TARGET_HEIGHT"]), "tip_hash": os.environ["FINAL_HASH"], "tx_count": int(os.environ["TX_COUNT"])},

--- a/scripts/devnet-go-binary-soak.sh
+++ b/scripts/devnet-go-binary-soak.sh
@@ -44,13 +44,11 @@ KEYGEN_GO="${RUBIN_PROCESS_ARTIFACT_ROOT}/keygen.go"
 KEYGEN_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/keygen.json"
 REPORT_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/go-binary-soak-report.json"
 BASE_HEIGHT=$((TARGET_HEIGHT - 1))
-BASE_MINE_BLOCKS="${TARGET_HEIGHT}"
+BASE_MINE_BLOCKS=$((BASE_HEIGHT + 1))
 A_DIR="${RUBIN_PROCESS_ARTIFACT_ROOT}/node-a"
 B_DIR="${RUBIN_PROCESS_ARTIFACT_ROOT}/node-b"
 C_DIR="${RUBIN_PROCESS_ARTIFACT_ROOT}/node-c"
-A_LOG="node-a.log"
-B_LOG="node-b.log"
-C_LOG="node-c.log"
+A_LOG="node-a.log" B_LOG="node-b.log" C_LOG="node-c.log"
 MINE_LOG="${RUBIN_PROCESS_ARTIFACT_ROOT}/mine-base.log"
 
 rpc_json() {
@@ -194,4 +192,8 @@ with open(os.environ["REPORT_JSON"], "w", encoding="utf-8") as f:
     json.dump(report, f, indent=2, sort_keys=True)
     f.write("\n")
 PY
-echo "PASS: Go binary soak reached height ${TARGET_HEIGHT} with tx ${TX_ID}; report=${REPORT_JSON}"
+if [[ "${RUBIN_PROCESS_KEEP_ARTIFACTS}" == "1" ]]; then
+  echo "PASS: Go binary soak reached height ${TARGET_HEIGHT} with tx ${TX_ID}; report=${REPORT_JSON}"
+else
+  echo "PASS: Go binary soak reached height ${TARGET_HEIGHT} with tx ${TX_ID}; set KEEP_TMP=1 to retain report"
+fi

--- a/scripts/devnet-go-binary-soak.sh
+++ b/scripts/devnet-go-binary-soak.sh
@@ -25,7 +25,8 @@ while (($#)); do
       ;;
   esac
 done
-[[ "${TARGET_HEIGHT}" =~ ^[0-9]+$ && "${TARGET_HEIGHT}" -ge 102 ]] || { echo "--target-height must be an integer >= 102" >&2; exit 2; }
+# Runtime txgen needs base height >=100; target 100 has no mature spend.
+[[ "${TARGET_HEIGHT}" =~ ^[0-9]+$ && "${TARGET_HEIGHT}" -ge 101 ]] || { echo "--target-height must be an integer >= 101" >&2; exit 2; }
 # shellcheck source=scripts/devnet-process-common.sh disable=SC1091
 source "${HELPER}"
 rubin_process_init go-binary-soak
@@ -141,8 +142,8 @@ for addr in "${A_RPC_ADDR}" "${B_RPC_ADDR}" "${C_RPC_ADDR}"; do rubin_process_wa
 for addr in "${A_RPC_ADDR}" "${B_RPC_ADDR}" "${C_RPC_ADDR}"; do wait_height "${addr}" "${BASE_HEIGHT}" 30; done
 echo "Submitting tx through Go RPC and mining it through /mine_next"
 TX_HEX="$("${TXGEN_BIN}" --datadir "${A_DIR}" --from-key "${FROM_DER_HEX}" --to-key "${TO_ADDRESS_HEX}" --amount 1 --fee 1 --submit-to "${A_RPC_ADDR}")"
-MEMPOOL_JSON="$(rpc_json GET "${A_RPC_ADDR}" /get_mempool)"
-TX_ID="$(printf '%s' "${MEMPOOL_JSON}" | python3 -c 'import json,sys; d=json.load(sys.stdin); assert d["count"] == 1; print(d["txids"][0])')"
+if ! MEMPOOL_JSON="$(rpc_json GET "${A_RPC_ADDR}" /get_mempool)"; then echo "get_mempool request failed: ${MEMPOOL_JSON}" >&2; exit 1; fi
+TX_ID="$(printf '%s' "${MEMPOOL_JSON}" | python3 -c 'import json,sys; d=json.load(sys.stdin); (d.get("count") == 1 and d.get("txids")) or sys.exit("expected mempool count=1; mempool_json="+json.dumps(d, sort_keys=True)); print(d["txids"][0])')"
 if ! MINE_JSON="$(rpc_json POST "${A_RPC_ADDR}" /mine_next '{}')"; then echo "mine_next request failed: ${MINE_JSON}" >&2; exit 1; fi
 IFS=$'\t' read -r FINAL_HEIGHT FINAL_HASH TX_COUNT < <(printf '%s' "${MINE_JSON}" | python3 -c 'import json,sys; d=json.load(sys.stdin); (d.get("mined") is True) or sys.exit("mine_next failed: "+str(d.get("error","missing mined result"))); print(d["height"], d["block_hash"], d["tx_count"], sep="\t")')
 [[ "${FINAL_HEIGHT}" == "${TARGET_HEIGHT}" && "${TX_COUNT}" -ge 2 ]] || {
@@ -153,9 +154,7 @@ wait_height "${A_RPC_ADDR}" "${TARGET_HEIGHT}" 30
 IFS=$'\t' read -r A_HEIGHT A_TIP < <(tip_tsv "${A_RPC_ADDR}")
 IFS=$'\t' read -r B_HEIGHT B_TIP < <(tip_tsv "${B_RPC_ADDR}")
 IFS=$'\t' read -r C_HEIGHT C_TIP < <(tip_tsv "${C_RPC_ADDR}")
-A_PEERS="$(wait_peers "${A_RPC_ADDR}" 2 30)"
-B_PEERS="$(wait_peers "${B_RPC_ADDR}" 1 30)"
-C_PEERS="$(wait_peers "${C_RPC_ADDR}" 1 30)"
+A_PEERS="$(wait_peers "${A_RPC_ADDR}" 2 30)" B_PEERS="$(wait_peers "${B_RPC_ADDR}" 1 30)" C_PEERS="$(wait_peers "${C_RPC_ADDR}" 1 30)"
 [[ "${A_HEIGHT}" == "${TARGET_HEIGHT}" && "${A_TIP}" == "${FINAL_HASH}" ]] || {
   echo "unexpected node-a checkpoint final=${FINAL_HASH} a_height=${A_HEIGHT} a_tip=${A_TIP}" >&2
   exit 1
@@ -165,7 +164,7 @@ C_PEERS="$(wait_peers "${C_RPC_ADDR}" 1 30)"
   exit 1
 }
 BLOCK_JSON="$(rpc_json GET "${A_RPC_ADDR}" "/get_block?height=${TARGET_HEIGHT}")"
-printf '%s' "${BLOCK_JSON}" | python3 -c 'import json,sys; d=json.load(sys.stdin); assert sys.argv[1].lower() in d["block_hex"].lower()' "${TX_HEX}"
+printf '%s' "${BLOCK_JSON}" | python3 -c 'import json,sys; d=json.load(sys.stdin); sys.argv[1].lower() in d.get("block_hex", "").lower() or sys.exit("submitted tx bytes missing from target block")' "${TX_HEX}"
 export REPORT_JSON TARGET_HEIGHT BASE_HEIGHT A_HEIGHT B_HEIGHT C_HEIGHT A_TIP B_TIP C_TIP A_PID B_PID C_PID A_RPC_ADDR B_RPC_ADDR C_RPC_ADDR A_PEERS B_PEERS C_PEERS TX_ID FINAL_HASH TX_COUNT
 python3 - <<'PY'
 import json, os

--- a/scripts/devnet-go-binary-soak.sh
+++ b/scripts/devnet-go-binary-soak.sh
@@ -7,10 +7,7 @@ GO_MODULE_ROOT="${REPO_ROOT}/clients/go"
 HELPER="${REPO_ROOT}/scripts/devnet-process-common.sh"
 TARGET_HEIGHT=120
 
-usage() {
-  echo "usage: $0 [--target-height N]" >&2
-}
-
+usage() { echo "usage: $0 [--target-height N]" >&2; }
 while (($#)); do
   case "$1" in
     --target-height)
@@ -28,16 +25,10 @@ while (($#)); do
       ;;
   esac
 done
-
-[[ "${TARGET_HEIGHT}" =~ ^[0-9]+$ && "${TARGET_HEIGHT}" -ge 102 ]] || {
-  echo "--target-height must be an integer >= 102" >&2
-  exit 2
-}
-
+[[ "${TARGET_HEIGHT}" =~ ^[0-9]+$ && "${TARGET_HEIGHT}" -ge 102 ]] || { echo "--target-height must be an integer >= 102" >&2; exit 2; }
 # shellcheck source=scripts/devnet-process-common.sh disable=SC1091
 source "${HELPER}"
 rubin_process_init go-binary-soak
-
 NODE_BIN="${RUBIN_PROCESS_ARTIFACT_ROOT}/rubin-node-go"
 TXGEN_BIN="${RUBIN_PROCESS_ARTIFACT_ROOT}/rubin-txgen"
 KEYGEN_GO="${RUBIN_PROCESS_ARTIFACT_ROOT}/keygen.go"
@@ -50,7 +41,7 @@ B_DIR="${RUBIN_PROCESS_ARTIFACT_ROOT}/node-b"
 C_DIR="${RUBIN_PROCESS_ARTIFACT_ROOT}/node-c"
 A_LOG="node-a.log" B_LOG="node-b.log" C_LOG="node-c.log"
 MINE_LOG="${RUBIN_PROCESS_ARTIFACT_ROOT}/mine-base.log"
-
+RUBIN_PROCESS_LOGS+=("${MINE_LOG}")
 rpc_json() {
   local method="$1" addr="$2" path="$3" body="${4:-}"
   python3 - "${method}" "${addr}" "${path}" "${body}" <<'PY'
@@ -69,15 +60,12 @@ with resp:
     print(resp.read().decode("utf-8"), end="")
 PY
 }
-
 tip_tsv() {
   rpc_json GET "$1" /get_tip | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d["height"], d["tip_hash"], sep="\t")'
 }
-
 metric_value() {
   rpc_json GET "$1" /metrics | awk -v name="$2" '$1 == name {print int($2); found=1} END {exit !found}'
 }
-
 wait_height() {
   local addr="$1" want="$2" timeout="$3" height hash
   local deadline=$((SECONDS + timeout))
@@ -90,7 +78,19 @@ wait_height() {
   echo "timeout waiting for ${addr} height=${want}" >&2
   return 1
 }
-
+wait_peers() {
+  local addr="$1" want="$2" timeout="$3" value
+  local deadline=$((SECONDS + timeout))
+  while ((SECONDS < deadline)); do
+    if value="$(metric_value "${addr}" rubin_node_peer_count 2>/dev/null)" && [[ "${value}" =~ ^[0-9]+$ && "${value}" -ge "${want}" ]]; then
+      printf '%s\n' "${value}"
+      return 0
+    fi
+    sleep 1
+  done
+  echo "timeout waiting for ${addr} peer_count>=${want}" >&2
+  return 1
+}
 write_keygen() {
   cat >"${KEYGEN_GO}" <<'EOF'
 package main
@@ -108,7 +108,6 @@ func main() {
 }
 EOF
 }
-
 echo "Building Go rubin-node and rubin-txgen"
 "${DEV_ENV}" -- go -C "${GO_MODULE_ROOT}" build -o "${NODE_BIN}" ./cmd/rubin-node
 "${DEV_ENV}" -- go -C "${GO_MODULE_ROOT}" build -o "${TXGEN_BIN}" ./cmd/rubin-txgen
@@ -117,13 +116,11 @@ write_keygen
 FROM_DER_HEX="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["from_der_hex"])' "${KEYGEN_JSON}")"
 MINE_ADDRESS_HEX="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["mine_address_hex"])' "${KEYGEN_JSON}")"
 TO_ADDRESS_HEX="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["to_address_hex"])' "${KEYGEN_JSON}")"
-
 mkdir -p "${A_DIR}" "${B_DIR}" "${C_DIR}"
 echo "Mining mature Go chain to height ${BASE_HEIGHT}"
 "${NODE_BIN}" --datadir "${A_DIR}" --mine-address "${MINE_ADDRESS_HEX}" --mine-blocks "${BASE_MINE_BLOCKS}" --mine-exit >"${MINE_LOG}" 2>&1
 cp -R "${A_DIR}/." "${B_DIR}/"
 cp -R "${A_DIR}/." "${C_DIR}/"
-
 echo "Starting three Go rubin-node processes"
 A_PID=""
 for _ in 1 2 3; do
@@ -136,14 +133,12 @@ rubin_process_start "${B_LOG}" "${NODE_BIN}" --datadir "${B_DIR}" --bind 127.0.0
 B_PID="${RUBIN_PROCESS_LAST_PID}"
 rubin_process_start "${C_LOG}" "${NODE_BIN}" --datadir "${C_DIR}" --bind 127.0.0.1:0 --rpc-bind 127.0.0.1:0 --peers "${A_P2P_ADDR}" --mine-address "${MINE_ADDRESS_HEX}"
 C_PID="${RUBIN_PROCESS_LAST_PID}"
-
 rubin_process_wait_for_log "${B_LOG}" "rpc: listening=" 30 "${B_PID}"
 B_RPC_ADDR="$(rubin_process_extract_rpc_addr "${B_LOG}")"
 rubin_process_wait_for_log "${C_LOG}" "rpc: listening=" 30 "${C_PID}"
 C_RPC_ADDR="$(rubin_process_extract_rpc_addr "${C_LOG}")"
 for addr in "${A_RPC_ADDR}" "${B_RPC_ADDR}" "${C_RPC_ADDR}"; do rubin_process_wait_for_rpc_ready "${addr}" 30; done
 for addr in "${A_RPC_ADDR}" "${B_RPC_ADDR}" "${C_RPC_ADDR}"; do wait_height "${addr}" "${BASE_HEIGHT}" 30; done
-
 echo "Submitting tx through Go RPC and mining it through /mine_next"
 TX_HEX="$("${TXGEN_BIN}" --datadir "${A_DIR}" --from-key "${FROM_DER_HEX}" --to-key "${TO_ADDRESS_HEX}" --amount 1 --fee 1 --submit-to "${A_RPC_ADDR}")"
 MEMPOOL_JSON="$(rpc_json GET "${A_RPC_ADDR}" /get_mempool)"
@@ -158,7 +153,9 @@ wait_height "${A_RPC_ADDR}" "${TARGET_HEIGHT}" 30
 IFS=$'\t' read -r A_HEIGHT A_TIP < <(tip_tsv "${A_RPC_ADDR}")
 IFS=$'\t' read -r B_HEIGHT B_TIP < <(tip_tsv "${B_RPC_ADDR}")
 IFS=$'\t' read -r C_HEIGHT C_TIP < <(tip_tsv "${C_RPC_ADDR}")
-A_PEERS="$(metric_value "${A_RPC_ADDR}" rubin_node_peer_count)" B_PEERS="$(metric_value "${B_RPC_ADDR}" rubin_node_peer_count)" C_PEERS="$(metric_value "${C_RPC_ADDR}" rubin_node_peer_count)"
+A_PEERS="$(wait_peers "${A_RPC_ADDR}" 2 30)"
+B_PEERS="$(wait_peers "${B_RPC_ADDR}" 1 30)"
+C_PEERS="$(wait_peers "${C_RPC_ADDR}" 1 30)"
 [[ "${A_HEIGHT}" == "${TARGET_HEIGHT}" && "${A_TIP}" == "${FINAL_HASH}" ]] || {
   echo "unexpected node-a checkpoint final=${FINAL_HASH} a_height=${A_HEIGHT} a_tip=${A_TIP}" >&2
   exit 1
@@ -169,29 +166,15 @@ A_PEERS="$(metric_value "${A_RPC_ADDR}" rubin_node_peer_count)" B_PEERS="$(metri
 }
 BLOCK_JSON="$(rpc_json GET "${A_RPC_ADDR}" "/get_block?height=${TARGET_HEIGHT}")"
 printf '%s' "${BLOCK_JSON}" | python3 -c 'import json,sys; d=json.load(sys.stdin); assert sys.argv[1].lower() in d["block_hex"].lower()' "${TX_HEX}"
-
 export REPORT_JSON TARGET_HEIGHT BASE_HEIGHT A_HEIGHT B_HEIGHT C_HEIGHT A_TIP B_TIP C_TIP A_PID B_PID C_PID A_RPC_ADDR B_RPC_ADDR C_RPC_ADDR A_PEERS B_PEERS C_PEERS TX_ID FINAL_HASH TX_COUNT
 python3 - <<'PY'
 import json, os
-report = {
-  "scenario": "go_binary_soak_skeleton",
-  "target_height": int(os.environ["TARGET_HEIGHT"]),
-  "base_height": int(os.environ["BASE_HEIGHT"]),
-  "participants": [
-    {"name": "node-a", "pid": int(os.environ["A_PID"]), "rpc": os.environ["A_RPC_ADDR"], "checkpoint_height": int(os.environ["A_HEIGHT"]), "tip_hash": os.environ["A_TIP"], "peer_count": int(os.environ["A_PEERS"])},
-    {"name": "node-b", "pid": int(os.environ["B_PID"]), "rpc": os.environ["B_RPC_ADDR"], "checkpoint_height": int(os.environ["B_HEIGHT"]), "tip_hash": os.environ["B_TIP"], "peer_count": int(os.environ["B_PEERS"])},
-    {"name": "node-c", "pid": int(os.environ["C_PID"]), "rpc": os.environ["C_RPC_ADDR"], "checkpoint_height": int(os.environ["C_HEIGHT"]), "tip_hash": os.environ["C_TIP"], "peer_count": int(os.environ["C_PEERS"])},
-  ],
-  "tx": {"id": os.environ["TX_ID"], "submission": "rpc:/submit_tx"},
-  "final": {"height": int(os.environ["TARGET_HEIGHT"]), "tip_hash": os.environ["FINAL_HASH"], "tx_count": int(os.environ["TX_COUNT"])},
-  "verdict": "PASS",
-}
+participants = []
+for node in ("A", "B", "C"):
+    participants.append({"name": f"node-{node.lower()}", "pid": int(os.environ[f"{node}_PID"]), "rpc": os.environ[f"{node}_RPC_ADDR"], "checkpoint_height": int(os.environ[f"{node}_HEIGHT"]), "tip_hash": os.environ[f"{node}_TIP"], "peer_count": int(os.environ[f"{node}_PEERS"])})
+report = {"scenario": "go_binary_soak_skeleton", "target_height": int(os.environ["TARGET_HEIGHT"]), "base_height": int(os.environ["BASE_HEIGHT"]), "participants": participants, "tx": {"id": os.environ["TX_ID"], "submission": "rpc:/submit_tx"}, "final": {"height": int(os.environ["TARGET_HEIGHT"]), "tip_hash": os.environ["FINAL_HASH"], "tx_count": int(os.environ["TX_COUNT"])}, "verdict": "PASS"}
 with open(os.environ["REPORT_JSON"], "w", encoding="utf-8") as f:
     json.dump(report, f, indent=2, sort_keys=True)
     f.write("\n")
 PY
-if [[ "${RUBIN_PROCESS_KEEP_ARTIFACTS}" == "1" ]]; then
-  echo "PASS: Go binary soak reached height ${TARGET_HEIGHT} with tx ${TX_ID}; report=${REPORT_JSON}"
-else
-  echo "PASS: Go binary soak reached height ${TARGET_HEIGHT} with tx ${TX_ID}; set KEEP_TMP=1 to retain report"
-fi
+if [[ "${RUBIN_PROCESS_KEEP_ARTIFACTS}" == "1" ]]; then echo "PASS: Go binary soak reached height ${TARGET_HEIGHT} with tx ${TX_ID}; report=${REPORT_JSON}"; else echo "PASS: Go binary soak reached height ${TARGET_HEIGHT} with tx ${TX_ID}; set KEEP_TMP=1 to retain report"; fi


### PR DESCRIPTION
## Scope
- Q-IMPL-GO-DEVNET-BINARY-SOAK-SKELETON-01 / issue #1229.
- Add `scripts/devnet-go-binary-soak.sh` for the Go-only binary soak skeleton.
- Build Go `rubin-node` and `rubin-txgen` binaries.
- Mine a mature Go base chain through the binary path.
- Start three managed Go node processes with live RPC endpoints.
- Submit one tx through `/submit_tx` using `rubin-txgen --submit-to`.
- Mine inclusion through `/mine_next` on the live RPC surface.
- Verify inclusion through `/get_block` and emit process evidence/report when artifacts are retained.

## Out of scope
- Rust process scenario.
- Restart/recovery path.
- Mixed-client mesh or convergence claim.
- New consensus, RPC, or P2P contract.
- Direct mempool/miner helper calls.
- Queue closeout.

<!-- rubin-agent-meta actor=codex action=pr-create branch=codex/q-impl-go-devnet-binary-soak-skeleton-01 -->
