### PR TITLE
RUB-26: relabel helper interop evidence

### DIFF
--- a/scripts/devnet-rust-binary-soak.sh
+++ b/scripts/devnet-rust-binary-soak.sh
@@ -1,19 +1,19 @@
 #!/usr/bin/env bash
-# devnet-rust-binary-soak.sh — RUB-27 process-soak skeleton harness.
+# devnet-rust-binary-soak.sh — RUB-27 Rust helper/advisory launch harness.
 #
 # Launches a real `rubin-node` Rust binary as a process, records honest
-# process-level evidence (mixed_client_evidence_v1 conformant), and fails
-# closed if the binary cannot be built or launched.
+# helper-only/advisory non-process evidence, and fails closed if the
+# binary cannot be built or launched.
 #
-# Skeleton scope (RUB-27): Rust-only process launch. The emitted evidence
-# is intentionally `verdict=FAIL` because a single-Rust skeleton has no
-# cross-implementation tx_path proof — that proof is owned by RUB-21,
-# RUB-22, RUB-23. The Go participant in the artifact is a declared
-# placeholder (name + implementation only) so the schema cross-field
-# gate (mixed_client_process_soak requires both go and rust impls and
-# at least 2 participants) accepts the artifact; downstream issues
-# replace the placeholder with a real-launched Go participant plus a
-# tx_path PASS section.
+# Skeleton scope (RUB-27): Rust-only process launch. The emitted
+# mixed_client_evidence_v1 artifact is a non-authoritative FAIL schema
+# marker labeled by scenario/failure_reason as helper-only/advisory and
+# non-process. It is intentionally NOT full mixed-client process-soak
+# evidence: a single-Rust helper run has no cross-implementation tx_path
+# proof, and that full process proof is owned by RUB-21, RUB-22, and
+# RUB-23. The Go participant in the marker is a declared placeholder
+# (name + implementation only) so the RUB-24 schema shape can still be
+# validated, while the RUB-25 PASS gate rejects it.
 #
 # Hostile-case enforcement (RUB-27 enumeration → enforcement layer):
 #   * missing Rust binary           → cargo build fails → exit non-zero before any
