### PR TITLE
node: add bounded /chain_identity, /health, /peers operator RPC routes (#1289)

### DIFF
--- a/clients/go/cmd/rubin-node/http_rpc.go
+++ b/clients/go/cmd/rubin-node/http_rpc.go
@@ -44,13 +44,13 @@ type devnetRPCState struct {
 	// flagged: shutdown observed by the gate at the moment of the
 	// readiness decision, not separately by main.
 	gate *readinessGate
-	// identity is the startup-wired chain identity used by the
-	// read-only operator route /chain_identity. nil means identity
-	// has not been wired yet (or the bare constructor was used by a
-	// test that does not exercise identity-dependent routes), and the
-	// /chain_identity handler MUST fail closed with 503 in that case.
-	// Set exactly once at startup via SetIdentity from main.go; never
-	// mutated after wiring.
+	// identity stores startup-provided chain identity for the
+	// /chain_identity route. nil means SetIdentity has not been called
+	// (e.g. a test fixture that does not exercise identity-dependent
+	// routes), and the /chain_identity handler returns 503 in that
+	// case. Multiple SetIdentity calls overwrite the previous value;
+	// in production cmd/rubin-node main.go invokes SetIdentity once
+	// during startup wiring.
 	identity *chainIdentity
 }
 
@@ -241,14 +241,13 @@ func (s *devnetRPCState) SetShutdownCtx(ctx context.Context) {
 	s.gate.setShutdownCtx(ctx)
 }
 
-// SetIdentity late-binds the startup-wired chain identity onto the
-// rpc state. cmd/rubin-node calls this once after
-// newDevnetRPCStateWithLifecycle so the /chain_identity handler reads
-// values straight from the wiring path; no devnet constants are
-// chosen inside the handler. Tests that exercise /chain_identity call
-// SetIdentity explicitly with the values they want to assert; tests
-// that do not exercise identity leave state.identity nil and observe
-// the canonical 503 fail-closed response. Nil-receiver safe.
+// SetIdentity stores the provided identity values on the rpc state
+// for the /chain_identity route to read. Subsequent calls overwrite
+// the previous value (no single-assignment guard); cmd/rubin-node
+// main.go invokes this once during startup wiring. Tests can call
+// SetIdentity with arbitrary values to observe the resulting
+// /chain_identity response, or leave state.identity nil to observe
+// the 503 response. Nil-receiver safe.
 func (s *devnetRPCState) SetIdentity(network string, chainID, genesisHash [32]byte) {
 	if s == nil {
 		return
@@ -1454,7 +1453,7 @@ func handleHealth(state *devnetRPCState, w http.ResponseWriter, r *http.Request)
 		HasTip:          hasTip,
 		BestKnownHeight: state.syncEngine.BestKnownHeight(),
 		InIBD:           state.syncEngine.IsInIBD(state.now()),
-		PeerCount:       len(state.peerManager.Snapshot()),
+		PeerCount:       state.peerManager.Count(),
 		MempoolTxs:      state.mempool.Len(),
 		MempoolBytes:    state.mempool.BytesUsed(),
 	}

--- a/clients/go/cmd/rubin-node/http_rpc.go
+++ b/clients/go/cmd/rubin-node/http_rpc.go
@@ -44,6 +44,25 @@ type devnetRPCState struct {
 	// flagged: shutdown observed by the gate at the moment of the
 	// readiness decision, not separately by main.
 	gate *readinessGate
+	// identity is the startup-wired chain identity used by the
+	// read-only operator route /chain_identity. nil means identity
+	// has not been wired yet (or the bare constructor was used by a
+	// test that does not exercise identity-dependent routes), and the
+	// /chain_identity handler MUST fail closed with 503 in that case.
+	// Set exactly once at startup via SetIdentity from main.go; never
+	// mutated after wiring.
+	identity *chainIdentity
+}
+
+// chainIdentity is a snapshot of startup-wired chain identity. Fields
+// flow into devnetRPCState through SetIdentity and feed the read-only
+// /chain_identity route. The struct deliberately stores raw [32]byte
+// values: hex encoding happens at the handler boundary so identity
+// comparison stays a byte equality check, not a hex string compare.
+type chainIdentity struct {
+	network     string
+	chainID     [32]byte
+	genesisHash [32]byte
 }
 
 // readyStateNotReady, readyStateReady, readyStateShutdown encode the
@@ -222,6 +241,25 @@ func (s *devnetRPCState) SetShutdownCtx(ctx context.Context) {
 	s.gate.setShutdownCtx(ctx)
 }
 
+// SetIdentity late-binds the startup-wired chain identity onto the
+// rpc state. cmd/rubin-node calls this once after
+// newDevnetRPCStateWithLifecycle so the /chain_identity handler reads
+// values straight from the wiring path; no devnet constants are
+// chosen inside the handler. Tests that exercise /chain_identity call
+// SetIdentity explicitly with the values they want to assert; tests
+// that do not exercise identity leave state.identity nil and observe
+// the canonical 503 fail-closed response. Nil-receiver safe.
+func (s *devnetRPCState) SetIdentity(network string, chainID, genesisHash [32]byte) {
+	if s == nil {
+		return
+	}
+	s.identity = &chainIdentity{
+		network:     network,
+		chainID:     chainID,
+		genesisHash: genesisHash,
+	}
+}
+
 type runningDevnetRPCServer struct {
 	addr   string
 	server *http.Server
@@ -315,6 +353,60 @@ type txStatusResponse struct {
 	Status string `json:"status"`
 	TxID   string `json:"txid,omitempty"`
 	Error  string `json:"error,omitempty"`
+}
+
+// chainIdentityResponse is the bounded read-only payload served by GET
+// /chain_identity. All three fields are required (no omitempty) so
+// the wire shape is stable for orchestrators that assert presence.
+type chainIdentityResponse struct {
+	Network        string `json:"network"`
+	ChainIDHex     string `json:"chain_id_hex"`
+	GenesisHashHex string `json:"genesis_hash_hex"`
+}
+
+// healthResponse is the bounded operator snapshot served by GET
+// /health. ready reads the existing readiness gate (this PR does not
+// redefine readiness/shutdown semantics). Height and TipHash are
+// pointer-typed so they encode as JSON null when the local ChainState
+// has no tip yet — has_tip distinguishes the two cases without
+// conflating "no tip" with "RPC failure". The remaining fields are
+// non-optional snapshots of existing node state; renaming or adding
+// fields is out of scope for this PR.
+type healthResponse struct {
+	Ready           bool    `json:"ready"`
+	HasTip          bool    `json:"has_tip"`
+	Height          *uint64 `json:"height"`
+	TipHash         *string `json:"tip_hash"`
+	BestKnownHeight uint64  `json:"best_known_height"`
+	InIBD           bool    `json:"in_ibd"`
+	PeerCount       int     `json:"peer_count"`
+	MempoolTxs      int     `json:"mempool_txs"`
+	MempoolBytes    int     `json:"mempool_bytes"`
+}
+
+// peerEntry mirrors the bounded subset of node.PeerState plus the
+// VersionPayloadV1 fields that an operator can act on. The handler
+// must NOT add free-form fields beyond this struct so the operator
+// surface stays bounded; out-of-scope additions belong in a new Q.
+type peerEntry struct {
+	Addr              string `json:"addr"`
+	HandshakeComplete bool   `json:"handshake_complete"`
+	BanScore          int    `json:"ban_score"`
+	LastError         string `json:"last_error"`
+	ProtocolVersion   uint32 `json:"protocol_version"`
+	BestHeight        uint64 `json:"best_height"`
+	TxRelay           bool   `json:"tx_relay"`
+	PrunedBelowHeight uint64 `json:"pruned_below_height"`
+	DaMempoolSize     uint32 `json:"da_mempool_size"`
+}
+
+// peersResponse is the bounded payload served by GET /peers. Count
+// equals len(Peers) by construction in handlePeers, and Peers is
+// sorted by Addr ascending for deterministic output across map
+// iteration randomization.
+type peersResponse struct {
+	Count int         `json:"count"`
+	Peers []peerEntry `json:"peers"`
 }
 
 func newDevnetRPCState(
@@ -575,6 +667,15 @@ func newDevnetRPCHandler(state *devnetRPCState) http.Handler {
 	})
 	mux.HandleFunc("/metrics", func(w http.ResponseWriter, r *http.Request) {
 		handleMetrics(state, w, r)
+	})
+	mux.HandleFunc("/chain_identity", func(w http.ResponseWriter, r *http.Request) {
+		handleChainIdentity(state, w, r)
+	})
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		handleHealth(state, w, r)
+	})
+	mux.HandleFunc("/peers", func(w http.ResponseWriter, r *http.Request) {
+		handlePeers(state, w, r)
 	})
 	return mux
 }
