### PR TITLE
RUB-206: mixed-client devnet evidence base + cross-impl tx_path invariant (#1485)

### DIFF
--- a/scripts/devnet/schema/mixed_client_evidence_v1.json
+++ b/scripts/devnet/schema/mixed_client_evidence_v1.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rubin-protocol.dev/schemas/scripts/devnet/mixed_client_evidence_v1.json",
+  "title": "Rubin Mixed-Client Devnet Evidence v1 — base slice (PR-A)",
+  "description": "Minimum process-soak evidence schema needed to prove cross-implementation tx propagation between Go and Rust nodes. Restart/reorg, timestamp policy, and endpoint port policy are deferred to follow-up slices.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "evidence_type",
+    "scenario",
+    "verdict",
+    "participants"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "rubin-mixed-client-devnet-evidence-v1"
+    },
+    "evidence_type": {
+      "type": "string",
+      "enum": [
+        "mixed_client_process_soak",
+        "single_client_process_soak"
+      ]
+    },
+    "scenario": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 200
+    },
+    "verdict": {
+      "type": "string",
+      "enum": [
+        "PASS",
+        "FAIL"
+      ]
+    },
+    "failure_reason": {
+      "type": "string",
+      "minLength": 1
+    },
+    "participants": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "implementation"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "pattern": "^node-[a-z0-9][a-z0-9-]{0,30}$"
+          },
+          "implementation": {
+            "type": "string",
+            "enum": [
+              "go",
+              "rust"
+            ]
+          }
+        }
+      }
+    },
+    "tx_path": {
+      "type": "object",
+      "required": [
+        "submitted_at",
+        "observed_at",
+        "tx_id"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "submitted_at": {
+          "type": "string",
+          "minLength": 1
+        },
+        "observed_at": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "tx_id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        }
+      }
+    }
+  }
+}

--- a/scripts/devnet/testdata/valid_minimal_mixed.json
+++ b/scripts/devnet/testdata/valid_minimal_mixed.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": "rubin-mixed-client-devnet-evidence-v1",
+  "evidence_type": "mixed_client_process_soak",
+  "scenario": "minimal_mixed_go_to_rust_propagation",
+  "verdict": "PASS",
+  "participants": [
+    {"name": "node-a", "implementation": "go"},
+    {"name": "node-b", "implementation": "rust"}
+  ],
+  "tx_path": {
+    "submitted_at": "node-a",
+    "observed_at": ["node-b"],
+    "tx_id": "3333333333333333333333333333333333333333333333333333333333333333"
+  }
+}

