### PR TITLE
node/txpool: RUB-162 Phase A — internal txpool parity (failure-atomicity, cleanup symmetry, DA error class ordering)

### DIFF
--- a/clients/rust/crates/rubin-node/benches/bench_support.rs
+++ b/clients/rust/crates/rubin-node/benches/bench_support.rs
@@ -286,7 +286,7 @@ pub fn fresh_txpool_fixture() -> (ChainState, Vec<u8>) {
     //     rolling fee floor.
     //   - new invariant: admit_with_metadata enforces the rolling fee
     //     floor (DEFAULT_MEMPOOL_MIN_FEE_RATE=1) via
-    //     validate_fee_floor_locked.
+    //     validate_fee_floor.
     //   - reachability: tx is well-formed; floor check is reached after
     //     apply_policy. Both the integration test (admit) and
     //     benchmarks (admit + relay metadata) traverse this path.

--- a/clients/rust/crates/rubin-node/benches/bench_support.rs
+++ b/clients/rust/crates/rubin-node/benches/bench_support.rs
@@ -277,7 +277,33 @@ pub fn engine_after_genesis(prefix: &str) -> SyncFixture {
 }
 
 pub fn fresh_txpool_fixture() -> (ChainState, Vec<u8>) {
-    let (state, outpoints, signer, from_address) = chain_state_with_spendable_utxos(1);
+    // RUB-162 Phase A migration rationale (per controller Path A
+    // approval 2026-05-03; fixture also exercised by
+    // tests/runtime_perf_guardrails.rs which goes through public
+    // TxPool::admit):
+    //   - old assumption: amount=90/fee=1 with weight ≈ 7829 admits
+    //     because pre-RUB-162 admit_with_metadata did not enforce the
+    //     rolling fee floor.
+    //   - new invariant: admit_with_metadata enforces the rolling fee
+    //     floor (DEFAULT_MEMPOOL_MIN_FEE_RATE=1) via
+    //     validate_fee_floor_locked.
+    //   - reachability: tx is well-formed; floor check is reached after
+    //     apply_policy. Both the integration test (admit) and
+    //     benchmarks (admit + relay metadata) traverse this path.
+    //   - replacement coverage: utxo bumped in-place to 20_000 (default
+    //     helper value 100 is preserved for other callers); fee bumped
+    //     to 8_000 so fee/weight ≈ 1.02 ≥ 1 (passes default floor with
+    //     headroom). Benchmark numbers measure the same operation; the
+    //     fee value is a fixture detail that doesn't materially affect
+    //     perf (admit's hot path is signature verification + index
+    //     insert, not the integer fee compare).
+    let (mut state, outpoints, signer, from_address) = chain_state_with_spendable_utxos(1);
+    // Bump only this fixture's UTXO so the helper's other callers
+    // (block_undo_fixture, runtime_baseline.rs::chain_state_clone) see
+    // the original value=100.
+    if let Some(entry) = state.utxos.get_mut(&outpoints[0]) {
+        entry.value = 20_000;
+    }
     let to_signer = Mldsa87Keypair::generate().expect("OpenSSL signer unavailable");
     let to_address = p2pk_covenant_data_for_pubkey(&to_signer.pubkey_bytes());
     let raw = signed_transfer_tx(
@@ -286,7 +312,7 @@ pub fn fresh_txpool_fixture() -> (ChainState, Vec<u8>) {
         &signer,
         SignedTransferSpec {
             amount: 90,
-            fee: 1,
+            fee: 8_000,
             nonce: 1,
             change_address: &from_address,
             to_address: &to_address,

--- a/clients/rust/crates/rubin-node/src/devnet_rpc.rs
+++ b/clients/rust/crates/rubin-node/src/devnet_rpc.rs
@@ -2211,7 +2211,7 @@ mod tests {
     /// chain_state for /submit_tx tests. Pre-RUB-162 tests used the
     /// conformance fixture (fee=10/weight=7653, fee_rate ≪ 1) which the
     /// post-RUB-162 admit_with_metadata correctly rejects with Unavailable
-    /// from validate_fee_floor_locked.
+    /// from validate_fee_floor.
     ///
     /// Returns (chain_state, raw_tx_bytes, chain_id). chain_id is the
     /// devnet genesis chain id — same as the production call site uses.

--- a/clients/rust/crates/rubin-node/src/devnet_rpc.rs
+++ b/clients/rust/crates/rubin-node/src/devnet_rpc.rs
@@ -2026,6 +2026,7 @@ mod tests {
     use serde_json::Value;
 
     use crate::io_utils::unique_temp_path;
+    use crate::test_helpers::signed_conflicting_p2pk_state_and_txs;
     use crate::{
         block_store_path, default_peer_runtime_config, default_sync_config,
         devnet_genesis_block_bytes, devnet_genesis_chain_id, BlockStore, ChainState, MinerConfig,
@@ -2203,6 +2204,25 @@ mod tests {
         state.height = vector.height.saturating_sub(1);
         state.utxos = fixture_utxos_to_map(&vector.utxos);
         state
+    }
+
+    /// RUB-162 Phase A test helper (per controller Q2 / Path A approval
+    /// 2026-05-03). Builds a fee-floor-compliant signed P2PK tx + matching
+    /// chain_state for /submit_tx tests. Pre-RUB-162 tests used the
+    /// conformance fixture (fee=10/weight=7653, fee_rate ≪ 1) which the
+    /// post-RUB-162 admit_with_metadata correctly rejects with Unavailable
+    /// from validate_fee_floor_locked.
+    ///
+    /// Returns (chain_state, raw_tx_bytes, chain_id). chain_id is the
+    /// devnet genesis chain id — same as the production call site uses.
+    /// input_value=7700 / output=10 → fee=7690 ≥ weight≈7653 ⇒ admits.
+    /// chain_state is bumped to has_tip=true / height=1 so admit_with_metadata
+    /// reaches the policy path (not the coinbase-context branch).
+    fn floor_compliant_signed_tx_and_state() -> (ChainState, Vec<u8>, [u8; 32]) {
+        let (mut state, raw, _other) = signed_conflicting_p2pk_state_and_txs(7700, 10, 9);
+        state.has_tip = true;
+        state.height = 1;
+        (state, raw, devnet_genesis_chain_id())
     }
 
     fn build_state_with_chain_state(
@@ -2785,18 +2805,36 @@ mod tests {
     }
 
     #[test]
-    fn submit_tx_accepts_valid_conformance_tx() {
+    fn submit_tx_accepts_floor_compliant_p2pk_tx() {
         let vector = positive_fixture_vector();
         assert!(vector.expect_ok, "{} should be positive fixture", vector.id);
-        let raw = hex::decode(&vector.tx_hex).expect("tx hex");
+        // RUB-162 Phase A migration rationale (per controller Q2 / Path A
+        // approval 2026-05-03):
+        //   - old assumption: positive_fixture_vector tx (fee=10/weight=
+        //     7653) admits via /submit_tx; pre-RUB-162 admit_with_metadata
+        //     did not enforce the rolling fee floor.
+        //   - new invariant: admit_with_metadata enforces the rolling fee
+        //     floor (DEFAULT=1) via validate_fee_floor_locked. The
+        //     conformance fixture is sub-floor and admits Unavailable.
+        //   - reachability: the test pins /submit_tx returning 200 +
+        //     duplicate detection + metrics increment — all of which require
+        //     a successful admit on the FIRST request. Reaches the txpool
+        //     admission path through DevnetRPC -> TxPool::admit.
+        //   - replacement coverage: floor_compliant_signed_tx_and_state()
+        //     builds a fee-floor-compliant signed tx (input=7700/output=10
+        //     ⇒ fee=7690 ≥ weight≈7653) using the in-tree
+        //     signed_conflicting_p2pk_state_and_txs helper. The test's
+        //     /submit_tx + duplicate + metrics invariants remain under
+        //     test. The conformance fixture's parsing/signature paths are
+        //     covered by relay_metadata +
+        //     admit_rejects_sub_floor_conformance_tx_as_unavailable_with_atomicity
+        //     (which asserts Unavailable in txpool.rs).
+        let (chain_state, raw, chain_id) = floor_compliant_signed_tx_and_state();
         let (_tx, txid, _wtxid, consumed) = parse_tx(&raw).expect("parse tx");
-        assert_eq!(consumed, raw.len(), "{}", vector.id);
+        assert_eq!(consumed, raw.len());
         let expected_txid = hex::encode(txid);
 
-        let state = build_state_with_chain_state(
-            chain_state_from_positive_fixture(&vector),
-            fixture_chain_id(vector.chain_id.as_deref()),
-        );
+        let state = build_state_with_chain_state(chain_state, chain_id);
         let response = route_request(
             &state,
             HttpRequest {
@@ -2891,16 +2929,24 @@ mod tests {
     fn submit_tx_calls_announce_callback_on_success() {
         use std::sync::atomic::{AtomicBool, Ordering};
 
-        let vector = positive_fixture_vector();
-        assert!(vector.expect_ok);
-        let raw = hex::decode(&vector.tx_hex).expect("decode tx hex");
+        // RUB-162 Phase A migration rationale (per controller Q2 / Path A
+        // approval 2026-05-03):
+        //   - old assumption: positive_fixture_vector tx admits via
+        //     /submit_tx and triggers the announce_tx callback.
+        //   - new invariant: admit_with_metadata enforces the rolling fee
+        //     floor; conformance fixture admits Unavailable and the
+        //     announce callback would never fire.
+        //   - reachability: test pins announce_tx invocation AFTER
+        //     successful admit. Reaches the txpool admission path through
+        //     DevnetRPC -> TxPool::admit success → announce side-effect.
+        //   - replacement coverage: same floor-compliant tx as the sibling
+        //     submit_tx_accepts_floor_compliant_p2pk_tx test; announce
+        //     side-effect on success invariant remains under test.
+        let (chain_state, raw, chain_id) = floor_compliant_signed_tx_and_state();
         let called = Arc::new(AtomicBool::new(false));
         let called_clone = Arc::clone(&called);
 
-        let mut state = build_state_with_chain_state(
-            chain_state_from_positive_fixture(&vector),
-            fixture_chain_id(vector.chain_id.as_deref()),
-        );
+        let mut state = build_state_with_chain_state(chain_state, chain_id);
         state.announce_tx = Some(Arc::new(move |_tx_bytes: &[u8], _meta| {
             called_clone.store(true, Ordering::SeqCst);
             Ok(())
@@ -2923,14 +2969,23 @@ mod tests {
 
     #[test]
     fn submit_tx_logs_announce_error_without_failing_rpc() {
-        let vector = positive_fixture_vector();
-        assert!(vector.expect_ok);
-        let raw = hex::decode(&vector.tx_hex).expect("decode tx hex");
+        // RUB-162 Phase A migration rationale (per controller Q2 / Path A
+        // approval 2026-05-03):
+        //   - old assumption: positive_fixture_vector tx admits via
+        //     /submit_tx and the announce_tx Err is logged but not
+        //     propagated; RPC still returns 200.
+        //   - new invariant: admit_with_metadata enforces the rolling fee
+        //     floor; conformance fixture admits Unavailable and the RPC
+        //     would return 503 without ever invoking announce_tx.
+        //   - reachability: test pins /submit_tx returning 200 even when
+        //     announce_tx returns Err — requires successful admit AND
+        //     announce invocation.
+        //   - replacement coverage: same floor-compliant tx as the sibling
+        //     submit_tx_accepts_floor_compliant_p2pk_tx test; "RPC succeeds
+        //     even with announce Err" invariant remains under test.
+        let (chain_state, raw, chain_id) = floor_compliant_signed_tx_and_state();
 
-        let mut state = build_state_with_chain_state(
-            chain_state_from_positive_fixture(&vector),
-            fixture_chain_id(vector.chain_id.as_deref()),
-        );
+        let mut state = build_state_with_chain_state(chain_state, chain_id);
         state.announce_tx = Some(Arc::new(|_tx_bytes: &[u8], _meta| {
             Err("relay failure".to_string())
         }));

--- a/clients/rust/crates/rubin-node/src/devnet_rpc.rs
+++ b/clients/rust/crates/rubin-node/src/devnet_rpc.rs
@@ -2806,15 +2806,14 @@ mod tests {
 
     #[test]
     fn submit_tx_accepts_floor_compliant_p2pk_tx() {
-        let vector = positive_fixture_vector();
-        assert!(vector.expect_ok, "{} should be positive fixture", vector.id);
         // RUB-162 Phase A migration rationale (per controller Q2 / Path A
-        // approval 2026-05-03):
+        // approval 2026-05-03; PR-1410 wave-3 Copilot Thread C update):
         //   - old assumption: positive_fixture_vector tx (fee=10/weight=
         //     7653) admits via /submit_tx; pre-RUB-162 admit_with_metadata
         //     did not enforce the rolling fee floor.
         //   - new invariant: admit_with_metadata enforces the rolling fee
-        //     floor (DEFAULT=1) via validate_fee_floor_locked. The
+        //     floor (DEFAULT=1) via the
+        //     `apply_post_consensus_policy_with_floor` helper. The
         //     conformance fixture is sub-floor and admits Unavailable.
         //   - reachability: the test pins /submit_tx returning 200 +
         //     duplicate detection + metrics increment — all of which require
@@ -2829,6 +2828,12 @@ mod tests {
         //     covered by relay_metadata +
         //     admit_rejects_sub_floor_conformance_tx_as_unavailable_with_atomicity
         //     (which asserts Unavailable in txpool.rs).
+        //   - PR-1410 wave-3 Copilot Thread C: removed the
+        //     `let vector = positive_fixture_vector(); assert!(vector.expect_ok, ...);`
+        //     prelude that was vestigial after the migration to
+        //     `floor_compliant_signed_tx_and_state()`. The test no longer
+        //     consumes the conformance fixture, so coupling its assertions
+        //     to CV-U-06 churn would be a stale-fixture coupling bug.
         let (chain_state, raw, chain_id) = floor_compliant_signed_tx_and_state();
         let (_tx, txid, _wtxid, consumed) = parse_tx(&raw).expect("parse tx");
         assert_eq!(consumed, raw.len());

--- a/clients/rust/crates/rubin-node/src/miner.rs
+++ b/clients/rust/crates/rubin-node/src/miner.rs
@@ -667,7 +667,7 @@ mod tests {
         //     with weight ≈ 7653 admits because pre-RUB-162
         //     admit_with_metadata did not enforce the rolling fee floor.
         //   - new invariant: admit_with_metadata enforces the rolling fee
-        //     floor (DEFAULT=1) via validate_fee_floor_locked.
+        //     floor (DEFAULT=1) via validate_fee_floor.
         //   - reachability: tx is well-formed; pool.admit reaches the
         //     txpool admission path. Mine_n then confirms blocks and
         //     evicts confirmed txs from the pool.

--- a/clients/rust/crates/rubin-node/src/miner.rs
+++ b/clients/rust/crates/rubin-node/src/miner.rs
@@ -661,8 +661,21 @@ mod tests {
 
     #[test]
     fn mine_n_evicts_confirmed_pool_transactions_between_blocks() {
+        // RUB-162 Phase A migration rationale (per controller Q2 / Path A
+        // approval 2026-05-03):
+        //   - old assumption: signed_p2pk_state_and_tx(20, 10) → fee=10
+        //     with weight ≈ 7653 admits because pre-RUB-162
+        //     admit_with_metadata did not enforce the rolling fee floor.
+        //   - new invariant: admit_with_metadata enforces the rolling fee
+        //     floor (DEFAULT=1) via validate_fee_floor_locked.
+        //   - reachability: tx is well-formed; pool.admit reaches the
+        //     txpool admission path. Mine_n then confirms blocks and
+        //     evicts confirmed txs from the pool.
+        //   - replacement coverage: input bumped to 7700 so fee = 7700 - 10
+        //     = 7690 ≥ weight (≈7653). The mine-then-evict invariant
+        //     remains under test.
         let (dir, _block_store, mut sync) = test_sync("rubin-rust-miner-pool-evict");
-        let (state, raw) = signed_p2pk_state_and_tx(20, 10);
+        let (state, raw) = signed_p2pk_state_and_tx(7700, 10);
         sync.chain_state.utxos = state.utxos;
 
         let mut pool = TxPool::new();
@@ -687,9 +700,23 @@ mod tests {
 
     #[test]
     fn mine_one_evicts_conflicting_pool_transaction_for_explicit_candidate() {
+        // RUB-162 Phase A migration rationale (per controller Q2 / Path A
+        // approval 2026-05-03):
+        //   - old assumption: signed_conflicting_p2pk_state_and_txs(20,10,9)
+        //     produced two txs with fee=10/fee=11 that admitted because
+        //     pre-RUB-162 admit_with_metadata did not enforce the rolling
+        //     fee floor.
+        //   - new invariant: admit_with_metadata enforces the rolling fee
+        //     floor.
+        //   - reachability: pool.admit on the conflicting_raw reaches the
+        //     txpool admission path; mine_one then includes the explicit
+        //     candidate which conflicts with the pool entry, evicting it.
+        //   - replacement coverage: input bumped to 7700 so both txs have
+        //     fees ≥ weight (~7653). The conflicting-eviction-on-explicit-
+        //     candidate invariant remains under test.
         let (dir, _block_store, mut sync) = test_sync("rubin-rust-miner-explicit-conflict");
         let (state, explicit_raw, conflicting_raw) =
-            signed_conflicting_p2pk_state_and_txs(20, 10, 9);
+            signed_conflicting_p2pk_state_and_txs(7700, 10, 9);
         sync.chain_state.utxos = state.utxos.clone();
 
         let mut pool = TxPool::new();

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -2354,6 +2354,20 @@ mod tests {
 
     #[test]
     fn handle_block_evicts_confirmed_pool_transactions_when_pool_provided() {
+        // RUB-162 Phase A migration rationale (per controller Q2 / Path A
+        // approval 2026-05-03):
+        //   - old assumption: signed_conflicting_p2pk_state_and_txs(20,10,9)
+        //     produces tx with fee=10/weight≈7653 that admits because
+        //     pre-RUB-162 admit_with_metadata did not enforce the rolling
+        //     fee floor.
+        //   - new invariant: admit_with_metadata enforces the rolling fee
+        //     floor (DEFAULT=1) via validate_fee_floor_locked.
+        //   - reachability: pool.admit reaches the txpool admission path;
+        //     the test then asserts handle_block evicts the confirmed tx
+        //     from the shared runtime pool.
+        //   - replacement coverage: input bumped to 7700 so fee=7690 ≥
+        //     weight (~7653). The handle_block-eviction-on-confirmation
+        //     invariant remains under test.
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
         let addr = listener.local_addr().expect("addr");
 
@@ -2365,7 +2379,7 @@ mod tests {
             engine.cfg.chain_id = devnet_genesis_chain_id();
 
             let (state, admitted_raw, _block_raw) =
-                signed_conflicting_p2pk_state_and_txs(20, 10, 9);
+                signed_conflicting_p2pk_state_and_txs(7700, 10, 9);
             engine.chain_state.utxos = state.utxos.clone();
 
             let genesis = parse_block_bytes(&devnet_genesis_block_bytes()).expect("parse genesis");
@@ -2408,6 +2422,19 @@ mod tests {
 
     #[test]
     fn handle_block_removes_conflicting_pool_transactions_when_pool_provided() {
+        // RUB-162 Phase A migration rationale (per controller Q2 / Path A
+        // approval 2026-05-03):
+        //   - old assumption: signed_conflicting_p2pk_state_and_txs(20,10,9)
+        //     admits the first tx and the test then verifies a conflicting
+        //     block tx triggers cleanup of the resident.
+        //   - new invariant: admit_with_metadata enforces the rolling fee
+        //     floor.
+        //   - reachability: pool.admit on admitted_raw reaches the
+        //     admission path; cleanup.apply then exercises the
+        //     remove_conflicting_outpoints path on the block-apply boundary.
+        //   - replacement coverage: input bumped to 7700 so both txs have
+        //     floor-compliant fees. Conflict-cleanup-on-block-apply
+        //     invariant remains under test.
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
         let addr = listener.local_addr().expect("addr");
 
@@ -2418,7 +2445,8 @@ mod tests {
             let mut engine = test_sync_engine_with_genesis();
             engine.cfg.chain_id = devnet_genesis_chain_id();
 
-            let (state, admitted_raw, block_raw) = signed_conflicting_p2pk_state_and_txs(20, 10, 9);
+            let (state, admitted_raw, block_raw) =
+                signed_conflicting_p2pk_state_and_txs(7700, 10, 9);
             engine.chain_state.utxos = state.utxos.clone();
 
             let genesis = parse_block_bytes(&devnet_genesis_block_bytes()).expect("parse genesis");

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -2361,7 +2361,7 @@ mod tests {
         //     pre-RUB-162 admit_with_metadata did not enforce the rolling
         //     fee floor.
         //   - new invariant: admit_with_metadata enforces the rolling fee
-        //     floor (DEFAULT=1) via validate_fee_floor_locked.
+        //     floor (DEFAULT=1) via validate_fee_floor.
         //   - reachability: pool.admit reaches the txpool admission path;
         //     the test then asserts handle_block evicts the confirmed tx
         //     from the shared runtime pool.

--- a/clients/rust/crates/rubin-node/src/sync_reorg.rs
+++ b/clients/rust/crates/rubin-node/src/sync_reorg.rs
@@ -927,7 +927,7 @@ mod tests {
         //     weight ≈ 7653 admits because pre-RUB-162 admit_with_metadata
         //     did not enforce the rolling fee floor.
         //   - new invariant: admit_with_metadata enforces the rolling fee
-        //     floor (DEFAULT=1) via validate_fee_floor_locked.
+        //     floor (DEFAULT=1) via validate_fee_floor.
         //   - reachability: tx is well-formed (signed_a/signed_b); admitted
         //     to the pool before reorg. The reorg test then exercises
         //     native suite cache invalidation when the canonical chain

--- a/clients/rust/crates/rubin-node/src/sync_reorg.rs
+++ b/clients/rust/crates/rubin-node/src/sync_reorg.rs
@@ -755,6 +755,20 @@ mod tests {
 
     #[test]
     fn apply_block_with_reorg_tip_extension_removes_conflicting_pool_spends() {
+        // RUB-162 Phase A migration rationale (per controller Q2 / Path A
+        // approval 2026-05-03):
+        //   - old assumption: signed_conflicting_p2pk_state_and_txs(20,10,9)
+        //     produces tx with fee=10/weight≈7653 that admits because
+        //     pre-RUB-162 admit_with_metadata did not enforce the rolling
+        //     fee floor.
+        //   - new invariant: admit_with_metadata enforces the rolling fee
+        //     floor.
+        //   - reachability: pool.admit reaches the txpool admission path;
+        //     apply_block_with_reorg's tx_pool_cleanup then exercises the
+        //     conflict-removal path on tip-extension.
+        //   - replacement coverage: input bumped to 7700 so both txs have
+        //     floor-compliant fees. Conflict-removal-on-tip-extension
+        //     invariant remains under test.
         let (mut engine, dir) = engine_with_store("rubin-reorg-tip-conflict");
         let (genesis, genesis_hash, gen_ts) = genesis_info();
         engine
@@ -762,7 +776,7 @@ mod tests {
             .expect("genesis");
         engine.cfg.chain_id = devnet_genesis_chain_id();
 
-        let (state, admitted_raw, block_raw) = signed_conflicting_p2pk_state_and_txs(20, 10, 9);
+        let (state, admitted_raw, block_raw) = signed_conflicting_p2pk_state_and_txs(7700, 10, 9);
         engine.chain_state.utxos = state.utxos.clone();
 
         let mut pool = TxPool::new();
@@ -907,6 +921,24 @@ mod tests {
 
     #[test]
     fn native_suites_cache_invalidated_on_reorg() {
+        // RUB-162 Phase A migration rationale (per controller Q2 / Path A
+        // approval 2026-05-03):
+        //   - old assumption: UTXO value=20, tx output_value=10 → fee=10,
+        //     weight ≈ 7653 admits because pre-RUB-162 admit_with_metadata
+        //     did not enforce the rolling fee floor.
+        //   - new invariant: admit_with_metadata enforces the rolling fee
+        //     floor (DEFAULT=1) via validate_fee_floor_locked.
+        //   - reachability: tx is well-formed (signed_a/signed_b); admitted
+        //     to the pool before reorg. The reorg test then exercises
+        //     native suite cache invalidation when the canonical chain
+        //     swaps.
+        //   - replacement coverage: both UTXOs bumped from value=20 to
+        //     value=20_000 so each tx fee = 20000-10 = 19990 (and
+        //     20000-9 = 19991) ≥ weight (~7653) — extra headroom over
+        //     the minimal floor-compliant value (~7700) to keep the
+        //     rotated-suite-witness fees comfortably above the floor
+        //     across both branches of the reorg path. Native-suite-
+        //     cache-invalidation-on-reorg invariant remains under test.
         let (mut engine, dir) = engine_with_store("rubin-reorg-native-suite");
         let (genesis, genesis_hash, gen_ts) = genesis_info();
         engine
@@ -929,7 +961,7 @@ mod tests {
         state.utxos.insert(
             outpoint_a.clone(),
             UtxoEntry {
-                value: 20,
+                value: 20_000,
                 covenant_type: rubin_consensus::constants::COV_TYPE_P2PK,
                 covenant_data: p2pk_covenant_data_for_pubkey(&signer_a.pubkey_bytes()),
                 creation_height: 0,
@@ -939,7 +971,7 @@ mod tests {
         state.utxos.insert(
             outpoint_b.clone(),
             UtxoEntry {
-                value: 20,
+                value: 20_000,
                 covenant_type: rubin_consensus::constants::COV_TYPE_P2PK,
                 covenant_data: p2pk_covenant_data_for_pubkey(&signer_b.pubkey_bytes()),
                 creation_height: 0,

--- a/clients/rust/crates/rubin-node/src/tx_relay.rs
+++ b/clients/rust/crates/rubin-node/src/tx_relay.rs
@@ -427,7 +427,7 @@ mod tests {
             crate::genesis::devnet_genesis_chain_id(),
             &crate::txpool::TxPoolConfig::default(),
         )
-        .expect("positive fixture relay metadata (floor-compliant signed P2PK)");
+        .expect("relay_metadata for floor-compliant signed P2PK tx");
         (tx_bytes, meta)
     }
 

--- a/clients/rust/crates/rubin-node/src/tx_relay.rs
+++ b/clients/rust/crates/rubin-node/src/tx_relay.rs
@@ -394,110 +394,40 @@ mod tests {
     use super::*;
     use crate::{default_sync_config, ChainState, SyncEngine};
 
-    #[derive(serde::Deserialize)]
-    struct FixtureFile<T> {
-        vectors: Vec<T>,
-    }
-
-    #[derive(Clone, serde::Deserialize)]
-    struct FixtureUtxo {
-        txid: String,
-        vout: u32,
-        value: u64,
-        covenant_type: u16,
-        covenant_data: String,
-        creation_height: u64,
-        created_by_coinbase: bool,
-    }
-
-    #[derive(Clone, serde::Deserialize)]
-    struct PositiveTxVector {
-        id: String,
-        tx_hex: String,
-        #[serde(default)]
-        chain_id: Option<String>,
-        height: u64,
-        expect_ok: bool,
-        utxos: Vec<FixtureUtxo>,
-    }
-
-    fn parse_hex32_test(name: &str, value: &str) -> [u8; 32] {
-        let raw = hex::decode(value).unwrap_or_else(|err| panic!("{name} hex: {err}"));
-        assert_eq!(raw.len(), 32, "{name} must be 32 bytes");
-        let mut out = [0u8; 32];
-        out.copy_from_slice(&raw);
-        out
-    }
-
-    fn fixture_utxos_to_map(
-        items: &[FixtureUtxo],
-    ) -> HashMap<rubin_consensus::Outpoint, rubin_consensus::UtxoEntry> {
-        let mut out = HashMap::with_capacity(items.len());
-        for item in items {
-            out.insert(
-                rubin_consensus::Outpoint {
-                    txid: parse_hex32_test("fixture utxo txid", &item.txid),
-                    vout: item.vout,
-                },
-                rubin_consensus::UtxoEntry {
-                    value: item.value,
-                    covenant_type: item.covenant_type,
-                    covenant_data: hex::decode(&item.covenant_data)
-                        .expect("fixture covenant_data hex"),
-                    creation_height: item.creation_height,
-                    created_by_coinbase: item.created_by_coinbase,
-                },
-            );
-        }
-        out
-    }
-
-    fn positive_fixture_vector() -> PositiveTxVector {
-        const UTXO_BASIC_FIXTURE_JSON: &str = include_str!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../../../conformance/fixtures/CV-UTXO-BASIC.json"
-        ));
-        let fixture: FixtureFile<PositiveTxVector> =
-            serde_json::from_str(UTXO_BASIC_FIXTURE_JSON).expect("parse positive fixture");
-        fixture
-            .vectors
-            .into_iter()
-            .find(|vector| vector.id == "CV-U-06")
-            .expect("positive fixture vector")
-    }
-
-    fn fixture_chain_id(chain_id: Option<&str>) -> [u8; 32] {
-        chain_id
-            .map(|value| parse_hex32_test("chain_id", value))
-            .unwrap_or([0u8; 32])
-    }
-
-    fn chain_state_from_positive_fixture(vector: &PositiveTxVector) -> ChainState {
-        let mut state = ChainState::new();
-        state.has_tip = vector.height > 0;
-        state.height = vector.height.saturating_sub(1);
-        state.utxos = fixture_utxos_to_map(&vector.utxos);
-        state
-    }
-
-    fn sync_engine_from_positive_fixture(vector: &PositiveTxVector) -> SyncEngine {
-        let mut cfg = default_sync_config(None, fixture_chain_id(vector.chain_id.as_deref()), None);
-        cfg.core_ext_deployments = rubin_consensus::CoreExtDeploymentProfiles::empty();
-        SyncEngine::new(chain_state_from_positive_fixture(vector), None, cfg).expect("sync engine")
-    }
+    // PR-1410 wave-2 — removed unused conformance-fixture types and
+    // helpers (`FixtureFile`, `FixtureUtxo`, `PositiveTxVector`,
+    // `parse_hex32_test`, `fixture_utxos_to_map`,
+    // `positive_fixture_vector`, `fixture_chain_id`,
+    // `chain_state_from_positive_fixture`,
+    // `sync_engine_from_positive_fixture`).
+    // The two consumer tests (`positive_fixture_tx_and_meta` builder
+    // and `handle_received_tx_with_valid_floor_compliant_tx_stores_and_relays`)
+    // now build a floor-compliant signed P2PK fixture inline via the
+    // public `signed_conflicting_p2pk_state_and_txs` helper because the
+    // conformance fixture's pre-signed tx (fee=10/weight≈7653) is
+    // sub-floor under the wave-2 `relay_metadata` rolling-floor check.
 
     fn positive_fixture_tx_and_meta() -> (Vec<u8>, crate::txpool::RelayTxMetadata) {
-        let vector = positive_fixture_vector();
-        let tx_bytes = hex::decode(&vector.tx_hex).expect("tx hex");
-        let state = chain_state_from_positive_fixture(&vector);
+        // PR-1410 wave-2 fixture migration: relay_metadata now enforces
+        // the same rolling fee floor as admit_with_metadata (see
+        // rub162_relay_metadata_da_below_rolling_floor_returns_unavailable_matching_admit).
+        // The conformance fixture (fee=10/weight≈7653 ⇒ fee_rate ≈ 0.0013)
+        // is sub-floor under DEFAULT_MEMPOOL_MIN_FEE_RATE=1, and bumping
+        // UTXO values inside the conformance state invalidates the
+        // signature baked into the fixture's pre-signed tx hex. Build
+        // a floor-compliant signed P2PK tx + matching state inline via
+        // the public test_helpers helper (mirrors the admit_* test
+        // migrations); fee = 20_000 - 10 = 19_990 ≫ weight*1.
+        let (state, tx_bytes, _second_tx_unused) =
+            crate::test_helpers::signed_conflicting_p2pk_state_and_txs(20_000, 10, 9);
         let meta = crate::txpool::relay_metadata(
             &tx_bytes,
             &state,
             None,
-            fixture_chain_id(vector.chain_id.as_deref()),
+            crate::genesis::devnet_genesis_chain_id(),
             &crate::txpool::TxPoolConfig::default(),
         )
-        .expect("positive fixture relay metadata");
+        .expect("positive fixture relay metadata (floor-compliant signed P2PK)");
         (tx_bytes, meta)
     }
 
@@ -1040,11 +970,20 @@ mod tests {
     }
 
     #[test]
-    fn handle_received_tx_with_valid_fixture_stores_and_relays() {
-        let vector = positive_fixture_vector();
-        assert!(vector.expect_ok, "{} should be positive fixture", vector.id);
-        let tx_bytes = hex::decode(&vector.tx_hex).expect("tx hex");
-        let sync_engine = sync_engine_from_positive_fixture(&vector);
+    fn handle_received_tx_with_valid_floor_compliant_tx_stores_and_relays() {
+        // PR-1410 wave-2 fixture migration: relay_metadata now enforces
+        // the same rolling fee floor as admit_with_metadata. The
+        // conformance fixture (fee=10/weight≈7653) is sub-floor and
+        // would now reject. Use a floor-compliant signed P2PK tx +
+        // matching SyncEngine inline (mirrors the admit_* migration
+        // pattern in txpool.rs); the test purpose (handle_received_tx
+        // stores + relays a valid tx, skips sender, broadcasts to
+        // other) is preserved.
+        let (chain_state, tx_bytes, _second_tx_unused) =
+            crate::test_helpers::signed_conflicting_p2pk_state_and_txs(20_000, 10, 9);
+        let mut cfg = default_sync_config(None, crate::genesis::devnet_genesis_chain_id(), None);
+        cfg.core_ext_deployments = rubin_consensus::CoreExtDeploymentProfiles::empty();
+        let sync_engine = SyncEngine::new(chain_state, None, cfg).expect("sync engine");
         let relay = TxRelayState::new();
         let pm = PeerManager::new(crate::p2p_runtime::default_peer_runtime_config(
             "devnet", 64,

--- a/clients/rust/crates/rubin-node/src/tx_relay.rs
+++ b/clients/rust/crates/rubin-node/src/tx_relay.rs
@@ -400,14 +400,14 @@ mod tests {
     // `positive_fixture_vector`, `fixture_chain_id`,
     // `chain_state_from_positive_fixture`,
     // `sync_engine_from_positive_fixture`).
-    // The two consumer tests (`positive_fixture_tx_and_meta` builder
+    // The two consumer tests (`floor_compliant_tx_and_meta` builder
     // and `handle_received_tx_with_valid_floor_compliant_tx_stores_and_relays`)
     // now build a floor-compliant signed P2PK fixture inline via the
     // public `signed_conflicting_p2pk_state_and_txs` helper because the
     // conformance fixture's pre-signed tx (fee=10/weight≈7653) is
     // sub-floor under the wave-2 `relay_metadata` rolling-floor check.
 
-    fn positive_fixture_tx_and_meta() -> (Vec<u8>, crate::txpool::RelayTxMetadata) {
+    fn floor_compliant_tx_and_meta() -> (Vec<u8>, crate::txpool::RelayTxMetadata) {
         // PR-1410 wave-2 fixture migration: relay_metadata now enforces
         // the same rolling fee floor as admit_with_metadata (see
         // rub162_relay_metadata_da_below_rolling_floor_returns_unavailable_matching_admit).
@@ -833,7 +833,7 @@ mod tests {
 
     #[test]
     fn announce_tx_with_real_tx_stores_and_broadcasts() {
-        let (tx_bytes, meta) = positive_fixture_tx_and_meta();
+        let (tx_bytes, meta) = floor_compliant_tx_and_meta();
         let relay = TxRelayState::new();
         let pm = PeerManager::new(crate::p2p_runtime::default_peer_runtime_config(
             "devnet", 64,
@@ -936,7 +936,7 @@ mod tests {
 
     #[test]
     fn announce_tx_uses_real_metadata_for_relay_pool_priority() {
-        let (tx_bytes, meta) = positive_fixture_tx_and_meta();
+        let (tx_bytes, meta) = floor_compliant_tx_and_meta();
         let incoming_txid = canonical_txid(&tx_bytes).unwrap();
         let existing_txid = [0xEE; 32];
         let relay = TxRelayState {

--- a/clients/rust/crates/rubin-node/src/txpool.rs
+++ b/clients/rust/crates/rubin-node/src/txpool.rs
@@ -3061,6 +3061,31 @@ mod tests {
             .expect("DA tx above both floors must admit");
         assert_eq!(pool.len(), 1);
         assert!(pool.txs.contains_key(&txid));
+        // PR-1410 wave-7 — prove the `_with_indexes` claim in the test
+        // name. Admit must populate ALL FOUR secondary indexes per the
+        // Phase A atomicity invariant (`insert_entry` at txpool.rs:420-434
+        // populates `spenders` / `heap_seqs` / `worst_heap` / `txs`
+        // together). Without these assertions the test would still pass
+        // even if `insert_entry` silently stopped updating one of the
+        // secondary indexes — leaving the atomicity / index-invariant
+        // path unpinned. The fixture is single-input single-output
+        // (`signed_p2pk_state_and_tx` at txpool.rs:1249-1275 inserts one
+        // outpoint), so every index size is exactly 1 after admit.
+        assert_eq!(
+            pool.spenders.len(),
+            1,
+            "single-input tx must populate exactly one spenders entry"
+        );
+        assert_eq!(
+            pool.heap_seqs.len(),
+            1,
+            "tx must be tracked in heap_seqs after insert_entry"
+        );
+        assert_eq!(
+            pool.worst_heap.len(),
+            1,
+            "tx must be pushed to worst_heap after insert_entry"
+        );
     }
 
     /// P1 #2 atomicity through public admit — Unavailable on relay-floor
@@ -3497,9 +3522,15 @@ mod tests {
     /// `mempool fee below rolling minimum` message).
     #[test]
     fn rub162_admit_sub_floor_da_anchor_classifies_as_da_rejected_not_floor_unavailable() {
-        // fee=10 ≪ weight (≈70 = MIN witness for DA tx) ⇒ sub-floor.
-        // Default conformance da_bytes ≈ 70. DA-required = da_bytes *
-        // (min_da=200 + surcharge=200) = ~28_000 ≫ fee=10 ⇒ sub-DA.
+        // weight ≈ 7600 from ML-DSA-87 witness + 64-byte da_payload
+        // (same shape as `rub162_admit_da_above_both_floors_admits_with_indexes`
+        // at lines 3037-3051). fee=10 ≪ weight ⇒ sub-floor under
+        // DEFAULT_MEMPOOL_MIN_FEE_RATE=1. da_bytes ≈ 70 (DA chunk core
+        // + 64-byte payload). DA-required = da_bytes * (min_da=200 +
+        // surcharge=200) ≈ 28_000 ≫ fee=10 ⇒ sub-DA. The asserts
+        // below pin only the test-relevant inequalities (10 < weight,
+        // 10 < required_da) — the ≈ values are illustrative bounds
+        // for the sub-floor / sub-DA classification reasoning.
         let (state, raw, weight, da_bytes) = build_signed_da_tx_with_fee(10, vec![0x55; 64]);
         assert!(
             10 < weight,

--- a/clients/rust/crates/rubin-node/src/txpool.rs
+++ b/clients/rust/crates/rubin-node/src/txpool.rs
@@ -435,15 +435,15 @@ impl TxPool {
         self.compact_worst_heap_if_needed();
     }
 
-    // PR-1410 wave-3 — removed `TxPool::validate_fee_floor_locked`
-    // impl-method. After the wave-3 drift-prevention helper extraction
-    // (`apply_post_consensus_policy_with_floor`), both
-    // `admit_with_metadata` and `relay_metadata` go through that helper,
-    // and the free `validate_fee_floor` predicate is the single
-    // source-of-truth call. The impl-method's `_locked` suffix was a
-    // historical TxPool-state convenience that no longer carries
-    // meaning (the predicate is stateless on the cfg field). Tests
-    // call the free `validate_fee_floor` directly.
+    // PR-1410 wave-3 — the historical TxPool impl-method that performed
+    // the rolling-floor check (the `_locked` suffix referred to its
+    // TxPool-state lock convenience) was removed. After the wave-3
+    // drift-prevention helper extraction (`apply_post_consensus_policy_with_floor`),
+    // both `admit_with_metadata` and `relay_metadata` go through that
+    // helper, and the free `validate_fee_floor` predicate is the single
+    // source-of-truth call. The historical `_locked` suffix no longer
+    // carries meaning — the predicate is stateless on the cfg field.
+    // Tests call the free `validate_fee_floor` directly.
 
     fn seed_worst_heap(&mut self) {
         let max_stale_tail = self.txs.len().saturating_add(1);
@@ -540,7 +540,7 @@ pub(crate) fn relay_metadata(
     // and the admit path (`admit_with_metadata`) cannot drift again.
     // Wave-2 already fixed one drift instance (relay_metadata had
     // skipped the rolling-floor check entirely while admit enforced it
-    // via `validate_fee_floor_locked`); the shared helper makes that
+    // via `validate_fee_floor`); the shared helper makes that
     // class of drift impossible by construction.
     let (weight, _, _) = tx_weight_and_stats_public(&tx)
         .map_err(|err| rejected(format!("transaction rejected: {err}")))?;
@@ -734,14 +734,13 @@ fn fee_rate_below_floor(fee: u64, weight: u64, floor: u64) -> bool {
     (fee as u128) < required
 }
 
-/// Free-function wrapper around the rolling-relay-floor predicate so
-/// both `TxPool::validate_fee_floor_locked` (impl-method on the admit
-/// path) and `relay_metadata` (free function on the relay path) share
-/// one source-of-truth check. Returns `Unavailable` (transient /
-/// retryable) on rolling-floor failure, mirroring Go
-/// `validateFeeFloorLocked` at clients/go/node/mempool.go:957-967. The
-/// `DEFAULT_MEMPOOL_MIN_FEE_RATE` clamp lives inside
-/// `fee_rate_below_floor` (Go-parity at
+/// Free-function predicate enforcing the rolling-relay-floor invariant
+/// shared by `admit_with_metadata` and `relay_metadata` via
+/// `apply_post_consensus_policy_with_floor` so both paths use one
+/// source-of-truth check. Returns `Unavailable` (transient / retryable)
+/// on rolling-floor failure, mirroring Go `validateFeeFloorLocked` at
+/// clients/go/node/mempool.go:957-967. The `DEFAULT_MEMPOOL_MIN_FEE_RATE`
+/// clamp lives inside `fee_rate_below_floor` (Go-parity at
 /// clients/go/node/mempool.go:1425-1427); the error message surfaces
 /// the post-clamp value for operator clarity.
 fn validate_fee_floor(fee: u64, weight: u64, cfg_floor: u64) -> Result<(), TxPoolAdmitError> {
@@ -866,9 +865,11 @@ pub(crate) fn reject_da_anchor_tx_policy(
     if da_bytes == 0 {
         // Non-DA transaction: the helper only enforces the DA half of the
         // Stage C admission contract. Non-DA relay-fee floor enforcement
-        // is now performed by `TxPool::validate_fee_floor_locked` (defined
-        // below), invoked from `TxPool::admit_with_metadata` AFTER this
-        // helper's `apply_policy` returns Ok — mirroring Go's
+        // is now performed by the free `validate_fee_floor` predicate
+        // (defined below), invoked inside
+        // `apply_post_consensus_policy_with_floor` which both
+        // `TxPool::admit_with_metadata` and `relay_metadata` call AFTER
+        // this helper's `apply_policy` returns Ok — mirroring Go's
         // `validateCapacityAdmissionLocked` calling `validateFeeFloorLocked`
         // at clients/go/node/mempool.go:1018-1024. Both `admit_with_metadata`
         // and `relay_metadata` zero-out the rolling floor before invoking
@@ -1360,10 +1361,10 @@ mod tests {
         //     tx; pre-RUB-162 admit_with_metadata did not enforce the rolling
         //     fee floor as a separate Unavailable classifier.
         //   - new invariant: admit_with_metadata classifies relay-floor
-        //     failure as Unavailable via validate_fee_floor_locked (mirrors
+        //     failure as Unavailable via validate_fee_floor (mirrors
         //     Go validateFeeFloorLocked). The conformance fixture has fee=10
         //     weight=7653 (fee_rate ≈ 0.0013, far below DEFAULT=1) and the
-        //     floor cannot be lowered via cfg because validate_fee_floor_locked
+        //     floor cannot be lowered via cfg because validate_fee_floor
         //     clamps to DEFAULT (Go parity).
         //   - why it reaches policy path: tx is well-formed; floor check is
         //     after apply_policy.
@@ -1557,7 +1558,7 @@ mod tests {
         //     reaches the pool-full ordering check and admit returns
         //     Unavailable("tx pool full") because the pre-RUB-162
         //     admit_with_metadata had no rolling-floor classification.
-        //   - new invariant: validate_fee_floor_locked runs BEFORE the
+        //   - new invariant: validate_fee_floor runs BEFORE the
         //     pool-full check (Go validateCapacityAdmissionLocked order
         //     at clients/go/node/mempool.go:1020-1024). Sub-floor
         //     candidates fail the floor check first.
@@ -1687,14 +1688,14 @@ mod tests {
         //     the rolling fee floor; the test exercised eviction-ordering.
         //   - new invariant: admit_with_metadata enforces the rolling fee
         //     floor (DEFAULT_MEMPOOL_MIN_FEE_RATE=1) via
-        //     validate_fee_floor_locked → Unavailable when fee/weight < 1.
+        //     validate_fee_floor → Unavailable when fee/weight < 1.
         //   - why it reaches policy path: tx is well-formed; floor check
         //     is after apply_policy, before eviction.
         //   - replacement coverage: input bumped to 7661 so fee = 7661 - 8
         //     = 7653 ≥ weight (≈7653) ⇒ fee/weight ≥ 1 ⇒ passes the
         //     default floor; eviction-ordering invariant remains under test.
         //     Cfg-zero opt-out is impossible because the floor is clamped
-        //     to DEFAULT inside validate_fee_floor_locked (Go parity).
+        //     to DEFAULT inside validate_fee_floor (Go parity).
         let (state, raw) = signed_p2pk_state_and_tx(
             7661,
             vec![TxOutput {
@@ -1755,7 +1756,7 @@ mod tests {
         //     the rolling fee floor; the test exercised heap-state
         //     preservation across reject + admit cycle.
         //   - new invariant: admit_with_metadata enforces the rolling fee
-        //     floor via validate_fee_floor_locked → Unavailable.
+        //     floor via validate_fee_floor → Unavailable.
         //   - why it reaches policy path: txs are well-formed; floor check
         //     is after apply_policy.
         //   - replacement coverage: input_value bumped to make fee_rate ≥ 1
@@ -1780,7 +1781,7 @@ mod tests {
             Vec::new(),
         );
         // Worse candidate: fee = 7662 - 9 = 7653; weight ≈ 7653 → fee_rate
-        // = 1.0. Above floor (passes validate_fee_floor_locked) but below
+        // = 1.0. Above floor (passes validate_fee_floor) but below
         // worst pool entry's fee_rate (2.0); pool-full eviction comparator
         // rejects with Unavailable.
         let (state_worse, raw_worse) = signed_p2pk_state_and_tx(
@@ -1979,7 +1980,7 @@ mod tests {
         //     did not enforce the rolling fee floor on non-DA txs.
         //   - new invariant: admit_with_metadata enforces the rolling fee
         //     floor (DEFAULT_MEMPOOL_MIN_FEE_RATE=1) for every admission
-        //     via validate_fee_floor_locked.
+        //     via validate_fee_floor.
         //   - reachability: tx is well-formed (parses, basic checks pass);
         //     floor check is after apply_policy. Original test goal is to
         //     exercise remove_conflicting_inputs via a previously-admitted
@@ -2196,7 +2197,7 @@ mod tests {
         //     7653) reaches next_block_mtp -> get_header_by_hash which
         //     fails with "read header"; pre-RUB-162 admit_with_metadata
         //     did not enforce the rolling fee floor at all.
-        //   - new invariant: validate_fee_floor_locked runs AFTER
+        //   - new invariant: validate_fee_floor runs AFTER
         //     apply_policy as the post-apply Go-parity placement
         //     (mirrors clients/go/node/mempool.go:1020-1024
         //     validateCapacityAdmissionLocked called from
@@ -2209,7 +2210,7 @@ mod tests {
         //     path (block_store.get_header_by_hash → Err propagated
         //     as Unavailable). header_lookup happens inside
         //     next_block_mtp which runs BEFORE both apply_policy and
-        //     validate_fee_floor_locked, so floor-compliance is NOT a
+        //     validate_fee_floor, so floor-compliance is NOT a
         //     reachability requirement for this branch — any well-formed
         //     tx with chain_state has_tip=true / height=0 and a
         //     canonical tip whose header is missing from the
@@ -2318,7 +2319,7 @@ mod tests {
         //     fee < relay-floor-or-DA-required (whichever was higher).
         //   - new invariant: apply_policy (containing the DA helper
         //     with cfg-zero override) runs BEFORE
-        //     validate_fee_floor_locked. With cfg-zero the DA helper
+        //     validate_fee_floor. With cfg-zero the DA helper
         //     checks fee >= max(0, da_required) = da_required, leaving
         //     DA-side classification intact while the rolling relay
         //     floor is enforced separately AFTER apply_policy. To pin
@@ -2868,8 +2869,9 @@ mod tests {
         // Non-DA tx (tx_kind=0, no DaChunkCore, no da_payload) must be admitted
         // by reject_da_anchor_tx_policy without applying any DA term, even with
         // aggressive rate config. Non-DA relay-fee floor enforcement now lives
-        // in TxPool::validate_fee_floor_locked (defined above) and runs from
-        // admit_with_metadata AFTER apply_policy returns Ok — mirroring Go's
+        // in the free validate_fee_floor predicate, invoked inside
+        // apply_post_consensus_policy_with_floor (called from admit_with_metadata
+        // AFTER apply_policy returns Ok) — mirroring Go's
         // validateCapacityAdmissionLocked → validateFeeFloorLocked split at
         // clients/go/node/mempool.go:1018-1024. This helper only validates the
         // DA half of the Stage C contract and intentionally short-circuits for
@@ -2922,7 +2924,7 @@ mod tests {
     use super::{fee_rate_below_floor, validate_fee_floor};
 
     /// P1 #4 fix — DA tx whose DA fee passes but rolling relay floor fails
-    /// must return Unavailable from validate_fee_floor_locked, NOT Rejected
+    /// must return Unavailable from validate_fee_floor, NOT Rejected
     /// from reject_da_anchor_tx_policy. Mirrors Go applyPolicyAgainstState
     /// behaviour (clients/go/node/mempool.go:798-833): mempool admit passes
     /// currentMempoolMinFeeRate=0 to the DA helper so the relay-floor
@@ -2931,10 +2933,10 @@ mod tests {
     ///
     /// Reachability: tx is well-formed (parses, basic+canonical checks pass,
     /// inputs not double-spent), DA-side floor configured to 0 so DA helper
-    /// short-circuits Ok, then validate_fee_floor_locked rejects on the
+    /// short-circuits Ok, then validate_fee_floor rejects on the
     /// rolling floor. The TxPoolConfig used has policy_min_da_fee_rate=0 and
     /// policy_da_surcharge_per_byte=0, so the DA helper's required term
-    /// is 0 — the only failing path is the new validate_fee_floor_locked.
+    /// is 0 — the only failing path is the new validate_fee_floor.
     #[test]
     fn rub162_admit_da_below_rolling_floor_returns_unavailable_not_rejected() {
         // Build a DA tx with low fee_rate (fee=1, weight ≈ 7653 from ML-DSA
@@ -2960,7 +2962,7 @@ mod tests {
         );
         assert!(
             err.message.contains("mempool fee below rolling minimum"),
-            "error message must come from validate_fee_floor_locked, not DA helper; got: {}",
+            "error message must come from validate_fee_floor, not DA helper; got: {}",
             err.message
         );
     }
@@ -2972,12 +2974,12 @@ mod tests {
     ///
     /// Reachability: tx is well-formed; DA-side terms force a non-zero
     /// required fee that the tx fails. apply_policy returns Err mapped
-    /// to Rejected before validate_fee_floor_locked is reached.
+    /// to Rejected before validate_fee_floor is reached.
     #[test]
     fn rub162_admit_da_below_da_floor_returns_rejected() {
         // Per RUB-162 RESP P1 #4 ordering: apply_policy (containing the
         // DA helper with cfg-zero override) runs BEFORE
-        // validate_fee_floor_locked. To pin the DA-side rejection path,
+        // validate_fee_floor. To pin the DA-side rejection path,
         // build a fixture that FAILS the DA-side terms
         // (fee < da_bytes * (min_da + surcharge)). The fixture also
         // PASSES the relay floor (fee >= weight) defensively — under
@@ -3276,7 +3278,7 @@ mod tests {
         assert!(!fee_rate_below_floor(7653, 7653, 1));
     }
 
-    /// P1 #4 + clamp regression — `validate_fee_floor_locked` propagates
+    /// P1 #4 + clamp regression — `validate_fee_floor` propagates
     /// a cfg-seeded zero into `fee_rate_below_floor`, which itself clamps
     /// to DEFAULT_MEMPOOL_MIN_FEE_RATE per Go `feeRateBelowFloor`
     /// (clients/go/node/mempool.go:1421-1434, with the in-helper clamp
@@ -3335,7 +3337,7 @@ mod tests {
             policy_da_surcharge_per_byte: 1,
             ..TxPoolConfig::default()
         };
-        // admit must reject with Unavailable from validate_fee_floor_locked.
+        // admit must reject with Unavailable from validate_fee_floor.
         let mut pool = TxPool::new_with_config(cfg.clone());
         let admit_err = pool
             .admit(&raw, &state, None, [0u8; 32])
@@ -3518,7 +3520,7 @@ mod tests {
         assert_eq!(
             err.kind,
             TxPoolAdmitErrorKind::Rejected,
-            "DA-rejection class must win when apply_policy runs before validate_fee_floor_locked; got kind={:?} message={}",
+            "DA-rejection class must win when apply_policy runs before validate_fee_floor; got kind={:?} message={}",
             err.kind,
             err.message
         );
@@ -3567,7 +3569,7 @@ mod tests {
         assert_eq!(
             err.kind,
             TxPoolAdmitErrorKind::Rejected,
-            "CORE_EXT pre-activation class must win when apply_policy runs before validate_fee_floor_locked; got kind={:?} message={}",
+            "CORE_EXT pre-activation class must win when apply_policy runs before validate_fee_floor; got kind={:?} message={}",
             err.kind,
             err.message
         );

--- a/clients/rust/crates/rubin-node/src/txpool.rs
+++ b/clients/rust/crates/rubin-node/src/txpool.rs
@@ -317,20 +317,41 @@ impl TxPool {
         };
 
         // Go-parity capacity admission (`capacityEvictionPlanLocked`,
-        // clients/go/node/mempool.go:1024) — runs AFTER both
+        // clients/go/node/mempool.go:1024-1030) — runs AFTER both
         // `apply_policy` and the rolling relay-fee floor check above, so
         // sub-floor / DA-rejected transactions never reach this branch
         // and the worst-entry comparison only considers floor-compliant
-        // candidates.
+        // candidates. The two distinct rejection classes are split into
+        // separate error messages so callers/operators can distinguish
+        // legitimate eviction-ordering rejection from internal heap
+        // invariant violation:
+        //   1. `current_worst_txid()` returns None or the txid resolves
+        //      to no entry → MAP-vs-HEAP corruption invariant: the
+        //      `worst_heap` lookup said there's a worst entry, but the
+        //      live `txs` map disagrees. Surfaced with a distinct
+        //      "tx pool capacity invariant violated" message so an
+        //      operator/log scraper can tell internal corruption from
+        //      a routine eviction-ordering rejection.
+        //   2. `compare_admit_priority` reports candidate is NOT strictly
+        //      greater than worst → routine eviction-ordering rejection
+        //      matching Go's
+        //      `"mempool capacity candidate rejected by eviction ordering"`
+        //      at clients/go/node/mempool.go:1028-1030.
         if self.txs.len() >= MAX_TX_POOL_TRANSACTIONS {
             let Some(worst_txid) = self.current_worst_txid() else {
-                return Err(unavailable("tx pool full"));
+                return Err(unavailable(
+                    "tx pool capacity invariant violated: worst_heap empty while txs at MAX",
+                ));
             };
             let Some(worst_entry) = self.txs.get(&worst_txid) else {
-                return Err(unavailable("tx pool full"));
+                return Err(unavailable(
+                    "tx pool capacity invariant violated: worst_heap entry missing from txs map",
+                ));
             };
             if compare_admit_priority(txid, &entry, worst_txid, worst_entry) != Ordering::Greater {
-                return Err(unavailable("tx pool full"));
+                return Err(unavailable(
+                    "mempool capacity candidate rejected by eviction ordering",
+                ));
             }
             self.remove_entry(&worst_txid);
         }
@@ -431,23 +452,10 @@ impl TxPool {
     /// has no `validate_fee_floor_locked` equivalent — see
     /// `clients/go/node/mempool.go:815-818`.
     fn validate_fee_floor_locked(&self, fee: u64, weight: u64) -> Result<(), TxPoolAdmitError> {
-        // Mirrors Go validateFeeFloorLocked
-        // (clients/go/node/mempool.go:957-967). The
-        // DEFAULT_MEMPOOL_MIN_FEE_RATE clamp lives inside
-        // fee_rate_below_floor itself (Go-parity at
-        // clients/go/node/mempool.go:1425-1427); this caller passes the
-        // cfg field as-is. The error message surfaces the post-clamp
-        // value for operator clarity by recomputing the same .max()
-        // locally so the message stays consistent with the predicate's
-        // actual decision basis.
-        let cfg_floor = self.cfg.policy_current_mempool_min_fee_rate;
-        if fee_rate_below_floor(fee, weight, cfg_floor) {
-            let surfaced_floor = cfg_floor.max(DEFAULT_MEMPOOL_MIN_FEE_RATE);
-            return Err(unavailable(format!(
-                "mempool fee below rolling minimum: fee={fee} weight={weight} min_fee_rate={surfaced_floor}"
-            )));
-        }
-        Ok(())
+        // Delegate to free `validate_fee_floor` so both the impl-method
+        // caller (`admit_with_metadata`) and the free-function caller
+        // (`relay_metadata`) share one source-of-truth predicate.
+        validate_fee_floor(fee, weight, self.cfg.policy_current_mempool_min_fee_rate)
     }
 
     fn seed_worst_heap(&mut self) {
@@ -513,6 +521,9 @@ pub(crate) fn relay_metadata(
         return Err(rejected("transaction rejected: non-canonical tx bytes"));
     }
 
+    let (weight, _, _) = tx_weight_and_stats_public(&tx)
+        .map_err(|err| rejected(format!("transaction rejected: {err}")))?;
+
     let next_height = next_block_height(chain_state)?;
     let block_mtp = next_block_mtp(block_store, next_height)?;
     let active_profiles = cfg
@@ -547,14 +558,29 @@ pub(crate) fn relay_metadata(
     // clients/go/node/mempool.go:823. Without the same zero override, a DA tx that pays
     // the DA-side floor but is below the rolling relay floor surfaces
     // here as `Rejected("DA fee below Stage C floor ... relay_fee_floor=...")`
-    // diverging from Go's relay-metadata contract. The relay path does
-    // NOT enforce the rolling relay floor (Go RelayMetadata extracts
-    // metadata after the policy helper has enforced only DA-side
-    // terms), so we do not call `validate_fee_floor_locked` here — only
-    // the DA-helper invocation gets the cfg-zero override.
+    // diverging from Go's relay-metadata contract.
     let mut policy_cfg = cfg.clone();
     policy_cfg.policy_current_mempool_min_fee_rate = 0;
     apply_policy(&tx, &chain_state.utxos, next_height, &policy_cfg).map_err(rejected)?;
+
+    // RUB-162 PR-1410 wave-2 fix — Rolling relay-floor enforcement on
+    // the relay path so `relay_metadata` is NOT weaker than `admit`.
+    // Without this, the cfg-zero override above lets a DA tx that pays
+    // the DA-side floor but is below the rolling relay floor pass the
+    // relay-metadata gate, while `TxPool::admit` rejects the same tx
+    // as `Unavailable`. Production peer relay (`tx_relay::handle_received_tx`)
+    // uses `relay_metadata` as the gate before re-announcing, so the
+    // mismatch would mean we propagate sub-floor DA tx through the
+    // network even though the local mempool refuses to admit them. Go
+    // avoids the divergence in the full node by re-running mempool
+    // admission via `CanonicalMempoolRelayMetadata` +
+    // `CanonicalMempoolTxPool.Put` — the equivalent here is to call
+    // the same `validate_fee_floor` predicate inline so the matrix is:
+    //   - DA tx fee < DA-required → Rejected (DA helper, above)
+    //   - DA tx fee >= DA-required, fee/weight < rolling floor → Unavailable
+    //   - DA tx fee >= both → Ok (relay metadata returned)
+    // mirroring `admit_with_metadata`.
+    validate_fee_floor(summary.fee, weight, cfg.policy_current_mempool_min_fee_rate)?;
 
     Ok(RelayTxMetadata {
         fee: summary.fee,
@@ -688,6 +714,26 @@ fn fee_rate_below_floor(fee: u64, weight: u64, floor: u64) -> bool {
     let floor = floor.max(DEFAULT_MEMPOOL_MIN_FEE_RATE);
     let required = (weight as u128) * (floor as u128);
     (fee as u128) < required
+}
+
+/// Free-function wrapper around the rolling-relay-floor predicate so
+/// both `TxPool::validate_fee_floor_locked` (impl-method on the admit
+/// path) and `relay_metadata` (free function on the relay path) share
+/// one source-of-truth check. Returns `Unavailable` (transient /
+/// retryable) on rolling-floor failure, mirroring Go
+/// `validateFeeFloorLocked` at clients/go/node/mempool.go:957-967. The
+/// `DEFAULT_MEMPOOL_MIN_FEE_RATE` clamp lives inside
+/// `fee_rate_below_floor` (Go-parity at
+/// clients/go/node/mempool.go:1425-1427); the error message surfaces
+/// the post-clamp value for operator clarity.
+fn validate_fee_floor(fee: u64, weight: u64, cfg_floor: u64) -> Result<(), TxPoolAdmitError> {
+    if fee_rate_below_floor(fee, weight, cfg_floor) {
+        let surfaced_floor = cfg_floor.max(DEFAULT_MEMPOOL_MIN_FEE_RATE);
+        return Err(unavailable(format!(
+            "mempool fee below rolling minimum: fee={fee} weight={weight} min_fee_rate={surfaced_floor}"
+        )));
+    }
+    Ok(())
 }
 
 pub(crate) fn apply_policy(
@@ -1339,23 +1385,36 @@ mod tests {
         assert_eq!(pool.heap_seqs.len(), 0, "no heap state on Err");
     }
 
+    /// PR-1410 wave-2 migration: this test previously asserted that
+    /// `relay_metadata` Ok'd the conformance fixture (fee=10 / weight≈
+    /// 7653 ⇒ fee/weight ≈ 0.0013, far below DEFAULT_MEMPOOL_MIN_FEE_RATE).
+    /// After the wave-2 fix `relay_metadata` enforces the same rolling
+    /// floor as `admit_with_metadata`, so the conformance fixture is
+    /// now sub-floor and rejects with Unavailable from the new floor
+    /// check inside `relay_metadata`. The polarity-accurate name
+    /// (`relay_metadata_rejects_sub_floor_conformance_tx_as_unavailable`)
+    /// reflects the asserted behaviour.
     #[test]
-    fn relay_metadata_accepts_valid_conformance_tx() {
+    fn relay_metadata_rejects_sub_floor_conformance_tx_as_unavailable() {
         let vector = positive_fixture_vector();
         let raw = hex::decode(&vector.tx_hex).expect("tx hex");
         let state = chain_state_from_positive_fixture(&vector);
 
-        let meta = relay_metadata(
+        let err = relay_metadata(
             &raw,
             &state,
             None,
             fixture_chain_id(vector.chain_id.as_deref()),
             &TxPoolConfig::default(),
         )
-        .expect("relay metadata");
+        .expect_err("conformance fixture has fee_rate well below DEFAULT_MEMPOOL_MIN_FEE_RATE");
 
-        assert_eq!(meta.size, raw.len());
-        assert!(meta.fee > 0, "relay metadata should derive non-zero fee");
+        assert_eq!(err.kind, TxPoolAdmitErrorKind::Unavailable);
+        assert!(
+            err.message.contains("mempool fee below rolling minimum"),
+            "expected rolling-floor message, got: {}",
+            err.message
+        );
     }
 
     #[test]
@@ -1529,7 +1588,77 @@ mod tests {
         }
         let err = pool.admit(&raw, &state, None, [0u8; 32]).unwrap_err();
         assert_eq!(err.kind, TxPoolAdmitErrorKind::Unavailable);
-        assert!(err.message.contains("tx pool full"));
+        // PR-1410 wave-2 — error message split per Go-parity at
+        // clients/go/node/mempool.go:1028-1030. Eviction-ordering
+        // rejection is now distinct from internal capacity invariant
+        // failure.
+        assert!(
+            err.message
+                .contains("mempool capacity candidate rejected by eviction ordering"),
+            "expected eviction-ordering message, got: {}",
+            err.message
+        );
+    }
+
+    /// PR-1410 wave-2 — direct `insert_entry` populates the worst_heap
+    /// without going through admit_with_metadata, so this test
+    /// exercises the routine eviction-ordering rejection path with a
+    /// fully populated heap (not the corruption invariants). Pinning
+    /// the new error-message format prevents future regressions that
+    /// would collapse this case back into a generic "tx pool full"
+    /// message and lose Go-parity at clients/go/node/mempool.go:1028-1030.
+    #[test]
+    fn rub162_admit_pool_full_eviction_ordering_message_distinct_from_invariant() {
+        let (state, raw) = signed_p2pk_state_and_tx(
+            7700,
+            vec![TxOutput {
+                value: 10,
+                covenant_type: COV_TYPE_P2PK,
+                covenant_data: p2pk_covenant_data_for_pubkey(&vec![0x77; 2592]),
+            }],
+            0x00,
+            None,
+            Vec::new(),
+        );
+        let (_tx, txid, _wtxid, consumed) = parse_tx(&raw).expect("parse tx");
+        assert_eq!(consumed, raw.len());
+
+        let mut pool = TxPool::new();
+        // Populate via the production `insert_entry` path so worst_heap +
+        // heap_seqs + spenders are all coherent — exercises the
+        // legitimate eviction-ordering rejection branch (NOT corruption).
+        for idx in 0..MAX_TX_POOL_TRANSACTIONS {
+            let mut key = [0u8; 32];
+            key[..8].copy_from_slice(&(idx as u64 + 1).to_le_bytes());
+            if key == txid {
+                key[8] = 1;
+            }
+            pool.insert_entry(
+                key,
+                TxPoolEntry {
+                    raw: vec![0xff],
+                    inputs: Vec::new(),
+                    fee: 10,
+                    weight: 1,
+                    size: 1,
+                },
+            );
+        }
+        let err = pool.admit(&raw, &state, None, [0u8; 32]).unwrap_err();
+        assert_eq!(err.kind, TxPoolAdmitErrorKind::Unavailable);
+        assert!(
+            err.message
+                .contains("mempool capacity candidate rejected by eviction ordering"),
+            "expected eviction-ordering message (Go-parity mempool.go:1028-1030), got: {}",
+            err.message
+        );
+        // Pin: legitimate eviction-ordering rejection MUST NOT collapse
+        // into the internal invariant-violation message.
+        assert!(
+            !err.message.contains("invariant violated"),
+            "eviction-ordering rejection must not surface as invariant violation; got: {}",
+            err.message
+        );
     }
 
     #[test]
@@ -3152,29 +3281,32 @@ mod tests {
             .expect("exact floor passes");
     }
 
-    /// P1 #1 fix — relay_metadata path also passes
-    /// `policy_current_mempool_min_fee_rate=0` to apply_policy ->
-    /// reject_da_anchor_tx_policy, mirroring Go RelayMetadata's
-    /// applyPolicyAgainstState invocation
-    /// (clients/go/node/mempool.go:472-495 -> 785-853 with the
-    /// hardcoded 0 at clients/go/node/mempool.go:823). A DA tx that
-    /// pays the DA-side floor but is below the rolling relay floor
-    /// must NOT surface as `Rejected("DA fee below Stage C floor")`
-    /// from relay_metadata; the relay path's contract (per
-    /// clients/go/node/mempool.go:472-495) extracts metadata after
-    /// DA-only enforcement, with no rolling-floor classification.
-    /// admit_with_metadata still rejects the same tx with Unavailable
-    /// (validate_fee_floor_locked enforces the rolling floor on the
-    /// admit path).
+    /// PR-1410 wave-2 fix — relay_metadata must NOT be weaker than
+    /// admit_with_metadata. The cfg-zero override before apply_policy
+    /// (clients/go/node/mempool.go:823) preserves DA-side error class
+    /// isolation, but Rust's prior implementation skipped the rolling
+    /// relay floor entirely on the relay path. That created a real
+    /// production divergence: `tx_relay::handle_received_tx` uses
+    /// `relay_metadata` as the gate before re-announcing, so a DA tx
+    /// that pays the DA-side floor but is below the rolling relay
+    /// floor was propagated through the network even though
+    /// `TxPool::admit` rejected the same tx. Go avoids the divergence
+    /// in the full node by re-running mempool admission via
+    /// `CanonicalMempoolRelayMetadata` + `CanonicalMempoolTxPool.Put`;
+    /// the equivalent here is to call the same `validate_fee_floor`
+    /// predicate inside `relay_metadata` after `apply_policy` succeeds
+    /// (controller decision option-c per PR #1410 thread fix).
     ///
     /// Proof assertion: same DA tx, same TxPoolConfig with non-zero
     /// rolling floor + DA-side terms; admit returns Unavailable; relay
-    /// metadata returns Ok with the extracted fee/size.
+    /// metadata ALSO returns Unavailable with the same message — they
+    /// must surface the same classification for the same tx so peer
+    /// relay never propagates a tx the local mempool refuses to admit.
     #[test]
-    fn rub162_relay_metadata_da_below_rolling_floor_returns_ok_not_rejected() {
+    fn rub162_relay_metadata_da_below_rolling_floor_returns_unavailable_matching_admit() {
         // weight ≈ 7653; DA-required = 2 * da_bytes (≈ 70 bytes ⇒ 140);
         // pick fee that beats DA-required but is well below relay floor
-        // (fee=1000 < weight=7653 ⇒ relay-floor reject on admit path).
+        // (fee=1000 < weight=7653 ⇒ relay-floor reject on both paths).
         let (state, raw, weight, da_bytes) = build_signed_da_tx_with_fee(1_000, vec![0x77; 64]);
         assert!(
             1_000 >= 2 * da_bytes,
@@ -3199,10 +3331,79 @@ mod tests {
         assert!(admit_err
             .message
             .contains("mempool fee below rolling minimum"));
-        // relay_metadata must succeed (Go-parity: relay path does not
-        // enforce relay floor, only DA-side terms).
+        // relay_metadata MUST also reject with Unavailable — same
+        // classification as admit so peer relay does not propagate a
+        // tx the local mempool refuses.
+        let relay_err = relay_metadata(&raw, &state, None, [0u8; 32], &cfg)
+            .expect_err("relay_metadata must reject below rolling floor (matching admit)");
+        assert_eq!(relay_err.kind, TxPoolAdmitErrorKind::Unavailable);
+        assert!(relay_err
+            .message
+            .contains("mempool fee below rolling minimum"));
+    }
+
+    /// PR-1410 wave-2 — DA tx whose DA fee fails the DA-side floor
+    /// must surface as Rejected (DA helper class, terminal) from
+    /// relay_metadata, NOT collapsed into the new rolling-floor
+    /// Unavailable class. Preserves DA-side error class isolation
+    /// while the new validate_fee_floor call sits AFTER apply_policy.
+    #[test]
+    fn rub162_relay_metadata_da_below_da_floor_returns_rejected_not_unavailable() {
+        // weight ≈ 7653; with min_da=200 + surcharge=200 + da_bytes≈70,
+        // DA-required ≈ 28000 ≫ fee=8000. The fee=8000 also passes the
+        // rolling floor (fee/weight ≈ 1.04 ≥ 1) so the DA-side reject
+        // is the ONLY rejection path — proves DA classification
+        // survives the new floor check.
+        let (state, raw, weight, da_bytes) = build_signed_da_tx_with_fee(8_000, vec![0x77; 64]);
+        let min_da = 200u64;
+        let surcharge = 200u64;
+        let required_da = da_bytes
+            .checked_mul(min_da + surcharge)
+            .expect("test arithmetic");
+        assert!(
+            8_000 < required_da,
+            "test setup must put fee below DA-required: 8000 < {required_da}"
+        );
+        assert!(
+            8_000 >= weight,
+            "test setup must put fee above rolling floor: 8000 >= weight={weight}"
+        );
+        let cfg = TxPoolConfig {
+            policy_current_mempool_min_fee_rate: DEFAULT_MEMPOOL_MIN_FEE_RATE,
+            policy_min_da_fee_rate: min_da,
+            policy_da_surcharge_per_byte: surcharge,
+            ..TxPoolConfig::default()
+        };
+        let err = relay_metadata(&raw, &state, None, [0u8; 32], &cfg)
+            .expect_err("relay_metadata must reject DA tx below DA-side floor");
+        assert_eq!(
+            err.kind,
+            TxPoolAdmitErrorKind::Rejected,
+            "DA-side rejection must remain terminal Rejected, NOT new rolling-floor Unavailable; got {:?}",
+            err
+        );
+        assert!(
+            err.message.contains("DA fee below Stage C floor"),
+            "error must come from DA helper, not floor check; got: {}",
+            err.message
+        );
+    }
+
+    /// PR-1410 wave-2 — DA tx whose fee passes BOTH floors must yield
+    /// relay metadata (Ok). Smoke for the post-fix happy path.
+    #[test]
+    fn rub162_relay_metadata_da_above_both_floors_returns_ok() {
+        // fee = 30000; DA-required = da_bytes(70)*1*2 = 140; weight≈7653,
+        // fee/weight ≈ 3.92 ≥ 1. Both floors pass.
+        let (state, raw, _weight, _da_bytes) = build_signed_da_tx_with_fee(30_000, vec![0x77; 64]);
+        let cfg = TxPoolConfig {
+            policy_current_mempool_min_fee_rate: DEFAULT_MEMPOOL_MIN_FEE_RATE,
+            policy_min_da_fee_rate: 1,
+            policy_da_surcharge_per_byte: 1,
+            ..TxPoolConfig::default()
+        };
         let meta = relay_metadata(&raw, &state, None, [0u8; 32], &cfg)
-            .expect("relay_metadata should succeed when DA-side terms pass");
+            .expect("relay_metadata should succeed when both floors pass");
         assert!(meta.fee > 0);
         assert_eq!(meta.size, raw.len());
     }

--- a/clients/rust/crates/rubin-node/src/txpool.rs
+++ b/clients/rust/crates/rubin-node/src/txpool.rs
@@ -322,27 +322,35 @@ impl TxPool {
         // into separate error messages so callers/operators can
         // distinguish legitimate eviction-ordering rejection from
         // internal heap invariant violation:
-        //   1a. `current_worst_txid()` returns None while txs.len()
-        //       >= MAX → MAP-vs-HEAP corruption invariant: live `txs`
-        //       at capacity but `worst_heap` lookup yields nothing.
-        //       Surfaced as
-        //       `"tx pool capacity invariant violated: worst_heap empty while txs at MAX"`.
-        //   1b. `current_worst_txid()` returns a txid that does NOT
-        //       resolve to a live `txs` entry → second MAP-vs-HEAP
-        //       corruption invariant: heap pointed at a stale txid the
-        //       map no longer has. Surfaced as
+        //   1.  `current_worst_txid()` returns a txid that does NOT
+        //       resolve to a live `txs` entry → MAP-vs-HEAP corruption
+        //       invariant: heap pointed at a stale txid the map no
+        //       longer has. Surfaced as
         //       `"tx pool capacity invariant violated: worst_heap entry missing from txs map"`.
         //   2.  `compare_admit_priority` reports candidate is NOT
         //       strictly greater than worst → routine eviction-ordering
         //       rejection matching Go's
         //       `"mempool capacity candidate rejected by eviction ordering"`
         //       at clients/go/node/mempool.go:1028-1030 verbatim.
+        //
+        // The historical `current_worst_txid()` returns None production
+        // error branch has been removed: it was unreachable by
+        // construction in this caller. `current_worst_txid()` always
+        // invokes `seed_worst_heap()`, which rebuilds `worst_heap` from
+        // `self.txs` whenever the heap is empty or out of sync; we only
+        // enter this block when `self.txs.len() >= MAX_TX_POOL_TRANSACTIONS > 0`.
+        // After the rebuild every heap entry pairs with a fresh
+        // `heap_seqs` entry, so the peek/pop loop inside
+        // `current_worst_txid()` cannot exhaust the heap to None. The
+        // `expect()` below documents that internal invariant; a panic
+        // here would indicate a regression in `seed_worst_heap()`
+        // itself.
         if self.txs.len() >= MAX_TX_POOL_TRANSACTIONS {
-            let Some(worst_txid) = self.current_worst_txid() else {
-                return Err(unavailable(
-                    "tx pool capacity invariant violated: worst_heap empty while txs at MAX",
-                ));
-            };
+            let worst_txid = self.current_worst_txid().expect(
+                "current_worst_txid is None only when self.txs is empty; \
+                 this branch is gated on self.txs.len() >= MAX_TX_POOL_TRANSACTIONS \
+                 and seed_worst_heap rebuilds worst_heap from non-empty txs",
+            );
             let Some(worst_entry) = self.txs.get(&worst_txid) else {
                 return Err(unavailable(
                     "tx pool capacity invariant violated: worst_heap entry missing from txs map",

--- a/clients/rust/crates/rubin-node/src/txpool.rs
+++ b/clients/rust/crates/rubin-node/src/txpool.rs
@@ -321,22 +321,25 @@ impl TxPool {
         // `apply_policy` and the rolling relay-fee floor check above, so
         // sub-floor / DA-rejected transactions never reach this branch
         // and the worst-entry comparison only considers floor-compliant
-        // candidates. The two distinct rejection classes are split into
-        // separate error messages so callers/operators can distinguish
-        // legitimate eviction-ordering rejection from internal heap
-        // invariant violation:
-        //   1. `current_worst_txid()` returns None or the txid resolves
-        //      to no entry → MAP-vs-HEAP corruption invariant: the
-        //      `worst_heap` lookup said there's a worst entry, but the
-        //      live `txs` map disagrees. Surfaced with a distinct
-        //      "tx pool capacity invariant violated" message so an
-        //      operator/log scraper can tell internal corruption from
-        //      a routine eviction-ordering rejection.
-        //   2. `compare_admit_priority` reports candidate is NOT strictly
-        //      greater than worst → routine eviction-ordering rejection
-        //      matching Go's
-        //      `"mempool capacity candidate rejected by eviction ordering"`
-        //      at clients/go/node/mempool.go:1028-1030.
+        // candidates. The three distinct rejection causes are split
+        // into separate error messages so callers/operators can
+        // distinguish legitimate eviction-ordering rejection from
+        // internal heap invariant violation:
+        //   1a. `current_worst_txid()` returns None while txs.len()
+        //       >= MAX → MAP-vs-HEAP corruption invariant: live `txs`
+        //       at capacity but `worst_heap` lookup yields nothing.
+        //       Surfaced as
+        //       `"tx pool capacity invariant violated: worst_heap empty while txs at MAX"`.
+        //   1b. `current_worst_txid()` returns a txid that does NOT
+        //       resolve to a live `txs` entry → second MAP-vs-HEAP
+        //       corruption invariant: heap pointed at a stale txid the
+        //       map no longer has. Surfaced as
+        //       `"tx pool capacity invariant violated: worst_heap entry missing from txs map"`.
+        //   2.  `compare_admit_priority` reports candidate is NOT
+        //       strictly greater than worst → routine eviction-ordering
+        //       rejection matching Go's
+        //       `"mempool capacity candidate rejected by eviction ordering"`
+        //       at clients/go/node/mempool.go:1028-1030 verbatim.
         if self.txs.len() >= MAX_TX_POOL_TRANSACTIONS {
             let Some(worst_txid) = self.current_worst_txid() else {
                 return Err(unavailable(
@@ -521,9 +524,6 @@ pub(crate) fn relay_metadata(
         return Err(rejected("transaction rejected: non-canonical tx bytes"));
     }
 
-    let (weight, _, _) = tx_weight_and_stats_public(&tx)
-        .map_err(|err| rejected(format!("transaction rejected: {err}")))?;
-
     let next_height = next_block_height(chain_state)?;
     let block_mtp = next_block_mtp(block_store, next_height)?;
     let active_profiles = cfg
@@ -580,6 +580,8 @@ pub(crate) fn relay_metadata(
     //   - DA tx fee >= DA-required, fee/weight < rolling floor → Unavailable
     //   - DA tx fee >= both → Ok (relay metadata returned)
     // mirroring `admit_with_metadata`.
+    let (weight, _, _) = tx_weight_and_stats_public(&tx)
+        .map_err(|err| rejected(format!("transaction rejected: {err}")))?;
     validate_fee_floor(summary.fee, weight, cfg.policy_current_mempool_min_fee_rate)?;
 
     Ok(RelayTxMetadata {

--- a/clients/rust/crates/rubin-node/src/txpool.rs
+++ b/clients/rust/crates/rubin-node/src/txpool.rs
@@ -2060,16 +2060,20 @@ mod tests {
         //     pool-full / capacity branches.
         //   - reachability: test's goal is the header_lookup failure
         //     path (block_store.get_header_by_hash → Err propagated
-        //     as Unavailable). Need a floor-compliant tx + matching
-        //     state with has_tip=true / height=0 + canonical tip at a
-        //     hash whose header is NOT in the block_store. (header
-        //     lookup happens inside next_block_mtp BEFORE apply_policy
-        //     → BEFORE the post-apply floor check, so a floor-compliant
-        //     fixture is required to reach the header path.)
-        //   - replacement coverage: build a floor-compliant signed
-        //     P2PK tx (input=7700) inline and use chain_state with the
-        //     same has_tip=true / height=0 setup as the original; the
-        //     header_lookup-failure invariant remains under test.
+        //     as Unavailable). header_lookup happens inside
+        //     next_block_mtp which runs BEFORE both apply_policy and
+        //     validate_fee_floor_locked, so floor-compliance is NOT a
+        //     reachability requirement for this branch — any well-formed
+        //     tx with chain_state has_tip=true / height=0 and a
+        //     canonical tip whose header is missing from the
+        //     block_store reaches the header_lookup branch.
+        //   - replacement coverage: build a signed P2PK tx (input=7700)
+        //     inline with chain_state has_tip=true / height=0; the
+        //     input value is left at 7700 only for consistency with the
+        //     general RUB-162 floor-compliant fixture policy across the
+        //     test module (harmless here because reachability does not
+        //     depend on it). The header_lookup-failure invariant remains
+        //     under test.
         let (mut state, raw) = signed_p2pk_state_and_tx(
             7700,
             vec![TxOutput {

--- a/clients/rust/crates/rubin-node/src/txpool.rs
+++ b/clients/rust/crates/rubin-node/src/txpool.rs
@@ -4,7 +4,7 @@ use std::collections::{BinaryHeap, HashMap, HashSet};
 use rubin_consensus::{
     apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles_and_suite_context,
     parse_block_header_bytes, parse_core_ext_covenant_data, parse_tx, tx_weight_and_stats_public,
-    CoreExtDeploymentProfiles, Outpoint, RotationProvider, SuiteRegistry, Tx, UtxoEntry,
+    CoreExtDeploymentProfiles, Outpoint, RotationProvider, SuiteRegistry,
 };
 
 use crate::sync::SuiteContext;
@@ -260,31 +260,6 @@ impl TxPool {
         let (weight, _, _) = tx_weight_and_stats_public(&tx)
             .map_err(|err| rejected(format!("transaction rejected: {err}")))?;
 
-        let mut prevalidated_evict: Option<[u8; 32]> = None;
-        if self.txs.len() >= MAX_TX_POOL_TRANSACTIONS {
-            let Some(worst_txid) = self.current_worst_txid() else {
-                return Err(unavailable("tx pool full"));
-            };
-            let Some(worst_entry) = self.txs.get(&worst_txid) else {
-                return Err(unavailable("tx pool full"));
-            };
-            if let Some(candidate_fee) = estimate_tx_fee(&tx, &chain_state.utxos) {
-                let candidate = TxPoolEntry {
-                    raw: Vec::new(),
-                    inputs: Vec::new(),
-                    fee: candidate_fee,
-                    weight,
-                    size: tx_bytes.len(),
-                };
-                if compare_admit_priority(txid, &candidate, worst_txid, worst_entry)
-                    != Ordering::Greater
-                {
-                    return Err(unavailable("tx pool full"));
-                }
-                prevalidated_evict = Some(worst_txid);
-            }
-        }
-
         let next_height = next_block_height(chain_state)?;
         let block_mtp = next_block_mtp(block_store, next_height)?;
         let active_profiles = self
@@ -311,7 +286,27 @@ impl TxPool {
                 registry,
             )
             .map_err(|err| rejected(format!("transaction rejected: {err}")))?;
-        apply_policy(&tx, &chain_state.utxos, next_height, &self.cfg).map_err(rejected)?;
+        // RUB-162 P1 #4 — DA error class ordering parity with Go
+        // `applyPolicyAgainstState` (clients/go/node/mempool.go:798-833):
+        // the mempool admit path passes `currentMempoolMinFeeRate=0` to the
+        // DA helper so that `max(relay_fee_floor, da_required_fee)` collapses
+        // to `da_required_fee`, leaving DA-side classification intact while
+        // delegating rolling relay-fee floor classification to a separate
+        // `validate_fee_floor_locked` call below that returns the symmetric
+        // `Unavailable` (transient/retryable) outcome non-DA tx receive. The
+        // miner caller (`reject_candidate`) keeps the live floor in its own
+        // policy_cfg construction because it has no `validate_fee_floor_locked`
+        // equivalent — the template needs to skip a tx whenever it fails any
+        // floor.
+        let mut policy_cfg = self.cfg.clone();
+        policy_cfg.policy_current_mempool_min_fee_rate = 0;
+        apply_policy(&tx, &chain_state.utxos, next_height, &policy_cfg).map_err(rejected)?;
+        // Rolling relay-floor classification: returns `Unavailable` so the
+        // failure class matches what non-DA tx receive (Go
+        // `validateFeeFloorLocked` clients/go/node/mempool.go:957-967) and
+        // so callers can back off rather than treating the rejection as
+        // terminal.
+        self.validate_fee_floor_locked(summary.fee, weight)?;
 
         let entry = TxPoolEntry {
             raw: tx_bytes.to_vec(),
@@ -321,23 +316,22 @@ impl TxPool {
             size: tx_bytes.len(),
         };
 
+        // Go-parity capacity admission (`capacityEvictionPlanLocked`,
+        // clients/go/node/mempool.go:1024) — runs AFTER both
+        // `apply_policy` and the rolling relay-fee floor check above, so
+        // sub-floor / DA-rejected transactions never reach this branch
+        // and the worst-entry comparison only considers floor-compliant
+        // candidates.
         if self.txs.len() >= MAX_TX_POOL_TRANSACTIONS {
-            let worst_txid = if let Some(worst_txid) = prevalidated_evict {
-                worst_txid
-            } else {
-                let Some(worst_txid) = self.current_worst_txid() else {
-                    return Err(unavailable("tx pool full"));
-                };
-                let Some(worst_entry) = self.txs.get(&worst_txid) else {
-                    return Err(unavailable("tx pool full"));
-                };
-                if compare_admit_priority(txid, &entry, worst_txid, worst_entry)
-                    != Ordering::Greater
-                {
-                    return Err(unavailable("tx pool full"));
-                }
-                worst_txid
+            let Some(worst_txid) = self.current_worst_txid() else {
+                return Err(unavailable("tx pool full"));
             };
+            let Some(worst_entry) = self.txs.get(&worst_txid) else {
+                return Err(unavailable("tx pool full"));
+            };
+            if compare_admit_priority(txid, &entry, worst_txid, worst_entry) != Ordering::Greater {
+                return Err(unavailable("tx pool full"));
+            }
             self.remove_entry(&worst_txid);
         }
 
@@ -418,6 +412,42 @@ impl TxPool {
             }
         }
         self.compact_worst_heap_if_needed();
+    }
+
+    /// Rejects entries whose fee/weight rate is below the rolling minimum
+    /// fee rate. Mirrors Go `validateFeeFloorLocked`
+    /// (clients/go/node/mempool.go:957-967). Returns `Unavailable`
+    /// (transient/retryable) so callers can back off rather than treating
+    /// the relay-floor rejection as terminal. This is the Phase A fix for
+    /// the RUB-162 / hostile RESP P1 #4 finding: relay-floor rejection is
+    /// classified separately from DA-side rejection. The corresponding Go
+    /// source path is documented above (clients/go/node/mempool.go:957-967).
+    ///
+    /// Reads the live floor from `cfg.policy_current_mempool_min_fee_rate`.
+    /// Production callers using `TxPool::admit` / `admit_with_metadata` go
+    /// through this check after `apply_policy` so the rolling floor is
+    /// enforced independent of the DA helper. The miner template caller
+    /// (`miner::reject_candidate`) keeps its own floor handling because it
+    /// has no `validate_fee_floor_locked` equivalent — see
+    /// `clients/go/node/mempool.go:815-818`.
+    fn validate_fee_floor_locked(&self, fee: u64, weight: u64) -> Result<(), TxPoolAdmitError> {
+        // Mirrors Go validateFeeFloorLocked
+        // (clients/go/node/mempool.go:957-967). The
+        // DEFAULT_MEMPOOL_MIN_FEE_RATE clamp lives inside
+        // fee_rate_below_floor itself (Go-parity at
+        // clients/go/node/mempool.go:1425-1427); this caller passes the
+        // cfg field as-is. The error message surfaces the post-clamp
+        // value for operator clarity by recomputing the same .max()
+        // locally so the message stays consistent with the predicate's
+        // actual decision basis.
+        let cfg_floor = self.cfg.policy_current_mempool_min_fee_rate;
+        if fee_rate_below_floor(fee, weight, cfg_floor) {
+            let surfaced_floor = cfg_floor.max(DEFAULT_MEMPOOL_MIN_FEE_RATE);
+            return Err(unavailable(format!(
+                "mempool fee below rolling minimum: fee={fee} weight={weight} min_fee_rate={surfaced_floor}"
+            )));
+        }
+        Ok(())
     }
 
     fn seed_worst_heap(&mut self) {
@@ -508,7 +538,23 @@ pub(crate) fn relay_metadata(
             registry,
         )
         .map_err(|err| rejected(format!("transaction rejected: {err}")))?;
-    apply_policy(&tx, &chain_state.utxos, next_height, cfg).map_err(rejected)?;
+    // RUB-162 P1 #1 — DA error class ordering parity for the relay
+    // metadata path. Go `RelayMetadata` routes through
+    // `checkParsedTransactionWithSnapshot` -> `applyPolicyAgainstState`
+    // (clients/go/node/mempool.go:472-495 -> 785-853), and
+    // `applyPolicyAgainstState` always passes
+    // `currentMempoolMinFeeRate=0` to `RejectDaAnchorTxPolicy` at
+    // clients/go/node/mempool.go:823. Without the same zero override, a DA tx that pays
+    // the DA-side floor but is below the rolling relay floor surfaces
+    // here as `Rejected("DA fee below Stage C floor ... relay_fee_floor=...")`
+    // diverging from Go's relay-metadata contract. The relay path does
+    // NOT enforce the rolling relay floor (Go RelayMetadata extracts
+    // metadata after the policy helper has enforced only DA-side
+    // terms), so we do not call `validate_fee_floor_locked` here — only
+    // the DA-helper invocation gets the cfg-zero override.
+    let mut policy_cfg = cfg.clone();
+    policy_cfg.policy_current_mempool_min_fee_rate = 0;
+    apply_policy(&tx, &chain_state.utxos, next_height, &policy_cfg).map_err(rejected)?;
 
     Ok(RelayTxMetadata {
         fee: summary.fee,
@@ -617,6 +663,31 @@ fn unavailable(message: impl Into<String>) -> TxPoolAdmitError {
         kind: TxPoolAdmitErrorKind::Unavailable,
         message: message.into(),
     }
+}
+
+/// Returns true if `fee` is below the rolling fee floor for `weight`.
+/// Mirrors Go `feeRateBelowFloor` (clients/go/node/mempool.go:1421-1434)
+/// using full-precision u128 cross-multiplication (`fee < weight * floor`).
+/// u128 holds any `u64 * u64` product losslessly, so the comparison is
+/// well-defined at every input including `weight == u64::MAX` and
+/// `floor == u64::MAX`.
+///
+/// Zero weight returns true: `validateFeeFloorLocked` callers treat
+/// `weight == 0` as an uncomputable rate ("treat as below floor"),
+/// matching Go's documented branch.
+///
+/// Floor argument is clamped up to `DEFAULT_MEMPOOL_MIN_FEE_RATE` if
+/// smaller, mirroring Go `feeRateBelowFloor`'s in-helper clamp at
+/// clients/go/node/mempool.go:1425-1427. Callers therefore always
+/// receive at-least-DEFAULT enforcement even if cfg-static or
+/// rolling-floor sources zero the field.
+fn fee_rate_below_floor(fee: u64, weight: u64, floor: u64) -> bool {
+    if weight == 0 {
+        return true;
+    }
+    let floor = floor.max(DEFAULT_MEMPOOL_MIN_FEE_RATE);
+    let required = (weight as u128) * (floor as u128);
+    (fee as u128) < required
 }
 
 pub(crate) fn apply_policy(
@@ -731,11 +802,16 @@ pub(crate) fn reject_da_anchor_tx_policy(
     if da_bytes == 0 {
         // Non-DA transaction: the helper only enforces the DA half of the
         // Stage C admission contract. Non-DA relay-fee floor enforcement
-        // is outside this helper and is the responsibility of a separate
-        // Rust standard mempool admission path (tracked as RUB-53);
-        // Rust does not yet ship a `validateFeeFloorLocked` analogue. The
-        // helper deliberately short-circuits here and does not compute fee
-        // or apply any DA-specific term to non-DA transactions.
+        // is now performed by `TxPool::validate_fee_floor_locked` (defined
+        // below), invoked from `TxPool::admit_with_metadata` AFTER this
+        // helper's `apply_policy` returns Ok — mirroring Go's
+        // `validateCapacityAdmissionLocked` calling `validateFeeFloorLocked`
+        // at clients/go/node/mempool.go:1018-1024. Both `admit_with_metadata`
+        // and `relay_metadata` zero-out the rolling floor before invoking
+        // this helper so the DA-side classification is preserved without
+        // double-charging the relay floor inside the DA helper. The helper
+        // deliberately short-circuits here for non-DA transactions and does
+        // not compute fee or apply any DA-specific term.
         return Ok(());
     }
     let relay_floor = weight.checked_mul(current_mempool_min_fee_rate).ok_or_else(|| {
@@ -918,25 +994,6 @@ fn compare_fee_rate(a: &TxPoolEntry, b: &TxPoolEntry) -> Ordering {
     compare_fee_rate_values(a.fee, a.weight, b.fee, b.weight)
 }
 
-fn estimate_tx_fee(tx: &Tx, utxos: &HashMap<Outpoint, UtxoEntry>) -> Option<u64> {
-    let mut total_in = 0u128;
-    for input in &tx.inputs {
-        let entry = utxos.get(&Outpoint {
-            txid: input.prev_txid,
-            vout: input.prev_vout,
-        })?;
-        total_in = total_in.checked_add(entry.value as u128)?;
-    }
-
-    let mut total_out = 0u128;
-    for output in &tx.outputs {
-        total_out = total_out.checked_add(output.value as u128)?;
-    }
-
-    let fee = total_in.checked_sub(total_out)?;
-    u64::try_from(fee).ok()
-}
-
 fn compare_fee_rate_values(fee_a: u64, weight_a: u64, fee_b: u64, weight_b: u64) -> Ordering {
     if weight_a == 0 || weight_b == 0 {
         return Ordering::Equal;
@@ -968,7 +1025,8 @@ mod tests {
         compare_admit_priority, compare_entries_for_mining, compare_fee_rate, conflict, mtp_median,
         next_block_height, next_block_mtp, reject_core_ext_tx_oversized_payload,
         reject_da_anchor_tx_policy, rejected, relay_metadata, unavailable, TxPool,
-        TxPoolAdmitErrorKind, TxPoolConfig, TxPoolEntry, MAX_TX_POOL_TRANSACTIONS,
+        TxPoolAdmitErrorKind, TxPoolConfig, TxPoolEntry, DEFAULT_MEMPOOL_MIN_FEE_RATE,
+        MAX_TX_POOL_TRANSACTIONS,
     };
     use crate::{
         block_store_path, default_sync_config, devnet_genesis_block_bytes, devnet_genesis_chain_id,
@@ -1232,36 +1290,53 @@ mod tests {
     }
 
     #[test]
-    fn admit_accepts_valid_conformance_tx() {
+    fn admit_rejects_sub_floor_conformance_tx_as_unavailable_with_atomicity() {
+        // RUB-162 Phase A migration rationale (per controller Q2 record):
+        //   - old assumption: TxPool::new() admits the canonical conformance
+        //     tx; pre-RUB-162 admit_with_metadata did not enforce the rolling
+        //     fee floor as a separate Unavailable classifier.
+        //   - new invariant: admit_with_metadata classifies relay-floor
+        //     failure as Unavailable via validate_fee_floor_locked (mirrors
+        //     Go validateFeeFloorLocked). The conformance fixture has fee=10
+        //     weight=7653 (fee_rate ≈ 0.0013, far below DEFAULT=1) and the
+        //     floor cannot be lowered via cfg because validate_fee_floor_locked
+        //     clamps to DEFAULT (Go parity).
+        //   - why it reaches policy path: tx is well-formed; floor check is
+        //     after apply_policy.
+        //   - replacement coverage: this test now asserts Unavailable
+        //     directly (the new correct behaviour); the floor-compliant
+        //     index-population smoke equivalent lives in
+        //     `rub162_admit_da_above_both_floors_admits_with_indexes`,
+        //     which exercises the same `insert_entry` + `spenders` /
+        //     `heap_seqs` population path under a fee-floor-compliant
+        //     DA fixture. The conformance fixture itself (RUB-54 scope)
+        //     is unchanged; only the in-test pool config is adapted.
         let vector = positive_fixture_vector();
         assert!(vector.expect_ok, "{} should be positive fixture", vector.id);
         let raw = hex::decode(&vector.tx_hex).expect("tx hex");
-        let (tx, txid, _wtxid, consumed) = parse_tx(&raw).expect("parse tx");
+        let (_tx, _txid, _wtxid, consumed) = parse_tx(&raw).expect("parse tx");
         assert_eq!(consumed, raw.len(), "{}", vector.id);
 
         let state = chain_state_from_positive_fixture(&vector);
         let mut pool = TxPool::new();
-        let admitted = pool
+        let err = pool
             .admit(
                 &raw,
                 &state,
                 None,
                 fixture_chain_id(vector.chain_id.as_deref()),
             )
-            .expect("admit valid tx");
+            .expect_err("conformance fixture has fee_rate well below DEFAULT_MEMPOOL_MIN_FEE_RATE");
+        assert_eq!(err.kind, TxPoolAdmitErrorKind::Unavailable);
+        assert!(err.message.contains("mempool fee below rolling minimum"));
 
-        assert_eq!(admitted, txid);
-        assert_eq!(pool.len(), 1);
-        let entry = pool.txs.get(&txid).expect("pool entry");
-        assert_eq!(entry.raw, raw);
-        assert_eq!(entry.inputs.len(), tx.inputs.len());
-        for input in &tx.inputs {
-            let outpoint = Outpoint {
-                txid: input.prev_txid,
-                vout: input.prev_vout,
-            };
-            assert_eq!(pool.spenders.get(&outpoint), Some(&txid));
-        }
+        // Proof assertion: pool.len(), pool.spenders.is_empty(), and
+        // pool.heap_seqs.len() pin the post-Err pool state to its pre-call
+        // baseline (0 / empty / 0); any partial insert by admit_with_metadata
+        // would surface as a non-zero mismatch on one of these three checks.
+        assert_eq!(pool.len(), 0, "no entry inserted on Unavailable");
+        assert!(pool.spenders.is_empty(), "no spenders inserted on Err");
+        assert_eq!(pool.heap_seqs.len(), 0, "no heap state on Err");
     }
 
     #[test]
@@ -1399,8 +1474,26 @@ mod tests {
 
     #[test]
     fn admit_rejects_pool_full() {
+        // RUB-162 Phase A migration rationale (per controller Path A
+        // approval 2026-05-03 + RESP P1 #2 reorder fix 2026-05-03):
+        //   - old assumption: input=10/output=10 → fee=0 candidate
+        //     reaches the pool-full ordering check and admit returns
+        //     Unavailable("tx pool full") because the pre-RUB-162
+        //     admit_with_metadata had no rolling-floor classification.
+        //   - new invariant: validate_fee_floor_locked runs BEFORE the
+        //     pool-full check (Go validateCapacityAdmissionLocked order
+        //     at clients/go/node/mempool.go:1020-1024). Sub-floor
+        //     candidates fail the floor check first.
+        //   - reachability: tx is well-formed; the pool-full ordering
+        //     branch is the test goal.
+        //   - replacement coverage: input bumped to 7700 so fee=7690 ≥
+        //     weight (~7653) ⇒ candidate passes floor and reaches the
+        //     pool-full ordering check this test is asserting. A
+        //     dedicated rub162_admit_full_pool_below_floor_returns_floor_
+        //     error_not_pool_full test below pins the new ordering for
+        //     sub-floor candidates.
         let (state, raw) = signed_p2pk_state_and_tx(
-            10,
+            7700,
             vec![TxOutput {
                 value: 10,
                 covenant_type: COV_TYPE_P2PK,
@@ -1420,12 +1513,15 @@ mod tests {
             if key == txid {
                 key[8] = 1;
             }
+            // Worst-pool entries sized to outrank candidate fee_rate so
+            // pool-full ordering rejects (worst fee_rate=10 > candidate
+            // fee_rate≈1.005, candidate cannot beat worst).
             pool.txs.insert(
                 key,
                 TxPoolEntry {
                     raw: vec![0xff],
                     inputs: Vec::new(),
-                    fee: 1,
+                    fee: 10,
                     weight: 1,
                     size: 1,
                 },
@@ -1438,8 +1534,22 @@ mod tests {
 
     #[test]
     fn admit_evicts_lowest_priority_when_pool_full() {
+        // RUB-162 Phase A migration rationale (per controller Q2 record):
+        //   - old assumption: input=10/output=8 → fee=2 with weight≈7653
+        //     admits because pre-RUB-162 admit_with_metadata didn't enforce
+        //     the rolling fee floor; the test exercised eviction-ordering.
+        //   - new invariant: admit_with_metadata enforces the rolling fee
+        //     floor (DEFAULT_MEMPOOL_MIN_FEE_RATE=1) via
+        //     validate_fee_floor_locked → Unavailable when fee/weight < 1.
+        //   - why it reaches policy path: tx is well-formed; floor check
+        //     is after apply_policy, before eviction.
+        //   - replacement coverage: input bumped to 7661 so fee = 7661 - 8
+        //     = 7653 ≥ weight (≈7653) ⇒ fee/weight ≥ 1 ⇒ passes the
+        //     default floor; eviction-ordering invariant remains under test.
+        //     Cfg-zero opt-out is impossible because the floor is clamped
+        //     to DEFAULT inside validate_fee_floor_locked (Go parity).
         let (state, raw) = signed_p2pk_state_and_tx(
-            10,
+            7661,
             vec![TxOutput {
                 value: 8,
                 covenant_type: COV_TYPE_P2PK,
@@ -1493,8 +1603,26 @@ mod tests {
 
     #[test]
     fn admit_reject_on_full_preserves_future_eviction() {
+        // RUB-162 Phase A migration rationale (per controller Q2 record):
+        //   - old assumption: pre-RUB-162 admit_with_metadata did not enforce
+        //     the rolling fee floor; the test exercised heap-state
+        //     preservation across reject + admit cycle.
+        //   - new invariant: admit_with_metadata enforces the rolling fee
+        //     floor via validate_fee_floor_locked → Unavailable.
+        //   - why it reaches policy path: txs are well-formed; floor check
+        //     is after apply_policy.
+        //   - replacement coverage: input_value bumped to make fee_rate ≥ 1
+        //     so both candidates pass the floor. The "worse" candidate now
+        //     has fee=7652, the "better" has fee=8000. Pool worst entry
+        //     bumped to fee_rate ≈ 0.9 so worse-candidate fee_rate (~1.0)
+        //     beats it but only marginally — preserves the test's intended
+        //     eviction-ordering interaction. Heap-state preservation
+        //     invariant (P1 #2 atomicity-related) remains under test.
+        // Better candidate: fee = 20000 - 8 = 19992; weight ≈ 7653 (ML-DSA
+        // witness) → fee_rate ≈ 2.61. Above floor; should beat worst pool
+        // entry (fee_rate = 2.0).
         let (state_better, raw_better) = signed_p2pk_state_and_tx(
-            10,
+            20_000,
             vec![TxOutput {
                 value: 8,
                 covenant_type: COV_TYPE_P2PK,
@@ -1504,8 +1632,12 @@ mod tests {
             None,
             Vec::new(),
         );
+        // Worse candidate: fee = 7662 - 9 = 7653; weight ≈ 7653 → fee_rate
+        // = 1.0. Above floor (passes validate_fee_floor_locked) but below
+        // worst pool entry's fee_rate (2.0); pool-full eviction comparator
+        // rejects with Unavailable.
         let (state_worse, raw_worse) = signed_p2pk_state_and_tx(
-            10,
+            7_662,
             vec![TxOutput {
                 value: 9,
                 covenant_type: COV_TYPE_P2PK,
@@ -1518,12 +1650,17 @@ mod tests {
 
         let mut pool = TxPool::new();
         let worst = [0x11; 32];
+        // Worst pool entry: fee_rate = 20000/10000 = 2.0. Above the default
+        // rolling floor (1) so the eviction-ordering test exercises the
+        // comparator branch that compares "worse candidate at floor" vs
+        // "above-floor resident worst". Inserted directly via pool.txs to
+        // bypass admit_with_metadata's floor check.
         pool.txs.insert(
             worst,
             TxPoolEntry {
                 raw: vec![0x01; raw_worse.len()],
                 inputs: Vec::new(),
-                fee: 2,
+                fee: 20_000,
                 weight: 10_000,
                 size: raw_worse.len(),
             },
@@ -1688,7 +1825,23 @@ mod tests {
 
     #[test]
     fn remove_conflicting_inputs_evicts_conflicting_mempool_entries() {
-        let (state, admitted_raw, block_raw) = signed_conflicting_p2pk_state_and_txs(20, 10, 9);
+        // RUB-162 Phase A migration rationale (per controller Q2 record,
+        // Path A approval 2026-05-03):
+        //   - old assumption: input=20 / first_output=10 → fee=10 with
+        //     weight ≈ 7653 admits because pre-RUB-162 admit_with_metadata
+        //     did not enforce the rolling fee floor on non-DA txs.
+        //   - new invariant: admit_with_metadata enforces the rolling fee
+        //     floor (DEFAULT_MEMPOOL_MIN_FEE_RATE=1) for every admission
+        //     via validate_fee_floor_locked.
+        //   - reachability: tx is well-formed (parses, basic checks pass);
+        //     floor check is after apply_policy. Original test goal is to
+        //     exercise remove_conflicting_inputs via a previously-admitted
+        //     tx + a block tx that double-spends the same input.
+        //   - replacement coverage: input bumped to 7700 so the admitted
+        //     tx fee = 7700 - 10 = 7690 ≥ weight (≈7653); the block tx
+        //     fee = 7700 - 9 = 7691 also above floor. Original conflict
+        //     scenario preserved.
+        let (state, admitted_raw, block_raw) = signed_conflicting_p2pk_state_and_txs(7700, 10, 9);
         let mut pool = TxPool::new();
         let admitted_txid = pool
             .admit(&admitted_raw, &state, None, devnet_genesis_chain_id())
@@ -1890,9 +2043,44 @@ mod tests {
 
     #[test]
     fn admit_reports_unavailable_when_header_lookup_fails() {
-        let vector = positive_fixture_vector();
-        let raw = hex::decode(&vector.tx_hex).expect("tx hex");
-        let mut state = chain_state_from_positive_fixture(&vector);
+        // RUB-162 Phase A migration rationale (per controller Path A
+        // approval 2026-05-03 + RESP P1 #2 reorder fix 2026-05-03):
+        //   - old assumption: positive_fixture_vector tx (fee=10/weight=
+        //     7653) reaches next_block_mtp -> get_header_by_hash which
+        //     fails with "read header"; pre-RUB-162 admit_with_metadata
+        //     did not enforce the rolling fee floor at all.
+        //   - new invariant: validate_fee_floor_locked runs AFTER
+        //     apply_policy as the post-apply Go-parity placement
+        //     (mirrors clients/go/node/mempool.go:1020-1024
+        //     validateCapacityAdmissionLocked called from
+        //     addToMempoolLocked AFTER applyPolicyAgainstState). The
+        //     conformance fixture is sub-floor so admit returns
+        //     Unavailable("mempool fee below rolling minimum") AFTER
+        //     apply_policy succeeds but BEFORE reaching the post-apply
+        //     pool-full / capacity branches.
+        //   - reachability: test's goal is the header_lookup failure
+        //     path (block_store.get_header_by_hash → Err propagated
+        //     as Unavailable). Need a floor-compliant tx + matching
+        //     state with has_tip=true / height=0 + canonical tip at a
+        //     hash whose header is NOT in the block_store. (header
+        //     lookup happens inside next_block_mtp BEFORE apply_policy
+        //     → BEFORE the post-apply floor check, so a floor-compliant
+        //     fixture is required to reach the header path.)
+        //   - replacement coverage: build a floor-compliant signed
+        //     P2PK tx (input=7700) inline and use chain_state with the
+        //     same has_tip=true / height=0 setup as the original; the
+        //     header_lookup-failure invariant remains under test.
+        let (mut state, raw) = signed_p2pk_state_and_tx(
+            7700,
+            vec![TxOutput {
+                value: 10,
+                covenant_type: COV_TYPE_P2PK,
+                covenant_data: p2pk_covenant_data_for_pubkey(&vec![0x99; 2592]),
+            }],
+            0x00,
+            None,
+            Vec::new(),
+        );
         state.has_tip = true;
         state.height = 0;
 
@@ -1902,12 +2090,7 @@ mod tests {
             .expect("set canonical tip");
 
         let err = TxPool::new()
-            .admit(
-                &raw,
-                &state,
-                Some(&store),
-                fixture_chain_id(vector.chain_id.as_deref()),
-            )
+            .admit(&raw, &state, Some(&store), [0u8; 32])
             .unwrap_err();
         assert_eq!(err.kind, TxPoolAdmitErrorKind::Unavailable);
         assert!(err.message.contains("read header"));
@@ -1926,8 +2109,32 @@ mod tests {
 
     #[test]
     fn admit_rejects_non_coinbase_anchor_outputs_by_policy() {
+        // RUB-162 Phase A migration rationale (per controller Path A
+        // approval 2026-05-03 + RESP P1 #2 reorder fix 2026-05-03):
+        //   - old assumption: input=10, sum-outputs=9 → fee=1 reaches
+        //     the anchor-output policy guard which returns Rejected.
+        //   - new invariant: apply_policy (which evaluates the
+        //     anchor-output policy) precedes the rolling-floor check
+        //     in admit_with_metadata; mirrors Go addToMempoolLocked
+        //     calling applyPolicyAgainstState then
+        //     validateCapacityAdmissionLocked → validateFeeFloorLocked
+        //     at clients/go/node/mempool.go:798-1024.
+        //   - Proof assertion: `assert_eq!(err.kind, Rejected)` plus
+        //     `err.message.contains("CORE_ANCHOR")` below pin the class
+        //     winner against the alternative `Unavailable("mempool fee
+        //     below rolling minimum")` outcome.
+        //   - reachability: tx is well-formed; the anchor-output
+        //     policy guard is the test goal. fee/weight headroom is
+        //     defensive (apply_policy rejects regardless), but kept
+        //     for parity with the cross-pollination matrix below.
+        //   - replacement coverage: input bumped to 20000 so
+        //     fee = 20000 - 9 = 19991 ≥ weight ⇒ candidate passes
+        //     floor (the two-output tx with anchor + p2pk has a
+        //     larger weight than single-output P2PK because of the
+        //     anchor covenant + p2pk witness; 20000 covers it with
+        //     headroom) and reaches the anchor-output policy guard.
         let (state, raw) = signed_p2pk_state_and_tx(
-            10,
+            20_000,
             vec![
                 TxOutput {
                     value: 0,
@@ -1953,12 +2160,31 @@ mod tests {
 
     #[test]
     fn admit_rejects_da_tx_below_policy_stage_c_floor() {
-        // Stage C: required_fee = max(relay_fee_floor, da_fee_floor + da_surcharge).
-        // With cfg defaults (current_mempool_min_fee_rate=1, min_da_fee_rate=1) and
-        // surcharge=1, the fee=1 (input=10, output=9) is below required, so admission
-        // rejects with the Stage C error message that names every term.
+        // RUB-162 Phase A migration rationale (per controller Path A
+        // approval 2026-05-03 + RESP P1 #2 reorder fix 2026-05-03):
+        //   - old assumption: input=10/output=9 fee=1, weight≈7653
+        //     → reaches DA-helper which returns Rejected because
+        //     fee < relay-floor-or-DA-required (whichever was higher).
+        //   - new invariant: apply_policy (containing the DA helper
+        //     with cfg-zero override) runs BEFORE
+        //     validate_fee_floor_locked. With cfg-zero the DA helper
+        //     checks fee >= max(0, da_required) = da_required, leaving
+        //     DA-side classification intact while the rolling relay
+        //     floor is enforced separately AFTER apply_policy. To pin
+        //     the DA-helper Stage C rejection path, fee must be
+        //     < DA-required so apply_policy rejects with Rejected.
+        //   - replacement coverage: input bumped to 8000 + fee=7991;
+        //     weight≈7653; surcharge bumped to 200 so DA-required ≈
+        //     da_bytes(70)*200 = 14000 > fee → DA-helper rejects with
+        //     the canonical Stage C error message + named-term debug
+        //     fields. The fee/weight headroom (≈1.04 ≥ default floor)
+        //     is defensive — apply_policy rejects regardless, but the
+        //     headroom keeps the fixture meaningful for the
+        //     cross-pollination ordering matrix below. The test's
+        //     purpose (verifying Stage C error message includes all
+        //     named debug fields) remains under test.
         let (state, raw) = signed_p2pk_state_and_tx(
-            10,
+            8000,
             vec![TxOutput {
                 value: 9,
                 covenant_type: COV_TYPE_P2PK,
@@ -1973,7 +2199,7 @@ mod tests {
             vec![0x77; 64],
         );
         let mut pool = TxPool::new_with_config(TxPoolConfig::default());
-        pool.cfg.policy_da_surcharge_per_byte = 1;
+        pool.cfg.policy_da_surcharge_per_byte = 200;
         let err = pool.admit(&raw, &state, None, [0u8; 32]).unwrap_err();
         assert_eq!(err.kind, TxPoolAdmitErrorKind::Rejected);
         assert!(
@@ -1994,8 +2220,27 @@ mod tests {
 
     #[test]
     fn admit_rejects_core_ext_output_pre_activation_by_policy() {
+        // RUB-162 Phase A migration rationale (per controller Path A
+        // approval 2026-05-03 + RESP P1 #2 reorder fix 2026-05-03):
+        //   - old assumption: input=10/output=9 fee=1 reached the
+        //     CORE_EXT pre-activation policy guard returning Rejected.
+        //   - new invariant: apply_policy (which evaluates the
+        //     CORE_EXT pre-activation policy) precedes the rolling-floor
+        //     check in admit_with_metadata.
+        //   - Proof assertion: `assert_eq!(err.kind, Rejected)` plus
+        //     `err.message.contains("CORE_EXT output pre-ACTIVE")`
+        //     below pin the class winner against the alternative
+        //     `Unavailable("mempool fee below rolling minimum")`
+        //     outcome.
+        //   - replacement coverage: input bumped to 7700 so fee=7691
+        //     ≥ weight ⇒ candidate also passes the floor (defensive,
+        //     since apply_policy rejects regardless) and reaches the
+        //     CORE_EXT pre-activation policy guard. The fixture is
+        //     mirrored in
+        //     rub162_admit_sub_floor_core_ext_classifies_as_core_ext_rejected
+        //     to PIN the cross-pollination class winner.
         let (state, raw) = signed_p2pk_state_and_tx(
-            10,
+            7700,
             vec![TxOutput {
                 value: 9,
                 covenant_type: COV_TYPE_EXT,
@@ -2014,8 +2259,21 @@ mod tests {
 
     #[test]
     fn admit_allows_core_ext_output_when_profile_is_active() {
+        // RUB-162 Phase A migration rationale (per controller Q2 record):
+        //   - old assumption: input=10/output=9 → fee=1 with weight≈7533
+        //     admits once core_ext profile is registered (pre-RUB-162 had no
+        //     fee-floor check).
+        //   - new invariant: admit_with_metadata enforces the rolling fee
+        //     floor (DEFAULT_MEMPOOL_MIN_FEE_RATE=1).
+        //   - why it reaches policy path: tx is well-formed; floor check is
+        //     after apply_policy and after the CORE_EXT pre-activation check
+        //     succeeds for the registered profile.
+        //   - replacement coverage: input bumped to 7542 so fee = 7542 - 9
+        //     = 7533 ≥ weight (≈7533) ⇒ fee/weight ≥ 1 ⇒ passes the
+        //     default floor; the test's CORE_EXT-profile-activation
+        //     invariant remains under test.
         let (state, raw) = signed_p2pk_state_and_tx(
-            10,
+            7_542,
             vec![TxOutput {
                 value: 9,
                 covenant_type: COV_TYPE_EXT,
@@ -2045,7 +2303,30 @@ mod tests {
 
     #[test]
     fn admit_rejects_core_ext_spend_pre_activation_by_policy() {
-        let (state, raw) = core_ext_spend_state_and_tx(9);
+        // RUB-162 Phase A migration rationale (per controller Path A
+        // approval 2026-05-03 + RESP P1 #2 reorder fix 2026-05-03):
+        //   - old assumption: core_ext_spend_state_and_tx helper sets
+        //     UTXO value=10/output value=9 → fee=1 reaches the
+        //     CORE_EXT-spend pre-activation policy guard.
+        //   - new invariant: apply_policy (which evaluates the
+        //     CORE_EXT spend pre-activation policy) precedes the
+        //     rolling-floor check in admit_with_metadata. Headroom is
+        //     defensive.
+        //   - Proof assertion: `assert_eq!(err.kind, Rejected)` plus
+        //     `err.message.contains("CORE_EXT spend pre-ACTIVE")`
+        //     below pin the class winner against the alternative
+        //     `Unavailable("mempool fee below rolling minimum")`
+        //     outcome.
+        //   - replacement coverage: bump UTXO value in-place to 7700
+        //     (helper's UTXO value patched after construction; helper
+        //     signature preserved for any future caller). fee = 7700 -
+        //     9 = 7691 ≥ weight ⇒ candidate also passes the floor; the
+        //     CORE_EXT-spend pre-activation guard remains the test
+        //     goal.
+        let (mut state, raw) = core_ext_spend_state_and_tx(9);
+        for entry in state.utxos.values_mut() {
+            entry.value = 7700;
+        }
         let err = TxPool::new()
             .admit(&raw, &state, None, [0u8; 32])
             .unwrap_err();
@@ -2435,10 +2716,13 @@ mod tests {
     fn stage_c_non_da_tx_short_circuits_admit() {
         // Non-DA tx (tx_kind=0, no DaChunkCore, no da_payload) must be admitted
         // by reject_da_anchor_tx_policy without applying any DA term, even with
-        // aggressive rate config. Non-DA relay-fee floor enforcement is outside
-        // this helper and is the responsibility of a separate Rust standard
-        // mempool admission path (tracked as RUB-53); Rust does not yet ship
-        // a `validateFeeFloorLocked` analogue.
+        // aggressive rate config. Non-DA relay-fee floor enforcement now lives
+        // in TxPool::validate_fee_floor_locked (defined above) and runs from
+        // admit_with_metadata AFTER apply_policy returns Ok — mirroring Go's
+        // validateCapacityAdmissionLocked → validateFeeFloorLocked split at
+        // clients/go/node/mempool.go:1018-1024. This helper only validates the
+        // DA half of the Stage C contract and intentionally short-circuits for
+        // non-DA inputs.
         let (state, raw) = signed_p2pk_state_and_tx(
             10,
             vec![TxOutput {
@@ -2471,5 +2755,612 @@ mod tests {
         state.utxos.clear(); // strip utxos so any fee compute would error
         run_da_policy(&raw, &state, 0, 0, 0)
             .expect("required=0 admits without compute_fee_no_verify");
+    }
+
+    // ====================================================================
+    // RUB-162 Phase A regression tests — section header
+    //
+    // Tests in this section exercise the four Phase A invariants from
+    // GitHub #1407 through the public TxPool::admit / admit_with_metadata
+    // entrypoint (NOT helper-only direct calls — that was the reviewer
+    // concern). Each individual test below carries its own Proof
+    // assertion in the doc-comment naming the exact assertion mechanism;
+    // see the `rub162_*` test functions for specifics.
+    // ====================================================================
+
+    use super::fee_rate_below_floor;
+
+    /// P1 #4 fix — DA tx whose DA fee passes but rolling relay floor fails
+    /// must return Unavailable from validate_fee_floor_locked, NOT Rejected
+    /// from reject_da_anchor_tx_policy. Mirrors Go applyPolicyAgainstState
+    /// behaviour (clients/go/node/mempool.go:798-833): mempool admit passes
+    /// currentMempoolMinFeeRate=0 to the DA helper so the relay-floor
+    /// classification is owned uniformly by validateFeeFloorLocked
+    /// (Unavailable, transient/retryable).
+    ///
+    /// Reachability: tx is well-formed (parses, basic+canonical checks pass,
+    /// inputs not double-spent), DA-side floor configured to 0 so DA helper
+    /// short-circuits Ok, then validate_fee_floor_locked rejects on the
+    /// rolling floor. The TxPoolConfig used has policy_min_da_fee_rate=0 and
+    /// policy_da_surcharge_per_byte=0, so the DA helper's required term
+    /// is 0 — the only failing path is the new validate_fee_floor_locked.
+    #[test]
+    fn rub162_admit_da_below_rolling_floor_returns_unavailable_not_rejected() {
+        // Build a DA tx with low fee_rate (fee=1, weight ≈ 7653 from ML-DSA
+        // witness + 64-byte da_payload).
+        let (state, raw, _weight, _da_bytes) = build_signed_da_tx_with_fee(1, vec![0x77; 64]);
+
+        // cfg with relay floor = DEFAULT (1) and DA-side terms zeroed so
+        // the DA helper's `required` collapses to 0 (short-circuit Ok).
+        let mut pool = TxPool::new_with_config(TxPoolConfig {
+            policy_current_mempool_min_fee_rate: DEFAULT_MEMPOOL_MIN_FEE_RATE,
+            policy_min_da_fee_rate: 0,
+            policy_da_surcharge_per_byte: 0,
+            ..TxPoolConfig::default()
+        });
+
+        let err = pool
+            .admit(&raw, &state, None, [0u8; 32])
+            .expect_err("DA tx with fee=1, weight≈7653 must fail relay floor");
+        assert_eq!(
+            err.kind,
+            TxPoolAdmitErrorKind::Unavailable,
+            "P1 #4 fix: relay-floor failure returns Unavailable (transient/retryable), NOT Rejected (terminal)"
+        );
+        assert!(
+            err.message.contains("mempool fee below rolling minimum"),
+            "error message must come from validate_fee_floor_locked, not DA helper; got: {}",
+            err.message
+        );
+    }
+
+    /// P1 #4 baseline preservation — DA tx whose DA fee fails the DA-side
+    /// floor (independent of the rolling relay floor) still returns
+    /// Rejected from reject_da_anchor_tx_policy. The Phase A change must
+    /// NOT regress DA-floor classification.
+    ///
+    /// Reachability: tx is well-formed; DA-side terms force a non-zero
+    /// required fee that the tx fails. apply_policy returns Err mapped
+    /// to Rejected before validate_fee_floor_locked is reached.
+    #[test]
+    fn rub162_admit_da_below_da_floor_returns_rejected() {
+        // Per RUB-162 RESP P1 #4 ordering: apply_policy (containing the
+        // DA helper with cfg-zero override) runs BEFORE
+        // validate_fee_floor_locked. To pin the DA-side rejection path,
+        // build a fixture that FAILS the DA-side terms
+        // (fee < da_bytes * (min_da + surcharge)). The fixture also
+        // PASSES the relay floor (fee >= weight) defensively — under
+        // WIP #6 ordering apply_policy rejects first regardless of
+        // floor compliance, but the headroom keeps the fixture stable
+        // if a future change reorders the validators again.
+        let (state, raw, weight, da_bytes) = build_signed_da_tx_with_fee(8_000, vec![0x77; 64]);
+        assert!(
+            8_000 >= weight,
+            "fee 8000 must >= weight {weight} to pass relay-floor (defensive headroom)"
+        );
+        // DA-required = da_bytes * (min_da + surcharge). With ~70 bytes
+        // and 200+200, da_required ≈ 28000 ≫ fee=8000.
+        let min_da = 200u64;
+        let surcharge = 200u64;
+        let required_da = da_bytes
+            .checked_mul(min_da + surcharge)
+            .expect("test arithmetic");
+        assert!(
+            8_000 < required_da,
+            "fee 8000 must be below DA-required {required_da} so DA helper rejects"
+        );
+        let mut pool = TxPool::new_with_config(TxPoolConfig {
+            policy_current_mempool_min_fee_rate: DEFAULT_MEMPOOL_MIN_FEE_RATE,
+            policy_min_da_fee_rate: min_da,
+            policy_da_surcharge_per_byte: surcharge,
+            ..TxPoolConfig::default()
+        });
+        let err = pool
+            .admit(&raw, &state, None, [0u8; 32])
+            .expect_err("DA tx with fee below DA-required must fail DA Stage C floor");
+        assert_eq!(
+            err.kind,
+            TxPoolAdmitErrorKind::Rejected,
+            "DA-side failure must remain Rejected (terminal); preserved RUB-122 behaviour"
+        );
+        assert!(
+            err.message.contains("DA fee below Stage C floor"),
+            "error must come from DA helper, not floor check; got: {}",
+            err.message
+        );
+    }
+
+    /// P1 #4 happy path — DA tx that passes BOTH the DA-side floor AND
+    /// the rolling relay floor admits cleanly.
+    #[test]
+    fn rub162_admit_da_above_both_floors_admits_with_indexes() {
+        // weight ≈ 7653 from ML-DSA witness + 64-byte da_payload. Pick
+        // fee that is comfortably above both floors:
+        //   relay floor: weight * DEFAULT (1) ≈ 7653
+        //   DA floor: da_bytes * 1 + da_bytes * 1 = 2 * da_bytes
+        // Use fee = 30000 (well above both for da_bytes around 70-100).
+        let (state, raw, weight, da_bytes) = build_signed_da_tx_with_fee(30_000, vec![0x77; 64]);
+        assert!(
+            weight <= 30_000,
+            "fee must cover relay floor (weight={weight})"
+        );
+        assert!(
+            2 * da_bytes <= 30_000,
+            "fee must cover DA term ({da_bytes} bytes)"
+        );
+
+        let mut pool = TxPool::new_with_config(TxPoolConfig {
+            policy_current_mempool_min_fee_rate: DEFAULT_MEMPOOL_MIN_FEE_RATE,
+            policy_min_da_fee_rate: 1,
+            policy_da_surcharge_per_byte: 1,
+            ..TxPoolConfig::default()
+        });
+        let txid = pool
+            .admit(&raw, &state, None, [0u8; 32])
+            .expect("DA tx above both floors must admit");
+        assert_eq!(pool.len(), 1);
+        assert!(pool.txs.contains_key(&txid));
+    }
+
+    /// P1 #2 atomicity through public admit — Unavailable on relay-floor
+    /// failure leaves all four pool indexes (txs / spenders / heap_seqs /
+    /// worst_heap) unchanged AND the lazy worst_heap filter
+    /// (current_worst_txid) unchanged. This proves admit_with_metadata
+    /// performs the rolling-floor classification BEFORE any insert_entry
+    /// call.
+    ///
+    /// Proof assertion: pre-populate via the production `insert_entry`
+    /// path (so all four indexes plus next_heap_id receive the resident
+    /// snapshot); capture every observable baseline; trigger the
+    /// rolling-floor rejection through the public admit entry; assert
+    /// the four index lengths + worst_heap length + next_heap_id +
+    /// current_worst_txid lookup are all unchanged.
+    #[test]
+    fn rub162_admit_atomicity_unavailable_floor_leaves_no_partial_state() {
+        let (state, raw, _weight, _da_bytes) = build_signed_da_tx_with_fee(1, vec![0x77; 64]);
+        let mut pool = TxPool::new_with_config(TxPoolConfig {
+            policy_current_mempool_min_fee_rate: DEFAULT_MEMPOOL_MIN_FEE_RATE,
+            policy_min_da_fee_rate: 0,
+            policy_da_surcharge_per_byte: 0,
+            ..TxPoolConfig::default()
+        });
+        // Pre-populate via the production `insert_entry` path so all four
+        // indexes (txs + spenders + heap_seqs + worst_heap) AND next_heap_id
+        // receive the resident state — required to detect any spurious
+        // mutation of cross-tx state during the failed admit.
+        let resident_txid = [0xAB; 32];
+        let resident_input = Outpoint {
+            txid: [0x77; 32],
+            vout: 0,
+        };
+        pool.insert_entry(
+            resident_txid,
+            TxPoolEntry {
+                raw: vec![0x01],
+                inputs: vec![resident_input.clone()],
+                fee: 100,
+                weight: 1,
+                size: 1,
+            },
+        );
+        let pool_len_before = pool.len();
+        let spenders_before = pool.spenders.len();
+        let heap_seqs_before = pool.heap_seqs.len();
+        let worst_heap_before = pool.worst_heap.len();
+        let next_heap_id_before = pool.next_heap_id;
+        let worst_txid_before = pool.current_worst_txid();
+
+        let err = pool
+            .admit(&raw, &state, None, [0u8; 32])
+            .expect_err("must fail rolling floor");
+        assert_eq!(err.kind, TxPoolAdmitErrorKind::Unavailable);
+
+        // Atomicity: every observable pool surface UNCHANGED across the
+        // failed admit (txs / spenders / heap_seqs / worst_heap len +
+        // next_heap_id + current_worst_txid lookup).
+        assert_eq!(pool.len(), pool_len_before, "txs unchanged on Err");
+        assert_eq!(
+            pool.spenders.len(),
+            spenders_before,
+            "spenders unchanged on Err"
+        );
+        assert_eq!(
+            pool.heap_seqs.len(),
+            heap_seqs_before,
+            "heap_seqs unchanged on Err"
+        );
+        assert_eq!(
+            pool.worst_heap.len(),
+            worst_heap_before,
+            "worst_heap unchanged on Err (no spurious WorstEntryKey push)"
+        );
+        assert_eq!(
+            pool.next_heap_id, next_heap_id_before,
+            "next_heap_id unchanged (no partial WorstEntryKey reservation)"
+        );
+        assert_eq!(
+            pool.current_worst_txid(),
+            worst_txid_before,
+            "current_worst_txid lookup unchanged (resident still observable)"
+        );
+        assert!(pool.txs.contains_key(&resident_txid), "resident untouched");
+        assert_eq!(
+            pool.spenders.get(&resident_input),
+            Some(&resident_txid),
+            "resident spenders entry untouched"
+        );
+    }
+
+    /// P1 #3 cleanup state symmetry — `evict_txids` removes the three
+    /// eager index maps that `insert_entry` adds (txs + spenders +
+    /// heap_seqs). The fourth structure `worst_heap` is intentionally
+    /// lazy: `remove_entry` does NOT pop the heap entry directly;
+    /// instead `compact_worst_heap_if_needed` rebuilds when the heap
+    /// grows past 2x the live count, and `current_worst_txid` filters
+    /// stale entries via the heap_seqs lookup. The test below pins both
+    /// the eager map clears AND the lazy filter (current_worst_txid is
+    /// None after eviction even though the heap entry is still
+    /// physically present).
+    ///
+    /// This is a regression guard: if a future change adds a new index
+    /// (e.g. wtxids) maintained by insert_entry, evict_txids must mirror
+    /// it via the same delete path; this test will then need extension
+    /// rather than letting the asymmetry leak silently.
+    #[test]
+    fn rub162_evict_txids_clears_all_indexes_added_by_insert_entry() {
+        let mut pool = TxPool::new_with_config(TxPoolConfig {
+            policy_current_mempool_min_fee_rate: 0,
+            ..TxPoolConfig::default()
+        });
+        let txid = [0xC1; 32];
+        let outpoint = Outpoint {
+            txid: [0xAA; 32],
+            vout: 0,
+        };
+        // Insert via the same private path admit_with_metadata uses so
+        // the test shares the production insert side.
+        pool.insert_entry(
+            txid,
+            TxPoolEntry {
+                raw: vec![0xff],
+                inputs: vec![outpoint.clone()],
+                fee: 100,
+                weight: 1,
+                size: 1,
+            },
+        );
+        assert!(pool.txs.contains_key(&txid));
+        assert_eq!(pool.spenders.get(&outpoint), Some(&txid));
+        assert!(pool.heap_seqs.contains_key(&txid));
+
+        pool.evict_txids(&[txid]);
+        assert!(!pool.txs.contains_key(&txid), "txs cleared");
+        assert!(!pool.spenders.contains_key(&outpoint), "spenders cleared");
+        assert!(!pool.heap_seqs.contains_key(&txid), "heap_seqs cleared");
+        // Lazy worst_heap behaviour: the physical heap entry MAY still
+        // exist (compaction is delayed via 2x threshold), but the
+        // public lookup must filter it out via the heap_seqs guard.
+        assert!(
+            pool.current_worst_txid().is_none(),
+            "current_worst_txid hides the evicted entry via the heap_seqs guard"
+        );
+    }
+
+    /// P1 #3 cleanup state symmetry — `remove_conflicting_outpoints`
+    /// (the public path used by reorg/conflict cleanup) routes through
+    /// `evict_txids` and clears the same indexes. The test populates a
+    /// resident, builds a conflicting outpoint, and asserts symmetric
+    /// removal.
+    #[test]
+    fn rub162_remove_conflicting_outpoints_clears_all_indexes() {
+        let mut pool = TxPool::new_with_config(TxPoolConfig {
+            policy_current_mempool_min_fee_rate: 0,
+            ..TxPoolConfig::default()
+        });
+        let txid = [0xC2; 32];
+        let outpoint = Outpoint {
+            txid: [0xBB; 32],
+            vout: 0,
+        };
+        pool.insert_entry(
+            txid,
+            TxPoolEntry {
+                raw: vec![0xff],
+                inputs: vec![outpoint.clone()],
+                fee: 100,
+                weight: 1,
+                size: 1,
+            },
+        );
+
+        // Conflict feed contains the resident's outpoint.
+        pool.remove_conflicting_outpoints(std::slice::from_ref(&outpoint));
+        assert!(
+            !pool.txs.contains_key(&txid),
+            "resident removed on conflict"
+        );
+        assert!(
+            !pool.spenders.contains_key(&outpoint),
+            "spenders cleared on conflict"
+        );
+        assert!(
+            !pool.heap_seqs.contains_key(&txid),
+            "heap_seqs cleared on conflict"
+        );
+    }
+
+    /// P1 #4 helper unit test — `fee_rate_below_floor` is a u128 cross-mul
+    /// predicate matching Go `feeRateBelowFloor`
+    /// (clients/go/node/mempool.go:1421-1434), including the in-helper
+    /// `floor < DefaultMempoolMinFeeRate` clamp at
+    /// clients/go/node/mempool.go:1425-1427. Calling with floor=0
+    /// promotes to DEFAULT_MEMPOOL_MIN_FEE_RATE
+    /// before the cross-mul, so a fee=0 / weight=100 / floor=0 input
+    /// rejects (required becomes 100*1=100 post-clamp, fee<100).
+    ///
+    /// Proof assertion: assertions below pin the documented Go branches:
+    /// - weight=0 always returns true (uncomputable rate)
+    /// - floor=0 + non-zero weight clamps to DEFAULT and uses required=weight*1
+    /// - exact-floor (fee == weight*floor) returns false
+    /// - one-below-floor returns true
+    /// - u128 boundary (u64::MAX*u64::MAX) lossless
+    #[test]
+    fn rub162_fee_rate_below_floor_helper_branches() {
+        // Zero weight: always below floor.
+        assert!(fee_rate_below_floor(u64::MAX, 0, 1));
+        // Zero floor: clamps to DEFAULT (1). For weight=100: required=100.
+        // fee=0 < 100 → true; fee=99 < 100 → true; fee=100 == 100 → false.
+        assert!(fee_rate_below_floor(0, 100, 0));
+        assert!(fee_rate_below_floor(99, 100, 0));
+        assert!(!fee_rate_below_floor(100, 100, 0));
+        // Exact floor: not below.
+        assert!(!fee_rate_below_floor(100, 100, 1));
+        // One below floor.
+        assert!(fee_rate_below_floor(99, 100, 1));
+        // u128 boundary: required = u64::MAX * u64::MAX. Fits u128, no wrap.
+        assert!(fee_rate_below_floor(u64::MAX, u64::MAX, 2));
+        assert!(!fee_rate_below_floor(u64::MAX, u64::MAX, 1));
+        // Concrete 7653 pin (matches the conformance fixture's weight).
+        assert!(fee_rate_below_floor(10, 7653, 1));
+        assert!(!fee_rate_below_floor(7653, 7653, 1));
+    }
+
+    /// P1 #4 + clamp regression — `validate_fee_floor_locked` propagates
+    /// a cfg-seeded zero into `fee_rate_below_floor`, which itself clamps
+    /// to DEFAULT_MEMPOOL_MIN_FEE_RATE per Go `feeRateBelowFloor`
+    /// (clients/go/node/mempool.go:1421-1434, with the in-helper clamp
+    /// at lines 1425-1427). The error message surfaces the post-clamp
+    /// value so operators see the actual decision basis.
+    #[test]
+    fn rub162_validate_fee_floor_locked_clamps_cfg_zero_to_default() {
+        let pool = TxPool::new_with_config(TxPoolConfig {
+            policy_current_mempool_min_fee_rate: 0,
+            ..TxPoolConfig::default()
+        });
+        // fee=0 weight=1: helper clamps floor 0 → DEFAULT (1); required = 1*1 = 1; fee<1 → reject.
+        let err = pool
+            .validate_fee_floor_locked(0, 1)
+            .expect_err("helper clamp must enforce DEFAULT even when cfg=0");
+        assert_eq!(err.kind, TxPoolAdmitErrorKind::Unavailable);
+        assert!(err.message.contains("min_fee_rate=1"));
+        // fee=1 weight=1: exact floor passes.
+        pool.validate_fee_floor_locked(1, 1)
+            .expect("exact floor passes");
+    }
+
+    /// P1 #1 fix — relay_metadata path also passes
+    /// `policy_current_mempool_min_fee_rate=0` to apply_policy ->
+    /// reject_da_anchor_tx_policy, mirroring Go RelayMetadata's
+    /// applyPolicyAgainstState invocation
+    /// (clients/go/node/mempool.go:472-495 -> 785-853 with the
+    /// hardcoded 0 at clients/go/node/mempool.go:823). A DA tx that
+    /// pays the DA-side floor but is below the rolling relay floor
+    /// must NOT surface as `Rejected("DA fee below Stage C floor")`
+    /// from relay_metadata; the relay path's contract (per
+    /// clients/go/node/mempool.go:472-495) extracts metadata after
+    /// DA-only enforcement, with no rolling-floor classification.
+    /// admit_with_metadata still rejects the same tx with Unavailable
+    /// (validate_fee_floor_locked enforces the rolling floor on the
+    /// admit path).
+    ///
+    /// Proof assertion: same DA tx, same TxPoolConfig with non-zero
+    /// rolling floor + DA-side terms; admit returns Unavailable; relay
+    /// metadata returns Ok with the extracted fee/size.
+    #[test]
+    fn rub162_relay_metadata_da_below_rolling_floor_returns_ok_not_rejected() {
+        // weight ≈ 7653; DA-required = 2 * da_bytes (≈ 70 bytes ⇒ 140);
+        // pick fee that beats DA-required but is well below relay floor
+        // (fee=1000 < weight=7653 ⇒ relay-floor reject on admit path).
+        let (state, raw, weight, da_bytes) = build_signed_da_tx_with_fee(1_000, vec![0x77; 64]);
+        assert!(
+            1_000 >= 2 * da_bytes,
+            "test setup must let DA-required fit fee: 2*{da_bytes} <= 1000"
+        );
+        assert!(
+            1_000 < weight,
+            "test setup must put fee below relay floor: 1000 < weight={weight}"
+        );
+        let cfg = TxPoolConfig {
+            policy_current_mempool_min_fee_rate: DEFAULT_MEMPOOL_MIN_FEE_RATE,
+            policy_min_da_fee_rate: 1,
+            policy_da_surcharge_per_byte: 1,
+            ..TxPoolConfig::default()
+        };
+        // admit must reject with Unavailable from validate_fee_floor_locked.
+        let mut pool = TxPool::new_with_config(cfg.clone());
+        let admit_err = pool
+            .admit(&raw, &state, None, [0u8; 32])
+            .expect_err("admit should reject below relay floor");
+        assert_eq!(admit_err.kind, TxPoolAdmitErrorKind::Unavailable);
+        assert!(admit_err
+            .message
+            .contains("mempool fee below rolling minimum"));
+        // relay_metadata must succeed (Go-parity: relay path does not
+        // enforce relay floor, only DA-side terms).
+        let meta = relay_metadata(&raw, &state, None, [0u8; 32], &cfg)
+            .expect("relay_metadata should succeed when DA-side terms pass");
+        assert!(meta.fee > 0);
+        assert_eq!(meta.size, raw.len());
+    }
+
+    /// P1 #2 fix — fee-floor classification runs BEFORE pool-full
+    /// ordering classification (Go `validateCapacityAdmissionLocked`
+    /// order at clients/go/node/mempool.go:1020-1024). A sub-floor
+    /// candidate against a full pool must surface the floor error,
+    /// not the pool-full error.
+    ///
+    /// Proof assertion: build a candidate with fee/weight far below
+    /// DEFAULT_MEMPOOL_MIN_FEE_RATE, fill the pool to capacity, then
+    /// call admit. Expected: TxPoolAdmitErrorKind::Unavailable with
+    /// "mempool fee below rolling minimum" message (NOT "tx pool full").
+    #[test]
+    fn rub162_admit_full_pool_below_floor_returns_floor_error_not_pool_full() {
+        // Sub-floor candidate: input=10 / output=8 → fee=2, weight≈7653.
+        let (state, raw) = signed_p2pk_state_and_tx(
+            10,
+            vec![TxOutput {
+                value: 8,
+                covenant_type: COV_TYPE_P2PK,
+                covenant_data: p2pk_covenant_data_for_pubkey(&vec![0x88; 2592]),
+            }],
+            0x00,
+            None,
+            Vec::new(),
+        );
+        let mut pool = TxPool::new();
+        // Fill pool to MAX so the pool-full ordering branch IS reachable.
+        for idx in 0..MAX_TX_POOL_TRANSACTIONS {
+            let mut key = [0u8; 32];
+            key[..8].copy_from_slice(&(idx as u64 + 1).to_le_bytes());
+            pool.txs.insert(
+                key,
+                TxPoolEntry {
+                    raw: vec![0xff],
+                    inputs: Vec::new(),
+                    fee: 100,
+                    weight: 1,
+                    size: 1,
+                },
+            );
+        }
+        let err = pool.admit(&raw, &state, None, [0u8; 32]).unwrap_err();
+        assert_eq!(err.kind, TxPoolAdmitErrorKind::Unavailable);
+        assert!(
+            err.message.contains("mempool fee below rolling minimum"),
+            "P1 #2: floor error must win over pool-full ordering; got: {}",
+            err.message
+        );
+        // Pool unchanged (atomicity preserved through the new ordering).
+        assert_eq!(pool.txs.len(), MAX_TX_POOL_TRANSACTIONS);
+    }
+
+    /// RUB-162 cross-pollination ordering PIN — a tx that is BOTH
+    /// sub-floor AND fails DA-side terms must classify as Rejected
+    /// (apply_policy → DA helper fires first under WIP #6 ordering),
+    /// NOT Unavailable (rolling floor would fire if it ran first).
+    /// Mirrors Go addToMempoolLocked at clients/go/node/mempool.go:798-1024
+    /// where applyPolicyAgainstState precedes validateCapacityAdmissionLocked
+    /// → validateFeeFloorLocked.
+    ///
+    /// Proof assertion: build a DA tx whose fee is below BOTH the rolling
+    /// floor AND the DA-required floor; admit returns
+    /// `TxPoolAdmitErrorKind::Rejected` with the canonical
+    /// `DA fee below Stage C floor` message (not the
+    /// `mempool fee below rolling minimum` message).
+    #[test]
+    fn rub162_admit_sub_floor_da_anchor_classifies_as_da_rejected_not_floor_unavailable() {
+        // fee=10 ≪ weight (≈70 = MIN witness for DA tx) ⇒ sub-floor.
+        // Default conformance da_bytes ≈ 70. DA-required = da_bytes *
+        // (min_da=200 + surcharge=200) = ~28_000 ≫ fee=10 ⇒ sub-DA.
+        let (state, raw, weight, da_bytes) = build_signed_da_tx_with_fee(10, vec![0x55; 64]);
+        assert!(
+            10 < weight,
+            "test setup must put fee below relay floor: 10 < weight={weight}"
+        );
+        let min_da = 200u64;
+        let surcharge = 200u64;
+        let required_da = da_bytes
+            .checked_mul(min_da + surcharge)
+            .expect("test arithmetic");
+        assert!(
+            10 < required_da,
+            "test setup must put fee below DA-required: 10 < da_required={required_da}"
+        );
+
+        let mut pool = TxPool::new_with_config(TxPoolConfig {
+            policy_current_mempool_min_fee_rate: DEFAULT_MEMPOOL_MIN_FEE_RATE,
+            policy_min_da_fee_rate: min_da,
+            policy_da_surcharge_per_byte: surcharge,
+            ..TxPoolConfig::default()
+        });
+        let err = pool
+            .admit(&raw, &state, None, [0u8; 32])
+            .expect_err("admit must reject when both sub-floor and sub-DA");
+        // Cross-pollination winner: apply_policy (DA helper) → Rejected.
+        assert_eq!(
+            err.kind,
+            TxPoolAdmitErrorKind::Rejected,
+            "DA-rejection class must win when apply_policy runs before validate_fee_floor_locked; got kind={:?} message={}",
+            err.kind,
+            err.message
+        );
+        assert!(
+            err.message.contains("DA fee below Stage C floor"),
+            "error must come from DA helper, not the rolling floor check; got: {}",
+            err.message
+        );
+        // Atomicity: no partial insert on cross-pollination reject.
+        assert_eq!(pool.len(), 0);
+        assert!(pool.spenders.is_empty());
+        assert_eq!(pool.heap_seqs.len(), 0);
+    }
+
+    /// RUB-162 cross-pollination ordering PIN — sub-floor tx with a
+    /// CORE_EXT output before its profile is active. Same ordering
+    /// invariant as the DA-anchor cross-pollination test above; ext-id
+    /// 7 is unregistered so the pre-activation guard inside
+    /// apply_policy is the relevant gate.
+    ///
+    /// Proof assertion: build a sub-floor P2PK→CORE_EXT tx with no
+    /// matching active profile; `assert_eq!(err.kind, Rejected)` plus
+    /// `err.message.contains("CORE_EXT output pre-ACTIVE")` below pin
+    /// the class winner against the alternative
+    /// `Unavailable("mempool fee below rolling minimum")` outcome.
+    #[test]
+    fn rub162_admit_sub_floor_core_ext_classifies_as_core_ext_rejected_not_floor_unavailable() {
+        // input=10 / output=9 → fee=1 with weight≈7533 ⇒ sub-floor.
+        // CORE_EXT output with ext_id=7 and no profile registered ⇒
+        // pre-activation guard rejects.
+        let (state, raw) = signed_p2pk_state_and_tx(
+            10,
+            vec![TxOutput {
+                value: 9,
+                covenant_type: COV_TYPE_EXT,
+                covenant_data: empty_core_ext_covenant_data(7),
+            }],
+            0x00,
+            None,
+            Vec::new(),
+        );
+        let mut pool = TxPool::new();
+        let err = pool
+            .admit(&raw, &state, None, [0u8; 32])
+            .expect_err("admit must reject when both sub-floor and pre-activation CORE_EXT");
+        assert_eq!(
+            err.kind,
+            TxPoolAdmitErrorKind::Rejected,
+            "CORE_EXT pre-activation class must win when apply_policy runs before validate_fee_floor_locked; got kind={:?} message={}",
+            err.kind,
+            err.message
+        );
+        assert!(
+            err.message.contains("CORE_EXT output pre-ACTIVE"),
+            "error must come from CORE_EXT pre-activation guard, not the rolling floor check; got: {}",
+            err.message
+        );
+        // Atomicity: no partial insert on cross-pollination reject.
+        assert_eq!(pool.len(), 0);
+        assert!(pool.spenders.is_empty());
+        assert_eq!(pool.heap_seqs.len(), 0);
     }
 }

--- a/clients/rust/crates/rubin-node/src/txpool.rs
+++ b/clients/rust/crates/rubin-node/src/txpool.rs
@@ -286,27 +286,24 @@ impl TxPool {
                 registry,
             )
             .map_err(|err| rejected(format!("transaction rejected: {err}")))?;
-        // RUB-162 P1 #4 — DA error class ordering parity with Go
-        // `applyPolicyAgainstState` (clients/go/node/mempool.go:798-833):
-        // the mempool admit path passes `currentMempoolMinFeeRate=0` to the
-        // DA helper so that `max(relay_fee_floor, da_required_fee)` collapses
-        // to `da_required_fee`, leaving DA-side classification intact while
-        // delegating rolling relay-fee floor classification to a separate
-        // `validate_fee_floor_locked` call below that returns the symmetric
-        // `Unavailable` (transient/retryable) outcome non-DA tx receive. The
-        // miner caller (`reject_candidate`) keeps the live floor in its own
-        // policy_cfg construction because it has no `validate_fee_floor_locked`
-        // equivalent — the template needs to skip a tx whenever it fails any
-        // floor.
-        let mut policy_cfg = self.cfg.clone();
-        policy_cfg.policy_current_mempool_min_fee_rate = 0;
-        apply_policy(&tx, &chain_state.utxos, next_height, &policy_cfg).map_err(rejected)?;
-        // Rolling relay-floor classification: returns `Unavailable` so the
-        // failure class matches what non-DA tx receive (Go
-        // `validateFeeFloorLocked` clients/go/node/mempool.go:957-967) and
-        // so callers can back off rather than treating the rejection as
-        // terminal.
-        self.validate_fee_floor_locked(summary.fee, weight)?;
+        // RUB-162 PR-1410 wave-3 drift-prevention: delegate the
+        // post-consensus policy sequence (cfg-clone with cfg-zero
+        // override → apply_policy → rolling-floor enforcement) to the
+        // shared `apply_post_consensus_policy_with_floor` helper so
+        // both `admit_with_metadata` and `relay_metadata` cannot drift
+        // again (Copilot PR-1410 wave-2 Thread 4 finding). The miner
+        // caller (`reject_candidate`) keeps its own policy_cfg
+        // construction because it has no rolling-floor equivalent —
+        // the template needs to skip a tx whenever it fails any floor
+        // (Go `applyPolicyAgainstState` mempool.go:815-818).
+        apply_post_consensus_policy_with_floor(
+            &tx,
+            &chain_state.utxos,
+            next_height,
+            summary.fee,
+            weight,
+            &self.cfg,
+        )?;
 
         let entry = TxPoolEntry {
             raw: tx_bytes.to_vec(),
@@ -438,28 +435,15 @@ impl TxPool {
         self.compact_worst_heap_if_needed();
     }
 
-    /// Rejects entries whose fee/weight rate is below the rolling minimum
-    /// fee rate. Mirrors Go `validateFeeFloorLocked`
-    /// (clients/go/node/mempool.go:957-967). Returns `Unavailable`
-    /// (transient/retryable) so callers can back off rather than treating
-    /// the relay-floor rejection as terminal. This is the Phase A fix for
-    /// the RUB-162 / hostile RESP P1 #4 finding: relay-floor rejection is
-    /// classified separately from DA-side rejection. The corresponding Go
-    /// source path is documented above (clients/go/node/mempool.go:957-967).
-    ///
-    /// Reads the live floor from `cfg.policy_current_mempool_min_fee_rate`.
-    /// Production callers using `TxPool::admit` / `admit_with_metadata` go
-    /// through this check after `apply_policy` so the rolling floor is
-    /// enforced independent of the DA helper. The miner template caller
-    /// (`miner::reject_candidate`) keeps its own floor handling because it
-    /// has no `validate_fee_floor_locked` equivalent — see
-    /// `clients/go/node/mempool.go:815-818`.
-    fn validate_fee_floor_locked(&self, fee: u64, weight: u64) -> Result<(), TxPoolAdmitError> {
-        // Delegate to free `validate_fee_floor` so both the impl-method
-        // caller (`admit_with_metadata`) and the free-function caller
-        // (`relay_metadata`) share one source-of-truth predicate.
-        validate_fee_floor(fee, weight, self.cfg.policy_current_mempool_min_fee_rate)
-    }
+    // PR-1410 wave-3 — removed `TxPool::validate_fee_floor_locked`
+    // impl-method. After the wave-3 drift-prevention helper extraction
+    // (`apply_post_consensus_policy_with_floor`), both
+    // `admit_with_metadata` and `relay_metadata` go through that helper,
+    // and the free `validate_fee_floor` predicate is the single
+    // source-of-truth call. The impl-method's `_locked` suffix was a
+    // historical TxPool-state convenience that no longer carries
+    // meaning (the predicate is stateless on the cfg field). Tests
+    // call the free `validate_fee_floor` directly.
 
     fn seed_worst_heap(&mut self) {
         let max_stale_tail = self.txs.len().saturating_add(1);
@@ -549,45 +533,77 @@ pub(crate) fn relay_metadata(
             registry,
         )
         .map_err(|err| rejected(format!("transaction rejected: {err}")))?;
-    // RUB-162 P1 #1 — DA error class ordering parity for the relay
-    // metadata path. Go `RelayMetadata` routes through
-    // `checkParsedTransactionWithSnapshot` -> `applyPolicyAgainstState`
-    // (clients/go/node/mempool.go:472-495 -> 785-853), and
-    // `applyPolicyAgainstState` always passes
-    // `currentMempoolMinFeeRate=0` to `RejectDaAnchorTxPolicy` at
-    // clients/go/node/mempool.go:823. Without the same zero override, a DA tx that pays
-    // the DA-side floor but is below the rolling relay floor surfaces
-    // here as `Rejected("DA fee below Stage C floor ... relay_fee_floor=...")`
-    // diverging from Go's relay-metadata contract.
-    let mut policy_cfg = cfg.clone();
-    policy_cfg.policy_current_mempool_min_fee_rate = 0;
-    apply_policy(&tx, &chain_state.utxos, next_height, &policy_cfg).map_err(rejected)?;
-
-    // RUB-162 PR-1410 wave-2 fix — Rolling relay-floor enforcement on
-    // the relay path so `relay_metadata` is NOT weaker than `admit`.
-    // Without this, the cfg-zero override above lets a DA tx that pays
-    // the DA-side floor but is below the rolling relay floor pass the
-    // relay-metadata gate, while `TxPool::admit` rejects the same tx
-    // as `Unavailable`. Production peer relay (`tx_relay::handle_received_tx`)
-    // uses `relay_metadata` as the gate before re-announcing, so the
-    // mismatch would mean we propagate sub-floor DA tx through the
-    // network even though the local mempool refuses to admit them. Go
-    // avoids the divergence in the full node by re-running mempool
-    // admission via `CanonicalMempoolRelayMetadata` +
-    // `CanonicalMempoolTxPool.Put` — the equivalent here is to call
-    // the same `validate_fee_floor` predicate inline so the matrix is:
-    //   - DA tx fee < DA-required → Rejected (DA helper, above)
-    //   - DA tx fee >= DA-required, fee/weight < rolling floor → Unavailable
-    //   - DA tx fee >= both → Ok (relay metadata returned)
-    // mirroring `admit_with_metadata`.
+    // RUB-162 PR-1410 wave-3 drift-prevention: delegate the
+    // post-consensus policy sequence (cfg-clone with cfg-zero override
+    // → apply_policy → rolling-floor enforcement) to the shared
+    // `apply_post_consensus_policy_with_floor` helper so the relay path
+    // and the admit path (`admit_with_metadata`) cannot drift again.
+    // Wave-2 already fixed one drift instance (relay_metadata had
+    // skipped the rolling-floor check entirely while admit enforced it
+    // via `validate_fee_floor_locked`); the shared helper makes that
+    // class of drift impossible by construction.
     let (weight, _, _) = tx_weight_and_stats_public(&tx)
         .map_err(|err| rejected(format!("transaction rejected: {err}")))?;
-    validate_fee_floor(summary.fee, weight, cfg.policy_current_mempool_min_fee_rate)?;
+    apply_post_consensus_policy_with_floor(
+        &tx,
+        &chain_state.utxos,
+        next_height,
+        summary.fee,
+        weight,
+        cfg,
+    )?;
 
     Ok(RelayTxMetadata {
         fee: summary.fee,
         size: tx_bytes.len(),
     })
+}
+
+/// Shared post-consensus policy sequence used by both
+/// `TxPool::admit_with_metadata` (admit gate) and `relay_metadata`
+/// (relay gate). Mirrors Go's `applyPolicyAgainstState` plus
+/// `validateFeeFloorLocked` pair (clients/go/node/mempool.go:798-833
+/// and mempool.go:957-967). Centralising the cfg-clone, cfg-zero
+/// override, `apply_policy` invocation and rolling-floor enforcement
+/// in one private helper prevents the public-gate-drift class that
+/// PR #1410 wave-2 fixed once already (relay_metadata had skipped the
+/// floor check while admit enforced it).
+///
+/// Order is mandatory and must NOT be changed without updating the
+/// matching Go reference: apply_policy(cfg-zero) runs first to
+/// classify DA-side rejections as Rejected (terminal), then
+/// validate_fee_floor with the original cfg's
+/// `policy_current_mempool_min_fee_rate` runs to classify rolling-
+/// relay-floor rejections as Unavailable (transient/retryable). Both
+/// public callers must use the same predicate so peer relay
+/// (`tx_relay::handle_received_tx`, which gates on `relay_metadata`)
+/// never propagates a tx that local `admit` would reject.
+///
+/// Caller responsibilities (kept out of this helper to preserve
+/// existing call-site semantics):
+///   - parse_tx + canonical bytes check + apply_non_coinbase_tx_basic_update
+///     must complete BEFORE this helper (signature verification +
+///     consensus state validation are upstream).
+///   - `fee` and `weight` are extracted by the caller (admit reads
+///     them at the start of the function; relay extracts weight
+///     between apply_non_coinbase and this helper).
+///   - The miner caller (`reject_candidate`) deliberately does NOT
+///     use this helper; miner has its own policy_cfg construction
+///     because it has no rolling-floor equivalent (Go
+///     `applyPolicyAgainstState` mempool.go:815-818 documents this
+///     same exception).
+fn apply_post_consensus_policy_with_floor(
+    tx: &rubin_consensus::Tx,
+    utxos: &HashMap<Outpoint, rubin_consensus::UtxoEntry>,
+    next_height: u64,
+    fee: u64,
+    weight: u64,
+    cfg: &TxPoolConfig,
+) -> Result<(), TxPoolAdmitError> {
+    let mut policy_cfg = cfg.clone();
+    policy_cfg.policy_current_mempool_min_fee_rate = 0;
+    apply_policy(tx, utxos, next_height, &policy_cfg).map_err(rejected)?;
+    validate_fee_floor(fee, weight, cfg.policy_current_mempool_min_fee_rate)
 }
 
 impl Default for TxPool {
@@ -2903,7 +2919,7 @@ mod tests {
     // see the `rub162_*` test functions for specifics.
     // ====================================================================
 
-    use super::fee_rate_below_floor;
+    use super::{fee_rate_below_floor, validate_fee_floor};
 
     /// P1 #4 fix — DA tx whose DA fee passes but rolling relay floor fails
     /// must return Unavailable from validate_fee_floor_locked, NOT Rejected
@@ -3267,20 +3283,15 @@ mod tests {
     /// at lines 1425-1427). The error message surfaces the post-clamp
     /// value so operators see the actual decision basis.
     #[test]
-    fn rub162_validate_fee_floor_locked_clamps_cfg_zero_to_default() {
-        let pool = TxPool::new_with_config(TxPoolConfig {
-            policy_current_mempool_min_fee_rate: 0,
-            ..TxPoolConfig::default()
-        });
-        // fee=0 weight=1: helper clamps floor 0 → DEFAULT (1); required = 1*1 = 1; fee<1 → reject.
-        let err = pool
-            .validate_fee_floor_locked(0, 1)
+    fn rub162_validate_fee_floor_clamps_cfg_zero_to_default() {
+        // fee=0 weight=1 cfg_floor=0: helper clamps floor 0 → DEFAULT (1);
+        // required = 1*1 = 1; fee<1 → reject.
+        let err = validate_fee_floor(0, 1, 0)
             .expect_err("helper clamp must enforce DEFAULT even when cfg=0");
         assert_eq!(err.kind, TxPoolAdmitErrorKind::Unavailable);
         assert!(err.message.contains("min_fee_rate=1"));
-        // fee=1 weight=1: exact floor passes.
-        pool.validate_fee_floor_locked(1, 1)
-            .expect("exact floor passes");
+        // fee=1 weight=1 cfg_floor=0: exact floor passes after clamp.
+        validate_fee_floor(1, 1, 0).expect("exact floor passes");
     }
 
     /// PR-1410 wave-2 fix — relay_metadata must NOT be weaker than


### PR DESCRIPTION
## Scope

Phase A of architect-split RUB-53 (Linear RUB-162 / GitHub issue #1407). Internal `clients/rust/crates/rubin-node/src/txpool.rs` parity work: failure-atomic `admit_with_metadata`, cleanup state symmetry across `remove_entry` / `evict_txids` / `remove_conflicting_outpoints`, Go-parity DA error class ordering, AND **rolling-relay-floor parity between admit and relay paths** (wave-2 fix + wave-3 drift-prevention helper).

Production code change confined to txpool.rs. Producer files (devnet_rpc.rs / miner.rs / p2p_runtime.rs / sync_reorg.rs / tx_relay.rs) and bench_support.rs receive only `#[cfg(test)]` fixture-migration changes per controller Path A approval (2026-05-03).

Production-code surface added in this PR:
- New free helper `fee_rate_below_floor(fee, weight, floor) -> bool` — pure u128 cross-mul matching Go `feeRateBelowFloor` (clients/go/node/mempool.go:1421-1434) with the in-helper clamp.
- New free helper `validate_fee_floor(fee, weight, cfg_floor) -> Result<(), TxPoolAdmitError>` — returns `Unavailable` (transient/retryable) on rolling-relay-floor failure, mirroring Go `validateFeeFloorLocked` (mempool.go:957-967).
- New private function `apply_post_consensus_policy_with_floor(tx, utxos, next_height, fee, weight, cfg) -> Result<(), TxPoolAdmitError>` (wave-3 drift-prevention) — centralises the cfg-clone + cfg-zero override + apply_policy + rolling-floor sequence so both `admit_with_metadata` and `relay_metadata` cannot drift.
- `admit_with_metadata` validation chain rewritten to match Go `addToMempoolLocked` order exactly (apply_non_coinbase → apply_post_consensus_policy_with_floor → capacity_eviction).
- `relay_metadata` mirrors admit's policy sequence via the same helper. **NEW (wave-2): relay_metadata now enforces the rolling relay floor (returns `Unavailable` for sub-floor DA tx)** — equivalent to admit. Pre-wave-2 relay_metadata only enforced DA-side terms; this created a production peer-relay divergence (`tx_relay::handle_received_tx` would propagate sub-floor DA tx that admit rejected). Go avoids the divergence in the full node via `CanonicalMempoolRelayMetadata` + `CanonicalMempoolTxPool.Put` re-running admission; the Rust equivalent is the inline floor check via the shared helper.
- Capacity error message split (3 distinct messages: 2 corruption invariants + Go-parity verbatim "mempool capacity candidate rejected by eviction ordering" at clients/go/node/mempool.go:1028-1030).
- `reject_da_anchor_tx_policy` non-DA short-circuit comment rewritten to describe the current split.

DA error class ordering (the P1 fix): a DA tx whose DA fee passes the DA-side floor but fails the rolling relay floor classifies as `Unavailable` (transient/retryable) — matching Go `validateFeeFloorLocked` — NOT as `Rejected` from the DA helper. DA tx whose DA fee fails the DA-side floor still classifies as `Rejected` (preserved RUB-122 baseline). Wave-2 made this hold on BOTH the admit and relay paths via `validate_fee_floor`. Wave-3 wrapped the shared sequence in `apply_post_consensus_policy_with_floor` so the property cannot drift between the two public gates.

Out of scope (deferred): producer wiring (admit_remote / admit_reorg / admit_with_source) is RUB-163 (#1408); legacy test/helpers cleanup is RUB-164 (#1409); rolling-floor lifecycle (raise/decay) is follow-up; conformance vectors are RUB-54; fast-reject / cheap precheck for spam DoS mitigation is RUB-165 (#1411 Go) + RUB-166 (#1412 Rust). PR body explicitly disclaims full RUB-53 parity. No new types/enums/Stats/AdmissionCounts/MempoolCapacityState/add_entry_locked surface introduced.

## Evidence

- 23 new `rub162_*` tests cover the 4 Phase A invariants end-to-end through the public `TxPool::admit` / `relay_metadata` surface (failure-atomicity, cleanup state symmetry, DA error class ordering, cross-pollination ordering pins).
- 13 existing `stage_c_*` RUB-122 DA fee policy tests pass unchanged.
- 19 `admit_*` legacy tests preserved with controller-Q2-rationale fixture migrations (input value bumps + one rename to behaviour-accurate name).
- 1 conformance test (`relay_metadata_rejects_sub_floor_conformance_tx_as_unavailable`) repurposed to assert Unavailable + atomicity (wave-2 polarity flip after relay floor enforcement).
- 3 new wave-2 relay matrix tests pin: `_da_below_rolling_floor_returns_unavailable_matching_admit`, `_da_below_da_floor_returns_rejected_not_unavailable`, `_da_above_both_floors_returns_ok`.
- 1 new wave-2 capacity error pin test: `rub162_admit_pool_full_eviction_ordering_message_distinct_from_invariant`.
- `cargo fmt --check` clean.
- `cargo clippy -p rubin-node --tests --no-deps -- -D warnings` clean.
- `cargo test -p rubin-node --lib` 540/540 PASS (including TCP-serial mode).
- Subagent pre-push-reviewer (hostile-style) on wave-2: PASS, 0 findings.
- Subagent coderabbit:code-reviewer on wave-2: APPROVED, 0 CRITICAL/IMPORTANT, 3 NIT (2 applied in polish; 3rd deferred per "not worth churning").
- /security-review on wave-2 final HEAD: 0 high-confidence vulnerabilities.
- Wave-3 drift-prevention helper extraction; wave-3.5 dropped vestigial conformance fixture coupling in submit_tx_accepts_floor_compliant_p2pk_tx (per Copilot wave-3 Thread C).

Refs: Linear RUB-162, GitHub issue #1407 (parent: #1339, Phase B: #1408, Phase C: #1409, follow-ups: #1411 / #1412).