### PR TITLE
[RUB-33] Expose Rust reorg observability counters

### DIFF
--- a/clients/rust/crates/rubin-node/src/devnet_rpc.rs
+++ b/clients/rust/crates/rubin-node/src/devnet_rpc.rs
@@ -1894,23 +1894,33 @@ fn handle_metrics(state: &DevnetRPCState, method: &str) -> HttpResponse {
 }
 
 fn render_prometheus_metrics(state: &DevnetRPCState) -> String {
-    let (tip_height, best_known_height, in_ibd, pv_lines) = match state.sync_engine.lock() {
-        Ok(engine) => {
-            let tip_height = match engine.tip() {
-                Ok(Some((height, _))) => height,
-                _ => 0,
-            };
-            let best_known_height = engine.best_known_height();
-            let in_ibd = if engine.is_in_ibd((state.now_unix)()) {
-                1
-            } else {
-                0
-            };
-            let pv_lines = engine.pv_telemetry_snapshot().prometheus_lines();
-            (tip_height, best_known_height, in_ibd, pv_lines)
-        }
-        Err(_) => (0, 0, 1, Vec::new()),
-    };
+    let (tip_height, best_known_height, in_ibd, reorg_count, last_reorg_depth, pv_lines) =
+        match state.sync_engine.lock() {
+            Ok(engine) => {
+                let tip_height = match engine.tip() {
+                    Ok(Some((height, _))) => height,
+                    _ => 0,
+                };
+                let best_known_height = engine.best_known_height();
+                let in_ibd = if engine.is_in_ibd((state.now_unix)()) {
+                    1
+                } else {
+                    0
+                };
+                let reorg_count = engine.reorg_count();
+                let last_reorg_depth = engine.last_reorg_depth();
+                let pv_lines = engine.pv_telemetry_snapshot().prometheus_lines();
+                (
+                    tip_height,
+                    best_known_height,
+                    in_ibd,
+                    reorg_count,
+                    last_reorg_depth,
+                    pv_lines,
+                )
+            }
+            Err(_) => (0, 0, 1, 0, 0, Vec::new()),
+        };
     let mempool_txs = match state.tx_pool.lock() {
         Ok(pool) => pool.len() as u64,
         Err(_) => 0,
@@ -1930,6 +1940,14 @@ fn render_prometheus_metrics(state: &DevnetRPCState) -> String {
             .to_string(),
         "# TYPE rubin_node_in_ibd gauge".to_string(),
         format!("rubin_node_in_ibd {in_ibd}"),
+        "# HELP rubin_node_reorg_total Total canonical reorg events observed by the sync engine."
+            .to_string(),
+        "# TYPE rubin_node_reorg_total counter".to_string(),
+        format!("rubin_node_reorg_total {reorg_count}"),
+        "# HELP rubin_node_last_reorg_depth Depth of the most recent canonical reorg, or 0 when no reorg depth is currently recorded."
+            .to_string(),
+        "# TYPE rubin_node_last_reorg_depth gauge".to_string(),
+        format!("rubin_node_last_reorg_depth {last_reorg_depth}"),
         "# HELP rubin_node_peer_count Currently tracked peers.".to_string(),
         "# TYPE rubin_node_peer_count gauge".to_string(),
         format!("rubin_node_peer_count {peer_count}"),
@@ -2684,12 +2702,15 @@ mod tests {
     use std::sync::{Arc, Mutex};
     use std::time::{Duration, Instant};
 
-    use rubin_consensus::{parse_tx, Outpoint, UtxoEntry};
+    use rubin_consensus::{block_hash, parse_tx, Outpoint, UtxoEntry};
     use serde_json::Value;
 
     use crate::io_utils::unique_temp_path;
     use crate::p2p_runtime::{PeerState, VersionPayloadV1};
-    use crate::test_helpers::signed_conflicting_p2pk_state_and_txs;
+    use crate::test_helpers::{
+        coinbase_only_block, coinbase_only_block_with_gen, genesis_info,
+        signed_conflicting_p2pk_state_and_txs,
+    };
     use crate::txpool::TxSource;
     use crate::{
         block_store_path, default_peer_runtime_config, default_sync_config,
@@ -4814,6 +4835,8 @@ mod tests {
             "rubin_node_tip_height",
             "rubin_node_best_known_height",
             "rubin_node_in_ibd",
+            "rubin_node_reorg_total",
+            "rubin_node_last_reorg_depth",
             "rubin_node_peer_count",
             "rubin_node_mempool_txs",
             "rubin_node_rpc_requests_total",
@@ -4856,6 +4879,95 @@ mod tests {
         assert!(body.contains(r#"rubin_node_rpc_requests_total{route="/get_tip",status="200"} 1"#));
         assert!(body.contains(r#"rubin_node_submit_tx_total{result="rejected"} 1"#));
         assert!(body.contains(r#"rubin_pv_mode{mode="off"} 1"#));
+        assert!(body.contains("rubin_node_reorg_total 0"), "{body}");
+        assert!(body.contains("rubin_node_last_reorg_depth 0"), "{body}");
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn metrics_render_exposes_reorg_counters_read_only() {
+        let (state, dir) = build_state(true);
+        let (_genesis, genesis_hash, gen_ts) = genesis_info();
+        let block3;
+
+        {
+            let mut engine = state.sync_engine.lock().expect("sync engine");
+            assert_eq!(engine.reorg_count(), 0);
+            assert_eq!(engine.last_reorg_depth(), 0);
+
+            let block1 = coinbase_only_block(1, genesis_hash, gen_ts + 1);
+            engine
+                .apply_block_with_reorg(&block1, None)
+                .expect("block1 canonical");
+            assert_eq!(engine.reorg_count(), 0);
+            assert_eq!(engine.last_reorg_depth(), 0);
+
+            let block1_alt = coinbase_only_block(1, genesis_hash, gen_ts + 2);
+            let block1_alt_hash = block_hash(&block1_alt[..rubin_consensus::BLOCK_HEADER_BYTES])
+                .expect("block1 alt hash");
+            engine
+                .block_store
+                .as_ref()
+                .expect("blockstore")
+                .store_block(
+                    block1_alt_hash,
+                    &block1_alt[..rubin_consensus::BLOCK_HEADER_BYTES],
+                    &block1_alt,
+                )
+                .expect("store block1 alt");
+
+            let subsidy1 = rubin_consensus::subsidy::block_subsidy(1, 0);
+            let block2_alt = coinbase_only_block_with_gen(2, subsidy1, block1_alt_hash, gen_ts + 3);
+            engine
+                .apply_block_with_reorg(&block2_alt, None)
+                .expect("reorg to heavier branch");
+            assert_eq!(engine.reorg_count(), 1);
+            assert_eq!(engine.last_reorg_depth(), 1);
+
+            let block2_alt_hash = block_hash(&block2_alt[..rubin_consensus::BLOCK_HEADER_BYTES])
+                .expect("block2 alt hash");
+            let subsidy2 = rubin_consensus::subsidy::block_subsidy(2, u128::from(subsidy1));
+            block3 =
+                coinbase_only_block_with_gen(3, subsidy1 + subsidy2, block2_alt_hash, gen_ts + 4);
+        }
+
+        let body1 = render_prometheus_metrics(&state);
+        let body2 = render_prometheus_metrics(&state);
+        for body in [&body1, &body2] {
+            for want in [
+                "# HELP rubin_node_reorg_total Total canonical reorg events observed by the sync engine.",
+                "# TYPE rubin_node_reorg_total counter",
+                "rubin_node_reorg_total 1",
+                "# HELP rubin_node_last_reorg_depth Depth of the most recent canonical reorg, or 0 when no reorg depth is currently recorded.",
+                "# TYPE rubin_node_last_reorg_depth gauge",
+                "rubin_node_last_reorg_depth 1",
+            ] {
+                assert!(body.contains(want), "missing {want:?} in {body}");
+            }
+            assert!(
+                !body.contains("rubin_node_reorg_total{")
+                    && !body.contains("rubin_node_last_reorg_depth{"),
+                "reorg metrics must stay unlabeled; body=\n{body}"
+            );
+        }
+
+        let engine = state.sync_engine.lock().expect("sync engine after render");
+        assert_eq!(engine.reorg_count(), 1);
+        assert_eq!(engine.last_reorg_depth(), 1);
+        drop(engine);
+
+        {
+            let mut engine = state.sync_engine.lock().expect("sync engine direct");
+            engine
+                .apply_block_with_reorg(&block3, None)
+                .expect("direct extension after reorg");
+            assert_eq!(engine.reorg_count(), 1);
+            assert_eq!(engine.last_reorg_depth(), 0);
+        }
+
+        let body3 = render_prometheus_metrics(&state);
+        assert!(body3.contains("rubin_node_reorg_total 1"), "{body3}");
+        assert!(body3.contains("rubin_node_last_reorg_depth 0"), "{body3}");
         fs::remove_dir_all(dir).expect("cleanup");
     }
 

--- a/clients/rust/crates/rubin-node/src/sync.rs
+++ b/clients/rust/crates/rubin-node/src/sync.rs
@@ -478,6 +478,8 @@ pub struct SyncEngine {
     pub(crate) cfg: SyncConfig,
     pub(crate) tip_timestamp: u64,
     pub(crate) best_known_height: u64,
+    last_reorg_depth: u64,
+    reorg_count: u64,
     pv_mode: ParallelValidationMode,
     pv_shadow_max_samples: u64,
     pv_shadow_mismatches: u64,
@@ -503,6 +505,8 @@ pub(crate) struct SyncRollbackState {
     pub canonical_removed_suffix: Option<Vec<String>>,
     pub tip_timestamp: u64,
     pub best_known_height: u64,
+    pub last_reorg_depth: u64,
+    pub reorg_count: u64,
 }
 
 pub fn default_sync_config(
@@ -570,6 +574,8 @@ impl SyncEngine {
             cfg,
             tip_timestamp,
             best_known_height,
+            last_reorg_depth: 0,
+            reorg_count: 0,
             pv_mode,
             pv_shadow_max_samples,
             pv_shadow_mismatches: 0,
@@ -603,6 +609,21 @@ impl SyncEngine {
 
     pub fn best_known_height(&self) -> u64 {
         self.best_known_height
+    }
+
+    pub fn last_reorg_depth(&self) -> u64 {
+        self.last_reorg_depth
+    }
+
+    pub fn reorg_count(&self) -> u64 {
+        self.reorg_count
+    }
+
+    pub(crate) fn note_reorg(&mut self, depth: u64) {
+        self.last_reorg_depth = depth;
+        if depth > 0 {
+            self.reorg_count = self.reorg_count.saturating_add(1);
+        }
     }
 
     pub fn chain_state_snapshot(&self) -> ChainState {
@@ -921,6 +942,9 @@ impl SyncEngine {
         if summary.block_height > self.best_known_height {
             self.best_known_height = summary.block_height;
         }
+        // Direct canonical apply clears the last-depth gauge; successful reorg
+        // reconnects set it again after the whole branch commits.
+        self.last_reorg_depth = 0;
         if pv_active {
             self.pv_telemetry
                 .record_commit_latency(commit_start.elapsed());
@@ -939,6 +963,8 @@ impl SyncEngine {
             canonical_removed_suffix: None,
             tip_timestamp: self.tip_timestamp,
             best_known_height: self.best_known_height,
+            last_reorg_depth: self.last_reorg_depth,
+            reorg_count: self.reorg_count,
         }
     }
 
@@ -958,6 +984,8 @@ impl SyncEngine {
                 .map(|bs| bs.canonical_suffix_from(reorg_base)),
             tip_timestamp: self.tip_timestamp,
             best_known_height: self.best_known_height,
+            last_reorg_depth: self.last_reorg_depth,
+            reorg_count: self.reorg_count,
         }
     }
 
@@ -989,6 +1017,8 @@ impl SyncEngine {
         self.chain_state = rb.chain_state;
         self.tip_timestamp = rb.tip_timestamp;
         self.best_known_height = rb.best_known_height;
+        self.last_reorg_depth = rb.last_reorg_depth;
+        self.reorg_count = rb.reorg_count;
 
         if let Some(path) = self.cfg.chain_state_path.as_ref() {
             if let Err(e) = self.chain_state.save(path) {

--- a/clients/rust/crates/rubin-node/src/sync_reorg.rs
+++ b/clients/rust/crates/rubin-node/src/sync_reorg.rs
@@ -320,6 +320,7 @@ impl SyncEngine {
 
         // Dry-run: preview the disconnect + reconnect on a cloned state.
         let disconnected_blocks = self.prepare_heavier_branch(&branch, common_ancestor_height)?;
+        let reorg_depth = u64::try_from(disconnected_blocks.len()).unwrap_or(u64::MAX);
 
         // Disconnect canonical chain back to the common ancestor.
         if let Err(err) = self.disconnect_canonical_to_ancestor(common_ancestor_height) {
@@ -360,12 +361,12 @@ impl SyncEngine {
             requeue_block_hashes: collect_disconnected_block_hashes(&disconnected_blocks),
         };
 
-        last_summary
-            .map(|summary| ApplyBlockWithReorgOutcome {
-                summary,
-                tx_pool_cleanup: cleanup,
-            })
-            .ok_or_else(|| "reorg branch was empty".into())
+        let summary = last_summary.ok_or_else(|| "reorg branch was empty".to_string())?;
+        self.note_reorg(reorg_depth);
+        Ok(ApplyBlockWithReorgOutcome {
+            summary,
+            tx_pool_cleanup: cleanup,
+        })
     }
 
     /// Dry-run validation: clone chain state, preview disconnect, then
@@ -870,6 +871,8 @@ mod tests {
         // Stored as side chain; canonical tip unchanged.
         assert_eq!(engine.chain_state.height, 1);
         assert_eq!(summary.block_height, 1);
+        assert_eq!(engine.reorg_count(), 0);
+        assert_eq!(engine.last_reorg_depth(), 0);
 
         std::fs::remove_dir_all(&dir).expect("cleanup");
     }
@@ -933,6 +936,20 @@ mod tests {
 
         assert_eq!(engine.chain_state.height, 2);
         assert_eq!(summary.block_height, 2);
+        assert_eq!(engine.reorg_count(), 1);
+        assert_eq!(engine.last_reorg_depth(), 1);
+
+        let block2_alt_hash =
+            rubin_consensus::block_hash(&block2_alt[..rubin_consensus::BLOCK_HEADER_BYTES])
+                .expect("hash2'");
+        let subsidy2 = rubin_consensus::subsidy::block_subsidy(2, u128::from(subsidy1));
+        let block3 =
+            coinbase_only_block_with_gen(3, subsidy1 + subsidy2, block2_alt_hash, gen_ts + 4);
+        engine
+            .apply_block_with_reorg(&block3, None)
+            .expect("direct extension after reorg");
+        assert_eq!(engine.reorg_count(), 1);
+        assert_eq!(engine.last_reorg_depth(), 0);
 
         std::fs::remove_dir_all(&dir).expect("cleanup");
     }


### PR DESCRIPTION
Linear: RUB-33
GitHub issue: Closes #1237

Invariant:
Rust node operator metrics expose reorg_total and last_reorg_depth with Go-aligned semantics, without adding orphan/P2P metrics or changing consensus/policy behavior.

Changed files:
- clients/rust/crates/rubin-node/src/sync.rs
- clients/rust/crates/rubin-node/src/sync_reorg.rs
- clients/rust/crates/rubin-node/src/devnet_rpc.rs

Validation:
- cargo fmt --check --manifest-path clients/rust/Cargo.toml --all
- cargo test --manifest-path clients/rust/Cargo.toml -p rubin-node reorg
- cargo test --manifest-path clients/rust/Cargo.toml -p rubin-node metrics
- cargo test --manifest-path clients/rust/Cargo.toml -p rubin-node
- cargo clippy --manifest-path clients/rust/Cargo.toml -p rubin-node -- -D warnings
- tooling-check --new-only --mode rust-deep
- rubin-precommit-one-review + one stock code-review pass: no findings
- rubin-push: PASS

Non-scope:
- no orphan pool metrics
- no P2P behavior changes
- no schema/report/harness changes
- no consensus or policy changes