### PR TITLE
RUB-206: mixed-client devnet evidence — re-cut PR-A from origin/main

### DIFF
--- a/scripts/devnet/schema/mixed_client_evidence_v1.json
+++ b/scripts/devnet/schema/mixed_client_evidence_v1.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rubin-protocol.dev/schemas/scripts/devnet/mixed_client_evidence_v1.json",
+  "title": "Rubin Mixed-Client Devnet Evidence v1 — base slice (PR-A)",
+  "description": "Minimum process-soak evidence schema needed to prove cross-implementation tx propagation between Go and Rust nodes. Restart/reorg, timestamp policy, and endpoint port policy are deferred to follow-up slices.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "evidence_type",
+    "scenario",
+    "verdict",
+    "participants"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "rubin-mixed-client-devnet-evidence-v1"
+    },
+    "evidence_type": {
+      "type": "string",
+      "enum": [
+        "mixed_client_process_soak",
+        "single_client_process_soak"
+      ]
+    },
+    "scenario": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 200
+    },
+    "verdict": {
+      "type": "string",
+      "enum": [
+        "PASS",
+        "FAIL"
+      ]
+    },
+    "failure_reason": {
+      "type": "string",
+      "minLength": 1
+    },
+    "participants": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "implementation"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "pattern": "^node-[a-z0-9][a-z0-9-]{0,30}$"
+          },
+          "implementation": {
+            "type": "string",
+            "enum": [
+              "go",
+              "rust"
+            ]
+          }
+        }
+      }
+    },
+    "tx_path": {
+      "type": "object",
+      "required": [
+        "submitted_at",
+        "observed_at",
+        "tx_id"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "submitted_at": {
+          "type": "string",
+          "minLength": 1
+        },
+        "observed_at": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "tx_id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        }
+      }
+    }
+  }
+}

--- a/scripts/devnet/schema/mixed_client_evidence_v1.json
+++ b/scripts/devnet/schema/mixed_client_evidence_v1.json
@@ -20,8 +20,7 @@
     "evidence_type": {
       "type": "string",
       "enum": [
-        "mixed_client_process_soak",
-        "single_client_process_soak"
+        "mixed_client_process_soak"
       ]
     },
     "scenario": {

--- a/scripts/devnet/testdata/valid_minimal_mixed.json
+++ b/scripts/devnet/testdata/valid_minimal_mixed.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": "rubin-mixed-client-devnet-evidence-v1",
+  "evidence_type": "mixed_client_process_soak",
+  "scenario": "minimal_mixed_go_to_rust_propagation",
+  "verdict": "PASS",
+  "participants": [
+    {"name": "node-a", "implementation": "go"},
+    {"name": "node-b", "implementation": "rust"}
+  ],
+  "tx_path": {
+    "submitted_at": "node-a",
+    "observed_at": ["node-b"],
+    "tx_id": "3333333333333333333333333333333333333333333333333333333333333333"
+  }
+}

--- a/scripts/devnet/validate_mixed_client_evidence.py
+++ b/scripts/devnet/validate_mixed_client_evidence.py
@@ -287,22 +287,25 @@ def _cross_field(data: dict) -> list[str]:
 def validate(fixture_path: Path, schema_path: Path) -> list[str]:
     """Return sorted, deduplicated error messages. Empty list = PASS.
 
-    Contract: `result == [] ⇒ data conforms to the committed-shape
-    encoded by `mixed_client_evidence_v1.json`. The committed schema is
-    ALWAYS enforced as a floor; the user-supplied `--schema` may add
-    extra constraints but cannot relax committed ones. This prevents
-    silent PASS on permissive alternate schemas.
+    Contract: an empty result list means the input data conforms to the
+    committed-shape encoded by ``mixed_client_evidence_v1.json``. The
+    committed schema is ALWAYS enforced as a floor; the user-supplied
+    ``--schema`` may add extra constraints but cannot relax committed
+    ones. This prevents silent PASS on permissive alternate schemas.
 
-    On any deterministic input failure (unreadable file, malformed JSON,
-    invalid schema object, or any schema-layer rejection of the fixture),
-    cross-field validation is NOT run; only the schema-owned errors are
-    returned. The CLI never raises a Python exception on bad input.
+    On any deterministic input failure (unreadable file, non-UTF-8 bytes,
+    malformed JSON, invalid schema object, or any schema-layer rejection
+    of the fixture), cross-field validation is NOT run; only the
+    schema-owned errors are returned. The CLI never raises a Python
+    exception on bad input.
     """
     try:
         with open(schema_path, encoding="utf-8") as f:
             user_schema = json.load(f)
     except OSError as e:
         return [f"schema: cannot read {schema_path}: {e}"]
+    except UnicodeDecodeError as e:
+        return [f"schema: non-UTF-8 bytes in {schema_path}: {e}"]
     except json.JSONDecodeError as e:
         return [f"schema: malformed JSON in {schema_path}: {e}"]
 
@@ -311,6 +314,8 @@ def validate(fixture_path: Path, schema_path: Path) -> list[str]:
             data = json.load(f)
     except OSError as e:
         return [f"fixture: cannot read {fixture_path}: {e}"]
+    except UnicodeDecodeError as e:
+        return [f"fixture: non-UTF-8 bytes in {fixture_path}: {e}"]
     except json.JSONDecodeError as e:
         return [f"fixture: malformed JSON in {fixture_path}: {e}"]
 
@@ -322,8 +327,16 @@ def validate(fixture_path: Path, schema_path: Path) -> list[str]:
     try:
         with open(DEFAULT_SCHEMA, encoding="utf-8") as f:
             committed_schema = json.load(f)
-    except (OSError, json.JSONDecodeError) as e:
+    except OSError as e:
         return [f"schema: cannot read committed schema {DEFAULT_SCHEMA}: {e}"]
+    except UnicodeDecodeError as e:
+        return [
+            f"schema: non-UTF-8 bytes in committed schema {DEFAULT_SCHEMA}: {e}"
+        ]
+    except json.JSONDecodeError as e:
+        return [
+            f"schema: malformed JSON in committed schema {DEFAULT_SCHEMA}: {e}"
+        ]
 
     committed_errors, schema_available = _schema_layer(data, committed_schema)
     if not schema_available:

