### PR TITLE
[RUB-27] Rust binary soak skeleton harness for devnet evidence

### DIFF
--- a/scripts/devnet-rust-binary-soak.sh
+++ b/scripts/devnet-rust-binary-soak.sh
@@ -85,10 +85,15 @@ cp "${CARGO_TARGET_BIN}" "${NODE_BIN}"
   exit 1
 }
 
-# Captured BEFORE the launch attempt: UTC-Z seconds-only canonical
-# format per RUB-208 / PR-C policy enforced by the schema regex on
-# participants[].started_at.
-STARTED_AT_UTC="$(python3 -c 'import datetime; print(datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"))')"
+# UTC-Z seconds-only canonical format per RUB-208 / PR-C policy
+# enforced by the schema regex on participants[].started_at. Captured
+# inside attempt_skeleton_launch AFTER the rpc-listening banner is
+# observed (P1 finding from PR #1510 review): on slow starts or banner
+# timeouts a pre-launch capture would have stamped evidence with a time
+# earlier than the actual observed start. The empty default here means
+# evidence carries no started_at on launch failure paths, which is
+# honest — we never observed a started state.
+STARTED_AT_UTC=""
 
 LAUNCH_FAILURE_REASON=""
 RPC_ADDR=""
@@ -109,6 +114,10 @@ attempt_skeleton_launch() {
     || { LAUNCH_FAILURE_REASON="rubin_process_start did not capture a pid"; return 1; }
   rubin_process_wait_for_log "${LOG_FILE}" "rpc: listening=" 60 "${NODE_PID}" \
     || { LAUNCH_FAILURE_REASON="rust skeleton did not emit rpc-listening banner within 60s"; return 1; }
+  # Stamped here, immediately after the rpc-listening banner is observed,
+  # so participants[].started_at reflects an observed start time rather
+  # than a pre-launch wall-clock guess.
+  STARTED_AT_UTC="$(python3 -c 'import datetime; print(datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"))')"
   RPC_ADDR="$(rubin_process_extract_rpc_addr "${LOG_FILE}")" \
     || { LAUNCH_FAILURE_REASON="failed to extract rpc-listening address from log"; return 1; }
   [[ -n "${RPC_ADDR}" ]] \
@@ -178,16 +187,30 @@ with open(e["EVIDENCE_JSON"], "w", encoding="utf-8") as f:
 # validated by validate_mixed_client_evidence.py — this report is
 # operator-facing audit material, kept in a sibling file so the
 # schema-validated artifact stays minimal.
+#
+# pid / rpc_endpoint / started_at_utc are recorded whenever they were
+# observed during the launch attempt, regardless of final launch_status
+# (P2 finding from PR #1510 review): a launch that registers a pid and
+# emits the rpc-listening banner before a later readiness check fails
+# previously dropped both fields, hiding identity that operators need
+# for failure forensics. The pid_observed / rpc_observed / started_observed
+# flags carry the boolean "did we ever see this during the attempt".
+node_pid_raw = (e.get("NODE_PID") or "").strip()
+rpc_addr_raw = (e.get("RPC_ADDR") or "").strip()
+started_at_raw = (e.get("STARTED_AT_UTC") or "").strip()
 report = {
     "scenario": "rust_binary_soak_skeleton",
     "implementation": "rust",
     "command_path": e["NODE_BIN"],
     "data_dir": e["DATA_DIR"],
     "log_file": e["LOG_FILE"],
-    "started_at_utc": e["STARTED_AT_UTC"],
     "launch_status": status,
-    "pid": int(e["NODE_PID"]) if status == "success" and e.get("NODE_PID") else None,
-    "rpc_endpoint": e["RPC_ADDR"] if status == "success" else None,
+    "pid": int(node_pid_raw) if node_pid_raw else None,
+    "pid_observed": bool(node_pid_raw),
+    "rpc_endpoint": rpc_addr_raw or None,
+    "rpc_observed": bool(rpc_addr_raw),
+    "started_at_utc": started_at_raw or None,
+    "started_observed": bool(started_at_raw),
     "failure_reason": e["LAUNCH_FAILURE_REASON"] if status == "failed" else None,
     "follow_ups": [
         "RUB-21 owns cross-implementation tx_path PASS evidence",

--- a/scripts/devnet-rust-binary-soak.sh
+++ b/scripts/devnet-rust-binary-soak.sh
@@ -16,7 +16,13 @@
 # tx_path PASS section.
 #
 # Hostile-case enforcement (RUB-27 enumeration → enforcement layer):
-#   * missing Rust binary           → cargo build fails → exit non-zero, no artifact
+#   * missing Rust binary           → cargo build fails → exit non-zero before any
+#                                     evidence/report JSON is written; the artifact
+#                                     root may still exist for forensics via the
+#                                     EXIT trap (rubin_process_init creates it
+#                                     up-front) — the failure signal is the
+#                                     non-zero exit and absence of the JSONs,
+#                                     not absence of the directory itself
 #   * binary exits immediately      → rubin_process_start detects exit-before-registration
 #   * pid recorded but already dead → wait_for_log checks rubin_process_is_alive per iteration
 #   * stdout/stderr in JSON parse   → evidence built via python json.dump, never via shell jq
@@ -71,24 +77,76 @@ mkdir -p "${DATA_DIR}"
 # exits non-zero before any artifact is emitted, satisfying the
 # "missing Rust binary" hostile case.
 echo "Building Rust rubin-node binary"
-# Pin the Cargo output directory under the harness artifact root so the
-# produced binary path is deterministic regardless of `CARGO_TARGET_DIR`
-# in the environment or `build.target-dir` set by a `.cargo/config.toml`
-# (PR #1510 wave-2 codex+copilot findings: Cargo can be told to write
-# elsewhere, in which case the previous hardcoded
-# `${RUST_WORKSPACE_ROOT}/target/release/rubin-node` lookup misses the
-# real binary and the harness fails after a successful build).
+# The produced binary path is derived from Cargo's authoritative build
+# output (machine-readable JSON event stream) instead of being guessed
+# from a host-layout assumption. Cargo emits one `compiler-artifact`
+# event per artifact; we select the one whose `target.name == "rubin-node"`
+# AND `target.kind` includes `"bin"` AND `executable` is non-null, then
+# take its `executable` path. That path is correct under every cargo
+# axis that affects placement: `--target-dir`, `CARGO_TARGET_DIR`,
+# `.cargo/config.toml build.target-dir`, `--target <triple>`,
+# `CARGO_BUILD_TARGET`, `.cargo/config.toml build.target`,
+# `--profile <name>`, and `--out-dir <dir>` (PR #1510 wave-3 codex
+# finding: previously pinned `${target-dir}/release/rubin-node` lookup
+# missed `target/<triple>/release/` placement when a target triple was
+# in effect). We still pass `--target-dir` so the artifact root (and
+# its EXIT-trap-managed cleanup) owns the build cache; cargo's metadata
+# is what actually tells the harness where the binary landed.
 # Side-effect: each invocation gets its own mktemp'd cargo-target/, so
-# nothing here reuses a shared cache — fine for a skeleton soak whose
-# job is to prove a real-process launch end-to-end on every run.
+# nothing reuses a shared cache — fine for a skeleton soak whose job
+# is to prove a real-process launch end-to-end on every run.
 CARGO_TARGET_DIR_LOCAL="${RUBIN_PROCESS_ARTIFACT_ROOT}/cargo-target"
+CARGO_BUILD_LOG="${RUBIN_PROCESS_ARTIFACT_ROOT}/cargo-build.jsonl"
 "${DEV_ENV}" -- cargo build \
   --manifest-path "${RUST_WORKSPACE_ROOT}/Cargo.toml" \
   --release --locked -p rubin-node \
-  --target-dir "${CARGO_TARGET_DIR_LOCAL}"
-CARGO_TARGET_BIN="${CARGO_TARGET_DIR_LOCAL}/release/rubin-node"
+  --target-dir "${CARGO_TARGET_DIR_LOCAL}" \
+  --message-format=json-render-diagnostics >"${CARGO_BUILD_LOG}"
+
+# Bounded fail-closed parser: scan only artifact events, accept only
+# the rubin-node bin executable, never path-guess. If cargo emits zero
+# matching events (e.g., a future cargo change to artifact semantics
+# or a stale toolchain), the parser exits 1 and the harness fails-
+# closed instead of running a stale binary or guessing a layout.
+CARGO_TARGET_BIN="$(python3 - "${CARGO_BUILD_LOG}" <<'PY'
+import json
+import sys
+
+log_path = sys.argv[1]
+selected = None
+with open(log_path, encoding="utf-8") as f:
+    for line in f:
+        line = line.strip()
+        if not line or not line.startswith("{"):
+            continue
+        try:
+            ev = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if ev.get("reason") != "compiler-artifact":
+            continue
+        target = ev.get("target") or {}
+        if target.get("name") != "rubin-node":
+            continue
+        kinds = target.get("kind") or []
+        if "bin" not in kinds:
+            continue
+        executable = ev.get("executable")
+        if not executable:
+            continue
+        # Don't break: take the LAST matching event so a release
+        # rebuild's final link wins over any earlier deps-only emission.
+        selected = executable
+if selected is None:
+    sys.exit(1)
+print(selected)
+PY
+)" || {
+  echo "cargo build emitted no compiler-artifact event with target.name=rubin-node, kind=bin, and a non-null executable; raw log: ${CARGO_BUILD_LOG}" >&2
+  exit 1
+}
 [[ -x "${CARGO_TARGET_BIN}" ]] || {
-  echo "cargo build did not produce executable: ${CARGO_TARGET_BIN}" >&2
+  echo "cargo-reported executable is not executable: ${CARGO_TARGET_BIN}" >&2
   exit 1
 }
 cp "${CARGO_TARGET_BIN}" "${NODE_BIN}"

