### PR TITLE
[RUB-25] Add mixed-client soak evidence gate

### DIFF
--- a/scripts/devnet-rust-binary-soak.sh
+++ b/scripts/devnet-rust-binary-soak.sh
@@ -39,28 +39,202 @@ RUST_WORKSPACE_ROOT="${REPO_ROOT}/clients/rust"
 HELPER="${REPO_ROOT}/scripts/devnet-process-common.sh"
 VALIDATOR="${REPO_ROOT}/scripts/devnet/validate_mixed_client_evidence.py"
 
-usage() { echo "usage: $0" >&2; }
-case "${1:-}" in
-  -h|--help)
-    usage
-    exit 0
-    ;;
-  "")
-    ;;
-  *)
-    usage
-    exit 2
-    ;;
-esac
+CHECK_EVIDENCE="" CHECK_EVIDENCE_MODE=0
 
-for tool in python3 perl; do
-  command -v "${tool}" >/dev/null 2>&1 || {
-    echo "${tool} is required for Rust binary soak skeleton" >&2
-    exit 1
-  }
+usage() { echo "usage: $0 [--check-evidence PATH]" >&2; }
+while (($#)); do
+  case "$1" in
+    --check-evidence)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      CHECK_EVIDENCE_MODE=1
+      CHECK_EVIDENCE="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
 done
+
+command -v python3 >/dev/null 2>&1 || {
+  echo "python3 is required for Rust binary soak skeleton" >&2
+  exit 1
+}
 [[ -r "${VALIDATOR}" ]] || { echo "validator unreadable: ${VALIDATOR}" >&2; exit 1; }
 [[ -x "${DEV_ENV}" ]] || { echo "dev-env wrapper missing or non-executable: ${DEV_ENV}" >&2; exit 1; }
+
+run_fips_preflight_before_captured_dev_env() {
+  if [[ "${RUBIN_OPENSSL_FIPS_MODE:-off}" != "only" ]]; then
+    return 0
+  fi
+  if [[ "${RUBIN_OPENSSL_SKIP_FIPS_GUARD:-0}" == "1" ]]; then
+    return 0
+  fi
+
+  echo "Running FIPS-only preflight before captured dev-env command streams" >&2
+  "${DEV_ENV}" -- "${REPO_ROOT}/scripts/crypto/openssl/fips-preflight.sh" >&2
+}
+
+run_validator() {
+  RUBIN_OPENSSL_SKIP_FIPS_GUARD=1 "${DEV_ENV}" -- python3 "${VALIDATOR}" "$@"
+}
+
+mixed_gate_fail() {
+  echo "FAIL: mixed-client process evidence gate: $*" >&2
+  return 1
+}
+
+print_prefixed_file() {
+  local label="$1" path="$2"
+  [[ -s "${path}" ]] || return 0
+  echo "${label}:" >&2
+  sed 's/^/  /' "${path}" >&2
+}
+
+check_mixed_client_pass_evidence() {
+  local artifact="${1:-}" validator_stdout="" validator_stderr=""
+  local expected_stdout gate_error validator_artifact validator_expected=""
+
+  [[ -n "${artifact}" ]] || mixed_gate_fail "artifact path is required" || return 1
+  [[ -f "${artifact}" ]] || mixed_gate_fail "artifact not found or not a regular file: ${artifact}" || return 1
+  [[ -r "${artifact}" ]] || mixed_gate_fail "artifact unreadable: ${artifact}" || return 1
+  [[ -s "${artifact}" ]] || mixed_gate_fail "artifact empty: ${artifact}" || return 1
+
+  run_fips_preflight_before_captured_dev_env
+
+  validator_stdout="$(mktemp "${TMPDIR:-/tmp}/rubin-mixed-validator-stdout.XXXXXX")" || return 1
+  validator_stderr="$(mktemp "${TMPDIR:-/tmp}/rubin-mixed-validator-stderr.XXXXXX")" || {
+    rm -f -- "${validator_stdout}"
+    return 1
+  }
+
+  if ! run_validator "${artifact}" >"${validator_stdout}" 2>"${validator_stderr}"; then
+    echo "FAIL: mixed-client process evidence gate validator rejected artifact: ${artifact}" >&2
+    print_prefixed_file "validator stdout" "${validator_stdout}"
+    print_prefixed_file "validator stderr" "${validator_stderr}"
+    rm -f -- "${validator_stdout}" "${validator_stderr}"
+    return 1
+  fi
+
+  validator_artifact="$(python3 -c 'from pathlib import Path; import sys; print(Path(sys.argv[1]))' "${artifact}")"
+  expected_stdout="PASS: ${validator_artifact}"
+  validator_expected="$(mktemp "${TMPDIR:-/tmp}/rubin-mixed-validator-expected.XXXXXX")" || {
+    rm -f -- "${validator_stdout}" "${validator_stderr}"
+    return 1
+  }
+  printf '%s\n' "${expected_stdout}" >"${validator_expected}"
+  if ! cmp -s "${validator_stdout}" "${validator_expected}"; then
+    echo "FAIL: mixed-client process evidence gate validator stdout contaminated for: ${artifact}" >&2
+    echo "expected stdout: ${expected_stdout}" >&2
+    print_prefixed_file "actual stdout" "${validator_stdout}"
+    print_prefixed_file "validator stderr" "${validator_stderr}"
+    rm -f -- "${validator_stdout}" "${validator_stderr}" "${validator_expected}"
+    return 1
+  fi
+
+  print_prefixed_file "validator stderr" "${validator_stderr}"
+  rm -f -- "${validator_stdout}" "${validator_stderr}" "${validator_expected}"
+
+  if ! gate_error="$(python3 - "${artifact}" 2>&1 <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+with open(path, encoding="utf-8") as f:
+    data = json.load(f)
+
+
+def fail(message: str) -> None:
+    print(message, file=sys.stderr)
+    sys.exit(1)
+
+
+if data.get("evidence_type") != "mixed_client_process_soak":
+    fail(
+        "evidence_type is not mixed_client_process_soak: "
+        f"{data.get('evidence_type')!r}"
+    )
+if data.get("verdict") != "PASS":
+    fail(
+        "verdict is not PASS; mixed-client process gate rejects "
+        f"{data.get('verdict')!r} evidence"
+    )
+if "failure_reason" in data:
+    fail("failure_reason is not allowed on PASS mixed-client process evidence")
+
+participants = data.get("participants")
+tx_path = data.get("tx_path")
+if not isinstance(participants, list) or not isinstance(tx_path, dict):
+    fail("schema floor unexpectedly allowed missing participants or tx_path")
+
+by_name = {p["name"]: p for p in participants}
+submitted_at = tx_path.get("submitted_at")
+observed_at = tx_path.get("observed_at")
+if not isinstance(submitted_at, str) or not isinstance(observed_at, list):
+    fail("schema floor unexpectedly allowed malformed tx_path references")
+
+missing_process_fields = []
+for participant in participants:
+    missing = [
+        field for field in ("endpoint", "started_at") if not participant.get(field)
+    ]
+    if missing:
+        missing_process_fields.append(
+            f"{participant['name']} missing {','.join(missing)}"
+        )
+
+if missing_process_fields:
+    fail(
+        "participant lacks real process evidence: "
+        + "; ".join(missing_process_fields)
+    )
+
+endpoint_owner = {}
+for participant in participants:
+    endpoint = participant["endpoint"]
+    previous = endpoint_owner.setdefault(endpoint, participant["name"])
+    if previous != participant["name"]:
+        fail(
+            "duplicate participant endpoint in PASS mixed-client process evidence: "
+            f"{endpoint!r} used by {previous!r} and {participant['name']!r}"
+        )
+
+referenced = [submitted_at, *observed_at]
+for name in referenced:
+    participant = by_name.get(name)
+    if participant is None:
+        fail(f"tx_path references undeclared participant: {name!r}")
+
+impls = {by_name[name]["implementation"] for name in referenced}
+if not {"go", "rust"} <= impls:
+    fail(
+        "tx_path does not reference both Go and Rust process participants; "
+        f"referenced implementations={sorted(impls)}"
+    )
+PY
+)"; then
+    echo "FAIL: mixed-client process evidence gate rejected artifact: ${artifact}" >&2
+    printf '%s\n' "${gate_error}" >&2
+    return 1
+  fi
+
+  echo "PASS: mixed-client process evidence gate accepted ${artifact}"
+}
+
+if [[ "${CHECK_EVIDENCE_MODE}" == "1" ]]; then
+  check_mixed_client_pass_evidence "${CHECK_EVIDENCE}"
+  exit 0
+fi
+
+command -v perl >/dev/null 2>&1 || {
+  echo "perl is required for Rust binary soak skeleton" >&2
+  exit 1
+}
 
 # shellcheck source=scripts/devnet-process-common.sh disable=SC1091
 source "${HELPER}"
