### PR TITLE
RUB-20 rust: align COV type constant names

### DIFF
--- a/clients/rust/crates/rubin-consensus-cli/src/txctx_harness.rs
+++ b/clients/rust/crates/rubin-consensus-cli/src/txctx_harness.rs
@@ -1,7 +1,7 @@
 use super::Response;
 use rubin_consensus::constants::{
-    COV_TYPE_ANCHOR, COV_TYPE_DA_COMMIT, COV_TYPE_EXT, COV_TYPE_P2PK, COV_TYPE_VAULT, SIGHASH_ALL,
-    SIGHASH_ANYONECANPAY, SIGHASH_NONE, SIGHASH_SINGLE, SUITE_ID_ML_DSA_87,
+    COV_TYPE_ANCHOR, COV_TYPE_CORE_EXT, COV_TYPE_DA_COMMIT, COV_TYPE_P2PK, COV_TYPE_VAULT,
+    SIGHASH_ALL, SIGHASH_ANYONECANPAY, SIGHASH_NONE, SIGHASH_SINGLE, SUITE_ID_ML_DSA_87,
 };
 use rubin_consensus::core_ext::{
     CoreExtActiveProfile, CoreExtProfiles, CoreExtVerificationBinding,
@@ -369,7 +369,7 @@ fn txctx_default_covenant_data(cov_type: u16) -> Result<Vec<u8>, String> {
 fn txctx_parse_covenant_type(name: &str) -> Result<u16, String> {
     match name.trim().to_uppercase().as_str() {
         "" | "CORE_P2PK" => Ok(COV_TYPE_P2PK),
-        "CORE_EXT" | "CORE_EXT_INACTIVE" => Ok(COV_TYPE_EXT),
+        "CORE_EXT" | "CORE_EXT_INACTIVE" => Ok(COV_TYPE_CORE_EXT),
         "CORE_ANCHOR" => Ok(COV_TYPE_ANCHOR),
         "CORE_VAULT" => Ok(COV_TYPE_VAULT),
         "CORE_DA_COMMIT" => Ok(COV_TYPE_DA_COMMIT),
@@ -420,7 +420,7 @@ fn txctx_has_active_input_ext_id(tc: &TxctxCase, ext_id: u16) -> bool {
     tc.inputs.iter().any(|input| {
         input.ext_id == ext_id
             && txctx_parse_covenant_type(&input.covenant_type)
-                .map(|cov_type| cov_type == COV_TYPE_EXT)
+                .map(|cov_type| cov_type == COV_TYPE_CORE_EXT)
                 .unwrap_or(false)
     })
 }
@@ -505,7 +505,7 @@ fn txctx_profile_error(tc: &TxctxCase) -> Option<&'static str> {
         let Ok(cov_type) = txctx_parse_covenant_type(&output.covenant_type) else {
             continue;
         };
-        if cov_type != COV_TYPE_EXT {
+        if cov_type != COV_TYPE_CORE_EXT {
             continue;
         }
         let Some(profile) = profiles_by_ext.get(&output.ext_id) else {
@@ -532,7 +532,7 @@ fn txctx_first_overflow_ext_id(outputs: &[TxctxOutput]) -> u16 {
         let Ok(cov_type) = txctx_parse_covenant_type(&output.covenant_type) else {
             continue;
         };
-        if cov_type != COV_TYPE_EXT {
+        if cov_type != COV_TYPE_CORE_EXT {
             continue;
         }
         *counts.entry(output.ext_id).or_insert(0usize) += 1;
@@ -596,7 +596,7 @@ fn txctx_build_artifacts(tc: &TxctxCase) -> Result<TxctxArtifacts, String> {
         } else {
             input.ext_id
         };
-        let covenant_data = if cov_type == COV_TYPE_EXT {
+        let covenant_data = if cov_type == COV_TYPE_CORE_EXT {
             txctx_core_ext_covdata(ext_id, &input.ext_payload_hex, &input.raw_ext_payload_hex)?
         } else {
             txctx_default_covenant_data(cov_type)?
@@ -638,7 +638,7 @@ fn txctx_build_artifacts(tc: &TxctxCase) -> Result<TxctxArtifacts, String> {
             txctx_decode_hex(&output.raw_covenant_data_hex)?
         } else {
             match cov_type {
-                COV_TYPE_EXT => txctx_core_ext_covdata(
+                COV_TYPE_CORE_EXT => txctx_core_ext_covdata(
                     output.ext_id,
                     &output.ext_payload_hex,
                     &output.raw_ext_payload_hex,

--- a/clients/rust/crates/rubin-consensus/src/constants.rs
+++ b/clients/rust/crates/rubin-consensus/src/constants.rs
@@ -41,6 +41,11 @@ pub const CORE_EXT_WITNESS_SLOTS: u64 = 1;
 pub const COV_TYPE_CORE_STEALTH: u16 = 0x0105;
 pub const CORE_STEALTH_WITNESS_SLOTS: u64 = 1;
 
+#[deprecated(note = "use COV_TYPE_CORE_EXT")]
+pub const COV_TYPE_EXT: u16 = COV_TYPE_CORE_EXT;
+#[deprecated(note = "use COV_TYPE_CORE_STEALTH")]
+pub const COV_TYPE_STEALTH: u16 = COV_TYPE_CORE_STEALTH;
+
 pub const MAX_TX_INPUTS: u64 = 1024;
 pub const MAX_TX_OUTPUTS: u64 = 1024;
 pub const MAX_WITNESS_ITEMS: u64 = 1024;
@@ -102,5 +107,17 @@ mod tests {
         assert_eq!(COV_TYPE_CORE_STEALTH, 0x0105);
         assert_eq!(COV_TYPE_CORE_EXT.to_le_bytes(), 0x0102u16.to_le_bytes());
         assert_eq!(COV_TYPE_CORE_STEALTH.to_le_bytes(), 0x0105u16.to_le_bytes());
+    }
+
+    #[allow(deprecated)]
+    #[test]
+    fn legacy_cov_type_aliases_preserve_wire_values() {
+        assert_eq!(COV_TYPE_EXT, COV_TYPE_CORE_EXT);
+        assert_eq!(COV_TYPE_STEALTH, COV_TYPE_CORE_STEALTH);
+        assert_eq!(COV_TYPE_EXT.to_le_bytes(), COV_TYPE_CORE_EXT.to_le_bytes());
+        assert_eq!(
+            COV_TYPE_STEALTH.to_le_bytes(),
+            COV_TYPE_CORE_STEALTH.to_le_bytes()
+        );
     }
 }

--- a/clients/rust/crates/rubin-consensus/src/constants.rs
+++ b/clients/rust/crates/rubin-consensus/src/constants.rs
@@ -36,9 +36,9 @@ pub const MAX_VAULT_KEYS: u8 = 12;
 pub const MAX_VAULT_WHITELIST_ENTRIES: u16 = 1024;
 pub const MAX_MULTISIG_KEYS: u8 = 12;
 pub const COV_TYPE_MULTISIG: u16 = 0x0104;
-pub const COV_TYPE_EXT: u16 = 0x0102;
+pub const COV_TYPE_CORE_EXT: u16 = 0x0102;
 pub const CORE_EXT_WITNESS_SLOTS: u64 = 1;
-pub const COV_TYPE_STEALTH: u16 = 0x0105;
+pub const COV_TYPE_CORE_STEALTH: u16 = 0x0105;
 pub const CORE_STEALTH_WITNESS_SLOTS: u64 = 1;
 
 pub const MAX_TX_INPUTS: u64 = 1024;
@@ -90,3 +90,17 @@ pub const SIGNAL_THRESHOLD: u32 = 1815;
 pub const FALLOW_PERIOD: u64 = 2016;
 
 pub const POW_LIMIT: [u8; 32] = [0xff; 32];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn core_cov_type_names_preserve_wire_values() {
+        assert_eq!(COV_TYPE_CORE_EXT, 0x0102);
+        assert_eq!(COV_TYPE_DA_COMMIT, 0x0103);
+        assert_eq!(COV_TYPE_CORE_STEALTH, 0x0105);
+        assert_eq!(COV_TYPE_CORE_EXT.to_le_bytes(), 0x0102u16.to_le_bytes());
+        assert_eq!(COV_TYPE_CORE_STEALTH.to_le_bytes(), 0x0105u16.to_le_bytes());
+    }
+}

--- a/clients/rust/crates/rubin-consensus/src/core_ext.rs
+++ b/clients/rust/crates/rubin-consensus/src/core_ext.rs
@@ -1050,7 +1050,7 @@ mod tests {
     use super::*;
     use crate::compactsize::encode_compact_size;
     use crate::constants::{
-        COV_TYPE_EXT, ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES, SUITE_ID_ML_DSA_87,
+        COV_TYPE_CORE_EXT, ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES, SUITE_ID_ML_DSA_87,
         VERIFY_COST_ML_DSA_87,
     };
     use crate::tx::{Tx, TxInput, TxOutput};
@@ -1067,7 +1067,7 @@ mod tests {
     fn dummy_entry(ext_id: u16) -> UtxoEntry {
         UtxoEntry {
             value: 1,
-            covenant_type: COV_TYPE_EXT,
+            covenant_type: COV_TYPE_CORE_EXT,
             covenant_data: core_ext_covdata(ext_id, b""),
             creation_height: 0,
             created_by_coinbase: false,
@@ -1092,7 +1092,7 @@ mod tests {
                 }],
                 outputs: vec![TxOutput {
                     value: 1,
-                    covenant_type: COV_TYPE_EXT,
+                    covenant_type: COV_TYPE_CORE_EXT,
                     covenant_data: vec![],
                 }],
                 locktime: 0,
@@ -1422,7 +1422,7 @@ mod tests {
             }],
             outputs: vec![TxOutput {
                 value: 90,
-                covenant_type: COV_TYPE_EXT,
+                covenant_type: COV_TYPE_CORE_EXT,
                 covenant_data: core_ext_covdata(ext_id, &[]),
             }],
             locktime: 0,
@@ -1437,7 +1437,7 @@ mod tests {
         };
         let resolved_inputs = vec![UtxoEntry {
             value: 100,
-            covenant_type: COV_TYPE_EXT,
+            covenant_type: COV_TYPE_CORE_EXT,
             covenant_data: core_ext_covdata(ext_id, &[0x99]),
             creation_height: 0,
             created_by_coinbase: false,
@@ -1464,7 +1464,7 @@ mod tests {
     fn core_ext_active_txcontext_missing_bundle_fails_closed() {
         let entry = UtxoEntry {
             value: 100,
-            covenant_type: COV_TYPE_EXT,
+            covenant_type: COV_TYPE_CORE_EXT,
             covenant_data: core_ext_covdata(7, &[0x99]),
             creation_height: 0,
             created_by_coinbase: false,
@@ -1504,7 +1504,7 @@ mod tests {
     fn core_ext_active_txcontext_missing_runtime_verifier_wins_before_bundle_checks() {
         let entry = UtxoEntry {
             value: 100,
-            covenant_type: COV_TYPE_EXT,
+            covenant_type: COV_TYPE_CORE_EXT,
             covenant_data: core_ext_covdata(7, &[0x99]),
             creation_height: 0,
             created_by_coinbase: false,
@@ -1544,7 +1544,7 @@ mod tests {
     fn core_ext_active_txcontext_openssl_binding_without_runtime_verifier_fails_closed() {
         let entry = UtxoEntry {
             value: 100,
-            covenant_type: COV_TYPE_EXT,
+            covenant_type: COV_TYPE_CORE_EXT,
             covenant_data: core_ext_covdata(7, &[0x99]),
             creation_height: 0,
             created_by_coinbase: false,
@@ -1609,7 +1609,7 @@ mod tests {
     fn core_ext_active_txcontext_legacy_binding_without_runtime_verifier_fails_closed() {
         let entry = UtxoEntry {
             value: 100,
-            covenant_type: COV_TYPE_EXT,
+            covenant_type: COV_TYPE_CORE_EXT,
             covenant_data: core_ext_covdata(7, &[0x99]),
             creation_height: 0,
             created_by_coinbase: false,
@@ -1656,7 +1656,7 @@ mod tests {
     fn core_ext_active_txcontext_native_binding_without_runtime_verifier_fails_closed() {
         let entry = UtxoEntry {
             value: 100,
-            covenant_type: COV_TYPE_EXT,
+            covenant_type: COV_TYPE_CORE_EXT,
             covenant_data: core_ext_covdata(7, &[0x99]),
             creation_height: 0,
             created_by_coinbase: false,
@@ -1703,7 +1703,7 @@ mod tests {
     fn core_ext_active_txcontext_missing_continuing_bundle_fails_closed() {
         let entry = UtxoEntry {
             value: 100,
-            covenant_type: COV_TYPE_EXT,
+            covenant_type: COV_TYPE_CORE_EXT,
             covenant_data: core_ext_covdata(7, &[0x99]),
             creation_height: 0,
             created_by_coinbase: false,
@@ -1750,7 +1750,7 @@ mod tests {
     fn core_ext_active_txcontext_reject_maps_to_sig_invalid() {
         let entry = UtxoEntry {
             value: 100,
-            covenant_type: COV_TYPE_EXT,
+            covenant_type: COV_TYPE_CORE_EXT,
             covenant_data: core_ext_covdata(7, &[0x99]),
             creation_height: 0,
             created_by_coinbase: false,
@@ -1797,7 +1797,7 @@ mod tests {
     fn core_ext_active_txcontext_error_maps_to_sig_alg_invalid() {
         let entry = UtxoEntry {
             value: 100,
-            covenant_type: COV_TYPE_EXT,
+            covenant_type: COV_TYPE_CORE_EXT,
             covenant_data: core_ext_covdata(7, &[0x99]),
             creation_height: 0,
             created_by_coinbase: false,
@@ -1858,7 +1858,7 @@ mod tests {
     fn core_ext_active_txcontext_openssl_digest32_binding_verifies_mldsa87_parity() {
         let entry = UtxoEntry {
             value: 100,
-            covenant_type: COV_TYPE_EXT,
+            covenant_type: COV_TYPE_CORE_EXT,
             covenant_data: core_ext_covdata(7, &[0x99]),
             creation_height: 0,
             created_by_coinbase: false,

--- a/clients/rust/crates/rubin-consensus/src/covenant_genesis.rs
+++ b/clients/rust/crates/rubin-consensus/src/covenant_genesis.rs
@@ -1,6 +1,6 @@
 use crate::constants::{
-    COV_TYPE_ANCHOR, COV_TYPE_DA_COMMIT, COV_TYPE_EXT, COV_TYPE_HTLC, COV_TYPE_MULTISIG,
-    COV_TYPE_P2PK, COV_TYPE_RESERVED_FUTURE, COV_TYPE_STEALTH, COV_TYPE_VAULT,
+    COV_TYPE_ANCHOR, COV_TYPE_CORE_EXT, COV_TYPE_CORE_STEALTH, COV_TYPE_DA_COMMIT, COV_TYPE_HTLC,
+    COV_TYPE_MULTISIG, COV_TYPE_P2PK, COV_TYPE_RESERVED_FUTURE, COV_TYPE_VAULT,
     MAX_ANCHOR_PAYLOAD_SIZE, MAX_COVENANT_DATA_PER_OUTPUT, MAX_P2PK_COVENANT_DATA,
 };
 use crate::core_ext::parse_core_ext_covenant_data;
@@ -88,7 +88,7 @@ pub fn validate_tx_covenants_genesis(
                 }
                 parse_htlc_covenant_data(&out.covenant_data)?;
             }
-            COV_TYPE_EXT => {
+            COV_TYPE_CORE_EXT => {
                 if out.value == 0 {
                     return Err(TxError::new(
                         ErrorCode::TxErrCovenantTypeInvalid,
@@ -103,7 +103,7 @@ pub fn validate_tx_covenants_genesis(
                 }
                 let _ = parse_core_ext_covenant_data(&out.covenant_data)?;
             }
-            COV_TYPE_STEALTH => {
+            COV_TYPE_CORE_STEALTH => {
                 if out.value == 0 {
                     return Err(TxError::new(
                         ErrorCode::TxErrCovenantTypeInvalid,

--- a/clients/rust/crates/rubin-consensus/src/coverage_hotspots_tests.rs
+++ b/clients/rust/crates/rubin-consensus/src/coverage_hotspots_tests.rs
@@ -1,7 +1,7 @@
 use std::sync::{Mutex, OnceLock};
 
 use crate::constants::{
-    COV_TYPE_HTLC, COV_TYPE_P2PK, COV_TYPE_STEALTH, LOCK_MODE_HEIGHT, LOCK_MODE_TIMESTAMP,
+    COV_TYPE_CORE_STEALTH, COV_TYPE_HTLC, COV_TYPE_P2PK, LOCK_MODE_HEIGHT, LOCK_MODE_TIMESTAMP,
     MAX_HTLC_COVENANT_DATA, MAX_STEALTH_COVENANT_DATA, ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES,
     ML_KEM_1024_CT_BYTES, SIGHASH_ALL, SIGHASH_ANYONECANPAY, SIGHASH_NONE, SIGHASH_SINGLE,
     SUITE_ID_ML_DSA_87, SUITE_ID_SENTINEL,
@@ -80,7 +80,7 @@ fn stealth_entry_for_pubkey(pubkey: &[u8]) -> UtxoEntry {
     cov[ML_KEM_1024_CT_BYTES as usize..].copy_from_slice(&crate::hash::sha3_256(pubkey));
     UtxoEntry {
         value: 100,
-        covenant_type: COV_TYPE_STEALTH,
+        covenant_type: COV_TYPE_CORE_STEALTH,
         covenant_data: cov,
         creation_height: 0,
         created_by_coinbase: false,

--- a/clients/rust/crates/rubin-consensus/src/sig_queue.rs
+++ b/clients/rust/crates/rubin-consensus/src/sig_queue.rs
@@ -439,7 +439,7 @@ mod tests {
     use super::*;
     use crate::compactsize::encode_compact_size;
     use crate::constants::{
-        COV_TYPE_EXT, COV_TYPE_HTLC, COV_TYPE_P2PK, COV_TYPE_STEALTH, LOCK_MODE_HEIGHT,
+        COV_TYPE_CORE_EXT, COV_TYPE_CORE_STEALTH, COV_TYPE_HTLC, COV_TYPE_P2PK, LOCK_MODE_HEIGHT,
         MAX_HTLC_COVENANT_DATA, MAX_STEALTH_COVENANT_DATA, ML_DSA_87_PUBKEY_BYTES,
         ML_DSA_87_SIG_BYTES, ML_KEM_1024_CT_BYTES, SIGHASH_ALL, SUITE_ID_ML_DSA_87,
         SUITE_ID_SENTINEL, VERIFY_COST_ML_DSA_87,
@@ -586,7 +586,7 @@ mod tests {
         out[ML_KEM_1024_CT_BYTES as usize..].copy_from_slice(&one_time_key_id);
         UtxoEntry {
             value: 100,
-            covenant_type: COV_TYPE_STEALTH,
+            covenant_type: COV_TYPE_CORE_STEALTH,
             covenant_data: out,
             creation_height: 0,
             created_by_coinbase: false,
@@ -1385,7 +1385,7 @@ mod tests {
         let keypair = Mldsa87Keypair::generate().expect("keypair");
         let entry = UtxoEntry {
             value: 1,
-            covenant_type: COV_TYPE_EXT,
+            covenant_type: COV_TYPE_CORE_EXT,
             covenant_data: core_ext_covdata(ext_id, b""),
             creation_height: 0,
             created_by_coinbase: false,
@@ -2106,7 +2106,7 @@ mod tests {
         let kp = Mldsa87Keypair::generate().expect("kp");
         let entry = UtxoEntry {
             value: 100,
-            covenant_type: COV_TYPE_STEALTH,
+            covenant_type: COV_TYPE_CORE_STEALTH,
             covenant_data: vec![0u8; 10], // wrong length (not 1600)
             creation_height: 0,
             created_by_coinbase: false,

--- a/clients/rust/crates/rubin-consensus/src/stealth.rs
+++ b/clients/rust/crates/rubin-consensus/src/stealth.rs
@@ -184,8 +184,8 @@ pub(crate) fn validate_stealth_spend_q(
 mod tests {
     use super::*;
     use crate::constants::{
-        COV_TYPE_STEALTH, MAX_STEALTH_COVENANT_DATA, ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES,
-        SUITE_ID_ML_DSA_87,
+        COV_TYPE_CORE_STEALTH, MAX_STEALTH_COVENANT_DATA, ML_DSA_87_PUBKEY_BYTES,
+        ML_DSA_87_SIG_BYTES, SUITE_ID_ML_DSA_87,
     };
     use crate::tx::{TxInput, TxOutput};
 
@@ -199,7 +199,7 @@ mod tests {
     fn dummy_entry(one_time_key_id: [u8; 32]) -> UtxoEntry {
         UtxoEntry {
             value: 100,
-            covenant_type: COV_TYPE_STEALTH,
+            covenant_type: COV_TYPE_CORE_STEALTH,
             covenant_data: stealth_cov_data(one_time_key_id),
             creation_height: 0,
             created_by_coinbase: false,

--- a/clients/rust/crates/rubin-consensus/src/tests/block_basic.rs
+++ b/clients/rust/crates/rubin-consensus/src/tests/block_basic.rs
@@ -1109,7 +1109,7 @@ fn stealth_spend_rejects_non_native_suite_via_rotation() {
 
     let entry = crate::utxo_basic::UtxoEntry {
         value: 100,
-        covenant_type: COV_TYPE_STEALTH,
+        covenant_type: COV_TYPE_CORE_STEALTH,
         covenant_data: vec![0u8; MAX_STEALTH_COVENANT_DATA as usize],
         creation_height: 0,
         created_by_coinbase: false,

--- a/clients/rust/crates/rubin-consensus/src/tests/connect_block_parallel_branches.rs
+++ b/clients/rust/crates/rubin-consensus/src/tests/connect_block_parallel_branches.rs
@@ -306,7 +306,7 @@ fn apply_non_coinbase_tx_basic_workq_stealth_branch() {
         },
         UtxoEntry {
             value: 500,
-            covenant_type: COV_TYPE_STEALTH,
+            covenant_type: COV_TYPE_CORE_STEALTH,
             covenant_data: cov_data,
             creation_height: 0,
             created_by_coinbase: false,
@@ -945,7 +945,7 @@ fn apply_non_coinbase_tx_basic_workq_vault_error_paths() {
 
     let mut disallowed_destination_tx = tx_base(crate::tx::TxOutput {
         value: 50,
-        covenant_type: COV_TYPE_EXT,
+        covenant_type: COV_TYPE_CORE_EXT,
         covenant_data: core_ext_covdata(1, &[]),
     });
     disallowed_destination_tx.witness = vec![
@@ -1004,7 +1004,7 @@ fn apply_non_coinbase_tx_basic_workq_core_ext_branches() {
         },
         UtxoEntry {
             value: 100,
-            covenant_type: COV_TYPE_EXT,
+            covenant_type: COV_TYPE_CORE_EXT,
             covenant_data: core_ext_covdata(42, &[]),
             creation_height: 0,
             created_by_coinbase: false,
@@ -1106,7 +1106,7 @@ fn apply_non_coinbase_tx_basic_workq_core_ext_branches() {
         },
         UtxoEntry {
             value: 100,
-            covenant_type: COV_TYPE_EXT,
+            covenant_type: COV_TYPE_CORE_EXT,
             covenant_data: core_ext_covdata(7, &[0x99]),
             creation_height: 0,
             created_by_coinbase: false,
@@ -1131,7 +1131,7 @@ fn apply_non_coinbase_tx_basic_workq_core_ext_branches() {
         }],
         outputs: vec![crate::tx::TxOutput {
             value: 90,
-            covenant_type: COV_TYPE_EXT,
+            covenant_type: COV_TYPE_CORE_EXT,
             covenant_data: vec![0x01],
         }],
         locktime: 0,

--- a/clients/rust/crates/rubin-consensus/src/tests/covenant_genesis.rs
+++ b/clients/rust/crates/rubin-consensus/src/tests/covenant_genesis.rs
@@ -239,7 +239,7 @@ fn validate_tx_covenants_genesis_ext_ok() {
     cov.extend_from_slice(&[0xaa, 0xbb]);
     tx.outputs = vec![crate::tx::TxOutput {
         value: 1,
-        covenant_type: COV_TYPE_EXT,
+        covenant_type: COV_TYPE_CORE_EXT,
         covenant_data: cov,
     }];
     validate_tx_covenants_genesis(&tx, 0, None).expect("ok");
@@ -253,7 +253,7 @@ fn validate_tx_covenants_genesis_ext_zero_value_rejected() {
     crate::compactsize::encode_compact_size(0, &mut cov);
     tx.outputs = vec![crate::tx::TxOutput {
         value: 0,
-        covenant_type: COV_TYPE_EXT,
+        covenant_type: COV_TYPE_CORE_EXT,
         covenant_data: cov,
     }];
     let err = validate_tx_covenants_genesis(&tx, 0, None).unwrap_err();
@@ -266,7 +266,7 @@ fn validate_tx_covenants_genesis_stealth_ok() {
     let cov = vec![0x55u8; MAX_STEALTH_COVENANT_DATA as usize];
     tx.outputs = vec![crate::tx::TxOutput {
         value: 1,
-        covenant_type: COV_TYPE_STEALTH,
+        covenant_type: COV_TYPE_CORE_STEALTH,
         covenant_data: cov,
     }];
     validate_tx_covenants_genesis(&tx, 0, None).expect("ok");
@@ -277,7 +277,7 @@ fn validate_tx_covenants_genesis_stealth_zero_value_rejected() {
     let mut tx = parse_tx(&minimal_tx_bytes()).expect("parse").0;
     tx.outputs = vec![crate::tx::TxOutput {
         value: 0,
-        covenant_type: COV_TYPE_STEALTH,
+        covenant_type: COV_TYPE_CORE_STEALTH,
         covenant_data: vec![0x55u8; MAX_STEALTH_COVENANT_DATA as usize],
     }];
     let err = validate_tx_covenants_genesis(&tx, 0, None).unwrap_err();

--- a/clients/rust/crates/rubin-consensus/src/tests/tx_validate_worker.rs
+++ b/clients/rust/crates/rubin-consensus/src/tests/tx_validate_worker.rs
@@ -494,7 +494,7 @@ fn validate_tx_local_ext_context_build_error() {
         txid: [0u8; 32],
         resolved_inputs: vec![UtxoEntry {
             value: 100,
-            covenant_type: COV_TYPE_EXT,
+            covenant_type: COV_TYPE_CORE_EXT,
             covenant_data: vec![0u8; 4], // malformed: too short for ext_id parse
             creation_height: 1,
             created_by_coinbase: false,
@@ -637,7 +637,7 @@ fn validate_tx_local_stealth_valid() {
         txid: [0u8; 32],
         resolved_inputs: vec![UtxoEntry {
             value: 100,
-            covenant_type: COV_TYPE_STEALTH,
+            covenant_type: COV_TYPE_CORE_STEALTH,
             covenant_data: stealth_covenant_data_for_pubkey(&kp.pubkey),
             creation_height: 1,
             created_by_coinbase: false,
@@ -696,7 +696,7 @@ fn validate_tx_local_core_ext_active_profile_valid() {
         txid: [0u8; 32],
         resolved_inputs: vec![UtxoEntry {
             value: 100,
-            covenant_type: COV_TYPE_EXT,
+            covenant_type: COV_TYPE_CORE_EXT,
             covenant_data: core_ext_covdata(1, &[0x99]),
             creation_height: 1,
             created_by_coinbase: false,
@@ -745,7 +745,7 @@ fn validate_tx_local_core_ext_txcontext_enabled_dispatches_verifier() {
         }],
         outputs: vec![TxOutput {
             value: 90,
-            covenant_type: COV_TYPE_EXT,
+            covenant_type: COV_TYPE_CORE_EXT,
             covenant_data: core_ext_covdata(7, &[]),
         }],
         locktime: 0,
@@ -761,7 +761,7 @@ fn validate_tx_local_core_ext_txcontext_enabled_dispatches_verifier() {
         txid: [0u8; 32],
         resolved_inputs: vec![UtxoEntry {
             value: 100,
-            covenant_type: COV_TYPE_EXT,
+            covenant_type: COV_TYPE_CORE_EXT,
             covenant_data: core_ext_covdata(7, &[0x99]),
             creation_height: 1,
             created_by_coinbase: false,
@@ -810,7 +810,7 @@ fn validate_tx_local_core_ext_txcontext_malformed_output_fails_before_verifier()
         }],
         outputs: vec![TxOutput {
             value: 90,
-            covenant_type: COV_TYPE_EXT,
+            covenant_type: COV_TYPE_CORE_EXT,
             covenant_data: vec![0x01],
         }],
         locktime: 0,
@@ -826,7 +826,7 @@ fn validate_tx_local_core_ext_txcontext_malformed_output_fails_before_verifier()
         txid: [0u8; 32],
         resolved_inputs: vec![UtxoEntry {
             value: 100,
-            covenant_type: COV_TYPE_EXT,
+            covenant_type: COV_TYPE_CORE_EXT,
             covenant_data: core_ext_covdata(7, &[0x99]),
             creation_height: 1,
             created_by_coinbase: false,
@@ -876,17 +876,17 @@ fn validate_tx_local_core_ext_txcontext_too_many_continuing_outputs_fails_before
         outputs: vec![
             TxOutput {
                 value: 30,
-                covenant_type: COV_TYPE_EXT,
+                covenant_type: COV_TYPE_CORE_EXT,
                 covenant_data: core_ext_covdata(7, &[]),
             },
             TxOutput {
                 value: 30,
-                covenant_type: COV_TYPE_EXT,
+                covenant_type: COV_TYPE_CORE_EXT,
                 covenant_data: core_ext_covdata(7, &[0x01]),
             },
             TxOutput {
                 value: 30,
-                covenant_type: COV_TYPE_EXT,
+                covenant_type: COV_TYPE_CORE_EXT,
                 covenant_data: core_ext_covdata(7, &[0x02]),
             },
         ],
@@ -903,7 +903,7 @@ fn validate_tx_local_core_ext_txcontext_too_many_continuing_outputs_fails_before
         txid: [0u8; 32],
         resolved_inputs: vec![UtxoEntry {
             value: 100,
-            covenant_type: COV_TYPE_EXT,
+            covenant_type: COV_TYPE_CORE_EXT,
             covenant_data: core_ext_covdata(7, &[0x99]),
             creation_height: 1,
             created_by_coinbase: false,

--- a/clients/rust/crates/rubin-consensus/src/tests/utxo_apply.rs
+++ b/clients/rust/crates/rubin-consensus/src/tests/utxo_apply.rs
@@ -1156,7 +1156,7 @@ fn apply_non_coinbase_tx_basic_vault_rejects_disallowed_destination_covenant_typ
     // Minimal valid CORE_EXT covenant_data: ext_id:u16le(1) || ext_payload_len:CompactSize(0).
     let core_ext_cov = vec![0x01, 0x00, 0x00];
     let whitelist_h = sha3_256(&crate::vault::output_descriptor_bytes(
-        COV_TYPE_EXT,
+        COV_TYPE_CORE_EXT,
         &core_ext_cov,
     ));
 
@@ -1183,7 +1183,7 @@ fn apply_non_coinbase_tx_basic_vault_rejects_disallowed_destination_covenant_typ
         ],
         outputs: vec![crate::tx::TxOutput {
             value: 100,
-            covenant_type: COV_TYPE_EXT,
+            covenant_type: COV_TYPE_CORE_EXT,
             covenant_data: core_ext_cov,
         }],
         locktime: 0,

--- a/clients/rust/crates/rubin-consensus/src/tx_validate_worker.rs
+++ b/clients/rust/crates/rubin-consensus/src/tx_validate_worker.rs
@@ -1,7 +1,7 @@
 use crate::block_basic::ParsedBlock;
 use crate::constants::{
-    CORE_EXT_WITNESS_SLOTS, CORE_STEALTH_WITNESS_SLOTS, COV_TYPE_EXT, COV_TYPE_HTLC,
-    COV_TYPE_MULTISIG, COV_TYPE_P2PK, COV_TYPE_STEALTH, COV_TYPE_VAULT,
+    CORE_EXT_WITNESS_SLOTS, CORE_STEALTH_WITNESS_SLOTS, COV_TYPE_CORE_EXT, COV_TYPE_CORE_STEALTH,
+    COV_TYPE_HTLC, COV_TYPE_MULTISIG, COV_TYPE_P2PK, COV_TYPE_VAULT,
 };
 use crate::core_ext::{validate_core_ext_spend_with_cache_and_suite_context_q, CoreExtProfiles};
 use crate::error::{ErrorCode, TxError};
@@ -264,7 +264,7 @@ fn validate_input_spend(
             )
         }
 
-        COV_TYPE_EXT => {
+        COV_TYPE_CORE_EXT => {
             if assigned.len() != CORE_EXT_WITNESS_SLOTS as usize {
                 return Err(TxError::new(
                     ErrorCode::TxErrParse,
@@ -287,7 +287,7 @@ fn validate_input_spend(
             )
         }
 
-        COV_TYPE_STEALTH => {
+        COV_TYPE_CORE_STEALTH => {
             if assigned.len() != CORE_STEALTH_WITNESS_SLOTS as usize {
                 return Err(TxError::new(
                     ErrorCode::TxErrParse,

--- a/clients/rust/crates/rubin-consensus/src/txcontext.rs
+++ b/clients/rust/crates/rubin-consensus/src/txcontext.rs
@@ -1,4 +1,4 @@
-use crate::constants::COV_TYPE_EXT;
+use crate::constants::COV_TYPE_CORE_EXT;
 use crate::core_ext::{parse_core_ext_covenant_data, CoreExtProfiles};
 use crate::error::{ErrorCode, TxError};
 use crate::tx::{Tx, TxOutput};
@@ -172,7 +172,7 @@ pub fn build_tx_context_output_ext_id_cache(
 ) -> Result<BTreeMap<u16, Vec<ExtIdCacheEntry>>, TxError> {
     let mut cache = BTreeMap::new();
     for (vout_index, output) in tx.outputs.iter().enumerate() {
-        if output.covenant_type != COV_TYPE_EXT {
+        if output.covenant_type != COV_TYPE_CORE_EXT {
             continue;
         }
         let covenant = parse_core_ext_covenant_data(&output.covenant_data)?;
@@ -195,7 +195,7 @@ pub(crate) fn collect_txcontext_ext_ids(
 ) -> Result<Vec<u16>, TxError> {
     let mut ext_ids = BTreeSet::new();
     for entry in resolved_inputs {
-        if entry.covenant_type != COV_TYPE_EXT {
+        if entry.covenant_type != COV_TYPE_CORE_EXT {
             continue;
         }
         let covenant = parse_core_ext_covenant_data(&entry.covenant_data)?;
@@ -309,7 +309,7 @@ mod tests {
             }],
             outputs: vec![TxOutput {
                 value: 10,
-                covenant_type: COV_TYPE_EXT,
+                covenant_type: COV_TYPE_CORE_EXT,
                 covenant_data: vec![0x01],
             }],
             locktime: 0,
@@ -349,7 +349,7 @@ mod tests {
             }],
             outputs: vec![TxOutput {
                 value: 33,
-                covenant_type: COV_TYPE_EXT,
+                covenant_type: COV_TYPE_CORE_EXT,
                 covenant_data: core_ext_covdata(7, &[0xaa]),
             }],
             locktime: 0,
@@ -360,7 +360,7 @@ mod tests {
         };
         let resolved_inputs = vec![UtxoEntry {
             value: 50,
-            covenant_type: COV_TYPE_EXT,
+            covenant_type: COV_TYPE_CORE_EXT,
             covenant_data: core_ext_covdata(7, &[0xbb]),
             creation_height: 0,
             created_by_coinbase: false,
@@ -383,21 +383,21 @@ mod tests {
         let resolved_inputs = vec![
             UtxoEntry {
                 value: 11,
-                covenant_type: COV_TYPE_EXT,
+                covenant_type: COV_TYPE_CORE_EXT,
                 covenant_data: core_ext_covdata(9, &[0x90]),
                 creation_height: 0,
                 created_by_coinbase: false,
             },
             UtxoEntry {
                 value: 12,
-                covenant_type: COV_TYPE_EXT,
+                covenant_type: COV_TYPE_CORE_EXT,
                 covenant_data: core_ext_covdata(7, &[0x71]),
                 creation_height: 0,
                 created_by_coinbase: false,
             },
             UtxoEntry {
                 value: 13,
-                covenant_type: COV_TYPE_EXT,
+                covenant_type: COV_TYPE_CORE_EXT,
                 covenant_data: core_ext_covdata(7, &[0x72]),
                 creation_height: 0,
                 created_by_coinbase: false,
@@ -421,7 +421,7 @@ mod tests {
     fn collect_txcontext_ext_ids_rejects_duplicate_active_profiles() {
         let resolved_inputs = vec![UtxoEntry {
             value: 11,
-            covenant_type: COV_TYPE_EXT,
+            covenant_type: COV_TYPE_CORE_EXT,
             covenant_data: core_ext_covdata(7, &[0x71]),
             creation_height: 0,
             created_by_coinbase: false,
@@ -468,7 +468,7 @@ mod tests {
             }],
             outputs: vec![TxOutput {
                 value: 33,
-                covenant_type: COV_TYPE_EXT,
+                covenant_type: COV_TYPE_CORE_EXT,
                 covenant_data: core_ext_covdata(7, &[]),
             }],
             locktime: 0,
@@ -479,7 +479,7 @@ mod tests {
         };
         let resolved_inputs = vec![UtxoEntry {
             value: 50,
-            covenant_type: COV_TYPE_EXT,
+            covenant_type: COV_TYPE_CORE_EXT,
             covenant_data: core_ext_covdata(7, &[0xbb]),
             creation_height: 0,
             created_by_coinbase: false,
@@ -510,7 +510,7 @@ mod tests {
             }],
             outputs: vec![TxOutput {
                 value: 33,
-                covenant_type: COV_TYPE_EXT,
+                covenant_type: COV_TYPE_CORE_EXT,
                 covenant_data: core_ext_covdata(7, &[]),
             }],
             locktime: 0,
@@ -557,7 +557,7 @@ mod tests {
         };
         let resolved_inputs = vec![UtxoEntry {
             value: 50,
-            covenant_type: COV_TYPE_EXT,
+            covenant_type: COV_TYPE_CORE_EXT,
             covenant_data: core_ext_covdata(7, &[0xbb]),
             creation_height: 0,
             created_by_coinbase: false,
@@ -609,7 +609,7 @@ mod tests {
             outputs: vec![
                 TxOutput {
                     value: 11,
-                    covenant_type: COV_TYPE_EXT,
+                    covenant_type: COV_TYPE_CORE_EXT,
                     covenant_data: core_ext_covdata(7, &[0x07, 0x01]),
                 },
                 TxOutput {
@@ -619,17 +619,17 @@ mod tests {
                 },
                 TxOutput {
                     value: 13,
-                    covenant_type: COV_TYPE_EXT,
+                    covenant_type: COV_TYPE_CORE_EXT,
                     covenant_data: core_ext_covdata(5, &[0x05, 0x01]),
                 },
                 TxOutput {
                     value: 14,
-                    covenant_type: COV_TYPE_EXT,
+                    covenant_type: COV_TYPE_CORE_EXT,
                     covenant_data: core_ext_covdata(7, &[0x07, 0x02]),
                 },
                 TxOutput {
                     value: 15,
-                    covenant_type: COV_TYPE_EXT,
+                    covenant_type: COV_TYPE_CORE_EXT,
                     covenant_data: core_ext_covdata(5, &[0x05, 0x02]),
                 },
             ],
@@ -642,14 +642,14 @@ mod tests {
         let resolved_inputs = vec![
             UtxoEntry {
                 value: 100,
-                covenant_type: COV_TYPE_EXT,
+                covenant_type: COV_TYPE_CORE_EXT,
                 covenant_data: core_ext_covdata(7, &[0xaa]),
                 creation_height: 0,
                 created_by_coinbase: false,
             },
             UtxoEntry {
                 value: 200,
-                covenant_type: COV_TYPE_EXT,
+                covenant_type: COV_TYPE_CORE_EXT,
                 covenant_data: core_ext_covdata(5, &[0xbb]),
                 creation_height: 0,
                 created_by_coinbase: false,
@@ -707,7 +707,7 @@ mod tests {
             }],
             outputs: vec![TxOutput {
                 value: 33,
-                covenant_type: COV_TYPE_EXT,
+                covenant_type: COV_TYPE_CORE_EXT,
                 covenant_data: core_ext_covdata(7, &[]),
             }],
             locktime: 0,
@@ -718,7 +718,7 @@ mod tests {
         };
         let resolved_inputs = vec![UtxoEntry {
             value: 50,
-            covenant_type: COV_TYPE_EXT,
+            covenant_type: COV_TYPE_CORE_EXT,
             covenant_data: core_ext_covdata(7, &[0xaa]),
             creation_height: 0,
             created_by_coinbase: false,
@@ -766,32 +766,32 @@ mod tests {
             outputs: vec![
                 TxOutput {
                     value: 1,
-                    covenant_type: COV_TYPE_EXT,
+                    covenant_type: COV_TYPE_CORE_EXT,
                     covenant_data: core_ext_covdata(9, &[0x91]),
                 },
                 TxOutput {
                     value: 2,
-                    covenant_type: COV_TYPE_EXT,
+                    covenant_type: COV_TYPE_CORE_EXT,
                     covenant_data: core_ext_covdata(7, &[0x71]),
                 },
                 TxOutput {
                     value: 3,
-                    covenant_type: COV_TYPE_EXT,
+                    covenant_type: COV_TYPE_CORE_EXT,
                     covenant_data: core_ext_covdata(9, &[0x92]),
                 },
                 TxOutput {
                     value: 4,
-                    covenant_type: COV_TYPE_EXT,
+                    covenant_type: COV_TYPE_CORE_EXT,
                     covenant_data: core_ext_covdata(7, &[0x72]),
                 },
                 TxOutput {
                     value: 5,
-                    covenant_type: COV_TYPE_EXT,
+                    covenant_type: COV_TYPE_CORE_EXT,
                     covenant_data: core_ext_covdata(7, &[0x73]),
                 },
                 TxOutput {
                     value: 6,
-                    covenant_type: COV_TYPE_EXT,
+                    covenant_type: COV_TYPE_CORE_EXT,
                     covenant_data: core_ext_covdata(9, &[0x93]),
                 },
             ],
@@ -804,14 +804,14 @@ mod tests {
         let resolved_inputs = vec![
             UtxoEntry {
                 value: 100,
-                covenant_type: COV_TYPE_EXT,
+                covenant_type: COV_TYPE_CORE_EXT,
                 covenant_data: core_ext_covdata(9, &[0xaa]),
                 creation_height: 0,
                 created_by_coinbase: false,
             },
             UtxoEntry {
                 value: 200,
-                covenant_type: COV_TYPE_EXT,
+                covenant_type: COV_TYPE_CORE_EXT,
                 covenant_data: core_ext_covdata(7, &[0xbb]),
                 creation_height: 0,
                 created_by_coinbase: false,

--- a/clients/rust/crates/rubin-consensus/src/utxo_basic.rs
+++ b/clients/rust/crates/rubin-consensus/src/utxo_basic.rs
@@ -2,8 +2,8 @@ use std::collections::HashMap;
 use std::ops::Range;
 
 use crate::constants::{
-    COINBASE_MATURITY, COV_TYPE_ANCHOR, COV_TYPE_DA_COMMIT, COV_TYPE_EXT, COV_TYPE_HTLC,
-    COV_TYPE_MULTISIG, COV_TYPE_P2PK, COV_TYPE_STEALTH, COV_TYPE_VAULT,
+    COINBASE_MATURITY, COV_TYPE_ANCHOR, COV_TYPE_CORE_EXT, COV_TYPE_CORE_STEALTH,
+    COV_TYPE_DA_COMMIT, COV_TYPE_HTLC, COV_TYPE_MULTISIG, COV_TYPE_P2PK, COV_TYPE_VAULT,
 };
 use crate::core_ext::{validate_core_ext_spend_with_cache_and_suite_context_q, CoreExtProfiles};
 use crate::covenant_genesis::validate_tx_covenants_genesis;
@@ -483,7 +483,7 @@ fn apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles_and_suite_c
                     )?,
                 }
             }
-            COV_TYPE_EXT => {
+            COV_TYPE_CORE_EXT => {
                 if assigned.len() != 1 {
                     return Err(TxError::new(
                         ErrorCode::TxErrParse,
@@ -521,7 +521,7 @@ fn apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles_and_suite_c
                     )?,
                 }
             }
-            COV_TYPE_STEALTH => {
+            COV_TYPE_CORE_STEALTH => {
                 if assigned.len() != 1 {
                     return Err(TxError::new(
                         ErrorCode::TxErrParse,
@@ -813,11 +813,11 @@ fn check_spend_covenant(covenant_type: u16, covenant_data: &[u8]) -> Result<(), 
     if covenant_type == COV_TYPE_P2PK {
         return Ok(());
     }
-    if covenant_type == COV_TYPE_EXT {
+    if covenant_type == COV_TYPE_CORE_EXT {
         let _ = crate::core_ext::parse_core_ext_covenant_data(covenant_data)?;
         return Ok(());
     }
-    if covenant_type == COV_TYPE_STEALTH {
+    if covenant_type == COV_TYPE_CORE_STEALTH {
         let _ = parse_stealth_covenant_data(covenant_data)?;
         return Ok(());
     }
@@ -963,7 +963,7 @@ mod tests {
             },
             UtxoEntry {
                 value: 100,
-                covenant_type: COV_TYPE_EXT,
+                covenant_type: COV_TYPE_CORE_EXT,
                 covenant_data: core_ext_covdata(7, &[0x99]),
                 creation_height: 0,
                 created_by_coinbase: false,
@@ -995,7 +995,7 @@ mod tests {
             }],
             outputs: vec![TxOutput {
                 value: 90,
-                covenant_type: COV_TYPE_EXT,
+                covenant_type: COV_TYPE_CORE_EXT,
                 covenant_data: core_ext_covdata(7, &[]),
             }],
             locktime: 0,
@@ -1063,7 +1063,7 @@ mod tests {
             }],
             outputs: vec![TxOutput {
                 value: 90,
-                covenant_type: COV_TYPE_EXT,
+                covenant_type: COV_TYPE_CORE_EXT,
                 covenant_data: vec![0x01],
             }],
             locktime: 0,
@@ -1121,17 +1121,17 @@ mod tests {
             outputs: vec![
                 TxOutput {
                     value: 30,
-                    covenant_type: COV_TYPE_EXT,
+                    covenant_type: COV_TYPE_CORE_EXT,
                     covenant_data: core_ext_covdata(7, &[]),
                 },
                 TxOutput {
                     value: 30,
-                    covenant_type: COV_TYPE_EXT,
+                    covenant_type: COV_TYPE_CORE_EXT,
                     covenant_data: core_ext_covdata(7, &[0x01]),
                 },
                 TxOutput {
                     value: 30,
-                    covenant_type: COV_TYPE_EXT,
+                    covenant_type: COV_TYPE_CORE_EXT,
                     covenant_data: core_ext_covdata(7, &[0x02]),
                 },
             ],
@@ -1189,7 +1189,7 @@ mod tests {
             }],
             outputs: vec![TxOutput {
                 value: 90,
-                covenant_type: COV_TYPE_EXT,
+                covenant_type: COV_TYPE_CORE_EXT,
                 covenant_data: vec![0x01],
             }],
             locktime: 0,
@@ -1714,7 +1714,7 @@ mod tests {
             },
             UtxoEntry {
                 value: 500,
-                covenant_type: COV_TYPE_STEALTH,
+                covenant_type: COV_TYPE_CORE_STEALTH,
                 covenant_data: stealth_covenant_data_for_pubkey(&keypair.pubkey_bytes()),
                 creation_height: 0,
                 created_by_coinbase: false,
@@ -1744,7 +1744,7 @@ mod tests {
             }],
             outputs: vec![TxOutput {
                 value: 90,
-                covenant_type: COV_TYPE_EXT,
+                covenant_type: COV_TYPE_CORE_EXT,
                 covenant_data: core_ext_covdata(7, &[]),
             }],
             locktime: 0,

--- a/clients/rust/crates/rubin-consensus/src/vault.rs
+++ b/clients/rust/crates/rubin-consensus/src/vault.rs
@@ -1,7 +1,7 @@
 use crate::compactsize::encode_compact_size;
 use crate::constants::{
-    CORE_STEALTH_WITNESS_SLOTS, COV_TYPE_EXT, COV_TYPE_HTLC, COV_TYPE_MULTISIG, COV_TYPE_P2PK,
-    COV_TYPE_STEALTH, COV_TYPE_VAULT, MAX_MULTISIG_KEYS, MAX_VAULT_KEYS,
+    CORE_STEALTH_WITNESS_SLOTS, COV_TYPE_CORE_EXT, COV_TYPE_CORE_STEALTH, COV_TYPE_HTLC,
+    COV_TYPE_MULTISIG, COV_TYPE_P2PK, COV_TYPE_VAULT, MAX_MULTISIG_KEYS, MAX_VAULT_KEYS,
     MAX_VAULT_WHITELIST_ENTRIES,
 };
 use crate::error::{ErrorCode, TxError};
@@ -199,8 +199,8 @@ pub fn output_descriptor_bytes(covenant_type: u16, covenant_data: &[u8]) -> Vec<
 pub fn witness_slots(covenant_type: u16, covenant_data: &[u8]) -> Result<usize, TxError> {
     match covenant_type {
         COV_TYPE_P2PK => Ok(1),
-        COV_TYPE_EXT => Ok(1),
-        COV_TYPE_STEALTH => Ok(CORE_STEALTH_WITNESS_SLOTS as usize),
+        COV_TYPE_CORE_EXT => Ok(1),
+        COV_TYPE_CORE_STEALTH => Ok(CORE_STEALTH_WITNESS_SLOTS as usize),
         COV_TYPE_MULTISIG => Ok(covenant_data.get(1).copied().unwrap_or(1) as usize),
         // CORE_VAULT: owner_lock_id[32] || threshold[1] || key_count[1] || ...
         COV_TYPE_VAULT => Ok(covenant_data.get(33).copied().unwrap_or(1) as usize),

--- a/clients/rust/crates/rubin-consensus/tests/covenant_genesis_fuzz.rs
+++ b/clients/rust/crates/rubin-consensus/tests/covenant_genesis_fuzz.rs
@@ -4,8 +4,8 @@
 //! Invariant: no panic on any parsed Tx + block_height; deterministic results.
 
 use rubin_consensus::constants::{
-    COV_TYPE_ANCHOR, COV_TYPE_DA_COMMIT, COV_TYPE_EXT, COV_TYPE_HTLC, COV_TYPE_MULTISIG,
-    COV_TYPE_P2PK, COV_TYPE_RESERVED_FUTURE, COV_TYPE_STEALTH, COV_TYPE_VAULT,
+    COV_TYPE_ANCHOR, COV_TYPE_CORE_EXT, COV_TYPE_CORE_STEALTH, COV_TYPE_DA_COMMIT, COV_TYPE_HTLC,
+    COV_TYPE_MULTISIG, COV_TYPE_P2PK, COV_TYPE_RESERVED_FUTURE, COV_TYPE_VAULT,
     MAX_P2PK_COVENANT_DATA, SUITE_ID_ML_DSA_87,
 };
 use rubin_consensus::{parse_tx, validate_tx_covenants_genesis, Tx, TxInput, TxOutput};
@@ -269,11 +269,11 @@ fn cov_genesis_all_known_types_no_panic() {
     for cov_type in [
         COV_TYPE_P2PK,
         COV_TYPE_ANCHOR,
-        COV_TYPE_EXT,
+        COV_TYPE_CORE_EXT,
         COV_TYPE_HTLC,
         COV_TYPE_VAULT,
         COV_TYPE_MULTISIG,
-        COV_TYPE_STEALTH,
+        COV_TYPE_CORE_STEALTH,
         COV_TYPE_DA_COMMIT,
         COV_TYPE_RESERVED_FUTURE,
         0xFFFF,

--- a/clients/rust/crates/rubin-consensus/tests/vault_multisig.rs
+++ b/clients/rust/crates/rubin-consensus/tests/vault_multisig.rs
@@ -396,12 +396,12 @@ fn witness_slots_p2pk() {
 
 #[test]
 fn witness_slots_ext() {
-    assert_eq!(witness_slots(0x0102, &[]).unwrap(), 1); // COV_TYPE_EXT
+    assert_eq!(witness_slots(0x0102, &[]).unwrap(), 1); // COV_TYPE_CORE_EXT
 }
 
 #[test]
 fn witness_slots_stealth() {
-    assert_eq!(witness_slots(0x0105, &[]).unwrap(), 1); // COV_TYPE_STEALTH (CORE_STEALTH_WITNESS_SLOTS=1)
+    assert_eq!(witness_slots(0x0105, &[]).unwrap(), 1); // COV_TYPE_CORE_STEALTH (CORE_STEALTH_WITNESS_SLOTS=1)
 }
 
 #[test]

--- a/clients/rust/crates/rubin-node/src/sync.rs
+++ b/clients/rust/crates/rubin-node/src/sync.rs
@@ -1199,7 +1199,9 @@ mod tests {
     use std::sync::Arc;
     use std::time::{SystemTime, UNIX_EPOCH};
 
-    use rubin_consensus::constants::{COV_TYPE_EXT, COV_TYPE_P2PK, POW_LIMIT, SUITE_ID_ML_DSA_87};
+    use rubin_consensus::constants::{
+        COV_TYPE_CORE_EXT, COV_TYPE_P2PK, POW_LIMIT, SUITE_ID_ML_DSA_87,
+    };
     use rubin_consensus::merkle::{witness_commitment_hash, witness_merkle_root_wtxids};
     use rubin_consensus::{
         block_hash, encode_compact_size, merkle_root_txids, parse_block_bytes, parse_tx,
@@ -1617,7 +1619,7 @@ mod tests {
             },
             UtxoEntry {
                 value: 100,
-                covenant_type: COV_TYPE_EXT,
+                covenant_type: COV_TYPE_CORE_EXT,
                 covenant_data: vec![0x01, 0x00, 0x00],
                 creation_height: 0,
                 created_by_coinbase: false,
@@ -1700,7 +1702,7 @@ mod tests {
             },
             UtxoEntry {
                 value: 100,
-                covenant_type: COV_TYPE_EXT,
+                covenant_type: COV_TYPE_CORE_EXT,
                 covenant_data: vec![0x01, 0x00, 0x00],
                 creation_height: 0,
                 created_by_coinbase: false,

--- a/clients/rust/crates/rubin-node/src/txpool.rs
+++ b/clients/rust/crates/rubin-node/src/txpool.rs
@@ -1432,7 +1432,7 @@ pub(crate) fn reject_core_ext_tx_oversized_payload(
         return Ok(());
     }
     for (i, output) in tx.outputs.iter().enumerate() {
-        if output.covenant_type != rubin_consensus::constants::COV_TYPE_EXT {
+        if output.covenant_type != rubin_consensus::constants::COV_TYPE_CORE_EXT {
             continue;
         }
         let cov = match parse_core_ext_covenant_data(&output.covenant_data) {
@@ -1616,7 +1616,7 @@ pub(crate) fn reject_core_ext_tx_pre_activation(
         .active_profiles_at_height(height)
         .map_err(|err| err.to_string())?;
     for output in &tx.outputs {
-        if output.covenant_type != rubin_consensus::constants::COV_TYPE_EXT {
+        if output.covenant_type != rubin_consensus::constants::COV_TYPE_CORE_EXT {
             continue;
         }
         let cov =
@@ -1637,7 +1637,7 @@ pub(crate) fn reject_core_ext_tx_pre_activation(
         let Some(entry) = utxos.get(&outpoint) else {
             continue;
         };
-        if entry.covenant_type != rubin_consensus::constants::COV_TYPE_EXT {
+        if entry.covenant_type != rubin_consensus::constants::COV_TYPE_CORE_EXT {
             continue;
         }
         let cov =
@@ -1813,7 +1813,7 @@ mod tests {
 
     use rubin_consensus::block::BLOCK_HEADER_BYTES;
     use rubin_consensus::constants::{
-        COV_TYPE_ANCHOR, COV_TYPE_EXT, COV_TYPE_P2PK, SUITE_ID_SENTINEL, TX_WIRE_VERSION,
+        COV_TYPE_ANCHOR, COV_TYPE_CORE_EXT, COV_TYPE_P2PK, SUITE_ID_SENTINEL, TX_WIRE_VERSION,
     };
     use rubin_consensus::{
         marshal_tx, p2pk_covenant_data_for_pubkey, parse_tx, sign_transaction,
@@ -2030,7 +2030,7 @@ mod tests {
             input.clone(),
             UtxoEntry {
                 value: 10,
-                covenant_type: COV_TYPE_EXT,
+                covenant_type: COV_TYPE_CORE_EXT,
                 covenant_data: empty_core_ext_covenant_data(ext_id),
                 creation_height: 0,
                 created_by_coinbase: false,
@@ -2256,7 +2256,7 @@ mod tests {
             10,
             vec![TxOutput {
                 value: 9,
-                covenant_type: COV_TYPE_EXT,
+                covenant_type: COV_TYPE_CORE_EXT,
                 covenant_data: empty_core_ext_covenant_data(7),
             }],
             0x00,
@@ -3396,7 +3396,7 @@ mod tests {
             7700,
             vec![TxOutput {
                 value: 9,
-                covenant_type: COV_TYPE_EXT,
+                covenant_type: COV_TYPE_CORE_EXT,
                 covenant_data: empty_core_ext_covenant_data(7),
             }],
             0x00,
@@ -3429,7 +3429,7 @@ mod tests {
             7_542,
             vec![TxOutput {
                 value: 9,
-                covenant_type: COV_TYPE_EXT,
+                covenant_type: COV_TYPE_CORE_EXT,
                 covenant_data: empty_core_ext_covenant_data(7),
             }],
             0x00,
@@ -3511,7 +3511,7 @@ mod tests {
             inputs: vec![],
             outputs: vec![TxOutput {
                 value: 1,
-                covenant_type: COV_TYPE_EXT,
+                covenant_type: COV_TYPE_CORE_EXT,
                 covenant_data: core_ext_covenant_data_with_payload(5, &[0u8; 32]),
             }],
             locktime: 0,
@@ -3532,7 +3532,7 @@ mod tests {
             inputs: vec![],
             outputs: vec![TxOutput {
                 value: 1,
-                covenant_type: COV_TYPE_EXT,
+                covenant_type: COV_TYPE_CORE_EXT,
                 covenant_data: core_ext_covenant_data_with_payload(5, &[0u8; 48]),
             }],
             locktime: 0,
@@ -3553,7 +3553,7 @@ mod tests {
             inputs: vec![],
             outputs: vec![TxOutput {
                 value: 1,
-                covenant_type: COV_TYPE_EXT,
+                covenant_type: COV_TYPE_CORE_EXT,
                 covenant_data: core_ext_covenant_data_with_payload(5, &[0u8; 49]),
             }],
             locktime: 0,
@@ -3597,7 +3597,7 @@ mod tests {
             inputs: vec![],
             outputs: vec![TxOutput {
                 value: 1,
-                covenant_type: COV_TYPE_EXT,
+                covenant_type: COV_TYPE_CORE_EXT,
                 covenant_data: core_ext_covenant_data_with_payload(5, &[0u8; 100]),
             }],
             locktime: 0,
@@ -3618,7 +3618,7 @@ mod tests {
             inputs: vec![],
             outputs: vec![TxOutput {
                 value: 1,
-                covenant_type: COV_TYPE_EXT,
+                covenant_type: COV_TYPE_CORE_EXT,
                 covenant_data: core_ext_covenant_data_with_payload(5, &[]),
             }],
             locktime: 0,
@@ -4755,7 +4755,7 @@ mod tests {
             10,
             vec![TxOutput {
                 value: 9,
-                covenant_type: COV_TYPE_EXT,
+                covenant_type: COV_TYPE_CORE_EXT,
                 covenant_data: empty_core_ext_covenant_data(7),
             }],
             0x00,

--- a/clients/rust/fuzz/fuzz_targets/spend_dispatch_structural.rs
+++ b/clients/rust/fuzz/fuzz_targets/spend_dispatch_structural.rs
@@ -32,8 +32,8 @@ fuzz_target!(|data: &[u8]| {
         1 => 0x0100, // COV_TYPE_HTLC
         2 => 0x0101, // COV_TYPE_VAULT
         3 => 0x0104, // COV_TYPE_MULTISIG
-        4 => 0x0102, // COV_TYPE_EXT
-        5 => 0x0105, // COV_TYPE_STEALTH
+        4 => 0x0102, // COV_TYPE_CORE_EXT
+        5 => 0x0105, // COV_TYPE_CORE_STEALTH
         _ => unreachable!(),
     };
     pos += 2; // consume both bytes for layout stability
@@ -106,8 +106,8 @@ fuzz_target!(|data: &[u8]| {
     // (2 slots), VAULT/MULTISIG (threshold-dependent) are reachable.
     let witness_slot_count: usize = match covenant_type {
         0x0000 => 1, // COV_TYPE_P2PK
-        0x0102 => 1, // COV_TYPE_EXT
-        0x0105 => 1, // COV_TYPE_STEALTH
+        0x0102 => 1, // COV_TYPE_CORE_EXT
+        0x0105 => 1, // COV_TYPE_CORE_STEALTH
         0x0100 => 2, // COV_TYPE_HTLC
         0x0104 => {   // COV_TYPE_MULTISIG: threshold from covenant_data[1]
             covenant_data.get(1).copied().unwrap_or(1).max(1) as usize

--- a/clients/rust/fuzz/fuzz_targets/txcontext_bundle.rs
+++ b/clients/rust/fuzz/fuzz_targets/txcontext_bundle.rs
@@ -1,7 +1,7 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use rubin_consensus::constants::{COV_TYPE_EXT, COV_TYPE_P2PK};
+use rubin_consensus::constants::{COV_TYPE_CORE_EXT, COV_TYPE_P2PK};
 
 fuzz_target!(|data: &[u8]| {
     if data.len() < 4 {
@@ -47,7 +47,7 @@ fuzz_target!(|data: &[u8]| {
         });
         resolved_inputs.push(rubin_consensus::UtxoEntry {
             value: 1 + take(1).first().copied().unwrap_or(0) as u64,
-            covenant_type: if is_ext { COV_TYPE_EXT } else { COV_TYPE_P2PK },
+            covenant_type: if is_ext { COV_TYPE_CORE_EXT } else { COV_TYPE_P2PK },
             covenant_data: if is_ext {
                 mk_cov(ext_id, payload)
             } else {
@@ -66,7 +66,7 @@ fuzz_target!(|data: &[u8]| {
         let is_ext = take(1).first().copied().unwrap_or(0) % 2 == 0;
         outputs.push(rubin_consensus::TxOutput {
             value: take(1).first().copied().unwrap_or(0) as u64,
-            covenant_type: if is_ext { COV_TYPE_EXT } else { COV_TYPE_P2PK },
+            covenant_type: if is_ext { COV_TYPE_CORE_EXT } else { COV_TYPE_P2PK },
             covenant_data: if is_ext {
                 mk_cov(ext_id, payload)
             } else {

--- a/clients/rust/fuzz/fuzz_targets/validate_tx_local.rs
+++ b/clients/rust/fuzz/fuzz_targets/validate_tx_local.rs
@@ -50,8 +50,8 @@ fuzz_target!(|data: &[u8]| {
         1 => 0x0100, // COV_TYPE_HTLC
         2 => 0x0101, // COV_TYPE_VAULT
         3 => 0x0104, // COV_TYPE_MULTISIG
-        4 => 0x0102, // COV_TYPE_EXT
-        5 => 0x0105, // COV_TYPE_STEALTH
+        4 => 0x0102, // COV_TYPE_CORE_EXT
+        5 => 0x0105, // COV_TYPE_CORE_STEALTH
         _ => unreachable!(),
     };
 


### PR DESCRIPTION
Refs: Q-IMPL-CONSENSUS-COV-TYPE-CONSTANT-NAMING-PARITY-01

## Summary

RUB-20 naming-only Rust COV constant parity cleanup.

Invariant: Rust COV-related identifiers match Go/spec terminology without changing numeric values, wire bytes, fixtures, or runtime behavior.

## Scope

Changed surface: `clients/rust/**` only.

| Old Rust identifier | New Rust identifier | Go/spec counterpart | Value |
| --- | --- | --- | --- |
| `COV_TYPE_EXT` | `COV_TYPE_CORE_EXT` | `COV_TYPE_CORE_EXT` | `0x0102` |
| `COV_TYPE_STEALTH` | `COV_TYPE_CORE_STEALTH` | `COV_TYPE_CORE_STEALTH` | `0x0105` |

Compatibility: old Rust public constants are retained as deprecated aliases to the new names.

Consensus rules unchanged: YES
SECTION_HASHES.json unchanged: YES

### Parity exemption justification

This is the approved RUB-20 Rust-only naming parity cleanup. Go already uses the target names; this PR renames Rust identifiers to match Go/spec terminology while preserving the same numeric values (`0x0102`, `0x0105`) and updating Rust call sites only. No Go implementation change is required for parity.

## Non-Scope

- no Go changes
- no numeric value changes
- no serialization or wire-format changes
- no spec, fixture, conformance, or generated artifact changes
- no runtime behavior change

## Validation

- `cargo fmt --check`
- `cargo test -p rubin-consensus`
- `cargo test -p rubin-consensus-cli`
- `cargo test -p rubin-node`
- `cargo test -p rubin-consensus constants::tests:: -- --nocapture`
- `cargo check --manifest-path fuzz/Cargo.toml --bins`
- `cargo clippy --workspace -- -D warnings`
- `git diff --check`
- `tooling-check --new-only --mode rust-deep`
- `rubin-precommit-one-review`
- stock read-only code-review subagents: no findings
- `rubin-push` with typed no-coverage reason for Rust naming-only no-branch/no-logic diff: PASS

Refs: RUB-20; GitHub mirror #1192.


<!-- rubin-agent-meta actor=unknown action=pr-edit via=cl branch=codex/RUB-20-cov-type-constant-naming-parity wt=rubin-protocol-codex-RUB-20 utc=2026-05-14T16:53:45Z -->