--- a/scripts/devnet-rust-binary-soak.sh
+++ b/scripts/devnet-rust-binary-soak.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# devnet-rust-binary-soak.sh — RUB-27 process-soak skeleton harness.
+#
+# Launches a real `rubin-node` Rust binary as a process, records honest
+# process-level evidence (mixed_client_evidence_v1 conformant), and fails
+# closed if the binary cannot be built or launched.
+#
+# Skeleton scope (RUB-27): Rust-only process launch. The emitted evidence
+# is intentionally `verdict=FAIL` because a single-Rust skeleton has no
+# cross-implementation tx_path proof — that proof is owned by RUB-21,
+# RUB-22, RUB-23. The Go participant in the artifact is a declared
+# placeholder (name + implementation only) so the schema cross-field
+# gate (mixed_client_process_soak requires both go and rust impls and
+# at least 2 participants) accepts the artifact; downstream issues
+# replace the placeholder with a real-launched Go participant plus a
+# tx_path PASS section.
+#
+# Hostile-case enforcement (RUB-27 enumeration → enforcement layer):
+#   * missing Rust binary           → cargo build fails → exit non-zero, no artifact
+#   * binary exits immediately      → rubin_process_start detects exit-before-registration
+#   * pid recorded but already dead → wait_for_log checks rubin_process_is_alive per iteration
+#   * stdout/stderr in JSON parse   → evidence built via python json.dump, never via shell jq
+#   * helper artifact labeled real  → evidence emitter only fills endpoint/started_at on real launch
+#   * timeout returns pass          → wait_for_* non-zero on timeout, harness exits non-zero
+#   * wrong implementation identity → hardcoded "rust" string in evidence emitter
+#   * schema misses command/pid     → command/pid live in custom REPORT (out-of-band of schema)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEV_ENV="${REPO_ROOT}/scripts/dev-env.sh"
+RUST_WORKSPACE_ROOT="${REPO_ROOT}/clients/rust"
+HELPER="${REPO_ROOT}/scripts/devnet-process-common.sh"
+VALIDATOR="${REPO_ROOT}/scripts/devnet/validate_mixed_client_evidence.py"
+
+usage() { echo "usage: $0" >&2; }
+case "${1:-}" in
+  -h|--help)
+    usage
+    exit 0
+    ;;
+  "")
+    ;;
+  *)
+    usage
+    exit 2
+    ;;
+esac
+
+for tool in python3 perl; do
+  command -v "${tool}" >/dev/null 2>&1 || {
+    echo "${tool} is required for Rust binary soak skeleton" >&2
+    exit 1
+  }
+done
+[[ -r "${VALIDATOR}" ]] || { echo "validator unreadable: ${VALIDATOR}" >&2; exit 1; }
+[[ -x "${DEV_ENV}" ]] || { echo "dev-env wrapper missing or non-executable: ${DEV_ENV}" >&2; exit 1; }
+
+# shellcheck source=scripts/devnet-process-common.sh disable=SC1091
+source "${HELPER}"
+rubin_process_init rust-binary-soak
+
+NODE_BIN="${RUBIN_PROCESS_ARTIFACT_ROOT}/rubin-node-rust"
+DATA_DIR="${RUBIN_PROCESS_ARTIFACT_ROOT}/node-rust"
+LOG_FILE="node-rust.log"
+REPORT_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/rust-binary-soak-report.json"
+EVIDENCE_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/rust-binary-soak-evidence.json"
+mkdir -p "${DATA_DIR}"
+
+# Build the Rust binary via the project dev-env wrapper. cargo failure
+# exits non-zero before any artifact is emitted, satisfying the
+# "missing Rust binary" hostile case.
+echo "Building Rust rubin-node binary"
+"${DEV_ENV}" -- cargo build \
+  --manifest-path "${RUST_WORKSPACE_ROOT}/Cargo.toml" \
+  --release --locked -p rubin-node
+CARGO_TARGET_BIN="${RUST_WORKSPACE_ROOT}/target/release/rubin-node"
+[[ -x "${CARGO_TARGET_BIN}" ]] || {
+  echo "cargo build did not produce executable: ${CARGO_TARGET_BIN}" >&2
+  exit 1
+}
+cp "${CARGO_TARGET_BIN}" "${NODE_BIN}"
+[[ -x "${NODE_BIN}" ]] || {
+  echo "rust binary copy is not executable: ${NODE_BIN}" >&2
+  exit 1
+}
+
+# Captured BEFORE the launch attempt: UTC-Z seconds-only canonical
+# format per RUB-208 / PR-C policy enforced by the schema regex on
+# participants[].started_at.
+STARTED_AT_UTC="$(python3 -c 'import datetime; print(datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"))')"
+
+LAUNCH_FAILURE_REASON=""
+RPC_ADDR=""
+NODE_PID=""
+
+# Single-purpose function so set -e stays on for the rest of the script
+# while each helper failure routes into LAUNCH_FAILURE_REASON. Bash
+# leaves set -e disarmed for commands followed by `||`, so the
+# `cmd || { reason=...; return 1; }` form here does not abort the script
+# on a single helper failure — the calling `if` block decides next steps.
+attempt_skeleton_launch() {
+  rubin_process_start "${LOG_FILE}" "${NODE_BIN}" \
+    --network devnet --datadir "${DATA_DIR}" \
+    --bind 127.0.0.1:0 --rpc-bind 127.0.0.1:0 \
+    || { LAUNCH_FAILURE_REASON="rubin_process_start did not register a Rust skeleton process"; return 1; }
+  NODE_PID="${RUBIN_PROCESS_LAST_PID:-}"
+  [[ -n "${NODE_PID}" ]] \
+    || { LAUNCH_FAILURE_REASON="rubin_process_start did not capture a pid"; return 1; }
+  rubin_process_wait_for_log "${LOG_FILE}" "rpc: listening=" 60 "${NODE_PID}" \
+    || { LAUNCH_FAILURE_REASON="rust skeleton did not emit rpc-listening banner within 60s"; return 1; }
+  RPC_ADDR="$(rubin_process_extract_rpc_addr "${LOG_FILE}")" \
+    || { LAUNCH_FAILURE_REASON="failed to extract rpc-listening address from log"; return 1; }
+  [[ -n "${RPC_ADDR}" ]] \
+    || { LAUNCH_FAILURE_REASON="rpc-listening banner missing address payload"; return 1; }
+  rubin_process_wait_for_rpc_ready "${RPC_ADDR}" 30 \
+    || { LAUNCH_FAILURE_REASON="rust skeleton /get_tip RPC was not reachable within 30s"; return 1; }
+  rubin_process_is_alive "${NODE_PID}" \
+    || { LAUNCH_FAILURE_REASON="rust skeleton process pid=${NODE_PID} exited after RPC probe"; return 1; }
+  return 0
+}
+
+LAUNCH_STATUS="failed"
+if attempt_skeleton_launch; then
+  LAUNCH_STATUS="success"
+fi
+
+export EVIDENCE_JSON REPORT_JSON LAUNCH_STATUS LAUNCH_FAILURE_REASON \
+       RPC_ADDR STARTED_AT_UTC NODE_BIN NODE_PID LOG_FILE DATA_DIR
+python3 - <<'PY'
+import json
+import os
+
+e = os.environ
+status = e["LAUNCH_STATUS"]
+
+if status == "success":
+    failure_reason = (
+        "rust-only skeleton run; cross-implementation tx_path proof is "
+        "RUB-21/22/23"
+    )
+    rust_participant = {
+        "name": "node-rust",
+        "implementation": "rust",
+        "endpoint": e["RPC_ADDR"],
+        "started_at": e["STARTED_AT_UTC"],
+    }
+else:
+    failure_reason = (
+        e["LAUNCH_FAILURE_REASON"]
+        or "rust skeleton launch failed without a specific reason"
+    )
+    # Honest evidence: on launch failure no real endpoint/started_at
+    # was observed, so the rust participant carries name+implementation
+    # only. The schema-required cross-impl participant pair is satisfied
+    # by the declared go placeholder below.
+    rust_participant = {"name": "node-rust", "implementation": "rust"}
+
+evidence = {
+    "schema_version": "rubin-mixed-client-devnet-evidence-v1",
+    "evidence_type": "mixed_client_process_soak",
+    "scenario": "rust_binary_soak_skeleton",
+    "verdict": "FAIL",
+    "failure_reason": failure_reason,
+    "participants": [
+        rust_participant,
+        # Declared Go placeholder. RUB-21/22/23 replace this with a
+        # real-launched Go participant plus a tx_path PASS section.
+        {"name": "node-go", "implementation": "go"},
+    ],
+}
+with open(e["EVIDENCE_JSON"], "w", encoding="utf-8") as f:
+    json.dump(evidence, f, indent=2, sort_keys=True)
+    f.write("\n")
+
+# Out-of-band custom report: carries command path / pid that the
+# committed mixed_client_evidence_v1 schema does not model. Not
+# validated by validate_mixed_client_evidence.py — this report is
+# operator-facing audit material, kept in a sibling file so the
+# schema-validated artifact stays minimal.
+report = {
+    "scenario": "rust_binary_soak_skeleton",
+    "implementation": "rust",
+    "command_path": e["NODE_BIN"],
+    "data_dir": e["DATA_DIR"],
+    "log_file": e["LOG_FILE"],
+    "started_at_utc": e["STARTED_AT_UTC"],
+    "launch_status": status,
+    "pid": int(e["NODE_PID"]) if status == "success" and e.get("NODE_PID") else None,
+    "rpc_endpoint": e["RPC_ADDR"] if status == "success" else None,
+    "failure_reason": e["LAUNCH_FAILURE_REASON"] if status == "failed" else None,
+    "follow_ups": [
+        "RUB-21 owns cross-implementation tx_path PASS evidence",
+        "RUB-22/23 own end-to-end tx propagation",
+        "RUB-25 owns CI fail-closed gate integration",
+    ],
+}
+with open(e["REPORT_JSON"], "w", encoding="utf-8") as f:
+    json.dump(report, f, indent=2, sort_keys=True)
+    f.write("\n")
+PY
+
+# RUB-24 schema validator is the canonical gate: must accept the
+# skeleton artifact (well-formed shape) regardless of LAUNCH_STATUS.
+# A validator rejection here is a real bug in this harness, not a
+# launch-time symptom — let `set -e` propagate the non-zero exit.
+echo "Validating emitted evidence via RUB-24 schema validator"
+python3 "${VALIDATOR}" "${EVIDENCE_JSON}"
+
+if [[ "${LAUNCH_STATUS}" == "success" ]]; then
+  PASS_SUMMARY="SKELETON: rust binary soak launched pid=${NODE_PID} rpc=${RPC_ADDR} (verdict=FAIL/skeleton-only; cross-impl tx_path is RUB-21/22/23)"
+  if [[ "${RUBIN_PROCESS_KEEP_ARTIFACTS}" == "1" ]]; then
+    echo "${PASS_SUMMARY}; report=${REPORT_JSON} evidence=${EVIDENCE_JSON}"
+  else
+    echo "${PASS_SUMMARY}; set KEEP_TMP=1 to retain artifacts"
+  fi
+  exit 0
+else
+  FAIL_SUMMARY="FAIL: rust skeleton launch failed: ${LAUNCH_FAILURE_REASON}"
+  echo "${FAIL_SUMMARY}; report=${REPORT_JSON} evidence=${EVIDENCE_JSON}" >&2
+  exit 1
+fi

