### PR TITLE
fix(go-p2p): disconnect on partial frame timeout

### DIFF
--- a/clients/go/node/p2p/peer_runtime.go
+++ b/clients/go/node/p2p/peer_runtime.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"os"
 	"time"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/node"
@@ -57,8 +56,7 @@ func (p *peer) run(ctx context.Context) error {
 }
 
 func shouldIgnoreReadError(err error) bool {
-	var netErr net.Error
-	return errors.Is(err, os.ErrDeadlineExceeded) || (errors.As(err, &netErr) && netErr.Timeout())
+	return !isPartialFrameTimeout(err) && isReadTimeout(err)
 }
 
 func normalizeReadError(err error) error {

--- a/clients/go/node/p2p/peer_runtime_test.go
+++ b/clients/go/node/p2p/peer_runtime_test.go
@@ -21,12 +21,56 @@ func (timeoutErr) Error() string   { return "timeout" }
 func (timeoutErr) Timeout() bool   { return true }
 func (timeoutErr) Temporary() bool { return true }
 
+type scriptedRead struct {
+	data []byte
+	err  error
+}
+
+type scriptedConn struct {
+	reads []scriptedRead
+	bytes.Buffer
+}
+
+func (c *scriptedConn) Read(p []byte) (int, error) {
+	if len(c.reads) == 0 {
+		return 0, io.EOF
+	}
+	current := &c.reads[0]
+	if len(current.data) > 0 {
+		n := copy(p, current.data)
+		current.data = current.data[n:]
+		if len(current.data) > 0 {
+			return n, nil
+		}
+		err := current.err
+		c.reads = c.reads[1:]
+		return n, err
+	}
+	err := current.err
+	c.reads = c.reads[1:]
+	return 0, err
+}
+
+func (c *scriptedConn) Write(p []byte) (int, error) { return c.Buffer.Write(p) }
+func (c *scriptedConn) Close() error                { return nil }
+func (c *scriptedConn) LocalAddr() net.Addr         { return stubAddr("local") }
+func (c *scriptedConn) RemoteAddr() net.Addr        { return stubAddr("remote") }
+func (c *scriptedConn) SetDeadline(time.Time) error { return nil }
+func (c *scriptedConn) SetReadDeadline(time.Time) error {
+	return nil
+}
+func (c *scriptedConn) SetWriteDeadline(time.Time) error { return nil }
+
 func TestShouldIgnoreAndNormalizeReadError(t *testing.T) {
 	if !shouldIgnoreReadError(os.ErrDeadlineExceeded) {
 		t.Fatalf("expected os.ErrDeadlineExceeded to be ignored")
 	}
 	if !shouldIgnoreReadError(timeoutErr{}) {
 		t.Fatalf("expected timeout net.Error to be ignored")
+	}
+	partialTimeout := partialFrameTimeoutError{part: "header", read: 1, want: wireHeaderSize, err: timeoutErr{}}
+	if shouldIgnoreReadError(partialTimeout) {
+		t.Fatalf("partial frame timeout must disconnect instead of being ignored")
 	}
 	if shouldIgnoreReadError(io.EOF) {
 		t.Fatalf("expected EOF to not be ignored")
@@ -41,6 +85,86 @@ func TestShouldIgnoreAndNormalizeReadError(t *testing.T) {
 	boom := errors.New("boom")
 	if err := normalizeReadError(boom); !errors.Is(err, boom) {
 		t.Fatalf("normalizeReadError changed error: %v", err)
+	}
+}
+
+func TestRunDisconnectsOnPartialHeaderTimeoutBeforeFakeFrame(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	p.service.cfg.PeerRuntimeConfig.ReadDeadline = time.Millisecond
+
+	staleHeaderPrefix := mustPeerRuntimeFrameBytes(t, p, message{Command: messagePing})[:8]
+	fakeValidFrame := mustPeerRuntimeFrameBytes(t, p, message{Command: messagePing})
+	p.conn = &scriptedConn{reads: []scriptedRead{
+		{data: staleHeaderPrefix},
+		{err: timeoutErr{}},
+		{data: fakeValidFrame},
+	}}
+
+	err := p.run(context.Background())
+	if err == nil {
+		t.Fatalf("partial header timeout was ignored and allowed a later fake frame parse")
+	}
+	var partial partialFrameTimeoutError
+	if !errors.As(err, &partial) {
+		t.Fatalf("err=%v, want partialFrameTimeoutError", err)
+	}
+	if partial.part != "header" || partial.read != len(staleHeaderPrefix) || partial.want != wireHeaderSize {
+		t.Fatalf("partial timeout=%+v, want header %d/%d", partial, len(staleHeaderPrefix), wireHeaderSize)
+	}
+}
+
+func TestRunDisconnectsOnPayloadTimeoutBeforeFakeFrame(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		prefixBytes int
+	}{
+		{name: "timeout before first payload byte", prefixBytes: 0},
+		{name: "timeout after one payload byte", prefixBytes: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p := newPeerRuntimeTestPeer(t)
+			p.service.cfg.PeerRuntimeConfig.ReadDeadline = time.Millisecond
+
+			payload := []byte{0xaa, 0xbb}
+			firstFrame := mustPeerRuntimeFrameBytes(t, p, message{Command: messageTx, Payload: payload})
+			fakeValidFrame := mustPeerRuntimeFrameBytes(t, p, message{Command: messagePing})
+			reads := []scriptedRead{{data: firstFrame[:wireHeaderSize]}}
+			if tc.prefixBytes > 0 {
+				reads = append(reads, scriptedRead{data: payload[:tc.prefixBytes]})
+			}
+			reads = append(reads,
+				scriptedRead{err: timeoutErr{}},
+				scriptedRead{data: fakeValidFrame},
+			)
+			p.conn = &scriptedConn{reads: reads}
+
+			err := p.run(context.Background())
+			if err == nil {
+				t.Fatalf("partial payload timeout was ignored and allowed a later fake frame parse")
+			}
+			var partial partialFrameTimeoutError
+			if !errors.As(err, &partial) {
+				t.Fatalf("err=%v, want partialFrameTimeoutError", err)
+			}
+			wantRead := wireHeaderSize + tc.prefixBytes
+			if partial.part != "payload" || partial.read != wantRead || partial.want != wireHeaderSize+len(payload) {
+				t.Fatalf("partial timeout=%+v, want payload %d/%d", partial, wantRead, wireHeaderSize+len(payload))
+			}
+		})
+	}
+}
+
+func TestRunKeepsIdleTimeoutAndCompleteFrameValid(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	p.service.cfg.PeerRuntimeConfig.ReadDeadline = time.Millisecond
+	p.conn = &scriptedConn{reads: []scriptedRead{
+		{err: timeoutErr{}},
+		{data: mustPeerRuntimeFrameBytes(t, p, message{Command: messagePing})},
+		{err: io.EOF},
+	}}
+
+	if err := p.run(context.Background()); err != nil {
+		t.Fatalf("idle timeout followed by a complete valid frame should remain valid, got %v", err)
 	}
 }
 
@@ -325,4 +449,18 @@ func mustMarshalPeerRuntimeTx(t *testing.T, tx *consensus.Tx) []byte {
 		t.Fatalf("MarshalTx: %v", err)
 	}
 	return b
+}
+
+func mustPeerRuntimeFrameBytes(t *testing.T, p *peer, frame message) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := writeFrame(
+		&buf,
+		networkMagic(p.service.cfg.PeerRuntimeConfig.Network),
+		frame,
+		p.service.cfg.PeerRuntimeConfig.MaxMessageSize,
+	); err != nil {
+		t.Fatalf("writeFrame(%q): %v", frame.Command, err)
+	}
+	return buf.Bytes()
 }

