### PR TITLE
cmd/rubin-node: explicit HTTP timeouts + honest 413 for oversized /submit_tx body

### DIFF
--- a/clients/go/cmd/rubin-node/http_rpc.go
+++ b/clients/go/cmd/rubin-node/http_rpc.go
@@ -210,6 +210,19 @@ func startDevnetRPCServer(
 	server := &http.Server{
 		Handler:           newDevnetRPCHandler(state),
 		ReadHeaderTimeout: 5 * time.Second,
+		// ReadTimeout bounds the total duration for reading the entire
+		// request (headers + body) — it is NOT a body-only budget layered
+		// on top of ReadHeaderTimeout. 10 s is ample for a 2 MiB body plus
+		// normal-size headers and stops slow-loris body writes from pinning
+		// a goroutine indefinitely.
+		// WriteTimeout is deliberately NOT set: Go's WriteTimeout is a
+		// request-scoped total-handler deadline, not a per-syscall socket
+		// timeout like Rust's `set_write_timeout(5s)` in devnet_rpc.rs. A
+		// hard WriteTimeout would abort long-running RPCs such as
+		// /mine_next (PoW-bound) even when the client is reading promptly.
+		// IdleTimeout keeps the connection pool bounded.
+		ReadTimeout: 10 * time.Second,
+		IdleTimeout: 60 * time.Second,
 	}
 	go func() {
 		<-ctx.Done()
@@ -440,23 +453,19 @@ func handleSubmitTx(state *devnetRPCState, w http.ResponseWriter, r *http.Reques
 		return
 	}
 	var req submitTxRequest
-	body := io.LimitReader(r.Body, maxBodyBytes+1) // +1 to detect over-limit
 	defer r.Body.Close()
-	dec := json.NewDecoder(body)
+	// http.MaxBytesReader enforces maxBodyBytes for chunked / unknown-length
+	// bodies as well. When the limit is exceeded the wrapped reader surfaces
+	// a *http.MaxBytesError, which lets us return 413 instead of collapsing
+	// an oversized body into a generic "invalid JSON body" 400.
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+	dec := json.NewDecoder(r.Body)
 	if err := dec.Decode(&req); err != nil {
-		state.metrics.noteSubmit("bad_request")
-		writeJSONResponse(state, route, w, http.StatusBadRequest, submitTxResponse{
-			Accepted: false,
-			Error:    "invalid JSON body",
-		})
+		respondSubmitTxBodyError(state, route, w, err)
 		return
 	}
-	if err := ensureJSONBodyEOF(dec); err != nil {
-		state.metrics.noteSubmit("bad_request")
-		writeJSONResponse(state, route, w, http.StatusBadRequest, submitTxResponse{
-			Accepted: false,
-			Error:    "invalid JSON body",
-		})
+	if err := drainSubmitTxBody(dec, r.Body); err != nil {
+		respondSubmitTxBodyError(state, route, w, err)
 		return
 	}
 	raw, err := decodeHexPayload(req.TxHex)
@@ -873,16 +882,39 @@ func classifySubmitErr(err error) (int, string) {
 	return http.StatusUnprocessableEntity, "rejected"
 }
 
-func ensureJSONBodyEOF(dec *json.Decoder) error {
+// drainSubmitTxBody finishes reading the /submit_tx body after the first JSON
+// value has been decoded. It must distinguish three tail shapes:
+//
+//  1. Clean EOF (valid-only body) — return nil.
+//  2. Non-whitespace trailing content within the cap — return a JSON-garbage
+//     error so the caller returns 400.
+//  3. Trailing content that exceeds maxBodyBytes — let http.MaxBytesReader
+//     surface *http.MaxBytesError directly so the caller returns 413.
+//
+// The decoder's already-buffered tail and the underlying body reader are
+// concatenated into a single stream via io.MultiReader and read through
+// io.ReadAll. Every byte of the combined tail is then inspected for
+// non-whitespace content, and http.MaxBytesReader surfaces
+// *http.MaxBytesError from io.ReadAll when the combined tail exceeds the
+// cap. This closes the "garbage past dec.Buffered()" class the earlier
+// split-read implementation missed.
+func drainSubmitTxBody(dec *json.Decoder, body io.Reader) error {
 	if dec == nil {
 		return errors.New("nil decoder")
 	}
-	var extra any
-	if err := dec.Decode(&extra); err != io.EOF {
-		if err == nil {
+	// Scan BOTH the decoder's already-buffered tail and the rest of the
+	// underlying body as a single stream. Reading through body (via
+	// MultiReader → io.ReadAll) lets http.MaxBytesReader surface
+	// *http.MaxBytesError for oversized tails while every byte in the
+	// combined stream is inspected for non-whitespace garbage.
+	tail, err := io.ReadAll(io.MultiReader(dec.Buffered(), body))
+	if err != nil {
+		return err
+	}
+	for _, b := range tail {
+		if b != ' ' && b != '\t' && b != '\n' && b != '\r' {
 			return errors.New("unexpected trailing JSON value")
 		}
-		return err
 	}
 	return nil
 }
@@ -892,4 +924,26 @@ func (s *devnetRPCState) now() uint64 {
 		return nowUnixU64()
 	}
 	return s.nowUnix()
+}
+
+// respondSubmitTxBodyError classifies a /submit_tx body-read / JSON-decode
+// error into 413 "request body too large" when the http.MaxBytesReader cap
+// was crossed and 400 "invalid JSON body" otherwise. Both the initial
+// dec.Decode and the trailing drainSubmitTxBody check route through this
+// helper so the oversize-vs-malformed distinction stays consistent on every
+// path.
+func respondSubmitTxBodyError(state *devnetRPCState, route string, w http.ResponseWriter, err error) {
+	state.metrics.noteSubmit("bad_request")
+	var maxErr *http.MaxBytesError
+	if errors.As(err, &maxErr) {
+		writeJSONResponse(state, route, w, http.StatusRequestEntityTooLarge, submitTxResponse{
+			Accepted: false,
+			Error:    "request body too large",
+		})
+		return
+	}
+	writeJSONResponse(state, route, w, http.StatusBadRequest, submitTxResponse{
+		Accepted: false,
+		Error:    "invalid JSON body",
+	})
 }

--- a/clients/go/cmd/rubin-node/http_rpc.go
+++ b/clients/go/cmd/rubin-node/http_rpc.go
@@ -453,12 +453,15 @@ func handleSubmitTx(state *devnetRPCState, w http.ResponseWriter, r *http.Reques
 		return
 	}
 	var req submitTxRequest
-	defer r.Body.Close()
 	// http.MaxBytesReader enforces maxBodyBytes for chunked / unknown-length
 	// bodies as well. When the limit is exceeded the wrapped reader surfaces
 	// a *http.MaxBytesError, which lets us return 413 instead of collapsing
 	// an oversized body into a generic "invalid JSON body" 400.
 	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+	// Defer the Close AFTER the MaxBytesReader wrap so the deferred call
+	// targets the wrapped reader (any wrapper-specific Close behavior runs,
+	// and the close aligns with what dec / drainSubmitTxBody actually read).
+	defer r.Body.Close()
 	dec := json.NewDecoder(r.Body)
 	if err := dec.Decode(&req); err != nil {
 		respondSubmitTxBodyError(state, route, w, err)

--- a/clients/go/cmd/rubin-node/http_rpc_test.go
+++ b/clients/go/cmd/rubin-node/http_rpc_test.go
@@ -622,9 +622,10 @@ func TestDevnetRPCSubmitTxRejectsTrailingGarbageAfterBufferedWindow(t *testing.T
 	server := httptest.NewServer(newDevnetRPCHandler(mustRPCState(t, false)))
 	defer server.Close()
 
-	// The decoder's internal buffer is a few KiB; 512 KiB of whitespace is
-	// guaranteed to push the trailing 'x' past dec.Buffered() into the raw
-	// body stream.
+	// 512 KiB of whitespace is chosen to exceed typical json.Decoder buffering
+	// while remaining well below the 2 MiB body cap, so the trailing 'x' is
+	// expected to be read from the underlying body stream rather than only from
+	// dec.Buffered().
 	payload := `{"tx_hex":"00"}` + strings.Repeat(" ", 512*1024) + "x"
 	resp, err := http.Post(server.URL+"/submit_tx", "application/json", strings.NewReader(payload))
 	if err != nil {

--- a/clients/go/cmd/rubin-node/http_rpc_test.go
+++ b/clients/go/cmd/rubin-node/http_rpc_test.go
@@ -532,6 +532,141 @@ func TestDevnetRPCSubmitTxRejectsInvalidTx(t *testing.T) {
 	}
 }
 
+// TestDevnetRPCSubmitTxRejectsOversizedContentLength covers the ContentLength
+// short-circuit path (header advertises oversized body → 413 without reading
+// any bytes).
+func TestDevnetRPCSubmitTxRejectsOversizedContentLength(t *testing.T) {
+	server := httptest.NewServer(newDevnetRPCHandler(mustRPCState(t, false)))
+	defer server.Close()
+
+	// 3 MiB body exceeds the 2 MiB cap; http.Post sets Content-Length.
+	payload := strings.Repeat("a", 3*1024*1024)
+	resp, err := http.Post(server.URL+"/submit_tx", "application/json", strings.NewReader(payload))
+	if err != nil {
+		t.Fatalf("Post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status=%d, want 413", resp.StatusCode)
+	}
+}
+
+// TestDevnetRPCSubmitTxRejectsOversizedChunkedTrailingBody covers the
+// post-decode path: a valid short JSON value is followed by enough trailing
+// bytes (on a chunked/unknown-length body) to exceed maxBodyBytes. The
+// drainSubmitTxBody path must classify this as 413, not collapse into a
+// generic 400, because http.MaxBytesReader surfaces *http.MaxBytesError
+// during the io.ReadAll over the combined tail.
+func TestDevnetRPCSubmitTxRejectsOversizedChunkedTrailingBody(t *testing.T) {
+	server := httptest.NewServer(newDevnetRPCHandler(mustRPCState(t, false)))
+	defer server.Close()
+
+	payload := `{"tx_hex":"00"}` + strings.Repeat("a", 3*1024*1024) // >3 MiB trailer
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/submit_tx", strings.NewReader(payload))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.ContentLength = -1
+	req.TransferEncoding = []string{"chunked"}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status=%d, want 413 (trailing oversize must not collapse to 400)", resp.StatusCode)
+	}
+}
+
+// TestDevnetRPCServerExplicitTimeouts pins the Rust-parity timeout surface on
+// the underlying http.Server so a future edit that drops ReadTimeout /
+// WriteTimeout / IdleTimeout gets caught before landing.
+func TestDevnetRPCServerExplicitTimeouts(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	srv, err := startDevnetRPCServer(ctx, "127.0.0.1:0", mustRPCState(t, false), io.Discard, io.Discard)
+	if err != nil {
+		t.Fatalf("startDevnetRPCServer: %v", err)
+	}
+	if srv == nil || srv.server == nil {
+		t.Fatal("nil server")
+	}
+	defer func() { _ = srv.Close(context.Background()) }()
+
+	if got, want := srv.server.ReadHeaderTimeout, 5*time.Second; got != want {
+		t.Errorf("ReadHeaderTimeout=%v, want %v", got, want)
+	}
+	if got, want := srv.server.ReadTimeout, 10*time.Second; got != want {
+		t.Errorf("ReadTimeout=%v, want %v", got, want)
+	}
+	// WriteTimeout is intentionally zero: Go's WriteTimeout is a
+	// request-scoped total-handler deadline, which would abort long-running
+	// RPCs like /mine_next. See rationale in startDevnetRPCServer.
+	if got := srv.server.WriteTimeout; got != 0 {
+		t.Errorf("WriteTimeout=%v, want 0 (WriteTimeout aborts long handlers in Go)", got)
+	}
+	if got, want := srv.server.IdleTimeout, 60*time.Second; got != want {
+		t.Errorf("IdleTimeout=%v, want %v", got, want)
+	}
+}
+
+// TestDevnetRPCSubmitTxRejectsTrailingGarbageAfterBufferedWindow pins the
+// drainSubmitTxBody full-stream scan: a valid JSON body followed by a long
+// whitespace run that pushes trailing garbage past the decoder's internal
+// buffer must still return 400. Without the MultiReader(dec.Buffered(), body)
+// scan, the garbage byte slipped past and /submit_tx incorrectly accepted
+// a malformed body.
+func TestDevnetRPCSubmitTxRejectsTrailingGarbageAfterBufferedWindow(t *testing.T) {
+	server := httptest.NewServer(newDevnetRPCHandler(mustRPCState(t, false)))
+	defer server.Close()
+
+	// The decoder's internal buffer is a few KiB; 512 KiB of whitespace is
+	// guaranteed to push the trailing 'x' past dec.Buffered() into the raw
+	// body stream.
+	payload := `{"tx_hex":"00"}` + strings.Repeat(" ", 512*1024) + "x"
+	resp, err := http.Post(server.URL+"/submit_tx", "application/json", strings.NewReader(payload))
+	if err != nil {
+		t.Fatalf("Post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status=%d, want 400 (trailing garbage past buffered window must not be accepted)", resp.StatusCode)
+	}
+}
+
+// TestDevnetRPCSubmitTxRejectsOversizedChunkedBody covers the previously
+// mis-classified path: a chunked / unknown-length body that exceeds
+// maxBodyBytes must surface as 413, not collapse to "invalid JSON body" 400
+// because the drainSubmitTxBody path truncated the stream before
+// json.Decode.
+func TestDevnetRPCSubmitTxRejectsOversizedChunkedBody(t *testing.T) {
+	server := httptest.NewServer(newDevnetRPCHandler(mustRPCState(t, false)))
+	defer server.Close()
+
+	// Valid JSON prefix so the decoder advances past the opening tokens and
+	// only hits the body-size limit while reading the oversized string value.
+	payload := `{"tx_hex":"` + strings.Repeat("a", 3*1024*1024) + `"}` // >3 MiB, cap is 2 MiB
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/submit_tx", strings.NewReader(payload))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	// Force chunked transfer so the ContentLength short-circuit does not fire;
+	// the MaxBytesReader branch must convert the oversize into 413.
+	req.ContentLength = -1
+	req.TransferEncoding = []string{"chunked"}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status=%d, want 413 (chunked body must not collapse to 400)", resp.StatusCode)
+	}
+}
+
 func TestDevnetRPCSubmitTxAcceptsValidTxAndAnnounces(t *testing.T) {
 	fromKey := mustRPCMLDSA87Keypair(t)
 	toKey := mustRPCMLDSA87Keypair(t)
@@ -1384,8 +1519,8 @@ func TestDevnetRPCTxStatusEmptyTxIDValueIsClassifiedAsMissing(t *testing.T) {
 }
 
 func TestDevnetRPCGetTxValuelessTxIDKeyClassifiedAsMissing(t *testing.T) {
-	// Go/Rust parity regression (Codex thread PRRT_kwDORQ3qGs57NpSB):
-	// ?txid (key without `=`) or ?txid&txid=<hex> — Go's net/url parses a
+	// Go/Rust parity regression: ?txid (key without `=`) or ?txid&txid=<hex>
+	// — Go's net/url parses a
 	// key without `=` into url.Values{"txid":[""]}, so Query().Get returns
 	// "" (missing). Rust parser must match: treat key without `=` as
 	// present-with-empty, classify as missing, first-match semantic (never
@@ -1419,8 +1554,7 @@ func TestDevnetRPCGetTxFailsClosedOn503BeforeParsingInvalidTxID(t *testing.T) {
 	// Contract: mempool unavailability is a 503 fail-closed regardless of
 	// query-string validity. A nil mempool + invalid txid MUST return 503
 	// (not 400). Previously handleGetTx parsed first and returned 400 on
-	// bad query, masking the unavailability. Copilot thread
-	// PRRT_kwDORQ3qGs57N-UC flagged this ordering bug.
+	// bad query, masking the unavailability.
 	req := httptest.NewRequest(http.MethodGet, "/get_tx?txid=invalid-not-hex", nil)
 	rec := httptest.NewRecorder()
 	handleGetTx(nil, rec, req)
@@ -1437,8 +1571,7 @@ func TestDevnetRPCGetTxFailsClosedOn503BeforeParsingInvalidTxID(t *testing.T) {
 }
 
 func TestDevnetRPCTxStatusFailsClosedOn503BeforeParsingInvalidTxID(t *testing.T) {
-	// Parity sibling of the handleGetTx ordering fix. Copilot thread
-	// PRRT_kwDORQ3qGs57N-UX.
+	// Parity sibling of the handleGetTx ordering fix.
 	req := httptest.NewRequest(http.MethodGet, "/tx_status?txid=invalid-not-hex", nil)
 	rec := httptest.NewRecorder()
 	handleTxStatus(nil, rec, req)

--- a/clients/go/cmd/rubin-node/http_rpc_test.go
+++ b/clients/go/cmd/rubin-node/http_rpc_test.go
@@ -640,8 +640,8 @@ func TestDevnetRPCSubmitTxRejectsTrailingGarbageAfterBufferedWindow(t *testing.T
 // TestDevnetRPCSubmitTxRejectsOversizedChunkedBody covers the previously
 // mis-classified path: a chunked / unknown-length body that exceeds
 // maxBodyBytes must surface as 413, not collapse to "invalid JSON body" 400
-// because the drainSubmitTxBody path truncated the stream before
-// json.Decode.
+// due to the pre-MaxBytesReader body-limiting/reader behavior when the
+// size limit is hit during json.Decode.
 func TestDevnetRPCSubmitTxRejectsOversizedChunkedBody(t *testing.T) {
 	server := httptest.NewServer(newDevnetRPCHandler(mustRPCState(t, false)))
 	defer server.Close()


### PR DESCRIPTION
Go-first slice of #1148 RPC load hardening. No endpoint or wire-contract change.

- `http_rpc.go` / `startDevnetRPCServer`: explicit `ReadHeaderTimeout=5s`, `ReadTimeout=10s`, `IdleTimeout=60s`. `WriteTimeout` is **intentionally zero** because Go's `WriteTimeout` is a request-scoped total-handler deadline (unlike Rust's per-syscall `set_write_timeout` in `devnet_rpc.rs`) and would abort long-running RPCs such as `/mine_next`. Slow-loris body writes are bounded by `ReadTimeout`; idle keep-alive is bounded by `IdleTimeout`.
- `http_rpc.go` / `handleSubmitTx`: `http.MaxBytesReader` + `errors.As(*http.MaxBytesError)` classifies every oversize (Content-Length, chunked body, chunked trailing after a decoded JSON value) as `413 "request body too large"` via the shared `respondSubmitTxBodyError` helper.
- `http_rpc.go` / `drainSubmitTxBody`: concatenates the decoder's buffered tail and the underlying body reader into a single `io.MultiReader`, reads through `io.ReadAll` (bounded by `MaxBytesReader`), and scans every byte of the combined tail for non-whitespace content. This closes the "garbage past `dec.Buffered()`" class that a split buffered-scan + `io.Copy` drain missed. `ensureJSONBodyEOF` is removed.
- `http_rpc_test.go`: regressions for each status-code path — oversized Content-Length `413`, oversized chunked body `413`, oversized chunked trailing `413`, trailing garbage past the decoder's buffered window `400`, and an explicit timeout test that reads `runningDevnetRPCServer.server` fields and pins `WriteTimeout=0`.

Closes #1148
Q-IMPL-NODE-DEVNET-RPC-LOAD-HARDENING-01


<!-- rubin-agent-meta actor=unknown action=pr-edit via=cl branch=main wt=rubin-protocol utc=2026-04-24T00:36:45Z -->
