### PR TITLE
RUB-252E reduce Go consensus CLI test CCN

### DIFF
--- a/clients/go/cmd/rubin-consensus-cli/runtime_test.go
+++ b/clients/go/cmd/rubin-consensus-cli/runtime_test.go
@@ -236,7 +236,17 @@ func mustRunErrAny(t *testing.T, req Request) Response {
 	return resp
 }
 
-func TestRubinConsensusCLI_RunFromStdin_CoversKeyOps(t *testing.T) {
+type runtimeKeyOpsFixture struct {
+	blockBytes  []byte
+	headerBytes []byte
+	chainIDHex  string
+	txHex       string
+	targetHex   string
+}
+
+func newRuntimeKeyOpsFixture(t *testing.T) runtimeKeyOpsFixture {
+	t.Helper()
+
 	blockBytes, headerBytes := mineGenesisBlockBytes(t)
 
 	var chainID [32]byte
@@ -248,247 +258,246 @@ func TestRubinConsensusCLI_RunFromStdin_CoversKeyOps(t *testing.T) {
 
 	targetHex := mustHex32(consensus.POW_LIMIT)
 
-	t.Run("bad_request", func(t *testing.T) {
-		resp := runRawJSON(t, []byte("{"), runFromStdin)
-		if resp.Ok || resp.Err == "" {
-			t.Fatalf("expected error")
-		}
-	})
+	return runtimeKeyOpsFixture{
+		blockBytes:  blockBytes,
+		headerBytes: headerBytes,
+		chainIDHex:  chainIDHex,
+		txHex:       txHex,
+		targetHex:   targetHex,
+	}
+}
 
+func TestRubinConsensusCLI_RunFromStdin_CoversKeyOps(t *testing.T) {
+	fixture := newRuntimeKeyOpsFixture(t)
+
+	t.Run("bad_request", testRuntimeKeyOpBadRequest)
 	t.Run("parse_tx_ok_and_error", func(t *testing.T) {
-		ok := mustRunOk(t, Request{Op: "parse_tx", TxHex: txHex})
-		if ok.TxidHex == "" || ok.WtxidHex == "" || ok.Consumed == 0 {
-			t.Fatalf("unexpected ok resp: %+v", ok)
-		}
-
-		_ = mustRunErrAny(t, Request{Op: "parse_tx", TxHex: "00"})
+		testRuntimeKeyOpParseTx(t, fixture)
 	})
-
 	t.Run("fork_work_and_choice", func(t *testing.T) {
-		r := mustRunOk(t, Request{Op: "fork_work", Target: "0x01"})
-		if r.WorkHex == "" {
-			t.Fatalf("unexpected resp: %+v", r)
-		}
-
-		sel := mustRunOk(t, Request{
-			Op: "fork_choice_select",
-			Chains: []ForkChoiceChain{
-				{ID: "a", Targets: []string{"0x02"}, TipHash: "0x02"},
-				{ID: "b", Targets: []string{"0x02"}, TipHash: "0x01"}, // tie-break by smaller tip hash
-			},
-		})
-		if sel.Winner != "b" || sel.Chainwork == "" {
-			t.Fatalf("unexpected resp: %+v", sel)
-		}
+		testRuntimeKeyOpForkWorkAndChoice(t)
 	})
-
-	// merkle_root / witness_merkle_root
 	t.Run("merkle_roots", func(t *testing.T) {
-		var a, b [32]byte
-		a[31] = 1
-		b[31] = 2
-		r1 := mustRunOk(t, Request{Op: "merkle_root", Txids: []string{mustHex32(a), mustHex32(b)}})
-		if r1.MerkleHex == "" {
-			t.Fatalf("unexpected resp: %+v", r1)
-		}
-		r2 := mustRunOk(t, Request{Op: "witness_merkle_root", Wtxids: []string{mustHex32(a), mustHex32(b)}})
-		if r2.WitnessMerkleHex == "" {
-			t.Fatalf("unexpected resp: %+v", r2)
-		}
+		testRuntimeKeyOpMerkleRoots(t)
 	})
-
-	// sighash_v1 / tx_weight_and_stats
 	t.Run("sighash_and_weight", func(t *testing.T) {
-		r1 := mustRunOk(t, Request{
-			Op:         "sighash_v1",
-			TxHex:      txHex,
-			InputIndex: 0,
-			InputValue: 0,
-			ChainIDHex: chainIDHex,
-		})
-		if len(r1.DigestHex) != 64 {
-			t.Fatalf("unexpected resp: %+v", r1)
-		}
-
-		_ = mustRunOk(t, Request{Op: "tx_weight_and_stats", TxHex: txHex})
+		testRuntimeKeyOpSighashAndWeight(t, fixture)
 	})
-
-	// header hash / pow check
 	t.Run("block_hash_and_pow_check", func(t *testing.T) {
-		r1 := mustRunOk(t, Request{Op: "block_hash", HeaderHex: mustHexBytes(headerBytes)})
-		if len(r1.BlockHash) != 64 {
-			t.Fatalf("unexpected resp: %+v", r1)
-		}
-		_ = mustRunOk(t, Request{
-			Op:        "pow_check",
-			HeaderHex: mustHexBytes(headerBytes),
-			TargetHex: targetHex,
-		})
+		testRuntimeKeyOpBlockHashAndPowCheck(t, fixture)
 	})
-
 	t.Run("retarget_v1_both_forms", func(t *testing.T) {
-		r1 := runRequest(t, Request{
-			Op:             "retarget_v1",
-			TargetOldHex:   targetHex,
-			TimestampFirst: 100,
-			TimestampLast:  200,
-		})
-		if !r1.Ok || len(r1.TargetNew) != 64 {
-			t.Fatalf("unexpected resp: %+v", r1)
-		}
-		r2 := runRequest(t, Request{
-			Op:               "retarget_v1",
-			TargetOldHex:     targetHex,
-			WindowTimestamps: []uint64{1}, // wrong count -> fast error path, but covers the clamped branch
-		})
-		if r2.Ok || r2.Err != string(consensus.TX_ERR_PARSE) {
-			t.Fatalf("expected TX_ERR_PARSE: %+v", r2)
-		}
+		testRuntimeKeyOpRetargetV1BothForms(t, fixture)
 	})
-
-	// block basic / fees / connect
 	t.Run("block_validation_and_connect", func(t *testing.T) {
-		blockHex := mustHexBytes(blockBytes)
-
-		r1 := runRequest(t, Request{Op: "block_basic_check", BlockHex: blockHex, Height: 0})
-		if !r1.Ok || len(r1.BlockHash) != 64 {
-			t.Fatalf("unexpected resp: %+v", r1)
-		}
-		r2 := runRequest(t, Request{Op: "block_basic_check_with_fees", BlockHex: blockHex, Height: 0, AlreadyGenerated: 0, SumFees: 0})
-		if !r2.Ok || len(r2.BlockHash) != 64 {
-			t.Fatalf("unexpected resp: %+v", r2)
-		}
-		r3 := runRequest(t, Request{Op: "connect_block_basic", BlockHex: blockHex, Height: 0, AlreadyGenerated: 0, SumFees: 0, ChainIDHex: ""})
-		if !r3.Ok {
-			t.Fatalf("unexpected resp: %+v", r3)
-		}
+		testRuntimeKeyOpBlockValidationAndConnect(t, fixture)
 	})
-
-	// compact blocks / telemetry / policy helpers (pure ops)
 	t.Run("compact_and_policy_ops", func(t *testing.T) {
-		var wtxid [32]byte
-		wtxid[0] = 1
-		_ = runRequest(t, Request{Op: "compact_shortid", WtxidHex: mustHex32(wtxid), Nonce1: 1, Nonce2: 2})
-		_ = runRequest(t, Request{Op: "compact_collision_fallback", MissingIndices: []int{2, 1}, GetblocktxnOK: ptrBool(true)})
-		_ = runRequest(t, Request{Op: "compact_witness_roundtrip", PubkeyLength: 3, SigLength: 5})
-		_ = runRequest(t, Request{Op: "compact_batch_verify", BatchSize: 4, InvalidIndices: nil})
-		_ = runRequest(t, Request{
-			Op:               "compact_prefill_roundtrip",
-			TxCount:          5,
-			PrefilledIndices: []int{0},
-			MempoolIndices:   []int{1, 2},
-			BlocktxnIndices:  []int{3, 4},
-		})
-		_ = runRequest(t, Request{
-			Op:                "compact_state_machine",
-			ChunkCount:        2,
-			InitialChunks:     []int{0},
-			InitialCommitSeen: ptrBool(false),
-			Events: []any{
-				map[string]any{"type": "commit"},
-				map[string]any{"type": "chunk", "index": 1},
-				map[string]any{"type": "checkblock"},
-				map[string]any{"type": "tick", "blocks": 1},
-			},
-		})
-		_ = runRequest(t, Request{Op: "compact_orphan_limits", CurrentPeerBytes: 1, CurrentDaIDBytes: 2, CurrentGlobalBytes: 3, IncomingChunkBytes: 4})
-		_ = runRequest(t, Request{
-			Op:                  "compact_orphan_storm",
-			GlobalLimit:         100,
-			CurrentGlobalBytes:  95,
-			IncomingChunkBytes:  10,
-			IncomingHasCommit:   ptrBool(false),
-			StormTriggerPct:     90,
-			RecoverySuccessRate: 90,
-			ObservationMinutes:  10,
-		})
-		_ = runRequest(t, Request{Op: "compact_chunk_count_cap", ChunkCount: 1, MaxDAChunkCount: 2})
-		_ = runRequest(t, Request{Op: "compact_sendcmpct_modes", InIBD: ptrBool(true)})
-		_ = runRequest(t, Request{Op: "compact_peer_quality", Events: []any{"getblocktxn_required"}, ElapsedBlocks: 0})
-		_ = runRequest(t, Request{Op: "compact_prefetch_caps", PeerStreamsBPS: []int{5_000_000, 10}, PerPeerBPS: 4_000_000, GlobalBPS: 4_000_001})
-
-		rRate := runRequest(t, Request{Op: "compact_telemetry_rate", CompletedSets: 1, TotalSets: 2})
-		if !rRate.Ok {
-			t.Fatalf("unexpected resp: %+v", rRate)
-		}
-
-		rFields := runRequest(t, Request{Op: "compact_telemetry_fields", Telemetry: map[string]any{}})
-		if rFields.Ok || rFields.Err == "" {
-			t.Fatalf("expected missing telemetry fields error: %+v", rFields)
-		}
-
-		_ = runRequest(t, Request{Op: "compact_grace_period", ElapsedBlocks: 0, Events: []any{"prefetch_completed"}})
-		_ = runRequest(t, Request{
-			Op:      "compact_eviction_tiebreak",
-			Entries: []map[string]any{{"da_id": "b", "fee": 100, "wire_bytes": 10, "received_time": 2}, {"da_id": "a", "fee": 50, "wire_bytes": 10, "received_time": 1}},
-		})
-		_ = runRequest(t, Request{Op: "compact_a_to_b_retention", ChunkCount: 3, InitialChunks: []int{0}, CommitArrives: ptrBool(true)})
-		_ = runRequest(t, Request{
-			Op:      "compact_duplicate_commit",
-			Commits: []map[string]any{{"da_id": "x", "peer": "p1"}, {"da_id": "x", "peer": "p2"}},
-		})
-		_ = runRequest(t, Request{Op: "compact_total_fee", CommitFee: 1, ChunkFees: []int{2, 3}})
-		_ = runRequest(t, Request{Op: "compact_pinned_accounting", CapBytes: 10, CurrentPinnedBytes: 9, IncomingPayload: 2})
-		_ = runRequest(t, Request{Op: "compact_storm_commit_bearing", OrphanPoolFillPct: 95, StormTriggerPct: 90, ContainsCommit: ptrBool(true)})
+		testRuntimeKeyOpCompactAndPolicyOps(t)
 	})
-
 	t.Run("descriptor_nonce_timestamp_and_orders", func(t *testing.T) {
-		r1 := runRequest(t, Request{Op: "output_descriptor_bytes", CovenantType: consensus.COV_TYPE_ANCHOR, CovenantDataHex: mustHexBytes(bytes.Repeat([]byte{0x11}, 32))})
-		if !r1.Ok || r1.DescriptorHex == "" {
-			t.Fatalf("unexpected resp: %+v", r1)
-		}
-		r2 := runRequest(t, Request{Op: "output_descriptor_hash", CovenantType: consensus.COV_TYPE_ANCHOR, CovenantDataHex: mustHexBytes(bytes.Repeat([]byte{0x11}, 32))})
-		if !r2.Ok || len(r2.DigestHex) != 64 {
-			t.Fatalf("unexpected resp: %+v", r2)
-		}
-
-		dup := runRequest(t, Request{Op: "nonce_replay_intrablock", Nonces: []uint64{1, 2, 1}})
-		if dup.Ok || dup.Err == "" || len(dup.Duplicates) == 0 {
-			t.Fatalf("expected replay error: %+v", dup)
-		}
-
-		ts := runRequest(t, Request{Op: "timestamp_bounds", MTP: 100, Timestamp: 101})
-		if !ts.Ok {
-			t.Fatalf("unexpected resp: %+v", ts)
-		}
-
-		order := runRequest(t, Request{Op: "determinism_order", Keys: []any{"0x02", "0x01", "a"}})
-		if !order.Ok || len(order.SortedKeys) == 0 {
-			t.Fatalf("unexpected resp: %+v", order)
-		}
-
-		v := runRequest(t, Request{Op: "validation_order", Checks: []Check{{Name: "a", Fails: false}, {Name: "b", Fails: true, Err: "E"}}})
-		if v.Ok || v.Err != "E" || v.FirstErr != "E" || len(v.Evaluated) != 2 {
-			t.Fatalf("unexpected resp: %+v", v)
-		}
+		testRuntimeKeyOpDescriptorNonceTimestampAndOrders(t)
 	})
-
 	t.Run("htlc_and_vault_policy_ops", func(t *testing.T) {
-		r1 := runRequest(t, Request{Op: "htlc_ordering_policy", Path: "refund", LocktimeOK: ptrBool(false)})
-		if r1.Ok || r1.Err == "" {
-			t.Fatalf("expected refund locktime error: %+v", r1)
-		}
-
-		r2 := runRequest(t, Request{Op: "htlc_ordering_policy", Path: "claim", VerifyOK: ptrBool(false)})
-		if r2.Ok || r2.Err != string(consensus.TX_ERR_SIG_INVALID) || !r2.VerifyCalled {
-			t.Fatalf("unexpected resp: %+v", r2)
-		}
-
-		r3 := runRequest(t, Request{
-			Op:              "vault_policy_rules",
-			OwnerLockID:     "o",
-			VaultInputCount: 1,
-			NonVaultLockIDs: []string{"o"},
-			SumOut:          10,
-			SumInVault:      10,
-			Slots:           1,
-			KeyCount:        1,
-			Whitelist:       []string{"aa"},
-		})
-		if !r3.Ok {
-			t.Fatalf("unexpected resp: %+v", r3)
-		}
+		testRuntimeKeyOpHTLCAndVaultPolicyOps(t)
 	})
+}
+
+func testRuntimeKeyOpBadRequest(t *testing.T) {
+	t.Helper()
+	resp := runRawJSON(t, []byte("{"), runFromStdin)
+	if resp.Ok || resp.Err == "" {
+		t.Fatalf("expected error")
+	}
+}
+
+func testRuntimeKeyOpParseTx(t *testing.T, fixture runtimeKeyOpsFixture) {
+	t.Helper()
+	ok := mustRunOk(t, Request{Op: "parse_tx", TxHex: fixture.txHex})
+	if ok.TxidHex == "" || ok.WtxidHex == "" || ok.Consumed == 0 {
+		t.Fatalf("unexpected ok resp: %+v", ok)
+	}
+	_ = mustRunErrAny(t, Request{Op: "parse_tx", TxHex: "00"})
+}
+
+func testRuntimeKeyOpForkWorkAndChoice(t *testing.T) {
+	t.Helper()
+	r := mustRunOk(t, Request{Op: "fork_work", Target: "0x01"})
+	if r.WorkHex == "" {
+		t.Fatalf("unexpected resp: %+v", r)
+	}
+	sel := mustRunOk(t, Request{
+		Op: "fork_choice_select",
+		Chains: []ForkChoiceChain{
+			{ID: "a", Targets: []string{"0x02"}, TipHash: "0x02"},
+			{ID: "b", Targets: []string{"0x02"}, TipHash: "0x01"},
+		},
+	})
+	if sel.Winner != "b" || sel.Chainwork == "" {
+		t.Fatalf("unexpected resp: %+v", sel)
+	}
+}
+
+func testRuntimeKeyOpMerkleRoots(t *testing.T) {
+	t.Helper()
+	var a, b [32]byte
+	a[31] = 1
+	b[31] = 2
+	r1 := mustRunOk(t, Request{Op: "merkle_root", Txids: []string{mustHex32(a), mustHex32(b)}})
+	if r1.MerkleHex == "" {
+		t.Fatalf("unexpected resp: %+v", r1)
+	}
+	r2 := mustRunOk(t, Request{Op: "witness_merkle_root", Wtxids: []string{mustHex32(a), mustHex32(b)}})
+	if r2.WitnessMerkleHex == "" {
+		t.Fatalf("unexpected resp: %+v", r2)
+	}
+}
+
+func testRuntimeKeyOpSighashAndWeight(t *testing.T, fixture runtimeKeyOpsFixture) {
+	t.Helper()
+	r1 := mustRunOk(t, Request{
+		Op:         "sighash_v1",
+		TxHex:      fixture.txHex,
+		InputIndex: 0,
+		InputValue: 0,
+		ChainIDHex: fixture.chainIDHex,
+	})
+	if len(r1.DigestHex) != 64 {
+		t.Fatalf("unexpected resp: %+v", r1)
+	}
+	_ = mustRunOk(t, Request{Op: "tx_weight_and_stats", TxHex: fixture.txHex})
+}
+
+func testRuntimeKeyOpBlockHashAndPowCheck(t *testing.T, fixture runtimeKeyOpsFixture) {
+	t.Helper()
+	headerHex := mustHexBytes(fixture.headerBytes)
+	r1 := mustRunOk(t, Request{Op: "block_hash", HeaderHex: headerHex})
+	if len(r1.BlockHash) != 64 {
+		t.Fatalf("unexpected resp: %+v", r1)
+	}
+	_ = mustRunOk(t, Request{Op: "pow_check", HeaderHex: headerHex, TargetHex: fixture.targetHex})
+}
+
+func testRuntimeKeyOpRetargetV1BothForms(t *testing.T, fixture runtimeKeyOpsFixture) {
+	t.Helper()
+	r1 := runRequest(t, Request{Op: "retarget_v1", TargetOldHex: fixture.targetHex, TimestampFirst: 100, TimestampLast: 200})
+	if !r1.Ok || len(r1.TargetNew) != 64 {
+		t.Fatalf("unexpected resp: %+v", r1)
+	}
+	r2 := runRequest(t, Request{Op: "retarget_v1", TargetOldHex: fixture.targetHex, WindowTimestamps: []uint64{1}})
+	if r2.Ok || r2.Err != string(consensus.TX_ERR_PARSE) {
+		t.Fatalf("expected TX_ERR_PARSE: %+v", r2)
+	}
+}
+
+func testRuntimeKeyOpBlockValidationAndConnect(t *testing.T, fixture runtimeKeyOpsFixture) {
+	t.Helper()
+	blockHex := mustHexBytes(fixture.blockBytes)
+	r1 := runRequest(t, Request{Op: "block_basic_check", BlockHex: blockHex, Height: 0})
+	if !r1.Ok || len(r1.BlockHash) != 64 {
+		t.Fatalf("unexpected resp: %+v", r1)
+	}
+	r2 := runRequest(t, Request{Op: "block_basic_check_with_fees", BlockHex: blockHex, Height: 0, AlreadyGenerated: 0, SumFees: 0})
+	if !r2.Ok || len(r2.BlockHash) != 64 {
+		t.Fatalf("unexpected resp: %+v", r2)
+	}
+	r3 := runRequest(t, Request{Op: "connect_block_basic", BlockHex: blockHex, Height: 0, AlreadyGenerated: 0, SumFees: 0, ChainIDHex: ""})
+	if !r3.Ok {
+		t.Fatalf("unexpected resp: %+v", r3)
+	}
+}
+
+func testRuntimeKeyOpCompactAndPolicyOps(t *testing.T) {
+	t.Helper()
+	var wtxid [32]byte
+	wtxid[0] = 1
+	_ = runRequest(t, Request{Op: "compact_shortid", WtxidHex: mustHex32(wtxid), Nonce1: 1, Nonce2: 2})
+	_ = runRequest(t, Request{Op: "compact_collision_fallback", MissingIndices: []int{2, 1}, GetblocktxnOK: ptrBool(true)})
+	_ = runRequest(t, Request{Op: "compact_witness_roundtrip", PubkeyLength: 3, SigLength: 5})
+	_ = runRequest(t, Request{Op: "compact_batch_verify", BatchSize: 4, InvalidIndices: nil})
+	_ = runRequest(t, Request{Op: "compact_prefill_roundtrip", TxCount: 5, PrefilledIndices: []int{0}, MempoolIndices: []int{1, 2}, BlocktxnIndices: []int{3, 4}})
+	_ = runRequest(t, Request{
+		Op:                "compact_state_machine",
+		ChunkCount:        2,
+		InitialChunks:     []int{0},
+		InitialCommitSeen: ptrBool(false),
+		Events:            []any{map[string]any{"type": "commit"}, map[string]any{"type": "chunk", "index": 1}, map[string]any{"type": "checkblock"}, map[string]any{"type": "tick", "blocks": 1}},
+	})
+	_ = runRequest(t, Request{Op: "compact_orphan_limits", CurrentPeerBytes: 1, CurrentDaIDBytes: 2, CurrentGlobalBytes: 3, IncomingChunkBytes: 4})
+	_ = runRequest(t, Request{Op: "compact_orphan_storm", GlobalLimit: 100, CurrentGlobalBytes: 95, IncomingChunkBytes: 10, IncomingHasCommit: ptrBool(false), StormTriggerPct: 90, RecoverySuccessRate: 90, ObservationMinutes: 10})
+	_ = runRequest(t, Request{Op: "compact_chunk_count_cap", ChunkCount: 1, MaxDAChunkCount: 2})
+	_ = runRequest(t, Request{Op: "compact_sendcmpct_modes", InIBD: ptrBool(true)})
+	_ = runRequest(t, Request{Op: "compact_peer_quality", Events: []any{"getblocktxn_required"}, ElapsedBlocks: 0})
+	_ = runRequest(t, Request{Op: "compact_prefetch_caps", PeerStreamsBPS: []int{5_000_000, 10}, PerPeerBPS: 4_000_000, GlobalBPS: 4_000_001})
+	assertRuntimeKeyOpCompactTelemetry(t)
+	_ = runRequest(t, Request{Op: "compact_grace_period", ElapsedBlocks: 0, Events: []any{"prefetch_completed"}})
+	_ = runRequest(t, Request{Op: "compact_eviction_tiebreak", Entries: []map[string]any{{"da_id": "b", "fee": 100, "wire_bytes": 10, "received_time": 2}, {"da_id": "a", "fee": 50, "wire_bytes": 10, "received_time": 1}}})
+	_ = runRequest(t, Request{Op: "compact_a_to_b_retention", ChunkCount: 3, InitialChunks: []int{0}, CommitArrives: ptrBool(true)})
+	_ = runRequest(t, Request{Op: "compact_duplicate_commit", Commits: []map[string]any{{"da_id": "x", "peer": "p1"}, {"da_id": "x", "peer": "p2"}}})
+	_ = runRequest(t, Request{Op: "compact_total_fee", CommitFee: 1, ChunkFees: []int{2, 3}})
+	_ = runRequest(t, Request{Op: "compact_pinned_accounting", CapBytes: 10, CurrentPinnedBytes: 9, IncomingPayload: 2})
+	_ = runRequest(t, Request{Op: "compact_storm_commit_bearing", OrphanPoolFillPct: 95, StormTriggerPct: 90, ContainsCommit: ptrBool(true)})
+}
+
+func assertRuntimeKeyOpCompactTelemetry(t *testing.T) {
+	t.Helper()
+	rRate := runRequest(t, Request{Op: "compact_telemetry_rate", CompletedSets: 1, TotalSets: 2})
+	if !rRate.Ok {
+		t.Fatalf("unexpected resp: %+v", rRate)
+	}
+	rFields := runRequest(t, Request{Op: "compact_telemetry_fields", Telemetry: map[string]any{}})
+	if rFields.Ok || rFields.Err == "" {
+		t.Fatalf("expected missing telemetry fields error: %+v", rFields)
+	}
+}
+
+func testRuntimeKeyOpDescriptorNonceTimestampAndOrders(t *testing.T) {
+	t.Helper()
+	r1 := runRequest(t, Request{Op: "output_descriptor_bytes", CovenantType: consensus.COV_TYPE_ANCHOR, CovenantDataHex: mustHexBytes(bytes.Repeat([]byte{0x11}, 32))})
+	if !r1.Ok || r1.DescriptorHex == "" {
+		t.Fatalf("unexpected resp: %+v", r1)
+	}
+	r2 := runRequest(t, Request{Op: "output_descriptor_hash", CovenantType: consensus.COV_TYPE_ANCHOR, CovenantDataHex: mustHexBytes(bytes.Repeat([]byte{0x11}, 32))})
+	if !r2.Ok || len(r2.DigestHex) != 64 {
+		t.Fatalf("unexpected resp: %+v", r2)
+	}
+	dup := runRequest(t, Request{Op: "nonce_replay_intrablock", Nonces: []uint64{1, 2, 1}})
+	if dup.Ok || dup.Err == "" || len(dup.Duplicates) == 0 {
+		t.Fatalf("expected replay error: %+v", dup)
+	}
+	assertRuntimeKeyOpOrdering(t)
+}
+
+func assertRuntimeKeyOpOrdering(t *testing.T) {
+	t.Helper()
+	ts := runRequest(t, Request{Op: "timestamp_bounds", MTP: 100, Timestamp: 101})
+	if !ts.Ok {
+		t.Fatalf("unexpected resp: %+v", ts)
+	}
+	order := runRequest(t, Request{Op: "determinism_order", Keys: []any{"0x02", "0x01", "a"}})
+	if !order.Ok || len(order.SortedKeys) == 0 {
+		t.Fatalf("unexpected resp: %+v", order)
+	}
+	v := runRequest(t, Request{Op: "validation_order", Checks: []Check{{Name: "a", Fails: false}, {Name: "b", Fails: true, Err: "E"}}})
+	if v.Ok || v.Err != "E" || v.FirstErr != "E" || len(v.Evaluated) != 2 {
+		t.Fatalf("unexpected resp: %+v", v)
+	}
+}
+
+func testRuntimeKeyOpHTLCAndVaultPolicyOps(t *testing.T) {
+	t.Helper()
+	r1 := runRequest(t, Request{Op: "htlc_ordering_policy", Path: "refund", LocktimeOK: ptrBool(false)})
+	if r1.Ok || r1.Err == "" {
+		t.Fatalf("expected refund locktime error: %+v", r1)
+	}
+	r2 := runRequest(t, Request{Op: "htlc_ordering_policy", Path: "claim", VerifyOK: ptrBool(false)})
+	if r2.Ok || r2.Err != string(consensus.TX_ERR_SIG_INVALID) || !r2.VerifyCalled {
+		t.Fatalf("unexpected resp: %+v", r2)
+	}
+	r3 := runRequest(t, Request{Op: "vault_policy_rules", OwnerLockID: "o", VaultInputCount: 1, NonVaultLockIDs: []string{"o"}, SumOut: 10, SumInVault: 10, Slots: 1, KeyCount: 1, Whitelist: []string{"aa"}})
+	if !r3.Ok {
+		t.Fatalf("unexpected resp: %+v", r3)
+	}
 }
 
 func ptrBool(v bool) *bool { return &v }
@@ -741,181 +750,233 @@ func TestMainCallsRunFromStdin(t *testing.T) {
 }
 
 func TestRubinConsensusCLI_RuntimeHelpers(t *testing.T) {
-	t.Run("parseHexU256To32", func(t *testing.T) {
-		if _, err := parseHexU256To32(""); err == nil {
-			t.Fatalf("expected error")
-		}
-		v, err := parseHexU256To32("0x1")
-		if err != nil || v[31] != 0x01 {
-			t.Fatalf("unexpected: v=%x err=%v", v, err)
-		}
-		if _, err := parseHexU256To32("0x" + strings.Repeat("11", 33)); err == nil {
-			t.Fatalf("expected overflow error")
-		}
-	})
+	t.Run("parseHexU256To32", testRuntimeHelperParseHexU256To32)
+	t.Run("parseExactHex32_and_optionals", testRuntimeHelperParseExactHex32AndOptionals)
+	t.Run("parseBlockValidationInputs", testRuntimeHelperParseBlockValidationInputs)
+	t.Run("buildUtxoMap_errors", testRuntimeHelperBuildUtxoMapErrors)
+	t.Run("parseKeyBytes", testRuntimeHelperParseKeyBytes)
+	t.Run("default_and_cast_helpers", testRuntimeHelperDefaultAndCastHelpers)
+	t.Run("writeConsensusErr_non_txerror", testRuntimeHelperWriteConsensusErrNonTxError)
+	t.Run("compactsize_helpers", testRuntimeHelperCompactSize)
+	t.Run("slice_and_int_helpers", testRuntimeHelperSliceAndIntHelpers)
+}
 
-	t.Run("parseExactHex32_and_optionals", func(t *testing.T) {
-		if _, err := parseExactHex32("00"); err == nil {
-			t.Fatalf("expected error")
-		}
-		if _, err := parseExactHex32("zz"); err == nil {
-			t.Fatalf("expected error")
-		}
-		okHex := hex.EncodeToString(make([]byte, 32))
-		v, err := parseExactHex32(okHex)
-		if err != nil || v != ([32]byte{}) {
-			t.Fatalf("unexpected: v=%x err=%v", v, err)
-		}
-		if opt, err := parseOptionalHex32("", "bad"); err != nil || opt != nil {
-			t.Fatalf("unexpected: opt=%v err=%v", opt, err)
-		}
-		if opt, err := parseOptionalHex32("zz", "bad expected"); err == nil || opt != nil {
-			t.Fatalf("expected error")
-		}
-		if opt, err := parseOptionalHex32(okHex, "bad expected"); err != nil || opt == nil || *opt != ([32]byte{}) {
-			t.Fatalf("unexpected optional success: opt=%v err=%v", opt, err)
-		}
-		chainID, err := parseOptionalChainIDHex("")
-		if err != nil || chainID != ([32]byte{}) {
-			t.Fatalf("unexpected: %x err=%v", chainID, err)
-		}
-		if _, err := parseOptionalChainIDHex("00"); err == nil {
-			t.Fatalf("expected bad chain_id error")
-		}
-		if chainID, err := parseOptionalChainIDHex(okHex); err != nil || chainID != ([32]byte{}) {
-			t.Fatalf("unexpected chain_id success: %x err=%v", chainID, err)
-		}
-	})
+func testRuntimeHelperParseHexU256To32(t *testing.T) {
+	t.Helper()
+	if _, err := parseHexU256To32(""); err == nil {
+		t.Fatalf("expected error")
+	}
+	v, err := parseHexU256To32("0x1")
+	if err != nil || v[31] != 0x01 {
+		t.Fatalf("unexpected: v=%x err=%v", v, err)
+	}
+	if _, err := parseHexU256To32("0x" + strings.Repeat("11", 33)); err == nil {
+		t.Fatalf("expected overflow error")
+	}
+}
 
-	t.Run("parseBlockValidationInputs", func(t *testing.T) {
-		blockBytes, _ := mineGenesisBlockBytes(t)
-		req := Request{
-			BlockHex:       hex.EncodeToString(blockBytes),
-			ExpectedPrev:   hex.EncodeToString(make([]byte, 32)),
-			ExpectedTarget: hex.EncodeToString(make([]byte, 32)),
-		}
-		raw, expectedPrev, expectedTarget, err := parseBlockValidationInputs(req)
-		if err != nil || len(raw) == 0 || expectedPrev == nil || expectedTarget == nil {
-			t.Fatalf("unexpected success parse: len=%d prev=%v target=%v err=%v", len(raw), expectedPrev, expectedTarget, err)
-		}
-		if _, _, _, err := parseBlockValidationInputs(Request{BlockHex: "zz"}); err == nil {
-			t.Fatalf("expected bad block error")
-		}
-		if _, _, _, err := parseBlockValidationInputs(Request{BlockHex: hex.EncodeToString(blockBytes), ExpectedTarget: "zz"}); err == nil {
-			t.Fatalf("expected bad expected_target error")
-		}
-	})
+func testRuntimeHelperParseExactHex32AndOptionals(t *testing.T) {
+	t.Helper()
+	okHex := hex.EncodeToString(make([]byte, 32))
+	assertParseExactHex32Cases(t, okHex)
+	assertParseOptionalHex32Cases(t, okHex)
+	assertParseOptionalChainIDHexCases(t, okHex)
+}
 
-	t.Run("buildUtxoMap_errors", func(t *testing.T) {
-		if _, err := buildUtxoMap([]UtxoJSON{{Txid: "00", CovenantDataHex: ""}}); err == nil {
-			t.Fatalf("expected bad utxo txid")
-		}
-		if _, err := buildUtxoMap([]UtxoJSON{{Txid: hex.EncodeToString(make([]byte, 32)), CovenantDataHex: "zz"}}); err == nil {
-			t.Fatalf("expected bad utxo covenant_data")
-		}
-	})
+func assertParseExactHex32Cases(t *testing.T, okHex string) {
+	t.Helper()
+	if _, err := parseExactHex32("00"); err == nil {
+		t.Fatalf("expected error")
+	}
+	if _, err := parseExactHex32("zz"); err == nil {
+		t.Fatalf("expected error")
+	}
+	v, err := parseExactHex32(okHex)
+	if err != nil || v != ([32]byte{}) {
+		t.Fatalf("unexpected: v=%x err=%v", v, err)
+	}
+}
 
-	t.Run("parseKeyBytes", func(t *testing.T) {
-		if b, err := parseKeyBytes("0x1"); err != nil || len(b) != 1 || b[0] != 0x01 {
-			t.Fatalf("unexpected: %x err=%v", b, err)
-		}
-		if _, err := parseKeyBytes("0xzz"); err == nil {
-			t.Fatalf("expected error")
-		}
-		if b, err := parseKeyBytes("abc"); err != nil || string(b) != "abc" {
-			t.Fatalf("unexpected ascii parse: %x err=%v", b, err)
-		}
-		if b, err := parseKeyBytes(42); err != nil || string(b) != "42" {
-			t.Fatalf("unexpected generic parse: %x err=%v", b, err)
-		}
-	})
+func assertParseOptionalHex32Cases(t *testing.T, okHex string) {
+	t.Helper()
+	if opt, err := parseOptionalHex32("", "bad"); err != nil || opt != nil {
+		t.Fatalf("unexpected: opt=%v err=%v", opt, err)
+	}
+	if opt, err := parseOptionalHex32("zz", "bad expected"); err == nil || opt != nil {
+		t.Fatalf("expected error")
+	}
+	if opt, err := parseOptionalHex32(okHex, "bad expected"); err != nil || opt == nil || *opt != ([32]byte{}) {
+		t.Fatalf("unexpected optional success: opt=%v err=%v", opt, err)
+	}
+}
 
-	t.Run("default_and_cast_helpers", func(t *testing.T) {
-		if !boolOrDefault(nil, true) || boolOrDefault(ptrBool(false), true) {
-			t.Fatalf("boolOrDefault mismatch")
-		}
-		var u8 uint8 = 7
-		if uint8OrDefault(nil, 3) != 3 || uint8OrDefault(&u8, 3) != 7 {
-			t.Fatalf("uint8OrDefault mismatch")
-		}
-		var u64 uint64 = 11
-		if uint64OrDefault(nil, 5) != 5 || uint64OrDefault(&u64, 5) != 11 {
-			t.Fatalf("uint64OrDefault mismatch")
-		}
+func assertParseOptionalChainIDHexCases(t *testing.T, okHex string) {
+	t.Helper()
+	chainID, err := parseOptionalChainIDHex("")
+	if err != nil || chainID != ([32]byte{}) {
+		t.Fatalf("unexpected: %x err=%v", chainID, err)
+	}
+	if _, err := parseOptionalChainIDHex("00"); err == nil {
+		t.Fatalf("expected bad chain_id error")
+	}
+	if chainID, err := parseOptionalChainIDHex(okHex); err != nil || chainID != ([32]byte{}) {
+		t.Fatalf("unexpected chain_id success: %x err=%v", chainID, err)
+	}
+}
 
-		if toInt(float64(3), 9) != 3 || toInt(int64(4), 9) != 4 || toInt(uint64(5), 9) != 5 || toInt("x", 9) != 9 {
-			t.Fatalf("toInt mismatch")
-		}
-		if toInt(float64(3.5), 9) != 9 || toInt(uint64(platformMaxInt)+1, 9) != 9 {
-			t.Fatalf("toInt bounds mismatch")
-		}
-		if toString("ok", "bad") != "ok" || toString(123, "bad") != "bad" {
-			t.Fatalf("toString mismatch")
-		}
-		if !toBool(true, false) || toBool("x", false) {
-			t.Fatalf("toBool mismatch")
-		}
-	})
+func testRuntimeHelperParseBlockValidationInputs(t *testing.T) {
+	t.Helper()
+	blockBytes, _ := mineGenesisBlockBytes(t)
+	req := Request{
+		BlockHex:       hex.EncodeToString(blockBytes),
+		ExpectedPrev:   hex.EncodeToString(make([]byte, 32)),
+		ExpectedTarget: hex.EncodeToString(make([]byte, 32)),
+	}
+	raw, expectedPrev, expectedTarget, err := parseBlockValidationInputs(req)
+	if err != nil || len(raw) == 0 || expectedPrev == nil || expectedTarget == nil {
+		t.Fatalf("unexpected success parse: len=%d prev=%v target=%v err=%v", len(raw), expectedPrev, expectedTarget, err)
+	}
+	if _, _, _, err := parseBlockValidationInputs(Request{BlockHex: "zz"}); err == nil {
+		t.Fatalf("expected bad block error")
+	}
+	if _, _, _, err := parseBlockValidationInputs(Request{BlockHex: hex.EncodeToString(blockBytes), ExpectedTarget: "zz"}); err == nil {
+		t.Fatalf("expected bad expected_target error")
+	}
+}
 
-	t.Run("writeConsensusErr_non_txerror", func(t *testing.T) {
-		var out bytes.Buffer
-		writeConsensusErr(&out, io.EOF)
-		var resp Response
-		if err := json.Unmarshal(out.Bytes(), &resp); err != nil {
-			t.Fatalf("unmarshal response: %v", err)
-		}
-		if resp.Ok || resp.Err != io.EOF.Error() {
-			t.Fatalf("unexpected response: %+v", resp)
-		}
-	})
+func testRuntimeHelperBuildUtxoMapErrors(t *testing.T) {
+	t.Helper()
+	if _, err := buildUtxoMap([]UtxoJSON{{Txid: "00", CovenantDataHex: ""}}); err == nil {
+		t.Fatalf("expected bad utxo txid")
+	}
+	if _, err := buildUtxoMap([]UtxoJSON{{Txid: hex.EncodeToString(make([]byte, 32)), CovenantDataHex: "zz"}}); err == nil {
+		t.Fatalf("expected bad utxo covenant_data")
+	}
+}
 
-	t.Run("compactsize_helpers", func(t *testing.T) {
-		cases := []uint64{0, 1, 0xfc, 0xfd, 0xffff, 0x1_0000, 0x1_0000_0000}
-		for _, n := range cases {
-			enc := consensus.EncodeCompactSize(n)
-			dec, consumed, err := consensus.DecodeCompactSize(enc)
-			if err != nil || dec != n || consumed != len(enc) {
-				t.Fatalf("n=%d enc=%x dec=%d consumed=%d err=%v", n, enc, dec, consumed, err)
-			}
-		}
-		if _, _, err := consensus.DecodeCompactSize(nil); err == nil {
-			t.Fatalf("expected error")
-		}
-		if _, _, err := consensus.DecodeCompactSize([]byte{0xfd, 0x01}); err == nil {
-			t.Fatalf("expected short error")
-		}
-		if _, _, err := consensus.DecodeCompactSize([]byte{0xfe, 0x01, 0x02, 0x03}); err == nil {
-			t.Fatalf("expected short error")
-		}
-		if _, _, err := consensus.DecodeCompactSize([]byte{0xff, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07}); err == nil {
-			t.Fatalf("expected short error")
-		}
-	})
+func testRuntimeHelperParseKeyBytes(t *testing.T) {
+	t.Helper()
+	if b, err := parseKeyBytes("0x1"); err != nil || len(b) != 1 || b[0] != 0x01 {
+		t.Fatalf("unexpected: %x err=%v", b, err)
+	}
+	if _, err := parseKeyBytes("0xzz"); err == nil {
+		t.Fatalf("expected error")
+	}
+	if b, err := parseKeyBytes("abc"); err != nil || string(b) != "abc" {
+		t.Fatalf("unexpected ascii parse: %x err=%v", b, err)
+	}
+	if b, err := parseKeyBytes(42); err != nil || string(b) != "42" {
+		t.Fatalf("unexpected generic parse: %x err=%v", b, err)
+	}
+}
 
-	t.Run("slice_and_int_helpers", func(t *testing.T) {
-		if slicesEqualInt([]int{1}, []int{1, 2}) {
-			t.Fatalf("expected false")
+func testRuntimeHelperDefaultAndCastHelpers(t *testing.T) {
+	t.Helper()
+	assertDefaultHelpers(t)
+	assertCastHelpers(t)
+}
+
+func assertDefaultHelpers(t *testing.T) {
+	t.Helper()
+	if !boolOrDefault(nil, true) || boolOrDefault(ptrBool(false), true) {
+		t.Fatalf("boolOrDefault mismatch")
+	}
+	var u8 uint8 = 7
+	if uint8OrDefault(nil, 3) != 3 || uint8OrDefault(&u8, 3) != 7 {
+		t.Fatalf("uint8OrDefault mismatch")
+	}
+	var u64 uint64 = 11
+	if uint64OrDefault(nil, 5) != 5 || uint64OrDefault(&u64, 5) != 11 {
+		t.Fatalf("uint64OrDefault mismatch")
+	}
+}
+
+func assertCastHelpers(t *testing.T) {
+	t.Helper()
+	if toInt(float64(3), 9) != 3 || toInt(int64(4), 9) != 4 || toInt(uint64(5), 9) != 5 || toInt("x", 9) != 9 {
+		t.Fatalf("toInt mismatch")
+	}
+	if toInt(float64(3.5), 9) != 9 || toInt(uint64(platformMaxInt)+1, 9) != 9 {
+		t.Fatalf("toInt bounds mismatch")
+	}
+	if toString("ok", "bad") != "ok" || toString(123, "bad") != "bad" {
+		t.Fatalf("toString mismatch")
+	}
+	if !toBool(true, false) || toBool("x", false) {
+		t.Fatalf("toBool mismatch")
+	}
+}
+
+func testRuntimeHelperWriteConsensusErrNonTxError(t *testing.T) {
+	t.Helper()
+	var out bytes.Buffer
+	writeConsensusErr(&out, io.EOF)
+	var resp Response
+	if err := json.Unmarshal(out.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if resp.Ok || resp.Err != io.EOF.Error() {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+}
+
+func testRuntimeHelperCompactSize(t *testing.T) {
+	t.Helper()
+	for _, n := range []uint64{0, 1, 0xfc, 0xfd, 0xffff, 0x1_0000, 0x1_0000_0000} {
+		enc := consensus.EncodeCompactSize(n)
+		dec, consumed, err := consensus.DecodeCompactSize(enc)
+		if err != nil || dec != n || consumed != len(enc) {
+			t.Fatalf("n=%d enc=%x dec=%d consumed=%d err=%v", n, enc, dec, consumed, err)
 		}
-		if slicesEqualInt([]int{1, 2}, []int{1, 3}) {
-			t.Fatalf("expected false")
-		}
-		if !slicesEqualInt([]int{1, 2}, []int{1, 2}) {
-			t.Fatalf("expected true")
-		}
-		u := uniqueSortedInt([]int{3, 1, 3, 2})
-		if !slicesEqualInt(u, []int{1, 2, 3}) {
-			t.Fatalf("unexpected unique: %v", u)
-		}
-		if unique := uniqueSortedInt(nil); len(unique) != 0 {
-			t.Fatalf("expected empty")
-		}
-		if minInt(1, 2) != 1 || minInt(2, 1) != 1 {
-			t.Fatalf("minInt wrong")
-		}
-		if maxInt(1, 2) != 2 || maxInt(2, 1) != 2 {
-			t.Fatalf("maxInt wrong")
-		}
-	})
+	}
+	assertCompactSizeRejectsShortInputs(t)
+}
+
+func assertCompactSizeRejectsShortInputs(t *testing.T) {
+	t.Helper()
+	if _, _, err := consensus.DecodeCompactSize(nil); err == nil {
+		t.Fatalf("expected error")
+	}
+	if _, _, err := consensus.DecodeCompactSize([]byte{0xfd, 0x01}); err == nil {
+		t.Fatalf("expected short error")
+	}
+	if _, _, err := consensus.DecodeCompactSize([]byte{0xfe, 0x01, 0x02, 0x03}); err == nil {
+		t.Fatalf("expected short error")
+	}
+	if _, _, err := consensus.DecodeCompactSize([]byte{0xff, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07}); err == nil {
+		t.Fatalf("expected short error")
+	}
+}
+
+func testRuntimeHelperSliceAndIntHelpers(t *testing.T) {
+	t.Helper()
+	if slicesEqualInt([]int{1}, []int{1, 2}) {
+		t.Fatalf("expected false")
+	}
+	if slicesEqualInt([]int{1, 2}, []int{1, 3}) {
+		t.Fatalf("expected false")
+	}
+	if !slicesEqualInt([]int{1, 2}, []int{1, 2}) {
+		t.Fatalf("expected true")
+	}
+	assertUniqueSortedInt(t)
+	if minInt(1, 2) != 1 || minInt(2, 1) != 1 {
+		t.Fatalf("minInt wrong")
+	}
+	if maxInt(1, 2) != 2 || maxInt(2, 1) != 2 {
+		t.Fatalf("maxInt wrong")
+	}
+}
+
+func assertUniqueSortedInt(t *testing.T) {
+	t.Helper()
+	u := uniqueSortedInt([]int{3, 1, 3, 2})
+	if !slicesEqualInt(u, []int{1, 2, 3}) {
+		t.Fatalf("unexpected unique: %v", u)
+	}
+	if unique := uniqueSortedInt(nil); len(unique) != 0 {
+		t.Fatalf("expected empty")
+	}
 }
 
 func TestRubinConsensusCLI_FeatureBitsStateOp(t *testing.T) {
@@ -930,6 +991,14 @@ func TestRubinConsensusCLI_FeatureBitsStateOp(t *testing.T) {
 		Height:             consensus.SIGNAL_WINDOW,
 		WindowSignalCounts: []uint32{consensus.SIGNAL_THRESHOLD},
 	})
+	assertLockedInFeatureBitsResponse(t, resp, act)
+
+	t.Run("bit_out_of_range", testFeatureBitsBitOutOfRange)
+	t.Run("started_has_no_estimated_activation", testFeatureBitsStartedHasNoEstimatedActivation)
+}
+
+func assertLockedInFeatureBitsResponse(t *testing.T, resp Response, activationHeight uint64) {
+	t.Helper()
 	if resp.State != "LOCKED_IN" {
 		t.Fatalf("expected LOCKED_IN, got %q", resp.State)
 	}
@@ -948,45 +1017,47 @@ func TestRubinConsensusCLI_FeatureBitsStateOp(t *testing.T) {
 	if resp.EstimatedActivate == nil || *resp.EstimatedActivate != 2*consensus.SIGNAL_WINDOW {
 		t.Fatalf("unexpected estimated_activation_height: %v", resp.EstimatedActivate)
 	}
-	if resp.ActivationHeight == nil || *resp.ActivationHeight != act {
+	if resp.ActivationHeight == nil || *resp.ActivationHeight != activationHeight {
 		t.Fatalf("unexpected activation_height: %v", resp.ActivationHeight)
 	}
 	if resp.ConsensusActive == nil || !*resp.ConsensusActive {
 		t.Fatalf("unexpected consensus_active: %v", resp.ConsensusActive)
 	}
+}
 
-	t.Run("bit_out_of_range", func(t *testing.T) {
-		_ = mustRunErr(t, Request{
-			Op:                 "featurebits_state",
-			Name:               "X",
-			Bit:                32,
-			StartHeight:        0,
-			TimeoutHeight:      1,
-			Height:             0,
-			WindowSignalCounts: nil,
-		}, string(consensus.BLOCK_ERR_PARSE))
-	})
+func testFeatureBitsBitOutOfRange(t *testing.T) {
+	t.Helper()
+	_ = mustRunErr(t, Request{
+		Op:                 "featurebits_state",
+		Name:               "X",
+		Bit:                32,
+		StartHeight:        0,
+		TimeoutHeight:      1,
+		Height:             0,
+		WindowSignalCounts: nil,
+	}, string(consensus.BLOCK_ERR_PARSE))
+}
 
-	t.Run("started_has_no_estimated_activation", func(t *testing.T) {
-		act := uint64(1)
-		resp := mustRunOk(t, Request{
-			Op:                 "featurebits_state",
-			Name:               "X",
-			Bit:                0,
-			StartHeight:        0,
-			TimeoutHeight:      consensus.SIGNAL_WINDOW * 10,
-			ActivationHeight:   &act,
-			Height:             0,
-			WindowSignalCounts: nil,
-		})
-		if resp.State != "STARTED" {
-			t.Fatalf("expected STARTED, got %q", resp.State)
-		}
-		if resp.EstimatedActivate != nil {
-			t.Fatalf("expected nil estimated_activation_height, got %v", resp.EstimatedActivate)
-		}
-		if resp.ConsensusActive == nil || *resp.ConsensusActive {
-			t.Fatalf("unexpected consensus_active: %v", resp.ConsensusActive)
-		}
+func testFeatureBitsStartedHasNoEstimatedActivation(t *testing.T) {
+	t.Helper()
+	act := uint64(1)
+	resp := mustRunOk(t, Request{
+		Op:                 "featurebits_state",
+		Name:               "X",
+		Bit:                0,
+		StartHeight:        0,
+		TimeoutHeight:      consensus.SIGNAL_WINDOW * 10,
+		ActivationHeight:   &act,
+		Height:             0,
+		WindowSignalCounts: nil,
 	})
+	if resp.State != "STARTED" {
+		t.Fatalf("expected STARTED, got %q", resp.State)
+	}
+	if resp.EstimatedActivate != nil {
+		t.Fatalf("expected nil estimated_activation_height, got %v", resp.EstimatedActivate)
+	}
+	if resp.ConsensusActive == nil || *resp.ConsensusActive {
+		t.Fatalf("unexpected consensus_active: %v", resp.ConsensusActive)
+	}
 }


### PR DESCRIPTION
Invariant:
Reduce Codacy Go test-only CCN in rubin-consensus-cli tests without changing CLI runtime behavior.

Layer:
tests

Files changed:
- clients/go/cmd/rubin-consensus-cli/runtime_test.go

Tests:
- gofmt on changed Go file
- git diff --check
- gocyclo -over 15 clients/go/cmd/rubin-consensus-cli/runtime_test.go
- python3 -m lizard -l go clients/go/cmd/rubin-consensus-cli/runtime_test.go
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -v ./cmd/rubin-consensus-cli -run "TestRubinConsensusCLI_(RunFromStdin_CoversKeyOps|RuntimeHelpers|FeatureBitsStateOp)$" -count=1'
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -v ./cmd/rubin-consensus-cli -count=1'
- rubin-push coverage command: scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -v ./cmd/rubin-consensus-cli -coverprofile=/tmp/rub252e-consensus-cli-tests.cover -count=1'

Behavior impact:
No production code changes.

Known non-goals:
- No CLI runtime behavior changes.
- No consensus, policy, conformance, fixture, formal, Rust, or generated artifact changes.
