### PR TITLE
RUB-225: wire Rust production shutdown signals

### DIFF
--- a/clients/rust/Cargo.lock
+++ b/clients/rust/Cargo.lock
@@ -265,6 +265,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -580,6 +590,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3",
+ "signal-hook",
  "syn",
 ]
 
@@ -667,6 +678,26 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "syn"

--- a/clients/rust/crates/rubin-node/Cargo.toml
+++ b/clients/rust/crates/rubin-node/Cargo.toml
@@ -34,6 +34,7 @@ harness = false
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin_include)'] }
 
 [package.metadata.cargo-machete]
-# RUB-234/RUB-225 intentionally stage cross-platform signal dependencies before
-# platform-specific shutdown wiring consumes them.
+# RUB-225 uses platform-specific signal dependencies behind cfg gates. Host-only
+# cargo-machete runs can miss the inactive cfg arm, so keep both explicitly
+# ignored while the production lifecycle owns the cross-platform stop contract.
 ignored = ["ctrlc", "signal-hook"]

--- a/clients/rust/crates/rubin-node/Cargo.toml
+++ b/clients/rust/crates/rubin-node/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-ctrlc = { version = "3.5.2", features = ["termination"] }
+ctrlc = "3.5.2"
 hex = "0.4"
 num-bigint = "0.4"
 serde = { version = "1.0", features = ["derive"] }
@@ -12,6 +12,9 @@ serde_json = "1.0"
 sha3 = "0.10"
 
 rubin-consensus = { path = "../rubin-consensus" }
+
+[target.'cfg(unix)'.dependencies]
+signal-hook = "0.3"
 
 [dev-dependencies]
 criterion = "0.5"
@@ -31,6 +34,6 @@ harness = false
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin_include)'] }
 
 [package.metadata.cargo-machete]
-# RUB-234 intentionally stages the cross-platform signal dependency before the
-# RUB-225 runtime shutdown wiring consumes it.
-ignored = ["ctrlc"]
+# RUB-234/RUB-225 intentionally stage cross-platform signal dependencies before
+# platform-specific shutdown wiring consumes them.
+ignored = ["ctrlc", "signal-hook"]

--- a/clients/rust/crates/rubin-node/src/devnet_rpc.rs
+++ b/clients/rust/crates/rubin-node/src/devnet_rpc.rs
@@ -6368,6 +6368,38 @@ mod tests {
     }
 
     #[test]
