### PR TITLE
node: add mempool fee eviction rolling floor

### DIFF
--- a/clients/go/cmd/rubin-node/http_rpc_test.go
+++ b/clients/go/cmd/rubin-node/http_rpc_test.go
@@ -96,7 +96,7 @@ func mustRPCStateWithSpendableUTXOAndMempoolConfig(
 	prevTxid[0] = 0x44
 	outpoint := consensus.Outpoint{Txid: prevTxid, Vout: 0}
 	chainState.Utxos[outpoint] = consensus.UtxoEntry{
-		Value:             100,
+		Value:             1_000_000,
 		CovenantType:      consensus.COV_TYPE_P2PK,
 		CovenantData:      append([]byte(nil), fromAddress...),
 		CreationHeight:    0,
@@ -145,12 +145,12 @@ func mustRPCSignedTransferTx(
 		}},
 		Outputs: []consensus.TxOutput{
 			{
-				Value:        90,
+				Value:        100_000,
 				CovenantType: consensus.COV_TYPE_P2PK,
 				CovenantData: append([]byte(nil), toAddress...),
 			},
 			{
-				Value:        9,
+				Value:        800_000,
 				CovenantType: consensus.COV_TYPE_P2PK,
 				CovenantData: append([]byte(nil), changeAddress...),
 			},
@@ -889,7 +889,7 @@ func TestDevnetRPCSubmitTxAcceptsDaCommitUnderDefaultPolicy(t *testing.T) {
 		announced = append(announced, append([]byte(nil), tx...))
 		return nil
 	})
-	txBytes, wantTxID := mustRPCSignedDaCommitTx(t, utxos, input, 10, 7, fromKey, toAddress, []byte("commitmeta"), []byte("chunkdata0"))
+	txBytes, wantTxID := mustRPCSignedDaCommitTx(t, utxos, input, 100_000, 7, fromKey, toAddress, []byte("commitmeta"), []byte("chunkdata0"))
 	server := httptest.NewServer(newDevnetRPCHandler(state))
 	defer server.Close()
 

--- a/clients/go/cmd/rubin-node/http_rpc_test.go
+++ b/clients/go/cmd/rubin-node/http_rpc_test.go
@@ -89,18 +89,38 @@ func mustRPCStateWithSpendableUTXOAndMempoolConfig(
 	mempoolConfig node.MempoolConfig,
 ) (*devnetRPCState, consensus.Outpoint, map[consensus.Outpoint]consensus.UtxoEntry) {
 	t.Helper()
+	state, outpoints, utxos := mustRPCStateWithSpendableUTXOsAndMempoolConfig(t, fromAddress, []uint64{1_000_000}, announceTx, mempoolConfig)
+	return state, outpoints[0], utxos
+}
+
+func mustRPCStateWithSpendableUTXOsAndMempoolConfig(
+	t *testing.T,
+	fromAddress []byte,
+	values []uint64,
+	announceTx func([]byte) error,
+	mempoolConfig node.MempoolConfig,
+) (*devnetRPCState, []consensus.Outpoint, map[consensus.Outpoint]consensus.UtxoEntry) {
+	t.Helper()
 	dir := t.TempDir()
 	chainStatePath := node.ChainStatePath(dir)
 	chainState := node.NewChainState()
-	var prevTxid [32]byte
-	prevTxid[0] = 0x44
-	outpoint := consensus.Outpoint{Txid: prevTxid, Vout: 0}
-	chainState.Utxos[outpoint] = consensus.UtxoEntry{
-		Value:             1_000_000,
-		CovenantType:      consensus.COV_TYPE_P2PK,
-		CovenantData:      append([]byte(nil), fromAddress...),
-		CreationHeight:    0,
-		CreatedByCoinbase: false,
+	if len(values) == 0 {
+		t.Fatalf("mustRPCStateWithSpendableUTXOsAndMempoolConfig requires at least one value")
+	}
+	outpoints := make([]consensus.Outpoint, 0, len(values))
+	for i, value := range values {
+		var prevTxid [32]byte
+		prevTxid[0] = 0x44
+		prevTxid[31] = byte(i)
+		outpoint := consensus.Outpoint{Txid: prevTxid, Vout: 0}
+		outpoints = append(outpoints, outpoint)
+		chainState.Utxos[outpoint] = consensus.UtxoEntry{
+			Value:             value,
+			CovenantType:      consensus.COV_TYPE_P2PK,
+			CovenantData:      append([]byte(nil), fromAddress...),
+			CreationHeight:    0,
+			CreatedByCoinbase: false,
+		}
 	}
 	if err := chainState.Save(chainStatePath); err != nil {
 		t.Fatalf("Save: %v", err)
@@ -122,7 +142,7 @@ func mustRPCStateWithSpendableUTXOAndMempoolConfig(
 	peerManager := node.NewPeerManager(node.DefaultPeerRuntimeConfig("devnet", 8))
 	state := newDevnetRPCState(syncEngine, blockStore, mempool, peerManager, announceTx, nil, io.Discard, nil)
 	state.nowUnix = func() uint64 { return 0 }
-	return state, outpoint, chainState.Utxos
+	return state, outpoints, chainState.Utxos
 }
 
 func mustRPCSignedTransferTx(
@@ -133,11 +153,33 @@ func mustRPCSignedTransferTx(
 	toAddress []byte,
 ) ([]byte, string) {
 	t.Helper()
+	return mustRPCSignedTransferTxWithFee(t, utxos, input, 100_000, 100_000, 1, signer, toAddress)
+}
+
+func mustRPCSignedTransferTxWithFee(
+	t *testing.T,
+	utxos map[consensus.Outpoint]consensus.UtxoEntry,
+	input consensus.Outpoint,
+	amount uint64,
+	fee uint64,
+	nonce uint64,
+	signer *consensus.MLDSA87Keypair,
+	toAddress []byte,
+) ([]byte, string) {
+	t.Helper()
+	entry, ok := utxos[input]
+	if !ok {
+		t.Fatalf("missing utxo for %x:%d", input.Txid, input.Vout)
+	}
+	if amount > entry.Value || fee > entry.Value-amount {
+		t.Fatalf("utxo value=%d, want at least amount=%d plus fee=%d", entry.Value, amount, fee)
+	}
 	changeAddress := consensus.P2PKCovenantDataForPubkey(signer.PubkeyBytes())
+	change := entry.Value - amount - fee
 	tx := &consensus.Tx{
 		Version: 1,
 		TxKind:  0x00,
-		TxNonce: 1,
+		TxNonce: nonce,
 		Inputs: []consensus.TxInput{{
 			PrevTxid: input.Txid,
 			PrevVout: input.Vout,
@@ -145,17 +187,21 @@ func mustRPCSignedTransferTx(
 		}},
 		Outputs: []consensus.TxOutput{
 			{
-				Value:        100_000,
+				Value:        amount,
 				CovenantType: consensus.COV_TYPE_P2PK,
 				CovenantData: append([]byte(nil), toAddress...),
 			},
-			{
-				Value:        800_000,
+		},
+		Locktime: 0,
+	}
+	if change > 0 {
+		tx.Outputs = append(tx.Outputs,
+			consensus.TxOutput{
+				Value:        change,
 				CovenantType: consensus.COV_TYPE_P2PK,
 				CovenantData: append([]byte(nil), changeAddress...),
 			},
-		},
-		Locktime: 0,
+		)
 	}
 	if err := consensus.SignTransaction(tx, utxos, node.DevnetGenesisChainID(), signer); err != nil {
 		t.Fatalf("SignTransaction: %v", err)
@@ -1000,6 +1046,83 @@ func TestDevnetRPCSubmitTxRejectsDuplicateMempoolEntry(t *testing.T) {
 	}
 }
 
+func TestDevnetRPCSubmitTxBelowRollingFloorReturnsUnavailable(t *testing.T) {
+	fromKey := mustRPCMLDSA87Keypair(t)
+	toKey := mustRPCMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+
+	var announceCalled bool
+	cfg := node.DefaultMempoolConfig()
+	cfg.MaxTransactions = 1
+	state, inputs, utxos := mustRPCStateWithSpendableUTXOsAndMempoolConfig(t, fromAddress, []uint64{1_000_000, 1_000_000, 1_000_000}, func(tx []byte) error {
+		announceCalled = true
+		return nil
+	}, cfg)
+	seedTx, _ := mustRPCSignedTransferTxWithFee(t, utxos, inputs[0], 100_000, 100_000, 1, fromKey, toAddress)
+	betterTx, _ := mustRPCSignedTransferTxWithFee(t, utxos, inputs[1], 100_000, 700_000, 2, fromKey, toAddress)
+	belowFloorTx, _ := mustRPCSignedTransferTxWithFee(t, utxos, inputs[2], 100_000, 1, 3, fromKey, toAddress)
+	if err := state.mempool.AddTx(seedTx); err != nil {
+		t.Fatalf("AddTx(seed): %v", err)
+	}
+	if err := state.mempool.AddTx(betterTx); err != nil {
+		t.Fatalf("AddTx(better): %v", err)
+	}
+	if got := state.mempool.Len(); got != 1 {
+		t.Fatalf("mempool len=%d after rolling-floor seed, want 1", got)
+	}
+
+	server := httptest.NewServer(newDevnetRPCHandler(state))
+	defer server.Close()
+	body, err := json.Marshal(submitTxRequest{TxHex: hex.EncodeToString(belowFloorTx)})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	resp, err := http.Post(server.URL+"/submit_tx", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("Post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d, want 503", resp.StatusCode)
+	}
+
+	var got submitTxResponse
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if got.Accepted {
+		t.Fatalf("accepted=true, want false")
+	}
+	if got.TxID != "" {
+		t.Fatalf("txid=%q, want empty unavailable response", got.TxID)
+	}
+	if !strings.Contains(got.Error, "mempool fee below rolling minimum") {
+		t.Fatalf("error=%q, want rolling minimum message", got.Error)
+	}
+	if announceCalled {
+		t.Fatalf("announceTx was called for unavailable below-floor tx")
+	}
+	if got := state.mempool.Len(); got != 1 {
+		t.Fatalf("mempool len=%d, want unchanged 1", got)
+	}
+	admission := state.mempool.AdmissionCounts()
+	if admission.Accepted != 2 || admission.Unavailable != 1 || admission.Conflict != 0 || admission.Rejected != 0 {
+		t.Fatalf("admission counts=%+v, want two accepted and one unavailable", admission)
+	}
+	metrics := renderPrometheusMetrics(state)
+	for _, want := range []string{
+		`rubin_node_submit_tx_total{result="unavailable"} 1`,
+		`rubin_node_mempool_admit_total{result="accepted"} 2`,
+		`rubin_node_mempool_admit_total{result="unavailable"} 1`,
+		`rubin_node_mempool_txs 1`,
+	} {
+		if !strings.Contains(metrics, want) {
+			t.Fatalf("missing %q in metrics %q", want, metrics)
+		}
+	}
+}
+
 func TestDevnetRPCSubmitTxRejectsLowFeeDaCommitWhenSurchargePolicyEnabled(t *testing.T) {
 	fromKey := mustRPCMLDSA87Keypair(t)
 	toKey := mustRPCMLDSA87Keypair(t)
@@ -1650,6 +1773,7 @@ func TestClassifySubmitErrVariants(t *testing.T) {
 		{name: "conflict already present", err: &node.TxAdmitError{Kind: node.TxAdmitConflict, Message: "already in mempool"}, wantStatus: http.StatusConflict, wantResult: "conflict"},
 		{name: "conflict double spend", err: &node.TxAdmitError{Kind: node.TxAdmitConflict, Message: "double-spend conflict"}, wantStatus: http.StatusConflict, wantResult: "conflict"},
 		{name: "unavailable mempool full", err: &node.TxAdmitError{Kind: node.TxAdmitUnavailable, Message: "mempool full"}, wantStatus: http.StatusServiceUnavailable, wantResult: "unavailable"},
+		{name: "unavailable rolling floor", err: &node.TxAdmitError{Kind: node.TxAdmitUnavailable, Message: "mempool fee below rolling minimum"}, wantStatus: http.StatusServiceUnavailable, wantResult: "unavailable"},
 		{name: "unavailable blockstore", err: &node.TxAdmitError{Kind: node.TxAdmitUnavailable, Message: "blockstore unavailable"}, wantStatus: http.StatusServiceUnavailable, wantResult: "unavailable"},
 		{name: "rejected consensus", err: &node.TxAdmitError{Kind: node.TxAdmitRejected, Message: "transaction rejected"}, wantStatus: http.StatusUnprocessableEntity, wantResult: "rejected"},
 		{name: "fallback unknown error", err: errors.New("something unexpected"), wantStatus: http.StatusUnprocessableEntity, wantResult: "rejected"},

--- a/clients/go/node/coverage_hotspots_test.go
+++ b/clients/go/node/coverage_hotspots_test.go
@@ -101,11 +101,11 @@ func TestCoverage_MempoolHelpers(t *testing.T) {
 		existingTxID = txid
 		break
 	}
-	if err := mp.validateAdmissionLocked(&mempoolEntry{txid: existingTxID, weight: 1, size: 1}); err == nil {
+	if err := mp.validateNonCapacityAdmissionLocked(&mempoolEntry{txid: existingTxID, weight: 1, size: 1}); err == nil {
 		t.Fatalf("expected duplicate tx rejection")
 	}
 	mp.maxTxs = len(mp.txs)
-	if err := mp.validateAdmissionLocked(&mempoolEntry{txid: [32]byte{0xaa}, fee: 1, weight: 1, size: 1}); err == nil {
+	if err := mp.addEntryLocked(&mempoolEntry{txid: [32]byte{0xaa}, fee: 1, weight: 1, size: 1}); err == nil {
 		t.Fatalf("expected mempool full")
 	}
 	if got := pickEntries(mp.snapshotEntries(), 1, 1<<20); len(got) != 1 {

--- a/clients/go/node/coverage_hotspots_test.go
+++ b/clients/go/node/coverage_hotspots_test.go
@@ -82,14 +82,14 @@ func TestCoverage_MempoolHelpers(t *testing.T) {
 	toKey := mustNodeMLDSA87Keypair(t)
 	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
 	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
-	st, outpoints := testSpendableChainState(fromAddress, []uint64{100, 100})
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000, 1_000_000})
 
 	mp, err := NewMempool(st, nil, devnetGenesisChainID)
 	if err != nil {
 		t.Fatalf("NewMempool: %v", err)
 	}
-	tx1 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 1, 1, fromKey, fromAddress, toAddress)
-	tx2 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[1]}, 90, 2, 2, fromKey, fromAddress, toAddress)
+	tx1 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 100_000, 1, fromKey, fromAddress, toAddress)
+	tx2 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[1]}, 100_000, 200_000, 2, fromKey, fromAddress, toAddress)
 	if err := mp.AddTx(tx1); err != nil {
 		t.Fatalf("AddTx(tx1): %v", err)
 	}
@@ -105,7 +105,7 @@ func TestCoverage_MempoolHelpers(t *testing.T) {
 		t.Fatalf("expected duplicate tx rejection")
 	}
 	mp.maxTxs = len(mp.txs)
-	if err := mp.validateAdmissionLocked(&mempoolEntry{txid: [32]byte{0xaa}, fee: 0, weight: 1, size: 1}); err == nil {
+	if err := mp.validateAdmissionLocked(&mempoolEntry{txid: [32]byte{0xaa}, fee: 1, weight: 1, size: 1}); err == nil {
 		t.Fatalf("expected mempool full")
 	}
 	if got := pickEntries(mp.snapshotEntries(), 1, 1<<20); len(got) != 1 {

--- a/clients/go/node/coverage_hotspots_test.go
+++ b/clients/go/node/coverage_hotspots_test.go
@@ -101,7 +101,7 @@ func TestCoverage_MempoolHelpers(t *testing.T) {
 		existingTxID = txid
 		break
 	}
-	if err := mp.validateAdmissionLocked(&mempoolEntry{txid: existingTxID, size: 1}); err == nil {
+	if err := mp.validateAdmissionLocked(&mempoolEntry{txid: existingTxID, weight: 1, size: 1}); err == nil {
 		t.Fatalf("expected duplicate tx rejection")
 	}
 	mp.maxTxs = len(mp.txs)

--- a/clients/go/node/coverage_sub80_followup_test.go
+++ b/clients/go/node/coverage_sub80_followup_test.go
@@ -29,16 +29,16 @@ func TestCoverageResidual_MempoolBranches(t *testing.T) {
 	if err := (*Mempool)(nil).RemoveConflictingParsed(&consensus.ParsedBlock{}); err == nil {
 		t.Fatalf("expected nil mempool parsed conflict rejection")
 	}
-	if got := compareFeeRate(nil, &mempoolEntry{fee: 1, size: 1}); got != 0 {
+	if got := compareFeeRate(nil, &mempoolEntry{fee: 1, weight: 1, size: 1}); got != 0 {
 		t.Fatalf("compareFeeRate(nil)= %d", got)
 	}
-	if got := compareFeeRate(&mempoolEntry{fee: 2, size: 1}, &mempoolEntry{fee: 1, size: 1}); got <= 0 {
+	if got := compareFeeRate(&mempoolEntry{fee: 2, weight: 1, size: 1}, &mempoolEntry{fee: 1, weight: 1, size: 1}); got <= 0 {
 		t.Fatalf("expected first feerate to win")
 	}
 	if got := compareFeeRate(&mempoolEntry{fee: 1, size: 2}, &mempoolEntry{fee: 1, size: 1}); got >= 0 {
 		t.Fatalf("expected second feerate to win")
 	}
-	entries := []*mempoolEntry{{txid: [32]byte{0x02}, fee: 10, size: 1}, {txid: [32]byte{0x01}, fee: 10, size: 1}}
+	entries := []*mempoolEntry{{txid: [32]byte{0x02}, fee: 10, weight: 1, size: 1}, {txid: [32]byte{0x01}, fee: 10, weight: 1, size: 1}}
 	sortMempoolEntries(entries)
 	if entries[0].txid[0] != 0x01 {
 		t.Fatalf("expected deterministic txid tie-break")
@@ -109,11 +109,11 @@ func TestCoverageResidual_MempoolLimitBranches(t *testing.T) {
 	if err := mp.validateAdmissionLocked(&mempoolEntry{txid: [32]byte{0x01}, size: 0}); err == nil {
 		t.Fatalf("expected invalid size rejection")
 	}
-	if err := mp.addEntryLocked(&mempoolEntry{txid: [32]byte{0x02}, size: 1}); err != nil {
+	if err := mp.addEntryLocked(&mempoolEntry{txid: [32]byte{0x02}, weight: 1, size: 1}); err != nil {
 		t.Fatalf("addEntryLocked(count seed): %v", err)
 	}
-	if err := mp.validateAdmissionLocked(&mempoolEntry{txid: [32]byte{0x03}, size: 1}); err == nil {
-		t.Fatalf("expected count-limit rejection")
+	if err := mp.validateAdmissionLocked(&mempoolEntry{txid: [32]byte{0x03}, weight: 1, size: 1}); err == nil {
+		t.Fatalf("expected capacity rejection")
 	}
 	mp.mu.Unlock()
 
@@ -125,11 +125,11 @@ func TestCoverageResidual_MempoolLimitBranches(t *testing.T) {
 		t.Fatalf("NewMempool(bytes): %v", err)
 	}
 	mpBytes.mu.Lock()
-	if err := mpBytes.addEntryLocked(&mempoolEntry{txid: [32]byte{0x04}, size: 1}); err != nil {
+	if err := mpBytes.addEntryLocked(&mempoolEntry{txid: [32]byte{0x04}, weight: 1, size: 1}); err != nil {
 		t.Fatalf("addEntryLocked(byte seed): %v", err)
 	}
-	if err := mpBytes.validateAdmissionLocked(&mempoolEntry{txid: [32]byte{0x05}, size: 2}); err == nil {
-		t.Fatalf("expected byte-limit rejection")
+	if err := mpBytes.validateAdmissionLocked(&mempoolEntry{txid: [32]byte{0x05}, weight: 1, size: 2}); err == nil {
+		t.Fatalf("expected byte-capacity rejection")
 	}
 	mpBytes.usedBytes = 1
 	mpBytes.deleteEntryLocked([32]byte{0x06}, &mempoolEntry{size: 2})

--- a/clients/go/node/coverage_sub80_followup_test.go
+++ b/clients/go/node/coverage_sub80_followup_test.go
@@ -58,7 +58,7 @@ func TestCoverageResidual_MempoolBranches(t *testing.T) {
 	if err := mp.RemoveConflictingParsed(nil); err == nil {
 		t.Fatalf("expected nil parsed block conflict rejection")
 	}
-	if err := mp.validateAdmissionLocked(nil); err == nil {
+	if err := mp.validateNonCapacityAdmissionLocked(nil); err == nil {
 		t.Fatalf("expected nil mempool entry rejection")
 	}
 	if err := mp.EvictConfirmed([]byte{0x00}); err == nil {
@@ -106,13 +106,13 @@ func TestCoverageResidual_MempoolLimitBranches(t *testing.T) {
 		t.Fatalf("NewMempool: %v", err)
 	}
 	mp.mu.Lock()
-	if err := mp.validateAdmissionLocked(&mempoolEntry{txid: [32]byte{0x01}, size: 0}); err == nil {
+	if err := mp.validateNonCapacityAdmissionLocked(&mempoolEntry{txid: [32]byte{0x01}, size: 0}); err == nil {
 		t.Fatalf("expected invalid size rejection")
 	}
 	if err := mp.addEntryLocked(&mempoolEntry{txid: [32]byte{0x02}, fee: 1, weight: 1, size: 1}); err != nil {
 		t.Fatalf("addEntryLocked(count seed): %v", err)
 	}
-	if err := mp.validateAdmissionLocked(&mempoolEntry{txid: [32]byte{0x03}, fee: 1, weight: 1, size: 1}); err == nil {
+	if err := mp.addEntryLocked(&mempoolEntry{txid: [32]byte{0x03}, fee: 1, weight: 1, size: 1}); err == nil {
 		t.Fatalf("expected capacity rejection")
 	}
 	mp.mu.Unlock()
@@ -128,7 +128,7 @@ func TestCoverageResidual_MempoolLimitBranches(t *testing.T) {
 	if err := mpBytes.addEntryLocked(&mempoolEntry{txid: [32]byte{0x04}, fee: 1, weight: 1, size: 1}); err != nil {
 		t.Fatalf("addEntryLocked(byte seed): %v", err)
 	}
-	if err := mpBytes.validateAdmissionLocked(&mempoolEntry{txid: [32]byte{0x05}, fee: 1, weight: 1, size: 2}); err == nil {
+	if err := mpBytes.addEntryLocked(&mempoolEntry{txid: [32]byte{0x05}, fee: 1, weight: 1, size: 2}); err == nil {
 		t.Fatalf("expected byte-capacity rejection")
 	}
 	mpBytes.usedBytes = 1

--- a/clients/go/node/coverage_sub80_followup_test.go
+++ b/clients/go/node/coverage_sub80_followup_test.go
@@ -35,7 +35,7 @@ func TestCoverageResidual_MempoolBranches(t *testing.T) {
 	if got := compareFeeRate(&mempoolEntry{fee: 2, weight: 1, size: 1}, &mempoolEntry{fee: 1, weight: 1, size: 1}); got <= 0 {
 		t.Fatalf("expected first feerate to win")
 	}
-	if got := compareFeeRate(&mempoolEntry{fee: 1, size: 2}, &mempoolEntry{fee: 1, size: 1}); got >= 0 {
+	if got := compareFeeRate(&mempoolEntry{fee: 1, weight: 2, size: 1}, &mempoolEntry{fee: 1, weight: 1, size: 2}); got >= 0 {
 		t.Fatalf("expected second feerate to win")
 	}
 	entries := []*mempoolEntry{{txid: [32]byte{0x02}, fee: 10, weight: 1, size: 1}, {txid: [32]byte{0x01}, fee: 10, weight: 1, size: 1}}

--- a/clients/go/node/coverage_sub80_followup_test.go
+++ b/clients/go/node/coverage_sub80_followup_test.go
@@ -74,14 +74,14 @@ func TestCoverageResidual_RemoveConflictingParsesBlockBytes(t *testing.T) {
 	toKey := mustNodeMLDSA87Keypair(t)
 	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
 	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
-	st, outpoints := testSpendableChainState(fromAddress, []uint64{100})
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000})
 
 	mp, err := NewMempool(st, nil, devnetGenesisChainID)
 	if err != nil {
 		t.Fatalf("NewMempool: %v", err)
 	}
-	txPool := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 1, 1, fromKey, fromAddress, toAddress)
-	txBlock := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 89, 2, 2, fromKey, fromAddress, toAddress)
+	txPool := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 100_000, 1, fromKey, fromAddress, toAddress)
+	txBlock := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 200_000, 2, fromKey, fromAddress, toAddress)
 	if err := mp.AddTx(txPool); err != nil {
 		t.Fatalf("AddTx(txPool): %v", err)
 	}
@@ -109,10 +109,10 @@ func TestCoverageResidual_MempoolLimitBranches(t *testing.T) {
 	if err := mp.validateAdmissionLocked(&mempoolEntry{txid: [32]byte{0x01}, size: 0}); err == nil {
 		t.Fatalf("expected invalid size rejection")
 	}
-	if err := mp.addEntryLocked(&mempoolEntry{txid: [32]byte{0x02}, weight: 1, size: 1}); err != nil {
+	if err := mp.addEntryLocked(&mempoolEntry{txid: [32]byte{0x02}, fee: 1, weight: 1, size: 1}); err != nil {
 		t.Fatalf("addEntryLocked(count seed): %v", err)
 	}
-	if err := mp.validateAdmissionLocked(&mempoolEntry{txid: [32]byte{0x03}, weight: 1, size: 1}); err == nil {
+	if err := mp.validateAdmissionLocked(&mempoolEntry{txid: [32]byte{0x03}, fee: 1, weight: 1, size: 1}); err == nil {
 		t.Fatalf("expected capacity rejection")
 	}
 	mp.mu.Unlock()
@@ -125,10 +125,10 @@ func TestCoverageResidual_MempoolLimitBranches(t *testing.T) {
 		t.Fatalf("NewMempool(bytes): %v", err)
 	}
 	mpBytes.mu.Lock()
-	if err := mpBytes.addEntryLocked(&mempoolEntry{txid: [32]byte{0x04}, weight: 1, size: 1}); err != nil {
+	if err := mpBytes.addEntryLocked(&mempoolEntry{txid: [32]byte{0x04}, fee: 1, weight: 1, size: 1}); err != nil {
 		t.Fatalf("addEntryLocked(byte seed): %v", err)
 	}
-	if err := mpBytes.validateAdmissionLocked(&mempoolEntry{txid: [32]byte{0x05}, weight: 1, size: 2}); err == nil {
+	if err := mpBytes.validateAdmissionLocked(&mempoolEntry{txid: [32]byte{0x05}, fee: 1, weight: 1, size: 2}); err == nil {
 		t.Fatalf("expected byte-capacity rejection")
 	}
 	mpBytes.usedBytes = 1

--- a/clients/go/node/devnet_test.go
+++ b/clients/go/node/devnet_test.go
@@ -98,7 +98,7 @@ func TestDevnetThreeNodeSyncAndDeterminism(t *testing.T) {
 func TestDevnetTwoNodeFullBlockP2PBaseline(t *testing.T) {
 	const (
 		txAmount = 10
-		txFee    = 1
+		txFee    = 100_000
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -273,7 +273,7 @@ func TestDevnetSoakWithTxGenAndRestart(t *testing.T) {
 		checkpointEvery = 100
 		txInterval      = 10
 		txAmount        = 10
-		txFee           = 1
+		txFee           = 100_000
 		restartAt       = 700
 		killAt          = 500
 	)

--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -1010,10 +1010,7 @@ func (m *Mempool) capacityStateLocked(candidate *mempoolEntry) (mempoolCapacityS
 	bytePressure := usedBytes > maxBytes-candidateSize
 	targetBytes := maxBytes
 	if bytePressure {
-		targetBytes = uint64(m.effectiveLowWaterBytesLocked()) // #nosec G115 -- effectiveLowWaterBytesLocked returns 0 or a positive value derived from positive maxBytes.
-		if targetBytes < candidateSize {
-			targetBytes = candidateSize
-		}
+		targetBytes = mempoolBytePressureTarget(uint64(m.effectiveLowWaterBytesLocked()), candidateSize) // #nosec G115 -- effectiveLowWaterBytesLocked returns 0 or a positive value derived from positive maxBytes.
 	}
 	return mempoolCapacityState{
 		maxBytes:      maxBytes,
@@ -1025,6 +1022,13 @@ func (m *Mempool) capacityStateLocked(candidate *mempoolEntry) (mempoolCapacityS
 		countPressure: countPressure,
 		bytePressure:  bytePressure,
 	}, nil
+}
+
+func mempoolBytePressureTarget(lowWaterBytes uint64, candidateSize uint64) uint64 {
+	if lowWaterBytes < candidateSize {
+		return candidateSize
+	}
+	return lowWaterBytes
 }
 
 func (state mempoolCapacityState) underPressure() bool {

--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -931,10 +931,7 @@ func (m *Mempool) capacityEvictionPlanLocked(candidate *mempoolEntry) ([]*mempoo
 	totalCount := len(m.txs) + 1
 	targetBytes := maxBytes
 	if bytePressure {
-		targetBytes, err = nonNegativeMempoolIntToUint64("low_water_bytes", m.effectiveLowWaterBytesLocked())
-		if err != nil {
-			return nil, false, err
-		}
+		targetBytes = uint64(m.effectiveLowWaterBytesLocked()) // #nosec G115 -- effectiveLowWaterBytesLocked returns 0 or a positive value derived from positive maxBytes.
 	}
 	planPool := make([]mempoolEvictionPlanEntry, 0, len(m.txs)+1)
 	admissionSeqs := make(map[uint64][32]byte, len(m.txs))
@@ -963,10 +960,7 @@ func (m *Mempool) capacityEvictionPlanLocked(candidate *mempoolEntry) ([]*mempoo
 			return nil, true, nil
 		}
 		evictedEntries = append(evictedEntries, worst.entry)
-		worstSize, err := nonNegativeMempoolIntToUint64("eviction_entry_size", worst.entry.size)
-		if err != nil {
-			return nil, false, err
-		}
+		worstSize := uint64(worst.entry.size) // #nosec G115 -- validateEvictionMetadata rejects non-positive entry sizes before this loop.
 		if totalBytes >= worstSize {
 			totalBytes -= worstSize
 		} else {

--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -493,7 +493,6 @@ func (m *Mempool) EvictConfirmedParsed(block *consensus.ParsedBlock) error {
 		for _, txid := range block.Txids {
 			m.removeTxLocked(txid)
 		}
-		m.decayMinFeeRateAfterConnectedBlockLocked()
 	})
 }
 
@@ -803,27 +802,53 @@ func newMempoolEntry(checked *consensus.CheckedTransaction, inputs []consensus.O
 	}
 }
 
-func (m *Mempool) addEntryLocked(entry *mempoolEntry) error {
-	if entry != nil && entry.source == "" {
+func normalizeMempoolEntryDefaults(entry *mempoolEntry) {
+	if entry == nil {
+		return
+	}
+	if entry.source == "" {
 		entry.source = mempoolTxSourceLocal
 	}
-	if entry != nil && entry.wtxid == ([32]byte{}) {
+	if entry.wtxid == ([32]byte{}) {
 		entry.wtxid = entry.txid
 	}
+}
+
+func (m *Mempool) addEntryLocked(entry *mempoolEntry) error {
+	normalizeMempoolEntryDefaults(entry)
 	if err := m.validateNonCapacityAdmissionLocked(entry); err != nil {
 		return err
 	}
-	if err := m.validateFeeFloorLocked(entry); err != nil {
-		return err
-	}
-	evictedEntries, candidateEvicted, err := m.capacityEvictionPlanLocked(entry)
+	evictedEntries, err := m.validateCapacityAdmissionLocked(entry)
 	if err != nil {
 		return err
 	}
-	if candidateEvicted {
-		return txAdmitUnavailable("mempool capacity candidate rejected by eviction ordering")
-	}
 	m.ensureMinFeeRateLocked()
+	m.ensureIndexesLocked()
+	for _, evicted := range evictedEntries {
+		m.deleteEntryLocked(evicted.txid, evicted)
+	}
+	m.assignAdmissionSeqLocked(entry)
+	m.insertEntryIndexesLocked(entry)
+	m.raiseMinFeeRateAfterEvictionLocked(evictedEntries)
+	return nil
+}
+
+func (m *Mempool) validateCapacityAdmissionLocked(entry *mempoolEntry) ([]*mempoolEntry, error) {
+	if err := m.validateFeeFloorLocked(entry); err != nil {
+		return nil, err
+	}
+	evictedEntries, candidateEvicted, err := m.capacityEvictionPlanLocked(entry)
+	if err != nil {
+		return nil, err
+	}
+	if candidateEvicted {
+		return nil, txAdmitUnavailable("mempool capacity candidate rejected by eviction ordering")
+	}
+	return evictedEntries, nil
+}
+
+func (m *Mempool) ensureIndexesLocked() {
 	if m.txs == nil {
 		m.txs = make(map[[32]byte]*mempoolEntry)
 	}
@@ -833,23 +858,24 @@ func (m *Mempool) addEntryLocked(entry *mempoolEntry) error {
 	if m.spenders == nil {
 		m.spenders = make(map[consensus.Outpoint][32]byte)
 	}
-	for _, evicted := range evictedEntries {
-		m.deleteEntryLocked(evicted.txid, evicted)
-	}
+}
+
+func (m *Mempool) assignAdmissionSeqLocked(entry *mempoolEntry) {
 	if entry.admissionSeq == 0 {
 		m.lastAdmissionSeq++
 		entry.admissionSeq = m.lastAdmissionSeq
 	} else if entry.admissionSeq > m.lastAdmissionSeq {
 		m.lastAdmissionSeq = entry.admissionSeq
 	}
+}
+
+func (m *Mempool) insertEntryIndexesLocked(entry *mempoolEntry) {
 	m.txs[entry.txid] = entry
 	m.wtxids[entry.wtxid] = entry.txid
 	m.usedBytes += entry.size
 	for _, op := range entry.inputs {
 		m.spenders[op] = entry.txid
 	}
-	m.raiseMinFeeRateAfterEvictionLocked(evictedEntries)
-	return nil
 }
 
 func (m *Mempool) snapshotEntries() []*mempoolEntry {

--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -704,20 +704,10 @@ func (m *Mempool) removeTxLocked(txid [32]byte) {
 }
 
 func (m *Mempool) validateAdmissionLocked(entry *mempoolEntry) error {
-	if err := m.validateNonCapacityAdmissionLocked(entry); err != nil {
-		return err
-	}
-	if err := m.validateFeeFloorLocked(entry); err != nil {
-		return err
-	}
-	_, candidateEvicted, err := m.capacityEvictionPlanLocked(entry)
-	if err != nil {
-		return err
-	}
-	if candidateEvicted {
-		return txAdmitUnavailable("mempool capacity candidate rejected by eviction ordering")
-	}
-	return nil
+	// Keep this helper limited to non-capacity checks so callers that
+	// immediately proceed to addEntryLocked do not duplicate the fee-floor
+	// and eviction-plan scan work under the same lock.
+	return m.validateNonCapacityAdmissionLocked(entry)
 }
 
 func (m *Mempool) validateNonCapacityAdmissionLocked(entry *mempoolEntry) error {

--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -1032,31 +1032,50 @@ func (m *Mempool) evictionPlanPoolLocked(candidate *mempoolEntry) ([]mempoolEvic
 
 func dryRunCapacityEvictions(planPool []mempoolEvictionPlanEntry, state mempoolCapacityState, maxTxs int) ([]*mempoolEntry, bool, error) {
 	evictedEntries := make([]*mempoolEntry, 0)
-	for (state.totalCount > maxTxs || state.totalBytes > state.targetBytes) && len(planPool) > 0 {
-		worstIndex := 0
-		for i := 1; i < len(planPool); i++ {
-			if evictionPlanEntryWorse(planPool[i], planPool[worstIndex]) {
-				worstIndex = i
-			}
-		}
+	for state.exceedsEvictionTarget(maxTxs) && len(planPool) > 0 {
+		worstIndex := worstEvictionPlanIndex(planPool)
 		worst := planPool[worstIndex]
 		if worst.candidate {
 			return nil, true, nil
 		}
 		evictedEntries = append(evictedEntries, worst.entry)
-		worstSize := uint64(worst.entry.size) // #nosec G115 -- validateEvictionMetadata rejects non-positive entry sizes before this loop.
-		if state.totalBytes >= worstSize {
-			state.totalBytes -= worstSize
-		} else {
-			return nil, false, txAdmitUnavailable("mempool eviction byte accounting underflow")
+		if err := state.applyDryRunEviction(worst.entry); err != nil {
+			return nil, false, err
 		}
-		state.totalCount--
 		planPool = append(planPool[:worstIndex], planPool[worstIndex+1:]...)
 	}
-	if state.totalCount > maxTxs || state.totalBytes > state.maxBytes {
+	if state.exceedsHardCapacity(maxTxs) {
 		return nil, false, txAdmitUnavailable(fmt.Sprintf("mempool capacity remains exceeded after dry-run eviction: count=%d/%d bytes=%d/%d", state.totalCount, maxTxs, state.totalBytes, state.maxBytes))
 	}
 	return evictedEntries, false, nil
+}
+
+func (state mempoolCapacityState) exceedsEvictionTarget(maxTxs int) bool {
+	return state.totalCount > maxTxs || state.totalBytes > state.targetBytes
+}
+
+func (state mempoolCapacityState) exceedsHardCapacity(maxTxs int) bool {
+	return state.totalCount > maxTxs || state.totalBytes > state.maxBytes
+}
+
+func (state *mempoolCapacityState) applyDryRunEviction(entry *mempoolEntry) error {
+	worstSize := uint64(entry.size) // #nosec G115 -- validateEvictionMetadata rejects non-positive entry sizes before this helper.
+	if state.totalBytes < worstSize {
+		return txAdmitUnavailable("mempool eviction byte accounting underflow")
+	}
+	state.totalBytes -= worstSize
+	state.totalCount--
+	return nil
+}
+
+func worstEvictionPlanIndex(planPool []mempoolEvictionPlanEntry) int {
+	worstIndex := 0
+	for i := 1; i < len(planPool); i++ {
+		if evictionPlanEntryWorse(planPool[i], planPool[worstIndex]) {
+			worstIndex = i
+		}
+	}
+	return worstIndex
 }
 
 func nonNegativeMempoolIntToUint64(label string, value int) (uint64, error) {

--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -15,6 +15,10 @@ import (
 const (
 	DefaultMempoolMaxTransactions = 300
 	DefaultMempoolMaxBytes        = consensus.MAX_RELAY_MSG_BYTES
+	DefaultMempoolMinFeeRate      = uint64(1)
+
+	mempoolLowWaterNumerator   = 9
+	mempoolLowWaterDenominator = 10
 )
 
 type mempoolTxSource string
@@ -38,18 +42,20 @@ type mempoolEntry struct {
 }
 
 type Mempool struct {
-	mu               sync.RWMutex
-	chainState       *ChainState
-	blockStore       *BlockStore
-	chainID          [32]byte
-	policy           MempoolConfig
-	maxTxs           int
-	maxBytes         int
-	usedBytes        int
-	lastAdmissionSeq uint64
-	txs              map[[32]byte]*mempoolEntry
-	wtxids           map[[32]byte][32]byte
-	spenders         map[consensus.Outpoint][32]byte
+	mu                sync.RWMutex
+	chainState        *ChainState
+	blockStore        *BlockStore
+	chainID           [32]byte
+	policy            MempoolConfig
+	maxTxs            int
+	maxBytes          int
+	lowWaterBytes     int
+	usedBytes         int
+	lastAdmissionSeq  uint64
+	currentMinFeeRate uint64
+	txs               map[[32]byte]*mempoolEntry
+	wtxids            map[[32]byte][32]byte
+	spenders          map[consensus.Outpoint][32]byte
 	// Admission counters are bumped exactly once for each AddTx call on a
 	// non-nil Mempool that reaches the final outcome accounting path.
 	// Nil-receiver calls return before that defer is registered and are
@@ -149,15 +155,17 @@ func NewMempoolWithConfig(chainState *ChainState, blockStore *BlockStore, chainI
 	}
 	cfg = normalizeMempoolConfig(cfg)
 	return &Mempool{
-		chainState: chainState,
-		blockStore: blockStore,
-		chainID:    chainID,
-		policy:     cfg,
-		maxTxs:     cfg.MaxTransactions,
-		maxBytes:   cfg.MaxBytes,
-		txs:        make(map[[32]byte]*mempoolEntry),
-		wtxids:     make(map[[32]byte][32]byte),
-		spenders:   make(map[consensus.Outpoint][32]byte),
+		chainState:        chainState,
+		blockStore:        blockStore,
+		chainID:           chainID,
+		policy:            cfg,
+		maxTxs:            cfg.MaxTransactions,
+		maxBytes:          cfg.MaxBytes,
+		lowWaterBytes:     defaultMempoolLowWaterBytes(cfg.MaxBytes),
+		currentMinFeeRate: DefaultMempoolMinFeeRate,
+		txs:               make(map[[32]byte]*mempoolEntry),
+		wtxids:            make(map[[32]byte][32]byte),
+		spenders:          make(map[consensus.Outpoint][32]byte),
 	}, nil
 }
 
@@ -169,6 +177,18 @@ func normalizeMempoolConfig(cfg MempoolConfig) MempoolConfig {
 		cfg.MaxBytes = DefaultMempoolMaxBytes
 	}
 	return cfg
+}
+
+func defaultMempoolLowWaterBytes(maxBytes int) int {
+	if maxBytes <= 0 {
+		return 0
+	}
+	lowWater := (maxBytes/mempoolLowWaterDenominator)*mempoolLowWaterNumerator +
+		((maxBytes % mempoolLowWaterDenominator) * mempoolLowWaterNumerator / mempoolLowWaterDenominator)
+	if lowWater > maxBytes {
+		return maxBytes
+	}
+	return lowWater
 }
 
 func (m *Mempool) Len() int {
@@ -477,6 +497,7 @@ func (m *Mempool) EvictConfirmedParsed(block *consensus.ParsedBlock) error {
 		for _, txid := range block.Txids {
 			m.removeTxLocked(txid)
 		}
+		m.decayMinFeeRateAfterConnectedBlockLocked()
 	})
 }
 
@@ -671,11 +692,28 @@ func (m *Mempool) removeTxLocked(txid [32]byte) {
 }
 
 func (m *Mempool) validateAdmissionLocked(entry *mempoolEntry) error {
+	if err := m.validateNonCapacityAdmissionLocked(entry); err != nil {
+		return err
+	}
+	_, candidateEvicted, err := m.capacityEvictionPlanLocked(entry)
+	if err != nil {
+		return err
+	}
+	if candidateEvicted {
+		return txAdmitUnavailable("mempool capacity candidate rejected by eviction ordering")
+	}
+	return nil
+}
+
+func (m *Mempool) validateNonCapacityAdmissionLocked(entry *mempoolEntry) error {
 	if entry == nil {
 		return txAdmitRejected("nil mempool entry")
 	}
 	if entry.size <= 0 {
 		return txAdmitRejected("invalid mempool entry size")
+	}
+	if entry.weight == 0 {
+		return txAdmitRejected("invalid mempool entry weight")
 	}
 	txid := entry.txid
 	if txid == ([32]byte{}) {
@@ -691,16 +729,24 @@ func (m *Mempool) validateAdmissionLocked(entry *mempoolEntry) error {
 	if existing, exists := m.wtxids[wtxid]; exists {
 		return txAdmitConflict(fmt.Sprintf("mempool wtxid conflict with %x", existing))
 	}
+	source := entry.source
+	if source == "" {
+		source = mempoolTxSourceLocal
+	}
+	if !validMempoolTxSource(source) {
+		return txAdmitRejected(fmt.Sprintf("invalid mempool tx source %q", source))
+	}
 	for _, op := range entry.inputs {
 		if existing, ok := m.spenders[op]; ok {
 			return txAdmitConflict(fmt.Sprintf("mempool double-spend conflict with %x", existing))
 		}
 	}
-	if len(m.txs) >= m.maxTxs {
-		return txAdmitUnavailable(fmt.Sprintf("mempool transaction count limit reached: current=%d max=%d", len(m.txs), m.maxTxs))
-	}
-	if entry.size > m.maxBytes || m.usedBytes > m.maxBytes-entry.size {
-		return txAdmitUnavailable(fmt.Sprintf("mempool byte limit exceeded: current=%d tx=%d max=%d", m.usedBytes, entry.size, m.maxBytes))
+	if entry.admissionSeq != 0 {
+		for existingTxid, existing := range m.txs {
+			if existing != nil && existing.admissionSeq == entry.admissionSeq {
+				return txAdmitConflict(fmt.Sprintf("mempool admission sequence conflict with %x", existingTxid))
+			}
+		}
 	}
 	if m.lastAdmissionSeq == ^uint64(0) {
 		return txAdmitUnavailable("mempool admission sequence exhausted")
@@ -722,15 +768,23 @@ func newMempoolEntry(checked *consensus.CheckedTransaction, inputs []consensus.O
 }
 
 func (m *Mempool) addEntryLocked(entry *mempoolEntry) error {
-	if entry == nil {
-		return txAdmitRejected("nil mempool entry")
+	if entry != nil && entry.source == "" {
+		entry.source = mempoolTxSourceLocal
 	}
-	if entry.size <= 0 {
-		return txAdmitRejected("invalid mempool entry size")
+	if entry != nil && entry.wtxid == ([32]byte{}) {
+		entry.wtxid = entry.txid
 	}
-	if entry.txid == ([32]byte{}) {
-		return txAdmitRejected("invalid mempool entry txid")
+	if err := m.validateNonCapacityAdmissionLocked(entry); err != nil {
+		return err
 	}
+	evictedEntries, candidateEvicted, err := m.capacityEvictionPlanLocked(entry)
+	if err != nil {
+		return err
+	}
+	if candidateEvicted {
+		return txAdmitUnavailable("mempool capacity candidate rejected by eviction ordering")
+	}
+	m.ensureMinFeeRateLocked()
 	if m.txs == nil {
 		m.txs = make(map[[32]byte]*mempoolEntry)
 	}
@@ -740,17 +794,14 @@ func (m *Mempool) addEntryLocked(entry *mempoolEntry) error {
 	if m.spenders == nil {
 		m.spenders = make(map[consensus.Outpoint][32]byte)
 	}
+	for _, evicted := range evictedEntries {
+		m.deleteEntryLocked(evicted.txid, evicted)
+	}
 	if entry.admissionSeq == 0 {
 		m.lastAdmissionSeq++
 		entry.admissionSeq = m.lastAdmissionSeq
 	} else if entry.admissionSeq > m.lastAdmissionSeq {
 		m.lastAdmissionSeq = entry.admissionSeq
-	}
-	if entry.source == "" {
-		entry.source = mempoolTxSourceLocal
-	}
-	if entry.wtxid == ([32]byte{}) {
-		entry.wtxid = entry.txid
 	}
 	m.txs[entry.txid] = entry
 	m.wtxids[entry.wtxid] = entry.txid
@@ -758,6 +809,7 @@ func (m *Mempool) addEntryLocked(entry *mempoolEntry) error {
 	for _, op := range entry.inputs {
 		m.spenders[op] = entry.txid
 	}
+	m.raiseMinFeeRateAfterEvictionLocked(evictedEntries)
 	return nil
 }
 
@@ -841,6 +893,252 @@ func (m *Mempool) deleteEntryLocked(txid [32]byte, entry *mempoolEntry) {
 	}
 }
 
+type mempoolEvictionPlanEntry struct {
+	entry     *mempoolEntry
+	candidate bool
+}
+
+func (m *Mempool) capacityEvictionPlanLocked(candidate *mempoolEntry) ([]*mempoolEntry, bool, error) {
+	if candidate == nil {
+		return nil, false, txAdmitRejected("nil mempool entry")
+	}
+	if m.maxTxs <= 0 || m.maxBytes <= 0 {
+		return nil, false, txAdmitUnavailable(fmt.Sprintf("invalid mempool capacity limits: max_txs=%d max_bytes=%d", m.maxTxs, m.maxBytes))
+	}
+	if candidate.size > m.maxBytes {
+		return nil, false, txAdmitUnavailable(fmt.Sprintf("mempool byte limit exceeded: current=%d tx=%d max=%d", m.usedBytes, candidate.size, m.maxBytes))
+	}
+	if m.usedBytes < 0 {
+		return nil, false, txAdmitUnavailable(fmt.Sprintf("invalid mempool byte accounting: used=%d", m.usedBytes))
+	}
+	usedBytes, err := nonNegativeMempoolIntToUint64("used_bytes", m.usedBytes)
+	if err != nil {
+		return nil, false, err
+	}
+	candidateSize, err := nonNegativeMempoolIntToUint64("candidate_size", candidate.size)
+	if err != nil {
+		return nil, false, err
+	}
+	maxBytes, err := nonNegativeMempoolIntToUint64("max_bytes", m.maxBytes)
+	if err != nil {
+		return nil, false, err
+	}
+	countPressure := len(m.txs) >= m.maxTxs
+	bytePressure := m.usedBytes > m.maxBytes-candidate.size
+	if !countPressure && !bytePressure {
+		return nil, false, nil
+	}
+	currentMinFeeRate := m.currentMinFeeRateLocked()
+	if feeRateBelowFloor(candidate.fee, candidate.weight, currentMinFeeRate) {
+		return nil, false, txAdmitRejected(fmt.Sprintf("mempool fee below rolling minimum: fee=%d weight=%d min_fee_rate=%d", candidate.fee, candidate.weight, currentMinFeeRate))
+	}
+
+	totalBytes := usedBytes + candidateSize
+	totalCount := len(m.txs) + 1
+	targetBytes := maxBytes
+	if bytePressure {
+		targetBytes, err = nonNegativeMempoolIntToUint64("low_water_bytes", m.effectiveLowWaterBytesLocked())
+		if err != nil {
+			return nil, false, err
+		}
+	}
+	planPool := make([]mempoolEvictionPlanEntry, 0, len(m.txs)+1)
+	admissionSeqs := make(map[uint64][32]byte, len(m.txs))
+	for _, entry := range m.txs {
+		if err := validateEvictionMetadata(entry); err != nil {
+			return nil, false, err
+		}
+		if existing, exists := admissionSeqs[entry.admissionSeq]; exists {
+			return nil, false, txAdmitRejected(fmt.Sprintf("duplicate mempool entry admission_seq %d existing=%x new=%x", entry.admissionSeq, existing, entry.txid))
+		}
+		admissionSeqs[entry.admissionSeq] = entry.txid
+		planPool = append(planPool, mempoolEvictionPlanEntry{entry: entry})
+	}
+	planPool = append(planPool, mempoolEvictionPlanEntry{entry: candidate, candidate: true})
+
+	evictedEntries := make([]*mempoolEntry, 0)
+	for (totalCount > m.maxTxs || totalBytes > targetBytes) && len(planPool) > 0 {
+		worstIndex := 0
+		for i := 1; i < len(planPool); i++ {
+			if evictionPlanEntryWorse(planPool[i], planPool[worstIndex]) {
+				worstIndex = i
+			}
+		}
+		worst := planPool[worstIndex]
+		if worst.candidate {
+			return nil, true, nil
+		}
+		evictedEntries = append(evictedEntries, worst.entry)
+		worstSize, err := nonNegativeMempoolIntToUint64("eviction_entry_size", worst.entry.size)
+		if err != nil {
+			return nil, false, err
+		}
+		if totalBytes >= worstSize {
+			totalBytes -= worstSize
+		} else {
+			return nil, false, txAdmitUnavailable("mempool eviction byte accounting underflow")
+		}
+		totalCount--
+		planPool = append(planPool[:worstIndex], planPool[worstIndex+1:]...)
+	}
+	if totalCount > m.maxTxs || totalBytes > maxBytes {
+		return nil, false, txAdmitUnavailable(fmt.Sprintf("mempool capacity remains exceeded after dry-run eviction: count=%d/%d bytes=%d/%d", totalCount, m.maxTxs, totalBytes, m.maxBytes))
+	}
+	return evictedEntries, false, nil
+}
+
+func nonNegativeMempoolIntToUint64(label string, value int) (uint64, error) {
+	if value < 0 {
+		return 0, txAdmitUnavailable(fmt.Sprintf("invalid mempool %s: %d", label, value))
+	}
+	return uint64(value), nil
+}
+
+func validateEvictionMetadata(entry *mempoolEntry) error {
+	if entry == nil {
+		return txAdmitRejected("nil mempool entry")
+	}
+	if entry.txid == ([32]byte{}) {
+		return txAdmitRejected("invalid mempool entry txid")
+	}
+	if entry.size <= 0 {
+		return txAdmitRejected("invalid mempool entry size")
+	}
+	if entry.weight == 0 {
+		return txAdmitRejected("invalid mempool entry weight")
+	}
+	if entry.admissionSeq == 0 {
+		return txAdmitRejected(fmt.Sprintf("invalid mempool entry admission_seq for txid %x", entry.txid))
+	}
+	return nil
+}
+
+func evictionPlanEntryWorse(a, b mempoolEvictionPlanEntry) bool {
+	if a.entry == nil || b.entry == nil {
+		return a.entry != nil && b.entry == nil
+	}
+	if cmp := compareMempoolEvictionPriority(a, b); cmp != 0 {
+		return cmp < 0
+	}
+	return bytes.Compare(a.entry.txid[:], b.entry.txid[:]) > 0
+}
+
+func compareMempoolEvictionPriority(a, b mempoolEvictionPlanEntry) int {
+	if a.entry == nil || b.entry == nil {
+		return 0
+	}
+	if cmp := compareEvictionFeeRate(a.entry, b.entry); cmp != 0 {
+		return cmp
+	}
+	if a.entry.fee != b.entry.fee {
+		if a.entry.fee > b.entry.fee {
+			return 1
+		}
+		return -1
+	}
+	aSeq := evictionAdmissionSeq(a)
+	bSeq := evictionAdmissionSeq(b)
+	if aSeq != bSeq {
+		if aSeq > bSeq {
+			return 1
+		}
+		return -1
+	}
+	return 0
+}
+
+func evictionAdmissionSeq(entry mempoolEvictionPlanEntry) uint64 {
+	if entry.candidate {
+		return 0
+	}
+	if entry.entry == nil {
+		return 0
+	}
+	return entry.entry.admissionSeq
+}
+
+func (m *Mempool) ensureMinFeeRateLocked() {
+	if m.currentMinFeeRate < DefaultMempoolMinFeeRate {
+		m.currentMinFeeRate = DefaultMempoolMinFeeRate
+	}
+}
+
+func (m *Mempool) currentMinFeeRateLocked() uint64 {
+	if m.currentMinFeeRate < DefaultMempoolMinFeeRate {
+		return DefaultMempoolMinFeeRate
+	}
+	return m.currentMinFeeRate
+}
+
+func (m *Mempool) effectiveLowWaterBytesLocked() int {
+	if m.lowWaterBytes > 0 || m.maxBytes <= 0 {
+		return m.lowWaterBytes
+	}
+	return defaultMempoolLowWaterBytes(m.maxBytes)
+}
+
+func feeRateBelowFloor(fee uint64, weight uint64, floor uint64) bool {
+	if weight == 0 {
+		return true
+	}
+	if floor < DefaultMempoolMinFeeRate {
+		floor = DefaultMempoolMinFeeRate
+	}
+	hi, lo := bits.Mul64(weight, floor)
+	if hi != 0 {
+		return true
+	}
+	return fee < lo
+}
+
+func (m *Mempool) raiseMinFeeRateAfterEvictionLocked(evictedEntries []*mempoolEntry) {
+	if len(evictedEntries) == 0 {
+		return
+	}
+	m.ensureMinFeeRateLocked()
+	var highestEvictedFloor uint64
+	for _, entry := range evictedEntries {
+		floor, ok := entryFloorRate(entry)
+		if ok && floor > highestEvictedFloor {
+			highestEvictedFloor = floor
+		}
+	}
+	raised := saturatingAddMinRelayFeeStep(highestEvictedFloor)
+	if raised > m.currentMinFeeRate {
+		m.currentMinFeeRate = raised
+	}
+}
+
+func (m *Mempool) decayMinFeeRateAfterConnectedBlockLocked() {
+	m.ensureMinFeeRateLocked()
+	if m.usedBytes >= m.effectiveLowWaterBytesLocked() {
+		return
+	}
+	decayed := m.currentMinFeeRate / 2
+	if decayed < DefaultMempoolMinFeeRate {
+		decayed = DefaultMempoolMinFeeRate
+	}
+	m.currentMinFeeRate = decayed
+}
+
+func entryFloorRate(entry *mempoolEntry) (uint64, bool) {
+	if entry == nil || entry.weight == 0 {
+		return 0, false
+	}
+	floor := entry.fee / entry.weight
+	if entry.fee%entry.weight != 0 {
+		floor++
+	}
+	return floor, true
+}
+
+func saturatingAddMinRelayFeeStep(v uint64) uint64 {
+	if v > ^uint64(0)-DefaultMempoolMinFeeRate {
+		return ^uint64(0)
+	}
+	return v + DefaultMempoolMinFeeRate
+}
+
 func compareFeeRate(a *mempoolEntry, b *mempoolEntry) int {
 	if a == nil || b == nil {
 		return 0
@@ -852,8 +1150,22 @@ func compareFeeRateValues(feeA uint64, sizeA int, feeB uint64, sizeB int) int {
 	if sizeA <= 0 || sizeB <= 0 {
 		return 0
 	}
-	ahi, alo := bits.Mul64(feeA, uint64(sizeB))
-	bhi, blo := bits.Mul64(feeB, uint64(sizeA))
+	return compareFeeRateWeightValues(feeA, uint64(sizeA), feeB, uint64(sizeB))
+}
+
+func compareEvictionFeeRate(a *mempoolEntry, b *mempoolEntry) int {
+	if a == nil || b == nil {
+		return 0
+	}
+	return compareFeeRateWeightValues(a.fee, a.weight, b.fee, b.weight)
+}
+
+func compareFeeRateWeightValues(feeA uint64, weightA uint64, feeB uint64, weightB uint64) int {
+	if weightA == 0 || weightB == 0 {
+		return 0
+	}
+	ahi, alo := bits.Mul64(feeA, weightB)
+	bhi, blo := bits.Mul64(feeB, weightA)
 	if ahi != bhi {
 		if ahi > bhi {
 			return 1

--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -185,9 +185,6 @@ func defaultMempoolLowWaterBytes(maxBytes int) int {
 	}
 	lowWater := (maxBytes/mempoolLowWaterDenominator)*mempoolLowWaterNumerator +
 		((maxBytes % mempoolLowWaterDenominator) * mempoolLowWaterNumerator / mempoolLowWaterDenominator)
-	if lowWater > maxBytes {
-		return maxBytes
-	}
 	return lowWater
 }
 
@@ -902,29 +899,26 @@ func (m *Mempool) capacityEvictionPlanLocked(candidate *mempoolEntry) ([]*mempoo
 	if candidate == nil {
 		return nil, false, txAdmitRejected("nil mempool entry")
 	}
-	if m.maxTxs <= 0 || m.maxBytes <= 0 {
-		return nil, false, txAdmitUnavailable(fmt.Sprintf("invalid mempool capacity limits: max_txs=%d max_bytes=%d", m.maxTxs, m.maxBytes))
-	}
-	if candidate.size > m.maxBytes {
-		return nil, false, txAdmitUnavailable(fmt.Sprintf("mempool byte limit exceeded: current=%d tx=%d max=%d", m.usedBytes, candidate.size, m.maxBytes))
-	}
-	if m.usedBytes < 0 {
-		return nil, false, txAdmitUnavailable(fmt.Sprintf("invalid mempool byte accounting: used=%d", m.usedBytes))
-	}
-	usedBytes, err := nonNegativeMempoolIntToUint64("used_bytes", m.usedBytes)
+	maxBytes, err := nonNegativeMempoolIntToUint64("max_bytes", m.maxBytes)
 	if err != nil {
 		return nil, false, err
+	}
+	if m.maxTxs <= 0 || maxBytes == 0 {
+		return nil, false, txAdmitUnavailable(fmt.Sprintf("invalid mempool capacity limits: max_txs=%d max_bytes=%d", m.maxTxs, m.maxBytes))
 	}
 	candidateSize, err := nonNegativeMempoolIntToUint64("candidate_size", candidate.size)
 	if err != nil {
 		return nil, false, err
 	}
-	maxBytes, err := nonNegativeMempoolIntToUint64("max_bytes", m.maxBytes)
+	usedBytes, err := nonNegativeMempoolIntToUint64("used_bytes", m.usedBytes)
 	if err != nil {
 		return nil, false, err
 	}
+	if candidateSize > maxBytes {
+		return nil, false, txAdmitUnavailable(fmt.Sprintf("mempool byte limit exceeded: current=%d tx=%d max=%d", m.usedBytes, candidate.size, m.maxBytes))
+	}
 	countPressure := len(m.txs) >= m.maxTxs
-	bytePressure := m.usedBytes > m.maxBytes-candidate.size
+	bytePressure := usedBytes > maxBytes-candidateSize
 	if !countPressure && !bytePressure {
 		return nil, false, nil
 	}

--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -1011,6 +1011,9 @@ func (m *Mempool) capacityStateLocked(candidate *mempoolEntry) (mempoolCapacityS
 	targetBytes := maxBytes
 	if bytePressure {
 		targetBytes = uint64(m.effectiveLowWaterBytesLocked()) // #nosec G115 -- effectiveLowWaterBytesLocked returns 0 or a positive value derived from positive maxBytes.
+		if targetBytes < candidateSize {
+			targetBytes = candidateSize
+		}
 	}
 	return mempoolCapacityState{
 		maxBytes:      maxBytes,

--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -775,7 +775,7 @@ func (m *Mempool) validateAdmissionSeqLocked(entry *mempoolEntry) error {
 	if entry.admissionSeq != 0 {
 		for existingTxid, existing := range m.txs {
 			if existing != nil && existing.admissionSeq == entry.admissionSeq {
-				return txAdmitConflict(fmt.Sprintf("mempool admission sequence conflict with %x", existingTxid))
+				return txAdmitRejected(fmt.Sprintf("mempool admission sequence conflict with %x", existingTxid))
 			}
 		}
 	}

--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -706,6 +706,22 @@ func (m *Mempool) validateAdmissionLocked(entry *mempoolEntry) error {
 }
 
 func (m *Mempool) validateNonCapacityAdmissionLocked(entry *mempoolEntry) error {
+	if err := validateBasicMempoolEntry(entry); err != nil {
+		return err
+	}
+	if err := m.validateEntryIdentityLocked(entry); err != nil {
+		return err
+	}
+	if err := validateMempoolEntrySource(entry.source); err != nil {
+		return err
+	}
+	if err := m.validateEntryInputsLocked(entry); err != nil {
+		return err
+	}
+	return m.validateAdmissionSeqLocked(entry)
+}
+
+func validateBasicMempoolEntry(entry *mempoolEntry) error {
 	if entry == nil {
 		return txAdmitRejected("nil mempool entry")
 	}
@@ -715,6 +731,10 @@ func (m *Mempool) validateNonCapacityAdmissionLocked(entry *mempoolEntry) error 
 	if entry.weight == 0 {
 		return txAdmitRejected("invalid mempool entry weight")
 	}
+	return nil
+}
+
+func (m *Mempool) validateEntryIdentityLocked(entry *mempoolEntry) error {
 	txid := entry.txid
 	if txid == ([32]byte{}) {
 		return txAdmitRejected("invalid mempool entry txid")
@@ -729,18 +749,29 @@ func (m *Mempool) validateNonCapacityAdmissionLocked(entry *mempoolEntry) error 
 	if existing, exists := m.wtxids[wtxid]; exists {
 		return txAdmitConflict(fmt.Sprintf("mempool wtxid conflict with %x", existing))
 	}
-	source := entry.source
+	return nil
+}
+
+func validateMempoolEntrySource(source mempoolTxSource) error {
 	if source == "" {
 		source = mempoolTxSourceLocal
 	}
 	if !validMempoolTxSource(source) {
 		return txAdmitRejected(fmt.Sprintf("invalid mempool tx source %q", source))
 	}
+	return nil
+}
+
+func (m *Mempool) validateEntryInputsLocked(entry *mempoolEntry) error {
 	for _, op := range entry.inputs {
 		if existing, ok := m.spenders[op]; ok {
 			return txAdmitConflict(fmt.Sprintf("mempool double-spend conflict with %x", existing))
 		}
 	}
+	return nil
+}
+
+func (m *Mempool) validateAdmissionSeqLocked(entry *mempoolEntry) error {
 	if entry.admissionSeq != 0 {
 		for existingTxid, existing := range m.txs {
 			if existing != nil && existing.admissionSeq == entry.admissionSeq {
@@ -912,56 +943,96 @@ type mempoolEvictionPlanEntry struct {
 	candidate bool
 }
 
+type mempoolCapacityState struct {
+	maxBytes      uint64
+	candidateSize uint64
+	usedBytes     uint64
+	targetBytes   uint64
+	totalBytes    uint64
+	totalCount    int
+	countPressure bool
+	bytePressure  bool
+}
+
 func (m *Mempool) capacityEvictionPlanLocked(candidate *mempoolEntry) ([]*mempoolEntry, bool, error) {
 	if candidate == nil {
 		return nil, false, txAdmitRejected("nil mempool entry")
 	}
-	maxBytes, err := nonNegativeMempoolIntToUint64("max_bytes", m.maxBytes)
+	state, err := m.capacityStateLocked(candidate)
 	if err != nil {
 		return nil, false, err
 	}
+	if !state.underPressure() {
+		return nil, false, nil
+	}
+	planPool, err := m.evictionPlanPoolLocked(candidate)
+	if err != nil {
+		return nil, false, err
+	}
+	return dryRunCapacityEvictions(planPool, state, m.maxTxs)
+}
+
+func (m *Mempool) capacityStateLocked(candidate *mempoolEntry) (mempoolCapacityState, error) {
+	maxBytes, err := nonNegativeMempoolIntToUint64("max_bytes", m.maxBytes)
+	if err != nil {
+		return mempoolCapacityState{}, err
+	}
 	if m.maxTxs <= 0 || maxBytes == 0 {
-		return nil, false, txAdmitUnavailable(fmt.Sprintf("invalid mempool capacity limits: max_txs=%d max_bytes=%d", m.maxTxs, m.maxBytes))
+		return mempoolCapacityState{}, txAdmitUnavailable(fmt.Sprintf("invalid mempool capacity limits: max_txs=%d max_bytes=%d", m.maxTxs, m.maxBytes))
 	}
 	candidateSize, err := nonNegativeMempoolIntToUint64("candidate_size", candidate.size)
 	if err != nil {
-		return nil, false, err
+		return mempoolCapacityState{}, err
 	}
 	usedBytes, err := nonNegativeMempoolIntToUint64("used_bytes", m.usedBytes)
 	if err != nil {
-		return nil, false, err
+		return mempoolCapacityState{}, err
 	}
 	if candidateSize > maxBytes {
-		return nil, false, txAdmitUnavailable(fmt.Sprintf("mempool byte limit exceeded: current=%d tx=%d max=%d", m.usedBytes, candidate.size, m.maxBytes))
+		return mempoolCapacityState{}, txAdmitUnavailable(fmt.Sprintf("mempool byte limit exceeded: current=%d tx=%d max=%d", m.usedBytes, candidate.size, m.maxBytes))
 	}
 	countPressure := len(m.txs) >= m.maxTxs
 	bytePressure := usedBytes > maxBytes-candidateSize
-	if !countPressure && !bytePressure {
-		return nil, false, nil
-	}
-
-	totalBytes := usedBytes + candidateSize
-	totalCount := len(m.txs) + 1
 	targetBytes := maxBytes
 	if bytePressure {
 		targetBytes = uint64(m.effectiveLowWaterBytesLocked()) // #nosec G115 -- effectiveLowWaterBytesLocked returns 0 or a positive value derived from positive maxBytes.
 	}
+	return mempoolCapacityState{
+		maxBytes:      maxBytes,
+		candidateSize: candidateSize,
+		usedBytes:     usedBytes,
+		targetBytes:   targetBytes,
+		totalBytes:    usedBytes + candidateSize,
+		totalCount:    len(m.txs) + 1,
+		countPressure: countPressure,
+		bytePressure:  bytePressure,
+	}, nil
+}
+
+func (state mempoolCapacityState) underPressure() bool {
+	return state.countPressure || state.bytePressure
+}
+
+func (m *Mempool) evictionPlanPoolLocked(candidate *mempoolEntry) ([]mempoolEvictionPlanEntry, error) {
 	planPool := make([]mempoolEvictionPlanEntry, 0, len(m.txs)+1)
 	admissionSeqs := make(map[uint64][32]byte, len(m.txs))
 	for _, entry := range m.txs {
 		if err := validateEvictionMetadata(entry); err != nil {
-			return nil, false, err
+			return nil, err
 		}
 		if existing, exists := admissionSeqs[entry.admissionSeq]; exists {
-			return nil, false, txAdmitRejected(fmt.Sprintf("duplicate mempool entry admission_seq %d existing=%x new=%x", entry.admissionSeq, existing, entry.txid))
+			return nil, txAdmitRejected(fmt.Sprintf("duplicate mempool entry admission_seq %d existing=%x new=%x", entry.admissionSeq, existing, entry.txid))
 		}
 		admissionSeqs[entry.admissionSeq] = entry.txid
 		planPool = append(planPool, mempoolEvictionPlanEntry{entry: entry})
 	}
 	planPool = append(planPool, mempoolEvictionPlanEntry{entry: candidate, candidate: true})
+	return planPool, nil
+}
 
+func dryRunCapacityEvictions(planPool []mempoolEvictionPlanEntry, state mempoolCapacityState, maxTxs int) ([]*mempoolEntry, bool, error) {
 	evictedEntries := make([]*mempoolEntry, 0)
-	for (totalCount > m.maxTxs || totalBytes > targetBytes) && len(planPool) > 0 {
+	for (state.totalCount > maxTxs || state.totalBytes > state.targetBytes) && len(planPool) > 0 {
 		worstIndex := 0
 		for i := 1; i < len(planPool); i++ {
 			if evictionPlanEntryWorse(planPool[i], planPool[worstIndex]) {
@@ -974,16 +1045,16 @@ func (m *Mempool) capacityEvictionPlanLocked(candidate *mempoolEntry) ([]*mempoo
 		}
 		evictedEntries = append(evictedEntries, worst.entry)
 		worstSize := uint64(worst.entry.size) // #nosec G115 -- validateEvictionMetadata rejects non-positive entry sizes before this loop.
-		if totalBytes >= worstSize {
-			totalBytes -= worstSize
+		if state.totalBytes >= worstSize {
+			state.totalBytes -= worstSize
 		} else {
 			return nil, false, txAdmitUnavailable("mempool eviction byte accounting underflow")
 		}
-		totalCount--
+		state.totalCount--
 		planPool = append(planPool[:worstIndex], planPool[worstIndex+1:]...)
 	}
-	if totalCount > m.maxTxs || totalBytes > maxBytes {
-		return nil, false, txAdmitUnavailable(fmt.Sprintf("mempool capacity remains exceeded after dry-run eviction: count=%d/%d bytes=%d/%d", totalCount, m.maxTxs, totalBytes, m.maxBytes))
+	if state.totalCount > maxTxs || state.totalBytes > state.maxBytes {
+		return nil, false, txAdmitUnavailable(fmt.Sprintf("mempool capacity remains exceeded after dry-run eviction: count=%d/%d bytes=%d/%d", state.totalCount, maxTxs, state.totalBytes, state.maxBytes))
 	}
 	return evictedEntries, false, nil
 }

--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -692,6 +692,9 @@ func (m *Mempool) validateAdmissionLocked(entry *mempoolEntry) error {
 	if err := m.validateNonCapacityAdmissionLocked(entry); err != nil {
 		return err
 	}
+	if err := m.validateFeeFloorLocked(entry); err != nil {
+		return err
+	}
 	_, candidateEvicted, err := m.capacityEvictionPlanLocked(entry)
 	if err != nil {
 		return err
@@ -751,6 +754,17 @@ func (m *Mempool) validateNonCapacityAdmissionLocked(entry *mempoolEntry) error 
 	return nil
 }
 
+func (m *Mempool) validateFeeFloorLocked(entry *mempoolEntry) error {
+	if entry == nil {
+		return txAdmitRejected("nil mempool entry")
+	}
+	currentMinFeeRate := m.currentMinFeeRateLocked()
+	if feeRateBelowFloor(entry.fee, entry.weight, currentMinFeeRate) {
+		return txAdmitRejected(fmt.Sprintf("mempool fee below rolling minimum: fee=%d weight=%d min_fee_rate=%d", entry.fee, entry.weight, currentMinFeeRate))
+	}
+	return nil
+}
+
 func newMempoolEntry(checked *consensus.CheckedTransaction, inputs []consensus.Outpoint, source mempoolTxSource) *mempoolEntry {
 	return &mempoolEntry{
 		raw:    append([]byte(nil), checked.Bytes...),
@@ -772,6 +786,9 @@ func (m *Mempool) addEntryLocked(entry *mempoolEntry) error {
 		entry.wtxid = entry.txid
 	}
 	if err := m.validateNonCapacityAdmissionLocked(entry); err != nil {
+		return err
+	}
+	if err := m.validateFeeFloorLocked(entry); err != nil {
 		return err
 	}
 	evictedEntries, candidateEvicted, err := m.capacityEvictionPlanLocked(entry)
@@ -921,10 +938,6 @@ func (m *Mempool) capacityEvictionPlanLocked(candidate *mempoolEntry) ([]*mempoo
 	bytePressure := usedBytes > maxBytes-candidateSize
 	if !countPressure && !bytePressure {
 		return nil, false, nil
-	}
-	currentMinFeeRate := m.currentMinFeeRateLocked()
-	if feeRateBelowFloor(candidate.fee, candidate.weight, currentMinFeeRate) {
-		return nil, false, txAdmitRejected(fmt.Sprintf("mempool fee below rolling minimum: fee=%d weight=%d min_fee_rate=%d", candidate.fee, candidate.weight, currentMinFeeRate))
 	}
 
 	totalBytes := usedBytes + candidateSize

--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -794,7 +794,7 @@ func (m *Mempool) validateFeeFloorLocked(entry *mempoolEntry) error {
 	}
 	currentMinFeeRate := m.currentMinFeeRateLocked()
 	if feeRateBelowFloor(entry.fee, entry.weight, currentMinFeeRate) {
-		return txAdmitRejected(fmt.Sprintf("mempool fee below rolling minimum: fee=%d weight=%d min_fee_rate=%d", entry.fee, entry.weight, currentMinFeeRate))
+		return txAdmitUnavailable(fmt.Sprintf("mempool fee below rolling minimum: fee=%d weight=%d min_fee_rate=%d", entry.fee, entry.weight, currentMinFeeRate))
 	}
 	return nil
 }
@@ -1143,6 +1143,7 @@ func compareMempoolEvictionPriority(a, b mempoolEvictionPlanEntry) int {
 
 func evictionAdmissionSeq(entry mempoolEvictionPlanEntry) uint64 {
 	if entry.candidate {
+		// Treat the candidate as oldest on exact fee ties so capacity pressure is no-RBF.
 		return 0
 	}
 	if entry.entry == nil {
@@ -1233,14 +1234,7 @@ func compareFeeRate(a *mempoolEntry, b *mempoolEntry) int {
 	if a == nil || b == nil {
 		return 0
 	}
-	return compareFeeRateValues(a.fee, a.size, b.fee, b.size)
-}
-
-func compareFeeRateValues(feeA uint64, sizeA int, feeB uint64, sizeB int) int {
-	if sizeA <= 0 || sizeB <= 0 {
-		return 0
-	}
-	return compareFeeRateWeightValues(feeA, uint64(sizeA), feeB, uint64(sizeB))
+	return compareFeeRateWeightValues(a.fee, a.weight, b.fee, b.weight)
 }
 
 func compareEvictionFeeRate(a *mempoolEntry, b *mempoolEntry) int {

--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -363,10 +363,6 @@ func (m *Mempool) addTxWithSource(txBytes []byte, source mempoolTxSource) (retEr
 	defer m.mu.Unlock()
 
 	entry := newMempoolEntry(checked, inputs, source)
-	if err := m.validateAdmissionLocked(entry); err != nil {
-		return err
-	}
-
 	return m.addEntryLocked(entry)
 }
 
@@ -704,10 +700,20 @@ func (m *Mempool) removeTxLocked(txid [32]byte) {
 }
 
 func (m *Mempool) validateAdmissionLocked(entry *mempoolEntry) error {
-	// Keep this helper limited to non-capacity checks so callers that
-	// immediately proceed to addEntryLocked do not duplicate the fee-floor
-	// and eviction-plan scan work under the same lock.
-	return m.validateNonCapacityAdmissionLocked(entry)
+	if err := m.validateNonCapacityAdmissionLocked(entry); err != nil {
+		return err
+	}
+	if err := m.validateFeeFloorLocked(entry); err != nil {
+		return err
+	}
+	_, candidateEvicted, err := m.capacityEvictionPlanLocked(entry)
+	if err != nil {
+		return err
+	}
+	if candidateEvicted {
+		return txAdmitUnavailable("mempool capacity candidate rejected by eviction ordering")
+	}
+	return nil
 }
 
 func (m *Mempool) validateNonCapacityAdmissionLocked(entry *mempoolEntry) error {

--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -185,6 +185,9 @@ func defaultMempoolLowWaterBytes(maxBytes int) int {
 	}
 	lowWater := (maxBytes/mempoolLowWaterDenominator)*mempoolLowWaterNumerator +
 		((maxBytes % mempoolLowWaterDenominator) * mempoolLowWaterNumerator / mempoolLowWaterDenominator)
+	if lowWater == 0 {
+		return 1
+	}
 	return lowWater
 }
 
@@ -1216,11 +1219,7 @@ func entryFloorRate(entry *mempoolEntry) (uint64, bool) {
 	if entry == nil || entry.weight == 0 {
 		return 0, false
 	}
-	floor := entry.fee / entry.weight
-	if entry.fee%entry.weight != 0 {
-		floor++
-	}
-	return floor, true
+	return entry.fee / entry.weight, true
 }
 
 func saturatingAddMinRelayFeeStep(v uint64) uint64 {

--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -699,23 +699,6 @@ func (m *Mempool) removeTxLocked(txid [32]byte) {
 	m.deleteEntryLocked(txid, entry)
 }
 
-func (m *Mempool) validateAdmissionLocked(entry *mempoolEntry) error {
-	if err := m.validateNonCapacityAdmissionLocked(entry); err != nil {
-		return err
-	}
-	if err := m.validateFeeFloorLocked(entry); err != nil {
-		return err
-	}
-	_, candidateEvicted, err := m.capacityEvictionPlanLocked(entry)
-	if err != nil {
-		return err
-	}
-	if candidateEvicted {
-		return txAdmitUnavailable("mempool capacity candidate rejected by eviction ordering")
-	}
-	return nil
-}
-
 func (m *Mempool) validateNonCapacityAdmissionLocked(entry *mempoolEntry) error {
 	if err := validateBasicMempoolEntry(entry); err != nil {
 		return err

--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -330,8 +330,8 @@ func (m *Mempool) AddReorgTx(txBytes []byte) (retErr error) {
 }
 
 // addTxWithSource validates and admits a transaction while recording the
-// caller-declared origin in the mempool entry. The source is metadata only in
-// this foundation slice; it must not influence admission or eviction behavior.
+// caller-declared origin in the mempool entry. Source provenance does not
+// grant admission priority or bypasses; invalid source values reject.
 func (m *Mempool) addTxWithSource(txBytes []byte, source mempoolTxSource) (retErr error) {
 	if m == nil {
 		return txAdmitUnavailable("nil mempool")
@@ -495,6 +495,18 @@ func (m *Mempool) EvictConfirmed(blockBytes []byte) error {
 func (m *Mempool) EvictConfirmedParsed(block *consensus.ParsedBlock) error {
 	return m.withLockedParsedBlock(block, func(block *consensus.ParsedBlock) {
 		for _, txid := range block.Txids {
+			m.removeTxLocked(txid)
+		}
+		m.decayMinFeeRateAfterConnectedBlockLocked()
+	})
+}
+
+func (m *Mempool) applyConnectedBlockParsed(block *consensus.ParsedBlock) error {
+	return m.withLockedParsedBlock(block, func(block *consensus.ParsedBlock) {
+		for _, txid := range block.Txids {
+			m.removeTxLocked(txid)
+		}
+		for txid := range m.collectConflictsLocked(block) {
 			m.removeTxLocked(txid)
 		}
 		m.decayMinFeeRateAfterConnectedBlockLocked()
@@ -1238,10 +1250,8 @@ func compareFeeRate(a *mempoolEntry, b *mempoolEntry) int {
 }
 
 func compareEvictionFeeRate(a *mempoolEntry, b *mempoolEntry) int {
-	if a == nil || b == nil {
-		return 0
-	}
-	return compareFeeRateWeightValues(a.fee, a.weight, b.fee, b.weight)
+	// Eviction and miner selection intentionally share the fee/weight axis.
+	return compareFeeRate(a, b)
 }
 
 func compareFeeRateWeightValues(feeA uint64, weightA uint64, feeB uint64, weightB uint64) int {

--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -331,7 +331,7 @@ func (m *Mempool) AddReorgTx(txBytes []byte) (retErr error) {
 
 // addTxWithSource validates and admits a transaction while recording the
 // caller-declared origin in the mempool entry. Source provenance does not
-// grant admission priority or bypasses; invalid source values reject.
+// grant admission priority or bypass; invalid source values reject.
 func (m *Mempool) addTxWithSource(txBytes []byte, source mempoolTxSource) (retErr error) {
 	if m == nil {
 		return txAdmitUnavailable("nil mempool")

--- a/clients/go/node/mempool_test.go
+++ b/clients/go/node/mempool_test.go
@@ -20,13 +20,13 @@ func TestMempoolAdd(t *testing.T) {
 	toKey := mustNodeMLDSA87Keypair(t)
 	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
 	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
-	st, outpoints := testSpendableChainState(fromAddress, []uint64{100})
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000})
 
 	mp, err := NewMempool(st, nil, devnetGenesisChainID)
 	if err != nil {
 		t.Fatalf("new mempool: %v", err)
 	}
-	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 1, 1, fromKey, fromAddress, toAddress)
+	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 100_000, 1, fromKey, fromAddress, toAddress)
 	if err := mp.AddTx(txBytes); err != nil {
 		t.Fatalf("AddTx: %v", err)
 	}
@@ -40,13 +40,13 @@ func TestMempoolAcceptedEntryMetadataAndIndexes(t *testing.T) {
 	toKey := mustNodeMLDSA87Keypair(t)
 	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
 	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
-	st, outpoints := testSpendableChainState(fromAddress, []uint64{100})
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000})
 
 	mp, err := NewMempool(st, nil, devnetGenesisChainID)
 	if err != nil {
 		t.Fatalf("new mempool: %v", err)
 	}
-	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 3, 1, fromKey, fromAddress, toAddress)
+	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 300_000, 1, fromKey, fromAddress, toAddress)
 	tx, txid, wtxid, _, err := consensus.ParseTx(txBytes)
 	if err != nil {
 		t.Fatalf("ParseTx: %v", err)
@@ -75,8 +75,8 @@ func TestMempoolAcceptedEntryMetadataAndIndexes(t *testing.T) {
 	if entry.wtxid != wtxid {
 		t.Fatalf("entry wtxid=%x, want %x", entry.wtxid, wtxid)
 	}
-	if entry.fee != 3 {
-		t.Fatalf("entry fee=%d, want 3", entry.fee)
+	if entry.fee != 300_000 {
+		t.Fatalf("entry fee=%d, want 300000", entry.fee)
 	}
 	if entry.weight != weight {
 		t.Fatalf("entry weight=%d, want %d", entry.weight, weight)
@@ -103,7 +103,7 @@ func TestMempoolAdmissionSourceWrappersRecordOrigin(t *testing.T) {
 	toKey := mustNodeMLDSA87Keypair(t)
 	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
 	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
-	st, outpoints := testSpendableChainState(fromAddress, []uint64{100, 100, 100})
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000, 1_000_000, 1_000_000})
 
 	mp, err := NewMempool(st, nil, devnetGenesisChainID)
 	if err != nil {
@@ -141,7 +141,7 @@ func TestMempoolAdmissionSourceWrappersRecordOrigin(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{tc.outpoint}, 90, 3, tc.nonce, fromKey, fromAddress, toAddress)
+		txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{tc.outpoint}, 100_000, 300_000, tc.nonce, fromKey, fromAddress, toAddress)
 		if err := tc.admitFunc(txBytes); err != nil {
 			t.Fatalf("%s admit: %v", tc.name, err)
 		}
@@ -163,13 +163,13 @@ func TestMempoolRejectsInvalidEntrySource(t *testing.T) {
 	toKey := mustNodeMLDSA87Keypair(t)
 	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
 	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
-	st, outpoints := testSpendableChainState(fromAddress, []uint64{100})
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000})
 
 	mp, err := NewMempool(st, nil, devnetGenesisChainID)
 	if err != nil {
 		t.Fatalf("new mempool: %v", err)
 	}
-	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 1, 1, fromKey, fromAddress, toAddress)
+	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 100_000, 1, fromKey, fromAddress, toAddress)
 	err = mp.addTxWithSource(txBytes, "sidecar")
 	if err == nil || !strings.Contains(err.Error(), "invalid mempool tx source") {
 		t.Fatalf("expected invalid source rejection, got %v", err)
@@ -195,6 +195,7 @@ func TestMempoolAddEntryLockedInitializesMetadataIndexes(t *testing.T) {
 		txid:         [32]byte{0x02},
 		wtxid:        [32]byte{0x03},
 		inputs:       []consensus.Outpoint{op},
+		fee:          5,
 		weight:       5,
 		size:         7,
 		admissionSeq: 9,
@@ -606,13 +607,13 @@ func TestMempoolEntryIndexesRemovedWithEntry(t *testing.T) {
 	toKey := mustNodeMLDSA87Keypair(t)
 	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
 	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
-	st, outpoints := testSpendableChainState(fromAddress, []uint64{100})
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000})
 
 	mp, err := NewMempool(st, nil, devnetGenesisChainID)
 	if err != nil {
 		t.Fatalf("new mempool: %v", err)
 	}
-	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 3, 1, fromKey, fromAddress, toAddress)
+	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 300_000, 1, fromKey, fromAddress, toAddress)
 	_, txid, wtxid, _, err := consensus.ParseTx(txBytes)
 	if err != nil {
 		t.Fatalf("ParseTx: %v", err)
@@ -640,7 +641,7 @@ func TestMempoolAdmissionSeqOnlyAcceptedTxs(t *testing.T) {
 	toKey := mustNodeMLDSA87Keypair(t)
 	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
 	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
-	st, outpoints := testSpendableChainState(fromAddress, []uint64{100, 100})
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000, 1_000_000})
 
 	mp, err := NewMempool(st, nil, devnetGenesisChainID)
 	if err != nil {
@@ -653,8 +654,8 @@ func TestMempoolAdmissionSeqOnlyAcceptedTxs(t *testing.T) {
 		t.Fatalf("lastAdmissionSeq after malformed=%d, want 0", mp.lastAdmissionSeq)
 	}
 
-	tx1 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 1, 1, fromKey, fromAddress, toAddress)
-	tx2 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[1]}, 90, 1, 2, fromKey, fromAddress, toAddress)
+	tx1 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 100_000, 1, fromKey, fromAddress, toAddress)
+	tx2 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[1]}, 100_000, 100_000, 2, fromKey, fromAddress, toAddress)
 	if err := mp.AddTx(tx1); err != nil {
 		t.Fatalf("AddTx(tx1): %v", err)
 	}
@@ -680,13 +681,13 @@ func TestMempoolAdmissionSeqDoesNotWrap(t *testing.T) {
 	toKey := mustNodeMLDSA87Keypair(t)
 	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
 	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
-	st, outpoints := testSpendableChainState(fromAddress, []uint64{100})
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000})
 
 	mp, err := NewMempool(st, nil, devnetGenesisChainID)
 	if err != nil {
 		t.Fatalf("new mempool: %v", err)
 	}
-	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 1, 1, fromKey, fromAddress, toAddress)
+	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 100_000, 1, fromKey, fromAddress, toAddress)
 	mp.lastAdmissionSeq = ^uint64(0)
 
 	err = mp.AddTx(txBytes)
@@ -713,18 +714,18 @@ func TestMempoolRejectsDuplicateWtxidIndexWithoutMutation(t *testing.T) {
 	toKey := mustNodeMLDSA87Keypair(t)
 	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
 	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
-	st, outpoints := testSpendableChainState(fromAddress, []uint64{100, 100})
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000, 1_000_000})
 
 	mp, err := NewMempool(st, nil, devnetGenesisChainID)
 	if err != nil {
 		t.Fatalf("new mempool: %v", err)
 	}
-	tx1 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 1, 1, fromKey, fromAddress, toAddress)
+	tx1 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 100_000, 1, fromKey, fromAddress, toAddress)
 	if err := mp.AddTx(tx1); err != nil {
 		t.Fatalf("AddTx(tx1): %v", err)
 	}
 	tx1ID := txID(t, tx1)
-	tx2 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[1]}, 90, 1, 2, fromKey, fromAddress, toAddress)
+	tx2 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[1]}, 100_000, 100_000, 2, fromKey, fromAddress, toAddress)
 	_, tx2ID, tx2Wtxid, _, err := consensus.ParseTx(tx2)
 	if err != nil {
 		t.Fatalf("ParseTx(tx2): %v", err)
@@ -769,13 +770,13 @@ func TestMempoolAddTxWaitsForChainStateWriter(t *testing.T) {
 	toKey := mustNodeMLDSA87Keypair(t)
 	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
 	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
-	st, outpoints := testSpendableChainState(fromAddress, []uint64{100})
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000})
 
 	mp, err := NewMempool(st, nil, devnetGenesisChainID)
 	if err != nil {
 		t.Fatalf("new mempool: %v", err)
 	}
-	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 1, 1, fromKey, fromAddress, toAddress)
+	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 100_000, 1, fromKey, fromAddress, toAddress)
 
 	st.admissionMu.Lock()
 	done := make(chan error, 1)
@@ -809,13 +810,13 @@ func TestMempoolAddTxRejectsWhenWriterInvalidatesSnapshotBeforeAdmission(t *test
 	toKey := mustNodeMLDSA87Keypair(t)
 	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
 	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
-	st, outpoints := testSpendableChainState(fromAddress, []uint64{100})
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000})
 
 	mp, err := NewMempool(st, nil, devnetGenesisChainID)
 	if err != nil {
 		t.Fatalf("new mempool: %v", err)
 	}
-	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 1, 1, fromKey, fromAddress, toAddress)
+	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 100_000, 1, fromKey, fromAddress, toAddress)
 
 	st.admissionMu.Lock()
 	st.mu.Lock()
@@ -897,19 +898,19 @@ func TestMempoolRelayMetadata(t *testing.T) {
 	toKey := mustNodeMLDSA87Keypair(t)
 	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
 	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
-	st, outpoints := testSpendableChainState(fromAddress, []uint64{100})
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000})
 
 	mp, err := NewMempool(st, nil, devnetGenesisChainID)
 	if err != nil {
 		t.Fatalf("new mempool: %v", err)
 	}
-	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 3, 5, fromKey, fromAddress, toAddress)
+	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 300_000, 5, fromKey, fromAddress, toAddress)
 	meta, err := mp.RelayMetadata(txBytes)
 	if err != nil {
 		t.Fatalf("RelayMetadata: %v", err)
 	}
-	if meta.Fee != 3 {
-		t.Fatalf("fee=%d, want 3", meta.Fee)
+	if meta.Fee != 300_000 {
+		t.Fatalf("fee=%d, want 300000", meta.Fee)
 	}
 	if meta.Size != len(txBytes) {
 		t.Fatalf("size=%d, want %d", meta.Size, len(txBytes))
@@ -921,13 +922,13 @@ func TestMempoolRelayMetadataTrailingBytes(t *testing.T) {
 	toKey := mustNodeMLDSA87Keypair(t)
 	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
 	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
-	st, outpoints := testSpendableChainState(fromAddress, []uint64{100})
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000})
 
 	mp, err := NewMempool(st, nil, devnetGenesisChainID)
 	if err != nil {
 		t.Fatalf("new mempool: %v", err)
 	}
-	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 3, 5, fromKey, fromAddress, toAddress)
+	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 300_000, 5, fromKey, fromAddress, toAddress)
 	txBytes = append(txBytes, 0x00)
 	if _, err := mp.RelayMetadata(txBytes); err == nil || !strings.Contains(err.Error(), "trailing bytes after canonical tx") {
 		t.Fatalf("expected trailing-bytes rejection, got %v", err)
@@ -992,7 +993,7 @@ func TestMempoolPolicyAllowsSufficientFeeDaCommit(t *testing.T) {
 	toKey := mustNodeMLDSA87Keypair(t)
 	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
 	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
-	st, outpoints := testSpendableChainState(fromAddress, []uint64{100})
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000})
 
 	mp, err := NewMempoolWithConfig(st, nil, devnetGenesisChainID, MempoolConfig{
 		PolicyDaSurchargePerByte: 1,
@@ -1001,7 +1002,7 @@ func TestMempoolPolicyAllowsSufficientFeeDaCommit(t *testing.T) {
 		t.Fatalf("new mempool: %v", err)
 	}
 
-	txBytes := mustBuildSignedDaCommitTx(t, st.Utxos, outpoints[0], 80, 10, 1, fromKey, toAddress, []byte("0123456789"))
+	txBytes := mustBuildSignedDaCommitTx(t, st.Utxos, outpoints[0], 100_000, 900_000, 1, fromKey, toAddress, []byte("0123456789"))
 	if err := mp.AddTx(txBytes); err != nil {
 		t.Fatalf("expected DA tx admission, got %v", err)
 	}
@@ -1116,7 +1117,7 @@ func TestMempoolPolicyRejectsCoreExtSpendPreActivation(t *testing.T) {
 func TestMempoolPolicyAllowsCoreExtWhenProfileActive(t *testing.T) {
 	fromKey := mustNodeMLDSA87Keypair(t)
 	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
-	st, outpoints := testSpendableChainState(fromAddress, []uint64{100})
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000})
 
 	mp, err := NewMempoolWithConfig(st, nil, devnetGenesisChainID, MempoolConfig{
 		PolicyRejectCoreExtPreActivation: true,
@@ -1126,7 +1127,7 @@ func TestMempoolPolicyAllowsCoreExtWhenProfileActive(t *testing.T) {
 		t.Fatalf("new mempool: %v", err)
 	}
 
-	txBytes := mustBuildSignedCoreExtOutputTx(t, st.Utxos, outpoints[0], 90, 1, 1, fromKey, fromAddress, 7)
+	txBytes := mustBuildSignedCoreExtOutputTx(t, st.Utxos, outpoints[0], 100_000, 100_000, 1, fromKey, fromAddress, 7)
 	if err := mp.AddTx(txBytes); err != nil {
 		t.Fatalf("expected CORE_EXT tx admission, got %v", err)
 	}
@@ -1134,8 +1135,8 @@ func TestMempoolPolicyAllowsCoreExtWhenProfileActive(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected relay metadata success, got %v", err)
 	}
-	if meta.Fee != 1 {
-		t.Fatalf("relay fee=%d, want 1", meta.Fee)
+	if meta.Fee != 100_000 {
+		t.Fatalf("relay fee=%d, want 100000", meta.Fee)
 	}
 }
 
@@ -1236,7 +1237,7 @@ func TestMempoolPolicyRejectsOversizedCoreExtPayload(t *testing.T) {
 func TestMempoolPolicyAllowsCoreExtPayloadUnderLimit(t *testing.T) {
 	fromKey := mustNodeMLDSA87Keypair(t)
 	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
-	st, outpoints := testSpendableChainState(fromAddress, []uint64{100})
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000})
 
 	mp, err := NewMempoolWithConfig(st, nil, devnetGenesisChainID, MempoolConfig{
 		PolicyMaxExtPayloadBytes: 48,
@@ -1258,8 +1259,8 @@ func TestMempoolPolicyAllowsCoreExtPayloadUnderLimit(t *testing.T) {
 			Sequence: 0,
 		}},
 		Outputs: []consensus.TxOutput{
-			{Value: 90, CovenantType: consensus.COV_TYPE_CORE_EXT, CovenantData: coreExtCovenantDataForNodeTest(7, make([]byte, 32))},
-			{Value: entry.Value - 91, CovenantType: consensus.COV_TYPE_P2PK, CovenantData: append([]byte(nil), fromAddress...)},
+			{Value: 100_000, CovenantType: consensus.COV_TYPE_CORE_EXT, CovenantData: coreExtCovenantDataForNodeTest(7, make([]byte, 32))},
+			{Value: entry.Value - 200_000, CovenantType: consensus.COV_TYPE_P2PK, CovenantData: append([]byte(nil), fromAddress...)},
 		},
 		Locktime: 0,
 	}
@@ -1313,9 +1314,9 @@ func TestPolicyInputSnapshotCopiesOnlySpentInputs(t *testing.T) {
 	toKey := mustNodeMLDSA87Keypair(t)
 	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
 	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
-	st, outpoints := testSpendableChainState(fromAddress, []uint64{100, 200})
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000, 2_000_000})
 
-	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 1, 1, fromKey, fromAddress, toAddress)
+	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 100_000, 1, fromKey, fromAddress, toAddress)
 	tx, _, _, _, err := consensus.ParseTx(txBytes)
 	if err != nil {
 		t.Fatalf("ParseTx: %v", err)
@@ -1381,9 +1382,9 @@ func TestPolicyInputSnapshotRejectsMissingInput(t *testing.T) {
 	toKey := mustNodeMLDSA87Keypair(t)
 	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
 	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
-	st, outpoints := testSpendableChainState(fromAddress, []uint64{100})
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000})
 
-	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 1, 1, fromKey, fromAddress, toAddress)
+	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 100_000, 1, fromKey, fromAddress, toAddress)
 	tx, _, _, _, err := consensus.ParseTx(txBytes)
 	if err != nil {
 		t.Fatalf("ParseTx: %v", err)
@@ -1402,14 +1403,14 @@ func TestMempoolDoubleSpend(t *testing.T) {
 	toKey := mustNodeMLDSA87Keypair(t)
 	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
 	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
-	st, outpoints := testSpendableChainState(fromAddress, []uint64{100})
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000})
 
 	mp, err := NewMempool(st, nil, devnetGenesisChainID)
 	if err != nil {
 		t.Fatalf("new mempool: %v", err)
 	}
-	tx1 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 1, 1, fromKey, fromAddress, toAddress)
-	tx2 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 89, 2, 2, fromKey, fromAddress, toAddress)
+	tx1 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 100_000, 1, fromKey, fromAddress, toAddress)
+	tx2 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 200_000, 2, fromKey, fromAddress, toAddress)
 	if err := mp.AddTx(tx1); err != nil {
 		t.Fatalf("AddTx(tx1): %v", err)
 	}
@@ -1572,6 +1573,90 @@ func TestMempoolCapacityRejectsBelowRollingFloorWithoutMutation(t *testing.T) {
 	}
 }
 
+func TestMempoolRollingFloorRejectsBelowCapacityWithoutMutation(t *testing.T) {
+	fromKey := mustNodeMLDSA87Keypair(t)
+	toKey := mustNodeMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000})
+
+	txBelowFloor := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 1, 1, fromKey, fromAddress, toAddress)
+	mp, err := NewMempoolWithConfig(st, nil, devnetGenesisChainID, MempoolConfig{MaxTransactions: 10, MaxBytes: 1 << 20})
+	if err != nil {
+		t.Fatalf("new mempool: %v", err)
+	}
+	mp.currentMinFeeRate = 8
+	before, err := snapshotMempool(mp)
+	if err != nil {
+		t.Fatalf("snapshot before below-capacity below-floor: %v", err)
+	}
+	if err := mp.AddTx(txBelowFloor); err == nil || !strings.Contains(err.Error(), "mempool fee below rolling minimum") {
+		t.Fatalf("expected below-capacity below-floor rejection, got %v", err)
+	}
+	after, err := snapshotMempool(mp)
+	if err != nil {
+		t.Fatalf("snapshot after below-capacity below-floor: %v", err)
+	}
+	if !reflect.DeepEqual(after, before) {
+		t.Fatalf("below-capacity floor reject mutated mempool: before=%+v after=%+v", before, after)
+	}
+	if mp.usedBytes != 0 || mp.lastAdmissionSeq != 0 || mp.currentMinFeeRate != 8 {
+		t.Fatalf("below-capacity floor reject state usedBytes=%d seq=%d floor=%d", mp.usedBytes, mp.lastAdmissionSeq, mp.currentMinFeeRate)
+	}
+}
+
+func TestMempoolRollingFloorDirectHelperRejectsBelowCapacity(t *testing.T) {
+	mp := &Mempool{maxTxs: 10, maxBytes: 100, currentMinFeeRate: 8}
+	err := mp.validateAdmissionLocked(&mempoolEntry{
+		txid:   [32]byte{0x51},
+		fee:    7,
+		weight: 1,
+		size:   1,
+	})
+	if err == nil || !strings.Contains(err.Error(), "mempool fee below rolling minimum") {
+		t.Fatalf("expected direct below-floor rejection, got %v", err)
+	}
+	if len(mp.txs) != 0 || mp.usedBytes != 0 || mp.lastAdmissionSeq != 0 || mp.currentMinFeeRate != 8 {
+		t.Fatalf("direct floor reject mutated mempool: len=%d used=%d seq=%d floor=%d", len(mp.txs), mp.usedBytes, mp.lastAdmissionSeq, mp.currentMinFeeRate)
+	}
+}
+
+func TestMempoolRollingFloorAcceptsExactFloorBelowCapacity(t *testing.T) {
+	const floor = uint64(8)
+	fromKey := mustNodeMLDSA87Keypair(t)
+	toKey := mustNodeMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000})
+
+	probe := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 1, 1, fromKey, fromAddress, toAddress)
+	parsed, _, _, _, err := consensus.ParseTx(probe)
+	if err != nil {
+		t.Fatalf("ParseTx(probe): %v", err)
+	}
+	weight, _, _, err := consensus.TxWeightAndStats(parsed)
+	if err != nil {
+		t.Fatalf("TxWeightAndStats(probe): %v", err)
+	}
+	exactFee := weight * floor
+	txExactFloor := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, exactFee, 1, fromKey, fromAddress, toAddress)
+	mp, err := NewMempoolWithConfig(st, nil, devnetGenesisChainID, MempoolConfig{MaxTransactions: 10, MaxBytes: 1 << 20})
+	if err != nil {
+		t.Fatalf("new mempool: %v", err)
+	}
+	mp.currentMinFeeRate = floor
+	if err := mp.AddTx(txExactFloor); err != nil {
+		t.Fatalf("AddTx(exact floor): %v", err)
+	}
+	entry := mp.txs[txID(t, txExactFloor)]
+	if entry == nil {
+		t.Fatal("exact-floor tx missing from mempool")
+	}
+	if feeRateBelowFloor(entry.fee, entry.weight, floor) {
+		t.Fatalf("accepted exact-floor entry still below floor: fee=%d weight=%d floor=%d", entry.fee, entry.weight, floor)
+	}
+}
+
 func TestMempoolByteCapEvictsToLowWater(t *testing.T) {
 	fromKey := mustNodeMLDSA87Keypair(t)
 	toKey := mustNodeMLDSA87Keypair(t)
@@ -1726,10 +1811,10 @@ func TestMempoolByteCapAllowsExactBoundary(t *testing.T) {
 	toKey := mustNodeMLDSA87Keypair(t)
 	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
 	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
-	st, outpoints := testSpendableChainState(fromAddress, []uint64{100, 100})
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000, 1_000_000})
 
-	tx1 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 2, 1, fromKey, fromAddress, toAddress)
-	tx2 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[1]}, 90, 2, 2, fromKey, fromAddress, toAddress)
+	tx1 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 200_000, 1, fromKey, fromAddress, toAddress)
+	tx2 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[1]}, 100_000, 200_000, 2, fromKey, fromAddress, toAddress)
 	mp, err := NewMempoolWithConfig(st, nil, devnetGenesisChainID, MempoolConfig{
 		MaxTransactions: 10,
 		MaxBytes:        len(tx1) + len(tx2),
@@ -1757,14 +1842,14 @@ func TestMempoolAdmissionRejectsDoNotMutateByteAccounting(t *testing.T) {
 	toKey := mustNodeMLDSA87Keypair(t)
 	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
 	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
-	st, outpoints := testSpendableChainState(fromAddress, []uint64{100, 100})
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000, 1_000_000})
 
 	mp, err := NewMempoolWithConfig(st, nil, devnetGenesisChainID, MempoolConfig{MaxTransactions: 10})
 	if err != nil {
 		t.Fatalf("new mempool: %v", err)
 	}
-	tx1 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 2, 1, fromKey, fromAddress, toAddress)
-	txDoubleSpend := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 89, 3, 2, fromKey, fromAddress, toAddress)
+	tx1 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 200_000, 1, fromKey, fromAddress, toAddress)
+	txDoubleSpend := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 300_000, 2, fromKey, fromAddress, toAddress)
 	if err := mp.AddTx(tx1); err != nil {
 		t.Fatalf("AddTx(tx1): %v", err)
 	}
@@ -1798,10 +1883,10 @@ func TestRestoreMempoolSnapshotRecomputesByteAccounting(t *testing.T) {
 	toKey := mustNodeMLDSA87Keypair(t)
 	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
 	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
-	st, outpoints := testSpendableChainState(fromAddress, []uint64{100, 100})
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000, 1_000_000})
 
-	tx1 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 2, 1, fromKey, fromAddress, toAddress)
-	tx2 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[1]}, 90, 2, 2, fromKey, fromAddress, toAddress)
+	tx1 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 200_000, 1, fromKey, fromAddress, toAddress)
+	tx2 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[1]}, 100_000, 200_000, 2, fromKey, fromAddress, toAddress)
 	mp, err := NewMempoolWithConfig(st, nil, devnetGenesisChainID, MempoolConfig{
 		MaxTransactions: 10,
 		MaxBytes:        len(tx1) + len(tx2),
@@ -1865,15 +1950,15 @@ func TestRestoreMempoolSnapshotPreservesAdmissionSeqHighWatermark(t *testing.T) 
 	toKey := mustNodeMLDSA87Keypair(t)
 	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
 	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
-	st, outpoints := testSpendableChainState(fromAddress, []uint64{100, 100, 100})
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000, 1_000_000, 1_000_000})
 
 	mp, err := NewMempool(st, nil, devnetGenesisChainID)
 	if err != nil {
 		t.Fatalf("new mempool: %v", err)
 	}
-	tx1 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 1, 1, fromKey, fromAddress, toAddress)
-	tx2 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[1]}, 90, 1, 2, fromKey, fromAddress, toAddress)
-	tx3 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[2]}, 90, 1, 3, fromKey, fromAddress, toAddress)
+	tx1 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 100_000, 1, fromKey, fromAddress, toAddress)
+	tx2 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[1]}, 100_000, 100_000, 2, fromKey, fromAddress, toAddress)
+	tx3 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[2]}, 100_000, 100_000, 3, fromKey, fromAddress, toAddress)
 	if err := mp.AddTx(tx1); err != nil {
 		t.Fatalf("AddTx(tx1): %v", err)
 	}
@@ -1934,10 +2019,10 @@ func TestRestoreMempoolSnapshotRejectsInvalidEntriesWithoutMutation(t *testing.T
 	toKey := mustNodeMLDSA87Keypair(t)
 	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
 	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
-	st, outpoints := testSpendableChainState(fromAddress, []uint64{100, 100})
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000, 1_000_000})
 
-	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 2, 1, fromKey, fromAddress, toAddress)
-	txSecond := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[1]}, 90, 2, 2, fromKey, fromAddress, toAddress)
+	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 200_000, 1, fromKey, fromAddress, toAddress)
+	txSecond := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[1]}, 100_000, 200_000, 2, fromKey, fromAddress, toAddress)
 	txSecondID := txID(t, txSecond)
 	mp, err := NewMempoolWithConfig(st, nil, devnetGenesisChainID, MempoolConfig{
 		MaxTransactions: 10,
@@ -1955,7 +2040,7 @@ func TestRestoreMempoolSnapshotRejectsInvalidEntriesWithoutMutation(t *testing.T
 	}
 	wantTxID := txID(t, txBytes)
 	wantBytes := mp.usedBytes
-	txDoubleSpend := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 89, 3, 2, fromKey, fromAddress, toAddress)
+	txDoubleSpend := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 300_000, 2, fromKey, fromAddress, toAddress)
 	doubleSpendID := txID(t, txDoubleSpend)
 	snapshotEntry := func(txRaw []byte, id [32]byte, inputs []consensus.Outpoint) mempoolEntry {
 		parsed, _, wtxid, _, err := consensus.ParseTx(txRaw)
@@ -2169,10 +2254,10 @@ func TestRestoreMempoolSnapshotAllowsExactCapacityBoundary(t *testing.T) {
 	toKey := mustNodeMLDSA87Keypair(t)
 	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
 	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
-	st, outpoints := testSpendableChainState(fromAddress, []uint64{100, 100})
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000, 1_000_000})
 
-	tx1 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 2, 1, fromKey, fromAddress, toAddress)
-	tx2 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[1]}, 90, 2, 2, fromKey, fromAddress, toAddress)
+	tx1 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 200_000, 1, fromKey, fromAddress, toAddress)
+	tx2 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[1]}, 100_000, 200_000, 2, fromKey, fromAddress, toAddress)
 	source, err := NewMempoolWithConfig(st, nil, devnetGenesisChainID, MempoolConfig{
 		MaxTransactions: 2,
 		MaxBytes:        len(tx1) + len(tx2),
@@ -2255,13 +2340,13 @@ func TestMempoolEviction(t *testing.T) {
 	toKey := mustNodeMLDSA87Keypair(t)
 	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
 	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
-	st, outpoints := testSpendableChainState(fromAddress, []uint64{100})
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000})
 
 	mp, err := NewMempool(st, nil, devnetGenesisChainID)
 	if err != nil {
 		t.Fatalf("new mempool: %v", err)
 	}
-	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 1, 1, fromKey, fromAddress, toAddress)
+	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 100_000, 1, fromKey, fromAddress, toAddress)
 	if err := mp.AddTx(txBytes); err != nil {
 		t.Fatalf("AddTx: %v", err)
 	}
@@ -2283,15 +2368,15 @@ func TestMempoolSelectByFee(t *testing.T) {
 	toKey := mustNodeMLDSA87Keypair(t)
 	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
 	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
-	st, outpoints := testSpendableChainState(fromAddress, []uint64{100, 100, 100})
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000, 1_000_000, 1_000_000})
 
 	mp, err := NewMempool(st, nil, devnetGenesisChainID)
 	if err != nil {
 		t.Fatalf("new mempool: %v", err)
 	}
-	txLow := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 1, 1, fromKey, fromAddress, toAddress)
-	txHigh := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[1]}, 90, 3, 2, fromKey, fromAddress, toAddress)
-	txMid := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[2]}, 90, 2, 3, fromKey, fromAddress, toAddress)
+	txLow := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 100_000, 1, fromKey, fromAddress, toAddress)
+	txHigh := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[1]}, 100_000, 300_000, 2, fromKey, fromAddress, toAddress)
+	txMid := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[2]}, 100_000, 200_000, 3, fromKey, fromAddress, toAddress)
 	for _, txBytes := range [][]byte{txLow, txHigh, txMid} {
 		if err := mp.AddTx(txBytes); err != nil {
 			t.Fatalf("AddTx: %v", err)
@@ -2326,7 +2411,7 @@ func TestMinerMineOneSelectsFromMempool(t *testing.T) {
 	toKey := mustNodeMLDSA87Keypair(t)
 	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
 	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
-	st, outpoints := testSpendableChainState(fromAddress, []uint64{100})
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000})
 	st.HasTip = true
 	st.Height = 100
 	st.TipHash = tipHash
@@ -2341,7 +2426,7 @@ func TestMinerMineOneSelectsFromMempool(t *testing.T) {
 	}
 	syncEngine.SetMempool(mp)
 
-	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 1, 1, fromKey, fromAddress, toAddress)
+	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 100_000, 1, fromKey, fromAddress, toAddress)
 	if err := mp.AddTx(txBytes); err != nil {
 		t.Fatalf("AddTx: %v", err)
 	}
