### PR TITLE
RUB-264: split Rust OpenSSL facade shape

### DIFF
--- a/clients/rust/crates/rubin-consensus/src/verify_sig_openssl.rs
+++ b/clients/rust/crates/rubin-consensus/src/verify_sig_openssl.rs
@@ -137,6 +137,7 @@ impl Mldsa87Keypair {
             // canonical suite registry. ctx is freed on every error path after
             // allocation. On successful keygen, pkey ownership is either consumed
             // by read_mldsa87_pubkey on failure or stored in Mldsa87Keypair.
+            // If keygen fails after writing pkey, this path frees it below.
             openssl_sys::ERR_clear_error();
             let ctx = ffi::EVP_PKEY_CTX_new_from_name(
                 core::ptr::null_mut(),
@@ -153,6 +154,9 @@ impl Mldsa87Keypair {
             let mut pkey: *mut openssl_sys::EVP_PKEY = core::ptr::null_mut();
             if openssl_sys::EVP_PKEY_keygen(ctx, &mut pkey) <= 0 || pkey.is_null() {
                 openssl_sys::EVP_PKEY_CTX_free(ctx);
+                if !pkey.is_null() {
+                    openssl_sys::EVP_PKEY_free(pkey);
+                }
                 return Err(openssl_parse_error("openssl: EVP_PKEY_keygen failed"));
             }
             openssl_sys::EVP_PKEY_CTX_free(ctx);

--- a/clients/rust/crates/rubin-consensus/src/verify_sig_openssl.rs
+++ b/clients/rust/crates/rubin-consensus/src/verify_sig_openssl.rs
@@ -55,12 +55,16 @@ fn read_mldsa87_pubkey(pkey: *mut openssl_sys::EVP_PKEY) -> Result<Vec<u8>, TxEr
 fn new_digest_sign_ctx(
     pkey: *mut openssl_sys::EVP_PKEY,
 ) -> Result<*mut openssl_sys::EVP_MD_CTX, TxError> {
+    if pkey.is_null() {
+        return Err(openssl_parse_error("openssl: nil ML-DSA keypair"));
+    }
     unsafe {
-        // SAFETY: pkey is a non-null live EVP_PKEY owned by Mldsa87Keypair for
-        // the duration of signing. ERR_clear_error only resets OpenSSL's
-        // thread-local error queue. OpenSSL allocates mctx here; every failure
-        // after allocation frees it before returning, while success transfers
-        // the context to sign_mldsa87_digest for exactly one signing operation.
+        // SAFETY: the null precheck above keeps this safe wrapper from passing
+        // a null pkey into OpenSSL. Production callers pass a live EVP_PKEY
+        // owned by Mldsa87Keypair for the duration of signing. ERR_clear_error
+        // only resets OpenSSL's thread-local error queue. OpenSSL allocates
+        // mctx here; every failure after allocation frees it before returning,
+        // while success transfers it to sign_mldsa87_digest for one operation.
         openssl_sys::ERR_clear_error();
         let mctx = ffi::EVP_MD_CTX_new();
         if mctx.is_null() {

--- a/clients/rust/crates/rubin-consensus/src/verify_sig_openssl.rs
+++ b/clients/rust/crates/rubin-consensus/src/verify_sig_openssl.rs
@@ -52,20 +52,13 @@ fn read_mldsa87_pubkey(pkey: *mut openssl_sys::EVP_PKEY) -> Result<Vec<u8>, TxEr
     }
 }
 
-/// # Safety
-///
-/// If `pkey` is non-null, it must point to a live `EVP_PKEY` that remains valid
-/// until this function returns. A null pointer is accepted only to fail closed
-/// before any OpenSSL FFI call.
-unsafe fn new_digest_sign_ctx(
-    pkey: *mut openssl_sys::EVP_PKEY,
-) -> Result<*mut openssl_sys::EVP_MD_CTX, TxError> {
+fn new_digest_sign_ctx(keypair: &Mldsa87Keypair) -> Result<*mut openssl_sys::EVP_MD_CTX, TxError> {
+    let pkey = keypair.pkey;
     if pkey.is_null() {
         return Err(openssl_parse_error("openssl: nil ML-DSA keypair"));
     }
     unsafe {
-        // SAFETY: the function contract requires any non-null pkey to be live
-        // for this call. Production callers pass a Mldsa87Keypair-owned key.
+        // SAFETY: Mldsa87Keypair owns pkey and keeps it live for this call.
         // ERR_clear_error only resets OpenSSL's thread-local error queue.
         // OpenSSL allocates mctx here; every failure after allocation frees it
         // before returning, while success transfers it to sign_mldsa87_digest.
@@ -176,11 +169,7 @@ impl Mldsa87Keypair {
         if self.pkey.is_null() {
             return Err(openssl_parse_error("openssl: nil ML-DSA keypair"));
         }
-        let mctx = unsafe {
-            // SAFETY: self.pkey was checked non-null above and is owned by this
-            // keypair for the duration of the signing operation.
-            new_digest_sign_ctx(self.pkey)?
-        };
+        let mctx = new_digest_sign_ctx(self)?;
         sign_mldsa87_digest(mctx, digest32)
     }
 }

--- a/clients/rust/crates/rubin-consensus/src/verify_sig_openssl.rs
+++ b/clients/rust/crates/rubin-consensus/src/verify_sig_openssl.rs
@@ -355,6 +355,10 @@ pub(crate) fn openssl_verify_sig_digest_oneshot(
         return Err(TxError::new(ErrorCode::TxErrParse, "openssl: empty input"));
     }
 
+    // SAFETY: alg is a static OpenSSL algorithm name, and pubkey, signature,
+    // and msg are immutable slices whose pointers remain valid for each FFI
+    // call. This block owns pkey and mctx after allocation and frees both on
+    // every error and success path before returning.
     unsafe {
         openssl_sys::ERR_clear_error();
 

--- a/clients/rust/crates/rubin-consensus/src/verify_sig_openssl.rs
+++ b/clients/rust/crates/rubin-consensus/src/verify_sig_openssl.rs
@@ -52,19 +52,23 @@ fn read_mldsa87_pubkey(pkey: *mut openssl_sys::EVP_PKEY) -> Result<Vec<u8>, TxEr
     }
 }
 
-fn new_digest_sign_ctx(
+/// # Safety
+///
+/// If `pkey` is non-null, it must point to a live `EVP_PKEY` that remains valid
+/// until this function returns. A null pointer is accepted only to fail closed
+/// before any OpenSSL FFI call.
+unsafe fn new_digest_sign_ctx(
     pkey: *mut openssl_sys::EVP_PKEY,
 ) -> Result<*mut openssl_sys::EVP_MD_CTX, TxError> {
     if pkey.is_null() {
         return Err(openssl_parse_error("openssl: nil ML-DSA keypair"));
     }
     unsafe {
-        // SAFETY: the null precheck above keeps this safe wrapper from passing
-        // a null pkey into OpenSSL. Production callers pass a live EVP_PKEY
-        // owned by Mldsa87Keypair for the duration of signing. ERR_clear_error
-        // only resets OpenSSL's thread-local error queue. OpenSSL allocates
-        // mctx here; every failure after allocation frees it before returning,
-        // while success transfers it to sign_mldsa87_digest for one operation.
+        // SAFETY: the function contract requires any non-null pkey to be live
+        // for this call. Production callers pass a Mldsa87Keypair-owned key.
+        // ERR_clear_error only resets OpenSSL's thread-local error queue.
+        // OpenSSL allocates mctx here; every failure after allocation frees it
+        // before returning, while success transfers it to sign_mldsa87_digest.
         openssl_sys::ERR_clear_error();
         let mctx = ffi::EVP_MD_CTX_new();
         if mctx.is_null() {
@@ -172,7 +176,11 @@ impl Mldsa87Keypair {
         if self.pkey.is_null() {
             return Err(openssl_parse_error("openssl: nil ML-DSA keypair"));
         }
-        let mctx = new_digest_sign_ctx(self.pkey)?;
+        let mctx = unsafe {
+            // SAFETY: self.pkey was checked non-null above and is owned by this
+            // keypair for the duration of the signing operation.
+            new_digest_sign_ctx(self.pkey)?
+        };
         sign_mldsa87_digest(mctx, digest32)
     }
 }

--- a/clients/rust/crates/rubin-consensus/src/verify_sig_openssl.rs
+++ b/clients/rust/crates/rubin-consensus/src/verify_sig_openssl.rs
@@ -6,6 +6,7 @@ mod ffi;
 mod keypair;
 
 use crate::constants::{ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES, SUITE_ID_ML_DSA_87};
+use crate::error::ErrorCode::{TxErrSigInvalid, TxErrSigNoncanonical};
 use crate::error::{ErrorCode, TxError};
 use crate::tx_helpers::DigestSigner;
 use core::ffi::CStr;
@@ -18,6 +19,11 @@ pub use keypair::Mldsa87Keypair;
 
 const OPENSSL_INIT_LOAD_CONFIG: u64 = 0x0000_0040;
 const OPENSSL_INIT_NO_LOAD_CONFIG: u64 = 0x0000_0080;
+const ERR_KEY_CTX: &str = "openssl: EVP_PKEY_CTX_new_from_name failed";
+const ERR_RAW_PUBKEY: &str = "openssl: EVP_PKEY_get_raw_public_key failed";
+const ERR_BAD_PUBKEY_LEN: &str = "openssl: non-canonical ML-DSA public key length";
+const ERR_DIGEST_SIGN: &str = "openssl: EVP_DigestSign failed";
+const ERR_BAD_SIG_LEN: &str = "openssl: non-canonical ML-DSA signature length";
 
 static OPENSSL_CONSENSUS_INIT: OnceLock<Result<(), TxError>> = OnceLock::new();
 
@@ -36,16 +42,11 @@ fn read_mldsa87_pubkey(pkey: *mut openssl_sys::EVP_PKEY) -> Result<Vec<u8>, TxEr
         let mut pubkey_len = pubkey.len();
         if ffi::EVP_PKEY_get_raw_public_key(pkey, pubkey.as_mut_ptr(), &mut pubkey_len) <= 0 {
             openssl_sys::EVP_PKEY_free(pkey);
-            return Err(openssl_parse_error(
-                "openssl: EVP_PKEY_get_raw_public_key failed",
-            ));
+            return Err(openssl_parse_error(ERR_RAW_PUBKEY));
         }
         if pubkey_len != ML_DSA_87_PUBKEY_BYTES as usize {
             openssl_sys::EVP_PKEY_free(pkey);
-            return Err(TxError::new(
-                ErrorCode::TxErrSigNoncanonical,
-                "openssl: non-canonical ML-DSA public key length",
-            ));
+            return Err(TxError::new(TxErrSigNoncanonical, ERR_BAD_PUBKEY_LEN));
         }
         Ok(pubkey)
     }
@@ -102,17 +103,11 @@ fn sign_mldsa87_digest(
         ) <= 0
         {
             ffi::EVP_MD_CTX_free(mctx);
-            return Err(TxError::new(
-                ErrorCode::TxErrSigInvalid,
-                "openssl: EVP_DigestSign failed",
-            ));
+            return Err(TxError::new(TxErrSigInvalid, ERR_DIGEST_SIGN));
         }
         ffi::EVP_MD_CTX_free(mctx);
         if sig_len != ML_DSA_87_SIG_BYTES as usize {
-            return Err(TxError::new(
-                ErrorCode::TxErrSigNoncanonical,
-                "openssl: non-canonical ML-DSA signature length",
-            ));
+            return Err(TxError::new(TxErrSigNoncanonical, ERR_BAD_SIG_LEN));
         }
         signature.truncate(sig_len);
         Ok(signature)
@@ -148,9 +143,7 @@ impl Mldsa87Keypair {
                 core::ptr::null(),
             );
             if ctx.is_null() {
-                return Err(openssl_parse_error(
-                    "openssl: EVP_PKEY_CTX_new_from_name failed",
-                ));
+                return Err(openssl_parse_error(ERR_KEY_CTX));
             }
             if openssl_sys::EVP_PKEY_keygen_init(ctx) <= 0 {
                 openssl_sys::EVP_PKEY_CTX_free(ctx);

--- a/clients/rust/crates/rubin-consensus/src/verify_sig_openssl.rs
+++ b/clients/rust/crates/rubin-consensus/src/verify_sig_openssl.rs
@@ -56,9 +56,11 @@ fn new_digest_sign_ctx(
 ) -> Result<*mut openssl_sys::EVP_MD_CTX, TxError> {
     unsafe {
         // SAFETY: pkey is a non-null live EVP_PKEY owned by Mldsa87Keypair for
-        // the duration of signing. OpenSSL allocates mctx here; every failure
-        // after allocation frees it before returning, while success transfers the
-        // context to sign_mldsa87_digest for exactly one signing operation.
+        // the duration of signing. ERR_clear_error only resets OpenSSL's
+        // thread-local error queue. OpenSSL allocates mctx here; every failure
+        // after allocation frees it before returning, while success transfers
+        // the context to sign_mldsa87_digest for exactly one signing operation.
+        openssl_sys::ERR_clear_error();
         let mctx = ffi::EVP_MD_CTX_new();
         if mctx.is_null() {
             return Err(openssl_parse_error("openssl: EVP_MD_CTX_new failed"));
@@ -173,8 +175,6 @@ impl Mldsa87Keypair {
         if self.pkey.is_null() {
             return Err(openssl_parse_error("openssl: nil ML-DSA keypair"));
         }
-        // SAFETY: ERR_clear_error only resets OpenSSL's thread-local error queue.
-        unsafe { openssl_sys::ERR_clear_error() };
         let mctx = new_digest_sign_ctx(self.pkey)?;
         sign_mldsa87_digest(mctx, digest32)
     }

--- a/clients/rust/crates/rubin-consensus/src/verify_sig_openssl.rs
+++ b/clients/rust/crates/rubin-consensus/src/verify_sig_openssl.rs
@@ -170,9 +170,6 @@ impl Mldsa87Keypair {
     }
 
     pub fn sign_digest32(&self, digest32: [u8; 32]) -> Result<Vec<u8>, TxError> {
-        if self.pkey.is_null() {
-            return Err(openssl_parse_error("openssl: nil ML-DSA keypair"));
-        }
         let mctx = new_digest_sign_ctx(self)?;
         sign_mldsa87_digest(mctx, digest32)
     }

--- a/clients/rust/crates/rubin-consensus/src/verify_sig_openssl.rs
+++ b/clients/rust/crates/rubin-consensus/src/verify_sig_openssl.rs
@@ -1,6 +1,9 @@
 mod alg;
 mod binding;
+mod bootstrap;
 mod digest;
+mod ffi;
+mod keypair;
 
 use crate::constants::{ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES, SUITE_ID_ML_DSA_87};
 use crate::error::{ErrorCode, TxError};
@@ -9,218 +12,125 @@ use core::ffi::CStr;
 use std::sync::OnceLock;
 
 use alg::suite_alg_name;
+use bootstrap::ensure_openssl_bootstrap;
 use digest::map_digest_verify_rc;
+pub use keypair::Mldsa87Keypair;
 
 const OPENSSL_INIT_LOAD_CONFIG: u64 = 0x0000_0040;
 const OPENSSL_INIT_NO_LOAD_CONFIG: u64 = 0x0000_0080;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum OpenSslFipsMode {
-    Off,
-    Ready,
-    Only,
-}
-
-static OPENSSL_BOOTSTRAP_STATE: OnceLock<Result<(), TxError>> = OnceLock::new();
 static OPENSSL_CONSENSUS_INIT: OnceLock<Result<(), TxError>> = OnceLock::new();
 
-extern "C" {
-    fn EVP_PKEY_CTX_new_from_name(
-        libctx: *mut core::ffi::c_void,
-        name: *const core::ffi::c_char,
-        propq: *const core::ffi::c_char,
-    ) -> *mut openssl_sys::EVP_PKEY_CTX;
-
-    fn EVP_PKEY_new_raw_public_key_ex(
-        libctx: *mut core::ffi::c_void,
-        keytype: *const core::ffi::c_char,
-        propq: *const core::ffi::c_char,
-        key: *const core::ffi::c_uchar,
-        keylen: usize,
-    ) -> *mut openssl_sys::EVP_PKEY;
-
-    fn EVP_MD_CTX_new() -> *mut openssl_sys::EVP_MD_CTX;
-    fn EVP_MD_CTX_free(ctx: *mut openssl_sys::EVP_MD_CTX);
-
-    fn EVP_DigestVerifyInit_ex(
-        ctx: *mut openssl_sys::EVP_MD_CTX,
-        pctx: *mut *mut openssl_sys::EVP_PKEY_CTX,
-        mdname: *const core::ffi::c_char,
-        libctx: *mut core::ffi::c_void,
-        props: *const core::ffi::c_char,
-        pkey: *mut openssl_sys::EVP_PKEY,
-        params: *const core::ffi::c_void,
-    ) -> core::ffi::c_int;
-
-    fn EVP_DigestVerify(
-        ctx: *mut openssl_sys::EVP_MD_CTX,
-        sigret: *const core::ffi::c_uchar,
-        siglen: usize,
-        tbs: *const core::ffi::c_uchar,
-        tbslen: usize,
-    ) -> core::ffi::c_int;
-
-    fn EVP_DigestSignInit_ex(
-        ctx: *mut openssl_sys::EVP_MD_CTX,
-        pctx: *mut *mut openssl_sys::EVP_PKEY_CTX,
-        mdname: *const core::ffi::c_char,
-        libctx: *mut core::ffi::c_void,
-        props: *const core::ffi::c_char,
-        pkey: *mut openssl_sys::EVP_PKEY,
-        params: *const core::ffi::c_void,
-    ) -> core::ffi::c_int;
-
-    fn EVP_DigestSign(
-        ctx: *mut openssl_sys::EVP_MD_CTX,
-        sigret: *mut core::ffi::c_uchar,
-        siglen: *mut usize,
-        tbs: *const core::ffi::c_uchar,
-        tbslen: usize,
-    ) -> core::ffi::c_int;
-
-    fn OPENSSL_init_crypto(opts: u64, settings: *const core::ffi::c_void) -> core::ffi::c_int;
-
-    fn EVP_set_default_properties(
-        libctx: *mut core::ffi::c_void,
-        propq: *const core::ffi::c_char,
-    ) -> core::ffi::c_int;
-
-    fn EVP_PKEY_get_raw_public_key(
-        pkey: *const openssl_sys::EVP_PKEY,
-        pub_: *mut core::ffi::c_uchar,
-        publen: *mut usize,
-    ) -> core::ffi::c_int;
-}
-
-pub struct Mldsa87Keypair {
-    pkey: *mut openssl_sys::EVP_PKEY,
-    pubkey: Vec<u8>,
-}
-
-impl Drop for Mldsa87Keypair {
-    fn drop(&mut self) {
-        unsafe {
-            if !self.pkey.is_null() {
-                openssl_sys::EVP_PKEY_free(self.pkey);
-                self.pkey = core::ptr::null_mut();
-            }
-        }
-    }
-}
-
-impl Mldsa87Keypair {
-    pub fn generate() -> Result<Self, TxError> {
-        ensure_openssl_bootstrap()?;
-        let alg = suite_alg_name(SUITE_ID_ML_DSA_87)?;
-        unsafe {
-            openssl_sys::ERR_clear_error();
-            let ctx =
-                EVP_PKEY_CTX_new_from_name(core::ptr::null_mut(), alg.as_ptr(), core::ptr::null());
-            if ctx.is_null() {
-                return Err(TxError::new(
-                    ErrorCode::TxErrParse,
-                    "openssl: EVP_PKEY_CTX_new_from_name failed",
-                ));
-            }
-            if openssl_sys::EVP_PKEY_keygen_init(ctx) <= 0 {
-                openssl_sys::EVP_PKEY_CTX_free(ctx);
-                return Err(TxError::new(
-                    ErrorCode::TxErrParse,
-                    "openssl: EVP_PKEY_keygen_init failed",
-                ));
-            }
-            let mut pkey: *mut openssl_sys::EVP_PKEY = core::ptr::null_mut();
-            if openssl_sys::EVP_PKEY_keygen(ctx, &mut pkey) <= 0 || pkey.is_null() {
-                openssl_sys::EVP_PKEY_CTX_free(ctx);
-                return Err(TxError::new(
-                    ErrorCode::TxErrParse,
-                    "openssl: EVP_PKEY_keygen failed",
-                ));
-            }
-            openssl_sys::EVP_PKEY_CTX_free(ctx);
-
-            let mut pubkey = vec![0u8; ML_DSA_87_PUBKEY_BYTES as usize];
-            let mut pubkey_len = pubkey.len();
-            if EVP_PKEY_get_raw_public_key(pkey, pubkey.as_mut_ptr(), &mut pubkey_len) <= 0 {
-                openssl_sys::EVP_PKEY_free(pkey);
-                return Err(TxError::new(
-                    ErrorCode::TxErrParse,
-                    "openssl: EVP_PKEY_get_raw_public_key failed",
-                ));
-            }
-            if pubkey_len != ML_DSA_87_PUBKEY_BYTES as usize {
-                openssl_sys::EVP_PKEY_free(pkey);
-                return Err(TxError::new(
-                    ErrorCode::TxErrSigNoncanonical,
-                    "openssl: non-canonical ML-DSA public key length",
-                ));
-            }
-            Ok(Self { pkey, pubkey })
-        }
-    }
-
-    pub fn pubkey_bytes(&self) -> Vec<u8> {
-        self.pubkey.clone()
-    }
-
-    pub fn sign_digest32(&self, digest32: [u8; 32]) -> Result<Vec<u8>, TxError> {
-        if self.pkey.is_null() {
+fn generate_mldsa87_keypair() -> Result<(*mut openssl_sys::EVP_PKEY, Vec<u8>), TxError> {
+    ensure_openssl_bootstrap()?;
+    let alg = suite_alg_name(SUITE_ID_ML_DSA_87)?;
+    unsafe {
+        openssl_sys::ERR_clear_error();
+        let ctx =
+            ffi::EVP_PKEY_CTX_new_from_name(core::ptr::null_mut(), alg.as_ptr(), core::ptr::null());
+        if ctx.is_null() {
             return Err(TxError::new(
                 ErrorCode::TxErrParse,
-                "openssl: nil ML-DSA keypair",
+                "openssl: EVP_PKEY_CTX_new_from_name failed",
             ));
         }
-        unsafe {
-            openssl_sys::ERR_clear_error();
-            let mctx = EVP_MD_CTX_new();
-            if mctx.is_null() {
-                return Err(TxError::new(
-                    ErrorCode::TxErrParse,
-                    "openssl: EVP_MD_CTX_new failed",
-                ));
-            }
-            if EVP_DigestSignInit_ex(
-                mctx,
-                core::ptr::null_mut(),
-                core::ptr::null(),
-                core::ptr::null_mut(),
-                core::ptr::null(),
-                self.pkey,
-                core::ptr::null(),
-            ) <= 0
-            {
-                EVP_MD_CTX_free(mctx);
-                return Err(TxError::new(
-                    ErrorCode::TxErrParse,
-                    "openssl: EVP_DigestSignInit_ex failed",
-                ));
-            }
-            let mut signature = vec![0u8; ML_DSA_87_SIG_BYTES as usize];
-            let mut sig_len = signature.len();
-            if EVP_DigestSign(
-                mctx,
-                signature.as_mut_ptr(),
-                &mut sig_len,
-                digest32.as_ptr(),
-                digest32.len(),
-            ) <= 0
-            {
-                EVP_MD_CTX_free(mctx);
-                return Err(TxError::new(
-                    ErrorCode::TxErrSigInvalid,
-                    "openssl: EVP_DigestSign failed",
-                ));
-            }
-            EVP_MD_CTX_free(mctx);
-            if sig_len != ML_DSA_87_SIG_BYTES as usize {
-                return Err(TxError::new(
-                    ErrorCode::TxErrSigNoncanonical,
-                    "openssl: non-canonical ML-DSA signature length",
-                ));
-            }
-            signature.truncate(sig_len);
-            Ok(signature)
+        if openssl_sys::EVP_PKEY_keygen_init(ctx) <= 0 {
+            openssl_sys::EVP_PKEY_CTX_free(ctx);
+            return Err(TxError::new(
+                ErrorCode::TxErrParse,
+                "openssl: EVP_PKEY_keygen_init failed",
+            ));
         }
+        let mut pkey: *mut openssl_sys::EVP_PKEY = core::ptr::null_mut();
+        if openssl_sys::EVP_PKEY_keygen(ctx, &mut pkey) <= 0 || pkey.is_null() {
+            openssl_sys::EVP_PKEY_CTX_free(ctx);
+            return Err(TxError::new(
+                ErrorCode::TxErrParse,
+                "openssl: EVP_PKEY_keygen failed",
+            ));
+        }
+        openssl_sys::EVP_PKEY_CTX_free(ctx);
+
+        let mut pubkey = vec![0u8; ML_DSA_87_PUBKEY_BYTES as usize];
+        let mut pubkey_len = pubkey.len();
+        if ffi::EVP_PKEY_get_raw_public_key(pkey, pubkey.as_mut_ptr(), &mut pubkey_len) <= 0 {
+            openssl_sys::EVP_PKEY_free(pkey);
+            return Err(TxError::new(
+                ErrorCode::TxErrParse,
+                "openssl: EVP_PKEY_get_raw_public_key failed",
+            ));
+        }
+        if pubkey_len != ML_DSA_87_PUBKEY_BYTES as usize {
+            openssl_sys::EVP_PKEY_free(pkey);
+            return Err(TxError::new(
+                ErrorCode::TxErrSigNoncanonical,
+                "openssl: non-canonical ML-DSA public key length",
+            ));
+        }
+        Ok((pkey, pubkey))
+    }
+}
+
+fn sign_mldsa87_digest32(
+    pkey: *mut openssl_sys::EVP_PKEY,
+    digest32: [u8; 32],
+) -> Result<Vec<u8>, TxError> {
+    if pkey.is_null() {
+        return Err(TxError::new(
+            ErrorCode::TxErrParse,
+            "openssl: nil ML-DSA keypair",
+        ));
+    }
+    unsafe {
+        openssl_sys::ERR_clear_error();
+        let mctx = ffi::EVP_MD_CTX_new();
+        if mctx.is_null() {
+            return Err(TxError::new(
+                ErrorCode::TxErrParse,
+                "openssl: EVP_MD_CTX_new failed",
+            ));
+        }
+        if ffi::EVP_DigestSignInit_ex(
+            mctx,
+            core::ptr::null_mut(),
+            core::ptr::null(),
+            core::ptr::null_mut(),
+            core::ptr::null(),
+            pkey,
+            core::ptr::null(),
+        ) <= 0
+        {
+            ffi::EVP_MD_CTX_free(mctx);
+            return Err(TxError::new(
+                ErrorCode::TxErrParse,
+                "openssl: EVP_DigestSignInit_ex failed",
+            ));
+        }
+        let mut signature = vec![0u8; ML_DSA_87_SIG_BYTES as usize];
+        let mut sig_len = signature.len();
+        if ffi::EVP_DigestSign(
+            mctx,
+            signature.as_mut_ptr(),
+            &mut sig_len,
+            digest32.as_ptr(),
+            digest32.len(),
+        ) <= 0
+        {
+            ffi::EVP_MD_CTX_free(mctx);
+            return Err(TxError::new(
+                ErrorCode::TxErrSigInvalid,
+                "openssl: EVP_DigestSign failed",
+            ));
+        }
+        ffi::EVP_MD_CTX_free(mctx);
+        if sig_len != ML_DSA_87_SIG_BYTES as usize {
+            return Err(TxError::new(
+                ErrorCode::TxErrSigNoncanonical,
+                "openssl: non-canonical ML-DSA signature length",
+            ));
+        }
+        signature.truncate(sig_len);
+        Ok(signature)
     }
 }
 
@@ -232,34 +142,6 @@ impl DigestSigner for Mldsa87Keypair {
     fn sign_digest32(&self, digest32: [u8; 32]) -> Result<Vec<u8>, TxError> {
         Mldsa87Keypair::sign_digest32(self, digest32)
     }
-}
-
-fn parse_openssl_fips_mode(raw: &str) -> Result<OpenSslFipsMode, TxError> {
-    match raw.trim().to_ascii_lowercase().as_str() {
-        "" | "off" => Ok(OpenSslFipsMode::Off),
-        "ready" => Ok(OpenSslFipsMode::Ready),
-        "only" => Ok(OpenSslFipsMode::Only),
-        _ => Err(TxError::new(
-            ErrorCode::TxErrParse,
-            "openssl bootstrap: invalid RUBIN_OPENSSL_FIPS_MODE",
-        )),
-    }
-}
-
-fn ensure_openssl_bootstrap() -> Result<(), TxError> {
-    let mode_raw = std::env::var("RUBIN_OPENSSL_FIPS_MODE").unwrap_or_default();
-    let mode = parse_openssl_fips_mode(&mode_raw)?;
-    ensure_openssl_bootstrap_for_mode(mode)
-}
-
-fn ensure_openssl_bootstrap_for_mode(mode: OpenSslFipsMode) -> Result<(), TxError> {
-    if mode == OpenSslFipsMode::Off {
-        return Ok(());
-    }
-
-    let require_fips = mode == OpenSslFipsMode::Only;
-    let state = OPENSSL_BOOTSTRAP_STATE.get_or_init(|| openssl_bootstrap(require_fips));
-    state.clone()
 }
 
 fn set_env_if_empty(key: &str, value: Option<String>) {
@@ -291,22 +173,6 @@ fn openssl_check_sigalg(alg: &'static CStr, props: &'static CStr) -> Result<(), 
     Ok(())
 }
 
-#[cfg(test)]
-pub(crate) fn test_set_env_if_empty(key: &str, value: Option<String>) {
-    set_env_if_empty(key, value);
-}
-
-#[cfg(test)]
-pub(crate) fn test_ensure_openssl_bootstrap_for_mode(mode_raw: &str) -> Result<(), TxError> {
-    let mode = parse_openssl_fips_mode(mode_raw)?;
-    ensure_openssl_bootstrap_for_mode(mode)
-}
-
-#[cfg(test)]
-pub(crate) fn test_openssl_check_sigalg_bad_alg() -> Result<(), TxError> {
-    openssl_check_sigalg(c"NOT-A-REAL-SIGALG", c"")
-}
-
 fn openssl_bootstrap(require_fips: bool) -> Result<(), TxError> {
     set_env_if_empty("OPENSSL_CONF", std::env::var("RUBIN_OPENSSL_CONF").ok());
     set_env_if_empty(
@@ -316,7 +182,7 @@ fn openssl_bootstrap(require_fips: bool) -> Result<(), TxError> {
 
     unsafe {
         openssl_sys::ERR_clear_error();
-        if OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, core::ptr::null()) != 1 {
+        if ffi::OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, core::ptr::null()) != 1 {
             return Err(TxError::new(
                 ErrorCode::TxErrParse,
                 "openssl bootstrap: OPENSSL_init_crypto failed",
@@ -335,7 +201,7 @@ fn openssl_bootstrap(require_fips: bool) -> Result<(), TxError> {
             ));
         }
 
-        if EVP_set_default_properties(core::ptr::null_mut(), c"fips=yes".as_ptr()) != 1 {
+        if ffi::EVP_set_default_properties(core::ptr::null_mut(), c"fips=yes".as_ptr()) != 1 {
             return Err(TxError::new(
                 ErrorCode::TxErrParse,
                 "openssl bootstrap: EVP_set_default_properties(fips=yes) failed",
@@ -368,7 +234,7 @@ fn openssl_consensus_bootstrap() -> Result<(), TxError> {
     unsafe {
         openssl_sys::ERR_clear_error();
         map_openssl_init_rc(
-            OPENSSL_init_crypto(OPENSSL_INIT_NO_LOAD_CONFIG, core::ptr::null()),
+            ffi::OPENSSL_init_crypto(OPENSSL_INIT_NO_LOAD_CONFIG, core::ptr::null()),
             "openssl consensus init: OPENSSL_init_crypto failed",
         )?;
     }
@@ -446,7 +312,7 @@ pub(crate) fn openssl_verify_sig_digest_oneshot(
     unsafe {
         openssl_sys::ERR_clear_error();
 
-        let pkey = EVP_PKEY_new_raw_public_key_ex(
+        let pkey = ffi::EVP_PKEY_new_raw_public_key_ex(
             core::ptr::null_mut(),
             alg.as_ptr(),
             core::ptr::null(),
@@ -460,7 +326,7 @@ pub(crate) fn openssl_verify_sig_digest_oneshot(
             ));
         }
 
-        let mctx = EVP_MD_CTX_new();
+        let mctx = ffi::EVP_MD_CTX_new();
         if mctx.is_null() {
             openssl_sys::EVP_PKEY_free(pkey);
             return Err(TxError::new(
@@ -469,7 +335,7 @@ pub(crate) fn openssl_verify_sig_digest_oneshot(
             ));
         }
 
-        if EVP_DigestVerifyInit_ex(
+        if ffi::EVP_DigestVerifyInit_ex(
             mctx,
             core::ptr::null_mut(),
             core::ptr::null(),
@@ -479,7 +345,7 @@ pub(crate) fn openssl_verify_sig_digest_oneshot(
             core::ptr::null(),
         ) <= 0
         {
-            EVP_MD_CTX_free(mctx);
+            ffi::EVP_MD_CTX_free(mctx);
             openssl_sys::EVP_PKEY_free(pkey);
             return Err(TxError::new(
                 ErrorCode::TxErrParse,
@@ -487,7 +353,7 @@ pub(crate) fn openssl_verify_sig_digest_oneshot(
             ));
         }
 
-        let rc = EVP_DigestVerify(
+        let rc = ffi::EVP_DigestVerify(
             mctx,
             signature.as_ptr(),
             signature.len(),
@@ -495,7 +361,7 @@ pub(crate) fn openssl_verify_sig_digest_oneshot(
             msg.len(),
         );
 
-        EVP_MD_CTX_free(mctx);
+        ffi::EVP_MD_CTX_free(mctx);
         openssl_sys::EVP_PKEY_free(pkey);
         map_digest_verify_rc(rc)
     }
@@ -503,6 +369,11 @@ pub(crate) fn openssl_verify_sig_digest_oneshot(
 
 #[cfg(test)]
 pub(crate) use alg::test_suite_alg_name;
+#[cfg(test)]
+pub(crate) use bootstrap::{
+    parse_openssl_fips_mode, test_ensure_openssl_bootstrap_for_mode,
+    test_openssl_check_sigalg_bad_alg, test_set_env_if_empty, OpenSslFipsMode,
+};
 #[cfg(test)]
 pub(crate) use digest::{
     test_openssl_verify_sig_digest_oneshot_bad_alg,

--- a/clients/rust/crates/rubin-consensus/src/verify_sig_openssl.rs
+++ b/clients/rust/crates/rubin-consensus/src/verify_sig_openssl.rs
@@ -21,42 +21,22 @@ const OPENSSL_INIT_NO_LOAD_CONFIG: u64 = 0x0000_0080;
 
 static OPENSSL_CONSENSUS_INIT: OnceLock<Result<(), TxError>> = OnceLock::new();
 
-fn generate_mldsa87_keypair() -> Result<(*mut openssl_sys::EVP_PKEY, Vec<u8>), TxError> {
-    ensure_openssl_bootstrap()?;
-    let alg = suite_alg_name(SUITE_ID_ML_DSA_87)?;
-    unsafe {
-        openssl_sys::ERR_clear_error();
-        let ctx =
-            ffi::EVP_PKEY_CTX_new_from_name(core::ptr::null_mut(), alg.as_ptr(), core::ptr::null());
-        if ctx.is_null() {
-            return Err(TxError::new(
-                ErrorCode::TxErrParse,
-                "openssl: EVP_PKEY_CTX_new_from_name failed",
-            ));
-        }
-        if openssl_sys::EVP_PKEY_keygen_init(ctx) <= 0 {
-            openssl_sys::EVP_PKEY_CTX_free(ctx);
-            return Err(TxError::new(
-                ErrorCode::TxErrParse,
-                "openssl: EVP_PKEY_keygen_init failed",
-            ));
-        }
-        let mut pkey: *mut openssl_sys::EVP_PKEY = core::ptr::null_mut();
-        if openssl_sys::EVP_PKEY_keygen(ctx, &mut pkey) <= 0 || pkey.is_null() {
-            openssl_sys::EVP_PKEY_CTX_free(ctx);
-            return Err(TxError::new(
-                ErrorCode::TxErrParse,
-                "openssl: EVP_PKEY_keygen failed",
-            ));
-        }
-        openssl_sys::EVP_PKEY_CTX_free(ctx);
+fn openssl_parse_error(message: &'static str) -> TxError {
+    TxError::new(ErrorCode::TxErrParse, message)
+}
 
+fn read_mldsa87_pubkey(pkey: *mut openssl_sys::EVP_PKEY) -> Result<Vec<u8>, TxError> {
+    unsafe {
+        // SAFETY: pkey is a live EVP_PKEY owned by the caller. The output
+        // buffer is ML_DSA_87_PUBKEY_BYTES long, and OpenSSL writes at most the
+        // provided length through pubkey_len. On failure or non-canonical length
+        // this helper consumes and frees pkey so no partially initialized keypair
+        // can leak ownership.
         let mut pubkey = vec![0u8; ML_DSA_87_PUBKEY_BYTES as usize];
         let mut pubkey_len = pubkey.len();
         if ffi::EVP_PKEY_get_raw_public_key(pkey, pubkey.as_mut_ptr(), &mut pubkey_len) <= 0 {
             openssl_sys::EVP_PKEY_free(pkey);
-            return Err(TxError::new(
-                ErrorCode::TxErrParse,
+            return Err(openssl_parse_error(
                 "openssl: EVP_PKEY_get_raw_public_key failed",
             ));
         }
@@ -67,28 +47,21 @@ fn generate_mldsa87_keypair() -> Result<(*mut openssl_sys::EVP_PKEY, Vec<u8>), T
                 "openssl: non-canonical ML-DSA public key length",
             ));
         }
-        Ok((pkey, pubkey))
+        Ok(pubkey)
     }
 }
 
-fn sign_mldsa87_digest32(
+fn new_digest_sign_ctx(
     pkey: *mut openssl_sys::EVP_PKEY,
-    digest32: [u8; 32],
-) -> Result<Vec<u8>, TxError> {
-    if pkey.is_null() {
-        return Err(TxError::new(
-            ErrorCode::TxErrParse,
-            "openssl: nil ML-DSA keypair",
-        ));
-    }
+) -> Result<*mut openssl_sys::EVP_MD_CTX, TxError> {
     unsafe {
-        openssl_sys::ERR_clear_error();
+        // SAFETY: pkey is a non-null live EVP_PKEY owned by Mldsa87Keypair for
+        // the duration of signing. OpenSSL allocates mctx here; every failure
+        // after allocation frees it before returning, while success transfers the
+        // context to sign_mldsa87_digest for exactly one signing operation.
         let mctx = ffi::EVP_MD_CTX_new();
         if mctx.is_null() {
-            return Err(TxError::new(
-                ErrorCode::TxErrParse,
-                "openssl: EVP_MD_CTX_new failed",
-            ));
+            return Err(openssl_parse_error("openssl: EVP_MD_CTX_new failed"));
         }
         if ffi::EVP_DigestSignInit_ex(
             mctx,
@@ -101,11 +74,21 @@ fn sign_mldsa87_digest32(
         ) <= 0
         {
             ffi::EVP_MD_CTX_free(mctx);
-            return Err(TxError::new(
-                ErrorCode::TxErrParse,
-                "openssl: EVP_DigestSignInit_ex failed",
-            ));
+            return Err(openssl_parse_error("openssl: EVP_DigestSignInit_ex failed"));
         }
+        Ok(mctx)
+    }
+}
+
+fn sign_mldsa87_digest(
+    mctx: *mut openssl_sys::EVP_MD_CTX,
+    digest32: [u8; 32],
+) -> Result<Vec<u8>, TxError> {
+    unsafe {
+        // SAFETY: mctx is returned by new_digest_sign_ctx and is valid until this
+        // function frees it on every path. signature is allocated to the maximum
+        // ML-DSA-87 signature size, sig_len points to its current capacity, and
+        // digest32 is an owned 32-byte digest with a stable pointer for the call.
         let mut signature = vec![0u8; ML_DSA_87_SIG_BYTES as usize];
         let mut sig_len = signature.len();
         if ffi::EVP_DigestSign(
@@ -131,6 +114,69 @@ fn sign_mldsa87_digest32(
         }
         signature.truncate(sig_len);
         Ok(signature)
+    }
+}
+
+impl Drop for Mldsa87Keypair {
+    fn drop(&mut self) {
+        unsafe {
+            // SAFETY: pkey ownership is unique to this keypair. The null check
+            // makes Drop idempotent against earlier explicit cleanup paths.
+            if !self.pkey.is_null() {
+                openssl_sys::EVP_PKEY_free(self.pkey);
+                self.pkey = core::ptr::null_mut();
+            }
+        }
+    }
+}
+
+impl Mldsa87Keypair {
+    pub fn generate() -> Result<Self, TxError> {
+        ensure_openssl_bootstrap()?;
+        let alg = suite_alg_name(SUITE_ID_ML_DSA_87)?;
+        unsafe {
+            // SAFETY: alg is a static NUL-terminated CStr selected from the
+            // canonical suite registry. ctx is freed on every error path after
+            // allocation. On successful keygen, pkey ownership is either consumed
+            // by read_mldsa87_pubkey on failure or stored in Mldsa87Keypair.
+            openssl_sys::ERR_clear_error();
+            let ctx = ffi::EVP_PKEY_CTX_new_from_name(
+                core::ptr::null_mut(),
+                alg.as_ptr(),
+                core::ptr::null(),
+            );
+            if ctx.is_null() {
+                return Err(openssl_parse_error(
+                    "openssl: EVP_PKEY_CTX_new_from_name failed",
+                ));
+            }
+            if openssl_sys::EVP_PKEY_keygen_init(ctx) <= 0 {
+                openssl_sys::EVP_PKEY_CTX_free(ctx);
+                return Err(openssl_parse_error("openssl: EVP_PKEY_keygen_init failed"));
+            }
+            let mut pkey: *mut openssl_sys::EVP_PKEY = core::ptr::null_mut();
+            if openssl_sys::EVP_PKEY_keygen(ctx, &mut pkey) <= 0 || pkey.is_null() {
+                openssl_sys::EVP_PKEY_CTX_free(ctx);
+                return Err(openssl_parse_error("openssl: EVP_PKEY_keygen failed"));
+            }
+            openssl_sys::EVP_PKEY_CTX_free(ctx);
+            let pubkey = read_mldsa87_pubkey(pkey)?;
+            Ok(Self { pkey, pubkey })
+        }
+    }
+
+    pub fn pubkey_bytes(&self) -> Vec<u8> {
+        self.pubkey.clone()
+    }
+
+    pub fn sign_digest32(&self, digest32: [u8; 32]) -> Result<Vec<u8>, TxError> {
+        if self.pkey.is_null() {
+            return Err(openssl_parse_error("openssl: nil ML-DSA keypair"));
+        }
+        // SAFETY: ERR_clear_error only resets OpenSSL's thread-local error queue.
+        unsafe { openssl_sys::ERR_clear_error() };
+        let mctx = new_digest_sign_ctx(self.pkey)?;
+        sign_mldsa87_digest(mctx, digest32)
     }
 }
 

--- a/clients/rust/crates/rubin-consensus/src/verify_sig_openssl/bootstrap.rs
+++ b/clients/rust/crates/rubin-consensus/src/verify_sig_openssl/bootstrap.rs
@@ -1,0 +1,55 @@
+use crate::error::{ErrorCode, TxError};
+use std::sync::OnceLock;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum OpenSslFipsMode {
+    Off,
+    Ready,
+    Only,
+}
+
+static OPENSSL_BOOTSTRAP_STATE: OnceLock<Result<(), TxError>> = OnceLock::new();
+
+pub(crate) fn parse_openssl_fips_mode(raw: &str) -> Result<OpenSslFipsMode, TxError> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "" | "off" => Ok(OpenSslFipsMode::Off),
+        "ready" => Ok(OpenSslFipsMode::Ready),
+        "only" => Ok(OpenSslFipsMode::Only),
+        _ => Err(TxError::new(
+            ErrorCode::TxErrParse,
+            "openssl bootstrap: invalid RUBIN_OPENSSL_FIPS_MODE",
+        )),
+    }
+}
+
+pub(super) fn ensure_openssl_bootstrap() -> Result<(), TxError> {
+    let mode_raw = std::env::var("RUBIN_OPENSSL_FIPS_MODE").unwrap_or_default();
+    let mode = parse_openssl_fips_mode(&mode_raw)?;
+    ensure_openssl_bootstrap_for_mode(mode)
+}
+
+fn ensure_openssl_bootstrap_for_mode(mode: OpenSslFipsMode) -> Result<(), TxError> {
+    if mode == OpenSslFipsMode::Off {
+        return Ok(());
+    }
+
+    let require_fips = mode == OpenSslFipsMode::Only;
+    let state = OPENSSL_BOOTSTRAP_STATE.get_or_init(|| super::openssl_bootstrap(require_fips));
+    state.clone()
+}
+
+#[cfg(test)]
+pub(crate) fn test_set_env_if_empty(key: &str, value: Option<String>) {
+    super::set_env_if_empty(key, value);
+}
+
+#[cfg(test)]
+pub(crate) fn test_ensure_openssl_bootstrap_for_mode(mode_raw: &str) -> Result<(), TxError> {
+    let mode = parse_openssl_fips_mode(mode_raw)?;
+    ensure_openssl_bootstrap_for_mode(mode)
+}
+
+#[cfg(test)]
+pub(crate) fn test_openssl_check_sigalg_bad_alg() -> Result<(), TxError> {
+    super::openssl_check_sigalg(c"NOT-A-REAL-SIGALG", c"")
+}

--- a/clients/rust/crates/rubin-consensus/src/verify_sig_openssl/ffi.rs
+++ b/clients/rust/crates/rubin-consensus/src/verify_sig_openssl/ffi.rs
@@ -1,0 +1,61 @@
+extern "C" {
+    pub(super) fn EVP_PKEY_CTX_new_from_name(
+        libctx: *mut core::ffi::c_void,
+        name: *const core::ffi::c_char,
+        propq: *const core::ffi::c_char,
+    ) -> *mut openssl_sys::EVP_PKEY_CTX;
+    pub(super) fn EVP_PKEY_new_raw_public_key_ex(
+        libctx: *mut core::ffi::c_void,
+        keytype: *const core::ffi::c_char,
+        propq: *const core::ffi::c_char,
+        key: *const core::ffi::c_uchar,
+        keylen: usize,
+    ) -> *mut openssl_sys::EVP_PKEY;
+    pub(super) fn EVP_MD_CTX_new() -> *mut openssl_sys::EVP_MD_CTX;
+    pub(super) fn EVP_MD_CTX_free(ctx: *mut openssl_sys::EVP_MD_CTX);
+    pub(super) fn EVP_DigestVerifyInit_ex(
+        ctx: *mut openssl_sys::EVP_MD_CTX,
+        pctx: *mut *mut openssl_sys::EVP_PKEY_CTX,
+        mdname: *const core::ffi::c_char,
+        libctx: *mut core::ffi::c_void,
+        props: *const core::ffi::c_char,
+        pkey: *mut openssl_sys::EVP_PKEY,
+        params: *const core::ffi::c_void,
+    ) -> core::ffi::c_int;
+    pub(super) fn EVP_DigestVerify(
+        ctx: *mut openssl_sys::EVP_MD_CTX,
+        sigret: *const core::ffi::c_uchar,
+        siglen: usize,
+        tbs: *const core::ffi::c_uchar,
+        tbslen: usize,
+    ) -> core::ffi::c_int;
+    pub(super) fn EVP_DigestSignInit_ex(
+        ctx: *mut openssl_sys::EVP_MD_CTX,
+        pctx: *mut *mut openssl_sys::EVP_PKEY_CTX,
+        mdname: *const core::ffi::c_char,
+        libctx: *mut core::ffi::c_void,
+        props: *const core::ffi::c_char,
+        pkey: *mut openssl_sys::EVP_PKEY,
+        params: *const core::ffi::c_void,
+    ) -> core::ffi::c_int;
+    pub(super) fn EVP_DigestSign(
+        ctx: *mut openssl_sys::EVP_MD_CTX,
+        sigret: *mut core::ffi::c_uchar,
+        siglen: *mut usize,
+        tbs: *const core::ffi::c_uchar,
+        tbslen: usize,
+    ) -> core::ffi::c_int;
+    pub(super) fn OPENSSL_init_crypto(
+        opts: u64,
+        settings: *const core::ffi::c_void,
+    ) -> core::ffi::c_int;
+    pub(super) fn EVP_set_default_properties(
+        libctx: *mut core::ffi::c_void,
+        propq: *const core::ffi::c_char,
+    ) -> core::ffi::c_int;
+    pub(super) fn EVP_PKEY_get_raw_public_key(
+        pkey: *const openssl_sys::EVP_PKEY,
+        pub_: *mut core::ffi::c_uchar,
+        publen: *mut usize,
+    ) -> core::ffi::c_int;
+}

--- a/clients/rust/crates/rubin-consensus/src/verify_sig_openssl/keypair.rs
+++ b/clients/rust/crates/rubin-consensus/src/verify_sig_openssl/keypair.rs
@@ -1,0 +1,33 @@
+use crate::error::TxError;
+
+pub struct Mldsa87Keypair {
+    pub(super) pkey: *mut openssl_sys::EVP_PKEY,
+    pub(super) pubkey: Vec<u8>,
+}
+
+impl Drop for Mldsa87Keypair {
+    fn drop(&mut self) {
+        unsafe {
+            // SAFETY: pkey ownership is unique to this keypair and is released at most once.
+            if !self.pkey.is_null() {
+                openssl_sys::EVP_PKEY_free(self.pkey);
+                self.pkey = core::ptr::null_mut();
+            }
+        }
+    }
+}
+
+impl Mldsa87Keypair {
+    pub fn generate() -> Result<Self, TxError> {
+        let (pkey, pubkey) = super::generate_mldsa87_keypair()?;
+        Ok(Self { pkey, pubkey })
+    }
+
+    pub fn pubkey_bytes(&self) -> Vec<u8> {
+        self.pubkey.clone()
+    }
+
+    pub fn sign_digest32(&self, digest32: [u8; 32]) -> Result<Vec<u8>, TxError> {
+        super::sign_mldsa87_digest32(self.pkey, digest32)
+    }
+}

--- a/clients/rust/crates/rubin-consensus/src/verify_sig_openssl/keypair.rs
+++ b/clients/rust/crates/rubin-consensus/src/verify_sig_openssl/keypair.rs
@@ -1,33 +1,4 @@
-use crate::error::TxError;
-
 pub struct Mldsa87Keypair {
     pub(super) pkey: *mut openssl_sys::EVP_PKEY,
     pub(super) pubkey: Vec<u8>,
-}
-
-impl Drop for Mldsa87Keypair {
-    fn drop(&mut self) {
-        unsafe {
-            // SAFETY: pkey ownership is unique to this keypair and is released at most once.
-            if !self.pkey.is_null() {
-                openssl_sys::EVP_PKEY_free(self.pkey);
-                self.pkey = core::ptr::null_mut();
-            }
-        }
-    }
-}
-
-impl Mldsa87Keypair {
-    pub fn generate() -> Result<Self, TxError> {
-        let (pkey, pubkey) = super::generate_mldsa87_keypair()?;
-        Ok(Self { pkey, pubkey })
-    }
-
-    pub fn pubkey_bytes(&self) -> Vec<u8> {
-        self.pubkey.clone()
-    }
-
-    pub fn sign_digest32(&self, digest32: [u8; 32]) -> Result<Vec<u8>, TxError> {
-        super::sign_mldsa87_digest32(self.pkey, digest32)
-    }
 }

--- a/clients/rust/crates/rubin-consensus/src/verify_sig_openssl/tests/mod.rs
+++ b/clients/rust/crates/rubin-consensus/src/verify_sig_openssl/tests/mod.rs
@@ -293,11 +293,14 @@ fn signing_ctx_rejects_public_only_key() {
         );
         assert!(!public_key.is_null(), "public-only EVP_PKEY allocation");
 
-        let mctx = super::new_digest_sign_ctx(public_key)
+        let public_only = Mldsa87Keypair {
+            pkey: public_key,
+            pubkey,
+        };
+        let mctx = super::new_digest_sign_ctx(&public_only)
             .expect("OpenSSL accepts public-only key at init before signing fails");
         let err = super::sign_mldsa87_digest(mctx, [0x42; 32])
             .expect_err("public-only EVP_PKEY must not sign a digest");
-        openssl_sys::EVP_PKEY_free(public_key);
         assert_eq!(err.code, ErrorCode::TxErrSigInvalid);
         assert_eq!(err.msg, "openssl: EVP_DigestSign failed");
     }
@@ -305,12 +308,12 @@ fn signing_ctx_rejects_public_only_key() {
 
 #[test]
 fn signing_ctx_rejects_null_key() {
-    let err = unsafe {
-        // SAFETY: null is an explicitly allowed defensive input that must fail
-        // before OpenSSL sees the pointer.
-        super::new_digest_sign_ctx(core::ptr::null_mut())
-    }
-    .expect_err("null EVP_PKEY must reject before OpenSSL sign init");
+    let keypair = Mldsa87Keypair {
+        pkey: core::ptr::null_mut(),
+        pubkey: vec![0; crate::constants::ML_DSA_87_PUBKEY_BYTES as usize],
+    };
+    let err = super::new_digest_sign_ctx(&keypair)
+        .expect_err("null EVP_PKEY must reject before OpenSSL sign init");
     assert_eq!(err.code, ErrorCode::TxErrParse);
     assert_eq!(err.msg, "openssl: nil ML-DSA keypair");
 }
@@ -322,9 +325,12 @@ fn signing_ctx_rejects_empty_key_at_init() {
         // before return. It has no key material, so sign init must reject it.
         let empty_key = openssl_sys::EVP_PKEY_new();
         assert!(!empty_key.is_null(), "empty EVP_PKEY allocation");
-        let err = super::new_digest_sign_ctx(empty_key)
+        let empty_keypair = Mldsa87Keypair {
+            pkey: empty_key,
+            pubkey: vec![0; crate::constants::ML_DSA_87_PUBKEY_BYTES as usize],
+        };
+        let err = super::new_digest_sign_ctx(&empty_keypair)
             .expect_err("empty EVP_PKEY must reject during OpenSSL sign init");
-        openssl_sys::EVP_PKEY_free(empty_key);
         assert_eq!(err.code, ErrorCode::TxErrParse);
         assert_eq!(err.msg, "openssl: EVP_DigestSignInit_ex failed");
     }

--- a/clients/rust/crates/rubin-consensus/src/verify_sig_openssl/tests/mod.rs
+++ b/clients/rust/crates/rubin-consensus/src/verify_sig_openssl/tests/mod.rs
@@ -306,9 +306,9 @@ fn signing_ctx_rejects_public_only_key() {
 #[test]
 fn signing_ctx_rejects_null_key() {
     let err = super::new_digest_sign_ctx(core::ptr::null_mut())
-        .expect_err("null EVP_PKEY must reject during OpenSSL sign init");
+        .expect_err("null EVP_PKEY must reject before OpenSSL sign init");
     assert_eq!(err.code, ErrorCode::TxErrParse);
-    assert_eq!(err.msg, "openssl: EVP_DigestSignInit_ex failed");
+    assert_eq!(err.msg, "openssl: nil ML-DSA keypair");
 }
 
 #[test]

--- a/clients/rust/crates/rubin-consensus/src/verify_sig_openssl/tests/mod.rs
+++ b/clients/rust/crates/rubin-consensus/src/verify_sig_openssl/tests/mod.rs
@@ -241,6 +241,19 @@ fn keypair_generate_pubkey_is_expected_length() {
 }
 
 #[test]
+fn read_pubkey_rejects_empty_key_and_consumes_it() {
+    unsafe {
+        // SAFETY: empty_key is allocated by OpenSSL and then transferred to
+        // read_mldsa87_pubkey, which frees it on this error path.
+        let empty_key = openssl_sys::EVP_PKEY_new();
+        assert!(!empty_key.is_null(), "empty EVP_PKEY allocation");
+        let err = super::read_mldsa87_pubkey(empty_key).expect_err("empty key has no raw pubkey");
+        assert_eq!(err.code, ErrorCode::TxErrParse);
+        assert_eq!(err.msg, "openssl: EVP_PKEY_get_raw_public_key failed");
+    }
+}
+
+#[test]
 fn keypair_pubkey_bytes_is_copy() {
     let Some(kp) = generate_or_skip() else { return };
     let a = kp.pubkey_bytes();

--- a/clients/rust/crates/rubin-consensus/src/verify_sig_openssl/tests/mod.rs
+++ b/clients/rust/crates/rubin-consensus/src/verify_sig_openssl/tests/mod.rs
@@ -304,6 +304,14 @@ fn signing_ctx_rejects_public_only_key() {
 }
 
 #[test]
+fn signing_ctx_rejects_null_key() {
+    let err = super::new_digest_sign_ctx(core::ptr::null_mut())
+        .expect_err("null EVP_PKEY must reject during OpenSSL sign init");
+    assert_eq!(err.code, ErrorCode::TxErrParse);
+    assert_eq!(err.msg, "openssl: EVP_DigestSignInit_ex failed");
+}
+
+#[test]
 fn keypair_close_idempotent() {
     let Some(kp) = generate_or_skip() else { return };
     drop(kp);

--- a/clients/rust/crates/rubin-consensus/src/verify_sig_openssl/tests/mod.rs
+++ b/clients/rust/crates/rubin-consensus/src/verify_sig_openssl/tests/mod.rs
@@ -305,10 +305,29 @@ fn signing_ctx_rejects_public_only_key() {
 
 #[test]
 fn signing_ctx_rejects_null_key() {
-    let err = super::new_digest_sign_ctx(core::ptr::null_mut())
-        .expect_err("null EVP_PKEY must reject before OpenSSL sign init");
+    let err = unsafe {
+        // SAFETY: null is an explicitly allowed defensive input that must fail
+        // before OpenSSL sees the pointer.
+        super::new_digest_sign_ctx(core::ptr::null_mut())
+    }
+    .expect_err("null EVP_PKEY must reject before OpenSSL sign init");
     assert_eq!(err.code, ErrorCode::TxErrParse);
     assert_eq!(err.msg, "openssl: nil ML-DSA keypair");
+}
+
+#[test]
+fn signing_ctx_rejects_empty_key_at_init() {
+    unsafe {
+        // SAFETY: empty_key is a live EVP_PKEY allocated by OpenSSL and freed
+        // before return. It has no key material, so sign init must reject it.
+        let empty_key = openssl_sys::EVP_PKEY_new();
+        assert!(!empty_key.is_null(), "empty EVP_PKEY allocation");
+        let err = super::new_digest_sign_ctx(empty_key)
+            .expect_err("empty EVP_PKEY must reject during OpenSSL sign init");
+        openssl_sys::EVP_PKEY_free(empty_key);
+        assert_eq!(err.code, ErrorCode::TxErrParse);
+        assert_eq!(err.msg, "openssl: EVP_DigestSignInit_ex failed");
+    }
 }
 
 #[test]

--- a/clients/rust/crates/rubin-consensus/src/verify_sig_openssl/tests/mod.rs
+++ b/clients/rust/crates/rubin-consensus/src/verify_sig_openssl/tests/mod.rs
@@ -120,6 +120,22 @@ fn parse_openssl_fips_mode_accepts_supported_values() {
 }
 
 #[test]
+fn parse_openssl_fips_mode_trims_and_ignores_case() {
+    assert_eq!(
+        parse_openssl_fips_mode(" OFF ").expect("trimmed off should parse"),
+        OpenSslFipsMode::Off
+    );
+    assert_eq!(
+        parse_openssl_fips_mode("\tReady\n").expect("trimmed ready should parse"),
+        OpenSslFipsMode::Ready
+    );
+    assert_eq!(
+        parse_openssl_fips_mode("Only").expect("case-insensitive only should parse"),
+        OpenSslFipsMode::Only
+    );
+}
+
+#[test]
 fn parse_openssl_fips_mode_rejects_unknown_value() {
     let err = parse_openssl_fips_mode("definitely-invalid")
         .expect_err("unknown mode must return parse error");
@@ -240,6 +256,27 @@ fn keypair_sign_digest_produces_expected_length() {
 }
 
 #[test]
+fn keypair_sign_digest_rejects_nil_private_key() {
+    let kp = Mldsa87Keypair {
+        pkey: core::ptr::null_mut(),
+        pubkey: vec![0xAB; crate::constants::ML_DSA_87_PUBKEY_BYTES as usize],
+    };
+    let pubkey = kp.pubkey_bytes();
+    assert_eq!(
+        pubkey.len(),
+        crate::constants::ML_DSA_87_PUBKEY_BYTES as usize
+    );
+    assert_eq!(pubkey[0], 0xAB);
+
+    let err = kp
+        .sign_digest32([0x42; 32])
+        .expect_err("nil pkey must reject before OpenSSL signing");
+    assert_eq!(err.code, ErrorCode::TxErrParse);
+    assert_eq!(err.msg, "openssl: nil ML-DSA keypair");
+    assert_eq!(kp.pubkey_bytes(), pubkey);
+}
+
+#[test]
 fn keypair_close_idempotent() {
     let Some(kp) = generate_or_skip() else { return };
     drop(kp);
@@ -267,6 +304,24 @@ fn verify_sig_empty_inputs_return_false_or_error() {
         Err(_) => {}
         Ok(true) => panic!("empty inputs must not verify as true"),
     }
+}
+
+#[test]
+fn openssl_digest_oneshot_rejects_empty_input_before_ffi() {
+    let err = super::openssl_verify_sig_digest_oneshot(c"ML-DSA-87", &[], &[1], &[1])
+        .expect_err("empty pubkey must reject before FFI");
+    assert_eq!(err.code, ErrorCode::TxErrParse);
+    assert_eq!(err.msg, "openssl: empty input");
+
+    let err = super::openssl_verify_sig_digest_oneshot(c"ML-DSA-87", &[1], &[], &[1])
+        .expect_err("empty signature must reject before FFI");
+    assert_eq!(err.code, ErrorCode::TxErrParse);
+    assert_eq!(err.msg, "openssl: empty input");
+
+    let err = super::openssl_verify_sig_digest_oneshot(c"ML-DSA-87", &[1], &[1], &[])
+        .expect_err("empty message must reject before FFI");
+    assert_eq!(err.code, ErrorCode::TxErrParse);
+    assert_eq!(err.msg, "openssl: empty input");
 }
 
 #[test]

--- a/clients/rust/crates/rubin-consensus/src/verify_sig_openssl/tests/mod.rs
+++ b/clients/rust/crates/rubin-consensus/src/verify_sig_openssl/tests/mod.rs
@@ -277,6 +277,33 @@ fn keypair_sign_digest_rejects_nil_private_key() {
 }
 
 #[test]
+fn signing_ctx_rejects_public_only_key() {
+    let Some(kp) = generate_or_skip() else { return };
+    let pubkey = kp.pubkey_bytes();
+    unsafe {
+        // SAFETY: public_key is owned by this test after successful OpenSSL
+        // allocation and is freed before return. The pubkey slice lives across
+        // the FFI call and has the canonical ML-DSA-87 public-key length.
+        let public_key = super::ffi::EVP_PKEY_new_raw_public_key_ex(
+            core::ptr::null_mut(),
+            c"ML-DSA-87".as_ptr(),
+            core::ptr::null(),
+            pubkey.as_ptr(),
+            pubkey.len(),
+        );
+        assert!(!public_key.is_null(), "public-only EVP_PKEY allocation");
+
+        let mctx = super::new_digest_sign_ctx(public_key)
+            .expect("OpenSSL accepts public-only key at init before signing fails");
+        let err = super::sign_mldsa87_digest(mctx, [0x42; 32])
+            .expect_err("public-only EVP_PKEY must not sign a digest");
+        openssl_sys::EVP_PKEY_free(public_key);
+        assert_eq!(err.code, ErrorCode::TxErrSigInvalid);
+        assert_eq!(err.msg, "openssl: EVP_DigestSign failed");
+    }
+}
+
+#[test]
 fn keypair_close_idempotent() {
     let Some(kp) = generate_or_skip() else { return };
     drop(kp);


### PR DESCRIPTION
Invariant:
Split the Rust OpenSSL verification facade shape across bootstrap, FFI, and keypair modules without changing OpenSSL verification behavior or public error surfaces.

Layer:
implementation

Files changed:
- clients/rust/crates/rubin-consensus/src/verify_sig_openssl.rs
- clients/rust/crates/rubin-consensus/src/verify_sig_openssl/bootstrap.rs
- clients/rust/crates/rubin-consensus/src/verify_sig_openssl/ffi.rs
- clients/rust/crates/rubin-consensus/src/verify_sig_openssl/keypair.rs
- clients/rust/crates/rubin-consensus/src/verify_sig_openssl/tests/mod.rs

Behavior impact:
No intended behavior change. FFI signatures, OpenSSL bootstrap mapping, keypair ownership/free ordering, and public error strings are preserved.

Non-goals:
- No Cargo changes.
- No Go changes.
- No conformance, formal, CI, fixture, or generated artifact changes.
- No crypto policy or consensus behavior change.

Validation:
- `scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo fmt --check'`
- `git diff --check`
- `python3 -m lizard -l rust clients/rust/crates/rubin-consensus/src/verify_sig_openssl.rs clients/rust/crates/rubin-consensus/src/verify_sig_openssl/bootstrap.rs clients/rust/crates/rubin-consensus/src/verify_sig_openssl/ffi.rs clients/rust/crates/rubin-consensus/src/verify_sig_openssl/keypair.rs clients/rust/crates/rubin-consensus/src/verify_sig_openssl/digest.rs clients/rust/crates/rubin-consensus/src/verify_sig_openssl/alg.rs clients/rust/crates/rubin-consensus/src/verify_sig_openssl/binding.rs`
- `scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test -p rubin-consensus verify_sig_openssl -- --test-threads=16 --nocapture'`
- `scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo clippy -p rubin-consensus -- -D warnings'`
- `scripts/dev-env.sh -- python3 tools/check_consensus_openssl_isolation.py clients/go/consensus/verify_sig_openssl.go clients/rust/crates/rubin-consensus/src/verify_sig_openssl.rs`
- `/Users/gpt/bin/rubin-precommit-one-review --repo /Users/gpt/Documents/rubin-protocol-codex-RUB-264 --base-ref origin/main --include-base-diff`
- one isolated read-only raw-diff reviewer: No findings
- `/Users/gpt/bin/rubin-push --repo /Users/gpt/Documents/rubin-protocol-codex-RUB-264 --base-ref origin/main --coverage-cmd "scripts/dev-env.sh -- ./scripts/preflight-codacy-coverage.sh" -- origin HEAD`

### Parity exemption justification
This PR is a Rust-only file-shape split inside the existing OpenSSL verification implementation. It preserves FFI signatures, keypair ownership/free ordering, OpenSSL bootstrap/error mapping, and public error strings; no matching Go change is required because the executable verification behavior is unchanged.