+    fn ready_endpoint_attach_shutdown_signal_wires_public_readiness_path() {
+        let shutdown_requested = Arc::new(AtomicBool::new(true));
+        let (state, dir) = build_state(false);
+        let state = super::attach_shutdown_signal_to_devnet_rpc_state(
+            state,
+            Arc::clone(&shutdown_requested),
+        );
+
+        let err = match start_devnet_rpc_server("127.0.0.1:0", state.clone()) {
+            Ok(_) => panic!("attached shutdown signal must prevent ready startup"),
+            Err(err) => err,
+        };
+
+        assert!(
+            err.contains("readiness transition failed"),
+            "unexpected startup error: {err}"
+        );
+        let response = route_request(
+            &state,
+            HttpRequest {
+                method: "GET".to_string(),
+                target: "/ready".to_string(),
+                body: Vec::new(),
+            },
+        );
+        assert_eq!(response.status, 503);
+        let body: Value = serde_json::from_slice(&response.body).expect("ready attach json");
+        assert_eq!(body["ready"], serde_json::json!(false));
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
     fn ready_endpoint_rejects_ready_startup_after_shutdown_signal() {
         let shutdown_requested = Arc::new(AtomicBool::new(true));
         let (mut state, dir) = build_state(false);
@@ -6586,6 +6618,21 @@ mod tests {
         let body_json: Value = serde_json::from_slice(body).expect("body json");
         assert_eq!(body_json["error"], serde_json::json!("GET required"));
         fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn readiness_gate_poison_reports_not_ready() {
+        let gate = Arc::new(super::ReadinessGate::default());
+        let gate_for_panic = Arc::clone(&gate);
+        let _ = std::panic::catch_unwind(move || {
+            let _guard = gate_for_panic.state.lock().expect("lock readiness");
+            panic!("poison readiness");
+        });
+
+        assert!(
+            !gate.is_ready(),
+            "poisoned readiness mutex must fail closed as not ready"
+        );
     }
 
     /// RUB-10 / GitHub #1151: `ReadinessGate::try_mark_ready_on_startup`

--- a/clients/rust/crates/rubin-node/src/devnet_rpc.rs
+++ b/clients/rust/crates/rubin-node/src/devnet_rpc.rs
@@ -66,8 +66,8 @@ pub struct DevnetRPCState {
     /// stamp), `Ready` (post-stamp), and `Shutdown`. The `Shutdown`
     /// state is reachable via `RunningDevnetRPCServer::close`, `Drop`,
     /// and the production `clients/rust/crates/rubin-node/src/main.rs`
-    /// stop-signal lifecycle, which routes SIGINT/SIGTERM through
-    /// `close()` before owned runtime services are torn down. Tests
+    /// stop-signal lifecycle, which routes the configured process stop
+    /// signal set through `close()` before owned runtime services are torn down. Tests
     /// exercise all three states (`ready_endpoint_reports_503_after_shutdown_sticky`
     /// drives the gate through `Shutdown` via `RunningDevnetRPCServer::close`).
     readiness: Arc<ReadinessGate>,
@@ -138,10 +138,12 @@ pub struct RunningDevnetRPCServer {
 ///       `/ready`);
 ///     * the lifecycle context has not been canceled by an external
 ///       signal before production lifecycle shutdown starts. Rust
-///       production `main.rs` wires the SIGINT/SIGTERM stop flag into
-///       this gate, so a stop observed before or during RPC startup
-///       stamps `Shutdown` and `/ready` reports 503 before
-///       `RunningDevnetRPCServer::close` tears the listener down.
+///       production `main.rs` wires the process stop flag into this
+///       gate. With `ctrlc`'s `termination` feature enabled, that flag
+///       is set for Ctrl-C/SIGINT and for Unix SIGTERM/SIGHUP, so a
+///       stop observed before or during RPC startup stamps `Shutdown`
+///       and `/ready` reports 503 before `RunningDevnetRPCServer::close`
+///       tears the listener down.
 ///
 ///   The mempool/miner/sync absence rows above are explicitly the
 ///   `go_rust_parity_matrix` row "mempool/miner/sync prerequisites

--- a/clients/rust/crates/rubin-node/src/devnet_rpc.rs
+++ b/clients/rust/crates/rubin-node/src/devnet_rpc.rs
@@ -139,11 +139,11 @@ pub struct RunningDevnetRPCServer {
 ///     * the lifecycle context has not been canceled by an external
 ///       signal before production lifecycle shutdown starts. Rust
 ///       production `main.rs` wires the process stop flag into this
-///       gate. With `ctrlc`'s `termination` feature enabled, that flag
-///       is set for Ctrl-C/SIGINT and for Unix SIGTERM/SIGHUP, so a
-///       stop observed before or during RPC startup stamps `Shutdown`
-///       and `/ready` reports 503 before `RunningDevnetRPCServer::close`
-///       tears the listener down.
+///       gate for the Go-aligned graceful-stop set: SIGINT and SIGTERM
+///       on Unix, and Ctrl-C on non-Unix platforms. SIGHUP is not part
+///       of the graceful-stop contract. A stop observed before or during
+///       RPC startup stamps `Shutdown` and `/ready` reports 503 before
+///       `RunningDevnetRPCServer::close` tears the listener down.
 ///
 ///   The mempool/miner/sync absence rows above are explicitly the
 ///   `go_rust_parity_matrix` row "mempool/miner/sync prerequisites

--- a/clients/rust/crates/rubin-node/src/devnet_rpc.rs
+++ b/clients/rust/crates/rubin-node/src/devnet_rpc.rs
@@ -61,22 +61,15 @@ pub struct DevnetRPCState {
     /// `NotReady` -> `Ready` (one-shot via `try_mark_ready_on_startup`)
     /// -> `Shutdown` (sticky terminal, via `mark_shutdown`).
     ///
-    /// Production Rust delivers two states observable to mixed-client
-    /// devnet evidence consumers today: `NotReady` (pre-`start_devnet_rpc_server`
-    /// stamp) and `Ready` (post-stamp). The third state (`Shutdown`)
-    /// is reachable via `RunningDevnetRPCServer::close` and `Drop`
-    /// (which fire on normal `RunningDevnetRPCServer` lifetime end and
-    /// stack unwinding), but `clients/rust/crates/rubin-node/src/main.rs`
-    /// installs no SIGINT/SIGTERM handler, so a signal-driven kill
-    /// terminates the process before `close()` runs and consumers see
-    /// connection-refused rather than the 503+`{"ready":false}` envelope.
-    /// Adding a signal handler that drives `mark_shutdown` is a
-    /// runtime-lifecycle change deliberately excluded from RUB-10 by
-    /// `class_change_stop_rule`; it is in scope for graceful-shutdown
-    /// follow-up work (RUB-21/RUB-22/RUB-23 own process-soak proof
-    /// per the issue's `non_goals`). Tests exercise all three states
-    /// (`ready_endpoint_reports_503_after_shutdown_sticky` drives the
-    /// gate through `Shutdown` via `RunningDevnetRPCServer::close`).
+    /// Production Rust delivers all three states observable to mixed-client
+    /// devnet evidence consumers: `NotReady` (pre-`start_devnet_rpc_server`
+    /// stamp), `Ready` (post-stamp), and `Shutdown`. The `Shutdown`
+    /// state is reachable via `RunningDevnetRPCServer::close`, `Drop`,
+    /// and the production `clients/rust/crates/rubin-node/src/main.rs`
+    /// stop-signal lifecycle, which routes SIGINT/SIGTERM through
+    /// `close()` before owned runtime services are torn down. Tests
+    /// exercise all three states (`ready_endpoint_reports_503_after_shutdown_sticky`
+    /// drives the gate through `Shutdown` via `RunningDevnetRPCServer::close`).
     readiness: Arc<ReadinessGate>,
 }
 
@@ -136,20 +129,19 @@ pub struct RunningDevnetRPCServer {
 ///   gate without binding a listener, and a code change that moved
 ///   the production stamp pre-bind would silently widen the
 ///   readiness window). It does NOT claim:
-///     * mempool admit-path is wired or fault-free (RUB-53 / #1339
-///       tracker is open; mempool policy parity slice has not landed
-///       and `/ready` does not gate on its readiness here);
+///     * mempool admit-path is fault-free (`/ready` does not gate on
+///       mempool policy or admission health here);
 ///     * miner is configured (live mining is opt-in via
 ///       `live_mining_cfg`; absence does not flip the gate to false);
 ///     * sync engine has reached chain tip or has any peer
 ///       (`PeerManager` peer count is observable via `/peers`, not
 ///       `/ready`);
 ///     * the lifecycle context has not been canceled by an external
-///       signal (Rust `main.rs` does not install SIGINT/SIGTERM
-///       handlers, so a signal-driven kill skips `mark_shutdown` and
-///       the gate stays `Ready` until process exit terminates the
-///       listener — the documented Rust-vs-Go divergence preserved
-///       from RUB-10).
+///       signal before production lifecycle shutdown starts. Rust
+///       production `main.rs` routes SIGINT/SIGTERM through
+///       `RunningDevnetRPCServer::close`, which stamps `Shutdown`; the
+///       gate itself remains a state latch and does not own signal
+///       handling.
 ///
 ///   The mempool/miner/sync absence rows above are explicitly the
 ///   `go_rust_parity_matrix` row "mempool/miner/sync prerequisites

--- a/clients/rust/crates/rubin-node/src/devnet_rpc.rs
+++ b/clients/rust/crates/rubin-node/src/devnet_rpc.rs
@@ -138,10 +138,10 @@ pub struct RunningDevnetRPCServer {
 ///       `/ready`);
 ///     * the lifecycle context has not been canceled by an external
 ///       signal before production lifecycle shutdown starts. Rust
-///       production `main.rs` routes SIGINT/SIGTERM through
-///       `RunningDevnetRPCServer::close`, which stamps `Shutdown`; the
-///       gate itself remains a state latch and does not own signal
-///       handling.
+///       production `main.rs` wires the SIGINT/SIGTERM stop flag into
+///       this gate, so a stop observed before or during RPC startup
+///       stamps `Shutdown` and `/ready` reports 503 before
+///       `RunningDevnetRPCServer::close` tears the listener down.
 ///
 ///   The mempool/miner/sync absence rows above are explicitly the
 ///   `go_rust_parity_matrix` row "mempool/miner/sync prerequisites
@@ -197,9 +197,9 @@ enum ReadyState {
     Shutdown,
 }
 
-#[derive(Default)]
 struct ReadinessGate {
     state: Mutex<ReadyStateCell>,
+    shutdown_requested: Option<Arc<AtomicBool>>,
 }
 
 struct ReadyStateCell(ReadyState);
@@ -210,7 +210,29 @@ impl Default for ReadyStateCell {
     }
 }
 
+impl Default for ReadinessGate {
+    fn default() -> Self {
+        Self {
+            state: Mutex::new(ReadyStateCell::default()),
+            shutdown_requested: None,
+        }
+    }
+}
+
 impl ReadinessGate {
+    fn with_shutdown_requested(shutdown_requested: Arc<AtomicBool>) -> Self {
+        Self {
+            state: Mutex::new(ReadyStateCell::default()),
+            shutdown_requested: Some(shutdown_requested),
+        }
+    }
+
+    fn shutdown_requested(&self) -> bool {
+        self.shutdown_requested
+            .as_ref()
+            .is_some_and(|flag| flag.load(Ordering::SeqCst))
+    }
+
     /// RUB-10 / GitHub #1151: boot-time `NotReady` -> `Ready` transition.
     /// Mirrors Go `readinessGate.TryMarkReadyOnStartup`
     /// (`clients/go/cmd/rubin-node/http_rpc.go:166-180`). Returns true iff the gate WAS `NotReady`
@@ -219,22 +241,21 @@ impl ReadinessGate {
     /// post-shutdown re-readiness is forbidden by design — operators
     /// must restart the node, matching Go's contract).
     ///
-    /// Documented divergence vs Go (matches the divergence note on
-    /// `is_ready` below): Go's implementation calls
-    /// `observeShutdownLocked` first and can return false (and stamp
-    /// Shutdown) when a wired `shutdownCtx` is observed canceled even
-    /// while state is still `NotReady`. Rust's RPC server exposes no
-    /// equivalent context cancellation channel, so the only paths
-    /// into `Shutdown` are the explicit `mark_shutdown()` call (from
-    /// `RunningDevnetRPCServer::close` and `Drop`). A poisoned mutex
-    /// is treated as not-ready (the function returns early without
-    /// flipping the cell value) — defense-in-depth so a panicked
-    /// operation that left the gate inconsistent cannot quietly
-    /// succeed here.
+    /// Mirrors Go's `observeShutdownLocked` behavior for production
+    /// signal shutdown when this gate has a wired stop flag: a
+    /// pre-requested stop stamps `Shutdown` and prevents the startup
+    /// ready transition. A poisoned mutex is treated as not-ready (the
+    /// function returns early without flipping the cell value) —
+    /// defense-in-depth so a panicked operation that left the gate
+    /// inconsistent cannot quietly succeed here.
     fn try_mark_ready_on_startup(&self) -> bool {
         let Ok(mut cell) = self.state.lock() else {
             return false;
         };
+        if self.shutdown_requested() {
+            cell.0 = ReadyState::Shutdown;
+            return false;
+        }
         if cell.0 != ReadyState::NotReady {
             return false;
         }
@@ -254,19 +275,22 @@ impl ReadinessGate {
     }
 
     /// RUB-10 / GitHub #1151: returns true iff the gate is currently in
-    /// the `Ready` state. Mirrors Go `readinessGate.IsReady`
-    /// (`clients/go/cmd/rubin-node/http_rpc.go:198-208`) without the `shutdownCtx` cancellation
-    /// observation hook — Rust's RPC server does not expose a context
-    /// cancellation channel, so the only paths into `Shutdown` are the
-    /// explicit `mark_shutdown()` call from `RunningDevnetRPCServer::close`
-    /// and `Drop`. A poisoned mutex is treated as not-ready
-    /// (defense-in-depth: a panicked operation that left the gate in
-    /// inconsistent state defaults to reporting not-ready).
+    /// the `Ready` state and no wired production stop signal has been
+    /// observed. Mirrors Go `readinessGate.IsReady`
+    /// (`clients/go/cmd/rubin-node/http_rpc.go:198-208`) including
+    /// cancellation observation when this gate has a wired stop flag.
+    /// A poisoned mutex is treated as not-ready (defense-in-depth: a
+    /// panicked operation that left the gate in inconsistent state
+    /// defaults to reporting not-ready).
     fn is_ready(&self) -> bool {
-        self.state
-            .lock()
-            .map(|cell| cell.0 == ReadyState::Ready)
-            .unwrap_or(false)
+        let Ok(mut cell) = self.state.lock() else {
+            return false;
+        };
+        if self.shutdown_requested() {
+            cell.0 = ReadyState::Shutdown;
+            return false;
+        }
+        cell.0 == ReadyState::Ready
     }
 }
 
@@ -508,6 +532,14 @@ pub fn new_devnet_rpc_state_with_tx_pool(
         // serving requests.
         readiness: Arc::new(ReadinessGate::default()),
     }
+}
+
+pub fn attach_shutdown_signal_to_devnet_rpc_state(
+    mut state: DevnetRPCState,
+    shutdown_requested: Arc<AtomicBool>,
+) -> DevnetRPCState {
+    state.readiness = Arc::new(ReadinessGate::with_shutdown_requested(shutdown_requested));
+    state
 }
 
 pub fn new_shared_runtime_tx_pool(sync_engine: &Arc<Mutex<SyncEngine>>) -> Arc<Mutex<TxPool>> {
@@ -6298,6 +6330,70 @@ mod tests {
         let body: Value = serde_json::from_slice(&response.body).expect("ready 200 json");
         assert_eq!(body["ready"], serde_json::json!(true));
         drop(server);
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn ready_endpoint_reports_503_after_shutdown_signal_before_close() {
+        let shutdown_requested = Arc::new(AtomicBool::new(false));
+        let (mut state, dir) = build_state(false);
+        state.readiness = Arc::new(super::ReadinessGate::with_shutdown_requested(Arc::clone(
+            &shutdown_requested,
+        )));
+        let server =
+            start_devnet_rpc_server("127.0.0.1:0", state.clone()).expect("start_devnet_rpc_server");
+        assert!(state.readiness.is_ready());
+
+        shutdown_requested.store(true, Ordering::SeqCst);
+        let response = route_request(
+            &state,
+            HttpRequest {
+                method: "GET".to_string(),
+                target: "/ready".to_string(),
+                body: Vec::new(),
+            },
+        );
+
+        assert_eq!(response.status, 503);
+        let body: Value = serde_json::from_slice(&response.body).expect("ready signal json");
+        assert_eq!(body["ready"], serde_json::json!(false));
+        assert!(
+            !state.readiness.is_ready(),
+            "observed shutdown signal must stamp readiness off before close"
+        );
+        drop(server);
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn ready_endpoint_rejects_ready_startup_after_shutdown_signal() {
+        let shutdown_requested = Arc::new(AtomicBool::new(true));
+        let (mut state, dir) = build_state(false);
+        state.readiness = Arc::new(super::ReadinessGate::with_shutdown_requested(
+            shutdown_requested,
+        ));
+
+        let err = match start_devnet_rpc_server("127.0.0.1:0", state.clone()) {
+            Ok(_) => panic!("shutdown-requested startup must not stamp ready"),
+            Err(err) => err,
+        };
+
+        assert!(
+            err.contains("readiness transition failed"),
+            "unexpected startup error: {err}"
+        );
+        assert!(!state.readiness.is_ready());
+        let response = route_request(
+            &state,
+            HttpRequest {
+                method: "GET".to_string(),
+                target: "/ready".to_string(),
+                body: Vec::new(),
+            },
+        );
+        assert_eq!(response.status, 503);
+        let body: Value = serde_json::from_slice(&response.body).expect("ready signal json");
+        assert_eq!(body["ready"], serde_json::json!(false));
         fs::remove_dir_all(dir).expect("cleanup");
     }
 

--- a/clients/rust/crates/rubin-node/src/devnet_rpc.rs
+++ b/clients/rust/crates/rubin-node/src/devnet_rpc.rs
@@ -36,6 +36,8 @@ const MAX_BODY_BYTES: usize = 2 * 1024 * 1024;
 const MAX_CHUNK_LINE_BYTES: usize = 4096;
 const MAX_CONCURRENT_RPC_CONNS: usize = 8;
 const RPC_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+pub const RPC_READINESS_TRANSITION_FAILED: &str =
+    "rpc readiness transition failed: server is already ready or shutdown";
 
 pub type AnnounceTxFn =
     Arc<dyn Fn(&[u8], crate::txpool::RelayTxMetadata) -> Result<(), String> + Send + Sync>;
@@ -598,9 +600,7 @@ pub fn start_devnet_rpc_server(
     // `mark_shutdown` on close.
     let readiness = Arc::clone(&state.readiness);
     if !readiness.try_mark_ready_on_startup() {
-        return Err(
-            "rpc readiness transition failed: server is already ready or shutdown".to_string(),
-        );
+        return Err(RPC_READINESS_TRANSITION_FAILED.to_string());
     }
     let join = thread::Builder::new()
         .name("rubin-devnet-rpc".to_string())

--- a/clients/rust/crates/rubin-node/src/main.rs
+++ b/clients/rust/crates/rubin-node/src/main.rs
@@ -10,6 +10,7 @@ use rubin_consensus::{
     canonical_rotation_network_name_normalized, normalized_rotation_network_name,
     SUPPORTED_ROTATION_NETWORK_NAMES_CSV,
 };
+use rubin_node::devnet_rpc::attach_shutdown_signal_to_devnet_rpc_state;
 use rubin_node::{
     block_store_path, chain_state_path, default_peer_runtime_config, default_sync_config,
     load_chain_state, load_genesis_config, new_devnet_rpc_state_with_tx_pool,
@@ -494,14 +495,17 @@ fn run(args: &[String], stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
             rubin_node::tx_relay::announce_block(block_bytes, &relay_state, &pm, &local, &pw)
         }))
     };
-    let state = new_devnet_rpc_state_with_tx_pool(
-        Arc::clone(&sync_engine),
-        Some(block_store),
-        Arc::clone(&tx_pool),
-        Arc::clone(&peer_manager),
-        announce_tx,
-        announce_block,
-        live_mining_cfg,
+    let state = attach_shutdown_signal_to_devnet_rpc_state(
+        new_devnet_rpc_state_with_tx_pool(
+            Arc::clone(&sync_engine),
+            Some(block_store),
+            Arc::clone(&tx_pool),
+            Arc::clone(&peer_manager),
+            announce_tx,
+            announce_block,
+            live_mining_cfg,
+        ),
+        stop_signal.shutdown_requested_flag(),
     );
     if !cfg.rpc_bind_addr.trim().is_empty() {
         server = match start_devnet_rpc_server(&cfg.rpc_bind_addr, state) {
@@ -569,6 +573,12 @@ impl StopSource for StopSignal {
             return;
         }
         let _ = self.wake_rx.recv();
+    }
+}
+
+impl StopSignal {
+    fn shutdown_requested_flag(&self) -> Arc<AtomicBool> {
+        Arc::clone(&self.requested)
     }
 }
 

--- a/clients/rust/crates/rubin-node/src/main.rs
+++ b/clients/rust/crates/rubin-node/src/main.rs
@@ -2,9 +2,9 @@ use std::env;
 use std::fs;
 use std::io::{self, Write};
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
-use std::thread;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{mpsc, Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use rubin_consensus::{
     canonical_rotation_network_name_normalized, normalized_rotation_network_name,
@@ -16,7 +16,7 @@ use rubin_node::{
     new_shared_runtime_tx_pool, parse_mine_address_arg, reconcile_chain_state_with_block_store,
     rpc_bind_host_is_loopback, start_devnet_rpc_server, start_node_p2p_service,
     validate_mainnet_genesis_guard, BlockStore, LoadedGenesisConfig, Miner, MinerConfig,
-    NodeP2PServiceConfig, PeerManager, SyncEngine,
+    NodeP2PServiceConfig, PeerManager, RunningDevnetRPCServer, RunningNodeP2PService, SyncEngine,
 };
 use serde::{Deserialize, Serialize};
 
@@ -437,6 +437,13 @@ fn run(args: &[String], stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
     };
     let sync_engine = Arc::new(Mutex::new(sync_engine));
     let tx_pool = new_shared_runtime_tx_pool(&sync_engine);
+    let stop_signal = match install_production_stop_signal() {
+        Ok(stop_signal) => stop_signal,
+        Err(err) => {
+            let _ = writeln!(stderr, "signal handler install failed: {err}");
+            return 2;
+        }
+    };
     // peer_runtime_cfg / peer_manager were constructed earlier (above
     // the dry-run early-exit) so the RUB-13 peer-slots banner could
     // render in the dry-run path matching the upstream sequencing at
@@ -462,6 +469,12 @@ fn run(args: &[String], stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
         }
     };
     let _ = writeln!(stdout, "p2p: listening={}", p2p_service.addr());
+    let mut server: Option<RunningDevnetRPCServer> = None;
+    if let Some(code) =
+        maybe_shutdown_if_requested(&stop_signal, &mut server, &mut p2p_service, stdout, stderr)
+    {
+        return code;
+    }
 
     let announce_tx: Option<rubin_node::devnet_rpc::AnnounceTxFn> = {
         let relay_state = p2p_service.relay_state();
@@ -490,27 +503,172 @@ fn run(args: &[String], stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
         announce_block,
         live_mining_cfg,
     );
-    let server = if cfg.rpc_bind_addr.trim().is_empty() {
-        None
-    } else {
-        match start_devnet_rpc_server(&cfg.rpc_bind_addr, state) {
+    if !cfg.rpc_bind_addr.trim().is_empty() {
+        server = match start_devnet_rpc_server(&cfg.rpc_bind_addr, state) {
             Ok(server) => Some(server),
             Err(err) => {
                 let _ = writeln!(stderr, "rpc start failed: {err}");
                 p2p_service.close();
                 return 2;
             }
-        }
-    };
+        };
+    }
     if let Some(server) = server.as_ref() {
         let _ = writeln!(stdout, "rpc: listening={}", server.addr());
+    }
+    if let Some(code) =
+        maybe_shutdown_if_requested(&stop_signal, &mut server, &mut p2p_service, stdout, stderr)
+    {
+        return code;
     }
     let _ = writeln!(stdout, "rubin-node skeleton running");
     let _ = stdout.flush();
 
-    loop {
-        thread::sleep(Duration::from_secs(60));
+    wait_for_stop_and_shutdown(&stop_signal, &mut server, &mut p2p_service, stdout, stderr)
+}
+
+trait StopSource {
+    fn stop_requested(&self) -> bool;
+    fn wait_for_stop(&self);
+}
+
+trait RpcLifecycle {
+    fn close_rpc(&mut self) -> Result<(), String>;
+}
+
+trait P2pLifecycle {
+    fn close_p2p(&mut self);
+}
+
+#[derive(Clone)]
+struct StopHandle {
+    requested: Arc<AtomicBool>,
+    wake: mpsc::SyncSender<()>,
+}
+
+struct StopSignal {
+    requested: Arc<AtomicBool>,
+    wake_rx: mpsc::Receiver<()>,
+}
+
+impl StopHandle {
+    fn request_stop(&self) {
+        self.requested.store(true, Ordering::SeqCst);
+        // A full channel already contains a pending stop wake.
+        let _ = self.wake.try_send(());
     }
+}
+
+impl StopSource for StopSignal {
+    fn stop_requested(&self) -> bool {
+        self.requested.load(Ordering::SeqCst)
+    }
+
+    fn wait_for_stop(&self) {
+        if self.stop_requested() {
+            return;
+        }
+        let _ = self.wake_rx.recv();
+    }
+}
+
+impl RpcLifecycle for RunningDevnetRPCServer {
+    fn close_rpc(&mut self) -> Result<(), String> {
+        RunningDevnetRPCServer::close(self)
+    }
+}
+
+impl P2pLifecycle for RunningNodeP2PService {
+    fn close_p2p(&mut self) {
+        RunningNodeP2PService::close(self);
+    }
+}
+
+fn stop_signal_pair() -> (StopHandle, StopSignal) {
+    let requested = Arc::new(AtomicBool::new(false));
+    let (wake, wake_rx) = mpsc::sync_channel(1);
+    (
+        StopHandle {
+            requested: Arc::clone(&requested),
+            wake,
+        },
+        StopSignal { requested, wake_rx },
+    )
+}
+
+fn install_production_stop_signal() -> Result<StopSignal, String> {
+    let (handle, stop_signal) = stop_signal_pair();
+    ctrlc::set_handler(move || handle.request_stop())
+        .map_err(|err| format!("install SIGINT/SIGTERM handler: {err}"))?;
+    Ok(stop_signal)
+}
+
+fn maybe_shutdown_if_requested<S, R, P>(
+    stop: &S,
+    rpc_server: &mut Option<R>,
+    p2p_service: &mut P,
+    stdout: &mut dyn Write,
+    stderr: &mut dyn Write,
+) -> Option<i32>
+where
+    S: StopSource,
+    R: RpcLifecycle,
+    P: P2pLifecycle,
+{
+    if stop.stop_requested() {
+        Some(shutdown_owned_services(
+            rpc_server,
+            p2p_service,
+            stdout,
+            stderr,
+        ))
+    } else {
+        None
+    }
+}
+
+fn wait_for_stop_and_shutdown<S, R, P>(
+    stop: &S,
+    rpc_server: &mut Option<R>,
+    p2p_service: &mut P,
+    stdout: &mut dyn Write,
+    stderr: &mut dyn Write,
+) -> i32
+where
+    S: StopSource,
+    R: RpcLifecycle,
+    P: P2pLifecycle,
+{
+    stop.wait_for_stop();
+    shutdown_owned_services(rpc_server, p2p_service, stdout, stderr)
+}
+
+fn shutdown_owned_services<R, P>(
+    rpc_server: &mut Option<R>,
+    p2p_service: &mut P,
+    stdout: &mut dyn Write,
+    stderr: &mut dyn Write,
+) -> i32
+where
+    R: RpcLifecycle,
+    P: P2pLifecycle,
+{
+    let mut exit_code = 0;
+    if let Some(server) = rpc_server.as_mut() {
+        if let Err(err) = server.close_rpc() {
+            let _ = writeln!(stderr, "rpc shutdown failed: {err}");
+            exit_code = 1;
+        }
+    }
+    p2p_service.close_p2p();
+    if exit_code == 0 {
+        let _ = writeln!(stdout, "rubin-node skeleton stopped");
+        let _ = stdout.flush();
+    } else {
+        let _ = writeln!(stderr, "rubin-node skeleton stopped with shutdown errors");
+        let _ = stderr.flush();
+    }
+    exit_code
 }
 
 /// RUB-13 / GitHub #1157: format the operator-facing `p2p: peer_slots=N
@@ -1033,10 +1191,12 @@ mod tests {
     use std::fs;
     use std::io;
     use std::path::PathBuf;
+    use std::{cell::RefCell, rc::Rc};
 
     use super::{
-        format_peer_slots_banner, legacy_exposure_hooks, parse_args, run, runtime_genesis_hash,
-        validate_config, LegacyExposureReport,
+        format_peer_slots_banner, legacy_exposure_hooks, maybe_shutdown_if_requested, parse_args,
+        run, runtime_genesis_hash, stop_signal_pair, validate_config, wait_for_stop_and_shutdown,
+        LegacyExposureReport,
     };
     use rubin_consensus::constants::{
         ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES, SUITE_ID_ML_DSA_87, VERIFY_COST_ML_DSA_87,
@@ -1140,13 +1300,19 @@ mod tests {
     }
 
     fn unique_temp_dir(prefix: &str) -> PathBuf {
-        std::env::temp_dir().join(format!(
+        let leaf = format!(
             "{prefix}-{}",
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .expect("time")
                 .as_nanos()
-        ))
+        );
+        assert!(leaf
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_'));
+        let mut path = std::env::temp_dir();
+        path.push(leaf);
+        path
     }
 
     fn legacy_exposure_contract_repo_path(rel: &str) -> PathBuf {
@@ -1169,6 +1335,163 @@ mod tests {
 
     fn production_rotation_networks() -> [&'static str; 4] {
         ["mainnet", "testnet", " MAINNET ", "\tTestNet\t"]
+    }
+
+    #[derive(Clone, Default)]
+    struct LifecycleEvents(Rc<RefCell<Vec<&'static str>>>);
+
+    impl LifecycleEvents {
+        fn push(&self, event: &'static str) {
+            self.0.borrow_mut().push(event);
+        }
+
+        fn snapshot(&self) -> Vec<&'static str> {
+            self.0.borrow().clone()
+        }
+    }
+
+    struct FakeRpcLifecycle {
+        events: LifecycleEvents,
+        close_result: Result<(), String>,
+    }
+
+    struct FakeP2pLifecycle {
+        events: LifecycleEvents,
+    }
+
+    impl super::RpcLifecycle for FakeRpcLifecycle {
+        fn close_rpc(&mut self) -> Result<(), String> {
+            self.events.push("rpc");
+            self.close_result.clone()
+        }
+    }
+
+    impl super::P2pLifecycle for FakeP2pLifecycle {
+        fn close_p2p(&mut self) {
+            self.events.push("p2p");
+        }
+    }
+
+    #[test]
+    fn signal_lifecycle_does_not_shutdown_before_stop_requested() {
+        let (_handle, stop_signal) = stop_signal_pair();
+        let events = LifecycleEvents::default();
+        let mut rpc_server = Some(FakeRpcLifecycle {
+            events: events.clone(),
+            close_result: Ok(()),
+        });
+        let mut p2p_service = FakeP2pLifecycle {
+            events: events.clone(),
+        };
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+
+        let result = maybe_shutdown_if_requested(
+            &stop_signal,
+            &mut rpc_server,
+            &mut p2p_service,
+            &mut stdout,
+            &mut stderr,
+        );
+
+        assert_eq!(result, None);
+        assert_eq!(events.snapshot(), Vec::<&'static str>::new());
+        assert!(stdout.is_empty());
+        assert!(stderr.is_empty());
+    }
+
+    #[test]
+    fn signal_lifecycle_waits_for_stop_then_closes_rpc_before_p2p() {
+        let (handle, stop_signal) = stop_signal_pair();
+        handle.request_stop();
+        handle.request_stop();
+        let events = LifecycleEvents::default();
+        let mut rpc_server = Some(FakeRpcLifecycle {
+            events: events.clone(),
+            close_result: Ok(()),
+        });
+        let mut p2p_service = FakeP2pLifecycle {
+            events: events.clone(),
+        };
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+
+        let code = wait_for_stop_and_shutdown(
+            &stop_signal,
+            &mut rpc_server,
+            &mut p2p_service,
+            &mut stdout,
+            &mut stderr,
+        );
+
+        assert_eq!(code, 0);
+        assert_eq!(events.snapshot(), vec!["rpc", "p2p"]);
+        assert_eq!(
+            String::from_utf8(stdout).expect("stdout utf8"),
+            "rubin-node skeleton stopped\n"
+        );
+        assert!(stderr.is_empty());
+    }
+
+    #[test]
+    fn signal_lifecycle_stop_before_rpc_start_closes_p2p_only() {
+        let (handle, stop_signal) = stop_signal_pair();
+        handle.request_stop();
+        let events = LifecycleEvents::default();
+        let mut rpc_server: Option<FakeRpcLifecycle> = None;
+        let mut p2p_service = FakeP2pLifecycle {
+            events: events.clone(),
+        };
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+
+        let result = maybe_shutdown_if_requested(
+            &stop_signal,
+            &mut rpc_server,
+            &mut p2p_service,
+            &mut stdout,
+            &mut stderr,
+        );
+
+        assert_eq!(result, Some(0));
+        assert_eq!(events.snapshot(), vec!["p2p"]);
+        assert_eq!(
+            String::from_utf8(stdout).expect("stdout utf8"),
+            "rubin-node skeleton stopped\n"
+        );
+        assert!(stderr.is_empty());
+    }
+
+    #[test]
+    fn signal_lifecycle_rpc_close_error_reports_failure_and_still_closes_p2p() {
+        let (handle, stop_signal) = stop_signal_pair();
+        handle.request_stop();
+        let events = LifecycleEvents::default();
+        let mut rpc_server = Some(FakeRpcLifecycle {
+            events: events.clone(),
+            close_result: Err("synthetic rpc timeout".to_string()),
+        });
+        let mut p2p_service = FakeP2pLifecycle {
+            events: events.clone(),
+        };
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+
+        let code = wait_for_stop_and_shutdown(
+            &stop_signal,
+            &mut rpc_server,
+            &mut p2p_service,
+            &mut stdout,
+            &mut stderr,
+        );
+
+        assert_eq!(code, 1);
+        assert_eq!(events.snapshot(), vec!["rpc", "p2p"]);
+        assert!(stdout.is_empty());
+        assert_eq!(
+            String::from_utf8(stderr).expect("stderr utf8"),
+            "rpc shutdown failed: synthetic rpc timeout\nrubin-node skeleton stopped with shutdown errors\n"
+        );
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/main.rs
+++ b/clients/rust/crates/rubin-node/src/main.rs
@@ -10,7 +10,9 @@ use rubin_consensus::{
     canonical_rotation_network_name_normalized, normalized_rotation_network_name,
     SUPPORTED_ROTATION_NETWORK_NAMES_CSV,
 };
-use rubin_node::devnet_rpc::attach_shutdown_signal_to_devnet_rpc_state;
+use rubin_node::devnet_rpc::{
+    attach_shutdown_signal_to_devnet_rpc_state, RPC_READINESS_TRANSITION_FAILED,
+};
 use rubin_node::{
     block_store_path, chain_state_path, default_peer_runtime_config, default_sync_config,
     load_chain_state, load_genesis_config, new_devnet_rpc_state_with_tx_pool,
@@ -655,7 +657,7 @@ where
     R: RpcLifecycle,
     P: P2pLifecycle,
 {
-    if stop.stop_requested() {
+    if stop.stop_requested() && err == RPC_READINESS_TRANSITION_FAILED {
         return shutdown_owned_services(rpc_server, p2p_service, stdout, stderr);
     }
     let _ = writeln!(stderr, "rpc start failed: {err}");
@@ -1257,7 +1259,7 @@ mod tests {
         format_peer_slots_banner, handle_rpc_start_error_after_maybe_stop, legacy_exposure_hooks,
         maybe_shutdown_if_requested, parse_args, run, runtime_genesis_hash, stop_signal_pair,
         validate_config, wait_for_stop_and_shutdown, LegacyExposureReport,
-        PRODUCTION_STOP_SIGNAL_SET,
+        PRODUCTION_STOP_SIGNAL_SET, RPC_READINESS_TRANSITION_FAILED,
     };
     use rubin_consensus::constants::{
         ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES, SUITE_ID_ML_DSA_87, VERIFY_COST_ML_DSA_87,
@@ -1558,7 +1560,7 @@ mod tests {
             &stop_signal,
             &mut rpc_server,
             &mut p2p_service,
-            "readiness transition failed: server is already ready or shutdown".to_string(),
+            RPC_READINESS_TRANSITION_FAILED.to_string(),
             &mut stdout,
             &mut stderr,
         );
@@ -1570,6 +1572,36 @@ mod tests {
             "rubin-node skeleton stopped\n"
         );
         assert!(stderr.is_empty());
+    }
+
+    #[test]
+    fn signal_lifecycle_stop_does_not_mask_rpc_bind_failure() {
+        let (handle, stop_signal) = stop_signal_pair();
+        handle.request_stop();
+        let events = LifecycleEvents::default();
+        let mut rpc_server: Option<FakeRpcLifecycle> = None;
+        let mut p2p_service = FakeP2pLifecycle {
+            events: events.clone(),
+        };
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+
+        let code = handle_rpc_start_error_after_maybe_stop(
+            &stop_signal,
+            &mut rpc_server,
+            &mut p2p_service,
+            "bind 127.0.0.1:0: synthetic failure".to_string(),
+            &mut stdout,
+            &mut stderr,
+        );
+
+        assert_eq!(code, 2);
+        assert_eq!(events.snapshot(), vec!["p2p"]);
+        assert!(stdout.is_empty());
+        assert_eq!(
+            String::from_utf8(stderr).expect("stderr utf8"),
+            "rpc start failed: bind 127.0.0.1:0: synthetic failure\n"
+        );
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/main.rs
+++ b/clients/rust/crates/rubin-node/src/main.rs
@@ -21,7 +21,7 @@ use rubin_node::{
 };
 use serde::{Deserialize, Serialize};
 
-const PRODUCTION_STOP_SIGNAL_SET: &str = "SIGINT/SIGTERM/SIGHUP";
+const PRODUCTION_STOP_SIGNAL_SET: &str = "SIGINT/SIGTERM";
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct CliConfig {
@@ -613,10 +613,32 @@ fn stop_signal_pair() -> (StopHandle, StopSignal) {
     )
 }
 
+#[cfg(unix)]
+fn production_unix_stop_signals() -> [i32; 2] {
+    [signal_hook::consts::SIGINT, signal_hook::consts::SIGTERM]
+}
+
+#[cfg(unix)]
+fn install_production_stop_signal() -> Result<StopSignal, String> {
+    let (handle, stop_signal) = stop_signal_pair();
+    let mut signals = signal_hook::iterator::Signals::new(production_unix_stop_signals())
+        .map_err(|err| format!("install {PRODUCTION_STOP_SIGNAL_SET} handler: {err}"))?;
+    std::thread::Builder::new()
+        .name("rubin-stop-signal".to_string())
+        .spawn(move || {
+            if signals.forever().next().is_some() {
+                handle.request_stop();
+            }
+        })
+        .map_err(|err| format!("start {PRODUCTION_STOP_SIGNAL_SET} handler: {err}"))?;
+    Ok(stop_signal)
+}
+
+#[cfg(not(unix))]
 fn install_production_stop_signal() -> Result<StopSignal, String> {
     let (handle, stop_signal) = stop_signal_pair();
     ctrlc::set_handler(move || handle.request_stop())
-        .map_err(|err| format!("install {PRODUCTION_STOP_SIGNAL_SET} handler: {err}"))?;
+        .map_err(|err| format!("install Ctrl-C handler: {err}"))?;
     Ok(stop_signal)
 }
 
@@ -1440,8 +1462,22 @@ mod tests {
     }
 
     #[test]
-    fn signal_lifecycle_contract_names_ctrlc_termination_signal_set() {
-        assert_eq!(PRODUCTION_STOP_SIGNAL_SET, "SIGINT/SIGTERM/SIGHUP");
+    fn signal_lifecycle_contract_names_go_aligned_signal_set() {
+        assert_eq!(PRODUCTION_STOP_SIGNAL_SET, "SIGINT/SIGTERM");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn signal_lifecycle_unix_signal_set_excludes_sighup_for_go_parity() {
+        let signals = super::production_unix_stop_signals();
+        assert_eq!(
+            signals,
+            [signal_hook::consts::SIGINT, signal_hook::consts::SIGTERM]
+        );
+        assert!(
+            !signals.contains(&signal_hook::consts::SIGHUP),
+            "SIGHUP is not part of the Go-aligned graceful shutdown contract"
+        );
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/main.rs
+++ b/clients/rust/crates/rubin-node/src/main.rs
@@ -21,6 +21,8 @@ use rubin_node::{
 };
 use serde::{Deserialize, Serialize};
 
+const PRODUCTION_STOP_SIGNAL_SET: &str = "SIGINT/SIGTERM/SIGHUP";
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct CliConfig {
     network: String,
@@ -511,9 +513,14 @@ fn run(args: &[String], stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
         server = match start_devnet_rpc_server(&cfg.rpc_bind_addr, state) {
             Ok(server) => Some(server),
             Err(err) => {
-                let _ = writeln!(stderr, "rpc start failed: {err}");
-                p2p_service.close();
-                return 2;
+                return handle_rpc_start_error_after_maybe_stop(
+                    &stop_signal,
+                    &mut server,
+                    &mut p2p_service,
+                    err,
+                    stdout,
+                    stderr,
+                );
             }
         };
     }
@@ -609,8 +616,29 @@ fn stop_signal_pair() -> (StopHandle, StopSignal) {
 fn install_production_stop_signal() -> Result<StopSignal, String> {
     let (handle, stop_signal) = stop_signal_pair();
     ctrlc::set_handler(move || handle.request_stop())
-        .map_err(|err| format!("install SIGINT/SIGTERM handler: {err}"))?;
+        .map_err(|err| format!("install {PRODUCTION_STOP_SIGNAL_SET} handler: {err}"))?;
     Ok(stop_signal)
+}
+
+fn handle_rpc_start_error_after_maybe_stop<S, R, P>(
+    stop: &S,
+    rpc_server: &mut Option<R>,
+    p2p_service: &mut P,
+    err: String,
+    stdout: &mut dyn Write,
+    stderr: &mut dyn Write,
+) -> i32
+where
+    S: StopSource,
+    R: RpcLifecycle,
+    P: P2pLifecycle,
+{
+    if stop.stop_requested() {
+        return shutdown_owned_services(rpc_server, p2p_service, stdout, stderr);
+    }
+    let _ = writeln!(stderr, "rpc start failed: {err}");
+    p2p_service.close_p2p();
+    2
 }
 
 fn maybe_shutdown_if_requested<S, R, P>(
@@ -1204,9 +1232,10 @@ mod tests {
     use std::{cell::RefCell, rc::Rc};
 
     use super::{
-        format_peer_slots_banner, legacy_exposure_hooks, maybe_shutdown_if_requested, parse_args,
-        run, runtime_genesis_hash, stop_signal_pair, validate_config, wait_for_stop_and_shutdown,
-        LegacyExposureReport,
+        format_peer_slots_banner, handle_rpc_start_error_after_maybe_stop, legacy_exposure_hooks,
+        maybe_shutdown_if_requested, parse_args, run, runtime_genesis_hash, stop_signal_pair,
+        validate_config, wait_for_stop_and_shutdown, LegacyExposureReport,
+        PRODUCTION_STOP_SIGNAL_SET,
     };
     use rubin_consensus::constants::{
         ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES, SUITE_ID_ML_DSA_87, VERIFY_COST_ML_DSA_87,
@@ -1411,6 +1440,11 @@ mod tests {
     }
 
     #[test]
+    fn signal_lifecycle_contract_names_ctrlc_termination_signal_set() {
+        assert_eq!(PRODUCTION_STOP_SIGNAL_SET, "SIGINT/SIGTERM/SIGHUP");
+    }
+
+    #[test]
     fn signal_lifecycle_waits_for_stop_then_closes_rpc_before_p2p() {
         let (handle, stop_signal) = stop_signal_pair();
         handle.request_stop();
@@ -1470,6 +1504,65 @@ mod tests {
             "rubin-node skeleton stopped\n"
         );
         assert!(stderr.is_empty());
+    }
+
+    #[test]
+    fn signal_lifecycle_rpc_start_error_after_stop_is_graceful_shutdown() {
+        let (handle, stop_signal) = stop_signal_pair();
+        handle.request_stop();
+        let events = LifecycleEvents::default();
+        let mut rpc_server: Option<FakeRpcLifecycle> = None;
+        let mut p2p_service = FakeP2pLifecycle {
+            events: events.clone(),
+        };
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+
+        let code = handle_rpc_start_error_after_maybe_stop(
+            &stop_signal,
+            &mut rpc_server,
+            &mut p2p_service,
+            "readiness transition failed: server is already ready or shutdown".to_string(),
+            &mut stdout,
+            &mut stderr,
+        );
+
+        assert_eq!(code, 0);
+        assert_eq!(events.snapshot(), vec!["p2p"]);
+        assert_eq!(
+            String::from_utf8(stdout).expect("stdout utf8"),
+            "rubin-node skeleton stopped\n"
+        );
+        assert!(stderr.is_empty());
+    }
+
+    #[test]
+    fn signal_lifecycle_rpc_start_error_without_stop_is_startup_failure() {
+        let (_handle, stop_signal) = stop_signal_pair();
+        let events = LifecycleEvents::default();
+        let mut rpc_server: Option<FakeRpcLifecycle> = None;
+        let mut p2p_service = FakeP2pLifecycle {
+            events: events.clone(),
+        };
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+
+        let code = handle_rpc_start_error_after_maybe_stop(
+            &stop_signal,
+            &mut rpc_server,
+            &mut p2p_service,
+            "bind 127.0.0.1:0: synthetic failure".to_string(),
+            &mut stdout,
+            &mut stderr,
+        );
+
+        assert_eq!(code, 2);
+        assert_eq!(events.snapshot(), vec!["p2p"]);
+        assert!(stdout.is_empty());
+        assert_eq!(
+            String::from_utf8(stderr).expect("stderr utf8"),
+            "rpc start failed: bind 127.0.0.1:0: synthetic failure\n"
+        );
     }
 
     #[test]

--- a/clients/rust/fuzz/Cargo.lock
+++ b/clients/rust/fuzz/Cargo.lock
@@ -15,12 +15,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
 ]
 
 [[package]]
@@ -42,6 +57,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -61,6 +82,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix",
+ "windows-sys",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -68,6 +100,18 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
 ]
 
 [[package]]
@@ -131,9 +175,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -150,6 +194,18 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
 
 [[package]]
 name = "num-bigint"
@@ -178,6 +234,21 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "openssl-sys"
@@ -249,6 +320,7 @@ dependencies = [
 name = "rubin-node"
 version = "0.0.0"
 dependencies = [
+ "ctrlc",
  "hex",
  "num-bigint",
  "rubin-consensus",
@@ -358,6 +430,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/clients/rust/fuzz/Cargo.lock
+++ b/clients/rust/fuzz/Cargo.lock
@@ -115,6 +115,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -327,6 +337,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3",
+ "signal-hook",
 ]
 
 [[package]]
@@ -387,6 +398,26 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "syn"


### PR DESCRIPTION
## Scope
- Linear: RUB-225.
- Wire Rust production `rubin-node` stop handling so SIGINT/SIGTERM on Unix, and Ctrl-C on non-Unix, requests bounded shutdown instead of sleeping forever.
- Route shutdown through owned runtime cleanup: RPC close first, then P2P close.
- Preserve real RPC startup failures: bind/spawn/start errors still report `rpc start failed` and return startup failure even if a stop signal races.
- Add signal dependency and Rust lockfile updates required for the platform-specific stop contract.

## Disposition
- Consensus impact: none.
- Go runtime changed: no.
- Rust runtime behavior changed: bounded production shutdown lifecycle only.
- Conformance/fixtures changed: no.
- P2P protocol changed: no.
- Signal parity: Unix graceful stop set matches Go SIGINT/SIGTERM; SIGHUP is excluded.
- Validation: `cargo test -p rubin-node`, `cargo clippy -p rubin-node -- -D warnings`, `tooling-check.sh --new-only --mode rust-deep`, one stock isolated code-review pass, and coverage lane all passed on head `744c9c6`.