@@ -2659,12 +2744,12 @@ func TestTxAdmitErrorKinds(t *testing.T) {
 	})
 
 	t.Run("duplicate tx conflict", func(t *testing.T) {
-		st, outpoints := testSpendableChainState(fromAddress, []uint64{100})
+		st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000})
 		mp, err := NewMempool(st, nil, devnetGenesisChainID)
 		if err != nil {
 			t.Fatalf("new mempool: %v", err)
 		}
-		tx := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 1, 1, fromKey, fromAddress, toAddress)
+		tx := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 100_000, 1, fromKey, fromAddress, toAddress)
 		if err := mp.AddTx(tx); err != nil {
 			t.Fatalf("first AddTx: %v", err)
 		}
@@ -2673,13 +2758,13 @@ func TestTxAdmitErrorKinds(t *testing.T) {
 	})
 
 	t.Run("double spend conflict", func(t *testing.T) {
-		st, outpoints := testSpendableChainState(fromAddress, []uint64{100})
+		st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000})
 		mp, err := NewMempool(st, nil, devnetGenesisChainID)
 		if err != nil {
 			t.Fatalf("new mempool: %v", err)
 		}
-		tx1 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 1, 1, fromKey, fromAddress, toAddress)
-		tx2 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 89, 2, 2, fromKey, fromAddress, toAddress)
+		tx1 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 100_000, 1, fromKey, fromAddress, toAddress)
+		tx2 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 200_000, 2, fromKey, fromAddress, toAddress)
 		if err := mp.AddTx(tx1); err != nil {
 			t.Fatalf("first AddTx: %v", err)
 		}
