### PR TITLE
fix(go): roll back threshold sig queue on validation errors

### DIFF
--- a/clients/go/consensus/sig_verify_batch.go
+++ b/clients/go/consensus/sig_verify_batch.go
@@ -109,6 +109,7 @@ func (q *SigCheckQueue) rollbackTo(mark sigCheckQueueMark) {
 	if q == nil || mark.len >= len(q.tasks) {
 		return
 	}
+	clear(q.tasks[mark.len:])
 	q.tasks = q.tasks[:mark.len]
 }
 

--- a/clients/go/consensus/sig_verify_batch.go
+++ b/clients/go/consensus/sig_verify_batch.go
@@ -38,6 +38,10 @@ type sigCheckTask struct {
 	errOnFail error // error to return if this verification fails
 }
 
+type sigCheckQueueMark struct {
+	len int
+}
+
 // NewSigCheckQueue creates a new signature check queue.
 // If workers <= 0, defaults to GOMAXPROCS.
 func NewSigCheckQueue(workers int) *SigCheckQueue {
@@ -92,6 +96,20 @@ func (q *SigCheckQueue) Len() int {
 		return 0
 	}
 	return len(q.tasks)
+}
+
+func (q *SigCheckQueue) mark() sigCheckQueueMark {
+	if q == nil {
+		return sigCheckQueueMark{}
+	}
+	return sigCheckQueueMark{len: len(q.tasks)}
+}
+
+func (q *SigCheckQueue) rollbackTo(mark sigCheckQueueMark) {
+	if q == nil || mark.len >= len(q.tasks) {
+		return
+	}
+	q.tasks = q.tasks[:mark.len]
 }
 
 // Panics returns the number of panics recovered during the last Flush.

--- a/clients/go/consensus/sig_verify_batch_test.go
+++ b/clients/go/consensus/sig_verify_batch_test.go
@@ -116,6 +116,38 @@ func TestSigCheckQueue_MultipleAllValid(t *testing.T) {
 	}
 }
 