--- a/scripts/devnet/validate_mixed_client_evidence.py
+++ b/scripts/devnet/validate_mixed_client_evidence.py
@@ -35,6 +35,21 @@ REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 DEFAULT_SCHEMA = REPO_ROOT / "scripts" / "devnet" / "schema" / "mixed_client_evidence_v1.json"
 
 
+def _path_key(err: object) -> tuple:
+    """Total-orderable sort key for jsonschema `ValidationError.absolute_path`.
+
+    `e.absolute_path` may legitimately mix int (array indices) and str
+    (object keys); a plain `list(e.absolute_path)` key raises
+    `TypeError: '<' not supported between 'int' and 'str'` when adjacent
+    errors have different element types at the same depth. This typed
+    tuple `(type(p).__name__, str(p))` reduces both to comparable str
+    pairs ('int' < 'str' lexicographically).
+    """
+    return tuple(
+        (type(p).__name__, str(p)) for p in getattr(err, "absolute_path", ())
+    )
+
+
 def _schema_layer(data: Any, schema: dict) -> tuple[list[str], bool]:
     """Run jsonschema Draft 2020-12 validation against `data`.
 
@@ -75,17 +90,8 @@ def _schema_layer(data: Any, schema: dict) -> tuple[list[str], bool]:
             True,
         )
 
-    # Total-orderable sort key: tuple of (type-tag, str-of-element) for
-    # each path component. `e.absolute_path` may legitimately mix int
-    # (array indices) and str (object keys) depending on which schema
-    # the validator runs against; a plain `list(e.absolute_path)` key
-    # raises `TypeError: '<' not supported between 'int' and 'str'` when
-    # adjacent errors have different element types at the same depth.
-    def _path_key(err: object) -> tuple:
-        return tuple(
-            (type(p).__name__, str(p)) for p in getattr(err, "absolute_path", ())
-        )
-
+    # Sort with the module-level `_path_key` (total-orderable across
+    # mixed int/str path elements; see its docstring for rationale).
     errors = sorted(raw_errors, key=_path_key)
     return (
         [
@@ -116,13 +122,14 @@ def _cross_field(data: dict) -> list[str]:
     evidence_type = data.get("evidence_type")
     verdict = data.get("verdict")
 
-    # Schema-independent minimal-shape guard. Defensive against
-    # permissive alternate `--schema` overrides that could admit input
-    # violating the committed shape; without these checks the direct
-    # indexing below would raise KeyError/TypeError instead of returning
-    # deterministic validation errors. The committed schema enforces
-    # all of these via `required` / `type` / `items`; this guard is the
-    # minimum needed to keep cross-field code safe under any schema.
+    # Belt-and-suspenders: the committed-schema floor in `validate()`
+    # already guarantees `participants` is a non-empty list of objects
+    # with str `name` and `implementation` (so the direct indexing
+    # below cannot KeyError on the standard call path). This
+    # schema-independent minimal-shape guard remains as defense-in-
+    # depth in case `_cross_field` is ever called from a future caller
+    # that bypasses the floor (e.g., direct unit-test invocation, or a
+    # refactor that loses the always-on committed-schema floor).
     minimal_shape_errors: list[str] = []
     if not isinstance(data.get("participants"), list) or not data.get("participants"):
         minimal_shape_errors.append(
@@ -189,10 +196,11 @@ def _cross_field(data: dict) -> list[str]:
 
     tx_path = data.get("tx_path")
     if isinstance(tx_path, dict):
-        # Committed-shape prerequisites for tx_path (same checks the
-        # committed schema enforces). Defensive against permissive
-        # alternate schemas that admit dict-shaped tx_path missing
-        # required keys or with wrong-type values.
+        # Belt-and-suspenders: committed-floor in `validate()` already
+        # guarantees tx_path is a dict with str `submitted_at`, list-
+        # of-str `observed_at`, and str `tx_id`. This guard remains as
+        # defense-in-depth (same rationale as the participant guard
+        # above) so direct calls into `_cross_field` cannot KeyError.
         tx_path_shape_errors: list[str] = []
         submitted_at = tx_path.get("submitted_at")
         observed_at = tx_path.get("observed_at")

--- a/scripts/devnet/validate_mixed_client_evidence.py
+++ b/scripts/devnet/validate_mixed_client_evidence.py
@@ -75,7 +75,18 @@ def _schema_layer(data: Any, schema: dict) -> tuple[list[str], bool]:
             True,
         )
 
-    errors = sorted(raw_errors, key=lambda e: list(e.absolute_path))
+    # Total-orderable sort key: tuple of (type-tag, str-of-element) for
+    # each path component. `e.absolute_path` may legitimately mix int
+    # (array indices) and str (object keys) depending on which schema
+    # the validator runs against; a plain `list(e.absolute_path)` key
+    # raises `TypeError: '<' not supported between 'int' and 'str'` when
+    # adjacent errors have different element types at the same depth.
+    def _path_key(err: object) -> tuple:
+        return tuple(
+            (type(p).__name__, str(p)) for p in getattr(err, "absolute_path", ())
+        )
+
+    errors = sorted(raw_errors, key=_path_key)
     return (
         [
             f"{'.'.join(str(p) for p in e.absolute_path) or '<root>'}: {e.message}"
@@ -104,11 +115,39 @@ def _cross_field(data: dict) -> list[str]:
     errors: list[str] = []
     evidence_type = data.get("evidence_type")
     verdict = data.get("verdict")
-    participants = data["participants"]
 
-    # Schema PASS contract: every entry in `participants` is a dict with
-    # `name` and `implementation` as strings; `valid_names` is therefore
-    # exhaustive (`all_participant_names_valid` by construction here).
+    # Schema-independent minimal-shape guard. Defensive against
+    # permissive alternate `--schema` overrides that could admit input
+    # violating the committed shape; without these checks the direct
+    # indexing below would raise KeyError/TypeError instead of returning
+    # deterministic validation errors. The committed schema enforces
+    # all of these via `required` / `type` / `items`; this guard is the
+    # minimum needed to keep cross-field code safe under any schema.
+    minimal_shape_errors: list[str] = []
+    if not isinstance(data.get("participants"), list) or not data.get("participants"):
+        minimal_shape_errors.append(
+            "<root>: alternate schema admitted; expected non-empty `participants` list"
+        )
+        return minimal_shape_errors
+    participants = data["participants"]
+    for i, p in enumerate(participants):
+        if not isinstance(p, dict):
+            minimal_shape_errors.append(
+                f"<root>: participants[{i}] not an object (alternate schema admitted)"
+            )
+            continue
+        if not isinstance(p.get("name"), str):
+            minimal_shape_errors.append(
+                f"<root>: participants[{i}].name not a string (alternate schema admitted)"
+            )
+        if not isinstance(p.get("implementation"), str):
+            minimal_shape_errors.append(
+                f"<root>: participants[{i}].implementation not a string (alternate schema admitted)"
+            )
+    if minimal_shape_errors:
+        return minimal_shape_errors
+    # all_participant_names_valid by construction (every p is dict with str name)
+
     impls = {p["implementation"] for p in participants}
     names_list = [p["name"] for p in participants]
     impl_by_name: dict[str, str] = {p["name"]: p["implementation"] for p in participants}
@@ -150,8 +189,34 @@ def _cross_field(data: dict) -> list[str]:
 
     tx_path = data.get("tx_path")
     if isinstance(tx_path, dict):
-        submitted_at = tx_path["submitted_at"]
-        observed_at = tx_path["observed_at"]
+        # Committed-shape prerequisites for tx_path (same checks the
+        # committed schema enforces). Defensive against permissive
+        # alternate schemas that admit dict-shaped tx_path missing
+        # required keys or with wrong-type values.
+        tx_path_shape_errors: list[str] = []
+        submitted_at = tx_path.get("submitted_at")
+        observed_at = tx_path.get("observed_at")
+        tx_id = tx_path.get("tx_id")
+        if not isinstance(submitted_at, str):
+            tx_path_shape_errors.append(
+                "<root>: tx_path.submitted_at not a string (alternate schema admitted)"
+            )
+        if (
+            not isinstance(observed_at, list)
+            or not observed_at
+            or not all(isinstance(o, str) for o in observed_at)
+        ):
+            tx_path_shape_errors.append(
+                "<root>: tx_path.observed_at not a non-empty list of strings "
+                "(alternate schema admitted)"
+            )
+        if not isinstance(tx_id, str):
+            tx_path_shape_errors.append(
+                "<root>: tx_path.tx_id not a string (alternate schema admitted)"
+            )
+        if tx_path_shape_errors:
+            errors.extend(tx_path_shape_errors)
+            return errors
 
         if submitted_at not in valid_names:
             errors.append(
@@ -170,8 +235,7 @@ def _cross_field(data: dict) -> list[str]:
         # name -> impl mapping is ambiguous and the duplicate-names
         # error above is authoritative) or when any observer name is
         # unknown (the per-observer "not in participants" error above
-        # is authoritative; chaining the cross-impl algorithm off an
-        # unknown name would KeyError on impl_by_name lookup).
+        # is authoritative).
         if (
             evidence_type == "mixed_client_process_soak"
             and verdict == "PASS"
@@ -211,14 +275,20 @@ def _cross_field(data: dict) -> list[str]:
 def validate(fixture_path: Path, schema_path: Path) -> list[str]:
     """Return sorted, deduplicated error messages. Empty list = PASS.
 
