### PR TITLE
node: add mempool entry metadata indexes

### DIFF
--- a/clients/go/node/coverage_sub80_followup_test.go
+++ b/clients/go/node/coverage_sub80_followup_test.go
@@ -109,7 +109,9 @@ func TestCoverageResidual_MempoolLimitBranches(t *testing.T) {
 	if err := mp.validateAdmissionLocked(&mempoolEntry{txid: [32]byte{0x01}, size: 0}); err == nil {
 		t.Fatalf("expected invalid size rejection")
 	}
-	mp.addEntryLocked(&mempoolEntry{txid: [32]byte{0x02}, size: 1})
+	if err := mp.addEntryLocked(&mempoolEntry{txid: [32]byte{0x02}, size: 1}); err != nil {
+		t.Fatalf("addEntryLocked(count seed): %v", err)
+	}
 	if err := mp.validateAdmissionLocked(&mempoolEntry{txid: [32]byte{0x03}, size: 1}); err == nil {
 		t.Fatalf("expected count-limit rejection")
 	}
@@ -123,7 +125,9 @@ func TestCoverageResidual_MempoolLimitBranches(t *testing.T) {
 		t.Fatalf("NewMempool(bytes): %v", err)
 	}
 	mpBytes.mu.Lock()
-	mpBytes.addEntryLocked(&mempoolEntry{txid: [32]byte{0x04}, size: 1})
+	if err := mpBytes.addEntryLocked(&mempoolEntry{txid: [32]byte{0x04}, size: 1}); err != nil {
+		t.Fatalf("addEntryLocked(byte seed): %v", err)
+	}
 	if err := mpBytes.validateAdmissionLocked(&mempoolEntry{txid: [32]byte{0x05}, size: 2}); err == nil {
 		t.Fatalf("expected byte-limit rejection")
 	}

--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -335,8 +335,7 @@ func (m *Mempool) addTxWithSource(txBytes []byte, source mempoolTxSource) (retEr
 		return err
 	}
 
-	m.addEntryLocked(entry)
-	return nil
+	return m.addEntryLocked(entry)
 }
 
 func validMempoolTxSource(source mempoolTxSource) bool {
@@ -667,6 +666,9 @@ func (m *Mempool) validateAdmissionLocked(entry *mempoolEntry) error {
 		return txAdmitRejected("invalid mempool entry size")
 	}
 	txid := entry.txid
+	if txid == ([32]byte{}) {
+		return txAdmitRejected("invalid mempool entry txid")
+	}
 	if _, exists := m.txs[txid]; exists {
 		return txAdmitConflict("tx already in mempool")
 	}
@@ -707,7 +709,16 @@ func newMempoolEntry(checked *consensus.CheckedTransaction, inputs []consensus.O
 	}
 }
 
