### PR TITLE
RUB-207: restart/reorg evidence cross-field invariants (PR-B)

### DIFF
--- a/scripts/devnet/schema/mixed_client_evidence_v1.json
+++ b/scripts/devnet/schema/mixed_client_evidence_v1.json
@@ -151,6 +151,10 @@
         },
         "final_state": {
           "type": "object",
+          "required": [
+            "tip",
+            "height"
+          ],
           "additionalProperties": false,
           "properties": {
             "tip": {

--- a/scripts/devnet/schema/mixed_client_evidence_v1.json
+++ b/scripts/devnet/schema/mixed_client_evidence_v1.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://rubin-protocol.dev/schemas/scripts/devnet/mixed_client_evidence_v1.json",
-  "title": "Rubin Mixed-Client Devnet Evidence v1 — base slice (PR-A)",
-  "description": "Minimum process-soak evidence schema needed to prove cross-implementation tx propagation between Go and Rust nodes. Restart/reorg, timestamp policy, and endpoint port policy are deferred to follow-up slices.",
+  "title": "Rubin Mixed-Client Devnet Evidence v1 — base + restart/reorg (PR-A + PR-B)",
+  "description": "Process-soak evidence schema needed to prove cross-implementation tx propagation between Go and Rust nodes (PR-A base) plus restart/reorg lifecycle-coherence evidence (PR-B). Timestamp/endpoint textual policy is deferred to RUB-208 (PR-C).",
   "type": "object",
   "required": [
     "schema_version",
@@ -89,6 +89,79 @@
         "tx_id": {
           "type": "string",
           "pattern": "^[0-9a-f]{64}$"
+        }
+      }
+    },
+    "restart": {
+      "type": "object",
+      "required": [
+        "stopped_node",
+        "pre_restart_height",
+        "catch_up_height"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "stopped_node": {
+          "type": "string",
+          "minLength": 1
+        },
+        "pre_restart_height": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "catch_up_height": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "post_restart_live_action": {
+          "type": "object",
+          "required": [
+            "accepted_by_peer"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "accepted_by_peer": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    },
+    "reorg": {
+      "type": "object",
+      "required": [
+        "fork_height",
+        "winning_branch_height",
+        "winning_branch_tip"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "fork_height": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "winning_branch_height": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "winning_branch_tip": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "final_state": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "tip": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "height": {
+              "type": "integer",
+              "minimum": 0
+            }
+          }
         }
       }
     }

--- a/scripts/devnet/validate_mixed_client_evidence.py
+++ b/scripts/devnet/validate_mixed_client_evidence.py
@@ -344,8 +344,21 @@ def _cross_field_restart(data: dict, valid_names: set[str]) -> list[str]:
         )
 
     # post_restart_live_action.accepted_by_peer cross-field checks.
+    # Defense-in-depth: a permissive alternate schema admitted via the
+    # direct-call path could pass a non-dict (string/list/int) for
+    # `post_restart_live_action`; without an explicit guard the dict
+    # branch is silently skipped and the live-action invariants
+    # fail-open. Mirror the top-level `restart` non-dict guard for the
+    # nested optional object.
     live_action = restart_obj.get("post_restart_live_action")
-    if isinstance(live_action, dict):
+    if "post_restart_live_action" in restart_obj and not isinstance(
+        live_action, dict
+    ):
+        errors.append(
+            "<root>: restart.post_restart_live_action not an object "
+            "(alternate schema admitted)"
+        )
+    elif isinstance(live_action, dict):
         accepted_by_peer = live_action.get("accepted_by_peer")
         if not isinstance(accepted_by_peer, str):
             errors.append(
@@ -436,9 +449,24 @@ def _cross_field_reorg(data: dict) -> list[str]:
     # final_state consistency check fires only when present (optional
     # per false_positive_cases: «reorg-only evidence should not require
     # restart fields ... fields absent by design must not be required
-    # retroactively»).
+    # retroactively»). When `final_state` IS declared, the schema now
+    # requires both `tip` and `height` (so consistency cannot be silently
+    # skipped on a partial object); the cross-field check below is the
+    # final-leg authority for value equality with the declared winning
+    # branch.
+    #
+    # Defense-in-depth: a permissive alternate schema admitted via the
+    # direct-call path could pass a non-dict for `final_state`; without
+    # an explicit guard the dict branch is silently skipped and the
+    # consistency invariants fail-open. Mirror the top-level `reorg`
+    # non-dict guard for the nested optional object.
     final_state = reorg_obj.get("final_state")
-    if isinstance(final_state, dict):
+    if "final_state" in reorg_obj and not isinstance(final_state, dict):
+        errors.append(
+            "<root>: reorg.final_state not an object "
+            "(alternate schema admitted)"
+        )
+    elif isinstance(final_state, dict):
         tip = final_state.get("tip")
         height = final_state.get("height")
         if isinstance(tip, str) and tip != winning_branch_tip:

--- a/scripts/devnet/validate_mixed_client_evidence.py
+++ b/scripts/devnet/validate_mixed_client_evidence.py
@@ -281,6 +281,182 @@ def _cross_field(data: dict) -> list[str]:
                 "<root>: tx_path not an object (alternate schema admitted)"
             )
 
+    # RUB-207 (RUB-24B): restart and reorg cross-field invariants.
+    # Both objects are optional at the schema level; cross-field checks
+    # only fire when the object is present. `valid_names` and
+    # `restart_obj`/`reorg_obj` are looked up via `data.get(...)` so the
+    # standard call path (after committed-schema floor PASS) is the
+    # primary reachability vector; direct `_cross_field` callers that
+    # bypass the floor reach the defensive minimal_shape branches via
+    # `RestartDirectFallbackTests` / `ReorgDirectFallbackTests`.
+    errors.extend(_cross_field_restart(data, valid_names))
+    errors.extend(_cross_field_reorg(data))
+
+    return errors
+
+
+def _cross_field_restart(data: dict, valid_names: set[str]) -> list[str]:
+    """Restart-evidence cross-field invariants (RUB-207).
+
+    Schema owns: type, required, minLength/minimum, additionalProperties.
+    Cross-field owns: participant-name membership, accepted_by_peer
+    distinct-from-stopped_node, and the catch_up_height >=
+    pre_restart_height rule with the reorg-explained-rollback escape.
+    """
+    errors: list[str] = []
+    restart_obj = data.get("restart")
+    if restart_obj is None:
+        return errors  # restart is optional
+
+    # Defense-in-depth minimal_shape (parallel to participants/tx_path
+    # pattern). Standard call path is gated by the committed-schema
+    # floor; direct `_cross_field` callers that bypass the floor reach
+    # these branches via `RestartDirectFallbackTests`.
+    shape_errors: list[str] = []
+    if not isinstance(restart_obj, dict):
+        return ["<root>: restart not an object (alternate schema admitted)"]
+    stopped_node = restart_obj.get("stopped_node")
+    pre_restart_height = restart_obj.get("pre_restart_height")
+    catch_up_height = restart_obj.get("catch_up_height")
+    if not isinstance(stopped_node, str):
+        shape_errors.append(
+            "<root>: restart.stopped_node not a string (alternate schema admitted)"
+        )
+    if not isinstance(pre_restart_height, int) or isinstance(
+        pre_restart_height, bool
+    ):
+        shape_errors.append(
+            "<root>: restart.pre_restart_height not an integer "
+            "(alternate schema admitted)"
+        )
+    if not isinstance(catch_up_height, int) or isinstance(catch_up_height, bool):
+        shape_errors.append(
+            "<root>: restart.catch_up_height not an integer "
+            "(alternate schema admitted)"
+        )
+    if shape_errors:
+        return shape_errors
+
+    # Participant-name membership for stopped_node.
+    if stopped_node not in valid_names:
+        errors.append(
+            f"restart.stopped_node: {stopped_node!r} not in participants"
+        )
+
+    # post_restart_live_action.accepted_by_peer cross-field checks.
+    live_action = restart_obj.get("post_restart_live_action")
+    if isinstance(live_action, dict):
+        accepted_by_peer = live_action.get("accepted_by_peer")
+        if not isinstance(accepted_by_peer, str):
+            errors.append(
+                "<root>: restart.post_restart_live_action.accepted_by_peer "
+                "not a string (alternate schema admitted)"
+            )
+        else:
+            if accepted_by_peer not in valid_names:
+                errors.append(
+                    "restart.post_restart_live_action.accepted_by_peer: "
+                    f"{accepted_by_peer!r} not in participants"
+                )
+            if accepted_by_peer == stopped_node:
+                errors.append(
+                    "restart.post_restart_live_action.accepted_by_peer: "
+                    f"{accepted_by_peer!r} equals stopped_node; live action "
+                    "cannot be accepted by the stopped participant"
+                )
+
+    # catch_up_height >= pre_restart_height invariant. The explicit
+    # escape: a reorg.fork_height < pre_restart_height explains a
+    # legitimate rollback below the pre-restart tip. Without that
+    # explanation, a silent decrease is a lifecycle-order violation.
+    if catch_up_height < pre_restart_height:
+        reorg_obj = data.get("reorg")
+        explained_by_reorg = (
+            isinstance(reorg_obj, dict)
+            and isinstance(reorg_obj.get("fork_height"), int)
+            and not isinstance(reorg_obj.get("fork_height"), bool)
+            and reorg_obj["fork_height"] < pre_restart_height
+        )
+        if not explained_by_reorg:
+            errors.append(
+                "restart.catch_up_height: "
+                f"{catch_up_height} below pre_restart_height "
+                f"{pre_restart_height} with no reorg explanation "
+                "(reorg.fork_height < pre_restart_height required)"
+            )
+    return errors
+
+
+def _cross_field_reorg(data: dict) -> list[str]:
+    """Reorg-evidence cross-field invariants (RUB-207).
+
+    Schema owns: type, required, minimum, hex pattern, additionalProperties.
+    Cross-field owns: fork_height < winning_branch_height ordering, and
+    final_state.{tip,height} consistency with the declared winning branch
+    when final_state is present.
+    """
+    errors: list[str] = []
+    reorg_obj = data.get("reorg")
+    if reorg_obj is None:
+        return errors  # reorg is optional
+
+    if not isinstance(reorg_obj, dict):
+        return ["<root>: reorg not an object (alternate schema admitted)"]
+
+    shape_errors: list[str] = []
+    fork_height = reorg_obj.get("fork_height")
+    winning_branch_height = reorg_obj.get("winning_branch_height")
+    winning_branch_tip = reorg_obj.get("winning_branch_tip")
+    if not isinstance(fork_height, int) or isinstance(fork_height, bool):
+        shape_errors.append(
+            "<root>: reorg.fork_height not an integer (alternate schema admitted)"
+        )
+    if not isinstance(winning_branch_height, int) or isinstance(
+        winning_branch_height, bool
+    ):
+        shape_errors.append(
+            "<root>: reorg.winning_branch_height not an integer "
+            "(alternate schema admitted)"
+        )
+    if not isinstance(winning_branch_tip, str):
+        shape_errors.append(
+            "<root>: reorg.winning_branch_tip not a string "
+            "(alternate schema admitted)"
+        )
+    if shape_errors:
+        return shape_errors
+
+    # Lifecycle-order invariant: fork_height < winning_branch_height.
+    if fork_height >= winning_branch_height:
+        errors.append(
+            f"reorg.fork_height: {fork_height} must be less than "
+            f"winning_branch_height {winning_branch_height}"
+        )
+
+    # final_state consistency check fires only when present (optional
+    # per false_positive_cases: «reorg-only evidence should not require
+    # restart fields ... fields absent by design must not be required
+    # retroactively»).
+    final_state = reorg_obj.get("final_state")
+    if isinstance(final_state, dict):
+        tip = final_state.get("tip")
+        height = final_state.get("height")
+        if isinstance(tip, str) and tip != winning_branch_tip:
+            errors.append(
+                "reorg.final_state.tip: "
+                f"{tip!r} must equal winning_branch_tip "
+                f"{winning_branch_tip!r}"
+            )
+        if (
+            isinstance(height, int)
+            and not isinstance(height, bool)
+            and height != winning_branch_height
+        ):
+            errors.append(
+                "reorg.final_state.height: "
+                f"{height} must equal winning_branch_height "
+                f"{winning_branch_height}"
+            )
     return errors
 
 

--- a/scripts/devnet/validate_mixed_client_evidence.py
+++ b/scripts/devnet/validate_mixed_client_evidence.py
@@ -467,19 +467,33 @@ def _cross_field_reorg(data: dict) -> list[str]:
             "(alternate schema admitted)"
         )
     elif isinstance(final_state, dict):
+        # Defense-in-depth element-shape: a permissive alternate schema
+        # admitted via the direct-call path could pass `final_state` as a
+        # dict whose `tip`/`height` have wrong inner types (int for tip,
+        # str/bool for height). Without explicit guards the consistency
+        # checks below silently fall through (`isinstance(...)` is False
+        # → no error appended), which fails open. Mirror the
+        # `_cross_field_restart.post_restart_live_action.accepted_by_peer`
+        # element-shape pattern at this nested-dict layer.
         tip = final_state.get("tip")
         height = final_state.get("height")
-        if isinstance(tip, str) and tip != winning_branch_tip:
+        if not isinstance(tip, str):
+            errors.append(
+                "<root>: reorg.final_state.tip not a string "
+                "(alternate schema admitted)"
+            )
+        elif tip != winning_branch_tip:
             errors.append(
                 "reorg.final_state.tip: "
                 f"{tip!r} must equal winning_branch_tip "
                 f"{winning_branch_tip!r}"
             )
-        if (
-            isinstance(height, int)
-            and not isinstance(height, bool)
-            and height != winning_branch_height
-        ):
+        if not isinstance(height, int) or isinstance(height, bool):
+            errors.append(
+                "<root>: reorg.final_state.height not an integer "
+                "(alternate schema admitted)"
+            )
+        elif height != winning_branch_height:
             errors.append(
                 "reorg.final_state.height: "
                 f"{height} must equal winning_branch_height "

--- a/tools/tests/test_validate_mixed_client_evidence.py
+++ b/tools/tests/test_validate_mixed_client_evidence.py
@@ -1097,6 +1097,69 @@ class RestartReorgSchemaOwnedTests(unittest.TestCase):
                 f"expected schema minLength violation; got {errors}",
             )
 
+    def test_reorg_final_state_missing_tip_schema_owned_only(self):
+        """reorg.final_state without `tip` is schema-rejected (RUB-207
+        wave-2 F1: chatgpt-codex P2 — incomplete final_state must not
+        silently pass cross-field consistency). Schema now requires both
+        tip and height when final_state is present, so cross-field never
+        sees a partial object on the standard call path."""
+        with tempfile.TemporaryDirectory() as td:
+            data = _valid_with_reorg(
+                fork_h=95, winning_h=100,
+                winning_tip=_VALID_TIP_HASH,
+                include_final_state=True,
+            )
+            del data["reorg"]["final_state"]["tip"]
+            errors = _validate_dict(Path(td), data)
+            self.assertTrue(errors)
+            self.assertTrue(
+                any("tip" in e and "required" in e for e in errors),
+                f"expected schema-required violation for final_state.tip; "
+                f"got {errors}",
+            )
+            self.assertFalse(
+                any("must equal winning_branch_tip" in e for e in errors),
+                f"cross-field consistency must not fire on schema-rejected "
+                f"input; got {errors}",
+            )
+
+    def test_reorg_final_state_missing_height_schema_owned_only(self):
+        """reorg.final_state without `height` is schema-rejected (sister
+        site of test_reorg_final_state_missing_tip_schema_owned_only)."""
+        with tempfile.TemporaryDirectory() as td:
+            data = _valid_with_reorg(
+                fork_h=95, winning_h=100,
+                winning_tip=_VALID_TIP_HASH,
+                include_final_state=True,
+            )
+            del data["reorg"]["final_state"]["height"]
+            errors = _validate_dict(Path(td), data)
+            self.assertTrue(errors)
+            self.assertTrue(
+                any("height" in e and "required" in e for e in errors),
+                f"expected schema-required violation for final_state.height; "
+                f"got {errors}",
+            )
+            self.assertFalse(
+                any("must equal winning_branch_height" in e for e in errors),
+                f"cross-field consistency must not fire on schema-rejected "
+                f"input; got {errors}",
+            )
+
+    def test_reorg_final_state_empty_object_schema_owned_only(self):
+        """reorg.final_state = {} is schema-rejected because BOTH tip
+        and height are now required when final_state is present."""
+        with tempfile.TemporaryDirectory() as td:
+            data = _valid_with_reorg(fork_h=95, winning_h=100)
+            data["reorg"]["final_state"] = {}
+            errors = _validate_dict(Path(td), data)
+            self.assertTrue(errors)
+            self.assertTrue(
+                any("tip" in e and "required" in e for e in errors)
+                or any("height" in e and "required" in e for e in errors),
+                f"expected schema-required violation; got {errors}",
+            )
+
 
 class RestartDirectFallbackTests(unittest.TestCase):
     """Direct invocation of `_cross_field_restart` BYPASSING the
@@ -1181,6 +1244,52 @@ class RestartDirectFallbackTests(unittest.TestCase):
             f"got {errors}",
         )
 
+    def test_cross_field_restart_live_action_not_dict_returns_alternate_admitted_error(self):
+        """RUB-207 wave-2 F2 (Copilot P2): a permissive alternate schema
+        admitted via the direct-call path could pass a non-dict
+        (string/list/int) for `post_restart_live_action`; without an
+        explicit guard the dict branch is silently skipped and the
+        live-action invariants fail-open. The minimal_shape branch must
+        emit a deterministic `(alternate schema admitted)` diagnostic
+        and not silently skip."""
+        errors = validator._cross_field_restart(
+            {"restart": {
+                "stopped_node": "node-a",
+                "pre_restart_height": 100,
+                "catch_up_height": 100,
+                "post_restart_live_action": "not-an-object",
+            }},
+            self._names(),
+        )
+        self.assertTrue(
+            any(
+                "restart.post_restart_live_action not an object" in e
+                and "alternate schema admitted" in e
+                for e in errors
+            ),
+            f"expected post_restart_live_action-not-object alternate-admitted "
+            f"error; got {errors}",
+        )
+
+    def test_cross_field_restart_live_action_list_returns_alternate_admitted_error(self):
+        """Sister site of the string case: list also rejected."""
+        errors = validator._cross_field_restart(
+            {"restart": {
+                "stopped_node": "node-a",
+                "pre_restart_height": 100,
+                "catch_up_height": 100,
+                "post_restart_live_action": ["node-b"],
+            }},
+            self._names(),
+        )
+        self.assertTrue(
+            any(
+                "restart.post_restart_live_action not an object" in e
+                for e in errors
+            ),
+            f"got {errors}",
+        )
+
 
 class ReorgDirectFallbackTests(unittest.TestCase):
     """Direct invocation of `_cross_field_reorg` BYPASSING the
@@ -1239,6 +1348,41 @@ class ReorgDirectFallbackTests(unittest.TestCase):
         }})
         self.assertTrue(
             any("reorg.fork_height not an integer" in e for e in errors),
+            f"got {errors}",
+        )
+
+    def test_cross_field_reorg_final_state_not_dict_returns_alternate_admitted_error(self):
+        """RUB-207 wave-2 F3 (Copilot P2): a permissive alternate schema
+        admitted via the direct-call path could pass a non-dict for
+        `final_state`; without an explicit guard the dict branch is
+        silently skipped and consistency invariants fail-open. Mirror of
+        the post_restart_live_action non-dict guard."""
+        errors = validator._cross_field_reorg({"reorg": {
+            "fork_height": 95,
+            "winning_branch_height": 100,
+            "winning_branch_tip": "a" * 64,
+            "final_state": "not-an-object",
+        }})
+        self.assertTrue(
+            any(
+                "reorg.final_state not an object" in e
+                and "alternate schema admitted" in e
+                for e in errors
+            ),
+            f"expected final_state-not-object alternate-admitted error; "
+            f"got {errors}",
+        )
+
+    def test_cross_field_reorg_final_state_int_returns_alternate_admitted_error(self):
+        """Sister site: int (or any non-dict) for final_state rejected."""
+        errors = validator._cross_field_reorg({"reorg": {
+            "fork_height": 95,
+            "winning_branch_height": 100,
+            "winning_branch_tip": "a" * 64,
+            "final_state": 42,
+        }})
+        self.assertTrue(
+            any("reorg.final_state not an object" in e for e in errors),
             f"got {errors}",
         )
 