@@ -97,22 +271,7 @@ echo "Building Rust rubin-node binary"
 # is to prove a real-process launch end-to-end on every run.
 CARGO_TARGET_DIR_LOCAL="${RUBIN_PROCESS_ARTIFACT_ROOT}/cargo-target"
 CARGO_BUILD_LOG="${RUBIN_PROCESS_ARTIFACT_ROOT}/cargo-build.jsonl"
-run_fips_preflight_before_captured_dev_env() {
-  if [[ "${RUBIN_OPENSSL_FIPS_MODE:-off}" != "only" ]]; then
-    return 0
-  fi
-  if [[ "${RUBIN_OPENSSL_SKIP_FIPS_GUARD:-0}" == "1" ]]; then
-    return 0
-  fi
-
-  echo "Running FIPS-only preflight before captured dev-env command streams" >&2
-  "${DEV_ENV}" -- "${REPO_ROOT}/scripts/crypto/openssl/fips-preflight.sh" >&2
-}
-
 run_fips_preflight_before_captured_dev_env
-run_validator() {
-  RUBIN_OPENSSL_SKIP_FIPS_GUARD=1 "${DEV_ENV}" -- python3 "${VALIDATOR}" "$@"
-}
 
 # Force the host triple as the build target (PR #1510 wave-N+1 codex
 # finding "Force host target before executing rubin-node"): without an

--- a/scripts/devnet-rust-binary-soak.sh
+++ b/scripts/devnet-rust-binary-soak.sh
@@ -39,28 +39,201 @@ RUST_WORKSPACE_ROOT="${REPO_ROOT}/clients/rust"
 HELPER="${REPO_ROOT}/scripts/devnet-process-common.sh"
 VALIDATOR="${REPO_ROOT}/scripts/devnet/validate_mixed_client_evidence.py"
 
-usage() { echo "usage: $0" >&2; }
-case "${1:-}" in
-  -h|--help)
-    usage
-    exit 0
-    ;;
-  "")
-    ;;
-  *)
-    usage
-    exit 2
-    ;;
-esac
+CHECK_EVIDENCE="" CHECK_EVIDENCE_MODE=0
 