@@ -1271,5 +1372,144 @@ func respondSubmitTxBodyError(state *devnetRPCState, route string, w http.Respon
 	writeJSONResponse(state, route, w, http.StatusBadRequest, submitTxResponse{
 		Accepted: false,
 		Error:    "invalid JSON body",
+	})
+}
+
+// handleChainIdentity serves GET /chain_identity. It echoes the
+// startup-wired chain identity so an operator can confirm which
+// network/chain the running node belongs to without reading logs or
+// /metrics. Identity flows from main.go startup wiring via
+// SetIdentity; this handler does NOT independently choose devnet
+// constants. Missing identity wiring fails closed with 503 instead of
+// fabricating a devnet-shaped response. Non-GET methods return 405
+// with an Allow: GET header (RFC 9110 §15.5.6) and the canonical JSON
+// error envelope used by /ready.
+func handleChainIdentity(state *devnetRPCState, w http.ResponseWriter, r *http.Request) {
+	const route = "/chain_identity"
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		writeJSONResponse(state, route, w, http.StatusMethodNotAllowed, submitTxResponse{
+			Accepted: false,
+			Error:    "GET required",
+		})
+		return
+	}
+	if state == nil || state.identity == nil || state.identity.network == "" {
+		writeJSONResponse(state, route, w, http.StatusServiceUnavailable, submitTxResponse{
+			Accepted: false,
+			Error:    "chain identity unavailable",
+		})
+		return
+	}
+	writeJSONResponse(state, route, w, http.StatusOK, chainIdentityResponse{
+		Network:        state.identity.network,
+		ChainIDHex:     hex.EncodeToString(state.identity.chainID[:]),
+		GenesisHashHex: hex.EncodeToString(state.identity.genesisHash[:]),
+	})
+}
+
+// handleHealth serves GET /health, the bounded operator snapshot for
+// orchestrators that need a single-call probe of liveness, tip state,
+// peer count, and mempool fill without scraping /metrics or chasing
+// individual routes. ready reads the existing readiness gate
+// (state.IsReady — observed under the gate's mutex with shutdown
+// atomically observed); this handler does NOT redefine readiness or
+// shutdown semantics. ready=false from the gate is reported as a
+// field on a 200 response, NOT as an HTTP failure: an orchestrator
+// distinguishes "node up but not yet ready" (200 + ready:false) from
+// "node missing required runtime state" (503). Missing BlockStore,
+// PeerManager, Mempool, or SyncEngine fails closed with 503 rather
+// than reporting fabricated zero counts.
+func handleHealth(state *devnetRPCState, w http.ResponseWriter, r *http.Request) {
+	const route = "/health"
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		writeJSONResponse(state, route, w, http.StatusMethodNotAllowed, submitTxResponse{
+			Accepted: false,
+			Error:    "GET required",
+		})
+		return
+	}
+	if state == nil ||
+		state.syncEngine == nil ||
+		state.blockStore == nil ||
+		state.peerManager == nil ||
+		state.mempool == nil {
+		writeJSONResponse(state, route, w, http.StatusServiceUnavailable, submitTxResponse{
+			Accepted: false,
+			Error:    "runtime dependency unavailable",
+		})
+		return
+	}
+	height, tipHash, hasTip, err := tipFromBlockStore(state.blockStore)
+	if err != nil {
+		writeJSONResponse(state, route, w, http.StatusServiceUnavailable, submitTxResponse{
+			Accepted: false,
+			Error:    err.Error(),
+		})
+		return
+	}
+	body := healthResponse{
+		Ready:           state.IsReady(),
+		HasTip:          hasTip,
+		BestKnownHeight: state.syncEngine.BestKnownHeight(),
+		InIBD:           state.syncEngine.IsInIBD(state.now()),
+		PeerCount:       len(state.peerManager.Snapshot()),
+		MempoolTxs:      state.mempool.Len(),
+		MempoolBytes:    state.mempool.BytesUsed(),
+	}
+	if hasTip {
+		body.Height = &height
+		tipHex := hex.EncodeToString(tipHash[:])
+		body.TipHash = &tipHex
+	}
+	writeJSONResponse(state, route, w, http.StatusOK, body)
+}
+
+// handlePeers serves GET /peers, the deterministic snapshot of
+// PeerManager.Snapshot() projected to a bounded JSON shape. Output
+// MUST be sorted by Addr ascending so /peers responses are stable
+// across map iteration randomization; map-iteration order would let
+// two consecutive scrapes diff against each other for no semantic
+// reason. Count equals len(Peers) by construction. Empty initialized
+// peer set returns 200 with count:0 and peers:[] (NOT null). Nil
+// PeerManager fails closed with 503; the handler never mutates peer
+// state or accepts admin actions.
+func handlePeers(state *devnetRPCState, w http.ResponseWriter, r *http.Request) {
+	const route = "/peers"
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		writeJSONResponse(state, route, w, http.StatusMethodNotAllowed, submitTxResponse{
+			Accepted: false,
+			Error:    "GET required",
+		})
+		return
+	}
+	if state == nil || state.peerManager == nil {
+		writeJSONResponse(state, route, w, http.StatusServiceUnavailable, submitTxResponse{
+			Accepted: false,
+			Error:    "peer manager unavailable",
+		})
+		return
+	}
+	snapshot := state.peerManager.Snapshot()
+	sort.Slice(snapshot, func(i, j int) bool { return snapshot[i].Addr < snapshot[j].Addr })
+	peers := make([]peerEntry, 0, len(snapshot))
+	for _, p := range snapshot {
+		peers = append(peers, peerEntry{
+			Addr:              p.Addr,
+			HandshakeComplete: p.HandshakeComplete,
+			BanScore:          p.BanScore,
+			LastError:         p.LastError,
+			ProtocolVersion:   p.RemoteVersion.ProtocolVersion,
+			BestHeight:        p.RemoteVersion.BestHeight,
+			TxRelay:           p.RemoteVersion.TxRelay,
+			PrunedBelowHeight: p.RemoteVersion.PrunedBelowHeight,
+			DaMempoolSize:     p.RemoteVersion.DaMempoolSize,
+		})
+	}
+	writeJSONResponse(state, route, w, http.StatusOK, peersResponse{
+		Count: len(peers),
+		Peers: peers,
 	})
 }

