### PR TITLE
Q-IMPL-CONSENSUS-POW-LENGTH-GUARD-ERROR-SURFACE-01

### DIFF
--- a/clients/go/consensus/pow.go
+++ b/clients/go/consensus/pow.go
@@ -102,6 +102,9 @@ func retargetV1WithActual(targetOld [32]byte, tActual uint64) ([32]byte, error) 
 
 // PowCheck verifies integer(block_hash, be) < integer(target, be).
 func PowCheck(headerBytes []byte, target [32]byte) error {
+	if len(headerBytes) != BLOCK_HEADER_BYTES {
+		return txerr(TX_ERR_PARSE, "pow: invalid header length")
+	}
 	targetInt := new(big.Int).SetBytes(target[:])
 	powLimit := new(big.Int).SetBytes(POW_LIMIT[:])
 	if targetInt.Sign() == 0 || targetInt.Cmp(powLimit) > 0 {

--- a/clients/go/consensus/pow_test.go
+++ b/clients/go/consensus/pow_test.go
@@ -2,6 +2,7 @@ package consensus
 
 import (
 	"encoding/hex"
+	"errors"
 	"math/big"
 	"testing"
 )
@@ -191,6 +192,49 @@ func TestPowCheck_TargetRangeInvalidZero(t *testing.T) {
 	}
 	if got := mustTxErrCode(t, err); got != BLOCK_ERR_TARGET_INVALID {
 		t.Fatalf("code=%s, want %s", got, BLOCK_ERR_TARGET_INVALID)
+	}
+}
+
+func TestPowCheck_HeaderLengthGuardSurface(t *testing.T) {
+	cases := []struct {
+		name   string
+		header []byte
+		target [32]byte
+	}{
+		{
+			name:   "short_valid_target",
+			header: make([]byte, BLOCK_HEADER_BYTES-1),
+			target: POW_LIMIT,
+		},
+		{
+			name:   "overlong_valid_target",
+			header: make([]byte, BLOCK_HEADER_BYTES+1),
+			target: POW_LIMIT,
+		},
+		{
+			name:   "short_zero_target",
+			header: make([]byte, BLOCK_HEADER_BYTES-1),
+			target: [32]byte{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := PowCheck(tc.header, tc.target)
+			if err == nil {
+				t.Fatalf("expected invalid header length error")
+			}
+			var te *TxError
+			if !errors.As(err, &te) {
+				t.Fatalf("expected *TxError, got %T: %v", err, err)
+			}
+			if te.Code != TX_ERR_PARSE {
+				t.Fatalf("code=%s, want %s", te.Code, TX_ERR_PARSE)
+			}
+			if te.Msg != "pow: invalid header length" {
+				t.Fatalf("msg=%q, want %q", te.Msg, "pow: invalid header length")
+			}
+		})
 	}
 }
 

--- a/clients/rust/crates/rubin-consensus/src/tests/tx_parse.rs
+++ b/clients/rust/crates/rubin-consensus/src/tests/tx_parse.rs
@@ -553,3 +553,28 @@ fn pow_check_strict_less() {
     let err = pow_check(&header, zero_target).unwrap_err();
     assert_eq!(err.code, ErrorCode::BlockErrTargetInvalid);
 }
+
+#[test]
+fn pow_check_rejects_invalid_header_length_before_target() {
+    for (name, header, target) in [
+        (
+            "short_valid_target",
+            vec![0u8; BLOCK_HEADER_BYTES - 1],
+            POW_LIMIT,
+        ),
+        (
+            "overlong_valid_target",
+            vec![0u8; BLOCK_HEADER_BYTES + 1],
+            POW_LIMIT,
+        ),
+        (
+            "short_zero_target",
+            vec![0u8; BLOCK_HEADER_BYTES - 1],
+            [0u8; 32],
+        ),
+    ] {
+        let err = pow_check(&header, target).unwrap_err();
+        assert_eq!(err.code, ErrorCode::TxErrParse, "{name}");
+        assert_eq!(err.msg, "pow: invalid header length", "{name}");
+    }
+}


### PR DESCRIPTION
Refs #1186

Architecture class: B
System boundary: Go PowCheck error ordering plus Go/Rust parity tests for PoW header-length rejection.
Single invariant or single contract delta: invalid PoW header length rejects before target/hash work with TX_ERR_PARSE and `pow: invalid header length`, matching Rust.
Non-goals: DA behavior, generic PoW redesign, BlockHash contract changes, conformance artifact changes, node/p2p runtime changes.
Class-change stop rule: any parser/state-machine/PoW redesign or cross-client contract widening stops this PR.
What this PR is NOT allowed to redesign: target/hash semantics, Rust runtime behavior, fixtures, protocol artifacts, CLI/lifecycle tooling.

<!-- rubin-agent-meta actor=Codex action=pr-create via=cl branch=codex/q-impl-consensus-pow-length-guard-error-surface-01 wt=rubin-protocol-q1186 utc=2026-04-22T22:05:03Z -->