-for tool in python3 perl; do
-  command -v "${tool}" >/dev/null 2>&1 || {
-    echo "${tool} is required for Rust binary soak skeleton" >&2
-    exit 1
-  }
+usage() { echo "usage: $0 [--check-evidence PATH]" >&2; }
+while (($#)); do
+  case "$1" in
+    --check-evidence)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      CHECK_EVIDENCE_MODE=1
+      CHECK_EVIDENCE="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
 done
+
+command -v python3 >/dev/null 2>&1 || {
+  echo "python3 is required for Rust binary soak skeleton" >&2
+  exit 1
+}
 [[ -r "${VALIDATOR}" ]] || { echo "validator unreadable: ${VALIDATOR}" >&2; exit 1; }
 [[ -x "${DEV_ENV}" ]] || { echo "dev-env wrapper missing or non-executable: ${DEV_ENV}" >&2; exit 1; }
+
+run_fips_preflight_before_captured_dev_env() {
+  if [[ "${RUBIN_OPENSSL_FIPS_MODE:-off}" != "only" ]]; then
+    return 0
+  fi
+  if [[ "${RUBIN_OPENSSL_SKIP_FIPS_GUARD:-0}" == "1" ]]; then
+    return 0
+  fi
+
+  echo "Running FIPS-only preflight before captured dev-env command streams" >&2
+  "${DEV_ENV}" -- "${REPO_ROOT}/scripts/crypto/openssl/fips-preflight.sh" >&2
+}
+
+run_validator() {
+  RUBIN_OPENSSL_SKIP_FIPS_GUARD=1 "${DEV_ENV}" -- python3 "${VALIDATOR}" "$@"
+}
+
+mixed_gate_fail() {
+  echo "FAIL: mixed-client process evidence gate: $*" >&2
+  return 1
+}
+
+print_prefixed_file() {
+  local label="$1" path="$2"
+  [[ -s "${path}" ]] || return 0
+  echo "${label}:" >&2
+  sed 's/^/  /' "${path}" >&2
+}
+
+check_mixed_client_pass_evidence() {
+  local artifact="${1:-}" validator_stdout="" validator_stderr=""
+  local gate_error
+
+  [[ -n "${artifact}" ]] || mixed_gate_fail "artifact path is required" || return 1
+  [[ -f "${artifact}" ]] || mixed_gate_fail "artifact not found or not a regular file: ${artifact}" || return 1
+  [[ -r "${artifact}" ]] || mixed_gate_fail "artifact unreadable: ${artifact}" || return 1
+  [[ -s "${artifact}" ]] || mixed_gate_fail "artifact empty: ${artifact}" || return 1
+
+  run_fips_preflight_before_captured_dev_env
+
+  validator_stdout="$(mktemp "${TMPDIR:-/tmp}/rubin-mixed-validator-stdout.XXXXXX")" || return 1
+  validator_stderr="$(mktemp "${TMPDIR:-/tmp}/rubin-mixed-validator-stderr.XXXXXX")" || {
+    rm -f -- "${validator_stdout}"
+    return 1
+  }
+
+  if ! run_validator "${artifact}" >"${validator_stdout}" 2>"${validator_stderr}"; then
+    echo "FAIL: mixed-client process evidence gate validator rejected artifact: ${artifact}" >&2
+    print_prefixed_file "validator stdout" "${validator_stdout}"
+    print_prefixed_file "validator stderr" "${validator_stderr}"
+    rm -f -- "${validator_stdout}" "${validator_stderr}"
+    return 1
+  fi
+
+  if ! python3 - "${validator_stdout}" "${artifact}" <<'PY'
+import sys; from pathlib import Path
+actual = Path(sys.argv[1]).read_text(encoding="utf-8")
+artifact = sys.argv[2]
+sys.exit(0 if actual in {f"PASS: {artifact}\n", f"PASS: {Path(artifact)}\n"} else 1)
+PY
+  then
+    echo "FAIL: mixed-client process evidence gate validator stdout contaminated for: ${artifact}" >&2
+    echo "expected stdout: PASS: ${artifact} (or validator Path spelling)" >&2
+    print_prefixed_file "actual stdout" "${validator_stdout}"
+    print_prefixed_file "validator stderr" "${validator_stderr}"
+    rm -f -- "${validator_stdout}" "${validator_stderr}"
+    return 1
+  fi
+
+  print_prefixed_file "validator stderr" "${validator_stderr}"
+  rm -f -- "${validator_stdout}" "${validator_stderr}"
+
+  if ! gate_error="$(python3 - "${artifact}" 2>&1 <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+with open(path, encoding="utf-8") as f:
+    data = json.load(f)
+
+
+def fail(message: str) -> None:
+    print(message, file=sys.stderr)
+    sys.exit(1)
+
+
+if data.get("evidence_type") != "mixed_client_process_soak":
+    fail(
+        "evidence_type is not mixed_client_process_soak: "
+        f"{data.get('evidence_type')!r}"
+    )
+if data.get("verdict") != "PASS":
+    fail(
+        "verdict is not PASS; mixed-client process gate rejects "
+        f"{data.get('verdict')!r} evidence"
+    )
+if "failure_reason" in data:
+    fail("failure_reason is not allowed on PASS mixed-client process evidence")
+
+participants = data.get("participants")
+tx_path = data.get("tx_path")
+if not isinstance(participants, list) or not isinstance(tx_path, dict):
+    fail("schema floor unexpectedly allowed missing participants or tx_path")
+
+by_name = {p["name"]: p for p in participants}
+submitted_at = tx_path.get("submitted_at")
+observed_at = tx_path.get("observed_at")
+if not isinstance(submitted_at, str) or not isinstance(observed_at, list):
+    fail("schema floor unexpectedly allowed malformed tx_path references")
+
+missing_process_fields = []
+for participant in participants:
+    missing = [
+        field for field in ("endpoint", "started_at") if not participant.get(field)
+    ]
+    if missing:
+        missing_process_fields.append(
+            f"{participant['name']} missing {','.join(missing)}"
+        )
+
+if missing_process_fields:
+    fail(
+        "participant lacks real process evidence: "
+        + "; ".join(missing_process_fields)
+    )
+
+endpoint_owner = {}
+for participant in participants:
+    endpoint = participant["endpoint"]
+    previous = endpoint_owner.setdefault(endpoint, participant["name"])
+    if previous != participant["name"]:
+        fail(
+            "duplicate participant endpoint in PASS mixed-client process evidence: "
+            f"{endpoint!r} used by {previous!r} and {participant['name']!r}"
+        )
+
+referenced = [submitted_at, *observed_at]
+for name in referenced:
+    participant = by_name.get(name)
+    if participant is None:
+        fail(f"tx_path references undeclared participant: {name!r}")
+
+impls = {by_name[name]["implementation"] for name in referenced}
+if not {"go", "rust"} <= impls:
+    fail(
+        "tx_path does not reference both Go and Rust process participants; "
+        f"referenced implementations={sorted(impls)}"
+    )
+PY
+)"; then
+    echo "FAIL: mixed-client process evidence gate rejected artifact: ${artifact}" >&2
+    printf '%s\n' "${gate_error}" >&2
+    return 1
+  fi
+
+  echo "PASS: mixed-client process evidence gate accepted ${artifact}"
+}
+
+if [[ "${CHECK_EVIDENCE_MODE}" == "1" ]]; then
+  check_mixed_client_pass_evidence "${CHECK_EVIDENCE}"
+  exit 0
+fi
+
+command -v perl >/dev/null 2>&1 || {
+  echo "perl is required for Rust binary soak skeleton" >&2
+  exit 1
+}
 
 # shellcheck source=scripts/devnet-process-common.sh disable=SC1091
 source "${HELPER}"
