### PR TITLE
RUB-230: prove rust-mined Go convergence evidence

### DIFF
--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -149,7 +149,6 @@ import (
 )
 type blockResp struct {
 	Hash string `json:"hash"`
-	BlockHash string `json:"block_hash"`
 	Height uint64 `json:"height"`
 	Canonical bool `json:"canonical"`
 	BlockHex string `json:"block_hex"`
@@ -167,8 +166,7 @@ func main() {
 	wantTxCount, err := strconv.ParseUint(*txCountRaw, 10, 64); if err != nil { die("bad tx_count") }
 	raw, err := os.ReadFile(*respPath); if err != nil { die("read block response: " + err.Error()) }
 	var resp blockResp; if err := json.Unmarshal(raw, &resp); err != nil { die("decode block response: " + err.Error()) }
-	gotHash := resp.Hash; if gotHash == "" { gotHash = resp.BlockHash }
-	if resp.Height != wantHeight || strings.ToLower(gotHash) != strings.ToLower(*hashHex) || !resp.Canonical { die("block response height/hash/canonical mismatch") }
+	if resp.Height != wantHeight || strings.ToLower(resp.Hash) != strings.ToLower(*hashHex) || !resp.Canonical { die("block response height/hash/canonical mismatch") }
 	txBytes, err := hex.DecodeString(strings.TrimSpace(*txHex)); if err != nil { die("decode tx_hex: " + err.Error()) }
 	_, wantTxid, _, consumed, err := consensus.ParseTx(txBytes); if err != nil || consumed != len(txBytes) { die("parse tx_hex failed") }
 	if hex.EncodeToString(wantTxid[:]) != strings.ToLower(*txidHex) { die("tx_hex txid mismatch") }

--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -7,17 +7,17 @@ CHECK_REPORT="" CHECK_REPORT_MODE="" MESH_TIMEOUT="${MESH_TIMEOUT:-90}" TX_PATH_
 usage() {
   cat >&2 <<EOF
 usage:
-  $0 [--go-submit-rust-accept]
+  $0 [--go-submit-rust-accept|--go-submit-rust-mine-go-converge]
   $0 --check-report PATH
   $0 --check-report-live PATH
 
 --check-report and --check-report-live validate mixed_client_mesh reports only.
-mixed_client_go_submit_rust_accept proof is same-run producer validation and is not
-accepted from public report revalidation paths.
+tx-path proofs are same-run producer validation and are not accepted from public
+report revalidation paths.
 EOF
 }
-while (($#)); do case "$1" in --go-submit-rust-accept) TX_PATH_MODE=1; shift ;; --check-report|--check-report-live) [[ $# -ge 2 ]] || { usage; exit 2; }; CHECK_REPORT_MODE=offline; [[ "$1" == "--check-report-live" ]] && CHECK_REPORT_MODE=live; CHECK_REPORT="$2"; shift 2 ;; -h|--help) usage; exit 0 ;; *) usage; exit 2 ;; esac; done
-if [[ -n "${CHECK_REPORT_MODE}" && "${TX_PATH_MODE}" == "1" ]]; then echo "--go-submit-rust-accept cannot be combined with --check-report or --check-report-live" >&2; exit 2; fi
+while (($#)); do case "$1" in --go-submit-rust-accept) TX_PATH_MODE=1; shift ;; --go-submit-rust-mine-go-converge) TX_PATH_MODE=2; shift ;; --check-report|--check-report-live) [[ $# -ge 2 ]] || { usage; exit 2; }; CHECK_REPORT_MODE=offline; [[ "$1" == "--check-report-live" ]] && CHECK_REPORT_MODE=live; CHECK_REPORT="$2"; shift 2 ;; -h|--help) usage; exit 0 ;; *) usage; exit 2 ;; esac; done
+if [[ -n "${CHECK_REPORT_MODE}" && "${TX_PATH_MODE}" != "0" ]]; then echo "tx-path modes cannot be combined with --check-report or --check-report-live" >&2; exit 2; fi
 need_tool() { command -v -- "$1" >/dev/null 2>&1 || { echo "$1 is required for mixed-client mesh evidence" >&2; exit 1; }; }
 validate_deterministic_tx_fee() {
   [[ "${DETERMINISTIC_TX_FEE}" =~ ^[0-9]{1,9}$ ]] || { echo "DETERMINISTIC_TX_FEE must be a positive integer <= 100000000" >&2; exit 2; }
@@ -34,6 +34,7 @@ from pathlib import Path
 path = Path(sys.argv[1]); live = sys.argv[3] == "live"; expected_mode = sys.argv[4]; dev_env = sys.argv[5]; go_module_root = sys.argv[6]
 SCENARIO_MESH = "mixed_client_mesh"
 SCENARIO_TX = "mixed_client_go_submit_rust_accept"
+SCENARIO_CONVERGE = "mixed_client_go_submit_rust_mine_go_converge"
 MAX_JSON_BYTES = 1_000_000
 MAX_PARSER_OUTPUT_BYTES = 100_000
 MAX_TX_HEX_CHARS = 20_000
@@ -217,16 +218,17 @@ def ts(value: object) -> bool:
 data = load_json_file("report", path)
 req(expected_mode in {"public", "producer-tx"}, f"check_report expected mode is invalid: {expected_mode!r}")
 scenario = data.get("scenario")
-tx_mode = scenario == SCENARIO_TX
-req(scenario in {SCENARIO_MESH, SCENARIO_TX}, f"scenario is not supported: {scenario!r}")
+tx_mode = scenario in {SCENARIO_TX, SCENARIO_CONVERGE}
+converge_mode = scenario == SCENARIO_CONVERGE
+req(scenario in {SCENARIO_MESH, SCENARIO_TX, SCENARIO_CONVERGE}, f"scenario is not supported: {scenario!r}")
 if tx_mode and expected_mode != "producer-tx":
     fail(("public tx-path check-report-live is unsupported" if live else "public tx-path check-report is unsupported") + "; same-run producer evidence is required")
 if expected_mode == "producer-tx":
-    req(tx_mode, "producer tx validation requires mixed_client_go_submit_rust_accept report")
+    req(tx_mode, "producer tx validation requires a mixed-client tx-path report")
 req(data.get("verdict") == "PASS", f"report verdict is not PASS: {data.get('verdict')!r}")
 req("failure_reason" not in data and "schema_marker" not in data, "PASS report must not carry failure/schema-marker verdict fields")
 base_keys = {"artifact_root", "final_verification", "legacy_schema_compatibility", "nodes", "peer_connectivity", "scenario", "verdict"}
-allowed_keys = base_keys | ({"go_submit", "rust_accept", "tx_path"} if tx_mode else set())
+allowed_keys = base_keys | ({"go_submit", "rust_accept", "tx_path"} if tx_mode else set()) | ({"rust_mine", "go_converge"} if converge_mode else set())
 req(set(data) == allowed_keys, f"report top-level keys mismatch: {sorted(data)}")
 artifact_root_arg = data.get("artifact_root"); artifact_root = checked_path("artifact_root", artifact_root_arg)
 legacy_schema = data.get("legacy_schema_compatibility")
@@ -293,9 +295,29 @@ if tx_mode:
     req(len({go_status, go_get, rust_status, rust_get}) == 4, "tx sidecar paths are not pairwise distinct")
     tx_sidecars(load_json_file("go_submit.tx_status", go_status), load_json_file("go_submit.get_tx", go_get), txid, txhex, "go_submit", "go", nodes_by_impl["go"]["rpc_endpoint"], f"/tx_status?txid={txid}", f"/get_tx?txid={txid}")
     tx_sidecars(load_json_file("rust_accept.tx_status", rust_status), load_json_file("rust_accept.get_tx", rust_get), txid, txhex, "rust_accept", "rust", nodes_by_impl["rust"]["rpc_endpoint"], f"/tx_status?txid={txid}", f"/get_tx?txid={txid}")
-    if live:
+    if live and not converge_mode:
         tx_sidecars(tx_rpc(nodes_by_impl["go"]["rpc_endpoint"], f"/tx_status?txid={txid}", "go_submit.tx_status", "go"), tx_rpc(nodes_by_impl["go"]["rpc_endpoint"], f"/get_tx?txid={txid}", "go_submit.get_tx", "go"), txid, txhex, "go_submit.live", "go", nodes_by_impl["go"]["rpc_endpoint"], f"/tx_status?txid={txid}", f"/get_tx?txid={txid}")
         tx_sidecars(tx_rpc(nodes_by_impl["rust"]["rpc_endpoint"], f"/tx_status?txid={txid}", "rust_accept.tx_status", "rust"), tx_rpc(nodes_by_impl["rust"]["rpc_endpoint"], f"/get_tx?txid={txid}", "rust_accept.get_tx", "rust"), txid, txhex, "rust_accept.live", "rust", nodes_by_impl["rust"]["rpc_endpoint"], f"/tx_status?txid={txid}", f"/get_tx?txid={txid}")
+    if converge_mode:
+        rust_mine = exact_object(data.get("rust_mine"), {"block_hash", "block_path", "class", "height", "mine_next_path", "mined_by", "raw_hex", "rpc_endpoint", "tx_count", "txid"}, "rust_mine")
+        go_converge = exact_object(data.get("go_converge"), {"block_hash", "block_path", "class", "converged_at", "height", "raw_hex", "rpc_endpoint", "tip_path", "txid"}, "go_converge")
+        req(rust_mine.get("class") == "mined_included" and rust_mine.get("mined_by") == "node-rust", "rust_mine is not node-rust mined_included")
+        req(go_converge.get("class") == "canonical_block_found" and go_converge.get("converged_at") == "node-go", "go_converge is not node-go canonical_block_found")
+        req(rust_mine.get("txid") == txid and go_converge.get("txid") == txid and rust_mine.get("raw_hex") == txhex and go_converge.get("raw_hex") == txhex, "mined/converged tx identity differs from submitted tx")
+        req(rust_mine.get("rpc_endpoint") == nodes_by_impl["rust"]["rpc_endpoint"] and go_converge.get("rpc_endpoint") == nodes_by_impl["go"]["rpc_endpoint"], "mined/converged RPC endpoints are not bound to expected nodes")
+        height, block_hash = rust_mine.get("height"), rust_mine.get("block_hash")
+        req(isinstance(height, int) and not isinstance(height, bool) and height >= 1, "rust_mine.height is malformed")
+        req(isinstance(block_hash, str) and re.fullmatch(r"[0-9a-f]{64}", block_hash), "rust_mine.block_hash is malformed")
+        req(isinstance(rust_mine.get("tx_count"), int) and not isinstance(rust_mine.get("tx_count"), bool) and rust_mine["tx_count"] >= 2, "rust_mine.tx_count does not prove coinbase plus submitted tx")
+        req(go_converge.get("height") == height and go_converge.get("block_hash") == block_hash, "go_converge does not match rust_mine height/hash")
+        mine_next = load_json_file("rust_mine.mine_next", artifact_file("rust_mine.mine_next_path", rust_mine.get("mine_next_path"), artifact_root))
+        req(mine_next.get("mined") is True and mine_next.get("height") == height and mine_next.get("block_hash") == block_hash and mine_next.get("tx_count") == rust_mine["tx_count"], "rust_mine mine_next sidecar does not match report")
+        for label, path_value in (("rust_mine.block_path", rust_mine.get("block_path")), ("go_converge.block_path", go_converge.get("block_path"))):
+            block = load_json_file(label, artifact_file(label, path_value, artifact_root))
+            actual_hash = block.get("hash") or block.get("block_hash")
+            req(block.get("canonical") is True and block.get("height") == height and actual_hash == block_hash and isinstance(block.get("block_hex"), str) and block["block_hex"], f"{label} does not prove canonical mined block")
+        tip = load_json_file("go_converge.tip", artifact_file("go_converge.tip_path", go_converge.get("tip_path"), artifact_root))
+        req(tip.get("has_tip") is True and tip.get("height") == height and tip.get("tip_hash") == block_hash, "go_converge tip sidecar does not match rust mined block")
 connectivity = data.get("peer_connectivity")
 req(isinstance(connectivity, dict), "PASS report missing peer_connectivity object")
 req(all(connectivity.get(f) is True for f in ("go_to_rust", "rust_to_go", "bidirectional_observed")), "peer_connectivity booleans are not all true")
@@ -319,7 +341,7 @@ PY
 }
 [[ "${MESH_TIMEOUT}" =~ ^[0-9]{1,3}$ ]] || { echo "MESH_TIMEOUT must be an integer in [1, 600]" >&2; exit 2; }; MESH_TIMEOUT="$((10#${MESH_TIMEOUT}))"; (( MESH_TIMEOUT >= 1 && MESH_TIMEOUT <= 600 )) || { echo "MESH_TIMEOUT must be an integer in [1, 600]" >&2; exit 2; }; export MESH_TIMEOUT
 if [[ -n "${CHECK_REPORT_MODE}" ]]; then need_tool python3; [[ -x "${DEV_ENV}" ]] || { echo "dev-env wrapper missing or non-executable: ${DEV_ENV}" >&2; exit 1; }; [[ -r "${VALIDATOR}" ]] || { echo "validator unreadable: ${VALIDATOR}" >&2; exit 1; }; check_report "${CHECK_REPORT}" "${CHECK_REPORT_MODE}"; exit 0; fi
-if (( TX_PATH_MODE == 1 )); then validate_deterministic_tx_fee; fi
+if (( TX_PATH_MODE >= 1 )); then validate_deterministic_tx_fee; fi
 need_tool python3; [[ -x "${DEV_ENV}" ]] || { echo "dev-env wrapper missing or non-executable: ${DEV_ENV}" >&2; exit 1; }; [[ -r "${VALIDATOR}" ]] || { echo "validator unreadable: ${VALIDATOR}" >&2; exit 1; }
 # shellcheck source=scripts/devnet-process-common.sh disable=SC1091
 source "${HELPER}"
@@ -329,8 +351,9 @@ GO_DIR="${RUBIN_PROCESS_ARTIFACT_ROOT}/node-go"; RUST_DIR="${RUBIN_PROCESS_ARTIF
 GO_LOG="node-go.log"; RUST_LOG="node-rust.log"; REPORT_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/mixed-client-mesh-report.json"; LEGACY_SCHEMA_MARKER_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/mixed-client-mesh-legacy-schema-marker.json"
 GO_PEERS_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/go-peers.json"; RUST_PEERS_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/rust-peers.json"
 GO_SUBMIT_STATUS_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/go-tx-status.json"; GO_SUBMIT_GET_TX_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/go-get-tx.json"; RUST_STATUS_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/rust-tx-status.json"; RUST_GET_TX_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/rust-get-tx.json"
-TXGEN_BIN="${RUBIN_PROCESS_ARTIFACT_ROOT}/rubin-txgen"; KEYGEN_GO="${RUBIN_PROCESS_ARTIFACT_ROOT}/keygen.go"; KEYGEN_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/keygen.json"; MINE_LOG="mine-go.log"
-GO_PID="" RUST_PID="" GO_RPC_ADDR="" RUST_RPC_ADDR="" GO_P2P_ADDR="" RUST_P2P_ADDR="" GO_STARTED_AT_UTC="" RUST_STARTED_AT_UTC="" GO_COMM="" RUST_COMM="" RUST_TO_GO_LOCAL_ADDR="" GO_CMD="" RUST_CMD="" GO_ARGV_JSON="" RUST_ARGV_JSON="" FINAL_PROCESS_IDENTITY_RECHECKED="" FINAL_RUST_OUTBOUND_LINK_RECHECKED="" FINAL_PEER_SNAPSHOTS_RECHECKED="" PROCESS_IDENTITY_REASON="" START_REASON="" BUILD_REASON="" TX_REASON="" TX_ID="" TX_HEX="" TX_FROM_KEY_FILE="" TX_FROM_KEY_DIR="" TX_TO_KEY=""
+RUST_MINE_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/rust-mine-next.json"; RUST_MINE_BLOCK_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/rust-mined-block.json"; GO_CONVERGE_TIP_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/go-converge-tip.json"; GO_CONVERGE_BLOCK_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/go-converge-block.json"
+TXGEN_BIN="${RUBIN_PROCESS_ARTIFACT_ROOT}/rubin-txgen"; KEYGEN_GO="${RUBIN_PROCESS_ARTIFACT_ROOT}/keygen.go"; KEYGEN_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/keygen.json"; BLOCK_CHECK_GO="${RUBIN_PROCESS_ARTIFACT_ROOT}/block-check.go"; MINE_LOG="mine-go.log"
+GO_PID="" RUST_PID="" GO_RPC_ADDR="" RUST_RPC_ADDR="" GO_P2P_ADDR="" RUST_P2P_ADDR="" GO_STARTED_AT_UTC="" RUST_STARTED_AT_UTC="" GO_COMM="" RUST_COMM="" RUST_TO_GO_LOCAL_ADDR="" GO_CMD="" RUST_CMD="" GO_ARGV_JSON="" RUST_ARGV_JSON="" FINAL_PROCESS_IDENTITY_RECHECKED="" FINAL_RUST_OUTBOUND_LINK_RECHECKED="" FINAL_PEER_SNAPSHOTS_RECHECKED="" PROCESS_IDENTITY_REASON="" START_REASON="" BUILD_REASON="" TX_REASON="" TX_ID="" TX_HEX="" TX_FROM_KEY_FILE="" TX_FROM_KEY_DIR="" TX_TO_KEY="" RUST_MINE_HEIGHT="" RUST_MINE_HASH="" RUST_MINE_TX_COUNT=""
 mkdir -p -- "${GO_DIR}" "${RUST_DIR}"
 run_fips_preflight_before_captured_dev_env() { [[ "${RUBIN_OPENSSL_FIPS_MODE:-off}" != "only" || "${RUBIN_OPENSSL_SKIP_FIPS_GUARD:-0}" == "1" ]] && return 0; echo "Running FIPS-only preflight before captured dev-env command streams" >&2; "${DEV_ENV}" -- "${REPO_ROOT}/scripts/crypto/openssl/fips-preflight.sh" >&2; }
 bounded() { perl -e 'alarm shift @ARGV; exec @ARGV; die "exec failed: $!\n"' 5 "$@"; }
@@ -341,7 +364,7 @@ disable_xtrace_for_secret() { case "$-" in *x*) set +x; return 0 ;; *) return 1 
 restore_xtrace_after_secret() { [[ "${1:-0}" == "1" ]] && set -x; return 0; }
 cleanup_tx_from_key_file() {
   local xtrace_was_enabled=0
-  if disable_xtrace_for_secret; then xtrace_was_enabled=1; fi
+  case "$-" in *x*) set +x; xtrace_was_enabled=1 ;; esac
   local secret_file="${TX_FROM_KEY_FILE:-}" secret_dir="${TX_FROM_KEY_DIR:-}" cleanup_status=0
   if [[ -n "${secret_file}" ]]; then rm -f -- "${secret_file}" || cleanup_status=$?; TX_FROM_KEY_FILE=""; fi
   if [[ -n "${secret_dir}" ]]; then rm -f -- "${secret_dir}/keygen-public.json" "${secret_dir}/from-key.hex" || cleanup_status=$?; rmdir -- "${secret_dir}" || cleanup_status=$?; TX_FROM_KEY_DIR=""; fi
@@ -363,7 +386,7 @@ tx_report_reason_token() {
   python3 - "${msg}" <<'PY'
 import re, sys
 msg = "\n".join(line[5:].strip() if line.startswith("FAIL:") else line for line in sys.argv[1].splitlines())
-rules = [("tx parser consumed mismatch", "tx_parser_consumed_mismatch"), ("tx parser timeout", "tx_parser_timeout"), ("tx parser unavailable", "tx_parser_unavailable"), ("tx parser output too large", "tx_parser_output_too_large"), ("tx parser malformed output", "tx_parser_malformed_output"), ("tx parser root is not an object", "tx_parser_root_invalid"), ("tx parser did not produce txid", "tx_parser_missing_txid"), ("tx parser failed", "tx_parser_failed"), ("tx_hex is malformed or unbounded", "tx_hex_malformed_or_unbounded"), ("txid is malformed", "txid_malformed"), ("tx report rpc endpoint mismatch", "tx_report_rpc_endpoint_mismatch"), ("capture identity mismatch", "capture_identity_mismatch"), ("tx sidecar paths are not pairwise distinct", "tx_sidecar_paths_not_distinct"), ("scenario mismatch", "scenario_mismatch"), ("verdict mismatch", "verdict_mismatch"), ("artifact_root mismatch", "artifact_root_mismatch"), ("tx_path identity mismatch", "tx_path_identity_mismatch"), ("tx report txid mismatch", "tx_identity_mismatch"), ("tx report raw transaction mismatch", "raw_tx_mismatch")]
+rules = [("mined/converged tx identity differs", "converged_tx_identity_mismatch"), ("go_converge does not match rust_mine", "go_converge_height_hash_mismatch"), ("rust_mine.tx_count", "rust_mine_tx_count_invalid"), ("mine_next sidecar does not match", "rust_mine_sidecar_invalid"), ("does not prove canonical mined block", "block_sidecar_invalid"), ("tip sidecar does not match", "go_converge_tip_invalid"), ("tx parser consumed mismatch", "tx_parser_consumed_mismatch"), ("tx parser timeout", "tx_parser_timeout"), ("tx parser unavailable", "tx_parser_unavailable"), ("tx parser output too large", "tx_parser_output_too_large"), ("tx parser malformed output", "tx_parser_malformed_output"), ("tx parser root is not an object", "tx_parser_root_invalid"), ("tx parser did not produce txid", "tx_parser_missing_txid"), ("tx parser failed", "tx_parser_failed"), ("tx_hex is malformed or unbounded", "tx_hex_malformed_or_unbounded"), ("txid is malformed", "txid_malformed"), ("tx report rpc endpoint mismatch", "tx_report_rpc_endpoint_mismatch"), ("capture identity mismatch", "capture_identity_mismatch"), ("tx sidecar paths are not pairwise distinct", "tx_sidecar_paths_not_distinct"), ("scenario mismatch", "scenario_mismatch"), ("verdict mismatch", "verdict_mismatch"), ("artifact_root mismatch", "artifact_root_mismatch"), ("tx_path identity mismatch", "tx_path_identity_mismatch"), ("tx report txid mismatch", "tx_identity_mismatch"), ("tx report raw transaction mismatch", "raw_tx_mismatch")]
 for needle, token in rules:
     if needle in msg:
         print(token)
@@ -536,7 +559,7 @@ func main() {
 	fromAddress := hex.EncodeToString(consensus.P2PKCovenantDataForPubkey(from.PubkeyBytes()))
 	path := filepath.Join(dir, "from-key.hex")
 	if err := os.WriteFile(path, []byte(hex.EncodeToString(der)+"\n"), 0o600); err != nil { panic(err) }
-	_ = json.NewEncoder(os.Stdout).Encode(map[string]string{"private_key_file": path, "from_address_hex": fromAddress, "to_address_hex": hex.EncodeToString(consensus.P2PKCovenantDataForPubkey(to.PubkeyBytes())), "mine_address_hex": fromAddress})
+	if err := json.NewEncoder(os.Stdout).Encode(map[string]string{"private_key_file": path, "from_address_hex": fromAddress, "to_address_hex": hex.EncodeToString(consensus.P2PKCovenantDataForPubkey(to.PubkeyBytes())), "mine_address_hex": fromAddress}); err != nil { panic(err) }
 }
 EOF
 }
@@ -640,15 +663,17 @@ PY
   return "${rc}"
 }
 prepare_tx_chainstate() {
-  local keygen_public_json keygen_fields_raw mine_address xtrace_was_enabled=0 status=0 rc=0
+  local keygen_public_json keygen_fields_raw mine_address keygen_raw="${KEYGEN_JSON}.raw" keygen_err="${KEYGEN_JSON}.stderr" xtrace_was_enabled=0 status=0 rc=0
   TX_REASON=""
   build_go_txgen || { TX_REASON="${BUILD_REASON:-go_txgen_build_failed}"; return 1; }
   write_keygen || { TX_REASON=go_submit_keygen_write_failed; return 1; }
   if disable_xtrace_for_secret; then xtrace_was_enabled=1; fi
   TX_FROM_KEY_DIR="$(make_tx_secret_dir "${TMPDIR:-/tmp}")" || { restore_xtrace_after_secret "${xtrace_was_enabled}"; TX_REASON=go_submit_keygen_tempdir_failed; return 1; }
   chmod 700 "${TX_FROM_KEY_DIR}" || { status=$?; cleanup_tx_from_key_file || true; restore_xtrace_after_secret "${xtrace_was_enabled}"; TX_REASON=go_submit_keygen_tempdir_failed; return "${status}"; }
-  keygen_public_json="$(bounded_mesh env RUBIN_OPENSSL_SKIP_FIPS_GUARD=1 "${DEV_ENV}" -- go -C "${GO_MODULE_ROOT}" run "${KEYGEN_GO}" "${TX_FROM_KEY_DIR}")" || { status=$?; cleanup_tx_from_key_file || true; restore_xtrace_after_secret "${xtrace_was_enabled}"; [[ ${status} -eq 142 ]] && TX_REASON=go_submit_keygen_timeout || TX_REASON=go_submit_keygen_failed; return "${status}"; }
+  bounded_mesh /usr/bin/env RUBIN_OPENSSL_SKIP_FIPS_GUARD=1 "${DEV_ENV}" -- go -C "${GO_MODULE_ROOT}" run "${KEYGEN_GO}" "${TX_FROM_KEY_DIR}" >"${keygen_raw}" 2>"${keygen_err}" || { status=$?; cleanup_tx_from_key_file || true; restore_xtrace_after_secret "${xtrace_was_enabled}"; [[ ${status} -eq 142 ]] && TX_REASON=go_submit_keygen_timeout || TX_REASON=go_submit_keygen_failed; return "${status}"; }
+  keygen_public_json="$(cat -- "${keygen_raw}")" || { cleanup_tx_from_key_file || true; restore_xtrace_after_secret "${xtrace_was_enabled}"; TX_REASON=go_submit_keygen_material_malformed_json; return 1; }
   keygen_fields_raw="$(parse_keygen_material "${keygen_public_json}")" || { rc=$?; cleanup_tx_from_key_file || true; restore_xtrace_after_secret "${xtrace_was_enabled}"; TX_REASON="$(keygen_material_reason "${rc}")"; return 1; }
+  rm -f -- "${keygen_raw}" "${keygen_err}" || { cleanup_tx_from_key_file || true; restore_xtrace_after_secret "${xtrace_was_enabled}"; TX_REASON=go_submit_keygen_cleanup_failed; return 1; }
   [[ "$(printf '%s\n' "${keygen_fields_raw}" | sed -n '$=')" == "3" ]] || { cleanup_tx_from_key_file || true; restore_xtrace_after_secret "${xtrace_was_enabled}"; TX_REASON=go_submit_keygen_material_malformed; return 1; }
   TX_FROM_KEY_FILE="$(printf '%s\n' "${keygen_fields_raw}" | sed -n '1p')"
   TX_TO_KEY="$(printf '%s\n' "${keygen_fields_raw}" | sed -n '2p')"
@@ -808,6 +833,127 @@ wait_rust_accept() {
   [[ -n "${last_retry_reason}" ]] && TX_REASON="rust_accept_timeout_last_${last_retry_reason#rust_accept_}" || TX_REASON="${TX_REASON:-rust_accept_pending_timeout}"
   return 1
 }
+write_block_check_go() {
+  cat >"${BLOCK_CHECK_GO}" <<'EOF'
+package main
+import (
+	"encoding/hex"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+)
+type blockResp struct {
+	Hash string `json:"hash"`
+	Height uint64 `json:"height"`
+	Canonical bool `json:"canonical"`
+	BlockHex string `json:"block_hex"`
+}
+func die(v any) { fmt.Fprintln(os.Stderr, v); os.Exit(1) }
+func main() {
+	respPath := flag.String("block-response", "", "")
+	txHex := flag.String("tx-hex", "", "")
+	txidHex := flag.String("txid", "", "")
+	heightRaw := flag.String("height", "", "")
+	hashHex := flag.String("hash", "", "")
+	flag.Parse()
+	wantHeight, err := strconv.ParseUint(*heightRaw, 10, 64); if err != nil { die("bad height") }
+	raw, err := os.ReadFile(*respPath); if err != nil { die("read block response: " + err.Error()) }
+	var resp blockResp; if err := json.Unmarshal(raw, &resp); err != nil { die("decode block response: " + err.Error()) }
+	if resp.Height != wantHeight || strings.ToLower(resp.Hash) != strings.ToLower(*hashHex) || !resp.Canonical { die("block response height/hash/canonical mismatch") }
+	txBytes, err := hex.DecodeString(strings.TrimSpace(*txHex)); if err != nil { die("decode tx_hex: " + err.Error()) }
+	_, wantTxid, _, consumed, err := consensus.ParseTx(txBytes); if err != nil || consumed != len(txBytes) { die("parse tx_hex failed") }
+	if hex.EncodeToString(wantTxid[:]) != strings.ToLower(*txidHex) { die("tx_hex txid mismatch") }
+	blockBytes, err := hex.DecodeString(strings.TrimSpace(resp.BlockHex)); if err != nil { die("decode block_hex: " + err.Error()) }
+	pb, err := consensus.ParseBlockBytes(blockBytes); if err != nil { die("parse block_hex failed: " + err.Error()) }
+	gotHash, err := consensus.BlockHash(pb.HeaderBytes); if err != nil || hex.EncodeToString(gotHash[:]) != strings.ToLower(*hashHex) { die("parsed block hash mismatch") }
+	for _, got := range pb.Txids { if got == wantTxid { return } }
+	die("submitted txid missing from parsed block txids")
+}
+EOF
+}
+verify_block_inclusion() {
+  local label="$1" block_path="$2" height="$3" block_hash="$4" output
+  [[ -s "${BLOCK_CHECK_GO}" ]] || write_block_check_go || { TX_REASON="${label}_block_check_write_failed"; return 1; }
+  output="$(RUBIN_OPENSSL_SKIP_FIPS_GUARD=1 "${DEV_ENV}" -- go -C "${GO_MODULE_ROOT}" run "${BLOCK_CHECK_GO}" --block-response "${block_path}" --tx-hex "${TX_HEX}" --txid "${TX_ID}" --height "${height}" --hash "${block_hash}" 2>&1)" || {
+    printf '%s\n' "${label} inclusion check failed: ${output}" >&2
+    TX_REASON="${label}_inclusion_failed"
+    return 1
+  }
+}
+parse_mine_next_response() {
+  python3 - "$1" <<'PY'
+import json, re, sys
+try:
+    with open(sys.argv[1], encoding="utf-8") as f:
+        data = json.load(f)
+except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+    sys.exit(13)
+if not isinstance(data, dict):
+    sys.exit(13)
+height, block_hash, tx_count = data.get("height"), data.get("block_hash"), data.get("tx_count")
+if data.get("mined") is not True:
+    sys.exit(14)
+if not isinstance(height, int) or isinstance(height, bool) or height < 1:
+    sys.exit(13)
+if not isinstance(block_hash, str) or not re.fullmatch(r"[0-9a-f]{64}", block_hash):
+    sys.exit(13)
+if not isinstance(tx_count, int) or isinstance(tx_count, bool) or tx_count < 2:
+    sys.exit(16)
+print(height, block_hash, tx_count, sep="\t")
+PY
+}
+rust_mine_including_tx() {
+  local parsed rc=0
+  TX_REASON=""
+  rpc_json POST "${RUST_RPC_ADDR}" /mine_next >"${RUST_MINE_JSON}" || { TX_REASON=rust_mine_rpc_failed; return 1; }
+  parsed="$(parse_mine_next_response "${RUST_MINE_JSON}")" || { rc=$?; case "${rc}" in 13) TX_REASON=rust_mine_malformed_rpc_body ;; 14) TX_REASON=rust_mine_unavailable ;; 16) TX_REASON=rust_mine_tx_count_invalid ;; *) TX_REASON=rust_mine_unknown_failure ;; esac; return 1; }
+  IFS=$'\t' read -r RUST_MINE_HEIGHT RUST_MINE_HASH RUST_MINE_TX_COUNT <<<"${parsed}" || { TX_REASON=rust_mine_malformed_rpc_body; return 1; }
+  rpc_json GET "${RUST_RPC_ADDR}" "/get_block?height=${RUST_MINE_HEIGHT}" >"${RUST_MINE_BLOCK_JSON}" || { TX_REASON=rust_mine_get_block_failed; return 1; }
+  verify_block_inclusion rust_mine "${RUST_MINE_BLOCK_JSON}" "${RUST_MINE_HEIGHT}" "${RUST_MINE_HASH}"
+}
+tip_matches() {
+  python3 - "$1" "$2" "$3" <<'PY'
+import json, sys
+path, height_raw, block_hash = sys.argv[1:4]
+try:
+    height = int(height_raw)
+    with open(path, encoding="utf-8") as f:
+        data = json.load(f)
+except (OSError, ValueError, json.JSONDecodeError, UnicodeDecodeError):
+    sys.exit(2)
+if not isinstance(data, dict):
+    sys.exit(2)
+sys.exit(0 if data.get("has_tip") is True and data.get("height") == height and data.get("tip_hash") == block_hash else 1)
+PY
+}
+wait_go_converge_to_rust_mined_block() {
+  local deadline tmp rc=0
+  TX_REASON=""
+  deadline=$((SECONDS + MESH_TIMEOUT)); tmp="${GO_CONVERGE_TIP_JSON}.tmp"
+  while (( SECONDS < deadline )); do
+    if rpc_json GET "${GO_RPC_ADDR}" /get_tip >"${tmp}"; then
+      if tip_matches "${tmp}" "${RUST_MINE_HEIGHT}" "${RUST_MINE_HASH}"; then
+        mv -- "${tmp}" "${GO_CONVERGE_TIP_JSON}" || { TX_REASON=go_converge_artifact_write_failed; return 1; }
+        rpc_json GET "${GO_RPC_ADDR}" "/get_block?height=${RUST_MINE_HEIGHT}" >"${GO_CONVERGE_BLOCK_JSON}" || { TX_REASON=go_converge_get_block_failed; return 1; }
+        verify_block_inclusion go_converge "${GO_CONVERGE_BLOCK_JSON}" "${RUST_MINE_HEIGHT}" "${RUST_MINE_HASH}"
+        return $?
+      else
+        rc=$?
+        (( rc == 2 )) && { rm -f -- "${tmp}"; TX_REASON=go_converge_malformed_rpc_body; return 1; }
+      fi
+    else
+      TX_REASON=go_converge_rpc_failed
+    fi
+    sleep 1
+  done
+  rm -f -- "${tmp}"
+  TX_REASON="${TX_REASON:-go_converge_timeout}"
+  return 1
+}
 write_outputs() {
   local verdict="$1" reason="${2:-}"
   export REPORT_JSON LEGACY_SCHEMA_MARKER_JSON verdict reason GO_PID RUST_PID GO_RPC_ADDR RUST_RPC_ADDR \
@@ -815,7 +961,8 @@ write_outputs() {
     GO_NODE_BIN RUST_NODE_BIN GO_CMD RUST_CMD GO_ARGV_JSON RUST_ARGV_JSON GO_PEERS_JSON RUST_PEERS_JSON \
     GO_PROCESS_ALIVE RUST_PROCESS_ALIVE GO_RPC_PROCESS_BACKED RUST_RPC_PROCESS_BACKED GO_P2P_PROCESS_BACKED RUST_P2P_PROCESS_BACKED \
     RUST_TO_GO_LOCAL_ADDR FINAL_PROCESS_IDENTITY_RECHECKED FINAL_RUST_OUTBOUND_LINK_RECHECKED FINAL_PEER_SNAPSHOTS_RECHECKED \
-    RUBIN_PROCESS_ARTIFACT_ROOT TX_PATH_MODE TX_ID TX_HEX GO_SUBMIT_STATUS_JSON GO_SUBMIT_GET_TX_JSON RUST_STATUS_JSON RUST_GET_TX_JSON
+    RUBIN_PROCESS_ARTIFACT_ROOT TX_PATH_MODE TX_ID TX_HEX GO_SUBMIT_STATUS_JSON GO_SUBMIT_GET_TX_JSON RUST_STATUS_JSON RUST_GET_TX_JSON \
+    RUST_MINE_JSON RUST_MINE_BLOCK_JSON GO_CONVERGE_TIP_JSON GO_CONVERGE_BLOCK_JSON RUST_MINE_HEIGHT RUST_MINE_HASH RUST_MINE_TX_COUNT
   python3 - <<'PY'
 import json, os
 e = os.environ
@@ -851,8 +998,11 @@ for impl, name, pid_key, rpc_key, p2p_key, started_key, comm_key, bin_key, cmd_k
     }
     nodes.append(node)
 go_snapshot, rust_snapshot = read_json(e["GO_PEERS_JSON"]), read_json(e["RUST_PEERS_JSON"])
+tx_path_mode = e.get("TX_PATH_MODE")
+tx_mode = tx_path_mode in {"1", "2"}
+converge_mode = tx_path_mode == "2"
 report = {
-    "scenario": "mixed_client_go_submit_rust_accept" if e.get("TX_PATH_MODE") == "1" else "mixed_client_mesh",
+    "scenario": "mixed_client_go_submit_rust_mine_go_converge" if converge_mode else "mixed_client_go_submit_rust_accept" if tx_mode else "mixed_client_mesh",
     "verdict": verdict,
     "artifact_root": e["RUBIN_PROCESS_ARTIFACT_ROOT"],
     "nodes": nodes,
@@ -872,11 +1022,14 @@ report = {
         "reason": "existing mixed_client_evidence_v1 PASS requires tx_path; RUB-21 mesh-only PASS lives in this report",
     },
 }
-if e.get("TX_PATH_MODE") == "1" and verdict == "PASS":
+if tx_mode and verdict == "PASS":
     tx_path = {"submitted_at": "node-go", "observed_at": ["node-rust"], "tx_id": e["TX_ID"]}
     report["tx_path"] = tx_path
     report["go_submit"] = {"txid": e["TX_ID"], "tx_hex": e["TX_HEX"], "rpc_endpoint": e["GO_RPC_ADDR"], "tx_status_path": e["GO_SUBMIT_STATUS_JSON"], "get_tx_path": e["GO_SUBMIT_GET_TX_JSON"]}
     report["rust_accept"] = {"txid": e["TX_ID"], "raw_hex": e["TX_HEX"], "rpc_endpoint": e["RUST_RPC_ADDR"], "tx_status_path": e["RUST_STATUS_JSON"], "get_tx_path": e["RUST_GET_TX_JSON"]}
+    if converge_mode:
+        report["rust_mine"] = {"block_hash": e["RUST_MINE_HASH"], "block_path": e["RUST_MINE_BLOCK_JSON"], "class": "mined_included", "height": int(e["RUST_MINE_HEIGHT"]), "mine_next_path": e["RUST_MINE_JSON"], "mined_by": "node-rust", "raw_hex": e["TX_HEX"], "rpc_endpoint": e["RUST_RPC_ADDR"], "tx_count": int(e["RUST_MINE_TX_COUNT"]), "txid": e["TX_ID"]}
+        report["go_converge"] = {"block_hash": e["RUST_MINE_HASH"], "block_path": e["GO_CONVERGE_BLOCK_JSON"], "class": "canonical_block_found", "converged_at": "node-go", "height": int(e["RUST_MINE_HEIGHT"]), "raw_hex": e["TX_HEX"], "rpc_endpoint": e["GO_RPC_ADDR"], "tip_path": e["GO_CONVERGE_TIP_JSON"], "txid": e["TX_ID"]}
 if verdict != "PASS":
     report["failure_reason"] = reason or "mixed-client mesh did not produce PASS evidence"
 with open(e["REPORT_JSON"], "w", encoding="utf-8") as f:
@@ -887,13 +1040,13 @@ legacy_schema_marker = {
     "schema_version": "rubin-mixed-client-devnet-evidence-v1",
     "evidence_type": "mixed_client_process_soak",
     "scenario": "mixed_client_mesh_schema_marker",
-    "verdict": "PASS" if e.get("TX_PATH_MODE") == "1" and verdict == "PASS" else "FAIL",
+    "verdict": "PASS" if tx_mode and verdict == "PASS" else "FAIL",
     "participants": [
         {"name": "node-go", "implementation": "go", **({"endpoint": e["GO_RPC_ADDR"], "started_at": e["GO_STARTED_AT_UTC"]} if e.get("GO_RPC_ADDR") and e.get("GO_STARTED_AT_UTC") else {})},
         {"name": "node-rust", "implementation": "rust", **({"endpoint": e["RUST_RPC_ADDR"], "started_at": e["RUST_STARTED_AT_UTC"]} if e.get("RUST_RPC_ADDR") and e.get("RUST_STARTED_AT_UTC") else {})},
     ],
 }
-if e.get("TX_PATH_MODE") == "1" and verdict == "PASS":
+if tx_mode and verdict == "PASS":
     legacy_schema_marker["tx_path"] = tx_path
 else:
     legacy_schema_marker["failure_reason"] = legacy_marker_reason
@@ -991,7 +1144,7 @@ start_go_node() {
 for tool in lsof perl ps sed sort; do command -v "${tool}" >/dev/null 2>&1 || finish_no_data "${tool}_unavailable"; done
 build_go_node || finish_no_data "${BUILD_REASON:-go_build_failed}"
 build_rust_node || finish_no_data "${BUILD_REASON:-rust_build_failed}"
-if (( TX_PATH_MODE == 1 )); then prepare_tx_chainstate || finish_no_data "${TX_REASON:-go_submit_chainstate_prepare_failed}"; fi
+if (( TX_PATH_MODE >= 1 )); then prepare_tx_chainstate || finish_no_data "${TX_REASON:-go_submit_chainstate_prepare_failed}"; fi
 start_go_node || finish_no_data "${START_REASON:-go_process_not_ready}"
 verify_process_identity node-go go "${GO_PID}" "${GO_RPC_ADDR}" "${GO_P2P_ADDR}" rubin-node-go go_process_identity || finish_no_data "${PROCESS_IDENTITY_REASON:-go_process_identity_unverified}"
 start_rust_node || finish_no_data "${START_REASON:-rust_process_not_ready}"
@@ -1007,16 +1160,20 @@ FINAL_RUST_OUTBOUND_LINK_RECHECKED=true
 wait_peer_snapshot node-rust-final "${RUST_RPC_ADDR}" "${RUST_PEERS_JSON}" "${MESH_TIMEOUT}" "${GO_P2P_ADDR}" || finish_no_data "${PEER_SNAPSHOT_REASON:-rust_final_peer_snapshot_missing_go_endpoint}"
 wait_peer_snapshot node-go-final "${GO_RPC_ADDR}" "${GO_PEERS_JSON}" "${MESH_TIMEOUT}" "${RUST_TO_GO_LOCAL_ADDR}" || finish_no_data "${PEER_SNAPSHOT_REASON:-go_final_peer_snapshot_missing_rust_endpoint}"
 FINAL_PEER_SNAPSHOTS_RECHECKED=true
-if (( TX_PATH_MODE == 1 )); then
+if (( TX_PATH_MODE >= 1 )); then
   submit_go_tx || finish_no_data "${TX_REASON:-go_submit_failed}"
   wait_rust_accept || finish_no_data "${TX_REASON:-rust_accept_failed}"
+  if (( TX_PATH_MODE == 2 )); then
+    rust_mine_including_tx || finish_no_data "${TX_REASON:-rust_mine_failed}"
+    wait_go_converge_to_rust_mined_block || finish_no_data "${TX_REASON:-go_converge_failed}"
+  fi
 fi
 PASS_REPORT_JSON="$(mktemp "/tmp/mixed-client-mesh-pass.XXXXXX")" || finish_no_data "pass_report_temp_failed"; FINAL_REPORT_JSON="${REPORT_JSON}"; REPORT_JSON="${PASS_REPORT_JSON}"
 write_outputs "PASS" || { REPORT_JSON="${FINAL_REPORT_JSON}"; finish_no_data "pass_report_write_failed"; }; REPORT_JSON="${FINAL_REPORT_JSON}"
 if ! run_validator "${LEGACY_SCHEMA_MARKER_JSON}" >&2; then
   rm -f -- "${PASS_REPORT_JSON}"; finish_no_data "legacy_schema_marker_validation_failed"
 fi
-if (( TX_PATH_MODE == 1 )); then
+if (( TX_PATH_MODE >= 1 )); then
   if ! check_err="$(check_report "${PASS_REPORT_JSON}" live producer-tx 2>&1)"; then
     rm -f -- "${PASS_REPORT_JSON}"; finish_no_data "pass_report_live_validation_$(combined_report_reason_token <<<"${check_err}")"
   fi
@@ -1026,5 +1183,5 @@ else
   fi
 fi
 mv -- "${PASS_REPORT_JSON}" "${REPORT_JSON}" || finish_no_data "pass_report_publish_failed"
-PASS_SCENARIO="mixed-client mesh connected"; (( TX_PATH_MODE == 1 )) && PASS_SCENARIO="Go-submit/Rust-accept path observed"
+PASS_SCENARIO="mixed-client mesh connected"; (( TX_PATH_MODE == 1 )) && PASS_SCENARIO="Go-submit/Rust-accept path observed"; (( TX_PATH_MODE == 2 )) && PASS_SCENARIO="Go-submit/Rust-mine/Go-converge path observed"
 [[ "${RUBIN_PROCESS_KEEP_ARTIFACTS}" == "1" ]] && echo "PASS: ${PASS_SCENARIO} go_pid=${GO_PID} rust_pid=${RUST_PID}; report=${REPORT_JSON} legacy_schema_marker=${LEGACY_SCHEMA_MARKER_JSON}" || echo "PASS: ${PASS_SCENARIO} go_pid=${GO_PID} rust_pid=${RUST_PID}; set KEEP_TMP=1 to retain report"

--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -16,7 +16,8 @@ tx-path proofs are same-run producer validation and are not accepted from public
 report revalidation paths.
 EOF
 }
-while (($#)); do case "$1" in --go-submit-rust-accept) TX_PATH_MODE=1; shift ;; --go-submit-rust-mine-go-converge) TX_PATH_MODE=2; shift ;; --check-report|--check-report-live) [[ $# -ge 2 ]] || { usage; exit 2; }; CHECK_REPORT_MODE=offline; [[ "$1" == "--check-report-live" ]] && CHECK_REPORT_MODE=live; CHECK_REPORT="$2"; shift 2 ;; -h|--help) usage; exit 0 ;; *) usage; exit 2 ;; esac; done
+set_tx_path_mode() { local mode="$1" flag="$2"; (( TX_PATH_MODE == 0 )) || { echo "tx-path modes are mutually exclusive: ${flag}" >&2; usage; exit 2; }; TX_PATH_MODE="${mode}"; }
+while (($#)); do case "$1" in --go-submit-rust-accept) set_tx_path_mode 1 "$1"; shift ;; --go-submit-rust-mine-go-converge) set_tx_path_mode 2 "$1"; shift ;; --check-report|--check-report-live) [[ $# -ge 2 ]] || { usage; exit 2; }; CHECK_REPORT_MODE=offline; [[ "$1" == "--check-report-live" ]] && CHECK_REPORT_MODE=live; CHECK_REPORT="$2"; shift 2 ;; -h|--help) usage; exit 0 ;; *) usage; exit 2 ;; esac; done
 if [[ -n "${CHECK_REPORT_MODE}" && "${TX_PATH_MODE}" != "0" ]]; then echo "tx-path modes cannot be combined with --check-report or --check-report-live" >&2; exit 2; fi
 need_tool() { command -v -- "$1" >/dev/null 2>&1 || { echo "$1 is required for mixed-client mesh evidence" >&2; exit 1; }; }
 validate_deterministic_tx_fee() {
@@ -127,8 +128,10 @@ def parse_txid_from_hex(txhex: str) -> str:
     req(parsed.get("ok") is True and isinstance(txid, str) and re.fullmatch(r"[0-9a-f]{64}", txid), "tx parser did not produce txid")
     req(parsed.get("consumed") == len(txhex) // 2, "tx parser consumed mismatch")
     return txid
-def verify_block_inclusion_sidecar(label: str, p: Path, txhex: str, txid: str, height: int, block_hash: str) -> None:
+def verify_block_inclusion_sidecar(label: str, p: Path, txhex: str, txid: str, height: int, block_hash: str, impl: str, endpoint: str, request_path: str) -> None:
     block = load_json_file(label, p)
+    req(set(block) == {"block_hex", "canonical", "hash", "height", "implementation", "request_path", "rpc_endpoint"}, f"{label} keys mismatch: {sorted(block)}")
+    req(block.get("implementation") == impl and block.get("rpc_endpoint") == endpoint and block.get("request_path") == request_path, f"{label} sidecar identity mismatch")
     actual_hash = block.get("hash") or block.get("block_hash")
     req(block.get("canonical") is True and block.get("height") == height and actual_hash == block_hash, f"{label} sidecar height/hash/canonical mismatch")
     req(isinstance(block.get("block_hex"), str) and block["block_hex"], f"{label} block_hex is missing")
@@ -371,11 +374,20 @@ if tx_mode:
         req(isinstance(block_hash, str) and re.fullmatch(r"[0-9a-f]{64}", block_hash), "rust_mine.block_hash is malformed")
         req(isinstance(rust_mine.get("tx_count"), int) and not isinstance(rust_mine.get("tx_count"), bool) and rust_mine["tx_count"] >= 2, "rust_mine.tx_count does not prove coinbase plus submitted tx")
         req(go_converge.get("height") == height and go_converge.get("block_hash") == block_hash, "go_converge does not match rust_mine height/hash")
-        mine_next = load_json_file("rust_mine.mine_next", artifact_file("rust_mine.mine_next_path", rust_mine.get("mine_next_path"), artifact_root))
+        rust_mine_next_path = artifact_file("rust_mine.mine_next_path", rust_mine.get("mine_next_path"), artifact_root)
+        rust_block_path = artifact_file("rust_mine.block_path", rust_mine.get("block_path"), artifact_root)
+        go_tip_path = artifact_file("go_converge.tip_path", go_converge.get("tip_path"), artifact_root)
+        go_block_path = artifact_file("go_converge.block_path", go_converge.get("block_path"), artifact_root)
+        req(len({rust_mine_next_path, rust_block_path, go_tip_path, go_block_path}) == 4, "converge sidecar paths are not pairwise distinct")
+        mine_next = load_json_file("rust_mine.mine_next", rust_mine_next_path)
+        req(set(mine_next) == {"block_hash", "height", "implementation", "mined", "nonce", "request_path", "rpc_endpoint", "timestamp", "tx_count"}, f"rust_mine.mine_next keys mismatch: {sorted(mine_next)}")
+        req(mine_next.get("implementation") == "rust" and mine_next.get("rpc_endpoint") == nodes_by_impl["rust"]["rpc_endpoint"] and mine_next.get("request_path") == "/mine_next", "rust_mine mine_next sidecar identity mismatch")
         req(mine_next.get("mined") is True and mine_next.get("height") == height and mine_next.get("block_hash") == block_hash and mine_next.get("tx_count") == rust_mine["tx_count"], "rust_mine mine_next sidecar does not match report")
-        for label, path_value in (("rust_mine.block_path", rust_mine.get("block_path")), ("go_converge.block_path", go_converge.get("block_path"))):
-            verify_block_inclusion_sidecar(label, artifact_file(label, path_value, artifact_root), txhex, txid, height, block_hash)
-        tip = load_json_file("go_converge.tip", artifact_file("go_converge.tip_path", go_converge.get("tip_path"), artifact_root))
+        verify_block_inclusion_sidecar("rust_mine.block_path", rust_block_path, txhex, txid, height, block_hash, "rust", nodes_by_impl["rust"]["rpc_endpoint"], f"/get_block?height={height}")
+        verify_block_inclusion_sidecar("go_converge.block_path", go_block_path, txhex, txid, height, block_hash, "go", nodes_by_impl["go"]["rpc_endpoint"], f"/get_block?height={height}")
+        tip = load_json_file("go_converge.tip", go_tip_path)
+        req(set(tip) == {"best_known_height", "has_tip", "height", "implementation", "in_ibd", "request_path", "rpc_endpoint", "tip_hash"}, f"go_converge.tip keys mismatch: {sorted(tip)}")
+        req(tip.get("implementation") == "go" and tip.get("rpc_endpoint") == nodes_by_impl["go"]["rpc_endpoint"] and tip.get("request_path") == "/get_tip", "go_converge tip sidecar identity mismatch")
         req(tip.get("has_tip") is True and tip.get("height") == height and tip.get("tip_hash") == block_hash, "go_converge tip sidecar does not match rust mined block")
 connectivity = data.get("peer_connectivity")
 req(isinstance(connectivity, dict), "PASS report missing peer_connectivity object")
@@ -445,7 +457,7 @@ tx_report_reason_token() {
   python3 - "${msg}" <<'PY'
 import re, sys
 msg = "\n".join(line[5:].strip() if line.startswith("FAIL:") else line for line in sys.argv[1].splitlines())
-rules = [("rust_mine is not node-rust mined_included", "rust_mine_class_invalid"), ("go_converge is not node-go canonical_block_found", "go_converge_class_invalid"), ("mined/converged RPC endpoints are not bound", "converge_rpc_endpoint_mismatch"), ("rust_mine.height is malformed", "rust_mine_height_invalid"), ("rust_mine.block_hash is malformed", "rust_mine_hash_invalid"), ("submitted txid missing from parsed block txids", "block_missing_submitted_txid"), ("parse block_hex failed", "block_hex_parse_failed"), ("parsed block hash mismatch", "block_hash_mismatch"), ("inclusion check timeout", "block_inclusion_timeout"), ("inclusion check failed", "block_inclusion_failed"), ("mined/converged tx identity differs", "converged_tx_identity_mismatch"), ("go_converge does not match rust_mine", "go_converge_height_hash_mismatch"), ("rust_mine.tx_count", "rust_mine_tx_count_invalid"), ("mine_next sidecar does not match", "rust_mine_sidecar_invalid"), ("sidecar height/hash/canonical mismatch", "block_sidecar_invalid"), ("block_hex is missing", "block_sidecar_invalid"), ("tip sidecar does not match", "go_converge_tip_invalid"), ("tx parser consumed mismatch", "tx_parser_consumed_mismatch"), ("tx parser timeout", "tx_parser_timeout"), ("tx parser unavailable", "tx_parser_unavailable"), ("tx parser output too large", "tx_parser_output_too_large"), ("tx parser malformed output", "tx_parser_malformed_output"), ("tx parser root is not an object", "tx_parser_root_invalid"), ("tx parser did not produce txid", "tx_parser_missing_txid"), ("tx parser failed", "tx_parser_failed"), ("tx_hex is malformed or unbounded", "tx_hex_malformed_or_unbounded"), ("txid is malformed", "txid_malformed"), ("tx report rpc endpoint mismatch", "tx_report_rpc_endpoint_mismatch"), ("capture identity mismatch", "capture_identity_mismatch"), ("tx sidecar paths are not pairwise distinct", "tx_sidecar_paths_not_distinct"), ("scenario mismatch", "scenario_mismatch"), ("verdict mismatch", "verdict_mismatch"), ("artifact_root mismatch", "artifact_root_mismatch"), ("tx_path identity mismatch", "tx_path_identity_mismatch"), ("tx report txid mismatch", "tx_identity_mismatch"), ("tx report raw transaction mismatch", "raw_tx_mismatch")]
+rules = [("rust_mine is not node-rust mined_included", "rust_mine_class_invalid"), ("go_converge is not node-go canonical_block_found", "go_converge_class_invalid"), ("mined/converged RPC endpoints are not bound", "converge_rpc_endpoint_mismatch"), ("rust_mine.height is malformed", "rust_mine_height_invalid"), ("rust_mine.block_hash is malformed", "rust_mine_hash_invalid"), ("sidecar identity mismatch", "converge_sidecar_identity_mismatch"), ("converge sidecar paths are not pairwise distinct", "converge_sidecar_paths_not_distinct"), ("submitted txid missing from parsed block txids", "block_missing_submitted_txid"), ("parse block_hex failed", "block_hex_parse_failed"), ("parsed block hash mismatch", "block_hash_mismatch"), ("inclusion check timeout", "block_inclusion_timeout"), ("inclusion check failed", "block_inclusion_failed"), ("mined/converged tx identity differs", "converged_tx_identity_mismatch"), ("go_converge does not match rust_mine", "go_converge_height_hash_mismatch"), ("rust_mine.tx_count", "rust_mine_tx_count_invalid"), ("mine_next sidecar does not match", "rust_mine_sidecar_invalid"), ("sidecar height/hash/canonical mismatch", "block_sidecar_invalid"), ("block_hex is missing", "block_sidecar_invalid"), ("tip sidecar does not match", "go_converge_tip_invalid"), ("tx parser consumed mismatch", "tx_parser_consumed_mismatch"), ("tx parser timeout", "tx_parser_timeout"), ("tx parser unavailable", "tx_parser_unavailable"), ("tx parser output too large", "tx_parser_output_too_large"), ("tx parser malformed output", "tx_parser_malformed_output"), ("tx parser root is not an object", "tx_parser_root_invalid"), ("tx parser did not produce txid", "tx_parser_missing_txid"), ("tx parser failed", "tx_parser_failed"), ("tx_hex is malformed or unbounded", "tx_hex_malformed_or_unbounded"), ("txid is malformed", "txid_malformed"), ("tx report rpc endpoint mismatch", "tx_report_rpc_endpoint_mismatch"), ("capture identity mismatch", "tx_capture_identity_mismatch"), ("tx sidecar paths are not pairwise distinct", "tx_sidecar_paths_not_distinct"), ("scenario mismatch", "scenario_mismatch"), ("verdict mismatch", "verdict_mismatch"), ("artifact_root mismatch", "artifact_root_mismatch"), ("tx_path identity mismatch", "tx_path_identity_mismatch"), ("tx report txid mismatch", "tx_identity_mismatch"), ("tx report raw transaction mismatch", "raw_tx_mismatch")]
 for needle, token in rules:
     if needle in msg:
         print(token)
@@ -501,9 +513,9 @@ except (urllib.error.URLError, TimeoutError, socket.timeout) as exc:
     sys.exit(1)
 PY
 }
-capture_tx_rpc_sidecar() {
-  local impl="$1" addr="$2" path="$3" out="$4" status=0; local tmp="${out}.raw"
-  rpc_json GET "${addr}" "${path}" >"${tmp}" || status=$?
+capture_rpc_sidecar() {
+  local impl="$1" method="$2" addr="$3" path="$4" out="$5" status=0; local tmp="${out}.raw"
+  rpc_json "${method}" "${addr}" "${path}" >"${tmp}" || status=$?
   (( status == 0 )) || { rm -f -- "${tmp}"; case "${status}" in 22) return 21 ;; 23) return 23 ;; *) return 22 ;; esac; }
   python3 - "${impl}" "${addr}" "${path}" "${tmp}" "${out}" <<'PY'
 import json, os, sys
@@ -529,6 +541,7 @@ finally:
     except OSError: pass
 PY
 }
+capture_tx_rpc_sidecar() { capture_rpc_sidecar "$1" GET "$2" "$3" "$4"; }
 pid_comm() { local pid="$1" raw comm status=0 err="${RUBIN_PROCESS_ARTIFACT_ROOT}/ps.err"; raw="$(bounded ps -ww -p "${pid}" -o comm= 2>"${err}")" || status=$?; (( status == 142 )) && return 3; [[ ${status} -eq 0 || ! -s "${err}" ]] || return 2; comm="$(sed -n '1p' <<<"${raw}")" || return 4; [[ -n "${comm}" ]] || return 1; basename -- "${comm}"; }
 pid_listens_on() {
   local pid="$1" endpoint="$2" out err status=0
@@ -973,10 +986,10 @@ PY
 rust_mine_including_tx() {
   local parsed rc=0
   TX_REASON=""
-  rpc_json POST "${RUST_RPC_ADDR}" /mine_next >"${RUST_MINE_JSON}" || { TX_REASON=rust_mine_rpc_failed; return 1; }
+  capture_rpc_sidecar rust POST "${RUST_RPC_ADDR}" /mine_next "${RUST_MINE_JSON}" || { rc=$?; TX_REASON="$(tx_capture_reason rust_mine "${rc}")"; return 1; }
   parsed="$(parse_mine_next_response "${RUST_MINE_JSON}")" || { rc=$?; case "${rc}" in 13) TX_REASON=rust_mine_malformed_rpc_body ;; 14) TX_REASON=rust_mine_unavailable ;; 16) TX_REASON=rust_mine_tx_count_invalid ;; *) TX_REASON=rust_mine_unknown_failure ;; esac; return 1; }
   IFS=$'\t' read -r RUST_MINE_HEIGHT RUST_MINE_HASH RUST_MINE_TX_COUNT <<<"${parsed}" || { TX_REASON=rust_mine_malformed_rpc_body; return 1; }
-  rpc_json GET "${RUST_RPC_ADDR}" "/get_block?height=${RUST_MINE_HEIGHT}" >"${RUST_MINE_BLOCK_JSON}" || { TX_REASON=rust_mine_get_block_failed; return 1; }
+  capture_rpc_sidecar rust GET "${RUST_RPC_ADDR}" "/get_block?height=${RUST_MINE_HEIGHT}" "${RUST_MINE_BLOCK_JSON}" || { rc=$?; TX_REASON="$(tx_capture_reason rust_mine_get_block "${rc}")"; return 1; }
   verify_block_inclusion rust_mine "${RUST_MINE_BLOCK_JSON}" "${RUST_MINE_HEIGHT}" "${RUST_MINE_HASH}"
 }
 tip_matches() {
@@ -995,27 +1008,30 @@ sys.exit(0 if data.get("has_tip") is True and data.get("height") == height and d
 PY
 }
 wait_go_converge_to_rust_mined_block() {
-  local deadline tmp rc=0
+  local deadline tmp rc=0 saw_valid_tip=false
   TX_REASON=""
   deadline=$((SECONDS + MESH_TIMEOUT)); tmp="${GO_CONVERGE_TIP_JSON}.tmp"
   while (( SECONDS < deadline )); do
-    if rpc_json GET "${GO_RPC_ADDR}" /get_tip >"${tmp}"; then
+    if capture_rpc_sidecar go GET "${GO_RPC_ADDR}" /get_tip "${tmp}"; then
       if tip_matches "${tmp}" "${RUST_MINE_HEIGHT}" "${RUST_MINE_HASH}"; then
         mv -- "${tmp}" "${GO_CONVERGE_TIP_JSON}" || { TX_REASON=go_converge_artifact_write_failed; return 1; }
-        rpc_json GET "${GO_RPC_ADDR}" "/get_block?height=${RUST_MINE_HEIGHT}" >"${GO_CONVERGE_BLOCK_JSON}" || { TX_REASON=go_converge_get_block_failed; return 1; }
+        capture_rpc_sidecar go GET "${GO_RPC_ADDR}" "/get_block?height=${RUST_MINE_HEIGHT}" "${GO_CONVERGE_BLOCK_JSON}" || { rc=$?; TX_REASON="$(tx_capture_reason go_converge_get_block "${rc}")"; return 1; }
         verify_block_inclusion go_converge "${GO_CONVERGE_BLOCK_JSON}" "${RUST_MINE_HEIGHT}" "${RUST_MINE_HASH}"
         return $?
       else
         rc=$?
         (( rc == 2 )) && { rm -f -- "${tmp}"; TX_REASON=go_converge_malformed_rpc_body; return 1; }
+        saw_valid_tip=true
+        TX_REASON=""
       fi
     else
-      TX_REASON=go_converge_rpc_failed
+      rc=$?
+      [[ "${saw_valid_tip}" == "true" ]] || TX_REASON="$(tx_capture_reason go_converge_tip "${rc}")"
     fi
     sleep 1
   done
   rm -f -- "${tmp}"
-  TX_REASON="${TX_REASON:-go_converge_timeout}"
+  [[ "${saw_valid_tip}" == "true" ]] && TX_REASON=go_converge_timeout || TX_REASON="${TX_REASON:-go_converge_timeout}"
   return 1
 }
 write_outputs() {

--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -29,7 +29,7 @@ run_validator() { RUBIN_OPENSSL_SKIP_FIPS_GUARD=1 "${DEV_ENV}" -- python3 "${VAL
 check_report() { local report="${1:-}" mode="${2:-offline}" expected_mode="${3:-public}"
   [[ -n "${report}" ]] || { echo "FAIL: report path is required" >&2; return 1; }
   RUBIN_OPENSSL_SKIP_FIPS_GUARD=1 "${DEV_ENV}" -- python3 - "${report}" "${VALIDATOR}" "${mode}" "${expected_mode}" "${DEV_ENV}" "${GO_MODULE_ROOT}" <<'PY'
-import datetime as dt, json, os, re, socket, struct, subprocess, sys, time, urllib.error, urllib.request
+import datetime as dt, json, os, re, socket, struct, subprocess, sys, tempfile, time, urllib.error, urllib.request
 from pathlib import Path
 path = Path(sys.argv[1]); live = sys.argv[3] == "live"; expected_mode = sys.argv[4]; dev_env = sys.argv[5]; go_module_root = sys.argv[6]
 SCENARIO_MESH = "mixed_client_mesh"
@@ -127,6 +127,67 @@ def parse_txid_from_hex(txhex: str) -> str:
     req(parsed.get("ok") is True and isinstance(txid, str) and re.fullmatch(r"[0-9a-f]{64}", txid), "tx parser did not produce txid")
     req(parsed.get("consumed") == len(txhex) // 2, "tx parser consumed mismatch")
     return txid
+def verify_block_inclusion_sidecar(label: str, p: Path, txhex: str, txid: str, height: int, block_hash: str) -> None:
+    block = load_json_file(label, p)
+    actual_hash = block.get("hash") or block.get("block_hash")
+    req(block.get("canonical") is True and block.get("height") == height and actual_hash == block_hash, f"{label} sidecar height/hash/canonical mismatch")
+    req(isinstance(block.get("block_hex"), str) and block["block_hex"], f"{label} block_hex is missing")
+    source = r'''
+package main
+import (
+	"encoding/hex"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+)
+type blockResp struct {
+	Hash string `json:"hash"`
+	BlockHash string `json:"block_hash"`
+	Height uint64 `json:"height"`
+	Canonical bool `json:"canonical"`
+	BlockHex string `json:"block_hex"`
+}
+func die(v any) { fmt.Fprintln(os.Stderr, v); os.Exit(1) }
+func main() {
+	respPath := flag.String("block-response", "", "")
+	txHex := flag.String("tx-hex", "", "")
+	txidHex := flag.String("txid", "", "")
+	heightRaw := flag.String("height", "", "")
+	hashHex := flag.String("hash", "", "")
+	flag.Parse()
+	wantHeight, err := strconv.ParseUint(*heightRaw, 10, 64); if err != nil { die("bad height") }
+	raw, err := os.ReadFile(*respPath); if err != nil { die("read block response: " + err.Error()) }
+	var resp blockResp; if err := json.Unmarshal(raw, &resp); err != nil { die("decode block response: " + err.Error()) }
+	gotHash := resp.Hash; if gotHash == "" { gotHash = resp.BlockHash }
+	if resp.Height != wantHeight || strings.ToLower(gotHash) != strings.ToLower(*hashHex) || !resp.Canonical { die("block response height/hash/canonical mismatch") }
+	txBytes, err := hex.DecodeString(strings.TrimSpace(*txHex)); if err != nil { die("decode tx_hex: " + err.Error()) }
+	_, wantTxid, _, consumed, err := consensus.ParseTx(txBytes); if err != nil || consumed != len(txBytes) { die("parse tx_hex failed") }
+	if hex.EncodeToString(wantTxid[:]) != strings.ToLower(*txidHex) { die("tx_hex txid mismatch") }
+	blockBytes, err := hex.DecodeString(strings.TrimSpace(resp.BlockHex)); if err != nil { die("decode block_hex: " + err.Error()) }
+	pb, err := consensus.ParseBlockBytes(blockBytes); if err != nil { die("parse block_hex failed: " + err.Error()) }
+	gotBlockHash, err := consensus.BlockHash(pb.HeaderBytes); if err != nil || hex.EncodeToString(gotBlockHash[:]) != strings.ToLower(*hashHex) { die("parsed block hash mismatch") }
+	for _, got := range pb.Txids { if got == wantTxid { return } }
+	die("submitted txid missing from parsed block txids")
+}
+'''
+    with tempfile.TemporaryDirectory(prefix="rubin-mesh-block-check-") as td:
+        source_path = Path(td) / "block-check.go"
+        source_path.write_text(source, encoding="utf-8")
+        try:
+            proc = subprocess.run([dev_env, "--", "go", "-C", go_module_root, "run", str(source_path), "--block-response", str(p), "--tx-hex", txhex, "--txid", txid, "--height", str(height), "--hash", block_hash], check=False, env={**os.environ, "RUBIN_OPENSSL_SKIP_FIPS_GUARD": "1"}, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, timeout=max(30, min(LIVE_TIMEOUT, 60)))
+        except subprocess.TimeoutExpired:
+            fail(f"{label} inclusion check timeout")
+        except OSError as exc:
+            fail(f"{label} inclusion check unavailable: {exc}")
+    stdout, stderr = proc.stdout or "", proc.stderr or ""
+    req(len(stdout) <= MAX_PARSER_OUTPUT_BYTES and len(stderr) <= MAX_PARSER_OUTPUT_BYTES, f"{label} inclusion check output too large")
+    if proc.returncode != 0:
+        detail = ((stderr or stdout).strip().splitlines() or ["block checker returned nonzero"])[0]
+        fail(f"{label} inclusion check failed: {detail}")
 def pid_exe(pid: int) -> str:
     proc = Path(f"/proc/{pid}/exe")
     if proc.exists() or Path("/proc").is_dir():
@@ -313,9 +374,7 @@ if tx_mode:
         mine_next = load_json_file("rust_mine.mine_next", artifact_file("rust_mine.mine_next_path", rust_mine.get("mine_next_path"), artifact_root))
         req(mine_next.get("mined") is True and mine_next.get("height") == height and mine_next.get("block_hash") == block_hash and mine_next.get("tx_count") == rust_mine["tx_count"], "rust_mine mine_next sidecar does not match report")
         for label, path_value in (("rust_mine.block_path", rust_mine.get("block_path")), ("go_converge.block_path", go_converge.get("block_path"))):
-            block = load_json_file(label, artifact_file(label, path_value, artifact_root))
-            actual_hash = block.get("hash") or block.get("block_hash")
-            req(block.get("canonical") is True and block.get("height") == height and actual_hash == block_hash and isinstance(block.get("block_hex"), str) and block["block_hex"], f"{label} does not prove canonical mined block")
+            verify_block_inclusion_sidecar(label, artifact_file(label, path_value, artifact_root), txhex, txid, height, block_hash)
         tip = load_json_file("go_converge.tip", artifact_file("go_converge.tip_path", go_converge.get("tip_path"), artifact_root))
         req(tip.get("has_tip") is True and tip.get("height") == height and tip.get("tip_hash") == block_hash, "go_converge tip sidecar does not match rust mined block")
 connectivity = data.get("peer_connectivity")
@@ -386,7 +445,7 @@ tx_report_reason_token() {
   python3 - "${msg}" <<'PY'
 import re, sys
 msg = "\n".join(line[5:].strip() if line.startswith("FAIL:") else line for line in sys.argv[1].splitlines())
-rules = [("mined/converged tx identity differs", "converged_tx_identity_mismatch"), ("go_converge does not match rust_mine", "go_converge_height_hash_mismatch"), ("rust_mine.tx_count", "rust_mine_tx_count_invalid"), ("mine_next sidecar does not match", "rust_mine_sidecar_invalid"), ("does not prove canonical mined block", "block_sidecar_invalid"), ("tip sidecar does not match", "go_converge_tip_invalid"), ("tx parser consumed mismatch", "tx_parser_consumed_mismatch"), ("tx parser timeout", "tx_parser_timeout"), ("tx parser unavailable", "tx_parser_unavailable"), ("tx parser output too large", "tx_parser_output_too_large"), ("tx parser malformed output", "tx_parser_malformed_output"), ("tx parser root is not an object", "tx_parser_root_invalid"), ("tx parser did not produce txid", "tx_parser_missing_txid"), ("tx parser failed", "tx_parser_failed"), ("tx_hex is malformed or unbounded", "tx_hex_malformed_or_unbounded"), ("txid is malformed", "txid_malformed"), ("tx report rpc endpoint mismatch", "tx_report_rpc_endpoint_mismatch"), ("capture identity mismatch", "capture_identity_mismatch"), ("tx sidecar paths are not pairwise distinct", "tx_sidecar_paths_not_distinct"), ("scenario mismatch", "scenario_mismatch"), ("verdict mismatch", "verdict_mismatch"), ("artifact_root mismatch", "artifact_root_mismatch"), ("tx_path identity mismatch", "tx_path_identity_mismatch"), ("tx report txid mismatch", "tx_identity_mismatch"), ("tx report raw transaction mismatch", "raw_tx_mismatch")]
+rules = [("rust_mine is not node-rust mined_included", "rust_mine_class_invalid"), ("go_converge is not node-go canonical_block_found", "go_converge_class_invalid"), ("mined/converged RPC endpoints are not bound", "converge_rpc_endpoint_mismatch"), ("rust_mine.height is malformed", "rust_mine_height_invalid"), ("rust_mine.block_hash is malformed", "rust_mine_hash_invalid"), ("submitted txid missing from parsed block txids", "block_missing_submitted_txid"), ("parse block_hex failed", "block_hex_parse_failed"), ("parsed block hash mismatch", "block_hash_mismatch"), ("inclusion check timeout", "block_inclusion_timeout"), ("inclusion check failed", "block_inclusion_failed"), ("mined/converged tx identity differs", "converged_tx_identity_mismatch"), ("go_converge does not match rust_mine", "go_converge_height_hash_mismatch"), ("rust_mine.tx_count", "rust_mine_tx_count_invalid"), ("mine_next sidecar does not match", "rust_mine_sidecar_invalid"), ("sidecar height/hash/canonical mismatch", "block_sidecar_invalid"), ("block_hex is missing", "block_sidecar_invalid"), ("tip sidecar does not match", "go_converge_tip_invalid"), ("tx parser consumed mismatch", "tx_parser_consumed_mismatch"), ("tx parser timeout", "tx_parser_timeout"), ("tx parser unavailable", "tx_parser_unavailable"), ("tx parser output too large", "tx_parser_output_too_large"), ("tx parser malformed output", "tx_parser_malformed_output"), ("tx parser root is not an object", "tx_parser_root_invalid"), ("tx parser did not produce txid", "tx_parser_missing_txid"), ("tx parser failed", "tx_parser_failed"), ("tx_hex is malformed or unbounded", "tx_hex_malformed_or_unbounded"), ("txid is malformed", "txid_malformed"), ("tx report rpc endpoint mismatch", "tx_report_rpc_endpoint_mismatch"), ("capture identity mismatch", "capture_identity_mismatch"), ("tx sidecar paths are not pairwise distinct", "tx_sidecar_paths_not_distinct"), ("scenario mismatch", "scenario_mismatch"), ("verdict mismatch", "verdict_mismatch"), ("artifact_root mismatch", "artifact_root_mismatch"), ("tx_path identity mismatch", "tx_path_identity_mismatch"), ("tx report txid mismatch", "tx_identity_mismatch"), ("tx report raw transaction mismatch", "raw_tx_mismatch")]
 for needle, token in rules:
     if needle in msg:
         print(token)
@@ -878,9 +937,14 @@ EOF
 verify_block_inclusion() {
   local label="$1" block_path="$2" height="$3" block_hash="$4" output
   [[ -s "${BLOCK_CHECK_GO}" ]] || write_block_check_go || { TX_REASON="${label}_block_check_write_failed"; return 1; }
-  output="$(RUBIN_OPENSSL_SKIP_FIPS_GUARD=1 "${DEV_ENV}" -- go -C "${GO_MODULE_ROOT}" run "${BLOCK_CHECK_GO}" --block-response "${block_path}" --tx-hex "${TX_HEX}" --txid "${TX_ID}" --height "${height}" --hash "${block_hash}" 2>&1)" || {
+  output="$(bounded_mesh /usr/bin/env RUBIN_OPENSSL_SKIP_FIPS_GUARD=1 "${DEV_ENV}" -- go -C "${GO_MODULE_ROOT}" run "${BLOCK_CHECK_GO}" --block-response "${block_path}" --tx-hex "${TX_HEX}" --txid "${TX_ID}" --height "${height}" --hash "${block_hash}" 2>&1)" || {
+    local status=$?
     printf '%s\n' "${label} inclusion check failed: ${output}" >&2
-    TX_REASON="${label}_inclusion_failed"
+    if [[ "${status}" -eq 142 ]]; then
+      TX_REASON="${label}_inclusion_timeout"
+    else
+      TX_REASON="${label}_inclusion_failed"
+    fi
     return 1
   }
 }

--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -128,7 +128,7 @@ def parse_txid_from_hex(txhex: str) -> str:
     req(parsed.get("ok") is True and isinstance(txid, str) and re.fullmatch(r"[0-9a-f]{64}", txid), "tx parser did not produce txid")
     req(parsed.get("consumed") == len(txhex) // 2, "tx parser consumed mismatch")
     return txid
-def verify_block_inclusion_sidecar(label: str, p: Path, txhex: str, txid: str, height: int, block_hash: str, impl: str, endpoint: str, request_path: str) -> None:
+def verify_block_inclusion_sidecar(label: str, p: Path, txhex: str, txid: str, height: int, block_hash: str, tx_count: int, impl: str, endpoint: str, request_path: str) -> None:
     block = load_json_file(label, p)
     req(set(block) == {"block_hex", "canonical", "hash", "height", "implementation", "request_path", "rpc_endpoint"}, f"{label} keys mismatch: {sorted(block)}")
     req(block.get("implementation") == impl and block.get("rpc_endpoint") == endpoint and block.get("request_path") == request_path, f"{label} sidecar identity mismatch")
@@ -161,8 +161,10 @@ func main() {
 	txidHex := flag.String("txid", "", "")
 	heightRaw := flag.String("height", "", "")
 	hashHex := flag.String("hash", "", "")
+	txCountRaw := flag.String("tx-count", "", "")
 	flag.Parse()
 	wantHeight, err := strconv.ParseUint(*heightRaw, 10, 64); if err != nil { die("bad height") }
+	wantTxCount, err := strconv.ParseUint(*txCountRaw, 10, 64); if err != nil { die("bad tx_count") }
 	raw, err := os.ReadFile(*respPath); if err != nil { die("read block response: " + err.Error()) }
 	var resp blockResp; if err := json.Unmarshal(raw, &resp); err != nil { die("decode block response: " + err.Error()) }
 	gotHash := resp.Hash; if gotHash == "" { gotHash = resp.BlockHash }
@@ -173,7 +175,9 @@ func main() {
 	blockBytes, err := hex.DecodeString(strings.TrimSpace(resp.BlockHex)); if err != nil { die("decode block_hex: " + err.Error()) }
 	pb, err := consensus.ParseBlockBytes(blockBytes); if err != nil { die("parse block_hex failed: " + err.Error()) }
 	gotBlockHash, err := consensus.BlockHash(pb.HeaderBytes); if err != nil || hex.EncodeToString(gotBlockHash[:]) != strings.ToLower(*hashHex) { die("parsed block hash mismatch") }
-	for _, got := range pb.Txids { if got == wantTxid { return } }
+	if pb.TxCount != wantTxCount { die("parsed block tx_count mismatch") }
+	if _, err := consensus.ValidateBlockBasicAtHeight(blockBytes, nil, nil, wantHeight); err != nil { die("basic block validation failed: " + err.Error()) }
+	for i, got := range pb.Txids { if i > 0 && got == wantTxid { return } }
 	die("submitted txid missing from parsed block txids")
 }
 '''
@@ -181,7 +185,7 @@ func main() {
         source_path = Path(td) / "block-check.go"
         source_path.write_text(source, encoding="utf-8")
         try:
-            proc = subprocess.run([dev_env, "--", "go", "-C", go_module_root, "run", str(source_path), "--block-response", str(p), "--tx-hex", txhex, "--txid", txid, "--height", str(height), "--hash", block_hash], check=False, env={**os.environ, "RUBIN_OPENSSL_SKIP_FIPS_GUARD": "1"}, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, timeout=max(30, min(LIVE_TIMEOUT, 60)))
+            proc = subprocess.run([dev_env, "--", "go", "-C", go_module_root, "run", str(source_path), "--block-response", str(p), "--tx-hex", txhex, "--txid", txid, "--height", str(height), "--hash", block_hash, "--tx-count", str(tx_count)], check=False, env={**os.environ, "RUBIN_OPENSSL_SKIP_FIPS_GUARD": "1"}, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, timeout=max(30, min(LIVE_TIMEOUT, 60)))
         except subprocess.TimeoutExpired:
             fail(f"{label} inclusion check timeout")
         except OSError as exc:
@@ -383,8 +387,8 @@ if tx_mode:
         req(set(mine_next) == {"block_hash", "height", "implementation", "mined", "nonce", "request_path", "rpc_endpoint", "timestamp", "tx_count"}, f"rust_mine.mine_next keys mismatch: {sorted(mine_next)}")
         req(mine_next.get("implementation") == "rust" and mine_next.get("rpc_endpoint") == nodes_by_impl["rust"]["rpc_endpoint"] and mine_next.get("request_path") == "/mine_next", "rust_mine mine_next sidecar identity mismatch")
         req(mine_next.get("mined") is True and mine_next.get("height") == height and mine_next.get("block_hash") == block_hash and mine_next.get("tx_count") == rust_mine["tx_count"], "rust_mine mine_next sidecar does not match report")
-        verify_block_inclusion_sidecar("rust_mine.block_path", rust_block_path, txhex, txid, height, block_hash, "rust", nodes_by_impl["rust"]["rpc_endpoint"], f"/get_block?height={height}")
-        verify_block_inclusion_sidecar("go_converge.block_path", go_block_path, txhex, txid, height, block_hash, "go", nodes_by_impl["go"]["rpc_endpoint"], f"/get_block?height={height}")
+        verify_block_inclusion_sidecar("rust_mine.block_path", rust_block_path, txhex, txid, height, block_hash, rust_mine["tx_count"], "rust", nodes_by_impl["rust"]["rpc_endpoint"], f"/get_block?height={height}")
+        verify_block_inclusion_sidecar("go_converge.block_path", go_block_path, txhex, txid, height, block_hash, rust_mine["tx_count"], "go", nodes_by_impl["go"]["rpc_endpoint"], f"/get_block?height={height}")
         tip = load_json_file("go_converge.tip", go_tip_path)
         req(set(tip) == {"best_known_height", "has_tip", "height", "implementation", "in_ibd", "request_path", "rpc_endpoint", "tip_hash"}, f"go_converge.tip keys mismatch: {sorted(tip)}")
         req(tip.get("implementation") == "go" and tip.get("rpc_endpoint") == nodes_by_impl["go"]["rpc_endpoint"] and tip.get("request_path") == "/get_tip", "go_converge tip sidecar identity mismatch")
@@ -457,7 +461,7 @@ tx_report_reason_token() {
   python3 - "${msg}" <<'PY'
 import re, sys
 msg = "\n".join(line[5:].strip() if line.startswith("FAIL:") else line for line in sys.argv[1].splitlines())
-rules = [("rust_mine is not node-rust mined_included", "rust_mine_class_invalid"), ("go_converge is not node-go canonical_block_found", "go_converge_class_invalid"), ("mined/converged RPC endpoints are not bound", "converge_rpc_endpoint_mismatch"), ("rust_mine.height is malformed", "rust_mine_height_invalid"), ("rust_mine.block_hash is malformed", "rust_mine_hash_invalid"), ("sidecar identity mismatch", "converge_sidecar_identity_mismatch"), ("converge sidecar paths are not pairwise distinct", "converge_sidecar_paths_not_distinct"), ("submitted txid missing from parsed block txids", "block_missing_submitted_txid"), ("parse block_hex failed", "block_hex_parse_failed"), ("parsed block hash mismatch", "block_hash_mismatch"), ("inclusion check timeout", "block_inclusion_timeout"), ("inclusion check failed", "block_inclusion_failed"), ("mined/converged tx identity differs", "converged_tx_identity_mismatch"), ("go_converge does not match rust_mine", "go_converge_height_hash_mismatch"), ("rust_mine.tx_count", "rust_mine_tx_count_invalid"), ("mine_next sidecar does not match", "rust_mine_sidecar_invalid"), ("sidecar height/hash/canonical mismatch", "block_sidecar_invalid"), ("block_hex is missing", "block_sidecar_invalid"), ("tip sidecar does not match", "go_converge_tip_invalid"), ("tx parser consumed mismatch", "tx_parser_consumed_mismatch"), ("tx parser timeout", "tx_parser_timeout"), ("tx parser unavailable", "tx_parser_unavailable"), ("tx parser output too large", "tx_parser_output_too_large"), ("tx parser malformed output", "tx_parser_malformed_output"), ("tx parser root is not an object", "tx_parser_root_invalid"), ("tx parser did not produce txid", "tx_parser_missing_txid"), ("tx parser failed", "tx_parser_failed"), ("tx_hex is malformed or unbounded", "tx_hex_malformed_or_unbounded"), ("txid is malformed", "txid_malformed"), ("tx report rpc endpoint mismatch", "tx_report_rpc_endpoint_mismatch"), ("capture identity mismatch", "tx_capture_identity_mismatch"), ("tx sidecar paths are not pairwise distinct", "tx_sidecar_paths_not_distinct"), ("scenario mismatch", "scenario_mismatch"), ("verdict mismatch", "verdict_mismatch"), ("artifact_root mismatch", "artifact_root_mismatch"), ("tx_path identity mismatch", "tx_path_identity_mismatch"), ("tx report txid mismatch", "tx_identity_mismatch"), ("tx report raw transaction mismatch", "raw_tx_mismatch")]
+rules = [("rust_mine is not node-rust mined_included", "rust_mine_class_invalid"), ("go_converge is not node-go canonical_block_found", "go_converge_class_invalid"), ("mined/converged RPC endpoints are not bound", "converge_rpc_endpoint_mismatch"), ("rust_mine.height is malformed", "rust_mine_height_invalid"), ("rust_mine.block_hash is malformed", "rust_mine_hash_invalid"), ("sidecar identity mismatch", "converge_sidecar_identity_mismatch"), ("converge sidecar paths are not pairwise distinct", "converge_sidecar_paths_not_distinct"), ("submitted txid missing from parsed block txids", "block_missing_submitted_txid"), ("parse block_hex failed", "block_hex_parse_failed"), ("parsed block hash mismatch", "block_hash_mismatch"), ("parsed block tx_count mismatch", "block_tx_count_mismatch"), ("basic block validation failed", "block_basic_validation_failed"), ("inclusion check timeout", "block_inclusion_timeout"), ("inclusion check failed", "block_inclusion_failed"), ("mined/converged tx identity differs", "converged_tx_identity_mismatch"), ("go_converge does not match rust_mine", "go_converge_height_hash_mismatch"), ("rust_mine.tx_count", "rust_mine_tx_count_invalid"), ("mine_next sidecar does not match", "rust_mine_sidecar_invalid"), ("sidecar height/hash/canonical mismatch", "block_sidecar_invalid"), ("block_hex is missing", "block_sidecar_invalid"), ("tip sidecar does not match", "go_converge_tip_invalid"), ("tx parser consumed mismatch", "tx_parser_consumed_mismatch"), ("tx parser timeout", "tx_parser_timeout"), ("tx parser unavailable", "tx_parser_unavailable"), ("tx parser output too large", "tx_parser_output_too_large"), ("tx parser malformed output", "tx_parser_malformed_output"), ("tx parser root is not an object", "tx_parser_root_invalid"), ("tx parser did not produce txid", "tx_parser_missing_txid"), ("tx parser failed", "tx_parser_failed"), ("tx_hex is malformed or unbounded", "tx_hex_malformed_or_unbounded"), ("txid is malformed", "txid_malformed"), ("tx report rpc endpoint mismatch", "tx_report_rpc_endpoint_mismatch"), ("capture identity mismatch", "tx_capture_identity_mismatch"), ("tx sidecar paths are not pairwise distinct", "tx_sidecar_paths_not_distinct"), ("scenario mismatch", "scenario_mismatch"), ("verdict mismatch", "verdict_mismatch"), ("artifact_root mismatch", "artifact_root_mismatch"), ("tx_path identity mismatch", "tx_path_identity_mismatch"), ("tx report txid mismatch", "tx_identity_mismatch"), ("tx report raw transaction mismatch", "raw_tx_mismatch")]
 for needle, token in rules:
     if needle in msg:
         print(token)
@@ -937,8 +941,10 @@ func main() {
 	txidHex := flag.String("txid", "", "")
 	heightRaw := flag.String("height", "", "")
 	hashHex := flag.String("hash", "", "")
+	txCountRaw := flag.String("tx-count", "", "")
 	flag.Parse()
 	wantHeight, err := strconv.ParseUint(*heightRaw, 10, 64); if err != nil { die("bad height") }
+	wantTxCount, err := strconv.ParseUint(*txCountRaw, 10, 64); if err != nil { die("bad tx_count") }
 	raw, err := os.ReadFile(*respPath); if err != nil { die("read block response: " + err.Error()) }
 	var resp blockResp; if err := json.Unmarshal(raw, &resp); err != nil { die("decode block response: " + err.Error()) }
 	if resp.Height != wantHeight || strings.ToLower(resp.Hash) != strings.ToLower(*hashHex) || !resp.Canonical { die("block response height/hash/canonical mismatch") }
@@ -948,7 +954,9 @@ func main() {
 	blockBytes, err := hex.DecodeString(strings.TrimSpace(resp.BlockHex)); if err != nil { die("decode block_hex: " + err.Error()) }
 	pb, err := consensus.ParseBlockBytes(blockBytes); if err != nil { die("parse block_hex failed: " + err.Error()) }
 	gotHash, err := consensus.BlockHash(pb.HeaderBytes); if err != nil || hex.EncodeToString(gotHash[:]) != strings.ToLower(*hashHex) { die("parsed block hash mismatch") }
-	for _, got := range pb.Txids { if got == wantTxid { return } }
+	if pb.TxCount != wantTxCount { die("parsed block tx_count mismatch") }
+	if _, err := consensus.ValidateBlockBasicAtHeight(blockBytes, nil, nil, wantHeight); err != nil { die("basic block validation failed: " + err.Error()) }
+	for i, got := range pb.Txids { if i > 0 && got == wantTxid { return } }
 	die("submitted txid missing from parsed block txids")
 }
 EOF
@@ -963,14 +971,16 @@ block_inclusion_failure_reason() {
     *"tx_hex txid mismatch"*) printf '%s\n' "${label}_txid_mismatch" ;;
     *"decode block_hex:"*|*"parse block_hex failed:"*) printf '%s\n' "${label}_block_hex_parse_failed" ;;
     *"parsed block hash mismatch"*) printf '%s\n' "${label}_block_hash_mismatch" ;;
+    *"parsed block tx_count mismatch"*) printf '%s\n' "${label}_block_tx_count_mismatch" ;;
+    *"basic block validation failed:"*) printf '%s\n' "${label}_block_basic_validation_failed" ;;
     *"submitted txid missing from parsed block txids"*) printf '%s\n' "${label}_block_missing_submitted_txid" ;;
     *) printf '%s\n' "${label}_inclusion_failed" ;;
   esac
 }
 verify_block_inclusion() {
-  local label="$1" block_path="$2" height="$3" block_hash="$4" output
+  local label="$1" block_path="$2" height="$3" block_hash="$4" tx_count="$5" output
   [[ -s "${BLOCK_CHECK_GO}" ]] || write_block_check_go || { TX_REASON="${label}_block_check_write_failed"; return 1; }
-  output="$(bounded_mesh /usr/bin/env RUBIN_OPENSSL_SKIP_FIPS_GUARD=1 "${DEV_ENV}" -- go -C "${GO_MODULE_ROOT}" run "${BLOCK_CHECK_GO}" --block-response "${block_path}" --tx-hex "${TX_HEX}" --txid "${TX_ID}" --height "${height}" --hash "${block_hash}" 2>&1)" || {
+  output="$(bounded_mesh /usr/bin/env RUBIN_OPENSSL_SKIP_FIPS_GUARD=1 "${DEV_ENV}" -- go -C "${GO_MODULE_ROOT}" run "${BLOCK_CHECK_GO}" --block-response "${block_path}" --tx-hex "${TX_HEX}" --txid "${TX_ID}" --height "${height}" --hash "${block_hash}" --tx-count "${tx_count}" 2>&1)" || {
     local status=$?
     printf '%s\n' "${label} inclusion check failed: ${output}" >&2
     if [[ "${status}" -eq 142 ]]; then
@@ -1049,7 +1059,7 @@ rust_mine_including_tx() {
   parsed="$(parse_mine_next_response "${RUST_MINE_JSON}")" || { rc=$?; case "${rc}" in 13) TX_REASON=rust_mine_malformed_rpc_body ;; 14) TX_REASON=rust_mine_unavailable ;; 16) TX_REASON=rust_mine_tx_count_invalid ;; *) TX_REASON=rust_mine_unknown_failure ;; esac; return 1; }
   IFS=$'\t' read -r RUST_MINE_HEIGHT RUST_MINE_HASH RUST_MINE_TX_COUNT <<<"${parsed}" || { TX_REASON=rust_mine_malformed_rpc_body; return 1; }
   capture_rpc_sidecar rust GET "${RUST_RPC_ADDR}" "/get_block?height=${RUST_MINE_HEIGHT}" "${RUST_MINE_BLOCK_JSON}" || { rc=$?; TX_REASON="$(tx_capture_reason rust_mine_get_block "${rc}")"; return 1; }
-  verify_block_inclusion rust_mine "${RUST_MINE_BLOCK_JSON}" "${RUST_MINE_HEIGHT}" "${RUST_MINE_HASH}"
+  verify_block_inclusion rust_mine "${RUST_MINE_BLOCK_JSON}" "${RUST_MINE_HEIGHT}" "${RUST_MINE_HASH}" "${RUST_MINE_TX_COUNT}"
 }
 tip_matches() {
   python3 - "$1" "$2" "$3" <<'PY'
@@ -1075,7 +1085,7 @@ wait_go_converge_to_rust_mined_block() {
       if tip_matches "${tmp}" "${RUST_MINE_HEIGHT}" "${RUST_MINE_HASH}"; then
         mv -- "${tmp}" "${GO_CONVERGE_TIP_JSON}" || { TX_REASON=go_converge_artifact_write_failed; return 1; }
         capture_rpc_sidecar go GET "${GO_RPC_ADDR}" "/get_block?height=${RUST_MINE_HEIGHT}" "${GO_CONVERGE_BLOCK_JSON}" || { rc=$?; TX_REASON="$(tx_capture_reason go_converge_get_block "${rc}")"; return 1; }
-        verify_block_inclusion go_converge "${GO_CONVERGE_BLOCK_JSON}" "${RUST_MINE_HEIGHT}" "${RUST_MINE_HASH}"
+        verify_block_inclusion go_converge "${GO_CONVERGE_BLOCK_JSON}" "${RUST_MINE_HEIGHT}" "${RUST_MINE_HASH}" "${RUST_MINE_TX_COUNT}"
         return $?
       else
         rc=$?

--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -514,9 +514,15 @@ except (urllib.error.URLError, TimeoutError, socket.timeout) as exc:
 PY
 }
 capture_rpc_sidecar() {
-  local impl="$1" method="$2" addr="$3" path="$4" out="$5" status=0; local tmp="${out}.raw"
+  local impl="$1" method="$2" addr="$3" path="$4" out="$5" preserve_http_error="${6:-}" status=0; local tmp="${out}.raw"
   rpc_json "${method}" "${addr}" "${path}" >"${tmp}" || status=$?
-  (( status == 0 )) || { rm -f -- "${tmp}"; case "${status}" in 22) return 21 ;; 23) return 23 ;; *) return 22 ;; esac; }
+  (( status == 0 )) || {
+    if [[ "${status}" -eq 22 && "${preserve_http_error}" == preserve-http-error ]]; then
+      return 21
+    fi
+    rm -f -- "${tmp}"
+    case "${status}" in 22) return 21 ;; 23) return 23 ;; *) return 22 ;; esac
+  }
   python3 - "${impl}" "${addr}" "${path}" "${tmp}" "${out}" <<'PY'
 import json, os, sys
 impl, addr, request_path, src, dst = sys.argv[1:6]
@@ -997,10 +1003,49 @@ if not isinstance(tx_count, int) or isinstance(tx_count, bool) or tx_count < 2:
 print(height, block_hash, tx_count, sep="\t")
 PY
 }
+mine_next_http_error_reason() {
+  python3 - "$1" <<'PY'
+import json
+import sys
+try:
+    with open(sys.argv[1], encoding="utf-8") as f:
+        data = json.load(f)
+except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+    print("rust_mine_http_error_body_malformed")
+    sys.exit(0)
+if not isinstance(data, dict):
+    print("rust_mine_http_error_body_malformed")
+    sys.exit(0)
+err = data.get("error")
+if not isinstance(err, str) or not err:
+    print("rust_mine_http_error")
+elif err == "live mining unavailable":
+    print("rust_mine_live_mining_unavailable")
+elif err == "rpc unavailable":
+    print("rust_mine_rpc_unavailable")
+elif err == "sync engine unavailable":
+    print("rust_mine_sync_unavailable")
+elif err == "tx pool unavailable":
+    print("rust_mine_tx_pool_unavailable")
+elif err == "POST required":
+    print("rust_mine_method_rejected")
+else:
+    print("rust_mine_rejected")
+PY
+}
 rust_mine_including_tx() {
   local parsed rc=0
   TX_REASON=""
-  capture_rpc_sidecar rust POST "${RUST_RPC_ADDR}" /mine_next "${RUST_MINE_JSON}" || { rc=$?; TX_REASON="$(tx_capture_reason rust_mine "${rc}")"; return 1; }
+  capture_rpc_sidecar rust POST "${RUST_RPC_ADDR}" /mine_next "${RUST_MINE_JSON}" preserve-http-error || {
+    rc=$?
+    if [[ "${rc}" -eq 21 ]]; then
+      TX_REASON="$(mine_next_http_error_reason "${RUST_MINE_JSON}.raw")"
+      rm -f -- "${RUST_MINE_JSON}.raw"
+    else
+      TX_REASON="$(tx_capture_reason rust_mine "${rc}")"
+    fi
+    return 1
+  }
   parsed="$(parse_mine_next_response "${RUST_MINE_JSON}")" || { rc=$?; case "${rc}" in 13) TX_REASON=rust_mine_malformed_rpc_body ;; 14) TX_REASON=rust_mine_unavailable ;; 16) TX_REASON=rust_mine_tx_count_invalid ;; *) TX_REASON=rust_mine_unknown_failure ;; esac; return 1; }
   IFS=$'\t' read -r RUST_MINE_HEIGHT RUST_MINE_HASH RUST_MINE_TX_COUNT <<<"${parsed}" || { TX_REASON=rust_mine_malformed_rpc_body; return 1; }
   capture_rpc_sidecar rust GET "${RUST_RPC_ADDR}" "/get_block?height=${RUST_MINE_HEIGHT}" "${RUST_MINE_BLOCK_JSON}" || { rc=$?; TX_REASON="$(tx_capture_reason rust_mine_get_block "${rc}")"; return 1; }

--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -132,8 +132,7 @@ def verify_block_inclusion_sidecar(label: str, p: Path, txhex: str, txid: str, h
     block = load_json_file(label, p)
     req(set(block) == {"block_hex", "canonical", "hash", "height", "implementation", "request_path", "rpc_endpoint"}, f"{label} keys mismatch: {sorted(block)}")
     req(block.get("implementation") == impl and block.get("rpc_endpoint") == endpoint and block.get("request_path") == request_path, f"{label} sidecar identity mismatch")
-    actual_hash = block.get("hash") or block.get("block_hash")
-    req(block.get("canonical") is True and block.get("height") == height and actual_hash == block_hash, f"{label} sidecar height/hash/canonical mismatch")
+    req(block.get("canonical") is True and block.get("height") == height and block.get("hash") == block_hash, f"{label} sidecar height/hash/canonical mismatch")
     req(isinstance(block.get("block_hex"), str) and block["block_hex"], f"{label} block_hex is missing")
     source = r'''
 package main
@@ -744,6 +743,7 @@ PY
 }
 prepare_tx_chainstate() {
   local keygen_public_json keygen_fields_raw mine_address keygen_raw="${KEYGEN_JSON}.raw" keygen_err="${KEYGEN_JSON}.stderr" xtrace_was_enabled=0 status=0 rc=0
+  trap 'rm -f -- "${keygen_raw}" "${keygen_err}" >/dev/null 2>&1 || true; trap - RETURN' RETURN
   TX_REASON=""
   build_go_txgen || { TX_REASON="${BUILD_REASON:-go_txgen_build_failed}"; return 1; }
   write_keygen || { TX_REASON=go_submit_keygen_write_failed; return 1; }

--- a/scripts/devnet-mixed-client-mesh.sh
+++ b/scripts/devnet-mixed-client-mesh.sh
@@ -947,6 +947,20 @@ func main() {
 }
 EOF
 }
+block_inclusion_failure_reason() {
+  local label="$1" output="$2"
+  case "${output}" in
+    *"read block response:"*) printf '%s\n' "${label}_block_response_read_failed" ;;
+    *"decode block response:"*) printf '%s\n' "${label}_block_response_malformed_json" ;;
+    *"block response height/hash/canonical mismatch"*) printf '%s\n' "${label}_block_sidecar_mismatch" ;;
+    *"decode tx_hex:"*|*"parse tx_hex failed"*) printf '%s\n' "${label}_tx_hex_parse_failed" ;;
+    *"tx_hex txid mismatch"*) printf '%s\n' "${label}_txid_mismatch" ;;
+    *"decode block_hex:"*|*"parse block_hex failed:"*) printf '%s\n' "${label}_block_hex_parse_failed" ;;
+    *"parsed block hash mismatch"*) printf '%s\n' "${label}_block_hash_mismatch" ;;
+    *"submitted txid missing from parsed block txids"*) printf '%s\n' "${label}_block_missing_submitted_txid" ;;
+    *) printf '%s\n' "${label}_inclusion_failed" ;;
+  esac
+}
 verify_block_inclusion() {
   local label="$1" block_path="$2" height="$3" block_hash="$4" output
   [[ -s "${BLOCK_CHECK_GO}" ]] || write_block_check_go || { TX_REASON="${label}_block_check_write_failed"; return 1; }
@@ -956,7 +970,7 @@ verify_block_inclusion() {
     if [[ "${status}" -eq 142 ]]; then
       TX_REASON="${label}_inclusion_timeout"
     else
-      TX_REASON="${label}_inclusion_failed"
+      TX_REASON="$(block_inclusion_failure_reason "${label}" "${output}")"
     fi
     return 1
   }

--- a/scripts/devnet/test_mixed_client_mesh_check_report.sh
+++ b/scripts/devnet/test_mixed_client_mesh_check_report.sh
@@ -56,6 +56,24 @@ expect_fail_contains() {
   require_contains "${output}" "${needle}" "${label}"
 }
 
+expect_fail_token() {
+  local label="$1" expected_token="$2" output token
+  shift 2
+  if output="$("$@" 2>&1)"; then
+    echo "FAIL: ${label} should fail" >&2
+    echo "actual output:" >&2
+    printf '%s\n' "${output}" >&2
+    exit 1
+  fi
+  token="$(printf '%s\n' "${output}" | tx_report_reason_token)"
+  if [[ "${token}" != "${expected_token}" ]]; then
+    echo "FAIL: ${label} produced token ${token}, want ${expected_token}" >&2
+    echo "actual output:" >&2
+    printf '%s\n' "${output}" >&2
+    exit 1
+  fi
+}
+
 extract_check_report() {
   python3 - "${HARNESS}" "${CHECK_REPORT_LIB}" <<'PY'
 from pathlib import Path
@@ -65,13 +83,16 @@ src, dst = map(Path, sys.argv[1:3])
 lines = src.read_text(encoding="utf-8").splitlines()
 start = next(i for i, line in enumerate(lines) if line.startswith("check_report()"))
 end = next(i for i, line in enumerate(lines[start:], start) if line.startswith('[[ "${MESH_TIMEOUT}"'))
-Path(dst).write_text("\n".join(lines[start:end]) + "\n", encoding="utf-8")
+token_start = next(i for i, line in enumerate(lines) if line.startswith("tx_report_reason_token()"))
+token_end = next(i for i, line in enumerate(lines[token_start:], token_start) if line.startswith("combined_report_reason_token()"))
+Path(dst).write_text("\n".join(lines[start:end] + [""] + lines[token_start:token_end]) + "\n", encoding="utf-8")
 PY
 }
 
 write_reports() {
   python3 - "${TMP_ROOT}" <<'PY'
 from pathlib import Path
+import hashlib
 import json
 import stat
 import sys
@@ -218,10 +239,17 @@ for impl, endpoint, prefix in (("go", go_rpc, "go"), ("rust", rust_rpc, "rust"))
         "txid": txid,
     })
 height = 102
-block_hash = "ab" * 32
 tx_count = 2
+header = b"\x00" * 116
+block_hash = hashlib.sha3_256(header).hexdigest()
+block_hex = header.hex() + "02" + tx_hex + tx_hex
+mutated_tx = bytearray.fromhex(tx_hex)
+mutated_tx[5] ^= 0x01
+missing_tx_block_hex = header.hex() + "02" + mutated_tx.hex() + mutated_tx.hex()
 for path in (artifact_root / "rust-mined-block.json", artifact_root / "go-converged-block.json"):
-    dump(path, {"block_hex": "00", "canonical": True, "hash": block_hash, "height": height})
+    dump(path, {"block_hex": block_hex, "canonical": True, "hash": block_hash, "height": height})
+dump(artifact_root / "go-converged-malformed-block.json", {"block_hex": "00", "canonical": True, "hash": block_hash, "height": height})
+dump(artifact_root / "go-converged-missing-tx-block.json", {"block_hex": missing_tx_block_hex, "canonical": True, "hash": block_hash, "height": height})
 dump(artifact_root / "rust-mine-next.json", {"block_hash": block_hash, "height": height, "mined": True, "nonce": 0, "timestamp": 1, "tx_count": tx_count})
 dump(artifact_root / "go-converge-tip.json", {"best_known_height": height, "has_tip": True, "height": height, "in_ibd": False, "tip_hash": block_hash})
 tx_report = {
@@ -276,6 +304,15 @@ dump(root / "converge-report.json", converge_report)
 bad_converge = json.loads(json.dumps(converge_report))
 bad_converge["go_converge"]["txid"] = "11" * 32
 dump(root / "converge-wrong-txid.json", bad_converge)
+bad_converge = json.loads(json.dumps(converge_report))
+bad_converge["rust_mine"]["class"] = "accepted_only"
+dump(root / "converge-bad-rust-class.json", bad_converge)
+bad_converge = json.loads(json.dumps(converge_report))
+bad_converge["go_converge"]["block_path"] = str(artifact_root / "go-converged-malformed-block.json")
+dump(root / "converge-malformed-block.json", bad_converge)
+bad_converge = json.loads(json.dumps(converge_report))
+bad_converge["go_converge"]["block_path"] = str(artifact_root / "go-converged-missing-tx-block.json")
+dump(root / "converge-missing-tx-block.json", bad_converge)
 (root / "empty.json").write_text("", encoding="utf-8")
 (root / "malformed.json").write_text("[", encoding="utf-8")
 with (root / "oversized.json").open("wb") as f:
@@ -284,6 +321,9 @@ print(root / "mesh-report.json")
 print(root / "tx-report.json")
 print(root / "converge-report.json")
 print(root / "converge-wrong-txid.json")
+print(root / "converge-bad-rust-class.json")
+print(root / "converge-malformed-block.json")
+print(root / "converge-missing-tx-block.json")
 PY
 }
 
@@ -297,7 +337,10 @@ MESH_REPORT="$(sed -n '1p' "${REPORT_LIST}")"
 TX_REPORT="$(sed -n '2p' "${REPORT_LIST}")"
 CONVERGE_REPORT="$(sed -n '3p' "${REPORT_LIST}")"
 CONVERGE_WRONG_TXID_REPORT="$(sed -n '4p' "${REPORT_LIST}")"
-[[ -n "${MESH_REPORT}" && -n "${TX_REPORT}" && -n "${CONVERGE_REPORT}" && -n "${CONVERGE_WRONG_TXID_REPORT}" ]] || { echo "failed to build synthetic reports" >&2; exit 1; }
+CONVERGE_BAD_RUST_CLASS_REPORT="$(sed -n '5p' "${REPORT_LIST}")"
+CONVERGE_MALFORMED_BLOCK_REPORT="$(sed -n '6p' "${REPORT_LIST}")"
+CONVERGE_MISSING_TX_BLOCK_REPORT="$(sed -n '7p' "${REPORT_LIST}")"
+[[ -n "${MESH_REPORT}" && -n "${TX_REPORT}" && -n "${CONVERGE_REPORT}" && -n "${CONVERGE_WRONG_TXID_REPORT}" && -n "${CONVERGE_BAD_RUST_CLASS_REPORT}" && -n "${CONVERGE_MALFORMED_BLOCK_REPORT}" && -n "${CONVERGE_MISSING_TX_BLOCK_REPORT}" ]] || { echo "failed to build synthetic reports" >&2; exit 1; }
 
 expect_pass_contains "public mesh check-report" "PASS: mixed_client_mesh report structurally accepted" "${HARNESS}" --check-report "${MESH_REPORT}"
 expect_fail_contains "public tx check-report" "public tx-path check-report is unsupported" "${HARNESS}" --check-report "${TX_REPORT}"
@@ -309,6 +352,11 @@ expect_pass_contains "producer tx internal check" "PASS: mixed_client_go_submit_
 expect_pass_contains "producer converge internal check" "PASS: mixed_client_go_submit_rust_mine_go_converge report structurally accepted" check_report "${CONVERGE_REPORT}" offline producer-tx
 expect_fail_contains "producer rejects mesh report" "producer tx validation requires a mixed-client tx-path report" check_report "${MESH_REPORT}" offline producer-tx
 expect_fail_contains "producer rejects converged txid drift" "mined/converged tx identity differs from submitted tx" check_report "${CONVERGE_WRONG_TXID_REPORT}" offline producer-tx
+expect_fail_contains "producer rejects malformed converge block" "go_converge.block_path inclusion check failed" check_report "${CONVERGE_MALFORMED_BLOCK_REPORT}" offline producer-tx
+expect_fail_contains "producer rejects converge block missing tx" "submitted txid missing from parsed block txids" check_report "${CONVERGE_MISSING_TX_BLOCK_REPORT}" offline producer-tx
+expect_fail_token "token maps converge class drift" "rust_mine_class_invalid" check_report "${CONVERGE_BAD_RUST_CLASS_REPORT}" offline producer-tx
+expect_fail_token "token maps malformed parsed block" "block_hex_parse_failed" check_report "${CONVERGE_MALFORMED_BLOCK_REPORT}" offline producer-tx
+expect_fail_token "token maps parsed block tx omission" "block_missing_submitted_txid" check_report "${CONVERGE_MISSING_TX_BLOCK_REPORT}" offline producer-tx
 
 expect_fail_contains "non-regular report" "report is not a regular file" "${HARNESS}" --check-report "${TMP_ROOT}"
 expect_fail_contains "empty report" "report is empty" "${HARNESS}" --check-report "${TMP_ROOT}/empty.json"

--- a/scripts/devnet/test_mixed_client_mesh_check_report.sh
+++ b/scripts/devnet/test_mixed_client_mesh_check_report.sh
@@ -118,8 +118,72 @@ for path in (go_bin, rust_bin):
     path.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
     path.chmod(path.stat().st_mode | stat.S_IXUSR)
 
-tx_hex = "010000000001000000000000000001010000000000000000016954e89e15c3eef53f39d5e758fd47dfc84f15f042cd83edc0c93723e93b7d0a83000a00000000000000b3ec7cf4503854f1f691ffb3c0bde5e22af4705161edb20ede25a62e3209a716b3ec7cf4503854f1f691ffb3c0bde5e22af4705161edb20ede25a62e3209a716000000000000"
-txid = "d379ae84430d5296e97a71ba8e6996d869b8c6e85b13b51ab0d8ee23455057e1"
+def compact_size(n: int) -> bytes:
+    if n < 0xfd:
+        return bytes([n])
+    if n <= 0xffff:
+        return b"\xfd" + n.to_bytes(2, "little")
+    if n <= 0xffffffff:
+        return b"\xfe" + n.to_bytes(4, "little")
+    return b"\xff" + n.to_bytes(8, "little")
+
+def sha3(data: bytes) -> bytes:
+    return hashlib.sha3_256(data).digest()
+
+def read_compact_size(buf: bytes, off: int) -> tuple[int, int]:
+    first = buf[off]
+    if first < 0xfd:
+        return first, off + 1
+    if first == 0xfd:
+        return int.from_bytes(buf[off + 1:off + 3], "little"), off + 3
+    if first == 0xfe:
+        return int.from_bytes(buf[off + 1:off + 5], "little"), off + 5
+    return int.from_bytes(buf[off + 1:off + 9], "little"), off + 9
+
+def txid_kind0(txb: bytes) -> bytes:
+    off = 0
+    off += 4  # version
+    tx_kind = txb[off]
+    off += 1
+    if tx_kind != 0:
+        raise ValueError("synthetic test only supports tx_kind=0")
+    off += 8  # nonce
+    n_inputs, off = read_compact_size(txb, off)
+    for _ in range(n_inputs):
+        off += 32 + 4
+        script_len, off = read_compact_size(txb, off)
+        off += script_len + 4
+    n_outputs, off = read_compact_size(txb, off)
+    for _ in range(n_outputs):
+        off += 8 + 2
+        covenant_len, off = read_compact_size(txb, off)
+        off += covenant_len
+    off += 4  # locktime
+    return sha3(txb[:off])
+
+def build_synthetic_submitted_tx() -> bytes:
+    return b"".join([
+        (1).to_bytes(4, "little"),
+        b"\x00",
+        (7).to_bytes(8, "little"),
+        compact_size(1),
+        b"\x11" * 32,
+        (0).to_bytes(4, "little"),
+        compact_size(0),
+        (0).to_bytes(4, "little"),
+        compact_size(1),
+        (0).to_bytes(8, "little"),
+        (0x0002).to_bytes(2, "little"),
+        compact_size(1),
+        b"\x42",
+        (0).to_bytes(4, "little"),
+        compact_size(0),
+        compact_size(0),
+    ])
+
+tx_bytes = build_synthetic_submitted_tx()
+tx_hex = tx_bytes.hex()
+txid = txid_kind0(tx_bytes).hex()
 go_rpc = "127.0.0.1:51001"
 go_p2p = "127.0.0.1:51002"
 rust_rpc = "127.0.0.1:51003"
@@ -250,19 +314,93 @@ for impl, endpoint, prefix in (("go", go_rpc, "go"), ("rust", rust_rpc, "rust"))
     })
 height = 102
 tx_count = 2
