### PR TITLE
RUB-19: add Rust work-from-target API parity

### DIFF
--- a/clients/rust/crates/rubin-consensus-cli/src/main.rs
+++ b/clients/rust/crates/rubin-consensus-cli/src/main.rs
@@ -10,16 +10,15 @@ use rubin_consensus::{
     block_hash, compact_shortid,
     connect_block_basic_in_memory_at_height_and_core_ext_deployments_with_suite_context,
     core_ext_profile_set_anchor_v1, featurebit_state_at_height_from_window_counts,
-    flagday_active_at_height, fork_work_from_target, merkle_root_txids,
-    parse_core_ext_covenant_data, parse_tx, pow_check, retarget_v1, retarget_v1_clamped,
-    sighash_v1_digest, tx_weight_and_stats_at_height, tx_weight_and_stats_public,
-    validate_block_basic_with_context_and_fees_at_height,
+    flagday_active_at_height, merkle_root_txids, parse_core_ext_covenant_data, parse_tx, pow_check,
+    retarget_v1, retarget_v1_clamped, sighash_v1_digest, tx_weight_and_stats_at_height,
+    tx_weight_and_stats_public, validate_block_basic_with_context_and_fees_at_height,
     validate_block_basic_with_context_at_height, validate_rotation_descriptor_for_network,
-    validate_rotation_set_for_network, validate_tx_covenants_genesis, CoreExtDeploymentProfile,
-    CoreExtDeploymentProfiles, CryptoRotationDescriptor, DescriptorRotationProvider, ErrorCode,
-    FeatureBitDeployment, FeatureBitState, FlagDayDeployment, InMemoryChainState, Outpoint,
-    RotationProvider, SuiteParams, SuiteRegistry, UtxoEntry,
-    ROTATION_V1_PRODUCTION_AT_MOST_ONE_DESCRIPTOR_ERR_STEM,
+    validate_rotation_set_for_network, validate_tx_covenants_genesis, work_from_target,
+    CoreExtDeploymentProfile, CoreExtDeploymentProfiles, CryptoRotationDescriptor,
+    DescriptorRotationProvider, ErrorCode, FeatureBitDeployment, FeatureBitState,
+    FlagDayDeployment, InMemoryChainState, Outpoint, RotationProvider, SuiteParams, SuiteRegistry,
+    UtxoEntry, ROTATION_V1_PRODUCTION_AT_MOST_ONE_DESCRIPTOR_ERR_STEM,
     ROTATION_V1_PRODUCTION_FINITE_H4_REQUIRED_ERR_STEM,
 };
 use rubin_node::{devnet_genesis_chain_id, ChainState, TxPool, TxPoolAdmitErrorKind, TxPoolConfig};
@@ -1891,7 +1890,7 @@ fn main() {
                 }
             };
 