--- a/clients/go/cmd/rubin-node/http_rpc_test.go
+++ b/clients/go/cmd/rubin-node/http_rpc_test.go
@@ -2072,15 +2072,12 @@ func TestDevnetRPCChainIdentityReportsWiredIdentity(t *testing.T) {
 	}
 }
 
-// TestDevnetRPCChainIdentityRejectsHardcodedDevnetConstants is the
-// hostile-review-matrix anchor for "Handler accidentally hardcodes
-// devnet chain id/hash". It wires identity values that DO NOT match
-// node.DevnetGenesisChainID()/DevnetGenesisBlockHash() and asserts
-// the response carries those wired values.
-// Proof assertion: body.ChainIDHex != hex(devnetChainID) AND
-// body.GenesisHashHex != hex(devnetGenesisHash); a handler that
-// returns devnet constants from a non-devnet-wired state fails the
-// strict not-equal check at the t.Fatalf calls below.
+// TestDevnetRPCChainIdentityRejectsHardcodedDevnetConstants wires
+// identity via SetIdentity with [32]byte values chosen to differ
+// from node.DevnetGenesisChainID() and node.DevnetGenesisBlockHash(),
+// then issues GET /chain_identity.
+// Proof assertion: body.ChainIDHex != hex.EncodeToString(devnetChainID[:])
+// and body.GenesisHashHex != hex.EncodeToString(devnetGenesisHash[:]).
 func TestDevnetRPCChainIdentityRejectsHardcodedDevnetConstants(t *testing.T) {
 	devnetChainID := node.DevnetGenesisChainID()
 	devnetGenesisHash := node.DevnetGenesisBlockHash()
@@ -2265,14 +2262,11 @@ func TestDevnetRPCHealthReportsReadyFalseAsField(t *testing.T) {
 	}
 }
 