@@ -97,22 +270,7 @@ echo "Building Rust rubin-node binary"
 # is to prove a real-process launch end-to-end on every run.
 CARGO_TARGET_DIR_LOCAL="${RUBIN_PROCESS_ARTIFACT_ROOT}/cargo-target"
 CARGO_BUILD_LOG="${RUBIN_PROCESS_ARTIFACT_ROOT}/cargo-build.jsonl"
-run_fips_preflight_before_captured_dev_env() {
-  if [[ "${RUBIN_OPENSSL_FIPS_MODE:-off}" != "only" ]]; then
-    return 0
-  fi
-  if [[ "${RUBIN_OPENSSL_SKIP_FIPS_GUARD:-0}" == "1" ]]; then
-    return 0
-  fi
-
-  echo "Running FIPS-only preflight before captured dev-env command streams" >&2
-  "${DEV_ENV}" -- "${REPO_ROOT}/scripts/crypto/openssl/fips-preflight.sh" >&2
-}
-
 run_fips_preflight_before_captured_dev_env
-run_validator() {
-  RUBIN_OPENSSL_SKIP_FIPS_GUARD=1 "${DEV_ENV}" -- python3 "${VALIDATOR}" "$@"
-}
 
 # Force the host triple as the build target (PR #1510 wave-N+1 codex
 # finding "Force host target before executing rubin-node"): without an

--- a/scripts/devnet/test_rust_skeleton_fixtures.sh
+++ b/scripts/devnet/test_rust_skeleton_fixtures.sh
@@ -1,29 +1,36 @@
 #!/usr/bin/env bash
-# test_rust_skeleton_fixtures.sh — RUB-27 fixture accept/reject test.
+# test_rust_skeleton_fixtures.sh — RUB-27 fixtures plus RUB-25 gate tests.
 #
-# Wires the committed Rust skeleton fixtures as test consumers, proving
-# the RUB-27 acceptance criterion "RUB-24 schema validator accepts the
-# valid skeleton artifact and rejects helper-only artifact" via the
-# committed validator (scripts/devnet/validate_mixed_client_evidence.py).
+# Wires the committed Rust skeleton fixtures to the RUB-24 validator
+# and exercises the RUB-25 mixed-client process evidence gate through
+# fixture-driven pass/fail boundaries.
 #
-# Without this script the two committed fixtures would have no in-repo
-# consumer; the harness only validates its own runtime-emitted artifact,
-# not the committed fixture pair. This script anchors the acceptance
-# claim to a reproducible exit-code + cross-field-message contract.
+# This does not prove live Go/Rust runtime behavior; it anchors schema
+# and shell-gate acceptance claims to reproducible fixture exit codes.
 
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 DEV_ENV="${REPO_ROOT}/scripts/dev-env.sh"
 VALIDATOR="${REPO_ROOT}/scripts/devnet/validate_mixed_client_evidence.py"
+GATE_SCRIPT="${REPO_ROOT}/scripts/devnet-rust-binary-soak.sh"
 VALID_FIXTURE="${REPO_ROOT}/scripts/devnet/testdata/rust_skeleton_fail_evidence_valid.json"
 REJECTED_FIXTURE="${REPO_ROOT}/scripts/devnet/testdata/rust_skeleton_helper_only_rejected.json"
+VALID_MIXED_FIXTURE="${REPO_ROOT}/scripts/devnet/testdata/valid_process_mixed.json"
 
 command -v python3 >/dev/null 2>&1 || { echo "python3 is required" >&2; exit 1; }
 [[ -x "${DEV_ENV}" ]] || { echo "dev-env wrapper missing or non-executable: ${DEV_ENV}" >&2; exit 1; }
 [[ -r "${VALIDATOR}" ]] || { echo "validator unreadable: ${VALIDATOR}" >&2; exit 1; }
+[[ -x "${GATE_SCRIPT}" ]] || { echo "gate script missing or non-executable: ${GATE_SCRIPT}" >&2; exit 1; }
 [[ -r "${VALID_FIXTURE}" ]] || { echo "valid fixture unreadable: ${VALID_FIXTURE}" >&2; exit 1; }
 [[ -r "${REJECTED_FIXTURE}" ]] || { echo "rejected fixture unreadable: ${REJECTED_FIXTURE}" >&2; exit 1; }
