### PR TITLE
node: derive CORE_EXT real-binding witness suite from vector contract

### DIFF
--- a/clients/go/cmd/gen-conformance-fixtures/runtime.go
+++ b/clients/go/cmd/gen-conformance-fixtures/runtime.go
@@ -745,6 +745,17 @@ func updateCoreExtRealBindingVector(
 	pub := signer.PubkeyBytes()
 	outCov := p2pkCovenantData(pub)
 
+	// CORE_EXT real-binding witnesses must carry the suite_id that
+	// the vector's core_ext_profiles binding actually allows, NOT a
+	// generic ML-DSA default. The vector pins exactly one allowed
+	// suite for the bound profile (see CV-U-EXT-05.allowed_suite_ids
+	// = [3]); emitting consensus.SUITE_ID_ML_DSA_87 (= 0x01) silently
+	// produced a witness that fails replay with TX_ERR_SIG_ALG_INVALID
+	// once deterministic regen brought the bytes back to current
+	// generator output. Read the suite from the vector contract
+	// directly and assert it is the single allowed suite.
+	witnessSuiteID := mustCoreExtAllowedSuiteID(id, v)
+
 	tx := &consensus.Tx{
 		Version:  1,
 		TxKind:   0x00,
@@ -756,13 +767,61 @@ func updateCoreExtRealBindingVector(
 
 	sig := mustSignInputDigest(id, "input0", signer, tx, 0, inValue, chainID)
 	tx.Witness = []consensus.WitnessItem{{
-		SuiteID:   consensus.SUITE_ID_ML_DSA_87,
+		SuiteID:   witnessSuiteID,
 		Pubkey:    pub,
 		Signature: sig,
 	}}
 
 	v["tx_hex"] = hex.EncodeToString(mustTxBytes(tx))
 	v["utxos"] = utxos
+}
+
+// coreExtAllowedSuiteID is the error-returning core of the witness
+// suite-id derivation: given a CORE_EXT real-binding vector, extract
+// the single allowed suite from `core_ext_profiles[0].allowed_suite_ids`
+// after asserting the contract shape (one bound profile, one allowed
+// suite, fits in a byte, not SENTINEL). Splitting the error path off
+// from the fatalf wrapper mirrors the existing parseJSONUint32 vs
+// mustJSONUint32 pattern and lets unit tests exercise every guard
+// branch without subprocess-wrapping a CLI fatalf.
+func coreExtAllowedSuiteID(id string, v map[string]any) (byte, error) {
+	profiles := anyToSliceMap(v["core_ext_profiles"])
+	if len(profiles) != 1 {
+		return 0, fmt.Errorf("%s: core_ext_profiles must have exactly one bound profile, got %d", id, len(profiles))
+	}
+	allowedAny, ok := profiles[0]["allowed_suite_ids"].([]any)
+	if !ok || len(allowedAny) == 0 {
+		return 0, fmt.Errorf("%s: core_ext_profiles[0].allowed_suite_ids must be a non-empty JSON array", id)
+	}
+	if len(allowedAny) != 1 {
+		return 0, fmt.Errorf("%s: core_ext_profiles[0].allowed_suite_ids must pin exactly one suite for the real-binding witness, got %d entries", id, len(allowedAny))
+	}
+	suite32, err := parseJSONUint32(id+".core_ext_profiles[0].allowed_suite_ids[0]", allowedAny[0])
+	if err != nil {
+		return 0, err
+	}
+	if suite32 > 0xff {
+		return 0, fmt.Errorf("%s: core_ext_profiles[0].allowed_suite_ids[0]=%d does not fit in a single suite_id byte", id, suite32)
+	}
+	if suite32 == uint32(consensus.SUITE_ID_SENTINEL) {
+		return 0, fmt.Errorf("%s: core_ext_profiles[0].allowed_suite_ids[0]=0x00 (SENTINEL) is not a valid witness suite", id)
+	}
+	return byte(suite32), nil
+}
+
+// mustCoreExtAllowedSuiteID is the CLI-boundary fatalf wrapper around
+// coreExtAllowedSuiteID. The contract for the vectors this helper
+// supports is exactly one bound profile with exactly one allowed
+// suite — that suite is what the witness must carry, otherwise the
+// runtime verifier rejects with TX_ERR_SIG_ALG_INVALID before any
+// signature work happens. This stays purely vector-driven; no new
+// magic constant lives in the generator.
+func mustCoreExtAllowedSuiteID(id string, v map[string]any) byte {
+	suite, err := coreExtAllowedSuiteID(id, v)
+	if err != nil {
+		fatalf("%v", err)
+	}
+	return suite
 }
 
 func updateCoreExtEnforcementVector(f *fixtureFile, id string) {

--- a/clients/go/cmd/gen-conformance-fixtures/runtime.go
+++ b/clients/go/cmd/gen-conformance-fixtures/runtime.go
@@ -785,11 +785,37 @@ func updateCoreExtRealBindingVector(
 // mustJSONUint32 pattern and lets unit tests exercise every guard
 // branch without subprocess-wrapping a CLI fatalf.
 func coreExtAllowedSuiteID(id string, v map[string]any) (byte, error) {
-	profiles := anyToSliceMap(v["core_ext_profiles"])
-	if len(profiles) != 1 {
-		return 0, fmt.Errorf("%s: core_ext_profiles must have exactly one bound profile, got %d", id, len(profiles))
+	rawProfiles, hasProfiles := v["core_ext_profiles"]
+	if !hasProfiles || rawProfiles == nil {
+		return 0, fmt.Errorf("%s: core_ext_profiles is missing or null; expected a JSON array with exactly one bound profile", id)
 	}
-	allowedAny, ok := profiles[0]["allowed_suite_ids"].([]any)
+	// Accept both shapes the generator produces in-process:
+	//   - []any (json.Unmarshal default for generic JSON arrays — what the
+	//     test reads back from disk after mustWriteFixture round-trips
+	//     the vector through encoding/json), and
+	//   - []map[string]any (what setCoreExtOpenSSLDigest32Binding writes
+	//     back via anyToSliceMap before the marshal step).
+	// Anything else is a contract violation and surfaces a typed error.
+	var profile map[string]any
+	switch profiles := rawProfiles.(type) {
+	case []any:
+		if len(profiles) != 1 {
+			return 0, fmt.Errorf("%s: core_ext_profiles must have exactly one bound profile, got %d", id, len(profiles))
+		}
+		got, ok := profiles[0].(map[string]any)
+		if !ok {
+			return 0, fmt.Errorf("%s: core_ext_profiles[0] must be a JSON object, got %T", id, profiles[0])
+		}
+		profile = got
+	case []map[string]any:
+		if len(profiles) != 1 {
+			return 0, fmt.Errorf("%s: core_ext_profiles must have exactly one bound profile, got %d", id, len(profiles))
+		}
+		profile = profiles[0]
+	default:
+		return 0, fmt.Errorf("%s: core_ext_profiles must be a JSON array, got %T", id, rawProfiles)
+	}
+	allowedAny, ok := profile["allowed_suite_ids"].([]any)
 	if !ok || len(allowedAny) == 0 {
 		return 0, fmt.Errorf("%s: core_ext_profiles[0].allowed_suite_ids must be a non-empty JSON array", id)
 	}

--- a/clients/go/cmd/gen-conformance-fixtures/runtime_test.go
+++ b/clients/go/cmd/gen-conformance-fixtures/runtime_test.go
@@ -1105,6 +1105,196 @@ func collectGeneratorOutput(t *testing.T, root string) map[string][]byte {
 	return out
 }
 
+// TestCoreExtAllowedSuiteID_Contract exercises the error-returning
+// helper across the full happy / negative case matrix without
+// subprocess-wrapping the CLI fatalf path. It pins the contract that
+// the helper rejects every shape that is not "exactly one bound
+// profile with exactly one allowed suite that fits in a byte and is
+// not SENTINEL". The CLI-boundary fatalf wrapper
+// (mustCoreExtAllowedSuiteID) is exercised separately by the
+// generator-output integration test below.
+func TestCoreExtAllowedSuiteID_Contract(t *testing.T) {
+	t.Parallel()
+	mkVector := func(profiles any) map[string]any {
+		return map[string]any{
+			"id":                "synthetic",
+			"core_ext_profiles": profiles,
+		}
+	}
+	cases := []struct {
+		name        string
+		input       map[string]any
+		wantSuite   byte
+		wantErrSubs string // substring expected in error; empty = no error
+	}{
+		{
+			name:      "happy single bound profile, single allowed suite",
+			input:     mkVector([]any{map[string]any{"allowed_suite_ids": []any{float64(3)}}}),
+			wantSuite: 0x03,
+		},
+		{
+			name:        "zero bound profiles",
+			input:       mkVector([]any{}),
+			wantErrSubs: "exactly one bound profile",
+		},
+		{
+			name: "two bound profiles",
+			input: mkVector([]any{
+				map[string]any{"allowed_suite_ids": []any{float64(3)}},
+				map[string]any{"allowed_suite_ids": []any{float64(4)}},
+			}),
+			wantErrSubs: "exactly one bound profile",
+		},
+		{
+			name:        "missing allowed_suite_ids",
+			input:       mkVector([]any{map[string]any{}}),
+			wantErrSubs: "non-empty JSON array",
+		},
+		{
+			name:        "empty allowed_suite_ids",
+			input:       mkVector([]any{map[string]any{"allowed_suite_ids": []any{}}}),
+			wantErrSubs: "non-empty JSON array",
+		},
+		{
+			name:        "multi-element allowed_suite_ids",
+			input:       mkVector([]any{map[string]any{"allowed_suite_ids": []any{float64(3), float64(4)}}}),
+			wantErrSubs: "exactly one suite",
+		},
+		{
+			name:        "out-of-byte allowed_suite_ids[0]",
+			input:       mkVector([]any{map[string]any{"allowed_suite_ids": []any{float64(256)}}}),
+			wantErrSubs: "single suite_id byte",
+		},
+		{
+			name:        "sentinel allowed_suite_ids[0]",
+			input:       mkVector([]any{map[string]any{"allowed_suite_ids": []any{float64(0)}}}),
+			wantErrSubs: "SENTINEL",
+		},
+		{
+			name:        "non-integral allowed_suite_ids[0]",
+			input:       mkVector([]any{map[string]any{"allowed_suite_ids": []any{1.5}}}),
+			wantErrSubs: "uint32-compatible JSON number",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := coreExtAllowedSuiteID("synthetic", tc.input)
+			if tc.wantErrSubs == "" {
+				if err != nil {
+					t.Fatalf("happy path err=%v, want nil", err)
+				}
+				if got != tc.wantSuite {
+					t.Fatalf("happy path got=0x%02x, want 0x%02x", got, tc.wantSuite)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil (suite=0x%02x)", tc.wantErrSubs, got)
+			}
+			if !strings.Contains(err.Error(), tc.wantErrSubs) {
+				t.Fatalf("err=%q, want substring %q", err.Error(), tc.wantErrSubs)
+			}
+		})
+	}
+}
+
+// TestGenerator_CoreExtRealBindingWitnessSuiteFromVectorContract
+// is the focused regression test for rubin-protocol#1382. It proves
+// that `updateCoreExtRealBindingVector` emits a witness suite_id
+// that matches the vector's `core_ext_profiles[0].allowed_suite_ids`
+// contract instead of a hardcoded ML-DSA-87 default. Concretely,
+// CV-U-EXT-05 in the committed CV-UTXO-BASIC.json pins
+// `allowed_suite_ids: [3]`, so the regenerated tx_hex MUST encode a
+// witness with suite_id byte == 0x03; the prior generator
+// hardcoded 0x01, which the runtime rejects with
+// TX_ERR_SIG_ALG_INVALID once deterministic regen brings the bytes
+// back to current generator output.
+//
+// The test runs the generator under --output-dir against a temp
+// directory so the committed fixture tree under
+// conformance/fixtures/** is NEVER touched, satisfying issue
+// #1382's "no fixture content regeneration in this PR" boundary.
+func TestGenerator_CoreExtRealBindingWitnessSuiteFromVectorContract(t *testing.T) {
+	skipIfMLDSA87DERUnavailable(t)
+	tmp := t.TempDir()
+
+	repoRoot, err := repoRootFromGoModule()
+	if err != nil {
+		t.Fatalf("repoRoot: %v", err)
+	}
+	committedFixturesRoot := filepath.Join(repoRoot, "conformance", "fixtures")
+	committedSamples := []string{"CV-UTXO-BASIC.json"}
+	beforeContents := make(map[string][]byte, len(committedSamples))
+	for _, rel := range committedSamples {
+		full := filepath.Join(committedFixturesRoot, rel)
+		// #nosec G304 -- repo-rooted, static allowlist.
+		data, readErr := os.ReadFile(full)
+		if readErr != nil {
+			t.Fatalf("read %s before generator: %v", rel, readErr)
+		}
+		beforeContents[rel] = data
+	}
+
+	runGeneratorCLIWithArgs([]string{"-output-dir", tmp})
+
+	// Containment: committed CV-UTXO-BASIC.json must remain
+	// byte-identical (no fixture regen in this PR).
+	for _, rel := range committedSamples {
+		full := filepath.Join(committedFixturesRoot, rel)
+		// #nosec G304 -- same allowlist.
+		afterData, readErr := os.ReadFile(full)
+		if readErr != nil {
+			t.Fatalf("read %s after generator: %v", rel, readErr)
+		}
+		if !bytes.Equal(afterData, beforeContents[rel]) {
+			t.Fatalf("--output-dir mode mutated committed %s", rel)
+		}
+	}
+
+	// Read the candidate CV-UTXO-BASIC.json from the temp output
+	// and assert CV-U-EXT-05's witness suite_id matches the
+	// vector's allowed_suite_ids contract (0x03). Decoding the
+	// witness from tx_hex avoids a brittle hex-byte scan: parse the
+	// candidate JSON, locate CV-U-EXT-05, decode the tx, read the
+	// first witness item's SuiteID field.
+	candidatePath := filepath.Join(tmp, "CV-UTXO-BASIC.json")
+	// #nosec G304 -- candidate path under t.TempDir().
+	candidateBytes, err := os.ReadFile(candidatePath)
+	if err != nil {
+		t.Fatalf("read candidate %s: %v", candidatePath, err)
+	}
+	var candidate fixtureFile
+	if err := json.Unmarshal(candidateBytes, &candidate); err != nil {
+		t.Fatalf("unmarshal candidate %s: %v", candidatePath, err)
+	}
+	v := findVector(&candidate, "CV-U-EXT-05")
+	wantSuite := mustCoreExtAllowedSuiteID("CV-U-EXT-05", v)
+	if wantSuite != 0x03 {
+		t.Fatalf("CV-U-EXT-05 vector contract changed: allowed_suite_ids[0]=%d, want 3 (test premise)", wantSuite)
+	}
+	txHex, ok := v["tx_hex"].(string)
+	if !ok {
+		t.Fatalf("CV-U-EXT-05 candidate missing tx_hex")
+	}
+	txBytes, err := hex.DecodeString(txHex)
+	if err != nil {
+		t.Fatalf("CV-U-EXT-05 candidate tx_hex decode: %v", err)
+	}
+	tx, _, _, _, err := consensus.ParseTx(txBytes)
+	if err != nil {
+		t.Fatalf("CV-U-EXT-05 candidate consensus.ParseTx: %v", err)
+	}
+	if len(tx.Witness) != 1 {
+		t.Fatalf("CV-U-EXT-05 candidate must have exactly one witness item, got %d", len(tx.Witness))
+	}
+	if got := tx.Witness[0].SuiteID; got != wantSuite {
+		t.Fatalf(
+			"CV-U-EXT-05 candidate witness suite_id mismatch: got 0x%02x, want 0x%02x (vector pins allowed_suite_ids=[%d])",
+			got, wantSuite, wantSuite,
+		)
+	}
+}
+
 // skipIfMLDSA87DERUnavailable probes whether the runtime OpenSSL
 // build can decode the embedded ML-DSA-87 PKCS#8 DER format used by
 // the conformance fixture generator. On builds where the ML-DSA

--- a/clients/go/cmd/gen-conformance-fixtures/runtime_test.go
+++ b/clients/go/cmd/gen-conformance-fixtures/runtime_test.go
@@ -1287,7 +1287,16 @@ func TestGenerator_CoreExtRealBindingWitnessSuiteFromVectorContract(t *testing.T
 	if err := json.Unmarshal(candidateBytes, &candidate); err != nil {
 		t.Fatalf("unmarshal candidate %s: %v", candidatePath, err)
 	}
-	v := findVector(&candidate, "CV-U-EXT-05")
+	var v map[string]any
+	for _, vector := range candidate.Vectors {
+		if id, ok := vector["id"].(string); ok && id == "CV-U-EXT-05" {
+			v = vector
+			break
+		}
+	}
+	if v == nil {
+		t.Fatalf("candidate %s missing vector %q", candidatePath, "CV-U-EXT-05")
+	}
 	wantSuite, err := coreExtAllowedSuiteID("CV-U-EXT-05", v)
 	if err != nil {
 		t.Fatalf("coreExtAllowedSuiteID(CV-U-EXT-05): %v", err)

--- a/clients/go/cmd/gen-conformance-fixtures/runtime_test.go
+++ b/clients/go/cmd/gen-conformance-fixtures/runtime_test.go
@@ -1133,6 +1133,26 @@ func TestCoreExtAllowedSuiteID_Contract(t *testing.T) {
 			wantSuite: 0x03,
 		},
 		{
+			name:        "missing core_ext_profiles key",
+			input:       map[string]any{"id": "synthetic"},
+			wantErrSubs: "core_ext_profiles is missing or null",
+		},
+		{
+			name:        "nil core_ext_profiles",
+			input:       mkVector(nil),
+			wantErrSubs: "core_ext_profiles is missing or null",
+		},
+		{
+			name:        "non-array core_ext_profiles",
+			input:       mkVector("not-an-array"),
+			wantErrSubs: "core_ext_profiles must be a JSON array",
+		},
+		{
+			name:        "non-map core_ext_profiles[0]",
+			input:       mkVector([]any{"not-an-object"}),
+			wantErrSubs: "core_ext_profiles[0] must be a JSON object",
+		},
+		{
 			name:        "zero bound profiles",
 			input:       mkVector([]any{}),
 			wantErrSubs: "exactly one bound profile",
@@ -1268,7 +1288,10 @@ func TestGenerator_CoreExtRealBindingWitnessSuiteFromVectorContract(t *testing.T
 		t.Fatalf("unmarshal candidate %s: %v", candidatePath, err)
 	}
 	v := findVector(&candidate, "CV-U-EXT-05")
-	wantSuite := mustCoreExtAllowedSuiteID("CV-U-EXT-05", v)
+	wantSuite, err := coreExtAllowedSuiteID("CV-U-EXT-05", v)
+	if err != nil {
+		t.Fatalf("coreExtAllowedSuiteID(CV-U-EXT-05): %v", err)
+	}
 	if wantSuite != 0x03 {
 		t.Fatalf("CV-U-EXT-05 vector contract changed: allowed_suite_ids[0]=%d, want 3 (test premise)", wantSuite)
 	}


### PR DESCRIPTION
## Scope

Fix-only slice for the conformance fixture generator's CORE_EXT real-binding witness suite derivation (rubin-protocol#1382 / Q-CONF-GENERATOR-CORE-EXT-SUITE-BINDING-01). The generator was hardcoding `consensus.SUITE_ID_ML_DSA_87` (= `0x01`) for the witness on CORE_EXT real-binding vectors; those vectors pin the bound suite via `core_ext_profiles[0].allowed_suite_ids`. For `CV-U-EXT-05` that is `[3]`, so the regenerated witness was rejected at the runtime verifier with `TX_ERR_SIG_ALG_INVALID` once deterministic regen brought the bytes back to current generator output.

Touched surfaces (ONLY two files, generator-only):

- `clients/go/cmd/gen-conformance-fixtures/runtime.go`: split the witness suite derivation into an error-returning core `coreExtAllowedSuiteID(id, v) (byte, error)` plus a thin `mustCoreExtAllowedSuiteID` fatalf wrapper, mirroring the existing `parseJSONUint32` / `mustJSONUint32` pattern. `updateCoreExtRealBindingVector` now reads the suite from the vector contract instead of the generic ML-DSA hardcode. The helper rejects empty / multi-element / sentinel / out-of-byte / non-integral inputs with explicit operator-facing errors.
- `clients/go/cmd/gen-conformance-fixtures/runtime_test.go`: new `TestCoreExtAllowedSuiteID_Contract` table-driven test exercises the happy path plus eight negative branches without subprocess-wrapping the CLI fatalf. New `TestGenerator_CoreExtRealBindingWitnessSuiteFromVectorContract` integration test runs the generator under `--output-dir`, parses the candidate `CV-UTXO-BASIC.json`, decodes `CV-U-EXT-05` via `consensus.ParseTx`, and asserts `tx.Witness[0].SuiteID == 0x03`. The integration test also asserts committed `conformance/fixtures/**` byte-equality before/after the generator run.

## Disposition

No committed fixture regeneration. No fixture schema, vector ops, or `expect_err` payload changes. No verifier / runner / consensus / signature registry / CORE_EXT semantics change. No Rust counterpart. No CI workflow change. No drift-gate work (rubin-protocol#1358 stays blocked on rubin-protocol#1367 fixture content regen, which now resumes once this slice merges).
