### PR TITLE
Q-IMPL-CONSENSUS-OVERFLOW-DIAGNOSTICS-PARITY-01 (#1189): overflow diagnostics parity

### DIFF
--- a/clients/go/cmd/rubin-consensus-cli/runtime_test.go
+++ b/clients/go/cmd/rubin-consensus-cli/runtime_test.go
@@ -140,10 +140,6 @@ func runRawJSON(t *testing.T, raw []byte, entry func()) Response {
 	if err != nil {
 		t.Fatalf("pipe stdin: %v", err)
 	}
-	if _, err := wIn.Write(raw); err != nil {
-		t.Fatalf("write stdin: %v", err)
-	}
-	_ = wIn.Close()
 
 	rOut, wOut, err := os.Pipe()
 	if err != nil {
@@ -154,11 +150,26 @@ func runRawJSON(t *testing.T, raw []byte, entry func()) Response {
 	oldOut := os.Stdout
 	os.Stdin = rIn
 	os.Stdout = wOut
+	defer func() {
+		os.Stdin = oldIn
+		os.Stdout = oldOut
+		_ = rIn.Close()
+		_ = rOut.Close()
+	}()
 
 	outCh := make(chan []byte, 1)
 	go func() {
 		b, _ := io.ReadAll(rOut)
 		outCh <- b
+	}()
+
+	writeErrCh := make(chan error, 1)
+	go func() {
+		_, err := wIn.Write(raw)
+		if closeErr := wIn.Close(); err == nil {
+			err = closeErr
+		}
+		writeErrCh <- err
 	}()
 
 	entry()
@@ -171,10 +182,14 @@ func runRawJSON(t *testing.T, raw []byte, entry func()) Response {
 		t.Fatalf("timeout waiting for CLI output")
 	}
 
-	os.Stdin = oldIn
-	os.Stdout = oldOut
-	_ = rIn.Close()
-	_ = rOut.Close()
+	select {
+	case err := <-writeErrCh:
+		if err != nil {
+			t.Fatalf("write stdin: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timeout waiting for stdin writer")
+	}
 
 	var resp Response
 	if err := json.Unmarshal(bytes.TrimSpace(outBytes), &resp); err != nil {

--- a/clients/go/cmd/rubin-consensus-cli/runtime_test.go
+++ b/clients/go/cmd/rubin-consensus-cli/runtime_test.go
@@ -155,6 +155,7 @@ func runRawJSON(t *testing.T, raw []byte, entry func()) Response {
 		os.Stdout = oldOut
 		_ = rIn.Close()
 		_ = rOut.Close()
+		_ = wOut.Close()
 	}()
 
 	outCh := make(chan []byte, 1)

--- a/clients/go/consensus/block_basic_txs.go
+++ b/clients/go/consensus/block_basic_txs.go
@@ -7,20 +7,27 @@ func accumulateBlockResourceStats(pb *ParsedBlock) (*blockTxStats, error) {
 		if err != nil {
 			return nil, err
 		}
-		stats.sumWeight, err = addU64(stats.sumWeight, w)
+		stats.sumWeight, err = addBlockResourceStat(stats.sumWeight, w, "sum_weight overflow")
 		if err != nil {
 			return nil, err
 		}
-		stats.sumDa, err = addU64(stats.sumDa, da)
+		stats.sumDa, err = addBlockResourceStat(stats.sumDa, da, "sum_da overflow")
 		if err != nil {
 			return nil, err
 		}
-		stats.sumAnchor, err = addU64(stats.sumAnchor, anchorBytes)
+		stats.sumAnchor, err = addBlockResourceStat(stats.sumAnchor, anchorBytes, "sum_anchor overflow")
 		if err != nil {
 			return nil, err
 		}
 	}
 	return stats, nil
+}
+
+func addBlockResourceStat(a uint64, b uint64, msg string) (uint64, error) {
+	if a > ^uint64(0)-b {
+		return 0, txerr(TX_ERR_PARSE, msg)
+	}
+	return a + b, nil
 }
 
 func validateBlockTxSemantics(pb *ParsedBlock, blockHeight uint64) error {

--- a/clients/go/consensus/block_basic_txs.go
+++ b/clients/go/consensus/block_basic_txs.go
@@ -24,10 +24,11 @@ func accumulateBlockResourceStats(pb *ParsedBlock) (*blockTxStats, error) {
 }
 
 func addBlockResourceStat(a uint64, b uint64, msg string) (uint64, error) {
-	if a > ^uint64(0)-b {
+	sum, err := addU64(a, b)
+	if err != nil {
 		return 0, txerr(TX_ERR_PARSE, msg)
 	}
-	return a + b, nil
+	return sum, nil
 }
 
 func validateBlockTxSemantics(pb *ParsedBlock, blockHeight uint64) error {

--- a/clients/go/consensus/block_basic_txs_test.go
+++ b/clients/go/consensus/block_basic_txs_test.go
@@ -45,6 +45,34 @@ func TestAccumulateBlockResourceStats_SumWeightOverflow(t *testing.T) {
 	if got := mustTxErrCode(t, err); got != TX_ERR_PARSE {
 		t.Fatalf("code=%s, want %s", got, TX_ERR_PARSE)
 	}
+	if got := err.Error(); got != "TX_ERR_PARSE: sum_weight overflow" {
+		t.Fatalf("err=%q, want %q", got, "TX_ERR_PARSE: sum_weight overflow")
+	}
+}
+
+func TestAddBlockResourceStat_OverflowMessages(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		msg  string
+	}{
+		{name: "sum_weight", msg: "sum_weight overflow"},
+		{name: "sum_da", msg: "sum_da overflow"},
+		{name: "sum_anchor", msg: "sum_anchor overflow"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := addBlockResourceStat(^uint64(0), 1, tc.msg)
+			if err == nil {
+				t.Fatalf("expected overflow error")
+			}
+			if got := mustTxErrCode(t, err); got != TX_ERR_PARSE {
+				t.Fatalf("code=%s, want %s", got, TX_ERR_PARSE)
+			}
+			want := "TX_ERR_PARSE: " + tc.msg
+			if got := err.Error(); got != want {
+				t.Fatalf("err=%q, want %q", got, want)
+			}
+		})
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/clients/rust/crates/rubin-consensus/src/block_basic/txs.rs
+++ b/clients/rust/crates/rubin-consensus/src/block_basic/txs.rs
@@ -17,20 +17,18 @@ pub(super) fn accumulate_block_resource_stats(pb: &ParsedBlock) -> Result<BlockT
     };
     for tx in &pb.txs {
         let (w, da, anchor_bytes) = tx_weight_and_stats(tx)?;
-        stats.sum_weight = stats
-            .sum_weight
-            .checked_add(w)
-            .ok_or_else(|| TxError::new(ErrorCode::TxErrParse, "u64 overflow"))?;
-        stats.sum_da = stats
-            .sum_da
-            .checked_add(da)
-            .ok_or_else(|| TxError::new(ErrorCode::TxErrParse, "u64 overflow"))?;
-        stats.sum_anchor = stats
-            .sum_anchor
-            .checked_add(anchor_bytes)
-            .ok_or_else(|| TxError::new(ErrorCode::TxErrParse, "u64 overflow"))?;
+        stats.sum_weight = add_block_resource_stat(stats.sum_weight, w, "sum_weight overflow")?;
+        stats.sum_da = add_block_resource_stat(stats.sum_da, da, "sum_da overflow")?;
+        stats.sum_anchor =
+            add_block_resource_stat(stats.sum_anchor, anchor_bytes, "sum_anchor overflow")?;
     }
     Ok(stats)
+}
+
+fn add_block_resource_stat(current: u64, delta: u64, msg: &'static str) -> Result<u64, TxError> {
+    current
+        .checked_add(delta)
+        .ok_or_else(|| TxError::new(ErrorCode::TxErrParse, msg))
 }
 
 pub(super) fn validate_block_tx_semantics(
@@ -180,6 +178,19 @@ mod tests {
         let pb = parsed_block(vec![coinbase(1), bad_da]);
         let err = accumulate_block_resource_stats(&pb).unwrap_err();
         assert_eq!(err.code, ErrorCode::TxErrParse);
+    }
+
+    #[test]
+    fn add_block_resource_stat_reports_named_overflow() {
+        for msg in [
+            "sum_weight overflow",
+            "sum_da overflow",
+            "sum_anchor overflow",
+        ] {
+            let err = add_block_resource_stat(u64::MAX, 1, msg).unwrap_err();
+            assert_eq!(err.code, ErrorCode::TxErrParse);
+            assert_eq!(err.msg, msg);
+        }
     }
 
     #[test]


### PR DESCRIPTION
Scope:
- align Go/Rust overflow diagnostics labels for block resource accumulators (`sum_weight`, `sum_da`, `sum_anchor`)
- add regression tests for named overflow errors in Go and Rust
- fix CLI `runRawJSON` stdin pipe ordering to prevent deep-gate deadlock

Refs: #1189

<!-- rubin-agent-meta actor=unknown action=pr-create via=cl branch=codex/q-impl-consensus-overflow-diagnostics-parity-01 wt=rubin-protocol-q1189 utc=2026-04-23T08:50:07Z -->