-header = b"\x00" * 116
-block_hash = hashlib.sha3_256(header).hexdigest()
-block_hex = header.hex() + "02" + tx_hex + tx_hex
+
+def merkle(ids: list[bytes], leaf_tag: int, node_tag: int) -> bytes:
+    level = [sha3(bytes([leaf_tag]) + item) for item in ids]
+    while len(level) > 1:
+        next_level = []
+        i = 0
+        while i < len(level):
+            if i == len(level) - 1:
+                next_level.append(level[i])
+                i += 1
+            else:
+                next_level.append(sha3(bytes([node_tag]) + level[i] + level[i + 1]))
+                i += 2
+        level = next_level
+    return level[0]
+
+def coinbase_with_witness_commitment(block_height: int, non_coinbase_txs: list[bytes]) -> tuple[bytes, bytes, bytes]:
+    wtxids = [bytes(32)] + [sha3(txb) for txb in non_coinbase_txs]
+    witness_root = merkle(wtxids, 0x02, 0x03)
+    commitment = sha3(b"RUBIN-WITNESS/" + witness_root)
+    core = b"".join([
+        (1).to_bytes(4, "little"),
+        b"\x00",
+        (0).to_bytes(8, "little"),
+        compact_size(1),
+        bytes(32),
+        (0xffffffff).to_bytes(4, "little"),
+        compact_size(0),
+        (0xffffffff).to_bytes(4, "little"),
+        compact_size(1),
+        (0).to_bytes(8, "little"),
+        (0x0002).to_bytes(2, "little"),
+        compact_size(len(commitment)),
+        commitment,
+        block_height.to_bytes(4, "little"),
+    ])
+    full = core + compact_size(0) + compact_size(0)
+    return full, sha3(core), sha3(full)
+
+def build_basic_block(non_coinbase_hex: str, block_height: int) -> tuple[str, str]:
+    non_coinbase = bytes.fromhex(non_coinbase_hex)
+    non_coinbase_txid = txid_kind0(non_coinbase)
+    if non_coinbase_hex == tx_hex and non_coinbase_txid.hex() != txid:
+        raise ValueError("synthetic txid fixture drift")
+    coinbase, coinbase_txid, _ = coinbase_with_witness_commitment(block_height, [non_coinbase])
+    txids = [coinbase_txid, non_coinbase_txid]
+    merkle_root = merkle(txids, 0x00, 0x01)
+    header = b"".join([
+        (1).to_bytes(4, "little"),
+        bytes(32),
+        merkle_root,
+        (1).to_bytes(8, "little"),
+        b"\xff" * 32,
+        (1).to_bytes(8, "little"),
+    ])
+    block = header + compact_size(2) + coinbase + non_coinbase
+    return block.hex(), sha3(header).hex()
+
+def corrupt_merkle_block(block_hex_value: str) -> tuple[str, str]:
+    block = bytearray.fromhex(block_hex_value)
+    block[4 + 32] ^= 0x01
+    return bytes(block).hex(), sha3(bytes(block[:116])).hex()
+
+def block_sidecar(impl: str, endpoint: str, block_hex_value: str, block_hash_value: str) -> dict:
+    return {"block_hex": block_hex_value, "canonical": True, "hash": block_hash_value, "height": height, "implementation": impl, "request_path": f"/get_block?height={height}", "rpc_endpoint": endpoint}
+
+block_hex, block_hash = build_basic_block(tx_hex, height)
 mutated_tx = bytearray.fromhex(tx_hex)
 mutated_tx[5] ^= 0x01