--- a/scripts/devnet-rust-binary-soak.sh
+++ b/scripts/devnet-rust-binary-soak.sh
@@ -97,6 +97,19 @@ echo "Building Rust rubin-node binary"
 # is to prove a real-process launch end-to-end on every run.
 CARGO_TARGET_DIR_LOCAL="${RUBIN_PROCESS_ARTIFACT_ROOT}/cargo-target"
 CARGO_BUILD_LOG="${RUBIN_PROCESS_ARTIFACT_ROOT}/cargo-build.jsonl"
+run_fips_preflight_before_captured_dev_env() {
+  if [[ "${RUBIN_OPENSSL_FIPS_MODE:-off}" != "only" ]]; then
+    return 0
+  fi
+  if [[ "${RUBIN_OPENSSL_SKIP_FIPS_GUARD:-0}" == "1" ]]; then
+    return 0
+  fi
+
+  echo "Running FIPS-only preflight before captured dev-env command streams" >&2
+  "${DEV_ENV}" -- "${REPO_ROOT}/scripts/crypto/openssl/fips-preflight.sh" >&2
+}
+
+run_fips_preflight_before_captured_dev_env
 # Force the host triple as the build target (PR #1510 wave-N+1 codex
 # finding "Force host target before executing rubin-node"): without an
 # explicit --target, cargo inherits CARGO_BUILD_TARGET / `build.target`
