### PR TITLE
Add advisory performance regression detection (#1363)

### DIFF
--- a/.github/workflows/combined-load-nightly.yml
+++ b/.github/workflows/combined-load-nightly.yml
@@ -76,7 +76,7 @@ jobs:
         run: |
           scripts/benchmarks/run_combined_load_benchmark.sh artifacts/combined-load
 
-      - name: Write combined-load advisory summary
+      - name: Append combined-load advisory summary to step summary
         if: always()
         run: |
           if [ -f artifacts/combined-load/combined_load_summary.md ]; then
@@ -85,9 +85,9 @@ jobs:
             {
               echo "# Combined-Load Advisory SLO"
               echo
-              echo "Status: \`no_data\`."
+              echo "Status: \`error\`."
               echo
-              echo "Combined-load summary artifact was not produced."
+              echo "Combined-load summary artifact was not produced; the benchmark wrapper failed before advisory summary emission or the summary write failed."
             } >> "$GITHUB_STEP_SUMMARY"
           fi
 

--- a/.github/workflows/combined-load-nightly.yml
+++ b/.github/workflows/combined-load-nightly.yml
@@ -81,6 +81,38 @@ jobs:
         run: |
           if [ -f artifacts/combined-load/combined_load_summary.md ]; then
             cat artifacts/combined-load/combined_load_summary.md >> "$GITHUB_STEP_SUMMARY"
+          elif [ -f artifacts/combined-load/combined_load_metrics.json ]; then
+            python3 - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import json
+          from pathlib import Path
+
+          metrics_path = Path("artifacts/combined-load/combined_load_metrics.json")
+          status = "no_data"
+          reason = "combined-load summary artifact was not produced"
+          try:
+              payload = json.loads(metrics_path.read_text(encoding="utf-8", errors="strict"))
+              raw_status = payload.get("status")
+              if isinstance(raw_status, str) and raw_status:
+                  status = raw_status
+              raw_reason = payload.get("reason")
+              if isinstance(raw_reason, str) and raw_reason:
+                  reason = raw_reason
+          except Exception as exc:
+              reason = f"combined-load metrics artifact could not be read: {exc}"
+
+          reason = reason.replace("\r", " ").replace("\n", " ")
+          print("# Combined-Load Advisory SLO")
+          print()
+          print(f"Status: `{status}`.")
+          print()
+          print(
+              "Combined-load summary artifact was not produced; fallback status was derived "
+              "from `combined_load_metrics.json` to keep the GitHub summary aligned with "
+              "the uploaded JSON artifact."
+          )
+          print()
+          print(f"- reason: {reason}")
+          PY
           else
             {
               echo "# Combined-Load Advisory SLO"

--- a/.github/workflows/combined-load-nightly.yml
+++ b/.github/workflows/combined-load-nightly.yml
@@ -85,9 +85,9 @@ jobs:
             {
               echo "# Combined-Load Advisory SLO"
               echo
-              echo "Status: \`error\`."
+              echo "Status: \`no_data\`."
               echo
-              echo "Combined-load summary artifact was not produced; the benchmark wrapper failed before advisory summary emission or the summary write failed."
+              echo "Combined-load summary artifact was not produced; the benchmark wrapper failed before advisory summary emission or the summary write failed. This is not classified as an advisory regression."
             } >> "$GITHUB_STEP_SUMMARY"
           fi
 

--- a/.github/workflows/combined-load-nightly.yml
+++ b/.github/workflows/combined-load-nightly.yml
@@ -76,6 +76,21 @@ jobs:
         run: |
           scripts/benchmarks/run_combined_load_benchmark.sh artifacts/combined-load
 
+      - name: Write combined-load advisory summary
+        if: always()
+        run: |
+          if [ -f artifacts/combined-load/combined_load_summary.md ]; then
+            cat artifacts/combined-load/combined_load_summary.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo "# Combined-Load Advisory SLO"
+              echo
+              echo "Status: \`no_data\`."
+              echo
+              echo "Combined-load summary artifact was not produced."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
       - name: Build combined-load trend artifact
         if: always()
         run: |

--- a/evidence/runtime-perf/CI_RUNTIME_PERF_GUARDRAILS.md
+++ b/evidence/runtime-perf/CI_RUNTIME_PERF_GUARDRAILS.md
@@ -45,13 +45,16 @@ Rust:
 
 ## Future soft-threshold path
 
-This lane is intentionally non-blocking for now. The next hardening step, if
-the project wants it later, is:
+This lane is intentionally non-blocking. Advisory regression detection may emit
+`warn` in summaries and artifacts for selected low-noise benchmark deltas, but
+that warning is not a merge-blocking status.
+
+Further threshold hardening, if the project wants it later, is:
 
 1. require several stable runs on `main`;
 2. pick only the low-noise subset of benchmarks;
-3. define soft thresholds per benchmark family;
-4. keep threshold breaches advisory first, not merge-blocking.
+3. refine soft thresholds per benchmark family;
+4. keep any promotion to a merge-blocking gate as a separate policy task.
 
 ## Mainline trend capture
 

--- a/evidence/runtime-perf/CI_RUNTIME_PERF_GUARDRAILS.md
+++ b/evidence/runtime-perf/CI_RUNTIME_PERF_GUARDRAILS.md
@@ -46,8 +46,10 @@ Rust:
 ## Future soft-threshold path
 
 This lane is intentionally non-blocking. Advisory regression detection may emit
-`warn` in summaries and artifacts for selected low-noise benchmark deltas, but
-that warning is not a merge-blocking status.
+`warn` in summaries and artifacts for selected low-noise `ns/op` benchmark
+deltas, but that warning is not a merge-blocking status. Allocation and byte
+metrics remain reported for context unless a later task adds explicit advisory
+thresholds for them.
 
 Further threshold hardening, if the project wants it later, is:
 

--- a/scripts/benchmarks/COMBINED_LOAD_SLO.md
+++ b/scripts/benchmarks/COMBINED_LOAD_SLO.md
@@ -52,4 +52,4 @@ Artifacts:
 - `combined_load_metrics.json`
 - `combined_load_summary.md`
 
-Both artifacts MUST be kept with workflow run metadata for audit evidence.
+These artifacts MUST be kept with workflow run metadata for audit evidence.

--- a/scripts/benchmarks/COMBINED_LOAD_SLO.md
+++ b/scripts/benchmarks/COMBINED_LOAD_SLO.md
@@ -31,6 +31,15 @@ SLO thresholds are stored in:
 
 - `scripts/benchmarks/combined_load_slo.json`
 
+The SLO is advisory. A threshold breach is emitted as `status: "warn"` in the
+parsed JSON and workflow summary, but it must not fail the nightly workflow.
+Missing benchmark data is emitted as `status: "no_data"` instead of being
+classified as a regression.
+
+Current threshold calibration remains intentionally broad. The nightly workflow
+preserves `trend.json` / `trend.md` so a later task can tighten thresholds from
+retained multi-run median, p90, and variance data.
+
 ## Evidence Lane
 
 Nightly/manual workflow:
@@ -41,5 +50,6 @@ Artifacts:
 
 - `combined_load_benchmark.txt`
 - `combined_load_metrics.json`
+- `combined_load_summary.md`
 
 Both artifacts MUST be kept with workflow run metadata for audit evidence.

--- a/scripts/benchmarks/combined_load_slo.json
+++ b/scripts/benchmarks/combined_load_slo.json
@@ -1,6 +1,12 @@
 {
   "benchmark": "BenchmarkValidateBlockBasicCombinedLoad",
+  "mode": "advisory",
   "max_ns_per_op": 3000000000,
   "max_b_per_op": 800000000,
-  "max_allocs_per_op": 3000000
+  "max_allocs_per_op": 3000000,
+  "calibration": {
+    "source": "evidence/runtime-perf/MAINLINE_TREND_CAPTURE.md",
+    "status": "broad_existing_limit_pending_multi_run_variance",
+    "reason": "The combined-load nightly lane now preserves trend artifacts, but the repository does not yet contain enough retained multi-run variance data to justify a tighter threshold. The existing broad SLO remains advisory-only."
+  }
 }

--- a/scripts/benchmarks/combined_load_slo.json
+++ b/scripts/benchmarks/combined_load_slo.json
@@ -1,6 +1,5 @@
 {
   "benchmark": "BenchmarkValidateBlockBasicCombinedLoad",
-  "mode": "advisory",
   "max_ns_per_op": 3000000000,
   "max_b_per_op": 800000000,
   "max_allocs_per_op": 3000000,

--- a/scripts/benchmarks/parse_go_bench.py
+++ b/scripts/benchmarks/parse_go_bench.py
@@ -11,10 +11,10 @@ from typing import Any
 
 
 CORE_METRIC_PATTERNS = {
-    "ns_per_op": re.compile(r"\b(?P<value>\S+)\s+ns/op\b"),
-    "mb_per_s": re.compile(r"\b(?P<value>\S+)\s+MB/s\b"),
-    "b_per_op": re.compile(r"\b(?P<value>\S+)\s+B/op\b"),
-    "allocs_per_op": re.compile(r"\b(?P<value>\S+)\s+allocs/op\b"),
+    "ns_per_op": re.compile(r"(?<!\S)(?P<value>\S+)\s+ns/op\b"),
+    "mb_per_s": re.compile(r"(?<!\S)(?P<value>\S+)\s+MB/s\b"),
+    "b_per_op": re.compile(r"(?<!\S)(?P<value>\S+)\s+B/op\b"),
+    "allocs_per_op": re.compile(r"(?<!\S)(?P<value>\S+)\s+allocs/op\b"),
 }
 
 
@@ -25,7 +25,7 @@ METRIC_CHECKS = [
 ]
 
 
-def parse_finite_number(raw: Any, label: str) -> float:
+def parse_finite_number(raw: Any, label: str, *, allow_zero: bool) -> float:
     if isinstance(raw, bool) or raw is None:
         raise ValueError(f"{label} is not numeric: {raw!r}")
     try:
@@ -34,11 +34,14 @@ def parse_finite_number(raw: Any, label: str) -> float:
         raise ValueError(f"{label} has invalid numeric token {raw!r}") from exc
     if not math.isfinite(value):
         raise ValueError(f"{label} has non-finite numeric token {raw!r}")
+    if value < 0 or (value == 0 and not allow_zero):
+        bound = "non-negative" if allow_zero else "positive"
+        raise ValueError(f"{label} must be {bound}: {raw!r}")
     return value
 
 
 def parse_metric(raw: str) -> float:
-    return parse_finite_number(raw.strip(), "metric")
+    return parse_finite_number(raw.strip(), "metric", allow_zero=True)
 
 
 def strip_go_benchmark_suffix(name: str) -> str:
@@ -86,7 +89,7 @@ def load_slo(path: Path) -> dict[str, Any]:
         if key not in payload:
             raise ValueError(f"SLO missing required key {key!r}")
     for _, limit_key in METRIC_CHECKS:
-        payload[limit_key] = parse_finite_number(payload[limit_key], f"SLO {limit_key}")
+        payload[limit_key] = parse_finite_number(payload[limit_key], f"SLO {limit_key}", allow_zero=False)
     return payload
 
 

--- a/scripts/benchmarks/parse_go_bench.py
+++ b/scripts/benchmarks/parse_go_bench.py
@@ -90,6 +90,8 @@ def load_slo(path: Path) -> dict[str, Any]:
             raise ValueError(f"SLO missing required key {key!r}")
     if not isinstance(payload["benchmark"], str) or not payload["benchmark"].strip():
         raise ValueError("SLO benchmark must be a non-empty string")
+    if payload["benchmark"] != payload["benchmark"].strip():
+        raise ValueError("SLO benchmark must not contain leading or trailing whitespace")
     for _, limit_key in METRIC_CHECKS:
         payload[limit_key] = parse_finite_number(payload[limit_key], f"SLO {limit_key}", allow_zero=False)
     return payload

--- a/scripts/benchmarks/parse_go_bench.py
+++ b/scripts/benchmarks/parse_go_bench.py
@@ -9,14 +9,12 @@ from pathlib import Path
 from typing import Any
 
 
-BENCH_LINE_RE = re.compile(
-    r"^(?P<name>BenchmarkValidateBlockBasicCombinedLoad(?:-\d+)?)\s+"
-    r"(?P<n>\d+)\s+"
-    r"(?P<ns>[\d.]+)\s+ns/op\s+"
-    r"(?:(?P<mbps>[\d.]+)\s+MB/s\s+)?"
-    r"(?P<bop>[\d.]+)\s+B/op\s+"
-    r"(?P<allocs>[\d.]+)\s+allocs/op$"
-)
+CORE_METRIC_PATTERNS = {
+    "ns_per_op": re.compile(r"\b(?P<value>[\d.]+)\s+ns/op\b"),
+    "mb_per_s": re.compile(r"\b(?P<value>[\d.]+)\s+MB/s\b"),
+    "b_per_op": re.compile(r"\b(?P<value>[\d.]+)\s+B/op\b"),
+    "allocs_per_op": re.compile(r"\b(?P<value>[\d.]+)\s+allocs/op\b"),
+}
 
 
 METRIC_CHECKS = [
@@ -28,6 +26,29 @@ METRIC_CHECKS = [
 
 def parse_metric(raw: str) -> float:
     return float(raw.strip())
+
+
+def parse_benchmark_line(line: str, benchmark: str) -> dict[str, Any] | None:
+    prefix = re.match(
+        rf"^(?P<name>{re.escape(benchmark)}(?:-\d+)?)\s+(?P<n>\d+)\s+(?P<metrics>.*)$",
+        line.strip(),
+    )
+    if prefix is None:
+        return None
+    metrics = prefix.group("metrics")
+    parsed: dict[str, Any] = {
+        "benchmark": prefix.group("name").split("-")[0],
+        "iterations": int(prefix.group("n")),
+    }
+    for key, pattern in CORE_METRIC_PATTERNS.items():
+        match = pattern.search(metrics)
+        if match is None:
+            if key == "mb_per_s":
+                parsed[key] = None
+                continue
+            return None
+        parsed[key] = parse_metric(match.group("value"))
+    return parsed
 
 
 def load_slo(path: Path) -> dict[str, Any]:
@@ -57,23 +78,22 @@ def no_data_result(slo: dict[str, Any] | None, reason: str) -> dict[str, Any]:
 
 
 def parse_benchmark(lines: list[str], slo: dict[str, Any]) -> dict[str, Any]:
-    match = None
+    benchmark = str(slo["benchmark"])
+    parsed = None
     for line in lines:
-        parsed = BENCH_LINE_RE.match(line.strip())
-        if parsed:
-            match = parsed
+        parsed = parse_benchmark_line(line, benchmark)
+        if parsed is not None:
             break
-    if match is None:
-        return no_data_result(slo, "benchmark line for BenchmarkValidateBlockBasicCombinedLoad not found")
+    if parsed is None:
+        return no_data_result(slo, f"benchmark line for {benchmark} not found")
 
-    benchmark_name = match.group("name").split("-")[0]
     result: dict[str, Any] = {
-        "benchmark": benchmark_name,
-        "iterations": int(match.group("n")),
-        "ns_per_op": parse_metric(match.group("ns")),
-        "mb_per_s": parse_metric(match.group("mbps")) if match.group("mbps") else None,
-        "b_per_op": parse_metric(match.group("bop")),
-        "allocs_per_op": parse_metric(match.group("allocs")),
+        "benchmark": parsed["benchmark"],
+        "iterations": parsed["iterations"],
+        "ns_per_op": parsed["ns_per_op"],
+        "mb_per_s": parsed["mb_per_s"],
+        "b_per_op": parsed["b_per_op"],
+        "allocs_per_op": parsed["allocs_per_op"],
         "slo": slo,
         "status": "pass",
         "violations": [],
@@ -81,10 +101,10 @@ def parse_benchmark(lines: list[str], slo: dict[str, Any]) -> dict[str, Any]:
         "advisory": True,
     }
 
-    if benchmark_name != slo.get("benchmark"):
+    if result["benchmark"] != slo.get("benchmark"):
         return no_data_result(
             slo,
-            f"benchmark mismatch: got {benchmark_name!r}, expected {slo.get('benchmark')!r}",
+            f"benchmark mismatch: got {result['benchmark']!r}, expected {slo.get('benchmark')!r}",
         )
 
     for metric_key, limit_key in METRIC_CHECKS:

--- a/scripts/benchmarks/parse_go_bench.py
+++ b/scripts/benchmarks/parse_go_bench.py
@@ -6,6 +6,7 @@ import json
 import re
 import sys
 from pathlib import Path
+from typing import Any
 
 
 BENCH_LINE_RE = re.compile(
@@ -18,42 +19,55 @@ BENCH_LINE_RE = re.compile(
 )
 
 
+METRIC_CHECKS = [
+    ("ns_per_op", "max_ns_per_op"),
+    ("b_per_op", "max_b_per_op"),
+    ("allocs_per_op", "max_allocs_per_op"),
+]
+
+
 def parse_metric(raw: str) -> float:
     return float(raw.strip())
 
 
-def main() -> int:
-    parser = argparse.ArgumentParser(description="Parse Go benchmark output and enforce SLO.")
-    parser.add_argument("--input", required=True, help="Path to go test benchmark stdout file.")
-    parser.add_argument("--slo", required=True, help="Path to JSON SLO config.")
-    parser.add_argument("--output", required=True, help="Path to write parsed JSON metrics.")
-    args = parser.parse_args()
+def load_slo(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8", errors="strict"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"SLO JSON root is {type(payload).__name__}, expected object")
+    for key in ["benchmark", "max_ns_per_op", "max_b_per_op", "max_allocs_per_op"]:
+        if key not in payload:
+            raise ValueError(f"SLO missing required key {key!r}")
+    return payload
 
-    input_path = Path(args.input)
-    slo_path = Path(args.slo)
-    output_path = Path(args.output)
 
-    if not input_path.exists():
-        print(f"ERROR: benchmark output not found: {input_path}", file=sys.stderr)
-        return 1
-    if not slo_path.exists():
-        print(f"ERROR: SLO file not found: {slo_path}", file=sys.stderr)
-        return 1
+def no_data_result(slo: dict[str, Any] | None, reason: str) -> dict[str, Any]:
+    return {
+        "benchmark": slo.get("benchmark") if slo else None,
+        "iterations": None,
+        "ns_per_op": None,
+        "mb_per_s": None,
+        "b_per_op": None,
+        "allocs_per_op": None,
+        "slo": slo,
+        "status": "no_data",
+        "violations": [],
+        "reason": reason,
+        "advisory": True,
+    }
 
-    lines = input_path.read_text(encoding="utf-8", errors="strict").splitlines()
+
+def parse_benchmark(lines: list[str], slo: dict[str, Any]) -> dict[str, Any]:
     match = None
     for line in lines:
-        m = BENCH_LINE_RE.match(line.strip())
-        if m:
-            match = m
+        parsed = BENCH_LINE_RE.match(line.strip())
+        if parsed:
+            match = parsed
             break
     if match is None:
-        print("ERROR: benchmark line for BenchmarkValidateBlockBasicCombinedLoad not found", file=sys.stderr)
-        return 1
+        return no_data_result(slo, "benchmark line for BenchmarkValidateBlockBasicCombinedLoad not found")
 
-    slo = json.loads(slo_path.read_text(encoding="utf-8", errors="strict"))
     benchmark_name = match.group("name").split("-")[0]
-    result = {
+    result: dict[str, Any] = {
         "benchmark": benchmark_name,
         "iterations": int(match.group("n")),
         "ns_per_op": parse_metric(match.group("ns")),
@@ -63,38 +77,98 @@ def main() -> int:
         "slo": slo,
         "status": "pass",
         "violations": [],
+        "reason": "combined-load benchmark is within advisory SLO",
+        "advisory": True,
     }
 
     if benchmark_name != slo.get("benchmark"):
-        result["status"] = "fail"
-        result["violations"].append(
-            f"benchmark mismatch: got {benchmark_name!r}, expected {slo.get('benchmark')!r}"
+        return no_data_result(
+            slo,
+            f"benchmark mismatch: got {benchmark_name!r}, expected {slo.get('benchmark')!r}",
         )
 
-    checks = [
-        ("ns_per_op", "max_ns_per_op"),
-        ("b_per_op", "max_b_per_op"),
-        ("allocs_per_op", "max_allocs_per_op"),
-    ]
-    for metric_key, limit_key in checks:
+    for metric_key, limit_key in METRIC_CHECKS:
         limit = float(slo[limit_key])
         value = float(result[metric_key])
         if value > limit:
-            result["status"] = "fail"
-            result["violations"].append(
-                f"{metric_key}={value} exceeds {limit_key}={limit}"
-            )
+            result["status"] = "warn"
+            result["violations"].append(f"{metric_key}={value} exceeds {limit_key}={limit}")
+    if result["status"] == "warn":
+        result["reason"] = "combined-load benchmark exceeded advisory SLO; workflow remains non-blocking"
+    return result
 
+
+def render_summary(result: dict[str, Any]) -> str:
+    lines = [
+        "# Combined-Load Advisory SLO",
+        "",
+        f"Status: `{result['status']}`.",
+        "",
+        "This check is advisory only. `warn` and `no_data` do not fail the workflow.",
+        "",
+        f"- benchmark: `{result.get('benchmark')}`",
+        f"- ns_per_op: `{result.get('ns_per_op')}`",
+        f"- b_per_op: `{result.get('b_per_op')}`",
+        f"- allocs_per_op: `{result.get('allocs_per_op')}`",
+        f"- reason: {result.get('reason')}",
+        "",
+    ]
+    violations = result.get("violations") or []
+    if violations:
+        lines.extend(["## Advisory violations", ""])
+        lines.extend(f"- {violation}" for violation in violations)
+        lines.append("")
+    return "\n".join(lines)
+
+
+def write_outputs(output_path: Path, summary_path: Path | None, result: dict[str, Any]) -> None:
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    output_path.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
+    output_path.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if summary_path is not None:
+        summary_path.parent.mkdir(parents=True, exist_ok=True)
+        summary_path.write_text(render_summary(result), encoding="utf-8")
 
-    if result["status"] != "pass":
-        print("ERROR: combined-load SLO failed", file=sys.stderr)
-        for violation in result["violations"]:
-            print(f" - {violation}", file=sys.stderr)
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Parse Go benchmark output and emit advisory combined-load SLO status.")
+    parser.add_argument("--input", required=True, help="Path to go test benchmark stdout file.")
+    parser.add_argument("--slo", required=True, help="Path to JSON SLO config.")
+    parser.add_argument("--output", required=True, help="Path to write parsed JSON metrics.")
+    parser.add_argument("--summary", help="Optional path to write markdown advisory summary.")
+    args = parser.parse_args()
+
+    input_path = Path(args.input)
+    slo_path = Path(args.slo)
+    output_path = Path(args.output)
+    summary_path = Path(args.summary) if args.summary else None
+
+    if not slo_path.exists():
+        print(f"ERROR: SLO file not found: {slo_path}", file=sys.stderr)
+        return 1
+    try:
+        slo = load_slo(slo_path)
+    except (json.JSONDecodeError, ValueError) as exc:
+        print(f"ERROR: invalid SLO file {slo_path}: {exc}", file=sys.stderr)
         return 1
 
-    print("OK: combined-load benchmark parsed and within SLO.")
+    if not input_path.exists():
+        result = no_data_result(slo, f"benchmark output not found: {input_path}")
+        write_outputs(output_path, summary_path, result)
+        print("WARN: combined-load benchmark data unavailable; wrote no_data advisory result.")
+        return 0
+
+    lines = input_path.read_text(encoding="utf-8", errors="strict").splitlines()
+    result = parse_benchmark(lines, slo)
+    write_outputs(output_path, summary_path, result)
+
+    if result["status"] == "pass":
+        print("OK: combined-load benchmark parsed and within advisory SLO.")
+    elif result["status"] == "warn":
+        print("WARN: combined-load advisory SLO exceeded; workflow remains non-blocking.", file=sys.stderr)
+        for violation in result["violations"]:
+            print(f" - {violation}", file=sys.stderr)
+    else:
+        print("WARN: combined-load benchmark data unavailable; wrote no_data advisory result.", file=sys.stderr)
     return 0
 
 

--- a/scripts/benchmarks/parse_go_bench.py
+++ b/scripts/benchmarks/parse_go_bench.py
@@ -92,6 +92,8 @@ def load_slo(path: Path) -> dict[str, Any]:
         raise ValueError("SLO benchmark must be a non-empty string")
     if any(ch.isspace() for ch in payload["benchmark"]):
         raise ValueError("SLO benchmark must not contain whitespace")
+    if re.search(r"-\d+$", payload["benchmark"]):
+        raise ValueError("SLO benchmark must not include Go CPU suffix")
     for _, limit_key in METRIC_CHECKS:
         payload[limit_key] = parse_finite_number(payload[limit_key], f"SLO {limit_key}", allow_zero=False)
     return payload
@@ -194,7 +196,16 @@ def main() -> int:
     parser.add_argument("--slo", required=True, help="Path to JSON SLO config.")
     parser.add_argument("--output", required=True, help="Path to write parsed JSON metrics.")
     parser.add_argument("--summary", help="Optional path to write markdown advisory summary.")
+    parser.add_argument(
+        "--producer-exit-code",
+        type=int,
+        default=0,
+        help="Exit code from the benchmark producer; non-zero forces advisory no_data.",
+    )
     args = parser.parse_args()
+
+    if args.producer_exit_code < 0:
+        parser.error("--producer-exit-code must be non-negative")
 
     input_path = Path(args.input)
     slo_path = Path(args.slo)
@@ -209,6 +220,12 @@ def main() -> int:
     except (json.JSONDecodeError, UnicodeDecodeError, ValueError) as exc:
         print(f"ERROR: invalid SLO file {slo_path}: {exc}", file=sys.stderr)
         return 1
+
+    if args.producer_exit_code != 0:
+        result = no_data_result(slo, f"benchmark command failed with status {args.producer_exit_code}")
+        write_outputs(output_path, summary_path, result)
+        print("WARN: combined-load benchmark command failed; wrote no_data advisory result.", file=sys.stderr)
+        return 0
 
     if not input_path.exists():
         result = no_data_result(slo, f"benchmark output not found: {input_path}")

--- a/scripts/benchmarks/parse_go_bench.py
+++ b/scripts/benchmarks/parse_go_bench.py
@@ -88,6 +88,8 @@ def load_slo(path: Path) -> dict[str, Any]:
     for key in ["benchmark", "max_ns_per_op", "max_b_per_op", "max_allocs_per_op"]:
         if key not in payload:
             raise ValueError(f"SLO missing required key {key!r}")
+    if not isinstance(payload["benchmark"], str) or not payload["benchmark"].strip():
+        raise ValueError("SLO benchmark must be a non-empty string")
     for _, limit_key in METRIC_CHECKS:
         payload[limit_key] = parse_finite_number(payload[limit_key], f"SLO {limit_key}", allow_zero=False)
     return payload

--- a/scripts/benchmarks/parse_go_bench.py
+++ b/scripts/benchmarks/parse_go_bench.py
@@ -28,27 +28,38 @@ def parse_metric(raw: str) -> float:
     return float(raw.strip())
 
 
-def parse_benchmark_line(line: str, benchmark: str) -> dict[str, Any] | None:
+def strip_go_benchmark_suffix(name: str) -> str:
+    parts = name.rsplit("-", 1)
+    if len(parts) == 2 and parts[1].isdigit():
+        return parts[0]
+    return name
+
+
+def parse_benchmark_line(line: str, benchmark: str) -> tuple[dict[str, Any] | None, str | None]:
     prefix = re.match(
         rf"^(?P<name>{re.escape(benchmark)}(?:-\d+)?)\s+(?P<n>\d+)\s+(?P<metrics>.*)$",
         line.strip(),
     )
     if prefix is None:
-        return None
+        return None, None
     metrics = prefix.group("metrics")
     parsed: dict[str, Any] = {
-        "benchmark": prefix.group("name").split("-")[0],
+        "benchmark": strip_go_benchmark_suffix(prefix.group("name")),
         "iterations": int(prefix.group("n")),
     }
+    missing: list[str] = []
     for key, pattern in CORE_METRIC_PATTERNS.items():
         match = pattern.search(metrics)
         if match is None:
             if key == "mb_per_s":
                 parsed[key] = None
                 continue
-            return None
+            missing.append(key)
+            continue
         parsed[key] = parse_metric(match.group("value"))
-    return parsed
+    if missing:
+        return None, f"benchmark line for {benchmark} missing required metric(s): {', '.join(missing)}"
+    return parsed, None
 
 
 def load_slo(path: Path) -> dict[str, Any]:
@@ -80,12 +91,15 @@ def no_data_result(slo: dict[str, Any] | None, reason: str) -> dict[str, Any]:
 def parse_benchmark(lines: list[str], slo: dict[str, Any]) -> dict[str, Any]:
     benchmark = str(slo["benchmark"])
     parsed = None
+    parse_issue = None
     for line in lines:
-        parsed = parse_benchmark_line(line, benchmark)
+        parsed, parse_issue = parse_benchmark_line(line, benchmark)
+        if parse_issue is not None:
+            break
         if parsed is not None:
             break
     if parsed is None:
-        return no_data_result(slo, f"benchmark line for {benchmark} not found")
+        return no_data_result(slo, parse_issue or f"benchmark line for {benchmark} not found")
 
     result: dict[str, Any] = {
         "benchmark": parsed["benchmark"],

--- a/scripts/benchmarks/parse_go_bench.py
+++ b/scripts/benchmarks/parse_go_bench.py
@@ -202,7 +202,7 @@ def main() -> int:
         return 1
     try:
         slo = load_slo(slo_path)
-    except (json.JSONDecodeError, ValueError) as exc:
+    except (json.JSONDecodeError, UnicodeDecodeError, ValueError) as exc:
         print(f"ERROR: invalid SLO file {slo_path}: {exc}", file=sys.stderr)
         return 1
 
@@ -212,7 +212,13 @@ def main() -> int:
         print("WARN: combined-load benchmark data unavailable; wrote no_data advisory result.")
         return 0
 
-    lines = input_path.read_text(encoding="utf-8", errors="strict").splitlines()
+    try:
+        lines = input_path.read_text(encoding="utf-8", errors="strict").splitlines()
+    except (OSError, UnicodeDecodeError) as exc:
+        result = no_data_result(slo, f"benchmark output unreadable: {input_path}: {exc}")
+        write_outputs(output_path, summary_path, result)
+        print("WARN: combined-load benchmark data unavailable; wrote no_data advisory result.", file=sys.stderr)
+        return 0
     result = parse_benchmark(lines, slo)
     write_outputs(output_path, summary_path, result)
 

--- a/scripts/benchmarks/parse_go_bench.py
+++ b/scripts/benchmarks/parse_go_bench.py
@@ -51,6 +51,13 @@ def strip_go_benchmark_suffix(name: str) -> str:
     return name
 
 
+def go_benchmark_line_name(line: str) -> str | None:
+    match = re.match(r"^(?P<name>Benchmark\S+(?:-\d+)?)\s+\d+\s+", line.strip())
+    if match is None:
+        return None
+    return strip_go_benchmark_suffix(match.group("name"))
+
+
 def parse_benchmark_line(line: str, benchmark: str) -> tuple[dict[str, Any] | None, str | None]:
     prefix = re.match(
         rf"^(?P<name>{re.escape(benchmark)}(?:-\d+)?)\s+(?P<n>\d+)\s+(?P<metrics>.*)$",
@@ -119,14 +126,23 @@ def parse_benchmark(lines: list[str], slo: dict[str, Any]) -> dict[str, Any]:
     benchmark = str(slo["benchmark"])
     parsed = None
     parse_issue = None
+    available_benchmarks: list[str] = []
     for line in lines:
+        line_name = go_benchmark_line_name(line)
+        if line_name is not None:
+            available_benchmarks.append(line_name)
         parsed, parse_issue = parse_benchmark_line(line, benchmark)
         if parse_issue is not None:
             break
         if parsed is not None:
             break
     if parsed is None:
-        return no_data_result(slo, parse_issue or f"benchmark line for {benchmark} not found")
+        if parse_issue is not None:
+            return no_data_result(slo, parse_issue)
+        if available_benchmarks:
+            available = ", ".join(sorted(set(available_benchmarks)))
+            raise ValueError(f"SLO benchmark {benchmark!r} not found in benchmark output; available benchmark(s): {available}")
+        return no_data_result(slo, f"benchmark line for {benchmark} not found")
 
     result: dict[str, Any] = {
         "benchmark": parsed["benchmark"],
@@ -184,7 +200,7 @@ def render_summary(result: dict[str, Any]) -> str:
 
 def write_outputs(output_path: Path, summary_path: Path | None, result: dict[str, Any]) -> None:
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    output_path.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    output_path.write_text(json.dumps(result, allow_nan=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     if summary_path is not None:
         summary_path.parent.mkdir(parents=True, exist_ok=True)
         summary_path.write_text(render_summary(result), encoding="utf-8")
@@ -240,7 +256,11 @@ def main() -> int:
         write_outputs(output_path, summary_path, result)
         print("WARN: combined-load benchmark data unavailable; wrote no_data advisory result.", file=sys.stderr)
         return 0
-    result = parse_benchmark(lines, slo)
+    try:
+        result = parse_benchmark(lines, slo)
+    except ValueError as exc:
+        print(f"ERROR: invalid combined-load SLO benchmark selection: {exc}", file=sys.stderr)
+        return 1
     write_outputs(output_path, summary_path, result)
 
     if result["status"] == "pass":

--- a/scripts/benchmarks/parse_go_bench.py
+++ b/scripts/benchmarks/parse_go_bench.py
@@ -230,7 +230,7 @@ def main() -> int:
     if not input_path.exists():
         result = no_data_result(slo, f"benchmark output not found: {input_path}")
         write_outputs(output_path, summary_path, result)
-        print("WARN: combined-load benchmark data unavailable; wrote no_data advisory result.")
+        print("WARN: combined-load benchmark data unavailable; wrote no_data advisory result.", file=sys.stderr)
         return 0
 
     try:

--- a/scripts/benchmarks/parse_go_bench.py
+++ b/scripts/benchmarks/parse_go_bench.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import re
 import sys
 from pathlib import Path
@@ -10,10 +11,10 @@ from typing import Any
 
 
 CORE_METRIC_PATTERNS = {
-    "ns_per_op": re.compile(r"\b(?P<value>[\d.]+)\s+ns/op\b"),
-    "mb_per_s": re.compile(r"\b(?P<value>[\d.]+)\s+MB/s\b"),
-    "b_per_op": re.compile(r"\b(?P<value>[\d.]+)\s+B/op\b"),
-    "allocs_per_op": re.compile(r"\b(?P<value>[\d.]+)\s+allocs/op\b"),
+    "ns_per_op": re.compile(r"\b(?P<value>\S+)\s+ns/op\b"),
+    "mb_per_s": re.compile(r"\b(?P<value>\S+)\s+MB/s\b"),
+    "b_per_op": re.compile(r"\b(?P<value>\S+)\s+B/op\b"),
+    "allocs_per_op": re.compile(r"\b(?P<value>\S+)\s+allocs/op\b"),
 }
 
 
@@ -25,7 +26,14 @@ METRIC_CHECKS = [
 
 
 def parse_metric(raw: str) -> float:
-    return float(raw.strip())
+    token = raw.strip()
+    try:
+        value = float(token)
+    except ValueError as exc:
+        raise ValueError(f"invalid numeric token {token!r}") from exc
+    if not math.isfinite(value):
+        raise ValueError(f"non-finite numeric token {token!r}")
+    return value
 
 
 def strip_go_benchmark_suffix(name: str) -> str:
@@ -56,7 +64,10 @@ def parse_benchmark_line(line: str, benchmark: str) -> tuple[dict[str, Any] | No
                 continue
             missing.append(key)
             continue
-        parsed[key] = parse_metric(match.group("value"))
+        try:
+            parsed[key] = parse_metric(match.group("value"))
+        except ValueError as exc:
+            return None, f"benchmark line for {benchmark} has malformed {key}: {exc}"
     if missing:
         return None, f"benchmark line for {benchmark} missing required metric(s): {', '.join(missing)}"
     return parsed, None

--- a/scripts/benchmarks/parse_go_bench.py
+++ b/scripts/benchmarks/parse_go_bench.py
@@ -90,8 +90,8 @@ def load_slo(path: Path) -> dict[str, Any]:
             raise ValueError(f"SLO missing required key {key!r}")
     if not isinstance(payload["benchmark"], str) or not payload["benchmark"].strip():
         raise ValueError("SLO benchmark must be a non-empty string")
-    if payload["benchmark"] != payload["benchmark"].strip():
-        raise ValueError("SLO benchmark must not contain leading or trailing whitespace")
+    if any(ch.isspace() for ch in payload["benchmark"]):
+        raise ValueError("SLO benchmark must not contain whitespace")
     for _, limit_key in METRIC_CHECKS:
         payload[limit_key] = parse_finite_number(payload[limit_key], f"SLO {limit_key}", allow_zero=False)
     return payload

--- a/scripts/benchmarks/parse_go_bench.py
+++ b/scripts/benchmarks/parse_go_bench.py
@@ -25,15 +25,20 @@ METRIC_CHECKS = [
 ]
 
 
-def parse_metric(raw: str) -> float:
-    token = raw.strip()
+def parse_finite_number(raw: Any, label: str) -> float:
+    if isinstance(raw, bool) or raw is None:
+        raise ValueError(f"{label} is not numeric: {raw!r}")
     try:
-        value = float(token)
-    except ValueError as exc:
-        raise ValueError(f"invalid numeric token {token!r}") from exc
+        value = float(raw)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{label} has invalid numeric token {raw!r}") from exc
     if not math.isfinite(value):
-        raise ValueError(f"non-finite numeric token {token!r}")
+        raise ValueError(f"{label} has non-finite numeric token {raw!r}")
     return value
+
+
+def parse_metric(raw: str) -> float:
+    return parse_finite_number(raw.strip(), "metric")
 
 
 def strip_go_benchmark_suffix(name: str) -> str:
@@ -80,6 +85,8 @@ def load_slo(path: Path) -> dict[str, Any]:
     for key in ["benchmark", "max_ns_per_op", "max_b_per_op", "max_allocs_per_op"]:
         if key not in payload:
             raise ValueError(f"SLO missing required key {key!r}")
+    for _, limit_key in METRIC_CHECKS:
+        payload[limit_key] = parse_finite_number(payload[limit_key], f"SLO {limit_key}")
     return payload
 
 

--- a/scripts/benchmarks/run_combined_load_benchmark.sh
+++ b/scripts/benchmarks/run_combined_load_benchmark.sh
@@ -15,6 +15,7 @@ BENCH_ITERS="${RUBIN_COMBINED_LOAD_BENCH_ITERS:-1}"
 
 echo "[combined-load] running Go benchmark (iters=${BENCH_ITERS}x)"
 
+set +e
 "$ROOT_DIR/scripts/dev-env.sh" -- bash -lc "
   cd '$ROOT_DIR/clients/go'
   go test ./consensus \
@@ -24,6 +25,19 @@ echo "[combined-load] running Go benchmark (iters=${BENCH_ITERS}x)"
     -count=1 \
     -benchtime='${BENCH_ITERS}x'
 " | tee "$RAW_OUT"
+pipe_status=("${PIPESTATUS[@]}")
+bench_status=${pipe_status[0]}
+tee_status=${pipe_status[1]:-0}
+set -e
+
+if (( tee_status != 0 )); then
+  echo "ERROR: failed to write combined-load benchmark output: $RAW_OUT" >&2
+  exit "$tee_status"
+fi
+
+if (( bench_status != 0 )); then
+  echo "[combined-load] benchmark command failed with status ${bench_status}; emitting advisory no_data artifact if parser cannot find benchmark data" >&2
+fi
 
 python3 "$ROOT_DIR/scripts/benchmarks/parse_go_bench.py" \
   --input "$RAW_OUT" \

--- a/scripts/benchmarks/run_combined_load_benchmark.sh
+++ b/scripts/benchmarks/run_combined_load_benchmark.sh
@@ -36,14 +36,15 @@ if (( tee_status != 0 )); then
 fi
 
 if (( bench_status != 0 )); then
-  echo "[combined-load] benchmark command failed with status ${bench_status}; emitting advisory no_data artifact if parser cannot find benchmark data" >&2
+  echo "[combined-load] benchmark command failed with status ${bench_status}; emitting advisory no_data artifact" >&2
 fi
 
 python3 "$ROOT_DIR/scripts/benchmarks/parse_go_bench.py" \
   --input "$RAW_OUT" \
   --slo "$SLO_FILE" \
   --output "$JSON_OUT" \
-  --summary "$SUMMARY_OUT"
+  --summary "$SUMMARY_OUT" \
+  --producer-exit-code "$bench_status"
 
 echo "[combined-load] artifacts:"
 echo "  - $RAW_OUT"

--- a/scripts/benchmarks/run_combined_load_benchmark.sh
+++ b/scripts/benchmarks/run_combined_load_benchmark.sh
@@ -8,6 +8,7 @@ mkdir -p "$OUT_DIR"
 
 RAW_OUT="$OUT_DIR/combined_load_benchmark.txt"
 JSON_OUT="$OUT_DIR/combined_load_metrics.json"
+SUMMARY_OUT="$OUT_DIR/combined_load_summary.md"
 SLO_FILE="$ROOT_DIR/scripts/benchmarks/combined_load_slo.json"
 
 BENCH_ITERS="${RUBIN_COMBINED_LOAD_BENCH_ITERS:-1}"
@@ -27,8 +28,10 @@ echo "[combined-load] running Go benchmark (iters=${BENCH_ITERS}x)"
 python3 "$ROOT_DIR/scripts/benchmarks/parse_go_bench.py" \
   --input "$RAW_OUT" \
   --slo "$SLO_FILE" \
-  --output "$JSON_OUT"
+  --output "$JSON_OUT" \
+  --summary "$SUMMARY_OUT"
 
 echo "[combined-load] artifacts:"
 echo "  - $RAW_OUT"
 echo "  - $JSON_OUT"
+echo "  - $SUMMARY_OUT"

--- a/scripts/runtime_perf/compare_runtime_perf.py
+++ b/scripts/runtime_perf/compare_runtime_perf.py
@@ -4,12 +4,79 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
+from typing import Any
+
+ADVISORY_THRESHOLDS: list[dict[str, Any]] = [
+    {
+        "suite": "go",
+        "benchmark": "BenchmarkMempoolAddTx",
+        "metric": "ns_per_op",
+        "max_regression_pct": 20.0,
+        "reason": "selected low-noise in-memory Go mempool admission candidate from mainline trend capture",
+    },
+    {
+        "suite": "go",
+        "benchmark": "BenchmarkMempoolRelayMetadata",
+        "metric": "ns_per_op",
+        "max_regression_pct": 20.0,
+        "reason": "selected low-noise in-memory Go relay metadata candidate from mainline trend capture",
+    },
+    {
+        "suite": "go",
+        "benchmark": "BenchmarkCloneChainState",
+        "metric": "ns_per_op",
+        "max_regression_pct": 25.0,
+        "reason": "selected deterministic Go chain-state clone candidate from mainline trend capture",
+    },
+    {
+        "suite": "rust",
+        "benchmark": "rubin_node_txpool/admit",
+        "metric": "ns_per_op",
+        "max_regression_pct": 20.0,
+        "reason": "selected low-noise Rust txpool admission candidate from mainline trend capture",
+    },
+    {
+        "suite": "rust",
+        "benchmark": "rubin_node_txpool/relay_metadata",
+        "metric": "ns_per_op",
+        "max_regression_pct": 20.0,
+        "reason": "selected low-noise Rust relay metadata candidate from mainline trend capture",
+    },
+    {
+        "suite": "rust",
+        "benchmark": "rubin_node_chainstate_clone",
+        "metric": "ns_per_op",
+        "max_regression_pct": 25.0,
+        "reason": "selected deterministic Rust chain-state clone candidate from mainline trend capture",
+    },
+]
+
+METRIC_FILES = {
+    "go": "go_metrics.json",
+    "rust": "rust_metrics.json",
+}
+
+ROW_FIELDS = {
+    "go": ["ns_per_op", "b_per_op", "allocs_per_op"],
+    "rust": ["ns_per_op"],
+}
+
+THRESHOLD_INDEX = {
+    (item["suite"], item["benchmark"], item["metric"]): item
+    for item in ADVISORY_THRESHOLDS
+}
 
 
-def load_json(path: Path) -> dict | None:
+def load_json(path: Path) -> tuple[dict[str, Any] | None, str | None]:
     if not path.exists():
-        return None
-    return json.loads(path.read_text(encoding="utf-8", errors="strict"))
+        return None, f"missing artifact: {path}"
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8", errors="strict"))
+    except json.JSONDecodeError as exc:
+        return None, f"malformed JSON in {path}: {exc}"
+    if not isinstance(payload, dict):
+        return None, f"JSON root in {path} is {type(payload).__name__}, expected object"
+    return payload, None
 
 
 def load_exit_code(path: Path) -> int | None:
@@ -24,32 +91,184 @@ def pct_delta(base: float, head: float) -> float | None:
     return ((head - base) / base) * 100.0
 
 
-def build_rows(base_metrics: dict[str, dict], head_metrics: dict[str, dict], fields: list[str]) -> list[dict]:
-    rows: list[dict] = []
+def metrics_from_payload(suite: str, payload: dict[str, Any] | None) -> dict[str, dict[str, Any]]:
+    if payload is None:
+        return {}
+    if suite in {"go", "rust"}:
+        metrics = payload.get("metrics")
+        return metrics if isinstance(metrics, dict) else {}
+    return {}
+
+
+def classify_delta(
+    *,
+    suite: str,
+    benchmark: str,
+    metric: str,
+    base_value: Any,
+    head_value: Any,
+    threshold: dict[str, Any] | None,
+    base_issue: str | None,
+    head_issue: str | None,
+) -> dict[str, Any]:
+    if threshold is None:
+        return {
+            "status": "unselected",
+            "reason": "benchmark metric is outside the selected low-noise advisory threshold set",
+        }
+    entry = {
+        "suite": suite,
+        "benchmark": benchmark,
+        "metric": metric,
+        "baseline": base_value,
+        "observed": head_value,
+        "delta_pct": None,
+        "threshold_pct": threshold["max_regression_pct"],
+        "status": "no_data",
+        "reason": threshold["reason"],
+    }
+    if base_issue or head_issue:
+        entry["reason"] = "; ".join(issue for issue in [base_issue, head_issue] if issue)
+        return entry
+    if base_value is None or head_value is None:
+        entry["reason"] = "baseline or observed metric missing; no advisory decision"
+        return entry
+    delta = pct_delta(float(base_value), float(head_value))
+    entry["delta_pct"] = delta
+    if delta is None:
+        entry["reason"] = "baseline metric is zero; percent delta unavailable"
+        return entry
+    if delta > float(threshold["max_regression_pct"]):
+        entry["status"] = "warn"
+        entry["reason"] = (
+            f"observed regression {delta:+.2f}% exceeds advisory threshold "
+            f"{float(threshold['max_regression_pct']):.2f}%"
+        )
+    else:
+        entry["status"] = "pass"
+        entry["reason"] = (
+            f"observed delta {delta:+.2f}% is within advisory threshold "
+            f"{float(threshold['max_regression_pct']):.2f}%"
+        )
+    return entry
+
+
+def build_rows(
+    suite: str,
+    base_metrics: dict[str, dict[str, Any]],
+    head_metrics: dict[str, dict[str, Any]],
+    fields: list[str],
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
     for name in sorted(set(base_metrics) | set(head_metrics)):
         base = base_metrics.get(name)
         head = head_metrics.get(name)
-        row = {"name": name, "base": base, "head": head, "deltas": {}}
+        row: dict[str, Any] = {"suite": suite, "name": name, "base": base, "head": head, "deltas": {}, "advisory": {}}
         if base and head:
             for field in fields:
                 if field in base and field in head:
                     row["deltas"][field] = pct_delta(float(base[field]), float(head[field]))
+        for field in fields:
+            threshold = THRESHOLD_INDEX.get((suite, name, field))
+            row["advisory"][field] = classify_delta(
+                suite=suite,
+                benchmark=name,
+                metric=field,
+                base_value=base.get(field) if base else None,
+                head_value=head.get(field) if head else None,
+                threshold=threshold,
+                base_issue=None,
+                head_issue=None,
+            )
         rows.append(row)
     return rows
 
 
-def render_table(title: str, rows: list[dict], fields: list[str]) -> list[str]:
-    lines = [f"### {title}", "", "| Benchmark | Base ns/op | Head ns/op | Δ ns/op |", "|---|---:|---:|---:|"]
+def build_advisory_decisions(
+    metric_sets: dict[str, tuple[dict[str, dict[str, Any]], dict[str, dict[str, Any]], str | None, str | None]]
+) -> list[dict[str, Any]]:
+    decisions: list[dict[str, Any]] = []
+    for threshold in ADVISORY_THRESHOLDS:
+        suite = threshold["suite"]
+        benchmark = threshold["benchmark"]
+        metric = threshold["metric"]
+        base_metrics, head_metrics, base_issue, head_issue = metric_sets.get(suite, ({}, {}, "missing suite", "missing suite"))
+        base = base_metrics.get(benchmark, {})
+        head = head_metrics.get(benchmark, {})
+        decisions.append(
+            classify_delta(
+                suite=suite,
+                benchmark=benchmark,
+                metric=metric,
+                base_value=base.get(metric),
+                head_value=head.get(metric),
+                threshold=threshold,
+                base_issue=base_issue if not base_metrics else None,
+                head_issue=head_issue if not head_metrics else None,
+            )
+        )
+    return decisions
+
+
+def advisory_status(decisions: list[dict[str, Any]]) -> str:
+    statuses = [decision["status"] for decision in decisions]
+    if "warn" in statuses:
+        return "warn"
+    if "no_data" in statuses:
+        return "no_data"
+    return "pass"
+
+
+def render_value(value: Any) -> str:
+    if value is None:
+        return "n/a"
+    if isinstance(value, float):
+        return f"{value:.0f}"
+    return str(value)
+
+
+def render_table(title: str, rows: list[dict[str, Any]]) -> list[str]:
+    lines = [f"### {title}", "", "| Benchmark | Base ns/op | Head ns/op | Delta | Advisory |", "|---|---:|---:|---:|---|"]
     for row in rows:
         base = row["base"]
         head = row["head"]
         if not base or not head:
-            lines.append(f"| `{row['name']}` | {'missing' if not base else base.get('ns_per_op', 'n/a')} | {'missing' if not head else head.get('ns_per_op', 'n/a')} | n/a |")
+            lines.append(
+                f"| `{row['name']}` | {'missing' if not base else render_value(base.get('ns_per_op'))} | "
+                f"{'missing' if not head else render_value(head.get('ns_per_op'))} | n/a | no_data |"
+            )
             continue
         delta = row["deltas"].get("ns_per_op")
         delta_str = "n/a" if delta is None else f"{delta:+.2f}%"
+        advisory = row["advisory"].get("ns_per_op", {"status": "unselected"})["status"]
         lines.append(
-            f"| `{row['name']}` | {base['ns_per_op']:.0f} | {head['ns_per_op']:.0f} | {delta_str} |"
+            f"| `{row['name']}` | {render_value(base.get('ns_per_op'))} | "
+            f"{render_value(head.get('ns_per_op'))} | {delta_str} | {advisory} |"
+        )
+    lines.append("")
+    return lines
+
+
+def render_advisory_summary(decisions: list[dict[str, Any]]) -> list[str]:
+    lines = [
+        "## Advisory regression detection",
+        "",
+        f"Overall advisory status: `{advisory_status(decisions)}`.",
+        "",
+        "This status is informational only. Threshold WARN does not fail this workflow.",
+        "",
+        "| Suite | Benchmark | Metric | Baseline | Observed | Delta | Threshold | Status | Reason |",
+        "|---|---|---|---:|---:|---:|---:|---|---|",
+    ]
+    for item in decisions:
+        delta = item.get("delta_pct")
+        delta_str = "n/a" if delta is None else f"{float(delta):+.2f}%"
+        threshold = item.get("threshold_pct")
+        threshold_str = "n/a" if threshold is None else f"{float(threshold):.2f}%"
+        lines.append(
+            f"| `{item['suite']}` | `{item['benchmark']}` | `{item['metric']}` | "
+            f"{render_value(item.get('baseline'))} | {render_value(item.get('observed'))} | "
+            f"{delta_str} | {threshold_str} | `{item['status']}` | {item['reason']} |"
         )
     lines.append("")
     return lines
@@ -68,12 +287,26 @@ def main() -> int:
     summary_path = Path(args.summary)
     output_path = Path(args.output)
 
-    base_go = load_json(base_dir / "go_metrics.json")
-    head_go = load_json(head_dir / "go_metrics.json")
-    base_rust = load_json(base_dir / "rust_metrics.json")
-    head_rust = load_json(head_dir / "rust_metrics.json")
+    loaded: dict[str, tuple[dict[str, Any] | None, str | None, dict[str, Any] | None, str | None]] = {}
+    input_issues: list[str] = []
+    for suite, filename in METRIC_FILES.items():
+        base_payload, base_issue = load_json(base_dir / filename)
+        head_payload, head_issue = load_json(head_dir / filename)
+        loaded[suite] = (base_payload, base_issue, head_payload, head_issue)
+        input_issues.extend(issue for issue in [base_issue, head_issue] if issue)
+
     base_rc = load_exit_code(base_dir / "exit_code.txt")
     head_rc = load_exit_code(head_dir / "exit_code.txt")
+
+    metric_sets: dict[str, tuple[dict[str, dict[str, Any]], dict[str, dict[str, Any]], str | None, str | None]] = {}
+    suite_rows: dict[str, list[dict[str, Any]]] = {}
+    for suite, (base_payload, base_issue, head_payload, head_issue) in loaded.items():
+        base_metrics = metrics_from_payload(suite, base_payload)
+        head_metrics = metrics_from_payload(suite, head_payload)
+        metric_sets[suite] = (base_metrics, head_metrics, base_issue, head_issue)
+        suite_rows[suite] = build_rows(suite, base_metrics, head_metrics, ROW_FIELDS[suite])
+
+    advisory = build_advisory_decisions(metric_sets)
 
     summary_lines = [
         "# Runtime Perf Guardrails",
@@ -85,47 +318,42 @@ def main() -> int:
         "",
     ]
 
-    result = {
-        "base_exit_code": base_rc,
-        "head_exit_code": head_rc,
-        "go": None,
-        "rust": None,
-    }
+    summary_lines.extend(render_advisory_summary(advisory))
 
-    if base_go and head_go:
-        go_rows = build_rows(base_go["metrics"], head_go["metrics"], ["ns_per_op", "b_per_op", "allocs_per_op"])
-        summary_lines.extend(render_table("Go", go_rows, ["ns_per_op", "b_per_op", "allocs_per_op"]))
-        result["go"] = go_rows
-    else:
-        summary_lines.extend(["### Go", "", "Go metrics missing in either base or head artifact.", ""])
-
-    if base_rust and head_rust:
-        rust_rows = build_rows(base_rust["metrics"], head_rust["metrics"], ["ns_per_op"])
-        summary_lines.extend(render_table("Rust", rust_rows, ["ns_per_op"]))
-        missing = sorted(set(base_rust.get("missing", [])) | set(head_rust.get("missing", [])))
-        if missing:
-            summary_lines.extend(["Missing rust targets:", ""])
-            for name in missing:
-                summary_lines.append(f"- `{name}`")
-            summary_lines.append("")
-        result["rust"] = rust_rows
-    else:
-        summary_lines.extend(["### Rust", "", "Rust metrics missing in either base or head artifact.", ""])
+    for suite, title in [("go", "Go"), ("rust", "Rust")]:
+        rows = suite_rows[suite]
+        if rows:
+            summary_lines.extend(render_table(title, rows))
+        else:
+            summary_lines.extend([f"### {title}", "", f"{title} metrics missing in either base or head artifact.", ""])
 
     summary_lines.extend(
         [
             "## Threshold policy",
             "",
             "- this lane is informational only;",
-            "- it must not block merge while the baseline is still stabilizing;",
-            "- follow-up perf slices can promote specific stable deltas into soft thresholds later.",
+            "- advisory threshold warnings must not block merge;",
+            "- missing or malformed benchmark data is reported as `no_data`, not as a regression;",
+            "- thresholds apply only to selected low-noise candidates documented in trend-capture evidence.",
             "",
         ]
     )
 
+    result = {
+        "base_exit_code": base_rc,
+        "head_exit_code": head_rc,
+        "input_issues": input_issues,
+        "advisory_status": advisory_status(advisory),
+        "advisory_thresholds": ADVISORY_THRESHOLDS,
+        "advisory": advisory,
+        "go": suite_rows["go"] or None,
+        "rust": suite_rows["rust"] or None,
+    }
+
     summary_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
     summary_path.write_text("\n".join(summary_lines), encoding="utf-8")
-    output_path.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
+    output_path.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return 0
 
 

--- a/scripts/runtime_perf/compare_runtime_perf.py
+++ b/scripts/runtime_perf/compare_runtime_perf.py
@@ -84,6 +84,8 @@ def coerce_metric(value: Any) -> tuple[float | None, str | None]:
         return None, f"non-numeric metric value: {value!r}"
     if not math.isfinite(metric):
         return None, f"non-finite metric value: {value!r}"
+    if metric < 0:
+        return None, f"negative metric value: {value!r}"
     return metric, None
 
 

--- a/scripts/runtime_perf/compare_runtime_perf.py
+++ b/scripts/runtime_perf/compare_runtime_perf.py
@@ -107,15 +107,40 @@ def pct_delta(base: float, head: float) -> float | None:
     return ((head - base) / base) * 100.0
 
 
-def metrics_from_payload(suite: str, payload: dict[str, Any] | None) -> tuple[dict[str, dict[str, Any]], str | None]:
+def missing_from_payload(suite: str, payload: dict[str, Any] | None) -> tuple[list[str], str | None]:
     if payload is None:
-        return {}, None
+        return [], None
+    raw_missing = payload.get("missing", [])
+    if raw_missing is None:
+        return [], None
+    if not isinstance(raw_missing, list):
+        return [], f"{suite} metrics artifact field 'missing' is {type(raw_missing).__name__}, expected list"
+    missing: list[str] = []
+    for item in raw_missing:
+        if not isinstance(item, str):
+            return [], f"{suite} metrics artifact field 'missing' contains {type(item).__name__}, expected string"
+        missing.append(item)
+    return sorted(set(missing)), None
+
+
+def metrics_from_payload(suite: str, payload: dict[str, Any] | None) -> tuple[dict[str, dict[str, Any]], list[str]]:
+    if payload is None:
+        return {}, []
     if suite in {"go", "rust"}:
         metrics = payload.get("metrics")
         if not isinstance(metrics, dict):
-            return {}, f"{suite} metrics artifact missing object field 'metrics'"
-        return metrics, None
-    return {}, f"unknown metrics suite: {suite}"
+            return {}, [f"{suite} metrics artifact missing object field 'metrics'"]
+        normalized: dict[str, dict[str, Any]] = {}
+        issues: list[str] = []
+        for benchmark, metric_values in metrics.items():
+            if not isinstance(metric_values, dict):
+                issues.append(
+                    f"{suite} metrics entry for {benchmark} is {type(metric_values).__name__}, expected object"
+                )
+                continue
+            normalized[benchmark] = metric_values
+        return normalized, issues
+    return {}, [f"unknown metrics suite: {suite}"]
 
 
 def classify_delta(
@@ -185,9 +210,11 @@ def build_rows(
     fields: list[str],
     base_issue: str | None,
     head_issue: str | None,
+    extra_names: list[str] | None = None,
 ) -> list[dict[str, Any]]:
     rows: list[dict[str, Any]] = []
-    for name in sorted(set(base_metrics) | set(head_metrics)):
+    row_names = set(base_metrics) | set(head_metrics) | set(extra_names or [])
+    for name in sorted(row_names):
         base = base_metrics.get(name)
         head = head_metrics.get(name)
         row: dict[str, Any] = {"suite": suite, "name": name, "base": base, "head": head, "deltas": {}, "advisory": {}}
@@ -338,14 +365,28 @@ def main() -> int:
 
     metric_sets: dict[str, tuple[dict[str, dict[str, Any]], dict[str, dict[str, Any]], str | None, str | None]] = {}
     suite_rows: dict[str, list[dict[str, Any]]] = {}
+    missing_by_suite: dict[str, dict[str, list[str]]] = {}
     for suite, (base_payload, base_issue, head_payload, head_issue) in loaded.items():
-        base_metrics, base_shape_issue = metrics_from_payload(suite, base_payload)
-        head_metrics, head_shape_issue = metrics_from_payload(suite, head_payload)
-        base_data_issue = base_issue or base_shape_issue
-        head_data_issue = head_issue or head_shape_issue
-        input_issues.extend(issue for issue in [base_shape_issue, head_shape_issue] if issue)
+        base_metrics, base_shape_issues = metrics_from_payload(suite, base_payload)
+        head_metrics, head_shape_issues = metrics_from_payload(suite, head_payload)
+        base_missing, base_missing_issue = missing_from_payload(suite, base_payload)
+        head_missing, head_missing_issue = missing_from_payload(suite, head_payload)
+        base_data_issue = base_issue or "; ".join(base_shape_issues + ([base_missing_issue] if base_missing_issue else [])) or None
+        head_data_issue = head_issue or "; ".join(head_shape_issues + ([head_missing_issue] if head_missing_issue else [])) or None
+        input_issues.extend(base_shape_issues)
+        input_issues.extend(head_shape_issues)
+        input_issues.extend(issue for issue in [base_missing_issue, head_missing_issue] if issue)
+        missing_by_suite[suite] = {"base": base_missing, "head": head_missing}
         metric_sets[suite] = (base_metrics, head_metrics, base_data_issue, head_data_issue)
-        suite_rows[suite] = build_rows(suite, base_metrics, head_metrics, ROW_FIELDS[suite], base_data_issue, head_data_issue)
+        suite_rows[suite] = build_rows(
+            suite,
+            base_metrics,
+            head_metrics,
+            ROW_FIELDS[suite],
+            base_data_issue,
+            head_data_issue,
+            sorted(set(base_missing) | set(head_missing)),
+        )
 
     advisory = build_advisory_decisions(metric_sets)
 
@@ -388,6 +429,7 @@ def main() -> int:
         "advisory_status": advisory_status(advisory),
         "advisory_thresholds": [dict(item) for item in ADVISORY_THRESHOLDS],
         "advisory": advisory,
+        "missing": missing_by_suite,
         "go": suite_rows["go"],
         "rust": suite_rows["rust"],
     }

--- a/scripts/runtime_perf/compare_runtime_perf.py
+++ b/scripts/runtime_perf/compare_runtime_perf.py
@@ -91,13 +91,15 @@ def pct_delta(base: float, head: float) -> float | None:
     return ((head - base) / base) * 100.0
 
 
-def metrics_from_payload(suite: str, payload: dict[str, Any] | None) -> dict[str, dict[str, Any]]:
+def metrics_from_payload(suite: str, payload: dict[str, Any] | None) -> tuple[dict[str, dict[str, Any]], str | None]:
     if payload is None:
-        return {}
+        return {}, None
     if suite in {"go", "rust"}:
         metrics = payload.get("metrics")
-        return metrics if isinstance(metrics, dict) else {}
-    return {}
+        if not isinstance(metrics, dict):
+            return {}, f"{suite} metrics artifact missing object field 'metrics'"
+        return metrics, None
+    return {}, f"unknown metrics suite: {suite}"
 
 
 def classify_delta(
@@ -158,6 +160,8 @@ def build_rows(
     base_metrics: dict[str, dict[str, Any]],
     head_metrics: dict[str, dict[str, Any]],
     fields: list[str],
+    base_issue: str | None,
+    head_issue: str | None,
 ) -> list[dict[str, Any]]:
     rows: list[dict[str, Any]] = []
     for name in sorted(set(base_metrics) | set(head_metrics)):
@@ -177,8 +181,8 @@ def build_rows(
                 base_value=base.get(field) if base else None,
                 head_value=head.get(field) if head else None,
                 threshold=threshold,
-                base_issue=None,
-                head_issue=None,
+                base_issue=base_issue,
+                head_issue=head_issue,
             )
         rows.append(row)
     return rows
@@ -203,8 +207,8 @@ def build_advisory_decisions(
                 base_value=base.get(metric),
                 head_value=head.get(metric),
                 threshold=threshold,
-                base_issue=base_issue if not base_metrics else None,
-                head_issue=head_issue if not head_metrics else None,
+                base_issue=base_issue,
+                head_issue=head_issue,
             )
         )
     return decisions
@@ -301,10 +305,13 @@ def main() -> int:
     metric_sets: dict[str, tuple[dict[str, dict[str, Any]], dict[str, dict[str, Any]], str | None, str | None]] = {}
     suite_rows: dict[str, list[dict[str, Any]]] = {}
     for suite, (base_payload, base_issue, head_payload, head_issue) in loaded.items():
-        base_metrics = metrics_from_payload(suite, base_payload)
-        head_metrics = metrics_from_payload(suite, head_payload)
-        metric_sets[suite] = (base_metrics, head_metrics, base_issue, head_issue)
-        suite_rows[suite] = build_rows(suite, base_metrics, head_metrics, ROW_FIELDS[suite])
+        base_metrics, base_shape_issue = metrics_from_payload(suite, base_payload)
+        head_metrics, head_shape_issue = metrics_from_payload(suite, head_payload)
+        base_data_issue = base_issue or base_shape_issue
+        head_data_issue = head_issue or head_shape_issue
+        input_issues.extend(issue for issue in [base_shape_issue, head_shape_issue] if issue)
+        metric_sets[suite] = (base_metrics, head_metrics, base_data_issue, head_data_issue)
+        suite_rows[suite] = build_rows(suite, base_metrics, head_metrics, ROW_FIELDS[suite], base_data_issue, head_data_issue)
 
     advisory = build_advisory_decisions(metric_sets)
 
@@ -325,7 +332,7 @@ def main() -> int:
         if rows:
             summary_lines.extend(render_table(title, rows))
         else:
-            summary_lines.extend([f"### {title}", "", f"{title} metrics missing in either base or head artifact.", ""])
+            summary_lines.extend([f"### {title}", "", f"{title} metrics unavailable or empty in either base or head artifact.", ""])
 
     summary_lines.extend(
         [
@@ -346,8 +353,8 @@ def main() -> int:
         "advisory_status": advisory_status(advisory),
         "advisory_thresholds": ADVISORY_THRESHOLDS,
         "advisory": advisory,
-        "go": suite_rows["go"] or None,
-        "rust": suite_rows["rust"] or None,
+        "go": suite_rows["go"],
+        "rust": suite_rows["rust"],
     }
 
     summary_path.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/runtime_perf/compare_runtime_perf.py
+++ b/scripts/runtime_perf/compare_runtime_perf.py
@@ -101,10 +101,14 @@ def load_json(path: Path) -> tuple[dict[str, Any] | None, str | None]:
     return payload, None
 
 
-def load_exit_code(path: Path) -> int | None:
+def load_exit_code(path: Path) -> tuple[int | None, str | None]:
     if not path.exists():
-        return None
-    return int(path.read_text(encoding="utf-8", errors="strict").strip())
+        return None, None
+    raw = path.read_text(encoding="utf-8", errors="strict").strip()
+    try:
+        return int(raw), None
+    except ValueError:
+        return None, f"malformed exit code in {path}: {raw!r}"
 
 
 def pct_delta(base: float, head: float) -> float | None:
@@ -387,8 +391,9 @@ def main() -> int:
         loaded[suite] = (base_payload, base_issue, head_payload, head_issue)
         input_issues.extend(issue for issue in [base_issue, head_issue] if issue)
 
-    base_rc = load_exit_code(base_dir / "exit_code.txt")
-    head_rc = load_exit_code(head_dir / "exit_code.txt")
+    base_rc, base_rc_issue = load_exit_code(base_dir / "exit_code.txt")
+    head_rc, head_rc_issue = load_exit_code(head_dir / "exit_code.txt")
+    input_issues.extend(issue for issue in [base_rc_issue, head_rc_issue] if issue)
 
     metric_sets: dict[
         str,

--- a/scripts/runtime_perf/compare_runtime_perf.py
+++ b/scripts/runtime_perf/compare_runtime_perf.py
@@ -93,7 +93,13 @@ def load_json(path: Path) -> tuple[dict[str, Any] | None, str | None]:
     if not path.exists():
         return None, f"missing artifact: {path}"
     try:
-        payload = json.loads(path.read_text(encoding="utf-8", errors="strict"))
+        raw = path.read_text(encoding="utf-8", errors="strict")
+    except UnicodeDecodeError as exc:
+        return None, f"invalid UTF-8 in {path}: {exc}"
+    except OSError as exc:
+        return None, f"cannot read artifact {path}: {exc}"
+    try:
+        payload = json.loads(raw)
     except json.JSONDecodeError as exc:
         return None, f"malformed JSON in {path}: {exc}"
     if not isinstance(payload, dict):
@@ -104,7 +110,12 @@ def load_json(path: Path) -> tuple[dict[str, Any] | None, str | None]:
 def load_exit_code(path: Path) -> tuple[int | None, str | None]:
     if not path.exists():
         return None, None
-    raw = path.read_text(encoding="utf-8", errors="strict").strip()
+    try:
+        raw = path.read_text(encoding="utf-8", errors="strict").strip()
+    except UnicodeDecodeError as exc:
+        return None, f"invalid UTF-8 in {path}: {exc}"
+    except OSError as exc:
+        return None, f"cannot read exit code artifact {path}: {exc}"
     try:
         return int(raw), None
     except ValueError:

--- a/scripts/runtime_perf/compare_runtime_perf.py
+++ b/scripts/runtime_perf/compare_runtime_perf.py
@@ -338,15 +338,15 @@ def render_table(title: str, rows: list[dict[str, Any]]) -> list[str]:
     for row in rows:
         base = row["base"]
         head = row["head"]
+        advisory = row["advisory"].get("ns_per_op", {"status": "unselected"})["status"]
         if not base or not head:
             lines.append(
                 f"| `{row['name']}` | {'missing' if not base else render_value(base.get('ns_per_op'))} | "
-                f"{'missing' if not head else render_value(head.get('ns_per_op'))} | n/a | no_data |"
+                f"{'missing' if not head else render_value(head.get('ns_per_op'))} | n/a | {advisory} |"
             )
             continue
         delta = row["deltas"].get("ns_per_op")
         delta_str = "n/a" if delta is None else f"{delta:+.2f}%"
-        advisory = row["advisory"].get("ns_per_op", {"status": "unselected"})["status"]
         lines.append(
             f"| `{row['name']}` | {render_value(base.get('ns_per_op'))} | "
             f"{render_value(head.get('ns_per_op'))} | {delta_str} | {advisory} |"

--- a/scripts/runtime_perf/compare_runtime_perf.py
+++ b/scripts/runtime_perf/compare_runtime_perf.py
@@ -89,6 +89,16 @@ def coerce_metric(value: Any) -> tuple[float | None, str | None]:
     return metric, None
 
 
+def json_safe_value(value: Any) -> Any:
+    if isinstance(value, float) and not math.isfinite(value):
+        return None
+    if isinstance(value, dict):
+        return {key: json_safe_value(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [json_safe_value(item) for item in value]
+    return value
+
+
 def load_json(path: Path) -> tuple[dict[str, Any] | None, str | None]:
     if not path.exists():
         return None, f"missing artifact: {path}"
@@ -190,8 +200,8 @@ def classify_delta(
         "suite": suite,
         "benchmark": benchmark,
         "metric": metric,
-        "baseline": base_value,
-        "observed": head_value,
+        "baseline": json_safe_value(base_value),
+        "observed": json_safe_value(head_value),
         "delta_pct": None,
         "threshold_pct": threshold["max_regression_pct"],
         "status": "no_data",
@@ -246,7 +256,14 @@ def build_rows(
     for name in sorted(row_names):
         base = base_metrics.get(name)
         head = head_metrics.get(name)
-        row: dict[str, Any] = {"suite": suite, "name": name, "base": base, "head": head, "deltas": {}, "advisory": {}}
+        row: dict[str, Any] = {
+            "suite": suite,
+            "name": name,
+            "base": json_safe_value(base),
+            "head": json_safe_value(head),
+            "deltas": {},
+            "advisory": {},
+        }
         if base and head:
             for field in fields:
                 if field in base and field in head:
@@ -499,7 +516,7 @@ def main() -> int:
     summary_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.parent.mkdir(parents=True, exist_ok=True)
     summary_path.write_text("\n".join(summary_lines), encoding="utf-8")
-    output_path.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    output_path.write_text(json.dumps(result, allow_nan=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return 0
 
 

--- a/scripts/runtime_perf/compare_runtime_perf.py
+++ b/scripts/runtime_perf/compare_runtime_perf.py
@@ -67,6 +67,22 @@ THRESHOLD_INDEX = {
 }
 
 
+def validate_threshold_registry() -> None:
+    unknown_suites = sorted({item["suite"] for item in ADVISORY_THRESHOLDS} - set(METRIC_FILES))
+    if unknown_suites:
+        joined = ", ".join(unknown_suites)
+        raise ValueError(f"advisory threshold suite(s) not configured in METRIC_FILES: {joined}")
+
+
+def coerce_metric(value: Any) -> tuple[float | None, str | None]:
+    if isinstance(value, bool) or value is None:
+        return None, f"non-numeric metric value: {value!r}"
+    try:
+        return float(value), None
+    except (TypeError, ValueError):
+        return None, f"non-numeric metric value: {value!r}"
+
+
 def load_json(path: Path) -> tuple[dict[str, Any] | None, str | None]:
     if not path.exists():
         return None, f"missing artifact: {path}"
@@ -135,7 +151,14 @@ def classify_delta(
     if base_value is None or head_value is None:
         entry["reason"] = "baseline or observed metric missing; no advisory decision"
         return entry
-    delta = pct_delta(float(base_value), float(head_value))
+    base_float, base_float_issue = coerce_metric(base_value)
+    head_float, head_float_issue = coerce_metric(head_value)
+    if base_float_issue or head_float_issue:
+        entry["reason"] = "baseline or observed metric is non-numeric: " + "; ".join(
+            issue for issue in [base_float_issue, head_float_issue] if issue
+        )
+        return entry
+    delta = pct_delta(base_float, head_float)
     entry["delta_pct"] = delta
     if delta is None:
         entry["reason"] = "baseline metric is zero; percent delta unavailable"
@@ -171,7 +194,10 @@ def build_rows(
         if base and head:
             for field in fields:
                 if field in base and field in head:
-                    row["deltas"][field] = pct_delta(float(base[field]), float(head[field]))
+                    base_float, base_float_issue = coerce_metric(base[field])
+                    head_float, head_float_issue = coerce_metric(head[field])
+                    if base_float_issue is None and head_float_issue is None:
+                        row["deltas"][field] = pct_delta(base_float, head_float)
         for field in fields:
             threshold = THRESHOLD_INDEX.get((suite, name, field))
             row["advisory"][field] = classify_delta(
@@ -231,6 +257,13 @@ def render_value(value: Any) -> str:
     return str(value)
 
 
+def render_markdown_cell(value: Any, limit: int = 240) -> str:
+    text = render_value(value).replace("\r", " ").replace("\n", " ").replace("|", "\\|")
+    if len(text) > limit:
+        return text[: limit - 3] + "..."
+    return text
+
+
 def render_table(title: str, rows: list[dict[str, Any]]) -> list[str]:
     lines = [f"### {title}", "", "| Benchmark | Base ns/op | Head ns/op | Delta | Advisory |", "|---|---:|---:|---:|---|"]
     for row in rows:
@@ -272,7 +305,7 @@ def render_advisory_summary(decisions: list[dict[str, Any]]) -> list[str]:
         lines.append(
             f"| `{item['suite']}` | `{item['benchmark']}` | `{item['metric']}` | "
             f"{render_value(item.get('baseline'))} | {render_value(item.get('observed'))} | "
-            f"{delta_str} | {threshold_str} | `{item['status']}` | {item['reason']} |"
+            f"{delta_str} | {threshold_str} | `{item['status']}` | {render_markdown_cell(item['reason'])} |"
         )
     lines.append("")
     return lines
@@ -285,6 +318,7 @@ def main() -> int:
     parser.add_argument("--summary", required=True)
     parser.add_argument("--output", required=True)
     args = parser.parse_args()
+    validate_threshold_registry()
 
     base_dir = Path(args.base_dir)
     head_dir = Path(args.head_dir)
@@ -341,7 +375,8 @@ def main() -> int:
             "- this lane is informational only;",
             "- advisory threshold warnings must not block merge;",
             "- missing or malformed benchmark data is reported as `no_data`, not as a regression;",
-            "- thresholds apply only to selected low-noise candidates documented in trend-capture evidence.",
+            "- thresholds apply only to selected low-noise `ns_per_op` candidates documented in trend-capture evidence;",
+            "- byte and allocation metrics remain reported but unthresholded in this advisory slice.",
             "",
         ]
     )
@@ -351,7 +386,7 @@ def main() -> int:
         "head_exit_code": head_rc,
         "input_issues": input_issues,
         "advisory_status": advisory_status(advisory),
-        "advisory_thresholds": ADVISORY_THRESHOLDS,
+        "advisory_thresholds": [dict(item) for item in ADVISORY_THRESHOLDS],
         "advisory": advisory,
         "go": suite_rows["go"],
         "rust": suite_rows["rust"],

--- a/scripts/runtime_perf/compare_runtime_perf.py
+++ b/scripts/runtime_perf/compare_runtime_perf.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 from pathlib import Path
 from typing import Any
 
@@ -78,9 +79,12 @@ def coerce_metric(value: Any) -> tuple[float | None, str | None]:
     if isinstance(value, bool) or value is None:
         return None, f"non-numeric metric value: {value!r}"
     try:
-        return float(value), None
+        metric = float(value)
     except (TypeError, ValueError):
         return None, f"non-numeric metric value: {value!r}"
+    if not math.isfinite(metric):
+        return None, f"non-finite metric value: {value!r}"
+    return metric, None
 
 
 def load_json(path: Path) -> tuple[dict[str, Any] | None, str | None]:
@@ -123,24 +127,30 @@ def missing_from_payload(suite: str, payload: dict[str, Any] | None) -> tuple[li
     return sorted(set(missing)), None
 
 
-def metrics_from_payload(suite: str, payload: dict[str, Any] | None) -> tuple[dict[str, dict[str, Any]], list[str]]:
+def metrics_from_payload(
+    suite: str,
+    payload: dict[str, Any] | None,
+) -> tuple[dict[str, dict[str, Any]], str | None, dict[str, str], list[str]]:
     if payload is None:
-        return {}, []
+        return {}, None, {}, []
     if suite in {"go", "rust"}:
         metrics = payload.get("metrics")
         if not isinstance(metrics, dict):
-            return {}, [f"{suite} metrics artifact missing object field 'metrics'"]
+            issue = f"{suite} metrics artifact missing object field 'metrics'"
+            return {}, issue, {}, [issue]
         normalized: dict[str, dict[str, Any]] = {}
-        issues: list[str] = []
+        entry_issues: dict[str, str] = {}
+        input_issues: list[str] = []
         for benchmark, metric_values in metrics.items():
             if not isinstance(metric_values, dict):
-                issues.append(
-                    f"{suite} metrics entry for {benchmark} is {type(metric_values).__name__}, expected object"
-                )
+                issue = f"{suite} metrics entry for {benchmark} is {type(metric_values).__name__}, expected object"
+                entry_issues[benchmark] = issue
+                input_issues.append(issue)
                 continue
             normalized[benchmark] = metric_values
-        return normalized, issues
-    return {}, [f"unknown metrics suite: {suite}"]
+        return normalized, None, entry_issues, input_issues
+    issue = f"unknown metrics suite: {suite}"
+    return {}, issue, {}, [issue]
 
 
 def classify_delta(
@@ -208,12 +218,14 @@ def build_rows(
     base_metrics: dict[str, dict[str, Any]],
     head_metrics: dict[str, dict[str, Any]],
     fields: list[str],
-    base_issue: str | None,
-    head_issue: str | None,
+    base_suite_issue: str | None,
+    head_suite_issue: str | None,
+    base_entry_issues: dict[str, str],
+    head_entry_issues: dict[str, str],
     extra_names: list[str] | None = None,
 ) -> list[dict[str, Any]]:
     rows: list[dict[str, Any]] = []
-    row_names = set(base_metrics) | set(head_metrics) | set(extra_names or [])
+    row_names = set(base_metrics) | set(head_metrics) | set(base_entry_issues) | set(head_entry_issues) | set(extra_names or [])
     for name in sorted(row_names):
         base = base_metrics.get(name)
         head = head_metrics.get(name)
@@ -234,22 +246,35 @@ def build_rows(
                 base_value=base.get(field) if base else None,
                 head_value=head.get(field) if head else None,
                 threshold=threshold,
-                base_issue=base_issue,
-                head_issue=head_issue,
+                base_issue=base_suite_issue or base_entry_issues.get(name),
+                head_issue=head_suite_issue or head_entry_issues.get(name),
             )
         rows.append(row)
     return rows
 
 
 def build_advisory_decisions(
-    metric_sets: dict[str, tuple[dict[str, dict[str, Any]], dict[str, dict[str, Any]], str | None, str | None]]
+    metric_sets: dict[
+        str,
+        tuple[
+            dict[str, dict[str, Any]],
+            dict[str, dict[str, Any]],
+            str | None,
+            str | None,
+            dict[str, str],
+            dict[str, str],
+        ],
+    ]
 ) -> list[dict[str, Any]]:
     decisions: list[dict[str, Any]] = []
     for threshold in ADVISORY_THRESHOLDS:
         suite = threshold["suite"]
         benchmark = threshold["benchmark"]
         metric = threshold["metric"]
-        base_metrics, head_metrics, base_issue, head_issue = metric_sets.get(suite, ({}, {}, "missing suite", "missing suite"))
+        base_metrics, head_metrics, base_suite_issue, head_suite_issue, base_entry_issues, head_entry_issues = metric_sets.get(
+            suite,
+            ({}, {}, "missing suite", "missing suite", {}, {}),
+        )
         base = base_metrics.get(benchmark, {})
         head = head_metrics.get(benchmark, {})
         decisions.append(
@@ -260,8 +285,8 @@ def build_advisory_decisions(
                 base_value=base.get(metric),
                 head_value=head.get(metric),
                 threshold=threshold,
-                base_issue=base_issue,
-                head_issue=head_issue,
+                base_issue=base_suite_issue or base_entry_issues.get(benchmark),
+                head_issue=head_suite_issue or head_entry_issues.get(benchmark),
             )
         )
     return decisions
@@ -363,21 +388,38 @@ def main() -> int:
     base_rc = load_exit_code(base_dir / "exit_code.txt")
     head_rc = load_exit_code(head_dir / "exit_code.txt")
 
-    metric_sets: dict[str, tuple[dict[str, dict[str, Any]], dict[str, dict[str, Any]], str | None, str | None]] = {}
+    metric_sets: dict[
+        str,
+        tuple[
+            dict[str, dict[str, Any]],
+            dict[str, dict[str, Any]],
+            str | None,
+            str | None,
+            dict[str, str],
+            dict[str, str],
+        ],
+    ] = {}
     suite_rows: dict[str, list[dict[str, Any]]] = {}
     missing_by_suite: dict[str, dict[str, list[str]]] = {}
     for suite, (base_payload, base_issue, head_payload, head_issue) in loaded.items():
-        base_metrics, base_shape_issues = metrics_from_payload(suite, base_payload)
-        head_metrics, head_shape_issues = metrics_from_payload(suite, head_payload)
+        base_metrics, base_suite_issue, base_entry_issues, base_shape_issues = metrics_from_payload(suite, base_payload)
+        head_metrics, head_suite_issue, head_entry_issues, head_shape_issues = metrics_from_payload(suite, head_payload)
         base_missing, base_missing_issue = missing_from_payload(suite, base_payload)
         head_missing, head_missing_issue = missing_from_payload(suite, head_payload)
-        base_data_issue = base_issue or "; ".join(base_shape_issues + ([base_missing_issue] if base_missing_issue else [])) or None
-        head_data_issue = head_issue or "; ".join(head_shape_issues + ([head_missing_issue] if head_missing_issue else [])) or None
+        base_data_issue = base_issue or base_suite_issue
+        head_data_issue = head_issue or head_suite_issue
         input_issues.extend(base_shape_issues)
         input_issues.extend(head_shape_issues)
         input_issues.extend(issue for issue in [base_missing_issue, head_missing_issue] if issue)
         missing_by_suite[suite] = {"base": base_missing, "head": head_missing}
-        metric_sets[suite] = (base_metrics, head_metrics, base_data_issue, head_data_issue)
+        metric_sets[suite] = (
+            base_metrics,
+            head_metrics,
+            base_data_issue,
+            head_data_issue,
+            base_entry_issues,
+            head_entry_issues,
+        )
         suite_rows[suite] = build_rows(
             suite,
             base_metrics,
@@ -385,6 +427,8 @@ def main() -> int:
             ROW_FIELDS[suite],
             base_data_issue,
             head_data_issue,
+            base_entry_issues,
+            head_entry_issues,
             sorted(set(base_missing) | set(head_missing)),
         )
 

--- a/tools/tests/test_perf_advisory_regression.py
+++ b/tools/tests/test_perf_advisory_regression.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 # Tests execute repo-local Python CLIs through argv lists only.
 import subprocess  # nosec B404
 import sys
@@ -13,6 +14,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 COMPARE = REPO_ROOT / "scripts" / "runtime_perf" / "compare_runtime_perf.py"
 PARSE_COMBINED = REPO_ROOT / "scripts" / "benchmarks" / "parse_go_bench.py"
+RUN_COMBINED = REPO_ROOT / "scripts" / "benchmarks" / "run_combined_load_benchmark.sh"
 SLO = REPO_ROOT / "scripts" / "benchmarks" / "combined_load_slo.json"
 TREND = REPO_ROOT / "scripts" / "runtime_perf" / "build_runtime_perf_trend.py"
 
@@ -256,6 +258,70 @@ class RuntimePerfAdvisoryTests(unittest.TestCase):
         self.assertIn("malformed JSON", go_row["advisory"]["ns_per_op"]["reason"])
         self.assertEqual(doc["rust"], [])
 
+    def test_non_object_metric_entry_is_no_data_not_traceback(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            base = root / "base"
+            head = root / "head"
+            write_json(
+                base / "go_metrics.json",
+                {
+                    "suite": "go",
+                    "metrics": {
+                        "BenchmarkMempoolAddTx": [],
+                    },
+                },
+            )
+            write_json(
+                head / "go_metrics.json",
+                {
+                    "suite": "go",
+                    "metrics": {
+                        "BenchmarkMempoolAddTx": {
+                            "iterations": 1,
+                            "ns_per_op": 130.0,
+                            "b_per_op": 10.0,
+                            "allocs_per_op": 1.0,
+                        }
+                    },
+                },
+            )
+
+            doc = self.run_compare(base, head, root / "out")
+
+        self.assertIn("metrics entry for BenchmarkMempoolAddTx is list", "\n".join(doc["input_issues"]))
+        add_tx = next(item for item in doc["advisory"] if item["benchmark"] == "BenchmarkMempoolAddTx")
+        self.assertEqual(add_tx["status"], "no_data")
+        self.assertIn("expected object", add_tx["reason"])
+
+    def test_rust_missing_list_surfaces_rows_and_no_data(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            base = root / "base"
+            head = root / "head"
+            for side in [base, head]:
+                write_json(
+                    side / "rust_metrics.json",
+                    {
+                        "suite": "rust",
+                        "metrics": {
+                            "rubin_node_txpool/admit": {"ns_per_op": 100.0},
+                        },
+                        "missing": ["rubin_node_txpool/relay_metadata"],
+                    },
+                )
+
+            doc = self.run_compare(base, head, root / "out")
+            summary_text = (root / "out" / "summary.md").read_text(encoding="utf-8")
+
+        self.assertEqual(doc["missing"]["rust"]["base"], ["rubin_node_txpool/relay_metadata"])
+        self.assertEqual(doc["missing"]["rust"]["head"], ["rubin_node_txpool/relay_metadata"])
+        missing_row = next(row for row in doc["rust"] if row["name"] == "rubin_node_txpool/relay_metadata")
+        self.assertIsNone(missing_row["base"])
+        self.assertIsNone(missing_row["head"])
+        self.assertEqual(missing_row["advisory"]["ns_per_op"]["status"], "no_data")
+        self.assertIn("rubin_node_txpool/relay_metadata", summary_text)
+
     def test_combined_load_slo_breach_is_advisory_warn_exit_zero(self):
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)
@@ -325,6 +391,32 @@ class RuntimePerfAdvisoryTests(unittest.TestCase):
         self.assertEqual(doc["status"], "no_data")
         self.assertIn("benchmark output not found", doc["reason"])
         self.assertIn("Status: `no_data`", summary_text)
+
+    def test_combined_load_wrapper_emits_no_data_when_benchmark_command_fails(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            out_dir = root / "combined"
+            env = os.environ.copy()
+            env["RUBIN_OPENSSL_PREFIX"] = str(root / "missing-openssl")
+            # The command is a repo-local shell wrapper with temp artifact output only.
+            proc = subprocess.run(  # nosec B603
+                [str(RUN_COMBINED), str(out_dir)],
+                check=False,
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            doc = json.loads((out_dir / "combined_load_metrics.json").read_text(encoding="utf-8"))
+            summary_text = (out_dir / "combined_load_summary.md").read_text(encoding="utf-8")
+            raw_exists = (out_dir / "combined_load_benchmark.txt").exists()
+
+        self.assertEqual(doc["status"], "no_data")
+        self.assertIn("benchmark line for BenchmarkValidateBlockBasicCombinedLoad not found", doc["reason"])
+        self.assertIn("Status: `no_data`", summary_text)
+        self.assertTrue(raw_exists)
+        self.assertIn("RUBIN_OPENSSL_PREFIX", proc.stderr)
+        self.assertIn("benchmark command failed", proc.stderr)
 
     def test_malformed_combined_load_metric_has_distinct_no_data_reason(self):
         with tempfile.TemporaryDirectory() as td:

--- a/tools/tests/test_perf_advisory_regression.py
+++ b/tools/tests/test_perf_advisory_regression.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+# Tests execute repo-local Python CLIs through argv lists only.
+import subprocess  # nosec B404
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+COMPARE = REPO_ROOT / "scripts" / "runtime_perf" / "compare_runtime_perf.py"
+PARSE_COMBINED = REPO_ROOT / "scripts" / "benchmarks" / "parse_go_bench.py"
+SLO = REPO_ROOT / "scripts" / "benchmarks" / "combined_load_slo.json"
+
+
+def write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+class RuntimePerfAdvisoryTests(unittest.TestCase):
+    def run_compare(self, base: Path, head: Path, out: Path) -> dict:
+        summary = out / "summary.md"
+        delta = out / "delta.json"
+        # The command is a repo-local script through sys.executable with temp file arguments only.
+        proc = subprocess.run(  # nosec B603
+            [
+                sys.executable,
+                str(COMPARE),
+                "--base-dir",
+                str(base),
+                "--head-dir",
+                str(head),
+                "--summary",
+                str(summary),
+                "--output",
+                str(delta),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertTrue(summary.exists())
+        self.assertTrue(delta.exists())
+        return json.loads(delta.read_text(encoding="utf-8"))
+
+    def test_all_selected_low_noise_metrics_pass_when_within_thresholds(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            base = root / "base"
+            head = root / "head"
+            write_json(
+                base / "go_metrics.json",
+                {
+                    "suite": "go",
+                    "metrics": {
+                        "BenchmarkMempoolAddTx": {"iterations": 1, "ns_per_op": 100.0, "b_per_op": 10.0, "allocs_per_op": 1.0},
+                        "BenchmarkMempoolRelayMetadata": {"iterations": 1, "ns_per_op": 100.0, "b_per_op": 10.0, "allocs_per_op": 1.0},
+                        "BenchmarkCloneChainState": {"iterations": 1, "ns_per_op": 100.0, "b_per_op": 10.0, "allocs_per_op": 1.0},
+                    },
+                },
+            )
+            write_json(
+                head / "go_metrics.json",
+                {
+                    "suite": "go",
+                    "metrics": {
+                        "BenchmarkMempoolAddTx": {"iterations": 1, "ns_per_op": 110.0, "b_per_op": 10.0, "allocs_per_op": 1.0},
+                        "BenchmarkMempoolRelayMetadata": {"iterations": 1, "ns_per_op": 110.0, "b_per_op": 10.0, "allocs_per_op": 1.0},
+                        "BenchmarkCloneChainState": {"iterations": 1, "ns_per_op": 110.0, "b_per_op": 10.0, "allocs_per_op": 1.0},
+                    },
+                },
+            )
+            write_json(
+                base / "rust_metrics.json",
+                {
+                    "suite": "rust",
+                    "metrics": {
+                        "rubin_node_txpool/admit": {"ns_per_op": 100.0},
+                        "rubin_node_txpool/relay_metadata": {"ns_per_op": 100.0},
+                        "rubin_node_chainstate_clone": {"ns_per_op": 100.0},
+                    },
+                },
+            )
+            write_json(
+                head / "rust_metrics.json",
+                {
+                    "suite": "rust",
+                    "metrics": {
+                        "rubin_node_txpool/admit": {"ns_per_op": 110.0},
+                        "rubin_node_txpool/relay_metadata": {"ns_per_op": 110.0},
+                        "rubin_node_chainstate_clone": {"ns_per_op": 110.0},
+                    },
+                },
+            )
+
+            doc = self.run_compare(base, head, root / "out")
+            summary_text = (root / "out" / "summary.md").read_text(encoding="utf-8")
+
+        self.assertEqual(doc["input_issues"], [])
+        self.assertEqual(doc["advisory_status"], "pass")
+        self.assertTrue(all(item["status"] == "pass" for item in doc["advisory"]))
+        self.assertIn("Overall advisory status: `pass`", summary_text)
+
+    def test_selected_low_noise_regression_warns_without_failing(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            base = root / "base"
+            head = root / "head"
+            write_json(
+                base / "go_metrics.json",
+                {
+                    "suite": "go",
+                    "metrics": {
+                        "BenchmarkMempoolAddTx": {
+                            "iterations": 1,
+                            "ns_per_op": 100.0,
+                            "b_per_op": 10.0,
+                            "allocs_per_op": 1.0,
+                        },
+                        "BenchmarkMempoolRelayMetadata": {
+                            "iterations": 1,
+                            "ns_per_op": 100.0,
+                            "b_per_op": 10.0,
+                            "allocs_per_op": 1.0,
+                        },
+                        "BenchmarkCloneChainState": {
+                            "iterations": 1,
+                            "ns_per_op": 100.0,
+                            "b_per_op": 10.0,
+                            "allocs_per_op": 1.0,
+                        },
+                        "BenchmarkMinerBuildContext": {
+                            "iterations": 1,
+                            "ns_per_op": 100.0,
+                            "b_per_op": 10.0,
+                            "allocs_per_op": 1.0,
+                        },
+                    },
+                },
+            )
+            write_json(
+                head / "go_metrics.json",
+                {
+                    "suite": "go",
+                    "metrics": {
+                        "BenchmarkMempoolAddTx": {
+                            "iterations": 1,
+                            "ns_per_op": 130.0,
+                            "b_per_op": 10.0,
+                            "allocs_per_op": 1.0,
+                        },
+                        "BenchmarkMempoolRelayMetadata": {
+                            "iterations": 1,
+                            "ns_per_op": 100.0,
+                            "b_per_op": 10.0,
+                            "allocs_per_op": 1.0,
+                        },
+                        "BenchmarkCloneChainState": {
+                            "iterations": 1,
+                            "ns_per_op": 100.0,
+                            "b_per_op": 10.0,
+                            "allocs_per_op": 1.0,
+                        },
+                        "BenchmarkMinerBuildContext": {
+                            "iterations": 1,
+                            "ns_per_op": 1000.0,
+                            "b_per_op": 10.0,
+                            "allocs_per_op": 1.0,
+                        },
+                    },
+                },
+            )
+            write_json(
+                base / "rust_metrics.json",
+                {
+                    "suite": "rust",
+                    "metrics": {
+                        "rubin_node_txpool/admit": {"ns_per_op": 100.0},
+                        "rubin_node_txpool/relay_metadata": {"ns_per_op": 100.0},
+                        "rubin_node_chainstate_clone": {"ns_per_op": 100.0},
+                    },
+                },
+            )
+            write_json(
+                head / "rust_metrics.json",
+                {
+                    "suite": "rust",
+                    "metrics": {
+                        "rubin_node_txpool/admit": {"ns_per_op": 100.0},
+                        "rubin_node_txpool/relay_metadata": {"ns_per_op": 100.0},
+                        "rubin_node_chainstate_clone": {"ns_per_op": 100.0},
+                    },
+                },
+            )
+
+            doc = self.run_compare(base, head, root / "out")
+            summary_text = (root / "out" / "summary.md").read_text(encoding="utf-8")
+
+        self.assertEqual(doc["input_issues"], [])
+        self.assertEqual(doc["advisory_status"], "warn")
+        self.assertIn("Overall advisory status: `warn`", summary_text)
+        add_tx = next(item for item in doc["advisory"] if item["benchmark"] == "BenchmarkMempoolAddTx")
+        self.assertEqual(add_tx["status"], "warn")
+        self.assertEqual(add_tx["baseline"], 100.0)
+        self.assertEqual(add_tx["observed"], 130.0)
+        self.assertEqual(add_tx["threshold_pct"], 20.0)
+        miner = next(row for row in doc["go"] if row["name"] == "BenchmarkMinerBuildContext")
+        self.assertEqual(miner["advisory"]["ns_per_op"]["status"], "unselected")
+
+    def test_missing_or_malformed_metrics_are_no_data_not_regression(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            base = root / "base"
+            head = root / "head"
+            base.mkdir()
+            head.mkdir()
+            (base / "go_metrics.json").write_text("{not-json\n", encoding="utf-8")
+            write_json(
+                head / "go_metrics.json",
+                {
+                    "suite": "go",
+                    "metrics": {
+                        "BenchmarkMempoolAddTx": {
+                            "iterations": 1,
+                            "ns_per_op": 130.0,
+                            "b_per_op": 10.0,
+                            "allocs_per_op": 1.0,
+                        }
+                    },
+                },
+            )
+
+            doc = self.run_compare(base, head, root / "out")
+
+        self.assertIn("malformed JSON", "\n".join(doc["input_issues"]))
+        add_tx = next(item for item in doc["advisory"] if item["benchmark"] == "BenchmarkMempoolAddTx")
+        self.assertEqual(add_tx["status"], "no_data")
+        self.assertNotEqual(add_tx["status"], "warn")
+
+    def test_combined_load_slo_breach_is_advisory_warn_exit_zero(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            raw = root / "bench.txt"
+            out = root / "combined.json"
+            summary = root / "summary.md"
+            raw.write_text(
+                "setup banner from wrapper\n"
+                "BenchmarkValidateBlockBasicCombinedLoad-8 1 4000000000 ns/op 900000000 B/op 4000000 allocs/op\n",
+                encoding="utf-8",
+            )
+            # The command is a repo-local script through sys.executable with temp file arguments only.
+            proc = subprocess.run(  # nosec B603
+                [
+                    sys.executable,
+                    str(PARSE_COMBINED),
+                    "--input",
+                    str(raw),
+                    "--slo",
+                    str(SLO),
+                    "--output",
+                    str(out),
+                    "--summary",
+                    str(summary),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            doc = json.loads(out.read_text(encoding="utf-8"))
+            summary_text = summary.read_text(encoding="utf-8")
+
+        self.assertEqual(doc["status"], "warn")
+        self.assertTrue(doc["advisory"])
+        self.assertIn("workflow remains non-blocking", doc["reason"])
+        self.assertIn("Status: `warn`", summary_text)
+
+    def test_missing_combined_load_line_is_no_data_not_regression(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            raw = root / "bench.txt"
+            out = root / "combined.json"
+            raw.write_text("dev-env banner\nok no benchmark here\n", encoding="utf-8")
+            # The command is a repo-local script through sys.executable with temp file arguments only.
+            proc = subprocess.run(  # nosec B603
+                [
+                    sys.executable,
+                    str(PARSE_COMBINED),
+                    "--input",
+                    str(raw),
+                    "--slo",
+                    str(SLO),
+                    "--output",
+                    str(out),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            doc = json.loads(out.read_text(encoding="utf-8"))
+
+        self.assertEqual(doc["status"], "no_data")
+        self.assertEqual(doc["violations"], [])
+        self.assertIn("not found", doc["reason"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_perf_advisory_regression.py
+++ b/tools/tests/test_perf_advisory_regression.py
@@ -355,6 +355,34 @@ class RuntimePerfAdvisoryTests(unittest.TestCase):
         add_tx = next(item for item in doc["advisory"] if item["benchmark"] == "BenchmarkMempoolAddTx")
         self.assertEqual(add_tx["status"], "warn")
 
+    def test_missing_unselected_row_summary_matches_json_status(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            base = root / "base"
+            head = root / "head"
+            write_json(
+                base / "go_metrics.json",
+                {
+                    "suite": "go",
+                    "metrics": {
+                        "BenchmarkMinerBuildContext": {
+                            "iterations": 1,
+                            "ns_per_op": 100.0,
+                            "b_per_op": 10.0,
+                            "allocs_per_op": 1.0,
+                        },
+                    },
+                },
+            )
+            write_json(head / "go_metrics.json", {"suite": "go", "metrics": {}})
+
+            doc = self.run_compare(base, head, root / "out")
+            summary_text = (root / "out" / "summary.md").read_text(encoding="utf-8")
+
+        miner = next(row for row in doc["go"] if row["name"] == "BenchmarkMinerBuildContext")
+        self.assertEqual(miner["advisory"]["ns_per_op"]["status"], "unselected")
+        self.assertIn("| `BenchmarkMinerBuildContext` | 100 | missing | n/a | unselected |", summary_text)
+
     def test_malformed_exit_code_records_input_issue_without_masking_warning(self):
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)
@@ -786,6 +814,43 @@ class RuntimePerfAdvisoryTests(unittest.TestCase):
                 self.assertFalse(out.exists())
                 self.assertIn(f"SLO {limit_key}", proc.stderr)
                 self.assertNotIn("Traceback", proc.stderr)
+
+    def test_invalid_combined_load_slo_benchmark_fails_closed(self):
+        for value in [None, "", "   ", 123]:
+            with self.subTest(value=repr(value)), tempfile.TemporaryDirectory() as td:
+                root = Path(td)
+                raw = root / "bench.txt"
+                slo = root / "slo.json"
+                out = root / "combined.json"
+                raw.write_text(
+                    "BenchmarkValidateBlockBasicCombinedLoad-8 1 4000000000 ns/op "
+                    "900000000 B/op 4000000 allocs/op\n",
+                    encoding="utf-8",
+                )
+                payload = json.loads(SLO.read_text(encoding="utf-8"))
+                payload["benchmark"] = value
+                write_json(slo, payload)
+                # The command is a repo-local script through sys.executable with temp file arguments only.
+                proc = subprocess.run(  # nosec B603
+                    [
+                        sys.executable,
+                        str(PARSE_COMBINED),
+                        "--input",
+                        str(raw),
+                        "--slo",
+                        str(slo),
+                        "--output",
+                        str(out),
+                    ],
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
+
+            self.assertNotEqual(proc.returncode, 0)
+            self.assertFalse(out.exists())
+            self.assertIn("SLO benchmark must be a non-empty string", proc.stderr)
+            self.assertNotIn("Traceback", proc.stderr)
 
     def test_non_numeric_selected_metric_is_no_data_not_traceback(self):
         with tempfile.TemporaryDirectory() as td:

--- a/tools/tests/test_perf_advisory_regression.py
+++ b/tools/tests/test_perf_advisory_regression.py
@@ -239,7 +239,11 @@ class RuntimePerfAdvisoryTests(unittest.TestCase):
         self.assertIn("malformed JSON", "\n".join(doc["input_issues"]))
         add_tx = next(item for item in doc["advisory"] if item["benchmark"] == "BenchmarkMempoolAddTx")
         self.assertEqual(add_tx["status"], "no_data")
+        self.assertIn("malformed JSON", add_tx["reason"])
         self.assertNotEqual(add_tx["status"], "warn")
+        go_row = next(row for row in doc["go"] if row["name"] == "BenchmarkMempoolAddTx")
+        self.assertIn("malformed JSON", go_row["advisory"]["ns_per_op"]["reason"])
+        self.assertEqual(doc["rust"], [])
 
     def test_combined_load_slo_breach_is_advisory_warn_exit_zero(self):
         with tempfile.TemporaryDirectory() as td:

--- a/tools/tests/test_perf_advisory_regression.py
+++ b/tools/tests/test_perf_advisory_regression.py
@@ -586,6 +586,44 @@ class RuntimePerfAdvisoryTests(unittest.TestCase):
             self.assertIn("malformed ns_per_op", doc["reason"])
             self.assertNotIn("Traceback", proc.stderr)
 
+    def test_non_finite_combined_load_slo_threshold_fails_closed(self):
+        for limit_key in ["max_ns_per_op", "max_b_per_op", "max_allocs_per_op"]:
+            for value in [float("nan"), float("inf")]:
+                with self.subTest(limit_key=limit_key, value=str(value)), tempfile.TemporaryDirectory() as td:
+                    root = Path(td)
+                    raw = root / "bench.txt"
+                    slo = root / "slo.json"
+                    out = root / "combined.json"
+                    raw.write_text(
+                        "BenchmarkValidateBlockBasicCombinedLoad-8 1 4000000000 ns/op "
+                        "900000000 B/op 4000000 allocs/op\n",
+                        encoding="utf-8",
+                    )
+                    payload = json.loads(SLO.read_text(encoding="utf-8"))
+                    payload[limit_key] = value
+                    write_json(slo, payload)
+                    # The command is a repo-local script through sys.executable with temp file arguments only.
+                    proc = subprocess.run(  # nosec B603
+                        [
+                            sys.executable,
+                            str(PARSE_COMBINED),
+                            "--input",
+                            str(raw),
+                            "--slo",
+                            str(slo),
+                            "--output",
+                            str(out),
+                        ],
+                        check=False,
+                        capture_output=True,
+                        text=True,
+                    )
+
+                self.assertNotEqual(proc.returncode, 0)
+                self.assertFalse(out.exists())
+                self.assertIn(f"SLO {limit_key} has non-finite numeric token", proc.stderr)
+                self.assertNotIn("Traceback", proc.stderr)
+
     def test_non_numeric_selected_metric_is_no_data_not_traceback(self):
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)

--- a/tools/tests/test_perf_advisory_regression.py
+++ b/tools/tests/test_perf_advisory_regression.py
@@ -671,11 +671,50 @@ class RuntimePerfAdvisoryTests(unittest.TestCase):
             raw_exists = (out_dir / "combined_load_benchmark.txt").exists()
 
         self.assertEqual(doc["status"], "no_data")
-        self.assertIn("benchmark line for BenchmarkValidateBlockBasicCombinedLoad not found", doc["reason"])
+        self.assertIn("benchmark command failed", doc["reason"])
         self.assertIn("Status: `no_data`", summary_text)
         self.assertTrue(raw_exists)
         self.assertIn("RUBIN_OPENSSL_PREFIX", proc.stderr)
         self.assertIn("benchmark command failed", proc.stderr)
+
+    def test_combined_load_producer_failure_overrides_valid_stdout(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            raw = root / "bench.txt"
+            out = root / "combined.json"
+            summary = root / "summary.md"
+            raw.write_text(
+                "BenchmarkValidateBlockBasicCombinedLoad-8 1 4000000000 ns/op "
+                "900000000 B/op 4000000 allocs/op\n",
+                encoding="utf-8",
+            )
+            # The command is a repo-local script through sys.executable with temp file arguments only.
+            proc = subprocess.run(  # nosec B603
+                [
+                    sys.executable,
+                    str(PARSE_COMBINED),
+                    "--input",
+                    str(raw),
+                    "--slo",
+                    str(SLO),
+                    "--output",
+                    str(out),
+                    "--summary",
+                    str(summary),
+                    "--producer-exit-code",
+                    "1",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            doc = json.loads(out.read_text(encoding="utf-8"))
+            summary_text = summary.read_text(encoding="utf-8")
+
+        self.assertEqual(doc["status"], "no_data")
+        self.assertIn("benchmark command failed with status 1", doc["reason"])
+        self.assertIn("Status: `no_data`", summary_text)
 
     def test_malformed_combined_load_metric_has_distinct_no_data_reason(self):
         with tempfile.TemporaryDirectory() as td:
@@ -823,6 +862,7 @@ class RuntimePerfAdvisoryTests(unittest.TestCase):
             " BenchmarkValidateBlockBasicCombinedLoad ",
             "BenchmarkValidate BlockBasicCombinedLoad",
             "BenchmarkValidate\tBlockBasicCombinedLoad",
+            "BenchmarkValidateBlockBasicCombinedLoad-8",
             123,
         ]:
             with self.subTest(value=repr(value)), tempfile.TemporaryDirectory() as td:

--- a/tools/tests/test_perf_advisory_regression.py
+++ b/tools/tests/test_perf_advisory_regression.py
@@ -253,7 +253,8 @@ class RuntimePerfAdvisoryTests(unittest.TestCase):
             summary = root / "summary.md"
             raw.write_text(
                 "setup banner from wrapper\n"
-                "BenchmarkValidateBlockBasicCombinedLoad-8 1 4000000000 ns/op 900000000 B/op 4000000 allocs/op\n",
+                "BenchmarkValidateBlockBasicCombinedLoad-8 1 4000000000 ns/op "
+                "12 custom/op 900000000 B/op 4000000 allocs/op 99 verifies/op\n",
                 encoding="utf-8",
             )
             # The command is a repo-local script through sys.executable with temp file arguments only.
@@ -282,6 +283,46 @@ class RuntimePerfAdvisoryTests(unittest.TestCase):
         self.assertTrue(doc["advisory"])
         self.assertIn("workflow remains non-blocking", doc["reason"])
         self.assertIn("Status: `warn`", summary_text)
+
+    def test_non_numeric_selected_metric_is_no_data_not_traceback(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            base = root / "base"
+            head = root / "head"
+            write_json(
+                base / "go_metrics.json",
+                {
+                    "suite": "go",
+                    "metrics": {
+                        "BenchmarkMempoolAddTx": {
+                            "iterations": 1,
+                            "ns_per_op": "n/a",
+                            "b_per_op": 10.0,
+                            "allocs_per_op": 1.0,
+                        }
+                    },
+                },
+            )
+            write_json(
+                head / "go_metrics.json",
+                {
+                    "suite": "go",
+                    "metrics": {
+                        "BenchmarkMempoolAddTx": {
+                            "iterations": 1,
+                            "ns_per_op": 130.0,
+                            "b_per_op": 10.0,
+                            "allocs_per_op": 1.0,
+                        }
+                    },
+                },
+            )
+
+            doc = self.run_compare(base, head, root / "out")
+
+        add_tx = next(item for item in doc["advisory"] if item["benchmark"] == "BenchmarkMempoolAddTx")
+        self.assertEqual(add_tx["status"], "no_data")
+        self.assertIn("non-numeric", add_tx["reason"])
 
     def test_missing_combined_load_line_is_no_data_not_regression(self):
         with tempfile.TemporaryDirectory() as td:

--- a/tools/tests/test_perf_advisory_regression.py
+++ b/tools/tests/test_perf_advisory_regression.py
@@ -386,6 +386,63 @@ class RuntimePerfAdvisoryTests(unittest.TestCase):
         add_tx = next(item for item in doc["advisory"] if item["benchmark"] == "BenchmarkMempoolAddTx")
         self.assertEqual(add_tx["status"], "warn")
 
+    def test_invalid_utf8_metric_artifact_is_no_data_not_traceback(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            base = root / "base"
+            head = root / "head"
+            base.mkdir(parents=True)
+            (base / "go_metrics.json").write_bytes(b"\xff\xfe")
+            write_json(
+                head / "go_metrics.json",
+                {
+                    "suite": "go",
+                    "metrics": {
+                        "BenchmarkMempoolAddTx": {
+                            "iterations": 1,
+                            "ns_per_op": 130.0,
+                            "b_per_op": 10.0,
+                            "allocs_per_op": 1.0,
+                        }
+                    },
+                },
+            )
+
+            doc = self.run_compare(base, head, root / "out")
+
+        self.assertIn("invalid UTF-8", "\n".join(doc["input_issues"]))
+        add_tx = next(item for item in doc["advisory"] if item["benchmark"] == "BenchmarkMempoolAddTx")
+        self.assertEqual(add_tx["status"], "no_data")
+
+    def test_invalid_utf8_exit_code_records_input_issue_without_masking_warning(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            base = root / "base"
+            head = root / "head"
+            for side, add_tx_ns in [(base, 100.0), (head, 130.0)]:
+                write_json(
+                    side / "go_metrics.json",
+                    {
+                        "suite": "go",
+                        "metrics": {
+                            "BenchmarkMempoolAddTx": {
+                                "iterations": 1,
+                                "ns_per_op": add_tx_ns,
+                                "b_per_op": 10.0,
+                                "allocs_per_op": 1.0,
+                            },
+                        },
+                    },
+                )
+            (base / "exit_code.txt").write_bytes(b"\xff\xfe")
+
+            doc = self.run_compare(base, head, root / "out")
+
+        self.assertIsNone(doc["base_exit_code"])
+        self.assertIn("invalid UTF-8", "\n".join(doc["input_issues"]))
+        add_tx = next(item for item in doc["advisory"] if item["benchmark"] == "BenchmarkMempoolAddTx")
+        self.assertEqual(add_tx["status"], "warn")
+
     def test_non_finite_selected_metric_is_no_data_not_pass(self):
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)
@@ -657,6 +714,40 @@ class RuntimePerfAdvisoryTests(unittest.TestCase):
             self.assertEqual(doc["status"], "no_data")
             self.assertIn("malformed ns_per_op", doc["reason"])
             self.assertNotIn("Traceback", proc.stderr)
+
+    def test_invalid_utf8_combined_load_input_writes_no_data_summary(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            raw = root / "bench.txt"
+            out = root / "combined.json"
+            summary = root / "summary.md"
+            raw.write_bytes(b"\xff\xfe")
+            # The command is a repo-local script through sys.executable with temp file arguments only.
+            proc = subprocess.run(  # nosec B603
+                [
+                    sys.executable,
+                    str(PARSE_COMBINED),
+                    "--input",
+                    str(raw),
+                    "--slo",
+                    str(SLO),
+                    "--output",
+                    str(out),
+                    "--summary",
+                    str(summary),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            doc = json.loads(out.read_text(encoding="utf-8"))
+            summary_text = summary.read_text(encoding="utf-8")
+
+        self.assertEqual(doc["status"], "no_data")
+        self.assertIn("benchmark output unreadable", doc["reason"])
+        self.assertIn("Status: `no_data`", summary_text)
+        self.assertNotIn("Traceback", proc.stderr)
 
     def test_invalid_combined_load_slo_threshold_fails_closed(self):
         for limit_key in ["max_ns_per_op", "max_b_per_op", "max_allocs_per_op"]:

--- a/tools/tests/test_perf_advisory_regression.py
+++ b/tools/tests/test_perf_advisory_regression.py
@@ -58,7 +58,12 @@ class RuntimePerfAdvisoryTests(unittest.TestCase):
         self.assertEqual(proc.returncode, 0, proc.stderr)
         self.assertTrue(summary.exists())
         self.assertTrue(delta.exists())
-        return json.loads(delta.read_text(encoding="utf-8"))
+        raw_delta = delta.read_text(encoding="utf-8")
+
+        def reject_non_standard_json_constant(token: str):
+            raise AssertionError(f"delta.json contains non-standard JSON constant {token}")
+
+        return json.loads(raw_delta, parse_constant=reject_non_standard_json_constant)
 
     def test_all_selected_low_noise_metrics_pass_when_within_thresholds(self):
         with tempfile.TemporaryDirectory() as td:
@@ -510,7 +515,10 @@ class RuntimePerfAdvisoryTests(unittest.TestCase):
         add_tx = next(item for item in doc["advisory"] if item["benchmark"] == "BenchmarkMempoolAddTx")
         self.assertEqual(add_tx["status"], "no_data")
         self.assertIn("non-finite", add_tx["reason"])
+        self.assertIsNone(add_tx["observed"])
         self.assertIsNone(add_tx["delta_pct"])
+        row = next(item for item in doc["go"] if item["name"] == "BenchmarkMempoolAddTx")
+        self.assertIsNone(row["head"]["ns_per_op"])
 
     def test_negative_selected_metric_is_no_data_not_pass(self):
         with tempfile.TemporaryDirectory() as td:
@@ -968,6 +976,38 @@ class RuntimePerfAdvisoryTests(unittest.TestCase):
         self.assertEqual(doc["status"], "no_data")
         self.assertEqual(doc["violations"], [])
         self.assertIn("not found", doc["reason"])
+
+    def test_unmatched_combined_load_slo_benchmark_fails_closed(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            raw = root / "bench.txt"
+            out = root / "combined.json"
+            raw.write_text(
+                "BenchmarkDifferentCombinedLoad-8 1 400 ns/op 10 B/op 1 allocs/op\n",
+                encoding="utf-8",
+            )
+            # The command is a repo-local script through sys.executable with temp file arguments only.
+            proc = subprocess.run(  # nosec B603
+                [
+                    sys.executable,
+                    str(PARSE_COMBINED),
+                    "--input",
+                    str(raw),
+                    "--slo",
+                    str(SLO),
+                    "--output",
+                    str(out),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+        self.assertEqual(proc.returncode, 1)
+        self.assertFalse(out.exists())
+        self.assertIn("SLO benchmark", proc.stderr)
+        self.assertIn("BenchmarkDifferentCombinedLoad", proc.stderr)
+        self.assertNotIn("Traceback", proc.stderr)
 
     def test_advisory_threshold_registry_matches_trend_low_noise_candidates(self):
         compare = load_module(COMPARE, "compare_runtime_perf_for_test")

--- a/tools/tests/test_perf_advisory_regression.py
+++ b/tools/tests/test_perf_advisory_regression.py
@@ -355,6 +355,37 @@ class RuntimePerfAdvisoryTests(unittest.TestCase):
         add_tx = next(item for item in doc["advisory"] if item["benchmark"] == "BenchmarkMempoolAddTx")
         self.assertEqual(add_tx["status"], "warn")
 
+    def test_malformed_exit_code_records_input_issue_without_masking_warning(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            base = root / "base"
+            head = root / "head"
+            for side, add_tx_ns in [(base, 100.0), (head, 130.0)]:
+                write_json(
+                    side / "go_metrics.json",
+                    {
+                        "suite": "go",
+                        "metrics": {
+                            "BenchmarkMempoolAddTx": {
+                                "iterations": 1,
+                                "ns_per_op": add_tx_ns,
+                                "b_per_op": 10.0,
+                                "allocs_per_op": 1.0,
+                            },
+                        },
+                    },
+                )
+            (base / "exit_code.txt").write_text("not-an-int\n", encoding="utf-8")
+            (head / "exit_code.txt").write_text("0\n", encoding="utf-8")
+
+            doc = self.run_compare(base, head, root / "out")
+
+        self.assertIsNone(doc["base_exit_code"])
+        self.assertEqual(doc["head_exit_code"], 0)
+        self.assertIn("malformed exit code", "\n".join(doc["input_issues"]))
+        add_tx = next(item for item in doc["advisory"] if item["benchmark"] == "BenchmarkMempoolAddTx")
+        self.assertEqual(add_tx["status"], "warn")
+
     def test_non_finite_selected_metric_is_no_data_not_pass(self):
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)

--- a/tools/tests/test_perf_advisory_regression.py
+++ b/tools/tests/test_perf_advisory_regression.py
@@ -816,7 +816,15 @@ class RuntimePerfAdvisoryTests(unittest.TestCase):
                 self.assertNotIn("Traceback", proc.stderr)
 
     def test_invalid_combined_load_slo_benchmark_fails_closed(self):
-        for value in [None, "", "   ", " BenchmarkValidateBlockBasicCombinedLoad ", 123]:
+        for value in [
+            None,
+            "",
+            "   ",
+            " BenchmarkValidateBlockBasicCombinedLoad ",
+            "BenchmarkValidate BlockBasicCombinedLoad",
+            "BenchmarkValidate\tBlockBasicCombinedLoad",
+            123,
+        ]:
             with self.subTest(value=repr(value)), tempfile.TemporaryDirectory() as td:
                 root = Path(td)
                 raw = root / "bench.txt"

--- a/tools/tests/test_perf_advisory_regression.py
+++ b/tools/tests/test_perf_advisory_regression.py
@@ -294,6 +294,108 @@ class RuntimePerfAdvisoryTests(unittest.TestCase):
         self.assertEqual(add_tx["status"], "no_data")
         self.assertIn("expected object", add_tx["reason"])
 
+    def test_malformed_unselected_entry_does_not_mask_selected_warning(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            base = root / "base"
+            head = root / "head"
+            for side, add_tx_ns in [(base, 100.0), (head, 130.0)]:
+                write_json(
+                    side / "go_metrics.json",
+                    {
+                        "suite": "go",
+                        "metrics": {
+                            "BenchmarkMempoolAddTx": {
+                                "iterations": 1,
+                                "ns_per_op": add_tx_ns,
+                                "b_per_op": 10.0,
+                                "allocs_per_op": 1.0,
+                            },
+                            "BenchmarkMinerBuildContext": [],
+                        },
+                    },
+                )
+
+            doc = self.run_compare(base, head, root / "out")
+
+        self.assertIn("metrics entry for BenchmarkMinerBuildContext is list", "\n".join(doc["input_issues"]))
+        self.assertEqual(doc["advisory_status"], "warn")
+        add_tx = next(item for item in doc["advisory"] if item["benchmark"] == "BenchmarkMempoolAddTx")
+        self.assertEqual(add_tx["status"], "warn")
+        self.assertEqual(add_tx["baseline"], 100.0)
+        self.assertEqual(add_tx["observed"], 130.0)
+        miner = next(row for row in doc["go"] if row["name"] == "BenchmarkMinerBuildContext")
+        self.assertEqual(miner["advisory"]["ns_per_op"]["status"], "unselected")
+
+    def test_malformed_missing_list_does_not_mask_selected_warning(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            base = root / "base"
+            head = root / "head"
+            for side, add_tx_ns in [(base, 100.0), (head, 130.0)]:
+                write_json(
+                    side / "go_metrics.json",
+                    {
+                        "suite": "go",
+                        "metrics": {
+                            "BenchmarkMempoolAddTx": {
+                                "iterations": 1,
+                                "ns_per_op": add_tx_ns,
+                                "b_per_op": 10.0,
+                                "allocs_per_op": 1.0,
+                            },
+                        },
+                        "missing": "not-a-list",
+                    },
+                )
+
+            doc = self.run_compare(base, head, root / "out")
+
+        self.assertIn("field 'missing' is str, expected list", "\n".join(doc["input_issues"]))
+        add_tx = next(item for item in doc["advisory"] if item["benchmark"] == "BenchmarkMempoolAddTx")
+        self.assertEqual(add_tx["status"], "warn")
+
+    def test_non_finite_selected_metric_is_no_data_not_pass(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            base = root / "base"
+            head = root / "head"
+            write_json(
+                base / "go_metrics.json",
+                {
+                    "suite": "go",
+                    "metrics": {
+                        "BenchmarkMempoolAddTx": {
+                            "iterations": 1,
+                            "ns_per_op": 100.0,
+                            "b_per_op": 10.0,
+                            "allocs_per_op": 1.0,
+                        }
+                    },
+                },
+            )
+            write_json(
+                head / "go_metrics.json",
+                {
+                    "suite": "go",
+                    "metrics": {
+                        "BenchmarkMempoolAddTx": {
+                            "iterations": 1,
+                            "ns_per_op": float("nan"),
+                            "b_per_op": 10.0,
+                            "allocs_per_op": 1.0,
+                        }
+                    },
+                },
+            )
+
+            doc = self.run_compare(base, head, root / "out")
+
+        add_tx = next(item for item in doc["advisory"] if item["benchmark"] == "BenchmarkMempoolAddTx")
+        self.assertEqual(add_tx["status"], "no_data")
+        self.assertIn("non-finite", add_tx["reason"])
+        self.assertIsNone(add_tx["delta_pct"])
+
     def test_rust_missing_list_surfaces_rows_and_no_data(self):
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)
@@ -449,6 +551,40 @@ class RuntimePerfAdvisoryTests(unittest.TestCase):
         self.assertEqual(doc["status"], "no_data")
         self.assertIn("missing required metric", doc["reason"])
         self.assertNotIn("not found", doc["reason"])
+
+    def test_malformed_combined_load_numeric_token_is_no_data_not_traceback(self):
+        for token in ["400..0", "NaN"]:
+            with self.subTest(token=token), tempfile.TemporaryDirectory() as td:
+                root = Path(td)
+                raw = root / "bench.txt"
+                out = root / "combined.json"
+                raw.write_text(
+                    f"BenchmarkValidateBlockBasicCombinedLoad-8 1 {token} ns/op "
+                    "900000000 B/op 4000000 allocs/op\n",
+                    encoding="utf-8",
+                )
+                # The command is a repo-local script through sys.executable with temp file arguments only.
+                proc = subprocess.run(  # nosec B603
+                    [
+                        sys.executable,
+                        str(PARSE_COMBINED),
+                        "--input",
+                        str(raw),
+                        "--slo",
+                        str(SLO),
+                        "--output",
+                        str(out),
+                    ],
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
+                self.assertEqual(proc.returncode, 0, proc.stderr)
+                doc = json.loads(out.read_text(encoding="utf-8"))
+
+            self.assertEqual(doc["status"], "no_data")
+            self.assertIn("malformed ns_per_op", doc["reason"])
+            self.assertNotIn("Traceback", proc.stderr)
 
     def test_non_numeric_selected_metric_is_no_data_not_traceback(self):
         with tempfile.TemporaryDirectory() as td:

--- a/tools/tests/test_perf_advisory_regression.py
+++ b/tools/tests/test_perf_advisory_regression.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import importlib.util
 import json
 # Tests execute repo-local Python CLIs through argv lists only.
 import subprocess  # nosec B404
@@ -13,11 +14,21 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 COMPARE = REPO_ROOT / "scripts" / "runtime_perf" / "compare_runtime_perf.py"
 PARSE_COMBINED = REPO_ROOT / "scripts" / "benchmarks" / "parse_go_bench.py"
 SLO = REPO_ROOT / "scripts" / "benchmarks" / "combined_load_slo.json"
+TREND = REPO_ROOT / "scripts" / "runtime_perf" / "build_runtime_perf_trend.py"
 
 
 def write_json(path: Path, payload: object) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def load_module(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load module from {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 class RuntimePerfAdvisoryTests(unittest.TestCase):
@@ -284,6 +295,69 @@ class RuntimePerfAdvisoryTests(unittest.TestCase):
         self.assertIn("workflow remains non-blocking", doc["reason"])
         self.assertIn("Status: `warn`", summary_text)
 
+    def test_missing_combined_load_input_file_writes_no_data_summary(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            out = root / "combined.json"
+            summary = root / "summary.md"
+            # The command is a repo-local script through sys.executable with temp file arguments only.
+            proc = subprocess.run(  # nosec B603
+                [
+                    sys.executable,
+                    str(PARSE_COMBINED),
+                    "--input",
+                    str(root / "missing-benchmark.txt"),
+                    "--slo",
+                    str(SLO),
+                    "--output",
+                    str(out),
+                    "--summary",
+                    str(summary),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            doc = json.loads(out.read_text(encoding="utf-8"))
+            summary_text = summary.read_text(encoding="utf-8")
+
+        self.assertEqual(doc["status"], "no_data")
+        self.assertIn("benchmark output not found", doc["reason"])
+        self.assertIn("Status: `no_data`", summary_text)
+
+    def test_malformed_combined_load_metric_has_distinct_no_data_reason(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            raw = root / "bench.txt"
+            out = root / "combined.json"
+            raw.write_text(
+                "BenchmarkValidateBlockBasicCombinedLoad-8 1 4000000000 ns/op 4000000 allocs/op\n",
+                encoding="utf-8",
+            )
+            # The command is a repo-local script through sys.executable with temp file arguments only.
+            proc = subprocess.run(  # nosec B603
+                [
+                    sys.executable,
+                    str(PARSE_COMBINED),
+                    "--input",
+                    str(raw),
+                    "--slo",
+                    str(SLO),
+                    "--output",
+                    str(out),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            doc = json.loads(out.read_text(encoding="utf-8"))
+
+        self.assertEqual(doc["status"], "no_data")
+        self.assertIn("missing required metric", doc["reason"])
+        self.assertNotIn("not found", doc["reason"])
+
     def test_non_numeric_selected_metric_is_no_data_not_traceback(self):
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)
@@ -352,6 +426,22 @@ class RuntimePerfAdvisoryTests(unittest.TestCase):
         self.assertEqual(doc["status"], "no_data")
         self.assertEqual(doc["violations"], [])
         self.assertIn("not found", doc["reason"])
+
+    def test_advisory_threshold_registry_matches_trend_low_noise_candidates(self):
+        compare = load_module(COMPARE, "compare_runtime_perf_for_test")
+        trend = load_module(TREND, "build_runtime_perf_trend_for_test")
+
+        threshold_keys = {
+            (item["suite"], item["benchmark"], item["metric"])
+            for item in compare.ADVISORY_THRESHOLDS
+        }
+        trend_keys = {
+            (item["suite"], item["benchmark"], item["metric"])
+            for item in trend.LOW_NOISE_CANDIDATES
+            if item["suite"] in {"go", "rust"}
+        }
+
+        self.assertEqual(threshold_keys, trend_keys)
 
 
 if __name__ == "__main__":

--- a/tools/tests/test_perf_advisory_regression.py
+++ b/tools/tests/test_perf_advisory_regression.py
@@ -816,7 +816,7 @@ class RuntimePerfAdvisoryTests(unittest.TestCase):
                 self.assertNotIn("Traceback", proc.stderr)
 
     def test_invalid_combined_load_slo_benchmark_fails_closed(self):
-        for value in [None, "", "   ", 123]:
+        for value in [None, "", "   ", " BenchmarkValidateBlockBasicCombinedLoad ", 123]:
             with self.subTest(value=repr(value)), tempfile.TemporaryDirectory() as td:
                 root = Path(td)
                 raw = root / "bench.txt"
@@ -849,7 +849,7 @@ class RuntimePerfAdvisoryTests(unittest.TestCase):
 
             self.assertNotEqual(proc.returncode, 0)
             self.assertFalse(out.exists())
-            self.assertIn("SLO benchmark must be a non-empty string", proc.stderr)
+            self.assertIn("SLO benchmark must", proc.stderr)
             self.assertNotIn("Traceback", proc.stderr)
 
     def test_non_numeric_selected_metric_is_no_data_not_traceback(self):

--- a/tools/tests/test_perf_advisory_regression.py
+++ b/tools/tests/test_perf_advisory_regression.py
@@ -396,6 +396,47 @@ class RuntimePerfAdvisoryTests(unittest.TestCase):
         self.assertIn("non-finite", add_tx["reason"])
         self.assertIsNone(add_tx["delta_pct"])
 
+    def test_negative_selected_metric_is_no_data_not_pass(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            base = root / "base"
+            head = root / "head"
+            write_json(
+                base / "go_metrics.json",
+                {
+                    "suite": "go",
+                    "metrics": {
+                        "BenchmarkMempoolAddTx": {
+                            "iterations": 1,
+                            "ns_per_op": 100.0,
+                            "b_per_op": 10.0,
+                            "allocs_per_op": 1.0,
+                        }
+                    },
+                },
+            )
+            write_json(
+                head / "go_metrics.json",
+                {
+                    "suite": "go",
+                    "metrics": {
+                        "BenchmarkMempoolAddTx": {
+                            "iterations": 1,
+                            "ns_per_op": -1.0,
+                            "b_per_op": 10.0,
+                            "allocs_per_op": 1.0,
+                        }
+                    },
+                },
+            )
+
+            doc = self.run_compare(base, head, root / "out")
+
+        add_tx = next(item for item in doc["advisory"] if item["benchmark"] == "BenchmarkMempoolAddTx")
+        self.assertEqual(add_tx["status"], "no_data")
+        self.assertIn("negative metric value", add_tx["reason"])
+        self.assertIsNone(add_tx["delta_pct"])
+
     def test_rust_missing_list_surfaces_rows_and_no_data(self):
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)
@@ -553,7 +594,7 @@ class RuntimePerfAdvisoryTests(unittest.TestCase):
         self.assertNotIn("not found", doc["reason"])
 
     def test_malformed_combined_load_numeric_token_is_no_data_not_traceback(self):
-        for token in ["400..0", "NaN"]:
+        for token in ["400..0", "NaN", "-400"]:
             with self.subTest(token=token), tempfile.TemporaryDirectory() as td:
                 root = Path(td)
                 raw = root / "bench.txt"
@@ -586,9 +627,9 @@ class RuntimePerfAdvisoryTests(unittest.TestCase):
             self.assertIn("malformed ns_per_op", doc["reason"])
             self.assertNotIn("Traceback", proc.stderr)
 
-    def test_non_finite_combined_load_slo_threshold_fails_closed(self):
+    def test_invalid_combined_load_slo_threshold_fails_closed(self):
         for limit_key in ["max_ns_per_op", "max_b_per_op", "max_allocs_per_op"]:
-            for value in [float("nan"), float("inf")]:
+            for value in [float("nan"), float("inf"), -1.0, 0.0]:
                 with self.subTest(limit_key=limit_key, value=str(value)), tempfile.TemporaryDirectory() as td:
                     root = Path(td)
                     raw = root / "bench.txt"
@@ -621,7 +662,7 @@ class RuntimePerfAdvisoryTests(unittest.TestCase):
 
                 self.assertNotEqual(proc.returncode, 0)
                 self.assertFalse(out.exists())
-                self.assertIn(f"SLO {limit_key} has non-finite numeric token", proc.stderr)
+                self.assertIn(f"SLO {limit_key}", proc.stderr)
                 self.assertNotIn("Traceback", proc.stderr)
 
     def test_non_numeric_selected_metric_is_no_data_not_traceback(self):


### PR DESCRIPTION
## Scope
- Adds advisory runtime-perf regression status for selected low-noise `ns_per_op` benchmark deltas.
- Makes combined-load SLO parsing emit advisory `pass` / `warn` / `no_data` JSON and summary artifacts without failing on advisory threshold breach.
- Adds focused parser/comparison tests for pass, warn, no-data, malformed data, non-numeric data, and unselected benchmark behavior.

## Disposition
- Closes #1363.
- Architecture class: B.
- CI blocking policy changed: no.
- Go/Rust runtime changed: no.
- Conformance changed: no.
- Advisory thresholds currently cover selected `ns_per_op` candidates only; byte/allocation metrics remain reported but unthresholded.