-// TestDevnetRPCHealthFailsClosedOnMissingState asserts /health
-// returns 503 (not a fabricated 200) when a required runtime
-// dependency is missing. nil state is the strongest fail-closed input
-// because every per-field nil branch shares the same envelope.
-// Proof assertion: rec.Code == http.StatusServiceUnavailable AND
-// rec.Header.Get("Content-Type") == "application/json"; a handler
-// that fabricates a 200 or emits plain-text fails one of the two
-// t.Fatalf calls below.
+// TestDevnetRPCHealthFailsClosedOnMissingState invokes the /health
+// handler with a nil state, exercising the strongest fail-closed
+// input on the handler.
+// Proof assertion: rec.Code == http.StatusServiceUnavailable
+// and rec.Header.Get("Content-Type") == "application/json".
 func TestDevnetRPCHealthFailsClosedOnMissingState(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/health", nil)
 	rec := httptest.NewRecorder()

--- a/clients/go/cmd/rubin-node/http_rpc_test.go
+++ b/clients/go/cmd/rubin-node/http_rpc_test.go
@@ -2262,9 +2262,8 @@ func TestDevnetRPCHealthReportsReadyFalseAsField(t *testing.T) {
 	}
 }
 
-// TestDevnetRPCHealthFailsClosedOnMissingState invokes the /health
-// handler with a nil state, exercising the strongest fail-closed
-// input on the handler.
+// TestDevnetRPCHealthFailsClosedOnMissingState calls the /health
+// handler with a nil *devnetRPCState.
 // Proof assertion: rec.Code == http.StatusServiceUnavailable
 // and rec.Header.Get("Content-Type") == "application/json".
 func TestDevnetRPCHealthFailsClosedOnMissingState(t *testing.T) {

--- a/clients/go/cmd/rubin-node/http_rpc_test.go
+++ b/clients/go/cmd/rubin-node/http_rpc_test.go
@@ -2006,3 +2006,475 @@ func TestReadinessGate_ConcurrentRaceCannotResurrectReady(t *testing.T) {
 		}
 	}
 }
