### PR TITLE
node: enforce reorg requeue admission order (#1337)

### DIFF
--- a/clients/go/node/mempool_test.go
+++ b/clients/go/node/mempool_test.go
@@ -310,6 +310,10 @@ func TestMempoolEvictionComparatorTiers(t *testing.T) {
 	if !evictionPlanEntryWorse(local, remote) {
 		t.Fatal("source provenance unexpectedly affected eviction ordering before deterministic txid tie-break")
 	}
+	reorg := mempoolEvictionPlanEntry{entry: &mempoolEntry{txid: [32]byte{0x0a}, fee: 3, weight: 3, size: 1, admissionSeq: 7, source: mempoolTxSourceReorg}}
+	if !evictionPlanEntryWorse(reorg, remote) {
+		t.Fatal("reorg source provenance unexpectedly affected eviction ordering before deterministic txid tie-break")
+	}
 }
 
 func TestMempoolFeeRateComparatorUsesWeightAndDoesNotOverflow(t *testing.T) {
@@ -2107,6 +2111,100 @@ func TestMempoolAddReorgTxUsesRollingFloor(t *testing.T) {
 	}
 	if got := mp.currentMinFeeRate; got != 8 {
 		t.Fatalf("currentMinFeeRate after reorg floor reject=%d, want 8", got)
+	}
+}
+
+func TestMempoolAddReorgTxUsesNormalCapacityAdmission(t *testing.T) {
+	fromKey := mustNodeMLDSA87Keypair(t)
+	toKey := mustNodeMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000, 1_000_000})
+
+	resident := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 300_000, 1, fromKey, fromAddress, toAddress)
+	lowerReorg := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[1]}, 100_000, 100_000, 2, fromKey, fromAddress, toAddress)
+	betterReorg := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[1]}, 100_000, 400_000, 3, fromKey, fromAddress, toAddress)
+	mp, err := NewMempoolWithConfig(st, nil, devnetGenesisChainID, MempoolConfig{MaxTransactions: 1, MaxBytes: 1 << 20})
+	if err != nil {
+		t.Fatalf("new mempool: %v", err)
+	}
+	if err := mp.AddTx(resident); err != nil {
+		t.Fatalf("AddTx(resident): %v", err)
+	}
+	before, err := snapshotMempool(mp)
+	if err != nil {
+		t.Fatalf("snapshot before lower reorg: %v", err)
+	}
+
+	err = mp.AddReorgTx(lowerReorg)
+	var admitErr *TxAdmitError
+	if !errors.As(err, &admitErr) || admitErr.Kind != TxAdmitUnavailable {
+		t.Fatalf("lower AddReorgTx err=%T %v, want TxAdmitUnavailable", err, err)
+	}
+	if !strings.Contains(err.Error(), "mempool capacity candidate rejected by eviction ordering") {
+		t.Fatalf("lower AddReorgTx error=%v, want capacity candidate rejection", err)
+	}
+	afterReject, err := snapshotMempool(mp)
+	if err != nil {
+		t.Fatalf("snapshot after lower reorg: %v", err)
+	}
+	if !reflect.DeepEqual(afterReject, before) {
+		t.Fatalf("lower reorg candidate mutated mempool: before=%+v after=%+v", before, afterReject)
+	}
+	if mp.Contains(txID(t, lowerReorg)) {
+		t.Fatalf("lower reorg candidate entered mempool")
+	}
+
+	if err := mp.AddReorgTx(betterReorg); err != nil {
+		t.Fatalf("AddReorgTx(better): %v", err)
+	}
+	if mp.Contains(txID(t, resident)) {
+		t.Fatalf("normal capacity admission kept lower-priority resident")
+	}
+	betterEntry := mp.txs[txID(t, betterReorg)]
+	if betterEntry == nil {
+		t.Fatalf("better reorg candidate missing after normal admission")
+	}
+	if betterEntry.source != mempoolTxSourceReorg {
+		t.Fatalf("better reorg source=%q, want %q", betterEntry.source, mempoolTxSourceReorg)
+	}
+}
+
+func TestMempoolAddReorgTxRejectsConflictBeforeEviction(t *testing.T) {
+	fromKey := mustNodeMLDSA87Keypair(t)
+	toKey := mustNodeMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000})
+
+	resident := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 200_000, 1, fromKey, fromAddress, toAddress)
+	conflictingReorg := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 400_000, 2, fromKey, fromAddress, toAddress)
+	mp, err := NewMempoolWithConfig(st, nil, devnetGenesisChainID, MempoolConfig{MaxTransactions: 1, MaxBytes: 1 << 20})
+	if err != nil {
+		t.Fatalf("new mempool: %v", err)
+	}
+	if err := mp.AddTx(resident); err != nil {
+		t.Fatalf("AddTx(resident): %v", err)
+	}
+	before, err := snapshotMempool(mp)
+	if err != nil {
+		t.Fatalf("snapshot before conflicting reorg: %v", err)
+	}
+
+	err = mp.AddReorgTx(conflictingReorg)
+	var admitErr *TxAdmitError
+	if !errors.As(err, &admitErr) || admitErr.Kind != TxAdmitConflict {
+		t.Fatalf("conflicting AddReorgTx err=%T %v, want TxAdmitConflict", err, err)
+	}
+	after, err := snapshotMempool(mp)
+	if err != nil {
+		t.Fatalf("snapshot after conflicting reorg: %v", err)
+	}
+	if !reflect.DeepEqual(after, before) {
+		t.Fatalf("conflicting reorg tx mutated mempool: before=%+v after=%+v", before, after)
+	}
+	if mp.Contains(txID(t, conflictingReorg)) {
+		t.Fatalf("conflicting reorg tx entered mempool")
 	}
 }
 

