### PR TITLE
RUB-41: align Rust /ready semantics with Go via narrow doc + hostile tests (#1329)

### DIFF
--- a/clients/rust/crates/rubin-node/src/devnet_rpc.rs
+++ b/clients/rust/crates/rubin-node/src/devnet_rpc.rs
@@ -107,15 +107,27 @@ pub struct RunningDevnetRPCServer {
 ///   `ReadinessGate::try_mark_ready_on_startup` path has not yet
 ///   completed its `NotReady` -> `Ready` transition". `/ready` reports
 ///   503 + `{ready: false}` (the JSON envelope byte-pinned by
-///   `ready_response_body_byte_pinned_against_go_format`). This is
+///   `ready_response_body_byte_pinned_rust_wire_format`). This is
 ///   the state a freshly constructed `DevnetRPCState` exposes BEFORE
 ///   `start_devnet_rpc_server` runs the post-bind stamp at the
 ///   `try_mark_ready_on_startup` call site below; orchestrators MUST
-///   treat 503 as "not-started" and not interleave work.
+///   treat 503 as "not-ready / unavailable" and not interleave work.
+///   Note: 503 alone does NOT distinguish `NotReady` (pre-stamp) from
+///   `Shutdown` (post-stamp) — both report 503 + `{ready:false}` by
+///   design. Consumers that need to distinguish boot-up from drain
+///   must use process-level signals (start log line, supervisor
+///   state) rather than reading meaning into the 503 source state.
 /// - `Ready` (post-`start_devnet_rpc_server` happy path):
-///   `is_ready() == true` claims ONLY that the RPC accept loop is
-///   bound on its listener and the gate has transitioned through the
-///   single boot stamp. It does NOT claim:
+///   `is_ready() == true` claims ONLY that the boot-time
+///   `try_mark_ready_on_startup` stamp has completed exactly once on
+///   the gate (the gate is a state latch, not a listener-bound
+///   invariant; production wiring at `start_devnet_rpc_server`
+///   stamps the gate post-bind so on the production happy path
+///   `is_ready() == true` coincides with a bound RPC listener, but
+///   nothing inside the gate enforces that — tests can stamp the
+///   gate without binding a listener, and a code change that moved
+///   the production stamp pre-bind would silently widen the
+///   readiness window). It does NOT claim:
 ///     * mempool admit-path is wired or fault-free (RUB-53 / #1339
 ///       tracker is open; mempool policy parity slice has not landed
 ///       and `/ready` does not gate on its readiness here);
@@ -135,9 +147,11 @@ pub struct RunningDevnetRPCServer {
 ///   `go_rust_parity_matrix` row "mempool/miner/sync prerequisites
 ///   if claimed" answered with NOT CLAIMED. Operators reading
 ///   `/ready == true` who need stronger guarantees must layer
-///   additional checks on top (e.g. `/peers` count, `/get_tip`
-///   non-zero height) and treat `/ready` as the boot-stamp latch
-///   only.
+///   additional checks on top (e.g. `/peers` count for peer
+///   liveness, `/get_tip` `has_tip == true` for chain initialization
+///   — note "non-zero height" is NOT a sound heuristic because a
+///   genesis-only chain legitimately reports height 0) and treat
+///   `/ready` as the boot-stamp latch only.
 ///
 /// - `Shutdown` (post-`mark_shutdown` terminal): sticky; once entered
 ///   the gate never returns to `Ready`. `/ready` reports 503 + `{ready:
@@ -150,10 +164,17 @@ pub struct RunningDevnetRPCServer {
 /// on 405 method-not-allowed) and by the `ReadyResponse` struct
 /// envelope. `coverage_reachability_matrix` row "public readiness
 /// check used by localhost/devnet tooling" is satisfied by the
-/// `ready_endpoint_*` test family in `tests` module which exercises
-/// the gate transitions ONLY through the public HTTP route_request
-/// path (no direct `state.readiness.is_ready()` shortcut from the
-/// asserts so a future bug in the public dispatch is caught).
+/// `ready_endpoint_*` test family in `tests` module which asserts
+/// `/ready` HTTP behavior via the public `route_request` dispatch.
+/// Some tests in the family additionally call `state.readiness.*`
+/// directly for setup (driving the gate to a target state) or for
+/// secondary post-condition assertions (e.g.
+/// `ready_endpoint_partial_start_returns_503` calls
+/// `try_mark_ready_on_startup` after the dispatch to prove the
+/// gate stayed in NotReady, not Shutdown). The PRIMARY readiness
+/// assertion in every `ready_endpoint_*` test is the public
+/// `route_request` response (status code + body bytes); helper
+/// calls supplement that, they do not replace it.
 ///
 /// Routes that Go's mixed-client tooling can scrape but Rust does
 /// NOT serve today: `GET /health` (rich operator snapshot at
@@ -5985,7 +6006,7 @@ mod tests {
     /// Proof assertion: byte-equality on body + content_type +
     /// extra_headers for each of the three response classes.
     #[test]
-    fn ready_response_body_byte_pinned_against_go_format() {
+    fn ready_response_body_byte_pinned_rust_wire_format() {
         let (state, dir) = build_state(true);
         // 200 path requires Ready; stamp it directly without going
         // through start_devnet_rpc_server (no listener needed for a

--- a/clients/rust/crates/rubin-node/src/devnet_rpc.rs
+++ b/clients/rust/crates/rubin-node/src/devnet_rpc.rs
@@ -105,10 +105,13 @@ pub struct RunningDevnetRPCServer {
 ///
 /// - `NotReady` (boot zero-value): means "the
 ///   `ReadinessGate::try_mark_ready_on_startup` path has not yet
-///   completed its `NotReady` -> `Ready` transition". `/ready` reports
-///   503 + `{ready: false}` (the JSON envelope byte-pinned by
-///   `ready_response_body_byte_pinned_rust_wire_format`). This is
-///   the state a freshly constructed `DevnetRPCState` exposes BEFORE
+///   completed its `NotReady` -> `Ready` transition". `GET /ready`
+///   reports 503 + `{ready: false}` (the JSON envelope byte-pinned by
+///   `ready_response_body_byte_pinned_rust_wire_format`); non-GET
+///   methods on `/ready` always return 405 + `Allow: GET` regardless
+///   of gate state per RFC 9110 §15.5.6 (handler dispatch order:
+///   method check first, then state read). This is the state a
+///   freshly constructed `DevnetRPCState` exposes BEFORE
 ///   `start_devnet_rpc_server` runs the post-bind stamp at the
 ///   `try_mark_ready_on_startup` call site below; orchestrators MUST
 ///   treat 503 as "not-ready / unavailable" and not interleave work.
@@ -154,9 +157,11 @@ pub struct RunningDevnetRPCServer {
 ///   `/ready` as the boot-stamp latch only.
 ///
 /// - `Shutdown` (post-`mark_shutdown` terminal): sticky; once entered
-///   the gate never returns to `Ready`. `/ready` reports 503 + `{ready:
-///   false}` permanently for this gate's lifetime; operator-facing
-///   recovery is process restart, not a /ready-driven re-arm.
+///   the gate never returns to `Ready`. `GET /ready` reports 503 +
+///   `{ready: false}` permanently for this gate's lifetime; non-GET
+///   methods on `/ready` continue to return 405 + `Allow: GET`
+///   independently of gate state. Operator-facing recovery is
+///   process restart, not a /ready-driven re-arm.
 ///
 /// `go_rust_parity_matrix` row "error status and response shape" is
 /// pinned by `handle_ready` below (200 vs 503 status code; `{ready:

--- a/clients/rust/crates/rubin-node/src/devnet_rpc.rs
+++ b/clients/rust/crates/rubin-node/src/devnet_rpc.rs
@@ -752,7 +752,7 @@ fn route_request(state: &DevnetRPCState, req: HttpRequest) -> HttpResponse {
 ///     (post-`try_mark_ready_on_startup`, pre-`mark_shutdown`)
 ///   - 503 `{"ready":false}` when the gate is in `NotReady`
 ///     (pre-startup) or `Shutdown` (post-shutdown) state
-///   - 405 `{accepted: false, error: "GET required"}` with
+///   - 405 `{"accepted":false,"error":"GET required"}` with
 ///     `Allow: GET` header on non-GET methods, per RFC 9110 §15.5.6
 ///
 /// Mirrors Go's `handleReady` at
@@ -805,7 +805,7 @@ fn handle_ready(state: &DevnetRPCState, method: &str) -> HttpResponse {
 ///   - 200 `{count: usize, peers: [PeerEntry...]}` sorted by `addr`
 ///     ascending, on a successful GET (any peer count, including
 ///     zero — empty peer set is `{"count":0,"peers":[]}`)
-///   - 405 `{accepted: false, error: "GET required"}` with
+///   - 405 `{"accepted":false,"error":"GET required"}` with
 ///     `Allow: GET` header on non-GET methods, per RFC 9110 §15.5.6
 ///
 /// Mirrors Go's `handlePeers` at `clients/go/cmd/rubin-node/http_rpc.go:1584-1621`
@@ -5930,7 +5930,7 @@ mod tests {
     /// Proof assertion: drive `/ready` through `route_request` (the
     /// production HTTP dispatch entry the accept loop calls) WITHOUT
     /// calling `start_devnet_rpc_server`. The asserts below pin the
-    /// public-path output (status 503 + body `{"ready": false}`) and
+    /// public-path output (status 503 + body `{"ready":false}`) and
     /// the post-condition that the gate remains eligible for the
     /// boot-time stamp (proof anchor: `try_mark_ready_on_startup`
     /// returns true after the dispatch, which only succeeds from

--- a/clients/rust/crates/rubin-node/src/devnet_rpc.rs
+++ b/clients/rust/crates/rubin-node/src/devnet_rpc.rs
@@ -96,6 +96,77 @@ pub struct RunningDevnetRPCServer {
 /// `Shutdown`. `Shutdown` is observable via `is_ready() == false` and
 /// is the operational signal mixed-client devnet evidence consumers
 /// use to stop submitting work to a draining node.
+///
+/// RUB-41 / GitHub #1329 readiness-meaning matrix (the `go_rust_parity_matrix`
+/// row "not-started/starting/ready/unavailable meaning" enumerated
+/// per state). The semantics that `is_ready() == true` claims and what
+/// it does NOT claim are pinned here so future readers can recover
+/// the bounded readiness contract from the source alone:
+///
+/// - `NotReady` (boot zero-value): means "the
+///   `ReadinessGate::try_mark_ready_on_startup` path has not yet
+///   completed its `NotReady` -> `Ready` transition". `/ready` reports
+///   503 + `{ready: false}` (the JSON envelope byte-pinned by
+///   `ready_response_body_byte_pinned_against_go_format`). This is
+///   the state a freshly constructed `DevnetRPCState` exposes BEFORE
+///   `start_devnet_rpc_server` runs the post-bind stamp at the
+///   `try_mark_ready_on_startup` call site below; orchestrators MUST
+///   treat 503 as "not-started" and not interleave work.
+/// - `Ready` (post-`start_devnet_rpc_server` happy path):
+///   `is_ready() == true` claims ONLY that the RPC accept loop is
+///   bound on its listener and the gate has transitioned through the
+///   single boot stamp. It does NOT claim:
+///     * mempool admit-path is wired or fault-free (RUB-53 / #1339
+///       tracker is open; mempool policy parity slice has not landed
+///       and `/ready` does not gate on its readiness here);
+///     * miner is configured (live mining is opt-in via
+///       `live_mining_cfg`; absence does not flip the gate to false);
+///     * sync engine has reached chain tip or has any peer
+///       (`PeerManager` peer count is observable via `/peers`, not
+///       `/ready`);
+///     * the lifecycle context has not been canceled by an external
+///       signal (Rust `main.rs` does not install SIGINT/SIGTERM
+///       handlers, so a signal-driven kill skips `mark_shutdown` and
+///       the gate stays `Ready` until process exit terminates the
+///       listener — the documented Rust-vs-Go divergence preserved
+///       from RUB-10).
+///
+///   The mempool/miner/sync absence rows above are explicitly the
+///   `go_rust_parity_matrix` row "mempool/miner/sync prerequisites
+///   if claimed" answered with NOT CLAIMED. Operators reading
+///   `/ready == true` who need stronger guarantees must layer
+///   additional checks on top (e.g. `/peers` count, `/get_tip`
+///   non-zero height) and treat `/ready` as the boot-stamp latch
+///   only.
+///
+/// - `Shutdown` (post-`mark_shutdown` terminal): sticky; once entered
+///   the gate never returns to `Ready`. `/ready` reports 503 + `{ready:
+///   false}` permanently for this gate's lifetime; operator-facing
+///   recovery is process restart, not a /ready-driven re-arm.
+///
+/// `go_rust_parity_matrix` row "error status and response shape" is
+/// pinned by `handle_ready` below (200 vs 503 status code; `{ready:
+/// bool}` body; `application/json` Content-Type; `Allow: GET` header
+/// on 405 method-not-allowed) and by the `ReadyResponse` struct
+/// envelope. `coverage_reachability_matrix` row "public readiness
+/// check used by localhost/devnet tooling" is satisfied by the
+/// `ready_endpoint_*` test family in `tests` module which exercises
+/// the gate transitions ONLY through the public HTTP route_request
+/// path (no direct `state.readiness.is_ready()` shortcut from the
+/// asserts so a future bug in the public dispatch is caught).
+///
+/// Routes that Go's mixed-client tooling can scrape but Rust does
+/// NOT serve today: `GET /health` (rich operator snapshot at
+/// `clients/go/cmd/rubin-node/http_rpc.go::handleHealth` L1517+,
+/// returning ready+chain_context+mempool counts+peer_count) and
+/// `GET /chain_identity` (chain identity mux at the same Go file
+/// L701-703; `/health` mux follows at L704). Adding either Rust
+/// mirror is explicitly out of
+/// scope for RUB-41 because the `class_change_stop_rule` would
+/// trigger ("If readiness needs new endpoint/schema/lifecycle
+/// behavior, stop and split"). RUB-41 narrows to `/ready` SEMANTICS
+/// only; the missing routes are deferred to a follow-up slice once
+/// the contract for adding them has its own architect review.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum ReadyState {
     NotReady,
@@ -5808,6 +5879,179 @@ mod tests {
             ReadyState::Ready,
             ReadyState::Shutdown,
         ];
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    /// RUB-41 / GitHub #1329 hostile_case "partial startup": a
+    /// `DevnetRPCState` constructed via `new_devnet_rpc_state` but
+    /// never passed through `start_devnet_rpc_server` MUST report
+    /// `/ready` as 503 + `{ready: false}` regardless of any other
+    /// node wiring already in place. The boot-time
+    /// `try_mark_ready_on_startup` stamp lives inside
+    /// `start_devnet_rpc_server`, so a
+    /// half-spawned node — for example a fixture that constructs the
+    /// state to exercise some other handler in isolation, or a
+    /// production startup that bails before the listener is bound —
+    /// MUST NOT be observed as ready by orchestrators.
+    ///
+    /// This is the public-path counterpart of the boot-state row in
+    /// the `ReadinessGate` parity matrix doc. It complements
+    /// `ready_endpoint_reports_503_when_not_ready` (which exercises
+    /// the gate-only path) by asserting that a richer state object
+    /// (block_store wired, peer_manager wired, sync_engine populated)
+    /// still reports 503 when the gate is at boot zero-value.
+    ///
+    /// Proof assertion: drive `/ready` through `route_request` (the
+    /// production HTTP dispatch entry the accept loop calls) WITHOUT
+    /// calling `start_devnet_rpc_server`. The asserts below pin the
+    /// public-path output (status 503 + body `{"ready": false}`) and
+    /// the post-condition that the gate remains eligible for the
+    /// boot-time stamp (proof anchor: `try_mark_ready_on_startup`
+    /// returns true after the dispatch, which only succeeds from
+    /// the `NotReady` initial cell value).
+    #[test]
+    fn ready_endpoint_partial_start_returns_503() {
+        let (state, dir) = build_state(true);
+        // Sanity: gate is at boot zero-value, not yet stamped Ready.
+        assert!(
+            !state.readiness.is_ready(),
+            "freshly constructed gate must report not-ready before \
+             start_devnet_rpc_server"
+        );
+        let response = route_request(
+            &state,
+            HttpRequest {
+                method: "GET".to_string(),
+                target: "/ready".to_string(),
+                body: Vec::new(),
+            },
+        );
+        assert_eq!(
+            response.status, 503,
+            "/ready on a partially-started node must report 503 (boot \
+             zero-value gate); got status={}",
+            response.status
+        );
+        let body: Value =
+            serde_json::from_slice(&response.body).expect("partial-start ready 503 json");
+        assert_eq!(body["ready"], serde_json::json!(false));
+        // Proof anchor: try_mark_ready_on_startup returns true only
+        // when the gate is at the NotReady initial cell value. The
+        // assertion below therefore pins that the partial-start path
+        // leaves the gate in NotReady (not Shutdown), so the boot-
+        // time stamp can still complete on the same state object.
+        assert!(
+            state.readiness.try_mark_ready_on_startup(),
+            "partial-start gate must still be in NotReady (eligible \
+             for boot stamp), not Shutdown"
+        );
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    /// RUB-41 / GitHub #1329 hostile_case "status field mismatch vs
+    /// Go": pin the exact byte format Rust's `/ready` responses
+    /// produce so a future change to `json_response` or the
+    /// `ReadyResponse` struct cannot silently drift from the wire
+    /// shape orchestrators (mixed-client devnet evidence consumers,
+    /// Codacy/Copilot health probes, operator scripts) parse.
+    ///
+    /// Pinned by this test (RUB-10 PR #1472 baseline preserved):
+    /// - 200 path: `Content-Type: application/json`, body bytes
+    ///   `{"ready":true}` (no trailing newline, no whitespace inside
+    ///   braces, fields in declaration order).
+    /// - 503 path: `Content-Type: application/json`, body bytes
+    ///   `{"ready":false}`.
+    /// - 405 path: `Content-Type: application/json` + `Allow: GET`
+    ///   header, body bytes `{"accepted":false,"error":"GET required"}`
+    ///   (no `txid` field — `Option::None` skipped via
+    ///   `skip_serializing_if`).
+    ///
+    /// Documented divergence vs Go that this test does NOT close
+    /// (out of RUB-41 scope per `class_change_stop_rule`): Go's
+    /// `writeJSONResponse` calls `json.NewEncoder(w).Encode(payload)`,
+    /// which appends a `\n` byte per Go documentation
+    /// (`encoding/json.Encoder.Encode`). Rust's `json_response` calls
+    /// `serde_json::to_vec(payload)` which does NOT append `\n`. So
+    /// Go emits `{"ready":true}\n` (15 bytes) where Rust emits
+    /// `{"ready":true}` (14 bytes); both are valid JSON and every
+    /// JSON parser accepts both. Aligning the trailing newline is a
+    /// broader `json_response` refactor that touches every Rust RPC
+    /// handler — out of scope here, deferred to a future slice that
+    /// owns "Rust JSON wire-format trailing-newline parity" if
+    /// orchestrators ever need byte-exact equality (today the
+    /// `Content-Length` header lets parsers terminate cleanly without
+    /// the trailing newline).
+    ///
+    /// Proof assertion: byte-equality on body + content_type +
+    /// extra_headers for each of the three response classes.
+    #[test]
+    fn ready_response_body_byte_pinned_against_go_format() {
+        let (state, dir) = build_state(true);
+        // 200 path requires Ready; stamp it directly without going
+        // through start_devnet_rpc_server (no listener needed for a
+        // body-only byte-pin test).
+        assert!(state.readiness.try_mark_ready_on_startup());
+        let r200 = route_request(
+            &state,
+            HttpRequest {
+                method: "GET".to_string(),
+                target: "/ready".to_string(),
+                body: Vec::new(),
+            },
+        );
+        assert_eq!(r200.status, 200);
+        assert_eq!(r200.content_type, "application/json");
+        assert_eq!(
+            r200.body.as_slice(),
+            b"{\"ready\":true}".as_slice(),
+            "200 body bytes must match the pinned Rust wire format \
+             (no trailing newline, no whitespace); got: {:?}",
+            String::from_utf8_lossy(&r200.body)
+        );
+        // 503 path: flip gate to Shutdown, ready=false.
+        state.readiness.mark_shutdown();
+        let r503 = route_request(
+            &state,
+            HttpRequest {
+                method: "GET".to_string(),
+                target: "/ready".to_string(),
+                body: Vec::new(),
+            },
+        );
+        assert_eq!(r503.status, 503);
+        assert_eq!(r503.content_type, "application/json");
+        assert_eq!(
+            r503.body.as_slice(),
+            b"{\"ready\":false}".as_slice(),
+            "503 body bytes must match the pinned Rust wire format; \
+             got: {:?}",
+            String::from_utf8_lossy(&r503.body)
+        );
+        // 405 path: non-GET method, error envelope + Allow header.
+        let r405 = route_request(
+            &state,
+            HttpRequest {
+                method: "POST".to_string(),
+                target: "/ready".to_string(),
+                body: Vec::new(),
+            },
+        );
+        assert_eq!(r405.status, 405);
+        assert_eq!(r405.content_type, "application/json");
+        assert_eq!(
+            r405.body.as_slice(),
+            b"{\"accepted\":false,\"error\":\"GET required\"}".as_slice(),
+            "405 body bytes must match the pinned Rust error envelope \
+             (no `txid` field per skip_serializing_if); got: {:?}",
+            String::from_utf8_lossy(&r405.body)
+        );
+        assert!(
+            r405.extra_headers
+                .iter()
+                .any(|(name, value)| *name == "Allow" && value == "GET"),
+            "405 response must carry `Allow: GET` per RFC 9110 \
+             §15.5.6 (also pinned by ready_endpoint_returns_405_*)"
+        );
         fs::remove_dir_all(dir).expect("cleanup");
     }
 

--- a/clients/rust/crates/rubin-node/src/devnet_rpc.rs
+++ b/clients/rust/crates/rubin-node/src/devnet_rpc.rs
@@ -66,7 +66,7 @@ pub struct DevnetRPCState {
     /// stack unwinding), but `clients/rust/crates/rubin-node/src/main.rs`
     /// installs no SIGINT/SIGTERM handler, so a signal-driven kill
     /// terminates the process before `close()` runs and consumers see
-    /// connection-refused rather than the 503+`{ready:false}` envelope.
+    /// connection-refused rather than the 503+`{"ready":false}` envelope.
     /// Adding a signal handler that drives `mark_shutdown` is a
     /// runtime-lifecycle change deliberately excluded from RUB-10 by
     /// `class_change_stop_rule`; it is in scope for graceful-shutdown
@@ -106,7 +106,7 @@ pub struct RunningDevnetRPCServer {
 /// - `NotReady` (boot zero-value): means "the
 ///   `ReadinessGate::try_mark_ready_on_startup` path has not yet
 ///   completed its `NotReady` -> `Ready` transition". `GET /ready`
-///   reports 503 + `{ready: false}` (the JSON envelope byte-pinned by
+///   reports 503 + `{"ready":false}` (the JSON envelope byte-pinned by
 ///   `ready_response_body_byte_pinned_rust_wire_format`); non-GET
 ///   methods on `/ready` always return 405 + `Allow: GET` regardless
 ///   of gate state per RFC 9110 §15.5.6 (handler dispatch order:
@@ -116,7 +116,7 @@ pub struct RunningDevnetRPCServer {
 ///   `try_mark_ready_on_startup` call site below; orchestrators MUST
 ///   treat 503 as "not-ready / unavailable" and not interleave work.
 ///   Note: 503 alone does NOT distinguish `NotReady` (pre-stamp) from
-///   `Shutdown` (post-stamp) — both report 503 + `{ready:false}` by
+///   `Shutdown` (post-stamp) — both report 503 + `{"ready":false}` by
 ///   design. Consumers that need to distinguish boot-up from drain
 ///   must use process-level signals (start log line, supervisor
 ///   state) rather than reading meaning into the 503 source state.
@@ -158,7 +158,7 @@ pub struct RunningDevnetRPCServer {
 ///
 /// - `Shutdown` (post-`mark_shutdown` terminal): sticky; once entered
 ///   the gate never returns to `Ready`. `GET /ready` reports 503 +
-///   `{ready: false}` permanently for this gate's lifetime; non-GET
+///   `{"ready":false}` permanently for this gate's lifetime; non-GET
 ///   methods on `/ready` continue to return 405 + `Allow: GET`
 ///   independently of gate state. Operator-facing recovery is
 ///   process restart, not a /ready-driven re-arm.
@@ -748,9 +748,9 @@ fn route_request(state: &DevnetRPCState, req: HttpRequest) -> HttpResponse {
 
 /// RUB-10 / GitHub #1151: `/ready` endpoint for mixed-client devnet
 /// evidence consumers. Returns one of:
-///   - 200 `{ready: true}` when the gate is in `Ready` state
+///   - 200 `{"ready":true}` when the gate is in `Ready` state
 ///     (post-`try_mark_ready_on_startup`, pre-`mark_shutdown`)
-///   - 503 `{ready: false}` when the gate is in `NotReady`
+///   - 503 `{"ready":false}` when the gate is in `NotReady`
 ///     (pre-startup) or `Shutdown` (post-shutdown) state
 ///   - 405 `{accepted: false, error: "GET required"}` with
 ///     `Allow: GET` header on non-GET methods, per RFC 9110 §15.5.6
@@ -5608,7 +5608,7 @@ mod tests {
     }
 
     /// RUB-10 / GitHub #1151: `/ready` endpoint reports 503 + body
-    /// `{ready: false}` when the readiness gate is in the initial
+    /// `{"ready":false}` when the readiness gate is in the initial
     /// `NotReady` state (before `start_devnet_rpc_server` has stamped
     /// it `Ready`). Mirrors Go's `handleReady` 503 branch at
     /// `clients/go/cmd/rubin-node/http_rpc.go:669`.
@@ -5641,7 +5641,7 @@ mod tests {
         fs::remove_dir_all(dir).expect("cleanup");
     }
 
-    /// RUB-10 / GitHub #1151: `/ready` reports 200 + `{ready: true}`
+    /// RUB-10 / GitHub #1151: `/ready` reports 200 + `{"ready":true}`
     /// after `start_devnet_rpc_server` stamps the gate `Ready`.
     /// Mirrors Go's `handleReady` 200 branch at `clients/go/cmd/rubin-node/http_rpc.go:666` and
     /// proves the production startup wiring (mark-ready post-bind in
@@ -5678,7 +5678,7 @@ mod tests {
 
     /// RUB-10 / GitHub #1151: shutdown is sticky. After
     /// `RunningDevnetRPCServer::close` (or Drop) stamps `Shutdown`,
-    /// `/ready` reports 503 + `{ready: false}` permanently — mixed-
+    /// `/ready` reports 503 + `{"ready":false}` permanently — mixed-
     /// client orchestrators must stop submitting work to a draining
     /// node. Mirrors Go's `MarkShutdown` semantics at
     /// `clients/go/cmd/rubin-node/http_rpc.go:184-191` (sticky
@@ -5911,7 +5911,7 @@ mod tests {
     /// RUB-41 / GitHub #1329 hostile_case "partial startup": a
     /// `DevnetRPCState` constructed via `new_devnet_rpc_state` but
     /// never passed through `start_devnet_rpc_server` MUST report
-    /// `/ready` as 503 + `{ready: false}` regardless of any other
+    /// `/ready` as 503 + `{"ready":false}` regardless of any other
     /// node wiring already in place. The boot-time
     /// `try_mark_ready_on_startup` stamp lives inside
     /// `start_devnet_rpc_server`, so a


### PR DESCRIPTION
## Summary

RUB-41 / GitHub #1329 (`Q-RUST-LOCALHOST-READINESS-SIGNAL-PARITY-01`) narrow-scope slice on top of RUB-10 / PR #1472. Closes the `single_contract_delta` ("Align Rust readiness status semantics with Go for localhost/devnet operator flows") via doc-narrowing on `ReadinessGate` plus 2 hostile-case tests, with **0 production code change** and **1 file touched** (`clients/rust/crates/rubin-node/src/devnet_rpc.rs`).

## Changes

1. Doc-narrow `ReadinessGate` with explicit `go_rust_parity_matrix` row enumerated per state (NotReady/Ready/Shutdown). Ready state gets explicit "claims X / does NOT claim Y" matrix listing mempool/miner/sync/lifecycle dimensions NOT validated. Discloses Go-only `/health` (operator snapshot at `clients/go/cmd/rubin-node/http_rpc.go::handleHealth` L1517+) and `/chain_identity` (mux at L701-703; `/health` mux at L704) as deferred per `class_change_stop_rule`.

2. Two hostile-case tests through public `route_request` path:
  - `ready_endpoint_partial_start_returns_503` — partial-start scenario (state created but `start_devnet_rpc_server` not called → 503 + `{"ready":false}`)
  - `ready_response_body_byte_pinned_rust_wire_format` — exact byte format pin for 200/503/405 paths; documents but does NOT close the trailing-newline JSON divergence vs Goʼs `json.NewEncoder.Encode` (broader json_response refactor; out of scope per non_goal "No broad RPC/API redesign")

## Wave fixes folded in

- Wave-1 (5×P2 Copilot): 5 doc precision fixes — NotReady/Ready bullet wording, partial-start docstring proof anchor, test rename to `ready_response_body_byte_pinned_rust_wire_format`, `/get_tip has_tip` heuristic
- Wave-2 (2×P1 Copilot): GET method qualifier on `/ready reports 503` claims (NotReady + Shutdown bullets)
- Wave-3 (1×P2 Copilot): valid JSON `{"ready":bool}` in value-example doc fragments (10 substitutions)
- Wave-4 (3×P2 Copilot): wire-format-byte-tight 405 envelope `{"accepted":false,"error":"GET required"}`, byte-tight `{"ready":false}` (no whitespace), test rename reflected in PR body

## Out of scope (preserves `class_change_stop_rule`)

- No new endpoint (`/health`, `/chain_identity` deferred)
- No new schema (`ReadyResponse` envelope unchanged)
- No new lifecycle behavior (no SIGINT/SIGTERM handler — RUB-21/22/23 process-soak proof scope)
- No Go-side change
- No mempool/miner/sync wiring change
- No JSON wire-format trailing-newline alignment (deferred)

## Required matrices

- `go_rust_parity_matrix`: rows enumerated in new `ReadinessGate` doc
- `coverage_reachability_matrix`: row "public readiness check used by localhost/devnet tooling" satisfied by `ready_endpoint_*` test family (now 6 tests; all assert via `route_request`)
- `conformance_matrix`, `spec_fixture_matrix`, `formal_proof_matrix`: not_applicable per issue body

## Receipts

- core: PASS (initial pre-push)
- tooling: PASS (initial pre-push)
- review fanout: PASS (parity / issue-matrix / prepush-hostile, all RUNTIME_SANDBOX read-only)
- coverage: PASS (434s)
- delta: PASS

## Test plan

- [x] cargo fmt clean
- [x] cargo clippy --lib --all-targets -D warnings clean
- [x] cargo test devnet_rpc::tests::ready_endpoint_* (6 tests PASS) including renamed `ready_response_body_byte_pinned_rust_wire_format`
- [x] CI: validator + test + Kani + formal + coverage + CodeQL + Codacy + security_ai (Go 1.26.3 from #1482 toolchain) — all 16 PASS at HEAD 5745540

Refs: #1329

<!-- rubin-agent-meta actor=unknown action=pr-edit via=cl branch=claude/rub-41-rust-readiness-parity wt=rubin-protocol-claude-rub-41 utc=2026-05-07T21:31:14Z -->