--- a/scripts/devnet/validate_mixed_client_evidence.py
+++ b/scripts/devnet/validate_mixed_client_evidence.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Validate mixed-client devnet process-soak evidence — base slice (PR-A).
+
+Enforces the minimum invariants needed to prove cross-implementation tx
+propagation between Go and Rust nodes:
+
+* JSON Schema Draft 2020-12 shape (top-level fields, participant shape, tx_path
+  shape) via the committed schema.
+* Cross-field invariants the schema cannot express on its own:
+    - mixed_client_process_soak requires both go and rust participants;
+    - single_client_process_soak requires one implementation;
+    - verdict=FAIL requires non-empty failure_reason;
+    - tx_path.submitted_at and observed_at must reference declared participants;
+    - mixed_client_process_soak with verdict=PASS must include at least one
+      observer whose implementation differs from the submitter's; same-impl
+      propagation in a mixed participant set is NOT mixed-client proof.
+
+Restart / reorg cross-field invariants, timestamp / endpoint textual policy,
+and the helper-vs-real-process distinction are deferred to follow-up slices.
+
+Used as the offline gate for `mixed_client_process_soak` PASS evidence.
+
+Usage:
+    python3 scripts/devnet/validate_mixed_client_evidence.py FIXTURE.json
+    python3 scripts/devnet/validate_mixed_client_evidence.py --schema PATH FIXTURE.json
+
+Exits 0 on PASS, 1 on validation failure or unreadable input.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+DEFAULT_SCHEMA = REPO_ROOT / "scripts" / "devnet" / "schema" / "mixed_client_evidence_v1.json"
+
+SCHEMA_VERSION = "rubin-mixed-client-devnet-evidence-v1"
+PROCESS_SOAK_TYPES = ("mixed_client_process_soak", "single_client_process_soak")
+
+
+def _validate_with_jsonschema(data: Any, schema: dict) -> list[str]:
+    try:
+        import jsonschema  # type: ignore[import-untyped]
+    except ImportError:
+        return [
+            "<root>: jsonschema library unavailable; install jsonschema for full Draft 2020-12 validation"
+        ]
+    validator = jsonschema.Draft202012Validator(schema)
+    errors = sorted(validator.iter_errors(data), key=lambda e: list(e.absolute_path))
+    return [
+        f"{'.'.join(str(p) for p in e.absolute_path) or '<root>'}: {e.message}"
+        for e in errors
+    ]
+
+
+def _validate_cross_field(data: Any) -> list[str]:
+    """Cross-field invariants jsonschema cannot express."""
+    errors: list[str] = []
+    if not isinstance(data, dict):
+        return ["<root>: top-level JSON must be an object"]
+
+    if data.get("schema_version") != SCHEMA_VERSION:
+        errors.append(
+            f"schema_version: must be exactly '{SCHEMA_VERSION}'; got {data.get('schema_version')!r}"
+        )
+
+    evidence_type = data.get("evidence_type")
+    verdict = data.get("verdict")
+
+    if verdict == "FAIL":
+        reason = data.get("failure_reason")
+        if not isinstance(reason, str) or not reason.strip():
+            errors.append(
+                "failure_reason: required and must be non-empty when verdict=FAIL"
+            )
+
+    participants = data.get("participants")
+    if not isinstance(participants, list) or not participants:
+        if evidence_type in PROCESS_SOAK_TYPES:
+            errors.append(
+                f"participants: required for evidence_type={evidence_type!r}"
+            )
+        return errors
+
+    impls = [p.get("implementation") for p in participants if isinstance(p, dict)]
+    names_list = [
+        p.get("name")
+        for p in participants
+        if isinstance(p, dict) and isinstance(p.get("name"), str)
+    ]
+    impl_by_name: dict[str, str] = {
+        p.get("name"): p.get("implementation")
+        for p in participants
+        if isinstance(p, dict) and isinstance(p.get("name"), str)
+    }
+    valid_names = set(impl_by_name)
+
+    if evidence_type == "mixed_client_process_soak":
+        if not (any(i == "go" for i in impls) and any(i == "rust" for i in impls)):
+            observed = sorted({i for i in impls if isinstance(i, str)})
+            errors.append(
+                "participants: evidence_type=mixed_client_process_soak requires "
+                "at least one implementation=go and one implementation=rust; "
+                f"observed implementations={observed}"
+            )
+        if len(participants) < 2:
+            errors.append(
+                "participants: evidence_type=mixed_client_process_soak "
+                "requires at least 2 participants"
+            )
+    elif evidence_type == "single_client_process_soak":
+        unique = {i for i in impls if isinstance(i, str)}
+        if len(unique) > 1:
+            errors.append(
+                "participants: evidence_type=single_client_process_soak "
+                f"requires one implementation; observed={sorted(unique)}"
+            )
+
+    duplicates = sorted({n for n in names_list if names_list.count(n) > 1})
+    if duplicates:
+        errors.append(f"participants: duplicate names: {duplicates}")
+
+    tx_path = data.get("tx_path")
+    if isinstance(tx_path, dict):
+        submitted_at = tx_path.get("submitted_at")
+        observed_at = tx_path.get("observed_at")
+
+        if isinstance(submitted_at, str) and submitted_at not in valid_names:
+            errors.append(
+                f"tx_path.submitted_at: {submitted_at!r} not in participants"
+            )
+
+        if isinstance(observed_at, list):
+            for i, observer in enumerate(observed_at):
+                if isinstance(observer, str) and observer not in valid_names:
+                    errors.append(
+                        f"tx_path.observed_at[{i}]: {observer!r} not in participants"
+                    )
+
+        if (
+            evidence_type == "mixed_client_process_soak"
+            and verdict == "PASS"
+            and isinstance(submitted_at, str)
+            and submitted_at in impl_by_name
+            and isinstance(observed_at, list)
+        ):
+            submitter_impl = impl_by_name[submitted_at]
+            observer_impls = {
+                impl_by_name[o]
+                for o in observed_at
+                if isinstance(o, str) and o in impl_by_name
+            }
+            if not any(impl != submitter_impl for impl in observer_impls):
+                errors.append(
+                    "tx_path: mixed_client_process_soak with verdict=PASS "
+                    "requires at least one observer with implementation != "
+                    f"submitted_at.implementation; submitter={submitted_at!r} "
+                    f"implementation={submitter_impl!r}, observer implementations="
+                    f"{sorted(observer_impls)}"
+                )
+    elif (
+        evidence_type == "mixed_client_process_soak" and verdict == "PASS"
+    ):
+        errors.append(
+            "tx_path: required for evidence_type=mixed_client_process_soak "
+            "with verdict=PASS"
+        )
+
+    return errors
+
+
+def validate(fixture_path: Path, schema_path: Path) -> list[str]:
+    """Return sorted, deduplicated error messages. Empty list = PASS."""
+    try:
+        with open(schema_path, encoding="utf-8") as f:
+            schema = json.load(f)
+    except OSError as e:
+        return [f"schema: cannot read {schema_path}: {e}"]
+    except json.JSONDecodeError as e:
+        return [f"schema: malformed JSON in {schema_path}: {e}"]
+
+    try:
+        with open(fixture_path, encoding="utf-8") as f:
+            data = json.load(f)
+    except OSError as e:
+        return [f"fixture: cannot read {fixture_path}: {e}"]
+    except json.JSONDecodeError as e:
+        return [f"fixture: malformed JSON in {fixture_path}: {e}"]
+
+    errors: list[str] = []
+    errors.extend(_validate_with_jsonschema(data, schema))
+    errors.extend(_validate_cross_field(data))
+    return sorted(set(errors))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate mixed-client devnet evidence JSON (base slice)."
+    )
+    parser.add_argument(
+        "fixture", type=Path, help="Path to evidence JSON file to validate."
+    )
+    parser.add_argument(
+        "--schema",
+        type=Path,
+        default=DEFAULT_SCHEMA,
+        help=(
+            f"Path to schema JSON (default: {DEFAULT_SCHEMA.relative_to(REPO_ROOT)})."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    errors = validate(args.fixture, args.schema)
+    if errors:
+        print(f"FAIL: {args.fixture}", file=sys.stderr)
+        for err in errors:
+            print(f"  - {err}", file=sys.stderr)
+        return 1
+    print(f"PASS: {args.fixture}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/devnet/validate_mixed_client_evidence.py
+++ b/scripts/devnet/validate_mixed_client_evidence.py
@@ -68,7 +68,12 @@ def _validate_cross_field(data: Any) -> list[str]:
 
     Per-site decisions:
 
-      S1  top-level non-object             AUTHORITATIVE (jsonschema-absent path)
+      S1  top-level non-object             REMOVED (schema's root `type:
+                                              object` is authoritative; in the
+                                              jsonschema-absent path the
+                                              "library unavailable" message
+                                              from `_validate_with_jsonschema`
+                                              is itself the operative signal)
       S2  schema_version mismatch          GATED on isinstance(str)
                                               (schema `const` handles None/wrong-type)
       S3  verdict=FAIL ⇒ failure_reason    GATED on (None or empty str)
@@ -107,7 +112,15 @@ def _validate_cross_field(data: Any) -> list[str]:
     """
     errors: list[str] = []
     if not isinstance(data, dict):
-        return ["<root>: top-level JSON must be an object"]
+        # S1: schema's root `type: object` is authoritative for non-object
+        # inputs. When jsonschema is available (the standard path), it
+        # emits "<root>: <value> is not of type 'object'"; emitting a
+        # second cross-field "top-level JSON must be an object" message
+        # would duplicate. When jsonschema is unavailable, the
+        # `<root>: jsonschema library unavailable` message from
+        # `_validate_with_jsonschema` is itself the operative signal —
+        # so we return no additional cross-field message either way.
+        return errors
 
     # S2: only emit cross-field "expected vs got" wording when schema_version
     # is a string but wrong value; missing or wrong-type cases are reported

--- a/scripts/devnet/validate_mixed_client_evidence.py
+++ b/scripts/devnet/validate_mixed_client_evidence.py
@@ -50,40 +50,79 @@ def _validate_with_jsonschema(data: Any, schema: dict) -> list[str]:
             "<root>: jsonschema library unavailable; install jsonschema for full Draft 2020-12 validation"
         ]
     validator = jsonschema.Draft202012Validator(schema)
-    errors = sorted(validator.iter_errors(data), key=lambda e: list(e.absolute_path))
+    # Iteration order is left to `validate`, which deduplicates and
+    # lexicographically re-sorts the merged error stream via
+    # `sorted(set(...))`; an inner sort here would be discarded.
     return [
         f"{'.'.join(str(p) for p in e.absolute_path) or '<root>'}: {e.message}"
-        for e in errors
+        for e in validator.iter_errors(data)
     ]
 
 
 def _validate_cross_field(data: Any) -> list[str]:
-    """Cross-field invariants jsonschema cannot express."""
+    """Cross-field invariants jsonschema cannot express.
+
+    Class-closure invariant: every cross-field check below MUST gate on
+    the input being schema-valid for the field it inspects, so the
+    cross-field message does not duplicate or contradict the schema
+    layer's authoritative type/const/required error on the same case.
+
+    Per-site decisions:
+
+      S1  top-level non-object             AUTHORITATIVE (jsonschema-absent path)
+      S2  schema_version mismatch          GATED on isinstance(str)
+                                              (schema `const` handles None/wrong-type)
+      S3  verdict=FAIL ⇒ failure_reason    GATED on (None or empty str)
+                                              (schema `type` handles wrong-type)
+      S4  participants required             REMOVED (schema `required` + `minItems`
+                                              already authoritative)
+      S5  mixed_client go+rust              GATED on any valid string impl
+                                              (schema per-participant required
+                                               handles all-missing)
+      S6  single_client one impl            implicit gate (needs ≥2 string impls)
+      S7  duplicate participant names       AUTHORITATIVE (schema lacks uniqueItems
+                                              over `name`)
+      S8  tx_path.submitted_at not in set   gates on isinstance(str)
+      S9  tx_path.observed_at[i] not in set gates on isinstance(str)
+      S10 cross-impl observer differ        GATED on every observer impl known
+                                              (wave-3)
+      S11 mixed PASS ⇒ tx_path required     GATED on `tx_path is None`
+                                              (schema `type` handles wrong-type)
+    """
     errors: list[str] = []
     if not isinstance(data, dict):
         return ["<root>: top-level JSON must be an object"]
 
-    if data.get("schema_version") != SCHEMA_VERSION:
+    # S2: only emit cross-field "expected vs got" wording when schema_version
+    # is a string but wrong value; missing or wrong-type cases are reported
+    # authoritatively by the schema's `const` constraint, and emitting a
+    # second cross-field message would duplicate.
+    schema_version = data.get("schema_version")
+    if isinstance(schema_version, str) and schema_version != SCHEMA_VERSION:
         errors.append(
-            f"schema_version: must be exactly '{SCHEMA_VERSION}'; got {data.get('schema_version')!r}"
+            f"schema_version: must be exactly '{SCHEMA_VERSION}'; got {schema_version!r}"
         )
 
     evidence_type = data.get("evidence_type")
     verdict = data.get("verdict")
 
+    # S3: cross-field is the authoritative source for the conditional
+    # requirement (verdict=FAIL ⇒ failure_reason non-empty); only emit
+    # when the field is missing or an empty string. Wrong-type values are
+    # reported authoritatively by the schema's `type: string` constraint.
     if verdict == "FAIL":
         reason = data.get("failure_reason")
-        if not isinstance(reason, str) or not reason.strip():
+        if reason is None or (isinstance(reason, str) and not reason.strip()):
             errors.append(
                 "failure_reason: required and must be non-empty when verdict=FAIL"
             )
 
+    # S4: when participants is missing/wrong-type/empty the schema layer
+    # reports `required` / `type` / `minItems` authoritatively; the early
+    # return below is a guard against None-deref in downstream cross-field
+    # code, not a duplicate message source.
     participants = data.get("participants")
     if not isinstance(participants, list) or not participants:
-        if evidence_type in PROCESS_SOAK_TYPES:
-            errors.append(
-                f"participants: required for evidence_type={evidence_type!r}"
-            )
         return errors
 
     impls = [p.get("implementation") for p in participants if isinstance(p, dict)]
@@ -110,8 +149,19 @@ def _validate_cross_field(data: Any) -> list[str]:
     }
 
     if evidence_type == "mixed_client_process_soak":
-        if not (any(i == "go" for i in impls) and any(i == "rust" for i in impls)):
-            observed = sorted({i for i in impls if isinstance(i, str)})
+        # S5: only emit the "go AND rust required" cross-impl message when
+        # at least one participant has a known string `implementation`. If
+        # every participant is schema-invalid (missing impl or wrong type),
+        # the per-participant `participants[i].implementation: required`
+        # errors from the schema layer are authoritative; emitting a
+        # cross-field "observed implementations=[]" message on top would
+        # duplicate.
+        valid_impls = [i for i in impls if isinstance(i, str)]
+        if valid_impls and not (
+            any(i == "go" for i in valid_impls)
+            and any(i == "rust" for i in valid_impls)
+        ):
+            observed = sorted(set(valid_impls))
             errors.append(
                 "participants: evidence_type=mixed_client_process_soak requires "
                 "at least one implementation=go and one implementation=rust; "
@@ -185,7 +235,13 @@ def _validate_cross_field(data: Any) -> list[str]:
                     f"{[f'{n}/{i}' for n, i in observer_pairs]}"
                 )
     elif (
-        evidence_type == "mixed_client_process_soak" and verdict == "PASS"
+        # Only emit "tx_path: required" when the field is genuinely absent
+        # or null. A wrong-type tx_path (list, string, etc.) is reported
+        # authoritatively by the schema layer as a type error; emitting a
+        # cross-field "required" message on top would be misleading.
+        tx_path is None
+        and evidence_type == "mixed_client_process_soak"
+        and verdict == "PASS"
     ):
         errors.append(
             "tx_path: required for evidence_type=mixed_client_process_soak "

--- a/scripts/devnet/validate_mixed_client_evidence.py
+++ b/scripts/devnet/validate_mixed_client_evidence.py
@@ -152,20 +152,28 @@ def _validate_cross_field(data: Any) -> list[str]:
                         f"tx_path.observed_at[{i}]: {observer!r} not in participants"
                     )
 
+        # Cross-impl tx_path invariant only fires when every participant on
+        # the tx_path has a known string implementation. If the submitter or
+        # any string observer is missing impl, the schema layer already emits
+        # `participants[i].implementation` as the real problem; running the
+        # cross-impl check on a partial dataset would emit a duplicative and
+        # misleading "submitter/observer differ" error on top of it.
+        string_observers = (
+            [o for o in observed_at if isinstance(o, str)]
+            if isinstance(observed_at, list)
+            else []
+        )
         if (
             evidence_type == "mixed_client_process_soak"
             and verdict == "PASS"
             and isinstance(submitted_at, str)
             and submitted_at in impl_by_name
-            and isinstance(observed_at, list)
+            and string_observers
+            and all(o in impl_by_name for o in string_observers)
         ):
             submitter_impl = impl_by_name[submitted_at]
             observer_pairs = sorted(
-                {
-                    (o, impl_by_name[o])
-                    for o in observed_at
-                    if isinstance(o, str) and o in impl_by_name
-                }
+                {(o, impl_by_name[o]) for o in string_observers}
             )
             observer_impls = {impl for _, impl in observer_pairs}
             if not any(impl != submitter_impl for impl in observer_impls):

--- a/scripts/devnet/validate_mixed_client_evidence.py
+++ b/scripts/devnet/validate_mixed_client_evidence.py
@@ -188,6 +188,11 @@ def _validate_cross_field(data: Any) -> list[str]:
     duplicates = sorted(n for n, c in name_counts.items() if c > 1)
     if duplicates:
         errors.append(f"participants: duplicate names: {duplicates}")
+    # The S10 cross-impl observer-differ check below is gated on
+    # `not duplicates` so name->impl-keyed semantics do not chain off
+    # the ambiguous (last-write-wins) `impl_by_name` mapping when names
+    # are duplicated. S8/S9 participant-membership lookups use the
+    # set-valued `valid_names` and are correct regardless of duplicates.
 
     tx_path = data.get("tx_path")
     if isinstance(tx_path, dict):

--- a/scripts/devnet/validate_mixed_client_evidence.py
+++ b/scripts/devnet/validate_mixed_client_evidence.py
@@ -235,10 +235,11 @@ def _validate_cross_field(data: Any) -> list[str]:
                     f"{[f'{n}/{i}' for n, i in observer_pairs]}"
                 )
     elif (
-        # Only emit "tx_path: required" when the field is genuinely absent
-        # or null. A wrong-type tx_path (list, string, etc.) is reported
-        # authoritatively by the schema layer as a type error; emitting a
-        # cross-field "required" message on top would be misleading.
+        # Only emit the cross-field tx_path-required message when the
+        # field is genuinely absent or null. A wrong-type tx_path (list,
+        # string, etc.) is reported authoritatively by the schema layer
+        # as a type error; emitting a cross-field required-message on top
+        # would be misleading (S11 in the verdict table above).
         tx_path is None
         and evidence_type == "mixed_client_process_soak"
         and verdict == "PASS"

--- a/scripts/devnet/validate_mixed_client_evidence.py
+++ b/scripts/devnet/validate_mixed_client_evidence.py
@@ -81,15 +81,27 @@ def _validate_cross_field(data: Any) -> list[str]:
       S6  single_client one impl            implicit gate (needs ≥2 string impls)
       S7  duplicate participant names       AUTHORITATIVE (schema lacks uniqueItems
                                               over `name`)
-      S8  tx_path.submitted_at not in set   gates on isinstance(str)
-      S9  tx_path.observed_at[i] not in set gates on isinstance(str)
-      S10 cross-impl observer differ        GATED on every observer impl known
-                                              AND no duplicate participant
-                                              names (wave-3 + wave-5 fix:
-                                              impl_by_name is unreliable when
-                                              names duplicate, so the name
-                                              ambiguity cross-field error is
-                                              authoritative)
+      S8  tx_path.submitted_at not in set   GATED on every participant being
+                                              fully schema-shaped (dict + str
+                                              name) AND isinstance(str) (wave-6:
+                                              partial-shape participants make
+                                              `valid_names` incomplete and the
+                                              membership diagnostic misleading)
+      S9  tx_path.observed_at[i] not in set GATED on every participant being
+                                              fully schema-shaped AND
+                                              isinstance(str) per-item (wave-6:
+                                              same as S8)
+      S10 cross-impl observer differ        GATED on (a) every observer impl
+                                              known, (b) no duplicate participant
+                                              names, (c) `observed_at` is a
+                                              non-empty list of ONLY strings
+                                              (wave-3 + wave-5 + wave-6:
+                                              impl_by_name unreliable when
+                                              names duplicate; cross-impl must
+                                              not chain off the string-subset
+                                              of a mixed-type observed_at when
+                                              schema reports the item-type
+                                              error)
       S11 mixed PASS ⇒ tx_path required     GATED on `tx_path is None`
                                               (schema `type` handles wrong-type)
     """
@@ -151,6 +163,17 @@ def _validate_cross_field(data: Any) -> list[str]:
         for p in participants
         if isinstance(p, dict) and isinstance(p.get("name"), str)
     }
+    # Element-shape gate for S8/S9: only run participant-membership
+    # diagnostics on the tx_path lookups when every participant entry is
+    # fully schema-shaped (a dict with a string `name`). When any item is
+    # partially schema-invalid, `valid_names` is incomplete and a
+    # `tx_path.{submitted_at,observed_at} not in participants` message
+    # would be misleading; the schema layer reports each malformed item's
+    # `participants[i]` errors authoritatively.
+    participants_fully_named = all(
+        isinstance(p, dict) and isinstance(p.get("name"), str)
+        for p in participants
+    )
 
     if evidence_type == "mixed_client_process_soak":
         # S5: only emit the "go AND rust required" cross-impl message when
@@ -199,12 +222,16 @@ def _validate_cross_field(data: Any) -> list[str]:
         submitted_at = tx_path.get("submitted_at")
         observed_at = tx_path.get("observed_at")
 
-        if isinstance(submitted_at, str) and submitted_at not in valid_names:
+        if (
+            participants_fully_named
+            and isinstance(submitted_at, str)
+            and submitted_at not in valid_names
+        ):
             errors.append(
                 f"tx_path.submitted_at: {submitted_at!r} not in participants"
             )
 
-        if isinstance(observed_at, list):
+        if participants_fully_named and isinstance(observed_at, list):
             for i, observer in enumerate(observed_at):
                 if isinstance(observer, str) and observer not in valid_names:
                     errors.append(
@@ -212,19 +239,21 @@ def _validate_cross_field(data: Any) -> list[str]:
                     )
 
         # Cross-impl tx_path invariant only fires when every participant on
-        # the tx_path has a known string implementation AND participant names
-        # are unique. If the submitter or any string observer is missing impl,
-        # the schema layer already emits `participants[i].implementation` as
-        # the real problem. If duplicate names exist, `impl_by_name` is
-        # ambiguous (last-write-wins) — the duplicate-names cross-field
-        # error above is authoritative; running the name->impl-keyed
-        # cross-impl algorithm on top of an ambiguous mapping would emit a
-        # misleading "submitter/observer differ" error chained off arbitrary
-        # impl resolution.
-        string_observers = (
-            [o for o in observed_at if isinstance(o, str)]
+        # the tx_path has a known string implementation, participant names
+        # are unique, AND `observed_at` is a non-empty list whose items
+        # are ALL strings. If any observer item is non-string, the schema
+        # layer already emits an `observed_at[i]` type error; running the
+        # cross-impl algorithm on the string-subset of a mixed-type list
+        # would stack a misleading "submitter/observer differ" message on
+        # top of the schema-owned item-type rejection. If duplicate names
+        # exist, `impl_by_name` is last-write-wins ambiguous — the
+        # duplicate-names cross-field error above is authoritative.
+        observed_at_strs: list[str] | None = (
+            list(observed_at)
             if isinstance(observed_at, list)
-            else []
+            and observed_at
+            and all(isinstance(o, str) for o in observed_at)
+            else None
         )
         if (
             evidence_type == "mixed_client_process_soak"
@@ -232,12 +261,12 @@ def _validate_cross_field(data: Any) -> list[str]:
             and not duplicates
             and isinstance(submitted_at, str)
             and submitted_at in impl_by_name
-            and string_observers
-            and all(o in impl_by_name for o in string_observers)
+            and observed_at_strs is not None
+            and all(o in impl_by_name for o in observed_at_strs)
         ):
             submitter_impl = impl_by_name[submitted_at]
             observer_pairs = sorted(
-                {(o, impl_by_name[o]) for o in string_observers}
+                {(o, impl_by_name[o]) for o in observed_at_strs}
             )
             observer_impls = {impl for _, impl in observer_pairs}
             if not any(impl != submitter_impl for impl in observer_impls):

--- a/scripts/devnet/validate_mixed_client_evidence.py
+++ b/scripts/devnet/validate_mixed_client_evidence.py
@@ -39,7 +39,6 @@ REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 DEFAULT_SCHEMA = REPO_ROOT / "scripts" / "devnet" / "schema" / "mixed_client_evidence_v1.json"
 
 SCHEMA_VERSION = "rubin-mixed-client-devnet-evidence-v1"
-PROCESS_SOAK_TYPES = ("mixed_client_process_soak", "single_client_process_soak")
 
 
 def _validate_with_jsonschema(data: Any, schema: dict) -> list[str]:
@@ -85,7 +84,12 @@ def _validate_cross_field(data: Any) -> list[str]:
       S8  tx_path.submitted_at not in set   gates on isinstance(str)
       S9  tx_path.observed_at[i] not in set gates on isinstance(str)
       S10 cross-impl observer differ        GATED on every observer impl known
-                                              (wave-3)
+                                              AND no duplicate participant
+                                              names (wave-3 + wave-5 fix:
+                                              impl_by_name is unreliable when
+                                              names duplicate, so the name
+                                              ambiguity cross-field error is
+                                              authoritative)
       S11 mixed PASS ⇒ tx_path required     GATED on `tx_path is None`
                                               (schema `type` handles wrong-type)
     """
@@ -203,11 +207,15 @@ def _validate_cross_field(data: Any) -> list[str]:
                     )
 
         # Cross-impl tx_path invariant only fires when every participant on
-        # the tx_path has a known string implementation. If the submitter or
-        # any string observer is missing impl, the schema layer already emits
-        # `participants[i].implementation` as the real problem; running the
-        # cross-impl check on a partial dataset would emit a duplicative and
-        # misleading "submitter/observer differ" error on top of it.
+        # the tx_path has a known string implementation AND participant names
+        # are unique. If the submitter or any string observer is missing impl,
+        # the schema layer already emits `participants[i].implementation` as
+        # the real problem. If duplicate names exist, `impl_by_name` is
+        # ambiguous (last-write-wins) — the duplicate-names cross-field
+        # error above is authoritative; running the name->impl-keyed
+        # cross-impl algorithm on top of an ambiguous mapping would emit a
+        # misleading "submitter/observer differ" error chained off arbitrary
+        # impl resolution.
         string_observers = (
             [o for o in observed_at if isinstance(o, str)]
             if isinstance(observed_at, list)
@@ -216,6 +224,7 @@ def _validate_cross_field(data: Any) -> list[str]:
         if (
             evidence_type == "mixed_client_process_soak"
             and verdict == "PASS"
+            and not duplicates
             and isinstance(submitted_at, str)
             and submitted_at in impl_by_name
             and string_observers

--- a/scripts/devnet/validate_mixed_client_evidence.py
+++ b/scripts/devnet/validate_mixed_client_evidence.py
@@ -29,6 +29,7 @@ Exits 0 on PASS, 1 on validation failure or unreadable input.
 from __future__ import annotations
 
 import argparse
+import collections
 import json
 import sys
 from pathlib import Path
@@ -91,12 +92,22 @@ def _validate_cross_field(data: Any) -> list[str]:
         for p in participants
         if isinstance(p, dict) and isinstance(p.get("name"), str)
     ]
+    # Restrict impl_by_name to fully-typed (str, str) entries so the dict's
+    # declared type holds at runtime — None implementations are filtered out
+    # here and re-surfaced via the schema-level "implementation: required" error
+    # rather than leaking through the cross-impl branch.
     impl_by_name: dict[str, str] = {
-        p.get("name"): p.get("implementation")
+        p["name"]: p["implementation"]
+        for p in participants
+        if isinstance(p, dict)
+        and isinstance(p.get("name"), str)
+        and isinstance(p.get("implementation"), str)
+    }
+    valid_names = {
+        p.get("name")
         for p in participants
         if isinstance(p, dict) and isinstance(p.get("name"), str)
     }
-    valid_names = set(impl_by_name)
 
     if evidence_type == "mixed_client_process_soak":
         if not (any(i == "go" for i in impls) and any(i == "rust" for i in impls)):
@@ -119,7 +130,8 @@ def _validate_cross_field(data: Any) -> list[str]:
                 f"requires one implementation; observed={sorted(unique)}"
             )
 
-    duplicates = sorted({n for n in names_list if names_list.count(n) > 1})
+    name_counts = collections.Counter(names_list)
+    duplicates = sorted(n for n, c in name_counts.items() if c > 1)
     if duplicates:
         errors.append(f"participants: duplicate names: {duplicates}")
 
@@ -148,18 +160,21 @@ def _validate_cross_field(data: Any) -> list[str]:
             and isinstance(observed_at, list)
         ):
             submitter_impl = impl_by_name[submitted_at]
-            observer_impls = {
-                impl_by_name[o]
-                for o in observed_at
-                if isinstance(o, str) and o in impl_by_name
-            }
+            observer_pairs = sorted(
+                {
+                    (o, impl_by_name[o])
+                    for o in observed_at
+                    if isinstance(o, str) and o in impl_by_name
+                }
+            )
+            observer_impls = {impl for _, impl in observer_pairs}
             if not any(impl != submitter_impl for impl in observer_impls):
                 errors.append(
                     "tx_path: mixed_client_process_soak with verdict=PASS "
-                    "requires at least one observer with implementation != "
-                    f"submitted_at.implementation; submitter={submitted_at!r} "
-                    f"implementation={submitter_impl!r}, observer implementations="
-                    f"{sorted(observer_impls)}"
+                    "requires observer implementation to differ from submitter "
+                    "implementation; submitter "
+                    f"{submitted_at!r}/{submitter_impl}, observers="
+                    f"{[f'{n}/{i}' for n, i in observer_pairs]}"
                 )
     elif (
         evidence_type == "mixed_client_process_soak" and verdict == "PASS"

--- a/scripts/devnet/validate_mixed_client_evidence.py
+++ b/scripts/devnet/validate_mixed_client_evidence.py
@@ -170,7 +170,7 @@ def _validate_cross_field(data: Any) -> list[str]:
     # `tx_path.{submitted_at,observed_at} not in participants` message
     # would be misleading; the schema layer reports each malformed item's
     # `participants[i]` errors authoritatively.
-    participants_fully_named = all(
+    all_participant_names_valid = all(
         isinstance(p, dict) and isinstance(p.get("name"), str)
         for p in participants
     )
@@ -223,7 +223,7 @@ def _validate_cross_field(data: Any) -> list[str]:
         observed_at = tx_path.get("observed_at")
 
         if (
-            participants_fully_named
+            all_participant_names_valid
             and isinstance(submitted_at, str)
             and submitted_at not in valid_names
         ):
@@ -231,7 +231,7 @@ def _validate_cross_field(data: Any) -> list[str]:
                 f"tx_path.submitted_at: {submitted_at!r} not in participants"
             )
 
-        if participants_fully_named and isinstance(observed_at, list):
+        if all_participant_names_valid and isinstance(observed_at, list):
             for i, observer in enumerate(observed_at):
                 if isinstance(observer, str) and observer not in valid_names:
                     errors.append(

--- a/tools/tests/test_validate_mixed_client_evidence.py
+++ b/tools/tests/test_validate_mixed_client_evidence.py
@@ -138,6 +138,75 @@ class MalformedInputTests(unittest.TestCase):
                 f"cross-field 'participants: required' fired; got {errors}",
             )
 
+    def test_partial_schema_shape_participants_suppress_membership_diagnostic(self):
+        """When ANY participant is partially schema-invalid (item is not a
+        dict, or item.name is not a string), `valid_names` is incomplete;
+        the schema layer's per-item type/required errors are authoritative.
+        S8/S9 `tx_path.{submitted_at,observed_at} not in participants`
+        diagnostics must NOT fire on top of that incomplete view (S8/S9
+        wave-6 element-shape gate)."""
+        with tempfile.TemporaryDirectory() as td:
+            data = _load_committed_valid()
+            data["scenario"] = "partial_shape_participant_with_tx_path_lookup"
+            # First participant has wrong-type name (int); second is
+            # well-shaped. tx_path references a name that ISN'T in
+            # `valid_names` so without the gate S8/S9 would emit a
+            # misleading "not in participants" message even though the
+            # real problem is reported by the schema (`participants[0].name`
+            # type error).
+            data["participants"] = [
+                {"name": 42, "implementation": "go"},  # type: ignore[dict-item]
+                {"name": "node-b", "implementation": "rust"},
+            ]
+            data["tx_path"]["submitted_at"] = "node-a"
+            data["tx_path"]["observed_at"] = ["node-b"]
+            errors = _validate_dict(Path(td), data)
+            # Schema reports the type error on the malformed name.
+            self.assertTrue(
+                any("name" in e for e in errors),
+                f"expected schema type/pattern error on participants[0].name; got {errors}",
+            )
+            # Cross-field membership diagnostic must NOT fire because
+            # `participants_fully_named` is False.
+            self.assertFalse(
+                any("not in participants" in e for e in errors),
+                f"S8/S9 membership diagnostic fired despite partial-shape participants; got {errors}",
+            )
+
+    def test_observed_at_with_non_string_item_suppresses_cross_impl_check(self):
+        """When `observed_at` is a list whose items are not all strings,
+        the schema layer reports the item-type error authoritatively. S10
+        cross-impl observer-differ check must NOT additionally fire on the
+        string subset (S10 wave-6 list-purity gate)."""
+        with tempfile.TemporaryDirectory() as td:
+            data = _load_committed_valid()
+            data["scenario"] = "observed_at_mixed_types"
+            data["participants"] = [
+                {"name": "node-a", "implementation": "go"},
+                {"name": "node-b", "implementation": "go"},
+                {"name": "node-c", "implementation": "rust"},
+            ]
+            data["tx_path"]["submitted_at"] = "node-a"
+            # Mixed-type observed_at: schema reports item-type error on 42;
+            # without the gate, cross-impl would still run on the string
+            # subset ["node-b"] (same impl as submitter "go") and emit a
+            # misleading differ message.
+            data["tx_path"]["observed_at"] = ["node-b", 42]  # type: ignore[list-item]
+            errors = _validate_dict(Path(td), data)
+            # Schema reports the item-type error.
+            self.assertTrue(
+                any("observed_at" in e for e in errors),
+                f"expected schema error on tx_path.observed_at item-type; got {errors}",
+            )
+            # Cross-impl differ must NOT fire on the string subset.
+            self.assertFalse(
+                any(
+                    ("submitter" in e and "observer" in e and "differ" in e)
+                    for e in errors
+                ),
+                f"S10 fired on string subset of mixed-type observed_at; got {errors}",
+            )
+
     def test_duplicate_names_suppress_cross_impl_observer_differ_check(self):
         """When participant names are duplicated, `impl_by_name` is
         last-write-wins ambiguous; the duplicate-names cross-field error
@@ -147,7 +216,12 @@ class MalformedInputTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             data = _load_committed_valid()
             data["scenario"] = "duplicate_names_with_cross_impl_setup"
-            # node-a appears twice with conflicting impls; node-c is rust.
+            # node-a appears twice (same impl=go); node-c is rust. Without
+            # the gate, the cross-impl algorithm would resolve `node-a` via
+            # last-write-wins `impl_by_name` and, with submitted_at and the
+            # sole observer both pointing at node-a, emit a misleading
+            # "submitter/observer differ" message even though the underlying
+            # ambiguity is the duplicate-name cross-field error.
             data["participants"] = [
                 {"name": "node-a", "implementation": "go"},
                 {"name": "node-a", "implementation": "go"},

--- a/tools/tests/test_validate_mixed_client_evidence.py
+++ b/tools/tests/test_validate_mixed_client_evidence.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Tests for scripts/devnet/validate_mixed_client_evidence.py — base slice (PR-A).
+
+Targets the cross-implementation tx_path invariant established by RUB-206:
+mixed_client_process_soak with verdict=PASS must include at least one observer
+whose implementation differs from the submitter's. Tests cover the hostile
+matrix from the issue contract plus accepted/false-positive paths.
+
+Restart/reorg cross-field, timestamp policy, endpoint policy, and helper-vs-
+real-process distinction are not exercised here (deferred to RUB-207/RUB-208).
+"""
+from __future__ import annotations
+
+import contextlib
+import copy
+import io
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_DIR = REPO_ROOT / "scripts" / "devnet"
+SCHEMA_PATH = SCRIPT_DIR / "schema" / "mixed_client_evidence_v1.json"
+TESTDATA_DIR = SCRIPT_DIR / "testdata"
+
+sys.path.insert(0, str(SCRIPT_DIR))
+import validate_mixed_client_evidence as validator  # noqa: E402
+
+
+def _load_committed_valid() -> dict:
+    with open(TESTDATA_DIR / "valid_minimal_mixed.json", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _validate_dict(td: Path, data: dict) -> list[str]:
+    fixture = td / "case.json"
+    fixture.write_text(json.dumps(data), encoding="utf-8")
+    return validator.validate(fixture, SCHEMA_PATH)
+
+
+def _assert_one(testcase: unittest.TestCase, errors: list[str], *needles: str) -> None:
+    """Assert at least one error contains every needle."""
+    testcase.assertTrue(errors, "expected validation errors but got none")
+    testcase.assertTrue(
+        any(all(n in e for n in needles) for e in errors),
+        f"no error matched all needles {needles!r}; got {errors}",
+    )
+
+
+class CommittedFixtureTests(unittest.TestCase):
+    def test_committed_valid_minimal_mixed_passes(self):
+        errors = validator.validate(
+            TESTDATA_DIR / "valid_minimal_mixed.json", SCHEMA_PATH
+        )
+        self.assertEqual(errors, [], f"committed valid fixture must pass; got {errors}")
+
+
+class MalformedInputTests(unittest.TestCase):
+    def test_missing_file(self):
+        with tempfile.TemporaryDirectory() as td:
+            errors = validator.validate(Path(td) / "nope.json", SCHEMA_PATH)
+            _assert_one(self, errors, "cannot read")
+
+    def test_malformed_json(self):
+        with tempfile.TemporaryDirectory() as td:
+            f = Path(td) / "bad.json"
+            f.write_text("{not valid", encoding="utf-8")
+            _assert_one(self, validator.validate(f, SCHEMA_PATH), "malformed JSON")
+
+    def test_top_level_array_rejected(self):
+        with tempfile.TemporaryDirectory() as td:
+            f = Path(td) / "arr.json"
+            f.write_text("[]", encoding="utf-8")
+            self.assertTrue(validator.validate(f, SCHEMA_PATH))
+
+
+class CrossImplTxPathRejectionTests(unittest.TestCase):
+    """T13 hostile cases: same-impl propagation in mixed-client set rejected."""
+
+    def test_go_to_go_only_in_mixed_set_rejected(self):
+        """{go, go, rust} with tx_path go-1 -> [go-2] must reject (T13 case 1)."""
+        with tempfile.TemporaryDirectory() as td:
+            data = _load_committed_valid()
+            data["scenario"] = "go_to_go_only_in_mixed_set"
+            data["participants"] = [
+                {"name": "node-a", "implementation": "go"},
+                {"name": "node-b", "implementation": "go"},
+                {"name": "node-c", "implementation": "rust"},
+            ]
+            data["tx_path"]["submitted_at"] = "node-a"
+            data["tx_path"]["observed_at"] = ["node-b"]
+            errors = _validate_dict(Path(td), data)
+            _assert_one(self, errors, "tx_path", "implementation", "submitted_at")
+
+    def test_rust_to_rust_only_in_mixed_set_rejected(self):
+        """{rust, rust, go} with tx_path rust-1 -> [rust-2] must reject (T13 case 2)."""
+        with tempfile.TemporaryDirectory() as td:
+            data = _load_committed_valid()
+            data["scenario"] = "rust_to_rust_only_in_mixed_set"
+            data["participants"] = [
+                {"name": "node-a", "implementation": "rust"},
+                {"name": "node-b", "implementation": "rust"},
+                {"name": "node-c", "implementation": "go"},
+            ]
+            data["tx_path"]["submitted_at"] = "node-a"
+            data["tx_path"]["observed_at"] = ["node-b"]
+            errors = _validate_dict(Path(td), data)
+            _assert_one(self, errors, "tx_path", "implementation", "submitted_at")
+
+    def test_submitter_only_observer_rejected(self):
+        """observed_at == [submitted_at] for mixed-client PASS must reject."""
+        with tempfile.TemporaryDirectory() as td:
+            data = _load_committed_valid()
+            data["tx_path"]["observed_at"] = ["node-a"]
+            errors = _validate_dict(Path(td), data)
+            _assert_one(self, errors, "tx_path", "implementation")
+
+    def test_unknown_observer_rejected(self):
+        """tx_path.observed_at referencing a non-participant rejects."""
+        with tempfile.TemporaryDirectory() as td:
+            data = _load_committed_valid()
+            data["tx_path"]["observed_at"] = ["node-ghost"]
+            errors = _validate_dict(Path(td), data)
+            _assert_one(self, errors, "tx_path.observed_at", "node-ghost")
+
+    def test_unknown_submitter_rejected(self):
+        """tx_path.submitted_at referencing a non-participant rejects."""
+        with tempfile.TemporaryDirectory() as td:
+            data = _load_committed_valid()
+            data["tx_path"]["submitted_at"] = "node-ghost"
+            errors = _validate_dict(Path(td), data)
+            _assert_one(self, errors, "tx_path.submitted_at", "node-ghost")
+
+    def test_pass_without_tx_path_rejected(self):
+        """mixed-client PASS without tx_path block must reject."""
+        with tempfile.TemporaryDirectory() as td:
+            data = _load_committed_valid()
+            del data["tx_path"]
+            errors = _validate_dict(Path(td), data)
+            _assert_one(self, errors, "tx_path", "required")
+
+
+class CrossImplTxPathAcceptedTests(unittest.TestCase):
+    def test_rust_to_go_passes(self):
+        with tempfile.TemporaryDirectory() as td:
+            data = _load_committed_valid()
+            data["scenario"] = "rust_to_go_propagation"
+            data["participants"] = [
+                {"name": "node-a", "implementation": "rust"},
+                {"name": "node-b", "implementation": "go"},
+            ]
+            data["tx_path"]["submitted_at"] = "node-a"
+            data["tx_path"]["observed_at"] = ["node-b"]
+            self.assertEqual(
+                _validate_dict(Path(td), data), [], "rust->go must pass"
+            )
+
+    def test_multi_hop_go_go_rust_passes(self):
+        """Submitter Go, observer Go AND observer Rust — cross-impl exists, passes."""
+        with tempfile.TemporaryDirectory() as td:
+            data = _load_committed_valid()
+            data["scenario"] = "multi_hop_go_go_rust"
+            data["participants"] = [
+                {"name": "node-a", "implementation": "go"},
+                {"name": "node-b", "implementation": "go"},
+                {"name": "node-c", "implementation": "rust"},
+            ]
+            data["tx_path"]["submitted_at"] = "node-a"
+            data["tx_path"]["observed_at"] = ["node-b", "node-c"]
+            self.assertEqual(
+                _validate_dict(Path(td), data),
+                [],
+                "multi-hop with cross-impl observer must pass",
+            )
+
+    def test_fail_without_propagation_passes(self):
+        """FAIL evidence may describe partial propagation without cross-impl rule."""
+        with tempfile.TemporaryDirectory() as td:
+            data = _load_committed_valid()
+            data["scenario"] = "fail_partial_propagation"
+            data["verdict"] = "FAIL"
+            data["failure_reason"] = "node-b crashed before tx observation"
+            data["tx_path"]["observed_at"] = ["node-a"]
+            self.assertEqual(
+                _validate_dict(Path(td), data),
+                [],
+                "FAIL is not gated by cross-impl rule",
+            )
+
+    def test_single_client_go_to_go_passes(self):
+        """single_client_process_soak with one impl is not gated by mixed rule."""
+        with tempfile.TemporaryDirectory() as td:
+            data = _load_committed_valid()
+            data["evidence_type"] = "single_client_process_soak"
+            data["scenario"] = "single_client_go_local"
+            data["participants"] = [
+                {"name": "node-a", "implementation": "go"},
+                {"name": "node-b", "implementation": "go"},
+            ]
+            data["tx_path"]["submitted_at"] = "node-a"
+            data["tx_path"]["observed_at"] = ["node-b"]
+            self.assertEqual(
+                _validate_dict(Path(td), data),
+                [],
+                "single_client go->go must pass",
+            )
+
+
+class SchemaShapeTests(unittest.TestCase):
+    def test_unknown_schema_version_rejected(self):
+        with tempfile.TemporaryDirectory() as td:
+            data = _load_committed_valid()
+            data["schema_version"] = "rubin-mixed-client-devnet-evidence-v2"
+            _assert_one(self, _validate_dict(Path(td), data), "schema_version")
+
+    def test_implementation_missing_rejected(self):
+        with tempfile.TemporaryDirectory() as td:
+            data = _load_committed_valid()
+            del data["participants"][0]["implementation"]
+            errors = _validate_dict(Path(td), data)
+            _assert_one(self, errors, "implementation")
+
+    def test_implementation_unknown_value_rejected(self):
+        with tempfile.TemporaryDirectory() as td:
+            data = _load_committed_valid()
+            data["participants"][0]["implementation"] = "java"
+            _assert_one(self, _validate_dict(Path(td), data), "implementation")
+
+    def test_mixed_client_with_one_impl_only_rejected(self):
+        with tempfile.TemporaryDirectory() as td:
+            data = _load_committed_valid()
+            data["participants"] = [
+                {"name": "node-a", "implementation": "go"},
+                {"name": "node-b", "implementation": "go"},
+            ]
+            errors = _validate_dict(Path(td), data)
+            _assert_one(self, errors, "implementation=go", "implementation=rust")
+
+    def test_fail_without_failure_reason_rejected(self):
+        with tempfile.TemporaryDirectory() as td:
+            data = _load_committed_valid()
+            data["verdict"] = "FAIL"
+            _assert_one(self, _validate_dict(Path(td), data), "failure_reason")
+
+    def test_duplicate_participant_names_rejected(self):
+        with tempfile.TemporaryDirectory() as td:
+            data = _load_committed_valid()
+            data["participants"][1]["name"] = "node-a"
+            _assert_one(self, _validate_dict(Path(td), data), "duplicate")
+
+    def test_tx_id_wrong_length_rejected(self):
+        with tempfile.TemporaryDirectory() as td:
+            data = _load_committed_valid()
+            data["tx_path"]["tx_id"] = "abc123"
+            self.assertTrue(_validate_dict(Path(td), data))
+
+    def test_participant_name_uppercase_rejected(self):
+        with tempfile.TemporaryDirectory() as td:
+            data = _load_committed_valid()
+            data["participants"][0]["name"] = "NODE-A"
+            self.assertTrue(_validate_dict(Path(td), data))
+
+
+class DeterminismTests(unittest.TestCase):
+    def test_deterministic_on_identical_input(self):
+        with tempfile.TemporaryDirectory() as td:
+            data = _load_committed_valid()
+            data["participants"][1]["implementation"] = "go"
+            runs = [_validate_dict(Path(td), copy.deepcopy(data)) for _ in range(3)]
+            self.assertEqual(runs[0], runs[1])
+            self.assertEqual(runs[1], runs[2])
+
+
+class CliTests(unittest.TestCase):
+    def test_main_zero_on_valid_fixture(self):
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            rc = validator.main([str(TESTDATA_DIR / "valid_minimal_mixed.json")])
+        self.assertEqual(rc, 0)
+        self.assertIn("PASS", buf.getvalue())
+
+    def test_main_nonzero_on_invalid_fixture(self):
+        with tempfile.TemporaryDirectory() as td:
+            data = _load_committed_valid()
+            data["participants"] = [
+                {"name": "node-a", "implementation": "go"},
+                {"name": "node-b", "implementation": "go"},
+                {"name": "node-c", "implementation": "rust"},
+            ]
+            data["tx_path"]["observed_at"] = ["node-b"]
+            f = Path(td) / "go_to_go.json"
+            f.write_text(json.dumps(data), encoding="utf-8")
+            buf = io.StringIO()
+            with contextlib.redirect_stderr(buf):
+                rc = validator.main([str(f)])
+            self.assertEqual(rc, 1)
+            self.assertIn("FAIL", buf.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_validate_mixed_client_evidence.py
+++ b/tools/tests/test_validate_mixed_client_evidence.py
@@ -138,6 +138,36 @@ class MalformedInputTests(unittest.TestCase):
                 f"cross-field 'participants: required' fired; got {errors}",
             )
 
+    def test_duplicate_names_suppress_cross_impl_observer_differ_check(self):
+        """When participant names are duplicated, `impl_by_name` is
+        last-write-wins ambiguous; the duplicate-names cross-field error
+        is authoritative. The cross-impl observer-differ check must NOT
+        additionally fire on top of an ambiguous mapping (S10 wave-5
+        gate)."""
+        with tempfile.TemporaryDirectory() as td:
+            data = _load_committed_valid()
+            data["scenario"] = "duplicate_names_with_cross_impl_setup"
+            # node-a appears twice with conflicting impls; node-c is rust.
+            data["participants"] = [
+                {"name": "node-a", "implementation": "go"},
+                {"name": "node-a", "implementation": "go"},
+                {"name": "node-c", "implementation": "rust"},
+            ]
+            data["tx_path"]["submitted_at"] = "node-a"
+            data["tx_path"]["observed_at"] = ["node-a"]
+            errors = _validate_dict(Path(td), data)
+            self.assertTrue(
+                any("duplicate names" in e for e in errors),
+                f"expected duplicate-names cross-field error; got {errors}",
+            )
+            self.assertFalse(
+                any(
+                    ("submitter" in e and "observer" in e and "differ" in e)
+                    for e in errors
+                ),
+                f"cross-impl observer-differ fired despite duplicate names; got {errors}",
+            )
+
     def test_all_participants_missing_impl_no_cross_impl_requirement_message(self):
         """When ALL participants lack `implementation`, schema reports
         each missing-required error; the cross-impl 'go AND rust required'
@@ -392,13 +422,15 @@ class SchemaShapeTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             data = _load_committed_valid()
             data["tx_path"]["tx_id"] = "abc123"
-            self.assertTrue(_validate_dict(Path(td), data))
+            errors = _validate_dict(Path(td), data)
+            _assert_one(self, errors, "tx_path.tx_id", "does not match")
 
     def test_participant_name_uppercase_rejected(self):
         with tempfile.TemporaryDirectory() as td:
             data = _load_committed_valid()
             data["participants"][0]["name"] = "NODE-A"
-            self.assertTrue(_validate_dict(Path(td), data))
+            errors = _validate_dict(Path(td), data)
+            _assert_one(self, errors, "participants.0.name", "does not match")
 
 
 class DeterminismTests(unittest.TestCase):

--- a/tools/tests/test_validate_mixed_client_evidence.py
+++ b/tools/tests/test_validate_mixed_client_evidence.py
@@ -75,6 +75,114 @@ class MalformedInputTests(unittest.TestCase):
             f.write_text("[]", encoding="utf-8")
             self.assertTrue(validator.validate(f, SCHEMA_PATH))
 
+    def test_missing_schema_version_no_duplicate_cross_field_message(self):
+        """When `schema_version` is missing, schema's `const` reports the
+        real problem; the cross-field "expected vs got" wording must NOT
+        additionally fire (S2 class-closure)."""
+        with tempfile.TemporaryDirectory() as td:
+            data = _load_committed_valid()
+            del data["schema_version"]
+            errors = _validate_dict(Path(td), data)
+            self.assertTrue(
+                any("schema_version" in e for e in errors),
+                f"expected schema error on missing schema_version; got {errors}",
+            )
+            self.assertFalse(
+                any("must be exactly" in e for e in errors),
+                f"cross-field 'must be exactly' fired on missing field; got {errors}",
+            )
+
+    def test_wrong_type_schema_version_no_duplicate_cross_field_message(self):
+        """When `schema_version` is wrong-type (int), schema's `type` is
+        authoritative; cross-field message must NOT fire (S2)."""
+        with tempfile.TemporaryDirectory() as td:
+            data = _load_committed_valid()
+            data["schema_version"] = 42  # type: ignore[assignment]
+            errors = _validate_dict(Path(td), data)
+            self.assertFalse(
+                any("must be exactly" in e for e in errors),
+                f"cross-field 'must be exactly' fired on wrong-type; got {errors}",
+            )
+
+    def test_failure_reason_wrong_type_no_duplicate_message(self):
+        """verdict=FAIL with wrong-type failure_reason: schema's type
+        check is authoritative; cross-field "required and non-empty" must
+        NOT fire (S3)."""
+        with tempfile.TemporaryDirectory() as td:
+            data = _load_committed_valid()
+            data["verdict"] = "FAIL"
+            data["failure_reason"] = 42  # type: ignore[assignment]
+            errors = _validate_dict(Path(td), data)
+            self.assertTrue(
+                any("failure_reason" in e for e in errors),
+                f"expected schema error on wrong-type failure_reason; got {errors}",
+            )
+            self.assertFalse(
+                any(
+                    "required and must be non-empty when verdict=FAIL" in e
+                    for e in errors
+                ),
+                f"cross-field 'required and non-empty' fired on wrong-type; got {errors}",
+            )
+
+    def test_participants_wrong_type_no_duplicate_required_message(self):
+        """When participants is wrong-type (dict instead of list), schema
+        is authoritative; cross-field 'required for evidence_type=' must
+        NOT fire (S4 closure: cross-field message removed)."""
+        with tempfile.TemporaryDirectory() as td:
+            data = _load_committed_valid()
+            data["participants"] = {"node-a": "go"}  # type: ignore[assignment]
+            errors = _validate_dict(Path(td), data)
+            self.assertFalse(
+                any("participants: required" in e for e in errors),
+                f"cross-field 'participants: required' fired; got {errors}",
+            )
+
+    def test_all_participants_missing_impl_no_cross_impl_requirement_message(self):
+        """When ALL participants lack `implementation`, schema reports
+        each missing-required error; the cross-impl 'go AND rust required'
+        message must NOT additionally fire (S5)."""
+        with tempfile.TemporaryDirectory() as td:
+            data = _load_committed_valid()
+            for p in data["participants"]:
+                p.pop("implementation", None)
+            errors = _validate_dict(Path(td), data)
+            self.assertTrue(
+                any("implementation" in e for e in errors),
+                f"expected schema errors on missing impls; got {errors}",
+            )
+            self.assertFalse(
+                any(
+                    "implementation=go and one implementation=rust" in e
+                    for e in errors
+                ),
+                f"cross-impl requirement message duplicates schema; got {errors}",
+            )
+
+    def test_wrong_type_tx_path_does_not_trigger_required_fallback(self):
+        """When `tx_path` is present but has a wrong type (e.g. list, string),
+        the schema layer reports the type error authoritatively; the
+        cross-field fallback must NOT additionally emit
+        `tx_path: required ...` on the same case (Copilot wave-4 P2).
+        """
+        for wrong in ([], "", 42):
+            with tempfile.TemporaryDirectory() as td:
+                data = _load_committed_valid()
+                data["scenario"] = "tx_path_wrong_type"
+                data["tx_path"] = wrong  # type: ignore[assignment]
+                errors = _validate_dict(Path(td), data)
+                self.assertTrue(
+                    any("tx_path" in e for e in errors),
+                    f"expected schema type error on wrong-type tx_path={wrong!r}; got {errors}",
+                )
+                self.assertFalse(
+                    any(
+                        ("tx_path: required" in e and "mixed_client_process_soak" in e)
+                        for e in errors
+                    ),
+                    f"`tx_path: required` fallback fired on wrong-type tx_path={wrong!r}; got {errors}",
+                )
+
     def test_observer_missing_impl_does_not_trigger_cross_impl_error(self):
         """If a string observer references a participant with no string
         `implementation`, the schema layer reports the missing field; the

--- a/tools/tests/test_validate_mixed_client_evidence.py
+++ b/tools/tests/test_validate_mixed_client_evidence.py
@@ -92,7 +92,7 @@ class CrossImplTxPathRejectionTests(unittest.TestCase):
             data["tx_path"]["submitted_at"] = "node-a"
             data["tx_path"]["observed_at"] = ["node-b"]
             errors = _validate_dict(Path(td), data)
-            _assert_one(self, errors, "tx_path", "implementation", "submitted_at")
+            _assert_one(self, errors, "tx_path", "submitter", "observer")
 
     def test_rust_to_rust_only_in_mixed_set_rejected(self):
         """{rust, rust, go} with tx_path rust-1 -> [rust-2] must reject (T13 case 2)."""
@@ -107,7 +107,7 @@ class CrossImplTxPathRejectionTests(unittest.TestCase):
             data["tx_path"]["submitted_at"] = "node-a"
             data["tx_path"]["observed_at"] = ["node-b"]
             errors = _validate_dict(Path(td), data)
-            _assert_one(self, errors, "tx_path", "implementation", "submitted_at")
+            _assert_one(self, errors, "tx_path", "submitter", "observer")
 
     def test_submitter_only_observer_rejected(self):
         """observed_at == [submitted_at] for mixed-client PASS must reject."""

--- a/tools/tests/test_validate_mixed_client_evidence.py
+++ b/tools/tests/test_validate_mixed_client_evidence.py
@@ -167,7 +167,7 @@ class MalformedInputTests(unittest.TestCase):
                 f"expected schema type/pattern error on participants[0].name; got {errors}",
             )
             # Cross-field membership diagnostic must NOT fire because
-            # `participants_fully_named` is False.
+            # `all_participant_names_valid` is False.
             self.assertFalse(
                 any("not in participants" in e for e in errors),
                 f"S8/S9 membership diagnostic fired despite partial-shape participants; got {errors}",

--- a/tools/tests/test_validate_mixed_client_evidence.py
+++ b/tools/tests/test_validate_mixed_client_evidence.py
@@ -75,6 +75,36 @@ class MalformedInputTests(unittest.TestCase):
             f.write_text("[]", encoding="utf-8")
             self.assertTrue(validator.validate(f, SCHEMA_PATH))
 
+    def test_observer_missing_impl_does_not_trigger_cross_impl_error(self):
+        """If a string observer references a participant with no string
+        `implementation`, the schema layer reports the missing field; the
+        cross-impl check must NOT additionally emit a duplicative
+        submitter/observer error on the same case (Copilot wave-3 P2).
+        """
+        with tempfile.TemporaryDirectory() as td:
+            data = _load_committed_valid()
+            data["scenario"] = "observer_missing_impl"
+            data["participants"] = [
+                {"name": "node-a", "implementation": "go"},
+                {"name": "node-b"},  # implementation field omitted
+            ]
+            data["tx_path"]["submitted_at"] = "node-a"
+            data["tx_path"]["observed_at"] = ["node-b"]
+            errors = _validate_dict(Path(td), data)
+            # schema layer must report the missing field
+            self.assertTrue(
+                any("implementation" in e for e in errors),
+                f"expected schema error on missing implementation; got {errors}",
+            )
+            # cross-impl algorithm must NOT additionally fire
+            self.assertFalse(
+                any(
+                    ("submitter" in e and "observer" in e and "differ" in e)
+                    for e in errors
+                ),
+                f"cross-impl check fired on incomplete data; got {errors}",
+            )
+
 
 class CrossImplTxPathRejectionTests(unittest.TestCase):
     """T13 hostile cases: same-impl propagation in mixed-client set rejected."""

--- a/tools/tests/test_validate_mixed_client_evidence.py
+++ b/tools/tests/test_validate_mixed_client_evidence.py
@@ -70,10 +70,21 @@ class MalformedInputTests(unittest.TestCase):
             _assert_one(self, validator.validate(f, SCHEMA_PATH), "malformed JSON")
 
     def test_top_level_array_rejected(self):
+        """Top-level non-object input: schema owns the root `type: object`
+        rejection; the cross-field `<root>: top-level JSON must be an
+        object` message must NOT fire on top of the schema's authoritative
+        error (S1 wave-7 close)."""
         with tempfile.TemporaryDirectory() as td:
             f = Path(td) / "arr.json"
             f.write_text("[]", encoding="utf-8")
-            self.assertTrue(validator.validate(f, SCHEMA_PATH))
+            errors = validator.validate(f, SCHEMA_PATH)
+            # Schema reports the root type-mismatch authoritatively.
+            _assert_one(self, errors, "is not of type", "object")
+            # Custom cross-field root message must NOT fire.
+            self.assertFalse(
+                any("top-level JSON must be an object" in e for e in errors),
+                f"cross-field S1 root message duplicates schema error; got {errors}",
+            )
 
     def test_missing_schema_version_no_duplicate_cross_field_message(self):
         """When `schema_version` is missing, schema's `const` reports the


### PR DESCRIPTION
## Scope

- Issue: RUB-206 / Closes #1485 (parent: RUB-24, replaces oversized #1483 as PR-A of 3-PR sequential split)
- Invariant: For `mixed_client_process_soak` evidence with `verdict: PASS`, tx_path must include at least one observer with `implementation` differing from the submitter's. Go→Go inside `{go,go,rust}` is NOT mixed-client proof.
- Architecture class: B (bounded extension).
- Changed files (4 new, 1033 LoC cumulative): JSON Schema + Python validator + 1 testdata fixture + 35 unittest cases.

## Non-scope

- No clients/go, clients/rust, conformance, formal, devnet runtime change.
- No CI workflow change.
- No restart/reorg cross-field invariants (RUB-207 PR-B).
- No timestamp/endpoint textual policy — no `format: date-time`, no port-range alternation, no `_check_endpoint_port` (RUB-208 PR-C).
- No `node_role` const / helper-vs-real-process distinction (deferred).
- No new pip dependency (validator imports stdlib + already-pinned `jsonschema==4.19.2`).

**Bundle-waiver disclosure**: 1033 LoC across 4 files exceeds default 400 LoC budget per `feedback_schema_pr_loc_split_rule`. Schema (97) + validator (363) = 460 LoC ≈ threshold; tests (558) + fixture (15) reflect 10-case hostile matrix coverage + 8 class-closure tests for the cross-field "schema-authoritative duplication" umbrella (S1-S11 verdict table in `_validate_cross_field`'s docstring with sub-dimension gates: entry × element-shape × list-purity × site interactions). Architect-approved bundle path per RUB-206 split_boundary clause; controller chat 2026-05-08 explicitly authorised the class-closure sweep + finite Option B follow-up sweeps for cited threads.

## Verification

- `python3 -m unittest tools.tests.test_validate_mixed_client_evidence`: PASS, 35 cases (10 hostile-matrix mappings + 5 accepted + 8 schema-shape + 1 determinism + 2 CLI + 8 class-closure malformed-input + 1 committed fixture).
- `python3 -m unittest discover -s tools/tests -p 'test_*.py'`: PASS, no regression in repo Python suite.
- Validator CLI smoke: `valid_minimal_mixed.json` → exit 0; same fixture mutated to {go,go,rust} go→[go] → exit 1, FAIL with cited reason.
- `rubin-common-preflight` lanes core/tooling/coverage at HEAD `bbae48d`: PASS / PASS / PASS_WITH_COVERAGE_SKIP (`AUTOMATIC_NO_COVERAGE_SURFACE`).
- `rubin-review-fanout` at HEAD `bbae48d`: issue-matrix PASS, prepush-hostile PASS, parity NOT_APPLICABLE.
- `rubin-delta-receipt` at HEAD `bbae48d`: PASS.


<!-- rubin-agent-meta actor=claude action=pr-edit via=cl branch=claude/strange-jepsen-cdd76f wt=strange-jepsen-cdd76f utc=2026-05-08T10:55:46Z -->
