### PR TITLE
fix(go-p2p): route tx relay into canonical mempool

### DIFF
--- a/clients/go/cmd/rubin-node/main.go
+++ b/clients/go/cmd/rubin-node/main.go
@@ -32,6 +32,8 @@ var newSyncEngineFn = node.NewSyncEngine
 
 var newMempoolFn = node.NewMempoolWithConfig
 
+var newP2PServiceFn = p2p.NewService
+
 func applySuiteContextToSyncConfig(cfg *node.SyncConfig, rotation consensus.RotationProvider, registry *consensus.SuiteRegistry) {
 	if cfg == nil {
 		return
@@ -459,7 +461,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
-	p2pService, err := p2p.NewService(p2p.ServiceConfig{
+	p2pService, err := newP2PServiceFn(p2p.ServiceConfig{
 		BindAddr:          cfg.BindAddr,
 		BootstrapPeers:    cfg.Peers,
 		UserAgent:         "rubin-node/go",
@@ -469,6 +471,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 		SyncConfig:        syncCfg,
 		SyncEngine:        syncEngine,
 		BlockStore:        blockStore,
+		TxPool:            p2p.NewCanonicalMempoolTxPool(mempool),
 		TxMetadataFunc:    mempool.RelayMetadata,
 	})
 	if err != nil {

--- a/clients/go/cmd/rubin-node/main.go
+++ b/clients/go/cmd/rubin-node/main.go
@@ -472,7 +472,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 		SyncEngine:        syncEngine,
 		BlockStore:        blockStore,
 		TxPool:            p2p.NewCanonicalMempoolTxPool(mempool),
-		TxMetadataFunc:    mempool.RelayMetadata,
+		TxMetadataFunc:    p2p.CanonicalMempoolRelayMetadata,
 	})
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "p2p init failed: %v\n", err)

--- a/clients/go/cmd/rubin-node/main_test.go
+++ b/clients/go/cmd/rubin-node/main_test.go
@@ -1510,7 +1510,14 @@ func TestRunWiresP2PToCanonicalMempool(t *testing.T) {
 		t.Fatalf("p2p TxPool type=%T, want *p2p.CanonicalMempoolTxPool", captured.TxPool)
 	}
 	if captured.TxMetadataFunc == nil {
-		t.Fatal("expected p2p TxMetadataFunc to use canonical mempool metadata")
+		t.Fatal("expected p2p TxMetadataFunc")
+	}
+	meta, err := captured.TxMetadataFunc([]byte{0xFF})
+	if err != nil {
+		t.Fatalf("canonical p2p TxMetadataFunc should be lightweight, got %v", err)
+	}
+	if meta.Size != 1 {
+		t.Fatalf("canonical p2p metadata size=%d, want 1", meta.Size)
 	}
 }
 

--- a/clients/go/cmd/rubin-node/main_test.go
+++ b/clients/go/cmd/rubin-node/main_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/node"
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/node/p2p"
 )
 
 type failWriter struct{}
@@ -1484,6 +1485,32 @@ func TestRunPassesGenesisCoreExtProfilesToMempool(t *testing.T) {
 	}
 	if !ok || !profile.Active {
 		t.Fatalf("expected active core_ext profile at activation height")
+	}
+}
+
+func TestRunWiresP2PToCanonicalMempool(t *testing.T) {
+	prev := newP2PServiceFn
+	var captured p2p.ServiceConfig
+	newP2PServiceFn = func(cfg p2p.ServiceConfig) (*p2p.Service, error) {
+		captured = cfg
+		return nil, errors.New("capture p2p config")
+	}
+	t.Cleanup(func() { newP2PServiceFn = prev })
+
+	dir := t.TempDir()
+	var errOut bytes.Buffer
+	code := run([]string{"--datadir", dir, "--bind", "127.0.0.1:0", "--rpc-bind", ""}, io.Discard, &errOut)
+	if code != 2 {
+		t.Fatalf("expected exit code 2 from captured p2p init, got %d (stderr=%q)", code, errOut.String())
+	}
+	if !strings.Contains(errOut.String(), "capture p2p config") {
+		t.Fatalf("stderr=%q, want capture error", errOut.String())
+	}
+	if _, ok := captured.TxPool.(*p2p.CanonicalMempoolTxPool); !ok {
+		t.Fatalf("p2p TxPool type=%T, want *p2p.CanonicalMempoolTxPool", captured.TxPool)
+	}
+	if captured.TxMetadataFunc == nil {
+		t.Fatal("expected p2p TxMetadataFunc to use canonical mempool metadata")
 	}
 }
 

