### PR TITLE
Q-IMPL-GO-DEVNET-BINARY-SOAK-RESTART-01 (#1230)

### DIFF
--- a/scripts/devnet-go-binary-soak.sh
+++ b/scripts/devnet-go-binary-soak.sh
@@ -61,6 +61,7 @@ POST_RESTART_CATCHUP_PEERS="0"
 POST_RESTART_MINE_HEIGHT=""
 POST_RESTART_MINE_HASH=""
 POST_RESTART_MINE_TX_COUNT="0"
+POST_RESTART_ACCEPTED_PEER=""
 INCLUSION_PROOF_NODE="node-a"
 rpc_json() {
   local method="$1" addr="$2" path="$3" body="${4:-}"
@@ -110,6 +111,10 @@ wait_peers() {
   done
   echo "timeout waiting for ${addr} peer_count>=${want}" >&2
   return 1
+}
+block_matches_hash_canonical() {
+  local block_json="$1" expected_hash="$2"
+  printf '%s' "${block_json}" | python3 -c 'import json,sys; d=json.load(sys.stdin); expected=sys.argv[1].lower(); actual=(d.get("hash") or d.get("block_hash") or "").lower(); actual == expected or sys.exit(1); d.get("canonical") is True or sys.exit(2)' "${expected_hash}"
 }
 unregister_managed_pid() {
   local stale_pid="${1:-}" kept=() pid
@@ -203,7 +208,7 @@ if (( WITH_RESTART == 1 )); then
   wait_height "${B_RPC_ADDR}" "${TARGET_HEIGHT}" 60
   IFS=$'\t' read -r POST_RESTART_CATCHUP_HEIGHT POST_RESTART_CATCHUP_TIP < <(tip_tsv "${B_RPC_ADDR}")
   POST_RESTART_CATCHUP_PEERS="$(wait_peers "${B_RPC_ADDR}" 1 30)"
-  echo "Mining one additional block after restart to exercise live process path"
+  echo "Mining one additional block after restart through restarted node-b"
   if ! POST_RESTART_MINE_JSON="$(rpc_json POST "${B_RPC_ADDR}" /mine_next '{}')"; then echo "post-restart mine_next request failed: ${POST_RESTART_MINE_JSON}" >&2; exit 1; fi
   IFS=$'\t' read -r POST_RESTART_MINE_HEIGHT POST_RESTART_MINE_HASH POST_RESTART_MINE_TX_COUNT < <(printf '%s' "${POST_RESTART_MINE_JSON}" | python3 -c 'import json,sys; d=json.load(sys.stdin); (d.get("mined") is True) or sys.exit("post-restart mine_next failed: "+str(d.get("error","missing mined result"))); print(d["height"], d["block_hash"], d["tx_count"], sep="\t")')
   POST_RESTART_TARGET_HEIGHT=$((TARGET_HEIGHT + 1))
@@ -211,19 +216,41 @@ if (( WITH_RESTART == 1 )); then
     echo "unexpected post-restart mine_next result height=${POST_RESTART_MINE_HEIGHT} tx_count=${POST_RESTART_MINE_TX_COUNT}" >&2
     exit 1
   }
+  wait_height "${A_RPC_ADDR}" "${POST_RESTART_TARGET_HEIGHT}" 90
   wait_height "${B_RPC_ADDR}" "${POST_RESTART_TARGET_HEIGHT}" 60
+  POST_RESTART_B_BLOCK_JSON="$(rpc_json GET "${B_RPC_ADDR}" "/get_block?height=${POST_RESTART_TARGET_HEIGHT}")"
+  block_matches_hash_canonical "${POST_RESTART_B_BLOCK_JSON}" "${POST_RESTART_MINE_HASH}" || {
+    echo "post-restart block was not adopted by restarted node-b at height=${POST_RESTART_TARGET_HEIGHT} hash=${POST_RESTART_MINE_HASH}" >&2
+    exit 1
+  }
+  POST_RESTART_A_BLOCK_JSON="$(rpc_json GET "${A_RPC_ADDR}" "/get_block?height=${POST_RESTART_TARGET_HEIGHT}")"
+  block_matches_hash_canonical "${POST_RESTART_A_BLOCK_JSON}" "${POST_RESTART_MINE_HASH}" || {
+    echo "post-restart block was not adopted by node-a at height=${POST_RESTART_TARGET_HEIGHT} hash=${POST_RESTART_MINE_HASH}" >&2
+    exit 1
+  }
+  POST_RESTART_ACCEPTED_PEER="node-a"
   INCLUSION_PROOF_NODE="node-b"
 fi
 IFS=$'\t' read -r A_HEIGHT A_TIP < <(tip_tsv "${A_RPC_ADDR}")
 IFS=$'\t' read -r B_HEIGHT B_TIP < <(tip_tsv "${B_RPC_ADDR}")
 IFS=$'\t' read -r C_HEIGHT C_TIP < <(tip_tsv "${C_RPC_ADDR}")
-A_PEERS="$(wait_peers "${A_RPC_ADDR}" 2 30)" B_PEERS="$(wait_peers "${B_RPC_ADDR}" 1 30)" C_PEERS="$(wait_peers "${C_RPC_ADDR}" 1 30)"
 if (( WITH_RESTART == 1 )); then
-  [[ (("${A_HEIGHT}" == "${TARGET_HEIGHT}" && "${A_TIP}" == "${FINAL_HASH}") || ("${A_HEIGHT}" == "${POST_RESTART_MINE_HEIGHT}" && "${A_TIP}" == "${POST_RESTART_MINE_HASH}")) ]] || {
-    echo "unexpected restart node-a checkpoint target=${TARGET_HEIGHT}/${FINAL_HASH} post_restart=${POST_RESTART_MINE_HEIGHT}/${POST_RESTART_MINE_HASH} got=${A_HEIGHT}/${A_TIP}" >&2
+  A_PEERS="$(wait_peers "${A_RPC_ADDR}" 1 30)"
+else
+  A_PEERS="$(wait_peers "${A_RPC_ADDR}" 2 30)"
+fi
+B_PEERS="$(wait_peers "${B_RPC_ADDR}" 1 30)" C_PEERS="$(wait_peers "${C_RPC_ADDR}" 1 30)"
+if (( WITH_RESTART == 1 )); then
+  [[ "${POST_RESTART_ACCEPTED_PEER}" == "node-a" ]] || {
+    echo "unexpected post-restart adoption marker=${POST_RESTART_ACCEPTED_PEER}" >&2
     exit 1
   }
-  [[ "${B_HEIGHT}" == "${POST_RESTART_MINE_HEIGHT}" && "${B_TIP}" == "${POST_RESTART_MINE_HASH}" && (("${C_HEIGHT}" == "${BASE_HEIGHT}" && -n "${C_TIP}") || ("${C_HEIGHT}" == "${TARGET_HEIGHT}" && "${C_TIP}" == "${FINAL_HASH}") || ("${C_HEIGHT}" == "${POST_RESTART_MINE_HEIGHT}" && "${C_TIP}" == "${POST_RESTART_MINE_HASH}")) && "${A_PEERS}" -ge 2 && "${B_PEERS}" -ge 1 && "${C_PEERS}" -ge 1 ]] || {
+  POST_RESTART_A_BLOCK_JSON="$(rpc_json GET "${A_RPC_ADDR}" "/get_block?height=${POST_RESTART_MINE_HEIGHT}")"
+  block_matches_hash_canonical "${POST_RESTART_A_BLOCK_JSON}" "${POST_RESTART_MINE_HASH}" || {
+    echo "post-restart adoption marker node-a mismatch height=${A_HEIGHT} tip=${A_TIP}" >&2
+    exit 1
+  }
+  [[ "${A_HEIGHT}" == "${POST_RESTART_MINE_HEIGHT}" && "${A_TIP}" == "${POST_RESTART_MINE_HASH}" && "${B_HEIGHT}" == "${POST_RESTART_MINE_HEIGHT}" && "${B_TIP}" == "${POST_RESTART_MINE_HASH}" && (("${C_HEIGHT}" == "${BASE_HEIGHT}" && -n "${C_TIP}") || ("${C_HEIGHT}" == "${TARGET_HEIGHT}" && "${C_TIP}" == "${FINAL_HASH}") || ("${C_HEIGHT}" == "${POST_RESTART_MINE_HEIGHT}" && "${C_TIP}" == "${POST_RESTART_MINE_HASH}")) && "${A_PEERS}" -ge 1 && "${B_PEERS}" -ge 1 && "${C_PEERS}" -ge 1 ]] || {
     echo "unexpected restart checkpoint/connectivity post_restart=${POST_RESTART_MINE_HASH} b_height=${B_HEIGHT} c_height=${C_HEIGHT} peers=${A_PEERS}/${B_PEERS}/${C_PEERS}" >&2
     exit 1
   }
@@ -240,6 +267,8 @@ fi
 if (( WITH_RESTART == 1 )); then
   BLOCK_JSON="$(rpc_json GET "${B_RPC_ADDR}" "/get_block?height=${TARGET_HEIGHT}")"
   POST_RESTART_BLOCK_JSON="$(rpc_json GET "${B_RPC_ADDR}" "/get_block?height=${POST_RESTART_MINE_HEIGHT}")"
+  block_matches_hash_canonical "${BLOCK_JSON}" "${FINAL_HASH}" || { echo "restart target block mismatch canonical/hash expected=${FINAL_HASH}" >&2; exit 1; }
+  block_matches_hash_canonical "${POST_RESTART_BLOCK_JSON}" "${POST_RESTART_MINE_HASH}" || { echo "restart post-restart block mismatch canonical/hash expected=${POST_RESTART_MINE_HASH}" >&2; exit 1; }
 else
   BLOCK_JSON="$(rpc_json GET "${A_RPC_ADDR}" "/get_block?height=${TARGET_HEIGHT}")"
 fi
@@ -247,7 +276,7 @@ printf '%s' "${BLOCK_JSON}" | python3 -c 'import json,sys; d=json.load(sys.stdin
 if (( WITH_RESTART == 1 )); then
   printf '%s' "${POST_RESTART_BLOCK_JSON}" | python3 -c 'import json,sys; d=json.load(sys.stdin); h=d.get("block_hex",""); (isinstance(h, str) and len(h) > 0) or sys.exit("post-restart block visibility check failed")'
 fi
-export REPORT_JSON TARGET_HEIGHT BASE_HEIGHT A_HEIGHT B_HEIGHT C_HEIGHT A_TIP B_TIP C_TIP A_PID B_PID C_PID A_RPC_ADDR B_RPC_ADDR C_RPC_ADDR A_PEERS B_PEERS C_PEERS TX_ID FINAL_HASH TX_COUNT WITH_RESTART PRE_RESTART_B_HEIGHT PRE_RESTART_B_TIP PRE_RESTART_B_RPC_ADDR PRE_RESTART_B_PID POST_RESTART_B_RPC_ADDR POST_RESTART_B_PID POST_RESTART_CATCHUP_HEIGHT POST_RESTART_CATCHUP_TIP POST_RESTART_CATCHUP_PEERS POST_RESTART_MINE_HEIGHT POST_RESTART_MINE_HASH POST_RESTART_MINE_TX_COUNT INCLUSION_PROOF_NODE
+export REPORT_JSON TARGET_HEIGHT BASE_HEIGHT A_HEIGHT B_HEIGHT C_HEIGHT A_TIP B_TIP C_TIP A_PID B_PID C_PID A_RPC_ADDR B_RPC_ADDR C_RPC_ADDR A_PEERS B_PEERS C_PEERS TX_ID FINAL_HASH TX_COUNT WITH_RESTART PRE_RESTART_B_HEIGHT PRE_RESTART_B_TIP PRE_RESTART_B_RPC_ADDR PRE_RESTART_B_PID POST_RESTART_B_RPC_ADDR POST_RESTART_B_PID POST_RESTART_CATCHUP_HEIGHT POST_RESTART_CATCHUP_TIP POST_RESTART_CATCHUP_PEERS POST_RESTART_MINE_HEIGHT POST_RESTART_MINE_HASH POST_RESTART_MINE_TX_COUNT POST_RESTART_ACCEPTED_PEER INCLUSION_PROOF_NODE
 python3 - <<'PY'
 import json, os
 participants = []
@@ -294,6 +323,7 @@ if restart_enabled:
             "height": int(os.environ["POST_RESTART_MINE_HEIGHT"]),
             "block_hash": os.environ["POST_RESTART_MINE_HASH"],
             "tx_count": int(os.environ["POST_RESTART_MINE_TX_COUNT"]),
+            "accepted_by_peer": os.environ["POST_RESTART_ACCEPTED_PEER"],
         },
     }
 else:

--- a/scripts/devnet-go-binary-soak.sh
+++ b/scripts/devnet-go-binary-soak.sh
@@ -282,7 +282,10 @@ if (( WITH_RESTART == 1 )); then
   rubin_process_wait_for_rpc_ready "${B_RPC_ADDR}" 30
   wait_height "${B_RPC_ADDR}" "${TARGET_HEIGHT}" 60
   IFS=$'\t' read -r POST_RESTART_CATCHUP_HEIGHT POST_RESTART_CATCHUP_TIP < <(tip_tsv "${B_RPC_ADDR}")
-  POST_RESTART_CATCHUP_PEERS="$(wait_peers "${B_RPC_ADDR}" 1 30)"
+  if ! POST_RESTART_CATCHUP_PEERS="$(wait_peers "${B_RPC_ADDR}" 1 30)"; then
+    echo "failed post-restart node-b peer wait addr=${B_RPC_ADDR} want=1 timeout=30" >&2
+    exit 1
+  fi
   echo "Mining one additional block after restart through restarted node-b"
   if ! POST_RESTART_MINE_JSON="$(rpc_json POST "${B_RPC_ADDR}" /mine_next '{}')"; then echo "post-restart mine_next request failed: ${POST_RESTART_MINE_JSON}" >&2; exit 1; fi
   IFS=$'\t' read -r POST_RESTART_MINE_HEIGHT POST_RESTART_MINE_HASH POST_RESTART_MINE_TX_COUNT < <(printf '%s' "${POST_RESTART_MINE_JSON}" | python3 -c 'import json,sys; d=json.load(sys.stdin); (d.get("mined") is True) or sys.exit("post-restart mine_next failed: "+str(d.get("error","missing mined result"))); print(d["height"], d["block_hash"], d["tx_count"], sep="\t")')
@@ -309,8 +312,18 @@ fi
 IFS=$'\t' read -r A_HEIGHT A_TIP < <(tip_tsv "${A_RPC_ADDR}")
 IFS=$'\t' read -r B_HEIGHT B_TIP < <(tip_tsv "${B_RPC_ADDR}")
 IFS=$'\t' read -r C_HEIGHT C_TIP < <(tip_tsv "${C_RPC_ADDR}")
-A_PEERS="$(wait_peers "${A_RPC_ADDR}" 2 30)"
-B_PEERS="$(wait_peers "${B_RPC_ADDR}" 1 30)" C_PEERS="$(wait_peers "${C_RPC_ADDR}" 1 30)"
+if ! A_PEERS="$(wait_peers "${A_RPC_ADDR}" 2 30)"; then
+  echo "failed node-a peer wait addr=${A_RPC_ADDR} want=2 timeout=30" >&2
+  exit 1
+fi
+if ! B_PEERS="$(wait_peers "${B_RPC_ADDR}" 1 30)"; then
+  echo "failed node-b peer wait addr=${B_RPC_ADDR} want=1 timeout=30" >&2
+  exit 1
+fi
+if ! C_PEERS="$(wait_peers "${C_RPC_ADDR}" 1 30)"; then
+  echo "failed node-c peer wait addr=${C_RPC_ADDR} want=1 timeout=30" >&2
+  exit 1
+fi
 if (( WITH_RESTART == 1 )); then
   [[ "${POST_RESTART_ACCEPTED_PEER}" == "node-a" ]] || {
     echo "unexpected post-restart adoption marker=${POST_RESTART_ACCEPTED_PEER}" >&2

--- a/scripts/devnet-go-binary-soak.sh
+++ b/scripts/devnet-go-binary-soak.sh
@@ -5,8 +5,7 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DEV_ENV="${REPO_ROOT}/scripts/dev-env.sh"
 GO_MODULE_ROOT="${REPO_ROOT}/clients/go"
 HELPER="${REPO_ROOT}/scripts/devnet-process-common.sh"
-TARGET_HEIGHT=120
-WITH_RESTART=0
+TARGET_HEIGHT=120 WITH_RESTART=0
 
 usage() { echo "usage: $0 [--target-height N] [--with-restart]" >&2; }
 while (($#)); do
@@ -29,7 +28,7 @@ while (($#)); do
       exit 2
       ;;
   esac
-done
+done; for tool in python3 perl lsof; do command -v "${tool}" >/dev/null 2>&1 || { echo "${tool} is required for Go binary soak evidence" >&2; exit 1; }; done
 # Runtime txgen needs base height >=100; bound height to keep the soak finite.
 TARGET_HEIGHT="$(python3 -c 'import sys; s=sys.argv[1]; n=int(s) if s.isdecimal() else -1; 101 <= n <= 10000 or sys.exit(2); print(n)' "${TARGET_HEIGHT}")" || { echo "--target-height must be an integer in [101, 10000]" >&2; exit 2; }
 # shellcheck source=scripts/devnet-process-common.sh disable=SC1091
@@ -51,8 +50,7 @@ B_PROXY_LOG="node-b-proxy.log" C_PROXY_LOG="node-c-proxy.log"
 B_RESTART_LOG="node-b-restart.log"
 MINE_LOG="${RUBIN_PROCESS_ARTIFACT_ROOT}/mine-base.log"
 RUBIN_PROCESS_LOGS+=("${MINE_LOG}")
-PRE_RESTART_B_HEIGHT=""
-PRE_RESTART_B_TIP=""
+PRE_RESTART_B_HEIGHT="" PRE_RESTART_B_TIP=""
 PRE_RESTART_B_RPC_ADDR="" PRE_RESTART_B_P2P_ADDR=""
 PRE_RESTART_B_PID=""
 POST_RESTART_B_RPC_ADDR="" POST_RESTART_B_P2P_ADDR=""
@@ -118,7 +116,7 @@ wait_peers() {
 }
 block_matches_hash_canonical() {
   local block_json="$1" expected_hash="$2"
-  printf '%s' "${block_json}" | python3 -c 'import json,sys; d=json.load(sys.stdin); expected=sys.argv[1].lower(); actual=(d.get("hash") or d.get("block_hash") or "").lower(); actual == expected or sys.exit(1); d.get("canonical") is True or sys.exit(2)' "${expected_hash}"
+  printf '%s' "${block_json}" | python3 -c 'import json,sys; d=json.load(sys.stdin); expected=sys.argv[1].lower(); actual=(d.get("hash") or d.get("block_hash") or "").lower(); canonical=d.get("canonical"); (actual == expected and canonical is True) or sys.exit("expected_hash=%s actual_hash=%s actual_canonical=%r" % (expected, actual or "<missing>", canonical))' "${expected_hash}"
 }
 describe_block_json() { local block_json="$1"; printf '%s' "${block_json}" | python3 -c 'import json,sys; d=json.load(sys.stdin); actual=d.get("hash") or d.get("block_hash") or "<missing>"; print("reported_hash=%s reported_canonical=%r" % (actual, d.get("canonical")))'; }
 stop_registered_pid() { local managed_pid="${1:-}" rc=0 kept=() pid; [[ -n "${managed_pid}" ]] || return 1; rubin_process_stop_pid "${managed_pid}" || rc=$?; for pid in "${RUBIN_PROCESS_PIDS[@]}"; do [[ "${pid}" == "${managed_pid}" ]] || kept+=("${pid}"); done; if ((${#kept[@]})); then RUBIN_PROCESS_PIDS=("${kept[@]}"); else RUBIN_PROCESS_PIDS=(); fi; if ((${#RUBIN_PROCESS_PIDS[@]})); then for pid in "${RUBIN_PROCESS_PIDS[@]}"; do [[ "${pid}" != "${managed_pid}" ]] || { echo "stale managed pid remained registered after stop: ${managed_pid}" >&2; return 1; }; done; fi; return "${rc}"; }
@@ -129,8 +127,8 @@ target_file = sys.argv[1]; listener = socket.socket(); listener.setsockopt(socke
 print(f"proxy: listening={listener.getsockname()[0]}:{listener.getsockname()[1]}", flush=True)
 def pump(src, dst):
     try:
-        while data := src.recv(65536):
-            dst.sendall(data)
+        data = src.recv(65536)
+        while data: dst.sendall(data); data = src.recv(65536)
     except OSError:
         pass
     for sock in (src, dst):
@@ -142,6 +140,7 @@ while True:
         host, port = open(target_file, encoding="utf-8").read().strip().rsplit(":", 1)
         if host != "127.0.0.1": raise ValueError("proxy target must be loopback")
         upstream = socket.create_connection((host, int(port)), timeout=5)
+        upstream.settimeout(None)
     except Exception:
         client.close(); continue
     for src, dst in ((client, upstream), (upstream, client)):

--- a/scripts/devnet-go-binary-soak.sh
+++ b/scripts/devnet-go-binary-soak.sh
@@ -120,6 +120,7 @@ block_matches_hash_canonical() {
   local block_json="$1" expected_hash="$2"
   printf '%s' "${block_json}" | python3 -c 'import json,sys; d=json.load(sys.stdin); expected=sys.argv[1].lower(); actual=(d.get("hash") or d.get("block_hash") or "").lower(); actual == expected or sys.exit(1); d.get("canonical") is True or sys.exit(2)' "${expected_hash}"
 }
+stop_registered_pid() { local managed_pid="${1:-}" rc=0 kept=() pid; [[ -n "${managed_pid}" ]] || return 1; rubin_process_stop_pid "${managed_pid}" || rc=$?; for pid in "${RUBIN_PROCESS_PIDS[@]}"; do [[ "${pid}" == "${managed_pid}" ]] || kept+=("${pid}"); done; if ((${#kept[@]})); then RUBIN_PROCESS_PIDS=("${kept[@]}"); else RUBIN_PROCESS_PIDS=(); fi; if ((${#RUBIN_PROCESS_PIDS[@]})); then for pid in "${RUBIN_PROCESS_PIDS[@]}"; do [[ "${pid}" != "${managed_pid}" ]] || { echo "stale managed pid remained registered after stop: ${managed_pid}" >&2; return 1; }; done; fi; return "${rc}"; }
 write_tcp_proxy() {
   cat >"${TCP_PROXY_PY}" <<'PY'
 import socket, sys, threading
@@ -153,10 +154,10 @@ start_proxy() {
   PROXY_PID="" PROXY_ADDR=""
   rubin_process_start "${log_file}" python3 -u "${TCP_PROXY_PY}" "${target_file}"
   PROXY_PID="${RUBIN_PROCESS_LAST_PID}"
-  rubin_process_wait_for_log "${log_file}" "proxy: listening=" 30 "${PROXY_PID}"
+  rubin_process_wait_for_log "${log_file}" "proxy: listening=" 30 "${PROXY_PID}" || { stop_registered_pid "${PROXY_PID}" || true; PROXY_PID=""; return 1; }
   PROXY_ADDR="$(sed -n 's/.*proxy: listening=//p' "${RUBIN_PROCESS_ARTIFACT_ROOT}/${log_file}" | tail -n 1 | tr -d '[:space:]')"
-  [[ -n "${PROXY_ADDR}" ]] || { echo "missing proxy listening banner in ${log_file}" >&2; return 1; }
-  [[ "${PROXY_ADDR}" == 127.0.0.1:* ]] || { echo "proxy must listen on 127.0.0.1, got ${PROXY_ADDR}" >&2; return 1; }
+  [[ -n "${PROXY_ADDR}" ]] || { echo "missing proxy listening banner in ${log_file}" >&2; stop_registered_pid "${PROXY_PID}" || true; PROXY_PID=""; return 1; }
+  [[ "${PROXY_ADDR}" == 127.0.0.1:* ]] || { echo "proxy must listen on 127.0.0.1, got ${PROXY_ADDR}" >&2; stop_registered_pid "${PROXY_PID}" || true; PROXY_PID=""; return 1; }
 }
 STARTED_PID=""
 STARTED_RPC=""
@@ -185,18 +186,18 @@ start_node_ready() {
   STARTED_PID="" STARTED_RPC="" STARTED_P2P=""
   if ! rubin_process_start "${log_file}" "${NODE_BIN}" "${args[@]}"; then
     echo "${label} start failed" >&2
-    [[ -z "${RUBIN_PROCESS_LAST_PID}" ]] || rubin_process_stop_pid "${RUBIN_PROCESS_LAST_PID}" || true
+    [[ -z "${RUBIN_PROCESS_LAST_PID}" ]] || stop_registered_pid "${RUBIN_PROCESS_LAST_PID}" || true
     return 1
   fi
   STARTED_PID="${RUBIN_PROCESS_LAST_PID}"
   if ! rubin_process_wait_for_log "${log_file}" "rpc: listening=" 30 "${STARTED_PID}"; then
     echo "${label} did not become ready" >&2
-    rubin_process_stop_pid "${STARTED_PID}" || true
+    stop_registered_pid "${STARTED_PID}" || true
     STARTED_PID=""
     return 1
   fi
-  STARTED_RPC="$(rubin_process_extract_rpc_addr "${log_file}")" || { rubin_process_stop_pid "${STARTED_PID}" || true; return 1; }
-  STARTED_P2P="$(p2p_addr_for_pid "${STARTED_PID}" "${STARTED_RPC}" 30)" || { rubin_process_stop_pid "${STARTED_PID}" || true; return 1; }
+  STARTED_RPC="$(rubin_process_extract_rpc_addr "${log_file}")" || { stop_registered_pid "${STARTED_PID}" || true; return 1; }
+  STARTED_P2P="$(p2p_addr_for_pid "${STARTED_PID}" "${STARTED_RPC}" 30)" || { stop_registered_pid "${STARTED_PID}" || true; return 1; }
 }
 start_soak_cluster() {
   A_PID="" B_PID="" C_PID="" A_RPC_ADDR="" B_RPC_ADDR="" C_RPC_ADDR=""
@@ -262,7 +263,7 @@ if (( WITH_RESTART == 1 )); then
   PRE_RESTART_B_RPC_ADDR="${B_RPC_ADDR}" PRE_RESTART_B_P2P_ADDR="${B_P2P_ADDR}"
   PRE_RESTART_B_PID="${B_PID}"
   echo "Stopping node-b pid=${B_PID} at deterministic restart checkpoint height ${PRE_RESTART_B_HEIGHT}"
-  rubin_process_stop_pid "${B_PID}"
+  stop_registered_pid "${B_PID}"
 fi
 echo "Submitting tx through Go RPC and mining it through /mine_next"
 TX_HEX="$("${TXGEN_BIN}" --datadir "${A_DIR}" --from-key "${FROM_DER_HEX}" --to-key "${TO_ADDRESS_HEX}" --amount 1 --fee 1 --submit-to "${A_RPC_ADDR}")"

--- a/scripts/devnet-go-binary-soak.sh
+++ b/scripts/devnet-go-binary-soak.sh
@@ -6,14 +6,19 @@ DEV_ENV="${REPO_ROOT}/scripts/dev-env.sh"
 GO_MODULE_ROOT="${REPO_ROOT}/clients/go"
 HELPER="${REPO_ROOT}/scripts/devnet-process-common.sh"
 TARGET_HEIGHT=120
+WITH_RESTART=0
 
-usage() { echo "usage: $0 [--target-height N]" >&2; }
+usage() { echo "usage: $0 [--target-height N] [--with-restart]" >&2; }
 while (($#)); do
   case "$1" in
     --target-height)
       [[ $# -ge 2 ]] || { usage; exit 2; }
       TARGET_HEIGHT="$2"
       shift 2
+      ;;
+    --with-restart)
+      WITH_RESTART=1
+      shift
       ;;
     -h|--help)
       usage
@@ -41,8 +46,16 @@ A_DIR="${RUBIN_PROCESS_ARTIFACT_ROOT}/node-a"
 B_DIR="${RUBIN_PROCESS_ARTIFACT_ROOT}/node-b"
 C_DIR="${RUBIN_PROCESS_ARTIFACT_ROOT}/node-c"
 A_LOG="node-a.log" B_LOG="node-b.log" C_LOG="node-c.log"
+B_RESTART_LOG="node-b-restart.log"
 MINE_LOG="${RUBIN_PROCESS_ARTIFACT_ROOT}/mine-base.log"
 RUBIN_PROCESS_LOGS+=("${MINE_LOG}")
+PRE_RESTART_B_HEIGHT=""
+PRE_RESTART_B_TIP=""
+PRE_RESTART_B_RPC_ADDR=""
+PRE_RESTART_B_PID=""
+POST_RESTART_B_RPC_ADDR=""
+POST_RESTART_B_PID=""
+INCLUSION_PROOF_NODE="node-a"
 rpc_json() {
   local method="$1" addr="$2" path="$3" body="${4:-}"
   python3 - "${method}" "${addr}" "${path}" "${body}" <<'PY'
@@ -92,6 +105,20 @@ wait_peers() {
   echo "timeout waiting for ${addr} peer_count>=${want}" >&2
   return 1
 }
+unregister_managed_pid() {
+  local stale_pid="${1:-}" kept=() pid
+  [[ -n "${stale_pid}" ]] || return 1
+  for pid in "${RUBIN_PROCESS_PIDS[@]}"; do
+    [[ "${pid}" == "${stale_pid}" ]] || kept+=("${pid}")
+  done
+  RUBIN_PROCESS_PIDS=("${kept[@]}")
+}
+stop_managed_pid() {
+  local managed_pid="${1:-}"
+  [[ -n "${managed_pid}" ]] || return 1
+  rubin_process_stop_pid "${managed_pid}"
+  unregister_managed_pid "${managed_pid}"
+}
 write_keygen() {
   cat >"${KEYGEN_GO}" <<'EOF'
 package main
@@ -127,7 +154,7 @@ A_PID=""
 for _ in 1 2 3; do
   A_P2P_ADDR="$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(f"127.0.0.1:{s.getsockname()[1]}"); s.close()')"
   if rubin_process_start "${A_LOG}" "${NODE_BIN}" --datadir "${A_DIR}" --bind "${A_P2P_ADDR}" --rpc-bind 127.0.0.1:0 --mine-address "${MINE_ADDRESS_HEX}" && rubin_process_wait_for_log "${A_LOG}" "rpc: listening=" 30 "${RUBIN_PROCESS_LAST_PID}"; then A_PID="${RUBIN_PROCESS_LAST_PID}"; A_RPC_ADDR="$(rubin_process_extract_rpc_addr "${A_LOG}")"; break; fi
-  [[ -z "${RUBIN_PROCESS_LAST_PID}" ]] || rubin_process_stop_pid "${RUBIN_PROCESS_LAST_PID}" || true
+  [[ -z "${RUBIN_PROCESS_LAST_PID}" ]] || stop_managed_pid "${RUBIN_PROCESS_LAST_PID}" || true
 done
 [[ -n "${A_PID}" ]] || { echo "failed to start node-a after retrying loopback bind ports" >&2; exit 1; }
 rubin_process_start "${B_LOG}" "${NODE_BIN}" --datadir "${B_DIR}" --bind 127.0.0.1:0 --rpc-bind 127.0.0.1:0 --peers "${A_P2P_ADDR}" --mine-address "${MINE_ADDRESS_HEX}"
@@ -140,6 +167,13 @@ rubin_process_wait_for_log "${C_LOG}" "rpc: listening=" 30 "${C_PID}"
 C_RPC_ADDR="$(rubin_process_extract_rpc_addr "${C_LOG}")"
 for addr in "${A_RPC_ADDR}" "${B_RPC_ADDR}" "${C_RPC_ADDR}"; do rubin_process_wait_for_rpc_ready "${addr}" 30; done
 for addr in "${A_RPC_ADDR}" "${B_RPC_ADDR}" "${C_RPC_ADDR}"; do wait_height "${addr}" "${BASE_HEIGHT}" 30; done
+if (( WITH_RESTART == 1 )); then
+  IFS=$'\t' read -r PRE_RESTART_B_HEIGHT PRE_RESTART_B_TIP < <(tip_tsv "${B_RPC_ADDR}")
+  PRE_RESTART_B_RPC_ADDR="${B_RPC_ADDR}"
+  PRE_RESTART_B_PID="${B_PID}"
+  echo "Stopping node-b pid=${B_PID} at deterministic restart checkpoint height ${PRE_RESTART_B_HEIGHT}"
+  stop_managed_pid "${B_PID}"
+fi
 echo "Submitting tx through Go RPC and mining it through /mine_next"
 TX_HEX="$("${TXGEN_BIN}" --datadir "${A_DIR}" --from-key "${FROM_DER_HEX}" --to-key "${TO_ADDRESS_HEX}" --amount 1 --fee 1 --submit-to "${A_RPC_ADDR}")"
 if ! MEMPOOL_JSON="$(rpc_json GET "${A_RPC_ADDR}" /get_mempool)"; then echo "get_mempool request failed: ${MEMPOOL_JSON}" >&2; exit 1; fi
@@ -151,6 +185,18 @@ IFS=$'\t' read -r FINAL_HEIGHT FINAL_HASH TX_COUNT < <(printf '%s' "${MINE_JSON}
   exit 1
 }
 wait_height "${A_RPC_ADDR}" "${TARGET_HEIGHT}" 30
+if (( WITH_RESTART == 1 )); then
+  echo "Restarting node-b from disk-backed datadir ${B_DIR}"
+  rubin_process_start "${B_RESTART_LOG}" "${NODE_BIN}" --datadir "${B_DIR}" --bind 127.0.0.1:0 --rpc-bind 127.0.0.1:0 --peers "${A_P2P_ADDR}" --mine-address "${MINE_ADDRESS_HEX}"
+  B_PID="${RUBIN_PROCESS_LAST_PID}"
+  POST_RESTART_B_PID="${B_PID}"
+  rubin_process_wait_for_log "${B_RESTART_LOG}" "rpc: listening=" 30 "${B_PID}"
+  B_RPC_ADDR="$(rubin_process_extract_rpc_addr "${B_RESTART_LOG}")"
+  POST_RESTART_B_RPC_ADDR="${B_RPC_ADDR}"
+  rubin_process_wait_for_rpc_ready "${B_RPC_ADDR}" 30
+  wait_height "${B_RPC_ADDR}" "${TARGET_HEIGHT}" 60
+  INCLUSION_PROOF_NODE="node-b-restarted"
+fi
 IFS=$'\t' read -r A_HEIGHT A_TIP < <(tip_tsv "${A_RPC_ADDR}")
 IFS=$'\t' read -r B_HEIGHT B_TIP < <(tip_tsv "${B_RPC_ADDR}")
 IFS=$'\t' read -r C_HEIGHT C_TIP < <(tip_tsv "${C_RPC_ADDR}")
@@ -159,21 +205,65 @@ A_PEERS="$(wait_peers "${A_RPC_ADDR}" 2 30)" B_PEERS="$(wait_peers "${B_RPC_ADDR
   echo "unexpected node-a checkpoint final=${FINAL_HASH} a_height=${A_HEIGHT} a_tip=${A_TIP}" >&2
   exit 1
 }
-[[ (("${B_HEIGHT}" == "${BASE_HEIGHT}" && -n "${B_TIP}") || ("${B_HEIGHT}" == "${TARGET_HEIGHT}" && "${B_TIP}" == "${FINAL_HASH}")) && (("${C_HEIGHT}" == "${BASE_HEIGHT}" && -n "${C_TIP}") || ("${C_HEIGHT}" == "${TARGET_HEIGHT}" && "${C_TIP}" == "${FINAL_HASH}")) && "${A_PEERS}" -ge 2 && "${B_PEERS}" -ge 1 && "${C_PEERS}" -ge 1 ]] || {
-  echo "unexpected peer checkpoint/connectivity final=${FINAL_HASH} b_height=${B_HEIGHT} c_height=${C_HEIGHT} peers=${A_PEERS}/${B_PEERS}/${C_PEERS}" >&2
-  exit 1
-}
-BLOCK_JSON="$(rpc_json GET "${A_RPC_ADDR}" "/get_block?height=${TARGET_HEIGHT}")"
+if (( WITH_RESTART == 1 )); then
+  [[ "${B_HEIGHT}" == "${TARGET_HEIGHT}" && "${B_TIP}" == "${FINAL_HASH}" && (("${C_HEIGHT}" == "${BASE_HEIGHT}" && -n "${C_TIP}") || ("${C_HEIGHT}" == "${TARGET_HEIGHT}" && "${C_TIP}" == "${FINAL_HASH}")) && "${A_PEERS}" -ge 2 && "${B_PEERS}" -ge 1 && "${C_PEERS}" -ge 1 ]] || {
+    echo "unexpected restart checkpoint/connectivity final=${FINAL_HASH} b_height=${B_HEIGHT} c_height=${C_HEIGHT} peers=${A_PEERS}/${B_PEERS}/${C_PEERS}" >&2
+    exit 1
+  }
+else
+  [[ (("${B_HEIGHT}" == "${BASE_HEIGHT}" && -n "${B_TIP}") || ("${B_HEIGHT}" == "${TARGET_HEIGHT}" && "${B_TIP}" == "${FINAL_HASH}")) && (("${C_HEIGHT}" == "${BASE_HEIGHT}" && -n "${C_TIP}") || ("${C_HEIGHT}" == "${TARGET_HEIGHT}" && "${C_TIP}" == "${FINAL_HASH}")) && "${A_PEERS}" -ge 2 && "${B_PEERS}" -ge 1 && "${C_PEERS}" -ge 1 ]] || {
+    echo "unexpected peer checkpoint/connectivity final=${FINAL_HASH} b_height=${B_HEIGHT} c_height=${C_HEIGHT} peers=${A_PEERS}/${B_PEERS}/${C_PEERS}" >&2
+    exit 1
+  }
+fi
+if (( WITH_RESTART == 1 )); then
+  BLOCK_JSON="$(rpc_json GET "${B_RPC_ADDR}" "/get_block?height=${TARGET_HEIGHT}")"
+else
+  BLOCK_JSON="$(rpc_json GET "${A_RPC_ADDR}" "/get_block?height=${TARGET_HEIGHT}")"
+fi
 printf '%s' "${BLOCK_JSON}" | python3 -c 'import json,sys; d=json.load(sys.stdin); sys.argv[1].lower() in d.get("block_hex", "").lower() or sys.exit("submitted tx bytes missing from target block")' "${TX_HEX}"
-export REPORT_JSON TARGET_HEIGHT BASE_HEIGHT A_HEIGHT B_HEIGHT C_HEIGHT A_TIP B_TIP C_TIP A_PID B_PID C_PID A_RPC_ADDR B_RPC_ADDR C_RPC_ADDR A_PEERS B_PEERS C_PEERS TX_ID FINAL_HASH TX_COUNT
+export REPORT_JSON TARGET_HEIGHT BASE_HEIGHT A_HEIGHT B_HEIGHT C_HEIGHT A_TIP B_TIP C_TIP A_PID B_PID C_PID A_RPC_ADDR B_RPC_ADDR C_RPC_ADDR A_PEERS B_PEERS C_PEERS TX_ID FINAL_HASH TX_COUNT WITH_RESTART PRE_RESTART_B_HEIGHT PRE_RESTART_B_TIP PRE_RESTART_B_RPC_ADDR PRE_RESTART_B_PID POST_RESTART_B_RPC_ADDR POST_RESTART_B_PID INCLUSION_PROOF_NODE
 python3 - <<'PY'
 import json, os
 participants = []
 for node in ("A", "B", "C"):
     participants.append({"name": f"node-{node.lower()}", "pid": int(os.environ[f"{node}_PID"]), "rpc": os.environ[f"{node}_RPC_ADDR"], "checkpoint_height": int(os.environ[f"{node}_HEIGHT"]), "tip_hash": os.environ[f"{node}_TIP"], "peer_count": int(os.environ[f"{node}_PEERS"])})
-report = {"scenario": "go_binary_soak_skeleton", "target_height": int(os.environ["TARGET_HEIGHT"]), "base_height": int(os.environ["BASE_HEIGHT"]), "participants": participants, "tx": {"id": os.environ["TX_ID"], "submission": "rpc:/submit_tx"}, "final": {"height": int(os.environ["TARGET_HEIGHT"]), "tip_hash": os.environ["FINAL_HASH"], "tx_count": int(os.environ["TX_COUNT"])}, "verdict": "PASS"}
+restart_enabled = os.environ["WITH_RESTART"] == "1"
+report = {
+    "scenario": "go_binary_soak_restart" if restart_enabled else "go_binary_soak_skeleton",
+    "target_height": int(os.environ["TARGET_HEIGHT"]),
+    "base_height": int(os.environ["BASE_HEIGHT"]),
+    "participants": participants,
+    "tx": {
+        "id": os.environ["TX_ID"],
+        "submission": "rpc:/submit_tx",
+        "post_restart_inclusion_node": os.environ["INCLUSION_PROOF_NODE"],
+    },
+    "final": {"height": int(os.environ["TARGET_HEIGHT"]), "tip_hash": os.environ["FINAL_HASH"], "tx_count": int(os.environ["TX_COUNT"])},
+    "verdict": "PASS",
+}
+if restart_enabled:
+    report["restart"] = {
+        "enabled": True,
+        "stopped_node": "node-b",
+        "checkpoint_before_stop": {
+            "height": int(os.environ["PRE_RESTART_B_HEIGHT"]),
+            "tip_hash": os.environ["PRE_RESTART_B_TIP"],
+            "rpc": os.environ["PRE_RESTART_B_RPC_ADDR"],
+            "pid": int(os.environ["PRE_RESTART_B_PID"]),
+        },
+        "state_after_catchup": {
+            "height": int(os.environ["B_HEIGHT"]),
+            "tip_hash": os.environ["B_TIP"],
+            "rpc": os.environ["POST_RESTART_B_RPC_ADDR"],
+            "pid": int(os.environ["POST_RESTART_B_PID"]),
+            "peer_count": int(os.environ["B_PEERS"]),
+        },
+    }
+else:
+    report["restart"] = {"enabled": False}
 with open(os.environ["REPORT_JSON"], "w", encoding="utf-8") as f:
     json.dump(report, f, indent=2, sort_keys=True)
     f.write("\n")
 PY
-if [[ "${RUBIN_PROCESS_KEEP_ARTIFACTS}" == "1" ]]; then echo "PASS: Go binary soak reached height ${TARGET_HEIGHT} with tx ${TX_ID}; report=${REPORT_JSON}"; else echo "PASS: Go binary soak reached height ${TARGET_HEIGHT} with tx ${TX_ID}; set KEEP_TMP=1 to retain report"; fi
+if [[ "${RUBIN_PROCESS_KEEP_ARTIFACTS}" == "1" ]]; then echo "PASS: Go binary soak reached height ${TARGET_HEIGHT} with tx ${TX_ID} (restart=${WITH_RESTART}); report=${REPORT_JSON}"; else echo "PASS: Go binary soak reached height ${TARGET_HEIGHT} with tx ${TX_ID} (restart=${WITH_RESTART}); set KEEP_TMP=1 to retain report"; fi

--- a/scripts/devnet-go-binary-soak.sh
+++ b/scripts/devnet-go-binary-soak.sh
@@ -119,7 +119,26 @@ block_matches_hash_canonical() {
   printf '%s' "${block_json}" | python3 -c 'import json,sys; d=json.load(sys.stdin); expected=sys.argv[1].lower(); actual=(d.get("hash") or d.get("block_hash") or "").lower(); canonical=d.get("canonical"); (actual == expected and canonical is True) or sys.exit("expected_hash=%s actual_hash=%s actual_canonical=%r" % (expected, actual or "<missing>", canonical))' "${expected_hash}"
 }
 describe_block_json() { local block_json="$1"; printf '%s' "${block_json}" | python3 -c 'import json,sys; d=json.load(sys.stdin); actual=d.get("hash") or d.get("block_hash") or "<missing>"; print("reported_hash=%s reported_canonical=%r" % (actual, d.get("canonical")))'; }
-stop_registered_pid() { local managed_pid="${1:-}" rc=0 kept=() pid; [[ -n "${managed_pid}" ]] || return 1; rubin_process_stop_pid "${managed_pid}" || rc=$?; for pid in "${RUBIN_PROCESS_PIDS[@]}"; do [[ "${pid}" == "${managed_pid}" ]] || kept+=("${pid}"); done; if ((${#kept[@]})); then RUBIN_PROCESS_PIDS=("${kept[@]}"); else RUBIN_PROCESS_PIDS=(); fi; if ((${#RUBIN_PROCESS_PIDS[@]})); then for pid in "${RUBIN_PROCESS_PIDS[@]}"; do [[ "${pid}" != "${managed_pid}" ]] || { echo "stale managed pid remained registered after stop: ${managed_pid}" >&2; return 1; }; done; fi; return "${rc}"; }
+stop_registered_pid() {
+  local managed_pid="${1:-}" rc=0 kept=() pid
+  [[ -n "${managed_pid}" ]] || return 1
+  rubin_process_stop_pid "${managed_pid}" || rc=$?
+  for pid in "${RUBIN_PROCESS_PIDS[@]}"; do
+    [[ "${pid}" == "${managed_pid}" ]] || kept+=("${pid}")
+  done
+  if ((${#kept[@]})); then
+    RUBIN_PROCESS_PIDS=("${kept[@]}")
+  else
+    RUBIN_PROCESS_PIDS=()
+  fi
+  for pid in "${RUBIN_PROCESS_PIDS[@]}"; do
+    [[ "${pid}" != "${managed_pid}" ]] || {
+      echo "stale managed pid remained registered after stop: ${managed_pid}" >&2
+      return 1
+    }
+  done
+  return "${rc}"
+}
 write_tcp_proxy() {
   cat >"${TCP_PROXY_PY}" <<'PY'
 import socket, sys, threading
@@ -296,12 +315,18 @@ if (( WITH_RESTART == 1 )); then
   }
   wait_height "${A_RPC_ADDR}" "${POST_RESTART_TARGET_HEIGHT}" 90
   wait_height "${B_RPC_ADDR}" "${POST_RESTART_TARGET_HEIGHT}" 60
-  POST_RESTART_B_BLOCK_JSON="$(rpc_json GET "${B_RPC_ADDR}" "/get_block?height=${POST_RESTART_TARGET_HEIGHT}")"
+  if ! POST_RESTART_B_BLOCK_JSON="$(rpc_json GET "${B_RPC_ADDR}" "/get_block?height=${POST_RESTART_TARGET_HEIGHT}")"; then
+    echo "post-restart restarted node-b get_block failed addr=${B_RPC_ADDR} height=${POST_RESTART_TARGET_HEIGHT}: ${POST_RESTART_B_BLOCK_JSON}" >&2
+    exit 1
+  fi
   block_matches_hash_canonical "${POST_RESTART_B_BLOCK_JSON}" "${POST_RESTART_MINE_HASH}" || {
     echo "post-restart block was not adopted by restarted node-b at height=${POST_RESTART_TARGET_HEIGHT} expected_hash=${POST_RESTART_MINE_HASH} $(describe_block_json "${POST_RESTART_B_BLOCK_JSON}")" >&2
     exit 1
   }
-  POST_RESTART_A_BLOCK_JSON="$(rpc_json GET "${A_RPC_ADDR}" "/get_block?height=${POST_RESTART_TARGET_HEIGHT}")"
+  if ! POST_RESTART_A_BLOCK_JSON="$(rpc_json GET "${A_RPC_ADDR}" "/get_block?height=${POST_RESTART_TARGET_HEIGHT}")"; then
+    echo "post-restart node-a get_block failed addr=${A_RPC_ADDR} height=${POST_RESTART_TARGET_HEIGHT}: ${POST_RESTART_A_BLOCK_JSON}" >&2
+    exit 1
+  fi
   block_matches_hash_canonical "${POST_RESTART_A_BLOCK_JSON}" "${POST_RESTART_MINE_HASH}" || {
     echo "post-restart block was not adopted by node-a at height=${POST_RESTART_TARGET_HEIGHT} expected_hash=${POST_RESTART_MINE_HASH} $(describe_block_json "${POST_RESTART_A_BLOCK_JSON}")" >&2
     exit 1
@@ -329,7 +354,10 @@ if (( WITH_RESTART == 1 )); then
     echo "unexpected post-restart adoption marker=${POST_RESTART_ACCEPTED_PEER}" >&2
     exit 1
   }
-  POST_RESTART_A_BLOCK_JSON="$(rpc_json GET "${A_RPC_ADDR}" "/get_block?height=${POST_RESTART_MINE_HEIGHT}")"
+  if ! POST_RESTART_A_BLOCK_JSON="$(rpc_json GET "${A_RPC_ADDR}" "/get_block?height=${POST_RESTART_MINE_HEIGHT}")"; then
+    echo "post-restart adoption marker node-a get_block failed addr=${A_RPC_ADDR} height=${POST_RESTART_MINE_HEIGHT}: ${POST_RESTART_A_BLOCK_JSON}" >&2
+    exit 1
+  fi
   block_matches_hash_canonical "${POST_RESTART_A_BLOCK_JSON}" "${POST_RESTART_MINE_HASH}" || {
     echo "post-restart adoption marker node-a mismatch height=${POST_RESTART_MINE_HEIGHT} expected_hash=${POST_RESTART_MINE_HASH} $(describe_block_json "${POST_RESTART_A_BLOCK_JSON}")" >&2
     exit 1
@@ -349,12 +377,21 @@ else
   }
 fi
 if (( WITH_RESTART == 1 )); then
-  BLOCK_JSON="$(rpc_json GET "${B_RPC_ADDR}" "/get_block?height=${TARGET_HEIGHT}")"
-  POST_RESTART_BLOCK_JSON="$(rpc_json GET "${B_RPC_ADDR}" "/get_block?height=${POST_RESTART_MINE_HEIGHT}")"
+  if ! BLOCK_JSON="$(rpc_json GET "${B_RPC_ADDR}" "/get_block?height=${TARGET_HEIGHT}")"; then
+    echo "restart target block get_block failed addr=${B_RPC_ADDR} height=${TARGET_HEIGHT}: ${BLOCK_JSON}" >&2
+    exit 1
+  fi
+  if ! POST_RESTART_BLOCK_JSON="$(rpc_json GET "${B_RPC_ADDR}" "/get_block?height=${POST_RESTART_MINE_HEIGHT}")"; then
+    echo "restart post-restart block get_block failed addr=${B_RPC_ADDR} height=${POST_RESTART_MINE_HEIGHT}: ${POST_RESTART_BLOCK_JSON}" >&2
+    exit 1
+  fi
   block_matches_hash_canonical "${BLOCK_JSON}" "${FINAL_HASH}" || { echo "restart target block mismatch expected_hash=${FINAL_HASH} $(describe_block_json "${BLOCK_JSON}")" >&2; exit 1; }
   block_matches_hash_canonical "${POST_RESTART_BLOCK_JSON}" "${POST_RESTART_MINE_HASH}" || { echo "restart post-restart block mismatch expected_hash=${POST_RESTART_MINE_HASH} $(describe_block_json "${POST_RESTART_BLOCK_JSON}")" >&2; exit 1; }
 else
-  BLOCK_JSON="$(rpc_json GET "${A_RPC_ADDR}" "/get_block?height=${TARGET_HEIGHT}")"
+  if ! BLOCK_JSON="$(rpc_json GET "${A_RPC_ADDR}" "/get_block?height=${TARGET_HEIGHT}")"; then
+    echo "target block get_block failed addr=${A_RPC_ADDR} height=${TARGET_HEIGHT}: ${BLOCK_JSON}" >&2
+    exit 1
+  fi
 fi
 printf '%s' "${BLOCK_JSON}" | python3 -c 'import json,sys; d=json.load(sys.stdin); sys.argv[1].lower() in d.get("block_hex", "").lower() or sys.exit("submitted tx bytes missing from target block")' "${TX_HEX}"
 if (( WITH_RESTART == 1 )); then

--- a/scripts/devnet-go-binary-soak.sh
+++ b/scripts/devnet-go-binary-soak.sh
@@ -135,6 +135,25 @@ stop_managed_pid() {
   rubin_process_stop_pid "${managed_pid}"
   unregister_managed_pid "${managed_pid}"
 }
+STARTED_PID=""
+STARTED_RPC=""
+start_node_ready() {
+  local label="$1" log_file="$2" datadir="$3" bind_addr="$4" peers="$5" attempt="$6"
+  STARTED_PID="" STARTED_RPC=""
+  if ! rubin_process_start "${log_file}" "${NODE_BIN}" --datadir "${datadir}" --bind "${bind_addr}" --rpc-bind 127.0.0.1:0 --peers "${peers}" --mine-address "${MINE_ADDRESS_HEX}"; then
+    echo "${label} attempt ${attempt} failed; retrying with fresh loopback port(s)" >&2
+    [[ -z "${RUBIN_PROCESS_LAST_PID}" ]] || stop_managed_pid "${RUBIN_PROCESS_LAST_PID}" || true
+    return 1
+  fi
+  STARTED_PID="${RUBIN_PROCESS_LAST_PID}"
+  if ! rubin_process_wait_for_log "${log_file}" "rpc: listening=" 30 "${STARTED_PID}"; then
+    echo "${label} did not become ready on attempt ${attempt}; retrying with fresh loopback port(s)" >&2
+    stop_managed_pid "${STARTED_PID}" || true
+    STARTED_PID=""
+    return 1
+  fi
+  STARTED_RPC="$(rubin_process_extract_rpc_addr "${log_file}")" || return 1
+}
 stop_cluster_attempt() {
   local managed_pid
   for managed_pid in "${C_PID:-}" "${B_PID:-}" "${A_PID:-}"; do
@@ -150,48 +169,12 @@ start_soak_cluster() {
     A_P2P_ADDR="$(allocate_loopback_addr)" || return 1
     B_P2P_ADDR="$(allocate_loopback_addr)" || return 1
     C_P2P_ADDR="$(allocate_loopback_addr)" || return 1
-    if ! rubin_process_start "${A_LOG}" "${NODE_BIN}" --datadir "${A_DIR}" --bind "${A_P2P_ADDR}" --rpc-bind 127.0.0.1:0 --peers "${B_P2P_ADDR},${C_P2P_ADDR}" --mine-address "${MINE_ADDRESS_HEX}"; then
-      echo "node-a start attempt ${attempt} failed; retrying with fresh loopback ports" >&2
-      stop_cluster_attempt
-      ((attempt++))
-      continue
-    fi
-    A_PID="${RUBIN_PROCESS_LAST_PID}"
-    if ! rubin_process_wait_for_log "${A_LOG}" "rpc: listening=" 30 "${A_PID}"; then
-      echo "node-a did not become ready on attempt ${attempt}; retrying with fresh loopback ports" >&2
-      stop_cluster_attempt
-      ((attempt++))
-      continue
-    fi
-    A_RPC_ADDR="$(rubin_process_extract_rpc_addr "${A_LOG}")" || { stop_cluster_attempt; return 1; }
-    if ! rubin_process_start "${B_LOG}" "${NODE_BIN}" --datadir "${B_DIR}" --bind "${B_P2P_ADDR}" --rpc-bind 127.0.0.1:0 --peers "${A_P2P_ADDR}" --mine-address "${MINE_ADDRESS_HEX}"; then
-      echo "node-b start attempt ${attempt} failed; retrying with fresh loopback ports" >&2
-      stop_cluster_attempt
-      ((attempt++))
-      continue
-    fi
-    B_PID="${RUBIN_PROCESS_LAST_PID}"
-    if ! rubin_process_wait_for_log "${B_LOG}" "rpc: listening=" 30 "${B_PID}"; then
-      echo "node-b did not become ready on attempt ${attempt}; retrying with fresh loopback ports" >&2
-      stop_cluster_attempt
-      ((attempt++))
-      continue
-    fi
-    B_RPC_ADDR="$(rubin_process_extract_rpc_addr "${B_LOG}")" || { stop_cluster_attempt; return 1; }
-    if ! rubin_process_start "${C_LOG}" "${NODE_BIN}" --datadir "${C_DIR}" --bind "${C_P2P_ADDR}" --rpc-bind 127.0.0.1:0 --peers "${A_P2P_ADDR}" --mine-address "${MINE_ADDRESS_HEX}"; then
-      echo "node-c start attempt ${attempt} failed; retrying with fresh loopback ports" >&2
-      stop_cluster_attempt
-      ((attempt++))
-      continue
-    fi
-    C_PID="${RUBIN_PROCESS_LAST_PID}"
-    if ! rubin_process_wait_for_log "${C_LOG}" "rpc: listening=" 30 "${C_PID}"; then
-      echo "node-c did not become ready on attempt ${attempt}; retrying with fresh loopback ports" >&2
-      stop_cluster_attempt
-      ((attempt++))
-      continue
-    fi
-    C_RPC_ADDR="$(rubin_process_extract_rpc_addr "${C_LOG}")" || { stop_cluster_attempt; return 1; }
+    start_node_ready node-a "${A_LOG}" "${A_DIR}" "${A_P2P_ADDR}" "${B_P2P_ADDR},${C_P2P_ADDR}" "${attempt}" || { stop_cluster_attempt; ((attempt++)); continue; }
+    A_PID="${STARTED_PID}" A_RPC_ADDR="${STARTED_RPC}"
+    start_node_ready node-b "${B_LOG}" "${B_DIR}" "${B_P2P_ADDR}" "${A_P2P_ADDR}" "${attempt}" || { stop_cluster_attempt; ((attempt++)); continue; }
+    B_PID="${STARTED_PID}" B_RPC_ADDR="${STARTED_RPC}"
+    start_node_ready node-c "${C_LOG}" "${C_DIR}" "${C_P2P_ADDR}" "${A_P2P_ADDR}" "${attempt}" || { stop_cluster_attempt; ((attempt++)); continue; }
+    C_PID="${STARTED_PID}" C_RPC_ADDR="${STARTED_RPC}"
     if rubin_process_wait_for_rpc_ready "${A_RPC_ADDR}" 30 && rubin_process_wait_for_rpc_ready "${B_RPC_ADDR}" 30 && rubin_process_wait_for_rpc_ready "${C_RPC_ADDR}" 30; then
       return 0
     fi
@@ -209,22 +192,12 @@ restart_node_b() {
     if (( attempt > 1 )); then
       B_P2P_ADDR="$(allocate_loopback_addr)" || return 1
     fi
-    if ! rubin_process_start "${B_RESTART_LOG}" "${NODE_BIN}" --datadir "${B_DIR}" --bind "${B_P2P_ADDR}" --rpc-bind 127.0.0.1:0 --peers "${A_P2P_ADDR}" --mine-address "${MINE_ADDRESS_HEX}"; then
-      echo "node-b restart attempt ${attempt} failed; retrying with fresh loopback port" >&2
-      [[ -z "${RUBIN_PROCESS_LAST_PID}" ]] || stop_managed_pid "${RUBIN_PROCESS_LAST_PID}" || true
-      ((attempt++))
-      continue
-    fi
-    B_PID="${RUBIN_PROCESS_LAST_PID}"
-    if rubin_process_wait_for_log "${B_RESTART_LOG}" "rpc: listening=" 30 "${B_PID}"; then
-      B_RPC_ADDR="$(rubin_process_extract_rpc_addr "${B_RESTART_LOG}")" || return 1
+    if start_node_ready "node-b restart" "${B_RESTART_LOG}" "${B_DIR}" "${B_P2P_ADDR}" "${A_P2P_ADDR}" "${attempt}"; then
+      B_PID="${STARTED_PID}" B_RPC_ADDR="${STARTED_RPC}"
       POST_RESTART_B_PID="${B_PID}"
       POST_RESTART_B_RPC_ADDR="${B_RPC_ADDR}"
       return 0
     fi
-    echo "node-b restart did not become ready on attempt ${attempt}; retrying with fresh loopback port" >&2
-    stop_managed_pid "${B_PID}" || true
-    B_PID=""
     ((attempt++))
   done
   echo "failed to restart node-b after ${NODE_RESTART_ATTEMPTS} attempts" >&2

--- a/scripts/devnet-go-binary-soak.sh
+++ b/scripts/devnet-go-binary-soak.sh
@@ -28,7 +28,13 @@ while (($#)); do
       exit 2
       ;;
   esac
-done; for tool in python3 perl lsof; do command -v "${tool}" >/dev/null 2>&1 || { echo "${tool} is required for Go binary soak evidence" >&2; exit 1; }; done
+done
+for tool in python3 perl lsof; do
+  command -v "${tool}" >/dev/null 2>&1 || {
+    echo "${tool} is required for Go binary soak evidence" >&2
+    exit 1
+  }
+done
 # Runtime txgen needs base height >=100; bound height to keep the soak finite.
 TARGET_HEIGHT="$(python3 -c 'import sys; s=sys.argv[1]; n=int(s) if s.isdecimal() else -1; 101 <= n <= 10000 or sys.exit(2); print(n)' "${TARGET_HEIGHT}")" || { echo "--target-height must be an integer in [101, 10000]" >&2; exit 2; }
 # shellcheck source=scripts/devnet-process-common.sh disable=SC1091

--- a/scripts/devnet-go-binary-soak.sh
+++ b/scripts/devnet-go-binary-soak.sh
@@ -7,6 +7,8 @@ GO_MODULE_ROOT="${REPO_ROOT}/clients/go"
 HELPER="${REPO_ROOT}/scripts/devnet-process-common.sh"
 TARGET_HEIGHT=120
 WITH_RESTART=0
+CLUSTER_START_ATTEMPTS=5
+NODE_RESTART_ATTEMPTS=5
 
 usage() { echo "usage: $0 [--target-height N] [--with-restart]" >&2; }
 while (($#)); do
@@ -133,6 +135,101 @@ stop_managed_pid() {
   rubin_process_stop_pid "${managed_pid}"
   unregister_managed_pid "${managed_pid}"
 }
+stop_cluster_attempt() {
+  local managed_pid
+  for managed_pid in "${C_PID:-}" "${B_PID:-}" "${A_PID:-}"; do
+    [[ -z "${managed_pid}" ]] || stop_managed_pid "${managed_pid}" || true
+  done
+  A_PID="" B_PID="" C_PID=""
+}
+start_soak_cluster() {
+  local attempt
+  attempt=1
+  while (( attempt <= CLUSTER_START_ATTEMPTS )); do
+    A_PID="" B_PID="" C_PID="" A_RPC_ADDR="" B_RPC_ADDR="" C_RPC_ADDR=""
+    A_P2P_ADDR="$(allocate_loopback_addr)" || return 1
+    B_P2P_ADDR="$(allocate_loopback_addr)" || return 1
+    C_P2P_ADDR="$(allocate_loopback_addr)" || return 1
+    if ! rubin_process_start "${A_LOG}" "${NODE_BIN}" --datadir "${A_DIR}" --bind "${A_P2P_ADDR}" --rpc-bind 127.0.0.1:0 --peers "${B_P2P_ADDR},${C_P2P_ADDR}" --mine-address "${MINE_ADDRESS_HEX}"; then
+      echo "node-a start attempt ${attempt} failed; retrying with fresh loopback ports" >&2
+      stop_cluster_attempt
+      ((attempt++))
+      continue
+    fi
+    A_PID="${RUBIN_PROCESS_LAST_PID}"
+    if ! rubin_process_wait_for_log "${A_LOG}" "rpc: listening=" 30 "${A_PID}"; then
+      echo "node-a did not become ready on attempt ${attempt}; retrying with fresh loopback ports" >&2
+      stop_cluster_attempt
+      ((attempt++))
+      continue
+    fi
+    A_RPC_ADDR="$(rubin_process_extract_rpc_addr "${A_LOG}")" || { stop_cluster_attempt; return 1; }
+    if ! rubin_process_start "${B_LOG}" "${NODE_BIN}" --datadir "${B_DIR}" --bind "${B_P2P_ADDR}" --rpc-bind 127.0.0.1:0 --peers "${A_P2P_ADDR}" --mine-address "${MINE_ADDRESS_HEX}"; then
+      echo "node-b start attempt ${attempt} failed; retrying with fresh loopback ports" >&2
+      stop_cluster_attempt
+      ((attempt++))
+      continue
+    fi
+    B_PID="${RUBIN_PROCESS_LAST_PID}"
+    if ! rubin_process_wait_for_log "${B_LOG}" "rpc: listening=" 30 "${B_PID}"; then
+      echo "node-b did not become ready on attempt ${attempt}; retrying with fresh loopback ports" >&2
+      stop_cluster_attempt
+      ((attempt++))
+      continue
+    fi
+    B_RPC_ADDR="$(rubin_process_extract_rpc_addr "${B_LOG}")" || { stop_cluster_attempt; return 1; }
+    if ! rubin_process_start "${C_LOG}" "${NODE_BIN}" --datadir "${C_DIR}" --bind "${C_P2P_ADDR}" --rpc-bind 127.0.0.1:0 --peers "${A_P2P_ADDR}" --mine-address "${MINE_ADDRESS_HEX}"; then
+      echo "node-c start attempt ${attempt} failed; retrying with fresh loopback ports" >&2
+      stop_cluster_attempt
+      ((attempt++))
+      continue
+    fi
+    C_PID="${RUBIN_PROCESS_LAST_PID}"
+    if ! rubin_process_wait_for_log "${C_LOG}" "rpc: listening=" 30 "${C_PID}"; then
+      echo "node-c did not become ready on attempt ${attempt}; retrying with fresh loopback ports" >&2
+      stop_cluster_attempt
+      ((attempt++))
+      continue
+    fi
+    C_RPC_ADDR="$(rubin_process_extract_rpc_addr "${C_LOG}")" || { stop_cluster_attempt; return 1; }
+    if rubin_process_wait_for_rpc_ready "${A_RPC_ADDR}" 30 && rubin_process_wait_for_rpc_ready "${B_RPC_ADDR}" 30 && rubin_process_wait_for_rpc_ready "${C_RPC_ADDR}" 30; then
+      return 0
+    fi
+    echo "cluster RPC readiness failed on attempt ${attempt}; retrying with fresh loopback ports" >&2
+    stop_cluster_attempt
+    ((attempt++))
+  done
+  echo "failed to start three-node cluster after ${CLUSTER_START_ATTEMPTS} attempts" >&2
+  return 1
+}
+restart_node_b() {
+  local attempt
+  attempt=1
+  while (( attempt <= NODE_RESTART_ATTEMPTS )); do
+    if (( attempt > 1 )); then
+      B_P2P_ADDR="$(allocate_loopback_addr)" || return 1
+    fi
+    if ! rubin_process_start "${B_RESTART_LOG}" "${NODE_BIN}" --datadir "${B_DIR}" --bind "${B_P2P_ADDR}" --rpc-bind 127.0.0.1:0 --peers "${A_P2P_ADDR}" --mine-address "${MINE_ADDRESS_HEX}"; then
+      echo "node-b restart attempt ${attempt} failed; retrying with fresh loopback port" >&2
+      [[ -z "${RUBIN_PROCESS_LAST_PID}" ]] || stop_managed_pid "${RUBIN_PROCESS_LAST_PID}" || true
+      ((attempt++))
+      continue
+    fi
+    B_PID="${RUBIN_PROCESS_LAST_PID}"
+    if rubin_process_wait_for_log "${B_RESTART_LOG}" "rpc: listening=" 30 "${B_PID}"; then
+      B_RPC_ADDR="$(rubin_process_extract_rpc_addr "${B_RESTART_LOG}")" || return 1
+      POST_RESTART_B_PID="${B_PID}"
+      POST_RESTART_B_RPC_ADDR="${B_RPC_ADDR}"
+      return 0
+    fi
+    echo "node-b restart did not become ready on attempt ${attempt}; retrying with fresh loopback port" >&2
+    stop_managed_pid "${B_PID}" || true
+    B_PID=""
+    ((attempt++))
+  done
+  echo "failed to restart node-b after ${NODE_RESTART_ATTEMPTS} attempts" >&2
+  return 1
+}
 write_keygen() {
   cat >"${KEYGEN_GO}" <<'EOF'
 package main
@@ -164,24 +261,7 @@ echo "Mining mature Go chain to height ${BASE_HEIGHT}"
 cp -R "${A_DIR}/." "${B_DIR}/"
 cp -R "${A_DIR}/." "${C_DIR}/"
 echo "Starting three Go rubin-node processes"
-A_PID=""
-B_P2P_ADDR="$(allocate_loopback_addr)"
-C_P2P_ADDR="$(allocate_loopback_addr)"
-for _ in 1 2 3; do
-  A_P2P_ADDR="$(allocate_loopback_addr)"
-  if rubin_process_start "${A_LOG}" "${NODE_BIN}" --datadir "${A_DIR}" --bind "${A_P2P_ADDR}" --rpc-bind 127.0.0.1:0 --peers "${B_P2P_ADDR},${C_P2P_ADDR}" --mine-address "${MINE_ADDRESS_HEX}" && rubin_process_wait_for_log "${A_LOG}" "rpc: listening=" 30 "${RUBIN_PROCESS_LAST_PID}"; then A_PID="${RUBIN_PROCESS_LAST_PID}"; A_RPC_ADDR="$(rubin_process_extract_rpc_addr "${A_LOG}")"; break; fi
-  [[ -z "${RUBIN_PROCESS_LAST_PID}" ]] || stop_managed_pid "${RUBIN_PROCESS_LAST_PID}" || true
-done
-[[ -n "${A_PID}" ]] || { echo "failed to start node-a after retrying loopback bind ports" >&2; exit 1; }
-rubin_process_start "${B_LOG}" "${NODE_BIN}" --datadir "${B_DIR}" --bind "${B_P2P_ADDR}" --rpc-bind 127.0.0.1:0 --peers "${A_P2P_ADDR}" --mine-address "${MINE_ADDRESS_HEX}"
-B_PID="${RUBIN_PROCESS_LAST_PID}"
-rubin_process_start "${C_LOG}" "${NODE_BIN}" --datadir "${C_DIR}" --bind "${C_P2P_ADDR}" --rpc-bind 127.0.0.1:0 --peers "${A_P2P_ADDR}" --mine-address "${MINE_ADDRESS_HEX}"
-C_PID="${RUBIN_PROCESS_LAST_PID}"
-rubin_process_wait_for_log "${B_LOG}" "rpc: listening=" 30 "${B_PID}"
-B_RPC_ADDR="$(rubin_process_extract_rpc_addr "${B_LOG}")"
-rubin_process_wait_for_log "${C_LOG}" "rpc: listening=" 30 "${C_PID}"
-C_RPC_ADDR="$(rubin_process_extract_rpc_addr "${C_LOG}")"
-for addr in "${A_RPC_ADDR}" "${B_RPC_ADDR}" "${C_RPC_ADDR}"; do rubin_process_wait_for_rpc_ready "${addr}" 30; done
+start_soak_cluster
 for addr in "${A_RPC_ADDR}" "${B_RPC_ADDR}" "${C_RPC_ADDR}"; do wait_height "${addr}" "${BASE_HEIGHT}" 30; done
 if (( WITH_RESTART == 1 )); then
   IFS=$'\t' read -r PRE_RESTART_B_HEIGHT PRE_RESTART_B_TIP < <(tip_tsv "${B_RPC_ADDR}")
@@ -203,12 +283,7 @@ IFS=$'\t' read -r FINAL_HEIGHT FINAL_HASH TX_COUNT < <(printf '%s' "${MINE_JSON}
 wait_height "${A_RPC_ADDR}" "${TARGET_HEIGHT}" 30
 if (( WITH_RESTART == 1 )); then
   echo "Restarting node-b from disk-backed datadir ${B_DIR}"
-  rubin_process_start "${B_RESTART_LOG}" "${NODE_BIN}" --datadir "${B_DIR}" --bind "${B_P2P_ADDR}" --rpc-bind 127.0.0.1:0 --peers "${A_P2P_ADDR}" --mine-address "${MINE_ADDRESS_HEX}"
-  B_PID="${RUBIN_PROCESS_LAST_PID}"
-  POST_RESTART_B_PID="${B_PID}"
-  rubin_process_wait_for_log "${B_RESTART_LOG}" "rpc: listening=" 30 "${B_PID}"
-  B_RPC_ADDR="$(rubin_process_extract_rpc_addr "${B_RESTART_LOG}")"
-  POST_RESTART_B_RPC_ADDR="${B_RPC_ADDR}"
+  restart_node_b
   rubin_process_wait_for_rpc_ready "${B_RPC_ADDR}" 30
   wait_height "${B_RPC_ADDR}" "${TARGET_HEIGHT}" 60
   IFS=$'\t' read -r POST_RESTART_CATCHUP_HEIGHT POST_RESTART_CATCHUP_TIP < <(tip_tsv "${B_RPC_ADDR}")
@@ -239,11 +314,7 @@ fi
 IFS=$'\t' read -r A_HEIGHT A_TIP < <(tip_tsv "${A_RPC_ADDR}")
 IFS=$'\t' read -r B_HEIGHT B_TIP < <(tip_tsv "${B_RPC_ADDR}")
 IFS=$'\t' read -r C_HEIGHT C_TIP < <(tip_tsv "${C_RPC_ADDR}")
-if (( WITH_RESTART == 1 )); then
-  A_PEERS="$(wait_peers "${A_RPC_ADDR}" 1 30)"
-else
-  A_PEERS="$(wait_peers "${A_RPC_ADDR}" 2 30)"
-fi
+A_PEERS="$(wait_peers "${A_RPC_ADDR}" 2 30)"
 B_PEERS="$(wait_peers "${B_RPC_ADDR}" 1 30)" C_PEERS="$(wait_peers "${C_RPC_ADDR}" 1 30)"
 if (( WITH_RESTART == 1 )); then
   [[ "${POST_RESTART_ACCEPTED_PEER}" == "node-a" ]] || {
@@ -255,7 +326,7 @@ if (( WITH_RESTART == 1 )); then
     echo "post-restart adoption marker node-a mismatch height=${A_HEIGHT} tip=${A_TIP}" >&2
     exit 1
   }
-  [[ "${A_HEIGHT}" == "${POST_RESTART_MINE_HEIGHT}" && "${A_TIP}" == "${POST_RESTART_MINE_HASH}" && "${B_HEIGHT}" == "${POST_RESTART_MINE_HEIGHT}" && "${B_TIP}" == "${POST_RESTART_MINE_HASH}" && (("${C_HEIGHT}" == "${BASE_HEIGHT}" && -n "${C_TIP}") || ("${C_HEIGHT}" == "${TARGET_HEIGHT}" && "${C_TIP}" == "${FINAL_HASH}") || ("${C_HEIGHT}" == "${POST_RESTART_MINE_HEIGHT}" && "${C_TIP}" == "${POST_RESTART_MINE_HASH}")) && "${A_PEERS}" -ge 1 && "${B_PEERS}" -ge 1 && "${C_PEERS}" -ge 1 ]] || {
+  [[ "${A_HEIGHT}" == "${POST_RESTART_MINE_HEIGHT}" && "${A_TIP}" == "${POST_RESTART_MINE_HASH}" && "${B_HEIGHT}" == "${POST_RESTART_MINE_HEIGHT}" && "${B_TIP}" == "${POST_RESTART_MINE_HASH}" && (("${C_HEIGHT}" == "${BASE_HEIGHT}" && -n "${C_TIP}") || ("${C_HEIGHT}" == "${TARGET_HEIGHT}" && "${C_TIP}" == "${FINAL_HASH}") || ("${C_HEIGHT}" == "${POST_RESTART_MINE_HEIGHT}" && "${C_TIP}" == "${POST_RESTART_MINE_HASH}")) && "${A_PEERS}" -ge 2 && "${B_PEERS}" -ge 1 && "${C_PEERS}" -ge 1 ]] || {
     echo "unexpected restart checkpoint/connectivity post_restart=${POST_RESTART_MINE_HASH} b_height=${B_HEIGHT} c_height=${C_HEIGHT} peers=${A_PEERS}/${B_PEERS}/${C_PEERS}" >&2
     exit 1
   }
@@ -296,7 +367,7 @@ report = {
     "tx": {
         "id": os.environ["TX_ID"],
         "submission": "rpc:/submit_tx",
-        "post_restart_inclusion_node": os.environ["INCLUSION_PROOF_NODE"],
+        "inclusion_proof_node": os.environ["INCLUSION_PROOF_NODE"],
         "inclusion_height": int(os.environ["TARGET_HEIGHT"]),
     },
     "final": {

--- a/scripts/devnet-go-binary-soak.sh
+++ b/scripts/devnet-go-binary-soak.sh
@@ -55,6 +55,9 @@ PRE_RESTART_B_RPC_ADDR=""
 PRE_RESTART_B_PID=""
 POST_RESTART_B_RPC_ADDR=""
 POST_RESTART_B_PID=""
+POST_RESTART_CATCHUP_HEIGHT=""
+POST_RESTART_CATCHUP_TIP=""
+POST_RESTART_CATCHUP_PEERS="0"
 POST_RESTART_MINE_HEIGHT=""
 POST_RESTART_MINE_HASH=""
 POST_RESTART_MINE_TX_COUNT="0"
@@ -198,6 +201,8 @@ if (( WITH_RESTART == 1 )); then
   POST_RESTART_B_RPC_ADDR="${B_RPC_ADDR}"
   rubin_process_wait_for_rpc_ready "${B_RPC_ADDR}" 30
   wait_height "${B_RPC_ADDR}" "${TARGET_HEIGHT}" 60
+  IFS=$'\t' read -r POST_RESTART_CATCHUP_HEIGHT POST_RESTART_CATCHUP_TIP < <(tip_tsv "${B_RPC_ADDR}")
+  POST_RESTART_CATCHUP_PEERS="$(wait_peers "${B_RPC_ADDR}" 1 30)"
   echo "Mining one additional block after restart to exercise live process path"
   if ! POST_RESTART_MINE_JSON="$(rpc_json POST "${B_RPC_ADDR}" /mine_next '{}')"; then echo "post-restart mine_next request failed: ${POST_RESTART_MINE_JSON}" >&2; exit 1; fi
   IFS=$'\t' read -r POST_RESTART_MINE_HEIGHT POST_RESTART_MINE_HASH POST_RESTART_MINE_TX_COUNT < <(printf '%s' "${POST_RESTART_MINE_JSON}" | python3 -c 'import json,sys; d=json.load(sys.stdin); (d.get("mined") is True) or sys.exit("post-restart mine_next failed: "+str(d.get("error","missing mined result"))); print(d["height"], d["block_hash"], d["tx_count"], sep="\t")')
@@ -242,7 +247,7 @@ printf '%s' "${BLOCK_JSON}" | python3 -c 'import json,sys; d=json.load(sys.stdin
 if (( WITH_RESTART == 1 )); then
   printf '%s' "${POST_RESTART_BLOCK_JSON}" | python3 -c 'import json,sys; d=json.load(sys.stdin); h=d.get("block_hex",""); (isinstance(h, str) and len(h) > 0) or sys.exit("post-restart block visibility check failed")'
 fi
-export REPORT_JSON TARGET_HEIGHT BASE_HEIGHT A_HEIGHT B_HEIGHT C_HEIGHT A_TIP B_TIP C_TIP A_PID B_PID C_PID A_RPC_ADDR B_RPC_ADDR C_RPC_ADDR A_PEERS B_PEERS C_PEERS TX_ID FINAL_HASH TX_COUNT WITH_RESTART PRE_RESTART_B_HEIGHT PRE_RESTART_B_TIP PRE_RESTART_B_RPC_ADDR PRE_RESTART_B_PID POST_RESTART_B_RPC_ADDR POST_RESTART_B_PID POST_RESTART_MINE_HEIGHT POST_RESTART_MINE_HASH POST_RESTART_MINE_TX_COUNT INCLUSION_PROOF_NODE
+export REPORT_JSON TARGET_HEIGHT BASE_HEIGHT A_HEIGHT B_HEIGHT C_HEIGHT A_TIP B_TIP C_TIP A_PID B_PID C_PID A_RPC_ADDR B_RPC_ADDR C_RPC_ADDR A_PEERS B_PEERS C_PEERS TX_ID FINAL_HASH TX_COUNT WITH_RESTART PRE_RESTART_B_HEIGHT PRE_RESTART_B_TIP PRE_RESTART_B_RPC_ADDR PRE_RESTART_B_PID POST_RESTART_B_RPC_ADDR POST_RESTART_B_PID POST_RESTART_CATCHUP_HEIGHT POST_RESTART_CATCHUP_TIP POST_RESTART_CATCHUP_PEERS POST_RESTART_MINE_HEIGHT POST_RESTART_MINE_HASH POST_RESTART_MINE_TX_COUNT INCLUSION_PROOF_NODE
 python3 - <<'PY'
 import json, os
 participants = []
@@ -278,11 +283,11 @@ if restart_enabled:
             "pid": int(os.environ["PRE_RESTART_B_PID"]),
         },
         "state_after_catchup": {
-            "height": int(os.environ["B_HEIGHT"]),
-            "tip_hash": os.environ["B_TIP"],
+            "height": int(os.environ["POST_RESTART_CATCHUP_HEIGHT"]),
+            "tip_hash": os.environ["POST_RESTART_CATCHUP_TIP"],
             "rpc": os.environ["POST_RESTART_B_RPC_ADDR"],
             "pid": int(os.environ["POST_RESTART_B_PID"]),
-            "peer_count": int(os.environ["B_PEERS"]),
+            "peer_count": int(os.environ["POST_RESTART_CATCHUP_PEERS"]),
         },
         "post_restart_live_action": {
             "action": "mine_next",

--- a/scripts/devnet-go-binary-soak.sh
+++ b/scripts/devnet-go-binary-soak.sh
@@ -55,6 +55,9 @@ PRE_RESTART_B_RPC_ADDR=""
 PRE_RESTART_B_PID=""
 POST_RESTART_B_RPC_ADDR=""
 POST_RESTART_B_PID=""
+POST_RESTART_MINE_HEIGHT=""
+POST_RESTART_MINE_HASH=""
+POST_RESTART_MINE_TX_COUNT="0"
 INCLUSION_PROOF_NODE="node-a"
 rpc_json() {
   local method="$1" addr="$2" path="$3" body="${4:-}"
@@ -195,22 +198,35 @@ if (( WITH_RESTART == 1 )); then
   POST_RESTART_B_RPC_ADDR="${B_RPC_ADDR}"
   rubin_process_wait_for_rpc_ready "${B_RPC_ADDR}" 30
   wait_height "${B_RPC_ADDR}" "${TARGET_HEIGHT}" 60
-  INCLUSION_PROOF_NODE="node-b-restarted"
+  echo "Mining one additional block after restart to exercise live process path"
+  if ! POST_RESTART_MINE_JSON="$(rpc_json POST "${B_RPC_ADDR}" /mine_next '{}')"; then echo "post-restart mine_next request failed: ${POST_RESTART_MINE_JSON}" >&2; exit 1; fi
+  IFS=$'\t' read -r POST_RESTART_MINE_HEIGHT POST_RESTART_MINE_HASH POST_RESTART_MINE_TX_COUNT < <(printf '%s' "${POST_RESTART_MINE_JSON}" | python3 -c 'import json,sys; d=json.load(sys.stdin); (d.get("mined") is True) or sys.exit("post-restart mine_next failed: "+str(d.get("error","missing mined result"))); print(d["height"], d["block_hash"], d["tx_count"], sep="\t")')
+  POST_RESTART_TARGET_HEIGHT=$((TARGET_HEIGHT + 1))
+  [[ "${POST_RESTART_MINE_HEIGHT}" == "${POST_RESTART_TARGET_HEIGHT}" && "${POST_RESTART_MINE_TX_COUNT}" -ge 1 ]] || {
+    echo "unexpected post-restart mine_next result height=${POST_RESTART_MINE_HEIGHT} tx_count=${POST_RESTART_MINE_TX_COUNT}" >&2
+    exit 1
+  }
+  wait_height "${B_RPC_ADDR}" "${POST_RESTART_TARGET_HEIGHT}" 60
+  INCLUSION_PROOF_NODE="node-b"
 fi
 IFS=$'\t' read -r A_HEIGHT A_TIP < <(tip_tsv "${A_RPC_ADDR}")
 IFS=$'\t' read -r B_HEIGHT B_TIP < <(tip_tsv "${B_RPC_ADDR}")
 IFS=$'\t' read -r C_HEIGHT C_TIP < <(tip_tsv "${C_RPC_ADDR}")
 A_PEERS="$(wait_peers "${A_RPC_ADDR}" 2 30)" B_PEERS="$(wait_peers "${B_RPC_ADDR}" 1 30)" C_PEERS="$(wait_peers "${C_RPC_ADDR}" 1 30)"
-[[ "${A_HEIGHT}" == "${TARGET_HEIGHT}" && "${A_TIP}" == "${FINAL_HASH}" ]] || {
-  echo "unexpected node-a checkpoint final=${FINAL_HASH} a_height=${A_HEIGHT} a_tip=${A_TIP}" >&2
-  exit 1
-}
 if (( WITH_RESTART == 1 )); then
-  [[ "${B_HEIGHT}" == "${TARGET_HEIGHT}" && "${B_TIP}" == "${FINAL_HASH}" && (("${C_HEIGHT}" == "${BASE_HEIGHT}" && -n "${C_TIP}") || ("${C_HEIGHT}" == "${TARGET_HEIGHT}" && "${C_TIP}" == "${FINAL_HASH}")) && "${A_PEERS}" -ge 2 && "${B_PEERS}" -ge 1 && "${C_PEERS}" -ge 1 ]] || {
-    echo "unexpected restart checkpoint/connectivity final=${FINAL_HASH} b_height=${B_HEIGHT} c_height=${C_HEIGHT} peers=${A_PEERS}/${B_PEERS}/${C_PEERS}" >&2
+  [[ (("${A_HEIGHT}" == "${TARGET_HEIGHT}" && "${A_TIP}" == "${FINAL_HASH}") || ("${A_HEIGHT}" == "${POST_RESTART_MINE_HEIGHT}" && "${A_TIP}" == "${POST_RESTART_MINE_HASH}")) ]] || {
+    echo "unexpected restart node-a checkpoint target=${TARGET_HEIGHT}/${FINAL_HASH} post_restart=${POST_RESTART_MINE_HEIGHT}/${POST_RESTART_MINE_HASH} got=${A_HEIGHT}/${A_TIP}" >&2
+    exit 1
+  }
+  [[ "${B_HEIGHT}" == "${POST_RESTART_MINE_HEIGHT}" && "${B_TIP}" == "${POST_RESTART_MINE_HASH}" && (("${C_HEIGHT}" == "${BASE_HEIGHT}" && -n "${C_TIP}") || ("${C_HEIGHT}" == "${TARGET_HEIGHT}" && "${C_TIP}" == "${FINAL_HASH}") || ("${C_HEIGHT}" == "${POST_RESTART_MINE_HEIGHT}" && "${C_TIP}" == "${POST_RESTART_MINE_HASH}")) && "${A_PEERS}" -ge 2 && "${B_PEERS}" -ge 1 && "${C_PEERS}" -ge 1 ]] || {
+    echo "unexpected restart checkpoint/connectivity post_restart=${POST_RESTART_MINE_HASH} b_height=${B_HEIGHT} c_height=${C_HEIGHT} peers=${A_PEERS}/${B_PEERS}/${C_PEERS}" >&2
     exit 1
   }
 else
+  [[ "${A_HEIGHT}" == "${TARGET_HEIGHT}" && "${A_TIP}" == "${FINAL_HASH}" ]] || {
+    echo "unexpected node-a checkpoint final=${FINAL_HASH} a_height=${A_HEIGHT} a_tip=${A_TIP}" >&2
+    exit 1
+  }
   [[ (("${B_HEIGHT}" == "${BASE_HEIGHT}" && -n "${B_TIP}") || ("${B_HEIGHT}" == "${TARGET_HEIGHT}" && "${B_TIP}" == "${FINAL_HASH}")) && (("${C_HEIGHT}" == "${BASE_HEIGHT}" && -n "${C_TIP}") || ("${C_HEIGHT}" == "${TARGET_HEIGHT}" && "${C_TIP}" == "${FINAL_HASH}")) && "${A_PEERS}" -ge 2 && "${B_PEERS}" -ge 1 && "${C_PEERS}" -ge 1 ]] || {
     echo "unexpected peer checkpoint/connectivity final=${FINAL_HASH} b_height=${B_HEIGHT} c_height=${C_HEIGHT} peers=${A_PEERS}/${B_PEERS}/${C_PEERS}" >&2
     exit 1
@@ -218,11 +234,15 @@ else
 fi
 if (( WITH_RESTART == 1 )); then
   BLOCK_JSON="$(rpc_json GET "${B_RPC_ADDR}" "/get_block?height=${TARGET_HEIGHT}")"
+  POST_RESTART_BLOCK_JSON="$(rpc_json GET "${B_RPC_ADDR}" "/get_block?height=${POST_RESTART_MINE_HEIGHT}")"
 else
   BLOCK_JSON="$(rpc_json GET "${A_RPC_ADDR}" "/get_block?height=${TARGET_HEIGHT}")"
 fi
 printf '%s' "${BLOCK_JSON}" | python3 -c 'import json,sys; d=json.load(sys.stdin); sys.argv[1].lower() in d.get("block_hex", "").lower() or sys.exit("submitted tx bytes missing from target block")' "${TX_HEX}"
-export REPORT_JSON TARGET_HEIGHT BASE_HEIGHT A_HEIGHT B_HEIGHT C_HEIGHT A_TIP B_TIP C_TIP A_PID B_PID C_PID A_RPC_ADDR B_RPC_ADDR C_RPC_ADDR A_PEERS B_PEERS C_PEERS TX_ID FINAL_HASH TX_COUNT WITH_RESTART PRE_RESTART_B_HEIGHT PRE_RESTART_B_TIP PRE_RESTART_B_RPC_ADDR PRE_RESTART_B_PID POST_RESTART_B_RPC_ADDR POST_RESTART_B_PID INCLUSION_PROOF_NODE
+if (( WITH_RESTART == 1 )); then
+  printf '%s' "${POST_RESTART_BLOCK_JSON}" | python3 -c 'import json,sys; d=json.load(sys.stdin); h=d.get("block_hex",""); (isinstance(h, str) and len(h) > 0) or sys.exit("post-restart block visibility check failed")'
+fi
+export REPORT_JSON TARGET_HEIGHT BASE_HEIGHT A_HEIGHT B_HEIGHT C_HEIGHT A_TIP B_TIP C_TIP A_PID B_PID C_PID A_RPC_ADDR B_RPC_ADDR C_RPC_ADDR A_PEERS B_PEERS C_PEERS TX_ID FINAL_HASH TX_COUNT WITH_RESTART PRE_RESTART_B_HEIGHT PRE_RESTART_B_TIP PRE_RESTART_B_RPC_ADDR PRE_RESTART_B_PID POST_RESTART_B_RPC_ADDR POST_RESTART_B_PID POST_RESTART_MINE_HEIGHT POST_RESTART_MINE_HASH POST_RESTART_MINE_TX_COUNT INCLUSION_PROOF_NODE
 python3 - <<'PY'
 import json, os
 participants = []
@@ -238,8 +258,13 @@ report = {
         "id": os.environ["TX_ID"],
         "submission": "rpc:/submit_tx",
         "post_restart_inclusion_node": os.environ["INCLUSION_PROOF_NODE"],
+        "inclusion_height": int(os.environ["TARGET_HEIGHT"]),
     },
-    "final": {"height": int(os.environ["TARGET_HEIGHT"]), "tip_hash": os.environ["FINAL_HASH"], "tx_count": int(os.environ["TX_COUNT"])},
+    "final": {
+        "height": int(os.environ["POST_RESTART_MINE_HEIGHT"] if restart_enabled else os.environ["TARGET_HEIGHT"]),
+        "tip_hash": os.environ["POST_RESTART_MINE_HASH"] if restart_enabled else os.environ["FINAL_HASH"],
+        "tx_count": int(os.environ["POST_RESTART_MINE_TX_COUNT"] if restart_enabled else os.environ["TX_COUNT"]),
+    },
     "verdict": "PASS",
 }
 if restart_enabled:
@@ -259,6 +284,12 @@ if restart_enabled:
             "pid": int(os.environ["POST_RESTART_B_PID"]),
             "peer_count": int(os.environ["B_PEERS"]),
         },
+        "post_restart_live_action": {
+            "action": "mine_next",
+            "height": int(os.environ["POST_RESTART_MINE_HEIGHT"]),
+            "block_hash": os.environ["POST_RESTART_MINE_HASH"],
+            "tx_count": int(os.environ["POST_RESTART_MINE_TX_COUNT"]),
+        },
     }
 else:
     report["restart"] = {"enabled": False}
@@ -266,4 +297,13 @@ with open(os.environ["REPORT_JSON"], "w", encoding="utf-8") as f:
     json.dump(report, f, indent=2, sort_keys=True)
     f.write("\n")
 PY
-if [[ "${RUBIN_PROCESS_KEEP_ARTIFACTS}" == "1" ]]; then echo "PASS: Go binary soak reached height ${TARGET_HEIGHT} with tx ${TX_ID} (restart=${WITH_RESTART}); report=${REPORT_JSON}"; else echo "PASS: Go binary soak reached height ${TARGET_HEIGHT} with tx ${TX_ID} (restart=${WITH_RESTART}); set KEEP_TMP=1 to retain report"; fi
+if (( WITH_RESTART == 1 )); then
+  PASS_SUMMARY="PASS: Go binary soak mined tx at height ${TARGET_HEIGHT} and post-restart block at height ${POST_RESTART_MINE_HEIGHT} (tx=${TX_ID}, restart=1)"
+else
+  PASS_SUMMARY="PASS: Go binary soak reached height ${TARGET_HEIGHT} with tx ${TX_ID} (restart=0)"
+fi
+if [[ "${RUBIN_PROCESS_KEEP_ARTIFACTS}" == "1" ]]; then
+  echo "${PASS_SUMMARY}; report=${REPORT_JSON}"
+else
+  echo "${PASS_SUMMARY}; set KEEP_TMP=1 to retain report"
+fi

--- a/scripts/devnet-go-binary-soak.sh
+++ b/scripts/devnet-go-binary-soak.sh
@@ -7,8 +7,6 @@ GO_MODULE_ROOT="${REPO_ROOT}/clients/go"
 HELPER="${REPO_ROOT}/scripts/devnet-process-common.sh"
 TARGET_HEIGHT=120
 WITH_RESTART=0
-CLUSTER_START_ATTEMPTS=5
-NODE_RESTART_ATTEMPTS=5
 
 usage() { echo "usage: $0 [--target-height N] [--with-restart]" >&2; }
 while (($#)); do
@@ -41,6 +39,7 @@ NODE_BIN="${RUBIN_PROCESS_ARTIFACT_ROOT}/rubin-node-go"
 TXGEN_BIN="${RUBIN_PROCESS_ARTIFACT_ROOT}/rubin-txgen"
 KEYGEN_GO="${RUBIN_PROCESS_ARTIFACT_ROOT}/keygen.go"
 KEYGEN_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/keygen.json"
+TCP_PROXY_PY="${RUBIN_PROCESS_ARTIFACT_ROOT}/tcp_proxy.py"
 REPORT_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/go-binary-soak-report.json"
 BASE_HEIGHT=$((TARGET_HEIGHT - 1))
 BASE_MINE_BLOCKS=$((BASE_HEIGHT + 1))
@@ -48,14 +47,15 @@ A_DIR="${RUBIN_PROCESS_ARTIFACT_ROOT}/node-a"
 B_DIR="${RUBIN_PROCESS_ARTIFACT_ROOT}/node-b"
 C_DIR="${RUBIN_PROCESS_ARTIFACT_ROOT}/node-c"
 A_LOG="node-a.log" B_LOG="node-b.log" C_LOG="node-c.log"
+B_PROXY_LOG="node-b-proxy.log" C_PROXY_LOG="node-c-proxy.log"
 B_RESTART_LOG="node-b-restart.log"
 MINE_LOG="${RUBIN_PROCESS_ARTIFACT_ROOT}/mine-base.log"
 RUBIN_PROCESS_LOGS+=("${MINE_LOG}")
 PRE_RESTART_B_HEIGHT=""
 PRE_RESTART_B_TIP=""
-PRE_RESTART_B_RPC_ADDR=""
+PRE_RESTART_B_RPC_ADDR="" PRE_RESTART_B_P2P_ADDR=""
 PRE_RESTART_B_PID=""
-POST_RESTART_B_RPC_ADDR=""
+POST_RESTART_B_RPC_ADDR="" POST_RESTART_B_P2P_ADDR=""
 POST_RESTART_B_PID=""
 POST_RESTART_CATCHUP_HEIGHT=""
 POST_RESTART_CATCHUP_TIP=""
@@ -65,6 +65,8 @@ POST_RESTART_MINE_HASH=""
 POST_RESTART_MINE_TX_COUNT="0"
 POST_RESTART_ACCEPTED_PEER=""
 INCLUSION_PROOF_NODE="node-a"
+B_PROXY_TARGET="${RUBIN_PROCESS_ARTIFACT_ROOT}/node-b-proxy-target"
+C_PROXY_TARGET="${RUBIN_PROCESS_ARTIFACT_ROOT}/node-c-proxy-target"
 rpc_json() {
   local method="$1" addr="$2" path="$3" body="${4:-}"
   python3 - "${method}" "${addr}" "${path}" "${body}" <<'PY'
@@ -118,90 +120,108 @@ block_matches_hash_canonical() {
   local block_json="$1" expected_hash="$2"
   printf '%s' "${block_json}" | python3 -c 'import json,sys; d=json.load(sys.stdin); expected=sys.argv[1].lower(); actual=(d.get("hash") or d.get("block_hash") or "").lower(); actual == expected or sys.exit(1); d.get("canonical") is True or sys.exit(2)' "${expected_hash}"
 }
-allocate_loopback_addr() {
-  python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(f"127.0.0.1:{s.getsockname()[1]}"); s.close()'
+write_tcp_proxy() {
+  cat >"${TCP_PROXY_PY}" <<'PY'
+import socket, sys, threading
+target_file = sys.argv[1]; listener = socket.socket(); listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1); listener.bind(("127.0.0.1", 0)); listener.listen()
+print(f"proxy: listening={listener.getsockname()[0]}:{listener.getsockname()[1]}", flush=True)
+def pump(src, dst):
+    try:
+        while data := src.recv(65536):
+            dst.sendall(data)
+    except OSError:
+        pass
+    for sock in (src, dst):
+        try: sock.close()
+        except OSError: pass
+while True:
+    client, _ = listener.accept()
+    try:
+        host, port = open(target_file, encoding="utf-8").read().strip().rsplit(":", 1)
+        if host != "127.0.0.1": raise ValueError("proxy target must be loopback")
+        upstream = socket.create_connection((host, int(port)), timeout=5)
+    except Exception:
+        client.close(); continue
+    for src, dst in ((client, upstream), (upstream, client)):
+        threading.Thread(target=pump, args=(src, dst), daemon=True).start()
+PY
 }
-unregister_managed_pid() {
-  local stale_pid="${1:-}" kept=() pid
-  [[ -n "${stale_pid}" ]] || return 1
-  for pid in "${RUBIN_PROCESS_PIDS[@]}"; do
-    [[ "${pid}" == "${stale_pid}" ]] || kept+=("${pid}")
-  done
-  RUBIN_PROCESS_PIDS=("${kept[@]}")
-}
-stop_managed_pid() {
-  local managed_pid="${1:-}"
-  [[ -n "${managed_pid}" ]] || return 1
-  rubin_process_stop_pid "${managed_pid}"
-  unregister_managed_pid "${managed_pid}"
+PROXY_PID=""
+PROXY_ADDR=""
+start_proxy() {
+  local log_file="$1" target_file="$2"
+  PROXY_PID="" PROXY_ADDR=""
+  rubin_process_start "${log_file}" python3 -u "${TCP_PROXY_PY}" "${target_file}"
+  PROXY_PID="${RUBIN_PROCESS_LAST_PID}"
+  rubin_process_wait_for_log "${log_file}" "proxy: listening=" 30 "${PROXY_PID}"
+  PROXY_ADDR="$(sed -n 's/.*proxy: listening=//p' "${RUBIN_PROCESS_ARTIFACT_ROOT}/${log_file}" | tail -n 1 | tr -d '[:space:]')"
+  [[ -n "${PROXY_ADDR}" ]] || { echo "missing proxy listening banner in ${log_file}" >&2; return 1; }
+  [[ "${PROXY_ADDR}" == 127.0.0.1:* ]] || { echo "proxy must listen on 127.0.0.1, got ${PROXY_ADDR}" >&2; return 1; }
 }
 STARTED_PID=""
 STARTED_RPC=""
+STARTED_P2P=""
+p2p_addr_for_pid() {
+  local pid="$1" rpc_addr="$2" timeout="$3"
+  command -v lsof >/dev/null 2>&1 || { echo "lsof is required to resolve p2p :0 bind address" >&2; return 1; }
+  python3 - "${pid}" "${rpc_addr}" "${timeout}" <<'PY'
+import re, subprocess, sys, time
+pid, rpc_addr, timeout = sys.argv[1], sys.argv[2], int(sys.argv[3]); deadline = time.time() + timeout
+while time.time() < deadline:
+    proc = subprocess.run(["lsof", "-nP", "-a", "-p", pid, "-iTCP", "-sTCP:LISTEN", "-Fn"], text=True, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+    addrs = sorted({line[1:].strip() for line in proc.stdout.splitlines() if line.startswith("n") and line[1:].strip() != rpc_addr and re.fullmatch(r"127\.0\.0\.1:[0-9]+", line[1:].strip())})
+    if len(addrs) == 1:
+        print(addrs[0]); sys.exit(0)
+    if len(addrs) > 1:
+        sys.exit(f"ambiguous p2p listen addresses for pid={pid}: {addrs}")
+    time.sleep(1)
+sys.exit(f"timeout resolving p2p listen address for pid={pid}")
+PY
+}
 start_node_ready() {
-  local label="$1" log_file="$2" datadir="$3" bind_addr="$4" peers="$5" attempt="$6"
-  STARTED_PID="" STARTED_RPC=""
-  if ! rubin_process_start "${log_file}" "${NODE_BIN}" --datadir "${datadir}" --bind "${bind_addr}" --rpc-bind 127.0.0.1:0 --peers "${peers}" --mine-address "${MINE_ADDRESS_HEX}"; then
-    echo "${label} attempt ${attempt} failed; retrying with fresh loopback port(s)" >&2
-    [[ -z "${RUBIN_PROCESS_LAST_PID}" ]] || stop_managed_pid "${RUBIN_PROCESS_LAST_PID}" || true
+  local label="$1" log_file="$2" datadir="$3" peers="${4:-}" args
+  args=(--datadir "${datadir}" --bind 127.0.0.1:0 --rpc-bind 127.0.0.1:0 --mine-address "${MINE_ADDRESS_HEX}")
+  [[ -z "${peers}" ]] || args+=(--peers "${peers}")
+  STARTED_PID="" STARTED_RPC="" STARTED_P2P=""
+  if ! rubin_process_start "${log_file}" "${NODE_BIN}" "${args[@]}"; then
+    echo "${label} start failed" >&2
+    [[ -z "${RUBIN_PROCESS_LAST_PID}" ]] || rubin_process_stop_pid "${RUBIN_PROCESS_LAST_PID}" || true
     return 1
   fi
   STARTED_PID="${RUBIN_PROCESS_LAST_PID}"
   if ! rubin_process_wait_for_log "${log_file}" "rpc: listening=" 30 "${STARTED_PID}"; then
-    echo "${label} did not become ready on attempt ${attempt}; retrying with fresh loopback port(s)" >&2
-    stop_managed_pid "${STARTED_PID}" || true
+    echo "${label} did not become ready" >&2
+    rubin_process_stop_pid "${STARTED_PID}" || true
     STARTED_PID=""
     return 1
   fi
-  STARTED_RPC="$(rubin_process_extract_rpc_addr "${log_file}")" || return 1
-}
-stop_cluster_attempt() {
-  local managed_pid
-  for managed_pid in "${C_PID:-}" "${B_PID:-}" "${A_PID:-}"; do
-    [[ -z "${managed_pid}" ]] || stop_managed_pid "${managed_pid}" || true
-  done
-  A_PID="" B_PID="" C_PID=""
+  STARTED_RPC="$(rubin_process_extract_rpc_addr "${log_file}")" || { rubin_process_stop_pid "${STARTED_PID}" || true; return 1; }
+  STARTED_P2P="$(p2p_addr_for_pid "${STARTED_PID}" "${STARTED_RPC}" 30)" || { rubin_process_stop_pid "${STARTED_PID}" || true; return 1; }
 }
 start_soak_cluster() {
-  local attempt
-  attempt=1
-  while (( attempt <= CLUSTER_START_ATTEMPTS )); do
-    A_PID="" B_PID="" C_PID="" A_RPC_ADDR="" B_RPC_ADDR="" C_RPC_ADDR=""
-    A_P2P_ADDR="$(allocate_loopback_addr)" || return 1
-    B_P2P_ADDR="$(allocate_loopback_addr)" || return 1
-    C_P2P_ADDR="$(allocate_loopback_addr)" || return 1
-    start_node_ready node-a "${A_LOG}" "${A_DIR}" "${A_P2P_ADDR}" "${B_P2P_ADDR},${C_P2P_ADDR}" "${attempt}" || { stop_cluster_attempt; ((attempt++)); continue; }
-    A_PID="${STARTED_PID}" A_RPC_ADDR="${STARTED_RPC}"
-    start_node_ready node-b "${B_LOG}" "${B_DIR}" "${B_P2P_ADDR}" "${A_P2P_ADDR}" "${attempt}" || { stop_cluster_attempt; ((attempt++)); continue; }
-    B_PID="${STARTED_PID}" B_RPC_ADDR="${STARTED_RPC}"
-    start_node_ready node-c "${C_LOG}" "${C_DIR}" "${C_P2P_ADDR}" "${A_P2P_ADDR}" "${attempt}" || { stop_cluster_attempt; ((attempt++)); continue; }
-    C_PID="${STARTED_PID}" C_RPC_ADDR="${STARTED_RPC}"
-    if rubin_process_wait_for_rpc_ready "${A_RPC_ADDR}" 30 && rubin_process_wait_for_rpc_ready "${B_RPC_ADDR}" 30 && rubin_process_wait_for_rpc_ready "${C_RPC_ADDR}" 30; then
-      return 0
-    fi
-    echo "cluster RPC readiness failed on attempt ${attempt}; retrying with fresh loopback ports" >&2
-    stop_cluster_attempt
-    ((attempt++))
-  done
-  echo "failed to start three-node cluster after ${CLUSTER_START_ATTEMPTS} attempts" >&2
-  return 1
+  A_PID="" B_PID="" C_PID="" A_RPC_ADDR="" B_RPC_ADDR="" C_RPC_ADDR=""
+  start_node_ready node-b "${B_LOG}" "${B_DIR}" || return 1
+  B_PID="${STARTED_PID}" B_RPC_ADDR="${STARTED_RPC}" B_P2P_ADDR="${STARTED_P2P}"
+  printf '%s\n' "${B_P2P_ADDR}" >"${B_PROXY_TARGET}"
+  start_proxy "${B_PROXY_LOG}" "${B_PROXY_TARGET}"
+  B_PROXY_ADDR="${PROXY_ADDR}"
+  start_node_ready node-c "${C_LOG}" "${C_DIR}" || return 1
+  C_PID="${STARTED_PID}" C_RPC_ADDR="${STARTED_RPC}" C_P2P_ADDR="${STARTED_P2P}"
+  printf '%s\n' "${C_P2P_ADDR}" >"${C_PROXY_TARGET}"
+  start_proxy "${C_PROXY_LOG}" "${C_PROXY_TARGET}"
+  C_PROXY_ADDR="${PROXY_ADDR}"
+  start_node_ready node-a "${A_LOG}" "${A_DIR}" "${B_PROXY_ADDR},${C_PROXY_ADDR}" || return 1
+  A_PID="${STARTED_PID}" A_RPC_ADDR="${STARTED_RPC}" A_P2P_ADDR="${STARTED_P2P}"
+  rubin_process_wait_for_rpc_ready "${A_RPC_ADDR}" 30
+  rubin_process_wait_for_rpc_ready "${B_RPC_ADDR}" 30
+  rubin_process_wait_for_rpc_ready "${C_RPC_ADDR}" 30
 }
 restart_node_b() {
-  local attempt
-  attempt=1
-  while (( attempt <= NODE_RESTART_ATTEMPTS )); do
-    if (( attempt > 1 )); then
-      B_P2P_ADDR="$(allocate_loopback_addr)" || return 1
-    fi
-    if start_node_ready "node-b restart" "${B_RESTART_LOG}" "${B_DIR}" "${B_P2P_ADDR}" "${A_P2P_ADDR}" "${attempt}"; then
-      B_PID="${STARTED_PID}" B_RPC_ADDR="${STARTED_RPC}"
-      POST_RESTART_B_PID="${B_PID}"
-      POST_RESTART_B_RPC_ADDR="${B_RPC_ADDR}"
-      return 0
-    fi
-    ((attempt++))
-  done
-  echo "failed to restart node-b after ${NODE_RESTART_ATTEMPTS} attempts" >&2
-  return 1
+  start_node_ready "node-b restart" "${B_RESTART_LOG}" "${B_DIR}" "${A_P2P_ADDR}" || return 1
+  B_PID="${STARTED_PID}" B_RPC_ADDR="${STARTED_RPC}" B_P2P_ADDR="${STARTED_P2P}"
+  printf '%s\n' "${B_P2P_ADDR}" >"${B_PROXY_TARGET}"
+  POST_RESTART_B_PID="${B_PID}"
+  POST_RESTART_B_RPC_ADDR="${B_RPC_ADDR}" POST_RESTART_B_P2P_ADDR="${B_P2P_ADDR}"
 }
 write_keygen() {
   cat >"${KEYGEN_GO}" <<'EOF'
@@ -224,6 +244,7 @@ echo "Building Go rubin-node and rubin-txgen"
 "${DEV_ENV}" -- go -C "${GO_MODULE_ROOT}" build -o "${NODE_BIN}" ./cmd/rubin-node
 "${DEV_ENV}" -- go -C "${GO_MODULE_ROOT}" build -o "${TXGEN_BIN}" ./cmd/rubin-txgen
 write_keygen
+write_tcp_proxy
 "${DEV_ENV}" -- go -C "${GO_MODULE_ROOT}" run "${KEYGEN_GO}" >"${KEYGEN_JSON}"
 FROM_DER_HEX="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["from_der_hex"])' "${KEYGEN_JSON}")"
 MINE_ADDRESS_HEX="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["mine_address_hex"])' "${KEYGEN_JSON}")"
@@ -238,10 +259,10 @@ start_soak_cluster
 for addr in "${A_RPC_ADDR}" "${B_RPC_ADDR}" "${C_RPC_ADDR}"; do wait_height "${addr}" "${BASE_HEIGHT}" 30; done
 if (( WITH_RESTART == 1 )); then
   IFS=$'\t' read -r PRE_RESTART_B_HEIGHT PRE_RESTART_B_TIP < <(tip_tsv "${B_RPC_ADDR}")
-  PRE_RESTART_B_RPC_ADDR="${B_RPC_ADDR}"
+  PRE_RESTART_B_RPC_ADDR="${B_RPC_ADDR}" PRE_RESTART_B_P2P_ADDR="${B_P2P_ADDR}"
   PRE_RESTART_B_PID="${B_PID}"
   echo "Stopping node-b pid=${B_PID} at deterministic restart checkpoint height ${PRE_RESTART_B_HEIGHT}"
-  stop_managed_pid "${B_PID}"
+  rubin_process_stop_pid "${B_PID}"
 fi
 echo "Submitting tx through Go RPC and mining it through /mine_next"
 TX_HEX="$("${TXGEN_BIN}" --datadir "${A_DIR}" --from-key "${FROM_DER_HEX}" --to-key "${TO_ADDRESS_HEX}" --amount 1 --fee 1 --submit-to "${A_RPC_ADDR}")"
@@ -325,28 +346,23 @@ printf '%s' "${BLOCK_JSON}" | python3 -c 'import json,sys; d=json.load(sys.stdin
 if (( WITH_RESTART == 1 )); then
   printf '%s' "${POST_RESTART_BLOCK_JSON}" | python3 -c 'import json,sys; d=json.load(sys.stdin); h=d.get("block_hex",""); (isinstance(h, str) and len(h) > 0) or sys.exit("post-restart block visibility check failed")'
 fi
-export REPORT_JSON TARGET_HEIGHT BASE_HEIGHT A_HEIGHT B_HEIGHT C_HEIGHT A_TIP B_TIP C_TIP A_PID B_PID C_PID A_RPC_ADDR B_RPC_ADDR C_RPC_ADDR A_PEERS B_PEERS C_PEERS TX_ID FINAL_HASH TX_COUNT WITH_RESTART PRE_RESTART_B_HEIGHT PRE_RESTART_B_TIP PRE_RESTART_B_RPC_ADDR PRE_RESTART_B_PID POST_RESTART_B_RPC_ADDR POST_RESTART_B_PID POST_RESTART_CATCHUP_HEIGHT POST_RESTART_CATCHUP_TIP POST_RESTART_CATCHUP_PEERS POST_RESTART_MINE_HEIGHT POST_RESTART_MINE_HASH POST_RESTART_MINE_TX_COUNT POST_RESTART_ACCEPTED_PEER INCLUSION_PROOF_NODE
+export REPORT_JSON TARGET_HEIGHT BASE_HEIGHT A_HEIGHT B_HEIGHT C_HEIGHT A_TIP B_TIP C_TIP A_PID B_PID C_PID A_RPC_ADDR B_RPC_ADDR C_RPC_ADDR A_P2P_ADDR B_P2P_ADDR C_P2P_ADDR A_PEERS B_PEERS C_PEERS TX_ID FINAL_HASH TX_COUNT WITH_RESTART PRE_RESTART_B_HEIGHT PRE_RESTART_B_TIP PRE_RESTART_B_RPC_ADDR PRE_RESTART_B_P2P_ADDR PRE_RESTART_B_PID POST_RESTART_B_RPC_ADDR POST_RESTART_B_P2P_ADDR POST_RESTART_B_PID POST_RESTART_CATCHUP_HEIGHT POST_RESTART_CATCHUP_TIP POST_RESTART_CATCHUP_PEERS POST_RESTART_MINE_HEIGHT POST_RESTART_MINE_HASH POST_RESTART_MINE_TX_COUNT POST_RESTART_ACCEPTED_PEER INCLUSION_PROOF_NODE
 python3 - <<'PY'
 import json, os
-participants = []
-for node in ("A", "B", "C"):
-    participants.append({"name": f"node-{node.lower()}", "pid": int(os.environ[f"{node}_PID"]), "rpc": os.environ[f"{node}_RPC_ADDR"], "checkpoint_height": int(os.environ[f"{node}_HEIGHT"]), "tip_hash": os.environ[f"{node}_TIP"], "peer_count": int(os.environ[f"{node}_PEERS"])})
-restart_enabled = os.environ["WITH_RESTART"] == "1"
+e = os.environ
+i = lambda key: int(e[key])
+participants = [{"name": f"node-{n.lower()}", "pid": i(f"{n}_PID"), "rpc": e[f"{n}_RPC_ADDR"], "p2p": e[f"{n}_P2P_ADDR"], "checkpoint_height": i(f"{n}_HEIGHT"), "tip_hash": e[f"{n}_TIP"], "peer_count": i(f"{n}_PEERS")} for n in ("A", "B", "C")]
+restart_enabled = e["WITH_RESTART"] == "1"
 report = {
     "scenario": "go_binary_soak_restart" if restart_enabled else "go_binary_soak_skeleton",
-    "target_height": int(os.environ["TARGET_HEIGHT"]),
-    "base_height": int(os.environ["BASE_HEIGHT"]),
+    "target_height": i("TARGET_HEIGHT"),
+    "base_height": i("BASE_HEIGHT"),
     "participants": participants,
-    "tx": {
-        "id": os.environ["TX_ID"],
-        "submission": "rpc:/submit_tx",
-        "inclusion_proof_node": os.environ["INCLUSION_PROOF_NODE"],
-        "inclusion_height": int(os.environ["TARGET_HEIGHT"]),
-    },
+    "tx": {"id": e["TX_ID"], "submission": "rpc:/submit_tx", "inclusion_proof_node": e["INCLUSION_PROOF_NODE"], "inclusion_height": i("TARGET_HEIGHT")},
     "final": {
-        "height": int(os.environ["POST_RESTART_MINE_HEIGHT"] if restart_enabled else os.environ["TARGET_HEIGHT"]),
-        "tip_hash": os.environ["POST_RESTART_MINE_HASH"] if restart_enabled else os.environ["FINAL_HASH"],
-        "tx_count": int(os.environ["POST_RESTART_MINE_TX_COUNT"] if restart_enabled else os.environ["TX_COUNT"]),
+        "height": i("POST_RESTART_MINE_HEIGHT" if restart_enabled else "TARGET_HEIGHT"),
+        "tip_hash": e["POST_RESTART_MINE_HASH"] if restart_enabled else e["FINAL_HASH"],
+        "tx_count": i("POST_RESTART_MINE_TX_COUNT" if restart_enabled else "TX_COUNT"),
     },
     "verdict": "PASS",
 }
@@ -354,30 +370,13 @@ if restart_enabled:
     report["restart"] = {
         "enabled": True,
         "stopped_node": "node-b",
-        "checkpoint_before_stop": {
-            "height": int(os.environ["PRE_RESTART_B_HEIGHT"]),
-            "tip_hash": os.environ["PRE_RESTART_B_TIP"],
-            "rpc": os.environ["PRE_RESTART_B_RPC_ADDR"],
-            "pid": int(os.environ["PRE_RESTART_B_PID"]),
-        },
-        "state_after_catchup": {
-            "height": int(os.environ["POST_RESTART_CATCHUP_HEIGHT"]),
-            "tip_hash": os.environ["POST_RESTART_CATCHUP_TIP"],
-            "rpc": os.environ["POST_RESTART_B_RPC_ADDR"],
-            "pid": int(os.environ["POST_RESTART_B_PID"]),
-            "peer_count": int(os.environ["POST_RESTART_CATCHUP_PEERS"]),
-        },
-        "post_restart_live_action": {
-            "action": "mine_next",
-            "height": int(os.environ["POST_RESTART_MINE_HEIGHT"]),
-            "block_hash": os.environ["POST_RESTART_MINE_HASH"],
-            "tx_count": int(os.environ["POST_RESTART_MINE_TX_COUNT"]),
-            "accepted_by_peer": os.environ["POST_RESTART_ACCEPTED_PEER"],
-        },
+        "checkpoint_before_stop": {"height": i("PRE_RESTART_B_HEIGHT"), "tip_hash": e["PRE_RESTART_B_TIP"], "rpc": e["PRE_RESTART_B_RPC_ADDR"], "p2p": e["PRE_RESTART_B_P2P_ADDR"], "pid": i("PRE_RESTART_B_PID")},
+        "state_after_catchup": {"height": i("POST_RESTART_CATCHUP_HEIGHT"), "tip_hash": e["POST_RESTART_CATCHUP_TIP"], "rpc": e["POST_RESTART_B_RPC_ADDR"], "p2p": e["POST_RESTART_B_P2P_ADDR"], "pid": i("POST_RESTART_B_PID"), "peer_count": i("POST_RESTART_CATCHUP_PEERS")},
+        "post_restart_live_action": {"action": "mine_next", "height": i("POST_RESTART_MINE_HEIGHT"), "block_hash": e["POST_RESTART_MINE_HASH"], "tx_count": i("POST_RESTART_MINE_TX_COUNT"), "accepted_by_peer": e["POST_RESTART_ACCEPTED_PEER"]},
     }
 else:
     report["restart"] = {"enabled": False}
-with open(os.environ["REPORT_JSON"], "w", encoding="utf-8") as f:
+with open(e["REPORT_JSON"], "w", encoding="utf-8") as f:
     json.dump(report, f, indent=2, sort_keys=True)
     f.write("\n")
 PY

--- a/scripts/devnet-go-binary-soak.sh
+++ b/scripts/devnet-go-binary-soak.sh
@@ -120,10 +120,7 @@ block_matches_hash_canonical() {
   local block_json="$1" expected_hash="$2"
   printf '%s' "${block_json}" | python3 -c 'import json,sys; d=json.load(sys.stdin); expected=sys.argv[1].lower(); actual=(d.get("hash") or d.get("block_hash") or "").lower(); actual == expected or sys.exit(1); d.get("canonical") is True or sys.exit(2)' "${expected_hash}"
 }
-describe_block_json() {
-  local block_json="$1"
-  printf '%s' "${block_json}" | python3 -c 'import json,sys; d=json.load(sys.stdin); actual=d.get("hash") or d.get("block_hash") or "<missing>"; print("reported_hash=%s reported_canonical=%r" % (actual, d.get("canonical")))'
-}
+describe_block_json() { local block_json="$1"; printf '%s' "${block_json}" | python3 -c 'import json,sys; d=json.load(sys.stdin); actual=d.get("hash") or d.get("block_hash") or "<missing>"; print("reported_hash=%s reported_canonical=%r" % (actual, d.get("canonical")))'; }
 stop_registered_pid() { local managed_pid="${1:-}" rc=0 kept=() pid; [[ -n "${managed_pid}" ]] || return 1; rubin_process_stop_pid "${managed_pid}" || rc=$?; for pid in "${RUBIN_PROCESS_PIDS[@]}"; do [[ "${pid}" == "${managed_pid}" ]] || kept+=("${pid}"); done; if ((${#kept[@]})); then RUBIN_PROCESS_PIDS=("${kept[@]}"); else RUBIN_PROCESS_PIDS=(); fi; if ((${#RUBIN_PROCESS_PIDS[@]})); then for pid in "${RUBIN_PROCESS_PIDS[@]}"; do [[ "${pid}" != "${managed_pid}" ]] || { echo "stale managed pid remained registered after stop: ${managed_pid}" >&2; return 1; }; done; fi; return "${rc}"; }
 write_tcp_proxy() {
   cat >"${TCP_PROXY_PY}" <<'PY'
@@ -299,14 +296,12 @@ if (( WITH_RESTART == 1 )); then
   wait_height "${B_RPC_ADDR}" "${POST_RESTART_TARGET_HEIGHT}" 60
   POST_RESTART_B_BLOCK_JSON="$(rpc_json GET "${B_RPC_ADDR}" "/get_block?height=${POST_RESTART_TARGET_HEIGHT}")"
   block_matches_hash_canonical "${POST_RESTART_B_BLOCK_JSON}" "${POST_RESTART_MINE_HASH}" || {
-    actual="$(describe_block_json "${POST_RESTART_B_BLOCK_JSON}")"
-    echo "post-restart block was not adopted by restarted node-b at height=${POST_RESTART_TARGET_HEIGHT} expected_hash=${POST_RESTART_MINE_HASH} ${actual}" >&2
+    echo "post-restart block was not adopted by restarted node-b at height=${POST_RESTART_TARGET_HEIGHT} expected_hash=${POST_RESTART_MINE_HASH} $(describe_block_json "${POST_RESTART_B_BLOCK_JSON}")" >&2
     exit 1
   }
   POST_RESTART_A_BLOCK_JSON="$(rpc_json GET "${A_RPC_ADDR}" "/get_block?height=${POST_RESTART_TARGET_HEIGHT}")"
   block_matches_hash_canonical "${POST_RESTART_A_BLOCK_JSON}" "${POST_RESTART_MINE_HASH}" || {
-    actual="$(describe_block_json "${POST_RESTART_A_BLOCK_JSON}")"
-    echo "post-restart block was not adopted by node-a at height=${POST_RESTART_TARGET_HEIGHT} expected_hash=${POST_RESTART_MINE_HASH} ${actual}" >&2
+    echo "post-restart block was not adopted by node-a at height=${POST_RESTART_TARGET_HEIGHT} expected_hash=${POST_RESTART_MINE_HASH} $(describe_block_json "${POST_RESTART_A_BLOCK_JSON}")" >&2
     exit 1
   }
   POST_RESTART_ACCEPTED_PEER="node-a"
@@ -324,8 +319,7 @@ if (( WITH_RESTART == 1 )); then
   }
   POST_RESTART_A_BLOCK_JSON="$(rpc_json GET "${A_RPC_ADDR}" "/get_block?height=${POST_RESTART_MINE_HEIGHT}")"
   block_matches_hash_canonical "${POST_RESTART_A_BLOCK_JSON}" "${POST_RESTART_MINE_HASH}" || {
-    actual="$(describe_block_json "${POST_RESTART_A_BLOCK_JSON}")"
-    echo "post-restart adoption marker node-a mismatch height=${POST_RESTART_MINE_HEIGHT} expected_hash=${POST_RESTART_MINE_HASH} ${actual}" >&2
+    echo "post-restart adoption marker node-a mismatch height=${POST_RESTART_MINE_HEIGHT} expected_hash=${POST_RESTART_MINE_HASH} $(describe_block_json "${POST_RESTART_A_BLOCK_JSON}")" >&2
     exit 1
   }
   [[ "${A_HEIGHT}" == "${POST_RESTART_MINE_HEIGHT}" && "${A_TIP}" == "${POST_RESTART_MINE_HASH}" && "${B_HEIGHT}" == "${POST_RESTART_MINE_HEIGHT}" && "${B_TIP}" == "${POST_RESTART_MINE_HASH}" && (("${C_HEIGHT}" == "${BASE_HEIGHT}" && -n "${C_TIP}") || ("${C_HEIGHT}" == "${TARGET_HEIGHT}" && "${C_TIP}" == "${FINAL_HASH}") || ("${C_HEIGHT}" == "${POST_RESTART_MINE_HEIGHT}" && "${C_TIP}" == "${POST_RESTART_MINE_HASH}")) && "${A_PEERS}" -ge 2 && "${B_PEERS}" -ge 1 && "${C_PEERS}" -ge 1 ]] || {
@@ -345,8 +339,8 @@ fi
 if (( WITH_RESTART == 1 )); then
   BLOCK_JSON="$(rpc_json GET "${B_RPC_ADDR}" "/get_block?height=${TARGET_HEIGHT}")"
   POST_RESTART_BLOCK_JSON="$(rpc_json GET "${B_RPC_ADDR}" "/get_block?height=${POST_RESTART_MINE_HEIGHT}")"
-  block_matches_hash_canonical "${BLOCK_JSON}" "${FINAL_HASH}" || { actual="$(describe_block_json "${BLOCK_JSON}")"; echo "restart target block mismatch expected_hash=${FINAL_HASH} ${actual}" >&2; exit 1; }
-  block_matches_hash_canonical "${POST_RESTART_BLOCK_JSON}" "${POST_RESTART_MINE_HASH}" || { actual="$(describe_block_json "${POST_RESTART_BLOCK_JSON}")"; echo "restart post-restart block mismatch expected_hash=${POST_RESTART_MINE_HASH} ${actual}" >&2; exit 1; }
+  block_matches_hash_canonical "${BLOCK_JSON}" "${FINAL_HASH}" || { echo "restart target block mismatch expected_hash=${FINAL_HASH} $(describe_block_json "${BLOCK_JSON}")" >&2; exit 1; }
+  block_matches_hash_canonical "${POST_RESTART_BLOCK_JSON}" "${POST_RESTART_MINE_HASH}" || { echo "restart post-restart block mismatch expected_hash=${POST_RESTART_MINE_HASH} $(describe_block_json "${POST_RESTART_BLOCK_JSON}")" >&2; exit 1; }
 else
   BLOCK_JSON="$(rpc_json GET "${A_RPC_ADDR}" "/get_block?height=${TARGET_HEIGHT}")"
 fi

--- a/scripts/devnet-go-binary-soak.sh
+++ b/scripts/devnet-go-binary-soak.sh
@@ -120,6 +120,10 @@ block_matches_hash_canonical() {
   local block_json="$1" expected_hash="$2"
   printf '%s' "${block_json}" | python3 -c 'import json,sys; d=json.load(sys.stdin); expected=sys.argv[1].lower(); actual=(d.get("hash") or d.get("block_hash") or "").lower(); actual == expected or sys.exit(1); d.get("canonical") is True or sys.exit(2)' "${expected_hash}"
 }
+describe_block_json() {
+  local block_json="$1"
+  printf '%s' "${block_json}" | python3 -c 'import json,sys; d=json.load(sys.stdin); actual=d.get("hash") or d.get("block_hash") or "<missing>"; print("reported_hash=%s reported_canonical=%r" % (actual, d.get("canonical")))'
+}
 stop_registered_pid() { local managed_pid="${1:-}" rc=0 kept=() pid; [[ -n "${managed_pid}" ]] || return 1; rubin_process_stop_pid "${managed_pid}" || rc=$?; for pid in "${RUBIN_PROCESS_PIDS[@]}"; do [[ "${pid}" == "${managed_pid}" ]] || kept+=("${pid}"); done; if ((${#kept[@]})); then RUBIN_PROCESS_PIDS=("${kept[@]}"); else RUBIN_PROCESS_PIDS=(); fi; if ((${#RUBIN_PROCESS_PIDS[@]})); then for pid in "${RUBIN_PROCESS_PIDS[@]}"; do [[ "${pid}" != "${managed_pid}" ]] || { echo "stale managed pid remained registered after stop: ${managed_pid}" >&2; return 1; }; done; fi; return "${rc}"; }
 write_tcp_proxy() {
   cat >"${TCP_PROXY_PY}" <<'PY'
@@ -295,12 +299,14 @@ if (( WITH_RESTART == 1 )); then
   wait_height "${B_RPC_ADDR}" "${POST_RESTART_TARGET_HEIGHT}" 60
   POST_RESTART_B_BLOCK_JSON="$(rpc_json GET "${B_RPC_ADDR}" "/get_block?height=${POST_RESTART_TARGET_HEIGHT}")"
   block_matches_hash_canonical "${POST_RESTART_B_BLOCK_JSON}" "${POST_RESTART_MINE_HASH}" || {
-    echo "post-restart block was not adopted by restarted node-b at height=${POST_RESTART_TARGET_HEIGHT} hash=${POST_RESTART_MINE_HASH}" >&2
+    actual="$(describe_block_json "${POST_RESTART_B_BLOCK_JSON}")"
+    echo "post-restart block was not adopted by restarted node-b at height=${POST_RESTART_TARGET_HEIGHT} expected_hash=${POST_RESTART_MINE_HASH} ${actual}" >&2
     exit 1
   }
   POST_RESTART_A_BLOCK_JSON="$(rpc_json GET "${A_RPC_ADDR}" "/get_block?height=${POST_RESTART_TARGET_HEIGHT}")"
   block_matches_hash_canonical "${POST_RESTART_A_BLOCK_JSON}" "${POST_RESTART_MINE_HASH}" || {
-    echo "post-restart block was not adopted by node-a at height=${POST_RESTART_TARGET_HEIGHT} hash=${POST_RESTART_MINE_HASH}" >&2
+    actual="$(describe_block_json "${POST_RESTART_A_BLOCK_JSON}")"
+    echo "post-restart block was not adopted by node-a at height=${POST_RESTART_TARGET_HEIGHT} expected_hash=${POST_RESTART_MINE_HASH} ${actual}" >&2
     exit 1
   }
   POST_RESTART_ACCEPTED_PEER="node-a"
@@ -318,7 +324,8 @@ if (( WITH_RESTART == 1 )); then
   }
   POST_RESTART_A_BLOCK_JSON="$(rpc_json GET "${A_RPC_ADDR}" "/get_block?height=${POST_RESTART_MINE_HEIGHT}")"
   block_matches_hash_canonical "${POST_RESTART_A_BLOCK_JSON}" "${POST_RESTART_MINE_HASH}" || {
-    echo "post-restart adoption marker node-a mismatch height=${A_HEIGHT} tip=${A_TIP}" >&2
+    actual="$(describe_block_json "${POST_RESTART_A_BLOCK_JSON}")"
+    echo "post-restart adoption marker node-a mismatch height=${POST_RESTART_MINE_HEIGHT} expected_hash=${POST_RESTART_MINE_HASH} ${actual}" >&2
     exit 1
   }
   [[ "${A_HEIGHT}" == "${POST_RESTART_MINE_HEIGHT}" && "${A_TIP}" == "${POST_RESTART_MINE_HASH}" && "${B_HEIGHT}" == "${POST_RESTART_MINE_HEIGHT}" && "${B_TIP}" == "${POST_RESTART_MINE_HASH}" && (("${C_HEIGHT}" == "${BASE_HEIGHT}" && -n "${C_TIP}") || ("${C_HEIGHT}" == "${TARGET_HEIGHT}" && "${C_TIP}" == "${FINAL_HASH}") || ("${C_HEIGHT}" == "${POST_RESTART_MINE_HEIGHT}" && "${C_TIP}" == "${POST_RESTART_MINE_HASH}")) && "${A_PEERS}" -ge 2 && "${B_PEERS}" -ge 1 && "${C_PEERS}" -ge 1 ]] || {
@@ -338,8 +345,8 @@ fi
 if (( WITH_RESTART == 1 )); then
   BLOCK_JSON="$(rpc_json GET "${B_RPC_ADDR}" "/get_block?height=${TARGET_HEIGHT}")"
   POST_RESTART_BLOCK_JSON="$(rpc_json GET "${B_RPC_ADDR}" "/get_block?height=${POST_RESTART_MINE_HEIGHT}")"
-  block_matches_hash_canonical "${BLOCK_JSON}" "${FINAL_HASH}" || { echo "restart target block mismatch canonical/hash expected=${FINAL_HASH}" >&2; exit 1; }
-  block_matches_hash_canonical "${POST_RESTART_BLOCK_JSON}" "${POST_RESTART_MINE_HASH}" || { echo "restart post-restart block mismatch canonical/hash expected=${POST_RESTART_MINE_HASH}" >&2; exit 1; }
+  block_matches_hash_canonical "${BLOCK_JSON}" "${FINAL_HASH}" || { actual="$(describe_block_json "${BLOCK_JSON}")"; echo "restart target block mismatch expected_hash=${FINAL_HASH} ${actual}" >&2; exit 1; }
+  block_matches_hash_canonical "${POST_RESTART_BLOCK_JSON}" "${POST_RESTART_MINE_HASH}" || { actual="$(describe_block_json "${POST_RESTART_BLOCK_JSON}")"; echo "restart post-restart block mismatch expected_hash=${POST_RESTART_MINE_HASH} ${actual}" >&2; exit 1; }
 else
   BLOCK_JSON="$(rpc_json GET "${A_RPC_ADDR}" "/get_block?height=${TARGET_HEIGHT}")"
 fi

--- a/scripts/devnet-go-binary-soak.sh
+++ b/scripts/devnet-go-binary-soak.sh
@@ -116,6 +116,9 @@ block_matches_hash_canonical() {
   local block_json="$1" expected_hash="$2"
   printf '%s' "${block_json}" | python3 -c 'import json,sys; d=json.load(sys.stdin); expected=sys.argv[1].lower(); actual=(d.get("hash") or d.get("block_hash") or "").lower(); actual == expected or sys.exit(1); d.get("canonical") is True or sys.exit(2)' "${expected_hash}"
 }
+allocate_loopback_addr() {
+  python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(f"127.0.0.1:{s.getsockname()[1]}"); s.close()'
+}
 unregister_managed_pid() {
   local stale_pid="${1:-}" kept=() pid
   [[ -n "${stale_pid}" ]] || return 1
@@ -162,15 +165,17 @@ cp -R "${A_DIR}/." "${B_DIR}/"
 cp -R "${A_DIR}/." "${C_DIR}/"
 echo "Starting three Go rubin-node processes"
 A_PID=""
+B_P2P_ADDR="$(allocate_loopback_addr)"
+C_P2P_ADDR="$(allocate_loopback_addr)"
 for _ in 1 2 3; do
-  A_P2P_ADDR="$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(f"127.0.0.1:{s.getsockname()[1]}"); s.close()')"
-  if rubin_process_start "${A_LOG}" "${NODE_BIN}" --datadir "${A_DIR}" --bind "${A_P2P_ADDR}" --rpc-bind 127.0.0.1:0 --mine-address "${MINE_ADDRESS_HEX}" && rubin_process_wait_for_log "${A_LOG}" "rpc: listening=" 30 "${RUBIN_PROCESS_LAST_PID}"; then A_PID="${RUBIN_PROCESS_LAST_PID}"; A_RPC_ADDR="$(rubin_process_extract_rpc_addr "${A_LOG}")"; break; fi
+  A_P2P_ADDR="$(allocate_loopback_addr)"
+  if rubin_process_start "${A_LOG}" "${NODE_BIN}" --datadir "${A_DIR}" --bind "${A_P2P_ADDR}" --rpc-bind 127.0.0.1:0 --peers "${B_P2P_ADDR},${C_P2P_ADDR}" --mine-address "${MINE_ADDRESS_HEX}" && rubin_process_wait_for_log "${A_LOG}" "rpc: listening=" 30 "${RUBIN_PROCESS_LAST_PID}"; then A_PID="${RUBIN_PROCESS_LAST_PID}"; A_RPC_ADDR="$(rubin_process_extract_rpc_addr "${A_LOG}")"; break; fi
   [[ -z "${RUBIN_PROCESS_LAST_PID}" ]] || stop_managed_pid "${RUBIN_PROCESS_LAST_PID}" || true
 done
 [[ -n "${A_PID}" ]] || { echo "failed to start node-a after retrying loopback bind ports" >&2; exit 1; }
-rubin_process_start "${B_LOG}" "${NODE_BIN}" --datadir "${B_DIR}" --bind 127.0.0.1:0 --rpc-bind 127.0.0.1:0 --peers "${A_P2P_ADDR}" --mine-address "${MINE_ADDRESS_HEX}"
+rubin_process_start "${B_LOG}" "${NODE_BIN}" --datadir "${B_DIR}" --bind "${B_P2P_ADDR}" --rpc-bind 127.0.0.1:0 --peers "${A_P2P_ADDR}" --mine-address "${MINE_ADDRESS_HEX}"
 B_PID="${RUBIN_PROCESS_LAST_PID}"
-rubin_process_start "${C_LOG}" "${NODE_BIN}" --datadir "${C_DIR}" --bind 127.0.0.1:0 --rpc-bind 127.0.0.1:0 --peers "${A_P2P_ADDR}" --mine-address "${MINE_ADDRESS_HEX}"
+rubin_process_start "${C_LOG}" "${NODE_BIN}" --datadir "${C_DIR}" --bind "${C_P2P_ADDR}" --rpc-bind 127.0.0.1:0 --peers "${A_P2P_ADDR}" --mine-address "${MINE_ADDRESS_HEX}"
 C_PID="${RUBIN_PROCESS_LAST_PID}"
 rubin_process_wait_for_log "${B_LOG}" "rpc: listening=" 30 "${B_PID}"
 B_RPC_ADDR="$(rubin_process_extract_rpc_addr "${B_LOG}")"
@@ -198,7 +203,7 @@ IFS=$'\t' read -r FINAL_HEIGHT FINAL_HASH TX_COUNT < <(printf '%s' "${MINE_JSON}
 wait_height "${A_RPC_ADDR}" "${TARGET_HEIGHT}" 30
 if (( WITH_RESTART == 1 )); then
   echo "Restarting node-b from disk-backed datadir ${B_DIR}"
-  rubin_process_start "${B_RESTART_LOG}" "${NODE_BIN}" --datadir "${B_DIR}" --bind 127.0.0.1:0 --rpc-bind 127.0.0.1:0 --peers "${A_P2P_ADDR}" --mine-address "${MINE_ADDRESS_HEX}"
+  rubin_process_start "${B_RESTART_LOG}" "${NODE_BIN}" --datadir "${B_DIR}" --bind "${B_P2P_ADDR}" --rpc-bind 127.0.0.1:0 --peers "${A_P2P_ADDR}" --mine-address "${MINE_ADDRESS_HEX}"
   B_PID="${RUBIN_PROCESS_LAST_PID}"
   POST_RESTART_B_PID="${B_PID}"
   rubin_process_wait_for_log "${B_RESTART_LOG}" "rpc: listening=" 30 "${B_PID}"


### PR DESCRIPTION
## Scope
- Q-IMPL-GO-DEVNET-BINARY-SOAK-RESTART-01 (#1230)
- Architecture class: B
- System boundary: one Go devnet evidence script, `scripts/devnet-go-binary-soak.sh`
- Single invariant: Go restart evidence must use a real stopped/restarted `rubin-node` process, avoid released-port P2P assumptions, and fail closed at the local evidence boundary when proof RPCs or peer waits fail.

## What Changed
- Starts node P2P listeners with `--bind 127.0.0.1:0`; the port is owned by `rubin-node`, not pre-probed and reused later.
- Uses `lsof` as a fail-closed local harness oracle to extract the live P2P listener after the RPC listener is known.
- Keeps node-b reachable across restart through a script-local loopback proxy whose target is rewritten after restarted node-b exposes its new live P2P listener.
- Stops node-b at a deterministic checkpoint, restarts it from the same datadir, waits for catch-up, then mines one additional block through restarted node-b and proves node-a adopted it.
- Unregisters intentionally stopped managed PIDs from the helper cleanup list so final cleanup does not act on stale or reused PIDs.
- Improves restart-path canonical/hash mismatch diagnostics so failure messages include expected and actual block hash/canonical fields.
- Fails fast for missing `python3`/`perl`/`lsof`, removes Python 3.8-only walrus syntax from the embedded proxy, resets the proxy upstream socket to blocking mode after bounded connect, and makes the block canonical/hash helper emit expected/actual/canonical diagnostics.
- Local repair `e8c3290` fail-closes every `wait_peers` capture so peer-count timeouts stop at the peer gate instead of flowing into later checkpoint/report logic.
- Local repair `38762ac` fail-closes every proof-critical `get_block` RPC capture with phase/address/height/captured-output diagnostics and rewrites `stop_registered_pid` into behavior-preserving multiline control flow for auditability.
- Local repair `5c99ae5` splits the argument-parser `done` and required-tool preflight into separate multiline shell blocks without changing behavior.

## Proof Scope
- Proof scope: local network devnet evidence.
- `lsof`, the loopback proxy, and `get_block` diagnostics are evidence-harness mechanics only; this PR does not add a runtime/API address-reporting or logging guarantee.
- This PR does not claim network finality, Rust restart evidence, mixed-client behavior, storage redesign, or a new report schema.

## Validation
- `bash -n scripts/devnet-go-binary-soak.sh`
- `shellcheck scripts/devnet-go-binary-soak.sh`
- `git diff --check`
- Repo pre-commit hook: `[OK] Pre-commit hygiene: clean.`
- Proxy Python 3.7 AST parse smoke
- Missing-`lsof` fail-fast smoke
- Proxy idle >5s socket smoke
- Block diagnostic negative smoke for expected/actual/canonical output
- Missing-`lsof`, zero-listener, and ambiguous-listener reject smokes
- Formatter smoke for `reported_hash` / `reported_canonical`
- Targeted `wait_peers` reject smoke for peer-gate diagnostics
- Targeted `get_block` reject smoke for address/height/captured-output diagnostics
- `stop_registered_pid` helper smoke for managed-PID unregister behavior
- `KEEP_TMP=1 ./scripts/devnet-go-binary-soak.sh --target-height 120`
- `KEEP_TMP=1 ./scripts/devnet-go-binary-soak.sh --target-height 120 --with-restart`
- `KEEP_TMP=1 ./scripts/devnet-go-binary-soak.sh --target-height 180 --with-restart`
- `bash "$HOME"/rubin-tool-scaffolding/scripts/tooling-check.sh --new-only --mode go-deep --repo <repo>`
- Semgrep on `scripts/devnet-go-binary-soak.sh`
- Session doctor
- Rubin quality receipt on clean local head `38762ac`
- Rubin quality receipt on clean local head `5c99ae5`
- Hostile reviewer PASS: `20260423T204314Z-e703e24-fixpass` on head `e703e245ace5ff2317fd37fedf214b16fa0560fe`
- Hostile reviewer PASS: `20260423T211706Z-a7f92a9-fixpass` on head `a7f92a93a2412b6db9f80a1a0f58c50648d7197c`
- Hostile reviewer PASS: `20260423T220332Z-6579f4d-fixpass` on head `6579f4d8883e8494634097a2e8c8f600802de4cb`
- Hostile reviewer PASS: `20260423T225605Z-e8c3290-fixpass` on local pre-push head `e8c32903f23aea2ab85023a22db0e4340ca6b846` against remote base `e709e58ecda94f62c0f4509656ca7326fd323bbc`
- Hostile reviewer PASS: `20260423T234143Z-38762ac-fixpass` on local pre-push head `38762ac34411376b7b934951e5482ea16dbbfc6d` against remote base `e8c32903f23aea2ab85023a22db0e4340ca6b846`
- Hostile reviewer PASS: `20260424T001932Z-5c99ae5-fixpass` on local pre-push head `5c99ae53c5eca23b2055f5113c4cb4b9e9b6d641` against remote base `12024e16559caed2849ca7ca3dbb6d39602770df`

## Non-Goals
- No Go runtime API or logging contract change
- No Rust participation
- No partition or reorg scenario
- No mixed-client mesh semantics
- No schema or protocol contract redesign

<!-- rubin-agent-meta actor=Codex action=pr-edit via=cl branch=codex/q-impl-go-devnet-binary-soak-restart-01 wt=rubin-protocol-q1230 utc=2026-04-24T004100Z -->


<!-- rubin-agent-meta actor=Codex action=pr-edit via=cl branch=codex/q-impl-go-devnet-binary-soak-restart-01 wt=rubin-protocol-q1230 utc=2026-04-24T00:40:50Z -->