--- a/clients/go/node/sync_reorg.go
+++ b/clients/go/node/sync_reorg.go
@@ -273,7 +273,8 @@ func (s *SyncEngine) requeueDisconnectedTransactions(disconnectedBlocks [][]byte
 	if s == nil || s.mempool == nil || len(disconnectedBlocks) == 0 {
 		return
 	}
-	for blockIndex := len(disconnectedBlocks) - 1; blockIndex >= 0; blockIndex-- {
+	// Disconnect helpers append blocks tip-down, matching h_max -> h_min requeue order.
+	for blockIndex := 0; blockIndex < len(disconnectedBlocks); blockIndex++ {
 		txs, err := nonCoinbaseBlockTransactions(disconnectedBlocks[blockIndex])
 		if err != nil {
 			continue

--- a/clients/go/node/sync_reorg_test.go
+++ b/clients/go/node/sync_reorg_test.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"bytes"
 	"encoding/hex"
 	"errors"
 	"os"
@@ -585,6 +586,151 @@ func TestApplyBlockWithReorgRequeuesDisconnectedTransactionsIntoMempool(t *testi
 	}
 	if engine.chainState.TipHash == summaryA101.BlockHash {
 		t.Fatalf("tip hash still points to old branch")
+	}
+}
+
+func TestRequeueDisconnectedTransactionsUsesTipDownOrderAndContinuesAfterReject(t *testing.T) {
+	fromKey := mustReorgMLDSA87Keypair(t)
+	toKey := mustReorgMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{
+		1_000_000,
+		1_000_000,
+		1_000_000,
+		1_000_000,
+	})
+	mempool, err := NewMempool(st, nil, devnetGenesisChainID)
+	if err != nil {
+		t.Fatalf("NewMempool: %v", err)
+	}
+	var stderr bytes.Buffer
+	engine := &SyncEngine{mempool: mempool, stderr: &stderr}
+
+	txHighFirst := mustBuildSignedTransferTxForSyncTest(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 200_000, 1, fromKey, fromAddress, toAddress)
+	txRejectedDuplicate := mustBuildSignedTransferTxForSyncTest(t, st.Utxos, []consensus.Outpoint{outpoints[1]}, 100_000, 200_000, 2, fromKey, fromAddress, toAddress)
+	txHighAfterReject := mustBuildSignedTransferTxForSyncTest(t, st.Utxos, []consensus.Outpoint{outpoints[2]}, 100_000, 200_000, 3, fromKey, fromAddress, toAddress)
+	txLow := mustBuildSignedTransferTxForSyncTest(t, st.Utxos, []consensus.Outpoint{outpoints[3]}, 100_000, 200_000, 4, fromKey, fromAddress, toAddress)
+	if err := mempool.AddTx(txRejectedDuplicate); err != nil {
+		t.Fatalf("AddTx(duplicate setup): %v", err)
+	}
+	seqBeforeRequeue := mempool.lastAdmissionSeq
+
+	_, _, highFirstWtxid, _, err := consensus.ParseTx(txHighFirst)
+	if err != nil {
+		t.Fatalf("ParseTx(txHighFirst): %v", err)
+	}
+	_, _, rejectedWtxid, _, err := consensus.ParseTx(txRejectedDuplicate)
+	if err != nil {
+		t.Fatalf("ParseTx(txRejectedDuplicate): %v", err)
+	}
+	_, _, highAfterWtxid, _, err := consensus.ParseTx(txHighAfterReject)
+	if err != nil {
+		t.Fatalf("ParseTx(txHighAfterReject): %v", err)
+	}
+	_, _, lowWtxid, _, err := consensus.ParseTx(txLow)
+	if err != nil {
+		t.Fatalf("ParseTx(txLow): %v", err)
+	}
+
+	blockHigh := buildMultiTxBlock(
+		t,
+		[32]byte{0xa1},
+		consensus.POW_LIMIT,
+		reorgTestTimestamp(202),
+		reorgTestCoinbaseForWtxids(t, 202, consensus.BlockSubsidy(202, 0)+600_000, fromAddress, [][32]byte{{}, highFirstWtxid, rejectedWtxid, highAfterWtxid}),
+		txHighFirst,
+		txRejectedDuplicate,
+		txHighAfterReject,
+	)
+	blockLow := buildMultiTxBlock(
+		t,
+		[32]byte{0xa0},
+		consensus.POW_LIMIT,
+		reorgTestTimestamp(201),
+		reorgTestCoinbaseForWtxids(t, 201, consensus.BlockSubsidy(201, 0)+200_000, fromAddress, [][32]byte{{}, lowWtxid}),
+		txLow,
+	)
+
+	engine.requeueDisconnectedTransactions([][]byte{blockHigh, blockLow})
+
+	if !strings.Contains(stderr.String(), "mempool: requeue-tx:") {
+		t.Fatalf("expected duplicate requeue rejection to be logged, got %q", stderr.String())
+	}
+	for _, tc := range []struct {
+		name string
+		tx   []byte
+		seq  uint64
+	}{
+		{name: "high_first", tx: txHighFirst, seq: seqBeforeRequeue + 1},
+		{name: "high_after_reject", tx: txHighAfterReject, seq: seqBeforeRequeue + 2},
+		{name: "low", tx: txLow, seq: seqBeforeRequeue + 3},
+	} {
+		txid := txID(t, tc.tx)
+		entry := mempool.txs[txid]
+		if entry == nil {
+			t.Fatalf("%s requeued tx %x missing", tc.name, txid)
+		}
+		if entry.source != mempoolTxSourceReorg {
+			t.Fatalf("%s source=%q, want %q", tc.name, entry.source, mempoolTxSourceReorg)
+		}
+		if entry.admissionSeq != tc.seq {
+			t.Fatalf("%s admissionSeq=%d, want %d", tc.name, entry.admissionSeq, tc.seq)
+		}
+	}
+	duplicateEntry := mempool.txs[txID(t, txRejectedDuplicate)]
+	if duplicateEntry == nil {
+		t.Fatalf("duplicate setup tx missing after requeue")
+	}
+	if duplicateEntry.source != mempoolTxSourceLocal || duplicateEntry.admissionSeq != seqBeforeRequeue {
+		t.Fatalf("duplicate setup entry changed source/seq: source=%q seq=%d", duplicateEntry.source, duplicateEntry.admissionSeq)
+	}
+}
+
+func TestRequeueDisconnectedTransactionsUsesAdmissionFeeFloor(t *testing.T) {
+	fromKey := mustReorgMLDSA87Keypair(t)
+	toKey := mustReorgMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000})
+	mempool, err := NewMempool(st, nil, devnetGenesisChainID)
+	if err != nil {
+		t.Fatalf("NewMempool: %v", err)
+	}
+	mempool.currentMinFeeRate = 8
+	var stderr bytes.Buffer
+	engine := &SyncEngine{mempool: mempool, stderr: &stderr}
+
+	txBelowFloor := mustBuildSignedTransferTxForSyncTest(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 1, 1, fromKey, fromAddress, toAddress)
+	_, _, belowFloorWtxid, _, err := consensus.ParseTx(txBelowFloor)
+	if err != nil {
+		t.Fatalf("ParseTx(txBelowFloor): %v", err)
+	}
+	block := buildMultiTxBlock(
+		t,
+		[32]byte{0xb0},
+		consensus.POW_LIMIT,
+		reorgTestTimestamp(203),
+		reorgTestCoinbaseForWtxids(t, 203, consensus.BlockSubsidy(203, 0)+1, fromAddress, [][32]byte{{}, belowFloorWtxid}),
+		txBelowFloor,
+	)
+
+	engine.requeueDisconnectedTransactions([][]byte{block})
+
+	if !strings.Contains(stderr.String(), "mempool fee below rolling minimum") {
+		t.Fatalf("expected rolling-floor rejection in stderr, got %q", stderr.String())
+	}
+	if got := mempool.Len(); got != 0 {
+		t.Fatalf("mempool len after below-floor requeue=%d, want 0", got)
+	}
+	if mempool.Contains(txID(t, txBelowFloor)) {
+		t.Fatalf("below-floor requeue tx entered mempool")
+	}
+	if mempool.lastAdmissionSeq != 0 {
+		t.Fatalf("lastAdmissionSeq after below-floor requeue=%d, want 0", mempool.lastAdmissionSeq)
+	}
+	if got := mempool.currentMinFeeRate; got != 8 {
+		t.Fatalf("currentMinFeeRate after below-floor requeue=%d, want 8", got)
 	}
 }
 


### PR DESCRIPTION
## Scope

Closes #1337.

Architecture class: B.
System boundary: Go `SyncEngine` reorg requeue path and standard mempool admission tests.

Single invariant: disconnected non-coinbase txs are requeued best-effort through normal Go mempool admission in deterministic tip-down/block-body order, with no protected reorg priority, no fee-floor bypass, no conflict bypass, and no RBF.

Non-goals: no Rust changes; Rust parity is tracked by #1339. No conformance, P2P/RPC, telemetry, consensus, or mempool admission redesign.

## Disposition

- Requeue order now preserves the disconnected block order produced by the existing disconnect helpers.
- Requeue rejects continue with remaining txs.
- `source=reorg` is covered against fee-floor, conflict, capacity, and source-priority bypasses.
- Verification: focused Go reorg/mempool tests, package Go tests, `go vet`, `gofmt`, `git diff --check`, go-deep tooling gate, and hostile review PASS.