--- a/clients/go/node/p2p/handlers_tx_test.go
+++ b/clients/go/node/p2p/handlers_tx_test.go
@@ -51,6 +51,74 @@ func putRelayTx(pool *MemoryTxPool, txid [32]byte, raw []byte) bool {
 	return pool.Put(txid, raw, uint64(len(raw)), len(raw))
 }
 
+type rejectingTxPool struct{}
+
+func (rejectingTxPool) Get([32]byte) ([]byte, bool) { return nil, false }
+
+func (rejectingTxPool) Has([32]byte) bool { return false }
+
+func (rejectingTxPool) Put([32]byte, []byte, uint64, int) bool { return false }
+
+func wireCanonicalMempoolForP2PTest(t *testing.T, h *testHarness) *node.Mempool {
+	t.Helper()
+	if h == nil || h.service == nil {
+		t.Fatal("nil p2p test harness")
+	}
+	mempool, err := node.NewMempool(h.chainState, h.blockStore, node.DevnetGenesisChainID())
+	if err != nil {
+		t.Fatalf("NewMempool: %v", err)
+	}
+	h.syncEngine.SetMempool(mempool)
+	h.service.cfg.TxPool = NewCanonicalMempoolTxPool(mempool)
+	h.service.cfg.TxMetadataFunc = mempool.RelayMetadata
+	return mempool
+}
+
+func signedCanonicalP2PTxForHarness(t *testing.T, h *testHarness, nonce uint64) ([]byte, [32]byte, map[consensus.Outpoint]consensus.UtxoEntry) {
+	t.Helper()
+	txBytes, txid, utxos := signedCanonicalP2PTxWithoutSeeding(t, nonce)
+	seedHarnessUtxos(h, utxos)
+	return txBytes, txid, utxos
+}
+
+func signedCanonicalP2PTxWithoutSeeding(t *testing.T, nonce uint64) ([]byte, [32]byte, map[consensus.Outpoint]consensus.UtxoEntry) {
+	t.Helper()
+	fromKey := mustP2PMLDSA87Keypair(t)
+	toKey := mustP2PMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+	utxos, outpoints := testP2PUtxoSet(fromAddress, []uint64{100})
+	for op, entry := range utxos {
+		entry.CreatedByCoinbase = false
+		entry.CreationHeight = 0
+		utxos[op] = entry
+	}
+	txBytes := mustBuildSignedP2PTx(t, utxos, []consensus.Outpoint{outpoints[0]}, 90, 1, nonce, fromKey, fromAddress, toAddress)
+	txid, err := canonicalTxID(txBytes)
+	if err != nil {
+		t.Fatalf("canonicalTxID: %v", err)
+	}
+	return txBytes, txid, utxos
+}
+
+func seedHarnessUtxos(h *testHarness, utxos map[consensus.Outpoint]consensus.UtxoEntry) {
+	for op, entry := range utxos {
+		h.chainState.Utxos[op] = entry
+	}
+}
+
+func parsedBlockHasTxID(block *consensus.ParsedBlock, txid [32]byte) bool {
+	if block == nil {
+		return false
+	}
+	for _, got := range block.Txids {
+		if got == txid {
+			return true
+		}
+	}
+	return false
+}
+
 func TestHandleTxMalformed(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -211,6 +279,72 @@ func TestAnnounceTx(t *testing.T) {
 	})
 }
 
