### PR TITLE
RUB-173: Wire p2p runtime canonical txpool admits as Remote (#1420)

### DIFF
--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -137,8 +137,17 @@ pub struct PeerRelayContext<'a> {
     /// production block-apply cleanup path in `p2p_service.rs`) into the
     /// peer-tx live message dispatch so peer transactions admit through
     /// the canonical source-aware entry after relay-cache success. The
-    /// `Remote` provenance matches Go's `Mempool.AddRemoteTx` (called
-    /// from `clients/go/node/p2p/handlers_tx.go::handleTx`).
+    /// `Remote` provenance matches Go's `Mempool.AddRemoteTx`
+    /// (`clients/go/node/mempool.go:416`). Go's p2p production path
+    /// reaches `AddRemoteTx` through three indirections:
+    /// `clients/go/node/p2p/handlers_tx.go::handleTx` (line 45) calls
+    /// `cfg.TxPool.Put` against the `TxPool` interface, which
+    /// production wiring at
+    /// `clients/go/cmd/rubin-node/main.go:489`
+    /// (`p2p.NewCanonicalMempoolTxPool(mempool)`) routes through
+    /// `CanonicalMempoolTxPool.Put`
+    /// (`clients/go/node/p2p/mempool.go:45-54`); that method's last
+    /// statement (line 53) is `p.mempool.AddRemoteTx(raw)`.
     pub tx_pool: &'a std::sync::Mutex<crate::txpool::TxPool>,
 }
 
