### PR TITLE
p2p: clamp remote best_height and reject absurd protocol_version in handshake

### DIFF
--- a/clients/go/node/p2p/coverage_hotspots_test.go
+++ b/clients/go/node/p2p/coverage_hotspots_test.go
@@ -77,6 +77,64 @@ func TestCoverage_NewServiceDefaultsAndAnnounceBlock(t *testing.T) {
 	}
 }
 
+func TestValidateRemoteVersion_Bounds(t *testing.T) {
+	chainID := node.DevnetGenesisChainID()
+	genesis := node.DevnetGenesisBlockHash()
+	makePayload := func(pv uint32) node.VersionPayloadV1 {
+		p := testVersionPayload(chainID, genesis, "ua", 0)
+		p.ProtocolVersion = pv
+		return p
+	}
+	cases := []struct {
+		name     string
+		pv       uint32
+		wantErr  bool
+		errMatch string
+	}{
+		{"zero rejected", 0, true, "invalid protocol_version"},
+		{"over max rejected", maxProtocolVersion + 1, true, "exceeds max"},
+		{"normal accepted", ProtocolVersion, false, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var state node.PeerState
+			err := validateRemoteVersion(makePayload(tc.pv), ProtocolVersion, chainID, genesis, 10, &state)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("pv=%d: want error, got nil", tc.pv)
+				}
+				if !strings.Contains(err.Error(), tc.errMatch) {
+					t.Fatalf("pv=%d: err=%q, want substring %q", tc.pv, err.Error(), tc.errMatch)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("pv=%d: want nil error, got %v", tc.pv, err)
+			}
+		})
+	}
+}
+
+func TestClampRemoteBestHeight(t *testing.T) {
+	cases := []struct {
+		name                string
+		localHeight, remote uint64
+		want                uint64
+	}{
+		{"within delta returns remote", 100, 500, 500},
+		{"absurd remote clamps to local+delta", 100, 99_999_999, 100 + maxBestHeightDelta},
+		{"saturates when local near uint64 max", ^uint64(0) - 1, ^uint64(0), ^uint64(0)},
+		{"zero local caps remote to delta", 0, 10 * maxBestHeightDelta, maxBestHeightDelta},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := clampRemoteBestHeight(tc.localHeight, tc.remote); got != tc.want {
+				t.Fatalf("local=%d remote=%d: got %d want %d", tc.localHeight, tc.remote, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestCoverage_HandshakeHelpers(t *testing.T) {
 	localConn, remoteConn := net.Pipe()
 	defer localConn.Close()

--- a/clients/go/node/p2p/handshake.go
+++ b/clients/go/node/p2p/handshake.go
@@ -119,6 +119,14 @@ func interruptHandshakeOnContextCancel(ctx context.Context, conn net.Conn, done 
 	}
 }
 
+// maxProtocolVersion is the absolute upper bound for a remote peer's
+// claimed protocol_version, mirroring the Rust client's MAX_PROTOCOL_VERSION
+// in clients/rust/crates/rubin-node/src/p2p_runtime.rs. A version above this
+// bound is rejected by validateRemoteVersion regardless of local/remote
+// adjacency so absurd claims from a malicious or misconfigured peer cannot
+// slip past the pairwise compatibility window.
+const maxProtocolVersion uint32 = 1024
+
 func validateRemoteVersion(
 	remote node.VersionPayloadV1,
 	localProtocolVersion uint32,
@@ -131,6 +139,9 @@ func validateRemoteVersion(
 	case remote.ProtocolVersion == 0:
 		state.LastError = "invalid protocol_version"
 		return errors.New("invalid protocol_version")
+	case remote.ProtocolVersion > maxProtocolVersion:
+		state.LastError = fmt.Sprintf("protocol_version %d exceeds max %d", remote.ProtocolVersion, maxProtocolVersion)
+		return fmt.Errorf("protocol_version %d exceeds max %d", remote.ProtocolVersion, maxProtocolVersion)
 	case !protocolVersionsCompatible(localProtocolVersion, remote.ProtocolVersion):
 		state.LastError = fmt.Sprintf("protocol_version mismatch: local=%d remote=%d", localProtocolVersion, remote.ProtocolVersion)
 		return fmt.Errorf("protocol_version mismatch: local=%d remote=%d", localProtocolVersion, remote.ProtocolVersion)

--- a/clients/go/node/p2p/service_sync.go
+++ b/clients/go/node/p2p/service_sync.go
@@ -5,12 +5,33 @@ import (
 	"os"
 )
 
+// maxBestHeightDelta bounds how far above the local tip a peer's claimed
+// best_height is allowed to influence sync decisions, mirroring the Rust
+// client's MAX_BEST_HEIGHT_DELTA in clients/rust/crates/rubin-node/src/p2p_runtime.rs.
+// Without this clamp a malicious or misconfigured peer reporting an absurdly
+// high best_height could force unnecessary sync behaviour downstream.
+const maxBestHeightDelta uint64 = 100_000
+
+// clampRemoteBestHeight returns the peer's claimed best_height bounded by
+// localHeight + maxBestHeightDelta. Uses saturating addition so a localHeight
+// near uint64 max does not wrap and silently accept arbitrary remote claims.
+func clampRemoteBestHeight(localHeight, remote uint64) uint64 {
+	upper := localHeight + maxBestHeightDelta
+	if upper < localHeight {
+		upper = ^uint64(0)
+	}
+	if remote > upper {
+		return upper
+	}
+	return remote
+}
+
 func (s *Service) requestBlocksIfBehind(p *peer) error {
 	localHeight, hasTip, err := s.tipHeight()
 	if err != nil {
 		return err
 	}
-	remoteBest := p.snapshotState().RemoteVersion.BestHeight
+	remoteBest := clampRemoteBestHeight(localHeight, p.snapshotState().RemoteVersion.BestHeight)
 	if hasTip && localHeight >= remoteBest {
 		return nil
 	}

--- a/clients/go/node/p2p/service_sync.go
+++ b/clients/go/node/p2p/service_sync.go
@@ -9,7 +9,7 @@ import (
 // best_height is allowed to influence sync decisions, mirroring the Rust
 // client's MAX_BEST_HEIGHT_DELTA in clients/rust/crates/rubin-node/src/p2p_runtime.rs.
 // Without this clamp a malicious or misconfigured peer reporting an absurdly
-// high best_height could force unnecessary sync behaviour downstream.
+// high best_height could force unnecessary sync behavior downstream.
 const maxBestHeightDelta uint64 = 100_000
 
 // clampRemoteBestHeight returns the peer's claimed best_height bounded by


### PR DESCRIPTION
Go-first slice of #1184 handshake normalization. Mirrors Rust bounds without widening the wire contract.

- `handshake.go`: `maxProtocolVersion = 1024` constant; new rejection branch in `validateRemoteVersion` with error string `"protocol_version %d exceeds max %d"` matching Rust's `MAX_PROTOCOL_VERSION` path.
- `service_sync.go`: `maxBestHeightDelta = 100_000` constant; `clampRemoteBestHeight` helper with saturating addition; `requestBlocksIfBehind` uses the clamp before the sync decision.
- `coverage_hotspots_test.go`: `TestValidateRemoteVersion_Bounds` (zero / over-max / normal) and `TestClampRemoteBestHeight` (within-delta / absurd / saturating / zero-local).

Full parity closure for #1184 is a separate follow-up.

Closes #1184
Q-IMPL-NODE-P2P-VERSION-HEIGHT-NORMALIZATION-01
