### PR TITLE
RUB-176: token-aware tx_relay canonical-admission boundary checker (#1432)

### DIFF
--- a/clients/rust/Cargo.lock
+++ b/clients/rust/Cargo.lock
@@ -507,6 +507,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3",
+ "syn",
 ]
 
 [[package]]

--- a/clients/rust/crates/rubin-node/Cargo.toml
+++ b/clients/rust/crates/rubin-node/Cargo.toml
@@ -14,6 +14,13 @@ rubin-consensus = { path = "../rubin-consensus" }
 
 [dev-dependencies]
 criterion = "0.5"
+# RUB-176 / GitHub #1432: token-aware tx_relay canonical-admission boundary
+# checker. Test-only AST parser used by tx_relay.rs's boundary checker module
+# to walk the production AST and detect direct syntactic canonical TxPool
+# admission call expressions while ignoring comments, string literals, raw
+# strings, doc comments, and `#[cfg(test)]` items. Scoped to dev-dependencies
+# so it never enters the production binary or the runtime dependency graph.
+syn = { version = "2", features = ["full", "visit"] }
 
 [[bench]]
 name = "runtime_baseline"

--- a/clients/rust/crates/rubin-node/src/tx_relay.rs
+++ b/clients/rust/crates/rubin-node/src/tx_relay.rs
@@ -1248,8 +1248,8 @@ mod tests {
         use syn::parse::{Parse, ParseStream};
         use syn::visit::Visit;
         use syn::{
-            Attribute, Expr, ExprCall, ExprMethodCall, ExprPath, File, Ident, ImplItem, Item,
-            ItemFn, Lit, LitBool, Path, QSelf, Token, TraitItem, Type,
+            Arm, Attribute, Expr, ExprCall, ExprMethodCall, ExprPath, File, Ident, ImplItem, Item,
+            ItemFn, Lit, LitBool, Path, QSelf, Stmt, Token, TraitItem, Type,
         };
 
         /// Method idents that constitute canonical `TxPool` admission per
@@ -1390,45 +1390,109 @@ mod tests {
             attrs_imply_test(attrs)
         }
 
-        fn attrs_imply_test(attrs: &[Attribute]) -> bool {
-            attrs.iter().any(attr_implies_test)
-        }
-
-        // Returns true iff this `#[cfg(...)]` attribute's predicate
-        // logically implies `test ∈ C` for every config C that
-        // satisfies it. Skip-from-production rule:
-        //   skip(I) ⇔ ∀C. P(I)(C) ⇒ test ∈ C
+        // Returns true iff the conjunction of every `#[cfg(...)]`
+        // attribute on the carrier (Item / ImplItem / TraitItem /
+        // Expr / Stmt / Arm) logically implies `test ∈ C` for every
+        // config C that satisfies all of them. Multiple
+        // `#[cfg(P1)] #[cfg(P2)]` attributes on the same carrier are
+        // AND-ed by Rust, so the carrier is enabled iff `P1 ∧ P2 ∧ …`,
+        // and `(P1 ∧ P2 ∧ …) ⇒ test` is the right skip predicate.
+        //
+        // Skip-from-production rule:
+        //   skip(I) ⇔ ∀C. (∧ᵢ Pᵢ(I)(C)) ⇒ test ∈ C
         // per the Rust reference's ConfigurationPredicate grammar
         // (`all` / `any` / `not` / option / `true` / `false`).
         //
-        // Algorithm: parse the attribute body into a `CfgPred` AST
-        // and evaluate it symbolically with `test = false` and every
-        // other identifier left as a free Boolean variable. The
-        // predicate `P` implies test iff `P` is decidably-
-        // unsatisfiable in the world where test is absent.
-        // `value_under_test_absent` returns:
+        // Algorithm: parse each cfg attribute body into a `CfgPred`
+        // AST, wrap the parsed list in `CfgPred::All` (semantic
+        // conjunction), and evaluate it symbolically with
+        // `test = false` and every other identifier left as a free
+        // Boolean variable. The conjoined predicate implies test iff
+        // it is decidably-unsatisfiable in the world where test is
+        // absent. `value_under_test_absent` returns:
         //   `Some(false)`  decidably-unsatisfiable     ⇒ skip
         //   `Some(true)`   decidably-true on test ∉ C  ⇒ NOT skip
         //   `None`         depends on free identifiers ⇒ NOT skip
-        fn attr_implies_test(attr: &Attribute) -> bool {
-            if !attr.path().is_ident("cfg") {
+        // Non-cfg attributes (e.g. `#[derive(...)]`) do not gate
+        // compilation and are ignored.
+        fn attrs_imply_test(attrs: &[Attribute]) -> bool {
+            let cfg_preds: Vec<CfgPred> = attrs
+                .iter()
+                .filter(|a| a.path().is_ident("cfg"))
+                .filter_map(|a| a.parse_args::<CfgPred>().ok())
+                .collect();
+            if cfg_preds.is_empty() {
                 return false;
             }
-            match attr.parse_args::<CfgPred>() {
-                Ok(pred) => matches!(value_under_test_absent(&pred), Some(false)),
-                Err(_) => false,
+            // skip iff the conjoined predicate is unsatisfiable when
+            // test is absent. SAT enumerates assignments to all
+            // distinct free variables, so multi-cfg cases that
+            // collapse to `test` are correctly identified even when
+            // no single attribute implies test.
+            !satisfiable_under_test_absent(&CfgPred::All(cfg_preds))
+        }
+
+        // Returns the attribute slice attached to an `Expr`. Almost
+        // every `Expr` variant carries its own `attrs` field; the
+        // catch-all `_` returns an empty slice for non-attribute-
+        // carrying variants (forward-compatibility with future syn
+        // additions).
+        fn expr_attrs(expr: &Expr) -> &[Attribute] {
+            match expr {
+                Expr::Array(e) => &e.attrs,
+                Expr::Assign(e) => &e.attrs,
+                Expr::Async(e) => &e.attrs,
+                Expr::Await(e) => &e.attrs,
+                Expr::Binary(e) => &e.attrs,
+                Expr::Block(e) => &e.attrs,
+                Expr::Break(e) => &e.attrs,
+                Expr::Call(e) => &e.attrs,
+                Expr::Cast(e) => &e.attrs,
+                Expr::Closure(e) => &e.attrs,
+                Expr::Const(e) => &e.attrs,
+                Expr::Continue(e) => &e.attrs,
+                Expr::Field(e) => &e.attrs,
+                Expr::ForLoop(e) => &e.attrs,
+                Expr::Group(e) => &e.attrs,
+                Expr::If(e) => &e.attrs,
+                Expr::Index(e) => &e.attrs,
+                Expr::Infer(e) => &e.attrs,
+                Expr::Let(e) => &e.attrs,
+                Expr::Lit(e) => &e.attrs,
+                Expr::Loop(e) => &e.attrs,
+                Expr::Macro(e) => &e.attrs,
+                Expr::Match(e) => &e.attrs,
+                Expr::MethodCall(e) => &e.attrs,
+                Expr::Paren(e) => &e.attrs,
+                Expr::Path(e) => &e.attrs,
+                Expr::Range(e) => &e.attrs,
+                Expr::Reference(e) => &e.attrs,
+                Expr::Repeat(e) => &e.attrs,
+                Expr::Return(e) => &e.attrs,
+                Expr::Struct(e) => &e.attrs,
+                Expr::Try(e) => &e.attrs,
+                Expr::TryBlock(e) => &e.attrs,
+                Expr::Tuple(e) => &e.attrs,
+                Expr::Unary(e) => &e.attrs,
+                Expr::Unsafe(e) => &e.attrs,
+                Expr::While(e) => &e.attrs,
+                Expr::Yield(e) => &e.attrs,
+                _ => &[],
             }
         }
 
         // Surface form of a Rust `ConfigurationPredicate` we model.
-        // `Other` covers any non-`test` identifier predicate, any
-        // `name = "value"` option, and any unknown function-call
-        // form; these evaluate to the unknown truth value.
+        // `Var(name)` covers any non-`test` identifier predicate,
+        // any `name = "value"` option (encoded as `name="..."`), and
+        // any unknown function-call form. Variables with the same
+        // surface name resolve to the same Boolean variable during
+        // SAT search — so `cfg(any(test, foo))` ∧ `cfg(any(test, not(foo)))`
+        // collapses to `test` because `foo ∧ ¬foo` is unsatisfiable.
         enum CfgPred {
             Test,
             True,
             False,
-            Other,
+            Var(String),
             All(Vec<CfgPred>),
             Any(Vec<CfgPred>),
             Not(Box<CfgPred>),
@@ -1474,73 +1538,99 @@ mod tests {
                             }
                             Ok(CfgPred::Not(Box::new(pred)))
                         }
-                        _ => Ok(CfgPred::Other),
+                        // Unknown function-call form (e.g.
+                        // `version("1.0")`) — keyed by the surface
+                        // ident only. Sufficient for SAT correctness
+                        // because two unknown calls with the same
+                        // ident collide as the same variable.
+                        _ => Ok(CfgPred::Var(name)),
                     }
                 } else if input.peek(Token![=]) {
                     input.parse::<Token![=]>()?;
-                    let _: Lit = input.parse()?;
-                    Ok(CfgPred::Other)
+                    let lit: Lit = input.parse()?;
+                    let value_repr = match &lit {
+                        Lit::Str(s) => format!("\"{}\"", s.value()),
+                        Lit::Int(i) => i.token().to_string(),
+                        Lit::Bool(b) => b.value.to_string(),
+                        _ => String::from("?"),
+                    };
+                    Ok(CfgPred::Var(format!("{name}={value_repr}")))
                 } else if name == "test" {
                     Ok(CfgPred::Test)
                 } else {
-                    Ok(CfgPred::Other)
+                    Ok(CfgPred::Var(name))
                 }
             }
         }
 
-        // Evaluates `P` with `test = false` and every other identifier
-        // left as a free Boolean variable. Returns:
-        //   `Some(false)` if `P` is decidably-unsatisfiable when
-        //                 `test` is absent (⇒ `P ⇒ test`)
-        //   `Some(true)`  if `P` is decidably-true on every test-absent
-        //                 config (⇒ `P ⇏ test`)
-        //   `None`        if the truth value depends on free identifiers
-        //                 (caller treats `None` as not-implying-test)
-        fn value_under_test_absent(p: &CfgPred) -> Option<bool> {
+        // Returns `true` iff `P` has a satisfying assignment to its
+        // free Boolean variables when `test` is forced to `false`.
+        // Equivalently: `¬satisfiable_under_test_absent(P)` is the
+        // skip predicate (`P ⇒ test` iff no model satisfies `P` with
+        // `test ∉ C`).
+        //
+        // Implementation: collect the set of distinct `Var(name)`
+        // identifiers reachable from `P`, then enumerate all
+        // 2^|vars| assignments and short-circuit on the first
+        // satisfying one. Capped at 16 distinct vars (real-world cfg
+        // predicates are far smaller) — beyond the cap the function
+        // conservatively returns `true` (caller treats unknown as
+        // not-implying-test, leaving the carrier in production scope).
+        fn satisfiable_under_test_absent(p: &CfgPred) -> bool {
+            let mut vars: Vec<String> = Vec::new();
+            collect_vars(p, &mut vars);
+            let n = vars.len();
+            if n > 16 {
+                return true;
+            }
+            let total: u64 = 1u64 << n;
+            for mask in 0..total {
+                let env: Vec<(&str, bool)> = vars
+                    .iter()
+                    .enumerate()
+                    .map(|(i, name)| (name.as_str(), (mask >> i) & 1 == 1))
+                    .collect();
+                if evaluate_under_test_absent(p, &env) {
+                    return true;
+                }
+            }
+            false
+        }
+
+        fn collect_vars(p: &CfgPred, vars: &mut Vec<String>) {
             match p {
-                CfgPred::Test => Some(false),
-                CfgPred::True => Some(true),
-                CfgPred::False => Some(false),
-                CfgPred::Other => None,
-                CfgPred::All(children) => {
-                    // Empty `all()` is the empty conjunction = top.
-                    if children.is_empty() {
-                        return Some(true);
+                CfgPred::Var(name) => {
+                    if !vars.iter().any(|v| v == name) {
+                        vars.push(name.clone());
                     }
-                    let mut any_unknown = false;
+                }
+                CfgPred::All(children) | CfgPred::Any(children) => {
                     for c in children {
-                        match value_under_test_absent(c) {
-                            Some(false) => return Some(false),
-                            Some(true) => continue,
-                            None => any_unknown = true,
-                        }
+                        collect_vars(c, vars);
                     }
-                    if any_unknown {
-                        None
-                    } else {
-                        Some(true)
-                    }
+                }
+                CfgPred::Not(inner) => collect_vars(inner, vars),
+                CfgPred::Test | CfgPred::True | CfgPred::False => {}
+            }
+        }
+
+        fn evaluate_under_test_absent(p: &CfgPred, env: &[(&str, bool)]) -> bool {
+            match p {
+                CfgPred::Test => false,
+                CfgPred::True => true,
+                CfgPred::False => false,
+                CfgPred::Var(name) => env
+                    .iter()
+                    .find(|(v, _)| *v == name.as_str())
+                    .map(|(_, val)| *val)
+                    .unwrap_or(false),
+                CfgPred::All(children) => {
+                    children.iter().all(|c| evaluate_under_test_absent(c, env))
                 }
                 CfgPred::Any(children) => {
-                    // Empty `any()` is the empty disjunction = bottom.
-                    if children.is_empty() {
-                        return Some(false);
-                    }
-                    let mut any_unknown = false;
-                    for c in children {
-                        match value_under_test_absent(c) {
-                            Some(true) => return Some(true),
-                            Some(false) => continue,
-                            None => any_unknown = true,
-                        }
-                    }
-                    if any_unknown {
-                        None
-                    } else {
-                        Some(false)
-                    }
+                    children.iter().any(|c| evaluate_under_test_absent(c, env))
                 }
-                CfgPred::Not(inner) => value_under_test_absent(inner).map(|b| !b),
+                CfgPred::Not(inner) => !evaluate_under_test_absent(inner, env),
             }
         }
 
@@ -1580,6 +1670,45 @@ mod tests {
                     return;
                 }
                 syn::visit::visit_trait_item(self, item);
+            }
+
+            fn visit_expr(&mut self, expr: &'ast Expr) {
+                // Below-item-level cfg-skip: Rust allows `#[cfg(...)]`
+                // on any expression form (`ExprBlock`, `ExprIf`,
+                // `ExprMatch`, etc.). The attribute set on the
+                // expression itself gates whether the expression is
+                // compiled in non-test builds.
+                if attrs_imply_test(expr_attrs(expr)) {
+                    return;
+                }
+                syn::visit::visit_expr(self, expr);
+            }
+
+            fn visit_arm(&mut self, arm: &'ast Arm) {
+                // `match x { #[cfg(test)] _ => TxPool::admit(tx) }` —
+                // the arm is gated independently of the match
+                // expression as a whole.
+                if attrs_imply_test(&arm.attrs) {
+                    return;
+                }
+                syn::visit::visit_arm(self, arm);
+            }
+
+            fn visit_stmt(&mut self, stmt: &'ast Stmt) {
+                // `let`-bindings and standalone macro statements
+                // carry their own attribute set. Inner expression /
+                // item statements have attrs on the wrapped node and
+                // are filtered through `visit_expr` / `visit_item`
+                // already.
+                let attrs: &[Attribute] = match stmt {
+                    Stmt::Local(local) => &local.attrs,
+                    Stmt::Macro(m) => &m.attrs,
+                    Stmt::Expr(_, _) | Stmt::Item(_) => &[][..],
+                };
+                if attrs_imply_test(attrs) {
+                    return;
+                }
+                syn::visit::visit_stmt(self, stmt);
             }
 
             fn visit_expr_method_call(&mut self, node: &'ast ExprMethodCall) {
@@ -2226,6 +2355,122 @@ impl Foo {
             other => {
                 panic!("expected admission detection inside production impl-fn body, got {other:?}")
             }
+        }
+    }
+
+    #[test]
+    fn multi_cfg_attrs_combine_via_conjunction_implies_test() {
+        // `#[cfg(any(test, foo))] #[cfg(any(test, not(foo)))]`
+        // ≡ `(test ∨ foo) ∧ (test ∨ ¬foo)` ≡ `test ∨ (foo ∧ ¬foo)`
+        // ≡ `test`. Conjunction implies test even though no single
+        // attribute does. Skip rule MUST treat the carrier as
+        // test-only.
+        let src = "\
+pub fn handle_received_tx() {}
+
+#[cfg(any(test, foo))]
+#[cfg(any(test, not(foo)))]
+fn test_only_via_conjunction() {
+    crate::txpool::TxPool::admit(tx);
+}
+";
+        check_tx_relay_boundary_source(src).expect(
+            "conjunction of two cfg attrs collapses to test; item must be skipped per-conjunction",
+        );
+    }
+
+    #[test]
+    fn multi_cfg_attrs_unrelated_to_test_remain_production() {
+        // Negative control for the conjunction logic: two cfg
+        // attributes neither of which involves test should leave the
+        // item in production scope.
+        let src = "\
+pub fn handle_received_tx() {}
+
+#[cfg(any(unix, windows))]
+#[cfg(target_pointer_width = \"64\")]
+fn cross_platform_helper() {
+    crate::txpool::TxPool::admit(tx);
+}
+";
+        match check_tx_relay_boundary_source(src) {
+            Err(BoundaryCheckError::ProductionAdmissionCall(_)) => {}
+            other => panic!(
+                "expected admission detection inside cfg(unix|windows) ∧ cfg(64-bit) helper, got {other:?}"
+            ),
+        }
+    }
+
+    #[test]
+    fn cfg_test_on_block_expression_inside_production_fn_is_skipped() {
+        // Below-item-level cfg-skip: `#[cfg(test)] { ... }` block
+        // expression inside a production function body. Without the
+        // visit_expr override the admission call inside would be
+        // walked and reported.
+        let src = "\
+pub fn handle_received_tx() {
+    #[cfg(test)]
+    {
+        crate::txpool::TxPool::admit(tx);
+    }
+}
+";
+        check_tx_relay_boundary_source(src)
+            .expect("#[cfg(test)] block expression inside production fn must be skipped");
+    }
+
+    #[test]
+    fn cfg_test_on_match_arm_inside_production_fn_is_skipped() {
+        // Below-item-level cfg-skip: `match x { #[cfg(test)] _ => ... }`
+        // arm inside a production fn. Default visit_expr_match
+        // descends into arms; without the visit_arm override the
+        // admission call in the test-only arm body would be reported.
+        let src = "\
+pub fn handle_received_tx() {
+    let x = 0;
+    match x {
+        #[cfg(test)]
+        _ => { crate::txpool::TxPool::admit(tx); }
+        _ => (),
+    }
+}
+";
+        check_tx_relay_boundary_source(src)
+            .expect("#[cfg(test)] match arm inside production fn must be skipped");
+    }
+
+    #[test]
+    fn cfg_test_on_let_stmt_inside_production_fn_is_skipped() {
+        // Below-item-level cfg-skip: `#[cfg(test)] let _ = ...;`
+        // statement inside a production fn body. The Stmt::Local
+        // attrs are checked via the visit_stmt override.
+        let src = "\
+pub fn handle_received_tx() {
+    #[cfg(test)]
+    let _ = crate::txpool::TxPool::admit(tx);
+}
+";
+        check_tx_relay_boundary_source(src)
+            .expect("#[cfg(test)] let-stmt inside production fn must be skipped");
+    }
+
+    #[test]
+    fn block_expression_without_cfg_test_inside_production_fn_admission_is_detected() {
+        // Negative control for visit_expr-level cfg-skip: an
+        // ordinary block expression with an admission call inside a
+        // production function MUST still be detected.
+        let src = "\
+pub fn handle_received_tx() {
+    {
+        crate::txpool::TxPool::admit(tx);
+    }
+}
+";
+        match check_tx_relay_boundary_source(src) {
+            Err(BoundaryCheckError::ProductionAdmissionCall(_)) => {}
+            other => panic!(
+                "expected admission detection inside ordinary block expression, got {other:?}"
+            ),
         }
     }
 

--- a/clients/rust/crates/rubin-node/src/tx_relay.rs
+++ b/clients/rust/crates/rubin-node/src/tx_relay.rs
@@ -126,12 +126,23 @@
 //!    `<self::TxPool>::method`, plus all `<X as Trait>::method`
 //!    trait-qualified variants).
 //!
