### PR TITLE
[Q-GO-MEMPOOL-CAPACITY-BYTES-EVICTION-CONFIG-01] Make Go mempool capacity reject-only and byte-aware

### DIFF
--- a/clients/go/cmd/rubin-node/main.go
+++ b/clients/go/cmd/rubin-node/main.go
@@ -251,6 +251,8 @@ func run(args []string, stdout, stderr io.Writer) int {
 	fs.StringVar(&cfg.LogLevel, "log-level", defaults.LogLevel, "log level: debug|info|warn|error")
 	genesisFile := fs.String("genesis-file", "", "path to genesis pack JSON with chain_id_hex, genesis hash, and optional core_ext_profiles")
 	fs.IntVar(&cfg.MaxPeers, "max-peers", defaults.MaxPeers, "max connected peers")
+	fs.IntVar(&cfg.MempoolMaxTxs, "mempool-max-txs", defaults.MempoolMaxTxs, "maximum canonical mempool transactions")
+	fs.IntVar(&cfg.MempoolMaxBytes, "mempool-max-bytes", defaults.MempoolMaxBytes, "maximum canonical mempool serialized transaction bytes")
 	fs.StringVar(&cfg.MineAddress, "mine-address", "", "miner pubkey: 64-char hex key_id or 66-char hex suite_id||key_id")
 	mineBlocks := fs.Int("mine-blocks", 0, "mine N blocks locally after startup")
 	mineExit := fs.Bool("mine-exit", false, "exit immediately after local mining")
@@ -396,6 +398,8 @@ func run(args []string, stdout, stderr io.Writer) int {
 		return 2
 	}
 	mempoolCfg := node.DefaultMempoolConfig()
+	mempoolCfg.MaxTransactions = cfg.MempoolMaxTxs
+	mempoolCfg.MaxBytes = cfg.MempoolMaxBytes
 	mempoolCfg.CoreExtProfiles = genesisCfg.CoreExtProfiles
 	mempool, err := newMempoolFn(chainState, blockStore, chainIDFromGenesis, mempoolCfg)
 	if err != nil {

--- a/clients/go/cmd/rubin-node/main_test.go
+++ b/clients/go/cmd/rubin-node/main_test.go
@@ -1636,6 +1636,36 @@ func TestRunPassesGenesisCoreExtProfilesToMempool(t *testing.T) {
 	}
 }
 
+func TestRunPassesMempoolLimitsToMempoolAndPrintsConfig(t *testing.T) {
+	prev := newMempoolFn
+	var captured node.MempoolConfig
+	newMempoolFn = func(st *node.ChainState, store *node.BlockStore, chainID [32]byte, cfg node.MempoolConfig) (*node.Mempool, error) {
+		captured = cfg
+		return node.NewMempoolWithConfig(st, store, chainID, cfg)
+	}
+	t.Cleanup(func() { newMempoolFn = prev })
+
+	dir := t.TempDir()
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	code := run([]string{"--dry-run", "--datadir", dir, "--mempool-max-txs", "7", "--mempool-max-bytes", "4096"}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("expected exit code 0, got %d (stderr=%q)", code, errOut.String())
+	}
+	if captured.MaxTransactions != 7 {
+		t.Fatalf("mempool MaxTransactions=%d, want 7", captured.MaxTransactions)
+	}
+	if captured.MaxBytes != 4096 {
+		t.Fatalf("mempool MaxBytes=%d, want 4096", captured.MaxBytes)
+	}
+	if !strings.Contains(out.String(), `"mempool_max_txs": 7`) {
+		t.Fatalf("printed config missing mempool_max_txs: %q", out.String())
+	}
+	if !strings.Contains(out.String(), `"mempool_max_bytes": 4096`) {
+		t.Fatalf("printed config missing mempool_max_bytes: %q", out.String())
+	}
+}
+
 func TestRunWiresP2PToCanonicalMempool(t *testing.T) {
 	prev := newP2PServiceFn
 	var captured p2p.ServiceConfig
@@ -1807,6 +1837,31 @@ func TestRunInvalidConfigMaxPeers(t *testing.T) {
 	)
 	if code == 0 {
 		t.Fatalf("expected non-zero exit code")
+	}
+}
+
+func TestRunInvalidConfigMempoolLimits(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "txs", args: []string{"--mempool-max-txs", "0"}, want: "mempool_max_txs"},
+		{name: "bytes", args: []string{"--mempool-max-bytes", "0"}, want: "mempool_max_bytes"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			var out bytes.Buffer
+			var errOut bytes.Buffer
+			args := append([]string{"--dry-run", "--datadir", dir}, tc.args...)
+			code := run(args, &out, &errOut)
+			if code != 2 {
+				t.Fatalf("code=%d, want 2", code)
+			}
+			if !strings.Contains(errOut.String(), "invalid config") || !strings.Contains(errOut.String(), tc.want) {
+				t.Fatalf("stderr=%q, want %s validation error", errOut.String(), tc.want)
+			}
+		})
 	}
 }
 

--- a/clients/go/node/config.go
+++ b/clients/go/node/config.go
@@ -22,6 +22,8 @@ type Config struct {
 	LogLevel           string              `json:"log_level"`
 	Peers              []string            `json:"peers"`
 	MaxPeers           int                 `json:"max_peers"`
+	MempoolMaxTxs      int                 `json:"mempool_max_txs"`
+	MempoolMaxBytes    int                 `json:"mempool_max_bytes"`
 	ChainID            string              `json:"chain_id_hex,omitempty"`
 	MineAddress        string              `json:"mine_address"`
 	RotationDescriptor *RotationConfigJSON `json:"rotation_descriptor,omitempty"`
@@ -324,14 +326,17 @@ func DefaultDataDir() string {
 }
 
 func DefaultConfig() Config {
+	mempoolDefaults := DefaultMempoolConfig()
 	return Config{
-		Network:     "devnet",
-		DataDir:     DefaultDataDir(),
-		BindAddr:    "0.0.0.0:19111",
-		RPCBindAddr: "",
-		Peers:       nil,
-		LogLevel:    "info",
-		MaxPeers:    64,
+		Network:         "devnet",
+		DataDir:         DefaultDataDir(),
+		BindAddr:        "0.0.0.0:19111",
+		RPCBindAddr:     "",
+		Peers:           nil,
+		LogLevel:        "info",
+		MaxPeers:        64,
+		MempoolMaxTxs:   mempoolDefaults.MaxTransactions,
+		MempoolMaxBytes: mempoolDefaults.MaxBytes,
 	}
 }
 
@@ -387,6 +392,12 @@ func ValidateConfig(cfg Config) error {
 	}
 	if cfg.MaxPeers > 4096 {
 		return errors.New("max_peers must be <= 4096")
+	}
+	if cfg.MempoolMaxTxs <= 0 {
+		return errors.New("mempool_max_txs must be > 0")
+	}
+	if cfg.MempoolMaxBytes <= 0 {
+		return errors.New("mempool_max_bytes must be > 0")
 	}
 	if cfg.MineAddress != "" {
 		raw, err := hex.DecodeString(cfg.MineAddress)

--- a/clients/go/node/config_rotation_test.go
+++ b/clients/go/node/config_rotation_test.go
@@ -818,6 +818,8 @@ func TestValidateConfig_RejectsMissingSuiteRegistryAlgName(t *testing.T) {
 		"bind_addr":"0.0.0.0:19111",
 		"log_level":"info",
 		"max_peers":64,
+		"mempool_max_txs":300,
+		"mempool_max_bytes":96000000,
 		"mine_address":"",
 		"suite_registry":[{"suite_id":66,"pubkey_len":2592,"sig_len":4627,"verify_cost":19}]
 	}`), &cfg); err != nil {
@@ -830,11 +832,13 @@ func TestValidateConfig_RejectsMissingSuiteRegistryAlgName(t *testing.T) {
 
 func TestRotationConfigJSON_Roundtrip(t *testing.T) {
 	cfg := Config{
-		Network:  "devnet",
-		DataDir:  "/tmp/test",
-		BindAddr: "0.0.0.0:19111",
-		LogLevel: "info",
-		MaxPeers: 64,
+		Network:         "devnet",
+		DataDir:         "/tmp/test",
+		BindAddr:        "0.0.0.0:19111",
+		LogLevel:        "info",
+		MaxPeers:        64,
+		MempoolMaxTxs:   DefaultMempoolMaxTransactions,
+		MempoolMaxBytes: DefaultMempoolMaxBytes,
 		RotationDescriptor: &RotationConfigJSON{
 			Name:         "test",
 			OldSuiteID:   1,
@@ -907,6 +911,8 @@ func TestValidateConfig_AcceptsLegacySuiteRegistryOpenSSLAlgAlias(t *testing.T) 
 		"bind_addr":"0.0.0.0:19111",
 		"log_level":"info",
 		"max_peers":64,
+		"mempool_max_txs":300,
+		"mempool_max_bytes":96000000,
 		"mine_address":"",
 		"suite_registry":[{"suite_id":66,"pubkey_len":2592,"sig_len":4627,"verify_cost":8,"openssl_alg":"ML-DSA-87"}]
 	}`), &cfg); err != nil {

--- a/clients/go/node/config_test.go
+++ b/clients/go/node/config_test.go
@@ -125,6 +125,37 @@ func TestValidateConfigRejectsMaxPeersTooHigh(t *testing.T) {
 	}
 }
 
