### PR TITLE
node: enforce genesis identity preflight before filesystem mutation (#1283)

### DIFF
--- a/clients/go/cmd/rubin-node/main.go
+++ b/clients/go/cmd/rubin-node/main.go
@@ -306,6 +306,24 @@ func run(args []string, stdout, stderr io.Writer) int {
 		_, _ = fmt.Fprintf(stderr, "invalid genesis file: %v\n", err)
 		return 2
 	}
+	// Genesis-identity guards run BEFORE the first filesystem mutation
+	// (os.MkdirAll(cfg.DataDir) below). A wrong devnet chain_id /
+	// genesis_hash, or a misconfigured mainnet runtime, must reject on a
+	// clean filesystem so operators do not end up with partial datadir /
+	// chainstate / blockstore artifacts that the next startup would have
+	// to detect and recover. Both validators are pure functions over the
+	// already-parsed config; failure paths only print to stderr and
+	// return exit code 2.
+	if cfg.Network == "devnet" {
+		if err := node.ValidateDevnetGenesisIdentity(genesisCfg.ChainID, genesisCfg.GenesisHash); err != nil {
+			_, _ = fmt.Fprintf(stderr, "devnet genesis identity guard failed: %v\n", err)
+			return 2
+		}
+	}
+	if err := node.ValidateMainnetGenesisGuard(node.SyncConfig{Network: cfg.Network}); err != nil {
+		_, _ = fmt.Fprintf(stderr, "mainnet genesis guard failed: %v\n", err)
+		return 2
+	}
 	if err := os.MkdirAll(cfg.DataDir, 0o750); err != nil {
 		_, _ = fmt.Fprintf(stderr, "datadir create failed: %v\n", err)
 		return 2
@@ -340,21 +358,12 @@ func run(args []string, stdout, stderr io.Writer) int {
 	applySuiteContextToSyncConfig(&syncCfg, rotation, registry)
 	syncCfg.ParallelValidationMode = *pvMode
 	syncCfg.PVShadowMaxSamples = *pvShadowMax
-	// Mainnet target / genesis guard runs BEFORE any reconcile-driven
-	// state mutation (truncate_canonical / chainstate replay). MkdirAll,
-	// LoadChainState, and OpenBlockStore above are read/open-only
-	// operations that do not rewrite canonical or chainstate contents;
-	// the authoritative boundary we care about is reconcile + save +
-	// sync engine start, and the guard must run before that boundary.
-	// Mirror of Rust main.rs validate_mainnet_genesis_guard pre-reconcile
-	// call. NewSyncEngine also runs the same guard internally (see
-	// sync.go validateMainnetGenesisGuard) so tests / embedded callers
-	// that construct an engine directly still get the check.
-	// Devnet / test networks no-op.
-	if err := node.ValidateMainnetGenesisGuard(syncCfg); err != nil {
-		_, _ = fmt.Fprintf(stderr, "mainnet genesis guard failed: %v\n", err)
-		return 2
-	}
+	// Genesis-identity guards (devnet ValidateDevnetGenesisIdentity and
+	// mainnet ValidateMainnetGenesisGuard) ran above before MkdirAll, so
+	// any malformed pack or misconfigured mainnet runtime has already
+	// rejected on a clean filesystem. NewSyncEngine still re-runs the
+	// mainnet guard internally for embedded / test callers that
+	// construct an engine directly with a custom SyncConfig.
 	// Reconcile + save BEFORE constructing the sync engine. Rust mirror
 	// in clients/rust/crates/rubin-node/src/main.rs: the contract is
 	// that chainstate is persisted to disk BEFORE any sync / P2P / RPC /

--- a/clients/go/cmd/rubin-node/main_test.go
+++ b/clients/go/cmd/rubin-node/main_test.go
@@ -805,6 +805,154 @@ func TestRunRejectsInvalidGenesisFileBeforeDataDirCreate(t *testing.T) {
 	}
 }
 
+// writeGenesisPackForTest serializes a minimal devnet genesis pack to a
+// temp file. Both chain_id and genesis_hash are mandatory to exercise
+// the boot-time identity guards: parseGenesisConfigFull rejects missing
+// hash via parseGenesisHash, so a wrong-hash test still needs a valid
+// 32-byte hex value (just one that disagrees with canonical).
+func writeGenesisPackForTest(t *testing.T, dir string, chainID, genesisHash [32]byte) string {
+	t.Helper()
+	pack := map[string]string{
+		"chain_id_hex":     hex.EncodeToString(chainID[:]),
+		"genesis_hash_hex": hex.EncodeToString(genesisHash[:]),
+	}
+	raw, err := json.Marshal(pack)
+	if err != nil {
+		t.Fatalf("json.Marshal(genesis pack): %v", err)
+	}
+	path := filepath.Join(dir, "genesis-pack.json")
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatalf("WriteFile(%s): %v", path, err)
+	}
+	return path
+}
+
+// TestRunRejectsDevnetWrongChainIDBeforeDataDirCreate proves the
+// boot-time devnet identity guard fires BEFORE os.MkdirAll(cfg.DataDir).
+// The blocker-file at --datadir would force os.MkdirAll to fail with
+// "datadir create failed" if the guard skipped or ran after MkdirAll;
+// the asymmetric assertion (stderr contains the guard error AND does
+// NOT contain "datadir create failed") is what proves the ordering, not
+// just rejection. Reverting the guard to its old post-MkdirAll position
+// turns this test red.
+func TestRunRejectsDevnetWrongChainIDBeforeDataDirCreate(t *testing.T) {
+	dir := t.TempDir()
+	blocker := filepath.Join(dir, "not-a-dir")
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatalf("WriteFile(blocker): %v", err)
+	}
+	wrongChainID := node.DevnetGenesisChainID()
+	wrongChainID[0] ^= 0x01
+	genesisPath := writeGenesisPackForTest(t, dir, wrongChainID, node.DevnetGenesisBlockHash())
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	code := run(
+		[]string{
+			"--network", "devnet",
+			"--datadir", blocker,
+			"--genesis-file", genesisPath,
+		},
+		&out,
+		&errOut,
+	)
+	if code != 2 {
+		t.Fatalf("expected exit code 2, got %d (stderr=%q)", code, errOut.String())
+	}
+	if !strings.Contains(errOut.String(), "devnet genesis identity guard failed") {
+		t.Fatalf("stderr missing guard prefix: %q", errOut.String())
+	}
+	if !strings.Contains(errOut.String(), "genesis chain_id mismatch") {
+		t.Fatalf("stderr missing chain_id mismatch class: %q", errOut.String())
+	}
+	if strings.Contains(errOut.String(), "datadir create failed") {
+		t.Fatalf("devnet identity guard must reject before datadir create: %q", errOut.String())
+	}
+}
+
+// TestRunRejectsDevnetWrongHashBeforeDataDirCreate is the genesis_hash
+// counterpart of TestRunRejectsDevnetWrongChainIDBeforeDataDirCreate.
+// chain_id stays canonical so the helper passes the chain_id arm and
+// reaches the hash arm, locking in that both arms run pre-MkdirAll.
+func TestRunRejectsDevnetWrongHashBeforeDataDirCreate(t *testing.T) {
+	dir := t.TempDir()
+	blocker := filepath.Join(dir, "not-a-dir")
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatalf("WriteFile(blocker): %v", err)
+	}
+	wrongHash := node.DevnetGenesisBlockHash()
+	wrongHash[0] ^= 0x01
+	genesisPath := writeGenesisPackForTest(t, dir, node.DevnetGenesisChainID(), wrongHash)
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	code := run(
+		[]string{
+			"--network", "devnet",
+			"--datadir", blocker,
+			"--genesis-file", genesisPath,
+		},
+		&out,
+		&errOut,
+	)
+	if code != 2 {
+		t.Fatalf("expected exit code 2, got %d (stderr=%q)", code, errOut.String())
+	}
+	if !strings.Contains(errOut.String(), "devnet genesis identity guard failed") {
+		t.Fatalf("stderr missing guard prefix: %q", errOut.String())
+	}
+	if !strings.Contains(errOut.String(), "genesis_hash mismatch") {
+		t.Fatalf("stderr missing genesis_hash mismatch class: %q", errOut.String())
+	}
+	if strings.Contains(errOut.String(), "datadir create failed") {
+		t.Fatalf("devnet identity guard must reject before datadir create: %q", errOut.String())
+	}
+}
+
+// TestRunRejectsMainnetMisconfigBeforeDataDirCreate covers the third
+// boot-time guard arm: ValidateMainnetGenesisGuard rejects a mainnet
+// runtime that did not wire ExpectedTarget. The CLI does not expose an
+// expected-target flag yet, so any --network mainnet invocation
+// currently fails the guard with "mainnet requires explicit
+// expected_target". The asymmetric assertion proves the guard runs
+// pre-MkdirAll: if the guard moved back below MkdirAll, the blocker
+// file would force a "datadir create failed" stderr line.
+func TestRunRejectsMainnetMisconfigBeforeDataDirCreate(t *testing.T) {
+	dir := t.TempDir()
+	blocker := filepath.Join(dir, "not-a-dir")
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatalf("WriteFile(blocker): %v", err)
+	}
+	// Valid genesis-pack shape — chain_id / genesis_hash are devnet
+	// canonical, which is fine on mainnet because the devnet identity
+	// guard is gated on cfg.Network == "devnet" and skips here.
+	genesisPath := writeGenesisPackForTest(t, dir, node.DevnetGenesisChainID(), node.DevnetGenesisBlockHash())
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	code := run(
+		[]string{
+			"--network", "mainnet",
+			"--datadir", blocker,
+			"--genesis-file", genesisPath,
+		},
+		&out,
+		&errOut,
+	)
+	if code != 2 {
+		t.Fatalf("expected exit code 2, got %d (stderr=%q)", code, errOut.String())
+	}
+	if !strings.Contains(errOut.String(), "mainnet genesis guard failed") {
+		t.Fatalf("stderr missing mainnet guard prefix: %q", errOut.String())
+	}
+	if !strings.Contains(errOut.String(), "mainnet requires explicit expected_target") {
+		t.Fatalf("stderr missing expected_target class: %q", errOut.String())
+	}
+	if strings.Contains(errOut.String(), "datadir create failed") {
+		t.Fatalf("mainnet guard must reject before datadir create: %q", errOut.String())
+	}
+}
+
 func TestRunLegacyExposureScanPropagatesEncodeFailure(t *testing.T) {
 	dir := t.TempDir()
 	if err := testLegacyExposureTippedChainState().Save(node.ChainStatePath(dir)); err != nil {

--- a/clients/go/node/sync.go
+++ b/clients/go/node/sync.go
@@ -202,6 +202,39 @@ func validateMainnetGenesisGuard(cfg SyncConfig) error {
 	return nil
 }
 
+// ValidateDevnetGenesisIdentity reports whether a parsed genesis-pack
+// identity (chain_id, genesis_hash) matches the published canonical
+// devnet pack. It is intended to run at startup AFTER the genesis file
+// is parsed and BEFORE any filesystem mutation (datadir create,
+// chainstate load, blockstore open, reconcile, save, sync engine
+// construction). On mismatch returns *consensus.TxError with
+// BLOCK_ERR_LINKAGE_INVALID and the same Msg strings as the runtime
+// height-0 guards in applyCanonicalParsedBlock so log / ban-score /
+// debugging correlate boot-time and runtime rejects under the same
+// class. Callers MUST only invoke this for cfg.Network == "devnet";
+// for other networks the canonical pack identity is undefined here.
+//
+// This helper is intentionally NOT integrated into NewSyncEngine:
+// SyncConfig does not carry the parsed genesis_hash, so a guard there
+// would observe only ChainID and could not actually detect a mismatched
+// hash in an embedded caller. The boot-time call site in
+// cmd/rubin-node/main.go is the only place that has both inputs.
+func ValidateDevnetGenesisIdentity(chainID, genesisHash [32]byte) error {
+	if chainID != devnetGenesisChainID {
+		return &consensus.TxError{
+			Code: consensus.BLOCK_ERR_LINKAGE_INVALID,
+			Msg:  "genesis chain_id mismatch",
+		}
+	}
+	if genesisHash != devnetGenesisBlockHash {
+		return &consensus.TxError{
+			Code: consensus.BLOCK_ERR_LINKAGE_INVALID,
+			Msg:  "genesis_hash mismatch",
+		}
+	}
+	return nil
+}
+
 // BootstrapCanonicalGenesisIfEmpty applies the published canonical genesis
 // block to an empty chainstate when the configured network has one, so the
 // chain always starts from the published bytes rather than from a miner-

--- a/clients/go/node/sync_genesis_identity_test.go
+++ b/clients/go/node/sync_genesis_identity_test.go
@@ -400,3 +400,54 @@ func TestMinerMineOne_PropagatesBootstrapError(t *testing.T) {
 		t.Fatalf("expected %q, got %q", "sync engine is not initialized", err.Error())
 	}
 }
+
+// TestValidateDevnetGenesisIdentity_Canonical pins the happy path: the
+// helper accepts the published canonical devnet pack identity. The two
+// canonical inputs come from the same exported helpers cmd/rubin-node
+// uses to seed parsedGenesisConfig defaults, so a regression in either
+// constant or in the helper surfaces here.
+func TestValidateDevnetGenesisIdentity_Canonical(t *testing.T) {
+	if err := ValidateDevnetGenesisIdentity(DevnetGenesisChainID(), DevnetGenesisBlockHash()); err != nil {
+		t.Fatalf("expected nil for canonical devnet identity, got %v", err)
+	}
+}
+
+// TestValidateDevnetGenesisIdentity_WrongChainID locks in the wire
+// contract: a genesis-pack chain_id that differs from the canonical
+// devnet chain_id MUST be rejected with a *consensus.TxError carrying
+// BLOCK_ERR_LINKAGE_INVALID and Msg "genesis chain_id mismatch", same
+// shape as the runtime height-0 chain_id reject in
+// applyCanonicalParsedBlock. The errors.As assertion mirrors the
+// pattern handlers_block.go uses for ban-score escalation, so the
+// boot-time and runtime classes are interchangeable from the consumer
+// side.
+func TestValidateDevnetGenesisIdentity_WrongChainID(t *testing.T) {
+	wrongChainID := DevnetGenesisChainID()
+	wrongChainID[0] ^= 0x01
+	err := ValidateDevnetGenesisIdentity(wrongChainID, DevnetGenesisBlockHash())
+	if err == nil {
+		t.Fatal("expected genesis chain_id mismatch TxError, got nil")
+	}
+	var txErr *consensus.TxError
+	if !errors.As(err, &txErr) {
+		t.Fatalf("expected *consensus.TxError, got %T: %v", err, err)
+	}
+	if txErr.Code != consensus.BLOCK_ERR_LINKAGE_INVALID {
+		t.Fatalf("expected code %s, got %s", consensus.BLOCK_ERR_LINKAGE_INVALID, txErr.Code)
+	}
+	if txErr.Msg != "genesis chain_id mismatch" {
+		t.Fatalf("expected msg %q, got %q", "genesis chain_id mismatch", txErr.Msg)
+	}
+}
+
+// TestValidateDevnetGenesisIdentity_WrongHash mirrors the wrong-chain_id
+// test for the genesis_hash field. Reuses assertGenesisHashMismatchTxError
+// to match the assertion shape used by the existing height-0
+// genesis_hash tests in this file (TxError code + exact Msg string), so
+// the boot-time helper and the runtime guard share one verifier.
+func TestValidateDevnetGenesisIdentity_WrongHash(t *testing.T) {
+	wrongHash := DevnetGenesisBlockHash()
+	wrongHash[0] ^= 0x01
+	err := ValidateDevnetGenesisIdentity(DevnetGenesisChainID(), wrongHash)
+	assertGenesisHashMismatchTxError(t, err)
+}


### PR DESCRIPTION
## Summary

Closes #1283 (Q-GO-GENESIS-PREFLIGHT-BEFORE-STATE-MUTATION-01). Adds a Go-only boot-time genesis-identity preflight that rejects invalid genesis-pack configuration before any filesystem mutation, so a malformed startup leaves no partial datadir, chainstate, or blockstore artifacts on disk.

- **`clients/go/node/sync.go`** — new exported pure helper `ValidateDevnetGenesisIdentity(chainID, hash [32]byte) error`. Returns `*consensus.TxError{Code: BLOCK_ERR_LINKAGE_INVALID, Msg: "genesis chain_id mismatch" | "genesis_hash mismatch"}` on devnet identity mismatch, mirroring the runtime height-0 guards in `applyCanonicalParsedBlock` (sync.go L515 / L537) so log / ban-score / debug correlate boot-time and runtime rejects under one class. Intentionally NOT integrated into `NewSyncEngine`: `SyncConfig` does not carry the parsed `genesis_hash`, so a guard there would observe only `ChainID` and could not actually detect a hash mismatch in an embedded caller. The doc comment states this constraint explicitly so future maintainers do not silently add a cosmetic guard.
- **`clients/go/cmd/rubin-node/main.go`** — invokes the new devnet helper (gated on `cfg.Network == "devnet"`) and the existing `node.ValidateMainnetGenesisGuard` immediately after `parseGenesisConfigFull` (L307) and BEFORE `os.MkdirAll(cfg.DataDir)` (L327). The previous post-`OpenBlockStore` mainnet guard call is removed and the multi-paragraph comment block replaced with a short pointer to the new placement. `NewSyncEngine` still re-runs the mainnet guard internally for embedded / test callers that construct an engine directly.

## Architecture class

B (sustaining). One invariant: invalid genesis identity (devnet wrong chain_id or genesis_hash, mainnet runtime misconfigured) MUST be rejected before any filesystem mutation. Bundle waiver granted by controller for 4 files: one production guard surface (`main.go`) plus three coverage surfaces (helper definition in `sync.go`, internal embedded-caller parity tests in `sync_genesis_identity_test.go`, public/runtime black-box tests in `main_test.go`).

## Non-goals (out of scope, explicitly)

- No `SyncConfig.GenesisHash` field addition.
- No `NewSyncEngine` devnet-identity integration (would be cosmetic — see helper doc comment).
- No mainnet `ExpectedTarget` CLI flag wiring (mainnet remains intentionally fail-closed at boot).
- No Rust client touch (frozen per controller).
- No conformance fixture change (reused error strings already in production at sync.go L515 / L537 and p2p/handshake.go L154-155; verified absent from `conformance/fixtures/`).
- No wire format / API contract / schema change.
- No sync engine, miner, P2P, RPC, or devnet harness redesign.

## Test plan

- [x] `gofmt -l` — clean on 4 changed files.
- [x] `go vet ./node/... ./cmd/rubin-node/...` — clean.
- [x] `rubin-common-preflight`: PASS (5/5 lanes, no waiver). bot-premortem PASS, git-diff-check PASS, local-agent-hygiene PASS, tooling-check PASS (283.6s), rubin-protocol-coverage PASS (368.4s). Diff coverage **100.00% (29/29)**, variation +0.02%, head 91.98%.
- [x] `go test ./node ./cmd/rubin-node` — full package PASS.
- [x] Targeted: `go test ./node -run 'TestValidateDevnetGenesisIdentity'` — 3/3 PASS. `go test ./cmd/rubin-node -run 'TestRunRejects(Devnet|Mainnet|NonDevnet|InvalidGenesis)'` — 5/5 PASS (3 new + 2 pre-existing untouched).

### New test cases

Helper unit tests (`sync_genesis_identity_test.go`):
- `TestValidateDevnetGenesisIdentity_Canonical` — happy path, canonical pack returns nil.
- `TestValidateDevnetGenesisIdentity_WrongChainID` — wrong chain_id → `*consensus.TxError{BLOCK_ERR_LINKAGE_INVALID, "genesis chain_id mismatch"}` (asserted via `errors.As`).
- `TestValidateDevnetGenesisIdentity_WrongHash` — wrong hash → `*consensus.TxError{BLOCK_ERR_LINKAGE_INVALID, "genesis_hash mismatch"}` (asserted via shared `assertGenesisHashMismatchTxError` helper).

Black-box ordering tests (`main_test.go`):
- `TestRunRejectsDevnetWrongChainIDBeforeDataDirCreate` — `--network devnet --genesis-file <pack with wrong chain_id_hex>`.
- `TestRunRejectsDevnetWrongHashBeforeDataDirCreate` — wrong `genesis_hash_hex` (chain_id canonical to reach the hash arm).
- `TestRunRejectsMainnetMisconfigBeforeDataDirCreate` — `--network mainnet --genesis-file <valid pack>` exercises the mainnet guard arm.

Each black-box test uses the existing **blocker-file** pattern: `--datadir` is set to a regular file, so `os.MkdirAll` would fail loudly with `"datadir create failed"` if the guard ever moved back below MkdirAll. The asymmetric assertion (stderr contains the specific guard error AND does NOT contain `"datadir create failed"`) is what proves the **ordering** invariant — not just that rejection happens. Reverting any guard back below `os.MkdirAll` turns the tests red.

Closes #1283
Q-GO-GENESIS-PREFLIGHT-BEFORE-STATE-MUTATION-01