+func TestAnnounceTxRelaysIntoCanonicalMempoolAndMiner(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	source := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	sourceMempool := wireCanonicalMempoolForP2PTest(t, source)
+	txBytes, txid, utxos := signedCanonicalP2PTxForHarness(t, source, 9001)
+	if err := sourceMempool.AddTx(txBytes); err != nil {
+		t.Fatalf("source canonical AddTx: %v", err)
+	}
+	if err := source.service.Start(ctx); err != nil {
+		t.Fatalf("source.Start: %v", err)
+	}
+	defer source.service.Close()
+
+	sink := newTestHarness(t, 1, "127.0.0.1:0", []string{source.service.Addr()})
+	sinkMempool := wireCanonicalMempoolForP2PTest(t, sink)
+	seedHarnessUtxos(sink, utxos)
+	if err := sink.service.Start(ctx); err != nil {
+		t.Fatalf("sink.Start: %v", err)
+	}
+	defer sink.service.Close()
+
+	waitFor(t, 5*time.Second, func() bool {
+		return source.peerManager.Count() == 1 && sink.peerManager.Count() == 1
+	})
+
+	if err := source.service.AnnounceTx(txBytes); err != nil {
+		t.Fatalf("AnnounceTx: %v", err)
+	}
+	if !sourceMempool.Contains(txid) {
+		t.Fatal("source canonical mempool should contain announced tx")
+	}
+	waitFor(t, 5*time.Second, func() bool {
+		return sinkMempool.Contains(txid)
+	})
+
+	minerCfg := node.DefaultMinerConfig()
+	minerCfg.TimestampSource = func() uint64 {
+		sink.timestamp++
+		return sink.timestamp
+	}
+	miner, err := node.NewMiner(sink.chainState, sink.blockStore, sink.syncEngine, minerCfg)
+	if err != nil {
+		t.Fatalf("NewMiner: %v", err)
+	}
+	mined, err := miner.MineOne(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("MineOne: %v", err)
+	}
+	if mined.TxCount != 2 {
+		t.Fatalf("mined tx_count=%d, want 2", mined.TxCount)
+	}
+	blockBytes, err := sink.blockStore.GetBlockByHash(mined.Hash)
+	if err != nil {
+		t.Fatalf("GetBlockByHash: %v", err)
+	}
+	parsed, err := consensus.ParseBlockBytes(blockBytes)
+	if err != nil {
+		t.Fatalf("ParseBlockBytes: %v", err)
+	}
+	if !parsedBlockHasTxID(parsed, txid) {
+		t.Fatalf("mined block missing relayed tx %x", txid)
+	}
+}
+
 func TestAnnounceTxNonCanonical(t *testing.T) {
 	txBytes := minimalValidTxBytes(t)
 	nonCanonical := append(txBytes, 0x00)
@@ -328,6 +462,87 @@ func TestHandleTxMetadataErrorIsPeerNeutralAndMarksSeen(t *testing.T) {
 	}
 }
 