+func TestDefaultConfigIncludesMempoolLimits(t *testing.T) {
+	cfg := DefaultConfig()
+	if cfg.MempoolMaxTxs != DefaultMempoolMaxTransactions {
+		t.Fatalf("mempool_max_txs=%d, want %d", cfg.MempoolMaxTxs, DefaultMempoolMaxTransactions)
+	}
+	if cfg.MempoolMaxBytes != DefaultMempoolMaxBytes {
+		t.Fatalf("mempool_max_bytes=%d, want %d", cfg.MempoolMaxBytes, DefaultMempoolMaxBytes)
+	}
+}
+
+func TestValidateConfigRejectsInvalidMempoolLimits(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		edit func(*Config)
+		want string
+	}{
+		{name: "zero txs", edit: func(cfg *Config) { cfg.MempoolMaxTxs = 0 }, want: "mempool_max_txs"},
+		{name: "negative txs", edit: func(cfg *Config) { cfg.MempoolMaxTxs = -1 }, want: "mempool_max_txs"},
+		{name: "zero bytes", edit: func(cfg *Config) { cfg.MempoolMaxBytes = 0 }, want: "mempool_max_bytes"},
+		{name: "negative bytes", edit: func(cfg *Config) { cfg.MempoolMaxBytes = -1 }, want: "mempool_max_bytes"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := DefaultConfig()
+			tc.edit(&cfg)
+			if err := ValidateConfig(cfg); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected %s rejection, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
 func TestParseMineAddressAcceptsKeyIDAndCanonicalEncoding(t *testing.T) {
 	raw := strings.Repeat("11", mineAddressKeyIDBytes)
 	got, err := ParseMineAddress(raw)

--- a/clients/go/node/coverage_sub80_followup_test.go
+++ b/clients/go/node/coverage_sub80_followup_test.go
@@ -43,9 +43,6 @@ func TestCoverageResidual_MempoolBranches(t *testing.T) {
 	if entries[0].txid[0] != 0x01 {
 		t.Fatalf("expected deterministic txid tie-break")
 	}
-	if got := compareEntryPriority(nil, &mempoolEntry{txid: [32]byte{0x01}, fee: 1, size: 1}); got != 0 {
-		t.Fatalf("compareEntryPriority(nil)= %d", got)
-	}
 
 	st := NewChainState()
 	mp, err := NewMempool(st, nil, devnetGenesisChainID)
@@ -99,72 +96,43 @@ func TestCoverageResidual_RemoveConflictingParsesBlockBytes(t *testing.T) {
 	}
 }
 
-func TestCoverageResidual_CompareEntryPriorityTieBreakers(t *testing.T) {
-	if got := compareEntryPriority(
-		&mempoolEntry{txid: [32]byte{0x01}, fee: 10, size: 2},
-		&mempoolEntry{txid: [32]byte{0x02}, fee: 5, size: 1},
-	); got <= 0 {
-		t.Fatalf("expected higher absolute fee to win when fee rates tie, got %d", got)
-	}
-
-	if got := compareEntryPriority(
-		&mempoolEntry{txid: [32]byte{0x01}, fee: 10, weight: 4, size: 2},
-		&mempoolEntry{txid: [32]byte{0x02}, fee: 10, weight: 5, size: 2},
-	); got <= 0 {
-		t.Fatalf("expected lower weight to win when fee and fee rate tie, got %d", got)
-	}
-
-	if got := compareEntryPriority(
-		&mempoolEntry{txid: [32]byte{0x01}, fee: 10, weight: 4, size: 2},
-		&mempoolEntry{txid: [32]byte{0x02}, fee: 10, weight: 4, size: 2},
-	); got <= 0 {
-		t.Fatalf("expected lower txid to win deterministic tie-break, got %d", got)
-	}
-}
-
-func TestCoverageResidual_MempoolHeapRepairBranches(t *testing.T) {
+func TestCoverageResidual_MempoolLimitBranches(t *testing.T) {
 	st := NewChainState()
-	mp, err := NewMempool(st, nil, devnetGenesisChainID)
+	mp, err := NewMempoolWithConfig(st, nil, devnetGenesisChainID, MempoolConfig{
+		MaxTransactions: 1,
+		MaxBytes:        10,
+	})
 	if err != nil {
 		t.Fatalf("NewMempool: %v", err)
 	}
-
 	mp.mu.Lock()
-	defer mp.mu.Unlock()
+	if err := mp.validateAdmissionLocked(&mempoolEntry{txid: [32]byte{0x01}, size: 0}); err == nil {
+		t.Fatalf("expected invalid size rejection")
+	}
+	mp.addEntryLocked(&mempoolEntry{txid: [32]byte{0x02}, size: 1})
+	if err := mp.validateAdmissionLocked(&mempoolEntry{txid: [32]byte{0x03}, size: 1}); err == nil {
+		t.Fatalf("expected count-limit rejection")
+	}
+	mp.mu.Unlock()
 
-	liveTxid := [32]byte{0x10}
-	mp.txs[liveTxid] = &mempoolEntry{
-		raw:    []byte{0x01},
-		txid:   liveTxid,
-		inputs: nil,
-		fee:    2,
-		weight: 1,
-		size:   1,
+	mpBytes, err := NewMempoolWithConfig(st, nil, devnetGenesisChainID, MempoolConfig{
+		MaxTransactions: 10,
+		MaxBytes:        2,
+	})
+	if err != nil {
+		t.Fatalf("NewMempool(bytes): %v", err)
 	}
-
-	gotTxid, entry, ok := mp.peekWorstLocked()
-	if !ok || entry == nil || gotTxid != liveTxid {
-		t.Fatalf("peekWorstLocked seeded heap = (%x, %v, %v)", gotTxid, entry, ok)
+	mpBytes.mu.Lock()
+	mpBytes.addEntryLocked(&mempoolEntry{txid: [32]byte{0x04}, size: 1})
+	if err := mpBytes.validateAdmissionLocked(&mempoolEntry{txid: [32]byte{0x05}, size: 2}); err == nil {
+		t.Fatalf("expected byte-limit rejection")
 	}
-
-	staleTxid := [32]byte{0x01}
-	stale := &mempoolHeapItem{txid: staleTxid, fee: 1, weight: 1, size: 1, heapID: 99, index: 0}
-	liveItem := mp.heapItems[liveTxid]
-	liveItem.index = 1
-	mp.worstHeap = mempoolWorstHeap{stale, liveItem}
-	mp.heapItems[staleTxid] = stale
-	mp.heapSeqs[staleTxid] = stale.heapID
-
-	gotTxid, entry, ok = mp.peekWorstLocked()
-	if !ok || entry == nil || gotTxid != liveTxid {
-		t.Fatalf("peekWorstLocked after stale cleanup = (%x, %v, %v)", gotTxid, entry, ok)
+	mpBytes.usedBytes = 1
+	mpBytes.deleteEntryLocked([32]byte{0x06}, &mempoolEntry{size: 2})
+	if mpBytes.usedBytes != 0 {
+		t.Fatalf("delete underflow guard left usedBytes=%d", mpBytes.usedBytes)
 	}
-	if _, ok := mp.heapItems[staleTxid]; ok {
-		t.Fatalf("expected stale heap item cleanup")
-	}
-	if _, ok := mp.heapSeqs[staleTxid]; ok {
-		t.Fatalf("expected stale heap seq cleanup")
-	}
+	mpBytes.mu.Unlock()
 }
 
 func TestCoverageResidual_CoreExtPolicyBranches(t *testing.T) {

--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -2,7 +2,6 @@ package node
 
 import (
 	"bytes"
-	"container/heap"
 	"errors"
 	"fmt"
 	"math/bits"
@@ -12,7 +11,10 @@ import (
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
 )
 
-const maxMempoolTransactions = 300
+const (
+	DefaultMempoolMaxTransactions = 300
+	DefaultMempoolMaxBytes        = consensus.MAX_RELAY_MSG_BYTES
+)
 
 type mempoolEntry struct {
 	raw    []byte
@@ -30,60 +32,15 @@ type Mempool struct {
 	chainID    [32]byte
 	policy     MempoolConfig
 	maxTxs     int
+	maxBytes   int
+	usedBytes  int
 	txs        map[[32]byte]*mempoolEntry
 	spenders   map[consensus.Outpoint][32]byte
-	worstHeap  mempoolWorstHeap
-	heapItems  map[[32]byte]*mempoolHeapItem
-	heapSeqs   map[[32]byte]uint64
-	nextHeapID uint64
-}
-
-type mempoolHeapItem struct {
-	txid   [32]byte
-	fee    uint64
-	weight uint64
-	size   int
-	heapID uint64
-	index  int
-}
-
-type mempoolPriority struct {
-	fee    uint64
-	size   int
-	weight uint64
-	txid   [32]byte
-}
-
-type mempoolWorstHeap []*mempoolHeapItem
-
-func (h mempoolWorstHeap) Len() int { return len(h) }
-
-func (h mempoolWorstHeap) Less(i, j int) bool {
-	return compareHeapItemPriority(h[i], h[j]) < 0
-}
-
-func (h mempoolWorstHeap) Swap(i, j int) {
-	h[i], h[j] = h[j], h[i]
-	h[i].index = i
-	h[j].index = j
-}
-
-func (h *mempoolWorstHeap) Push(x any) {
-	item := x.(*mempoolHeapItem)
-	item.index = len(*h)
-	*h = append(*h, item)
-}
-
-func (h *mempoolWorstHeap) Pop() any {
-	old := *h
-	n := len(old)
-	item := old[n-1]
-	item.index = -1
-	*h = old[:n-1]
-	return item
 }
 
 type MempoolConfig struct {
+	MaxTransactions                      int
+	MaxBytes                             int
 	PolicyDaSurchargePerByte             uint64
 	PolicyRejectNonCoinbaseAnchorOutputs bool
 	PolicyRejectCoreExtPreActivation     bool
@@ -136,6 +93,8 @@ func NewMempool(chainState *ChainState, blockStore *BlockStore, chainID [32]byte
 func DefaultMempoolConfig() MempoolConfig {
 	minerDefaults := DefaultMinerConfig()
 	return MempoolConfig{
+		MaxTransactions:                      DefaultMempoolMaxTransactions,
+		MaxBytes:                             DefaultMempoolMaxBytes,
 		PolicyDaSurchargePerByte:             minerDefaults.PolicyDaSurchargePerByte,
 		PolicyRejectNonCoinbaseAnchorOutputs: minerDefaults.PolicyRejectNonCoinbaseAnchorOutputs,
 		PolicyRejectCoreExtPreActivation:     minerDefaults.PolicyRejectCoreExtPreActivation,
@@ -146,18 +105,27 @@ func NewMempoolWithConfig(chainState *ChainState, blockStore *BlockStore, chainI
 	if chainState == nil {
 		return nil, errors.New("nil chainstate")
 	}
+	cfg = normalizeMempoolConfig(cfg)
 	return &Mempool{
 		chainState: chainState,
 		blockStore: blockStore,
 		chainID:    chainID,
 		policy:     cfg,
-		maxTxs:     maxMempoolTransactions,
+		maxTxs:     cfg.MaxTransactions,
+		maxBytes:   cfg.MaxBytes,
 		txs:        make(map[[32]byte]*mempoolEntry),
 		spenders:   make(map[consensus.Outpoint][32]byte),
-		worstHeap:  make(mempoolWorstHeap, 0, maxMempoolTransactions),
-		heapItems:  make(map[[32]byte]*mempoolHeapItem),
-		heapSeqs:   make(map[[32]byte]uint64),
 	}, nil
+}
+
+func normalizeMempoolConfig(cfg MempoolConfig) MempoolConfig {
+	if cfg.MaxTransactions <= 0 {
+		cfg.MaxTransactions = DefaultMempoolMaxTransactions
+	}
+	if cfg.MaxBytes <= 0 {
+		cfg.MaxBytes = DefaultMempoolMaxBytes
+	}
+	return cfg
 }
 
 func (m *Mempool) Len() int {
@@ -552,15 +520,15 @@ func (m *Mempool) removeTxLocked(txid [32]byte) {
 	if !ok {
 		return
 	}
-	if item, ok := m.heapItems[txid]; ok && item != nil && item.index >= 0 && item.index < len(m.worstHeap) && m.worstHeap[item.index] == item {
-		heap.Remove(&m.worstHeap, item.index)
-	}
 	m.deleteEntryLocked(txid, entry)
 }
 
 func (m *Mempool) validateAdmissionLocked(entry *mempoolEntry) error {
 	if entry == nil {
 		return txAdmitRejected("nil mempool entry")
+	}
+	if entry.size <= 0 {
+		return txAdmitRejected("invalid mempool entry size")
 	}
 	txid := entry.txid
 	if _, exists := m.txs[txid]; exists {
@@ -572,12 +540,10 @@ func (m *Mempool) validateAdmissionLocked(entry *mempoolEntry) error {
 		}
 	}
 	if len(m.txs) >= m.maxTxs {
-		worstTxid, worstEntry, ok := m.peekWorstLocked()
-		if !ok || compareEntryPriority(entry, worstEntry) <= 0 {
-			return txAdmitUnavailable("mempool full")
-		}
-		m.popWorstLocked()
-		m.removePoppedWorstLocked(worstTxid, worstEntry)
+		return txAdmitUnavailable(fmt.Sprintf("mempool transaction count limit reached: current=%d max=%d", len(m.txs), m.maxTxs))
+	}
+	if entry.size > m.maxBytes || m.usedBytes > m.maxBytes-entry.size {
+		return txAdmitUnavailable(fmt.Sprintf("mempool byte limit exceeded: current=%d tx=%d max=%d", m.usedBytes, entry.size, m.maxBytes))
 	}
 	return nil
 }
@@ -594,16 +560,11 @@ func newMempoolEntry(checked *consensus.CheckedTransaction, inputs []consensus.O
 }
 
 func (m *Mempool) addEntryLocked(entry *mempoolEntry) {
-	m.nextHeapID++
-	heapID := m.nextHeapID
 	m.txs[entry.txid] = entry
-	m.heapSeqs[entry.txid] = heapID
+	m.usedBytes += entry.size
 	for _, op := range entry.inputs {
 		m.spenders[op] = entry.txid
 	}
-	item := newHeapItem(entry.txid, entry, heapID)
-	heap.Push(&m.worstHeap, item)
-	m.heapItems[entry.txid] = item
 }
 
 func (m *Mempool) snapshotEntries() []*mempoolEntry {
@@ -666,131 +627,20 @@ func outpointFromInput(in consensus.TxInput) consensus.Outpoint {
 	return consensus.Outpoint{Txid: in.PrevTxid, Vout: in.PrevVout}
 }
 
-func newHeapItem(txid [32]byte, entry *mempoolEntry, heapID uint64) *mempoolHeapItem {
-	return &mempoolHeapItem{
-		txid:   txid,
-		fee:    entry.fee,
-		weight: entry.weight,
-		size:   entry.size,
-		heapID: heapID,
-	}
-}
-
-func (m *Mempool) seedWorstHeapLocked() {
-	if len(m.heapItems) >= len(m.txs) {
-		return
-	}
-	for txid, entry := range m.txs {
-		if _, ok := m.heapItems[txid]; ok {
-			continue
-		}
-		m.nextHeapID++
-		heapID := m.nextHeapID
-		m.heapSeqs[txid] = heapID
-		item := newHeapItem(txid, entry, heapID)
-		heap.Push(&m.worstHeap, item)
-		m.heapItems[txid] = item
-	}
-}
-
-func (m *Mempool) peekWorstLocked() ([32]byte, *mempoolEntry, bool) {
-	m.seedWorstHeapLocked()
-	for len(m.worstHeap) > 0 {
-		item := m.worstHeap[0]
-		entry := m.txs[item.txid]
-		if entry == nil {
-			heap.Pop(&m.worstHeap)
-			delete(m.heapItems, item.txid)
-			delete(m.heapSeqs, item.txid)
-			continue
-		}
-		return item.txid, entry, true
-	}
-	return [32]byte{}, nil, false
-}
-
-func (m *Mempool) popWorstLocked() ([32]byte, *mempoolEntry, bool) {
-	txid, entry, ok := m.peekWorstLocked()
-	if !ok {
-		return [32]byte{}, nil, false
-	}
-	heap.Pop(&m.worstHeap)
-	delete(m.heapItems, txid)
-	return txid, entry, true
-}
-
-func (m *Mempool) removePoppedWorstLocked(txid [32]byte, entry *mempoolEntry) {
-	m.deleteEntryLocked(txid, entry)
-}
-
 func (m *Mempool) deleteEntryLocked(txid [32]byte, entry *mempoolEntry) {
 	delete(m.txs, txid)
-	delete(m.heapItems, txid)
-	delete(m.heapSeqs, txid)
 	if entry == nil {
 		return
 	}
+	if entry.size > 0 {
+		if m.usedBytes >= entry.size {
+			m.usedBytes -= entry.size
+		} else {
+			m.usedBytes = 0
+		}
+	}
 	for _, op := range entry.inputs {
 		delete(m.spenders, op)
-	}
-}
-
-func compareEntryPriority(a *mempoolEntry, b *mempoolEntry) int {
-	if a == nil || b == nil {
-		return 0
-	}
-	return comparePriorityValues(priorityFromEntry(a), priorityFromEntry(b))
-}
-
-func compareHeapItemPriority(a *mempoolHeapItem, b *mempoolHeapItem) int {
-	if a == nil || b == nil {
-		return 0
-	}
-	return comparePriorityValues(priorityFromHeapItem(a), priorityFromHeapItem(b))
-}
-
-func priorityFromEntry(entry *mempoolEntry) mempoolPriority {
-	return mempoolPriority{
-		fee:    entry.fee,
-		size:   entry.size,
-		weight: entry.weight,
-		txid:   entry.txid,
-	}
-}
-
-func priorityFromHeapItem(item *mempoolHeapItem) mempoolPriority {
-	return mempoolPriority{
-		fee:    item.fee,
-		size:   item.size,
-		weight: item.weight,
-		txid:   item.txid,
-	}
-}
-
-func comparePriorityValues(a mempoolPriority, b mempoolPriority) int {
-	cmp := compareFeeRateValues(a.fee, a.size, b.fee, b.size)
-	if cmp != 0 {
-		return cmp
-	}
-	if a.fee != b.fee {
-		if a.fee > b.fee {
-			return 1
-		}
-		return -1
-	}
-	if a.weight != b.weight {
-		if a.weight < b.weight {
-			return 1
-		}
-		return -1
-	}
-	switch cmp := bytes.Compare(a.txid[:], b.txid[:]); {
-	case cmp < 0:
-		return 1
-	case cmp > 0:
-		return -1
-	default:
-		return 0
 	}
 }
 

--- a/clients/go/node/mempool_test.go
+++ b/clients/go/node/mempool_test.go
@@ -890,12 +890,14 @@ func TestRestoreMempoolSnapshotRejectsInvalidEntriesWithoutMutation(t *testing.T
 	toKey := mustNodeMLDSA87Keypair(t)
 	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
 	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
-	st, outpoints := testSpendableChainState(fromAddress, []uint64{100})
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{100, 100})
 
 	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 2, 1, fromKey, fromAddress, toAddress)
+	txSecond := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[1]}, 90, 2, 2, fromKey, fromAddress, toAddress)
+	txSecondID := txID(t, txSecond)
 	mp, err := NewMempoolWithConfig(st, nil, devnetGenesisChainID, MempoolConfig{
 		MaxTransactions: 10,
-		MaxBytes:        len(txBytes) * 2,
+		MaxBytes:        len(txBytes) + len(txSecond),
 	})
 	if err != nil {
 		t.Fatalf("new mempool: %v", err)
@@ -935,9 +937,10 @@ func TestRestoreMempoolSnapshotRejectsInvalidEntriesWithoutMutation(t *testing.T
 	}
 
 	for _, tc := range []struct {
-		name   string
-		mutate func(mempoolSnapshot) mempoolSnapshot
-		want   string
+		name      string
+		configure func(*Mempool)
+		mutate    func(mempoolSnapshot) mempoolSnapshot
+		want      string
 	}{
 		{
 			name:   "zero_size",
@@ -999,8 +1002,37 @@ func TestRestoreMempoolSnapshotRejectsInvalidEntriesWithoutMutation(t *testing.T
 			},
 			want: "duplicate mempool snapshot spender",
 		},
+		{
+			name: "aggregate_count_over_cap",
+			configure: func(m *Mempool) {
+				m.maxTxs = 1
+			},
+			mutate: func(base mempoolSnapshot) mempoolSnapshot {
+				bad := cloneSnapshotForTest(base)
+				bad.entries = append(bad.entries, snapshotEntry(txSecond, txSecondID, []consensus.Outpoint{outpoints[1]}))
+				return bad
+			},
+			want: "mempool snapshot exceeds transaction cap",
+		},
+		{
+			name: "aggregate_bytes_over_cap",
+			configure: func(m *Mempool) {
+				m.maxBytes = len(txBytes) + len(txSecond) - 1
+			},
+			mutate: func(base mempoolSnapshot) mempoolSnapshot {
+				bad := cloneSnapshotForTest(base)
+				bad.entries = append(bad.entries, snapshotEntry(txSecond, txSecondID, []consensus.Outpoint{outpoints[1]}))
+				return bad
+			},
+			want: "mempool snapshot exceeds byte cap",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			mp.maxTxs = 10
+			mp.maxBytes = len(txBytes) + len(txSecond)
+			if tc.configure != nil {
+				tc.configure(mp)
+			}
 			bad := tc.mutate(snapshot)
 			if err := restoreMempoolSnapshot(mp, bad); err == nil || !strings.Contains(err.Error(), tc.want) {
 				t.Fatalf("expected %q rejection, got %v", tc.want, err)
@@ -1015,6 +1047,51 @@ func TestRestoreMempoolSnapshotRejectsInvalidEntriesWithoutMutation(t *testing.T
 				t.Fatalf("usedBytes=%d, want %d after rejected restore", mp.usedBytes, wantBytes)
 			}
 		})
+	}
+}
+
+func TestRestoreMempoolSnapshotAllowsExactCapacityBoundary(t *testing.T) {
+	fromKey := mustNodeMLDSA87Keypair(t)
+	toKey := mustNodeMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{100, 100})
+
+	tx1 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 2, 1, fromKey, fromAddress, toAddress)
+	tx2 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[1]}, 90, 2, 2, fromKey, fromAddress, toAddress)
+	source, err := NewMempoolWithConfig(st, nil, devnetGenesisChainID, MempoolConfig{
+		MaxTransactions: 2,
+		MaxBytes:        len(tx1) + len(tx2),
+	})
+	if err != nil {
+		t.Fatalf("new source mempool: %v", err)
+	}
+	if err := source.AddTx(tx1); err != nil {
+		t.Fatalf("source AddTx(tx1): %v", err)
+	}
+	if err := source.AddTx(tx2); err != nil {
+		t.Fatalf("source AddTx(tx2): %v", err)
+	}
+	snapshot, err := snapshotMempool(source)
+	if err != nil {
+		t.Fatalf("snapshotMempool: %v", err)
+	}
+
+	target, err := NewMempoolWithConfig(st, nil, devnetGenesisChainID, MempoolConfig{
+		MaxTransactions: 2,
+		MaxBytes:        len(tx1) + len(tx2),
+	})
+	if err != nil {
+		t.Fatalf("new target mempool: %v", err)
+	}
+	if err := restoreMempoolSnapshot(target, snapshot); err != nil {
+		t.Fatalf("restoreMempoolSnapshot exact boundary: %v", err)
+	}
+	if got := target.Len(); got != 2 {
+		t.Fatalf("mempool len=%d, want 2", got)
+	}
+	if target.usedBytes != len(tx1)+len(tx2) {
+		t.Fatalf("usedBytes=%d, want %d", target.usedBytes, len(tx1)+len(tx2))
 	}
 }
 

--- a/clients/go/node/mempool_test.go
+++ b/clients/go/node/mempool_test.go
@@ -883,6 +883,12 @@ func TestRestoreMempoolSnapshotRecomputesByteAccounting(t *testing.T) {
 	if mp.Contains(txID(t, tx2)) {
 		t.Fatalf("restored mempool still contains tx2")
 	}
+	if err := mp.AddTx(tx2); err != nil {
+		t.Fatalf("AddTx(tx2) after restore: %v", err)
+	}
+	if mp.usedBytes != len(tx1)+len(tx2) {
+		t.Fatalf("usedBytes=%d, want %d after post-restore AddTx", mp.usedBytes, len(tx1)+len(tx2))
+	}
 }
 
 func TestRestoreMempoolSnapshotRejectsInvalidEntriesWithoutMutation(t *testing.T) {

--- a/clients/go/node/mempool_test.go
+++ b/clients/go/node/mempool_test.go
@@ -692,18 +692,17 @@ func TestMempoolDoubleSpend(t *testing.T) {
 	}
 }
 
-func TestMempoolFullEvictsLowestPriority(t *testing.T) {
+func TestMempoolFullRejectsWithoutEviction(t *testing.T) {
 	fromKey := mustNodeMLDSA87Keypair(t)
 	toKey := mustNodeMLDSA87Keypair(t)
 	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
 	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
 	st, outpoints := testSpendableChainState(fromAddress, []uint64{100, 100, 100})
 
-	mp, err := NewMempool(st, nil, devnetGenesisChainID)
+	mp, err := NewMempoolWithConfig(st, nil, devnetGenesisChainID, MempoolConfig{MaxTransactions: 2})
 	if err != nil {
 		t.Fatalf("new mempool: %v", err)
 	}
-	mp.maxTxs = 2
 
 	txLow := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 1, 1, fromKey, fromAddress, toAddress)
 	txHigh := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[1]}, 90, 4, 2, fromKey, fromAddress, toAddress)
@@ -715,11 +714,14 @@ func TestMempoolFullEvictsLowestPriority(t *testing.T) {
 	if err := mp.AddTx(txHigh); err != nil {
 		t.Fatalf("AddTx(high): %v", err)
 	}
-	if err := mp.AddTx(txBetter); err != nil {
-		t.Fatalf("AddTx(better) should evict low priority entry: %v", err)
+	if err := mp.AddTx(txBetter); err == nil || !strings.Contains(err.Error(), "mempool transaction count limit reached") {
+		t.Fatalf("expected count-limit rejection without eviction, got %v", err)
 	}
 	if got := mp.Len(); got != 2 {
 		t.Fatalf("mempool len=%d, want 2", got)
+	}
+	if mp.usedBytes != len(txLow)+len(txHigh) {
+		t.Fatalf("usedBytes=%d, want %d", mp.usedBytes, len(txLow)+len(txHigh))
 	}
 
 	selected := mp.SelectTransactions(3, 1<<20)
@@ -728,137 +730,158 @@ func TestMempoolFullEvictsLowestPriority(t *testing.T) {
 	}
 	got := []string{txIDHex(t, selected[0]), txIDHex(t, selected[1])}
 	wantHigh := txIDHex(t, txHigh)
-	wantBetter := txIDHex(t, txBetter)
 	wantLow := txIDHex(t, txLow)
-	if got[0] != wantHigh || got[1] != wantBetter {
-		t.Fatalf("selected=%v, want [%s %s]", got, wantHigh, wantBetter)
+	if got[0] != wantHigh || got[1] != wantLow {
+		t.Fatalf("selected=%v, want [%s %s]", got, wantHigh, wantLow)
 	}
-	if got[0] == wantLow || got[1] == wantLow {
-		t.Fatalf("lowest-priority tx should have been evicted: %v", got)
-	}
-}
-
-func TestMempoolFullRejectsWorsePriorityCandidate(t *testing.T) {
-	fromKey := mustNodeMLDSA87Keypair(t)
-	toKey := mustNodeMLDSA87Keypair(t)
-	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
-	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
-	st, outpoints := testSpendableChainState(fromAddress, []uint64{100, 100, 100})
-
-	mp, err := NewMempool(st, nil, devnetGenesisChainID)
-	if err != nil {
-		t.Fatalf("new mempool: %v", err)
-	}
-	mp.maxTxs = 2
-
-	txLow := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 2, 1, fromKey, fromAddress, toAddress)
-	txHigh := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[1]}, 90, 4, 2, fromKey, fromAddress, toAddress)
-	txWorse := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[2]}, 90, 1, 3, fromKey, fromAddress, toAddress)
-
-	if err := mp.AddTx(txLow); err != nil {
-		t.Fatalf("AddTx(low): %v", err)
-	}
-	if err := mp.AddTx(txHigh); err != nil {
-		t.Fatalf("AddTx(high): %v", err)
-	}
-	if err := mp.AddTx(txWorse); err == nil || !strings.Contains(err.Error(), "mempool full") {
-		t.Fatalf("expected mempool full rejection, got %v", err)
-	}
-	if got := mp.Len(); got != 2 {
-		t.Fatalf("mempool len=%d, want 2", got)
-	}
-
-	selected := mp.SelectTransactions(3, 1<<20)
-	got := []string{txIDHex(t, selected[0]), txIDHex(t, selected[1])}
-	if got[0] != txIDHex(t, txHigh) || got[1] != txIDHex(t, txLow) {
-		t.Fatalf("selected=%v, want [%s %s]", got, txIDHex(t, txHigh), txIDHex(t, txLow))
+	if mp.Contains(txID(t, txBetter)) {
+		t.Fatalf("rejected over-cap tx entered mempool")
 	}
 }
 
-func TestMempoolFullRejectPreservesFutureEvictionCandidate(t *testing.T) {
-	fromKey := mustNodeMLDSA87Keypair(t)
-	toKey := mustNodeMLDSA87Keypair(t)
-	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
-	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
-	st, outpoints := testSpendableChainState(fromAddress, []uint64{100, 100, 100, 100})
-
-	mp, err := NewMempool(st, nil, devnetGenesisChainID)
-	if err != nil {
-		t.Fatalf("new mempool: %v", err)
-	}
-	mp.maxTxs = 2
-
-	txLow := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 2, 1, fromKey, fromAddress, toAddress)
-	txHigh := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[1]}, 90, 4, 2, fromKey, fromAddress, toAddress)
-	txWorse := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[2]}, 90, 1, 3, fromKey, fromAddress, toAddress)
-	txBetter := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[3]}, 90, 3, 4, fromKey, fromAddress, toAddress)
-
-	if err := mp.AddTx(txLow); err != nil {
-		t.Fatalf("AddTx(low): %v", err)
-	}
-	if err := mp.AddTx(txHigh); err != nil {
-		t.Fatalf("AddTx(high): %v", err)
-	}
-	if err := mp.AddTx(txWorse); err == nil || !strings.Contains(err.Error(), "mempool full") {
-		t.Fatalf("expected mempool full rejection, got %v", err)
-	}
-	if err := mp.AddTx(txBetter); err != nil {
-		t.Fatalf("AddTx(better) should still evict low priority entry after prior reject: %v", err)
-	}
-
-	selected := mp.SelectTransactions(3, 1<<20)
-	got := []string{txIDHex(t, selected[0]), txIDHex(t, selected[1])}
-	if got[0] != txIDHex(t, txHigh) || got[1] != txIDHex(t, txBetter) {
-		t.Fatalf("selected=%v, want [%s %s]", got, txIDHex(t, txHigh), txIDHex(t, txBetter))
-	}
-}
-
-func TestRestoreMempoolSnapshotClearsStaleWorstHeapState(t *testing.T) {
+func TestMempoolByteCapRejectsWithoutMutation(t *testing.T) {
 	fromKey := mustNodeMLDSA87Keypair(t)
 	toKey := mustNodeMLDSA87Keypair(t)
 	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
 	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
 	st, outpoints := testSpendableChainState(fromAddress, []uint64{100, 100})
 
-	mp, err := NewMempool(st, nil, devnetGenesisChainID)
+	tx1 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 2, 1, fromKey, fromAddress, toAddress)
+	tx2 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[1]}, 90, 2, 2, fromKey, fromAddress, toAddress)
+	mp, err := NewMempoolWithConfig(st, nil, devnetGenesisChainID, MempoolConfig{
+		MaxTransactions: 10,
+		MaxBytes:        len(tx1) + len(tx2) - 1,
+	})
 	if err != nil {
 		t.Fatalf("new mempool: %v", err)
 	}
