### PR TITLE
node: add boot-time GET /ready and tighten shutdown ordering (#1295)

### DIFF
--- a/clients/go/cmd/rubin-node/http_rpc.go
+++ b/clients/go/cmd/rubin-node/http_rpc.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
@@ -33,11 +34,63 @@ type devnetRPCState struct {
 	// so concurrent HTTP handlers cannot interleave chain/mempool updates.
 	rpcMut sync.Mutex
 	miner  *node.Miner // devnet live mining for POST /mine_next; nil disables the route
+	// ready is the operator-visible readiness flag exposed via GET /ready.
+	// false until cmd/rubin-node has finished blockstore open, chainstate
+	// load, p2pService.Start, and RPC bind/listen; flipped back to false at
+	// the start of the shutdown drain so /ready stops claiming healthy as
+	// soon as SIGINT/SIGTERM fires. The single new public/operator surface
+	// in this PR is the bounded GET /ready route + this flag's setter.
+	ready atomic.Bool
+}
+
+// SetReady toggles the operator-visible readiness flag observed by the
+// GET /ready handler. Safe under nil receiver so cmd/rubin-node can call
+// it unconditionally without re-checking whether the RPC server actually
+// started (the wrapper-level SetReady gates on rpcServer != nil).
+func (s *devnetRPCState) SetReady(ready bool) {
+	if s == nil {
+		return
+	}
+	s.ready.Store(ready)
+}
+
+// IsReady reports the current readiness flag value.
+func (s *devnetRPCState) IsReady() bool {
+	if s == nil {
+		return false
+	}
+	return s.ready.Load()
 }
 
 type runningDevnetRPCServer struct {
 	addr   string
 	server *http.Server
+	state  *devnetRPCState
+}
+
+// SetReady forwards the readiness toggle to the underlying state so the
+// GET /ready handler observes the new value. Nil-receiver safe: callers
+// in cmd/rubin-node use a single `if rpcServer != nil` gate at startup
+// (only invoke after a non-nil return from startDevnetRPCServer) but
+// this method also tolerates a nil receiver to keep the shutdown path
+// robust against partial-init failure paths.
+func (s *runningDevnetRPCServer) SetReady(ready bool) {
+	if s == nil {
+		return
+	}
+	s.state.SetReady(ready)
+}
+
+// IsReady reads the underlying readiness flag. Nil-receiver safe:
+// returns false if the server wrapper or its backing state is nil.
+// cmd/rubin-node uses this to print runtime evidence of each
+// SetReady transition to stdout (the banner-style audit trail
+// TestRunRPCBindReadyEndpointReportsLifecycle scans).
+func (s *runningDevnetRPCServer) IsReady() bool {
+	if s == nil {
+		return false
+	}
+	return s.state.IsReady()
 }
 
 type rpcMetrics struct {
@@ -191,8 +244,15 @@ func (m *rpcMetrics) snapshot() (map[string]uint64, map[string]uint64) {
 	return routeStatus, submitByResult
 }
 
+// startDevnetRPCServer binds the devnet RPC listener and starts serving.
+// Shutdown is driven exclusively by cmd/rubin-node/main.go's deferred
+// rpcServer.Close(...) call; this function neither accepts nor observes
+// a context — there used to be an inline `<-ctx.Done()` goroutine that
+// called server.Shutdown in parallel with main.go's defer, but that
+// produced two concurrent Shutdown calls on the same *http.Server. The
+// defer in main.go is the single canonical Shutdown call site, so the
+// readiness flag's "false-on-shutdown" hop runs at exactly one place.
 func startDevnetRPCServer(
-	ctx context.Context,
 	bindAddr string,
 	state *devnetRPCState,
 	stdout, stderr io.Writer,
@@ -225,12 +285,6 @@ func startDevnetRPCServer(
 		IdleTimeout: 60 * time.Second,
 	}
 	go func() {
-		<-ctx.Done()
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		_ = server.Shutdown(shutdownCtx)
-	}()
-	go func() {
 		err := server.Serve(listener)
 		if err != nil && !errors.Is(err, http.ErrServerClosed) && stderr != nil {
 			_, _ = fmt.Fprintf(stderr, "rpc server failed: %v\n", err)
@@ -240,7 +294,7 @@ func startDevnetRPCServer(
 	if stdout != nil {
 		_, _ = fmt.Fprintf(stdout, "rpc: listening=%s\n", addr)
 	}
-	return &runningDevnetRPCServer{addr: addr, server: server}, nil
+	return &runningDevnetRPCServer{addr: addr, server: server, state: state}, nil
 }
 
 func (s *runningDevnetRPCServer) Close(ctx context.Context) error {
@@ -250,8 +304,45 @@ func (s *runningDevnetRPCServer) Close(ctx context.Context) error {
 	return s.server.Shutdown(ctx)
 }
 
+// readyResponse is the tiny JSON payload served by GET /ready. The shape
+// is intentionally minimal: a single boolean. Status code (200 vs 503) is
+// the primary contract for orchestrators; the body is for human eyes.
+type readyResponse struct {
+	Ready bool `json:"ready"`
+}
+
+func handleReady(state *devnetRPCState, w http.ResponseWriter, r *http.Request) {
+	const route = "/ready"
+	if r.Method != http.MethodGet {
+		// RFC 9110 §15.5.6 requires 405 responses to advertise the
+		// permitted methods via an Allow response header so generic HTTP
+		// clients and debugging tools can self-correct without re-reading
+		// the body. Set the header BEFORE writeJSONResponse calls
+		// WriteHeader because headers are frozen once status is written.
+		w.Header().Set("Allow", http.MethodGet)
+		// Match the JSON-error envelope used by the rest of the devnet
+		// RPC surface (see handleGetTip / handleSubmitTx non-method paths
+		// at L364+ / L511+) so /ready stays machine-readable on error.
+		// Status stays 405 — semantically correct for method-not-allowed
+		// and pinned by TestReadyHandlerRejectsNonGet.
+		writeJSONResponse(state, route, w, http.StatusMethodNotAllowed, submitTxResponse{
+			Accepted: false,
+			Error:    "GET required",
+		})
+		return
+	}
+	if state.IsReady() {
+		writeJSONResponse(state, route, w, http.StatusOK, readyResponse{Ready: true})
+		return
+	}
+	writeJSONResponse(state, route, w, http.StatusServiceUnavailable, readyResponse{Ready: false})
+}
+
 func newDevnetRPCHandler(state *devnetRPCState) http.Handler {
 	mux := http.NewServeMux()
+	mux.HandleFunc("/ready", func(w http.ResponseWriter, r *http.Request) {
+		handleReady(state, w, r)
+	})
 	mux.HandleFunc("/get_tip", func(w http.ResponseWriter, r *http.Request) {
 		handleGetTip(state, w, r)
 	})

--- a/clients/go/cmd/rubin-node/http_rpc_test.go
+++ b/clients/go/cmd/rubin-node/http_rpc_test.go
@@ -583,10 +583,7 @@ func TestDevnetRPCSubmitTxRejectsOversizedChunkedTrailingBody(t *testing.T) {
 // the underlying http.Server so a future edit that drops ReadTimeout /
 // WriteTimeout / IdleTimeout gets caught before landing.
 func TestDevnetRPCServerExplicitTimeouts(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	srv, err := startDevnetRPCServer(ctx, "127.0.0.1:0", mustRPCState(t, false), io.Discard, io.Discard)
+	srv, err := startDevnetRPCServer("127.0.0.1:0", mustRPCState(t, false), io.Discard, io.Discard)
 	if err != nil {
 		t.Fatalf("startDevnetRPCServer: %v", err)
 	}
@@ -907,9 +904,7 @@ func TestTxAdmitErrorKindHTTPMapping(t *testing.T) {
 
 func TestStartDevnetRPCServerLifecycle(t *testing.T) {
 	state := mustRPCState(t, false)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	server, err := startDevnetRPCServer(ctx, "127.0.0.1:0", state, nil, nil)
+	server, err := startDevnetRPCServer("127.0.0.1:0", state, nil, nil)
 	if err != nil {
 		t.Fatalf("startDevnetRPCServer: %v", err)
 	}
@@ -932,11 +927,8 @@ func TestStartDevnetRPCServerLifecycle(t *testing.T) {
 
 func TestStartDevnetRPCServerWritesListeningBannerAndCloseHandlesNil(t *testing.T) {
 	state := mustRPCState(t, false)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	var stdout bytes.Buffer
-	server, err := startDevnetRPCServer(ctx, "127.0.0.1:0", state, &stdout, nil)
+	server, err := startDevnetRPCServer("127.0.0.1:0", state, &stdout, nil)
 	if err != nil {
 		t.Fatalf("startDevnetRPCServer: %v", err)
 	}
@@ -954,7 +946,7 @@ func TestStartDevnetRPCServerWritesListeningBannerAndCloseHandlesNil(t *testing.
 }
 
 func TestStartDevnetRPCServerDisabledReturnsNil(t *testing.T) {
-	server, err := startDevnetRPCServer(context.Background(), "   ", mustRPCState(t, false), nil, nil)
+	server, err := startDevnetRPCServer("   ", mustRPCState(t, false), nil, nil)
 	if err != nil {
 		t.Fatalf("startDevnetRPCServer: %v", err)
 	}
@@ -964,7 +956,7 @@ func TestStartDevnetRPCServerDisabledReturnsNil(t *testing.T) {
 }
 
 func TestStartDevnetRPCServerRejectsNilState(t *testing.T) {
-	server, err := startDevnetRPCServer(context.Background(), "127.0.0.1:0", nil, nil, nil)
+	server, err := startDevnetRPCServer("127.0.0.1:0", nil, nil, nil)
 	if err == nil {
 		t.Fatal("expected nil-state error")
 	}
@@ -1586,4 +1578,118 @@ func TestDevnetRPCTxStatusFailsClosedOn503BeforeParsingInvalidTxID(t *testing.T)
 	if !strings.Contains(got.Error, "mempool unavailable") {
 		t.Fatalf("Error=%q, want 'mempool unavailable'", got.Error)
 	}
+}
+
+// TestReadyHandlerReports503WhenNotReady pins the default-state contract:
+// a fresh devnetRPCState must report not-ready until cmd/rubin-node has
+// flipped the flag at the all-subsystems-up boundary. atomic.Bool's zero
+// value is false, so a freshly constructed state observes 503 with body
+// {"ready":false}. Reverting that default in the future would silently
+// re-introduce the false-ready-during-partial-init class.
+func TestReadyHandlerReports503WhenNotReady(t *testing.T) {
+	state := mustRPCState(t, false)
+	handler := newDevnetRPCHandler(state)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/ready", nil)
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d, want 503", rec.Code)
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/json" {
+		t.Fatalf("Content-Type=%q, want application/json", got)
+	}
+	var body readyResponse
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if body.Ready {
+		t.Fatalf("body.Ready=true, want false")
+	}
+}
+
+// TestReadyHandlerReports200AfterSetReady pins the positive contract:
+// once SetReady(true) is invoked, GET /ready returns 200 with body
+// {"ready":true}. Subsequent SetReady(false) flips the response back to
+// 503, mirroring cmd/rubin-node's shutdown ordering where SetReady(false)
+// runs at the start of the drain.
+func TestReadyHandlerReports200AfterSetReady(t *testing.T) {
+	state := mustRPCState(t, false)
+	state.SetReady(true)
+	handler := newDevnetRPCHandler(state)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/ready", nil)
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d, want 200", rec.Code)
+	}
+	var body readyResponse
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if !body.Ready {
+		t.Fatalf("body.Ready=false, want true")
+	}
+
+	// Flip back to false — same handler instance must observe new state.
+	state.SetReady(false)
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/ready", nil))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status after SetReady(false)=%d, want 503", rec.Code)
+	}
+}
+
+// TestReadyHandlerRejectsNonGet locks the method contract: only GET is
+// served. POST/PUT/DELETE/etc must return 405 so probes that accidentally
+// use a non-idempotent verb fail loudly rather than silently observing an
+// unrelated body.
+func TestReadyHandlerRejectsNonGet(t *testing.T) {
+	state := mustRPCState(t, false)
+	state.SetReady(true)
+	handler := newDevnetRPCHandler(state)
+	for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodDelete} {
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, httptest.NewRequest(method, "/ready", nil))
+		if rec.Code != http.StatusMethodNotAllowed {
+			t.Fatalf("method=%s status=%d, want 405", method, rec.Code)
+		}
+		// Error body uses the same submitTxResponse JSON envelope as the
+		// rest of the devnet RPC surface (see handleGetTip / handleSubmitTx
+		// non-method paths) so the endpoint stays machine-readable on error
+		// rather than returning plain-text http.Error.
+		if got := rec.Header().Get("Content-Type"); got != "application/json" {
+			t.Fatalf("method=%s Content-Type=%q, want application/json", method, got)
+		}
+		// RFC 9110 §15.5.6: 405 responses MUST list the permitted methods
+		// in the Allow header so generic HTTP clients can self-correct.
+		if got := rec.Header().Get("Allow"); got != http.MethodGet {
+			t.Fatalf("method=%s Allow=%q, want %q", method, got, http.MethodGet)
+		}
+		var body submitTxResponse
+		if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+			t.Fatalf("method=%s Decode: %v", method, err)
+		}
+		if body.Accepted {
+			t.Fatalf("method=%s body.Accepted=true, want false", method)
+		}
+		if !strings.Contains(body.Error, "GET required") {
+			t.Fatalf("method=%s body.Error=%q, want substring 'GET required'", method, body.Error)
+		}
+	}
+}
+
+// TestRunningServerSetReadyNilSafe documents that the wrapper-level
+// SetReady tolerates a nil receiver, which keeps cmd/rubin-node's
+// shutdown path robust if a future refactor introduces an early return
+// before rpcServer is fully constructed.
+func TestRunningServerSetReadyNilSafe(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("nil-receiver SetReady panicked: %v", r)
+		}
+	}()
+	var s *runningDevnetRPCServer
+	s.SetReady(true)
+	s.SetReady(false)
 }

--- a/clients/go/cmd/rubin-node/main.go
+++ b/clients/go/cmd/rubin-node/main.go
@@ -516,7 +516,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 		}
 	}
 	rpcState := newDevnetRPCState(syncEngine, blockStore, mempool, peerManager, p2pService.AnnounceTx, stderr, liveMiner)
-	rpcServer, err := startDevnetRPCServer(ctx, cfg.RPCBindAddr, rpcState, stdout, stderr)
+	rpcServer, err := startDevnetRPCServer(cfg.RPCBindAddr, rpcState, stdout, stderr)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "rpc start failed: %v\n", err)
 		return 2
@@ -529,8 +529,44 @@ func run(args []string, stdout, stderr io.Writer) int {
 		}()
 	}
 
+	// Readiness flag flips to true ONLY after blockstore open, chainstate
+	// load, p2pService.Start, and RPC bind/listen have all succeeded — the
+	// "all subsystems up" boundary. Gated on rpcServer != nil so the flag
+	// is never claimed when --rpc-bind is empty (no GET /ready surface).
+	// Also gated on ctx.Err() == nil via the helper below: if SIGINT or
+	// SIGTERM was observed in the narrow window between RPC bind success
+	// and this call site, the helper skips the SetReady(true) flip so
+	// the "/ready returns 503 the moment shutdown is observed" contract
+	// is not briefly violated during fast start/stop cycles. Set BEFORE
+	// the "running" stdout banner so test harnesses that wait on the
+	// banner observe a coherent state: log line + GET /ready 200. The
+	// "rpc: ready=true" stdout line is runtime evidence (printed value
+	// reads the flag AFTER SetReady) — not the operator signal itself.
+	// The operator signal is the GET /ready 200 response; this stdout
+	// banner exists so subprocess regression tests can pin that SetReady
+	// actually executed at this exact call site.
+	maybeFlipReadyOnStartup(ctx, rpcServer, stdout)
 	_, _ = fmt.Fprintln(stdout, "rubin-node skeleton running")
 	<-ctx.Done()
+	// Flip readiness false at the START of the shutdown drain — BEFORE
+	// the deferred rpcServer.Close + p2pService.Close fire on return —
+	// so /ready stops claiming healthy as soon as SIGINT/SIGTERM is
+	// observed, even while in-flight RPC handlers are still draining
+	// inside server.Shutdown's grace window. The "rpc: ready=false"
+	// stdout line is the runtime evidence the regression test scans for
+	// after the child exits cleanly: handler-level unit tests cannot
+	// observe the production main.go invocation of SetReady(false) on
+	// the shutdown path, and a post-SIGINT HTTP poll against /ready is
+	// inherently racy because http.Server.Shutdown immediately closes
+	// idle connections and rejects new accepts. Printing the flag value
+	// AFTER SetReady(false) makes the literal "rpc: ready=false" the
+	// only way the line can read; deleting or moving the SetReady(false)
+	// call past the print would change the value to true and turn the
+	// regression test red.
+	if rpcServer != nil {
+		rpcServer.SetReady(false)
+		_, _ = fmt.Fprintf(stdout, "rpc: ready=%v\n", rpcServer.IsReady())
+	}
 	_, _ = fmt.Fprintln(stdout, "rubin-node skeleton stopped")
 	return 0
 }
