### PR TITLE
policy: Stage C overflow + zero-surcharge clarification

### DIFF
--- a/POLICY_MEMPOOL_ADMISSION_GENESIS.md
+++ b/POLICY_MEMPOOL_ADMISSION_GENESIS.md
@@ -149,6 +149,22 @@ This means a DA transaction must satisfy both the base relay-fee floor
 and the DA-specific floor, with any DA surcharge applied only to DA
 bytes.
 
+**Arithmetic and overflow rule.** All Stage C fee-floor arithmetic
+MUST be evaluated with checked widening arithmetic or an equivalent
+overflow-safe integer comparison. If any multiplication or addition
+required to compute or compare `relay_fee_floor(tx)`,
+`da_fee_floor(tx)`, `da_surcharge(tx)`, `da_required_fee(tx)`, or
+`required_fee(tx)` would overflow the implementation's exact integer
+domain, the candidate transaction MUST be rejected as non-standard.
+Wraparound, truncation, floating-point comparison, and
+saturating-to-pass behavior are forbidden.
+
+`PolicyDaSurchargePerByte = 0` disables only the surcharge term. It
+does NOT disable `da_fee_floor(tx)` when `min_da_fee_rate > 0`; the
+DA floor is still applied via `da_required_fee(tx) = da_fee_floor(tx)
++ 0 = da_fee_floor(tx)`, and `required_fee(tx)` still takes the
+`max(...)` of the relay-fee floor and the DA floor.
+
 `current_mempool_min_fee_rate` is the rolling local floor defined and
 maintained by the parent `spec/RUBIN_MEMPOOL_POLICY.md` §10
 (raise after capacity eviction, decay on connected-block events). The

--- a/POLICY_MEMPOOL_ADMISSION_GENESIS.md
+++ b/POLICY_MEMPOOL_ADMISSION_GENESIS.md
@@ -153,11 +153,11 @@ bytes.
 MUST be evaluated with checked widening arithmetic or an equivalent
 overflow-safe integer comparison. If any multiplication or addition
 required to compute or compare `relay_fee_floor(tx)`,
-`da_fee_floor(tx)`, `da_surcharge(tx)`, `da_fee_floor(tx) +
-da_surcharge(tx)`, or `required_fee(tx)` would overflow the
-implementation's exact integer domain, the candidate transaction MUST
-be rejected as non-standard. Wraparound, truncation, floating-point
-comparison, and saturating-to-pass behavior are forbidden.
+`da_fee_floor(tx)`, `da_surcharge(tx)`, `da_fee_floor(tx) + da_surcharge(tx)`,
+or `required_fee(tx)` would overflow the implementation's exact integer
+domain, the candidate transaction MUST be rejected as non-standard.
+Wraparound, truncation, floating-point comparison, and
+saturating-to-pass behavior are forbidden.
 
 `PolicyDaSurchargePerByte = 0` disables only the surcharge term. It
 does NOT disable `da_fee_floor(tx)` when `min_da_fee_rate > 0`; the

--- a/POLICY_MEMPOOL_ADMISSION_GENESIS.md
+++ b/POLICY_MEMPOOL_ADMISSION_GENESIS.md
@@ -153,17 +153,17 @@ bytes.
 MUST be evaluated with checked widening arithmetic or an equivalent
 overflow-safe integer comparison. If any multiplication or addition
 required to compute or compare `relay_fee_floor(tx)`,
-`da_fee_floor(tx)`, `da_surcharge(tx)`, `da_required_fee(tx)`, or
-`required_fee(tx)` would overflow the implementation's exact integer
-domain, the candidate transaction MUST be rejected as non-standard.
-Wraparound, truncation, floating-point comparison, and
-saturating-to-pass behavior are forbidden.
+`da_fee_floor(tx)`, `da_surcharge(tx)`, `da_fee_floor(tx) +
+da_surcharge(tx)`, or `required_fee(tx)` would overflow the
+implementation's exact integer domain, the candidate transaction MUST
+be rejected as non-standard. Wraparound, truncation, floating-point
+comparison, and saturating-to-pass behavior are forbidden.
 
 `PolicyDaSurchargePerByte = 0` disables only the surcharge term. It
 does NOT disable `da_fee_floor(tx)` when `min_da_fee_rate > 0`; the
-DA floor is still applied via `da_required_fee(tx) = da_fee_floor(tx)
-+ 0 = da_fee_floor(tx)`, and `required_fee(tx)` still takes the
-`max(...)` of the relay-fee floor and the DA floor.
+DA floor is still applied via `da_fee_floor(tx) + 0 =
+da_fee_floor(tx)`, and `required_fee(tx)` still takes the `max(...)`
+of the relay-fee floor and the DA floor.
 
 `current_mempool_min_fee_rate` is the rolling local floor defined and
 maintained by the parent `spec/RUBIN_MEMPOOL_POLICY.md` §10


### PR DESCRIPTION
## Scope

Clarify Stage C fee-gate wording in `POLICY_MEMPOOL_ADMISSION_GENESIS.md` so Go, Rust, and conformance agents implement identical fail-closed overflow behavior.

- Add explicit overflow / fail-closed rule for all Stage C fee-floor arithmetic (`relay_fee_floor`, `da_fee_floor`, `da_surcharge`, `da_required_fee`, `required_fee`).
- Add explicit zero-surcharge clarification: `PolicyDaSurchargePerByte = 0` disables only the surcharge term, not `da_fee_floor` when `min_da_fee_rate > 0`.
- Stage C formula itself is unchanged.

## Disposition

- Architecture class: A (local policy text patch)
- System boundary: `POLICY_MEMPOOL_ADMISSION_GENESIS.md` Stage C wording only
- Single invariant: DA fee-floor overflow and zero-surcharge semantics are explicit
- Consensus impact: none
- Go/Rust/conformance implementation: NO
- New policy file: NO
- Fee-market / RBF / CPFP / package-relay text: NO
- Verification: `git diff --check` clean; only `POLICY_MEMPOOL_ADMISSION_GENESIS.md` changed (+16 LoC); Stage C reread post-edit; no new `POLICY_DA_FEE_FLOOR_VALIDATION.md` exists.