-	mp.maxTxs = 1
 
-	txLow := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 1, 1, fromKey, fromAddress, toAddress)
-	txBetter := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[1]}, 90, 3, 2, fromKey, fromAddress, toAddress)
-	if err := mp.AddTx(txLow); err != nil {
-		t.Fatalf("AddTx(low): %v", err)
+	if err := mp.AddTx(tx1); err != nil {
+		t.Fatalf("AddTx(tx1): %v", err)
+	}
+	if err := mp.AddTx(tx2); err == nil || !strings.Contains(err.Error(), "mempool byte limit exceeded") {
+		t.Fatalf("expected byte-limit rejection, got %v", err)
+	}
+	if got := mp.Len(); got != 1 {
+		t.Fatalf("mempool len=%d, want 1", got)
+	}
+	if mp.usedBytes != len(tx1) {
+		t.Fatalf("usedBytes=%d, want %d", mp.usedBytes, len(tx1))
+	}
+	if mp.Contains(txID(t, tx2)) {
+		t.Fatalf("rejected byte-cap tx entered mempool")
+	}
+}
+
+func TestMempoolByteCapAllowsExactBoundary(t *testing.T) {
+	fromKey := mustNodeMLDSA87Keypair(t)
+	toKey := mustNodeMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{100, 100})
+
+	tx1 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 2, 1, fromKey, fromAddress, toAddress)
+	tx2 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[1]}, 90, 2, 2, fromKey, fromAddress, toAddress)
+	mp, err := NewMempoolWithConfig(st, nil, devnetGenesisChainID, MempoolConfig{
+		MaxTransactions: 10,
+		MaxBytes:        len(tx1) + len(tx2),
+	})
+	if err != nil {
+		t.Fatalf("new mempool: %v", err)
 	}
 