@@ -2703,7 +2788,7 @@ func TestTxAdmitErrorKinds(t *testing.T) {
 	})
 
 	t.Run("invalid tx rejected", func(t *testing.T) {
-		st, _ := testSpendableChainState(fromAddress, []uint64{100})
+		st, _ := testSpendableChainState(fromAddress, []uint64{1_000_000})
 		mp, err := NewMempool(st, nil, devnetGenesisChainID)
 		if err != nil {
 			t.Fatalf("new mempool: %v", err)
@@ -2726,7 +2811,7 @@ func TestMempoolAllTxIDsReturnsEveryEntry(t *testing.T) {
 	toKey := mustNodeMLDSA87Keypair(t)
 	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
 	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
-	st, outpoints := testSpendableChainState(fromAddress, []uint64{100, 100, 100})
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000, 1_000_000, 1_000_000})
 
 	mp, err := NewMempool(st, nil, devnetGenesisChainID)
 	if err != nil {
@@ -2735,7 +2820,7 @@ func TestMempoolAllTxIDsReturnsEveryEntry(t *testing.T) {
 
 	want := make(map[[32]byte]struct{})
 	for i := 0; i < 3; i++ {
-		txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[i]}, 90, 1, 1, fromKey, fromAddress, toAddress)
+		txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[i]}, 100_000, 100_000, 1, fromKey, fromAddress, toAddress)
 		if err := mp.AddTx(txBytes); err != nil {
 			t.Fatalf("AddTx[%d]: %v", i, err)
 		}
@@ -2764,7 +2849,7 @@ func TestMempoolAllTxIDsSortedDeterministic(t *testing.T) {
 	toKey := mustNodeMLDSA87Keypair(t)
 	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
 	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
-	st, outpoints := testSpendableChainState(fromAddress, []uint64{100, 100, 100})
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000, 1_000_000, 1_000_000})
 
 	mp, err := NewMempool(st, nil, devnetGenesisChainID)
 	if err != nil {
@@ -2772,7 +2857,7 @@ func TestMempoolAllTxIDsSortedDeterministic(t *testing.T) {
 	}
 	var ids [][32]byte
 	for i := 0; i < 3; i++ {
-		txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[i]}, 90, 1, 1, fromKey, fromAddress, toAddress)
+		txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[i]}, 100_000, 100_000, 1, fromKey, fromAddress, toAddress)
 		if err := mp.AddTx(txBytes); err != nil {
 			t.Fatalf("AddTx[%d]: %v", i, err)
 		}