-//! Production scope is established via
-//! `Attribute::parse_nested_meta` over each item's attributes —
-//! items carrying `#[cfg(test)]`, `#[cfg(any(test, ...))]`, or
-//! `#[cfg(all(test, ...))]` are skipped recursively. The boundary
-//! is established by AST attribute walk, NOT by textual
-//! `split_once("#[cfg(test)]")` on the source string.
+//! Production scope is established by structural recursion over the
+//! Rust `ConfigurationPredicate` grammar
+//! (<https://doc.rust-lang.org/reference/conditional-compilation.html>):
+//! an item is skipped from production scan iff its `#[cfg(...)]`
+//! predicate logically implies `test ∈ C` for every config `C`
+//! that satisfies it (`skip(I) ⇔ ∀C. P(I)(C) ⇒ test ∈ C`). The
+//! attribute body is parsed via `attr.parse_args::<CfgPred>()` into a
+//! recursive `CfgPred` AST and evaluated symbolically with `test`
+//! forced to `false`. The grammar's six productions (`test`, `true`,
+//! `false`, identifier-or-name=value option, `all(P*)`, `any(P*)`,
+//! `not(P)`) are all handled. Empty `all()` is the empty conjunction
+//! (always-true → not skipped); empty `any()` is the empty
+//! disjunction (always-false → vacuously skipped). The skip rule is
+//! applied per `Item`, per `ImplItem` (members of `impl` blocks),
+//! and per `TraitItem` (members of `trait` declarations); the
+//! boundary is NOT established by textual `split_once("#[cfg(test)]")`
+//! on the source.
 //!
 //! Allowed claim language for this checker (matches RUB-176 /
 //! GitHub issue #1432):
