### PR TITLE
ci: rely on Codacy for coverage threshold enforcement

### DIFF
--- a/.github/workflows/codacy-coverage.yml
+++ b/.github/workflows/codacy-coverage.yml
@@ -110,18 +110,6 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
-      - name: Enforce local coverage gates
-        if: github.event_name == 'pull_request'
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ github.token }}
-          HEAD_GO_COVERAGE: ${{ github.workspace }}/clients/go/coverage.out
-          HEAD_RUST_LCOV: ${{ github.workspace }}/clients/rust/lcov.info
-          HEAD_COVERAGE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-        run: |
-          chmod +x scripts/preflight-codacy-coverage.sh
-          ./scripts/preflight-codacy-coverage.sh "origin/${{ github.base_ref }}"
-
       - name: Upload to Codacy
         env:
           CODACY_API_TOKEN: ${{ secrets.CODACY_API_TOKEN }}

--- a/.github/workflows/codacy-coverage.yml
+++ b/.github/workflows/codacy-coverage.yml
@@ -112,6 +112,7 @@ jobs:
 
       - name: Enforce local coverage gates
         if: github.event_name == 'pull_request'
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
           HEAD_GO_COVERAGE: ${{ github.workspace }}/clients/go/coverage.out

--- a/tools/tests/test_list_workflow_shell_targets.py
+++ b/tools/tests/test_list_workflow_shell_targets.py
@@ -27,7 +27,6 @@ class WorkflowShellTargetTests(unittest.TestCase):
                 "scripts/crypto/openssl/fips-preflight.sh",
                 "scripts/dev-env.sh",
                 "scripts/node-runtime-total-parity-gate.sh",
-                "scripts/preflight-codacy-coverage.sh",
                 "scripts/run-codacy-coverage.sh",
                 "scripts/runtime_perf/run_runtime_perf_suite.sh",
                 "scripts/rust-consensus-total-parity-gate.sh",


### PR DESCRIPTION
## Summary

This PR removes the in-repo `Enforce local coverage gates` step from the `codacy-coverage` workflow. Coverage artifacts are still generated, archived, and uploaded to Codacy, so Codacy server-side checks remain the merge authority.

## Scope

- [ ] Documentation-only
- [ ] Implementation-only change (no consensus change)
- [ ] Consensus-affecting change (requires explicit process)
- [x] CI workflow-only change

**Consensus boundary (required):**

- Consensus rules unchanged: YES
- `SECTION_HASHES.json` unchanged: YES
- Wire format unchanged: YES

## PR/task fields

- Architecture class: A
- System boundary: `.github/workflows/codacy-coverage.yml`, `tools/tests/test_list_workflow_shell_targets.py`
- Single invariant or single contract delta: GitHub Actions no longer enforces the local coverage threshold before Codacy upload; local pre-push coverage and Codacy SaaS checks remain separate gates.
- Non-goals: no coverage threshold change, no local wrapper bypass, no Go/Rust code change, no Codacy reporter change, no coverage generation/upload removal.
- Class-change stop rule: if more workflow policy or Codacy reporter behavior is needed, split it into a separate PR.
- What this PR is NOT allowed to redesign: coverage generation, Codacy reporter invocation, local pre-push coverage policy, Go/Rust test coverage policy.

## Evidence / Gates

- `git diff --check`
- workflow YAML syntax check from local pre-push gate
- workflow shell target helper tests from local pre-push gate
- `rubin-common-preflight --repo <repo>`: PASS, including `rubin-protocol-coverage`
- `cl push`: PASS, pushed `fad246d`

## Risk

This does not weaken local pre-push coverage. It removes only the duplicate GitHub Actions enforce step so the workflow can still reach Codacy upload and Codacy server-side policy can make the final coverage decision.

Refs: Q-CI-CODACY-UPLOAD-CONTINUE-01


<!-- rubin-agent-meta actor=Codex action=pr-edit via=cl branch=codex/coverage-preflight-continue-on-error wt=rubin-protocol utc=2026-04-25T15:10:45Z -->
