### PR TITLE
RUB-164: Clean residual Rust txpool legacy fixtures after producer wiring (#1409)

### DIFF
--- a/clients/rust/crates/rubin-node/src/tx_relay.rs
+++ b/clients/rust/crates/rubin-node/src/tx_relay.rs
@@ -70,12 +70,15 @@
 //!
 //! Canonical source-aware admission (`TxSource::Local` /
 //! `TxSource::Remote` / `TxSource::Reorg`) is owned by the
-//! per-producer slices. The currently merged producers are RUB-169
-//! reorg requeue (`TxSource::Reorg`) and RUB-171 RPC submit
-//! (`TxSource::Local`). The `TxSource::Remote` p2p producer
-//! wiring is planned (RUB-173) and not yet landed in production;
-//! when it lands, that slice MUST NOT treat a successful relay
-//! outcome here as proof of canonical admission.
+//! per-producer slices. All three producer slices are merged:
+//! RUB-169 reorg requeue (`TxSource::Reorg`), RUB-171 RPC submit
+//! (`TxSource::Local`), and RUB-173 p2p relay (`TxSource::Remote`,
+//! at `p2p_runtime.rs::collect_live_responses` MESSAGE_TX via the
+//! `PeerRelayContext.tx_pool` carrier; gated by a successful
+//! `RelayTxOutcome::Relayed` from `handle_received_tx` here).
+//! None of those producer slices may treat a successful relay
+//! outcome here as proof of canonical admission — admission
+//! happens in the per-producer caller, not in this module.
 //!
 //! # Go counterpart (API/sequence parity ONLY — NOT production-boundary parity)
 //!
@@ -87,10 +90,11 @@
 //! p2p service config struct literal — so Go production is NOT a
 //! relay-cache/canonical split — it admits to the canonical pool
 //! from inside `handleTx`. The relay-cache/canonical split
-//! described in this docstring is currently a Rust-only structural
-//! choice; the `TxSource::Remote` p2p producer wiring planned for
-//! RUB-173 will introduce the canonical-admission counterpart on
-//! the Rust side.
+//! described in this docstring is a Rust-only structural choice;
+//! the `TxSource::Remote` p2p producer counterpart was introduced
+//! by RUB-173 / GitHub #1420 in
+//! `p2p_runtime.rs::collect_live_responses` MESSAGE_TX (after a
+//! `RelayTxOutcome::Relayed` outcome from this module).
 //!
 //! `clients/go/node/p2p/handlers_tx.go::handleTx` runs the same
 //! sequence (oversize → parse → tx_seen → relayTxMetadata →


### PR DESCRIPTION
# RUB-164 / GitHub #1409 — Clean residual Rust txpool legacy fixtures after producer wiring

## Invariant
After Rust txpool internal parity (RUB-162), producer wiring (RUB-163 children RUB-169/170/171/172/173), and Rust fast-reject parity (RUB-166) all landed, remaining legacy txpool tests/helpers no longer encode obsolete admission/cleanup/source/fee-floor assumptions.

## Class
A — mechanical doc-only cleanup. No behavior, no code, no tests changed.

## Cleanup-only declaration
This PR does NOT claim new parity coverage. Phase C cleanup after Phase A/B and fast-reject parity land. Per issue contract: this is not a behavior PR.

## Changes (1 file, +14/-10 lines)

- `clients/rust/crates/rubin-node/src/tx_relay.rs` (module-level docstring, 2 sites stale due to RUB-173 child of RUB-163 producer-wiring track):
  - **Lines 71-82** (producer-merger status enumeration): replaced "currently merged producers are RUB-169 ... RUB-171 ... TxSource::Remote p2p producer wiring is planned (RUB-173) and not yet landed in production" with "All three producer slices are merged: RUB-169 reorg requeue (TxSource::Reorg), RUB-171 RPC submit (TxSource::Local), and RUB-173 p2p relay (TxSource::Remote, at p2p_runtime.rs::collect_live_responses MESSAGE_TX via the PeerRelayContext.tx_pool carrier; gated by a successful RelayTxOutcome::Relayed from handle_received_tx here)". The "must not treat Relayed as proof of canonical admission" rule is kept — that's the still-current relay-only invariant for THIS module.
  - **Lines 89-95** (Go counterpart parity section): replaced "the TxSource::Remote p2p producer wiring planned for RUB-173 will introduce the canonical-admission counterpart on the Rust side" with "the TxSource::Remote p2p producer counterpart was introduced by RUB-173 / GitHub #1420 in p2p_runtime.rs::collect_live_responses MESSAGE_TX (after a RelayTxOutcome::Relayed outcome from this module)".

## Out of scope (forbidden surfaces honored)

- No production behavior changes (docstring-only).
- No code, test, or boundary_checker AST-walker scope changes (the cfg-test skip rule is unaffected by docstring lines, which are `#![doc]` attribute nodes).
- No changes to txpool.rs internals, p2p_*.rs, devnet_rpc.rs, sync_reorg.rs, miner.rs, Cargo.toml/Cargo.lock, conformance/**.
- No producer wiring changes. No fast-reject behavior change. No Go code changes. No conformance vectors.

## Go counterpart parity (verified by grep+Read at HEAD)

```
clients/go/cmd/rubin-node/main.go:489-490   TxPool: p2p.NewCanonicalMempoolTxPool(mempool); TxMetadataFunc: p2p.CanonicalMempoolRelayMetadata
clients/go/node/p2p/handlers_tx.go:45        cfg.TxPool.Put (interface dispatch)
clients/go/node/p2p/mempool.go:45-54         CanonicalMempoolTxPool.Put → line 53: p.mempool.AddRemoteTx(raw)
clients/go/node/mempool.go:416               Mempool.AddRemoteTx → addTxWithSource(_, mempoolTxSourceRemote)
clients/go/node/p2p/tx_metadata.go:12        CanonicalMempoolRelayMetadata
```

## Local gates @ HEAD

- `cargo fmt -p rubin-node -- --check`: clean
- `cargo clippy -p rubin-node --tests --no-deps -- -D warnings`: clean
- `cargo test -p rubin-node --lib tx_relay -- --test-threads=1`: 75/75 PASS (boundary_checker AST scan unchanged)
- `rubin-common-preflight --lane core`: PASS (git-diff-check, local-agent-hygiene, bot-premortem all PASS)
- `rubin-common-preflight --lane tooling --serial-rust-tests`: PASS (30.6s after orphan-cleanup retry)
- `rubin-common-preflight --lane coverage --serial-rust-tests`: PASS (291s)
- `rubin-review-fanout` aggregate: PASS (issue-matrix PASS, prepush-hostile PASS, parity PASS — content-grounded)
- `rubin-delta-receipt`: PASS

## Anti-overclaim

- This PR does NOT claim new parity coverage. The producer-wiring chain (RUB-169/170/171/172/173) was already covered by its own slices' tests; this cleanup only refreshes the docstring narrative that was carrying the pre-RUB-173 "planned / not yet landed" wording.
- This PR does NOT modify tx_relay.rs code, handle_received_tx signature (still 7-arg with no canonical TxPool handle), RelayTxOutcome variants, ban-score policy, oversize/parse-fail handling, or the boundary_checker AST walker.
- The Rust runtime ordering divergence (relay-cache first → canonical admit after) versus Go's canonical-first inline path is a pre-existing Rust-only structural choice from RUB-178/RUB-173, openly disclosed in this docstring.

Closes #1409
