### PR TITLE
[RUB-228] Fail-close helper-only partition controls

### DIFF
--- a/scripts/devnet-process-common.sh
+++ b/scripts/devnet-process-common.sh
@@ -370,6 +370,7 @@ rubin_process_register_topology_node() {
 
 rubin_process_register_proxy_link() {
   local source="${1:-}" target="${2:-}" proxy_addr="${3:-}" target_file="${4:-}" target_i target_endpoint
+  _rubin_process_require_init || return 1
   _rubin_process_node_index "${source}" >/dev/null || { _rubin_process_error "NO_DATA: reason=unknown_source source=${source:-<empty>}"; return 1; }
   target_i="$(_rubin_process_node_index "${target}")" || { _rubin_process_error "NO_DATA: reason=unknown_target target=${target:-<empty>}"; return 1; }
   [[ "${source}" != "${target}" ]] || { _rubin_process_error "NO_DATA: reason=same_node source=${source} target=${target}"; return 1; }
@@ -386,6 +387,15 @@ rubin_process_register_proxy_link() {
 rubin_process_probe_endpoint() {
   local endpoint="${1:-}" timeout="${2:-1}" rc=0
   _rubin_process_loopback_endpoint "${endpoint}" || { _rubin_process_error "NO_DATA: reason=invalid_probe_endpoint endpoint=${endpoint:-<empty>}"; return 1; }
+  command -v python3 >/dev/null 2>&1 || { _rubin_process_error "NO_DATA: reason=python3_unavailable endpoint=${endpoint}"; return 1; }
+  python3 - "${timeout}" <<'PY' >/dev/null 2>&1 || { _rubin_process_error "NO_DATA: reason=invalid_probe_timeout endpoint=${endpoint}"; return 1; }
+import math, sys
+try:
+    value = float(sys.argv[1])
+except (OverflowError, ValueError):
+    sys.exit(1)
+sys.exit(0 if math.isfinite(value) and value > 0 else 1)
+PY
   python3 - "${endpoint}" "${timeout}" <<'PY' || rc=$?
 import socket, sys
 endpoint, timeout = sys.argv[1], float(sys.argv[2])
@@ -418,6 +428,7 @@ _rubin_process_node_is_fresh() {
 
 _rubin_process_control_pair() {
   local action="${1:-}" source="${2:-}" target="${3:-}" source_i target_i link_i target_file target_endpoint current_target
+  _rubin_process_require_init || return 1
   source_i="$(_rubin_process_node_index "${source}")" || { _rubin_process_error "NO_DATA: phase=${action} reason=unknown_source source=${source:-<empty>} target=${target:-<empty>}"; return 1; }
   [[ "${source}" != "${target}" ]] || { _rubin_process_error "NO_DATA: phase=${action} reason=same_node source=${source} target=${target}"; return 1; }
   ((${#RUBIN_PROCESS_TOPOLOGY_NAMES[@]} >= 2)) || { _rubin_process_error "NO_DATA: phase=${action} reason=single_node_topology source=${source} target=${target}"; return 1; }

--- a/scripts/devnet-process-common.sh
+++ b/scripts/devnet-process-common.sh
@@ -338,12 +338,12 @@ _rubin_process_runtime_comm_matches() {
 
 _rubin_process_pid_listens_on() {
   local pid="${1:-}" endpoint="${2:-}"
-  command -v lsof >/dev/null 2>&1 || { _rubin_process_error "lsof is required to prove process-backed endpoint"; return 1; }
+  command -v lsof >/dev/null 2>&1 || { _rubin_process_error "NO_DATA: reason=lsof_unavailable pid=${pid} endpoint=${endpoint}"; return 2; }
   lsof -nP -a -p "${pid}" -iTCP -sTCP:LISTEN -Fn 2>/dev/null | grep -F -x -q -- "n${endpoint}"
 }
 
 rubin_process_register_topology_node() {
-  local name="${1:-}" implementation="${2:-}" pid="${3:-}" endpoint="${4:-}" expected_executable="${5:-}" comm
+  local name="${1:-}" implementation="${2:-}" pid="${3:-}" endpoint="${4:-}" expected_executable="${5:-}" comm listen_status=0
   _rubin_process_require_init || return 1
   _rubin_process_name "${name}" || { _rubin_process_error "NO_DATA: reason=invalid_node_name node=${name:-<empty>}"; return 1; }
   _rubin_process_implementation "${implementation}" || { _rubin_process_error "NO_DATA: reason=invalid_implementation node=${name} implementation=${implementation:-<empty>}"; return 1; }
@@ -353,7 +353,12 @@ rubin_process_register_topology_node() {
   fi
   _rubin_process_managed_pid "${pid}" || { _rubin_process_error "NO_DATA: reason=unmanaged_node_pid node=${name} pid=${pid}"; return 1; }
   _rubin_process_loopback_endpoint "${endpoint}" || { _rubin_process_error "NO_DATA: reason=invalid_node_endpoint node=${name} endpoint=${endpoint:-<empty>}"; return 1; }
-  _rubin_process_pid_listens_on "${pid}" "${endpoint}" || { _rubin_process_error "NO_DATA: reason=node_endpoint_not_process_backed node=${name} pid=${pid} endpoint=${endpoint}"; return 1; }
+  _rubin_process_pid_listens_on "${pid}" "${endpoint}" || listen_status=$?
+  (( listen_status == 0 )) || {
+    (( listen_status == 2 )) && return 1
+    _rubin_process_error "NO_DATA: reason=node_endpoint_not_process_backed node=${name} pid=${pid} endpoint=${endpoint}"
+    return 1
+  }
   comm="$(_rubin_process_pid_comm "${pid}")" || { _rubin_process_error "NO_DATA: reason=process_identity_unverified node=${name} pid=${pid}"; return 1; }
   _rubin_process_runtime_comm_matches "${implementation}" "${comm}" || { _rubin_process_error "NO_DATA: reason=process_identity_unverified node=${name} implementation=${implementation} pid=${pid} comm=${comm}"; return 1; }
   [[ -n "${expected_executable}" ]] || { _rubin_process_error "NO_DATA: reason=missing_expected_executable node=${name} implementation=${implementation} pid=${pid}"; return 1; }
@@ -421,14 +426,17 @@ _rubin_process_node_is_fresh() {
 }
 
 _rubin_process_control_pair() {
-  local action="${1:-}" source="${2:-}" target="${3:-}" source_i target_i link_i target_file target_endpoint current_target
+  local action="${1:-}" source="${2:-}" target="${3:-}" source_i target_i link_i target_file target_endpoint current_target source_fresh=0 target_fresh=0
   _rubin_process_require_init || return 1
   source_i="$(_rubin_process_node_index "${source}")" || { _rubin_process_error "NO_DATA: phase=${action} reason=unknown_source source=${source:-<empty>} target=${target:-<empty>}"; return 1; }
   [[ "${source}" != "${target}" ]] || { _rubin_process_error "NO_DATA: phase=${action} reason=same_node source=${source} target=${target}"; return 1; }
   ((${#RUBIN_PROCESS_TOPOLOGY_NAMES[@]} >= 2)) || { _rubin_process_error "NO_DATA: phase=${action} reason=single_node_topology source=${source} target=${target}"; return 1; }
   target_i="$(_rubin_process_node_index "${target}")" || { _rubin_process_error "NO_DATA: phase=${action} reason=unknown_target source=${source} target=${target:-<empty>}"; return 1; }
   [[ "${RUBIN_PROCESS_TOPOLOGY_IMPLS[$source_i]}" != "${RUBIN_PROCESS_TOPOLOGY_IMPLS[$target_i]}" ]] || { _rubin_process_error "NO_DATA: phase=${action} reason=same_client_topology source=${source} target=${target}"; return 1; }
-  if ! _rubin_process_node_is_fresh "${source_i}" || ! _rubin_process_node_is_fresh "${target_i}"; then
+  _rubin_process_node_is_fresh "${source_i}" || source_fresh=$?
+  _rubin_process_node_is_fresh "${target_i}" || target_fresh=$?
+  (( source_fresh != 2 && target_fresh != 2 )) || return 1
+  if (( source_fresh != 0 || target_fresh != 0 )); then
     _rubin_process_error "NO_DATA: phase=${action} reason=stale_topology source=${source} target=${target}"
     return 1
   fi

--- a/scripts/devnet-process-common.sh
+++ b/scripts/devnet-process-common.sh
@@ -238,6 +238,7 @@ rubin_process_start() {
   _rubin_process_require_artifact_parent "${log_file}" || return 1
   command -v perl >/dev/null 2>&1 || { _rubin_process_error "perl is required to launch managed process groups"; return 1; }
   launch_exec_realpath="$(_rubin_process_executable_realpath "$1")" || { _rubin_process_error "failed to resolve executable identity for $1"; return 1; }
+  set -- "${launch_exec_realpath}" "${@:2}"
 
   perl -e 'setpgrp(0, 0) or die "setpgrp failed: $!"; exec { $ARGV[0] } @ARGV or die "exec failed: $!"' -- "$@" >"${log_file}" 2>&1 &
   launch_status=$?

--- a/scripts/devnet-process-common.sh
+++ b/scripts/devnet-process-common.sh
@@ -300,7 +300,7 @@ _rubin_process_executable_realpath() {
     resolved="$(command -v -- "${executable}" 2>/dev/null)" || return 1
   fi
   [[ -n "${resolved}" && -f "${resolved}" && -x "${resolved}" ]] || return 1
-  perl -MCwd=realpath -e 'my $p = realpath($ARGV[0]); defined $p && -f $p && -x $p or exit 1; print "$p\n";' "${resolved}"
+  perl -MCwd=realpath -e 'my $p = realpath($ARGV[0]); defined $p && -f $p && -x $p or exit 1; print "$p\n";' -- "${resolved}"
 }
 
 _rubin_process_started_exec_realpath() {
@@ -325,7 +325,7 @@ _rubin_process_pid_comm() {
   local pid="${1:-}" comm
   comm="$(ps -p "${pid}" -o comm= 2>/dev/null | awk 'NR==1 {print $1}')" || return 1
   [[ -n "${comm}" ]] || return 1
-  basename "${comm}"
+  basename -- "${comm}"
 }
 
 _rubin_process_runtime_comm_matches() {
@@ -541,7 +541,7 @@ rubin_process_dump_artifacts() {
   for log_file in "${RUBIN_PROCESS_LOGS[@]}"; do
     _rubin_process_require_artifact_parent "${log_file}" || { _rubin_process_error "skipping unsafe log file: ${log_file}"; continue; }
     [[ -f "${log_file}" ]] || continue
-    _rubin_process_error "----- $(basename "${log_file}") -----"
+    _rubin_process_error "----- $(basename -- "${log_file}") -----"
     tail -n 80 "${log_file}" >&2 || true
   done
 }

--- a/scripts/devnet-process-common.sh
+++ b/scripts/devnet-process-common.sh
@@ -20,6 +20,14 @@ unset _rubin_process_existing_exit_trap
 RUBIN_PROCESS_PIDS=()
 RUBIN_PROCESS_LOGS=()
 RUBIN_PROCESS_LAST_PID=""
+RUBIN_PROCESS_TOPOLOGY_NAMES=()
+RUBIN_PROCESS_TOPOLOGY_IMPLS=()
+RUBIN_PROCESS_TOPOLOGY_PIDS=()
+RUBIN_PROCESS_TOPOLOGY_ENDPOINTS=()
+RUBIN_PROCESS_PROXY_SOURCES=()
+RUBIN_PROCESS_PROXY_TARGETS=()
+RUBIN_PROCESS_PROXY_ADDRS=()
+RUBIN_PROCESS_PROXY_TARGET_FILES=()
 _RUBIN_PROCESS_CREATED_PARENT=""
 _RUBIN_PROCESS_CREATED_ROOT=""
 _RUBIN_PROCESS_CREATED_ROOT_REAL=""
@@ -44,6 +52,17 @@ _rubin_process_uint_decimal() {
 }
 
 _rubin_process_pid() { [[ "${1:-}" =~ ^[1-9][0-9]*$ ]]; }
+_rubin_process_name() { [[ "${1:-}" =~ ^node-[a-z0-9][a-z0-9-]{0,30}$ ]]; }
+_rubin_process_implementation() { [[ "${1:-}" == "go" || "${1:-}" == "rust" ]]; }
+_rubin_process_loopback_endpoint() {
+  local endpoint="${1:-}" host port port_dec
+  [[ "${endpoint}" == 127.0.0.1:* ]] || return 1
+  host="${endpoint%:*}"
+  port="${endpoint##*:}"
+  [[ "${host}" == "127.0.0.1" && "${port}" =~ ^[0-9]+$ ]] || return 1
+  port_dec="$(_rubin_process_uint_decimal port "${port}" 2>/dev/null)" || return 1
+  (( port_dec >= 1 && port_dec <= 65535 ))
+}
 
 _rubin_process_has_parent_ref() { case "/${1:-}/" in *"/../"*) return 0 ;; *) return 1 ;; esac; }
 
@@ -111,6 +130,14 @@ _rubin_process_clear_state() {
   RUBIN_PROCESS_PIDS=()
   RUBIN_PROCESS_LOGS=()
   RUBIN_PROCESS_LAST_PID=""
+  RUBIN_PROCESS_TOPOLOGY_NAMES=()
+  RUBIN_PROCESS_TOPOLOGY_IMPLS=()
+  RUBIN_PROCESS_TOPOLOGY_PIDS=()
+  RUBIN_PROCESS_TOPOLOGY_ENDPOINTS=()
+  RUBIN_PROCESS_PROXY_SOURCES=()
+  RUBIN_PROCESS_PROXY_TARGETS=()
+  RUBIN_PROCESS_PROXY_ADDRS=()
+  RUBIN_PROCESS_PROXY_TARGET_FILES=()
   RUBIN_PROCESS_ARTIFACT_ROOT=""
   _RUBIN_PROCESS_CREATED_PARENT=""
   _RUBIN_PROCESS_CREATED_ROOT=""
@@ -175,6 +202,14 @@ rubin_process_init() {
   RUBIN_PROCESS_PIDS=()
   RUBIN_PROCESS_LOGS=()
   RUBIN_PROCESS_LAST_PID=""
+  RUBIN_PROCESS_TOPOLOGY_NAMES=()
+  RUBIN_PROCESS_TOPOLOGY_IMPLS=()
+  RUBIN_PROCESS_TOPOLOGY_PIDS=()
+  RUBIN_PROCESS_TOPOLOGY_ENDPOINTS=()
+  RUBIN_PROCESS_PROXY_SOURCES=()
+  RUBIN_PROCESS_PROXY_TARGETS=()
+  RUBIN_PROCESS_PROXY_ADDRS=()
+  RUBIN_PROCESS_PROXY_TARGET_FILES=()
   trap rubin_process_exit_trap EXIT
 }
 
@@ -215,6 +250,149 @@ rubin_process_start() {
   RUBIN_PROCESS_LOGS+=("${log_file}")
   disown "${started_pid}" 2>/dev/null || true
 }
+
+_rubin_process_node_index() {
+  local name="${1:-}" i
+  for ((i=0; i<${#RUBIN_PROCESS_TOPOLOGY_NAMES[@]}; i++)); do
+    [[ "${RUBIN_PROCESS_TOPOLOGY_NAMES[$i]}" == "${name}" ]] || continue
+    printf '%s\n' "${i}"
+    return 0
+  done
+  return 1
+}
+
+_rubin_process_link_index() {
+  local source="${1:-}" target="${2:-}" i
+  for ((i=0; i<${#RUBIN_PROCESS_PROXY_SOURCES[@]}; i++)); do
+    [[ "${RUBIN_PROCESS_PROXY_SOURCES[$i]}" == "${source}" && "${RUBIN_PROCESS_PROXY_TARGETS[$i]}" == "${target}" ]] || continue
+    printf '%s\n' "${i}"
+    return 0
+  done
+  return 1
+}
+
+_rubin_process_managed_pid() {
+  local pid="${1:-}" current
+  for current in "${RUBIN_PROCESS_PIDS[@]}"; do
+    [[ "${current}" == "${pid}" ]] && return 0
+  done
+  return 1
+}
+
+_rubin_process_pid_comm() {
+  local pid="${1:-}" comm
+  comm="$(ps -p "${pid}" -o comm= 2>/dev/null | awk 'NR==1 {print $1}')" || return 1
+  [[ -n "${comm}" ]] || return 1
+  basename "${comm}"
+}
+
+_rubin_process_runtime_comm_matches() {
+  local implementation="${1:-}" comm="${2:-}"
+  case "${implementation}:${comm}" in
+    go:rubin-node-go|rust:rubin-node-rust) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+_rubin_process_pid_listens_on() {
+  local pid="${1:-}" endpoint="${2:-}"
+  command -v lsof >/dev/null 2>&1 || { _rubin_process_error "lsof is required to prove process-backed endpoint"; return 1; }
+  lsof -nP -a -p "${pid}" -iTCP -sTCP:LISTEN -Fn 2>/dev/null | grep -F -x -q -- "n${endpoint}"
+}
+
+rubin_process_register_topology_node() {
+  local name="${1:-}" implementation="${2:-}" pid="${3:-}" endpoint="${4:-}" comm
+  _rubin_process_require_init || return 1
+  _rubin_process_name "${name}" || { _rubin_process_error "NO_DATA: reason=invalid_node_name node=${name:-<empty>}"; return 1; }
+  _rubin_process_implementation "${implementation}" || { _rubin_process_error "NO_DATA: reason=invalid_implementation node=${name} implementation=${implementation:-<empty>}"; return 1; }
+  if ! _rubin_process_pid "${pid}" || ! rubin_process_is_alive "${pid}"; then
+    _rubin_process_error "NO_DATA: reason=dead_node_pid node=${name} pid=${pid:-<empty>}"
+    return 1
+  fi
+  _rubin_process_managed_pid "${pid}" || { _rubin_process_error "NO_DATA: reason=unmanaged_node_pid node=${name} pid=${pid}"; return 1; }
+  _rubin_process_loopback_endpoint "${endpoint}" || { _rubin_process_error "NO_DATA: reason=invalid_node_endpoint node=${name} endpoint=${endpoint:-<empty>}"; return 1; }
+  _rubin_process_pid_listens_on "${pid}" "${endpoint}" || { _rubin_process_error "NO_DATA: reason=node_endpoint_not_process_backed node=${name} pid=${pid} endpoint=${endpoint}"; return 1; }
+  comm="$(_rubin_process_pid_comm "${pid}")" || { _rubin_process_error "NO_DATA: reason=process_identity_unverified node=${name} pid=${pid}"; return 1; }
+  _rubin_process_runtime_comm_matches "${implementation}" "${comm}" || { _rubin_process_error "NO_DATA: reason=process_identity_unverified node=${name} implementation=${implementation} pid=${pid} comm=${comm}"; return 1; }
+  ! _rubin_process_node_index "${name}" >/dev/null || { _rubin_process_error "NO_DATA: reason=duplicate_node node=${name}"; return 1; }
+  RUBIN_PROCESS_TOPOLOGY_NAMES+=("${name}")
+  RUBIN_PROCESS_TOPOLOGY_IMPLS+=("${implementation}")
+  RUBIN_PROCESS_TOPOLOGY_PIDS+=("${pid}")
+  RUBIN_PROCESS_TOPOLOGY_ENDPOINTS+=("${endpoint}")
+}
+
+rubin_process_register_proxy_link() {
+  local source="${1:-}" target="${2:-}" proxy_addr="${3:-}" target_file="${4:-}" target_i target_endpoint
+  _rubin_process_node_index "${source}" >/dev/null || { _rubin_process_error "NO_DATA: reason=unknown_source source=${source:-<empty>}"; return 1; }
+  target_i="$(_rubin_process_node_index "${target}")" || { _rubin_process_error "NO_DATA: reason=unknown_target target=${target:-<empty>}"; return 1; }
+  [[ "${source}" != "${target}" ]] || { _rubin_process_error "NO_DATA: reason=same_node source=${source} target=${target}"; return 1; }
+  _rubin_process_loopback_endpoint "${proxy_addr}" || { _rubin_process_error "NO_DATA: reason=invalid_proxy_endpoint proxy=${proxy_addr:-<empty>}"; return 1; }
+  _rubin_process_require_artifact_parent "${target_file}" || return 1
+  target_endpoint="${RUBIN_PROCESS_TOPOLOGY_ENDPOINTS[$target_i]}"
+  [[ -r "${target_file}" && "$(tr -d '[:space:]' <"${target_file}")" == "${target_endpoint}" ]] || { _rubin_process_error "NO_DATA: reason=missing_proxy_target source=${source} target=${target}"; return 1; }
+  RUBIN_PROCESS_PROXY_SOURCES+=("${source}")
+  RUBIN_PROCESS_PROXY_TARGETS+=("${target}")
+  RUBIN_PROCESS_PROXY_ADDRS+=("${proxy_addr}")
+  RUBIN_PROCESS_PROXY_TARGET_FILES+=("${target_file}")
+}
+
+rubin_process_probe_endpoint() {
+  local endpoint="${1:-}" timeout="${2:-1}" rc=0
+  _rubin_process_loopback_endpoint "${endpoint}" || { _rubin_process_error "NO_DATA: reason=invalid_probe_endpoint endpoint=${endpoint:-<empty>}"; return 1; }
+  python3 - "${endpoint}" "${timeout}" <<'PY' || rc=$?
+import socket, sys
+endpoint, timeout = sys.argv[1], float(sys.argv[2])
+host, port = endpoint.rsplit(":", 1)
+try:
+    sock = socket.create_connection((host, int(port)), timeout=timeout)
+    sock.settimeout(timeout)
+    data = sock.recv(1)
+    sock.close()
+    sys.exit(0 if data else 1)
+except socket.timeout:
+    sys.exit(2)
+except OSError:
+    sys.exit(1)
+PY
+  case "${rc}" in
+    0) return 0 ;;
+    2) _rubin_process_error "NO_DATA: reason=probe_timeout endpoint=${endpoint}"; return 1 ;;
+    *) _rubin_process_error "NO_DATA: reason=probe_disconnected endpoint=${endpoint}"; return 1 ;;
+  esac
+}
+
+_rubin_process_node_is_fresh() {
+  local index="${1:-}" pid endpoint
+  pid="${RUBIN_PROCESS_TOPOLOGY_PIDS[$index]}"
+  endpoint="${RUBIN_PROCESS_TOPOLOGY_ENDPOINTS[$index]}"
+  rubin_process_is_alive "${pid}" && _rubin_process_pid_listens_on "${pid}" "${endpoint}"
+}
+
+_rubin_process_control_pair() {
+  local action="${1:-}" source="${2:-}" target="${3:-}" source_i target_i link_i target_file target_endpoint current_target
+  source_i="$(_rubin_process_node_index "${source}")" || { _rubin_process_error "NO_DATA: phase=${action} reason=unknown_source source=${source:-<empty>} target=${target:-<empty>}"; return 1; }
+  [[ "${source}" != "${target}" ]] || { _rubin_process_error "NO_DATA: phase=${action} reason=same_node source=${source} target=${target}"; return 1; }
+  ((${#RUBIN_PROCESS_TOPOLOGY_NAMES[@]} >= 2)) || { _rubin_process_error "NO_DATA: phase=${action} reason=single_node_topology source=${source} target=${target}"; return 1; }
+  target_i="$(_rubin_process_node_index "${target}")" || { _rubin_process_error "NO_DATA: phase=${action} reason=unknown_target source=${source} target=${target:-<empty>}"; return 1; }
+  [[ "${RUBIN_PROCESS_TOPOLOGY_IMPLS[$source_i]}" != "${RUBIN_PROCESS_TOPOLOGY_IMPLS[$target_i]}" ]] || { _rubin_process_error "NO_DATA: phase=${action} reason=same_client_topology source=${source} target=${target}"; return 1; }
+  if ! _rubin_process_node_is_fresh "${source_i}" || ! _rubin_process_node_is_fresh "${target_i}"; then
+    _rubin_process_error "NO_DATA: phase=${action} reason=stale_topology source=${source} target=${target}"
+    return 1
+  fi
+  link_i="$(_rubin_process_link_index "${source}" "${target}")" || { _rubin_process_error "NO_DATA: phase=${action} reason=missing_proxy_link source=${source} target=${target}"; return 1; }
+  target_file="${RUBIN_PROCESS_PROXY_TARGET_FILES[$link_i]}"
+  target_endpoint="${RUBIN_PROCESS_TOPOLOGY_ENDPOINTS[$target_i]}"
+  _rubin_process_require_artifact_parent "${target_file}" || return 1
+  [[ -r "${target_file}" ]] || { _rubin_process_error "NO_DATA: phase=${action} reason=missing_proxy_target source=${source} target=${target}"; return 1; }
+  current_target="$(tr -d '[:space:]' <"${target_file}")"
+  [[ "${action}" != "partition" || "${current_target}" != "drop" ]] || { _rubin_process_error "NO_DATA: phase=partition reason=no_effect source=${source} target=${target}"; return 1; }
+  [[ "${action}" != "heal" || "${current_target}" != "${target_endpoint}" ]] || { _rubin_process_error "NO_DATA: phase=heal reason=no_effect source=${source} target=${target}"; return 1; }
+  _rubin_process_error "NO_DATA: phase=${action} reason=runtime_edge_verifier_required source=${source} target=${target}"
+  return 1
+}
+
+rubin_process_partition_pair() { _rubin_process_control_pair partition "$@"; }
+rubin_process_heal_pair() { _rubin_process_control_pair heal "$@"; }
 
 rubin_process_stop_pid() {
   local pid="${1:-}" grace_seconds deadline

--- a/scripts/devnet-process-common.sh
+++ b/scripts/devnet-process-common.sh
@@ -18,12 +18,15 @@ if [[ "${_rubin_process_existing_exit_trap}" == *"rubin_process_exit_trap"* ]]; 
 fi
 unset _rubin_process_existing_exit_trap
 RUBIN_PROCESS_PIDS=()
+RUBIN_PROCESS_STARTED_PIDS=()
+RUBIN_PROCESS_STARTED_EXEC_REALPATHS=()
 RUBIN_PROCESS_LOGS=()
 RUBIN_PROCESS_LAST_PID=""
 RUBIN_PROCESS_TOPOLOGY_NAMES=()
 RUBIN_PROCESS_TOPOLOGY_IMPLS=()
 RUBIN_PROCESS_TOPOLOGY_PIDS=()
 RUBIN_PROCESS_TOPOLOGY_ENDPOINTS=()
+RUBIN_PROCESS_TOPOLOGY_EXEC_REALPATHS=()
 RUBIN_PROCESS_PROXY_SOURCES=()
 RUBIN_PROCESS_PROXY_TARGETS=()
 RUBIN_PROCESS_PROXY_ADDRS=()
@@ -128,12 +131,15 @@ _rubin_process_require_artifact_parent() {
 _rubin_process_clear_state() {
   trap - EXIT
   RUBIN_PROCESS_PIDS=()
+  RUBIN_PROCESS_STARTED_PIDS=()
+  RUBIN_PROCESS_STARTED_EXEC_REALPATHS=()
   RUBIN_PROCESS_LOGS=()
   RUBIN_PROCESS_LAST_PID=""
   RUBIN_PROCESS_TOPOLOGY_NAMES=()
   RUBIN_PROCESS_TOPOLOGY_IMPLS=()
   RUBIN_PROCESS_TOPOLOGY_PIDS=()
   RUBIN_PROCESS_TOPOLOGY_ENDPOINTS=()
+  RUBIN_PROCESS_TOPOLOGY_EXEC_REALPATHS=()
   RUBIN_PROCESS_PROXY_SOURCES=()
   RUBIN_PROCESS_PROXY_TARGETS=()
   RUBIN_PROCESS_PROXY_ADDRS=()
@@ -200,12 +206,15 @@ rubin_process_init() {
     return 1
   }
   RUBIN_PROCESS_PIDS=()
+  RUBIN_PROCESS_STARTED_PIDS=()
+  RUBIN_PROCESS_STARTED_EXEC_REALPATHS=()
   RUBIN_PROCESS_LOGS=()
   RUBIN_PROCESS_LAST_PID=""
   RUBIN_PROCESS_TOPOLOGY_NAMES=()
   RUBIN_PROCESS_TOPOLOGY_IMPLS=()
   RUBIN_PROCESS_TOPOLOGY_PIDS=()
   RUBIN_PROCESS_TOPOLOGY_ENDPOINTS=()
+  RUBIN_PROCESS_TOPOLOGY_EXEC_REALPATHS=()
   RUBIN_PROCESS_PROXY_SOURCES=()
   RUBIN_PROCESS_PROXY_TARGETS=()
   RUBIN_PROCESS_PROXY_ADDRS=()
@@ -219,7 +228,7 @@ rubin_process_is_alive() {
 }
 
 rubin_process_start() {
-  local log_file log_dir launch_status started_pid
+  local log_file log_dir launch_exec_realpath launch_status started_pid
   (( $# >= 2 )) || { _rubin_process_error "rubin_process_start requires a log path and command"; return 1; }
   log_file="$(_rubin_process_resolve_log "$1")" || return 1
   shift
@@ -227,9 +236,10 @@ rubin_process_start() {
   _rubin_process_mkdir_under_artifact_root "${log_dir}" || return 1
   _rubin_process_require_artifact_parent "${log_file}" || return 1
   command -v perl >/dev/null 2>&1 || { _rubin_process_error "perl is required to launch managed process groups"; return 1; }
+  launch_exec_realpath="$(_rubin_process_executable_realpath "$1")" || { _rubin_process_error "failed to resolve executable identity for $1"; return 1; }
 
   RUBIN_PROCESS_LAST_PID=""
-  perl -e 'setpgrp(0, 0) or die "setpgrp failed: $!"; exec @ARGV or die "exec failed: $!"' -- "$@" >"${log_file}" 2>&1 &
+  perl -e 'setpgrp(0, 0) or die "setpgrp failed: $!"; exec { $ARGV[0] } @ARGV or die "exec failed: $!"' -- "$@" >"${log_file}" 2>&1 &
   launch_status=$?
   if (( launch_status != 0 )); then
     _rubin_process_error "failed to launch background command for ${log_file}"
@@ -247,6 +257,8 @@ rubin_process_start() {
   # shellcheck disable=SC2034 # caller scripts read this state after sourcing.
   RUBIN_PROCESS_LAST_PID="${started_pid}"
   RUBIN_PROCESS_PIDS+=("${started_pid}")
+  RUBIN_PROCESS_STARTED_PIDS+=("${started_pid}")
+  RUBIN_PROCESS_STARTED_EXEC_REALPATHS+=("${launch_exec_realpath}")
   RUBIN_PROCESS_LOGS+=("${log_file}")
   disown "${started_pid}" 2>/dev/null || true
 }
@@ -279,6 +291,36 @@ _rubin_process_managed_pid() {
   return 1
 }
 
+_rubin_process_executable_realpath() {
+  local executable="${1:-}" resolved
+  [[ -n "${executable}" ]] || return 1
+  if [[ "${executable}" == */* ]]; then
+    resolved="${executable}"
+  else
+    resolved="$(command -v -- "${executable}" 2>/dev/null)" || return 1
+  fi
+  [[ -n "${resolved}" && -f "${resolved}" && -x "${resolved}" ]] || return 1
+  perl -MCwd=realpath -e 'my $p = realpath($ARGV[0]); defined $p && -f $p && -x $p or exit 1; print "$p\n";' "${resolved}"
+}
+
+_rubin_process_started_exec_realpath() {
+  local pid="${1:-}" i
+  _rubin_process_pid "${pid}" || return 1
+  for ((i=${#RUBIN_PROCESS_STARTED_PIDS[@]} - 1; i >= 0; i--)); do
+    [[ "${RUBIN_PROCESS_STARTED_PIDS[$i]}" == "${pid}" ]] || continue
+    printf '%s\n' "${RUBIN_PROCESS_STARTED_EXEC_REALPATHS[$i]}"
+    return 0
+  done
+  return 1
+}
+
+_rubin_process_started_exec_matches() {
+  local pid="${1:-}" expected_exec="${2:-}" started_exec
+  [[ -n "${expected_exec}" ]] || return 1
+  started_exec="$(_rubin_process_started_exec_realpath "${pid}")" || return 1
+  [[ "${started_exec}" == "${expected_exec}" ]]
+}
+
 _rubin_process_pid_comm() {
   local pid="${1:-}" comm
   comm="$(ps -p "${pid}" -o comm= 2>/dev/null | awk 'NR==1 {print $1}')" || return 1
@@ -301,7 +343,7 @@ _rubin_process_pid_listens_on() {
 }
 
 rubin_process_register_topology_node() {
-  local name="${1:-}" implementation="${2:-}" pid="${3:-}" endpoint="${4:-}" comm
+  local name="${1:-}" implementation="${2:-}" pid="${3:-}" endpoint="${4:-}" expected_executable="${5:-}" comm expected_exec started_exec
   _rubin_process_require_init || return 1
   _rubin_process_name "${name}" || { _rubin_process_error "NO_DATA: reason=invalid_node_name node=${name:-<empty>}"; return 1; }
   _rubin_process_implementation "${implementation}" || { _rubin_process_error "NO_DATA: reason=invalid_implementation node=${name} implementation=${implementation:-<empty>}"; return 1; }
@@ -314,11 +356,16 @@ rubin_process_register_topology_node() {
   _rubin_process_pid_listens_on "${pid}" "${endpoint}" || { _rubin_process_error "NO_DATA: reason=node_endpoint_not_process_backed node=${name} pid=${pid} endpoint=${endpoint}"; return 1; }
   comm="$(_rubin_process_pid_comm "${pid}")" || { _rubin_process_error "NO_DATA: reason=process_identity_unverified node=${name} pid=${pid}"; return 1; }
   _rubin_process_runtime_comm_matches "${implementation}" "${comm}" || { _rubin_process_error "NO_DATA: reason=process_identity_unverified node=${name} implementation=${implementation} pid=${pid} comm=${comm}"; return 1; }
+  [[ -n "${expected_executable}" ]] || { _rubin_process_error "NO_DATA: reason=missing_expected_executable node=${name} implementation=${implementation} pid=${pid}"; return 1; }
+  expected_exec="$(_rubin_process_executable_realpath "${expected_executable}")" || { _rubin_process_error "NO_DATA: reason=expected_executable_unverified node=${name} implementation=${implementation} pid=${pid}"; return 1; }
+  started_exec="$(_rubin_process_started_exec_realpath "${pid}")" || { _rubin_process_error "NO_DATA: reason=process_identity_unverified node=${name} implementation=${implementation} pid=${pid}"; return 1; }
+  [[ "${started_exec}" == "${expected_exec}" ]] || { _rubin_process_error "NO_DATA: reason=process_identity_unverified node=${name} implementation=${implementation} pid=${pid}"; return 1; }
   ! _rubin_process_node_index "${name}" >/dev/null || { _rubin_process_error "NO_DATA: reason=duplicate_node node=${name}"; return 1; }
   RUBIN_PROCESS_TOPOLOGY_NAMES+=("${name}")
   RUBIN_PROCESS_TOPOLOGY_IMPLS+=("${implementation}")
   RUBIN_PROCESS_TOPOLOGY_PIDS+=("${pid}")
   RUBIN_PROCESS_TOPOLOGY_ENDPOINTS+=("${endpoint}")
+  RUBIN_PROCESS_TOPOLOGY_EXEC_REALPATHS+=("${expected_exec}")
 }
 
 rubin_process_register_proxy_link() {
@@ -362,10 +409,11 @@ PY
 }
 
 _rubin_process_node_is_fresh() {
-  local index="${1:-}" pid endpoint
+  local index="${1:-}" pid endpoint expected_exec
   pid="${RUBIN_PROCESS_TOPOLOGY_PIDS[$index]}"
   endpoint="${RUBIN_PROCESS_TOPOLOGY_ENDPOINTS[$index]}"
-  rubin_process_is_alive "${pid}" && _rubin_process_pid_listens_on "${pid}" "${endpoint}"
+  expected_exec="${RUBIN_PROCESS_TOPOLOGY_EXEC_REALPATHS[$index]:-}"
+  rubin_process_is_alive "${pid}" && _rubin_process_started_exec_matches "${pid}" "${expected_exec}" && _rubin_process_pid_listens_on "${pid}" "${endpoint}"
 }
 
 _rubin_process_control_pair() {

--- a/scripts/devnet-process-common.sh
+++ b/scripts/devnet-process-common.sh
@@ -343,7 +343,7 @@ _rubin_process_pid_listens_on() {
 }
 
 rubin_process_register_topology_node() {
-  local name="${1:-}" implementation="${2:-}" pid="${3:-}" endpoint="${4:-}" expected_executable="${5:-}" comm expected_exec started_exec
+  local name="${1:-}" implementation="${2:-}" pid="${3:-}" endpoint="${4:-}" expected_executable="${5:-}" comm
   _rubin_process_require_init || return 1
   _rubin_process_name "${name}" || { _rubin_process_error "NO_DATA: reason=invalid_node_name node=${name:-<empty>}"; return 1; }
   _rubin_process_implementation "${implementation}" || { _rubin_process_error "NO_DATA: reason=invalid_implementation node=${name} implementation=${implementation:-<empty>}"; return 1; }
@@ -357,15 +357,9 @@ rubin_process_register_topology_node() {
   comm="$(_rubin_process_pid_comm "${pid}")" || { _rubin_process_error "NO_DATA: reason=process_identity_unverified node=${name} pid=${pid}"; return 1; }
   _rubin_process_runtime_comm_matches "${implementation}" "${comm}" || { _rubin_process_error "NO_DATA: reason=process_identity_unverified node=${name} implementation=${implementation} pid=${pid} comm=${comm}"; return 1; }
   [[ -n "${expected_executable}" ]] || { _rubin_process_error "NO_DATA: reason=missing_expected_executable node=${name} implementation=${implementation} pid=${pid}"; return 1; }
-  expected_exec="$(_rubin_process_executable_realpath "${expected_executable}")" || { _rubin_process_error "NO_DATA: reason=expected_executable_unverified node=${name} implementation=${implementation} pid=${pid}"; return 1; }
-  started_exec="$(_rubin_process_started_exec_realpath "${pid}")" || { _rubin_process_error "NO_DATA: reason=process_identity_unverified node=${name} implementation=${implementation} pid=${pid}"; return 1; }
-  [[ "${started_exec}" == "${expected_exec}" ]] || { _rubin_process_error "NO_DATA: reason=process_identity_unverified node=${name} implementation=${implementation} pid=${pid}"; return 1; }
-  ! _rubin_process_node_index "${name}" >/dev/null || { _rubin_process_error "NO_DATA: reason=duplicate_node node=${name}"; return 1; }
-  RUBIN_PROCESS_TOPOLOGY_NAMES+=("${name}")
-  RUBIN_PROCESS_TOPOLOGY_IMPLS+=("${implementation}")
-  RUBIN_PROCESS_TOPOLOGY_PIDS+=("${pid}")
-  RUBIN_PROCESS_TOPOLOGY_ENDPOINTS+=("${endpoint}")
-  RUBIN_PROCESS_TOPOLOGY_EXEC_REALPATHS+=("${expected_exec}")
+  _rubin_process_executable_realpath "${expected_executable}" >/dev/null || { _rubin_process_error "NO_DATA: reason=expected_executable_unverified node=${name} implementation=${implementation} pid=${pid}"; return 1; }
+  _rubin_process_error "NO_DATA: reason=runtime_identity_verifier_required node=${name} implementation=${implementation} pid=${pid}"
+  return 1
 }
 
 rubin_process_register_proxy_link() {

--- a/scripts/devnet-process-common.sh
+++ b/scripts/devnet-process-common.sh
@@ -337,9 +337,12 @@ _rubin_process_runtime_comm_matches() {
 }
 
 _rubin_process_pid_listens_on() {
-  local pid="${1:-}" endpoint="${2:-}"
+  local pid="${1:-}" endpoint="${2:-}" lsof_output lsof_status=0
   command -v lsof >/dev/null 2>&1 || { _rubin_process_error "NO_DATA: reason=lsof_unavailable pid=${pid} endpoint=${endpoint}"; return 2; }
-  lsof -nP -a -p "${pid}" -iTCP -sTCP:LISTEN -Fn 2>/dev/null | grep -F -x -q -- "n${endpoint}"
+  lsof_output="$(lsof -nP -a -p "${pid}" -iTCP -sTCP:LISTEN -Fn 2>&1)" || lsof_status=$?
+  grep -F -x -q -- "n${endpoint}" <<<"${lsof_output}" && return 0
+  (( lsof_status == 0 || ${#lsof_output} == 0 )) || { _rubin_process_error "NO_DATA: reason=lsof_failed pid=${pid} endpoint=${endpoint}"; return 2; }
+  return 1
 }
 
 rubin_process_register_topology_node() {

--- a/scripts/devnet-process-common.sh
+++ b/scripts/devnet-process-common.sh
@@ -230,6 +230,7 @@ rubin_process_is_alive() {
 rubin_process_start() {
   local log_file log_dir launch_exec_realpath launch_status started_pid
   (( $# >= 2 )) || { _rubin_process_error "rubin_process_start requires a log path and command"; return 1; }
+  RUBIN_PROCESS_LAST_PID=""
   log_file="$(_rubin_process_resolve_log "$1")" || return 1
   shift
   log_dir="$(dirname "${log_file}")"
@@ -238,7 +239,6 @@ rubin_process_start() {
   command -v perl >/dev/null 2>&1 || { _rubin_process_error "perl is required to launch managed process groups"; return 1; }
   launch_exec_realpath="$(_rubin_process_executable_realpath "$1")" || { _rubin_process_error "failed to resolve executable identity for $1"; return 1; }
 
-  RUBIN_PROCESS_LAST_PID=""
   perl -e 'setpgrp(0, 0) or die "setpgrp failed: $!"; exec { $ARGV[0] } @ARGV or die "exec failed: $!"' -- "$@" >"${log_file}" 2>&1 &
   launch_status=$?
   if (( launch_status != 0 )); then

--- a/scripts/devnet/test_partition_control_fixtures.sh
+++ b/scripts/devnet/test_partition_control_fixtures.sh
@@ -157,7 +157,6 @@ start_server rust-helper send; RUST_PID="${SERVER_PID}" RUST_ENDPOINT="${SERVER_
 start_server silent-helper silent; SILENT_ENDPOINT="${SERVER_ENDPOINT}"
 start_spoof_server basename-spoof rubin-node-go; SPOOF_GO_PID="${SERVER_PID}" SPOOF_GO_ENDPOINT="${SERVER_ENDPOINT}"
 SPOOF_GO_COMM="$(_rubin_process_pid_comm "${SPOOF_GO_PID}")" || { echo "failed to read spoof process comm" >&2; exit 1; }; [[ "${SPOOF_GO_COMM}" == "rubin-node-go" ]] || { echo "spoof fixture did not expose rubin-node-go comm: ${SPOOF_GO_COMM}" >&2; exit 1; }
-
 expect_fail_with_path_contains "lsof unavailable registration" "reason=lsof_unavailable" "${NO_TOOLS_DIR}" rubin_process_register_topology_node node-go go "${GO_PID}" "${GO_ENDPOINT}" "${EXPECTED_GO_BIN}"
 expect_fail_contains "fake go identity" "reason=process_identity_unverified" rubin_process_register_topology_node node-go go "${GO_PID}" "${GO_ENDPOINT}"
 expect_fail_contains "basename spoof missing expected executable" "reason=missing_expected_executable" rubin_process_register_topology_node node-spoof go "${SPOOF_GO_PID}" "${SPOOF_GO_ENDPOINT}"

--- a/scripts/devnet/test_partition_control_fixtures.sh
+++ b/scripts/devnet/test_partition_control_fixtures.sh
@@ -195,5 +195,5 @@ printf '%s\n' "${RUST_ENDPOINT}" >"${TARGET_FILE}"
 expect_fail_contains "stale topology" "reason=stale_topology" rubin_process_partition_pair node-go node-rust
 
 rubin_process_cleanup 0
-rm -f "${PARENT}/expect-fail-output.txt"; rmdir "${PARENT}"
+[[ "${RUBIN_PROCESS_KEEP_ARTIFACTS:-0}" == "1" ]] || { rm -f "${PARENT}/expect-fail-output.txt"; rmdir "${PARENT}"; }
 printf 'PASS: partition control helpers fail closed without live runtime proof\n'

--- a/scripts/devnet/test_partition_control_fixtures.sh
+++ b/scripts/devnet/test_partition_control_fixtures.sh
@@ -27,6 +27,17 @@ expect_fail_contains() {
   require_contains "${output}" "${needle}" "${label}"
 }
 
+expect_fail_with_path_contains() {
+  local label="$1" needle="$2" path="$3"
+  shift 3
+  local output
+  if output="$(PATH="${path}" "$@" 2>&1)"; then
+    printf 'expected failure for %s\n' "${label}" >&2
+    return 1
+  fi
+  require_contains "${output}" "${needle}" "${label}"
+}
+
 write_server() {
   cat >"$1" <<'PY'
 import socket, sys, threading, time
@@ -129,10 +140,12 @@ trap cleanup_fixture EXIT
 
 SERVER_PY="${RUBIN_PROCESS_ARTIFACT_ROOT}/helper server.py"
 EXPECTED_GO_BIN="${RUBIN_PROCESS_ARTIFACT_ROOT}/expected/rubin-node-go"
+NO_TOOLS_DIR="${RUBIN_PROCESS_ARTIFACT_ROOT}/no-tools"
 TARGET_FILE="${RUBIN_PROCESS_ARTIFACT_ROOT}/proxy target.txt"
 MISSING_TARGET="${RUBIN_PROCESS_ARTIFACT_ROOT}/missing target.txt"
 write_server "${SERVER_PY}"
 write_runtime_stub "${EXPECTED_GO_BIN}"
+mkdir "${NO_TOOLS_DIR}"
 
 SERVER_PID="" SERVER_ENDPOINT="" SPOOF_EXECUTABLE=""
 start_server go-helper send; GO_PID="${SERVER_PID}" GO_ENDPOINT="${SERVER_ENDPOINT}"
@@ -141,6 +154,7 @@ start_server silent-helper silent; SILENT_ENDPOINT="${SERVER_ENDPOINT}"
 start_spoof_server basename-spoof rubin-node-go; SPOOF_GO_PID="${SERVER_PID}" SPOOF_GO_ENDPOINT="${SERVER_ENDPOINT}"
 SPOOF_GO_COMM="$(_rubin_process_pid_comm "${SPOOF_GO_PID}")" || { echo "failed to read spoof process comm" >&2; exit 1; }; [[ "${SPOOF_GO_COMM}" == "rubin-node-go" ]] || { echo "spoof fixture did not expose rubin-node-go comm: ${SPOOF_GO_COMM}" >&2; exit 1; }
 
+expect_fail_with_path_contains "lsof unavailable registration" "reason=lsof_unavailable" "${NO_TOOLS_DIR}" rubin_process_register_topology_node node-go go "${GO_PID}" "${GO_ENDPOINT}" "${EXPECTED_GO_BIN}"
 expect_fail_contains "fake go identity" "reason=process_identity_unverified" rubin_process_register_topology_node node-go go "${GO_PID}" "${GO_ENDPOINT}"
 expect_fail_contains "basename spoof missing expected executable" "reason=missing_expected_executable" rubin_process_register_topology_node node-spoof go "${SPOOF_GO_PID}" "${SPOOF_GO_ENDPOINT}"
 expect_fail_contains "basename spoof arbitrary expected executable" "reason=runtime_identity_verifier_required" rubin_process_register_topology_node node-spoof go "${SPOOF_GO_PID}" "${SPOOF_GO_ENDPOINT}" "${SPOOF_EXECUTABLE}"
@@ -162,6 +176,7 @@ seed_nodes go go
 expect_fail_contains "same client" "reason=same_client_topology" rubin_process_partition_pair node-go node-rust
 
 seed_nodes
+expect_fail_with_path_contains "lsof unavailable control" "reason=lsof_unavailable" "${NO_TOOLS_DIR}" rubin_process_partition_pair node-go node-rust
 seed_link "${MISSING_TARGET}"
 expect_fail_contains "missing proxy target" "reason=missing_proxy_target" rubin_process_partition_pair node-go node-rust
 

--- a/scripts/devnet/test_partition_control_fixtures.sh
+++ b/scripts/devnet/test_partition_control_fixtures.sh
@@ -5,6 +5,12 @@ HELPER="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/scripts/devnet-proce
 # shellcheck source=scripts/devnet-process-common.sh disable=SC1091
 source "${HELPER}"
 
+if ! command -v lsof >/dev/null 2>&1; then
+  printf 'SKIP: NO_DATA reason=lsof_unavailable fixture=partition_control\n'
+  exit 0
+fi
+
+# Fixture-only internal _rubin_process_* calls seed hostile states unreachable through public APIs.
 require_contains() {
   local haystack="$1" needle="$2" label="$3"
   [[ "${haystack}" == *"${needle}"* ]] || { printf 'missing %s in %s: %s\n' "${needle}" "${label}" "${haystack}" >&2; return 1; }
@@ -115,6 +121,8 @@ cleanup_fixture() {
   exit "${status}"
 }
 RUBIN_PROCESS_ARTIFACT_PARENT="${PARENT}"
+expect_fail_contains "proxy before init" "rubin_process_init must run" rubin_process_register_proxy_link node-go node-rust 127.0.0.1:1 "${PARENT}/missing-target"
+expect_fail_contains "control before init" "rubin_process_init must run" rubin_process_partition_pair node-go node-rust
 rubin_process_init partition-control-fail-closed
 trap cleanup_fixture EXIT
 
@@ -137,6 +145,7 @@ expect_fail_contains "basename spoof missing expected executable" "reason=missin
 expect_fail_contains "basename spoof identity" "reason=process_identity_unverified" rubin_process_register_topology_node node-spoof go "${SPOOF_GO_PID}" "${SPOOF_GO_ENDPOINT}" "${EXPECTED_GO_BIN}"
 ((${#RUBIN_PROCESS_TOPOLOGY_NAMES[@]} == 0)) || { echo "fake process was registered as topology" >&2; exit 1; }
 expect_fail_contains "socket timeout" "reason=probe_timeout" rubin_process_probe_endpoint "${SILENT_ENDPOINT}" 1
+expect_fail_contains "invalid probe timeout" "reason=invalid_probe_timeout" rubin_process_probe_endpoint "${GO_ENDPOINT}" not-a-float
 expect_fail_contains "unknown source" "reason=unknown_source" rubin_process_partition_pair node-missing node-rust
 
 RUBIN_PROCESS_TOPOLOGY_NAMES=(node-go)

--- a/scripts/devnet/test_partition_control_fixtures.sh
+++ b/scripts/devnet/test_partition_control_fixtures.sh
@@ -149,6 +149,13 @@ mkdir "${NO_TOOLS_DIR}"
 
 SERVER_PID="" SERVER_ENDPOINT="" SPOOF_EXECUTABLE=""
 start_server go-helper send; GO_PID="${SERVER_PID}" GO_ENDPOINT="${SERVER_ENDPOINT}"
+START_FAILURE_LOG="${RUBIN_PROCESS_ARTIFACT_ROOT}/start failure.txt"
+if rubin_process_start missing-command.log "${RUBIN_PROCESS_ARTIFACT_ROOT}/missing-command" 2>"${START_FAILURE_LOG}"; then
+  echo "expected start failure for missing command" >&2
+  exit 1
+fi
+require_contains "$(cat "${START_FAILURE_LOG}")" "failed to resolve executable identity" "start clears stale last pid"
+[[ -z "${RUBIN_PROCESS_LAST_PID}" ]] || { echo "failed start left stale RUBIN_PROCESS_LAST_PID=${RUBIN_PROCESS_LAST_PID}" >&2; exit 1; }
 start_server rust-helper send; RUST_PID="${SERVER_PID}" RUST_ENDPOINT="${SERVER_ENDPOINT}"
 start_server silent-helper silent; SILENT_ENDPOINT="${SERVER_ENDPOINT}"
 start_spoof_server basename-spoof rubin-node-go; SPOOF_GO_PID="${SERVER_PID}" SPOOF_GO_ENDPOINT="${SERVER_ENDPOINT}"

--- a/scripts/devnet/test_partition_control_fixtures.sh
+++ b/scripts/devnet/test_partition_control_fixtures.sh
@@ -79,6 +79,7 @@ start_spoof_server() {
   local label="$1" runtime_name="$2" log_file spoof_bin
   log_file="${label}.log"
   spoof_bin="${RUBIN_PROCESS_ARTIFACT_ROOT}/${runtime_name}"
+  SPOOF_EXECUTABLE="${spoof_bin}"
   cat >"${spoof_bin}" <<'PL'
 #!/usr/bin/env perl
 use strict; use warnings;
@@ -133,7 +134,7 @@ MISSING_TARGET="${RUBIN_PROCESS_ARTIFACT_ROOT}/missing target.txt"
 write_server "${SERVER_PY}"
 write_runtime_stub "${EXPECTED_GO_BIN}"
 
-SERVER_PID="" SERVER_ENDPOINT=""
+SERVER_PID="" SERVER_ENDPOINT="" SPOOF_EXECUTABLE=""
 start_server go-helper send; GO_PID="${SERVER_PID}" GO_ENDPOINT="${SERVER_ENDPOINT}"
 start_server rust-helper send; RUST_PID="${SERVER_PID}" RUST_ENDPOINT="${SERVER_ENDPOINT}"
 start_server silent-helper silent; SILENT_ENDPOINT="${SERVER_ENDPOINT}"
@@ -142,7 +143,8 @@ SPOOF_GO_COMM="$(_rubin_process_pid_comm "${SPOOF_GO_PID}")" || { echo "failed t
 
 expect_fail_contains "fake go identity" "reason=process_identity_unverified" rubin_process_register_topology_node node-go go "${GO_PID}" "${GO_ENDPOINT}"
 expect_fail_contains "basename spoof missing expected executable" "reason=missing_expected_executable" rubin_process_register_topology_node node-spoof go "${SPOOF_GO_PID}" "${SPOOF_GO_ENDPOINT}"
-expect_fail_contains "basename spoof identity" "reason=process_identity_unverified" rubin_process_register_topology_node node-spoof go "${SPOOF_GO_PID}" "${SPOOF_GO_ENDPOINT}" "${EXPECTED_GO_BIN}"
+expect_fail_contains "basename spoof arbitrary expected executable" "reason=runtime_identity_verifier_required" rubin_process_register_topology_node node-spoof go "${SPOOF_GO_PID}" "${SPOOF_GO_ENDPOINT}" "${SPOOF_EXECUTABLE}"
+expect_fail_contains "basename spoof identity mismatch" "reason=runtime_identity_verifier_required" rubin_process_register_topology_node node-spoof go "${SPOOF_GO_PID}" "${SPOOF_GO_ENDPOINT}" "${EXPECTED_GO_BIN}"
 ((${#RUBIN_PROCESS_TOPOLOGY_NAMES[@]} == 0)) || { echo "fake process was registered as topology" >&2; exit 1; }
 expect_fail_contains "socket timeout" "reason=probe_timeout" rubin_process_probe_endpoint "${SILENT_ENDPOINT}" 1
 expect_fail_contains "invalid probe timeout" "reason=invalid_probe_timeout" rubin_process_probe_endpoint "${GO_ENDPOINT}" not-a-float

--- a/scripts/devnet/test_partition_control_fixtures.sh
+++ b/scripts/devnet/test_partition_control_fixtures.sh
@@ -16,23 +16,23 @@ require_contains() {
 expect_fail_contains() {
   local label="$1" needle="$2"
   shift 2
-  local output
-  if output="$("$@" 2>&1)"; then
+  local output output_file="${PARENT}/expect-fail-output.txt"
+  if "$@" >"${output_file}" 2>&1; then
     printf 'expected failure for %s\n' "${label}" >&2
     return 1
   fi
+  output="$(<"${output_file}")"
   require_contains "${output}" "${needle}" "${label}"
 }
 
 expect_fail_with_path_contains() {
-  local label="$1" needle="$2" path="$3"
+  local label="$1" needle="$2" path="$3" old_path rc
   shift 3
-  local output
-  if output="$(PATH="${path}" "$@" 2>&1)"; then
-    printf 'expected failure for %s\n' "${label}" >&2
-    return 1
-  fi
-  require_contains "${output}" "${needle}" "${label}"
+  old_path="${PATH}"
+  PATH="${path}"
+  if expect_fail_contains "${label}" "${needle}" "$@"; then rc=0; else rc=$?; fi
+  PATH="${old_path}"
+  return "${rc}"
 }
 
 write_server() {
@@ -195,5 +195,5 @@ printf '%s\n' "${RUST_ENDPOINT}" >"${TARGET_FILE}"
 expect_fail_contains "stale topology" "reason=stale_topology" rubin_process_partition_pair node-go node-rust
 
 rubin_process_cleanup 0
-rmdir "${PARENT}"
+rm -f "${PARENT}/expect-fail-output.txt"; rmdir "${PARENT}"
 printf 'PASS: partition control helpers fail closed without live runtime proof\n'

--- a/scripts/devnet/test_partition_control_fixtures.sh
+++ b/scripts/devnet/test_partition_control_fixtures.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HELPER="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/scripts/devnet-process-common.sh"
+# shellcheck source=scripts/devnet-process-common.sh disable=SC1091
+source "${HELPER}"
+
+require_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  [[ "${haystack}" == *"${needle}"* ]] || { printf 'missing %s in %s: %s\n' "${needle}" "${label}" "${haystack}" >&2; return 1; }
+}
+
+expect_fail_contains() {
+  local label="$1" needle="$2"
+  shift 2
+  local output
+  if output="$("$@" 2>&1)"; then
+    printf 'expected failure for %s\n' "${label}" >&2
+    return 1
+  fi
+  require_contains "${output}" "${needle}" "${label}"
+}
+
+write_server() {
+  cat >"$1" <<'PY'
+import socket, sys, threading, time
+mode = sys.argv[1]
+listener = socket.socket()
+listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+listener.bind(("127.0.0.1", 0))
+listener.listen()
+print(f"server: listening={listener.getsockname()[0]}:{listener.getsockname()[1]}", flush=True)
+def handle(conn):
+    try:
+        if mode == "send":
+            conn.sendall(b"ok")
+        else:
+            time.sleep(3)
+    except OSError:
+        pass
+    finally:
+        try:
+            conn.close()
+        except OSError:
+            pass
+while True:
+    conn, _ = listener.accept()
+    threading.Thread(target=handle, args=(conn,), daemon=True).start()
+PY
+}
+
+server_addr() { sed -n 's/.*server: listening=//p' "$1" | tail -n 1 | tr -d '[:space:]'; }
+
+start_server() {
+  local label="$1" mode="$2" log_file
+  log_file="${label}.log"
+  rubin_process_start "${log_file}" python3 -u "${SERVER_PY}" "${mode}"
+  rubin_process_wait_for_log "${log_file}" "server: listening=" 10 "${RUBIN_PROCESS_LAST_PID}"
+  SERVER_PID="${RUBIN_PROCESS_LAST_PID}"
+  SERVER_ENDPOINT="$(server_addr "${RUBIN_PROCESS_ARTIFACT_ROOT}/${log_file}")"
+}
+
+seed_nodes() {
+  RUBIN_PROCESS_TOPOLOGY_NAMES=(node-go node-rust)
+  RUBIN_PROCESS_TOPOLOGY_IMPLS=("${1:-go}" "${2:-rust}")
+  RUBIN_PROCESS_TOPOLOGY_PIDS=("${GO_PID}" "${RUST_PID}")
+  RUBIN_PROCESS_TOPOLOGY_ENDPOINTS=("${GO_ENDPOINT}" "${RUST_ENDPOINT}")
+}
+
+seed_link() {
+  RUBIN_PROCESS_PROXY_SOURCES=(node-go)
+  RUBIN_PROCESS_PROXY_TARGETS=(node-rust)
+  RUBIN_PROCESS_PROXY_ADDRS=("127.0.0.1:1")
+  RUBIN_PROCESS_PROXY_TARGET_FILES=("$1")
+}
+
+PARENT="$(mktemp -d "${TMPDIR:-/tmp}/rubin partition fail closed.XXXXXX")"
+cleanup_fixture() {
+  local status=$?
+  rubin_process_cleanup "${status}" || true
+  [[ "${status}" != "0" || ! -d "${PARENT}" ]] || rmdir "${PARENT}" || true
+  exit "${status}"
+}
+RUBIN_PROCESS_ARTIFACT_PARENT="${PARENT}"
+rubin_process_init partition-control-fail-closed
+trap cleanup_fixture EXIT
+
+SERVER_PY="${RUBIN_PROCESS_ARTIFACT_ROOT}/helper server.py"
+TARGET_FILE="${RUBIN_PROCESS_ARTIFACT_ROOT}/proxy target.txt"
+MISSING_TARGET="${RUBIN_PROCESS_ARTIFACT_ROOT}/missing target.txt"
+write_server "${SERVER_PY}"
+
+SERVER_PID="" SERVER_ENDPOINT=""
+start_server go-helper send; GO_PID="${SERVER_PID}" GO_ENDPOINT="${SERVER_ENDPOINT}"
+start_server rust-helper send; RUST_PID="${SERVER_PID}" RUST_ENDPOINT="${SERVER_ENDPOINT}"
+start_server silent-helper silent; SILENT_ENDPOINT="${SERVER_ENDPOINT}"
+
+expect_fail_contains "fake go identity" "reason=process_identity_unverified" rubin_process_register_topology_node node-go go "${GO_PID}" "${GO_ENDPOINT}"
+((${#RUBIN_PROCESS_TOPOLOGY_NAMES[@]} == 0)) || { echo "fake process was registered as topology" >&2; exit 1; }
+expect_fail_contains "socket timeout" "reason=probe_timeout" rubin_process_probe_endpoint "${SILENT_ENDPOINT}" 1
+expect_fail_contains "unknown source" "reason=unknown_source" rubin_process_partition_pair node-missing node-rust
+
+RUBIN_PROCESS_TOPOLOGY_NAMES=(node-go)
+RUBIN_PROCESS_TOPOLOGY_IMPLS=(go)
+RUBIN_PROCESS_TOPOLOGY_PIDS=("${GO_PID}")
+RUBIN_PROCESS_TOPOLOGY_ENDPOINTS=("${GO_ENDPOINT}")
+expect_fail_contains "same node" "reason=same_node" rubin_process_partition_pair node-go node-go
+expect_fail_contains "single node" "reason=single_node_topology" rubin_process_partition_pair node-go node-rust
+
+seed_nodes go go
+expect_fail_contains "same client" "reason=same_client_topology" rubin_process_partition_pair node-go node-rust
+
+seed_nodes
+seed_link "${MISSING_TARGET}"
+expect_fail_contains "missing proxy target" "reason=missing_proxy_target" rubin_process_partition_pair node-go node-rust
+
+printf 'drop\n' >"${TARGET_FILE}"
+seed_link "${TARGET_FILE}"
+expect_fail_contains "partition no effect" "reason=no_effect" rubin_process_partition_pair node-go node-rust
+printf '%s\n' "${RUST_ENDPOINT}" >"${TARGET_FILE}"
+expect_fail_contains "heal no effect" "reason=no_effect" rubin_process_heal_pair node-go node-rust
+expect_fail_contains "runtime verifier required" "reason=runtime_edge_verifier_required" rubin_process_partition_pair node-go node-rust
+
+rubin_process_stop_pid "${RUST_PID}" || true
+printf '%s\n' "${RUST_ENDPOINT}" >"${TARGET_FILE}"
+expect_fail_contains "stale topology" "reason=stale_topology" rubin_process_partition_pair node-go node-rust
+
+rubin_process_cleanup 0
+rmdir "${PARENT}"
+printf 'PASS: partition control helpers fail closed without live runtime proof\n'

--- a/scripts/devnet/test_partition_control_fixtures.sh
+++ b/scripts/devnet/test_partition_control_fixtures.sh
@@ -49,6 +49,15 @@ while True:
 PY
 }
 
+write_runtime_stub() {
+  mkdir -p "$(dirname "$1")"
+  cat >"$1" <<'SH'
+#!/usr/bin/env sh
+exit 99
+SH
+  chmod +x "$1"
+}
+
 server_addr() { sed -n 's/.*server: listening=//p' "$1" | tail -n 1 | tr -d '[:space:]'; }
 
 start_server() {
@@ -60,11 +69,35 @@ start_server() {
   SERVER_ENDPOINT="$(server_addr "${RUBIN_PROCESS_ARTIFACT_ROOT}/${log_file}")"
 }
 
+start_spoof_server() {
+  local label="$1" runtime_name="$2" log_file spoof_bin
+  log_file="${label}.log"
+  spoof_bin="${RUBIN_PROCESS_ARTIFACT_ROOT}/${runtime_name}"
+  cat >"${spoof_bin}" <<'PL'
+#!/usr/bin/env perl
+use strict; use warnings;
+use IO::Socket::INET;
+$0 =~ s{.*/}{}; $| = 1;
+my $listener = IO::Socket::INET->new(LocalAddr => "127.0.0.1", LocalPort => 0, Listen => 5, ReuseAddr => 1, Proto => "tcp") or die "listen failed: $!";
+print "server: listening=127.0.0.1:" . $listener->sockport() . "\n";
+while (1) {
+  my $client = $listener->accept();
+  next unless $client; print {$client} "ok"; close $client;
+}
+PL
+  chmod +x "${spoof_bin}"
+  rubin_process_start "${log_file}" "${spoof_bin}"
+  rubin_process_wait_for_log "${log_file}" "server: listening=" 10 "${RUBIN_PROCESS_LAST_PID}"
+  SERVER_PID="${RUBIN_PROCESS_LAST_PID}"
+  SERVER_ENDPOINT="$(server_addr "${RUBIN_PROCESS_ARTIFACT_ROOT}/${log_file}")"
+}
+
 seed_nodes() {
   RUBIN_PROCESS_TOPOLOGY_NAMES=(node-go node-rust)
   RUBIN_PROCESS_TOPOLOGY_IMPLS=("${1:-go}" "${2:-rust}")
   RUBIN_PROCESS_TOPOLOGY_PIDS=("${GO_PID}" "${RUST_PID}")
   RUBIN_PROCESS_TOPOLOGY_ENDPOINTS=("${GO_ENDPOINT}" "${RUST_ENDPOINT}")
+  RUBIN_PROCESS_TOPOLOGY_EXEC_REALPATHS=("$(_rubin_process_started_exec_realpath "${GO_PID}")" "$(_rubin_process_started_exec_realpath "${RUST_PID}")")
 }
 
 seed_link() {
@@ -86,16 +119,22 @@ rubin_process_init partition-control-fail-closed
 trap cleanup_fixture EXIT
 
 SERVER_PY="${RUBIN_PROCESS_ARTIFACT_ROOT}/helper server.py"
+EXPECTED_GO_BIN="${RUBIN_PROCESS_ARTIFACT_ROOT}/expected/rubin-node-go"
 TARGET_FILE="${RUBIN_PROCESS_ARTIFACT_ROOT}/proxy target.txt"
 MISSING_TARGET="${RUBIN_PROCESS_ARTIFACT_ROOT}/missing target.txt"
 write_server "${SERVER_PY}"
+write_runtime_stub "${EXPECTED_GO_BIN}"
 
 SERVER_PID="" SERVER_ENDPOINT=""
 start_server go-helper send; GO_PID="${SERVER_PID}" GO_ENDPOINT="${SERVER_ENDPOINT}"
 start_server rust-helper send; RUST_PID="${SERVER_PID}" RUST_ENDPOINT="${SERVER_ENDPOINT}"
 start_server silent-helper silent; SILENT_ENDPOINT="${SERVER_ENDPOINT}"
+start_spoof_server basename-spoof rubin-node-go; SPOOF_GO_PID="${SERVER_PID}" SPOOF_GO_ENDPOINT="${SERVER_ENDPOINT}"
+SPOOF_GO_COMM="$(_rubin_process_pid_comm "${SPOOF_GO_PID}")" || { echo "failed to read spoof process comm" >&2; exit 1; }; [[ "${SPOOF_GO_COMM}" == "rubin-node-go" ]] || { echo "spoof fixture did not expose rubin-node-go comm: ${SPOOF_GO_COMM}" >&2; exit 1; }
 
 expect_fail_contains "fake go identity" "reason=process_identity_unverified" rubin_process_register_topology_node node-go go "${GO_PID}" "${GO_ENDPOINT}"
+expect_fail_contains "basename spoof missing expected executable" "reason=missing_expected_executable" rubin_process_register_topology_node node-spoof go "${SPOOF_GO_PID}" "${SPOOF_GO_ENDPOINT}"
+expect_fail_contains "basename spoof identity" "reason=process_identity_unverified" rubin_process_register_topology_node node-spoof go "${SPOOF_GO_PID}" "${SPOOF_GO_ENDPOINT}" "${EXPECTED_GO_BIN}"
 ((${#RUBIN_PROCESS_TOPOLOGY_NAMES[@]} == 0)) || { echo "fake process was registered as topology" >&2; exit 1; }
 expect_fail_contains "socket timeout" "reason=probe_timeout" rubin_process_probe_endpoint "${SILENT_ENDPOINT}" 1
 expect_fail_contains "unknown source" "reason=unknown_source" rubin_process_partition_pair node-missing node-rust
@@ -104,6 +143,7 @@ RUBIN_PROCESS_TOPOLOGY_NAMES=(node-go)
 RUBIN_PROCESS_TOPOLOGY_IMPLS=(go)
 RUBIN_PROCESS_TOPOLOGY_PIDS=("${GO_PID}")
 RUBIN_PROCESS_TOPOLOGY_ENDPOINTS=("${GO_ENDPOINT}")
+RUBIN_PROCESS_TOPOLOGY_EXEC_REALPATHS=("$(_rubin_process_started_exec_realpath "${GO_PID}")")
 expect_fail_contains "same node" "reason=same_node" rubin_process_partition_pair node-go node-go
 expect_fail_contains "single node" "reason=single_node_topology" rubin_process_partition_pair node-go node-rust
 

--- a/scripts/devnet/test_partition_control_fixtures.sh
+++ b/scripts/devnet/test_partition_control_fixtures.sh
@@ -5,10 +5,7 @@ HELPER="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/scripts/devnet-proce
 # shellcheck source=scripts/devnet-process-common.sh disable=SC1091
 source "${HELPER}"
 
-if ! command -v lsof >/dev/null 2>&1; then
-  printf 'SKIP: NO_DATA reason=lsof_unavailable fixture=partition_control\n'
-  exit 0
-fi
+command -v lsof >/dev/null 2>&1 || { printf 'FAIL: NO_DATA reason=lsof_unavailable fixture=partition_control\n' >&2; exit 1; }
 
 # Fixture-only internal _rubin_process_* calls seed hostile states unreachable through public APIs.
 require_contains() {


### PR DESCRIPTION
Linear: RUB-228
GitHub issue: Closes #1517
Parent: RUB-29

Invariant:
Partition-control shell helpers fail closed for fake/helper-only process identity, stale topology, raw socket timeout-as-success, and no-effect controls. This PR does not claim live mixed-client partition/heal proof.

Changed files:
- scripts/devnet-process-common.sh
- scripts/devnet/test_partition_control_fixtures.sh

Validation:
- bash -n scripts/devnet-process-common.sh scripts/devnet/test_partition_control_fixtures.sh
- shellcheck scripts/devnet-process-common.sh scripts/devnet/test_partition_control_fixtures.sh
- bash scripts/devnet/test_partition_control_fixtures.sh
- git diff --check
- rubin-precommit-one-review + one stock code-review pass: no findings
- rubin-push: PASS

Non-scope:
- no live Go/Rust peer-state partition/heal proof; RUB-229 owns that
- no RUB-24 schema/validator/report changes
- no RUB-30 reorg proof
- no RUB-34 report rendering
- no Go/Rust node runtime or P2P behavior changes