### PR TITLE
RUB-178: wire canonical TxPool admission seam into Rust P2P production lifecycle (#1438)

### DIFF
--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -3079,10 +3079,12 @@ mod tests {
             // `pool.admit(...)` which delegates to `add_tx_with_source(_,
             // TxSource::Local, _)`. RUB-173 / GitHub #1420 will replace
             // the seam with `add_tx_with_source(_, TxSource::Remote, _)`
-            // and MUST update this assertion together with the source
-            // switch. The pin makes the source-attribution intermediate
-            // state explicit and regression-detectable: if anyone flips
-            // the seam to a different source variant, this test fails.
+            // and update this pin together with the source switch.
+            // Proof assertion: the `assert_eq!` below comparing
+            // `pool_guard.entry_source(&txid)` against
+            // `Some(crate::txpool::TxSource::Local)` is the regression
+            // anchor; any future seam-source flip without a paired
+            // update of this assertion produces a test failure here.
             assert_eq!(
                 pool_guard.entry_source(&txid),
                 Some(crate::txpool::TxSource::Local),

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -2977,22 +2977,25 @@ mod tests {
     /// Why this is not helper-only:
     ///
     ///   - The test does NOT call `pool.admit(...)` directly. Admission
-    ///     happens through `PeerSession::handle_live_message`, which is the
-    ///     same public entrypoint used by the production message loop in
-    ///     `clients/rust/crates/rubin-node/src/p2p_service.rs::handle_peer`.
+    ///     happens through `PeerSession::collect_live_responses`, the
+    ///     exact public method used by the production message loop in
+    ///     `clients/rust/crates/rubin-node/src/p2p_service.rs::handle_peer`
+    ///     (see the `session.collect_live_responses(msg, &mut engine,
+    ///     Some(&relay_ctx))` call in `handle_peer`'s message-loop body).
     ///   - The test constructs a real `PeerRelayContext` whose `tx_pool`
     ///     field uses the same `Mutex<TxPool>` shape that
     ///     `p2p_service.rs::handle_peer` constructs from
     ///     `&shared.tx_pool` (the canonical pool that already drives the
     ///     production block-apply cleanup path).
     ///   - The canonical pool side effect is asserted from outside the
-    ///     dispatch: after `handle_live_message` returns, `tx_pool.lock()`
-    ///     is taken and `pool.has(&txid)` is checked. The seam is the only
-    ///     code path that could put the txid there in this scenario.
+    ///     dispatch: after `collect_live_responses` returns,
+    ///     `tx_pool.lock()` is taken and `pool.contains(&txid)` plus
+    ///     `pool.entry_source(&txid)` are checked. The seam is the
+    ///     only code path that could put the txid there in this scenario.
     ///   - No `TxSource::Remote` claim. The seam uses legacy `pool.admit`;
     ///     source-aware classification is RUB-173 / GitHub #1420 follow-up.
     #[test]
-    fn handle_live_message_message_tx_admits_through_canonical_pool_seam() {
+    fn collect_live_responses_message_tx_admits_through_canonical_pool_seam() {
         use std::collections::HashMap;
         use std::sync::Mutex;
 
@@ -3058,8 +3061,8 @@ mod tests {
             };
 
             let _ = session
-                .handle_live_message(msg, &mut engine, Some(&relay_ctx))
-                .expect("handle_live_message MESSAGE_TX must succeed for floor-compliant tx");
+                .collect_live_responses(msg, &mut engine, Some(&relay_ctx))
+                .expect("collect_live_responses MESSAGE_TX must succeed for floor-compliant tx");
 
             let (_, txid, _, _consumed) = parse_tx(&tx_bytes).expect("parse tx for txid");
 
@@ -3113,7 +3116,8 @@ mod tests {
     }
 
     /// RUB-178 smoke test for the `relay_ctx = None` branch of
-    /// `MESSAGE_TX` dispatch.
+    /// `MESSAGE_TX` dispatch through the production dispatcher
+    /// `collect_live_responses`.
     ///
     /// The seam is structurally gated by `PeerRelayContext` itself:
     /// `ctx.tx_pool` is a field of `PeerRelayContext`, so absence of
@@ -3121,22 +3125,21 @@ mod tests {
     /// not through a runtime check that this test could observe. What
     /// this test DOES pin:
     ///
-    ///   - `handle_live_message(MESSAGE_TX, _, None)` returns `Ok`
-    ///     with an empty `TxPoolCleanupPlan` (no panic, no error,
-    ///     no spurious cleanup).
+    ///   - `collect_live_responses(MESSAGE_TX, _, None)` returns `Ok`
+    ///     with an empty `LiveMessageOutcome` (no responses, empty
+    ///     `tx_pool_cleanup`, no panic, no error).
     ///   - The dispatch does NOT depend on relay_ctx for parse/cap
     ///     handling — the `MESSAGE_TX` arm simply skips the
     ///     relay+canonical work block when `relay_ctx` is None.
     ///
-    /// What this test does NOT pin (and was previously overclaimed):
-    /// it does not observe absence-of-admission on a canonical pool,
-    /// because there is no canonical pool reachable in this
-    /// configuration — the type system makes the seam unreachable.
-    /// The seam-gated invariant is enforced by the
-    /// `PeerRelayContext.tx_pool: &Mutex<TxPool>` field's
-    /// non-optionality.
+    /// What this test does NOT pin: it does not observe
+    /// absence-of-admission on a canonical pool, because there is no
+    /// canonical pool reachable in this configuration — the type
+    /// system makes the seam unreachable. The seam-gated invariant
+    /// is enforced by the `PeerRelayContext.tx_pool: &Mutex<TxPool>`
+    /// field's non-optionality, not by a runtime check.
     #[test]
-    fn handle_live_message_message_tx_without_relay_ctx_does_not_admit() {
+    fn collect_live_responses_message_tx_without_relay_ctx_does_not_admit() {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
         let addr = listener.local_addr().expect("addr");
 
@@ -3163,9 +3166,10 @@ mod tests {
 
             // No relay_ctx -> the seam never fires.
             let outcome = session
-                .handle_live_message(msg, &mut engine, None)
+                .collect_live_responses(msg, &mut engine, None)
                 .expect("MESSAGE_TX without relay_ctx is a no-op");
-            assert!(outcome.is_empty());
+            assert!(outcome.responses.is_empty());
+            assert!(outcome.tx_pool_cleanup.is_empty());
         });
 
         let _client = TcpStream::connect(addr).expect("connect");

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -542,14 +542,32 @@ impl PeerSession {
                     // so RUB-173 will see the assertion break and update
                     // it together with the source-aware switch.
                     //
-                    // Admission errors are intentionally discarded — they
-                    // do NOT change `RelayTxOutcome` and do NOT contribute
-                    // to ban-score policy (per issue's failure_modes:
-                    // "preserve existing txpool caller error class; no new
-                    // policy ordering"). No log/metric is emitted; if a
-                    // future maintainer needs to observe relay-cache vs
-                    // canonical-pool divergence, that is a separate
-                    // observability change.
+                    // Admission Result is intentionally discarded — it
+                    // does NOT change `RelayTxOutcome` and does NOT
+                    // contribute to ban-score policy (per issue's
+                    // failure_modes: "preserve existing txpool caller
+                    // error class; no new policy ordering"). The
+                    // relay-cache leg has already accepted the tx, and
+                    // RUB-178's invariant is "seam is reachable", not
+                    // "every peer tx admits". Future divergence
+                    // observability is a separate change.
+                    //
+                    // Lock poisoning is a separate concern from admission
+                    // failure: a poisoned `tx_pool` Mutex means a prior
+                    // panic mid-mutation leaves the pool's internal
+                    // invariants potentially broken. Per existing
+                    // production precedent in
+                    // `clients/rust/crates/rubin-node/src/devnet_rpc.rs`'s
+                    // `handle_submit_tx` (which surfaces
+                    // `TxPoolAdmitErrorKind::Unavailable` on poisoned
+                    // lock) and `handle_mine_next` (which returns 503),
+                    // poison must be observable rather than silently
+                    // swallowed. The seam therefore matches the lock
+                    // result explicitly: on `Err(_)` it records an
+                    // explicit signal on `self.peer.last_error` so the
+                    // condition is not silent, while still preserving
+                    // the relay-only path (no `Err(...)` is returned
+                    // from `collect_live_responses`).
                     //
                     // Lock-ordering precedent: this is engine→pool nested.
                     // The caller in
@@ -565,13 +583,20 @@ impl PeerSession {
                     // pattern in `apply_tx_pool_cleanup`. The seam does
                     // not re-acquire the engine, so no deadlock from self.
                     if matches!(outcome, crate::tx_relay::RelayTxOutcome::Relayed) {
-                        if let Ok(mut pool) = ctx.tx_pool.lock() {
-                            let _ = pool.admit(
-                                &msg.payload,
-                                &sync_engine.chain_state,
-                                sync_engine.block_store.as_ref(),
-                                sync_engine.cfg.chain_id,
-                            );
+                        match ctx.tx_pool.lock() {
+                            Ok(mut pool) => {
+                                let _ = pool.admit(
+                                    &msg.payload,
+                                    &sync_engine.chain_state,
+                                    sync_engine.block_store.as_ref(),
+                                    sync_engine.cfg.chain_id,
+                                );
+                            }
+                            Err(_) => {
+                                self.peer.last_error =
+                                    "canonical tx_pool poisoned; peer-tx admission skipped"
+                                        .to_string();
+                            }
                         }
                     }
                     // Mirror Go's `peer.handleTx` parse-fail policy: parse
@@ -3170,6 +3195,127 @@ mod tests {
                 .expect("MESSAGE_TX without relay_ctx is a no-op");
             assert!(outcome.responses.is_empty());
             assert!(outcome.tx_pool_cleanup.is_empty());
+        });
+
+        let _client = TcpStream::connect(addr).expect("connect");
+        server.join().expect("server join");
+    }
+
+    /// RUB-178 / GitHub #1438: when `ctx.tx_pool` lock is poisoned,
+    /// the seam must produce an explicit signal on
+    /// `self.peer.last_error` rather than silently swallowing the
+    /// error. This matches the production precedent in
+    /// `clients/rust/crates/rubin-node/src/devnet_rpc.rs`'s
+    /// `handle_submit_tx` (which surfaces
+    /// `TxPoolAdmitErrorKind::Unavailable`) and `handle_mine_next`
+    /// (which returns 503).
+    ///
+    /// Proof assertion: the `assert!` calls below comparing
+    /// `session.state().last_error` to the poison-signal substring
+    /// and confirming `relay_state` still recorded the tx are the
+    /// regression anchors. Any change that re-introduces a silent
+    /// `if let Ok(...)` swallow on `tx_pool.lock()` will fail this
+    /// test.
+    #[test]
+    fn collect_live_responses_message_tx_signals_on_canonical_pool_poison() {
+        use std::collections::HashMap;
+        use std::sync::{Arc, Mutex};
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let addr = listener.local_addr().expect("addr");
+
+        let server = thread::spawn(move || {
+            let (stream, _) = listener.accept().expect("accept");
+            let mut session = PeerSession::new(stream, default_peer_runtime_config("devnet", 8))
+                .expect("session");
+
+            let (chain_state, tx_bytes, _unused) =
+                signed_conflicting_p2pk_state_and_txs(20_000, 10, 9);
+            let mut sync_cfg = crate::sync::default_sync_config(
+                None,
+                crate::genesis::devnet_genesis_chain_id(),
+                None,
+            );
+            sync_cfg.core_ext_deployments = rubin_consensus::CoreExtDeploymentProfiles::empty();
+            let mut engine =
+                crate::sync::SyncEngine::new(chain_state, None, sync_cfg).expect("sync engine");
+
+            let relay_state = crate::tx_relay::TxRelayState::new();
+            let peer_manager = PeerManager::new(default_peer_runtime_config("devnet", 64));
+            let _ = peer_manager.add_peer(PeerState {
+                addr: "other:8333".to_string(),
+                ..Default::default()
+            });
+            let peer_outboxes: Mutex<HashMap<String, crate::tx_relay::PeerOutbox>> =
+                Mutex::new(HashMap::new());
+            peer_outboxes.lock().unwrap().insert(
+                "sender:8333".to_string(),
+                crate::tx_relay::PeerOutbox::default(),
+            );
+            peer_outboxes.lock().unwrap().insert(
+                "other:8333".to_string(),
+                crate::tx_relay::PeerOutbox::default(),
+            );
+
+            // Poison the canonical TxPool Mutex by panicking inside a
+            // thread that holds the lock. After join, the Mutex is
+            // permanently poisoned for any subsequent `.lock()` call —
+            // mirrors the production failure mode where a panic during
+            // pool mutation leaves a poisoned shared handle.
+            let canonical_tx_pool: Arc<Mutex<TxPool>> = Arc::new(Mutex::new(TxPool::new()));
+            let poison_pool = Arc::clone(&canonical_tx_pool);
+            let _ = thread::spawn(move || {
+                let _guard = poison_pool.lock().unwrap();
+                panic!("intentional poison for RUB-178 poison-signal test");
+            })
+            .join();
+            assert!(
+                canonical_tx_pool.is_poisoned(),
+                "Mutex must be poisoned before exercising the seam"
+            );
+
+            let relay_ctx = PeerRelayContext {
+                relay_state: &relay_state,
+                peer_manager: &peer_manager,
+                local_addr: "local:8333",
+                peer_registered_addr: "sender:8333",
+                peer_writers: &peer_outboxes,
+                tx_pool: &canonical_tx_pool,
+            };
+
+            let msg = WireMessage {
+                command: MESSAGE_TX.to_string(),
+                payload: tx_bytes.clone(),
+            };
+
+            // Dispatch must NOT propagate the poison as an io::Error —
+            // the relay-only path is preserved per issue failure_modes.
+            let _ = session
+                .collect_live_responses(msg, &mut engine, Some(&relay_ctx))
+                .expect("dispatch must succeed even when canonical pool is poisoned");
+
+            // 1) explicit poison signal on peer state — refutes the
+            //    silent-swallow operational hazard the bot reviewer
+            //    flagged on PR #1455.
+            let observed_last_error = session.state().last_error;
+            assert!(
+                observed_last_error.contains("canonical tx_pool poisoned"),
+                "peer.last_error must signal the poisoned pool; got: {observed_last_error:?}"
+            );
+
+            // 2) relay-cache-only path remains separate and intact —
+            //    relay_state still admitted the tx via tx_relay's
+            //    own RelayTxPool, even though canonical admission was
+            //    skipped.
+            let (_, txid, _, _consumed) = parse_tx(&tx_bytes).expect("parse tx for txid");
+            assert!(
+                relay_state.tx_seen.has(&txid),
+                "tx_relay relay-cache `tx_seen` must still record the tx"
+            );
+            assert!(
+                relay_state.relay_pool.has(&txid),
+                "tx_relay relay-cache `relay_pool` must still record the tx"
+            );
         });
 
         let _client = TcpStream::connect(addr).expect("connect");

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -3213,9 +3213,7 @@ mod tests {
     /// Proof assertion: the `assert!` calls below comparing
     /// `session.state().last_error` to the poison-signal substring
     /// and confirming `relay_state` still recorded the tx are the
-    /// regression anchors. Any change that re-introduces a silent
-    /// `if let Ok(...)` swallow on `tx_pool.lock()` will fail this
-    /// test.
+    /// regression anchors for this case.
     #[test]
     fn collect_live_responses_message_tx_signals_on_canonical_pool_poison() {
         use std::collections::HashMap;

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -127,6 +127,21 @@ pub struct PeerRelayContext<'a> {
     /// Outbound relay queues: serialized wire frames enqueued by broadcast,
     /// drained by the peer thread to avoid concurrent TcpStream writes.
     pub peer_writers: &'a std::sync::Mutex<HashMap<String, crate::tx_relay::PeerOutbox>>,
+    /// Canonical TxPool admission seam (RUB-178 / GitHub #1438).
+    ///
+    /// Threads the existing `shared.tx_pool: Arc<Mutex<TxPool>>` handle
+    /// (introduced in PR #876, commit `ce270e3`, already used by the
+    /// production block-apply cleanup path in `p2p_service.rs`) into the
+    /// peer-tx live message dispatch so peer transactions can reach
+    /// canonical admission after relay-cache success.
+    ///
+    /// Class C lifecycle plumbing only. This field uses the legacy
+    /// `pool.admit(...)` entrypoint; source classification (Local / Reorg
+    /// / Remote) is owned by `add_tx_with_source` and the per-source
+    /// producer wiring tasks. RUB-173 / GitHub #1420 will replace this
+    /// seam with `add_tx_with_source(..., TxSource::Remote, ...)` for
+    /// peer-originated transactions.
+    pub tx_pool: &'a std::sync::Mutex<crate::txpool::TxPool>,
 }
 
 pub struct LiveMessageOutcome {
@@ -509,6 +524,34 @@ impl PeerSession {
                         ctx.local_addr,
                         ctx.peer_writers,
                     )?;
+                    // RUB-178 / GitHub #1438: canonical TxPool admission seam.
+                    //
+                    // Only fires after `handle_received_tx` returns
+                    // `RelayTxOutcome::Relayed`, which means the peer tx
+                    // already passed parse, dedup, and `relay_metadata`
+                    // (rolling fee floor). The seam threads the existing
+                    // `shared.tx_pool` handle one level deeper and uses the
+                    // legacy `pool.admit(...)` entrypoint — source
+                    // classification (`TxSource::Remote`) is reserved for
+                    // RUB-173 / GitHub #1420 replacement.
+                    //
+                    // Admission errors are observed but do NOT change
+                    // `RelayTxOutcome` or ban-score policy (per issue's
+                    // failure_modes: "preserve existing txpool caller error
+                    // class; no new policy ordering"). Lock acquisition
+                    // mirrors the existing block-apply cleanup path in
+                    // `p2p_service.rs::apply_tx_pool_cleanup` — lock,
+                    // operate, drop. No nested locks.
+                    if matches!(outcome, crate::tx_relay::RelayTxOutcome::Relayed) {
+                        if let Ok(mut pool) = ctx.tx_pool.lock() {
+                            let _ = pool.admit(
+                                &msg.payload,
+                                &sync_engine.chain_state,
+                                sync_engine.block_store.as_ref(),
+                                sync_engine.cfg.chain_id,
+                            );
+                        }
+                    }
                     // Mirror Go's `peer.handleTx` parse-fail policy: parse
                     // failures bump the peer ban score by 10 and fail the
                     // session only when the cumulative score crosses the
@@ -2904,5 +2947,171 @@ mod tests {
         let (kind, err) = server.join().expect("server join");
         assert_eq!(kind, io::ErrorKind::InvalidData);
         assert!(err.contains("unknown message type: weird"), "got: {err}");
+    }
+
+    /// RUB-178 / GitHub #1438: production-path reachability proof for the
+    /// canonical TxPool admission seam introduced in `PeerRelayContext`.
+    ///
+    /// Why this is not helper-only:
+    ///
+    ///   - The test does NOT call `pool.admit(...)` directly. Admission
+    ///     happens through `PeerSession::handle_live_message`, which is the
+    ///     same public entrypoint used by the production message loop in
+    ///     `p2p_service.rs::run_peer_session_loop` (see
+    ///     `p2p_service.rs:864`-ish wiring).
+    ///   - The test constructs a real `PeerRelayContext` whose `tx_pool`
+    ///     field uses the same `Mutex<TxPool>` shape that
+    ///     `p2p_service.rs::run_peer_session_loop` constructs from
+    ///     `&shared.tx_pool` (the canonical pool that already drives the
+    ///     production block-apply cleanup path).
+    ///   - The canonical pool side effect is asserted from outside the
+    ///     dispatch: after `handle_live_message` returns, `tx_pool.lock()`
+    ///     is taken and `pool.has(&txid)` is checked. The seam is the only
+    ///     code path that could put the txid there in this scenario.
+    ///   - No `TxSource::Remote` claim. The seam uses legacy `pool.admit`;
+    ///     source-aware classification is RUB-173 / GitHub #1420 follow-up.
+    #[test]
+    fn handle_live_message_message_tx_admits_through_canonical_pool_seam() {
+        use std::collections::HashMap;
+        use std::sync::Mutex;
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let addr = listener.local_addr().expect("addr");
+
+        let server = thread::spawn(move || {
+            let (stream, _) = listener.accept().expect("accept");
+            let mut session = PeerSession::new(stream, default_peer_runtime_config("devnet", 8))
+                .expect("session");
+
+            // Build a sync engine + chain state that admits a single
+            // floor-compliant signed P2PK tx (mirrors the existing
+            // tx_relay test pattern, intentionally — same fixture so the
+            // production tx_relay handle_received_tx leg returns
+            // `Relayed` and the canonical seam fires).
+            let (chain_state, tx_bytes, _unused) =
+                signed_conflicting_p2pk_state_and_txs(20_000, 10, 9);
+            let mut sync_cfg = crate::sync::default_sync_config(
+                None,
+                crate::genesis::devnet_genesis_chain_id(),
+                None,
+            );
+            sync_cfg.core_ext_deployments = rubin_consensus::CoreExtDeploymentProfiles::empty();
+            let mut engine =
+                crate::sync::SyncEngine::new(chain_state, None, sync_cfg).expect("sync engine");
+
+            // Production analogue of `shared.relay_state` /
+            // `shared.peer_manager` / `shared.peer_outboxes` /
+            // `shared.tx_pool` — the same handles `p2p_service.rs:814`
+            // threads into `PeerRelayContext`.
+            let relay_state = crate::tx_relay::TxRelayState::new();
+            let peer_manager = PeerManager::new(default_peer_runtime_config("devnet", 64));
+            let _ = peer_manager.add_peer(PeerState {
+                addr: "other:8333".to_string(),
+                ..Default::default()
+            });
+            let peer_outboxes: Mutex<HashMap<String, crate::tx_relay::PeerOutbox>> =
+                Mutex::new(HashMap::new());
+            peer_outboxes.lock().unwrap().insert(
+                "sender:8333".to_string(),
+                crate::tx_relay::PeerOutbox::default(),
+            );
+            peer_outboxes.lock().unwrap().insert(
+                "other:8333".to_string(),
+                crate::tx_relay::PeerOutbox::default(),
+            );
+            let canonical_tx_pool: Mutex<TxPool> = Mutex::new(TxPool::new());
+
+            let relay_ctx = PeerRelayContext {
+                relay_state: &relay_state,
+                peer_manager: &peer_manager,
+                local_addr: "local:8333",
+                peer_registered_addr: "sender:8333",
+                peer_writers: &peer_outboxes,
+                tx_pool: &canonical_tx_pool,
+            };
+
+            let msg = WireMessage {
+                command: MESSAGE_TX.to_string(),
+                payload: tx_bytes.clone(),
+            };
+
+            let _ = session
+                .handle_live_message(msg, &mut engine, Some(&relay_ctx))
+                .expect("handle_live_message MESSAGE_TX must succeed for floor-compliant tx");
+
+            let (_, txid, _, _consumed) = parse_tx(&tx_bytes).expect("parse tx for txid");
+
+            // 1) production-path reachability: the canonical pool side
+            //    effect is observable AFTER `handle_live_message` returns.
+            //    No direct `pool.admit(...)` call from the test reached
+            //    this state; the only path is through
+            //    `collect_live_responses::MESSAGE_TX` -> tx_relay::Relayed
+            //    -> ctx.tx_pool seam.
+            let pool_guard = canonical_tx_pool.lock().expect("pool lock");
+            assert!(
+                pool_guard.contains(&txid),
+                "canonical TxPool must contain the txid after MESSAGE_TX dispatch — \
+                 the seam is the only code path that could place it there in this test"
+            );
+            drop(pool_guard);
+
+            // 2) relay-cache-only path remains separate: tx_relay's
+            //    relay_state still records the tx as well. This proves
+            //    the seam is additive on top of the relay-only path,
+            //    not a replacement of it.
+            assert!(
+                relay_state.tx_seen.has(&txid),
+                "tx_relay relay-cache `tx_seen` must still record the tx"
+            );
+            assert!(
+                relay_state.relay_pool.has(&txid),
+                "tx_relay relay-cache `relay_pool` must still record the tx"
+            );
+        });
+
+        let _client = TcpStream::connect(addr).expect("connect");
+        server.join().expect("server join");
+    }
+
+    /// RUB-178 negative control: when `handle_live_message` is called
+    /// WITHOUT a `PeerRelayContext` (`relay_ctx = None`), no canonical
+    /// admission happens. This pins that the seam is genuinely gated on
+    /// the production context being present, and that the relay-cache
+    /// branch (which also lives behind `Some(ctx)`) keeps the same gate.
+    #[test]
+    fn handle_live_message_message_tx_without_relay_ctx_does_not_admit() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let addr = listener.local_addr().expect("addr");
+
+        let server = thread::spawn(move || {
+            let (stream, _) = listener.accept().expect("accept");
+            let mut session = PeerSession::new(stream, default_peer_runtime_config("devnet", 8))
+                .expect("session");
+
+            let (chain_state, tx_bytes, _unused) =
+                signed_conflicting_p2pk_state_and_txs(20_000, 10, 9);
+            let mut sync_cfg = crate::sync::default_sync_config(
+                None,
+                crate::genesis::devnet_genesis_chain_id(),
+                None,
+            );
+            sync_cfg.core_ext_deployments = rubin_consensus::CoreExtDeploymentProfiles::empty();
+            let mut engine =
+                crate::sync::SyncEngine::new(chain_state, None, sync_cfg).expect("sync engine");
+
+            let msg = WireMessage {
+                command: MESSAGE_TX.to_string(),
+                payload: tx_bytes,
+            };
+
+            // No relay_ctx -> the seam never fires.
+            let outcome = session
+                .handle_live_message(msg, &mut engine, None)
+                .expect("MESSAGE_TX without relay_ctx is a no-op");
+            assert!(outcome.is_empty());
+        });
+
+        let _client = TcpStream::connect(addr).expect("connect");
+        server.join().expect("server join");
     }
 }

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -554,7 +554,7 @@ impl PeerSession {
                     // Lock-ordering precedent: this is engine→pool nested.
                     // The caller in
                     // `clients/rust/crates/rubin-node/src/p2p_service.rs`
-                    // (`run_peer_session_loop`) holds
+                    // (`handle_peer`) holds
                     // `shared.sync_engine.lock()` while calling
                     // `collect_live_responses`, so the seam acquires
                     // `ctx.tx_pool.lock()` while engine remains held; both
@@ -2979,10 +2979,10 @@ mod tests {
     ///   - The test does NOT call `pool.admit(...)` directly. Admission
     ///     happens through `PeerSession::handle_live_message`, which is the
     ///     same public entrypoint used by the production message loop in
-    ///     `clients/rust/crates/rubin-node/src/p2p_service.rs::run_peer_session_loop`.
+    ///     `clients/rust/crates/rubin-node/src/p2p_service.rs::handle_peer`.
     ///   - The test constructs a real `PeerRelayContext` whose `tx_pool`
     ///     field uses the same `Mutex<TxPool>` shape that
-    ///     `p2p_service.rs::run_peer_session_loop` constructs from
+    ///     `p2p_service.rs::handle_peer` constructs from
     ///     `&shared.tx_pool` (the canonical pool that already drives the
     ///     production block-apply cleanup path).
     ///   - The canonical pool side effect is asserted from outside the

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -3067,9 +3067,9 @@ mod tests {
             let (_, txid, _, _consumed) = parse_tx(&tx_bytes).expect("parse tx for txid");
 
             // 1) production-path reachability: the canonical pool side
-            //    effect is observable AFTER `handle_live_message` returns.
-            //    No direct `pool.admit(...)` call from the test reached
-            //    this state; the only path is through
+            //    effect is observable AFTER `collect_live_responses`
+            //    returns. No direct `pool.admit(...)` call from the
+            //    test reached this state; the only path is through
             //    `collect_live_responses::MESSAGE_TX` -> tx_relay::Relayed
             //    -> ctx.tx_pool seam.
             let pool_guard = canonical_tx_pool.lock().expect("pool lock");

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -533,15 +533,37 @@ impl PeerSession {
                     // `shared.tx_pool` handle one level deeper and uses the
                     // legacy `pool.admit(...)` entrypoint — source
                     // classification (`TxSource::Remote`) is reserved for
-                    // RUB-173 / GitHub #1420 replacement.
+                    // RUB-173 / GitHub #1420 replacement. Until that lands,
+                    // the seam admits peer-relayed txs with the legacy
+                    // `pool.admit` default of `TxSource::Local`; the
+                    // production-path test below explicitly pins this
+                    // intermediate state via
+                    // `pool.entry_source(&txid) == Some(TxSource::Local)`
+                    // so RUB-173 will see the assertion break and update
+                    // it together with the source-aware switch.
                     //
-                    // Admission errors are observed but do NOT change
-                    // `RelayTxOutcome` or ban-score policy (per issue's
-                    // failure_modes: "preserve existing txpool caller error
-                    // class; no new policy ordering"). Lock acquisition
-                    // mirrors the existing block-apply cleanup path in
-                    // `p2p_service.rs::apply_tx_pool_cleanup` — lock,
-                    // operate, drop. No nested locks.
+                    // Admission errors are intentionally discarded — they
+                    // do NOT change `RelayTxOutcome` and do NOT contribute
+                    // to ban-score policy (per issue's failure_modes:
+                    // "preserve existing txpool caller error class; no new
+                    // policy ordering"). No log/metric is emitted; if a
+                    // future maintainer needs to observe relay-cache vs
+                    // canonical-pool divergence, that is a separate
+                    // observability change.
+                    //
+                    // Lock-ordering precedent: this is engine→pool nested.
+                    // The caller in
+                    // `clients/rust/crates/rubin-node/src/p2p_service.rs`
+                    // (`run_peer_session_loop`) holds
+                    // `shared.sync_engine.lock()` while calling
+                    // `collect_live_responses`, so the seam acquires
+                    // `ctx.tx_pool.lock()` while engine remains held; both
+                    // are dropped at the end of the caller's scope. This
+                    // matches the engine→pool nested ordering used by
+                    // `clients/rust/crates/rubin-node/src/devnet_rpc.rs`'s
+                    // `handle_mine_next`, NOT the engine-snapshot-then-drop
+                    // pattern in `apply_tx_pool_cleanup`. The seam does
+                    // not re-acquire the engine, so no deadlock from self.
                     if matches!(outcome, crate::tx_relay::RelayTxOutcome::Relayed) {
                         if let Ok(mut pool) = ctx.tx_pool.lock() {
                             let _ = pool.admit(
@@ -3053,6 +3075,21 @@ mod tests {
                 "canonical TxPool must contain the txid after MESSAGE_TX dispatch — \
                  the seam is the only code path that could place it there in this test"
             );
+            // RUB-178 intermediate-state pin: the seam uses legacy
+            // `pool.admit(...)` which delegates to `add_tx_with_source(_,
+            // TxSource::Local, _)`. RUB-173 / GitHub #1420 will replace
+            // the seam with `add_tx_with_source(_, TxSource::Remote, _)`
+            // and MUST update this assertion together with the source
+            // switch. The pin makes the source-attribution intermediate
+            // state explicit and regression-detectable: if anyone flips
+            // the seam to a different source variant, this test fails.
+            assert_eq!(
+                pool_guard.entry_source(&txid),
+                Some(crate::txpool::TxSource::Local),
+                "RUB-178 seam uses legacy pool.admit which records \
+                 TxSource::Local; RUB-173 / GitHub #1420 will switch to \
+                 TxSource::Remote and update this pin"
+            );
             drop(pool_guard);
 
             // 2) relay-cache-only path remains separate: tx_relay's
@@ -3073,11 +3110,29 @@ mod tests {
         server.join().expect("server join");
     }
 
-    /// RUB-178 negative control: when `handle_live_message` is called
-    /// WITHOUT a `PeerRelayContext` (`relay_ctx = None`), no canonical
-    /// admission happens. This pins that the seam is genuinely gated on
-    /// the production context being present, and that the relay-cache
-    /// branch (which also lives behind `Some(ctx)`) keeps the same gate.
+    /// RUB-178 smoke test for the `relay_ctx = None` branch of
+    /// `MESSAGE_TX` dispatch.
+    ///
+    /// The seam is structurally gated by `PeerRelayContext` itself:
+    /// `ctx.tx_pool` is a field of `PeerRelayContext`, so absence of
+    /// the context makes the seam unreachable through the type system,
+    /// not through a runtime check that this test could observe. What
+    /// this test DOES pin:
+    ///
+    ///   - `handle_live_message(MESSAGE_TX, _, None)` returns `Ok`
+    ///     with an empty `TxPoolCleanupPlan` (no panic, no error,
+    ///     no spurious cleanup).
+    ///   - The dispatch does NOT depend on relay_ctx for parse/cap
+    ///     handling — the `MESSAGE_TX` arm simply skips the
+    ///     relay+canonical work block when `relay_ctx` is None.
+    ///
+    /// What this test does NOT pin (and was previously overclaimed):
+    /// it does not observe absence-of-admission on a canonical pool,
+    /// because there is no canonical pool reachable in this
+    /// configuration — the type system makes the seam unreachable.
+    /// The seam-gated invariant is enforced by the
+    /// `PeerRelayContext.tx_pool: &Mutex<TxPool>` field's
+    /// non-optionality.
     #[test]
     fn handle_live_message_message_tx_without_relay_ctx_does_not_admit() {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind");

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -2957,8 +2957,7 @@ mod tests {
     ///   - The test does NOT call `pool.admit(...)` directly. Admission
     ///     happens through `PeerSession::handle_live_message`, which is the
     ///     same public entrypoint used by the production message loop in
-    ///     `p2p_service.rs::run_peer_session_loop` (see
-    ///     `p2p_service.rs:864`-ish wiring).
+    ///     `clients/rust/crates/rubin-node/src/p2p_service.rs::run_peer_session_loop`.
     ///   - The test constructs a real `PeerRelayContext` whose `tx_pool`
     ///     field uses the same `Mutex<TxPool>` shape that
     ///     `p2p_service.rs::run_peer_session_loop` constructs from
@@ -3001,8 +3000,9 @@ mod tests {
 
             // Production analogue of `shared.relay_state` /
             // `shared.peer_manager` / `shared.peer_outboxes` /
-            // `shared.tx_pool` — the same handles `p2p_service.rs:814`
-            // threads into `PeerRelayContext`.
+            // `shared.tx_pool` — same handles
+            // `clients/rust/crates/rubin-node/src/p2p_service.rs` threads
+            // into `PeerRelayContext`.
             let relay_state = crate::tx_relay::TxRelayState::new();
             let peer_manager = PeerManager::new(default_peer_runtime_config("devnet", 64));
             let _ = peer_manager.add_peer(PeerState {

--- a/clients/rust/crates/rubin-node/src/p2p_service.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_service.rs
@@ -804,13 +804,20 @@ fn handle_peer(
         addr: peer_addr.clone(),
     };
 
-    // Build relay context for message loop.
+    // Build relay context for message loop. RUB-178 / GitHub #1438:
+    // `tx_pool` threads the existing `shared.tx_pool` handle (already
+    // used by the block-apply cleanup path in `apply_tx_pool_cleanup`)
+    // into the peer-tx dispatch so peer transactions reach canonical
+    // admission via the legacy `pool.admit` seam in
+    // `collect_live_responses`. No new lifecycle ownership: this is
+    // the same `Arc<Mutex<TxPool>>` introduced for cleanup in PR #876.
     let relay_ctx = PeerRelayContext {
         relay_state: &shared.relay_state,
         peer_manager: &shared.peer_manager,
         local_addr: &shared.local_addr,
         peer_registered_addr: &peer_addr,
         peer_writers: &shared.peer_outboxes,
+        tx_pool: &shared.tx_pool,
     };
 
     {

--- a/clients/rust/crates/rubin-node/src/tx_relay.rs
+++ b/clients/rust/crates/rubin-node/src/tx_relay.rs
@@ -48,17 +48,9 @@
 //! facts in place, the application's shared pool is unreachable
 //! from this module's call graph through these surfaces.
 //!
-//! RUB-178 / GitHub #1438 boundary re-verification: `handle_received_tx`
-//! itself remains relay-only — its argument list still does NOT carry
-//! a canonical `TxPool` handle. The canonical-pool admission seam was
-//! added in the *caller* (`p2p_runtime.rs::collect_live_responses`'s
-//! `MESSAGE_TX` branch) via a new `PeerRelayContext.tx_pool` carrier
-//! field, so the call-graph claim above remains literally true through
-//! `handle_received_tx`'s signature, but a peer-relayed tx now reaches
-//! a canonical-pool admit immediately after `Relayed` in that caller.
-//! `TxSource::Remote` source-aware classification is RUB-173 / GitHub
-//! #1420 follow-up; RUB-178 uses the legacy `pool.admit` entrypoint
-//! which records `TxSource::Local` as an accepted intermediate state.
+//! RUB-178 / GitHub #1438: canonical-pool seam lives in
+//! `p2p_runtime.rs::collect_live_responses` MESSAGE_TX via the new
+//! `PeerRelayContext.tx_pool` carrier; `handle_received_tx` stays relay-only.
 //!
 //! The `boundary_checker` test module below uses `syn::parse_file`
 //! to walk this file's production AST and detect direct syntactic

--- a/clients/rust/crates/rubin-node/src/tx_relay.rs
+++ b/clients/rust/crates/rubin-node/src/tx_relay.rs
@@ -48,6 +48,18 @@
 //! facts in place, the application's shared pool is unreachable
 //! from this module's call graph through these surfaces.
 //!
+//! RUB-178 / GitHub #1438 boundary re-verification: `handle_received_tx`
+//! itself remains relay-only — its argument list still does NOT carry
+//! a canonical `TxPool` handle. The canonical-pool admission seam was
+//! added in the *caller* (`p2p_runtime.rs::collect_live_responses`'s
+//! `MESSAGE_TX` branch) via a new `PeerRelayContext.tx_pool` carrier
+//! field, so the call-graph claim above remains literally true through
+//! `handle_received_tx`'s signature, but a peer-relayed tx now reaches
+//! a canonical-pool admit immediately after `Relayed` in that caller.
+//! `TxSource::Remote` source-aware classification is RUB-173 / GitHub
+//! #1420 follow-up; RUB-178 uses the legacy `pool.admit` entrypoint
+//! which records `TxSource::Local` as an accepted intermediate state.
+//!
 //! The `boundary_checker` test module below uses `syn::parse_file`
 //! to walk this file's production AST and detect direct syntactic
 //! canonical-`TxPool` admission call expressions. It is a token-


### PR DESCRIPTION
## Scope (RUB-178 / GitHub #1438)

Class C lifecycle plumbing. Introduces a single canonical TxPool admission
seam in the Rust P2P production path so peer transactions reach canonical
admission after relay-cache success. Source/provenance classification
(`TxSource::Remote`) is RUB-173 / GitHub #1420 follow-up; this PR uses the
legacy `pool.admit` entrypoint which records `TxSource::Local` as an
explicit accepted intermediate state.

`one_invariant`: Rust P2P production path exposes exactly one canonical
TxPool admission seam for peer txs.

`architecture_class`: C (lifecycle/API plumbing only — no wire/handshake,
no relay-cache architecture, no txpool API/policy redesign, no source
classification).

## Changes

- `clients/rust/crates/rubin-node/src/p2p_runtime.rs`:
  - `PeerRelayContext` extended with non-optional
    `tx_pool: &'a Mutex<crate::txpool::TxPool>` field.
  - `collect_live_responses` MESSAGE_TX branch: after
    `tx_relay::handle_received_tx` returns `RelayTxOutcome::Relayed`,
    locks `ctx.tx_pool` and calls legacy `pool.admit(...)`. Errors
    intentionally discarded (no change to RelayTxOutcome or ban-score
    policy per issue's failure_modes).
  - 3 new tests through production dispatcher `collect_live_responses`:
    positive control with `pool.contains` + `pool.entry_source ==
    Some(TxSource::Local)` pin; negative control for `relay_ctx = None`
    branch; canonical-pool-unavailable failure mode pinned via lock-poison
    test that asserts `peer.last_error` carries the explicit
    `"canonical tx_pool poisoned"` signal and the relay-only path remains
    intact (`relay_state.tx_seen` / `relay_state.relay_pool` still record
    the txid).

- `clients/rust/crates/rubin-node/src/p2p_service.rs`:
  - Threads pre-existing `shared.tx_pool: Arc<Mutex<TxPool>>` (live since
    PR #876) into `PeerRelayContext` construction at `handle_peer` (line
    814). No new lifecycle ownership — same handle that already drives the
    production block-apply cleanup path.

- `clients/rust/crates/rubin-node/src/tx_relay.rs` **(scope exception)**:
  - Docstring-only re-verification (1-3 lines) per the file's own
    self-imposed rule at lines 44-49 ("MUST re-verify this boundary
    explicitly"). Note added that `handle_received_tx`'s argument list
    still does NOT carry a canonical TxPool handle; the seam was added in
    the *caller* via the new `PeerRelayContext.tx_pool` carrier field.
  - **Scope exception: tx_relay.rs docstring-only boundary re-verification required by its own comment contract.** No code/test/boundary-checker changes; controller-approved 2026-05-06.

## Anti-overclaim

- Does NOT claim `TxSource::Remote` source-aware admission (RUB-173/#1420 owns).
- Does NOT modify txpool internals, devnet_rpc, sync_reorg, miner, Cargo.toml/Cargo.lock, conformance/**.
- Does NOT change relay-cache architecture, wire protocol, ban-score policy, or admission ordering.

**RUB-178 creates the production seam only. Source/provenance remains legacy `Local` until RUB-173/#1420 replaces the seam with `TxSource::Remote`.**

## Inventory verified at HEAD@14fad87 (origin/main pre-merge baseline)

- `p2p_runtime.rs:2388/2455` `pool.admit(...)` — both inside `mod tests` boundary at line 1772; pre-existing test setup.
- Production code section before this PR: zero `pool.admit / TxPool::admit / add_tx_with_source` callsites in p2p_runtime.rs.
- `tx_relay.rs::handle_received_tx` signature: 7 params, no TxPool — relay-cache boundary locked by RUB-172/#1436 preserved through the function signature.
- Go reference: `clients/go/node/p2p/mempool.go:53` `AddRemoteTx` + `handlers_tx.go:45` `TxPool.Put` — Go has had canonical pool admission from p2p path since prior wiring.

## Local gates @ HEAD

- `cargo fmt --check -p rubin-node` clean
- `cargo clippy -p rubin-node --tests --no-deps -- -D warnings` clean
- `cargo test -p rubin-node --lib p2p_runtime -- --test-threads=1` 36/36 PASS
- Receipt status (after this PR's preflights):
  - core: PASS
  - tooling: PASS
  - coverage: PASS

## Linear

RUB-178 In Progress (status:CLAIMED, agent:claude). Blocks RUB-173/#1420 (now ready for Class B replacement after this lands).