+    Contract: `result == [] ⇒ data conforms to the committed-shape
+    encoded by `mixed_client_evidence_v1.json`. The committed schema is
+    ALWAYS enforced as a floor; the user-supplied `--schema` may add
+    extra constraints but cannot relax committed ones. This prevents
+    silent PASS on permissive alternate schemas.
+
     On any deterministic input failure (unreadable file, malformed JSON,
-    invalid schema object, or schema-layer rejection of the fixture),
+    invalid schema object, or any schema-layer rejection of the fixture),
     cross-field validation is NOT run; only the schema-owned errors are
-    returned.
+    returned. The CLI never raises a Python exception on bad input.
     """
     try:
         with open(schema_path, encoding="utf-8") as f:
-            schema = json.load(f)
+            user_schema = json.load(f)
     except OSError as e:
         return [f"schema: cannot read {schema_path}: {e}"]
     except json.JSONDecodeError as e:
@@ -232,30 +302,43 @@ def validate(fixture_path: Path, schema_path: Path) -> list[str]:
     except json.JSONDecodeError as e:
         return [f"fixture: malformed JSON in {fixture_path}: {e}"]
 
-    schema_errors, schema_available = _schema_layer(data, schema)
-    if schema_errors:
-        return sorted(set(schema_errors))
+    # Floor: ALWAYS run the committed schema regardless of `schema_path`.
+    # If the user supplied `DEFAULT_SCHEMA` (the canonical path), this is
+    # a no-op duplicate; if they supplied a permissive alternate schema,
+    # this catches every committed-shape violation the alternate schema
+    # would have admitted.
+    try:
+        with open(DEFAULT_SCHEMA, encoding="utf-8") as f:
+            committed_schema = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        return [f"schema: cannot read committed schema {DEFAULT_SCHEMA}: {e}"]
 
-    # Schema PASS → run cross-field invariants. (When jsonschema is
-    # unavailable, `schema_errors` already contains the «library
-    # unavailable» message and we never reach this branch.)
+    committed_errors, schema_available = _schema_layer(data, committed_schema)
     if not schema_available:
-        return sorted(set(schema_errors))
+        return committed_errors  # «jsonschema library unavailable» path
+    if committed_errors:
+        return sorted(set(committed_errors))
 
-    if not isinstance(data, dict):
-        # The committed schema enforces root `type: object`, so this
-        # branch is unreachable when the default `--schema` is used.
-        # However, `validate()` accepts a parametrized `schema_path`,
-        # so a permissive alternate schema (one that does not assert
-        # `type: object` at root) could let non-object fixtures past
-        # the schema layer. Returning `[]` here would silently PASS
-        # such input — break the «empty list = PASS» contract by
-        # surfacing a deterministic non-object error.
-        return [
-            "<root>: evidence must be a JSON object at top level "
-            "(schema layer did not enforce this)"
-        ]
+    # User-supplied schema may add extra constraints (e.g., stricter
+    # patterns or extra required fields). Run only when distinct from
+    # the committed schema to avoid duplicate work.
+    try:
+        same_schema = (
+            schema_path.resolve(strict=False) == DEFAULT_SCHEMA.resolve(strict=False)
+        )
+    except (OSError, RuntimeError):
+        same_schema = False
+    if not same_schema:
+        user_errors, _ = _schema_layer(data, user_schema)
+        if user_errors:
+            return sorted(set(user_errors))
 
+    # Both schema layers passed; data is committed-shape by construction
+    # (the committed schema enforces `type: object`, root `required`,
+    # `properties.*`, `additionalProperties: false`, and every
+    # constraint the cross-field code below relies on). `_cross_field`
+    # may safely index data["participants"], p["name"], p["implementation"],
+    # tx_path["submitted_at"], etc.
     return sorted(set(_cross_field(data)))
 
 

--- a/scripts/devnet/validate_mixed_client_evidence.py
+++ b/scripts/devnet/validate_mixed_client_evidence.py
@@ -243,10 +243,18 @@ def validate(fixture_path: Path, schema_path: Path) -> list[str]:
         return sorted(set(schema_errors))
 
     if not isinstance(data, dict):
-        # Defensive: schema's `type: object` would have already rejected
-        # non-dict input above, but the cross-field code below
-        # dereferences `data` as a dict.
-        return []
+        # The committed schema enforces root `type: object`, so this
+        # branch is unreachable when the default `--schema` is used.
+        # However, `validate()` accepts a parametrized `schema_path`,
+        # so a permissive alternate schema (one that does not assert
+        # `type: object` at root) could let non-object fixtures past
+        # the schema layer. Returning `[]` here would silently PASS
+        # such input — break the «empty list = PASS» contract by
+        # surfacing a deterministic non-object error.
+        return [
+            "<root>: evidence must be a JSON object at top level "
+            "(schema layer did not enforce this)"
+        ]
 
     return sorted(set(_cross_field(data)))
 

--- a/scripts/devnet/validate_mixed_client_evidence.py
+++ b/scripts/devnet/validate_mixed_client_evidence.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Validate mixed-client devnet process-soak evidence.
+
+Design rule:
+  * JSON Schema (Draft 2020-12) owns ALL shape/type/const/minLength/pattern
+    validation. The schema layer is the sole authority for «is this value
+    well-shaped?» errors.
+  * The Python cross-field layer runs ONLY when schema validation passes.
+    It enforces invariants jsonschema cannot express: participant-name
+    uniqueness, tx_path participant references, the cross-implementation
+    tx_path invariant, and the conditional «mixed PASS ⇒ tx_path
+    required» rule.
+  * On any malformed schema input (unreadable schema file, invalid JSON,
+    invalid Draft 2020-12 schema object), the CLI returns a deterministic
+    `schema: ...` error and exits 1 — never raises a traceback.
+
+Used as the offline gate for `mixed_client_process_soak` PASS evidence.
+
+Usage:
+    python3 scripts/devnet/validate_mixed_client_evidence.py FIXTURE.json
+    python3 scripts/devnet/validate_mixed_client_evidence.py --schema PATH FIXTURE.json
+
+Exits 0 on PASS, 1 on validation failure or unreadable input.
+"""
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+DEFAULT_SCHEMA = REPO_ROOT / "scripts" / "devnet" / "schema" / "mixed_client_evidence_v1.json"
+
+SCHEMA_VERSION = "rubin-mixed-client-devnet-evidence-v1"
+
+
+def _schema_layer(data: Any, schema: dict) -> tuple[list[str], bool]:
+    """Run jsonschema Draft 2020-12 validation against `data`.
+
+    Returns (errors, schema_available). `schema_available=False` means
+    `jsonschema` is not importable; the caller treats that as a fatal
+    deterministic error and skips cross-field validation.
+    """
+    try:
+        import jsonschema  # type: ignore[import-untyped]
+    except ImportError:
+        return (
+            [
+                "<root>: jsonschema library unavailable; install jsonschema "
+                "for full Draft 2020-12 validation"
+            ],
+            False,
+        )
+
+    # Construct the validator and explicitly check the schema object so a
+    # malformed Draft 2020-12 schema produces a deterministic
+    # `schema: invalid schema: ...` error rather than a traceback.
+    try:
+        jsonschema.Draft202012Validator.check_schema(schema)
+        validator = jsonschema.Draft202012Validator(schema)
+    except jsonschema.exceptions.SchemaError as e:
+        return ([f"schema: invalid schema: {e.message}"], True)
+    except Exception as e:  # defensive: any other validator-init failure
+        return (
+            [f"schema: validator construction failed: {type(e).__name__}: {e}"],
+            True,
+        )
+
+    try:
+        raw_errors = list(validator.iter_errors(data))
+    except Exception as e:  # defensive: jsonschema runtime exceptions
+        return (
+            [f"schema: validation runtime failed: {type(e).__name__}: {e}"],
+            True,
+        )
+
+    errors = sorted(raw_errors, key=lambda e: list(e.absolute_path))
+    return (
+        [
+            f"{'.'.join(str(p) for p in e.absolute_path) or '<root>'}: {e.message}"
+            for e in errors
+        ],
+        True,
+    )
+
+
+def _cross_field(data: dict) -> list[str]:
+    """Cross-field invariants. Caller MUST run this only after the schema
+    layer reports zero errors — otherwise schema-owned shape problems
+    would be re-asserted here as semantic «name lookup failed» messages.
+
+    Invariants (each one not expressible as a JSON Schema constraint):
+
+      * participants must have unique names (schema lacks per-property
+        uniqueItems).
+      * tx_path.submitted_at must reference a declared participant.
+      * tx_path.observed_at[i] must each reference a declared participant.
+      * mixed_client_process_soak with verdict=PASS requires tx_path
+        (and at least one observer whose implementation differs from the
+        submitter's — the T13 cross-implementation invariant).
+      * mixed_client_process_soak requires both `go` and `rust` impls.
+    """
+    errors: list[str] = []
+    evidence_type = data.get("evidence_type")
+    verdict = data.get("verdict")
+    participants = data["participants"]
+
+    impls = {p["implementation"] for p in participants}
+    names_list = [p["name"] for p in participants]
+    impl_by_name: dict[str, str] = {p["name"]: p["implementation"] for p in participants}
+    valid_names = set(impl_by_name)
+
+    # Mixed-client must have at least one go AND one rust participant.
+    if evidence_type == "mixed_client_process_soak":
+        if not ({"go", "rust"} <= impls):
+            errors.append(
+                "participants: evidence_type=mixed_client_process_soak requires "
+                "at least one implementation=go and one implementation=rust; "
+                f"observed implementations={sorted(impls)}"
+            )
+        if len(participants) < 2:
+            errors.append(
+                "participants: evidence_type=mixed_client_process_soak "
+                "requires at least 2 participants"
+            )
+
+    # Participant-name uniqueness.
+    duplicates = sorted(
+        n for n, c in collections.Counter(names_list).items() if c > 1
+    )
+    if duplicates:
+        errors.append(f"participants: duplicate names: {duplicates}")
+
+    # verdict=FAIL conditional requirement (schema makes failure_reason
+    # optional and `minLength: 1` rejects empty strings; cross-field is
+    # the authoritative source for the «verdict=FAIL ⇒ failure_reason
+    # must be present» rule).
+    if verdict == "FAIL" and "failure_reason" not in data:
+        errors.append(
+            "failure_reason: required when verdict=FAIL"
+        )
+
+    tx_path = data.get("tx_path")
+    if isinstance(tx_path, dict):
+        submitted_at = tx_path["submitted_at"]
+        observed_at = tx_path["observed_at"]
+
+        if submitted_at not in valid_names:
+            errors.append(
+                f"tx_path.submitted_at: {submitted_at!r} not in participants"
+            )
+        for i, observer in enumerate(observed_at):
+            if observer not in valid_names:
+                errors.append(
+                    f"tx_path.observed_at[{i}]: {observer!r} not in participants"
+                )
+
+        # T13 cross-implementation invariant: mixed_client_process_soak
+        # PASS evidence must show an observer whose implementation
+        # differs from the submitter's; otherwise it is not mixed-client
+        # propagation proof. Skipped when names are duplicated (the
+        # name -> impl mapping is ambiguous and the duplicate-names
+        # error above is authoritative) or when any observer name is
+        # unknown (the per-observer "not in participants" error above
+        # is authoritative; chaining the cross-impl algorithm off an
+        # unknown name would KeyError on impl_by_name lookup).
+        if (
+            evidence_type == "mixed_client_process_soak"
+            and verdict == "PASS"
+            and not duplicates
+            and submitted_at in impl_by_name
+            and all(o in impl_by_name for o in observed_at)
+        ):
+            submitter_impl = impl_by_name[submitted_at]
+            observer_pairs = sorted(
+                {(o, impl_by_name[o]) for o in observed_at}
+            )
+            if not any(impl != submitter_impl for _, impl in observer_pairs):
+                errors.append(
+                    "tx_path: mixed_client_process_soak with verdict=PASS "
+                    "requires observer implementation to differ from submitter "
+                    "implementation; submitter "
+                    f"{submitted_at!r}/{submitter_impl}, observers="
+                    f"{[f'{n}/{i}' for n, i in observer_pairs]}"
+                )
+    elif evidence_type == "mixed_client_process_soak" and verdict == "PASS":
+        errors.append(
+            "tx_path: required for evidence_type=mixed_client_process_soak "
+            "with verdict=PASS"
+        )
+
+    return errors
+
+
+def validate(fixture_path: Path, schema_path: Path) -> list[str]:
+    """Return sorted, deduplicated error messages. Empty list = PASS.
+
+    On any deterministic input failure (unreadable file, malformed JSON,
+    invalid schema object, or schema-layer rejection of the fixture),
+    cross-field validation is NOT run; only the schema-owned errors are
+    returned.
+    """
+    try:
+        with open(schema_path, encoding="utf-8") as f:
+            schema = json.load(f)
+    except OSError as e:
+        return [f"schema: cannot read {schema_path}: {e}"]
+    except json.JSONDecodeError as e:
+        return [f"schema: malformed JSON in {schema_path}: {e}"]
+
+    try:
+        with open(fixture_path, encoding="utf-8") as f:
+            data = json.load(f)
+    except OSError as e:
+        return [f"fixture: cannot read {fixture_path}: {e}"]
+    except json.JSONDecodeError as e:
+        return [f"fixture: malformed JSON in {fixture_path}: {e}"]
+
+    schema_errors, schema_available = _schema_layer(data, schema)
+    if schema_errors:
+        return sorted(set(schema_errors))
+
+    # Schema PASS → run cross-field invariants. (When jsonschema is
+    # unavailable, `schema_errors` already contains the «library
+    # unavailable» message and we never reach this branch.)
+    if not schema_available:
+        return sorted(set(schema_errors))
+
+    if not isinstance(data, dict):
+        # Defensive: schema's `type: object` would have already rejected
+        # non-dict input above, but the cross-field code below
+        # dereferences `data` as a dict.
+        return []
+
+    return sorted(set(_cross_field(data)))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate mixed-client devnet evidence JSON."
+    )
+    parser.add_argument(
+        "fixture", type=Path, help="Path to evidence JSON file to validate."
+    )
+    parser.add_argument(
+        "--schema",
+        type=Path,
+        default=DEFAULT_SCHEMA,
+        help=(
+            f"Path to schema JSON (default: {DEFAULT_SCHEMA.relative_to(REPO_ROOT)})."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    errors = validate(args.fixture, args.schema)
+    if errors:
+        print(f"FAIL: {args.fixture}", file=sys.stderr)
+        for err in errors:
+            print(f"  - {err}", file=sys.stderr)
+        return 1
+    print(f"PASS: {args.fixture}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/devnet/validate_mixed_client_evidence.py
+++ b/scripts/devnet/validate_mixed_client_evidence.py
@@ -263,19 +263,23 @@ def _cross_field(data: dict) -> list[str]:
                     f"{submitted_at!r}/{submitter_impl}, observers="
                     f"{[f'{n}/{i}' for n, i in observer_pairs]}"
                 )
-    elif (
-        # `tx_path is None` (absent) is the only remaining branch: schema
-        # validated `tx_path` as `type: object` when present, so the
-        # cross-field tx_path-required message only fires for genuinely
-        # absent tx_path on a mixed-client PASS soak.
-        tx_path is None
-        and evidence_type == "mixed_client_process_soak"
-        and verdict == "PASS"
-    ):
-        errors.append(
-            "tx_path: required for evidence_type=mixed_client_process_soak "
-            "with verdict=PASS"
-        )
+    elif evidence_type == "mixed_client_process_soak" and verdict == "PASS":
+        # Standard call path: schema validates `tx_path` as `type: object`
+        # when present, so on the standard path this branch only fires for
+        # genuinely absent `tx_path`. The non-None / non-dict case is
+        # reachable only on direct `_cross_field` calls that bypass the
+        # committed-schema floor (defense-in-depth, same rationale as the
+        # participants guard above); both subcases are exercised by direct
+        # tests in `CrossFieldDirectFallbackTests`.
+        if tx_path is None:
+            errors.append(
+                "tx_path: required for evidence_type=mixed_client_process_soak "
+                "with verdict=PASS"
+            )
+        else:
+            errors.append(
+                "<root>: tx_path not an object (alternate schema admitted)"
+            )
 
     return errors
 

--- a/scripts/devnet/validate_mixed_client_evidence.py
+++ b/scripts/devnet/validate_mixed_client_evidence.py
@@ -34,8 +34,6 @@ from typing import Any
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 DEFAULT_SCHEMA = REPO_ROOT / "scripts" / "devnet" / "schema" / "mixed_client_evidence_v1.json"
 
-SCHEMA_VERSION = "rubin-mixed-client-devnet-evidence-v1"
-
 
 def _schema_layer(data: Any, schema: dict) -> tuple[list[str], bool]:
     """Run jsonschema Draft 2020-12 validation against `data`.
@@ -108,6 +106,9 @@ def _cross_field(data: dict) -> list[str]:
     verdict = data.get("verdict")
     participants = data["participants"]
 
+    # Schema PASS contract: every entry in `participants` is a dict with
+    # `name` and `implementation` as strings; `valid_names` is therefore
+    # exhaustive (`all_participant_names_valid` by construction here).
     impls = {p["implementation"] for p in participants}
     names_list = [p["name"] for p in participants]
     impl_by_name: dict[str, str] = {p["name"]: p["implementation"] for p in participants}
@@ -133,6 +134,10 @@ def _cross_field(data: dict) -> list[str]:
     )
     if duplicates:
         errors.append(f"participants: duplicate names: {duplicates}")
+    # The T13 cross-impl invariant below is gated on `not duplicates` so
+    # name->impl-keyed semantics do not chain off the ambiguous
+    # last-write-wins `impl_by_name` mapping when names duplicate; the
+    # duplicate-names cross-field error above is then authoritative.
 
     # verdict=FAIL conditional requirement (schema makes failure_reason
     # optional and `minLength: 1` rejects empty strings; cross-field is
@@ -186,7 +191,15 @@ def _cross_field(data: dict) -> list[str]:
                     f"{submitted_at!r}/{submitter_impl}, observers="
                     f"{[f'{n}/{i}' for n, i in observer_pairs]}"
                 )
-    elif evidence_type == "mixed_client_process_soak" and verdict == "PASS":
+    elif (
+        # `tx_path is None` (absent) is the only remaining branch: schema
+        # validated `tx_path` as `type: object` when present, so the
+        # cross-field tx_path-required message only fires for genuinely
+        # absent tx_path on a mixed-client PASS soak.
+        tx_path is None
+        and evidence_type == "mixed_client_process_soak"
+        and verdict == "PASS"
+    ):
         errors.append(
             "tx_path: required for evidence_type=mixed_client_process_soak "
             "with verdict=PASS"

--- a/tools/tests/test_validate_mixed_client_evidence.py
+++ b/tools/tests/test_validate_mixed_client_evidence.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""Tests for scripts/devnet/validate_mixed_client_evidence.py.
+
+The validator design rule is: JSON Schema owns all shape/type/const/
+minLength/pattern; the Python cross-field layer runs ONLY after schema
+PASS. These tests exercise the layered contract end-to-end via the
+public `validate()` and `main()` entrypoints.
+"""
+from __future__ import annotations
+
+import contextlib
+import copy
+import io
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_DIR = REPO_ROOT / "scripts" / "devnet"
+SCHEMA_PATH = SCRIPT_DIR / "schema" / "mixed_client_evidence_v1.json"
+TESTDATA_DIR = SCRIPT_DIR / "testdata"
+
+sys.path.insert(0, str(SCRIPT_DIR))
+import validate_mixed_client_evidence as validator  # noqa: E402
+
+
+def _load_committed_valid() -> dict:
+    with open(TESTDATA_DIR / "valid_minimal_mixed.json", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _validate_dict(td: Path, data) -> list[str]:
+    fixture = td / "case.json"
+    fixture.write_text(json.dumps(data), encoding="utf-8")
+    return validator.validate(fixture, SCHEMA_PATH)
+
+
+def _assert_one(testcase: unittest.TestCase, errors: list[str], *needles: str) -> None:
+    testcase.assertTrue(errors, "expected validation errors but got none")
+    testcase.assertTrue(
+        any(all(n in e for n in needles) for e in errors),
+        f"no error matched all needles {needles!r}; got {errors}",
+    )
+
+
+class CommittedFixtureTests(unittest.TestCase):
+    def test_committed_valid_minimal_mixed_passes(self):
+        errors = validator.validate(
+            TESTDATA_DIR / "valid_minimal_mixed.json", SCHEMA_PATH
+        )
+        self.assertEqual(errors, [], f"committed valid fixture must pass; got {errors}")
+
+
+class CrossImplTxPathTests(unittest.TestCase):
+    """T13 invariant — the core RUB-206 contract."""
+
+    def test_same_impl_tx_path_in_mixed_set_rejected(self):
+        """{go, go, rust} with go-1 → [go-2] is NOT mixed-client proof."""
+        with tempfile.TemporaryDirectory() as td:
+            data = _load_committed_valid()
+            data["scenario"] = "go_to_go_only_in_mixed_set"
+            data["participants"] = [
+                {"name": "node-a", "implementation": "go"},
+                {"name": "node-b", "implementation": "go"},
+                {"name": "node-c", "implementation": "rust"},
+            ]
+            data["tx_path"]["submitted_at"] = "node-a"
+            data["tx_path"]["observed_at"] = ["node-b"]
+            errors = _validate_dict(Path(td), data)
+            _assert_one(self, errors, "tx_path", "submitter", "observer")
+
+    def test_rust_to_go_passes(self):
+        with tempfile.TemporaryDirectory() as td:
+            data = _load_committed_valid()
+            data["scenario"] = "rust_to_go_propagation"
+            data["participants"] = [
+                {"name": "node-a", "implementation": "rust"},
+                {"name": "node-b", "implementation": "go"},
+            ]
+            data["tx_path"]["submitted_at"] = "node-a"
+            data["tx_path"]["observed_at"] = ["node-b"]
+            self.assertEqual(_validate_dict(Path(td), data), [])
+
+    def test_unknown_observer_rejected(self):
+        with tempfile.TemporaryDirectory() as td:
+            data = _load_committed_valid()
+            data["tx_path"]["observed_at"] = ["node-ghost"]
+            errors = _validate_dict(Path(td), data)
+            _assert_one(self, errors, "tx_path.observed_at", "node-ghost")
+
+    def test_pass_without_tx_path_rejected(self):
+        with tempfile.TemporaryDirectory() as td:
+            data = _load_committed_valid()
+            del data["tx_path"]
+            errors = _validate_dict(Path(td), data)
+            _assert_one(self, errors, "tx_path", "required")
+
+    def test_duplicate_participant_names_rejected(self):
+        with tempfile.TemporaryDirectory() as td:
+            data = _load_committed_valid()
+            data["participants"][1]["name"] = "node-a"
+            errors = _validate_dict(Path(td), data)
+            _assert_one(self, errors, "duplicate")
+
+
+class FailClosedCliTests(unittest.TestCase):
+    """The CLI must never raise to the user; every input failure mode
+    yields a deterministic single-line `<prefix>: ...` message and an
+    exit code of 1."""
+
+    def test_invalid_schema_path_returns_deterministic_error(self):
+        with tempfile.TemporaryDirectory() as td:
+            errors = validator.validate(
+                TESTDATA_DIR / "valid_minimal_mixed.json", Path(td) / "no_such.json"
+            )
+            self.assertTrue(
+                any(e.startswith("schema:") and "cannot read" in e for e in errors),
+                f"expected `schema: cannot read ...`; got {errors}",
+            )
+            self.assertFalse(
+                any("Traceback" in e for e in errors),
+                f"validator leaked a traceback; got {errors}",
+            )
+
+    def test_malformed_schema_json_returns_deterministic_error(self):
+        with tempfile.TemporaryDirectory() as td:
+            bad_schema = Path(td) / "bad.json"
+            bad_schema.write_text("{not valid", encoding="utf-8")
+            errors = validator.validate(
+                TESTDATA_DIR / "valid_minimal_mixed.json", bad_schema
+            )
+            _assert_one(self, errors, "schema:", "malformed JSON")
+
+    def test_invalid_schema_object_returns_deterministic_error(self):
+        """A parseable but Draft 2020-12-invalid schema (e.g. `type: 99`)
+        must be caught by `Draft202012Validator.check_schema` and yield
+        a `schema: invalid schema: ...` line, never a traceback."""
+        with tempfile.TemporaryDirectory() as td:
+            bad_schema = Path(td) / "bad.json"
+            bad_schema.write_text(json.dumps({"type": 99}), encoding="utf-8")
+            errors = validator.validate(
+                TESTDATA_DIR / "valid_minimal_mixed.json", bad_schema
+            )
+            self.assertTrue(
+                any(e.startswith("schema:") and "invalid schema" in e for e in errors),
+                f"expected `schema: invalid schema: ...`; got {errors}",
+            )
+            self.assertFalse(
+                any("Traceback" in e for e in errors),
+                f"validator leaked a traceback; got {errors}",
+            )
+
+    def test_missing_fixture_returns_deterministic_error(self):
+        with tempfile.TemporaryDirectory() as td:
+            errors = validator.validate(Path(td) / "no_such.json", SCHEMA_PATH)
+            _assert_one(self, errors, "fixture:", "cannot read")
+
+    def test_malformed_fixture_json_returns_deterministic_error(self):
+        with tempfile.TemporaryDirectory() as td:
+            bad = Path(td) / "bad.json"
+            bad.write_text("{not valid", encoding="utf-8")
+            _assert_one(
+                self, validator.validate(bad, SCHEMA_PATH), "fixture:", "malformed JSON"
+            )
+
+
+class SchemaOwnedTests(unittest.TestCase):
+    """For each shape/type/const/minLength/pattern problem the schema
+    layer is the sole authority; the cross-field layer must not run on
+    these inputs (the validator returns schema-owned errors only and
+    cross-field is short-circuited)."""
+
+    def test_top_level_array_schema_owned_only(self):
+        with tempfile.TemporaryDirectory() as td:
+            f = Path(td) / "arr.json"
+            f.write_text("[]", encoding="utf-8")
+            errors = validator.validate(f, SCHEMA_PATH)
+            _assert_one(self, errors, "is not of type", "object")
+            # No cross-field message about top-level shape.
+            self.assertFalse(
+                any("top-level" in e for e in errors),
+                f"cross-field root message duplicates schema; got {errors}",
+            )
+
+    def test_empty_failure_reason_schema_owned_only(self):
+        """`failure_reason: ""` violates schema's `minLength: 1`. The
+        cross-field «verdict=FAIL ⇒ failure_reason required» rule must
+        not fire on top of the schema's authoritative rejection."""
+        with tempfile.TemporaryDirectory() as td:
+            data = _load_committed_valid()
+            data["verdict"] = "FAIL"
+            data["failure_reason"] = ""
+            errors = _validate_dict(Path(td), data)
+            _assert_one(self, errors, "failure_reason", "too short")
+            self.assertFalse(
+                any(
+                    "required when verdict=FAIL" in e
+                    for e in errors
+                ),
+                f"cross-field FAIL rule duplicates schema minLength; got {errors}",
+            )
+
+    def test_wrong_type_schema_version_schema_owned_only(self):
+        """`schema_version: 42` violates schema's `const`. The error
+        list must contain a schema-owned `schema_version` rejection
+        (positive assertion) and no cross-field 'must be exactly'
+        wording (negative assertion)."""
+        with tempfile.TemporaryDirectory() as td:
+            data = _load_committed_valid()
+            data["schema_version"] = 42  # type: ignore[assignment]
+            errors = _validate_dict(Path(td), data)
+            _assert_one(self, errors, "schema_version")
+            self.assertFalse(
+                any("must be exactly" in e for e in errors),
+                f"cross-field 'must be exactly' duplicates schema; got {errors}",
+            )
+
+    def test_wrong_type_participants_schema_owned_only(self):
+        """`participants: {"node-a": "go"}` violates schema's
+        `type: array`. The error list must contain a schema-owned
+        `participants` type rejection (positive assertion) and no
+        cross-field semantics on top of it."""
+        with tempfile.TemporaryDirectory() as td:
+            data = _load_committed_valid()
+            data["participants"] = {"node-a": "go"}  # type: ignore[assignment]
+            errors = _validate_dict(Path(td), data)
+            _assert_one(self, errors, "participants", "is not of type")
+            self.assertFalse(
+                any("duplicate" in e for e in errors),
+                f"cross-field S7 fired on schema-invalid participants; got {errors}",
+            )
+            self.assertFalse(
+                any("requires at least one implementation" in e for e in errors),
+                f"cross-field S5 fired on schema-invalid participants; got {errors}",
+            )
+
+
+class DeterminismTests(unittest.TestCase):
+    def test_deterministic_on_identical_input(self):
+        with tempfile.TemporaryDirectory() as td:
+            data = _load_committed_valid()
+            data["participants"][1]["implementation"] = "go"
+            runs = [_validate_dict(Path(td), copy.deepcopy(data)) for _ in range(3)]
+            self.assertEqual(runs[0], runs[1])
+            self.assertEqual(runs[1], runs[2])
+
+
+class CliTests(unittest.TestCase):
+    def test_main_zero_on_valid_fixture(self):
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            rc = validator.main([str(TESTDATA_DIR / "valid_minimal_mixed.json")])
+        self.assertEqual(rc, 0)
+        self.assertIn("PASS", buf.getvalue())
+
+    def test_main_nonzero_on_invalid_fixture(self):
+        with tempfile.TemporaryDirectory() as td:
+            data = _load_committed_valid()
+            data["participants"] = [
+                {"name": "node-a", "implementation": "go"},
+                {"name": "node-b", "implementation": "go"},
+                {"name": "node-c", "implementation": "rust"},
+            ]
+            data["tx_path"]["observed_at"] = ["node-b"]
+            f = Path(td) / "go_to_go.json"
+            f.write_text(json.dumps(data), encoding="utf-8")
+            buf = io.StringIO()
+            with contextlib.redirect_stderr(buf):
+                rc = validator.main([str(f)])
+            self.assertEqual(rc, 1)
+            self.assertIn("FAIL", buf.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_validate_mixed_client_evidence.py
+++ b/tools/tests/test_validate_mixed_client_evidence.py
@@ -539,6 +539,139 @@ class CrossFieldDirectFallbackTests(unittest.TestCase):
         )
 
 
+class TxPathDirectFallbackTests(unittest.TestCase):
+    """Direct invocation of `_cross_field` that BYPASSES `validate()`'s
+    committed-schema floor for the `tx_path` defensive shape branch
+    (lines 198-227). Without these tests the defensive `tx_path` minimal-
+    shape diagnostics would be unreachable on the standard call path and
+    would drift from the comment contract documented in the validator
+    (parallel to `CrossFieldDirectFallbackTests` above for participants).
+    """
+
+    @staticmethod
+    def _mixed_pass_with(tx_path) -> dict:
+        return {
+            "schema_version": "rubin-mixed-client-devnet-evidence-v1",
+            "evidence_type": "mixed_client_process_soak",
+            "scenario": "x",
+            "verdict": "PASS",
+            "participants": [
+                {"name": "node-a", "implementation": "go"},
+                {"name": "node-b", "implementation": "rust"},
+            ],
+            "tx_path": tx_path,
+        }
+
+    def test_cross_field_tx_path_submitted_at_not_string_returns_minimal_shape_error(self):
+        errors = validator._cross_field(
+            self._mixed_pass_with({
+                "submitted_at": 1,
+                "observed_at": ["node-b"],
+                "tx_id": "0" * 64,
+            })
+        )
+        self.assertTrue(
+            any(
+                "tx_path.submitted_at not a string" in e
+                and "alternate schema admitted" in e
+                for e in errors
+            ),
+            f"expected submitted_at-not-string minimal-shape error; got {errors}",
+        )
+
+    def test_cross_field_tx_path_observed_at_not_list_returns_minimal_shape_error(self):
+        errors = validator._cross_field(
+            self._mixed_pass_with({
+                "submitted_at": "node-a",
+                "observed_at": "node-b",
+                "tx_id": "0" * 64,
+            })
+        )
+        self.assertTrue(
+            any(
+                "tx_path.observed_at not a non-empty list of strings" in e
+                and "alternate schema admitted" in e
+                for e in errors
+            ),
+            f"expected observed_at-not-list minimal-shape error; got {errors}",
+        )
+
+    def test_cross_field_tx_path_observed_at_empty_returns_minimal_shape_error(self):
+        errors = validator._cross_field(
+            self._mixed_pass_with({
+                "submitted_at": "node-a",
+                "observed_at": [],
+                "tx_id": "0" * 64,
+            })
+        )
+        self.assertTrue(
+            any(
+                "tx_path.observed_at not a non-empty list of strings" in e
+                and "alternate schema admitted" in e
+                for e in errors
+            ),
+            f"expected observed_at-empty minimal-shape error; got {errors}",
+        )
+
+    def test_cross_field_tx_path_tx_id_not_string_returns_minimal_shape_error(self):
+        errors = validator._cross_field(
+            self._mixed_pass_with({
+                "submitted_at": "node-a",
+                "observed_at": ["node-b"],
+                "tx_id": 1,
+            })
+        )
+        self.assertTrue(
+            any(
+                "tx_path.tx_id not a string" in e
+                and "alternate schema admitted" in e
+                for e in errors
+            ),
+            f"expected tx_id-not-string minimal-shape error; got {errors}",
+        )
+
+    def test_cross_field_tx_path_non_dict_non_none_returns_alternate_admitted_error(self):
+        # Non-dict, non-None `tx_path` (e.g. a string or int admitted by a
+        # permissive alternate schema). Direct path must surface a
+        # deterministic minimal-shape error, not silently fall through.
+        errors = validator._cross_field(self._mixed_pass_with("not-an-object"))
+        self.assertTrue(
+            any(
+                "tx_path not an object" in e
+                and "alternate schema admitted" in e
+                for e in errors
+            ),
+            f"expected tx_path-not-object alternate-admitted error; got {errors}",
+        )
+
+
+class CrossFieldUnknownSubmitterTests(unittest.TestCase):
+    """Positive owner test for the cross-field diagnostic
+    `tx_path.submitted_at: <name> not in participants` (validator.py:229-232).
+    Schema cannot express participant-name membership, so the diagnostic is
+    a true cross-field invariant. This test must reach the diagnostic on
+    the standard call path (schema-valid fixture with a submitter name not
+    declared in `participants`).
+    """
+
+    def test_unknown_submitter_rejected(self):
+        with tempfile.TemporaryDirectory() as td:
+            data = _load_committed_valid()
+            data["tx_path"]["submitted_at"] = "node-ghost"
+            errors = _validate_dict(Path(td), data)
+            _assert_one(self, errors, "tx_path.submitted_at", "node-ghost", "not in participants")
+            # Class-closure: when the submitter is unknown, the T13
+            # cross-impl gate (line 251 `submitted_at in impl_by_name`)
+            # short-circuits, so the cross-impl diagnostic must NOT also
+            # fire — defense against a future refactor that drops the
+            # membership gate.
+            self.assertFalse(
+                any("requires observer implementation to differ" in e for e in errors),
+                f"unknown submitter must NOT spuriously trigger the T13 cross-impl "
+                f"message; got {errors}",
+            )
+
+
 class CliTests(unittest.TestCase):
     def test_main_zero_on_valid_fixture(self):
         buf = io.StringIO()

--- a/tools/tests/test_validate_mixed_client_evidence.py
+++ b/tools/tests/test_validate_mixed_client_evidence.py
@@ -393,6 +393,24 @@ class SchemaOwnedTests(unittest.TestCase):
                 f"cross-field FAIL rule duplicates schema minLength; got {errors}",
             )
 
+    def test_scenario_empty_string_schema_owned_only(self):
+        """`scenario: ""` violates schema's `minLength: 1`. Schema layer
+        is the sole authority for the bound."""
+        with tempfile.TemporaryDirectory() as td:
+            data = _load_committed_valid()
+            data["scenario"] = ""
+            errors = _validate_dict(Path(td), data)
+            _assert_one(self, errors, "scenario", "too short")
+
+    def test_scenario_too_long_schema_owned_only(self):
+        """`scenario` longer than `maxLength: 200` is rejected by the
+        schema layer."""
+        with tempfile.TemporaryDirectory() as td:
+            data = _load_committed_valid()
+            data["scenario"] = "x" * 201  # 1 over the maxLength: 200 bound
+            errors = _validate_dict(Path(td), data)
+            _assert_one(self, errors, "scenario", "too long")
+
     def test_wrong_type_schema_version_schema_owned_only(self):
         """`schema_version: 42` violates schema's `const`. The error
         list must contain a schema-owned `schema_version` rejection

--- a/tools/tests/test_validate_mixed_client_evidence.py
+++ b/tools/tests/test_validate_mixed_client_evidence.py
@@ -456,6 +456,89 @@ class DeterminismTests(unittest.TestCase):
             self.assertEqual(runs[1], runs[2])
 
 
+class CrossFieldDirectFallbackTests(unittest.TestCase):
+    """Direct invocation of `_cross_field` that BYPASSES `validate()`'s
+    committed-schema floor, exercising the defensive `minimal_shape_errors`
+    branches that protect future callers (refactor / direct unit test) which
+    skip the floor. Without these tests the defensive diagnostics would be
+    unreachable on the standard call path and would drift from the comment
+    contract documented in the validator (see lines 125-138).
+    """
+
+    def test_cross_field_non_list_participants_returns_minimal_shape_error(self):
+        # participants is a dict, not a list.
+        errors = validator._cross_field({
+            "schema_version": "rubin-mixed-client-devnet-evidence-v1",
+            "evidence_type": "mixed_client_process_soak",
+            "scenario": "x",
+            "verdict": "PASS",
+            "participants": {"node-a": "go"},
+            "tx_path": {
+                "submitted_at": "node-a",
+                "observed_at": ["node-b"],
+                "tx_id": "0" * 64,
+            },
+        })
+        self.assertEqual(
+            errors,
+            ["<root>: alternate schema admitted; expected non-empty `participants` list"],
+        )
+
+    def test_cross_field_empty_participants_returns_minimal_shape_error(self):
+        errors = validator._cross_field({
+            "evidence_type": "mixed_client_process_soak",
+            "verdict": "PASS",
+            "participants": [],
+        })
+        self.assertEqual(
+            errors,
+            ["<root>: alternate schema admitted; expected non-empty `participants` list"],
+        )
+
+    def test_cross_field_participant_not_object_returns_minimal_shape_error(self):
+        errors = validator._cross_field({
+            "evidence_type": "mixed_client_process_soak",
+            "verdict": "PASS",
+            "participants": ["node-a"],
+        })
+        self.assertTrue(
+            any(
+                "participants[0] not an object" in e and "alternate schema admitted" in e
+                for e in errors
+            ),
+            f"expected participant-not-object minimal-shape error; got {errors}",
+        )
+
+    def test_cross_field_participant_name_not_string_returns_minimal_shape_error(self):
+        errors = validator._cross_field({
+            "evidence_type": "mixed_client_process_soak",
+            "verdict": "PASS",
+            "participants": [{"name": 1, "implementation": "go"}],
+        })
+        self.assertTrue(
+            any(
+                "participants[0].name not a string" in e and "alternate schema admitted" in e
+                for e in errors
+            ),
+            f"expected name-not-string minimal-shape error; got {errors}",
+        )
+
+    def test_cross_field_participant_implementation_not_string_returns_minimal_shape_error(self):
+        errors = validator._cross_field({
+            "evidence_type": "mixed_client_process_soak",
+            "verdict": "PASS",
+            "participants": [{"name": "node-a", "implementation": 7}],
+        })
+        self.assertTrue(
+            any(
+                "participants[0].implementation not a string" in e
+                and "alternate schema admitted" in e
+                for e in errors
+            ),
+            f"expected implementation-not-string minimal-shape error; got {errors}",
+        )
+
+
 class CliTests(unittest.TestCase):
     def test_main_zero_on_valid_fixture(self):
         buf = io.StringIO()

--- a/tools/tests/test_validate_mixed_client_evidence.py
+++ b/tools/tests/test_validate_mixed_client_evidence.py
@@ -165,36 +165,127 @@ class FailClosedCliTests(unittest.TestCase):
                 self, validator.validate(bad, SCHEMA_PATH), "fixture:", "malformed JSON"
             )
 
-    def test_permissive_alternate_schema_does_not_silently_pass_non_object(self):
-        """When the user supplies an alternate `--schema` that does NOT
-        enforce `type: object` at the root, a non-object fixture must
-        still be rejected — not silently PASSed by the cross-field
-        layer's defensive non-dict guard. The committed schema does
-        enforce `type: object`, so this exercises the parametrized
-        `validate(fixture_path, schema_path)` boundary."""
+    def _permissive_schema(self, td: Path) -> Path:
+        """Helper: write a permissive schema (only $schema declared) to td."""
+        p = td / "permissive.json"
+        p.write_text(
+            json.dumps({"$schema": "https://json-schema.org/draft/2020-12/schema"}),
+            encoding="utf-8",
+        )
+        return p
+
+    def test_permissive_alternate_schema_non_object_root_rejected(self):
+        """Non-object root under alternate permissive schema: committed
+        schema is enforced as floor regardless of user's --schema, so
+        the validator returns a deterministic schema-owned type error."""
         with tempfile.TemporaryDirectory() as td:
-            # Permissive schema: matches any JSON value (no `type: object`).
-            permissive = Path(td) / "permissive.json"
-            permissive.write_text(
-                json.dumps({"$schema": "https://json-schema.org/draft/2020-12/schema"}),
+            tdp = Path(td)
+            permissive = self._permissive_schema(tdp)
+            for fixture_text in ("[]", "42", "null", '"hello"'):
+                fix = tdp / "f.json"
+                fix.write_text(fixture_text, encoding="utf-8")
+                errors = validator.validate(fix, permissive)
+                self.assertTrue(
+                    errors,
+                    f"validator silently PASSed non-object fixture {fixture_text!r}",
+                )
+                self.assertTrue(
+                    any("is not of type" in e and "object" in e for e in errors),
+                    f"validator did not surface schema-owned type error for "
+                    f"{fixture_text!r}; got {errors}",
+                )
+                self.assertFalse(
+                    any("Traceback" in e for e in errors),
+                    f"validator leaked traceback for {fixture_text!r}; got {errors}",
+                )
+
+    def test_permissive_alternate_schema_empty_object_rejected(self):
+        """`{}` under permissive alternate schema: committed-schema floor
+        catches missing required top-level fields."""
+        with tempfile.TemporaryDirectory() as td:
+            tdp = Path(td)
+            permissive = self._permissive_schema(tdp)
+            fix = tdp / "f.json"
+            fix.write_text("{}", encoding="utf-8")
+            errors = validator.validate(fix, permissive)
+            _assert_one(self, errors, "required")
+
+    def test_permissive_alternate_schema_empty_participants_rejected(self):
+        """`{participants: []}` under permissive alternate schema:
+        committed-schema floor catches `minItems: 1`."""
+        with tempfile.TemporaryDirectory() as td:
+            tdp = Path(td)
+            permissive = self._permissive_schema(tdp)
+            fix = tdp / "f.json"
+            fix.write_text(json.dumps({"participants": []}), encoding="utf-8")
+            errors = validator.validate(fix, permissive)
+            self.assertTrue(errors)
+            self.assertFalse(any("Traceback" in e for e in errors))
+
+    def test_permissive_alternate_schema_participant_missing_implementation_rejected(self):
+        """Participant missing `implementation` under permissive alt
+        schema: committed-schema floor catches missing required."""
+        with tempfile.TemporaryDirectory() as td:
+            tdp = Path(td)
+            permissive = self._permissive_schema(tdp)
+            fix = tdp / "f.json"
+            fix.write_text(
+                json.dumps({"participants": [{"name": "node-a"}]}),
                 encoding="utf-8",
             )
-            non_object_fixture = Path(td) / "arr.json"
-            non_object_fixture.write_text("[]", encoding="utf-8")
-            errors = validator.validate(non_object_fixture, permissive)
-            self.assertTrue(
-                errors,
-                "validator silently PASSed non-object fixture under alternate "
-                "permissive schema",
-            )
-            self.assertTrue(
-                any(
-                    "evidence must be a JSON object" in e
-                    or "expected" in e.lower()
-                    for e in errors
-                ),
-                f"validator did not surface clear non-object rejection; got {errors}",
-            )
+            errors = validator.validate(fix, permissive)
+            self.assertTrue(any("implementation" in e for e in errors))
+            self.assertFalse(any("Traceback" in e for e in errors))
+
+    def test_permissive_alternate_schema_empty_tx_path_rejected(self):
+        """`tx_path: {}` under permissive alt schema: committed-schema
+        floor catches missing required tx_path keys."""
+        with tempfile.TemporaryDirectory() as td:
+            tdp = Path(td)
+            permissive = self._permissive_schema(tdp)
+            data = _load_committed_valid()
+            data["tx_path"] = {}
+            fix = tdp / "f.json"
+            fix.write_text(json.dumps(data), encoding="utf-8")
+            errors = validator.validate(fix, permissive)
+            self.assertTrue(any("tx_path" in e for e in errors))
+            self.assertFalse(any("Traceback" in e for e in errors))
+
+    def test_permissive_alternate_schema_wrong_type_observed_at_rejected(self):
+        """`tx_path.observed_at` non-list under permissive alt schema:
+        committed-schema floor catches wrong type."""
+        with tempfile.TemporaryDirectory() as td:
+            tdp = Path(td)
+            permissive = self._permissive_schema(tdp)
+            data = _load_committed_valid()
+            data["tx_path"]["observed_at"] = "node-b"  # wrong type — should be array
+            fix = tdp / "f.json"
+            fix.write_text(json.dumps(data), encoding="utf-8")
+            errors = validator.validate(fix, permissive)
+            self.assertTrue(any("observed_at" in e for e in errors))
+            self.assertFalse(any("Traceback" in e for e in errors))
+
+    def test_alternate_schema_with_mixed_path_types_does_not_typeerror(self):
+        """Sort key for `_schema_layer` errors must be total-orderable
+        across mixed-type `absolute_path` (int + str). Constructed by
+        passing a fixture with errors at both `participants[0]` (int
+        index path) and `evidence_type` (str key path) under the
+        committed schema."""
+        with tempfile.TemporaryDirectory() as td:
+            tdp = Path(td)
+            data = _load_committed_valid()
+            data["evidence_type"] = "bogus"  # str-path enum violation
+            data["participants"][0]["name"] = "BAD-CAPS"  # int-then-str pattern violation
+            fix = tdp / "f.json"
+            fix.write_text(json.dumps(data), encoding="utf-8")
+            try:
+                errors = validator.validate(fix, SCHEMA_PATH)
+            except TypeError as e:
+                self.fail(f"sorted() raised TypeError on mixed path types: {e}")
+            self.assertTrue(errors)
+            # Should contain both errors
+            self.assertTrue(any("evidence_type" in e for e in errors))
+            self.assertTrue(any("name" in e for e in errors))
 
 
 class SchemaOwnedTests(unittest.TestCase):

--- a/tools/tests/test_validate_mixed_client_evidence.py
+++ b/tools/tests/test_validate_mixed_client_evidence.py
@@ -165,6 +165,37 @@ class FailClosedCliTests(unittest.TestCase):
                 self, validator.validate(bad, SCHEMA_PATH), "fixture:", "malformed JSON"
             )
 
+    def test_permissive_alternate_schema_does_not_silently_pass_non_object(self):
+        """When the user supplies an alternate `--schema` that does NOT
+        enforce `type: object` at the root, a non-object fixture must
+        still be rejected — not silently PASSed by the cross-field
+        layer's defensive non-dict guard. The committed schema does
+        enforce `type: object`, so this exercises the parametrized
+        `validate(fixture_path, schema_path)` boundary."""
+        with tempfile.TemporaryDirectory() as td:
+            # Permissive schema: matches any JSON value (no `type: object`).
+            permissive = Path(td) / "permissive.json"
+            permissive.write_text(
+                json.dumps({"$schema": "https://json-schema.org/draft/2020-12/schema"}),
+                encoding="utf-8",
+            )
+            non_object_fixture = Path(td) / "arr.json"
+            non_object_fixture.write_text("[]", encoding="utf-8")
+            errors = validator.validate(non_object_fixture, permissive)
+            self.assertTrue(
+                errors,
+                "validator silently PASSed non-object fixture under alternate "
+                "permissive schema",
+            )
+            self.assertTrue(
+                any(
+                    "evidence must be a JSON object" in e
+                    or "expected" in e.lower()
+                    for e in errors
+                ),
+                f"validator did not surface clear non-object rejection; got {errors}",
+            )
+
 
 class SchemaOwnedTests(unittest.TestCase):
     """For each shape/type/const/minLength/pattern problem the schema

--- a/tools/tests/test_validate_mixed_client_evidence.py
+++ b/tools/tests/test_validate_mixed_client_evidence.py
@@ -265,27 +265,96 @@ class FailClosedCliTests(unittest.TestCase):
             self.assertTrue(any("observed_at" in e for e in errors))
             self.assertFalse(any("Traceback" in e for e in errors))
 
-    def test_alternate_schema_with_mixed_path_types_does_not_typeerror(self):
-        """Sort key for `_schema_layer` errors must be total-orderable
-        across mixed-type `absolute_path` (int + str). Constructed by
-        passing a fixture with errors at both `participants[0]` (int
-        index path) and `evidence_type` (str key path) under the
-        committed schema."""
+    def test_path_key_total_orderable_across_int_and_str(self):
+        """Direct unit test of `_schema_layer`'s `_path_key`. A naive
+        `key=lambda e: list(e.absolute_path)` raises `TypeError` when
+        Python is asked to compare an int to a str at the same index;
+        the typed tuple key `(type-tag, str(p))` reduces both to
+        comparable str pairs. This is the regression vector identified
+        by the wave-2 prepush-hostile finding."""
+        # Synthetic error stand-ins — only `absolute_path` is read by
+        # `_path_key` per the implementation contract.
+        class _FakeErr:
+            def __init__(self, path):
+                self.absolute_path = path
+
+        # The buggy `list(absolute_path)` key raises TypeError on this:
+        keys = [validator._path_key(_FakeErr([0])), validator._path_key(_FakeErr(["x"]))]
+        # Sort must complete without raising.
+        try:
+            ordered = sorted(keys)
+        except TypeError as e:
+            self.fail(f"_path_key not total-orderable on int vs str: {e}")
+        # 'int' < 'str' lexicographically, so [0] sorts before ["x"].
+        self.assertEqual(ordered[0], (("int", "0"),))
+        self.assertEqual(ordered[1], (("str", "x"),))
+
+        # Same depth, mixed types — must not raise.
+        same_depth = [
+            validator._path_key(_FakeErr(["participants", 0])),
+            validator._path_key(_FakeErr(["participants", "extra_key"])),
+        ]
+        try:
+            sorted(same_depth)
+        except TypeError as e:
+            self.fail(f"_path_key not total-orderable at same depth: {e}")
+
+    def test_fail_without_failure_reason_cross_field_rejected(self):
+        """Cross-field positive branch: `verdict=FAIL` without
+        `failure_reason` must surface the conditional-required error
+        (committed schema makes failure_reason optional; cross-field is
+        sole authority)."""
         with tempfile.TemporaryDirectory() as td:
-            tdp = Path(td)
             data = _load_committed_valid()
-            data["evidence_type"] = "bogus"  # str-path enum violation
-            data["participants"][0]["name"] = "BAD-CAPS"  # int-then-str pattern violation
-            fix = tdp / "f.json"
-            fix.write_text(json.dumps(data), encoding="utf-8")
-            try:
-                errors = validator.validate(fix, SCHEMA_PATH)
-            except TypeError as e:
-                self.fail(f"sorted() raised TypeError on mixed path types: {e}")
-            self.assertTrue(errors)
-            # Should contain both errors
-            self.assertTrue(any("evidence_type" in e for e in errors))
-            self.assertTrue(any("name" in e for e in errors))
+            data["verdict"] = "FAIL"
+            # Don't include failure_reason at all (committed schema
+            # accepts because failure_reason is not in `required`).
+            errors = _validate_dict(Path(td), data)
+            _assert_one(self, errors, "failure_reason", "required")
+
+    def test_mixed_client_with_only_go_impls_rejected(self):
+        """Cross-field positive branch: `mixed_client_process_soak`
+        with all-go impls must surface the «requires at least one go
+        and one rust» rule (committed schema's enum admits both labels;
+        cross-field enforces distribution)."""
+        with tempfile.TemporaryDirectory() as td:
+            data = _load_committed_valid()
+            data["scenario"] = "all_go_in_mixed_set"
+            data["participants"] = [
+                {"name": "node-a", "implementation": "go"},
+                {"name": "node-b", "implementation": "go"},
+            ]
+            data["tx_path"]["submitted_at"] = "node-a"
+            data["tx_path"]["observed_at"] = ["node-b"]
+            errors = _validate_dict(Path(td), data)
+            _assert_one(
+                self,
+                errors,
+                "implementation=go",
+                "implementation=rust",
+            )
+
+    def test_mixed_client_with_single_participant_rejected(self):
+        """Cross-field positive branch: `mixed_client_process_soak`
+        with a single participant must surface the «requires at least
+        2 participants» rule (committed schema's `minItems: 1` admits
+        a single-participant list; cross-field enforces ≥2)."""
+        with tempfile.TemporaryDirectory() as td:
+            data = _load_committed_valid()
+            data["scenario"] = "single_participant_in_mixed_set"
+            data["participants"] = [
+                {"name": "node-a", "implementation": "go"},
+            ]
+            # Drop tx_path — single-participant data can't satisfy
+            # cross-impl invariant; we only want to surface the
+            # «requires at least 2 participants» message.
+            del data["tx_path"]
+            errors = _validate_dict(Path(td), data)
+            _assert_one(
+                self,
+                errors,
+                "requires at least 2 participants",
+            )
 
 
 class SchemaOwnedTests(unittest.TestCase):

--- a/tools/tests/test_validate_mixed_client_evidence.py
+++ b/tools/tests/test_validate_mixed_client_evidence.py
@@ -165,6 +165,90 @@ class FailClosedCliTests(unittest.TestCase):
                 self, validator.validate(bad, SCHEMA_PATH), "fixture:", "malformed JSON"
             )
 
+    # F1 owner tests — UnicodeDecodeError on each of three file-read sites
+    # in `validate()` (user schema, fixture, committed schema). Without
+    # explicit `UnicodeDecodeError` catches, non-UTF-8 bytes (e.g. 0xff)
+    # in any of these files would escape `validate()` as a Python
+    # traceback, breaking the fail-closed CLI contract.
+
+    def test_non_utf8_schema_returns_deterministic_error(self):
+        """Non-UTF-8 bytes in --schema path must yield a deterministic
+        `schema: non-UTF-8 bytes ...` error and exit 1; no traceback.
+        """
+        with tempfile.TemporaryDirectory() as td:
+            bad_schema = Path(td) / "bad_schema.json"
+            bad_schema.write_bytes(b"\xff\xfe{\"$schema\": \"x\"}")
+            errors = validator.validate(
+                TESTDATA_DIR / "valid_minimal_mixed.json", bad_schema
+            )
+            _assert_one(self, errors, "schema:", "non-UTF-8 bytes")
+            self.assertFalse(
+                any("Traceback" in e for e in errors),
+                f"validator leaked traceback on non-UTF-8 schema; got {errors}",
+            )
+
+    def test_non_utf8_fixture_returns_deterministic_error(self):
+        """Non-UTF-8 bytes in fixture path must yield a deterministic
+        `fixture: non-UTF-8 bytes ...` error and exit 1; no traceback.
+        """
+        with tempfile.TemporaryDirectory() as td:
+            bad_fixture = Path(td) / "bad_fixture.json"
+            bad_fixture.write_bytes(b"\xff\xfe{\"k\": \"v\"}")
+            errors = validator.validate(bad_fixture, SCHEMA_PATH)
+            _assert_one(self, errors, "fixture:", "non-UTF-8 bytes")
+            self.assertFalse(
+                any("Traceback" in e for e in errors),
+                f"validator leaked traceback on non-UTF-8 fixture; got {errors}",
+            )
+
+    def test_non_utf8_committed_schema_returns_deterministic_error(self):
+        """Non-UTF-8 bytes in the committed (DEFAULT_SCHEMA) file must
+        yield a deterministic `schema: non-UTF-8 bytes in committed
+        schema ...` error and exit 1; no traceback. Exercised by
+        monkeypatching `validator.DEFAULT_SCHEMA` to a corrupted
+        committed-schema fixture so the floor read fails.
+        """
+        with tempfile.TemporaryDirectory() as td:
+            bad_committed = Path(td) / "committed_corrupt.json"
+            bad_committed.write_bytes(b"\xff\xfe{}")
+            original = validator.DEFAULT_SCHEMA
+            try:
+                validator.DEFAULT_SCHEMA = bad_committed
+                errors = validator.validate(
+                    TESTDATA_DIR / "valid_minimal_mixed.json", SCHEMA_PATH
+                )
+            finally:
+                validator.DEFAULT_SCHEMA = original
+            _assert_one(
+                self,
+                errors,
+                "schema:",
+                "non-UTF-8 bytes",
+                "committed schema",
+            )
+            self.assertFalse(
+                any("Traceback" in e for e in errors),
+                f"validator leaked traceback on non-UTF-8 committed schema; "
+                f"got {errors}",
+            )
+
+    def test_main_cli_fail_closed_on_non_utf8_fixture(self):
+        """End-to-end CLI: non-UTF-8 fixture → exit 1, deterministic
+        prefix to stderr, no Python traceback at all.
+        """
+        with tempfile.TemporaryDirectory() as td:
+            bad = Path(td) / "bad.json"
+            bad.write_bytes(b"\xff\xfe garbage")
+            err_buf = io.StringIO()
+            out_buf = io.StringIO()
+            with contextlib.redirect_stderr(err_buf), contextlib.redirect_stdout(out_buf):
+                rc = validator.main([str(bad)])
+            self.assertEqual(rc, 1, f"main rc={rc}; stderr={err_buf.getvalue()!r}")
+            stderr = err_buf.getvalue()
+            self.assertIn("fixture:", stderr)
+            self.assertIn("non-UTF-8 bytes", stderr)
+            self.assertNotIn("Traceback", stderr)
+
     def _permissive_schema(self, td: Path) -> Path:
         """Helper: write a permissive schema (only $schema declared) to td."""
         p = td / "permissive.json"
@@ -460,9 +544,10 @@ class CrossFieldDirectFallbackTests(unittest.TestCase):
     """Direct invocation of `_cross_field` that BYPASSES `validate()`'s
     committed-schema floor, exercising the defensive `minimal_shape_errors`
     branches that protect future callers (refactor / direct unit test) which
-    skip the floor. Without these tests the defensive diagnostics would be
-    unreachable on the standard call path and would drift from the comment
-    contract documented in the validator (see lines 125-138).
+    skip the floor. Without these tests the defensive `(alternate schema
+    admitted)` diagnostics for `participants` would be unreachable on the
+    standard call path and would drift from the comment contract documented
+    in `_cross_field`.
     """
 
     def test_cross_field_non_list_participants_returns_minimal_shape_error(self):
@@ -541,11 +626,12 @@ class CrossFieldDirectFallbackTests(unittest.TestCase):
 
 class TxPathDirectFallbackTests(unittest.TestCase):
     """Direct invocation of `_cross_field` that BYPASSES `validate()`'s
-    committed-schema floor for the `tx_path` defensive shape branch
-    (lines 198-227). Without these tests the defensive `tx_path` minimal-
-    shape diagnostics would be unreachable on the standard call path and
-    would drift from the comment contract documented in the validator
-    (parallel to `CrossFieldDirectFallbackTests` above for participants).
+    committed-schema floor for the `tx_path` defensive shape branch.
+    Without these tests the defensive `tx_path` minimal-shape `(alternate
+    schema admitted)` diagnostics would be unreachable on the standard
+    call path and would drift from the comment contract documented in
+    `_cross_field` (parallel to `CrossFieldDirectFallbackTests` above for
+    `participants`).
     """
 
     @staticmethod
@@ -646,11 +732,11 @@ class TxPathDirectFallbackTests(unittest.TestCase):
 
 
 class CrossFieldUnknownSubmitterTests(unittest.TestCase):
-    """Positive owner test for the cross-field diagnostic
-    `tx_path.submitted_at: <name> not in participants` (validator.py:229-232).
-    Schema cannot express participant-name membership, so the diagnostic is
-    a true cross-field invariant. This test must reach the diagnostic on
-    the standard call path (schema-valid fixture with a submitter name not
+    """Positive owner test for the `_cross_field` diagnostic
+    `tx_path.submitted_at: <name> not in participants`. Schema cannot
+    express participant-name membership, so the diagnostic is a true
+    cross-field invariant. This test must reach the diagnostic on the
+    standard call path (schema-valid fixture with a submitter name not
     declared in `participants`).
     """
 
@@ -661,10 +747,10 @@ class CrossFieldUnknownSubmitterTests(unittest.TestCase):
             errors = _validate_dict(Path(td), data)
             _assert_one(self, errors, "tx_path.submitted_at", "node-ghost", "not in participants")
             # Class-closure: when the submitter is unknown, the T13
-            # cross-impl gate (line 251 `submitted_at in impl_by_name`)
-            # short-circuits, so the cross-impl diagnostic must NOT also
-            # fire — defense against a future refactor that drops the
-            # membership gate.
+            # cross-impl gate (`submitted_at in impl_by_name` predicate
+            # in `_cross_field`) short-circuits, so the cross-impl
+            # diagnostic must NOT also fire — defense against a future
+            # refactor that drops the membership gate.
             self.assertFalse(
                 any("requires observer implementation to differ" in e for e in errors),
                 f"unknown submitter must NOT spuriously trigger the T13 cross-impl "


### PR DESCRIPTION
## Scope

- Issue: RUB-206 / Closes #1485 (parent: RUB-24, replaces closed PR #1488 as the PR-A slice).
- Invariant: For `mixed_client_process_soak` evidence with `verdict: PASS`, tx_path must include at least one observer with `implementation` differing from the submitter's. Go→Go inside `{go,go,rust}` is NOT mixed-client proof.
- Design rule: JSON Schema (Draft 2020-12) owns all shape/type/const/minLength/pattern. The committed schema is ALWAYS enforced as floor regardless of `--schema`. The Python cross-field layer runs ONLY after schema PASS. The CLI never raises a traceback on bad schema input — every input failure mode yields a deterministic `<prefix>: ...` error and exit 1.

## Non-scope

- No clients/go, clients/rust, conformance, formal, devnet runtime change.
- No CI workflow change.
- No restart/reorg cross-field invariants (RUB-207 PR-B).
- No timestamp/endpoint textual policy (RUB-208 PR-C).
- No `single_client_process_soak` evidence (dropped from schema enum; future RUB-N owns it).
- No new pip dependency (validator imports stdlib + already-pinned `jsonschema==4.19.2`).

## Verification

- `python3 -m unittest tools.tests.test_validate_mixed_client_evidence`: PASS.
- `python3 -m unittest discover -s tools/tests -p 'test_*.py'`: PASS.


<!-- rubin-agent-meta actor=unknown action=pr-edit via=cl branch=claude/rub-206-v2 wt=rubin-protocol-claude-rub206-v2 utc=2026-05-08T13:36:19Z -->