@@ -669,6 +705,40 @@ type parsedGenesisConfig struct {
 	ChainID         [32]byte
 	GenesisHash     [32]byte
 	CoreExtProfiles consensus.CoreExtProfileProvider
+}
+
+// maybeFlipReadyOnStartup flips the operator-visible readiness flag to
+// true ONLY when all of (a) rpcServer is non-nil (RPC actually bound and
+// listening) and (b) ctx has not yet been canceled. The ctx check
+// closes a narrow race window: SIGINT/SIGTERM can be delivered between
+// startDevnetRPCServer returning a non-nil wrapper and run() reaching
+// the SetReady(true) call site. Without the ctx check, SetReady(true)
+// would fire even though shutdown was already requested, then the
+// existing post-<-ctx.Done() SetReady(false) would flip it back — but
+// in the gap /ready would briefly advertise 200, violating the "false
+// as soon as signal observed" contract during fast start/stop cycles.
+//
+// Per the same audit-banner contract used at the SetReady(false) call
+// site, the stdout "rpc: ready=true" line is printed immediately after
+// SetReady so its value reflects the actual flag state via
+// rpcServer.IsReady(), giving the integration test deterministic
+// runtime evidence that the flip executed at this exact site.
+func maybeFlipReadyOnStartup(ctx context.Context, rpcServer *runningDevnetRPCServer, stdout io.Writer) {
+	if rpcServer == nil {
+		return
+	}
+	select {
+	case <-ctx.Done():
+		// Shutdown already requested — leave readiness false so the
+		// upcoming defer-driven drain observes a flag that was never
+		// claimed healthy in the first place.
+		return
+	default:
+	}
+	rpcServer.SetReady(true)
+	if stdout != nil {
+		_, _ = fmt.Fprintf(stdout, "rpc: ready=%v\n", rpcServer.IsReady())
+	}
 }
 
 func parseGenesisConfig(path string) ([32]byte, [32]byte, error) {

--- a/clients/go/cmd/rubin-node/main_test.go
+++ b/clients/go/cmd/rubin-node/main_test.go
@@ -1,18 +1,22 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
+	"context"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"io"
 	"math"
 	"net"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -2191,6 +2195,174 @@ func TestRunNonDryRunWithRPCBindExitsOnSignal(t *testing.T) {
 	}
 }
 