-func (m *Mempool) addEntryLocked(entry *mempoolEntry) {
+func (m *Mempool) addEntryLocked(entry *mempoolEntry) error {
+	if entry == nil {
+		return txAdmitRejected("nil mempool entry")
+	}
+	if entry.size <= 0 {
+		return txAdmitRejected("invalid mempool entry size")
+	}
+	if entry.txid == ([32]byte{}) {
+		return txAdmitRejected("invalid mempool entry txid")
+	}
 	if m.txs == nil {
 		m.txs = make(map[[32]byte]*mempoolEntry)
 	}
@@ -735,6 +746,7 @@ func (m *Mempool) addEntryLocked(entry *mempoolEntry) {
 	for _, op := range entry.inputs {
 		m.spenders[op] = entry.txid
 	}
+	return nil
 }
 
 func (m *Mempool) snapshotEntries() []*mempoolEntry {

--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -670,6 +670,9 @@ func (m *Mempool) validateAdmissionLocked(entry *mempoolEntry) error {
 	if _, exists := m.txs[txid]; exists {
 		return txAdmitConflict("tx already in mempool")
 	}
+	if existing, exists := m.wtxids[entry.wtxid]; exists {
+		return txAdmitConflict(fmt.Sprintf("mempool wtxid conflict with %x", existing))
+	}
 	for _, op := range entry.inputs {
 		if existing, ok := m.spenders[op]; ok {
 			return txAdmitConflict(fmt.Sprintf("mempool double-spend conflict with %x", existing))

--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -670,7 +670,11 @@ func (m *Mempool) validateAdmissionLocked(entry *mempoolEntry) error {
 	if _, exists := m.txs[txid]; exists {
 		return txAdmitConflict("tx already in mempool")
 	}
-	if existing, exists := m.wtxids[entry.wtxid]; exists {
+	wtxid := entry.wtxid
+	if wtxid == ([32]byte{}) {
+		wtxid = entry.txid
+	}
+	if existing, exists := m.wtxids[wtxid]; exists {
 		return txAdmitConflict(fmt.Sprintf("mempool wtxid conflict with %x", existing))
 	}
 	for _, op := range entry.inputs {
@@ -721,6 +725,9 @@ func (m *Mempool) addEntryLocked(entry *mempoolEntry) {
 	}
 	if entry.source == "" {
 		entry.source = mempoolTxSourceLocal
+	}
+	if entry.wtxid == ([32]byte{}) {
+		entry.wtxid = entry.txid
 	}
 	m.txs[entry.txid] = entry
 	m.wtxids[entry.wtxid] = entry.txid

--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -297,6 +297,18 @@ func (m *Mempool) AddTx(txBytes []byte) (retErr error) {
 	return m.addTxWithSource(txBytes, mempoolTxSourceLocal)
 }
 
+// AddRemoteTx admits a transaction received from a peer while preserving the
+// same validation and admission policy as AddTx. The source is metadata only.
+func (m *Mempool) AddRemoteTx(txBytes []byte) (retErr error) {
+	return m.addTxWithSource(txBytes, mempoolTxSourceRemote)
+}
+
+// AddReorgTx admits a transaction requeued from a disconnected canonical block
+// while preserving the same validation and admission policy as AddTx.
+func (m *Mempool) AddReorgTx(txBytes []byte) (retErr error) {
+	return m.addTxWithSource(txBytes, mempoolTxSourceReorg)
+}
+
 // addTxWithSource validates and admits a transaction while recording the
 // caller-declared origin in the mempool entry. The source is metadata only in
 // this foundation slice; it must not influence admission or eviction behavior.

--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -17,26 +17,39 @@ const (
 	DefaultMempoolMaxBytes        = consensus.MAX_RELAY_MSG_BYTES
 )
 
+type mempoolTxSource string
+
+const (
+	mempoolTxSourceRemote mempoolTxSource = "remote"
+	mempoolTxSourceLocal  mempoolTxSource = "local"
+	mempoolTxSourceReorg  mempoolTxSource = "reorg"
+)
+
 type mempoolEntry struct {
-	raw    []byte
-	txid   [32]byte
-	inputs []consensus.Outpoint
-	fee    uint64
-	weight uint64
-	size   int
+	raw          []byte
+	txid         [32]byte
+	wtxid        [32]byte
+	inputs       []consensus.Outpoint
+	fee          uint64
+	weight       uint64
+	size         int
+	admissionSeq uint64
+	source       mempoolTxSource
 }
 
 type Mempool struct {
-	mu         sync.RWMutex
-	chainState *ChainState
-	blockStore *BlockStore
-	chainID    [32]byte
-	policy     MempoolConfig
-	maxTxs     int
-	maxBytes   int
-	usedBytes  int
-	txs        map[[32]byte]*mempoolEntry
-	spenders   map[consensus.Outpoint][32]byte
+	mu               sync.RWMutex
+	chainState       *ChainState
+	blockStore       *BlockStore
+	chainID          [32]byte
+	policy           MempoolConfig
+	maxTxs           int
+	maxBytes         int
+	usedBytes        int
+	nextAdmissionSeq uint64
+	txs              map[[32]byte]*mempoolEntry
+	wtxids           map[[32]byte][32]byte
+	spenders         map[consensus.Outpoint][32]byte
 	// Admission counters are bumped exactly once for each AddTx call on a
 	// non-nil Mempool that reaches the final outcome accounting path.
 	// Nil-receiver calls return before that defer is registered and are
@@ -143,6 +156,7 @@ func NewMempoolWithConfig(chainState *ChainState, blockStore *BlockStore, chainI
 		maxTxs:     cfg.MaxTransactions,
 		maxBytes:   cfg.MaxBytes,
 		txs:        make(map[[32]byte]*mempoolEntry),
+		wtxids:     make(map[[32]byte][32]byte),
 		spenders:   make(map[consensus.Outpoint][32]byte),
 	}, nil
 }
@@ -280,6 +294,13 @@ func (m *Mempool) Contains(txid [32]byte) bool {
 }
 
 func (m *Mempool) AddTx(txBytes []byte) (retErr error) {
+	return m.addTxWithSource(txBytes, mempoolTxSourceLocal)
+}
+
+// addTxWithSource validates and admits a transaction while recording the
+// caller-declared origin in the mempool entry. The source is metadata only in
+// this foundation slice; it must not influence admission or eviction behavior.
+func (m *Mempool) addTxWithSource(txBytes []byte, source mempoolTxSource) (retErr error) {
 	if m == nil {
 		return txAdmitUnavailable("nil mempool")
 	}
@@ -291,6 +312,9 @@ func (m *Mempool) AddTx(txBytes []byte) (retErr error) {
 	defer func() { m.noteAdmissionResult(retErr) }()
 	if m.chainState == nil {
 		return txAdmitUnavailable("nil chainstate")
+	}
+	if !validMempoolTxSource(source) {
+		return txAdmitRejected(fmt.Sprintf("invalid mempool tx source %q", source))
 	}
 
 	m.chainState.admissionMu.RLock()
@@ -306,13 +330,22 @@ func (m *Mempool) AddTx(txBytes []byte) (retErr error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	entry := newMempoolEntry(checked, inputs)
+	entry := newMempoolEntry(checked, inputs, source)
 	if err := m.validateAdmissionLocked(entry); err != nil {
 		return err
 	}
 
 	m.addEntryLocked(entry)
 	return nil
+}
+
+func validMempoolTxSource(source mempoolTxSource) bool {
+	switch source {
+	case mempoolTxSourceRemote, mempoolTxSourceLocal, mempoolTxSourceReorg:
+		return true
+	default:
+		return false
+	}
 }
 
 func (m *Mempool) RelayMetadata(txBytes []byte) (RelayTxMetadata, error) {
@@ -648,22 +681,46 @@ func (m *Mempool) validateAdmissionLocked(entry *mempoolEntry) error {
 	if entry.size > m.maxBytes || m.usedBytes > m.maxBytes-entry.size {
 		return txAdmitUnavailable(fmt.Sprintf("mempool byte limit exceeded: current=%d tx=%d max=%d", m.usedBytes, entry.size, m.maxBytes))
 	}
+	if m.nextAdmissionSeq == ^uint64(0) {
+		return txAdmitUnavailable("mempool admission sequence exhausted")
+	}
 	return nil
 }
 
-func newMempoolEntry(checked *consensus.CheckedTransaction, inputs []consensus.Outpoint) *mempoolEntry {
+func newMempoolEntry(checked *consensus.CheckedTransaction, inputs []consensus.Outpoint, source mempoolTxSource) *mempoolEntry {
 	return &mempoolEntry{
 		raw:    append([]byte(nil), checked.Bytes...),
 		txid:   checked.TxID,
+		wtxid:  checked.WTxID,
 		inputs: append([]consensus.Outpoint(nil), inputs...),
 		fee:    checked.Fee,
 		weight: checked.Weight,
 		size:   checked.SerializedSize,
+		source: source,
 	}
 }
 
 func (m *Mempool) addEntryLocked(entry *mempoolEntry) {
+	if m.txs == nil {
+		m.txs = make(map[[32]byte]*mempoolEntry)
+	}
+	if m.wtxids == nil {
+		m.wtxids = make(map[[32]byte][32]byte)
+	}
+	if m.spenders == nil {
+		m.spenders = make(map[consensus.Outpoint][32]byte)
+	}
+	if entry.admissionSeq == 0 {
+		m.nextAdmissionSeq++
+		entry.admissionSeq = m.nextAdmissionSeq
+	} else if entry.admissionSeq > m.nextAdmissionSeq {
+		m.nextAdmissionSeq = entry.admissionSeq
+	}
+	if entry.source == "" {
+		entry.source = mempoolTxSourceLocal
+	}
 	m.txs[entry.txid] = entry
+	m.wtxids[entry.wtxid] = entry.txid
 	m.usedBytes += entry.size
 	for _, op := range entry.inputs {
 		m.spenders[op] = entry.txid
@@ -744,6 +801,9 @@ func (m *Mempool) deleteEntryLocked(txid [32]byte, entry *mempoolEntry) {
 	}
 	for _, op := range entry.inputs {
 		delete(m.spenders, op)
+	}
+	if existing, ok := m.wtxids[entry.wtxid]; ok && existing == txid {
+		delete(m.wtxids, entry.wtxid)
 	}
 }
 

--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -46,7 +46,7 @@ type Mempool struct {
 	maxTxs           int
 	maxBytes         int
 	usedBytes        int
-	nextAdmissionSeq uint64
+	lastAdmissionSeq uint64
 	txs              map[[32]byte]*mempoolEntry
 	wtxids           map[[32]byte][32]byte
 	spenders         map[consensus.Outpoint][32]byte
@@ -681,7 +681,7 @@ func (m *Mempool) validateAdmissionLocked(entry *mempoolEntry) error {
 	if entry.size > m.maxBytes || m.usedBytes > m.maxBytes-entry.size {
 		return txAdmitUnavailable(fmt.Sprintf("mempool byte limit exceeded: current=%d tx=%d max=%d", m.usedBytes, entry.size, m.maxBytes))
 	}
-	if m.nextAdmissionSeq == ^uint64(0) {
+	if m.lastAdmissionSeq == ^uint64(0) {
 		return txAdmitUnavailable("mempool admission sequence exhausted")
 	}
 	return nil
@@ -711,10 +711,10 @@ func (m *Mempool) addEntryLocked(entry *mempoolEntry) {
 		m.spenders = make(map[consensus.Outpoint][32]byte)
 	}
 	if entry.admissionSeq == 0 {
-		m.nextAdmissionSeq++
-		entry.admissionSeq = m.nextAdmissionSeq
-	} else if entry.admissionSeq > m.nextAdmissionSeq {
-		m.nextAdmissionSeq = entry.admissionSeq
+		m.lastAdmissionSeq++
+		entry.admissionSeq = m.lastAdmissionSeq
+	} else if entry.admissionSeq > m.lastAdmissionSeq {
+		m.lastAdmissionSeq = entry.admissionSeq
 	}
 	if entry.source == "" {
 		entry.source = mempoolTxSourceLocal

--- a/clients/go/node/mempool_test.go
+++ b/clients/go/node/mempool_test.go
@@ -1221,6 +1221,56 @@ func TestRestoreMempoolSnapshotRecomputesByteAccounting(t *testing.T) {
 	}
 }
 
+func TestRestoreMempoolSnapshotPreservesAdmissionSeqHighWatermark(t *testing.T) {
+	fromKey := mustNodeMLDSA87Keypair(t)
+	toKey := mustNodeMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{100, 100, 100})
+
+	mp, err := NewMempool(st, nil, devnetGenesisChainID)
+	if err != nil {
+		t.Fatalf("new mempool: %v", err)
+	}
+	tx1 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 1, 1, fromKey, fromAddress, toAddress)
+	tx2 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[1]}, 90, 1, 2, fromKey, fromAddress, toAddress)
+	tx3 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[2]}, 90, 1, 3, fromKey, fromAddress, toAddress)
+	if err := mp.AddTx(tx1); err != nil {
+		t.Fatalf("AddTx(tx1): %v", err)
+	}
+	if err := mp.AddTx(tx2); err != nil {
+		t.Fatalf("AddTx(tx2): %v", err)
+	}
+	tx2ID := txID(t, tx2)
+	mp.mu.Lock()
+	mp.removeTxLocked(tx2ID)
+	if mp.lastAdmissionSeq != 2 {
+		t.Fatalf("lastAdmissionSeq after removing tx2=%d, want 2", mp.lastAdmissionSeq)
+	}
+	mp.mu.Unlock()
+
+	snapshot, err := snapshotMempool(mp)
+	if err != nil {
+		t.Fatalf("snapshotMempool: %v", err)
+	}
+	if snapshot.lastAdmissionSeq != 2 {
+		t.Fatalf("snapshot lastAdmissionSeq=%d, want 2", snapshot.lastAdmissionSeq)
+	}
+	if err := restoreMempoolSnapshot(mp, snapshot); err != nil {
+		t.Fatalf("restoreMempoolSnapshot: %v", err)
+	}
+	if mp.lastAdmissionSeq != 2 {
+		t.Fatalf("lastAdmissionSeq after restore=%d, want 2", mp.lastAdmissionSeq)
+	}
+	if err := mp.AddTx(tx3); err != nil {
+		t.Fatalf("AddTx(tx3): %v", err)
+	}
+	tx3ID := txID(t, tx3)
+	if got := mp.txs[tx3ID].admissionSeq; got != 3 {
+		t.Fatalf("tx3 admissionSeq=%d, want 3", got)
+	}
+}
+
 func TestRestoreMempoolSnapshotRejectsInvalidEntriesWithoutMutation(t *testing.T) {
 	fromKey := mustNodeMLDSA87Keypair(t)
 	toKey := mustNodeMLDSA87Keypair(t)
@@ -1269,7 +1319,7 @@ func TestRestoreMempoolSnapshotRejectsInvalidEntriesWithoutMutation(t *testing.T
 		for i := range base.entries {
 			entries = append(entries, cloneMempoolEntry(&base.entries[i]))
 		}
-		return mempoolSnapshot{entries: entries}
+		return mempoolSnapshot{entries: entries, lastAdmissionSeq: base.lastAdmissionSeq}
 	}
 	withEditedFirst := func(edit func(*mempoolEntry)) func(mempoolSnapshot) mempoolSnapshot {
 		return func(base mempoolSnapshot) mempoolSnapshot {
@@ -1374,6 +1424,15 @@ func TestRestoreMempoolSnapshotRejectsInvalidEntriesWithoutMutation(t *testing.T
 				return bad
 			},
 			want: "duplicate mempool snapshot wtxid",
+		},
+		{
+			name: "admission_high_watermark_below_entry_max",
+			mutate: func(base mempoolSnapshot) mempoolSnapshot {
+				bad := cloneSnapshotForTest(base)
+				bad.lastAdmissionSeq = bad.entries[0].admissionSeq - 1
+				return bad
+			},
+			want: "mempool snapshot admission high-watermark below restored max",
 		},
 		{
 			name: "duplicate_spender",

--- a/clients/go/node/mempool_test.go
+++ b/clients/go/node/mempool_test.go
@@ -163,6 +163,33 @@ func TestMempoolAddEntryLockedInitializesMetadataIndexes(t *testing.T) {
 	}
 }
 
+func TestMempoolAddEntryLockedDefaultsUnsetWtxid(t *testing.T) {
+	entry := &mempoolEntry{
+		txid: [32]byte{0x0a},
+		size: 1,
+	}
+
+	mp := &Mempool{
+		maxTxs:   1,
+		maxBytes: 10,
+	}
+	mp.addEntryLocked(entry)
+
+	if entry.wtxid != entry.txid {
+		t.Fatalf("entry wtxid=%x, want txid %x", entry.wtxid, entry.txid)
+	}
+	if got, ok := mp.wtxids[entry.txid]; !ok || got != entry.txid {
+		t.Fatalf("wtxid index got %x ok=%v, want txid %x", got, ok, entry.txid)
+	}
+	if got, ok := mp.wtxids[[32]byte{}]; ok {
+		t.Fatalf("zero wtxid key unexpectedly indexed txid %x", got)
+	}
+	err := mp.validateAdmissionLocked(&mempoolEntry{txid: [32]byte{0x0b}, size: 1})
+	if err == nil || !strings.Contains(err.Error(), "mempool transaction count limit reached") {
+		t.Fatalf("expected count-limit rejection after zero-wtxid default, got %v", err)
+	}
+}
+
 func TestMempoolEntryIndexesRemovedWithEntry(t *testing.T) {
 	fromKey := mustNodeMLDSA87Keypair(t)
 	toKey := mustNodeMLDSA87Keypair(t)

--- a/clients/go/node/mempool_test.go
+++ b/clients/go/node/mempool_test.go
@@ -98,6 +98,71 @@ func TestMempoolAcceptedEntryMetadataAndIndexes(t *testing.T) {
 	}
 }
 
+func TestMempoolRejectsInvalidEntrySource(t *testing.T) {
+	fromKey := mustNodeMLDSA87Keypair(t)
+	toKey := mustNodeMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{100})
+
+	mp, err := NewMempool(st, nil, devnetGenesisChainID)
+	if err != nil {
+		t.Fatalf("new mempool: %v", err)
+	}
+	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 1, 1, fromKey, fromAddress, toAddress)
+	err = mp.addTxWithSource(txBytes, "sidecar")
+	if err == nil || !strings.Contains(err.Error(), "invalid mempool tx source") {
+		t.Fatalf("expected invalid source rejection, got %v", err)
+	}
+	var txErr *TxAdmitError
+	if !errors.As(err, &txErr) {
+		t.Fatalf("expected TxAdmitError, got %T: %v", err, err)
+	}
+	if txErr.Kind != TxAdmitRejected {
+		t.Fatalf("expected TxAdmitRejected, got %v", txErr.Kind)
+	}
+	if got := mp.Len(); got != 0 {
+		t.Fatalf("mempool len=%d, want 0", got)
+	}
+	if mp.nextAdmissionSeq != 0 {
+		t.Fatalf("nextAdmissionSeq after invalid source=%d, want 0", mp.nextAdmissionSeq)
+	}
+}
+
+func TestMempoolAddEntryLockedInitializesMetadataIndexes(t *testing.T) {
+	op := consensus.Outpoint{Txid: [32]byte{0x01}, Vout: 2}
+	entry := &mempoolEntry{
+		txid:         [32]byte{0x02},
+		wtxid:        [32]byte{0x03},
+		inputs:       []consensus.Outpoint{op},
+		size:         7,
+		admissionSeq: 9,
+		source:       mempoolTxSourceReorg,
+	}
+
+	mp := &Mempool{}
+	mp.addEntryLocked(entry)
+
+	if mp.txs == nil || mp.wtxids == nil || mp.spenders == nil {
+		t.Fatalf("indexes were not initialized: txs=%v wtxids=%v spenders=%v", mp.txs != nil, mp.wtxids != nil, mp.spenders != nil)
+	}
+	if got := mp.txs[entry.txid]; got != entry {
+		t.Fatalf("tx index got %p, want entry %p", got, entry)
+	}
+	if got := mp.wtxids[entry.wtxid]; got != entry.txid {
+		t.Fatalf("wtxid index got %x, want txid %x", got, entry.txid)
+	}
+	if got := mp.spenders[op]; got != entry.txid {
+		t.Fatalf("spender index got %x, want txid %x", got, entry.txid)
+	}
+	if mp.nextAdmissionSeq != entry.admissionSeq {
+		t.Fatalf("nextAdmissionSeq=%d, want %d", mp.nextAdmissionSeq, entry.admissionSeq)
+	}
+	if mp.usedBytes != entry.size {
+		t.Fatalf("usedBytes=%d, want %d", mp.usedBytes, entry.size)
+	}
+}
+
 func TestMempoolEntryIndexesRemovedWithEntry(t *testing.T) {
 	fromKey := mustNodeMLDSA87Keypair(t)
 	toKey := mustNodeMLDSA87Keypair(t)

--- a/clients/go/node/mempool_test.go
+++ b/clients/go/node/mempool_test.go
@@ -98,6 +98,66 @@ func TestMempoolAcceptedEntryMetadataAndIndexes(t *testing.T) {
 	}
 }
 
+func TestMempoolAdmissionSourceWrappersRecordOrigin(t *testing.T) {
+	fromKey := mustNodeMLDSA87Keypair(t)
+	toKey := mustNodeMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{100, 100, 100})
+
+	mp, err := NewMempool(st, nil, devnetGenesisChainID)
+	if err != nil {
+		t.Fatalf("new mempool: %v", err)
+	}
+
+	cases := []struct {
+		name      string
+		outpoint  consensus.Outpoint
+		nonce     uint64
+		source    mempoolTxSource
+		admitFunc func([]byte) error
+	}{
+		{
+			name:      "local",
+			outpoint:  outpoints[0],
+			nonce:     1,
+			source:    mempoolTxSourceLocal,
+			admitFunc: mp.AddTx,
+		},
+		{
+			name:      "remote",
+			outpoint:  outpoints[1],
+			nonce:     2,
+			source:    mempoolTxSourceRemote,
+			admitFunc: mp.AddRemoteTx,
+		},
+		{
+			name:      "reorg",
+			outpoint:  outpoints[2],
+			nonce:     3,
+			source:    mempoolTxSourceReorg,
+			admitFunc: mp.AddReorgTx,
+		},
+	}
+
+	for _, tc := range cases {
+		txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{tc.outpoint}, 90, 3, tc.nonce, fromKey, fromAddress, toAddress)
+		if err := tc.admitFunc(txBytes); err != nil {
+			t.Fatalf("%s admit: %v", tc.name, err)
+		}
+		txid := txID(t, txBytes)
+		mp.mu.RLock()
+		entry := mp.txs[txid]
+		mp.mu.RUnlock()
+		if entry == nil {
+			t.Fatalf("%s entry for txid %x missing", tc.name, txid)
+		}
+		if entry.source != tc.source {
+			t.Fatalf("%s source=%q, want %q", tc.name, entry.source, tc.source)
+		}
+	}
+}
+
 func TestMempoolRejectsInvalidEntrySource(t *testing.T) {
 	fromKey := mustNodeMLDSA87Keypair(t)
 	toKey := mustNodeMLDSA87Keypair(t)

--- a/clients/go/node/mempool_test.go
+++ b/clients/go/node/mempool_test.go
@@ -141,7 +141,9 @@ func TestMempoolAddEntryLockedInitializesMetadataIndexes(t *testing.T) {
 	}
 
 	mp := &Mempool{}
-	mp.addEntryLocked(entry)
+	if err := mp.addEntryLocked(entry); err != nil {
+		t.Fatalf("addEntryLocked: %v", err)
+	}
 
 	if mp.txs == nil || mp.wtxids == nil || mp.spenders == nil {
 		t.Fatalf("indexes were not initialized: txs=%v wtxids=%v spenders=%v", mp.txs != nil, mp.wtxids != nil, mp.spenders != nil)
@@ -173,7 +175,9 @@ func TestMempoolAddEntryLockedDefaultsUnsetWtxid(t *testing.T) {
 		maxTxs:   1,
 		maxBytes: 10,
 	}
-	mp.addEntryLocked(entry)
+	if err := mp.addEntryLocked(entry); err != nil {
+		t.Fatalf("addEntryLocked: %v", err)
+	}
 
 	if entry.wtxid != entry.txid {
 		t.Fatalf("entry wtxid=%x, want txid %x", entry.wtxid, entry.txid)
@@ -187,6 +191,29 @@ func TestMempoolAddEntryLockedDefaultsUnsetWtxid(t *testing.T) {
 	err := mp.validateAdmissionLocked(&mempoolEntry{txid: [32]byte{0x0b}, size: 1})
 	if err == nil || !strings.Contains(err.Error(), "mempool transaction count limit reached") {
 		t.Fatalf("expected count-limit rejection after zero-wtxid default, got %v", err)
+	}
+}
+
+func TestMempoolAddEntryLockedRejectsZeroTxidWithoutMutation(t *testing.T) {
+	mp := &Mempool{}
+
+	err := mp.addEntryLocked(&mempoolEntry{size: 1})
+	if err == nil || !strings.Contains(err.Error(), "invalid mempool entry txid") {
+		t.Fatalf("expected invalid txid rejection, got %v", err)
+	}
+	if mp.txs != nil || mp.wtxids != nil || mp.spenders != nil {
+		t.Fatalf("indexes initialized after zero txid reject: txs=%v wtxids=%v spenders=%v", mp.txs != nil, mp.wtxids != nil, mp.spenders != nil)
+	}
+	if mp.usedBytes != 0 {
+		t.Fatalf("usedBytes=%d, want 0 after zero txid reject", mp.usedBytes)
+	}
+	if mp.lastAdmissionSeq != 0 {
+		t.Fatalf("lastAdmissionSeq=%d, want 0 after zero txid reject", mp.lastAdmissionSeq)
+	}
+
+	err = mp.validateAdmissionLocked(&mempoolEntry{size: 1})
+	if err == nil || !strings.Contains(err.Error(), "invalid mempool entry txid") {
+		t.Fatalf("expected validate invalid txid rejection, got %v", err)
 	}
 }
 

--- a/clients/go/node/mempool_test.go
+++ b/clients/go/node/mempool_test.go
@@ -270,6 +270,62 @@ func TestMempoolAdmissionSeqDoesNotWrap(t *testing.T) {
 	}
 }
 
+func TestMempoolRejectsDuplicateWtxidIndexWithoutMutation(t *testing.T) {
+	fromKey := mustNodeMLDSA87Keypair(t)
+	toKey := mustNodeMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{100, 100})
+
+	mp, err := NewMempool(st, nil, devnetGenesisChainID)
+	if err != nil {
+		t.Fatalf("new mempool: %v", err)
+	}
+	tx1 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 1, 1, fromKey, fromAddress, toAddress)
+	if err := mp.AddTx(tx1); err != nil {
+		t.Fatalf("AddTx(tx1): %v", err)
+	}
+	tx1ID := txID(t, tx1)
+	tx2 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[1]}, 90, 1, 2, fromKey, fromAddress, toAddress)
+	_, tx2ID, tx2Wtxid, _, err := consensus.ParseTx(tx2)
+	if err != nil {
+		t.Fatalf("ParseTx(tx2): %v", err)
+	}
+
+	mp.mu.Lock()
+	mp.wtxids[tx2Wtxid] = tx1ID
+	usedBytes := mp.usedBytes
+	lastAdmissionSeq := mp.lastAdmissionSeq
+	mp.mu.Unlock()
+
+	err = mp.AddTx(tx2)
+	if err == nil || !strings.Contains(err.Error(), "mempool wtxid conflict") {
+		t.Fatalf("expected wtxid conflict rejection, got %v", err)
+	}
+	var txErr *TxAdmitError
+	if !errors.As(err, &txErr) {
+		t.Fatalf("expected TxAdmitError, got %T: %v", err, err)
+	}
+	if txErr.Kind != TxAdmitConflict {
+		t.Fatalf("expected TxAdmitConflict, got %v", txErr.Kind)
+	}
+	if got := mp.Len(); got != 1 {
+		t.Fatalf("mempool len=%d, want 1 after wtxid conflict", got)
+	}
+	if mp.Contains(tx2ID) {
+		t.Fatalf("wtxid conflict admitted tx2 %x", tx2ID)
+	}
+	if mp.usedBytes != usedBytes {
+		t.Fatalf("usedBytes=%d, want %d after wtxid conflict", mp.usedBytes, usedBytes)
+	}
+	if mp.lastAdmissionSeq != lastAdmissionSeq {
+		t.Fatalf("lastAdmissionSeq=%d, want %d after wtxid conflict", mp.lastAdmissionSeq, lastAdmissionSeq)
+	}
+	if got := mp.wtxids[tx2Wtxid]; got != tx1ID {
+		t.Fatalf("wtxid index overwritten with %x, want existing %x", got, tx1ID)
+	}
+}
+
 func TestMempoolAddTxWaitsForChainStateWriter(t *testing.T) {
 	fromKey := mustNodeMLDSA87Keypair(t)
 	toKey := mustNodeMLDSA87Keypair(t)
@@ -1307,6 +1363,17 @@ func TestRestoreMempoolSnapshotRejectsInvalidEntriesWithoutMutation(t *testing.T
 				return bad
 			},
 			want: "duplicate mempool snapshot admission_seq",
+		},
+		{
+			name: "duplicate_wtxid",
+			mutate: func(base mempoolSnapshot) mempoolSnapshot {
+				bad := cloneSnapshotForTest(base)
+				duplicate := snapshotEntry(txSecond, txSecondID, []consensus.Outpoint{outpoints[1]})
+				duplicate.wtxid = bad.entries[0].wtxid
+				bad.entries = append(bad.entries, duplicate)
+				return bad
+			},
+			want: "duplicate mempool snapshot wtxid",
 		},
 		{
 			name: "duplicate_spender",

--- a/clients/go/node/mempool_test.go
+++ b/clients/go/node/mempool_test.go
@@ -35,6 +35,176 @@ func TestMempoolAdd(t *testing.T) {
 	}
 }
 
+func TestMempoolAcceptedEntryMetadataAndIndexes(t *testing.T) {
+	fromKey := mustNodeMLDSA87Keypair(t)
+	toKey := mustNodeMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{100})
+
+	mp, err := NewMempool(st, nil, devnetGenesisChainID)
+	if err != nil {
+		t.Fatalf("new mempool: %v", err)
+	}
+	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 3, 1, fromKey, fromAddress, toAddress)
+	tx, txid, wtxid, _, err := consensus.ParseTx(txBytes)
+	if err != nil {
+		t.Fatalf("ParseTx: %v", err)
+	}
+	weight, _, _, err := consensus.TxWeightAndStats(tx)
+	if err != nil {
+		t.Fatalf("TxWeightAndStats: %v", err)
+	}
+
+	if err := mp.addTxWithSource(txBytes, mempoolTxSourceRemote); err != nil {
+		t.Fatalf("addTxWithSource: %v", err)
+	}
+
+	mp.mu.RLock()
+	defer mp.mu.RUnlock()
+	entry, ok := mp.txs[txid]
+	if !ok {
+		t.Fatalf("entry for txid %x missing", txid)
+	}
+	if !bytes.Equal(entry.raw, txBytes) {
+		t.Fatal("entry raw bytes mismatch")
+	}
+	if entry.txid != txid {
+		t.Fatalf("entry txid=%x, want %x", entry.txid, txid)
+	}
+	if entry.wtxid != wtxid {
+		t.Fatalf("entry wtxid=%x, want %x", entry.wtxid, wtxid)
+	}
+	if entry.fee != 3 {
+		t.Fatalf("entry fee=%d, want 3", entry.fee)
+	}
+	if entry.weight != weight {
+		t.Fatalf("entry weight=%d, want %d", entry.weight, weight)
+	}
+	if entry.size != len(txBytes) {
+		t.Fatalf("entry wire bytes=%d, want %d", entry.size, len(txBytes))
+	}
+	if entry.admissionSeq != 1 {
+		t.Fatalf("entry admission_seq=%d, want 1", entry.admissionSeq)
+	}
+	if entry.source != mempoolTxSourceRemote {
+		t.Fatalf("entry source=%q, want %q", entry.source, mempoolTxSourceRemote)
+	}
+	if got, ok := mp.wtxids[wtxid]; !ok || got != txid {
+		t.Fatalf("wtxid index got %x ok=%v, want txid %x", got, ok, txid)
+	}
+	if got, ok := mp.spenders[outpoints[0]]; !ok || got != txid {
+		t.Fatalf("spender index got %x ok=%v, want txid %x", got, ok, txid)
+	}
+}
+
+func TestMempoolEntryIndexesRemovedWithEntry(t *testing.T) {
+	fromKey := mustNodeMLDSA87Keypair(t)
+	toKey := mustNodeMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{100})
+
+	mp, err := NewMempool(st, nil, devnetGenesisChainID)
+	if err != nil {
+		t.Fatalf("new mempool: %v", err)
+	}
+	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 3, 1, fromKey, fromAddress, toAddress)
+	_, txid, wtxid, _, err := consensus.ParseTx(txBytes)
+	if err != nil {
+		t.Fatalf("ParseTx: %v", err)
+	}
+	if err := mp.AddTx(txBytes); err != nil {
+		t.Fatalf("AddTx: %v", err)
+	}
+
+	mp.mu.Lock()
+	mp.removeTxLocked(txid)
+	if _, ok := mp.txs[txid]; ok {
+		t.Fatalf("removed txid %x still present", txid)
+	}
+	if _, ok := mp.wtxids[wtxid]; ok {
+		t.Fatalf("removed wtxid %x still indexed", wtxid)
+	}
+	if _, ok := mp.spenders[outpoints[0]]; ok {
+		t.Fatalf("removed spender %x:%d still indexed", outpoints[0].Txid, outpoints[0].Vout)
+	}
+	mp.mu.Unlock()
+}
+
+func TestMempoolAdmissionSeqOnlyAcceptedTxs(t *testing.T) {
+	fromKey := mustNodeMLDSA87Keypair(t)
+	toKey := mustNodeMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{100, 100})
+
+	mp, err := NewMempool(st, nil, devnetGenesisChainID)
+	if err != nil {
+		t.Fatalf("new mempool: %v", err)
+	}
+	if err := mp.AddTx([]byte{0xde, 0xad}); err == nil {
+		t.Fatal("malformed tx unexpectedly accepted")
+	}
+	if mp.nextAdmissionSeq != 0 {
+		t.Fatalf("nextAdmissionSeq after malformed=%d, want 0", mp.nextAdmissionSeq)
+	}
+
+	tx1 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 1, 1, fromKey, fromAddress, toAddress)
+	tx2 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[1]}, 90, 1, 2, fromKey, fromAddress, toAddress)
+	if err := mp.AddTx(tx1); err != nil {
+		t.Fatalf("AddTx(tx1): %v", err)
+	}
+	if got := mp.txs[txID(t, tx1)].admissionSeq; got != 1 {
+		t.Fatalf("tx1 admission_seq=%d, want 1", got)
+	}
+	if err := mp.AddTx(tx1); err == nil {
+		t.Fatal("duplicate tx unexpectedly accepted")
+	}
+	if mp.nextAdmissionSeq != 1 {
+		t.Fatalf("nextAdmissionSeq after duplicate=%d, want 1", mp.nextAdmissionSeq)
+	}
+	if err := mp.AddTx(tx2); err != nil {
+		t.Fatalf("AddTx(tx2): %v", err)
+	}
+	if got := mp.txs[txID(t, tx2)].admissionSeq; got != 2 {
+		t.Fatalf("tx2 admission_seq=%d, want 2", got)
+	}
+}
+
+func TestMempoolAdmissionSeqDoesNotWrap(t *testing.T) {
+	fromKey := mustNodeMLDSA87Keypair(t)
+	toKey := mustNodeMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{100})
+
+	mp, err := NewMempool(st, nil, devnetGenesisChainID)
+	if err != nil {
+		t.Fatalf("new mempool: %v", err)
+	}
+	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 1, 1, fromKey, fromAddress, toAddress)
+	mp.nextAdmissionSeq = ^uint64(0)
+
+	err = mp.AddTx(txBytes)
+	if err == nil || !strings.Contains(err.Error(), "mempool admission sequence exhausted") {
+		t.Fatalf("expected sequence exhaustion rejection, got %v", err)
+	}
+	var txErr *TxAdmitError
+	if !errors.As(err, &txErr) {
+		t.Fatalf("expected TxAdmitError, got %T: %v", err, err)
+	}
+	if txErr.Kind != TxAdmitUnavailable {
+		t.Fatalf("expected TxAdmitUnavailable, got %v", txErr.Kind)
+	}
+	if got := mp.Len(); got != 0 {
+		t.Fatalf("mempool len=%d, want 0", got)
+	}
+	if mp.nextAdmissionSeq != ^uint64(0) {
+		t.Fatalf("nextAdmissionSeq mutated to %d", mp.nextAdmissionSeq)
+	}
+}
+
 func TestMempoolAddTxWaitsForChainStateWriter(t *testing.T) {
 	fromKey := mustNodeMLDSA87Keypair(t)
 	toKey := mustNodeMLDSA87Keypair(t)
@@ -684,11 +854,25 @@ func TestMempoolDoubleSpend(t *testing.T) {
 	if err := mp.AddTx(tx1); err != nil {
 		t.Fatalf("AddTx(tx1): %v", err)
 	}
+	tx1ID := txID(t, tx1)
+	if got, ok := mp.spenders[outpoints[0]]; !ok || got != tx1ID {
+		t.Fatalf("spender index got %x ok=%v, want tx1 %x", got, ok, tx1ID)
+	}
+	seqAfterTx1 := mp.nextAdmissionSeq
 	if err := mp.AddTx(tx2); err == nil {
 		t.Fatalf("expected double-spend rejection")
 	}
 	if got := mp.Len(); got != 1 {
 		t.Fatalf("mempool len=%d, want 1", got)
+	}
+	if mp.Contains(txID(t, tx2)) {
+		t.Fatalf("conflicting tx entered mempool")
+	}
+	if got, ok := mp.spenders[outpoints[0]]; !ok || got != tx1ID {
+		t.Fatalf("spender index after conflict got %x ok=%v, want tx1 %x", got, ok, tx1ID)
+	}
+	if mp.nextAdmissionSeq != seqAfterTx1 {
+		t.Fatalf("nextAdmissionSeq after conflict=%d, want %d", mp.nextAdmissionSeq, seqAfterTx1)
 	}
 }
 
@@ -714,8 +898,12 @@ func TestMempoolFullRejectsWithoutEviction(t *testing.T) {
 	if err := mp.AddTx(txHigh); err != nil {
 		t.Fatalf("AddTx(high): %v", err)
 	}
+	seqAfterAccepted := mp.nextAdmissionSeq
 	if err := mp.AddTx(txBetter); err == nil || !strings.Contains(err.Error(), "mempool transaction count limit reached") {
 		t.Fatalf("expected count-limit rejection without eviction, got %v", err)
+	}
+	if mp.nextAdmissionSeq != seqAfterAccepted {
+		t.Fatalf("nextAdmissionSeq after capacity reject=%d, want %d", mp.nextAdmissionSeq, seqAfterAccepted)
 	}
 	if got := mp.Len(); got != 2 {
 		t.Fatalf("mempool len=%d, want 2", got)
@@ -877,6 +1065,27 @@ func TestRestoreMempoolSnapshotRecomputesByteAccounting(t *testing.T) {
 	if got := mp.Len(); got != 1 {
 		t.Fatalf("mempool len=%d, want 1", got)
 	}
+	tx1ID := txID(t, tx1)
+	_, _, tx1WTxID, _, err := consensus.ParseTx(tx1)
+	if err != nil {
+		t.Fatalf("ParseTx(tx1): %v", err)
+	}
+	restored := mp.txs[tx1ID]
+	if restored == nil {
+		t.Fatalf("restored entry for tx1 missing")
+	}
+	if restored.wtxid != tx1WTxID {
+		t.Fatalf("restored wtxid=%x, want %x", restored.wtxid, tx1WTxID)
+	}
+	if restored.admissionSeq != 1 {
+		t.Fatalf("restored admission_seq=%d, want 1", restored.admissionSeq)
+	}
+	if restored.source != mempoolTxSourceLocal {
+		t.Fatalf("restored source=%q, want %q", restored.source, mempoolTxSourceLocal)
+	}
+	if mp.nextAdmissionSeq != restored.admissionSeq {
+		t.Fatalf("nextAdmissionSeq after restore=%d, want %d", mp.nextAdmissionSeq, restored.admissionSeq)
+	}
 	if mp.usedBytes != len(tx1) {
 		t.Fatalf("usedBytes=%d, want %d", mp.usedBytes, len(tx1))
 	}
@@ -920,11 +1129,18 @@ func TestRestoreMempoolSnapshotRejectsInvalidEntriesWithoutMutation(t *testing.T
 	txDoubleSpend := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 89, 3, 2, fromKey, fromAddress, toAddress)
 	doubleSpendID := txID(t, txDoubleSpend)
 	snapshotEntry := func(txRaw []byte, id [32]byte, inputs []consensus.Outpoint) mempoolEntry {
+		_, _, wtxid, _, err := consensus.ParseTx(txRaw)
+		if err != nil {
+			t.Fatalf("ParseTx(snapshotEntry): %v", err)
+		}
 		return mempoolEntry{
-			raw:    append([]byte(nil), txRaw...),
-			txid:   id,
-			inputs: append([]consensus.Outpoint(nil), inputs...),
-			size:   len(txRaw),
+			raw:          append([]byte(nil), txRaw...),
+			txid:         id,
+			wtxid:        wtxid,
+			inputs:       append([]consensus.Outpoint(nil), inputs...),
+			size:         len(txRaw),
+			admissionSeq: 99,
+			source:       mempoolTxSourceLocal,
 		}
 	}
 	cloneSnapshotForTest := func(base mempoolSnapshot) mempoolSnapshot {
@@ -977,6 +1193,23 @@ func TestRestoreMempoolSnapshotRejectsInvalidEntriesWithoutMutation(t *testing.T
 				entry.txid[0] ^= 0x01
 			}),
 			want: "mempool snapshot entry txid mismatch",
+		},
+		{
+			name: "wtxid_mismatch",
+			mutate: withEditedFirst(func(entry *mempoolEntry) {
+				entry.wtxid[0] ^= 0x01
+			}),
+			want: "mempool snapshot entry wtxid mismatch",
+		},
+		{
+			name:   "zero_admission_seq",
+			mutate: withEditedFirst(func(entry *mempoolEntry) { entry.admissionSeq = 0 }),
+			want:   "invalid mempool snapshot entry admission_seq",
+		},
+		{
+			name:   "invalid_source",
+			mutate: withEditedFirst(func(entry *mempoolEntry) { entry.source = "sidecar" }),
+			want:   "invalid mempool snapshot entry source",
 		},
 		{
 			name:   "input_count_mismatch",

--- a/clients/go/node/mempool_test.go
+++ b/clients/go/node/mempool_test.go
@@ -1298,6 +1298,17 @@ func TestRestoreMempoolSnapshotRejectsInvalidEntriesWithoutMutation(t *testing.T
 			want: "duplicate mempool snapshot txid",
 		},
 		{
+			name: "duplicate_admission_seq",
+			mutate: func(base mempoolSnapshot) mempoolSnapshot {
+				bad := cloneSnapshotForTest(base)
+				duplicate := snapshotEntry(txSecond, txSecondID, []consensus.Outpoint{outpoints[1]})
+				duplicate.admissionSeq = bad.entries[0].admissionSeq
+				bad.entries = append(bad.entries, duplicate)
+				return bad
+			},
+			want: "duplicate mempool snapshot admission_seq",
+		},
+		{
 			name: "duplicate_spender",
 			mutate: func(base mempoolSnapshot) mempoolSnapshot {
 				bad := cloneSnapshotForTest(base)

--- a/clients/go/node/mempool_test.go
+++ b/clients/go/node/mempool_test.go
@@ -124,8 +124,8 @@ func TestMempoolRejectsInvalidEntrySource(t *testing.T) {
 	if got := mp.Len(); got != 0 {
 		t.Fatalf("mempool len=%d, want 0", got)
 	}
-	if mp.nextAdmissionSeq != 0 {
-		t.Fatalf("nextAdmissionSeq after invalid source=%d, want 0", mp.nextAdmissionSeq)
+	if mp.lastAdmissionSeq != 0 {
+		t.Fatalf("lastAdmissionSeq after invalid source=%d, want 0", mp.lastAdmissionSeq)
 	}
 }
 
@@ -155,8 +155,8 @@ func TestMempoolAddEntryLockedInitializesMetadataIndexes(t *testing.T) {
 	if got := mp.spenders[op]; got != entry.txid {
 		t.Fatalf("spender index got %x, want txid %x", got, entry.txid)
 	}
-	if mp.nextAdmissionSeq != entry.admissionSeq {
-		t.Fatalf("nextAdmissionSeq=%d, want %d", mp.nextAdmissionSeq, entry.admissionSeq)
+	if mp.lastAdmissionSeq != entry.admissionSeq {
+		t.Fatalf("lastAdmissionSeq=%d, want %d", mp.lastAdmissionSeq, entry.admissionSeq)
 	}
 	if mp.usedBytes != entry.size {
 		t.Fatalf("usedBytes=%d, want %d", mp.usedBytes, entry.size)
@@ -211,8 +211,8 @@ func TestMempoolAdmissionSeqOnlyAcceptedTxs(t *testing.T) {
 	if err := mp.AddTx([]byte{0xde, 0xad}); err == nil {
 		t.Fatal("malformed tx unexpectedly accepted")
 	}
-	if mp.nextAdmissionSeq != 0 {
-		t.Fatalf("nextAdmissionSeq after malformed=%d, want 0", mp.nextAdmissionSeq)
+	if mp.lastAdmissionSeq != 0 {
+		t.Fatalf("lastAdmissionSeq after malformed=%d, want 0", mp.lastAdmissionSeq)
 	}
 
 	tx1 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 1, 1, fromKey, fromAddress, toAddress)
@@ -226,8 +226,8 @@ func TestMempoolAdmissionSeqOnlyAcceptedTxs(t *testing.T) {
 	if err := mp.AddTx(tx1); err == nil {
 		t.Fatal("duplicate tx unexpectedly accepted")
 	}
-	if mp.nextAdmissionSeq != 1 {
-		t.Fatalf("nextAdmissionSeq after duplicate=%d, want 1", mp.nextAdmissionSeq)
+	if mp.lastAdmissionSeq != 1 {
+		t.Fatalf("lastAdmissionSeq after duplicate=%d, want 1", mp.lastAdmissionSeq)
 	}
 	if err := mp.AddTx(tx2); err != nil {
 		t.Fatalf("AddTx(tx2): %v", err)
@@ -249,7 +249,7 @@ func TestMempoolAdmissionSeqDoesNotWrap(t *testing.T) {
 		t.Fatalf("new mempool: %v", err)
 	}
 	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 1, 1, fromKey, fromAddress, toAddress)
-	mp.nextAdmissionSeq = ^uint64(0)
+	mp.lastAdmissionSeq = ^uint64(0)
 
 	err = mp.AddTx(txBytes)
 	if err == nil || !strings.Contains(err.Error(), "mempool admission sequence exhausted") {
@@ -265,8 +265,8 @@ func TestMempoolAdmissionSeqDoesNotWrap(t *testing.T) {
 	if got := mp.Len(); got != 0 {
 		t.Fatalf("mempool len=%d, want 0", got)
 	}
-	if mp.nextAdmissionSeq != ^uint64(0) {
-		t.Fatalf("nextAdmissionSeq mutated to %d", mp.nextAdmissionSeq)
+	if mp.lastAdmissionSeq != ^uint64(0) {
+		t.Fatalf("lastAdmissionSeq mutated to %d", mp.lastAdmissionSeq)
 	}
 }
 
@@ -923,7 +923,7 @@ func TestMempoolDoubleSpend(t *testing.T) {
 	if got, ok := mp.spenders[outpoints[0]]; !ok || got != tx1ID {
 		t.Fatalf("spender index got %x ok=%v, want tx1 %x", got, ok, tx1ID)
 	}
-	seqAfterTx1 := mp.nextAdmissionSeq
+	seqAfterTx1 := mp.lastAdmissionSeq
 	if err := mp.AddTx(tx2); err == nil {
 		t.Fatalf("expected double-spend rejection")
 	}
@@ -936,8 +936,8 @@ func TestMempoolDoubleSpend(t *testing.T) {
 	if got, ok := mp.spenders[outpoints[0]]; !ok || got != tx1ID {
 		t.Fatalf("spender index after conflict got %x ok=%v, want tx1 %x", got, ok, tx1ID)
 	}
-	if mp.nextAdmissionSeq != seqAfterTx1 {
-		t.Fatalf("nextAdmissionSeq after conflict=%d, want %d", mp.nextAdmissionSeq, seqAfterTx1)
+	if mp.lastAdmissionSeq != seqAfterTx1 {
+		t.Fatalf("lastAdmissionSeq after conflict=%d, want %d", mp.lastAdmissionSeq, seqAfterTx1)
 	}
 }
 
@@ -963,12 +963,12 @@ func TestMempoolFullRejectsWithoutEviction(t *testing.T) {
 	if err := mp.AddTx(txHigh); err != nil {
 		t.Fatalf("AddTx(high): %v", err)
 	}
-	seqAfterAccepted := mp.nextAdmissionSeq
+	seqAfterAccepted := mp.lastAdmissionSeq
 	if err := mp.AddTx(txBetter); err == nil || !strings.Contains(err.Error(), "mempool transaction count limit reached") {
 		t.Fatalf("expected count-limit rejection without eviction, got %v", err)
 	}
-	if mp.nextAdmissionSeq != seqAfterAccepted {
-		t.Fatalf("nextAdmissionSeq after capacity reject=%d, want %d", mp.nextAdmissionSeq, seqAfterAccepted)
+	if mp.lastAdmissionSeq != seqAfterAccepted {
+		t.Fatalf("lastAdmissionSeq after capacity reject=%d, want %d", mp.lastAdmissionSeq, seqAfterAccepted)
 	}
 	if got := mp.Len(); got != 2 {
 		t.Fatalf("mempool len=%d, want 2", got)
@@ -1148,8 +1148,8 @@ func TestRestoreMempoolSnapshotRecomputesByteAccounting(t *testing.T) {
 	if restored.source != mempoolTxSourceLocal {
 		t.Fatalf("restored source=%q, want %q", restored.source, mempoolTxSourceLocal)
 	}
-	if mp.nextAdmissionSeq != restored.admissionSeq {
-		t.Fatalf("nextAdmissionSeq after restore=%d, want %d", mp.nextAdmissionSeq, restored.admissionSeq)
+	if mp.lastAdmissionSeq != restored.admissionSeq {
+		t.Fatalf("lastAdmissionSeq after restore=%d, want %d", mp.lastAdmissionSeq, restored.admissionSeq)
 	}
 	if mp.usedBytes != len(tx1) {
 		t.Fatalf("usedBytes=%d, want %d", mp.usedBytes, len(tx1))

--- a/clients/go/node/p2p/mempool.go
+++ b/clients/go/node/p2p/mempool.go
@@ -50,7 +50,7 @@ func (p *CanonicalMempoolTxPool) Put(txid [32]byte, raw []byte, _ uint64, _ int)
 	if err != nil || rawTxid != txid {
 		return false
 	}
-	return p.mempool.AddTx(raw) == nil
+	return p.mempool.AddRemoteTx(raw) == nil
 }
 
 type MemoryTxPool struct {

--- a/clients/go/node/sync_mempool.go
+++ b/clients/go/node/sync_mempool.go
@@ -52,9 +52,6 @@ func restoreMempoolSnapshot(m *Mempool, snapshot mempoolSnapshot) error {
 		if _, exists := txs[entry.txid]; exists {
 			return fmt.Errorf("duplicate mempool snapshot txid %x", entry.txid)
 		}
-		if existing, exists := wtxids[entry.wtxid]; exists {
-			return fmt.Errorf("duplicate mempool snapshot wtxid %x existing=%x new=%x", entry.wtxid, existing, entry.txid)
-		}
 		if len(txs) >= maxTxs {
 			return fmt.Errorf("mempool snapshot exceeds transaction cap: count=%d max=%d", len(txs)+1, maxTxs)
 		}

--- a/clients/go/node/sync_mempool.go
+++ b/clients/go/node/sync_mempool.go
@@ -9,7 +9,8 @@ import (
 )
 
 type mempoolSnapshot struct {
-	entries []mempoolEntry
+	entries          []mempoolEntry
+	lastAdmissionSeq uint64
 }
 
 func snapshotMempool(m *Mempool) (mempoolSnapshot, error) {
@@ -25,7 +26,7 @@ func snapshotMempool(m *Mempool) (mempoolSnapshot, error) {
 	sort.Slice(entries, func(i, j int) bool {
 		return bytes.Compare(entries[i].txid[:], entries[j].txid[:]) < 0
 	})
-	return mempoolSnapshot{entries: entries}, nil
+	return mempoolSnapshot{entries: entries, lastAdmissionSeq: m.lastAdmissionSeq}, nil
 }
 
 func restoreMempoolSnapshot(m *Mempool, snapshot mempoolSnapshot) error {
@@ -80,11 +81,14 @@ func restoreMempoolSnapshot(m *Mempool, snapshot mempoolSnapshot) error {
 			maxAdmissionSeq = entryCopy.admissionSeq
 		}
 	}
+	if snapshot.lastAdmissionSeq < maxAdmissionSeq {
+		return fmt.Errorf("mempool snapshot admission high-watermark below restored max: last=%d max=%d", snapshot.lastAdmissionSeq, maxAdmissionSeq)
+	}
 	m.txs = txs
 	m.wtxids = wtxids
 	m.spenders = spenders
 	m.usedBytes = usedBytes
-	m.lastAdmissionSeq = maxAdmissionSeq
+	m.lastAdmissionSeq = snapshot.lastAdmissionSeq
 	return nil
 }
 

--- a/clients/go/node/sync_mempool.go
+++ b/clients/go/node/sync_mempool.go
@@ -44,7 +44,7 @@ func restoreMempoolSnapshot(m *Mempool, snapshot mempoolSnapshot) error {
 	spenders := make(map[consensus.Outpoint][32]byte)
 	admissionSeqs := make(map[uint64][32]byte, len(snapshot.entries))
 	usedBytes := 0
-	var nextAdmissionSeq uint64
+	var maxAdmissionSeq uint64
 	for _, item := range snapshot.entries {
 		entry := cloneMempoolEntry(&item)
 		if err := validateMempoolSnapshotEntry(entry); err != nil {
@@ -73,15 +73,15 @@ func restoreMempoolSnapshot(m *Mempool, snapshot mempoolSnapshot) error {
 		wtxids[entryCopy.wtxid] = entryCopy.txid
 		admissionSeqs[entryCopy.admissionSeq] = entryCopy.txid
 		usedBytes += entryCopy.size
-		if entryCopy.admissionSeq > nextAdmissionSeq {
-			nextAdmissionSeq = entryCopy.admissionSeq
+		if entryCopy.admissionSeq > maxAdmissionSeq {
+			maxAdmissionSeq = entryCopy.admissionSeq
 		}
 	}
 	m.txs = txs
 	m.wtxids = wtxids
 	m.spenders = spenders
 	m.usedBytes = usedBytes
-	m.nextAdmissionSeq = nextAdmissionSeq
+	m.lastAdmissionSeq = maxAdmissionSeq
 	return nil
 }
 

--- a/clients/go/node/sync_mempool.go
+++ b/clients/go/node/sync_mempool.go
@@ -42,6 +42,7 @@ func restoreMempoolSnapshot(m *Mempool, snapshot mempoolSnapshot) error {
 	txs := make(map[[32]byte]*mempoolEntry, len(snapshot.entries))
 	wtxids := make(map[[32]byte][32]byte, len(snapshot.entries))
 	spenders := make(map[consensus.Outpoint][32]byte)
+	admissionSeqs := make(map[uint64][32]byte, len(snapshot.entries))
 	usedBytes := 0
 	var nextAdmissionSeq uint64
 	for _, item := range snapshot.entries {
@@ -51,6 +52,9 @@ func restoreMempoolSnapshot(m *Mempool, snapshot mempoolSnapshot) error {
 		}
 		if _, exists := txs[entry.txid]; exists {
 			return fmt.Errorf("duplicate mempool snapshot txid %x", entry.txid)
+		}
+		if existing, exists := admissionSeqs[entry.admissionSeq]; exists {
+			return fmt.Errorf("duplicate mempool snapshot admission_seq %d existing=%x new=%x", entry.admissionSeq, existing, entry.txid)
 		}
 		if len(txs) >= maxTxs {
 			return fmt.Errorf("mempool snapshot exceeds transaction cap: count=%d max=%d", len(txs)+1, maxTxs)
@@ -67,6 +71,7 @@ func restoreMempoolSnapshot(m *Mempool, snapshot mempoolSnapshot) error {
 		entryCopy := entry
 		txs[entryCopy.txid] = &entryCopy
 		wtxids[entryCopy.wtxid] = entryCopy.txid
+		admissionSeqs[entryCopy.admissionSeq] = entryCopy.txid
 		usedBytes += entryCopy.size
 		if entryCopy.admissionSeq > nextAdmissionSeq {
 			nextAdmissionSeq = entryCopy.admissionSeq

--- a/clients/go/node/sync_mempool.go
+++ b/clients/go/node/sync_mempool.go
@@ -40,8 +40,10 @@ func restoreMempoolSnapshot(m *Mempool, snapshot mempoolSnapshot) error {
 		return fmt.Errorf("invalid mempool snapshot restore limits: max_txs=%d max_bytes=%d", maxTxs, maxBytes)
 	}
 	txs := make(map[[32]byte]*mempoolEntry, len(snapshot.entries))
+	wtxids := make(map[[32]byte][32]byte, len(snapshot.entries))
 	spenders := make(map[consensus.Outpoint][32]byte)
 	usedBytes := 0
+	var nextAdmissionSeq uint64
 	for _, item := range snapshot.entries {
 		entry := cloneMempoolEntry(&item)
 		if err := validateMempoolSnapshotEntry(entry); err != nil {
@@ -49,6 +51,9 @@ func restoreMempoolSnapshot(m *Mempool, snapshot mempoolSnapshot) error {
 		}
 		if _, exists := txs[entry.txid]; exists {
 			return fmt.Errorf("duplicate mempool snapshot txid %x", entry.txid)
+		}
+		if existing, exists := wtxids[entry.wtxid]; exists {
+			return fmt.Errorf("duplicate mempool snapshot wtxid %x existing=%x new=%x", entry.wtxid, existing, entry.txid)
 		}
 		if len(txs) >= maxTxs {
 			return fmt.Errorf("mempool snapshot exceeds transaction cap: count=%d max=%d", len(txs)+1, maxTxs)
@@ -64,11 +69,17 @@ func restoreMempoolSnapshot(m *Mempool, snapshot mempoolSnapshot) error {
 		}
 		entryCopy := entry
 		txs[entryCopy.txid] = &entryCopy
+		wtxids[entryCopy.wtxid] = entryCopy.txid
 		usedBytes += entryCopy.size
+		if entryCopy.admissionSeq > nextAdmissionSeq {
+			nextAdmissionSeq = entryCopy.admissionSeq
+		}
 	}
 	m.txs = txs
+	m.wtxids = wtxids
 	m.spenders = spenders
 	m.usedBytes = usedBytes
+	m.nextAdmissionSeq = nextAdmissionSeq
 	return nil
 }
 
@@ -79,7 +90,7 @@ func validateMempoolSnapshotEntry(entry mempoolEntry) error {
 	if entry.size != len(entry.raw) {
 		return fmt.Errorf("mempool snapshot entry size mismatch for txid %x: size=%d raw_len=%d", entry.txid, entry.size, len(entry.raw))
 	}
-	tx, txid, _, consumed, err := consensus.ParseTx(entry.raw)
+	tx, txid, wtxid, consumed, err := consensus.ParseTx(entry.raw)
 	if err != nil {
 		return fmt.Errorf("invalid mempool snapshot entry raw for txid %x: %w", entry.txid, err)
 	}
@@ -88,6 +99,15 @@ func validateMempoolSnapshotEntry(entry mempoolEntry) error {
 	}
 	if txid != entry.txid {
 		return fmt.Errorf("mempool snapshot entry txid mismatch: entry=%x raw=%x", entry.txid, txid)
+	}
+	if wtxid != entry.wtxid {
+		return fmt.Errorf("mempool snapshot entry wtxid mismatch: entry=%x raw=%x", entry.wtxid, wtxid)
+	}
+	if entry.admissionSeq == 0 {
+		return fmt.Errorf("invalid mempool snapshot entry admission_seq for txid %x: seq=0", entry.txid)
+	}
+	if !validMempoolTxSource(entry.source) {
+		return fmt.Errorf("invalid mempool snapshot entry source for txid %x: source=%q", entry.txid, entry.source)
 	}
 	if len(entry.inputs) != len(tx.Inputs) {
 		return fmt.Errorf("mempool snapshot entry input count mismatch for txid %x: entry=%d tx=%d", entry.txid, len(entry.inputs), len(tx.Inputs))
@@ -106,11 +126,14 @@ func cloneMempoolEntry(entry *mempoolEntry) mempoolEntry {
 		return mempoolEntry{}
 	}
 	return mempoolEntry{
-		raw:    append([]byte(nil), entry.raw...),
-		txid:   entry.txid,
-		inputs: append([]consensus.Outpoint(nil), entry.inputs...),
-		fee:    entry.fee,
-		weight: entry.weight,
-		size:   entry.size,
+		raw:          append([]byte(nil), entry.raw...),
+		txid:         entry.txid,
+		wtxid:        entry.wtxid,
+		inputs:       append([]consensus.Outpoint(nil), entry.inputs...),
+		fee:          entry.fee,
+		weight:       entry.weight,
+		size:         entry.size,
+		admissionSeq: entry.admissionSeq,
+		source:       entry.source,
 	}
 }

--- a/clients/go/node/sync_mempool.go
+++ b/clients/go/node/sync_mempool.go
@@ -47,11 +47,14 @@ func restoreMempoolSnapshot(m *Mempool, snapshot mempoolSnapshot) error {
 	var maxAdmissionSeq uint64
 	for _, item := range snapshot.entries {
 		entry := cloneMempoolEntry(&item)
-		if err := validateMempoolSnapshotEntry(entry); err != nil {
-			return err
-		}
 		if _, exists := txs[entry.txid]; exists {
 			return fmt.Errorf("duplicate mempool snapshot txid %x", entry.txid)
+		}
+		if existing, exists := wtxids[entry.wtxid]; exists {
+			return fmt.Errorf("duplicate mempool snapshot wtxid %x existing=%x new=%x", entry.wtxid, existing, entry.txid)
+		}
+		if err := validateMempoolSnapshotEntry(entry); err != nil {
+			return err
 		}
 		if existing, exists := admissionSeqs[entry.admissionSeq]; exists {
 			return fmt.Errorf("duplicate mempool snapshot admission_seq %d existing=%x new=%x", entry.admissionSeq, existing, entry.txid)

--- a/clients/go/node/sync_reorg.go
+++ b/clients/go/node/sync_reorg.go
@@ -279,7 +279,7 @@ func (s *SyncEngine) requeueDisconnectedTransactions(disconnectedBlocks [][]byte
 			continue
 		}
 		for _, txBytes := range txs {
-			if err := s.mempool.AddTx(txBytes); err != nil {
+			if err := s.mempool.AddReorgTx(txBytes); err != nil {
 				_, _ = fmt.Fprintf(s.stderr, "mempool: requeue-tx: %v\n", err)
 			}
 		}


### PR DESCRIPTION
## Scope

- Add Go mempool entry metadata and indexes for future deterministic policy decisions.
- Record local, remote, and reorg admission source metadata through the existing mempool admission path.
- Update the canonical P2P tx-pool adapter and reorg requeue call sites to use the source-specific mempool admission wrappers.
- Preserve current admission, duplicate, conflict, capacity, selection, and eviction behavior.

## Disposition

- Consensus impact: none
- Go behavior changed: internal metadata/indexing and source tagging only
- Admission policy changed: no
- Eviction behavior changed: no
- P2P routing behavior changed: no
- Reorg behavior changed: no
- Rust changed: no
- Conformance changed: no
