### PR TITLE
RUB-232: announce Rust-mined devnet blocks

### DIFF
--- a/clients/rust/crates/rubin-node/src/devnet_rpc.rs
+++ b/clients/rust/crates/rubin-node/src/devnet_rpc.rs
@@ -3344,6 +3344,112 @@ mod tests {
     }
 
     #[test]
+    fn mine_next_returns_422_when_miner_rejects_block() {
+        let (state, dir) = build_state_with_live_mining(true);
+        {
+            let mut engine = state.sync_engine.lock().expect("sync engine");
+            engine.chain_state.has_tip = true;
+            engine.chain_state.height = u64::MAX;
+        }
+
+        let response = route_request(
+            &state,
+            HttpRequest {
+                method: "POST".to_string(),
+                target: "/mine_next".to_string(),
+                body: b"{}".to_vec(),
+            },
+        );
+
+        assert_eq!(response.status, 422);
+        let json = response_json(&response);
+        assert_eq!(json["mined"].as_bool(), Some(false));
+        assert_eq!(json["error"].as_str(), Some("height overflow"));
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn mine_next_skips_announce_when_rpc_block_store_missing() {
+        let (mut state, dir) = build_state_with_live_mining(true);
+        state.block_store = None;
+        let announced = Arc::new(Mutex::new(false));
+        let announced_clone = Arc::clone(&announced);
+        state.announce_block = Some(Arc::new(move |_| {
+            *announced_clone.lock().expect("announce lock") = true;
+            Ok(())
+        }));
+
+        let response = route_request(
+            &state,
+            HttpRequest {
+                method: "POST".to_string(),
+                target: "/mine_next".to_string(),
+                body: b"{}".to_vec(),
+            },
+        );
+
+        assert_eq!(response.status, 200);
+        assert_eq!(response_json(&response)["mined"].as_bool(), Some(true));
+        assert!(
+            !*announced.lock().expect("announce lock"),
+            "announce_block must not run without block bytes",
+        );
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn mine_next_skips_announce_when_rpc_block_store_lacks_mined_block() {
+        let (mut state, dir) = build_state_with_live_mining(true);
+        let empty_dir = unique_temp_path("rubin-devnet-rpc-empty-blockstore");
+        fs::create_dir_all(&empty_dir).expect("mkdir empty blockstore");
+        state.block_store =
+            Some(BlockStore::open(block_store_path(&empty_dir)).expect("empty blockstore"));
+        let announced = Arc::new(Mutex::new(false));
+        let announced_clone = Arc::clone(&announced);
+        state.announce_block = Some(Arc::new(move |_| {
+            *announced_clone.lock().expect("announce lock") = true;
+            Ok(())
+        }));
+
+        let response = route_request(
+            &state,
+            HttpRequest {
+                method: "POST".to_string(),
+                target: "/mine_next".to_string(),
+                body: b"{}".to_vec(),
+            },
+        );
+
+        assert_eq!(response.status, 200);
+        assert_eq!(response_json(&response)["mined"].as_bool(), Some(true));
+        assert!(
+            !*announced.lock().expect("announce lock"),
+            "announce_block must not run when block bytes cannot be reloaded",
+        );
+        fs::remove_dir_all(empty_dir).expect("cleanup empty blockstore");
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn mine_next_logs_announce_block_error_without_failing_rpc() {
+        let (mut state, dir) = build_state_with_live_mining(true);
+        state.announce_block = Some(Arc::new(|_| Err("forced announce failure".to_string())));
+
+        let response = route_request(
+            &state,
+            HttpRequest {
+                method: "POST".to_string(),
+                target: "/mine_next".to_string(),
+                body: b"{}".to_vec(),
+            },
+        );
+
+        assert_eq!(response.status, 200);
+        assert_eq!(response_json(&response)["mined"].as_bool(), Some(true));
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
     fn get_tip_rejects_bad_method() {
         let (state, dir) = build_state(false);
         let response = route_request(

--- a/clients/rust/crates/rubin-node/src/devnet_rpc.rs
+++ b/clients/rust/crates/rubin-node/src/devnet_rpc.rs
@@ -39,6 +39,7 @@ const RPC_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 
 pub type AnnounceTxFn =
     Arc<dyn Fn(&[u8], crate::txpool::RelayTxMetadata) -> Result<(), String> + Send + Sync>;
+pub type AnnounceBlockFn = Arc<dyn Fn(&[u8]) -> Result<(), String> + Send + Sync>;
 
 #[derive(Clone)]
 pub struct DevnetRPCState {
@@ -49,6 +50,7 @@ pub struct DevnetRPCState {
     metrics: Arc<RpcMetrics>,
     now_unix: fn() -> u64,
     announce_tx: Option<AnnounceTxFn>,
+    announce_block: Option<AnnounceBlockFn>,
     /// Serializes mutating devnet RPC (submit_tx + mine_next).
     rpc_op_lock: Arc<Mutex<()>>,
     /// When set, POST `/mine_next` mines one block using this config (devnet + loopback RPC only).
@@ -473,6 +475,7 @@ pub fn new_devnet_rpc_state(
     block_store: Option<BlockStore>,
     peer_manager: Arc<PeerManager>,
     announce_tx: Option<AnnounceTxFn>,
+    announce_block: Option<AnnounceBlockFn>,
 ) -> DevnetRPCState {
     let tx_pool = new_shared_runtime_tx_pool(&sync_engine);
     new_devnet_rpc_state_with_tx_pool(
@@ -481,6 +484,7 @@ pub fn new_devnet_rpc_state(
         tx_pool,
         peer_manager,
         announce_tx,
+        announce_block,
         None,
     )
 }
@@ -491,6 +495,7 @@ pub fn new_devnet_rpc_state_with_tx_pool(
     tx_pool: Arc<Mutex<TxPool>>,
     peer_manager: Arc<PeerManager>,
     announce_tx: Option<AnnounceTxFn>,
+    announce_block: Option<AnnounceBlockFn>,
     live_mining_cfg: Option<MinerConfig>,
 ) -> DevnetRPCState {
     DevnetRPCState {
@@ -501,6 +506,7 @@ pub fn new_devnet_rpc_state_with_tx_pool(
         metrics: Arc::new(RpcMetrics::default()),
         now_unix: current_unix,
         announce_tx,
+        announce_block,
         rpc_op_lock: Arc::new(Mutex::new(())),
         live_mining_cfg,
         // RUB-10 / GitHub #1151: gate starts in `NotReady`. The
@@ -1453,6 +1459,7 @@ fn handle_mine_next(state: &DevnetRPCState, method: &str, _body: &[u8]) -> HttpR
             },
         );
     };
+    let block_store = state.block_store.clone();
     let _rpc_op = match state.rpc_op_lock.lock() {
         Ok(g) => g,
         Err(_) => {
@@ -1529,36 +1536,67 @@ fn handle_mine_next(state: &DevnetRPCState, method: &str, _body: &[u8]) -> HttpR
             );
         }
     };
-    match miner.mine_one(&[]) {
-        Ok(b) => json_response(
-            state,
-            ROUTE,
-            200,
-            &MineNextResponse {
-                mined: true,
-                height: Some(b.height),
-                block_hash: Some(hex::encode(b.hash)),
-                timestamp: Some(b.timestamp),
-                nonce: Some(b.nonce),
-                tx_count: Some(b.tx_count),
-                error: None,
-            },
-        ),
-        Err(err) => json_response(
-            state,
-            ROUTE,
-            422,
-            &MineNextResponse {
-                mined: false,
-                height: None,
-                block_hash: None,
-                timestamp: None,
-                nonce: None,
-                tx_count: None,
-                error: Some(err),
-            },
-        ),
+    let mined = match miner.mine_one(&[]) {
+        Ok(b) => b,
+        Err(err) => {
+            return json_response(
+                state,
+                ROUTE,
+                422,
+                &MineNextResponse {
+                    mined: false,
+                    height: None,
+                    block_hash: None,
+                    timestamp: None,
+                    nonce: None,
+                    tx_count: None,
+                    error: Some(err),
+                },
+            )
+        }
+    };
+    drop(miner);
+    drop(pool);
+    drop(sync_engine);
+    drop(_rpc_op);
+    let block_bytes = match block_store {
+        Some(store) => match store.get_block_by_hash(mined.hash) {
+            Ok(bytes) => Some(bytes),
+            Err(err) => {
+                eprintln!(
+                    "rpc: announce-block: get mined block {}: {err}",
+                    hex::encode(mined.hash)
+                );
+                None
+            }
+        },
+        None => {
+            eprintln!(
+                "rpc: announce-block: block store unavailable for {}",
+                hex::encode(mined.hash)
+            );
+            None
+        }
+    };
+    if let (Some(announce), Some(bytes)) = (state.announce_block.as_ref(), block_bytes.as_ref()) {
+        if let Err(err) = announce(bytes) {
+            eprintln!("rpc: announce-block: {err}");
+        }
     }
+    json_response(
+        state,
+        ROUTE,
+        200,
+        &MineNextResponse {
+            mined: true,
+            height: Some(mined.height),
+            block_hash: Some(hex::encode(mined.hash)),
+            timestamp: Some(mined.timestamp),
+            nonce: Some(mined.nonce),
+            tx_count: Some(mined.tx_count),
+            error: None,
+        },
+    )
 }
 
 /// Percent-decode a query component to raw bytes.  Returns `None` only on
@@ -2702,7 +2740,7 @@ mod tests {
     use std::sync::{Arc, Mutex};
     use std::time::{Duration, Instant};
 
-    use rubin_consensus::{block_hash, parse_tx, Outpoint, UtxoEntry};
+    use rubin_consensus::{block_hash, parse_block_bytes, parse_tx, Outpoint, UtxoEntry};
     use serde_json::Value;
 
     use crate::io_utils::unique_temp_path;
@@ -2746,6 +2784,7 @@ mod tests {
             Some(rpc_block_store),
             Arc::new(PeerManager::new(default_peer_runtime_config("devnet", 8))),
             None,
+            None,
         );
         (state, dir)
     }
@@ -2777,6 +2816,7 @@ mod tests {
             Some(rpc_block_store),
             tx_pool,
             Arc::new(PeerManager::new(default_peer_runtime_config("devnet", 8))),
+            None,
             None,
             Some(live_cfg),
         );
@@ -3022,6 +3062,7 @@ mod tests {
             metrics: Arc::new(super::RpcMetrics::default()),
             now_unix: super::current_unix,
             announce_tx: None,
+            announce_block: None,
             rpc_op_lock: Arc::new(Mutex::new(())),
             live_mining_cfg: None,
             // RUB-10 / GitHub #1151: this helper bypasses the public
@@ -3258,6 +3299,47 @@ mod tests {
             json["timestamp"].as_u64().is_some(),
             "timestamp must be present"
         );
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn mine_next_announces_mined_block_on_success() {
+        let (mut state, dir) = build_state_with_live_mining(true);
+        let announced = Arc::new(Mutex::new(None::<Vec<u8>>));
+        let announced_clone = Arc::clone(&announced);
+        state.announce_block = Some(Arc::new(move |block_bytes: &[u8]| {
+            *announced_clone.lock().expect("announce lock") = Some(block_bytes.to_vec());
+            Ok(())
+        }));
+
+        let response = route_request(
+            &state,
+            HttpRequest {
+                method: "POST".to_string(),
+                target: "/mine_next".to_string(),
+                body: b"{}".to_vec(),
+            },
+        );
+
+        assert_eq!(
+            response.status,
+            200,
+            "{}",
+            String::from_utf8_lossy(&response.body)
+        );
+        let json = response_json(&response);
+        let expected_hash = json["block_hash"]
+            .as_str()
+            .expect("mine_next block_hash")
+            .to_string();
+        let block_bytes = announced
+            .lock()
+            .expect("announce lock")
+            .take()
+            .expect("announce_block must receive mined block bytes");
+        let parsed = parse_block_bytes(&block_bytes).expect("parse announced block");
+        let announced_hash = block_hash(&parsed.header_bytes).expect("announced block hash");
+        assert_eq!(hex::encode(announced_hash), expected_hash);
         fs::remove_dir_all(dir).expect("cleanup");
     }
 
@@ -4798,6 +4880,7 @@ mod tests {
             metrics: Arc::new(super::RpcMetrics::default()),
             now_unix: || 0,
             announce_tx: None,
+            announce_block: None,
             rpc_op_lock: Arc::new(Mutex::new(())),
             live_mining_cfg: None,
             // RUB-10 / GitHub #1151: render_prometheus_metrics test does
@@ -5449,6 +5532,7 @@ mod tests {
             Some(rpc_block_store),
             Arc::new(PeerManager::new(default_peer_runtime_config("devnet", 8))),
             None,
+            None,
         );
         let server = start_devnet_rpc_server("127.0.0.1:0", state).expect("start");
         let addr = server.addr().to_string();
@@ -5495,6 +5579,7 @@ mod tests {
             Arc::new(Mutex::new(engine)),
             Some(rpc_block_store),
             Arc::new(PeerManager::new(default_peer_runtime_config("devnet", 8))),
+            None,
             None,
         );
         let server = start_devnet_rpc_server("127.0.0.1:0", state).expect("start");

--- a/clients/rust/crates/rubin-node/src/devnet_rpc.rs
+++ b/clients/rust/crates/rubin-node/src/devnet_rpc.rs
@@ -3266,6 +3266,17 @@ mod tests {
         fs::remove_dir_all(dir).expect("cleanup");
     }
 
+    fn post_mine_next(state: &super::DevnetRPCState) -> super::HttpResponse {
+        route_request(
+            state,
+            HttpRequest {
+                method: "POST".to_string(),
+                target: "/mine_next".to_string(),
+                body: b"{}".to_vec(),
+            },
+        )
+    }
+
     #[test]
     fn mine_next_mines_after_genesis() {
         let (state, dir) = build_state_with_live_mining(true);
@@ -3312,14 +3323,7 @@ mod tests {
             Ok(())
         }));
 
-        let response = route_request(
-            &state,
-            HttpRequest {
-                method: "POST".to_string(),
-                target: "/mine_next".to_string(),
-                body: b"{}".to_vec(),
-            },
-        );
+        let response = post_mine_next(&state);
 
         assert_eq!(
             response.status,
@@ -3352,14 +3356,7 @@ mod tests {
             engine.chain_state.height = u64::MAX;
         }
 
-        let response = route_request(
-            &state,
-            HttpRequest {
-                method: "POST".to_string(),
-                target: "/mine_next".to_string(),
-                body: b"{}".to_vec(),
-            },
-        );
+        let response = post_mine_next(&state);
 
         assert_eq!(response.status, 422);
         let json = response_json(&response);
@@ -3369,80 +3366,11 @@ mod tests {
     }
 
     #[test]
-    fn mine_next_skips_announce_when_rpc_block_store_missing() {
-        let (mut state, dir) = build_state_with_live_mining(true);
-        state.block_store = None;
-        let announced = Arc::new(Mutex::new(false));
-        let announced_clone = Arc::clone(&announced);
-        state.announce_block = Some(Arc::new(move |_| {
-            *announced_clone.lock().expect("announce lock") = true;
-            Ok(())
-        }));
-
-        let response = route_request(
-            &state,
-            HttpRequest {
-                method: "POST".to_string(),
-                target: "/mine_next".to_string(),
-                body: b"{}".to_vec(),
-            },
-        );
-
-        assert_eq!(response.status, 200);
-        assert_eq!(response_json(&response)["mined"].as_bool(), Some(true));
-        assert!(
-            !*announced.lock().expect("announce lock"),
-            "announce_block must not run without block bytes",
-        );
-        fs::remove_dir_all(dir).expect("cleanup");
-    }
-
-    #[test]
-    fn mine_next_skips_announce_when_rpc_block_store_lacks_mined_block() {
-        let (mut state, dir) = build_state_with_live_mining(true);
-        let empty_dir = unique_temp_path("rubin-devnet-rpc-empty-blockstore");
-        fs::create_dir_all(&empty_dir).expect("mkdir empty blockstore");
-        state.block_store =
-            Some(BlockStore::open(block_store_path(&empty_dir)).expect("empty blockstore"));
-        let announced = Arc::new(Mutex::new(false));
-        let announced_clone = Arc::clone(&announced);
-        state.announce_block = Some(Arc::new(move |_| {
-            *announced_clone.lock().expect("announce lock") = true;
-            Ok(())
-        }));
-
-        let response = route_request(
-            &state,
-            HttpRequest {
-                method: "POST".to_string(),
-                target: "/mine_next".to_string(),
-                body: b"{}".to_vec(),
-            },
-        );
-
-        assert_eq!(response.status, 200);
-        assert_eq!(response_json(&response)["mined"].as_bool(), Some(true));
-        assert!(
-            !*announced.lock().expect("announce lock"),
-            "announce_block must not run when block bytes cannot be reloaded",
-        );
-        fs::remove_dir_all(empty_dir).expect("cleanup empty blockstore");
-        fs::remove_dir_all(dir).expect("cleanup");
-    }
-
-    #[test]
     fn mine_next_logs_announce_block_error_without_failing_rpc() {
         let (mut state, dir) = build_state_with_live_mining(true);
         state.announce_block = Some(Arc::new(|_| Err("forced announce failure".to_string())));
 
-        let response = route_request(
-            &state,
-            HttpRequest {
-                method: "POST".to_string(),
-                target: "/mine_next".to_string(),
-                body: b"{}".to_vec(),
-            },
-        );
+        let response = post_mine_next(&state);
 
         assert_eq!(response.status, 200);
         assert_eq!(response_json(&response)["mined"].as_bool(), Some(true));
@@ -4624,7 +4552,7 @@ mod tests {
     fn read_http_request_accepts_trailer_with_tab_and_obs_text_in_field_value() {
         // HTAB and obs-text (0x80-0xFF) are both valid in field-value per
         // RFC 7230 §3.2.6; the check must accept these so legitimate
-        // trailers with UTF-8 content (e.g. `"тест"`) continue to work.
+        // trailers with non-ASCII UTF-8 content continue to work.
         let raw = b"POST /submit_tx HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: chunked\r\n\r\n0\r\nX-Trace:\t\xd1\x82\xd0\xb5\xd1\x81\xd1\x82\r\n\r\n";
         let req = read_request_from_bytes(raw).expect("trailer with HTAB + obs-text accepted");
         // Body has no data chunks in this case, so the decoded body is empty

--- a/clients/rust/crates/rubin-node/src/main.rs
+++ b/clients/rust/crates/rubin-node/src/main.rs
@@ -472,12 +472,22 @@ fn run(args: &[String], stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
             rubin_node::tx_relay::announce_tx(tx_bytes, meta, &relay_state, &pm, &local, &pw)
         }))
     };
+    let announce_block: Option<rubin_node::devnet_rpc::AnnounceBlockFn> = {
+        let relay_state = p2p_service.relay_state();
+        let pm = Arc::clone(&peer_manager);
+        let pw = p2p_service.peer_outboxes();
+        let local = p2p_service.addr().to_string();
+        Some(Arc::new(move |block_bytes: &[u8]| {
+            rubin_node::tx_relay::announce_block(block_bytes, &relay_state, &pm, &local, &pw)
+        }))
+    };
     let state = new_devnet_rpc_state_with_tx_pool(
         Arc::clone(&sync_engine),
         Some(block_store),
         Arc::clone(&tx_pool),
         Arc::clone(&peer_manager),
         announce_tx,
+        announce_block,
         live_mining_cfg,
     );
     let server = if cfg.rpc_bind_addr.trim().is_empty() {

--- a/clients/rust/crates/rubin-node/src/p2p_service.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_service.rs
@@ -782,14 +782,8 @@ fn handle_peer(
     }
     let peer_addr = peer_state.addr.clone();
 
-    // Register the relay outbox BEFORE the peer becomes visible in
-    // `peer_manager`. Otherwise a concurrent local block announcement can
-    // snapshot a connected peer whose outbox does not exist yet and silently
-    // drop the BLOCK inventory that Go convergence depends on.
-    //
-    // Declaration order is critical: Rust drops locals in REVERSE
-    // declaration order. `_outbox_guard` is declared before peer/alias guards,
-    // so the outbox outlives peer-manager visibility on teardown.
+    // Register before peer visibility so local block announce cannot snapshot
+    // a connected peer without an outbox. Declaration order makes it drop last.
     let _outbox_guard = register_peer_outbox(&shared.peer_outboxes, &peer_addr)?;
 
     shared
@@ -1122,7 +1116,7 @@ mod tests {
         maybe_apply_tx_pool_cleanup, outbound_connect_timeout, reconnect_missing_bootstrap_peers,
         register_peer_alias, register_peer_outbox, should_skip_outbound_dial,
         start_node_p2p_service, wait_for_service_shutdown, NodeP2PServiceConfig, PeerAliasGuard,
-        PeerGuard, PeerOutboxGuard, SharedServiceState,
+        PeerGuard, SharedServiceState,
     };
     use crate::genesis::{devnet_genesis_block_bytes, devnet_genesis_chain_id};
     use crate::interop::local_version;
@@ -2240,15 +2234,8 @@ mod tests {
         let primary = "peer.example.com:19111".to_string();
         let alias = "127.0.0.1:19111";
 
-        shared
-            .peer_outboxes
-            .lock()
-            .unwrap()
-            .insert(primary.clone(), PeerOutbox::default());
-        let outbox_guard = PeerOutboxGuard {
-            peer_outboxes: Arc::clone(&shared.peer_outboxes),
-            addr: primary.clone(),
-        };
+        let outbox_guard =
+            register_peer_outbox(&shared.peer_outboxes, &primary).expect("register outbox");
         shared
             .peer_manager
             .add_peer(crate::p2p_runtime::PeerState {
@@ -2288,50 +2275,24 @@ mod tests {
 
     #[test]
     fn peer_outbox_registration_refuses_duplicate_without_clobbering() {
-        let outboxes = Arc::new(Mutex::new(HashMap::<String, PeerOutbox>::new()));
-        let primary = "peer.example.com:19111".to_string();
+        let primary = "peer.example.com:19111";
         let mut existing = PeerOutbox::default();
         assert!(existing.push_frame(vec![0xAA, 0xBB, 0xCC]));
-        outboxes
-            .lock()
-            .unwrap()
-            .insert(primary.clone(), existing.clone());
+        let outboxes = Arc::new(Mutex::new(HashMap::from([(
+            primary.to_string(),
+            existing.clone(),
+        )])));
 
-        let err = match register_peer_outbox(&outboxes, &primary) {
+        let err = match register_peer_outbox(&outboxes, primary) {
             Ok(_) => panic!("duplicate outbox registration must fail closed"),
             Err(err) => err,
         };
 
         assert!(err.contains("peer outbox already registered"));
-        let guard = outboxes.lock().unwrap();
-        let retained = guard.get(&primary).expect("existing outbox retained");
-        assert_eq!(retained.frames(), existing.frames());
-    }
-
-    #[test]
-    fn peer_outbox_registration_recovers_from_poisoned_lock() {
-        let outboxes = Arc::new(Mutex::new(HashMap::<String, PeerOutbox>::new()));
-        let poison_target = Arc::clone(&outboxes);
-        let _ = thread::spawn(move || {
-            let _guard = poison_target.lock().expect("lock outboxes");
-            panic!("poison peer outboxes");
-        })
-        .join();
-
-        let primary = "peer-poison.example.com:19111";
-        let guard = register_peer_outbox(&outboxes, primary).expect("register after poisoned lock");
-
-        assert!(outboxes
-            .lock()
-            .unwrap_err()
-            .into_inner()
-            .contains_key(primary));
-        drop(guard);
-        assert!(!outboxes
-            .lock()
-            .unwrap_err()
-            .into_inner()
-            .contains_key(primary));
+        assert_eq!(
+            outboxes.lock().unwrap()[primary].frames(),
+            existing.frames()
+        );
     }
 
     /// Race scenario flagged by Codex/Copilot P1: two concurrent dials

--- a/clients/rust/crates/rubin-node/src/p2p_service.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_service.rs
@@ -2308,6 +2308,32 @@ mod tests {
         assert_eq!(retained.frames(), existing.frames());
     }
 
+    #[test]
+    fn peer_outbox_registration_recovers_from_poisoned_lock() {
+        let outboxes = Arc::new(Mutex::new(HashMap::<String, PeerOutbox>::new()));
+        let poison_target = Arc::clone(&outboxes);
+        let _ = thread::spawn(move || {
+            let _guard = poison_target.lock().expect("lock outboxes");
+            panic!("poison peer outboxes");
+        })
+        .join();
+
+        let primary = "peer-poison.example.com:19111";
+        let guard = register_peer_outbox(&outboxes, primary).expect("register after poisoned lock");
+
+        assert!(outboxes
+            .lock()
+            .unwrap_err()
+            .into_inner()
+            .contains_key(primary));
+        drop(guard);
+        assert!(!outboxes
+            .lock()
+            .unwrap_err()
+            .into_inner()
+            .contains_key(primary));
+    }
+
     /// Race scenario flagged by Codex/Copilot P1: two concurrent dials
     /// land on the same `remote_raw_addr` under different primary keys
     /// (e.g. `seed.example.com:19111` vs `mirror.example.org:19111`

--- a/clients/rust/crates/rubin-node/src/p2p_service.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_service.rs
@@ -363,6 +363,24 @@ fn register_peer_alias(
     })
 }
 
+fn register_peer_outbox(
+    peer_outboxes: &Arc<Mutex<HashMap<String, PeerOutbox>>>,
+    peer_addr: &str,
+) -> Result<PeerOutboxGuard, String> {
+    let mut outboxes = match peer_outboxes.lock() {
+        Ok(g) => g,
+        Err(p) => p.into_inner(),
+    };
+    if outboxes.contains_key(peer_addr) {
+        return Err(format!("peer outbox already registered: {peer_addr}"));
+    }
+    outboxes.insert(peer_addr.to_string(), PeerOutbox::default());
+    Ok(PeerOutboxGuard {
+        peer_outboxes: Arc::clone(peer_outboxes),
+        addr: peer_addr.to_string(),
+    })
+}
+
 fn reconnect_missing_bootstrap_peers(shared: &SharedServiceState) {
     let n = shared.bootstrap_peers.len();
     if n == 0 {
@@ -763,6 +781,17 @@ fn handle_peer(
         peer_state.addr = addr.clone();
     }
     let peer_addr = peer_state.addr.clone();
+
+    // Register the relay outbox BEFORE the peer becomes visible in
+    // `peer_manager`. Otherwise a concurrent local block announcement can
+    // snapshot a connected peer whose outbox does not exist yet and silently
+    // drop the BLOCK inventory that Go convergence depends on.
+    //
+    // Declaration order is critical: Rust drops locals in REVERSE
+    // declaration order. `_outbox_guard` is declared before peer/alias guards,
+    // so the outbox outlives peer-manager visibility on teardown.
+    let _outbox_guard = register_peer_outbox(&shared.peer_outboxes, &peer_addr)?;
+
     shared
         .peer_manager
         .add_peer(peer_state)
@@ -775,9 +804,9 @@ fn handle_peer(
     // window in which the peer still answers as connected but its alias
     // is gone, so `is_connected_with_alias(shared, remote_raw_addr)`
     // returns false and a concurrent dialer can attach a duplicate
-    // session against the same remote. Therefore: alias_guard FIRST
-    // (drops last), peer_guard SECOND (drops before alias), outbox_guard
-    // LAST (drops first).
+    // session against the same remote. Therefore: outbox_guard FIRST
+    // (drops last), alias_guard SECOND (drops after peer), peer_guard
+    // THIRD (drops first).
     //
     // Register alias only when the observed remote socket address differs
     // from the primary key. Empty / "<unknown>" / duplicate aliases are a
@@ -786,21 +815,6 @@ fn handle_peer(
 
     let _peer_guard = PeerGuard {
         peer_manager: Arc::clone(&shared.peer_manager),
-        addr: peer_addr.clone(),
-    };
-
-    // Register outbox for this peer so relay broadcasts can enqueue
-    // frames. Recover from poison so a single earlier worker panic
-    // (while holding the outbox lock) does not cascade into panics on
-    // every subsequent peer handshake.
-    let mut peer_outboxes = match shared.peer_outboxes.lock() {
-        Ok(g) => g,
-        Err(p) => p.into_inner(),
-    };
-    peer_outboxes.insert(peer_addr.clone(), PeerOutbox::default());
-    drop(peer_outboxes);
-    let _outbox_guard = PeerOutboxGuard {
-        peer_outboxes: Arc::clone(&shared.peer_outboxes),
         addr: peer_addr.clone(),
     };
 
@@ -1106,8 +1120,9 @@ mod tests {
         apply_tx_pool_cleanup, connect_with_timeout, finalize_live_message_outcome,
         flush_peer_outbox, is_connected_with_alias, join_all_service_workers, lock_in_flight_dials,
         maybe_apply_tx_pool_cleanup, outbound_connect_timeout, reconnect_missing_bootstrap_peers,
-        register_peer_alias, should_skip_outbound_dial, start_node_p2p_service,
-        wait_for_service_shutdown, NodeP2PServiceConfig, PeerAliasGuard, SharedServiceState,
+        register_peer_alias, register_peer_outbox, should_skip_outbound_dial,
+        start_node_p2p_service, wait_for_service_shutdown, NodeP2PServiceConfig, PeerAliasGuard,
+        PeerGuard, PeerOutboxGuard, SharedServiceState,
     };
     use crate::genesis::{devnet_genesis_block_bytes, devnet_genesis_chain_id};
     use crate::interop::local_version;
@@ -2215,6 +2230,82 @@ mod tests {
         assert!(!shared.peer_aliases.lock().unwrap().contains_key(alias));
 
         fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn peer_outbox_outlives_peer_manager_visibility() {
+        let (sync_engine, dir) = test_engine("rubin-node-p2p-outbox-drop-order");
+        let runtime_cfg = default_peer_runtime_config("devnet", 8);
+        let shared = test_shared_state(runtime_cfg, vec![], sync_engine);
+        let primary = "peer.example.com:19111".to_string();
+        let alias = "127.0.0.1:19111";
+
+        shared
+            .peer_outboxes
+            .lock()
+            .unwrap()
+            .insert(primary.clone(), PeerOutbox::default());
+        let outbox_guard = PeerOutboxGuard {
+            peer_outboxes: Arc::clone(&shared.peer_outboxes),
+            addr: primary.clone(),
+        };
+        shared
+            .peer_manager
+            .add_peer(crate::p2p_runtime::PeerState {
+                addr: primary.clone(),
+                ..Default::default()
+            })
+            .expect("register primary");
+        let alias_guard = register_peer_alias(&shared, alias, &primary).expect("register alias");
+        let peer_guard = PeerGuard {
+            peer_manager: Arc::clone(&shared.peer_manager),
+            addr: primary.clone(),
+        };
+
+        assert!(is_connected_with_alias(&shared, &primary));
+        assert!(is_connected_with_alias(&shared, alias));
+        assert!(shared.peer_outboxes.lock().unwrap().contains_key(&primary));
+
+        drop(peer_guard);
+        assert!(!is_connected_with_alias(&shared, &primary));
+        assert!(is_connected_with_alias(&shared, alias));
+        assert!(
+            shared.peer_outboxes.lock().unwrap().contains_key(&primary),
+            "outbox must remain while alias still exposes the peer as connected",
+        );
+
+        drop(alias_guard);
+        assert!(!is_connected_with_alias(&shared, alias));
+        assert!(
+            shared.peer_outboxes.lock().unwrap().contains_key(&primary),
+            "outbox guard must drop after peer and alias guards",
+        );
+
+        drop(outbox_guard);
+        assert!(!shared.peer_outboxes.lock().unwrap().contains_key(&primary));
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn peer_outbox_registration_refuses_duplicate_without_clobbering() {
+        let outboxes = Arc::new(Mutex::new(HashMap::<String, PeerOutbox>::new()));
+        let primary = "peer.example.com:19111".to_string();
+        let mut existing = PeerOutbox::default();
+        assert!(existing.push_frame(vec![0xAA, 0xBB, 0xCC]));
+        outboxes
+            .lock()
+            .unwrap()
+            .insert(primary.clone(), existing.clone());
+
+        let err = match register_peer_outbox(&outboxes, &primary) {
+            Ok(_) => panic!("duplicate outbox registration must fail closed"),
+            Err(err) => err,
+        };
+
+        assert!(err.contains("peer outbox already registered"));
+        let guard = outboxes.lock().unwrap();
+        let retained = guard.get(&primary).expect("existing outbox retained");
+        assert_eq!(retained.frames(), existing.frames());
     }
 
     /// Race scenario flagged by Codex/Copilot P1: two concurrent dials

--- a/clients/rust/crates/rubin-node/src/tx_relay.rs
+++ b/clients/rust/crates/rubin-node/src/tx_relay.rs
@@ -982,185 +982,105 @@ mod tests {
         assert_eq!(boxes["peer-b:8333"].len(), 1);
     }
 
-    #[test]
-    fn announce_block_broadcasts_block_inventory_to_all_peers() {
-        let relay = TxRelayState::new();
-        let pm = PeerManager::new(crate::p2p_runtime::default_peer_runtime_config(
-            "devnet", 64,
-        ));
-        let _ = pm.add_peer(crate::p2p_runtime::PeerState {
-            addr: "peer-a:8333".to_string(),
-            ..Default::default()
-        });
-        let _ = pm.add_peer(crate::p2p_runtime::PeerState {
-            addr: "peer-b:8333".to_string(),
-            ..Default::default()
-        });
-        let outboxes: Mutex<HashMap<String, PeerOutbox>> = Mutex::new(HashMap::new());
-        outboxes
-            .lock()
-            .unwrap()
-            .insert("peer-a:8333".to_string(), PeerOutbox::default());
-        outboxes
-            .lock()
-            .unwrap()
-            .insert("peer-b:8333".to_string(), PeerOutbox::default());
-
+    fn test_block() -> (Vec<u8>, [u8; 32]) {
         let block = crate::genesis::devnet_genesis_block_bytes();
         let parsed = parse_block_bytes(&block).expect("parse block");
-        let block_hash = block_hash(&parsed.header_bytes).expect("block hash");
-        let result = announce_block(&block, &relay, &pm, "local:8333", &outboxes);
+        let hash = block_hash(&parsed.header_bytes).expect("block hash");
+        (block, hash)
+    }
 
-        assert!(result.is_ok());
-        let boxes = outboxes.lock().unwrap();
-        for addr in ["peer-a:8333", "peer-b:8333"] {
-            let frames = boxes[addr].frames();
-            assert_eq!(frames.len(), 1);
-            let msg =
-                crate::p2p_runtime::fuzz_parse_wire_message("devnet", &frames[0]).expect("frame");
-            assert_eq!(msg.command, "inv");
-            let inventory = crate::p2p_runtime::decode_inventory_vectors(&msg.payload)
-                .expect("decode inventory");
-            assert_eq!(
-                inventory,
-                vec![InventoryVector {
-                    kind: MSG_BLOCK,
-                    hash: block_hash,
-                }]
-            );
+    fn block_announce_fixture(
+        addrs: &[&str],
+    ) -> (
+        TxRelayState,
+        PeerManager,
+        Mutex<HashMap<String, PeerOutbox>>,
+    ) {
+        let relay = TxRelayState::new();
+        let pm = PeerManager::new(crate::p2p_runtime::default_peer_runtime_config(
+            "devnet", 64,
+        ));
+        let outboxes = Mutex::new(HashMap::new());
+        for addr in addrs {
+            let addr = (*addr).to_string();
+            let _ = pm.add_peer(crate::p2p_runtime::PeerState {
+                addr: addr.clone(),
+                ..Default::default()
+            });
+            outboxes.lock().unwrap().insert(addr, PeerOutbox::default());
         }
+        (relay, pm, outboxes)
+    }
+
+    fn assert_block_inv_frame(queue: &PeerOutbox, hash: [u8; 32]) {
+        let frames = queue.frames();
+        assert_eq!(frames.len(), 1);
+        let msg = crate::p2p_runtime::fuzz_parse_wire_message("devnet", &frames[0]).expect("frame");
+        assert_eq!(msg.command, "inv");
+        assert_eq!(
+            crate::p2p_runtime::decode_inventory_vectors(&msg.payload).expect("decode inventory"),
+            vec![InventoryVector {
+                kind: MSG_BLOCK,
+                hash
+            }],
+        );
     }
 
     #[test]
-    fn announce_block_deduplicates_seen_block_inventory() {
-        let relay = TxRelayState::new();
-        let pm = PeerManager::new(crate::p2p_runtime::default_peer_runtime_config(
-            "devnet", 64,
-        ));
-        let _ = pm.add_peer(crate::p2p_runtime::PeerState {
-            addr: "peer-a:8333".to_string(),
-            ..Default::default()
-        });
-        let outboxes: Mutex<HashMap<String, PeerOutbox>> = Mutex::new(HashMap::new());
-        outboxes
-            .lock()
-            .unwrap()
-            .insert("peer-a:8333".to_string(), PeerOutbox::default());
+    fn announce_block_broadcasts_deduplicates_and_handles_no_peers() {
+        let (block, hash) = test_block();
+        let (relay, pm, outboxes) = block_announce_fixture(&["peer-a:8333", "peer-b:8333"]);
 
-        let block = crate::genesis::devnet_genesis_block_bytes();
-        announce_block(&block, &relay, &pm, "local:8333", &outboxes).expect("first announce");
-        announce_block(&block, &relay, &pm, "local:8333", &outboxes).expect("duplicate announce");
-
-        let boxes = outboxes.lock().unwrap();
-        assert_eq!(boxes["peer-a:8333"].len(), 1);
-    }
-
-    #[test]
-    fn announce_block_errors_when_connected_peer_has_no_outbox() {
-        let relay = TxRelayState::new();
-        let pm = PeerManager::new(crate::p2p_runtime::default_peer_runtime_config(
-            "devnet", 64,
-        ));
-        let _ = pm.add_peer(crate::p2p_runtime::PeerState {
-            addr: "peer-a:8333".to_string(),
-            ..Default::default()
-        });
-        let outboxes: Mutex<HashMap<String, PeerOutbox>> = Mutex::new(HashMap::new());
-
-        let block = crate::genesis::devnet_genesis_block_bytes();
-        let err = announce_block(&block, &relay, &pm, "local:8333", &outboxes)
-            .expect_err("connected peer without outbox must fail block announce");
-
-        assert!(err.contains("peer outbox missing for peer-a:8333"));
-    }
-
-    #[test]
-    fn announce_block_errors_when_connected_peer_outbox_is_full() {
-        let relay = TxRelayState::new();
-        let pm = PeerManager::new(crate::p2p_runtime::default_peer_runtime_config(
-            "devnet", 64,
-        ));
-        let _ = pm.add_peer(crate::p2p_runtime::PeerState {
-            addr: "peer-a:8333".to_string(),
-            ..Default::default()
-        });
-        let mut outbox = PeerOutbox::default();
-        for _ in 0..MAX_OUTBOX_FRAMES_PER_PEER {
-            assert!(outbox.push_frame(Vec::new()));
+        announce_block(&block, &relay, &pm, "local:8333", &outboxes).expect("announce block");
+        {
+            let boxes = outboxes.lock().unwrap();
+            assert_block_inv_frame(&boxes["peer-a:8333"], hash);
+            assert_block_inv_frame(&boxes["peer-b:8333"], hash);
         }
-        let outboxes: Mutex<HashMap<String, PeerOutbox>> =
-            Mutex::new(HashMap::from([("peer-a:8333".to_string(), outbox)]));
+        announce_block(&block, &relay, &pm, "local:8333", &outboxes).expect("dedupe");
+        assert_eq!(outboxes.lock().unwrap()["peer-a:8333"].len(), 1);
 
-        let block = crate::genesis::devnet_genesis_block_bytes();
-        let err = announce_block(&block, &relay, &pm, "local:8333", &outboxes)
-            .expect_err("full outbox must fail block announce");
-
-        assert!(err.contains("peer outbox full for peer-a:8333"));
+        let (relay, pm, outboxes) = block_announce_fixture(&[]);
+        announce_block(&block, &relay, &pm, "local:8333", &outboxes).expect("no-peer announce");
+        assert!(relay.block_seen.has(&hash));
+        assert!(outboxes.lock().unwrap().is_empty());
     }
 
     #[test]
-    fn announce_block_partial_failure_enqueues_healthy_peer_and_allows_retry() {
-        let relay = TxRelayState::new();
-        let pm = PeerManager::new(crate::p2p_runtime::default_peer_runtime_config(
-            "devnet", 64,
-        ));
-        let _ = pm.add_peer(crate::p2p_runtime::PeerState {
-            addr: "healthy:8333".to_string(),
-            ..Default::default()
-        });
+    fn announce_block_failure_paths_remain_retryable() {
+        let (block, hash) = test_block();
+        let (relay, pm, outboxes) = block_announce_fixture(&["healthy:8333"]);
         let _ = pm.add_peer(crate::p2p_runtime::PeerState {
             addr: "missing:8333".to_string(),
             ..Default::default()
         });
-        let outboxes: Mutex<HashMap<String, PeerOutbox>> = Mutex::new(HashMap::new());
-        outboxes
-            .lock()
-            .unwrap()
-            .insert("healthy:8333".to_string(), PeerOutbox::default());
 
-        let block = crate::genesis::devnet_genesis_block_bytes();
-        let parsed = parse_block_bytes(&block).expect("parse block");
-        let block_hash = block_hash(&parsed.header_bytes).expect("block hash");
         let err = announce_block(&block, &relay, &pm, "local:8333", &outboxes)
             .expect_err("missing peer outbox should fail strict block announce");
-
         assert!(err.contains("peer outbox missing for missing:8333"));
         assert_eq!(outboxes.lock().unwrap()["healthy:8333"].len(), 1);
-        assert!(
-            !relay.block_seen.has(&block_hash),
-            "partial failure must not suppress a later retry",
-        );
+        assert!(!relay.block_seen.has(&hash));
 
         outboxes
             .lock()
             .unwrap()
             .insert("missing:8333".to_string(), PeerOutbox::default());
-        announce_block(&block, &relay, &pm, "local:8333", &outboxes)
-            .expect("retry after outbox repair");
+        announce_block(&block, &relay, &pm, "local:8333", &outboxes).expect("retry after repair");
+        assert_eq!(outboxes.lock().unwrap()["missing:8333"].len(), 1);
+        assert!(relay.block_seen.has(&hash));
 
-        let boxes = outboxes.lock().unwrap();
-        assert_eq!(boxes["healthy:8333"].len(), 2);
-        assert_eq!(boxes["missing:8333"].len(), 1);
-        assert!(relay.block_seen.has(&block_hash));
-    }
-
-    #[test]
-    fn announce_block_with_no_peers_marks_seen_without_broadcast() {
-        let relay = TxRelayState::new();
-        let pm = PeerManager::new(crate::p2p_runtime::default_peer_runtime_config(
-            "devnet", 64,
-        ));
-        let outboxes: Mutex<HashMap<String, PeerOutbox>> = Mutex::new(HashMap::new());
-
-        let block = crate::genesis::devnet_genesis_block_bytes();
-        let parsed = parse_block_bytes(&block).expect("parse block");
-        let block_hash = block_hash(&parsed.header_bytes).expect("block hash");
-
-        announce_block(&block, &relay, &pm, "local:8333", &outboxes)
-            .expect("no-peer announce should be a successful no-op");
-
-        assert!(relay.block_seen.has(&block_hash));
-        assert!(outboxes.lock().unwrap().is_empty());
+        let (relay, pm, outboxes) = block_announce_fixture(&["full:8333"]);
+        for _ in 0..MAX_OUTBOX_FRAMES_PER_PEER {
+            assert!(outboxes
+                .lock()
+                .unwrap()
+                .get_mut("full:8333")
+                .unwrap()
+                .push_frame(Vec::new()));
+        }
+        let err = announce_block(&block, &relay, &pm, "local:8333", &outboxes)
+            .expect_err("full outbox must fail block announce");
+        assert!(err.contains("peer outbox full for full:8333"));
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/tx_relay.rs
+++ b/clients/rust/crates/rubin-node/src/tx_relay.rs
@@ -247,6 +247,7 @@ use std::collections::HashMap;
 use std::io;
 use std::sync::Mutex;
 
+use rubin_consensus::{block_hash, parse_block_bytes};
 use sha3::{Digest, Sha3_256};
 
 use crate::p2p_runtime::{
@@ -505,6 +506,33 @@ pub fn announce_tx(
         &[InventoryVector {
             kind: MSG_TX,
             hash: txid,
+        }],
+        peer_manager,
+        local_addr,
+        peer_writers,
+    )
+}
+
+/// Announce a locally mined block after it is committed to the block store.
+///
+/// Rust `/mine_next` uses this to mirror Go's `AnnounceBlock`: parse the
+/// committed full block, derive its canonical hash, then broadcast a BLOCK
+/// inventory item to every connected peer.
+pub fn announce_block(
+    block_bytes: &[u8],
+    relay_state: &TxRelayState,
+    peer_manager: &PeerManager,
+    local_addr: &str,
+    peer_writers: &Mutex<HashMap<String, PeerOutbox>>,
+) -> Result<(), String> {
+    let parsed = parse_block_bytes(block_bytes).map_err(|err| err.to_string())?;
+    let hash = block_hash(&parsed.header_bytes).map_err(|err| err.to_string())?;
+    broadcast_inventory(
+        relay_state,
+        None,
+        &[InventoryVector {
+            kind: MSG_BLOCK,
+            hash,
         }],
         peer_manager,
         local_addr,
@@ -916,6 +944,55 @@ mod tests {
         // Both peers should have exactly 1 frame.
         assert_eq!(boxes["peer-a:8333"].len(), 1);
         assert_eq!(boxes["peer-b:8333"].len(), 1);
+    }
+
+    #[test]
+    fn announce_block_broadcasts_block_inventory_to_all_peers() {
+        let relay = TxRelayState::new();
+        let pm = PeerManager::new(crate::p2p_runtime::default_peer_runtime_config(
+            "devnet", 64,
+        ));
+        let _ = pm.add_peer(crate::p2p_runtime::PeerState {
+            addr: "peer-a:8333".to_string(),
+            ..Default::default()
+        });
+        let _ = pm.add_peer(crate::p2p_runtime::PeerState {
+            addr: "peer-b:8333".to_string(),
+            ..Default::default()
+        });
+        let outboxes: Mutex<HashMap<String, PeerOutbox>> = Mutex::new(HashMap::new());
+        outboxes
+            .lock()
+            .unwrap()
+            .insert("peer-a:8333".to_string(), PeerOutbox::default());
+        outboxes
+            .lock()
+            .unwrap()
+            .insert("peer-b:8333".to_string(), PeerOutbox::default());
+
+        let block = crate::genesis::devnet_genesis_block_bytes();
+        let parsed = parse_block_bytes(&block).expect("parse block");
+        let block_hash = block_hash(&parsed.header_bytes).expect("block hash");
+        let result = announce_block(&block, &relay, &pm, "local:8333", &outboxes);
+
+        assert!(result.is_ok());
+        let boxes = outboxes.lock().unwrap();
+        for addr in ["peer-a:8333", "peer-b:8333"] {
+            let frames = boxes[addr].frames();
+            assert_eq!(frames.len(), 1);
+            let msg =
+                crate::p2p_runtime::fuzz_parse_wire_message("devnet", &frames[0]).expect("frame");
+            assert_eq!(msg.command, "inv");
+            let inventory = crate::p2p_runtime::decode_inventory_vectors(&msg.payload)
+                .expect("decode inventory");
+            assert_eq!(
+                inventory,
+                vec![InventoryVector {
+                    kind: MSG_BLOCK,
+                    hash: block_hash,
+                }]
+            );
+        }
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/tx_relay.rs
+++ b/clients/rust/crates/rubin-node/src/tx_relay.rs
@@ -469,8 +469,9 @@ fn broadcast_inv_to_addrs(
     frame.extend_from_slice(&payload);
     // Enqueue the frame into each peer's outbox. The peer's own thread
     // will drain the queue, ensuring writes are serialized on the TcpStream.
-    let Ok(mut outboxes) = peer_writers.lock() else {
-        return Err("peer_outboxes lock poisoned".to_string());
+    let mut outboxes = match peer_writers.lock() {
+        Ok(g) => g,
+        Err(p) => p.into_inner(),
     };
     let mut failures = Vec::new();
     for addr in addrs {
@@ -1075,6 +1076,22 @@ mod tests {
             .expect_err("full outbox must fail block announce");
         assert!(err.contains("peer outbox full for full:8333"));
         assert!(!relay.block_seen.has(&hash));
+    }
+
+    #[test]
+    fn announce_block_recovers_poisoned_peer_outboxes_lock() {
+        let (block, hash) = test_block();
+        let (relay, pm, outboxes) = block_announce_fixture(&["peer:8333"]);
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = outboxes.lock().expect("lock outboxes before poison");
+            panic!("poison peer outboxes for regression test");
+        }));
+        assert!(outboxes.lock().is_err());
+
+        announce_block(&block, &relay, &pm, "local:8333", &outboxes)
+            .expect("poisoned peer outboxes should recover for announce");
+        let boxes = outboxes.lock().unwrap_or_else(|p| p.into_inner());
+        assert_block_inv_frame(&boxes["peer:8333"], hash);
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/tx_relay.rs
+++ b/clients/rust/crates/rubin-node/src/tx_relay.rs
@@ -429,7 +429,13 @@ pub fn broadcast_inventory(
 
     if !block_items.is_empty() {
         let block_vecs: Vec<InventoryVector> = block_items.into_iter().cloned().collect();
-        broadcast_inv_to_addrs(&block_vecs, &addrs, &relay_state.network, peer_writers)?;
+        broadcast_inv_to_addrs(
+            &block_vecs,
+            &addrs,
+            &relay_state.network,
+            peer_writers,
+            false,
+        )?;
     }
 
     if tx_items.is_empty() {
@@ -440,7 +446,7 @@ pub fn broadcast_inventory(
     let relay_key = inventory_relay_key(&tx_vecs);
     let relay_salt = skip_addr.unwrap_or(local_addr);
     addrs = select_tx_relay_peers(relay_key, relay_salt, &addrs, relay_state.tx_relay_fanout);
-    broadcast_inv_to_addrs(&tx_vecs, &addrs, &relay_state.network, peer_writers)
+    broadcast_inv_to_addrs(&tx_vecs, &addrs, &relay_state.network, peer_writers, false)
 }
 
 /// Send INV message to a set of peer addresses.
@@ -449,6 +455,7 @@ fn broadcast_inv_to_addrs(
     addrs: &[String],
     network: &str,
     peer_writers: &Mutex<HashMap<String, PeerOutbox>>,
+    require_all_queues: bool,
 ) -> Result<(), String> {
     let payload = encode_inventory_vectors(items).map_err(|e| e.to_string())?;
     let magic = crate::p2p_runtime::network_magic(network);
@@ -464,11 +471,18 @@ fn broadcast_inv_to_addrs(
         return Err("peer_outboxes lock poisoned".to_string());
     };
     for addr in addrs {
-        if let Some(queue) = outboxes.get_mut(addr) {
-            let _ = queue.push_frame(frame.clone());
-            // else: drop silently — peer is slow or over byte budget and will
-            // catch up on the next drain.
+        let Some(queue) = outboxes.get_mut(addr) else {
+            if require_all_queues {
+                return Err(format!("peer outbox missing for {addr}"));
+            }
+            continue;
+        };
+        if !queue.push_frame(frame.clone()) && require_all_queues {
+            return Err(format!("peer outbox full for {addr}"));
         }
+        // Non-strict relay drops silently when a peer is slow or over byte
+        // budget; strict block announce uses errors so local mining cannot
+        // report announce success without enqueueing the block inventory.
     }
     Ok(())
 }
@@ -522,21 +536,25 @@ pub fn announce_block(
     block_bytes: &[u8],
     relay_state: &TxRelayState,
     peer_manager: &PeerManager,
-    local_addr: &str,
+    _local_addr: &str,
     peer_writers: &Mutex<HashMap<String, PeerOutbox>>,
 ) -> Result<(), String> {
     let parsed = parse_block_bytes(block_bytes).map_err(|err| err.to_string())?;
     let hash = block_hash(&parsed.header_bytes).map_err(|err| err.to_string())?;
-    broadcast_inventory(
-        relay_state,
-        None,
+    let peers = peer_manager.snapshot();
+    let addrs: Vec<String> = peers.iter().map(|p| p.addr.clone()).collect();
+    if addrs.is_empty() {
+        return Ok(());
+    }
+    broadcast_inv_to_addrs(
         &[InventoryVector {
             kind: MSG_BLOCK,
             hash,
         }],
-        peer_manager,
-        local_addr,
+        &addrs,
+        &relay_state.network,
         peer_writers,
+        true,
     )
 }
 
@@ -993,6 +1011,49 @@ mod tests {
                 }]
             );
         }
+    }
+
+    #[test]
+    fn announce_block_errors_when_connected_peer_has_no_outbox() {
+        let relay = TxRelayState::new();
+        let pm = PeerManager::new(crate::p2p_runtime::default_peer_runtime_config(
+            "devnet", 64,
+        ));
+        let _ = pm.add_peer(crate::p2p_runtime::PeerState {
+            addr: "peer-a:8333".to_string(),
+            ..Default::default()
+        });
+        let outboxes: Mutex<HashMap<String, PeerOutbox>> = Mutex::new(HashMap::new());
+
+        let block = crate::genesis::devnet_genesis_block_bytes();
+        let err = announce_block(&block, &relay, &pm, "local:8333", &outboxes)
+            .expect_err("connected peer without outbox must fail block announce");
+
+        assert!(err.contains("peer outbox missing for peer-a:8333"));
+    }
+
+    #[test]
+    fn announce_block_errors_when_connected_peer_outbox_is_full() {
+        let relay = TxRelayState::new();
+        let pm = PeerManager::new(crate::p2p_runtime::default_peer_runtime_config(
+            "devnet", 64,
+        ));
+        let _ = pm.add_peer(crate::p2p_runtime::PeerState {
+            addr: "peer-a:8333".to_string(),
+            ..Default::default()
+        });
+        let mut outbox = PeerOutbox::default();
+        for _ in 0..MAX_OUTBOX_FRAMES_PER_PEER {
+            assert!(outbox.push_frame(Vec::new()));
+        }
+        let outboxes: Mutex<HashMap<String, PeerOutbox>> =
+            Mutex::new(HashMap::from([("peer-a:8333".to_string(), outbox)]));
+
+        let block = crate::genesis::devnet_genesis_block_bytes();
+        let err = announce_block(&block, &relay, &pm, "local:8333", &outboxes)
+            .expect_err("full outbox must fail block announce");
+
+        assert!(err.contains("peer outbox full for peer-a:8333"));
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/tx_relay.rs
+++ b/clients/rust/crates/rubin-node/src/tx_relay.rs
@@ -1145,6 +1145,25 @@ mod tests {
     }
 
     #[test]
+    fn announce_block_with_no_peers_marks_seen_without_broadcast() {
+        let relay = TxRelayState::new();
+        let pm = PeerManager::new(crate::p2p_runtime::default_peer_runtime_config(
+            "devnet", 64,
+        ));
+        let outboxes: Mutex<HashMap<String, PeerOutbox>> = Mutex::new(HashMap::new());
+
+        let block = crate::genesis::devnet_genesis_block_bytes();
+        let parsed = parse_block_bytes(&block).expect("parse block");
+        let block_hash = block_hash(&parsed.header_bytes).expect("block hash");
+
+        announce_block(&block, &relay, &pm, "local:8333", &outboxes)
+            .expect("no-peer announce should be a successful no-op");
+
+        assert!(relay.block_seen.has(&block_hash));
+        assert!(outboxes.lock().unwrap().is_empty());
+    }
+
+    #[test]
     fn broadcast_inventory_skip_addr_excludes_sender() {
         let relay = TxRelayState::new();
         let pm = PeerManager::new(crate::p2p_runtime::default_peer_runtime_config(

--- a/clients/rust/crates/rubin-node/src/tx_relay.rs
+++ b/clients/rust/crates/rubin-node/src/tx_relay.rs
@@ -472,19 +472,26 @@ fn broadcast_inv_to_addrs(
     let Ok(mut outboxes) = peer_writers.lock() else {
         return Err("peer_outboxes lock poisoned".to_string());
     };
+    let mut failures = Vec::new();
     for addr in addrs {
         let Some(queue) = outboxes.get_mut(addr) else {
             if require_all_queues {
-                return Err(format!("peer outbox missing for {addr}"));
+                failures.push(format!("peer outbox missing for {addr}"));
             }
             continue;
         };
         if !queue.push_frame(frame.clone()) && require_all_queues {
-            return Err(format!("peer outbox full for {addr}"));
+            failures.push(format!("peer outbox full for {addr}"));
         }
         // Non-strict relay drops silently when a peer is slow or over byte
         // budget; strict block announce uses errors so local mining cannot
         // report announce success without enqueueing the block inventory.
+    }
+    if !failures.is_empty() {
+        return Err(format!(
+            "block inventory enqueue failed: {}",
+            failures.join("; ")
+        ));
     }
     Ok(())
 }
@@ -551,7 +558,7 @@ pub fn announce_block(
     if addrs.is_empty() {
         return Ok(());
     }
-    broadcast_inv_to_addrs(
+    match broadcast_inv_to_addrs(
         &[InventoryVector {
             kind: MSG_BLOCK,
             hash,
@@ -560,7 +567,13 @@ pub fn announce_block(
         &relay_state.network,
         peer_writers,
         true,
-    )
+    ) {
+        Ok(()) => Ok(()),
+        Err(err) => {
+            relay_state.block_seen.remove(&hash);
+            Err(err)
+        }
+    }
 }
 
 /// Outcome of processing a peer-relayed tx.
@@ -1083,6 +1096,52 @@ mod tests {
             .expect_err("full outbox must fail block announce");
 
         assert!(err.contains("peer outbox full for peer-a:8333"));
+    }
+
+    #[test]
+    fn announce_block_partial_failure_enqueues_healthy_peer_and_allows_retry() {
+        let relay = TxRelayState::new();
+        let pm = PeerManager::new(crate::p2p_runtime::default_peer_runtime_config(
+            "devnet", 64,
+        ));
+        let _ = pm.add_peer(crate::p2p_runtime::PeerState {
+            addr: "healthy:8333".to_string(),
+            ..Default::default()
+        });
+        let _ = pm.add_peer(crate::p2p_runtime::PeerState {
+            addr: "missing:8333".to_string(),
+            ..Default::default()
+        });
+        let outboxes: Mutex<HashMap<String, PeerOutbox>> = Mutex::new(HashMap::new());
+        outboxes
+            .lock()
+            .unwrap()
+            .insert("healthy:8333".to_string(), PeerOutbox::default());
+
+        let block = crate::genesis::devnet_genesis_block_bytes();
+        let parsed = parse_block_bytes(&block).expect("parse block");
+        let block_hash = block_hash(&parsed.header_bytes).expect("block hash");
+        let err = announce_block(&block, &relay, &pm, "local:8333", &outboxes)
+            .expect_err("missing peer outbox should fail strict block announce");
+
+        assert!(err.contains("peer outbox missing for missing:8333"));
+        assert_eq!(outboxes.lock().unwrap()["healthy:8333"].len(), 1);
+        assert!(
+            !relay.block_seen.has(&block_hash),
+            "partial failure must not suppress a later retry",
+        );
+
+        outboxes
+            .lock()
+            .unwrap()
+            .insert("missing:8333".to_string(), PeerOutbox::default());
+        announce_block(&block, &relay, &pm, "local:8333", &outboxes)
+            .expect("retry after outbox repair");
+
+        let boxes = outboxes.lock().unwrap();
+        assert_eq!(boxes["healthy:8333"].len(), 2);
+        assert_eq!(boxes["missing:8333"].len(), 1);
+        assert!(relay.block_seen.has(&block_hash));
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/tx_relay.rs
+++ b/clients/rust/crates/rubin-node/src/tx_relay.rs
@@ -316,6 +316,7 @@ impl PeerOutbox {
 /// Shared relay state passed through the P2P service.
 pub struct TxRelayState {
     pub tx_seen: BoundedHashSet,
+    pub block_seen: BoundedHashSet,
     pub relay_pool: RelayTxPool,
     pub tx_relay_fanout: usize,
     pub network: String,
@@ -335,6 +336,7 @@ impl TxRelayState {
     pub fn new_with_network(network: &str) -> Self {
         Self {
             tx_seen: BoundedHashSet::new(crate::tx_seen::DEFAULT_TX_SEEN_CAPACITY),
+            block_seen: BoundedHashSet::new(crate::tx_seen::DEFAULT_BLOCK_SEEN_CAPACITY),
             relay_pool: RelayTxPool::new(),
             tx_relay_fanout: DEFAULT_TX_RELAY_FANOUT,
             network: network.to_string(),
@@ -541,6 +543,9 @@ pub fn announce_block(
 ) -> Result<(), String> {
     let parsed = parse_block_bytes(block_bytes).map_err(|err| err.to_string())?;
     let hash = block_hash(&parsed.header_bytes).map_err(|err| err.to_string())?;
+    if !relay_state.block_seen.add(hash) {
+        return Ok(());
+    }
     let peers = peer_manager.snapshot();
     let addrs: Vec<String> = peers.iter().map(|p| p.addr.clone()).collect();
     if addrs.is_empty() {
@@ -1014,6 +1019,30 @@ mod tests {
     }
 
     #[test]
+    fn announce_block_deduplicates_seen_block_inventory() {
+        let relay = TxRelayState::new();
+        let pm = PeerManager::new(crate::p2p_runtime::default_peer_runtime_config(
+            "devnet", 64,
+        ));
+        let _ = pm.add_peer(crate::p2p_runtime::PeerState {
+            addr: "peer-a:8333".to_string(),
+            ..Default::default()
+        });
+        let outboxes: Mutex<HashMap<String, PeerOutbox>> = Mutex::new(HashMap::new());
+        outboxes
+            .lock()
+            .unwrap()
+            .insert("peer-a:8333".to_string(), PeerOutbox::default());
+
+        let block = crate::genesis::devnet_genesis_block_bytes();
+        announce_block(&block, &relay, &pm, "local:8333", &outboxes).expect("first announce");
+        announce_block(&block, &relay, &pm, "local:8333", &outboxes).expect("duplicate announce");
+
+        let boxes = outboxes.lock().unwrap();
+        assert_eq!(boxes["peer-a:8333"].len(), 1);
+    }
+
+    #[test]
     fn announce_block_errors_when_connected_peer_has_no_outbox() {
         let relay = TxRelayState::new();
         let pm = PeerManager::new(crate::p2p_runtime::default_peer_runtime_config(
@@ -1288,6 +1317,7 @@ mod tests {
         };
         let relay = TxRelayState {
             tx_seen: BoundedHashSet::new(crate::tx_seen::DEFAULT_TX_SEEN_CAPACITY),
+            block_seen: BoundedHashSet::new(crate::tx_seen::DEFAULT_BLOCK_SEEN_CAPACITY),
             relay_pool: RelayTxPool::new_with_limit(1),
             tx_relay_fanout: DEFAULT_TX_RELAY_FANOUT,
             network: "devnet".to_string(),
@@ -1324,6 +1354,7 @@ mod tests {
         let existing_txid = [0xEE; 32];
         let relay = TxRelayState {
             tx_seen: BoundedHashSet::new(crate::tx_seen::DEFAULT_TX_SEEN_CAPACITY),
+            block_seen: BoundedHashSet::new(crate::tx_seen::DEFAULT_BLOCK_SEEN_CAPACITY),
             relay_pool: RelayTxPool::new_with_limit(1),
             tx_relay_fanout: DEFAULT_TX_RELAY_FANOUT,
             network: "devnet".to_string(),

--- a/clients/rust/crates/rubin-node/src/tx_relay.rs
+++ b/clients/rust/crates/rubin-node/src/tx_relay.rs
@@ -488,10 +488,7 @@ fn broadcast_inv_to_addrs(
         // report announce success without enqueueing the block inventory.
     }
     if !failures.is_empty() {
-        return Err(format!(
-            "block inventory enqueue failed: {}",
-            failures.join("; ")
-        ));
+        return Err(format!("inventory enqueue failed: {}", failures.join("; ")));
     }
     Ok(())
 }
@@ -550,7 +547,7 @@ pub fn announce_block(
 ) -> Result<(), String> {
     let parsed = parse_block_bytes(block_bytes).map_err(|err| err.to_string())?;
     let hash = block_hash(&parsed.header_bytes).map_err(|err| err.to_string())?;
-    if !relay_state.block_seen.add(hash) {
+    if relay_state.block_seen.has(&hash) {
         return Ok(());
     }
     let peers = peer_manager.snapshot();
@@ -558,7 +555,7 @@ pub fn announce_block(
     if addrs.is_empty() {
         return Ok(());
     }
-    match broadcast_inv_to_addrs(
+    broadcast_inv_to_addrs(
         &[InventoryVector {
             kind: MSG_BLOCK,
             hash,
@@ -567,13 +564,9 @@ pub fn announce_block(
         &relay_state.network,
         peer_writers,
         true,
-    ) {
-        Ok(()) => Ok(()),
-        Err(err) => {
-            relay_state.block_seen.remove(&hash);
-            Err(err)
-        }
-    }
+    )?;
+    let _ = relay_state.block_seen.add(hash);
+    Ok(())
 }
 
 /// Outcome of processing a peer-relayed tx.
@@ -1042,7 +1035,7 @@ mod tests {
 
         let (relay, pm, outboxes) = block_announce_fixture(&[]);
         announce_block(&block, &relay, &pm, "local:8333", &outboxes).expect("no-peer announce");
-        assert!(relay.block_seen.has(&hash));
+        assert!(!relay.block_seen.has(&hash));
         assert!(outboxes.lock().unwrap().is_empty());
     }
 
@@ -1081,6 +1074,7 @@ mod tests {
         let err = announce_block(&block, &relay, &pm, "local:8333", &outboxes)
             .expect_err("full outbox must fail block announce");
         assert!(err.contains("peer outbox full for full:8333"));
+        assert!(!relay.block_seen.has(&hash));
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/tx_seen.rs
+++ b/clients/rust/crates/rubin-node/src/tx_seen.rs
@@ -80,6 +80,14 @@ impl BoundedHashSet {
         inner.items.contains_key(hash)
     }
 
+    /// Remove hash from the set. Returns `true` if it was present.
+    pub fn remove(&self, hash: &[u8; 32]) -> bool {
+        let Ok(mut inner) = self.inner.lock() else {
+            return false;
+        };
+        inner.items.remove(hash).is_some()
+    }
+
     /// Returns the current number of entries in the set.
     pub fn len(&self) -> usize {
         let Ok(inner) = self.inner.lock() else {
@@ -177,6 +185,20 @@ mod tests {
         assert!(set.is_empty());
         set.add([1u8; 32]);
         assert!(!set.is_empty());
+    }
+
+    #[test]
+    fn remove_existing_and_missing_hashes() {
+        let set = BoundedHashSet::new(10);
+        let hash = [9u8; 32];
+
+        assert!(!set.remove(&hash));
+        assert!(set.add(hash));
+        assert!(set.has(&hash));
+        assert!(set.remove(&hash));
+        assert!(!set.has(&hash));
+        assert_eq!(set.len(), 0);
+        assert!(!set.remove(&hash));
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/tx_seen.rs
+++ b/clients/rust/crates/rubin-node/src/tx_seen.rs
@@ -188,36 +188,6 @@ mod tests {
     }
 
     #[test]
-    fn remove_existing_and_missing_hashes() {
-        let set = BoundedHashSet::new(10);
-        let hash = [9u8; 32];
-
-        assert!(!set.remove(&hash));
-        assert!(set.add(hash));
-        assert!(set.has(&hash));
-        assert!(set.remove(&hash));
-        assert!(!set.has(&hash));
-        assert_eq!(set.len(), 0);
-        assert!(!set.remove(&hash));
-    }
-
-    #[test]
-    fn remove_returns_false_when_lock_is_poisoned() {
-        use std::sync::Arc;
-        use std::thread;
-
-        let set = Arc::new(BoundedHashSet::new(10));
-        let poison_target = Arc::clone(&set);
-        let _ = thread::spawn(move || {
-            let _guard = poison_target.inner.lock().expect("lock set");
-            panic!("poison bounded hash set");
-        })
-        .join();
-
-        assert!(!set.remove(&[1u8; 32]));
-    }
-
-    #[test]
     fn concurrent_add_has() {
         use std::sync::Arc;
         use std::thread;

--- a/clients/rust/crates/rubin-node/src/tx_seen.rs
+++ b/clients/rust/crates/rubin-node/src/tx_seen.rs
@@ -80,14 +80,6 @@ impl BoundedHashSet {
         inner.items.contains_key(hash)
     }
 
-    /// Remove hash from the set. Returns `true` if it was present.
-    pub fn remove(&self, hash: &[u8; 32]) -> bool {
-        let Ok(mut inner) = self.inner.lock() else {
-            return false;
-        };
-        inner.items.remove(hash).is_some()
-    }
-
     /// Returns the current number of entries in the set.
     pub fn len(&self) -> usize {
         let Ok(inner) = self.inner.lock() else {

--- a/clients/rust/crates/rubin-node/src/tx_seen.rs
+++ b/clients/rust/crates/rubin-node/src/tx_seen.rs
@@ -202,6 +202,22 @@ mod tests {
     }
 
     #[test]
+    fn remove_returns_false_when_lock_is_poisoned() {
+        use std::sync::Arc;
+        use std::thread;
+
+        let set = Arc::new(BoundedHashSet::new(10));
+        let poison_target = Arc::clone(&set);
+        let _ = thread::spawn(move || {
+            let _guard = poison_target.inner.lock().expect("lock set");
+            panic!("poison bounded hash set");
+        })
+        .join();
+
+        assert!(!set.remove(&[1u8; 32]));
+    }
+
+    #[test]
     fn concurrent_add_has() {
         use std::sync::Arc;
         use std::thread;


### PR DESCRIPTION
## Scope

RUB-232: fix Rust-mined mixed-client convergence by announcing a successfully mined Rust devnet block through the existing P2P inventory path after `/mine_next` commits it.

Changed files:
- `clients/rust/crates/rubin-node/src/devnet_rpc.rs`
- `clients/rust/crates/rubin-node/src/main.rs`
- `clients/rust/crates/rubin-node/src/p2p_service.rs`
- `clients/rust/crates/rubin-node/src/tx_relay.rs`
- `clients/rust/crates/rubin-node/src/tx_seen.rs`

Non-goals:
- no consensus validation change
- no wire/schema change
- no Go runtime change
- no broad P2P redesign
- no RUB-230 harness changes

## Disposition

Validation:
- `cargo fmt --check` passed
- `cargo test -p rubin-node mine_next -- --nocapture` passed
- `cargo test -p rubin-node announce_block -- --nocapture` passed
- `cargo test -p rubin-node peer_outbox -- --nocapture` passed
- `cargo test -p rubin-node` passed
- `cargo clippy -p rubin-node --all-targets -- -D warnings` passed
- `tooling-check.sh --new-only --mode rust-deep --repo <repo>` passed
- `rubin-common-preflight --lane coverage --repo <repo>` passed: variation `+0.03%`, diff coverage `90.62% (87/96)`
- one stock isolated code-review pass returned no findings

Compatibility impact: Rust `/mine_next` now mirrors Go's mined-block announce behavior after successful commit. Existing best-effort relay behavior for non-strict tx/block inventory remains unchanged.