+// TestRunRPCBindReadyEndpointReportsLifecycle proves the operator-visible
+// readiness contract end-to-end: in a real `run()` subprocess with
+// --rpc-bind set, the parent observes (a) the rpc:listening= banner, (b)
+// the "rubin-node skeleton running" banner — used as a barrier confirming
+// SetReady(true) has fired — (c) GET /ready returns 200 with body
+// {"ready":true} while the node is live, (d) on SIGINT the child exits 0
+// after printing the "stopped" banner. Reverting either the SetReady(true)
+// call or the SetReady(false)-before-drain ordering turns this red.
+//
+// Coverage rationale: handler-level unit tests in http_rpc_test.go pin the
+// 200/503 mapping deterministically. This test pins the cmd/rubin-node
+// wiring — that the flag is actually toggled by the boot sequence and not
+// just exposed as a method nobody calls.
+func TestRunRPCBindReadyEndpointReportsLifecycle(t *testing.T) {
+	if os.Getenv("RUBIN_NODE_READY_LIFECYCLE_CHILD") == "1" {
+		dir := t.TempDir()
+		code := run(
+			[]string{"--datadir", dir, "--bind", "127.0.0.1:0", "--rpc-bind", "127.0.0.1:0"},
+			os.Stdout,
+			os.Stderr,
+		)
+		os.Exit(code)
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestRunRPCBindReadyEndpointReportsLifecycle")
+	cmd.Env = append(os.Environ(), "RUBIN_NODE_READY_LIFECYCLE_CHILD=1")
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("StdoutPipe: %v", err)
+	}
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+	})
+
+	rpcAddrCh := make(chan string, 1)
+	runningCh := make(chan struct{})
+	stoppedCh := make(chan struct{})
+	var stdoutMu sync.Mutex
+	var stdoutBuf bytes.Buffer
+	scanDone := make(chan struct{})
+	go func() {
+		defer close(scanDone)
+		scanner := bufio.NewScanner(stdoutPipe)
+		runningClosed := false
+		stoppedClosed := false
+		for scanner.Scan() {
+			line := scanner.Text()
+			stdoutMu.Lock()
+			stdoutBuf.WriteString(line)
+			stdoutBuf.WriteByte('\n')
+			stdoutMu.Unlock()
+			if strings.HasPrefix(line, "rpc: listening=") {
+				select {
+				case rpcAddrCh <- strings.TrimPrefix(line, "rpc: listening="):
+				default:
+				}
+			}
+			if !runningClosed && strings.Contains(line, "rubin-node skeleton running") {
+				close(runningCh)
+				runningClosed = true
+			}
+			if !stoppedClosed && strings.Contains(line, "rubin-node skeleton stopped") {
+				close(stoppedCh)
+				stoppedClosed = true
+			}
+		}
+	}()
+
+	var rpcAddr string
+	select {
+	case rpcAddr = <-rpcAddrCh:
+	case <-time.After(20 * time.Second):
+		stdoutMu.Lock()
+		dump := stdoutBuf.String()
+		stdoutMu.Unlock()
+		t.Fatalf("timeout waiting for rpc:listening= banner; stdout so far=%q", dump)
+	}
+
+	// Wait for the "running" banner so SetReady(true) is guaranteed to
+	// have fired before we hit /ready. The banner is printed immediately
+	// after rpcServer.SetReady(true) in cmd/rubin-node/main.go.
+	select {
+	case <-runningCh:
+	case <-time.After(20 * time.Second):
+		stdoutMu.Lock()
+		dump := stdoutBuf.String()
+		stdoutMu.Unlock()
+		t.Fatalf("timeout waiting for running banner; stdout so far=%q", dump)
+	}
+
+	// Bounded HTTP timeout prevents the integration test from blocking on a
+	// wedged child until the outer `go test` deadline fires. 10 s is ample
+	// for a localhost devnet /ready response (typically <1 ms) and short
+	// enough to surface child hangs as a clean test failure.
+	httpClient := &http.Client{Timeout: 10 * time.Second}
+	resp, err := httpClient.Get("http://" + rpcAddr + "/ready")
+	if err != nil {
+		t.Fatalf("http.Get /ready: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("/ready status=%d, want 200; body=%s", resp.StatusCode, body)
+	}
+	if !strings.Contains(string(body), `"ready":true`) {
+		t.Fatalf("/ready body=%q, want ready:true", body)
+	}
+
+	if err := cmd.Process.Signal(syscall.SIGINT); err != nil {
+		t.Fatalf("Signal(SIGINT): %v", err)
+	}
+	if err := cmd.Wait(); err != nil {
+		ee := new(exec.ExitError)
+		if errors.As(err, &ee) {
+			t.Fatalf("child exit=%d, want 0", ee.ExitCode())
+		}
+		t.Fatalf("Wait: %v", err)
+	}
+	<-scanDone
+	select {
+	case <-stoppedCh:
+	default:
+		stdoutMu.Lock()
+		dump := stdoutBuf.String()
+		stdoutMu.Unlock()
+		t.Fatalf("missing stopped banner after clean exit; stdout=%q", dump)
+	}
+
+	// Runtime evidence audit: the production main.go entrypoint MUST
+	// have printed the "rpc: ready=true" banner before the "running"
+	// banner (boot-time SetReady(true) executed) AND the
+	// "rpc: ready=false" banner before the "stopped" banner (shutdown-
+	// time SetReady(false) executed). The printed values reflect the
+	// flag read AFTER each SetReady call, so removing or moving the
+	// SetReady(false) call past the print would change the literal to
+	// "rpc: ready=true" and turn this assertion red. This closes the
+	// false-ready-during-shutdown class which a post-SIGINT HTTP poll
+	// cannot observe deterministically (http.Server.Shutdown closes
+	// new accepts immediately).
+	stdoutMu.Lock()
+	full := stdoutBuf.String()
+	stdoutMu.Unlock()
+	readyTrueIdx := strings.Index(full, "rpc: ready=true")
+	if readyTrueIdx < 0 {
+		t.Fatalf("missing 'rpc: ready=true' boot-time runtime evidence; stdout=%q", full)
+	}
+	runningIdx := strings.Index(full, "rubin-node skeleton running")
+	if runningIdx < 0 || readyTrueIdx > runningIdx {
+		t.Fatalf("expected 'rpc: ready=true' before 'skeleton running'; stdout=%q", full)
+	}
+	readyFalseIdx := strings.Index(full, "rpc: ready=false")
+	if readyFalseIdx < 0 {
+		t.Fatalf("missing 'rpc: ready=false' shutdown-time runtime evidence; stdout=%q", full)
+	}
+	stoppedIdx := strings.Index(full, "rubin-node skeleton stopped")
+	if stoppedIdx < 0 || readyFalseIdx > stoppedIdx {
+		t.Fatalf("expected 'rpc: ready=false' before 'skeleton stopped'; stdout=%q", full)
+	}
+	if readyFalseIdx <= runningIdx {
+		t.Fatalf("expected 'rpc: ready=false' AFTER 'skeleton running'; stdout=%q", full)
+	}
+}
+
 func TestRunDevnetWithRPCBindInvalidMineAddressLogsStderr(t *testing.T) {
 	if os.Getenv("RUBIN_NODE_TEST_INVALID_MINE_ADDR_CHILD") == "1" {
 		dir := t.TempDir()
@@ -2274,5 +2446,61 @@ func TestRunDevnetWithRPCBindLiveMinerInitErrorLogsStderr(t *testing.T) {
 	s := stderr.String()
 	if !strings.Contains(s, "rpc: live mining disabled:") || !strings.Contains(s, "test miner init failed") {
 		t.Fatalf("stderr=%q, want live mining disabled + test miner init failed", s)
+	}
+}
+
+// TestMaybeFlipReadyOnStartupSkipsWhenCtxAlreadyCancelled pins the
+// shutdown-signal race-window guard: if SIGINT/SIGTERM is observed in
+// the narrow window between RPC bind success and the boot-time
+// SetReady(true) call site, the helper MUST skip the flip so the
+// readiness flag never advertises healthy after shutdown was already
+// requested. With a pre-canceled ctx the flag stays false and the
+// audit banner is NOT written. Reverting the select/default guard
+// would flip the flag and print the banner, turning this test red.
+func TestMaybeFlipReadyOnStartupSkipsWhenCtxAlreadyCancelled(t *testing.T) {
+	state := &devnetRPCState{}
+	server := &runningDevnetRPCServer{state: state}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var buf bytes.Buffer
+	maybeFlipReadyOnStartup(ctx, server, &buf)
+
+	if state.IsReady() {
+		t.Fatalf("expected ready=false when ctx already canceled, got true")
+	}
+	if got := buf.String(); got != "" {
+		t.Fatalf("expected no audit banner when ctx canceled, got %q", got)
+	}
+}
+
+// TestMaybeFlipReadyOnStartupFlipsWhenCtxLive pins the happy path: with
+// a live ctx (default branch of the select) the helper flips the flag
+// to true and writes the audit banner. Reverting the SetReady call or
+// the banner print would turn this test red.
+func TestMaybeFlipReadyOnStartupFlipsWhenCtxLive(t *testing.T) {
+	state := &devnetRPCState{}
+	server := &runningDevnetRPCServer{state: state}
+
+	var buf bytes.Buffer
+	maybeFlipReadyOnStartup(context.Background(), server, &buf)
+
+	if !state.IsReady() {
+		t.Fatalf("expected ready=true when ctx live, got false")
+	}
+	if got := buf.String(); !strings.Contains(got, "rpc: ready=true") {
+		t.Fatalf("expected audit banner 'rpc: ready=true', got %q", got)
+	}
+}
+
+// TestMaybeFlipReadyOnStartupNilServerNoOp pins the --rpc-bind="" path:
+// with a nil rpcServer the helper returns early without touching state
+// or stdout, so cmd/rubin-node main.go can call it unconditionally.
+func TestMaybeFlipReadyOnStartupNilServerNoOp(t *testing.T) {
+	var buf bytes.Buffer
+	maybeFlipReadyOnStartup(context.Background(), nil, &buf)
+	if got := buf.String(); got != "" {
+		t.Fatalf("expected no output for nil server, got %q", got)
 	}
 }


### PR DESCRIPTION
## Summary

Closes #1295 (Q-GO-DEVNET-SHUTDOWN-READINESS-SEMANTICS-01). The Go rubin-node now exposes a deterministic, machine-readable readiness barrier needed by the #1287 Go-only two-node devnet baseline harness as a substitute for stdout-line polling.

The single new public/operator surface in this PR is the bounded `GET /ready` route (HTTP 200 `{"ready":true}` once the all-subsystems-up boundary is reached, HTTP 503 `{"ready":false}` otherwise). The shutdown ordering is also tightened: the previously-inline `<-ctx.Done()` goroutine inside `startDevnetRPCServer` that called `server.Shutdown` in parallel with `cmd/rubin-node`'s `defer rpcServer.Close(...)` is removed, so the existing defer becomes the single canonical Shutdown call site.

- **`clients/go/cmd/rubin-node/http_rpc.go`** — new `atomic.Bool` readiness flag on `devnetRPCState` with `SetReady`/`IsReady` accessors; `runningDevnetRPCServer` wrapper exposes nil-safe `SetReady` and `IsReady` delegates; new `GET /ready` handler going through the existing `writeJSONResponse(...)` envelope helper. Non-GET requests return HTTP 405 with the JSON error envelope used by the rest of the devnet RPC surface AND the RFC 9110 §15.5.6-mandated `Allow: GET` header. The inline `<-ctx.Done()` goroutine inside `startDevnetRPCServer` is removed and the function signature no longer accepts a `ctx` parameter.
- **`clients/go/cmd/rubin-node/main.go`** — boot-time SetReady is wrapped in a small helper, `maybeFlipReadyOnStartup(ctx, rpcServer, stdout)`, that uses a `select { case <-ctx.Done(): return; default: }` guard so a SIGINT/SIGTERM observed in the narrow window between RPC bind success and this call site does NOT flip readiness to true. Helper is invoked immediately before the `"rubin-node skeleton running"` banner so the banner observation implies `/ready` is already 200. After `<-ctx.Done()` returns, `cmd/rubin-node` invokes `rpcServer.SetReady(false)` BEFORE the deferred `rpcServer.Close` + `p2pService.Close` fire, so the readiness flag is cleared after main.go observes cancellation and before the in-flight drain begins. Each `SetReady` call is followed by a stdout banner `rpc: ready=%v` reading the actual flag via `rpcServer.IsReady()` — runtime evidence the regression test scans for.

### Readiness contract this PR delivers (and what it does NOT)

This PR delivers **best-effort observable readiness** with one synchronization point each at boot and shutdown:

- Boot: readiness flips to true ONLY when `ctx.Err() == nil` is observed at the helper call site.
- Shutdown: readiness flips to false after `cmd/rubin-node`'s `<-ctx.Done()` returns and before the deferred `rpcServer.Close` fires.

This PR does NOT deliver a fully cancellation-linearizable readiness gate. There remains a sub-microsecond TOCTOU window between the helper's `select default` branch and the `SetReady(true)` store. Closing that window requires a synchronized lifecycle/readiness contract (mutex around the ctx-observation + state transition, OR an atomic CAS-style gate) — that change widens scope into a lifecycle redesign and is intentionally split into follow-up #1303 (`Atomic readiness/shutdown gate`).

## Architecture class

B (sustaining). One invariant: pre-mutation/post-mutation readiness barrier observable via HTTP and audit-banner stdout. 4 files, all in `clients/go/cmd/rubin-node/`.

## Non-goals (out of scope, explicit)

- No `/health`, `/status`, peers, chain-identity, metrics expansion. Bounded to `GET /ready`.
- No new lifecycle manager / process harness.
- No `server.BaseContext` rewrite or new request-context semantics.
- No new `Close()` methods on `SyncEngine` / `Mempool` / `BlockStore` / `ChainState`.
- No mutex / atomic CAS gate for cancellation-linearizable readiness — split to #1303.
- No Rust touch (frozen).
- No conformance / wire format / RPC schema change beyond the bounded `GET /ready` route + RFC 9110 `Allow` header on its 405.
- No miner / sync engine / P2P / RPC redesign.
- No persistence / restart semantics beyond what #1287 already needs.
- No `/metrics` field tightening — route untouched.

## Test plan

- [x] `gofmt -l` — clean
- [x] `go vet ./cmd/rubin-node/...` — clean
- [x] `pre-amend-audit.sh` — PASS
- [x] `rubin-common-preflight` — PASS (6/6 lanes, no waiver). Diff coverage exceeds 85% gate.
- [x] `go test ./cmd/rubin-node` full package — PASS
- [x] Targeted: 13 readiness-related tests (4 handler unit + 3 helper unit + 1 lifecycle integration + 5 pre-existing untouched) — PASS

### Test cases

Handler unit (`http_rpc_test.go`):
- `TestReadyHandlerReports503WhenNotReady` — `atomic.Bool` default-false → 503
- `TestReadyHandlerReports200AfterSetReady` — `SetReady(true)` → 200, `SetReady(false)` → 503
- `TestReadyHandlerRejectsNonGet` — POST/PUT/DELETE → 405 + JSON `submitTxResponse` envelope + `Allow: GET` header
- `TestRunningServerSetReadyNilSafe` — nil-receiver wrapper SetReady safety

Helper unit (`main_test.go`):
- `TestMaybeFlipReadyOnStartupSkipsWhenCtxAlreadyCancelled` — pre-cancelled ctx → flag stays false, no banner
- `TestMaybeFlipReadyOnStartupFlipsWhenCtxLive` — live ctx → flag flips, banner written
- `TestMaybeFlipReadyOnStartupNilServerNoOp` — nil server gate

Black-box integration (`main_test.go`):
- `TestRunRPCBindReadyEndpointReportsLifecycle` — subprocess run, scans stdout for the audit banners. Asserts ordering: `rpc: ready=true` BEFORE `"rubin-node skeleton running"`; `GET /ready` returns 200 + `"ready":true` while live; on SIGINT child exits 0 with `rpc: ready=false` BEFORE `"rubin-node skeleton stopped"`; `rpc: ready=false` AFTER `"rubin-node skeleton running"` (post-SIGINT, not boot-time).

The audit-banner regression catches: removing/moving any `SetReady` call relative to its co-located banner.

Closes #1295
Q-GO-DEVNET-SHUTDOWN-READINESS-SEMANTICS-01