@@ -2825,13 +2910,13 @@ func TestMempoolTxByIDReturnsRawAndDefensiveCopy(t *testing.T) {
 	toKey := mustNodeMLDSA87Keypair(t)
 	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
 	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
-	st, outpoints := testSpendableChainState(fromAddress, []uint64{100})
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000})
 
 	mp, err := NewMempool(st, nil, devnetGenesisChainID)
 	if err != nil {
 		t.Fatalf("new mempool: %v", err)
 	}
-	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 1, 1, fromKey, fromAddress, toAddress)
+	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 100_000, 1, fromKey, fromAddress, toAddress)
 	if err := mp.AddTx(txBytes); err != nil {
 		t.Fatalf("AddTx: %v", err)
 	}
@@ -2889,13 +2974,13 @@ func TestMempoolContainsReflectsAdmission(t *testing.T) {
 	toKey := mustNodeMLDSA87Keypair(t)
 	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
 	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
-	st, outpoints := testSpendableChainState(fromAddress, []uint64{100})
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000})
 
 	mp, err := NewMempool(st, nil, devnetGenesisChainID)
 	if err != nil {
 		t.Fatalf("new mempool: %v", err)
 	}
-	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 1, 1, fromKey, fromAddress, toAddress)
+	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 100_000, 1, fromKey, fromAddress, toAddress)
 	_, txid, _, _, err := consensus.ParseTx(txBytes)
 	if err != nil {
 		t.Fatalf("ParseTx: %v", err)
@@ -2933,7 +3018,7 @@ func TestMempoolBytesUsedTracksUsedBytes(t *testing.T) {
 	toKey := mustNodeMLDSA87Keypair(t)
 	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
 	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
-	st, outpoints := testSpendableChainState(fromAddress, []uint64{100})
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000})
 
 	mp, err := NewMempool(st, nil, devnetGenesisChainID)
 	if err != nil {
@@ -2942,7 +3027,7 @@ func TestMempoolBytesUsedTracksUsedBytes(t *testing.T) {
 	if got := mp.BytesUsed(); got != 0 {
 		t.Fatalf("BytesUsed empty=%d, want 0", got)
 	}
-	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 1, 1, fromKey, fromAddress, toAddress)
+	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 100_000, 1, fromKey, fromAddress, toAddress)
 	if err := mp.AddTx(txBytes); err != nil {
 		t.Fatalf("AddTx: %v", err)
 	}