+func TestHandleTxCanonicalMempoolRejectsMalformedAndMetadataWithoutMutation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	h := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	canonicalMempool := wireCanonicalMempoolForP2PTest(t, h)
+	if err := h.service.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer h.service.Close()
+
+	p := &peer{
+		service: h.service,
+		state:   node.PeerState{HandshakeComplete: true},
+	}
+
+	if err := p.handleTx([]byte{0xFF, 0xFE}); err != nil {
+		t.Fatalf("malformed handleTx should not return before ban threshold: %v", err)
+	}
+	if got := canonicalMempool.Len(); got != 0 {
+		t.Fatalf("canonical mempool len after malformed=%d, want 0", got)
+	}
+
+	txBytes, txid, _ := signedCanonicalP2PTxWithoutSeeding(t, 9002)
+	if err := p.handleTx(txBytes); err != nil {
+		t.Fatalf("metadata reject handleTx should be peer-neutral, got %v", err)
+	}
+	if got := canonicalMempool.Len(); got != 0 {
+		t.Fatalf("canonical mempool len after missing-utxo metadata reject=%d, want 0", got)
+	}
+	if !h.service.txSeen.Has(txid) {
+		t.Fatal("metadata-rejected tx should be marked seen to suppress getdata churn")
+	}
+	if canonicalMempool.Contains(txid) {
+		t.Fatal("metadata-rejected tx must not enter canonical mempool")
+	}
+}
+
+func TestHandleTxCanonicalMempoolDuplicateIsIdempotent(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	h := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	canonicalMempool := wireCanonicalMempoolForP2PTest(t, h)
+	txBytes, txid, _ := signedCanonicalP2PTxForHarness(t, h, 9003)
+	if err := h.service.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer h.service.Close()
+
+	p := &peer{
+		service: h.service,
+		state:   node.PeerState{HandshakeComplete: true},
+	}
+
+	wrongTxid := txid
+	wrongTxid[0] ^= 0x80
+	if h.service.cfg.TxPool.Put(wrongTxid, txBytes, 0, 0) {
+		t.Fatal("canonical adapter should reject txid/raw mismatch")
+	}
+	if got := canonicalMempool.Len(); got != 0 {
+		t.Fatalf("canonical mempool len after txid/raw mismatch=%d, want 0", got)
+	}
+
+	if err := p.handleTx(txBytes); err != nil {
+		t.Fatalf("handleTx first: %v", err)
+	}
+	if got := canonicalMempool.Len(); got != 1 {
+		t.Fatalf("canonical mempool len after first handleTx=%d, want 1", got)
+	}
+	if !canonicalMempool.Contains(txid) {
+		t.Fatal("canonical mempool should contain first relayed tx")
+	}
+	if err := p.handleTx(txBytes); err != nil {
+		t.Fatalf("handleTx duplicate: %v", err)
+	}
+	if got := canonicalMempool.Len(); got != 1 {
+		t.Fatalf("canonical mempool len after duplicate handleTx=%d, want 1", got)
+	}
+}
+
 func TestHandleTxDuplicateSkipsMetadataValidation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -387,6 +602,22 @@ func TestAnnounceTxMetadataError(t *testing.T) {
 	}
 	if h.service.txSeen.Has(txid) {
 		t.Fatal("failed AnnounceTx should not mark tx as seen")
+	}
+}
+
+func TestAnnounceTxAdmissionRejectDoesNotMarkSeen(t *testing.T) {
+	h := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	h.service.cfg.TxPool = rejectingTxPool{}
+	txBytes := minimalValidTxBytes(t)
+	txid, err := canonicalTxID(txBytes)
+	if err != nil {
+		t.Fatalf("canonicalTxID: %v", err)
+	}
+	if err := h.service.AnnounceTx(txBytes); err == nil {
+		t.Fatal("AnnounceTx should reject when tx was not admitted to relay pool")
+	}
+	if h.service.txSeen.Has(txid) {
+		t.Fatal("admission-rejected AnnounceTx must not mark tx as seen")
 	}
 }
 

--- a/clients/go/node/p2p/handlers_tx_test.go
+++ b/clients/go/node/p2p/handlers_tx_test.go
@@ -70,7 +70,7 @@ func wireCanonicalMempoolForP2PTest(t *testing.T, h *testHarness) *node.Mempool 
 	}
 	h.syncEngine.SetMempool(mempool)
 	h.service.cfg.TxPool = NewCanonicalMempoolTxPool(mempool)
-	h.service.cfg.TxMetadataFunc = mempool.RelayMetadata
+	h.service.cfg.TxMetadataFunc = CanonicalMempoolRelayMetadata
 	return mempool
 }
 
@@ -462,7 +462,7 @@ func TestHandleTxMetadataErrorIsPeerNeutralAndMarksSeen(t *testing.T) {
 	}
 }
 