--- a/tools/tests/test_validate_mixed_client_evidence.py
+++ b/tools/tests/test_validate_mixed_client_evidence.py
@@ -784,5 +784,459 @@ class CliTests(unittest.TestCase):
             self.assertIn("FAIL", buf.getvalue())
 
 
+# ---------------------------------------------------------------------------
+# RUB-207 (RUB-24B): restart and reorg cross-field invariants.
+# Schema owns: type, required, minLength, minimum, hex pattern,
+# additionalProperties. Cross-field owns: participant-name membership,
+# accepted_by_peer distinct-from-stopped_node, catch_up_height >=
+# pre_restart_height (with reorg-explained-rollback escape), reorg
+# fork_height < winning_branch_height, and final_state consistency
+# with the declared winning branch when present.
+# ---------------------------------------------------------------------------
+
+
+_VALID_TIP_HASH = "a" * 64
+_VALID_TIP_HASH_2 = "b" * 64
+
+
+def _valid_with_restart(stopped="node-a", peer="node-b",
+                        pre_h=100, catch_h=100,
+                        include_live_action=True) -> dict:
+    """Helper: committed valid fixture mutated to include a coherent
+    restart object with optional post_restart_live_action. Default
+    pairs (node-a stopped, node-b accepts live action) match the
+    committed participants set so cross-field membership passes."""
+    data = _load_committed_valid()
+    data["restart"] = {
+        "stopped_node": stopped,
+        "pre_restart_height": pre_h,
+        "catch_up_height": catch_h,
+    }
+    if include_live_action:
+        data["restart"]["post_restart_live_action"] = {
+            "accepted_by_peer": peer,
+        }
+    return data
+
+
+def _valid_with_reorg(fork_h=95, winning_h=100,
+                      winning_tip=_VALID_TIP_HASH,
+                      include_final_state=False,
+                      final_tip=None, final_height=None) -> dict:
+    """Helper: committed valid fixture mutated to include a coherent
+    reorg object with optional final_state. Default fork=95<winning=100
+    satisfies the lifecycle-order invariant; final_state is omitted by
+    default to exercise the false_positive_cases clause that absent
+    final_state must not be required retroactively."""
+    data = _load_committed_valid()
+    data["reorg"] = {
+        "fork_height": fork_h,
+        "winning_branch_height": winning_h,
+        "winning_branch_tip": winning_tip,
+    }
+    if include_final_state:
+        data["reorg"]["final_state"] = {
+            "tip": final_tip if final_tip is not None else winning_tip,
+            "height": final_height if final_height is not None else winning_h,
+        }
+    return data
+
+
+class RestartEvidenceTests(unittest.TestCase):
+    """Cross-field invariants for the optional `restart` object."""
+
+    def test_restart_only_evidence_passes(self):
+        """Valid restart added to committed valid fixture (no reorg)
+        passes; default catch_up >= pre_restart, accepted_by_peer in
+        participants and != stopped_node."""
+        with tempfile.TemporaryDirectory() as td:
+            self.assertEqual(_validate_dict(Path(td), _valid_with_restart()), [])
+
+    def test_restart_no_live_action_passes(self):
+        """post_restart_live_action is optional — restart without it
+        passes per false_positive_cases."""
+        with tempfile.TemporaryDirectory() as td:
+            data = _valid_with_restart(include_live_action=False)
+            self.assertEqual(_validate_dict(Path(td), data), [])
+
+    def test_restart_stopped_node_unknown_rejected(self):
+        """stopped_node references undeclared participant — schema
+        validates string shape only; the cross-field membership check
+        is the sole authority."""
+        with tempfile.TemporaryDirectory() as td:
+            data = _valid_with_restart(stopped="node-ghost")
+            errors = _validate_dict(Path(td), data)
+            _assert_one(self, errors, "restart.stopped_node",
+                        "node-ghost", "not in participants")
+
+    def test_restart_live_action_accepted_by_unknown_peer_rejected(self):
+        """accepted_by_peer references undeclared participant."""
+        with tempfile.TemporaryDirectory() as td:
+            data = _valid_with_restart(peer="node-ghost")
+            errors = _validate_dict(Path(td), data)
+            _assert_one(
+                self, errors,
+                "post_restart_live_action.accepted_by_peer",
+                "node-ghost", "not in participants",
+            )
+
+    def test_restart_live_action_accepted_by_stopped_node_rejected(self):
+        """accepted_by_peer equals stopped_node — live action cannot be
+        accepted by the stopped participant."""
+        with tempfile.TemporaryDirectory() as td:
+            data = _valid_with_restart(stopped="node-a", peer="node-a")
+            errors = _validate_dict(Path(td), data)
+            _assert_one(
+                self, errors,
+                "post_restart_live_action.accepted_by_peer",
+                "equals stopped_node",
+            )
+
+    def test_restart_catch_up_height_decrease_without_reorg_rejected(self):
+        """catch_up_height < pre_restart_height with no reorg
+        explanation — silent rollback is a lifecycle-order violation."""
+        with tempfile.TemporaryDirectory() as td:
+            data = _valid_with_restart(pre_h=100, catch_h=80)
+            errors = _validate_dict(Path(td), data)
+            _assert_one(
+                self, errors,
+                "restart.catch_up_height",
+                "below pre_restart_height",
+                "no reorg explanation",
+            )
+
+    def test_restart_catch_up_height_decrease_with_reorg_explanation_passes(self):
+        """site×site interaction: catch_up_height < pre_restart_height
+        is allowed when reorg.fork_height < pre_restart_height
+        explains the rollback."""
+        with tempfile.TemporaryDirectory() as td:
+            data = _valid_with_restart(pre_h=100, catch_h=80)
+            data.update(_valid_with_reorg(fork_h=70, winning_h=85))
+            self.assertEqual(_validate_dict(Path(td), data), [])
+
+    def test_restart_catch_up_height_decrease_with_high_fork_reorg_still_rejected(self):
+        """site×site negative: a reorg whose fork_height >=
+        pre_restart_height does NOT explain the catch_up rollback."""
+        with tempfile.TemporaryDirectory() as td:
+            data = _valid_with_restart(pre_h=100, catch_h=80)
+            data.update(_valid_with_reorg(fork_h=100, winning_h=110))
+            errors = _validate_dict(Path(td), data)
+            # Two findings expected: catch_up_height + fork_height >= winning
+            _assert_one(
+                self, errors,
+                "restart.catch_up_height",
+                "no reorg explanation",
+            )
+
+    def test_restart_catch_up_height_equal_to_pre_restart_passes(self):
+        """Boundary: catch_up_height == pre_restart_height passes
+        (the rule is >= not >)."""
+        with tempfile.TemporaryDirectory() as td:
+            data = _valid_with_restart(pre_h=100, catch_h=100)
+            self.assertEqual(_validate_dict(Path(td), data), [])
+
+
+class ReorgEvidenceTests(unittest.TestCase):
+    """Cross-field invariants for the optional `reorg` object."""
+
+    def test_reorg_only_evidence_passes(self):
+        """Valid reorg added (fork < winning) without restart object
+        and without final_state passes per false_positive_cases."""
+        with tempfile.TemporaryDirectory() as td:
+            self.assertEqual(_validate_dict(Path(td), _valid_with_reorg()), [])
+
+    def test_reorg_fork_height_equals_winning_rejected(self):
+        """Boundary: fork_height == winning_branch_height violates
+        lifecycle-order (fork must be strictly below winning)."""
+        with tempfile.TemporaryDirectory() as td:
+            data = _valid_with_reorg(fork_h=100, winning_h=100)
+            errors = _validate_dict(Path(td), data)
+            _assert_one(
+                self, errors,
+                "reorg.fork_height",
+                "must be less than winning_branch_height",
+            )
+
+    def test_reorg_fork_height_above_winning_rejected(self):
+        """fork_height > winning_branch_height violates lifecycle order."""
+        with tempfile.TemporaryDirectory() as td:
+            data = _valid_with_reorg(fork_h=120, winning_h=100)
+            errors = _validate_dict(Path(td), data)
+            _assert_one(
+                self, errors,
+                "reorg.fork_height",
+                "must be less than winning_branch_height",
+            )
+
+    def test_reorg_final_state_consistent_passes(self):
+        """final_state present and matches winning branch — passes."""
+        with tempfile.TemporaryDirectory() as td:
+            data = _valid_with_reorg(
+                fork_h=95, winning_h=100,
+                winning_tip=_VALID_TIP_HASH,
+                include_final_state=True,
+                final_tip=_VALID_TIP_HASH, final_height=100,
+            )
+            self.assertEqual(_validate_dict(Path(td), data), [])
+
+    def test_reorg_final_state_tip_inconsistent_rejected(self):
+        """final_state.tip differs from winning_branch_tip."""
+        with tempfile.TemporaryDirectory() as td:
+            data = _valid_with_reorg(
+                fork_h=95, winning_h=100,
+                winning_tip=_VALID_TIP_HASH,
+                include_final_state=True,
+                final_tip=_VALID_TIP_HASH_2, final_height=100,
+            )
+            errors = _validate_dict(Path(td), data)
+            _assert_one(
+                self, errors,
+                "reorg.final_state.tip",
+                "must equal winning_branch_tip",
+            )
+
+    def test_reorg_final_state_height_inconsistent_rejected(self):
+        """final_state.height differs from winning_branch_height."""
+        with tempfile.TemporaryDirectory() as td:
+            data = _valid_with_reorg(
+                fork_h=95, winning_h=100,
+                winning_tip=_VALID_TIP_HASH,
+                include_final_state=True,
+                final_tip=_VALID_TIP_HASH, final_height=99,
+            )
+            errors = _validate_dict(Path(td), data)
+            _assert_one(
+                self, errors,
+                "reorg.final_state.height",
+                "must equal winning_branch_height",
+            )
+
+    def test_reorg_final_state_absent_passes(self):
+        """false_positive_cases: reorg without final_state passes."""
+        with tempfile.TemporaryDirectory() as td:
+            data = _valid_with_reorg(include_final_state=False)
+            self.assertEqual(_validate_dict(Path(td), data), [])
+
+
+class RestartReorgSchemaOwnedTests(unittest.TestCase):
+    """Schema layer is the sole authority for type/required/minimum/
+    pattern problems on restart/reorg fields. The cross-field layer
+    must NOT also fire on schema-rejected inputs (short-circuit drift
+    check)."""
+
+    def test_restart_missing_required_field_schema_owned_only(self):
+        """restart without `stopped_node` is schema-rejected; no
+        cross-field "restart.stopped_node: ... not in participants"
+        diagnostic should appear."""
+        with tempfile.TemporaryDirectory() as td:
+            data = _load_committed_valid()
+            data["restart"] = {
+                # missing stopped_node
+                "pre_restart_height": 100,
+                "catch_up_height": 100,
+            }
+            errors = _validate_dict(Path(td), data)
+            self.assertTrue(errors)
+            self.assertTrue(
+                any("stopped_node" in e and "required" in e for e in errors),
+                f"expected schema-required violation; got {errors}",
+            )
+            self.assertFalse(
+                any("not in participants" in e for e in errors),
+                f"cross-field membership must not fire on schema-rejected "
+                f"input; got {errors}",
+            )
+
+    def test_reorg_missing_required_field_schema_owned_only(self):
+        """reorg without winning_branch_tip is schema-rejected; no
+        cross-field lifecycle error should fire."""
+        with tempfile.TemporaryDirectory() as td:
+            data = _load_committed_valid()
+            data["reorg"] = {
+                "fork_height": 95,
+                "winning_branch_height": 100,
+                # missing winning_branch_tip
+            }
+            errors = _validate_dict(Path(td), data)
+            self.assertTrue(errors)
+            self.assertTrue(
+                any("winning_branch_tip" in e and "required" in e for e in errors),
+                f"expected schema-required violation; got {errors}",
+            )
+            self.assertFalse(
+                any("must be less than winning_branch_height" in e for e in errors),
+                f"cross-field lifecycle order must not fire on schema-rejected "
+                f"input; got {errors}",
+            )
+
+    def test_reorg_winning_branch_tip_pattern_schema_owned_only(self):
+        """reorg.winning_branch_tip not matching ^[0-9a-f]{64}$ is
+        schema-rejected before cross-field consistency runs."""
+        with tempfile.TemporaryDirectory() as td:
+            data = _valid_with_reorg(winning_tip="not-a-hash")
+            errors = _validate_dict(Path(td), data)
+            self.assertTrue(errors)
+            self.assertTrue(
+                any("winning_branch_tip" in e for e in errors),
+                f"expected schema-pattern violation; got {errors}",
+            )
+
+    def test_restart_stopped_node_empty_string_schema_owned_only(self):
+        """restart.stopped_node empty string violates minLength:1."""
+        with tempfile.TemporaryDirectory() as td:
+            data = _valid_with_restart(stopped="")
+            errors = _validate_dict(Path(td), data)
+            self.assertTrue(errors)
+            self.assertTrue(
+                any("stopped_node" in e and "too short" in e for e in errors),
+                f"expected schema minLength violation; got {errors}",
+            )
+
+
+class RestartDirectFallbackTests(unittest.TestCase):
+    """Direct invocation of `_cross_field_restart` BYPASSING the
+    committed-schema floor, exercising the defensive
+    `(alternate schema admitted)` minimal-shape branches that protect
+    direct callers from KeyError. Parallel to
+    `CrossFieldDirectFallbackTests` for participants and
+    `TxPathDirectFallbackTests` for tx_path."""
+
+    @staticmethod
+    def _names() -> set[str]:
+        return {"node-a", "node-b"}
+
+    def test_cross_field_restart_non_dict(self):
+        errors = validator._cross_field_restart(
+            {"restart": "not-an-object"}, self._names()
+        )
+        self.assertTrue(
+            any("restart not an object" in e
+                and "alternate schema admitted" in e for e in errors),
+            f"got {errors}",
+        )
+
+    def test_cross_field_restart_stopped_node_not_string(self):
+        errors = validator._cross_field_restart(
+            {"restart": {
+                "stopped_node": 1,
+                "pre_restart_height": 100,
+                "catch_up_height": 100,
+            }},
+            self._names(),
+        )
+        self.assertTrue(
+            any("restart.stopped_node not a string" in e
+                and "alternate schema admitted" in e for e in errors),
+            f"got {errors}",
+        )
+
+    def test_cross_field_restart_pre_restart_height_not_int(self):
+        errors = validator._cross_field_restart(
+            {"restart": {
+                "stopped_node": "node-a",
+                "pre_restart_height": "100",
+                "catch_up_height": 100,
+            }},
+            self._names(),
+        )
+        self.assertTrue(
+            any("restart.pre_restart_height not an integer" in e
+                and "alternate schema admitted" in e for e in errors),
+            f"got {errors}",
+        )
+
+    def test_cross_field_restart_catch_up_height_not_int(self):
+        errors = validator._cross_field_restart(
+            {"restart": {
+                "stopped_node": "node-a",
+                "pre_restart_height": 100,
+                "catch_up_height": "100",
+            }},
+            self._names(),
+        )
+        self.assertTrue(
+            any("restart.catch_up_height not an integer" in e
+                and "alternate schema admitted" in e for e in errors),
+            f"got {errors}",
+        )
+
+    def test_cross_field_restart_pre_restart_height_bool_rejected(self):
+        """bool is a Python int subclass; the validator must explicitly
+        reject it because schema declares type:integer."""
+        errors = validator._cross_field_restart(
+            {"restart": {
+                "stopped_node": "node-a",
+                "pre_restart_height": True,
+                "catch_up_height": 100,
+            }},
+            self._names(),
+        )
+        self.assertTrue(
+            any("restart.pre_restart_height not an integer" in e for e in errors),
+            f"got {errors}",
+        )
+
+
+class ReorgDirectFallbackTests(unittest.TestCase):
+    """Direct invocation of `_cross_field_reorg` BYPASSING the
+    committed-schema floor (parallel to RestartDirectFallbackTests)."""
+
+    def test_cross_field_reorg_non_dict(self):
+        errors = validator._cross_field_reorg({"reorg": "not-an-object"})
+        self.assertTrue(
+            any("reorg not an object" in e
+                and "alternate schema admitted" in e for e in errors),
+            f"got {errors}",
+        )
+
+    def test_cross_field_reorg_fork_height_not_int(self):
+        errors = validator._cross_field_reorg({"reorg": {
+            "fork_height": "95",
+            "winning_branch_height": 100,
+            "winning_branch_tip": "a" * 64,
+        }})
+        self.assertTrue(
+            any("reorg.fork_height not an integer" in e
+                and "alternate schema admitted" in e for e in errors),
+            f"got {errors}",
+        )
+
+    def test_cross_field_reorg_winning_branch_height_not_int(self):
+        errors = validator._cross_field_reorg({"reorg": {
+            "fork_height": 95,
+            "winning_branch_height": "100",
+            "winning_branch_tip": "a" * 64,
+        }})
+        self.assertTrue(
+            any("reorg.winning_branch_height not an integer" in e
+                and "alternate schema admitted" in e for e in errors),
+            f"got {errors}",
+        )
+
+    def test_cross_field_reorg_winning_branch_tip_not_string(self):
+        errors = validator._cross_field_reorg({"reorg": {
+            "fork_height": 95,
+            "winning_branch_height": 100,
+            "winning_branch_tip": 12345,
+        }})
+        self.assertTrue(
+            any("reorg.winning_branch_tip not a string" in e
+                and "alternate schema admitted" in e for e in errors),
+            f"got {errors}",
+        )
+
+    def test_cross_field_reorg_fork_height_bool_rejected(self):
+        """bool is a Python int subclass; reject explicitly."""
+        errors = validator._cross_field_reorg({"reorg": {
+            "fork_height": True,
+            "winning_branch_height": 100,
+            "winning_branch_tip": "a" * 64,
+        }})
+        self.assertTrue(
+            any("reorg.fork_height not an integer" in e for e in errors),
+            f"got {errors}",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/tests/test_validate_mixed_client_evidence.py
+++ b/tools/tests/test_validate_mixed_client_evidence.py
@@ -921,7 +921,12 @@ class RestartEvidenceTests(unittest.TestCase):
             data = _valid_with_restart(pre_h=100, catch_h=80)
             data.update(_valid_with_reorg(fork_h=100, winning_h=110))
             errors = _validate_dict(Path(td), data)
-            # Two findings expected: catch_up_height + fork_height >= winning
+            # Exactly one finding expected: restart.catch_up_height fires
+            # because fork_height=100 is NOT < pre_restart_height=100, so
+            # the reorg-explained-rollback escape clause does not apply.
+            # The reorg lifecycle-order invariant (fork < winning) is
+            # satisfied here (100 < 110), so reorg.fork_height does NOT
+            # also fire.
             _assert_one(
                 self, errors,
                 "restart.catch_up_height",

--- a/tools/tests/test_validate_mixed_client_evidence.py
+++ b/tools/tests/test_validate_mixed_client_evidence.py
@@ -1386,6 +1386,107 @@ class ReorgDirectFallbackTests(unittest.TestCase):
             f"got {errors}",
         )
 
+    # --- final_state element-shape direct fallback (RUB-207 PR-B wave-3) ---
+    # Mirrors the `_cross_field_restart.post_restart_live_action.accepted_by_peer`
+    # element-shape pattern: when `final_state` IS a dict but its inner
+    # `tip`/`height` have wrong types, cross-field must emit an explicit
+    # `(alternate schema admitted)` diagnostic, not silently fall through.
+
+    def test_cross_field_reorg_final_state_tip_not_string_returns_alternate_admitted_error(self):
+        errors = validator._cross_field_reorg({"reorg": {
+            "fork_height": 95,
+            "winning_branch_height": 100,
+            "winning_branch_tip": "a" * 64,
+            "final_state": {"tip": 12345, "height": 100},
+        }})
+        self.assertTrue(
+            any("reorg.final_state.tip not a string" in e
+                and "alternate schema admitted" in e for e in errors),
+            f"got {errors}",
+        )
+
+    def test_cross_field_reorg_final_state_height_not_int_returns_alternate_admitted_error(self):
+        errors = validator._cross_field_reorg({"reorg": {
+            "fork_height": 95,
+            "winning_branch_height": 100,
+            "winning_branch_tip": "a" * 64,
+            "final_state": {"tip": "a" * 64, "height": "100"},
+        }})
+        self.assertTrue(
+            any("reorg.final_state.height not an integer" in e
+                and "alternate schema admitted" in e for e in errors),
+            f"got {errors}",
+        )
+
+    def test_cross_field_reorg_final_state_height_bool_returns_alternate_admitted_error(self):
+        # bool is a Python int subclass; must be explicitly rejected
+        # because the schema declares type:integer, paralleling the
+        # bool-rejection guard on `pre_restart_height`/`catch_up_height`/
+        # `fork_height`/`winning_branch_height`.
+        errors = validator._cross_field_reorg({"reorg": {
+            "fork_height": 95,
+            "winning_branch_height": 100,
+            "winning_branch_tip": "a" * 64,
+            "final_state": {"tip": "a" * 64, "height": True},
+        }})
+        self.assertTrue(
+            any("reorg.final_state.height not an integer" in e
+                and "alternate schema admitted" in e for e in errors),
+            f"got {errors}",
+        )
+
+    def test_cross_field_reorg_final_state_missing_tip_returns_alternate_admitted_error(self):
+        # Direct-call path with a permissive alternate schema admitting a
+        # final_state object that omits `tip` entirely. `final_state.get
+        # ("tip")` returns None → `isinstance(None, str)` is False → must
+        # emit the not-a-string element-shape diagnostic, NOT silently
+        # skip the consistency check.
+        errors = validator._cross_field_reorg({"reorg": {
+            "fork_height": 95,
+            "winning_branch_height": 100,
+            "winning_branch_tip": "a" * 64,
+            "final_state": {"height": 100},
+        }})
+        self.assertTrue(
+            any("reorg.final_state.tip not a string" in e
+                and "alternate schema admitted" in e for e in errors),
+            f"got {errors}",
+        )
+
+    def test_cross_field_reorg_final_state_missing_height_returns_alternate_admitted_error(self):
+        errors = validator._cross_field_reorg({"reorg": {
+            "fork_height": 95,
+            "winning_branch_height": 100,
+            "winning_branch_tip": "a" * 64,
+            "final_state": {"tip": "a" * 64},
+        }})
+        self.assertTrue(
+            any("reorg.final_state.height not an integer" in e
+                and "alternate schema admitted" in e for e in errors),
+            f"got {errors}",
+        )
+
+    # Class-closure sweep: also add positive owner for the
+    # `accepted_by_peer not a string` element-shape branch in
+    # `_cross_field_restart`, which had no direct-call test before
+    # wave-3 (only the parent live_action non-dict cases were covered).
+    def test_cross_field_restart_live_action_accepted_by_peer_not_string_returns_alternate_admitted_error(self):
+        errors = validator._cross_field_restart(
+            {"restart": {
+                "stopped_node": "node-a",
+                "pre_restart_height": 100,
+                "catch_up_height": 100,
+                "post_restart_live_action": {"accepted_by_peer": 12345},
+            }},
+            {"node-a", "node-b"},
+        )
+        self.assertTrue(
+            any("post_restart_live_action.accepted_by_peer" in e
+                and "not a string" in e
+                and "alternate schema admitted" in e for e in errors),
+            f"got {errors}",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Scope

- Issue: RUB-207 / Closes #1486 (parent: RUB-24, second slice after merged RUB-206 PR-A).
- Invariant: restart and reorg evidence must be internally coherent — participant references resolve to declared participants, live-action acknowledgements come from a participant that could observe (not the stopped one), and height/tip/fork fields do not describe an impossible lifecycle order.
- Design rule: JSON Schema (Draft 2020-12) owns shape/type/required/minimum/pattern/additionalProperties. The Python cross-field layer runs ONLY after schema PASS. Both `restart` and `reorg` are top-level optional objects; cross-field checks fire only when the corresponding object is present. `restart.catch_up_height < pre_restart_height` is allowed only when `reorg.fork_height < pre_restart_height` explains the rollback.

## Non-scope

- No clients/go, clients/rust, conformance, formal, devnet runtime change.
- No CI workflow change.
- No timestamp/endpoint textual policy (RUB-208 PR-C scope).
- No process supervisor / devnet orchestration runtime work.
- No new pip dependency.

## Verification

- `python3 -m unittest tools.tests.test_validate_mixed_client_evidence`: 88 tests PASS.
- `rubin-review-probe-pack --pack schema_validator`: PASS at 12/12 cases.

<!-- rubin-agent-meta actor=set action=pr-edit via=cl branch=claude/rub-207 wt=rubin-protocol-claude-rub-207 utc=2026-05-08T20:32:31Z -->