@@ -2969,7 +3054,7 @@ func TestMempoolAdmissionCountsAcceptedBumpsExactlyOnce(t *testing.T) {
 	toKey := mustNodeMLDSA87Keypair(t)
 	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
 	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
-	st, outpoints := testSpendableChainState(fromAddress, []uint64{100})
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000})
 
 	mp, err := NewMempool(st, nil, devnetGenesisChainID)
 	if err != nil {
@@ -2978,7 +3063,7 @@ func TestMempoolAdmissionCountsAcceptedBumpsExactlyOnce(t *testing.T) {
 	if got := mp.AdmissionCounts(); got != (MempoolAdmissionCounts{}) {
 		t.Fatalf("AdmissionCounts pre-AddTx=%+v, want zero", got)
 	}
-	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 1, 1, fromKey, fromAddress, toAddress)
+	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 100_000, 1, fromKey, fromAddress, toAddress)
 	if err := mp.AddTx(txBytes); err != nil {
 		t.Fatalf("AddTx: %v", err)
 	}
@@ -2998,13 +3083,13 @@ func TestMempoolAdmissionCountsConflictBumpsExactlyOnce(t *testing.T) {
 	toKey := mustNodeMLDSA87Keypair(t)
 	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
 	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
-	st, outpoints := testSpendableChainState(fromAddress, []uint64{100})
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000})
 
 	mp, err := NewMempool(st, nil, devnetGenesisChainID)
 	if err != nil {
 		t.Fatalf("new mempool: %v", err)
 	}
-	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 1, 1, fromKey, fromAddress, toAddress)
+	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 100_000, 1, fromKey, fromAddress, toAddress)
 	if err := mp.AddTx(txBytes); err != nil {
 		t.Fatalf("first AddTx: %v", err)
 	}
@@ -3039,13 +3124,13 @@ func TestMempoolAdmissionCountsRejectedBumpsExactlyOnce(t *testing.T) {
 	toKey := mustNodeMLDSA87Keypair(t)
 	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
 	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
-	st, outpoints := testSpendableChainState(fromAddress, []uint64{100})
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000})
 
 	mp, err := NewMempool(st, nil, devnetGenesisChainID)
 	if err != nil {
 		t.Fatalf("new mempool: %v", err)
 	}
-	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 1, 1, fromKey, fromAddress, toAddress)
+	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 100_000, 1, fromKey, fromAddress, toAddress)
 	// Append a trailing byte to force the "trailing bytes after canonical
 	// tx" reject path inside checkTransactionWithSnapshot.
 	bad := append([]byte{}, txBytes...)

--- a/clients/go/node/mempool_test.go
+++ b/clients/go/node/mempool_test.go
@@ -376,7 +376,8 @@ func TestDefaultMempoolLowWaterBytes(t *testing.T) {
 	}{
 		{name: "zero", maxBytes: 0, want: 0},
 		{name: "negative", maxBytes: -1, want: 0},
-		{name: "one", maxBytes: 1, want: 0},
+		{name: "one", maxBytes: 1, want: 1},
+		{name: "small", maxBytes: 9, want: 8},
 		{name: "ten", maxBytes: 10, want: 9},
 		{name: "remainder", maxBytes: 11, want: 9},
 	} {
@@ -533,6 +534,32 @@ func TestMempoolCapacityPlanRejectsInvalidExistingMetadata(t *testing.T) {
 				t.Fatalf("expected %q rejection, got %v", tc.want, err)
 			}
 		})
+	}
+}
+
+func TestMempoolEntryFloorRateUsesSatisfiableFloor(t *testing.T) {
+	entry := &mempoolEntry{
+		txid:   [32]byte{0x71},
+		fee:    3,
+		weight: 2,
+		size:   1,
+	}
+
+	floor, ok := entryFloorRate(entry)
+	if !ok {
+		t.Fatal("entryFloorRate returned !ok for valid entry")
+	}
+	if floor != 1 {
+		t.Fatalf("entryFloorRate=%d, want 1 for fee=3 weight=2", floor)
+	}
+	if feeRateBelowFloor(entry.fee, entry.weight, floor) {
+		t.Fatalf("entry is below its satisfiable floor: fee=%d weight=%d floor=%d", entry.fee, entry.weight, floor)
+	}
+	if !feeRateBelowFloor(entry.fee, entry.weight, floor+DefaultMempoolMinFeeRate) {
+		t.Fatalf("entry unexpectedly satisfies raised floor: fee=%d weight=%d floor=%d", entry.fee, entry.weight, floor+DefaultMempoolMinFeeRate)
+	}
+	if floor, ok := entryFloorRate(&mempoolEntry{txid: [32]byte{0x72}, fee: 3}); ok || floor != 0 {
+		t.Fatalf("zero-weight entryFloorRate=(%d,%v), want (0,false)", floor, ok)
 	}
 }
 
@@ -1707,6 +1734,35 @@ func TestMempoolByteCapEvictsToLowWater(t *testing.T) {
 	}
 	if !mp.Contains(txID(t, txHigh)) || !mp.Contains(txID(t, txBest)) {
 		t.Fatal("byte-pressure low-water trim removed expected survivors")
+	}
+}
+
+func TestMempoolSmallByteCapKeepsFittingCandidateAfterLowWaterTrim(t *testing.T) {
+	mp := &Mempool{maxTxs: 10, maxBytes: 2}
+	for _, entry := range []*mempoolEntry{
+		{txid: [32]byte{0x61}, fee: 1, weight: 1, size: 1},
+		{txid: [32]byte{0x62}, fee: 1, weight: 1, size: 1},
+	} {
+		if err := mp.addEntryLocked(entry); err != nil {
+			t.Fatalf("addEntryLocked(resident %x): %v", entry.txid, err)
+		}
+	}
+
+	candidate := &mempoolEntry{txid: [32]byte{0x63}, fee: 10, weight: 1, size: 1}
+	if err := mp.addEntryLocked(candidate); err != nil {
+		t.Fatalf("addEntryLocked(candidate): %v", err)
+	}
+	if got := mp.Len(); got != 1 {
+		t.Fatalf("mempool len=%d, want 1 after tiny-cap low-water trim", got)
+	}
+	if got := mp.usedBytes; got != 1 {
+		t.Fatalf("usedBytes=%d, want 1 after tiny-cap low-water trim", got)
+	}
+	if !mp.Contains(candidate.txid) {
+		t.Fatal("candidate fitting the hard byte cap was not admitted")
+	}
+	if mp.Contains([32]byte{0x61}) || mp.Contains([32]byte{0x62}) {
+		t.Fatal("tiny-cap low-water trim kept lower-priority residents")
 	}
 }
 

--- a/clients/go/node/mempool_test.go
+++ b/clients/go/node/mempool_test.go
@@ -1883,6 +1883,36 @@ func TestMempoolSmallByteCapKeepsFittingCandidateAfterLowWaterTrim(t *testing.T)
 	}
 }
 