@@ -108,12 +121,12 @@ CARGO_BUILD_LOG="${RUBIN_PROCESS_ARTIFACT_ROOT}/cargo-build.jsonl"
 # triple defeats every config/env axis that could redirect to a
 # non-host triple. Cargo CLI precedence: explicit --target overrides
 # CARGO_BUILD_TARGET env and .cargo/config.toml `build.target`.
-HOST_TRIPLE="$("${DEV_ENV}" -- rustc -vV | awk '/^host:/ {print $2}')"
+HOST_TRIPLE="$(RUBIN_OPENSSL_SKIP_FIPS_GUARD=1 "${DEV_ENV}" -- rustc -vV | awk '/^host:/ {print $2}')"
 [[ -n "${HOST_TRIPLE}" ]] || {
   echo "could not derive host target triple from rustc -vV output" >&2
   exit 1
 }
-"${DEV_ENV}" -- cargo build \
+RUBIN_OPENSSL_SKIP_FIPS_GUARD=1 "${DEV_ENV}" -- cargo build \
   --manifest-path "${RUST_WORKSPACE_ROOT}/Cargo.toml" \
   --release --locked -p rubin-node \
   --target "${HOST_TRIPLE}" \

--- a/scripts/devnet-rust-binary-soak.sh
+++ b/scripts/devnet-rust-binary-soak.sh
@@ -97,17 +97,47 @@ echo "Building Rust rubin-node binary"
 # is to prove a real-process launch end-to-end on every run.
 CARGO_TARGET_DIR_LOCAL="${RUBIN_PROCESS_ARTIFACT_ROOT}/cargo-target"
 CARGO_BUILD_LOG="${RUBIN_PROCESS_ARTIFACT_ROOT}/cargo-build.jsonl"
+# Force the host triple as the build target (PR #1510 wave-N+1 codex
+# finding "Force host target before executing rubin-node"): without an
+# explicit --target, cargo inherits CARGO_BUILD_TARGET / `build.target`
+# / .cargo/config.toml `[build] target=`. A non-host configured default
+# yields a cross-compiled binary; the cargo-metadata path resolution
+# below still picks the right path, but `rubin_process_start` then
+# fails at runtime with `exec format error` because the harness exec's
+# the artifact directly. Pinning --target to rustc's reported host
+# triple defeats every config/env axis that could redirect to a
+# non-host triple. Cargo CLI precedence: explicit --target overrides
+# CARGO_BUILD_TARGET env and .cargo/config.toml `build.target`.
+HOST_TRIPLE="$("${DEV_ENV}" -- rustc -vV | awk '/^host:/ {print $2}')"
+[[ -n "${HOST_TRIPLE}" ]] || {
+  echo "could not derive host target triple from rustc -vV output" >&2
+  exit 1
+}
 "${DEV_ENV}" -- cargo build \
   --manifest-path "${RUST_WORKSPACE_ROOT}/Cargo.toml" \
   --release --locked -p rubin-node \
+  --target "${HOST_TRIPLE}" \
   --target-dir "${CARGO_TARGET_DIR_LOCAL}" \
   --message-format=json-render-diagnostics >"${CARGO_BUILD_LOG}"
 
-# Bounded fail-closed parser: scan only artifact events, accept only
-# the rubin-node bin executable, never path-guess. If cargo emits zero
-# matching events (e.g., a future cargo change to artifact semantics
-# or a stale toolchain), the parser exits 1 and the harness fails-
-# closed instead of running a stale binary or guessing a layout.
+# Fail-closed JSONL parser. Cargo's --message-format=json-render-diagnostics
+# routes machine-readable JSON events to stdout (one event per line) and
+# human-rendered diagnostics to stderr; this stdout stream therefore
+# MUST be pure JSON. The parser exits non-zero on three classes of bad
+# input (PR #1510 wave-N+1 copilot P1 finding: previous "fail-closed"
+# label sat on a fail-OPEN body that silently `continue`d on contamination):
+#   (a) any non-empty line whose first byte isn't '{' (wrapper banner,
+#       dev-env preamble, environment-injected message) — fail-closed;
+#   (b) any line that starts with '{' but JSON-decodes with an error
+#       (truncated stream, encoding corruption) — fail-closed;
+#   (c) the whole stream contains zero compiler-artifact events
+#       matching target.name=rubin-node + kind=bin + non-null executable
+#       (cargo skipped the build, or toolchain changed event semantics)
+#       — fail-closed via final exit 1.
+# Empty lines are tolerated as a defensive compatibility hedge; valid
+# JSON events with reason != compiler-artifact (e.g., compiler-message,
+# build-script-executed, build-finished) are correctly skipped — they
+# are part of cargo's normal stream, not contamination.
 CARGO_TARGET_BIN="$(python3 - "${CARGO_BUILD_LOG}" <<'PY'
 import json
 import sys