@@ -1234,10 +1245,11 @@ mod tests {
     /// and known non-scope (alias wrappers, macro expansion, type
     /// resolution, cross-file analysis are explicit non-scope).
     mod boundary_checker {
+        use syn::parse::{Parse, ParseStream};
         use syn::visit::Visit;
         use syn::{
-            Attribute, Expr, ExprCall, ExprMethodCall, ExprPath, File, Item, ItemFn, Path, QSelf,
-            Type,
+            Attribute, Expr, ExprCall, ExprMethodCall, ExprPath, File, Ident, ImplItem, Item,
+            ItemFn, Lit, LitBool, Path, QSelf, Token, TraitItem, Type,
         };
 
         /// Method idents that constitute canonical `TxPool` admission per
@@ -1353,44 +1365,183 @@ mod tests {
                 Item::Use(i) => &i.attrs,
                 _ => return false,
             };
-            attrs_have_cfg_test(attrs)
+            attrs_imply_test(attrs)
         }
 
-        fn attrs_have_cfg_test(attrs: &[Attribute]) -> bool {
-            attrs.iter().any(attr_has_cfg_test_predicate)
+        fn impl_item_is_cfg_test(item: &ImplItem) -> bool {
+            let attrs: &[Attribute] = match item {
+                ImplItem::Const(c) => &c.attrs,
+                ImplItem::Fn(f) => &f.attrs,
+                ImplItem::Type(t) => &t.attrs,
+                ImplItem::Macro(m) => &m.attrs,
+                _ => return false,
+            };
+            attrs_imply_test(attrs)
         }
 
-        fn attr_has_cfg_test_predicate(attr: &Attribute) -> bool {
+        fn trait_item_is_cfg_test(item: &TraitItem) -> bool {
+            let attrs: &[Attribute] = match item {
+                TraitItem::Const(c) => &c.attrs,
+                TraitItem::Fn(f) => &f.attrs,
+                TraitItem::Type(t) => &t.attrs,
+                TraitItem::Macro(m) => &m.attrs,
+                _ => return false,
+            };
+            attrs_imply_test(attrs)
+        }
+
+        fn attrs_imply_test(attrs: &[Attribute]) -> bool {
+            attrs.iter().any(attr_implies_test)
+        }
+
+        // Returns true iff this `#[cfg(...)]` attribute's predicate
+        // logically implies `test ∈ C` for every config C that
+        // satisfies it. Skip-from-production rule:
+        //   skip(I) ⇔ ∀C. P(I)(C) ⇒ test ∈ C
+        // per the Rust reference's ConfigurationPredicate grammar
+        // (`all` / `any` / `not` / option / `true` / `false`).
+        //
+        // Algorithm: parse the attribute body into a `CfgPred` AST
+        // and evaluate it symbolically with `test = false` and every
+        // other identifier left as a free Boolean variable. The
+        // predicate `P` implies test iff `P` is decidably-
+        // unsatisfiable in the world where test is absent.
+        // `value_under_test_absent` returns:
+        //   `Some(false)`  decidably-unsatisfiable     ⇒ skip
+        //   `Some(true)`   decidably-true on test ∉ C  ⇒ NOT skip
+        //   `None`         depends on free identifiers ⇒ NOT skip
+        fn attr_implies_test(attr: &Attribute) -> bool {
             if !attr.path().is_ident("cfg") {
                 return false;
             }
-            let mut found = false;
-            // `parse_nested_meta` returns `Err` if the attribute body is
-            // malformed (e.g. `#[cfg]` with no parentheses); for our
-            // purposes a malformed cfg cannot establish a `test`
-            // predicate, so the `Err` branch is silently ignored.
-            let _ = attr.parse_nested_meta(|meta| {
-                if meta.path.is_ident("test") {
-                    found = true;
-                    return Ok(());
-                }
-                // `#[cfg(any(test, ...))]` and `#[cfg(all(test, ...))]`
-                // are conservatively treated as test-gated when `test`
-                // appears anywhere inside `any` / `all`. `#[cfg(not(test))]`
-                // does NOT match this branch and falls through unmatched —
-                // it is production code under the `cfg(test)` configuration
-                // and remains in scope for the checker.
-                if meta.path.is_ident("any") || meta.path.is_ident("all") {
-                    let _ = meta.parse_nested_meta(|inner| {
-                        if inner.path.is_ident("test") {
-                            found = true;
-                        }
-                        Ok(())
+            match attr.parse_args::<CfgPred>() {
+                Ok(pred) => matches!(value_under_test_absent(&pred), Some(false)),
+                Err(_) => false,
+            }
+        }
+
+        // Surface form of a Rust `ConfigurationPredicate` we model.
+        // `Other` covers any non-`test` identifier predicate, any
+        // `name = "value"` option, and any unknown function-call
+        // form; these evaluate to the unknown truth value.
+        enum CfgPred {
+            Test,
+            True,
+            False,
+            Other,
+            All(Vec<CfgPred>),
+            Any(Vec<CfgPred>),
+            Not(Box<CfgPred>),
+        }
+
+        impl Parse for CfgPred {
+            fn parse(input: ParseStream) -> syn::Result<Self> {
+                // Boolean literals (`true` / `false`) come first
+                // because they are reserved keywords and would
+                // otherwise be rejected by the `Ident` branch below.
+                if input.peek(LitBool) {
+                    let b: LitBool = input.parse()?;
+                    return Ok(if b.value {
+                        CfgPred::True
+                    } else {
+                        CfgPred::False
                     });
                 }
-                Ok(())
-            });
-            found
+                let ident: Ident = input.parse()?;
+                let name = ident.to_string();
+                if input.peek(syn::token::Paren) {
+                    let inner;
+                    syn::parenthesized!(inner in input);
+                    match name.as_str() {
+                        "all" => {
+                            let preds = inner.parse_terminated(CfgPred::parse, Token![,])?;
+                            Ok(CfgPred::All(preds.into_iter().collect()))
+                        }
+                        "any" => {
+                            let preds = inner.parse_terminated(CfgPred::parse, Token![,])?;
+                            Ok(CfgPred::Any(preds.into_iter().collect()))
+                        }
+                        "not" => {
+                            let pred: CfgPred = inner.parse()?;
+                            // `cfg(not(...))` accepts at most one
+                            // predicate; allow an optional trailing
+                            // comma but reject extra predicates.
+                            if inner.peek(Token![,]) {
+                                inner.parse::<Token![,]>()?;
+                            }
+                            if !inner.is_empty() {
+                                return Err(inner.error("not() takes one predicate"));
+                            }
+                            Ok(CfgPred::Not(Box::new(pred)))
+                        }
+                        _ => Ok(CfgPred::Other),
+                    }
+                } else if input.peek(Token![=]) {
+                    input.parse::<Token![=]>()?;
+                    let _: Lit = input.parse()?;
+                    Ok(CfgPred::Other)
+                } else if name == "test" {
+                    Ok(CfgPred::Test)
+                } else {
+                    Ok(CfgPred::Other)
+                }
+            }
+        }
+
+        // Evaluates `P` with `test = false` and every other identifier
+        // left as a free Boolean variable. Returns:
+        //   `Some(false)` if `P` is decidably-unsatisfiable when
+        //                 `test` is absent (⇒ `P ⇒ test`)
+        //   `Some(true)`  if `P` is decidably-true on every test-absent
+        //                 config (⇒ `P ⇏ test`)
+        //   `None`        if the truth value depends on free identifiers
+        //                 (caller treats `None` as not-implying-test)
+        fn value_under_test_absent(p: &CfgPred) -> Option<bool> {
+            match p {
+                CfgPred::Test => Some(false),
+                CfgPred::True => Some(true),
+                CfgPred::False => Some(false),
+                CfgPred::Other => None,
+                CfgPred::All(children) => {
+                    // Empty `all()` is the empty conjunction = top.
+                    if children.is_empty() {
+                        return Some(true);
+                    }
+                    let mut any_unknown = false;
+                    for c in children {
+                        match value_under_test_absent(c) {
+                            Some(false) => return Some(false),
+                            Some(true) => continue,
+                            None => any_unknown = true,
+                        }
+                    }
+                    if any_unknown {
+                        None
+                    } else {
+                        Some(true)
+                    }
+                }
+                CfgPred::Any(children) => {
+                    // Empty `any()` is the empty disjunction = bottom.
+                    if children.is_empty() {
+                        return Some(false);
+                    }
+                    let mut any_unknown = false;
+                    for c in children {
+                        match value_under_test_absent(c) {
+                            Some(true) => return Some(true),
+                            Some(false) => continue,
+                            None => any_unknown = true,
+                        }
+                    }
+                    if any_unknown {
+                        None
+                    } else {
+                        Some(false)
+                    }
+                }
+                CfgPred::Not(inner) => value_under_test_absent(inner).map(|b| !b),
+            }
         }
 
         #[derive(Default)]
@@ -1407,6 +1558,28 @@ mod tests {
                     return;
                 }
                 syn::visit::visit_item(self, item);
+            }
+
+            fn visit_impl_item(&mut self, item: &'ast ImplItem) {
+                // Per-item cfg-skip applied to associated items
+                // inside a production `impl` block. Without this
+                // override the default visitor descends into
+                // `#[cfg(test)] fn ...` bodies declared inside an
+                // otherwise-production impl.
+                if impl_item_is_cfg_test(item) {
+                    return;
+                }
+                syn::visit::visit_impl_item(self, item);
+            }
+
+            fn visit_trait_item(&mut self, item: &'ast TraitItem) {
+                // Per-item cfg-skip applied to associated items
+                // inside a production `trait` declaration (default-
+                // method bodies can contain expressions).
+                if trait_item_is_cfg_test(item) {
+                    return;
+                }
+                syn::visit::visit_trait_item(self, item);
             }
 
             fn visit_expr_method_call(&mut self, node: &'ast ExprMethodCall) {
@@ -1839,7 +2012,12 @@ pub mod production_helpers {
     }
 
     #[test]
-    fn cfg_any_test_predicate_is_skipped() {
+    fn cfg_any_test_with_feature_disjunct_is_production_admission_detected() {
+        // `cfg(any(test, feature = "x"))` is enabled when `feature="x"`
+        // is set in non-test builds, so the item IS production-reachable
+        // and the admission call inside MUST be detected. Skip rule
+        // requires the predicate to imply test on every config that
+        // satisfies it; disjunction with a non-test branch breaks that.
         let src = "\
 pub fn handle_received_tx() {}
 
@@ -1848,12 +2026,21 @@ fn experimental_helper() {
     crate::txpool::TxPool::admit(tx);
 }
 ";
-        check_tx_relay_boundary_source(src)
-            .expect("#[cfg(any(test, ...))] is treated as test-gated");
+        match check_tx_relay_boundary_source(src) {
+            Err(BoundaryCheckError::ProductionAdmissionCall(AdmissionCallKind::DirectPath {
+                path,
+            })) => assert_eq!(path, "crate::txpool::TxPool::admit"),
+            other => {
+                panic!("expected admission detection inside cfg(any(test, feature)), got {other:?}")
+            }
+        }
     }
 
     #[test]
-    fn cfg_all_test_predicate_is_skipped() {
+    fn cfg_all_test_with_other_conjunct_is_skipped() {
+        // `cfg(all(test, target_os = "linux"))` requires test ∈ C for
+        // the predicate to hold on any C, so it implies test and the
+        // item must be skipped from production scan.
         let src = "\
 pub fn handle_received_tx() {}
 
@@ -1863,7 +2050,183 @@ fn linux_test_helper() {
 }
 ";
         check_tx_relay_boundary_source(src)
-            .expect("#[cfg(all(test, ...))] is treated as test-gated");
+            .expect("#[cfg(all(test, ...))] implies test and must be skipped");
+    }
+
+    #[test]
+    fn cfg_any_with_only_test_disjuncts_is_skipped() {
+        // `cfg(any(test, test))` — every disjunct implies test, so the
+        // whole predicate implies test. Skip.
+        let src = "\
+pub fn handle_received_tx() {}
+
+#[cfg(any(test, test))]
+fn redundant_helper() {
+    crate::txpool::TxPool::admit(tx);
+}
+";
+        check_tx_relay_boundary_source(src)
+            .expect("any(test, test) implies test (every disjunct does)");
+    }
+
+    #[test]
+    fn cfg_any_with_one_test_and_one_non_test_is_production() {
+        // Adversarial depth-2: `cfg(any(test, foo))` with `foo` a bare
+        // identifier — config with `foo` enabled and test disabled
+        // satisfies the predicate, so the predicate does NOT imply test.
+        let src = "\
+pub fn handle_received_tx() {}
+
+#[cfg(any(test, foo))]
+fn helper() {
+    crate::txpool::TxPool::admit(tx);
+}
+";
+        match check_tx_relay_boundary_source(src) {
+            Err(BoundaryCheckError::ProductionAdmissionCall(_)) => {}
+            other => {
+                panic!("expected admission detection inside cfg(any(test, foo)), got {other:?}")
+            }
+        }
+    }
+
+    #[test]
+    fn cfg_nested_any_all_depth_3_skipped_when_every_branch_implies_test() {
+        // Depth-3: `cfg(any(all(test, foo), all(test, bar)))` —
+        // outer `any` requires every branch to imply test; both inner
+        // `all` branches contain a `test` conjunct, so each implies
+        // test. The whole predicate implies test → skip.
+        let src = "\
+pub fn handle_received_tx() {}
+
+#[cfg(any(all(test, foo), all(test, bar)))]
+fn deep_helper() {
+    crate::txpool::TxPool::admit(tx);
+}
+";
+        check_tx_relay_boundary_source(src)
+            .expect("cfg(any(all(test, foo), all(test, bar))) implies test at depth 3 — must skip");
+    }
+
+    #[test]
+    fn cfg_nested_all_any_depth_3_production_when_inner_any_does_not_imply_test() {
+        // Depth-3: `cfg(all(any(test, foo), bar))` — outer `all`
+        // implies test iff some conjunct implies test; the only `test`
+        // appearance is inside `any(test, foo)` whose `foo` disjunct
+        // breaks the implication; the `bar` conjunct has no test. So
+        // the whole predicate does NOT imply test → production.
+        let src = "\
+pub fn handle_received_tx() {}
+
+#[cfg(all(any(test, foo), bar))]
+fn deep_helper() {
+    crate::txpool::TxPool::admit(tx);
+}
+";
+        match check_tx_relay_boundary_source(src) {
+            Err(BoundaryCheckError::ProductionAdmissionCall(_)) => {}
+            other => panic!(
+                "expected admission detection inside cfg(all(any(test, foo), bar)), got {other:?}"
+            ),
+        }
+    }
+
+    #[test]
+    fn cfg_double_negation_of_test_implies_test_and_is_skipped() {
+        // `cfg(not(not(test)))` is logically equivalent to `cfg(test)`
+        // — implies test, must skip.
+        let src = "\
+pub fn handle_received_tx() {}
+
+#[cfg(not(not(test)))]
+fn helper() {
+    crate::txpool::TxPool::admit(tx);
+}
+";
+        check_tx_relay_boundary_source(src)
+            .expect("not(not(test)) collapses to test and must be skipped");
+    }
+
+    #[test]
+    fn cfg_false_literal_predicate_is_unsatisfiable_and_skipped() {
+        // `cfg(false)` is never enabled — the implication
+        // `predicate(C) ⇒ test ∈ C` holds vacuously. Skip.
+        let src = "\
+pub fn handle_received_tx() {}
+
+#[cfg(false)]
+fn never_compiled_helper() {
+    crate::txpool::TxPool::admit(tx);
+}
+";
+        check_tx_relay_boundary_source(src)
+            .expect("cfg(false) is unsatisfiable; vacuously implies test; must skip");
+    }
+
+    #[test]
+    fn cfg_test_on_impl_item_inside_production_impl_is_skipped() {
+        // ImplItem-level cfg-skip: `impl Foo { #[cfg(test)] fn helper() {...} }`
+        // inside a production impl block must be skipped per-item.
+        let src = "\
+pub fn handle_received_tx() {}
+
+pub struct Foo;
+impl Foo {
+    pub fn prod_method(&self) {}
+
+    #[cfg(test)]
+    fn test_only_method(&self) {
+        crate::txpool::TxPool::admit(tx);
+    }
+}
+";
+        check_tx_relay_boundary_source(src).expect(
+            "ImplItem with #[cfg(test)] inside production impl block must be skipped per-item",
+        );
+    }
+
+    #[test]
+    fn cfg_test_on_trait_item_default_method_inside_production_trait_is_skipped() {
+        // TraitItem-level cfg-skip: a default method body in a trait
+        // declaration with `#[cfg(test)]` must be skipped per-item.
+        let src = "\
+pub fn handle_received_tx() {}
+
+pub trait Foo {
+    fn prod_method(&self);
+
+    #[cfg(test)]
+    fn test_only_default(&self) {
+        crate::txpool::TxPool::admit(tx);
+    }
+}
+";
+        check_tx_relay_boundary_source(src).expect(
+            "TraitItem default-method body with #[cfg(test)] inside production trait must be skipped per-item",
+        );
+    }
+
+    #[test]
+    fn impl_item_without_cfg_test_inside_production_impl_admission_is_detected() {
+        // Negative control: an ordinary production impl-fn with an
+        // admission call must STILL be detected — the per-ImplItem
+        // skip applies only when `cfg(test)` attribute is present.
+        let src = "\
+pub fn handle_received_tx() {}
+
+pub struct Foo;
+impl Foo {
+    pub fn prod_method(&self) {
+        crate::txpool::TxPool::admit(tx);
+    }
+}
+";
+        match check_tx_relay_boundary_source(src) {
+            Err(BoundaryCheckError::ProductionAdmissionCall(_)) => {}
+            other => {
+                panic!("expected admission detection inside production impl-fn body, got {other:?}")
+            }
+        }
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/tx_relay.rs
+++ b/clients/rust/crates/rubin-node/src/tx_relay.rs
@@ -1933,11 +1933,14 @@ pub mod production_helpers {
 
     #[test]
     fn cfg_any_test_with_feature_disjunct_is_production_admission_detected() {
-        // `cfg(any(test, feature = "x"))` is enabled when `feature="x"`
-        // is set in non-test builds, so the item IS production-reachable
-        // and the admission call inside MUST be detected. Skip rule
-        // requires the predicate to imply test on every config that
-        // satisfies it; disjunction with a non-test branch breaks that.
+        // `cfg(any(test, feature = "x"))` is not the EXACT literal
+        // `#[cfg(test)]` shape, so the conservative scope scans the
+        // carrier as production and the admission call inside is
+        // detected. The carrier is also genuinely production-reachable
+        // when `feature = "x"` is set in non-test builds, so the
+        // detection direction is sound. The checker reaches this
+        // verdict by shape match alone — it does not evaluate cfg
+        // predicate semantics.
         let src = "\
 pub fn handle_received_tx() {}
 
@@ -2149,6 +2152,59 @@ fn cross_platform_helper() {
             Err(BoundaryCheckError::ProductionAdmissionCall(_)) => {}
             other => panic!(
                 "expected admission detection inside cfg(unix|windows) ∧ cfg(64-bit) helper, got {other:?}"
+            ),
+        }
+    }
+
+    #[test]
+    fn cfg_test_with_companion_non_cfg_attr_is_skipped_under_conservative_scope() {
+        // `#[cfg(test)] #[derive(Debug)]` — the `#[derive(...)]`
+        // attribute is a non-`cfg` attribute and does not gate
+        // compilation, so the cfg-attribute count remains 1 (the
+        // exact literal `#[cfg(test)]`) and the carrier is skipped.
+        // Pins the contract that `item_is_exact_cfg_test` filters
+        // attributes by `path().is_ident("cfg")` before counting,
+        // not by counting all attributes.
+        let src = "\
+pub fn handle_received_tx() {}
+
+#[cfg(test)]
+#[derive(Debug)]
+struct TestOnlyHelper {
+    bad_field: u32,
+}
+
+#[cfg(test)]
+fn helper() {
+    crate::txpool::TxPool::admit(tx);
+}
+";
+        check_tx_relay_boundary_source(src).expect(
+            "carrier with #[cfg(test)] + non-cfg companion attr (#[derive]) must be skipped",
+        );
+    }
+
+    #[test]
+    fn cfg_attr_form_does_not_count_as_exact_cfg_test_skip() {
+        // `#[cfg_attr(test, derive(Debug))]` — the attribute path
+        // is `cfg_attr`, not `cfg`. `item_is_exact_cfg_test`'s
+        // `path().is_ident("cfg")` filter excludes `cfg_attr`, so
+        // the cfg-attribute count is 0 and the carrier is scanned
+        // as production. `cfg_attr` evaluation is explicit non-scope
+        // per RUB-176 / GitHub issue #1432's `class_change_stop_rule`;
+        // any admission inside such a carrier fires the checker.
+        let src = "\
+pub fn handle_received_tx() {}
+
+#[cfg_attr(test, derive(Debug))]
+fn helper() {
+    crate::txpool::TxPool::admit(tx);
+}
+";
+        match check_tx_relay_boundary_source(src) {
+            Err(BoundaryCheckError::ProductionAdmissionCall(_)) => {}
+            other => panic!(
+                "expected admission detection inside cfg_attr(...) carrier under conservative scope, got {other:?}"
             ),
         }
     }

--- a/clients/rust/crates/rubin-node/src/tx_relay.rs
+++ b/clients/rust/crates/rubin-node/src/tx_relay.rs
@@ -14,15 +14,15 @@
 //! function signature: NONE of `handle_received_tx`'s
 //! non-primitive arguments carry a canonical `TxPool` handle
 //! today. This is a HEAD-snapshot observation, NOT a maintained
-//! invariant — neither the docstring nor the source-grep tripwire
-//! below scans `sync.rs`, `p2p_runtime.rs`, or any other carrier
-//! file, so a future PR could add a canonical-pool field to one
-//! of these structs in another file and both would silently stay
-//! green. RUB-176 / GitHub issue #1432 tracks a syntactic
-//! token-aware checker scoped to `tx_relay.rs` only — it does
-//! NOT inspect `sync.rs`, `p2p_runtime.rs`, or any other carrier
-//! file, so cross-file drift over carrier struct definitions
-//! remains an open gap not tracked by any current follow-up.
+//! invariant — neither the docstring nor the token-aware
+//! `boundary_checker` test module below scans `sync.rs`,
+//! `p2p_runtime.rs`, or any other carrier file, so a future PR
+//! could add a canonical-pool field to one of these structs in
+//! another file and both would silently stay green. The
+//! syntactic checker described under `# Boundary check` below is
+//! scoped to `tx_relay.rs` source only; cross-file drift over
+//! carrier struct definitions remains an open gap not tracked by
+//! any current follow-up.
 //! Observed at HEAD, field-by-field:
 //!  - `relay_state: &TxRelayState` (this file) — fields are
 //!    `tx_seen`, `relay_pool` (`RelayTxPool`), `tx_relay_fanout`,
@@ -48,16 +48,14 @@
 //! facts in place, the application's shared pool is unreachable
 //! from this module's call graph through these surfaces.
 //!
-//! The advisory source-level tripwire below scans the production
-//! section for a non-exhaustive list of obvious canonical-
-//! admission substrings; it is NOT a sound Rust parser, NOT an
-//! exhaustive proof, and NOT a guarantee that the boundary is
-//! enforced. Many spellings bypass it (see Known bypass classes
-//! below). RUB-176 / GitHub issue #1432 tracks a syntactic
-//! token-aware checker for direct admission call expressions in
-//! `tx_relay.rs`; it explicitly excludes alias wrappers, macro
-//! expansions, type-resolution completeness, and any cross-file
-//! inspection from its scope.
+//! The `boundary_checker` test module below uses `syn::parse_file`
+//! to walk this file's production AST and detect direct syntactic
+//! canonical-`TxPool` admission call expressions. It is a token-
+//! aware syntactic direct-call checker scoped to `tx_relay.rs`
+//! only. It does not perform Rust type or name resolution, does
+//! not expand macros, does not inspect any other file, and does
+//! not detect alias wrappers (see `# Boundary check` and
+//! `# Known non-scope` below for the full scope contract).
 //!
 //! `Relayed` indicates the dedup, metadata, and relay-pool storage
 //! steps completed successfully and `broadcast_inventory` was
@@ -104,62 +102,103 @@
 //! inline (matching `admit_with_metadata` on the canonical pool)
 //! but remains standalone non-admitting.
 //!
-//! # Boundary tripwire (advisory only)
+//! # Boundary check (RUB-176 / GitHub issue #1432 token-aware AST walk via `syn`)
 //!
-//! The test at the bottom of this file is an advisory
-//! defense-in-depth source-level substring scan on this file's
-//! production section, not a sound Rust parser and not an
-//! exhaustive proof. It splits this file's `include_str!`
-//! contents at the exact `mod tests` attribute marker (CRLF-
-//! normalized, marker_count == 1, fail-closed via `.expect`),
-//! runs a comment/string-blind line-equality check on the relay
-//! handler's signature opener (intended only to fail loudly if
-//! the handler is renamed in a careless rewrite — NOT a
-//! declaration anchor; a block comment, `///` doc line, or raw
-//! string line equal to the signature would also satisfy it),
-//! then scans for the dotted-method and UFCS forms (including
-//! module-path qualified) named after the three canonical-
-//! admission entries on `TxPool` (`admit`, `admit_with_metadata`,
-//! `add_tx_with_source`). The forbidden-substring list lives in
-//! the test; the docstring above does not embed those substrings
-//! or the signature-opener literal. A syntactic token-aware
-//! checker is split to RUB-176 / GitHub issue #1432; it is not
-//! sound (no alias/macro/type-resolution coverage) and its scope
-//! is `tx_relay.rs` only.
+//! The `boundary_checker` test module below uses `syn::parse_file`
+//! to parse this file's source and walks the production AST via
+//! `syn::visit::Visit`. It detects direct syntactic canonical-
+//! `TxPool` admission call expressions:
 //!
-//! False-positive surface (intentional, fail-closed): the dotted-
-//! method tokens scanned by the tripwire are receiver-agnostic —
-//! they match by literal substring, not by type — so the tripwire
-//! would also fire on similarly-named methods on any other
-//! receiver type that may live in this module in the future, on
-//! commented-out admission code left in production source, and on
-//! string literals containing those substrings. This is a
-//! deliberate defense-in-depth bias toward false-alarm over miss;
-//! if a future producer needs a similarly-named method on a
-//! different receiver inside this module, that producer either
-//! renames the surface here or replaces the tripwire with an
-//! AST-aware checker.
+//!  - `Expr::MethodCall` with method ident in {`admit`,
+//!    `admit_with_metadata`, `add_tx_with_source`};
+//!  - `Expr::Call` with `Expr::Path` (`qself: None`) whose path
+//!    terminal segment is one of those method idents AND whose
+//!    penultimate segment ident is `TxPool` (covers plain UFCS
+//!    `TxPool::method`, the leading-`::` absolute path
+//!    `::TxPool::method`, and module-qualified forms with prefixes
+//!    `crate`, `self`, `super`, `txpool`, `crate::txpool`,
+//!    `self::txpool`, `super::txpool`);
+//!  - `Expr::Call` with `Expr::Path` carrying `qself: Some(...)`
+//!    where the `qself.ty` is a `Type::Path` whose terminal segment
+//!    ident is `TxPool` (covers `<TxPool>::method`,
+//!    `<crate::TxPool>::method`, `<crate::txpool::TxPool>::method`,
+//!    `<super::TxPool>::method`, `<super::txpool::TxPool>::method`,
+//!    `<self::TxPool>::method`, plus all `<X as Trait>::method`
+//!    trait-qualified variants).
 //!
-//! Known bypass classes (NOT exhaustive — the canonical defense
-//! remains structural, per the function signature above; RUB-176
-//! / GitHub issue #1432 tracks only a syntactic checker scoped
-//! to `tx_relay.rs`, not sound and not cross-file):
-//!  - alias wrappers, function-pointer indirection, trait-object
-//!    dispatch, or any path that does not write a matching literal
-//!    substring in this file's source;
-//!  - macro expansions that hide the call;
-//!  - UFCS angle-bracket path spellings not in the catalog —
-//!    for example `<super::TxPool>::` or
-//!    `<super::txpool::TxPool>::` (which compile from this module
-//!    today, since `super` from `crate::tx_relay` resolves to
-//!    `crate`), and any future re-export or path alias that
-//!    introduces a new angle-bracket-qualified form. The closing
-//!    `>` separator breaks the substring spillover that catches
-//!    non-angle-bracket prefixed forms. (Note: `<self::TxPool>::`
-//!    would also bypass the substring scan if it compiled, but
-//!    `tx_relay.rs` does not import `TxPool` into `self::`, so
-//!    that exact spelling does not compile from this module
-//!    today.)
+//! Production scope is established via
+//! `Attribute::parse_nested_meta` over each item's attributes —
+//! items carrying `#[cfg(test)]`, `#[cfg(any(test, ...))]`, or
+//! `#[cfg(all(test, ...))]` are skipped recursively. The boundary
+//! is established by AST attribute walk, NOT by textual
+//! `split_once("#[cfg(test)]")` on the source string.
+//!
+//! Allowed claim language for this checker (matches RUB-176 /
+//! GitHub issue #1432):
+//!
+//!  - syntactic direct-call checker;
+//!  - token-aware over `tx_relay.rs` only;
+//!  - no comments / line-comments / block-comments / doc-comments /
+//!    string-literal / raw-string-literal / `#[cfg(test)]`-test-code
+//!    false positives — `syn` discards line and block comments
+//!    during parse; doc comments live in attribute nodes and are
+//!    not visited as expression-callable tokens; string and raw-
+//!    string literals are `Lit::Str` AST nodes and are not visited
+//!    as call callables; `#[cfg(test)]` items are skipped via the
+//!    AST attribute walk;
+//!  - no type-resolution completeness;
+//!  - no macro-expansion completeness;
+//!  - no cross-file carrier inspection;
+//!  - alias wrappers out of scope (`use crate::txpool::TxPool as
+//!    Pool` followed by `Pool::admit(...)` will not match because
+//!    the path's penultimate segment is `Pool`, not `TxPool`).
+//!
+//! Receiver-agnostic dotted-method detection: `.admit(...)` /
+//! `.admit_with_metadata(...)` / `.add_tx_with_source(...)` fire
+//! regardless of receiver type, since dotted-method calls do not
+//! resolve to a path with a known receiver type at the AST level.
+//! This is a deliberate defense-in-depth bias toward false-alarm
+//! over miss; if a future producer introduces a similarly-named
+//! method on a different receiver inside this module, that
+//! producer either renames the surface or escalates to a sounder
+//! checker via a separate Q-*.
+//!
+//! Fail-closed conditions (the checker returns `Err`):
+//!
+//!  - `syn::parse_file` fails on this file's source
+//!    (`BoundaryCheckError::ParseFailed`);
+//!  - the production handler `handle_received_tx` is not located
+//!    in production scope — renamed, removed, or accidentally
+//!    moved under `#[cfg(test)]`
+//!    (`BoundaryCheckError::HandlerMissing`);
+//!  - the file has no top-level items
+//!    (`BoundaryCheckError::EmptyFile`).
+//!
+//! # Known non-scope (bypass classes NOT detected — escalation requires class change)
+//!
+//! These bypass classes remain not detected by the token-aware
+//! checker; if any becomes a real concern, escalating to detection
+//! requires a class change beyond the syntactic-direct-call scope:
+//!
+//!  - alias wrappers via `use crate::txpool::TxPool as Pool;`
+//!    followed by `Pool::admit(...)` — name resolution beyond
+//!    syntactic paths is explicit non-scope;
+//!  - function-pointer indirection (`let f = TxPool::admit; f(tx)`),
+//!    trait-object dispatch, local type aliases, generic helpers
+//!    that hide the receiver type;
+//!  - macro invocations whose body contains admission calls —
+//!    `syn` treats macro bodies as unparsed token streams and the
+//!    visitor does not descend into them;
+//!  - type-level constructs whose `qself.ty` is not a plain
+//!    `Type::Path` ending in `TxPool` (for example,
+//!    `<&TxPool>::admit`, `<(TxPool)>::admit`, `<Box<TxPool>>::admit`,
+//!    or any `Wrapper<TxPool>` whose `Type::Path` terminal segment
+//!    is `Wrapper`, not `TxPool`);
+//!  - cross-file structural drift — a future PR could add a
+//!    canonical `TxPool` field to `SyncEngine`, `PeerManager`,
+//!    `PeerOutbox`, or `TxRelayState` in another file and the
+//!    checker would not detect that drift, since its surface is
+//!    `tx_relay.rs` source only.
 
 use std::collections::HashMap;
 use std::io;
@@ -1186,97 +1225,716 @@ mod tests {
         assert_eq!(boxes["other:8333"].len(), 1);
     }
 
+    /// RUB-176 / GitHub issue #1432 token-aware boundary checker.
+    ///
+    /// `syn`-based AST walk over `tx_relay.rs` production source
+    /// detecting direct syntactic canonical-`TxPool` admission call
+    /// expressions. See the module-level docstring under `# Boundary
+    /// check` for the full scope contract, allowed claim language,
+    /// and known non-scope (alias wrappers, macro expansion, type
+    /// resolution, cross-file analysis are explicit non-scope).
+    mod boundary_checker {
+        use syn::visit::Visit;
+        use syn::{
+            Attribute, Expr, ExprCall, ExprMethodCall, ExprPath, File, Item, ItemFn, Path, QSelf,
+            Type,
+        };
+
+        /// Method idents that constitute canonical `TxPool` admission per
+        /// RUB-174 / RUB-176.
+        pub const CANONICAL_ADMISSION_METHODS: &[&str] =
+            &["admit", "admit_with_metadata", "add_tx_with_source"];
+
+        /// Receiver type name used to disambiguate path-call detection
+        /// from methods on `RelayTxPool` and other receivers.
+        pub const TXPOOL_TYPE_NAME: &str = "TxPool";
+
+        /// Production handler name whose presence the checker requires.
+        pub const HANDLER_NAME: &str = "handle_received_tx";
+
+        /// Errors returned by [`check_tx_relay_boundary_source`].
+        #[derive(Debug, PartialEq, Eq)]
+        pub enum BoundaryCheckError {
+            /// `syn::parse_file` failed on the supplied source.
+            ParseFailed(String),
+            /// File has no top-level items — production/test boundary
+            /// cannot be established.
+            EmptyFile,
+            /// Production handler item is missing from the AST. Either
+            /// the file no longer contains `handle_received_tx`, or the
+            /// item was renamed or moved under `#[cfg(test)]` and is
+            /// therefore excluded from production scope.
+            HandlerMissing,
+            /// A direct syntactic canonical-admission call was found in
+            /// production scope.
+            ProductionAdmissionCall(AdmissionCallKind),
+        }
+
+        /// Direct-syntactic call families detected by
+        /// [`check_tx_relay_boundary_source`].
+        #[derive(Debug, PartialEq, Eq)]
+        pub enum AdmissionCallKind {
+            /// `<receiver>.admit(...)` / `.admit_with_metadata(...)` /
+            /// `.add_tx_with_source(...)`. Receiver-agnostic by design;
+            /// see the module-level docstring's note on receiver-agnostic
+            /// detection as deliberate defense-in-depth bias.
+            DottedMethod { method: String },
+            /// `TxPool::method(...)` /
+            /// `[crate|self|super|txpool|...]::TxPool::method(...)`.
+            /// Direct path call where the path's terminal segment is a
+            /// canonical admission method ident and the penultimate
+            /// segment ident is `TxPool`.
+            DirectPath { path: String },
+            /// `<TxPool>::method(...)` /
+            /// `<TxPool as Trait>::method(...)` /
+            /// `<crate::txpool::TxPool>::method(...)` etc. UFCS form
+            /// whose `qself.ty` terminal segment is `TxPool` and whose
+            /// path's terminal segment is a canonical admission method
+            /// ident.
+            QSelfPath { qself_ty: String, method: String },
+        }
+
+        /// Walks `source` as a Rust file via `syn::parse_file` and
+        /// returns `Ok(())` if no direct syntactic canonical-`TxPool`
+        /// admission call is present in production scope, or
+        /// `Err(BoundaryCheckError)` describing the first violation or
+        /// fail-closed condition.
+        ///
+        /// "Production scope" excludes any `Item` whose attributes
+        /// contain a `#[cfg(test)]`, `#[cfg(any(test, ...))]`, or
+        /// `#[cfg(all(test, ...))]` predicate, recursively. The
+        /// exclusion is established by walking `syn::Attribute` nodes
+        /// via `Attribute::parse_nested_meta`, NOT by textual
+        /// `split_once("#[cfg(test)]")` on the source string.
+        pub fn check_tx_relay_boundary_source(source: &str) -> Result<(), BoundaryCheckError> {
+            let file: File = syn::parse_file(source)
+                .map_err(|e| BoundaryCheckError::ParseFailed(e.to_string()))?;
+            if file.items.is_empty() {
+                return Err(BoundaryCheckError::EmptyFile);
+            }
+            let mut found_handler = false;
+            let mut visitor = AdmissionFinder::default();
+            for item in &file.items {
+                if item_is_cfg_test(item) {
+                    continue;
+                }
+                if let Item::Fn(ItemFn { sig, .. }) = item {
+                    if sig.ident == HANDLER_NAME {
+                        found_handler = true;
+                    }
+                }
+                visitor.visit_item(item);
+                if let Some(err) = visitor.found.take() {
+                    return Err(err);
+                }
+            }
+            if !found_handler {
+                return Err(BoundaryCheckError::HandlerMissing);
+            }
+            Ok(())
+        }
+
+        fn item_is_cfg_test(item: &Item) -> bool {
+            let attrs: &[Attribute] = match item {
+                Item::Const(i) => &i.attrs,
+                Item::Enum(i) => &i.attrs,
+                Item::ExternCrate(i) => &i.attrs,
+                Item::Fn(i) => &i.attrs,
+                Item::ForeignMod(i) => &i.attrs,
+                Item::Impl(i) => &i.attrs,
+                Item::Macro(i) => &i.attrs,
+                Item::Mod(i) => &i.attrs,
+                Item::Static(i) => &i.attrs,
+                Item::Struct(i) => &i.attrs,
+                Item::Trait(i) => &i.attrs,
+                Item::TraitAlias(i) => &i.attrs,
+                Item::Type(i) => &i.attrs,
+                Item::Union(i) => &i.attrs,
+                Item::Use(i) => &i.attrs,
+                _ => return false,
+            };
+            attrs_have_cfg_test(attrs)
+        }
+
+        fn attrs_have_cfg_test(attrs: &[Attribute]) -> bool {
+            attrs.iter().any(attr_has_cfg_test_predicate)
+        }
+
+        fn attr_has_cfg_test_predicate(attr: &Attribute) -> bool {
+            if !attr.path().is_ident("cfg") {
+                return false;
+            }
+            let mut found = false;
+            // `parse_nested_meta` returns `Err` if the attribute body is
+            // malformed (e.g. `#[cfg]` with no parentheses); for our
+            // purposes a malformed cfg cannot establish a `test`
+            // predicate, so the `Err` branch is silently ignored.
+            let _ = attr.parse_nested_meta(|meta| {
+                if meta.path.is_ident("test") {
+                    found = true;
+                    return Ok(());
+                }
+                // `#[cfg(any(test, ...))]` and `#[cfg(all(test, ...))]`
+                // are conservatively treated as test-gated when `test`
+                // appears anywhere inside `any` / `all`. `#[cfg(not(test))]`
+                // does NOT match this branch and falls through unmatched —
+                // it is production code under the `cfg(test)` configuration
+                // and remains in scope for the checker.
+                if meta.path.is_ident("any") || meta.path.is_ident("all") {
+                    let _ = meta.parse_nested_meta(|inner| {
+                        if inner.path.is_ident("test") {
+                            found = true;
+                        }
+                        Ok(())
+                    });
+                }
+                Ok(())
+            });
+            found
+        }
+
+        #[derive(Default)]
+        struct AdmissionFinder {
+            found: Option<BoundaryCheckError>,
+        }
+
+        impl<'ast> Visit<'ast> for AdmissionFinder {
+            fn visit_item(&mut self, item: &'ast Item) {
+                // Skip nested `#[cfg(test)]` items (e.g. inline
+                // `#[cfg(test)] mod inner_tests { ... }` inside a
+                // production `mod` block).
+                if item_is_cfg_test(item) {
+                    return;
+                }
+                syn::visit::visit_item(self, item);
+            }
+
+            fn visit_expr_method_call(&mut self, node: &'ast ExprMethodCall) {
+                let method = node.method.to_string();
+                if CANONICAL_ADMISSION_METHODS.contains(&method.as_str()) && self.found.is_none() {
+                    self.found = Some(BoundaryCheckError::ProductionAdmissionCall(
+                        AdmissionCallKind::DottedMethod { method },
+                    ));
+                    return;
+                }
+                syn::visit::visit_expr_method_call(self, node);
+            }
+
+            fn visit_expr_call(&mut self, node: &'ast ExprCall) {
+                if let Expr::Path(ExprPath { qself, path, .. }) = node.func.as_ref() {
+                    if let Some(kind) = match_admission_call(path, qself.as_ref()) {
+                        if self.found.is_none() {
+                            self.found = Some(BoundaryCheckError::ProductionAdmissionCall(kind));
+                            return;
+                        }
+                    }
+                }
+                syn::visit::visit_expr_call(self, node);
+            }
+        }
+
+        fn match_admission_call(path: &Path, qself: Option<&QSelf>) -> Option<AdmissionCallKind> {
+            let terminal = path.segments.last()?;
+            let method = terminal.ident.to_string();
+            if !CANONICAL_ADMISSION_METHODS.contains(&method.as_str()) {
+                return None;
+            }
+            match qself {
+                None => {
+                    if path.segments.len() < 2 {
+                        return None;
+                    }
+                    let prev = &path.segments[path.segments.len() - 2];
+                    if prev.ident == TXPOOL_TYPE_NAME {
+                        Some(AdmissionCallKind::DirectPath {
+                            path: path_to_string(path),
+                        })
+                    } else {
+                        None
+                    }
+                }
+                Some(qself) => {
+                    // `qself.ty` is `Box<Type>`; only `Type::Path` whose
+                    // terminal segment is `TxPool` qualifies. Other type
+                    // forms (Type::Reference, Type::TraitObject, generic
+                    // wrappers, etc.) are explicit non-scope per the
+                    // module docstring and are documented as not
+                    // detected by this checker.
+                    let Type::Path(type_path) = qself.ty.as_ref() else {
+                        return None;
+                    };
+                    let qself_terminal = type_path.path.segments.last()?;
+                    if qself_terminal.ident != TXPOOL_TYPE_NAME {
+                        return None;
+                    }
+                    Some(AdmissionCallKind::QSelfPath {
+                        qself_ty: path_to_string(&type_path.path),
+                        method,
+                    })
+                }
+            }
+        }
+
+        fn path_to_string(path: &Path) -> String {
+            let mut s = String::new();
+            if path.leading_colon.is_some() {
+                s.push_str("::");
+            }
+            for (i, seg) in path.segments.iter().enumerate() {
+                if i > 0 {
+                    s.push_str("::");
+                }
+                s.push_str(&seg.ident.to_string());
+            }
+            s
+        }
+    }
+
+    use boundary_checker::{
+        check_tx_relay_boundary_source, AdmissionCallKind, BoundaryCheckError,
+        CANONICAL_ADMISSION_METHODS,
+    };
+
+    /// Wrap a snippet body inside a minimal production-scope
+    /// `handle_received_tx` for snippet tests. `syn::parse_file` parses
+    /// the result without name-resolution, so unresolved identifiers
+    /// (e.g. `tx`, `pool`, `self::TxPool`) are accepted as long as the
+    /// surface syntax is valid Rust.
+    fn make_source_with_production_admission_body(body: &str) -> String {
+        format!("pub fn handle_received_tx() {{\n    {body}\n}}\n")
+    }
+
     #[test]
-    fn tx_relay_production_source_substring_tripwire_advisory_only() {
-        // RUB-172 advisory boundary tripwire. NOT a sound Rust
-        // parser and NOT exhaustive — see module docstring at the
-        // top of this file for scope, the comment/string-blind
-        // line-equality semantics, known bypass classes, and the
-        // RUB-176 / GitHub issue #1432 follow-up for a syntactic
-        // token-aware checker scoped to tx_relay.rs (not sound;
-        // no alias/macro/type-resolution coverage).
-        const TX_RELAY_SOURCE_RAW: &str = include_str!("tx_relay.rs");
-        let tx_relay_source = TX_RELAY_SOURCE_RAW.replace("\r\n", "\n");
-        const TEST_MOD_MARKER: &str = "\n#[cfg(test)]\nmod tests {";
-        let marker_count = tx_relay_source.matches(TEST_MOD_MARKER).count();
-        assert_eq!(
-            marker_count, 1,
-            "tx_relay.rs must contain the test-module marker exactly \
-             once; found {marker_count}",
+    fn live_source_token_aware_boundary_passes() {
+        const SRC: &str = include_str!("tx_relay.rs");
+        check_tx_relay_boundary_source(SRC).expect(
+            "current tx_relay.rs production source must pass the \
+             token-aware boundary checker — RUB-176 / GitHub issue #1432",
         );
-        let (production_section, _) = tx_relay_source
-            .split_once(TEST_MOD_MARKER)
-            .expect("tx_relay.rs must contain the exact test-module marker");
-        // Comment/string/raw-string-blind line-equality check:
-        // intended only to fail loudly if the relay handler is
-        // renamed in a careless rewrite. This is NOT a declaration
-        // anchor — a block comment, `///` doc line, or `r"..."`
-        // raw-string line whose trim_start equals the signature
-        // opener would also satisfy it. A syntactic token-aware
-        // anchor is split to RUB-176 / GitHub issue #1432.
-        let sanity_signature = concat!("pub", " fn handle_received_tx(");
-        assert!(
-            production_section
-                .lines()
-                .any(|line| line.trim_start() == sanity_signature),
-            "tx_relay.rs production section must contain a line whose \
-             trim_start equals the relay handler signature opener \
-             (advisory rename-detection check, not a declaration anchor)",
-        );
-        const FORBIDDEN: &[&str] = &[
-            // Dotted-method form
-            ".admit(",
-            ".admit_with_metadata(",
-            ".add_tx_with_source(",
-            // UFCS plain form `TxPool::method(...)` — the literal
-            // substring `TxPool::admit(` etc. ALSO catches every
-            // non-angle-bracket module-prefixed spelling via
-            // substring spillover, because the prefix concatenates
-            // directly with `TxPool::admit(` without any separator
-            // that breaks the substring match. Examples confirmed
-            // caught by these three entries: `crate::TxPool::admit(`,
-            // `crate::TxPool::admit_with_metadata(`,
-            // `crate::TxPool::add_tx_with_source(`,
-            // `crate::txpool::TxPool::admit(`,
-            // `super::TxPool::admit(`,
-            // `super::txpool::TxPool::admit(`,
-            // `txpool::TxPool::admit(`, and any future
-            // re-export/alias path that ends in `TxPool::admit(`-
-            // shaped text. Angle-bracket UFCS spellings (e.g.
-            // `<crate::TxPool>::admit(`) need separate explicit
-            // entries below because the closing `>` between the
-            // type and `::` breaks the substring spillover.
-            "TxPool::admit(",
-            "TxPool::admit_with_metadata(",
-            "TxPool::add_tx_with_source(",
-            // UFCS angle-bracket-qualified form `<TxPool>::method(...)`,
-            // `<crate::TxPool>::method(...)`, and the canonical full
-            // module path `<crate::txpool::TxPool>::method(...)`.
-            "<TxPool>::admit(",
-            "<TxPool>::admit_with_metadata(",
-            "<TxPool>::add_tx_with_source(",
-            "<crate::TxPool>::admit(",
-            "<crate::TxPool>::admit_with_metadata(",
-            "<crate::TxPool>::add_tx_with_source(",
-            "<crate::txpool::TxPool>::admit(",
-            "<crate::txpool::TxPool>::admit_with_metadata(",
-            "<crate::txpool::TxPool>::add_tx_with_source(",
-            // UFCS trait-qualified form `<TxPool as SomeTrait>::method(...)`
-            // catalog for bare, single-crate-prefix, and full-module-path
-            // qualified forms only. Does NOT cover `<self::*>` /
-            // `<super::*>` path qualifiers or other future spellings —
-            // those belong to the RUB-176 / GitHub issue #1432
-            // token-aware checker.
-            "<TxPool as ",
-            "<crate::TxPool as ",
-            "<crate::txpool::TxPool as ",
+    }
+
+    #[test]
+    fn negative_dotted_method_calls_all_three_methods_detected() {
+        for method in CANONICAL_ADMISSION_METHODS {
+            let src =
+                make_source_with_production_admission_body(&format!("let _ = pool.{method}(tx);"));
+            match check_tx_relay_boundary_source(&src) {
+                Err(BoundaryCheckError::ProductionAdmissionCall(
+                    AdmissionCallKind::DottedMethod { method: m },
+                )) => assert_eq!(m, *method),
+                other => panic!("expected DottedMethod for `pool.{method}(tx)`, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn negative_direct_path_calls_for_all_prefixes_and_methods() {
+        // Includes a leading-`::` absolute path (`::TxPool::method`) to
+        // exercise `path_to_string`'s `path.leading_colon.is_some()` branch
+        // in addition to all module-relative path prefixes.
+        let prefixes = [
+            "TxPool",
+            "::TxPool",
+            "crate::TxPool",
+            "crate::txpool::TxPool",
+            "self::TxPool",
+            "self::txpool::TxPool",
+            "super::TxPool",
+            "super::txpool::TxPool",
+            "txpool::TxPool",
         ];
-        for forbidden in FORBIDDEN {
-            assert!(
-                !production_section.contains(forbidden),
-                "tx_relay.rs production code must not contain canonical \
-                 TxPool admission token `{forbidden}` — RUB-172 boundary",
-            );
+        for prefix in prefixes {
+            for method in CANONICAL_ADMISSION_METHODS {
+                let src = make_source_with_production_admission_body(&format!(
+                    "let _ = {prefix}::{method}(tx);"
+                ));
+                match check_tx_relay_boundary_source(&src) {
+                    Err(BoundaryCheckError::ProductionAdmissionCall(
+                        AdmissionCallKind::DirectPath { path },
+                    )) => assert_eq!(
+                        path,
+                        format!("{prefix}::{method}"),
+                        "DirectPath text mismatch for prefix={prefix} method={method}"
+                    ),
+                    other => panic!("expected DirectPath for `{prefix}::{method}`, got {other:?}"),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn negative_qself_path_calls_for_all_qself_types_and_methods() {
+        let qself_types = [
+            "TxPool",
+            "crate::TxPool",
+            "crate::txpool::TxPool",
+            "self::TxPool",
+            "self::txpool::TxPool",
+            "super::TxPool",
+            "super::txpool::TxPool",
+        ];
+        for qty in qself_types {
+            for method in CANONICAL_ADMISSION_METHODS {
+                // Without trait qualifier: `<T>::method(tx)`.
+                let src_no_trait = make_source_with_production_admission_body(&format!(
+                    "let _ = <{qty}>::{method}(tx);"
+                ));
+                match check_tx_relay_boundary_source(&src_no_trait) {
+                    Err(BoundaryCheckError::ProductionAdmissionCall(
+                        AdmissionCallKind::QSelfPath {
+                            qself_ty,
+                            method: m,
+                        },
+                    )) => {
+                        assert_eq!(qself_ty, qty);
+                        assert_eq!(m, *method);
+                    }
+                    other => panic!("expected QSelfPath for `<{qty}>::{method}`, got {other:?}"),
+                }
+
+                // With trait qualifier: `<T as Trait>::method(tx)`.
+                let src_with_trait = make_source_with_production_admission_body(&format!(
+                    "let _ = <{qty} as TxPoolAdmit>::{method}(tx);"
+                ));
+                match check_tx_relay_boundary_source(&src_with_trait) {
+                    Err(BoundaryCheckError::ProductionAdmissionCall(
+                        AdmissionCallKind::QSelfPath {
+                            qself_ty,
+                            method: m,
+                        },
+                    )) => {
+                        assert_eq!(qself_ty, qty);
+                        assert_eq!(m, *method);
+                    }
+                    other => {
+                        panic!("expected QSelfPath for `<{qty} as Trait>::{method}`, got {other:?}")
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn old_substring_tripwire_would_have_missed_self_qualifier_form() {
+        // Documentation evidence: the RUB-172 substring tripwire's
+        // catalog included `<TxPool as`, `<crate::TxPool as`,
+        // `<crate::txpool::TxPool as` but did not list
+        // `<self::TxPool>` / `<self::TxPool as Trait>` /
+        // `<super::TxPool>` / `<super::txpool::TxPool>`. The
+        // token-aware checker catches all of them via the
+        // `qself.ty` terminal-segment match.
+        for snippet in [
+            "let _ = <self::TxPool>::admit(tx);",
+            "let _ = <self::TxPool as Trait>::admit_with_metadata(tx);",
+            "let _ = <super::TxPool>::add_tx_with_source(tx);",
+            "let _ = <super::txpool::TxPool>::admit(tx);",
+        ] {
+            let src = make_source_with_production_admission_body(snippet);
+            match check_tx_relay_boundary_source(&src) {
+                Err(BoundaryCheckError::ProductionAdmissionCall(
+                    AdmissionCallKind::QSelfPath { .. },
+                )) => {}
+                other => panic!("expected QSelfPath for `{snippet}`, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn dotted_method_check_is_receiver_agnostic_by_design() {
+        // The dotted-method check matches by method ident only — it
+        // cannot distinguish receiver types without name/type
+        // resolution. If a future `RelayTxPool` method were named
+        // `admit`, the checker would still fire on it. This is the
+        // deliberate defense-in-depth bias documented in the module
+        // docstring; the cure is renaming the method on `RelayTxPool`
+        // or escalating to a sounder checker via a separate Q-*.
+        let src = make_source_with_production_admission_body(
+            "let _ = some_relay_cache.admit_with_metadata(tx);",
+        );
+        match check_tx_relay_boundary_source(&src) {
+            Err(BoundaryCheckError::ProductionAdmissionCall(AdmissionCallKind::DottedMethod {
+                method,
+            })) => assert_eq!(method, "admit_with_metadata"),
+            other => panic!("expected DottedMethod, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn false_positive_module_doc_with_admission_text_passes() {
+        let src = "\
+//! Example: pool.admit(tx) is the canonical admission entrypoint, and
+//! `crate::txpool::TxPool::admit_with_metadata` is the metadata-bearing
+//! variant. `<super::txpool::TxPool as Trait>::add_tx_with_source` exists
+//! too. None of these examples should fire the boundary checker — they
+//! live in module docs.
+
+pub fn handle_received_tx() {}
+";
+        check_tx_relay_boundary_source(src).expect("module doc admission text must pass");
+    }
+
+    #[test]
+    fn false_positive_doc_comment_on_item_passes() {
+        let src = "\
+/// This handler does NOT call `TxPool::admit(tx)` or
+/// `crate::txpool::TxPool::add_tx_with_source(tx)`. Doc comments are
+/// attribute nodes, not expression-callable tokens.
+pub fn handle_received_tx() {}
+";
+        check_tx_relay_boundary_source(src).expect("doc comment admission text must pass");
+    }
+
+    #[test]
+    fn false_positive_line_comments_pass() {
+        let src = "\
+pub fn handle_received_tx() {
+    // pool.admit(tx);
+    // TxPool::admit(tx);
+    // crate::txpool::TxPool::admit_with_metadata(tx);
+    // <super::txpool::TxPool as Trait>::add_tx_with_source(tx);
+}
+";
+        check_tx_relay_boundary_source(src).expect("line comments must pass");
+    }
+
+    #[test]
+    fn false_positive_block_comments_pass() {
+        let src = "\
+pub fn handle_received_tx() {
+    /* pool.admit(tx); TxPool::admit_with_metadata(tx); */
+    /*
+     * <crate::txpool::TxPool>::admit(tx);
+     * <super::txpool::TxPool as Trait>::add_tx_with_source(tx);
+     */
+}
+";
+        check_tx_relay_boundary_source(src).expect("block comments must pass");
+    }
+
+    #[test]
+    fn false_positive_string_literals_pass() {
+        let src = r#"
+pub fn handle_received_tx() {
+    let _ = "pool.admit(tx)";
+    let _ = "TxPool::admit(tx)";
+    let _ = "<crate::txpool::TxPool as Trait>::add_tx_with_source(tx)";
+}
+"#;
+        check_tx_relay_boundary_source(src).expect("string literals must pass");
+    }
+
+    #[test]
+    fn false_positive_raw_string_literals_pass() {
+        // Constructed via concat! to avoid the nested raw-string trap
+        // (an outer `r##"..."##` would terminate inside an inner
+        // `r###"..."###` at the first `"##` boundary).
+        let src = concat!(
+            "pub fn handle_received_tx() {\n",
+            "    let _ = r\"<crate::TxPool>::admit(tx)\";\n",
+            "    let _ = r#\"<super::txpool::TxPool>::admit_with_metadata(tx)\"#;\n",
+            "    let _ = r##\"pool.add_tx_with_source(tx)\"##;\n",
+            "}\n",
+        );
+        check_tx_relay_boundary_source(src).expect("raw string literals must pass");
+    }
+
+    #[test]
+    fn false_positive_cfg_test_module_with_admission_calls_passes() {
+        let src = "\
+pub fn handle_received_tx() {}
+
+#[cfg(test)]
+mod tests {
+    fn t() {
+        pool.admit(tx);
+        TxPool::admit_with_metadata(tx);
+        crate::txpool::TxPool::add_tx_with_source(tx);
+        <super::txpool::TxPool as Trait>::admit(tx);
+    }
+}
+";
+        check_tx_relay_boundary_source(src).expect("#[cfg(test)] mod admission calls must pass");
+    }
+
+    #[test]
+    fn false_positive_cfg_test_function_with_admission_calls_passes() {
+        let src = "\
+pub fn handle_received_tx() {}
+
+#[cfg(test)]
+fn helper() {
+    pool.admit(tx);
+    crate::txpool::TxPool::admit(tx);
+}
+";
+        check_tx_relay_boundary_source(src).expect("#[cfg(test)] fn admission calls must pass");
+    }
+
+    #[test]
+    fn false_positive_relay_pool_put_call_passes() {
+        let src = "\
+pub fn handle_received_tx() {
+    relay_state.relay_pool.put(txid, tx_bytes, fee, size);
+    relay_pool.has(&txid);
+    relay_state.tx_seen.add(txid);
+}
+";
+        check_tx_relay_boundary_source(src)
+            .expect("RelayTxPool put/has/add methods must not fire admission check");
+    }
+
+    #[test]
+    fn false_positive_alias_wrapper_via_use_rename_is_explicit_non_scope() {
+        // `use crate::txpool::TxPool as Pool; Pool::admit(tx);` — the
+        // path's penultimate segment is `Pool`, not `TxPool`, so the
+        // syntactic checker does NOT match. This is documented explicit
+        // non-scope per the boundary_checker module docstring; a sounder
+        // check would require name-resolution which is a class change
+        // blocked by issue #1432 / RUB-176.
+        let src = "\
+use crate::txpool::TxPool as Pool;
+
+pub fn handle_received_tx() {
+    let _ = Pool::admit(tx);
+}
+";
+        check_tx_relay_boundary_source(src)
+            .expect("alias wrapper must pass — explicit non-scope per RUB-176 design note");
+    }
+
+    #[test]
+    fn false_positive_macro_invocation_hiding_admission_call_is_explicit_non_scope() {
+        // Macro bodies are unparsed token streams — `syn::Expr::Macro`
+        // does not expose them as visit-able expressions. A diff that
+        // hides admission behind a macro will silently pass the checker.
+        // Explicit non-scope per the boundary_checker module docstring.
+        let src = "\
+pub fn handle_received_tx() {
+    txpool_admit!(tx);
+}
+";
+        check_tx_relay_boundary_source(src)
+            .expect("macro invocation hiding admission must pass — explicit non-scope per RUB-176");
+    }
+
+    #[test]
+    fn nested_cfg_test_module_inside_production_mod_is_skipped() {
+        let src = "\
+pub fn handle_received_tx() {}
+
+pub mod production_helpers {
+    pub fn helper() {}
+
+    #[cfg(test)]
+    mod inner_tests {
+        fn negative_case() {
+            crate::txpool::TxPool::admit(tx);
+        }
+    }
+}
+";
+        check_tx_relay_boundary_source(src).expect(
+            "nested #[cfg(test)] mod inside production mod must be skipped via AST attribute walk",
+        );
+    }
+
+    #[test]
+    fn cfg_any_test_predicate_is_skipped() {
+        let src = "\
+pub fn handle_received_tx() {}
+
+#[cfg(any(test, feature = \"experimental\"))]
+fn experimental_helper() {
+    crate::txpool::TxPool::admit(tx);
+}
+";
+        check_tx_relay_boundary_source(src)
+            .expect("#[cfg(any(test, ...))] is treated as test-gated");
+    }
+
+    #[test]
+    fn cfg_all_test_predicate_is_skipped() {
+        let src = "\
+pub fn handle_received_tx() {}
+
+#[cfg(all(test, target_os = \"linux\"))]
+fn linux_test_helper() {
+    crate::txpool::TxPool::admit(tx);
+}
+";
+        check_tx_relay_boundary_source(src)
+            .expect("#[cfg(all(test, ...))] is treated as test-gated");
+    }
+
+    #[test]
+    fn cfg_not_test_predicate_is_production_and_admission_is_detected() {
+        // `#[cfg(not(test))]` is production code under `cfg(test)`
+        // configuration — it is visible during normal builds but
+        // disabled during test compilation. The checker treats it as
+        // production scope and detects admission calls inside it.
+        let src = "\
+pub fn handle_received_tx() {}
+
+#[cfg(not(test))]
+fn prod_only_helper() {
+    crate::txpool::TxPool::admit(tx);
+}
+";
+        match check_tx_relay_boundary_source(src) {
+            Err(BoundaryCheckError::ProductionAdmissionCall(AdmissionCallKind::DirectPath {
+                path,
+            })) => assert_eq!(path, "crate::txpool::TxPool::admit"),
+            other => {
+                panic!("expected DirectPath for cfg(not(test)) production helper, got {other:?}")
+            }
+        }
+    }
+
+    #[test]
+    fn fail_closed_on_invalid_rust_syntax() {
+        let src = "this is not valid rust syntax !!! @@@ <<< >>>";
+        match check_tx_relay_boundary_source(src) {
+            Err(BoundaryCheckError::ParseFailed(_)) => {}
+            other => panic!("expected ParseFailed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn fail_closed_on_empty_file() {
+        match check_tx_relay_boundary_source("") {
+            Err(BoundaryCheckError::EmptyFile) => {}
+            other => panic!("expected EmptyFile, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn fail_closed_on_renamed_handler() {
+        let src = "\
+pub fn handle_received_tx_renamed() {
+    let _ = pool.put(tx);
+}
+";
+        match check_tx_relay_boundary_source(src) {
+            Err(BoundaryCheckError::HandlerMissing) => {}
+            other => panic!("expected HandlerMissing, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn fail_closed_when_handler_is_only_under_cfg_test() {
+        // Production handler accidentally moved under `#[cfg(test)]` —
+        // checker must fail closed because it cannot see a
+        // production-scope handler item.
+        let src = "\
+pub fn other_production_fn() {}
+
+#[cfg(test)]
+fn handle_received_tx() {
+}
+";
+        match check_tx_relay_boundary_source(src) {
+            Err(BoundaryCheckError::HandlerMissing) => {}
+            other => panic!("expected HandlerMissing, got {other:?}"),
         }
     }
 

--- a/clients/rust/crates/rubin-node/src/tx_relay.rs
+++ b/clients/rust/crates/rubin-node/src/tx_relay.rs
@@ -1312,12 +1312,15 @@ mod tests {
         /// `Err(BoundaryCheckError)` describing the first violation or
         /// fail-closed condition.
         ///
-        /// "Production scope" excludes any `Item` whose attributes
-        /// contain a `#[cfg(test)]`, `#[cfg(any(test, ...))]`, or
-        /// `#[cfg(all(test, ...))]` predicate, recursively. The
-        /// exclusion is established by walking `syn::Attribute` nodes
-        /// via `Attribute::parse_nested_meta`, NOT by textual
-        /// `split_once("#[cfg(test)]")` on the source string.
+        /// "Production scope" excludes any carrier (`Item`,
+        /// `ImplItem`, `TraitItem`, `Expr`, `Stmt::Local`,
+        /// `Stmt::Macro`, `Arm`) whose `#[cfg(...)]` attribute
+        /// conjunction logically implies `test ∈ C`. The exclusion
+        /// is established by parsing each cfg attribute body via
+        /// `attr.parse_args::<CfgPred>()` into a structural AST and
+        /// evaluating the conjunction via `satisfiable_under_test_absent`,
+        /// NOT by textual `split_once("#[cfg(test)]")` on the source
+        /// string.
         pub fn check_tx_relay_boundary_source(source: &str) -> Result<(), BoundaryCheckError> {
             let file: File = syn::parse_file(source)
                 .map_err(|e| BoundaryCheckError::ParseFailed(e.to_string()))?;
@@ -1569,22 +1572,47 @@ mod tests {
         // skip predicate (`P ⇒ test` iff no model satisfies `P` with
         // `test ∉ C`).
         //
-        // Implementation: collect the set of distinct `Var(name)`
-        // identifiers reachable from `P`, then enumerate all
-        // 2^|vars| assignments and short-circuit on the first
-        // satisfying one. Capped at 16 distinct vars (real-world cfg
-        // predicates are far smaller) — beyond the cap the function
-        // conservatively returns `true` (caller treats unknown as
-        // not-implying-test, leaving the carrier in production scope).
+        // Implementation: first attempt structural simplification —
+        // a recursive walk that propagates `Some(false)` for `Test`,
+        // empty `any()`, and `False`, and `Some(true)` for empty
+        // `all()` and `True`, through `all`/`any`/`not`. The
+        // simplification short-circuits on decidable trees (e.g.
+        // `all(test, …)` resolves to `Some(false)` because one
+        // conjunct is unsatisfiable when test is absent, regardless
+        // of how many free vars the other conjuncts contain). Only
+        // when simplification cannot decide does the function fall
+        // back to SAT enumeration over distinct `Var(name)`
+        // identifiers (capped at 16 vars; beyond the cap returns
+        // `true` — conservative-not-skip — which is the safe
+        // direction for a boundary checker because under-skipping
+        // produces false positives, not false negatives).
+        //
+        // SAT enumeration honours mutual-exclusion of `name=value`
+        // options sharing the same `name`: at most one
+        // `name="value1"`, `name="value2"`, … can be true in any
+        // real config, so assignments that turn on multiple values
+        // for the same key are skipped (treated as physically
+        // impossible, not "satisfying"). This handles the
+        // `cfg(all(target_os="linux", target_os="windows"))`
+        // unsatisfiability case correctly.
         fn satisfiable_under_test_absent(p: &CfgPred) -> bool {
+            if let Some(value) = simplify_under_test_absent(p) {
+                return value;
+            }
             let mut vars: Vec<String> = Vec::new();
             collect_vars(p, &mut vars);
             let n = vars.len();
             if n > 16 {
                 return true;
             }
+            // Pre-compute same-key var groups (indices in `vars`)
+            // for mutual-exclusion enforcement during enumeration.
+            let groups = group_indices_by_key(&vars);
             let total: u64 = 1u64 << n;
             for mask in 0..total {
+                if violates_key_exclusivity(mask, &groups) {
+                    continue;
+                }
                 let env: Vec<(&str, bool)> = vars
                     .iter()
                     .enumerate()
@@ -1592,6 +1620,98 @@ mod tests {
                     .collect();
                 if evaluate_under_test_absent(p, &env) {
                     return true;
+                }
+            }
+            false
+        }
+
+        // Three-valued structural simplification with `test = false`.
+        // Returns `Some(b)` when `P` is decidable from grammar alone
+        // (no SAT search over free Var assignments needed) and
+        // `None` when the value depends on free identifiers. Cures
+        // the >16-var cap problem for predicates whose `test`
+        // appearance forces a structural shortcut.
+        fn simplify_under_test_absent(p: &CfgPred) -> Option<bool> {
+            match p {
+                CfgPred::Test => Some(false),
+                CfgPred::True => Some(true),
+                CfgPred::False => Some(false),
+                CfgPred::Var(_) => None,
+                CfgPred::All(children) => {
+                    if children.is_empty() {
+                        return Some(true);
+                    }
+                    let mut all_true = true;
+                    for c in children {
+                        match simplify_under_test_absent(c) {
+                            Some(false) => return Some(false),
+                            Some(true) => continue,
+                            None => all_true = false,
+                        }
+                    }
+                    if all_true {
+                        Some(true)
+                    } else {
+                        None
+                    }
+                }
+                CfgPred::Any(children) => {
+                    if children.is_empty() {
+                        return Some(false);
+                    }
+                    let mut all_false = true;
+                    for c in children {
+                        match simplify_under_test_absent(c) {
+                            Some(true) => return Some(true),
+                            Some(false) => continue,
+                            None => all_false = false,
+                        }
+                    }
+                    if all_false {
+                        Some(false)
+                    } else {
+                        None
+                    }
+                }
+                CfgPred::Not(inner) => simplify_under_test_absent(inner).map(|b| !b),
+            }
+        }
+
+        // Returns groups of indices in `vars` that share the same
+        // `name=` prefix. Two `name=value1` and `name=value2` Vars
+        // for the same key are mutually exclusive in any real Rust
+        // build configuration (e.g. `target_os` is exactly one of
+        // {"linux","windows","macos",…}), so SAT enumeration must
+        // skip assignments that turn on more than one of them.
+        fn group_indices_by_key(vars: &[String]) -> Vec<Vec<usize>> {
+            let mut groups: Vec<(String, Vec<usize>)> = Vec::new();
+            for (i, v) in vars.iter().enumerate() {
+                let key = match v.find('=') {
+                    Some(eq) => &v[..eq],
+                    None => continue,
+                };
+                if let Some(g) = groups.iter_mut().find(|(k, _)| k == key) {
+                    g.1.push(i);
+                } else {
+                    groups.push((key.to_string(), vec![i]));
+                }
+            }
+            groups
+                .into_iter()
+                .filter_map(|(_, idx)| if idx.len() > 1 { Some(idx) } else { None })
+                .collect()
+        }
+
+        fn violates_key_exclusivity(mask: u64, groups: &[Vec<usize>]) -> bool {
+            for g in groups {
+                let mut on = 0;
+                for &i in g {
+                    if (mask >> i) & 1 == 1 {
+                        on += 1;
+                        if on > 1 {
+                            return true;
+                        }
+                    }
                 }
             }
             false
@@ -2508,6 +2628,47 @@ pub fn handle_received_tx() {
                 "expected QSelfPath for parenthesised <crate::txpool::TxPool>::admit_with_metadata, got {other:?}"
             ),
         }
+    }
+
+    #[test]
+    fn mutually_exclusive_target_os_values_via_two_cfg_attrs_skipped() {
+        // `cfg(any(test, target_os="linux")) ∧ cfg(any(test, target_os="windows"))`
+        // — combined: `(test ∨ linux) ∧ (test ∨ windows)`. Under
+        // `target_os` mutual-exclusivity (a config has exactly one
+        // value), the only way both clauses hold without test is
+        // `linux ∧ windows`, which is impossible. Conjunction
+        // therefore implies test → SKIP.
+        let src = "\
+pub fn handle_received_tx() {}
+
+#[cfg(any(test, target_os = \"linux\"))]
+#[cfg(any(test, target_os = \"windows\"))]
+fn cross_os_test_only() {
+    crate::txpool::TxPool::admit(tx);
+}
+";
+        check_tx_relay_boundary_source(src).expect(
+            "mutually-exclusive target_os values across two cfg attrs implies test; must skip",
+        );
+    }
+
+    #[test]
+    fn many_distinct_vars_with_test_in_all_uses_structural_fast_path() {
+        // 17 free identifiers exceed the SAT cap (16), but the
+        // structural simplifier resolves `all(test, …)` to `false`
+        // under `test = absent` immediately — predicate implies test
+        // regardless of how many other free vars accompany it.
+        let src = "\
+pub fn handle_received_tx() {}
+
+#[cfg(all(test, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17))]
+fn many_var_helper() {
+    crate::txpool::TxPool::admit(tx);
+}
+";
+        check_tx_relay_boundary_source(src).expect(
+            "all(test, …17 distinct free vars) implies test via structural fast-path despite cap",
+        );
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/tx_relay.rs
+++ b/clients/rust/crates/rubin-node/src/tx_relay.rs
@@ -1723,7 +1723,14 @@ mod tests {
             }
 
             fn visit_expr_call(&mut self, node: &'ast ExprCall) {
-                if let Expr::Path(ExprPath { qself, path, .. }) = node.func.as_ref() {
+                // Peel `Expr::Paren` and `Expr::Group` wrappers around
+                // the callee so that parenthesised forms like
+                // `(TxPool::admit)(tx)` and
+                // `(<crate::txpool::TxPool>::admit_with_metadata)(tx)`
+                // are still detected. The default visitor would
+                // otherwise descend into the paren'd expression and
+                // never re-enter `visit_expr_call` on the inner path.
+                if let Some(ExprPath { qself, path, .. }) = unwrap_path_expr(node.func.as_ref()) {
                     if let Some(kind) = match_admission_call(path, qself.as_ref()) {
                         if self.found.is_none() {
                             self.found = Some(BoundaryCheckError::ProductionAdmissionCall(kind));
@@ -1732,6 +1739,18 @@ mod tests {
                     }
                 }
                 syn::visit::visit_expr_call(self, node);
+            }
+        }
+
+        // Strips `Expr::Paren` and `Expr::Group` wrappers and returns
+        // the inner `ExprPath` if any. Returns `None` for callees
+        // that are not (eventually) a path expression.
+        fn unwrap_path_expr(expr: &Expr) -> Option<&ExprPath> {
+            match expr {
+                Expr::Path(p) => Some(p),
+                Expr::Paren(p) => unwrap_path_expr(&p.expr),
+                Expr::Group(g) => unwrap_path_expr(&g.expr),
+                _ => None,
             }
         }
 
@@ -2452,6 +2471,61 @@ pub fn handle_received_tx() {
 ";
         check_tx_relay_boundary_source(src)
             .expect("#[cfg(test)] let-stmt inside production fn must be skipped");
+    }
+
+    #[test]
+    fn parenthesised_direct_path_call_is_detected() {
+        // `(TxPool::admit)(tx)` — parens around a path callee. The
+        // default Expr::Path match in visit_expr_call would skip this
+        // form because the immediate callee is Expr::Paren. The
+        // unwrap_path_expr helper peels Paren/Group to expose the
+        // inner ExprPath.
+        let src = make_source_with_production_admission_body("let _ = (TxPool::admit)(tx);");
+        match check_tx_relay_boundary_source(&src) {
+            Err(BoundaryCheckError::ProductionAdmissionCall(AdmissionCallKind::DirectPath {
+                path,
+            })) => assert_eq!(path, "TxPool::admit"),
+            other => panic!("expected DirectPath for parenthesised TxPool::admit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parenthesised_qself_path_call_is_detected() {
+        // `(<crate::txpool::TxPool>::admit_with_metadata)(tx)` — parens
+        // around a UFCS callee. Same Paren-unwrap fix applies.
+        let src = make_source_with_production_admission_body(
+            "let _ = (<crate::txpool::TxPool>::admit_with_metadata)(tx);",
+        );
+        match check_tx_relay_boundary_source(&src) {
+            Err(BoundaryCheckError::ProductionAdmissionCall(AdmissionCallKind::QSelfPath {
+                qself_ty,
+                method,
+            })) => {
+                assert_eq!(qself_ty, "crate::txpool::TxPool");
+                assert_eq!(method, "admit_with_metadata");
+            }
+            other => panic!(
+                "expected QSelfPath for parenthesised <crate::txpool::TxPool>::admit_with_metadata, got {other:?}"
+            ),
+        }
+    }
+
+    #[test]
+    fn doubly_parenthesised_direct_path_call_is_detected() {
+        // `((TxPool::add_tx_with_source))(tx)` — two layers of parens
+        // around the callee. The unwrap_path_expr recursion peels
+        // them one at a time.
+        let src = make_source_with_production_admission_body(
+            "let _ = ((TxPool::add_tx_with_source))(tx);",
+        );
+        match check_tx_relay_boundary_source(&src) {
+            Err(BoundaryCheckError::ProductionAdmissionCall(AdmissionCallKind::DirectPath {
+                path,
+            })) => assert_eq!(path, "TxPool::add_tx_with_source"),
+            other => panic!(
+                "expected DirectPath for doubly parenthesised TxPool::add_tx_with_source, got {other:?}"
+            ),
+        }
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/tx_relay.rs
+++ b/clients/rust/crates/rubin-node/src/tx_relay.rs
@@ -150,11 +150,10 @@
 //! `class_change_stop_rule`. The conservative scope flags such
 //! carriers as production (false-positive over false-negative): a
 //! production-only admission introduced under any non-exact cfg
-//! shape will fire the checker, with the false-positive remediated
-//! by either rewriting the cfg to the exact `#[cfg(test)]` form,
-//! moving the admission to the canonical-pool surface, or escalating
-//! to a sounder `ConfigurationPredicate` reachability engine via
-//! a separate task. A standalone task tracks that engine.
+//! shape will fire the checker; the false-positive is remediated by
+//! rewriting the cfg to the exact `#[cfg(test)]` form on a
+//! top-level `Item` or moving the admission off the production
+//! surface.
 //!
 //! Allowed claim language for this checker (matches RUB-176 /
 //! GitHub issue #1432):
@@ -227,11 +226,9 @@
 //!    `cfg(true)`, `cfg(false)`, multi-`#[cfg]` stacks, and
 //!    below-item-level cfg gates (on `ImplItem`, `TraitItem`,
 //!    `Expr`, `Arm`, `Stmt`, `FieldValue`) are scanned as
-//!    production. False-positive remediation is either rewriting
-//!    the gate to the exact `#[cfg(test)]` shape on a top-level
-//!    `Item`, removing the admission from production scope, or
-//!    escalating to a sounder reachability engine via a separate
-//!    task;
+//!    production. False-positive remediation is rewriting the gate
+//!    to the exact `#[cfg(test)]` shape on a top-level `Item` or
+//!    removing the admission from production scope;
 //!  - cross-file structural drift — a future PR could add a
 //!    canonical `TxPool` field to `SyncEngine`, `PeerManager`,
 //!    `PeerOutbox`, or `TxRelayState` in another file and the
@@ -1361,9 +1358,7 @@ mod tests {
         /// (false-positive over false-negative): general
         /// `ConfigurationPredicate` reachability and below-item-level
         /// cfg gating are explicit non-scope per RUB-176 / GitHub
-        /// issue #1432's `class_change_stop_rule`. A fully sound
-        /// reachability engine for cfg predicates is tracked
-        /// separately and is not part of this slice.
+        /// issue #1432's `class_change_stop_rule`.
         pub fn check_tx_relay_boundary_source(source: &str) -> Result<(), BoundaryCheckError> {
             let file: File = syn::parse_file(source)
                 .map_err(|e| BoundaryCheckError::ParseFailed(e.to_string()))?;

--- a/clients/rust/crates/rubin-node/src/tx_relay.rs
+++ b/clients/rust/crates/rubin-node/src/tx_relay.rs
@@ -1412,19 +1412,33 @@ mod tests {
             }
         }
 
-        // Returns true iff the `Item` carries the EXACT literal
-        // attribute `#[cfg(test)]` — that is, an attribute whose path
-        // is `cfg` and whose `Meta::List` parses as a single `Path`
-        // identifier `test`. Every other shape (`cfg(any(test, X))`,
-        // `cfg(all(test, X))`, `cfg(not(test))`, `cfg(target_os =
-        // "linux")`, `cfg_attr(...)`, multiple cfg attributes) returns
-        // false and the carrier is scanned as production. The narrow
-        // shape is the only skip class supported by RUB-176 / GitHub
-        // issue #1432; broader `ConfigurationPredicate` reachability
-        // is explicit non-scope per the issue's
-        // `class_change_stop_rule`.
+        // Returns true iff the `Item` carries EXACTLY ONE `#[cfg(...)]`
+        // attribute and that attribute is the EXACT literal
+        // `#[cfg(test)]` — `Meta::List` whose path is `cfg` and whose
+        // inner tokens parse as a single `Path` identifier `test`.
+        // Every other shape returns false and the carrier is scanned
+        // as production:
+        //
+        //  - `cfg(any(test, X))`, `cfg(all(test, X))`, `cfg(not(test))`,
+        //    `cfg(target_os = "linux")`, `cfg_attr(...)` — non-exact
+        //    inner shape;
+        //  - `#[cfg(test)] #[cfg(other)]` (or any other multi-`#[cfg]`
+        //    stack) — even with the literal `#[cfg(test)]` present,
+        //    the conjunction with another `#[cfg]` pushes the carrier
+        //    out of the single-attribute skip class.
+        //
+        // Non-cfg attributes (`#[derive(...)]`, `#[allow(...)]`, etc.)
+        // do not gate compilation and are ignored when counting cfg
+        // attributes. The narrow single-attribute shape is the only
+        // skip class supported by RUB-176 / GitHub issue #1432; broader
+        // `ConfigurationPredicate` reachability is explicit non-scope
+        // per the issue's `class_change_stop_rule`.
         fn item_is_exact_cfg_test(item: &Item) -> bool {
-            item_attrs(item).iter().any(attr_is_exact_cfg_test)
+            let cfg_attrs: Vec<&Attribute> = item_attrs(item)
+                .iter()
+                .filter(|a| a.path().is_ident("cfg"))
+                .collect();
+            cfg_attrs.len() == 1 && attr_is_exact_cfg_test(cfg_attrs[0])
         }
 
         fn attr_is_exact_cfg_test(attr: &Attribute) -> bool {
@@ -2094,8 +2108,12 @@ pub trait Foo {
     #[test]
     fn impl_item_without_cfg_test_inside_production_impl_admission_is_detected() {
         // Negative control: an ordinary production impl-fn with an
-        // admission call must STILL be detected — the per-ImplItem
-        // skip applies only when `cfg(test)` attribute is present.
+        // admission call must be detected. The conservative scope
+        // walks every `ImplItem` body inside a production `impl`
+        // unconditionally — there is no `ImplItem`-level cfg-skip,
+        // so this case is identical in handling to a `#[cfg(test)]`
+        // impl-fn (both fire the checker; the latter is pinned by
+        // `cfg_test_on_impl_item_is_production_under_conservative_scope`).
         let src = "\
 pub fn handle_received_tx() {}
 
@@ -2131,6 +2149,33 @@ fn cross_platform_helper() {
             Err(BoundaryCheckError::ProductionAdmissionCall(_)) => {}
             other => panic!(
                 "expected admission detection inside cfg(unix|windows) ∧ cfg(64-bit) helper, got {other:?}"
+            ),
+        }
+    }
+
+    #[test]
+    fn multi_cfg_attrs_test_first_other_second_is_production_under_conservative_scope() {
+        // `#[cfg(test)] #[cfg(other)]` — even though one of the two
+        // cfg attributes is the EXACT literal `#[cfg(test)]`, the
+        // multi-`#[cfg]` stack pushes the carrier out of the
+        // single-attribute skip class. The conservative scope
+        // requires exactly one cfg attribute and that attribute be
+        // the literal shape; any additional cfg attribute makes the
+        // carrier production. Pins the contract↔code alignment after
+        // tightening `item_is_exact_cfg_test` to count cfg attrs.
+        let src = "\
+pub fn handle_received_tx() {}
+
+#[cfg(test)]
+#[cfg(other)]
+fn helper() {
+    crate::txpool::TxPool::admit(tx);
+}
+";
+        match check_tx_relay_boundary_source(src) {
+            Err(BoundaryCheckError::ProductionAdmissionCall(_)) => {}
+            other => panic!(
+                "expected admission detection inside #[cfg(test)] + #[cfg(other)] stack under conservative scope, got {other:?}"
             ),
         }
     }
@@ -2295,9 +2340,13 @@ pub fn handle_received_tx() {
 
     #[test]
     fn struct_literal_field_value_without_cfg_test_admission_is_detected() {
-        // Negative control: an ordinary FieldValue with an admission
-        // call must STILL be detected — the per-FieldValue skip
-        // applies only when `cfg(test)` is present.
+        // Negative control: an ordinary FieldValue initialiser with
+        // an admission call must be detected. The conservative scope
+        // walks every `FieldValue` unconditionally — there is no
+        // `FieldValue`-level cfg-skip, so this case is identical in
+        // handling to a `#[cfg(test)]` FieldValue (both fire; the
+        // latter is pinned by
+        // `cfg_test_on_struct_literal_field_value_is_production_under_conservative_scope`).
         let src = "\
 pub fn handle_received_tx() {
     let _ = Foo {
@@ -2334,9 +2383,13 @@ pub fn handle_received_tx() {
 
     #[test]
     fn block_expression_without_cfg_test_inside_production_fn_admission_is_detected() {
-        // Negative control for visit_expr-level cfg-skip: an
-        // ordinary block expression with an admission call inside a
-        // production function MUST still be detected.
+        // Negative control: an ordinary block expression with an
+        // admission call inside a production function must be
+        // detected. The conservative scope walks every `Expr`
+        // unconditionally — there is no `Expr`-level cfg-skip, so
+        // this case is identical in handling to a `#[cfg(test)]`
+        // block expr (both fire; the latter is pinned by
+        // `cfg_test_on_block_expression_is_production_under_conservative_scope`).
         let src = "\
 pub fn handle_received_tx() {
     {
@@ -2354,10 +2407,12 @@ pub fn handle_received_tx() {
 
     #[test]
     fn cfg_not_test_predicate_is_production_and_admission_is_detected() {
-        // `#[cfg(not(test))]` is production code under `cfg(test)`
-        // configuration — it is visible during normal builds but
-        // disabled during test compilation. The checker treats it as
-        // production scope and detects admission calls inside it.
+        // `#[cfg(not(test))]` is enabled exactly when `test` is NOT
+        // in the active config set — i.e. visible during normal
+        // builds and disabled during test compilation, the opposite
+        // gate of `#[cfg(test)]`. It is also not the EXACT literal
+        // `#[cfg(test)]`, so the conservative scope scans it as
+        // production and detects admission calls inside it.
         let src = "\
 pub fn handle_received_tx() {}
 

--- a/clients/rust/crates/rubin-node/src/tx_relay.rs
+++ b/clients/rust/crates/rubin-node/src/tx_relay.rs
@@ -126,23 +126,35 @@
 //!    `<self::TxPool>::method`, plus all `<X as Trait>::method`
 //!    trait-qualified variants).
 //!
-//! Production scope is established by structural recursion over the
-//! Rust `ConfigurationPredicate` grammar
-//! (<https://doc.rust-lang.org/reference/conditional-compilation.html>):
-//! an item is skipped from production scan iff its `#[cfg(...)]`
-//! predicate logically implies `test ∈ C` for every config `C`
-//! that satisfies it (`skip(I) ⇔ ∀C. P(I)(C) ⇒ test ∈ C`). The
-//! attribute body is parsed via `attr.parse_args::<CfgPred>()` into a
-//! recursive `CfgPred` AST and evaluated symbolically with `test`
-//! forced to `false`. The grammar's six productions (`test`, `true`,
-//! `false`, identifier-or-name=value option, `all(P*)`, `any(P*)`,
-//! `not(P)`) are all handled. Empty `all()` is the empty conjunction
-//! (always-true → not skipped); empty `any()` is the empty
-//! disjunction (always-false → vacuously skipped). The skip rule is
-//! applied per `Item`, per `ImplItem` (members of `impl` blocks),
-//! and per `TraitItem` (members of `trait` declarations); the
-//! boundary is NOT established by textual `split_once("#[cfg(test)]")`
-//! on the source.
+//! Production scope is established by a deliberately conservative
+//! rule: a top-level [`Item`] is skipped from production scan iff
+//! its attribute set contains the EXACT literal `#[cfg(test)]` —
+//! that is, an attribute whose path is `cfg` and whose `Meta::List`
+//! parses as a single `Path` identifier `test`. Every other carrier
+//! shape is scanned as production. The skip rule is applied via
+//! `Visit::visit_item` and so handles top-level items as well as
+//! nested items reachable through the visitor. The boundary is NOT
+//! established by textual `split_once("#[cfg(test)]")` on the
+//! source.
+//!
+//! Conservative-scope rationale: general
+//! `ConfigurationPredicate` reachability — deciding whether a
+//! `cfg(any(test, X))`, `cfg(all(test, X))`, `cfg(not(test))`,
+//! `cfg(target_os = "linux")`, `cfg(false)`, multi-`#[cfg]` stack,
+//! or below-item-level cfg gate (on `ImplItem`, `TraitItem`,
+//! `Expr`, `Arm`, `Stmt`, `FieldValue`) is enabled in production
+//! builds — requires modelling the Rust `ConfigurationPredicate`
+//! grammar
+//! (<https://doc.rust-lang.org/reference/conditional-compilation.html>)
+//! and is explicit non-scope per RUB-176 / GitHub issue #1432's
+//! `class_change_stop_rule`. The conservative scope flags such
+//! carriers as production (false-positive over false-negative): a
+//! production-only admission introduced under any non-exact cfg
+//! shape will fire the checker, with the false-positive remediated
+//! by either rewriting the cfg to the exact `#[cfg(test)]` form,
+//! moving the admission to the canonical-pool surface, or escalating
+//! to a sounder `ConfigurationPredicate` reachability engine via
+//! a separate task. A standalone task tracks that engine.
 //!
 //! Allowed claim language for this checker (matches RUB-176 /
 //! GitHub issue #1432):
@@ -150,16 +162,21 @@
 //!  - syntactic direct-call checker;
 //!  - token-aware over `tx_relay.rs` only;
 //!  - no comments / line-comments / block-comments / doc-comments /
-//!    string-literal / raw-string-literal / `#[cfg(test)]`-test-code
-//!    false positives — `syn` discards line and block comments
+//!    string-literal / raw-string-literal / exact-`#[cfg(test)]`
+//!    item false positives — `syn` discards line and block comments
 //!    during parse; doc comments live in attribute nodes and are
 //!    not visited as expression-callable tokens; string and raw-
 //!    string literals are `Lit::Str` AST nodes and are not visited
-//!    as call callables; `#[cfg(test)]` items are skipped via the
-//!    AST attribute walk;
+//!    as call callables; items carrying the EXACT literal
+//!    `#[cfg(test)]` attribute are skipped via the AST attribute
+//!    walk;
 //!  - no type-resolution completeness;
 //!  - no macro-expansion completeness;
 //!  - no cross-file carrier inspection;
+//!  - no general `ConfigurationPredicate` reachability — only the
+//!    EXACT literal `#[cfg(test)]` shape is a skip class, every
+//!    other cfg shape and every below-item-level cfg gate is
+//!    scanned as production;
 //!  - alias wrappers out of scope (`use crate::txpool::TxPool as
 //!    Pool` followed by `Pool::admit(...)` will not match because
 //!    the path's penultimate segment is `Pool`, not `TxPool`).
@@ -205,6 +222,16 @@
 //!    `<&TxPool>::admit`, `<(TxPool)>::admit`, `<Box<TxPool>>::admit`,
 //!    or any `Wrapper<TxPool>` whose `Type::Path` terminal segment
 //!    is `Wrapper`, not `TxPool`);
+//!  - general `ConfigurationPredicate` reachability — `cfg(any(...))`,
+//!    `cfg(all(...))`, `cfg(not(...))`, `cfg(name = "value")`,
+//!    `cfg(true)`, `cfg(false)`, multi-`#[cfg]` stacks, and
+//!    below-item-level cfg gates (on `ImplItem`, `TraitItem`,
+//!    `Expr`, `Arm`, `Stmt`, `FieldValue`) are scanned as
+//!    production. False-positive remediation is either rewriting
+//!    the gate to the exact `#[cfg(test)]` shape on a top-level
+//!    `Item`, removing the admission from production scope, or
+//!    escalating to a sounder reachability engine via a separate
+//!    task;
 //!  - cross-file structural drift — a future PR could add a
 //!    canonical `TxPool` field to `SyncEngine`, `PeerManager`,
 //!    `PeerOutbox`, or `TxRelayState` in another file and the
@@ -1245,11 +1272,10 @@ mod tests {
     /// and known non-scope (alias wrappers, macro expansion, type
     /// resolution, cross-file analysis are explicit non-scope).
     mod boundary_checker {
-        use syn::parse::{Parse, ParseStream};
         use syn::visit::Visit;
         use syn::{
-            Arm, Attribute, Expr, ExprCall, ExprMethodCall, ExprPath, File, Ident, ImplItem, Item,
-            ItemFn, Lit, LitBool, Path, QSelf, Stmt, Token, TraitItem, Type,
+            Attribute, Expr, ExprCall, ExprMethodCall, ExprPath, File, Item, ItemFn, Meta, Path,
+            QSelf, Type,
         };
 
         /// Method idents that constitute canonical `TxPool` admission per
@@ -1312,15 +1338,32 @@ mod tests {
         /// `Err(BoundaryCheckError)` describing the first violation or
         /// fail-closed condition.
         ///
-        /// "Production scope" excludes any carrier (`Item`,
-        /// `ImplItem`, `TraitItem`, `Expr`, `Stmt::Local`,
-        /// `Stmt::Macro`, `Arm`) whose `#[cfg(...)]` attribute
-        /// conjunction logically implies `test ∈ C`. The exclusion
-        /// is established by parsing each cfg attribute body via
-        /// `attr.parse_args::<CfgPred>()` into a structural AST and
-        /// evaluating the conjunction via `satisfiable_under_test_absent`,
-        /// NOT by textual `split_once("#[cfg(test)]")` on the source
-        /// string.
+        /// "Production scope" excludes only [`Item`]s that carry the
+        /// EXACT literal attribute `#[cfg(test)]` — that is, an
+        /// attribute whose path is `cfg` and whose `Meta::List` parses
+        /// as a single `Path` identifier `test`. Every other carrier
+        /// shape is scanned as production:
+        ///
+        ///  - `#[cfg(any(test, X))]` items, `#[cfg(all(test, X))]`
+        ///    items, `#[cfg(not(test))]` items, `#[cfg(target_os =
+        ///    "linux")]` items, `#[cfg(false)]` items, multi-`#[cfg]`
+        ///    stacks — production;
+        ///  - `#[cfg(test)]` `ImplItem`s (associated `fn`s inside a
+        ///    production `impl`), `#[cfg(test)]` `TraitItem`s
+        ///    (default-method bodies inside a production `trait`),
+        ///    `#[cfg(test)]` `Expr`s (block / match / if / etc.),
+        ///    `#[cfg(test)]` `Arm`s (match arms), `#[cfg(test)]`
+        ///    `FieldValue`s (struct-literal initialisers),
+        ///    `#[cfg(test)]` `Stmt`s (`let` / standalone-macro
+        ///    statements) — production.
+        ///
+        /// The skip predicate is intentionally conservative
+        /// (false-positive over false-negative): general
+        /// `ConfigurationPredicate` reachability and below-item-level
+        /// cfg gating are explicit non-scope per RUB-176 / GitHub
+        /// issue #1432's `class_change_stop_rule`. A fully sound
+        /// reachability engine for cfg predicates is tracked
+        /// separately and is not part of this slice.
         pub fn check_tx_relay_boundary_source(source: &str) -> Result<(), BoundaryCheckError> {
             let file: File = syn::parse_file(source)
                 .map_err(|e| BoundaryCheckError::ParseFailed(e.to_string()))?;
@@ -1330,7 +1373,7 @@ mod tests {
             let mut found_handler = false;
             let mut visitor = AdmissionFinder::default();
             for item in &file.items {
-                if item_is_cfg_test(item) {
+                if item_is_exact_cfg_test(item) {
                     continue;
                 }
                 if let Item::Fn(ItemFn { sig, .. }) = item {
@@ -1349,8 +1392,12 @@ mod tests {
             Ok(())
         }
 
-        fn item_is_cfg_test(item: &Item) -> bool {
-            let attrs: &[Attribute] = match item {
+        // Returns the attribute slice attached to a top-level `Item`.
+        // Item variants outside this list (e.g. `Item::Verbatim`) do
+        // not carry attributes the checker can read — return an empty
+        // slice for those.
+        fn item_attrs(item: &Item) -> &[Attribute] {
+            match item {
                 Item::Const(i) => &i.attrs,
                 Item::Enum(i) => &i.attrs,
                 Item::ExternCrate(i) => &i.attrs,
@@ -1366,392 +1413,42 @@ mod tests {
                 Item::Type(i) => &i.attrs,
                 Item::Union(i) => &i.attrs,
                 Item::Use(i) => &i.attrs,
-                _ => return false,
-            };
-            attrs_imply_test(attrs)
-        }
-
-        fn impl_item_is_cfg_test(item: &ImplItem) -> bool {
-            let attrs: &[Attribute] = match item {
-                ImplItem::Const(c) => &c.attrs,
-                ImplItem::Fn(f) => &f.attrs,
-                ImplItem::Type(t) => &t.attrs,
-                ImplItem::Macro(m) => &m.attrs,
-                _ => return false,
-            };
-            attrs_imply_test(attrs)
-        }
-
-        fn trait_item_is_cfg_test(item: &TraitItem) -> bool {
-            let attrs: &[Attribute] = match item {
-                TraitItem::Const(c) => &c.attrs,
-                TraitItem::Fn(f) => &f.attrs,
-                TraitItem::Type(t) => &t.attrs,
-                TraitItem::Macro(m) => &m.attrs,
-                _ => return false,
-            };
-            attrs_imply_test(attrs)
-        }
-
-        // Returns true iff the conjunction of every `#[cfg(...)]`
-        // attribute on the carrier (Item / ImplItem / TraitItem /
-        // Expr / Stmt / Arm) logically implies `test ∈ C` for every
-        // config C that satisfies all of them. Multiple
-        // `#[cfg(P1)] #[cfg(P2)]` attributes on the same carrier are
-        // AND-ed by Rust, so the carrier is enabled iff `P1 ∧ P2 ∧ …`,
-        // and `(P1 ∧ P2 ∧ …) ⇒ test` is the right skip predicate.
-        //
-        // Skip-from-production rule:
-        //   skip(I) ⇔ ∀C. (∧ᵢ Pᵢ(I)(C)) ⇒ test ∈ C
-        // per the Rust reference's ConfigurationPredicate grammar
-        // (`all` / `any` / `not` / option / `true` / `false`).
-        //
-        // Algorithm: parse each cfg attribute body into a `CfgPred`
-        // AST, wrap the parsed list in `CfgPred::All` (semantic
-        // conjunction), and evaluate it symbolically with
-        // `test = false` and every other identifier left as a free
-        // Boolean variable. The conjoined predicate implies test iff
-        // it is decidably-unsatisfiable in the world where test is
-        // absent. `value_under_test_absent` returns:
-        //   `Some(false)`  decidably-unsatisfiable     ⇒ skip
-        //   `Some(true)`   decidably-true on test ∉ C  ⇒ NOT skip
-        //   `None`         depends on free identifiers ⇒ NOT skip
-        // Non-cfg attributes (e.g. `#[derive(...)]`) do not gate
-        // compilation and are ignored.
-        fn attrs_imply_test(attrs: &[Attribute]) -> bool {
-            let cfg_preds: Vec<CfgPred> = attrs
-                .iter()
-                .filter(|a| a.path().is_ident("cfg"))
-                .filter_map(|a| a.parse_args::<CfgPred>().ok())
-                .collect();
-            if cfg_preds.is_empty() {
-                return false;
-            }
-            // skip iff the conjoined predicate is unsatisfiable when
-            // test is absent. SAT enumerates assignments to all
-            // distinct free variables, so multi-cfg cases that
-            // collapse to `test` are correctly identified even when
-            // no single attribute implies test.
-            !satisfiable_under_test_absent(&CfgPred::All(cfg_preds))
-        }
-
-        // Returns the attribute slice attached to an `Expr`. Almost
-        // every `Expr` variant carries its own `attrs` field; the
-        // catch-all `_` returns an empty slice for non-attribute-
-        // carrying variants (forward-compatibility with future syn
-        // additions).
-        fn expr_attrs(expr: &Expr) -> &[Attribute] {
-            match expr {
-                Expr::Array(e) => &e.attrs,
-                Expr::Assign(e) => &e.attrs,
-                Expr::Async(e) => &e.attrs,
-                Expr::Await(e) => &e.attrs,
-                Expr::Binary(e) => &e.attrs,
-                Expr::Block(e) => &e.attrs,
-                Expr::Break(e) => &e.attrs,
-                Expr::Call(e) => &e.attrs,
-                Expr::Cast(e) => &e.attrs,
-                Expr::Closure(e) => &e.attrs,
-                Expr::Const(e) => &e.attrs,
-                Expr::Continue(e) => &e.attrs,
-                Expr::Field(e) => &e.attrs,
-                Expr::ForLoop(e) => &e.attrs,
-                Expr::Group(e) => &e.attrs,
-                Expr::If(e) => &e.attrs,
-                Expr::Index(e) => &e.attrs,
-                Expr::Infer(e) => &e.attrs,
-                Expr::Let(e) => &e.attrs,
-                Expr::Lit(e) => &e.attrs,
-                Expr::Loop(e) => &e.attrs,
-                Expr::Macro(e) => &e.attrs,
-                Expr::Match(e) => &e.attrs,
-                Expr::MethodCall(e) => &e.attrs,
-                Expr::Paren(e) => &e.attrs,
-                Expr::Path(e) => &e.attrs,
-                Expr::Range(e) => &e.attrs,
-                Expr::Reference(e) => &e.attrs,
-                Expr::Repeat(e) => &e.attrs,
-                Expr::Return(e) => &e.attrs,
-                Expr::Struct(e) => &e.attrs,
-                Expr::Try(e) => &e.attrs,
-                Expr::TryBlock(e) => &e.attrs,
-                Expr::Tuple(e) => &e.attrs,
-                Expr::Unary(e) => &e.attrs,
-                Expr::Unsafe(e) => &e.attrs,
-                Expr::While(e) => &e.attrs,
-                Expr::Yield(e) => &e.attrs,
                 _ => &[],
             }
         }
 
-        // Surface form of a Rust `ConfigurationPredicate` we model.
-        // `Var(name)` covers any non-`test` identifier predicate,
-        // any `name = "value"` option (encoded as `name="..."`), and
-        // any unknown function-call form. Variables with the same
-        // surface name resolve to the same Boolean variable during
-        // SAT search — so `cfg(any(test, foo))` ∧ `cfg(any(test, not(foo)))`
-        // collapses to `test` because `foo ∧ ¬foo` is unsatisfiable.
-        enum CfgPred {
-            Test,
-            True,
-            False,
-            Var(String),
-            All(Vec<CfgPred>),
-            Any(Vec<CfgPred>),
-            Not(Box<CfgPred>),
+        // Returns true iff the `Item` carries the EXACT literal
+        // attribute `#[cfg(test)]` — that is, an attribute whose path
+        // is `cfg` and whose `Meta::List` parses as a single `Path`
+        // identifier `test`. Every other shape (`cfg(any(test, X))`,
+        // `cfg(all(test, X))`, `cfg(not(test))`, `cfg(target_os =
+        // "linux")`, `cfg_attr(...)`, multiple cfg attributes) returns
+        // false and the carrier is scanned as production. The narrow
+        // shape is the only skip class supported by RUB-176 / GitHub
+        // issue #1432; broader `ConfigurationPredicate` reachability
+        // is explicit non-scope per the issue's
+        // `class_change_stop_rule`.
+        fn item_is_exact_cfg_test(item: &Item) -> bool {
+            item_attrs(item).iter().any(attr_is_exact_cfg_test)
         }
 
-        impl Parse for CfgPred {
-            fn parse(input: ParseStream) -> syn::Result<Self> {
-                // Boolean literals (`true` / `false`) come first
-                // because they are reserved keywords and would
-                // otherwise be rejected by the `Ident` branch below.
-                if input.peek(LitBool) {
-                    let b: LitBool = input.parse()?;
-                    return Ok(if b.value {
-                        CfgPred::True
-                    } else {
-                        CfgPred::False
-                    });
-                }
-                let ident: Ident = input.parse()?;
-                let name = ident.to_string();
-                if input.peek(syn::token::Paren) {
-                    let inner;
-                    syn::parenthesized!(inner in input);
-                    match name.as_str() {
-                        "all" => {
-                            let preds = inner.parse_terminated(CfgPred::parse, Token![,])?;
-                            Ok(CfgPred::All(preds.into_iter().collect()))
-                        }
-                        "any" => {
-                            let preds = inner.parse_terminated(CfgPred::parse, Token![,])?;
-                            Ok(CfgPred::Any(preds.into_iter().collect()))
-                        }
-                        "not" => {
-                            let pred: CfgPred = inner.parse()?;
-                            // `cfg(not(...))` accepts at most one
-                            // predicate; allow an optional trailing
-                            // comma but reject extra predicates.
-                            if inner.peek(Token![,]) {
-                                inner.parse::<Token![,]>()?;
-                            }
-                            if !inner.is_empty() {
-                                return Err(inner.error("not() takes one predicate"));
-                            }
-                            Ok(CfgPred::Not(Box::new(pred)))
-                        }
-                        // Unknown function-call form (e.g.
-                        // `version("1.0")`) — keyed by the surface
-                        // ident only. Sufficient for SAT correctness
-                        // because two unknown calls with the same
-                        // ident collide as the same variable.
-                        _ => Ok(CfgPred::Var(name)),
-                    }
-                } else if input.peek(Token![=]) {
-                    input.parse::<Token![=]>()?;
-                    let lit: Lit = input.parse()?;
-                    let value_repr = match &lit {
-                        Lit::Str(s) => format!("\"{}\"", s.value()),
-                        Lit::Int(i) => i.token().to_string(),
-                        Lit::Bool(b) => b.value.to_string(),
-                        _ => String::from("?"),
-                    };
-                    Ok(CfgPred::Var(format!("{name}={value_repr}")))
-                } else if name == "test" {
-                    Ok(CfgPred::Test)
-                } else {
-                    Ok(CfgPred::Var(name))
-                }
+        fn attr_is_exact_cfg_test(attr: &Attribute) -> bool {
+            let Meta::List(list) = &attr.meta else {
+                return false;
+            };
+            if !list.path.is_ident("cfg") {
+                return false;
             }
-        }
-
-        // Returns `true` iff `P` has a satisfying assignment to its
-        // free Boolean variables when `test` is forced to `false`.
-        // Equivalently: `¬satisfiable_under_test_absent(P)` is the
-        // skip predicate (`P ⇒ test` iff no model satisfies `P` with
-        // `test ∉ C`).
-        //
-        // Implementation: first attempt structural simplification —
-        // a recursive walk that propagates `Some(false)` for `Test`,
-        // empty `any()`, and `False`, and `Some(true)` for empty
-        // `all()` and `True`, through `all`/`any`/`not`. The
-        // simplification short-circuits on decidable trees (e.g.
-        // `all(test, …)` resolves to `Some(false)` because one
-        // conjunct is unsatisfiable when test is absent, regardless
-        // of how many free vars the other conjuncts contain). Only
-        // when simplification cannot decide does the function fall
-        // back to SAT enumeration over distinct `Var(name)`
-        // identifiers (capped at 16 vars; beyond the cap returns
-        // `true` — conservative-not-skip — which is the safe
-        // direction for a boundary checker because under-skipping
-        // produces false positives, not false negatives).
-        //
-        // SAT enumeration honours mutual-exclusion of `name=value`
-        // options sharing the same `name`: at most one
-        // `name="value1"`, `name="value2"`, … can be true in any
-        // real config, so assignments that turn on multiple values
-        // for the same key are skipped (treated as physically
-        // impossible, not "satisfying"). This handles the
-        // `cfg(all(target_os="linux", target_os="windows"))`
-        // unsatisfiability case correctly.
-        fn satisfiable_under_test_absent(p: &CfgPred) -> bool {
-            if let Some(value) = simplify_under_test_absent(p) {
-                return value;
-            }
-            let mut vars: Vec<String> = Vec::new();
-            collect_vars(p, &mut vars);
-            let n = vars.len();
-            if n > 16 {
-                return true;
-            }
-            // Pre-compute same-key var groups (indices in `vars`)
-            // for mutual-exclusion enforcement during enumeration.
-            let groups = group_indices_by_key(&vars);
-            let total: u64 = 1u64 << n;
-            for mask in 0..total {
-                if violates_key_exclusivity(mask, &groups) {
-                    continue;
-                }
-                let env: Vec<(&str, bool)> = vars
-                    .iter()
-                    .enumerate()
-                    .map(|(i, name)| (name.as_str(), (mask >> i) & 1 == 1))
-                    .collect();
-                if evaluate_under_test_absent(p, &env) {
-                    return true;
-                }
-            }
-            false
-        }
-
-        // Three-valued structural simplification with `test = false`.
-        // Returns `Some(b)` when `P` is decidable from grammar alone
-        // (no SAT search over free Var assignments needed) and
-        // `None` when the value depends on free identifiers. Cures
-        // the >16-var cap problem for predicates whose `test`
-        // appearance forces a structural shortcut.
-        fn simplify_under_test_absent(p: &CfgPred) -> Option<bool> {
-            match p {
-                CfgPred::Test => Some(false),
-                CfgPred::True => Some(true),
-                CfgPred::False => Some(false),
-                CfgPred::Var(_) => None,
-                CfgPred::All(children) => {
-                    if children.is_empty() {
-                        return Some(true);
-                    }
-                    let mut all_true = true;
-                    for c in children {
-                        match simplify_under_test_absent(c) {
-                            Some(false) => return Some(false),
-                            Some(true) => continue,
-                            None => all_true = false,
-                        }
-                    }
-                    if all_true {
-                        Some(true)
-                    } else {
-                        None
-                    }
-                }
-                CfgPred::Any(children) => {
-                    if children.is_empty() {
-                        return Some(false);
-                    }
-                    let mut all_false = true;
-                    for c in children {
-                        match simplify_under_test_absent(c) {
-                            Some(true) => return Some(true),
-                            Some(false) => continue,
-                            None => all_false = false,
-                        }
-                    }
-                    if all_false {
-                        Some(false)
-                    } else {
-                        None
-                    }
-                }
-                CfgPred::Not(inner) => simplify_under_test_absent(inner).map(|b| !b),
-            }
-        }
-
-        // Returns groups of indices in `vars` that share the same
-        // `name=` prefix. Two `name=value1` and `name=value2` Vars
-        // for the same key are mutually exclusive in any real Rust
-        // build configuration (e.g. `target_os` is exactly one of
-        // {"linux","windows","macos",…}), so SAT enumeration must
-        // skip assignments that turn on more than one of them.
-        fn group_indices_by_key(vars: &[String]) -> Vec<Vec<usize>> {
-            let mut groups: Vec<(String, Vec<usize>)> = Vec::new();
-            for (i, v) in vars.iter().enumerate() {
-                let key = match v.find('=') {
-                    Some(eq) => &v[..eq],
-                    None => continue,
-                };
-                if let Some(g) = groups.iter_mut().find(|(k, _)| k == key) {
-                    g.1.push(i);
-                } else {
-                    groups.push((key.to_string(), vec![i]));
-                }
-            }
-            groups
-                .into_iter()
-                .filter_map(|(_, idx)| if idx.len() > 1 { Some(idx) } else { None })
-                .collect()
-        }
-
-        fn violates_key_exclusivity(mask: u64, groups: &[Vec<usize>]) -> bool {
-            for g in groups {
-                let mut on = 0;
-                for &i in g {
-                    if (mask >> i) & 1 == 1 {
-                        on += 1;
-                        if on > 1 {
-                            return true;
-                        }
-                    }
-                }
-            }
-            false
-        }
-
-        fn collect_vars(p: &CfgPred, vars: &mut Vec<String>) {
-            match p {
-                CfgPred::Var(name) => {
-                    if !vars.iter().any(|v| v == name) {
-                        vars.push(name.clone());
-                    }
-                }
-                CfgPred::All(children) | CfgPred::Any(children) => {
-                    for c in children {
-                        collect_vars(c, vars);
-                    }
-                }
-                CfgPred::Not(inner) => collect_vars(inner, vars),
-                CfgPred::Test | CfgPred::True | CfgPred::False => {}
-            }
-        }
-
-        fn evaluate_under_test_absent(p: &CfgPred, env: &[(&str, bool)]) -> bool {
-            match p {
-                CfgPred::Test => false,
-                CfgPred::True => true,
-                CfgPred::False => false,
-                CfgPred::Var(name) => env
-                    .iter()
-                    .find(|(v, _)| *v == name.as_str())
-                    .map(|(_, val)| *val)
-                    .unwrap_or(false),
-                CfgPred::All(children) => {
-                    children.iter().all(|c| evaluate_under_test_absent(c, env))
-                }
-                CfgPred::Any(children) => {
-                    children.iter().any(|c| evaluate_under_test_absent(c, env))
-                }
-                CfgPred::Not(inner) => !evaluate_under_test_absent(inner, env),
-            }
+            // Parse the inner tokens as a single `Path` and require
+            // its sole ident to be `test`. Any other shape (e.g.
+            // `all(...)`, `any(...)`, `not(...)`, `name = "value"`)
+            // either fails to parse as a `Path` or has more than one
+            // segment, returning false — and the carrier is scanned
+            // as production.
+            let Ok(inner_path) = list.parse_args::<Path>() else {
+                return false;
+            };
+            inner_path.is_ident("test")
         }
 
         #[derive(Default)]
@@ -1761,74 +1458,20 @@ mod tests {
 
         impl<'ast> Visit<'ast> for AdmissionFinder {
             fn visit_item(&mut self, item: &'ast Item) {
-                // Skip nested `#[cfg(test)]` items (e.g. inline
-                // `#[cfg(test)] mod inner_tests { ... }` inside a
-                // production `mod` block).
-                if item_is_cfg_test(item) {
+                // Skip nested `#[cfg(test)] mod ...` (or any other
+                // nested `#[cfg(test)]` `Item`) — the same exact
+                // literal-attribute rule applied to top-level items
+                // applies here. Any other cfg shape (`any`, `all`,
+                // `not`, `name = "value"`, multi-cfg) on a nested
+                // item is scanned as production. Below-item-level
+                // cfg attributes (on `Expr`, `Arm`, `Stmt`,
+                // `FieldValue`, `ImplItem`, `TraitItem`) are also
+                // scanned as production — see the module docstring's
+                // "Known non-scope" section for the explicit list.
+                if item_is_exact_cfg_test(item) {
                     return;
                 }
                 syn::visit::visit_item(self, item);
-            }
-
-            fn visit_impl_item(&mut self, item: &'ast ImplItem) {
-                // Per-item cfg-skip applied to associated items
-                // inside a production `impl` block. Without this
-                // override the default visitor descends into
-                // `#[cfg(test)] fn ...` bodies declared inside an
-                // otherwise-production impl.
-                if impl_item_is_cfg_test(item) {
-                    return;
-                }
-                syn::visit::visit_impl_item(self, item);
-            }
-
-            fn visit_trait_item(&mut self, item: &'ast TraitItem) {
-                // Per-item cfg-skip applied to associated items
-                // inside a production `trait` declaration (default-
-                // method bodies can contain expressions).
-                if trait_item_is_cfg_test(item) {
-                    return;
-                }
-                syn::visit::visit_trait_item(self, item);
-            }
-
-            fn visit_expr(&mut self, expr: &'ast Expr) {
-                // Below-item-level cfg-skip: Rust allows `#[cfg(...)]`
-                // on any expression form (`ExprBlock`, `ExprIf`,
-                // `ExprMatch`, etc.). The attribute set on the
-                // expression itself gates whether the expression is
-                // compiled in non-test builds.
-                if attrs_imply_test(expr_attrs(expr)) {
-                    return;
-                }
-                syn::visit::visit_expr(self, expr);
-            }
-
-            fn visit_arm(&mut self, arm: &'ast Arm) {
-                // `match x { #[cfg(test)] _ => TxPool::admit(tx) }` —
-                // the arm is gated independently of the match
-                // expression as a whole.
-                if attrs_imply_test(&arm.attrs) {
-                    return;
-                }
-                syn::visit::visit_arm(self, arm);
-            }
-
-            fn visit_stmt(&mut self, stmt: &'ast Stmt) {
-                // `let`-bindings and standalone macro statements
-                // carry their own attribute set. Inner expression /
-                // item statements have attrs on the wrapped node and
-                // are filtered through `visit_expr` / `visit_item`
-                // already.
-                let attrs: &[Attribute] = match stmt {
-                    Stmt::Local(local) => &local.attrs,
-                    Stmt::Macro(m) => &m.attrs,
-                    Stmt::Expr(_, _) | Stmt::Item(_) => &[][..],
-                };
-                if attrs_imply_test(attrs) {
-                    return;
-                }
-                syn::visit::visit_stmt(self, stmt);
             }
 
             fn visit_expr_method_call(&mut self, node: &'ast ExprMethodCall) {
@@ -2305,10 +1948,15 @@ fn experimental_helper() {
     }
 
     #[test]
-    fn cfg_all_test_with_other_conjunct_is_skipped() {
-        // `cfg(all(test, target_os = "linux"))` requires test ∈ C for
-        // the predicate to hold on any C, so it implies test and the
-        // item must be skipped from production scan.
+    fn cfg_all_test_x_is_production_under_conservative_scope() {
+        // `cfg(all(test, target_os = "linux"))` is NOT the exact
+        // literal `#[cfg(test)]`, so the carrier is scanned as
+        // production under the conservative scope. The fact that the
+        // predicate logically implies `test` (every config that
+        // satisfies it has `test ∈ C`) is irrelevant — general
+        // `ConfigurationPredicate` reachability is explicit non-scope
+        // per RUB-176 / GitHub issue #1432's `class_change_stop_rule`.
+        // Conservative direction: false-positive over false-negative.
         let src = "\
 pub fn handle_received_tx() {}
 
@@ -2317,31 +1965,19 @@ fn linux_test_helper() {
     crate::txpool::TxPool::admit(tx);
 }
 ";
-        check_tx_relay_boundary_source(src)
-            .expect("#[cfg(all(test, ...))] implies test and must be skipped");
+        match check_tx_relay_boundary_source(src) {
+            Err(BoundaryCheckError::ProductionAdmissionCall(_)) => {}
+            other => panic!(
+                "expected admission detection inside cfg(all(test, target_os)) under conservative scope, got {other:?}"
+            ),
+        }
     }
 
     #[test]
-    fn cfg_any_with_only_test_disjuncts_is_skipped() {
-        // `cfg(any(test, test))` — every disjunct implies test, so the
-        // whole predicate implies test. Skip.
-        let src = "\
-pub fn handle_received_tx() {}
-
-#[cfg(any(test, test))]
-fn redundant_helper() {
-    crate::txpool::TxPool::admit(tx);
-}
-";
-        check_tx_relay_boundary_source(src)
-            .expect("any(test, test) implies test (every disjunct does)");
-    }
-
-    #[test]
-    fn cfg_any_with_one_test_and_one_non_test_is_production() {
-        // Adversarial depth-2: `cfg(any(test, foo))` with `foo` a bare
-        // identifier — config with `foo` enabled and test disabled
-        // satisfies the predicate, so the predicate does NOT imply test.
+    fn cfg_any_test_x_is_production_under_conservative_scope() {
+        // `cfg(any(test, foo))` — config with `foo` enabled and test
+        // disabled satisfies the predicate, so the carrier is genuinely
+        // production-reachable. Conservative scope flags it correctly.
         let src = "\
 pub fn handle_received_tx() {}
 
@@ -2359,50 +1995,12 @@ fn helper() {
     }
 
     #[test]
-    fn cfg_nested_any_all_depth_3_skipped_when_every_branch_implies_test() {
-        // Depth-3: `cfg(any(all(test, foo), all(test, bar)))` —
-        // outer `any` requires every branch to imply test; both inner
-        // `all` branches contain a `test` conjunct, so each implies
-        // test. The whole predicate implies test → skip.
-        let src = "\
-pub fn handle_received_tx() {}
-
-#[cfg(any(all(test, foo), all(test, bar)))]
-fn deep_helper() {
-    crate::txpool::TxPool::admit(tx);
-}
-";
-        check_tx_relay_boundary_source(src)
-            .expect("cfg(any(all(test, foo), all(test, bar))) implies test at depth 3 — must skip");
-    }
-
-    #[test]
-    fn cfg_nested_all_any_depth_3_production_when_inner_any_does_not_imply_test() {
-        // Depth-3: `cfg(all(any(test, foo), bar))` — outer `all`
-        // implies test iff some conjunct implies test; the only `test`
-        // appearance is inside `any(test, foo)` whose `foo` disjunct
-        // breaks the implication; the `bar` conjunct has no test. So
-        // the whole predicate does NOT imply test → production.
-        let src = "\
-pub fn handle_received_tx() {}
-
-#[cfg(all(any(test, foo), bar))]
-fn deep_helper() {
-    crate::txpool::TxPool::admit(tx);
-}
-";
-        match check_tx_relay_boundary_source(src) {
-            Err(BoundaryCheckError::ProductionAdmissionCall(_)) => {}
-            other => panic!(
-                "expected admission detection inside cfg(all(any(test, foo), bar)), got {other:?}"
-            ),
-        }
-    }
-
-    #[test]
-    fn cfg_double_negation_of_test_implies_test_and_is_skipped() {
-        // `cfg(not(not(test)))` is logically equivalent to `cfg(test)`
-        // — implies test, must skip.
+    fn cfg_double_negation_of_test_is_production_under_conservative_scope() {
+        // `cfg(not(not(test)))` is logically equivalent to
+        // `cfg(test)`, but it is not the EXACT literal `#[cfg(test)]`,
+        // so the conservative scope scans it as production. General
+        // `ConfigurationPredicate` reachability is explicit non-scope
+        // per RUB-176 / GitHub issue #1432's `class_change_stop_rule`.
         let src = "\
 pub fn handle_received_tx() {}
 
@@ -2411,14 +2009,22 @@ fn helper() {
     crate::txpool::TxPool::admit(tx);
 }
 ";
-        check_tx_relay_boundary_source(src)
-            .expect("not(not(test)) collapses to test and must be skipped");
+        match check_tx_relay_boundary_source(src) {
+            Err(BoundaryCheckError::ProductionAdmissionCall(_)) => {}
+            other => panic!(
+                "expected admission detection inside cfg(not(not(test))) under conservative scope, got {other:?}"
+            ),
+        }
     }
 
     #[test]
-    fn cfg_false_literal_predicate_is_unsatisfiable_and_skipped() {
-        // `cfg(false)` is never enabled — the implication
-        // `predicate(C) ⇒ test ∈ C` holds vacuously. Skip.
+    fn cfg_false_literal_is_production_under_conservative_scope() {
+        // `cfg(false)` is logically never-enabled, but it is not the
+        // EXACT literal `#[cfg(test)]`, so the conservative scope
+        // scans it as production. Detecting `cfg(false)` as
+        // unconditionally-disabled requires the same general
+        // `ConfigurationPredicate` reachability that is explicit
+        // non-scope.
         let src = "\
 pub fn handle_received_tx() {}
 
@@ -2427,14 +2033,23 @@ fn never_compiled_helper() {
     crate::txpool::TxPool::admit(tx);
 }
 ";
-        check_tx_relay_boundary_source(src)
-            .expect("cfg(false) is unsatisfiable; vacuously implies test; must skip");
+        match check_tx_relay_boundary_source(src) {
+            Err(BoundaryCheckError::ProductionAdmissionCall(_)) => {}
+            other => panic!(
+                "expected admission detection inside cfg(false) under conservative scope, got {other:?}"
+            ),
+        }
     }
 
     #[test]
-    fn cfg_test_on_impl_item_inside_production_impl_is_skipped() {
-        // ImplItem-level cfg-skip: `impl Foo { #[cfg(test)] fn helper() {...} }`
-        // inside a production impl block must be skipped per-item.
+    fn cfg_test_on_impl_item_is_production_under_conservative_scope() {
+        // `impl Foo { #[cfg(test)] fn ... }` carries the `#[cfg(test)]`
+        // attribute at the `ImplItem` level, NOT at the surrounding
+        // `Item::Impl` level. Below-item-level cfg gating is explicit
+        // non-scope per RUB-176 / GitHub issue #1432's
+        // `class_change_stop_rule`, so the conservative scope walks
+        // every `ImplItem` body inside a production `impl` and
+        // detects the admission call.
         let src = "\
 pub fn handle_received_tx() {}
 
@@ -2448,15 +2063,19 @@ impl Foo {
     }
 }
 ";
-        check_tx_relay_boundary_source(src).expect(
-            "ImplItem with #[cfg(test)] inside production impl block must be skipped per-item",
-        );
+        match check_tx_relay_boundary_source(src) {
+            Err(BoundaryCheckError::ProductionAdmissionCall(_)) => {}
+            other => panic!(
+                "expected admission detection inside #[cfg(test)] ImplItem under conservative scope, got {other:?}"
+            ),
+        }
     }
 
     #[test]
-    fn cfg_test_on_trait_item_default_method_inside_production_trait_is_skipped() {
-        // TraitItem-level cfg-skip: a default method body in a trait
-        // declaration with `#[cfg(test)]` must be skipped per-item.
+    fn cfg_test_on_trait_item_default_method_is_production_under_conservative_scope() {
+        // Same below-item-level non-scope rule applies to `TraitItem`
+        // default-method bodies inside a production `trait`
+        // declaration.
         let src = "\
 pub fn handle_received_tx() {}
 
@@ -2469,9 +2088,12 @@ pub trait Foo {
     }
 }
 ";
-        check_tx_relay_boundary_source(src).expect(
-            "TraitItem default-method body with #[cfg(test)] inside production trait must be skipped per-item",
-        );
+        match check_tx_relay_boundary_source(src) {
+            Err(BoundaryCheckError::ProductionAdmissionCall(_)) => {}
+            other => panic!(
+                "expected admission detection inside #[cfg(test)] TraitItem under conservative scope, got {other:?}"
+            ),
+        }
     }
 
     #[test]
@@ -2498,31 +2120,9 @@ impl Foo {
     }
 
     #[test]
-    fn multi_cfg_attrs_combine_via_conjunction_implies_test() {
-        // `#[cfg(any(test, foo))] #[cfg(any(test, not(foo)))]`
-        // ≡ `(test ∨ foo) ∧ (test ∨ ¬foo)` ≡ `test ∨ (foo ∧ ¬foo)`
-        // ≡ `test`. Conjunction implies test even though no single
-        // attribute does. Skip rule MUST treat the carrier as
-        // test-only.
-        let src = "\
-pub fn handle_received_tx() {}
-
-#[cfg(any(test, foo))]
-#[cfg(any(test, not(foo)))]
-fn test_only_via_conjunction() {
-    crate::txpool::TxPool::admit(tx);
-}
-";
-        check_tx_relay_boundary_source(src).expect(
-            "conjunction of two cfg attrs collapses to test; item must be skipped per-conjunction",
-        );
-    }
-
-    #[test]
     fn multi_cfg_attrs_unrelated_to_test_remain_production() {
-        // Negative control for the conjunction logic: two cfg
-        // attributes neither of which involves test should leave the
-        // item in production scope.
+        // Two cfg attributes neither of which is the exact literal
+        // `#[cfg(test)]` leave the item in production scope.
         let src = "\
 pub fn handle_received_tx() {}
 
@@ -2541,11 +2141,39 @@ fn cross_platform_helper() {
     }
 
     #[test]
-    fn cfg_test_on_block_expression_inside_production_fn_is_skipped() {
-        // Below-item-level cfg-skip: `#[cfg(test)] { ... }` block
-        // expression inside a production function body. Without the
-        // visit_expr override the admission call inside would be
-        // walked and reported.
+    fn multi_cfg_attrs_with_test_disjunct_is_production_under_conservative_scope() {
+        // Two cfg attributes whose conjunction logically implies
+        // `test` — `(test ∨ foo) ∧ (test ∨ ¬foo)` ≡ `test`. The
+        // conservative scope does NOT decode multi-attribute
+        // conjunctions; neither single attribute is the exact literal
+        // `#[cfg(test)]`, so the carrier is scanned as production.
+        // Multi-attribute `ConfigurationPredicate` reachability is
+        // explicit non-scope per RUB-176 / GitHub issue #1432's
+        // `class_change_stop_rule`.
+        let src = "\
+pub fn handle_received_tx() {}
+
+#[cfg(any(test, foo))]
+#[cfg(any(test, not(foo)))]
+fn test_only_via_conjunction() {
+    crate::txpool::TxPool::admit(tx);
+}
+";
+        match check_tx_relay_boundary_source(src) {
+            Err(BoundaryCheckError::ProductionAdmissionCall(_)) => {}
+            other => panic!(
+                "expected admission detection inside multi-cfg(any(test,...)) under conservative scope, got {other:?}"
+            ),
+        }
+    }
+
+    #[test]
+    fn cfg_test_on_block_expression_is_production_under_conservative_scope() {
+        // `#[cfg(test)] { ... }` block expression inside a production
+        // function body. Below-item-level cfg gating is explicit
+        // non-scope per RUB-176 / GitHub issue #1432's
+        // `class_change_stop_rule`, so the conservative scope walks
+        // the block body and detects the admission call.
         let src = "\
 pub fn handle_received_tx() {
     #[cfg(test)]
@@ -2554,16 +2182,21 @@ pub fn handle_received_tx() {
     }
 }
 ";
-        check_tx_relay_boundary_source(src)
-            .expect("#[cfg(test)] block expression inside production fn must be skipped");
+        match check_tx_relay_boundary_source(src) {
+            Err(BoundaryCheckError::ProductionAdmissionCall(_)) => {}
+            other => panic!(
+                "expected admission detection inside #[cfg(test)] block expr under conservative scope, got {other:?}"
+            ),
+        }
     }
 
     #[test]
-    fn cfg_test_on_match_arm_inside_production_fn_is_skipped() {
-        // Below-item-level cfg-skip: `match x { #[cfg(test)] _ => ... }`
-        // arm inside a production fn. Default visit_expr_match
-        // descends into arms; without the visit_arm override the
-        // admission call in the test-only arm body would be reported.
+    fn cfg_test_on_match_arm_is_production_under_conservative_scope() {
+        // `match x { #[cfg(test)] _ => TxPool::admit(tx); ... }` —
+        // the `#[cfg(test)]` is on the `Arm`, not on a top-level
+        // `Item`. Below-item-level cfg gating is non-scope per
+        // RUB-176 / GitHub issue #1432, so the conservative scope
+        // walks the arm body and detects the admission call.
         let src = "\
 pub fn handle_received_tx() {
     let x = 0;
@@ -2574,23 +2207,33 @@ pub fn handle_received_tx() {
     }
 }
 ";
-        check_tx_relay_boundary_source(src)
-            .expect("#[cfg(test)] match arm inside production fn must be skipped");
+        match check_tx_relay_boundary_source(src) {
+            Err(BoundaryCheckError::ProductionAdmissionCall(_)) => {}
+            other => panic!(
+                "expected admission detection inside #[cfg(test)] match arm under conservative scope, got {other:?}"
+            ),
+        }
     }
 
     #[test]
-    fn cfg_test_on_let_stmt_inside_production_fn_is_skipped() {
-        // Below-item-level cfg-skip: `#[cfg(test)] let _ = ...;`
-        // statement inside a production fn body. The Stmt::Local
-        // attrs are checked via the visit_stmt override.
+    fn cfg_test_on_let_stmt_is_production_under_conservative_scope() {
+        // `#[cfg(test)] let _ = TxPool::admit(tx);` — `Stmt::Local`
+        // attribute. Below-item-level cfg gating is non-scope per
+        // RUB-176 / GitHub issue #1432, so the conservative scope
+        // walks the let-binding initialiser and detects the
+        // admission call.
         let src = "\
 pub fn handle_received_tx() {
     #[cfg(test)]
     let _ = crate::txpool::TxPool::admit(tx);
 }
 ";
-        check_tx_relay_boundary_source(src)
-            .expect("#[cfg(test)] let-stmt inside production fn must be skipped");
+        match check_tx_relay_boundary_source(src) {
+            Err(BoundaryCheckError::ProductionAdmissionCall(_)) => {}
+            other => panic!(
+                "expected admission detection inside #[cfg(test)] let-stmt under conservative scope, got {other:?}"
+            ),
+        }
     }
 
     #[test]
@@ -2631,44 +2274,49 @@ pub fn handle_received_tx() {
     }
 
     #[test]
-    fn mutually_exclusive_target_os_values_via_two_cfg_attrs_skipped() {
-        // `cfg(any(test, target_os="linux")) ∧ cfg(any(test, target_os="windows"))`
-        // — combined: `(test ∨ linux) ∧ (test ∨ windows)`. Under
-        // `target_os` mutual-exclusivity (a config has exactly one
-        // value), the only way both clauses hold without test is
-        // `linux ∧ windows`, which is impossible. Conjunction
-        // therefore implies test → SKIP.
+    fn cfg_test_on_struct_literal_field_value_is_production_under_conservative_scope() {
+        // `Foo { #[cfg(test)] bad: TxPool::admit(tx), good: 0 }` —
+        // the `#[cfg(test)]` is on the `FieldValue`, not on a
+        // top-level `Item`. Below-item-level cfg gating is non-scope
+        // per RUB-176 / GitHub issue #1432, so the conservative
+        // scope walks the initialiser expression and detects the
+        // admission call.
         let src = "\
-pub fn handle_received_tx() {}
-
-#[cfg(any(test, target_os = \"linux\"))]
-#[cfg(any(test, target_os = \"windows\"))]
-fn cross_os_test_only() {
-    crate::txpool::TxPool::admit(tx);
+pub fn handle_received_tx() {
+    let _ = Foo {
+        #[cfg(test)]
+        bad: crate::txpool::TxPool::admit(tx),
+        good: 0,
+    };
 }
 ";
-        check_tx_relay_boundary_source(src).expect(
-            "mutually-exclusive target_os values across two cfg attrs implies test; must skip",
-        );
+        match check_tx_relay_boundary_source(src) {
+            Err(BoundaryCheckError::ProductionAdmissionCall(_)) => {}
+            other => panic!(
+                "expected admission detection inside #[cfg(test)] FieldValue under conservative scope, got {other:?}"
+            ),
+        }
     }
 
     #[test]
-    fn many_distinct_vars_with_test_in_all_uses_structural_fast_path() {
-        // 17 free identifiers exceed the SAT cap (16), but the
-        // structural simplifier resolves `all(test, …)` to `false`
-        // under `test = absent` immediately — predicate implies test
-        // regardless of how many other free vars accompany it.
+    fn struct_literal_field_value_without_cfg_test_admission_is_detected() {
+        // Negative control: an ordinary FieldValue with an admission
+        // call must STILL be detected — the per-FieldValue skip
+        // applies only when `cfg(test)` is present.
         let src = "\
-pub fn handle_received_tx() {}
-
-#[cfg(all(test, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17))]
-fn many_var_helper() {
-    crate::txpool::TxPool::admit(tx);
+pub fn handle_received_tx() {
+    let _ = Foo {
+        bad: crate::txpool::TxPool::admit(tx),
+        good: 0,
+    };
 }
 ";
-        check_tx_relay_boundary_source(src).expect(
-            "all(test, …17 distinct free vars) implies test via structural fast-path despite cap",
-        );
+        match check_tx_relay_boundary_source(src) {
+            Err(BoundaryCheckError::ProductionAdmissionCall(_)) => {}
+            other => panic!(
+                "expected admission detection inside ordinary FieldValue initialiser, got {other:?}"
+            ),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Scope

RUB-176 / GitHub #1432 follow-up to RUB-172 (PR #1429). Replaces the RUB-172 advisory source-grep tripwire test on `clients/rust/crates/rubin-node/src/tx_relay.rs` with a `#[cfg(test)]` `syn`-based AST checker that walks the production AST via `syn::visit::Visit` and detects direct syntactic canonical-`TxPool` admission call expressions: `Expr::MethodCall` with method ident in {`admit`, `admit_with_metadata`, `add_tx_with_source`}; `Expr::Call` with `Expr::Path` (qself=None) whose terminal segment is one of those method idents and penultimate segment is `TxPool`; `Expr::Call` with `Expr::Path` (qself=Some) whose `qself.ty` is a `Type::Path` ending in `TxPool`. Paren / Group callee wrappers are peeled by `unwrap_path_expr` so `(TxPool::admit)(tx)` and `((TxPool::admit))(tx)` are detected. Fails closed if `syn::parse_file` fails, if `handle_received_tx` is missing from production scope, or if the file has no top-level items.

Production-scope skip is deliberately conservative: a top-level `Item` is skipped iff its attribute set contains the EXACT literal `#[cfg(test)]` — that is, an attribute whose path is `cfg` and whose `Meta::List` parses as a single `Path` ident `test`. Every other carrier shape is scanned as production. This includes `cfg(any(test, X))`, `cfg(all(test, X))`, `cfg(not(test))`, `cfg(target_os = "linux")`, `cfg(false)`, multi-`#[cfg]` stacks, `cfg_attr(...)`, and below-item-level cfg gates on `ImplItem`, `TraitItem`, `Expr`, `Arm`, `Stmt`, `FieldValue`. Conservative direction is false-positive over false-negative: an admission introduced under any non-exact cfg shape will fire the checker; remediation is rewriting the gate to the exact `#[cfg(test)]` form on a top-level `Item`, removing the admission, or escalating to a sounder reachability engine.

General `ConfigurationPredicate` reachability is explicit non-scope per issue #1432's `class_change_stop_rule` and is not part of this slice.

Documented explicit non-scope. Two of these classes have passthrough false-positive tests pinning their non-scope status: alias wrappers (`use ... as Pool` then `Pool::admit`) via `false_positive_alias_wrapper_via_use_rename_is_explicit_non_scope`, and macro invocations hiding admission calls via `false_positive_macro_invocation_hiding_admission_call_is_explicit_non_scope`. The remaining classes are documented in the module docstring and PR scope but not covered by snippet tests in this slice: function-pointer indirection (`let f = TxPool::admit; f(tx)`), trait-object dispatch, local type aliases, and cross-file structural drift in `sync.rs` / `p2p_runtime.rs` / other carrier files. Each of these requires name-resolution or cross-file inspection beyond the syntactic-direct-call scope and is explicit non-scope per issue #1432's `class_change_stop_rule`. Receiver-agnostic dotted-method detection is deliberate defense-in-depth bias.

Files: `tx_relay.rs` (module docstring rewritten to allowed claim language; RUB-172 substring tripwire test removed; new `boundary_checker` test submodule + 32 token-aware tests added). `Cargo.toml` adds `syn = { version = "2", features = ["full", "visit"] }` under `[dev-dependencies]`. `Cargo.lock` +1 line (syn 2.0.117 was already a criterion transitive). No production code path, function signature, conformance vector, spec, or formal proof is touched. Go counterpart `handlers_tx.go::handleTx` is not touched — Go's p2p admits canonically from inside the handler (`TxPool: NewCanonicalMempoolTxPool(mempool)` wired at `main.go::run`), so Go has no relay-cache/canonical split needing a boundary checker; this checker is Rust-only test tooling.

## Evidence

- `cargo fmt --check -p rubin-node` clean.
- `cargo clippy -p rubin-node --tests --no-deps -- -D warnings` clean.
- `cargo test -p rubin-node --lib tx_relay`: 72 passed, 0 failed, 544 filtered out.
- `cargo test -p rubin-node --lib`: 616 passed, 0 failed.
- Cargo.lock churn: +1 line adding `"syn"` to rubin-node's resolved dependency list; syn 2.0.117 was already present as a criterion transitive — no new crate versions.
- Live-source AST check: `live_source_token_aware_boundary_passes` parses the current `tx_relay.rs` via `syn::parse_file` and reports zero canonical-`TxPool` admission calls in production scope.
- Old-vs-new evidence: `old_substring_tripwire_would_have_missed_self_qualifier_form` confirms the new checker detects `<self::TxPool>::admit`, `<self::TxPool as Trait>::admit_with_metadata`, `<super::TxPool>::add_tx_with_source`, `<super::txpool::TxPool>::admit` — all forms the RUB-172 substring catalog did not enumerate.
- Conservative-direction pinning: 7 tests at `cfg_*_is_production_under_conservative_scope` pin that `cfg(any(test, X))`, `cfg(all(test, X))`, `cfg(not(not(test)))`, `cfg(false)`, `#[cfg(test)]` on `ImplItem` / `TraitItem` / block expr / match arm / let-stmt / `FieldValue`, and multi-`#[cfg]` test-disjunct stacks all fire the checker.