-            match fork_work_from_target(target) {
+            match work_from_target(target) {
                 Ok(w) => {
                     let resp = Response {
                         ok: true,
@@ -1962,7 +1961,7 @@ fn main() {
                             return;
                         }
                     };
-                    match fork_work_from_target(t) {
+                    match work_from_target(t) {
                         Ok(w) => total += w,
                         Err(e) => {
                             let resp = Response {

--- a/clients/rust/crates/rubin-consensus/src/fork_choice.rs
+++ b/clients/rust/crates/rubin-consensus/src/fork_choice.rs
@@ -3,11 +3,11 @@ use crate::error::{ErrorCode, TxError};
 use num_bigint::BigUint;
 use num_traits::{One, Zero};
 
-// fork_work_from_target computes CANONICAL §23 per-block work:
+// work_from_target computes CANONICAL §23 per-block work:
 //   work = floor(2^256 / target)
 //
 // This is non-validation helper logic but MUST be deterministic and MUST NOT use floats.
-pub fn fork_work_from_target(target: [u8; 32]) -> Result<BigUint, TxError> {
+pub fn work_from_target(target: [u8; 32]) -> Result<BigUint, TxError> {
     let t = BigUint::from_bytes_be(&target);
     if t.is_zero() {
         return Err(TxError::new(
@@ -28,12 +28,22 @@ pub fn fork_work_from_target(target: [u8; 32]) -> Result<BigUint, TxError> {
     Ok(two256 / t)
 }
 
-pub fn fork_chainwork_from_targets(targets: &[[u8; 32]]) -> Result<BigUint, TxError> {
+pub fn chain_work_from_targets(targets: &[[u8; 32]]) -> Result<BigUint, TxError> {
     let mut total = BigUint::zero();
     for t in targets {
-        total += fork_work_from_target(*t)?;
+        total += work_from_target(*t)?;
     }
     Ok(total)
+}
+
+#[deprecated(note = "use work_from_target")]
+pub fn fork_work_from_target(target: [u8; 32]) -> Result<BigUint, TxError> {
+    work_from_target(target)
+}
+
+#[deprecated(note = "use chain_work_from_targets")]
+pub fn fork_chainwork_from_targets(targets: &[[u8; 32]]) -> Result<BigUint, TxError> {
+    chain_work_from_targets(targets)
 }
 
 #[cfg(test)]
@@ -41,24 +51,99 @@ mod tests {
     use super::*;
 
     #[test]
-    fn fork_work_accepts_pow_limit_boundary() {
-        let work = fork_work_from_target(POW_LIMIT).expect("pow_limit must be accepted");
+    fn work_from_target_accepts_pow_limit_boundary() {
+        let work = work_from_target(POW_LIMIT).expect("pow_limit must be accepted");
         assert_eq!(work, BigUint::one());
     }
 
     #[test]
-    fn fork_work_is_deterministic() {
+    fn work_from_target_is_deterministic() {
         let target = POW_LIMIT;
-        let w1 = fork_work_from_target(target).expect("work 1");
-        let w2 = fork_work_from_target(target).expect("work 2");
+        let w1 = work_from_target(target).expect("work 1");
+        let w2 = work_from_target(target).expect("work 2");
         assert_eq!(w1, w2);
     }
 
     #[test]
-    fn fork_chainwork_is_deterministic() {
+    fn chain_work_from_targets_is_deterministic() {
         let targets = [POW_LIMIT, POW_LIMIT];
-        let w1 = fork_chainwork_from_targets(&targets).expect("chainwork 1");
-        let w2 = fork_chainwork_from_targets(&targets).expect("chainwork 2");
+        let w1 = chain_work_from_targets(&targets).expect("chainwork 1");
+        let w2 = chain_work_from_targets(&targets).expect("chainwork 2");
         assert_eq!(w1, w2);
+    }
+
+    #[test]
+    fn work_from_target_rejects_zero_target_with_exact_error() {
+        let err = work_from_target([0u8; 32]).unwrap_err();
+        assert_eq!(err.code, ErrorCode::TxErrParse);
+        assert_eq!(err.msg, "fork_work: target is zero");
+    }
+
+    #[test]
+    fn work_from_target_accepts_one_min_target() {
+        let mut target = [0u8; 32];
+        target[31] = 0x01;
+
+        let work = work_from_target(target).expect("target one must be accepted");
+        let two256: BigUint = BigUint::one() << 256usize;
+        assert_eq!(work, two256);
+    }
+
+    #[test]
+    fn work_from_target_accepts_half_range_target() {
+        let mut target = [0u8; 32];
+        target[0] = 0x80;
+
+        let work = work_from_target(target).expect("half-range target must be accepted");
+        assert_eq!(work, BigUint::from(2u8));
+    }
+
+    #[test]
+    fn chain_work_from_targets_sums_and_propagates_invalid_target() {
+        let mut half = [0u8; 32];
+        half[0] = 0x80;
+
+        let total = chain_work_from_targets(&[POW_LIMIT, half]).expect("chainwork");
+        assert_eq!(total, BigUint::from(3u8));
+
+        let err = chain_work_from_targets(&[[0u8; 32], POW_LIMIT]).unwrap_err();
+        assert_eq!(err.code, ErrorCode::TxErrParse);
+        assert_eq!(err.msg, "fork_work: target is zero");
+    }
+
+    #[test]
+    fn above_pow_limit_target_is_unrepresentable_with_current_pow_limit() {
+        assert_eq!(POW_LIMIT, [0xffu8; 32]);
+        let pow_limit = BigUint::from_bytes_be(&POW_LIMIT);
+        let max_u256 = (BigUint::one() << 256usize) - BigUint::one();
+        assert_eq!(pow_limit, max_u256);
+    }
+
+    #[allow(deprecated)]
+    #[test]
+    fn deprecated_fork_work_aliases_match_canonical_helpers() {
+        let mut half = [0u8; 32];
+        half[0] = 0x80;
+
+        assert_eq!(
+            fork_work_from_target(half).expect("alias work"),
+            work_from_target(half).expect("canonical work")
+        );
+
+        let alias_err = fork_work_from_target([0u8; 32]).unwrap_err();
+        let canonical_err = work_from_target([0u8; 32]).unwrap_err();
+        assert_eq!(alias_err.code, canonical_err.code);
+        assert_eq!(alias_err.msg, canonical_err.msg);
+
+        let targets = [POW_LIMIT, half];
+        assert_eq!(
+            fork_chainwork_from_targets(&targets).expect("alias chainwork"),
+            chain_work_from_targets(&targets).expect("canonical chainwork")
+        );
+
+        let alias_err = fork_chainwork_from_targets(&[[0u8; 32], POW_LIMIT]).unwrap_err();
+        let canonical_err = chain_work_from_targets(&[[0u8; 32], POW_LIMIT]).unwrap_err();
+        assert_eq!(alias_err.code, canonical_err.code);
+        assert_eq!(alias_err.msg, canonical_err.msg);
     }
 }

--- a/clients/rust/crates/rubin-consensus/src/lib.rs
+++ b/clients/rust/crates/rubin-consensus/src/lib.rs
@@ -79,6 +79,8 @@ pub use featurebits::{
     FeatureBitState,
 };
 pub use flagday::{flagday_active_at_height, FlagDayDeployment};
+pub use fork_choice::{chain_work_from_targets, work_from_target};
+#[allow(deprecated)]
 pub use fork_choice::{fork_chainwork_from_targets, fork_work_from_target};
 pub use htlc::{parse_htlc_covenant_data, validate_htlc_spend, HtlcCovenant};
 pub use merkle::merkle_root_txids;

--- a/clients/rust/crates/rubin-consensus/src/tests/utxo_apply.rs
+++ b/clients/rust/crates/rubin-consensus/src/tests/utxo_apply.rs
@@ -1380,40 +1380,42 @@ fn apply_non_coinbase_tx_basic_multisig_input_accepted() {
 }
 
 #[test]
-fn fork_work_vectors() {
+fn work_from_target_vectors() {
     let ff = [0xffu8; 32];
-    let w = crate::fork_work_from_target(ff).expect("work");
+    let w = crate::work_from_target(ff).expect("work");
     assert_eq!(w, BigUint::one());
 
     let mut half = [0u8; 32];
     half[0] = 0x80;
-    let w = crate::fork_work_from_target(half).expect("work");
+    let w = crate::work_from_target(half).expect("work");
     assert_eq!(w, BigUint::from(2u8));
 
     let mut one = [0u8; 32];
     one[31] = 0x01;
-    let w = crate::fork_work_from_target(one).expect("work");
+    let w = crate::work_from_target(one).expect("work");
     let two256: BigUint = BigUint::one() << 256usize;
     assert_eq!(w, two256);
 }
 
 #[test]
-fn fork_work_rejects_zero_target() {
-    let err = crate::fork_work_from_target([0u8; 32]).unwrap_err();
+fn work_from_target_rejects_zero_target() {
+    let err = crate::work_from_target([0u8; 32]).unwrap_err();
     assert_eq!(err.code, ErrorCode::TxErrParse);
+    assert_eq!(err.msg, "fork_work: target is zero");
 }
 
 #[test]
-fn fork_chainwork_from_targets_accumulates_and_propagates_error() {
+fn chain_work_from_targets_accumulates_and_propagates_error() {
     let ff = [0xffu8; 32];
     let mut half = [0u8; 32];
     half[0] = 0x80;
 
-    let total = crate::fork_chainwork_from_targets(&[ff, half]).expect("chainwork");
+    let total = crate::chain_work_from_targets(&[ff, half]).expect("chainwork");
     assert_eq!(total, BigUint::from(3u8));
 
-    let err = crate::fork_chainwork_from_targets(&[[0u8; 32], ff]).unwrap_err();
+    let err = crate::chain_work_from_targets(&[[0u8; 32], ff]).unwrap_err();
     assert_eq!(err.code, ErrorCode::TxErrParse);
+    assert_eq!(err.msg, "fork_work: target is zero");
 }
 
 #[test]

--- a/clients/rust/crates/rubin-node/src/blockstore.rs
+++ b/clients/rust/crates/rubin-node/src/blockstore.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 
 use num_bigint::BigUint;
 use rubin_consensus::{
-    block_hash, fork_chainwork_from_targets, parse_block_header_bytes, BLOCK_HEADER_BYTES,
+    block_hash, chain_work_from_targets, parse_block_header_bytes, BLOCK_HEADER_BYTES,
 };
 use serde::{Deserialize, Serialize};
 
@@ -542,7 +542,7 @@ impl BlockStore {
             targets.push(header.target);
             current = header.prev_block_hash;
         }
-        fork_chainwork_from_targets(&targets).map_err(|e| e.to_string())
+        chain_work_from_targets(&targets).map_err(|e| e.to_string())
     }
 
     // ----- Undo storage -----

--- a/clients/rust/crates/rubin-node/src/sync_reorg.rs
+++ b/clients/rust/crates/rubin-node/src/sync_reorg.rs
@@ -390,8 +390,8 @@ impl SyncEngine {
         let ancestor_work = block_store.chain_work(common_ancestor_hash)?;
 
         let branch_targets: Vec<[u8; 32]> = branch.iter().map(|b| b.target).collect();
-        let branch_work = rubin_consensus::fork_chainwork_from_targets(&branch_targets)
-            .map_err(|e| e.to_string())?;
+        let branch_work =
+            rubin_consensus::chain_work_from_targets(&branch_targets).map_err(|e| e.to_string())?;
 
         let candidate_work = ancestor_work + branch_work;
 

--- a/clients/rust/fuzz/fuzz_targets/fork_work.rs
+++ b/clients/rust/fuzz/fuzz_targets/fork_work.rs
@@ -2,7 +2,7 @@
 
 use libfuzzer_sys::fuzz_target;
 
-// Fuzz fork_work_from_target: chainwork calculation (2^256 / target).
+// Fuzz work_from_target: chainwork calculation (2^256 / target).
 // Tests no-panic, determinism, and BigUint arithmetic on arbitrary targets.
 fuzz_target!(|data: &[u8]| {
     if data.len() < 32 {
@@ -12,17 +12,17 @@ fuzz_target!(|data: &[u8]| {
     let mut target = [0u8; 32];
     target.copy_from_slice(&data[..32]);
 
-    let r1 = rubin_consensus::fork_work_from_target(target);
-    let r2 = rubin_consensus::fork_work_from_target(target);
+    let r1 = rubin_consensus::work_from_target(target);
+    let r2 = rubin_consensus::work_from_target(target);
 
     match (&r1, &r2) {
         (Ok(a), Ok(b)) => {
             if a != b {
-                panic!("fork_work_from_target non-deterministic");
+                panic!("work_from_target non-deterministic");
             }
         }
         (Err(_), Err(_)) => {}
-        _ => panic!("fork_work_from_target non-deterministic error/ok mismatch"),
+        _ => panic!("work_from_target non-deterministic error/ok mismatch"),
     }
 
     // Also test chainwork accumulation if enough data.
@@ -34,6 +34,6 @@ fuzz_target!(|data: &[u8]| {
             t.copy_from_slice(&data[i * 32..(i + 1) * 32]);
             targets.push(t);
         }
-        let _ = rubin_consensus::fork_chainwork_from_targets(&targets);
+        let _ = rubin_consensus::chain_work_from_targets(&targets);
     }
 });


### PR DESCRIPTION
Closes #1191

Invariant:
Rust consensus work-from-target helper API matches Go naming/shape/edge behavior without changing consensus math.

Layer:
Rust implementation API parity, consensus-adjacent.

Files changed:
- Rust consensus fork-choice helper API and exports
- Rust consensus CLI/callsite/fuzz references to canonical helper names

Tests:
- `cargo fmt --check` - PASS
- `cargo test -p rubin-consensus fork_choice` - PASS
- `cargo test -p rubin-consensus` - PASS
- `cargo test -p rubin-consensus-cli` - PASS
- `cargo test -p rubin-node` - PASS
- `cargo check --manifest-path fuzz/Cargo.toml --bins` - PASS
- `cargo clippy --workspace -- -D warnings` - PASS
- `tooling-check.sh --new-only --mode rust-deep` - PASS
- stock code-review subagent - No findings
- `rubin-push` local gates - PASS

Behavior impact:
No consensus math, target encoding, POW limit, retarget, block validation, fork-choice selection, CLI op, or JSON output behavior changed.

Compatibility impact:
Adds canonical Rust `work_from_target` / `chain_work_from_targets`; preserves old public `fork_*` helpers as deprecated wrappers.

Known non-goals:
No Go, conformance, formal, spec, workflow, or Cargo changes.

### Parity exemption justification

This is a Rust-to-Go API naming parity change. The Go consensus/reference API already exposes the target work helper shape that RUB-19 asks Rust to match, so a matching Go source change would be artificial churn. The PR changes Rust consensus helper names and Rust callsites only, preserves old Rust wrappers for compatibility, and does not change consensus math, CLI operation names, JSON output, fixtures, or conformance behavior.