--- a/clients/go/node/p2p/wire.go
+++ b/clients/go/node/p2p/wire.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"math"
 	"net"
+	"os"
 	"strconv"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
@@ -57,6 +58,31 @@ type frameHeader struct {
 	Command  string
 	Size     uint32
 	Checksum [4]byte
+}
+
+type partialFrameTimeoutError struct {
+	part string
+	read int
+	want int
+	err  error
+}
+
+func (e partialFrameTimeoutError) Error() string {
+	return fmt.Sprintf("%s timeout after partial frame read: %d/%d bytes", e.part, e.read, e.want)
+}
+
+func (e partialFrameTimeoutError) Unwrap() error {
+	return e.err
+}
+
+func isPartialFrameTimeout(err error) bool {
+	var partial partialFrameTimeoutError
+	return errors.As(err, &partial)
+}
+
+func isReadTimeout(err error) bool {
+	var netErr net.Error
+	return errors.Is(err, os.ErrDeadlineExceeded) || (errors.As(err, &netErr) && netErr.Timeout())
 }
 
 type InventoryVector struct {
@@ -114,7 +140,12 @@ func readPayloadWithChecksum(r io.Reader, size uint32, wantChecksum [4]byte) ([]
 			chunkLen = streamReadChunkBytes
 		}
 		chunk := make([]byte, chunkLen)
-		if _, err := io.ReadFull(r, chunk); err != nil {
+		n, err := io.ReadFull(r, chunk)
+		if err != nil {
+			read := wireHeaderSize + len(payload) + n
+			if isReadTimeout(err) {
+				return nil, partialFrameTimeoutError{part: "payload", read: read, want: wireHeaderSize + int(size), err: err}
+			}
 			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
 				return nil, io.ErrUnexpectedEOF
 			}
@@ -138,7 +169,11 @@ func readPayloadWithChecksum(r io.Reader, size uint32, wantChecksum [4]byte) ([]
 func readFrameHeader(r io.Reader, expectedMagic [4]byte, maxMessageSize uint32) (frameHeader, error) {
 	var header frameHeader
 	var raw [wireHeaderSize]byte
-	if _, err := io.ReadFull(r, raw[:]); err != nil {
+	n, err := io.ReadFull(r, raw[:])
+	if err != nil {
+		if isReadTimeout(err) && n > 0 {
+			return header, partialFrameTimeoutError{part: "header", read: n, want: wireHeaderSize, err: err}
+		}
 		return header, err
 	}
 	if !bytes.Equal(raw[0:4], expectedMagic[:]) {


### PR DESCRIPTION
Closes #1286

## Scope

Architecture class: B
System boundary: `clients/go/node/p2p/wire.go`, `clients/go/node/p2p/peer_runtime.go`, and targeted tests in `clients/go/node/p2p/peer_runtime_test.go`.
Single invariant or single contract delta: after partial Go P2P frame progress, a header or payload read timeout returns a non-ignored disconnect error so the peer lifecycle closes the connection instead of continuing to parse a potentially desynchronized stream.
Non-goals: no Rust changes, no sync/miner/genesis changes, no compact relay or DA relay work, no generic P2P redesign, no devnet harness expansion, no public wire-format change.
Class-change stop rule: if this requires a new parser/state machine, public wire contract change, Rust parity implementation, mixed-client harness, relay redesign, or broader peer lifecycle redesign, stop and split.
What this PR is NOT allowed to redesign: P2P framing format, command caps, checksum/magic validation, handshake protocol, peer manager, reconnect policy, ban scoring, sync/miner/genesis behavior, or Rust behavior.

## Behavior

- Adds an internal `partialFrameTimeoutError` for timeout-after-progress during frame header or payload reads.
- Keeps zero-byte idle read timeout retryable in `peer.run`.
- Makes `peer.run` return on partial-frame timeout, allowing existing `handleConn` cleanup to close the peer connection.
- Covers stale partial header/payload followed by a fake valid frame through `peer.run` tests.

## Validation

- `go test ./node/p2p -run 'Test(ShouldIgnoreAndNormalizeReadError|RunDisconnectsOnPartialHeaderTimeoutBeforeFakeFrame|RunDisconnectsOnPayloadTimeoutBeforeFakeFrame|RunKeepsIdleTimeoutAndCompleteFrameValid)$' -count=1` PASS
- `go test ./node/p2p -count=1` PASS
- `gofmt` / `git diff --check` PASS
- `tooling-check.sh --new-only --mode go-deep --repo <repo>` PASS
- `rubin-quality-gate` PASS
- `rubin-common-preflight` PASS; coverage variation `+0.02%`, diff coverage `88.46%`
- Hostile reviewer RESP `20260425T171734Z-03fb49f-postdiff`: PASS for head `03fb49f211862a90cb57c40cd79855fe7099c459`

## Notes

A separate raw `TOOLING_GOSEC_FULL=1` attempt hit pre-existing findings outside the touched files. The sanctioned new-only Go gate and common preflight passed for this diff.


<!-- rubin-agent-meta actor=gpt5 action=pr-create via=cl branch=codex/q-go-p2p-timeout-disconnect-semantics-01 wt=rubin-protocol utc=2026-04-25T17:30:16Z -->