+	if err := mp.AddTx(tx1); err != nil {
+		t.Fatalf("AddTx(tx1): %v", err)
+	}
+	if err := mp.AddTx(tx2); err != nil {
+		t.Fatalf("AddTx(tx2) at exact byte cap: %v", err)
+	}
+	if got := mp.Len(); got != 2 {
+		t.Fatalf("mempool len=%d, want 2", got)
+	}
+	if mp.usedBytes != len(tx1)+len(tx2) {
+		t.Fatalf("usedBytes=%d, want %d", mp.usedBytes, len(tx1)+len(tx2))
+	}
+}
+
+func TestMempoolAdmissionRejectsDoNotMutateByteAccounting(t *testing.T) {
+	fromKey := mustNodeMLDSA87Keypair(t)
+	toKey := mustNodeMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{100, 100})
+
+	mp, err := NewMempoolWithConfig(st, nil, devnetGenesisChainID, MempoolConfig{MaxTransactions: 10})
+	if err != nil {
+		t.Fatalf("new mempool: %v", err)
+	}
+	tx1 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 2, 1, fromKey, fromAddress, toAddress)
+	txDoubleSpend := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 89, 3, 2, fromKey, fromAddress, toAddress)
+	if err := mp.AddTx(tx1); err != nil {
+		t.Fatalf("AddTx(tx1): %v", err)
+	}
+	wantBytes := mp.usedBytes
+	wantLen := mp.Len()
+
+	for _, tc := range []struct {
+		name string
+		raw  []byte
+	}{
+		{name: "duplicate", raw: tx1},
+		{name: "double_spend", raw: txDoubleSpend},
+		{name: "malformed", raw: []byte{0xde, 0xad}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := mp.AddTx(tc.raw); err == nil {
+				t.Fatalf("expected rejection")
+			}
+			if got := mp.Len(); got != wantLen {
+				t.Fatalf("mempool len=%d, want %d", got, wantLen)
+			}
+			if mp.usedBytes != wantBytes {
+				t.Fatalf("usedBytes=%d, want %d", mp.usedBytes, wantBytes)
+			}
+		})
+	}
+}
+
+func TestRestoreMempoolSnapshotRecomputesByteAccounting(t *testing.T) {
+	fromKey := mustNodeMLDSA87Keypair(t)
+	toKey := mustNodeMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{100, 100})
+
+	tx1 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 2, 1, fromKey, fromAddress, toAddress)
+	tx2 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[1]}, 90, 2, 2, fromKey, fromAddress, toAddress)
+	mp, err := NewMempoolWithConfig(st, nil, devnetGenesisChainID, MempoolConfig{
+		MaxTransactions: 10,
+		MaxBytes:        len(tx1) + len(tx2),
+	})
+	if err != nil {
+		t.Fatalf("new mempool: %v", err)
+	}
+	if err := mp.AddTx(tx1); err != nil {
+		t.Fatalf("AddTx(tx1): %v", err)
+	}
 	snapshot, err := snapshotMempool(mp)
 	if err != nil {
 		t.Fatalf("snapshotMempool: %v", err)
 	}