+
+// nonDevnetChainID and nonDevnetGenesisHash are fixed [32]byte values
+// chosen specifically to NOT match node.DevnetGenesisChainID() or
+// node.DevnetGenesisBlockHash(). The /chain_identity tests inject
+// these via SetIdentity and assert the handler echoes them verbatim;
+// a handler that secretly hardcodes devnet constants would emit the
+// devnet hexes instead and fail the assertion. The values are fixed
+// (not random) so the assertion is deterministic across CI runs.
+var (
+	nonDevnetChainID = [32]byte{
+		0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
+		0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
+		0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
+		0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
+	}
+	nonDevnetGenesisHash = [32]byte{
+		0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb,
+		0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb,
+		0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb,
+		0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb,
+	}
+)
+
+// TestDevnetRPCChainIdentityReportsWiredIdentity proves the handler
+// echoes the identity values that flowed through SetIdentity. Network
+// is exercised against a non-default ("testnet") to catch a handler
+// that always reports "devnet".
+func TestDevnetRPCChainIdentityReportsWiredIdentity(t *testing.T) {
+	state := mustRPCState(t, false)
+	state.SetIdentity("testnet", nonDevnetChainID, nonDevnetGenesisHash)
+	server := httptest.NewServer(newDevnetRPCHandler(state))
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/chain_identity")
+	if err != nil {
+		t.Fatalf("GET /chain_identity: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d want 200", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Content-Type"); got != "application/json" {
+		t.Fatalf("Content-Type=%q want application/json", got)
+	}
+	var body chainIdentityResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Network != "testnet" {
+		t.Fatalf("network=%q want testnet", body.Network)
+	}
+	if body.ChainIDHex != hex.EncodeToString(nonDevnetChainID[:]) {
+		t.Fatalf("chain_id_hex=%q want %q", body.ChainIDHex, hex.EncodeToString(nonDevnetChainID[:]))
+	}
+	if body.GenesisHashHex != hex.EncodeToString(nonDevnetGenesisHash[:]) {
+		t.Fatalf("genesis_hash_hex=%q want %q", body.GenesisHashHex, hex.EncodeToString(nonDevnetGenesisHash[:]))
+	}
+	// Hex contract: 64 lowercase chars, no 0x prefix.
+	if len(body.ChainIDHex) != 64 || strings.HasPrefix(body.ChainIDHex, "0x") || strings.ToLower(body.ChainIDHex) != body.ChainIDHex {
+		t.Fatalf("chain_id_hex shape violation: %q", body.ChainIDHex)
+	}
+	if len(body.GenesisHashHex) != 64 || strings.HasPrefix(body.GenesisHashHex, "0x") || strings.ToLower(body.GenesisHashHex) != body.GenesisHashHex {
+		t.Fatalf("genesis_hash_hex shape violation: %q", body.GenesisHashHex)
+	}
+}
+
+// TestDevnetRPCChainIdentityRejectsHardcodedDevnetConstants is the
+// hostile-review-matrix anchor for "Handler accidentally hardcodes
+// devnet chain id/hash". It wires identity values that DO NOT match
+// node.DevnetGenesisChainID()/DevnetGenesisBlockHash() and asserts
+// the response carries those wired values, so a handler that
+// hardcodes devnet constants (or falls through to a devnet default
+// when state.identity is set) fails this test red.
+func TestDevnetRPCChainIdentityRejectsHardcodedDevnetConstants(t *testing.T) {
+	devnetChainID := node.DevnetGenesisChainID()
+	devnetGenesisHash := node.DevnetGenesisBlockHash()
+	if nonDevnetChainID == devnetChainID || nonDevnetGenesisHash == devnetGenesisHash {
+		t.Fatalf("test fixture broken: non-devnet constants accidentally match devnet")
+	}
+	state := mustRPCState(t, false)
+	state.SetIdentity("devnet", nonDevnetChainID, nonDevnetGenesisHash)
+	server := httptest.NewServer(newDevnetRPCHandler(state))
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/chain_identity")
+	if err != nil {
+		t.Fatalf("GET /chain_identity: %v", err)
+	}
+	defer resp.Body.Close()
+	var body chainIdentityResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.ChainIDHex == hex.EncodeToString(devnetChainID[:]) {
+		t.Fatalf("chain_id_hex matches devnet constant; handler appears to hardcode devnet identity")
+	}
+	if body.GenesisHashHex == hex.EncodeToString(devnetGenesisHash[:]) {
+		t.Fatalf("genesis_hash_hex matches devnet constant; handler appears to hardcode devnet identity")
+	}
+}
+
+// TestDevnetRPCChainIdentityFailsClosedWithoutWiredIdentity asserts
+// the handler returns 503 when SetIdentity has not been called. A
+// fabricated 200 with devnet defaults would silently mislead an
+// operator about which chain the node is on; failing closed is the
+// load-bearing contract.
+func TestDevnetRPCChainIdentityFailsClosedWithoutWiredIdentity(t *testing.T) {
+	state := mustRPCState(t, false)
+	// Deliberately do NOT call state.SetIdentity.
+	server := httptest.NewServer(newDevnetRPCHandler(state))
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/chain_identity")
+	if err != nil {
+		t.Fatalf("GET /chain_identity: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d want 503", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Content-Type"); got != "application/json" {
+		t.Fatalf("Content-Type=%q want application/json (no plain-text 503)", got)
+	}
+}
+
+// TestDevnetRPCChainIdentityRejectsBadMethod asserts non-GET methods
+// produce 405 + Allow: GET + JSON envelope (not plain-text), matching
+// the canonical /ready handler shape.
+func TestDevnetRPCChainIdentityRejectsBadMethod(t *testing.T) {
+	state := mustRPCState(t, false)
+	state.SetIdentity("devnet", nonDevnetChainID, nonDevnetGenesisHash)
+	req := httptest.NewRequest(http.MethodPost, "/chain_identity", nil)
+	rec := httptest.NewRecorder()
+	newDevnetRPCHandler(state).ServeHTTP(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status=%d want 405", rec.Code)
+	}
+	if got := rec.Header().Get("Allow"); got != http.MethodGet {
+		t.Fatalf("Allow=%q want GET", got)
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/json" {
+		t.Fatalf("Content-Type=%q want application/json", got)
+	}
+}
+
+// TestDevnetRPCHealthReportsLiveSnapshot brings up a state with the
+// devnet genesis applied so has_tip=true, height=0, tip_hash=devnet
+// genesis hash, and adds one peer + one mempool tx so the bounded
+// counters are non-zero. Asserts every contracted field on /health.
+// The spendable UTXO injection happens AFTER genesis is applied so
+// blockstore.Tip() returns the genesis hash; mustRPCStateWithSpendableUTXO
+// alone leaves blockstore empty because it pre-stages a UTXO directly
+// in chainstate without going through syncEngine.ApplyBlock.
+func TestDevnetRPCHealthReportsLiveSnapshot(t *testing.T) {
+	fromKey := mustRPCMLDSA87Keypair(t)
+	toKey := mustRPCMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+	state, input, utxos := mustRPCStateWithSpendableUTXO(t, fromAddress, nil)
+	if _, err := state.syncEngine.ApplyBlock(node.DevnetGenesisBlockBytes(), nil); err != nil {
+		t.Fatalf("ApplyBlock(genesis): %v", err)
+	}
+	state.SetIdentity("devnet", node.DevnetGenesisChainID(), node.DevnetGenesisBlockHash())
+	if !state.TryMarkReadyOnStartup() {
+		t.Fatalf("TryMarkReadyOnStartup: false on a fresh gate")
+	}
+	// Inject one peer with a known address + version so peer_count == 1.
+	if err := state.peerManager.AddPeer(&node.PeerState{
+		Addr:              "127.0.0.1:30001",
+		HandshakeComplete: true,
+		BanScore:          0,
+		LastError:         "",
+		RemoteVersion: node.VersionPayloadV1{
+			ProtocolVersion: 1,
+			TxRelay:         true,
+			BestHeight:      7,
+		},
+	}); err != nil {
+		t.Fatalf("AddPeer: %v", err)
+	}
+	// Admit one tx so mempool_txs == 1 and mempool_bytes == len(txBytes).
+	txBytes, _ := mustRPCSignedTransferTx(t, utxos, input, fromKey, toAddress)
+	if err := state.mempool.AddTx(txBytes); err != nil {
+		t.Fatalf("AddTx: %v", err)
+	}
+	server := httptest.NewServer(newDevnetRPCHandler(state))
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/health")
+	if err != nil {
+		t.Fatalf("GET /health: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d want 200", resp.StatusCode)
+	}
+	var body healthResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !body.Ready {
+		t.Fatalf("ready=false; expected true after TryMarkReadyOnStartup")
+	}
+	if !body.HasTip {
+		t.Fatalf("has_tip=false; expected true (no genesis applied?)")
+	}
+	if body.Height == nil {
+		t.Fatalf("height is null; expected non-nil with has_tip=true")
+	}
+	if body.TipHash == nil || len(*body.TipHash) != 64 {
+		t.Fatalf("tip_hash invalid: %v", body.TipHash)
+	}
+	if body.PeerCount != 1 {
+		t.Fatalf("peer_count=%d want 1", body.PeerCount)
+	}
+	if body.MempoolTxs != 1 {
+		t.Fatalf("mempool_txs=%d want 1", body.MempoolTxs)
+	}
+	if body.MempoolBytes != len(txBytes) {
+		t.Fatalf("mempool_bytes=%d want %d", body.MempoolBytes, len(txBytes))
+	}
+}
+
+// TestDevnetRPCHealthReportsReadyFalseAsField asserts a
+// not-yet-ready node returns 200 with ready:false (not 503). The
+// readiness gate is independent of /health's HTTP success; an
+// orchestrator distinguishes "boot" (200 + ready:false) from "broken"
+// (503).
+func TestDevnetRPCHealthReportsReadyFalseAsField(t *testing.T) {
+	state := mustRPCState(t, false)
+	// Deliberately do NOT call TryMarkReadyOnStartup so IsReady is false.
+	server := httptest.NewServer(newDevnetRPCHandler(state))
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/health")
+	if err != nil {
+		t.Fatalf("GET /health: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d want 200 (ready=false is a field, not an error)", resp.StatusCode)
+	}
+	var body healthResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Ready {
+		t.Fatalf("ready=true on a non-ready node")
+	}
+	if body.HasTip {
+		t.Fatalf("has_tip=true; expected false on a node without genesis applied")
+	}
+	if body.Height != nil || body.TipHash != nil {
+		t.Fatalf("height/tip_hash non-nil with has_tip=false: %v / %v", body.Height, body.TipHash)
+	}
+}
+
+// TestDevnetRPCHealthFailsClosedOnMissingState asserts /health
+// returns 503 (not a fabricated 200) when a required runtime
+// dependency is missing. nil state covers the strongest fail-closed
+// path; per-field nil paths share the same envelope.
+func TestDevnetRPCHealthFailsClosedOnMissingState(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rec := httptest.NewRecorder()
+	newDevnetRPCHandler(nil).ServeHTTP(rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d want 503", rec.Code)
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/json" {
+		t.Fatalf("Content-Type=%q want application/json (no plain-text 503)", got)
+	}
+}
+
+// TestDevnetRPCHealthRejectsBadMethod asserts non-GET produces 405 +
+// Allow: GET + JSON envelope.
+func TestDevnetRPCHealthRejectsBadMethod(t *testing.T) {
+	state := mustRPCState(t, false)
+	req := httptest.NewRequest(http.MethodPost, "/health", nil)
+	rec := httptest.NewRecorder()
+	newDevnetRPCHandler(state).ServeHTTP(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status=%d want 405", rec.Code)
+	}
+	if got := rec.Header().Get("Allow"); got != http.MethodGet {
+		t.Fatalf("Allow=%q want GET", got)
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/json" {
+		t.Fatalf("Content-Type=%q want application/json", got)
+	}
+}
+
+// TestDevnetRPCPeersDeterministicSortByAddr injects three peers in
+// non-sorted insertion order (and with map iteration randomization
+// in PeerManager) and asserts /peers returns them sorted by addr
+// ascending. Count == len(peers) is checked simultaneously.
+func TestDevnetRPCPeersDeterministicSortByAddr(t *testing.T) {
+	state := mustRPCState(t, false)
+	addrs := []string{"127.0.0.1:30003", "127.0.0.1:30001", "127.0.0.1:30002"}
+	for _, addr := range addrs {
+		if err := state.peerManager.AddPeer(&node.PeerState{
+			Addr:              addr,
+			HandshakeComplete: true,
+			BanScore:          0,
+			LastError:         "",
+			RemoteVersion: node.VersionPayloadV1{
+				ProtocolVersion: 1,
+				TxRelay:         true,
+			},
+		}); err != nil {
+			t.Fatalf("AddPeer %q: %v", addr, err)
+		}
+	}
+	server := httptest.NewServer(newDevnetRPCHandler(state))
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/peers")
+	if err != nil {
+		t.Fatalf("GET /peers: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d want 200", resp.StatusCode)
+	}
+	var body peersResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Count != len(body.Peers) {
+		t.Fatalf("count=%d != len(peers)=%d", body.Count, len(body.Peers))
+	}
+	if body.Count != 3 {
+		t.Fatalf("count=%d want 3", body.Count)
+	}
+	wantSorted := []string{"127.0.0.1:30001", "127.0.0.1:30002", "127.0.0.1:30003"}
+	for i, want := range wantSorted {
+		if body.Peers[i].Addr != want {
+			t.Fatalf("peers[%d].addr=%q want %q (sort by addr asc violated)", i, body.Peers[i].Addr, want)
+		}
+	}
+}
+
+// TestDevnetRPCPeersEmptyReturnsEmptyArray asserts an initialized
+// node with zero peers returns 200, count:0, and a JSON empty array
+// for "peers" (NOT null and NOT 503). This is the false-positive
+// case from the issue contract: zero peers is healthy.
+func TestDevnetRPCPeersEmptyReturnsEmptyArray(t *testing.T) {
+	state := mustRPCState(t, false)
+	server := httptest.NewServer(newDevnetRPCHandler(state))
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/peers")
+	if err != nil {
+		t.Fatalf("GET /peers: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d want 200 (empty peer set is healthy)", resp.StatusCode)
+	}
+	rawBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if !strings.Contains(string(rawBody), `"peers":[]`) {
+		t.Fatalf("body=%q want JSON empty array `\"peers\":[]` (not null)", string(rawBody))
+	}
+	var body peersResponse
+	if err := json.Unmarshal(rawBody, &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Count != 0 {
+		t.Fatalf("count=%d want 0", body.Count)
+	}
+	if len(body.Peers) != 0 {
+		t.Fatalf("len(peers)=%d want 0", len(body.Peers))
+	}
+}
+
+// TestDevnetRPCPeersFailsClosedOnNilPeerManager asserts /peers
+// returns 503 when state.peerManager is nil. Constructed manually so
+// the nil path is exercised through the public handler, not internal
+// state mutation.
+func TestDevnetRPCPeersFailsClosedOnNilPeerManager(t *testing.T) {
+	state := &devnetRPCState{
+		gate:    newReadinessGate(context.TODO()),
+		stderr:  io.Discard,
+		nowUnix: func() uint64 { return 0 },
+		metrics: newRPCMetrics(),
+		// peerManager intentionally left nil.
+	}
+	req := httptest.NewRequest(http.MethodGet, "/peers", nil)
+	rec := httptest.NewRecorder()
+	newDevnetRPCHandler(state).ServeHTTP(rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d want 503", rec.Code)
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/json" {
+		t.Fatalf("Content-Type=%q want application/json", got)
+	}
+}
+
+// TestDevnetRPCPeersRejectsBadMethod asserts non-GET produces 405 +
+// Allow: GET + JSON envelope.
+func TestDevnetRPCPeersRejectsBadMethod(t *testing.T) {
+	state := mustRPCState(t, false)
+	req := httptest.NewRequest(http.MethodPost, "/peers", nil)
+	rec := httptest.NewRecorder()
+	newDevnetRPCHandler(state).ServeHTTP(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status=%d want 405", rec.Code)
+	}
+	if got := rec.Header().Get("Allow"); got != http.MethodGet {
+		t.Fatalf("Allow=%q want GET", got)
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/json" {
+		t.Fatalf("Content-Type=%q want application/json", got)
+	}
+}
+
+// TestDevnetRPCPeersExposesAllBoundedFields populates one peer with
+// every contracted field set to a distinct non-zero value and asserts
+// every field round-trips through the JSON response. This catches a
+// handler that silently drops a contracted field or maps it to the
+// wrong PeerState/VersionPayloadV1 attribute.
+func TestDevnetRPCPeersExposesAllBoundedFields(t *testing.T) {
+	state := mustRPCState(t, false)
+	peer := &node.PeerState{
+		Addr:              "127.0.0.1:31337",
+		HandshakeComplete: true,
+		BanScore:          17,
+		LastError:         "previous handshake timed out",
+		RemoteVersion: node.VersionPayloadV1{
+			ProtocolVersion:   2,
+			TxRelay:           true,
+			BestHeight:        99,
+			PrunedBelowHeight: 12,
+			DaMempoolSize:     34,
+		},
+	}
+	if err := state.peerManager.AddPeer(peer); err != nil {
+		t.Fatalf("AddPeer: %v", err)
+	}
+	server := httptest.NewServer(newDevnetRPCHandler(state))
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/peers")
+	if err != nil {
+		t.Fatalf("GET /peers: %v", err)
+	}
+	defer resp.Body.Close()
+	var body peersResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Count != 1 {
+		t.Fatalf("count=%d want 1", body.Count)
+	}
+	got := body.Peers[0]
+	want := peerEntry{
+		Addr:              "127.0.0.1:31337",
+		HandshakeComplete: true,
+		BanScore:          17,
+		LastError:         "previous handshake timed out",
+		ProtocolVersion:   2,
+		BestHeight:        99,
+		TxRelay:           true,
+		PrunedBelowHeight: 12,
+		DaMempoolSize:     34,
+	}
+	if got != want {
+		t.Fatalf("peer entry mismatch:\n got=%+v\nwant=%+v", got, want)
+	}
+}

--- a/clients/go/cmd/rubin-node/http_rpc_test.go
+++ b/clients/go/cmd/rubin-node/http_rpc_test.go
@@ -2076,9 +2076,11 @@ func TestDevnetRPCChainIdentityReportsWiredIdentity(t *testing.T) {
 // hostile-review-matrix anchor for "Handler accidentally hardcodes
 // devnet chain id/hash". It wires identity values that DO NOT match
 // node.DevnetGenesisChainID()/DevnetGenesisBlockHash() and asserts
-// the response carries those wired values, so a handler that
-// hardcodes devnet constants (or falls through to a devnet default
-// when state.identity is set) fails this test red.
+// the response carries those wired values.
+// Proof assertion: body.ChainIDHex != hex(devnetChainID) AND
+// body.GenesisHashHex != hex(devnetGenesisHash); a handler that
+// returns devnet constants from a non-devnet-wired state fails the
+// strict not-equal check at the t.Fatalf calls below.
 func TestDevnetRPCChainIdentityRejectsHardcodedDevnetConstants(t *testing.T) {
 	devnetChainID := node.DevnetGenesisChainID()
 	devnetGenesisHash := node.DevnetGenesisBlockHash()
@@ -2265,8 +2267,12 @@ func TestDevnetRPCHealthReportsReadyFalseAsField(t *testing.T) {
 
 // TestDevnetRPCHealthFailsClosedOnMissingState asserts /health
 // returns 503 (not a fabricated 200) when a required runtime
-// dependency is missing. nil state covers the strongest fail-closed
-// path; per-field nil paths share the same envelope.
+// dependency is missing. nil state is the strongest fail-closed input
+// because every per-field nil branch shares the same envelope.
+// Proof assertion: rec.Code == http.StatusServiceUnavailable AND
+// rec.Header.Get("Content-Type") == "application/json"; a handler
+// that fabricates a 200 or emits plain-text fails one of the two
+// t.Fatalf calls below.
 func TestDevnetRPCHealthFailsClosedOnMissingState(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/health", nil)
 	rec := httptest.NewRecorder()

--- a/clients/go/cmd/rubin-node/main.go
+++ b/clients/go/cmd/rubin-node/main.go
@@ -529,6 +529,14 @@ func run(args []string, stdout, stderr io.Writer) int {
 	// helper to keep production-wiring and regression-wiring paths
 	// identical.
 	rpcState := newDevnetRPCStateWithLifecycle(syncEngine, blockStore, mempool, peerManager, p2pService.AnnounceTx, stderr, liveMiner, ctx)
+	// Late-bind the startup-wired chain identity so the read-only
+	// /chain_identity handler echoes the values that already flowed
+	// through genesis parsing + network canonicalization, rather than
+	// synthesizing devnet constants inside the handler. Done in one
+	// place after newDevnetRPCStateWithLifecycle so production wiring
+	// matches the regression-test wiring path that calls SetIdentity
+	// directly.
+	rpcState.SetIdentity(cfg.Network, chainIDFromGenesis, genesisHashFromGenesis)
 	rpcServer, err := startDevnetRPCServer(cfg.RPCBindAddr, rpcState, stdout, stderr)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "rpc start failed: %v\n", err)


### PR DESCRIPTION
Closes #1289.

## Architecture class
B (bounded read-only operator surface within the existing Go cmd/rubin-node HTTP RPC).

## System boundary
`clients/go/cmd/rubin-node/http_rpc.go`, `http_rpc_test.go`, `main.go` only. No production CLI flags beyond the new SetIdentity wiring path. No new HTTP framework, no new RPC contract for non-RPC surfaces, no consensus path, no Rust, no P2P relay or peer mutation, no mempool admission change, no block validation/mining change, no lifecycle/readiness redesign.

## Single invariant
A running Go rubin-node exposes a deterministic machine-readable operator snapshot via three bounded read-only HTTP routes that read existing wired state, without log/stdout/metrics scraping. Identity is startup-wired (no handler-side devnet synthesis); /health reads the existing readiness gate without redefining shutdown semantics; /peers is sorted by addr ascending with `count == len(peers)`; every route returns JSON 405 on non-GET and JSON 503 on missing required runtime dependency.

## Field contract summary
- `GET /chain_identity` → `{network, chain_id_hex (64 lowercase hex, no 0x), genesis_hash_hex (64 lowercase hex, no 0x)}` from `state.identity` set at startup via `SetIdentity(cfg.Network, chainIDFromGenesis, genesisHashFromGenesis)`. nil identity → 503.
- `GET /health` → `{ready, has_tip, height, tip_hash, best_known_height, in_ibd, peer_count, mempool_txs, mempool_bytes}`. `ready` reads existing `state.IsReady()`. `ready=false` is reported as a field on a 200 (NOT 503). nil SyncEngine/BlockStore/PeerManager/Mempool → 503.
- `GET /peers` → `{count, peers[]}` sorted by `addr` ascending with deterministic output across map iteration. `count == len(peers)`. Empty initialized peer set → 200 + `count:0` + `peers:[]` (NOT null). nil PeerManager → 503.

All three routes return 405 + `Allow: GET` header (RFC 9110 §15.5.6) + JSON envelope on non-GET, matching the canonical /ready handler shape.

## Tests run
- `go test ./cmd/rubin-node -run 'TestDevnetRPC(ChainIdentity|Health|Peers)' -count=1 -race -v`: 13 new tests PASS, including hostile-matrix anchors (non-devnet identity round-trip to defeat hardcoded-devnet handlers, nil-state 503 on each route, deterministic peer sort across 3 non-sorted insertions, JSON empty array vs null for empty peer set, ready:false-as-field vs 503 distinction, 405 + Allow header on non-GET).
- `go test ./cmd/rubin-node -count=1 -race`: full pkg PASS, 13.3s, no regression.
- `gofmt -l` empty; `go vet` clean.
- `tooling-check.sh --new-only --mode go-deep`: golangci-lint diff-mode 0 issues; cargo-deny ok; cargo-machete ok; go-deep all packages PASS.
- `rubin-common-preflight`: 6/6 PASS on clean committed HEAD.
- Hostile reviewer post-diff REQ: PASS, no findings.

## Out of scope (kept untouched)
Rust implementation; conformance fixture changes; compact relay; DA relay; fee estimate; auth; admin/mutation endpoints; dashboard; metrics additions; P2P protocol behavior; PeerManager semantics; mempool admission; block validation/mining; lifecycle/readiness redesign beyond reading the existing gate.