### PR TITLE
ci: define fuzz crash promotion flow

### DIFF
--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -46,6 +46,7 @@ jobs:
           path: |
             .artifacts/fuzz-stage2/**
             clients/go/consensus/testdata/fuzz/**
+          include-hidden-files: true
           if-no-files-found: warn
           retention-days: 14
 
@@ -76,10 +77,41 @@ jobs:
         env:
           RUST_FUZZ_TIME: ${{ github.event.inputs.rust_fuzz_time || '60' }}
         run: |
+          quote_env_value() {
+            local value="$1"
+            printf "'"
+            printf '%s' "$value" | sed "s/'/'\"'\"'/g"
+            printf "'"
+          }
+
+          write_env_field() {
+            local key="$1"
+            local value="$2"
+            printf '%s=%s\n' "$key" "$(quote_env_value "$value")"
+          }
+
+          RUST_ARTIFACTS_DIR="$GITHUB_WORKSPACE/.artifacts/fuzz-rust"
+          mkdir -p "$RUST_ARTIFACTS_DIR"
           cd clients/rust
           TARGETS=(merkle_determinism retarget_no_panic biguint_roundtrip sighash parse_tx parse_block_bytes compactsize validate_block_basic pow_check compact_shortid parse_htlc parse_vault parse_multisig fork_work block_subsidy covenant_genesis p2p_wire_message p2p_version_payload sig_verify_openssl sig_cache_structural connect_block_inmem da_chunk_hash_verify tx_dep_graph da_payload_commit_verify tx_relay_announce tx_relay_receive)
+          {
+            write_env_field "commit_sha" "${GITHUB_SHA}"
+            write_env_field "workflow_run_id" "${GITHUB_RUN_ID}"
+            write_env_field "workflow_run_attempt" "${GITHUB_RUN_ATTEMPT}"
+            write_env_field "rust_fuzz_time" "${RUST_FUZZ_TIME}"
+            write_env_field "artifact_dir" ".artifacts/fuzz-rust"
+            write_env_field "mutation_policy" "manual-only; ci does not commit, push, regenerate tracked fixtures, or open issues"
+            write_env_field "promotion_docs" "conformance/README.md#fuzz-crash-promotion-manual-only"
+          } > "$RUST_ARTIFACTS_DIR/run-metadata.env"
           STATUS=0
           for target in "${TARGETS[@]}"; do
+            {
+              write_env_field "commit_sha" "${GITHUB_SHA}"
+              write_env_field "target" "${target}"
+              write_env_field "artifacts_path" "clients/rust/fuzz/artifacts/${target}"
+              write_env_field "corpus_path" "clients/rust/fuzz/corpus/${target}"
+              write_env_field "command" "cd clients/rust && cargo fuzz run \"${target}\" -- -max_total_time=\"${RUST_FUZZ_TIME}\""
+            } > "$RUST_ARTIFACTS_DIR/${target}.metadata.env"
             echo "==> fuzzing $target for ${RUST_FUZZ_TIME}s"
             if ! cargo fuzz run "$target" -- -max_total_time="${RUST_FUZZ_TIME}"; then
               STATUS=1
@@ -95,6 +127,9 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: fuzz-rust-${{ github.run_id }}
-          path: clients/rust/fuzz/artifacts/
+          path: |
+            .artifacts/fuzz-rust/**
+            clients/rust/fuzz/artifacts/
+          include-hidden-files: true
           if-no-files-found: warn
           retention-days: 14

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -100,3 +100,60 @@ Guard-проверка (CI):
 ```bash
 scripts/dev-env.sh -- python3 tools/check_conformance_fixtures_policy.py
 ```
+
+## Fuzz crash promotion (manual-only)
+
+Nightly fuzz jobs are discovery jobs only. They upload crash artifacts and
+metadata for manual triage; CI MUST NOT commit, push, regenerate fixtures, or
+open issues automatically.
+
+Each fuzz artifact bundle must include enough metadata to reproduce a crash:
+
+- target name;
+- seed, corpus, or crash artifact path;
+- exact local command;
+- commit SHA;
+- workflow run id/attempt when produced by GitHub Actions.
+
+Per-target metadata uses explicit path keys:
+
+- Go metadata includes `corpus_path`, `artifacts_path`, and legacy `seed_path`.
+  The Go fuzz engine stores committed corpus inputs and crash/minimized outputs
+  under the same target directory, so all three keys point to
+  `clients/go/<package>/testdata/fuzz/<FuzzTarget>/`.
+- Rust metadata includes `corpus_path` for committed seed promotion and
+  `artifacts_path` for crash artifacts under `clients/rust/fuzz/artifacts/`.
+
+Manual promotion flow:
+
+1. Download the failed workflow artifact and read its `run-metadata.env` plus the
+   matching `<target>.metadata.env`.
+   Metadata files are shell-quoted dotenv files, so they can be inspected as
+   text or sourced by a local shell without executing command field contents.
+   Go consensus fuzz files are uploaded directly under
+   `clients/go/consensus/testdata/fuzz/**`. Go `node/p2p` fuzz files are in
+   `.artifacts/fuzz-stage2/go-fuzz-testdata.tgz`; extract that archive before
+   following a `clients/go/node/p2p/testdata/fuzz/<FuzzTarget>/` metadata path.
+2. Reproduce the crash at the recorded commit SHA using the recorded command.
+   For Go targets this is the `go test -run=^$ -fuzz=...` command under
+   `clients/go`; for Rust targets this is the `cargo fuzz run ...` command under
+   `clients/rust`.
+3. Dedup before opening or updating an issue: check existing committed fuzz
+   seeds/tests, open issues, and recent nightly failures for the same target and
+   crash signature.
+4. Promote only a reproduced protocol crash. Add the minimized input as a
+   committed regression seed or a focused regression test in the target's normal
+   test surface. Do not promote one-off infrastructure flakes.
+5. Close the issue only after the PR contains either the committed seed/test that
+   fails before the fix and passes after it, or explicit false-positive evidence
+   explaining why no protocol regression exists.
+
+Manual seed destinations:
+
+- Go fuzz seeds: `clients/go/<package>/testdata/fuzz/<FuzzTarget>/`
+- Rust fuzz seeds: `clients/rust/fuzz/corpus/<target>/`. That corpus directory
+  is gitignored by default, so commit selected regression seeds with
+  `git add -f clients/rust/fuzz/corpus/<target>/<seed-file>`.
+
+Fuzz artifact upload alone is not a regression closeout. It is only triage
+evidence until a human reproduction and seed/test promotion decision exists.

--- a/scripts/ci/run_fuzz_stage2.sh
+++ b/scripts/ci/run_fuzz_stage2.sh
@@ -41,6 +41,36 @@ TARGETS=(
   "./node/p2p:FuzzDecodeVersionPayload"
 )
 
+usage() {
+  cat <<USAGE
+Usage: scripts/ci/run_fuzz_stage2.sh
+
+Runs the bounded Go stage2 fuzz target list and writes reproducibility metadata
+under .artifacts/fuzz-stage2/. The script does not commit, push, regenerate
+tracked fixtures, or open issues.
+
+Environment:
+  FUZZ_TIME=${FUZZ_TIME}
+  FUZZ_MINIMIZE_TIME=${FUZZ_MINIMIZE_TIME}
+
+Artifact metadata includes:
+  commit SHA, package, target, corpus/artifact paths, command, log path.
+USAGE
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+if (($# > 0)); then
+  echo "FAIL: unexpected arguments: $*" >&2
+  usage >&2
+  exit 2
+fi
+
+COMMIT_SHA="${GITHUB_SHA:-$(git -C "${ROOT_DIR}" rev-parse HEAD 2>/dev/null || printf '%s' unknown)}"
+
 mkdir -p "${ARTIFACTS_DIR}"
 STATUS=0
 
@@ -61,12 +91,79 @@ collect_artifacts() {
   fi
 }
 
+seed_path_for_pkg() {
+  local pkg="$1"
+  local target="$2"
+
+  case "${pkg}" in
+    ./consensus)
+      printf 'clients/go/consensus/testdata/fuzz/%s\n' "${target}"
+      ;;
+    ./node/p2p)
+      printf 'clients/go/node/p2p/testdata/fuzz/%s\n' "${target}"
+      ;;
+    *)
+      printf 'clients/go/%s/testdata/fuzz/%s\n' "${pkg#./}" "${target}"
+      ;;
+  esac
+}
+
+quote_env_value() {
+  local value="$1"
+  printf "'"
+  printf '%s' "${value}" | sed "s/'/'\"'\"'/g"
+  printf "'"
+}
+
+write_env_field() {
+  local key="$1"
+  local value="$2"
+  printf '%s=%s\n' "${key}" "$(quote_env_value "${value}")"
+}
+
+write_run_metadata() {
+  {
+    write_env_field "commit_sha" "${COMMIT_SHA}"
+    write_env_field "workflow_run_id" "${GITHUB_RUN_ID:-local}"
+    write_env_field "workflow_run_attempt" "${GITHUB_RUN_ATTEMPT:-local}"
+    write_env_field "fuzz_time" "${FUZZ_TIME}"
+    write_env_field "fuzz_minimize_time" "${FUZZ_MINIMIZE_TIME}"
+    write_env_field "artifact_dir" ".artifacts/fuzz-stage2"
+    write_env_field "mutation_policy" "manual-only; ci does not commit, push, regenerate tracked fixtures, or open issues"
+    write_env_field "promotion_docs" "conformance/README.md#fuzz-crash-promotion-manual-only"
+  } > "${ARTIFACTS_DIR}/run-metadata.env"
+}
+
+write_target_metadata() {
+  local pkg="$1"
+  local target="$2"
+  local metadata_file="${ARTIFACTS_DIR}/${target}.metadata.env"
+  local artifacts_path
+  local corpus_path
+  corpus_path="$(seed_path_for_pkg "${pkg}" "${target}")"
+  artifacts_path="${corpus_path}"
+
+  {
+    write_env_field "commit_sha" "${COMMIT_SHA}"
+    write_env_field "package" "${pkg}"
+    write_env_field "target" "${target}"
+    write_env_field "corpus_path" "${corpus_path}"
+    write_env_field "artifacts_path" "${artifacts_path}"
+    write_env_field "seed_path" "${corpus_path}"
+    write_env_field "command" "cd clients/go && go test -run=^$ -fuzz=\"${target}\" -fuzztime=\"${FUZZ_TIME}\" -fuzzminimizetime=\"${FUZZ_MINIMIZE_TIME}\" \"${pkg}\""
+    write_env_field "log_path" ".artifacts/fuzz-stage2/${target}.log"
+  } > "${metadata_file}"
+}
+
 trap collect_artifacts EXIT
+write_run_metadata
 
 {
   echo "fuzz stage2 started at: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo "commit sha: ${COMMIT_SHA}"
   echo "fuzz time per target: ${FUZZ_TIME}"
   echo "fuzz minimize time: ${FUZZ_MINIMIZE_TIME}"
+  echo "metadata: ${ARTIFACTS_DIR}/run-metadata.env"
 } > "${ARTIFACTS_DIR}/summary.log"
 
 cd "${GO_DIR}"
@@ -75,7 +172,9 @@ for spec in "${TARGETS[@]}"; do
   pkg="${spec%%:*}"
   target="${spec##*:}"
   log_file="${ARTIFACTS_DIR}/${target}.log"
+  write_target_metadata "${pkg}" "${target}"
   echo "==> running ${target} (${pkg})" | tee -a "${ARTIFACTS_DIR}/summary.log"
+  echo "metadata ${target}: ${ARTIFACTS_DIR}/${target}.metadata.env" >> "${ARTIFACTS_DIR}/summary.log"
   if ! go test -run=^$ -fuzz="${target}" -fuzztime="${FUZZ_TIME}" -fuzzminimizetime="${FUZZ_MINIMIZE_TIME}" "${pkg}" >"${log_file}" 2>&1; then
     STATUS=1
     echo "FAIL ${target}" | tee -a "${ARTIFACTS_DIR}/summary.log"


### PR DESCRIPTION
## Summary

Defines the manual fuzz crash artifact -> committed regression seed/test promotion flow for Q-FUZZ-REGRESSION-SEED-PROMOTION-01.

Architecture class: B

System boundary: fuzz-nightly artifact metadata, Go stage2 fuzz artifact collection, and focused conformance README promotion docs.

Single invariant or contract delta: nightly fuzz artifacts include enough metadata for a human to reproduce and manually promote real crashes into committed regression seeds/tests or documented false-positive closeout, without CI mutating repo files.

## Changes

- `.github/workflows/fuzz-nightly.yml`: writes shell-quoted Rust fuzz run/target metadata under `.artifacts/fuzz-rust/**` and keeps artifact upload on `if: always()`.
- `scripts/ci/run_fuzz_stage2.sh`: writes shell-quoted Go run/target metadata under `.artifacts/fuzz-stage2/**`, adds `--help`, and rejects unexpected script args.
- `conformance/README.md`: documents manual promotion steps: crash -> reproduce -> dedup -> seed/test or false-positive evidence -> issue closeout.

## Non-goals

- No new fuzz targets.
- No runtime fixes.
- No automatic commit/push of fuzz artifacts.
- No automatic issue creation.
- No conformance fixture semantic changes.
- No performance workflow changes.

What this PR is NOT allowed to redesign: Go/Rust runtime semantics, fuzz target inventory, conformance fixture semantics, performance workflows, queue/closeout policy, automatic issue creation, automatic seed commit/push, or CI lifecycle architecture.

Class-change stop rule: stop and split if this requires new fuzz targets, runtime fixes, fixture changes, auto issue bot, auto seed commit/push, or new CI architecture.

## Validation

- Neon wide-context preflight recorded for Q-FUZZ-REGRESSION-SEED-PROMOTION-01 with matrices: memory id `10638`.
- `bash -n scripts/ci/run_fuzz_stage2.sh`
- `shellcheck scripts/ci/run_fuzz_stage2.sh`
- `scripts/dev-env.sh -- bash -lc 'FUZZ_TIME=1s FUZZ_MINIMIZE_TIME=1s scripts/ci/run_fuzz_stage2.sh --help'`
- Ruby YAML parse for `.github/workflows/fuzz-nightly.yml`
- Extracted Rust workflow shell block parsed with `bash -n`.
- Go induced failure smoke with fake `go`: metadata artifacts were written, and sourcing fields containing single quote, semicolon, and `&&` did not execute payload contents.
- Rust induced failure smoke with fake `cargo`: metadata artifacts were written, source smoke did not execute payload contents, and Rust target metadata used `artifacts_path`/`corpus_path` without `seed_path`.
- Static scan found no `git add`, `git commit`, `git push`, `gh issue`, or `gh pr` mutation commands in touched workflow/script/docs.
- `git diff --check`
- `rubin-quality-gate receipt`: PASS for fix-pass dirty diff.
- `rubin-common-preflight` with `RUBIN_CODACY_COVERAGE_SKIP=NO_COVERAGE_SURFACE`: `PASS_WITH_COVERAGE_SKIP` on commit `7ea5f0c`; coverage lane `SKIPPED` with `authorization=EXPLICIT_NO_COVERAGE_SURFACE`.
- Hostile review `REQ-20260430T163650Z-7ea5f0c-prepush-stale-remote`: PASS.
- `cl push -u origin HEAD`: PASS, job `20260430T164228Z-77978-16850a9c`.

## Notes

- `actionlint` was not available locally or in `scripts/dev-env.sh`; workflow sanity was checked with Ruby YAML parsing plus extracted shell `bash -n`.
- Full nightly fuzz was not run; this PR changes metadata/docs/manual promotion flow only.

Closes #1361

<!-- rubin-agent-meta actor=Codex action=pr-update via=gh branch=codex/q1361-fuzz-regression-seed-promotion wt=rubin-protocol-codex-q1361 utc=2026-04-30T16:43:30Z -->
