### PR TITLE
RUB-52: expose Go standard mempool policy telemetry

### DIFF
--- a/clients/go/cmd/rubin-node/http_rpc.go
+++ b/clients/go/cmd/rubin-node/http_rpc.go
@@ -1167,6 +1167,7 @@ func renderPrometheusMetrics(state *devnetRPCState) string {
 		mempoolTxs         float64
 		mempoolBytes       float64
 		mempoolAdmit       node.MempoolAdmissionCounts
+		mempoolStats       node.MempoolStats
 		peerLifecycleExits uint64
 		routeStatus        map[string]uint64
 		submitByResult     map[string]uint64
@@ -1196,6 +1197,14 @@ func renderPrometheusMetrics(state *devnetRPCState) string {
 		// repeatedly cannot perturb the counters.
 		mempoolBytes = float64(state.mempool.BytesUsed())
 		mempoolAdmit = state.mempool.AdmissionCounts()
+		// Stats is a read-only snapshot: Load() of the resident-eviction
+		// atomic counter plus an RLock-protected read of max_bytes /
+		// low_water_bytes / current min fee rate / tx count / bytes
+		// used. Repeated /metrics scrapes never mutate any of those.
+		// On a nil-mempool state path this branch is skipped and
+		// mempoolStats keeps its zero value, so the standard-mempool
+		// gauges below render as 0 without panicking.
+		mempoolStats = state.mempool.Stats()
 	}
 	if state != nil && state.peerLifecycleExits != nil {
 		// Pure atomic.Load behind the closure — repeated /metrics
@@ -1249,6 +1258,28 @@ func renderPrometheusMetrics(state *devnetRPCState) string {
 		fmt.Sprintf(`rubin_node_mempool_admit_total{result="conflict"} %d`, mempoolAdmit.Conflict),
 		fmt.Sprintf(`rubin_node_mempool_admit_total{result="rejected"} %d`, mempoolAdmit.Rejected),
 		fmt.Sprintf(`rubin_node_mempool_admit_total{result="unavailable"} %d`, mempoolAdmit.Unavailable),
+		// Standard mempool capacity / fee-floor / eviction telemetry.
+		// max_bytes and low_water_bytes are read live from the mempool
+		// (NOT from MempoolConfig defaults) so they reflect any
+		// per-instance override; min_fee_rate reflects the rolling
+		// post-eviction floor maintained by raiseMinFeeRateAfterEvictionLocked
+		// and decayMinFeeRateAfterConnectedBlockLocked. The eviction
+		// counter increments exactly once per resident-entry capacity
+		// eviction (deleteEntryLocked loop in addEntryLocked); candidate-
+		// worst rejection at capacity and fee-floor rejection do not
+		// increment it.
+		"# HELP rubin_node_mempool_max_bytes Configured byte cap for the standard mempool.",
+		"# TYPE rubin_node_mempool_max_bytes gauge",
+		fmt.Sprintf("rubin_node_mempool_max_bytes %d", mempoolStats.MaxBytes),
+		"# HELP rubin_node_mempool_low_water_bytes Capacity low-water byte threshold used during eviction planning for the standard mempool.",
+		"# TYPE rubin_node_mempool_low_water_bytes gauge",
+		fmt.Sprintf("rubin_node_mempool_low_water_bytes %d", mempoolStats.LowWaterBytes),
+		"# HELP rubin_node_mempool_min_fee_rate Current rolling minimum fee rate (per-weight units) enforced at standard mempool admission.",
+		"# TYPE rubin_node_mempool_min_fee_rate gauge",
+		fmt.Sprintf("rubin_node_mempool_min_fee_rate %d", mempoolStats.MinFeeRate),
+		"# HELP rubin_node_mempool_evicted_resident_total Cumulative resident-entry capacity evictions; candidate-worst rejection and fee-floor rejection are not counted here.",
+		"# TYPE rubin_node_mempool_evicted_resident_total counter",
+		fmt.Sprintf("rubin_node_mempool_evicted_resident_total %d", mempoolStats.EvictedResidentTotal),
 		// Unlabeled lifecycle-exit counter; the underlying exit cause
 		// (remote close, protocol error, local Service.Close) is not
 		// available at the unregisterPeer site without plumbing it

--- a/clients/go/cmd/rubin-node/http_rpc.go
+++ b/clients/go/cmd/rubin-node/http_rpc.go
@@ -1167,11 +1167,17 @@ func renderPrometheusMetrics(state *devnetRPCState) string {
 		mempoolTxs         float64
 		mempoolBytes       float64
 		mempoolAdmit       node.MempoolAdmissionCounts
-		mempoolStats       node.MempoolStats
 		peerLifecycleExits uint64
 		routeStatus        map[string]uint64
 		submitByResult     map[string]uint64
 	)
+	// Default mempool snapshot for the state==nil branch matches what
+	// (*node.Mempool)(nil).Stats() returns: counters/sizes 0 with
+	// MinFeeRate=DefaultMempoolMinFeeRate. Keeping this consistent with
+	// the nil-receiver convention means /metrics on a state==nil
+	// fixture and a state!=nil/state.mempool==nil fixture render the
+	// same baseline floor instead of differing by 0 vs 1.
+	mempoolStats := node.MempoolStats{MinFeeRate: node.DefaultMempoolMinFeeRate}
 	if state != nil && state.syncEngine != nil {
 		bestKnownHeight = float64(state.syncEngine.BestKnownHeight())
 		reorgCount = state.syncEngine.ReorgCount()
@@ -1188,23 +1194,22 @@ func renderPrometheusMetrics(state *devnetRPCState) string {
 		peerCount = float64(len(state.peerManager.Snapshot()))
 	}
 	if state != nil && state.mempool != nil {
-		mempoolTxs = float64(state.mempool.Len())
-		// BytesUsed is a scrape-time read of the mempool's existing
-		// usedBytes accounting (already maintained on every AddTx /
-		// RemoveTx). AdmissionCounts is a snapshot of the per-outcome
-		// counters that AddTx bumps at the final return path — read
-		// here is purely a Load(), no increment, so rendering /metrics
-		// repeatedly cannot perturb the counters.
-		mempoolBytes = float64(state.mempool.BytesUsed())
-		mempoolAdmit = state.mempool.AdmissionCounts()
-		// Stats is a read-only snapshot: Load() of the resident-eviction
-		// atomic counter plus an RLock-protected read of max_bytes /
-		// low_water_bytes / current min fee rate / tx count / bytes
-		// used. Repeated /metrics scrapes never mutate any of those.
-		// On a nil-mempool state path this branch is skipped and
-		// mempoolStats keeps its zero value, so the standard-mempool
-		// gauges below render as 0 without panicking.
+		// Stats is a read-only snapshot taken under m.mu.RLock; it
+		// covers tx count, bytes used, capacity caps, rolling fee
+		// floor, and the resident-eviction counter coherently. We
+		// reuse its TxCount/BytesUsed for the existing gauges so
+		// rubin_node_mempool_txs / rubin_node_mempool_bytes come from
+		// the SAME instant as rubin_node_mempool_max_bytes /
+		// low_water_bytes / min_fee_rate / evicted_resident_total —
+		// avoiding a split-snapshot publication where independent
+		// Len()/BytesUsed()/Stats() calls observe different states.
+		// AdmissionCounts is the closed-enum atomic.Load surface
+		// (accepted/conflict/rejected/unavailable); reading it here
+		// is purely a Load() and does not perturb the counters.
 		mempoolStats = state.mempool.Stats()
+		mempoolTxs = float64(mempoolStats.TxCount)
+		mempoolBytes = float64(mempoolStats.BytesUsed)
+		mempoolAdmit = state.mempool.AdmissionCounts()
 	}
 	if state != nil && state.peerLifecycleExits != nil {
 		// Pure atomic.Load behind the closure — repeated /metrics

--- a/clients/go/cmd/rubin-node/http_rpc_test.go
+++ b/clients/go/cmd/rubin-node/http_rpc_test.go
@@ -1289,6 +1289,12 @@ func TestRenderPrometheusMetricsIncludesV1Names(t *testing.T) {
 		"rubin_node_block_apply_total",
 		"rubin_node_peer_count",
 		"rubin_node_mempool_txs",
+		"rubin_node_mempool_bytes",
+		"rubin_node_mempool_admit_total",
+		"rubin_node_mempool_max_bytes",
+		"rubin_node_mempool_low_water_bytes",
+		"rubin_node_mempool_min_fee_rate",
+		"rubin_node_mempool_evicted_resident_total",
 		"rubin_node_rpc_requests_total",
 		"rubin_node_submit_tx_total",
 	} {
@@ -1329,11 +1335,73 @@ func TestRenderPrometheusMetricsHandlesNilStateAndNilMetrics(t *testing.T) {
 		`rubin_node_mempool_admit_total{result="conflict"} 0`,
 		`rubin_node_mempool_admit_total{result="rejected"} 0`,
 		`rubin_node_mempool_admit_total{result="unavailable"} 0`,
+		"rubin_node_mempool_max_bytes 0",
+		"rubin_node_mempool_low_water_bytes 0",
+		"rubin_node_mempool_min_fee_rate 0",
+		"rubin_node_mempool_evicted_resident_total 0",
 		"rubin_node_p2p_peer_lifecycle_exits_total 0",
 	} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("missing %q in metrics body %q", want, body)
 		}
+	}
+}
+
+// TestRenderPrometheusMetricsScrapePurity asserts that two consecutive
+// scrapes of the same wired state return byte-identical output. This
+// pins the Linear "Scraping /metrics is read-only: two consecutive
+// scrapes do not increment counters" invariant for the standard
+// mempool gauges and the resident-eviction counter.
+func TestRenderPrometheusMetricsScrapePurity(t *testing.T) {
+	state := mustRPCState(t, true)
+	state.metrics.note("/get_tip", http.StatusOK)
+	state.metrics.noteSubmit("accepted")
+	first := renderPrometheusMetrics(state)
+	second := renderPrometheusMetrics(state)
+	if first != second {
+		t.Fatalf("scrape not pure: first vs second differ\n--- first ---\n%s\n--- second ---\n%s", first, second)
+	}
+	for _, want := range []string{
+		"rubin_node_mempool_max_bytes",
+		"rubin_node_mempool_low_water_bytes",
+		"rubin_node_mempool_min_fee_rate",
+		"rubin_node_mempool_evicted_resident_total",
+	} {
+		if !strings.Contains(first, want) {
+			t.Fatalf("scrape-purity body missing standard-mempool metric %q in %q", want, first)
+		}
+	}
+}
+
+// TestRenderPrometheusMetricsStandardMempoolGaugesReflectLiveState
+// asserts that max_bytes, low_water_bytes, and min_fee_rate render
+// from the wired mempool's current struct fields, not from
+// MempoolConfig defaults.
+func TestRenderPrometheusMetricsStandardMempoolGaugesReflectLiveState(t *testing.T) {
+	state := mustRPCState(t, true)
+	got := state.mempool.Stats()
+	body := renderPrometheusMetrics(state)
+	for _, want := range []string{
+		fmt.Sprintf("rubin_node_mempool_max_bytes %d", got.MaxBytes),
+		fmt.Sprintf("rubin_node_mempool_low_water_bytes %d", got.LowWaterBytes),
+		fmt.Sprintf("rubin_node_mempool_min_fee_rate %d", got.MinFeeRate),
+		fmt.Sprintf("rubin_node_mempool_evicted_resident_total %d", got.EvictedResidentTotal),
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("missing %q in metrics body %q", want, body)
+		}
+	}
+	if got.MaxBytes <= 0 {
+		t.Fatalf("MaxBytes=%d, want positive default for wired devnet state", got.MaxBytes)
+	}
+	if got.LowWaterBytes <= 0 || got.LowWaterBytes >= got.MaxBytes {
+		t.Fatalf("LowWaterBytes=%d, want 0<x<MaxBytes(%d)", got.LowWaterBytes, got.MaxBytes)
+	}
+	if got.MinFeeRate < node.DefaultMempoolMinFeeRate {
+		t.Fatalf("MinFeeRate=%d, want >= DefaultMempoolMinFeeRate %d", got.MinFeeRate, node.DefaultMempoolMinFeeRate)
+	}
+	if got.EvictedResidentTotal != 0 {
+		t.Fatalf("EvictedResidentTotal=%d on a freshly-wired state, want 0", got.EvictedResidentTotal)
 	}
 }
 

--- a/clients/go/cmd/rubin-node/http_rpc_test.go
+++ b/clients/go/cmd/rubin-node/http_rpc_test.go
@@ -1405,6 +1405,35 @@ func TestRenderPrometheusMetricsStandardMempoolGaugesReflectLiveState(t *testing
 	}
 }
 
+// TestRenderPrometheusMetricsNilMempoolFieldRendersBaselineFloor
+// covers the second nil branch flagged by reviewer P2: state is
+// non-nil but state.mempool is nil. The renderer's default
+// mempoolStats seeded with MinFeeRate=DefaultMempoolMinFeeRate must
+// also reach this path so the baseline floor is reported here, not
+// 0. Without this assertion a regression that re-zeros the
+// initializer for the state.mempool==nil branch could pass through.
+func TestRenderPrometheusMetricsNilMempoolFieldRendersBaselineFloor(t *testing.T) {
+	state := mustRPCState(t, true)
+	state.mempool = nil
+	body := renderPrometheusMetrics(state)
+	for _, want := range []string{
+		"rubin_node_mempool_txs 0",
+		"rubin_node_mempool_bytes 0",
+		`rubin_node_mempool_admit_total{result="accepted"} 0`,
+		`rubin_node_mempool_admit_total{result="conflict"} 0`,
+		`rubin_node_mempool_admit_total{result="rejected"} 0`,
+		`rubin_node_mempool_admit_total{result="unavailable"} 0`,
+		"rubin_node_mempool_max_bytes 0",
+		"rubin_node_mempool_low_water_bytes 0",
+		fmt.Sprintf("rubin_node_mempool_min_fee_rate %d", node.DefaultMempoolMinFeeRate),
+		"rubin_node_mempool_evicted_resident_total 0",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("missing %q in metrics body %q", want, body)
+		}
+	}
+}
+
 func TestRenderPrometheusMetricsExposesBlockApplyCountersReadOnly(t *testing.T) {
 	state := mustRPCState(t, true)
 	initial := state.syncEngine.BlockApplyCounts()

--- a/clients/go/cmd/rubin-node/http_rpc_test.go
+++ b/clients/go/cmd/rubin-node/http_rpc_test.go
@@ -1337,7 +1337,7 @@ func TestRenderPrometheusMetricsHandlesNilStateAndNilMetrics(t *testing.T) {
 		`rubin_node_mempool_admit_total{result="unavailable"} 0`,
 		"rubin_node_mempool_max_bytes 0",
 		"rubin_node_mempool_low_water_bytes 0",
-		"rubin_node_mempool_min_fee_rate 0",
+		fmt.Sprintf("rubin_node_mempool_min_fee_rate %d", node.DefaultMempoolMinFeeRate),
 		"rubin_node_mempool_evicted_resident_total 0",
 		"rubin_node_p2p_peer_lifecycle_exits_total 0",
 	} {

--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -98,9 +98,14 @@ type Mempool struct {
 // state. Field order matches the /metrics rendering order in
 // renderPrometheusMetrics so the textual output is stable across
 // readings. Reading a snapshot does not mutate any mempool state.
-// A nil receiver returns the zero value, so callers do not need to
-// special-case uninitialized mempool wiring (mirrors the
-// AdmissionCounts nil-receiver convention).
+//
+// Nil-receiver contract (matches CurrentMinFeeRateSnapshot
+// convention): a nil *Mempool returns counters and sizes set to
+// zero (TxCount, BytesUsed, MaxBytes, LowWaterBytes,
+// EvictedResidentTotal) but MinFeeRate set to
+// DefaultMempoolMinFeeRate. Callers do not need to special-case
+// uninitialized mempool wiring; /metrics on an un-wired state
+// renders the documented baseline floor instead of 0.
 type MempoolStats struct {
 	TxCount              int
 	BytesUsed            int

--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -286,13 +286,14 @@ func (m *Mempool) AdmissionCounts() MempoolAdmissionCounts {
 // min_fee_rate reflect the rolling state including the post-eviction
 // adjustments performed by raiseMinFeeRateAfterEvictionLocked and
 // decayMinFeeRateAfterConnectedBlockLocked. EvictedResidentTotal is
-// loaded INSIDE the read-lock window (writers bump the counter under
-// m.mu.Lock in addEntryLocked's deleteEntryLocked loop, so taking
-// the read lock first means a concurrent admit-and-evict either
-// completed before this Load — counter and gauges both reflect the
-// post-eviction state — or is blocked behind the writer's Lock.
-// Loading before RLock would let the reader observe a pre-eviction
-// counter together with post-eviction gauges).
+// loaded INSIDE the read-lock window. Writers bump that counter
+// under m.mu.Lock inside addEntryLocked's deleteEntryLocked loop,
+// so the reader's m.mu.RLock pairs with the writer's m.mu.Lock and
+// the atomic.Load observes the same critical section as the gauge
+// fields read on the surrounding lines. Covered by
+// TestMempoolStatsScrapePurity and the
+// TestMempoolStatsResidentEvictionIncrementsExactlyOnce assertion
+// chain in clients/go/node/mempool_test.go.
 //
 // Nil-safety follows the existing exported-accessor convention used
 // by CurrentMinFeeRateSnapshot, BytesUsed, AdmissionCounts: a nil

--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -80,7 +80,7 @@ type Mempool struct {
 	// evictedResidentTotal counts cumulative resident-entry capacity
 	// evictions since process start. It is bumped exactly once per
 	// already-admitted entry that is removed by capacity pressure
-	// (the deleteEntryLocked loop in addParsedTransactionLocked after
+	// (the deleteEntryLocked loop in addEntryLocked after
 	// validateCapacityAdmissionLocked classifies the candidate as
 	// admitted-and-evicting). Candidate-worst rejection — where the
 	// incoming candidate is rejected at capacity and no resident is

--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -286,16 +286,28 @@ func (m *Mempool) AdmissionCounts() MempoolAdmissionCounts {
 // min_fee_rate reflect the rolling state including the post-eviction
 // adjustments performed by raiseMinFeeRateAfterEvictionLocked and
 // decayMinFeeRateAfterConnectedBlockLocked. EvictedResidentTotal is
-// loaded outside the lock from the atomic counter; the other fields
-// are read under m.mu.RLock to keep them mutually consistent. A nil
-// receiver returns a zero MempoolStats so /metrics scraping a node
-// without a wired mempool emits zero-valued lines instead of
-// panicking.
+// loaded INSIDE the read-lock window (writers bump the counter under
+// m.mu.Lock in addEntryLocked's deleteEntryLocked loop, so taking
+// the read lock first means a concurrent admit-and-evict either
+// completed before this Load — counter and gauges both reflect the
+// post-eviction state — or is blocked behind the writer's Lock.
+// Loading before RLock would let the reader observe a pre-eviction
+// counter together with post-eviction gauges).
+//
+// Nil-safety follows the existing exported-accessor convention used
+// by CurrentMinFeeRateSnapshot, BytesUsed, AdmissionCounts: a nil
+// receiver returns counters/sizes 0, but MinFeeRate defaults to
+// DefaultMempoolMinFeeRate. This keeps /metrics rendering on an
+// uninitialized state agreeing with the rest of the Mempool API
+// instead of advertising rubin_node_mempool_min_fee_rate = 0, which
+// would disagree with CurrentMinFeeRateSnapshot's nil return and
+// the documented baseline floor.
 func (m *Mempool) Stats() MempoolStats {
 	if m == nil {
-		return MempoolStats{}
+		return MempoolStats{
+			MinFeeRate: DefaultMempoolMinFeeRate,
+		}
 	}
-	evicted := m.evictedResidentTotal.Load()
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	return MempoolStats{
@@ -304,7 +316,7 @@ func (m *Mempool) Stats() MempoolStats {
 		MaxBytes:             m.maxBytes,
 		LowWaterBytes:        m.effectiveLowWaterBytesLocked(),
 		MinFeeRate:           m.currentMinFeeRateLocked(),
-		EvictedResidentTotal: evicted,
+		EvictedResidentTotal: m.evictedResidentTotal.Load(),
 	}
 }
 

--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -76,6 +76,38 @@ type Mempool struct {
 	admitConflict    atomic.Uint64
 	admitRejected    atomic.Uint64
 	admitUnavailable atomic.Uint64
+
+	// evictedResidentTotal counts cumulative resident-entry capacity
+	// evictions since process start. It is bumped exactly once per
+	// already-admitted entry that is removed by capacity pressure
+	// (the deleteEntryLocked loop in addParsedTransactionLocked after
+	// validateCapacityAdmissionLocked classifies the candidate as
+	// admitted-and-evicting). Candidate-worst rejection — where the
+	// incoming candidate is rejected at capacity and no resident is
+	// evicted — does not increment this counter; that path returns
+	// txAdmitUnavailable before the deleteEntryLocked loop. Fee-floor
+	// rejection of an incoming transaction never reaches this counter
+	// either, because the fee-floor check happens before
+	// validateCapacityAdmissionLocked. Confirmed-block removals via
+	// EvictConfirmed/applyConnectedBlock are conflict resolution, not
+	// policy capacity eviction, and also do not increment this counter.
+	evictedResidentTotal atomic.Uint64
+}
+
+// MempoolStats is the snapshot view of standard mempool telemetry
+// state. Field order matches the /metrics rendering order in
+// renderPrometheusMetrics so the textual output is stable across
+// readings. Reading a snapshot does not mutate any mempool state.
+// A nil receiver returns the zero value, so callers do not need to
+// special-case uninitialized mempool wiring (mirrors the
+// AdmissionCounts nil-receiver convention).
+type MempoolStats struct {
+	TxCount              int
+	BytesUsed            int
+	MaxBytes             int
+	LowWaterBytes        int
+	MinFeeRate           uint64
+	EvictedResidentTotal uint64
 }
 
 // MempoolAdmissionCounts is the snapshot view of admission outcomes.
@@ -244,6 +276,35 @@ func (m *Mempool) AdmissionCounts() MempoolAdmissionCounts {
 		Conflict:    m.admitConflict.Load(),
 		Rejected:    m.admitRejected.Load(),
 		Unavailable: m.admitUnavailable.Load(),
+	}
+}
+
+// Stats returns a current snapshot of standard mempool telemetry
+// state for the /metrics renderer. The snapshot reads live struct
+// fields under the read lock — values are NOT cached duplicates of
+// MempoolConfig defaults — so max_bytes, low_water_bytes, and
+// min_fee_rate reflect the rolling state including the post-eviction
+// adjustments performed by raiseMinFeeRateAfterEvictionLocked and
+// decayMinFeeRateAfterConnectedBlockLocked. EvictedResidentTotal is
+// loaded outside the lock from the atomic counter; the other fields
+// are read under m.mu.RLock to keep them mutually consistent. A nil
+// receiver returns a zero MempoolStats so /metrics scraping a node
+// without a wired mempool emits zero-valued lines instead of
+// panicking.
+func (m *Mempool) Stats() MempoolStats {
+	if m == nil {
+		return MempoolStats{}
+	}
+	evicted := m.evictedResidentTotal.Load()
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return MempoolStats{
+		TxCount:              len(m.txs),
+		BytesUsed:            m.usedBytes,
+		MaxBytes:             m.maxBytes,
+		LowWaterBytes:        m.effectiveLowWaterBytesLocked(),
+		MinFeeRate:           m.currentMinFeeRateLocked(),
+		EvictedResidentTotal: evicted,
 	}
 }
 
@@ -924,6 +985,13 @@ func (m *Mempool) addEntryLocked(entry *mempoolEntry) error {
 	m.ensureIndexesLocked()
 	for _, evicted := range evictedEntries {
 		m.deleteEntryLocked(evicted.txid, evicted)
+		// Bump the resident-eviction counter exactly once per
+		// already-admitted entry that capacity pressure removes here.
+		// Candidate-worst rejection returned txAdmitUnavailable above
+		// without populating evictedEntries, so that path skips this
+		// loop entirely. Fee-floor rejection returned earlier from
+		// validateFeeFloorLocked and likewise never reaches here.
+		m.evictedResidentTotal.Add(1)
 	}
 	m.assignAdmissionSeqLocked(entry)
 	m.insertEntryIndexesLocked(entry)

--- a/clients/go/node/mempool_test.go
+++ b/clients/go/node/mempool_test.go
@@ -4025,6 +4025,72 @@ func TestMempoolStatsResidentEvictionIncrementsExactlyOnce(t *testing.T) {
 	}
 }
 
+// TestMempoolStatsResidentEvictionIncrementsByNOnMultiTrim asserts
+// the "+1 per evicted resident" contract under byte-pressure where
+// one admission removes more than one resident. Capacity-trimming
+// to low_water_bytes can evict multiple residents in a single
+// addEntryLocked call; the counter must track the actual number of
+// removed residents, not just "did at least one eviction happen".
+// Reviewer P2 finding on PR #1405: the prior single-eviction test
+// left this path uncovered.
+func TestMempoolStatsResidentEvictionIncrementsByNOnMultiTrim(t *testing.T) {
+	// Force byte-pressure trim with multiple evictions.
+	// maxBytes=20 → defaultMempoolLowWaterBytes(20) = (20/10)*9 = 18.
+	// maxTxs=10 keeps the count limit non-binding so every eviction
+	// here is byte-pressure-driven, not count-pressure-driven.
+	// 4 residents of size=5 each fill the pool to 20 bytes.
+	// A candidate of size=10 (fee=1000, evicts the worst residents
+	// per the eviction-ordering comparator) admits with target =
+	// mempoolBytePressureTarget(18, 10) = 18; capacity-trimming
+	// must drop residents until usedBytes+candidateSize <= 18,
+	// which after evicting 3 residents (15 bytes residents + 10
+	// candidate = 25 still over... actually after 3 evictions one
+	// resident remains: 5 bytes + 10 candidate = 15 <= 18 ✓).
+	mp := &Mempool{maxTxs: 10, maxBytes: 20}
+	residents := []*mempoolEntry{
+		{txid: [32]byte{0x01}, fee: 1, weight: 1, size: 5},
+		{txid: [32]byte{0x02}, fee: 2, weight: 1, size: 5},
+		{txid: [32]byte{0x03}, fee: 3, weight: 1, size: 5},
+		{txid: [32]byte{0x04}, fee: 4, weight: 1, size: 5},
+	}
+	for _, r := range residents {
+		if err := mp.addEntryLocked(r); err != nil {
+			t.Fatalf("addEntryLocked(resident=%x): %v", r.txid[0], err)
+		}
+	}
+	if got := mp.Stats().EvictedResidentTotal; got != 0 {
+		t.Fatalf("EvictedResidentTotal after seeding=%d, want 0", got)
+	}
+	candidate := &mempoolEntry{
+		txid:   [32]byte{0x10},
+		fee:    1000,
+		weight: 1,
+		size:   10,
+	}
+	if err := mp.addEntryLocked(candidate); err != nil {
+		t.Fatalf("addEntryLocked(displacing candidate): %v", err)
+	}
+	// Counter must reflect every evicted resident, not just one.
+	// After admission: TxCount = (4 - N_evicted) + 1; the test
+	// asserts the symmetric counter increment instead of hardcoding
+	// N because the exact eviction count depends on the eviction
+	// comparator's tie-breaking, but it must equal "len(residents) -
+	// (TxCount - 1)" by construction.
+	stats := mp.Stats()
+	wantEvicted := uint64(len(residents)) - uint64(stats.TxCount-1)
+	if stats.EvictedResidentTotal != wantEvicted {
+		t.Fatalf("EvictedResidentTotal=%d, want %d (one bump per evicted resident; TxCount=%d, started with %d residents)",
+			stats.EvictedResidentTotal, wantEvicted, stats.TxCount, len(residents))
+	}
+	// Sanity: at least 2 residents must have been evicted to make
+	// this a real multi-trim case, distinct from the single-evict
+	// test above.
+	if stats.EvictedResidentTotal < 2 {
+		t.Fatalf("EvictedResidentTotal=%d, want >=2 to exercise multi-resident trim",
+			stats.EvictedResidentTotal)
+	}
+}
+
 // TestMempoolStatsCandidateWorstRejectionDoesNotCount asserts that
 // rejecting an incoming candidate at capacity (because it is the
 // worst entry per eviction ordering) MUST NOT increment the

--- a/clients/go/node/mempool_test.go
+++ b/clients/go/node/mempool_test.go
@@ -3926,3 +3926,158 @@ func TestMempoolAdmissionCountsNilReceiver(t *testing.T) {
 		t.Fatalf("AdmissionCounts nil receiver=%+v, want zero struct", got)
 	}
 }
+
+// TestMempoolStatsNilReceiver pins the nil-safety contract used by
+// /metrics rendering: a nil mempool returns the zero-value
+// MempoolStats struct without panicking, so the standard-mempool
+// gauges below render as 0 on a node fixture without a wired
+// mempool.
+func TestMempoolStatsNilReceiver(t *testing.T) {
+	var mp *Mempool
+	if got := mp.Stats(); got != (MempoolStats{}) {
+		t.Fatalf("Stats nil receiver=%+v, want zero struct", got)
+	}
+}
+
+// TestMempoolStatsReadsLiveStateNotConfigDefaults asserts that
+// MaxBytes / LowWaterBytes / MinFeeRate are read from the mempool's
+// current struct fields, not from MempoolConfig defaults. This is the
+// Linear "max_bytes, low_water_bytes, and min_fee_rate are reported
+// from current mempool state, not hardcoded duplicates" invariant.
+func TestMempoolStatsReadsLiveStateNotConfigDefaults(t *testing.T) {
+	mp := &Mempool{
+		maxTxs:            5,
+		maxBytes:          12345,
+		lowWaterBytes:     6789,
+		currentMinFeeRate: 42,
+	}
+	got := mp.Stats()
+	if got.MaxBytes != 12345 {
+		t.Fatalf("MaxBytes=%d, want 12345", got.MaxBytes)
+	}
+	if got.LowWaterBytes != 6789 {
+		t.Fatalf("LowWaterBytes=%d, want 6789", got.LowWaterBytes)
+	}
+	if got.MinFeeRate != 42 {
+		t.Fatalf("MinFeeRate=%d, want 42", got.MinFeeRate)
+	}
+	if got.TxCount != 0 {
+		t.Fatalf("TxCount=%d, want 0", got.TxCount)
+	}
+	if got.BytesUsed != 0 {
+		t.Fatalf("BytesUsed=%d, want 0", got.BytesUsed)
+	}
+	if got.EvictedResidentTotal != 0 {
+		t.Fatalf("EvictedResidentTotal=%d, want 0", got.EvictedResidentTotal)
+	}
+}
+
+// TestMempoolStatsScrapePurity asserts that two consecutive Stats()
+// calls observe the same EvictedResidentTotal: reading the snapshot
+// must not mutate any underlying counter or gauge. This protects the
+// /metrics endpoint contract that scraping is a pure observation.
+func TestMempoolStatsScrapePurity(t *testing.T) {
+	mp := &Mempool{maxTxs: 5, maxBytes: 12345}
+	mp.evictedResidentTotal.Store(7)
+	first := mp.Stats()
+	second := mp.Stats()
+	if first != second {
+		t.Fatalf("Stats() not pure: first=%+v second=%+v", first, second)
+	}
+	if first.EvictedResidentTotal != 7 {
+		t.Fatalf("EvictedResidentTotal=%d, want 7", first.EvictedResidentTotal)
+	}
+}
+
+// TestMempoolStatsResidentEvictionIncrementsExactlyOnce force-runs
+// the eviction code path: a 1-slot mempool with one resident, then
+// addEntryLocked with a higher-fee candidate that displaces the
+// resident. EvictedResidentTotal must increase by exactly one.
+// Mirrors the Linear invariant "A resident-entry capacity eviction
+// increments the eviction counter exactly once."
+func TestMempoolStatsResidentEvictionIncrementsExactlyOnce(t *testing.T) {
+	mp := &Mempool{maxTxs: 1, maxBytes: 100}
+	resident := &mempoolEntry{
+		txid:   [32]byte{0x01},
+		fee:    10,
+		weight: 1,
+		size:   1,
+	}
+	if err := mp.addEntryLocked(resident); err != nil {
+		t.Fatalf("addEntryLocked(resident): %v", err)
+	}
+	if got := mp.Stats().EvictedResidentTotal; got != 0 {
+		t.Fatalf("EvictedResidentTotal after first admit=%d, want 0", got)
+	}
+	candidate := &mempoolEntry{
+		txid:   [32]byte{0x02},
+		fee:    100,
+		weight: 1,
+		size:   1,
+	}
+	if err := mp.addEntryLocked(candidate); err != nil {
+		t.Fatalf("addEntryLocked(displacing candidate): %v", err)
+	}
+	if got := mp.Stats().EvictedResidentTotal; got != 1 {
+		t.Fatalf("EvictedResidentTotal after eviction=%d, want 1", got)
+	}
+}
+
+// TestMempoolStatsCandidateWorstRejectionDoesNotCount asserts that
+// rejecting an incoming candidate at capacity (because it is the
+// worst entry per eviction ordering) MUST NOT increment the
+// resident-eviction counter. No resident is removed in that path.
+// Mirrors Linear "Candidate rejection at capacity ... is not counted
+// as a resident eviction."
+func TestMempoolStatsCandidateWorstRejectionDoesNotCount(t *testing.T) {
+	mp := &Mempool{maxTxs: 1, maxBytes: 100}
+	resident := &mempoolEntry{
+		txid:   [32]byte{0x10},
+		fee:    100,
+		weight: 1,
+		size:   1,
+	}
+	if err := mp.addEntryLocked(resident); err != nil {
+		t.Fatalf("addEntryLocked(resident): %v", err)
+	}
+	worstCandidate := &mempoolEntry{
+		txid:   [32]byte{0x11},
+		fee:    1,
+		weight: 1,
+		size:   1,
+	}
+	err := mp.addEntryLocked(worstCandidate)
+	if err == nil || !strings.Contains(err.Error(), "mempool capacity candidate rejected by eviction ordering") {
+		t.Fatalf("expected candidate-worst rejection, got %v", err)
+	}
+	if got := mp.Stats().EvictedResidentTotal; got != 0 {
+		t.Fatalf("EvictedResidentTotal after candidate-worst rejection=%d, want 0", got)
+	}
+}
+
+// TestMempoolStatsFeeFloorRejectionDoesNotCount asserts that
+// rejecting an incoming candidate below the rolling minimum fee rate
+// MUST NOT increment the resident-eviction counter. Fee-floor
+// rejection happens in validateFeeFloorLocked before the eviction
+// plan is consulted, so no resident is touched. Mirrors Linear
+// "fee-floor rejection is not counted as a resident eviction."
+func TestMempoolStatsFeeFloorRejectionDoesNotCount(t *testing.T) {
+	mp := &Mempool{
+		maxTxs:            10,
+		maxBytes:          1000,
+		currentMinFeeRate: 1000,
+	}
+	tooCheap := &mempoolEntry{
+		txid:   [32]byte{0x21},
+		fee:    1,
+		weight: 1,
+		size:   1,
+	}
+	err := mp.addEntryLocked(tooCheap)
+	if err == nil || !strings.Contains(err.Error(), "mempool fee below rolling minimum") {
+		t.Fatalf("expected fee-floor rejection, got %v", err)
+	}
+	if got := mp.Stats().EvictedResidentTotal; got != 0 {
+		t.Fatalf("EvictedResidentTotal after fee-floor rejection=%d, want 0", got)
+	}
+}

--- a/clients/go/node/mempool_test.go
+++ b/clients/go/node/mempool_test.go
@@ -3928,14 +3928,16 @@ func TestMempoolAdmissionCountsNilReceiver(t *testing.T) {
 }
 
 // TestMempoolStatsNilReceiver pins the nil-safety contract used by
-// /metrics rendering: a nil mempool returns the zero-value
-// MempoolStats struct without panicking, so the standard-mempool
-// gauges below render as 0 on a node fixture without a wired
-// mempool.
+// /metrics rendering: a nil mempool returns counters/sizes 0 and
+// MinFeeRate=DefaultMempoolMinFeeRate, mirroring the existing
+// CurrentMinFeeRateSnapshot nil-safe convention so /metrics on an
+// uninitialized state advertises the baseline floor instead of 0.
+// Without panicking either way.
 func TestMempoolStatsNilReceiver(t *testing.T) {
 	var mp *Mempool
-	if got := mp.Stats(); got != (MempoolStats{}) {
-		t.Fatalf("Stats nil receiver=%+v, want zero struct", got)
+	want := MempoolStats{MinFeeRate: DefaultMempoolMinFeeRate}
+	if got := mp.Stats(); got != want {
+		t.Fatalf("Stats nil receiver=%+v, want %+v", got, want)
 	}
 }
 


### PR DESCRIPTION
## Scope

Expose Go standard mempool policy telemetry: add four new metric
lines to `/metrics` backed by a new public `MempoolStats` snapshot
accessor on `*node.Mempool`. Resident-entry capacity evictions get a
new `atomic.Uint64` counter that is bumped exactly once per evicted
resident and never on candidate-worst rejection or fee-floor
rejection.

Conceptual inventory → final metric names (per Linear RUB-52
"PR body lists the final metric names and explains any mapping from
the conceptual inventory above to existing rubin_node_* names"):

| Linear concept | Existing line (kept) | New line (this PR) |
|---|---|---|
| current standard mempool tx count | `rubin_node_mempool_txs` (gauge) | — |
| current standard mempool used bytes | `rubin_node_mempool_bytes` (gauge) | — |
| standard mempool max bytes | — | `rubin_node_mempool_max_bytes` (gauge) |
| standard mempool low-water bytes | — | `rubin_node_mempool_low_water_bytes` (gauge) |
| current rolling minimum fee rate | — | `rubin_node_mempool_min_fee_rate` (gauge) |
| cumulative resident-entry capacity evictions | — | `rubin_node_mempool_evicted_resident_total` (counter) |
| bounded admission/result counters | `rubin_node_mempool_admit_total{result}` (counter) + `rubin_node_submit_tx_total{result}` (counter) | — |

Files changed (4):

- `clients/go/node/mempool.go`: `MempoolStats` snapshot type +
  `(*Mempool).Stats()` accessor + `evictedResidentTotal atomic.Uint64`
  field. Bump `+1` per resident evicted inside the existing
  `addEntryLocked` `deleteEntryLocked` loop. Stats() loads the
  atomic counter INSIDE the read-lock window so writers' Lock pairs
  with reader's RLock (no race between Load and gauge fields).
  Nil receiver returns `MempoolStats{MinFeeRate: DefaultMempoolMinFeeRate}`
  matching the existing `CurrentMinFeeRateSnapshot` nil convention;
  type doc describes that contract verbatim.
- `clients/go/cmd/rubin-node/http_rpc.go`: wire `state.mempool.Stats()`
  into `renderPrometheusMetrics` as a single snapshot for
  tx_count / bytes / new gauges / counter (the prior separate
  `Len()` / `BytesUsed()` calls were dropped to avoid split-instant
  publication). `mempoolStats` is seeded to
  `MempoolStats{MinFeeRate: DefaultMempoolMinFeeRate}` so a
  state==nil scrape and a state.mempool==nil scrape both render the
  same baseline floor. Emit four new lines with the existing
  `rubin_node_*` prefix and a closed unlabeled shape.
- `clients/go/node/mempool_test.go`: seven focused tests pin
  nil-receiver baseline floor, live-state-not-config-defaults,
  scrape purity, resident-eviction `+1`, multi-trim resident-eviction
  `+N`, candidate-worst rejection no-count, fee-floor rejection no-count.
- `clients/go/cmd/rubin-node/http_rpc_test.go`: extend
  `TestRenderPrometheusMetricsIncludesV1Names` and
  `TestRenderPrometheusMetricsHandlesNilStateAndNilMetrics` with
  the four new metric names plus zero-rendered lines (with
  `min_fee_rate=DefaultMempoolMinFeeRate`), and add
  `TestRenderPrometheusMetricsScrapePurity` (byte-identical body
  across two consecutive scrapes),
  `TestRenderPrometheusMetricsStandardMempoolGaugesReflectLiveState`
  (rendered values match `state.mempool.Stats()` field-by-field), and
  `TestRenderPrometheusMetricsNilMempoolFieldRendersBaselineFloor`
  (state!=nil && state.mempool==nil renders the same baseline floor
  as state==nil).

Out of scope:

- No mempool admission, eviction, rolling-floor, reorg, relay, block
  validation, or consensus behavior change.
- No claim of Go/Rust mempool policy parity (Linear RUB-52 is
  go-only; rust-freeze active).
- No DA-pool fee-floor coverage claim or DA-pool telemetry mixed
  into standard-mempool metric names.
- No new control-plane API beyond the existing `/metrics` surface.
- No new config knobs, no histogram/percentile redesign, no
  metrics-backend redesign, no CI workflow change, no fixture
  regeneration, no Rust changes. Tracked as RUB-52.

## Evidence

- branch HEAD `089d7b9`. Wave history vs origin/main: `a2119f9`
  (initial telemetry slice) → `70b1481` (Stats race + nil-floor +
  single-snapshot, addressing Copilot wave-1 P1+P1+P2 review) →
  `9d14ecf` (Stats lock-ordering comment rewrite) → `6fa7bc5`
  (Copilot wave-2 P2: MempoolStats type doc verbatim, multi-trim
  test, state.mempool==nil scrape test) → `089d7b9` (wave-3 doc
  cleanup: stale function-name reference fixed in
  `evictedResidentTotal` doc — `addParsedTransactionLocked` →
  `addEntryLocked`).
- `cd clients/go && gofmt -l node cmd/rubin-node` clean
- `cd clients/go && go vet ./node ./cmd/rubin-node` clean
- focused: `go test ./node -run 'TestMempoolStats' -count=1 -v` →
  7/7 PASS
- focused: `go test ./cmd/rubin-node -run 'TestRenderPrometheusMetrics' -count=1 -v`
  → 12/12 PASS
- package: `go test ./node -count=1` PASS
- package: `go test ./cmd/rubin-node -count=1` PASS
- `tooling-check.sh --new-only --mode go-deep` PASS
- `rubin-common-preflight` 6/6 PASS on `a2119f9` and `6fa7bc5`
  (full coverage stage); the comment-only deltas in `9d14ecf` and
  `089d7b9` were pushed under
  `RUBIN_MACHINE_PREFLIGHT_BYPASS=CONTROLLER_APPROVED_SMALL_FIXPASS`
  with reason / ref / head bound to the exact commit
- hostile-review post-diff RESP PASS chain on `a2119f9`, `70b1481`,
  `6fa7bc5`, `089d7b9`
- bot-reviewer (Copilot) wave-1 P1+P1+P2 addressed in `70b1481` and
  wave-2 P2 (3 threads) addressed in `6fa7bc5`+`089d7b9` —
  six threads total, all resolved with per-thread inline replies
  citing commit SHA + file:line + verification:
  [discussion_r3176418910](https://github.com/2tbmz9y2xt-lang/rubin-protocol/pull/1405#discussion_r3176418910),
  [discussion_r3176419069](https://github.com/2tbmz9y2xt-lang/rubin-protocol/pull/1405#discussion_r3176419069),
  [discussion_r3176419231](https://github.com/2tbmz9y2xt-lang/rubin-protocol/pull/1405#discussion_r3176419231),
  [discussion_r3176467291](https://github.com/2tbmz9y2xt-lang/rubin-protocol/pull/1405#discussion_r3176467291),
  [discussion_r3176471704](https://github.com/2tbmz9y2xt-lang/rubin-protocol/pull/1405#discussion_r3176471704),
  [discussion_r3176471803](https://github.com/2tbmz9y2xt-lang/rubin-protocol/pull/1405#discussion_r3176471803)
- pre-push LOCAL SECURITY REVIEW PASS
