### PR TITLE
Q1188 nil covenant error parity

### DIFF
--- a/clients/go/consensus/coverage_hotspots_test.go
+++ b/clients/go/consensus/coverage_hotspots_test.go
@@ -1,6 +1,7 @@
 package consensus
 
 import (
+	"errors"
 	"math/big"
 	"testing"
 )
@@ -199,5 +200,77 @@ func TestCoverage_StealthBranches(t *testing.T) {
 	}
 	if err := validateCoreStealthSpend(entry, w, tx, 0, 1, [32]byte{}, 0); err == nil {
 		t.Fatalf("expected noncanonical witness rejection")
+	}
+}
+
+func TestCoverage_NilCovenantDataUsesGenericMalformedContext(t *testing.T) {
+	cases := []struct {
+		name    string
+		parse   func([]byte) error
+		code    ErrorCode
+		message string
+	}{
+		{
+			name: "htlc",
+			parse: func(covData []byte) error {
+				_, err := ParseHTLCCovenantData(covData)
+				return err
+			},
+			code:    TX_ERR_COVENANT_TYPE_INVALID,
+			message: "CORE_HTLC covenant_data length mismatch",
+		},
+		{
+			name: "vault",
+			parse: func(covData []byte) error {
+				_, err := ParseVaultCovenantData(covData)
+				return err
+			},
+			code:    TX_ERR_VAULT_MALFORMED,
+			message: "CORE_VAULT covenant_data too short",
+		},
+		{
+			name: "stealth",
+			parse: func(covData []byte) error {
+				_, err := ParseStealthCovenantData(covData)
+				return err
+			},
+			code:    TX_ERR_COVENANT_TYPE_INVALID,
+			message: "CORE_STEALTH covenant_data length mismatch",
+		},
+		{
+			name: "multisig",
+			parse: func(covData []byte) error {
+				_, err := ParseMultisigCovenantData(covData)
+				return err
+			},
+			code:    TX_ERR_COVENANT_TYPE_INVALID,
+			message: "CORE_MULTISIG covenant_data too short",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name+"/nil", func(t *testing.T) {
+			assertTxErrCodeMsg(t, tc.parse(nil), tc.code, tc.message)
+		})
+		t.Run(tc.name+"/empty", func(t *testing.T) {
+			assertTxErrCodeMsg(t, tc.parse([]byte{}), tc.code, tc.message)
+		})
+	}
+}
+
+func assertTxErrCodeMsg(t *testing.T, err error, code ErrorCode, message string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	var te *TxError
+	if !errors.As(err, &te) {
+		t.Fatalf("expected *TxError, got %T: %v", err, err)
+	}
+	if te.Code != code {
+		t.Fatalf("code=%s, want %s", te.Code, code)
+	}
+	if te.Msg != message {
+		t.Fatalf("msg=%q, want %q", te.Msg, message)
 	}
 }

--- a/clients/go/consensus/htlc.go
+++ b/clients/go/consensus/htlc.go
@@ -11,9 +11,6 @@ type HTLCCovenant struct {
 }
 
 func ParseHTLCCovenantData(covData []byte) (*HTLCCovenant, error) {
-	if covData == nil {
-		return nil, txerr(TX_ERR_COVENANT_TYPE_INVALID, "nil CORE_HTLC covenant_data")
-	}
 	if len(covData) != MAX_HTLC_COVENANT_DATA {
 		return nil, txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_HTLC covenant_data length mismatch")
 	}

--- a/clients/go/consensus/stealth.go
+++ b/clients/go/consensus/stealth.go
@@ -6,9 +6,6 @@ type StealthCovenant struct {
 }
 
 func ParseStealthCovenantData(covData []byte) (*StealthCovenant, error) {
-	if covData == nil {
-		return nil, txerr(TX_ERR_COVENANT_TYPE_INVALID, "nil CORE_STEALTH covenant_data")
-	}
 	if len(covData) != MAX_STEALTH_COVENANT_DATA {
 		return nil, txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_STEALTH covenant_data length mismatch")
 	}

--- a/clients/go/consensus/vault.go
+++ b/clients/go/consensus/vault.go
@@ -30,9 +30,6 @@ func ParseVaultCovenantDataForSpend(covData []byte) (*VaultCovenant, error) {
 }
 
 func parseVaultCovenantData(covData []byte, enforceWhitelistCanonical bool) (*VaultCovenant, error) {
-	if covData == nil {
-		return nil, txerr(TX_ERR_VAULT_MALFORMED, "nil CORE_VAULT covenant_data")
-	}
 	if len(covData) < 34 {
 		return nil, txerr(TX_ERR_VAULT_MALFORMED, "CORE_VAULT covenant_data too short")
 	}
@@ -92,9 +89,6 @@ func parseVaultCovenantData(covData []byte, enforceWhitelistCanonical bool) (*Va
 }
 
 func ParseMultisigCovenantData(covData []byte) (*MultisigCovenant, error) {
-	if covData == nil {
-		return nil, txerr(TX_ERR_COVENANT_TYPE_INVALID, "nil CORE_MULTISIG covenant_data")
-	}
 	if len(covData) < 34 {
 		return nil, txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_MULTISIG covenant_data too short")
 	}


### PR DESCRIPTION
Scope:
- Architecture class: B
- Boundary: Go consensus covenant parser error surface for HTLC, Vault, Stealth, and sibling Multisig.
- Invariant: nil covenant_data uses the same generic malformed/length error as empty covenant_data.
- Non-goals: Rust production changes, conformance vector changes, covenant redesign.

Closes #1188