-missing_tx_block_hex = header.hex() + "02" + mutated_tx.hex() + mutated_tx.hex()
-dump(artifact_root / "rust-mined-block.json", {"block_hex": block_hex, "canonical": True, "hash": block_hash, "height": height, "implementation": "rust", "request_path": f"/get_block?height={height}", "rpc_endpoint": rust_rpc})
-dump(artifact_root / "go-converged-block.json", {"block_hex": block_hex, "canonical": True, "hash": block_hash, "height": height, "implementation": "go", "request_path": f"/get_block?height={height}", "rpc_endpoint": go_rpc})
-dump(artifact_root / "go-converged-wrong-source-block.json", {"block_hex": block_hex, "canonical": True, "hash": block_hash, "height": height, "implementation": "rust", "request_path": f"/get_block?height={height}", "rpc_endpoint": rust_rpc})
+missing_tx_block_hex, missing_tx_hash = build_basic_block(mutated_tx.hex(), height)
+corrupt_block_hex, corrupt_block_hash = corrupt_merkle_block(block_hex)
+
+dump(artifact_root / "rust-mined-block.json", block_sidecar("rust", rust_rpc, block_hex, block_hash))
+dump(artifact_root / "go-converged-block.json", block_sidecar("go", go_rpc, block_hex, block_hash))
+dump(artifact_root / "go-converged-wrong-source-block.json", block_sidecar("rust", rust_rpc, block_hex, block_hash))
 dump(artifact_root / "go-converged-malformed-block.json", {"block_hex": "00", "canonical": True, "hash": block_hash, "height": height, "implementation": "go", "request_path": f"/get_block?height={height}", "rpc_endpoint": go_rpc})
