### PR TITLE
node: add bounded mempool bytes gauge and admit counter (#1288)

### DIFF
--- a/clients/go/cmd/rubin-node/http_rpc.go
+++ b/clients/go/cmd/rubin-node/http_rpc.go
@@ -1021,6 +1021,8 @@ func renderPrometheusMetrics(state *devnetRPCState) string {
 		inIBD           float64
 		peerCount       float64
 		mempoolTxs      float64
+		mempoolBytes    float64
+		mempoolAdmit    node.MempoolAdmissionCounts
 		routeStatus     map[string]uint64
 		submitByResult  map[string]uint64
 	)
@@ -1038,6 +1040,14 @@ func renderPrometheusMetrics(state *devnetRPCState) string {
 	}
 	if state != nil && state.mempool != nil {
 		mempoolTxs = float64(state.mempool.Len())
+		// BytesUsed is a scrape-time read of the mempool's existing
+		// usedBytes accounting (already maintained on every AddTx /
+		// RemoveTx). AdmissionCounts is a snapshot of the per-outcome
+		// counters that AddTx bumps at the final return path — read
+		// here is purely a Load(), no increment, so rendering /metrics
+		// repeatedly cannot perturb the counters.
+		mempoolBytes = float64(state.mempool.BytesUsed())
+		mempoolAdmit = state.mempool.AdmissionCounts()
 	}
 	if state != nil && state.metrics != nil {
 		routeStatus, submitByResult = state.metrics.snapshot()
@@ -1063,6 +1073,19 @@ func renderPrometheusMetrics(state *devnetRPCState) string {
 		"# HELP rubin_node_mempool_txs Number of transactions currently in the mempool.",
 		"# TYPE rubin_node_mempool_txs gauge",
 		fmt.Sprintf("rubin_node_mempool_txs %.0f", mempoolTxs),
+		"# HELP rubin_node_mempool_bytes Raw byte size of transactions currently in the mempool.",
+		"# TYPE rubin_node_mempool_bytes gauge",
+		fmt.Sprintf("rubin_node_mempool_bytes %.0f", mempoolBytes),
+		"# HELP rubin_node_mempool_admit_total Total mempool AddTx outcomes by result label.",
+		"# TYPE rubin_node_mempool_admit_total counter",
+		// Fixed rendering order: accepted, conflict, rejected,
+		// unavailable. Buckets are the closed enum
+		// MempoolAdmissionCounts; no free-form labels are emitted from
+		// this surface.
+		fmt.Sprintf(`rubin_node_mempool_admit_total{result="accepted"} %d`, mempoolAdmit.Accepted),
+		fmt.Sprintf(`rubin_node_mempool_admit_total{result="conflict"} %d`, mempoolAdmit.Conflict),
+		fmt.Sprintf(`rubin_node_mempool_admit_total{result="rejected"} %d`, mempoolAdmit.Rejected),
+		fmt.Sprintf(`rubin_node_mempool_admit_total{result="unavailable"} %d`, mempoolAdmit.Unavailable),
 		"# HELP rubin_node_rpc_requests_total Total HTTP RPC requests by route and status.",
 		"# TYPE rubin_node_rpc_requests_total counter",
 	)

--- a/clients/go/cmd/rubin-node/http_rpc_test.go
+++ b/clients/go/cmd/rubin-node/http_rpc_test.go
@@ -830,10 +830,101 @@ func TestRenderPrometheusMetricsHandlesNilStateAndNilMetrics(t *testing.T) {
 		"rubin_node_in_ibd 0",
 		"rubin_node_peer_count 0",
 		"rubin_node_mempool_txs 0",
+		"rubin_node_mempool_bytes 0",
+		`rubin_node_mempool_admit_total{result="accepted"} 0`,
+		`rubin_node_mempool_admit_total{result="conflict"} 0`,
+		`rubin_node_mempool_admit_total{result="rejected"} 0`,
+		`rubin_node_mempool_admit_total{result="unavailable"} 0`,
 	} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("missing %q in metrics body %q", want, body)
 		}
+	}
+}
+
+// TestRenderPrometheusMetricsMempoolBytesAndAdmitTotal pins the new
+// scrape surface added by #1288: rubin_node_mempool_bytes (gauge,
+// reflects mempool.BytesUsed at scrape) and the four bounded
+// rubin_node_mempool_admit_total{result=...} counter buckets in a
+// fixed rendering order. The test bumps three buckets via real AddTx
+// outcomes (accepted via valid tx, conflict via duplicate tx,
+// rejected via trailing-bytes parse error), reads /metrics, and
+// asserts (a) every bucket line is present in the fixed
+// accepted/conflict/rejected/unavailable order, (b) values match the
+// counter snapshot, (c) BytesUsed reflects the byte size of the
+// accepted transaction. The unavailable bucket stays at 0 because the
+// test mempool has a non-nil chainstate.
+func TestRenderPrometheusMetricsMempoolBytesAndAdmitTotal(t *testing.T) {
+	fromKey := mustRPCMLDSA87Keypair(t)
+	toKey := mustRPCMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+	state, input, utxos := mustRPCStateWithSpendableUTXO(t, fromAddress, nil)
+	txBytes, _ := mustRPCSignedTransferTx(t, utxos, input, fromKey, toAddress)
+	if err := state.mempool.AddTx(txBytes); err != nil {
+		t.Fatalf("AddTx accept: %v", err)
+	}
+	// Bump conflict bucket via duplicate AddTx.
+	if err := state.mempool.AddTx(txBytes); err == nil {
+		t.Fatalf("duplicate AddTx unexpectedly accepted")
+	}
+	// Bump rejected bucket via trailing-bytes parse error.
+	bad := append([]byte{}, txBytes...)
+	bad = append(bad, 0x00)
+	if err := state.mempool.AddTx(bad); err == nil {
+		t.Fatalf("malformed AddTx unexpectedly accepted")
+	}
+
+	body := renderPrometheusMetrics(state)
+	for _, want := range []string{
+		"# TYPE rubin_node_mempool_bytes gauge",
+		"# TYPE rubin_node_mempool_admit_total counter",
+		`rubin_node_mempool_admit_total{result="accepted"} 1`,
+		`rubin_node_mempool_admit_total{result="conflict"} 1`,
+		`rubin_node_mempool_admit_total{result="rejected"} 1`,
+		`rubin_node_mempool_admit_total{result="unavailable"} 0`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("missing %q in metrics body %q", want, body)
+		}
+	}
+	// Fixed rendering order: accepted < conflict < rejected < unavailable.
+	idxAccepted := strings.Index(body, `rubin_node_mempool_admit_total{result="accepted"}`)
+	idxConflict := strings.Index(body, `rubin_node_mempool_admit_total{result="conflict"}`)
+	idxRejected := strings.Index(body, `rubin_node_mempool_admit_total{result="rejected"}`)
+	idxUnavailable := strings.Index(body, `rubin_node_mempool_admit_total{result="unavailable"}`)
+	if !(idxAccepted >= 0 && idxAccepted < idxConflict && idxConflict < idxRejected && idxRejected < idxUnavailable) {
+		t.Fatalf("admit_total buckets not in fixed accepted<conflict<rejected<unavailable order; positions %d,%d,%d,%d body=%q", idxAccepted, idxConflict, idxRejected, idxUnavailable, body)
+	}
+	// BytesUsed reflected as gauge: equals the raw byte size of the
+	// single accepted transaction.
+	if !strings.Contains(body, fmt.Sprintf("rubin_node_mempool_bytes %d", len(txBytes))) {
+		t.Fatalf("rubin_node_mempool_bytes does not reflect BytesUsed=%d in body %q", len(txBytes), body)
+	}
+}
+
+// TestRenderPrometheusMetricsTwiceDoesNotIncrementAdmitCounters pins
+// the scrape-time-no-increment contract: rendering /metrics is a pure
+// counter Load() and MUST NOT bump any of the four
+// rubin_node_mempool_admit_total buckets. After one accepted AddTx,
+// rendering twice and re-snapshotting AdmissionCounts must yield the
+// SAME accepted=1 value.
+func TestRenderPrometheusMetricsTwiceDoesNotIncrementAdmitCounters(t *testing.T) {
+	fromKey := mustRPCMLDSA87Keypair(t)
+	toKey := mustRPCMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+	state, input, utxos := mustRPCStateWithSpendableUTXO(t, fromAddress, nil)
+	txBytes, _ := mustRPCSignedTransferTx(t, utxos, input, fromKey, toAddress)
+	if err := state.mempool.AddTx(txBytes); err != nil {
+		t.Fatalf("AddTx: %v", err)
+	}
+	pre := state.mempool.AdmissionCounts()
+	_ = renderPrometheusMetrics(state)
+	_ = renderPrometheusMetrics(state)
+	post := state.mempool.AdmissionCounts()
+	if pre != post {
+		t.Fatalf("AdmissionCounts changed across two /metrics renders: pre=%+v post=%+v (scrape-time increment regression)", pre, post)
 	}
 }
 

