### PR TITLE
feat(go): expose block apply outcome metrics (#1294)

### DIFF
--- a/clients/go/cmd/rubin-node/http_rpc.go
+++ b/clients/go/cmd/rubin-node/http_rpc.go
@@ -1162,6 +1162,7 @@ func renderPrometheusMetrics(state *devnetRPCState) string {
 		inIBD              float64
 		reorgCount         uint64
 		lastReorgDepth     uint64
+		blockApply         node.BlockApplyCounts
 		peerCount          float64
 		mempoolTxs         float64
 		mempoolBytes       float64
@@ -1174,6 +1175,7 @@ func renderPrometheusMetrics(state *devnetRPCState) string {
 		bestKnownHeight = float64(state.syncEngine.BestKnownHeight())
 		reorgCount = state.syncEngine.ReorgCount()
 		lastReorgDepth = state.syncEngine.LastReorgDepth()
+		blockApply = state.syncEngine.BlockApplyCounts()
 		if state.syncEngine.IsInIBD(state.now()) {
 			inIBD = 1
 		}
@@ -1224,6 +1226,10 @@ func renderPrometheusMetrics(state *devnetRPCState) string {
 		"# HELP rubin_node_last_reorg_depth Depth of the most recent canonical reorg, or 0 when no reorg depth is currently recorded.",
 		"# TYPE rubin_node_last_reorg_depth gauge",
 		fmt.Sprintf("rubin_node_last_reorg_depth %d", lastReorgDepth),
+		"# HELP rubin_node_block_apply_total Total canonical block apply outcomes by result label.",
+		"# TYPE rubin_node_block_apply_total counter",
+		fmt.Sprintf(`rubin_node_block_apply_total{result="accepted"} %d`, blockApply.Accepted),
+		fmt.Sprintf(`rubin_node_block_apply_total{result="rejected"} %d`, blockApply.Rejected),
 		"# HELP rubin_node_peer_count Currently tracked peers.",
 		"# TYPE rubin_node_peer_count gauge",
 		fmt.Sprintf("rubin_node_peer_count %.0f", peerCount),

--- a/clients/go/cmd/rubin-node/http_rpc_test.go
+++ b/clients/go/cmd/rubin-node/http_rpc_test.go
@@ -1163,6 +1163,7 @@ func TestRenderPrometheusMetricsIncludesV1Names(t *testing.T) {
 		"rubin_node_in_ibd",
 		"rubin_node_reorg_total",
 		"rubin_node_last_reorg_depth",
+		"rubin_node_block_apply_total",
 		"rubin_node_peer_count",
 		"rubin_node_mempool_txs",
 		"rubin_node_rpc_requests_total",
@@ -1196,6 +1197,8 @@ func TestRenderPrometheusMetricsHandlesNilStateAndNilMetrics(t *testing.T) {
 		"rubin_node_in_ibd 0",
 		"rubin_node_reorg_total 0",
 		"rubin_node_last_reorg_depth 0",
+		`rubin_node_block_apply_total{result="accepted"} 0`,
+		`rubin_node_block_apply_total{result="rejected"} 0`,
 		"rubin_node_peer_count 0",
 		"rubin_node_mempool_txs 0",
 		"rubin_node_mempool_bytes 0",
@@ -1208,6 +1211,64 @@ func TestRenderPrometheusMetricsHandlesNilStateAndNilMetrics(t *testing.T) {
 		if !strings.Contains(body, want) {
 			t.Fatalf("missing %q in metrics body %q", want, body)
 		}
+	}
+}
+
+func TestRenderPrometheusMetricsExposesBlockApplyCountersReadOnly(t *testing.T) {
+	state := mustRPCState(t, true)
+	initial := state.syncEngine.BlockApplyCounts()
+	if initial.Accepted != 1 || initial.Rejected != 0 {
+		t.Fatalf("initial BlockApplyCounts=%+v, want accepted=1 rejected=0 after devnet genesis", initial)
+	}
+
+	target := consensus.POW_LIMIT
+	block1 := mustRPCSingleTxBlock(
+		t,
+		node.DevnetGenesisBlockHash(),
+		target,
+		mustRPCReorgTestTimestamp(t, 1),
+		mustRPCCoinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 1, consensus.BlockSubsidy(1, 0)),
+	)
+	summary1, err := state.syncEngine.ApplyBlock(block1, nil)
+	if err != nil {
+		t.Fatalf("ApplyBlock(block1): %v", err)
+	}
+
+	invalidBlock2 := append([]byte(nil), mustRPCSingleTxBlock(
+		t,
+		summary1.BlockHash,
+		target,
+		mustRPCReorgTestTimestamp(t, 2),
+		mustRPCCoinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 2, consensus.BlockSubsidy(2, summary1.AlreadyGenerated)),
+	)...)
+	invalidBlock2[4+32] ^= 0x01 // keep the block parseable but break merkle-root validation.
+	if _, err := state.syncEngine.ApplyBlock(invalidBlock2, nil); err == nil {
+		t.Fatalf("expected invalid canonical block rejection")
+	}
+
+	beforeRender := state.syncEngine.BlockApplyCounts()
+	if beforeRender.Accepted != 2 || beforeRender.Rejected != 1 {
+		t.Fatalf("pre-render BlockApplyCounts=%+v, want accepted=2 rejected=1", beforeRender)
+	}
+	body1 := renderPrometheusMetrics(state)
+	body2 := renderPrometheusMetrics(state)
+	for _, body := range []string{body1, body2} {
+		for _, want := range []string{
+			"# TYPE rubin_node_block_apply_total counter",
+			`rubin_node_block_apply_total{result="accepted"} 2`,
+			`rubin_node_block_apply_total{result="rejected"} 1`,
+		} {
+			if !strings.Contains(body, want) {
+				t.Fatalf("missing %q in metrics body %q", want, body)
+			}
+		}
+		if strings.Contains(body, `rubin_node_block_apply_total{result="`) &&
+			(strings.Contains(body, `error=`) || strings.Contains(body, `hash=`) || strings.Contains(body, `peer=`)) {
+			t.Fatalf("block apply metrics leaked unbounded labels in body %q", body)
+		}
+	}
+	if afterRender := state.syncEngine.BlockApplyCounts(); afterRender != beforeRender {
+		t.Fatalf("renderPrometheusMetrics mutated BlockApplyCounts from %+v to %+v", beforeRender, afterRender)
 	}
 }
 

--- a/clients/go/cmd/rubin-node/http_rpc_test.go
+++ b/clients/go/cmd/rubin-node/http_rpc_test.go
@@ -1262,9 +1262,11 @@ func TestRenderPrometheusMetricsExposesBlockApplyCountersReadOnly(t *testing.T) 
 				t.Fatalf("missing %q in metrics body %q", want, body)
 			}
 		}
-		if strings.Contains(body, `rubin_node_block_apply_total{result="`) &&
-			(strings.Contains(body, `error=`) || strings.Contains(body, `hash=`) || strings.Contains(body, `peer=`)) {
-			t.Fatalf("block apply metrics leaked unbounded labels in body %q", body)
+		for _, line := range strings.Split(body, "\n") {
+			if strings.HasPrefix(line, `rubin_node_block_apply_total{`) &&
+				(strings.Contains(line, `error=`) || strings.Contains(line, `hash=`) || strings.Contains(line, `peer=`)) {
+				t.Fatalf("block apply metrics leaked unbounded labels in line %q from body %q", line, body)
+			}
 		}
 	}
 	if afterRender := state.syncEngine.BlockApplyCounts(); afterRender != beforeRender {

--- a/clients/go/node/sync.go
+++ b/clients/go/node/sync.go
@@ -76,6 +76,14 @@ type BlockApplyCounts struct {
 	Rejected uint64
 }
 
+type blockApplyMetricOutcome uint8
+
+const (
+	blockApplyMetricNone blockApplyMetricOutcome = iota
+	blockApplyMetricAccepted
+	blockApplyMetricRejected
+)
+
 type SyncEngine struct {
 	chainState      *ChainState
 	blockStore      *BlockStore
@@ -465,7 +473,6 @@ type syncRollbackState struct {
 	bestKnownHeight uint64
 	lastReorgDepth  uint64
 	reorgCount      uint64
-	blockApply      BlockApplyCounts
 }
 
 func (s *SyncEngine) captureRollbackState() (syncRollbackState, error) {
@@ -495,7 +502,6 @@ func (s *SyncEngine) captureRollbackState() (syncRollbackState, error) {
 		bestKnownHeight: s.bestKnownHeight,
 		lastReorgDepth:  s.lastReorgDepth,
 		reorgCount:      s.reorgCount,
-		blockApply:      s.blockApply,
 	}, nil
 }
 
@@ -529,7 +535,6 @@ func (s *SyncEngine) rollbackApplyBlock(cause error, state syncRollbackState) er
 	s.bestKnownHeight = state.bestKnownHeight
 	s.lastReorgDepth = state.lastReorgDepth
 	s.reorgCount = state.reorgCount
-	s.blockApply = state.blockApply
 	s.mu.Unlock()
 	if restoreErr != nil {
 		return fmt.Errorf("%w (rollback failed: %v)", cause, restoreErr)
@@ -542,15 +547,25 @@ func (s *SyncEngine) applyCanonicalParsedBlock(
 	blockBytes []byte,
 	prevTimestamps []uint64,
 ) (*ChainStateConnectSummary, error) {
+	summary, outcome, err := s.applyCanonicalParsedBlockTracked(pb, blockBytes, prevTimestamps)
+	s.noteBlockApplyOutcome(outcome)
+	return summary, err
+}
+
+func (s *SyncEngine) applyCanonicalParsedBlockTracked(
+	pb *consensus.ParsedBlock,
+	blockBytes []byte,
+	prevTimestamps []uint64,
+) (*ChainStateConnectSummary, blockApplyMetricOutcome, error) {
 	if s == nil || s.chainState == nil {
-		return nil, errors.New("sync engine is not initialized")
+		return nil, blockApplyMetricNone, errors.New("sync engine is not initialized")
 	}
 	if pb == nil {
-		return nil, errors.New("nil parsed block")
+		return nil, blockApplyMetricNone, errors.New("nil parsed block")
 	}
 	blockHeight, _, err := nextBlockContext(s.chainState)
 	if err != nil {
-		return nil, err
+		return nil, blockApplyMetricNone, err
 	}
 	var zeroID [32]byte
 	if blockHeight == 0 && s.cfg.ChainID != zeroID && s.cfg.ChainID != devnetGenesisChainID {
@@ -562,14 +577,14 @@ func (s *SyncEngine) applyCanonicalParsedBlock(
 		// Wrap with a TxError so peer attribution is class-closed for both
 		// genesis-identity classes (chain_id mismatch and genesis_hash
 		// mismatch below).
-		return nil, &consensus.TxError{
+		return nil, blockApplyMetricNone, &consensus.TxError{
 			Code: consensus.BLOCK_ERR_LINKAGE_INVALID,
 			Msg:  "genesis chain_id mismatch",
 		}
 	}
 	blockHash, err := consensus.BlockHash(pb.HeaderBytes)
 	if err != nil {
-		return nil, err
+		return nil, blockApplyMetricNone, err
 	}
 	// Defense in depth on top of the chain_id guard above: at height 0 on a
 	// devnet runtime, the block must be the published devnet genesis. Without
@@ -584,7 +599,7 @@ func (s *SyncEngine) applyCanonicalParsedBlock(
 	// `var txErr *consensus.TxError; errors.As(err, &txErr)` pattern in
 	// p2p/handlers_block.go.
 	if blockHeight == 0 && s.cfg.ChainID == devnetGenesisChainID && blockHash != devnetGenesisBlockHash {
-		return nil, &consensus.TxError{
+		return nil, blockApplyMetricNone, &consensus.TxError{
 			Code: consensus.BLOCK_ERR_LINKAGE_INVALID,
 			Msg:  "genesis_hash mismatch",
 		}
@@ -592,7 +607,7 @@ func (s *SyncEngine) applyCanonicalParsedBlock(
 
 	rollbackState, err := s.captureRollbackState()
 	if err != nil {
-		return nil, err
+		return nil, blockApplyMetricNone, err
 	}
 	prevState := cloneChainState(rollbackState.chainState)
 
@@ -639,8 +654,7 @@ func (s *SyncEngine) applyCanonicalParsedBlock(
 		} else {
 			s.pvTelemetry.RecordBlockSkipped()
 		}
-		s.noteBlockApplyRejected()
-		return nil, err
+		return nil, blockApplyMetricRejected, err
 	}
 	if pvActive {
 		s.pvTelemetry.RecordBlockValidated()
@@ -677,12 +691,11 @@ func (s *SyncEngine) applyCanonicalParsedBlock(
 	}
 	commitStart := time.Now()
 	if err := s.persistAppliedBlock(summary, blockHash, pb, blockBytes, prevState); err != nil {
-		return nil, s.rollbackApplyBlock(err, rollbackState)
+		return nil, blockApplyMetricNone, s.rollbackApplyBlock(err, rollbackState)
 	}
 	s.pvTelemetry.RecordCommitLatency(time.Since(commitStart))
 
 	s.recordAppliedBlock(summary.BlockHeight, pb.Header.Timestamp)
-	s.noteBlockApplyAccepted()
 	if s.mempool != nil {
 		if err := s.mempool.EvictConfirmedParsed(pb); err != nil {
 			_, _ = fmt.Fprintf(s.stderr, "mempool: evict-confirmed: %v\n", err)
@@ -691,7 +704,7 @@ func (s *SyncEngine) applyCanonicalParsedBlock(
 			_, _ = fmt.Fprintf(s.stderr, "mempool: remove-conflicting: %v\n", err)
 		}
 	}
-	return summary, nil
+	return summary, blockApplyMetricAccepted, nil
 }
 
 // txErrCode extracts the consensus.TxError code string from err for
@@ -747,6 +760,15 @@ func (s *SyncEngine) noteBlockApplyAccepted() {
 	s.blockApply.Accepted++
 }
 
+func (s *SyncEngine) noteBlockApplyAcceptedN(count uint64) {
+	if s == nil || count == 0 {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.blockApply.Accepted += count
+}
+
 func (s *SyncEngine) noteBlockApplyRejected() {
 	if s == nil {
 		return
@@ -754,6 +776,17 @@ func (s *SyncEngine) noteBlockApplyRejected() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.blockApply.Rejected++
+}
+
+func (s *SyncEngine) noteBlockApplyOutcome(outcome blockApplyMetricOutcome) {
+	switch outcome {
+	case blockApplyMetricNone:
+		return
+	case blockApplyMetricAccepted:
+		s.noteBlockApplyAccepted()
+	case blockApplyMetricRejected:
+		s.noteBlockApplyRejected()
+	}
 }
 
 func (s *SyncEngine) noteReorg(depth uint64) {

--- a/clients/go/node/sync.go
+++ b/clients/go/node/sync.go
@@ -70,6 +70,12 @@ type HeaderRequest struct {
 	Limit    uint64
 }
 
+// BlockApplyCounts is the bounded canonical block-apply outcome metric state.
+type BlockApplyCounts struct {
+	Accepted uint64
+	Rejected uint64
+}
+
 type SyncEngine struct {
 	chainState      *ChainState
 	blockStore      *BlockStore
@@ -81,6 +87,7 @@ type SyncEngine struct {
 	bestKnownHeight uint64
 	lastReorgDepth  uint64
 	reorgCount      uint64
+	blockApply      BlockApplyCounts
 
 	pvMode             parallelValidationMode
 	pvShadowMax        uint64
@@ -393,6 +400,15 @@ func (s *SyncEngine) ReorgCount() uint64 {
 	return s.reorgCount
 }
 
+func (s *SyncEngine) BlockApplyCounts() BlockApplyCounts {
+	if s == nil {
+		return BlockApplyCounts{}
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.blockApply
+}
+
 // isInIBDUnchecked returns true if the engine appears to be in IBD based on
 // the recorded tip timestamp and the configured IBD lag threshold. Unlike
 // IsInIBD, it does not require a nowUnix argument — it uses time.Now().
@@ -449,6 +465,7 @@ type syncRollbackState struct {
 	bestKnownHeight uint64
 	lastReorgDepth  uint64
 	reorgCount      uint64
+	blockApply      BlockApplyCounts
 }
 
 func (s *SyncEngine) captureRollbackState() (syncRollbackState, error) {
@@ -478,6 +495,7 @@ func (s *SyncEngine) captureRollbackState() (syncRollbackState, error) {
 		bestKnownHeight: s.bestKnownHeight,
 		lastReorgDepth:  s.lastReorgDepth,
 		reorgCount:      s.reorgCount,
+		blockApply:      s.blockApply,
 	}, nil
 }
 
@@ -511,6 +529,7 @@ func (s *SyncEngine) rollbackApplyBlock(cause error, state syncRollbackState) er
 	s.bestKnownHeight = state.bestKnownHeight
 	s.lastReorgDepth = state.lastReorgDepth
 	s.reorgCount = state.reorgCount
+	s.blockApply = state.blockApply
 	s.mu.Unlock()
 	if restoreErr != nil {
 		return fmt.Errorf("%w (rollback failed: %v)", cause, restoreErr)
@@ -620,6 +639,7 @@ func (s *SyncEngine) applyCanonicalParsedBlock(
 		} else {
 			s.pvTelemetry.RecordBlockSkipped()
 		}
+		s.noteBlockApplyRejected()
 		return nil, err
 	}
 	if pvActive {
@@ -662,6 +682,7 @@ func (s *SyncEngine) applyCanonicalParsedBlock(
 	s.pvTelemetry.RecordCommitLatency(time.Since(commitStart))
 
 	s.recordAppliedBlock(summary.BlockHeight, pb.Header.Timestamp)
+	s.noteBlockApplyAccepted()
 	if s.mempool != nil {
 		if err := s.mempool.EvictConfirmedParsed(pb); err != nil {
 			_, _ = fmt.Fprintf(s.stderr, "mempool: evict-confirmed: %v\n", err)
@@ -715,6 +736,24 @@ func (s *SyncEngine) recordAppliedBlock(height uint64, timestamp uint64) {
 		s.bestKnownHeight = height
 	}
 	s.lastReorgDepth = 0
+}
+
+func (s *SyncEngine) noteBlockApplyAccepted() {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.blockApply.Accepted++
+}
+
+func (s *SyncEngine) noteBlockApplyRejected() {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.blockApply.Rejected++
 }
 
 func (s *SyncEngine) noteReorg(depth uint64) {

--- a/clients/go/node/sync.go
+++ b/clients/go/node/sync.go
@@ -577,7 +577,7 @@ func (s *SyncEngine) applyCanonicalParsedBlockTracked(
 		// Wrap with a TxError so peer attribution is class-closed for both
 		// genesis-identity classes (chain_id mismatch and genesis_hash
 		// mismatch below).
-		return nil, blockApplyMetricNone, &consensus.TxError{
+		return nil, blockApplyMetricRejected, &consensus.TxError{
 			Code: consensus.BLOCK_ERR_LINKAGE_INVALID,
 			Msg:  "genesis chain_id mismatch",
 		}
@@ -599,7 +599,7 @@ func (s *SyncEngine) applyCanonicalParsedBlockTracked(
 	// `var txErr *consensus.TxError; errors.As(err, &txErr)` pattern in
 	// p2p/handlers_block.go.
 	if blockHeight == 0 && s.cfg.ChainID == devnetGenesisChainID && blockHash != devnetGenesisBlockHash {
-		return nil, blockApplyMetricNone, &consensus.TxError{
+		return nil, blockApplyMetricRejected, &consensus.TxError{
 			Code: consensus.BLOCK_ERR_LINKAGE_INVALID,
 			Msg:  "genesis_hash mismatch",
 		}

--- a/clients/go/node/sync_reorg.go
+++ b/clients/go/node/sync_reorg.go
@@ -126,6 +126,7 @@ func (s *SyncEngine) applyHeavierBranch(
 	}
 
 	var summary *ChainStateConnectSummary
+	var pendingAccepted uint64
 	for i, item := range branch {
 		// Derive fresh timestamps from the (updated) canonical index for
 		// each block in the branch.  The stale caller prevTimestamps was
@@ -136,12 +137,21 @@ func (s *SyncEngine) applyHeavierBranch(
 		if tsErr != nil {
 			return nil, s.rollbackApplyBlock(tsErr, rollbackState)
 		}
-		summary, err = s.applyCanonicalParsedBlock(item.parsed, item.blockBytes, freshTs)
+		var outcome blockApplyMetricOutcome
+		summary, outcome, err = s.applyCanonicalParsedBlockTracked(item.parsed, item.blockBytes, freshTs)
 		if err != nil {
-			return nil, s.rollbackApplyBlock(err, rollbackState)
+			rollbackErr := s.rollbackApplyBlock(err, rollbackState)
+			if outcome == blockApplyMetricRejected {
+				s.noteBlockApplyRejected()
+			}
+			return nil, rollbackErr
+		}
+		if outcome == blockApplyMetricAccepted {
+			pendingAccepted++
 		}
 	}
 	s.requeueDisconnectedTransactions(disconnectedBlocks)
+	s.noteBlockApplyAcceptedN(pendingAccepted)
 	s.noteReorg(reorgDepth)
 	return summary, nil
 }

--- a/clients/go/node/sync_reorg_test.go
+++ b/clients/go/node/sync_reorg_test.go
@@ -425,18 +425,41 @@ func TestApplyCanonicalParsedBlockHelperErrors(t *testing.T) {
 		t.Fatalf("expected nil sync engine error")
 	}
 
-	engine, _, _ := newReorgTestEngine(t)
+	target := consensus.POW_LIMIT
+	newEmptyEngine := func(t *testing.T, chainID [32]byte) *SyncEngine {
+		t.Helper()
+		dir := t.TempDir()
+		store, err := OpenBlockStore(BlockStorePath(dir))
+		if err != nil {
+			t.Fatalf("OpenBlockStore: %v", err)
+		}
+		engine, err := NewSyncEngine(NewChainState(), store, DefaultSyncConfig(&target, chainID, ChainStatePath(dir)))
+		if err != nil {
+			t.Fatalf("NewSyncEngine: %v", err)
+		}
+		return engine
+	}
+
+	engine := newEmptyEngine(t, devnetGenesisChainID)
 	if _, err := engine.applyCanonicalParsedBlock(nil, nil, nil); err == nil {
 		t.Fatalf("expected nil parsed block error")
 	}
 
-	engine.cfg.ChainID = [32]byte{0x99}
-	pb, err := consensus.ParseBlockBytes(devnetGenesisBlockBytes)
-	if err != nil {
-		t.Fatalf("ParseBlockBytes(genesis): %v", err)
-	}
-	if _, err := engine.applyCanonicalParsedBlock(pb, devnetGenesisBlockBytes, nil); err == nil {
+	engine = newEmptyEngine(t, [32]byte{0x99})
+	if _, err := engine.ApplyBlock(devnetGenesisBlockBytes, nil); err == nil {
 		t.Fatalf("expected genesis chain_id mismatch")
+	}
+	if got := engine.BlockApplyCounts(); got.Accepted != 0 || got.Rejected != 1 {
+		t.Fatalf("genesis chain_id mismatch BlockApplyCounts=%+v, want accepted=0 rejected=1", got)
+	}
+
+	engine = newEmptyEngine(t, devnetGenesisChainID)
+	badGenesis := buildSingleTxBlock(t, [32]byte{}, target, reorgTestTimestamp(1), coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 0, 0))
+	if _, err := engine.ApplyBlock(badGenesis, nil); err == nil {
+		t.Fatalf("expected genesis_hash mismatch")
+	}
+	if got := engine.BlockApplyCounts(); got.Accepted != 0 || got.Rejected != 1 {
+		t.Fatalf("genesis_hash mismatch BlockApplyCounts=%+v, want accepted=0 rejected=1", got)
 	}
 }
 

--- a/clients/go/node/sync_reorg_test.go
+++ b/clients/go/node/sync_reorg_test.go
@@ -55,6 +55,7 @@ func TestReorgTwoMiners(t *testing.T) {
 	} else if work.Sign() <= 0 {
 		t.Fatalf("ChainWork(B1)=%s, want positive", work)
 	}
+	beforeReorgCounts := engine.BlockApplyCounts()
 
 	subsidy2 := consensus.BlockSubsidy(2, subsidy1)
 	blockB1Hash, err := consensus.BlockHash(blockHeaderBytes(t, blockB1))
@@ -74,6 +75,9 @@ func TestReorgTwoMiners(t *testing.T) {
 	}
 	if count := engine.ReorgCount(); count != 1 {
 		t.Fatalf("ReorgCount()=%d, want 1", count)
+	}
+	if after := engine.BlockApplyCounts(); after.Accepted != beforeReorgCounts.Accepted+2 || after.Rejected != beforeReorgCounts.Rejected {
+		t.Fatalf("BlockApplyCounts after successful reorg=%+v, want accepted=%d rejected=%d", after, beforeReorgCounts.Accepted+2, beforeReorgCounts.Rejected)
 	}
 
 	b1CanonicalHash, ok, err := store.CanonicalHash(1)
@@ -807,6 +811,9 @@ func TestApplyBlockWithReorgRollbackRestoresMempoolAfterPersistFailure(t *testin
 	subsidyB102 := consensus.BlockSubsidy(102, alreadyGenerated+subsidyB101)
 	blockB102 := buildSingleTxBlock(t, blockB101Hash, target, 204, reorgTestCoinbaseForAddress(t, 102, subsidyB102, destAddress))
 
+	beforeReorgCounts := engine.BlockApplyCounts()
+	var duringFailedCommitCounts BlockApplyCounts
+	observedFailedCommit := false
 	prevWrite := writeFileAtomicFn
 	t.Cleanup(func() { writeFileAtomicFn = prevWrite })
 	indexWrites := 0
@@ -814,6 +821,8 @@ func TestApplyBlockWithReorgRollbackRestoresMempoolAfterPersistFailure(t *testin
 		if path == store.indexPath {
 			indexWrites++
 			if indexWrites == 3 {
+				observedFailedCommit = true
+				duringFailedCommitCounts = engine.BlockApplyCounts()
 				return os.ErrPermission
 			}
 		}
@@ -822,6 +831,15 @@ func TestApplyBlockWithReorgRollbackRestoresMempoolAfterPersistFailure(t *testin
 
 	if _, err := engine.ApplyBlockWithReorg(blockB102, nil); err == nil {
 		t.Fatalf("expected reorg persist failure")
+	}
+	if !observedFailedCommit {
+		t.Fatalf("expected forced index write failure to be observed")
+	}
+	if duringFailedCommitCounts != beforeReorgCounts {
+		t.Fatalf("speculative reorg apply published BlockApplyCounts before rollback: got %+v want %+v", duringFailedCommitCounts, beforeReorgCounts)
+	}
+	if after := engine.BlockApplyCounts(); after != beforeReorgCounts {
+		t.Fatalf("failed reorg changed BlockApplyCounts from %+v to %+v", beforeReorgCounts, after)
 	}
 	if engine.chainState.Height != summaryA101.BlockHeight || engine.chainState.TipHash != summaryA101.BlockHash {
 		t.Fatalf("chainstate tip changed after rollback: height=%d hash=%x", engine.chainState.Height, engine.chainState.TipHash)

--- a/clients/go/node/sync_reorg_test.go
+++ b/clients/go/node/sync_reorg_test.go
@@ -173,11 +173,15 @@ func blockHeaderBytes(t *testing.T, blockBytes []byte) []byte {
 
 func TestApplyBlockWithReorgRejectsMissingParent(t *testing.T) {
 	engine, _, target := newReorgTestEngine(t)
+	before := engine.BlockApplyCounts()
 	var missingParent [32]byte
 	missingParent[0] = 0x42
 	block := buildSingleTxBlock(t, missingParent, target, 77, coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 1, consensus.BlockSubsidy(1, 0)))
 	if _, err := engine.ApplyBlockWithReorg(block, nil); !errors.Is(err, ErrParentNotFound) {
 		t.Fatalf("ApplyBlockWithReorg(missing parent) err=%v, want ErrParentNotFound", err)
+	}
+	if after := engine.BlockApplyCounts(); after != before {
+		t.Fatalf("missing-parent block changed BlockApplyCounts from %+v to %+v", before, after)
 	}
 }
 
@@ -198,8 +202,12 @@ func TestApplyBlockWithReorgRejectsInvalidNonHeavierSideBranch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BlockHash(invalid B1): %v", err)
 	}
+	beforeInvalidSide := engine.BlockApplyCounts()
 	if _, err := engine.ApplyBlockWithReorg(invalidB1, nil); err == nil {
 		t.Fatalf("expected invalid competing branch rejection")
+	}
+	if after := engine.BlockApplyCounts(); after != beforeInvalidSide {
+		t.Fatalf("invalid non-canonical side branch changed BlockApplyCounts from %+v to %+v", beforeInvalidSide, after)
 	}
 
 	if engine.chainState.Height != 1 || engine.chainState.TipHash != summaryA1.BlockHash {
@@ -956,9 +964,13 @@ func TestApplyBlockWithReorgKeepsLighterSideBranchOffCanonicalTip(t *testing.T) 
 	}
 
 	sideB1 := buildSingleTxBlock(t, devnetGenesisBlockHash, target, 4, coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 1, subsidy1))
+	beforeSide := engine.BlockApplyCounts()
 	sideSummary, err := engine.ApplyBlockWithReorg(sideB1, nil)
 	if err != nil {
 		t.Fatalf("ApplyBlockWithReorg(B1): %v", err)
+	}
+	if after := engine.BlockApplyCounts(); after != beforeSide {
+		t.Fatalf("lighter side branch changed BlockApplyCounts from %+v to %+v", beforeSide, after)
 	}
 	if sideSummary.BlockHeight != 1 {
 		t.Fatalf("side branch synthetic height=%d, want 1", sideSummary.BlockHeight)

--- a/clients/go/node/sync_test.go
+++ b/clients/go/node/sync_test.go
@@ -383,6 +383,65 @@ func TestSyncEngineApplyBlockPersistsChainstateAndStore(t *testing.T) {
 	}
 }
 
+func TestSyncEngineBlockApplyCountsCanonicalAcceptedRejected(t *testing.T) {
+	dir := t.TempDir()
+	chainStatePath := ChainStatePath(dir)
+	store, err := OpenBlockStore(BlockStorePath(dir))
+	if err != nil {
+		t.Fatalf("open blockstore: %v", err)
+	}
+	st := NewChainState()
+	target := consensus.POW_LIMIT
+	engine, err := NewSyncEngine(st, store, DefaultSyncConfig(&target, devnetGenesisChainID, chainStatePath))
+	if err != nil {
+		t.Fatalf("new sync engine: %v", err)
+	}
+	if got := engine.BlockApplyCounts(); got != (BlockApplyCounts{}) {
+		t.Fatalf("initial BlockApplyCounts=%+v, want zero", got)
+	}
+
+	if _, err := engine.ApplyBlock(devnetGenesisBlockBytes, nil); err != nil {
+		t.Fatalf("ApplyBlock(genesis): %v", err)
+	}
+	if got := engine.BlockApplyCounts(); got.Accepted != 1 || got.Rejected != 0 {
+		t.Fatalf("after genesis BlockApplyCounts=%+v, want accepted=1 rejected=0", got)
+	}
+
+	block1Coinbase := coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 1, 1)
+	block1 := buildSingleTxBlock(t, devnetGenesisBlockHash, target, 2, block1Coinbase)
+	summary1, err := engine.ApplyBlock(block1, nil)
+	if err != nil {
+		t.Fatalf("ApplyBlock(block1): %v", err)
+	}
+	if got := engine.BlockApplyCounts(); got.Accepted != 2 || got.Rejected != 0 {
+		t.Fatalf("after block1 BlockApplyCounts=%+v, want accepted=2 rejected=0", got)
+	}
+	tipHeight, tipHash, ok, err := store.Tip()
+	if err != nil {
+		t.Fatalf("Tip after accepted block1: %v", err)
+	}
+	if !ok || tipHeight != summary1.BlockHeight || tipHash != summary1.BlockHash {
+		t.Fatalf("canonical tip after accepted block1=%d/%x ok=%v, want %d/%x", tipHeight, tipHash, ok, summary1.BlockHeight, summary1.BlockHash)
+	}
+
+	block2Coinbase := coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 2, consensus.BlockSubsidy(2, summary1.AlreadyGenerated))
+	invalidBlock2 := append([]byte(nil), buildSingleTxBlock(t, summary1.BlockHash, target, 3, block2Coinbase)...)
+	invalidBlock2[4+32] ^= 0x01 // keep the block parseable but break merkle-root validation.
+	if _, err := engine.ApplyBlock(invalidBlock2, nil); err == nil {
+		t.Fatalf("expected invalid canonical block rejection")
+	}
+	if got := engine.BlockApplyCounts(); got.Accepted != 2 || got.Rejected != 1 {
+		t.Fatalf("after invalid block BlockApplyCounts=%+v, want accepted=2 rejected=1", got)
+	}
+	tipHeight, tipHash, ok, err = store.Tip()
+	if err != nil {
+		t.Fatalf("Tip after rejected block2: %v", err)
+	}
+	if !ok || tipHeight != summary1.BlockHeight || tipHash != summary1.BlockHash {
+		t.Fatalf("canonical tip changed after rejected block2=%d/%x ok=%v, want %d/%x", tipHeight, tipHash, ok, summary1.BlockHeight, summary1.BlockHash)
+	}
+}
+
 // TestSyncEngineApplyBlockPutUndoFailureRollsBackCanonicalTip lives in
 // sync_unix_test.go behind a `//go:build unix` tag: after the E.3
 // TOCTOU hardening the undo write no longer routes through
@@ -625,6 +684,9 @@ func TestSyncEngineApplyBlock_RollbackOnSaveFailure(t *testing.T) {
 		t.Fatalf("expected apply error")
 	}
 
+	if got := engine.BlockApplyCounts(); got != (BlockApplyCounts{}) {
+		t.Fatalf("persist failure changed BlockApplyCounts=%+v, want zero", got)
+	}
 	after, err := stateToDisk(st)
 	if err != nil {
 		t.Fatalf("stateToDisk after: %v", err)

--- a/clients/go/node/sync_test.go
+++ b/clients/go/node/sync_test.go
@@ -153,6 +153,15 @@ func TestPVShadowStats_NilEngine(t *testing.T) {
 	}
 }
 
+func TestBlockApplyCountsNilEngine(t *testing.T) {
+	var nilEngine *SyncEngine
+	if got := nilEngine.BlockApplyCounts(); got != (BlockApplyCounts{}) {
+		t.Fatalf("nil BlockApplyCounts=%+v, want zero", got)
+	}
+	nilEngine.noteBlockApplyAccepted()
+	nilEngine.noteBlockApplyRejected()
+}
+
 func TestPVShadowMismatch_IsBounded(t *testing.T) {
 	st := NewChainState()
 	cfg := DefaultSyncConfig(nil, [32]byte{}, "")

--- a/clients/go/node/sync_test.go
+++ b/clients/go/node/sync_test.go
@@ -159,7 +159,14 @@ func TestBlockApplyCountsNilEngine(t *testing.T) {
 		t.Fatalf("nil BlockApplyCounts=%+v, want zero", got)
 	}
 	nilEngine.noteBlockApplyAccepted()
+	nilEngine.noteBlockApplyAcceptedN(2)
 	nilEngine.noteBlockApplyRejected()
+	nilEngine.noteBlockApplyOutcome(blockApplyMetricNone)
+	nilEngine.noteBlockApplyOutcome(blockApplyMetricAccepted)
+	nilEngine.noteBlockApplyOutcome(blockApplyMetricRejected)
+	if got := nilEngine.BlockApplyCounts(); got != (BlockApplyCounts{}) {
+		t.Fatalf("nil BlockApplyCounts after notes=%+v, want zero", got)
+	}
 }
 
 func TestPVShadowMismatch_IsBounded(t *testing.T) {


### PR DESCRIPTION
Closes #1294.

Architecture class: B

System boundary:
- Go SyncEngine canonical block apply metrics
- Go /metrics renderer
- Focused Go node and RPC tests

Single invariant:
- `rubin_node_block_apply_total{result="accepted"}` counts final canonical apply success only.
- `rubin_node_block_apply_total{result="rejected"}` counts canonical validation/apply reject only.

Non-goals:
- No orphan metrics.
- No reorg metric changes.
- No Rust changes.
- No block validation behavior changes.
- No dashboard/schema redesign.

Local verification:
- Focused Go node/RPC tests passed.
- Go deep tooling gate passed.
- `rubin-common-preflight` passed.
- Hostile review PASS: `REQ-20260428T161144Z-2b18dc8-fixpass`.