@@ -115,14 +145,22 @@ import sys
 log_path = sys.argv[1]
 selected = None
 with open(log_path, encoding="utf-8") as f:
-    for line in f:
-        line = line.strip()
-        if not line or not line.startswith("{"):
+    for raw in f:
+        line = raw.strip()
+        if not line:
             continue
+        if not line.startswith("{"):
+            sys.stderr.write(
+                f"cargo build log contamination: non-JSON line: {line[:160]!r}\n"
+            )
+            sys.exit(1)
         try:
             ev = json.loads(line)
-        except json.JSONDecodeError:
-            continue
+        except json.JSONDecodeError as exc:
+            sys.stderr.write(
+                f"cargo build log JSON parse error: {exc}: {line[:160]!r}\n"
+            )
+            sys.exit(1)
         if ev.get("reason") != "compiler-artifact":
             continue
         target = ev.get("target") or {}
@@ -142,7 +180,7 @@ if selected is None:
 print(selected)
 PY
 )" || {
-  echo "cargo build emitted no compiler-artifact event with target.name=rubin-node, kind=bin, and a non-null executable; raw log: ${CARGO_BUILD_LOG}" >&2
+  echo "cargo build log parser failed (no rubin-node bin executable artifact, or contamination); raw log: ${CARGO_BUILD_LOG}" >&2
   exit 1
 }
 [[ -x "${CARGO_TARGET_BIN}" ]] || {
@@ -205,19 +243,35 @@ if attempt_skeleton_launch; then
 fi
 
 export EVIDENCE_JSON REPORT_JSON LAUNCH_STATUS LAUNCH_FAILURE_REASON \
-       RPC_ADDR STARTED_AT_UTC NODE_BIN NODE_PID LOG_FILE DATA_DIR
+       RPC_ADDR STARTED_AT_UTC NODE_BIN NODE_PID LOG_FILE DATA_DIR \
+       RUBIN_PROCESS_ARTIFACT_ROOT
 python3 - <<'PY'
 import json
 import os
 
 e = os.environ
 status = e["LAUNCH_STATUS"]
+launch_failure_raw = (e.get("LAUNCH_FAILURE_REASON") or "").strip()
 
+# Compute one effective_failure_reason and use it in BOTH evidence and
+# report (PR #1510 wave-N+1 copilot P2 finding: previously evidence had
+# an "or '...skeleton...'" fallback while report passed
+# LAUNCH_FAILURE_REASON through unchanged, so a failed-path with empty
+# env var produced an empty/None report.failure_reason while evidence
+# had explicit text). Single computed value eliminates the asymmetry.
 if status == "success":
-    failure_reason = (
+    effective_failure_reason = (
         "rust-only skeleton run; cross-implementation tx_path proof is "
         "RUB-21/22/23"
     )
+elif launch_failure_raw:
+    effective_failure_reason = launch_failure_raw
+else:
+    effective_failure_reason = (
+        "rust skeleton launch failed without a specific reason"
+    )
+
+if status == "success":
     rust_participant = {
         "name": "node-rust",
         "implementation": "rust",
@@ -225,10 +279,6 @@ if status == "success":
         "started_at": e["STARTED_AT_UTC"],
     }
 else:
-    failure_reason = (
-        e["LAUNCH_FAILURE_REASON"]
-        or "rust skeleton launch failed without a specific reason"
-    )
     # Honest evidence: on launch failure no real endpoint/started_at
     # was observed, so the rust participant carries name+implementation
     # only. The schema-required cross-impl participant pair is satisfied
@@ -240,7 +290,7 @@ evidence = {
     "evidence_type": "mixed_client_process_soak",
     "scenario": "rust_binary_soak_skeleton",
     "verdict": "FAIL",
-    "failure_reason": failure_reason,
+    "failure_reason": effective_failure_reason,
     "participants": [
         rust_participant,
         # Declared Go placeholder. RUB-21/22/23 replace this with a
@@ -260,20 +310,32 @@ with open(e["EVIDENCE_JSON"], "w", encoding="utf-8") as f:
 #
 # pid / rpc_endpoint / started_at_utc are recorded whenever they were
 # observed during the launch attempt, regardless of final launch_status
-# (P2 finding from PR #1510 review): a launch that registers a pid and
-# emits the rpc-listening banner before a later readiness check fails
-# previously dropped both fields, hiding identity that operators need
-# for failure forensics. The pid_observed / rpc_observed / started_observed
-# flags carry the boolean "did we ever see this during the attempt".
+# (PR #1510 wave-1 copilot P2 finding): a launch that registers a pid
+# and emits the rpc-listening banner before a later readiness check
+# fails previously dropped both fields, hiding identity that operators
+# need for failure forensics. The pid_observed / rpc_observed /
+# started_observed booleans carry "did we ever see this".
+#
+# log_path is the absolute resolved location of the harness log,
+# alongside artifact_root, so an operator reading this report from
+# outside the harness CWD (tarball, archived report, ticket attachment)
+# can still resolve and tail the log file without re-deriving the
+# artifact-root prefix (PR #1510 wave-N+1 controller-isolated reviewer
+# P2 finding: report was carrying log_file relative-only).
 node_pid_raw = (e.get("NODE_PID") or "").strip()
 rpc_addr_raw = (e.get("RPC_ADDR") or "").strip()
 started_at_raw = (e.get("STARTED_AT_UTC") or "").strip()
+artifact_root = e["RUBIN_PROCESS_ARTIFACT_ROOT"]
+log_file_relative = e["LOG_FILE"]
+log_path_absolute = os.path.join(artifact_root, log_file_relative)
 report = {
     "scenario": "rust_binary_soak_skeleton",
     "implementation": "rust",
     "command_path": e["NODE_BIN"],
     "data_dir": e["DATA_DIR"],
-    "log_file": e["LOG_FILE"],
+    "artifact_root": artifact_root,
+    "log_file": log_file_relative,
+    "log_path": log_path_absolute,
     "launch_status": status,
     "pid": int(node_pid_raw) if node_pid_raw else None,
     "pid_observed": bool(node_pid_raw),
@@ -281,7 +343,7 @@ report = {
     "rpc_observed": bool(rpc_addr_raw),
     "started_at_utc": started_at_raw or None,
     "started_observed": bool(started_at_raw),
-    "failure_reason": e["LAUNCH_FAILURE_REASON"] if status == "failed" else None,
+    "failure_reason": effective_failure_reason,
     "follow_ups": [
         "RUB-21 owns cross-implementation tx_path PASS evidence",
         "RUB-22/23 own end-to-end tx propagation",

--- a/scripts/devnet-rust-binary-soak.sh
+++ b/scripts/devnet-rust-binary-soak.sh
@@ -110,6 +110,10 @@ run_fips_preflight_before_captured_dev_env() {
 }
 
 run_fips_preflight_before_captured_dev_env
+run_validator() {
+  RUBIN_OPENSSL_SKIP_FIPS_GUARD=1 "${DEV_ENV}" -- python3 "${VALIDATOR}" "$@"
+}
+
 # Force the host triple as the build target (PR #1510 wave-N+1 codex
 # finding "Force host target before executing rubin-node"): without an
 # explicit --target, cargo inherits CARGO_BUILD_TARGET / `build.target`
@@ -373,7 +377,7 @@ PY
 # A validator rejection here is a real bug in this harness, not a
 # launch-time symptom — let `set -e` propagate the non-zero exit.
 echo "Validating emitted evidence via RUB-24 schema validator"
-python3 "${VALIDATOR}" "${EVIDENCE_JSON}"
+run_validator "${EVIDENCE_JSON}"
 
 if [[ "${LAUNCH_STATUS}" == "success" ]]; then
   PASS_SUMMARY="SKELETON: rust binary soak launched pid=${NODE_PID} rpc=${RPC_ADDR} (verdict=FAIL/skeleton-only; cross-impl tx_path is RUB-21/22/23)"
@@ -384,7 +388,11 @@ if [[ "${LAUNCH_STATUS}" == "success" ]]; then
   fi
   exit 0
 else
-  FAIL_SUMMARY="FAIL: rust skeleton launch failed: ${LAUNCH_FAILURE_REASON}"
+  FAILURE_REASON_FOR_SUMMARY="${LAUNCH_FAILURE_REASON}"
+  if [[ -z "${FAILURE_REASON_FOR_SUMMARY//[[:space:]]/}" ]]; then
+    FAILURE_REASON_FOR_SUMMARY="rust skeleton launch failed without a specific reason"
+  fi
+  FAIL_SUMMARY="FAIL: rust skeleton launch failed: ${FAILURE_REASON_FOR_SUMMARY}"
   echo "${FAIL_SUMMARY}; report=${REPORT_JSON} evidence=${EVIDENCE_JSON}" >&2
   exit 1
 fi

--- a/scripts/devnet-rust-binary-soak.sh
+++ b/scripts/devnet-rust-binary-soak.sh
@@ -71,10 +71,22 @@ mkdir -p "${DATA_DIR}"
 # exits non-zero before any artifact is emitted, satisfying the
 # "missing Rust binary" hostile case.
 echo "Building Rust rubin-node binary"
+# Pin the Cargo output directory under the harness artifact root so the
+# produced binary path is deterministic regardless of `CARGO_TARGET_DIR`
+# in the environment or `build.target-dir` set by a `.cargo/config.toml`
+# (PR #1510 wave-2 codex+copilot findings: Cargo can be told to write
+# elsewhere, in which case the previous hardcoded
+# `${RUST_WORKSPACE_ROOT}/target/release/rubin-node` lookup misses the
+# real binary and the harness fails after a successful build).
+# Side-effect: each invocation gets its own mktemp'd cargo-target/, so
+# nothing here reuses a shared cache — fine for a skeleton soak whose
+# job is to prove a real-process launch end-to-end on every run.
+CARGO_TARGET_DIR_LOCAL="${RUBIN_PROCESS_ARTIFACT_ROOT}/cargo-target"
 "${DEV_ENV}" -- cargo build \
   --manifest-path "${RUST_WORKSPACE_ROOT}/Cargo.toml" \
-  --release --locked -p rubin-node
-CARGO_TARGET_BIN="${RUST_WORKSPACE_ROOT}/target/release/rubin-node"
+  --release --locked -p rubin-node \
+  --target-dir "${CARGO_TARGET_DIR_LOCAL}"
+CARGO_TARGET_BIN="${CARGO_TARGET_DIR_LOCAL}/release/rubin-node"
 [[ -x "${CARGO_TARGET_BIN}" ]] || {
   echo "cargo build did not produce executable: ${CARGO_TARGET_BIN}" >&2
   exit 1

--- a/scripts/devnet/test_rust_skeleton_fixtures.sh
+++ b/scripts/devnet/test_rust_skeleton_fixtures.sh
@@ -58,7 +58,7 @@ for needle in \
   "requires at least 2 participants" \
   "at least one implementation=go and one implementation=rust" \
   "tx_path: required for evidence_type=mixed_client_process_soak with verdict=PASS"; do
-  if ! printf '%s\n' "${REJECTED_OUTPUT}" | grep -qF -- "${needle}"; then
+  if [[ "${REJECTED_OUTPUT}" != *"${needle}"* ]]; then
     echo "FAIL: helper-only rejection missing expected cross-field message: ${needle}" >&2
     echo "actual output:" >&2
     printf '%s\n' "${REJECTED_OUTPUT}" >&2

--- a/scripts/devnet/test_rust_skeleton_fixtures.sh
+++ b/scripts/devnet/test_rust_skeleton_fixtures.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# test_rust_skeleton_fixtures.sh — RUB-27 fixture accept/reject test.
+#
+# Wires the committed Rust skeleton fixtures as test consumers, proving
+# the RUB-27 acceptance criterion "RUB-24 schema validator accepts the
+# valid skeleton artifact and rejects helper-only artifact" via the
+# committed validator (scripts/devnet/validate_mixed_client_evidence.py).
+#
+# Without this script the two committed fixtures would have no in-repo
+# consumer; the harness only validates its own runtime-emitted artifact,
+# not the committed fixture pair. This script anchors the acceptance
+# claim to a reproducible exit-code + cross-field-message contract.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+VALIDATOR="${REPO_ROOT}/scripts/devnet/validate_mixed_client_evidence.py"
+VALID_FIXTURE="${REPO_ROOT}/scripts/devnet/testdata/rust_skeleton_fail_evidence_valid.json"
+REJECTED_FIXTURE="${REPO_ROOT}/scripts/devnet/testdata/rust_skeleton_helper_only_rejected.json"
+
+command -v python3 >/dev/null 2>&1 || { echo "python3 is required" >&2; exit 1; }
+[[ -r "${VALIDATOR}" ]] || { echo "validator unreadable: ${VALIDATOR}" >&2; exit 1; }
+[[ -r "${VALID_FIXTURE}" ]] || { echo "valid fixture unreadable: ${VALID_FIXTURE}" >&2; exit 1; }
+[[ -r "${REJECTED_FIXTURE}" ]] || { echo "rejected fixture unreadable: ${REJECTED_FIXTURE}" >&2; exit 1; }
+
+# Acceptance leg 1: validator MUST accept the well-formed FAIL skeleton.
+echo "test_rust_skeleton_fixtures: valid fixture must validate"
+if ! python3 "${VALIDATOR}" "${VALID_FIXTURE}"; then
+  echo "FAIL: validator rejected the valid skeleton fixture" >&2
+  exit 1
+fi
+
+# Acceptance leg 2: validator MUST reject the helper-only shape and
+# surface the three expected cross-field rejections (missing 2nd
+# participant, missing go counterpart impl, tx_path required for PASS).
+# Pinning to specific cross-field messages — not just non-zero exit —
+# anchors the acceptance to the rejection class, not to a generic
+# schema-shape failure that some future schema relaxation could mask.
+echo "test_rust_skeleton_fixtures: helper-only fixture must be rejected"
+REJECTED_OUTPUT="$(python3 "${VALIDATOR}" "${REJECTED_FIXTURE}" 2>&1 || true)"
+REJECTED_RC=0
+python3 "${VALIDATOR}" "${REJECTED_FIXTURE}" >/dev/null 2>&1 || REJECTED_RC=$?
+if [[ "${REJECTED_RC}" == "0" ]]; then
+  echo "FAIL: validator accepted the helper-only fixture (expected rejection)" >&2
+  echo "actual output:" >&2
+  printf '%s\n' "${REJECTED_OUTPUT}" >&2
+  exit 1
+fi
+
+for needle in \
+  "requires at least 2 participants" \
+  "at least one implementation=go and one implementation=rust" \
+  "tx_path: required for evidence_type=mixed_client_process_soak with verdict=PASS"; do
+  if ! printf '%s\n' "${REJECTED_OUTPUT}" | grep -qF -- "${needle}"; then
+    echo "FAIL: helper-only rejection missing expected cross-field message: ${needle}" >&2
+    echo "actual output:" >&2
+    printf '%s\n' "${REJECTED_OUTPUT}" >&2
+    exit 1
+  fi
+done
+
+echo "PASS: rust skeleton fixtures accept/reject pair confirmed"

--- a/scripts/devnet/test_rust_skeleton_fixtures.sh
+++ b/scripts/devnet/test_rust_skeleton_fixtures.sh
@@ -37,9 +37,16 @@ fi
 # anchors the acceptance to the rejection class, not to a generic
 # schema-shape failure that some future schema relaxation could mask.
 echo "test_rust_skeleton_fixtures: helper-only fixture must be rejected"
-REJECTED_OUTPUT="$(python3 "${VALIDATOR}" "${REJECTED_FIXTURE}" 2>&1 || true)"
-REJECTED_RC=0
-python3 "${VALIDATOR}" "${REJECTED_FIXTURE}" >/dev/null 2>&1 || REJECTED_RC=$?
+# Single validator invocation captures both stderr+stdout and exit code
+# (P2 finding from PR #1510 review): the previous double-invocation
+# could mask a behavior change between runs. The if/else form keeps
+# `set -e` armed for everything else and binds REJECTED_RC to the
+# exact exit code of the captured invocation.
+if REJECTED_OUTPUT="$(python3 "${VALIDATOR}" "${REJECTED_FIXTURE}" 2>&1)"; then
+  REJECTED_RC=0
+else
+  REJECTED_RC=$?
+fi
 if [[ "${REJECTED_RC}" == "0" ]]; then
   echo "FAIL: validator accepted the helper-only fixture (expected rejection)" >&2
   echo "actual output:" >&2

--- a/scripts/devnet/test_rust_skeleton_fixtures.sh
+++ b/scripts/devnet/test_rust_skeleton_fixtures.sh
@@ -14,18 +14,38 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DEV_ENV="${REPO_ROOT}/scripts/dev-env.sh"
 VALIDATOR="${REPO_ROOT}/scripts/devnet/validate_mixed_client_evidence.py"
 VALID_FIXTURE="${REPO_ROOT}/scripts/devnet/testdata/rust_skeleton_fail_evidence_valid.json"
 REJECTED_FIXTURE="${REPO_ROOT}/scripts/devnet/testdata/rust_skeleton_helper_only_rejected.json"
 
 command -v python3 >/dev/null 2>&1 || { echo "python3 is required" >&2; exit 1; }
+[[ -x "${DEV_ENV}" ]] || { echo "dev-env wrapper missing or non-executable: ${DEV_ENV}" >&2; exit 1; }
 [[ -r "${VALIDATOR}" ]] || { echo "validator unreadable: ${VALIDATOR}" >&2; exit 1; }
 [[ -r "${VALID_FIXTURE}" ]] || { echo "valid fixture unreadable: ${VALID_FIXTURE}" >&2; exit 1; }
 [[ -r "${REJECTED_FIXTURE}" ]] || { echo "rejected fixture unreadable: ${REJECTED_FIXTURE}" >&2; exit 1; }
 
+run_fips_preflight_before_captured_dev_env() {
+  if [[ "${RUBIN_OPENSSL_FIPS_MODE:-off}" != "only" ]]; then
+    return 0
+  fi
+  if [[ "${RUBIN_OPENSSL_SKIP_FIPS_GUARD:-0}" == "1" ]]; then
+    return 0
+  fi
+
+  echo "Running FIPS-only preflight before captured dev-env validator streams" >&2
+  "${DEV_ENV}" -- "${REPO_ROOT}/scripts/crypto/openssl/fips-preflight.sh" >&2
+}
+
+run_validator() {
+  RUBIN_OPENSSL_SKIP_FIPS_GUARD=1 "${DEV_ENV}" -- python3 "${VALIDATOR}" "$@"
+}
+
+run_fips_preflight_before_captured_dev_env
+
 # Acceptance leg 1: validator MUST accept the well-formed FAIL skeleton.
 echo "test_rust_skeleton_fixtures: valid fixture must validate"
-if ! python3 "${VALIDATOR}" "${VALID_FIXTURE}"; then
+if ! run_validator "${VALID_FIXTURE}"; then
   echo "FAIL: validator rejected the valid skeleton fixture" >&2
   exit 1
 fi
@@ -42,7 +62,7 @@ echo "test_rust_skeleton_fixtures: helper-only fixture must be rejected"
 # could mask a behavior change between runs. The if/else form keeps
 # `set -e` armed for everything else and binds REJECTED_RC to the
 # exact exit code of the captured invocation.
-if REJECTED_OUTPUT="$(python3 "${VALIDATOR}" "${REJECTED_FIXTURE}" 2>&1)"; then
+if REJECTED_OUTPUT="$(run_validator "${REJECTED_FIXTURE}" 2>&1)"; then
   REJECTED_RC=0
 else
   REJECTED_RC=$?

--- a/scripts/devnet/testdata/rust_skeleton_fail_evidence_valid.json
+++ b/scripts/devnet/testdata/rust_skeleton_fail_evidence_valid.json
@@ -1,0 +1,19 @@
+{
+  "evidence_type": "mixed_client_process_soak",
+  "failure_reason": "rust-only skeleton run; cross-implementation tx_path proof is RUB-21/22/23",
+  "participants": [
+    {
+      "endpoint": "127.0.0.1:54321",
+      "implementation": "rust",
+      "name": "node-rust",
+      "started_at": "2026-05-09T09:50:00Z"
+    },
+    {
+      "implementation": "go",
+      "name": "node-go"
+    }
+  ],
+  "scenario": "rust_binary_soak_skeleton",
+  "schema_version": "rubin-mixed-client-devnet-evidence-v1",
+  "verdict": "FAIL"
+}

--- a/scripts/devnet/testdata/rust_skeleton_helper_only_rejected.json
+++ b/scripts/devnet/testdata/rust_skeleton_helper_only_rejected.json
@@ -1,0 +1,12 @@
+{
+  "evidence_type": "mixed_client_process_soak",
+  "participants": [
+    {
+      "implementation": "rust",
+      "name": "node-rust"
+    }
+  ],
+  "scenario": "rust_only_helper_label_rejected",
+  "schema_version": "rubin-mixed-client-devnet-evidence-v1",
+  "verdict": "PASS"
+}


### PR DESCRIPTION
## Scope

- New `scripts/devnet-rust-binary-soak.sh` harness: builds Rust `rubin-node` via `dev-env.sh -- cargo build --release --locked --message-format=json-render-diagnostics -p rubin-node --target-dir <harness>`, derives the executable path from cargo's authoritative `compiler-artifact` event (a bounded fail-closed Python parser scans the JSON event stream for `target.name=rubin-node`, kind contains `bin`, non-null `executable`; last matching event wins). Launches the resolved binary as a real process via the existing `rubin_process_*` helpers, captures pid/endpoint/started_at, emits two artifacts.
- Schema-validated artifact (`mixed_client_process_soak` v1): `verdict=FAIL` with explicit `failure_reason` ("rust-only skeleton run; cross-implementation tx_path proof is RUB-21/22/23"); 2 participants — real Rust (`endpoint`+`started_at`) and declared Go placeholder (`name`+`implementation` only) satisfying the schema cross-field gate `{go,rust} ⊆ impls` and `≥2 participants` without a false dual-launch claim.
- Out-of-band custom report carries `command_path`/`pid`/`launch_status`/`pid_observed`/`rpc_observed`/`started_observed`/`failure_reason`/`follow_ups` — fields the committed schema does not model. `started_at_utc` is captured AFTER the rpc-listening banner is observed (not pre-launch) so the timestamp reflects observed state; pid/rpc/started_at are recorded in the report whenever observed during a launch attempt regardless of final `launch_status`, with boolean `*_observed` flags for failure forensics.
- New `scripts/devnet/test_rust_skeleton_fixtures.sh`: standalone wrapper wiring both committed fixtures into `validate_mixed_client_evidence.py` from a single validator invocation (captures both stderr+stdout and exit code), asserting (a) valid fixture exits 0 AND (b) helper-only fixture exits non-zero with all three pinned cross-field rejection messages (`requires at least 2 participants`, `at least one implementation=go and one implementation=rust`, `tx_path: required for evidence_type=mixed_client_process_soak with verdict=PASS`).
- Two testdata fixtures: `rust_skeleton_fail_evidence_valid.json` (validator PASS) and `rust_skeleton_helper_only_rejected.json` (validator FAIL via 3 cross-field rejections).
- Total: 4 files / ~415 LoC cumulative additions / class C / shell+JSON-only diff.

## Non-scope

- No Go runtime changes (zero `clients/go/**` edits).
- No Rust runtime changes (zero `clients/rust/**` edits; the existing `rubin-node` skeleton-mode entrypoint already prints the `rpc: listening=` banner the harness consumes).
- No tx_path proof (RUB-21/22/23 own; the FAIL verdict + failure_reason explicitly defers to those issues).
- No restart/reorg proof (RUB-28/30 own).
- No CI blocking gate (RUB-25 owns).
- No schema or validator modifications (RUB-24 owns; merged at `e8e0863`).
- No P2P / node-lifecycle / policy redesign.

## Verification

- `shellcheck -x` PASS on both new scripts; `bash -n` syntax PASS.
- Direct harness smoke (`KEEP_TMP=1 ./scripts/devnet-rust-binary-soak.sh`): cargo built into the harness-managed target dir, parser resolved the binary from cargo's metadata stream, real Rust process launched (pid + `127.0.0.1:<os-port>` endpoint + UTC-Z `started_at` captured AFTER banner observation), `validate_mixed_client_evidence.py` PASS on the emitted artifact.
- Hostile env smoke (`CARGO_TARGET_DIR=/tmp/should-be-ignored`): `--target-dir` flag wins, parser resolves binary correctly. Target-override smoke (`CARGO_BUILD_TARGET=$HOST_TRIPLE`): cargo places binary under `<target-dir>/<triple>/release/rubin-node`, parser still resolves it from cargo's emit — the exact axis the previous wave-2 fix missed.
- `scripts/devnet/test_rust_skeleton_fixtures.sh`: validator accepts the valid skeleton fixture; rejects the helper-only fixture with all three expected cross-field messages — pinned-message assertion anchors the acceptance to the rejection class, not a generic schema-shape failure.
- Receipt stack: core PASS, tooling PASS, coverage `PASS_WITH_COVERAGE_SKIP` (`AUTOMATIC_NO_COVERAGE_SURFACE` — shell+JSON-only diff has no coverable Go/Rust source), review fanout BYPASSED with controller chat-approval (issue-matrix and parity reviewer lanes returned PASS substantively against the wave-4 source packet; prepush-hostile reviewer's lane file emitted PROBE_PACK/PROBE_CASES_RUN/PROBE_FAILURES_PROMOTED values that disagreed with the actual `rubin-review-probe-pack` output for this shell-only diff which classifies as `pack=not_applicable status=SKIPPED`, and `feedback_reviewer_runs_bash_probe_no_manual_patch` HARD memory forbids coder-side patching of probe fields), delta receipt PASS via controller-approved `cl push --fast-path small-fixpass`.
- Closes #1231.

<!-- rubin-agent-meta actor=gpt5 action=pr-edit via=cl branch=main wt=rubin-protocol utc=2026-05-09T17:03:58Z -->
