### PR TITLE
[RUB-22A] Add txgen from-key file input

### DIFF
--- a/clients/go/cmd/rubin-txgen/from_key_file_unix.go
+++ b/clients/go/cmd/rubin-txgen/from_key_file_unix.go
@@ -1,0 +1,34 @@
+//go:build unix
+
+package main
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+func openRegularFromKeyFile(path string) (*os.File, error) {
+	fd, err := syscall.Open(path, syscall.O_RDONLY|syscall.O_CLOEXEC|syscall.O_NOFOLLOW|syscall.O_NONBLOCK, 0)
+	if err != nil {
+		if errors.Is(err, syscall.ELOOP) {
+			return nil, errors.New("from-key-file must be a regular file")
+		}
+		return nil, errors.New("read from-key-file failed")
+	}
+	f := os.NewFile(uintptr(fd), path)
+	if f == nil {
+		_ = syscall.Close(fd)
+		return nil, errors.New("read from-key-file failed")
+	}
+	openedInfo, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return nil, errors.New("read from-key-file failed")
+	}
+	if !openedInfo.Mode().IsRegular() {
+		_ = f.Close()
+		return nil, errors.New("from-key-file must be a regular file")
+	}
+	return f, nil
+}

--- a/clients/go/cmd/rubin-txgen/from_key_file_unix_test.go
+++ b/clients/go/cmd/rubin-txgen/from_key_file_unix_test.go
@@ -1,0 +1,130 @@
+//go:build unix
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestLoadFromKeyDERReadsFromKeyFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "from-key.hex")
+	if err := os.WriteFile(path, []byte("00\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile from-key: %v", err)
+	}
+
+	der, err := loadFromKeyDER("", path)
+	if err != nil {
+		t.Fatalf("loadFromKeyDER: %v", err)
+	}
+	if !bytes.Equal(der, []byte{0x00}) {
+		t.Fatalf("der=%x, want 00", der)
+	}
+}
+
+func TestRunRejectsUnreadableFromKeyFile(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := run([]string{
+		"--from-key-file", filepath.Join(t.TempDir(), "missing.hex"),
+		"--to-key", "00",
+		"--amount", "1",
+	}, &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("missing from-key-file exit=%d", code)
+	}
+	if !strings.Contains(stderr.String(), "invalid from-key-file: read from-key-file") {
+		t.Fatalf("stderr=%q", stderr.String())
+	}
+}
+
+func TestOpenRegularFromKeyFileRejectsSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.hex")
+	if err := os.WriteFile(target, []byte("00"), 0o600); err != nil {
+		t.Fatalf("WriteFile target: %v", err)
+	}
+	link := filepath.Join(dir, "from-key.hex")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	f, err := openRegularFromKeyFile(link)
+	if err == nil {
+		_ = f.Close()
+		t.Fatal("expected symlink rejection")
+	}
+	if !strings.Contains(err.Error(), "from-key-file must be a regular file") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestRunRejectsNonRegularFromKeyFile(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := run([]string{
+		"--from-key-file", t.TempDir(),
+		"--to-key", "00",
+		"--amount", "1",
+	}, &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("non-regular from-key-file exit=%d", code)
+	}
+	if !strings.Contains(stderr.String(), "invalid from-key-file: from-key-file must be a regular file") {
+		t.Fatalf("stderr=%q", stderr.String())
+	}
+}
+
+func TestRunRejectsFIFOFromKeyFileWithoutBlocking(t *testing.T) {
+	fifoPath := filepath.Join(t.TempDir(), "from-key.fifo")
+	if err := syscall.Mkfifo(fifoPath, 0o600); err != nil {
+		t.Skipf("mkfifo unavailable: %v", err)
+	}
+	dataDir := t.TempDir()
+
+	done := make(chan string, 1)
+	go func() {
+		var stdout bytes.Buffer
+		var stderr bytes.Buffer
+		code := run([]string{
+			"--datadir", dataDir,
+			"--from-key-file", fifoPath,
+			"--to-key", "00",
+			"--amount", "1",
+		}, &stdout, &stderr)
+		done <- fmt.Sprintf("%d:%s", code, stderr.String())
+	}()
+
+	select {
+	case got := <-done:
+		if !strings.HasPrefix(got, "2:") {
+			t.Fatalf("fifo from-key-file result=%q", got)
+		}
+		if !strings.Contains(got, "invalid from-key-file: from-key-file must be a regular file") {
+			t.Fatalf("fifo from-key-file stderr=%q", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("run blocked opening FIFO from-key-file")
+	}
+}
+
+func TestLoadFromKeyDERRejectsOversizedFromKeyFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "from-key.hex")
+	if err := os.WriteFile(path, bytes.Repeat([]byte("0"), maxFromKeyFileBytes+1), 0o600); err != nil {
+		t.Fatalf("WriteFile oversized from-key: %v", err)
+	}
+
+	_, err := loadFromKeyDER("", path)
+	if err == nil {
+		t.Fatal("expected oversized from-key-file error")
+	}
+	if !strings.Contains(err.Error(), fmt.Sprintf("from-key-file exceeds %d bytes", maxFromKeyFileBytes)) {
+		t.Fatalf("err=%v", err)
+	}
+}

