### PR TITLE
ci: bump go-version pin '1.25.9' -> '1.26.3' (exact, security_ai unblock)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: '1.25.9'
+          go-version: '1.26.3'
           cache: true
           cache-dependency-path: |
             clients/go/go.mod
@@ -272,7 +272,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: '1.25.9'
+          go-version: '1.26.3'
           cache: true
           cache-dependency-path: clients/go/go.mod
 
@@ -501,7 +501,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: '1.25.9'
+          go-version: '1.26.3'
           cache: true
           cache-dependency-path: clients/go/go.mod
 
@@ -615,7 +615,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: '1.25.9'
+          go-version: '1.26.3'
           cache: true
           cache-dependency-path: clients/go/go.mod
 

--- a/.github/workflows/codacy-coverage.yml
+++ b/.github/workflows/codacy-coverage.yml
@@ -59,7 +59,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: '1.25.9'
+          go-version: '1.26.3'
           cache: true
           cache-dependency-path: clients/go/go.mod
 

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: '1.25.9'
+          go-version: '1.26.3'
           cache: true
           cache-dependency-path: clients/go/go.mod
 

--- a/.github/workflows/runtime-perf-guardrails.yml
+++ b/.github/workflows/runtime-perf-guardrails.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: '1.25.9'
+          go-version: '1.26.3'
           cache: true
           cache-dependency-path: |
             clients/go/go.mod


### PR DESCRIPTION
## Summary

Bumps GitHub Actions `go-version` pin across all CI workflows from exact-pin `'1.25.9'` to exact-pin `'1.26.3'` to unblock the `security_ai` (govulncheck) gate tripping on GO-2026-4971 / GO-2026-4918 (published 2026-05-07).

## Why exact `'1.26.3'` and not minor `'1.25.x'` / `'1.26.x'`

Two prior force-pushes on this PR revealed the actual blocker: `actions/setup-go`'s minor-pin resolver reads from a cached `versions-manifest.json` hosted at `github.com/actions/go-versions`, which lags behind golang.org by days after a Go release. So:

- `'1.25.x'` resolved to **1.25.9** on the runner (manifest cache had not picked up 1.25.10).
- `'1.26.x'` resolved to **1.26.2** (manifest cache had not picked up 1.26.3).
- Both pre-fix patches still trip govulncheck.

Per `actions/setup-go` docs: when the requested version is not in the cached manifest, the action falls back to **direct download from `https://go.dev/dl/`**. Verified `go1.26.3.linux-amd64.tar.gz` returns HTTP 200 and matches the locally-installed Go 1.26.3 in `~/sdk` (controller workstation also reports 1.26.3 local). So `'1.26.3'` exact-pin is the only form that pulls a fix-bearing toolchain right now.

Trade-off: this exact-pin reverts the auto-upgrade posture. Once `actions/setup-go`'s `versions-manifest` catches up to 1.25.10 / 1.26.3 (typically within days of a Go release), a follow-up CI slice can relax to `'1.26.x'` for resumed auto-upgrade.

## Files changed (CI infrastructure only)

- `.github/workflows/ci.yml` (4 occurrences)
- `.github/workflows/codacy-coverage.yml` (1)
- `.github/workflows/runtime-perf-guardrails.yml` (1)
- `.github/workflows/fuzz-nightly.yml` (1)

7 total `'1.25.9'` -> `'1.26.3'` substitutions. **No Go source code, no `go.mod`, no `go.sum`, no runtime change, no Rust change.** `go.mod` declares `go 1.24.13` minimum so 1.26.3 runs clean. The `kani.yml` workflow uses a separate Rust nightly toolchain and is not affected.

## Why a separate PR

Originally folded into PR #1481 (RUB-41 Rust readiness-parity slice) as a CI unblock, but per controller scope-discipline directive split out so PR #1481 retains its narrow Rust readiness-semantics scope. PR #1481 will pick up this toolchain bump via `gh pr update-branch` after merge.

## Test plan

- [ ] `security_ai` produces SUCCESS (no GO-2026-4971/4918 trip)
- [ ] `test` produces SUCCESS (same govulncheck logic in Go test path)
- [ ] Other Go-touching jobs (`Go node race gate`, `coverage`, `runtime-perf`, `Conformance fixtures drift check`, `CodeQL Analysis (go, autobuild)`, `fuzz-nightly` weekly) build cleanly on 1.26.3

Refs: GO-2026-4971, GO-2026-4918

<!-- rubin-agent-meta actor=unknown action=pr-edit via=cl branch=claude/ci-go-version-bump-1.26x wt=rubin-protocol-claude-ci-go-bump utc=2026-05-07T21:00:04Z -->