-func TestHandleTxCanonicalMempoolRejectsMalformedAndMetadataWithoutMutation(t *testing.T) {
+func TestHandleTxCanonicalMempoolRejectsMalformedAndAdmissionWithoutMutation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -487,16 +487,16 @@ func TestHandleTxCanonicalMempoolRejectsMalformedAndMetadataWithoutMutation(t *t
 
 	txBytes, txid, _ := signedCanonicalP2PTxWithoutSeeding(t, 9002)
 	if err := p.handleTx(txBytes); err != nil {
-		t.Fatalf("metadata reject handleTx should be peer-neutral, got %v", err)
+		t.Fatalf("admission reject handleTx should be peer-neutral, got %v", err)
 	}
 	if got := canonicalMempool.Len(); got != 0 {
-		t.Fatalf("canonical mempool len after missing-utxo metadata reject=%d, want 0", got)
+		t.Fatalf("canonical mempool len after missing-utxo admission reject=%d, want 0", got)
 	}
 	if !h.service.txSeen.Has(txid) {
-		t.Fatal("metadata-rejected tx should be marked seen to suppress getdata churn")
+		t.Fatal("admission-rejected tx should be marked seen to suppress getdata churn")
 	}
 	if canonicalMempool.Contains(txid) {
-		t.Fatal("metadata-rejected tx must not enter canonical mempool")
+		t.Fatal("admission-rejected tx must not enter canonical mempool")
 	}
 }
 
@@ -540,6 +540,38 @@ func TestHandleTxCanonicalMempoolDuplicateIsIdempotent(t *testing.T) {
 	}
 	if got := canonicalMempool.Len(); got != 1 {
 		t.Fatalf("canonical mempool len after duplicate handleTx=%d, want 1", got)
+	}
+}
+
+func TestHandleTxCanonicalMempoolSkipsValidatingMetadataProvider(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	h := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	canonicalMempool := wireCanonicalMempoolForP2PTest(t, h)
+	txBytes, txid, _ := signedCanonicalP2PTxForHarness(t, h, 9004)
+	var metadataCalls atomic.Int32
+	h.service.cfg.TxMetadataFunc = func([]byte) (node.RelayTxMetadata, error) {
+		metadataCalls.Add(1)
+		return node.RelayTxMetadata{}, errors.New("unexpected validating metadata call")
+	}
+	if err := h.service.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer h.service.Close()
+
+	p := &peer{
+		service: h.service,
+		state:   node.PeerState{HandshakeComplete: true},
+	}
+	if err := p.handleTx(txBytes); err != nil {
+		t.Fatalf("handleTx canonical mempool: %v", err)
+	}
+	if got := metadataCalls.Load(); got != 0 {
+		t.Fatalf("validating metadata calls=%d, want 0 for canonical mempool", got)
+	}
+	if !canonicalMempool.Contains(txid) {
+		t.Fatal("canonical mempool should contain relayed tx admitted through Put/AddTx")
 	}
 }
 
@@ -618,6 +650,29 @@ func TestAnnounceTxAdmissionRejectDoesNotMarkSeen(t *testing.T) {
 	}
 	if h.service.txSeen.Has(txid) {
 		t.Fatal("admission-rejected AnnounceTx must not mark tx as seen")
+	}
+}
+
+func TestAnnounceTxAlreadyAdmittedSkipsMetadataValidation(t *testing.T) {
+	h := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	canonicalMempool := wireCanonicalMempoolForP2PTest(t, h)
+	txBytes, txid, _ := signedCanonicalP2PTxForHarness(t, h, 9005)
+	if err := canonicalMempool.AddTx(txBytes); err != nil {
+		t.Fatalf("canonical AddTx: %v", err)
+	}
+	var metadataCalls atomic.Int32
+	h.service.cfg.TxMetadataFunc = func([]byte) (node.RelayTxMetadata, error) {
+		metadataCalls.Add(1)
+		return node.RelayTxMetadata{}, errors.New("unexpected validating metadata call")
+	}
+	if err := h.service.AnnounceTx(txBytes); err != nil {
+		t.Fatalf("AnnounceTx already-admitted canonical tx: %v", err)
+	}
+	if got := metadataCalls.Load(); got != 0 {
+		t.Fatalf("validating metadata calls=%d, want 0 for already-admitted tx", got)
+	}
+	if !h.service.txSeen.Has(txid) {
+		t.Fatal("announced tx should be marked seen after already-admitted broadcast")
 	}
 }
 

