### PR TITLE
[RUB-21] Prove mixed Go/Rust devnet mesh evidence

### DIFF
--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -179,8 +179,7 @@ source "${HELPER}"
 rubin_process_init mixed-client-mesh
 GO_NODE_BIN="${RUBIN_PROCESS_ARTIFACT_ROOT}/rubin-node-go"; RUST_NODE_BIN="${RUBIN_PROCESS_ARTIFACT_ROOT}/rubin-node-rust"
 GO_DIR="${RUBIN_PROCESS_ARTIFACT_ROOT}/node-go"; RUST_DIR="${RUBIN_PROCESS_ARTIFACT_ROOT}/node-rust"
-GO_LOG="node-go.log"; RUST_LOG="node-rust.log"
-REPORT_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/mixed-client-mesh-report.json"; LEGACY_SCHEMA_MARKER_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/mixed-client-mesh-legacy-schema-marker.json"
+GO_LOG="node-go.log"; RUST_LOG="node-rust.log"; REPORT_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/mixed-client-mesh-report.json"; LEGACY_SCHEMA_MARKER_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/mixed-client-mesh-legacy-schema-marker.json"
 GO_PEERS_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/go-peers.json"; RUST_PEERS_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/rust-peers.json"
 GO_PID="" RUST_PID="" GO_RPC_ADDR="" RUST_RPC_ADDR="" GO_P2P_ADDR="" RUST_P2P_ADDR="" GO_STARTED_AT_UTC="" RUST_STARTED_AT_UTC="" GO_COMM="" RUST_COMM="" RUST_TO_GO_LOCAL_ADDR="" GO_CMD="" RUST_CMD="" GO_ARGV_JSON="" RUST_ARGV_JSON="" FINAL_PROCESS_IDENTITY_RECHECKED="" FINAL_RUST_OUTBOUND_LINK_RECHECKED="" FINAL_PEER_SNAPSHOTS_RECHECKED=""
 mkdir -p -- "${GO_DIR}" "${RUST_DIR}"
@@ -337,10 +336,7 @@ if verdict != "PASS":
 with open(e["REPORT_JSON"], "w", encoding="utf-8") as f:
     json.dump(report, f, indent=2, sort_keys=True)
     f.write("\n")
-legacy_marker_reason = reason if verdict != "PASS" and reason else (
-    "mixed-client mesh process/connectivity PASS is recorded in sibling report; "
-    "existing schema v1 PASS requires tx_path proof owned by RUB-22/RUB-23"
-)
+legacy_marker_reason = reason if verdict != "PASS" and reason else "mixed-client mesh process/connectivity PASS is recorded in sibling report; existing schema v1 PASS requires tx_path proof owned by RUB-22/RUB-23"
 legacy_schema_marker = {
     "schema_version": "rubin-mixed-client-devnet-evidence-v1",
     "evidence_type": "mixed_client_process_soak",

--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -26,8 +26,9 @@ def eventually(fn, message: str) -> None:
         if not live or time.monotonic() >= deadline: fail(message)
         time.sleep(1)
 def checked_path(label: str, value: object) -> Path:
-    req(isinstance(value, str) and value.strip() == value and value and value[0] not in "'\"" and value[-1] not in "'\"", f"{label} is not an unquoted path string")
-    p = Path(value); req(p.is_absolute(), f"{label} is not absolute"); return p
+    req(isinstance(value, str) and value.strip() == value and value and value[0] not in "'\"" and value[-1] not in "'\"" and "\0" not in value and all(ord(c) >= 32 for c in value), f"{label} is not a safe unquoted path string")
+    try: p = Path(value); req(p.is_absolute(), f"{label} is not absolute"); return p.resolve()
+    except (OSError, ValueError) as exc: fail(f"{label} path is invalid: {exc}")
 def ep(value: object) -> bool:
     if not isinstance(value, str): return False
     host, sep, port = value.partition(":")
@@ -64,7 +65,7 @@ def pid_argv(pid: int) -> list[str]:
         if j < 0: break
         args.append(raw[i:j].decode("utf-8", "surrogateescape")); i = j + 1
     return args
-def argv_eq(actual: list[str], expected: list[str]) -> bool: return len(actual) == len(expected) and bool(actual) and Path(actual[0]).resolve() == Path(expected[0]).resolve() and actual[1:] == expected[1:]
+def argv_eq(actual: list[str], expected: list[str]) -> bool: return len(actual) == len(expected) and bool(actual) and checked_path("live argv[0]", actual[0]) == checked_path("report command_argv[0]", expected[0]) and actual[1:] == expected[1:]
 def lsof_lines(pid: int, state: str) -> list[str]:
     try:
         p = subprocess.run(["lsof", "-nP", "-a", "-p", str(pid), "-iTCP", f"-sTCP:{state}", "-Fn"], check=False, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=5)
@@ -106,10 +107,10 @@ req(isinstance(data, dict), "report root is not an object")
 req(data.get("scenario") == "mixed_client_mesh", f"scenario is not mixed_client_mesh: {data.get('scenario')!r}")
 req(data.get("verdict") == "PASS", f"report verdict is not PASS: {data.get('verdict')!r}")
 req("failure_reason" not in data and "schema_marker" not in data, "PASS report must not carry failure/schema-marker verdict fields")
-artifact_root = checked_path("artifact_root", data.get("artifact_root")).resolve()
+artifact_root_arg = data.get("artifact_root"); artifact_root = checked_path("artifact_root", artifact_root_arg)
 legacy_schema = data.get("legacy_schema_compatibility")
 req(isinstance(legacy_schema, dict) and legacy_schema.get("authoritative") is False and "verdict" not in legacy_schema and nonempty_str(legacy_schema.get("marker_path")), "legacy_schema_compatibility missing marker_path")
-marker_path = checked_path("legacy_schema_compatibility.marker_path", legacy_schema.get("marker_path")).resolve()
+marker_path = checked_path("legacy_schema_compatibility.marker_path", legacy_schema.get("marker_path"))
 try: marker_path.relative_to(artifact_root)
 except ValueError: fail("legacy marker is outside artifact_root")
 req(marker_path.is_file() and marker_path.stat().st_size > 0, "legacy marker is missing, unreadable, or empty")
@@ -130,21 +131,21 @@ for node in nodes:
     expected_name, expected_bin = expected[impl]
     req(name == expected_name, f"{impl} node has invalid name: {name!r}")
     command, binary, command_argv = node.get("command"), node.get("binary"), node.get("command_argv")
-    binary_path = checked_path(f"{name}.binary", binary).resolve()
+    binary_path = checked_path(f"{name}.binary", binary)
     try: binary_path.relative_to(artifact_root)
     except ValueError: fail(f"{name} binary is outside artifact_root")
     req(node.get("process_comm") == expected_bin, f"{name} process_comm does not prove {impl} identity")
-    req(nonempty_str(command) and isinstance(command_argv, list) and all(isinstance(arg, str) for arg in command_argv) and command_argv and Path(command_argv[0]).is_absolute() and Path(command_argv[0]).resolve() == binary_path and binary_path.name == expected_bin and binary_path.is_file() and os.access(binary_path, os.X_OK), f"{name} command/binary is not bound to executable {expected_bin}")
+    req(nonempty_str(command) and isinstance(command_argv, list) and all(isinstance(arg, str) for arg in command_argv) and command_argv and checked_path(f"{name}.command_argv[0]", command_argv[0]) == binary_path and binary_path.name == expected_bin and binary_path.is_file() and os.access(binary_path, os.X_OK), f"{name} command/binary is not bound to executable {expected_bin}")
     req(ep(node.get("rpc_endpoint")) and ep(node.get("p2p_endpoint")) and ts(node.get("started_at")), f"{name} has malformed endpoint or timestamp")
     req(isinstance(node.get("pid"), int) and not isinstance(node.get("pid"), bool) and node["pid"] > 0, f"{name} pid is not a positive integer")
     if live:
-        eventually(lambda node=node, binary_path=binary_path, command_argv=command_argv: Path(pid_exe(node["pid"])).resolve() == binary_path and argv_eq(pid_argv(node["pid"]), command_argv), f"{name} live process argv/executable does not match report")
+        eventually(lambda node=node, binary_path=binary_path, command_argv=command_argv: checked_path(f"{name}.live_exe", pid_exe(node["pid"])) == binary_path and argv_eq(pid_argv(node["pid"]), command_argv), f"{name} live process argv/executable does not match report")
         eventually(lambda node=node: owns_listen(node["pid"], node["rpc_endpoint"]) and owns_listen(node["pid"], node["p2p_endpoint"]), f"{name} live listeners are not pid-owned")
     for field in ("process_alive", "rpc_endpoint_process_backed", "p2p_endpoint_process_backed"):
         req(node.get(field) is True, f"{name} does not prove {field}")
 req((impls := {n["implementation"] for n in nodes}) == {"go", "rust"}, f"PASS report requires one go and one rust node, got {sorted(impls)}")
 nodes_by_impl = {node["implementation"]: node for node in nodes}
-req(nodes_by_impl["go"]["command_argv"] == [nodes_by_impl["go"]["binary"], "--network", "devnet", "--datadir", str(Path(data["artifact_root"]) / "node-go"), "--bind", "127.0.0.1:0", "--rpc-bind", "127.0.0.1:0"] and nodes_by_impl["rust"]["command_argv"] == [nodes_by_impl["rust"]["binary"], "--network", "devnet", "--datadir", str(Path(data["artifact_root"]) / "node-rust"), "--bind", "127.0.0.1:0", "--rpc-bind", "127.0.0.1:0", "--peer", nodes_by_impl["go"]["p2p_endpoint"]], "node command_argv does not match exact launched argv")
+req(nodes_by_impl["go"]["command_argv"] == [nodes_by_impl["go"]["binary"], "--network", "devnet", "--datadir", str(Path(artifact_root_arg) / "node-go"), "--bind", "127.0.0.1:0", "--rpc-bind", "127.0.0.1:0"] and nodes_by_impl["rust"]["command_argv"] == [nodes_by_impl["rust"]["binary"], "--network", "devnet", "--datadir", str(Path(artifact_root_arg) / "node-rust"), "--bind", "127.0.0.1:0", "--rpc-bind", "127.0.0.1:0", "--peer", nodes_by_impl["go"]["p2p_endpoint"]], "node command_argv does not match exact launched argv")
 req(nodes_by_impl["go"]["pid"] != nodes_by_impl["rust"]["pid"], "go/rust process evidence uses the same pid")
 req(nodes_by_impl["go"]["binary"] != nodes_by_impl["rust"]["binary"] and nodes_by_impl["go"]["command"] != nodes_by_impl["rust"]["command"] and nodes_by_impl["go"].get("command_argv") != nodes_by_impl["rust"].get("command_argv"), "go/rust process evidence is not implementation-distinct")
 req(len({nodes_by_impl[i][f] for i in ("go", "rust") for f in ("rpc_endpoint", "p2p_endpoint")}) == 4, "node rpc/p2p endpoints are not pairwise distinct")

--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -25,31 +25,39 @@ need_tool() { command -v -- "$1" >/dev/null 2>&1 || { echo "$1 is required for m
 check_report() { local report="${1:-}" mode="${2:-offline}"
   [[ -n "${report}" ]] || { echo "FAIL: report path is required" >&2; return 1; }
   python3 - "${report}" "${DEV_ENV}" "${VALIDATOR}" "${mode}" <<'PY'
-import datetime as dt, json, os, subprocess, sys, urllib.request
+import datetime as dt, json, os, socket, subprocess, sys, time, urllib.error, urllib.request
 from pathlib import Path
 path = Path(sys.argv[1])
 live = sys.argv[4] == "live"
+try: LIVE_TIMEOUT = max(1, min(600, int(os.environ.get("MESH_TIMEOUT", "10"))))
+except ValueError: LIVE_TIMEOUT = 10
 def fail(message: str) -> None: print(f"FAIL: {message}", file=sys.stderr); sys.exit(1)
 def req(ok: bool, message: str) -> None:
     if not ok: fail(message)
-def run(argv: list[str]) -> str:
-    try:
-        p = subprocess.run(argv, check=False, text=True, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, timeout=5)
-    except (OSError, subprocess.TimeoutExpired) as exc:
-        fail(f"live check failed for {argv[0]}: {exc}")
-    req(p.returncode == 0 and p.stdout.strip(), f"live check failed: {' '.join(argv)}")
-    return p.stdout.strip().splitlines()[0]
+def eventually(fn, message: str) -> None:
+    deadline = time.monotonic() + LIVE_TIMEOUT
+    while True:
+        if fn(): return
+        if not live or time.monotonic() >= deadline: fail(message)
+        time.sleep(1)
 def checked_path(label: str, value: object) -> Path:
     req(isinstance(value, str) and value.strip() == value and value and value[0] not in "'\"" and value[-1] not in "'\"", f"{label} is not an unquoted path string")
-    p = Path(value)
-    req(p.is_absolute(), f"{label} is not absolute")
-    return p
+    p = Path(value); req(p.is_absolute(), f"{label} is not absolute"); return p
 def ep(value: object) -> bool:
     if not isinstance(value, str): return False
     host, sep, port = value.partition(":")
     return sep == ":" and host == "127.0.0.1" and ":" not in port and port.isascii() and port.isdigit() and 1 <= len(port) <= 5 and 1 <= int(port) <= 65535
 def nonempty_str(value: object) -> bool: return isinstance(value, str) and bool(value.strip())
-def ps_comm(pid: int) -> str: return os.path.basename(run(["ps", "-ww", "-p", str(pid), "-o", "comm="]))
+def pid_exe(pid: int) -> str:
+    proc = Path(f"/proc/{pid}/exe")
+    if proc.exists() or Path("/proc").is_dir():
+        try: return str(proc.resolve(strict=True))
+        except FileNotFoundError: return ""
+        except OSError as exc: fail(f"pid_exe_failed: {exc}")
+    try:
+        import ctypes; buf = ctypes.create_string_buffer(4096); n = ctypes.CDLL(None).proc_pidpath(int(pid), buf, len(buf))
+    except (AttributeError, OSError) as exc: fail(f"pid_exe_unavailable: {exc}")
+    return os.path.realpath(buf.value.decode()) if n > 0 else ""
 def lsof_lines(pid: int, state: str) -> list[str]:
     try:
         p = subprocess.run(["lsof", "-nP", "-a", "-p", str(pid), "-iTCP", f"-sTCP:{state}", "-Fn"], check=False, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=5)
@@ -62,11 +70,13 @@ def lsof_lines(pid: int, state: str) -> list[str]:
 def owns_listen(pid: int, endpoint: str) -> bool: return endpoint in lsof_lines(pid, "LISTEN")
 def peers(addr: str) -> dict:
     try:
-        with urllib.request.urlopen(f"http://{addr}/peers", timeout=5) as resp:
-            data = json.loads(resp.read().decode("utf-8"))
-    except Exception as exc:
-        fail(f"live peer snapshot failed for {addr}: {exc}")
-    return data if isinstance(data, dict) else {}
+        with urllib.request.urlopen(f"http://{addr}/peers", timeout=5) as resp: data = json.loads(resp.read().decode("utf-8"))
+    except (urllib.error.URLError, TimeoutError, socket.timeout):
+        return None
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        fail(f"live peer snapshot malformed JSON for {addr}: {exc}")
+    req(isinstance(data, dict), f"live peer snapshot malformed JSON for {addr}")
+    return data
 def snapshot_norm(snapshot: object) -> list[tuple[str, bool]]:
     count = snapshot.get("count") if isinstance(snapshot, dict) else None
     peers = snapshot.get("peers") if isinstance(snapshot, dict) else None
@@ -124,8 +134,8 @@ for node in nodes:
     req(ep(node.get("rpc_endpoint")) and ep(node.get("p2p_endpoint")) and ts(node.get("started_at")), f"{name} has malformed endpoint or timestamp")
     req(isinstance(node.get("pid"), int) and not isinstance(node.get("pid"), bool) and node["pid"] > 0, f"{name} pid is not a positive integer")
     if live:
-        req(ps_comm(node["pid"]) == expected_bin, f"{name} live process identity does not match report")
-        req(owns_listen(node["pid"], node["rpc_endpoint"]) and owns_listen(node["pid"], node["p2p_endpoint"]), f"{name} live listeners are not pid-owned")
+        eventually(lambda node=node, binary_path=binary_path: Path(pid_exe(node["pid"])).resolve() == binary_path, f"{name} live process executable does not match report")
+        eventually(lambda node=node: owns_listen(node["pid"], node["rpc_endpoint"]) and owns_listen(node["pid"], node["p2p_endpoint"]), f"{name} live listeners are not pid-owned")
     for field in ("process_alive", "rpc_endpoint_process_backed", "p2p_endpoint_process_backed"):
         req(node.get(field) is True, f"{name} does not prove {field}")
 req((impls := {n["implementation"] for n in nodes}) == {"go", "rust"}, f"PASS report requires one go and one rust node, got {sorted(impls)}")
@@ -143,7 +153,7 @@ req(all(ep(links.get(f)) for f in ("go_peer_snapshot_expected_addr", "rust_peer_
 req(rust_expected == nodes_by_impl["go"]["p2p_endpoint"] and links.get("rust_outbound_remote_addr") == rust_expected and links.get("rust_outbound_local_addr") == go_expected and links.get("rust_outbound_pid") == nodes_by_impl["rust"]["pid"], "peer evidence is not bound to expected counterpart endpoints")
 req(isinstance(go_expected, str) and go_expected not in {rust_expected, nodes_by_impl["rust"]["p2p_endpoint"], nodes_by_impl["go"]["rpc_endpoint"], nodes_by_impl["rust"]["rpc_endpoint"]}, "go peer evidence is not a rust outbound peer address")
 if live:
-    req(f"{go_expected}->{rust_expected}" in lsof_lines(nodes_by_impl["rust"]["pid"], "ESTABLISHED"), "rust outbound TCP link is not live and rust-owned")
+    eventually(lambda: f"{go_expected}->{rust_expected}" in lsof_lines(nodes_by_impl["rust"]["pid"], "ESTABLISHED"), "rust outbound TCP link is not live and rust-owned")
 final = data.get("final_verification")
 req(isinstance(final, dict) and all(final.get(f) is True for f in ("producer_side", "process_identity_rechecked", "rust_outbound_link_rechecked", "peer_snapshots_rechecked")), "PASS report missing producer-side final verification")
 req(final.get("rust_outbound_pid") == nodes_by_impl["rust"]["pid"] and final.get("rust_outbound_local_addr") == go_expected and final.get("rust_outbound_remote_addr") == rust_expected, "final verification is not bound to peer evidence")
@@ -151,8 +161,8 @@ for field, expected_addr in (("go_peer_snapshot", go_expected), ("rust_peer_snap
     stored = snapshot_norm(connectivity.get(field))
     req((expected_addr, True) in stored, f"{field} missing expected completed peer")
     if live:
-        fresh = snapshot_norm(peers(nodes_by_impl["go" if field.startswith("go_") else "rust"]["rpc_endpoint"]))
-        req(stored == fresh, f"{field} differs from live exact peer set")
+        endpoint = nodes_by_impl["go" if field.startswith("go_") else "rust"]["rpc_endpoint"]
+        eventually(lambda endpoint=endpoint, stored=stored: (fresh := peers(endpoint)) is not None and stored == snapshot_norm(fresh), f"{field} differs from live exact peer set")
 if not live: fail("offline check cannot prove PASS; use --check-report-live")
 print(f"PASS: mixed-client mesh report accepted {path}")
 PY
@@ -225,8 +235,7 @@ extract_log_addr() {
   local log_file="$1" prefix="$2" path addr
   path="$(_rubin_process_resolve_log "${log_file}")" || return 1
   addr="$(sed -n "s/.*${prefix}//p" "${path}" | tail -n 1 | tr -d '[:space:]')" || return 1
-  [[ "${addr}" == 127.0.0.1:* ]] || return 1
-  printf '%s\n' "${addr}"
+  [[ "${addr}" == 127.0.0.1:* ]] || return 1; printf '%s\n' "${addr}"
 }
 build_go_node() { echo "Building Go rubin-node binary" >&2; "${DEV_ENV}" -- go -C "${GO_MODULE_ROOT}" build -o "${GO_NODE_BIN}" ./cmd/rubin-node || return 1; [[ -x "${GO_NODE_BIN}" ]]; }
 build_rust_node() {
@@ -235,8 +244,7 @@ build_rust_node() {
   run_fips_preflight_before_captured_dev_env || return 1
   host_triple="$(RUBIN_OPENSSL_SKIP_FIPS_GUARD=1 "${DEV_ENV}" -- rustc -vV | awk '/^host:/ {print $2}')" || return 1
   [[ -n "${host_triple}" ]] || return 1
-  cargo_target_dir="${RUBIN_PROCESS_ARTIFACT_ROOT}/cargo-target"
-  cargo_log="${RUBIN_PROCESS_ARTIFACT_ROOT}/cargo-build.jsonl"
+  cargo_target_dir="${RUBIN_PROCESS_ARTIFACT_ROOT}/cargo-target"; cargo_log="${RUBIN_PROCESS_ARTIFACT_ROOT}/cargo-build.jsonl"
   RUBIN_OPENSSL_SKIP_FIPS_GUARD=1 "${DEV_ENV}" -- cargo build --manifest-path "${RUST_WORKSPACE_ROOT}/Cargo.toml" --release --locked -p rubin-node --target "${host_triple}" --target-dir "${cargo_target_dir}" --message-format=json-render-diagnostics >"${cargo_log}" || return 1
   cargo_bin="$(python3 - "${cargo_log}" <<'PY'
 import json, sys
@@ -348,7 +356,7 @@ with open(e["LEGACY_SCHEMA_MARKER_JSON"], "w", encoding="utf-8") as f:
     f.write("\n")
 PY
 }
-finish_no_data() { local reason="$1"; write_outputs "NO_DATA" "${reason}"; run_validator "${LEGACY_SCHEMA_MARKER_JSON}" >&2; echo "NO_DATA: ${reason}; report=${REPORT_JSON} legacy_schema_marker=${LEGACY_SCHEMA_MARKER_JSON}" >&2; exit 1; }
+finish_no_data() { local reason="$1"; write_outputs "NO_DATA" "${reason}" || { echo "FAIL_REPORT_WRITE_FAILED: ${reason}" >&2; exit 1; }; run_validator "${LEGACY_SCHEMA_MARKER_JSON}" >&2 || { echo "FAIL_REPORT_VALIDATION_FAILED: ${reason}; report=${REPORT_JSON} legacy_schema_marker=${LEGACY_SCHEMA_MARKER_JSON}" >&2; exit 1; }; echo "NO_DATA: ${reason}; report=${REPORT_JSON} legacy_schema_marker=${LEGACY_SCHEMA_MARKER_JSON}" >&2; exit 1; }
 wait_peer_snapshot() {
   local label="$1" addr="$2" out="$3" timeout="$4" expected="$5" deadline tmp
   deadline=$((SECONDS + timeout)); PEER_SNAPSHOT_REASON=""
@@ -392,34 +400,25 @@ verify_process_identity() {
   [[ "${comm}" == "${expected_comm}" ]] || { echo "${label} process comm=${comm}, want ${expected_comm}" >&2; return 1; }
   pid_listens_on "${pid}" "${rpc_addr}" || { rc=$?; [[ ${rc} -eq 2 ]] && finish_no_data "lsof_failed"; [[ ${rc} -eq 3 ]] && finish_no_data "lsof_timeout"; echo "${label} rpc endpoint is not process-backed: ${rpc_addr}" >&2; return 1; }
   pid_listens_on "${pid}" "${p2p_addr}" || { rc=$?; [[ ${rc} -eq 2 ]] && finish_no_data "lsof_failed"; [[ ${rc} -eq 3 ]] && finish_no_data "lsof_timeout"; echo "${label} p2p endpoint is not process-backed: ${p2p_addr}" >&2; return 1; }
-  case "${impl}" in
-    go) GO_COMM="${comm}"; GO_PROCESS_ALIVE=true; GO_RPC_PROCESS_BACKED=true; GO_P2P_PROCESS_BACKED=true ;;
-    rust) RUST_COMM="${comm}"; RUST_PROCESS_ALIVE=true; RUST_RPC_PROCESS_BACKED=true; RUST_P2P_PROCESS_BACKED=true ;;
-    *) return 1 ;;
-  esac
+  [[ "${impl}" == "go" ]] && { GO_COMM="${comm}"; GO_PROCESS_ALIVE=true; GO_RPC_PROCESS_BACKED=true; GO_P2P_PROCESS_BACKED=true; return 0; }
+  [[ "${impl}" == "rust" ]] && { RUST_COMM="${comm}"; RUST_PROCESS_ALIVE=true; RUST_RPC_PROCESS_BACKED=true; RUST_P2P_PROCESS_BACKED=true; return 0; }
+  return 1
 }
 start_rust_node() {
   local -a argv=("${RUST_NODE_BIN}" --network devnet --datadir "${RUST_DIR}" --bind 127.0.0.1:0 --rpc-bind 127.0.0.1:0 --peer "${GO_P2P_ADDR}")
   RUST_CMD="$(argv_cmd "${argv[@]}")"; RUST_ARGV_JSON="$(argv_json "${argv[@]}")"
-  rubin_process_start "${RUST_LOG}" "${argv[@]}" || return 1
-  RUST_PID="${RUBIN_PROCESS_LAST_PID}"
-  rubin_process_wait_for_log "${RUST_LOG}" "p2p: listening=" 60 "${RUST_PID}" || return 1
-  rubin_process_wait_for_log "${RUST_LOG}" "rpc: listening=" 60 "${RUST_PID}" || return 1
-  RUST_P2P_ADDR="$(extract_log_addr "${RUST_LOG}" "p2p: listening=")" || return 1
-  RUST_RPC_ADDR="$(rubin_process_extract_rpc_addr "${RUST_LOG}")" || return 1
-  rubin_process_wait_for_rpc_ready "${RUST_RPC_ADDR}" 30 || return 1
-  RUST_STARTED_AT_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  rubin_process_start "${RUST_LOG}" "${argv[@]}" || return 1; RUST_PID="${RUBIN_PROCESS_LAST_PID}"
+  rubin_process_wait_for_log "${RUST_LOG}" "p2p: listening=" 60 "${RUST_PID}" || return 1; rubin_process_wait_for_log "${RUST_LOG}" "rpc: listening=" 60 "${RUST_PID}" || return 1
+  RUST_P2P_ADDR="$(extract_log_addr "${RUST_LOG}" "p2p: listening=")" || return 1; RUST_RPC_ADDR="$(rubin_process_extract_rpc_addr "${RUST_LOG}")" || return 1
+  rubin_process_wait_for_rpc_ready "${RUST_RPC_ADDR}" 30 || return 1; RUST_STARTED_AT_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 }
 start_go_node() {
   local -a argv=("${GO_NODE_BIN}" --network devnet --datadir "${GO_DIR}" --bind 127.0.0.1:0 --rpc-bind 127.0.0.1:0)
   GO_CMD="$(argv_cmd "${argv[@]}")"; GO_ARGV_JSON="$(argv_json "${argv[@]}")"
-  rubin_process_start "${GO_LOG}" "${argv[@]}" || return 1
-  GO_PID="${RUBIN_PROCESS_LAST_PID}"
-  rubin_process_wait_for_log "${GO_LOG}" "rpc: listening=" 60 "${GO_PID}" || return 1
-  GO_RPC_ADDR="$(rubin_process_extract_rpc_addr "${GO_LOG}")" || return 1
+  rubin_process_start "${GO_LOG}" "${argv[@]}" || return 1; GO_PID="${RUBIN_PROCESS_LAST_PID}"
+  rubin_process_wait_for_log "${GO_LOG}" "rpc: listening=" 60 "${GO_PID}" || return 1; GO_RPC_ADDR="$(rubin_process_extract_rpc_addr "${GO_LOG}")" || return 1
   GO_P2P_ADDR="$(p2p_addr_for_pid "${GO_PID}" "${GO_RPC_ADDR}" 30)" || { rc=$?; [[ ${rc} -eq 42 ]] && finish_no_data "lsof_failed"; [[ ${rc} -eq 43 ]] && finish_no_data "lsof_timeout"; return 1; }
-  rubin_process_wait_for_rpc_ready "${GO_RPC_ADDR}" 30 || return 1
-  GO_STARTED_AT_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  rubin_process_wait_for_rpc_ready "${GO_RPC_ADDR}" 30 || return 1; GO_STARTED_AT_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 }
 command -v lsof >/dev/null 2>&1 || finish_no_data "lsof_unavailable"; command -v perl >/dev/null 2>&1 || finish_no_data "perl_unavailable"
 build_go_node || finish_no_data "go_build_failed"

--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -26,9 +26,7 @@ while (($#)); do
       ;;
   esac
 done
-need_tool() {
-  command -v -- "$1" >/dev/null 2>&1 || { echo "$1 is required for mixed-client mesh evidence" >&2; exit 1; }
-}
+need_tool() { command -v -- "$1" >/dev/null 2>&1 || { echo "$1 is required for mixed-client mesh evidence" >&2; exit 1; }; }
 check_report() {
   local report="${1:-}"
   [[ -n "${report}" ]] || { echo "FAIL: report path is required" >&2; return 1; }
@@ -60,8 +58,8 @@ def argv0(value: object) -> str:
     if not nonempty_str(value): return ""
     try: return shlex.split(value)[0]
     except ValueError: return ""
-def ps_comm(pid: int) -> str: return os.path.basename(run(["ps", "-p", str(pid), "-o", "comm="]))
-def ps_argv0(pid: int) -> str: return argv0(run(["ps", "-p", str(pid), "-o", "command="]))
+def ps_comm(pid: int) -> str: return os.path.basename(run(["ps", "-ww", "-p", str(pid), "-o", "comm="]))
+def ps_argv0(pid: int) -> str: return run(["ps", "-ww", "-p", str(pid), "-o", "comm="])
 def lsof_lines(pid: int, state: str) -> list[str]:
     p = subprocess.run(["lsof", "-nP", "-a", "-p", str(pid), "-iTCP", f"-sTCP:{state}", "-Fn"], check=False, text=True, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, timeout=5)
     return [line[1:] for line in p.stdout.splitlines() if line.startswith("n")]
@@ -157,7 +155,7 @@ print(f"PASS: mixed-client mesh report accepted {path}")
 PY
 }
 if [[ "${CHECK_REPORT_MODE}" == "1" ]]; then need_tool python3; need_tool lsof; check_report "${CHECK_REPORT}"; exit 0; fi
-need_tool python3; need_tool perl
+need_tool python3
 [[ -x "${DEV_ENV}" ]] || { echo "dev-env wrapper missing or non-executable: ${DEV_ENV}" >&2; exit 1; }
 [[ -r "${VALIDATOR}" ]] || { echo "validator unreadable: ${VALIDATOR}" >&2; exit 1; }
 # shellcheck source=scripts/devnet-process-common.sh disable=SC1091
@@ -179,6 +177,7 @@ FINAL_PROCESS_IDENTITY_RECHECKED="" FINAL_RUST_OUTBOUND_LINK_RECHECKED="" FINAL_
 mkdir -p -- "${GO_DIR}" "${RUST_DIR}"
 run_fips_preflight_before_captured_dev_env() { [[ "${RUBIN_OPENSSL_FIPS_MODE:-off}" != "only" || "${RUBIN_OPENSSL_SKIP_FIPS_GUARD:-0}" == "1" ]] && return 0; echo "Running FIPS-only preflight before captured dev-env command streams" >&2; "${DEV_ENV}" -- "${REPO_ROOT}/scripts/crypto/openssl/fips-preflight.sh" >&2; }
 run_validator() { RUBIN_OPENSSL_SKIP_FIPS_GUARD=1 "${DEV_ENV}" -- python3 "${VALIDATOR}" "$@"; }
+argv_cmd() { local out="" arg q; for arg; do printf -v q "%q" "$arg"; out+="${out:+ }${q}"; done; printf '%s\n' "${out}"; }
 rpc_json() {
   local method="$1" addr="$2" path="$3"
   python3 - "${method}" "${addr}" "${path}" <<'PY'
@@ -197,7 +196,7 @@ PY
 }
 pid_comm() {
   local pid="$1" comm
-  comm="$(ps -p "${pid}" -o comm= 2>/dev/null | awk 'NR==1 {print $1}')" || return 1; [[ -n "${comm}" ]] || return 1; basename -- "${comm}"
+  comm="$(ps -ww -p "${pid}" -o comm= 2>/dev/null | sed -n '1p')" || return 1; [[ -n "${comm}" ]] || return 1; basename -- "${comm}"
 }
 pid_listens_on() {
   local pid="$1" endpoint="$2" out status=0
@@ -242,11 +241,12 @@ build_rust_node() {
 import json, sys
 selected = None
 with open(sys.argv[1], encoding="utf-8") as f:
-    for raw in f:
+    for line_no, raw in enumerate(f, 1):
         line = raw.strip()
         if not line: continue
         if not line.startswith("{"): sys.exit(f"cargo build log contamination: {line[:160]!r}")
-        ev = json.loads(line)
+        try: ev = json.loads(line)
+        except json.JSONDecodeError as exc: sys.exit(f"malformed cargo JSON at line {line_no}: {exc.msg}")
         if ev.get("reason") != "compiler-artifact": continue
         target = ev.get("target") or {}
         if target.get("name") == "rubin-node" and "bin" in (target.get("kind") or []) and ev.get("executable"): selected = ev["executable"]
@@ -396,11 +396,9 @@ verify_process_identity() {
   esac
 }
 start_rust_node() {
-  RUST_CMD="${RUST_NODE_BIN} --network devnet --datadir ${RUST_DIR} --bind 127.0.0.1:0 --rpc-bind 127.0.0.1:0 --peer ${GO_P2P_ADDR}"
-  rubin_process_start "${RUST_LOG}" "${RUST_NODE_BIN}" \
-    --network devnet --datadir "${RUST_DIR}" \
-    --bind 127.0.0.1:0 --rpc-bind 127.0.0.1:0 \
-    --peer "${GO_P2P_ADDR}" || return 1
+  local -a argv=("${RUST_NODE_BIN}" --network devnet --datadir "${RUST_DIR}" --bind 127.0.0.1:0 --rpc-bind 127.0.0.1:0 --peer "${GO_P2P_ADDR}")
+  RUST_CMD="$(argv_cmd "${argv[@]}")"
+  rubin_process_start "${RUST_LOG}" "${argv[@]}" || return 1
   RUST_PID="${RUBIN_PROCESS_LAST_PID}"
   rubin_process_wait_for_log "${RUST_LOG}" "p2p: listening=" 60 "${RUST_PID}" || return 1
   rubin_process_wait_for_log "${RUST_LOG}" "rpc: listening=" 60 "${RUST_PID}" || return 1
@@ -410,10 +408,9 @@ start_rust_node() {
   RUST_STARTED_AT_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 }
 start_go_node() {
-  GO_CMD="${GO_NODE_BIN} --network devnet --datadir ${GO_DIR} --bind 127.0.0.1:0 --rpc-bind 127.0.0.1:0"
-  rubin_process_start "${GO_LOG}" "${GO_NODE_BIN}" \
-    --network devnet --datadir "${GO_DIR}" \
-    --bind 127.0.0.1:0 --rpc-bind 127.0.0.1:0 || return 1
+  local -a argv=("${GO_NODE_BIN}" --network devnet --datadir "${GO_DIR}" --bind 127.0.0.1:0 --rpc-bind 127.0.0.1:0)
+  GO_CMD="$(argv_cmd "${argv[@]}")"
+  rubin_process_start "${GO_LOG}" "${argv[@]}" || return 1
   GO_PID="${RUBIN_PROCESS_LAST_PID}"
   rubin_process_wait_for_log "${GO_LOG}" "rpc: listening=" 60 "${GO_PID}" || return 1
   GO_RPC_ADDR="$(rubin_process_extract_rpc_addr "${GO_LOG}")" || return 1
@@ -422,7 +419,7 @@ start_go_node() {
   GO_STARTED_AT_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 }
 [[ "${MESH_TIMEOUT}" =~ ^[0-9]+$ && "${MESH_TIMEOUT}" -ge 1 && "${MESH_TIMEOUT}" -le 600 ]] || { echo "MESH_TIMEOUT must be an integer in [1, 600]" >&2; exit 2; }
-command -v lsof >/dev/null 2>&1 || finish_no_data "lsof_unavailable"
+command -v lsof >/dev/null 2>&1 || finish_no_data "lsof_unavailable"; command -v perl >/dev/null 2>&1 || finish_no_data "perl_unavailable"
 build_go_node || finish_no_data "go_build_failed"
 build_rust_node || finish_no_data "rust_build_failed"
 start_go_node || finish_no_data "go_process_not_ready"

--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -1,0 +1,486 @@
+#!/usr/bin/env bash
+# RUB-21: launch one real Go node and one real Rust node, then prove a live
+# mixed-client mesh through process identity plus bidirectional peer snapshots.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEV_ENV="${REPO_ROOT}/scripts/dev-env.sh"
+GO_MODULE_ROOT="${REPO_ROOT}/clients/go"
+RUST_WORKSPACE_ROOT="${REPO_ROOT}/clients/rust"
+HELPER="${REPO_ROOT}/scripts/devnet-process-common.sh"
+VALIDATOR="${REPO_ROOT}/scripts/devnet/validate_mixed_client_evidence.py"
+
+CHECK_REPORT="" CHECK_REPORT_MODE=0
+MESH_TIMEOUT="${MESH_TIMEOUT:-90}"
+
+usage() { echo "usage: $0 [--check-report PATH]" >&2; }
+while (($#)); do
+  case "$1" in
+    --check-report)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      CHECK_REPORT_MODE=1
+      CHECK_REPORT="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+need_tool() {
+  command -v -- "$1" >/dev/null 2>&1 || { echo "$1 is required for mixed-client mesh evidence" >&2; exit 1; }
+}
+
+check_report() {
+  local report="${1:-}"
+  [[ -n "${report}" ]] || { echo "FAIL: report path is required" >&2; return 1; }
+  python3 - "${report}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+
+def fail(message: str) -> None:
+    print(f"FAIL: {message}", file=sys.stderr)
+    sys.exit(1)
+
+try:
+    with path.open(encoding="utf-8") as f:
+        data = json.load(f)
+except OSError as exc:
+    fail(f"cannot read report: {exc}")
+except json.JSONDecodeError as exc:
+    fail(f"malformed JSON report: {exc}")
+
+if not isinstance(data, dict):
+    fail("report root is not an object")
+if data.get("scenario") != "mixed_client_mesh":
+    fail(f"scenario is not mixed_client_mesh: {data.get('scenario')!r}")
+verdict = data.get("verdict")
+if verdict != "PASS":
+    reason = data.get("failure_reason")
+    if verdict not in {"FAIL", "NO_DATA"} or not isinstance(reason, str) or not reason:
+        fail("non-PASS report must carry verdict FAIL/NO_DATA and failure_reason")
+    print(f"PASS: non-PASS mixed-client mesh report is typed: {path}")
+    sys.exit(0)
+if "failure_reason" in data:
+    fail("PASS report must not carry failure_reason")
+
+nodes = data.get("nodes")
+if not isinstance(nodes, list) or len(nodes) != 2:
+    fail("PASS report requires exactly two node records")
+if not all(isinstance(node, dict) for node in nodes):
+    fail("node entry is not an object")
+impls = {node.get("implementation") for node in nodes}
+if impls != {"go", "rust"}:
+    fail(f"PASS report requires one go and one rust node, got {sorted(str(impl) for impl in impls)}")
+expected_comm = {"go": "rubin-node-go", "rust": "rubin-node-rust"}
+for node in nodes:
+    impl = node.get("implementation")
+    name = node.get("name")
+    if not isinstance(name, str) or not name.startswith("node-"):
+        fail(f"node has invalid name: {name!r}")
+    if node.get("process_comm") != expected_comm.get(impl):
+        fail(f"{name} process_comm does not prove {impl} identity")
+    for field in ("pid", "command", "binary", "rpc_endpoint", "p2p_endpoint", "started_at"):
+        if field not in node or node[field] in ("", None):
+            fail(f"{name} missing {field}")
+    if not isinstance(node["pid"], int) or node["pid"] <= 0:
+        fail(f"{name} pid is not a positive integer")
+    for field in ("process_alive", "rpc_endpoint_process_backed", "p2p_endpoint_process_backed"):
+        if node.get(field) is not True:
+            fail(f"{name} does not prove {field}")
+
+connectivity = data.get("peer_connectivity")
+if not isinstance(connectivity, dict):
+    fail("PASS report missing peer_connectivity object")
+for field in ("go_to_rust", "rust_to_go", "bidirectional_observed"):
+    if connectivity.get(field) is not True:
+        fail(f"peer_connectivity.{field} is not true")
+for field in ("go_peer_snapshot", "rust_peer_snapshot"):
+    snapshot = connectivity.get(field)
+    if not isinstance(snapshot, dict) or snapshot.get("count", 0) < 1:
+        fail(f"{field} must show at least one peer")
+    peers = snapshot.get("peers")
+    if not isinstance(peers, list) or not peers:
+        fail(f"{field}.peers must be non-empty")
+    if not any(peer.get("handshake_complete") is True for peer in peers if isinstance(peer, dict)):
+        fail(f"{field} lacks a completed handshake")
+
+print(f"PASS: mixed-client mesh report accepted {path}")
+PY
+}
+
+if [[ "${CHECK_REPORT_MODE}" == "1" ]]; then
+  need_tool python3
+  check_report "${CHECK_REPORT}"
+  exit 0
+fi
+
+need_tool python3
+need_tool perl
+[[ -x "${DEV_ENV}" ]] || { echo "dev-env wrapper missing or non-executable: ${DEV_ENV}" >&2; exit 1; }
+[[ -r "${VALIDATOR}" ]] || { echo "validator unreadable: ${VALIDATOR}" >&2; exit 1; }
+
+# shellcheck source=scripts/devnet-process-common.sh disable=SC1091
+source "${HELPER}"
+rubin_process_init mixed-client-mesh
+
+GO_NODE_BIN="${RUBIN_PROCESS_ARTIFACT_ROOT}/rubin-node-go"
+RUST_NODE_BIN="${RUBIN_PROCESS_ARTIFACT_ROOT}/rubin-node-rust"
+GO_DIR="${RUBIN_PROCESS_ARTIFACT_ROOT}/node-go"
+RUST_DIR="${RUBIN_PROCESS_ARTIFACT_ROOT}/node-rust"
+GO_LOG="node-go.log"
+RUST_LOG="node-rust.log"
+REPORT_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/mixed-client-mesh-report.json"
+EVIDENCE_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/mixed-client-mesh-schema-marker.json"
+GO_PEERS_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/go-peers.json"
+RUST_PEERS_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/rust-peers.json"
+
+GO_PID="" RUST_PID="" GO_RPC_ADDR="" RUST_RPC_ADDR="" GO_P2P_ADDR="" RUST_P2P_ADDR=""
+GO_STARTED_AT_UTC="" RUST_STARTED_AT_UTC="" GO_COMM="" RUST_COMM=""
+GO_CMD="" RUST_CMD=""
+mkdir -p -- "${GO_DIR}" "${RUST_DIR}"
+
+run_fips_preflight_before_captured_dev_env() {
+  if [[ "${RUBIN_OPENSSL_FIPS_MODE:-off}" != "only" || "${RUBIN_OPENSSL_SKIP_FIPS_GUARD:-0}" == "1" ]]; then
+    return 0
+  fi
+  echo "Running FIPS-only preflight before captured dev-env command streams" >&2
+  "${DEV_ENV}" -- "${REPO_ROOT}/scripts/crypto/openssl/fips-preflight.sh" >&2
+}
+
+run_validator() {
+  RUBIN_OPENSSL_SKIP_FIPS_GUARD=1 "${DEV_ENV}" -- python3 "${VALIDATOR}" "$@"
+}
+
+utc_now() {
+  python3 -c 'import datetime; print(datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"))'
+}
+
+rpc_json() {
+  local method="$1" addr="$2" path="$3"
+  python3 - "${method}" "${addr}" "${path}" <<'PY'
+import socket
+import sys
+import urllib.error
+import urllib.request
+method, addr, path = sys.argv[1:4]
+req = urllib.request.Request(f"http://{addr}{path}", method=method)
+try:
+    with urllib.request.urlopen(req, timeout=5) as resp:
+        print(resp.read().decode("utf-8"), end="")
+except urllib.error.HTTPError as exc:
+    print(exc.read().decode("utf-8"), end="")
+    sys.exit(22)
+except (urllib.error.URLError, TimeoutError, socket.timeout) as exc:
+    print(f"request failed: {getattr(exc, 'reason', exc)}", end="")
+    sys.exit(1)
+PY
+}
+
+pid_comm() {
+  local pid="$1" comm
+  comm="$(ps -p "${pid}" -o comm= 2>/dev/null | awk 'NR==1 {print $1}')" || return 1
+  [[ -n "${comm}" ]] || return 1
+  basename -- "${comm}"
+}
+
+pid_listens_on() {
+  local pid="$1" endpoint="$2" out status=0
+  out="$(lsof -nP -a -p "${pid}" -iTCP -sTCP:LISTEN -Fn 2>&1)" || status=$?
+  grep -F -x -q -- "n${endpoint}" <<<"${out}" && return 0
+  (( status == 0 || ${#out} == 0 )) || return 2
+  return 1
+}
+
+p2p_addr_for_pid() {
+  local pid="$1" rpc_addr="$2" timeout="$3"
+  python3 - "${pid}" "${rpc_addr}" "${timeout}" <<'PY'
+import re
+import subprocess
+import sys
+import time
+pid, rpc_addr, timeout = sys.argv[1], sys.argv[2], int(sys.argv[3])
+deadline = time.time() + timeout
+while time.time() < deadline:
+    proc = subprocess.run(
+        ["lsof", "-nP", "-a", "-p", pid, "-iTCP", "-sTCP:LISTEN", "-Fn"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+    )
+    addrs = sorted(
+        {
+            line[1:].strip()
+            for line in proc.stdout.splitlines()
+            if line.startswith("n")
+            and line[1:].strip() != rpc_addr
+            and re.fullmatch(r"127\.0\.0\.1:[0-9]+", line[1:].strip())
+        }
+    )
+    if len(addrs) == 1:
+        print(addrs[0])
+        sys.exit(0)
+    if len(addrs) > 1:
+        sys.exit(f"ambiguous p2p listen addresses for pid={pid}: {addrs}")
+    time.sleep(1)
+sys.exit(f"timeout resolving p2p listen address for pid={pid}")
+PY
+}
+
+extract_log_addr() {
+  local log_file="$1" prefix="$2" path addr
+  path="$(_rubin_process_resolve_log "${log_file}")" || return 1
+  addr="$(sed -n "s/.*${prefix}//p" "${path}" | tail -n 1 | tr -d '[:space:]')" || return 1
+  [[ "${addr}" == 127.0.0.1:* ]] || return 1
+  printf '%s\n' "${addr}"
+}
+
+build_go_node() {
+  echo "Building Go rubin-node binary" >&2
+  "${DEV_ENV}" -- go -C "${GO_MODULE_ROOT}" build -o "${GO_NODE_BIN}" ./cmd/rubin-node || return 1
+  [[ -x "${GO_NODE_BIN}" ]]
+}
+
+build_rust_node() {
+  local host_triple cargo_target_dir cargo_log cargo_bin
+  echo "Building Rust rubin-node binary" >&2
+  run_fips_preflight_before_captured_dev_env
+  host_triple="$(RUBIN_OPENSSL_SKIP_FIPS_GUARD=1 "${DEV_ENV}" -- rustc -vV | awk '/^host:/ {print $2}')" || return 1
+  [[ -n "${host_triple}" ]] || return 1
+  cargo_target_dir="${RUBIN_PROCESS_ARTIFACT_ROOT}/cargo-target"
+  cargo_log="${RUBIN_PROCESS_ARTIFACT_ROOT}/cargo-build.jsonl"
+  RUBIN_OPENSSL_SKIP_FIPS_GUARD=1 "${DEV_ENV}" -- cargo build \
+    --manifest-path "${RUST_WORKSPACE_ROOT}/Cargo.toml" \
+    --release --locked -p rubin-node \
+    --target "${host_triple}" \
+    --target-dir "${cargo_target_dir}" \
+    --message-format=json-render-diagnostics >"${cargo_log}" || return 1
+  cargo_bin="$(python3 - "${cargo_log}" <<'PY'
+import json
+import sys
+selected = None
+with open(sys.argv[1], encoding="utf-8") as f:
+    for raw in f:
+        line = raw.strip()
+        if not line:
+            continue
+        if not line.startswith("{"):
+            sys.exit(f"cargo build log contamination: {line[:160]!r}")
+        ev = json.loads(line)
+        if ev.get("reason") != "compiler-artifact":
+            continue
+        target = ev.get("target") or {}
+        if target.get("name") == "rubin-node" and "bin" in (target.get("kind") or []) and ev.get("executable"):
+            selected = ev["executable"]
+if selected is None:
+    sys.exit("no rubin-node executable artifact in cargo JSON stream")
+print(selected)
+PY
+)" || return 1
+  [[ -x "${cargo_bin}" ]] || return 1
+  cp -- "${cargo_bin}" "${RUST_NODE_BIN}" || return 1
+  [[ -x "${RUST_NODE_BIN}" ]]
+}
+
+write_outputs() {
+  local verdict="$1" reason="${2:-}"
+  export REPORT_JSON EVIDENCE_JSON verdict reason GO_PID RUST_PID GO_RPC_ADDR RUST_RPC_ADDR \
+    GO_P2P_ADDR RUST_P2P_ADDR GO_STARTED_AT_UTC RUST_STARTED_AT_UTC GO_COMM RUST_COMM \
+    GO_NODE_BIN RUST_NODE_BIN GO_CMD RUST_CMD GO_PEERS_JSON RUST_PEERS_JSON \
+    RUBIN_PROCESS_ARTIFACT_ROOT
+  python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+e = os.environ
+verdict = e["verdict"]
+reason = (e.get("reason") or "").strip()
+
+def read_json(path: str) -> dict:
+    try:
+        with open(path, encoding="utf-8") as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return {"count": 0, "peers": []}
+
+nodes = []
+for impl, name, pid_key, rpc_key, p2p_key, started_key, comm_key, bin_key, cmd_key in (
+    ("go", "node-go", "GO_PID", "GO_RPC_ADDR", "GO_P2P_ADDR", "GO_STARTED_AT_UTC", "GO_COMM", "GO_NODE_BIN", "GO_CMD"),
+    ("rust", "node-rust", "RUST_PID", "RUST_RPC_ADDR", "RUST_P2P_ADDR", "RUST_STARTED_AT_UTC", "RUST_COMM", "RUST_NODE_BIN", "RUST_CMD"),
+):
+    pid_raw = (e.get(pid_key) or "").strip()
+    node = {
+        "name": name,
+        "implementation": impl,
+        "pid": int(pid_raw) if pid_raw.isdigit() else None,
+        "command": e.get(cmd_key) or "",
+        "binary": e.get(bin_key) or "",
+        "rpc_endpoint": e.get(rpc_key) or None,
+        "p2p_endpoint": e.get(p2p_key) or None,
+        "started_at": e.get(started_key) or None,
+        "process_comm": e.get(comm_key) or None,
+        "process_alive": bool(pid_raw),
+        "rpc_endpoint_process_backed": bool(e.get(rpc_key)),
+        "p2p_endpoint_process_backed": bool(e.get(p2p_key)),
+    }
+    nodes.append(node)
+
+go_snapshot = read_json(e["GO_PEERS_JSON"])
+rust_snapshot = read_json(e["RUST_PEERS_JSON"])
+report = {
+    "scenario": "mixed_client_mesh",
+    "verdict": verdict,
+    "artifact_root": e["RUBIN_PROCESS_ARTIFACT_ROOT"],
+    "nodes": nodes,
+    "peer_connectivity": {
+        "go_to_rust": verdict == "PASS",
+        "rust_to_go": verdict == "PASS",
+        "bidirectional_observed": verdict == "PASS",
+        "go_peer_snapshot": go_snapshot,
+        "rust_peer_snapshot": rust_snapshot,
+    },
+    "schema_marker": {
+        "path": e["EVIDENCE_JSON"],
+        "verdict": "FAIL",
+        "reason": "existing mixed_client_evidence_v1 PASS requires tx_path; RUB-21 mesh-only PASS lives in this report",
+    },
+}
+if verdict != "PASS":
+    report["failure_reason"] = reason or "mixed-client mesh did not produce PASS evidence"
+with open(e["REPORT_JSON"], "w", encoding="utf-8") as f:
+    json.dump(report, f, indent=2, sort_keys=True)
+    f.write("\n")
+
+marker_reason = reason if verdict != "PASS" and reason else (
+    "mixed-client mesh process/connectivity PASS is recorded in sibling report; "
+    "existing schema v1 PASS requires tx_path proof owned by RUB-22/RUB-23"
+)
+schema_marker = {
+    "schema_version": "rubin-mixed-client-devnet-evidence-v1",
+    "evidence_type": "mixed_client_process_soak",
+    "scenario": "mixed_client_mesh_schema_marker",
+    "verdict": "FAIL",
+    "failure_reason": marker_reason,
+    "participants": [
+        {"name": "node-go", "implementation": "go", **({"endpoint": e["GO_RPC_ADDR"], "started_at": e["GO_STARTED_AT_UTC"]} if e.get("GO_RPC_ADDR") and e.get("GO_STARTED_AT_UTC") else {})},
+        {"name": "node-rust", "implementation": "rust", **({"endpoint": e["RUST_RPC_ADDR"], "started_at": e["RUST_STARTED_AT_UTC"]} if e.get("RUST_RPC_ADDR") and e.get("RUST_STARTED_AT_UTC") else {})},
+    ],
+}
+with open(e["EVIDENCE_JSON"], "w", encoding="utf-8") as f:
+    json.dump(schema_marker, f, indent=2, sort_keys=True)
+    f.write("\n")
+PY
+}
+
+finish_no_data() {
+  local reason="$1"
+  write_outputs "NO_DATA" "${reason}"
+  run_validator "${EVIDENCE_JSON}" >&2
+  echo "NO_DATA: ${reason}; report=${REPORT_JSON} schema_marker=${EVIDENCE_JSON}" >&2
+  exit 1
+}
+
+wait_peer_snapshot() {
+  local label="$1" addr="$2" out="$3" timeout="$4" deadline tmp
+  deadline=$((SECONDS + timeout))
+  tmp="${out}.tmp"
+  while (( SECONDS < deadline )); do
+    if rpc_json GET "${addr}" /peers >"${tmp}" 2>/dev/null \
+      && python3 - "${tmp}" <<'PY' >/dev/null 2>&1
+import json
+import sys
+with open(sys.argv[1], encoding="utf-8") as f:
+    data = json.load(f)
+peers = data.get("peers")
+ok = isinstance(peers, list) and data.get("count", 0) >= 1 and any(
+    isinstance(p, dict) and p.get("handshake_complete") is True for p in peers
+)
+sys.exit(0 if ok else 1)
+PY
+    then
+      mv -- "${tmp}" "${out}"
+      return 0
+    fi
+    sleep 1
+  done
+  rm -f -- "${tmp}"
+  echo "timeout waiting for ${label} /peers completed handshake" >&2
+  return 1
+}
+
+verify_process_identity() {
+  local label="$1" impl="$2" pid="$3" rpc_addr="$4" p2p_addr="$5" expected_comm="$6" comm
+  rubin_process_is_alive "${pid}" || { echo "${label} pid is not alive: ${pid}" >&2; return 1; }
+  comm="$(pid_comm "${pid}")" || { echo "${label} process comm unavailable: ${pid}" >&2; return 1; }
+  [[ "${comm}" == "${expected_comm}" ]] || { echo "${label} process comm=${comm}, want ${expected_comm}" >&2; return 1; }
+  pid_listens_on "${pid}" "${rpc_addr}" || { echo "${label} rpc endpoint is not process-backed: ${rpc_addr}" >&2; return 1; }
+  pid_listens_on "${pid}" "${p2p_addr}" || { echo "${label} p2p endpoint is not process-backed: ${p2p_addr}" >&2; return 1; }
+  case "${impl}" in
+    go) GO_COMM="${comm}" ;;
+    rust) RUST_COMM="${comm}" ;;
+    *) return 1 ;;
+  esac
+}
+
+start_rust_node() {
+  RUST_CMD="${RUST_NODE_BIN} --network devnet --datadir ${RUST_DIR} --bind 127.0.0.1:0 --rpc-bind 127.0.0.1:0 --peer ${GO_P2P_ADDR}"
+  rubin_process_start "${RUST_LOG}" "${RUST_NODE_BIN}" \
+    --network devnet --datadir "${RUST_DIR}" \
+    --bind 127.0.0.1:0 --rpc-bind 127.0.0.1:0 \
+    --peer "${GO_P2P_ADDR}" || return 1
+  RUST_PID="${RUBIN_PROCESS_LAST_PID}"
+  rubin_process_wait_for_log "${RUST_LOG}" "p2p: listening=" 60 "${RUST_PID}" || return 1
+  rubin_process_wait_for_log "${RUST_LOG}" "rpc: listening=" 60 "${RUST_PID}" || return 1
+  RUST_P2P_ADDR="$(extract_log_addr "${RUST_LOG}" "p2p: listening=")" || return 1
+  RUST_RPC_ADDR="$(rubin_process_extract_rpc_addr "${RUST_LOG}")" || return 1
+  rubin_process_wait_for_rpc_ready "${RUST_RPC_ADDR}" 30 || return 1
+  RUST_STARTED_AT_UTC="$(utc_now)"
+}
+
+start_go_node() {
+  GO_CMD="${GO_NODE_BIN} --network devnet --datadir ${GO_DIR} --bind 127.0.0.1:0 --rpc-bind 127.0.0.1:0"
+  rubin_process_start "${GO_LOG}" "${GO_NODE_BIN}" \
+    --network devnet --datadir "${GO_DIR}" \
+    --bind 127.0.0.1:0 --rpc-bind 127.0.0.1:0 || return 1
+  GO_PID="${RUBIN_PROCESS_LAST_PID}"
+  rubin_process_wait_for_log "${GO_LOG}" "rpc: listening=" 60 "${GO_PID}" || return 1
+  GO_RPC_ADDR="$(rubin_process_extract_rpc_addr "${GO_LOG}")" || return 1
+  GO_P2P_ADDR="$(p2p_addr_for_pid "${GO_PID}" "${GO_RPC_ADDR}" 30)" || return 1
+  rubin_process_wait_for_rpc_ready "${GO_RPC_ADDR}" 30 || return 1
+  GO_STARTED_AT_UTC="$(utc_now)"
+}
+
+[[ "${MESH_TIMEOUT}" =~ ^[0-9]+$ && "${MESH_TIMEOUT}" -ge 1 && "${MESH_TIMEOUT}" -le 600 ]] || {
+  echo "MESH_TIMEOUT must be an integer in [1, 600]" >&2
+  exit 2
+}
+command -v lsof >/dev/null 2>&1 || finish_no_data "lsof_unavailable"
+
+build_go_node || finish_no_data "go_build_failed"
+build_rust_node || finish_no_data "rust_build_failed"
+start_go_node || finish_no_data "go_process_not_ready"
+verify_process_identity node-go go "${GO_PID}" "${GO_RPC_ADDR}" "${GO_P2P_ADDR}" rubin-node-go || finish_no_data "go_process_identity_unverified"
+start_rust_node || finish_no_data "rust_process_not_ready"
+verify_process_identity node-rust rust "${RUST_PID}" "${RUST_RPC_ADDR}" "${RUST_P2P_ADDR}" rubin-node-rust || finish_no_data "rust_process_identity_unverified"
+wait_peer_snapshot node-go "${GO_RPC_ADDR}" "${GO_PEERS_JSON}" "${MESH_TIMEOUT}" || finish_no_data "go_peer_snapshot_missing_completed_handshake"
+wait_peer_snapshot node-rust "${RUST_RPC_ADDR}" "${RUST_PEERS_JSON}" "${MESH_TIMEOUT}" || finish_no_data "rust_peer_snapshot_missing_completed_handshake"
+
+write_outputs "PASS"
+run_validator "${EVIDENCE_JSON}" >&2
+check_report "${REPORT_JSON}" >&2
+if [[ "${RUBIN_PROCESS_KEEP_ARTIFACTS}" == "1" ]]; then
+  echo "PASS: mixed-client mesh connected go_pid=${GO_PID} rust_pid=${RUST_PID}; report=${REPORT_JSON} schema_marker=${EVIDENCE_JSON}"
+else
+  echo "PASS: mixed-client mesh connected go_pid=${GO_PID} rust_pid=${RUST_PID}; set KEEP_TMP=1 to retain report"
+fi

--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -56,7 +56,7 @@ def ep(value: object) -> bool:
 def nonempty_str(value: object) -> bool: return isinstance(value, str) and bool(value.strip())
 def ps_comm(pid: int) -> str: return os.path.basename(run(["ps", "-ww", "-p", str(pid), "-o", "comm="]))
 def lsof_lines(pid: int, state: str) -> list[str]:
-    p = subprocess.run(["lsof", "-nP", "-a", "-p", str(pid), "-iTCP", f"-sTCP:{state}", "-Fn"], check=False, text=True, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, timeout=5)
+    p = subprocess.run(["lsof", "-nP", "-a", "-p", str(pid), "-iTCP", f"-sTCP:{state}", "-Fn"], check=False, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=5); req(p.returncode == 0 or not p.stderr.strip(), "lsof_failed")
     return [line[1:] for line in p.stdout.splitlines() if line.startswith("n")]
 def owns_listen(pid: int, endpoint: str) -> bool: return endpoint in lsof_lines(pid, "LISTEN")
 def peers(addr: str) -> dict:
@@ -211,7 +211,8 @@ import re, subprocess, sys, time
 pid, rpc_addr, timeout = sys.argv[1], sys.argv[2], int(sys.argv[3])
 deadline = time.time() + timeout
 while time.time() < deadline:
-    proc = subprocess.run(["lsof", "-nP", "-a", "-p", pid, "-iTCP", "-sTCP:LISTEN", "-Fn"], text=True, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+    proc = subprocess.run(["lsof", "-nP", "-a", "-p", pid, "-iTCP", "-sTCP:LISTEN", "-Fn"], text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    if proc.returncode != 0 and proc.stderr.strip(): sys.exit(42)
     addrs = sorted({line[1:].strip() for line in proc.stdout.splitlines() if line.startswith("n") and line[1:].strip() != rpc_addr and re.fullmatch(r"127\.0\.0\.1:[0-9]+", line[1:].strip())})
     if len(addrs) == 1: print(addrs[0]); sys.exit(0)
     if len(addrs) > 1: sys.exit(f"ambiguous p2p listen addresses for pid={pid}: {addrs}")
@@ -373,11 +374,11 @@ PY
   return 1
 }
 wait_rust_to_go_link() {
-  local missing="$1" ambiguous="$2" deadline out status
-  deadline=$((SECONDS + MESH_TIMEOUT))
+  local missing="$1" ambiguous="$2" deadline out status err_file err
+  deadline=$((SECONDS + MESH_TIMEOUT)); err_file="${RUBIN_PROCESS_ARTIFACT_ROOT}/lsof-established.err"
   while (( SECONDS < deadline )); do
-    status=0; out="$(lsof -nP -a -p "${RUST_PID}" -iTCP -sTCP:ESTABLISHED -Fn 2>/dev/null | REMOTE_ADDR="${GO_P2P_ADDR}" perl -ne 'BEGIN{$r=$ENV{REMOTE_ADDR}} chomp; s/^n// or next; print "$1\n" if /^(127[.]0[.]0[.]1:[0-9]+)->\Q$r\E$/' | sort -u)" || status=$?
-    (( status == 0 || ${#out} == 0 )) || finish_no_data "${missing}"
+    status=0; out="$(lsof -nP -a -p "${RUST_PID}" -iTCP -sTCP:ESTABLISHED -Fn 2>"${err_file}" | REMOTE_ADDR="${GO_P2P_ADDR}" perl -ne 'BEGIN{$r=$ENV{REMOTE_ADDR}} chomp; s/^n// or next; print "$1\n" if /^(127[.]0[.]0[.]1:[0-9]+)->\Q$r\E$/' | sort -u)" || status=$?; err="$(<"${err_file}")"
+    (( status == 0 || (${#out} == 0 && ${#err} == 0) )) || finish_no_data "lsof_failed"
     [[ "${out}" != *$'\n'* ]] || finish_no_data "${ambiguous}"; [[ -z "${out}" ]] || { RUST_TO_GO_LOCAL_ADDR="${out}"; return 0; }
     sleep 1
   done; finish_no_data "${missing}"
@@ -387,8 +388,8 @@ verify_process_identity() {
   rubin_process_is_alive "${pid}" || { echo "${label} pid is not alive: ${pid}" >&2; return 1; }
   comm="$(pid_comm "${pid}")" || { echo "${label} process comm unavailable: ${pid}" >&2; return 1; }
   [[ "${comm}" == "${expected_comm}" ]] || { echo "${label} process comm=${comm}, want ${expected_comm}" >&2; return 1; }
-  pid_listens_on "${pid}" "${rpc_addr}" || { echo "${label} rpc endpoint is not process-backed: ${rpc_addr}" >&2; return 1; }
-  pid_listens_on "${pid}" "${p2p_addr}" || { echo "${label} p2p endpoint is not process-backed: ${p2p_addr}" >&2; return 1; }
+  pid_listens_on "${pid}" "${rpc_addr}" || { [[ $? -eq 2 ]] && finish_no_data "lsof_failed"; echo "${label} rpc endpoint is not process-backed: ${rpc_addr}" >&2; return 1; }
+  pid_listens_on "${pid}" "${p2p_addr}" || { [[ $? -eq 2 ]] && finish_no_data "lsof_failed"; echo "${label} p2p endpoint is not process-backed: ${p2p_addr}" >&2; return 1; }
   case "${impl}" in
     go) GO_COMM="${comm}"; GO_PROCESS_ALIVE=true; GO_RPC_PROCESS_BACKED=true; GO_P2P_PROCESS_BACKED=true ;;
     rust) RUST_COMM="${comm}"; RUST_PROCESS_ALIVE=true; RUST_RPC_PROCESS_BACKED=true; RUST_P2P_PROCESS_BACKED=true ;;
@@ -414,7 +415,7 @@ start_go_node() {
   GO_PID="${RUBIN_PROCESS_LAST_PID}"
   rubin_process_wait_for_log "${GO_LOG}" "rpc: listening=" 60 "${GO_PID}" || return 1
   GO_RPC_ADDR="$(rubin_process_extract_rpc_addr "${GO_LOG}")" || return 1
-  GO_P2P_ADDR="$(p2p_addr_for_pid "${GO_PID}" "${GO_RPC_ADDR}" 30)" || return 1
+  GO_P2P_ADDR="$(p2p_addr_for_pid "${GO_PID}" "${GO_RPC_ADDR}" 30)" || { [[ $? -eq 42 ]] && finish_no_data "lsof_failed"; return 1; }
   rubin_process_wait_for_rpc_ready "${GO_RPC_ADDR}" 30 || return 1
   GO_STARTED_AT_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 }

--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -180,11 +180,13 @@ GO_NODE_BIN="${RUBIN_PROCESS_ARTIFACT_ROOT}/rubin-node-go"; RUST_NODE_BIN="${RUB
 GO_DIR="${RUBIN_PROCESS_ARTIFACT_ROOT}/node-go"; RUST_DIR="${RUBIN_PROCESS_ARTIFACT_ROOT}/node-rust"
 GO_LOG="node-go.log"; RUST_LOG="node-rust.log"; REPORT_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/mixed-client-mesh-report.json"; LEGACY_SCHEMA_MARKER_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/mixed-client-mesh-legacy-schema-marker.json"
 GO_PEERS_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/go-peers.json"; RUST_PEERS_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/rust-peers.json"
-GO_PID="" RUST_PID="" GO_RPC_ADDR="" RUST_RPC_ADDR="" GO_P2P_ADDR="" RUST_P2P_ADDR="" GO_STARTED_AT_UTC="" RUST_STARTED_AT_UTC="" GO_COMM="" RUST_COMM="" RUST_TO_GO_LOCAL_ADDR="" GO_CMD="" RUST_CMD="" GO_ARGV_JSON="" RUST_ARGV_JSON="" FINAL_PROCESS_IDENTITY_RECHECKED="" FINAL_RUST_OUTBOUND_LINK_RECHECKED="" FINAL_PEER_SNAPSHOTS_RECHECKED=""
+GO_PID="" RUST_PID="" GO_RPC_ADDR="" RUST_RPC_ADDR="" GO_P2P_ADDR="" RUST_P2P_ADDR="" GO_STARTED_AT_UTC="" RUST_STARTED_AT_UTC="" GO_COMM="" RUST_COMM="" RUST_TO_GO_LOCAL_ADDR="" GO_CMD="" RUST_CMD="" GO_ARGV_JSON="" RUST_ARGV_JSON="" FINAL_PROCESS_IDENTITY_RECHECKED="" FINAL_RUST_OUTBOUND_LINK_RECHECKED="" FINAL_PEER_SNAPSHOTS_RECHECKED="" PROCESS_IDENTITY_REASON="" START_REASON="" BUILD_REASON=""
 mkdir -p -- "${GO_DIR}" "${RUST_DIR}"
 run_fips_preflight_before_captured_dev_env() { [[ "${RUBIN_OPENSSL_FIPS_MODE:-off}" != "only" || "${RUBIN_OPENSSL_SKIP_FIPS_GUARD:-0}" == "1" ]] && return 0; echo "Running FIPS-only preflight before captured dev-env command streams" >&2; "${DEV_ENV}" -- "${REPO_ROOT}/scripts/crypto/openssl/fips-preflight.sh" >&2; }
-bounded() { perl -e 'alarm shift @ARGV; exec @ARGV' 5 "$@"; }
+bounded() { perl -e 'alarm shift @ARGV; exec @ARGV; die "exec failed: $!\n"' 5 "$@"; }
 argv_cmd() { local out="" arg q; for arg; do printf -v q "%q" "$arg"; out+="${out:+ }${q}"; done; printf '%s\n' "${out}"; }; argv_json() { python3 -c 'import json,sys; print(json.dumps(sys.argv[1:]))' "$@"; }
+loopback_endpoint() { local endpoint="${1:-}" port; [[ "${endpoint}" =~ ^127[.]0[.]0[.]1:([0-9]{1,5})$ ]] || return 1; port="${BASH_REMATCH[1]}"; (( 10#${port} >= 1 && 10#${port} <= 65535 )); }
+check_report_reason_token() { python3 -c 'import sys; msg=" ".join(x[5:].strip() for x in sys.stdin.read().splitlines() if x.startswith("FAIL:")); rules=[("live peer snapshot malformed JSON","live_peer_snapshot_malformed_json"),("differs from live exact peer set","live_peer_snapshot_mismatch"),("live listeners are not pid-owned","live_listener_not_pid_owned"),("rust outbound TCP link is not live and rust-owned","rust_outbound_link_not_live"),("argv_unavailable","argv_unavailable"),("live process argv/executable does not match report","argv_mismatch"),("lsof_timeout","lsof_timeout"),("lsof_unavailable","lsof_unavailable"),("lsof_failed","lsof_failed"),("pid_exe_failed","pid_exe_failed"),("pid_exe_unavailable","pid_exe_unavailable"),("argv","argv_mismatch"),("same pid","same_pid"),("process_comm","process_identity_invalid"),("process_alive","process_identity_invalid"),("process-backed","process_identity_invalid"),("peer snapshot","peer_snapshot_invalid"),("legacy marker","legacy_marker_invalid"),("failure/schema-marker","pass_report_has_failure_fields"),("failure_reason","pass_report_has_failure_fields"),("root is not an object","report_root_invalid")]; print(next((t for p,t in rules if p in msg), "unknown"))'; }
 rpc_json() {
   local method="$1" addr="$2" path="$3"
   python3 - "${method}" "${addr}" "${path}" <<'PY'
@@ -194,8 +196,13 @@ req = urllib.request.Request(f"http://{addr}{path}", method=method)
 try:
     with urllib.request.urlopen(req, timeout=5) as resp: print(resp.read().decode("utf-8"), end="")
 except urllib.error.HTTPError as exc:
-    print(exc.read().decode("utf-8"), end="")
+    try:
+        print(exc.read().decode("utf-8"), end="")
+    except UnicodeDecodeError:
+        sys.exit(23)
     sys.exit(22)
+except UnicodeDecodeError:
+    sys.exit(23)
 except (urllib.error.URLError, TimeoutError, socket.timeout) as exc:
     print(f"request failed: {getattr(exc, 'reason', exc)}", end="")
     sys.exit(1)
@@ -224,26 +231,30 @@ while time.time() < deadline:
         time.sleep(1); continue
     addrs = sorted({line[1:].strip() for line in proc.stdout.splitlines() if line.startswith("n") and line[1:].strip() != rpc_addr and re.fullmatch(r"127\.0\.0\.1:[0-9]+", line[1:].strip())})
     if len(addrs) == 1: print(addrs[0]); sys.exit(0)
-    if len(addrs) > 1: sys.exit(f"ambiguous p2p listen addresses for pid={pid}: {addrs}")
+    if len(addrs) > 1:
+        print(f"ambiguous p2p listen addresses for pid={pid}: {addrs}", file=sys.stderr)
+        sys.exit(44)
     time.sleep(1)
-sys.exit(f"timeout resolving p2p listen address for pid={pid}")
+print(f"timeout resolving p2p listen address for pid={pid}", file=sys.stderr)
+sys.exit(45)
 PY
 }
 extract_log_addr() {
   local log_file="$1" prefix="$2" path addr
   path="$(_rubin_process_resolve_log "${log_file}")" || return 1
   addr="$(sed -n "s/.*${prefix}//p" "${path}" | tail -n 1 | tr -d '[:space:]')" || return 1
-  [[ "${addr}" == 127.0.0.1:* ]] || return 1; printf '%s\n' "${addr}"
+  [[ -n "${addr}" ]] || return 1; printf '%s\n' "${addr}"
 }
-build_go_node() { echo "Building Go rubin-node binary" >&2; "${DEV_ENV}" -- go -C "${GO_MODULE_ROOT}" build -o "${GO_NODE_BIN}" ./cmd/rubin-node || return 1; [[ -x "${GO_NODE_BIN}" ]]; }
+build_go_node() { BUILD_REASON=""; echo "Building Go rubin-node binary" >&2; "${DEV_ENV}" -- go -C "${GO_MODULE_ROOT}" build -o "${GO_NODE_BIN}" ./cmd/rubin-node || { BUILD_REASON=go_build_failed; return 1; }; [[ -x "${GO_NODE_BIN}" ]] || { BUILD_REASON=go_binary_missing_or_not_executable; return 1; }; }
 build_rust_node() {
-  local host_triple cargo_target_dir cargo_log cargo_bin
+  local host_triple cargo_target_dir cargo_log cargo_bin rc
+  BUILD_REASON=""
   echo "Building Rust rubin-node binary" >&2
-  run_fips_preflight_before_captured_dev_env || return 1
-  host_triple="$(RUBIN_OPENSSL_SKIP_FIPS_GUARD=1 "${DEV_ENV}" -- rustc -vV | awk '/^host:/ {print $2}')" || return 1
-  [[ -n "${host_triple}" ]] || return 1
+  run_fips_preflight_before_captured_dev_env || { BUILD_REASON=rust_fips_preflight_failed; return 1; }
+  host_triple="$(RUBIN_OPENSSL_SKIP_FIPS_GUARD=1 "${DEV_ENV}" -- rustc -vV | awk '/^host:/ {print $2}')" || { BUILD_REASON=rust_host_triple_failed; return 1; }
+  [[ -n "${host_triple}" ]] || { BUILD_REASON=rust_host_triple_missing; return 1; }
   cargo_target_dir="${RUBIN_PROCESS_ARTIFACT_ROOT}/cargo-target"; cargo_log="${RUBIN_PROCESS_ARTIFACT_ROOT}/cargo-build.jsonl"
-  RUBIN_OPENSSL_SKIP_FIPS_GUARD=1 "${DEV_ENV}" -- cargo build --manifest-path "${RUST_WORKSPACE_ROOT}/Cargo.toml" --release --locked -p rubin-node --target "${host_triple}" --target-dir "${cargo_target_dir}" --message-format=json-render-diagnostics >"${cargo_log}" || return 1
+  RUBIN_OPENSSL_SKIP_FIPS_GUARD=1 "${DEV_ENV}" -- cargo build --manifest-path "${RUST_WORKSPACE_ROOT}/Cargo.toml" --release --locked -p rubin-node --target "${host_triple}" --target-dir "${cargo_target_dir}" --message-format=json-render-diagnostics >"${cargo_log}" || { BUILD_REASON=rust_cargo_build_failed; return 1; }
   cargo_bin="$(python3 - "${cargo_log}" <<'PY'
 import json, sys
 selected = None
@@ -251,19 +262,19 @@ with open(sys.argv[1], encoding="utf-8") as f:
     for line_no, raw in enumerate(f, 1):
         line = raw.strip()
         if not line: continue
-        if not line.startswith("{"): sys.exit(f"cargo build log contamination: {line[:160]!r}")
+        if not line.startswith("{"): sys.exit(2)
         try: ev = json.loads(line)
-        except json.JSONDecodeError as exc: sys.exit(f"malformed cargo JSON at line {line_no}: {exc.msg}")
+        except json.JSONDecodeError: sys.exit(2)
         if ev.get("reason") != "compiler-artifact": continue
         target = ev.get("target") or {}
         if target.get("name") == "rubin-node" and "bin" in (target.get("kind") or []) and ev.get("executable"): selected = ev["executable"]
-if selected is None: sys.exit("no rubin-node executable artifact in cargo JSON stream")
+if selected is None: sys.exit(3)
 print(selected)
 PY
-)" || return 1
-  [[ -x "${cargo_bin}" ]] || return 1
-  cp -- "${cargo_bin}" "${RUST_NODE_BIN}" || return 1
-  [[ -x "${RUST_NODE_BIN}" ]]
+  )" || { rc=$?; [[ ${rc} -eq 2 ]] && BUILD_REASON=rust_cargo_json_malformed || BUILD_REASON=rust_cargo_artifact_missing; return 1; }
+  [[ -x "${cargo_bin}" ]] || { BUILD_REASON=rust_cargo_artifact_missing; return 1; }
+  cp -- "${cargo_bin}" "${RUST_NODE_BIN}" || { BUILD_REASON=rust_binary_copy_failed; return 1; }
+  [[ -x "${RUST_NODE_BIN}" ]] || { BUILD_REASON=rust_binary_not_executable; return 1; }
 }
 write_outputs() {
   local verdict="$1" reason="${2:-}"
@@ -362,21 +373,25 @@ wait_peer_snapshot() {
       if python3 - "${tmp}" "${expected}" <<'PY' >/dev/null 2>&1
 import json, sys
 with open(sys.argv[1], encoding="utf-8") as f:
-    data = json.load(f)
+    try:
+        data = json.load(f)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        sys.exit(4)
 if not isinstance(data, dict):
-    sys.exit(4)
+    sys.exit(5)
 expected, peers, count = sys.argv[2], data.get("peers"), data.get("count")
 def ep(v): return isinstance(v, str) and v.count(":") == 1 and v.startswith("127.0.0.1:") and (p := v.rsplit(":", 1)[-1]).isdigit() and 1 <= len(p) <= 5 and 1 <= int(p) <= 65535
 shape = isinstance(count, int) and not isinstance(count, bool) and isinstance(peers, list) and count == len(peers) and all(isinstance(p, dict) and ep(p.get("addr")) and isinstance(p.get("handshake_complete"), bool) for p in peers) and len({p.get("addr") for p in peers}) == len(peers)
-has_expected = isinstance(peers, list) and any(isinstance(p, dict) and p.get("addr") == expected and p.get("handshake_complete") is True for p in peers)
-sys.exit(0 if shape and has_expected and count == 1 else 3 if shape and has_expected else 4 if not shape else 1)
+has_expected_complete = isinstance(peers, list) and any(isinstance(p, dict) and p.get("addr") == expected and p.get("handshake_complete") is True for p in peers)
+has_expected_incomplete = isinstance(peers, list) and any(isinstance(p, dict) and p.get("addr") == expected and p.get("handshake_complete") is False for p in peers)
+sys.exit(0 if shape and has_expected_complete and count == 1 else 3 if shape and has_expected_complete else 5 if not shape else 6 if has_expected_incomplete else 7)
 PY
       then mv -- "${tmp}" "${out}" || { PEER_SNAPSHOT_REASON=peer_snapshot_artifact_write_failed; rm -f -- "${tmp}" "${tmp}.err"; return 1; }; return 0
-      else rc=$?; [[ ${rc} -eq 3 ]] && PEER_SNAPSHOT_REASON=unexpected_peer_snapshot_peer; [[ ${rc} -eq 4 ]] && PEER_SNAPSHOT_REASON=peer_snapshot_malformed_json; fi
-    else PEER_SNAPSHOT_REASON=peer_snapshot_rpc_failed; fi
+      else rc=$?; [[ ${rc} -eq 3 ]] && PEER_SNAPSHOT_REASON=unexpected_peer_snapshot_peer; [[ ${rc} -eq 4 ]] && PEER_SNAPSHOT_REASON=peer_snapshot_malformed_json; [[ ${rc} -eq 5 ]] && PEER_SNAPSHOT_REASON=peer_snapshot_invalid_shape; [[ ${rc} -eq 6 ]] && PEER_SNAPSHOT_REASON=peer_snapshot_handshake_incomplete; [[ ${rc} -eq 7 ]] && PEER_SNAPSHOT_REASON=peer_snapshot_expected_peer_absent; fi
+    else rc=$?; [[ ${rc} -eq 23 ]] && PEER_SNAPSHOT_REASON=peer_snapshot_malformed_json || PEER_SNAPSHOT_REASON=peer_snapshot_rpc_failed; fi
     sleep 1
   done
-  if [[ "${PEER_SNAPSHOT_REASON:-}" == peer_snapshot_rpc_failed || -s "${tmp}.err" ]]; then PEER_SNAPSHOT_REASON=peer_snapshot_rpc_failed; elif [[ "${PEER_SNAPSHOT_REASON:-}" == unexpected_peer_snapshot_peer || "${PEER_SNAPSHOT_REASON:-}" == peer_snapshot_malformed_json ]]; then :; elif [[ -s "${tmp}" ]] && ! python3 -m json.tool "${tmp}" >/dev/null 2>&1; then PEER_SNAPSHOT_REASON=peer_snapshot_malformed_json; else PEER_SNAPSHOT_REASON="${label}_peer_snapshot_missing_endpoint"; fi
+  if [[ "${PEER_SNAPSHOT_REASON:-}" == peer_snapshot_rpc_failed || -s "${tmp}.err" ]]; then PEER_SNAPSHOT_REASON=peer_snapshot_rpc_failed; elif [[ "${PEER_SNAPSHOT_REASON:-}" == unexpected_peer_snapshot_peer || "${PEER_SNAPSHOT_REASON:-}" == peer_snapshot_malformed_json || "${PEER_SNAPSHOT_REASON:-}" == peer_snapshot_invalid_shape || "${PEER_SNAPSHOT_REASON:-}" == peer_snapshot_handshake_incomplete || "${PEER_SNAPSHOT_REASON:-}" == peer_snapshot_expected_peer_absent ]]; then :; elif [[ -s "${tmp}" ]] && ! python3 -m json.tool "${tmp}" >/dev/null 2>&1; then PEER_SNAPSHOT_REASON=peer_snapshot_malformed_json; else PEER_SNAPSHOT_REASON="${label}_peer_snapshot_missing_endpoint"; fi
   rm -f -- "${tmp}" "${tmp}.err"
   echo "timeout waiting for ${label} /peers completed handshake: ${PEER_SNAPSHOT_REASON}" >&2
   return 1
@@ -394,44 +409,50 @@ wait_rust_to_go_link() {
   done; finish_no_data "${missing}"
 }
 verify_process_identity() {
-  local label="$1" impl="$2" pid="$3" rpc_addr="$4" p2p_addr="$5" expected_comm="$6" comm
-  rubin_process_is_alive "${pid}" || { echo "${label} pid is not alive: ${pid}" >&2; return 1; }
-  comm="$(pid_comm "${pid}")" || { rc=$?; [[ ${rc} -eq 2 ]] && finish_no_data "ps_failed"; [[ ${rc} -eq 3 ]] && finish_no_data "ps_timeout"; [[ ${rc} -eq 4 ]] && finish_no_data "sed_failed"; echo "${label} process comm unavailable: ${pid}" >&2; return 1; }
-  [[ "${comm}" == "${expected_comm}" ]] || { echo "${label} process comm=${comm}, want ${expected_comm}" >&2; return 1; }
-  pid_listens_on "${pid}" "${rpc_addr}" || { rc=$?; [[ ${rc} -eq 2 ]] && finish_no_data "lsof_failed"; [[ ${rc} -eq 3 ]] && finish_no_data "lsof_timeout"; echo "${label} rpc endpoint is not process-backed: ${rpc_addr}" >&2; return 1; }
-  pid_listens_on "${pid}" "${p2p_addr}" || { rc=$?; [[ ${rc} -eq 2 ]] && finish_no_data "lsof_failed"; [[ ${rc} -eq 3 ]] && finish_no_data "lsof_timeout"; echo "${label} p2p endpoint is not process-backed: ${p2p_addr}" >&2; return 1; }
+  local label="$1" impl="$2" pid="$3" rpc_addr="$4" p2p_addr="$5" expected_comm="$6" reason_prefix="$7" comm rc
+  PROCESS_IDENTITY_REASON=""
+  rubin_process_is_alive "${pid}" || { PROCESS_IDENTITY_REASON="${reason_prefix}_process_not_alive"; echo "${label} pid is not alive: ${pid}" >&2; return 1; }
+  comm="$(pid_comm "${pid}")" || { rc=$?; case "${rc}" in 2) PROCESS_IDENTITY_REASON="${reason_prefix}_ps_failed" ;; 3) PROCESS_IDENTITY_REASON="${reason_prefix}_ps_timeout" ;; 4) PROCESS_IDENTITY_REASON="${reason_prefix}_sed_failed" ;; *) PROCESS_IDENTITY_REASON="${reason_prefix}_comm_unavailable" ;; esac; echo "${label} process comm unavailable: ${pid}" >&2; return 1; }
+  [[ "${comm}" == "${expected_comm}" ]] || { PROCESS_IDENTITY_REASON="${reason_prefix}_comm_mismatch"; echo "${label} process comm=${comm}, want ${expected_comm}" >&2; return 1; }
+  pid_listens_on "${pid}" "${rpc_addr}" || { rc=$?; case "${rc}" in 2) PROCESS_IDENTITY_REASON="${reason_prefix}_lsof_failed" ;; 3) PROCESS_IDENTITY_REASON="${reason_prefix}_lsof_timeout" ;; *) PROCESS_IDENTITY_REASON="${reason_prefix}_rpc_endpoint_not_process_backed" ;; esac; echo "${label} rpc endpoint is not process-backed: ${rpc_addr}" >&2; return 1; }
+  pid_listens_on "${pid}" "${p2p_addr}" || { rc=$?; case "${rc}" in 2) PROCESS_IDENTITY_REASON="${reason_prefix}_lsof_failed" ;; 3) PROCESS_IDENTITY_REASON="${reason_prefix}_lsof_timeout" ;; *) PROCESS_IDENTITY_REASON="${reason_prefix}_p2p_endpoint_not_process_backed" ;; esac; echo "${label} p2p endpoint is not process-backed: ${p2p_addr}" >&2; return 1; }
   [[ "${impl}" == "go" ]] && { GO_COMM="${comm}"; GO_PROCESS_ALIVE=true; GO_RPC_PROCESS_BACKED=true; GO_P2P_PROCESS_BACKED=true; return 0; }
   [[ "${impl}" == "rust" ]] && { RUST_COMM="${comm}"; RUST_PROCESS_ALIVE=true; RUST_RPC_PROCESS_BACKED=true; RUST_P2P_PROCESS_BACKED=true; return 0; }
   return 1
 }
 start_rust_node() {
   local -a argv=("${RUST_NODE_BIN}" --network devnet --datadir "${RUST_DIR}" --bind 127.0.0.1:0 --rpc-bind 127.0.0.1:0 --peer "${GO_P2P_ADDR}")
+  START_REASON=""
   RUST_CMD="$(argv_cmd "${argv[@]}")"; RUST_ARGV_JSON="$(argv_json "${argv[@]}")"
-  rubin_process_start "${RUST_LOG}" "${argv[@]}" || return 1; RUST_PID="${RUBIN_PROCESS_LAST_PID}"
-  rubin_process_wait_for_log "${RUST_LOG}" "p2p: listening=" 60 "${RUST_PID}" || return 1; rubin_process_wait_for_log "${RUST_LOG}" "rpc: listening=" 60 "${RUST_PID}" || return 1
-  RUST_P2P_ADDR="$(extract_log_addr "${RUST_LOG}" "p2p: listening=")" || return 1; RUST_RPC_ADDR="$(rubin_process_extract_rpc_addr "${RUST_LOG}")" || return 1
-  rubin_process_wait_for_rpc_ready "${RUST_RPC_ADDR}" 30 || return 1; RUST_STARTED_AT_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  rubin_process_start "${RUST_LOG}" "${argv[@]}" || { START_REASON=rust_launch_failed; return 1; }; RUST_PID="${RUBIN_PROCESS_LAST_PID}"
+  rubin_process_wait_for_log "${RUST_LOG}" "p2p: listening=" 60 "${RUST_PID}" || { START_REASON=rust_p2p_log_wait_failed; return 1; }
+  rubin_process_wait_for_log "${RUST_LOG}" "rpc: listening=" 60 "${RUST_PID}" || { START_REASON=rust_rpc_log_wait_failed; return 1; }
+  RUST_P2P_ADDR="$(extract_log_addr "${RUST_LOG}" "p2p: listening=")" || { START_REASON=rust_p2p_addr_extract_failed; return 1; }; loopback_endpoint "${RUST_P2P_ADDR}" || finish_no_data "rust_p2p_addr_malformed"
+  RUST_RPC_ADDR="$(rubin_process_extract_rpc_addr "${RUST_LOG}")" || { START_REASON=rust_rpc_addr_extract_failed; return 1; }; loopback_endpoint "${RUST_RPC_ADDR}" || finish_no_data "rust_rpc_addr_malformed"
+  rubin_process_wait_for_rpc_ready "${RUST_RPC_ADDR}" 30 || { START_REASON=rust_rpc_ready_timeout; return 1; }; RUST_STARTED_AT_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 }
 start_go_node() {
   local -a argv=("${GO_NODE_BIN}" --network devnet --datadir "${GO_DIR}" --bind 127.0.0.1:0 --rpc-bind 127.0.0.1:0)
+  START_REASON=""
   GO_CMD="$(argv_cmd "${argv[@]}")"; GO_ARGV_JSON="$(argv_json "${argv[@]}")"
-  rubin_process_start "${GO_LOG}" "${argv[@]}" || return 1; GO_PID="${RUBIN_PROCESS_LAST_PID}"
-  rubin_process_wait_for_log "${GO_LOG}" "rpc: listening=" 60 "${GO_PID}" || return 1; GO_RPC_ADDR="$(rubin_process_extract_rpc_addr "${GO_LOG}")" || return 1
-  GO_P2P_ADDR="$(p2p_addr_for_pid "${GO_PID}" "${GO_RPC_ADDR}" 30)" || { rc=$?; [[ ${rc} -eq 42 ]] && finish_no_data "lsof_failed"; [[ ${rc} -eq 43 ]] && finish_no_data "lsof_timeout"; return 1; }
-  rubin_process_wait_for_rpc_ready "${GO_RPC_ADDR}" 30 || return 1; GO_STARTED_AT_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  rubin_process_start "${GO_LOG}" "${argv[@]}" || { START_REASON=go_launch_failed; return 1; }; GO_PID="${RUBIN_PROCESS_LAST_PID}"
+  rubin_process_wait_for_log "${GO_LOG}" "rpc: listening=" 60 "${GO_PID}" || { START_REASON=go_rpc_log_wait_failed; return 1; }
+  GO_RPC_ADDR="$(rubin_process_extract_rpc_addr "${GO_LOG}")" || { START_REASON=go_rpc_addr_extract_failed; return 1; }; loopback_endpoint "${GO_RPC_ADDR}" || finish_no_data "go_rpc_addr_malformed"
+  GO_P2P_ADDR="$(p2p_addr_for_pid "${GO_PID}" "${GO_RPC_ADDR}" 30)" || { rc=$?; [[ ${rc} -eq 42 ]] && finish_no_data "lsof_failed"; [[ ${rc} -eq 43 ]] && finish_no_data "lsof_timeout"; [[ ${rc} -eq 44 ]] && finish_no_data "go_p2p_addr_ambiguous"; [[ ${rc} -eq 45 ]] && finish_no_data "go_p2p_addr_timeout"; return 1; }; loopback_endpoint "${GO_P2P_ADDR}" || finish_no_data "go_p2p_addr_malformed"
+  rubin_process_wait_for_rpc_ready "${GO_RPC_ADDR}" 30 || { START_REASON=go_rpc_ready_timeout; return 1; }; GO_STARTED_AT_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 }
-for tool in lsof perl sed sort; do command -v "${tool}" >/dev/null 2>&1 || finish_no_data "${tool}_unavailable"; done
-build_go_node || finish_no_data "go_build_failed"
-build_rust_node || finish_no_data "rust_build_failed"
-start_go_node || finish_no_data "go_process_not_ready"
-verify_process_identity node-go go "${GO_PID}" "${GO_RPC_ADDR}" "${GO_P2P_ADDR}" rubin-node-go || finish_no_data "go_process_identity_unverified"
-start_rust_node || finish_no_data "rust_process_not_ready"
-verify_process_identity node-rust rust "${RUST_PID}" "${RUST_RPC_ADDR}" "${RUST_P2P_ADDR}" rubin-node-rust || finish_no_data "rust_process_identity_unverified"
+for tool in lsof perl ps sed sort; do command -v "${tool}" >/dev/null 2>&1 || finish_no_data "${tool}_unavailable"; done
+build_go_node || finish_no_data "${BUILD_REASON:-go_build_failed}"
+build_rust_node || finish_no_data "${BUILD_REASON:-rust_build_failed}"
+start_go_node || finish_no_data "${START_REASON:-go_process_not_ready}"
+verify_process_identity node-go go "${GO_PID}" "${GO_RPC_ADDR}" "${GO_P2P_ADDR}" rubin-node-go go_process_identity || finish_no_data "${PROCESS_IDENTITY_REASON:-go_process_identity_unverified}"
+start_rust_node || finish_no_data "${START_REASON:-rust_process_not_ready}"
+verify_process_identity node-rust rust "${RUST_PID}" "${RUST_RPC_ADDR}" "${RUST_P2P_ADDR}" rubin-node-rust rust_process_identity || finish_no_data "${PROCESS_IDENTITY_REASON:-rust_process_identity_unverified}"
 wait_peer_snapshot node-rust "${RUST_RPC_ADDR}" "${RUST_PEERS_JSON}" "${MESH_TIMEOUT}" "${GO_P2P_ADDR}" || finish_no_data "${PEER_SNAPSHOT_REASON:-rust_peer_snapshot_missing_go_endpoint}"
 wait_rust_to_go_link rust_to_go_tcp_link_missing rust_to_go_tcp_link_ambiguous
 wait_peer_snapshot node-go "${GO_RPC_ADDR}" "${GO_PEERS_JSON}" "${MESH_TIMEOUT}" "${RUST_TO_GO_LOCAL_ADDR}" || finish_no_data "${PEER_SNAPSHOT_REASON:-go_peer_snapshot_missing_rust_endpoint}"
-verify_process_identity node-go-final go "${GO_PID}" "${GO_RPC_ADDR}" "${GO_P2P_ADDR}" rubin-node-go || finish_no_data "go_final_process_identity_unverified"
-verify_process_identity node-rust-final rust "${RUST_PID}" "${RUST_RPC_ADDR}" "${RUST_P2P_ADDR}" rubin-node-rust || finish_no_data "rust_final_process_identity_unverified"
+verify_process_identity node-go-final go "${GO_PID}" "${GO_RPC_ADDR}" "${GO_P2P_ADDR}" rubin-node-go go_final_process_identity || finish_no_data "${PROCESS_IDENTITY_REASON:-go_final_process_identity_unverified}"
+verify_process_identity node-rust-final rust "${RUST_PID}" "${RUST_RPC_ADDR}" "${RUST_P2P_ADDR}" rubin-node-rust rust_final_process_identity || finish_no_data "${PROCESS_IDENTITY_REASON:-rust_final_process_identity_unverified}"
 FINAL_PROCESS_IDENTITY_RECHECKED=true
 wait_rust_to_go_link rust_final_to_go_tcp_link_missing rust_final_to_go_tcp_link_ambiguous
 FINAL_RUST_OUTBOUND_LINK_RECHECKED=true
@@ -440,9 +461,11 @@ wait_peer_snapshot node-go-final "${GO_RPC_ADDR}" "${GO_PEERS_JSON}" "${MESH_TIM
 FINAL_PEER_SNAPSHOTS_RECHECKED=true
 PASS_REPORT_JSON="$(mktemp "/tmp/mixed-client-mesh-pass.XXXXXX")" || finish_no_data "pass_report_temp_failed"; FINAL_REPORT_JSON="${REPORT_JSON}"; REPORT_JSON="${PASS_REPORT_JSON}"
 write_outputs "PASS" || { REPORT_JSON="${FINAL_REPORT_JSON}"; finish_no_data "pass_report_write_failed"; }; REPORT_JSON="${FINAL_REPORT_JSON}"
-if run_validator "${LEGACY_SCHEMA_MARKER_JSON}" >&2 && check_report "${PASS_REPORT_JSON}" live >&2; then
-  mv -- "${PASS_REPORT_JSON}" "${REPORT_JSON}" || finish_no_data "pass_report_publish_failed"
-else
-  rm -f -- "${PASS_REPORT_JSON}"; finish_no_data "pass_report_validation_failed"
+if ! run_validator "${LEGACY_SCHEMA_MARKER_JSON}" >&2; then
+  rm -f -- "${PASS_REPORT_JSON}"; finish_no_data "legacy_schema_marker_validation_failed"
 fi
+if ! check_err="$(check_report "${PASS_REPORT_JSON}" live 2>&1)"; then
+  rm -f -- "${PASS_REPORT_JSON}"; finish_no_data "pass_report_live_validation_$(check_report_reason_token <<<"${check_err}")"
+fi
+mv -- "${PASS_REPORT_JSON}" "${REPORT_JSON}" || finish_no_data "pass_report_publish_failed"
 [[ "${RUBIN_PROCESS_KEEP_ARTIFACTS}" == "1" ]] && echo "PASS: mixed-client mesh connected go_pid=${GO_PID} rust_pid=${RUST_PID}; report=${REPORT_JSON} legacy_schema_marker=${LEGACY_SCHEMA_MARKER_JSON}" || echo "PASS: mixed-client mesh connected go_pid=${GO_PID} rust_pid=${RUST_PID}; set KEEP_TMP=1 to retain report"

--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -30,7 +30,7 @@ need_tool() { command -v -- "$1" >/dev/null 2>&1 || { echo "$1 is required for m
 check_report() {
   local report="${1:-}"
   [[ -n "${report}" ]] || { echo "FAIL: report path is required" >&2; return 1; }
-  python3 - "${report}" <<'PY'
+  python3 - "${report}" "${DEV_ENV}" "${VALIDATOR}" <<'PY'
 import datetime as dt, json, os, shlex, subprocess, sys, urllib.request
 from pathlib import Path
 path = Path(sys.argv[1])
@@ -107,6 +107,9 @@ try:
 except (OSError, json.JSONDecodeError) as exc:
     fail(f"legacy marker is not readable JSON: {exc}")
 req(isinstance(marker, dict) and marker.get("scenario") == "mixed_client_mesh_schema_marker" and marker.get("verdict") == "FAIL" and marker.get("evidence_type") == "mixed_client_process_soak", "legacy marker has wrong non-authoritative FAIL shape")
+try: validator = subprocess.run([sys.argv[2], "--", "python3", sys.argv[3], str(marker_path)], check=False, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=30)
+except (OSError, subprocess.TimeoutExpired) as exc: fail(f"legacy marker schema validation failed: {exc}")
+req(validator.returncode == 0, "legacy marker schema validation failed: " + ((validator.stderr or validator.stdout).strip().splitlines() or ["validator returned nonzero"])[0])
 nodes = data.get("nodes")
 req(isinstance(nodes, list) and len(nodes) == 2 and all(isinstance(n, dict) for n in nodes), "PASS report requires exactly two node records")
 expected = {"go": ("node-go", "rubin-node-go"), "rust": ("node-rust", "rubin-node-rust")}

--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -7,13 +7,13 @@ CHECK_REPORT="" CHECK_REPORT_MODE="" MESH_TIMEOUT="${MESH_TIMEOUT:-90}"
 usage() { echo "usage: $0 [--check-report PATH|--check-report-live PATH]" >&2; }
 while (($#)); do case "$1" in --check-report|--check-report-live) [[ $# -ge 2 ]] || { usage; exit 2; }; CHECK_REPORT_MODE=offline; [[ "$1" == "--check-report-live" ]] && CHECK_REPORT_MODE=live; CHECK_REPORT="$2"; shift 2 ;; -h|--help) usage; exit 0 ;; *) usage; exit 2 ;; esac; done
 need_tool() { command -v -- "$1" >/dev/null 2>&1 || { echo "$1 is required for mixed-client mesh evidence" >&2; exit 1; }; }
-validator_python() { local py; for py in "${RUBIN_VALIDATOR_PYTHON:-}" python3 /opt/homebrew/bin/python3 /usr/local/bin/python3 "${HOME}/.local/bin/python3"; do [[ -n "${py}" ]] || continue; command -v -- "${py}" >/dev/null 2>&1 || continue; "${py}" -c 'import jsonschema' >/dev/null 2>&1 && { printf '%s\n' "${py}"; return 0; }; done; return 1; }
+run_validator() { RUBIN_OPENSSL_SKIP_FIPS_GUARD=1 "${DEV_ENV}" -- python3 "${VALIDATOR}" "$@"; }
 check_report() { local report="${1:-}" mode="${2:-offline}"
   [[ -n "${report}" ]] || { echo "FAIL: report path is required" >&2; return 1; }
-  python3 - "${report}" "${VALIDATOR}" "${mode}" "$(validator_python || true)" <<'PY'
+  RUBIN_OPENSSL_SKIP_FIPS_GUARD=1 "${DEV_ENV}" -- python3 - "${report}" "${VALIDATOR}" "${mode}" <<'PY'
 import datetime as dt, json, os, socket, struct, subprocess, sys, time, urllib.error, urllib.request
 from pathlib import Path
-path = Path(sys.argv[1]); live = sys.argv[3] == "live"; validator_py = sys.argv[4]
+path = Path(sys.argv[1]); live = sys.argv[3] == "live"
 try: LIVE_TIMEOUT = max(1, min(600, int(os.environ.get("MESH_TIMEOUT", "10"))))
 except ValueError: LIVE_TIMEOUT = 10
 def fail(message: str) -> None: print(f"FAIL: {message}", file=sys.stderr); sys.exit(1)
@@ -118,8 +118,7 @@ try:
 except (OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
     fail(f"legacy marker is not readable JSON: {exc}")
 req(isinstance(marker, dict) and marker.get("scenario") == "mixed_client_mesh_schema_marker" and marker.get("verdict") == "FAIL" and marker.get("evidence_type") == "mixed_client_process_soak", "legacy marker has wrong non-authoritative FAIL shape")
-req(bool(validator_py), "validator_unavailable: python jsonschema unavailable")
-try: validator = subprocess.run([validator_py, sys.argv[2], str(marker_path)], check=False, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=30)
+try: validator = subprocess.run([sys.executable, sys.argv[2], str(marker_path)], check=False, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=30)
 except (OSError, subprocess.TimeoutExpired) as exc: fail(f"legacy marker schema validation failed: {exc}")
 req(validator.returncode == 0, "legacy marker schema validation failed: " + ((validator.stderr or validator.stdout).strip().splitlines() or ["validator returned nonzero"])[0])
 nodes = data.get("nodes")
@@ -184,7 +183,6 @@ GO_PEERS_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/go-peers.json"; RUST_PEERS_JSON="$
 GO_PID="" RUST_PID="" GO_RPC_ADDR="" RUST_RPC_ADDR="" GO_P2P_ADDR="" RUST_P2P_ADDR="" GO_STARTED_AT_UTC="" RUST_STARTED_AT_UTC="" GO_COMM="" RUST_COMM="" RUST_TO_GO_LOCAL_ADDR="" GO_CMD="" RUST_CMD="" GO_ARGV_JSON="" RUST_ARGV_JSON="" FINAL_PROCESS_IDENTITY_RECHECKED="" FINAL_RUST_OUTBOUND_LINK_RECHECKED="" FINAL_PEER_SNAPSHOTS_RECHECKED=""
 mkdir -p -- "${GO_DIR}" "${RUST_DIR}"
 run_fips_preflight_before_captured_dev_env() { [[ "${RUBIN_OPENSSL_FIPS_MODE:-off}" != "only" || "${RUBIN_OPENSSL_SKIP_FIPS_GUARD:-0}" == "1" ]] && return 0; echo "Running FIPS-only preflight before captured dev-env command streams" >&2; "${DEV_ENV}" -- "${REPO_ROOT}/scripts/crypto/openssl/fips-preflight.sh" >&2; }
-run_validator() { local py; py="$(validator_python)" || { echo "validator_unavailable: python jsonschema unavailable" >&2; return 1; }; "${py}" "${VALIDATOR}" "$@"; }
 bounded() { perl -e 'alarm shift @ARGV; exec @ARGV' 5 "$@"; }
 argv_cmd() { local out="" arg q; for arg; do printf -v q "%q" "$arg"; out+="${out:+ }${q}"; done; printf '%s\n' "${out}"; }; argv_json() { python3 -c 'import json,sys; print(json.dumps(sys.argv[1:]))' "$@"; }
 rpc_json() {

--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -67,29 +67,20 @@ if data.get("scenario") != "mixed_client_mesh":
 verdict = data.get("verdict")
 if verdict != "PASS":
     fail(f"report verdict is not PASS: {verdict!r}")
-if "failure_reason" in data:
-    fail("PASS report must not carry failure_reason")
-if "schema_marker" in data:
-    fail("PASS report must not embed legacy schema marker as report verdict")
+if "failure_reason" in data or "schema_marker" in data:
+    fail("PASS report must not carry failure/schema-marker verdict fields")
 legacy_schema = data.get("legacy_schema_compatibility")
-if not isinstance(legacy_schema, dict):
-    fail("PASS report missing legacy_schema_compatibility boundary")
-if legacy_schema.get("authoritative") is not False:
-    fail("legacy_schema_compatibility must be non-authoritative")
-if "verdict" in legacy_schema:
-    fail("legacy_schema_compatibility must not carry a verdict field")
-if not legacy_schema.get("marker_path"):
+if not isinstance(legacy_schema, dict) or legacy_schema.get("authoritative") is not False or "verdict" in legacy_schema or not legacy_schema.get("marker_path"):
     fail("legacy_schema_compatibility missing marker_path")
 
 nodes = data.get("nodes")
-if not isinstance(nodes, list) or len(nodes) != 2:
+if not isinstance(nodes, list) or len(nodes) != 2 or not all(isinstance(node, dict) for node in nodes):
     fail("PASS report requires exactly two node records")
-if not all(isinstance(node, dict) for node in nodes):
-    fail("node entry is not an object")
 impls = {node.get("implementation") for node in nodes}
 if impls != {"go", "rust"}:
     fail(f"PASS report requires one go and one rust node, got {sorted(str(impl) for impl in impls)}")
 expected_comm = {"go": "rubin-node-go", "rust": "rubin-node-rust"}
+nodes_by_impl = {node["implementation"]: node for node in nodes}
 for node in nodes:
     impl = node.get("implementation")
     name = node.get("name")
@@ -109,18 +100,26 @@ for node in nodes:
 connectivity = data.get("peer_connectivity")
 if not isinstance(connectivity, dict):
     fail("PASS report missing peer_connectivity object")
-for field in ("go_to_rust", "rust_to_go", "bidirectional_observed"):
-    if connectivity.get(field) is not True:
-        fail(f"peer_connectivity.{field} is not true")
-for field in ("go_peer_snapshot", "rust_peer_snapshot"):
+if any(connectivity.get(field) is not True for field in ("go_to_rust", "rust_to_go", "bidirectional_observed")):
+    fail("peer_connectivity booleans are not all true")
+links = connectivity.get("counterpart_links")
+if not isinstance(links, dict):
+    fail("PASS report missing counterpart_links")
+go_expected = links.get("go_peer_snapshot_expected_addr")
+rust_expected = links.get("rust_peer_snapshot_expected_addr")
+if rust_expected != nodes_by_impl["go"]["p2p_endpoint"] or links.get("rust_outbound_remote_addr") != rust_expected or links.get("rust_outbound_local_addr") != go_expected or links.get("rust_outbound_pid") != nodes_by_impl["rust"]["pid"]:
+    fail("peer evidence is not bound to expected counterpart endpoints")
+if not isinstance(go_expected, str) or go_expected in {rust_expected, nodes_by_impl["rust"]["p2p_endpoint"], nodes_by_impl["go"]["rpc_endpoint"], nodes_by_impl["rust"]["rpc_endpoint"]}:
+    fail("go peer evidence is not a rust outbound peer address")
+for field, expected_addr in (("go_peer_snapshot", go_expected), ("rust_peer_snapshot", rust_expected)):
     snapshot = connectivity.get(field)
     if not isinstance(snapshot, dict) or snapshot.get("count", 0) < 1:
         fail(f"{field} must show at least one peer")
     peers = snapshot.get("peers")
-    if not isinstance(peers, list) or not peers:
-        fail(f"{field}.peers must be non-empty")
-    if not any(peer.get("handshake_complete") is True for peer in peers if isinstance(peer, dict)):
-        fail(f"{field} lacks a completed handshake")
+    if not isinstance(peers, list) or not peers or snapshot.get("count") != len(peers):
+        fail(f"{field}.peers/count are internally inconsistent")
+    if not any(peer.get("addr") == expected_addr and peer.get("handshake_complete") is True for peer in peers if isinstance(peer, dict)):
+        fail(f"{field} lacks completed handshake for expected counterpart")
 
 print(f"PASS: mixed-client mesh report accepted {path}")
 PY
@@ -152,9 +151,8 @@ LEGACY_SCHEMA_MARKER_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/mixed-client-mesh-lega
 GO_PEERS_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/go-peers.json"
 RUST_PEERS_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/rust-peers.json"
 
-GO_PID="" RUST_PID="" GO_RPC_ADDR="" RUST_RPC_ADDR="" GO_P2P_ADDR="" RUST_P2P_ADDR=""
-GO_STARTED_AT_UTC="" RUST_STARTED_AT_UTC="" GO_COMM="" RUST_COMM=""
-GO_CMD="" RUST_CMD=""
+GO_PID="" RUST_PID="" GO_RPC_ADDR="" RUST_RPC_ADDR="" GO_P2P_ADDR="" RUST_P2P_ADDR="" GO_STARTED_AT_UTC="" RUST_STARTED_AT_UTC=""
+GO_COMM="" RUST_COMM="" RUST_TO_GO_LOCAL_ADDR="" GO_CMD="" RUST_CMD=""
 mkdir -p -- "${GO_DIR}" "${RUST_DIR}"
 
 run_fips_preflight_before_captured_dev_env() {
@@ -305,6 +303,7 @@ write_outputs() {
     GO_P2P_ADDR RUST_P2P_ADDR GO_STARTED_AT_UTC RUST_STARTED_AT_UTC GO_COMM RUST_COMM \
     GO_NODE_BIN RUST_NODE_BIN GO_CMD RUST_CMD GO_PEERS_JSON RUST_PEERS_JSON \
     GO_PROCESS_ALIVE RUST_PROCESS_ALIVE GO_RPC_PROCESS_BACKED RUST_RPC_PROCESS_BACKED GO_P2P_PROCESS_BACKED RUST_P2P_PROCESS_BACKED \
+    RUST_TO_GO_LOCAL_ADDR \
     RUBIN_PROCESS_ARTIFACT_ROOT
   python3 - <<'PY'
 import json
@@ -345,8 +344,7 @@ for impl, name, pid_key, rpc_key, p2p_key, started_key, comm_key, bin_key, cmd_k
     }
     nodes.append(node)
 
-go_snapshot = read_json(e["GO_PEERS_JSON"])
-rust_snapshot = read_json(e["RUST_PEERS_JSON"])
+go_snapshot, rust_snapshot = read_json(e["GO_PEERS_JSON"]), read_json(e["RUST_PEERS_JSON"])
 report = {
     "scenario": "mixed_client_mesh",
     "verdict": verdict,
@@ -356,6 +354,7 @@ report = {
         "go_to_rust": verdict == "PASS",
         "rust_to_go": verdict == "PASS",
         "bidirectional_observed": verdict == "PASS",
+        "counterpart_links": {"go_peer_snapshot_expected_addr": e.get("RUST_TO_GO_LOCAL_ADDR") or None, "rust_peer_snapshot_expected_addr": e.get("GO_P2P_ADDR") or None, "rust_outbound_local_addr": e.get("RUST_TO_GO_LOCAL_ADDR") or None, "rust_outbound_remote_addr": e.get("GO_P2P_ADDR") or None, "rust_outbound_pid": int(e["RUST_PID"]) if e.get("RUST_PID", "").isdigit() else None},
         "go_peer_snapshot": go_snapshot,
         "rust_peer_snapshot": rust_snapshot,
     },
@@ -402,19 +401,19 @@ finish_no_data() {
 }
 
 wait_peer_snapshot() {
-  local label="$1" addr="$2" out="$3" timeout="$4" deadline tmp
+  local label="$1" addr="$2" out="$3" timeout="$4" expected="$5" deadline tmp
   deadline=$((SECONDS + timeout))
   tmp="${out}.tmp"
   while (( SECONDS < deadline )); do
     if rpc_json GET "${addr}" /peers >"${tmp}" 2>/dev/null \
-      && python3 - "${tmp}" <<'PY' >/dev/null 2>&1
+      && python3 - "${tmp}" "${expected}" <<'PY' >/dev/null 2>&1
 import json
 import sys
 with open(sys.argv[1], encoding="utf-8") as f:
     data = json.load(f)
-peers = data.get("peers")
-ok = isinstance(peers, list) and data.get("count", 0) >= 1 and any(
-    isinstance(p, dict) and p.get("handshake_complete") is True for p in peers
+expected, peers = sys.argv[2], data.get("peers")
+ok = isinstance(peers, list) and data.get("count") == len(peers) and any(
+    isinstance(p, dict) and p.get("addr") == expected and p.get("handshake_complete") is True for p in peers
 )
 sys.exit(0 if ok else 1)
 PY
@@ -483,8 +482,10 @@ start_go_node || finish_no_data "go_process_not_ready"
 verify_process_identity node-go go "${GO_PID}" "${GO_RPC_ADDR}" "${GO_P2P_ADDR}" rubin-node-go || finish_no_data "go_process_identity_unverified"
 start_rust_node || finish_no_data "rust_process_not_ready"
 verify_process_identity node-rust rust "${RUST_PID}" "${RUST_RPC_ADDR}" "${RUST_P2P_ADDR}" rubin-node-rust || finish_no_data "rust_process_identity_unverified"
-wait_peer_snapshot node-go "${GO_RPC_ADDR}" "${GO_PEERS_JSON}" "${MESH_TIMEOUT}" || finish_no_data "go_peer_snapshot_missing_completed_handshake"
-wait_peer_snapshot node-rust "${RUST_RPC_ADDR}" "${RUST_PEERS_JSON}" "${MESH_TIMEOUT}" || finish_no_data "rust_peer_snapshot_missing_completed_handshake"
+wait_peer_snapshot node-rust "${RUST_RPC_ADDR}" "${RUST_PEERS_JSON}" "${MESH_TIMEOUT}" "${GO_P2P_ADDR}" || finish_no_data "rust_peer_snapshot_missing_go_endpoint"
+RUST_TO_GO_LOCAL_ADDR="$(lsof -nP -a -p "${RUST_PID}" -iTCP -sTCP:ESTABLISHED -Fn 2>/dev/null | REMOTE_ADDR="${GO_P2P_ADDR}" perl -ne 'BEGIN{$r=$ENV{REMOTE_ADDR}} chomp; s/^n// or next; print "$1\n" if /^(127[.]0[.]0[.]1:[0-9]+)->\Q$r\E$/' | sort -u)" || finish_no_data "rust_to_go_tcp_link_missing"
+[[ -n "${RUST_TO_GO_LOCAL_ADDR}" && "${RUST_TO_GO_LOCAL_ADDR}" != *$'\n'* ]] || finish_no_data "rust_to_go_tcp_link_ambiguous"
+wait_peer_snapshot node-go "${GO_RPC_ADDR}" "${GO_PEERS_JSON}" "${MESH_TIMEOUT}" "${RUST_TO_GO_LOCAL_ADDR}" || finish_no_data "go_peer_snapshot_missing_rust_endpoint"
 verify_process_identity node-go-final go "${GO_PID}" "${GO_RPC_ADDR}" "${GO_P2P_ADDR}" rubin-node-go || finish_no_data "go_final_process_identity_unverified"
 verify_process_identity node-rust-final rust "${RUST_PID}" "${RUST_RPC_ADDR}" "${RUST_P2P_ADDR}" rubin-node-rust || finish_no_data "rust_final_process_identity_unverified"
 

--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -14,9 +14,9 @@ check_report() { local report="${1:-}" mode="${2:-offline}"
 import datetime as dt, json, os, socket, struct, subprocess, sys, time, urllib.error, urllib.request
 from pathlib import Path
 path = Path(sys.argv[1]); live = sys.argv[3] == "live"
-try: LIVE_TIMEOUT = max(1, min(600, int(os.environ.get("MESH_TIMEOUT", "10"))))
-except ValueError: LIVE_TIMEOUT = 10
 def fail(message: str) -> None: print(f"FAIL: {message}", file=sys.stderr); sys.exit(1)
+try: LIVE_TIMEOUT = int(os.environ["MESH_TIMEOUT"])
+except (KeyError, ValueError): fail("MESH_TIMEOUT must be an integer in [1, 600]")
 def req(ok: bool, message: str) -> None:
     if not ok: fail(message)
 def eventually(fn, message: str) -> None:
@@ -85,13 +85,13 @@ def peers(addr: str) -> dict:
         fail(f"live peer snapshot malformed JSON for {addr}: {exc}")
     req(isinstance(data, dict), f"live peer snapshot malformed JSON for {addr}")
     return data
-def snapshot_norm(snapshot: object, expected_addr: str) -> list[tuple[str, bool]]:
+def snapshot_norm(snapshot: object, expected_addr: str, exact: bool = True) -> list[tuple[str, bool]]:
     count = snapshot.get("count") if isinstance(snapshot, dict) else None
     peers = snapshot.get("peers") if isinstance(snapshot, dict) else None
     req(isinstance(count, int) and not isinstance(count, bool) and isinstance(peers, list) and count == len(peers), "peer snapshot count/peers are invalid")
     norm = sorted((p.get("addr"), p.get("handshake_complete")) for p in peers if isinstance(p, dict) and ep(p.get("addr")) and isinstance(p.get("handshake_complete"), bool))
     req(len(norm) == len(peers) and len({addr for addr, _ in norm}) == len(norm), "peer snapshot entries are malformed or duplicated")
-    req(norm == [(expected_addr, True)], "peer snapshot has unexpected peer set")
+    if exact: req(norm == [(expected_addr, True)], "peer snapshot has unexpected peer set")
     return norm
 def ts(value: object) -> bool:
     if not isinstance(value, str) or len(value) != 20 or value[-1] != "Z": return False
@@ -166,13 +166,13 @@ for field, expected_addr in (("go_peer_snapshot", go_expected), ("rust_peer_snap
     stored = snapshot_norm(connectivity.get(field), expected_addr)
     if live:
         endpoint = nodes_by_impl["go" if field.startswith("go_") else "rust"]["rpc_endpoint"]
-        eventually(lambda endpoint=endpoint, stored=stored, expected_addr=expected_addr: (fresh := peers(endpoint)) is not None and stored == snapshot_norm(fresh, expected_addr), f"{field} differs from live exact peer set")
+        eventually(lambda endpoint=endpoint, stored=stored, expected_addr=expected_addr: (fresh := peers(endpoint)) is not None and stored == snapshot_norm(fresh, expected_addr, False), f"{field} differs from live exact peer set")
 print(f"PASS: mixed-client mesh report {'accepted' if live else 'structurally accepted'} {path}" + ("" if live else "; live proof not checked"))
 PY
 }
+[[ "${MESH_TIMEOUT}" =~ ^[0-9]{1,3}$ ]] || { echo "MESH_TIMEOUT must be an integer in [1, 600]" >&2; exit 2; }; MESH_TIMEOUT="$((10#${MESH_TIMEOUT}))"; (( MESH_TIMEOUT >= 1 && MESH_TIMEOUT <= 600 )) || { echo "MESH_TIMEOUT must be an integer in [1, 600]" >&2; exit 2; }; export MESH_TIMEOUT
 if [[ -n "${CHECK_REPORT_MODE}" ]]; then need_tool python3; check_report "${CHECK_REPORT}" "${CHECK_REPORT_MODE}"; exit 0; fi
 need_tool python3; [[ -x "${DEV_ENV}" ]] || { echo "dev-env wrapper missing or non-executable: ${DEV_ENV}" >&2; exit 1; }; [[ -r "${VALIDATOR}" ]] || { echo "validator unreadable: ${VALIDATOR}" >&2; exit 1; }
-[[ "${MESH_TIMEOUT}" =~ ^[0-9]{1,3}$ ]] || { echo "MESH_TIMEOUT must be an integer in [1, 600]" >&2; exit 2; }; MESH_TIMEOUT="$((10#${MESH_TIMEOUT}))"; (( MESH_TIMEOUT >= 1 && MESH_TIMEOUT <= 600 )) || { echo "MESH_TIMEOUT must be an integer in [1, 600]" >&2; exit 2; }
 # shellcheck source=scripts/devnet-process-common.sh disable=SC1091
 source "${HELPER}"
 rubin_process_init mixed-client-mesh

--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -443,7 +443,7 @@ FINAL_PEER_SNAPSHOTS_RECHECKED=true
 PASS_REPORT_JSON="${REPORT_JSON}.pass.tmp"; FINAL_REPORT_JSON="${REPORT_JSON}"; REPORT_JSON="${PASS_REPORT_JSON}"
 write_outputs "PASS" || { REPORT_JSON="${FINAL_REPORT_JSON}"; finish_no_data "pass_report_write_failed"; }; REPORT_JSON="${FINAL_REPORT_JSON}"
 if run_validator "${LEGACY_SCHEMA_MARKER_JSON}" >&2 && check_report "${PASS_REPORT_JSON}" live >&2; then
-  mv -- "${PASS_REPORT_JSON}" "${REPORT_JSON}"
+  mv -- "${PASS_REPORT_JSON}" "${REPORT_JSON}" || finish_no_data "pass_report_publish_failed"
 else
   rm -f -- "${PASS_REPORT_JSON}"; finish_no_data "pass_report_validation_failed"
 fi

--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -2,8 +2,7 @@
 set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DEV_ENV="${REPO_ROOT}/scripts/dev-env.sh"; GO_MODULE_ROOT="${REPO_ROOT}/clients/go"
-RUST_WORKSPACE_ROOT="${REPO_ROOT}/clients/rust"; HELPER="${REPO_ROOT}/scripts/devnet-process-common.sh"
-VALIDATOR="${REPO_ROOT}/scripts/devnet/validate_mixed_client_evidence.py"
+RUST_WORKSPACE_ROOT="${REPO_ROOT}/clients/rust"; HELPER="${REPO_ROOT}/scripts/devnet-process-common.sh"; VALIDATOR="${REPO_ROOT}/scripts/devnet/validate_mixed_client_evidence.py"
 CHECK_REPORT="" CHECK_REPORT_MODE="" MESH_TIMEOUT="${MESH_TIMEOUT:-90}"
 usage() { echo "usage: $0 [--check-report PATH|--check-report-live PATH]" >&2; }
 while (($#)); do case "$1" in --check-report|--check-report-live) [[ $# -ge 2 ]] || { usage; exit 2; }; CHECK_REPORT_MODE=offline; [[ "$1" == "--check-report-live" ]] && CHECK_REPORT_MODE=live; CHECK_REPORT="$2"; shift 2 ;; -h|--help) usage; exit 0 ;; *) usage; exit 2 ;; esac; done
@@ -84,12 +83,13 @@ def peers(addr: str) -> dict:
         fail(f"live peer snapshot malformed JSON for {addr}: {exc}")
     req(isinstance(data, dict), f"live peer snapshot malformed JSON for {addr}")
     return data
-def snapshot_norm(snapshot: object) -> list[tuple[str, bool]]:
+def snapshot_norm(snapshot: object, expected_addr: str) -> list[tuple[str, bool]]:
     count = snapshot.get("count") if isinstance(snapshot, dict) else None
     peers = snapshot.get("peers") if isinstance(snapshot, dict) else None
     req(isinstance(count, int) and not isinstance(count, bool) and isinstance(peers, list) and count == len(peers), "peer snapshot count/peers are invalid")
     norm = sorted((p.get("addr"), p.get("handshake_complete")) for p in peers if isinstance(p, dict) and ep(p.get("addr")) and isinstance(p.get("handshake_complete"), bool))
     req(len(norm) == len(peers) and len({addr for addr, _ in norm}) == len(norm), "peer snapshot entries are malformed or duplicated")
+    req(norm == [(expected_addr, True)], "peer snapshot has unexpected peer set")
     return norm
 def ts(value: object) -> bool:
     if not isinstance(value, str) or len(value) != 20 or value[-1] != "Z": return False
@@ -117,7 +117,7 @@ try:
 except (OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
     fail(f"legacy marker is not readable JSON: {exc}")
 req(isinstance(marker, dict) and marker.get("scenario") == "mixed_client_mesh_schema_marker" and marker.get("verdict") == "FAIL" and marker.get("evidence_type") == "mixed_client_process_soak", "legacy marker has wrong non-authoritative FAIL shape")
-try: validator = subprocess.run([sys.argv[2], "--", "python3", sys.argv[3], str(marker_path)], check=False, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=30)
+try: validator = subprocess.run(["python3", sys.argv[3], str(marker_path)], check=False, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=30)
 except (OSError, subprocess.TimeoutExpired) as exc: fail(f"legacy marker schema validation failed: {exc}")
 req(validator.returncode == 0, "legacy marker schema validation failed: " + ((validator.stderr or validator.stdout).strip().splitlines() or ["validator returned nonzero"])[0])
 nodes = data.get("nodes")
@@ -161,11 +161,10 @@ final = data.get("final_verification")
 req(isinstance(final, dict) and all(final.get(f) is True for f in ("producer_side", "process_identity_rechecked", "rust_outbound_link_rechecked", "peer_snapshots_rechecked")), "PASS report missing producer-side final verification")
 req(final.get("rust_outbound_pid") == nodes_by_impl["rust"]["pid"] and final.get("rust_outbound_local_addr") == go_expected and final.get("rust_outbound_remote_addr") == rust_expected, "final verification is not bound to peer evidence")
 for field, expected_addr in (("go_peer_snapshot", go_expected), ("rust_peer_snapshot", rust_expected)):
-    stored = snapshot_norm(connectivity.get(field))
-    req((expected_addr, True) in stored, f"{field} missing expected completed peer")
+    stored = snapshot_norm(connectivity.get(field), expected_addr)
     if live:
         endpoint = nodes_by_impl["go" if field.startswith("go_") else "rust"]["rpc_endpoint"]
-        eventually(lambda endpoint=endpoint, stored=stored: (fresh := peers(endpoint)) is not None and stored == snapshot_norm(fresh), f"{field} differs from live exact peer set")
+        eventually(lambda endpoint=endpoint, stored=stored, expected_addr=expected_addr: (fresh := peers(endpoint)) is not None and stored == snapshot_norm(fresh, expected_addr), f"{field} differs from live exact peer set")
 if not live: fail("offline check cannot prove PASS; use --check-report-live")
 print(f"PASS: mixed-client mesh report accepted {path}")
 PY
@@ -184,7 +183,7 @@ GO_PEERS_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/go-peers.json"; RUST_PEERS_JSON="$
 GO_PID="" RUST_PID="" GO_RPC_ADDR="" RUST_RPC_ADDR="" GO_P2P_ADDR="" RUST_P2P_ADDR="" GO_STARTED_AT_UTC="" RUST_STARTED_AT_UTC="" GO_COMM="" RUST_COMM="" RUST_TO_GO_LOCAL_ADDR="" GO_CMD="" RUST_CMD="" GO_ARGV_JSON="" RUST_ARGV_JSON="" FINAL_PROCESS_IDENTITY_RECHECKED="" FINAL_RUST_OUTBOUND_LINK_RECHECKED="" FINAL_PEER_SNAPSHOTS_RECHECKED=""
 mkdir -p -- "${GO_DIR}" "${RUST_DIR}"
 run_fips_preflight_before_captured_dev_env() { [[ "${RUBIN_OPENSSL_FIPS_MODE:-off}" != "only" || "${RUBIN_OPENSSL_SKIP_FIPS_GUARD:-0}" == "1" ]] && return 0; echo "Running FIPS-only preflight before captured dev-env command streams" >&2; "${DEV_ENV}" -- "${REPO_ROOT}/scripts/crypto/openssl/fips-preflight.sh" >&2; }
-run_validator() { RUBIN_OPENSSL_SKIP_FIPS_GUARD=1 "${DEV_ENV}" -- python3 "${VALIDATOR}" "$@"; }
+run_validator() { python3 "${VALIDATOR}" "$@"; }
 bounded() { perl -e 'alarm shift @ARGV; exec @ARGV' 5 "$@"; }
 argv_cmd() { local out="" arg q; for arg; do printf -v q "%q" "$arg"; out+="${out:+ }${q}"; done; printf '%s\n' "${out}"; }; argv_json() { python3 -c 'import json,sys; print(json.dumps(sys.argv[1:]))' "$@"; }
 rpc_json() {
@@ -362,23 +361,24 @@ wait_peer_snapshot() {
   deadline=$((SECONDS + timeout)); PEER_SNAPSHOT_REASON=""
   tmp="${out}.tmp"
   while (( SECONDS < deadline )); do
-    if { rpc_json GET "${addr}" /peers >"${tmp}" 2>"${tmp}.err" && { PEER_SNAPSHOT_REASON=""; true; } || { PEER_SNAPSHOT_REASON=peer_snapshot_rpc_failed; false; }; } \
-      && python3 - "${tmp}" "${expected}" <<'PY' >/dev/null 2>&1
+    if rpc_json GET "${addr}" /peers >"${tmp}" 2>"${tmp}.err"; then
+      PEER_SNAPSHOT_REASON=""
+      if python3 - "${tmp}" "${expected}" <<'PY' >/dev/null 2>&1
 import json, sys
 with open(sys.argv[1], encoding="utf-8") as f:
     data = json.load(f)
 expected, peers, count = sys.argv[2], data.get("peers"), data.get("count")
 def ep(v): return isinstance(v, str) and v.count(":") == 1 and v.startswith("127.0.0.1:") and (p := v.rsplit(":", 1)[-1]).isdigit() and 1 <= len(p) <= 5 and 1 <= int(p) <= 65535
-ok = isinstance(count, int) and not isinstance(count, bool) and isinstance(peers, list) and count == len(peers) and all(isinstance(p, dict) and ep(p.get("addr")) and isinstance(p.get("handshake_complete"), bool) for p in peers) and len({p.get("addr") for p in peers}) == len(peers) and any(p.get("addr") == expected and p.get("handshake_complete") is True for p in peers)
-sys.exit(0 if ok else 1)
+shape = isinstance(count, int) and not isinstance(count, bool) and isinstance(peers, list) and count == len(peers) and all(isinstance(p, dict) and ep(p.get("addr")) and isinstance(p.get("handshake_complete"), bool) for p in peers) and len({p.get("addr") for p in peers}) == len(peers)
+has_expected = isinstance(peers, list) and any(isinstance(p, dict) and p.get("addr") == expected and p.get("handshake_complete") is True for p in peers)
+sys.exit(0 if shape and has_expected and count == 1 else 3 if shape and has_expected else 4 if not shape else 1)
 PY
-    then
-      mv -- "${tmp}" "${out}" || { PEER_SNAPSHOT_REASON=peer_snapshot_artifact_write_failed; rm -f -- "${tmp}" "${tmp}.err"; return 1; }
-      return 0
-    fi
+      then mv -- "${tmp}" "${out}" || { PEER_SNAPSHOT_REASON=peer_snapshot_artifact_write_failed; rm -f -- "${tmp}" "${tmp}.err"; return 1; }; return 0
+      else rc=$?; [[ ${rc} -eq 3 ]] && PEER_SNAPSHOT_REASON=unexpected_peer_snapshot_peer; [[ ${rc} -eq 4 ]] && PEER_SNAPSHOT_REASON=peer_snapshot_malformed_json; fi
+    else PEER_SNAPSHOT_REASON=peer_snapshot_rpc_failed; fi
     sleep 1
   done
-  if [[ "${PEER_SNAPSHOT_REASON:-}" == peer_snapshot_rpc_failed || -s "${tmp}.err" ]]; then PEER_SNAPSHOT_REASON=peer_snapshot_rpc_failed; elif [[ -s "${tmp}" ]] && ! python3 -m json.tool "${tmp}" >/dev/null 2>&1; then PEER_SNAPSHOT_REASON=peer_snapshot_malformed_json; else PEER_SNAPSHOT_REASON="${label}_peer_snapshot_missing_endpoint"; fi
+  if [[ "${PEER_SNAPSHOT_REASON:-}" == peer_snapshot_rpc_failed || -s "${tmp}.err" ]]; then PEER_SNAPSHOT_REASON=peer_snapshot_rpc_failed; elif [[ "${PEER_SNAPSHOT_REASON:-}" == unexpected_peer_snapshot_peer || "${PEER_SNAPSHOT_REASON:-}" == peer_snapshot_malformed_json ]]; then :; elif [[ -s "${tmp}" ]] && ! python3 -m json.tool "${tmp}" >/dev/null 2>&1; then PEER_SNAPSHOT_REASON=peer_snapshot_malformed_json; else PEER_SNAPSHOT_REASON="${label}_peer_snapshot_missing_endpoint"; fi
   rm -f -- "${tmp}" "${tmp}.err"
   echo "timeout waiting for ${label} /peers completed handshake: ${PEER_SNAPSHOT_REASON}" >&2
   return 1

--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -30,7 +30,7 @@ need_tool() { command -v -- "$1" >/dev/null 2>&1 || { echo "$1 is required for m
 check_report() { local report="${1:-}" mode="${2:-offline}"
   [[ -n "${report}" ]] || { echo "FAIL: report path is required" >&2; return 1; }
   python3 - "${report}" "${DEV_ENV}" "${VALIDATOR}" "${mode}" <<'PY'
-import datetime as dt, json, os, shlex, subprocess, sys, urllib.request
+import datetime as dt, json, os, subprocess, sys, urllib.request
 from pathlib import Path
 path = Path(sys.argv[1])
 live = sys.argv[4] == "live"
@@ -54,10 +54,6 @@ def ep(value: object) -> bool:
     host, sep, port = value.partition(":")
     return sep == ":" and host == "127.0.0.1" and ":" not in port and port.isascii() and port.isdigit() and 1 <= int(port) <= 65535
 def nonempty_str(value: object) -> bool: return isinstance(value, str) and bool(value.strip())
-def argv0(value: object) -> str:
-    if not nonempty_str(value): return ""
-    try: return shlex.split(value)[0]
-    except ValueError: return ""
 def ps_comm(pid: int) -> str: return os.path.basename(run(["ps", "-ww", "-p", str(pid), "-o", "comm="]))
 def lsof_lines(pid: int, state: str) -> list[str]:
     p = subprocess.run(["lsof", "-nP", "-a", "-p", str(pid), "-iTCP", f"-sTCP:{state}", "-Fn"], check=False, text=True, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, timeout=5)
@@ -118,12 +114,12 @@ for node in nodes:
     req(isinstance(impl, str) and impl in expected, f"node has invalid implementation: {impl!r}")
     expected_name, expected_bin = expected[impl]
     req(name == expected_name, f"{impl} node has invalid name: {name!r}")
-    command, binary, command_argv0 = node.get("command"), node.get("binary"), argv0(node.get("command"))
+    command, binary, command_argv = node.get("command"), node.get("binary"), node.get("command_argv")
     binary_path = checked_path(f"{name}.binary", binary).resolve()
     try: binary_path.relative_to(artifact_root)
     except ValueError: fail(f"{name} binary is outside artifact_root")
     req(node.get("process_comm") == expected_bin, f"{name} process_comm does not prove {impl} identity")
-    req(nonempty_str(command) and Path(command_argv0).is_absolute() and Path(command_argv0).resolve() == binary_path and binary_path.name == expected_bin and binary_path.is_file() and os.access(binary_path, os.X_OK), f"{name} command/binary is not bound to executable {expected_bin}")
+    req(nonempty_str(command) and isinstance(command_argv, list) and all(isinstance(arg, str) for arg in command_argv) and command_argv and Path(command_argv[0]).is_absolute() and Path(command_argv[0]).resolve() == binary_path and binary_path.name == expected_bin and binary_path.is_file() and os.access(binary_path, os.X_OK), f"{name} command/binary is not bound to executable {expected_bin}")
     req(ep(node.get("rpc_endpoint")) and ep(node.get("p2p_endpoint")) and ts(node.get("started_at")), f"{name} has malformed endpoint or timestamp")
     req(isinstance(node.get("pid"), int) and not isinstance(node.get("pid"), bool) and node["pid"] > 0, f"{name} pid is not a positive integer")
     if live: req(ps_comm(node["pid"]) == expected_bin, f"{name} live process identity does not match report"); req(owns_listen(node["pid"], node["rpc_endpoint"]) and owns_listen(node["pid"], node["p2p_endpoint"]), f"{name} live listeners are not pid-owned")
@@ -133,7 +129,7 @@ impls = {n["implementation"] for n in nodes}
 req(impls == {"go", "rust"}, f"PASS report requires one go and one rust node, got {sorted(impls)}")
 nodes_by_impl = {node["implementation"]: node for node in nodes}
 req(nodes_by_impl["go"]["pid"] != nodes_by_impl["rust"]["pid"], "go/rust process evidence uses the same pid")
-req(nodes_by_impl["go"]["binary"] != nodes_by_impl["rust"]["binary"] and nodes_by_impl["go"]["command"] != nodes_by_impl["rust"]["command"], "go/rust process evidence is not implementation-distinct")
+req(nodes_by_impl["go"]["binary"] != nodes_by_impl["rust"]["binary"] and nodes_by_impl["go"]["command"] != nodes_by_impl["rust"]["command"] and nodes_by_impl["go"].get("command_argv") != nodes_by_impl["rust"].get("command_argv"), "go/rust process evidence is not implementation-distinct")
 connectivity = data.get("peer_connectivity")
 req(isinstance(connectivity, dict), "PASS report missing peer_connectivity object")
 req(all(connectivity.get(f) is True for f in ("go_to_rust", "rust_to_go", "bidirectional_observed")), "peer_connectivity booleans are not all true")
@@ -173,12 +169,12 @@ LEGACY_SCHEMA_MARKER_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/mixed-client-mesh-lega
 GO_PEERS_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/go-peers.json"
 RUST_PEERS_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/rust-peers.json"
 GO_PID="" RUST_PID="" GO_RPC_ADDR="" RUST_RPC_ADDR="" GO_P2P_ADDR="" RUST_P2P_ADDR="" GO_STARTED_AT_UTC="" RUST_STARTED_AT_UTC=""
-GO_COMM="" RUST_COMM="" RUST_TO_GO_LOCAL_ADDR="" GO_CMD="" RUST_CMD=""
+GO_COMM="" RUST_COMM="" RUST_TO_GO_LOCAL_ADDR="" GO_CMD="" RUST_CMD="" GO_ARGV_JSON="" RUST_ARGV_JSON=""
 FINAL_PROCESS_IDENTITY_RECHECKED="" FINAL_RUST_OUTBOUND_LINK_RECHECKED="" FINAL_PEER_SNAPSHOTS_RECHECKED=""
 mkdir -p -- "${GO_DIR}" "${RUST_DIR}"
 run_fips_preflight_before_captured_dev_env() { [[ "${RUBIN_OPENSSL_FIPS_MODE:-off}" != "only" || "${RUBIN_OPENSSL_SKIP_FIPS_GUARD:-0}" == "1" ]] && return 0; echo "Running FIPS-only preflight before captured dev-env command streams" >&2; "${DEV_ENV}" -- "${REPO_ROOT}/scripts/crypto/openssl/fips-preflight.sh" >&2; }
 run_validator() { RUBIN_OPENSSL_SKIP_FIPS_GUARD=1 "${DEV_ENV}" -- python3 "${VALIDATOR}" "$@"; }
-argv_cmd() { local out="" arg q; for arg; do printf -v q "%q" "$arg"; out+="${out:+ }${q}"; done; printf '%s\n' "${out}"; }
+argv_cmd() { local out="" arg q; for arg; do printf -v q "%q" "$arg"; out+="${out:+ }${q}"; done; printf '%s\n' "${out}"; }; argv_json() { python3 -c 'import json,sys; print(json.dumps(sys.argv[1:]))' "$@"; }
 rpc_json() {
   local method="$1" addr="$2" path="$3"
   python3 - "${method}" "${addr}" "${path}" <<'PY'
@@ -263,7 +259,7 @@ write_outputs() {
   local verdict="$1" reason="${2:-}"
   export REPORT_JSON LEGACY_SCHEMA_MARKER_JSON verdict reason GO_PID RUST_PID GO_RPC_ADDR RUST_RPC_ADDR \
     GO_P2P_ADDR RUST_P2P_ADDR GO_STARTED_AT_UTC RUST_STARTED_AT_UTC GO_COMM RUST_COMM \
-    GO_NODE_BIN RUST_NODE_BIN GO_CMD RUST_CMD GO_PEERS_JSON RUST_PEERS_JSON \
+    GO_NODE_BIN RUST_NODE_BIN GO_CMD RUST_CMD GO_ARGV_JSON RUST_ARGV_JSON GO_PEERS_JSON RUST_PEERS_JSON \
     GO_PROCESS_ALIVE RUST_PROCESS_ALIVE GO_RPC_PROCESS_BACKED RUST_RPC_PROCESS_BACKED GO_P2P_PROCESS_BACKED RUST_P2P_PROCESS_BACKED \
     RUST_TO_GO_LOCAL_ADDR FINAL_PROCESS_IDENTITY_RECHECKED FINAL_RUST_OUTBOUND_LINK_RECHECKED FINAL_PEER_SNAPSHOTS_RECHECKED \
     RUBIN_PROCESS_ARTIFACT_ROOT
@@ -279,9 +275,9 @@ def read_json(path: str) -> dict:
     except (OSError, json.JSONDecodeError):
         return {"count": 0, "peers": []}
 nodes = []
-for impl, name, pid_key, rpc_key, p2p_key, started_key, comm_key, bin_key, cmd_key in (
-    ("go", "node-go", "GO_PID", "GO_RPC_ADDR", "GO_P2P_ADDR", "GO_STARTED_AT_UTC", "GO_COMM", "GO_NODE_BIN", "GO_CMD"),
-    ("rust", "node-rust", "RUST_PID", "RUST_RPC_ADDR", "RUST_P2P_ADDR", "RUST_STARTED_AT_UTC", "RUST_COMM", "RUST_NODE_BIN", "RUST_CMD"),
+for impl, name, pid_key, rpc_key, p2p_key, started_key, comm_key, bin_key, cmd_key, argv_key in (
+    ("go", "node-go", "GO_PID", "GO_RPC_ADDR", "GO_P2P_ADDR", "GO_STARTED_AT_UTC", "GO_COMM", "GO_NODE_BIN", "GO_CMD", "GO_ARGV_JSON"),
+    ("rust", "node-rust", "RUST_PID", "RUST_RPC_ADDR", "RUST_P2P_ADDR", "RUST_STARTED_AT_UTC", "RUST_COMM", "RUST_NODE_BIN", "RUST_CMD", "RUST_ARGV_JSON"),
 ):
     pid_raw = (e.get(pid_key) or "").strip()
     prefix = impl.upper()
@@ -290,6 +286,7 @@ for impl, name, pid_key, rpc_key, p2p_key, started_key, comm_key, bin_key, cmd_k
         "implementation": impl,
         "pid": int(pid_raw) if pid_raw.isdigit() else None,
         "command": e.get(cmd_key) or "",
+        "command_argv": json.loads(e.get(argv_key) or "[]"),
         "binary": e.get(bin_key) or "",
         "rpc_endpoint": e.get(rpc_key) or None,
         "p2p_endpoint": e.get(p2p_key) or None,
@@ -398,7 +395,7 @@ verify_process_identity() {
 }
 start_rust_node() {
   local -a argv=("${RUST_NODE_BIN}" --network devnet --datadir "${RUST_DIR}" --bind 127.0.0.1:0 --rpc-bind 127.0.0.1:0 --peer "${GO_P2P_ADDR}")
-  RUST_CMD="$(argv_cmd "${argv[@]}")"
+  RUST_CMD="$(argv_cmd "${argv[@]}")"; RUST_ARGV_JSON="$(argv_json "${argv[@]}")"
   rubin_process_start "${RUST_LOG}" "${argv[@]}" || return 1
   RUST_PID="${RUBIN_PROCESS_LAST_PID}"
   rubin_process_wait_for_log "${RUST_LOG}" "p2p: listening=" 60 "${RUST_PID}" || return 1
@@ -410,7 +407,7 @@ start_rust_node() {
 }
 start_go_node() {
   local -a argv=("${GO_NODE_BIN}" --network devnet --datadir "${GO_DIR}" --bind 127.0.0.1:0 --rpc-bind 127.0.0.1:0)
-  GO_CMD="$(argv_cmd "${argv[@]}")"
+  GO_CMD="$(argv_cmd "${argv[@]}")"; GO_ARGV_JSON="$(argv_json "${argv[@]}")"
   rubin_process_start "${GO_LOG}" "${argv[@]}" || return 1
   GO_PID="${RUBIN_PROCESS_LAST_PID}"
   rubin_process_wait_for_log "${GO_LOG}" "rpc: listening=" 60 "${GO_PID}" || return 1

--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -73,6 +73,17 @@ if verdict != "PASS":
     sys.exit(0)
 if "failure_reason" in data:
     fail("PASS report must not carry failure_reason")
+if "schema_marker" in data:
+    fail("PASS report must not embed legacy schema marker as report verdict")
+legacy_schema = data.get("legacy_schema_compatibility")
+if not isinstance(legacy_schema, dict):
+    fail("PASS report missing legacy_schema_compatibility boundary")
+if legacy_schema.get("authoritative") is not False:
+    fail("legacy_schema_compatibility must be non-authoritative")
+if "verdict" in legacy_schema:
+    fail("legacy_schema_compatibility must not carry a verdict field")
+if not legacy_schema.get("marker_path"):
+    fail("legacy_schema_compatibility missing marker_path")
 
 nodes = data.get("nodes")
 if not isinstance(nodes, list) or len(nodes) != 2:
@@ -141,7 +152,7 @@ RUST_DIR="${RUBIN_PROCESS_ARTIFACT_ROOT}/node-rust"
 GO_LOG="node-go.log"
 RUST_LOG="node-rust.log"
 REPORT_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/mixed-client-mesh-report.json"
-EVIDENCE_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/mixed-client-mesh-schema-marker.json"
+LEGACY_SCHEMA_MARKER_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/mixed-client-mesh-legacy-schema-marker.json"
 GO_PEERS_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/go-peers.json"
 RUST_PEERS_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/rust-peers.json"
 
@@ -294,7 +305,7 @@ PY
 
 write_outputs() {
   local verdict="$1" reason="${2:-}"
-  export REPORT_JSON EVIDENCE_JSON verdict reason GO_PID RUST_PID GO_RPC_ADDR RUST_RPC_ADDR \
+  export REPORT_JSON LEGACY_SCHEMA_MARKER_JSON verdict reason GO_PID RUST_PID GO_RPC_ADDR RUST_RPC_ADDR \
     GO_P2P_ADDR RUST_P2P_ADDR GO_STARTED_AT_UTC RUST_STARTED_AT_UTC GO_COMM RUST_COMM \
     GO_NODE_BIN RUST_NODE_BIN GO_CMD RUST_CMD GO_PEERS_JSON RUST_PEERS_JSON \
     RUBIN_PROCESS_ARTIFACT_ROOT
@@ -350,9 +361,10 @@ report = {
         "go_peer_snapshot": go_snapshot,
         "rust_peer_snapshot": rust_snapshot,
     },
-    "schema_marker": {
-        "path": e["EVIDENCE_JSON"],
-        "verdict": "FAIL",
+    "legacy_schema_compatibility": {
+        "authoritative": False,
+        "marker_path": e["LEGACY_SCHEMA_MARKER_JSON"],
+        "purpose": "schema-valid legacy artifact only; not the mesh report verdict",
         "reason": "existing mixed_client_evidence_v1 PASS requires tx_path; RUB-21 mesh-only PASS lives in this report",
     },
 }
@@ -362,23 +374,23 @@ with open(e["REPORT_JSON"], "w", encoding="utf-8") as f:
     json.dump(report, f, indent=2, sort_keys=True)
     f.write("\n")
 
-marker_reason = reason if verdict != "PASS" and reason else (
+legacy_marker_reason = reason if verdict != "PASS" and reason else (
     "mixed-client mesh process/connectivity PASS is recorded in sibling report; "
     "existing schema v1 PASS requires tx_path proof owned by RUB-22/RUB-23"
 )
-schema_marker = {
+legacy_schema_marker = {
     "schema_version": "rubin-mixed-client-devnet-evidence-v1",
     "evidence_type": "mixed_client_process_soak",
     "scenario": "mixed_client_mesh_schema_marker",
     "verdict": "FAIL",
-    "failure_reason": marker_reason,
+    "failure_reason": legacy_marker_reason,
     "participants": [
         {"name": "node-go", "implementation": "go", **({"endpoint": e["GO_RPC_ADDR"], "started_at": e["GO_STARTED_AT_UTC"]} if e.get("GO_RPC_ADDR") and e.get("GO_STARTED_AT_UTC") else {})},
         {"name": "node-rust", "implementation": "rust", **({"endpoint": e["RUST_RPC_ADDR"], "started_at": e["RUST_STARTED_AT_UTC"]} if e.get("RUST_RPC_ADDR") and e.get("RUST_STARTED_AT_UTC") else {})},
     ],
 }
-with open(e["EVIDENCE_JSON"], "w", encoding="utf-8") as f:
-    json.dump(schema_marker, f, indent=2, sort_keys=True)
+with open(e["LEGACY_SCHEMA_MARKER_JSON"], "w", encoding="utf-8") as f:
+    json.dump(legacy_schema_marker, f, indent=2, sort_keys=True)
     f.write("\n")
 PY
 }
@@ -386,8 +398,8 @@ PY
 finish_no_data() {
   local reason="$1"
   write_outputs "NO_DATA" "${reason}"
-  run_validator "${EVIDENCE_JSON}" >&2
-  echo "NO_DATA: ${reason}; report=${REPORT_JSON} schema_marker=${EVIDENCE_JSON}" >&2
+  run_validator "${LEGACY_SCHEMA_MARKER_JSON}" >&2
+  echo "NO_DATA: ${reason}; report=${REPORT_JSON} legacy_schema_marker=${LEGACY_SCHEMA_MARKER_JSON}" >&2
   exit 1
 }
 
@@ -477,10 +489,10 @@ wait_peer_snapshot node-go "${GO_RPC_ADDR}" "${GO_PEERS_JSON}" "${MESH_TIMEOUT}"
 wait_peer_snapshot node-rust "${RUST_RPC_ADDR}" "${RUST_PEERS_JSON}" "${MESH_TIMEOUT}" || finish_no_data "rust_peer_snapshot_missing_completed_handshake"
 
 write_outputs "PASS"
-run_validator "${EVIDENCE_JSON}" >&2
+run_validator "${LEGACY_SCHEMA_MARKER_JSON}" >&2
 check_report "${REPORT_JSON}" >&2
 if [[ "${RUBIN_PROCESS_KEEP_ARTIFACTS}" == "1" ]]; then
-  echo "PASS: mixed-client mesh connected go_pid=${GO_PID} rust_pid=${RUST_PID}; report=${REPORT_JSON} schema_marker=${EVIDENCE_JSON}"
+  echo "PASS: mixed-client mesh connected go_pid=${GO_PID} rust_pid=${RUST_PID}; report=${REPORT_JSON} legacy_schema_marker=${LEGACY_SCHEMA_MARKER_JSON}"
 else
   echo "PASS: mixed-client mesh connected go_pid=${GO_PID} rust_pid=${RUST_PID}; set KEEP_TMP=1 to retain report"
 fi

--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -230,7 +230,7 @@ build_go_node() { echo "Building Go rubin-node binary" >&2; "${DEV_ENV}" -- go -
 build_rust_node() {
   local host_triple cargo_target_dir cargo_log cargo_bin
   echo "Building Rust rubin-node binary" >&2
-  run_fips_preflight_before_captured_dev_env
+  run_fips_preflight_before_captured_dev_env || return 1
   host_triple="$(RUBIN_OPENSSL_SKIP_FIPS_GUARD=1 "${DEV_ENV}" -- rustc -vV | awk '/^host:/ {print $2}')" || return 1
   [[ -n "${host_triple}" ]] || return 1
   cargo_target_dir="${RUBIN_PROCESS_ARTIFACT_ROOT}/cargo-target"

--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -122,34 +122,35 @@ for node in nodes:
     req(nonempty_str(command) and isinstance(command_argv, list) and all(isinstance(arg, str) for arg in command_argv) and command_argv and Path(command_argv[0]).is_absolute() and Path(command_argv[0]).resolve() == binary_path and binary_path.name == expected_bin and binary_path.is_file() and os.access(binary_path, os.X_OK), f"{name} command/binary is not bound to executable {expected_bin}")
     req(ep(node.get("rpc_endpoint")) and ep(node.get("p2p_endpoint")) and ts(node.get("started_at")), f"{name} has malformed endpoint or timestamp")
     req(isinstance(node.get("pid"), int) and not isinstance(node.get("pid"), bool) and node["pid"] > 0, f"{name} pid is not a positive integer")
-    if live: req(ps_comm(node["pid"]) == expected_bin, f"{name} live process identity does not match report"); req(owns_listen(node["pid"], node["rpc_endpoint"]) and owns_listen(node["pid"], node["p2p_endpoint"]), f"{name} live listeners are not pid-owned")
+    if live:
+        req(ps_comm(node["pid"]) == expected_bin, f"{name} live process identity does not match report")
+        req(owns_listen(node["pid"], node["rpc_endpoint"]) and owns_listen(node["pid"], node["p2p_endpoint"]), f"{name} live listeners are not pid-owned")
     for field in ("process_alive", "rpc_endpoint_process_backed", "p2p_endpoint_process_backed"):
         req(node.get(field) is True, f"{name} does not prove {field}")
-impls = {n["implementation"] for n in nodes}
-req(impls == {"go", "rust"}, f"PASS report requires one go and one rust node, got {sorted(impls)}")
+req((impls := {n["implementation"] for n in nodes}) == {"go", "rust"}, f"PASS report requires one go and one rust node, got {sorted(impls)}")
 nodes_by_impl = {node["implementation"]: node for node in nodes}
 req(nodes_by_impl["go"]["pid"] != nodes_by_impl["rust"]["pid"], "go/rust process evidence uses the same pid")
 req(nodes_by_impl["go"]["binary"] != nodes_by_impl["rust"]["binary"] and nodes_by_impl["go"]["command"] != nodes_by_impl["rust"]["command"] and nodes_by_impl["go"].get("command_argv") != nodes_by_impl["rust"].get("command_argv"), "go/rust process evidence is not implementation-distinct")
-endpoints = [nodes_by_impl[i][f] for i in ("go", "rust") for f in ("rpc_endpoint", "p2p_endpoint")]
-req(len(set(endpoints)) == 4, "node rpc/p2p endpoints are not pairwise distinct")
+req(len({nodes_by_impl[i][f] for i in ("go", "rust") for f in ("rpc_endpoint", "p2p_endpoint")}) == 4, "node rpc/p2p endpoints are not pairwise distinct")
 connectivity = data.get("peer_connectivity")
 req(isinstance(connectivity, dict), "PASS report missing peer_connectivity object")
 req(all(connectivity.get(f) is True for f in ("go_to_rust", "rust_to_go", "bidirectional_observed")), "peer_connectivity booleans are not all true")
-links = connectivity.get("counterpart_links")
-req(isinstance(links, dict), "PASS report missing counterpart_links")
-go_expected = links.get("go_peer_snapshot_expected_addr")
-rust_expected = links.get("rust_peer_snapshot_expected_addr")
+req(isinstance(links := connectivity.get("counterpart_links"), dict), "PASS report missing counterpart_links")
+go_expected, rust_expected = links.get("go_peer_snapshot_expected_addr"), links.get("rust_peer_snapshot_expected_addr")
 req(all(ep(links.get(f)) for f in ("go_peer_snapshot_expected_addr", "rust_peer_snapshot_expected_addr", "rust_outbound_local_addr", "rust_outbound_remote_addr")), "counterpart link endpoint is malformed")
 req(rust_expected == nodes_by_impl["go"]["p2p_endpoint"] and links.get("rust_outbound_remote_addr") == rust_expected and links.get("rust_outbound_local_addr") == go_expected and links.get("rust_outbound_pid") == nodes_by_impl["rust"]["pid"], "peer evidence is not bound to expected counterpart endpoints")
 req(isinstance(go_expected, str) and go_expected not in {rust_expected, nodes_by_impl["rust"]["p2p_endpoint"], nodes_by_impl["go"]["rpc_endpoint"], nodes_by_impl["rust"]["rpc_endpoint"]}, "go peer evidence is not a rust outbound peer address")
-if live: req(f"{go_expected}->{rust_expected}" in lsof_lines(nodes_by_impl["rust"]["pid"], "ESTABLISHED"), "rust outbound TCP link is not live and rust-owned")
+if live:
+    req(f"{go_expected}->{rust_expected}" in lsof_lines(nodes_by_impl["rust"]["pid"], "ESTABLISHED"), "rust outbound TCP link is not live and rust-owned")
 final = data.get("final_verification")
 req(isinstance(final, dict) and all(final.get(f) is True for f in ("producer_side", "process_identity_rechecked", "rust_outbound_link_rechecked", "peer_snapshots_rechecked")), "PASS report missing producer-side final verification")
 req(final.get("rust_outbound_pid") == nodes_by_impl["rust"]["pid"] and final.get("rust_outbound_local_addr") == go_expected and final.get("rust_outbound_remote_addr") == rust_expected, "final verification is not bound to peer evidence")
 for field, expected_addr in (("go_peer_snapshot", go_expected), ("rust_peer_snapshot", rust_expected)):
     stored = snapshot_norm(connectivity.get(field))
     req((expected_addr, True) in stored, f"{field} missing expected completed peer")
-    if live: fresh = snapshot_norm(peers(nodes_by_impl["go" if field.startswith("go_") else "rust"]["rpc_endpoint"])); req(stored == fresh, f"{field} differs from live exact peer set")
+    if live:
+        fresh = snapshot_norm(peers(nodes_by_impl["go" if field.startswith("go_") else "rust"]["rpc_endpoint"]))
+        req(stored == fresh, f"{field} differs from live exact peer set")
 print(f"PASS: mixed-client mesh report accepted {path}")
 PY
 }

--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -79,7 +79,7 @@ def snapshot_norm(snapshot: object) -> list[tuple[str, bool]]:
     peers = snapshot.get("peers") if isinstance(snapshot, dict) else None
     req(isinstance(count, int) and not isinstance(count, bool) and isinstance(peers, list) and count == len(peers), "peer snapshot count/peers are invalid")
     norm = sorted((p.get("addr"), p.get("handshake_complete")) for p in peers if isinstance(p, dict) and ep(p.get("addr")) and isinstance(p.get("handshake_complete"), bool))
-    req(len(norm) == len(peers) and len(set(norm)) == len(norm), "peer snapshot entries are malformed or duplicated")
+    req(len(norm) == len(peers) and len({addr for addr, _ in norm}) == len(norm), "peer snapshot entries are malformed or duplicated")
     return norm
 def ts(value: object) -> bool:
     if not isinstance(value, str) or len(value) != 20 or value[-1] != "Z": return False
@@ -361,7 +361,7 @@ with open(sys.argv[1], encoding="utf-8") as f:
     data = json.load(f)
 expected, peers, count = sys.argv[2], data.get("peers"), data.get("count")
 def ep(v): return isinstance(v, str) and v.count(":") == 1 and v.startswith("127.0.0.1:") and v.rsplit(":", 1)[-1].isdigit() and 1 <= int(v.rsplit(":", 1)[-1]) <= 65535
-ok = isinstance(count, int) and not isinstance(count, bool) and isinstance(peers, list) and count == len(peers) and all(isinstance(p, dict) and ep(p.get("addr")) and isinstance(p.get("handshake_complete"), bool) for p in peers) and any(p.get("addr") == expected and p.get("handshake_complete") is True for p in peers)
+ok = isinstance(count, int) and not isinstance(count, bool) and isinstance(peers, list) and count == len(peers) and all(isinstance(p, dict) and ep(p.get("addr")) and isinstance(p.get("handshake_complete"), bool) for p in peers) and len({p.get("addr") for p in peers}) == len(peers) and any(p.get("addr") == expected and p.get("handshake_complete") is True for p in peers)
 sys.exit(0 if ok else 1)
 PY
     then

--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -27,13 +27,13 @@ while (($#)); do
   esac
 done
 need_tool() { command -v -- "$1" >/dev/null 2>&1 || { echo "$1 is required for mixed-client mesh evidence" >&2; exit 1; }; }
-check_report() {
-  local report="${1:-}"
+check_report() { local report="${1:-}" mode="${2:-offline}"
   [[ -n "${report}" ]] || { echo "FAIL: report path is required" >&2; return 1; }
-  python3 - "${report}" "${DEV_ENV}" "${VALIDATOR}" <<'PY'
+  python3 - "${report}" "${DEV_ENV}" "${VALIDATOR}" "${mode}" <<'PY'
 import datetime as dt, json, os, shlex, subprocess, sys, urllib.request
 from pathlib import Path
 path = Path(sys.argv[1])
+live = sys.argv[4] == "live"
 def fail(message: str) -> None: print(f"FAIL: {message}", file=sys.stderr); sys.exit(1)
 def req(ok: bool, message: str) -> None:
     if not ok: fail(message)
@@ -127,8 +127,7 @@ for node in nodes:
     req(nonempty_str(command) and Path(command_argv0).is_absolute() and Path(command_argv0).resolve() == binary_path and binary_path.name == expected_bin and binary_path.is_file() and os.access(binary_path, os.X_OK), f"{name} command/binary is not bound to executable {expected_bin}")
     req(ep(node.get("rpc_endpoint")) and ep(node.get("p2p_endpoint")) and ts(node.get("started_at")), f"{name} has malformed endpoint or timestamp")
     req(isinstance(node.get("pid"), int) and not isinstance(node.get("pid"), bool) and node["pid"] > 0, f"{name} pid is not a positive integer")
-    req(ps_comm(node["pid"]) == expected_bin and Path(ps_argv0(node["pid"])).resolve() == binary_path, f"{name} live process identity does not match report")
-    req(owns_listen(node["pid"], node["rpc_endpoint"]) and owns_listen(node["pid"], node["p2p_endpoint"]), f"{name} live listeners are not pid-owned")
+    if live: req(ps_comm(node["pid"]) == expected_bin and Path(ps_argv0(node["pid"])).resolve() == binary_path, f"{name} live process identity does not match report"); req(owns_listen(node["pid"], node["rpc_endpoint"]) and owns_listen(node["pid"], node["p2p_endpoint"]), f"{name} live listeners are not pid-owned")
     for field in ("process_alive", "rpc_endpoint_process_backed", "p2p_endpoint_process_backed"):
         req(node.get(field) is True, f"{name} does not prove {field}")
 impls = {n["implementation"] for n in nodes}
@@ -146,18 +145,18 @@ rust_expected = links.get("rust_peer_snapshot_expected_addr")
 req(all(ep(links.get(f)) for f in ("go_peer_snapshot_expected_addr", "rust_peer_snapshot_expected_addr", "rust_outbound_local_addr", "rust_outbound_remote_addr")), "counterpart link endpoint is malformed")
 req(rust_expected == nodes_by_impl["go"]["p2p_endpoint"] and links.get("rust_outbound_remote_addr") == rust_expected and links.get("rust_outbound_local_addr") == go_expected and links.get("rust_outbound_pid") == nodes_by_impl["rust"]["pid"], "peer evidence is not bound to expected counterpart endpoints")
 req(isinstance(go_expected, str) and go_expected not in {rust_expected, nodes_by_impl["rust"]["p2p_endpoint"], nodes_by_impl["go"]["rpc_endpoint"], nodes_by_impl["rust"]["rpc_endpoint"]}, "go peer evidence is not a rust outbound peer address")
-req(f"{go_expected}->{rust_expected}" in lsof_lines(nodes_by_impl["rust"]["pid"], "ESTABLISHED"), "rust outbound TCP link is not live and rust-owned")
+if live: req(f"{go_expected}->{rust_expected}" in lsof_lines(nodes_by_impl["rust"]["pid"], "ESTABLISHED"), "rust outbound TCP link is not live and rust-owned")
 final = data.get("final_verification")
 req(isinstance(final, dict) and all(final.get(f) is True for f in ("producer_side", "process_identity_rechecked", "rust_outbound_link_rechecked", "peer_snapshots_rechecked")), "PASS report missing producer-side final verification")
 req(final.get("rust_outbound_pid") == nodes_by_impl["rust"]["pid"] and final.get("rust_outbound_local_addr") == go_expected and final.get("rust_outbound_remote_addr") == rust_expected, "final verification is not bound to peer evidence")
 for field, expected_addr in (("go_peer_snapshot", go_expected), ("rust_peer_snapshot", rust_expected)):
     stored = snapshot_norm(connectivity.get(field))
-    live = snapshot_norm(peers(nodes_by_impl["go" if field.startswith("go_") else "rust"]["rpc_endpoint"]))
-    req(stored == live and (expected_addr, True) in stored, f"{field} differs from live exact peer set")
+    req((expected_addr, True) in stored, f"{field} missing expected completed peer")
+    if live: fresh = snapshot_norm(peers(nodes_by_impl["go" if field.startswith("go_") else "rust"]["rpc_endpoint"])); req(stored == fresh, f"{field} differs from live exact peer set")
 print(f"PASS: mixed-client mesh report accepted {path}")
 PY
 }
-if [[ "${CHECK_REPORT_MODE}" == "1" ]]; then need_tool python3; need_tool lsof; check_report "${CHECK_REPORT}"; exit 0; fi
+if [[ "${CHECK_REPORT_MODE}" == "1" ]]; then need_tool python3; check_report "${CHECK_REPORT}" offline; exit 0; fi
 need_tool python3
 [[ -x "${DEV_ENV}" ]] || { echo "dev-env wrapper missing or non-executable: ${DEV_ENV}" >&2; exit 1; }
 [[ -r "${VALIDATOR}" ]] || { echo "validator unreadable: ${VALIDATOR}" >&2; exit 1; }
@@ -421,7 +420,8 @@ start_go_node() {
   rubin_process_wait_for_rpc_ready "${GO_RPC_ADDR}" 30 || return 1
   GO_STARTED_AT_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 }
-[[ "${MESH_TIMEOUT}" =~ ^[0-9]+$ && "${MESH_TIMEOUT}" -ge 1 && "${MESH_TIMEOUT}" -le 600 ]] || { echo "MESH_TIMEOUT must be an integer in [1, 600]" >&2; exit 2; }
+[[ "${MESH_TIMEOUT}" =~ ^[0-9]+$ ]] || { echo "MESH_TIMEOUT must be an integer in [1, 600]" >&2; exit 2; }
+MESH_TIMEOUT="$((10#${MESH_TIMEOUT}))"; (( MESH_TIMEOUT >= 1 && MESH_TIMEOUT <= 600 )) || { echo "MESH_TIMEOUT must be an integer in [1, 600]" >&2; exit 2; }
 command -v lsof >/dev/null 2>&1 || finish_no_data "lsof_unavailable"; command -v perl >/dev/null 2>&1 || finish_no_data "perl_unavailable"
 build_go_node || finish_no_data "go_build_failed"
 build_rust_node || finish_no_data "rust_build_failed"
@@ -442,7 +442,7 @@ wait_peer_snapshot node-go-final "${GO_RPC_ADDR}" "${GO_PEERS_JSON}" "${MESH_TIM
 FINAL_PEER_SNAPSHOTS_RECHECKED=true
 PASS_REPORT_JSON="${REPORT_JSON}.pass.tmp"; FINAL_REPORT_JSON="${REPORT_JSON}"; REPORT_JSON="${PASS_REPORT_JSON}"
 write_outputs "PASS"; REPORT_JSON="${FINAL_REPORT_JSON}"
-if run_validator "${LEGACY_SCHEMA_MARKER_JSON}" >&2 && check_report "${PASS_REPORT_JSON}" >&2; then
+if run_validator "${LEGACY_SCHEMA_MARKER_JSON}" >&2 && check_report "${PASS_REPORT_JSON}" live >&2; then
   mv -- "${PASS_REPORT_JSON}" "${REPORT_JSON}"
 else
   rm -f -- "${PASS_REPORT_JSON}"; finish_no_data "pass_report_validation_failed"

--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -46,6 +46,13 @@ def fail(message: str) -> None:
 def req(ok: bool, message: str) -> None:
     if not ok:
         fail(message)
+def ep(value: object) -> bool:
+    if not isinstance(value, str) or not value.startswith("127.0.0.1:"):
+        return False
+    port = value.rsplit(":", 1)[1]
+    return port.isdigit() and 1 <= int(port) <= 65535
+def ts(value: object) -> bool:
+    return isinstance(value, str) and len(value) == 20 and value.endswith("Z") and value[4] == value[7] == "-" and value[10] == "T" and value[13] == value[16] == ":" and (value[:4] + value[5:7] + value[8:10] + value[11:13] + value[14:16] + value[17:19]).isdigit()
 try:
     with path.open(encoding="utf-8") as f:
         data = json.load(f)
@@ -70,8 +77,9 @@ for node in nodes:
     name = node.get("name")
     req(isinstance(name, str) and name.startswith("node-"), f"node has invalid name: {name!r}")
     req(node.get("process_comm") == expected_comm.get(impl), f"{name} process_comm does not prove {impl} identity")
-    for field in ("pid", "command", "binary", "rpc_endpoint", "p2p_endpoint", "started_at"):
+    for field in ("pid", "command", "binary"):
         req(field in node and node[field] not in ("", None), f"{name} missing {field}")
+    req(ep(node.get("rpc_endpoint")) and ep(node.get("p2p_endpoint")) and ts(node.get("started_at")), f"{name} has malformed endpoint or timestamp")
     req(isinstance(node["pid"], int) and node["pid"] > 0, f"{name} pid is not a positive integer")
     for field in ("process_alive", "rpc_endpoint_process_backed", "p2p_endpoint_process_backed"):
         req(node.get(field) is True, f"{name} does not prove {field}")
@@ -82,6 +90,7 @@ links = connectivity.get("counterpart_links")
 req(isinstance(links, dict), "PASS report missing counterpart_links")
 go_expected = links.get("go_peer_snapshot_expected_addr")
 rust_expected = links.get("rust_peer_snapshot_expected_addr")
+req(all(ep(links.get(f)) for f in ("go_peer_snapshot_expected_addr", "rust_peer_snapshot_expected_addr", "rust_outbound_local_addr", "rust_outbound_remote_addr")), "counterpart link endpoint is malformed")
 req(rust_expected == nodes_by_impl["go"]["p2p_endpoint"] and links.get("rust_outbound_remote_addr") == rust_expected and links.get("rust_outbound_local_addr") == go_expected and links.get("rust_outbound_pid") == nodes_by_impl["rust"]["pid"], "peer evidence is not bound to expected counterpart endpoints")
 req(isinstance(go_expected, str) and go_expected not in {rust_expected, nodes_by_impl["rust"]["p2p_endpoint"], nodes_by_impl["go"]["rpc_endpoint"], nodes_by_impl["rust"]["rpc_endpoint"]}, "go peer evidence is not a rust outbound peer address")
 for field, expected_addr in (("go_peer_snapshot", go_expected), ("rust_peer_snapshot", rust_expected)):
@@ -89,6 +98,7 @@ for field, expected_addr in (("go_peer_snapshot", go_expected), ("rust_peer_snap
     req(isinstance(snapshot, dict) and snapshot.get("count", 0) >= 1, f"{field} must show at least one peer")
     peers = snapshot.get("peers")
     req(isinstance(peers, list) and peers and snapshot.get("count") == len(peers), f"{field}.peers/count are internally inconsistent")
+    req(all(isinstance(p, dict) and ep(p.get("addr")) and isinstance(p.get("handshake_complete"), bool) for p in peers), f"{field}.peers contain malformed entries")
     req(any(p.get("addr") == expected_addr and p.get("handshake_complete") is True for p in peers if isinstance(p, dict)), f"{field} lacks completed handshake for expected counterpart")
 print(f"PASS: mixed-client mesh report accepted {path}")
 PY
@@ -117,16 +127,8 @@ RUST_PEERS_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/rust-peers.json"
 GO_PID="" RUST_PID="" GO_RPC_ADDR="" RUST_RPC_ADDR="" GO_P2P_ADDR="" RUST_P2P_ADDR="" GO_STARTED_AT_UTC="" RUST_STARTED_AT_UTC=""
 GO_COMM="" RUST_COMM="" RUST_TO_GO_LOCAL_ADDR="" GO_CMD="" RUST_CMD=""
 mkdir -p -- "${GO_DIR}" "${RUST_DIR}"
-run_fips_preflight_before_captured_dev_env() {
-  if [[ "${RUBIN_OPENSSL_FIPS_MODE:-off}" != "only" || "${RUBIN_OPENSSL_SKIP_FIPS_GUARD:-0}" == "1" ]]; then
-    return 0
-  fi
-  echo "Running FIPS-only preflight before captured dev-env command streams" >&2
-  "${DEV_ENV}" -- "${REPO_ROOT}/scripts/crypto/openssl/fips-preflight.sh" >&2
-}
-run_validator() {
-  RUBIN_OPENSSL_SKIP_FIPS_GUARD=1 "${DEV_ENV}" -- python3 "${VALIDATOR}" "$@"
-}
+run_fips_preflight_before_captured_dev_env() { [[ "${RUBIN_OPENSSL_FIPS_MODE:-off}" != "only" || "${RUBIN_OPENSSL_SKIP_FIPS_GUARD:-0}" == "1" ]] && return 0; echo "Running FIPS-only preflight before captured dev-env command streams" >&2; "${DEV_ENV}" -- "${REPO_ROOT}/scripts/crypto/openssl/fips-preflight.sh" >&2; }
+run_validator() { RUBIN_OPENSSL_SKIP_FIPS_GUARD=1 "${DEV_ENV}" -- python3 "${VALIDATOR}" "$@"; }
 rpc_json() {
   local method="$1" addr="$2" path="$3"
   python3 - "${method}" "${addr}" "${path}" <<'PY'
@@ -201,11 +203,7 @@ extract_log_addr() {
   [[ "${addr}" == 127.0.0.1:* ]] || return 1
   printf '%s\n' "${addr}"
 }
-build_go_node() {
-  echo "Building Go rubin-node binary" >&2
-  "${DEV_ENV}" -- go -C "${GO_MODULE_ROOT}" build -o "${GO_NODE_BIN}" ./cmd/rubin-node || return 1
-  [[ -x "${GO_NODE_BIN}" ]]
-}
+build_go_node() { echo "Building Go rubin-node binary" >&2; "${DEV_ENV}" -- go -C "${GO_MODULE_ROOT}" build -o "${GO_NODE_BIN}" ./cmd/rubin-node || return 1; [[ -x "${GO_NODE_BIN}" ]]; }
 build_rust_node() {
   local host_triple cargo_target_dir cargo_log cargo_bin
   echo "Building Rust rubin-node binary" >&2
@@ -341,13 +339,7 @@ with open(e["LEGACY_SCHEMA_MARKER_JSON"], "w", encoding="utf-8") as f:
 PY
 }
 
-finish_no_data() {
-  local reason="$1"
-  write_outputs "NO_DATA" "${reason}"
-  run_validator "${LEGACY_SCHEMA_MARKER_JSON}" >&2
-  echo "NO_DATA: ${reason}; report=${REPORT_JSON} legacy_schema_marker=${LEGACY_SCHEMA_MARKER_JSON}" >&2
-  exit 1
-}
+finish_no_data() { local reason="$1"; write_outputs "NO_DATA" "${reason}"; run_validator "${LEGACY_SCHEMA_MARKER_JSON}" >&2; echo "NO_DATA: ${reason}; report=${REPORT_JSON} legacy_schema_marker=${LEGACY_SCHEMA_MARKER_JSON}" >&2; exit 1; }
 
 wait_peer_snapshot() {
   local label="$1" addr="$2" out="$3" timeout="$4" expected="$5" deadline tmp

--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -36,6 +36,7 @@ check_report() {
   local report="${1:-}"
   [[ -n "${report}" ]] || { echo "FAIL: report path is required" >&2; return 1; }
   python3 - "${report}" <<'PY'
+import datetime as dt
 import json
 import sys
 from pathlib import Path
@@ -52,7 +53,12 @@ def ep(value: object) -> bool:
     port = value.rsplit(":", 1)[1]
     return port.isdigit() and 1 <= int(port) <= 65535
 def ts(value: object) -> bool:
-    return isinstance(value, str) and len(value) == 20 and value.endswith("Z") and value[4] == value[7] == "-" and value[10] == "T" and value[13] == value[16] == ":" and (value[:4] + value[5:7] + value[8:10] + value[11:13] + value[14:16] + value[17:19]).isdigit()
+    if not isinstance(value, str) or len(value) != 20 or value[-1] != "Z":
+        return False
+    try:
+        return dt.datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").strftime("%Y-%m-%dT%H:%M:%SZ") == value
+    except ValueError:
+        return False
 try:
     with path.open(encoding="utf-8") as f:
         data = json.load(f)

--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -66,11 +66,7 @@ if data.get("scenario") != "mixed_client_mesh":
     fail(f"scenario is not mixed_client_mesh: {data.get('scenario')!r}")
 verdict = data.get("verdict")
 if verdict != "PASS":
-    reason = data.get("failure_reason")
-    if verdict not in {"FAIL", "NO_DATA"} or not isinstance(reason, str) or not reason:
-        fail("non-PASS report must carry verdict FAIL/NO_DATA and failure_reason")
-    print(f"PASS: non-PASS mixed-client mesh report is typed: {path}")
-    sys.exit(0)
+    fail(f"report verdict is not PASS: {verdict!r}")
 if "failure_reason" in data:
     fail("PASS report must not carry failure_reason")
 if "schema_marker" in data:
@@ -308,6 +304,7 @@ write_outputs() {
   export REPORT_JSON LEGACY_SCHEMA_MARKER_JSON verdict reason GO_PID RUST_PID GO_RPC_ADDR RUST_RPC_ADDR \
     GO_P2P_ADDR RUST_P2P_ADDR GO_STARTED_AT_UTC RUST_STARTED_AT_UTC GO_COMM RUST_COMM \
     GO_NODE_BIN RUST_NODE_BIN GO_CMD RUST_CMD GO_PEERS_JSON RUST_PEERS_JSON \
+    GO_PROCESS_ALIVE RUST_PROCESS_ALIVE GO_RPC_PROCESS_BACKED RUST_RPC_PROCESS_BACKED GO_P2P_PROCESS_BACKED RUST_P2P_PROCESS_BACKED \
     RUBIN_PROCESS_ARTIFACT_ROOT
   python3 - <<'PY'
 import json
@@ -331,6 +328,7 @@ for impl, name, pid_key, rpc_key, p2p_key, started_key, comm_key, bin_key, cmd_k
     ("rust", "node-rust", "RUST_PID", "RUST_RPC_ADDR", "RUST_P2P_ADDR", "RUST_STARTED_AT_UTC", "RUST_COMM", "RUST_NODE_BIN", "RUST_CMD"),
 ):
     pid_raw = (e.get(pid_key) or "").strip()
+    prefix = impl.upper()
     node = {
         "name": name,
         "implementation": impl,
@@ -341,9 +339,9 @@ for impl, name, pid_key, rpc_key, p2p_key, started_key, comm_key, bin_key, cmd_k
         "p2p_endpoint": e.get(p2p_key) or None,
         "started_at": e.get(started_key) or None,
         "process_comm": e.get(comm_key) or None,
-        "process_alive": bool(pid_raw),
-        "rpc_endpoint_process_backed": bool(e.get(rpc_key)),
-        "p2p_endpoint_process_backed": bool(e.get(p2p_key)),
+        "process_alive": verdict == "PASS" and e.get(f"{prefix}_PROCESS_ALIVE") == "true",
+        "rpc_endpoint_process_backed": verdict == "PASS" and e.get(f"{prefix}_RPC_PROCESS_BACKED") == "true",
+        "p2p_endpoint_process_backed": verdict == "PASS" and e.get(f"{prefix}_P2P_PROCESS_BACKED") == "true",
     }
     nodes.append(node)
 
@@ -439,8 +437,8 @@ verify_process_identity() {
   pid_listens_on "${pid}" "${rpc_addr}" || { echo "${label} rpc endpoint is not process-backed: ${rpc_addr}" >&2; return 1; }
   pid_listens_on "${pid}" "${p2p_addr}" || { echo "${label} p2p endpoint is not process-backed: ${p2p_addr}" >&2; return 1; }
   case "${impl}" in
-    go) GO_COMM="${comm}" ;;
-    rust) RUST_COMM="${comm}" ;;
+    go) GO_COMM="${comm}"; GO_PROCESS_ALIVE=true; GO_RPC_PROCESS_BACKED=true; GO_P2P_PROCESS_BACKED=true ;;
+    rust) RUST_COMM="${comm}"; RUST_PROCESS_ALIVE=true; RUST_RPC_PROCESS_BACKED=true; RUST_P2P_PROCESS_BACKED=true ;;
     *) return 1 ;;
   esac
 }
@@ -487,6 +485,8 @@ start_rust_node || finish_no_data "rust_process_not_ready"
 verify_process_identity node-rust rust "${RUST_PID}" "${RUST_RPC_ADDR}" "${RUST_P2P_ADDR}" rubin-node-rust || finish_no_data "rust_process_identity_unverified"
 wait_peer_snapshot node-go "${GO_RPC_ADDR}" "${GO_PEERS_JSON}" "${MESH_TIMEOUT}" || finish_no_data "go_peer_snapshot_missing_completed_handshake"
 wait_peer_snapshot node-rust "${RUST_RPC_ADDR}" "${RUST_PEERS_JSON}" "${MESH_TIMEOUT}" || finish_no_data "rust_peer_snapshot_missing_completed_handshake"
+verify_process_identity node-go-final go "${GO_PID}" "${GO_RPC_ADDR}" "${GO_P2P_ADDR}" rubin-node-go || finish_no_data "go_final_process_identity_unverified"
+verify_process_identity node-rust-final rust "${RUST_PID}" "${RUST_RPC_ADDR}" "${RUST_P2P_ADDR}" rubin-node-rust || finish_no_data "rust_final_process_identity_unverified"
 
 write_outputs "PASS"
 run_validator "${LEGACY_SCHEMA_MARKER_JSON}" >&2

--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -14,10 +14,7 @@ while (($#)); do
       [[ $# -ge 2 ]] || { usage; exit 2; }
       CHECK_REPORT_MODE=offline; [[ "$1" == "--check-report-live" ]] && CHECK_REPORT_MODE=live; CHECK_REPORT="$2"; shift 2
       ;;
-    -h|--help)
-      usage
-      exit 0
-      ;;
+    -h|--help) usage; exit 0 ;;
     *)
       usage
       exit 2

--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -48,10 +48,10 @@ def req(ok: bool, message: str) -> None:
     if not ok:
         fail(message)
 def ep(value: object) -> bool:
-    if not isinstance(value, str) or not value.startswith("127.0.0.1:"):
+    if not isinstance(value, str):
         return False
-    port = value.rsplit(":", 1)[1]
-    return port.isdigit() and 1 <= int(port) <= 65535
+    host, sep, port = value.partition(":")
+    return sep == ":" and host == "127.0.0.1" and ":" not in port and port.isascii() and port.isdigit() and 1 <= int(port) <= 65535
 def ts(value: object) -> bool:
     if not isinstance(value, str) or len(value) != 20 or value[-1] != "Z":
         return False
@@ -101,9 +101,10 @@ req(rust_expected == nodes_by_impl["go"]["p2p_endpoint"] and links.get("rust_out
 req(isinstance(go_expected, str) and go_expected not in {rust_expected, nodes_by_impl["rust"]["p2p_endpoint"], nodes_by_impl["go"]["rpc_endpoint"], nodes_by_impl["rust"]["rpc_endpoint"]}, "go peer evidence is not a rust outbound peer address")
 for field, expected_addr in (("go_peer_snapshot", go_expected), ("rust_peer_snapshot", rust_expected)):
     snapshot = connectivity.get(field)
-    req(isinstance(snapshot, dict) and snapshot.get("count", 0) >= 1, f"{field} must show at least one peer")
+    count = snapshot.get("count") if isinstance(snapshot, dict) else None
+    req(isinstance(snapshot, dict) and isinstance(count, int) and not isinstance(count, bool) and count >= 1, f"{field} must show at least one peer")
     peers = snapshot.get("peers")
-    req(isinstance(peers, list) and peers and snapshot.get("count") == len(peers), f"{field}.peers/count are internally inconsistent")
+    req(isinstance(peers, list) and peers and count == len(peers), f"{field}.peers/count are internally inconsistent")
     req(all(isinstance(p, dict) and ep(p.get("addr")) and isinstance(p.get("handshake_complete"), bool) for p in peers), f"{field}.peers contain malformed entries")
     req(any(p.get("addr") == expected_addr and p.get("handshake_complete") is True for p in peers if isinstance(p, dict)), f"{field} lacks completed handshake for expected counterpart")
 print(f"PASS: mixed-client mesh report accepted {path}")
@@ -358,8 +359,8 @@ import json
 import sys
 with open(sys.argv[1], encoding="utf-8") as f:
     data = json.load(f)
-expected, peers = sys.argv[2], data.get("peers")
-ok = isinstance(peers, list) and data.get("count") == len(peers) and any(
+expected, peers, count = sys.argv[2], data.get("peers"), data.get("count")
+ok = isinstance(count, int) and not isinstance(count, bool) and isinstance(peers, list) and count == len(peers) and any(
     isinstance(p, dict) and p.get("addr") == expected and p.get("handshake_complete") is True for p in peers
 )
 sys.exit(0 if ok else 1)

--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -53,12 +53,9 @@ def ps_comm(pid: int) -> str: return os.path.basename(run(["ps", "-ww", "-p", st
 def lsof_lines(pid: int, state: str) -> list[str]:
     try:
         p = subprocess.run(["lsof", "-nP", "-a", "-p", str(pid), "-iTCP", f"-sTCP:{state}", "-Fn"], check=False, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=5)
-    except FileNotFoundError:
-        fail("lsof_unavailable")
-    except subprocess.TimeoutExpired:
-        fail("lsof_timeout")
-    except OSError as exc:
-        fail(f"lsof_failed: {exc}")
+    except FileNotFoundError: fail("lsof_unavailable")
+    except subprocess.TimeoutExpired: fail("lsof_timeout")
+    except OSError as exc: fail(f"lsof_failed: {exc}")
     req(p.returncode == 0 or not (p.stdout.strip() or p.stderr.strip()), "lsof_failed")
     if p.returncode != 0: return []
     return [line[1:] for line in p.stdout.splitlines() if line.startswith("n")]
@@ -161,11 +158,8 @@ print(f"PASS: mixed-client mesh report accepted {path}")
 PY
 }
 if [[ -n "${CHECK_REPORT_MODE}" ]]; then need_tool python3; check_report "${CHECK_REPORT}" "${CHECK_REPORT_MODE}"; exit 0; fi
-need_tool python3
-[[ -x "${DEV_ENV}" ]] || { echo "dev-env wrapper missing or non-executable: ${DEV_ENV}" >&2; exit 1; }
-[[ -r "${VALIDATOR}" ]] || { echo "validator unreadable: ${VALIDATOR}" >&2; exit 1; }
-[[ "${MESH_TIMEOUT}" =~ ^[0-9]{1,3}$ ]] || { echo "MESH_TIMEOUT must be an integer in [1, 600]" >&2; exit 2; }
-MESH_TIMEOUT="$((10#${MESH_TIMEOUT}))"; (( MESH_TIMEOUT >= 1 && MESH_TIMEOUT <= 600 )) || { echo "MESH_TIMEOUT must be an integer in [1, 600]" >&2; exit 2; }
+need_tool python3; [[ -x "${DEV_ENV}" ]] || { echo "dev-env wrapper missing or non-executable: ${DEV_ENV}" >&2; exit 1; }; [[ -r "${VALIDATOR}" ]] || { echo "validator unreadable: ${VALIDATOR}" >&2; exit 1; }
+[[ "${MESH_TIMEOUT}" =~ ^[0-9]{1,3}$ ]] || { echo "MESH_TIMEOUT must be an integer in [1, 600]" >&2; exit 2; }; MESH_TIMEOUT="$((10#${MESH_TIMEOUT}))"; (( MESH_TIMEOUT >= 1 && MESH_TIMEOUT <= 600 )) || { echo "MESH_TIMEOUT must be an integer in [1, 600]" >&2; exit 2; }
 # shellcheck source=scripts/devnet-process-common.sh disable=SC1091
 source "${HELPER}"
 rubin_process_init mixed-client-mesh
@@ -174,9 +168,7 @@ GO_DIR="${RUBIN_PROCESS_ARTIFACT_ROOT}/node-go"; RUST_DIR="${RUBIN_PROCESS_ARTIF
 GO_LOG="node-go.log"; RUST_LOG="node-rust.log"
 REPORT_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/mixed-client-mesh-report.json"; LEGACY_SCHEMA_MARKER_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/mixed-client-mesh-legacy-schema-marker.json"
 GO_PEERS_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/go-peers.json"; RUST_PEERS_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/rust-peers.json"
-GO_PID="" RUST_PID="" GO_RPC_ADDR="" RUST_RPC_ADDR="" GO_P2P_ADDR="" RUST_P2P_ADDR="" GO_STARTED_AT_UTC="" RUST_STARTED_AT_UTC=""
-GO_COMM="" RUST_COMM="" RUST_TO_GO_LOCAL_ADDR="" GO_CMD="" RUST_CMD="" GO_ARGV_JSON="" RUST_ARGV_JSON=""
-FINAL_PROCESS_IDENTITY_RECHECKED="" FINAL_RUST_OUTBOUND_LINK_RECHECKED="" FINAL_PEER_SNAPSHOTS_RECHECKED=""
+GO_PID="" RUST_PID="" GO_RPC_ADDR="" RUST_RPC_ADDR="" GO_P2P_ADDR="" RUST_P2P_ADDR="" GO_STARTED_AT_UTC="" RUST_STARTED_AT_UTC="" GO_COMM="" RUST_COMM="" RUST_TO_GO_LOCAL_ADDR="" GO_CMD="" RUST_CMD="" GO_ARGV_JSON="" RUST_ARGV_JSON="" FINAL_PROCESS_IDENTITY_RECHECKED="" FINAL_RUST_OUTBOUND_LINK_RECHECKED="" FINAL_PEER_SNAPSHOTS_RECHECKED=""
 mkdir -p -- "${GO_DIR}" "${RUST_DIR}"
 run_fips_preflight_before_captured_dev_env() { [[ "${RUBIN_OPENSSL_FIPS_MODE:-off}" != "only" || "${RUBIN_OPENSSL_SKIP_FIPS_GUARD:-0}" == "1" ]] && return 0; echo "Running FIPS-only preflight before captured dev-env command streams" >&2; "${DEV_ENV}" -- "${REPO_ROOT}/scripts/crypto/openssl/fips-preflight.sh" >&2; }
 run_validator() { RUBIN_OPENSSL_SKIP_FIPS_GUARD=1 "${DEV_ENV}" -- python3 "${VALIDATOR}" "$@"; }

--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -84,7 +84,7 @@ try:
         data = json.load(f)
 except OSError as exc:
     fail(f"cannot read report: {exc}")
-except json.JSONDecodeError as exc:
+except (json.JSONDecodeError, UnicodeDecodeError) as exc:
     fail(f"malformed JSON report: {exc}")
 req(isinstance(data, dict), "report root is not an object")
 req(data.get("scenario") == "mixed_client_mesh", f"scenario is not mixed_client_mesh: {data.get('scenario')!r}")
@@ -99,7 +99,7 @@ except ValueError: fail("legacy marker is outside artifact_root")
 req(marker_path.is_file() and marker_path.stat().st_size > 0, "legacy marker is missing, unreadable, or empty")
 try:
     with marker_path.open(encoding="utf-8") as f: marker = json.load(f)
-except (OSError, json.JSONDecodeError) as exc:
+except (OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
     fail(f"legacy marker is not readable JSON: {exc}")
 req(isinstance(marker, dict) and marker.get("scenario") == "mixed_client_mesh_schema_marker" and marker.get("verdict") == "FAIL" and marker.get("evidence_type") == "mixed_client_process_soak", "legacy marker has wrong non-authoritative FAIL shape")
 try: validator = subprocess.run([sys.argv[2], "--", "python3", sys.argv[3], str(marker_path)], check=False, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=30)
@@ -129,6 +129,7 @@ for node in nodes:
         req(node.get(field) is True, f"{name} does not prove {field}")
 req((impls := {n["implementation"] for n in nodes}) == {"go", "rust"}, f"PASS report requires one go and one rust node, got {sorted(impls)}")
 nodes_by_impl = {node["implementation"]: node for node in nodes}
+req(nodes_by_impl["go"]["command_argv"] == [nodes_by_impl["go"]["binary"], "--network", "devnet", "--datadir", str(Path(data["artifact_root"]) / "node-go"), "--bind", "127.0.0.1:0", "--rpc-bind", "127.0.0.1:0"] and nodes_by_impl["rust"]["command_argv"] == [nodes_by_impl["rust"]["binary"], "--network", "devnet", "--datadir", str(Path(data["artifact_root"]) / "node-rust"), "--bind", "127.0.0.1:0", "--rpc-bind", "127.0.0.1:0", "--peer", nodes_by_impl["go"]["p2p_endpoint"]], "node command_argv does not match exact launched argv")
 req(nodes_by_impl["go"]["pid"] != nodes_by_impl["rust"]["pid"], "go/rust process evidence uses the same pid")
 req(nodes_by_impl["go"]["binary"] != nodes_by_impl["rust"]["binary"] and nodes_by_impl["go"]["command"] != nodes_by_impl["rust"]["command"] and nodes_by_impl["go"].get("command_argv") != nodes_by_impl["rust"].get("command_argv"), "go/rust process evidence is not implementation-distinct")
 req(len({nodes_by_impl[i][f] for i in ("go", "rust") for f in ("rpc_endpoint", "p2p_endpoint")}) == 4, "node rpc/p2p endpoints are not pairwise distinct")
@@ -154,29 +155,27 @@ for field, expected_addr in (("go_peer_snapshot", go_expected), ("rust_peer_snap
 print(f"PASS: mixed-client mesh report accepted {path}")
 PY
 }
-if [[ "${CHECK_REPORT_MODE}" == "1" ]]; then need_tool python3; check_report "${CHECK_REPORT}" offline; exit 0; fi
+if [[ "${CHECK_REPORT_MODE}" == "1" ]]; then need_tool python3; check_report "${CHECK_REPORT}" live; exit 0; fi
 need_tool python3
 [[ -x "${DEV_ENV}" ]] || { echo "dev-env wrapper missing or non-executable: ${DEV_ENV}" >&2; exit 1; }
 [[ -r "${VALIDATOR}" ]] || { echo "validator unreadable: ${VALIDATOR}" >&2; exit 1; }
+[[ "${MESH_TIMEOUT}" =~ ^[0-9]{1,3}$ ]] || { echo "MESH_TIMEOUT must be an integer in [1, 600]" >&2; exit 2; }
+MESH_TIMEOUT="$((10#${MESH_TIMEOUT}))"; (( MESH_TIMEOUT >= 1 && MESH_TIMEOUT <= 600 )) || { echo "MESH_TIMEOUT must be an integer in [1, 600]" >&2; exit 2; }
 # shellcheck source=scripts/devnet-process-common.sh disable=SC1091
 source "${HELPER}"
 rubin_process_init mixed-client-mesh
-GO_NODE_BIN="${RUBIN_PROCESS_ARTIFACT_ROOT}/rubin-node-go"
-RUST_NODE_BIN="${RUBIN_PROCESS_ARTIFACT_ROOT}/rubin-node-rust"
-GO_DIR="${RUBIN_PROCESS_ARTIFACT_ROOT}/node-go"
-RUST_DIR="${RUBIN_PROCESS_ARTIFACT_ROOT}/node-rust"
-GO_LOG="node-go.log"
-RUST_LOG="node-rust.log"
-REPORT_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/mixed-client-mesh-report.json"
-LEGACY_SCHEMA_MARKER_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/mixed-client-mesh-legacy-schema-marker.json"
-GO_PEERS_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/go-peers.json"
-RUST_PEERS_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/rust-peers.json"
+GO_NODE_BIN="${RUBIN_PROCESS_ARTIFACT_ROOT}/rubin-node-go"; RUST_NODE_BIN="${RUBIN_PROCESS_ARTIFACT_ROOT}/rubin-node-rust"
+GO_DIR="${RUBIN_PROCESS_ARTIFACT_ROOT}/node-go"; RUST_DIR="${RUBIN_PROCESS_ARTIFACT_ROOT}/node-rust"
+GO_LOG="node-go.log"; RUST_LOG="node-rust.log"
+REPORT_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/mixed-client-mesh-report.json"; LEGACY_SCHEMA_MARKER_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/mixed-client-mesh-legacy-schema-marker.json"
+GO_PEERS_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/go-peers.json"; RUST_PEERS_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/rust-peers.json"
 GO_PID="" RUST_PID="" GO_RPC_ADDR="" RUST_RPC_ADDR="" GO_P2P_ADDR="" RUST_P2P_ADDR="" GO_STARTED_AT_UTC="" RUST_STARTED_AT_UTC=""
 GO_COMM="" RUST_COMM="" RUST_TO_GO_LOCAL_ADDR="" GO_CMD="" RUST_CMD="" GO_ARGV_JSON="" RUST_ARGV_JSON=""
 FINAL_PROCESS_IDENTITY_RECHECKED="" FINAL_RUST_OUTBOUND_LINK_RECHECKED="" FINAL_PEER_SNAPSHOTS_RECHECKED=""
 mkdir -p -- "${GO_DIR}" "${RUST_DIR}"
 run_fips_preflight_before_captured_dev_env() { [[ "${RUBIN_OPENSSL_FIPS_MODE:-off}" != "only" || "${RUBIN_OPENSSL_SKIP_FIPS_GUARD:-0}" == "1" ]] && return 0; echo "Running FIPS-only preflight before captured dev-env command streams" >&2; "${DEV_ENV}" -- "${REPO_ROOT}/scripts/crypto/openssl/fips-preflight.sh" >&2; }
 run_validator() { RUBIN_OPENSSL_SKIP_FIPS_GUARD=1 "${DEV_ENV}" -- python3 "${VALIDATOR}" "$@"; }
+bounded() { perl -e 'alarm shift @ARGV; exec @ARGV' 5 "$@"; }
 argv_cmd() { local out="" arg q; for arg; do printf -v q "%q" "$arg"; out+="${out:+ }${q}"; done; printf '%s\n' "${out}"; }; argv_json() { python3 -c 'import json,sys; print(json.dumps(sys.argv[1:]))' "$@"; }
 rpc_json() {
   local method="$1" addr="$2" path="$3"
@@ -195,13 +194,14 @@ except (urllib.error.URLError, TimeoutError, socket.timeout) as exc:
 PY
 }
 pid_comm() {
-  local pid="$1" comm
-  comm="$(ps -ww -p "${pid}" -o comm= 2>/dev/null | sed -n '1p')" || return 1; [[ -n "${comm}" ]] || return 1; basename -- "${comm}"
+  local pid="$1" comm status=0 err="${RUBIN_PROCESS_ARTIFACT_ROOT}/ps.err"
+  comm="$(bounded ps -ww -p "${pid}" -o comm= 2>"${err}" | sed -n '1p')" || status=$?; (( status == 142 )) && return 3; [[ ${status} -eq 0 || ! -s "${err}" ]] || return 2; [[ -n "${comm}" ]] || return 1; basename -- "${comm}"
 }
 pid_listens_on() {
   local pid="$1" endpoint="$2" out status=0
-  out="$(lsof -nP -a -p "${pid}" -iTCP -sTCP:LISTEN -Fn 2>&1)" || status=$?
+  out="$(bounded lsof -nP -a -p "${pid}" -iTCP -sTCP:LISTEN -Fn 2>&1)" || status=$?
   grep -F -x -q -- "n${endpoint}" <<<"${out}" && return 0
+  (( status == 142 )) && return 3
   (( status == 0 || ${#out} == 0 )) || return 2
   return 1
 }
@@ -212,7 +212,8 @@ import re, subprocess, sys, time
 pid, rpc_addr, timeout = sys.argv[1], sys.argv[2], int(sys.argv[3])
 deadline = time.time() + timeout
 while time.time() < deadline:
-    proc = subprocess.run(["lsof", "-nP", "-a", "-p", pid, "-iTCP", "-sTCP:LISTEN", "-Fn"], text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    try: proc = subprocess.run(["lsof", "-nP", "-a", "-p", pid, "-iTCP", "-sTCP:LISTEN", "-Fn"], text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=5)
+    except subprocess.TimeoutExpired: sys.exit(43)
     if proc.returncode != 0 and proc.stderr.strip(): sys.exit(42)
     addrs = sorted({line[1:].strip() for line in proc.stdout.splitlines() if line.startswith("n") and line[1:].strip() != rpc_addr and re.fullmatch(r"127\.0\.0\.1:[0-9]+", line[1:].strip())})
     if len(addrs) == 1: print(addrs[0]); sys.exit(0)
@@ -351,10 +352,10 @@ PY
 finish_no_data() { local reason="$1"; write_outputs "NO_DATA" "${reason}"; run_validator "${LEGACY_SCHEMA_MARKER_JSON}" >&2; echo "NO_DATA: ${reason}; report=${REPORT_JSON} legacy_schema_marker=${LEGACY_SCHEMA_MARKER_JSON}" >&2; exit 1; }
 wait_peer_snapshot() {
   local label="$1" addr="$2" out="$3" timeout="$4" expected="$5" deadline tmp
-  deadline=$((SECONDS + timeout))
+  deadline=$((SECONDS + timeout)); PEER_SNAPSHOT_REASON=""
   tmp="${out}.tmp"
   while (( SECONDS < deadline )); do
-    if rpc_json GET "${addr}" /peers >"${tmp}" 2>/dev/null \
+    if { rpc_json GET "${addr}" /peers >"${tmp}" 2>"${tmp}.err" || { PEER_SNAPSHOT_REASON=peer_snapshot_rpc_failed; false; }; } \
       && python3 - "${tmp}" "${expected}" <<'PY' >/dev/null 2>&1
 import json, sys
 with open(sys.argv[1], encoding="utf-8") as f:
@@ -370,16 +371,17 @@ PY
     fi
     sleep 1
   done
-  rm -f -- "${tmp}"
-  echo "timeout waiting for ${label} /peers completed handshake" >&2
+  if [[ "${PEER_SNAPSHOT_REASON:-}" == peer_snapshot_rpc_failed || -s "${tmp}.err" ]]; then PEER_SNAPSHOT_REASON=peer_snapshot_rpc_failed; elif [[ -s "${tmp}" ]] && ! python3 -m json.tool "${tmp}" >/dev/null 2>&1; then PEER_SNAPSHOT_REASON=peer_snapshot_malformed_json; else PEER_SNAPSHOT_REASON="${label}_peer_snapshot_missing_endpoint"; fi
+  rm -f -- "${tmp}" "${tmp}.err"
+  echo "timeout waiting for ${label} /peers completed handshake: ${PEER_SNAPSHOT_REASON}" >&2
   return 1
 }
 wait_rust_to_go_link() {
   local missing="$1" ambiguous="$2" deadline out status err_file err
   deadline=$((SECONDS + MESH_TIMEOUT)); err_file="${RUBIN_PROCESS_ARTIFACT_ROOT}/lsof-established.err"
   while (( SECONDS < deadline )); do
-    status=0; out="$(lsof -nP -a -p "${RUST_PID}" -iTCP -sTCP:ESTABLISHED -Fn 2>"${err_file}" | REMOTE_ADDR="${GO_P2P_ADDR}" perl -ne 'BEGIN{$r=$ENV{REMOTE_ADDR}} chomp; s/^n// or next; print "$1\n" if /^(127[.]0[.]0[.]1:[0-9]+)->\Q$r\E$/' | sort -u)" || status=$?; err="$(<"${err_file}")"
-    (( status == 0 || (${#out} == 0 && ${#err} == 0) )) || finish_no_data "lsof_failed"
+    status=0; out="$(bounded lsof -nP -a -p "${RUST_PID}" -iTCP -sTCP:ESTABLISHED -Fn 2>"${err_file}" | REMOTE_ADDR="${GO_P2P_ADDR}" perl -ne 'BEGIN{$r=$ENV{REMOTE_ADDR}} chomp; s/^n// or next; print "$1\n" if /^(127[.]0[.]0[.]1:[0-9]+)->\Q$r\E$/' | sort -u)" || status=$?; err="$(<"${err_file}")"
+    (( status == 142 )) && finish_no_data "lsof_timeout"; (( status == 0 || (${#out} == 0 && ${#err} == 0) )) || finish_no_data "lsof_failed"
     [[ "${out}" != *$'\n'* ]] || finish_no_data "${ambiguous}"; [[ -z "${out}" ]] || { RUST_TO_GO_LOCAL_ADDR="${out}"; return 0; }
     sleep 1
   done; finish_no_data "${missing}"
@@ -387,10 +389,10 @@ wait_rust_to_go_link() {
 verify_process_identity() {
   local label="$1" impl="$2" pid="$3" rpc_addr="$4" p2p_addr="$5" expected_comm="$6" comm
   rubin_process_is_alive "${pid}" || { echo "${label} pid is not alive: ${pid}" >&2; return 1; }
-  comm="$(pid_comm "${pid}")" || { echo "${label} process comm unavailable: ${pid}" >&2; return 1; }
+  comm="$(pid_comm "${pid}")" || { rc=$?; [[ ${rc} -eq 2 ]] && finish_no_data "ps_failed"; [[ ${rc} -eq 3 ]] && finish_no_data "ps_timeout"; echo "${label} process comm unavailable: ${pid}" >&2; return 1; }
   [[ "${comm}" == "${expected_comm}" ]] || { echo "${label} process comm=${comm}, want ${expected_comm}" >&2; return 1; }
-  pid_listens_on "${pid}" "${rpc_addr}" || { [[ $? -eq 2 ]] && finish_no_data "lsof_failed"; echo "${label} rpc endpoint is not process-backed: ${rpc_addr}" >&2; return 1; }
-  pid_listens_on "${pid}" "${p2p_addr}" || { [[ $? -eq 2 ]] && finish_no_data "lsof_failed"; echo "${label} p2p endpoint is not process-backed: ${p2p_addr}" >&2; return 1; }
+  pid_listens_on "${pid}" "${rpc_addr}" || { rc=$?; [[ ${rc} -eq 2 ]] && finish_no_data "lsof_failed"; [[ ${rc} -eq 3 ]] && finish_no_data "lsof_timeout"; echo "${label} rpc endpoint is not process-backed: ${rpc_addr}" >&2; return 1; }
+  pid_listens_on "${pid}" "${p2p_addr}" || { rc=$?; [[ ${rc} -eq 2 ]] && finish_no_data "lsof_failed"; [[ ${rc} -eq 3 ]] && finish_no_data "lsof_timeout"; echo "${label} p2p endpoint is not process-backed: ${p2p_addr}" >&2; return 1; }
   case "${impl}" in
     go) GO_COMM="${comm}"; GO_PROCESS_ALIVE=true; GO_RPC_PROCESS_BACKED=true; GO_P2P_PROCESS_BACKED=true ;;
     rust) RUST_COMM="${comm}"; RUST_PROCESS_ALIVE=true; RUST_RPC_PROCESS_BACKED=true; RUST_P2P_PROCESS_BACKED=true ;;
@@ -416,12 +418,10 @@ start_go_node() {
   GO_PID="${RUBIN_PROCESS_LAST_PID}"
   rubin_process_wait_for_log "${GO_LOG}" "rpc: listening=" 60 "${GO_PID}" || return 1
   GO_RPC_ADDR="$(rubin_process_extract_rpc_addr "${GO_LOG}")" || return 1
-  GO_P2P_ADDR="$(p2p_addr_for_pid "${GO_PID}" "${GO_RPC_ADDR}" 30)" || { [[ $? -eq 42 ]] && finish_no_data "lsof_failed"; return 1; }
+  GO_P2P_ADDR="$(p2p_addr_for_pid "${GO_PID}" "${GO_RPC_ADDR}" 30)" || { rc=$?; [[ ${rc} -eq 42 ]] && finish_no_data "lsof_failed"; [[ ${rc} -eq 43 ]] && finish_no_data "lsof_timeout"; return 1; }
   rubin_process_wait_for_rpc_ready "${GO_RPC_ADDR}" 30 || return 1
   GO_STARTED_AT_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 }
-[[ "${MESH_TIMEOUT}" =~ ^[0-9]{1,3}$ ]] || { echo "MESH_TIMEOUT must be an integer in [1, 600]" >&2; exit 2; }
-MESH_TIMEOUT="$((10#${MESH_TIMEOUT}))"; (( MESH_TIMEOUT >= 1 && MESH_TIMEOUT <= 600 )) || { echo "MESH_TIMEOUT must be an integer in [1, 600]" >&2; exit 2; }
 command -v lsof >/dev/null 2>&1 || finish_no_data "lsof_unavailable"; command -v perl >/dev/null 2>&1 || finish_no_data "perl_unavailable"
 build_go_node || finish_no_data "go_build_failed"
 build_rust_node || finish_no_data "rust_build_failed"
@@ -429,16 +429,16 @@ start_go_node || finish_no_data "go_process_not_ready"
 verify_process_identity node-go go "${GO_PID}" "${GO_RPC_ADDR}" "${GO_P2P_ADDR}" rubin-node-go || finish_no_data "go_process_identity_unverified"
 start_rust_node || finish_no_data "rust_process_not_ready"
 verify_process_identity node-rust rust "${RUST_PID}" "${RUST_RPC_ADDR}" "${RUST_P2P_ADDR}" rubin-node-rust || finish_no_data "rust_process_identity_unverified"
-wait_peer_snapshot node-rust "${RUST_RPC_ADDR}" "${RUST_PEERS_JSON}" "${MESH_TIMEOUT}" "${GO_P2P_ADDR}" || finish_no_data "rust_peer_snapshot_missing_go_endpoint"
+wait_peer_snapshot node-rust "${RUST_RPC_ADDR}" "${RUST_PEERS_JSON}" "${MESH_TIMEOUT}" "${GO_P2P_ADDR}" || finish_no_data "${PEER_SNAPSHOT_REASON:-rust_peer_snapshot_missing_go_endpoint}"
 wait_rust_to_go_link rust_to_go_tcp_link_missing rust_to_go_tcp_link_ambiguous
-wait_peer_snapshot node-go "${GO_RPC_ADDR}" "${GO_PEERS_JSON}" "${MESH_TIMEOUT}" "${RUST_TO_GO_LOCAL_ADDR}" || finish_no_data "go_peer_snapshot_missing_rust_endpoint"
+wait_peer_snapshot node-go "${GO_RPC_ADDR}" "${GO_PEERS_JSON}" "${MESH_TIMEOUT}" "${RUST_TO_GO_LOCAL_ADDR}" || finish_no_data "${PEER_SNAPSHOT_REASON:-go_peer_snapshot_missing_rust_endpoint}"
 verify_process_identity node-go-final go "${GO_PID}" "${GO_RPC_ADDR}" "${GO_P2P_ADDR}" rubin-node-go || finish_no_data "go_final_process_identity_unverified"
 verify_process_identity node-rust-final rust "${RUST_PID}" "${RUST_RPC_ADDR}" "${RUST_P2P_ADDR}" rubin-node-rust || finish_no_data "rust_final_process_identity_unverified"
 FINAL_PROCESS_IDENTITY_RECHECKED=true
 wait_rust_to_go_link rust_final_to_go_tcp_link_missing rust_final_to_go_tcp_link_ambiguous
 FINAL_RUST_OUTBOUND_LINK_RECHECKED=true
-wait_peer_snapshot node-rust-final "${RUST_RPC_ADDR}" "${RUST_PEERS_JSON}" "${MESH_TIMEOUT}" "${GO_P2P_ADDR}" || finish_no_data "rust_final_peer_snapshot_missing_go_endpoint"
-wait_peer_snapshot node-go-final "${GO_RPC_ADDR}" "${GO_PEERS_JSON}" "${MESH_TIMEOUT}" "${RUST_TO_GO_LOCAL_ADDR}" || finish_no_data "go_final_peer_snapshot_missing_rust_endpoint"
+wait_peer_snapshot node-rust-final "${RUST_RPC_ADDR}" "${RUST_PEERS_JSON}" "${MESH_TIMEOUT}" "${GO_P2P_ADDR}" || finish_no_data "${PEER_SNAPSHOT_REASON:-rust_final_peer_snapshot_missing_go_endpoint}"
+wait_peer_snapshot node-go-final "${GO_RPC_ADDR}" "${GO_PEERS_JSON}" "${MESH_TIMEOUT}" "${RUST_TO_GO_LOCAL_ADDR}" || finish_no_data "${PEER_SNAPSHOT_REASON:-go_final_peer_snapshot_missing_rust_endpoint}"
 FINAL_PEER_SNAPSHOTS_RECHECKED=true
 PASS_REPORT_JSON="${REPORT_JSON}.pass.tmp"; FINAL_REPORT_JSON="${REPORT_JSON}"; REPORT_JSON="${PASS_REPORT_JSON}"
 write_outputs "PASS"; REPORT_JSON="${FINAL_REPORT_JSON}"

--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -74,10 +74,13 @@ def peers(addr: str) -> dict:
     except Exception as exc:
         fail(f"live peer snapshot failed for {addr}: {exc}")
     return data if isinstance(data, dict) else {}
-def snapshot_exact(snapshot: object, expected: str) -> None:
+def snapshot_norm(snapshot: object) -> list[tuple[str, bool]]:
     count = snapshot.get("count") if isinstance(snapshot, dict) else None
     peers = snapshot.get("peers") if isinstance(snapshot, dict) else None
-    req(count == 1 and isinstance(peers, list) and len(peers) == 1 and peers[0] == {"addr": expected, "handshake_complete": True} and ep(expected), f"peer snapshot is not exact single completed peer {expected}")
+    req(isinstance(count, int) and not isinstance(count, bool) and isinstance(peers, list) and count == len(peers), "peer snapshot count/peers are invalid")
+    norm = sorted((p.get("addr"), p.get("handshake_complete")) for p in peers if isinstance(p, dict) and ep(p.get("addr")) and isinstance(p.get("handshake_complete"), bool))
+    req(len(norm) == len(peers) and len(set(norm)) == len(norm), "peer snapshot entries are malformed or duplicated")
+    return norm
 def ts(value: object) -> bool:
     if not isinstance(value, str) or len(value) != 20 or value[-1] != "Z": return False
     try:
@@ -148,9 +151,9 @@ final = data.get("final_verification")
 req(isinstance(final, dict) and all(final.get(f) is True for f in ("producer_side", "process_identity_rechecked", "rust_outbound_link_rechecked", "peer_snapshots_rechecked")), "PASS report missing producer-side final verification")
 req(final.get("rust_outbound_pid") == nodes_by_impl["rust"]["pid"] and final.get("rust_outbound_local_addr") == go_expected and final.get("rust_outbound_remote_addr") == rust_expected, "final verification is not bound to peer evidence")
 for field, expected_addr in (("go_peer_snapshot", go_expected), ("rust_peer_snapshot", rust_expected)):
-    snapshot_exact(connectivity.get(field), expected_addr)
-snapshot_exact(peers(nodes_by_impl["go"]["rpc_endpoint"]), go_expected)
-snapshot_exact(peers(nodes_by_impl["rust"]["rpc_endpoint"]), rust_expected)
+    stored = snapshot_norm(connectivity.get(field))
+    live = snapshot_norm(peers(nodes_by_impl["go" if field.startswith("go_") else "rust"]["rpc_endpoint"]))
+    req(stored == live and (expected_addr, True) in stored, f"{field} differs from live exact peer set")
 print(f"PASS: mixed-client mesh report accepted {path}")
 PY
 }
@@ -357,7 +360,8 @@ import json, sys
 with open(sys.argv[1], encoding="utf-8") as f:
     data = json.load(f)
 expected, peers, count = sys.argv[2], data.get("peers"), data.get("count")
-ok = count == 1 and isinstance(peers, list) and len(peers) == 1 and peers[0] == {"addr": expected, "handshake_complete": True}
+def ep(v): return isinstance(v, str) and v.count(":") == 1 and v.startswith("127.0.0.1:") and v.rsplit(":", 1)[-1].isdigit() and 1 <= int(v.rsplit(":", 1)[-1]) <= 65535
+ok = isinstance(count, int) and not isinstance(count, bool) and isinstance(peers, list) and count == len(peers) and all(isinstance(p, dict) and ep(p.get("addr")) and isinstance(p.get("handshake_complete"), bool) for p in peers) and any(p.get("addr") == expected and p.get("handshake_complete") is True for p in peers)
 sys.exit(0 if ok else 1)
 PY
     then

--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-
 set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DEV_ENV="${REPO_ROOT}/scripts/dev-env.sh"
@@ -7,7 +6,6 @@ GO_MODULE_ROOT="${REPO_ROOT}/clients/go"
 RUST_WORKSPACE_ROOT="${REPO_ROOT}/clients/rust"
 HELPER="${REPO_ROOT}/scripts/devnet-process-common.sh"
 VALIDATOR="${REPO_ROOT}/scripts/devnet/validate_mixed_client_evidence.py"
-
 CHECK_REPORT="" CHECK_REPORT_MODE=0
 MESH_TIMEOUT="${MESH_TIMEOUT:-90}"
 usage() { echo "usage: $0 [--check-report PATH]" >&2; }
@@ -36,7 +34,7 @@ check_report() {
   local report="${1:-}"
   [[ -n "${report}" ]] || { echo "FAIL: report path is required" >&2; return 1; }
   python3 - "${report}" <<'PY'
-import datetime as dt, json, sys
+import datetime as dt, json, shlex, sys
 from pathlib import Path
 path = Path(sys.argv[1])
 def fail(message: str) -> None:
@@ -51,6 +49,10 @@ def ep(value: object) -> bool:
     return sep == ":" and host == "127.0.0.1" and ":" not in port and port.isascii() and port.isdigit() and 1 <= int(port) <= 65535
 def nonempty_str(value: object) -> bool:
     return isinstance(value, str) and bool(value.strip())
+def argv0(value: object) -> str:
+    if not nonempty_str(value): return ""
+    try: return shlex.split(value)[0]
+    except ValueError: return ""
 def ts(value: object) -> bool:
     if not isinstance(value, str) or len(value) != 20 or value[-1] != "Z":
         return False
@@ -73,14 +75,17 @@ legacy_schema = data.get("legacy_schema_compatibility")
 req(isinstance(legacy_schema, dict) and legacy_schema.get("authoritative") is False and "verdict" not in legacy_schema and nonempty_str(legacy_schema.get("marker_path")), "legacy_schema_compatibility missing marker_path")
 nodes = data.get("nodes")
 req(isinstance(nodes, list) and len(nodes) == 2 and all(isinstance(n, dict) for n in nodes), "PASS report requires exactly two node records")
-expected_comm = {"go": "rubin-node-go", "rust": "rubin-node-rust"}
+expected = {"go": ("node-go", "rubin-node-go"), "rust": ("node-rust", "rubin-node-rust")}
 for node in nodes:
     impl = node.get("implementation")
     name = node.get("name")
-    req(isinstance(impl, str) and impl in expected_comm, f"node has invalid implementation: {impl!r}")
-    req(isinstance(name, str) and name.startswith("node-"), f"node has invalid name: {name!r}")
-    req(node.get("process_comm") == expected_comm.get(impl), f"{name} process_comm does not prove {impl} identity")
-    req(all(nonempty_str(node.get(field)) for field in ("command", "binary")), f"{name} missing command or binary")
+    req(isinstance(impl, str) and impl in expected, f"node has invalid implementation: {impl!r}")
+    expected_name, expected_bin = expected[impl]
+    req(name == expected_name, f"{impl} node has invalid name: {name!r}")
+    command, binary, command_argv0 = node.get("command"), node.get("binary"), argv0(node.get("command"))
+    req(node.get("process_comm") == expected_bin, f"{name} process_comm does not prove {impl} identity")
+    req(nonempty_str(command) and nonempty_str(binary) and Path(binary).is_absolute(), f"{name} missing absolute command or binary")
+    req(command_argv0 == binary and Path(binary).name == expected_bin, f"{name} command/binary is not bound to {expected_bin}")
     req(ep(node.get("rpc_endpoint")) and ep(node.get("p2p_endpoint")) and ts(node.get("started_at")), f"{name} has malformed endpoint or timestamp")
     req(isinstance(node.get("pid"), int) and not isinstance(node.get("pid"), bool) and node["pid"] > 0, f"{name} pid is not a positive integer")
     for field in ("process_alive", "rpc_endpoint_process_backed", "p2p_endpoint_process_backed"):
@@ -88,6 +93,8 @@ for node in nodes:
 impls = {n["implementation"] for n in nodes}
 req(impls == {"go", "rust"}, f"PASS report requires one go and one rust node, got {sorted(impls)}")
 nodes_by_impl = {node["implementation"]: node for node in nodes}
+req(nodes_by_impl["go"]["pid"] != nodes_by_impl["rust"]["pid"], "go/rust process evidence uses the same pid")
+req(nodes_by_impl["go"]["binary"] != nodes_by_impl["rust"]["binary"] and nodes_by_impl["go"]["command"] != nodes_by_impl["rust"]["command"], "go/rust process evidence is not implementation-distinct")
 connectivity = data.get("peer_connectivity")
 req(isinstance(connectivity, dict), "PASS report missing peer_connectivity object")
 req(all(connectivity.get(f) is True for f in ("go_to_rust", "rust_to_go", "bidirectional_observed")), "peer_connectivity booleans are not all true")
@@ -251,7 +258,6 @@ PY
   cp -- "${cargo_bin}" "${RUST_NODE_BIN}" || return 1
   [[ -x "${RUST_NODE_BIN}" ]]
 }
-
 write_outputs() {
   local verdict="$1" reason="${2:-}"
   export REPORT_JSON LEGACY_SCHEMA_MARKER_JSON verdict reason GO_PID RUST_PID GO_RPC_ADDR RUST_RPC_ADDR \
@@ -272,7 +278,6 @@ def read_json(path: str) -> dict:
             return json.load(f)
     except (OSError, json.JSONDecodeError):
         return {"count": 0, "peers": []}
-
 nodes = []
 for impl, name, pid_key, rpc_key, p2p_key, started_key, comm_key, bin_key, cmd_key in (
     ("go", "node-go", "GO_PID", "GO_RPC_ADDR", "GO_P2P_ADDR", "GO_STARTED_AT_UTC", "GO_COMM", "GO_NODE_BIN", "GO_CMD"),
@@ -295,7 +300,6 @@ for impl, name, pid_key, rpc_key, p2p_key, started_key, comm_key, bin_key, cmd_k
         "p2p_endpoint_process_backed": verdict == "PASS" and e.get(f"{prefix}_P2P_PROCESS_BACKED") == "true",
     }
     nodes.append(node)
-
 go_snapshot, rust_snapshot = read_json(e["GO_PEERS_JSON"]), read_json(e["RUST_PEERS_JSON"])
 report = {
     "scenario": "mixed_client_mesh",
@@ -323,7 +327,6 @@ if verdict != "PASS":
 with open(e["REPORT_JSON"], "w", encoding="utf-8") as f:
     json.dump(report, f, indent=2, sort_keys=True)
     f.write("\n")
-
 legacy_marker_reason = reason if verdict != "PASS" and reason else (
     "mixed-client mesh process/connectivity PASS is recorded in sibling report; "
     "existing schema v1 PASS requires tx_path proof owned by RUB-22/RUB-23"
@@ -416,7 +419,6 @@ start_go_node() {
   exit 2
 }
 command -v lsof >/dev/null 2>&1 || finish_no_data "lsof_unavailable"
-
 build_go_node || finish_no_data "go_build_failed"
 build_rust_node || finish_no_data "rust_build_failed"
 start_go_node || finish_no_data "go_process_not_ready"

--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -51,7 +51,15 @@ def ep(value: object) -> bool:
 def nonempty_str(value: object) -> bool: return isinstance(value, str) and bool(value.strip())
 def ps_comm(pid: int) -> str: return os.path.basename(run(["ps", "-ww", "-p", str(pid), "-o", "comm="]))
 def lsof_lines(pid: int, state: str) -> list[str]:
-    p = subprocess.run(["lsof", "-nP", "-a", "-p", str(pid), "-iTCP", f"-sTCP:{state}", "-Fn"], check=False, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=5); req(p.returncode == 0 or not (p.stdout.strip() or p.stderr.strip()), "lsof_failed")
+    try:
+        p = subprocess.run(["lsof", "-nP", "-a", "-p", str(pid), "-iTCP", f"-sTCP:{state}", "-Fn"], check=False, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=5)
+    except FileNotFoundError:
+        fail("lsof_unavailable")
+    except subprocess.TimeoutExpired:
+        fail("lsof_timeout")
+    except OSError as exc:
+        fail(f"lsof_failed: {exc}")
+    req(p.returncode == 0 or not (p.stdout.strip() or p.stderr.strip()), "lsof_failed")
     if p.returncode != 0: return []
     return [line[1:] for line in p.stdout.splitlines() if line.startswith("n")]
 def owns_listen(pid: int, endpoint: str) -> bool: return endpoint in lsof_lines(pid, "LISTEN")
@@ -148,7 +156,8 @@ for field, expected_addr in (("go_peer_snapshot", go_expected), ("rust_peer_snap
     if live:
         fresh = snapshot_norm(peers(nodes_by_impl["go" if field.startswith("go_") else "rust"]["rpc_endpoint"]))
         req(stored == fresh, f"{field} differs from live exact peer set")
-print(f"PASS: mixed-client mesh report {'accepted' if live else 'structure accepted'} {path}")
+if not live: fail("offline check cannot prove PASS; use --check-report-live")
+print(f"PASS: mixed-client mesh report accepted {path}")
 PY
 }
 if [[ -n "${CHECK_REPORT_MODE}" ]]; then need_tool python3; check_report "${CHECK_REPORT}" "${CHECK_REPORT_MODE}"; exit 0; fi

--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -7,12 +7,13 @@ CHECK_REPORT="" CHECK_REPORT_MODE="" MESH_TIMEOUT="${MESH_TIMEOUT:-90}"
 usage() { echo "usage: $0 [--check-report PATH|--check-report-live PATH]" >&2; }
 while (($#)); do case "$1" in --check-report|--check-report-live) [[ $# -ge 2 ]] || { usage; exit 2; }; CHECK_REPORT_MODE=offline; [[ "$1" == "--check-report-live" ]] && CHECK_REPORT_MODE=live; CHECK_REPORT="$2"; shift 2 ;; -h|--help) usage; exit 0 ;; *) usage; exit 2 ;; esac; done
 need_tool() { command -v -- "$1" >/dev/null 2>&1 || { echo "$1 is required for mixed-client mesh evidence" >&2; exit 1; }; }
+validator_python() { local py; for py in "${RUBIN_VALIDATOR_PYTHON:-}" python3 /opt/homebrew/bin/python3 /usr/local/bin/python3 "${HOME}/.local/bin/python3"; do [[ -n "${py}" ]] || continue; command -v -- "${py}" >/dev/null 2>&1 || continue; "${py}" -c 'import jsonschema' >/dev/null 2>&1 && { printf '%s\n' "${py}"; return 0; }; done; return 1; }
 check_report() { local report="${1:-}" mode="${2:-offline}"
   [[ -n "${report}" ]] || { echo "FAIL: report path is required" >&2; return 1; }
-  python3 - "${report}" "${DEV_ENV}" "${VALIDATOR}" "${mode}" <<'PY'
+  python3 - "${report}" "${VALIDATOR}" "${mode}" "$(validator_python || true)" <<'PY'
 import datetime as dt, json, os, socket, struct, subprocess, sys, time, urllib.error, urllib.request
 from pathlib import Path
-path = Path(sys.argv[1]); live = sys.argv[4] == "live"
+path = Path(sys.argv[1]); live = sys.argv[3] == "live"; validator_py = sys.argv[4]
 try: LIVE_TIMEOUT = max(1, min(600, int(os.environ.get("MESH_TIMEOUT", "10"))))
 except ValueError: LIVE_TIMEOUT = 10
 def fail(message: str) -> None: print(f"FAIL: {message}", file=sys.stderr); sys.exit(1)
@@ -117,7 +118,8 @@ try:
 except (OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
     fail(f"legacy marker is not readable JSON: {exc}")
 req(isinstance(marker, dict) and marker.get("scenario") == "mixed_client_mesh_schema_marker" and marker.get("verdict") == "FAIL" and marker.get("evidence_type") == "mixed_client_process_soak", "legacy marker has wrong non-authoritative FAIL shape")
-try: validator = subprocess.run(["python3", sys.argv[3], str(marker_path)], check=False, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=30)
+req(bool(validator_py), "validator_unavailable: python jsonschema unavailable")
+try: validator = subprocess.run([validator_py, sys.argv[2], str(marker_path)], check=False, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=30)
 except (OSError, subprocess.TimeoutExpired) as exc: fail(f"legacy marker schema validation failed: {exc}")
 req(validator.returncode == 0, "legacy marker schema validation failed: " + ((validator.stderr or validator.stdout).strip().splitlines() or ["validator returned nonzero"])[0])
 nodes = data.get("nodes")
@@ -183,7 +185,7 @@ GO_PEERS_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/go-peers.json"; RUST_PEERS_JSON="$
 GO_PID="" RUST_PID="" GO_RPC_ADDR="" RUST_RPC_ADDR="" GO_P2P_ADDR="" RUST_P2P_ADDR="" GO_STARTED_AT_UTC="" RUST_STARTED_AT_UTC="" GO_COMM="" RUST_COMM="" RUST_TO_GO_LOCAL_ADDR="" GO_CMD="" RUST_CMD="" GO_ARGV_JSON="" RUST_ARGV_JSON="" FINAL_PROCESS_IDENTITY_RECHECKED="" FINAL_RUST_OUTBOUND_LINK_RECHECKED="" FINAL_PEER_SNAPSHOTS_RECHECKED=""
 mkdir -p -- "${GO_DIR}" "${RUST_DIR}"
 run_fips_preflight_before_captured_dev_env() { [[ "${RUBIN_OPENSSL_FIPS_MODE:-off}" != "only" || "${RUBIN_OPENSSL_SKIP_FIPS_GUARD:-0}" == "1" ]] && return 0; echo "Running FIPS-only preflight before captured dev-env command streams" >&2; "${DEV_ENV}" -- "${REPO_ROOT}/scripts/crypto/openssl/fips-preflight.sh" >&2; }
-run_validator() { python3 "${VALIDATOR}" "$@"; }
+run_validator() { local py; py="$(validator_python)" || { echo "validator_unavailable: python jsonschema unavailable" >&2; return 1; }; "${py}" "${VALIDATOR}" "$@"; }
 bounded() { perl -e 'alarm shift @ARGV; exec @ARGV' 5 "$@"; }
 argv_cmd() { local out="" arg q; for arg; do printf -v q "%q" "$arg"; out+="${out:+ }${q}"; done; printf '%s\n' "${out}"; }; argv_json() { python3 -c 'import json,sys; print(json.dumps(sys.argv[1:]))' "$@"; }
 rpc_json() {
@@ -367,6 +369,8 @@ wait_peer_snapshot() {
 import json, sys
 with open(sys.argv[1], encoding="utf-8") as f:
     data = json.load(f)
+if not isinstance(data, dict):
+    sys.exit(4)
 expected, peers, count = sys.argv[2], data.get("peers"), data.get("count")
 def ep(v): return isinstance(v, str) and v.count(":") == 1 and v.startswith("127.0.0.1:") and (p := v.rsplit(":", 1)[-1]).isdigit() and 1 <= len(p) <= 5 and 1 <= int(p) <= 65535
 shape = isinstance(count, int) and not isinstance(count, bool) and isinstance(peers, list) and count == len(peers) and all(isinstance(p, dict) and ep(p.get("addr")) and isinstance(p.get("handshake_complete"), bool) for p in peers) and len({p.get("addr") for p in peers}) == len(peers)
@@ -440,7 +444,7 @@ FINAL_RUST_OUTBOUND_LINK_RECHECKED=true
 wait_peer_snapshot node-rust-final "${RUST_RPC_ADDR}" "${RUST_PEERS_JSON}" "${MESH_TIMEOUT}" "${GO_P2P_ADDR}" || finish_no_data "${PEER_SNAPSHOT_REASON:-rust_final_peer_snapshot_missing_go_endpoint}"
 wait_peer_snapshot node-go-final "${GO_RPC_ADDR}" "${GO_PEERS_JSON}" "${MESH_TIMEOUT}" "${RUST_TO_GO_LOCAL_ADDR}" || finish_no_data "${PEER_SNAPSHOT_REASON:-go_final_peer_snapshot_missing_rust_endpoint}"
 FINAL_PEER_SNAPSHOTS_RECHECKED=true
-PASS_REPORT_JSON="${REPORT_JSON}.pass.tmp"; FINAL_REPORT_JSON="${REPORT_JSON}"; REPORT_JSON="${PASS_REPORT_JSON}"
+PASS_REPORT_JSON="$(mktemp "/tmp/mixed-client-mesh-pass.XXXXXX")" || finish_no_data "pass_report_temp_failed"; FINAL_REPORT_JSON="${REPORT_JSON}"; REPORT_JSON="${PASS_REPORT_JSON}"
 write_outputs "PASS" || { REPORT_JSON="${FINAL_REPORT_JSON}"; finish_no_data "pass_report_write_failed"; }; REPORT_JSON="${FINAL_REPORT_JSON}"
 if run_validator "${LEGACY_SCHEMA_MARKER_JSON}" >&2 && check_report "${PASS_REPORT_JSON}" live >&2; then
   mv -- "${PASS_REPORT_JSON}" "${REPORT_JSON}" || finish_no_data "pass_report_publish_failed"

--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -34,28 +34,54 @@ check_report() {
   local report="${1:-}"
   [[ -n "${report}" ]] || { echo "FAIL: report path is required" >&2; return 1; }
   python3 - "${report}" <<'PY'
-import datetime as dt, json, shlex, sys
+import datetime as dt, json, os, shlex, subprocess, sys, urllib.request
 from pathlib import Path
 path = Path(sys.argv[1])
-def fail(message: str) -> None:
-    print(f"FAIL: {message}", file=sys.stderr)
-    sys.exit(1)
+def fail(message: str) -> None: print(f"FAIL: {message}", file=sys.stderr); sys.exit(1)
 def req(ok: bool, message: str) -> None:
     if not ok: fail(message)
+def run(argv: list[str]) -> str:
+    try:
+        p = subprocess.run(argv, check=False, text=True, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, timeout=5)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        fail(f"live check failed for {argv[0]}: {exc}")
+    req(p.returncode == 0 and p.stdout.strip(), f"live check failed: {' '.join(argv)}")
+    return p.stdout.strip().splitlines()[0]
+def checked_path(label: str, value: object) -> Path:
+    req(isinstance(value, str) and value.strip() == value and value and value[0] not in "'\"" and value[-1] not in "'\"", f"{label} is not an unquoted path string")
+    p = Path(value)
+    req(p.is_absolute(), f"{label} is not absolute")
+    return p
 def ep(value: object) -> bool:
-    if not isinstance(value, str):
-        return False
+    if not isinstance(value, str): return False
     host, sep, port = value.partition(":")
     return sep == ":" and host == "127.0.0.1" and ":" not in port and port.isascii() and port.isdigit() and 1 <= int(port) <= 65535
-def nonempty_str(value: object) -> bool:
-    return isinstance(value, str) and bool(value.strip())
+def nonempty_str(value: object) -> bool: return isinstance(value, str) and bool(value.strip())
 def argv0(value: object) -> str:
     if not nonempty_str(value): return ""
     try: return shlex.split(value)[0]
     except ValueError: return ""
+def ps_comm(pid: int) -> str: return os.path.basename(run(["ps", "-p", str(pid), "-o", "comm="]))
+def ps_argv0(pid: int) -> str: return argv0(run(["ps", "-p", str(pid), "-o", "command="]))
+def lsof_lines(pid: int, state: str) -> list[str]:
+    p = subprocess.run(["lsof", "-nP", "-a", "-p", str(pid), "-iTCP", f"-sTCP:{state}", "-Fn"], check=False, text=True, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, timeout=5)
+    return [line[1:] for line in p.stdout.splitlines() if line.startswith("n")]
+def owns_listen(pid: int, endpoint: str) -> bool: return endpoint in lsof_lines(pid, "LISTEN")
+def peers(addr: str) -> dict:
+    try:
+        with urllib.request.urlopen(f"http://{addr}/peers", timeout=5) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+    except Exception as exc:
+        fail(f"live peer snapshot failed for {addr}: {exc}")
+    return data if isinstance(data, dict) else {}
+def snapshot_has(snapshot: object, expected: str) -> int:
+    count = snapshot.get("count") if isinstance(snapshot, dict) else None
+    peers = snapshot.get("peers") if isinstance(snapshot, dict) else None
+    req(isinstance(count, int) and not isinstance(count, bool) and isinstance(peers, list) and count == len(peers), "peer snapshot count/peers are invalid")
+    req(any(isinstance(p, dict) and p.get("addr") == expected and p.get("handshake_complete") is True for p in peers), f"peer snapshot lacks completed handshake for {expected}")
+    return count
 def ts(value: object) -> bool:
-    if not isinstance(value, str) or len(value) != 20 or value[-1] != "Z":
-        return False
+    if not isinstance(value, str) or len(value) != 20 or value[-1] != "Z": return False
     try:
         return dt.datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").strftime("%Y-%m-%dT%H:%M:%SZ") == value
     except ValueError:
@@ -71,8 +97,18 @@ req(isinstance(data, dict), "report root is not an object")
 req(data.get("scenario") == "mixed_client_mesh", f"scenario is not mixed_client_mesh: {data.get('scenario')!r}")
 req(data.get("verdict") == "PASS", f"report verdict is not PASS: {data.get('verdict')!r}")
 req("failure_reason" not in data and "schema_marker" not in data, "PASS report must not carry failure/schema-marker verdict fields")
+artifact_root = checked_path("artifact_root", data.get("artifact_root")).resolve()
 legacy_schema = data.get("legacy_schema_compatibility")
 req(isinstance(legacy_schema, dict) and legacy_schema.get("authoritative") is False and "verdict" not in legacy_schema and nonempty_str(legacy_schema.get("marker_path")), "legacy_schema_compatibility missing marker_path")
+marker_path = checked_path("legacy_schema_compatibility.marker_path", legacy_schema.get("marker_path")).resolve()
+try: marker_path.relative_to(artifact_root)
+except ValueError: fail("legacy marker is outside artifact_root")
+req(marker_path.is_file() and marker_path.stat().st_size > 0, "legacy marker is missing, unreadable, or empty")
+try:
+    with marker_path.open(encoding="utf-8") as f: marker = json.load(f)
+except (OSError, json.JSONDecodeError) as exc:
+    fail(f"legacy marker is not readable JSON: {exc}")
+req(isinstance(marker, dict) and marker.get("scenario") == "mixed_client_mesh_schema_marker" and marker.get("verdict") == "FAIL" and marker.get("evidence_type") == "mixed_client_process_soak", "legacy marker has wrong non-authoritative FAIL shape")
 nodes = data.get("nodes")
 req(isinstance(nodes, list) and len(nodes) == 2 and all(isinstance(n, dict) for n in nodes), "PASS report requires exactly two node records")
 expected = {"go": ("node-go", "rubin-node-go"), "rust": ("node-rust", "rubin-node-rust")}
@@ -83,11 +119,15 @@ for node in nodes:
     expected_name, expected_bin = expected[impl]
     req(name == expected_name, f"{impl} node has invalid name: {name!r}")
     command, binary, command_argv0 = node.get("command"), node.get("binary"), argv0(node.get("command"))
+    binary_path = checked_path(f"{name}.binary", binary).resolve()
+    try: binary_path.relative_to(artifact_root)
+    except ValueError: fail(f"{name} binary is outside artifact_root")
     req(node.get("process_comm") == expected_bin, f"{name} process_comm does not prove {impl} identity")
-    req(nonempty_str(command) and nonempty_str(binary) and Path(binary).is_absolute(), f"{name} missing absolute command or binary")
-    req(command_argv0 == binary and Path(binary).name == expected_bin, f"{name} command/binary is not bound to {expected_bin}")
+    req(nonempty_str(command) and Path(command_argv0).is_absolute() and Path(command_argv0).resolve() == binary_path and binary_path.name == expected_bin and binary_path.is_file() and os.access(binary_path, os.X_OK), f"{name} command/binary is not bound to executable {expected_bin}")
     req(ep(node.get("rpc_endpoint")) and ep(node.get("p2p_endpoint")) and ts(node.get("started_at")), f"{name} has malformed endpoint or timestamp")
     req(isinstance(node.get("pid"), int) and not isinstance(node.get("pid"), bool) and node["pid"] > 0, f"{name} pid is not a positive integer")
+    req(ps_comm(node["pid"]) == expected_bin and Path(ps_argv0(node["pid"])).resolve() == binary_path, f"{name} live process identity does not match report")
+    req(owns_listen(node["pid"], node["rpc_endpoint"]) and owns_listen(node["pid"], node["p2p_endpoint"]), f"{name} live listeners are not pid-owned")
     for field in ("process_alive", "rpc_endpoint_process_backed", "p2p_endpoint_process_backed"):
         req(node.get(field) is True, f"{name} does not prove {field}")
 impls = {n["implementation"] for n in nodes}
@@ -105,21 +145,20 @@ rust_expected = links.get("rust_peer_snapshot_expected_addr")
 req(all(ep(links.get(f)) for f in ("go_peer_snapshot_expected_addr", "rust_peer_snapshot_expected_addr", "rust_outbound_local_addr", "rust_outbound_remote_addr")), "counterpart link endpoint is malformed")
 req(rust_expected == nodes_by_impl["go"]["p2p_endpoint"] and links.get("rust_outbound_remote_addr") == rust_expected and links.get("rust_outbound_local_addr") == go_expected and links.get("rust_outbound_pid") == nodes_by_impl["rust"]["pid"], "peer evidence is not bound to expected counterpart endpoints")
 req(isinstance(go_expected, str) and go_expected not in {rust_expected, nodes_by_impl["rust"]["p2p_endpoint"], nodes_by_impl["go"]["rpc_endpoint"], nodes_by_impl["rust"]["rpc_endpoint"]}, "go peer evidence is not a rust outbound peer address")
+req(f"{go_expected}->{rust_expected}" in lsof_lines(nodes_by_impl["rust"]["pid"], "ESTABLISHED"), "rust outbound TCP link is not live and rust-owned")
 final = data.get("final_verification")
 req(isinstance(final, dict) and all(final.get(f) is True for f in ("producer_side", "process_identity_rechecked", "rust_outbound_link_rechecked", "peer_snapshots_rechecked")), "PASS report missing producer-side final verification")
 req(final.get("rust_outbound_pid") == nodes_by_impl["rust"]["pid"] and final.get("rust_outbound_local_addr") == go_expected and final.get("rust_outbound_remote_addr") == rust_expected, "final verification is not bound to peer evidence")
 for field, expected_addr in (("go_peer_snapshot", go_expected), ("rust_peer_snapshot", rust_expected)):
     snapshot = connectivity.get(field)
-    count = snapshot.get("count") if isinstance(snapshot, dict) else None
-    req(isinstance(snapshot, dict) and isinstance(count, int) and not isinstance(count, bool) and count >= 1, f"{field} must show at least one peer")
-    peers = snapshot.get("peers")
-    req(isinstance(peers, list) and peers and count == len(peers), f"{field}.peers/count are internally inconsistent")
-    req(all(isinstance(p, dict) and ep(p.get("addr")) and isinstance(p.get("handshake_complete"), bool) for p in peers), f"{field}.peers contain malformed entries")
-    req(any(p.get("addr") == expected_addr and p.get("handshake_complete") is True for p in peers if isinstance(p, dict)), f"{field} lacks completed handshake for expected counterpart")
+    count = snapshot_has(snapshot, expected_addr)
+    req(count >= 1 and all(isinstance(p, dict) and ep(p.get("addr")) and isinstance(p.get("handshake_complete"), bool) for p in snapshot["peers"]), f"{field}.peers contain malformed entries")
+req(snapshot_has(peers(nodes_by_impl["go"]["rpc_endpoint"]), go_expected) == connectivity["go_peer_snapshot"]["count"], "live go peer snapshot differs from report")
+req(snapshot_has(peers(nodes_by_impl["rust"]["rpc_endpoint"]), rust_expected) == connectivity["rust_peer_snapshot"]["count"], "live rust peer snapshot differs from report")
 print(f"PASS: mixed-client mesh report accepted {path}")
 PY
 }
-if [[ "${CHECK_REPORT_MODE}" == "1" ]]; then need_tool python3; check_report "${CHECK_REPORT}"; exit 0; fi
+if [[ "${CHECK_REPORT_MODE}" == "1" ]]; then need_tool python3; need_tool lsof; check_report "${CHECK_REPORT}"; exit 0; fi
 need_tool python3
 need_tool perl
 [[ -x "${DEV_ENV}" ]] || { echo "dev-env wrapper missing or non-executable: ${DEV_ENV}" >&2; exit 1; }
@@ -146,15 +185,11 @@ run_validator() { RUBIN_OPENSSL_SKIP_FIPS_GUARD=1 "${DEV_ENV}" -- python3 "${VAL
 rpc_json() {
   local method="$1" addr="$2" path="$3"
   python3 - "${method}" "${addr}" "${path}" <<'PY'
-import socket
-import sys
-import urllib.error
-import urllib.request
+import socket, sys, urllib.error, urllib.request
 method, addr, path = sys.argv[1:4]
 req = urllib.request.Request(f"http://{addr}{path}", method=method)
 try:
-    with urllib.request.urlopen(req, timeout=5) as resp:
-        print(resp.read().decode("utf-8"), end="")
+    with urllib.request.urlopen(req, timeout=5) as resp: print(resp.read().decode("utf-8"), end="")
 except urllib.error.HTTPError as exc:
     print(exc.read().decode("utf-8"), end="")
     sys.exit(22)
@@ -165,9 +200,7 @@ PY
 }
 pid_comm() {
   local pid="$1" comm
-  comm="$(ps -p "${pid}" -o comm= 2>/dev/null | awk 'NR==1 {print $1}')" || return 1
-  [[ -n "${comm}" ]] || return 1
-  basename -- "${comm}"
+  comm="$(ps -p "${pid}" -o comm= 2>/dev/null | awk 'NR==1 {print $1}')" || return 1; [[ -n "${comm}" ]] || return 1; basename -- "${comm}"
 }
 pid_listens_on() {
   local pid="$1" endpoint="$2" out status=0
@@ -179,33 +212,14 @@ pid_listens_on() {
 p2p_addr_for_pid() {
   local pid="$1" rpc_addr="$2" timeout="$3"
   python3 - "${pid}" "${rpc_addr}" "${timeout}" <<'PY'
-import re
-import subprocess
-import sys
-import time
+import re, subprocess, sys, time
 pid, rpc_addr, timeout = sys.argv[1], sys.argv[2], int(sys.argv[3])
 deadline = time.time() + timeout
 while time.time() < deadline:
-    proc = subprocess.run(
-        ["lsof", "-nP", "-a", "-p", pid, "-iTCP", "-sTCP:LISTEN", "-Fn"],
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.DEVNULL,
-    )
-    addrs = sorted(
-        {
-            line[1:].strip()
-            for line in proc.stdout.splitlines()
-            if line.startswith("n")
-            and line[1:].strip() != rpc_addr
-            and re.fullmatch(r"127\.0\.0\.1:[0-9]+", line[1:].strip())
-        }
-    )
-    if len(addrs) == 1:
-        print(addrs[0])
-        sys.exit(0)
-    if len(addrs) > 1:
-        sys.exit(f"ambiguous p2p listen addresses for pid={pid}: {addrs}")
+    proc = subprocess.run(["lsof", "-nP", "-a", "-p", pid, "-iTCP", "-sTCP:LISTEN", "-Fn"], text=True, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+    addrs = sorted({line[1:].strip() for line in proc.stdout.splitlines() if line.startswith("n") and line[1:].strip() != rpc_addr and re.fullmatch(r"127\.0\.0\.1:[0-9]+", line[1:].strip())})
+    if len(addrs) == 1: print(addrs[0]); sys.exit(0)
+    if len(addrs) > 1: sys.exit(f"ambiguous p2p listen addresses for pid={pid}: {addrs}")
     time.sleep(1)
 sys.exit(f"timeout resolving p2p listen address for pid={pid}")
 PY
@@ -226,31 +240,20 @@ build_rust_node() {
   [[ -n "${host_triple}" ]] || return 1
   cargo_target_dir="${RUBIN_PROCESS_ARTIFACT_ROOT}/cargo-target"
   cargo_log="${RUBIN_PROCESS_ARTIFACT_ROOT}/cargo-build.jsonl"
-  RUBIN_OPENSSL_SKIP_FIPS_GUARD=1 "${DEV_ENV}" -- cargo build \
-    --manifest-path "${RUST_WORKSPACE_ROOT}/Cargo.toml" \
-    --release --locked -p rubin-node \
-    --target "${host_triple}" \
-    --target-dir "${cargo_target_dir}" \
-    --message-format=json-render-diagnostics >"${cargo_log}" || return 1
+  RUBIN_OPENSSL_SKIP_FIPS_GUARD=1 "${DEV_ENV}" -- cargo build --manifest-path "${RUST_WORKSPACE_ROOT}/Cargo.toml" --release --locked -p rubin-node --target "${host_triple}" --target-dir "${cargo_target_dir}" --message-format=json-render-diagnostics >"${cargo_log}" || return 1
   cargo_bin="$(python3 - "${cargo_log}" <<'PY'
-import json
-import sys
+import json, sys
 selected = None
 with open(sys.argv[1], encoding="utf-8") as f:
     for raw in f:
         line = raw.strip()
-        if not line:
-            continue
-        if not line.startswith("{"):
-            sys.exit(f"cargo build log contamination: {line[:160]!r}")
+        if not line: continue
+        if not line.startswith("{"): sys.exit(f"cargo build log contamination: {line[:160]!r}")
         ev = json.loads(line)
-        if ev.get("reason") != "compiler-artifact":
-            continue
+        if ev.get("reason") != "compiler-artifact": continue
         target = ev.get("target") or {}
-        if target.get("name") == "rubin-node" and "bin" in (target.get("kind") or []) and ev.get("executable"):
-            selected = ev["executable"]
-if selected is None:
-    sys.exit("no rubin-node executable artifact in cargo JSON stream")
+        if target.get("name") == "rubin-node" and "bin" in (target.get("kind") or []) and ev.get("executable"): selected = ev["executable"]
+if selected is None: sys.exit("no rubin-node executable artifact in cargo JSON stream")
 print(selected)
 PY
 )" || return 1
@@ -267,8 +270,7 @@ write_outputs() {
     RUST_TO_GO_LOCAL_ADDR FINAL_PROCESS_IDENTITY_RECHECKED FINAL_RUST_OUTBOUND_LINK_RECHECKED FINAL_PEER_SNAPSHOTS_RECHECKED \
     RUBIN_PROCESS_ARTIFACT_ROOT
   python3 - <<'PY'
-import json
-import os
+import json, os
 e = os.environ
 verdict = e["verdict"]
 reason = (e.get("reason") or "").strip()

--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -130,6 +130,8 @@ req(impls == {"go", "rust"}, f"PASS report requires one go and one rust node, go
 nodes_by_impl = {node["implementation"]: node for node in nodes}
 req(nodes_by_impl["go"]["pid"] != nodes_by_impl["rust"]["pid"], "go/rust process evidence uses the same pid")
 req(nodes_by_impl["go"]["binary"] != nodes_by_impl["rust"]["binary"] and nodes_by_impl["go"]["command"] != nodes_by_impl["rust"]["command"] and nodes_by_impl["go"].get("command_argv") != nodes_by_impl["rust"].get("command_argv"), "go/rust process evidence is not implementation-distinct")
+endpoints = [nodes_by_impl[i][f] for i in ("go", "rust") for f in ("rpc_endpoint", "p2p_endpoint")]
+req(len(set(endpoints)) == 4, "node rpc/p2p endpoints are not pairwise distinct")
 connectivity = data.get("peer_connectivity")
 req(isinstance(connectivity, dict), "PASS report missing peer_connectivity object")
 req(all(connectivity.get(f) is True for f in ("go_to_rust", "rust_to_go", "bidirectional_observed")), "peer_connectivity booleans are not all true")

--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -166,8 +166,7 @@ for field, expected_addr in (("go_peer_snapshot", go_expected), ("rust_peer_snap
     if live:
         endpoint = nodes_by_impl["go" if field.startswith("go_") else "rust"]["rpc_endpoint"]
         eventually(lambda endpoint=endpoint, stored=stored, expected_addr=expected_addr: (fresh := peers(endpoint)) is not None and stored == snapshot_norm(fresh, expected_addr), f"{field} differs from live exact peer set")
-if not live: fail("offline check cannot prove PASS; use --check-report-live")
-print(f"PASS: mixed-client mesh report accepted {path}")
+print(f"PASS: mixed-client mesh report {'accepted' if live else 'structurally accepted'} {path}" + ("" if live else "; live proof not checked"))
 PY
 }
 if [[ -n "${CHECK_REPORT_MODE}" ]]; then need_tool python3; check_report "${CHECK_REPORT}" "${CHECK_REPORT_MODE}"; exit 0; fi

--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -6,15 +6,13 @@ GO_MODULE_ROOT="${REPO_ROOT}/clients/go"
 RUST_WORKSPACE_ROOT="${REPO_ROOT}/clients/rust"
 HELPER="${REPO_ROOT}/scripts/devnet-process-common.sh"
 VALIDATOR="${REPO_ROOT}/scripts/devnet/validate_mixed_client_evidence.py"
-CHECK_REPORT="" CHECK_REPORT_MODE=0 MESH_TIMEOUT="${MESH_TIMEOUT:-90}"
-usage() { echo "usage: $0 [--check-report PATH]" >&2; }
+CHECK_REPORT="" CHECK_REPORT_MODE="" MESH_TIMEOUT="${MESH_TIMEOUT:-90}"
+usage() { echo "usage: $0 [--check-report PATH|--check-report-live PATH]" >&2; }
 while (($#)); do
   case "$1" in
-    --check-report)
+    --check-report|--check-report-live)
       [[ $# -ge 2 ]] || { usage; exit 2; }
-      CHECK_REPORT_MODE=1
-      CHECK_REPORT="$2"
-      shift 2
+      CHECK_REPORT_MODE=offline; [[ "$1" == "--check-report-live" ]] && CHECK_REPORT_MODE=live; CHECK_REPORT="$2"; shift 2
       ;;
     -h|--help)
       usage
@@ -56,7 +54,8 @@ def ep(value: object) -> bool:
 def nonempty_str(value: object) -> bool: return isinstance(value, str) and bool(value.strip())
 def ps_comm(pid: int) -> str: return os.path.basename(run(["ps", "-ww", "-p", str(pid), "-o", "comm="]))
 def lsof_lines(pid: int, state: str) -> list[str]:
-    p = subprocess.run(["lsof", "-nP", "-a", "-p", str(pid), "-iTCP", f"-sTCP:{state}", "-Fn"], check=False, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=5); req(p.returncode == 0 or not p.stderr.strip(), "lsof_failed")
+    p = subprocess.run(["lsof", "-nP", "-a", "-p", str(pid), "-iTCP", f"-sTCP:{state}", "-Fn"], check=False, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=5); req(p.returncode == 0 or not (p.stdout.strip() or p.stderr.strip()), "lsof_failed")
+    if p.returncode != 0: return []
     return [line[1:] for line in p.stdout.splitlines() if line.startswith("n")]
 def owns_listen(pid: int, endpoint: str) -> bool: return endpoint in lsof_lines(pid, "LISTEN")
 def peers(addr: str) -> dict:
@@ -152,10 +151,10 @@ for field, expected_addr in (("go_peer_snapshot", go_expected), ("rust_peer_snap
     if live:
         fresh = snapshot_norm(peers(nodes_by_impl["go" if field.startswith("go_") else "rust"]["rpc_endpoint"]))
         req(stored == fresh, f"{field} differs from live exact peer set")
-print(f"PASS: mixed-client mesh report accepted {path}")
+print(f"PASS: mixed-client mesh report {'accepted' if live else 'structure accepted'} {path}")
 PY
 }
-if [[ "${CHECK_REPORT_MODE}" == "1" ]]; then need_tool python3; check_report "${CHECK_REPORT}" live; exit 0; fi
+if [[ -n "${CHECK_REPORT_MODE}" ]]; then need_tool python3; check_report "${CHECK_REPORT}" "${CHECK_REPORT_MODE}"; exit 0; fi
 need_tool python3
 [[ -x "${DEV_ENV}" ]] || { echo "dev-env wrapper missing or non-executable: ${DEV_ENV}" >&2; exit 1; }
 [[ -r "${VALIDATOR}" ]] || { echo "validator unreadable: ${VALIDATOR}" >&2; exit 1; }
@@ -198,11 +197,11 @@ pid_comm() {
   comm="$(bounded ps -ww -p "${pid}" -o comm= 2>"${err}" | sed -n '1p')" || status=$?; (( status == 142 )) && return 3; [[ ${status} -eq 0 || ! -s "${err}" ]] || return 2; [[ -n "${comm}" ]] || return 1; basename -- "${comm}"
 }
 pid_listens_on() {
-  local pid="$1" endpoint="$2" out status=0
-  out="$(bounded lsof -nP -a -p "${pid}" -iTCP -sTCP:LISTEN -Fn 2>&1)" || status=$?
-  grep -F -x -q -- "n${endpoint}" <<<"${out}" && return 0
+  local pid="$1" endpoint="$2" out err status=0
+  out="$(bounded lsof -nP -a -p "${pid}" -iTCP -sTCP:LISTEN -Fn 2>"${RUBIN_PROCESS_ARTIFACT_ROOT}/lsof-listen.err")" || status=$?; err="$(<"${RUBIN_PROCESS_ARTIFACT_ROOT}/lsof-listen.err")"
   (( status == 142 )) && return 3
-  (( status == 0 || ${#out} == 0 )) || return 2
+  (( status == 0 || (${#out} == 0 && ${#err} == 0) )) || return 2
+  (( status == 0 )) && grep -F -x -q -- "n${endpoint}" <<<"${out}" && return 0
   return 1
 }
 p2p_addr_for_pid() {
@@ -214,7 +213,9 @@ deadline = time.time() + timeout
 while time.time() < deadline:
     try: proc = subprocess.run(["lsof", "-nP", "-a", "-p", pid, "-iTCP", "-sTCP:LISTEN", "-Fn"], text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=5)
     except subprocess.TimeoutExpired: sys.exit(43)
-    if proc.returncode != 0 and proc.stderr.strip(): sys.exit(42)
+    if proc.returncode != 0:
+        if proc.stdout.strip() or proc.stderr.strip(): sys.exit(42)
+        time.sleep(1); continue
     addrs = sorted({line[1:].strip() for line in proc.stdout.splitlines() if line.startswith("n") and line[1:].strip() != rpc_addr and re.fullmatch(r"127\.0\.0\.1:[0-9]+", line[1:].strip())})
     if len(addrs) == 1: print(addrs[0]); sys.exit(0)
     if len(addrs) > 1: sys.exit(f"ambiguous p2p listen addresses for pid={pid}: {addrs}")
@@ -355,7 +356,7 @@ wait_peer_snapshot() {
   deadline=$((SECONDS + timeout)); PEER_SNAPSHOT_REASON=""
   tmp="${out}.tmp"
   while (( SECONDS < deadline )); do
-    if { rpc_json GET "${addr}" /peers >"${tmp}" 2>"${tmp}.err" || { PEER_SNAPSHOT_REASON=peer_snapshot_rpc_failed; false; }; } \
+    if { rpc_json GET "${addr}" /peers >"${tmp}" 2>"${tmp}.err" && { PEER_SNAPSHOT_REASON=""; true; } || { PEER_SNAPSHOT_REASON=peer_snapshot_rpc_failed; false; }; } \
       && python3 - "${tmp}" "${expected}" <<'PY' >/dev/null 2>&1
 import json, sys
 with open(sys.argv[1], encoding="utf-8") as f:

--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -36,22 +36,21 @@ check_report() {
   local report="${1:-}"
   [[ -n "${report}" ]] || { echo "FAIL: report path is required" >&2; return 1; }
   python3 - "${report}" <<'PY'
-import datetime as dt
-import json
-import sys
+import datetime as dt, json, sys
 from pathlib import Path
 path = Path(sys.argv[1])
 def fail(message: str) -> None:
     print(f"FAIL: {message}", file=sys.stderr)
     sys.exit(1)
 def req(ok: bool, message: str) -> None:
-    if not ok:
-        fail(message)
+    if not ok: fail(message)
 def ep(value: object) -> bool:
     if not isinstance(value, str):
         return False
     host, sep, port = value.partition(":")
     return sep == ":" and host == "127.0.0.1" and ":" not in port and port.isascii() and port.isdigit() and 1 <= int(port) <= 65535
+def nonempty_str(value: object) -> bool:
+    return isinstance(value, str) and bool(value.strip())
 def ts(value: object) -> bool:
     if not isinstance(value, str) or len(value) != 20 or value[-1] != "Z":
         return False
@@ -71,24 +70,24 @@ req(data.get("scenario") == "mixed_client_mesh", f"scenario is not mixed_client_
 req(data.get("verdict") == "PASS", f"report verdict is not PASS: {data.get('verdict')!r}")
 req("failure_reason" not in data and "schema_marker" not in data, "PASS report must not carry failure/schema-marker verdict fields")
 legacy_schema = data.get("legacy_schema_compatibility")
-req(isinstance(legacy_schema, dict) and legacy_schema.get("authoritative") is False and "verdict" not in legacy_schema and legacy_schema.get("marker_path"), "legacy_schema_compatibility missing marker_path")
+req(isinstance(legacy_schema, dict) and legacy_schema.get("authoritative") is False and "verdict" not in legacy_schema and nonempty_str(legacy_schema.get("marker_path")), "legacy_schema_compatibility missing marker_path")
 nodes = data.get("nodes")
 req(isinstance(nodes, list) and len(nodes) == 2 and all(isinstance(n, dict) for n in nodes), "PASS report requires exactly two node records")
-impls = {n.get("implementation") for n in nodes}
-req(impls == {"go", "rust"}, f"PASS report requires one go and one rust node, got {sorted(str(i) for i in impls)}")
 expected_comm = {"go": "rubin-node-go", "rust": "rubin-node-rust"}
-nodes_by_impl = {node["implementation"]: node for node in nodes}
 for node in nodes:
     impl = node.get("implementation")
     name = node.get("name")
+    req(isinstance(impl, str) and impl in expected_comm, f"node has invalid implementation: {impl!r}")
     req(isinstance(name, str) and name.startswith("node-"), f"node has invalid name: {name!r}")
     req(node.get("process_comm") == expected_comm.get(impl), f"{name} process_comm does not prove {impl} identity")
-    for field in ("pid", "command", "binary"):
-        req(field in node and node[field] not in ("", None), f"{name} missing {field}")
+    req(all(nonempty_str(node.get(field)) for field in ("command", "binary")), f"{name} missing command or binary")
     req(ep(node.get("rpc_endpoint")) and ep(node.get("p2p_endpoint")) and ts(node.get("started_at")), f"{name} has malformed endpoint or timestamp")
-    req(isinstance(node["pid"], int) and node["pid"] > 0, f"{name} pid is not a positive integer")
+    req(isinstance(node.get("pid"), int) and not isinstance(node.get("pid"), bool) and node["pid"] > 0, f"{name} pid is not a positive integer")
     for field in ("process_alive", "rpc_endpoint_process_backed", "p2p_endpoint_process_backed"):
         req(node.get(field) is True, f"{name} does not prove {field}")
+impls = {n["implementation"] for n in nodes}
+req(impls == {"go", "rust"}, f"PASS report requires one go and one rust node, got {sorted(impls)}")
+nodes_by_impl = {node["implementation"]: node for node in nodes}
 connectivity = data.get("peer_connectivity")
 req(isinstance(connectivity, dict), "PASS report missing peer_connectivity object")
 req(all(connectivity.get(f) is True for f in ("go_to_rust", "rust_to_go", "bidirectional_observed")), "peer_connectivity booleans are not all true")
@@ -99,6 +98,9 @@ rust_expected = links.get("rust_peer_snapshot_expected_addr")
 req(all(ep(links.get(f)) for f in ("go_peer_snapshot_expected_addr", "rust_peer_snapshot_expected_addr", "rust_outbound_local_addr", "rust_outbound_remote_addr")), "counterpart link endpoint is malformed")
 req(rust_expected == nodes_by_impl["go"]["p2p_endpoint"] and links.get("rust_outbound_remote_addr") == rust_expected and links.get("rust_outbound_local_addr") == go_expected and links.get("rust_outbound_pid") == nodes_by_impl["rust"]["pid"], "peer evidence is not bound to expected counterpart endpoints")
 req(isinstance(go_expected, str) and go_expected not in {rust_expected, nodes_by_impl["rust"]["p2p_endpoint"], nodes_by_impl["go"]["rpc_endpoint"], nodes_by_impl["rust"]["rpc_endpoint"]}, "go peer evidence is not a rust outbound peer address")
+final = data.get("final_verification")
+req(isinstance(final, dict) and all(final.get(f) is True for f in ("producer_side", "process_identity_rechecked", "rust_outbound_link_rechecked", "peer_snapshots_rechecked")), "PASS report missing producer-side final verification")
+req(final.get("rust_outbound_pid") == nodes_by_impl["rust"]["pid"] and final.get("rust_outbound_local_addr") == go_expected and final.get("rust_outbound_remote_addr") == rust_expected, "final verification is not bound to peer evidence")
 for field, expected_addr in (("go_peer_snapshot", go_expected), ("rust_peer_snapshot", rust_expected)):
     snapshot = connectivity.get(field)
     count = snapshot.get("count") if isinstance(snapshot, dict) else None
@@ -111,16 +113,13 @@ print(f"PASS: mixed-client mesh report accepted {path}")
 PY
 }
 if [[ "${CHECK_REPORT_MODE}" == "1" ]]; then need_tool python3; check_report "${CHECK_REPORT}"; exit 0; fi
-
 need_tool python3
 need_tool perl
 [[ -x "${DEV_ENV}" ]] || { echo "dev-env wrapper missing or non-executable: ${DEV_ENV}" >&2; exit 1; }
 [[ -r "${VALIDATOR}" ]] || { echo "validator unreadable: ${VALIDATOR}" >&2; exit 1; }
-
 # shellcheck source=scripts/devnet-process-common.sh disable=SC1091
 source "${HELPER}"
 rubin_process_init mixed-client-mesh
-
 GO_NODE_BIN="${RUBIN_PROCESS_ARTIFACT_ROOT}/rubin-node-go"
 RUST_NODE_BIN="${RUBIN_PROCESS_ARTIFACT_ROOT}/rubin-node-rust"
 GO_DIR="${RUBIN_PROCESS_ARTIFACT_ROOT}/node-go"
@@ -133,6 +132,7 @@ GO_PEERS_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/go-peers.json"
 RUST_PEERS_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/rust-peers.json"
 GO_PID="" RUST_PID="" GO_RPC_ADDR="" RUST_RPC_ADDR="" GO_P2P_ADDR="" RUST_P2P_ADDR="" GO_STARTED_AT_UTC="" RUST_STARTED_AT_UTC=""
 GO_COMM="" RUST_COMM="" RUST_TO_GO_LOCAL_ADDR="" GO_CMD="" RUST_CMD=""
+FINAL_PROCESS_IDENTITY_RECHECKED="" FINAL_RUST_OUTBOUND_LINK_RECHECKED="" FINAL_PEER_SNAPSHOTS_RECHECKED=""
 mkdir -p -- "${GO_DIR}" "${RUST_DIR}"
 run_fips_preflight_before_captured_dev_env() { [[ "${RUBIN_OPENSSL_FIPS_MODE:-off}" != "only" || "${RUBIN_OPENSSL_SKIP_FIPS_GUARD:-0}" == "1" ]] && return 0; echo "Running FIPS-only preflight before captured dev-env command streams" >&2; "${DEV_ENV}" -- "${REPO_ROOT}/scripts/crypto/openssl/fips-preflight.sh" >&2; }
 run_validator() { RUBIN_OPENSSL_SKIP_FIPS_GUARD=1 "${DEV_ENV}" -- python3 "${VALIDATOR}" "$@"; }
@@ -258,16 +258,14 @@ write_outputs() {
     GO_P2P_ADDR RUST_P2P_ADDR GO_STARTED_AT_UTC RUST_STARTED_AT_UTC GO_COMM RUST_COMM \
     GO_NODE_BIN RUST_NODE_BIN GO_CMD RUST_CMD GO_PEERS_JSON RUST_PEERS_JSON \
     GO_PROCESS_ALIVE RUST_PROCESS_ALIVE GO_RPC_PROCESS_BACKED RUST_RPC_PROCESS_BACKED GO_P2P_PROCESS_BACKED RUST_P2P_PROCESS_BACKED \
-    RUST_TO_GO_LOCAL_ADDR \
+    RUST_TO_GO_LOCAL_ADDR FINAL_PROCESS_IDENTITY_RECHECKED FINAL_RUST_OUTBOUND_LINK_RECHECKED FINAL_PEER_SNAPSHOTS_RECHECKED \
     RUBIN_PROCESS_ARTIFACT_ROOT
   python3 - <<'PY'
 import json
 import os
-
 e = os.environ
 verdict = e["verdict"]
 reason = (e.get("reason") or "").strip()
-
 def read_json(path: str) -> dict:
     try:
         with open(path, encoding="utf-8") as f:
@@ -312,6 +310,7 @@ report = {
         "go_peer_snapshot": go_snapshot,
         "rust_peer_snapshot": rust_snapshot,
     },
+    "final_verification": {"producer_side": verdict == "PASS", "process_identity_rechecked": e.get("FINAL_PROCESS_IDENTITY_RECHECKED") == "true", "rust_outbound_link_rechecked": e.get("FINAL_RUST_OUTBOUND_LINK_RECHECKED") == "true", "peer_snapshots_rechecked": e.get("FINAL_PEER_SNAPSHOTS_RECHECKED") == "true", "rust_outbound_pid": int(e["RUST_PID"]) if e.get("RUST_PID", "").isdigit() else None, "rust_outbound_local_addr": e.get("RUST_TO_GO_LOCAL_ADDR") or None, "rust_outbound_remote_addr": e.get("GO_P2P_ADDR") or None},
     "legacy_schema_compatibility": {
         "authoritative": False,
         "marker_path": e["LEGACY_SCHEMA_MARKER_JSON"],
@@ -345,9 +344,7 @@ with open(e["LEGACY_SCHEMA_MARKER_JSON"], "w", encoding="utf-8") as f:
     f.write("\n")
 PY
 }
-
 finish_no_data() { local reason="$1"; write_outputs "NO_DATA" "${reason}"; run_validator "${LEGACY_SCHEMA_MARKER_JSON}" >&2; echo "NO_DATA: ${reason}; report=${REPORT_JSON} legacy_schema_marker=${LEGACY_SCHEMA_MARKER_JSON}" >&2; exit 1; }
-
 wait_peer_snapshot() {
   local label="$1" addr="$2" out="$3" timeout="$4" expected="$5" deadline tmp
   deadline=$((SECONDS + timeout))
@@ -375,7 +372,6 @@ PY
   echo "timeout waiting for ${label} /peers completed handshake" >&2
   return 1
 }
-
 verify_process_identity() {
   local label="$1" impl="$2" pid="$3" rpc_addr="$4" p2p_addr="$5" expected_comm="$6" comm
   rubin_process_is_alive "${pid}" || { echo "${label} pid is not alive: ${pid}" >&2; return 1; }
@@ -389,7 +385,6 @@ verify_process_identity() {
     *) return 1 ;;
   esac
 }
-
 start_rust_node() {
   RUST_CMD="${RUST_NODE_BIN} --network devnet --datadir ${RUST_DIR} --bind 127.0.0.1:0 --rpc-bind 127.0.0.1:0 --peer ${GO_P2P_ADDR}"
   rubin_process_start "${RUST_LOG}" "${RUST_NODE_BIN}" \
@@ -404,7 +399,6 @@ start_rust_node() {
   rubin_process_wait_for_rpc_ready "${RUST_RPC_ADDR}" 30 || return 1
   RUST_STARTED_AT_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 }
-
 start_go_node() {
   GO_CMD="${GO_NODE_BIN} --network devnet --datadir ${GO_DIR} --bind 127.0.0.1:0 --rpc-bind 127.0.0.1:0"
   rubin_process_start "${GO_LOG}" "${GO_NODE_BIN}" \
@@ -417,7 +411,6 @@ start_go_node() {
   rubin_process_wait_for_rpc_ready "${GO_RPC_ADDR}" 30 || return 1
   GO_STARTED_AT_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 }
-
 [[ "${MESH_TIMEOUT}" =~ ^[0-9]+$ && "${MESH_TIMEOUT}" -ge 1 && "${MESH_TIMEOUT}" -le 600 ]] || {
   echo "MESH_TIMEOUT must be an integer in [1, 600]" >&2
   exit 2
@@ -436,7 +429,13 @@ RUST_TO_GO_LOCAL_ADDR="$(lsof -nP -a -p "${RUST_PID}" -iTCP -sTCP:ESTABLISHED -F
 wait_peer_snapshot node-go "${GO_RPC_ADDR}" "${GO_PEERS_JSON}" "${MESH_TIMEOUT}" "${RUST_TO_GO_LOCAL_ADDR}" || finish_no_data "go_peer_snapshot_missing_rust_endpoint"
 verify_process_identity node-go-final go "${GO_PID}" "${GO_RPC_ADDR}" "${GO_P2P_ADDR}" rubin-node-go || finish_no_data "go_final_process_identity_unverified"
 verify_process_identity node-rust-final rust "${RUST_PID}" "${RUST_RPC_ADDR}" "${RUST_P2P_ADDR}" rubin-node-rust || finish_no_data "rust_final_process_identity_unverified"
-
+FINAL_PROCESS_IDENTITY_RECHECKED=true
+RUST_TO_GO_LOCAL_ADDR="$(lsof -nP -a -p "${RUST_PID}" -iTCP -sTCP:ESTABLISHED -Fn 2>/dev/null | REMOTE_ADDR="${GO_P2P_ADDR}" perl -ne 'BEGIN{$r=$ENV{REMOTE_ADDR}} chomp; s/^n// or next; print "$1\n" if /^(127[.]0[.]0[.]1:[0-9]+)->\Q$r\E$/' | sort -u)" || finish_no_data "rust_final_to_go_tcp_link_missing"
+[[ -n "${RUST_TO_GO_LOCAL_ADDR}" && "${RUST_TO_GO_LOCAL_ADDR}" != *$'\n'* ]] || finish_no_data "rust_final_to_go_tcp_link_ambiguous"
+FINAL_RUST_OUTBOUND_LINK_RECHECKED=true
+wait_peer_snapshot node-rust-final "${RUST_RPC_ADDR}" "${RUST_PEERS_JSON}" "${MESH_TIMEOUT}" "${GO_P2P_ADDR}" || finish_no_data "rust_final_peer_snapshot_missing_go_endpoint"
+wait_peer_snapshot node-go-final "${GO_RPC_ADDR}" "${GO_PEERS_JSON}" "${MESH_TIMEOUT}" "${RUST_TO_GO_LOCAL_ADDR}" || finish_no_data "go_final_peer_snapshot_missing_rust_endpoint"
+FINAL_PEER_SNAPSHOTS_RECHECKED=true
 write_outputs "PASS"
 run_validator "${LEGACY_SCHEMA_MARKER_JSON}" >&2
 check_report "${REPORT_JSON}" >&2

--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -59,7 +59,6 @@ def argv0(value: object) -> str:
     try: return shlex.split(value)[0]
     except ValueError: return ""
 def ps_comm(pid: int) -> str: return os.path.basename(run(["ps", "-ww", "-p", str(pid), "-o", "comm="]))
-def ps_argv0(pid: int) -> str: return run(["ps", "-ww", "-p", str(pid), "-o", "comm="])
 def lsof_lines(pid: int, state: str) -> list[str]:
     p = subprocess.run(["lsof", "-nP", "-a", "-p", str(pid), "-iTCP", f"-sTCP:{state}", "-Fn"], check=False, text=True, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, timeout=5)
     return [line[1:] for line in p.stdout.splitlines() if line.startswith("n")]
@@ -127,7 +126,7 @@ for node in nodes:
     req(nonempty_str(command) and Path(command_argv0).is_absolute() and Path(command_argv0).resolve() == binary_path and binary_path.name == expected_bin and binary_path.is_file() and os.access(binary_path, os.X_OK), f"{name} command/binary is not bound to executable {expected_bin}")
     req(ep(node.get("rpc_endpoint")) and ep(node.get("p2p_endpoint")) and ts(node.get("started_at")), f"{name} has malformed endpoint or timestamp")
     req(isinstance(node.get("pid"), int) and not isinstance(node.get("pid"), bool) and node["pid"] > 0, f"{name} pid is not a positive integer")
-    if live: req(ps_comm(node["pid"]) == expected_bin and Path(ps_argv0(node["pid"])).resolve() == binary_path, f"{name} live process identity does not match report"); req(owns_listen(node["pid"], node["rpc_endpoint"]) and owns_listen(node["pid"], node["p2p_endpoint"]), f"{name} live listeners are not pid-owned")
+    if live: req(ps_comm(node["pid"]) == expected_bin, f"{name} live process identity does not match report"); req(owns_listen(node["pid"], node["rpc_endpoint"]) and owns_listen(node["pid"], node["p2p_endpoint"]), f"{name} live listeners are not pid-owned")
     for field in ("process_alive", "rpc_endpoint_process_backed", "p2p_endpoint_process_backed"):
         req(node.get(field) is True, f"{name} does not prove {field}")
 impls = {n["implementation"] for n in nodes}

--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -1,34 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-DEV_ENV="${REPO_ROOT}/scripts/dev-env.sh"
-GO_MODULE_ROOT="${REPO_ROOT}/clients/go"
-RUST_WORKSPACE_ROOT="${REPO_ROOT}/clients/rust"
-HELPER="${REPO_ROOT}/scripts/devnet-process-common.sh"
+DEV_ENV="${REPO_ROOT}/scripts/dev-env.sh"; GO_MODULE_ROOT="${REPO_ROOT}/clients/go"
+RUST_WORKSPACE_ROOT="${REPO_ROOT}/clients/rust"; HELPER="${REPO_ROOT}/scripts/devnet-process-common.sh"
 VALIDATOR="${REPO_ROOT}/scripts/devnet/validate_mixed_client_evidence.py"
 CHECK_REPORT="" CHECK_REPORT_MODE="" MESH_TIMEOUT="${MESH_TIMEOUT:-90}"
 usage() { echo "usage: $0 [--check-report PATH|--check-report-live PATH]" >&2; }
-while (($#)); do
-  case "$1" in
-    --check-report|--check-report-live)
-      [[ $# -ge 2 ]] || { usage; exit 2; }
-      CHECK_REPORT_MODE=offline; [[ "$1" == "--check-report-live" ]] && CHECK_REPORT_MODE=live; CHECK_REPORT="$2"; shift 2
-      ;;
-    -h|--help) usage; exit 0 ;;
-    *)
-      usage
-      exit 2
-      ;;
-  esac
-done
+while (($#)); do case "$1" in --check-report|--check-report-live) [[ $# -ge 2 ]] || { usage; exit 2; }; CHECK_REPORT_MODE=offline; [[ "$1" == "--check-report-live" ]] && CHECK_REPORT_MODE=live; CHECK_REPORT="$2"; shift 2 ;; -h|--help) usage; exit 0 ;; *) usage; exit 2 ;; esac; done
 need_tool() { command -v -- "$1" >/dev/null 2>&1 || { echo "$1 is required for mixed-client mesh evidence" >&2; exit 1; }; }
 check_report() { local report="${1:-}" mode="${2:-offline}"
   [[ -n "${report}" ]] || { echo "FAIL: report path is required" >&2; return 1; }
   python3 - "${report}" "${DEV_ENV}" "${VALIDATOR}" "${mode}" <<'PY'
-import datetime as dt, json, os, socket, subprocess, sys, time, urllib.error, urllib.request
+import datetime as dt, json, os, socket, struct, subprocess, sys, time, urllib.error, urllib.request
 from pathlib import Path
-path = Path(sys.argv[1])
-live = sys.argv[4] == "live"
+path = Path(sys.argv[1]); live = sys.argv[4] == "live"
 try: LIVE_TIMEOUT = max(1, min(600, int(os.environ.get("MESH_TIMEOUT", "10"))))
 except ValueError: LIVE_TIMEOUT = 10
 def fail(message: str) -> None: print(f"FAIL: {message}", file=sys.stderr); sys.exit(1)
@@ -58,6 +43,28 @@ def pid_exe(pid: int) -> str:
         import ctypes; buf = ctypes.create_string_buffer(4096); n = ctypes.CDLL(None).proc_pidpath(int(pid), buf, len(buf))
     except (AttributeError, OSError) as exc: fail(f"pid_exe_unavailable: {exc}")
     return os.path.realpath(buf.value.decode()) if n > 0 else ""
+def pid_argv(pid: int) -> list[str]:
+    cmdline = Path(f"/proc/{pid}/cmdline")
+    if cmdline.exists() or Path("/proc").is_dir():
+        try: raw = cmdline.read_bytes()
+        except FileNotFoundError: return []
+        except OSError as exc: fail(f"argv_unavailable: {exc}")
+        return [a.decode("utf-8", "surrogateescape") for a in raw.rstrip(b"\0").split(b"\0") if a]
+    try:
+        import ctypes; libc = ctypes.CDLL(None); mib = (ctypes.c_int * 3)(1, 49, int(pid)); size = ctypes.c_size_t(0)
+        if libc.sysctl(mib, 3, None, ctypes.byref(size), None, 0) != 0: fail("argv_unavailable")
+        buf = ctypes.create_string_buffer(size.value)
+        if libc.sysctl(mib, 3, buf, ctypes.byref(size), None, 0) != 0: fail("argv_unavailable")
+    except (AttributeError, OSError) as exc: fail(f"argv_unavailable: {exc}")
+    raw = buf.raw[:size.value]; argc = struct.unpack_from("i", raw)[0]; i = raw.find(b"\0", 4)
+    while i < len(raw) and raw[i] == 0: i += 1
+    args = []
+    for _ in range(argc):
+        j = raw.find(b"\0", i)
+        if j < 0: break
+        args.append(raw[i:j].decode("utf-8", "surrogateescape")); i = j + 1
+    return args
+def argv_eq(actual: list[str], expected: list[str]) -> bool: return len(actual) == len(expected) and bool(actual) and Path(actual[0]).resolve() == Path(expected[0]).resolve() and actual[1:] == expected[1:]
 def lsof_lines(pid: int, state: str) -> list[str]:
     try:
         p = subprocess.run(["lsof", "-nP", "-a", "-p", str(pid), "-iTCP", f"-sTCP:{state}", "-Fn"], check=False, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=5)
@@ -86,13 +93,10 @@ def snapshot_norm(snapshot: object) -> list[tuple[str, bool]]:
     return norm
 def ts(value: object) -> bool:
     if not isinstance(value, str) or len(value) != 20 or value[-1] != "Z": return False
-    try:
-        return dt.datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").strftime("%Y-%m-%dT%H:%M:%SZ") == value
-    except ValueError:
-        return False
+    try: return dt.datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").strftime("%Y-%m-%dT%H:%M:%SZ") == value
+    except ValueError: return False
 try:
-    with path.open(encoding="utf-8") as f:
-        data = json.load(f)
+    with path.open(encoding="utf-8") as f: data = json.load(f)
 except OSError as exc:
     fail(f"cannot read report: {exc}")
 except (json.JSONDecodeError, UnicodeDecodeError) as exc:
@@ -120,8 +124,7 @@ nodes = data.get("nodes")
 req(isinstance(nodes, list) and len(nodes) == 2 and all(isinstance(n, dict) for n in nodes), "PASS report requires exactly two node records")
 expected = {"go": ("node-go", "rubin-node-go"), "rust": ("node-rust", "rubin-node-rust")}
 for node in nodes:
-    impl = node.get("implementation")
-    name = node.get("name")
+    impl, name = node.get("implementation"), node.get("name")
     req(isinstance(impl, str) and impl in expected, f"node has invalid implementation: {impl!r}")
     expected_name, expected_bin = expected[impl]
     req(name == expected_name, f"{impl} node has invalid name: {name!r}")
@@ -134,7 +137,7 @@ for node in nodes:
     req(ep(node.get("rpc_endpoint")) and ep(node.get("p2p_endpoint")) and ts(node.get("started_at")), f"{name} has malformed endpoint or timestamp")
     req(isinstance(node.get("pid"), int) and not isinstance(node.get("pid"), bool) and node["pid"] > 0, f"{name} pid is not a positive integer")
     if live:
-        eventually(lambda node=node, binary_path=binary_path: Path(pid_exe(node["pid"])).resolve() == binary_path, f"{name} live process executable does not match report")
+        eventually(lambda node=node, binary_path=binary_path, command_argv=command_argv: Path(pid_exe(node["pid"])).resolve() == binary_path and argv_eq(pid_argv(node["pid"]), command_argv), f"{name} live process argv/executable does not match report")
         eventually(lambda node=node: owns_listen(node["pid"], node["rpc_endpoint"]) and owns_listen(node["pid"], node["p2p_endpoint"]), f"{name} live listeners are not pid-owned")
     for field in ("process_alive", "rpc_endpoint_process_backed", "p2p_endpoint_process_backed"):
         req(node.get(field) is True, f"{name} does not prove {field}")
@@ -200,10 +203,7 @@ except (urllib.error.URLError, TimeoutError, socket.timeout) as exc:
     sys.exit(1)
 PY
 }
-pid_comm() {
-  local pid="$1" comm status=0 err="${RUBIN_PROCESS_ARTIFACT_ROOT}/ps.err"
-  comm="$(bounded ps -ww -p "${pid}" -o comm= 2>"${err}" | sed -n '1p')" || status=$?; (( status == 142 )) && return 3; [[ ${status} -eq 0 || ! -s "${err}" ]] || return 2; [[ -n "${comm}" ]] || return 1; basename -- "${comm}"
-}
+pid_comm() { local pid="$1" raw comm status=0 err="${RUBIN_PROCESS_ARTIFACT_ROOT}/ps.err"; raw="$(bounded ps -ww -p "${pid}" -o comm= 2>"${err}")" || status=$?; (( status == 142 )) && return 3; [[ ${status} -eq 0 || ! -s "${err}" ]] || return 2; comm="$(sed -n '1p' <<<"${raw}")" || return 4; [[ -n "${comm}" ]] || return 1; basename -- "${comm}"; }
 pid_listens_on() {
   local pid="$1" endpoint="$2" out err status=0
   out="$(bounded lsof -nP -a -p "${pid}" -iTCP -sTCP:LISTEN -Fn 2>"${RUBIN_PROCESS_ARTIFACT_ROOT}/lsof-listen.err")" || status=$?; err="$(<"${RUBIN_PROCESS_ARTIFACT_ROOT}/lsof-listen.err")"
@@ -373,7 +373,7 @@ ok = isinstance(count, int) and not isinstance(count, bool) and isinstance(peers
 sys.exit(0 if ok else 1)
 PY
     then
-      mv -- "${tmp}" "${out}"
+      mv -- "${tmp}" "${out}" || { PEER_SNAPSHOT_REASON=peer_snapshot_artifact_write_failed; rm -f -- "${tmp}" "${tmp}.err"; return 1; }
       return 0
     fi
     sleep 1
@@ -384,11 +384,13 @@ PY
   return 1
 }
 wait_rust_to_go_link() {
-  local missing="$1" ambiguous="$2" deadline out status err_file err
+  local missing="$1" ambiguous="$2" deadline raw out status err_file err
   deadline=$((SECONDS + MESH_TIMEOUT)); err_file="${RUBIN_PROCESS_ARTIFACT_ROOT}/lsof-established.err"
   while (( SECONDS < deadline )); do
-    status=0; out="$(bounded lsof -nP -a -p "${RUST_PID}" -iTCP -sTCP:ESTABLISHED -Fn 2>"${err_file}" | REMOTE_ADDR="${GO_P2P_ADDR}" perl -ne 'BEGIN{$r=$ENV{REMOTE_ADDR}} chomp; s/^n// or next; print "$1\n" if /^(127[.]0[.]0[.]1:[0-9]+)->\Q$r\E$/' | sort -u)" || status=$?; err="$(<"${err_file}")"
-    (( status == 142 )) && finish_no_data "lsof_timeout"; (( status == 0 || (${#out} == 0 && ${#err} == 0) )) || finish_no_data "lsof_failed"
+    status=0; raw="$(bounded lsof -nP -a -p "${RUST_PID}" -iTCP -sTCP:ESTABLISHED -Fn 2>"${err_file}")" || status=$?; err="$(<"${err_file}")"
+    (( status == 142 )) && finish_no_data "lsof_timeout"; (( status == 0 || (${#raw} == 0 && ${#err} == 0) )) || finish_no_data "lsof_failed"
+    out="$(REMOTE_ADDR="${GO_P2P_ADDR}" perl -ne 'BEGIN{$r=$ENV{REMOTE_ADDR}} chomp; s/^n// or next; print "$1\n" if /^(127[.]0[.]0[.]1:[0-9]+)->\Q$r\E$/' <<<"${raw}")" || finish_no_data "perl_failed"
+    out="$(sort -u <<<"${out}")" || finish_no_data "sort_failed"
     [[ "${out}" != *$'\n'* ]] || finish_no_data "${ambiguous}"; [[ -z "${out}" ]] || { RUST_TO_GO_LOCAL_ADDR="${out}"; return 0; }
     sleep 1
   done; finish_no_data "${missing}"
@@ -396,7 +398,7 @@ wait_rust_to_go_link() {
 verify_process_identity() {
   local label="$1" impl="$2" pid="$3" rpc_addr="$4" p2p_addr="$5" expected_comm="$6" comm
   rubin_process_is_alive "${pid}" || { echo "${label} pid is not alive: ${pid}" >&2; return 1; }
-  comm="$(pid_comm "${pid}")" || { rc=$?; [[ ${rc} -eq 2 ]] && finish_no_data "ps_failed"; [[ ${rc} -eq 3 ]] && finish_no_data "ps_timeout"; echo "${label} process comm unavailable: ${pid}" >&2; return 1; }
+  comm="$(pid_comm "${pid}")" || { rc=$?; [[ ${rc} -eq 2 ]] && finish_no_data "ps_failed"; [[ ${rc} -eq 3 ]] && finish_no_data "ps_timeout"; [[ ${rc} -eq 4 ]] && finish_no_data "sed_failed"; echo "${label} process comm unavailable: ${pid}" >&2; return 1; }
   [[ "${comm}" == "${expected_comm}" ]] || { echo "${label} process comm=${comm}, want ${expected_comm}" >&2; return 1; }
   pid_listens_on "${pid}" "${rpc_addr}" || { rc=$?; [[ ${rc} -eq 2 ]] && finish_no_data "lsof_failed"; [[ ${rc} -eq 3 ]] && finish_no_data "lsof_timeout"; echo "${label} rpc endpoint is not process-backed: ${rpc_addr}" >&2; return 1; }
   pid_listens_on "${pid}" "${p2p_addr}" || { rc=$?; [[ ${rc} -eq 2 ]] && finish_no_data "lsof_failed"; [[ ${rc} -eq 3 ]] && finish_no_data "lsof_timeout"; echo "${label} p2p endpoint is not process-backed: ${p2p_addr}" >&2; return 1; }
@@ -420,7 +422,7 @@ start_go_node() {
   GO_P2P_ADDR="$(p2p_addr_for_pid "${GO_PID}" "${GO_RPC_ADDR}" 30)" || { rc=$?; [[ ${rc} -eq 42 ]] && finish_no_data "lsof_failed"; [[ ${rc} -eq 43 ]] && finish_no_data "lsof_timeout"; return 1; }
   rubin_process_wait_for_rpc_ready "${GO_RPC_ADDR}" 30 || return 1; GO_STARTED_AT_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 }
-command -v lsof >/dev/null 2>&1 || finish_no_data "lsof_unavailable"; command -v perl >/dev/null 2>&1 || finish_no_data "perl_unavailable"
+for tool in lsof perl sed sort; do command -v "${tool}" >/dev/null 2>&1 || finish_no_data "${tool}_unavailable"; done
 build_go_node || finish_no_data "go_build_failed"
 build_rust_node || finish_no_data "rust_build_failed"
 start_go_node || finish_no_data "go_process_not_ready"
@@ -439,7 +441,7 @@ wait_peer_snapshot node-rust-final "${RUST_RPC_ADDR}" "${RUST_PEERS_JSON}" "${ME
 wait_peer_snapshot node-go-final "${GO_RPC_ADDR}" "${GO_PEERS_JSON}" "${MESH_TIMEOUT}" "${RUST_TO_GO_LOCAL_ADDR}" || finish_no_data "${PEER_SNAPSHOT_REASON:-go_final_peer_snapshot_missing_rust_endpoint}"
 FINAL_PEER_SNAPSHOTS_RECHECKED=true
 PASS_REPORT_JSON="${REPORT_JSON}.pass.tmp"; FINAL_REPORT_JSON="${REPORT_JSON}"; REPORT_JSON="${PASS_REPORT_JSON}"
-write_outputs "PASS"; REPORT_JSON="${FINAL_REPORT_JSON}"
+write_outputs "PASS" || { REPORT_JSON="${FINAL_REPORT_JSON}"; finish_no_data "pass_report_write_failed"; }; REPORT_JSON="${FINAL_REPORT_JSON}"
 if run_validator "${LEGACY_SCHEMA_MARKER_JSON}" >&2 && check_report "${PASS_REPORT_JSON}" live >&2; then
   mv -- "${PASS_REPORT_JSON}" "${REPORT_JSON}"
 else

--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -74,12 +74,10 @@ def peers(addr: str) -> dict:
     except Exception as exc:
         fail(f"live peer snapshot failed for {addr}: {exc}")
     return data if isinstance(data, dict) else {}
-def snapshot_has(snapshot: object, expected: str) -> int:
+def snapshot_exact(snapshot: object, expected: str) -> None:
     count = snapshot.get("count") if isinstance(snapshot, dict) else None
     peers = snapshot.get("peers") if isinstance(snapshot, dict) else None
-    req(isinstance(count, int) and not isinstance(count, bool) and isinstance(peers, list) and count == len(peers), "peer snapshot count/peers are invalid")
-    req(any(isinstance(p, dict) and p.get("addr") == expected and p.get("handshake_complete") is True for p in peers), f"peer snapshot lacks completed handshake for {expected}")
-    return count
+    req(count == 1 and isinstance(peers, list) and len(peers) == 1 and peers[0] == {"addr": expected, "handshake_complete": True} and ep(expected), f"peer snapshot is not exact single completed peer {expected}")
 def ts(value: object) -> bool:
     if not isinstance(value, str) or len(value) != 20 or value[-1] != "Z": return False
     try:
@@ -150,11 +148,9 @@ final = data.get("final_verification")
 req(isinstance(final, dict) and all(final.get(f) is True for f in ("producer_side", "process_identity_rechecked", "rust_outbound_link_rechecked", "peer_snapshots_rechecked")), "PASS report missing producer-side final verification")
 req(final.get("rust_outbound_pid") == nodes_by_impl["rust"]["pid"] and final.get("rust_outbound_local_addr") == go_expected and final.get("rust_outbound_remote_addr") == rust_expected, "final verification is not bound to peer evidence")
 for field, expected_addr in (("go_peer_snapshot", go_expected), ("rust_peer_snapshot", rust_expected)):
-    snapshot = connectivity.get(field)
-    count = snapshot_has(snapshot, expected_addr)
-    req(count >= 1 and all(isinstance(p, dict) and ep(p.get("addr")) and isinstance(p.get("handshake_complete"), bool) for p in snapshot["peers"]), f"{field}.peers contain malformed entries")
-req(snapshot_has(peers(nodes_by_impl["go"]["rpc_endpoint"]), go_expected) == connectivity["go_peer_snapshot"]["count"], "live go peer snapshot differs from report")
-req(snapshot_has(peers(nodes_by_impl["rust"]["rpc_endpoint"]), rust_expected) == connectivity["rust_peer_snapshot"]["count"], "live rust peer snapshot differs from report")
+    snapshot_exact(connectivity.get(field), expected_addr)
+snapshot_exact(peers(nodes_by_impl["go"]["rpc_endpoint"]), go_expected)
+snapshot_exact(peers(nodes_by_impl["rust"]["rpc_endpoint"]), rust_expected)
 print(f"PASS: mixed-client mesh report accepted {path}")
 PY
 }
@@ -357,14 +353,11 @@ wait_peer_snapshot() {
   while (( SECONDS < deadline )); do
     if rpc_json GET "${addr}" /peers >"${tmp}" 2>/dev/null \
       && python3 - "${tmp}" "${expected}" <<'PY' >/dev/null 2>&1
-import json
-import sys
+import json, sys
 with open(sys.argv[1], encoding="utf-8") as f:
     data = json.load(f)
 expected, peers, count = sys.argv[2], data.get("peers"), data.get("count")
-ok = isinstance(count, int) and not isinstance(count, bool) and isinstance(peers, list) and count == len(peers) and any(
-    isinstance(p, dict) and p.get("addr") == expected and p.get("handshake_complete") is True for p in peers
-)
+ok = count == 1 and isinstance(peers, list) and len(peers) == 1 and peers[0] == {"addr": expected, "handshake_complete": True}
 sys.exit(0 if ok else 1)
 PY
     then

--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -440,11 +440,11 @@ FINAL_RUST_OUTBOUND_LINK_RECHECKED=true
 wait_peer_snapshot node-rust-final "${RUST_RPC_ADDR}" "${RUST_PEERS_JSON}" "${MESH_TIMEOUT}" "${GO_P2P_ADDR}" || finish_no_data "rust_final_peer_snapshot_missing_go_endpoint"
 wait_peer_snapshot node-go-final "${GO_RPC_ADDR}" "${GO_PEERS_JSON}" "${MESH_TIMEOUT}" "${RUST_TO_GO_LOCAL_ADDR}" || finish_no_data "go_final_peer_snapshot_missing_rust_endpoint"
 FINAL_PEER_SNAPSHOTS_RECHECKED=true
-write_outputs "PASS"
-run_validator "${LEGACY_SCHEMA_MARKER_JSON}" >&2
-check_report "${REPORT_JSON}" >&2
-if [[ "${RUBIN_PROCESS_KEEP_ARTIFACTS}" == "1" ]]; then
-  echo "PASS: mixed-client mesh connected go_pid=${GO_PID} rust_pid=${RUST_PID}; report=${REPORT_JSON} legacy_schema_marker=${LEGACY_SCHEMA_MARKER_JSON}"
+PASS_REPORT_JSON="${REPORT_JSON}.pass.tmp"; FINAL_REPORT_JSON="${REPORT_JSON}"; REPORT_JSON="${PASS_REPORT_JSON}"
+write_outputs "PASS"; REPORT_JSON="${FINAL_REPORT_JSON}"
+if run_validator "${LEGACY_SCHEMA_MARKER_JSON}" >&2 && check_report "${PASS_REPORT_JSON}" >&2; then
+  mv -- "${PASS_REPORT_JSON}" "${REPORT_JSON}"
 else
-  echo "PASS: mixed-client mesh connected go_pid=${GO_PID} rust_pid=${RUST_PID}; set KEEP_TMP=1 to retain report"
+  rm -f -- "${PASS_REPORT_JSON}"; finish_no_data "pass_report_validation_failed"
 fi
+[[ "${RUBIN_PROCESS_KEEP_ARTIFACTS}" == "1" ]] && echo "PASS: mixed-client mesh connected go_pid=${GO_PID} rust_pid=${RUST_PID}; report=${REPORT_JSON} legacy_schema_marker=${LEGACY_SCHEMA_MARKER_JSON}" || echo "PASS: mixed-client mesh connected go_pid=${GO_PID} rust_pid=${RUST_PID}; set KEEP_TMP=1 to retain report"

--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -6,8 +6,7 @@ GO_MODULE_ROOT="${REPO_ROOT}/clients/go"
 RUST_WORKSPACE_ROOT="${REPO_ROOT}/clients/rust"
 HELPER="${REPO_ROOT}/scripts/devnet-process-common.sh"
 VALIDATOR="${REPO_ROOT}/scripts/devnet/validate_mixed_client_evidence.py"
-CHECK_REPORT="" CHECK_REPORT_MODE=0
-MESH_TIMEOUT="${MESH_TIMEOUT:-90}"
+CHECK_REPORT="" CHECK_REPORT_MODE=0 MESH_TIMEOUT="${MESH_TIMEOUT:-90}"
 usage() { echo "usage: $0 [--check-report PATH]" >&2; }
 while (($#)); do
   case "$1" in
@@ -158,8 +157,7 @@ print(f"PASS: mixed-client mesh report accepted {path}")
 PY
 }
 if [[ "${CHECK_REPORT_MODE}" == "1" ]]; then need_tool python3; need_tool lsof; check_report "${CHECK_REPORT}"; exit 0; fi
-need_tool python3
-need_tool perl
+need_tool python3; need_tool perl
 [[ -x "${DEV_ENV}" ]] || { echo "dev-env wrapper missing or non-executable: ${DEV_ENV}" >&2; exit 1; }
 [[ -r "${VALIDATOR}" ]] || { echo "validator unreadable: ${VALIDATOR}" >&2; exit 1; }
 # shellcheck source=scripts/devnet-process-common.sh disable=SC1091
@@ -374,6 +372,16 @@ PY
   echo "timeout waiting for ${label} /peers completed handshake" >&2
   return 1
 }
+wait_rust_to_go_link() {
+  local missing="$1" ambiguous="$2" deadline out status
+  deadline=$((SECONDS + MESH_TIMEOUT))
+  while (( SECONDS < deadline )); do
+    status=0; out="$(lsof -nP -a -p "${RUST_PID}" -iTCP -sTCP:ESTABLISHED -Fn 2>/dev/null | REMOTE_ADDR="${GO_P2P_ADDR}" perl -ne 'BEGIN{$r=$ENV{REMOTE_ADDR}} chomp; s/^n// or next; print "$1\n" if /^(127[.]0[.]0[.]1:[0-9]+)->\Q$r\E$/' | sort -u)" || status=$?
+    (( status == 0 || ${#out} == 0 )) || finish_no_data "${missing}"
+    [[ "${out}" != *$'\n'* ]] || finish_no_data "${ambiguous}"; [[ -z "${out}" ]] || { RUST_TO_GO_LOCAL_ADDR="${out}"; return 0; }
+    sleep 1
+  done; finish_no_data "${missing}"
+}
 verify_process_identity() {
   local label="$1" impl="$2" pid="$3" rpc_addr="$4" p2p_addr="$5" expected_comm="$6" comm
   rubin_process_is_alive "${pid}" || { echo "${label} pid is not alive: ${pid}" >&2; return 1; }
@@ -413,10 +421,7 @@ start_go_node() {
   rubin_process_wait_for_rpc_ready "${GO_RPC_ADDR}" 30 || return 1
   GO_STARTED_AT_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 }
-[[ "${MESH_TIMEOUT}" =~ ^[0-9]+$ && "${MESH_TIMEOUT}" -ge 1 && "${MESH_TIMEOUT}" -le 600 ]] || {
-  echo "MESH_TIMEOUT must be an integer in [1, 600]" >&2
-  exit 2
-}
+[[ "${MESH_TIMEOUT}" =~ ^[0-9]+$ && "${MESH_TIMEOUT}" -ge 1 && "${MESH_TIMEOUT}" -le 600 ]] || { echo "MESH_TIMEOUT must be an integer in [1, 600]" >&2; exit 2; }
 command -v lsof >/dev/null 2>&1 || finish_no_data "lsof_unavailable"
 build_go_node || finish_no_data "go_build_failed"
 build_rust_node || finish_no_data "rust_build_failed"
@@ -425,14 +430,12 @@ verify_process_identity node-go go "${GO_PID}" "${GO_RPC_ADDR}" "${GO_P2P_ADDR}"
 start_rust_node || finish_no_data "rust_process_not_ready"
 verify_process_identity node-rust rust "${RUST_PID}" "${RUST_RPC_ADDR}" "${RUST_P2P_ADDR}" rubin-node-rust || finish_no_data "rust_process_identity_unverified"
 wait_peer_snapshot node-rust "${RUST_RPC_ADDR}" "${RUST_PEERS_JSON}" "${MESH_TIMEOUT}" "${GO_P2P_ADDR}" || finish_no_data "rust_peer_snapshot_missing_go_endpoint"
-RUST_TO_GO_LOCAL_ADDR="$(lsof -nP -a -p "${RUST_PID}" -iTCP -sTCP:ESTABLISHED -Fn 2>/dev/null | REMOTE_ADDR="${GO_P2P_ADDR}" perl -ne 'BEGIN{$r=$ENV{REMOTE_ADDR}} chomp; s/^n// or next; print "$1\n" if /^(127[.]0[.]0[.]1:[0-9]+)->\Q$r\E$/' | sort -u)" || finish_no_data "rust_to_go_tcp_link_missing"
-[[ -n "${RUST_TO_GO_LOCAL_ADDR}" && "${RUST_TO_GO_LOCAL_ADDR}" != *$'\n'* ]] || finish_no_data "rust_to_go_tcp_link_ambiguous"
+wait_rust_to_go_link rust_to_go_tcp_link_missing rust_to_go_tcp_link_ambiguous
 wait_peer_snapshot node-go "${GO_RPC_ADDR}" "${GO_PEERS_JSON}" "${MESH_TIMEOUT}" "${RUST_TO_GO_LOCAL_ADDR}" || finish_no_data "go_peer_snapshot_missing_rust_endpoint"
 verify_process_identity node-go-final go "${GO_PID}" "${GO_RPC_ADDR}" "${GO_P2P_ADDR}" rubin-node-go || finish_no_data "go_final_process_identity_unverified"
 verify_process_identity node-rust-final rust "${RUST_PID}" "${RUST_RPC_ADDR}" "${RUST_P2P_ADDR}" rubin-node-rust || finish_no_data "rust_final_process_identity_unverified"
 FINAL_PROCESS_IDENTITY_RECHECKED=true
-RUST_TO_GO_LOCAL_ADDR="$(lsof -nP -a -p "${RUST_PID}" -iTCP -sTCP:ESTABLISHED -Fn 2>/dev/null | REMOTE_ADDR="${GO_P2P_ADDR}" perl -ne 'BEGIN{$r=$ENV{REMOTE_ADDR}} chomp; s/^n// or next; print "$1\n" if /^(127[.]0[.]0[.]1:[0-9]+)->\Q$r\E$/' | sort -u)" || finish_no_data "rust_final_to_go_tcp_link_missing"
-[[ -n "${RUST_TO_GO_LOCAL_ADDR}" && "${RUST_TO_GO_LOCAL_ADDR}" != *$'\n'* ]] || finish_no_data "rust_final_to_go_tcp_link_ambiguous"
+wait_rust_to_go_link rust_final_to_go_tcp_link_missing rust_final_to_go_tcp_link_ambiguous
 FINAL_RUST_OUTBOUND_LINK_RECHECKED=true
 wait_peer_snapshot node-rust-final "${RUST_RPC_ADDR}" "${RUST_PEERS_JSON}" "${MESH_TIMEOUT}" "${GO_P2P_ADDR}" || finish_no_data "rust_final_peer_snapshot_missing_go_endpoint"
 wait_peer_snapshot node-go-final "${GO_RPC_ADDR}" "${GO_PEERS_JSON}" "${MESH_TIMEOUT}" "${RUST_TO_GO_LOCAL_ADDR}" || finish_no_data "go_final_peer_snapshot_missing_rust_endpoint"

--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -419,7 +419,7 @@ start_go_node() {
   rubin_process_wait_for_rpc_ready "${GO_RPC_ADDR}" 30 || return 1
   GO_STARTED_AT_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 }
-[[ "${MESH_TIMEOUT}" =~ ^[0-9]+$ ]] || { echo "MESH_TIMEOUT must be an integer in [1, 600]" >&2; exit 2; }
+[[ "${MESH_TIMEOUT}" =~ ^[0-9]{1,3}$ ]] || { echo "MESH_TIMEOUT must be an integer in [1, 600]" >&2; exit 2; }
 MESH_TIMEOUT="$((10#${MESH_TIMEOUT}))"; (( MESH_TIMEOUT >= 1 && MESH_TIMEOUT <= 600 )) || { echo "MESH_TIMEOUT must be an integer in [1, 600]" >&2; exit 2; }
 command -v lsof >/dev/null 2>&1 || finish_no_data "lsof_unavailable"; command -v perl >/dev/null 2>&1 || finish_no_data "perl_unavailable"
 build_go_node || finish_no_data "go_build_failed"

--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
-# RUB-21: launch one real Go node and one real Rust node, then prove a live
-# mixed-client mesh through process identity plus bidirectional peer snapshots.
 
 set -euo pipefail
-
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DEV_ENV="${REPO_ROOT}/scripts/dev-env.sh"
 GO_MODULE_ROOT="${REPO_ROOT}/clients/go"
@@ -13,7 +10,6 @@ VALIDATOR="${REPO_ROOT}/scripts/devnet/validate_mixed_client_evidence.py"
 
 CHECK_REPORT="" CHECK_REPORT_MODE=0
 MESH_TIMEOUT="${MESH_TIMEOUT:-90}"
-
 usage() { echo "usage: $0 [--check-report PATH]" >&2; }
 while (($#)); do
   case "$1" in
@@ -33,11 +29,9 @@ while (($#)); do
       ;;
   esac
 done
-
 need_tool() {
   command -v -- "$1" >/dev/null 2>&1 || { echo "$1 is required for mixed-client mesh evidence" >&2; exit 1; }
 }
-
 check_report() {
   local report="${1:-}"
   [[ -n "${report}" ]] || { echo "FAIL: report path is required" >&2; return 1; }
@@ -45,13 +39,13 @@ check_report() {
 import json
 import sys
 from pathlib import Path
-
 path = Path(sys.argv[1])
-
 def fail(message: str) -> None:
     print(f"FAIL: {message}", file=sys.stderr)
     sys.exit(1)
-
+def req(ok: bool, message: str) -> None:
+    if not ok:
+        fail(message)
 try:
     with path.open(encoding="utf-8") as f:
         data = json.load(f)
@@ -59,77 +53,47 @@ except OSError as exc:
     fail(f"cannot read report: {exc}")
 except json.JSONDecodeError as exc:
     fail(f"malformed JSON report: {exc}")
-
-if not isinstance(data, dict):
-    fail("report root is not an object")
-if data.get("scenario") != "mixed_client_mesh":
-    fail(f"scenario is not mixed_client_mesh: {data.get('scenario')!r}")
-verdict = data.get("verdict")
-if verdict != "PASS":
-    fail(f"report verdict is not PASS: {verdict!r}")
-if "failure_reason" in data or "schema_marker" in data:
-    fail("PASS report must not carry failure/schema-marker verdict fields")
+req(isinstance(data, dict), "report root is not an object")
+req(data.get("scenario") == "mixed_client_mesh", f"scenario is not mixed_client_mesh: {data.get('scenario')!r}")
+req(data.get("verdict") == "PASS", f"report verdict is not PASS: {data.get('verdict')!r}")
+req("failure_reason" not in data and "schema_marker" not in data, "PASS report must not carry failure/schema-marker verdict fields")
 legacy_schema = data.get("legacy_schema_compatibility")
-if not isinstance(legacy_schema, dict) or legacy_schema.get("authoritative") is not False or "verdict" in legacy_schema or not legacy_schema.get("marker_path"):
-    fail("legacy_schema_compatibility missing marker_path")
-
+req(isinstance(legacy_schema, dict) and legacy_schema.get("authoritative") is False and "verdict" not in legacy_schema and legacy_schema.get("marker_path"), "legacy_schema_compatibility missing marker_path")
 nodes = data.get("nodes")
-if not isinstance(nodes, list) or len(nodes) != 2 or not all(isinstance(node, dict) for node in nodes):
-    fail("PASS report requires exactly two node records")
-impls = {node.get("implementation") for node in nodes}
-if impls != {"go", "rust"}:
-    fail(f"PASS report requires one go and one rust node, got {sorted(str(impl) for impl in impls)}")
+req(isinstance(nodes, list) and len(nodes) == 2 and all(isinstance(n, dict) for n in nodes), "PASS report requires exactly two node records")
+impls = {n.get("implementation") for n in nodes}
+req(impls == {"go", "rust"}, f"PASS report requires one go and one rust node, got {sorted(str(i) for i in impls)}")
 expected_comm = {"go": "rubin-node-go", "rust": "rubin-node-rust"}
 nodes_by_impl = {node["implementation"]: node for node in nodes}
 for node in nodes:
     impl = node.get("implementation")
     name = node.get("name")
-    if not isinstance(name, str) or not name.startswith("node-"):
-        fail(f"node has invalid name: {name!r}")
-    if node.get("process_comm") != expected_comm.get(impl):
-        fail(f"{name} process_comm does not prove {impl} identity")
+    req(isinstance(name, str) and name.startswith("node-"), f"node has invalid name: {name!r}")
+    req(node.get("process_comm") == expected_comm.get(impl), f"{name} process_comm does not prove {impl} identity")
     for field in ("pid", "command", "binary", "rpc_endpoint", "p2p_endpoint", "started_at"):
-        if field not in node or node[field] in ("", None):
-            fail(f"{name} missing {field}")
-    if not isinstance(node["pid"], int) or node["pid"] <= 0:
-        fail(f"{name} pid is not a positive integer")
+        req(field in node and node[field] not in ("", None), f"{name} missing {field}")
+    req(isinstance(node["pid"], int) and node["pid"] > 0, f"{name} pid is not a positive integer")
     for field in ("process_alive", "rpc_endpoint_process_backed", "p2p_endpoint_process_backed"):
-        if node.get(field) is not True:
-            fail(f"{name} does not prove {field}")
-
+        req(node.get(field) is True, f"{name} does not prove {field}")
 connectivity = data.get("peer_connectivity")
-if not isinstance(connectivity, dict):
-    fail("PASS report missing peer_connectivity object")
-if any(connectivity.get(field) is not True for field in ("go_to_rust", "rust_to_go", "bidirectional_observed")):
-    fail("peer_connectivity booleans are not all true")
+req(isinstance(connectivity, dict), "PASS report missing peer_connectivity object")
+req(all(connectivity.get(f) is True for f in ("go_to_rust", "rust_to_go", "bidirectional_observed")), "peer_connectivity booleans are not all true")
 links = connectivity.get("counterpart_links")
-if not isinstance(links, dict):
-    fail("PASS report missing counterpart_links")
+req(isinstance(links, dict), "PASS report missing counterpart_links")
 go_expected = links.get("go_peer_snapshot_expected_addr")
 rust_expected = links.get("rust_peer_snapshot_expected_addr")
-if rust_expected != nodes_by_impl["go"]["p2p_endpoint"] or links.get("rust_outbound_remote_addr") != rust_expected or links.get("rust_outbound_local_addr") != go_expected or links.get("rust_outbound_pid") != nodes_by_impl["rust"]["pid"]:
-    fail("peer evidence is not bound to expected counterpart endpoints")
-if not isinstance(go_expected, str) or go_expected in {rust_expected, nodes_by_impl["rust"]["p2p_endpoint"], nodes_by_impl["go"]["rpc_endpoint"], nodes_by_impl["rust"]["rpc_endpoint"]}:
-    fail("go peer evidence is not a rust outbound peer address")
+req(rust_expected == nodes_by_impl["go"]["p2p_endpoint"] and links.get("rust_outbound_remote_addr") == rust_expected and links.get("rust_outbound_local_addr") == go_expected and links.get("rust_outbound_pid") == nodes_by_impl["rust"]["pid"], "peer evidence is not bound to expected counterpart endpoints")
+req(isinstance(go_expected, str) and go_expected not in {rust_expected, nodes_by_impl["rust"]["p2p_endpoint"], nodes_by_impl["go"]["rpc_endpoint"], nodes_by_impl["rust"]["rpc_endpoint"]}, "go peer evidence is not a rust outbound peer address")
 for field, expected_addr in (("go_peer_snapshot", go_expected), ("rust_peer_snapshot", rust_expected)):
     snapshot = connectivity.get(field)
-    if not isinstance(snapshot, dict) or snapshot.get("count", 0) < 1:
-        fail(f"{field} must show at least one peer")
+    req(isinstance(snapshot, dict) and snapshot.get("count", 0) >= 1, f"{field} must show at least one peer")
     peers = snapshot.get("peers")
-    if not isinstance(peers, list) or not peers or snapshot.get("count") != len(peers):
-        fail(f"{field}.peers/count are internally inconsistent")
-    if not any(peer.get("addr") == expected_addr and peer.get("handshake_complete") is True for peer in peers if isinstance(peer, dict)):
-        fail(f"{field} lacks completed handshake for expected counterpart")
-
+    req(isinstance(peers, list) and peers and snapshot.get("count") == len(peers), f"{field}.peers/count are internally inconsistent")
+    req(any(p.get("addr") == expected_addr and p.get("handshake_complete") is True for p in peers if isinstance(p, dict)), f"{field} lacks completed handshake for expected counterpart")
 print(f"PASS: mixed-client mesh report accepted {path}")
 PY
 }
-
-if [[ "${CHECK_REPORT_MODE}" == "1" ]]; then
-  need_tool python3
-  check_report "${CHECK_REPORT}"
-  exit 0
-fi
+if [[ "${CHECK_REPORT_MODE}" == "1" ]]; then need_tool python3; check_report "${CHECK_REPORT}"; exit 0; fi
 
 need_tool python3
 need_tool perl
@@ -150,11 +114,9 @@ REPORT_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/mixed-client-mesh-report.json"
 LEGACY_SCHEMA_MARKER_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/mixed-client-mesh-legacy-schema-marker.json"
 GO_PEERS_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/go-peers.json"
 RUST_PEERS_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/rust-peers.json"
-
 GO_PID="" RUST_PID="" GO_RPC_ADDR="" RUST_RPC_ADDR="" GO_P2P_ADDR="" RUST_P2P_ADDR="" GO_STARTED_AT_UTC="" RUST_STARTED_AT_UTC=""
 GO_COMM="" RUST_COMM="" RUST_TO_GO_LOCAL_ADDR="" GO_CMD="" RUST_CMD=""
 mkdir -p -- "${GO_DIR}" "${RUST_DIR}"
-
 run_fips_preflight_before_captured_dev_env() {
   if [[ "${RUBIN_OPENSSL_FIPS_MODE:-off}" != "only" || "${RUBIN_OPENSSL_SKIP_FIPS_GUARD:-0}" == "1" ]]; then
     return 0
@@ -162,15 +124,9 @@ run_fips_preflight_before_captured_dev_env() {
   echo "Running FIPS-only preflight before captured dev-env command streams" >&2
   "${DEV_ENV}" -- "${REPO_ROOT}/scripts/crypto/openssl/fips-preflight.sh" >&2
 }
-
 run_validator() {
   RUBIN_OPENSSL_SKIP_FIPS_GUARD=1 "${DEV_ENV}" -- python3 "${VALIDATOR}" "$@"
 }
-
-utc_now() {
-  python3 -c 'import datetime; print(datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"))'
-}
-
 rpc_json() {
   local method="$1" addr="$2" path="$3"
   python3 - "${method}" "${addr}" "${path}" <<'PY'
@@ -191,14 +147,12 @@ except (urllib.error.URLError, TimeoutError, socket.timeout) as exc:
     sys.exit(1)
 PY
 }
-
 pid_comm() {
   local pid="$1" comm
   comm="$(ps -p "${pid}" -o comm= 2>/dev/null | awk 'NR==1 {print $1}')" || return 1
   [[ -n "${comm}" ]] || return 1
   basename -- "${comm}"
 }
-
 pid_listens_on() {
   local pid="$1" endpoint="$2" out status=0
   out="$(lsof -nP -a -p "${pid}" -iTCP -sTCP:LISTEN -Fn 2>&1)" || status=$?
@@ -206,7 +160,6 @@ pid_listens_on() {
   (( status == 0 || ${#out} == 0 )) || return 2
   return 1
 }
-
 p2p_addr_for_pid() {
   local pid="$1" rpc_addr="$2" timeout="$3"
   python3 - "${pid}" "${rpc_addr}" "${timeout}" <<'PY'
@@ -241,7 +194,6 @@ while time.time() < deadline:
 sys.exit(f"timeout resolving p2p listen address for pid={pid}")
 PY
 }
-
 extract_log_addr() {
   local log_file="$1" prefix="$2" path addr
   path="$(_rubin_process_resolve_log "${log_file}")" || return 1
@@ -249,13 +201,11 @@ extract_log_addr() {
   [[ "${addr}" == 127.0.0.1:* ]] || return 1
   printf '%s\n' "${addr}"
 }
-
 build_go_node() {
   echo "Building Go rubin-node binary" >&2
   "${DEV_ENV}" -- go -C "${GO_MODULE_ROOT}" build -o "${GO_NODE_BIN}" ./cmd/rubin-node || return 1
   [[ -x "${GO_NODE_BIN}" ]]
 }
-
 build_rust_node() {
   local host_triple cargo_target_dir cargo_log cargo_bin
   echo "Building Rust rubin-node binary" >&2
@@ -308,7 +258,6 @@ write_outputs() {
   python3 - <<'PY'
 import json
 import os
-from pathlib import Path
 
 e = os.environ
 verdict = e["verdict"]
@@ -454,7 +403,7 @@ start_rust_node() {
   RUST_P2P_ADDR="$(extract_log_addr "${RUST_LOG}" "p2p: listening=")" || return 1
   RUST_RPC_ADDR="$(rubin_process_extract_rpc_addr "${RUST_LOG}")" || return 1
   rubin_process_wait_for_rpc_ready "${RUST_RPC_ADDR}" 30 || return 1
-  RUST_STARTED_AT_UTC="$(utc_now)"
+  RUST_STARTED_AT_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 }
 
 start_go_node() {
@@ -467,7 +416,7 @@ start_go_node() {
   GO_RPC_ADDR="$(rubin_process_extract_rpc_addr "${GO_LOG}")" || return 1
   GO_P2P_ADDR="$(p2p_addr_for_pid "${GO_PID}" "${GO_RPC_ADDR}" 30)" || return 1
   rubin_process_wait_for_rpc_ready "${GO_RPC_ADDR}" 30 || return 1
-  GO_STARTED_AT_UTC="$(utc_now)"
+  GO_STARTED_AT_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 }
 
 [[ "${MESH_TIMEOUT}" =~ ^[0-9]+$ && "${MESH_TIMEOUT}" -ge 1 && "${MESH_TIMEOUT}" -le 600 ]] || {

--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -52,7 +52,7 @@ def checked_path(label: str, value: object) -> Path:
 def ep(value: object) -> bool:
     if not isinstance(value, str): return False
     host, sep, port = value.partition(":")
-    return sep == ":" and host == "127.0.0.1" and ":" not in port and port.isascii() and port.isdigit() and 1 <= int(port) <= 65535
+    return sep == ":" and host == "127.0.0.1" and ":" not in port and port.isascii() and port.isdigit() and 1 <= len(port) <= 5 and 1 <= int(port) <= 65535
 def nonempty_str(value: object) -> bool: return isinstance(value, str) and bool(value.strip())
 def ps_comm(pid: int) -> str: return os.path.basename(run(["ps", "-ww", "-p", str(pid), "-o", "comm="]))
 def lsof_lines(pid: int, state: str) -> list[str]:
@@ -360,7 +360,7 @@ import json, sys
 with open(sys.argv[1], encoding="utf-8") as f:
     data = json.load(f)
 expected, peers, count = sys.argv[2], data.get("peers"), data.get("count")
-def ep(v): return isinstance(v, str) and v.count(":") == 1 and v.startswith("127.0.0.1:") and v.rsplit(":", 1)[-1].isdigit() and 1 <= int(v.rsplit(":", 1)[-1]) <= 65535
+def ep(v): return isinstance(v, str) and v.count(":") == 1 and v.startswith("127.0.0.1:") and (p := v.rsplit(":", 1)[-1]).isdigit() and 1 <= len(p) <= 5 and 1 <= int(p) <= 65535
 ok = isinstance(count, int) and not isinstance(count, bool) and isinstance(peers, list) and count == len(peers) and all(isinstance(p, dict) and ep(p.get("addr")) and isinstance(p.get("handshake_complete"), bool) for p in peers) and len({p.get("addr") for p in peers}) == len(peers) and any(p.get("addr") == expected and p.get("handshake_complete") is True for p in peers)
 sys.exit(0 if ok else 1)
 PY


### PR DESCRIPTION
Closes #1223

Invariant:
Mixed Go/Rust devnet mesh evidence must fail closed and must not accept helper-only, malformed, stale-process, arbitrary-peer, same-client, or shape-only PASS artifacts.

Layer:
Orchestration/evidence shell harness for process-level devnet proof.

Files changed:
- scripts/devnet-mixed-client-mesh.sh

Validation:
- /Users/gpt/bin/rubin-precommit-one-review --repo /Users/gpt/Documents/rubin-protocol-codex-rub-21 --base-ref origin/main --include-base-diff
- isolated stock code-review PASS on HEAD 8654c852e714f4ee638991d4d3ac1d400127b12e
- /Users/gpt/bin/rubin-push --repo /Users/gpt/Documents/rubin-protocol-codex-rub-21 --base-ref origin/main --coverage-cmd 'RUBIN_PROCESS_KEEP_ARTIFACTS=1 MESH_TIMEOUT=180 ./scripts/devnet-mixed-client-mesh.sh' -- origin HEAD

Coverage evidence:
- live mixed-client mesh smoke PASS
- produced report accepted while Go/Rust processes were live
- retained artifact root: /var/folders/h7/50y3jvf90qv0dlv472k6xrp80000gn/T/mixed-client-mesh.0BCivJ

Consensus impact: none.
Policy impact: none.
Go/Rust parity impact: evidence-only process mesh proof; no runtime behavior changes.
Non-scope: no tx submit/mine/converge proof, no restart proof, no partition-heal proof, no schema change, no Go/Rust runtime change.
