### PR TITLE
RUB-236: add Rust txpool snapshot restore

### DIFF
--- a/clients/rust/crates/rubin-node/src/txpool.rs
+++ b/clients/rust/crates/rubin-node/src/txpool.rs
@@ -125,10 +125,8 @@ pub struct TxPoolEntry {
     pub source: TxSource,
 }
 
-/// Defensive rollback snapshot for Rust `TxPool`. Go `sync_mempool.go` map:
-/// raw/inputs/fee/weight/size/source -> `TxPoolEntry`, txid -> `TxPoolSnapshotEntry.txid`,
-/// admissionSeq/lastAdmissionSeq -> `heap_id`/`next_heap_id`, currentMinFeeRate -> Rust cfg floor.
-/// Go wtxid has no Rust resident/index field; restore reparses raw and validates txid/weight/inputs.
+/// Defensive rollback snapshot for Rust `TxPool`.
+/// Maps Go `sync_mempool.go` fields to Rust resident state; Rust stores no resident wtxid.
 #[derive(Debug, Clone)]
 pub struct TxPoolSnapshot {
     cfg: TxPoolConfig,
@@ -2193,30 +2191,20 @@ mod tests {
     }
 
     fn assert_txpool_snapshot_same(actual: &TxPoolSnapshot, expected: &TxPoolSnapshot) {
-        assert_eq!(actual.entries.len(), expected.entries.len(), "entry count");
-        assert_eq!(
-            actual.next_heap_id, expected.next_heap_id,
-            "heap high-water"
-        );
-        assert_eq!(
-            actual.max_transactions, expected.max_transactions,
-            "max txs"
-        );
-        assert_eq!(actual.max_bytes, expected.max_bytes, "max bytes");
-        assert_eq!(
-            actual.low_water_bytes, expected.low_water_bytes,
-            "low water"
-        );
-        assert_eq!(actual.used_bytes, expected.used_bytes, "used bytes");
+        assert_eq!(actual.entries.len(), expected.entries.len());
+        assert_eq!(actual.next_heap_id, expected.next_heap_id);
+        assert_eq!(actual.max_transactions, expected.max_transactions);
+        assert_eq!(actual.max_bytes, expected.max_bytes);
+        assert_eq!(actual.low_water_bytes, expected.low_water_bytes);
+        assert_eq!(actual.used_bytes, expected.used_bytes);
         assert_eq!(
             actual.cfg.policy_current_mempool_min_fee_rate,
-            expected.cfg.policy_current_mempool_min_fee_rate,
-            "current floor"
+            expected.cfg.policy_current_mempool_min_fee_rate
         );
         for (actual, expected) in actual.entries.iter().zip(&expected.entries) {
-            assert_eq!(actual.txid, expected.txid, "txid");
-            assert_eq!(actual.heap_id, expected.heap_id, "heap id");
-            assert_eq!(actual.entry, expected.entry, "entry");
+            assert_eq!(actual.txid, expected.txid);
+            assert_eq!(actual.heap_id, expected.heap_id);
+            assert_eq!(actual.entry, expected.entry);
         }
     }
 

--- a/clients/rust/crates/rubin-node/src/txpool.rs
+++ b/clients/rust/crates/rubin-node/src/txpool.rs
@@ -404,6 +404,9 @@ impl TxPool {
                 snapshot.next_heap_id, max_heap_id
             )));
         }
+        if snapshot.next_heap_id == u64::MAX {
+            return Err(rejected("txpool snapshot heap high-watermark saturated"));
+        }
 
         self.cfg.policy_current_mempool_min_fee_rate = snapshot.current_mempool_min_fee_rate;
         self.txs = txs;
@@ -2622,6 +2625,9 @@ mod tests {
         let mut high_water = guard_snapshot.clone();
         high_water.next_heap_id = 1;
         reject(high_water, "high-watermark");
+        let mut saturated = guard_snapshot.clone();
+        saturated.next_heap_id = u64::MAX;
+        reject(saturated, "high-watermark saturated");
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/txpool.rs
+++ b/clients/rust/crates/rubin-node/src/txpool.rs
@@ -314,7 +314,7 @@ impl TxPool {
         if self.next_heap_id < max_heap_id {
             return Err(rejected("txpool snapshot heap high-watermark below max"));
         }
-        if u64::MAX - self.next_heap_id <= self.max_transactions as u64 {
+        if u64::MAX - self.next_heap_id <= (self.max_transactions as u64).saturating_add(1) {
             return Err(rejected("txpool snapshot heap near saturation"));
         }
         let floor = self.cfg.policy_current_mempool_min_fee_rate;
@@ -425,7 +425,7 @@ impl TxPool {
                 snapshot.next_heap_id, max_heap_id
             )));
         }
-        if u64::MAX - snapshot.next_heap_id <= self.max_transactions as u64 {
+        if u64::MAX - snapshot.next_heap_id <= (self.max_transactions as u64).saturating_add(1) {
             return Err(rejected("txpool snapshot heap near saturation"));
         }
 
@@ -2618,14 +2618,14 @@ mod tests {
         high_water.next_heap_id = 1;
         reject(high_water, "high-watermark");
         let mut saturated = guard_snapshot.clone();
-        saturated.next_heap_id = u64::MAX - 1;
+        saturated.next_heap_id = u64::MAX - 8;
         reject(saturated, "heap near saturation");
         target.used_bytes += 1;
         assert!(target.snapshot().is_err());
         target.used_bytes -= 1;
         target.next_heap_id = 1;
         assert!(target.snapshot().is_err());
-        target.next_heap_id = u64::MAX - 1;
+        target.next_heap_id = u64::MAX - 8;
         assert!(target.snapshot().is_err());
     }
 

--- a/clients/rust/crates/rubin-node/src/txpool.rs
+++ b/clients/rust/crates/rubin-node/src/txpool.rs
@@ -132,9 +132,6 @@ pub(crate) struct TxPoolSnapshot {
     current_mempool_min_fee_rate: u64,
     entries: Vec<TxPoolSnapshotEntry>,
     next_heap_id: u64,
-    max_transactions: usize,
-    max_bytes: usize,
-    low_water_bytes: usize,
     used_bytes: usize,
 }
 
@@ -310,9 +307,6 @@ impl TxPool {
             current_mempool_min_fee_rate: self.cfg.policy_current_mempool_min_fee_rate,
             entries,
             next_heap_id: self.next_heap_id,
-            max_transactions: self.max_transactions,
-            max_bytes: self.max_bytes,
-            low_water_bytes: self.low_water_bytes,
             used_bytes: self.used_bytes,
         })
     }