+[[ -r "${VALID_MIXED_FIXTURE}" ]] || { echo "valid mixed fixture unreadable: ${VALID_MIXED_FIXTURE}" >&2; exit 1; }
+
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/rubin-rust-skeleton-fixtures.XXXXXX")"
+cleanup() {
+  rm -rf -- "${TMP_ROOT}"
+}
+trap cleanup EXIT
 
 run_fips_preflight_before_captured_dev_env() {
   if [[ "${RUBIN_OPENSSL_FIPS_MODE:-off}" != "only" ]]; then
@@ -39,6 +46,135 @@ run_fips_preflight_before_captured_dev_env() {
 
 run_validator() {
   RUBIN_OPENSSL_SKIP_FIPS_GUARD=1 "${DEV_ENV}" -- python3 "${VALIDATOR}" "$@"
+}
+
+run_gate() {
+  "${GATE_SCRIPT}" --check-evidence "$@"
+}
+
+require_output_contains() {
+  local output="$1" needle="$2" label="$3"
+  if [[ "${output}" != *"${needle}"* ]]; then
+    echo "FAIL: ${label} missing expected text: ${needle}" >&2
+    echo "actual output:" >&2
+    printf '%s\n' "${output}" >&2
+    exit 1
+  fi
+}
+
+expect_gate_pass() {
+  local fixture="$1" label="$2" output
+  if ! output="$(run_gate "${fixture}" 2>&1)"; then
+    echo "FAIL: ${label} should pass mixed-client gate" >&2
+    echo "actual output:" >&2
+    printf '%s\n' "${output}" >&2
+    exit 1
+  fi
+  require_output_contains "${output}" "PASS: mixed-client process evidence gate accepted ${fixture}" "${label}"
+}
+
+expect_gate_fail() {
+  local fixture="$1" label="$2" needle="$3" output
+  if output="$(run_gate "${fixture}" 2>&1)"; then
+    echo "FAIL: ${label} should fail mixed-client gate" >&2
+    echo "actual output:" >&2
+    printf '%s\n' "${output}" >&2
+    exit 1
+  fi
+  require_output_contains "${output}" "${needle}" "${label}"
+}
+
+write_same_client_fixture() {
+  local path="$1"
+  cat >"${path}" <<'JSON'
+{
+  "schema_version": "rubin-mixed-client-devnet-evidence-v1",
+  "evidence_type": "mixed_client_process_soak",
+  "scenario": "same_client_selected_path_with_unselected_rust",
+  "verdict": "PASS",
+  "participants": [
+    {
+      "name": "node-go-a",
+      "implementation": "go",
+      "endpoint": "127.0.0.1:41001",
+      "started_at": "2026-05-09T10:00:00Z"
+    },
+    {
+      "name": "node-go-b",
+      "implementation": "go",
+      "endpoint": "127.0.0.1:41002",
+      "started_at": "2026-05-09T10:00:01Z"
+    },
+    {
+      "name": "node-rust",
+      "implementation": "rust",
+      "endpoint": "127.0.0.1:41003",
+      "started_at": "2026-05-09T10:00:02Z"
+    }
+  ],
+  "tx_path": {
+    "submitted_at": "node-go-a",
+    "observed_at": ["node-go-b"],
+    "tx_id": "5555555555555555555555555555555555555555555555555555555555555555"
+  }
+}
+JSON
+}
+
+write_stdout_contaminated_fixture() {
+  local path="$1"
+  {
+    printf '%s\n' "dev-env banner on stdout"
+    cat "${VALID_MIXED_FIXTURE}"
+  } >"${path}"
+}
+
+write_unselected_helper_fixture() {
+  local path="$1"
+  cat >"${path}" <<'JSON'
+{
+  "schema_version": "rubin-mixed-client-devnet-evidence-v1",
+  "evidence_type": "mixed_client_process_soak",
+  "scenario": "selected_mixed_with_unselected_helper",
+  "verdict": "PASS",
+  "participants": [
+    {"name": "node-go", "implementation": "go", "endpoint": "127.0.0.1:41001", "started_at": "2026-05-09T10:00:00Z"},
+    {"name": "node-rust", "implementation": "rust", "endpoint": "127.0.0.1:41002", "started_at": "2026-05-09T10:00:01Z"},
+    {"name": "node-rust-helper", "implementation": "rust"}
+  ],
+  "tx_path": {"submitted_at": "node-go", "observed_at": ["node-rust"], "tx_id": "6666666666666666666666666666666666666666666666666666666666666666"}
+}
+JSON
+}
+
+write_repair2_fixtures() {
+  local selected_dup="$1" unselected_dup="$2" pass_failure_reason="$3"
+  python3 - "${VALID_MIXED_FIXTURE}" "${selected_dup}" "${unselected_dup}" "${pass_failure_reason}" <<'PY'
+import copy, json, sys
+
+src, selected_dup, unselected_dup, pass_failure_reason = sys.argv[1:5]
+with open(src, encoding="utf-8") as f:
+    base = json.load(f)
+selected = copy.deepcopy(base)
+selected["participants"][1]["endpoint"] = selected["participants"][0]["endpoint"]
+unselected = copy.deepcopy(base)
+unselected["participants"].append({
+    "name": "node-go-shadow",
+    "implementation": "go",
+    "endpoint": base["participants"][0]["endpoint"],
+    "started_at": "2026-05-09T10:00:02Z",
+})
+contradictory = copy.deepcopy(base)
+contradictory["failure_reason"] = "no data should not pass"
+for path, data in (
+    (selected_dup, selected),
+    (unselected_dup, unselected),
+    (pass_failure_reason, contradictory),
+):
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, sort_keys=True)
+        f.write("\n")
+PY
 }
 
 run_fips_preflight_before_captured_dev_env
@@ -86,4 +222,46 @@ for needle in \
   fi
 done
 
-echo "PASS: rust skeleton fixtures accept/reject pair confirmed"
+echo "test_rust_skeleton_fixtures: mixed-client gate must pass valid process fixture"
+expect_gate_pass "${VALID_MIXED_FIXTURE}" "valid mixed process fixture"
+
+SPACE_DIR="${TMP_ROOT}/path with spaces [rubin]"
+mkdir -p -- "${SPACE_DIR}"
+SPACE_FIXTURE="${SPACE_DIR}/valid mixed process.json"
+cp "${VALID_MIXED_FIXTURE}" "${SPACE_FIXTURE}"
+expect_gate_pass "${SPACE_FIXTURE}" "valid mixed process fixture path with spaces"
+
+echo "test_rust_skeleton_fixtures: mixed-client gate must fail closed on boundary fixtures"
+MISSING_FIXTURE="${TMP_ROOT}/missing-mixed.json"
+EMPTY_FIXTURE="${TMP_ROOT}/empty-mixed.json"
+WRONG_ROOT_FIXTURE="${TMP_ROOT}/wrong-root-mixed.json"
+MALFORMED_FIXTURE="${TMP_ROOT}/malformed-mixed.json"
+STDOUT_CONTAMINATED_FIXTURE="${TMP_ROOT}/stdout-contaminated-mixed.json"
+SAME_CLIENT_FIXTURE="${TMP_ROOT}/same-client-mixed.json"
+UNSELECTED_HELPER_FIXTURE="${TMP_ROOT}/unselected-helper-mixed.json"
+SELECTED_DUP_ENDPOINT_FIXTURE="${TMP_ROOT}/selected-duplicate-endpoint-mixed.json"
+UNSELECTED_DUP_ENDPOINT_FIXTURE="${TMP_ROOT}/unselected-duplicate-endpoint-mixed.json"
+PASS_FAILURE_REASON_FIXTURE="${TMP_ROOT}/pass-failure-reason-mixed.json"
+touch "${EMPTY_FIXTURE}"
+printf '%s\n' '[]' >"${WRONG_ROOT_FIXTURE}"
+printf '%s\n' '{"schema_version":"rubin-mixed-client-devnet-evidence-v1"}' '{"extra":"ndjson"}' >"${MALFORMED_FIXTURE}"
+write_stdout_contaminated_fixture "${STDOUT_CONTAMINATED_FIXTURE}"
+write_same_client_fixture "${SAME_CLIENT_FIXTURE}"
+write_unselected_helper_fixture "${UNSELECTED_HELPER_FIXTURE}"
+write_repair2_fixtures "${SELECTED_DUP_ENDPOINT_FIXTURE}" "${UNSELECTED_DUP_ENDPOINT_FIXTURE}" "${PASS_FAILURE_REASON_FIXTURE}"
+
+expect_gate_fail "${MISSING_FIXTURE}" "missing artifact" "artifact not found or not a regular file"
+expect_gate_fail "" "empty --check-evidence argument" "artifact path is required"
+expect_gate_fail "${EMPTY_FIXTURE}" "empty artifact" "artifact empty"
+expect_gate_fail "${MALFORMED_FIXTURE}" "malformed artifact" "validator rejected artifact"
+expect_gate_fail "${WRONG_ROOT_FIXTURE}" "wrong root artifact" "validator rejected artifact"
+expect_gate_fail "${STDOUT_CONTAMINATED_FIXTURE}" "stdout-contaminated artifact" "validator rejected artifact"
+expect_gate_fail "${REJECTED_FIXTURE}" "helper-only artifact" "validator rejected artifact"
+expect_gate_fail "${VALID_FIXTURE}" "no-data/failure artifact" "verdict is not PASS"
+expect_gate_fail "${SAME_CLIENT_FIXTURE}" "same-client selected path" "requires observer implementation to differ"
+expect_gate_fail "${UNSELECTED_HELPER_FIXTURE}" "unselected helper-only participant" "participant lacks real process evidence"
+expect_gate_fail "${SELECTED_DUP_ENDPOINT_FIXTURE}" "selected duplicate endpoint" "duplicate participant endpoint"
+expect_gate_fail "${UNSELECTED_DUP_ENDPOINT_FIXTURE}" "unselected duplicate endpoint" "duplicate participant endpoint"
+expect_gate_fail "${PASS_FAILURE_REASON_FIXTURE}" "PASS with failure_reason" "failure_reason is not allowed"
+
+echo "PASS: rust skeleton fixtures and mixed-client gate boundaries confirmed"

--- a/scripts/devnet/test_rust_skeleton_fixtures.sh
+++ b/scripts/devnet/test_rust_skeleton_fixtures.sh
@@ -1,29 +1,36 @@
 #!/usr/bin/env bash
-# test_rust_skeleton_fixtures.sh — RUB-27 fixture accept/reject test.
+# test_rust_skeleton_fixtures.sh — RUB-27 fixtures plus RUB-25 gate tests.
 #
-# Wires the committed Rust skeleton fixtures as test consumers, proving
-# the RUB-27 acceptance criterion "RUB-24 schema validator accepts the
-# valid skeleton artifact and rejects helper-only artifact" via the
-# committed validator (scripts/devnet/validate_mixed_client_evidence.py).
+# Wires the committed Rust skeleton fixtures to the RUB-24 validator
+# and exercises the RUB-25 mixed-client process evidence gate through
+# fixture-driven pass/fail boundaries.
 #
-# Without this script the two committed fixtures would have no in-repo
-# consumer; the harness only validates its own runtime-emitted artifact,
-# not the committed fixture pair. This script anchors the acceptance
-# claim to a reproducible exit-code + cross-field-message contract.
+# This does not prove live Go/Rust runtime behavior; it anchors schema
+# and shell-gate acceptance claims to reproducible fixture exit codes.
 
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 DEV_ENV="${REPO_ROOT}/scripts/dev-env.sh"
 VALIDATOR="${REPO_ROOT}/scripts/devnet/validate_mixed_client_evidence.py"
+GATE_SCRIPT="${REPO_ROOT}/scripts/devnet-rust-binary-soak.sh"
 VALID_FIXTURE="${REPO_ROOT}/scripts/devnet/testdata/rust_skeleton_fail_evidence_valid.json"
 REJECTED_FIXTURE="${REPO_ROOT}/scripts/devnet/testdata/rust_skeleton_helper_only_rejected.json"
+VALID_MIXED_FIXTURE="${REPO_ROOT}/scripts/devnet/testdata/valid_process_mixed.json"
 
 command -v python3 >/dev/null 2>&1 || { echo "python3 is required" >&2; exit 1; }
 [[ -x "${DEV_ENV}" ]] || { echo "dev-env wrapper missing or non-executable: ${DEV_ENV}" >&2; exit 1; }
 [[ -r "${VALIDATOR}" ]] || { echo "validator unreadable: ${VALIDATOR}" >&2; exit 1; }
+[[ -x "${GATE_SCRIPT}" ]] || { echo "gate script missing or non-executable: ${GATE_SCRIPT}" >&2; exit 1; }
 [[ -r "${VALID_FIXTURE}" ]] || { echo "valid fixture unreadable: ${VALID_FIXTURE}" >&2; exit 1; }
 [[ -r "${REJECTED_FIXTURE}" ]] || { echo "rejected fixture unreadable: ${REJECTED_FIXTURE}" >&2; exit 1; }
+[[ -r "${VALID_MIXED_FIXTURE}" ]] || { echo "valid mixed fixture unreadable: ${VALID_MIXED_FIXTURE}" >&2; exit 1; }
+
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/rubin-rust-skeleton-fixtures.XXXXXX")"
+cleanup() {
+  rm -rf -- "${TMP_ROOT}"
+}
+trap cleanup EXIT
 
 run_fips_preflight_before_captured_dev_env() {
   if [[ "${RUBIN_OPENSSL_FIPS_MODE:-off}" != "only" ]]; then
@@ -39,6 +46,135 @@ run_fips_preflight_before_captured_dev_env() {
 
 run_validator() {
   RUBIN_OPENSSL_SKIP_FIPS_GUARD=1 "${DEV_ENV}" -- python3 "${VALIDATOR}" "$@"
+}
+
+run_gate() {
+  "${GATE_SCRIPT}" --check-evidence "$@"
+}
+
+require_output_contains() {
+  local output="$1" needle="$2" label="$3"
+  if [[ "${output}" != *"${needle}"* ]]; then
+    echo "FAIL: ${label} missing expected text: ${needle}" >&2
+    echo "actual output:" >&2
+    printf '%s\n' "${output}" >&2
+    exit 1
+  fi
+}
+
+expect_gate_pass() {
+  local fixture="$1" label="$2" output
+  if ! output="$(run_gate "${fixture}" 2>&1)"; then
+    echo "FAIL: ${label} should pass mixed-client gate" >&2
+    echo "actual output:" >&2
+    printf '%s\n' "${output}" >&2
+    exit 1
+  fi
+  require_output_contains "${output}" "PASS: mixed-client process evidence gate accepted ${fixture}" "${label}"
+}
+
+expect_gate_fail() {
+  local fixture="$1" label="$2" needle="$3" output
+  if output="$(run_gate "${fixture}" 2>&1)"; then
+    echo "FAIL: ${label} should fail mixed-client gate" >&2
+    echo "actual output:" >&2
+    printf '%s\n' "${output}" >&2
+    exit 1
+  fi
+  require_output_contains "${output}" "${needle}" "${label}"
+}
+
+write_same_client_fixture() {
+  local path="$1"
+  cat >"${path}" <<'JSON'
+{
+  "schema_version": "rubin-mixed-client-devnet-evidence-v1",
+  "evidence_type": "mixed_client_process_soak",
+  "scenario": "same_client_selected_path_with_unselected_rust",
+  "verdict": "PASS",
+  "participants": [
+    {
+      "name": "node-go-a",
+      "implementation": "go",
+      "endpoint": "127.0.0.1:41001",
+      "started_at": "2026-05-09T10:00:00Z"
+    },
+    {
+      "name": "node-go-b",
+      "implementation": "go",
+      "endpoint": "127.0.0.1:41002",
+      "started_at": "2026-05-09T10:00:01Z"
+    },
+    {
+      "name": "node-rust",
+      "implementation": "rust",
+      "endpoint": "127.0.0.1:41003",
+      "started_at": "2026-05-09T10:00:02Z"
+    }
+  ],
+  "tx_path": {
+    "submitted_at": "node-go-a",
+    "observed_at": ["node-go-b"],
+    "tx_id": "5555555555555555555555555555555555555555555555555555555555555555"
+  }
+}
+JSON
+}
+
+write_stdout_contaminated_fixture() {
+  local path="$1"
+  {
+    printf '%s\n' "dev-env banner on stdout"
+    cat "${VALID_MIXED_FIXTURE}"
+  } >"${path}"
+}
+
+write_unselected_helper_fixture() {
+  local path="$1"
+  cat >"${path}" <<'JSON'
+{
+  "schema_version": "rubin-mixed-client-devnet-evidence-v1",
+  "evidence_type": "mixed_client_process_soak",
+  "scenario": "selected_mixed_with_unselected_helper",
+  "verdict": "PASS",
+  "participants": [
+    {"name": "node-go", "implementation": "go", "endpoint": "127.0.0.1:41001", "started_at": "2026-05-09T10:00:00Z"},
+    {"name": "node-rust", "implementation": "rust", "endpoint": "127.0.0.1:41002", "started_at": "2026-05-09T10:00:01Z"},
+    {"name": "node-rust-helper", "implementation": "rust"}
+  ],
+  "tx_path": {"submitted_at": "node-go", "observed_at": ["node-rust"], "tx_id": "6666666666666666666666666666666666666666666666666666666666666666"}
+}
+JSON
+}
+
+write_repair2_fixtures() {
+  local selected_dup="$1" unselected_dup="$2" pass_failure_reason="$3"
+  python3 - "${VALID_MIXED_FIXTURE}" "${selected_dup}" "${unselected_dup}" "${pass_failure_reason}" <<'PY'
+import copy, json, sys
+
+src, selected_dup, unselected_dup, pass_failure_reason = sys.argv[1:5]
+with open(src, encoding="utf-8") as f:
+    base = json.load(f)
+selected = copy.deepcopy(base)
+selected["participants"][1]["endpoint"] = selected["participants"][0]["endpoint"]
+unselected = copy.deepcopy(base)
+unselected["participants"].append({
+    "name": "node-go-shadow",
+    "implementation": "go",
+    "endpoint": base["participants"][0]["endpoint"],
+    "started_at": "2026-05-09T10:00:02Z",
+})
+contradictory = copy.deepcopy(base)
+contradictory["failure_reason"] = "no data should not pass"
+for path, data in (
+    (selected_dup, selected),
+    (unselected_dup, unselected),
+    (pass_failure_reason, contradictory),
+):
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, sort_keys=True)
+        f.write("\n")
+PY
 }
 
 run_fips_preflight_before_captured_dev_env
@@ -86,4 +222,47 @@ for needle in \
   fi
 done
 
-echo "PASS: rust skeleton fixtures accept/reject pair confirmed"
+echo "test_rust_skeleton_fixtures: mixed-client gate must pass valid process fixture"
+expect_gate_pass "${VALID_MIXED_FIXTURE}" "valid mixed process fixture"
+(cd "${REPO_ROOT}" && expect_gate_pass "./scripts/devnet/testdata/valid_process_mixed.json" "valid mixed process fixture with ./ spelling")
+
+SPACE_DIR="${TMP_ROOT}/path with spaces [rubin]"
+mkdir -p -- "${SPACE_DIR}"
+SPACE_FIXTURE="${SPACE_DIR}/valid mixed process.json"
+cp "${VALID_MIXED_FIXTURE}" "${SPACE_FIXTURE}"
+expect_gate_pass "${SPACE_FIXTURE}" "valid mixed process fixture path with spaces"
+
+echo "test_rust_skeleton_fixtures: mixed-client gate must fail closed on boundary fixtures"
+MISSING_FIXTURE="${TMP_ROOT}/missing-mixed.json"
+EMPTY_FIXTURE="${TMP_ROOT}/empty-mixed.json"
+WRONG_ROOT_FIXTURE="${TMP_ROOT}/wrong-root-mixed.json"
+MALFORMED_FIXTURE="${TMP_ROOT}/malformed-mixed.json"
+STDOUT_CONTAMINATED_FIXTURE="${TMP_ROOT}/stdout-contaminated-mixed.json"
+SAME_CLIENT_FIXTURE="${TMP_ROOT}/same-client-mixed.json"
+UNSELECTED_HELPER_FIXTURE="${TMP_ROOT}/unselected-helper-mixed.json"
+SELECTED_DUP_ENDPOINT_FIXTURE="${TMP_ROOT}/selected-duplicate-endpoint-mixed.json"
+UNSELECTED_DUP_ENDPOINT_FIXTURE="${TMP_ROOT}/unselected-duplicate-endpoint-mixed.json"
+PASS_FAILURE_REASON_FIXTURE="${TMP_ROOT}/pass-failure-reason-mixed.json"
+touch "${EMPTY_FIXTURE}"
+printf '%s\n' '[]' >"${WRONG_ROOT_FIXTURE}"
+printf '%s\n' '{"schema_version":"rubin-mixed-client-devnet-evidence-v1"}' '{"extra":"ndjson"}' >"${MALFORMED_FIXTURE}"
+write_stdout_contaminated_fixture "${STDOUT_CONTAMINATED_FIXTURE}"
+write_same_client_fixture "${SAME_CLIENT_FIXTURE}"
+write_unselected_helper_fixture "${UNSELECTED_HELPER_FIXTURE}"
+write_repair2_fixtures "${SELECTED_DUP_ENDPOINT_FIXTURE}" "${UNSELECTED_DUP_ENDPOINT_FIXTURE}" "${PASS_FAILURE_REASON_FIXTURE}"
+
+expect_gate_fail "${MISSING_FIXTURE}" "missing artifact" "artifact not found or not a regular file"
+expect_gate_fail "" "empty --check-evidence argument" "artifact path is required"
+expect_gate_fail "${EMPTY_FIXTURE}" "empty artifact" "artifact empty"
+expect_gate_fail "${MALFORMED_FIXTURE}" "malformed artifact" "validator rejected artifact"
+expect_gate_fail "${WRONG_ROOT_FIXTURE}" "wrong root artifact" "validator rejected artifact"
+expect_gate_fail "${STDOUT_CONTAMINATED_FIXTURE}" "stdout-contaminated artifact" "validator rejected artifact"
+expect_gate_fail "${REJECTED_FIXTURE}" "helper-only artifact" "validator rejected artifact"
+expect_gate_fail "${VALID_FIXTURE}" "no-data/failure artifact" "verdict is not PASS"
+expect_gate_fail "${SAME_CLIENT_FIXTURE}" "same-client selected path" "requires observer implementation to differ"
+expect_gate_fail "${UNSELECTED_HELPER_FIXTURE}" "unselected helper-only participant" "participant lacks real process evidence"
+expect_gate_fail "${SELECTED_DUP_ENDPOINT_FIXTURE}" "selected duplicate endpoint" "duplicate participant endpoint"
+expect_gate_fail "${UNSELECTED_DUP_ENDPOINT_FIXTURE}" "unselected duplicate endpoint" "duplicate participant endpoint"
+expect_gate_fail "${PASS_FAILURE_REASON_FIXTURE}" "PASS with failure_reason" "failure_reason is not allowed"
+
+echo "PASS: rust skeleton fixtures and mixed-client gate boundaries confirmed"

--- a/scripts/devnet/testdata/valid_process_mixed.json
+++ b/scripts/devnet/testdata/valid_process_mixed.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": "rubin-mixed-client-devnet-evidence-v1",
+  "evidence_type": "mixed_client_process_soak",
+  "scenario": "process_mixed_go_to_rust_propagation",
+  "verdict": "PASS",
+  "participants": [
+    {
+      "name": "node-go",
+      "implementation": "go",
+      "endpoint": "127.0.0.1:41001",
+      "started_at": "2026-05-09T10:00:00Z"
+    },
+    {
+      "name": "node-rust",
+      "implementation": "rust",
+      "endpoint": "127.0.0.1:41002",
+      "started_at": "2026-05-09T10:00:01Z"
+    }
+  ],
+  "tx_path": {
+    "submitted_at": "node-go",
+    "observed_at": ["node-rust"],
+    "tx_id": "4444444444444444444444444444444444444444444444444444444444444444"
+  }
+}


### PR DESCRIPTION
Issue: RUB-25 / #1227

Invariant: mixed-client process soak evidence must fail closed. Missing, empty, malformed, helper-only, same-client, no-data-as-pass, duplicate-endpoint, and stdout-contaminated artifacts cannot pass as mixed-client evidence.

Changed surface:
- scripts/devnet-rust-binary-soak.sh
- scripts/devnet/test_rust_skeleton_fixtures.sh
- scripts/devnet/testdata/valid_process_mixed.json

Non-scope:
- no Go/Rust runtime changes
- no schema or validator contract change
- no CI policy change
- no full live soak claim

Validation:
- bash -n changed shell scripts
- shellcheck changed shell scripts
- bash scripts/devnet/test_rust_skeleton_fixtures.sh
- python3 scripts/devnet/validate_mixed_client_evidence.py scripts/devnet/testdata/valid_minimal_mixed.json
- scripts/devnet-rust-binary-soak.sh --check-evidence scripts/devnet/testdata/valid_process_mixed.json
- git diff --check
- rubin-push PASS
- stable hostile reviewer PASS on 7f50cde

Slice note: 450 added+deleted LOC, within the approved soft cap for one atomic shell/evidence slice.


<!-- rubin-agent-meta actor=unknown action=pr-create via=cl branch=codex/rub-25-process-soak-gate wt=rubin-protocol-codex-rub-25 utc=2026-05-09T23:35:18Z -->