--- a/clients/go/cmd/rubin-node/http_rpc_test.go
+++ b/clients/go/cmd/rubin-node/http_rpc_test.go
@@ -893,7 +893,7 @@ func TestRenderPrometheusMetricsMempoolBytesAndAdmitTotal(t *testing.T) {
 	idxConflict := strings.Index(body, `rubin_node_mempool_admit_total{result="conflict"}`)
 	idxRejected := strings.Index(body, `rubin_node_mempool_admit_total{result="rejected"}`)
 	idxUnavailable := strings.Index(body, `rubin_node_mempool_admit_total{result="unavailable"}`)
-	if !(idxAccepted >= 0 && idxAccepted < idxConflict && idxConflict < idxRejected && idxRejected < idxUnavailable) {
+	if idxAccepted < 0 || idxAccepted >= idxConflict || idxConflict >= idxRejected || idxRejected >= idxUnavailable {
 		t.Fatalf("admit_total buckets not in fixed accepted<conflict<rejected<unavailable order; positions %d,%d,%d,%d body=%q", idxAccepted, idxConflict, idxRejected, idxUnavailable, body)
 	}
 	// BytesUsed reflected as gauge: equals the raw byte size of the

--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -283,10 +283,11 @@ func (m *Mempool) AddTx(txBytes []byte) (retErr error) {
 	if m == nil {
 		return txAdmitUnavailable("nil mempool")
 	}
-	// Single defer bumps exactly one admission counter per call based
-	// on the final return value. Registered AFTER the nil-receiver
-	// guard above so a nil mempool still returns the typed unavailable
-	// error without attempting to record a counter on nil.
+	// Exactly one admission counter increment per non-nil-receiver call,
+	// based on the final return value. Registered AFTER the nil-receiver
+	// guard above so a nil mempool returns the typed unavailable error
+	// without recording a counter — there is no mempool instance to own
+	// the metric state.
 	defer func() { m.noteAdmissionResult(retErr) }()
 	if m.chainState == nil {
 		return txAdmitUnavailable("nil chainstate")

--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -7,6 +7,7 @@ import (
 	"math/bits"
 	"sort"
 	"sync"
+	"sync/atomic"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
 )
@@ -36,6 +37,28 @@ type Mempool struct {
 	usedBytes  int
 	txs        map[[32]byte]*mempoolEntry
 	spenders   map[consensus.Outpoint][32]byte
+	// Admission counters are bumped exactly once per AddTx call, at the
+	// final outcome. Lock-free via atomic.Uint64 — no impact on the
+	// admissionMu / mu ordering. Buckets are the closed enum
+	// {accepted, conflict, rejected, unavailable}; any non-TxAdmitError
+	// reachable from AddTx falls into the rejected bucket so no
+	// unbounded label class can grow from this surface.
+	admitAccepted    atomic.Uint64
+	admitConflict    atomic.Uint64
+	admitRejected    atomic.Uint64
+	admitUnavailable atomic.Uint64
+}
+
+// MempoolAdmissionCounts is the snapshot view of admission outcomes.
+// Field order matches the /metrics rendering order in
+// renderPrometheusMetrics so the textual output is stable across
+// readings. Values are monotonic counts since process start; readers
+// MUST treat them as Prometheus counters.
+type MempoolAdmissionCounts struct {
+	Accepted    uint64
+	Conflict    uint64
+	Rejected    uint64
+	Unavailable uint64
 }
 
 type MempoolConfig struct {
@@ -137,6 +160,74 @@ func (m *Mempool) Len() int {
 	return len(m.txs)
 }
 
+// BytesUsed returns the total raw byte size of transactions currently
+// resident in the mempool. Mirrors the existing usedBytes accounting
+// already maintained on every AddTx / RemoveTx path. Returns 0 on a
+// nil receiver so callers (e.g. /metrics rendering) can scrape
+// unconditionally.
+func (m *Mempool) BytesUsed() int {
+	if m == nil {
+		return 0
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.usedBytes
+}
+
+// AdmissionCounts returns a snapshot of the per-outcome admission
+// counters bumped at the final return path of AddTx. Values are
+// monotonic counts since process start. Returns a zero-valued struct
+// on a nil receiver so callers (e.g. /metrics rendering) can scrape
+// unconditionally. Field order matches the fixed metric rendering
+// order in renderPrometheusMetrics.
+func (m *Mempool) AdmissionCounts() MempoolAdmissionCounts {
+	if m == nil {
+		return MempoolAdmissionCounts{}
+	}
+	return MempoolAdmissionCounts{
+		Accepted:    m.admitAccepted.Load(),
+		Conflict:    m.admitConflict.Load(),
+		Rejected:    m.admitRejected.Load(),
+		Unavailable: m.admitUnavailable.Load(),
+	}
+}
+
+// noteAdmissionResult bumps exactly one outcome counter based on the
+// final error returned by AddTx. nil error → accepted; *TxAdmitError →
+// matching kind bucket; any other (currently unreachable) error
+// falls into the rejected bucket as a fail-closed default so this
+// helper never silently swallows a metric and never invents a new
+// label. AddTx wires this via named return + defer so every return
+// path increments exactly one counter.
+func (m *Mempool) noteAdmissionResult(err error) {
+	if m == nil {
+		return
+	}
+	if err == nil {
+		m.admitAccepted.Add(1)
+		return
+	}
+	var admitErr *TxAdmitError
+	if errors.As(err, &admitErr) {
+		switch admitErr.Kind {
+		case TxAdmitConflict:
+			m.admitConflict.Add(1)
+		case TxAdmitRejected:
+			m.admitRejected.Add(1)
+		case TxAdmitUnavailable:
+			m.admitUnavailable.Add(1)
+		default:
+			// Unknown TxAdmitErrorKind — bucket as rejected so we never
+			// grow a new label silently.
+			m.admitRejected.Add(1)
+		}
+		return
+	}
+	// Non-TxAdmitError reaching AddTx is currently unreachable per
+	// audit, but bucket as rejected to keep the outcome closed.
+	m.admitRejected.Add(1)
+}
+
 // AllTxIDs returns the txids of every transaction currently in the mempool.
 // The slice ordering is not guaranteed to be stable between calls.
 func (m *Mempool) AllTxIDs() [][32]byte {
@@ -182,10 +273,15 @@ func (m *Mempool) Contains(txid [32]byte) bool {
 	return ok
 }
 
-func (m *Mempool) AddTx(txBytes []byte) error {
+func (m *Mempool) AddTx(txBytes []byte) (retErr error) {
 	if m == nil {
 		return txAdmitUnavailable("nil mempool")
 	}
+	// Single defer bumps exactly one admission counter per call based
+	// on the final return value. Registered AFTER the nil-receiver
+	// guard above so a nil mempool still returns the typed unavailable
+	// error without attempting to record a counter on nil.
+	defer func() { m.noteAdmissionResult(retErr) }()
 	if m.chainState == nil {
 		return txAdmitUnavailable("nil chainstate")
 	}

--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -42,7 +42,11 @@ type Mempool struct {
 	// admissionMu / mu ordering. Buckets are the closed enum
 	// {accepted, conflict, rejected, unavailable}; any non-TxAdmitError
 	// reachable from AddTx falls into the rejected bucket so no
-	// unbounded label class can grow from this surface.
+	// unbounded label class can grow from this surface. P2P disconnect
+	// metrics are intentionally not tracked here; they are scoped to
+	// issue #1307 because the disconnect boundary needs a separate
+	// semantic audit (no double-count, normal shutdown is not a peer
+	// fault).
 	admitAccepted    atomic.Uint64
 	admitConflict    atomic.Uint64
 	admitRejected    atomic.Uint64

--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -37,16 +37,18 @@ type Mempool struct {
 	usedBytes  int
 	txs        map[[32]byte]*mempoolEntry
 	spenders   map[consensus.Outpoint][32]byte
-	// Admission counters are bumped exactly once per AddTx call, at the
-	// final outcome. Lock-free via atomic.Uint64 — no impact on the
-	// admissionMu / mu ordering. Buckets are the closed enum
-	// {accepted, conflict, rejected, unavailable}; any non-TxAdmitError
-	// reachable from AddTx falls into the rejected bucket so no
-	// unbounded label class can grow from this surface. P2P disconnect
-	// metrics are intentionally not tracked here; they are scoped to
-	// issue #1307 because the disconnect boundary needs a separate
-	// semantic audit (no double-count, normal shutdown is not a peer
-	// fault).
+	// Admission counters are bumped exactly once for each AddTx call on a
+	// non-nil Mempool that reaches the final outcome accounting path.
+	// Nil-receiver calls return before that defer is registered and are
+	// therefore intentionally excluded from these counters. Lock-free via
+	// atomic.Uint64 — no impact on the admissionMu / mu ordering. Buckets
+	// are the closed enum {accepted, conflict, rejected, unavailable};
+	// any non-TxAdmitError reachable from AddTx falls into the rejected
+	// bucket so no unbounded label class can grow from this surface. P2P
+	// disconnect metrics are intentionally not tracked here; they are
+	// scoped to issue #1307 because the disconnect boundary needs a
+	// separate semantic audit (no double-count, normal shutdown is not a
+	// peer fault).
 	admitAccepted    atomic.Uint64
 	admitConflict    atomic.Uint64
 	admitRejected    atomic.Uint64

--- a/clients/go/node/mempool_test.go
+++ b/clients/go/node/mempool_test.go
@@ -1815,3 +1815,173 @@ func TestMempoolContainsNilReceiver(t *testing.T) {
 		t.Fatalf("Contains on nil receiver=true, want false")
 	}
 }
+
+// TestMempoolBytesUsedTracksUsedBytes pins the BytesUsed gauge: empty
+// mempool reports 0; after a successful AddTx BytesUsed reflects the
+// raw transaction byte size accounted in the existing usedBytes field.
+// This is the metric scrape source for rubin_node_mempool_bytes.
+func TestMempoolBytesUsedTracksUsedBytes(t *testing.T) {
+	fromKey := mustNodeMLDSA87Keypair(t)
+	toKey := mustNodeMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{100})
+
+	mp, err := NewMempool(st, nil, devnetGenesisChainID)
+	if err != nil {
+		t.Fatalf("new mempool: %v", err)
+	}
+	if got := mp.BytesUsed(); got != 0 {
+		t.Fatalf("BytesUsed empty=%d, want 0", got)
+	}
+	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 1, 1, fromKey, fromAddress, toAddress)
+	if err := mp.AddTx(txBytes); err != nil {
+		t.Fatalf("AddTx: %v", err)
+	}
+	if got := mp.BytesUsed(); got != len(txBytes) {
+		t.Fatalf("BytesUsed=%d, want %d (raw tx size)", got, len(txBytes))
+	}
+}
+
+// TestMempoolBytesUsedNilReceiver pins the nil-safety contract used by
+// the /metrics rendering path: a nil mempool reports 0 bytes without
+// panicking, so the scrape rendering can call BytesUsed unconditionally.
+func TestMempoolBytesUsedNilReceiver(t *testing.T) {
+	var mp *Mempool
+	if got := mp.BytesUsed(); got != 0 {
+		t.Fatalf("BytesUsed nil receiver=%d, want 0", got)
+	}
+}
+
+// TestMempoolAdmissionCountsAcceptedBumpsExactlyOnce pins that a happy
+// AddTx call increments only the Accepted bucket of the admission
+// counters and leaves the other three buckets at zero.
+func TestMempoolAdmissionCountsAcceptedBumpsExactlyOnce(t *testing.T) {
+	fromKey := mustNodeMLDSA87Keypair(t)
+	toKey := mustNodeMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{100})
+
+	mp, err := NewMempool(st, nil, devnetGenesisChainID)
+	if err != nil {
+		t.Fatalf("new mempool: %v", err)
+	}
+	if got := mp.AdmissionCounts(); got != (MempoolAdmissionCounts{}) {
+		t.Fatalf("AdmissionCounts pre-AddTx=%+v, want zero", got)
+	}
+	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 1, 1, fromKey, fromAddress, toAddress)
+	if err := mp.AddTx(txBytes); err != nil {
+		t.Fatalf("AddTx: %v", err)
+	}
+	got := mp.AdmissionCounts()
+	if got.Accepted != 1 || got.Conflict != 0 || got.Rejected != 0 || got.Unavailable != 0 {
+		t.Fatalf("AdmissionCounts after accepted AddTx=%+v, want only Accepted=1", got)
+	}
+}
+
+// TestMempoolAdmissionCountsConflictBumpsExactlyOnce pins that a
+// duplicate-txid AddTx call routes to the Conflict bucket. The first
+// AddTx accepts; the second AddTx with the same bytes hits the
+// validateAdmissionLocked duplicate-spender path which returns
+// txAdmitConflict.
+func TestMempoolAdmissionCountsConflictBumpsExactlyOnce(t *testing.T) {
+	fromKey := mustNodeMLDSA87Keypair(t)
+	toKey := mustNodeMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{100})
+
+	mp, err := NewMempool(st, nil, devnetGenesisChainID)
+	if err != nil {
+		t.Fatalf("new mempool: %v", err)
+	}
+	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 1, 1, fromKey, fromAddress, toAddress)
+	if err := mp.AddTx(txBytes); err != nil {
+		t.Fatalf("first AddTx: %v", err)
+	}
+	dupErr := mp.AddTx(txBytes)
+	if dupErr == nil {
+		t.Fatalf("duplicate AddTx unexpectedly accepted")
+	}
+	var admitErr *TxAdmitError
+	if !errors.As(dupErr, &admitErr) || admitErr.Kind != TxAdmitConflict {
+		t.Fatalf("duplicate AddTx err=%v (kind=%v), want TxAdmitConflict", dupErr, func() any {
+			if admitErr != nil {
+				return admitErr.Kind
+			}
+			return "<nil>"
+		}())
+	}
+	got := mp.AdmissionCounts()
+	if got.Accepted != 1 {
+		t.Fatalf("AdmissionCounts.Accepted=%d, want 1 (first AddTx)", got.Accepted)
+	}
+	if got.Conflict != 1 || got.Rejected != 0 || got.Unavailable != 0 {
+		t.Fatalf("AdmissionCounts after duplicate=%+v, want Conflict=1", got)
+	}
+}
+
+// TestMempoolAdmissionCountsRejectedBumpsExactlyOnce pins that an
+// AddTx call rejected by the parse-time path (here: trailing bytes
+// after canonical tx) routes to the Rejected bucket via the
+// txAdmitRejected helper inside checkTransactionWithSnapshot.
+func TestMempoolAdmissionCountsRejectedBumpsExactlyOnce(t *testing.T) {
+	fromKey := mustNodeMLDSA87Keypair(t)
+	toKey := mustNodeMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{100})
+
+	mp, err := NewMempool(st, nil, devnetGenesisChainID)
+	if err != nil {
+		t.Fatalf("new mempool: %v", err)
+	}
+	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 1, 1, fromKey, fromAddress, toAddress)
+	// Append a trailing byte to force the "trailing bytes after canonical
+	// tx" reject path inside checkTransactionWithSnapshot.
+	bad := append([]byte{}, txBytes...)
+	bad = append(bad, 0x00)
+	addErr := mp.AddTx(bad)
+	if addErr == nil {
+		t.Fatalf("malformed AddTx unexpectedly accepted")
+	}
+	var admitErr *TxAdmitError
+	if !errors.As(addErr, &admitErr) || admitErr.Kind != TxAdmitRejected {
+		t.Fatalf("malformed AddTx err=%v, want TxAdmitRejected", addErr)
+	}
+	got := mp.AdmissionCounts()
+	if got.Rejected != 1 || got.Accepted != 0 || got.Conflict != 0 || got.Unavailable != 0 {
+		t.Fatalf("AdmissionCounts after malformed=%+v, want Rejected=1", got)
+	}
+}
+
+// TestMempoolAdmissionCountsUnavailableBumpsExactlyOnce pins that an
+// AddTx call hitting the nil-chainstate guard routes to the
+// Unavailable bucket. nil-chainstate is the explicit unavailable
+// branch documented in AddTx.
+func TestMempoolAdmissionCountsUnavailableBumpsExactlyOnce(t *testing.T) {
+	mp := &Mempool{} // chainState nil — exercises txAdmitUnavailable("nil chainstate")
+	addErr := mp.AddTx([]byte{0x00})
+	if addErr == nil {
+		t.Fatalf("AddTx on nil-chainstate mempool unexpectedly accepted")
+	}
+	var admitErr *TxAdmitError
+	if !errors.As(addErr, &admitErr) || admitErr.Kind != TxAdmitUnavailable {
+		t.Fatalf("AddTx err=%v, want TxAdmitUnavailable", addErr)
+	}
+	got := mp.AdmissionCounts()
+	if got.Unavailable != 1 || got.Accepted != 0 || got.Conflict != 0 || got.Rejected != 0 {
+		t.Fatalf("AdmissionCounts after unavailable=%+v, want Unavailable=1", got)
+	}
+}
+
+// TestMempoolAdmissionCountsNilReceiver pins the nil-safety contract
+// used by /metrics rendering: a nil mempool returns the zero-value
+// MempoolAdmissionCounts struct without panicking.
+func TestMempoolAdmissionCountsNilReceiver(t *testing.T) {
+	var mp *Mempool
+	if got := mp.AdmissionCounts(); got != (MempoolAdmissionCounts{}) {
+		t.Fatalf("AdmissionCounts nil receiver=%+v, want zero struct", got)
+	}
+}


### PR DESCRIPTION
Closes #1288.

Surface two bounded scrape-time signals on `/metrics` for the Go node mempool admission boundary:

- `rubin_node_mempool_bytes` (gauge) — raw byte size of transactions currently in the mempool, sourced from a new `Mempool.BytesUsed()` accessor. Nil-receiver safe.
- `rubin_node_mempool_admit_total{result="accepted|conflict|rejected|unavailable"}` (counter) — exactly one increment per non-nil-receiver `Mempool.AddTx` invocation; nil-receiver calls return unavailable without recording a counter because no mempool instance exists to own metrics state, wired via named-return + `defer m.noteAdmissionResult(retErr)` so every exit path bumps exactly one bucket. Bucket is mapped from the typed `*TxAdmitError.Kind`; any non-`TxAdmitError` return falls through to `rejected` so the label set stays bounded to exactly four values.

A new `MempoolAdmissionCounts` struct (4×`uint64`) provides the snapshot view; `AdmissionCounts()` is a pure atomic-read accessor that does not contend with the admission hot path. `renderPrometheusMetrics` emits the four buckets in fixed `accepted < conflict < rejected < unavailable` text-position order.

## Scope (controller-narrowed)

This PR is scoped to mempool metrics only per the canonical scope-disposition comment on #1288:
https://github.com/2tbmz9y2xt-lang/rubin-protocol/issues/1288#issuecomment-4322855541

Explicitly out of scope (each tracked in its own follow-up issue):

- P2P disconnect/error metrics — split to **#1307** (Q-GO-P2P-DISCONNECT-METRICS-BOUNDARY-01); the disconnect boundary needs a separate semantic audit (no double-count, normal shutdown is not a peer fault).
- Block accept/reject metrics — #1294
- Health/status/peers/chain-identity RPC — #1289
- Lifecycle/readiness — #1303 / #1304
- Full-block devnet harness — #1287

The carve-out is anchored in source at the admit-counter site (`clients/go/node/mempool.go` line ~46) so a future maintainer asking "where are the P2P metrics?" finds the answer next to the field.

## Tests

- 7 mempool unit tests covering `BytesUsed`, nil receivers, and each of the four admission outcomes (accepted, conflict via duplicate `AddTx`, rejected via trailing-byte parse failure, unavailable via nil chainstate) bumping its bucket exactly once.
- 2 `/metrics` render tests covering populated render (4 buckets, fixed order, gauge equals `len(txBytes)`) and twice-render-no-increment (proves no scrape-time mutation).
- 1 extended nil-state render test asserting the 5 new metric lines at zero.

All `-race`-clean. Local checks: `gofmt -l` empty, `go vet` clean, `go test ./node ./cmd/rubin-node -count=1 -race` PASS, `rubin-common-preflight` 6/6 PASS, hostile reviewer PASS (`REQ-20260426T202940Z-7732235-fixpass`, findings: none).

## Test plan

- [x] CI required checks green
- [x] Coverage gate +0% variation, diff coverage ≥85%
- [x] No reviewer-thread regressions