@@ -322,17 +316,17 @@ impl TxPool {
         &mut self,
         snapshot: &TxPoolSnapshot,
     ) -> Result<(), TxPoolAdmitError> {
-        if snapshot.max_transactions == 0 || snapshot.max_bytes == 0 {
+        if self.max_transactions == 0 || self.max_bytes == 0 {
             return Err(unavailable(format!(
                 "invalid txpool snapshot restore limits: max_txs={} max_bytes={}",
-                snapshot.max_transactions, snapshot.max_bytes
+                self.max_transactions, self.max_bytes
             )));
         }
-        if snapshot.entries.len() > snapshot.max_transactions {
+        if snapshot.entries.len() > self.max_transactions {
             return Err(unavailable(format!(
                 "txpool snapshot exceeds transaction cap: count={} max={}",
                 snapshot.entries.len(),
-                snapshot.max_transactions
+                self.max_transactions
             )));
         }
 
@@ -369,10 +363,10 @@ impl TxPool {
             let next_used = used_bytes
                 .checked_add(item.entry.size)
                 .ok_or_else(|| unavailable("txpool snapshot byte accounting overflow"))?;
-            if item.entry.size > snapshot.max_bytes || next_used > snapshot.max_bytes {
+            if item.entry.size > self.max_bytes || next_used > self.max_bytes {
                 return Err(unavailable(format!(
                     "txpool snapshot exceeds byte cap: used={} entry={} max={}",
-                    used_bytes, item.entry.size, snapshot.max_bytes
+                    used_bytes, item.entry.size, self.max_bytes
                 )));
             }
             for input in &item.entry.inputs {
@@ -417,9 +411,6 @@ impl TxPool {
         self.heap_seqs = heap_seqs;
         self.worst_heap = worst_heap;
         self.next_heap_id = snapshot.next_heap_id;
-        self.max_transactions = snapshot.max_transactions;
-        self.max_bytes = snapshot.max_bytes;
-        self.low_water_bytes = snapshot.low_water_bytes;
         self.used_bytes = used_bytes;
         Ok(())
     }
@@ -2196,9 +2187,6 @@ mod tests {
     fn assert_txpool_snapshot_same(actual: &TxPoolSnapshot, expected: &TxPoolSnapshot) {
         assert_eq!(actual.entries.len(), expected.entries.len());
         assert_eq!(actual.next_heap_id, expected.next_heap_id);
-        assert_eq!(actual.max_transactions, expected.max_transactions);
-        assert_eq!(actual.max_bytes, expected.max_bytes);
-        assert_eq!(actual.low_water_bytes, expected.low_water_bytes);
         assert_eq!(actual.used_bytes, expected.used_bytes);
         assert_eq!(
             actual.current_mempool_min_fee_rate,
@@ -2514,7 +2502,6 @@ mod tests {
 
         pool.evict_txids(&[txid_a, txid_b]);
         pool.cfg.policy_current_mempool_min_fee_rate = 99;
-        pool.set_capacity_for_test(1, 1);
         assert!(pool.is_empty(), "live pool mutated before restore");
 
         pool.restore_snapshot(&snapshot)
@@ -2543,6 +2530,7 @@ mod tests {
             pool.cfg.policy_reject_core_ext_pre_activation
                 && pool.cfg.policy_current_mempool_min_fee_rate == 11
         );
+        assert_eq!(pool.max_transactions, 7);
     }
 
     #[test]
@@ -2550,6 +2538,18 @@ mod tests {
         let (guard_pool, _guard_a, _guard_b) = txpool_snapshot_test_pool();
         let guard_snapshot = guard_pool.snapshot().expect("guard snapshot");
         let (mut target, _target_a, _target_b) = txpool_snapshot_test_pool();
+        let mut duplicate_spender = guard_snapshot.clone();
+        let (_conflict_state, raw_a, raw_b) = signed_conflicting_p2pk_state_and_txs(7700, 10, 9);
+        let (_txid_a, item_a) = txpool_snapshot_entry_from_raw(raw_a, 7690, TxSource::Local, 1);
+        let (_txid_b, item_b) = txpool_snapshot_entry_from_raw(raw_b, 7691, TxSource::Remote, 2);
+        duplicate_spender.entries = vec![item_a, item_b];
+        duplicate_spender.used_bytes = duplicate_spender
+            .entries
+            .iter()
+            .map(|item| item.entry.size)
+            .sum();
+        duplicate_spender.next_heap_id = 2;
+        target.set_capacity_for_test(7, duplicate_spender.used_bytes + 1);
 
         let mut reject = |poison: TxPoolSnapshot, needle: &str| {
             let before = target.snapshot().expect("target snapshot before poison");
@@ -2572,18 +2572,6 @@ mod tests {
         duplicate_txid.entries.push(duplicate_item);
         reject(duplicate_txid, "duplicate txpool snapshot txid");
 
-        let mut duplicate_spender = guard_snapshot.clone();
-        let (_conflict_state, raw_a, raw_b) = signed_conflicting_p2pk_state_and_txs(7700, 10, 9);
-        let (_txid_a, item_a) = txpool_snapshot_entry_from_raw(raw_a, 7690, TxSource::Local, 1);
-        let (_txid_b, item_b) = txpool_snapshot_entry_from_raw(raw_b, 7691, TxSource::Remote, 2);
-        duplicate_spender.entries = vec![item_a, item_b];
-        duplicate_spender.used_bytes = duplicate_spender
-            .entries
-            .iter()
-            .map(|item| item.entry.size)
-            .sum();
-        duplicate_spender.max_bytes = duplicate_spender.used_bytes + 1;
-        duplicate_spender.next_heap_id = 2;
         reject(duplicate_spender, "duplicate txpool snapshot spender");
 
         let mut duplicate_heap = guard_snapshot.clone();
@@ -2616,12 +2604,18 @@ mod tests {
         let mut zero_weight = guard_snapshot.clone();
         zero_weight.entries[0].entry.weight = 0;
         reject(zero_weight, "invalid txpool snapshot entry weight");
-        let mut count_cap = guard_snapshot.clone();
-        count_cap.max_transactions = 1;
-        reject(count_cap, "transaction cap");
-        let mut byte_cap = guard_snapshot.clone();
-        byte_cap.max_bytes = guard_snapshot.entries[0].entry.size;
-        reject(byte_cap, "byte cap");
+        let reject_live_cap = |max_txs, max_bytes, needle| {
+            let mut target = TxPool::new();
+            target.set_capacity_for_test(max_txs, max_bytes);
+            let before = target.snapshot().expect("empty target snapshot");
+            let err = target
+                .restore_snapshot(&guard_snapshot)
+                .expect_err("live capacity must fail closed");
+            assert!(err.message.contains(needle), "got: {}", err.message);
+            assert_txpool_snapshot_same(&target.snapshot().expect("after"), &before);
+        };
+        reject_live_cap(1, usize::MAX, "transaction cap");
+        reject_live_cap(7, guard_snapshot.entries[0].entry.size, "byte cap");
         let mut used_mismatch = guard_snapshot.clone();
         used_mismatch.used_bytes += 1;
         reject(used_mismatch, "used_bytes mismatch");

--- a/clients/rust/crates/rubin-node/src/txpool.rs
+++ b/clients/rust/crates/rubin-node/src/txpool.rs
@@ -126,7 +126,7 @@ pub struct TxPoolEntry {
 }
 
 /// Defensive rollback snapshot for Rust `TxPool`.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(not(test), allow(dead_code))]
 pub(crate) struct TxPoolSnapshot {
     current_mempool_min_fee_rate: u64,
@@ -135,10 +135,11 @@ pub(crate) struct TxPoolSnapshot {
     used_bytes: usize,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(not(test), allow(dead_code))]
 struct TxPoolSnapshotEntry {
     txid: [u8; 32],
+    wtxid: [u8; 32],
     entry: TxPoolEntry,
     heap_id: u64,
 }
@@ -296,8 +297,10 @@ impl TxPool {
                     hex::encode(txid)
                 )));
             }
+            let wtxid = validate_txpool_snapshot_entry(*txid, None, entry)?;
             entries.push(TxPoolSnapshotEntry {
                 txid: *txid,
+                wtxid,
                 entry: entry.clone(),
                 heap_id,
             });
@@ -331,6 +334,7 @@ impl TxPool {
         }
 
         let mut txs = HashMap::with_capacity(snapshot.entries.len());
+        let mut wtxids = HashMap::with_capacity(snapshot.entries.len());
         let mut spenders = HashMap::new();
         let mut heap_seqs = HashMap::with_capacity(snapshot.entries.len());
         let mut admission_seqs = HashMap::with_capacity(snapshot.entries.len());
@@ -352,7 +356,15 @@ impl TxPool {
                     hex::encode(item.txid)
                 )));
             }
-            validate_txpool_snapshot_entry(item.txid, &item.entry)?;
+            if let Some(existing) = wtxids.insert(item.wtxid, item.txid) {
+                return Err(rejected(format!(
+                    "duplicate txpool snapshot wtxid {} existing={} new={}",
+                    hex::encode(item.wtxid),
+                    hex::encode(existing),
+                    hex::encode(item.txid)
+                )));
+            }
+            validate_txpool_snapshot_entry(item.txid, Some(item.wtxid), &item.entry)?;
             if let Some(existing) = admission_seqs.insert(heap_id, item.txid) {
                 return Err(rejected(format!(
                     "duplicate txpool snapshot heap id {heap_id} existing={} new={}",
@@ -978,8 +990,9 @@ impl TxPool {
 #[cfg_attr(not(test), allow(dead_code))]
 fn validate_txpool_snapshot_entry(
     txid: [u8; 32],
+    wtxid: Option<[u8; 32]>,
     entry: &TxPoolEntry,
-) -> Result<(), TxPoolAdmitError> {
+) -> Result<[u8; 32], TxPoolAdmitError> {
     if entry.size == 0 {
         return Err(rejected(format!(
             "invalid txpool snapshot entry size for txid {}: size=0 raw_len={}",
@@ -1001,7 +1014,7 @@ fn validate_txpool_snapshot_entry(
             entry.raw.len()
         )));
     }
-    let (tx, raw_txid, _wtxid, consumed) = parse_tx(&entry.raw).map_err(|err| {
+    let (tx, raw_txid, raw_wtxid, consumed) = parse_tx(&entry.raw).map_err(|err| {
         rejected(format!(
             "invalid txpool snapshot entry raw for txid {}: {err}",
             hex::encode(txid)
@@ -1020,6 +1033,12 @@ fn validate_txpool_snapshot_entry(
             "txpool snapshot entry txid mismatch: entry={} raw={}",
             hex::encode(txid),
             hex::encode(raw_txid)
+        )));
+    }
+    if wtxid.is_some_and(|wtxid| wtxid != raw_wtxid) {
+        return Err(rejected(format!(
+            "txpool snapshot entry wtxid mismatch for txid {}",
+            hex::encode(txid)
         )));
     }
     let (weight, _, _) = tx_weight_and_stats_public(&tx).map_err(|err| {
@@ -1051,7 +1070,7 @@ fn validate_txpool_snapshot_entry(
         )));
     }
     // Go validates string source; Rust's closed `TxSource` cannot represent invalid values.
-    Ok(())
+    Ok(raw_wtxid)
 }
 
 /// Returns the metadata a relay peer needs to forward the transaction
@@ -2132,7 +2151,7 @@ mod tests {
         source: TxSource,
         heap_id: u64,
     ) -> ([u8; 32], TxPoolSnapshotEntry) {
-        let (tx, txid, _wtxid, consumed) = parse_tx(&raw).expect("parse snapshot raw");
+        let (tx, txid, wtxid, consumed) = parse_tx(&raw).expect("parse snapshot raw");
         assert_eq!(consumed, raw.len(), "snapshot raw must be canonical");
         let inputs = tx
             .inputs
@@ -2148,6 +2167,7 @@ mod tests {
             txid,
             TxPoolSnapshotEntry {
                 txid,
+                wtxid,
                 entry: TxPoolEntry {
                     raw,
                     inputs,
@@ -2185,21 +2205,6 @@ mod tests {
         pool.insert_entry(txid_a, item_a.entry);
         pool.insert_entry(txid_b, item_b.entry);
         (pool, txid_a, txid_b)
-    }
-
-    fn assert_txpool_snapshot_same(actual: &TxPoolSnapshot, expected: &TxPoolSnapshot) {
-        assert_eq!(actual.entries.len(), expected.entries.len());
-        assert_eq!(actual.next_heap_id, expected.next_heap_id);
-        assert_eq!(actual.used_bytes, expected.used_bytes);
-        assert_eq!(
-            actual.current_mempool_min_fee_rate,
-            expected.current_mempool_min_fee_rate
-        );
-        for (actual, expected) in actual.entries.iter().zip(&expected.entries) {
-            assert_eq!(actual.txid, expected.txid);
-            assert_eq!(actual.heap_id, expected.heap_id);
-            assert_eq!(actual.entry, expected.entry);
-        }
     }
 
     fn genesis_coinbase_bytes() -> Vec<u8> {
@@ -2500,7 +2505,6 @@ mod tests {
         let selected_before = pool.select_transactions(10, usize::MAX);
         let heap_before = pool.worst_heap.clone().into_sorted_vec();
         let snapshot = pool.snapshot().expect("snapshot");
-        assert_eq!(snapshot.entries[0].txid, txid_a.min(txid_b));
         assert_eq!(snapshot.entries[1].txid, txid_a.max(txid_b));
 
         pool.evict_txids(&[txid_a, txid_b]);
@@ -2509,7 +2513,7 @@ mod tests {
 
         pool.restore_snapshot(&snapshot)
             .expect("valid snapshot restores");
-        assert_txpool_snapshot_same(&pool.snapshot().expect("snapshot"), &snapshot);
+        assert_eq!(&pool.snapshot().expect("snapshot"), &snapshot);
         assert_eq!(pool.worst_heap.clone().into_sorted_vec(), heap_before);
         for item in &snapshot.entries {
             assert_eq!(pool.heap_seqs.get(&item.txid), Some(&item.heap_id));
@@ -2564,9 +2568,9 @@ mod tests {
                 "expected error containing {needle:?}, got: {}",
                 err.message
             );
-            assert_txpool_snapshot_same(
+            assert_eq!(
                 &target.snapshot().expect("target snapshot after poison"),
-                &before,
+                &before
             );
         };
 
@@ -2580,6 +2584,9 @@ mod tests {
         let mut duplicate_heap = guard_snapshot.clone();
         duplicate_heap.entries[1].heap_id = duplicate_heap.entries[0].heap_id;
         reject(duplicate_heap, "duplicate txpool snapshot heap id");
+        let mut duplicate_wtxid = guard_snapshot.clone();
+        duplicate_wtxid.entries[1].wtxid = duplicate_wtxid.entries[0].wtxid;
+        reject(duplicate_wtxid, "duplicate txpool snapshot wtxid");
 
         let mut missing_heap = guard_snapshot.clone();
         missing_heap.entries[0].heap_id = 0;
@@ -2588,25 +2595,18 @@ mod tests {
         invalid_raw.entries[0].entry.raw = vec![0xff];
         invalid_raw.entries[0].entry.size = 1;
         reject(invalid_raw, "invalid txpool snapshot entry raw");
-        let mut trailing = guard_snapshot.clone();
-        trailing.entries[0].entry.raw.push(0);
-        trailing.entries[0].entry.size += 1;
-        reject(trailing, "trailing bytes");
         let mut txid_mismatch = guard_snapshot.clone();
         txid_mismatch.entries[0].txid = [0x99; 32];
         reject(txid_mismatch, "txid mismatch");
+        let mut wtxid_mismatch = guard_snapshot.clone();
+        wtxid_mismatch.entries[0].wtxid = [0x88; 32];
+        reject(wtxid_mismatch, "wtxid mismatch");
         let mut weight_mismatch = guard_snapshot.clone();
         weight_mismatch.entries[0].entry.weight += 1;
         reject(weight_mismatch, "weight mismatch");
         let mut input_mismatch = guard_snapshot.clone();
         input_mismatch.entries[0].entry.inputs.clear();
         reject(input_mismatch, "input list mismatch");
-        let mut zero_size = guard_snapshot.clone();
-        zero_size.entries[0].entry.size = 0;
-        reject(zero_size, "invalid txpool snapshot entry size");
-        let mut zero_weight = guard_snapshot.clone();
-        zero_weight.entries[0].entry.weight = 0;
-        reject(zero_weight, "invalid txpool snapshot entry weight");
         let reject_live_cap = |max_txs, max_bytes, needle| {
             let mut target = TxPool::new();
             target.set_capacity_for_test(max_txs, max_bytes);
@@ -2615,7 +2615,7 @@ mod tests {
                 .restore_snapshot(&guard_snapshot)
                 .expect_err("live capacity must fail closed");
             assert!(err.message.contains(needle), "got: {}", err.message);
-            assert_txpool_snapshot_same(&target.snapshot().expect("after"), &before);
+            assert_eq!(&target.snapshot().expect("after"), &before);
         };
         reject_live_cap(1, usize::MAX, "transaction cap");
         reject_live_cap(7, guard_snapshot.entries[0].entry.size, "byte cap");

--- a/clients/rust/crates/rubin-node/src/txpool.rs
+++ b/clients/rust/crates/rubin-node/src/txpool.rs
@@ -1003,6 +1003,9 @@ fn validate_txpool_snapshot_entry(
     wtxid: Option<[u8; 32]>,
     entry: &TxPoolEntry,
 ) -> Result<[u8; 32], TxPoolAdmitError> {
+    if txid == [0u8; 32] {
+        return Err(rejected("invalid txpool snapshot entry txid"));
+    }
     if entry.size == 0 {
         return Err(rejected("invalid txpool snapshot entry size"));
     }
@@ -2581,6 +2584,9 @@ mod tests {
         let mut txid_mismatch = guard_snapshot.clone();
         txid_mismatch.entries[0].txid = [0x99; 32];
         reject(txid_mismatch, "txid mismatch");
+        let mut zero_txid = guard_snapshot.clone();
+        zero_txid.entries[0].txid = [0u8; 32];
+        reject(zero_txid, "invalid txpool snapshot entry txid");
         let mut wtxid_mismatch = guard_snapshot.clone();
         wtxid_mismatch.entries[0].wtxid = [0x88; 32];
         reject(wtxid_mismatch, "wtxid mismatch");

--- a/clients/rust/crates/rubin-node/src/txpool.rs
+++ b/clients/rust/crates/rubin-node/src/txpool.rs
@@ -416,8 +416,8 @@ impl TxPool {
                 snapshot.next_heap_id, max_heap_id
             )));
         }
-        if snapshot.next_heap_id == u64::MAX {
-            return Err(rejected("txpool snapshot heap high-watermark saturated"));
+        if u64::MAX - snapshot.next_heap_id < self.max_transactions as u64 {
+            return Err(rejected("txpool snapshot heap near saturation"));
         }
 
         self.cfg.policy_current_mempool_min_fee_rate = snapshot.current_mempool_min_fee_rate;
@@ -2626,8 +2626,8 @@ mod tests {
         high_water.next_heap_id = 1;
         reject(high_water, "high-watermark");
         let mut saturated = guard_snapshot.clone();
-        saturated.next_heap_id = u64::MAX;
-        reject(saturated, "high-watermark saturated");
+        saturated.next_heap_id = u64::MAX - 1;
+        reject(saturated, "heap near saturation");
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/txpool.rs
+++ b/clients/rust/crates/rubin-node/src/txpool.rs
@@ -306,8 +306,12 @@ impl TxPool {
             });
         }
         entries.sort_by_key(|item| item.txid);
+        if u64::MAX - self.next_heap_id <= self.max_transactions as u64 {
+            return Err(rejected("txpool snapshot heap near saturation"));
+        }
+        let floor = self.cfg.policy_current_mempool_min_fee_rate;
         Ok(TxPoolSnapshot {
-            current_mempool_min_fee_rate: self.cfg.policy_current_mempool_min_fee_rate,
+            current_mempool_min_fee_rate: floor.max(DEFAULT_MEMPOOL_MIN_FEE_RATE),
             entries,
             next_heap_id: self.next_heap_id,
             used_bytes: self.used_bytes,
@@ -417,7 +421,8 @@ impl TxPool {
             return Err(rejected("txpool snapshot heap near saturation"));
         }
 
-        self.cfg.policy_current_mempool_min_fee_rate = snapshot.current_mempool_min_fee_rate;
+        let floor = snapshot.current_mempool_min_fee_rate;
+        self.cfg.policy_current_mempool_min_fee_rate = floor.max(DEFAULT_MEMPOOL_MIN_FEE_RATE);
         self.txs = txs;
         self.spenders = spenders;
         self.heap_seqs = heap_seqs;
@@ -2502,7 +2507,6 @@ mod tests {
         let selected_before = pool.select_transactions(10, usize::MAX);
         let heap_before = pool.worst_heap.clone().into_sorted_vec();
         let snapshot = pool.snapshot().expect("snapshot");
-        assert_eq!(snapshot.entries[1].txid, txid_a.max(txid_b));
 
         pool.evict_txids(&[txid_a, txid_b]);
         pool.cfg.policy_current_mempool_min_fee_rate = 99;
@@ -2522,7 +2526,7 @@ mod tests {
         assert_eq!(pool.cfg.policy_current_mempool_min_fee_rate, 7);
 
         let lenient_snapshot = TxPool::new_with_config(TxPoolConfig {
-            policy_current_mempool_min_fee_rate: 11,
+            policy_current_mempool_min_fee_rate: 0,
             policy_reject_core_ext_pre_activation: false,
             ..TxPoolConfig::default()
         })
@@ -2530,11 +2534,8 @@ mod tests {
         .expect("lenient snapshot");
         pool.restore_snapshot(&lenient_snapshot)
             .expect("empty snapshot restores");
-        assert!(
-            pool.cfg.policy_reject_core_ext_pre_activation
-                && pool.cfg.policy_current_mempool_min_fee_rate == 11
-        );
-        assert_eq!(pool.max_transactions, 7);
+        assert!(pool.cfg.policy_reject_core_ext_pre_activation);
+        assert!(pool.cfg.policy_current_mempool_min_fee_rate == DEFAULT_MEMPOOL_MIN_FEE_RATE);
     }
 
     #[test]
@@ -2575,16 +2576,13 @@ mod tests {
         let duplicate_item = duplicate_txid.entries[0].clone();
         duplicate_txid.entries.push(duplicate_item);
         reject(duplicate_txid, "duplicate txpool snapshot txid");
-
         reject(duplicate_spender, "duplicate txpool snapshot spender");
-
         let mut duplicate_heap = guard_snapshot.clone();
         duplicate_heap.entries[1].heap_id = duplicate_heap.entries[0].heap_id;
         reject(duplicate_heap, "duplicate txpool snapshot heap id");
         let mut duplicate_wtxid = guard_snapshot.clone();
         duplicate_wtxid.entries[1].wtxid = duplicate_wtxid.entries[0].wtxid;
         reject(duplicate_wtxid, "duplicate txpool snapshot wtxid");
-
         let mut missing_heap = guard_snapshot.clone();
         missing_heap.entries[0].heap_id = 0;
         reject(missing_heap, "invalid txpool snapshot heap id");
@@ -2628,6 +2626,8 @@ mod tests {
         let mut saturated = guard_snapshot.clone();
         saturated.next_heap_id = u64::MAX - 1;
         reject(saturated, "heap near saturation");
+        target.next_heap_id = u64::MAX - 1;
+        assert!(target.snapshot().is_err());
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/txpool.rs
+++ b/clients/rust/crates/rubin-node/src/txpool.rs
@@ -284,19 +284,21 @@ impl TxPool {
     #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn snapshot(&self) -> Result<TxPoolSnapshot, TxPoolAdmitError> {
         let mut entries = Vec::with_capacity(self.txs.len());
+        let mut used_bytes = 0usize;
+        let mut max_heap_id = 0u64;
         for (txid, entry) in &self.txs {
-            let heap_id = self.heap_seqs.get(txid).copied().ok_or_else(|| {
-                rejected(format!(
-                    "txpool snapshot invariant violated: missing heap sequence for txid {}",
-                    hex::encode(txid)
-                ))
-            })?;
+            let heap_id = self
+                .heap_seqs
+                .get(txid)
+                .copied()
+                .ok_or_else(|| rejected("txpool snapshot missing heap sequence"))?;
             if heap_id == 0 {
-                return Err(rejected(format!(
-                    "txpool snapshot invariant violated: invalid heap sequence for txid {}: heap_id=0",
-                    hex::encode(txid)
-                )));
+                return Err(rejected("invalid txpool snapshot heap id"));
             }
+            used_bytes = used_bytes
+                .checked_add(entry.size)
+                .ok_or_else(|| unavailable("txpool snapshot byte accounting overflow"))?;
+            max_heap_id = max_heap_id.max(heap_id);
             let wtxid = validate_txpool_snapshot_entry(*txid, None, entry)?;
             entries.push(TxPoolSnapshotEntry {
                 txid: *txid,
@@ -306,6 +308,12 @@ impl TxPool {
             });
         }
         entries.sort_by_key(|item| item.txid);
+        if self.used_bytes != used_bytes {
+            return Err(rejected("txpool snapshot used_bytes mismatch"));
+        }
+        if self.next_heap_id < max_heap_id {
+            return Err(rejected("txpool snapshot heap high-watermark below max"));
+        }
         if u64::MAX - self.next_heap_id <= self.max_transactions as u64 {
             return Err(rejected("txpool snapshot heap near saturation"));
         }
@@ -314,7 +322,7 @@ impl TxPool {
             current_mempool_min_fee_rate: floor.max(DEFAULT_MEMPOOL_MIN_FEE_RATE),
             entries,
             next_heap_id: self.next_heap_id,
-            used_bytes: self.used_bytes,
+            used_bytes,
         })
     }
 
@@ -996,25 +1004,13 @@ fn validate_txpool_snapshot_entry(
     entry: &TxPoolEntry,
 ) -> Result<[u8; 32], TxPoolAdmitError> {
     if entry.size == 0 {
-        return Err(rejected(format!(
-            "invalid txpool snapshot entry size for txid {}: size=0 raw_len={}",
-            hex::encode(txid),
-            entry.raw.len()
-        )));
+        return Err(rejected("invalid txpool snapshot entry size"));
     }
     if entry.weight == 0 {
-        return Err(rejected(format!(
-            "invalid txpool snapshot entry weight for txid {}: weight=0",
-            hex::encode(txid)
-        )));
+        return Err(rejected("invalid txpool snapshot entry weight"));
     }
     if entry.size != entry.raw.len() {
-        return Err(rejected(format!(
-            "txpool snapshot entry size mismatch for txid {}: size={} raw_len={}",
-            hex::encode(txid),
-            entry.size,
-            entry.raw.len()
-        )));
+        return Err(rejected("txpool snapshot entry size mismatch"));
     }
     let (tx, raw_txid, raw_wtxid, consumed) = parse_tx(&entry.raw).map_err(|err| {
         rejected(format!(
@@ -1023,12 +1019,7 @@ fn validate_txpool_snapshot_entry(
         ))
     })?;
     if consumed != entry.raw.len() {
-        return Err(rejected(format!(
-            "txpool snapshot entry has trailing bytes for txid {}: consumed={} raw_len={}",
-            hex::encode(txid),
-            consumed,
-            entry.raw.len()
-        )));
+        return Err(rejected("txpool snapshot entry has trailing bytes"));
     }
     if raw_txid != txid {
         return Err(rejected(format!(
@@ -1037,18 +1028,18 @@ fn validate_txpool_snapshot_entry(
             hex::encode(raw_txid)
         )));
     }
-    if wtxid.is_some_and(|wtxid| wtxid != raw_wtxid) {
-        return Err(rejected(format!(
-            "txpool snapshot entry wtxid mismatch for txid {}",
-            hex::encode(txid)
-        )));
+    if let Some(wtxid) = wtxid {
+        if wtxid != raw_wtxid {
+            return Err(rejected(format!(
+                "txpool snapshot entry wtxid mismatch: entry={} raw={} txid={}",
+                hex::encode(wtxid),
+                hex::encode(raw_wtxid),
+                hex::encode(txid)
+            )));
+        }
     }
-    let (weight, _, _) = tx_weight_and_stats_public(&tx).map_err(|err| {
-        rejected(format!(
-            "invalid txpool snapshot entry weight for txid {}: {err}",
-            hex::encode(txid)
-        ))
-    })?;
+    let (weight, _, _) = tx_weight_and_stats_public(&tx)
+        .map_err(|err| rejected(format!("invalid txpool snapshot entry weight: {err}")))?;
     if entry.weight != weight {
         return Err(rejected(format!(
             "txpool snapshot entry weight mismatch: entry={} computed={} txid={}",
@@ -1066,10 +1057,7 @@ fn validate_txpool_snapshot_entry(
         })
         .collect();
     if entry.inputs != inputs {
-        return Err(rejected(format!(
-            "txpool snapshot entry input list mismatch for txid {}",
-            hex::encode(txid)
-        )));
+        return Err(rejected("txpool snapshot entry input list mismatch"));
     }
     // Go validates string source; Rust's closed `TxSource` cannot represent invalid values.
     Ok(raw_wtxid)
@@ -2626,6 +2614,11 @@ mod tests {
         let mut saturated = guard_snapshot.clone();
         saturated.next_heap_id = u64::MAX - 1;
         reject(saturated, "heap near saturation");
+        target.used_bytes += 1;
+        assert!(target.snapshot().is_err());
+        target.used_bytes -= 1;
+        target.next_heap_id = 1;
+        assert!(target.snapshot().is_err());
         target.next_heap_id = u64::MAX - 1;
         assert!(target.snapshot().is_err());
     }

--- a/clients/rust/crates/rubin-node/src/txpool.rs
+++ b/clients/rust/crates/rubin-node/src/txpool.rs
@@ -125,6 +125,28 @@ pub struct TxPoolEntry {
     pub source: TxSource,
 }
 
+/// Defensive rollback snapshot for Rust `TxPool`. Go `sync_mempool.go` map:
+/// raw/inputs/fee/weight/size/source -> `TxPoolEntry`, txid -> `TxPoolSnapshotEntry.txid`,
+/// admissionSeq/lastAdmissionSeq -> `heap_id`/`next_heap_id`, currentMinFeeRate -> Rust cfg floor.
+/// Go wtxid has no Rust resident/index field; restore reparses raw and validates txid/weight/inputs.
+#[derive(Debug, Clone)]
+pub struct TxPoolSnapshot {
+    cfg: TxPoolConfig,
+    entries: Vec<TxPoolSnapshotEntry>,
+    next_heap_id: u64,
+    max_transactions: usize,
+    max_bytes: usize,
+    low_water_bytes: usize,
+    used_bytes: usize,
+}
+
+#[derive(Debug, Clone)]
+struct TxPoolSnapshotEntry {
+    txid: [u8; 32],
+    entry: TxPoolEntry,
+    heap_id: u64,
+}
+
 #[derive(Debug, Clone)]
 pub struct TxPool {
     cfg: TxPoolConfig,
@@ -260,6 +282,146 @@ impl TxPool {
 
     pub fn is_empty(&self) -> bool {
         self.txs.is_empty()
+    }
+
+    /// Capture a defensive rollback snapshot sorted by txid so later rollback
+    /// boundaries never rely on `HashMap` iteration order.
+    pub fn snapshot(&self) -> Result<TxPoolSnapshot, TxPoolAdmitError> {
+        let mut entries = Vec::with_capacity(self.txs.len());
+        for (txid, entry) in &self.txs {
+            let heap_id = self.heap_seqs.get(txid).copied().ok_or_else(|| {
+                rejected(format!(
+                    "txpool snapshot invariant violated: missing heap sequence for txid {}",
+                    hex::encode(txid)
+                ))
+            })?;
+            if heap_id == 0 {
+                return Err(rejected(format!(
+                    "txpool snapshot invariant violated: invalid heap sequence for txid {}: heap_id=0",
+                    hex::encode(txid)
+                )));
+            }
+            entries.push(TxPoolSnapshotEntry {
+                txid: *txid,
+                entry: entry.clone(),
+                heap_id,
+            });
+        }
+        entries.sort_by(|a, b| a.txid.cmp(&b.txid));
+        Ok(TxPoolSnapshot {
+            cfg: self.cfg.clone(),
+            entries,
+            next_heap_id: self.next_heap_id,
+            max_transactions: self.max_transactions,
+            max_bytes: self.max_bytes,
+            low_water_bytes: self.low_water_bytes,
+            used_bytes: self.used_bytes,
+        })
+    }
+
+    /// Validate and restore `TxPoolSnapshot`; live state is replaced only after
+    /// entries, accounting, capacity, and heap/admission high-water validate.
+    pub fn restore_snapshot(&mut self, snapshot: &TxPoolSnapshot) -> Result<(), TxPoolAdmitError> {
+        if snapshot.max_transactions == 0 || snapshot.max_bytes == 0 {
+            return Err(unavailable(format!(
+                "invalid txpool snapshot restore limits: max_txs={} max_bytes={}",
+                snapshot.max_transactions, snapshot.max_bytes
+            )));
+        }
+        if snapshot.entries.len() > snapshot.max_transactions {
+            return Err(unavailable(format!(
+                "txpool snapshot exceeds transaction cap: count={} max={}",
+                snapshot.entries.len(),
+                snapshot.max_transactions
+            )));
+        }
+
+        let mut txs = HashMap::with_capacity(snapshot.entries.len());
+        let mut spenders = HashMap::new();
+        let mut heap_seqs = HashMap::with_capacity(snapshot.entries.len());
+        let mut admission_seqs = HashMap::with_capacity(snapshot.entries.len());
+        let mut worst_heap = BinaryHeap::with_capacity(snapshot.entries.len());
+        let mut used_bytes = 0usize;
+        let mut max_heap_id = 0u64;
+
+        for item in &snapshot.entries {
+            if txs.contains_key(&item.txid) {
+                return Err(rejected(format!(
+                    "duplicate txpool snapshot txid {}",
+                    hex::encode(item.txid)
+                )));
+            }
+            let heap_id = item.heap_id;
+            if heap_id == 0 {
+                return Err(rejected(format!(
+                    "invalid txpool snapshot heap id for txid {}: heap_id=0",
+                    hex::encode(item.txid)
+                )));
+            }
+            validate_txpool_snapshot_entry(item.txid, &item.entry)?;
+            if let Some(existing) = admission_seqs.insert(heap_id, item.txid) {
+                return Err(rejected(format!(
+                    "duplicate txpool snapshot heap id {heap_id} existing={} new={}",
+                    hex::encode(existing),
+                    hex::encode(item.txid)
+                )));
+            }
+            let next_used = used_bytes
+                .checked_add(item.entry.size)
+                .ok_or_else(|| unavailable("txpool snapshot byte accounting overflow"))?;
+            if item.entry.size > snapshot.max_bytes || next_used > snapshot.max_bytes {
+                return Err(unavailable(format!(
+                    "txpool snapshot exceeds byte cap: used={} entry={} max={}",
+                    used_bytes, item.entry.size, snapshot.max_bytes
+                )));
+            }
+            for input in &item.entry.inputs {
+                if let Some(existing) = spenders.insert(input.clone(), item.txid) {
+                    return Err(rejected(format!(
+                        "duplicate txpool snapshot spender txid={} vout={} existing={} new={}",
+                        hex::encode(input.txid),
+                        input.vout,
+                        hex::encode(existing),
+                        hex::encode(item.txid)
+                    )));
+                }
+            }
+            used_bytes = next_used;
+            max_heap_id = max_heap_id.max(heap_id);
+            heap_seqs.insert(item.txid, heap_id);
+            worst_heap.push(WorstEntryKey {
+                txid: item.txid,
+                fee: item.entry.fee,
+                weight: item.entry.weight,
+                heap_id,
+            });
+            txs.insert(item.txid, item.entry.clone());
+        }
+
+        if snapshot.used_bytes != used_bytes {
+            return Err(rejected(format!(
+                "txpool snapshot used_bytes mismatch: snapshot={} computed={}",
+                snapshot.used_bytes, used_bytes
+            )));
+        }
+        if snapshot.next_heap_id < max_heap_id {
+            return Err(rejected(format!(
+                "txpool snapshot heap high-watermark below restored max: next={} max={}",
+                snapshot.next_heap_id, max_heap_id
+            )));
+        }
+
+        self.cfg = snapshot.cfg.clone();
+        self.txs = txs;
+        self.spenders = spenders;
+        self.heap_seqs = heap_seqs;
+        self.worst_heap = worst_heap;
+        self.next_heap_id = snapshot.next_heap_id;
+        self.max_transactions = snapshot.max_transactions;
+        self.max_bytes = snapshot.max_bytes;
+        self.low_water_bytes = snapshot.low_water_bytes;
+        self.used_bytes = used_bytes;
+        Ok(())
     }
 
     /// Returns the txids of every transaction currently in the pool.
@@ -817,6 +979,84 @@ impl TxPool {
         }
         self.worst_heap = rebuilt;
     }
+}
+
+fn validate_txpool_snapshot_entry(
+    txid: [u8; 32],
+    entry: &TxPoolEntry,
+) -> Result<(), TxPoolAdmitError> {
+    if entry.size == 0 {
+        return Err(rejected(format!(
+            "invalid txpool snapshot entry size for txid {}: size=0 raw_len={}",
+            hex::encode(txid),
+            entry.raw.len()
+        )));
+    }
+    if entry.weight == 0 {
+        return Err(rejected(format!(
+            "invalid txpool snapshot entry weight for txid {}: weight=0",
+            hex::encode(txid)
+        )));
+    }
+    if entry.size != entry.raw.len() {
+        return Err(rejected(format!(
+            "txpool snapshot entry size mismatch for txid {}: size={} raw_len={}",
+            hex::encode(txid),
+            entry.size,
+            entry.raw.len()
+        )));
+    }
+    let (tx, raw_txid, _wtxid, consumed) = parse_tx(&entry.raw).map_err(|err| {
+        rejected(format!(
+            "invalid txpool snapshot entry raw for txid {}: {err}",
+            hex::encode(txid)
+        ))
+    })?;
+    if consumed != entry.raw.len() {
+        return Err(rejected(format!(
+            "txpool snapshot entry has trailing bytes for txid {}: consumed={} raw_len={}",
+            hex::encode(txid),
+            consumed,
+            entry.raw.len()
+        )));
+    }
+    if raw_txid != txid {
+        return Err(rejected(format!(
+            "txpool snapshot entry txid mismatch: entry={} raw={}",
+            hex::encode(txid),
+            hex::encode(raw_txid)
+        )));
+    }
+    let (weight, _, _) = tx_weight_and_stats_public(&tx).map_err(|err| {
+        rejected(format!(
+            "invalid txpool snapshot entry weight for txid {}: {err}",
+            hex::encode(txid)
+        ))
+    })?;
+    if entry.weight != weight {
+        return Err(rejected(format!(
+            "txpool snapshot entry weight mismatch: entry={} computed={} txid={}",
+            entry.weight,
+            weight,
+            hex::encode(txid)
+        )));
+    }
+    let inputs: Vec<Outpoint> = tx
+        .inputs
+        .iter()
+        .map(|input| Outpoint {
+            txid: input.prev_txid,
+            vout: input.prev_vout,
+        })
+        .collect();
+    if entry.inputs != inputs {
+        return Err(rejected(format!(
+            "txpool snapshot entry input list mismatch for txid {}",
+            hex::encode(txid)
+        )));
+    }
+    // Go validates string source; Rust's closed `TxSource` cannot represent invalid values.
+    Ok(())
 }
 
 /// Returns the metadata a relay peer needs to forward the transaction
@@ -1828,7 +2068,8 @@ mod tests {
         fee_precheck_p2pk_output_value, mtp_median, next_block_height, next_block_mtp,
         reject_core_ext_tx_oversized_payload, reject_da_anchor_tx_policy, rejected, relay_metadata,
         tx_pool_byte_pressure_target, unavailable, TxPool, TxPoolAdmitErrorKind, TxPoolConfig,
-        TxPoolEntry, TxSource, DEFAULT_MEMPOOL_MIN_FEE_RATE, MAX_TX_POOL_TRANSACTIONS,
+        TxPoolEntry, TxPoolSnapshot, TxPoolSnapshotEntry, TxSource, DEFAULT_MEMPOOL_MIN_FEE_RATE,
+        MAX_TX_POOL_TRANSACTIONS,
     };
     use crate::{
         block_store_path, default_sync_config, devnet_genesis_block_bytes, devnet_genesis_chain_id,
@@ -1887,6 +2128,95 @@ mod tests {
             weight,
             size,
             source,
+        }
+    }
+
+    fn txpool_snapshot_entry_from_raw(
+        raw: Vec<u8>,
+        fee: u64,
+        source: TxSource,
+        heap_id: u64,
+    ) -> ([u8; 32], TxPoolSnapshotEntry) {
+        let (tx, txid, _wtxid, consumed) = parse_tx(&raw).expect("parse snapshot raw");
+        assert_eq!(consumed, raw.len(), "snapshot raw must be canonical");
+        let inputs = tx
+            .inputs
+            .iter()
+            .map(|input| Outpoint {
+                txid: input.prev_txid,
+                vout: input.prev_vout,
+            })
+            .collect();
+        let (weight, _, _) = tx_weight_and_stats_public(&tx).expect("snapshot weight");
+        let size = raw.len();
+        (
+            txid,
+            TxPoolSnapshotEntry {
+                txid,
+                entry: TxPoolEntry {
+                    raw,
+                    inputs,
+                    fee,
+                    weight,
+                    size,
+                    source,
+                },
+                heap_id,
+            },
+        )
+    }
+
+    fn txpool_snapshot_test_pool() -> (TxPool, [u8; 32], [u8; 32]) {
+        let (_state_a, raw_a) = signed_p2pk_state_and_tx(
+            20_000,
+            vec![TxOutput {
+                value: 8,
+                covenant_type: COV_TYPE_P2PK,
+                covenant_data: p2pk_covenant_data_for_pubkey(&vec![0x31; 2592]),
+            }],
+            0x00,
+            None,
+            Vec::new(),
+        );
+        let (_state_b, raw_b) = core_ext_spend_state_and_tx(7);
+        let (txid_a, item_a) = txpool_snapshot_entry_from_raw(raw_a, 19_992, TxSource::Remote, 1);
+        let (txid_b, item_b) = txpool_snapshot_entry_from_raw(raw_b, 1, TxSource::Reorg, 2);
+        let max_bytes = item_a.entry.size + item_b.entry.size + 100;
+        let mut pool = TxPool::new_with_config(TxPoolConfig {
+            policy_current_mempool_min_fee_rate: 7,
+            ..TxPoolConfig::default()
+        });
+        pool.set_capacity_for_test(7, max_bytes);
+        pool.insert_entry(txid_a, item_a.entry);
+        pool.insert_entry(txid_b, item_b.entry);
+        (pool, txid_a, txid_b)
+    }
+
+    fn assert_txpool_snapshot_same(actual: &TxPoolSnapshot, expected: &TxPoolSnapshot) {
+        assert_eq!(actual.entries.len(), expected.entries.len(), "entry count");
+        assert_eq!(
+            actual.next_heap_id, expected.next_heap_id,
+            "heap high-water"
+        );
+        assert_eq!(
+            actual.max_transactions, expected.max_transactions,
+            "max txs"
+        );
+        assert_eq!(actual.max_bytes, expected.max_bytes, "max bytes");
+        assert_eq!(
+            actual.low_water_bytes, expected.low_water_bytes,
+            "low water"
+        );
+        assert_eq!(actual.used_bytes, expected.used_bytes, "used bytes");
+        assert_eq!(
+            actual.cfg.policy_current_mempool_min_fee_rate,
+            expected.cfg.policy_current_mempool_min_fee_rate,
+            "current floor"
+        );
+        for (actual, expected) in actual.entries.iter().zip(&expected.entries) {
+            assert_eq!(actual.txid, expected.txid, "txid");
+            assert_eq!(actual.heap_id, expected.heap_id, "heap id");
+            assert_eq!(actual.entry, expected.entry, "entry");
         }
     }
 
@@ -2180,6 +2510,124 @@ mod tests {
         let pool = TxPool::default();
         assert!(pool.is_empty());
         assert_eq!(pool.len(), 0);
+    }
+
+    #[test]
+    fn txpool_snapshot_round_trip_preserves_rust_state_and_go_field_mapping() {
+        let (mut pool, txid_a, txid_b) = txpool_snapshot_test_pool();
+        let selected_before = pool.select_transactions(10, usize::MAX);
+        let heap_before = pool.worst_heap.clone().into_sorted_vec();
+        let snapshot = pool.snapshot().expect("snapshot");
+        assert_eq!(snapshot.entries.len(), 2);
+        assert_eq!(snapshot.entries[0].txid, txid_a.min(txid_b));
+        assert_eq!(snapshot.entries[1].txid, txid_a.max(txid_b));
+
+        pool.evict_txids(&[txid_a, txid_b]);
+        pool.cfg.policy_current_mempool_min_fee_rate = 99;
+        pool.set_capacity_for_test(1, 1);
+        assert!(pool.is_empty(), "live pool mutated before restore");
+
+        pool.restore_snapshot(&snapshot)
+            .expect("valid snapshot restores");
+        assert_txpool_snapshot_same(&pool.snapshot().expect("snapshot"), &snapshot);
+        assert_eq!(pool.worst_heap.clone().into_sorted_vec(), heap_before);
+        for item in &snapshot.entries {
+            assert_eq!(pool.txs.get(&item.txid), Some(&item.entry));
+            assert_eq!(pool.heap_seqs.get(&item.txid), Some(&item.heap_id));
+            for input in &item.entry.inputs {
+                assert_eq!(pool.spenders.get(input), Some(&item.txid));
+            }
+        }
+        assert_eq!(pool.select_transactions(10, usize::MAX), selected_before);
+        assert_eq!(
+            pool.cfg.policy_current_mempool_min_fee_rate, 7,
+            "Go currentMinFeeRate maps to Rust cfg.policy_current_mempool_min_fee_rate"
+        );
+    }
+
+    #[test]
+    fn txpool_snapshot_restore_rejects_corruption_without_replacing_live_state() {
+        let (guard_pool, _guard_a, _guard_b) = txpool_snapshot_test_pool();
+        let guard_snapshot = guard_pool.snapshot().expect("guard snapshot");
+        let (mut target, _target_a, _target_b) = txpool_snapshot_test_pool();
+
+        let mut reject = |poison: TxPoolSnapshot, needle: &str| {
+            let before = target.snapshot().expect("target snapshot before poison");
+            let err = target
+                .restore_snapshot(&poison)
+                .expect_err("poison snapshot must fail closed");
+            assert!(
+                err.message.contains(needle),
+                "expected error containing {needle:?}, got: {}",
+                err.message
+            );
+            assert_txpool_snapshot_same(
+                &target.snapshot().expect("target snapshot after poison"),
+                &before,
+            );
+        };
+
+        let mut duplicate_txid = guard_snapshot.clone();
+        let duplicate_item = duplicate_txid.entries[0].clone();
+        duplicate_txid.entries.push(duplicate_item);
+        reject(duplicate_txid, "duplicate txpool snapshot txid");
+
+        let mut duplicate_spender = guard_snapshot.clone();
+        let (_conflict_state, raw_a, raw_b) = signed_conflicting_p2pk_state_and_txs(7700, 10, 9);
+        let (_txid_a, item_a) = txpool_snapshot_entry_from_raw(raw_a, 7690, TxSource::Local, 1);
+        let (_txid_b, item_b) = txpool_snapshot_entry_from_raw(raw_b, 7691, TxSource::Remote, 2);
+        duplicate_spender.entries = vec![item_a, item_b];
+        duplicate_spender.used_bytes = duplicate_spender
+            .entries
+            .iter()
+            .map(|item| item.entry.size)
+            .sum();
+        duplicate_spender.max_bytes = duplicate_spender.used_bytes + 1;
+        duplicate_spender.next_heap_id = 2;
+        reject(duplicate_spender, "duplicate txpool snapshot spender");
+
+        let mut duplicate_heap = guard_snapshot.clone();
+        duplicate_heap.entries[1].heap_id = duplicate_heap.entries[0].heap_id;
+        reject(duplicate_heap, "duplicate txpool snapshot heap id");
+
+        let mut missing_heap = guard_snapshot.clone();
+        missing_heap.entries[0].heap_id = 0;
+        reject(missing_heap, "invalid txpool snapshot heap id");
+        let mut invalid_raw = guard_snapshot.clone();
+        invalid_raw.entries[0].entry.raw = vec![0xff];
+        invalid_raw.entries[0].entry.size = 1;
+        reject(invalid_raw, "invalid txpool snapshot entry raw");
+        let mut trailing = guard_snapshot.clone();
+        trailing.entries[0].entry.raw.push(0);
+        trailing.entries[0].entry.size += 1;
+        reject(trailing, "trailing bytes");
+        let mut txid_mismatch = guard_snapshot.clone();
+        txid_mismatch.entries[0].txid = [0x99; 32];
+        reject(txid_mismatch, "txid mismatch");
+        let mut weight_mismatch = guard_snapshot.clone();
+        weight_mismatch.entries[0].entry.weight += 1;
+        reject(weight_mismatch, "weight mismatch");
+        let mut input_mismatch = guard_snapshot.clone();
+        input_mismatch.entries[0].entry.inputs.clear();
+        reject(input_mismatch, "input list mismatch");
+        let mut zero_size = guard_snapshot.clone();
+        zero_size.entries[0].entry.size = 0;
+        reject(zero_size, "invalid txpool snapshot entry size");
+        let mut zero_weight = guard_snapshot.clone();
+        zero_weight.entries[0].entry.weight = 0;
+        reject(zero_weight, "invalid txpool snapshot entry weight");
+        let mut count_cap = guard_snapshot.clone();
+        count_cap.max_transactions = 1;
+        reject(count_cap, "transaction cap");
+        let mut byte_cap = guard_snapshot.clone();
+        byte_cap.max_bytes = guard_snapshot.entries[0].entry.size;
+        reject(byte_cap, "byte cap");
+        let mut used_mismatch = guard_snapshot.clone();
+        used_mismatch.used_bytes += 1;
+        reject(used_mismatch, "used_bytes mismatch");
+        let mut high_water = guard_snapshot.clone();
+        high_water.next_heap_id = 1;
+        reject(high_water, "high-watermark");
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/txpool.rs
+++ b/clients/rust/crates/rubin-node/src/txpool.rs
@@ -320,10 +320,7 @@ impl TxPool {
         snapshot: &TxPoolSnapshot,
     ) -> Result<(), TxPoolAdmitError> {
         if self.max_transactions == 0 || self.max_bytes == 0 {
-            return Err(unavailable(format!(
-                "invalid txpool snapshot restore limits: max_txs={} max_bytes={}",
-                self.max_transactions, self.max_bytes
-            )));
+            return Err(unavailable("invalid txpool snapshot restore limits"));
         }
         if snapshot.entries.len() > self.max_transactions {
             return Err(unavailable(format!(

--- a/clients/rust/crates/rubin-node/src/txpool.rs
+++ b/clients/rust/crates/rubin-node/src/txpool.rs
@@ -2604,6 +2604,9 @@ mod tests {
         let mut input_mismatch = guard_snapshot.clone();
         input_mismatch.entries[0].entry.inputs.clear();
         reject(input_mismatch, "input list mismatch");
+        let mut zero_size = guard_snapshot.clone();
+        zero_size.entries[0].entry.size = 0;
+        reject(zero_size, "invalid txpool snapshot entry size");
         let reject_live_cap = |max_txs, max_bytes, needle| {
             let mut target = TxPool::new();
             target.set_capacity_for_test(max_txs, max_bytes);

--- a/clients/rust/crates/rubin-node/src/txpool.rs
+++ b/clients/rust/crates/rubin-node/src/txpool.rs
@@ -413,7 +413,7 @@ impl TxPool {
                 snapshot.next_heap_id, max_heap_id
             )));
         }
-        if u64::MAX - snapshot.next_heap_id < self.max_transactions as u64 {
+        if u64::MAX - snapshot.next_heap_id <= self.max_transactions as u64 {
             return Err(rejected("txpool snapshot heap near saturation"));
         }
 

--- a/clients/rust/crates/rubin-node/src/txpool.rs
+++ b/clients/rust/crates/rubin-node/src/txpool.rs
@@ -126,10 +126,10 @@ pub struct TxPoolEntry {
 }
 
 /// Defensive rollback snapshot for Rust `TxPool`.
-/// Maps Go `sync_mempool.go` fields to Rust resident state; Rust stores no resident wtxid.
 #[derive(Debug, Clone)]
-pub struct TxPoolSnapshot {
-    cfg: TxPoolConfig,
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) struct TxPoolSnapshot {
+    current_mempool_min_fee_rate: u64,
     entries: Vec<TxPoolSnapshotEntry>,
     next_heap_id: u64,
     max_transactions: usize,
@@ -139,6 +139,7 @@ pub struct TxPoolSnapshot {
 }
 
 #[derive(Debug, Clone)]
+#[cfg_attr(not(test), allow(dead_code))]
 struct TxPoolSnapshotEntry {
     txid: [u8; 32],
     entry: TxPoolEntry,
@@ -282,9 +283,8 @@ impl TxPool {
         self.txs.is_empty()
     }
 
-    /// Capture a defensive rollback snapshot sorted by txid so later rollback
-    /// boundaries never rely on `HashMap` iteration order.
-    pub fn snapshot(&self) -> Result<TxPoolSnapshot, TxPoolAdmitError> {
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn snapshot(&self) -> Result<TxPoolSnapshot, TxPoolAdmitError> {
         let mut entries = Vec::with_capacity(self.txs.len());
         for (txid, entry) in &self.txs {
             let heap_id = self.heap_seqs.get(txid).copied().ok_or_else(|| {
@@ -305,9 +305,9 @@ impl TxPool {
                 heap_id,
             });
         }
-        entries.sort_by(|a, b| a.txid.cmp(&b.txid));
+        entries.sort_by_key(|item| item.txid);
         Ok(TxPoolSnapshot {
-            cfg: self.cfg.clone(),
+            current_mempool_min_fee_rate: self.cfg.policy_current_mempool_min_fee_rate,
             entries,
             next_heap_id: self.next_heap_id,
             max_transactions: self.max_transactions,
@@ -317,9 +317,11 @@ impl TxPool {
         })
     }
 
-    /// Validate and restore `TxPoolSnapshot`; live state is replaced only after
-    /// entries, accounting, capacity, and heap/admission high-water validate.
-    pub fn restore_snapshot(&mut self, snapshot: &TxPoolSnapshot) -> Result<(), TxPoolAdmitError> {
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn restore_snapshot(
+        &mut self,
+        snapshot: &TxPoolSnapshot,
+    ) -> Result<(), TxPoolAdmitError> {
         if snapshot.max_transactions == 0 || snapshot.max_bytes == 0 {
             return Err(unavailable(format!(
                 "invalid txpool snapshot restore limits: max_txs={} max_bytes={}",
@@ -409,7 +411,7 @@ impl TxPool {
             )));
         }
 
-        self.cfg = snapshot.cfg.clone();
+        self.cfg.policy_current_mempool_min_fee_rate = snapshot.current_mempool_min_fee_rate;
         self.txs = txs;
         self.spenders = spenders;
         self.heap_seqs = heap_seqs;
@@ -979,6 +981,7 @@ impl TxPool {
     }
 }
 
+#[cfg_attr(not(test), allow(dead_code))]
 fn validate_txpool_snapshot_entry(
     txid: [u8; 32],
     entry: &TxPoolEntry,
@@ -2198,8 +2201,8 @@ mod tests {
         assert_eq!(actual.low_water_bytes, expected.low_water_bytes);
         assert_eq!(actual.used_bytes, expected.used_bytes);
         assert_eq!(
-            actual.cfg.policy_current_mempool_min_fee_rate,
-            expected.cfg.policy_current_mempool_min_fee_rate
+            actual.current_mempool_min_fee_rate,
+            expected.current_mempool_min_fee_rate
         );
         for (actual, expected) in actual.entries.iter().zip(&expected.entries) {
             assert_eq!(actual.txid, expected.txid);
@@ -2506,7 +2509,6 @@ mod tests {
         let selected_before = pool.select_transactions(10, usize::MAX);
         let heap_before = pool.worst_heap.clone().into_sorted_vec();
         let snapshot = pool.snapshot().expect("snapshot");
-        assert_eq!(snapshot.entries.len(), 2);
         assert_eq!(snapshot.entries[0].txid, txid_a.min(txid_b));
         assert_eq!(snapshot.entries[1].txid, txid_a.max(txid_b));
 
@@ -2520,16 +2522,26 @@ mod tests {
         assert_txpool_snapshot_same(&pool.snapshot().expect("snapshot"), &snapshot);
         assert_eq!(pool.worst_heap.clone().into_sorted_vec(), heap_before);
         for item in &snapshot.entries {
-            assert_eq!(pool.txs.get(&item.txid), Some(&item.entry));
             assert_eq!(pool.heap_seqs.get(&item.txid), Some(&item.heap_id));
             for input in &item.entry.inputs {
                 assert_eq!(pool.spenders.get(input), Some(&item.txid));
             }
         }
         assert_eq!(pool.select_transactions(10, usize::MAX), selected_before);
-        assert_eq!(
-            pool.cfg.policy_current_mempool_min_fee_rate, 7,
-            "Go currentMinFeeRate maps to Rust cfg.policy_current_mempool_min_fee_rate"
+        assert_eq!(pool.cfg.policy_current_mempool_min_fee_rate, 7);
+
+        let lenient_snapshot = TxPool::new_with_config(TxPoolConfig {
+            policy_current_mempool_min_fee_rate: 11,
+            policy_reject_core_ext_pre_activation: false,
+            ..TxPoolConfig::default()
+        })
+        .snapshot()
+        .expect("lenient snapshot");
+        pool.restore_snapshot(&lenient_snapshot)
+            .expect("empty snapshot restores");
+        assert!(
+            pool.cfg.policy_reject_core_ext_pre_activation
+                && pool.cfg.policy_current_mempool_min_fee_rate == 11
         );
     }
 


### PR DESCRIPTION
Invariant:
Rust TxPool rollback snapshots can be validated and restored without leaking corrupt resident state into the live pool.

Layer:
implementation / tests

Files changed:
- clients/rust/crates/rubin-node/src/txpool.rs

Tests:
- scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test -p rubin-node txpool_snapshot'
- scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo clippy -p rubin-node -- -D warnings'
- scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test -p rubin-node'
- /Users/gpt/bin/rubin-precommit-one-review --repo /Users/gpt/Documents/rubin-protocol-codex-RUB-236 --base-ref origin/main --include-base-diff
- /Users/gpt/bin/rubin-push --repo /Users/gpt/Documents/rubin-protocol-codex-RUB-236 --base-ref origin/main --coverage-cmd "scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test -p rubin-node txpool_snapshot && cargo clippy -p rubin-node -- -D warnings && cargo test -p rubin-node'" -- origin HEAD

Behavior impact:
Adds crate-local TxPool snapshot/restore support and focused tests. No production caller is wired in this Phase A PR.

Compatibility impact:
No public crate API exposure; snapshot/restore is crate-visible only.

Known non-goals:
- no Go changes
- no conformance/formal/fixture changes
- no P2P/sync/reorg integration in this PR
- no consensus behavior change

Follow-ups:
RUB-237 wires the cleanup/requeue transaction boundary after this PR merges.
