### PR TITLE
node/p2p: add bounded peer lifecycle exits counter (#1307)

### DIFF
--- a/clients/go/cmd/rubin-node/http_rpc.go
+++ b/clients/go/cmd/rubin-node/http_rpc.go
@@ -52,6 +52,15 @@ type devnetRPCState struct {
 	// in production cmd/rubin-node main.go invokes SetIdentity once
 	// during startup wiring.
 	identity *chainIdentity
+	// peerLifecycleExits is a closure provided by cmd/rubin-node main.go
+	// that returns the monotonic peer-lifecycle-exit count from the
+	// running *p2p.Service. nil means the closure has not been wired
+	// (e.g. a test fixture that does not exercise the metric); the
+	// metrics renderer treats a nil closure as 0 so scraping does not
+	// panic on a fixture state. The closure is itself a pure
+	// atomic.Load on the service side, so /metrics rendering does not
+	// mutate any counter.
+	peerLifecycleExits func() uint64
 }
 
 // chainIdentity is a snapshot of startup-wired chain identity. Fields
@@ -257,6 +266,20 @@ func (s *devnetRPCState) SetIdentity(network string, chainID, genesisHash [32]by
 		chainID:     chainID,
 		genesisHash: genesisHash,
 	}
+}
+
+// SetPeerLifecycleExitsFunc stores a closure that returns the
+// monotonic peer-lifecycle-exit count from the running *p2p.Service.
+// cmd/rubin-node main.go binds it to p2pService.PeerLifecycleExits
+// once during startup wiring. /metrics rendering reads it on each
+// scrape; a nil closure renders the metric as 0 so test fixtures
+// without a wired service still scrape cleanly. Subsequent calls
+// overwrite the previous closure. Nil-receiver safe.
+func (s *devnetRPCState) SetPeerLifecycleExitsFunc(fn func() uint64) {
+	if s == nil {
+		return
+	}
+	s.peerLifecycleExits = fn
 }
 
 type runningDevnetRPCServer struct {
@@ -1116,15 +1139,16 @@ func handleMetrics(state *devnetRPCState, w http.ResponseWriter, r *http.Request
 
 func renderPrometheusMetrics(state *devnetRPCState) string {
 	var (
-		tipHeight       float64
-		bestKnownHeight float64
-		inIBD           float64
-		peerCount       float64
-		mempoolTxs      float64
-		mempoolBytes    float64
-		mempoolAdmit    node.MempoolAdmissionCounts
-		routeStatus     map[string]uint64
-		submitByResult  map[string]uint64
+		tipHeight          float64
+		bestKnownHeight    float64
+		inIBD              float64
+		peerCount          float64
+		mempoolTxs         float64
+		mempoolBytes       float64
+		mempoolAdmit       node.MempoolAdmissionCounts
+		peerLifecycleExits uint64
+		routeStatus        map[string]uint64
+		submitByResult     map[string]uint64
 	)
 	if state != nil && state.syncEngine != nil {
 		bestKnownHeight = float64(state.syncEngine.BestKnownHeight())
@@ -1148,6 +1172,11 @@ func renderPrometheusMetrics(state *devnetRPCState) string {
 		// repeatedly cannot perturb the counters.
 		mempoolBytes = float64(state.mempool.BytesUsed())
 		mempoolAdmit = state.mempool.AdmissionCounts()
+	}
+	if state != nil && state.peerLifecycleExits != nil {
+		// Pure atomic.Load behind the closure — repeated /metrics
+		// scrapes never bump the underlying counter.
+		peerLifecycleExits = state.peerLifecycleExits()
 	}
 	if state != nil && state.metrics != nil {
 		routeStatus, submitByResult = state.metrics.snapshot()
@@ -1186,6 +1215,14 @@ func renderPrometheusMetrics(state *devnetRPCState) string {
 		fmt.Sprintf(`rubin_node_mempool_admit_total{result="conflict"} %d`, mempoolAdmit.Conflict),
 		fmt.Sprintf(`rubin_node_mempool_admit_total{result="rejected"} %d`, mempoolAdmit.Rejected),
 		fmt.Sprintf(`rubin_node_mempool_admit_total{result="unavailable"} %d`, mempoolAdmit.Unavailable),
+		// Unlabeled lifecycle-exit counter; the underlying exit cause
+		// (remote close, protocol error, local Service.Close) is not
+		// available at the unregisterPeer site without plumbing it
+		// through, so labeled buckets cannot be proven non-overlapping
+		// today and are intentionally not emitted (issue #1307).
+		"# HELP rubin_node_p2p_peer_lifecycle_exits_total Total peer lifecycle exits observed by the p2p service since process start.",
+		"# TYPE rubin_node_p2p_peer_lifecycle_exits_total counter",
+		fmt.Sprintf("rubin_node_p2p_peer_lifecycle_exits_total %d", peerLifecycleExits),
 		"# HELP rubin_node_rpc_requests_total Total HTTP RPC requests by route and status.",
 		"# TYPE rubin_node_rpc_requests_total counter",
 	)

--- a/clients/go/cmd/rubin-node/http_rpc_test.go
+++ b/clients/go/cmd/rubin-node/http_rpc_test.go
@@ -835,6 +835,7 @@ func TestRenderPrometheusMetricsHandlesNilStateAndNilMetrics(t *testing.T) {
 		`rubin_node_mempool_admit_total{result="conflict"} 0`,
 		`rubin_node_mempool_admit_total{result="rejected"} 0`,
 		`rubin_node_mempool_admit_total{result="unavailable"} 0`,
+		"rubin_node_p2p_peer_lifecycle_exits_total 0",
 	} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("missing %q in metrics body %q", want, body)
@@ -925,6 +926,69 @@ func TestRenderPrometheusMetricsTwiceDoesNotIncrementAdmitCounters(t *testing.T)
 	post := state.mempool.AdmissionCounts()
 	if pre != post {
 		t.Fatalf("AdmissionCounts changed across two /metrics renders: pre=%+v post=%+v (scrape-time increment regression)", pre, post)
+	}
+}
+
+// TestRenderPrometheusMetricsExposesPeerLifecycleExits wires a stub
+// closure on devnetRPCState that returns a fixed non-zero count and
+// renders /metrics once.
+// Proof assertion: body contains "rubin_node_p2p_peer_lifecycle_exits_total 7"
+// (the value returned by the stub) AND contains the HELP/TYPE
+// preamble for that metric AND the metric is unlabeled (no `{...}`
+// brace appears between the metric name and the value).
+func TestRenderPrometheusMetricsExposesPeerLifecycleExits(t *testing.T) {
+	state := mustRPCState(t, false)
+	state.SetPeerLifecycleExitsFunc(func() uint64 { return 7 })
+	body := renderPrometheusMetrics(state)
+	for _, want := range []string{
+		"# HELP rubin_node_p2p_peer_lifecycle_exits_total Total peer lifecycle exits observed by the p2p service since process start.",
+		"# TYPE rubin_node_p2p_peer_lifecycle_exits_total counter",
+		"rubin_node_p2p_peer_lifecycle_exits_total 7",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("missing %q in metrics body %q", want, body)
+		}
+	}
+	// Reject any labeled form: the metric must be emitted unlabeled
+	// (single line "name <value>"), never "name{kind=...} <value>".
+	if strings.Contains(body, "rubin_node_p2p_peer_lifecycle_exits_total{") {
+		t.Fatalf("metric emitted with labels — must stay unlabeled per #1307: %q", body)
+	}
+}
+
+// TestRenderPrometheusMetricsTwiceDoesNotMutatePeerLifecycleExits
+// pins the scrape-time-no-mutation contract for the new lifecycle
+// exit metric. The stub closure tracks how many times the renderer
+// invokes it; the renderer is allowed to call the closure (it is a
+// pure Load() on the production side), but the rendered counter
+// value MUST equal what the closure returns each scrape — render
+// itself MUST NOT add any per-scrape delta.
+// Proof assertion: rendered value on second scrape equals first
+// scrape's value (closure returns constant 5).
+func TestRenderPrometheusMetricsTwiceDoesNotMutatePeerLifecycleExits(t *testing.T) {
+	state := mustRPCState(t, false)
+	const fixedValue uint64 = 5
+	state.SetPeerLifecycleExitsFunc(func() uint64 { return fixedValue })
+	body1 := renderPrometheusMetrics(state)
+	body2 := renderPrometheusMetrics(state)
+	want := "rubin_node_p2p_peer_lifecycle_exits_total 5"
+	if !strings.Contains(body1, want) || !strings.Contains(body2, want) {
+		t.Fatalf("expected %q in both renders; body1=%q body2=%q", want, body1, body2)
+	}
+}
+
+// TestRenderPrometheusMetricsNilPeerLifecycleClosureRendersZero
+// covers the test-fixture path where SetPeerLifecycleExitsFunc was
+// never called.
+// Proof assertion: body contains "rubin_node_p2p_peer_lifecycle_exits_total 0"
+// without panic.
+func TestRenderPrometheusMetricsNilPeerLifecycleClosureRendersZero(t *testing.T) {
+	state := mustRPCState(t, false)
+	// Deliberately do NOT call state.SetPeerLifecycleExitsFunc.
+	body := renderPrometheusMetrics(state)
+	want := "rubin_node_p2p_peer_lifecycle_exits_total 0"
+	if !strings.Contains(body, want) {
+		t.Fatalf("missing %q (nil closure must render 0): body=%q", want, body)
 	}
 }
 

--- a/clients/go/cmd/rubin-node/main.go
+++ b/clients/go/cmd/rubin-node/main.go
@@ -537,6 +537,11 @@ func run(args []string, stdout, stderr io.Writer) int {
 	// matches the regression-test wiring path that calls SetIdentity
 	// directly.
 	rpcState.SetIdentity(cfg.Network, chainIDFromGenesis, genesisHashFromGenesis)
+	// Bind the peer-lifecycle-exit closure so /metrics rendering can
+	// observe the running *p2p.Service counter without cmd/rubin-node's
+	// RPC state taking a structural dependency on the p2p package —
+	// same indirection pattern as p2pService.AnnounceTx above.
+	rpcState.SetPeerLifecycleExitsFunc(p2pService.PeerLifecycleExits)
 	rpcServer, err := startDevnetRPCServer(cfg.RPCBindAddr, rpcState, stdout, stderr)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "rpc start failed: %v\n", err)

--- a/clients/go/node/p2p/peer_runtime_test.go
+++ b/clients/go/node/p2p/peer_runtime_test.go
@@ -464,3 +464,108 @@ func mustPeerRuntimeFrameBytes(t *testing.T, p *peer, frame message) []byte {
 	}
 	return buf.Bytes()
 }
+
+// TestPeerLifecycleExitsCounter_SingleRemovalIncrementsOnce registers
+// one peer manually, calls unregisterPeer once.
+// Proof assertion: PeerLifecycleExits() == 1 after the call AND
+// the peer key is gone from s.peers.
+func TestPeerLifecycleExitsCounter_SingleRemovalIncrementsOnce(t *testing.T) {
+	h := newTestHarness(t, 0, "127.0.0.1:0", nil)
+	p := &peer{service: h.service, state: node.PeerState{Addr: "peer-A"}}
+	h.service.peers[p.addr()] = p
+	if got := h.service.PeerLifecycleExits(); got != 0 {
+		t.Fatalf("baseline counter=%d want 0", got)
+	}
+	h.service.unregisterPeer(p)
+	if got := h.service.PeerLifecycleExits(); got != 1 {
+		t.Fatalf("counter=%d want 1 after one unregister", got)
+	}
+	if _, still := h.service.peers[p.addr()]; still {
+		t.Fatalf("peer still registered after unregister")
+	}
+}
+
+// TestPeerLifecycleExitsCounter_RepeatedUnregisterDoesNotDoubleCount
+// pins the dedupe contract: cleanup retries on an already-removed
+// peer must not bump the counter again.
+// Proof assertion: PeerLifecycleExits() == 1 after the second
+// unregisterPeer call (the first bumped to 1, the second is a no-op).
+func TestPeerLifecycleExitsCounter_RepeatedUnregisterDoesNotDoubleCount(t *testing.T) {
+	h := newTestHarness(t, 0, "127.0.0.1:0", nil)
+	p := &peer{service: h.service, state: node.PeerState{Addr: "peer-B"}}
+	h.service.peers[p.addr()] = p
+	h.service.unregisterPeer(p)
+	first := h.service.PeerLifecycleExits()
+	h.service.unregisterPeer(p)
+	if got := h.service.PeerLifecycleExits(); got != first {
+		t.Fatalf("counter=%d want %d after repeat unregister (no second bump)", got, first)
+	}
+	if first != 1 {
+		t.Fatalf("first unregister bumped counter to %d, want 1", first)
+	}
+}
+
+// TestPeerLifecycleExitsCounter_AliasEntriesCountAsOneExit registers
+// a peer twice into s.peers under two distinct keys, mirroring
+// registerPeer's canonical-addr-plus-remoteAddr-alias path.
+// Proof assertion: PeerLifecycleExits() == 1 after one
+// unregisterPeer call AND len(s.peers) == 0; the alias entries
+// collapse into a single exit increment.
+func TestPeerLifecycleExitsCounter_AliasEntriesCountAsOneExit(t *testing.T) {
+	h := newTestHarness(t, 0, "127.0.0.1:0", nil)
+	p := &peer{service: h.service, state: node.PeerState{Addr: "peer-C"}}
+	h.service.peers[p.addr()] = p
+	h.service.peers["peer-C-alias"] = p
+	if len(h.service.peers) != 2 {
+		t.Fatalf("setup peers=%d want 2", len(h.service.peers))
+	}
+	h.service.unregisterPeer(p)
+	if got := h.service.PeerLifecycleExits(); got != 1 {
+		t.Fatalf("counter=%d want 1 (alias entries collapse into one exit)", got)
+	}
+	if len(h.service.peers) != 0 {
+		t.Fatalf("peers map=%d after alias unregister, want 0", len(h.service.peers))
+	}
+}
+
+// TestPeerLifecycleExitsCounter_UnknownPeerNoBump constructs a peer
+// that was never registered and calls unregisterPeer on it.
+// Proof assertion: PeerLifecycleExits() == 0 because
+// unregisterPeer's `remove` flag stays false when the peer has no
+// entry in s.peers, so the increment branch is skipped.
+func TestPeerLifecycleExitsCounter_UnknownPeerNoBump(t *testing.T) {
+	h := newTestHarness(t, 0, "127.0.0.1:0", nil)
+	stranger := &peer{service: h.service, state: node.PeerState{Addr: "peer-stranger"}}
+	h.service.unregisterPeer(stranger)
+	if got := h.service.PeerLifecycleExits(); got != 0 {
+		t.Fatalf("counter=%d want 0 for unregister on never-registered peer", got)
+	}
+}
+
+// TestPeerLifecycleExitsCounter_NilReceiverReturnsZero pins the
+// nil-receiver contract on the public accessor.
+// Proof assertion: ((*Service)(nil)).PeerLifecycleExits() == 0
+// without panic.
+func TestPeerLifecycleExitsCounter_NilReceiverReturnsZero(t *testing.T) {
+	var s *Service
+	if got := s.PeerLifecycleExits(); got != 0 {
+		t.Fatalf("nil receiver counter=%d want 0", got)
+	}
+}
+
+// TestPeerLifecycleExitsCounter_TwoPeersExitsTotalsTwo registers two
+// distinct peers and unregisters both.
+// Proof assertion: PeerLifecycleExits() == 2; the increment is
+// per-peer, not per-call or per-map-entry.
+func TestPeerLifecycleExitsCounter_TwoPeersExitsTotalsTwo(t *testing.T) {
+	h := newTestHarness(t, 0, "127.0.0.1:0", nil)
+	p1 := &peer{service: h.service, state: node.PeerState{Addr: "peer-1"}}
+	p2 := &peer{service: h.service, state: node.PeerState{Addr: "peer-2"}}
+	h.service.peers[p1.addr()] = p1
+	h.service.peers[p2.addr()] = p2
+	h.service.unregisterPeer(p1)
+	h.service.unregisterPeer(p2)
+	if got := h.service.PeerLifecycleExits(); got != 2 {
+		t.Fatalf("counter=%d want 2 after two distinct peer exits", got)
+	}
+}

--- a/clients/go/node/p2p/service.go
+++ b/clients/go/node/p2p/service.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
@@ -78,6 +79,20 @@ type Service struct {
 	blockSeen *boundedHashSet
 	txSeen    *boundedHashSet
 	orphans   *orphanPool
+
+	// peerLifecycleExits counts peer lifecycle exits at the single
+	// canonical removal boundary inside unregisterPeer. The counter is
+	// incremented exactly once per unregisterPeer call that actually
+	// deletes one or more entries from the s.peers map (i.e. when the
+	// dedupe flag remove==true). Repeated unregisterPeer calls on the
+	// same already-removed peer leave remove==false and do not bump
+	// the counter. The metric is intentionally unlabeled: the
+	// underlying exit cause (remote EOF, protocol error, local
+	// Service.Close ctx cancel, request/send error) is not available
+	// at the unregisterPeer site without plumbing it through, and
+	// labeled buckets cannot be proven non-overlapping under the
+	// current cleanup graph (issue #1307).
+	peerLifecycleExits atomic.Uint64
 }
 
 type peer struct {

--- a/clients/go/node/p2p/service_peer_lifecycle.go
+++ b/clients/go/node/p2p/service_peer_lifecycle.go
@@ -97,11 +97,33 @@ func (s *Service) unregisterPeer(p *peer) {
 	}
 	s.peersMu.Unlock()
 	if remove {
+		// Lifecycle-exit counter increments here, exactly once per
+		// unregisterPeer call that actually deleted peer entries from
+		// the s.peers map. Repeat calls on the same already-removed
+		// peer leave remove==false above and do not reach this line,
+		// so cleanup retries cannot double-count. atomic.Uint64.Add is
+		// safe to call without peersMu (the lock has been released
+		// above) because the counter is independent of peer-map state.
+		s.peerLifecycleExits.Add(1)
 		s.cfg.PeerManager.RemovePeer(addr)
 	}
 	if remove && s.isOutboundAddr(addr) {
 		s.scheduleReconnect(addr)
 	}
+}
+
+// PeerLifecycleExits returns the monotonic count of peer lifecycle
+// exits observed by this Service since construction. The counter is
+// incremented inside unregisterPeer at the single canonical removal
+// boundary; see the field comment on Service.peerLifecycleExits for
+// the dedupe contract. Pure atomic.Load — safe to call concurrently
+// with unregisterPeer and from /metrics rendering. Returns 0 on a
+// nil receiver so scrape callers can read unconditionally.
+func (s *Service) PeerLifecycleExits() uint64 {
+	if s == nil {
+		return 0
+	}
+	return s.peerLifecycleExits.Load()
 }
 
 func peerAddressKey(outboundAddr string, runtimeAddr string) string {


### PR DESCRIPTION
Closes #1307.

## Architecture class
B (bounded extension within the existing Go p2p service lifecycle + the existing /metrics rendering surface).

## System boundary
`clients/go/node/p2p/service.go`, `service_peer_lifecycle.go`, `peer_runtime_test.go`, `clients/go/cmd/rubin-node/http_rpc.go`, `http_rpc_test.go`, `main.go`. No new HTTP route, no peer mutation API, no PeerManager contract change, no wire protocol change, no consensus path, no Rust, no mempool admission, no block validation/mining, no lifecycle/readiness redesign.

## Single invariant
P2P disconnect/lifecycle metrics MUST count real peer lifecycle exits exactly once at the single canonical removal boundary inside `p2p.Service.unregisterPeer` (when the peer-map dedupe sets `remove==true`), without double-counting through repeated cleanup paths and without mislabeling normal local `Service.Close` shutdown as peer-fault evidence. The metric is intentionally unlabeled because the underlying exit cause is not available at the unregisterPeer site and labeled buckets cannot be proven non-overlapping under the current cleanup graph.

## Exact metric
- Name: `rubin_node_p2p_peer_lifecycle_exits_total`
- Type: counter (Prometheus text format)
- Labels: **none** (intentionally unlabeled per controller's "default to the minimal honest metric unless you can prove labeled buckets are non-overlapping" directive)

## Exact event boundary
Counter increment site is exactly inside the existing `if remove { ... }` block in `unregisterPeer` after the `peersMu` critical section is released. The increment is `s.peerLifecycleExits.Add(1)` on a new `atomic.Uint64` field on `*p2p.Service`.

## Why it cannot double count
- The `remove` flag in `unregisterPeer` is set only when the iteration over `s.peers` actually deleted at least one entry. Repeated `unregisterPeer` calls on an already-removed peer leave `remove==false`, so the increment branch is unreachable on cleanup retries.
- Alias map entries for the same peer (canonical addr key plus the `remoteAddr` alias key registered by `registerPeer`) are deleted in the same loop; the `remove` flag flips once for the whole loop, so one peer with N alias keys produces exactly one increment.
- The increment site is NOT in `applyPostHandshakeDisconnectError` and NOT in `peer.run`/`handleConn` return paths. The `defer s.unregisterPeer(current)` at line 51 of `handleConn` is the single canonical exit point that fires on every error and graceful return after a peer was registered. There is no second counter site that could race or duplicate.

## Why local shutdown is not misreported as peer fault
The metric name is `peer_lifecycle_exits_total`, NOT `peer_fault_total` or `peer_disconnect_total`. The wire-level identifier carries no fault-attribution claim. `Service.Close` triggers peer-connection close and ctx-cancel, which causes each `handleConn` goroutine to return and its deferred `unregisterPeer` to fire — these are correctly classified as lifecycle exits, not faults. A future labeled-bucket version (e.g. `kind=remote|protocol_error|local_shutdown`) is intentionally NOT introduced today because the exit cause is not available at the `unregisterPeer` site without plumbing it through, and labeled buckets cannot be proven non-overlapping under the current cleanup graph.

## Evidence commands and results
- `gofmt -l` on all 6 changed files: empty
- `go vet ./node/p2p ./cmd/rubin-node`: clean
- `cd clients/go && go test ./node/p2p -run 'TestPeerLifecycleExitsCounter' -count=1 -race -v`: 6/6 new tests PASS (single-bump, repeat-no-double, alias-collapse, unknown-peer-no-bump, nil-receiver, two-peers-totals-two)
- `cd clients/go && go test ./cmd/rubin-node -run 'TestRenderPrometheusMetrics' -count=1 -race -v`: 7/7 tests PASS (including 3 new + 1 extended baseline)
- `cd clients/go && go test ./node/p2p ./cmd/rubin-node -count=1`: full pkg PASS, no regression
- `tooling-check.sh --new-only --mode go-deep`: golangci-lint diff mode 0 issues; cargo-deny ok; cargo-machete ok; go-deep all packages PASS
- `rubin-common-preflight`: 6/6 PASS on clean committed HEAD `ee73209`
- Hostile reviewer post-diff REQ: PASS, no findings

A pre-existing race in `TestReconnectDuePeersDialsDuePeer` (between `reconnectBackoff()` reading package-level `defaultReconnectInitial`/`Maximum` and the test's `overrideReconnectTiming` cleanup writing them back) reproduces on `origin/main` and is NOT introduced by this PR. It lives in `reconnect.go` / `reconnect_test.go` (neither file is in this PR's allowed surface) and addressing it would require a class-change scope expansion per the issue stop rule.

## Out of scope (kept untouched)
mempool metrics; block accept/reject metrics; `/health`, `/peers`, `/chain_identity`; readiness/lifecycle control-plane; peer scoring/ban/reconnect/backoff; P2P wire protocol; compact relay; DA relay; Rust; conformance fixtures; new metrics framework; labeled-bucket version of the disconnect metric (deferred until exit-cause plumbing is justified by a separate Q-*).