--- a/clients/go/cmd/rubin-txgen/from_key_file_unsupported.go
+++ b/clients/go/cmd/rubin-txgen/from_key_file_unsupported.go
@@ -1,0 +1,12 @@
+//go:build !unix
+
+package main
+
+import (
+	"errors"
+	"os"
+)
+
+func openRegularFromKeyFile(_ string) (*os.File, error) {
+	return nil, errors.New("from-key-file unsupported on this platform")
+}

--- a/clients/go/cmd/rubin-txgen/from_key_file_unsupported_test.go
+++ b/clients/go/cmd/rubin-txgen/from_key_file_unsupported_test.go
@@ -1,0 +1,36 @@
+//go:build !unix
+
+package main
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadFromKeyDERRejectsFromKeyFileUnsupported(t *testing.T) {
+	_, err := loadFromKeyDER("", filepath.Join(t.TempDir(), "from-key.hex"))
+	if err == nil {
+		t.Fatal("expected unsupported from-key-file error")
+	}
+	if !strings.Contains(err.Error(), "from-key-file unsupported on this platform") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestRunRejectsFromKeyFileUnsupported(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := run([]string{
+		"--from-key-file", filepath.Join(t.TempDir(), "from-key.hex"),
+		"--to-key", "00",
+		"--amount", "1",
+	}, &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("unsupported from-key-file exit=%d", code)
+	}
+	if !strings.Contains(stderr.String(), "invalid from-key-file: from-key-file unsupported on this platform") {
+		t.Fatalf("stderr=%q", stderr.String())
+	}
+}

--- a/clients/go/cmd/rubin-txgen/main.go
+++ b/clients/go/cmd/rubin-txgen/main.go
@@ -38,6 +38,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 
 	datadir := fs.String("datadir", node.DefaultDataDir(), "node data directory")
 	fromKeyHex := fs.String("from-key", "", "hex-encoded ML-DSA private key DER")
+	fromKeyFile := fs.String("from-key-file", "", "path to hex-encoded ML-DSA private key DER")
 	toKeyHex := fs.String("to-key", "", "destination P2PK key_id hex or canonical covenant_data hex")
 	amount := fs.Uint64("amount", 0, "transfer amount")
 	fee := fs.Uint64("fee", 0, "transaction fee")
@@ -45,8 +46,14 @@ func run(args []string, stdout, stderr io.Writer) int {
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
-	if strings.TrimSpace(*fromKeyHex) == "" {
-		_, _ = fmt.Fprintln(stderr, "missing required --from-key")
+	fromKeyFlagSet := strings.TrimSpace(*fromKeyHex) != ""
+	fromKeyFileSet := strings.TrimSpace(*fromKeyFile) != ""
+	if !fromKeyFlagSet && !fromKeyFileSet {
+		_, _ = fmt.Fprintln(stderr, "missing required --from-key or --from-key-file")
+		return 2
+	}
+	if fromKeyFlagSet && fromKeyFileSet {
+		_, _ = fmt.Fprintln(stderr, "--from-key and --from-key-file are mutually exclusive")
 		return 2
 	}
 	if strings.TrimSpace(*toKeyHex) == "" {
@@ -62,15 +69,19 @@ func run(args []string, stdout, stderr io.Writer) int {
 		return 2
 	}
 	dataDir := node.NormalizeDataDir(*datadir)
+	fromKeyErrorPrefix := "invalid from-key"
+	if fromKeyFileSet {
+		fromKeyErrorPrefix = "invalid from-key-file"
+	}
 
-	fromDER, err := decodeHexFlag(*fromKeyHex)
+	fromDER, err := loadFromKeyDER(*fromKeyHex, *fromKeyFile)
 	if err != nil {
-		_, _ = fmt.Fprintf(stderr, "invalid from-key: %v\n", err)
+		_, _ = fmt.Fprintf(stderr, "%s: %v\n", fromKeyErrorPrefix, err)
 		return 2
 	}
 	fromKey, err := consensus.NewMLDSA87KeypairFromDER(fromDER)
 	if err != nil {
-		_, _ = fmt.Fprintf(stderr, "invalid from-key: %v\n", err)
+		_, _ = fmt.Fprintf(stderr, "%s: %v\n", fromKeyErrorPrefix, err)
 		return 2
 	}
 	defer fromKey.Close()
@@ -214,6 +225,49 @@ func validateLocalSubmitHost(host string) error {
 		return fmt.Errorf("submit target host %q must be localhost or loopback", hostname)
 	}
 	return nil
+}
+
+const maxFromKeyFileBytes = 1 << 20
+
+func loadFromKeyDER(fromKeyHex string, fromKeyFile string) ([]byte, error) {
+	fromKeyFlagSet := strings.TrimSpace(fromKeyHex) != ""
+	fromKeyFileSet := strings.TrimSpace(fromKeyFile) != ""
+	switch {
+	case fromKeyFlagSet && fromKeyFileSet:
+		return nil, errors.New("--from-key and --from-key-file are mutually exclusive")
+	case fromKeyFileSet:
+		path := strings.TrimSpace(fromKeyFile)
+		f, err := openRegularFromKeyFile(path)
+		if err != nil {
+			return nil, err
+		}
+		defer f.Close()
+		raw, err := readOpenedFromKeyFile(f)
+		if err != nil {
+			return nil, err
+		}
+		return decodeHexFlag(string(raw))
+	default:
+		return decodeHexFlag(fromKeyHex)
+	}
+}
+
+func readOpenedFromKeyFile(f *os.File) ([]byte, error) {
+	openedInfo, err := f.Stat()
+	if err != nil {
+		return nil, errors.New("read from-key-file failed")
+	}
+	if !openedInfo.Mode().IsRegular() {
+		return nil, errors.New("from-key-file must be a regular file")
+	}
+	raw, err := io.ReadAll(io.LimitReader(f, maxFromKeyFileBytes+1))
+	if err != nil {
+		return nil, errors.New("read from-key-file failed")
+	}
+	if len(raw) > maxFromKeyFileBytes {
+		return nil, fmt.Errorf("from-key-file exceeds %d bytes", maxFromKeyFileBytes)
+	}
+	return raw, nil
 }
 
 func decodeHexFlag(value string) ([]byte, error) {

--- a/clients/go/cmd/rubin-txgen/main_test.go
+++ b/clients/go/cmd/rubin-txgen/main_test.go
@@ -157,7 +157,7 @@ func TestRunRejectsMissingRequiredFlags(t *testing.T) {
 	if code := run([]string{}, &stdout, &stderr); code != 2 {
 		t.Fatalf("missing from-key exit=%d", code)
 	}
-	if !strings.Contains(stderr.String(), "missing required --from-key") {
+	if stderr.String() != "missing required --from-key or --from-key-file\n" {
 		t.Fatalf("stderr=%q", stderr.String())
 	}
 
@@ -175,6 +175,109 @@ func TestRunRejectsMissingRequiredFlags(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "missing or zero --amount") {
 		t.Fatalf("stderr=%q", stderr.String())
+	}
+}
+
+func TestRunRejectsAmbiguousFromKeyInputs(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := run([]string{
+		"--from-key", "00",
+		"--from-key-file", filepath.Join(t.TempDir(), "from-key.hex"),
+		"--to-key", "00",
+		"--amount", "1",
+	}, &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("ambiguous from-key exit=%d", code)
+	}
+	if !strings.Contains(stderr.String(), "mutually exclusive") {
+		t.Fatalf("stderr=%q", stderr.String())
+	}
+}
+
+func TestRunKeepsDirectFromKeyDiagnosticPrefix(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := run([]string{
+		"--from-key", "0",
+		"--to-key", "00",
+		"--amount", "1",
+	}, &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("direct from-key exit=%d", code)
+	}
+	if !strings.HasPrefix(stderr.String(), "invalid from-key: ") {
+		t.Fatalf("stderr=%q", stderr.String())
+	}
+	if strings.HasPrefix(stderr.String(), "invalid from-key-file: ") {
+		t.Fatalf("direct from-key used file prefix: stderr=%q", stderr.String())
+	}
+}
+
+func TestRunUsesFromKeyFileDiagnosticPrefix(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := run([]string{
+		"--from-key-file", filepath.Join(t.TempDir(), "missing.hex"),
+		"--to-key", "00",
+		"--amount", "1",
+	}, &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("from-key-file exit=%d", code)
+	}
+	if !strings.HasPrefix(stderr.String(), "invalid from-key-file: ") {
+		t.Fatalf("stderr=%q", stderr.String())
+	}
+	if strings.HasPrefix(stderr.String(), "invalid from-key: ") {
+		t.Fatalf("from-key-file used direct prefix: stderr=%q", stderr.String())
+	}
+}
+
+func TestLoadFromKeyDERRejectsAmbiguousInputs(t *testing.T) {
+	_, err := loadFromKeyDER("00", filepath.Join(t.TempDir(), "from-key.hex"))
+	if err == nil {
+		t.Fatal("expected ambiguous from-key error")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestReadOpenedFromKeyFileRejectsNonRegularDescriptor(t *testing.T) {
+	dirHandle, err := os.Open(t.TempDir())
+	if err != nil {
+		t.Skipf("open directory handle unavailable: %v", err)
+	}
+	defer dirHandle.Close()
+
+	_, err = readOpenedFromKeyFile(dirHandle)
+	if err == nil {
+		t.Fatal("expected non-regular descriptor error")
+	}
+	if !strings.Contains(err.Error(), "from-key-file must be a regular file") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestReadOpenedFromKeyFileRejectsClosedDescriptor(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "from-key.hex")
+	if err := os.WriteFile(path, []byte("00"), 0o600); err != nil {
+		t.Fatalf("WriteFile from-key: %v", err)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("Open from-key: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("Close from-key: %v", err)
+	}
+
+	_, err = readOpenedFromKeyFile(f)
+	if err == nil {
+		t.Fatal("expected closed descriptor error")
+	}
+	if !strings.Contains(err.Error(), "read from-key-file failed") {
+		t.Fatalf("err=%v", err)
 	}
 }
 


### PR DESCRIPTION
Issue: RUB-22 split from #1525

Invariant:
- rubin-txgen can read ML-DSA private key DER hex from a bounded regular file, so callers do not need to pass private key material through argv.

Layer:
- implementation/tooling

Files changed:
- clients/go/cmd/rubin-txgen/**

Non-scope:
- devnet mixed-client mesh harness
- Go-submit/Rust-accept evidence production
- offline check-report hardening

Validation:
- scripts/dev-env.sh -- go -C clients/go test ./cmd/rubin-txgen
- scripts/dev-env.sh -- go -C clients/go vet ./cmd/rubin-txgen
- gofmt -l changed Go files
- git diff --check
- /Users/gpt/bin/rubin-push PASS

Consensus impact:
- none

Policy impact:
- none

Go/Rust parity impact:
- none; txgen CLI helper only