--- a/clients/go/node/p2p/mempool.go
+++ b/clients/go/node/p2p/mempool.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"math/bits"
 	"sync"
+
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/node"
 )
 
 const defaultMaxTxPoolSize = 1000
@@ -12,6 +14,43 @@ type TxPool interface {
 	Get(txid [32]byte) ([]byte, bool)
 	Has(txid [32]byte) bool
 	Put(txid [32]byte, raw []byte, fee uint64, size int) bool
+}
+
+// CanonicalMempoolTxPool adapts the node mempool to the P2P relay TxPool
+// interface without introducing a second relay-owned transaction store.
+type CanonicalMempoolTxPool struct {
+	mempool *node.Mempool
+}
+
+// NewCanonicalMempoolTxPool returns a TxPool backed by the canonical node
+// mempool used by RPC submission and miner candidate selection.
+func NewCanonicalMempoolTxPool(mempool *node.Mempool) *CanonicalMempoolTxPool {
+	return &CanonicalMempoolTxPool{mempool: mempool}
+}
+
+func (p *CanonicalMempoolTxPool) Get(txid [32]byte) ([]byte, bool) {
+	if p == nil || p.mempool == nil {
+		return nil, false
+	}
+	return p.mempool.TxByID(txid)
+}
+
+func (p *CanonicalMempoolTxPool) Has(txid [32]byte) bool {
+	if p == nil || p.mempool == nil {
+		return false
+	}
+	return p.mempool.Contains(txid)
+}
+
+func (p *CanonicalMempoolTxPool) Put(txid [32]byte, raw []byte, _ uint64, _ int) bool {
+	if p == nil || p.mempool == nil {
+		return false
+	}
+	rawTxid, err := canonicalTxID(raw)
+	if err != nil || rawTxid != txid {
+		return false
+	}
+	return p.mempool.AddTx(raw) == nil
 }
 
 type MemoryTxPool struct {

--- a/clients/go/node/p2p/mempool_test.go
+++ b/clients/go/node/p2p/mempool_test.go
@@ -78,6 +78,31 @@ func TestMemoryTxPool_NilReceiver(t *testing.T) {
 	}
 }
 
