### PR TITLE
RUB-136: pin CI OpenSSL floor for ML-DSA deterministic signing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,7 +283,18 @@ jobs:
           RUBIN_OPENSSL_CONF: ${{ env.OPENSSL_CONF }}
           RUBIN_OPENSSL_FIPS_MODE: only
         run: |
-          scripts/dev-env.sh -- bash -lc "cd clients/go && go test ./consensus -run '^TestSignDigest32ForConformanceFixture_Deterministic$' -count=1 -v"
+          set -euo pipefail
+          TEST_NAME=TestSignDigest32ForConformanceFixture_Deterministic
+          OUT="$(mktemp)"
+          scripts/dev-env.sh -- bash -lc "cd clients/go && go test -json -run '^${TEST_NAME}$' ./consensus -count=1" | tee "$OUT"
+          if jq -e --arg t "$TEST_NAME" 'select(.Test == $t and .Action == "skip")' < "$OUT" >/dev/null; then
+            echo "ERROR: ${TEST_NAME} was SKIPPED; the OpenSSL runtime/provider does not expose ML-DSA-87 deterministic-mode signing on this lane" >&2
+            exit 1
+          fi
+          if ! jq -e --arg t "$TEST_NAME" 'select(.Test == $t and .Action == "pass")' < "$OUT" >/dev/null; then
+            echo "ERROR: ${TEST_NAME} did not emit a PASS event; deterministic-mode runtime evidence is missing" >&2
+            exit 1
+          fi
 
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,16 +282,23 @@ jobs:
           RUBIN_OPENSSL_MODULES: ${{ env.OPENSSL_MODULES }}
           RUBIN_OPENSSL_CONF: ${{ env.OPENSSL_CONF }}
           RUBIN_OPENSSL_FIPS_MODE: only
+          # Preflight already enforced in a dedicated earlier step; skipping
+          # the dev-env.sh re-guard here keeps the wrapper's banner/preflight
+          # chatter out of stdout, so jq parses pure go test -json NDJSON.
+          RUBIN_OPENSSL_SKIP_FIPS_GUARD: '1'
         run: |
           set -euo pipefail
           TEST_NAME=TestSignDigest32ForConformanceFixture_Deterministic
           OUT="$(mktemp)"
           scripts/dev-env.sh -- bash -lc "cd clients/go && go test -json -run '^${TEST_NAME}$' ./consensus -count=1" | tee "$OUT"
-          if jq -e --arg t "$TEST_NAME" 'select(.Test == $t and .Action == "skip")' < "$OUT" >/dev/null; then
+          # jq -R 'fromjson?' tolerates any non-JSON line that might appear on
+          # stdout (defense in depth against future wrapper noise) and only
+          # parses well-formed event lines.
+          if jq -Re --arg t "$TEST_NAME" 'fromjson? | select(.Test == $t and .Action == "skip")' < "$OUT" >/dev/null; then
             echo "ERROR: ${TEST_NAME} was SKIPPED; the OpenSSL runtime/provider does not expose ML-DSA-87 deterministic-mode signing on this lane" >&2
             exit 1
           fi
-          if ! jq -e --arg t "$TEST_NAME" 'select(.Test == $t and .Action == "pass")' < "$OUT" >/dev/null; then
+          if ! jq -Re --arg t "$TEST_NAME" 'fromjson? | select(.Test == $t and .Action == "pass")' < "$OUT" >/dev/null; then
             echo "ERROR: ${TEST_NAME} did not emit a PASS event; deterministic-mode runtime evidence is missing" >&2
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,6 +275,16 @@ jobs:
           go-version: '1.25.9'
           cache: true
           cache-dependency-path: clients/go/go.mod
+
+      - name: OpenSSL deterministic ML-DSA-87 signing smoke
+        env:
+          RUBIN_OPENSSL_PREFIX: ${{ env.OPENSSL_DIR }}
+          RUBIN_OPENSSL_MODULES: ${{ env.OPENSSL_MODULES }}
+          RUBIN_OPENSSL_CONF: ${{ env.OPENSSL_CONF }}
+          RUBIN_OPENSSL_FIPS_MODE: only
+        run: |
+          scripts/dev-env.sh -- bash -lc "cd clients/go && go test ./consensus -run '^TestSignDigest32ForConformanceFixture_Deterministic$' -count=1 -v"
+
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           components: rustfmt, clippy
@@ -465,6 +475,11 @@ jobs:
             echo "OPENSSL_MODULES=$MODULES_DIR"
             echo "OPENSSL_CONF=$PREFIX/ssl/openssl-fips.cnf"
           } >> "$GITHUB_ENV"
+
+      - name: Verify OpenSSL PQ algorithms
+        run: |
+          openssl version
+          openssl list -signature-algorithms | grep -E 'ML-DSA-87'
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
@@ -667,6 +682,12 @@ jobs:
             echo "OPENSSL_MODULES=$MODULES_DIR"
             echo "OPENSSL_CONF=$PREFIX/ssl/openssl-fips.cnf"
           } >> "$GITHUB_ENV"
