### PR TITLE
RUB-161: harden Go OpenSSL signer/key-export FFI lifetime + pre-C guards

### DIFF
--- a/clients/go/consensus/openssl_signer.go
+++ b/clients/go/consensus/openssl_signer.go
@@ -400,9 +400,9 @@ func (k *MLDSA87Keypair) PrivateKeyDER() ([]byte, error) {
 // degenerate case is observed:
 //
 //   - derNil == true    → wrapped error reporting the nil DER pointer
-//     even though the C helper signalled success (rc==0).
+//     even though the C helper signaled success (rc==0).
 //   - derLen == 0       → wrapped error reporting zero DER length
-//     even though the C helper signalled success.
+//     even though the C helper signaled success.
 //   - derLen overflows  → wrapped error reporting that the length
 //     does not fit into C.int (which the byte-copy below takes as
 //     a C.int and silently truncates on overflow on 64-bit hosts).

--- a/clients/go/consensus/openssl_signer.go
+++ b/clients/go/consensus/openssl_signer.go
@@ -168,6 +168,7 @@ func openSSLPublicKeyBytesWithErrBuf(pkey *C.EVP_PKEY, expectedPubkeyLen int, er
 	// cause an index-out-of-range panic at the C-pointer boundary instead
 	// of a clean error. Public callers route through validateOpenSSLAlgorithm,
 	// but this helper is package-local and must guard its own boundary.
+	// Covered by TestOpenSSLPublicKeyBytes_NonPositivePubkeyLenErrors.
 	if expectedPubkeyLen <= 0 {
 		return nil, fmt.Errorf("openssl pubkey length must be positive, got %d", expectedPubkeyLen)
 	}
@@ -252,7 +253,10 @@ func signOpenSSLDigest32(pkey *C.EVP_PKEY, digest [32]byte, maxSigBytes int, exa
 	// exactSigBytes greater than maxSigBytes can never be satisfied by
 	// the C call because the C helper writes at most maxSigBytes and the
 	// post-call length check would always reject. Mirrors the
-	// conformance-only path's nil/zero-receiver guard.
+	// conformance-only path's nil/zero-receiver guard. Covered by
+	// TestSignOpenSSLDigest32_NilPKeyErrors,
+	// TestSignOpenSSLDigest32_NonPositiveMaxSigBytesErrors, and
+	// TestSignOpenSSLDigest32_ExactGreaterThanMaxErrors.
 	if pkey == nil {
 		return nil, fmt.Errorf("nil openssl key")
 	}

--- a/clients/go/consensus/openssl_signer.go
+++ b/clients/go/consensus/openssl_signer.go
@@ -365,11 +365,12 @@ func (k *MLDSA87Keypair) PrivateKeyDER() ([]byte, error) {
 	}
 
 	// Deferred runtime.KeepAlive(k) extends k's compiler-tracked liveness
-	// to function exit, which covers both the rubin_private_key_to_der
-	// FFI call below and the final byte-copy return expression. A finalizer
-	// that fired mid-call could free k.pkey while the C helper still holds
-	// it, or invalidate the C-owned DER buffer before its bytes are copied
-	// into the returned Go slice.
+	// to function exit, which covers the rubin_private_key_to_der C call
+	// below. A finalizer that fired during that call could free k.pkey
+	// (EVP_PKEY) while the C helper is still using it. The C-owned DER
+	// buffer that the C call writes to der is owned by the C allocation
+	// and freed by defer C.rubin_free_der(der) below; it is independent
+	// of k.pkey and KeepAlive(k) is not needed to keep der alive.
 	defer runtime.KeepAlive(k)
 
 	errBuf := newOpenSSLErrorBuffer()
@@ -400,16 +401,17 @@ func (k *MLDSA87Keypair) PrivateKeyDER() ([]byte, error) {
 }
 
 // validatePrivateKeyDERPostC inspects the post-success outputs of
-// rubin_private_key_to_der and returns a wrapped fmt.Errorf when any
-// degenerate case is observed:
+// rubin_private_key_to_der and returns a fmt.Errorf describing the
+// degenerate case observed (no inner cause is wrapped via %w; the
+// helper itself is the source of the diagnostic):
 //
-//   - derNil == true    → wrapped error reporting the nil DER pointer
-//     even though the C helper signaled success (rc==0).
-//   - derLen == 0       → wrapped error reporting zero DER length
-//     even though the C helper signaled success.
-//   - derLen overflows  → wrapped error reporting that the length
-//     does not fit into C.int (which the byte-copy below takes as
-//     a C.int and silently truncates on overflow on 64-bit hosts).
+//   - derNil == true    → error reporting the nil DER pointer even
+//     though the C helper signaled success (rc==0).
+//   - derLen == 0       → error reporting zero DER length even
+//     though the C helper signaled success.
+//   - derLen overflows  → error reporting that the length does not
+//     fit into C.int (which the byte-copy below takes as a C.int
+//     and silently truncates on overflow on 64-bit hosts).
 //
 // Extracted from PrivateKeyDER so the three crypto-defensive branches
 // remain unit-test-reachable through this helper. (No typed/sentinel

--- a/clients/go/consensus/openssl_signer.go
+++ b/clients/go/consensus/openssl_signer.go
@@ -382,27 +382,48 @@ func (k *MLDSA87Keypair) PrivateKeyDER() ([]byte, error) {
 	}
 	defer C.rubin_free_der(der)
 
-	// Defensive post-C success checks before the byte-copy return. The
-	// C helper already returns -1 on every internal failure, but a
-	// degenerate runtime that signaled success (rc=0) yet left
-	// out=nil/out_len=0 would otherwise turn into an empty/silent DER
-	// copy. derLen also must fit into C.int because the byte-copy below
-	// takes a C.int length and silently truncates on overflow on 64-bit
-	// hosts.
-	if der == nil {
-		return nil, fmt.Errorf("openssl private key export returned nil DER pointer")
-	}
-	if derLen == 0 {
-		return nil, fmt.Errorf("openssl private key export returned zero DER length")
-	}
-	if uint64(derLen) > uint64(math.MaxInt32) {
-		return nil, fmt.Errorf(
-			"openssl private key export DER length=%d exceeds C.int range",
-			uint64(derLen),
-		)
+	// Defensive post-C success checks before the byte-copy return.
+	// validatePrivateKeyDERPostC isolates the three crypto-defensive
+	// branches (rc==0 but degenerate runtime returned nil/zero/overflow
+	// outputs) so they can be unit-tested without a working OpenSSL
+	// fault injector. Mirrors validateConformanceSignResult at
+	// clients/go/consensus/openssl_signer_conformance_fixture.go:205.
+	if err := validatePrivateKeyDERPostC(der == nil, uint64(derLen)); err != nil {
+		return nil, err
 	}
 
 	return C.GoBytes(unsafe.Pointer(der), C.int(derLen)), nil
+}
+
+// validatePrivateKeyDERPostC inspects the post-success outputs of
+// rubin_private_key_to_der and returns a wrapped fmt.Errorf when any
+// degenerate case is observed:
+//
+//   - derNil == true    → wrapped error reporting the nil DER pointer
+//     even though the C helper signalled success (rc==0).
+//   - derLen == 0       → wrapped error reporting zero DER length
+//     even though the C helper signalled success.
+//   - derLen overflows  → wrapped error reporting that the length
+//     does not fit into C.int (which the byte-copy below takes as
+//     a C.int and silently truncates on overflow on 64-bit hosts).
+//
+// Extracted from PrivateKeyDER so the three crypto-defensive branches
+// remain unit-test-reachable through this helper. (No typed/sentinel
+// error type — callers match by string contains in tests.)
+func validatePrivateKeyDERPostC(derNil bool, derLen uint64) error {
+	if derNil {
+		return fmt.Errorf("openssl private key export returned nil DER pointer")
+	}
+	if derLen == 0 {
+		return fmt.Errorf("openssl private key export returned zero DER length")
+	}
+	if derLen > uint64(math.MaxInt32) {
+		return fmt.Errorf(
+			"openssl private key export DER length=%d exceeds C.int range",
+			derLen,
+		)
+	}
+	return nil
 }
 
 func cStringTrim0(b []byte) string {

--- a/clients/go/consensus/openssl_signer.go
+++ b/clients/go/consensus/openssl_signer.go
@@ -163,11 +163,10 @@ func openSSLPublicKeyBytesWithErrBuf(pkey *C.EVP_PKEY, expectedPubkeyLen int, er
 	if pkey == nil {
 		return nil, fmt.Errorf("nil openssl key")
 	}
-	// Fail closed before allocating the pubkey buffer and taking the
-	// first-element address below: a non-positive expected length would
-	// cause an index-out-of-range panic at the C-pointer boundary instead
-	// of a clean error. Public callers route through validateOpenSSLAlgorithm,
-	// but this helper is package-local and must guard its own boundary.
+	// Reject non-positive expectedPubkeyLen at this package-local helper
+	// boundary so a degenerate caller cannot reach the make([]byte, ...)
+	// allocation or the C-pointer take-address site with an unusable
+	// length. Public callers already route through validateOpenSSLAlgorithm.
 	// Covered by TestOpenSSLPublicKeyBytes_NonPositivePubkeyLenErrors.
 	if expectedPubkeyLen <= 0 {
 		return nil, fmt.Errorf("openssl pubkey length must be positive, got %d", expectedPubkeyLen)
@@ -246,13 +245,14 @@ func signOpenSSLDigest32(pkey *C.EVP_PKEY, digest [32]byte, maxSigBytes int, exa
 	if err := ensureOpenSSLBootstrap(); err != nil {
 		return nil, err
 	}
-	// Fail closed at the FFI boundary before allocating the signature
-	// buffer and taking its first-element address below. A nil pkey would
-	// dereference inside the C helper; a non-positive maxSigBytes would
-	// panic on the signature-buffer first-element address; an
-	// exactSigBytes greater than maxSigBytes can never be satisfied by
-	// the C call because the C helper writes at most maxSigBytes and the
-	// post-call length check would always reject. Mirrors the
+	// Reject three classes of unusable inputs at this package-local FFI
+	// boundary so a degenerate caller cannot reach the make([]byte, ...)
+	// allocation, the C-pointer take-address site, or the C helper with
+	// inputs the call cannot satisfy: nil pkey (which the C helper would
+	// dereference), non-positive maxSigBytes (which the take-address site
+	// cannot index), and exactSigBytes greater than maxSigBytes (which
+	// the C helper cannot satisfy because it writes at most maxSigBytes
+	// and the post-call length check then rejects). Mirrors the
 	// conformance-only path's nil/zero-receiver guard. Covered by
 	// TestSignOpenSSLDigest32_NilPKeyErrors,
 	// TestSignOpenSSLDigest32_NonPositiveMaxSigBytesErrors, and

--- a/clients/go/consensus/openssl_signer.go
+++ b/clients/go/consensus/openssl_signer.go
@@ -132,6 +132,7 @@ import "C"
 
 import (
 	"fmt"
+	"math"
 	"runtime"
 	"unsafe"
 )
@@ -161,6 +162,14 @@ func newOpenSSLErrorBuffer() []byte {
 func openSSLPublicKeyBytesWithErrBuf(pkey *C.EVP_PKEY, expectedPubkeyLen int, errBuf []byte) ([]byte, error) {
 	if pkey == nil {
 		return nil, fmt.Errorf("nil openssl key")
+	}
+	// Fail closed before allocating the pubkey buffer and taking the
+	// first-element address below: a non-positive expected length would
+	// cause an index-out-of-range panic at the C-pointer boundary instead
+	// of a clean error. Public callers route through validateOpenSSLAlgorithm,
+	// but this helper is package-local and must guard its own boundary.
+	if expectedPubkeyLen <= 0 {
+		return nil, fmt.Errorf("openssl pubkey length must be positive, got %d", expectedPubkeyLen)
 	}
 	if len(errBuf) == 0 {
 		errBuf = newOpenSSLErrorBuffer()
@@ -235,6 +244,26 @@ func newOpenSSLRawKeypairFromDER(alg string, der []byte, expectedPubkeyLen int) 
 func signOpenSSLDigest32(pkey *C.EVP_PKEY, digest [32]byte, maxSigBytes int, exactSigBytes int) ([]byte, error) {
 	if err := ensureOpenSSLBootstrap(); err != nil {
 		return nil, err
+	}
+	// Fail closed at the FFI boundary before allocating the signature
+	// buffer and taking its first-element address below. A nil pkey would
+	// dereference inside the C helper; a non-positive maxSigBytes would
+	// panic on the signature-buffer first-element address; an
+	// exactSigBytes greater than maxSigBytes can never be satisfied by
+	// the C call because the C helper writes at most maxSigBytes and the
+	// post-call length check would always reject. Mirrors the
+	// conformance-only path's nil/zero-receiver guard.
+	if pkey == nil {
+		return nil, fmt.Errorf("nil openssl key")
+	}
+	if maxSigBytes <= 0 {
+		return nil, fmt.Errorf("openssl maxSigBytes must be positive, got %d", maxSigBytes)
+	}
+	if exactSigBytes > maxSigBytes {
+		return nil, fmt.Errorf(
+			"openssl exactSigBytes=%d exceeds maxSigBytes=%d",
+			exactSigBytes, maxSigBytes,
+		)
 	}
 
 	errBuf := newOpenSSLErrorBuffer()
@@ -314,7 +343,13 @@ func (k *MLDSA87Keypair) SignDigest32(digest [32]byte) ([]byte, error) {
 	if k == nil || k.pkey == nil {
 		return nil, fmt.Errorf("nil keypair")
 	}
-	return signOpenSSLDigest32(k.pkey, digest, ML_DSA_87_SIG_BYTES, ML_DSA_87_SIG_BYTES)
+	sig, err := signOpenSSLDigest32(k.pkey, digest, ML_DSA_87_SIG_BYTES, ML_DSA_87_SIG_BYTES)
+	// runtime.KeepAlive(k) AFTER signOpenSSLDigest32 returns so the
+	// finalizer cannot free k.pkey while the underlying C call is still
+	// using it. A pre-call KeepAlive would not cover the C call window.
+	// Mirrors the conformance-only helper at clients/go/consensus/openssl_signer_conformance_fixture.go:174.
+	runtime.KeepAlive(k)
+	return sig, err
 }
 
 func (k *MLDSA87Keypair) PrivateKeyDER() ([]byte, error) {
@@ -324,6 +359,14 @@ func (k *MLDSA87Keypair) PrivateKeyDER() ([]byte, error) {
 	if k == nil || k.pkey == nil {
 		return nil, fmt.Errorf("nil keypair")
 	}
+
+	// Deferred runtime.KeepAlive(k) extends k's compiler-tracked liveness
+	// to function exit, which covers both the rubin_private_key_to_der
+	// FFI call below and the final byte-copy return expression. A finalizer
+	// that fired mid-call could free k.pkey while the C helper still holds
+	// it, or invalidate the C-owned DER buffer before its bytes are copied
+	// into the returned Go slice.
+	defer runtime.KeepAlive(k)
 
 	errBuf := newOpenSSLErrorBuffer()
 	var der *C.uchar
@@ -338,6 +381,26 @@ func (k *MLDSA87Keypair) PrivateKeyDER() ([]byte, error) {
 		return nil, fmt.Errorf("openssl private key export failed: %s", cStringTrim0(errBuf))
 	}
 	defer C.rubin_free_der(der)
+
+	// Defensive post-C success checks before the byte-copy return. The
+	// C helper already returns -1 on every internal failure, but a
+	// degenerate runtime that signaled success (rc=0) yet left
+	// out=nil/out_len=0 would otherwise turn into an empty/silent DER
+	// copy. derLen also must fit into C.int because the byte-copy below
+	// takes a C.int length and silently truncates on overflow on 64-bit
+	// hosts.
+	if der == nil {
+		return nil, fmt.Errorf("openssl private key export returned nil DER pointer")
+	}
+	if derLen == 0 {
+		return nil, fmt.Errorf("openssl private key export returned zero DER length")
+	}
+	if uint64(derLen) > uint64(math.MaxInt32) {
+		return nil, fmt.Errorf(
+			"openssl private key export DER length=%d exceeds C.int range",
+			uint64(derLen),
+		)
+	}
 
 	return C.GoBytes(unsafe.Pointer(der), C.int(derLen)), nil
 }

--- a/clients/go/consensus/openssl_signer_additional_test.go
+++ b/clients/go/consensus/openssl_signer_additional_test.go
@@ -3,6 +3,7 @@
 package consensus
 
 import (
+	"math"
 	"strings"
 	"testing"
 )
@@ -281,6 +282,50 @@ func TestMLDSA87Keypair_PrivateKeyDER_NilKeypairErrors(t *testing.T) {
 	kp = &MLDSA87Keypair{}
 	if _, err := kp.PrivateKeyDER(); err == nil {
 		t.Fatalf("expected nil keypair error")
+	}
+}
+
+func TestValidatePrivateKeyDERPostC_NilPointerErrors(t *testing.T) {
+	err := validatePrivateKeyDERPostC(true, 1)
+	if err == nil {
+		t.Fatalf("expected error for nil DER pointer")
+	}
+	if !strings.Contains(err.Error(), "nil DER pointer") {
+		t.Fatalf("missing nil-pointer marker in error: %v", err)
+	}
+}
+
+func TestValidatePrivateKeyDERPostC_ZeroLengthErrors(t *testing.T) {
+	err := validatePrivateKeyDERPostC(false, 0)
+	if err == nil {
+		t.Fatalf("expected error for zero DER length")
+	}
+	if !strings.Contains(err.Error(), "zero DER length") {
+		t.Fatalf("missing zero-length marker in error: %v", err)
+	}
+}
+
+func TestValidatePrivateKeyDERPostC_OverflowErrors(t *testing.T) {
+	for _, derLen := range []uint64{
+		uint64(math.MaxInt32) + 1,
+		uint64(math.MaxInt32) + 1024,
+		math.MaxUint64,
+	} {
+		err := validatePrivateKeyDERPostC(false, derLen)
+		if err == nil {
+			t.Fatalf("derLen=%d: expected overflow error", derLen)
+		}
+		if !strings.Contains(err.Error(), "exceeds C.int range") {
+			t.Fatalf("derLen=%d: missing overflow marker in error: %v", derLen, err)
+		}
+	}
+}
+
+func TestValidatePrivateKeyDERPostC_AcceptsValidLengths(t *testing.T) {
+	for _, derLen := range []uint64{1, 32, 4096, uint64(math.MaxInt32)} {
+		if err := validatePrivateKeyDERPostC(false, derLen); err != nil {
+			t.Fatalf("derLen=%d: unexpected error: %v", derLen, err)
+		}
 	}
 }
 

--- a/clients/go/consensus/openssl_signer_additional_test.go
+++ b/clients/go/consensus/openssl_signer_additional_test.go
@@ -91,6 +91,116 @@ func TestOpenSSLPublicKeyBytes_NilKeyErrors(t *testing.T) {
 	}
 }
 
+// TestOpenSSLPublicKeyBytes_NonPositivePubkeyLenErrors covers the
+// package-local FFI guard added for Q-SEC-GO-OPENSSL-SIGNER-LIFETIME-GUARDS-01:
+// a non-positive expectedPubkeyLen would otherwise panic at the
+// unsafe.Pointer(&pubkey[0]) site after make([]byte, 0). A clean error
+// is required before any C call or unsafe pointer use.
+func TestOpenSSLPublicKeyBytes_NonPositivePubkeyLenErrors(t *testing.T) {
+	kp := mustMLDSA87Keypair(t)
+
+	for _, badLen := range []int{0, -1, -42} {
+		_, err := openSSLPublicKeyBytesWithErrBuf(kp.pkey, badLen, nil)
+		if err == nil {
+			t.Fatalf("openSSLPublicKeyBytesWithErrBuf(non-nil pkey, %d, nil) returned nil error", badLen)
+		}
+		if !strings.Contains(err.Error(), "openssl pubkey length must be positive") {
+			t.Fatalf("badLen=%d err=%q, want substring %q", badLen, err.Error(), "openssl pubkey length must be positive")
+		}
+	}
+}
+
+// TestSignOpenSSLDigest32_NilPKeyErrors covers the helper-level
+// pre-C guard added for Q-SEC-GO-OPENSSL-SIGNER-LIFETIME-GUARDS-01.
+// signOpenSSLDigest32 must reject a nil pkey before allocating the
+// signature buffer or passing the pointer to C, so a direct caller
+// outside MLDSA87Keypair.SignDigest32 fails closed.
+func TestSignOpenSSLDigest32_NilPKeyErrors(t *testing.T) {
+	var digest [32]byte
+	digest[0] = 0x77
+
+	_, err := signOpenSSLDigest32(nil, digest, ML_DSA_87_SIG_BYTES, ML_DSA_87_SIG_BYTES)
+	if err == nil {
+		t.Fatalf("signOpenSSLDigest32(nil pkey, ...) returned nil error")
+	}
+	if !strings.Contains(err.Error(), "nil openssl key") {
+		t.Fatalf("err=%q, want substring %q", err.Error(), "nil openssl key")
+	}
+}
+
+// TestSignOpenSSLDigest32_NonPositiveMaxSigBytesErrors covers the
+// pre-C guard for maxSigBytes <= 0. Without the guard, make([]byte,
+// 0) plus &signature[0] panics at the unsafe.Pointer site; make([]byte,
+// -1) panics inside the runtime allocator. Both must surface as a
+// clean error from the FFI boundary.
+func TestSignOpenSSLDigest32_NonPositiveMaxSigBytesErrors(t *testing.T) {
+	kp := mustMLDSA87Keypair(t)
+
+	var digest [32]byte
+	digest[0] = 0x33
+
+	for _, badMax := range []int{0, -1, -1024} {
+		_, err := signOpenSSLDigest32(kp.pkey, digest, badMax, 0)
+		if err == nil {
+			t.Fatalf("signOpenSSLDigest32(pkey, _, %d, 0) returned nil error", badMax)
+		}
+		if !strings.Contains(err.Error(), "openssl maxSigBytes must be positive") {
+			t.Fatalf("badMax=%d err=%q, want substring %q", badMax, err.Error(), "openssl maxSigBytes must be positive")
+		}
+	}
+}
+
+// TestSignOpenSSLDigest32_ExactGreaterThanMaxErrors covers the
+// pre-C guard for exactSigBytes > maxSigBytes. The C helper writes
+// at most maxSigBytes, so any exactSigBytes greater than that can
+// never be satisfied; rejecting before the C call avoids spending
+// an OpenSSL signing operation on a request the caller cannot
+// possibly accept.
+func TestSignOpenSSLDigest32_ExactGreaterThanMaxErrors(t *testing.T) {
+	kp := mustMLDSA87Keypair(t)
+
+	var digest [32]byte
+	digest[0] = 0x44
+
+	_, err := signOpenSSLDigest32(kp.pkey, digest, ML_DSA_87_SIG_BYTES, ML_DSA_87_SIG_BYTES+1)
+	if err == nil {
+		t.Fatalf("signOpenSSLDigest32 returned nil error for exactSigBytes>maxSigBytes")
+	}
+	if !strings.Contains(err.Error(), "exceeds maxSigBytes") {
+		t.Fatalf("err=%q, want substring %q", err.Error(), "exceeds maxSigBytes")
+	}
+}
+
+// TestMLDSA87Keypair_SignDigest32_KeepsKeypairAliveAcrossCall covers
+// the runtime.KeepAlive(k) added after signOpenSSLDigest32 returns:
+// the keypair finalizer must not free k.pkey while the C call is in
+// flight. We cannot directly observe finalizer timing in a unit test,
+// but a successful sign+verify roundtrip on a freshly generated
+// keypair proves the post-call KeepAlive is on the live path; if the
+// pkey were freed mid-call the C side would crash or produce an
+// invalid signature.
+func TestMLDSA87Keypair_SignDigest32_KeepsKeypairAliveAcrossCall(t *testing.T) {
+	kp := mustMLDSA87Keypair(t)
+
+	var digest [32]byte
+	digest[0] = 0x55
+
+	sig, err := kp.SignDigest32(digest)
+	if err != nil {
+		t.Fatalf("SignDigest32: %v", err)
+	}
+	if len(sig) != ML_DSA_87_SIG_BYTES {
+		t.Fatalf("sig len=%d, want %d", len(sig), ML_DSA_87_SIG_BYTES)
+	}
+	ok, vErr := opensslVerifySigOneShot("ML-DSA-87", kp.PubkeyBytes(), sig, digest[:])
+	if vErr != nil {
+		t.Fatalf("opensslVerifySigOneShot: %v", vErr)
+	}
+	if !ok {
+		t.Fatalf("hedged production signature rejected by verifier under same pubkey")
+	}
+}
+
 func TestSignOpenSSLDigest32_ExactSigLenMismatchErrors(t *testing.T) {
 	kp := mustMLDSA87Keypair(t)
 


### PR DESCRIPTION
## Scope

Harden the Go OpenSSL signer/key-export FFI surface in
`clients/go/consensus/openssl_signer.go` against unusable inputs at
the package-local boundary, and ensure Go-owned keypair objects stay
alive across each FFI call so a finalizer cannot free `EVP_PKEY`
mid-call.

Seven local-Go-only changes:

- `openSSLPublicKeyBytesWithErrBuf` rejects `expectedPubkeyLen <= 0`
  before the `make([]byte, ...)` allocation and the C-pointer
  take-address site.
- `signOpenSSLDigest32` rejects nil `pkey`, non-positive
  `maxSigBytes`, and `exactSigBytes > maxSigBytes` before the C call.
- `MLDSA87Keypair.SignDigest32` runs `runtime.KeepAlive(k)` AFTER
  `signOpenSSLDigest32` returns so the finalizer cannot free
  `k.pkey` while the underlying C call is still using it.
- `MLDSA87Keypair.PrivateKeyDER` adds defensive post-C nil/zero/
  overflow checks (extracted into the new pure-Go helper
  `validatePrivateKeyDERPostC`, mirroring the
  `validateConformanceSignResult` shape already used by the
  conformance-only sibling) and uses `defer runtime.KeepAlive(k)` at
  function entry so `k` is alive across both
  `rubin_private_key_to_der` and the byte-copy return.

Tests in `openssl_signer_additional_test.go` cover every new branch
via the helper-level seam plus a sign+verify roundtrip.

Out of scope: the C entrypoints, OpenSSL provider/FIPS bootstrap, the
conformance-fixture deterministic helper, the verifier path, the
generator, the CLI, the Rust counterpart, conformance fixtures, spec,
and rubin-formal proofs are unchanged. The existing
`C.GoBytes(unsafe.Pointer(der), C.int(derLen))` call in
`PrivateKeyDER` is preserved byte-identical to baseline. No
cross-client parity claim, no determinism claim, no security-audit-
complete claim. Tracked as RUB-161.

## Evidence

- `gofmt -l` clean on touched files
- `go vet ./consensus` clean
- `go test ./consensus -count=1` PASS
- focused: `go test ./consensus -run 'TestMLDSA87Keypair|TestSignOpenSSLDigest32|TestOpenSSL_MLDSA87|TestOpenSSLPublicKeyBytes|TestSignDigest32ForConformanceFixture|TestValidatePrivateKeyDERPostC' -count=1` PASS
- `tooling-check.sh --new-only --mode go-deep` PASS, including
  `go-unsafe-cgo-diff-guard` PASS (no NEW unsafe surface)
- `rubin-common-preflight` 5/5 PASS (bot-premortem, git-diff-check,
  local-agent-hygiene, tooling-check, rubin-protocol-coverage)
- hostile-review RESP PASS on head 5c56a11