-dump(artifact_root / "go-converged-missing-tx-block.json", {"block_hex": missing_tx_block_hex, "canonical": True, "hash": block_hash, "height": height, "implementation": "go", "request_path": f"/get_block?height={height}", "rpc_endpoint": go_rpc})
+dump(artifact_root / "rust-missing-tx-block.json", block_sidecar("rust", rust_rpc, missing_tx_block_hex, missing_tx_hash))
+dump(artifact_root / "go-converged-missing-tx-block.json", block_sidecar("go", go_rpc, missing_tx_block_hex, missing_tx_hash))
+dump(artifact_root / "rust-corrupt-merkle-block.json", block_sidecar("rust", rust_rpc, corrupt_block_hex, corrupt_block_hash))
+dump(artifact_root / "go-corrupt-merkle-block.json", block_sidecar("go", go_rpc, corrupt_block_hex, corrupt_block_hash))
 dump(artifact_root / "rust-mine-next.json", {"block_hash": block_hash, "height": height, "implementation": "rust", "mined": True, "nonce": 0, "request_path": "/mine_next", "rpc_endpoint": rust_rpc, "timestamp": 1, "tx_count": tx_count})
+dump(artifact_root / "rust-missing-tx-mine-next.json", {"block_hash": missing_tx_hash, "height": height, "implementation": "rust", "mined": True, "nonce": 0, "request_path": "/mine_next", "rpc_endpoint": rust_rpc, "timestamp": 1, "tx_count": tx_count})
+dump(artifact_root / "rust-corrupt-merkle-mine-next.json", {"block_hash": corrupt_block_hash, "height": height, "implementation": "rust", "mined": True, "nonce": 0, "request_path": "/mine_next", "rpc_endpoint": rust_rpc, "timestamp": 1, "tx_count": tx_count})
+dump(artifact_root / "rust-tx-count-mismatch-mine-next.json", {"block_hash": block_hash, "height": height, "implementation": "rust", "mined": True, "nonce": 0, "request_path": "/mine_next", "rpc_endpoint": rust_rpc, "timestamp": 1, "tx_count": 3})
 dump(artifact_root / "go-converge-tip.json", {"best_known_height": height, "has_tip": True, "height": height, "implementation": "go", "in_ibd": False, "request_path": "/get_tip", "rpc_endpoint": go_rpc, "tip_hash": block_hash})