+func TestMempoolBytePressureAdmitsCandidateLargerThanLowWaterWhenFitsHardCap(t *testing.T) {
+	residentID := [32]byte{0x80}
+	candidateID := [32]byte{0x81}
+	mp := &Mempool{maxTxs: 10, maxBytes: 100}
+	resident := &mempoolEntry{txid: residentID, fee: 1, weight: 1, size: 95}
+	if err := mp.addEntryLocked(resident); err != nil {
+		t.Fatalf("addEntryLocked(resident): %v", err)
+	}
+	if got, want := mp.effectiveLowWaterBytesLocked(), 90; got != want {
+		t.Fatalf("lowWater=%d, want %d", got, want)
+	}
+
+	candidate := &mempoolEntry{txid: candidateID, fee: 100, weight: 1, size: 95}
+	if err := mp.addEntryLocked(candidate); err != nil {
+		t.Fatalf("addEntryLocked(candidate): %v", err)
+	}
+	if got := mp.Len(); got != 1 {
+		t.Fatalf("mempool len=%d, want 1 after byte-pressure replacement", got)
+	}
+	if got := mp.usedBytes; got != 95 {
+		t.Fatalf("usedBytes=%d, want candidate hard-cap size 95", got)
+	}
+	if !mp.Contains(candidateID) {
+		t.Fatal("candidate fitting maxBytes was not admitted")
+	}
+	if mp.Contains(residentID) {
+		t.Fatal("byte-pressure replacement kept lower-priority resident")
+	}
+}
+
 func TestMempoolDuplicateRejectsBeforeEviction(t *testing.T) {
 	fromKey := mustNodeMLDSA87Keypair(t)
 	toKey := mustNodeMLDSA87Keypair(t)

--- a/clients/go/node/mempool_test.go
+++ b/clients/go/node/mempool_test.go
@@ -1996,21 +1996,27 @@ func TestMempoolRollingMinFeeDecaysOnlyOnConnectedBlockLowWater(t *testing.T) {
 	if err := mp.EvictConfirmedParsed(&consensus.ParsedBlock{}); err != nil {
 		t.Fatalf("EvictConfirmedParsed: %v", err)
 	}
+	if got := mp.currentMinFeeRate; got != 8 {
+		t.Fatalf("EvictConfirmedParsed decayed floor to %d, want 8", got)
+	}
+	if err := mp.applyConnectedBlockParsed(&consensus.ParsedBlock{}); err != nil {
+		t.Fatalf("applyConnectedBlockParsed: %v", err)
+	}
 	if got := mp.currentMinFeeRate; got != 4 {
 		t.Fatalf("connected block low-water decay=%d, want 4", got)
 	}
 	mp.currentMinFeeRate = 8
 	mp.usedBytes = mp.effectiveLowWaterBytesLocked()
-	if err := mp.EvictConfirmedParsed(&consensus.ParsedBlock{}); err != nil {
-		t.Fatalf("EvictConfirmedParsed at low-water boundary: %v", err)
+	if err := mp.applyConnectedBlockParsed(&consensus.ParsedBlock{}); err != nil {
+		t.Fatalf("applyConnectedBlockParsed at low-water boundary: %v", err)
 	}
 	if got := mp.currentMinFeeRate; got != 8 {
 		t.Fatalf("boundary usedBytes decayed floor to %d, want 8", got)
 	}
 	mp.currentMinFeeRate = DefaultMempoolMinFeeRate
 	mp.usedBytes = 0
-	if err := mp.EvictConfirmedParsed(&consensus.ParsedBlock{}); err != nil {
-		t.Fatalf("EvictConfirmedParsed at base floor: %v", err)
+	if err := mp.applyConnectedBlockParsed(&consensus.ParsedBlock{}); err != nil {
+		t.Fatalf("applyConnectedBlockParsed at base floor: %v", err)
 	}
 	if got := mp.currentMinFeeRate; got != DefaultMempoolMinFeeRate {
 		t.Fatalf("base floor decayed to %d, want %d", got, DefaultMempoolMinFeeRate)

--- a/clients/go/node/mempool_test.go
+++ b/clients/go/node/mempool_test.go
@@ -638,6 +638,24 @@ func TestMempoolRaiseMinFeeRatePreservesDivisibleEvictedFloor(t *testing.T) {
 	}
 }
 
+func TestMempoolSortAndEvictionUseWeightFeeRate(t *testing.T) {
+	feeSizeWinner := &mempoolEntry{txid: [32]byte{0xb1}, fee: 4, weight: 4, size: 1}
+	feeWeightWinner := &mempoolEntry{txid: [32]byte{0xb2}, fee: 2, weight: 1, size: 1}
+
+	entries := []*mempoolEntry{feeSizeWinner, feeWeightWinner}
+	sortMempoolEntries(entries)
+	if entries[0] != feeWeightWinner {
+		t.Fatalf("sortMempoolEntries picked txid %x first, want fee/weight winner %x", entries[0].txid, feeWeightWinner.txid)
+	}
+
+	if !evictionPlanEntryWorse(
+		mempoolEvictionPlanEntry{entry: feeSizeWinner},
+		mempoolEvictionPlanEntry{entry: feeWeightWinner},
+	) {
+		t.Fatal("eviction priority did not mark lower fee/weight entry as worse")
+	}
+}
+
 func TestMempoolAddEntryLockedCapacityPlanRejectsWithoutMutation(t *testing.T) {
 	badResidentID := [32]byte{0x30}
 	mp := &Mempool{
@@ -1668,8 +1686,13 @@ func TestMempoolCapacityRejectsBelowRollingFloorWithoutMutation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("snapshot before below-floor: %v", err)
 	}
-	if err := mp.AddTx(txBelowFloor); err == nil || !strings.Contains(err.Error(), "mempool fee below rolling minimum") {
+	err = mp.AddTx(txBelowFloor)
+	if err == nil || !strings.Contains(err.Error(), "mempool fee below rolling minimum") {
 		t.Fatalf("expected below-floor rejection, got %v", err)
+	}
+	var txErr *TxAdmitError
+	if !errors.As(err, &txErr) || txErr.Kind != TxAdmitUnavailable {
+		t.Fatalf("below-floor err=%v, want TxAdmitUnavailable", err)
 	}
 	after, err := snapshotMempool(mp)
 	if err != nil {
@@ -1700,8 +1723,13 @@ func TestMempoolRollingFloorRejectsBelowCapacityWithoutMutation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("snapshot before below-capacity below-floor: %v", err)
 	}
-	if err := mp.AddTx(txBelowFloor); err == nil || !strings.Contains(err.Error(), "mempool fee below rolling minimum") {
+	err = mp.AddTx(txBelowFloor)
+	if err == nil || !strings.Contains(err.Error(), "mempool fee below rolling minimum") {
 		t.Fatalf("expected below-capacity below-floor rejection, got %v", err)
+	}
+	var txErr *TxAdmitError
+	if !errors.As(err, &txErr) || txErr.Kind != TxAdmitUnavailable {
+		t.Fatalf("below-capacity floor err=%v, want TxAdmitUnavailable", err)
 	}
 	after, err := snapshotMempool(mp)
 	if err != nil {
@@ -1725,6 +1753,10 @@ func TestMempoolRollingFloorDirectHelperRejectsBelowCapacity(t *testing.T) {
 	})
 	if err == nil || !strings.Contains(err.Error(), "mempool fee below rolling minimum") {
 		t.Fatalf("expected direct below-floor rejection, got %v", err)
+	}
+	var txErr *TxAdmitError
+	if !errors.As(err, &txErr) || txErr.Kind != TxAdmitUnavailable {
+		t.Fatalf("direct floor err=%v, want TxAdmitUnavailable", err)
 	}
 	if len(mp.txs) != 0 || mp.usedBytes != 0 || mp.lastAdmissionSeq != 0 || mp.currentMinFeeRate != 8 {
 		t.Fatalf("direct floor reject mutated mempool: len=%d used=%d seq=%d floor=%d", len(mp.txs), mp.usedBytes, mp.lastAdmissionSeq, mp.currentMinFeeRate)
@@ -1813,31 +1845,41 @@ func TestMempoolByteCapEvictsToLowWater(t *testing.T) {
 }
 
 func TestMempoolSmallByteCapKeepsFittingCandidateAfterLowWaterTrim(t *testing.T) {
-	mp := &Mempool{maxTxs: 10, maxBytes: 2}
-	for _, entry := range []*mempoolEntry{
-		{txid: [32]byte{0x61}, fee: 1, weight: 1, size: 1},
-		{txid: [32]byte{0x62}, fee: 1, weight: 1, size: 1},
+	for _, tc := range []struct {
+		name     string
+		maxBytes int
+	}{
+		{name: "one", maxBytes: 1},
+		{name: "two", maxBytes: 2},
+		{name: "five", maxBytes: 5},
+		{name: "nine", maxBytes: 9},
 	} {
-		if err := mp.addEntryLocked(entry); err != nil {
-			t.Fatalf("addEntryLocked(resident %x): %v", entry.txid, err)
-		}
-	}
+		t.Run(tc.name, func(t *testing.T) {
+			residentID := [32]byte{byte(0x60 + tc.maxBytes)}
+			candidateID := [32]byte{byte(0x70 + tc.maxBytes)}
+			mp := &Mempool{maxTxs: 10, maxBytes: tc.maxBytes}
+			resident := &mempoolEntry{txid: residentID, fee: 1, weight: 1, size: tc.maxBytes}
+			if err := mp.addEntryLocked(resident); err != nil {
+				t.Fatalf("addEntryLocked(resident): %v", err)
+			}
 
-	candidate := &mempoolEntry{txid: [32]byte{0x63}, fee: 10, weight: 1, size: 1}
-	if err := mp.addEntryLocked(candidate); err != nil {
-		t.Fatalf("addEntryLocked(candidate): %v", err)
-	}
-	if got := mp.Len(); got != 1 {
-		t.Fatalf("mempool len=%d, want 1 after tiny-cap low-water trim", got)
-	}
-	if got := mp.usedBytes; got != 1 {
-		t.Fatalf("usedBytes=%d, want 1 after tiny-cap low-water trim", got)
-	}
-	if !mp.Contains(candidate.txid) {
-		t.Fatal("candidate fitting the hard byte cap was not admitted")
-	}
-	if mp.Contains([32]byte{0x61}) || mp.Contains([32]byte{0x62}) {
-		t.Fatal("tiny-cap low-water trim kept lower-priority residents")
+			candidate := &mempoolEntry{txid: candidateID, fee: 10, weight: 1, size: 1}
+			if err := mp.addEntryLocked(candidate); err != nil {
+				t.Fatalf("addEntryLocked(candidate): %v", err)
+			}
+			if got := mp.Len(); got != 1 {
+				t.Fatalf("mempool len=%d, want 1 after small-cap low-water trim", got)
+			}
+			if got := mp.usedBytes; got != 1 {
+				t.Fatalf("usedBytes=%d, want 1 after small-cap low-water trim", got)
+			}
+			if !mp.Contains(candidate.txid) {
+				t.Fatal("candidate fitting the hard byte cap was not admitted")
+			}
+			if mp.Contains(resident.txid) {
+				t.Fatal("small-cap low-water trim kept lower-priority resident")
+			}
+		})
 	}
 }
 
@@ -2923,6 +2965,18 @@ func TestTxAdmitErrorKinds(t *testing.T) {
 			t.Fatalf("first AddTx: %v", err)
 		}
 		err = mp.AddTx(tx2)
+		assertKind(t, err, TxAdmitUnavailable)
+	})
+
+	t.Run("rolling floor unavailable", func(t *testing.T) {
+		st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000})
+		mp, err := NewMempoolWithConfig(st, nil, devnetGenesisChainID, MempoolConfig{MaxTransactions: 10, MaxBytes: 1 << 20})
+		if err != nil {
+			t.Fatalf("new mempool: %v", err)
+		}
+		mp.currentMinFeeRate = 8
+		tx := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 1, 1, fromKey, fromAddress, toAddress)
+		err = mp.AddTx(tx)
 		assertKind(t, err, TxAdmitUnavailable)
 	})
 

--- a/clients/go/node/mempool_test.go
+++ b/clients/go/node/mempool_test.go
@@ -359,16 +359,106 @@ func TestMempoolAddEntryLockedRejectsInvalidSourceAndDuplicateAdmissionSeq(t *te
 	}
 }
 
-func TestMempoolCapacityPlanRejectsNegativeByteAccounting(t *testing.T) {
-	mp := &Mempool{maxTxs: 10, maxBytes: 100, usedBytes: -1}
-	_, _, err := mp.capacityEvictionPlanLocked(&mempoolEntry{
-		txid:   [32]byte{0x21},
-		fee:    1,
-		weight: 1,
-		size:   1,
+func TestDefaultMempoolLowWaterBytes(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		maxBytes int
+		want     int
+	}{
+		{name: "zero", maxBytes: 0, want: 0},
+		{name: "negative", maxBytes: -1, want: 0},
+		{name: "one", maxBytes: 1, want: 0},
+		{name: "ten", maxBytes: 10, want: 9},
+		{name: "remainder", maxBytes: 11, want: 9},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := defaultMempoolLowWaterBytes(tc.maxBytes); got != tc.want {
+				t.Fatalf("defaultMempoolLowWaterBytes(%d)=%d, want %d", tc.maxBytes, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMempoolCapacityPlanRejectsInvalidDryRunInputs(t *testing.T) {
+	validCandidate := func() *mempoolEntry {
+		return &mempoolEntry{
+			txid:   [32]byte{0x21},
+			fee:    1,
+			weight: 1,
+			size:   1,
+		}
+	}
+	for _, tc := range []struct {
+		name      string
+		mp        *Mempool
+		candidate *mempoolEntry
+		want      string
+	}{
+		{
+			name:      "nil_candidate",
+			mp:        &Mempool{maxTxs: 10, maxBytes: 100},
+			candidate: nil,
+			want:      "nil mempool entry",
+		},
+		{
+			name:      "negative_max_bytes",
+			mp:        &Mempool{maxTxs: 10, maxBytes: -1},
+			candidate: validCandidate(),
+			want:      "invalid mempool max_bytes",
+		},
+		{
+			name:      "zero_capacity",
+			mp:        &Mempool{maxTxs: 0, maxBytes: 100},
+			candidate: validCandidate(),
+			want:      "invalid mempool capacity limits",
+		},
+		{
+			name: "negative_candidate_size",
+			mp:   &Mempool{maxTxs: 10, maxBytes: 100},
+			candidate: &mempoolEntry{
+				txid:   [32]byte{0x22},
+				fee:    1,
+				weight: 1,
+				size:   -1,
+			},
+			want: "invalid mempool candidate_size",
+		},
+		{
+			name:      "negative_used_bytes",
+			mp:        &Mempool{maxTxs: 10, maxBytes: 100, usedBytes: -1},
+			candidate: validCandidate(),
+			want:      "invalid mempool used_bytes",
+		},
+		{
+			name: "candidate_over_max_bytes",
+			mp:   &Mempool{maxTxs: 10, maxBytes: 1},
+			candidate: &mempoolEntry{
+				txid:   [32]byte{0x23},
+				fee:    1,
+				weight: 1,
+				size:   2,
+			},
+			want: "mempool byte limit exceeded",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := tc.mp.capacityEvictionPlanLocked(tc.candidate)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected %q rejection, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+func TestMempoolRejectsZeroWeightMetadata(t *testing.T) {
+	mp := &Mempool{maxTxs: 10, maxBytes: 100}
+	err := mp.validateAdmissionLocked(&mempoolEntry{
+		txid: [32]byte{0x21},
+		fee:  1,
+		size: 1,
 	})
-	if err == nil || !strings.Contains(err.Error(), "invalid mempool byte accounting") {
-		t.Fatalf("expected negative byte accounting rejection, got %v", err)
+	if err == nil || !strings.Contains(err.Error(), "invalid mempool entry weight") {
+		t.Fatalf("expected zero weight rejection, got %v", err)
 	}
 }
 
@@ -1686,6 +1776,17 @@ func TestRestoreMempoolSnapshotPreservesAdmissionSeqHighWatermark(t *testing.T) 
 	tx3ID := txID(t, tx3)
 	if got := mp.txs[tx3ID].admissionSeq; got != 3 {
 		t.Fatalf("tx3 admissionSeq=%d, want 3", got)
+	}
+}
+
+func TestSnapshotMempoolNormalizesRollingFloor(t *testing.T) {
+	mp := &Mempool{}
+	snapshot, err := snapshotMempool(mp)
+	if err != nil {
+		t.Fatalf("snapshotMempool: %v", err)
+	}
+	if snapshot.currentMinFeeRate != DefaultMempoolMinFeeRate {
+		t.Fatalf("snapshot currentMinFeeRate=%d, want %d", snapshot.currentMinFeeRate, DefaultMempoolMinFeeRate)
 	}
 }
 

--- a/clients/go/node/mempool_test.go
+++ b/clients/go/node/mempool_test.go
@@ -1987,6 +1987,93 @@ func TestMempoolRollingMinFeeDecaysOnlyOnConnectedBlockLowWater(t *testing.T) {
 	}
 }
 
+func TestMempoolConnectedBlockDecaySeesConfirmedAndConflictingRemovals(t *testing.T) {
+	spentByBlock := consensus.Outpoint{Txid: [32]byte{0xc1}, Vout: 2}
+	confirmedID := [32]byte{0xa1}
+	conflictingID := [32]byte{0xb1}
+	mp := &Mempool{maxTxs: 10, maxBytes: 100, currentMinFeeRate: 8}
+	confirmed := &mempoolEntry{
+		txid:         confirmedID,
+		wtxid:        confirmedID,
+		fee:          8,
+		weight:       1,
+		size:         5,
+		admissionSeq: 1,
+		source:       mempoolTxSourceLocal,
+	}
+	conflicting := &mempoolEntry{
+		txid:         conflictingID,
+		wtxid:        conflictingID,
+		inputs:       []consensus.Outpoint{spentByBlock},
+		fee:          8,
+		weight:       1,
+		size:         90,
+		admissionSeq: 2,
+		source:       mempoolTxSourceLocal,
+	}
+	if err := mp.addEntryLocked(confirmed); err != nil {
+		t.Fatalf("add confirmed entry: %v", err)
+	}
+	if err := mp.addEntryLocked(conflicting); err != nil {
+		t.Fatalf("add conflicting entry: %v", err)
+	}
+	if got := mp.usedBytes; got != 95 {
+		t.Fatalf("usedBytes before connected block=%d, want 95", got)
+	}
+
+	block := &consensus.ParsedBlock{
+		Txids: [][32]byte{[32]byte{0x01}, confirmedID},
+		Txs: []*consensus.Tx{
+			{},
+			{Inputs: []consensus.TxInput{{PrevTxid: spentByBlock.Txid, PrevVout: spentByBlock.Vout}}},
+		},
+	}
+	if err := mp.applyConnectedBlockParsed(block); err != nil {
+		t.Fatalf("applyConnectedBlockParsed: %v", err)
+	}
+	if mp.Contains(confirmedID) {
+		t.Fatal("connected block left confirmed tx in mempool")
+	}
+	if mp.Contains(conflictingID) {
+		t.Fatal("connected block left conflicting tx in mempool")
+	}
+	if got := mp.usedBytes; got != 0 {
+		t.Fatalf("usedBytes after connected block=%d, want 0", got)
+	}
+	if got := mp.currentMinFeeRate; got != 4 {
+		t.Fatalf("currentMinFeeRate after confirmed+conflict removals=%d, want 4", got)
+	}
+}
+
+func TestMempoolAddReorgTxUsesRollingFloor(t *testing.T) {
+	fromKey := mustNodeMLDSA87Keypair(t)
+	toKey := mustNodeMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000})
+	mp, err := NewMempoolWithConfig(st, nil, devnetGenesisChainID, MempoolConfig{MaxTransactions: 10, MaxBytes: 1 << 20})
+	if err != nil {
+		t.Fatalf("new mempool: %v", err)
+	}
+	mp.currentMinFeeRate = 8
+	txBelowFloor := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 1, 1, fromKey, fromAddress, toAddress)
+
+	err = mp.AddReorgTx(txBelowFloor)
+	var admitErr *TxAdmitError
+	if !errors.As(err, &admitErr) || admitErr.Kind != TxAdmitUnavailable {
+		t.Fatalf("AddReorgTx below rolling floor error=%T %v, want TxAdmitUnavailable", err, err)
+	}
+	if got := mp.Len(); got != 0 {
+		t.Fatalf("mempool len after reorg floor reject=%d, want 0", got)
+	}
+	if mp.lastAdmissionSeq != 0 {
+		t.Fatalf("lastAdmissionSeq after reorg floor reject=%d, want 0", mp.lastAdmissionSeq)
+	}
+	if got := mp.currentMinFeeRate; got != 8 {
+		t.Fatalf("currentMinFeeRate after reorg floor reject=%d, want 8", got)
+	}
+}
+
 func TestMempoolByteCapAllowsExactBoundary(t *testing.T) {
 	fromKey := mustNodeMLDSA87Keypair(t)
 	toKey := mustNodeMLDSA87Keypair(t)

--- a/clients/go/node/mempool_test.go
+++ b/clients/go/node/mempool_test.go
@@ -538,28 +538,103 @@ func TestMempoolCapacityPlanRejectsInvalidExistingMetadata(t *testing.T) {
 }
 
 func TestMempoolEntryFloorRateUsesSatisfiableFloor(t *testing.T) {
-	entry := &mempoolEntry{
-		txid:   [32]byte{0x71},
-		fee:    3,
-		weight: 2,
-		size:   1,
-	}
+	for _, tc := range []struct {
+		name   string
+		fee    uint64
+		weight uint64
+		want   uint64
+	}{
+		{name: "C1_non_div_even_3_over_2", fee: 3, weight: 2, want: 1},
+		{name: "C2_non_div_odd_5_over_3", fee: 5, weight: 3, want: 1},
+		{name: "C3_non_div_big_7_over_4", fee: 7, weight: 4, want: 1},
+		{name: "C4_divisible_4_over_2", fee: 4, weight: 2, want: 2},
+		{name: "C5_divisible_9_over_3", fee: 9, weight: 3, want: 3},
+		{name: "C6_fee_equals_weight", fee: 1, weight: 1, want: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			entry := &mempoolEntry{
+				txid:   [32]byte{0x71},
+				fee:    tc.fee,
+				weight: tc.weight,
+				size:   1,
+			}
 
-	floor, ok := entryFloorRate(entry)
-	if !ok {
-		t.Fatal("entryFloorRate returned !ok for valid entry")
-	}
-	if floor != 1 {
-		t.Fatalf("entryFloorRate=%d, want 1 for fee=3 weight=2", floor)
-	}
-	if feeRateBelowFloor(entry.fee, entry.weight, floor) {
-		t.Fatalf("entry is below its satisfiable floor: fee=%d weight=%d floor=%d", entry.fee, entry.weight, floor)
-	}
-	if !feeRateBelowFloor(entry.fee, entry.weight, floor+DefaultMempoolMinFeeRate) {
-		t.Fatalf("entry unexpectedly satisfies raised floor: fee=%d weight=%d floor=%d", entry.fee, entry.weight, floor+DefaultMempoolMinFeeRate)
+			floor, ok := entryFloorRate(entry)
+			if !ok {
+				t.Fatal("entryFloorRate returned !ok for valid entry")
+			}
+			if floor != tc.want {
+				t.Fatalf("entryFloorRate=%d, want %d for fee=%d weight=%d", floor, tc.want, tc.fee, tc.weight)
+			}
+			if feeRateBelowFloor(entry.fee, entry.weight, floor) {
+				t.Fatalf("entry is below its satisfiable floor: fee=%d weight=%d floor=%d", entry.fee, entry.weight, floor)
+			}
+			if !feeRateBelowFloor(entry.fee, entry.weight, floor+DefaultMempoolMinFeeRate) {
+				t.Fatalf("entry unexpectedly satisfies raised floor: fee=%d weight=%d floor=%d", entry.fee, entry.weight, floor+DefaultMempoolMinFeeRate)
+			}
+		})
 	}
 	if floor, ok := entryFloorRate(&mempoolEntry{txid: [32]byte{0x72}, fee: 3}); ok || floor != 0 {
 		t.Fatalf("zero-weight entryFloorRate=(%d,%v), want (0,false)", floor, ok)
+	}
+}
+
+func TestMempoolRaiseMinFeeRateUsesHighestSatisfiableEvictedFloor(t *testing.T) {
+	mp := &Mempool{maxTxs: 10, maxBytes: 100, currentMinFeeRate: DefaultMempoolMinFeeRate}
+	mp.raiseMinFeeRateAfterEvictionLocked([]*mempoolEntry{
+		{txid: [32]byte{0x81}, fee: 3, weight: 2, size: 1},
+		{txid: [32]byte{0x82}, fee: 10, weight: 2, size: 1},
+		{txid: [32]byte{0x83}, fee: 7, weight: 4, size: 1},
+	})
+
+	wantFloor := uint64(5) + DefaultMempoolMinFeeRate
+	if got := mp.currentMinFeeRate; got != wantFloor {
+		t.Fatalf("currentMinFeeRate=%d, want %d after mixed non-divisible/divisible eviction", got, wantFloor)
+	}
+	if err := mp.validateFeeFloorLocked(&mempoolEntry{txid: [32]byte{0x84}, fee: 12, weight: 2, size: 1}); err != nil {
+		t.Fatalf("candidate at raised floor was rejected: %v", err)
+	}
+	for _, entry := range []*mempoolEntry{
+		{txid: [32]byte{0x85}, fee: 10, weight: 2, size: 1},
+		{txid: [32]byte{0x86}, fee: 8, weight: 2, size: 1},
+	} {
+		if err := mp.validateFeeFloorLocked(entry); err == nil || !strings.Contains(err.Error(), "mempool fee below rolling minimum") {
+			t.Fatalf("candidate below raised floor was not rejected as below-floor: fee=%d weight=%d err=%v", entry.fee, entry.weight, err)
+		}
+	}
+}
+
+func TestMempoolRaiseMinFeeRateUsesHighestNonDivisibleEvictedFloor(t *testing.T) {
+	mp := &Mempool{maxTxs: 10, maxBytes: 100, currentMinFeeRate: DefaultMempoolMinFeeRate}
+	mp.raiseMinFeeRateAfterEvictionLocked([]*mempoolEntry{
+		{txid: [32]byte{0xa1}, fee: 3, weight: 2, size: 1},
+		{txid: [32]byte{0xa2}, fee: 7, weight: 4, size: 1},
+	})
+
+	wantFloor := uint64(1) + DefaultMempoolMinFeeRate
+	if got := mp.currentMinFeeRate; got != wantFloor {
+		t.Fatalf("currentMinFeeRate=%d, want %d after all-non-divisible eviction", got, wantFloor)
+	}
+	if err := mp.validateFeeFloorLocked(&mempoolEntry{txid: [32]byte{0xa3}, fee: 4, weight: 2, size: 1}); err != nil {
+		t.Fatalf("candidate at non-divisible raised floor was rejected: %v", err)
+	}
+}
+
+func TestMempoolRaiseMinFeeRatePreservesDivisibleEvictedFloor(t *testing.T) {
+	mp := &Mempool{maxTxs: 10, maxBytes: 100, currentMinFeeRate: DefaultMempoolMinFeeRate}
+	mp.raiseMinFeeRateAfterEvictionLocked([]*mempoolEntry{
+		{txid: [32]byte{0x91}, fee: 4, weight: 2, size: 1},
+	})
+
+	wantFloor := uint64(2) + DefaultMempoolMinFeeRate
+	if got := mp.currentMinFeeRate; got != wantFloor {
+		t.Fatalf("currentMinFeeRate=%d, want %d after divisible eviction", got, wantFloor)
+	}
+	if err := mp.validateFeeFloorLocked(&mempoolEntry{txid: [32]byte{0x92}, fee: 6, weight: 2, size: 1}); err != nil {
+		t.Fatalf("candidate at divisible raised floor was rejected: %v", err)
+	}
+	if err := mp.validateFeeFloorLocked(&mempoolEntry{txid: [32]byte{0x93}, fee: 4, weight: 2, size: 1}); err == nil || !strings.Contains(err.Error(), "mempool fee below rolling minimum") {
+		t.Fatalf("candidate below divisible raised floor was not rejected as below-floor: %v", err)
 	}
 }
 

--- a/clients/go/node/mempool_test.go
+++ b/clients/go/node/mempool_test.go
@@ -336,15 +336,23 @@ func TestMempoolAddEntryLockedRejectsInvalidSourceAndDuplicateAdmissionSeq(t *te
 	if err := mp.addEntryLocked(first); err != nil {
 		t.Fatalf("addEntryLocked(first): %v", err)
 	}
-	if err := mp.addEntryLocked(&mempoolEntry{
+	err := mp.addEntryLocked(&mempoolEntry{
 		txid:         [32]byte{0x12},
 		fee:          1,
 		weight:       1,
 		size:         1,
 		admissionSeq: 7,
 		source:       mempoolTxSourceRemote,
-	}); err == nil || !strings.Contains(err.Error(), "mempool admission sequence conflict") {
+	})
+	if err == nil || !strings.Contains(err.Error(), "mempool admission sequence conflict") {
 		t.Fatalf("expected admission sequence conflict, got %v", err)
+	}
+	var txErr *TxAdmitError
+	if !errors.As(err, &txErr) {
+		t.Fatalf("expected TxAdmitError for admission sequence conflict, got %T: %v", err, err)
+	}
+	if txErr.Kind != TxAdmitRejected {
+		t.Fatalf("admission sequence conflict kind=%v, want %v", txErr.Kind, TxAdmitRejected)
 	}
 	if err := mp.addEntryLocked(&mempoolEntry{
 		txid:   [32]byte{0x13},

--- a/clients/go/node/mempool_test.go
+++ b/clients/go/node/mempool_test.go
@@ -195,12 +195,13 @@ func TestMempoolAddEntryLockedInitializesMetadataIndexes(t *testing.T) {
 		txid:         [32]byte{0x02},
 		wtxid:        [32]byte{0x03},
 		inputs:       []consensus.Outpoint{op},
+		weight:       5,
 		size:         7,
 		admissionSeq: 9,
 		source:       mempoolTxSourceReorg,
 	}
 
-	mp := &Mempool{}
+	mp := &Mempool{maxTxs: 10, maxBytes: 100}
 	if err := mp.addEntryLocked(entry); err != nil {
 		t.Fatalf("addEntryLocked: %v", err)
 	}
@@ -227,8 +228,10 @@ func TestMempoolAddEntryLockedInitializesMetadataIndexes(t *testing.T) {
 
 func TestMempoolAddEntryLockedDefaultsUnsetWtxid(t *testing.T) {
 	entry := &mempoolEntry{
-		txid: [32]byte{0x0a},
-		size: 1,
+		txid:   [32]byte{0x0a},
+		fee:    1,
+		weight: 1,
+		size:   1,
 	}
 
 	mp := &Mempool{
@@ -248,16 +251,16 @@ func TestMempoolAddEntryLockedDefaultsUnsetWtxid(t *testing.T) {
 	if got, ok := mp.wtxids[[32]byte{}]; ok {
 		t.Fatalf("zero wtxid key unexpectedly indexed txid %x", got)
 	}
-	err := mp.validateAdmissionLocked(&mempoolEntry{txid: [32]byte{0x0b}, size: 1})
-	if err == nil || !strings.Contains(err.Error(), "mempool transaction count limit reached") {
-		t.Fatalf("expected count-limit rejection after zero-wtxid default, got %v", err)
+	err := mp.validateAdmissionLocked(&mempoolEntry{txid: [32]byte{0x0b}, fee: 1, weight: 1, size: 1})
+	if err == nil || !strings.Contains(err.Error(), "mempool capacity candidate rejected by eviction ordering") {
+		t.Fatalf("expected candidate-worst rejection after zero-wtxid default, got %v", err)
 	}
 }
 
 func TestMempoolAddEntryLockedRejectsZeroTxidWithoutMutation(t *testing.T) {
 	mp := &Mempool{}
 
-	err := mp.addEntryLocked(&mempoolEntry{size: 1})
+	err := mp.addEntryLocked(&mempoolEntry{weight: 1, size: 1})
 	if err == nil || !strings.Contains(err.Error(), "invalid mempool entry txid") {
 		t.Fatalf("expected invalid txid rejection, got %v", err)
 	}
@@ -271,9 +274,101 @@ func TestMempoolAddEntryLockedRejectsZeroTxidWithoutMutation(t *testing.T) {
 		t.Fatalf("lastAdmissionSeq=%d, want 0 after zero txid reject", mp.lastAdmissionSeq)
 	}
 
-	err = mp.validateAdmissionLocked(&mempoolEntry{size: 1})
+	err = mp.validateAdmissionLocked(&mempoolEntry{weight: 1, size: 1})
 	if err == nil || !strings.Contains(err.Error(), "invalid mempool entry txid") {
 		t.Fatalf("expected validate invalid txid rejection, got %v", err)
+	}
+}
+
+func TestMempoolEvictionComparatorTiers(t *testing.T) {
+	lowerRate := mempoolEvictionPlanEntry{entry: &mempoolEntry{txid: [32]byte{0x01}, fee: 1, weight: 2, size: 1, admissionSeq: 1}}
+	higherRate := mempoolEvictionPlanEntry{entry: &mempoolEntry{txid: [32]byte{0x02}, fee: 1, weight: 1, size: 1, admissionSeq: 2}}
+	if !evictionPlanEntryWorse(lowerRate, higherRate) {
+		t.Fatal("lower fee/weight entry was not worse")
+	}
+
+	lowerAbsoluteFee := mempoolEvictionPlanEntry{entry: &mempoolEntry{txid: [32]byte{0x03}, fee: 1, weight: 1, size: 1000, admissionSeq: 3}}
+	higherAbsoluteFee := mempoolEvictionPlanEntry{entry: &mempoolEntry{txid: [32]byte{0x04}, fee: 2, weight: 2, size: 1, admissionSeq: 4}}
+	if !evictionPlanEntryWorse(lowerAbsoluteFee, higherAbsoluteFee) {
+		t.Fatal("lower absolute fee tie-break was not worse before admission_seq")
+	}
+
+	older := mempoolEvictionPlanEntry{entry: &mempoolEntry{txid: [32]byte{0x05}, fee: 3, weight: 3, size: 1, admissionSeq: 5}}
+	newer := mempoolEvictionPlanEntry{entry: &mempoolEntry{txid: [32]byte{0x06}, fee: 3, weight: 3, size: 1, admissionSeq: 6}}
+	if !evictionPlanEntryWorse(older, newer) {
+		t.Fatal("older admission_seq tie-break was not worse")
+	}
+
+	candidate := mempoolEvictionPlanEntry{entry: &mempoolEntry{txid: [32]byte{0x07}, fee: 3, weight: 3, size: 1}, candidate: true}
+	if !evictionPlanEntryWorse(candidate, older) {
+		t.Fatal("capacity candidate did not compare as virtual admission_seq=0")
+	}
+
+	local := mempoolEvictionPlanEntry{entry: &mempoolEntry{txid: [32]byte{0x09}, fee: 3, weight: 3, size: 1, admissionSeq: 7, source: mempoolTxSourceLocal}}
+	remote := mempoolEvictionPlanEntry{entry: &mempoolEntry{txid: [32]byte{0x08}, fee: 3, weight: 3, size: 1, admissionSeq: 7, source: mempoolTxSourceRemote}}
+	if !evictionPlanEntryWorse(local, remote) {
+		t.Fatal("source provenance unexpectedly affected eviction ordering before deterministic txid tie-break")
+	}
+}
+
+func TestMempoolFeeRateComparatorUsesWeightAndDoesNotOverflow(t *testing.T) {
+	if got := compareFeeRateWeightValues(^uint64(0), ^uint64(0)-1, ^uint64(0)-1, ^uint64(0)); got <= 0 {
+		t.Fatalf("overflow-sensitive fee-rate compare=%d, want first greater", got)
+	}
+	lowWeightFeeRate := &mempoolEntry{txid: [32]byte{0x01}, fee: 10, weight: 5, size: 10_000, admissionSeq: 1}
+	highWeightFeeRate := &mempoolEntry{txid: [32]byte{0x02}, fee: 10, weight: 10, size: 1, admissionSeq: 2}
+	if !evictionPlanEntryWorse(mempoolEvictionPlanEntry{entry: highWeightFeeRate}, mempoolEvictionPlanEntry{entry: lowWeightFeeRate}) {
+		t.Fatal("eviction comparator used wire bytes instead of weight")
+	}
+}
+
+func TestMempoolAddEntryLockedRejectsInvalidSourceAndDuplicateAdmissionSeq(t *testing.T) {
+	mp := &Mempool{maxTxs: 10, maxBytes: 100}
+	first := &mempoolEntry{
+		txid:         [32]byte{0x11},
+		fee:          1,
+		weight:       1,
+		size:         1,
+		admissionSeq: 7,
+		source:       mempoolTxSourceLocal,
+	}
+	if err := mp.addEntryLocked(first); err != nil {
+		t.Fatalf("addEntryLocked(first): %v", err)
+	}
+	if err := mp.addEntryLocked(&mempoolEntry{
+		txid:         [32]byte{0x12},
+		fee:          1,
+		weight:       1,
+		size:         1,
+		admissionSeq: 7,
+		source:       mempoolTxSourceRemote,
+	}); err == nil || !strings.Contains(err.Error(), "mempool admission sequence conflict") {
+		t.Fatalf("expected admission sequence conflict, got %v", err)
+	}
+	if err := mp.addEntryLocked(&mempoolEntry{
+		txid:   [32]byte{0x13},
+		fee:    1,
+		weight: 1,
+		size:   1,
+		source: "sidecar",
+	}); err == nil || !strings.Contains(err.Error(), "invalid mempool tx source") {
+		t.Fatalf("expected invalid source rejection, got %v", err)
+	}
+	if got := mp.Len(); got != 1 {
+		t.Fatalf("mempool len=%d, want 1 after helper rejects", got)
+	}
+}
+
+func TestMempoolCapacityPlanRejectsNegativeByteAccounting(t *testing.T) {
+	mp := &Mempool{maxTxs: 10, maxBytes: 100, usedBytes: -1}
+	_, _, err := mp.capacityEvictionPlanLocked(&mempoolEntry{
+		txid:   [32]byte{0x21},
+		fee:    1,
+		weight: 1,
+		size:   1,
+	})
+	if err == nil || !strings.Contains(err.Error(), "invalid mempool byte accounting") {
+		t.Fatalf("expected negative byte accounting rejection, got %v", err)
 	}
 }
 
@@ -1111,21 +1206,21 @@ func TestMempoolDoubleSpend(t *testing.T) {
 	}
 }
 
-func TestMempoolFullRejectsWithoutEviction(t *testing.T) {
+func TestMempoolFullEvictsWorstByFeeWeight(t *testing.T) {
 	fromKey := mustNodeMLDSA87Keypair(t)
 	toKey := mustNodeMLDSA87Keypair(t)
 	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
 	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
-	st, outpoints := testSpendableChainState(fromAddress, []uint64{100, 100, 100})
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000, 1_000_000, 1_000_000})
 
-	mp, err := NewMempoolWithConfig(st, nil, devnetGenesisChainID, MempoolConfig{MaxTransactions: 2})
+	mp, err := NewMempoolWithConfig(st, nil, devnetGenesisChainID, MempoolConfig{MaxTransactions: 2, MaxBytes: 1 << 20})
 	if err != nil {
 		t.Fatalf("new mempool: %v", err)
 	}
 
-	txLow := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 1, 1, fromKey, fromAddress, toAddress)
-	txHigh := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[1]}, 90, 4, 2, fromKey, fromAddress, toAddress)
-	txBetter := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[2]}, 90, 2, 3, fromKey, fromAddress, toAddress)
+	txLow := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 100_000, 1, fromKey, fromAddress, toAddress)
+	txHigh := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[1]}, 100_000, 200_000, 2, fromKey, fromAddress, toAddress)
+	txBest := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[2]}, 100_000, 300_000, 3, fromKey, fromAddress, toAddress)
 
 	if err := mp.AddTx(txLow); err != nil {
 		t.Fatalf("AddTx(low): %v", err)
@@ -1133,18 +1228,26 @@ func TestMempoolFullRejectsWithoutEviction(t *testing.T) {
 	if err := mp.AddTx(txHigh); err != nil {
 		t.Fatalf("AddTx(high): %v", err)
 	}
-	seqAfterAccepted := mp.lastAdmissionSeq
-	if err := mp.AddTx(txBetter); err == nil || !strings.Contains(err.Error(), "mempool transaction count limit reached") {
-		t.Fatalf("expected count-limit rejection without eviction, got %v", err)
-	}
-	if mp.lastAdmissionSeq != seqAfterAccepted {
-		t.Fatalf("lastAdmissionSeq after capacity reject=%d, want %d", mp.lastAdmissionSeq, seqAfterAccepted)
+	if err := mp.AddTx(txBest); err != nil {
+		t.Fatalf("AddTx(best): %v", err)
 	}
 	if got := mp.Len(); got != 2 {
 		t.Fatalf("mempool len=%d, want 2", got)
 	}
-	if mp.usedBytes != len(txLow)+len(txHigh) {
-		t.Fatalf("usedBytes=%d, want %d", mp.usedBytes, len(txLow)+len(txHigh))
+	if mp.Contains(txID(t, txLow)) {
+		t.Fatal("lowest fee/weight tx remained after count-pressure eviction")
+	}
+	if !mp.Contains(txID(t, txHigh)) || !mp.Contains(txID(t, txBest)) {
+		t.Fatal("capacity eviction removed a survivor with better fee/weight")
+	}
+	if got := mp.lastAdmissionSeq; got != 3 {
+		t.Fatalf("lastAdmissionSeq=%d, want 3", got)
+	}
+	if got := mp.txs[txID(t, txBest)].admissionSeq; got != 3 {
+		t.Fatalf("best admission_seq=%d, want 3", got)
+	}
+	if mp.currentMinFeeRate <= DefaultMempoolMinFeeRate {
+		t.Fatalf("currentMinFeeRate=%d, want above base floor after actual eviction", mp.currentMinFeeRate)
 	}
 
 	selected := mp.SelectTransactions(3, 1<<20)
@@ -1152,25 +1255,22 @@ func TestMempoolFullRejectsWithoutEviction(t *testing.T) {
 		t.Fatalf("selected=%d, want 2", len(selected))
 	}
 	got := []string{txIDHex(t, selected[0]), txIDHex(t, selected[1])}
+	wantBest := txIDHex(t, txBest)
 	wantHigh := txIDHex(t, txHigh)
-	wantLow := txIDHex(t, txLow)
-	if got[0] != wantHigh || got[1] != wantLow {
-		t.Fatalf("selected=%v, want [%s %s]", got, wantHigh, wantLow)
-	}
-	if mp.Contains(txID(t, txBetter)) {
-		t.Fatalf("rejected over-cap tx entered mempool")
+	if got[0] != wantBest || got[1] != wantHigh {
+		t.Fatalf("selected=%v, want [%s %s]", got, wantBest, wantHigh)
 	}
 }
 
-func TestMempoolByteCapRejectsWithoutMutation(t *testing.T) {
+func TestMempoolCandidateWorstRejectsWithoutMutation(t *testing.T) {
 	fromKey := mustNodeMLDSA87Keypair(t)
 	toKey := mustNodeMLDSA87Keypair(t)
 	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
 	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
-	st, outpoints := testSpendableChainState(fromAddress, []uint64{100, 100})
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000, 1_000_000})
 
-	tx1 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 2, 1, fromKey, fromAddress, toAddress)
-	tx2 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[1]}, 90, 2, 2, fromKey, fromAddress, toAddress)
+	tx1 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 200_000, 1, fromKey, fromAddress, toAddress)
+	tx2 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[1]}, 100_000, 100_000, 2, fromKey, fromAddress, toAddress)
 	mp, err := NewMempoolWithConfig(st, nil, devnetGenesisChainID, MempoolConfig{
 		MaxTransactions: 10,
 		MaxBytes:        len(tx1) + len(tx2) - 1,
@@ -1182,17 +1282,213 @@ func TestMempoolByteCapRejectsWithoutMutation(t *testing.T) {
 	if err := mp.AddTx(tx1); err != nil {
 		t.Fatalf("AddTx(tx1): %v", err)
 	}
-	if err := mp.AddTx(tx2); err == nil || !strings.Contains(err.Error(), "mempool byte limit exceeded") {
-		t.Fatalf("expected byte-limit rejection, got %v", err)
+	before, err := snapshotMempool(mp)
+	if err != nil {
+		t.Fatalf("snapshot before candidate-worst: %v", err)
+	}
+	usedBytes := mp.usedBytes
+	if err := mp.AddTx(tx2); err == nil || !strings.Contains(err.Error(), "mempool capacity candidate rejected by eviction ordering") {
+		t.Fatalf("expected candidate-worst rejection, got %v", err)
+	}
+	after, err := snapshotMempool(mp)
+	if err != nil {
+		t.Fatalf("snapshot after candidate-worst: %v", err)
+	}
+	if !reflect.DeepEqual(after, before) {
+		t.Fatalf("mempool snapshot mutated after candidate-worst reject: before=%+v after=%+v", before, after)
 	}
 	if got := mp.Len(); got != 1 {
 		t.Fatalf("mempool len=%d, want 1", got)
 	}
-	if mp.usedBytes != len(tx1) {
-		t.Fatalf("usedBytes=%d, want %d", mp.usedBytes, len(tx1))
+	if mp.usedBytes != usedBytes {
+		t.Fatalf("usedBytes=%d, want %d", mp.usedBytes, usedBytes)
 	}
 	if mp.Contains(txID(t, tx2)) {
 		t.Fatalf("rejected byte-cap tx entered mempool")
+	}
+}
+
+func TestMempoolCapacityRejectsBelowRollingFloorWithoutMutation(t *testing.T) {
+	fromKey := mustNodeMLDSA87Keypair(t)
+	toKey := mustNodeMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000, 1_000_000})
+
+	tx1 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 200_000, 1, fromKey, fromAddress, toAddress)
+	txBelowFloor := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[1]}, 100_000, 1, 2, fromKey, fromAddress, toAddress)
+	mp, err := NewMempoolWithConfig(st, nil, devnetGenesisChainID, MempoolConfig{MaxTransactions: 1, MaxBytes: 1 << 20})
+	if err != nil {
+		t.Fatalf("new mempool: %v", err)
+	}
+	if err := mp.AddTx(tx1); err != nil {
+		t.Fatalf("AddTx(tx1): %v", err)
+	}
+	before, err := snapshotMempool(mp)
+	if err != nil {
+		t.Fatalf("snapshot before below-floor: %v", err)
+	}
+	if err := mp.AddTx(txBelowFloor); err == nil || !strings.Contains(err.Error(), "mempool fee below rolling minimum") {
+		t.Fatalf("expected below-floor rejection, got %v", err)
+	}
+	after, err := snapshotMempool(mp)
+	if err != nil {
+		t.Fatalf("snapshot after below-floor: %v", err)
+	}
+	if !reflect.DeepEqual(after, before) {
+		t.Fatalf("below-floor capacity reject mutated mempool: before=%+v after=%+v", before, after)
+	}
+	if mp.Contains(txID(t, txBelowFloor)) {
+		t.Fatal("below-floor capacity candidate entered mempool")
+	}
+}
+
+func TestMempoolByteCapEvictsToLowWater(t *testing.T) {
+	fromKey := mustNodeMLDSA87Keypair(t)
+	toKey := mustNodeMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000, 1_000_000, 1_000_000, 1_000_000})
+
+	txLow := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 100_000, 1, fromKey, fromAddress, toAddress)
+	txMid := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[1]}, 100_000, 200_000, 2, fromKey, fromAddress, toAddress)
+	txHigh := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[2]}, 100_000, 300_000, 3, fromKey, fromAddress, toAddress)
+	txBest := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[3]}, 100_000, 400_000, 4, fromKey, fromAddress, toAddress)
+	maxBytes := len(txLow) + len(txMid) + len(txHigh)
+	mp, err := NewMempoolWithConfig(st, nil, devnetGenesisChainID, MempoolConfig{
+		MaxTransactions: 10,
+		MaxBytes:        maxBytes,
+	})
+	if err != nil {
+		t.Fatalf("new mempool: %v", err)
+	}
+	for _, item := range []struct {
+		name string
+		raw  []byte
+	}{
+		{name: "low", raw: txLow},
+		{name: "mid", raw: txMid},
+		{name: "high", raw: txHigh},
+	} {
+		if err := mp.AddTx(item.raw); err != nil {
+			t.Fatalf("AddTx(%s): %v", item.name, err)
+		}
+	}
+	if err := mp.AddTx(txBest); err != nil {
+		t.Fatalf("AddTx(best): %v", err)
+	}
+	if got, wantMax := mp.usedBytes, mp.effectiveLowWaterBytesLocked(); got > wantMax {
+		t.Fatalf("usedBytes=%d, want <= lowWater %d after byte-pressure eviction", got, wantMax)
+	}
+	if mp.Contains(txID(t, txLow)) || mp.Contains(txID(t, txMid)) {
+		t.Fatal("byte-pressure low-water trim kept lower-priority evicted entries")
+	}
+	if !mp.Contains(txID(t, txHigh)) || !mp.Contains(txID(t, txBest)) {
+		t.Fatal("byte-pressure low-water trim removed expected survivors")
+	}
+}
+
+func TestMempoolDuplicateRejectsBeforeEviction(t *testing.T) {
+	fromKey := mustNodeMLDSA87Keypair(t)
+	toKey := mustNodeMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000})
+
+	tx := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 200_000, 1, fromKey, fromAddress, toAddress)
+	mp, err := NewMempoolWithConfig(st, nil, devnetGenesisChainID, MempoolConfig{MaxTransactions: 1, MaxBytes: 1 << 20})
+	if err != nil {
+		t.Fatalf("new mempool: %v", err)
+	}
+	if err := mp.AddTx(tx); err != nil {
+		t.Fatalf("AddTx(tx): %v", err)
+	}
+	before, err := snapshotMempool(mp)
+	if err != nil {
+		t.Fatalf("snapshot before duplicate: %v", err)
+	}
+	if err := mp.AddTx(tx); err == nil || !strings.Contains(err.Error(), "tx already in mempool") {
+		t.Fatalf("expected duplicate rejection before eviction, got %v", err)
+	}
+	after, err := snapshotMempool(mp)
+	if err != nil {
+		t.Fatalf("snapshot after duplicate: %v", err)
+	}
+	if !reflect.DeepEqual(after, before) {
+		t.Fatalf("duplicate path mutated mempool: before=%+v after=%+v", before, after)
+	}
+}
+
+func TestMempoolConflictRejectsBeforeEvictionUnderPressure(t *testing.T) {
+	fromKey := mustNodeMLDSA87Keypair(t)
+	toKey := mustNodeMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000})
+
+	tx := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 100_000, 1, fromKey, fromAddress, toAddress)
+	conflictingHigherFee := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 200_000, 2, fromKey, fromAddress, toAddress)
+	mp, err := NewMempoolWithConfig(st, nil, devnetGenesisChainID, MempoolConfig{MaxTransactions: 1, MaxBytes: 1 << 20})
+	if err != nil {
+		t.Fatalf("new mempool: %v", err)
+	}
+	if err := mp.AddTx(tx); err != nil {
+		t.Fatalf("AddTx(tx): %v", err)
+	}
+	before, err := snapshotMempool(mp)
+	if err != nil {
+		t.Fatalf("snapshot before conflict: %v", err)
+	}
+	if err := mp.AddTx(conflictingHigherFee); err == nil || !strings.Contains(err.Error(), "mempool double-spend conflict") {
+		t.Fatalf("expected conflict rejection before eviction, got %v", err)
+	}
+	after, err := snapshotMempool(mp)
+	if err != nil {
+		t.Fatalf("snapshot after conflict: %v", err)
+	}
+	if !reflect.DeepEqual(after, before) {
+		t.Fatalf("conflict path mutated mempool: before=%+v after=%+v", before, after)
+	}
+	if !mp.Contains(txID(t, tx)) || mp.Contains(txID(t, conflictingHigherFee)) {
+		t.Fatal("conflict path replaced resident transaction")
+	}
+}
+
+func TestMempoolRollingMinFeeDecaysOnlyOnConnectedBlockLowWater(t *testing.T) {
+	st := NewChainState()
+	mp, err := NewMempoolWithConfig(st, nil, devnetGenesisChainID, MempoolConfig{MaxBytes: 1000})
+	if err != nil {
+		t.Fatalf("new mempool: %v", err)
+	}
+	mp.currentMinFeeRate = 8
+	mp.usedBytes = mp.effectiveLowWaterBytesLocked() - 1
+	if err := mp.RemoveConflictingParsed(&consensus.ParsedBlock{}); err != nil {
+		t.Fatalf("RemoveConflictingParsed: %v", err)
+	}
+	if got := mp.currentMinFeeRate; got != 8 {
+		t.Fatalf("RemoveConflictingParsed decayed floor to %d, want 8", got)
+	}
+	if err := mp.EvictConfirmedParsed(&consensus.ParsedBlock{}); err != nil {
+		t.Fatalf("EvictConfirmedParsed: %v", err)
+	}
+	if got := mp.currentMinFeeRate; got != 4 {
+		t.Fatalf("connected block low-water decay=%d, want 4", got)
+	}
+	mp.currentMinFeeRate = 8
+	mp.usedBytes = mp.effectiveLowWaterBytesLocked()
+	if err := mp.EvictConfirmedParsed(&consensus.ParsedBlock{}); err != nil {
+		t.Fatalf("EvictConfirmedParsed at low-water boundary: %v", err)
+	}
+	if got := mp.currentMinFeeRate; got != 8 {
+		t.Fatalf("boundary usedBytes decayed floor to %d, want 8", got)
+	}
+	mp.currentMinFeeRate = DefaultMempoolMinFeeRate
+	mp.usedBytes = 0
+	if err := mp.EvictConfirmedParsed(&consensus.ParsedBlock{}); err != nil {
+		t.Fatalf("EvictConfirmedParsed at base floor: %v", err)
+	}
+	if got := mp.currentMinFeeRate; got != DefaultMempoolMinFeeRate {
+		t.Fatalf("base floor decayed to %d, want %d", got, DefaultMempoolMinFeeRate)
 	}
 }
 