+func TestCanonicalMempoolTxPoolNilSafe(t *testing.T) {
+	var nilPool *CanonicalMempoolTxPool
+	var txid [32]byte
+	if raw, ok := nilPool.Get(txid); ok || raw != nil {
+		t.Fatalf("nil adapter Get=(%x,%v), want nil,false", raw, ok)
+	}
+	if nilPool.Has(txid) {
+		t.Fatal("nil adapter Has should return false")
+	}
+	if nilPool.Put(txid, []byte{0x01}, 1, 1) {
+		t.Fatal("nil adapter Put should return false")
+	}
+
+	emptyAdapter := NewCanonicalMempoolTxPool(nil)
+	if raw, ok := emptyAdapter.Get(txid); ok || raw != nil {
+		t.Fatalf("nil-backed adapter Get=(%x,%v), want nil,false", raw, ok)
+	}
+	if emptyAdapter.Has(txid) {
+		t.Fatal("nil-backed adapter Has should return false")
+	}
+	if emptyAdapter.Put(txid, []byte{0x01}, 1, 1) {
+		t.Fatal("nil-backed adapter Put should return false")
+	}
+}
+
 func TestMemoryTxPool_ConcurrentSafe(t *testing.T) {
 	pool := NewMemoryTxPool()
 	var wg sync.WaitGroup

--- a/clients/go/node/p2p/service.go
+++ b/clients/go/node/p2p/service.go
@@ -182,12 +182,12 @@ func (s *Service) AnnounceTx(txBytes []byte) error {
 	if consumed != len(txBytes) {
 		return errors.New("non-canonical tx bytes")
 	}
-	meta, err := s.relayTxMetadata(txBytes)
-	if err != nil {
-		return err
-	}
 	admitted := s.cfg.TxPool.Has(txid)
 	if !admitted {
+		meta, err := s.relayTxMetadata(txBytes)
+		if err != nil {
+			return err
+		}
 		admitted = s.cfg.TxPool.Put(txid, txBytes, meta.Fee, meta.Size)
 	}
 	if !admitted && !s.cfg.TxPool.Has(txid) {

--- a/clients/go/node/p2p/service.go
+++ b/clients/go/node/p2p/service.go
@@ -186,7 +186,13 @@ func (s *Service) AnnounceTx(txBytes []byte) error {
 	if err != nil {
 		return err
 	}
-	s.cfg.TxPool.Put(txid, txBytes, meta.Fee, meta.Size)
+	admitted := s.cfg.TxPool.Has(txid)
+	if !admitted {
+		admitted = s.cfg.TxPool.Put(txid, txBytes, meta.Fee, meta.Size)
+	}
+	if !admitted && !s.cfg.TxPool.Has(txid) {
+		return errors.New("tx not admitted to relay pool")
+	}
 	if !s.txSeen.Add(txid) {
 		return nil
 	}

--- a/clients/go/node/p2p/tx_metadata.go
+++ b/clients/go/node/p2p/tx_metadata.go
@@ -6,9 +6,19 @@ import (
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/node"
 )
 
+// CanonicalMempoolRelayMetadata is the lightweight metadata provider for
+// CanonicalMempoolTxPool. Callers parse txBytes before metadata lookup; full
+// policy/admission validation happens once in node.Mempool.AddTx via TxPool.Put.
+func CanonicalMempoolRelayMetadata(txBytes []byte) (node.RelayTxMetadata, error) {
+	return node.RelayTxMetadata{Size: len(txBytes)}, nil
+}
+
 func (s *Service) relayTxMetadata(txBytes []byte) (node.RelayTxMetadata, error) {
 	if s == nil {
 		return node.RelayTxMetadata{}, errors.New("nil service")
+	}
+	if _, ok := s.cfg.TxPool.(*CanonicalMempoolTxPool); ok {
+		return CanonicalMempoolRelayMetadata(txBytes)
 	}
 	if s.cfg.TxMetadataFunc == nil {
 		return node.RelayTxMetadata{}, errors.New("nil tx metadata func")


### PR DESCRIPTION
Closes #1284.

## Scope

Architecture class: B - bounded extension inside existing Go node/P2P tx relay wiring.

System boundary: Go `rubin-node` runtime construction, Go P2P tx relay/admission path, and canonical Go `node.Mempool` used by RPC/miner.

Single invariant: a production Go P2P tx relay that admits a tx must route that tx into the same canonical `node.Mempool` instance used by RPC and miner; rejects must not mutate that mempool.

## In Scope

- Wire production Go P2P tx relay to the canonical node mempool.
- Keep valid relayed txs visible to the same mempool used by RPC/miner.
- Reject malformed, duplicate, and admission-rejected txs without bad mempool side effects.
- Cover the actual Go P2P handler/admission path with targeted tests.

## Non-Goals

- No Rust changes.
- No compact relay or DA relay work.
- No eviction policy redesign.
- No new metrics unless required by existing interfaces.
- No devnet harness expansion.
- No sync, miner, or genesis redesign.

## Class-Change Stop Rule

If closing a finding requires a new wire/API contract, lifecycle controller, devnet proof architecture, or cross-language redesign, stop and split rather than widening this PR.
