### PR TITLE
Q-IMPL-NODE-P2P-UNKNOWN-COMMAND-POLICY-01 (#1183): explicit post-handshake unknown-command policy

### DIFF
--- a/clients/go/node/p2p/coverage_hotspots_test.go
+++ b/clients/go/node/p2p/coverage_hotspots_test.go
@@ -2,6 +2,7 @@ package p2p
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"strings"
 	"testing"
@@ -293,9 +294,7 @@ func TestCoverage_HandleConnSuccessPath(t *testing.T) {
 
 func TestCoverage_HandleConnRunErrorPath(t *testing.T) {
 	h := newTestHarness(t, 1, "127.0.0.1:0", nil)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	h.service.ctx = ctx
+	h.service.ctx = context.Background()
 
 	local, remote := net.Pipe()
 	defer local.Close()
@@ -303,32 +302,37 @@ func TestCoverage_HandleConnRunErrorPath(t *testing.T) {
 
 	remoteDone := make(chan error, 1)
 	go func() {
+		remoteVersion := testVersionPayload(node.DevnetGenesisChainID(), node.DevnetGenesisBlockHash(), "remote", 0)
+		if err := completeRemoteHandshake(remote, h.service.cfg.PeerRuntimeConfig, remoteVersion); err != nil {
+			remoteDone <- err
+			return
+		}
 		frame, err := readFrame(remote, networkMagic(h.service.cfg.PeerRuntimeConfig.Network), h.service.cfg.PeerRuntimeConfig.MaxMessageSize)
 		if err != nil {
 			remoteDone <- err
 			return
 		}
-		if frame.Command != messageVersion {
-			remoteDone <- nil
+		if frame.Command != messageGetAddr {
+			remoteDone <- fmt.Errorf("unexpected outbound command: %s", frame.Command)
 			return
 		}
-		payload, err := encodeVersionPayload(testVersionPayload(node.DevnetGenesisChainID(), node.DevnetGenesisBlockHash(), "remote", 0))
-		if err != nil {
+		if err := writeFrame(
+			remote,
+			networkMagic(h.service.cfg.PeerRuntimeConfig.Network),
+			message{Command: "weird"},
+			h.service.cfg.PeerRuntimeConfig.MaxMessageSize,
+		); err != nil {
 			remoteDone <- err
 			return
 		}
-		if err := writeFrame(remote, networkMagic(h.service.cfg.PeerRuntimeConfig.Network), message{Command: messageVersion, Payload: payload}, h.service.cfg.PeerRuntimeConfig.MaxMessageSize); err != nil {
-			remoteDone <- err
-			return
-		}
-		err = writeFrame(remote, networkMagic(h.service.cfg.PeerRuntimeConfig.Network), message{Command: messageVersion, Payload: payload}, h.service.cfg.PeerRuntimeConfig.MaxMessageSize)
-		if err != nil && strings.Contains(err.Error(), "closed pipe") {
-			err = nil
-		}
-		remoteDone <- err
+		remoteDone <- nil
 	}()
 
-	h.service.handleConn(local, "")
+	if err := h.service.handleConn(local, ""); err == nil {
+		t.Fatalf("expected run error for unknown post-handshake command")
+	} else if !strings.Contains(err.Error(), "unknown message type: weird") {
+		t.Fatalf("handleConn error=%v, want unknown message type: weird", err)
+	}
 	if err := <-remoteDone; err != nil {
 		t.Fatalf("remote sequence: %v", err)
 	}

--- a/clients/go/node/p2p/peer_runtime.go
+++ b/clients/go/node/p2p/peer_runtime.go
@@ -12,6 +12,18 @@ import (
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/node"
 )
 
+type postHandshakeUnknownCommandError struct {
+	command string
+}
+
+func (e postHandshakeUnknownCommandError) Error() string {
+	return fmt.Sprintf("unknown message type: %s", e.command)
+}
+
+func (e postHandshakeUnknownCommandError) peerReason() string {
+	return fmt.Sprintf("unknown command: %s", e.command)
+}
+
 func (p *peer) run(ctx context.Context) error {
 	for {
 		if ctx != nil {
@@ -81,8 +93,16 @@ func (p *peer) handleMessage(frame message) error {
 	case messageVerAck:
 		return errors.New("invalid verack after handshake")
 	default:
-		return fmt.Errorf("unknown message type: %s", frame.Command)
+		return postHandshakeUnknownCommandError{command: frame.Command}
 	}
+}
+
+func unknownCommandPolicyReason(err error) (string, bool) {
+	var unknownErr postHandshakeUnknownCommandError
+	if errors.As(err, &unknownErr) {
+		return unknownErr.peerReason(), true
+	}
+	return "", false
 }
 
 func (p *peer) send(command string, payload []byte) error {
@@ -114,6 +134,17 @@ func (p *peer) setLastError(reason string) {
 	state := p.state
 	p.stateMu.Unlock()
 	_ = p.service.cfg.PeerManager.UpsertPeer(&state)
+}
+
+func (p *peer) applyPostHandshakeDisconnectError(err error) {
+	if err == nil {
+		return
+	}
+	if reason, ok := unknownCommandPolicyReason(err); ok {
+		p.setLastError(reason)
+		return
+	}
+	p.setLastError(err.Error())
 }
 
 func (p *peer) bumpBan(delta int, reason string) bool {

--- a/clients/go/node/p2p/peer_runtime_test.go
+++ b/clients/go/node/p2p/peer_runtime_test.go
@@ -165,6 +165,31 @@ func TestApplyPostHandshakeDisconnectErrorUnknownCommandNoBan(t *testing.T) {
 	if snap.LastError != "unknown command: weird" {
 		t.Fatalf("last_error=%q, want unknown command: weird", snap.LastError)
 	}
+
+	unknownReason, unknownOK := unknownCommandPolicyReason(errors.New("plain runtime error"))
+	if unknownOK || unknownReason != "" {
+		t.Fatalf("plain error reason=%q ok=%v, want empty/false", unknownReason, unknownOK)
+	}
+}
+
+func TestApplyPostHandshakeDisconnectErrorNilAndGenericFallback(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	p.setLastError("keep")
+	before := p.snapshotState()
+	p.applyPostHandshakeDisconnectError(nil)
+	after := p.snapshotState()
+	if after.LastError != before.LastError || after.BanScore != before.BanScore {
+		t.Fatalf("nil disconnect error mutated state: before=%+v after=%+v", before, after)
+	}
+
+	p.applyPostHandshakeDisconnectError(errors.New("plain runtime error"))
+	snap := p.snapshotState()
+	if snap.LastError != "plain runtime error" {
+		t.Fatalf("last_error=%q, want plain runtime error", snap.LastError)
+	}
+	if snap.BanScore != 0 {
+		t.Fatalf("ban_score=%d, want 0 for generic runtime error mapping", snap.BanScore)
+	}
 }
 
 func TestRunUnknownCommandDisconnectWithoutBan(t *testing.T) {

--- a/clients/go/node/p2p/peer_runtime_test.go
+++ b/clients/go/node/p2p/peer_runtime_test.go
@@ -147,6 +147,68 @@ func TestSetLastErrorAndBumpBanPersistState(t *testing.T) {
 	}
 }
 
+func TestApplyPostHandshakeDisconnectErrorUnknownCommandNoBan(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	err := postHandshakeUnknownCommandError{command: "weird"}
+	reason, ok := unknownCommandPolicyReason(err)
+	if !ok {
+		t.Fatalf("unknown command policy reason not detected")
+	}
+	if reason != "unknown command: weird" {
+		t.Fatalf("reason=%q, want unknown command: weird", reason)
+	}
+	p.applyPostHandshakeDisconnectError(err)
+	snap := p.snapshotState()
+	if snap.BanScore != 0 {
+		t.Fatalf("ban_score=%d, want 0 for unknown post-handshake command", snap.BanScore)
+	}
+	if snap.LastError != "unknown command: weird" {
+		t.Fatalf("last_error=%q, want unknown command: weird", snap.LastError)
+	}
+}
+
+func TestRunUnknownCommandDisconnectWithoutBan(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	local, remote := net.Pipe()
+	defer local.Close()
+	defer remote.Close()
+	p.conn = local
+	p.service.cfg.PeerRuntimeConfig.ReadDeadline = 0
+	p.service.cfg.PeerRuntimeConfig.WriteDeadline = 0
+
+	writeErrCh := make(chan error, 1)
+	go func() {
+		writeErrCh <- writeFrame(
+			remote,
+			networkMagic(p.service.cfg.PeerRuntimeConfig.Network),
+			message{Command: "weird"},
+			p.service.cfg.PeerRuntimeConfig.MaxMessageSize,
+		)
+	}()
+
+	err := p.run(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "unknown message type: weird") {
+		t.Fatalf("expected unknown-command disconnect error, got %v", err)
+	}
+	if writeErr := <-writeErrCh; writeErr != nil {
+		t.Fatalf("writeFrame(unknown): %v", writeErr)
+	}
+
+	reason, ok := unknownCommandPolicyReason(err)
+	if !ok || reason != "unknown command: weird" {
+		t.Fatalf("reason=%q ok=%v, want unknown command policy reason", reason, ok)
+	}
+
+	p.applyPostHandshakeDisconnectError(err)
+	snap := p.snapshotState()
+	if snap.BanScore != 0 {
+		t.Fatalf("ban_score=%d, want 0 for unknown command disconnect", snap.BanScore)
+	}
+	if snap.LastError != "unknown command: weird" {
+		t.Fatalf("last_error=%q, want unknown command: weird", snap.LastError)
+	}
+}
+
 func TestSendAndRunContextCancellation(t *testing.T) {
 	p := newPeerRuntimeTestPeer(t)
 	local, remote := net.Pipe()

--- a/clients/go/node/p2p/service_peer_lifecycle.go
+++ b/clients/go/node/p2p/service_peer_lifecycle.go
@@ -59,7 +59,7 @@ func (s *Service) handleConn(conn net.Conn, outboundAddr string) error {
 		current.setLastError(err.Error())
 	}
 	if err := current.run(s.ctx); err != nil && s.ctx.Err() == nil {
-		current.setLastError(err.Error())
+		current.applyPostHandshakeDisconnectError(err)
 		return err
 	}
 	return nil


### PR DESCRIPTION
## Scope
- make post-handshake unknown-command handling explicit in Go p2p runtime/lifecycle
- keep policy disconnect-only (no ban bump) with explicit peer reason mapping
- add targeted Go regressions for unknown-command disconnect-without-ban behavior

## Out Of Scope
- pre-handshake policy
- payload cap/parser redesign
- reconnect/ban-threshold redesign
- Rust runtime behavior changes

Closes #1183