+dump(artifact_root / "go-missing-tx-tip.json", {"best_known_height": height, "has_tip": True, "height": height, "implementation": "go", "in_ibd": False, "request_path": "/get_tip", "rpc_endpoint": go_rpc, "tip_hash": missing_tx_hash})
+dump(artifact_root / "go-corrupt-merkle-tip.json", {"best_known_height": height, "has_tip": True, "height": height, "implementation": "go", "in_ibd": False, "request_path": "/get_tip", "rpc_endpoint": go_rpc, "tip_hash": corrupt_block_hash})
 tx_report = {
     **mesh_report,
     "go_submit": {
@@ -328,8 +466,25 @@ bad_converge = json.loads(json.dumps(converge_report))
 bad_converge["go_converge"]["block_path"] = str(artifact_root / "go-converged-malformed-block.json")
 dump(root / "converge-malformed-block.json", bad_converge)
 bad_converge = json.loads(json.dumps(converge_report))
+bad_converge["rust_mine"]["block_hash"] = missing_tx_hash
+bad_converge["rust_mine"]["block_path"] = str(artifact_root / "rust-missing-tx-block.json")
+bad_converge["rust_mine"]["mine_next_path"] = str(artifact_root / "rust-missing-tx-mine-next.json")
+bad_converge["go_converge"]["block_hash"] = missing_tx_hash
 bad_converge["go_converge"]["block_path"] = str(artifact_root / "go-converged-missing-tx-block.json")
+bad_converge["go_converge"]["tip_path"] = str(artifact_root / "go-missing-tx-tip.json")
 dump(root / "converge-missing-tx-block.json", bad_converge)
+bad_converge = json.loads(json.dumps(converge_report))
+bad_converge["rust_mine"]["block_hash"] = corrupt_block_hash
+bad_converge["rust_mine"]["block_path"] = str(artifact_root / "rust-corrupt-merkle-block.json")
+bad_converge["rust_mine"]["mine_next_path"] = str(artifact_root / "rust-corrupt-merkle-mine-next.json")
+bad_converge["go_converge"]["block_hash"] = corrupt_block_hash
+bad_converge["go_converge"]["block_path"] = str(artifact_root / "go-corrupt-merkle-block.json")
+bad_converge["go_converge"]["tip_path"] = str(artifact_root / "go-corrupt-merkle-tip.json")
+dump(root / "converge-bad-merkle-block.json", bad_converge)
+bad_converge = json.loads(json.dumps(converge_report))
+bad_converge["rust_mine"]["tx_count"] = 3
+bad_converge["rust_mine"]["mine_next_path"] = str(artifact_root / "rust-tx-count-mismatch-mine-next.json")
+dump(root / "converge-tx-count-mismatch.json", bad_converge)
 (root / "empty.json").write_text("", encoding="utf-8")
 (root / "malformed.json").write_text("[", encoding="utf-8")
 with (root / "oversized.json").open("wb") as f:
@@ -343,6 +498,8 @@ print(root / "converge-duplicate-sidecar-path.json")
 print(root / "converge-wrong-sidecar-source.json")
 print(root / "converge-malformed-block.json")
 print(root / "converge-missing-tx-block.json")
+print(root / "converge-bad-merkle-block.json")
+print(root / "converge-tx-count-mismatch.json")
 PY
 }
 
@@ -361,7 +518,9 @@ CONVERGE_DUPLICATE_SIDECAR_REPORT="$(sed -n '6p' "${REPORT_LIST}")"
 CONVERGE_WRONG_SIDECAR_SOURCE_REPORT="$(sed -n '7p' "${REPORT_LIST}")"
 CONVERGE_MALFORMED_BLOCK_REPORT="$(sed -n '8p' "${REPORT_LIST}")"
 CONVERGE_MISSING_TX_BLOCK_REPORT="$(sed -n '9p' "${REPORT_LIST}")"
-[[ -n "${MESH_REPORT}" && -n "${TX_REPORT}" && -n "${CONVERGE_REPORT}" && -n "${CONVERGE_WRONG_TXID_REPORT}" && -n "${CONVERGE_BAD_RUST_CLASS_REPORT}" && -n "${CONVERGE_DUPLICATE_SIDECAR_REPORT}" && -n "${CONVERGE_WRONG_SIDECAR_SOURCE_REPORT}" && -n "${CONVERGE_MALFORMED_BLOCK_REPORT}" && -n "${CONVERGE_MISSING_TX_BLOCK_REPORT}" ]] || { echo "failed to build synthetic reports" >&2; exit 1; }
+CONVERGE_BAD_MERKLE_BLOCK_REPORT="$(sed -n '10p' "${REPORT_LIST}")"
+CONVERGE_TX_COUNT_MISMATCH_REPORT="$(sed -n '11p' "${REPORT_LIST}")"
+[[ -n "${MESH_REPORT}" && -n "${TX_REPORT}" && -n "${CONVERGE_REPORT}" && -n "${CONVERGE_WRONG_TXID_REPORT}" && -n "${CONVERGE_BAD_RUST_CLASS_REPORT}" && -n "${CONVERGE_DUPLICATE_SIDECAR_REPORT}" && -n "${CONVERGE_WRONG_SIDECAR_SOURCE_REPORT}" && -n "${CONVERGE_MALFORMED_BLOCK_REPORT}" && -n "${CONVERGE_MISSING_TX_BLOCK_REPORT}" && -n "${CONVERGE_BAD_MERKLE_BLOCK_REPORT}" && -n "${CONVERGE_TX_COUNT_MISMATCH_REPORT}" ]] || { echo "failed to build synthetic reports" >&2; exit 1; }
 
 expect_pass_contains "public mesh check-report" "PASS: mixed_client_mesh report structurally accepted" "${HARNESS}" --check-report "${MESH_REPORT}"
 expect_fail_contains "public tx check-report" "public tx-path check-report is unsupported" "${HARNESS}" --check-report "${TX_REPORT}"
@@ -378,13 +537,19 @@ expect_fail_contains "producer rejects reused converge sidecar path" "converge s
 expect_fail_contains "producer rejects wrong-source converge block" "go_converge.block_path sidecar identity mismatch" check_report "${CONVERGE_WRONG_SIDECAR_SOURCE_REPORT}" offline producer-tx
 expect_fail_contains "producer rejects malformed converge block" "go_converge.block_path inclusion check failed" check_report "${CONVERGE_MALFORMED_BLOCK_REPORT}" offline producer-tx
 expect_fail_contains "producer rejects converge block missing tx" "submitted txid missing from parsed block txids" check_report "${CONVERGE_MISSING_TX_BLOCK_REPORT}" offline producer-tx
+expect_fail_contains "producer rejects uncommitted converge block tx list" "basic block validation failed" check_report "${CONVERGE_BAD_MERKLE_BLOCK_REPORT}" offline producer-tx
+expect_fail_contains "producer rejects converge block tx_count mismatch" "parsed block tx_count mismatch" check_report "${CONVERGE_TX_COUNT_MISMATCH_REPORT}" offline producer-tx
 expect_fail_token "token maps converge class drift" "rust_mine_class_invalid" check_report "${CONVERGE_BAD_RUST_CLASS_REPORT}" offline producer-tx
 expect_fail_token "token maps reused converge sidecar path" "converge_sidecar_paths_not_distinct" check_report "${CONVERGE_DUPLICATE_SIDECAR_REPORT}" offline producer-tx
 expect_fail_token "token maps wrong-source converge sidecar" "converge_sidecar_identity_mismatch" check_report "${CONVERGE_WRONG_SIDECAR_SOURCE_REPORT}" offline producer-tx
 expect_fail_token "token maps malformed parsed block" "block_hex_parse_failed" check_report "${CONVERGE_MALFORMED_BLOCK_REPORT}" offline producer-tx
 expect_fail_token "token maps parsed block tx omission" "block_missing_submitted_txid" check_report "${CONVERGE_MISSING_TX_BLOCK_REPORT}" offline producer-tx
+expect_fail_token "token maps uncommitted block tx list" "block_basic_validation_failed" check_report "${CONVERGE_BAD_MERKLE_BLOCK_REPORT}" offline producer-tx
+expect_fail_token "token maps block tx_count mismatch" "block_tx_count_mismatch" check_report "${CONVERGE_TX_COUNT_MISMATCH_REPORT}" offline producer-tx
 [[ "$(block_inclusion_failure_reason rust_mine "parse block_hex failed: short block")" == "rust_mine_block_hex_parse_failed" ]] || { echo "FAIL: rust mine parse failure reason collapsed" >&2; exit 1; }
 [[ "$(block_inclusion_failure_reason rust_mine "parsed block hash mismatch")" == "rust_mine_block_hash_mismatch" ]] || { echo "FAIL: rust mine hash mismatch reason collapsed" >&2; exit 1; }
+[[ "$(block_inclusion_failure_reason rust_mine "basic block validation failed: BLOCK_ERR_MERKLE_INVALID")" == "rust_mine_block_basic_validation_failed" ]] || { echo "FAIL: rust mine basic block failure reason collapsed" >&2; exit 1; }
+[[ "$(block_inclusion_failure_reason go_converge "parsed block tx_count mismatch")" == "go_converge_block_tx_count_mismatch" ]] || { echo "FAIL: go converge tx_count mismatch reason collapsed" >&2; exit 1; }
 [[ "$(block_inclusion_failure_reason go_converge "submitted txid missing from parsed block txids")" == "go_converge_block_missing_submitted_txid" ]] || { echo "FAIL: go converge missing-tx reason collapsed" >&2; exit 1; }
 [[ "$(block_inclusion_failure_reason go_converge "block response height/hash/canonical mismatch")" == "go_converge_block_sidecar_mismatch" ]] || { echo "FAIL: go converge sidecar mismatch reason collapsed" >&2; exit 1; }
 printf '{"mined":false,"error":"live mining unavailable"}\n' >"${TMP_ROOT}/mine-live-unavailable.json"

--- a/scripts/devnet/test_mixed_client_mesh_check_report.sh
+++ b/scripts/devnet/test_mixed_client_mesh_check_report.sh
@@ -85,7 +85,9 @@ start = next(i for i, line in enumerate(lines) if line.startswith("check_report(
 end = next(i for i, line in enumerate(lines[start:], start) if line.startswith('[[ "${MESH_TIMEOUT}"'))
 token_start = next(i for i, line in enumerate(lines) if line.startswith("tx_report_reason_token()"))
 token_end = next(i for i, line in enumerate(lines[token_start:], token_start) if line.startswith("combined_report_reason_token()"))
-Path(dst).write_text("\n".join(lines[start:end] + [""] + lines[token_start:token_end]) + "\n", encoding="utf-8")
+block_reason_start = next(i for i, line in enumerate(lines) if line.startswith("block_inclusion_failure_reason()"))
+block_reason_end = next(i for i, line in enumerate(lines[block_reason_start:], block_reason_start) if line.startswith("verify_block_inclusion()"))
+Path(dst).write_text("\n".join(lines[start:end] + [""] + lines[token_start:token_end] + [""] + lines[block_reason_start:block_reason_end]) + "\n", encoding="utf-8")
 PY
 }
 
@@ -373,6 +375,10 @@ expect_fail_token "token maps reused converge sidecar path" "converge_sidecar_pa
 expect_fail_token "token maps wrong-source converge sidecar" "converge_sidecar_identity_mismatch" check_report "${CONVERGE_WRONG_SIDECAR_SOURCE_REPORT}" offline producer-tx
 expect_fail_token "token maps malformed parsed block" "block_hex_parse_failed" check_report "${CONVERGE_MALFORMED_BLOCK_REPORT}" offline producer-tx
 expect_fail_token "token maps parsed block tx omission" "block_missing_submitted_txid" check_report "${CONVERGE_MISSING_TX_BLOCK_REPORT}" offline producer-tx
+[[ "$(block_inclusion_failure_reason rust_mine "parse block_hex failed: short block")" == "rust_mine_block_hex_parse_failed" ]] || { echo "FAIL: rust mine parse failure reason collapsed" >&2; exit 1; }
+[[ "$(block_inclusion_failure_reason rust_mine "parsed block hash mismatch")" == "rust_mine_block_hash_mismatch" ]] || { echo "FAIL: rust mine hash mismatch reason collapsed" >&2; exit 1; }
+[[ "$(block_inclusion_failure_reason go_converge "submitted txid missing from parsed block txids")" == "go_converge_block_missing_submitted_txid" ]] || { echo "FAIL: go converge missing-tx reason collapsed" >&2; exit 1; }
+[[ "$(block_inclusion_failure_reason go_converge "block response height/hash/canonical mismatch")" == "go_converge_block_sidecar_mismatch" ]] || { echo "FAIL: go converge sidecar mismatch reason collapsed" >&2; exit 1; }
 
 expect_fail_contains "non-regular report" "report is not a regular file" "${HARNESS}" --check-report "${TMP_ROOT}"
 expect_fail_contains "empty report" "report is empty" "${HARNESS}" --check-report "${TMP_ROOT}/empty.json"

--- a/scripts/devnet/test_mixed_client_mesh_check_report.sh
+++ b/scripts/devnet/test_mixed_client_mesh_check_report.sh
@@ -15,7 +15,8 @@ command -v python3 >/dev/null 2>&1 || { echo "python3 is required" >&2; exit 1; 
 [[ -x "${DEV_ENV}" ]] || { echo "dev-env wrapper missing or non-executable: ${DEV_ENV}" >&2; exit 1; }
 [[ -r "${VALIDATOR}" ]] || { echo "validator unreadable: ${VALIDATOR}" >&2; exit 1; }
 
-TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/rubin-mesh-check-report.XXXXXX")"
+TMP_PARENT="$(cd -- "${TMPDIR:-/tmp}" && pwd -P)" || { echo "test TMPDIR parent is not usable: ${TMPDIR:-/tmp}" >&2; exit 1; }
+TMP_ROOT="$(mktemp -d "${TMP_PARENT%/}/rubin-mesh-check-report.XXXXXX")"
 cleanup() {
   rm -rf -- "${TMP_ROOT}"
 }
@@ -216,6 +217,13 @@ for impl, endpoint, prefix in (("go", go_rpc, "go"), ("rust", rust_rpc, "rust"))
         "rpc_endpoint": endpoint,
         "txid": txid,
     })
+height = 102
+block_hash = "ab" * 32
+tx_count = 2
+for path in (artifact_root / "rust-mined-block.json", artifact_root / "go-converged-block.json"):
+    dump(path, {"block_hex": "00", "canonical": True, "hash": block_hash, "height": height})
+dump(artifact_root / "rust-mine-next.json", {"block_hash": block_hash, "height": height, "mined": True, "nonce": 0, "timestamp": 1, "tx_count": tx_count})
+dump(artifact_root / "go-converge-tip.json", {"best_known_height": height, "has_tip": True, "height": height, "in_ibd": False, "tip_hash": block_hash})
 tx_report = {
     **mesh_report,
     "go_submit": {
@@ -237,12 +245,45 @@ tx_report = {
     "tx_path": tx_path,
 }
 dump(root / "tx-report.json", tx_report)
+converge_report = {
+    **tx_report,
+    "go_converge": {
+        "block_hash": block_hash,
+        "block_path": str(artifact_root / "go-converged-block.json"),
+        "class": "canonical_block_found",
+        "converged_at": "node-go",
+        "height": height,
+        "raw_hex": tx_hex,
+        "rpc_endpoint": go_rpc,
+        "tip_path": str(artifact_root / "go-converge-tip.json"),
+        "txid": txid,
+    },
+    "rust_mine": {
+        "block_hash": block_hash,
+        "block_path": str(artifact_root / "rust-mined-block.json"),
+        "class": "mined_included",
+        "height": height,
+        "mine_next_path": str(artifact_root / "rust-mine-next.json"),
+        "mined_by": "node-rust",
+        "raw_hex": tx_hex,
+        "rpc_endpoint": rust_rpc,
+        "tx_count": tx_count,
+        "txid": txid,
+    },
+    "scenario": "mixed_client_go_submit_rust_mine_go_converge",
+}
+dump(root / "converge-report.json", converge_report)
+bad_converge = json.loads(json.dumps(converge_report))
+bad_converge["go_converge"]["txid"] = "11" * 32
+dump(root / "converge-wrong-txid.json", bad_converge)
 (root / "empty.json").write_text("", encoding="utf-8")
 (root / "malformed.json").write_text("[", encoding="utf-8")
 with (root / "oversized.json").open("wb") as f:
     f.write(b" " * 1_000_001)
 print(root / "mesh-report.json")
 print(root / "tx-report.json")
+print(root / "converge-report.json")
+print(root / "converge-wrong-txid.json")
 PY
 }
 
@@ -254,15 +295,20 @@ REPORT_LIST="${TMP_ROOT}/reports.txt"
 write_reports >"${REPORT_LIST}"
 MESH_REPORT="$(sed -n '1p' "${REPORT_LIST}")"
 TX_REPORT="$(sed -n '2p' "${REPORT_LIST}")"
-[[ -n "${MESH_REPORT}" && -n "${TX_REPORT}" ]] || { echo "failed to build synthetic reports" >&2; exit 1; }
+CONVERGE_REPORT="$(sed -n '3p' "${REPORT_LIST}")"
+CONVERGE_WRONG_TXID_REPORT="$(sed -n '4p' "${REPORT_LIST}")"
+[[ -n "${MESH_REPORT}" && -n "${TX_REPORT}" && -n "${CONVERGE_REPORT}" && -n "${CONVERGE_WRONG_TXID_REPORT}" ]] || { echo "failed to build synthetic reports" >&2; exit 1; }
 
 expect_pass_contains "public mesh check-report" "PASS: mixed_client_mesh report structurally accepted" "${HARNESS}" --check-report "${MESH_REPORT}"
 expect_fail_contains "public tx check-report" "public tx-path check-report is unsupported" "${HARNESS}" --check-report "${TX_REPORT}"
+expect_fail_contains "public converge check-report" "public tx-path check-report is unsupported" "${HARNESS}" --check-report "${CONVERGE_REPORT}"
 expect_fail_contains "public tx check-report-live" "public tx-path check-report-live is unsupported" "${HARNESS}" --check-report-live "${TX_REPORT}"
-expect_fail_contains "combined tx flag and check-report" "cannot be combined" "${HARNESS}" --go-submit-rust-accept --check-report "${TX_REPORT}"
+expect_fail_contains "combined tx flag and check-report" "tx-path modes cannot be combined" "${HARNESS}" --go-submit-rust-accept --check-report "${TX_REPORT}"
 
 expect_pass_contains "producer tx internal check" "PASS: mixed_client_go_submit_rust_accept report structurally accepted" check_report "${TX_REPORT}" offline producer-tx
-expect_fail_contains "producer rejects mesh report" "producer tx validation requires mixed_client_go_submit_rust_accept report" check_report "${MESH_REPORT}" offline producer-tx
+expect_pass_contains "producer converge internal check" "PASS: mixed_client_go_submit_rust_mine_go_converge report structurally accepted" check_report "${CONVERGE_REPORT}" offline producer-tx
+expect_fail_contains "producer rejects mesh report" "producer tx validation requires a mixed-client tx-path report" check_report "${MESH_REPORT}" offline producer-tx
+expect_fail_contains "producer rejects converged txid drift" "mined/converged tx identity differs from submitted tx" check_report "${CONVERGE_WRONG_TXID_REPORT}" offline producer-tx
 
 expect_fail_contains "non-regular report" "report is not a regular file" "${HARNESS}" --check-report "${TMP_ROOT}"
 expect_fail_contains "empty report" "report is empty" "${HARNESS}" --check-report "${TMP_ROOT}/empty.json"

--- a/scripts/devnet/test_mixed_client_mesh_check_report.sh
+++ b/scripts/devnet/test_mixed_client_mesh_check_report.sh
@@ -85,9 +85,17 @@ start = next(i for i, line in enumerate(lines) if line.startswith("check_report(
 end = next(i for i, line in enumerate(lines[start:], start) if line.startswith('[[ "${MESH_TIMEOUT}"'))
 token_start = next(i for i, line in enumerate(lines) if line.startswith("tx_report_reason_token()"))
 token_end = next(i for i, line in enumerate(lines[token_start:], token_start) if line.startswith("combined_report_reason_token()"))
+capture_start = next(i for i, line in enumerate(lines) if line.startswith("rpc_json()"))
+capture_end = next(i for i, line in enumerate(lines[capture_start:], capture_start) if line.startswith("pid_comm()"))
+tx_capture_start = next(i for i, line in enumerate(lines) if line.startswith("tx_capture_reason()"))
+tx_capture_end = next(i for i, line in enumerate(lines[tx_capture_start:], tx_capture_start) if line.startswith("tx_sidecar_reason()"))
 block_reason_start = next(i for i, line in enumerate(lines) if line.startswith("block_inclusion_failure_reason()"))
 block_reason_end = next(i for i, line in enumerate(lines[block_reason_start:], block_reason_start) if line.startswith("verify_block_inclusion()"))
-Path(dst).write_text("\n".join(lines[start:end] + [""] + lines[token_start:token_end] + [""] + lines[block_reason_start:block_reason_end]) + "\n", encoding="utf-8")
+mine_reason_start = next(i for i, line in enumerate(lines) if line.startswith("mine_next_http_error_reason()"))
+mine_reason_end = next(i for i, line in enumerate(lines[mine_reason_start:], mine_reason_start) if line.startswith("rust_mine_including_tx()"))
+rust_mine_start = next(i for i, line in enumerate(lines) if line.startswith("rust_mine_including_tx()"))
+rust_mine_end = next(i for i, line in enumerate(lines[rust_mine_start:], rust_mine_start) if line.startswith("tip_matches()"))
+Path(dst).write_text("\n".join(lines[start:end] + [""] + lines[token_start:token_end] + [""] + lines[capture_start:capture_end] + [""] + lines[tx_capture_start:tx_capture_end] + [""] + lines[block_reason_start:block_reason_end] + [""] + lines[mine_reason_start:mine_reason_end] + [""] + lines[rust_mine_start:rust_mine_end]) + "\n", encoding="utf-8")
 PY
 }
 
@@ -379,6 +387,28 @@ expect_fail_token "token maps parsed block tx omission" "block_missing_submitted
 [[ "$(block_inclusion_failure_reason rust_mine "parsed block hash mismatch")" == "rust_mine_block_hash_mismatch" ]] || { echo "FAIL: rust mine hash mismatch reason collapsed" >&2; exit 1; }
 [[ "$(block_inclusion_failure_reason go_converge "submitted txid missing from parsed block txids")" == "go_converge_block_missing_submitted_txid" ]] || { echo "FAIL: go converge missing-tx reason collapsed" >&2; exit 1; }
 [[ "$(block_inclusion_failure_reason go_converge "block response height/hash/canonical mismatch")" == "go_converge_block_sidecar_mismatch" ]] || { echo "FAIL: go converge sidecar mismatch reason collapsed" >&2; exit 1; }
+printf '{"mined":false,"error":"live mining unavailable"}\n' >"${TMP_ROOT}/mine-live-unavailable.json"
+printf '{"mined":false,"error":"sync engine unavailable"}\n' >"${TMP_ROOT}/mine-sync-unavailable.json"
+printf '{"mined":false,"error":"tx pool unavailable"}\n' >"${TMP_ROOT}/mine-pool-unavailable.json"
+printf '{"mined":false,"error":"template rejected"}\n' >"${TMP_ROOT}/mine-rejected.json"
+[[ "$(mine_next_http_error_reason "${TMP_ROOT}/mine-live-unavailable.json")" == "rust_mine_live_mining_unavailable" ]] || { echo "FAIL: live mining error reason collapsed" >&2; exit 1; }
+[[ "$(mine_next_http_error_reason "${TMP_ROOT}/mine-sync-unavailable.json")" == "rust_mine_sync_unavailable" ]] || { echo "FAIL: sync unavailable error reason collapsed" >&2; exit 1; }
+[[ "$(mine_next_http_error_reason "${TMP_ROOT}/mine-pool-unavailable.json")" == "rust_mine_tx_pool_unavailable" ]] || { echo "FAIL: tx pool unavailable error reason collapsed" >&2; exit 1; }
+[[ "$(mine_next_http_error_reason "${TMP_ROOT}/mine-rejected.json")" == "rust_mine_rejected" ]] || { echo "FAIL: miner rejection error reason collapsed" >&2; exit 1; }
+rpc_json() {
+  [[ "$1" == "POST" && "$3" == "/mine_next" ]] || return 1
+  printf '{"mined":false,"error":"tx pool unavailable"}\n'
+  return 22
+}
+export RUST_RPC_ADDR="127.0.0.1:59999"
+RUST_MINE_JSON="${TMP_ROOT}/mine-next-sidecar.json"
+TX_REASON=""
+if rust_mine_including_tx; then
+  echo "FAIL: rust_mine_including_tx should fail on /mine_next HTTP error" >&2
+  exit 1
+fi
+[[ "${TX_REASON}" == "rust_mine_tx_pool_unavailable" ]] || { echo "FAIL: mine_next HTTP body did not map through raw sidecar to TX_REASON: ${TX_REASON}" >&2; exit 1; }
+[[ ! -e "${RUST_MINE_JSON}.raw" ]] || { echo "FAIL: mine_next HTTP raw body was not cleaned up" >&2; exit 1; }
 
 expect_fail_contains "non-regular report" "report is not a regular file" "${HARNESS}" --check-report "${TMP_ROOT}"
 expect_fail_contains "empty report" "report is empty" "${HARNESS}" --check-report "${TMP_ROOT}/empty.json"

--- a/scripts/devnet/test_mixed_client_mesh_check_report.sh
+++ b/scripts/devnet/test_mixed_client_mesh_check_report.sh
@@ -99,6 +99,71 @@ Path(dst).write_text("\n".join(lines[start:end] + [""] + lines[token_start:token
 PY
 }
 
+extract_prepare_tx_chainstate() {
+  python3 - "${HARNESS}" "${PREPARE_TX_CHAINSTATE_LIB}" <<'PY'
+from pathlib import Path
+import sys
+
+src, dst = map(Path, sys.argv[1:3])
+lines = src.read_text(encoding="utf-8").splitlines()
+start = next(i for i, line in enumerate(lines) if line.startswith("prepare_tx_chainstate()"))
+end = next(i for i, line in enumerate(lines[start:], start) if line.startswith("parse_txid()"))
+Path(dst).write_text("\n".join(lines[start:end]) + "\n", encoding="utf-8")
+PY
+}
+
+check_prepare_tx_chainstate_cleanup() {
+  local probe="${TMP_ROOT}/prepare-tx-chainstate-cleanup.sh" probe_root="${TMP_ROOT}/prepare-tx-chainstate-cleanup"
+  mkdir -p -- "${probe_root}"
+  cat >"${probe}" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$1"
+probe_root="$2"
+KEYGEN_JSON="${probe_root}/keygen.json"
+KEYGEN_GO="${probe_root}/keygen.go"
+GO_MODULE_ROOT="${probe_root}/go"
+DEV_ENV="${probe_root}/dev-env.sh"
+GO_NODE_BIN="${probe_root}/rubin-node"
+GO_DIR="${probe_root}/go-node"
+RUST_DIR="${probe_root}/rust-node"
+MINE_LOG="${probe_root}/mine-go.log"
+TMPDIR="${probe_root}/tmp"
+TX_REASON=""
+TX_FROM_KEY_DIR=""
+TX_FROM_KEY_FILE=""
+TX_TO_KEY=""
+mkdir -p -- "${TMPDIR}" "${GO_MODULE_ROOT}" "${GO_DIR}" "${RUST_DIR}"
+
+build_go_txgen() { :; }
+write_keygen() { :; }
+disable_xtrace_for_secret() { return 1; }
+restore_xtrace_after_secret() { :; }
+make_tx_secret_dir() {
+  mkdir -p -- "${probe_root}/secret"
+  printf '%s\n' "${probe_root}/secret"
+}
+cleanup_tx_from_key_file() { :; }
+bounded_mesh() {
+  printf '{"malformed":true}\n'
+  printf 'keygen stderr\n' >&2
+}
+parse_keygen_material() { return 9; }
+keygen_material_reason() { printf '%s\n' go_submit_keygen_material_malformed; }
+
+set +e
+prepare_tx_chainstate
+rc=$?
+set -e
+[[ ${rc} -ne 0 ]] || { echo "FAIL: prepare_tx_chainstate should fail on malformed keygen material" >&2; exit 1; }
+[[ "${TX_REASON}" == "go_submit_keygen_material_malformed" ]] || { echo "FAIL: unexpected TX_REASON: ${TX_REASON}" >&2; exit 1; }
+[[ ! -e "${KEYGEN_JSON}.raw" ]] || { echo "FAIL: keygen raw sidecar survived failure" >&2; exit 1; }
+[[ ! -e "${KEYGEN_JSON}.stderr" ]] || { echo "FAIL: keygen stderr sidecar survived failure" >&2; exit 1; }
+SH
+  bash "${probe}" "${PREPARE_TX_CHAINSTATE_LIB}" "${probe_root}"
+}
+
 write_reports() {
   python3 - "${TMP_ROOT}" <<'PY'
 from pathlib import Path
@@ -504,7 +569,10 @@ PY
 }
 
 CHECK_REPORT_LIB="${TMP_ROOT}/check-report-lib.sh"
+PREPARE_TX_CHAINSTATE_LIB="${TMP_ROOT}/prepare-tx-chainstate-lib.sh"
 extract_check_report
+extract_prepare_tx_chainstate
+check_prepare_tx_chainstate_cleanup
 # shellcheck source=/dev/null
 source "${CHECK_REPORT_LIB}"
 REPORT_LIST="${TMP_ROOT}/reports.txt"

--- a/scripts/devnet/test_mixed_client_mesh_check_report.sh
+++ b/scripts/devnet/test_mixed_client_mesh_check_report.sh
@@ -246,12 +246,13 @@ block_hex = header.hex() + "02" + tx_hex + tx_hex
 mutated_tx = bytearray.fromhex(tx_hex)
 mutated_tx[5] ^= 0x01
 missing_tx_block_hex = header.hex() + "02" + mutated_tx.hex() + mutated_tx.hex()
-for path in (artifact_root / "rust-mined-block.json", artifact_root / "go-converged-block.json"):
-    dump(path, {"block_hex": block_hex, "canonical": True, "hash": block_hash, "height": height})
-dump(artifact_root / "go-converged-malformed-block.json", {"block_hex": "00", "canonical": True, "hash": block_hash, "height": height})
-dump(artifact_root / "go-converged-missing-tx-block.json", {"block_hex": missing_tx_block_hex, "canonical": True, "hash": block_hash, "height": height})
-dump(artifact_root / "rust-mine-next.json", {"block_hash": block_hash, "height": height, "mined": True, "nonce": 0, "timestamp": 1, "tx_count": tx_count})
-dump(artifact_root / "go-converge-tip.json", {"best_known_height": height, "has_tip": True, "height": height, "in_ibd": False, "tip_hash": block_hash})
+dump(artifact_root / "rust-mined-block.json", {"block_hex": block_hex, "canonical": True, "hash": block_hash, "height": height, "implementation": "rust", "request_path": f"/get_block?height={height}", "rpc_endpoint": rust_rpc})
+dump(artifact_root / "go-converged-block.json", {"block_hex": block_hex, "canonical": True, "hash": block_hash, "height": height, "implementation": "go", "request_path": f"/get_block?height={height}", "rpc_endpoint": go_rpc})
+dump(artifact_root / "go-converged-wrong-source-block.json", {"block_hex": block_hex, "canonical": True, "hash": block_hash, "height": height, "implementation": "rust", "request_path": f"/get_block?height={height}", "rpc_endpoint": rust_rpc})
+dump(artifact_root / "go-converged-malformed-block.json", {"block_hex": "00", "canonical": True, "hash": block_hash, "height": height, "implementation": "go", "request_path": f"/get_block?height={height}", "rpc_endpoint": go_rpc})
+dump(artifact_root / "go-converged-missing-tx-block.json", {"block_hex": missing_tx_block_hex, "canonical": True, "hash": block_hash, "height": height, "implementation": "go", "request_path": f"/get_block?height={height}", "rpc_endpoint": go_rpc})
+dump(artifact_root / "rust-mine-next.json", {"block_hash": block_hash, "height": height, "implementation": "rust", "mined": True, "nonce": 0, "request_path": "/mine_next", "rpc_endpoint": rust_rpc, "timestamp": 1, "tx_count": tx_count})
+dump(artifact_root / "go-converge-tip.json", {"best_known_height": height, "has_tip": True, "height": height, "implementation": "go", "in_ibd": False, "request_path": "/get_tip", "rpc_endpoint": go_rpc, "tip_hash": block_hash})
 tx_report = {
     **mesh_report,
     "go_submit": {
@@ -308,6 +309,12 @@ bad_converge = json.loads(json.dumps(converge_report))
 bad_converge["rust_mine"]["class"] = "accepted_only"
 dump(root / "converge-bad-rust-class.json", bad_converge)
 bad_converge = json.loads(json.dumps(converge_report))
+bad_converge["go_converge"]["block_path"] = str(artifact_root / "rust-mined-block.json")
+dump(root / "converge-duplicate-sidecar-path.json", bad_converge)
+bad_converge = json.loads(json.dumps(converge_report))
+bad_converge["go_converge"]["block_path"] = str(artifact_root / "go-converged-wrong-source-block.json")
+dump(root / "converge-wrong-sidecar-source.json", bad_converge)
+bad_converge = json.loads(json.dumps(converge_report))
 bad_converge["go_converge"]["block_path"] = str(artifact_root / "go-converged-malformed-block.json")
 dump(root / "converge-malformed-block.json", bad_converge)
 bad_converge = json.loads(json.dumps(converge_report))
@@ -322,6 +329,8 @@ print(root / "tx-report.json")
 print(root / "converge-report.json")
 print(root / "converge-wrong-txid.json")
 print(root / "converge-bad-rust-class.json")
+print(root / "converge-duplicate-sidecar-path.json")
+print(root / "converge-wrong-sidecar-source.json")
 print(root / "converge-malformed-block.json")
 print(root / "converge-missing-tx-block.json")
 PY
@@ -338,23 +347,30 @@ TX_REPORT="$(sed -n '2p' "${REPORT_LIST}")"
 CONVERGE_REPORT="$(sed -n '3p' "${REPORT_LIST}")"
 CONVERGE_WRONG_TXID_REPORT="$(sed -n '4p' "${REPORT_LIST}")"
 CONVERGE_BAD_RUST_CLASS_REPORT="$(sed -n '5p' "${REPORT_LIST}")"
-CONVERGE_MALFORMED_BLOCK_REPORT="$(sed -n '6p' "${REPORT_LIST}")"
-CONVERGE_MISSING_TX_BLOCK_REPORT="$(sed -n '7p' "${REPORT_LIST}")"
-[[ -n "${MESH_REPORT}" && -n "${TX_REPORT}" && -n "${CONVERGE_REPORT}" && -n "${CONVERGE_WRONG_TXID_REPORT}" && -n "${CONVERGE_BAD_RUST_CLASS_REPORT}" && -n "${CONVERGE_MALFORMED_BLOCK_REPORT}" && -n "${CONVERGE_MISSING_TX_BLOCK_REPORT}" ]] || { echo "failed to build synthetic reports" >&2; exit 1; }
+CONVERGE_DUPLICATE_SIDECAR_REPORT="$(sed -n '6p' "${REPORT_LIST}")"
+CONVERGE_WRONG_SIDECAR_SOURCE_REPORT="$(sed -n '7p' "${REPORT_LIST}")"
+CONVERGE_MALFORMED_BLOCK_REPORT="$(sed -n '8p' "${REPORT_LIST}")"
+CONVERGE_MISSING_TX_BLOCK_REPORT="$(sed -n '9p' "${REPORT_LIST}")"
+[[ -n "${MESH_REPORT}" && -n "${TX_REPORT}" && -n "${CONVERGE_REPORT}" && -n "${CONVERGE_WRONG_TXID_REPORT}" && -n "${CONVERGE_BAD_RUST_CLASS_REPORT}" && -n "${CONVERGE_DUPLICATE_SIDECAR_REPORT}" && -n "${CONVERGE_WRONG_SIDECAR_SOURCE_REPORT}" && -n "${CONVERGE_MALFORMED_BLOCK_REPORT}" && -n "${CONVERGE_MISSING_TX_BLOCK_REPORT}" ]] || { echo "failed to build synthetic reports" >&2; exit 1; }
 
 expect_pass_contains "public mesh check-report" "PASS: mixed_client_mesh report structurally accepted" "${HARNESS}" --check-report "${MESH_REPORT}"
 expect_fail_contains "public tx check-report" "public tx-path check-report is unsupported" "${HARNESS}" --check-report "${TX_REPORT}"
 expect_fail_contains "public converge check-report" "public tx-path check-report is unsupported" "${HARNESS}" --check-report "${CONVERGE_REPORT}"
 expect_fail_contains "public tx check-report-live" "public tx-path check-report-live is unsupported" "${HARNESS}" --check-report-live "${TX_REPORT}"
 expect_fail_contains "combined tx flag and check-report" "tx-path modes cannot be combined" "${HARNESS}" --go-submit-rust-accept --check-report "${TX_REPORT}"
+expect_fail_contains "combined tx-path flags reject" "tx-path modes are mutually exclusive" "${HARNESS}" --go-submit-rust-accept --go-submit-rust-mine-go-converge
 
 expect_pass_contains "producer tx internal check" "PASS: mixed_client_go_submit_rust_accept report structurally accepted" check_report "${TX_REPORT}" offline producer-tx
 expect_pass_contains "producer converge internal check" "PASS: mixed_client_go_submit_rust_mine_go_converge report structurally accepted" check_report "${CONVERGE_REPORT}" offline producer-tx
 expect_fail_contains "producer rejects mesh report" "producer tx validation requires a mixed-client tx-path report" check_report "${MESH_REPORT}" offline producer-tx
 expect_fail_contains "producer rejects converged txid drift" "mined/converged tx identity differs from submitted tx" check_report "${CONVERGE_WRONG_TXID_REPORT}" offline producer-tx
+expect_fail_contains "producer rejects reused converge sidecar path" "converge sidecar paths are not pairwise distinct" check_report "${CONVERGE_DUPLICATE_SIDECAR_REPORT}" offline producer-tx
+expect_fail_contains "producer rejects wrong-source converge block" "go_converge.block_path sidecar identity mismatch" check_report "${CONVERGE_WRONG_SIDECAR_SOURCE_REPORT}" offline producer-tx
 expect_fail_contains "producer rejects malformed converge block" "go_converge.block_path inclusion check failed" check_report "${CONVERGE_MALFORMED_BLOCK_REPORT}" offline producer-tx
 expect_fail_contains "producer rejects converge block missing tx" "submitted txid missing from parsed block txids" check_report "${CONVERGE_MISSING_TX_BLOCK_REPORT}" offline producer-tx
 expect_fail_token "token maps converge class drift" "rust_mine_class_invalid" check_report "${CONVERGE_BAD_RUST_CLASS_REPORT}" offline producer-tx
+expect_fail_token "token maps reused converge sidecar path" "converge_sidecar_paths_not_distinct" check_report "${CONVERGE_DUPLICATE_SIDECAR_REPORT}" offline producer-tx
+expect_fail_token "token maps wrong-source converge sidecar" "converge_sidecar_identity_mismatch" check_report "${CONVERGE_WRONG_SIDECAR_SOURCE_REPORT}" offline producer-tx
 expect_fail_token "token maps malformed parsed block" "block_hex_parse_failed" check_report "${CONVERGE_MALFORMED_BLOCK_REPORT}" offline producer-tx
 expect_fail_token "token maps parsed block tx omission" "block_missing_submitted_txid" check_report "${CONVERGE_MISSING_TX_BLOCK_REPORT}" offline producer-tx
 


### PR DESCRIPTION
Invariant:
Rust-mined live devnet blocks must be proven as committed blocks and observed by the Go node before the mixed-client convergence report can PASS.

Layer:
Operations / devnet evidence harness only.

Files changed:
- `scripts/devnet-mixed-client-mesh.sh`
- `scripts/devnet/test_mixed_client_mesh_check_report.sh`

Tests:
- `bash -n scripts/devnet-mixed-client-mesh.sh scripts/devnet/test_mixed_client_mesh_check_report.sh`
- `shellcheck scripts/devnet-mixed-client-mesh.sh scripts/devnet/test_mixed_client_mesh_check_report.sh`
- `git diff --check`
- `scripts/devnet/test_mixed_client_mesh_check_report.sh`
- `scripts/dev-env.sh -- bash -lc 'scripts/devnet/test_mixed_client_mesh_check_report.sh && scripts/devnet/test_mixed_client_mesh_keygen_material.sh'`
- `KEEP_TMP=1 MESH_TIMEOUT=180 scripts/devnet-mixed-client-mesh.sh --go-submit-rust-mine-go-converge`

Behavior impact:
- Adds the `--go-submit-rust-mine-go-converge` evidence path.
- Requires Rust `/mine_next`, Rust `/get_block`, Go `/get_tip`, and Go `/get_block` evidence before PASS.
- Verifies parsed block hash, parsed `tx_count`, basic block commitments, and non-coinbase submitted txid containment before claiming inclusion.
- Preserves `/mine_next` HTTP error bodies long enough to map typed failure reasons, then removes raw sidecar residue.

Compatibility impact:
- No Go runtime code changed.
- No Rust runtime code changed.
- No consensus, conformance fixture, schema, or validator changes.

Known non-goals:
- No mixed-client runtime redesign.
- No P2P protocol change.
- No Go/Rust consensus behavior change.
- No new conformance vectors.

Not checked:
- Long soak beyond the focused live convergence acceptance command.