+
+      - name: Verify OpenSSL PQ algorithms
+        run: |
+          openssl version
+          openssl list -signature-algorithms | grep -E 'ML-DSA-87'
+
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: clients/go/go.mod


### PR DESCRIPTION
## Scope

Pin the CI OpenSSL floor for ML-DSA deterministic signing inside
`.github/workflows/ci.yml` only. Three changes inside existing jobs;
no new workflow file, no new job, no production code, fixture, or
Rust path is touched.

- `test` job: a new "OpenSSL deterministic ML-DSA-87 signing smoke"
  step runs after the existing FIPS provider preflight under
  `RUBIN_OPENSSL_FIPS_MODE=only` and `RUBIN_OPENSSL_SKIP_FIPS_GUARD=1`
  (preflight already ran as a dedicated earlier step in the same
  job; the per-step skip-guard suppresses the `[dev-env] enforcing
  FIPS-only runtime guard via fips-preflight.sh` banner so the
  parser only sees `go test -json` NDJSON). The step invokes
  `go test -json -run '^TestSignDigest32ForConformanceFixture_Deterministic$' ./consensus`
  through `scripts/dev-env.sh`, captures the NDJSON event stream
  via `tee`, and asserts via `jq -Re --arg t ... 'fromjson? | select(...)'`
  that (a) zero events for that test have `Action == "skip"` and
  (b) at least one event has `Action == "pass"`. `fromjson?`
  silently drops any non-JSON line as defence-in-depth against
  future wrapper noise. A skip or missing PASS exits the step with
  an explicit error naming the missing OpenSSL runtime/provider
  surface — the smoke is fail-closed against the
  `mustMLDSA87Keypair`/`t.Skipf` capability path AND against any
  pipe-source contamination class.
- `go_race_node` job: a new two-line "Verify OpenSSL PQ algorithms"
  step runs `openssl version` and
  `openssl list -signature-algorithms | grep -E 'ML-DSA-87'` after
  the existing `Build OpenSSL 3.5.5 bundle` step, mirroring the
  identical step already present in `test` and `formal_refinement`.
- `conformance_fixtures_drift` job: same new two-line "Verify
  OpenSSL PQ algorithms" step, mirroring the same pattern.

Out of scope: production signing, signature verification, the
conformance-fixture deterministic helper itself, the conformance
fixtures, the spec, the formal bridge, the Rust counterpart
(rust-freeze; RUB-136 is `go-only` per its routing labels), the
FIPS provider/bootstrap policy, the OpenSSL bundle build script
(`scripts/crypto/openssl/build-openssl-bundle.sh`), and the broader
CI lane structure. The existing `Verify OpenSSL PQ algorithms`
steps in `test` and `formal_refinement` are preserved unchanged.
The new smoke reuses the existing `TestSignDigest32ForConformanceFixture_Deterministic`
test as its runtime probe; no new test is introduced. Tracked as
RUB-136.

## Evidence

- branch on `af4b12b`; cumulative diff is 1 file, +33 / -1 lines:
  `0ab0132` (initial smoke + version-evidence) → `eb8ce10`
  (fail-closed JSON-event assertion against SKIP) → `af4b12b`
  (env skip-guard + jq -R/fromjson defence vs wrapper banner)
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` clean
- local replay under exact CI env shape (`RUBIN_OPENSSL_FIPS_MODE=only`
  + `RUBIN_OPENSSL_SKIP_FIPS_GUARD=1`, `scripts/dev-env.sh`,
  `go test -json`, `tee`, `jq -Re 'fromjson?'`):
  clean go-test-json → no skip + pass found;
  banner-prefixed NDJSON → no skip + pass found (filter strips);
  synthetic skip events → skip detected (fail-closed) + no false PASS
- `git diff --name-only origin/main...HEAD` returns exactly
  `.github/workflows/ci.yml`
- `rubin-common-preflight` PASS_WITH_COVERAGE_SKIP authorization=AUTOMATIC_NO_COVERAGE_SURFACE
  on head `af4b12b` (workflow-only diff has no coverable Go/Rust
  surface; surface classifier authorisation)
- hostile-review post-diff RESP BLOCKED on `0ab0132` flagged the
  fail-open SKIP path (closed by `eb8ce10`); fix-pass-1 RESP PASS
  on `eb8ce10`; fix-pass-2 RESP confirms local af4b12b code passes
  the reviewer's independent replay (`PASS` on local diff;
  procedural BLOCKED on push-state drift, closed by this push +
  the inline thread replies)
- bot-reviewer threads resolved on this push: Codex Connector P1
  ([discussion_r3175684955](https://github.com/2tbmz9y2xt-lang/rubin-protocol/pull/1402#discussion_r3175684955)),
  Copilot P1 ([discussion_r3175685193](https://github.com/2tbmz9y2xt-lang/rubin-protocol/pull/1402#discussion_r3175685193))
- pre-push LOCAL SECURITY REVIEW PASS