### PR TITLE
RUB-171: wire devnet RPC submit_tx as Local source-aware producer

### DIFF
--- a/clients/rust/crates/rubin-node/src/devnet_rpc.rs
+++ b/clients/rust/crates/rubin-node/src/devnet_rpc.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::miner::{Miner, MinerConfig};
 use crate::p2p_runtime::PeerManager;
+use crate::txpool::TxSource;
 use crate::{BlockStore, SyncEngine, TxPool, TxPoolAdmitErrorKind, TxPoolConfig};
 
 const MAX_HEADER_BYTES: usize = 64 * 1024;
@@ -785,12 +786,25 @@ fn handle_submit_tx(state: &DevnetRPCState, method: &str, body: &[u8]) -> HttpRe
             );
         }
     };
+    // RUB-171 producer-wiring slice (RUB-163 child). Devnet RPC submit_tx is
+    // the canonical Local producer entry into the txpool: it admits a
+    // user-submitted transaction on the local node, mirroring Go
+    // `handleSubmitTx` (clients/go/cmd/rubin-node/http_rpc.go:924) which
+    // calls `mempool.AddTx` -> `addTxWithSource(_, mempoolTxSourceLocal)`
+    // (clients/go/node/mempool.go:411). Tagging the admission as
+    // `TxSource::Local` is observability metadata only — admission ordering,
+    // eviction priority and consensus semantics remain source-blind (see
+    // `txpool.rs::compare_entries_for_mining` and the
+    // `source_does_not_affect_admission_ordering` test from RUB-174). Source
+    // is recorded on the resulting `TxPoolEntry` and surfaced via
+    // `TxPool::entry_source` for downstream parity tests.
     let admit_result = match state.tx_pool.lock() {
-        Ok(mut pool) => pool.admit_with_metadata(
+        Ok(mut pool) => pool.add_tx_with_source(
             &tx_bytes,
             &chain_state,
             fresh_block_store.as_ref(),
             chain_id,
+            TxSource::Local,
         ),
         Err(_) => Err(crate::TxPoolAdmitError {
             kind: TxPoolAdmitErrorKind::Unavailable,
@@ -2027,6 +2041,7 @@ mod tests {
 
     use crate::io_utils::unique_temp_path;
     use crate::test_helpers::signed_conflicting_p2pk_state_and_txs;
+    use crate::txpool::TxSource;
     use crate::{
         block_store_path, default_peer_runtime_config, default_sync_config,
         devnet_genesis_block_bytes, devnet_genesis_chain_id, BlockStore, ChainState, MinerConfig,
@@ -2870,6 +2885,98 @@ mod tests {
         assert!(metrics.contains(r#"rubin_node_submit_tx_total{result="accepted"} 1"#));
         assert!(
             metrics.contains(r#"rubin_node_rpc_requests_total{route="/submit_tx",status="200"} 1"#)
+        );
+    }
+
+    #[test]
+    fn submit_tx_records_local_source_provenance_on_accepted_admission() {
+        // RUB-171 producer-wiring slice (RUB-163 child). Devnet RPC
+        // /submit_tx admits user-submitted transactions as the canonical
+        // Local txpool producer (mirrors Go handleSubmitTx ->
+        // mempool.AddTx -> addTxWithSource(_, mempoolTxSourceLocal)).
+        //
+        // Reachability: the test drives a real /submit_tx request through
+        // `route_request` (NOT via TxPool::add_tx_with_source helper) so
+        // the full RPC handler -> rpc_op lock -> tx_pool lock ->
+        // add_tx_with_source(_, TxSource::Local) chain runs end to end.
+        // Helper-only coverage of source recording is already exercised
+        // by RUB-174 baseline tests in txpool.rs; this slice's invariant
+        // is the runtime path through the RPC producer surface.
+        //
+        // Proof assertion: assert_eq!(pool.entry_source(&txid),
+        // Some(TxSource::Local)) below pins the producer-source variant
+        // recorded by handle_submit_tx for the admitted entry. Mutating
+        // the production line from TxSource::Local to TxSource::Remote
+        // or TxSource::Reorg makes this exact assertion fail with
+        // `left: Some(Remote|Reorg), right: Some(Local)`. Reverting to
+        // the legacy pool.admit_with_metadata wrapper still defaults to
+        // Local under the RUB-174 wrapper-chain, so that revert is a
+        // code-readability / grep-discoverability regression rather than
+        // a runtime-asserted regression.
+        //
+        // Proof assertion (control): assert_eq!(control_pool.entry_source(
+        // &control_txid), Some(TxSource::Reorg)) below admits a separate
+        // tx via add_tx_with_source(_, TxSource::Reorg) on a fresh
+        // TxPool::new() and pins the recorded variant. This proves the
+        // accessor is genuinely variant-discriminating: a regression
+        // that hardcoded entry_source to a single variant would still
+        // pass the primary Local assertion above but fail the Reorg
+        // assertion in the control branch below.
+        let (chain_state, raw, chain_id) = floor_compliant_signed_tx_and_state();
+        let (_tx, txid, _wtxid, consumed) = parse_tx(&raw).expect("parse tx");
+        assert_eq!(consumed, raw.len());
+
+        let state = build_state_with_chain_state(chain_state, chain_id);
+        let response = route_request(
+            &state,
+            HttpRequest {
+                method: "POST".to_string(),
+                target: "/submit_tx".to_string(),
+                body: format!(r#"{{"tx_hex":"{}"}}"#, hex::encode(&raw)).into_bytes(),
+            },
+        );
+
+        assert_eq!(response.status, 200);
+        let body = response_json(&response);
+        assert_eq!(body["accepted"].as_bool(), Some(true));
+
+        // Primary assertion: the entry admitted through the RPC submit
+        // path carries the Local source tag (would FAIL with Remote /
+        // Reorg / None on any mutation of the production line).
+        let pool = state.tx_pool.lock().expect("tx pool");
+        assert_eq!(
+            pool.entry_source(&txid),
+            Some(TxSource::Local),
+            "RPC /submit_tx must record TxSource::Local provenance on the admitted entry",
+        );
+        drop(pool);
+
+        // Mutation-distinguishing control: admit a SEPARATE tx into a
+        // FRESH pool (with its own state) directly via the source-aware
+        // API with TxSource::Reorg, and verify entry_source returns
+        // Reorg. This proves entry_source is genuinely variant-aware
+        // and is not silently returning a constant. If the accessor or
+        // recording was hardcoded to a single variant, the primary
+        // assertion above would still pass for that variant — this
+        // control catches that class of regression.
+        let (control_state, control_raw, control_chain_id) = floor_compliant_signed_tx_and_state();
+        let (_ctx, control_txid, _cwtxid, ccons) =
+            parse_tx(&control_raw).expect("parse control tx");
+        assert_eq!(ccons, control_raw.len());
+        let mut control_pool = TxPool::new();
+        control_pool
+            .add_tx_with_source(
+                &control_raw,
+                &control_state,
+                None,
+                control_chain_id,
+                TxSource::Reorg,
+            )
+            .expect("control admit");
+        assert_eq!(
+            control_pool.entry_source(&control_txid),
+            Some(TxSource::Reorg),
+            "TxPool::entry_source must return the variant recorded at admission time",
         );
     }
 
@@ -3786,13 +3893,24 @@ mod tests {
         let payload = raw.to_vec();
         let client = std::thread::spawn(move || {
             let mut stream = TcpStream::connect(addr).expect("connect");
+            // RUB-171 wave-1 fix: set the read timeout BEFORE
+            // `shutdown(Write)`. On macOS, `setsockopt(SO_RCVTIMEO)` after
+            // a half-close transitions can return `EINVAL` (errno 22)
+            // because the socket leaves the state where `setsockopt` is
+            // accepted on the receive direction. Under regular `cargo
+            // test` the close completes after this call so the test races
+            // through; under `cargo tarpaulin` instrumentation the close
+            // serializes earlier and the call deterministically fails.
+            // Setting the timeout first preserves the read-timeout
+            // semantics needed below and is portable across macOS / Linux
+            // socket behaviour.
+            stream
+                .set_read_timeout(Some(Duration::from_secs(2)))
+                .expect("set read timeout");
             stream.write_all(&payload).expect("write payload");
             stream
                 .shutdown(std::net::Shutdown::Write)
                 .expect("shutdown write");
-            stream
-                .set_read_timeout(Some(Duration::from_secs(2)))
-                .expect("set read timeout");
             let mut response = Vec::new();
             let _ = stream.read_to_end(&mut response);
             response


### PR DESCRIPTION
## Scope

Rust producer-wiring slice (RUB-163 child) on top of RUB-174 source-aware admission API and RUB-169 reorg producer wiring. Routes the `handle_submit_tx` admit call in `devnet_rpc.rs` through `pool.add_tx_with_source(_, _, _, _, TxSource::Local)` so accepted /submit_tx admissions explicitly carry `Local` provenance. Mirrors Go `handleSubmitTx` -> `mempool.AddTx` -> `addTxWithSource(_, mempoolTxSourceLocal)` chain (`clients/go/cmd/rubin-node/http_rpc.go:924` -> `clients/go/node/mempool.go:411`).

Also reorders `set_read_timeout` BEFORE `shutdown(Write)` in the `handle_connection_roundtrip` test helper. On macOS `setsockopt(SO_RCVTIMEO)` after a half-close transition can return `EINVAL` because the kernel rejects receive-side socket options once `SS_CANTRCVMORE` is set. Pure test infrastructure fix; no production semantics change.

Does NOT change:

- admission semantics (source remains observability metadata only — verified source-blind by RUB-174 baseline test `source_does_not_affect_admission_ordering`)
- RPC response shape (accepted/txid/error fields unchanged)
- announce timing (post-admission, fire-and-forget)
- error classification (Conflict/Rejected/Unavailable -> 409/422/503 preserved)
- producer wiring outside `devnet_rpc.rs` (RUB-170, RUB-172, RUB-173 each own their surface)
- Go reference implementation (read-only)

Files touched: `clients/rust/crates/rubin-node/src/devnet_rpc.rs` (+122/-4).

## Evidence

- `cargo fmt --check` clean
- `cargo clippy -p rubin-node --tests --no-deps -- -D warnings` clean
- `cargo test -p rubin-node --lib` PASS 574/574
- `rubin-common-preflight --allow-rust --serial-rust-tests` PASS 7/7 (bot-premortem, git-diff-check, tcp-test-serial-enforce, http-parser-invariants, local-agent-hygiene, tooling-check, rubin-protocol-coverage)
- 4 local Opus reviewer agents: hostile PASS / parity PARITY OK 7/7 dimensions / security NO HIGH-CONFIDENCE VULNS / pre-push PASS
- pre-push reviewer EMPIRICALLY mutated `TxSource::Local` -> `TxSource::Remote`, test FAILED with `Some(Remote) vs Some(Local)`; restored -> PASS. Mutation kill confirmed.