### PR TITLE
[RUB-16] Surface Rust txpool requeue cleanup failures

### DIFF
--- a/clients/rust/crates/rubin-node/src/p2p_service.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_service.rs
@@ -941,7 +941,18 @@ fn apply_tx_pool_cleanup(
         .tx_pool
         .lock()
         .map_err(|_| "tx pool unavailable".to_string())?;
-    tx_pool_cleanup.apply(&mut tx_pool, &chain_state, block_store.as_ref(), chain_id);
+    let report = tx_pool_cleanup.apply_with_report(
+        &mut tx_pool,
+        &chain_state,
+        block_store.as_ref(),
+        chain_id,
+    );
+    if report.has_requeue_failures() {
+        return Err(format!(
+            "tx pool cleanup requeue failed: {}",
+            report.requeue_failure_summary()
+        ));
+    }
     Ok(())
 }
 
@@ -1095,6 +1106,7 @@ mod tests {
         LiveMessageOutcome, PeerManager, PeerRuntimeConfig, VersionPayloadV1, WireMessage, MSG_TX,
     };
     use crate::sync_reorg::TxPoolCleanupPlan;
+    use crate::test_helpers::{block_with_txs, signed_conflicting_p2pk_state_and_txs};
     use crate::tx_relay::PeerOutbox;
     use crate::tx_relay::TxRelayState;
     use crate::{
@@ -1148,6 +1160,71 @@ mod tests {
             peer_aliases: Arc::new(Mutex::new(HashMap::new())),
             local_addr: "127.0.0.1:0".to_string(),
         }
+    }
+
+    fn test_shared_state_after_genesis(prefix: &str) -> (SharedServiceState, std::path::PathBuf) {
+        let (sync_engine, dir) = test_engine(prefix);
+        {
+            let mut engine = sync_engine.lock().expect("sync engine");
+            let genesis = devnet_genesis_block_bytes();
+            engine
+                .apply_block_with_reorg(&genesis, None)
+                .expect("apply genesis");
+        }
+        let shared = test_shared_state(
+            default_peer_runtime_config("devnet", 8),
+            Vec::new(),
+            sync_engine,
+        );
+        (shared, dir)
+    }
+
+    fn store_requeue_block(shared: &SharedServiceState, txs: &[Vec<u8>]) -> [u8; 32] {
+        let block = block_with_txs(1, 0, test_genesis_hash(), 2, txs);
+        let block_hash_bytes = block_hash(&block[..BLOCK_HEADER_BYTES]).expect("block hash");
+        let engine = shared.sync_engine.lock().expect("sync engine");
+        let block_store = engine.block_store.as_ref().expect("blockstore");
+        block_store
+            .store_block(block_hash_bytes, &block[..BLOCK_HEADER_BYTES], &block)
+            .expect("store requeue block");
+        block_hash_bytes
+    }
+
+    fn store_invalid_requeue_block(shared: &SharedServiceState) -> [u8; 32] {
+        let block = block_with_txs(1, 0, test_genesis_hash(), 3, &[]);
+        let header = &block[..BLOCK_HEADER_BYTES];
+        let block_hash_bytes = block_hash(header).expect("block hash");
+        let engine = shared.sync_engine.lock().expect("sync engine");
+        let block_store = engine.block_store.as_ref().expect("blockstore");
+        block_store
+            .store_block(block_hash_bytes, header, header)
+            .expect("store invalid requeue block");
+        block_hash_bytes
+    }
+
+    fn requeue_cleanup(block_hash_bytes: [u8; 32]) -> TxPoolCleanupPlan {
+        TxPoolCleanupPlan::from_parts_for_test(Vec::new(), Vec::new(), vec![block_hash_bytes])
+    }
+
+    fn assert_requeue_cleanup_error(result: Result<(), String>, expected_bucket: &str) {
+        let err = result.expect_err("requeue cleanup failure must reach live caller");
+        assert!(
+            err.contains("tx pool cleanup requeue failed:"),
+            "unexpected error prefix: {err}"
+        );
+        for field in [
+            "requeue_blocks_unavailable",
+            "requeue_blocks_invalid",
+            "requeue_conflict",
+            "requeue_rejected",
+            "requeue_unavailable",
+        ] {
+            assert!(err.contains(field), "missing {field} in error: {err}");
+        }
+        assert!(
+            err.contains(expected_bucket),
+            "missing expected bucket {expected_bucket}: {err}"
+        );
     }
 
     fn wait_until(deadline: Instant, check: impl Fn() -> bool) {
@@ -1235,6 +1312,74 @@ mod tests {
         apply_tx_pool_cleanup(&shared, cleanup).expect("cleanup should apply");
 
         fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn apply_tx_pool_cleanup_surfaces_all_requeue_failure_buckets() {
+        let (shared, dir) = test_shared_state_after_genesis("rubin-node-p2p-requeue-missing-block");
+        assert_requeue_cleanup_error(
+            apply_tx_pool_cleanup(&shared, requeue_cleanup([0x44; 32])),
+            "requeue_blocks_unavailable=1",
+        );
+        fs::remove_dir_all(dir).expect("cleanup missing block");
+
+        let (shared, dir) = test_shared_state_after_genesis("rubin-node-p2p-requeue-invalid-block");
+        let invalid_block_hash = store_invalid_requeue_block(&shared);
+        assert_requeue_cleanup_error(
+            apply_tx_pool_cleanup(&shared, requeue_cleanup(invalid_block_hash)),
+            "requeue_blocks_invalid=1",
+        );
+        fs::remove_dir_all(dir).expect("cleanup invalid block");
+
+        let (shared, dir) = test_shared_state_after_genesis("rubin-node-p2p-requeue-unavailable");
+        let (state, low_fee_raw, _) = signed_conflicting_p2pk_state_and_txs(20, 10, 9);
+        {
+            let mut engine = shared.sync_engine.lock().expect("sync engine");
+            engine.chain_state.utxos = state.utxos.clone();
+        }
+        let low_fee_block_hash = store_requeue_block(&shared, std::slice::from_ref(&low_fee_raw));
+        assert_requeue_cleanup_error(
+            apply_tx_pool_cleanup(&shared, requeue_cleanup(low_fee_block_hash)),
+            "requeue_unavailable=1",
+        );
+        fs::remove_dir_all(dir).expect("cleanup unavailable");
+
+        let (shared, dir) = test_shared_state_after_genesis("rubin-node-p2p-requeue-rejected");
+        let (_, missing_utxo_raw, _) = signed_conflicting_p2pk_state_and_txs(7700, 10, 9);
+        let rejected_block_hash =
+            store_requeue_block(&shared, std::slice::from_ref(&missing_utxo_raw));
+        assert_requeue_cleanup_error(
+            apply_tx_pool_cleanup(&shared, requeue_cleanup(rejected_block_hash)),
+            "requeue_rejected=1",
+        );
+        fs::remove_dir_all(dir).expect("cleanup rejected");
+
+        let (shared, dir) = test_shared_state_after_genesis("rubin-node-p2p-requeue-conflict");
+        let (state, admitted_raw, _) = signed_conflicting_p2pk_state_and_txs(7700, 10, 9);
+        {
+            let mut engine = shared.sync_engine.lock().expect("sync engine");
+            engine.chain_state.utxos = state.utxos.clone();
+        }
+        let conflict_block_hash = store_requeue_block(&shared, std::slice::from_ref(&admitted_raw));
+        {
+            let engine = shared.sync_engine.lock().expect("sync engine");
+            shared
+                .tx_pool
+                .lock()
+                .expect("tx pool")
+                .admit(
+                    &admitted_raw,
+                    &engine.chain_state,
+                    engine.block_store.as_ref(),
+                    engine.cfg.chain_id,
+                )
+                .expect("preload duplicate");
+        }
+        assert_requeue_cleanup_error(
+            apply_tx_pool_cleanup(&shared, requeue_cleanup(conflict_block_hash)),
+            "requeue_conflict=1",
+        );
+        fs::remove_dir_all(dir).expect("cleanup conflict");
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/p2p_service.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_service.rs
@@ -883,7 +883,10 @@ fn handle_peer(
                 drop(engine);
                 finalize_live_message_outcome(&shared, outcome, pending_cleanup)?
             };
-            maybe_apply_tx_pool_cleanup(&shared, tx_pool_cleanup)?;
+            log_tx_pool_cleanup_requeue_failure(&maybe_apply_tx_pool_cleanup(
+                &shared,
+                tx_pool_cleanup,
+            )?);
             responses
         };
         for outbound in outbound_messages {
@@ -925,7 +928,7 @@ where
 fn apply_tx_pool_cleanup(
     shared: &SharedServiceState,
     tx_pool_cleanup: TxPoolCleanupPlan,
-) -> Result<(), String> {
+) -> Result<Option<String>, String> {
     let (chain_state, block_store, chain_id) = {
         let engine = shared
             .sync_engine
@@ -948,22 +951,25 @@ fn apply_tx_pool_cleanup(
         chain_id,
     );
     if report.has_requeue_failures() {
-        return Err(format!(
-            "tx pool cleanup requeue failed: {}",
-            report.requeue_failure_summary()
-        ));
+        return Ok(Some(report.requeue_failure_summary()));
     }
-    Ok(())
+    Ok(None)
 }
 
 fn maybe_apply_tx_pool_cleanup(
     shared: &SharedServiceState,
     tx_pool_cleanup: TxPoolCleanupPlan,
-) -> Result<(), String> {
+) -> Result<Option<String>, String> {
     if tx_pool_cleanup.is_empty() {
-        return Ok(());
+        return Ok(None);
     }
     apply_tx_pool_cleanup(shared, tx_pool_cleanup)
+}
+
+fn log_tx_pool_cleanup_requeue_failure(summary: &Option<String>) {
+    if let Some(summary) = summary {
+        eprintln!("p2p: tx pool cleanup requeue failed: {summary}");
+    }
 }
 
 fn finalize_live_message_outcome(
@@ -977,7 +983,10 @@ fn finalize_live_message_outcome(
             outcome.tx_pool_cleanup.merge(pending_cleanup),
         )),
         Err(err) => {
-            maybe_apply_tx_pool_cleanup(shared, pending_cleanup)?;
+            log_tx_pool_cleanup_requeue_failure(&maybe_apply_tx_pool_cleanup(
+                shared,
+                pending_cleanup,
+            )?);
             Err(format!("handle live message: {err}"))
         }
     }
@@ -1116,21 +1125,6 @@ mod tests {
 
     static DNS_RESOLVER_TEST_LOCK: Mutex<()> = Mutex::new(());
 
-    struct ActiveDnsResolversRestore {
-        previous: usize,
-    }
-
-    impl Drop for ActiveDnsResolversRestore {
-        fn drop(&mut self) {
-            super::ACTIVE_DNS_RESOLVERS.store(self.previous, Ordering::SeqCst);
-        }
-    }
-
-    fn force_active_dns_resolvers_for_test(count: usize) -> ActiveDnsResolversRestore {
-        let previous = super::ACTIVE_DNS_RESOLVERS.swap(count, Ordering::SeqCst);
-        ActiveDnsResolversRestore { previous }
-    }
-
     fn unique_temp_dir(prefix: &str) -> std::path::PathBuf {
         std::env::temp_dir().join(format!(
             "{prefix}-{}",
@@ -1223,11 +1217,16 @@ mod tests {
         TxPoolCleanupPlan::from_parts_for_test(Vec::new(), Vec::new(), vec![block_hash_bytes])
     }
 
-    fn assert_requeue_cleanup_error(result: Result<(), String>, expected_bucket: &str) {
-        let err = result.expect_err("requeue cleanup failure must reach live caller");
+    fn assert_requeue_cleanup_failure(
+        result: Result<Option<String>, String>,
+        expected_bucket: &str,
+    ) {
+        let err = result
+            .expect("routine requeue failure must not be infrastructure-fatal")
+            .expect("requeue cleanup failure must reach live caller");
         assert!(
-            err.contains("tx pool cleanup requeue failed:"),
-            "unexpected error prefix: {err}"
+            err.contains("requeue_attempted="),
+            "unexpected cleanup summary: {err}"
         );
         for field in [
             "requeue_blocks_unavailable",
@@ -1326,7 +1325,10 @@ mod tests {
         let cleanup =
             TxPoolCleanupPlan::from_parts_for_test(vec![[0x11; 32]], Vec::new(), Vec::new());
 
-        apply_tx_pool_cleanup(&shared, cleanup).expect("cleanup should apply");
+        assert_eq!(
+            apply_tx_pool_cleanup(&shared, cleanup).expect("cleanup should apply"),
+            None
+        );
 
         fs::remove_dir_all(dir).expect("cleanup");
     }
@@ -1334,7 +1336,7 @@ mod tests {
     #[test]
     fn apply_tx_pool_cleanup_surfaces_all_requeue_failure_buckets() {
         let (shared, dir) = test_shared_state_after_genesis("rubin-node-p2p-requeue-missing-block");
-        assert_requeue_cleanup_error(
+        assert_requeue_cleanup_failure(
             apply_tx_pool_cleanup(&shared, requeue_cleanup([0x44; 32])),
             "requeue_blocks_unavailable=1",
         );
@@ -1342,7 +1344,7 @@ mod tests {
 
         let (shared, dir) = test_shared_state_after_genesis("rubin-node-p2p-requeue-invalid-block");
         let invalid_block_hash = store_invalid_requeue_block(&shared);
-        assert_requeue_cleanup_error(
+        assert_requeue_cleanup_failure(
             apply_tx_pool_cleanup(&shared, requeue_cleanup(invalid_block_hash)),
             "requeue_blocks_invalid=1",
         );
@@ -1355,7 +1357,7 @@ mod tests {
             engine.chain_state.utxos = state.utxos.clone();
         }
         let low_fee_block_hash = store_requeue_block(&shared, std::slice::from_ref(&low_fee_raw));
-        assert_requeue_cleanup_error(
+        assert_requeue_cleanup_failure(
             apply_tx_pool_cleanup(&shared, requeue_cleanup(low_fee_block_hash)),
             "requeue_unavailable=1",
         );
@@ -1365,7 +1367,7 @@ mod tests {
         let (_, missing_utxo_raw, _) = signed_conflicting_p2pk_state_and_txs(7700, 10, 9);
         let rejected_block_hash =
             store_requeue_block(&shared, std::slice::from_ref(&missing_utxo_raw));
-        assert_requeue_cleanup_error(
+        assert_requeue_cleanup_failure(
             apply_tx_pool_cleanup(&shared, requeue_cleanup(rejected_block_hash)),
             "requeue_rejected=1",
         );
@@ -1392,8 +1394,8 @@ mod tests {
                 )
                 .expect("preload duplicate");
         }
-        assert_requeue_cleanup_error(
-            apply_tx_pool_cleanup(&shared, requeue_cleanup(conflict_block_hash)),
+        assert_requeue_cleanup_failure(
+            maybe_apply_tx_pool_cleanup(&shared, requeue_cleanup(conflict_block_hash)),
             "requeue_conflict=1",
         );
         fs::remove_dir_all(dir).expect("cleanup conflict");
@@ -1408,8 +1410,11 @@ mod tests {
             sync_engine,
         );
 
-        maybe_apply_tx_pool_cleanup(&shared, TxPoolCleanupPlan::default())
-            .expect("empty cleanup should noop");
+        assert_eq!(
+            maybe_apply_tx_pool_cleanup(&shared, TxPoolCleanupPlan::default())
+                .expect("empty cleanup should noop"),
+            None
+        );
 
         fs::remove_dir_all(dir).expect("cleanup");
     }
@@ -2025,9 +2030,7 @@ mod tests {
 
     #[test]
     fn connect_with_timeout_rejects_unresolvable_addr() {
-        let _dns_guard = DNS_RESOLVER_TEST_LOCK
-            .lock()
-            .expect("dns resolver test lock");
+        let _dns_guard = DNS_RESOLVER_TEST_LOCK.lock().unwrap();
         let err = connect_with_timeout("bad host:19111", Duration::from_millis(25)).unwrap_err();
         assert!(
             err.contains("peer address resolution failed"),
@@ -2627,12 +2630,11 @@ mod tests {
 
     #[test]
     fn connect_with_timeout_rejects_when_dns_resolvers_saturated() {
-        let _dns_guard = DNS_RESOLVER_TEST_LOCK
-            .lock()
-            .expect("dns resolver test lock");
-        let _resolver_restore =
-            force_active_dns_resolvers_for_test(super::MAX_DNS_RESOLVER_THREADS);
+        let _dns_guard = DNS_RESOLVER_TEST_LOCK.lock().unwrap();
+        let prev = super::ACTIVE_DNS_RESOLVERS.load(Ordering::SeqCst);
+        super::ACTIVE_DNS_RESOLVERS.store(super::MAX_DNS_RESOLVER_THREADS, Ordering::SeqCst);
         let result = super::connect_with_timeout("unreachable.test:80", Duration::from_secs(1));
+        super::ACTIVE_DNS_RESOLVERS.store(prev, Ordering::SeqCst);
         let err = result.unwrap_err();
         assert!(
             err.contains("DNS resolver limit reached"),
@@ -2653,9 +2655,7 @@ mod tests {
 
     #[test]
     fn connect_with_timeout_hostname_uses_dns_resolver_path() {
-        let _dns_guard = DNS_RESOLVER_TEST_LOCK
-            .lock()
-            .expect("dns resolver test lock");
+        let _dns_guard = DNS_RESOLVER_TEST_LOCK.lock().unwrap();
         // "localhost:1" resolves via DNS (not IP literal fast path),
         // covering the resolver thread spawn + channel recv + addr iteration.
         // Port 1 is refused immediately, so this is fast.

--- a/clients/rust/crates/rubin-node/src/p2p_service.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_service.rs
@@ -940,16 +940,18 @@ fn apply_tx_pool_cleanup(
             engine.chain_id(),
         )
     };
-    let mut tx_pool = shared
-        .tx_pool
-        .lock()
-        .map_err(|_| "tx pool unavailable".to_string())?;
-    let report = tx_pool_cleanup.apply_with_report(
-        &mut tx_pool,
-        &chain_state,
-        block_store.as_ref(),
-        chain_id,
-    );
+    let report = {
+        let mut tx_pool = shared
+            .tx_pool
+            .lock()
+            .map_err(|_| "tx pool unavailable".to_string())?;
+        tx_pool_cleanup.apply_with_report(
+            &mut tx_pool,
+            &chain_state,
+            block_store.as_ref(),
+            chain_id,
+        )
+    };
     if report.has_requeue_failures() {
         return Ok(Some(report.requeue_failure_summary()));
     }

--- a/clients/rust/crates/rubin-node/src/p2p_service.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_service.rs
@@ -1114,6 +1114,23 @@ mod tests {
     };
     use std::collections::HashMap;
 
+    static DNS_RESOLVER_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    struct ActiveDnsResolversRestore {
+        previous: usize,
+    }
+
+    impl Drop for ActiveDnsResolversRestore {
+        fn drop(&mut self) {
+            super::ACTIVE_DNS_RESOLVERS.store(self.previous, Ordering::SeqCst);
+        }
+    }
+
+    fn force_active_dns_resolvers_for_test(count: usize) -> ActiveDnsResolversRestore {
+        let previous = super::ACTIVE_DNS_RESOLVERS.swap(count, Ordering::SeqCst);
+        ActiveDnsResolversRestore { previous }
+    }
+
     fn unique_temp_dir(prefix: &str) -> std::path::PathBuf {
         std::env::temp_dir().join(format!(
             "{prefix}-{}",
@@ -2008,6 +2025,9 @@ mod tests {
 
     #[test]
     fn connect_with_timeout_rejects_unresolvable_addr() {
+        let _dns_guard = DNS_RESOLVER_TEST_LOCK
+            .lock()
+            .expect("dns resolver test lock");
         let err = connect_with_timeout("bad host:19111", Duration::from_millis(25)).unwrap_err();
         assert!(
             err.contains("peer address resolution failed"),
@@ -2607,10 +2627,12 @@ mod tests {
 
     #[test]
     fn connect_with_timeout_rejects_when_dns_resolvers_saturated() {
-        let prev = super::ACTIVE_DNS_RESOLVERS.load(Ordering::SeqCst);
-        super::ACTIVE_DNS_RESOLVERS.store(super::MAX_DNS_RESOLVER_THREADS, Ordering::SeqCst);
+        let _dns_guard = DNS_RESOLVER_TEST_LOCK
+            .lock()
+            .expect("dns resolver test lock");
+        let _resolver_restore =
+            force_active_dns_resolvers_for_test(super::MAX_DNS_RESOLVER_THREADS);
         let result = super::connect_with_timeout("unreachable.test:80", Duration::from_secs(1));
-        super::ACTIVE_DNS_RESOLVERS.store(prev, Ordering::SeqCst);
         let err = result.unwrap_err();
         assert!(
             err.contains("DNS resolver limit reached"),
@@ -2631,6 +2653,9 @@ mod tests {
 
     #[test]
     fn connect_with_timeout_hostname_uses_dns_resolver_path() {
+        let _dns_guard = DNS_RESOLVER_TEST_LOCK
+            .lock()
+            .expect("dns resolver test lock");
         // "localhost:1" resolves via DNS (not IP literal fast path),
         // covering the resolver thread spawn + channel recv + addr iteration.
         // Port 1 is refused immediately, so this is fast.

--- a/clients/rust/crates/rubin-node/src/sync_reorg.rs
+++ b/clients/rust/crates/rubin-node/src/sync_reorg.rs
@@ -1516,8 +1516,8 @@ mod tests {
     }
 
     #[test]
-    fn reorg_requeue_policy_reject_is_reported_without_pool_mutation() {
-        let (mut engine, dir) = engine_with_store("rubin-reorg-requeue-policy-reject");
+    fn reorg_requeue_below_fee_floor_is_reported_without_pool_mutation() {
+        let (mut engine, dir) = engine_with_store("rubin-reorg-requeue-below-fee-floor");
         let (genesis, genesis_hash, gen_ts) = genesis_info();
         engine
             .apply_block_with_reorg(&genesis, None)

--- a/clients/rust/crates/rubin-node/src/sync_reorg.rs
+++ b/clients/rust/crates/rubin-node/src/sync_reorg.rs
@@ -2,7 +2,6 @@ use rubin_consensus::{
     block_hash, parse_block_bytes, parse_tx, read_compact_size_bytes,
     validate_block_basic_with_context_at_height, Outpoint, ParsedBlock, BLOCK_HEADER_BYTES,
 };
-use std::io::Write;
 use std::ops::Deref;
 
 use crate::blockstore::BlockStore;
@@ -126,7 +125,13 @@ impl TxPoolCleanupPlan {
     ) {
         // Best-effort compatibility path. Live callers that need authoritative
         // requeue visibility must use `apply_with_report`.
-        let _ = self.apply_with_report(pool, chain_state, block_store, chain_id);
+        let report = self.apply_with_report(pool, chain_state, block_store, chain_id);
+        if report.has_requeue_failures() {
+            eprintln!(
+                "mempool: requeue cleanup failed: {}",
+                report.requeue_failure_summary()
+            );
+        }
     }
 
     pub(crate) fn apply_with_report(
@@ -148,12 +153,10 @@ impl TxPoolCleanupPlan {
                 let Ok(block_bytes) = block_store.get_block_by_hash(*block_hash) else {
                     report.requeue_blocks_unavailable =
                         report.requeue_blocks_unavailable.saturating_add(1);
-                    log_requeue_block_failure(block_hash, "block unavailable");
                     continue;
                 };
                 let Ok(txs) = non_coinbase_tx_bytes(&block_bytes) else {
                     report.requeue_blocks_invalid = report.requeue_blocks_invalid.saturating_add(1);
-                    log_requeue_block_failure(block_hash, "block parse failed");
                     continue;
                 };
                 // Reorg requeue: route through source-aware admission so the
@@ -178,10 +181,7 @@ impl TxPoolCleanupPlan {
                         TxSource::Reorg,
                     ) {
                         Ok(_) => report.record_requeue_accepted(),
-                        Err(err) => {
-                            report.record_requeue_error(&err);
-                            log_requeue_tx_failure(&err);
-                        }
+                        Err(err) => report.record_requeue_error(&err),
                     }
                 }
             }
@@ -189,9 +189,6 @@ impl TxPoolCleanupPlan {
             report.requeue_blocks_unavailable = report
                 .requeue_blocks_unavailable
                 .saturating_add(self.requeue_block_hashes.len());
-            for block_hash in &self.requeue_block_hashes {
-                log_requeue_block_failure(block_hash, "blockstore unavailable");
-            }
         }
         report
     }
@@ -263,19 +260,6 @@ impl TxPoolCleanupPlan {
             requeue_block_hashes,
         }
     }
-}
-
-fn log_requeue_block_failure(block_hash: &[u8; 32], reason: &str) {
-    let _ = writeln!(
-        std::io::stderr(),
-        "mempool: requeue-block {}: {}",
-        hex::encode(block_hash),
-        reason
-    );
-}
-
-fn log_requeue_tx_failure(err: &TxPoolAdmitError) {
-    let _ = writeln!(std::io::stderr(), "mempool: requeue-tx: {err}");
 }
 
 #[derive(Clone, Debug)]

--- a/clients/rust/crates/rubin-node/src/sync_reorg.rs
+++ b/clients/rust/crates/rubin-node/src/sync_reorg.rs
@@ -48,7 +48,7 @@ pub struct TxPoolCleanupPlan {
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-struct TxPoolCleanupReport {
+pub(crate) struct TxPoolCleanupReport {
     requeue_blocks_unavailable: usize,
     requeue_blocks_invalid: usize,
     requeue_attempted: usize,
@@ -59,17 +59,32 @@ struct TxPoolCleanupReport {
 }
 
 impl TxPoolCleanupReport {
-    #[cfg(test)]
-    fn requeue_failed(&self) -> usize {
+    pub(crate) fn requeue_failed(&self) -> usize {
         self.requeue_conflict
             .saturating_add(self.requeue_rejected)
             .saturating_add(self.requeue_unavailable)
     }
 
-    #[cfg(test)]
-    fn requeue_blocks_failed(&self) -> usize {
+    pub(crate) fn requeue_blocks_failed(&self) -> usize {
         self.requeue_blocks_unavailable
             .saturating_add(self.requeue_blocks_invalid)
+    }
+
+    pub(crate) fn has_requeue_failures(&self) -> bool {
+        self.requeue_failed() > 0 || self.requeue_blocks_failed() > 0
+    }
+
+    pub(crate) fn requeue_failure_summary(&self) -> String {
+        format!(
+            "requeue_attempted={} requeue_accepted={} requeue_blocks_unavailable={} requeue_blocks_invalid={} requeue_conflict={} requeue_rejected={} requeue_unavailable={}",
+            self.requeue_attempted,
+            self.requeue_accepted,
+            self.requeue_blocks_unavailable,
+            self.requeue_blocks_invalid,
+            self.requeue_conflict,
+            self.requeue_rejected,
+            self.requeue_unavailable
+        )
     }
 
     fn record_requeue_attempt(&mut self) {
@@ -109,10 +124,12 @@ impl TxPoolCleanupPlan {
         block_store: Option<&BlockStore>,
         chain_id: [u8; 32],
     ) {
+        // Best-effort compatibility path. Live callers that need authoritative
+        // requeue visibility must use `apply_with_report`.
         let _ = self.apply_with_report(pool, chain_state, block_store, chain_id);
     }
 
-    fn apply_with_report(
+    pub(crate) fn apply_with_report(
         &self,
         pool: &mut TxPool,
         chain_state: &crate::ChainState,

--- a/clients/rust/crates/rubin-node/src/sync_reorg.rs
+++ b/clients/rust/crates/rubin-node/src/sync_reorg.rs
@@ -2,12 +2,13 @@ use rubin_consensus::{
     block_hash, parse_block_bytes, parse_tx, read_compact_size_bytes,
     validate_block_basic_with_context_at_height, Outpoint, ParsedBlock, BLOCK_HEADER_BYTES,
 };
+use std::io::Write;
 use std::ops::Deref;
 
 use crate::blockstore::BlockStore;
 use crate::chainstate::ChainStateConnectSummary;
 use crate::sync::SyncEngine;
-use crate::txpool::{TxPool, TxSource};
+use crate::txpool::{TxPool, TxPoolAdmitError, TxPoolAdmitErrorKind, TxSource};
 
 pub(crate) const PARENT_BLOCK_NOT_FOUND_ERR: &str = "parent block not found";
 
@@ -46,6 +47,54 @@ pub struct TxPoolCleanupPlan {
     requeue_block_hashes: Vec<[u8; 32]>,
 }
 
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+struct TxPoolCleanupReport {
+    requeue_blocks_unavailable: usize,
+    requeue_blocks_invalid: usize,
+    requeue_attempted: usize,
+    requeue_accepted: usize,
+    requeue_conflict: usize,
+    requeue_rejected: usize,
+    requeue_unavailable: usize,
+}
+
+impl TxPoolCleanupReport {
+    #[cfg(test)]
+    fn requeue_failed(&self) -> usize {
+        self.requeue_conflict
+            .saturating_add(self.requeue_rejected)
+            .saturating_add(self.requeue_unavailable)
+    }
+
+    #[cfg(test)]
+    fn requeue_blocks_failed(&self) -> usize {
+        self.requeue_blocks_unavailable
+            .saturating_add(self.requeue_blocks_invalid)
+    }
+
+    fn record_requeue_attempt(&mut self) {
+        self.requeue_attempted = self.requeue_attempted.saturating_add(1);
+    }
+
+    fn record_requeue_accepted(&mut self) {
+        self.requeue_accepted = self.requeue_accepted.saturating_add(1);
+    }
+
+    fn record_requeue_error(&mut self, err: &TxPoolAdmitError) {
+        match err.kind {
+            TxPoolAdmitErrorKind::Conflict => {
+                self.requeue_conflict = self.requeue_conflict.saturating_add(1);
+            }
+            TxPoolAdmitErrorKind::Rejected => {
+                self.requeue_rejected = self.requeue_rejected.saturating_add(1);
+            }
+            TxPoolAdmitErrorKind::Unavailable => {
+                self.requeue_unavailable = self.requeue_unavailable.saturating_add(1);
+            }
+        }
+    }
+}
+
 impl TxPoolCleanupPlan {
     pub fn is_empty(&self) -> bool {
         self.confirmed_txids.is_empty()
@@ -60,6 +109,17 @@ impl TxPoolCleanupPlan {
         block_store: Option<&BlockStore>,
         chain_id: [u8; 32],
     ) {
+        let _ = self.apply_with_report(pool, chain_state, block_store, chain_id);
+    }
+
+    fn apply_with_report(
+        &self,
+        pool: &mut TxPool,
+        chain_state: &crate::ChainState,
+        block_store: Option<&BlockStore>,
+        chain_id: [u8; 32],
+    ) -> TxPoolCleanupReport {
+        let mut report = TxPoolCleanupReport::default();
         if !self.confirmed_txids.is_empty() {
             pool.evict_txids(&self.confirmed_txids);
         }
@@ -69,9 +129,14 @@ impl TxPoolCleanupPlan {
         if let Some(block_store) = block_store {
             for block_hash in self.requeue_block_hashes.iter().rev() {
                 let Ok(block_bytes) = block_store.get_block_by_hash(*block_hash) else {
+                    report.requeue_blocks_unavailable =
+                        report.requeue_blocks_unavailable.saturating_add(1);
+                    log_requeue_block_failure(block_hash, "block unavailable");
                     continue;
                 };
                 let Ok(txs) = non_coinbase_tx_bytes(&block_bytes) else {
+                    report.requeue_blocks_invalid = report.requeue_blocks_invalid.saturating_add(1);
+                    log_requeue_block_failure(block_hash, "block parse failed");
                     continue;
                 };
                 // Reorg requeue: route through source-aware admission so the
@@ -87,16 +152,31 @@ impl TxPoolCleanupPlan {
                 // intentionally remain unchanged: they remove entries from
                 // existing state and must not mutate any source counter.
                 for tx_bytes in txs {
-                    let _ = pool.add_tx_with_source(
+                    report.record_requeue_attempt();
+                    match pool.add_tx_with_source(
                         &tx_bytes,
                         chain_state,
                         Some(block_store),
                         chain_id,
                         TxSource::Reorg,
-                    );
+                    ) {
+                        Ok(_) => report.record_requeue_accepted(),
+                        Err(err) => {
+                            report.record_requeue_error(&err);
+                            log_requeue_tx_failure(&err);
+                        }
+                    }
                 }
             }
+        } else if !self.requeue_block_hashes.is_empty() {
+            report.requeue_blocks_unavailable = report
+                .requeue_blocks_unavailable
+                .saturating_add(self.requeue_block_hashes.len());
+            for block_hash in &self.requeue_block_hashes {
+                log_requeue_block_failure(block_hash, "blockstore unavailable");
+            }
         }
+        report
     }
 
     pub fn merge(mut self, mut other: Self) -> Self {
@@ -166,6 +246,19 @@ impl TxPoolCleanupPlan {
             requeue_block_hashes,
         }
     }
+}
+
+fn log_requeue_block_failure(block_hash: &[u8; 32], reason: &str) {
+    let _ = writeln!(
+        std::io::stderr(),
+        "mempool: requeue-block {}: {}",
+        hex::encode(block_hash),
+        reason
+    );
+}
+
+fn log_requeue_tx_failure(err: &TxPoolAdmitError) {
+    let _ = writeln!(std::io::stderr(), "mempool: requeue-tx: {err}");
 }
 
 #[derive(Clone, Debug)]
@@ -1343,12 +1436,16 @@ mod tests {
         let outcome = engine
             .apply_block_with_reorg(&block2_alt, None)
             .expect("reorg to heavier branch");
-        outcome.tx_pool_cleanup.apply(
+        let report = outcome.tx_pool_cleanup.apply_with_report(
             &mut pool,
             &engine.chain_state,
             engine.block_store.as_ref(),
             engine.cfg.chain_id,
         );
+        assert_eq!(report.requeue_attempted, 1);
+        assert_eq!(report.requeue_accepted, 1);
+        assert_eq!(report.requeue_failed(), 0);
+        assert_eq!(report.requeue_blocks_failed(), 0);
         assert_ne!(
             engine.chain_state.tip_hash, block1_hash,
             "reorg must switch tip away from block 1"
@@ -1399,5 +1496,143 @@ mod tests {
 
         std::fs::remove_dir_all(&dir).expect("cleanup primary");
         std::fs::remove_dir_all(&dir2).expect("cleanup ctrl");
+    }
+
+    #[test]
+    fn reorg_requeue_policy_reject_is_reported_without_pool_mutation() {
+        let (mut engine, dir) = engine_with_store("rubin-reorg-requeue-policy-reject");
+        let (genesis, genesis_hash, gen_ts) = genesis_info();
+        engine
+            .apply_block_with_reorg(&genesis, None)
+            .expect("genesis");
+        engine.cfg.chain_id = devnet_genesis_chain_id();
+
+        let (state, low_fee_raw, _block_raw) = signed_conflicting_p2pk_state_and_txs(20, 10, 9);
+        engine.chain_state.utxos = state.utxos.clone();
+        let block1 = block_with_txs(
+            1,
+            0,
+            genesis_hash,
+            gen_ts + 1,
+            std::slice::from_ref(&low_fee_raw),
+        );
+        engine
+            .apply_block_with_reorg(&block1, None)
+            .expect("apply block 1");
+
+        let block1_alt = coinbase_only_block(1, genesis_hash, gen_ts + 2);
+        let block1_alt_hash =
+            rubin_consensus::block_hash(&block1_alt[..rubin_consensus::BLOCK_HEADER_BYTES])
+                .expect("hash block 1'");
+        engine
+            .block_store
+            .as_ref()
+            .unwrap()
+            .store_block(
+                block1_alt_hash,
+                &block1_alt[..rubin_consensus::BLOCK_HEADER_BYTES],
+                &block1_alt,
+            )
+            .expect("store block 1'");
+        let subsidy1 = rubin_consensus::subsidy::block_subsidy(1, 0);
+        let block2_alt = coinbase_only_block_with_gen(2, subsidy1, block1_alt_hash, gen_ts + 3);
+
+        let mut pool = TxPool::new();
+        let outcome = engine
+            .apply_block_with_reorg(&block2_alt, None)
+            .expect("reorg to heavier branch");
+        let report = outcome.tx_pool_cleanup.apply_with_report(
+            &mut pool,
+            &engine.chain_state,
+            engine.block_store.as_ref(),
+            engine.cfg.chain_id,
+        );
+
+        assert_eq!(report.requeue_attempted, 1);
+        assert_eq!(report.requeue_accepted, 0);
+        assert_eq!(report.requeue_unavailable, 1);
+        assert_eq!(report.requeue_failed(), 1);
+        assert_eq!(report.requeue_blocks_failed(), 0);
+        assert!(
+            pool.is_empty(),
+            "failed below-floor requeue must not insert or index the tx as accepted"
+        );
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    #[test]
+    fn reorg_requeue_duplicate_conflict_is_reported_without_replacing_entry() {
+        let (mut engine, dir) = engine_with_store("rubin-reorg-requeue-duplicate-conflict");
+        let (genesis, genesis_hash, gen_ts) = genesis_info();
+        engine
+            .apply_block_with_reorg(&genesis, None)
+            .expect("genesis");
+        engine.cfg.chain_id = devnet_genesis_chain_id();
+
+        let (state, admitted_raw, _block_raw) = signed_conflicting_p2pk_state_and_txs(7700, 10, 9);
+        engine.chain_state.utxos = state.utxos.clone();
+        let block1 = block_with_txs(
+            1,
+            0,
+            genesis_hash,
+            gen_ts + 1,
+            std::slice::from_ref(&admitted_raw),
+        );
+        engine
+            .apply_block_with_reorg(&block1, None)
+            .expect("apply block 1");
+
+        let block1_alt = coinbase_only_block(1, genesis_hash, gen_ts + 2);
+        let block1_alt_hash =
+            rubin_consensus::block_hash(&block1_alt[..rubin_consensus::BLOCK_HEADER_BYTES])
+                .expect("hash block 1'");
+        engine
+            .block_store
+            .as_ref()
+            .unwrap()
+            .store_block(
+                block1_alt_hash,
+                &block1_alt[..rubin_consensus::BLOCK_HEADER_BYTES],
+                &block1_alt,
+            )
+            .expect("store block 1'");
+        let subsidy1 = rubin_consensus::subsidy::block_subsidy(1, 0);
+        let block2_alt = coinbase_only_block_with_gen(2, subsidy1, block1_alt_hash, gen_ts + 3);
+
+        let outcome = engine
+            .apply_block_with_reorg(&block2_alt, None)
+            .expect("reorg to heavier branch");
+        let (_, requeued_txid, _, consumed) =
+            rubin_consensus::parse_tx(&admitted_raw).expect("parse admitted");
+        assert_eq!(consumed, admitted_raw.len());
+
+        let mut pool = TxPool::new();
+        pool.admit(
+            &admitted_raw,
+            &engine.chain_state,
+            engine.block_store.as_ref(),
+            engine.cfg.chain_id,
+        )
+        .expect("preload duplicate");
+        assert_eq!(pool.entry_source(&requeued_txid), Some(TxSource::Local));
+
+        let report = outcome.tx_pool_cleanup.apply_with_report(
+            &mut pool,
+            &engine.chain_state,
+            engine.block_store.as_ref(),
+            engine.cfg.chain_id,
+        );
+
+        assert_eq!(report.requeue_attempted, 1);
+        assert_eq!(report.requeue_accepted, 0);
+        assert_eq!(report.requeue_conflict, 1);
+        assert_eq!(report.requeue_failed(), 1);
+        assert_eq!(pool.len(), 1);
+        assert_eq!(
+            pool.entry_source(&requeued_txid),
+            Some(TxSource::Local),
+            "duplicate failed requeue must not replace the existing Local entry as Reorg"
+        );
+        std::fs::remove_dir_all(&dir).expect("cleanup");
     }
 }


### PR DESCRIPTION
Closes #1171

Invariant:
Rust live txpool cleanup must not report success when any requeue failure bucket is non-zero.

Layer:
Protocol/runtime implementation, Rust node.

Files changed:
- clients/rust/crates/rubin-node/src/sync_reorg.rs
- clients/rust/crates/rubin-node/src/p2p_service.rs

Validation:
- cargo fmt --check --manifest-path clients/rust/Cargo.toml
- cargo test --manifest-path clients/rust/Cargo.toml -p rubin-node requeue
- cargo test --manifest-path clients/rust/Cargo.toml -p rubin-node txpool
- cargo test --manifest-path clients/rust/Cargo.toml -p rubin-node
- cargo clippy --manifest-path clients/rust/Cargo.toml -p rubin-node -- -D warnings
- /Users/gpt/bin/rubin-precommit-one-review --repo /Users/gpt/Documents/rubin-protocol-codex-rub-16 --base-ref origin/main --include-base-diff
- /Users/gpt/bin/rubin-push --repo /Users/gpt/Documents/rubin-protocol-codex-rub-16 --base-ref origin/main --coverage-cmd 'cargo test --manifest-path clients/rust/Cargo.toml -p rubin-node requeue' -- origin HEAD

Consensus impact: none.
Policy impact: none.
Go/Rust parity impact: Rust visibility cleanup only; no Go behavior change.
Non-scope: no mempool policy redesign, no P2P protocol change, no consensus validation change.
