### PR TITLE
node: tighten Go persistence directory modes (#1377)

### DIFF
--- a/clients/go/cmd/rubin-node/main.go
+++ b/clients/go/cmd/rubin-node/main.go
@@ -329,7 +329,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 		_, _ = fmt.Fprintf(stderr, "mainnet genesis guard failed: %v\n", err)
 		return 2
 	}
-	if err := os.MkdirAll(cfg.DataDir, 0o750); err != nil {
+	if err := os.MkdirAll(cfg.DataDir, 0o700); err != nil {
 		_, _ = fmt.Fprintf(stderr, "datadir create failed: %v\n", err)
 		return 2
 	}

--- a/clients/go/cmd/rubin-node/main_test.go
+++ b/clients/go/cmd/rubin-node/main_test.go
@@ -31,6 +31,17 @@ type failWriter struct{}
 
 func (failWriter) Write([]byte) (int, error) { return 0, errors.New("write failed") }
 
+func assertPathMode(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	if got := info.Mode().Perm(); got != want {
+		t.Fatalf("mode %s = %04o, want %04o", path, got, want)
+	}
+}
+
 type legacyExposureReportJSON struct {
 	ReportVersion         uint64  `json:"report_version"`
 	MeasurementScope      string  `json:"measurement_scope"`
@@ -364,6 +375,32 @@ func TestRunNormalizesDataDirBeforeChainStateAndBlockStorePathDerivation(t *test
 	}
 	if _, err := os.Stat(node.ChainStatePath(escaped)); !os.IsNotExist(err) {
 		t.Fatalf("raw symlink traversal path was used; stat err=%v path=%s", err, node.ChainStatePath(escaped))
+	}
+}
+
+func TestRunCreatesPrivatePersistencePaths(t *testing.T) {
+	datadir := filepath.Join(t.TempDir(), "data")
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	code := run([]string{"--dry-run", "--datadir", datadir}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("expected exit code 0, got %d (stderr=%q)", code, errOut.String())
+	}
+
+	assertPathMode(t, datadir, 0o700)
+	assertPathMode(t, node.ChainStatePath(datadir), 0o600)
+	blockstore := node.BlockStorePath(datadir)
+	assertPathMode(t, blockstore, 0o700)
+	assertPathMode(t, filepath.Join(blockstore, "blocks"), 0o700)
+	assertPathMode(t, filepath.Join(blockstore, "headers"), 0o700)
+	assertPathMode(t, filepath.Join(blockstore, "undo"), 0o700)
+
+	var reopenOut bytes.Buffer
+	var reopenErr bytes.Buffer
+	reopenCode := run([]string{"--dry-run", "--datadir", datadir}, &reopenOut, &reopenErr)
+	if reopenCode != 0 {
+		t.Fatalf("reopen dry-run exit code %d (stderr=%q)", reopenCode, reopenErr.String())
 	}
 }
 

--- a/clients/go/node/blockstore.go
+++ b/clients/go/node/blockstore.go
@@ -57,13 +57,13 @@ func OpenBlockStore(rootPath string) (*BlockStore, error) {
 	headersDir := filepath.Join(rootPath, "headers")
 	undoDir := filepath.Join(rootPath, "undo")
 
-	if err := os.MkdirAll(blocksDir, 0o750); err != nil {
+	if err := os.MkdirAll(blocksDir, 0o700); err != nil {
 		return nil, err
 	}
-	if err := os.MkdirAll(headersDir, 0o750); err != nil {
+	if err := os.MkdirAll(headersDir, 0o700); err != nil {
 		return nil, err
 	}
-	if err := os.MkdirAll(undoDir, 0o750); err != nil {
+	if err := os.MkdirAll(undoDir, 0o700); err != nil {
 		return nil, err
 	}
 

--- a/clients/go/node/blockstore_test.go
+++ b/clients/go/node/blockstore_test.go
@@ -3,6 +3,7 @@ package node
 import (
 	"bytes"
 	"encoding/binary"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
@@ -23,6 +24,17 @@ func mustOpenBlockStore(t *testing.T, path string) *BlockStore {
 	return store
 }
 
+func assertNodePathMode(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	if got := info.Mode().Perm(); got != want {
+		t.Fatalf("mode %s = %04o, want %04o", path, got, want)
+	}
+}
+
 func mustHeaderHash(t *testing.T, header []byte) [32]byte {
 	t.Helper()
 	hash, err := consensus.BlockHash(header)
@@ -40,6 +52,38 @@ func mustPutBlock(t *testing.T, store *BlockStore, height uint64, seed byte, non
 		t.Fatalf("put block height=%d: %v", height, err)
 	}
 	return hash, header
+}
+
+func TestOpenBlockStoreCreatesPrivateDirsAndFiles(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "blockstore")
+	store := mustOpenBlockStore(t, root)
+
+	assertNodePathMode(t, root, 0o700)
+	assertNodePathMode(t, store.blocksDir, 0o700)
+	assertNodePathMode(t, store.headersDir, 0o700)
+	assertNodePathMode(t, store.undoDir, 0o700)
+
+	header := testHeaderBytes(31, 31)
+	hash := mustHeaderHash(t, header)
+	blockBytes := []byte("private block payload")
+	if err := store.CommitCanonicalBlock(0, hash, header, blockBytes, &BlockUndo{}); err != nil {
+		t.Fatalf("commit canonical block: %v", err)
+	}
+
+	hashHex := hex.EncodeToString(hash[:])
+	assertNodePathMode(t, filepath.Join(root, "index.json"), 0o600)
+	assertNodePathMode(t, filepath.Join(store.blocksDir, hashHex+".bin"), 0o600)
+	assertNodePathMode(t, filepath.Join(store.headersDir, hashHex+".bin"), 0o600)
+	assertNodePathMode(t, filepath.Join(store.undoDir, hashHex+".json"), 0o600)
+
+	reopened := mustOpenBlockStore(t, root)
+	tipHeight, tipHash, ok, err := reopened.Tip()
+	if err != nil {
+		t.Fatalf("reopened tip: %v", err)
+	}
+	if !ok || tipHeight != 0 || tipHash != hash {
+		t.Fatalf("reopened tip = ok=%v height=%d hash=%x, want height 0 hash %x", ok, tipHeight, tipHash, hash)
+	}
 }
 
 func TestBlockStorePutGetAndTip(t *testing.T) {

--- a/clients/go/node/chainstate.go
+++ b/clients/go/node/chainstate.go
@@ -329,7 +329,7 @@ func (s *ChainState) Save(path string) error {
 		return fmt.Errorf("encode chainstate: %w", err)
 	}
 	raw = append(raw, '\n')
-	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return err
 	}
 	return writeFileAtomic(path, raw, 0o600)

--- a/clients/go/node/chainstate_test.go
+++ b/clients/go/node/chainstate_test.go
@@ -99,6 +99,26 @@ func TestChainStateSaveLoadRoundTripDeterministic(t *testing.T) {
 	}
 }
 
+func TestChainStateSaveCreatesPrivateParentAndFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing-parent", "chainstate.json")
+	st := NewChainState()
+
+	if err := st.Save(path); err != nil {
+		t.Fatalf("save chainstate: %v", err)
+	}
+
+	assertNodePathMode(t, filepath.Dir(path), 0o700)
+	assertNodePathMode(t, path, 0o600)
+
+	loaded, err := LoadChainState(path)
+	if err != nil {
+		t.Fatalf("load saved chainstate: %v", err)
+	}
+	if loaded.HasTip || loaded.Height != 0 || len(loaded.Utxos) != 0 {
+		t.Fatalf("unexpected loaded empty chainstate: has_tip=%v height=%d utxos=%d", loaded.HasTip, loaded.Height, len(loaded.Utxos))
+	}
+}
+
 func TestChainStateConnectBlockDeterministicUpdate(t *testing.T) {
 	target := consensus.POW_LIMIT
 


### PR DESCRIPTION
## Scope
- Tighten Go persistence directory creation modes for `rubin-node` datadir, `BlockStore` dirs, and `ChainState.Save` parent dirs from `0750` to `0700`.
- Add focused Go tests proving fresh create, private file modes, and reopen/readback behavior.

## Disposition
- Architecture class: B.
- Go-only; no Rust, conformance, fixture, script, workflow, or storage layout changes.
- Path normalization and atomic write semantics unchanged.
- File content modes remain `0600`.
- Closes #1377.