+func TestSigCheckQueue_RollbackClearsDroppedTail(t *testing.T) {
+	q := NewSigCheckQueue(1)
+	firstPubkey := []byte{0x01}
+	firstSig := []byte{0x02}
+	droppedPubkey := []byte{0x03}
+	droppedSig := []byte{0x04}
+
+	q.Push(SUITE_ID_ML_DSA_87, firstPubkey, firstSig, [32]byte{0x11}, txerr(TX_ERR_SIG_INVALID, "keep"))
+	mark := q.mark()
+	q.Push(SUITE_ID_ML_DSA_87, droppedPubkey, droppedSig, [32]byte{0x22}, txerr(TX_ERR_SIG_INVALID, "drop"))
+
+	q.rollbackTo(mark)
+	if q.Len() != 1 {
+		t.Fatalf("expected rollback to preserve one task, got %d", q.Len())
+	}
+	if len(q.tasks[0].pubkey) == 0 || len(q.tasks[0].sig) == 0 || q.tasks[0].errOnFail == nil {
+		t.Fatal("rollback cleared preserved task")
+	}
+
+	backing := q.tasks[:cap(q.tasks)]
+	if len(backing) < 2 {
+		t.Fatalf("test requires retained backing slot, got cap %d", cap(q.tasks))
+	}
+	dropped := backing[1]
+	if dropped.pubkey != nil || dropped.sig != nil || dropped.errOnFail != nil {
+		t.Fatalf("rollback retained dropped task references: pubkey=%v sig=%v err=%v", dropped.pubkey, dropped.sig, dropped.errOnFail)
+	}
+	if dropped.suiteID != 0 || dropped.digest != ([32]byte{}) {
+		t.Fatalf("rollback retained dropped task values: suite=%d digest=%x", dropped.suiteID, dropped.digest)
+	}
+}
+
 func TestSigCheckQueue_DeterministicFirstError(t *testing.T) {
 	kp := mustMLDSA87Keypair(t)
 

--- a/clients/go/consensus/sig_verify_queued.go
+++ b/clients/go/consensus/sig_verify_queued.go
@@ -132,36 +132,41 @@ func validateThresholdSigSpendQ(
 
 	nativeSpend := rotation.NativeSpendSuites(blockHeight)
 	valid := 0
+	queueMark := sigQueue.mark()
+	rollbackOnError := func(err error) error {
+		sigQueue.rollbackTo(queueMark)
+		return err
+	}
 
 	for i := range keys {
 		w := ws[i]
 		if w.SuiteID == SUITE_ID_SENTINEL {
 			if len(w.Pubkey) != 0 || len(w.Signature) != 0 {
-				return txerr(TX_ERR_PARSE, "SENTINEL witness must be keyless")
+				return rollbackOnError(txerr(TX_ERR_PARSE, "SENTINEL witness must be keyless"))
 			}
 			continue
 		}
 
 		if !nativeSpend.Contains(w.SuiteID) {
-			return txerr(TX_ERR_SIG_ALG_INVALID, context+" suite not in native spend set")
+			return rollbackOnError(txerr(TX_ERR_SIG_ALG_INVALID, context+" suite not in native spend set"))
 		}
 
 		params, ok := registry.Lookup(w.SuiteID)
 		if !ok {
-			return txerr(TX_ERR_SIG_ALG_INVALID, context+" suite not registered")
+			return rollbackOnError(txerr(TX_ERR_SIG_ALG_INVALID, context+" suite not registered"))
 		}
 
 		if len(w.Pubkey) != params.PubkeyLen || len(w.Signature) != params.SigLen+1 {
-			return txerr(TX_ERR_SIG_NONCANONICAL, "non-canonical witness item lengths")
+			return rollbackOnError(txerr(TX_ERR_SIG_NONCANONICAL, "non-canonical witness item lengths"))
 		}
 
 		if err := verifyMLDSAKeyAndSigQ(w, keys[i], tx, inputIndex, inputValue, chainID, cache, sigQueue, registry, context); err != nil {
-			return err
+			return rollbackOnError(err)
 		}
 		valid++
 	}
 	if valid < int(threshold) {
-		return txerr(TX_ERR_SIG_INVALID, context+" threshold not met")
+		return rollbackOnError(txerr(TX_ERR_SIG_INVALID, context+" threshold not met"))
 	}
 	return nil
 }

--- a/clients/go/consensus/sig_verify_queued_test.go
+++ b/clients/go/consensus/sig_verify_queued_test.go
@@ -1,6 +1,7 @@
 package consensus
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -252,6 +253,164 @@ func TestValidateThresholdSigSpendQ_ThresholdNotMet(t *testing.T) {
 	}
 	if !isTxErrCode(err, TX_ERR_SIG_INVALID) {
 		t.Fatalf("expected TX_ERR_SIG_INVALID, got: %v", err)
+	}
+}
+
+func TestValidateThresholdSigSpendQ_RollbackOnThresholdFailure(t *testing.T) {
+	kp1 := mustMLDSA87Keypair(t)
+	kp2 := mustMLDSA87Keypair(t)
+	keyID1 := sha3_256(kp1.PubkeyBytes())
+	keyID2 := sha3_256(kp2.PubkeyBytes())
+
+	tx, inputIndex, inputValue, chainID := testSighashContextTx()
+	cache, _ := NewSighashV1PrehashCache(tx)
+	sig1 := signDigestWithSighashType(t, kp1, tx, inputIndex, inputValue, chainID, SIGHASH_ALL)
+
+	keys := [][32]byte{keyID1, keyID2}
+	ws := []WitnessItem{
+		{SuiteID: SUITE_ID_ML_DSA_87, Pubkey: kp1.PubkeyBytes(), Signature: sig1},
+		{SuiteID: SUITE_ID_SENTINEL, Pubkey: nil, Signature: nil},
+	}
+
+	q := NewSigCheckQueue(1)
+	err := validateThresholdSigSpendQ(keys, 2, ws, tx, inputIndex, inputValue, chainID, 0, cache, q, "TEST-MULTISIG", nil, nil)
+	if err == nil {
+		t.Fatal("expected threshold not met error")
+	}
+	if !isTxErrCode(err, TX_ERR_SIG_INVALID) {
+		t.Fatalf("expected TX_ERR_SIG_INVALID, got: %v", err)
+	}
+	if q.Len() != 0 {
+		t.Fatalf("expected rollback to clear threshold task, got %d queued tasks", q.Len())
+	}
+}
+
+func TestValidateThresholdSigSpendQ_RollbackPreservesExistingQueue(t *testing.T) {
+	existingKP := mustMLDSA87Keypair(t)
+	existingDigest := [32]byte{0xA5}
+	existingSig, err := existingKP.SignDigest32(existingDigest)
+	if err != nil {
+		t.Fatalf("existing sign: %v", err)
+	}
+
+	q := NewSigCheckQueue(1)
+	q.Push(SUITE_ID_ML_DSA_87, existingKP.PubkeyBytes(), existingSig, existingDigest, txerr(TX_ERR_SIG_INVALID, "existing invalid"))
+
+	kp1 := mustMLDSA87Keypair(t)
+	kp2 := mustMLDSA87Keypair(t)
+	keyID1 := sha3_256(kp1.PubkeyBytes())
+	keyID2 := sha3_256(kp2.PubkeyBytes())
+
+	tx, inputIndex, inputValue, chainID := testSighashContextTx()
+	cache, _ := NewSighashV1PrehashCache(tx)
+	sig1 := signDigestWithSighashType(t, kp1, tx, inputIndex, inputValue, chainID, SIGHASH_ALL)
+
+	keys := [][32]byte{keyID1, keyID2}
+	ws := []WitnessItem{
+		{SuiteID: SUITE_ID_ML_DSA_87, Pubkey: kp1.PubkeyBytes(), Signature: sig1},
+		{SuiteID: SUITE_ID_SENTINEL, Pubkey: nil, Signature: nil},
+	}
+
+	err = validateThresholdSigSpendQ(keys, 2, ws, tx, inputIndex, inputValue, chainID, 0, cache, q, "TEST-MULTISIG", nil, nil)
+	if err == nil {
+		t.Fatal("expected threshold not met error")
+	}
+	if q.Len() != 1 {
+		t.Fatalf("expected rollback to preserve prior task only, got %d queued tasks", q.Len())
+	}
+	if err := q.Flush(); err != nil {
+		t.Fatalf("prior queued task should still flush: %v", err)
+	}
+}
+
+func TestValidateThresholdSigSpendQ_RollbackOnLateThresholdErrors(t *testing.T) {
+	kp1 := mustMLDSA87Keypair(t)
+	kp2 := mustMLDSA87Keypair(t)
+	keyID1 := sha3_256(kp1.PubkeyBytes())
+	keyID2 := sha3_256(kp2.PubkeyBytes())
+
+	tx, inputIndex, inputValue, chainID := testSighashContextTx()
+	cache, _ := NewSighashV1PrehashCache(tx)
+	sig1 := signDigestWithSighashType(t, kp1, tx, inputIndex, inputValue, chainID, SIGHASH_ALL)
+	sig2 := signDigestWithSighashType(t, kp2, tx, inputIndex, inputValue, chainID, SIGHASH_ALL)
+	invalidSighashSig := append([]byte(nil), sig2...)
+	invalidSighashSig[len(invalidSighashSig)-1] = 0x00
+
+	existingKP := mustMLDSA87Keypair(t)
+	existingDigest := [32]byte{0xA6}
+	existingSig, err := existingKP.SignDigest32(existingDigest)
+	if err != nil {
+		t.Fatalf("existing sign: %v", err)
+	}
+
+	validFirst := WitnessItem{SuiteID: SUITE_ID_ML_DSA_87, Pubkey: kp1.PubkeyBytes(), Signature: sig1}
+	tests := []struct {
+		name       string
+		keys       [][32]byte
+		second     WitnessItem
+		wantErr    ErrorCode
+		wantErrMsg string
+	}{
+		{
+			name:       "sentinel_with_data",
+			keys:       [][32]byte{keyID1, keyID2},
+			second:     WitnessItem{SuiteID: SUITE_ID_SENTINEL, Pubkey: []byte{0x01}, Signature: nil},
+			wantErr:    TX_ERR_PARSE,
+			wantErrMsg: "SENTINEL witness must be keyless",
+		},
+		{
+			name:       "invalid_suite",
+			keys:       [][32]byte{keyID1, keyID2},
+			second:     WitnessItem{SuiteID: 0xFE, Pubkey: kp2.PubkeyBytes(), Signature: sig2},
+			wantErr:    TX_ERR_SIG_ALG_INVALID,
+			wantErrMsg: "suite not in native spend set",
+		},
+		{
+			name:       "noncanonical_lengths",
+			keys:       [][32]byte{keyID1, keyID2},
+			second:     WitnessItem{SuiteID: SUITE_ID_ML_DSA_87, Pubkey: kp2.PubkeyBytes(), Signature: sig2[:ML_DSA_87_SIG_BYTES]},
+			wantErr:    TX_ERR_SIG_NONCANONICAL,
+			wantErrMsg: "non-canonical witness item lengths",
+		},
+		{
+			name:       "key_binding_mismatch",
+			keys:       [][32]byte{keyID1, [32]byte{0xEE}},
+			second:     WitnessItem{SuiteID: SUITE_ID_ML_DSA_87, Pubkey: kp2.PubkeyBytes(), Signature: sig2},
+			wantErr:    TX_ERR_SIG_INVALID,
+			wantErrMsg: "key binding mismatch",
+		},
+		{
+			name:       "invalid_sighash_type",
+			keys:       [][32]byte{keyID1, keyID2},
+			second:     WitnessItem{SuiteID: SUITE_ID_ML_DSA_87, Pubkey: kp2.PubkeyBytes(), Signature: invalidSighashSig},
+			wantErr:    TX_ERR_SIGHASH_TYPE_INVALID,
+			wantErrMsg: "invalid sighash_type",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			q := NewSigCheckQueue(1)
+			q.Push(SUITE_ID_ML_DSA_87, existingKP.PubkeyBytes(), existingSig, existingDigest, txerr(TX_ERR_SIG_INVALID, "existing invalid"))
+			preLen := q.Len()
+
+			err := validateThresholdSigSpendQ(tc.keys, 2, []WitnessItem{validFirst, tc.second}, tx, inputIndex, inputValue, chainID, 0, cache, q, "TEST-MULTISIG", nil, nil)
+			if err == nil {
+				t.Fatal("expected late threshold error")
+			}
+			if !isTxErrCode(err, tc.wantErr) {
+				t.Fatalf("expected %s, got: %v", tc.wantErr, err)
+			}
+			if tc.wantErrMsg != "" && !strings.Contains(err.Error(), tc.wantErrMsg) {
+				t.Fatalf("expected error containing %q, got: %v", tc.wantErrMsg, err)
+			}
+			if q.Len() != preLen {
+				t.Fatalf("expected rollback to pre-call queue length %d, got %d", preLen, q.Len())
+			}
+			if err := q.Flush(); err != nil {
+				t.Fatalf("pre-existing queued task should still flush: %v", err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Scope

Q-IMPL-CONSENSUS-SIG-QUEUE-ROLLBACK-PARITY-01 / #1190

- Architecture class: B
- System boundary: Go `clients/go/consensus` queued threshold signature validation and `SigCheckQueue` rollback semantics
- Single invariant: threshold-sig validation rollback removes only helper-local queued tasks, preserves older queued tasks, and clears dropped queue tail slots
- Changed surface: `sig_verify_batch.go`, `sig_verify_batch_test.go`, `sig_verify_queued.go`, `sig_verify_queued_test.go`
- Non-goals: no wire/schema/spec/conformance vector change; no Rust production change; no suite registry/cache/worker redesign; no threshold witness ordering redesign
- Class-change stop rule: parser/state-machine/public contract/cross-language redesign is out of scope

## Validation

Local Rubin gates and GitHub checks are green on the updated PR head.


<!-- rubin-agent-meta actor=Codex action=pr-edit via=cl branch=codex/q-impl-consensus-sig-queue-rollback-parity-01-clean wt=rubin-protocol-q1190 utc=2026-04-22T20:55:28Z -->
