### PR TITLE
ci: add check-only conformance fixture drift gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -625,9 +625,59 @@ jobs:
           cd rubin-formal
           lake env lean --run RubinFormal/Refinement/Main.lean
 
+  conformance_fixtures_drift:
+    name: Conformance fixtures drift check
+    needs: policy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Cache OpenSSL 3.5 bundle
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: |
+            ~/.cache/rubin-openssl/bundle-3.5.5
+            ~/.cache/rubin-openssl/work/openssl-3.5.5.tar.gz
+          key: openssl-bundle-${{ runner.os }}-3.5.5-v2
+      - name: Build OpenSSL 3.5.5 bundle
+        run: |
+          set -euo pipefail
+          PREFIX="$HOME/.cache/rubin-openssl/bundle-3.5.5"
+          MODULES_DIR="$PREFIX/lib/ossl-modules"
+          if [ ! -d "$MODULES_DIR" ] && [ -d "$PREFIX/lib64/ossl-modules" ]; then
+            MODULES_DIR="$PREFIX/lib64/ossl-modules"
+          fi
+          if [ ! -x "$PREFIX/bin/openssl" ] || [ ! -f "$PREFIX/ssl/openssl-fips.cnf" ] || [ ! -d "$MODULES_DIR" ]; then
+            OPENSSL_VERSION=3.5.5 PREFIX="$PREFIX" bash scripts/crypto/openssl/build-openssl-bundle.sh
+          fi
+          if [ -d "$PREFIX/lib/ossl-modules" ]; then
+            MODULES_DIR="$PREFIX/lib/ossl-modules"
+          elif [ -d "$PREFIX/lib64/ossl-modules" ]; then
+            MODULES_DIR="$PREFIX/lib64/ossl-modules"
+          else
+            echo "ERROR: OpenSSL modules directory not found under $PREFIX/lib*/ossl-modules" >&2
+            exit 1
+          fi
+          {
+            echo "$PREFIX/bin"
+          } >> "$GITHUB_PATH"
+          {
+            echo "OPENSSL_DIR=$PREFIX"
+            echo "PKG_CONFIG_PATH=$PREFIX/lib64/pkgconfig:$PREFIX/lib/pkgconfig"
+            echo "LD_LIBRARY_PATH=$PREFIX/lib64:$PREFIX/lib"
+            echo "OPENSSL_MODULES=$MODULES_DIR"
+            echo "OPENSSL_CONF=$PREFIX/ssl/openssl-fips.cnf"
+          } >> "$GITHUB_ENV"
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: clients/go/go.mod
+          cache-dependency-path: |
+            clients/go/go.sum
+      - name: Run conformance fixtures drift check
+        run: scripts/dev-env.sh -- python3 tools/check_conformance_fixtures_drift.py
+
   validator:
     name: validator
-    needs: [policy, security_ai, formal, test, formal_refinement]
+    needs: [policy, security_ai, formal, test, formal_refinement, conformance_fixtures_drift]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
@@ -639,9 +689,10 @@ jobs:
             [formal]="${{ needs.formal.result }}"
             [test]="${{ needs.test.result }}"
             [formal_refinement]="${{ needs.formal_refinement.result }}"
+            [conformance_fixtures_drift]="${{ needs.conformance_fixtures_drift.result }}"
           )
           failed=0
