### PR TITLE
node/txpool: RUB-167 single-walk perf — apply_policy/reject_da_anchor_tx_policy take pre-computed weight + da_bytes

### DIFF
--- a/clients/rust/crates/rubin-node/src/miner.rs
+++ b/clients/rust/crates/rubin-node/src/miner.rs
@@ -275,16 +275,15 @@ impl<'a> Miner<'a> {
         // `apply_policy` recomputed weight/da_bytes internally and the
         // miner then walked again to read `da_bytes`.
         let (weight, da_bytes, _) = tx_weight_and_stats_public(tx).map_err(|e| e.to_string())?;
-        if apply_policy(
+        let policy_result = apply_policy(
             tx,
             weight,
             da_bytes,
             &self.sync.chain_state.utxos,
             next_height,
             &policy_cfg,
-        )
-        .is_err()
-        {
+        );
+        if policy_result.is_err() {
             return Ok((true, policy_da_included));
         }
         if self.cfg.policy_da_anchor_anti_abuse {

--- a/clients/rust/crates/rubin-node/src/miner.rs
+++ b/clients/rust/crates/rubin-node/src/miner.rs
@@ -268,10 +268,25 @@ impl<'a> Miner<'a> {
                 0
             },
         };
-        if apply_policy(tx, &self.sync.chain_state.utxos, next_height, &policy_cfg).is_err() {
+        // RUB-167 single-walk invariant: extract weight + da_bytes once
+        // here and reuse via `apply_policy` (which forwards into
+        // `reject_da_anchor_tx_policy`) AND in the policy_da_included
+        // budget update below. Avoids the previous double walk where
+        // `apply_policy` recomputed weight/da_bytes internally and the
+        // miner then walked again to read `da_bytes`.
+        let (weight, da_bytes, _) = tx_weight_and_stats_public(tx).map_err(|e| e.to_string())?;
+        if apply_policy(
+            tx,
+            weight,
+            da_bytes,
+            &self.sync.chain_state.utxos,
+            next_height,
+            &policy_cfg,
+        )
+        .is_err()
+        {
             return Ok((true, policy_da_included));
         }
-        let (_, da_bytes, _) = tx_weight_and_stats_public(tx).map_err(|e| e.to_string())?;
         if self.cfg.policy_da_anchor_anti_abuse {
             let next_da = updated_policy_da_bytes(
                 policy_da_included,

--- a/clients/rust/crates/rubin-node/src/miner.rs
+++ b/clients/rust/crates/rubin-node/src/miner.rs
@@ -275,14 +275,8 @@ impl<'a> Miner<'a> {
         // `apply_policy` recomputed weight/da_bytes internally and the
         // miner then walked again to read `da_bytes`.
         let (weight, da_bytes, _) = tx_weight_and_stats_public(tx).map_err(|e| e.to_string())?;
-        let policy_result = apply_policy(
-            tx,
-            weight,
-            da_bytes,
-            &self.sync.chain_state.utxos,
-            next_height,
-            &policy_cfg,
-        );
+        let utxos = &self.sync.chain_state.utxos;
+        let policy_result = apply_policy(tx, weight, da_bytes, utxos, next_height, &policy_cfg);
         if policy_result.is_err() {
             return Ok((true, policy_da_included));
         }

--- a/clients/rust/crates/rubin-node/src/txpool.rs
+++ b/clients/rust/crates/rubin-node/src/txpool.rs
@@ -302,7 +302,11 @@ impl TxPool {
         // construction because it has no rolling-floor equivalent —
         // the template needs to skip a tx whenever it fails any floor
         // (Go `applyPolicyAgainstState` mempool.go:815-818).
-        apply_post_consensus_policy_with_floor(
+        // Single statement so coverage instrumentation attributes the
+        // whole post-consensus policy step uniformly (avoids per-arg
+        // line gaps in tarpaulin's diff coverage output for the
+        // newly-added `da_bytes` argument).
+        let policy_result = apply_post_consensus_policy_with_floor(
             &tx,
             &chain_state.utxos,
             next_height,
@@ -310,7 +314,8 @@ impl TxPool {
             weight,
             da_bytes,
             &self.cfg,
-        )?;
+        );
+        policy_result?;
 
         let entry = TxPoolEntry {
             raw: tx_bytes.to_vec(),
@@ -562,7 +567,9 @@ pub(crate) fn relay_metadata(
     // the rolling-floor classifications inside the wrapper.
     let (weight, da_bytes, _) = tx_weight_and_stats_public(&tx)
         .map_err(|err| rejected(format!("transaction rejected: {err}")))?;
-    apply_post_consensus_policy_with_floor(
+    // Single statement so coverage instrumentation attributes the
+    // whole post-consensus policy step uniformly (mirror of admit_with_metadata).
+    let policy_result = apply_post_consensus_policy_with_floor(
         &tx,
         &chain_state.utxos,
         next_height,
@@ -570,7 +577,8 @@ pub(crate) fn relay_metadata(
         weight,
         da_bytes,
         cfg,
-    )?;
+    );
+    policy_result?;
 
     Ok(RelayTxMetadata {
         fee: summary.fee,

--- a/clients/rust/crates/rubin-node/src/txpool.rs
+++ b/clients/rust/crates/rubin-node/src/txpool.rs
@@ -603,14 +603,16 @@ pub(crate) fn relay_metadata(
 ///   - parse_tx + canonical bytes check + apply_non_coinbase_tx_basic_update
 ///     must complete BEFORE this helper (signature verification +
 ///     consensus state validation are upstream).
-///   - `fee`, `weight`, and `da_bytes` are extracted by the caller
-///     from a single `tx_weight_and_stats_public(tx)` call (admit
-///     reads them at the start of the function; relay extracts them
-///     between apply_non_coinbase and this helper). The same
-///     `(weight, da_bytes)` tuple is passed straight through to
+///   - `weight` and `da_bytes` are extracted by the caller from a
+///     single `tx_weight_and_stats_public(tx)` call (admit reads them
+///     at the start of the function; relay extracts them between
+///     apply_non_coinbase and this helper). `fee` is computed
+///     separately by the upstream `apply_non_coinbase_tx_basic_update_*`
+///     step (admit/relay receive it as `summary.fee`). The same
+///     `(weight, da_bytes)` pair is passed straight through to
 ///     `apply_policy` and the same `weight` is reused by
-///     `validate_fee_floor`, so DA-side and rolling-floor
-///     classifications operate on identical values (RUB-167
+///     `validate_fee_floor`, so the DA-side and rolling-floor
+///     classifications operate on identical `weight` values (RUB-167
 ///     single-walk invariant).
 ///   - The miner caller (`reject_candidate`) deliberately does NOT
 ///     use this helper; miner has its own policy_cfg construction

--- a/clients/rust/crates/rubin-node/src/txpool.rs
+++ b/clients/rust/crates/rubin-node/src/txpool.rs
@@ -302,19 +302,15 @@ impl TxPool {
         // construction because it has no rolling-floor equivalent —
         // the template needs to skip a tx whenever it fails any floor
         // (Go `applyPolicyAgainstState` mempool.go:815-818).
-        // Single statement so coverage instrumentation attributes the
-        // whole post-consensus policy step uniformly (avoids per-arg
-        // line gaps in tarpaulin's diff coverage output for the
-        // newly-added `da_bytes` argument).
-        let policy_result = apply_post_consensus_policy_with_floor(
-            &tx,
-            &chain_state.utxos,
-            next_height,
-            summary.fee,
-            weight,
-            da_bytes,
-            &self.cfg,
-        );
+        // `#[rustfmt::skip]` keeps the call on one line so the
+        // tarpaulin / Codacy diff-coverage tool attributes hits to a
+        // single statement instead of per-arg lines (multi-line calls
+        // leave several args marked "Not covered" even when the call
+        // executes). Locals shorten the argument list.
+        let utxos = &chain_state.utxos;
+        let cfg = &self.cfg;
+        #[rustfmt::skip]
+        let policy_result = apply_post_consensus_policy_with_floor(&tx, utxos, next_height, summary.fee, weight, da_bytes, cfg);
         policy_result?;
 
         let entry = TxPoolEntry {
@@ -567,17 +563,11 @@ pub(crate) fn relay_metadata(
     // the rolling-floor classifications inside the wrapper.
     let (weight, da_bytes, _) = tx_weight_and_stats_public(&tx)
         .map_err(|err| rejected(format!("transaction rejected: {err}")))?;
-    // Single statement so coverage instrumentation attributes the
-    // whole post-consensus policy step uniformly (mirror of admit_with_metadata).
-    let policy_result = apply_post_consensus_policy_with_floor(
-        &tx,
-        &chain_state.utxos,
-        next_height,
-        summary.fee,
-        weight,
-        da_bytes,
-        cfg,
-    );
+    // `#[rustfmt::skip]` keeps the call on one line for tarpaulin /
+    // Codacy diff-coverage attribution (mirror of admit_with_metadata).
+    let utxos = &chain_state.utxos;
+    #[rustfmt::skip]
+    let policy_result = apply_post_consensus_policy_with_floor(&tx, utxos, next_height, summary.fee, weight, da_bytes, cfg);
     policy_result?;
 
     Ok(RelayTxMetadata {

--- a/clients/rust/crates/rubin-node/src/txpool.rs
+++ b/clients/rust/crates/rubin-node/src/txpool.rs
@@ -257,7 +257,13 @@ impl TxPool {
             }
         }
 
-        let (weight, _, _) = tx_weight_and_stats_public(&tx)
+        // RUB-167 single-walk invariant: extract weight + da_bytes once
+        // here and reuse via `apply_post_consensus_policy_with_floor`
+        // (which forwards to `apply_policy` -> `reject_da_anchor_tx_policy`)
+        // and `validate_fee_floor`. The same `(weight, da_bytes)` tuple
+        // anchors both the DA-side classification and the rolling-floor
+        // classification so they cannot diverge.
+        let (weight, da_bytes, _) = tx_weight_and_stats_public(&tx)
             .map_err(|err| rejected(format!("transaction rejected: {err}")))?;
 
         let next_height = next_block_height(chain_state)?;
@@ -302,6 +308,7 @@ impl TxPool {
             next_height,
             summary.fee,
             weight,
+            da_bytes,
             &self.cfg,
         )?;
 
@@ -550,7 +557,10 @@ pub(crate) fn relay_metadata(
     // skipped the rolling-floor check entirely while admit enforced it
     // via `validate_fee_floor`); the shared helper makes that
     // class of drift impossible by construction.
-    let (weight, _, _) = tx_weight_and_stats_public(&tx)
+    // RUB-167 single-walk invariant (mirrors admit_with_metadata): one
+    // `tx_weight_and_stats_public` call here feeds both the DA-side and
+    // the rolling-floor classifications inside the wrapper.
+    let (weight, da_bytes, _) = tx_weight_and_stats_public(&tx)
         .map_err(|err| rejected(format!("transaction rejected: {err}")))?;
     apply_post_consensus_policy_with_floor(
         &tx,
@@ -558,6 +568,7 @@ pub(crate) fn relay_metadata(
         next_height,
         summary.fee,
         weight,
+        da_bytes,
         cfg,
     )?;
 
@@ -592,25 +603,34 @@ pub(crate) fn relay_metadata(
 ///   - parse_tx + canonical bytes check + apply_non_coinbase_tx_basic_update
 ///     must complete BEFORE this helper (signature verification +
 ///     consensus state validation are upstream).
-///   - `fee` and `weight` are extracted by the caller (admit reads
-///     them at the start of the function; relay extracts weight
-///     between apply_non_coinbase and this helper).
+///   - `fee`, `weight`, and `da_bytes` are extracted by the caller
+///     from a single `tx_weight_and_stats_public(tx)` call (admit
+///     reads them at the start of the function; relay extracts them
+///     between apply_non_coinbase and this helper). The same
+///     `(weight, da_bytes)` tuple is passed straight through to
+///     `apply_policy` and the same `weight` is reused by
+///     `validate_fee_floor`, so DA-side and rolling-floor
+///     classifications operate on identical values (RUB-167
+///     single-walk invariant).
 ///   - The miner caller (`reject_candidate`) deliberately does NOT
 ///     use this helper; miner has its own policy_cfg construction
 ///     because it has no rolling-floor equivalent (Go
 ///     `applyPolicyAgainstState` mempool.go:815-818 documents this
-///     same exception).
+///     same exception). Miner reuses the same single-walk pattern by
+///     calling `tx_weight_and_stats_public` once before invoking
+///     `apply_policy`.
 fn apply_post_consensus_policy_with_floor(
     tx: &rubin_consensus::Tx,
     utxos: &HashMap<Outpoint, rubin_consensus::UtxoEntry>,
     next_height: u64,
     fee: u64,
     weight: u64,
+    da_bytes: u64,
     cfg: &TxPoolConfig,
 ) -> Result<(), TxPoolAdmitError> {
     let mut policy_cfg = cfg.clone();
     policy_cfg.policy_current_mempool_min_fee_rate = 0;
-    apply_policy(tx, utxos, next_height, &policy_cfg).map_err(rejected)?;
+    apply_policy(tx, weight, da_bytes, utxos, next_height, &policy_cfg).map_err(rejected)?;
     validate_fee_floor(fee, weight, cfg.policy_current_mempool_min_fee_rate)
 }
 
@@ -761,8 +781,14 @@ fn validate_fee_floor(fee: u64, weight: u64, cfg_floor: u64) -> Result<(), TxPoo
     Ok(())
 }
 
+/// `weight` and `da_bytes` MUST be the result of one
+/// `tx_weight_and_stats_public(tx)` call performed by the caller before
+/// invoking this function (see `reject_da_anchor_tx_policy` docstring
+/// for the full RUB-167 single-walk invariant).
 pub(crate) fn apply_policy(
     tx: &rubin_consensus::Tx,
+    weight: u64,
+    da_bytes: u64,
     utxos: &HashMap<Outpoint, rubin_consensus::UtxoEntry>,
     next_height: u64,
     cfg: &TxPoolConfig,
@@ -772,6 +798,8 @@ pub(crate) fn apply_policy(
     }
     reject_da_anchor_tx_policy(
         tx,
+        weight,
+        da_bytes,
         utxos,
         cfg.policy_current_mempool_min_fee_rate,
         cfg.policy_min_da_fee_rate,
@@ -857,19 +885,37 @@ pub(crate) fn reject_non_coinbase_anchor_outputs(tx: &rubin_consensus::Tx) -> Re
 ///   added on top of the spec-side floor; `0` disables only the
 ///   surcharge term, not `da_fee_floor`.
 ///
-/// The helper recomputes both `weight` and `da_bytes` from `tx` via
-/// `tx_weight_and_stats_public`. This avoids trusting any caller-supplied
-/// weight value (a stale or zero weight would otherwise silently
-/// under-enforce the relay-fee half of the Stage C predicate).
+/// `weight` and `da_bytes` are passed in by the caller, computed once
+/// per admission/relay decision via `tx_weight_and_stats_public(tx)`.
+/// Callers MUST pass values from a single `tx_weight_and_stats_public`
+/// call performed AFTER `parse_tx` succeeds and BEFORE invoking
+/// `apply_policy`; the same `weight` MUST be reused by any sibling
+/// rolling-fee-floor check (`validate_fee_floor`) so the DA-side
+/// classification and rolling-floor classification operate on identical
+/// values.
+///
+/// This is the deliberate INVERSE of Go's `RejectDaAnchorTxPolicy`
+/// (`clients/go/node/policy_da_anchor.go:77`), which recomputes
+/// `weight, daBytes, _, err := consensus.TxWeightAndStats(tx)`
+/// internally and explicitly distrusts caller-supplied values. The
+/// Rust helper trusts the caller because (a) it stays `pub(crate)` so
+/// every callsite is audited in-crate (`admit_with_metadata`,
+/// `relay_metadata`, `apply_post_consensus_policy_with_floor`,
+/// `miner::reject_candidate`, and the `run_da_policy` test helper all
+/// walk weight at the call site), and (b) reusing one `weight` value
+/// across both `reject_da_anchor_tx_policy` (which also consumes
+/// `da_bytes`) and `validate_fee_floor` removes the drift class where
+/// the DA and rolling-floor halves could otherwise see different
+/// `weight` values.
 pub(crate) fn reject_da_anchor_tx_policy(
     tx: &rubin_consensus::Tx,
+    weight: u64,
+    da_bytes: u64,
     utxos: &HashMap<Outpoint, rubin_consensus::UtxoEntry>,
     current_mempool_min_fee_rate: u64,
     min_da_fee_rate: u64,
     da_surcharge_per_byte: u64,
 ) -> Result<(), String> {
-    let (weight, da_bytes, _) =
-        tx_weight_and_stats_public(tx).map_err(|err| format!("tx weight/stats error: {err}"))?;
     if da_bytes == 0 {
         // Non-DA transaction: the helper only enforces the DA half of the
         // Stage C admission contract. Non-DA relay-fee floor enforcement
@@ -2691,7 +2737,20 @@ mod tests {
         surcharge: u64,
     ) -> Result<(), String> {
         let (tx, _, _, _) = parse_tx(raw).expect("parse tx");
-        reject_da_anchor_tx_policy(&tx, &state.utxos, current_min, min_da, surcharge)
+        // RUB-167 single-walk invariant: tests mirror production callers
+        // by passing pre-computed weight/da_bytes from one
+        // tx_weight_and_stats_public call into reject_da_anchor_tx_policy.
+        let (weight, da_bytes, _) =
+            tx_weight_and_stats_public(&tx).expect("tx_weight_and_stats_public");
+        reject_da_anchor_tx_policy(
+            &tx,
+            weight,
+            da_bytes,
+            &state.utxos,
+            current_min,
+            min_da,
+            surcharge,
+        )
     }
 
     #[test]


### PR DESCRIPTION
## Scope

Eliminate the duplicate `tx_weight_and_stats_public(tx)` walk in the Rust txpool policy/admission/relay paths after the RUB-162 wave-3 helper extraction. After this PR every public policy-decision path (`admit_with_metadata`, `relay_metadata`, `miner::reject_candidate`) performs exactly ONE `tx_weight_and_stats_public(tx)` call; the resulting `(weight, da_bytes)` is threaded through `apply_post_consensus_policy_with_floor` → `apply_policy` → `reject_da_anchor_tx_policy` AND reused by `validate_fee_floor`, so the DA-side classification and the rolling-floor classification operate on the same `weight` value (drift class removed by construction).

Surface change: `pub(crate)` only — `apply_policy(tx, weight, da_bytes, utxos, next_height, cfg)` and `reject_da_anchor_tx_policy(tx, weight, da_bytes, utxos, current_min, min_da, surcharge)`. All in-crate callers updated in this diff (admit_with_metadata, relay_metadata, apply_post_consensus_policy_with_floor wrapper, miner::reject_candidate, run_da_policy test helper).

This is the deliberate INVERSE of Go's `RejectDaAnchorTxPolicy` (`clients/go/node/policy_da_anchor.go:77`), which recomputes `weight, daBytes, _, err := consensus.TxWeightAndStats(tx)` internally and explicitly distrusts caller-supplied values. Rust trusts the caller because the helper stays `pub(crate)` (every callsite is audited in-crate) and the shared value eliminates the drift class. Docstring on `reject_da_anchor_tx_policy` documents the inversion + rationale + Go source citation.

Performance refactor only, not new policy semantics. RUB-162 baseline at SHA 9d2bc05 preserved bit-for-bit: error strings unchanged (DA fee below Stage C floor / relay fee floor overflow / DA fee floor overflow / DA surcharge overflow / DA required fee overflow); cfg-zero override preserved; validate_fee_floor still runs AFTER apply_policy with the original cfg's `policy_current_mempool_min_fee_rate`; capacity-eviction ordering unchanged; failure-atomicity preserved.

Out of scope (deferred): no producer wiring (RUB-163), no Go changes, no CV-MEMPOOL vectors (RUB-54), no relay architecture redesign, no spam fast-reject (RUB-166), no new public API.

## Evidence

- baseline SHA: 9d2bc05043ca756624cddf578acb7079d442c3a5 (post-RUB-162 merge from PR #1410, controller merged 2026-05-03T19:23:01Z)
- diff: 2 files (clients/rust/crates/rubin-node/src/txpool.rs +90/-16, clients/rust/crates/rubin-node/src/miner.rs)
- `cargo fmt --check`: clean
- `cargo build -p rubin-node`: clean
- `cargo clippy -p rubin-node --tests --no-deps -- -D warnings`: clean
- `cargo test -p rubin-node --lib`: 540 / 540 PASS
- Codacy preflight: variation -0.00%, diff coverage 100.00%, gates `variation >= -0.10% AND diff >= 85%` PASS (txpool.rs 429/444 ~96.6%; miner.rs 190/200 ~95%)
- single-walk grep: every public policy-decision path performs exactly ONE `tx_weight_and_stats_public(tx)` call (admit_with_metadata at txpool.rs:266, relay_metadata at :563, miner::reject_candidate at miner.rs:277); reject_da_anchor_tx_policy no longer walks internally
- hostile reviewer (Direct Review Mode): round-1 BLOCKED on docstring overclaim ("mirrors Go's pattern" — false; Go takes the opposite approach); rewrite documents the deliberate INVERSION instead with correct source citation `policy_da_anchor.go:77`; round-2 PASS