@@ -527,9 +536,16 @@ impl PeerSession {
                     // transactions admit via
                     // `add_tx_with_source(..., TxSource::Remote, ...)`,
                     // matching Go's `Mempool.AddRemoteTx`
-                    // (`clients/go/node/mempool.go`) which is the shared
-                    // body called from
-                    // `clients/go/node/p2p/handlers_tx.go::handleTx`.
+                    // (`clients/go/node/mempool.go:416`). Go's p2p
+                    // production path reaches `AddRemoteTx` indirectly:
+                    // `handlers_tx.go::handleTx` calls
+                    // `cfg.TxPool.Put` (the `TxPool` interface), which
+                    // production wiring
+                    // (`clients/go/cmd/rubin-node/main.go:489`,
+                    // `NewCanonicalMempoolTxPool(mempool)`) routes
+                    // through `CanonicalMempoolTxPool.Put`
+                    // (`clients/go/node/p2p/mempool.go:45-54`); line 53
+                    // is `p.mempool.AddRemoteTx(raw)`.
                     //
                     // Only fires after `handle_received_tx` returns
                     // `RelayTxOutcome::Relayed`, which means the peer tx

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -3024,9 +3024,15 @@ mod tests {
 
     /// RUB-178 / GitHub #1438 introduced this production-path
     /// reachability proof for the canonical TxPool admission seam in
-    /// `PeerRelayContext`; RUB-173 / GitHub #1420 flipped the
-    /// `entry_source` assertion from `Local` to `Remote` after the seam
-    /// switched to `add_tx_with_source(_, _, _, _, TxSource::Remote)`.
+    /// `PeerRelayContext`; RUB-173 / GitHub #1420 paired the seam swap
+    /// to `add_tx_with_source(_, _, _, _, TxSource::Remote)` with an
+    /// `entry_source` parity update from `Local` to `Remote`.
+    ///
+    /// Proof assertion: the `assert_eq!(pool_guard.entry_source(&txid),
+    /// Some(crate::txpool::TxSource::Remote), ...)` near the end of
+    /// this test is the regression anchor that breaks if the seam
+    /// regresses to legacy `pool.admit` (Local) or any other source
+    /// variant.
     ///
     /// Why this is not helper-only:
     ///

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -127,20 +127,18 @@ pub struct PeerRelayContext<'a> {
     /// Outbound relay queues: serialized wire frames enqueued by broadcast,
     /// drained by the peer thread to avoid concurrent TcpStream writes.
     pub peer_writers: &'a std::sync::Mutex<HashMap<String, crate::tx_relay::PeerOutbox>>,
-    /// Canonical TxPool admission seam (RUB-178 / GitHub #1438).
+    /// Canonical TxPool admission seam with source-aware classification
+    /// (RUB-178 / GitHub #1438 introduced the lifecycle plumbing using
+    /// legacy `pool.admit`; RUB-173 / GitHub #1420 swapped the call to
+    /// `add_tx_with_source(..., TxSource::Remote, ...)`).
     ///
     /// Threads the existing `shared.tx_pool: Arc<Mutex<TxPool>>` handle
     /// (introduced in PR #876, commit `ce270e3`, already used by the
     /// production block-apply cleanup path in `p2p_service.rs`) into the
-    /// peer-tx live message dispatch so peer transactions can reach
-    /// canonical admission after relay-cache success.
-    ///
-    /// Class C lifecycle plumbing only. This field uses the legacy
-    /// `pool.admit(...)` entrypoint; source classification (Local / Reorg
-    /// / Remote) is owned by `add_tx_with_source` and the per-source
-    /// producer wiring tasks. RUB-173 / GitHub #1420 will replace this
-    /// seam with `add_tx_with_source(..., TxSource::Remote, ...)` for
-    /// peer-originated transactions.
+    /// peer-tx live message dispatch so peer transactions admit through
+    /// the canonical source-aware entry after relay-cache success. The
+    /// `Remote` provenance matches Go's `Mempool.AddRemoteTx` (called
+    /// from `clients/go/node/p2p/handlers_tx.go::handleTx`).
     pub tx_pool: &'a std::sync::Mutex<crate::txpool::TxPool>,
 }
 
@@ -524,33 +522,44 @@ impl PeerSession {
                         ctx.local_addr,
                         ctx.peer_writers,
                     )?;
-                    // RUB-178 / GitHub #1438: canonical TxPool admission seam.
+                    // RUB-173 / GitHub #1420: canonical TxPool admission
+                    // seam with source-aware classification. Peer-relayed
+                    // transactions admit via
+                    // `add_tx_with_source(..., TxSource::Remote, ...)`,
+                    // matching Go's `Mempool.AddRemoteTx`
+                    // (`clients/go/node/mempool.go`) which is the shared
+                    // body called from
+                    // `clients/go/node/p2p/handlers_tx.go::handleTx`.
                     //
                     // Only fires after `handle_received_tx` returns
                     // `RelayTxOutcome::Relayed`, which means the peer tx
                     // already passed parse, dedup, and `relay_metadata`
-                    // (rolling fee floor). The seam threads the existing
-                    // `shared.tx_pool` handle one level deeper and uses the
-                    // legacy `pool.admit(...)` entrypoint — source
-                    // classification (`TxSource::Remote`) is reserved for
-                    // RUB-173 / GitHub #1420 replacement. Until that lands,
-                    // the seam admits peer-relayed txs with the legacy
-                    // `pool.admit` default of `TxSource::Local`; the
-                    // production-path test below explicitly pins this
-                    // intermediate state via
-                    // `pool.entry_source(&txid) == Some(TxSource::Local)`
-                    // so RUB-173 will see the assertion break and update
-                    // it together with the source-aware switch.
+                    // (rolling fee floor). Source is recorded on
+                    // `TxPoolEntry.source` for observability and
+                    // downstream filtering; per `add_tx_with_source` doc,
+                    // source does NOT affect validation, admission
+                    // ordering, or capacity-eviction priority — admission
+                    // is source-blind, only provenance differs.
+                    //
+                    // RUB-178 / GitHub #1438 introduced this seam first
+                    // using the legacy `pool.admit(...)` entrypoint
+                    // (which records `TxSource::Local`) as an explicit
+                    // Class C lifecycle prerequisite; this slice (RUB-173)
+                    // is the Class B replacement that flips source
+                    // classification to `Remote`. The production-path
+                    // test below pins
+                    // `pool.entry_source(&txid) == Some(TxSource::Remote)`
+                    // as the Go/Rust source-provenance parity anchor.
                     //
                     // Admission Result is intentionally discarded — it
                     // does NOT change `RelayTxOutcome` and does NOT
-                    // contribute to ban-score policy (per issue's
+                    // contribute to ban-score policy (per RUB-178 issue's
                     // failure_modes: "preserve existing txpool caller
                     // error class; no new policy ordering"). The
                     // relay-cache leg has already accepted the tx, and
-                    // RUB-178's invariant is "seam is reachable", not
-                    // "every peer tx admits". Future divergence
-                    // observability is a separate change.
+                    // the seam's invariant is now "seam admits with
+                    // Remote source", not "every peer tx admits". Future
+                    // divergence observability is a separate change.
                     //
                     // Lock poisoning is a separate concern from admission
                     // failure: a poisoned `tx_pool` Mutex means a prior
@@ -585,11 +594,12 @@ impl PeerSession {
                     if matches!(outcome, crate::tx_relay::RelayTxOutcome::Relayed) {
                         match ctx.tx_pool.lock() {
                             Ok(mut pool) => {
-                                let _ = pool.admit(
+                                let _ = pool.add_tx_with_source(
                                     &msg.payload,
                                     &sync_engine.chain_state,
                                     sync_engine.block_store.as_ref(),
                                     sync_engine.cfg.chain_id,
+                                    crate::txpool::TxSource::Remote,
                                 );
                             }
                             Err(_) => {
@@ -2996,14 +3006,18 @@ mod tests {
         assert!(err.contains("unknown message type: weird"), "got: {err}");
     }
 
-    /// RUB-178 / GitHub #1438: production-path reachability proof for the
-    /// canonical TxPool admission seam introduced in `PeerRelayContext`.
+    /// RUB-178 / GitHub #1438 introduced this production-path
+    /// reachability proof for the canonical TxPool admission seam in
+    /// `PeerRelayContext`; RUB-173 / GitHub #1420 flipped the
+    /// `entry_source` assertion from `Local` to `Remote` after the seam
+    /// switched to `add_tx_with_source(_, _, _, _, TxSource::Remote)`.
     ///
     /// Why this is not helper-only:
     ///
-    ///   - The test does NOT call `pool.admit(...)` directly. Admission
-    ///     happens through `PeerSession::collect_live_responses`, the
-    ///     exact public method used by the production message loop in
+    ///   - The test does NOT call `add_tx_with_source(...)` or
+    ///     `pool.admit(...)` directly. Admission happens through
+    ///     `PeerSession::collect_live_responses`, the exact public
+    ///     method used by the production message loop in
     ///     `clients/rust/crates/rubin-node/src/p2p_service.rs::handle_peer`
     ///     (see the `session.collect_live_responses(msg, &mut engine,
     ///     Some(&relay_ctx))` call in `handle_peer`'s message-loop body).
@@ -3017,8 +3031,11 @@ mod tests {
     ///     `tx_pool.lock()` is taken and `pool.contains(&txid)` plus
     ///     `pool.entry_source(&txid)` are checked. The seam is the
     ///     only code path that could put the txid there in this scenario.
-    ///   - No `TxSource::Remote` claim. The seam uses legacy `pool.admit`;
-    ///     source-aware classification is RUB-173 / GitHub #1420 follow-up.
+    ///   - Source classification: `entry_source(&txid)` is asserted to
+    ///     equal `Some(TxSource::Remote)` per RUB-173 / GitHub #1420.
+    ///     This matches Go's `Mempool.AddRemoteTx` provenance and breaks
+    ///     if the seam regresses to legacy `pool.admit` (Local) or any
+    ///     other source variant.
     #[test]
     fn collect_live_responses_message_tx_admits_through_canonical_pool_seam() {
         use std::collections::HashMap;
@@ -3103,22 +3120,23 @@ mod tests {
                 "canonical TxPool must contain the txid after MESSAGE_TX dispatch — \
                  the seam is the only code path that could place it there in this test"
             );
-            // RUB-178 intermediate-state pin: the seam uses legacy
-            // `pool.admit(...)` which delegates to `add_tx_with_source(_,
-            // TxSource::Local, _)`. RUB-173 / GitHub #1420 will replace
-            // the seam with `add_tx_with_source(_, TxSource::Remote, _)`
-            // and update this pin together with the source switch.
-            // Proof assertion: the `assert_eq!` below comparing
+            // RUB-173 / GitHub #1420 source-provenance pin: the seam
+            // uses `add_tx_with_source(_, _, _, _, TxSource::Remote)`
+            // which records `Remote` on `TxPoolEntry.source` to match
+            // Go's `Mempool.AddRemoteTx` provenance. Proof assertion:
+            // the `assert_eq!` below comparing
             // `pool_guard.entry_source(&txid)` against
-            // `Some(crate::txpool::TxSource::Local)` is the regression
-            // anchor; any future seam-source flip without a paired
-            // update of this assertion produces a test failure here.
+            // `Some(crate::txpool::TxSource::Remote)` is the parity
+            // anchor; any regression that drops back to legacy
+            // `pool.admit` (Local) or any other source variant
+            // produces a test failure here.
             assert_eq!(
                 pool_guard.entry_source(&txid),
-                Some(crate::txpool::TxSource::Local),
-                "RUB-178 seam uses legacy pool.admit which records \
-                 TxSource::Local; RUB-173 / GitHub #1420 will switch to \
-                 TxSource::Remote and update this pin"
+                Some(crate::txpool::TxSource::Remote),
+                "RUB-173 / GitHub #1420 seam uses \
+                 add_tx_with_source(_, _, _, _, TxSource::Remote) — \
+                 peer-relayed txs must record Remote provenance to match \
+                 Go AddRemoteTx"
             );
             drop(pool_guard);
 

--- a/clients/rust/crates/rubin-node/src/p2p_service.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_service.rs
@@ -804,12 +804,14 @@ fn handle_peer(
         addr: peer_addr.clone(),
     };
 
-    // Build relay context for message loop. RUB-178 / GitHub #1438:
-    // `tx_pool` threads the existing `shared.tx_pool` handle (already
-    // used by the block-apply cleanup path in `apply_tx_pool_cleanup`)
-    // into the peer-tx dispatch so peer transactions reach canonical
-    // admission via the legacy `pool.admit` seam in
-    // `collect_live_responses`. No new lifecycle ownership: this is
+    // Build relay context for message loop. RUB-178 / GitHub #1438
+    // introduced the lifecycle plumbing; `tx_pool` threads the existing
+    // `shared.tx_pool` handle (already used by the block-apply cleanup
+    // path in `apply_tx_pool_cleanup`) into the peer-tx dispatch so
+    // peer transactions reach canonical admission via the seam in
+    // `collect_live_responses`. RUB-173 / GitHub #1420 then swapped that
+    // seam to `add_tx_with_source(..., TxSource::Remote, ...)` for
+    // source-aware classification. No new lifecycle ownership: this is
     // the same `Arc<Mutex<TxPool>>` introduced for cleanup in PR #876.
     let relay_ctx = PeerRelayContext {
         relay_state: &shared.relay_state,


### PR DESCRIPTION
# RUB-173 / GitHub #1420 — Wire p2p runtime canonical txpool admits as Remote

## Invariant
Rust P2P production canonical txpool admission uses `TxSource::Remote`.

## Class
B (replacement) — swap the seam introduced by RUB-178 / #1438 (merged in `cffcd48`) from legacy `pool.admit(...)` to source-aware `add_tx_with_source(_, _, _, _, TxSource::Remote)`.

## Changes

- `clients/rust/crates/rubin-node/src/p2p_runtime.rs`:
  - **Production seam** (`collect_live_responses` MESSAGE_TX, ~line 597):
    `pool.admit(...)` → `pool.add_tx_with_source(..., crate::txpool::TxSource::Remote)`. Lock-poison handling, admission-`Result`-discard, and engine→pool nested lock ordering all preserved unchanged.
  - **Module-level docstring** (`PeerRelayContext.tx_pool` field): updated to reflect Remote provenance with full Go callsite chain.
  - **Seam-purpose comment block**: updated narrative; lock-ordering and poisoning rationale blocks unchanged.
  - **RUB-178 production-path test** (`collect_live_responses_message_tx_admits_through_canonical_pool_seam`): flipped `entry_source` pin from `Some(TxSource::Local)` to `Some(TxSource::Remote)` — the parity anchor that breaks if the seam regresses to legacy `pool.admit` or any other source variant.
  - **Test docstring + inline pin comment**: updated to RUB-173 source-provenance pin language with explicit `Proof assertion:` anchor naming the `assert_eq!` line.

- `clients/rust/crates/rubin-node/src/p2p_service.rs` (comment-only, controller-approved narrow scope expansion 2026-05-06):
  - **`handle_peer` `PeerRelayContext` build comment** (~lines 807-815): updated stale "legacy `pool.admit` seam" wording to reference both RUB-178 (lifecycle plumbing) and RUB-173 (source-aware swap to `add_tx_with_source(..., TxSource::Remote, ...)`). Resolves Copilot P2 doc-drift finding on PR #1456 thread `PRRT_kwDORQ3qGs5__rmB`. No code/test/behavior change.

## Out of scope (forbidden surfaces honored)

- `tx_relay.rs` unchanged — relay-cache boundary preserved; `handle_received_tx` signature still 7-arg with no canonical TxPool handle.
- `txpool.rs` internals unchanged — `add_tx_with_source` already `pub` since RUB-167; `pool.admit` still available for legacy callers including test setup at p2p_runtime.rs:2488/2555 (RUB-162 block-cleanup test fixtures, intentionally Local-source).
- `devnet_rpc.rs` / `sync_reorg.rs` / `miner.rs` / `Cargo.toml` / `Cargo.lock` / `conformance/**` untouched.
- `p2p_service.rs` was originally `forbidden_surfaces` for RUB-173; controller-approved narrow scope expansion 2026-05-06 limits the touch to a comment-only doc-drift fix (no code/test/behavior change).

## Go counterpart parity (verified by grep+Read at HEAD)

```
clients/go/node/p2p/handlers_tx.go:45    cfg.TxPool.Put (interface dispatch)
clients/go/cmd/rubin-node/main.go:489    TxPool: p2p.NewCanonicalMempoolTxPool(mempool)
clients/go/node/p2p/mempool.go:45-54     CanonicalMempoolTxPool.Put → line 53: p.mempool.AddRemoteTx(raw)
clients/go/node/mempool.go:416           Mempool.AddRemoteTx → addTxWithSource(_, mempoolTxSourceRemote)
```

All four file:line anchors are cited in the Rust seam docstring/inline comment after the `Mempool.AddRemoteTx` parity claim.

## Local gates @ HEAD

- `cargo fmt -p rubin-node -- --check`: clean
- `cargo test -p rubin-node --lib p2p_runtime -- --test-threads=1`: 36/36 PASS
- `cargo clippy -p rubin-node --tests --no-deps -- -D warnings`: clean
- `rubin-common-preflight --lane core`: PASS
- `rubin-common-preflight --lane tooling --serial-rust-tests`: PASS (23s)
- `rubin-common-preflight --lane coverage --serial-rust-tests`: PASS (288s)
- `rubin-review-fanout` aggregate: PASS (issue-matrix PASS, prepush-hostile PASS, parity PASS)
- `rubin-delta-receipt`: PASS (review-fanout-reused: auto-review-neutral; comment-only delta from prior fanout HEAD)

## Anti-overclaim

- This PR does NOT change `RelayTxOutcome` mapping or ban-score policy ordering. The `add_tx_with_source` `Result` is intentionally discarded (preserved from RUB-178 failure_mode contract: "preserve existing txpool caller error class; no new policy ordering").
- This PR does NOT modify `tx_relay.rs` — the relay-cache boundary contract from RUB-172 stays intact; the canonical seam is in the *caller*, not in `handle_received_tx`.
- This PR does NOT introduce new fixtures, conformance vectors, or formal companions (issue declares both `not_applicable`).
- The Rust runtime ordering (relay-cache first → canonical admit after) versus Go's canonical-first inline path is a pre-existing Rust-only structural choice from RUB-178, openly documented in `tx_relay.rs:80-93` and intentionally out of scope here.

Closes #1420

