### PR TITLE
RUB-252C reduce Go P2P service CCN

### DIFF
--- a/clients/go/node/p2p/peer_runtime.go
+++ b/clients/go/node/p2p/peer_runtime.go
@@ -25,17 +25,11 @@ func (e postHandshakeUnknownCommandError) peerReason() string {
 
 func (p *peer) run(ctx context.Context) error {
 	for {
-		if ctx != nil {
-			select {
-			case <-ctx.Done():
-				return nil
-			default:
-			}
+		if peerRunContextDone(ctx) {
+			return nil
 		}
-		if deadline := p.service.cfg.PeerRuntimeConfig.ReadDeadline; deadline > 0 {
-			if err := p.conn.SetReadDeadline(time.Now().Add(deadline)); err != nil {
-				return err
-			}
+		if err := p.setReadDeadline(); err != nil {
+			return err
 		}
 		frame, err := readFrameWithPayloadLimit(
 			p.conn,
@@ -55,6 +49,26 @@ func (p *peer) run(ctx context.Context) error {
 	}
 }
 
+func peerRunContextDone(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	select {
+	case <-ctx.Done():
+		return true
+	default:
+		return false
+	}
+}
+
+func (p *peer) setReadDeadline() error {
+	deadline := p.service.cfg.PeerRuntimeConfig.ReadDeadline
+	if deadline <= 0 {
+		return nil
+	}
+	return p.conn.SetReadDeadline(time.Now().Add(deadline))
+}
+
 func shouldIgnoreReadError(err error) bool {
 	return !isPartialFrameTimeout(err) && isReadTimeout(err)
 }
@@ -70,26 +84,62 @@ func normalizeReadError(err error) error {
 
 func (p *peer) handleMessage(frame message) error {
 	switch frame.Command {
-	case messageInv:
-		return p.handleInv(frame.Payload)
-	case messageGetData:
-		return p.handleGetData(frame.Payload)
-	case messageBlock:
-		return p.handleBlock(frame.Payload)
-	case messageTx:
-		return p.handleTx(frame.Payload)
-	case messageGetBlk:
-		return p.handleGetBlocks(frame.Payload)
-	case messageGetAddr:
-		return p.handleGetAddr(frame.Payload)
-	case messageAddr:
-		return p.handleAddr(frame.Payload)
+	case messageInv, messageGetData, messageBlock, messageTx, messageGetBlk:
+		return p.handleRelayMessage(frame)
+	case messageGetAddr, messageAddr:
+		return p.handleAddressMessage(frame)
 	case messagePing, messagePong, messageHeaders:
 		return nil
 	case messageVersion:
 		return errors.New("invalid version message after handshake")
 	case messageVerAck:
 		return errors.New("invalid verack after handshake")
+	default:
+		return postHandshakeUnknownCommandError{command: frame.Command}
+	}
+}
+
+func (p *peer) handleRelayMessage(frame message) error {
+	switch frame.Command {
+	case messageInv, messageGetData:
+		return p.handleInventoryRelayMessage(frame)
+	case messageBlock, messageTx, messageGetBlk:
+		return p.handleObjectRelayMessage(frame)
+	default:
+		return postHandshakeUnknownCommandError{command: frame.Command}
+	}
+}
+
+func (p *peer) handleInventoryRelayMessage(frame message) error {
+	switch frame.Command {
+	case messageInv:
+		return p.handleInv(frame.Payload)
+	case messageGetData:
+		return p.handleGetData(frame.Payload)
+	default:
+		return postHandshakeUnknownCommandError{command: frame.Command}
+	}
+}
+
+func (p *peer) handleObjectRelayMessage(frame message) error {
+	switch frame.Command {
+	case messageBlock:
+		return p.handleBlock(frame.Payload)
+	case messageTx:
+		return p.handleTx(frame.Payload)
+	case messageGetBlk:
+		return p.handleGetBlocks(frame.Payload)
+	default:
+		return postHandshakeUnknownCommandError{command: frame.Command}
+	}
+}
+
+func (p *peer) handleAddressMessage(frame message) error {
+	switch frame.Command {
+	case messageGetAddr:
+		return p.handleGetAddr(frame.Payload)
+	case messageAddr:
+		return p.handleAddr(frame.Payload)
 	default:
 		return postHandshakeUnknownCommandError{command: frame.Command}
 	}

--- a/clients/go/node/p2p/service.go
+++ b/clients/go/node/p2p/service.go
@@ -106,51 +106,10 @@ type peer struct {
 }
 
 func NewService(cfg ServiceConfig) (*Service, error) {
-	if strings.TrimSpace(cfg.BindAddr) == "" {
-		return nil, errors.New("bind address is required")
+	if err := validateServiceConfig(cfg); err != nil {
+		return nil, err
 	}
-	if cfg.PeerManager == nil {
-		return nil, errors.New("nil peer manager")
-	}
-	if cfg.SyncEngine == nil {
-		return nil, errors.New("nil sync engine")
-	}
-	if cfg.BlockStore == nil {
-		return nil, errors.New("nil blockstore")
-	}
-	if cfg.TxMetadataFunc == nil {
-		return nil, errors.New("nil tx metadata func")
-	}
-	if cfg.TxPool == nil {
-		cfg.TxPool = NewMemoryTxPool()
-	}
-	if cfg.Now == nil {
-		cfg.Now = time.Now
-	}
-	if strings.TrimSpace(cfg.UserAgent) == "" {
-		cfg.UserAgent = "rubin-go/p2p"
-	}
-	var zero [32]byte
-	if cfg.GenesisHash == zero {
-		cfg.GenesisHash = node.DevnetGenesisBlockHash()
-	}
-	if cfg.LocatorLimit <= 0 {
-		cfg.LocatorLimit = defaultLocatorLimit
-	}
-	if cfg.GetBlocksBatchSize == 0 {
-		if cfg.SyncConfig.HeaderBatchLimit > 0 {
-			cfg.GetBlocksBatchSize = cfg.SyncConfig.HeaderBatchLimit
-		} else {
-			cfg.GetBlocksBatchSize = defaultGetBlocksBatchLimit
-		}
-	}
-	cfg.PeerRuntimeConfig = mergePeerRuntimeConfig(cfg.PeerRuntimeConfig)
-	if cfg.PeerRuntimeConfig.Network == "" {
-		cfg.PeerRuntimeConfig.Network = cfg.SyncConfig.Network
-	}
-	if cfg.TxRelayFanout <= 0 {
-		cfg.TxRelayFanout = defaultTxRelayFanout
-	}
+	cfg = normalizeServiceConfig(cfg)
 	outboundAddrs := normalizeDialTargets(cfg.BootstrapPeers)
 	addrMgr := newAddrManager(cfg.Now)
 	seedAddrManagerFromBootstrap(addrMgr, outboundAddrs)
@@ -166,6 +125,72 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 		txSeen:         newBoundedHashSet(defaultTxSeenCapacity),
 		orphans:        newOrphanPool(500),
 	}, nil
+}
+
+func validateServiceConfig(cfg ServiceConfig) error {
+	for _, check := range []struct {
+		invalid bool
+		err     string
+	}{
+		{strings.TrimSpace(cfg.BindAddr) == "", "bind address is required"},
+		{cfg.PeerManager == nil, "nil peer manager"},
+		{cfg.SyncEngine == nil, "nil sync engine"},
+		{cfg.BlockStore == nil, "nil blockstore"},
+		{cfg.TxMetadataFunc == nil, "nil tx metadata func"},
+	} {
+		if check.invalid {
+			return errors.New(check.err)
+		}
+	}
+	return nil
+}
+
+func normalizeServiceConfig(cfg ServiceConfig) ServiceConfig {
+	if cfg.TxPool == nil {
+		cfg.TxPool = NewMemoryTxPool()
+	}
+	cfg = normalizeServiceIdentityConfig(cfg)
+	cfg.GetBlocksBatchSize = normalizeGetBlocksBatchSize(cfg.GetBlocksBatchSize, cfg.SyncConfig.HeaderBatchLimit)
+	cfg.PeerRuntimeConfig = normalizeServicePeerRuntimeConfig(cfg.PeerRuntimeConfig, cfg.SyncConfig.Network)
+	if cfg.TxRelayFanout <= 0 {
+		cfg.TxRelayFanout = defaultTxRelayFanout
+	}
+	return cfg
+}
+
+func normalizeServiceIdentityConfig(cfg ServiceConfig) ServiceConfig {
+	if cfg.Now == nil {
+		cfg.Now = time.Now
+	}
+	if strings.TrimSpace(cfg.UserAgent) == "" {
+		cfg.UserAgent = "rubin-go/p2p"
+	}
+	var zero [32]byte
+	if cfg.GenesisHash == zero {
+		cfg.GenesisHash = node.DevnetGenesisBlockHash()
+	}
+	if cfg.LocatorLimit <= 0 {
+		cfg.LocatorLimit = defaultLocatorLimit
+	}
+	return cfg
+}
+
+func normalizeGetBlocksBatchSize(configured, headerBatchLimit uint64) uint64 {
+	if configured > 0 {
+		return configured
+	}
+	if headerBatchLimit > 0 {
+		return headerBatchLimit
+	}
+	return defaultGetBlocksBatchLimit
+}
+
+func normalizeServicePeerRuntimeConfig(cfg node.PeerRuntimeConfig, syncNetwork string) node.PeerRuntimeConfig {
+	cfg = mergePeerRuntimeConfig(cfg)
+	if cfg.Network == "" {
+		cfg.Network = syncNetwork
+	}
+	return cfg
 }
 
 func (s *Service) AnnounceBlock(blockBytes []byte) error {
@@ -190,28 +215,42 @@ func (s *Service) AnnounceTx(txBytes []byte) error {
 	if s == nil {
 		return errors.New("nil service")
 	}
-	_, txid, _, consumed, err := consensus.ParseTx(txBytes)
+	txid, err := parseCanonicalTxID(txBytes)
 	if err != nil {
 		return err
 	}
-	if consumed != len(txBytes) {
-		return errors.New("non-canonical tx bytes")
-	}
-	admitted := s.cfg.TxPool.Has(txid)
-	if !admitted {
-		meta, err := s.relayTxMetadata(txBytes)
-		if err != nil {
-			return err
-		}
-		admitted = s.cfg.TxPool.Put(txid, txBytes, meta.Fee, meta.Size)
-	}
-	if !admitted && !s.cfg.TxPool.Has(txid) {
-		return errors.New("tx not admitted to relay pool")
+	if err := s.ensureRelayTxAdmitted(txid, txBytes); err != nil {
+		return err
 	}
 	if !s.txSeen.Add(txid) {
 		return nil
 	}
 	return s.broadcastInventory(nil, []InventoryVector{{Type: MSG_TX, Hash: txid}})
+}
+
+func parseCanonicalTxID(txBytes []byte) ([32]byte, error) {
+	_, txid, _, consumed, err := consensus.ParseTx(txBytes)
+	if err != nil {
+		return [32]byte{}, err
+	}
+	if consumed != len(txBytes) {
+		return [32]byte{}, errors.New("non-canonical tx bytes")
+	}
+	return txid, nil
+}
+
+func (s *Service) ensureRelayTxAdmitted(txid [32]byte, txBytes []byte) error {
+	if s.cfg.TxPool.Has(txid) {
+		return nil
+	}
+	meta, err := s.relayTxMetadata(txBytes)
+	if err != nil {
+		return err
+	}
+	if s.cfg.TxPool.Put(txid, txBytes, meta.Fee, meta.Size) || s.cfg.TxPool.Has(txid) {
+		return nil
+	}
+	return errors.New("tx not admitted to relay pool")
 }
 
 func normalizePeerAddrs(addrs []string) []string {

--- a/clients/go/node/p2p/service_listener.go
+++ b/clients/go/node/p2p/service_listener.go
@@ -80,26 +80,9 @@ func (s *Service) Start(ctx context.Context) error {
 		ctx = context.Background()
 	}
 
-	// Register this Start invocation with startWG atomically with the
-	// dormant/started check, under the same peersMu that guards closed.
-	// This is critical for sync.WaitGroup correctness: Go panics with
-	// "Add called concurrently with Wait" if Add transitions the counter
-	// from 0 while Wait is running. Close sets s.closed=true under peersMu
-	// and then calls startWG.Wait. By taking the write lock here and
-	// reading s.closed before calling Add, we guarantee that once Close
-	// has published closed=true, no subsequent Start can Add — it will
-	// observe closed=true and return without touching startWG.
-	s.peersMu.Lock()
-	if s.closed {
-		s.peersMu.Unlock()
-		return errors.New("service already closed")
+	if err := s.registerStart(); err != nil {
+		return err
 	}
-	if s.listener != nil {
-		s.peersMu.Unlock()
-		return errors.New("service already started")
-	}
-	s.startWG.Add(1)
-	s.peersMu.Unlock()
 	defer s.startWG.Done()
 
 	listener, err := net.Listen("tcp", s.cfg.BindAddr)
@@ -110,14 +93,29 @@ func (s *Service) Start(ctx context.Context) error {
 		hook(s, listener)
 	}
 
-	// Authoritative transition. Re-check closed/started under the write
-	// lock so that a concurrent Close that ran while net.Listen was still
-	// executing is linearized ahead of the listener publish: if Close won
-	// the race, drop the freshly created listener and surface the same
-	// dormant error as the fast path. loopWG.Add runs under the lock and
-	// BEFORE the goroutines are spawned so a concurrent Close's
-	// loopWG.Wait sees the counter even if scheduling delays acceptLoop
-	// or reconnectLoop past the unlock.
+	if err := s.publishListener(ctx, listener); err != nil {
+		return err
+	}
+	s.startOutboundPeers()
+	return nil
+}
+
+func (s *Service) registerStart() error {
+	// Register this Start invocation with startWG atomically with the
+	// dormant/started check, under the same peersMu that guards closed.
+	s.peersMu.Lock()
+	defer s.peersMu.Unlock()
+	if s.closed {
+		return errors.New("service already closed")
+	}
+	if s.listener != nil {
+		return errors.New("service already started")
+	}
+	s.startWG.Add(1)
+	return nil
+}
+
+func (s *Service) publishListener(ctx context.Context, listener net.Listener) error {
 	newCtx, cancel := context.WithCancel(ctx)
 	s.peersMu.Lock()
 	if s.closed {
@@ -141,6 +139,10 @@ func (s *Service) Start(ctx context.Context) error {
 
 	go s.acceptLoop()
 	go s.reconnectLoop(s.ctx)
+	return nil
+}
+
+func (s *Service) startOutboundPeers() {
 	for _, peerAddr := range s.outboundAddrs {
 		peerAddr = strings.TrimSpace(peerAddr)
 		if peerAddr == "" {
@@ -148,7 +150,6 @@ func (s *Service) Start(ctx context.Context) error {
 		}
 		s.startDialPeer(peerAddr)
 	}
-	return nil
 }
 
 // Close cancels the service context, closes the listener, tears down every


### PR DESCRIPTION
Invariant:
Reduce Codacy Go CCN rows in low-risk P2P service control-flow helpers without changing P2P service behavior.

Layer:
implementation / tests

Files changed:
- clients/go/node/p2p/peer_runtime.go
- clients/go/node/p2p/service.go
- clients/go/node/p2p/service_listener.go

Tests:
- git diff --check origin/main...HEAD — PASS
- python3 -m lizard clients/go/node/p2p/peer_runtime.go clients/go/node/p2p/service.go clients/go/node/p2p/service_listener.go — PASS, no warnings
- gocyclo -over 8 clients/go/node/p2p/peer_runtime.go clients/go/node/p2p/service.go clients/go/node/p2p/service_listener.go — PASS
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -v ./node/p2p -run "Test(HandleMessageRejectsInvalidKinds|RunUnknownCommandDisconnectWithoutBan|Coverage_HandshakeHelpers|Coverage_AnnounceTxAndHandleTxBranches|AnnounceTx|AnnounceTxRelaysIntoCanonicalMempoolAndMiner|AnnounceTxAdmissionRejectDoesNotMarkSeen|NewService|Coverage_NewServiceAndListenerGuards|Service_Start|Service_Close|AutoReconnect|Reconnect)" -count=1' — PASS
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -v ./node/p2p -count=1' — PASS
- /Users/gpt/bin/rubin-push --repo /Users/gpt/Documents/rubin-protocol-codex-RUB-252C-service --base-ref origin/main --coverage-cmd "scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node/p2p -coverprofile=/tmp/rub252c-service.cover'" -- origin HEAD — PASS, package coverage 93.7%

Behavior impact:
No intended behavior change. This PR extracts existing P2P service control-flow into focused helpers and preserves existing tests around message routing, service config/defaults, AnnounceTx, Start/Close lifecycle, reconnect, and full node/p2p package behavior.

Non-goals:
- No wire encoding/decoding changes.
- No parser/framing changes.
- No consensus, policy, fixture, Rust, or conformance changes.