-          for key in policy security_ai formal test formal_refinement; do
+          for key in policy security_ai formal test formal_refinement conformance_fixtures_drift; do
             value="${results[$key]}"
             echo "$key=$value"
             if [ "$value" != "success" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -670,6 +670,7 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: clients/go/go.mod
+          cache: true
           cache-dependency-path: |
             clients/go/go.sum
       - name: Run conformance fixtures drift check

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -127,9 +127,18 @@ scripts/dev-env.sh -- bash -lc \
   `conformance/fixtures` или путь под ним;
 - production signing path (`SignDigest32`, hedged ML-DSA) **не** меняется.
 
-Использование: предусмотрено для будущей CI-only drift gate
-(`Q-CONF-FIXTURE-DRIFT-CHECK-01`), которая сравнит candidate bytes
-с committed bytes без мутации репо.
+CI drift gate (`Q-CONF-FIXTURE-DRIFT-CHECK-01`):
+
+```bash
+scripts/dev-env.sh -- python3 tools/check_conformance_fixtures_drift.py
+```
+
+Скрипт запускает `gen-conformance-fixtures --output-dir <isolated-temp>`,
+а затем побайтово сравнивает каждый сгенерированный файл с committed
+`conformance/fixtures/**`. Exit `0` — без drift, exit `1` — drift, exit
+`2` — usage / environment ошибка. Скрипт **никогда** не пишет под
+`conformance/fixtures/**` (auto-regen в CI запрещён); ручная
+регенерация остаётся authoritative path.
 
 ## Fuzz crash promotion (manual-only)
 

--- a/tools/check_conformance_fixtures_drift.py
+++ b/tools/check_conformance_fixtures_drift.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Check-only conformance fixture drift gate.
+
+Generates the deterministic generator-owned fixture set into an isolated
+temporary output directory via `clients/go/cmd/gen-conformance-fixtures
+--output-dir <abs>` and compares each produced file byte-for-byte against
+the corresponding file under `conformance/fixtures/`. Exits 0 when every
+generated file matches its committed counterpart, exits 1 on any drift,
+exits 2 on usage / environment errors. Never writes inside
+`conformance/fixtures/**` and never invokes the generator without the
+`--output-dir` flag, so committed fixtures are never mutated. Manual
+fixture regeneration remains the authoritative path; this gate only
+detects drift after the fact.
+"""
+
+from __future__ import annotations
+
+import argparse
+import filecmp
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Optional, Sequence
+
+
+COMMITTED_FIXTURES_REL = Path("conformance/fixtures")
+GENERATOR_PACKAGE = "./cmd/gen-conformance-fixtures"
+GO_MODULE_REL = Path("clients/go")
+
+# Hardcoded expected generator-owned fixture set per
+# rubin-protocol#1358 task body. Every entry MUST be emitted by the
+# deterministic generator and MUST byte-match the committed fixture.
+# Adding or removing an entry here is a deliberate scope change.
+EXPECTED_FIXTURES: tuple[Path, ...] = (
+    Path("CV-UTXO-BASIC.json"),
+    Path("CV-MULTISIG.json"),
+    Path("CV-EXT.json"),
+    Path("CV-VAULT.json"),
+    Path("CV-HTLC.json"),
+    Path("CV-SUBSIDY.json"),
+    Path("devnet/devnet-vault-create-01.json"),
+    Path("devnet/devnet-htlc-claim-01.json"),
+    Path("devnet/devnet-multisig-spend-01.json"),
+)
+
+
+def parse_args(argv: Optional[Sequence[str]]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="check_conformance_fixtures_drift.py",
+        description=(
+            "Generate fixtures into an isolated temp dir and fail on byte "
+            "drift vs committed fixtures. Never writes committed files."
+        ),
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=".",
+        help="Path to the rubin-protocol repo root (default: cwd).",
+    )
+    parser.add_argument(
+        "--keep-output-dir",
+        action="store_true",
+        help="Do not delete the candidate output directory on exit.",
+    )
+    return parser.parse_args(argv)
+
+
+def run_generator(repo_root: Path, output_dir: Path) -> None:
+    if not output_dir.is_absolute():
+        raise RuntimeError(f"output_dir must be absolute: {output_dir}")
+    cmd = [
+        "go",
+        "run",
+        GENERATOR_PACKAGE,
+        f"--output-dir={output_dir}",
+    ]
+    go_cwd = repo_root / GO_MODULE_REL
+    if not go_cwd.is_dir():
+        raise RuntimeError(f"missing Go module dir: {go_cwd}")
+    completed = subprocess.run(
+        cmd,
+        cwd=str(go_cwd),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        sys.stderr.write(completed.stdout)
+        sys.stderr.write(completed.stderr)
+        raise RuntimeError(
+            f"generator exited with code {completed.returncode}"
+        )
+
+
+def relative_files(root: Path) -> list[Path]:
+    out: list[Path] = []
+    for path in sorted(root.rglob("*")):
+        if path.is_file():
+            out.append(path.relative_to(root))
+    return out
+
+
+def diff_set(
+    candidate_root: Path, committed_root: Path
+) -> tuple[list[Path], list[Path], list[Path], list[Path], list[Path]]:
+    missing_committed: list[Path] = []
+    differing: list[Path] = []
+    matching: list[Path] = []
+    seen_in_candidate: set[Path] = set()
+    for rel in relative_files(candidate_root):
+        seen_in_candidate.add(rel)
+        committed_path = committed_root / rel
+        candidate_path = candidate_root / rel
+        if not committed_path.is_file():
+            missing_committed.append(rel)
+            continue
+        if filecmp.cmp(str(candidate_path), str(committed_path), shallow=False):
+            matching.append(rel)
+        else:
+            differing.append(rel)
+    expected_set = set(EXPECTED_FIXTURES)
+    missing_candidate = sorted(expected_set - seen_in_candidate)
+    extra_candidate = sorted(seen_in_candidate - expected_set)
+    return missing_committed, differing, matching, missing_candidate, extra_candidate
+
+
+def assert_committed_untouched(
+    repo_root: Path, candidate_root: Path
+) -> None:
+    committed_root = (repo_root / COMMITTED_FIXTURES_REL).resolve()
+    candidate_resolved = candidate_root.resolve()
+    if str(candidate_resolved).startswith(str(committed_root) + os.sep):
+        raise RuntimeError(
+            f"candidate output {candidate_resolved} is inside committed "
+            f"fixture root {committed_root}; refusing to run"
+        )
+    if candidate_resolved == committed_root:
+        raise RuntimeError(
+            f"candidate output equals committed fixture root {committed_root}; "
+            f"refusing to run"
+        )
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = parse_args(argv)
+    repo_root = Path(args.repo_root).resolve()
+    committed_root = repo_root / COMMITTED_FIXTURES_REL
+    if not committed_root.is_dir():
+        print(
+            f"ERROR: committed fixtures dir not found: {committed_root}",
+            file=sys.stderr,
+        )
+        return 2
+
+    output_dir = Path(tempfile.mkdtemp(prefix="rubin-fixture-drift-")).resolve()
+    try:
+        assert_committed_untouched(repo_root, output_dir)
+        run_generator(repo_root, output_dir)
+        (
+            missing_committed,
+            differing,
+            matching,
+            missing_candidate,
+            extra_candidate,
+        ) = diff_set(output_dir, committed_root)
+        expected_count = len(EXPECTED_FIXTURES)
+        all_expected_matched = (
+            len(matching) == expected_count
+            and not missing_committed
+            and not differing
+            and not missing_candidate
+            and not extra_candidate
+        )
+        if all_expected_matched:
+            print(
+                f"OK: conformance fixture drift check passed "
+                f"({len(matching)} generator-owned files match committed)"
+            )
+            return 0
+        if missing_candidate:
+            print(
+                "ERROR: candidate generator did not emit expected "
+                "generator-owned fixture(s) (regression in generator output set):",
+                file=sys.stderr,
+            )
+            for rel in missing_candidate:
+                print(f"  - {rel}", file=sys.stderr)
+        if extra_candidate:
+            print(
+                "ERROR: candidate generator emitted unexpected file(s) "
+                "outside the declared generator-owned set:",
+                file=sys.stderr,
+            )
+            for rel in extra_candidate:
+                print(f"  ? {rel}", file=sys.stderr)
+        if missing_committed:
+            print(
+                "ERROR: candidate generator produced files that are not "
+                "present under conformance/fixtures/:",
+                file=sys.stderr,
+            )
+            for rel in missing_committed:
+                print(f"  + {rel}", file=sys.stderr)
+        if differing:
+            print(
+                "ERROR: candidate fixture bytes differ from committed "
+                "fixture bytes (manual regeneration required):",
+                file=sys.stderr,
+            )
+            for rel in differing:
+                print(f"  ~ {rel}", file=sys.stderr)
+        return 1
+    except RuntimeError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+    finally:
+        if not args.keep_output_dir:
+            shutil.rmtree(output_dir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/check_conformance_fixtures_drift.py
+++ b/tools/check_conformance_fixtures_drift.py
@@ -155,7 +155,11 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         )
         return 2
 
-    output_dir = Path(tempfile.mkdtemp(prefix="rubin-fixture-drift-")).resolve()
+    try:
+        output_dir = Path(tempfile.mkdtemp(prefix="rubin-fixture-drift-")).resolve()
+    except OSError as exc:
+        print(f"ERROR: failed to create candidate output dir: {exc}", file=sys.stderr)
+        return 2
     try:
         assert_committed_untouched(repo_root, output_dir)
         run_generator(repo_root, output_dir)
@@ -213,7 +217,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             for rel in differing:
                 print(f"  ~ {rel}", file=sys.stderr)
         return 1
-    except RuntimeError as exc:
+    except (RuntimeError, FileNotFoundError, OSError) as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 2
     finally:

--- a/tools/tests/test_check_conformance_fixtures_drift.py
+++ b/tools/tests/test_check_conformance_fixtures_drift.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import io
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+TOOLS_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(TOOLS_DIR))
+
+import check_conformance_fixtures_drift as m
+
+
+def _populate_committed(root: Path) -> None:
+    for rel in m.EXPECTED_FIXTURES:
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(rel.as_posix().encode("utf-8"))
+
+
+def _populate_candidate(
+    root: Path,
+    *,
+    skip: tuple[Path, ...] = (),
+    extra: tuple[Path, ...] = (),
+    mutate: tuple[Path, ...] = (),
+) -> None:
+    for rel in m.EXPECTED_FIXTURES:
+        if rel in skip:
+            continue
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        body = rel.as_posix().encode("utf-8")
+        if rel in mutate:
+            body = body + b"-MUTATED"
+        path.write_bytes(body)
+    for rel in extra:
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"extra")
+
+
+class DiffSetTests(unittest.TestCase):
+    def test_all_match(self):
+        with tempfile.TemporaryDirectory() as td:
+            committed = Path(td) / "committed"
+            candidate = Path(td) / "candidate"
+            committed.mkdir()
+            candidate.mkdir()
+            _populate_committed(committed)
+            _populate_candidate(candidate)
+            missing_committed, differing, matching, missing_candidate, extra_candidate = (
+                m.diff_set(candidate, committed)
+            )
+        self.assertEqual(missing_committed, [])
+        self.assertEqual(differing, [])
+        self.assertEqual(len(matching), len(m.EXPECTED_FIXTURES))
+        self.assertEqual(missing_candidate, [])
+        self.assertEqual(extra_candidate, [])
+
+    def test_byte_differing(self):
+        target = m.EXPECTED_FIXTURES[0]
+        with tempfile.TemporaryDirectory() as td:
+            committed = Path(td) / "committed"
+            candidate = Path(td) / "candidate"
+            committed.mkdir()
+            candidate.mkdir()
+            _populate_committed(committed)
+            _populate_candidate(candidate, mutate=(target,))
+            _, differing, matching, missing_candidate, extra_candidate = m.diff_set(
+                candidate, committed
+            )
+        self.assertEqual(differing, [target])
+        self.assertEqual(len(matching), len(m.EXPECTED_FIXTURES) - 1)
+        self.assertEqual(missing_candidate, [])
+        self.assertEqual(extra_candidate, [])
+
+    def test_missing_candidate(self):
+        target = m.EXPECTED_FIXTURES[2]
+        with tempfile.TemporaryDirectory() as td:
+            committed = Path(td) / "committed"
+            candidate = Path(td) / "candidate"
+            committed.mkdir()
+            candidate.mkdir()
+            _populate_committed(committed)
+            _populate_candidate(candidate, skip=(target,))
+            _, differing, matching, missing_candidate, extra_candidate = m.diff_set(
+                candidate, committed
+            )
+        self.assertEqual(differing, [])
+        self.assertEqual(len(matching), len(m.EXPECTED_FIXTURES) - 1)
+        self.assertEqual(missing_candidate, [target])
+        self.assertEqual(extra_candidate, [])
+
+    def test_extra_candidate(self):
+        extra = Path("CV-NOT-EXPECTED.json")
+        with tempfile.TemporaryDirectory() as td:
+            committed = Path(td) / "committed"
+            candidate = Path(td) / "candidate"
+            committed.mkdir()
+            candidate.mkdir()
+            _populate_committed(committed)
+            _populate_candidate(candidate, extra=(extra,))
+            missing_committed, _, matching, missing_candidate, extra_candidate = m.diff_set(
+                candidate, committed
+            )
+        self.assertEqual(missing_committed, [extra])
+        self.assertEqual(len(matching), len(m.EXPECTED_FIXTURES))
+        self.assertEqual(missing_candidate, [])
+        self.assertEqual(extra_candidate, [extra])
+
+
+class MainExitCodeTests(unittest.TestCase):
+    def test_main_clean_returns_zero(self):
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            committed = repo_root / m.COMMITTED_FIXTURES_REL
+            committed.mkdir(parents=True)
+            _populate_committed(committed)
+            (repo_root / m.GO_MODULE_REL).mkdir(parents=True, exist_ok=True)
+
+            def fake_run(_repo_root, out_dir):
+                _populate_candidate(out_dir)
+
+            captured = io.StringIO()
+            with mock.patch.object(m, "run_generator", side_effect=fake_run):
+                with mock.patch("sys.stdout", captured):
+                    rc = m.main(["--repo-root", str(repo_root)])
+        self.assertEqual(rc, 0)
+        self.assertIn(
+            f"OK: conformance fixture drift check passed ({len(m.EXPECTED_FIXTURES)} generator-owned files match committed)",
+            captured.getvalue(),
+        )
+
+    def test_main_missing_committed_dir_returns_two(self):
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            captured = io.StringIO()
+            with mock.patch("sys.stderr", captured):
+                rc = m.main(["--repo-root", str(repo_root)])
+        self.assertEqual(rc, 2)
+        self.assertIn("ERROR: committed fixtures dir not found", captured.getvalue())
+
+    def test_main_subprocess_filenotfound_returns_two(self):
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            committed = repo_root / m.COMMITTED_FIXTURES_REL
+            committed.mkdir(parents=True)
+            _populate_committed(committed)
+            (repo_root / m.GO_MODULE_REL).mkdir(parents=True, exist_ok=True)
+
+            def raise_fnf(*_args, **_kwargs):
+                raise FileNotFoundError(2, "No such file or directory: 'go'")
+
+            captured = io.StringIO()
+            with mock.patch("subprocess.run", side_effect=raise_fnf):
+                with mock.patch("sys.stderr", captured):
+                    rc = m.main(["--repo-root", str(repo_root)])
+        self.assertEqual(rc, 2)
+        self.assertIn("ERROR:", captured.getvalue())
+        self.assertNotIn("Traceback", captured.getvalue())
+
+    def test_main_candidate_inside_committed_root_refused(self):
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            committed = repo_root / m.COMMITTED_FIXTURES_REL
+            committed.mkdir(parents=True)
+            _populate_committed(committed)
+            (repo_root / m.GO_MODULE_REL).mkdir(parents=True, exist_ok=True)
+
+            forbidden_root = committed / "candidate"
+            forbidden_root.mkdir()
+
+            def fake_mkdtemp(prefix=""):  # noqa: ARG001 - matches stdlib signature
+                _ = prefix
+                return str(forbidden_root)
+
+            captured = io.StringIO()
+            with mock.patch("tempfile.mkdtemp", side_effect=fake_mkdtemp):
+                with mock.patch("sys.stderr", captured):
+                    rc = m.main(["--repo-root", str(repo_root)])
+        self.assertEqual(rc, 2)
+        self.assertIn(
+            "candidate output", captured.getvalue()
+        )
+
+    def test_main_drift_detected_returns_one(self):
+        target = m.EXPECTED_FIXTURES[1]
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            committed = repo_root / m.COMMITTED_FIXTURES_REL
+            committed.mkdir(parents=True)
+            _populate_committed(committed)
+            (repo_root / m.GO_MODULE_REL).mkdir(parents=True, exist_ok=True)
+
+            def fake_run(_repo_root, out_dir):
+                _populate_candidate(out_dir, mutate=(target,))
+
+            captured = io.StringIO()
+            with mock.patch.object(m, "run_generator", side_effect=fake_run):
+                with mock.patch("sys.stderr", captured):
+                    rc = m.main(["--repo-root", str(repo_root)])
+        self.assertEqual(rc, 1)
+        self.assertIn(f"~ {target}", captured.getvalue())
+
+    def test_main_missing_expected_returns_one(self):
+        target = m.EXPECTED_FIXTURES[3]
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            committed = repo_root / m.COMMITTED_FIXTURES_REL
+            committed.mkdir(parents=True)
+            _populate_committed(committed)
+            (repo_root / m.GO_MODULE_REL).mkdir(parents=True, exist_ok=True)
+
+            def fake_run(_repo_root, out_dir):
+                _populate_candidate(out_dir, skip=(target,))
+
+            captured = io.StringIO()
+            with mock.patch.object(m, "run_generator", side_effect=fake_run):
+                with mock.patch("sys.stderr", captured):
+                    rc = m.main(["--repo-root", str(repo_root)])
+        self.assertEqual(rc, 1)
+        self.assertIn(f"- {target}", captured.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs: Q-CONF-FIXTURE-DRIFT-CHECK-01

## Summary

Implements Q-CONF-FIXTURE-DRIFT-CHECK-01: adds a check-only conformance fixture drift gate. Wraps the existing `clients/go/cmd/gen-conformance-fixtures --output-dir <abs>` mode (added in #1374) into `tools/check_conformance_fixtures_drift.py`, which generates the deterministic generator-owned fixture set into an isolated `tempfile.mkdtemp` directory and per-file byte-compares against committed `conformance/fixtures/`. Fails closed on (a) byte difference, (b) any of the 9 expected generator-owned fixtures missing from candidate output, (c) any unexpected candidate file outside the declared expected set, (d) any candidate file missing from committed fixtures, or (e) candidate match count != 9. Wired through a dedicated `conformance_fixtures_drift` CI job (needs: policy, OpenSSL 3.5.5 bundle setup matching the test/formal_refinement pattern, setup-go with `cache: true`, dev-env.sh wrapper) added to validator's required `needs` list. Documented exit-code contract (0=match, 1=drift, 2=usage/environment) is hardened to catch `(RuntimeError, FileNotFoundError, OSError)` and protected by a new `tools/tests/test_check_conformance_fixtures_drift.py` (10 unittest tests covering all four `diff_set` classes plus six `main()` exit-code paths). The existing `tools/check_conformance_fixtures_policy.py` forbidden-substring rule for workflows is unchanged because the workflow only invokes the wrapper script.

## Scope

Touched surfaces (4 files, all under controller-approved class C surfaces):

- `tools/check_conformance_fixtures_drift.py` (new wrapper, stdlib-only; hardened exit-2 contract for missing `go` / `OSError` / tempdir-setup failures)
- `tools/tests/test_check_conformance_fixtures_drift.py` (new, 10 stdlib-unittest tests; auto-discovered by the existing policy-job step `python3 -m unittest discover -s tools/tests -p 'test_*.py'`)
- `.github/workflows/ci.yml` (new dedicated `conformance_fixtures_drift` job with OpenSSL 3.5.5 bundle setup, setup-go `cache: true`, dev-env.sh wrapper; validator `needs` and enforcement-loop entries updated)
- `conformance/README.md` (one-paragraph flip from "future drift gate" to active gate documentation; manual regeneration remains the authoritative path)

Consensus rules unchanged: YES
SECTION_HASHES.json unchanged: YES

## Disposition

No generator code change (--output-dir mode and deterministic ML-DSA-87 helper already exist on origin/main). No conformance runner / validator semantic change. No fixture content / schema / vector ops / `expect_err` change. No new vectors. No Go / Rust runtime or consensus change. No Rust counterpart. No spec / formal / Lean refinement bridge change. No `tools/check_conformance_fixtures_policy.py` substring-rule loosening. No auto-regenerate path; manual fixture governance remains the authoritative path. No `protocol/*` fixture or manually-authored fixture touched.