-
-	staleTxid := [32]byte{0xee}
-	staleItem := &mempoolHeapItem{txid: staleTxid, heapID: 99, index: 0}
-	mp.worstHeap = mempoolWorstHeap{staleItem}
-	mp.heapItems = map[[32]byte]*mempoolHeapItem{staleTxid: staleItem}
-	mp.heapSeqs = map[[32]byte]uint64{staleTxid: 99}
-
+	if err := mp.AddTx(tx2); err != nil {
+		t.Fatalf("AddTx(tx2): %v", err)
+	}
 	if err := restoreMempoolSnapshot(mp, snapshot); err != nil {
 		t.Fatalf("restoreMempoolSnapshot: %v", err)
 	}
-	if len(mp.worstHeap) != 0 || len(mp.heapItems) != 0 || len(mp.heapSeqs) != 0 {
-		t.Fatalf("restore must clear heap state: heap=%d items=%d seqs=%d", len(mp.worstHeap), len(mp.heapItems), len(mp.heapSeqs))
+	if got := mp.Len(); got != 1 {
+		t.Fatalf("mempool len=%d, want 1", got)
 	}
-	if err := mp.AddTx(txBetter); err != nil {
-		t.Fatalf("AddTx(better) after restore should evict low priority entry: %v", err)
+	if mp.usedBytes != len(tx1) {
+		t.Fatalf("usedBytes=%d, want %d", mp.usedBytes, len(tx1))
 	}
-
-	selected := mp.SelectTransactions(2, 1<<20)
-	if len(selected) != 1 {
-		t.Fatalf("selected count=%d, want 1", len(selected))
-	}
-	if txIDHex(t, selected[0]) != txIDHex(t, txBetter) {
-		t.Fatalf("selected=%s, want %s", txIDHex(t, selected[0]), txIDHex(t, txBetter))
+	if mp.Contains(txID(t, tx2)) {
+		t.Fatalf("restored mempool still contains tx2")
 	}
 }
 
@@ -926,11 +949,8 @@ func TestMempoolEviction(t *testing.T) {
 	if got := mp.Len(); got != 0 {
 		t.Fatalf("mempool len=%d, want 0", got)
 	}
-	if got := len(mp.worstHeap); got != 0 {
-		t.Fatalf("worstHeap len=%d, want 0", got)
-	}
-	if got := len(mp.heapItems); got != 0 {
-		t.Fatalf("heapItems len=%d, want 0", got)
+	if got := mp.usedBytes; got != 0 {
+		t.Fatalf("usedBytes=%d, want 0", got)
 	}
 }
 
@@ -1278,11 +1298,17 @@ func mustBuildCoreExtSpendTx(
 
 func txIDHex(t *testing.T, txBytes []byte) string {
 	t.Helper()
+	txid := txID(t, txBytes)
+	return fmt.Sprintf("%x", txid[:])
+}
+
+func txID(t *testing.T, txBytes []byte) [32]byte {
+	t.Helper()
 	_, txid, _, _, err := consensus.ParseTx(txBytes)
 	if err != nil {
 		t.Fatalf("ParseTx: %v", err)
 	}
-	return fmt.Sprintf("%x", txid[:])
+	return txid
 }
 
 func TestTxAdmitErrorKinds(t *testing.T) {
@@ -1339,17 +1365,15 @@ func TestTxAdmitErrorKinds(t *testing.T) {
 
 	t.Run("mempool full unavailable", func(t *testing.T) {
 		st, outpoints := testSpendableChainState(fromAddress, []uint64{100, 100})
-		mp, err := NewMempool(st, nil, devnetGenesisChainID)
+		mp, err := NewMempoolWithConfig(st, nil, devnetGenesisChainID, MempoolConfig{MaxTransactions: 1})
 		if err != nil {
 			t.Fatalf("new mempool: %v", err)
 		}
-		mp.maxTxs = 1
 		tx1 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 5, 1, fromKey, fromAddress, toAddress)
 		tx2 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[1]}, 90, 1, 2, fromKey, fromAddress, toAddress)
 		if err := mp.AddTx(tx1); err != nil {
 			t.Fatalf("first AddTx: %v", err)
 		}
-		// tx2 has lower fee-rate than tx1 so cannot evict → pool full
 		err = mp.AddTx(tx2)
 		assertKind(t, err, TxAdmitUnavailable)
 	})
@@ -1410,9 +1434,8 @@ func TestMempoolAllTxIDsReturnsEveryEntry(t *testing.T) {
 }
 
 func TestMempoolAllTxIDsSortedDeterministic(t *testing.T) {
-	// Copilot thread on PR #1199: verify that sorting AllTxIDs produces
-	// deterministic lexicographic order (handler sorts; this test proves
-	// the data is sortable and the result matches expectation).
+	// Verify that sorting AllTxIDs produces deterministic lexicographic order;
+	// handlers sort the IDs before presenting them.
 	fromKey := mustNodeMLDSA87Keypair(t)
 	toKey := mustNodeMLDSA87Keypair(t)
 	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())

--- a/clients/go/node/mempool_test.go
+++ b/clients/go/node/mempool_test.go
@@ -885,6 +885,139 @@ func TestRestoreMempoolSnapshotRecomputesByteAccounting(t *testing.T) {
 	}
 }
 
+func TestRestoreMempoolSnapshotRejectsInvalidEntriesWithoutMutation(t *testing.T) {
+	fromKey := mustNodeMLDSA87Keypair(t)
+	toKey := mustNodeMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{100})
+
+	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 2, 1, fromKey, fromAddress, toAddress)
+	mp, err := NewMempoolWithConfig(st, nil, devnetGenesisChainID, MempoolConfig{
+		MaxTransactions: 10,
+		MaxBytes:        len(txBytes) * 2,
+	})
+	if err != nil {
+		t.Fatalf("new mempool: %v", err)
+	}
+	if err := mp.AddTx(txBytes); err != nil {
+		t.Fatalf("AddTx: %v", err)
+	}
+	snapshot, err := snapshotMempool(mp)
+	if err != nil {
+		t.Fatalf("snapshotMempool: %v", err)
+	}
+	wantTxID := txID(t, txBytes)
+	wantBytes := mp.usedBytes
+	txDoubleSpend := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 89, 3, 2, fromKey, fromAddress, toAddress)
+	doubleSpendID := txID(t, txDoubleSpend)
+	snapshotEntry := func(txRaw []byte, id [32]byte, inputs []consensus.Outpoint) mempoolEntry {
+		return mempoolEntry{
+			raw:    append([]byte(nil), txRaw...),
+			txid:   id,
+			inputs: append([]consensus.Outpoint(nil), inputs...),
+			size:   len(txRaw),
+		}
+	}
+	cloneSnapshotForTest := func(base mempoolSnapshot) mempoolSnapshot {
+		entries := make([]mempoolEntry, 0, len(base.entries))
+		for i := range base.entries {
+			entries = append(entries, cloneMempoolEntry(&base.entries[i]))
+		}
+		return mempoolSnapshot{entries: entries}
+	}
+	withEditedFirst := func(edit func(*mempoolEntry)) func(mempoolSnapshot) mempoolSnapshot {
+		return func(base mempoolSnapshot) mempoolSnapshot {
+			bad := cloneSnapshotForTest(base)
+			edit(&bad.entries[0])
+			return bad
+		}
+	}
+
+	for _, tc := range []struct {
+		name   string
+		mutate func(mempoolSnapshot) mempoolSnapshot
+		want   string
+	}{
+		{
+			name:   "zero_size",
+			mutate: withEditedFirst(func(entry *mempoolEntry) { entry.size = 0 }),
+			want:   "invalid mempool snapshot entry size",
+		},
+		{
+			name:   "size_mismatch",
+			mutate: withEditedFirst(func(entry *mempoolEntry) { entry.size = len(entry.raw) + 1 }),
+			want:   "mempool snapshot entry size mismatch",
+		},
+		{
+			name:   "malformed_raw",
+			mutate: withEditedFirst(func(entry *mempoolEntry) { entry.raw, entry.size = []byte{0xde, 0xad}, 2 }),
+			want:   "invalid mempool snapshot entry raw",
+		},
+		{
+			name: "trailing_bytes",
+			mutate: withEditedFirst(func(entry *mempoolEntry) {
+				entry.raw = append(entry.raw, 0)
+				entry.size = len(entry.raw)
+			}),
+			want: "mempool snapshot entry has trailing bytes",
+		},
+		{
+			name: "txid_mismatch",
+			mutate: withEditedFirst(func(entry *mempoolEntry) {
+				entry.txid[0] ^= 0x01
+			}),
+			want: "mempool snapshot entry txid mismatch",
+		},
+		{
+			name:   "input_count_mismatch",
+			mutate: withEditedFirst(func(entry *mempoolEntry) { entry.inputs = nil }),
+			want:   "mempool snapshot entry input count mismatch",
+		},
+		{
+			name: "input_mismatch",
+			mutate: withEditedFirst(func(entry *mempoolEntry) {
+				entry.inputs[0].Vout++
+			}),
+			want: "mempool snapshot entry input mismatch",
+		},
+		{
+			name: "duplicate_txid",
+			mutate: func(base mempoolSnapshot) mempoolSnapshot {
+				bad := cloneSnapshotForTest(base)
+				bad.entries = append(bad.entries, bad.entries[0])
+				return bad
+			},
+			want: "duplicate mempool snapshot txid",
+		},
+		{
+			name: "duplicate_spender",
+			mutate: func(base mempoolSnapshot) mempoolSnapshot {
+				bad := cloneSnapshotForTest(base)
+				bad.entries = append(bad.entries, snapshotEntry(txDoubleSpend, doubleSpendID, []consensus.Outpoint{outpoints[0]}))
+				return bad
+			},
+			want: "duplicate mempool snapshot spender",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			bad := tc.mutate(snapshot)
+			if err := restoreMempoolSnapshot(mp, bad); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected %q rejection, got %v", tc.want, err)
+			}
+			if got := mp.Len(); got != 1 {
+				t.Fatalf("mempool len=%d, want 1 after rejected restore", got)
+			}
+			if !mp.Contains(wantTxID) {
+				t.Fatalf("rejected restore removed existing tx %x", wantTxID)
+			}
+			if mp.usedBytes != wantBytes {
+				t.Fatalf("usedBytes=%d, want %d after rejected restore", mp.usedBytes, wantBytes)
+			}
+		})
+	}
+}
+
 func TestMempoolAddTxHeightOverflow(t *testing.T) {
 	st := &ChainState{HasTip: true, Height: ^uint64(0)} // MaxUint64
 	mp, err := NewMempool(st, nil, devnetGenesisChainID)

--- a/clients/go/node/sync_mempool.go
+++ b/clients/go/node/sync_mempool.go
@@ -90,7 +90,7 @@ func validateMempoolSnapshotEntry(entry mempoolEntry) error {
 		return fmt.Errorf("mempool snapshot entry txid mismatch: entry=%x raw=%x", entry.txid, txid)
 	}
 	if len(entry.inputs) != len(tx.Inputs) {
-		return fmt.Errorf("mempool snapshot entry input count mismatch for txid %x: entry=%d raw=%d", entry.txid, len(entry.inputs), len(tx.Inputs))
+		return fmt.Errorf("mempool snapshot entry input count mismatch for txid %x: entry=%d tx=%d", entry.txid, len(entry.inputs), len(tx.Inputs))
 	}
 	for i, in := range tx.Inputs {
 		want := consensus.Outpoint{Txid: in.PrevTxid, Vout: in.PrevVout}

--- a/clients/go/node/sync_mempool.go
+++ b/clients/go/node/sync_mempool.go
@@ -32,10 +32,10 @@ func restoreMempoolSnapshot(m *Mempool, snapshot mempoolSnapshot) error {
 	if m == nil {
 		return nil
 	}
-	m.mu.RLock()
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	maxTxs := m.maxTxs
 	maxBytes := m.maxBytes
-	m.mu.RUnlock()
 	if maxTxs <= 0 || maxBytes <= 0 {
 		return fmt.Errorf("invalid mempool snapshot restore limits: max_txs=%d max_bytes=%d", maxTxs, maxBytes)
 	}
@@ -66,8 +66,6 @@ func restoreMempoolSnapshot(m *Mempool, snapshot mempoolSnapshot) error {
 		txs[entryCopy.txid] = &entryCopy
 		usedBytes += entryCopy.size
 	}
-	m.mu.Lock()
-	defer m.mu.Unlock()
 	m.txs = txs
 	m.spenders = spenders
 	m.usedBytes = usedBytes

--- a/clients/go/node/sync_mempool.go
+++ b/clients/go/node/sync_mempool.go
@@ -35,12 +35,13 @@ func restoreMempoolSnapshot(m *Mempool, snapshot mempoolSnapshot) error {
 	defer m.mu.Unlock()
 	m.txs = make(map[[32]byte]*mempoolEntry, len(snapshot.entries))
 	m.spenders = make(map[consensus.Outpoint][32]byte)
-	m.worstHeap = make(mempoolWorstHeap, 0, len(snapshot.entries))
-	m.heapItems = make(map[[32]byte]*mempoolHeapItem, len(snapshot.entries))
-	m.heapSeqs = make(map[[32]byte]uint64, len(snapshot.entries))
+	m.usedBytes = 0
 	for _, item := range snapshot.entries {
 		entry := cloneMempoolEntry(&item)
 		m.txs[entry.txid] = &entry
+		if entry.size > 0 {
+			m.usedBytes += entry.size
+		}
 		for _, op := range entry.inputs {
 			m.spenders[op] = entry.txid
 		}

--- a/clients/go/node/sync_mempool.go
+++ b/clients/go/node/sync_mempool.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"bytes"
+	"fmt"
 	"sort"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
@@ -31,19 +32,59 @@ func restoreMempoolSnapshot(m *Mempool, snapshot mempoolSnapshot) error {
 	if m == nil {
 		return nil
 	}
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.txs = make(map[[32]byte]*mempoolEntry, len(snapshot.entries))
-	m.spenders = make(map[consensus.Outpoint][32]byte)
-	m.usedBytes = 0
+	txs := make(map[[32]byte]*mempoolEntry, len(snapshot.entries))
+	spenders := make(map[consensus.Outpoint][32]byte)
+	usedBytes := 0
 	for _, item := range snapshot.entries {
 		entry := cloneMempoolEntry(&item)
-		m.txs[entry.txid] = &entry
-		if entry.size > 0 {
-			m.usedBytes += entry.size
+		if err := validateMempoolSnapshotEntry(entry); err != nil {
+			return err
+		}
+		if _, exists := txs[entry.txid]; exists {
+			return fmt.Errorf("duplicate mempool snapshot txid %x", entry.txid)
 		}
 		for _, op := range entry.inputs {
-			m.spenders[op] = entry.txid
+			if existing, exists := spenders[op]; exists {
+				return fmt.Errorf("duplicate mempool snapshot spender txid=%x vout=%d existing=%x new=%x", op.Txid, op.Vout, existing, entry.txid)
+			}
+			spenders[op] = entry.txid
+		}
+		entryCopy := entry
+		txs[entryCopy.txid] = &entryCopy
+		usedBytes += entryCopy.size
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.txs = txs
+	m.spenders = spenders
+	m.usedBytes = usedBytes
+	return nil
+}
+
+func validateMempoolSnapshotEntry(entry mempoolEntry) error {
+	if entry.size <= 0 {
+		return fmt.Errorf("invalid mempool snapshot entry size for txid %x: size=%d raw_len=%d", entry.txid, entry.size, len(entry.raw))
+	}
+	if entry.size != len(entry.raw) {
+		return fmt.Errorf("mempool snapshot entry size mismatch for txid %x: size=%d raw_len=%d", entry.txid, entry.size, len(entry.raw))
+	}
+	tx, txid, _, consumed, err := consensus.ParseTx(entry.raw)
+	if err != nil {
+		return fmt.Errorf("invalid mempool snapshot entry raw for txid %x: %w", entry.txid, err)
+	}
+	if consumed != len(entry.raw) {
+		return fmt.Errorf("mempool snapshot entry has trailing bytes for txid %x: consumed=%d raw_len=%d", entry.txid, consumed, len(entry.raw))
+	}
+	if txid != entry.txid {
+		return fmt.Errorf("mempool snapshot entry txid mismatch: entry=%x raw=%x", entry.txid, txid)
+	}
+	if len(entry.inputs) != len(tx.Inputs) {
+		return fmt.Errorf("mempool snapshot entry input count mismatch for txid %x: entry=%d raw=%d", entry.txid, len(entry.inputs), len(tx.Inputs))
+	}
+	for i, in := range tx.Inputs {
+		want := consensus.Outpoint{Txid: in.PrevTxid, Vout: in.PrevVout}
+		if entry.inputs[i] != want {
+			return fmt.Errorf("mempool snapshot entry input mismatch for txid %x at index=%d", entry.txid, i)
 		}
 	}
 	return nil

--- a/clients/go/node/sync_mempool.go
+++ b/clients/go/node/sync_mempool.go
@@ -32,6 +32,13 @@ func restoreMempoolSnapshot(m *Mempool, snapshot mempoolSnapshot) error {
 	if m == nil {
 		return nil
 	}
+	m.mu.RLock()
+	maxTxs := m.maxTxs
+	maxBytes := m.maxBytes
+	m.mu.RUnlock()
+	if maxTxs <= 0 || maxBytes <= 0 {
+		return fmt.Errorf("invalid mempool snapshot restore limits: max_txs=%d max_bytes=%d", maxTxs, maxBytes)
+	}
 	txs := make(map[[32]byte]*mempoolEntry, len(snapshot.entries))
 	spenders := make(map[consensus.Outpoint][32]byte)
 	usedBytes := 0
@@ -42,6 +49,12 @@ func restoreMempoolSnapshot(m *Mempool, snapshot mempoolSnapshot) error {
 		}
 		if _, exists := txs[entry.txid]; exists {
 			return fmt.Errorf("duplicate mempool snapshot txid %x", entry.txid)
+		}
+		if len(txs) >= maxTxs {
+			return fmt.Errorf("mempool snapshot exceeds transaction cap: count=%d max=%d", len(txs)+1, maxTxs)
+		}
+		if entry.size > maxBytes || usedBytes > maxBytes-entry.size {
+			return fmt.Errorf("mempool snapshot exceeds byte cap: used=%d entry=%d max=%d", usedBytes, entry.size, maxBytes)
 		}
 		for _, op := range entry.inputs {
 			if existing, exists := spenders[op]; exists {


### PR DESCRIPTION
Scope:
- Go canonical mempool enforces configured transaction-count and serialized-byte caps as reject-only admission boundaries.
- Go rollback restore rebuilds canonical mempool state under the same count/byte/accounting invariants.
- Go node config/CLI exposes those limits and wires them into canonical mempool construction.
- Go tests cover count cap, byte cap, exact byte boundary, reject no-mutation, restore validation, and mempool byte accounting after restore/removal.

Architecture class: B
System boundary: Go node mempool admission/accounting plus rubin-node config/flag wiring.
Single invariant or single contract delta: canonical Go mempool admission and restore reject over configured count/byte capacity without mutating existing mempool state.
Non-goals: Rust, eviction policy, fee ranking redesign, metrics, compact relay, DA relay, devnet harness expansion.
Class-change stop rule: any eviction/ranking policy, cross-client parity redesign, or new runtime/harness contract is out of this PR.
What this PR is NOT allowed to redesign: miner selection policy, relay protocol, consensus validation, or Rust txpool behavior.

Closes #1285.

<!-- rubin-agent-meta actor=gpt5 action=pr-create via=cl branch=codex/q-go-mempool-capacity-bytes-eviction-config-01 wt=rubin-protocol utc=2026-04-25T22:56:49Z -->


<!-- rubin-agent-meta actor=gpt5 action=pr-edit via=cl branch=codex/q-go-mempool-capacity-bytes-eviction-config-01 wt=rubin-protocol utc=2026-04-26T06:21:41Z -->
