### PR TITLE
p2p: fail-closed relayTxMetadata instead of synthesizing fake fee/size

### DIFF
--- a/clients/go/node/p2p/coverage_hotspots_test.go
+++ b/clients/go/node/p2p/coverage_hotspots_test.go
@@ -124,6 +124,9 @@ func TestCoverage_AnnounceTxAndHandleTxBranches(t *testing.T) {
 	txBytes := mustBuildSignedP2PTx(t, utxos, []consensus.Outpoint{outpoints[0]}, 90, 1, 1, fromKey, fromAddress, toAddress)
 
 	p := newPeerRuntimeTestPeer(t)
+	p.service.cfg.TxMetadataFunc = func(b []byte) (node.RelayTxMetadata, error) {
+		return node.RelayTxMetadata{Fee: 0, Size: len(b)}, nil
+	}
 	p.service.cfg.PeerRuntimeConfig.BanThreshold = 100
 	if err := p.handleTx(append(txBytes, 0x00)); err != nil {
 		t.Fatalf("expected below-threshold invalid tx to be ignored, got %v", err)

--- a/clients/go/node/p2p/coverage_hotspots_test.go
+++ b/clients/go/node/p2p/coverage_hotspots_test.go
@@ -49,11 +49,12 @@ func TestCoverage_NewServiceAndListenerGuards(t *testing.T) {
 func TestCoverage_NewServiceDefaultsAndAnnounceBlock(t *testing.T) {
 	h := newTestHarness(t, 1, "127.0.0.1:0", nil)
 	svc, err := NewService(ServiceConfig{
-		BindAddr:    "127.0.0.1:0",
-		PeerManager: h.peerManager,
-		SyncConfig:  h.syncCfg,
-		SyncEngine:  h.syncEngine,
-		BlockStore:  h.blockStore,
+		BindAddr:       "127.0.0.1:0",
+		PeerManager:    h.peerManager,
+		SyncConfig:     h.syncCfg,
+		SyncEngine:     h.syncEngine,
+		BlockStore:     h.blockStore,
+		TxMetadataFunc: testHarnessDefaultTxMetadata,
 	})
 	if err != nil {
 		t.Fatalf("NewService: %v", err)
@@ -124,9 +125,6 @@ func TestCoverage_AnnounceTxAndHandleTxBranches(t *testing.T) {
 	txBytes := mustBuildSignedP2PTx(t, utxos, []consensus.Outpoint{outpoints[0]}, 90, 1, 1, fromKey, fromAddress, toAddress)
 
 	p := newPeerRuntimeTestPeer(t)
-	p.service.cfg.TxMetadataFunc = func(b []byte) (node.RelayTxMetadata, error) {
-		return node.RelayTxMetadata{Fee: 0, Size: len(b)}, nil
-	}
 	p.service.cfg.PeerRuntimeConfig.BanThreshold = 100
 	if err := p.handleTx(append(txBytes, 0x00)); err != nil {
 		t.Fatalf("expected below-threshold invalid tx to be ignored, got %v", err)

--- a/clients/go/node/p2p/coverage_sub80_followup_test.go
+++ b/clients/go/node/p2p/coverage_sub80_followup_test.go
@@ -129,6 +129,11 @@ func TestRelayTxMetadataNilProviderErrors(t *testing.T) {
 	}
 
 	h := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	// NewService fails closed on nil TxMetadataFunc, so the harness wires a
+	// default. Clear it after construction to prove the method-level guard
+	// still refuses to synthesize metadata if the provider is removed at
+	// runtime.
+	h.service.cfg.TxMetadataFunc = nil
 	_, err := h.service.relayTxMetadata([]byte{0xAA, 0xBB, 0xCC})
 	if err == nil {
 		t.Fatal("relayTxMetadata must error when TxMetadataFunc is nil")
@@ -146,6 +151,21 @@ func TestRelayTxMetadataNilProviderErrors(t *testing.T) {
 	}
 	if meta.Fee != 9 || meta.Size != 7 {
 		t.Fatalf("provider meta=%+v, want fee=9 size=7", meta)
+	}
+}
+
+func TestNewServiceRejectsNilTxMetadataFunc(t *testing.T) {
+	h := newTestHarness(t, 0, "127.0.0.1:0", nil)
+	if _, err := NewService(ServiceConfig{
+		BindAddr:    "127.0.0.1:0",
+		PeerManager: h.peerManager,
+		SyncConfig:  h.syncCfg,
+		SyncEngine:  h.syncEngine,
+		BlockStore:  h.blockStore,
+	}); err == nil {
+		t.Fatal("NewService must reject a ServiceConfig with nil TxMetadataFunc")
+	} else if !strings.Contains(err.Error(), "tx metadata") {
+		t.Fatalf("error=%q, want substring 'tx metadata'", err.Error())
 	}
 }
 

--- a/clients/go/node/p2p/coverage_sub80_followup_test.go
+++ b/clients/go/node/p2p/coverage_sub80_followup_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -122,19 +123,24 @@ func TestInventoryRelayKeyMultipleItems(t *testing.T) {
 	}
 }
 
-func TestRelayTxMetadataFallbackAndProvider(t *testing.T) {
+func TestRelayTxMetadataNilProviderErrors(t *testing.T) {
+	if _, err := (*Service)(nil).relayTxMetadata(nil); err == nil {
+		t.Fatal("relayTxMetadata on nil service should error")
+	}
+
 	h := newTestHarness(t, 1, "127.0.0.1:0", nil)
-	meta, err := h.service.relayTxMetadata([]byte{0xAA, 0xBB, 0xCC})
-	if err != nil {
-		t.Fatalf("fallback relayTxMetadata: %v", err)
+	_, err := h.service.relayTxMetadata([]byte{0xAA, 0xBB, 0xCC})
+	if err == nil {
+		t.Fatal("relayTxMetadata must error when TxMetadataFunc is nil")
 	}
-	if meta.Fee != 0 || meta.Size != 3 {
-		t.Fatalf("fallback meta=%+v, want fee=0 size=3", meta)
+	if !strings.Contains(err.Error(), "tx metadata") {
+		t.Fatalf("error=%q, want substring 'tx metadata'", err.Error())
 	}
+
 	h.service.cfg.TxMetadataFunc = func([]byte) (node.RelayTxMetadata, error) {
 		return node.RelayTxMetadata{Fee: 9, Size: 7}, nil
 	}
-	meta, err = h.service.relayTxMetadata([]byte{0x00})
+	meta, err := h.service.relayTxMetadata([]byte{0x00})
 	if err != nil {
 		t.Fatalf("provider relayTxMetadata: %v", err)
 	}

--- a/clients/go/node/p2p/handlers_tx_test.go
+++ b/clients/go/node/p2p/handlers_tx_test.go
@@ -89,6 +89,9 @@ func TestHandleTxValid(t *testing.T) {
 	defer cancel()
 
 	h := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	h.service.cfg.TxMetadataFunc = func(b []byte) (node.RelayTxMetadata, error) {
+		return node.RelayTxMetadata{Fee: 0, Size: len(b)}, nil
+	}
 	if err := h.service.Start(ctx); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -169,12 +172,18 @@ func TestAnnounceTx(t *testing.T) {
 	defer cancel()
 
 	source := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	source.service.cfg.TxMetadataFunc = func(b []byte) (node.RelayTxMetadata, error) {
+		return node.RelayTxMetadata{Fee: 0, Size: len(b)}, nil
+	}
 	if err := source.service.Start(ctx); err != nil {
 		t.Fatalf("source.Start: %v", err)
 	}
 	defer source.service.Close()
 
 	sink := newTestHarness(t, 1, "127.0.0.1:0", []string{source.service.Addr()})
+	sink.service.cfg.TxMetadataFunc = func(b []byte) (node.RelayTxMetadata, error) {
+		return node.RelayTxMetadata{Fee: 0, Size: len(b)}, nil
+	}
 	if err := sink.service.Start(ctx); err != nil {
 		t.Fatalf("sink.Start: %v", err)
 	}
@@ -242,6 +251,9 @@ func TestHandleTxPoolFullMarksSeen(t *testing.T) {
 	defer cancel()
 
 	h := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	h.service.cfg.TxMetadataFunc = func(b []byte) (node.RelayTxMetadata, error) {
+		return node.RelayTxMetadata{Fee: 0, Size: len(b)}, nil
+	}
 	if err := h.service.Start(ctx); err != nil {
 		t.Fatalf("Start: %v", err)
 	}

--- a/clients/go/node/p2p/handlers_tx_test.go
+++ b/clients/go/node/p2p/handlers_tx_test.go
@@ -89,9 +89,6 @@ func TestHandleTxValid(t *testing.T) {
 	defer cancel()
 
 	h := newTestHarness(t, 1, "127.0.0.1:0", nil)
-	h.service.cfg.TxMetadataFunc = func(b []byte) (node.RelayTxMetadata, error) {
-		return node.RelayTxMetadata{Fee: 0, Size: len(b)}, nil
-	}
 	if err := h.service.Start(ctx); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -172,18 +169,12 @@ func TestAnnounceTx(t *testing.T) {
 	defer cancel()
 
 	source := newTestHarness(t, 1, "127.0.0.1:0", nil)
-	source.service.cfg.TxMetadataFunc = func(b []byte) (node.RelayTxMetadata, error) {
-		return node.RelayTxMetadata{Fee: 0, Size: len(b)}, nil
-	}
 	if err := source.service.Start(ctx); err != nil {
 		t.Fatalf("source.Start: %v", err)
 	}
 	defer source.service.Close()
 
 	sink := newTestHarness(t, 1, "127.0.0.1:0", []string{source.service.Addr()})
-	sink.service.cfg.TxMetadataFunc = func(b []byte) (node.RelayTxMetadata, error) {
-		return node.RelayTxMetadata{Fee: 0, Size: len(b)}, nil
-	}
 	if err := sink.service.Start(ctx); err != nil {
 		t.Fatalf("sink.Start: %v", err)
 	}
@@ -251,9 +242,6 @@ func TestHandleTxPoolFullMarksSeen(t *testing.T) {
 	defer cancel()
 
 	h := newTestHarness(t, 1, "127.0.0.1:0", nil)
-	h.service.cfg.TxMetadataFunc = func(b []byte) (node.RelayTxMetadata, error) {
-		return node.RelayTxMetadata{Fee: 0, Size: len(b)}, nil
-	}
 	if err := h.service.Start(ctx); err != nil {
 		t.Fatalf("Start: %v", err)
 	}

--- a/clients/go/node/p2p/peer_runtime_test.go
+++ b/clients/go/node/p2p/peer_runtime_test.go
@@ -295,6 +295,7 @@ func newPeerRuntimeTestPeer(t *testing.T) *peer {
 		SyncEngine:        syncEngine,
 		BlockStore:        blockStore,
 		TxPool:            NewMemoryTxPool(),
+		TxMetadataFunc:    testHarnessDefaultTxMetadata,
 		PeerRuntimeConfig: node.DefaultPeerRuntimeConfig("devnet", 8),
 		Now:               time.Now,
 	}

--- a/clients/go/node/p2p/service.go
+++ b/clients/go/node/p2p/service.go
@@ -103,6 +103,9 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 	if cfg.BlockStore == nil {
 		return nil, errors.New("nil blockstore")
 	}
+	if cfg.TxMetadataFunc == nil {
+		return nil, errors.New("nil tx metadata func")
+	}
 	if cfg.TxPool == nil {
 		cfg.TxPool = NewMemoryTxPool()
 	}

--- a/clients/go/node/p2p/service_test.go
+++ b/clients/go/node/p2p/service_test.go
@@ -658,6 +658,14 @@ func TestRetainOrResolveOrphanImmediatelyResolvesWhenParentAlreadyExists(t *test
 	}
 }
 
+// testHarnessDefaultTxMetadata is the TxMetadataFunc wired by newTestHarness
+// and newPeerRuntimeTestPeer so tests that do not exercise fee/size specifics
+// still satisfy the NewService non-nil-provider contract. Tests that need a
+// specific provider override the field after construction.
+func testHarnessDefaultTxMetadata(b []byte) (node.RelayTxMetadata, error) {
+	return node.RelayTxMetadata{Fee: 0, Size: len(b)}, nil
+}
+
 func newTestHarness(t *testing.T, blockCount int, bindAddr string, bootstrapPeers []string) *testHarness {
 	t.Helper()
 
@@ -708,6 +716,7 @@ func newTestHarness(t *testing.T, blockCount int, bindAddr string, bootstrapPeer
 		SyncConfig:        syncCfg,
 		SyncEngine:        syncEngine,
 		BlockStore:        blockStore,
+		TxMetadataFunc:    testHarnessDefaultTxMetadata,
 	})
 	if err != nil {
 		t.Fatalf("NewService: %v", err)

--- a/clients/go/node/p2p/tx_metadata.go
+++ b/clients/go/node/p2p/tx_metadata.go
@@ -1,13 +1,17 @@
 package p2p
 
-import "github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/node"
+import (
+	"errors"
+
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/node"
+)
 
 func (s *Service) relayTxMetadata(txBytes []byte) (node.RelayTxMetadata, error) {
-	if s != nil && s.cfg.TxMetadataFunc != nil {
-		return s.cfg.TxMetadataFunc(txBytes)
+	if s == nil {
+		return node.RelayTxMetadata{}, errors.New("nil service")
 	}
-	return node.RelayTxMetadata{
-		Fee:  0,
-		Size: len(txBytes),
-	}, nil
+	if s.cfg.TxMetadataFunc == nil {
+		return node.RelayTxMetadata{}, errors.New("nil tx metadata func")
+	}
+	return s.cfg.TxMetadataFunc(txBytes)
 }


### PR DESCRIPTION
Fail-closed `relayTxMetadata` in Go P2P: replace the `Fee=0 / Size=len(txBytes)` synthesis fallback with an explicit error when no authoritative `TxMetadataFunc` provider is configured. P2P tests updated to declare explicit providers instead of relying on the removed fallback.

Closes #1177
Q-IMPL-NODE-TX-METADATA-HONESTY-PARITY-01