@@ -1355,6 +1651,7 @@ func TestRestoreMempoolSnapshotPreservesAdmissionSeqHighWatermark(t *testing.T) 
 	if err := mp.AddTx(tx2); err != nil {
 		t.Fatalf("AddTx(tx2): %v", err)
 	}
+	mp.currentMinFeeRate = 7
 	tx2ID := txID(t, tx2)
 	mp.mu.Lock()
 	mp.removeTxLocked(tx2ID)
@@ -1370,11 +1667,18 @@ func TestRestoreMempoolSnapshotPreservesAdmissionSeqHighWatermark(t *testing.T) 
 	if snapshot.lastAdmissionSeq != 2 {
 		t.Fatalf("snapshot lastAdmissionSeq=%d, want 2", snapshot.lastAdmissionSeq)
 	}
+	if snapshot.currentMinFeeRate != 7 {
+		t.Fatalf("snapshot currentMinFeeRate=%d, want 7", snapshot.currentMinFeeRate)
+	}
+	mp.currentMinFeeRate = 3
 	if err := restoreMempoolSnapshot(mp, snapshot); err != nil {
 		t.Fatalf("restoreMempoolSnapshot: %v", err)
 	}
 	if mp.lastAdmissionSeq != 2 {
 		t.Fatalf("lastAdmissionSeq after restore=%d, want 2", mp.lastAdmissionSeq)
+	}
+	if mp.currentMinFeeRate != 7 {
+		t.Fatalf("currentMinFeeRate after restore=%d, want 7", mp.currentMinFeeRate)
 	}
 	if err := mp.AddTx(tx3); err != nil {
 		t.Fatalf("AddTx(tx3): %v", err)
@@ -1414,9 +1718,13 @@ func TestRestoreMempoolSnapshotRejectsInvalidEntriesWithoutMutation(t *testing.T
 	txDoubleSpend := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 89, 3, 2, fromKey, fromAddress, toAddress)
 	doubleSpendID := txID(t, txDoubleSpend)
 	snapshotEntry := func(txRaw []byte, id [32]byte, inputs []consensus.Outpoint) mempoolEntry {
-		_, _, wtxid, _, err := consensus.ParseTx(txRaw)
+		parsed, _, wtxid, _, err := consensus.ParseTx(txRaw)
 		if err != nil {
 			t.Fatalf("ParseTx(snapshotEntry): %v", err)
+		}
+		weight, _, _, err := consensus.TxWeightAndStats(parsed)
+		if err != nil {
+			t.Fatalf("TxWeightAndStats(snapshotEntry): %v", err)
 		}
 		return mempoolEntry{
 			raw:          append([]byte(nil), txRaw...),
@@ -1424,6 +1732,7 @@ func TestRestoreMempoolSnapshotRejectsInvalidEntriesWithoutMutation(t *testing.T
 			wtxid:        wtxid,
 			inputs:       append([]consensus.Outpoint(nil), inputs...),
 			size:         len(txRaw),
+			weight:       weight,
 			admissionSeq: 99,
 			source:       mempoolTxSourceLocal,
 		}
@@ -1433,7 +1742,7 @@ func TestRestoreMempoolSnapshotRejectsInvalidEntriesWithoutMutation(t *testing.T
 		for i := range base.entries {
 			entries = append(entries, cloneMempoolEntry(&base.entries[i]))
 		}
-		return mempoolSnapshot{entries: entries, lastAdmissionSeq: base.lastAdmissionSeq}
+		return mempoolSnapshot{entries: entries, lastAdmissionSeq: base.lastAdmissionSeq, currentMinFeeRate: base.currentMinFeeRate}
 	}
 	withEditedFirst := func(edit func(*mempoolEntry)) func(mempoolSnapshot) mempoolSnapshot {
 		return func(base mempoolSnapshot) mempoolSnapshot {
@@ -1453,6 +1762,16 @@ func TestRestoreMempoolSnapshotRejectsInvalidEntriesWithoutMutation(t *testing.T
 			name:   "zero_size",
 			mutate: withEditedFirst(func(entry *mempoolEntry) { entry.size = 0 }),
 			want:   "invalid mempool snapshot entry size",
+		},
+		{
+			name:   "zero_weight",
+			mutate: withEditedFirst(func(entry *mempoolEntry) { entry.weight = 0 }),
+			want:   "invalid mempool snapshot entry weight",
+		},
+		{
+			name:   "weight_mismatch",
+			mutate: withEditedFirst(func(entry *mempoolEntry) { entry.weight++ }),
+			want:   "mempool snapshot entry weight mismatch",
 		},
 		{
 			name:   "size_mismatch",
@@ -2129,13 +2448,13 @@ func TestTxAdmitErrorKinds(t *testing.T) {
 	})
 
 	t.Run("mempool full unavailable", func(t *testing.T) {
-		st, outpoints := testSpendableChainState(fromAddress, []uint64{100, 100})
-		mp, err := NewMempoolWithConfig(st, nil, devnetGenesisChainID, MempoolConfig{MaxTransactions: 1})
+		st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000, 1_000_000})
+		mp, err := NewMempoolWithConfig(st, nil, devnetGenesisChainID, MempoolConfig{MaxTransactions: 1, MaxBytes: 1 << 20})
 		if err != nil {
 			t.Fatalf("new mempool: %v", err)
 		}
-		tx1 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 90, 5, 1, fromKey, fromAddress, toAddress)
-		tx2 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[1]}, 90, 1, 2, fromKey, fromAddress, toAddress)
+		tx1 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 200_000, 1, fromKey, fromAddress, toAddress)
+		tx2 := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[1]}, 100_000, 200_000, 2, fromKey, fromAddress, toAddress)
 		if err := mp.AddTx(tx1); err != nil {
 			t.Fatalf("first AddTx: %v", err)
 		}

