### PR TITLE
conformance: add mempool edge property accounting

### DIFF
--- a/conformance/EDGE_PACK_BASELINE.json
+++ b/conformance/EDGE_PACK_BASELINE.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "description": "Machine-readable baseline for critical conformance edge coverage across parse/weight/sighash/covenants/difficulty/DA domains.",
+  "description": "Machine-readable baseline for critical conformance edge coverage across parse/weight/sighash/covenants/difficulty/DA/mempool policy domains.",
   "domains": [
     {
       "name": "parse",
@@ -119,6 +119,64 @@
           "CV-C-30",
           "CV-C-31"
         ]
+      }
+    },
+    {
+      "name": "mempool_policy",
+      "gates": [
+        "CV-MEMPOOL"
+      ],
+      "min_vectors_total": 10,
+      "required_vectors_by_gate": {
+        "CV-MEMPOOL": [
+          "CV-MEMPOOL-01-ROLLING-FLOOR-ACCEPTED",
+          "CV-MEMPOOL-02-ROLLING-FLOOR-UNAVAILABLE",
+          "CV-MEMPOOL-03-DA-FLOOR-REJECTED",
+          "CV-MEMPOOL-04-DA-FLOOR-ACCEPTED",
+          "CV-MEMPOOL-05-OMITTED-CURRENT-FLOOR-DEFAULT",
+          "CV-MEMPOOL-06-MALFORMED-TX-PARSE-FIRST",
+          "CV-MEMPOOL-RELAY-METADATA-01-ACCEPTED-READONLY",
+          "CV-MEMPOOL-RELAY-METADATA-02-ROLLING-FLOOR-UNAVAILABLE-READONLY",
+          "CV-MEMPOOL-RELAY-METADATA-03-DA-FLOOR-REJECTED-READONLY",
+          "CV-MEMPOOL-RELAY-METADATA-04-MALFORMED-PARSE-FIRST-READONLY"
+        ]
+      },
+      "coverage_accounting": {
+        "proof_coverage_domain": "mempool_policy"
+      }
+    },
+    {
+      "name": "da_fee_floor",
+      "gates": [
+        "CV-DA-FEE-FLOOR"
+      ],
+      "min_vectors_total": 20,
+      "required_vectors_by_gate": {
+        "CV-DA-FEE-FLOOR": [
+          "CV-DA-FEE-FLOOR-01-DA-EXACT",
+          "CV-DA-FEE-FLOOR-02-DA-UNDER",
+          "CV-DA-FEE-FLOOR-03-DA-ABOVE",
+          "CV-DA-FEE-FLOOR-04-RELAY-DOMINANT-UNDER",
+          "CV-DA-FEE-FLOOR-05-MIN-PLUS-SURCHARGE-EXACT",
+          "CV-DA-FEE-FLOOR-06-MIN-PLUS-SURCHARGE-UNDER",
+          "CV-DA-FEE-FLOOR-07-DA-FLOOR-OVERFLOW",
+          "CV-DA-FEE-FLOOR-08-NON-DA-RELAY-PASS",
+          "CV-DA-FEE-FLOOR-09-RELAY-DOMINANT-BELOW-BOTH",
+          "CV-DA-FEE-FLOOR-10-RELAY-DOMINANT-EXACT",
+          "CV-DA-FEE-FLOOR-11-TIE-UNDER",
+          "CV-DA-FEE-FLOOR-12-RELAY-FLOOR-OVERFLOW",
+          "CV-DA-FEE-FLOOR-13-DA-SURCHARGE-OVERFLOW",
+          "CV-DA-FEE-FLOOR-14-DA-REQUIRED-FEE-OVERFLOW",
+          "CV-DA-FEE-FLOOR-15-ZERO-MIN-SURCHARGE-EXACT",
+          "CV-DA-FEE-FLOOR-16-TIE-EXACT",
+          "CV-DA-FEE-FLOOR-17-DA-ZERO-REQUIRED-SKIPS-FEE",
+          "CV-DA-FEE-FLOOR-18-NON-DA-SKIPS-FEE",
+          "CV-DA-FEE-FLOOR-19-OMITTED-CURRENT-FLOOR-DEFAULT",
+          "CV-DA-FEE-FLOOR-20-MALFORMED-TX-PARSE-FIRST"
+        ]
+      },
+      "coverage_accounting": {
+        "proof_coverage_domain": "da_fee_floor"
       }
     }
   ]

