### PR TITLE
RUB-237: classify Rust txpool cleanup failure boundary

### DIFF
--- a/clients/rust/crates/rubin-node/src/p2p_service.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_service.rs
@@ -953,21 +953,17 @@ fn apply_tx_pool_cleanup(
             .tx_pool
             .lock()
             .map_err(|_| "tx pool unavailable".to_string())?;
-        let snapshot = tx_pool
-            .snapshot()
-            .map_err(|err| format!("tx pool cleanup snapshot: {err}"))?;
-        let report = tx_pool_cleanup.apply_with_report(
+        // Cleanup plans are emitted only after the sync engine accepted a
+        // block/reorg, or from pending cleanup for an already accepted orphan
+        // parent. Match Go's post-success best-effort cleanup shape: confirmed
+        // evictions, conflict removals, and successful requeues remain visible
+        // even if another requeue item reports a failure.
+        tx_pool_cleanup.apply_with_report(
             &mut tx_pool,
             &chain_state,
             block_store.as_ref(),
             chain_id,
-        );
-        if report.has_requeue_failures() {
-            tx_pool
-                .restore_snapshot(&snapshot)
-                .map_err(|err| format!("tx pool cleanup rollback: {err}"))?;
-        }
-        report
+        )
     };
     if report.has_requeue_failures() {
         return Ok(Some(report.requeue_failure_summary()));
@@ -1138,6 +1134,7 @@ mod tests {
     use crate::test_helpers::{block_with_txs, signed_conflicting_p2pk_state_and_txs};
     use crate::tx_relay::PeerOutbox;
     use crate::tx_relay::TxRelayState;
+    use crate::txpool::TxSource;
     use crate::{
         block_store_path, default_sync_config, BlockStore, ChainState, SyncEngine, TxPool,
     };
@@ -1464,16 +1461,10 @@ mod tests {
     }
 
     #[test]
-    fn apply_tx_pool_cleanup_rolls_back_partial_mutations_on_requeue_failure() {
+    fn apply_tx_pool_cleanup_keeps_post_success_best_effort_mutations_on_requeue_failure() {
         let missing_requeue_block = [0x44; 32];
         let (shared, dir, admitted_txid, _) =
-            shared_state_with_admitted_tx("rubin-node-p2p-cleanup-rollback-confirmed");
-        let before = shared
-            .tx_pool
-            .lock()
-            .expect("tx pool")
-            .snapshot()
-            .expect("snapshot before confirmed cleanup failure");
+            shared_state_with_admitted_tx("rubin-node-p2p-cleanup-best-effort-confirmed");
         let cleanup = TxPoolCleanupPlan::from_parts_for_test(
             vec![admitted_txid],
             Vec::new(),
@@ -1483,26 +1474,19 @@ mod tests {
             apply_tx_pool_cleanup(&shared, cleanup),
             "requeue_blocks_unavailable=1",
         );
-        let after = shared
-            .tx_pool
-            .lock()
-            .expect("tx pool")
-            .snapshot()
-            .expect("snapshot after confirmed cleanup failure");
         assert_eq!(
-            after, before,
-            "failed requeue must roll back confirmed-tx eviction"
+            shared
+                .tx_pool
+                .lock()
+                .expect("tx pool")
+                .tx_by_id(&admitted_txid),
+            None,
+            "post-success cleanup keeps confirmed-tx eviction despite later requeue failure"
         );
-        fs::remove_dir_all(dir).expect("cleanup confirmed rollback");
+        fs::remove_dir_all(dir).expect("cleanup confirmed best-effort");
 
-        let (shared, dir, _admitted_txid, conflicting_input) =
-            shared_state_with_admitted_tx("rubin-node-p2p-cleanup-rollback-conflict");
-        let before = shared
-            .tx_pool
-            .lock()
-            .expect("tx pool")
-            .snapshot()
-            .expect("snapshot before conflict cleanup failure");
+        let (shared, dir, admitted_txid, conflicting_input) =
+            shared_state_with_admitted_tx("rubin-node-p2p-cleanup-best-effort-conflict");
         let cleanup = TxPoolCleanupPlan::from_parts_for_test(
             Vec::new(),
             vec![conflicting_input],
@@ -1512,32 +1496,26 @@ mod tests {
             apply_tx_pool_cleanup(&shared, cleanup),
             "requeue_blocks_unavailable=1",
         );
-        let after = shared
-            .tx_pool
-            .lock()
-            .expect("tx pool")
-            .snapshot()
-            .expect("snapshot after conflict cleanup failure");
         assert_eq!(
-            after, before,
-            "failed requeue must roll back conflict removal"
+            shared
+                .tx_pool
+                .lock()
+                .expect("tx pool")
+                .tx_by_id(&admitted_txid),
+            None,
+            "post-success cleanup keeps conflict removal despite later requeue failure"
         );
-        fs::remove_dir_all(dir).expect("cleanup conflict rollback");
+        fs::remove_dir_all(dir).expect("cleanup conflict best-effort");
 
         let (shared, dir) =
-            test_shared_state_after_genesis("rubin-node-p2p-cleanup-rollback-requeue");
+            test_shared_state_after_genesis("rubin-node-p2p-cleanup-best-effort-requeue");
         let (state, requeue_raw, _) = signed_conflicting_p2pk_state_and_txs(7700, 10, 9);
         {
             let mut engine = shared.sync_engine.lock().expect("sync engine");
             engine.chain_state.utxos = state.utxos.clone();
         }
+        let (_, requeue_txid, _, _) = parse_tx(&requeue_raw).expect("parse requeue tx");
         let requeue_block_hash = store_requeue_block(&shared, std::slice::from_ref(&requeue_raw));
-        let before = shared
-            .tx_pool
-            .lock()
-            .expect("tx pool")
-            .snapshot()
-            .expect("snapshot before accepted requeue rollback");
         let cleanup = TxPoolCleanupPlan::from_parts_for_test(
             Vec::new(),
             Vec::new(),
@@ -1549,19 +1527,16 @@ mod tests {
         );
         assert!(
             summary.contains("requeue_accepted=1"),
-            "test must prove a requeue mutation happened before rollback: {summary}"
+            "test must prove a requeue mutation happened before the later failure: {summary}"
         );
-        let after = shared
-            .tx_pool
-            .lock()
-            .expect("tx pool")
-            .snapshot()
-            .expect("snapshot after accepted requeue rollback");
-        assert_eq!(
-            after, before,
-            "failed requeue must roll back accepted requeue admission state"
+        let pool = shared.tx_pool.lock().expect("tx pool");
+        assert!(
+            pool.tx_by_id(&requeue_txid).is_some(),
+            "post-success cleanup keeps accepted requeue admission despite later requeue failure"
         );
-        fs::remove_dir_all(dir).expect("cleanup requeue rollback");
+        assert_eq!(pool.entry_source(&requeue_txid), Some(TxSource::Reorg));
+        drop(pool);
+        fs::remove_dir_all(dir).expect("cleanup requeue best-effort");
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/p2p_service.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_service.rs
@@ -953,12 +953,21 @@ fn apply_tx_pool_cleanup(
             .tx_pool
             .lock()
             .map_err(|_| "tx pool unavailable".to_string())?;
-        tx_pool_cleanup.apply_with_report(
+        let snapshot = tx_pool
+            .snapshot()
+            .map_err(|err| format!("tx pool cleanup snapshot: {err}"))?;
+        let report = tx_pool_cleanup.apply_with_report(
             &mut tx_pool,
             &chain_state,
             block_store.as_ref(),
             chain_id,
-        )
+        );
+        if report.has_requeue_failures() {
+            tx_pool
+                .restore_snapshot(&snapshot)
+                .map_err(|err| format!("tx pool cleanup rollback: {err}"))?;
+        }
+        report
     };
     if report.has_requeue_failures() {
         return Ok(Some(report.requeue_failure_summary()));
@@ -1108,7 +1117,7 @@ mod tests {
     use std::thread;
     use std::time::{Duration, Instant};
 
-    use rubin_consensus::{block_hash, constants::POW_LIMIT, BLOCK_HEADER_BYTES};
+    use rubin_consensus::{block_hash, constants::POW_LIMIT, parse_tx, BLOCK_HEADER_BYTES};
 
     use super::{
         apply_tx_pool_cleanup, connect_with_timeout, finalize_live_message_outcome,
@@ -1228,10 +1237,51 @@ mod tests {
         TxPoolCleanupPlan::from_parts_for_test(Vec::new(), Vec::new(), vec![block_hash_bytes])
     }
 
+    fn shared_state_with_admitted_tx(
+        prefix: &str,
+    ) -> (
+        SharedServiceState,
+        std::path::PathBuf,
+        [u8; 32],
+        rubin_consensus::Outpoint,
+    ) {
+        let (shared, dir) = test_shared_state_after_genesis(prefix);
+        let (state, admitted_raw, _) = signed_conflicting_p2pk_state_and_txs(7700, 10, 9);
+        {
+            let mut engine = shared.sync_engine.lock().expect("sync engine");
+            engine.chain_state.utxos = state.utxos.clone();
+        }
+        let (tx, parsed_txid, _, consumed) = parse_tx(&admitted_raw).expect("parse admitted tx");
+        assert_eq!(consumed, admitted_raw.len());
+        let input = tx.inputs.first().expect("admitted tx input");
+        let conflicting_input = rubin_consensus::Outpoint {
+            txid: input.prev_txid,
+            vout: input.prev_vout,
+        };
+        let admitted_txid = {
+            let (chain_state, block_store, chain_id) = {
+                let engine = shared.sync_engine.lock().expect("sync engine");
+                (
+                    engine.chain_state_snapshot(),
+                    engine.block_store_snapshot(),
+                    engine.chain_id(),
+                )
+            };
+            shared
+                .tx_pool
+                .lock()
+                .expect("tx pool")
+                .admit(&admitted_raw, &chain_state, block_store.as_ref(), chain_id)
+                .expect("admit tx before cleanup failure")
+        };
+        assert_eq!(admitted_txid, parsed_txid);
+        (shared, dir, admitted_txid, conflicting_input)
+    }
+
     fn assert_requeue_cleanup_failure(
         result: Result<Option<String>, String>,
         expected_bucket: &str,
-    ) {
+    ) -> String {
         let err = result
             .expect("routine requeue failure must not be infrastructure-fatal")
             .expect("requeue cleanup failure must reach live caller");
@@ -1252,6 +1302,7 @@ mod tests {
             err.contains(expected_bucket),
             "missing expected bucket {expected_bucket}: {err}"
         );
+        err
     }
 
     fn wait_until(deadline: Instant, check: impl Fn() -> bool) {
@@ -1410,6 +1461,107 @@ mod tests {
             "requeue_conflict=1",
         );
         fs::remove_dir_all(dir).expect("cleanup conflict");
+    }
+
+    #[test]
+    fn apply_tx_pool_cleanup_rolls_back_partial_mutations_on_requeue_failure() {
+        let missing_requeue_block = [0x44; 32];
+        let (shared, dir, admitted_txid, _) =
+            shared_state_with_admitted_tx("rubin-node-p2p-cleanup-rollback-confirmed");
+        let before = shared
+            .tx_pool
+            .lock()
+            .expect("tx pool")
+            .snapshot()
+            .expect("snapshot before confirmed cleanup failure");
+        let cleanup = TxPoolCleanupPlan::from_parts_for_test(
+            vec![admitted_txid],
+            Vec::new(),
+            vec![missing_requeue_block],
+        );
+        assert_requeue_cleanup_failure(
+            apply_tx_pool_cleanup(&shared, cleanup),
+            "requeue_blocks_unavailable=1",
+        );
+        let after = shared
+            .tx_pool
+            .lock()
+            .expect("tx pool")
+            .snapshot()
+            .expect("snapshot after confirmed cleanup failure");
+        assert_eq!(
+            after, before,
+            "failed requeue must roll back confirmed-tx eviction"
+        );
+        fs::remove_dir_all(dir).expect("cleanup confirmed rollback");
+
+        let (shared, dir, _admitted_txid, conflicting_input) =
+            shared_state_with_admitted_tx("rubin-node-p2p-cleanup-rollback-conflict");
+        let before = shared
+            .tx_pool
+            .lock()
+            .expect("tx pool")
+            .snapshot()
+            .expect("snapshot before conflict cleanup failure");
+        let cleanup = TxPoolCleanupPlan::from_parts_for_test(
+            Vec::new(),
+            vec![conflicting_input],
+            vec![missing_requeue_block],
+        );
+        assert_requeue_cleanup_failure(
+            apply_tx_pool_cleanup(&shared, cleanup),
+            "requeue_blocks_unavailable=1",
+        );
+        let after = shared
+            .tx_pool
+            .lock()
+            .expect("tx pool")
+            .snapshot()
+            .expect("snapshot after conflict cleanup failure");
+        assert_eq!(
+            after, before,
+            "failed requeue must roll back conflict removal"
+        );
+        fs::remove_dir_all(dir).expect("cleanup conflict rollback");
+
+        let (shared, dir) =
+            test_shared_state_after_genesis("rubin-node-p2p-cleanup-rollback-requeue");
+        let (state, requeue_raw, _) = signed_conflicting_p2pk_state_and_txs(7700, 10, 9);
+        {
+            let mut engine = shared.sync_engine.lock().expect("sync engine");
+            engine.chain_state.utxos = state.utxos.clone();
+        }
+        let requeue_block_hash = store_requeue_block(&shared, std::slice::from_ref(&requeue_raw));
+        let before = shared
+            .tx_pool
+            .lock()
+            .expect("tx pool")
+            .snapshot()
+            .expect("snapshot before accepted requeue rollback");
+        let cleanup = TxPoolCleanupPlan::from_parts_for_test(
+            Vec::new(),
+            Vec::new(),
+            vec![missing_requeue_block, requeue_block_hash],
+        );
+        let summary = assert_requeue_cleanup_failure(
+            apply_tx_pool_cleanup(&shared, cleanup),
+            "requeue_blocks_unavailable=1",
+        );
+        assert!(
+            summary.contains("requeue_accepted=1"),
+            "test must prove a requeue mutation happened before rollback: {summary}"
+        );
+        let after = shared
+            .tx_pool
+            .lock()
+            .expect("tx pool")
+            .snapshot()
+            .expect("snapshot after accepted requeue rollback");
+        assert_eq!(
+            after, before,
+            "failed requeue must roll back accepted requeue admission state"
+        );
+        fs::remove_dir_all(dir).expect("cleanup requeue rollback");
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/p2p_service.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_service.rs
@@ -1108,6 +1108,7 @@ mod tests {
     use std::fs;
     use std::io;
     use std::net::{TcpListener, TcpStream};
+    use std::path::PathBuf;
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
     use std::thread;
@@ -1141,6 +1142,20 @@ mod tests {
     use std::collections::HashMap;
 
     static DNS_RESOLVER_TEST_LOCK: Mutex<()> = Mutex::new(());
+    const CLEANUP_TEST_AMOUNT: u64 = 7700;
+    const CLEANUP_TEST_FEE: u64 = 10;
+    const CLEANUP_TEST_WEIGHT: u64 = 9;
+    const MISSING_REQUEUE_BLOCK: [u8; 32] = [0x44; 32];
+
+    struct TempDirCleanupGuard {
+        path: PathBuf,
+    }
+
+    impl Drop for TempDirCleanupGuard {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
 
     fn unique_temp_dir(prefix: &str) -> std::path::PathBuf {
         std::env::temp_dir().join(format!(
@@ -1238,12 +1253,16 @@ mod tests {
         prefix: &str,
     ) -> (
         SharedServiceState,
-        std::path::PathBuf,
+        TempDirCleanupGuard,
         [u8; 32],
         rubin_consensus::Outpoint,
     ) {
         let (shared, dir) = test_shared_state_after_genesis(prefix);
-        let (state, admitted_raw, _) = signed_conflicting_p2pk_state_and_txs(7700, 10, 9);
+        let (state, admitted_raw, _) = signed_conflicting_p2pk_state_and_txs(
+            CLEANUP_TEST_AMOUNT,
+            CLEANUP_TEST_FEE,
+            CLEANUP_TEST_WEIGHT,
+        );
         {
             let mut engine = shared.sync_engine.lock().expect("sync engine");
             engine.chain_state.utxos = state.utxos.clone();
@@ -1272,7 +1291,12 @@ mod tests {
                 .expect("admit tx before cleanup failure")
         };
         assert_eq!(admitted_txid, parsed_txid);
-        (shared, dir, admitted_txid, conflicting_input)
+        (
+            shared,
+            TempDirCleanupGuard { path: dir },
+            admitted_txid,
+            conflicting_input,
+        )
     }
 
     fn assert_requeue_cleanup_failure(
@@ -1461,14 +1485,13 @@ mod tests {
     }
 
     #[test]
-    fn apply_tx_pool_cleanup_keeps_post_success_best_effort_mutations_on_requeue_failure() {
-        let missing_requeue_block = [0x44; 32];
-        let (shared, dir, admitted_txid, _) =
+    fn apply_tx_pool_cleanup_keeps_confirmed_eviction_on_requeue_failure() {
+        let (shared, _dir, admitted_txid, _) =
             shared_state_with_admitted_tx("rubin-node-p2p-cleanup-best-effort-confirmed");
         let cleanup = TxPoolCleanupPlan::from_parts_for_test(
             vec![admitted_txid],
             Vec::new(),
-            vec![missing_requeue_block],
+            vec![MISSING_REQUEUE_BLOCK],
         );
         assert_requeue_cleanup_failure(
             apply_tx_pool_cleanup(&shared, cleanup),
@@ -1483,14 +1506,16 @@ mod tests {
             None,
             "post-success cleanup keeps confirmed-tx eviction despite later requeue failure"
         );
-        fs::remove_dir_all(dir).expect("cleanup confirmed best-effort");
+    }
 
-        let (shared, dir, admitted_txid, conflicting_input) =
+    #[test]
+    fn apply_tx_pool_cleanup_keeps_conflict_removal_on_requeue_failure() {
+        let (shared, _dir, admitted_txid, conflicting_input) =
             shared_state_with_admitted_tx("rubin-node-p2p-cleanup-best-effort-conflict");
         let cleanup = TxPoolCleanupPlan::from_parts_for_test(
             Vec::new(),
             vec![conflicting_input],
-            vec![missing_requeue_block],
+            vec![MISSING_REQUEUE_BLOCK],
         );
         assert_requeue_cleanup_failure(
             apply_tx_pool_cleanup(&shared, cleanup),
@@ -1505,11 +1530,18 @@ mod tests {
             None,
             "post-success cleanup keeps conflict removal despite later requeue failure"
         );
-        fs::remove_dir_all(dir).expect("cleanup conflict best-effort");
+    }
 
+    #[test]
+    fn apply_tx_pool_cleanup_keeps_accepted_requeue_on_later_requeue_failure() {
         let (shared, dir) =
             test_shared_state_after_genesis("rubin-node-p2p-cleanup-best-effort-requeue");
-        let (state, requeue_raw, _) = signed_conflicting_p2pk_state_and_txs(7700, 10, 9);
+        let _dir = TempDirCleanupGuard { path: dir };
+        let (state, requeue_raw, _) = signed_conflicting_p2pk_state_and_txs(
+            CLEANUP_TEST_AMOUNT,
+            CLEANUP_TEST_FEE,
+            CLEANUP_TEST_WEIGHT,
+        );
         {
             let mut engine = shared.sync_engine.lock().expect("sync engine");
             engine.chain_state.utxos = state.utxos.clone();
@@ -1519,7 +1551,7 @@ mod tests {
         let cleanup = TxPoolCleanupPlan::from_parts_for_test(
             Vec::new(),
             Vec::new(),
-            vec![missing_requeue_block, requeue_block_hash],
+            vec![MISSING_REQUEUE_BLOCK, requeue_block_hash],
         );
         let summary = assert_requeue_cleanup_failure(
             apply_tx_pool_cleanup(&shared, cleanup),
@@ -1536,7 +1568,6 @@ mod tests {
         );
         assert_eq!(pool.entry_source(&requeue_txid), Some(TxSource::Reorg));
         drop(pool);
-        fs::remove_dir_all(dir).expect("cleanup requeue best-effort");
     }
 
     #[test]


### PR DESCRIPTION
Invariant:
Rust txpool cleanup after an accepted block/reorg is explicitly classified as post-success best-effort: confirmed evictions, conflict removals, and successful requeues remain visible even if a later requeue item reports failure.

Layer:
Rust implementation/tests.

Files changed:
- clients/rust/crates/rubin-node/src/p2p_service.rs

Non-goals:
- No Go changes.
- No conformance, formal, fixture, Cargo, or sync lifecycle changes.
- No new mempool policy semantics.

Validation:
- scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo fmt --check'
- git diff --check
- scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test -p rubin-node p2p_service::tests::apply_tx_pool_cleanup -- --nocapture'
- scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test -p rubin-node sync_reorg -- --nocapture'
- scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test -p rubin-node -- --nocapture'
- rubin-precommit-one-review --repo /Users/gpt/Documents/rubin-protocol-codex-RUB-237 --base-ref origin/main
- isolated stock code-review subagent: no findings
- rubin-push with coverage command: PASS

Linear:
RUB-237