--- a/clients/go/node/mempool_test.go
+++ b/clients/go/node/mempool_test.go
@@ -252,7 +252,7 @@ func TestMempoolAddEntryLockedDefaultsUnsetWtxid(t *testing.T) {
 	if got, ok := mp.wtxids[[32]byte{}]; ok {
 		t.Fatalf("zero wtxid key unexpectedly indexed txid %x", got)
 	}
-	err := mp.validateAdmissionLocked(&mempoolEntry{txid: [32]byte{0x0b}, fee: 1, weight: 1, size: 1})
+	err := mp.addEntryLocked(&mempoolEntry{txid: [32]byte{0x0b}, fee: 1, weight: 1, size: 1})
 	if err == nil || !strings.Contains(err.Error(), "mempool capacity candidate rejected by eviction ordering") {
 		t.Fatalf("expected candidate-worst rejection after zero-wtxid default, got %v", err)
 	}
@@ -275,7 +275,7 @@ func TestMempoolAddEntryLockedRejectsZeroTxidWithoutMutation(t *testing.T) {
 		t.Fatalf("lastAdmissionSeq=%d, want 0 after zero txid reject", mp.lastAdmissionSeq)
 	}
 
-	err = mp.validateAdmissionLocked(&mempoolEntry{weight: 1, size: 1})
+	err = mp.validateNonCapacityAdmissionLocked(&mempoolEntry{weight: 1, size: 1})
 	if err == nil || !strings.Contains(err.Error(), "invalid mempool entry txid") {
 		t.Fatalf("expected validate invalid txid rejection, got %v", err)
 	}
@@ -720,7 +720,7 @@ func TestMempoolAddEntryLockedCandidateWorstRejectsWithoutMutation(t *testing.T)
 
 func TestMempoolRejectsZeroWeightMetadata(t *testing.T) {
 	mp := &Mempool{maxTxs: 10, maxBytes: 100}
-	err := mp.validateAdmissionLocked(&mempoolEntry{
+	err := mp.validateNonCapacityAdmissionLocked(&mempoolEntry{
 		txid: [32]byte{0x21},
 		fee:  1,
 		size: 1,
@@ -1743,23 +1743,23 @@ func TestMempoolRollingFloorRejectsBelowCapacityWithoutMutation(t *testing.T) {
 	}
 }
 
-func TestMempoolRollingFloorDirectHelperRejectsBelowCapacity(t *testing.T) {
+func TestMempoolAddEntryLockedRejectsBelowFloor(t *testing.T) {
 	mp := &Mempool{maxTxs: 10, maxBytes: 100, currentMinFeeRate: 8}
-	err := mp.validateAdmissionLocked(&mempoolEntry{
+	err := mp.addEntryLocked(&mempoolEntry{
 		txid:   [32]byte{0x51},
 		fee:    7,
 		weight: 1,
 		size:   1,
 	})
 	if err == nil || !strings.Contains(err.Error(), "mempool fee below rolling minimum") {
-		t.Fatalf("expected direct below-floor rejection, got %v", err)
+		t.Fatalf("expected addEntryLocked below-floor rejection, got %v", err)
 	}
 	var txErr *TxAdmitError
 	if !errors.As(err, &txErr) || txErr.Kind != TxAdmitUnavailable {
-		t.Fatalf("direct floor err=%v, want TxAdmitUnavailable", err)
+		t.Fatalf("addEntryLocked floor err=%v, want TxAdmitUnavailable", err)
 	}
 	if len(mp.txs) != 0 || mp.usedBytes != 0 || mp.lastAdmissionSeq != 0 || mp.currentMinFeeRate != 8 {
-		t.Fatalf("direct floor reject mutated mempool: len=%d used=%d seq=%d floor=%d", len(mp.txs), mp.usedBytes, mp.lastAdmissionSeq, mp.currentMinFeeRate)
+		t.Fatalf("addEntryLocked floor reject mutated mempool: len=%d used=%d seq=%d floor=%d", len(mp.txs), mp.usedBytes, mp.lastAdmissionSeq, mp.currentMinFeeRate)
 	}
 }
 

--- a/clients/go/node/mempool_test.go
+++ b/clients/go/node/mempool_test.go
@@ -450,6 +450,145 @@ func TestMempoolCapacityPlanRejectsInvalidDryRunInputs(t *testing.T) {
 	}
 }
 
+func TestMempoolCapacityPlanRejectsInvalidExistingMetadata(t *testing.T) {
+	validExisting := func(txid [32]byte, seq uint64) *mempoolEntry {
+		return &mempoolEntry{
+			txid:         txid,
+			fee:          10,
+			weight:       1,
+			size:         1,
+			admissionSeq: seq,
+			source:       mempoolTxSourceLocal,
+		}
+	}
+	validCandidate := &mempoolEntry{
+		txid:   [32]byte{0xaa},
+		fee:    10,
+		weight: 1,
+		size:   1,
+	}
+	for _, tc := range []struct {
+		name    string
+		entries map[[32]byte]*mempoolEntry
+		want    string
+	}{
+		{
+			name:    "nil_existing",
+			entries: map[[32]byte]*mempoolEntry{{0x01}: nil},
+			want:    "nil mempool entry",
+		},
+		{
+			name:    "zero_txid",
+			entries: map[[32]byte]*mempoolEntry{{0x02}: {fee: 10, weight: 1, size: 1, admissionSeq: 1}},
+			want:    "invalid mempool entry txid",
+		},
+		{
+			name: "zero_size",
+			entries: map[[32]byte]*mempoolEntry{
+				{0x03}: {txid: [32]byte{0x03}, fee: 10, weight: 1, admissionSeq: 1},
+			},
+			want: "invalid mempool entry size",
+		},
+		{
+			name: "zero_weight",
+			entries: map[[32]byte]*mempoolEntry{
+				{0x04}: {txid: [32]byte{0x04}, fee: 10, size: 1, admissionSeq: 1},
+			},
+			want: "invalid mempool entry weight",
+		},
+		{
+			name: "zero_admission_seq",
+			entries: map[[32]byte]*mempoolEntry{
+				{0x05}: {txid: [32]byte{0x05}, fee: 10, weight: 1, size: 1},
+			},
+			want: "invalid mempool entry admission_seq",
+		},
+		{
+			name: "duplicate_admission_seq",
+			entries: map[[32]byte]*mempoolEntry{
+				{0x06}: validExisting([32]byte{0x06}, 1),
+				{0x07}: validExisting([32]byte{0x07}, 1),
+			},
+			want: "duplicate mempool entry admission_seq",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mp := &Mempool{
+				maxTxs:    1,
+				maxBytes:  100,
+				usedBytes: len(tc.entries),
+				txs:       tc.entries,
+			}
+			_, _, err := mp.capacityEvictionPlanLocked(validCandidate)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected %q rejection, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+func TestMempoolAddEntryLockedCapacityPlanRejectsWithoutMutation(t *testing.T) {
+	badResidentID := [32]byte{0x30}
+	mp := &Mempool{
+		maxTxs:    1,
+		maxBytes:  100,
+		usedBytes: 1,
+		txs: map[[32]byte]*mempoolEntry{
+			badResidentID: {
+				txid:         badResidentID,
+				fee:          10,
+				size:         1,
+				admissionSeq: 1,
+			},
+		},
+	}
+	err := mp.addEntryLocked(&mempoolEntry{
+		txid:   [32]byte{0x31},
+		fee:    10,
+		weight: 1,
+		size:   1,
+	})
+	if err == nil || !strings.Contains(err.Error(), "invalid mempool entry weight") {
+		t.Fatalf("expected capacity plan metadata rejection, got %v", err)
+	}
+	if len(mp.txs) != 1 || mp.txs[badResidentID] == nil || mp.wtxids != nil || mp.spenders != nil || mp.lastAdmissionSeq != 0 || mp.currentMinFeeRate != 0 || mp.usedBytes != 1 {
+		t.Fatalf("capacity-plan error mutated mempool: len=%d wtxids=%v spenders=%v seq=%d floor=%d used=%d", len(mp.txs), mp.wtxids != nil, mp.spenders != nil, mp.lastAdmissionSeq, mp.currentMinFeeRate, mp.usedBytes)
+	}
+}
+
+func TestMempoolAddEntryLockedCandidateWorstRejectsWithoutMutation(t *testing.T) {
+	mp := &Mempool{maxTxs: 1, maxBytes: 100}
+	resident := &mempoolEntry{
+		txid:   [32]byte{0x41},
+		fee:    100,
+		weight: 1,
+		size:   1,
+	}
+	if err := mp.addEntryLocked(resident); err != nil {
+		t.Fatalf("addEntryLocked(resident): %v", err)
+	}
+	before, err := snapshotMempool(mp)
+	if err != nil {
+		t.Fatalf("snapshot before direct candidate-worst: %v", err)
+	}
+	err = mp.addEntryLocked(&mempoolEntry{
+		txid:   [32]byte{0x42},
+		fee:    1,
+		weight: 1,
+		size:   1,
+	})
+	if err == nil || !strings.Contains(err.Error(), "mempool capacity candidate rejected by eviction ordering") {
+		t.Fatalf("expected direct candidate-worst rejection, got %v", err)
+	}
+	after, err := snapshotMempool(mp)
+	if err != nil {
+		t.Fatalf("snapshot after direct candidate-worst: %v", err)
+	}
+	if !reflect.DeepEqual(after, before) {
+		t.Fatalf("direct candidate-worst mutated mempool: before=%+v after=%+v", before, after)
+	}
+}
+
 func TestMempoolRejectsZeroWeightMetadata(t *testing.T) {
 	mp := &Mempool{maxTxs: 10, maxBytes: 100}
 	err := mp.validateAdmissionLocked(&mempoolEntry{

--- a/clients/go/node/p2p/handlers_tx_test.go
+++ b/clients/go/node/p2p/handlers_tx_test.go
@@ -87,13 +87,13 @@ func signedCanonicalP2PTxWithoutSeeding(t *testing.T, nonce uint64) ([]byte, [32
 	toKey := mustP2PMLDSA87Keypair(t)
 	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
 	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
-	utxos, outpoints := testP2PUtxoSet(fromAddress, []uint64{100})
+	utxos, outpoints := testP2PUtxoSet(fromAddress, []uint64{1_000_000})
 	for op, entry := range utxos {
 		entry.CreatedByCoinbase = false
 		entry.CreationHeight = 0
 		utxos[op] = entry
 	}
-	txBytes := mustBuildSignedP2PTx(t, utxos, []consensus.Outpoint{outpoints[0]}, 90, 1, nonce, fromKey, fromAddress, toAddress)
+	txBytes := mustBuildSignedP2PTx(t, utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 100_000, nonce, fromKey, fromAddress, toAddress)
 	txid, err := canonicalTxID(txBytes)
 	if err != nil {
 		t.Fatalf("canonicalTxID: %v", err)

--- a/clients/go/node/policy_core_ext_runtime_coverage_test.go
+++ b/clients/go/node/policy_core_ext_runtime_coverage_test.go
@@ -163,7 +163,7 @@ func TestRuntimeCoreExtPolicyFromStaticProfileProvider(t *testing.T) {
 	t.Run("MempoolAcceptsActiveCoreExtOutput", func(t *testing.T) {
 		fromKey := mustNodeMLDSA87Keypair(t)
 		fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
-		st, outpoints := testSpendableChainState(fromAddress, []uint64{100})
+		st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000})
 
 		// activation_height = 0 makes the profile ACTIVE from genesis, so the
 		// next-block height passes the activation gate.
@@ -176,7 +176,7 @@ func TestRuntimeCoreExtPolicyFromStaticProfileProvider(t *testing.T) {
 			t.Fatalf("NewMempoolWithConfig: %v", err)
 		}
 
-		txBytes := mustBuildSignedCoreExtOutputTx(t, st.Utxos, outpoints[0], 90, 1, 1, fromKey, fromAddress, extID)
+		txBytes := mustBuildSignedCoreExtOutputTx(t, st.Utxos, outpoints[0], 100_000, 100_000, 1, fromKey, fromAddress, extID)
 		if err := mp.AddTx(txBytes); err != nil {
 			t.Fatalf("expected ACTIVE-profile CORE_EXT output admission, got %v", err)
 		}
@@ -345,7 +345,7 @@ func TestRuntimeCoreExtPolicyFromStaticProfileProvider(t *testing.T) {
 
 		fromKey := mustNodeMLDSA87Keypair(t)
 		fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
-		st, outpoints := testSpendableChainState(fromAddress, []uint64{100})
+		st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000})
 		st.HasTip = true
 		st.Height = 100
 		st.TipHash = tipHash
@@ -373,7 +373,7 @@ func TestRuntimeCoreExtPolicyFromStaticProfileProvider(t *testing.T) {
 		}
 		syncEngine.SetMempool(mp)
 
-		txBytes := mustBuildSignedCoreExtOutputTx(t, st.Utxos, outpoints[0], 90, 1, 1, fromKey, fromAddress, extID)
+		txBytes := mustBuildSignedCoreExtOutputTx(t, st.Utxos, outpoints[0], 100_000, 100_000, 1, fromKey, fromAddress, extID)
 		if err := mp.AddTx(txBytes); err != nil {
 			t.Fatalf("mp.AddTx (ACTIVE CORE_EXT): %v", err)
 		}

--- a/clients/go/node/runtime_perf_baseline_test.go
+++ b/clients/go/node/runtime_perf_baseline_test.go
@@ -194,7 +194,7 @@ func TestMempoolAddTxPreservesBaseChainState(t *testing.T) {
 	toKey := mustBenchmarkNodeMLDSA87Keypair(t)
 	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
 	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
-	state, outpoints := benchmarkSpendableChainState(fromAddress, []uint64{100})
+	state, outpoints := benchmarkSpendableChainState(fromAddress, []uint64{1_000_000})
 	before := snapshotChainState(t, state)
 	mp, err := NewMempool(state, nil, devnetGenesisChainID)
 	if err != nil {
@@ -204,8 +204,8 @@ func TestMempoolAddTxPreservesBaseChainState(t *testing.T) {
 		t,
 		state.Utxos,
 		[]consensus.Outpoint{outpoints[0]},
-		90,
-		1,
+		100_000,
+		100_000,
 		1,
 		fromKey,
 		fromAddress,
@@ -250,7 +250,7 @@ func TestMempoolAddTxDaCommitPreservesBaseChainState(t *testing.T) {
 	toKey := mustBenchmarkNodeMLDSA87Keypair(t)
 	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
 	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
-	state, outpoints := benchmarkSpendableChainState(fromAddress, []uint64{100})
+	state, outpoints := benchmarkSpendableChainState(fromAddress, []uint64{1_000_000})
 	before := snapshotChainState(t, state)
 	mp, err := NewMempoolWithConfig(state, nil, devnetGenesisChainID, MempoolConfig{
 		PolicyDaSurchargePerByte: 1,
@@ -262,8 +262,8 @@ func TestMempoolAddTxDaCommitPreservesBaseChainState(t *testing.T) {
 		t,
 		state.Utxos,
 		outpoints[0],
-		80,
-		10,
+		100_000,
+		900_000,
 		1,
 		fromKey,
 		toAddress,
@@ -278,7 +278,7 @@ func TestMempoolAddTxDaCommitPreservesBaseChainState(t *testing.T) {
 func TestMempoolAddTxCoreExtPreservesBaseChainState(t *testing.T) {
 	fromKey := mustBenchmarkNodeMLDSA87Keypair(t)
 	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
-	state, outpoints := benchmarkSpendableChainState(fromAddress, []uint64{100})
+	state, outpoints := benchmarkSpendableChainState(fromAddress, []uint64{1_000_000})
 	before := snapshotChainState(t, state)
 	mp, err := NewMempoolWithConfig(state, nil, devnetGenesisChainID, MempoolConfig{
 		PolicyRejectCoreExtPreActivation: true,
@@ -291,8 +291,8 @@ func TestMempoolAddTxCoreExtPreservesBaseChainState(t *testing.T) {
 		t,
 		state.Utxos,
 		outpoints[0],
-		90,
-		1,
+		100_000,
+		100_000,
 		1,
 		fromKey,
 		fromAddress,
@@ -309,13 +309,13 @@ func BenchmarkMempoolAddTx(b *testing.B) {
 	toKey := mustBenchmarkNodeMLDSA87Keypair(b)
 	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
 	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
-	state, outpoints := benchmarkSpendableChainState(fromAddress, []uint64{100})
+	state, outpoints := benchmarkSpendableChainState(fromAddress, []uint64{1_000_000})
 	txBytes := mustBenchmarkSignedTransferTx(
 		b,
 		state.Utxos,
 		[]consensus.Outpoint{outpoints[0]},
-		90,
-		1,
+		100_000,
+		100_000,
 		1,
 		fromKey,
 		fromAddress,

--- a/clients/go/node/sync.go
+++ b/clients/go/node/sync.go
@@ -697,11 +697,8 @@ func (s *SyncEngine) applyCanonicalParsedBlockTracked(
 
 	s.recordAppliedBlock(summary.BlockHeight, pb.Header.Timestamp)
 	if s.mempool != nil {
-		if err := s.mempool.EvictConfirmedParsed(pb); err != nil {
-			_, _ = fmt.Fprintf(s.stderr, "mempool: evict-confirmed: %v\n", err)
-		}
-		if err := s.mempool.RemoveConflictingParsed(pb); err != nil {
-			_, _ = fmt.Fprintf(s.stderr, "mempool: remove-conflicting: %v\n", err)
+		if err := s.mempool.applyConnectedBlockParsed(pb); err != nil {
+			_, _ = fmt.Fprintf(s.stderr, "mempool: apply-connected-block: %v\n", err)
 		}
 	}
 	return summary, blockApplyMetricAccepted, nil

--- a/clients/go/node/sync_mempool.go
+++ b/clients/go/node/sync_mempool.go
@@ -127,11 +127,11 @@ func validateMempoolSnapshotEntry(entry mempoolEntry) error {
 		return fmt.Errorf("invalid mempool snapshot entry weight for txid %x: %w", entry.txid, err)
 	}
 	if entry.weight != weight {
-		return fmt.Errorf("mempool snapshot entry weight mismatch: entry=%d raw=%d txid=%x", entry.weight, weight, entry.txid)
+		return fmt.Errorf("mempool snapshot entry weight mismatch: entry=%d computed=%d txid=%x", entry.weight, weight, entry.txid)
 	}
 	if entry.admissionSeq == 0 {
 		return fmt.Errorf("invalid mempool snapshot entry admission_seq for txid %x: seq=0", entry.txid)
-	}
+		}
 	if !validMempoolTxSource(entry.source) {
 		return fmt.Errorf("invalid mempool snapshot entry source for txid %x: source=%q", entry.txid, entry.source)
 	}

--- a/clients/go/node/sync_mempool.go
+++ b/clients/go/node/sync_mempool.go
@@ -9,8 +9,9 @@ import (
 )
 
 type mempoolSnapshot struct {
-	entries          []mempoolEntry
-	lastAdmissionSeq uint64
+	entries           []mempoolEntry
+	lastAdmissionSeq  uint64
+	currentMinFeeRate uint64
 }
 
 func snapshotMempool(m *Mempool) (mempoolSnapshot, error) {
@@ -26,7 +27,11 @@ func snapshotMempool(m *Mempool) (mempoolSnapshot, error) {
 	sort.Slice(entries, func(i, j int) bool {
 		return bytes.Compare(entries[i].txid[:], entries[j].txid[:]) < 0
 	})
-	return mempoolSnapshot{entries: entries, lastAdmissionSeq: m.lastAdmissionSeq}, nil
+	currentMinFeeRate := m.currentMinFeeRate
+	if currentMinFeeRate < DefaultMempoolMinFeeRate {
+		currentMinFeeRate = DefaultMempoolMinFeeRate
+	}
+	return mempoolSnapshot{entries: entries, lastAdmissionSeq: m.lastAdmissionSeq, currentMinFeeRate: currentMinFeeRate}, nil
 }
 
 func restoreMempoolSnapshot(m *Mempool, snapshot mempoolSnapshot) error {
@@ -89,12 +94,17 @@ func restoreMempoolSnapshot(m *Mempool, snapshot mempoolSnapshot) error {
 	m.spenders = spenders
 	m.usedBytes = usedBytes
 	m.lastAdmissionSeq = snapshot.lastAdmissionSeq
+	m.currentMinFeeRate = snapshot.currentMinFeeRate
+	m.ensureMinFeeRateLocked()
 	return nil
 }
 
 func validateMempoolSnapshotEntry(entry mempoolEntry) error {
 	if entry.size <= 0 {
 		return fmt.Errorf("invalid mempool snapshot entry size for txid %x: size=%d raw_len=%d", entry.txid, entry.size, len(entry.raw))
+	}
+	if entry.weight == 0 {
+		return fmt.Errorf("invalid mempool snapshot entry weight for txid %x: weight=0", entry.txid)
 	}
 	if entry.size != len(entry.raw) {
 		return fmt.Errorf("mempool snapshot entry size mismatch for txid %x: size=%d raw_len=%d", entry.txid, entry.size, len(entry.raw))
@@ -111,6 +121,13 @@ func validateMempoolSnapshotEntry(entry mempoolEntry) error {
 	}
 	if wtxid != entry.wtxid {
 		return fmt.Errorf("mempool snapshot entry wtxid mismatch: entry=%x raw=%x", entry.wtxid, wtxid)
+	}
+	weight, _, _, err := consensus.TxWeightAndStats(tx)
+	if err != nil {
+		return fmt.Errorf("invalid mempool snapshot entry weight for txid %x: %w", entry.txid, err)
+	}
+	if entry.weight != weight {
+		return fmt.Errorf("mempool snapshot entry weight mismatch: entry=%d raw=%d txid=%x", entry.weight, weight, entry.txid)
 	}
 	if entry.admissionSeq == 0 {
 		return fmt.Errorf("invalid mempool snapshot entry admission_seq for txid %x: seq=0", entry.txid)

--- a/clients/go/node/sync_mempool.go
+++ b/clients/go/node/sync_mempool.go
@@ -131,7 +131,7 @@ func validateMempoolSnapshotEntry(entry mempoolEntry) error {
 	}
 	if entry.admissionSeq == 0 {
 		return fmt.Errorf("invalid mempool snapshot entry admission_seq for txid %x: seq=0", entry.txid)
-		}
+	}
 	if !validMempoolTxSource(entry.source) {
 		return fmt.Errorf("invalid mempool snapshot entry source for txid %x: source=%q", entry.txid, entry.source)
 	}

--- a/clients/go/node/sync_reorg_test.go
+++ b/clients/go/node/sync_reorg_test.go
@@ -530,7 +530,7 @@ func TestApplyBlockWithReorgRequeuesDisconnectedTransactionsIntoMempool(t *testi
 		engine.chainState.Utxos,
 		[]consensus.Outpoint{sourceOutpoint},
 		700,
-		50,
+		100_000,
 		1,
 		sourceKP,
 		sourceAddress,
@@ -547,7 +547,7 @@ func TestApplyBlockWithReorgRequeuesDisconnectedTransactionsIntoMempool(t *testi
 		prevHash,
 		target,
 		202,
-		reorgTestCoinbaseForWtxids(t, 101, subsidyA101+50, sourceAddress, [][32]byte{{}, spendWtxid}),
+		reorgTestCoinbaseForWtxids(t, 101, subsidyA101+100_000, sourceAddress, [][32]byte{{}, spendWtxid}),
 		spendTx,
 	)
 	summaryA101, err := engine.ApplyBlock(blockA101, nil)
@@ -617,14 +617,14 @@ func TestNativeSuitesCacheInvalidatedOnReorg(t *testing.T) {
 	sourceOutpointB := consensus.Outpoint{Txid: [32]byte{0x22}, Vout: 0}
 	utxos := map[consensus.Outpoint]consensus.UtxoEntry{
 		sourceOutpointA: {
-			Value:             750,
+			Value:             1_000_000,
 			CovenantType:      consensus.COV_TYPE_P2PK,
 			CovenantData:      append([]byte(nil), sourceAddressA...),
 			CreationHeight:    0,
 			CreatedByCoinbase: false,
 		},
 		sourceOutpointB: {
-			Value:             730,
+			Value:             1_000_000,
 			CovenantType:      consensus.COV_TYPE_P2PK,
 			CovenantData:      append([]byte(nil), sourceAddressB...),
 			CreationHeight:    0,
@@ -637,7 +637,7 @@ func TestNativeSuitesCacheInvalidatedOnReorg(t *testing.T) {
 		utxos,
 		[]consensus.Outpoint{sourceOutpointA},
 		680,
-		50,
+		100_000,
 		1,
 		sourceKPA,
 		sourceAddressA,
@@ -648,7 +648,7 @@ func TestNativeSuitesCacheInvalidatedOnReorg(t *testing.T) {
 		utxos,
 		[]consensus.Outpoint{sourceOutpointB},
 		665,
-		50,
+		100_000,
 		2,
 		sourceKPB,
 		sourceAddressB,
@@ -690,7 +690,7 @@ func TestNativeSuitesCacheInvalidatedOnReorg(t *testing.T) {
 		devnetGenesisBlockHash,
 		target,
 		reorgTestTimestamp(1),
-		reorgTestCoinbaseForWtxids(t, 1, subsidy1+50, sourceAddressA, [][32]byte{{}, blockASpendWtxid}),
+		reorgTestCoinbaseForWtxids(t, 1, subsidy1+100_000, sourceAddressA, [][32]byte{{}, blockASpendWtxid}),
 		blockASpend,
 	)
 	summaryA1, err := engine.ApplyBlock(blockA1, nil)
@@ -707,7 +707,7 @@ func TestNativeSuitesCacheInvalidatedOnReorg(t *testing.T) {
 		devnetGenesisBlockHash,
 		target,
 		reorgTestTimestamp(2),
-		reorgTestCoinbaseForWtxids(t, 1, subsidy1+50, destAddressB, [][32]byte{{}, blockBSpendWtxid}),
+		reorgTestCoinbaseForWtxids(t, 1, subsidy1+100_000, destAddressB, [][32]byte{{}, blockBSpendWtxid}),
 		blockBSpend,
 	)
 	if _, err := engine.ApplyBlockWithReorg(blockB1, nil); err != nil {
@@ -790,7 +790,7 @@ func TestApplyBlockWithReorgRollbackRestoresMempoolAfterPersistFailure(t *testin
 		engine.chainState.Utxos,
 		[]consensus.Outpoint{sourceOutpoint},
 		700,
-		50,
+		100_000,
 		1,
 		sourceKP,
 		sourceAddress,
@@ -820,7 +820,7 @@ func TestApplyBlockWithReorgRollbackRestoresMempoolAfterPersistFailure(t *testin
 		prevHash,
 		target,
 		203,
-		reorgTestCoinbaseForWtxids(t, 101, subsidyB101+50, destAddress, [][32]byte{{}, spendWtxid}),
+		reorgTestCoinbaseForWtxids(t, 101, subsidyB101+100_000, destAddress, [][32]byte{{}, spendWtxid}),
 		spendTx,
 	)
 	if _, err := engine.ApplyBlockWithReorg(blockB101, nil); err != nil {

--- a/clients/go/node/sync_reorg_test.go
+++ b/clients/go/node/sync_reorg_test.go
@@ -588,6 +588,98 @@ func TestApplyBlockWithReorgRequeuesDisconnectedTransactionsIntoMempool(t *testi
 	}
 }
 
+func TestApplyBlockDecaysMempoolFloorAfterConflictRemoval(t *testing.T) {
+	engine, store, target := newReorgTestEngine(t)
+
+	sourceKP := mustReorgMLDSA87Keypair(t)
+	destKP := mustReorgMLDSA87Keypair(t)
+	sourceAddress := consensus.P2PKCovenantDataForPubkey(sourceKP.PubkeyBytes())
+	destAddress := consensus.P2PKCovenantDataForPubkey(destKP.PubkeyBytes())
+
+	prevHash := devnetGenesisBlockHash
+	alreadyGenerated := uint64(0)
+	var sourceOutpoint consensus.Outpoint
+	for height := uint64(1); height <= 100; height++ {
+		subsidy := consensus.BlockSubsidy(height, alreadyGenerated)
+		coinbase := reorgTestCoinbaseForAddress(t, height, subsidy, sourceAddress)
+		block := buildSingleTxBlock(t, prevHash, target, height+1, coinbase)
+		summary, err := engine.ApplyBlock(block, nil)
+		if err != nil {
+			t.Fatalf("ApplyBlock(height=%d): %v", height, err)
+		}
+		if height == 1 {
+			_, coinbaseTxid, _, _, err := consensus.ParseTx(coinbase)
+			if err != nil {
+				t.Fatalf("ParseTx(coinbase height1): %v", err)
+			}
+			sourceOutpoint = consensus.Outpoint{Txid: coinbaseTxid, Vout: 0}
+		}
+		prevHash = summary.BlockHash
+		alreadyGenerated += subsidy
+	}
+
+	blockTx := mustBuildSignedTransferTxForSyncTest(
+		t,
+		engine.chainState.Utxos,
+		[]consensus.Outpoint{sourceOutpoint},
+		700,
+		100_000,
+		1,
+		sourceKP,
+		sourceAddress,
+		destAddress,
+	)
+	conflictingTx := mustBuildSignedTransferTxForSyncTest(
+		t,
+		engine.chainState.Utxos,
+		[]consensus.Outpoint{sourceOutpoint},
+		690,
+		100_000,
+		2,
+		sourceKP,
+		sourceAddress,
+		destAddress,
+	)
+	mempool, err := NewMempoolWithConfig(engine.chainState, store, devnetGenesisChainID, MempoolConfig{
+		MaxTransactions: 10,
+		MaxBytes:        len(conflictingTx),
+	})
+	if err != nil {
+		t.Fatalf("NewMempoolWithConfig: %v", err)
+	}
+	engine.SetMempool(mempool)
+	if err := mempool.AddTx(conflictingTx); err != nil {
+		t.Fatalf("AddTx(conflicting): %v", err)
+	}
+	mempool.currentMinFeeRate = 8
+	if mempool.usedBytes < mempool.effectiveLowWaterBytesLocked() {
+		t.Fatalf("test setup usedBytes=%d below lowWater=%d before block apply", mempool.usedBytes, mempool.effectiveLowWaterBytesLocked())
+	}
+
+	_, _, blockWtxid, _, err := consensus.ParseTx(blockTx)
+	if err != nil {
+		t.Fatalf("ParseTx(blockTx): %v", err)
+	}
+	subsidy := consensus.BlockSubsidy(101, alreadyGenerated)
+	block := buildMultiTxBlock(
+		t,
+		prevHash,
+		target,
+		202,
+		reorgTestCoinbaseForWtxids(t, 101, subsidy+100_000, sourceAddress, [][32]byte{{}, blockWtxid}),
+		blockTx,
+	)
+	if _, err := engine.ApplyBlock(block, nil); err != nil {
+		t.Fatalf("ApplyBlock(conflicting connected block): %v", err)
+	}
+	if got := mempool.Len(); got != 0 {
+		t.Fatalf("mempool len after conflict removal=%d, want 0", got)
+	}
+	if got := mempool.currentMinFeeRate; got != 4 {
+		t.Fatalf("currentMinFeeRate after connected block conflict removal=%d, want 4", got)
+	}
+}
+
 type countingRotationProvider struct {
 	suiteID    uint8
 	spendCalls int

--- a/clients/rust/crates/rubin-node/src/txpool.rs
+++ b/clients/rust/crates/rubin-node/src/txpool.rs
@@ -46,13 +46,11 @@ struct WorstEntryKey {
     txid: [u8; 32],
     fee: u64,
     weight: u64,
-    size: usize,
     heap_id: u64,
 }
 
 struct AdmitPriority<'a> {
     fee: u64,
-    size: usize,
     weight: u64,
     tie: &'a [u8],
 }
@@ -62,13 +60,11 @@ impl Ord for WorstEntryKey {
         compare_priority_values(
             AdmitPriority {
                 fee: other.fee,
-                size: other.size,
                 weight: other.weight,
                 tie: &other.txid,
             },
             AdmitPriority {
                 fee: self.fee,
-                size: self.size,
                 weight: self.weight,
                 tie: &self.txid,
             },
@@ -383,7 +379,6 @@ impl TxPool {
             txid,
             fee: entry.fee,
             weight: entry.weight,
-            size: entry.size,
             heap_id,
         });
         self.txs.insert(txid, entry);
@@ -442,7 +437,6 @@ impl TxPool {
                 txid: *txid,
                 fee: entry.fee,
                 weight: entry.weight,
-                size: entry.size,
                 heap_id,
             });
         }
@@ -792,13 +786,11 @@ fn compare_admit_priority(
     compare_priority_values(
         AdmitPriority {
             fee: a.fee,
-            size: a.size,
             weight: a.weight,
             tie: &txid_a,
         },
         AdmitPriority {
             fee: b.fee,
-            size: b.size,
             weight: b.weight,
             tie: &txid_b,
         },
@@ -806,7 +798,7 @@ fn compare_admit_priority(
 }
 
 fn compare_priority_values(a: AdmitPriority<'_>, b: AdmitPriority<'_>) -> Ordering {
-    match compare_fee_rate_values(a.fee, a.size, b.fee, b.size) {
+    match compare_fee_rate_values(a.fee, a.weight, b.fee, b.weight) {
         Ordering::Equal => match a.fee.cmp(&b.fee) {
             Ordering::Equal => match b.weight.cmp(&a.weight) {
                 Ordering::Equal => b.tie.cmp(a.tie),
@@ -819,7 +811,7 @@ fn compare_priority_values(a: AdmitPriority<'_>, b: AdmitPriority<'_>) -> Orderi
 }
 
 fn compare_fee_rate(a: &TxPoolEntry, b: &TxPoolEntry) -> Ordering {
-    compare_fee_rate_values(a.fee, a.size, b.fee, b.size)
+    compare_fee_rate_values(a.fee, a.weight, b.fee, b.weight)
 }
 
 fn estimate_tx_fee(tx: &Tx, utxos: &HashMap<Outpoint, UtxoEntry>) -> Option<u64> {
@@ -841,12 +833,12 @@ fn estimate_tx_fee(tx: &Tx, utxos: &HashMap<Outpoint, UtxoEntry>) -> Option<u64>
     u64::try_from(fee).ok()
 }
 
-fn compare_fee_rate_values(fee_a: u64, size_a: usize, fee_b: u64, size_b: usize) -> Ordering {
-    if size_a == 0 || size_b == 0 {
+fn compare_fee_rate_values(fee_a: u64, weight_a: u64, fee_b: u64, weight_b: u64) -> Ordering {
+    if weight_a == 0 || weight_b == 0 {
         return Ordering::Equal;
     }
-    let left = u128::from(fee_a) * (size_b as u128);
-    let right = u128::from(fee_b) * (size_a as u128);
+    let left = u128::from(fee_a) * u128::from(weight_b);
+    let right = u128::from(fee_b) * u128::from(weight_a);
     left.cmp(&right)
 }
 
@@ -1520,7 +1512,45 @@ mod tests {
         );
 
         let selected = pool.select_transactions(3, 40);
-        assert_eq!(selected, vec![vec![0x33], vec![0x22], vec![0x11]]);
+        assert_eq!(selected, vec![vec![0x11], vec![0x33], vec![0x22]]);
+    }
+
+    #[test]
+    fn txpool_fee_rate_uses_weight_not_size() {
+        let size_favored = TxPoolEntry {
+            raw: vec![0x41],
+            inputs: Vec::new(),
+            fee: 4,
+            weight: 4,
+            size: 1,
+        };
+        let weight_favored = TxPoolEntry {
+            raw: vec![0x21],
+            inputs: Vec::new(),
+            fee: 2,
+            weight: 1,
+            size: 1,
+        };
+
+        assert_eq!(
+            compare_fee_rate(&size_favored, &weight_favored),
+            Ordering::Less,
+            "fee/weight must rank 2/1 above 4/4 even when fee/size favors 4/1",
+        );
+        assert_eq!(
+            compare_admit_priority([0x41; 32], &size_favored, [0x21; 32], &weight_favored),
+            Ordering::Less,
+        );
+
+        let size_favored_txid: [u8; 32] = [0x41; 32];
+        let weight_favored_txid: [u8; 32] = [0x21; 32];
+        assert_eq!(
+            compare_entries_for_mining(
+                &(&weight_favored_txid, &weight_favored),
+                &(&size_favored_txid, &size_favored),
+            ),
+            Ordering::Less,
+        );
     }
 
     #[test]
@@ -1633,13 +1663,13 @@ mod tests {
     }
 
     #[test]
-    fn mining_sort_helpers_cover_zero_size_and_tiebreaks() {
+    fn mining_sort_helpers_cover_zero_weight_and_tiebreaks() {
         let zero = TxPoolEntry {
             raw: vec![0x00],
             inputs: Vec::new(),
             fee: 10,
-            weight: 10,
-            size: 0,
+            weight: 0,
+            size: 10,
         };
         let normal = TxPoolEntry {
             raw: vec![0x01],

--- a/scripts/devnet-rpc-parity-smoke.sh
+++ b/scripts/devnet-rpc-parity-smoke.sh
@@ -22,6 +22,7 @@ KEYGEN_JSON="${TMP_ROOT}/key_material.json"
 GO_RPC_ADDR="${GO_RPC_ADDR:-127.0.0.1:0}"
 RUST_RPC_ADDR="${RUST_RPC_ADDR:-127.0.0.1:0}"
 DETERMINISTIC_TX_FEE=10000
+RPC_REQUEST_TIMEOUT_SECONDS="${RPC_REQUEST_TIMEOUT_SECONDS:-10}"
 
 PIDS=()
 
@@ -90,13 +91,14 @@ wait_for_rpc_height() {
   local timeout="$2"
   local deadline=$((SECONDS + timeout))
   while (( SECONDS < deadline )); do
-    if python3 - "${rpc_addr}" 2>/dev/null <<'PY'
+    if python3 - "${rpc_addr}" "${RPC_REQUEST_TIMEOUT_SECONDS}" 2>/dev/null <<'PY'
 import json
 import sys
 import urllib.request
 
 rpc_addr = sys.argv[1]
-with urllib.request.urlopen(f"http://{rpc_addr}/get_tip", timeout=2) as resp:
+request_timeout = float(sys.argv[2])
+with urllib.request.urlopen(f"http://{rpc_addr}/get_tip", timeout=request_timeout) as resp:
     if resp.status != 200:
         raise SystemExit(1)
     data = json.load(resp)
@@ -109,32 +111,37 @@ PY
     fi
     sleep 1
   done
-  echo "timeout waiting for /get_tip on ${rpc_addr}" >&2
+  echo "timeout waiting for /get_tip on ${rpc_addr} after ${timeout}s (request_timeout=${RPC_REQUEST_TIMEOUT_SECONDS}s)" >&2
   return 1
 }
 
 read_tip_tsv() {
   local rpc_addr="$1"
-  python3 - "${rpc_addr}" <<'PY'
+  python3 - "${rpc_addr}" "${RPC_REQUEST_TIMEOUT_SECONDS}" <<'PY'
 import json
 import sys
 import urllib.request
 
 rpc_addr = sys.argv[1]
-with urllib.request.urlopen(f"http://{rpc_addr}/get_tip", timeout=2) as resp:
-    data = json.load(resp)
+request_timeout = float(sys.argv[2])
+try:
+    with urllib.request.urlopen(f"http://{rpc_addr}/get_tip", timeout=request_timeout) as resp:
+        data = json.load(resp)
+except Exception as exc:
+    raise SystemExit(f"/get_tip request failed for {rpc_addr} with request_timeout={request_timeout}s: {exc}")
 print(data["height"], data["tip_hash"], sep="\t")
 PY
 }
 
 check_metrics() {
   local rpc_addr="$1"
-  python3 - "${rpc_addr}" <<'PY'
+  python3 - "${rpc_addr}" "${RPC_REQUEST_TIMEOUT_SECONDS}" <<'PY'
 import re
 import sys
 import urllib.request
 
 rpc_addr = sys.argv[1]
+request_timeout = float(sys.argv[2])
 expected = {
     "rubin_node_tip_height",
     "rubin_node_best_known_height",
@@ -144,10 +151,13 @@ expected = {
     "rubin_node_rpc_requests_total",
     "rubin_node_submit_tx_total",
 }
-with urllib.request.urlopen(f"http://{rpc_addr}/metrics", timeout=2) as resp:
-    if resp.status != 200:
-        raise SystemExit(1)
-    body = resp.read().decode("utf-8")
+try:
+    with urllib.request.urlopen(f"http://{rpc_addr}/metrics", timeout=request_timeout) as resp:
+        if resp.status != 200:
+            raise SystemExit(f"/metrics returned status={resp.status} for {rpc_addr} with request_timeout={request_timeout}s")
+        body = resp.read().decode("utf-8")
+except Exception as exc:
+    raise SystemExit(f"/metrics request failed for {rpc_addr} with request_timeout={request_timeout}s: {exc}")
 names = set()
 for line in body.splitlines():
     line = line.strip()

--- a/scripts/devnet-rpc-parity-smoke.sh
+++ b/scripts/devnet-rpc-parity-smoke.sh
@@ -21,6 +21,7 @@ KEYGEN_JSON="${TMP_ROOT}/key_material.json"
 
 GO_RPC_ADDR="${GO_RPC_ADDR:-127.0.0.1:0}"
 RUST_RPC_ADDR="${RUST_RPC_ADDR:-127.0.0.1:0}"
+DETERMINISTIC_TX_FEE=10000
 
 PIDS=()
 
@@ -265,8 +266,12 @@ GO_TX_HEX="$("${GO_TXGEN_BIN}" \
   --from-key "${FROM_DER_HEX}" \
   --to-key "${TO_ADDRESS_HEX}" \
   --amount 1 \
-  --fee 1 \
+  --fee "${DETERMINISTIC_TX_FEE}" \
   --submit-to "${GO_RPC_ADDR}")"
+if [[ -z "${GO_TX_HEX}" ]]; then
+  echo "go txgen produced empty tx hex" >&2
+  exit 1
+fi
 
 echo "Submitting deterministic tx against Rust RPC"
 RUST_TX_HEX="$("${GO_TXGEN_BIN}" \
@@ -274,8 +279,12 @@ RUST_TX_HEX="$("${GO_TXGEN_BIN}" \
   --from-key "${FROM_DER_HEX}" \
   --to-key "${TO_ADDRESS_HEX}" \
   --amount 1 \
-  --fee 1 \
+  --fee "${DETERMINISTIC_TX_FEE}" \
   --submit-to "${RUST_RPC_ADDR}")"
+if [[ -z "${RUST_TX_HEX}" ]]; then
+  echo "rust txgen produced empty tx hex" >&2
+  exit 1
+fi
 
 check_metrics "${GO_RPC_ADDR}"
 check_metrics "${RUST_RPC_ADDR}"


### PR DESCRIPTION
Refs: Q-GO-MEMPOOL-FEE-EVICTION-ROLLING-FLOOR-01

## Summary
Closes #1336.

Architecture class: B.

System boundary: Go standard mempool admission/eviction path plus Rust txpool fee-rate comparator parity.

Single coupled invariant: rolling-floor-bounded no-RBF capacity admission.

Consensus rules unchanged: YES

SECTION_HASHES.json unchanged: YES

## Scope
This PR adds Go mempool fee/weight capacity eviction ordering, candidate-worst no-mutation rejection, and a rolling mempool floor that rises only after actual eviction and decays on connected-block low-water handling after confirmed and conflicting mempool removals for that block.

P2P admission policy: P2P-submitted transactions now enter the same canonical mempool relay minimum fee floor as other submit paths; this PR does not change P2P wire format or P2P handler implementation.

Reorg requeue policy: this PR does not add new reorg-requeue logic; existing reorg requeue uses the same canonical mempool admission floor as local and remote submit paths.

Rust scope: Rust txpool ordering now uses the same fee/weight comparator axis; this PR does not add Rust rolling-floor admission behavior.

Scope expanded test-only to update stale Go node, RPC, P2P, and devnet smoke accepted fixtures for the new relay fee floor; no RPC/P2P production handler implementation changed.

## Disposition
Go behavior changed: mempool admission/eviction policy and mempool mining selection now use the same fee/weight axis.

Rust changed: yes, txpool selection/admission comparator parity only.

Admission policy changed: yes, the relay minimum fee floor is enforced by the Go canonical mempool.

Eviction behavior changed: yes, full-pool capacity pressure evicts the worst entry by fee/weight ranking or rejects the candidate without mutation.

Non-goals: no new reorg requeue mechanism, no telemetry, no RPC/config surface, no conformance, no RBF/CPFP/package relay, no Rust rolling-floor implementation.

Verification: focused Go mempool tests, Rust txpool tests, package Go tests, go vet, devnet RPC parity smoke, go-deep tooling gate, common preflight, prior hostile review on a50341c, and controller-approved reviewer bypass for the latest narrow fix-pass.