--- a/conformance/EDGE_PACK_BASELINE.json
+++ b/conformance/EDGE_PACK_BASELINE.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "description": "Machine-readable baseline for critical conformance edge coverage across parse/weight/sighash/covenants/difficulty/DA/mempool policy domains.",
+  "description": "Machine-readable baseline for critical conformance edge coverage across parse/weight/sighash/covenants/difficulty/DA integrity/mempool policy/DA fee-floor policy domains.",
   "domains": [
     {
       "name": "parse",

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -50,17 +50,18 @@ scripts/dev-env.sh -- python3 tools/gen_conformance_matrix.py --check
 
 ## Error expectation fields in vectors
 
-Для большинства ops используется поле `expect_err`: это ожидаемый финальный код ошибки,
-который вернёт runtime для данного вектора.
+Most ops use the `expect_err` field: the expected final error code returned by
+the runtime for that vector.
 
-Для gate `CV-VALIDATION-ORDER` используется отдельное поле `expect_first_err`: это ожидаемый
-**первый** код ошибки по deterministic-order симулятору (nested/conflict cases).  
-Итоговый runtime-ошибочный код (`expect_err`) и `expect_first_err` могут отличаться по дизайну.
+The `CV-VALIDATION-ORDER` gate uses a separate `expect_first_err` field: the
+expected **first** error code from the deterministic-order simulator
+(nested/conflict cases). The final runtime error code (`expect_err`) and
+`expect_first_err` may intentionally differ.
 
 ## Edge-pack baseline (critical domains)
 
-`conformance/EDGE_PACK_BASELINE.json` фиксирует минимально требуемое edge-покрытие
-по доменам:
+`conformance/EDGE_PACK_BASELINE.json` pins the minimum required edge coverage
+by domain:
 
 - parse
 - weight
@@ -77,7 +78,7 @@ coverage. `tools/check_conformance_edge_pack.py` fails closed on fuzz/formal
 `present`, `covered`, or `complete` claims until a later PR adds concrete
 evidence validation.
 
-Проверка (локально/CI):
+Local/CI check:
 
 ```bash
 scripts/dev-env.sh -- python3 tools/check_conformance_edge_pack.py
@@ -95,17 +96,17 @@ The gate fails when:
 
 `clients/go/cmd/gen-conformance-fixtures` — **manual-only tool**.
 
-Правила:
+Rules:
 
-1. Mutating-режим генератора **НЕ** запускается из CI (ни в `ci.yml`, ни в других workflow).
-2. Регенерация fixtures выполняется вручную локально через reproducible env:
+1. The generator mutating mode **MUST NOT** run from CI (`ci.yml` or any other workflow).
+2. Fixture regeneration is manual-only through the reproducible env:
    - `scripts/dev-env.sh -- bash -lc 'cd clients/go && go run ./cmd/gen-conformance-fixtures'`
-3. Любое изменение `conformance/fixtures/CV-*.json` обязано сопровождаться обновлением
-   `conformance/fixtures/CHANGELOG.md` (что изменили, зачем, каким инструментом).
-4. Для точечных deterministic fixtures допускается отдельный генератор:
+3. Any change to `conformance/fixtures/CV-*.json` must update
+   `conformance/fixtures/CHANGELOG.md` with what changed, why, and which tool was used.
+4. Focused deterministic fixtures may use a dedicated generator:
    - `scripts/dev-env.sh -- python3 tools/gen_cv_da_integrity.py`
 
-Guard-проверка (CI):
+CI guard:
 
 ```bash
 scripts/dev-env.sh -- python3 tools/check_conformance_fixtures_policy.py
@@ -113,29 +114,29 @@ scripts/dev-env.sh -- python3 tools/check_conformance_fixtures_policy.py
 
 ### Check-only `--output-dir` mode
 
-`gen-conformance-fixtures` поддерживает non-mutating режим: при передаче
-абсолютного `--output-dir <path>` генератор пишет candidate fixtures
-**только** под `<path>`, не трогая `conformance/fixtures/**`. Источник
-данных по-прежнему читается из committed `conformance/fixtures/**`.
+`gen-conformance-fixtures` supports a non-mutating mode: with an absolute
+`--output-dir <path>`, the generator writes candidate fixtures **only** under
+`<path>` and does not touch `conformance/fixtures/**`. Source data is still read
+from committed `conformance/fixtures/**`.
 
 ```bash
 scripts/dev-env.sh -- bash -lc \
   'cd clients/go && go run ./cmd/gen-conformance-fixtures --output-dir /tmp/candidate-fixtures'
 ```
 
-Свойства check-only режима:
+Check-only mode properties:
 
-- ML-DSA-87 ключи deterministic, embedded под `clients/go/cmd/gen-conformance-fixtures/testdata/keys/*.der`
-  (committed conformance test material, не production keys);
-- подпись через `(*consensus.MLDSA87Keypair).SignDigest32ForConformanceFixture`
-  (FIPS 204 deterministic ML-DSA); package-level caller-grep guard
-  в `consensus/openssl_signer_conformance_fixture_test.go` ограничивает
-  использование этим генератором;
-- два прогона с разными `--output-dir` дают **byte-identical** результат
+- ML-DSA-87 keys are deterministic and embedded under
+  `clients/go/cmd/gen-conformance-fixtures/testdata/keys/*.der`
+  (committed conformance test material, not production keys);
+- signing uses `(*consensus.MLDSA87Keypair).SignDigest32ForConformanceFixture`
+  (FIPS 204 deterministic ML-DSA); the package-level caller-grep guard in
+  `consensus/openssl_signer_conformance_fixture_test.go` restricts use to this generator;
+- two runs with different `--output-dir` values produce **byte-identical** output
   (`TestGenerator_DeterministicOutputDir`);
-- `--output-dir` обязан быть абсолютным; запрет указывать committed
-  `conformance/fixtures` или путь под ним;
-- production signing path (`SignDigest32`, hedged ML-DSA) **не** меняется.
+- `--output-dir` must be absolute; committed `conformance/fixtures` and paths
+  under it are forbidden;
+- the production signing path (`SignDigest32`, hedged ML-DSA) **does not** change.
 
 CI drift gate (`Q-CONF-FIXTURE-DRIFT-CHECK-01`):
 
@@ -143,12 +144,12 @@ CI drift gate (`Q-CONF-FIXTURE-DRIFT-CHECK-01`):
 scripts/dev-env.sh -- python3 tools/check_conformance_fixtures_drift.py
 ```
 
-Скрипт запускает `gen-conformance-fixtures --output-dir <isolated-temp>`,
-а затем побайтово сравнивает каждый сгенерированный файл с committed
-`conformance/fixtures/**`. Exit `0` — без drift, exit `1` — drift, exit
-`2` — usage / environment ошибка. Скрипт **никогда** не пишет под
-`conformance/fixtures/**` (auto-regen в CI запрещён); ручная
-регенерация остаётся authoritative path.
+The script runs `gen-conformance-fixtures --output-dir <isolated-temp>`, then
+byte-compares every generated file with committed `conformance/fixtures/**`.
+Exit `0` means no drift, exit `1` means drift, and exit `2` means usage or
+environment error. The script **never** writes under `conformance/fixtures/**`
+(auto-regeneration in CI is forbidden); manual regeneration remains the
+authoritative path.
 
 ## Fuzz crash promotion (manual-only)
 

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -73,7 +73,8 @@ scripts/dev-env.sh -- python3 tools/gen_conformance_matrix.py --check
 
 Mempool/DA fee-floor domains are accounting-only here: they cite committed
 executable CV vector IDs and replay evidence, but do not claim fuzz or formal
-coverage until a committed fuzz target or formal proof exists.
+coverage. `tools/check_conformance_edge_pack.py` fails closed on fuzz/formal
+`present` claims until a later PR adds concrete evidence validation.
 
 Проверка (локально/CI):
 
@@ -87,7 +88,7 @@ Gate падает если:
 - общее число векторов в домене ниже baseline;
 - отсутствуют обязательные edge vector IDs из baseline.
 - `proof_coverage.json` claims fuzz/formal coverage for an edge/property domain
-  without committed matching evidence.
+  before the checker supports concrete evidence validation.
 
 ## Fixture governance (manual-only)
 

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -74,7 +74,8 @@ scripts/dev-env.sh -- python3 tools/gen_conformance_matrix.py --check
 Mempool/DA fee-floor domains are accounting-only here: they cite committed
 executable CV vector IDs and replay evidence, but do not claim fuzz or formal
 coverage. `tools/check_conformance_edge_pack.py` fails closed on fuzz/formal
-`present` claims until a later PR adds concrete evidence validation.
+`present`, `covered`, or `complete` claims until a later PR adds concrete
+evidence validation.
 
 Проверка (локально/CI):
 

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -68,6 +68,12 @@ scripts/dev-env.sh -- python3 tools/gen_conformance_matrix.py --check
 - covenants
 - difficulty
 - DA
+- mempool policy
+- DA fee-floor policy
+
+Mempool/DA fee-floor domains are accounting-only here: they cite committed
+executable CV vector IDs and replay evidence, but do not claim fuzz or formal
+coverage until a committed fuzz target or formal proof exists.
 
 Проверка (локально/CI):
 
@@ -80,6 +86,8 @@ Gate падает если:
 - отсутствует обязательный gate/fixture для домена;
 - общее число векторов в домене ниже baseline;
 - отсутствуют обязательные edge vector IDs из baseline.
+- `proof_coverage.json` claims fuzz/formal coverage for an edge/property domain
+  without committed matching evidence.
 
 ## Fixture governance (manual-only)
 

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -83,13 +83,13 @@ evidence validation.
 scripts/dev-env.sh -- python3 tools/check_conformance_edge_pack.py
 ```
 
-Gate падает если:
+The gate fails when:
 
-- отсутствует обязательный gate/fixture для домена;
-- общее число векторов в домене ниже baseline;
-- отсутствуют обязательные edge vector IDs из baseline;
-- `proof_coverage.json` заявляет fuzz/formal coverage для edge/property-домена
-  до того, как checker начнёт поддерживать валидацию конкретных evidence.
+- a required domain gate or fixture is missing;
+- a domain vector count is below the baseline;
+- required edge vector IDs from the baseline are missing;
+- `proof_coverage.json` claims fuzz/formal coverage for an edge/property domain
+  before the checker supports concrete evidence validation.
 
 ## Fixture governance (manual-only)
 

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -87,9 +87,9 @@ Gate падает если:
 
 - отсутствует обязательный gate/fixture для домена;
 - общее число векторов в домене ниже baseline;
-- отсутствуют обязательные edge vector IDs из baseline.
-- `proof_coverage.json` claims fuzz/formal coverage for an edge/property domain
-  before the checker supports concrete evidence validation.
+- отсутствуют обязательные edge vector IDs из baseline;
+- `proof_coverage.json` заявляет fuzz/formal coverage для edge/property-домена
+  до того, как checker начнёт поддерживать валидацию конкретных evidence.
 
 ## Fixture governance (manual-only)
 

--- a/proof_coverage.json
+++ b/proof_coverage.json
@@ -305,5 +305,83 @@
         "stage": 2
       }
     ]
-  }
+  },
+  "edge_property_domains": [
+    {
+      "name": "mempool_policy",
+      "conformance_gates": [
+        "CV-MEMPOOL"
+      ],
+      "vector_ids": [
+        "CV-MEMPOOL-01-ROLLING-FLOOR-ACCEPTED",
+        "CV-MEMPOOL-02-ROLLING-FLOOR-UNAVAILABLE",
+        "CV-MEMPOOL-03-DA-FLOOR-REJECTED",
+        "CV-MEMPOOL-04-DA-FLOOR-ACCEPTED",
+        "CV-MEMPOOL-05-OMITTED-CURRENT-FLOOR-DEFAULT",
+        "CV-MEMPOOL-06-MALFORMED-TX-PARSE-FIRST",
+        "CV-MEMPOOL-RELAY-METADATA-01-ACCEPTED-READONLY",
+        "CV-MEMPOOL-RELAY-METADATA-02-ROLLING-FLOOR-UNAVAILABLE-READONLY",
+        "CV-MEMPOOL-RELAY-METADATA-03-DA-FLOOR-REJECTED-READONLY",
+        "CV-MEMPOOL-RELAY-METADATA-04-MALFORMED-PARSE-FIRST-READONLY"
+      ],
+      "conformance_replay": {
+        "status": "present",
+        "command": "scripts/dev-env.sh -- python3 conformance/runner/run_cv_bundle.py --only-gates CV-MEMPOOL",
+        "evidence_source": "RUB-191 closeout on origin/main@79df40a942456abf432664a30c1911703f3545bb"
+      },
+      "go_rust_replay": "present",
+      "fuzz": {
+        "status": "deferred",
+        "issue": "RUB-129",
+        "reason": "No committed fuzz/property target for mempool_policy in this accounting PR."
+      },
+      "formal": {
+        "status": "not_claimed",
+        "reason": "No formal theorem/proof bridge is added or claimed for mempool_policy here."
+      }
+    },
+    {
+      "name": "da_fee_floor",
+      "conformance_gates": [
+        "CV-DA-FEE-FLOOR"
+      ],
+      "vector_ids": [
+        "CV-DA-FEE-FLOOR-01-DA-EXACT",
+        "CV-DA-FEE-FLOOR-02-DA-UNDER",
+        "CV-DA-FEE-FLOOR-03-DA-ABOVE",
+        "CV-DA-FEE-FLOOR-04-RELAY-DOMINANT-UNDER",
+        "CV-DA-FEE-FLOOR-05-MIN-PLUS-SURCHARGE-EXACT",
+        "CV-DA-FEE-FLOOR-06-MIN-PLUS-SURCHARGE-UNDER",
+        "CV-DA-FEE-FLOOR-07-DA-FLOOR-OVERFLOW",
+        "CV-DA-FEE-FLOOR-08-NON-DA-RELAY-PASS",
+        "CV-DA-FEE-FLOOR-09-RELAY-DOMINANT-BELOW-BOTH",
+        "CV-DA-FEE-FLOOR-10-RELAY-DOMINANT-EXACT",
+        "CV-DA-FEE-FLOOR-11-TIE-UNDER",
+        "CV-DA-FEE-FLOOR-12-RELAY-FLOOR-OVERFLOW",
+        "CV-DA-FEE-FLOOR-13-DA-SURCHARGE-OVERFLOW",
+        "CV-DA-FEE-FLOOR-14-DA-REQUIRED-FEE-OVERFLOW",
+        "CV-DA-FEE-FLOOR-15-ZERO-MIN-SURCHARGE-EXACT",
+        "CV-DA-FEE-FLOOR-16-TIE-EXACT",
+        "CV-DA-FEE-FLOOR-17-DA-ZERO-REQUIRED-SKIPS-FEE",
+        "CV-DA-FEE-FLOOR-18-NON-DA-SKIPS-FEE",
+        "CV-DA-FEE-FLOOR-19-OMITTED-CURRENT-FLOOR-DEFAULT",
+        "CV-DA-FEE-FLOOR-20-MALFORMED-TX-PARSE-FIRST"
+      ],
+      "conformance_replay": {
+        "status": "present",
+        "command": "scripts/dev-env.sh -- python3 conformance/runner/run_cv_bundle.py --only-gates CV-DA-FEE-FLOOR",
+        "evidence_source": "RUB-191 closeout on origin/main@79df40a942456abf432664a30c1911703f3545bb"
+      },
+      "go_rust_replay": "present",
+      "fuzz": {
+        "status": "deferred",
+        "issue": "RUB-129",
+        "reason": "No committed fuzz/property target for da_fee_floor in this accounting PR."
+      },
+      "formal": {
+        "status": "not_claimed",
+        "reason": "No formal theorem/proof bridge is added or claimed for da_fee_floor here."
+      }
+    }
+  ]
 }

--- a/tools/check_conformance_edge_pack.py
+++ b/tools/check_conformance_edge_pack.py
@@ -14,8 +14,11 @@ def fail(msg: str) -> int:
     return 1
 
 
-def load_json(path: Path) -> object:
-    return json.loads(path.read_text(encoding="utf-8"))
+def load_json(path: Path, *, label: str) -> object:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"{label} must contain valid JSON: {exc}") from exc
 
 
 def json_object(value: object, *, label: str) -> dict:
@@ -83,8 +86,8 @@ def main() -> int:
         return fail("proof_coverage.json not found")
 
     try:
-        baseline = json_object(load_json(baseline_path), label="EDGE_PACK_BASELINE.json")
-        proof_coverage = json_object(load_json(proof_coverage_path), label="proof_coverage.json")
+        baseline = json_object(load_json(baseline_path, label="EDGE_PACK_BASELINE.json"), label="EDGE_PACK_BASELINE.json")
+        proof_coverage = json_object(load_json(proof_coverage_path, label="proof_coverage.json"), label="proof_coverage.json")
         proof_domains = proof_domain_map(proof_coverage)
     except ValueError as exc:
         return fail(str(exc))
@@ -100,7 +103,8 @@ def main() -> int:
     fixture_gate_to_count: dict[str, int] = {}
     for fixture in fixtures_dir.glob("CV-*.json"):
         try:
-            data = json_object(load_json(fixture), label=str(fixture.relative_to(repo_root)))
+            fixture_label = str(fixture.relative_to(repo_root))
+            data = json_object(load_json(fixture, label=fixture_label), label=fixture_label)
         except ValueError as exc:
             return fail(str(exc))
         gate = data.get("gate")

--- a/tools/check_conformance_edge_pack.py
+++ b/tools/check_conformance_edge_pack.py
@@ -5,6 +5,9 @@ import json
 import sys
 from pathlib import Path
 
+CLAIMED_PRESENT_STATUSES = {"present", "covered", "complete"}
+KNOWN_ABSENT_STATUSES = {"absent", "deferred", "not_claimed", "not-applicable", "not_applicable"}
+
 
 def fail(msg: str) -> int:
     print(f"ERROR: {msg}", file=sys.stderr)
@@ -15,17 +18,78 @@ def load_json(path: Path) -> dict:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+def proof_domain_map(proof_coverage: dict) -> dict[str, dict]:
+    domains = proof_coverage.get("edge_property_domains", [])
+    if not isinstance(domains, list):
+        raise ValueError("proof_coverage.json edge_property_domains must be a list")
+    result: dict[str, dict] = {}
+    for domain in domains:
+        if not isinstance(domain, dict):
+            raise ValueError("proof_coverage.json edge_property_domains entries must be objects")
+        name = domain.get("name")
+        if not isinstance(name, str) or not name:
+            raise ValueError("proof_coverage.json edge_property_domains entries need non-empty name")
+        if name in result:
+            raise ValueError(f"proof_coverage.json duplicate edge_property_domain: {name}")
+        result[name] = domain
+    return result
+
+
+def fuzz_gates(proof_coverage: dict) -> set[str]:
+    gates: set[str] = set()
+    for section in ("fuzz", "go_fuzz"):
+        targets = proof_coverage.get(section, {}).get("targets", [])
+        if not isinstance(targets, list):
+            continue
+        for target in targets:
+            if not isinstance(target, dict):
+                continue
+            gate = target.get("conformance_gate")
+            if isinstance(gate, str) and gate:
+                gates.add(gate)
+    return gates
+
+
+def status_of(value: object) -> str:
+    if not isinstance(value, dict):
+        return ""
+    status = value.get("status")
+    return status if isinstance(status, str) else ""
+
+
+def string_list(value: object, *, field_name: str) -> tuple[list[str], str | None]:
+    if not isinstance(value, list):
+        return [], f"{field_name} must be list"
+    strings: list[str] = []
+    for item in value:
+        if not isinstance(item, str) or not item:
+            return [], f"{field_name} entries must be non-empty strings"
+        strings.append(item)
+    if len(set(strings)) != len(strings):
+        return [], f"{field_name} entries must be unique"
+    return strings, None
+
+
 def main() -> int:
     repo_root = Path(".").resolve()
     baseline_path = repo_root / "conformance" / "EDGE_PACK_BASELINE.json"
     fixtures_dir = repo_root / "conformance" / "fixtures"
+    proof_coverage_path = repo_root / "proof_coverage.json"
 
     if not baseline_path.exists():
         return fail("conformance/EDGE_PACK_BASELINE.json not found")
     if not fixtures_dir.exists():
         return fail("conformance/fixtures directory not found")
+    if not proof_coverage_path.exists():
+        return fail("proof_coverage.json not found")
 
     baseline = load_json(baseline_path)
+    proof_coverage = load_json(proof_coverage_path)
+    try:
+        proof_domains = proof_domain_map(proof_coverage)
+    except ValueError as exc:
+        return fail(str(exc))
+    committed_fuzz_gates = fuzz_gates(proof_coverage)
     if baseline.get("schema_version") != 1:
         return fail("EDGE_PACK_BASELINE.json schema_version must be 1")
 
@@ -65,6 +129,7 @@ def main() -> int:
         gates = domain.get("gates")
         min_vectors_total = domain.get("min_vectors_total")
         required_vectors_by_gate = domain.get("required_vectors_by_gate", {})
+        coverage_accounting = domain.get("coverage_accounting")
 
         if not isinstance(name, str) or not name:
             print("ERROR: domain name missing/invalid", file=sys.stderr)
@@ -82,14 +147,20 @@ def main() -> int:
             print(f"ERROR: domain {name}: required_vectors_by_gate must be object", file=sys.stderr)
             failures += 1
             continue
+        if coverage_accounting is not None and not isinstance(coverage_accounting, dict):
+            print(f"ERROR: domain {name}: coverage_accounting must be object", file=sys.stderr)
+            failures += 1
+            continue
 
         total = 0
         missing_gates: list[str] = []
+        gate_names: list[str] = []
         for gate in gates:
             if not isinstance(gate, str) or not gate:
                 print(f"ERROR: domain {name}: gate entry must be non-empty string", file=sys.stderr)
                 failures += 1
                 continue
+            gate_names.append(gate)
             if gate not in fixture_gate_to_count:
                 missing_gates.append(gate)
                 continue
@@ -123,6 +194,108 @@ def main() -> int:
                     file=sys.stderr,
                 )
                 failures += 1
+
+        if coverage_accounting is not None:
+            proof_domain_name = coverage_accounting.get("proof_coverage_domain")
+            if not isinstance(proof_domain_name, str) or not proof_domain_name:
+                print(
+                    f"ERROR: domain {name}: coverage_accounting.proof_coverage_domain must be non-empty string",
+                    file=sys.stderr,
+                )
+                failures += 1
+            elif proof_domain_name not in proof_domains:
+                print(
+                    f"FAIL: domain {name}: missing proof_coverage edge_property_domain {proof_domain_name}",
+                    file=sys.stderr,
+                )
+                failures += 1
+            else:
+                proof_domain = proof_domains[proof_domain_name]
+                proof_gates, proof_gates_error = string_list(
+                    proof_domain.get("conformance_gates"),
+                    field_name="proof_coverage conformance_gates",
+                )
+                if proof_gates_error is not None:
+                    print(
+                        f"ERROR: domain {name}: {proof_gates_error}",
+                        file=sys.stderr,
+                    )
+                    failures += 1
+                elif sorted(proof_gates) != sorted(gate_names):
+                    print(
+                        f"FAIL: domain {name}: proof_coverage gates do not match EDGE baseline gates",
+                        file=sys.stderr,
+                    )
+                    failures += 1
+                proof_vector_ids, proof_vector_ids_error = string_list(
+                    proof_domain.get("vector_ids"),
+                    field_name="proof_coverage vector_ids",
+                )
+                if proof_vector_ids_error is not None:
+                    print(
+                        f"ERROR: domain {name}: {proof_vector_ids_error}",
+                        file=sys.stderr,
+                    )
+                    failures += 1
+                else:
+                    present_for_domain: set[str] = set()
+                    for gate in gate_names:
+                        present_for_domain.update(fixture_gate_to_ids.get(gate, set()))
+                    missing_proof_ids = [
+                        vid
+                        for vid in proof_vector_ids
+                        if isinstance(vid, str) and vid not in present_for_domain
+                    ]
+                    if missing_proof_ids:
+                        print(
+                            f"FAIL: domain {name}: proof_coverage references missing vector IDs: {', '.join(missing_proof_ids)}",
+                            file=sys.stderr,
+                        )
+                        failures += 1
+                    for gate, required_ids in required_vectors_by_gate.items():
+                        if not isinstance(required_ids, list):
+                            continue
+                        missing_from_proof = [
+                            rid for rid in required_ids if isinstance(rid, str) and rid not in proof_vector_ids
+                        ]
+                        if missing_from_proof:
+                            print(
+                                f"FAIL: domain {name}: proof_coverage missing vector IDs: {', '.join(missing_from_proof)}",
+                                file=sys.stderr,
+                            )
+                            failures += 1
+
+                fuzz_status = status_of(proof_domain.get("fuzz"))
+                if fuzz_status in CLAIMED_PRESENT_STATUSES:
+                    missing_fuzz_gates = [gate for gate in gate_names if gate not in committed_fuzz_gates]
+                    if missing_fuzz_gates:
+                        print(
+                            f"FAIL: domain {name}: proof_coverage claims fuzz={fuzz_status} without committed fuzz target for gates: {', '.join(missing_fuzz_gates)}",
+                            file=sys.stderr,
+                        )
+                        failures += 1
+                elif fuzz_status and fuzz_status not in KNOWN_ABSENT_STATUSES:
+                    print(
+                        f"ERROR: domain {name}: unknown fuzz coverage status {fuzz_status}",
+                        file=sys.stderr,
+                    )
+                    failures += 1
+
+                formal_status = status_of(proof_domain.get("formal"))
+                if formal_status in CLAIMED_PRESENT_STATUSES:
+                    formal_evidence = proof_domain.get("formal_evidence", [])
+                    if not isinstance(formal_evidence, list) or not formal_evidence:
+                        print(
+                            f"FAIL: domain {name}: proof_coverage claims formal={formal_status} without formal_evidence",
+                            file=sys.stderr,
+                        )
+                        failures += 1
+                elif formal_status and formal_status not in KNOWN_ABSENT_STATUSES:
+                    print(
+                        f"ERROR: domain {name}: unknown formal coverage status {formal_status}",
+                        file=sys.stderr,
+                    )
+                    failures += 1
 
         print(f"OK: domain {name} total_vectors={total} min={min_vectors_total}")
 

--- a/tools/check_conformance_edge_pack.py
+++ b/tools/check_conformance_edge_pack.py
@@ -89,6 +89,7 @@ def main() -> int:
     if not isinstance(domains, list) or not domains:
         return fail("EDGE_PACK_BASELINE.json must contain non-empty domains list")
 
+    seen_domain_names: set[str] = set()
     fixture_gate_to_ids: dict[str, set[str]] = {}
     fixture_gate_to_count: dict[str, int] = {}
     for fixture in fixtures_dir.glob("CV-*.json"):
@@ -127,8 +128,14 @@ def main() -> int:
             print("ERROR: domain name missing/invalid", file=sys.stderr)
             failures += 1
             continue
-        if not isinstance(gates, list) or not gates:
-            print(f"ERROR: domain {name}: gates must be non-empty list", file=sys.stderr)
+        if name in seen_domain_names:
+            print(f"ERROR: duplicate domain name: {name}", file=sys.stderr)
+            failures += 1
+            continue
+        seen_domain_names.add(name)
+        gate_names, gate_names_error = string_list(gates, field_name=f"domain {name} gates", require_non_empty=True)
+        if gate_names_error is not None:
+            print(f"ERROR: domain {name}: {gate_names_error}", file=sys.stderr)
             failures += 1
             continue
         if not isinstance(min_vectors_total, int) or min_vectors_total < 0:
@@ -146,13 +153,7 @@ def main() -> int:
 
         total = 0
         missing_gates: list[str] = []
-        gate_names: list[str] = []
         for gate in gates:
-            if not isinstance(gate, str) or not gate:
-                print(f"ERROR: domain {name}: gate entry must be non-empty string", file=sys.stderr)
-                failures += 1
-                continue
-            gate_names.append(gate)
             if gate not in fixture_gate_to_count:
                 missing_gates.append(gate)
                 continue

--- a/tools/check_conformance_edge_pack.py
+++ b/tools/check_conformance_edge_pack.py
@@ -36,7 +36,7 @@ def proof_domain_map(proof_coverage: dict) -> dict[str, dict]:
         if not isinstance(domain, dict):
             raise ValueError("proof_coverage.json edge_property_domains entries must be objects")
         name = domain.get("name")
-        if not isinstance(name, str) or not name:
+        if not isinstance(name, str) or not name.strip():
             raise ValueError("proof_coverage.json edge_property_domains entries need non-empty name")
         if name in result:
             raise ValueError(f"proof_coverage.json duplicate edge_property_domain: {name}")
@@ -52,7 +52,7 @@ def coverage_status(value: object, *, field_name: str, field_present: bool) -> t
     if "status" not in value:
         return "", f"{field_name}.status must be present when {field_name} is present"
     status = value.get("status")
-    if not isinstance(status, str) or not status:
+    if not isinstance(status, str) or not status.strip():
         return "", f"{field_name}.status must be non-empty string"
     return status, None
 
@@ -64,7 +64,7 @@ def string_list(value: object, *, field_name: str, require_non_empty: bool = Fal
         return [], f"{field_name} must be non-empty list"
     strings: list[str] = []
     for item in value:
-        if not isinstance(item, str) or not item:
+        if not isinstance(item, str) or not item.strip():
             return [], f"{field_name} entries must be non-empty strings"
         strings.append(item)
     if len(set(strings)) != len(strings):
@@ -109,7 +109,7 @@ def main() -> int:
             return fail(str(exc))
         gate = data.get("gate")
         vectors = data.get("vectors", [])
-        if not isinstance(gate, str) or not gate:
+        if not isinstance(gate, str) or not gate.strip():
             return fail(f"{fixture.relative_to(repo_root)} has invalid gate")
         if not isinstance(vectors, list):
             return fail(f"{fixture.relative_to(repo_root)} vectors must be a list")
@@ -138,7 +138,7 @@ def main() -> int:
         required_vectors_by_gate = domain.get("required_vectors_by_gate", {})
         coverage_accounting = domain.get("coverage_accounting")
 
-        if not isinstance(name, str) or not name:
+        if not isinstance(name, str) or not name.strip():
             print("ERROR: domain name missing/invalid", file=sys.stderr)
             failures += 1
             continue
@@ -167,7 +167,7 @@ def main() -> int:
 
         total = 0
         missing_gates: list[str] = []
-        for gate in gates:
+        for gate in gate_names:
             if gate not in fixture_gate_to_count:
                 missing_gates.append(gate)
                 continue
@@ -185,6 +185,10 @@ def main() -> int:
             failures += 1
 
         for gate, raw_required_ids in required_vectors_by_gate.items():
+            if not isinstance(gate, str) or not gate.strip():
+                print(f"ERROR: domain {name}: required_vectors_by_gate keys must be non-empty strings", file=sys.stderr)
+                failures += 1
+                continue
             if gate not in fixture_gate_to_ids:
                 print(f"FAIL: domain {name}: required gate not found: {gate}", file=sys.stderr)
                 failures += 1
@@ -209,7 +213,7 @@ def main() -> int:
 
         if coverage_accounting is not None:
             proof_domain_name = coverage_accounting.get("proof_coverage_domain")
-            if not isinstance(proof_domain_name, str) or not proof_domain_name:
+            if not isinstance(proof_domain_name, str) or not proof_domain_name.strip():
                 print(
                     f"ERROR: domain {name}: coverage_accounting.proof_coverage_domain must be non-empty string",
                     file=sys.stderr,
@@ -265,6 +269,8 @@ def main() -> int:
                         )
                         failures += 1
                     for gate, raw_required_ids in required_vectors_by_gate.items():
+                        if not isinstance(gate, str) or not gate.strip():
+                            continue
                         required_ids, required_ids_error = string_list(
                             raw_required_ids,
                             field_name=f"required_vectors_by_gate[{gate}]",

--- a/tools/check_conformance_edge_pack.py
+++ b/tools/check_conformance_edge_pack.py
@@ -35,16 +35,24 @@ def proof_domain_map(proof_coverage: dict) -> dict[str, dict]:
     return result
 
 
-def status_of(value: object) -> str:
+def coverage_status(value: object, *, field_name: str) -> tuple[str, str | None]:
+    if value is None:
+        return "", None
     if not isinstance(value, dict):
-        return ""
+        return "", f"{field_name} must be object"
     status = value.get("status")
-    return status if isinstance(status, str) else ""
+    if status is None:
+        return "", None
+    if not isinstance(status, str) or not status:
+        return "", f"{field_name}.status must be non-empty string"
+    return status, None
 
 
-def string_list(value: object, *, field_name: str) -> tuple[list[str], str | None]:
+def string_list(value: object, *, field_name: str, require_non_empty: bool = False) -> tuple[list[str], str | None]:
     if not isinstance(value, list):
         return [], f"{field_name} must be list"
+    if require_non_empty and not value:
+        return [], f"{field_name} must be non-empty list"
     strings: list[str] = []
     for item in value:
         if not isinstance(item, str) or not item:
@@ -161,17 +169,22 @@ def main() -> int:
             )
             failures += 1
 
-        for gate, required_ids in required_vectors_by_gate.items():
+        for gate, raw_required_ids in required_vectors_by_gate.items():
             if gate not in fixture_gate_to_ids:
                 print(f"FAIL: domain {name}: required gate not found: {gate}", file=sys.stderr)
                 failures += 1
                 continue
-            if not isinstance(required_ids, list):
-                print(f"ERROR: domain {name}: required_vectors_by_gate[{gate}] must be list", file=sys.stderr)
+            required_ids, required_ids_error = string_list(
+                raw_required_ids,
+                field_name=f"required_vectors_by_gate[{gate}]",
+                require_non_empty=True,
+            )
+            if required_ids_error is not None:
+                print(f"ERROR: domain {name}: {required_ids_error}", file=sys.stderr)
                 failures += 1
                 continue
             present = fixture_gate_to_ids[gate]
-            missing = [rid for rid in required_ids if isinstance(rid, str) and rid not in present]
+            missing = [rid for rid in required_ids if rid not in present]
             if missing:
                 print(
                     f"FAIL: domain {name}: gate {gate} missing required vectors: {', '.join(missing)}",
@@ -236,12 +249,15 @@ def main() -> int:
                             file=sys.stderr,
                         )
                         failures += 1
-                    for gate, required_ids in required_vectors_by_gate.items():
-                        if not isinstance(required_ids, list):
+                    for gate, raw_required_ids in required_vectors_by_gate.items():
+                        required_ids, required_ids_error = string_list(
+                            raw_required_ids,
+                            field_name=f"required_vectors_by_gate[{gate}]",
+                            require_non_empty=True,
+                        )
+                        if required_ids_error is not None:
                             continue
-                        missing_from_proof = [
-                            rid for rid in required_ids if isinstance(rid, str) and rid not in proof_vector_ids
-                        ]
+                        missing_from_proof = [rid for rid in required_ids if rid not in proof_vector_ids]
                         if missing_from_proof:
                             print(
                                 f"FAIL: domain {name}: proof_coverage missing vector IDs: {', '.join(missing_from_proof)}",
@@ -249,8 +265,14 @@ def main() -> int:
                             )
                             failures += 1
 
-                fuzz_status = status_of(proof_domain.get("fuzz"))
-                if fuzz_status in CLAIMED_PRESENT_STATUSES:
+                fuzz_status, fuzz_status_error = coverage_status(
+                    proof_domain.get("fuzz"),
+                    field_name="proof_coverage fuzz",
+                )
+                if fuzz_status_error is not None:
+                    print(f"ERROR: domain {name}: {fuzz_status_error}", file=sys.stderr)
+                    failures += 1
+                elif fuzz_status in CLAIMED_PRESENT_STATUSES:
                     print(
                         f"FAIL: domain {name}: proof_coverage claims fuzz={fuzz_status}; committed fuzz evidence validation is not supported in this edge-pack checker",
                         file=sys.stderr,
@@ -263,8 +285,14 @@ def main() -> int:
                     )
                     failures += 1
 
-                formal_status = status_of(proof_domain.get("formal"))
-                if formal_status in CLAIMED_PRESENT_STATUSES:
+                formal_status, formal_status_error = coverage_status(
+                    proof_domain.get("formal"),
+                    field_name="proof_coverage formal",
+                )
+                if formal_status_error is not None:
+                    print(f"ERROR: domain {name}: {formal_status_error}", file=sys.stderr)
+                    failures += 1
+                elif formal_status in CLAIMED_PRESENT_STATUSES:
                     print(
                         f"FAIL: domain {name}: proof_coverage claims formal={formal_status}; committed formal evidence validation is not supported in this edge-pack checker",
                         file=sys.stderr,

--- a/tools/check_conformance_edge_pack.py
+++ b/tools/check_conformance_edge_pack.py
@@ -2,22 +2,11 @@
 from __future__ import annotations
 
 import json
-import re
 import sys
 from pathlib import Path
 
 CLAIMED_PRESENT_STATUSES = {"present", "covered", "complete"}
 KNOWN_ABSENT_STATUSES = {"absent", "deferred", "not_claimed", "not-applicable", "not_applicable"}
-FORMAL_EVIDENCE_SUFFIXES = {".lean", ".json", ".jsonl"}
-
-
-def contained_repo_path(repo_root: Path, raw_path: object) -> Path | None:
-    if not isinstance(raw_path, str) or not raw_path:
-        return None
-    candidate = Path(raw_path)
-    if candidate.is_absolute() or ".." in candidate.parts:
-        return None
-    return repo_root / candidate
 
 
 def fail(msg: str) -> int:
@@ -46,59 +35,6 @@ def proof_domain_map(proof_coverage: dict) -> dict[str, dict]:
     return result
 
 
-def rust_fuzz_target_exists(repo_root: Path, root_path: object, name: str) -> bool:
-    root = contained_repo_path(repo_root, root_path)
-    if root is None:
-        return False
-    return (root / "fuzz_targets" / f"{name}.rs").is_file()
-
-
-def go_fuzz_target_exists(repo_root: Path, root_path: object, name: str) -> bool:
-    if not name.startswith("Fuzz"):
-        return False
-    root = contained_repo_path(repo_root, root_path)
-    if root is None:
-        return False
-    if not root.is_dir():
-        return False
-    pattern = re.compile(rf"\bfunc\s+{re.escape(name)}\s*\(")
-    for source in root.rglob("*.go"):
-        try:
-            if pattern.search(source.read_text(encoding="utf-8")):
-                return True
-        except UnicodeDecodeError:
-            continue
-    return False
-
-
-def fuzz_gates(repo_root: Path, proof_coverage: dict) -> set[str]:
-    gates: set[str] = set()
-    sections = (
-        ("fuzz", rust_fuzz_target_exists),
-        ("go_fuzz", go_fuzz_target_exists),
-    )
-    for section, target_exists in sections:
-        body = proof_coverage.get(section, {})
-        if not isinstance(body, dict):
-            continue
-        root_path = body.get("path")
-        targets = body.get("targets", [])
-        if not isinstance(targets, list):
-            continue
-        for target in targets:
-            if not isinstance(target, dict):
-                continue
-            gate = target.get("conformance_gate")
-            name = target.get("name")
-            if isinstance(gate, str) and gate and isinstance(name, str) and target_exists(
-                repo_root,
-                root_path,
-                name,
-            ):
-                gates.add(gate)
-    return gates
-
-
 def status_of(value: object) -> str:
     if not isinstance(value, dict):
         return ""
@@ -117,27 +53,6 @@ def string_list(value: object, *, field_name: str) -> tuple[list[str], str | Non
     if len(set(strings)) != len(strings):
         return [], f"{field_name} entries must be unique"
     return strings, None
-
-
-def repo_relative_existing_paths(repo_root: Path, value: object, *, field_name: str) -> tuple[list[Path], str | None]:
-    if not isinstance(value, list):
-        return [], f"{field_name} must be list"
-    paths: list[Path] = []
-    for item in value:
-        if not isinstance(item, dict):
-            return [], f"{field_name} entries must be objects"
-        raw_path = item.get("path")
-        if not isinstance(raw_path, str) or not raw_path:
-            return [], f"{field_name} entries need non-empty path"
-        full_path = contained_repo_path(repo_root, raw_path)
-        if full_path is None:
-            return [], f"{field_name} paths must be repo-relative and contained"
-        if not raw_path.startswith("rubin-formal/") or full_path.suffix not in FORMAL_EVIDENCE_SUFFIXES:
-            return [], f"{field_name} paths must reference formal artifacts"
-        if not full_path.exists():
-            return [], f"{field_name} path does not exist: {raw_path}"
-        paths.append(full_path)
-    return paths, None
 
 
 def main() -> int:
@@ -159,7 +74,6 @@ def main() -> int:
         proof_domains = proof_domain_map(proof_coverage)
     except ValueError as exc:
         return fail(str(exc))
-    committed_fuzz_gates = fuzz_gates(repo_root, proof_coverage)
     if baseline.get("schema_version") != 1:
         return fail("EDGE_PACK_BASELINE.json schema_version must be 1")
 
@@ -337,13 +251,11 @@ def main() -> int:
 
                 fuzz_status = status_of(proof_domain.get("fuzz"))
                 if fuzz_status in CLAIMED_PRESENT_STATUSES:
-                    missing_fuzz_gates = [gate for gate in gate_names if gate not in committed_fuzz_gates]
-                    if missing_fuzz_gates:
-                        print(
-                            f"FAIL: domain {name}: proof_coverage claims fuzz={fuzz_status} without committed fuzz target for gates: {', '.join(missing_fuzz_gates)}",
-                            file=sys.stderr,
-                        )
-                        failures += 1
+                    print(
+                        f"FAIL: domain {name}: proof_coverage claims fuzz={fuzz_status}; committed fuzz evidence validation is not supported in this edge-pack checker",
+                        file=sys.stderr,
+                    )
+                    failures += 1
                 elif fuzz_status and fuzz_status not in KNOWN_ABSENT_STATUSES:
                     print(
                         f"ERROR: domain {name}: unknown fuzz coverage status {fuzz_status}",
@@ -353,18 +265,11 @@ def main() -> int:
 
                 formal_status = status_of(proof_domain.get("formal"))
                 if formal_status in CLAIMED_PRESENT_STATUSES:
-                    formal_evidence, formal_error = repo_relative_existing_paths(
-                        repo_root,
-                        proof_domain.get("formal_evidence", []),
-                        field_name="formal_evidence",
+                    print(
+                        f"FAIL: domain {name}: proof_coverage claims formal={formal_status}; committed formal evidence validation is not supported in this edge-pack checker",
+                        file=sys.stderr,
                     )
-                    if formal_error is not None or not formal_evidence:
-                        print(
-                            f"FAIL: domain {name}: proof_coverage claims formal={formal_status} without committed formal evidence"
-                            + (f": {formal_error}" if formal_error else ""),
-                            file=sys.stderr,
-                        )
-                        failures += 1
+                    failures += 1
                 elif formal_status and formal_status not in KNOWN_ABSENT_STATUSES:
                     print(
                         f"ERROR: domain {name}: unknown formal coverage status {formal_status}",

--- a/tools/check_conformance_edge_pack.py
+++ b/tools/check_conformance_edge_pack.py
@@ -35,14 +35,14 @@ def proof_domain_map(proof_coverage: dict) -> dict[str, dict]:
     return result
 
 
-def coverage_status(value: object, *, field_name: str) -> tuple[str, str | None]:
-    if value is None:
+def coverage_status(value: object, *, field_name: str, field_present: bool) -> tuple[str, str | None]:
+    if not field_present:
         return "", None
     if not isinstance(value, dict):
         return "", f"{field_name} must be object"
+    if "status" not in value:
+        return "", f"{field_name}.status must be present when {field_name} is present"
     status = value.get("status")
-    if status is None:
-        return "", None
     if not isinstance(status, str) or not status:
         return "", f"{field_name}.status must be non-empty string"
     return status, None
@@ -269,6 +269,7 @@ def main() -> int:
                 fuzz_status, fuzz_status_error = coverage_status(
                     proof_domain.get("fuzz"),
                     field_name="proof_coverage fuzz",
+                    field_present="fuzz" in proof_domain,
                 )
                 if fuzz_status_error is not None:
                     print(f"ERROR: domain {name}: {fuzz_status_error}", file=sys.stderr)
@@ -289,6 +290,7 @@ def main() -> int:
                 formal_status, formal_status_error = coverage_status(
                     proof_domain.get("formal"),
                     field_name="proof_coverage formal",
+                    field_present="formal" in proof_domain,
                 )
                 if formal_status_error is not None:
                     print(f"ERROR: domain {name}: {formal_status_error}", file=sys.stderr)

--- a/tools/check_conformance_edge_pack.py
+++ b/tools/check_conformance_edge_pack.py
@@ -14,8 +14,14 @@ def fail(msg: str) -> int:
     return 1
 
 
-def load_json(path: Path) -> dict:
+def load_json(path: Path) -> object:
     return json.loads(path.read_text(encoding="utf-8"))
+
+
+def json_object(value: object, *, label: str) -> dict:
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be a JSON object")
+    return value
 
 
 def proof_domain_map(proof_coverage: dict) -> dict[str, dict]:
@@ -76,9 +82,9 @@ def main() -> int:
     if not proof_coverage_path.exists():
         return fail("proof_coverage.json not found")
 
-    baseline = load_json(baseline_path)
-    proof_coverage = load_json(proof_coverage_path)
     try:
+        baseline = json_object(load_json(baseline_path), label="EDGE_PACK_BASELINE.json")
+        proof_coverage = json_object(load_json(proof_coverage_path), label="proof_coverage.json")
         proof_domains = proof_domain_map(proof_coverage)
     except ValueError as exc:
         return fail(str(exc))
@@ -93,7 +99,10 @@ def main() -> int:
     fixture_gate_to_ids: dict[str, set[str]] = {}
     fixture_gate_to_count: dict[str, int] = {}
     for fixture in fixtures_dir.glob("CV-*.json"):
-        data = load_json(fixture)
+        try:
+            data = json_object(load_json(fixture), label=str(fixture.relative_to(repo_root)))
+        except ValueError as exc:
+            return fail(str(exc))
         gate = data.get("gate")
         vectors = data.get("vectors", [])
         if not isinstance(gate, str) or not gate:

--- a/tools/check_conformance_edge_pack.py
+++ b/tools/check_conformance_edge_pack.py
@@ -2,11 +2,22 @@
 from __future__ import annotations
 
 import json
+import re
 import sys
 from pathlib import Path
 
 CLAIMED_PRESENT_STATUSES = {"present", "covered", "complete"}
 KNOWN_ABSENT_STATUSES = {"absent", "deferred", "not_claimed", "not-applicable", "not_applicable"}
+FORMAL_EVIDENCE_SUFFIXES = {".lean", ".json", ".jsonl"}
+
+
+def contained_repo_path(repo_root: Path, raw_path: object) -> Path | None:
+    if not isinstance(raw_path, str) or not raw_path:
+        return None
+    candidate = Path(raw_path)
+    if candidate.is_absolute() or ".." in candidate.parts:
+        return None
+    return repo_root / candidate
 
 
 def fail(msg: str) -> int:
@@ -35,17 +46,55 @@ def proof_domain_map(proof_coverage: dict) -> dict[str, dict]:
     return result
 
 
-def fuzz_gates(proof_coverage: dict) -> set[str]:
+def rust_fuzz_target_exists(repo_root: Path, root_path: object, name: str) -> bool:
+    root = contained_repo_path(repo_root, root_path)
+    if root is None:
+        return False
+    return (root / "fuzz_targets" / f"{name}.rs").is_file()
+
+
+def go_fuzz_target_exists(repo_root: Path, root_path: object, name: str) -> bool:
+    if not name.startswith("Fuzz"):
+        return False
+    root = contained_repo_path(repo_root, root_path)
+    if root is None:
+        return False
+    if not root.is_dir():
+        return False
+    pattern = re.compile(rf"\bfunc\s+{re.escape(name)}\s*\(")
+    for source in root.rglob("*.go"):
+        try:
+            if pattern.search(source.read_text(encoding="utf-8")):
+                return True
+        except UnicodeDecodeError:
+            continue
+    return False
+
+
+def fuzz_gates(repo_root: Path, proof_coverage: dict) -> set[str]:
     gates: set[str] = set()
-    for section in ("fuzz", "go_fuzz"):
-        targets = proof_coverage.get(section, {}).get("targets", [])
+    sections = (
+        ("fuzz", rust_fuzz_target_exists),
+        ("go_fuzz", go_fuzz_target_exists),
+    )
+    for section, target_exists in sections:
+        body = proof_coverage.get(section, {})
+        if not isinstance(body, dict):
+            continue
+        root_path = body.get("path")
+        targets = body.get("targets", [])
         if not isinstance(targets, list):
             continue
         for target in targets:
             if not isinstance(target, dict):
                 continue
             gate = target.get("conformance_gate")
-            if isinstance(gate, str) and gate:
+            name = target.get("name")
+            if isinstance(gate, str) and gate and isinstance(name, str) and target_exists(
+                repo_root,
+                root_path,
+                name,
+            ):
                 gates.add(gate)
     return gates
 
@@ -70,6 +119,27 @@ def string_list(value: object, *, field_name: str) -> tuple[list[str], str | Non
     return strings, None
 
 
+def repo_relative_existing_paths(repo_root: Path, value: object, *, field_name: str) -> tuple[list[Path], str | None]:
+    if not isinstance(value, list):
+        return [], f"{field_name} must be list"
+    paths: list[Path] = []
+    for item in value:
+        if not isinstance(item, dict):
+            return [], f"{field_name} entries must be objects"
+        raw_path = item.get("path")
+        if not isinstance(raw_path, str) or not raw_path:
+            return [], f"{field_name} entries need non-empty path"
+        full_path = contained_repo_path(repo_root, raw_path)
+        if full_path is None:
+            return [], f"{field_name} paths must be repo-relative and contained"
+        if not raw_path.startswith("rubin-formal/") or full_path.suffix not in FORMAL_EVIDENCE_SUFFIXES:
+            return [], f"{field_name} paths must reference formal artifacts"
+        if not full_path.exists():
+            return [], f"{field_name} path does not exist: {raw_path}"
+        paths.append(full_path)
+    return paths, None
+
+
 def main() -> int:
     repo_root = Path(".").resolve()
     baseline_path = repo_root / "conformance" / "EDGE_PACK_BASELINE.json"
@@ -89,7 +159,7 @@ def main() -> int:
         proof_domains = proof_domain_map(proof_coverage)
     except ValueError as exc:
         return fail(str(exc))
-    committed_fuzz_gates = fuzz_gates(proof_coverage)
+    committed_fuzz_gates = fuzz_gates(repo_root, proof_coverage)
     if baseline.get("schema_version") != 1:
         return fail("EDGE_PACK_BASELINE.json schema_version must be 1")
 
@@ -283,10 +353,15 @@ def main() -> int:
 
                 formal_status = status_of(proof_domain.get("formal"))
                 if formal_status in CLAIMED_PRESENT_STATUSES:
-                    formal_evidence = proof_domain.get("formal_evidence", [])
-                    if not isinstance(formal_evidence, list) or not formal_evidence:
+                    formal_evidence, formal_error = repo_relative_existing_paths(
+                        repo_root,
+                        proof_domain.get("formal_evidence", []),
+                        field_name="formal_evidence",
+                    )
+                    if formal_error is not None or not formal_evidence:
                         print(
-                            f"FAIL: domain {name}: proof_coverage claims formal={formal_status} without formal_evidence",
+                            f"FAIL: domain {name}: proof_coverage claims formal={formal_status} without committed formal evidence"
+                            + (f": {formal_error}" if formal_error else ""),
                             file=sys.stderr,
                         )
                         failures += 1

--- a/tools/check_conformance_edge_pack.py
+++ b/tools/check_conformance_edge_pack.py
@@ -122,6 +122,7 @@ def main() -> int:
 
     failures = 0
     for domain in domains:
+        domain_failures_before = failures
         if not isinstance(domain, dict):
             print("ERROR: domain entry must be object", file=sys.stderr)
             failures += 1
@@ -317,7 +318,8 @@ def main() -> int:
                     )
                     failures += 1
 
-        print(f"OK: domain {name} total_vectors={total} min={min_vectors_total}")
+        if failures == domain_failures_before:
+            print(f"OK: domain {name} total_vectors={total} min={min_vectors_total}")
 
     if failures:
         print(f"FAILED: edge-pack check found {failures} issue(s)", file=sys.stderr)

--- a/tools/tests/test_check_conformance_edge_pack.py
+++ b/tools/tests/test_check_conformance_edge_pack.py
@@ -40,11 +40,20 @@ def make_repo(
     vector_id: str = "V-1",
     proof_vector_ids: list[object] | None = None,
     proof_gates: list[object] | None = None,
+    formal_evidence: list[object] | None = None,
+    fuzz_targets: list[dict] | None = None,
+    go_fuzz_targets: list[dict] | None = None,
 ) -> None:
     if proof_vector_ids is None:
         proof_vector_ids = ["V-1"]
     if proof_gates is None:
         proof_gates = ["CV-TEST"]
+    if formal_evidence is None:
+        formal_evidence = []
+    if fuzz_targets is None:
+        fuzz_targets = []
+    if go_fuzz_targets is None:
+        go_fuzz_targets = []
     write_json(
         root / "conformance" / "fixtures" / "CV-TEST.json",
         {"gate": "CV-TEST", "vectors": [{"id": "V-1"}]},
@@ -68,8 +77,8 @@ def make_repo(
         root / "proof_coverage.json",
         {
             "version": 1,
-            "fuzz": {"targets": []},
-            "go_fuzz": {"targets": []},
+            "fuzz": {"path": "clients/rust/fuzz", "targets": fuzz_targets},
+            "go_fuzz": {"path": "clients/go/consensus", "targets": go_fuzz_targets},
             "edge_property_domains": [
                 {
                     "name": "test_domain",
@@ -77,6 +86,7 @@ def make_repo(
                     "vector_ids": proof_vector_ids,
                     "fuzz": {"status": fuzz_status},
                     "formal": {"status": formal_status},
+                    "formal_evidence": formal_evidence,
                 }
             ],
         },
@@ -114,6 +124,72 @@ class EdgePackCheckerTests(unittest.TestCase):
         self.assertEqual(rc, 1)
         self.assertIn("claims fuzz=present without committed fuzz target", captured.getvalue())
 
+    def test_fuzz_present_claim_with_metadata_only_target_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(
+                root,
+                fuzz_status="present",
+                fuzz_targets=[{"name": "missing_target", "conformance_gate": "CV-TEST"}],
+            )
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stderr(captured):
+                rc = m.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("claims fuzz=present without committed fuzz target", captured.getvalue())
+
+    def test_fuzz_present_claim_with_existing_rust_target_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            rust_target = root / "clients" / "rust" / "fuzz" / "fuzz_targets" / "test_target.rs"
+            rust_target.parent.mkdir(parents=True, exist_ok=True)
+            rust_target.write_text("fn main() {}\n", encoding="utf-8")
+            make_repo(
+                root,
+                fuzz_status="present",
+                fuzz_targets=[{"name": "test_target", "conformance_gate": "CV-TEST"}],
+            )
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stdout(captured):
+                rc = m.main()
+        self.assertEqual(rc, 0)
+        self.assertIn("OK: conformance edge-pack baseline satisfied.", captured.getvalue())
+
+    def test_go_fuzz_present_claim_with_existing_target_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            go_target = root / "clients" / "go" / "consensus" / "fuzz_test.go"
+            go_target.parent.mkdir(parents=True, exist_ok=True)
+            go_target.write_text("package consensus\n\nfunc FuzzEdgePack(f *testing.F) {}\n", encoding="utf-8")
+            make_repo(
+                root,
+                fuzz_status="present",
+                go_fuzz_targets=[{"name": "FuzzEdgePack", "conformance_gate": "CV-TEST"}],
+            )
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stdout(captured):
+                rc = m.main()
+        self.assertEqual(rc, 0)
+        self.assertIn("OK: conformance edge-pack baseline satisfied.", captured.getvalue())
+
+    def test_fuzz_present_claim_with_absolute_root_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(
+                root,
+                fuzz_status="present",
+                fuzz_targets=[{"name": "test_target", "conformance_gate": "CV-TEST"}],
+            )
+            proof_path = root / "proof_coverage.json"
+            proof = json.loads(proof_path.read_text(encoding="utf-8"))
+            proof["fuzz"]["path"] = "/tmp"
+            write_json(proof_path, proof)
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stderr(captured):
+                rc = m.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("claims fuzz=present without committed fuzz target", captured.getvalue())
+
     def test_formal_present_claim_without_evidence_fails(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)
@@ -122,7 +198,52 @@ class EdgePackCheckerTests(unittest.TestCase):
             with chdir(root), contextlib.redirect_stderr(captured):
                 rc = m.main()
         self.assertEqual(rc, 1)
-        self.assertIn("claims formal=present without formal_evidence", captured.getvalue())
+        self.assertIn("claims formal=present without committed formal evidence", captured.getvalue())
+
+    def test_formal_present_claim_with_missing_evidence_path_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(root, formal_status="present", formal_evidence=[{"path": "rubin-formal/missing.lean"}])
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stderr(captured):
+                rc = m.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("formal_evidence path does not exist: rubin-formal/missing.lean", captured.getvalue())
+
+    def test_formal_present_claim_with_absolute_evidence_path_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(root, formal_status="present", formal_evidence=[{"path": "/tmp/fake.lean"}])
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stderr(captured):
+                rc = m.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("formal_evidence paths must be repo-relative and contained", captured.getvalue())
+
+    def test_formal_present_claim_with_non_formal_artifact_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            evidence = root / "README.md"
+            evidence.write_text("not formal\n", encoding="utf-8")
+            make_repo(root, formal_status="present", formal_evidence=[{"path": "README.md"}])
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stderr(captured):
+                rc = m.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("formal_evidence paths must reference formal artifacts", captured.getvalue())
+
+    def test_formal_present_claim_with_existing_evidence_path_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            evidence = root / "rubin-formal" / "Proof.lean"
+            evidence.parent.mkdir(parents=True, exist_ok=True)
+            evidence.write_text("-- proof placeholder\n", encoding="utf-8")
+            make_repo(root, formal_status="present", formal_evidence=[{"path": "rubin-formal/Proof.lean"}])
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stdout(captured):
+                rc = m.main()
+        self.assertEqual(rc, 0)
+        self.assertIn("OK: conformance edge-pack baseline satisfied.", captured.getvalue())
 
     def test_proof_coverage_missing_vector_fails(self) -> None:
         with tempfile.TemporaryDirectory() as td:

--- a/tools/tests/test_check_conformance_edge_pack.py
+++ b/tools/tests/test_check_conformance_edge_pack.py
@@ -124,6 +124,20 @@ class EdgePackCheckerTests(unittest.TestCase):
         self.assertEqual(rc, 1)
         self.assertIn("duplicate domain name: test_domain", captured.getvalue())
 
+    def test_domain_name_rejects_whitespace_only(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(root)
+            baseline_path = root / "conformance" / "EDGE_PACK_BASELINE.json"
+            baseline = json.loads(baseline_path.read_text(encoding="utf-8"))
+            baseline["domains"][0]["name"] = "   "
+            write_json(baseline_path, baseline)
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stderr(captured):
+                rc = m.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("domain name missing/invalid", captured.getvalue())
+
     def test_baseline_top_level_array_fails_without_traceback(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)
@@ -150,6 +164,20 @@ class EdgePackCheckerTests(unittest.TestCase):
                 rc = m.main()
         self.assertEqual(rc, 1)
         self.assertIn("domain test_domain gates entries must be unique", captured.getvalue())
+
+    def test_domain_gate_rejects_whitespace_only(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(root)
+            baseline_path = root / "conformance" / "EDGE_PACK_BASELINE.json"
+            baseline = json.loads(baseline_path.read_text(encoding="utf-8"))
+            baseline["domains"][0]["gates"] = ["   "]
+            write_json(baseline_path, baseline)
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stderr(captured):
+                rc = m.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("domain test_domain gates entries must be non-empty strings", captured.getvalue())
 
     def test_required_vector_rejects_non_string_id(self) -> None:
         with tempfile.TemporaryDirectory() as td:
@@ -192,6 +220,20 @@ class EdgePackCheckerTests(unittest.TestCase):
                 rc = m.main()
         self.assertEqual(rc, 1)
         self.assertIn("required_vectors_by_gate[CV-TEST] must be non-empty list", captured.getvalue())
+
+    def test_required_vector_gate_key_rejects_whitespace_only(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(root)
+            baseline_path = root / "conformance" / "EDGE_PACK_BASELINE.json"
+            baseline = json.loads(baseline_path.read_text(encoding="utf-8"))
+            baseline["domains"][0]["required_vectors_by_gate"] = {"   ": ["V-1"]}
+            write_json(baseline_path, baseline)
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stderr(captured):
+                rc = m.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("required_vectors_by_gate keys must be non-empty strings", captured.getvalue())
 
     def test_proof_coverage_missing_vector_fails(self) -> None:
         with tempfile.TemporaryDirectory() as td:
@@ -242,6 +284,20 @@ class EdgePackCheckerTests(unittest.TestCase):
         self.assertIn("conformance/fixtures/CV-TEST.json must be a JSON object", captured.getvalue())
         self.assertNotIn("Traceback", captured.getvalue())
 
+    def test_fixture_gate_rejects_whitespace_only(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(root)
+            fixture_path = root / "conformance" / "fixtures" / "CV-TEST.json"
+            fixture = json.loads(fixture_path.read_text(encoding="utf-8"))
+            fixture["gate"] = "   "
+            write_json(fixture_path, fixture)
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stderr(captured):
+                rc = m.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("conformance/fixtures/CV-TEST.json has invalid gate", captured.getvalue())
+
     def test_proof_coverage_duplicate_domain_name_fails(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)
@@ -256,6 +312,20 @@ class EdgePackCheckerTests(unittest.TestCase):
         self.assertEqual(rc, 1)
         self.assertIn("proof_coverage.json duplicate edge_property_domain: test_domain", captured.getvalue())
 
+    def test_proof_coverage_domain_name_rejects_whitespace_only(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(root)
+            proof_path = root / "proof_coverage.json"
+            proof = json.loads(proof_path.read_text(encoding="utf-8"))
+            proof["edge_property_domains"][0]["name"] = "   "
+            write_json(proof_path, proof)
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stderr(captured):
+                rc = m.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("proof_coverage.json edge_property_domains entries need non-empty name", captured.getvalue())
+
     def test_proof_coverage_missing_required_vector_fails(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)
@@ -269,6 +339,20 @@ class EdgePackCheckerTests(unittest.TestCase):
                 rc = m.main()
         self.assertEqual(rc, 1)
         self.assertIn("proof_coverage missing vector IDs: V-1", captured.getvalue())
+
+    def test_coverage_accounting_domain_rejects_whitespace_only(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(root)
+            baseline_path = root / "conformance" / "EDGE_PACK_BASELINE.json"
+            baseline = json.loads(baseline_path.read_text(encoding="utf-8"))
+            baseline["domains"][0]["coverage_accounting"]["proof_coverage_domain"] = "   "
+            write_json(baseline_path, baseline)
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stderr(captured):
+                rc = m.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("coverage_accounting.proof_coverage_domain must be non-empty string", captured.getvalue())
 
     def test_proof_coverage_rejects_non_string_vector_id(self) -> None:
         with tempfile.TemporaryDirectory() as td:
@@ -351,6 +435,20 @@ class EdgePackCheckerTests(unittest.TestCase):
             proof_path = root / "proof_coverage.json"
             proof = json.loads(proof_path.read_text(encoding="utf-8"))
             proof["edge_property_domains"][0]["fuzz"] = {"status": 7}
+            write_json(proof_path, proof)
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stderr(captured):
+                rc = m.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("proof_coverage fuzz.status must be non-empty string", captured.getvalue())
+
+    def test_fuzz_whitespace_status_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(root)
+            proof_path = root / "proof_coverage.json"
+            proof = json.loads(proof_path.read_text(encoding="utf-8"))
+            proof["edge_property_domains"][0]["fuzz"] = {"status": "   "}
             write_json(proof_path, proof)
             captured = io.StringIO()
             with chdir(root), contextlib.redirect_stderr(captured):

--- a/tools/tests/test_check_conformance_edge_pack.py
+++ b/tools/tests/test_check_conformance_edge_pack.py
@@ -1,0 +1,169 @@
+"""Contract tests for tools/check_conformance_edge_pack.py."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+TOOLS_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(TOOLS_DIR))
+
+import check_conformance_edge_pack as m  # noqa: E402
+
+
+@contextlib.contextmanager
+def chdir(path: Path):
+    old = Path.cwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(old)
+
+
+def write_json(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def make_repo(
+    root: Path,
+    *,
+    fuzz_status: str = "deferred",
+    formal_status: str = "not_claimed",
+    vector_id: str = "V-1",
+    proof_vector_ids: list[object] | None = None,
+    proof_gates: list[object] | None = None,
+) -> None:
+    if proof_vector_ids is None:
+        proof_vector_ids = ["V-1"]
+    if proof_gates is None:
+        proof_gates = ["CV-TEST"]
+    write_json(
+        root / "conformance" / "fixtures" / "CV-TEST.json",
+        {"gate": "CV-TEST", "vectors": [{"id": "V-1"}]},
+    )
+    write_json(
+        root / "conformance" / "EDGE_PACK_BASELINE.json",
+        {
+            "schema_version": 1,
+            "domains": [
+                {
+                    "name": "test_domain",
+                    "gates": ["CV-TEST"],
+                    "min_vectors_total": 1,
+                    "required_vectors_by_gate": {"CV-TEST": [vector_id]},
+                    "coverage_accounting": {"proof_coverage_domain": "test_domain"},
+                }
+            ],
+        },
+    )
+    write_json(
+        root / "proof_coverage.json",
+        {
+            "version": 1,
+            "fuzz": {"targets": []},
+            "go_fuzz": {"targets": []},
+            "edge_property_domains": [
+                {
+                    "name": "test_domain",
+                    "conformance_gates": proof_gates,
+                    "vector_ids": proof_vector_ids,
+                    "fuzz": {"status": fuzz_status},
+                    "formal": {"status": formal_status},
+                }
+            ],
+        },
+    )
+
+
+class EdgePackCheckerTests(unittest.TestCase):
+    def test_clean_accounting_passes_with_deferred_fuzz_formal(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(root)
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stdout(captured):
+                rc = m.main()
+        self.assertEqual(rc, 0)
+        self.assertIn("OK: conformance edge-pack baseline satisfied.", captured.getvalue())
+
+    def test_missing_required_vector_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(root, vector_id="V-MISSING")
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stderr(captured):
+                rc = m.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("missing required vectors: V-MISSING", captured.getvalue())
+
+    def test_fuzz_present_claim_without_target_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(root, fuzz_status="present")
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stderr(captured):
+                rc = m.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("claims fuzz=present without committed fuzz target", captured.getvalue())
+
+    def test_formal_present_claim_without_evidence_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(root, formal_status="present")
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stderr(captured):
+                rc = m.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("claims formal=present without formal_evidence", captured.getvalue())
+
+    def test_proof_coverage_missing_vector_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(root, proof_vector_ids=["V-MISSING"])
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stderr(captured):
+                rc = m.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("proof_coverage references missing vector IDs: V-MISSING", captured.getvalue())
+
+    def test_proof_coverage_rejects_non_string_vector_id(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(root, proof_vector_ids=["V-1", 7])
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stderr(captured):
+                rc = m.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("proof_coverage vector_ids entries must be non-empty strings", captured.getvalue())
+
+    def test_proof_coverage_rejects_duplicate_vector_id(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(root, proof_vector_ids=["V-1", "V-1"])
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stderr(captured):
+                rc = m.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("proof_coverage vector_ids entries must be unique", captured.getvalue())
+
+    def test_proof_coverage_rejects_non_string_gate(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(root, proof_gates=["CV-TEST", 7])
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stderr(captured):
+                rc = m.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("proof_coverage conformance_gates entries must be non-empty strings", captured.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_check_conformance_edge_pack.py
+++ b/tools/tests/test_check_conformance_edge_pack.py
@@ -108,6 +108,48 @@ class EdgePackCheckerTests(unittest.TestCase):
         self.assertEqual(rc, 1)
         self.assertIn("missing required vectors: V-MISSING", captured.getvalue())
 
+    def test_required_vector_rejects_non_string_id(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(root)
+            baseline_path = root / "conformance" / "EDGE_PACK_BASELINE.json"
+            baseline = json.loads(baseline_path.read_text(encoding="utf-8"))
+            baseline["domains"][0]["required_vectors_by_gate"]["CV-TEST"] = ["V-1", 7]
+            write_json(baseline_path, baseline)
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stderr(captured):
+                rc = m.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("required_vectors_by_gate[CV-TEST] entries must be non-empty strings", captured.getvalue())
+
+    def test_required_vector_rejects_duplicate_id(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(root)
+            baseline_path = root / "conformance" / "EDGE_PACK_BASELINE.json"
+            baseline = json.loads(baseline_path.read_text(encoding="utf-8"))
+            baseline["domains"][0]["required_vectors_by_gate"]["CV-TEST"] = ["V-1", "V-1"]
+            write_json(baseline_path, baseline)
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stderr(captured):
+                rc = m.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("required_vectors_by_gate[CV-TEST] entries must be unique", captured.getvalue())
+
+    def test_required_vector_rejects_empty_list(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(root)
+            baseline_path = root / "conformance" / "EDGE_PACK_BASELINE.json"
+            baseline = json.loads(baseline_path.read_text(encoding="utf-8"))
+            baseline["domains"][0]["required_vectors_by_gate"]["CV-TEST"] = []
+            write_json(baseline_path, baseline)
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stderr(captured):
+                rc = m.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("required_vectors_by_gate[CV-TEST] must be non-empty list", captured.getvalue())
+
     def test_proof_coverage_missing_vector_fails(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)
@@ -182,6 +224,44 @@ class EdgePackCheckerTests(unittest.TestCase):
         self.assertEqual(rc, 1)
         self.assertIn("committed fuzz evidence validation is not supported", captured.getvalue())
 
+    def test_fuzz_covered_claim_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(root, fuzz_status="covered")
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stderr(captured):
+                rc = m.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("claims fuzz=covered", captured.getvalue())
+
+    def test_fuzz_scalar_present_shape_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(root)
+            proof_path = root / "proof_coverage.json"
+            proof = json.loads(proof_path.read_text(encoding="utf-8"))
+            proof["edge_property_domains"][0]["fuzz"] = "present"
+            write_json(proof_path, proof)
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stderr(captured):
+                rc = m.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("proof_coverage fuzz must be object", captured.getvalue())
+
+    def test_fuzz_non_string_status_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(root)
+            proof_path = root / "proof_coverage.json"
+            proof = json.loads(proof_path.read_text(encoding="utf-8"))
+            proof["edge_property_domains"][0]["fuzz"] = {"status": 7}
+            write_json(proof_path, proof)
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stderr(captured):
+                rc = m.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("proof_coverage fuzz.status must be non-empty string", captured.getvalue())
+
     def test_fuzz_unknown_status_fails(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)
@@ -204,6 +284,44 @@ class EdgePackCheckerTests(unittest.TestCase):
                 rc = m.main()
         self.assertEqual(rc, 1)
         self.assertIn("committed formal evidence validation is not supported", captured.getvalue())
+
+    def test_formal_complete_claim_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(root, formal_status="complete")
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stderr(captured):
+                rc = m.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("claims formal=complete", captured.getvalue())
+
+    def test_formal_scalar_present_shape_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(root)
+            proof_path = root / "proof_coverage.json"
+            proof = json.loads(proof_path.read_text(encoding="utf-8"))
+            proof["edge_property_domains"][0]["formal"] = "covered"
+            write_json(proof_path, proof)
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stderr(captured):
+                rc = m.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("proof_coverage formal must be object", captured.getvalue())
+
+    def test_formal_non_string_status_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(root)
+            proof_path = root / "proof_coverage.json"
+            proof = json.loads(proof_path.read_text(encoding="utf-8"))
+            proof["edge_property_domains"][0]["formal"] = {"status": 7}
+            write_json(proof_path, proof)
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stderr(captured):
+                rc = m.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("proof_coverage formal.status must be non-empty string", captured.getvalue())
 
     def test_formal_unknown_status_fails(self) -> None:
         with tempfile.TemporaryDirectory() as td:

--- a/tools/tests/test_check_conformance_edge_pack.py
+++ b/tools/tests/test_check_conformance_edge_pack.py
@@ -122,6 +122,19 @@ class EdgePackCheckerTests(unittest.TestCase):
         self.assertEqual(rc, 1)
         self.assertIn("duplicate domain name: test_domain", captured.getvalue())
 
+    def test_baseline_top_level_array_fails_without_traceback(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(root)
+            baseline_path = root / "conformance" / "EDGE_PACK_BASELINE.json"
+            baseline_path.write_text("[]\n", encoding="utf-8")
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stderr(captured):
+                rc = m.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("EDGE_PACK_BASELINE.json must be a JSON object", captured.getvalue())
+        self.assertNotIn("Traceback", captured.getvalue())
+
     def test_duplicate_domain_gate_fails(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)
@@ -187,6 +200,46 @@ class EdgePackCheckerTests(unittest.TestCase):
                 rc = m.main()
         self.assertEqual(rc, 1)
         self.assertIn("proof_coverage references missing vector IDs: V-MISSING", captured.getvalue())
+
+    def test_proof_coverage_top_level_array_fails_without_traceback(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(root)
+            proof_path = root / "proof_coverage.json"
+            proof_path.write_text("[]\n", encoding="utf-8")
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stderr(captured):
+                rc = m.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("proof_coverage.json must be a JSON object", captured.getvalue())
+        self.assertNotIn("Traceback", captured.getvalue())
+
+    def test_fixture_top_level_array_fails_without_traceback(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(root)
+            fixture_path = root / "conformance" / "fixtures" / "CV-TEST.json"
+            fixture_path.write_text("[]\n", encoding="utf-8")
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stderr(captured):
+                rc = m.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("conformance/fixtures/CV-TEST.json must be a JSON object", captured.getvalue())
+        self.assertNotIn("Traceback", captured.getvalue())
+
+    def test_proof_coverage_duplicate_domain_name_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(root)
+            proof_path = root / "proof_coverage.json"
+            proof = json.loads(proof_path.read_text(encoding="utf-8"))
+            proof["edge_property_domains"].append(dict(proof["edge_property_domains"][0]))
+            write_json(proof_path, proof)
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stderr(captured):
+                rc = m.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("proof_coverage.json duplicate edge_property_domain: test_domain", captured.getvalue())
 
     def test_proof_coverage_missing_required_vector_fails(self) -> None:
         with tempfile.TemporaryDirectory() as td:

--- a/tools/tests/test_check_conformance_edge_pack.py
+++ b/tools/tests/test_check_conformance_edge_pack.py
@@ -290,6 +290,35 @@ class EdgePackCheckerTests(unittest.TestCase):
         self.assertEqual(rc, 1)
         self.assertIn("proof_coverage fuzz.status must be non-empty string", captured.getvalue())
 
+    def test_fuzz_object_missing_status_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(root)
+            proof_path = root / "proof_coverage.json"
+            proof = json.loads(proof_path.read_text(encoding="utf-8"))
+            proof["edge_property_domains"][0]["fuzz"] = {}
+            write_json(proof_path, proof)
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stderr(captured):
+                rc = m.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("proof_coverage fuzz.status must be present", captured.getvalue())
+
+    def test_absent_fuzz_formal_fields_are_no_claims(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(root)
+            proof_path = root / "proof_coverage.json"
+            proof = json.loads(proof_path.read_text(encoding="utf-8"))
+            proof["edge_property_domains"][0].pop("fuzz")
+            proof["edge_property_domains"][0].pop("formal")
+            write_json(proof_path, proof)
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stdout(captured):
+                rc = m.main()
+        self.assertEqual(rc, 0)
+        self.assertIn("OK: conformance edge-pack baseline satisfied.", captured.getvalue())
+
     def test_fuzz_unknown_status_fails(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)
@@ -350,6 +379,20 @@ class EdgePackCheckerTests(unittest.TestCase):
                 rc = m.main()
         self.assertEqual(rc, 1)
         self.assertIn("proof_coverage formal.status must be non-empty string", captured.getvalue())
+
+    def test_formal_object_missing_status_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(root)
+            proof_path = root / "proof_coverage.json"
+            proof = json.loads(proof_path.read_text(encoding="utf-8"))
+            proof["edge_property_domains"][0]["formal"] = {}
+            write_json(proof_path, proof)
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stderr(captured):
+                rc = m.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("proof_coverage formal.status must be present", captured.getvalue())
 
     def test_formal_unknown_status_fails(self) -> None:
         with tempfile.TemporaryDirectory() as td:

--- a/tools/tests/test_check_conformance_edge_pack.py
+++ b/tools/tests/test_check_conformance_edge_pack.py
@@ -216,6 +216,19 @@ class EdgePackCheckerTests(unittest.TestCase):
         self.assertIn("proof_coverage.json must be a JSON object", captured.getvalue())
         self.assertNotIn("Traceback", captured.getvalue())
 
+    def test_proof_coverage_malformed_json_fails_without_traceback(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(root)
+            proof_path = root / "proof_coverage.json"
+            proof_path.write_text("{not-json\n", encoding="utf-8")
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stderr(captured):
+                rc = m.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("proof_coverage.json must contain valid JSON", captured.getvalue())
+        self.assertNotIn("Traceback", captured.getvalue())
+
     def test_fixture_top_level_array_fails_without_traceback(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)

--- a/tools/tests/test_check_conformance_edge_pack.py
+++ b/tools/tests/test_check_conformance_edge_pack.py
@@ -41,8 +41,6 @@ def make_repo(
     proof_vector_ids: list[object] | None = None,
     proof_gates: list[object] | None = None,
     formal_evidence: list[object] | None = None,
-    fuzz_targets: list[dict] | None = None,
-    go_fuzz_targets: list[dict] | None = None,
 ) -> None:
     if proof_vector_ids is None:
         proof_vector_ids = ["V-1"]
@@ -50,10 +48,6 @@ def make_repo(
         proof_gates = ["CV-TEST"]
     if formal_evidence is None:
         formal_evidence = []
-    if fuzz_targets is None:
-        fuzz_targets = []
-    if go_fuzz_targets is None:
-        go_fuzz_targets = []
     write_json(
         root / "conformance" / "fixtures" / "CV-TEST.json",
         {"gate": "CV-TEST", "vectors": [{"id": "V-1"}]},
@@ -77,8 +71,8 @@ def make_repo(
         root / "proof_coverage.json",
         {
             "version": 1,
-            "fuzz": {"path": "clients/rust/fuzz", "targets": fuzz_targets},
-            "go_fuzz": {"path": "clients/go/consensus", "targets": go_fuzz_targets},
+            "fuzz": {"targets": []},
+            "go_fuzz": {"targets": []},
             "edge_property_domains": [
                 {
                     "name": "test_domain",
@@ -114,137 +108,6 @@ class EdgePackCheckerTests(unittest.TestCase):
         self.assertEqual(rc, 1)
         self.assertIn("missing required vectors: V-MISSING", captured.getvalue())
 
-    def test_fuzz_present_claim_without_target_fails(self) -> None:
-        with tempfile.TemporaryDirectory() as td:
-            root = Path(td)
-            make_repo(root, fuzz_status="present")
-            captured = io.StringIO()
-            with chdir(root), contextlib.redirect_stderr(captured):
-                rc = m.main()
-        self.assertEqual(rc, 1)
-        self.assertIn("claims fuzz=present without committed fuzz target", captured.getvalue())
-
-    def test_fuzz_present_claim_with_metadata_only_target_fails(self) -> None:
-        with tempfile.TemporaryDirectory() as td:
-            root = Path(td)
-            make_repo(
-                root,
-                fuzz_status="present",
-                fuzz_targets=[{"name": "missing_target", "conformance_gate": "CV-TEST"}],
-            )
-            captured = io.StringIO()
-            with chdir(root), contextlib.redirect_stderr(captured):
-                rc = m.main()
-        self.assertEqual(rc, 1)
-        self.assertIn("claims fuzz=present without committed fuzz target", captured.getvalue())
-
-    def test_fuzz_present_claim_with_existing_rust_target_passes(self) -> None:
-        with tempfile.TemporaryDirectory() as td:
-            root = Path(td)
-            rust_target = root / "clients" / "rust" / "fuzz" / "fuzz_targets" / "test_target.rs"
-            rust_target.parent.mkdir(parents=True, exist_ok=True)
-            rust_target.write_text("fn main() {}\n", encoding="utf-8")
-            make_repo(
-                root,
-                fuzz_status="present",
-                fuzz_targets=[{"name": "test_target", "conformance_gate": "CV-TEST"}],
-            )
-            captured = io.StringIO()
-            with chdir(root), contextlib.redirect_stdout(captured):
-                rc = m.main()
-        self.assertEqual(rc, 0)
-        self.assertIn("OK: conformance edge-pack baseline satisfied.", captured.getvalue())
-
-    def test_go_fuzz_present_claim_with_existing_target_passes(self) -> None:
-        with tempfile.TemporaryDirectory() as td:
-            root = Path(td)
-            go_target = root / "clients" / "go" / "consensus" / "fuzz_test.go"
-            go_target.parent.mkdir(parents=True, exist_ok=True)
-            go_target.write_text("package consensus\n\nfunc FuzzEdgePack(f *testing.F) {}\n", encoding="utf-8")
-            make_repo(
-                root,
-                fuzz_status="present",
-                go_fuzz_targets=[{"name": "FuzzEdgePack", "conformance_gate": "CV-TEST"}],
-            )
-            captured = io.StringIO()
-            with chdir(root), contextlib.redirect_stdout(captured):
-                rc = m.main()
-        self.assertEqual(rc, 0)
-        self.assertIn("OK: conformance edge-pack baseline satisfied.", captured.getvalue())
-
-    def test_fuzz_present_claim_with_absolute_root_fails(self) -> None:
-        with tempfile.TemporaryDirectory() as td:
-            root = Path(td)
-            make_repo(
-                root,
-                fuzz_status="present",
-                fuzz_targets=[{"name": "test_target", "conformance_gate": "CV-TEST"}],
-            )
-            proof_path = root / "proof_coverage.json"
-            proof = json.loads(proof_path.read_text(encoding="utf-8"))
-            proof["fuzz"]["path"] = "/tmp"
-            write_json(proof_path, proof)
-            captured = io.StringIO()
-            with chdir(root), contextlib.redirect_stderr(captured):
-                rc = m.main()
-        self.assertEqual(rc, 1)
-        self.assertIn("claims fuzz=present without committed fuzz target", captured.getvalue())
-
-    def test_formal_present_claim_without_evidence_fails(self) -> None:
-        with tempfile.TemporaryDirectory() as td:
-            root = Path(td)
-            make_repo(root, formal_status="present")
-            captured = io.StringIO()
-            with chdir(root), contextlib.redirect_stderr(captured):
-                rc = m.main()
-        self.assertEqual(rc, 1)
-        self.assertIn("claims formal=present without committed formal evidence", captured.getvalue())
-
-    def test_formal_present_claim_with_missing_evidence_path_fails(self) -> None:
-        with tempfile.TemporaryDirectory() as td:
-            root = Path(td)
-            make_repo(root, formal_status="present", formal_evidence=[{"path": "rubin-formal/missing.lean"}])
-            captured = io.StringIO()
-            with chdir(root), contextlib.redirect_stderr(captured):
-                rc = m.main()
-        self.assertEqual(rc, 1)
-        self.assertIn("formal_evidence path does not exist: rubin-formal/missing.lean", captured.getvalue())
-
-    def test_formal_present_claim_with_absolute_evidence_path_fails(self) -> None:
-        with tempfile.TemporaryDirectory() as td:
-            root = Path(td)
-            make_repo(root, formal_status="present", formal_evidence=[{"path": "/tmp/fake.lean"}])
-            captured = io.StringIO()
-            with chdir(root), contextlib.redirect_stderr(captured):
-                rc = m.main()
-        self.assertEqual(rc, 1)
-        self.assertIn("formal_evidence paths must be repo-relative and contained", captured.getvalue())
-
-    def test_formal_present_claim_with_non_formal_artifact_fails(self) -> None:
-        with tempfile.TemporaryDirectory() as td:
-            root = Path(td)
-            evidence = root / "README.md"
-            evidence.write_text("not formal\n", encoding="utf-8")
-            make_repo(root, formal_status="present", formal_evidence=[{"path": "README.md"}])
-            captured = io.StringIO()
-            with chdir(root), contextlib.redirect_stderr(captured):
-                rc = m.main()
-        self.assertEqual(rc, 1)
-        self.assertIn("formal_evidence paths must reference formal artifacts", captured.getvalue())
-
-    def test_formal_present_claim_with_existing_evidence_path_passes(self) -> None:
-        with tempfile.TemporaryDirectory() as td:
-            root = Path(td)
-            evidence = root / "rubin-formal" / "Proof.lean"
-            evidence.parent.mkdir(parents=True, exist_ok=True)
-            evidence.write_text("-- proof placeholder\n", encoding="utf-8")
-            make_repo(root, formal_status="present", formal_evidence=[{"path": "rubin-formal/Proof.lean"}])
-            captured = io.StringIO()
-            with chdir(root), contextlib.redirect_stdout(captured):
-                rc = m.main()
-        self.assertEqual(rc, 0)
-        self.assertIn("OK: conformance edge-pack baseline satisfied.", captured.getvalue())
-
     def test_proof_coverage_missing_vector_fails(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)
@@ -254,6 +117,20 @@ class EdgePackCheckerTests(unittest.TestCase):
                 rc = m.main()
         self.assertEqual(rc, 1)
         self.assertIn("proof_coverage references missing vector IDs: V-MISSING", captured.getvalue())
+
+    def test_proof_coverage_missing_required_vector_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(root)
+            proof_path = root / "proof_coverage.json"
+            proof = json.loads(proof_path.read_text(encoding="utf-8"))
+            proof["edge_property_domains"][0]["vector_ids"] = []
+            write_json(proof_path, proof)
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stderr(captured):
+                rc = m.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("proof_coverage missing vector IDs: V-1", captured.getvalue())
 
     def test_proof_coverage_rejects_non_string_vector_id(self) -> None:
         with tempfile.TemporaryDirectory() as td:
@@ -284,6 +161,59 @@ class EdgePackCheckerTests(unittest.TestCase):
                 rc = m.main()
         self.assertEqual(rc, 1)
         self.assertIn("proof_coverage conformance_gates entries must be non-empty strings", captured.getvalue())
+
+    def test_proof_coverage_rejects_gate_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(root, proof_gates=["CV-OTHER"])
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stderr(captured):
+                rc = m.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("proof_coverage gates do not match EDGE baseline gates", captured.getvalue())
+
+    def test_fuzz_present_claim_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(root, fuzz_status="present")
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stderr(captured):
+                rc = m.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("committed fuzz evidence validation is not supported", captured.getvalue())
+
+    def test_fuzz_unknown_status_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(root, fuzz_status="maybe")
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stderr(captured):
+                rc = m.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("unknown fuzz coverage status maybe", captured.getvalue())
+
+    def test_formal_present_claim_fails_closed_even_with_evidence_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            evidence = root / "rubin-formal" / "Proof.lean"
+            evidence.parent.mkdir(parents=True, exist_ok=True)
+            evidence.write_text("-- proof placeholder\n", encoding="utf-8")
+            make_repo(root, formal_status="present", formal_evidence=[{"path": "rubin-formal/Proof.lean"}])
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stderr(captured):
+                rc = m.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("committed formal evidence validation is not supported", captured.getvalue())
+
+    def test_formal_unknown_status_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(root, formal_status="maybe")
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stderr(captured):
+                rc = m.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("unknown formal coverage status maybe", captured.getvalue())
 
 
 if __name__ == "__main__":

--- a/tools/tests/test_check_conformance_edge_pack.py
+++ b/tools/tests/test_check_conformance_edge_pack.py
@@ -102,11 +102,13 @@ class EdgePackCheckerTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)
             make_repo(root, vector_id="V-MISSING")
+            stdout = io.StringIO()
             captured = io.StringIO()
-            with chdir(root), contextlib.redirect_stderr(captured):
+            with chdir(root), contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(captured):
                 rc = m.main()
         self.assertEqual(rc, 1)
         self.assertIn("missing required vectors: V-MISSING", captured.getvalue())
+        self.assertNotIn("OK: domain test_domain", stdout.getvalue())
 
     def test_duplicate_domain_name_fails(self) -> None:
         with tempfile.TemporaryDirectory() as td:

--- a/tools/tests/test_check_conformance_edge_pack.py
+++ b/tools/tests/test_check_conformance_edge_pack.py
@@ -108,6 +108,34 @@ class EdgePackCheckerTests(unittest.TestCase):
         self.assertEqual(rc, 1)
         self.assertIn("missing required vectors: V-MISSING", captured.getvalue())
 
+    def test_duplicate_domain_name_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(root)
+            baseline_path = root / "conformance" / "EDGE_PACK_BASELINE.json"
+            baseline = json.loads(baseline_path.read_text(encoding="utf-8"))
+            baseline["domains"].append(dict(baseline["domains"][0]))
+            write_json(baseline_path, baseline)
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stderr(captured):
+                rc = m.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("duplicate domain name: test_domain", captured.getvalue())
+
+    def test_duplicate_domain_gate_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(root)
+            baseline_path = root / "conformance" / "EDGE_PACK_BASELINE.json"
+            baseline = json.loads(baseline_path.read_text(encoding="utf-8"))
+            baseline["domains"][0]["gates"] = ["CV-TEST", "CV-TEST"]
+            write_json(baseline_path, baseline)
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stderr(captured):
+                rc = m.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("domain test_domain gates entries must be unique", captured.getvalue())
+
     def test_required_vector_rejects_non_string_id(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)


### PR DESCRIPTION
## Scope
- Add `mempool_policy` and `da_fee_floor` edge/property accounting domains for committed `CV-MEMPOOL` and `CV-DA-FEE-FLOOR` vector IDs.
- Add `proof_coverage.json` accounting entries and checker/tests for missing IDs, duplicate accounting keys, malformed status shapes, and fuzz/formal overclaim failure.
- No runtime, fixture-byte, replay-adapter, workflow, fuzz-target, or formal-proof changes.

## Disposition
- Architecture class: B.
- Consensus/runtime changed: no.
- Go/Rust runtime changed: no.
- Fixture vectors changed: no.
- Fuzz/property implementation: no; RUB-129 remains separate.
- Formal proof claim: no.
- Source: Linear RUB-128; RUB-191 closeout evidence consumed.
- Verification: edge-pack checker, conformance matrix check, fixture policy check, targeted CV replay (30 vectors), full CV bundle replay (603 vectors), Python checker tests (26 tests), and Python static checks.

Closes #1359.
