### PR TITLE
RUB-22: reject public tx-path check-report proof

### DIFF
--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -4,7 +4,18 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DEV_ENV="${REPO_ROOT}/scripts/dev-env.sh"; GO_MODULE_ROOT="${REPO_ROOT}/clients/go"
 RUST_WORKSPACE_ROOT="${REPO_ROOT}/clients/rust"; HELPER="${REPO_ROOT}/scripts/devnet-process-common.sh"; VALIDATOR="${REPO_ROOT}/scripts/devnet/validate_mixed_client_evidence.py"
 CHECK_REPORT="" CHECK_REPORT_MODE="" MESH_TIMEOUT="${MESH_TIMEOUT:-90}" TX_PATH_MODE=0 DETERMINISTIC_TX_FEE="${DETERMINISTIC_TX_FEE:-100000000}"
-usage() { printf '%s\n' "usage: $0 [--go-submit-rust-accept]" "usage: $0 --check-report PATH" "usage: $0 --check-report-live PATH" "--check-report and --check-report-live validate mixed_client_mesh and mixed_client_go_submit_rust_accept reports." >&2; }
+usage() {
+  cat >&2 <<EOF
+usage:
+  $0 [--go-submit-rust-accept]
+  $0 --check-report PATH
+  $0 --check-report-live PATH
+
+--check-report and --check-report-live validate mixed_client_mesh reports only.
+mixed_client_go_submit_rust_accept proof is same-run producer validation and is not
+accepted from public report revalidation paths.
+EOF
+}
 while (($#)); do case "$1" in --go-submit-rust-accept) TX_PATH_MODE=1; shift ;; --check-report|--check-report-live) [[ $# -ge 2 ]] || { usage; exit 2; }; CHECK_REPORT_MODE=offline; [[ "$1" == "--check-report-live" ]] && CHECK_REPORT_MODE=live; CHECK_REPORT="$2"; shift 2 ;; -h|--help) usage; exit 0 ;; *) usage; exit 2 ;; esac; done
 if [[ -n "${CHECK_REPORT_MODE}" && "${TX_PATH_MODE}" == "1" ]]; then echo "--go-submit-rust-accept cannot be combined with --check-report or --check-report-live" >&2; exit 2; fi
 need_tool() { command -v -- "$1" >/dev/null 2>&1 || { echo "$1 is required for mixed-client mesh evidence" >&2; exit 1; }; }
@@ -15,12 +26,12 @@ validate_deterministic_tx_fee() {
   export DETERMINISTIC_TX_FEE
 }
 run_validator() { RUBIN_OPENSSL_SKIP_FIPS_GUARD=1 "${DEV_ENV}" -- python3 "${VALIDATOR}" "$@"; }
-check_report() { local report="${1:-}" mode="${2:-offline}"
+check_report() { local report="${1:-}" mode="${2:-offline}" expected_mode="${3:-public}"
   [[ -n "${report}" ]] || { echo "FAIL: report path is required" >&2; return 1; }
-  RUBIN_OPENSSL_SKIP_FIPS_GUARD=1 "${DEV_ENV}" -- python3 - "${report}" "${VALIDATOR}" "${mode}" "${DEV_ENV}" "${GO_MODULE_ROOT}" <<'PY'
+  RUBIN_OPENSSL_SKIP_FIPS_GUARD=1 "${DEV_ENV}" -- python3 - "${report}" "${VALIDATOR}" "${mode}" "${expected_mode}" "${DEV_ENV}" "${GO_MODULE_ROOT}" <<'PY'
 import datetime as dt, json, os, re, socket, struct, subprocess, sys, time, urllib.error, urllib.request
 from pathlib import Path
-path = Path(sys.argv[1]); live = sys.argv[3] == "live"; dev_env = sys.argv[4]; go_module_root = sys.argv[5]
+path = Path(sys.argv[1]); live = sys.argv[3] == "live"; expected_mode = sys.argv[4]; dev_env = sys.argv[5]; go_module_root = sys.argv[6]
 SCENARIO_MESH = "mixed_client_mesh"
 SCENARIO_TX = "mixed_client_go_submit_rust_accept"
 MAX_JSON_BYTES = 1_000_000
@@ -57,10 +68,11 @@ def load_bounded_json(label: str, p: Path) -> object:
             raw = f.read(MAX_JSON_BYTES + 1)
     except OSError as exc:
         fail(f"{label} read failed: {exc}")
+    req(raw != b"", f"{label} is empty")
     req(len(raw) <= MAX_JSON_BYTES, f"{label} is too large")
     try:
         return json.loads(raw.decode("utf-8"))
-    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+    except (json.JSONDecodeError, UnicodeDecodeError, RecursionError, ValueError) as exc:
         fail(f"{label} malformed JSON: {exc}")
 def load_json_file(label: str, p: Path) -> dict:
     data = load_bounded_json(label, p)
@@ -88,7 +100,7 @@ def tx_rpc(addr: str, path_suffix: str, label: str, impl: str) -> dict:
     except (urllib.error.URLError, TimeoutError, socket.timeout) as exc: fail(f"{label} rpc failed: {exc}")
     req(len(raw) <= 1000000, f"{label} rpc response too large")
     try: data = json.loads(raw.decode("utf-8"))
-    except (json.JSONDecodeError, UnicodeDecodeError) as exc: fail(f"{label} rpc malformed JSON: {exc}")
+    except (json.JSONDecodeError, UnicodeDecodeError, RecursionError, ValueError) as exc: fail(f"{label} rpc malformed JSON: {exc}")
     req(isinstance(data, dict), f"{label} rpc root is not an object")
     data.update({"implementation": impl, "rpc_endpoint": addr, "request_path": path_suffix})
     return data
@@ -107,7 +119,7 @@ def parse_txid_from_hex(txhex: str) -> str:
         fail(f"tx parser failed: {detail}")
     try:
         parsed = json.loads(stdout)
-    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+    except (json.JSONDecodeError, UnicodeDecodeError, RecursionError, ValueError) as exc:
         fail(f"tx parser malformed output: {exc}")
     req(isinstance(parsed, dict), "tx parser root is not an object")
     txid = parsed.get("txid")
@@ -164,7 +176,7 @@ def peers(addr: str) -> dict:
     req(len(raw) <= MAX_JSON_BYTES, f"live peer snapshot too large for {addr}")
     try:
         data = json.loads(raw.decode("utf-8"))
-    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+    except (json.JSONDecodeError, UnicodeDecodeError, RecursionError, ValueError) as exc:
         fail(f"live peer snapshot malformed JSON for {addr}: {exc}")
     req(isinstance(data, dict), f"live peer snapshot malformed JSON for {addr}")
     return data
@@ -181,9 +193,14 @@ def ts(value: object) -> bool:
     try: return dt.datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").strftime("%Y-%m-%dT%H:%M:%SZ") == value
     except ValueError: return False
 data = load_json_file("report", path)
+req(expected_mode in {"public", "producer-tx"}, f"check_report expected mode is invalid: {expected_mode!r}")
 scenario = data.get("scenario")
 tx_mode = scenario == SCENARIO_TX
 req(scenario in {SCENARIO_MESH, SCENARIO_TX}, f"scenario is not supported: {scenario!r}")
+if tx_mode and expected_mode != "producer-tx":
+    fail(("public tx-path check-report-live is unsupported" if live else "public tx-path check-report is unsupported") + "; same-run producer evidence is required")
+if expected_mode == "producer-tx":
+    req(tx_mode, "producer tx validation requires mixed_client_go_submit_rust_accept report")
 req(data.get("verdict") == "PASS", f"report verdict is not PASS: {data.get('verdict')!r}")
 req("failure_reason" not in data and "schema_marker" not in data, "PASS report must not carry failure/schema-marker verdict fields")
 base_keys = {"artifact_root", "final_verification", "legacy_schema_compatibility", "nodes", "peer_connectivity", "scenario", "verdict"}
@@ -317,7 +334,7 @@ rubin_process_exit_trap_with_tx_secret_cleanup() {
   exit "${cleanup_status}"
 }
 trap rubin_process_exit_trap_with_tx_secret_cleanup EXIT
-check_report_reason_token() { python3 -c 'import sys; msg=" ".join(x[5:].strip() for x in sys.stdin.read().splitlines() if x.startswith("FAIL:")); rules=[("live peer snapshot malformed JSON","live_peer_snapshot_malformed_json"),("differs from live exact peer set","live_peer_snapshot_mismatch"),("live listeners are not pid-owned","live_listener_not_pid_owned"),("rust outbound TCP link is not live and rust-owned","rust_outbound_link_not_live"),("argv_unavailable","argv_unavailable"),("live process argv/executable does not match report","argv_mismatch"),("lsof_timeout","lsof_timeout"),("lsof_unavailable","lsof_unavailable"),("lsof_failed","lsof_failed"),("pid_exe_failed","pid_exe_failed"),("pid_exe_unavailable","pid_exe_unavailable"),("argv","argv_mismatch"),("same pid","same_pid"),("process_comm","process_identity_invalid"),("process_alive","process_identity_invalid"),("process-backed","process_identity_invalid"),("peer snapshot","peer_snapshot_invalid"),("legacy marker","legacy_marker_invalid"),("failure/schema-marker","pass_report_has_failure_fields"),("failure_reason","pass_report_has_failure_fields"),("root is not an object","report_root_invalid")]; print(next((t for p,t in rules if p in msg), "unknown"))'; }
+check_report_reason_token() { python3 -c 'import sys; msg=" ".join(x[5:].strip() for x in sys.stdin.read().splitlines() if x.startswith("FAIL:")); rules=[("public tx-path check-report-live is unsupported","public_tx_path_check_report_live_unsupported"),("public tx-path check-report is unsupported","public_tx_path_check_report_unsupported"),("same-run producer evidence is required","tx_path_requires_same_run_producer_evidence"),("report path is required","report_path_required"),("report is not a regular file","report_not_regular_file"),("report is empty","report_empty"),("report is too large","report_too_large"),("report read failed","report_read_failed"),("report malformed JSON","report_malformed_json"),("live peer snapshot malformed JSON","live_peer_snapshot_malformed_json"),("differs from live exact peer set","live_peer_snapshot_mismatch"),("live listeners are not pid-owned","live_listener_not_pid_owned"),("rust outbound TCP link is not live and rust-owned","rust_outbound_link_not_live"),("argv_unavailable","argv_unavailable"),("live process argv/executable does not match report","argv_mismatch"),("lsof_timeout","lsof_timeout"),("lsof_unavailable","lsof_unavailable"),("lsof_failed","lsof_failed"),("pid_exe_failed","pid_exe_failed"),("pid_exe_unavailable","pid_exe_unavailable"),("argv","argv_mismatch"),("same pid","same_pid"),("process_comm","process_identity_invalid"),("process_alive","process_identity_invalid"),("process-backed","process_identity_invalid"),("peer snapshot","peer_snapshot_invalid"),("legacy marker","legacy_marker_invalid"),("failure/schema-marker","pass_report_has_failure_fields"),("failure_reason","pass_report_has_failure_fields"),("root is not an object","report_root_invalid")]; print(next((t for p,t in rules if p in msg), "unknown"))'; }
 tx_report_reason_token() {
   local msg
   msg="$(cat)"
@@ -879,7 +896,7 @@ if ! run_validator "${LEGACY_SCHEMA_MARKER_JSON}" >&2; then
   rm -f -- "${PASS_REPORT_JSON}"; finish_no_data "legacy_schema_marker_validation_failed"
 fi
 if (( TX_PATH_MODE == 1 )); then
-  if ! check_err="$(check_report "${PASS_REPORT_JSON}" live 2>&1)"; then
+  if ! check_err="$(check_report "${PASS_REPORT_JSON}" live producer-tx 2>&1)"; then
     rm -f -- "${PASS_REPORT_JSON}"; finish_no_data "pass_report_live_validation_$(combined_report_reason_token <<<"${check_err}")"
   fi
 else

--- a/scripts/devnet/test_mixed_client_mesh_check_report.sh
+++ b/scripts/devnet/test_mixed_client_mesh_check_report.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HARNESS="${REPO_ROOT}/scripts/devnet-mixed-client-mesh.sh"
+DEV_ENV="${REPO_ROOT}/scripts/dev-env.sh"
+VALIDATOR="${REPO_ROOT}/scripts/devnet/validate_mixed_client_evidence.py"
+GO_MODULE_ROOT="${REPO_ROOT}/clients/go"
+MESH_TIMEOUT=1
+export GO_MODULE_ROOT
+export MESH_TIMEOUT
+
+command -v python3 >/dev/null 2>&1 || { echo "python3 is required" >&2; exit 1; }
+[[ -x "${HARNESS}" ]] || { echo "mixed-client mesh harness missing or non-executable: ${HARNESS}" >&2; exit 1; }
+[[ -x "${DEV_ENV}" ]] || { echo "dev-env wrapper missing or non-executable: ${DEV_ENV}" >&2; exit 1; }
+[[ -r "${VALIDATOR}" ]] || { echo "validator unreadable: ${VALIDATOR}" >&2; exit 1; }
+
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/rubin-mesh-check-report.XXXXXX")"
+cleanup() {
+  rm -rf -- "${TMP_ROOT}"
+}
+trap cleanup EXIT
+
+require_contains() {
+  local output="$1" needle="$2" label="$3"
+  if [[ "${output}" != *"${needle}"* ]]; then
+    echo "FAIL: ${label} missing expected text: ${needle}" >&2
+    echo "actual output:" >&2
+    printf '%s\n' "${output}" >&2
+    exit 1
+  fi
+}
+
+expect_pass_contains() {
+  local label="$1" needle="$2" output
+  shift 2
+  if ! output="$("$@" 2>&1)"; then
+    echo "FAIL: ${label} should pass" >&2
+    echo "actual output:" >&2
+    printf '%s\n' "${output}" >&2
+    exit 1
+  fi
+  require_contains "${output}" "${needle}" "${label}"
+}
+
+expect_fail_contains() {
+  local label="$1" needle="$2" output
+  shift 2
+  if output="$("$@" 2>&1)"; then
+    echo "FAIL: ${label} should fail" >&2
+    echo "actual output:" >&2
+    printf '%s\n' "${output}" >&2
+    exit 1
+  fi
+  require_contains "${output}" "${needle}" "${label}"
+}
+
+extract_check_report() {
+  python3 - "${HARNESS}" "${CHECK_REPORT_LIB}" <<'PY'
+from pathlib import Path
+import sys
+
+src, dst = map(Path, sys.argv[1:3])
+lines = src.read_text(encoding="utf-8").splitlines()
+start = next(i for i, line in enumerate(lines) if line.startswith("check_report()"))
+end = next(i for i, line in enumerate(lines[start:], start) if line.startswith('[[ "${MESH_TIMEOUT}"'))
+Path(dst).write_text("\n".join(lines[start:end]) + "\n", encoding="utf-8")
+PY
+}
+
+write_reports() {
+  python3 - "${TMP_ROOT}" <<'PY'
+from pathlib import Path
+import json
+import stat
+import sys
+
+root = Path(sys.argv[1])
+artifact_root = root / "artifact-root"
+artifact_root.mkdir()
+(artifact_root / "node-go").mkdir()
+(artifact_root / "node-rust").mkdir()
+go_bin = artifact_root / "rubin-node-go"
+rust_bin = artifact_root / "rubin-node-rust"
+for path in (go_bin, rust_bin):
+    path.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+tx_hex = "010000000001000000000000000001010000000000000000016954e89e15c3eef53f39d5e758fd47dfc84f15f042cd83edc0c93723e93b7d0a83000a00000000000000b3ec7cf4503854f1f691ffb3c0bde5e22af4705161edb20ede25a62e3209a716b3ec7cf4503854f1f691ffb3c0bde5e22af4705161edb20ede25a62e3209a716000000000000"
+txid = "d379ae84430d5296e97a71ba8e6996d869b8c6e85b13b51ab0d8ee23455057e1"
+go_rpc = "127.0.0.1:51001"
+go_p2p = "127.0.0.1:51002"
+rust_rpc = "127.0.0.1:51003"
+rust_p2p = "127.0.0.1:51004"
+rust_outbound = "127.0.0.1:51005"
+go_started = "2026-05-12T10:00:00Z"
+rust_started = "2026-05-12T10:00:01Z"
+
+def dump(path: Path, data: object) -> None:
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+def node(impl: str) -> dict:
+    is_go = impl == "go"
+    name = "node-go" if is_go else "node-rust"
+    binary = go_bin if is_go else rust_bin
+    argv = [
+        str(binary),
+        "--network",
+        "devnet",
+        "--datadir",
+        str(artifact_root / name),
+        "--bind",
+        "127.0.0.1:0",
+        "--rpc-bind",
+        "127.0.0.1:0",
+    ]
+    if not is_go:
+        argv.extend(["--peer", go_p2p])
+    return {
+        "binary": str(binary),
+        "command": " ".join(argv),
+        "command_argv": argv,
+        "implementation": impl,
+        "name": name,
+        "p2p_endpoint": go_p2p if is_go else rust_p2p,
+        "p2p_endpoint_process_backed": True,
+        "pid": 41001 if is_go else 41002,
+        "process_alive": True,
+        "process_comm": "rubin-node-go" if is_go else "rubin-node-rust",
+        "rpc_endpoint": go_rpc if is_go else rust_rpc,
+        "rpc_endpoint_process_backed": True,
+        "started_at": go_started if is_go else rust_started,
+    }
+
+nodes = [node("go"), node("rust")]
+connectivity = {
+    "bidirectional_observed": True,
+    "counterpart_links": {
+        "go_peer_snapshot_expected_addr": rust_outbound,
+        "rust_outbound_local_addr": rust_outbound,
+        "rust_outbound_pid": 41002,
+        "rust_outbound_remote_addr": go_p2p,
+        "rust_peer_snapshot_expected_addr": go_p2p,
+    },
+    "go_peer_snapshot": {"count": 1, "peers": [{"addr": rust_outbound, "handshake_complete": True}]},
+    "go_to_rust": True,
+    "rust_peer_snapshot": {"count": 1, "peers": [{"addr": go_p2p, "handshake_complete": True}]},
+    "rust_to_go": True,
+}
+final_verification = {
+    "peer_snapshots_rechecked": True,
+    "process_identity_rechecked": True,
+    "producer_side": True,
+    "rust_outbound_link_rechecked": True,
+    "rust_outbound_local_addr": rust_outbound,
+    "rust_outbound_pid": 41002,
+    "rust_outbound_remote_addr": go_p2p,
+}
+
+mesh_marker = artifact_root / "mesh-marker.json"
+dump(mesh_marker, {
+    "evidence_type": "mixed_client_process_soak",
+    "failure_reason": "schema v1 PASS requires tx_path; mesh PASS lives in sibling report",
+    "participants": [
+        {"endpoint": go_rpc, "implementation": "go", "name": "node-go", "started_at": go_started},
+        {"endpoint": rust_rpc, "implementation": "rust", "name": "node-rust", "started_at": rust_started},
+    ],
+    "scenario": "mixed_client_mesh_schema_marker",
+    "schema_version": "rubin-mixed-client-devnet-evidence-v1",
+    "verdict": "FAIL",
+})
+mesh_report = {
+    "artifact_root": str(artifact_root),
+    "final_verification": final_verification,
+    "legacy_schema_compatibility": {
+        "authoritative": False,
+        "marker_path": str(mesh_marker),
+        "purpose": "schema-valid legacy artifact only; not the mesh report verdict",
+        "reason": "existing mixed_client_evidence_v1 PASS requires tx_path",
+    },
+    "nodes": nodes,
+    "peer_connectivity": connectivity,
+    "scenario": "mixed_client_mesh",
+    "verdict": "PASS",
+}
+dump(root / "mesh-report.json", mesh_report)
+
+tx_marker = artifact_root / "tx-marker.json"
+tx_path = {"observed_at": ["node-rust"], "submitted_at": "node-go", "tx_id": txid}
+dump(tx_marker, {
+    "evidence_type": "mixed_client_process_soak",
+    "participants": [
+        {"endpoint": go_rpc, "implementation": "go", "name": "node-go", "started_at": go_started},
+        {"endpoint": rust_rpc, "implementation": "rust", "name": "node-rust", "started_at": rust_started},
+    ],
+    "scenario": "mixed_client_mesh_schema_marker",
+    "schema_version": "rubin-mixed-client-devnet-evidence-v1",
+    "tx_path": tx_path,
+    "verdict": "PASS",
+})
+for impl, endpoint, prefix in (("go", go_rpc, "go"), ("rust", rust_rpc, "rust")):
+    status_path = artifact_root / f"{prefix}-tx-status.json"
+    get_path = artifact_root / f"{prefix}-get-tx.json"
+    dump(status_path, {
+        "implementation": impl,
+        "request_path": f"/tx_status?txid={txid}",
+        "rpc_endpoint": endpoint,
+        "status": "pending",
+        "txid": txid,
+    })
+    dump(get_path, {
+        "found": True,
+        "implementation": impl,
+        "raw_hex": tx_hex,
+        "request_path": f"/get_tx?txid={txid}",
+        "rpc_endpoint": endpoint,
+        "txid": txid,
+    })
+tx_report = {
+    **mesh_report,
+    "go_submit": {
+        "get_tx_path": str(artifact_root / "go-get-tx.json"),
+        "rpc_endpoint": go_rpc,
+        "tx_hex": tx_hex,
+        "tx_status_path": str(artifact_root / "go-tx-status.json"),
+        "txid": txid,
+    },
+    "legacy_schema_compatibility": {**mesh_report["legacy_schema_compatibility"], "marker_path": str(tx_marker)},
+    "rust_accept": {
+        "get_tx_path": str(artifact_root / "rust-get-tx.json"),
+        "raw_hex": tx_hex,
+        "rpc_endpoint": rust_rpc,
+        "tx_status_path": str(artifact_root / "rust-tx-status.json"),
+        "txid": txid,
+    },
+    "scenario": "mixed_client_go_submit_rust_accept",
+    "tx_path": tx_path,
+}
+dump(root / "tx-report.json", tx_report)
+(root / "empty.json").write_text("", encoding="utf-8")
+(root / "malformed.json").write_text("[", encoding="utf-8")
+with (root / "oversized.json").open("wb") as f:
+    f.write(b" " * 1_000_001)
+print(root / "mesh-report.json")
+print(root / "tx-report.json")
+PY
+}
+
+CHECK_REPORT_LIB="${TMP_ROOT}/check-report-lib.sh"
+extract_check_report
+# shellcheck source=/dev/null
+source "${CHECK_REPORT_LIB}"
+REPORT_LIST="${TMP_ROOT}/reports.txt"
+write_reports >"${REPORT_LIST}"
+MESH_REPORT="$(sed -n '1p' "${REPORT_LIST}")"
+TX_REPORT="$(sed -n '2p' "${REPORT_LIST}")"
+[[ -n "${MESH_REPORT}" && -n "${TX_REPORT}" ]] || { echo "failed to build synthetic reports" >&2; exit 1; }
+
+expect_pass_contains "public mesh check-report" "PASS: mixed_client_mesh report structurally accepted" "${HARNESS}" --check-report "${MESH_REPORT}"
+expect_fail_contains "public tx check-report" "public tx-path check-report is unsupported" "${HARNESS}" --check-report "${TX_REPORT}"
+expect_fail_contains "public tx check-report-live" "public tx-path check-report-live is unsupported" "${HARNESS}" --check-report-live "${TX_REPORT}"
+expect_fail_contains "combined tx flag and check-report" "cannot be combined" "${HARNESS}" --go-submit-rust-accept --check-report "${TX_REPORT}"
+
+expect_pass_contains "producer tx internal check" "PASS: mixed_client_go_submit_rust_accept report structurally accepted" check_report "${TX_REPORT}" offline producer-tx
+expect_fail_contains "producer rejects mesh report" "producer tx validation requires mixed_client_go_submit_rust_accept report" check_report "${MESH_REPORT}" offline producer-tx
+
+expect_fail_contains "non-regular report" "report is not a regular file" "${HARNESS}" --check-report "${TMP_ROOT}"
+expect_fail_contains "empty report" "report is empty" "${HARNESS}" --check-report "${TMP_ROOT}/empty.json"
+expect_fail_contains "malformed report" "report malformed JSON" "${HARNESS}" --check-report "${TMP_ROOT}/malformed.json"
+expect_fail_contains "oversized report" "report is too large" "${HARNESS}" --check-report "${TMP_ROOT}/oversized.json"
+
+printf 'PASS: mixed-client mesh check-report public/internal boundaries are covered\n'


### PR DESCRIPTION
Refs RUB-22.

Invariant:
Public `--check-report` and `--check-report-live` must not accept retained `mixed_client_go_submit_rust_accept` reports as reusable proof. Tx-path proof remains same-run producer validation only.

Layer:
Orchestration/evidence harness.

Files changed:
- `scripts/devnet-mixed-client-mesh.sh`
- `scripts/devnet/test_mixed_client_mesh_check_report.sh`

Tests:
- `bash -n scripts/devnet-mixed-client-mesh.sh scripts/devnet/test_mixed_client_mesh_check_report.sh`
- `shellcheck scripts/devnet-mixed-client-mesh.sh scripts/devnet/test_mixed_client_mesh_check_report.sh`
- `/Users/gpt/bin/rubin-shell-harness-lint --repo /Users/gpt/Documents/rubin-protocol-codex-rub-22c1-check-report scripts/devnet-mixed-client-mesh.sh scripts/devnet/test_mixed_client_mesh_check_report.sh`
- `scripts/devnet/test_mixed_client_mesh_check_report.sh`
- `/Users/gpt/bin/rubin-precommit-one-review --repo /Users/gpt/Documents/rubin-protocol-codex-rub-22c1-check-report --base-ref origin/main --include-base-diff`
- isolated stock code-review: No findings
- `/Users/gpt/bin/rubin-push --repo /Users/gpt/Documents/rubin-protocol-codex-rub-22c1-check-report --base-ref origin/main --coverage-cmd 'scripts/devnet/test_mixed_client_mesh_check_report.sh' -- origin HEAD`\n\nBehavior impact:\nPublic offline/live report revalidation remains available for `mixed_client_mesh`; tx-path reports are rejected with deterministic unsupported-mode diagnostics.\n\nKnown non-goals:\n- No Go `rubin-txgen` changes.\n- No `--from-key-file` work.\n- No producer-side proof expansion beyond keeping same-run internal validation reachable.\n\nFollow-ups:\nC2 will handle producer/internal proof polish if still needed after this boundary slice merges.