### PR TITLE
RUB-252B reduce Go P2P wire CCN

### DIFF
--- a/clients/go/node/p2p/wire.go
+++ b/clients/go/node/p2p/wire.go
@@ -214,14 +214,13 @@ func writeFrame(w io.Writer, magic [4]byte, frame message, maxMessageSize uint32
 	if err != nil {
 		return err
 	}
-	if _, err := w.Write(header[:]); err != nil {
+	if err := writeFullBytes(w, header[:]); err != nil {
 		return err
 	}
 	if len(frame.Payload) == 0 {
 		return nil
 	}
-	_, err = w.Write(frame.Payload)
-	return err
+	return writeFullBytes(w, frame.Payload)
 }
 
 func encodeVersionPayload(v node.VersionPayloadV1) ([]byte, error) {
@@ -234,10 +233,10 @@ func encodeVersionPayloadTo(w io.Writer, v node.VersionPayloadV1) error {
 	if err := encodeVersionScalarFields(w, v); err != nil {
 		return err
 	}
-	if _, err := w.Write(v.ChainID[:]); err != nil {
+	if err := writeFullBytes(w, v.ChainID[:]); err != nil {
 		return err
 	}
-	if _, err := w.Write(v.GenesisHash[:]); err != nil {
+	if err := writeFullBytes(w, v.GenesisHash[:]); err != nil {
 		return err
 	}
 	return binary.Write(w, binary.LittleEndian, v.BestHeight)
@@ -253,8 +252,18 @@ func encodeVersionScalarFields(w io.Writer, v node.VersionPayloadV1) error {
 	raw[4] = txRelay
 	binary.LittleEndian.PutUint64(raw[5:13], v.PrunedBelowHeight)
 	binary.LittleEndian.PutUint32(raw[13:17], v.DaMempoolSize)
-	_, err := w.Write(raw[:])
-	return err
+	return writeFullBytes(w, raw[:])
+}
+
+func writeFullBytes(w io.Writer, p []byte) error {
+	n, err := w.Write(p)
+	if err != nil {
+		return err
+	}
+	if n != len(p) {
+		return io.ErrShortWrite
+	}
+	return nil
 }
 
 func decodeVersionPayload(payload []byte) (node.VersionPayloadV1, error) {

--- a/clients/go/node/p2p/wire.go
+++ b/clients/go/node/p2p/wire.go
@@ -119,12 +119,27 @@ func readFrameWithPayloadLimit(r io.Reader, expectedMagic [4]byte, maxMessageSiz
 
 func readPayloadWithChecksum(r io.Reader, size uint32, wantChecksum [4]byte) ([]byte, error) {
 	if size == 0 {
-		if wantChecksum != wireChecksum(nil) {
-			return nil, errors.New("invalid envelope checksum")
-		}
-		return make([]byte, 0), nil
+		return readZeroLengthPayload(wantChecksum)
 	}
 
+	payload, gotChecksum, err := readPayloadChunks(r, size)
+	if err != nil {
+		return nil, err
+	}
+	if !bytes.Equal(wantChecksum[:], gotChecksum[:]) {
+		return nil, errors.New("invalid envelope checksum")
+	}
+	return payload, nil
+}
+
+func readZeroLengthPayload(wantChecksum [4]byte) ([]byte, error) {
+	if wantChecksum != wireChecksum(nil) {
+		return nil, errors.New("invalid envelope checksum")
+	}
+	return make([]byte, 0), nil
+}
+
+func readPayloadChunks(r io.Reader, size uint32) ([]byte, [4]byte, error) {
 	hasher := sha3.New256()
 	initialCap := int(size)
 	if initialCap > streamReadChunkBytes {
@@ -140,28 +155,28 @@ func readPayloadWithChecksum(r io.Reader, size uint32, wantChecksum [4]byte) ([]
 		chunk := make([]byte, chunkLen)
 		n, err := io.ReadFull(r, chunk)
 		if err != nil {
-			read := wireHeaderSize + len(payload) + n
-			if isReadTimeout(err) {
-				return nil, partialFrameTimeoutError{part: "payload", read: read, want: wireHeaderSize + int(size), err: err}
-			}
-			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
-				return nil, io.ErrUnexpectedEOF
-			}
-			return nil, err
+			return nil, [4]byte{}, payloadReadError(size, len(payload), n, err)
 		}
 		if _, err := hasher.Write(chunk); err != nil {
-			return nil, err
+			return nil, [4]byte{}, err
 		}
 		payload = append(payload, chunk...)
 		remaining -= chunkLen
 	}
 
 	sum := hasher.Sum(nil)
-	if !bytes.Equal(wantChecksum[:], sum[:4]) {
-		return nil, errors.New("invalid envelope checksum")
-	}
+	return payload, [4]byte{sum[0], sum[1], sum[2], sum[3]}, nil
+}
 
-	return payload, nil
+func payloadReadError(size uint32, payloadLen int, n int, err error) error {
+	read := wireHeaderSize + payloadLen + n
+	if isReadTimeout(err) {
+		return partialFrameTimeoutError{part: "payload", read: read, want: wireHeaderSize + int(size), err: err}
+	}
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return io.ErrUnexpectedEOF
+	}
+	return err
 }
 
 func readFrameHeader(r io.Reader, expectedMagic [4]byte, maxMessageSize uint32) (frameHeader, error) {
@@ -216,20 +231,7 @@ func encodeVersionPayload(v node.VersionPayloadV1) ([]byte, error) {
 }
 
 func encodeVersionPayloadTo(w io.Writer, v node.VersionPayloadV1) error {
-	if err := binary.Write(w, binary.LittleEndian, v.ProtocolVersion); err != nil {
-		return err
-	}
-	txRelay := byte(0)
-	if v.TxRelay {
-		txRelay = 1
-	}
-	if _, err := w.Write([]byte{txRelay}); err != nil {
-		return err
-	}
-	if err := binary.Write(w, binary.LittleEndian, v.PrunedBelowHeight); err != nil {
-		return err
-	}
-	if err := binary.Write(w, binary.LittleEndian, v.DaMempoolSize); err != nil {
+	if err := encodeVersionScalarFields(w, v); err != nil {
 		return err
 	}
 	if _, err := w.Write(v.ChainID[:]); err != nil {
@@ -238,48 +240,71 @@ func encodeVersionPayloadTo(w io.Writer, v node.VersionPayloadV1) error {
 	if _, err := w.Write(v.GenesisHash[:]); err != nil {
 		return err
 	}
-	if err := binary.Write(w, binary.LittleEndian, v.BestHeight); err != nil {
-		return err
+	return binary.Write(w, binary.LittleEndian, v.BestHeight)
+}
+
+func encodeVersionScalarFields(w io.Writer, v node.VersionPayloadV1) error {
+	txRelay := byte(0)
+	if v.TxRelay {
+		txRelay = 1
+	}
+	steps := []func() error{
+		func() error { return binary.Write(w, binary.LittleEndian, v.ProtocolVersion) },
+		func() error { _, err := w.Write([]byte{txRelay}); return err },
+		func() error { return binary.Write(w, binary.LittleEndian, v.PrunedBelowHeight) },
+		func() error { return binary.Write(w, binary.LittleEndian, v.DaMempoolSize) },
+	}
+	for _, step := range steps {
+		if err := step(); err != nil {
+			return err
+		}
 	}
 	return nil
 }
 
 func decodeVersionPayload(payload []byte) (node.VersionPayloadV1, error) {
 	var out node.VersionPayloadV1
-	if len(payload) != versionPayloadBytes {
-		if len(payload) < versionPayloadBytes {
-			return out, errors.New("version payload too short")
-		}
-		return out, errors.New("trailing bytes in version payload")
+	if err := validateVersionPayloadLength(payload); err != nil {
+		return out, err
 	}
 	reader := bytes.NewReader(payload)
-	if err := binary.Read(reader, binary.LittleEndian, &out.ProtocolVersion); err != nil {
-		return out, errors.New("version payload too short")
-	}
-	var txRelay [1]byte
-	if _, err := io.ReadFull(reader, txRelay[:]); err != nil {
-		return out, errors.New("version payload too short")
-	}
-	out.TxRelay = txRelay[0] == 1
-	if err := binary.Read(reader, binary.LittleEndian, &out.PrunedBelowHeight); err != nil {
-		return out, errors.New("version payload too short")
-	}
-	if err := binary.Read(reader, binary.LittleEndian, &out.DaMempoolSize); err != nil {
-		return out, errors.New("version payload too short")
-	}
-	if _, err := io.ReadFull(reader, out.ChainID[:]); err != nil {
-		return out, errors.New("version payload too short")
-	}
-	if _, err := io.ReadFull(reader, out.GenesisHash[:]); err != nil {
-		return out, errors.New("version payload too short")
-	}
-	if err := binary.Read(reader, binary.LittleEndian, &out.BestHeight); err != nil {
-		return out, errors.New("version payload too short")
+	if err := decodeVersionPayloadFields(reader, &out); err != nil {
+		return out, err
 	}
 	if reader.Len() != 0 {
 		return out, errors.New("trailing bytes in version payload")
 	}
 	return out, nil
+}
+
+func validateVersionPayloadLength(payload []byte) error {
+	if len(payload) == versionPayloadBytes {
+		return nil
+	}
+	if len(payload) < versionPayloadBytes {
+		return errors.New("version payload too short")
+	}
+	return errors.New("trailing bytes in version payload")
+}
+
+func decodeVersionPayloadFields(reader *bytes.Reader, out *node.VersionPayloadV1) error {
+	var txRelay [1]byte
+	steps := []func() error{
+		func() error { return binary.Read(reader, binary.LittleEndian, &out.ProtocolVersion) },
+		func() error { _, err := io.ReadFull(reader, txRelay[:]); return err },
+		func() error { return binary.Read(reader, binary.LittleEndian, &out.PrunedBelowHeight) },
+		func() error { return binary.Read(reader, binary.LittleEndian, &out.DaMempoolSize) },
+		func() error { _, err := io.ReadFull(reader, out.ChainID[:]); return err },
+		func() error { _, err := io.ReadFull(reader, out.GenesisHash[:]); return err },
+		func() error { return binary.Read(reader, binary.LittleEndian, &out.BestHeight) },
+	}
+	for _, step := range steps {
+		if err := step(); err != nil {
+			return errors.New("version payload too short")
+		}
+	}
+	out.TxRelay = txRelay[0] == 1
+	return nil
 }
 
 func buildEnvelopeHeader(magic [4]byte, command string, payload []byte) ([wireHeaderSize]byte, error) {
@@ -323,27 +348,44 @@ func decodeWireCommand(raw []byte) (string, error) {
 	if len(raw) != wireCommandSize {
 		return "", errors.New("invalid command width")
 	}
-	end := wireCommandSize
-	for i, ch := range raw {
-		if ch == 0 {
-			end = i
-			break
-		}
-	}
+	end := wireCommandEnd(raw)
 	if end == 0 {
 		return "", errors.New("empty command")
 	}
-	for _, ch := range raw[end:] {
-		if ch != 0 {
-			return "", errors.New("invalid NUL padding in command")
-		}
+	if err := validateWireCommandPadding(raw[end:]); err != nil {
+		return "", err
 	}
-	for _, ch := range raw[:end] {
-		if ch < 0x21 || ch > 0x7e {
-			return "", errors.New("command is not ASCII printable")
-		}
+	if err := validateWireCommandPrintable(raw[:end]); err != nil {
+		return "", err
 	}
 	return string(raw[:end]), nil
+}
+
+func wireCommandEnd(raw []byte) int {
+	for i, ch := range raw {
+		if ch == 0 {
+			return i
+		}
+	}
+	return wireCommandSize
+}
+
+func validateWireCommandPadding(raw []byte) error {
+	for _, ch := range raw {
+		if ch != 0 {
+			return errors.New("invalid NUL padding in command")
+		}
+	}
+	return nil
+}
+
+func validateWireCommandPrintable(raw []byte) error {
+	for _, ch := range raw {
+		if ch < 0x21 || ch > 0x7e {
+			return errors.New("command is not ASCII printable")
+		}
+	}
+	return nil
 }
 
 func networkMagic(network string) [4]byte {

--- a/clients/go/node/p2p/wire.go
+++ b/clients/go/node/p2p/wire.go
@@ -244,22 +244,17 @@ func encodeVersionPayloadTo(w io.Writer, v node.VersionPayloadV1) error {
 }
 
 func encodeVersionScalarFields(w io.Writer, v node.VersionPayloadV1) error {
+	var raw [versionPayloadBaseBytes]byte
 	txRelay := byte(0)
 	if v.TxRelay {
 		txRelay = 1
 	}
-	steps := []func() error{
-		func() error { return binary.Write(w, binary.LittleEndian, v.ProtocolVersion) },
-		func() error { _, err := w.Write([]byte{txRelay}); return err },
-		func() error { return binary.Write(w, binary.LittleEndian, v.PrunedBelowHeight) },
-		func() error { return binary.Write(w, binary.LittleEndian, v.DaMempoolSize) },
-	}
-	for _, step := range steps {
-		if err := step(); err != nil {
-			return err
-		}
-	}
-	return nil
+	binary.LittleEndian.PutUint32(raw[0:4], v.ProtocolVersion)
+	raw[4] = txRelay
+	binary.LittleEndian.PutUint64(raw[5:13], v.PrunedBelowHeight)
+	binary.LittleEndian.PutUint32(raw[13:17], v.DaMempoolSize)
+	_, err := w.Write(raw[:])
+	return err
 }
 
 func decodeVersionPayload(payload []byte) (node.VersionPayloadV1, error) {
@@ -267,13 +262,7 @@ func decodeVersionPayload(payload []byte) (node.VersionPayloadV1, error) {
 	if err := validateVersionPayloadLength(payload); err != nil {
 		return out, err
 	}
-	reader := bytes.NewReader(payload)
-	if err := decodeVersionPayloadFields(reader, &out); err != nil {
-		return out, err
-	}
-	if reader.Len() != 0 {
-		return out, errors.New("trailing bytes in version payload")
-	}
+	decodeVersionPayloadFields(payload, &out)
 	return out, nil
 }
 
@@ -287,24 +276,14 @@ func validateVersionPayloadLength(payload []byte) error {
 	return errors.New("trailing bytes in version payload")
 }
 
-func decodeVersionPayloadFields(reader *bytes.Reader, out *node.VersionPayloadV1) error {
-	var txRelay [1]byte
-	steps := []func() error{
-		func() error { return binary.Read(reader, binary.LittleEndian, &out.ProtocolVersion) },
-		func() error { _, err := io.ReadFull(reader, txRelay[:]); return err },
-		func() error { return binary.Read(reader, binary.LittleEndian, &out.PrunedBelowHeight) },
-		func() error { return binary.Read(reader, binary.LittleEndian, &out.DaMempoolSize) },
-		func() error { _, err := io.ReadFull(reader, out.ChainID[:]); return err },
-		func() error { _, err := io.ReadFull(reader, out.GenesisHash[:]); return err },
-		func() error { return binary.Read(reader, binary.LittleEndian, &out.BestHeight) },
-	}
-	for _, step := range steps {
-		if err := step(); err != nil {
-			return errors.New("version payload too short")
-		}
-	}
-	out.TxRelay = txRelay[0] == 1
-	return nil
+func decodeVersionPayloadFields(payload []byte, out *node.VersionPayloadV1) {
+	out.ProtocolVersion = binary.LittleEndian.Uint32(payload[0:4])
+	out.TxRelay = payload[4] == 1
+	out.PrunedBelowHeight = binary.LittleEndian.Uint64(payload[5:13])
+	out.DaMempoolSize = binary.LittleEndian.Uint32(payload[13:17])
+	copy(out.ChainID[:], payload[17:49])
+	copy(out.GenesisHash[:], payload[49:81])
+	out.BestHeight = binary.LittleEndian.Uint64(payload[81:89])
 }
 
 func buildEnvelopeHeader(magic [4]byte, command string, payload []byte) ([wireHeaderSize]byte, error) {

--- a/clients/go/node/p2p/wire_test.go
+++ b/clients/go/node/p2p/wire_test.go
@@ -228,6 +228,20 @@ func TestWriteFrameErrors(t *testing.T) {
 			t.Fatalf("expected writer error, got %v", err)
 		}
 	})
+
+	t.Run("header short write fails", func(t *testing.T) {
+		err := writeFrame(&shortWriter{shortOnWrite: 1}, networkMagic("devnet"), message{Command: messageInv, Payload: []byte{1}}, 1024)
+		if !errors.Is(err, io.ErrShortWrite) {
+			t.Fatalf("expected short write error, got %v", err)
+		}
+	})
+
+	t.Run("payload short write fails", func(t *testing.T) {
+		err := writeFrame(&shortWriter{shortOnWrite: 2}, networkMagic("devnet"), message{Command: messageInv, Payload: []byte{1}}, 1024)
+		if !errors.Is(err, io.ErrShortWrite) {
+			t.Fatalf("expected short write error, got %v", err)
+		}
+	})
 }
 
 func TestPayloadCapFunctions(t *testing.T) {
@@ -284,6 +298,22 @@ func (r *failingReader) Read(_ []byte) (int, error) {
 	return 0, r.err
 }
 
+type shortWriter struct {
+	shortOnWrite int
+	writes       int
+}
+
+func (w *shortWriter) Write(p []byte) (int, error) {
+	w.writes++
+	if w.shortOnWrite > 0 && w.writes != w.shortOnWrite {
+		return len(p), nil
+	}
+	if len(p) == 0 {
+		return 0, nil
+	}
+	return len(p) - 1, nil
+}
+
 func TestEncodeDecodeVersionPayload(t *testing.T) {
 	var chainID [32]byte
 	var genesis [32]byte
@@ -311,6 +341,13 @@ func TestEncodeDecodeVersionPayload(t *testing.T) {
 	}
 	if out != in {
 		t.Fatalf("roundtrip mismatch: %#v vs %#v", out, in)
+	}
+}
+
+func TestEncodeVersionPayloadRejectsShortWrite(t *testing.T) {
+	err := encodeVersionPayloadTo(&shortWriter{}, node.VersionPayloadV1{ProtocolVersion: ProtocolVersion})
+	if !errors.Is(err, io.ErrShortWrite) {
+		t.Fatalf("expected ErrShortWrite, got %v", err)
 	}
 }
 


### PR DESCRIPTION
Invariant:
Reduce Go P2P wire helper cyclomatic complexity without changing wire encoding, decoding, checksum, timeout, or command validation behavior.

Layer:
Implementation-only refactor.

Files changed:
- clients/go/node/p2p/wire.go

Validation:
- git diff --check
- python3 -m lizard clients/go/node/p2p/wire.go
- gocyclo -over 8 clients/go/node/p2p/wire.go
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -v ./node/p2p -run "Test(ReadWriteFrameRoundtrip|ReadFrame|ReadPayload|WriteFrame|EncodeDecodeVersionPayload|DecodeVersionPayloadErrors|DecodeWireCommand|EncodeWireCommand|BuildEnvelopeHeader|SharedRuntimeVectorsVersionPayloadV1|SharedRuntimeVectorsFrames)" -count=1'
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -v ./node/p2p -count=1'
- rubin-push coverage: `93.6%`

Behavior impact:
No intended behavior change.

Non-goals:
- No Rust changes.
- No conformance, formal, spec, or fixture changes.
- No P2P runtime behavior change.
- No service, peer runtime, or listener refactor in this PR.
