### PR TITLE
mempool: apply rolling floor in relay metadata

### DIFF
--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -487,24 +487,14 @@ func validMempoolTxSource(source mempoolTxSource) bool {
 
 // RelayMetadata returns the metadata a relay peer needs to forward the
 // transaction (fee + serialized size). It runs full structural +
-// chainstate validation via checkParsedTransactionWithSnapshot but
-// intentionally DOES NOT enforce the rolling-relay-fee floor: the
-// admit-path policy (see `addTxWithSource` → `addEntryLockedWithFloor`
-// → `validateFeeFloorLockedWithFloor` in this file) is the uniform
-// owner of relay-floor classification (see `applyPolicyAgainstState`
-// docstring in this file for the matching admit-path rationale).
+// chainstate validation via checkParsedTransactionWithSnapshot and then
+// enforces the rolling-relay-fee floor read-only. Below-floor otherwise-valid
+// txs return the same TxAdmitUnavailable class/message family as admit-path
+// validateFeeFloorLockedWithFloor.
 //
-// Cross-client divergence between Go RelayMetadata and Rust relay_metadata:
-// Rust `relay_metadata` (clients/rust/crates/rubin-node/src/txpool.rs)
-// DOES enforce relay-floor inline via `apply_post_consensus_policy_with_floor`
-// → `validate_fee_floor`. The Go relay path delegates floor enforcement to
-// per-peer relay-policy + the admit-time check. RelayMetadata is a
-// read-only metadata fetcher and does NOT insert into the mempool. The
-// documented expected delta is: below-floor txs whose Go RelayMetadata
-// returns metadata while Rust relay_metadata returns `Unavailable`. This
-// asymmetry is INTENTIONAL pending a future cross-client unification slice
-// (separate follow-up — TBD). See the Rust pinning test
-// `rub166_relay_metadata_below_floor_p2pk_still_returns_unavailable_matching_admit`.
+// RelayMetadata is not full mempool admission: it does not insert, does not
+// record source/admission_seq, and does not check duplicate, conflict, or
+// capacity state. Those remain owned by addTxWithSource/addEntryLockedWithFloor.
 func (m *Mempool) RelayMetadata(txBytes []byte) (RelayTxMetadata, error) {
 	if m == nil {
 		return RelayTxMetadata{}, txAdmitUnavailable("nil mempool")
@@ -520,14 +510,31 @@ func (m *Mempool) RelayMetadata(txBytes []byte) (RelayTxMetadata, error) {
 	defer m.chainState.admissionMu.RUnlock()
 	snapshot := m.chainState.admissionSnapshotForInputs(relayMetadataInputs(tx))
 	policy := m.policySnapshot()
+	snappedFloor := m.CurrentMinFeeRateSnapshot()
 	checked, _, err := m.checkParsedTransactionWithSnapshot(txBytes, tx, txid, wtxid, snapshot, policy)
 	if err != nil {
+		return RelayTxMetadata{}, err
+	}
+	if err := m.validateRelayMetadataFeeFloor(checked, snappedFloor); err != nil {
 		return RelayTxMetadata{}, err
 	}
 	return RelayTxMetadata{
 		Fee:  checked.Fee,
 		Size: checked.SerializedSize,
 	}, nil
+}
+
+func (m *Mempool) validateRelayMetadataFeeFloor(checked *consensus.CheckedTransaction, snappedFloor uint64) error {
+	if checked == nil {
+		return txAdmitRejected("nil checked transaction")
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.validateFeeFloorLockedWithFloor(&mempoolEntry{
+		fee:    checked.Fee,
+		weight: checked.Weight,
+		size:   checked.SerializedSize,
+	}, snappedFloor)
 }
 
 func parseRelayMetadataTx(txBytes []byte) (*consensus.Tx, [32]byte, [32]byte, error) {
@@ -952,11 +959,9 @@ func (m *Mempool) validateFeeFloorLocked(entry *mempoolEntry) error {
 //     rejected against the current congestion-control policy. NEVER
 //     admits a transaction below the current rolling floor.
 //
-// Wave-7 (snap-once-pass-through) closed the decay race in one
-// direction but introduced the raise race in the opposite direction
-// (both Codex PRRT_TRxc and Copilot PRRT_TYQt found this). Wave-8
-// adds the locked re-read with max-of-(snap, live) per Copilot's
-// explicit wave-7 fix recommendation.
+// A prior snap-once pass-through closed the decay race in one direction but
+// introduced the raise race in the opposite direction. The locked re-read with
+// max-of-(snap, live) closes both sides.
 func (m *Mempool) validateFeeFloorLockedWithFloor(entry *mempoolEntry, snappedFloor uint64) error {
 	if entry == nil {
 		return txAdmitRejected("nil mempool entry")

--- a/clients/go/node/mempool_test.go
+++ b/clients/go/node/mempool_test.go
@@ -1037,6 +1037,7 @@ func TestMempoolRelayMetadata(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new mempool: %v", err)
 	}
+	mp.SetCurrentMinFeeRateForTest(8)
 	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 300_000, 5, fromKey, fromAddress, toAddress)
 	meta, err := mp.RelayMetadata(txBytes)
 	if err != nil {
@@ -1047,6 +1048,54 @@ func TestMempoolRelayMetadata(t *testing.T) {
 	}
 	if meta.Size != len(txBytes) {
 		t.Fatalf("size=%d, want %d", meta.Size, len(txBytes))
+	}
+	if got := mp.Len(); got != 0 {
+		t.Fatalf("RelayMetadata inserted tx; mempool len=%d, want 0", got)
+	}
+	if mp.Contains(txID(t, txBytes)) {
+		t.Fatalf("RelayMetadata inserted txid %x", txID(t, txBytes))
+	}
+	if got := mp.BytesUsed(); got != 0 {
+		t.Fatalf("RelayMetadata mutated bytes used=%d, want 0", got)
+	}
+	if mp.lastAdmissionSeq != 0 {
+		t.Fatalf("RelayMetadata consumed admission_seq=%d, want 0", mp.lastAdmissionSeq)
+	}
+}
+
+func TestMempoolRelayMetadataBelowRollingFloorUnavailable(t *testing.T) {
+	fromKey := mustNodeMLDSA87Keypair(t)
+	toKey := mustNodeMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000})
+
+	mp, err := NewMempool(st, nil, devnetGenesisChainID)
+	if err != nil {
+		t.Fatalf("new mempool: %v", err)
+	}
+	mp.SetCurrentMinFeeRateForTest(8)
+	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 1, 5, fromKey, fromAddress, toAddress)
+
+	_, err = mp.RelayMetadata(txBytes)
+	var txErr *TxAdmitError
+	if !errors.As(err, &txErr) || txErr.Kind != TxAdmitUnavailable {
+		t.Fatalf("RelayMetadata below-floor err=%T %v, want TxAdmitUnavailable", err, err)
+	}
+	if !strings.Contains(txErr.Message, "mempool fee below rolling minimum") {
+		t.Fatalf("below-floor reason %q does not match admit-path fee-floor wording", txErr.Message)
+	}
+	if got := mp.Len(); got != 0 {
+		t.Fatalf("RelayMetadata below-floor inserted tx; mempool len=%d, want 0", got)
+	}
+	if mp.Contains(txID(t, txBytes)) {
+		t.Fatalf("RelayMetadata below-floor inserted txid %x", txID(t, txBytes))
+	}
+	if got := mp.BytesUsed(); got != 0 {
+		t.Fatalf("RelayMetadata below-floor mutated bytes used=%d, want 0", got)
+	}
+	if mp.lastAdmissionSeq != 0 {
+		t.Fatalf("RelayMetadata below-floor consumed admission_seq=%d, want 0", mp.lastAdmissionSeq)
 	}
 }
 
@@ -1061,10 +1110,19 @@ func TestMempoolRelayMetadataTrailingBytes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new mempool: %v", err)
 	}
+	mp.SetCurrentMinFeeRateForTest(8)
 	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 300_000, 5, fromKey, fromAddress, toAddress)
 	txBytes = append(txBytes, 0x00)
-	if _, err := mp.RelayMetadata(txBytes); err == nil || !strings.Contains(err.Error(), "trailing bytes after canonical tx") {
+	_, err = mp.RelayMetadata(txBytes)
+	var txErr *TxAdmitError
+	if !errors.As(err, &txErr) || txErr.Kind != TxAdmitRejected {
+		t.Fatalf("RelayMetadata trailing bytes err=%T %v, want TxAdmitRejected", err, err)
+	}
+	if !strings.Contains(txErr.Message, "trailing bytes after canonical tx") {
 		t.Fatalf("expected trailing-bytes rejection, got %v", err)
+	}
+	if strings.Contains(txErr.Message, "mempool fee below rolling minimum") {
+		t.Fatalf("trailing-bytes path was stolen by rolling-floor check: %q", txErr.Message)
 	}
 }
 
@@ -1116,8 +1174,16 @@ func TestMempoolPolicyRejectsLowFeeDaCommit(t *testing.T) {
 	if err := mp.AddTx(txBytes); err == nil || !strings.Contains(err.Error(), "DA fee below Stage C floor") {
 		t.Fatalf("expected DA Stage C floor rejection, got %v", err)
 	}
-	if _, err := mp.RelayMetadata(txBytes); err == nil || !strings.Contains(err.Error(), "DA fee below Stage C floor") {
+	_, err = mp.RelayMetadata(txBytes)
+	var txErr *TxAdmitError
+	if !errors.As(err, &txErr) || txErr.Kind != TxAdmitRejected {
+		t.Fatalf("RelayMetadata low-fee DA err=%T %v, want TxAdmitRejected", err, err)
+	}
+	if !strings.Contains(txErr.Message, "DA fee below Stage C floor") {
 		t.Fatalf("expected relay metadata DA Stage C floor rejection, got %v", err)
+	}
+	if strings.Contains(txErr.Message, "mempool fee below rolling minimum") {
+		t.Fatalf("DA floor path was stolen by rolling-floor check: %q", txErr.Message)
 	}
 }
 

--- a/clients/go/node/mempool_test.go
+++ b/clients/go/node/mempool_test.go
@@ -1111,7 +1111,7 @@ func TestMempoolRelayMetadataTrailingBytes(t *testing.T) {
 		t.Fatalf("new mempool: %v", err)
 	}
 	mp.SetCurrentMinFeeRateForTest(8)
-	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 300_000, 5, fromKey, fromAddress, toAddress)
+	txBytes := mustBuildSignedTransferTx(t, st.Utxos, []consensus.Outpoint{outpoints[0]}, 100_000, 1, 5, fromKey, fromAddress, toAddress)
 	txBytes = append(txBytes, 0x00)
 	_, err = mp.RelayMetadata(txBytes)
 	var txErr *TxAdmitError

--- a/clients/go/node/runtime_perf_baseline_test.go
+++ b/clients/go/node/runtime_perf_baseline_test.go
@@ -222,7 +222,7 @@ func TestMempoolRelayMetadataPreservesBaseChainState(t *testing.T) {
 	toKey := mustBenchmarkNodeMLDSA87Keypair(t)
 	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
 	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
-	state, outpoints := benchmarkSpendableChainState(fromAddress, []uint64{100})
+	state, outpoints := benchmarkSpendableChainState(fromAddress, []uint64{1_000_000})
 	before := snapshotChainState(t, state)
 	mp, err := NewMempool(state, nil, devnetGenesisChainID)
 	if err != nil {
@@ -232,8 +232,8 @@ func TestMempoolRelayMetadataPreservesBaseChainState(t *testing.T) {
 		t,
 		state.Utxos,
 		[]consensus.Outpoint{outpoints[0]},
-		90,
-		3,
+		100_000,
+		100_000,
 		5,
 		fromKey,
 		fromAddress,
@@ -342,13 +342,13 @@ func BenchmarkMempoolRelayMetadata(b *testing.B) {
 	toKey := mustBenchmarkNodeMLDSA87Keypair(b)
 	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
 	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
-	state, outpoints := benchmarkSpendableChainState(fromAddress, []uint64{100})
+	state, outpoints := benchmarkSpendableChainState(fromAddress, []uint64{1_000_000})
 	txBytes := mustBenchmarkSignedTransferTx(
 		b,
 		state.Utxos,
 		[]consensus.Outpoint{outpoints[0]},
-		90,
-		3,
+		100_000,
+		100_000,
 		5,
 		fromKey,
 		fromAddress,

--- a/clients/rust/crates/rubin-node/src/txpool.rs
+++ b/clients/rust/crates/rubin-node/src/txpool.rs
@@ -687,19 +687,11 @@ impl TxPool {
 /// AND enforces the rolling-relay-fee floor inline via
 /// `apply_post_consensus_policy_with_floor` -> `validate_fee_floor`.
 ///
-/// Cross-client divergence between Go RelayMetadata and Rust relay_metadata:
-/// Go `RelayMetadata` (`clients/go/node/mempool.go`) does NOT enforce
-/// relay-floor inline; Go delegates floor enforcement to per-peer
-/// relay-policy + the admit-time `validateFeeFloorLockedWithFloor`.
-/// The Rust relay path enforces inline at relay-time. Go's
-/// `RelayMetadata` is a read-only metadata fetcher and does NOT insert
-/// into the mempool. The documented expected delta is: below-floor txs
-/// whose Go `RelayMetadata` returns metadata while Rust `relay_metadata`
-/// returns `Unavailable`. This asymmetry is INTENTIONAL pending a
-/// future cross-client unification slice (separate follow-up — TBD).
-/// The pinning test
-/// `rub166_relay_metadata_below_floor_p2pk_still_returns_unavailable_matching_admit`
-/// in this file documents the Rust side of the divergence.
+/// Cross-client parity: Go `RelayMetadata` (`clients/go/node/mempool.go`)
+/// also enforces the rolling floor read-only after structural + chainstate
+/// validation. Both relay metadata paths return `Unavailable` for otherwise
+/// valid below-floor txs. Neither path inserts into the mempool or performs
+/// duplicate, conflict, or capacity admission checks.
 pub(crate) fn relay_metadata(
     tx_bytes: &[u8],
     chain_state: &ChainState,
@@ -3891,18 +3883,10 @@ mod tests {
     /// PR-1410 wave-2 fix — relay_metadata must NOT be weaker than
     /// admit_with_metadata. The cfg-zero override before apply_policy
     /// (`applyPolicyAgainstState` in clients/go/node/mempool.go) preserves DA-side error class
-    /// isolation, but Rust's prior implementation skipped the rolling
-    /// relay floor entirely on the relay path. That created a real
-    /// production divergence: `tx_relay::handle_received_tx` uses
-    /// `relay_metadata` as the gate before re-announcing, so a DA tx
-    /// that pays the DA-side floor but is below the rolling relay
-    /// floor was propagated through the network even though
-    /// `TxPool::admit` rejected the same tx. Go avoids the divergence
-    /// in the full node by re-running mempool admission via
-    /// `CanonicalMempoolRelayMetadata` + `CanonicalMempoolTxPool.Put`;
-    /// the equivalent here is to call the same `validate_fee_floor`
-    /// predicate inside `relay_metadata` after `apply_policy` succeeds
-    /// (controller decision option-c per PR #1410 thread fix).
+    /// isolation. Both Rust `relay_metadata` and Go `RelayMetadata` enforce
+    /// the rolling relay floor after structural/chainstate/policy validation,
+    /// so relay metadata never propagates a tx the local mempool would reject
+    /// solely as below the rolling floor.
     ///
     /// Proof assertion: same DA tx, same TxPoolConfig with non-zero
     /// rolling floor + DA-side terms; admit returns Unavailable; relay


### PR DESCRIPTION
## Scope
- Aligns Go `RelayMetadata` with the rolling fee-floor classification: an otherwise-valid below-floor tx returns `TxAdmitUnavailable`.
- Keeps `RelayMetadata` read-only: no insertion, capacity admission, duplicate/conflict admission, P2P lifecycle, or conformance vector changes.
- Leaves Rust behavior unchanged; the Rust diff is stale divergence wording only.
- Closes #1461.

## Disposition
- Architecture class: B.
- Consensus impact: none.
- Go runtime behavior changed: `RelayMetadata` classification only.
- Rust behavior changed: no.
- Conformance changed: no.
- RUB-54 remains blocked until RUB-196 also closes.