@@ -62,7 +62,7 @@ while (($#)); do
 done
 
 command -v python3 >/dev/null 2>&1 || {
-  echo "python3 is required for Rust binary soak skeleton" >&2
+  echo "python3 is required for Rust helper/advisory launch marker" >&2
   exit 1
 }
 [[ -r "${VALIDATOR}" ]] || { echo "validator unreadable: ${VALIDATOR}" >&2; exit 1; }
@@ -98,7 +98,7 @@ print_prefixed_file() {
 
 check_mixed_client_pass_evidence() {
   local artifact="${1:-}" validator_stdout="" validator_stderr=""
-  local gate_error
+  local gate_error tmp_parent
 
   [[ -n "${artifact}" ]] || mixed_gate_fail "artifact path is required" || return 1
   [[ -f "${artifact}" ]] || mixed_gate_fail "artifact not found or not a regular file: ${artifact}" || return 1
@@ -107,8 +107,10 @@ check_mixed_client_pass_evidence() {
 
   run_fips_preflight_before_captured_dev_env
 
-  validator_stdout="$(mktemp "${TMPDIR:-/tmp}/rubin-mixed-validator-stdout.XXXXXX")" || return 1
-  validator_stderr="$(mktemp "${TMPDIR:-/tmp}/rubin-mixed-validator-stderr.XXXXXX")" || {
+  tmp_parent="${TMPDIR:-/tmp}"
+  tmp_parent="$(cd -- "${tmp_parent}" && pwd -P)" || return 1
+  validator_stdout="$(mktemp "${tmp_parent%/}/rubin-mixed-validator-stdout.XXXXXX")" || return 1
+  validator_stderr="$(mktemp "${tmp_parent%/}/rubin-mixed-validator-stderr.XXXXXX")" || {
     rm -f -- "${validator_stdout}"
     return 1
   }
@@ -231,19 +233,19 @@ if [[ "${CHECK_EVIDENCE_MODE}" == "1" ]]; then
 fi
 
 command -v perl >/dev/null 2>&1 || {
-  echo "perl is required for Rust binary soak skeleton" >&2
+  echo "perl is required for Rust helper/advisory launch marker" >&2
   exit 1
 }
 
 # shellcheck source=scripts/devnet-process-common.sh disable=SC1091
 source "${HELPER}"
-rubin_process_init rust-binary-soak
+rubin_process_init rust-helper-advisory
 
 NODE_BIN="${RUBIN_PROCESS_ARTIFACT_ROOT}/rubin-node-rust"
 DATA_DIR="${RUBIN_PROCESS_ARTIFACT_ROOT}/node-rust"
 LOG_FILE="node-rust.log"
-REPORT_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/rust-binary-soak-report.json"
-EVIDENCE_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/rust-binary-soak-evidence.json"
+REPORT_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/rust-helper-advisory-report.json"
+EVIDENCE_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/rust-helper-advisory-schema-marker.json"
 mkdir -p "${DATA_DIR}"
 
 # Build the Rust binary via the project dev-env wrapper. cargo failure
@@ -266,7 +268,7 @@ echo "Building Rust rubin-node binary"
 # its EXIT-trap-managed cleanup) owns the build cache; cargo's metadata
 # is what actually tells the harness where the binary landed.
 # Side-effect: each invocation gets its own mktemp'd cargo-target/, so
-# nothing reuses a shared cache — fine for a skeleton soak whose job
+# nothing reuses a shared cache — fine for a helper/advisory launch marker whose job
 # is to prove a real-process launch end-to-end on every run.
 CARGO_TARGET_DIR_LOCAL="${RUBIN_PROCESS_ARTIFACT_ROOT}/cargo-target"
 CARGO_BUILD_LOG="${RUBIN_PROCESS_ARTIFACT_ROOT}/cargo-build.jsonl"
@@ -370,7 +372,7 @@ cp "${CARGO_TARGET_BIN}" "${NODE_BIN}"
 
 # UTC-Z seconds-only canonical format per RUB-208 / PR-C policy
 # enforced by the schema regex on participants[].started_at. Captured
-# inside attempt_skeleton_launch AFTER the rpc-listening banner is
+# inside attempt_helper_launch AFTER the rpc-listening banner is
 # observed (P1 finding from PR #1510 review): on slow starts or banner
 # timeouts a pre-launch capture would have stamped evidence with a time
 # earlier than the actual observed start. The empty default here means
@@ -387,16 +389,16 @@ NODE_PID=""
 # leaves set -e disarmed for commands followed by `||`, so the
 # `cmd || { reason=...; return 1; }` form here does not abort the script
 # on a single helper failure — the calling `if` block decides next steps.
-attempt_skeleton_launch() {
+attempt_helper_launch() {
   rubin_process_start "${LOG_FILE}" "${NODE_BIN}" \
     --network devnet --datadir "${DATA_DIR}" \
     --bind 127.0.0.1:0 --rpc-bind 127.0.0.1:0 \
-    || { LAUNCH_FAILURE_REASON="rubin_process_start did not register a Rust skeleton process"; return 1; }
+    || { LAUNCH_FAILURE_REASON="rubin_process_start did not register a Rust helper/advisory process"; return 1; }
   NODE_PID="${RUBIN_PROCESS_LAST_PID:-}"
   [[ -n "${NODE_PID}" ]] \
     || { LAUNCH_FAILURE_REASON="rubin_process_start did not capture a pid"; return 1; }
   rubin_process_wait_for_log "${LOG_FILE}" "rpc: listening=" 60 "${NODE_PID}" \
-    || { LAUNCH_FAILURE_REASON="rust skeleton did not emit rpc-listening banner within 60s"; return 1; }
+    || { LAUNCH_FAILURE_REASON="Rust helper/advisory launch did not emit rpc-listening banner within 60s"; return 1; }
   # Stamped here, immediately after the rpc-listening banner is observed,
   # so participants[].started_at reflects an observed start time rather
   # than a pre-launch wall-clock guess.
@@ -406,14 +408,14 @@ attempt_skeleton_launch() {
   [[ -n "${RPC_ADDR}" ]] \
     || { LAUNCH_FAILURE_REASON="rpc-listening banner missing address payload"; return 1; }
   rubin_process_wait_for_rpc_ready "${RPC_ADDR}" 30 \
-    || { LAUNCH_FAILURE_REASON="rust skeleton /get_tip RPC was not reachable within 30s"; return 1; }
+    || { LAUNCH_FAILURE_REASON="Rust helper/advisory /get_tip RPC was not reachable within 30s"; return 1; }
   rubin_process_is_alive "${NODE_PID}" \
-    || { LAUNCH_FAILURE_REASON="rust skeleton process pid=${NODE_PID} exited after RPC probe"; return 1; }
+    || { LAUNCH_FAILURE_REASON="Rust helper/advisory process pid=${NODE_PID} exited after RPC probe"; return 1; }
   return 0
 }
 
 LAUNCH_STATUS="failed"
-if attempt_skeleton_launch; then
+if attempt_helper_launch; then
   LAUNCH_STATUS="success"
 fi
 
@@ -427,24 +429,23 @@ import os
 e = os.environ
 status = e["LAUNCH_STATUS"]
 launch_failure_raw = (e.get("LAUNCH_FAILURE_REASON") or "").strip()
+helper_boundary = (
+    "helper-only/advisory non-process Rust launch marker; full "
+    "mixed-client process tx_path proof is RUB-21/RUB-22/RUB-23"
+)
 
 # Compute one effective_failure_reason and use it in BOTH evidence and
 # report (PR #1510 wave-N+1 copilot P2 finding: previously evidence had
-# an "or '...skeleton...'" fallback while report passed
+# an older fallback while report passed
 # LAUNCH_FAILURE_REASON through unchanged, so a failed-path with empty
 # env var produced an empty/None report.failure_reason while evidence
 # had explicit text). Single computed value eliminates the asymmetry.
 if status == "success":
-    effective_failure_reason = (
-        "rust-only skeleton run; cross-implementation tx_path proof is "
-        "RUB-21/22/23"
-    )
+    effective_failure_reason = helper_boundary
 elif launch_failure_raw:
-    effective_failure_reason = launch_failure_raw
+    effective_failure_reason = f"{helper_boundary}; launch_failure={launch_failure_raw}"
 else:
-    effective_failure_reason = (
-        "rust skeleton launch failed without a specific reason"
-    )
+    effective_failure_reason = f"{helper_boundary}; launch_failure=unspecified"
 
 if status == "success":
     rust_participant = {
@@ -463,13 +464,14 @@ else:
 evidence = {
     "schema_version": "rubin-mixed-client-devnet-evidence-v1",
     "evidence_type": "mixed_client_process_soak",
-    "scenario": "rust_binary_soak_skeleton",
+    "scenario": "rust_helper_advisory_non_process_marker",
     "verdict": "FAIL",
     "failure_reason": effective_failure_reason,
     "participants": [
         rust_participant,
-        # Declared Go placeholder. RUB-21/22/23 replace this with a
-        # real-launched Go participant plus a tx_path PASS section.
+        # Declared Go placeholder. RUB-21/RUB-22/RUB-23 replace this
+        # marker with a real-launched Go participant plus a tx_path PASS
+        # process-soak artifact.
         {"name": "node-go", "implementation": "go"},
     ],
 }
@@ -504,7 +506,9 @@ artifact_root = e["RUBIN_PROCESS_ARTIFACT_ROOT"]
 log_file_relative = e["LOG_FILE"]
 log_path_absolute = os.path.join(artifact_root, log_file_relative)
 report = {
-    "scenario": "rust_binary_soak_skeleton",
+    "scenario": "rust_helper_advisory_non_process",
+    "evidence_class": "helper_only_advisory_non_process",
+    "claim_boundary": "does_not_prove_mixed_client_process_soak",
     "implementation": "rust",
     "command_path": e["NODE_BIN"],
     "data_dir": e["DATA_DIR"],
@@ -520,9 +524,9 @@ report = {
     "started_observed": bool(started_at_raw),
     "failure_reason": effective_failure_reason,
     "follow_ups": [
-        "RUB-21 owns cross-implementation tx_path PASS evidence",
-        "RUB-22/23 own end-to-end tx propagation",
-        "RUB-25 owns CI fail-closed gate integration",
+        "RUB-21 owns full mixed-client process tx_path PASS evidence",
+        "RUB-22/RUB-23 own end-to-end mixed-client tx propagation",
+        "RUB-25 owns CI fail-closed process evidence gate integration",
     ],
 }
 with open(e["REPORT_JSON"], "w", encoding="utf-8") as f:
@@ -530,15 +534,15 @@ with open(e["REPORT_JSON"], "w", encoding="utf-8") as f:
     f.write("\n")
 PY
 
-# RUB-24 schema validator is the canonical gate: must accept the
-# skeleton artifact (well-formed shape) regardless of LAUNCH_STATUS.
-# A validator rejection here is a real bug in this harness, not a
-# launch-time symptom — let `set -e` propagate the non-zero exit.
-echo "Validating emitted evidence via RUB-24 schema validator"
+# RUB-24 schema validator is used here only for the non-authoritative
+# helper/advisory FAIL marker shape. The marker must validate as a
+# well-formed FAIL object, while RUB-25's PASS gate still rejects it as
+# not full mixed-client process soak evidence.
+echo "Validating helper/advisory schema marker via RUB-24 schema validator"
 run_validator "${EVIDENCE_JSON}"
 
 if [[ "${LAUNCH_STATUS}" == "success" ]]; then
-  PASS_SUMMARY="SKELETON: rust binary soak launched pid=${NODE_PID} rpc=${RPC_ADDR} (verdict=FAIL/skeleton-only; cross-impl tx_path is RUB-21/22/23)"
+  PASS_SUMMARY="HELPER_ONLY_ADVISORY: rust binary launch observed pid=${NODE_PID} rpc=${RPC_ADDR} (non-process marker; full mixed-client tx_path proof is RUB-21/RUB-22/RUB-23)"
   if [[ "${RUBIN_PROCESS_KEEP_ARTIFACTS}" == "1" ]]; then
     echo "${PASS_SUMMARY}; report=${REPORT_JSON} evidence=${EVIDENCE_JSON}"
   else
@@ -548,9 +552,11 @@ if [[ "${LAUNCH_STATUS}" == "success" ]]; then
 else
   FAILURE_REASON_FOR_SUMMARY="${LAUNCH_FAILURE_REASON}"
   if [[ -z "${FAILURE_REASON_FOR_SUMMARY//[[:space:]]/}" ]]; then
-    FAILURE_REASON_FOR_SUMMARY="rust skeleton launch failed without a specific reason"
+    FAILURE_REASON_FOR_SUMMARY="launch_failure=unspecified"
+  else
+    FAILURE_REASON_FOR_SUMMARY="launch_failure=${FAILURE_REASON_FOR_SUMMARY}"
   fi
-  FAIL_SUMMARY="FAIL: rust skeleton launch failed: ${FAILURE_REASON_FOR_SUMMARY}"
+  FAIL_SUMMARY="FAIL: helper-only/advisory non-process Rust launch marker; full mixed-client process tx_path proof is RUB-21/RUB-22/RUB-23; ${FAILURE_REASON_FOR_SUMMARY}"
   echo "${FAIL_SUMMARY}; report=${REPORT_JSON} evidence=${EVIDENCE_JSON}" >&2
   exit 1
 fi

--- a/scripts/devnet-rust-binary-soak.sh
+++ b/scripts/devnet-rust-binary-soak.sh
@@ -98,7 +98,7 @@ print_prefixed_file() {
 
 check_mixed_client_pass_evidence() {
   local artifact="${1:-}" validator_stdout="" validator_stderr=""
-  local gate_error tmp_parent
+  local gate_error tmp_parent tmp_parent_raw
 
   [[ -n "${artifact}" ]] || mixed_gate_fail "artifact path is required" || return 1
   [[ -f "${artifact}" ]] || mixed_gate_fail "artifact not found or not a regular file: ${artifact}" || return 1
@@ -107,11 +107,18 @@ check_mixed_client_pass_evidence() {
 
   run_fips_preflight_before_captured_dev_env
 
-  tmp_parent="${TMPDIR:-/tmp}"
-  tmp_parent="$(cd -- "${tmp_parent}" && pwd -P)" || return 1
-  validator_stdout="$(mktemp "${tmp_parent%/}/rubin-mixed-validator-stdout.XXXXXX")" || return 1
+  tmp_parent_raw="${TMPDIR:-/tmp}"
+  tmp_parent="$(cd -- "${tmp_parent_raw}" && pwd -P)" || {
+    mixed_gate_fail "invalid TMPDIR for validator temp files: ${tmp_parent_raw}"
+    return 1
+  }
+  validator_stdout="$(mktemp "${tmp_parent%/}/rubin-mixed-validator-stdout.XXXXXX")" || {
+    mixed_gate_fail "failed to create validator stdout temp file under: ${tmp_parent}"
+    return 1
+  }
   validator_stderr="$(mktemp "${tmp_parent%/}/rubin-mixed-validator-stderr.XXXXXX")" || {
     rm -f -- "${validator_stdout}"
+    mixed_gate_fail "failed to create validator stderr temp file under: ${tmp_parent}"
     return 1
   }
 
@@ -506,7 +513,7 @@ artifact_root = e["RUBIN_PROCESS_ARTIFACT_ROOT"]
 log_file_relative = e["LOG_FILE"]
 log_path_absolute = os.path.join(artifact_root, log_file_relative)
 report = {
-    "scenario": "rust_helper_advisory_non_process",
+    "scenario": "rust_helper_advisory_non_process_marker",
     "evidence_class": "helper_only_advisory_non_process",
     "claim_boundary": "does_not_prove_mixed_client_process_soak",
     "implementation": "rust",

--- a/scripts/devnet/test_rust_skeleton_fixtures.sh
+++ b/scripts/devnet/test_rust_skeleton_fixtures.sh
@@ -29,9 +29,9 @@ command -v python3 >/dev/null 2>&1 || { echo "python3 is required" >&2; exit 1; 
 [[ -r "${REJECTED_FIXTURE}" ]] || { echo "rejected fixture unreadable: ${REJECTED_FIXTURE}" >&2; exit 1; }
 [[ -r "${VALID_MIXED_FIXTURE}" ]] || { echo "valid mixed fixture unreadable: ${VALID_MIXED_FIXTURE}" >&2; exit 1; }
 
-TMP_PARENT="${TMPDIR:-/tmp}"
-TMP_PARENT="$(cd -- "${TMP_PARENT}" && pwd -P)" || { echo "failed to canonicalize TMPDIR=${TMP_PARENT}" >&2; exit 1; }
-TMP_ROOT="$(mktemp -d "${TMP_PARENT%/}/rubin-rust-skeleton-fixtures.XXXXXX")"
+TMP_PARENT_RAW="${TMPDIR:-/tmp}"
+TMP_PARENT="$(cd -- "${TMP_PARENT_RAW}" && pwd -P)" || { echo "failed to canonicalize TMPDIR=${TMP_PARENT_RAW}" >&2; exit 1; }
+TMP_ROOT="$(mktemp -d "${TMP_PARENT%/}/rubin-rust-skeleton-fixtures.XXXXXX")" || { echo "failed to create fixture temp dir under ${TMP_PARENT}" >&2; exit 1; }
 cleanup() {
   rm -rf -- "${TMP_ROOT}"
 }

--- a/scripts/devnet/test_rust_skeleton_fixtures.sh
+++ b/scripts/devnet/test_rust_skeleton_fixtures.sh
@@ -249,10 +249,10 @@ if [[ "${REJECTED_RC}" == "0" ]]; then
 fi
 
 for needle in \
-  "helper_only_advisory_non_process" \
-  "is not one of ['mixed_client_process_soak']"; do
+  "evidence_type:" \
+  "helper_only_advisory_non_process"; do
   if [[ "${REJECTED_OUTPUT}" != *"${needle}"* ]]; then
-    echo "FAIL: helper-only rejection missing expected schema-boundary text: ${needle}" >&2
+    echo "FAIL: helper-only rejection missing expected stable schema-boundary marker: ${needle}" >&2
     echo "actual output:" >&2
     printf '%s\n' "${REJECTED_OUTPUT}" >&2
     exit 1

--- a/scripts/devnet/test_rust_skeleton_fixtures.sh
+++ b/scripts/devnet/test_rust_skeleton_fixtures.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
-# test_rust_skeleton_fixtures.sh — RUB-27 fixtures plus RUB-25 gate tests.
+# test_rust_skeleton_fixtures.sh — RUB-27 helper marker plus RUB-25 gate tests.
 #
-# Wires the committed Rust skeleton fixtures to the RUB-24 validator
-# and exercises the RUB-25 mixed-client process evidence gate through
-# fixture-driven pass/fail boundaries.
+# Wires the committed Rust helper/advisory marker fixtures to the RUB-24
+# validator and exercises the RUB-25 mixed-client process evidence gate
+# through fixture-driven pass/fail boundaries.
 #
-# This does not prove live Go/Rust runtime behavior; it anchors schema
-# and shell-gate acceptance claims to reproducible fixture exit codes.
+# This does not prove live Go/Rust runtime behavior; it anchors schema,
+# label-boundary, and shell-gate acceptance claims to reproducible
+# fixture exit codes.
 
 set -euo pipefail
 
@@ -14,7 +15,8 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 DEV_ENV="${REPO_ROOT}/scripts/dev-env.sh"
 VALIDATOR="${REPO_ROOT}/scripts/devnet/validate_mixed_client_evidence.py"
 GATE_SCRIPT="${REPO_ROOT}/scripts/devnet-rust-binary-soak.sh"
-VALID_FIXTURE="${REPO_ROOT}/scripts/devnet/testdata/rust_skeleton_fail_evidence_valid.json"
+HELPER_MARKER_FIXTURE="${REPO_ROOT}/scripts/devnet/testdata/rust_helper_advisory_non_process_marker.json"
+HELPER_FAILED_MARKER_FIXTURE="${REPO_ROOT}/scripts/devnet/testdata/rust_helper_advisory_failed_launch_marker.json"
 REJECTED_FIXTURE="${REPO_ROOT}/scripts/devnet/testdata/rust_skeleton_helper_only_rejected.json"
 VALID_MIXED_FIXTURE="${REPO_ROOT}/scripts/devnet/testdata/valid_process_mixed.json"
 
@@ -22,11 +24,14 @@ command -v python3 >/dev/null 2>&1 || { echo "python3 is required" >&2; exit 1; 
 [[ -x "${DEV_ENV}" ]] || { echo "dev-env wrapper missing or non-executable: ${DEV_ENV}" >&2; exit 1; }
 [[ -r "${VALIDATOR}" ]] || { echo "validator unreadable: ${VALIDATOR}" >&2; exit 1; }
 [[ -x "${GATE_SCRIPT}" ]] || { echo "gate script missing or non-executable: ${GATE_SCRIPT}" >&2; exit 1; }
-[[ -r "${VALID_FIXTURE}" ]] || { echo "valid fixture unreadable: ${VALID_FIXTURE}" >&2; exit 1; }
+[[ -r "${HELPER_MARKER_FIXTURE}" ]] || { echo "helper marker fixture unreadable: ${HELPER_MARKER_FIXTURE}" >&2; exit 1; }
+[[ -r "${HELPER_FAILED_MARKER_FIXTURE}" ]] || { echo "failed helper marker fixture unreadable: ${HELPER_FAILED_MARKER_FIXTURE}" >&2; exit 1; }
 [[ -r "${REJECTED_FIXTURE}" ]] || { echo "rejected fixture unreadable: ${REJECTED_FIXTURE}" >&2; exit 1; }
 [[ -r "${VALID_MIXED_FIXTURE}" ]] || { echo "valid mixed fixture unreadable: ${VALID_MIXED_FIXTURE}" >&2; exit 1; }
 
-TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/rubin-rust-skeleton-fixtures.XXXXXX")"
+TMP_PARENT="${TMPDIR:-/tmp}"
+TMP_PARENT="$(cd -- "${TMP_PARENT}" && pwd -P)" || { echo "failed to canonicalize TMPDIR=${TMP_PARENT}" >&2; exit 1; }
+TMP_ROOT="$(mktemp -d "${TMP_PARENT%/}/rubin-rust-skeleton-fixtures.XXXXXX")"
 cleanup() {
   rm -rf -- "${TMP_ROOT}"
 }
@@ -50,6 +55,34 @@ run_validator() {
 
 run_gate() {
   "${GATE_SCRIPT}" --check-evidence "$@"
+}
+
+assert_helper_marker_labels() {
+  local fixture="$1"
+  python3 - "${fixture}" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+with open(path, encoding="utf-8") as f:
+    data = json.load(f)
+
+errors = []
+if data.get("scenario") != "rust_helper_advisory_non_process_marker":
+    errors.append(f"scenario is not helper/advisory/non-process: {data.get('scenario')!r}")
+if data.get("verdict") != "FAIL":
+    errors.append(f"helper marker verdict must be FAIL: {data.get('verdict')!r}")
+reason = data.get("failure_reason")
+required = ["helper-only/advisory", "non-process", "full mixed-client process", "RUB-21", "RUB-22", "RUB-23"]
+if not isinstance(reason, str) or any(token not in reason for token in required):
+    errors.append(f"failure_reason does not pin helper/process boundary: {reason!r}")
+if data.get("evidence_type") != "mixed_client_process_soak":
+    errors.append("schema marker must keep the RUB-24 process enum so the validator can check its shape")
+if errors:
+    for err in errors:
+        print(f"FAIL: {err}", file=sys.stderr)
+    sys.exit(1)
+PY
 }
 
 require_output_contains() {
@@ -179,20 +212,25 @@ PY
 
 run_fips_preflight_before_captured_dev_env
 
-# Acceptance leg 1: validator MUST accept the well-formed FAIL skeleton.
-echo "test_rust_skeleton_fixtures: valid fixture must validate"
-if ! run_validator "${VALID_FIXTURE}"; then
-  echo "FAIL: validator rejected the valid skeleton fixture" >&2
+# Acceptance leg 1: validator MUST accept the well-formed helper/advisory
+# FAIL schema marker, and label checks MUST pin it as non-process.
+echo "test_rust_skeleton_fixtures: helper/advisory marker must validate and stay labeled"
+assert_helper_marker_labels "${HELPER_MARKER_FIXTURE}"
+if ! run_validator "${HELPER_MARKER_FIXTURE}"; then
+  echo "FAIL: validator rejected the helper/advisory schema marker" >&2
+  exit 1
+fi
+assert_helper_marker_labels "${HELPER_FAILED_MARKER_FIXTURE}"
+if ! run_validator "${HELPER_FAILED_MARKER_FIXTURE}"; then
+  echo "FAIL: validator rejected the failed helper/advisory schema marker" >&2
   exit 1
 fi
 
-# Acceptance leg 2: validator MUST reject the helper-only shape and
-# surface the three expected cross-field rejections (missing 2nd
-# participant, missing go counterpart impl, tx_path required for PASS).
-# Pinning to specific cross-field messages — not just non-zero exit —
-# anchors the acceptance to the rejection class, not to a generic
-# schema-shape failure that some future schema relaxation could mask.
-echo "test_rust_skeleton_fixtures: helper-only fixture must be rejected"
+# Acceptance leg 2: validator MUST reject an actual helper-only label as
+# outside the mixed_client_process_soak process schema. This pins the
+# process/helper class boundary at the schema floor instead of relying on
+# later cross-field failures under a stale process label.
+echo "test_rust_skeleton_fixtures: helper-only label must be rejected"
 # Single validator invocation captures both stderr+stdout and exit code
 # (P2 finding from PR #1510 review): the previous double-invocation
 # could mask a behavior change between runs. The if/else form keeps
@@ -211,11 +249,10 @@ if [[ "${REJECTED_RC}" == "0" ]]; then
 fi
 
 for needle in \
-  "requires at least 2 participants" \
-  "at least one implementation=go and one implementation=rust" \
-  "tx_path: required for evidence_type=mixed_client_process_soak with verdict=PASS"; do
+  "helper_only_advisory_non_process" \
+  "is not one of ['mixed_client_process_soak']"; do
   if [[ "${REJECTED_OUTPUT}" != *"${needle}"* ]]; then
-    echo "FAIL: helper-only rejection missing expected cross-field message: ${needle}" >&2
+    echo "FAIL: helper-only rejection missing expected schema-boundary text: ${needle}" >&2
     echo "actual output:" >&2
     printf '%s\n' "${REJECTED_OUTPUT}" >&2
     exit 1
@@ -257,12 +294,12 @@ expect_gate_fail "${EMPTY_FIXTURE}" "empty artifact" "artifact empty"
 expect_gate_fail "${MALFORMED_FIXTURE}" "malformed artifact" "validator rejected artifact"
 expect_gate_fail "${WRONG_ROOT_FIXTURE}" "wrong root artifact" "validator rejected artifact"
 expect_gate_fail "${STDOUT_CONTAMINATED_FIXTURE}" "stdout-contaminated artifact" "validator rejected artifact"
-expect_gate_fail "${REJECTED_FIXTURE}" "helper-only artifact" "validator rejected artifact"
-expect_gate_fail "${VALID_FIXTURE}" "no-data/failure artifact" "verdict is not PASS"
+expect_gate_fail "${REJECTED_FIXTURE}" "helper-only label artifact" "validator rejected artifact"
+expect_gate_fail "${HELPER_MARKER_FIXTURE}" "helper/advisory schema marker" "verdict is not PASS"
 expect_gate_fail "${SAME_CLIENT_FIXTURE}" "same-client selected path" "requires observer implementation to differ"
 expect_gate_fail "${UNSELECTED_HELPER_FIXTURE}" "unselected helper-only participant" "participant lacks real process evidence"
 expect_gate_fail "${SELECTED_DUP_ENDPOINT_FIXTURE}" "selected duplicate endpoint" "duplicate participant endpoint"
 expect_gate_fail "${UNSELECTED_DUP_ENDPOINT_FIXTURE}" "unselected duplicate endpoint" "duplicate participant endpoint"
 expect_gate_fail "${PASS_FAILURE_REASON_FIXTURE}" "PASS with failure_reason" "failure_reason is not allowed"
 
-echo "PASS: rust skeleton fixtures and mixed-client gate boundaries confirmed"
+echo "PASS: rust helper/advisory marker and mixed-client gate boundaries confirmed"

--- a/scripts/devnet/testdata/rust_helper_advisory_failed_launch_marker.json
+++ b/scripts/devnet/testdata/rust_helper_advisory_failed_launch_marker.json
@@ -1,0 +1,17 @@
+{
+  "evidence_type": "mixed_client_process_soak",
+  "failure_reason": "helper-only/advisory non-process Rust launch marker; full mixed-client process tx_path proof is RUB-21/RUB-22/RUB-23; launch_failure=Rust helper/advisory /get_tip RPC was not reachable within 30s",
+  "participants": [
+    {
+      "implementation": "rust",
+      "name": "node-rust"
+    },
+    {
+      "implementation": "go",
+      "name": "node-go"
+    }
+  ],
+  "scenario": "rust_helper_advisory_non_process_marker",
+  "schema_version": "rubin-mixed-client-devnet-evidence-v1",
+  "verdict": "FAIL"
+}

--- a/scripts/devnet/testdata/rust_helper_advisory_non_process_marker.json
+++ b/scripts/devnet/testdata/rust_helper_advisory_non_process_marker.json
@@ -1,6 +1,6 @@
 {
   "evidence_type": "mixed_client_process_soak",
-  "failure_reason": "rust-only skeleton run; cross-implementation tx_path proof is RUB-21/22/23",
+  "failure_reason": "helper-only/advisory non-process Rust launch marker; full mixed-client process tx_path proof is RUB-21/RUB-22/RUB-23",
   "participants": [
     {
       "endpoint": "127.0.0.1:54321",
@@ -13,7 +13,7 @@
       "name": "node-go"
     }
   ],
-  "scenario": "rust_binary_soak_skeleton",
+  "scenario": "rust_helper_advisory_non_process_marker",
   "schema_version": "rubin-mixed-client-devnet-evidence-v1",
   "verdict": "FAIL"
 }

--- a/scripts/devnet/testdata/rust_skeleton_helper_only_rejected.json
+++ b/scripts/devnet/testdata/rust_skeleton_helper_only_rejected.json
@@ -1,12 +1,12 @@
 {
-  "evidence_type": "mixed_client_process_soak",
+  "evidence_type": "helper_only_advisory_non_process",
   "participants": [
     {
       "implementation": "rust",
       "name": "node-rust"
     }
   ],
-  "scenario": "rust_only_helper_label_rejected",
+  "scenario": "rust_only_helper_advisory_non_process",
   "schema_version": "rubin-mixed-client-devnet-evidence-v1",
   "verdict": "PASS"
 }


### PR DESCRIPTION
## Summary
- Relabels the Rust helper launch artifact as helper-only/advisory non-process evidence.
- Keeps schema-shape validation separate from full mixed-client process-soak PASS evidence.
- Adds a failed-launch helper marker fixture and pins helper/process boundary checks in the fixture test.

## Tests
- scripts/devnet/test_rust_skeleton_fixtures.sh
- Shell syntax and harness lint gates passed.
- Codacy coverage preflight passed: variation +0.00%, diff coverage 100.00%.