### PR TITLE
[Q-CODACY-TEST-FUZZ-ONLY-CLEANUP-01] Reduce test/fuzz Codacy rows

### DIFF
--- a/clients/rust/crates/rubin-consensus/src/coverage_hotspots_tests.rs
+++ b/clients/rust/crates/rubin-consensus/src/coverage_hotspots_tests.rs
@@ -113,7 +113,8 @@ fn htlc_entry(covenant_data: Vec<u8>) -> UtxoEntry {
 
 fn htlc_claim_selector(selector_key_id: [u8; 32], preimage: &[u8]) -> WitnessItem {
     let mut sig = vec![0x00];
-    sig.extend_from_slice(&(preimage.len() as u16).to_le_bytes());
+    let preimage_len = u16::try_from(preimage.len()).expect("test preimage length fits u16");
+    sig.extend_from_slice(&preimage_len.to_le_bytes());
     sig.extend_from_slice(preimage);
     WitnessItem {
         suite_id: SUITE_ID_SENTINEL,
@@ -128,6 +129,81 @@ fn htlc_refund_selector(selector_key_id: [u8; 32]) -> WitnessItem {
         pubkey: selector_key_id.to_vec(),
         signature: vec![0x01],
     }
+}
+
+fn sentinel_witness(pubkey: Vec<u8>, signature: Vec<u8>) -> WitnessItem {
+    WitnessItem {
+        suite_id: SUITE_ID_SENTINEL,
+        pubkey,
+        signature,
+    }
+}
+
+fn mldsa_witness(pubkey_fill: u8, signature_fill: u8) -> WitnessItem {
+    WitnessItem {
+        suite_id: SUITE_ID_ML_DSA_87,
+        pubkey: mldsa_pubkey(pubkey_fill),
+        signature: mldsa_signature(signature_fill),
+    }
+}
+
+fn invalid_sig_alg_witness() -> WitnessItem {
+    WitnessItem {
+        suite_id: 0xff,
+        pubkey: vec![],
+        signature: vec![],
+    }
+}
+
+fn htlc_spend_error_code(
+    entry: &UtxoEntry,
+    path: &WitnessItem,
+    sig: &WitnessItem,
+    block_height: u64,
+    block_time: u64,
+) -> ErrorCode {
+    validate_htlc_spend(
+        entry,
+        path,
+        sig,
+        &base_tx(),
+        0,
+        100,
+        dummy_chain_id(),
+        block_height,
+        block_time,
+    )
+    .unwrap_err()
+    .code
+}
+
+fn assert_htlc_error_code(
+    entry: &UtxoEntry,
+    path: &WitnessItem,
+    sig: &WitnessItem,
+    block_height: u64,
+    block_time: u64,
+    expected: ErrorCode,
+) {
+    assert_eq!(
+        htlc_spend_error_code(entry, path, sig, block_height, block_time),
+        expected
+    );
+}
+
+fn assert_mature_htlc_error_code(
+    entry: &UtxoEntry,
+    path: &WitnessItem,
+    sig: &WitnessItem,
+    expected: ErrorCode,
+) {
+    assert_htlc_error_code(entry, path, sig, 0, 100, expected);
+}
+
+fn threshold_spend_error_code(keys: &[[u8; 32]], ws: &[WitnessItem]) -> ErrorCode {
+    validate_threshold_sig_spend(keys, 1, ws, &base_tx(), 0, 100, dummy_chain_id(), 0, "ctx")
+        .unwrap_err()
+        .code
 }
 
 fn openssl_env_lock() -> &'static Mutex<()> {
@@ -257,167 +333,59 @@ fn parse_htlc_covenant_data_rejects_invalid_variants() {
 fn validate_htlc_spend_rejects_selector_shape_errors() {
     let (claim_key_id, _, _, cov) = htlc_components(LOCK_MODE_HEIGHT, 5);
     let entry = htlc_entry(cov);
-    let path = WitnessItem {
+    let sig = mldsa_witness(1, 2);
+    let wrong_suite = WitnessItem {
         suite_id: 1,
         pubkey: vec![],
         signature: vec![],
     };
-    let sig = WitnessItem {
-        suite_id: SUITE_ID_ML_DSA_87,
-        pubkey: mldsa_pubkey(1),
-        signature: mldsa_signature(2),
-    };
-    let err = validate_htlc_spend(
-        &entry,
-        &path,
-        &sig,
-        &base_tx(),
-        0,
-        100,
-        dummy_chain_id(),
-        0,
-        0,
-    )
-    .unwrap_err();
-    assert_eq!(err.code, ErrorCode::TxErrParse);
+    assert_htlc_error_code(&entry, &wrong_suite, &sig, 0, 0, ErrorCode::TxErrParse);
 
-    let path = WitnessItem {
-        suite_id: SUITE_ID_SENTINEL,
-        pubkey: claim_key_id.to_vec(),
-        signature: vec![],
-    };
-    let err = validate_htlc_spend(
-        &entry,
-        &path,
-        &sig,
-        &base_tx(),
-        0,
-        100,
-        dummy_chain_id(),
-        0,
-        0,
-    )
-    .unwrap_err();
-    assert_eq!(err.code, ErrorCode::TxErrParse);
+    let empty_signature = sentinel_witness(claim_key_id.to_vec(), vec![]);
+    assert_htlc_error_code(&entry, &empty_signature, &sig, 0, 0, ErrorCode::TxErrParse);
 
-    let path = WitnessItem {
-        suite_id: SUITE_ID_SENTINEL,
-        pubkey: vec![1],
-        signature: vec![0],
-    };
-    let err = validate_htlc_spend(
-        &entry,
-        &path,
-        &sig,
-        &base_tx(),
-        0,
-        100,
-        dummy_chain_id(),
-        0,
-        0,
-    )
-    .unwrap_err();
-    assert_eq!(err.code, ErrorCode::TxErrParse);
+    let bad_key_len = sentinel_witness(vec![1], vec![0]);
+    assert_htlc_error_code(&entry, &bad_key_len, &sig, 0, 0, ErrorCode::TxErrParse);
 }
 
 #[test]
 fn validate_htlc_spend_rejects_claim_path_errors() {
     let (claim_key_id, _, preimage, cov) = htlc_components(LOCK_MODE_HEIGHT, 5);
     let entry = htlc_entry(cov);
-    let short = WitnessItem {
-        suite_id: SUITE_ID_SENTINEL,
-        pubkey: claim_key_id.to_vec(),
-        signature: vec![0x00, 0x01],
-    };
-    let sig = WitnessItem {
-        suite_id: SUITE_ID_ML_DSA_87,
-        pubkey: mldsa_pubkey(1),
-        signature: mldsa_signature(2),
-    };
-    let err = validate_htlc_spend(
-        &entry,
-        &short,
-        &sig,
-        &base_tx(),
-        0,
-        100,
-        dummy_chain_id(),
-        0,
-        0,
-    )
-    .unwrap_err();
-    assert_eq!(err.code, ErrorCode::TxErrParse);
+    let sig = mldsa_witness(1, 2);
+    let short = sentinel_witness(claim_key_id.to_vec(), vec![0x00, 0x01]);
+    assert_htlc_error_code(&entry, &short, &sig, 0, 0, ErrorCode::TxErrParse);
 
     let tiny_preimage = htlc_claim_selector(claim_key_id, &[1; 8]);
-    let err = validate_htlc_spend(
-        &entry,
-        &tiny_preimage,
-        &sig,
-        &base_tx(),
-        0,
-        100,
-        dummy_chain_id(),
-        0,
-        0,
-    )
-    .unwrap_err();
-    assert_eq!(err.code, ErrorCode::TxErrParse);
+    assert_htlc_error_code(&entry, &tiny_preimage, &sig, 0, 0, ErrorCode::TxErrParse);
 
-    let overflow_preimage = WitnessItem {
-        suite_id: SUITE_ID_SENTINEL,
-        pubkey: claim_key_id.to_vec(),
-        signature: {
-            let mut s = vec![0x00];
-            s.extend_from_slice(&257u16.to_le_bytes());
-            s.extend_from_slice(&vec![0u8; 257]);
-            s
-        },
-    };
-    let err = validate_htlc_spend(
+    let mut overflow_sig = vec![0x00];
+    overflow_sig.extend_from_slice(&257u16.to_le_bytes());
+    overflow_sig.extend_from_slice(&vec![0u8; 257]);
+    let overflow_preimage = sentinel_witness(claim_key_id.to_vec(), overflow_sig);
+    assert_htlc_error_code(
         &entry,
         &overflow_preimage,
         &sig,
-        &base_tx(),
-        0,
-        100,
-        dummy_chain_id(),
         0,
         0,
-    )
-    .unwrap_err();
-    assert_eq!(err.code, ErrorCode::TxErrParse);
+        ErrorCode::TxErrParse,
+    );
 
     let mut bad_preimage = preimage;
     bad_preimage[0] ^= 0xff;
     let path = htlc_claim_selector(claim_key_id, &bad_preimage);
-    let err = validate_htlc_spend(
-        &entry,
-        &path,
-        &sig,
-        &base_tx(),
-        0,
-        100,
-        dummy_chain_id(),
-        0,
-        0,
-    )
-    .unwrap_err();
-    assert_eq!(err.code, ErrorCode::TxErrSigInvalid);
+    assert_htlc_error_code(&entry, &path, &sig, 0, 0, ErrorCode::TxErrSigInvalid);
 
     let wrong_selector = htlc_claim_selector([0x33; 32], &preimage);
-    let err = validate_htlc_spend(
+    assert_htlc_error_code(
         &entry,
         &wrong_selector,
         &sig,
-        &base_tx(),
-        0,
-        100,
-        dummy_chain_id(),
         0,
         0,
-    )
-    .unwrap_err();
-    assert_eq!(err.code, ErrorCode::TxErrSigInvalid);
+        ErrorCode::TxErrSigInvalid,
+    );
 }
 
 #[test]
@@ -425,121 +393,39 @@ fn validate_htlc_spend_rejects_refund_and_signature_errors() {
     let (_, refund_key_id, _, cov) = htlc_components(LOCK_MODE_TIMESTAMP, 50);
     let entry = htlc_entry(cov);
     let path = htlc_refund_selector(refund_key_id);
-    let bad_sig = WitnessItem {
-        suite_id: 0xff,
-        pubkey: vec![],
-        signature: vec![],
-    };
-    let err = validate_htlc_spend(
+    let bad_sig = invalid_sig_alg_witness();
+    assert_htlc_error_code(
         &entry,
         &path,
         &bad_sig,
-        &base_tx(),
-        0,
-        100,
-        dummy_chain_id(),
         0,
         10,
-    )
-    .unwrap_err();
-    assert_eq!(err.code, ErrorCode::TxErrTimelockNotMet);
+        ErrorCode::TxErrTimelockNotMet,
+    );
 
-    let path = htlc_refund_selector(refund_key_id);
     let sig = WitnessItem {
         suite_id: SUITE_ID_ML_DSA_87,
         pubkey: mldsa_pubkey(1),
         signature: vec![0],
     };
-    let err = validate_htlc_spend(
-        &entry,
-        &path,
-        &sig,
-        &base_tx(),
-        0,
-        100,
-        dummy_chain_id(),
-        0,
-        100,
-    )
-    .unwrap_err();
     assert!(matches!(
-        err.code,
+        htlc_spend_error_code(&entry, &path, &sig, 0, 100),
         ErrorCode::TxErrSigNoncanonical
             | ErrorCode::TxErrSigInvalid
             | ErrorCode::TxErrSighashTypeInvalid
     ));
 
     let wrong_path = htlc_refund_selector([0x77; 32]);
-    let err = validate_htlc_spend(
-        &entry,
-        &wrong_path,
-        &bad_sig,
-        &base_tx(),
-        0,
-        100,
-        dummy_chain_id(),
-        0,
-        100,
-    )
-    .unwrap_err();
-    assert_eq!(err.code, ErrorCode::TxErrSigInvalid);
+    assert_mature_htlc_error_code(&entry, &wrong_path, &bad_sig, ErrorCode::TxErrSigInvalid);
 
-    let malformed_refund = WitnessItem {
-        suite_id: SUITE_ID_SENTINEL,
-        pubkey: refund_key_id.to_vec(),
-        signature: vec![0x01, 0x00],
-    };
-    let err = validate_htlc_spend(
-        &entry,
-        &malformed_refund,
-        &bad_sig,
-        &base_tx(),
-        0,
-        100,
-        dummy_chain_id(),
-        0,
-        100,
-    )
-    .unwrap_err();
-    assert_eq!(err.code, ErrorCode::TxErrParse);
+    let malformed_refund = sentinel_witness(refund_key_id.to_vec(), vec![0x01, 0x00]);
+    assert_mature_htlc_error_code(&entry, &malformed_refund, &bad_sig, ErrorCode::TxErrParse);
 
-    let good_sig_shape = WitnessItem {
-        suite_id: SUITE_ID_ML_DSA_87,
-        pubkey: mldsa_pubkey(9),
-        signature: mldsa_signature(8),
-    };
-    let err = validate_htlc_spend(
-        &entry,
-        &path,
-        &good_sig_shape,
-        &base_tx(),
-        0,
-        100,
-        dummy_chain_id(),
-        0,
-        100,
-    )
-    .unwrap_err();
-    assert_eq!(err.code, ErrorCode::TxErrSigInvalid);
+    let good_sig_shape = mldsa_witness(9, 8);
+    assert_mature_htlc_error_code(&entry, &path, &good_sig_shape, ErrorCode::TxErrSigInvalid);
 
-    let wrong_suite = WitnessItem {
-        suite_id: 0xff,
-        pubkey: vec![],
-        signature: vec![],
-    };
-    let err = validate_htlc_spend(
-        &entry,
-        &path,
-        &wrong_suite,
-        &base_tx(),
-        0,
-        100,
-        dummy_chain_id(),
-        0,
-        100,
-    )
-    .unwrap_err();
-    assert_eq!(err.code, ErrorCode::TxErrSigAlgInvalid);
+    let wrong_suite = invalid_sig_alg_witness();
+    assert_mature_htlc_error_code(&entry, &path, &wrong_suite, ErrorCode::TxErrSigAlgInvalid);
 }
 
 #[test]
@@ -574,80 +460,44 @@ fn validate_p2pk_spend_rejects_canonicality_and_binding_errors() {
 
 #[test]
 fn validate_threshold_sig_spend_rejects_assignment_and_threshold_errors() {
-    let tx = base_tx();
     let keys = vec![[1u8; 32], [2u8; 32]];
-    let ws = vec![WitnessItem {
-        suite_id: SUITE_ID_SENTINEL,
-        pubkey: vec![],
-        signature: vec![],
-    }];
-    let err = validate_threshold_sig_spend(&keys, 1, &ws, &tx, 0, 100, dummy_chain_id(), 0, "ctx")
-        .unwrap_err();
-    assert_eq!(err.code, ErrorCode::TxErrParse);
+    let empty_selector = sentinel_witness(vec![], vec![]);
+    let bad_selector_key = sentinel_witness(vec![1], vec![]);
 
-    let ws = vec![
-        WitnessItem {
-            suite_id: SUITE_ID_SENTINEL,
-            pubkey: vec![1],
-            signature: vec![],
-        },
-        WitnessItem {
-            suite_id: SUITE_ID_SENTINEL,
-            pubkey: vec![],
-            signature: vec![],
-        },
-    ];
-    let err = validate_threshold_sig_spend(&keys, 1, &ws, &tx, 0, 100, dummy_chain_id(), 0, "ctx")
-        .unwrap_err();
-    assert_eq!(err.code, ErrorCode::TxErrParse);
+    let ws = vec![empty_selector.clone()];
+    assert_eq!(
+        threshold_spend_error_code(&keys, &ws),
+        ErrorCode::TxErrParse
+    );
 
-    let ws = vec![
-        WitnessItem {
-            suite_id: SUITE_ID_SENTINEL,
-            pubkey: vec![],
-            signature: vec![],
-        },
-        WitnessItem {
-            suite_id: SUITE_ID_SENTINEL,
-            pubkey: vec![],
-            signature: vec![],
-        },
-    ];
-    let err = validate_threshold_sig_spend(&keys, 1, &ws, &tx, 0, 100, dummy_chain_id(), 0, "ctx")
-        .unwrap_err();
-    assert_eq!(err.code, ErrorCode::TxErrSigInvalid);
+    let ws = vec![bad_selector_key, empty_selector.clone()];
+    assert_eq!(
+        threshold_spend_error_code(&keys, &ws),
+        ErrorCode::TxErrParse
+    );
 
-    let ws = vec![
-        WitnessItem {
-            suite_id: SUITE_ID_ML_DSA_87,
-            pubkey: vec![1],
-            signature: vec![1],
-        },
-        WitnessItem {
-            suite_id: SUITE_ID_SENTINEL,
-            pubkey: vec![],
-            signature: vec![],
-        },
-    ];
-    let err = validate_threshold_sig_spend(&keys, 1, &ws, &tx, 0, 100, dummy_chain_id(), 0, "ctx")
-        .unwrap_err();
-    assert_eq!(err.code, ErrorCode::TxErrSigNoncanonical);
+    let ws = vec![empty_selector.clone(), empty_selector.clone()];
+    assert_eq!(
+        threshold_spend_error_code(&keys, &ws),
+        ErrorCode::TxErrSigInvalid
+    );
 
-    let ws = vec![
-        WitnessItem {
-            suite_id: SUITE_ID_ML_DSA_87,
-            pubkey: mldsa_pubkey(1),
-            signature: mldsa_signature(2),
-        },
-        WitnessItem {
-            suite_id: SUITE_ID_SENTINEL,
-            pubkey: vec![],
-            signature: vec![],
-        },
-    ];
-    let err = validate_threshold_sig_spend(&keys, 1, &ws, &tx, 0, 100, dummy_chain_id(), 0, "ctx")
-        .unwrap_err();
-    assert_eq!(err.code, ErrorCode::TxErrSigInvalid);
+    let bad_sig_shape = WitnessItem {
+        suite_id: SUITE_ID_ML_DSA_87,
+        pubkey: vec![1],
+        signature: vec![1],
+    };
+    let ws = vec![bad_sig_shape, empty_selector.clone()];
+    assert_eq!(
+        threshold_spend_error_code(&keys, &ws),
+        ErrorCode::TxErrSigNoncanonical
+    );
+
+    let ws = vec![mldsa_witness(1, 2), empty_selector];
+    assert_eq!(
+        threshold_spend_error_code(&keys, &ws),
+        ErrorCode::TxErrSigInvalid
+    );
 }
 
 #[test]

--- a/clients/rust/fuzz/fuzz_targets/tx_relay_receive.rs
+++ b/clients/rust/fuzz/fuzz_targets/tx_relay_receive.rs
@@ -50,10 +50,6 @@ fn selected_network(tag: u8) -> &'static str {
     }
 }
 
-fn max_peers_tag() -> u8 {
-    u8::try_from(MAX_PEERS).expect("fuzz MAX_PEERS fits u8")
-}
-
 fn build_peer_state(addr: String) -> PeerState {
     PeerState {
         addr,
@@ -142,7 +138,8 @@ fuzz_target!(|data: &[u8]| {
         return;
     }
 
-    let peer_count = usize::from(data[0] % (max_peers_tag() + 1));
+    let max_peers_tag = u8::try_from(MAX_PEERS).expect("fuzz MAX_PEERS fits u8");
+    let peer_count = usize::from(data[0] % (max_peers_tag + 1));
     let network = selected_network(data[1]);
     let mode = data[2];
     let tx_bytes = sample_tx_bytes(mode, &data[3..]);

--- a/clients/rust/fuzz/fuzz_targets/tx_relay_receive.rs
+++ b/clients/rust/fuzz/fuzz_targets/tx_relay_receive.rs
@@ -9,7 +9,6 @@ use rubin_node::tx_relay::{handle_received_tx, PeerOutbox, TxRelayState};
 use rubin_node::{build_coinbase_tx, default_sync_config, ChainState, SyncEngine};
 
 const MAX_PEERS: usize = 6;
-const MAX_PEERS_TAG: u8 = 6;
 const MAX_RAW_BYTES: usize = 4096;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -51,6 +50,10 @@ fn selected_network(tag: u8) -> &'static str {
     }
 }
 
+fn max_peers_tag() -> u8 {
+    u8::try_from(MAX_PEERS).expect("fuzz MAX_PEERS fits u8")
+}
+
 fn build_peer_state(addr: String) -> PeerState {
     PeerState {
         addr,
@@ -78,7 +81,9 @@ impl ReceiveFixture {
         let outboxes = Mutex::new(HashMap::new());
         for idx in 0..peer_count.min(MAX_PEERS) {
             let addr = format!("peer-{idx}:8333");
-            let _ = peer_manager.add_peer(build_peer_state(addr.clone()));
+            peer_manager
+                .add_peer(build_peer_state(addr.clone()))
+                .expect("fuzz peer insertion");
             outboxes
                 .lock()
                 .expect("peer outboxes")
@@ -137,7 +142,7 @@ fuzz_target!(|data: &[u8]| {
         return;
     }
 
-    let peer_count = usize::from(data[0] % (MAX_PEERS_TAG + 1));
+    let peer_count = usize::from(data[0] % (max_peers_tag() + 1));
     let network = selected_network(data[1]);
     let mode = data[2];
     let tx_bytes = sample_tx_bytes(mode, &data[3..]);

--- a/clients/rust/fuzz/fuzz_targets/tx_relay_receive.rs
+++ b/clients/rust/fuzz/fuzz_targets/tx_relay_receive.rs
@@ -9,6 +9,7 @@ use rubin_node::tx_relay::{handle_received_tx, PeerOutbox, TxRelayState};
 use rubin_node::{build_coinbase_tx, default_sync_config, ChainState, SyncEngine};
 
 const MAX_PEERS: usize = 6;
+const MAX_PEERS_TAG: u8 = 6;
 const MAX_RAW_BYTES: usize = 4096;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -24,21 +25,21 @@ fn sample_tx_bytes(mode: u8, data: &[u8]) -> Vec<u8> {
         .expect("coinbase fixture");
     match mode % 4 {
         0 => base,
-        1 => {
-            let mut mutated = base;
-            if mutated.is_empty() {
-                return mutated;
-            }
-            let flips = data.len().clamp(1, 4);
-            for i in 0..flips {
-                let idx = usize::from(data.get(i).copied().unwrap_or(0)) % mutated.len();
-                mutated[idx] ^= data.get(i + 4).copied().unwrap_or(0xa5);
-            }
-            mutated
-        }
+        1 => mutate_sample_tx(base, data),
         2 => base[..base.len().saturating_sub(1)].to_vec(),
         _ => data[..data.len().min(MAX_RAW_BYTES)].to_vec(),
     }
+}
+
+fn mutate_sample_tx(mut tx: Vec<u8>, data: &[u8]) -> Vec<u8> {
+    if tx.is_empty() {
+        return tx;
+    }
+    for i in 0..data.len().clamp(1, 4) {
+        let idx = usize::from(data.get(i).copied().unwrap_or(0)) % tx.len();
+        tx[idx] ^= data.get(i + 4).copied().unwrap_or(0xa5);
+    }
+    tx
 }
 
 fn selected_network(tag: u8) -> &'static str {
@@ -63,110 +64,72 @@ fn sync_engine_for(network: &str) -> SyncEngine {
     SyncEngine::new(ChainState::new(), None, cfg).expect("sync engine")
 }
 
-fn run_once(network: &str, peer_count: usize, tx_bytes: &[u8]) -> ReceiveSnapshot {
-    let relay = TxRelayState::new_with_network(network);
-    let peer_manager = PeerManager::new(default_peer_runtime_config(network, peer_count.max(1)));
-    let outboxes: Mutex<HashMap<String, PeerOutbox>> = Mutex::new(HashMap::new());
-    for idx in 0..peer_count {
-        let addr = format!("peer-{idx}:8333");
-        let _ = peer_manager.add_peer(build_peer_state(addr.clone()));
-        outboxes
-            .lock()
-            .expect("peer outboxes")
-            .insert(addr, PeerOutbox::default());
+struct ReceiveFixture {
+    relay: TxRelayState,
+    peer_manager: PeerManager,
+    outboxes: Mutex<HashMap<String, PeerOutbox>>,
+    sync_engine: SyncEngine,
+}
+
+impl ReceiveFixture {
+    fn new(network: &str, peer_count: usize) -> Self {
+        let relay = TxRelayState::new_with_network(network);
+        let peer_manager = PeerManager::new(default_peer_runtime_config(network, peer_count.max(1)));
+        let outboxes = Mutex::new(HashMap::new());
+        for idx in 0..peer_count.min(MAX_PEERS) {
+            let addr = format!("peer-{idx}:8333");
+            let _ = peer_manager.add_peer(build_peer_state(addr.clone()));
+            outboxes
+                .lock()
+                .expect("peer outboxes")
+                .insert(addr, PeerOutbox::default());
+        }
+        Self {
+            relay,
+            peer_manager,
+            outboxes,
+            sync_engine: sync_engine_for(network),
+        }
     }
 
-    let sync_engine = sync_engine_for(network);
-    let result = handle_received_tx(
-        tx_bytes,
-        &sync_engine,
-        &relay,
-        &peer_manager,
-        "peer-0:8333",
-        "local:8333",
-        &outboxes,
-    );
-    let outboxes_snapshot = outboxes
-        .lock()
-        .expect("peer outboxes")
-        .iter()
-        .map(|(addr, queue)| (addr.clone(), queue.clone()))
-        .collect();
-    ReceiveSnapshot {
-        result: match result {
-            Ok(outcome) => format!("ok:{outcome:?}"),
-            Err(err) => format!("{:?}:{}", err.kind(), err),
-        },
-        tx_seen_len: relay.tx_seen.len(),
-        relay_pool_len: relay.relay_pool.len(),
-        outboxes: outboxes_snapshot,
+    fn receive(&self, tx_bytes: &[u8]) -> ReceiveSnapshot {
+        let result = handle_received_tx(
+            tx_bytes,
+            &self.sync_engine,
+            &self.relay,
+            &self.peer_manager,
+            "peer-0:8333",
+            "local:8333",
+            &self.outboxes,
+        );
+        ReceiveSnapshot {
+            result: match result {
+                Ok(outcome) => format!("ok:{outcome:?}"),
+                Err(err) => format!("{:?}:{}", err.kind(), err),
+            },
+            tx_seen_len: self.relay.tx_seen.len(),
+            relay_pool_len: self.relay.relay_pool.len(),
+            outboxes: self.snapshot_outboxes(),
+        }
+    }
+
+    fn snapshot_outboxes(&self) -> BTreeMap<String, PeerOutbox> {
+        self.outboxes
+            .lock()
+            .expect("peer outboxes")
+            .iter()
+            .map(|(addr, queue)| (addr.clone(), queue.clone()))
+            .collect()
     }
 }
 
-fn run_twice_same_state(network: &str, peer_count: usize, tx_bytes: &[u8]) -> (ReceiveSnapshot, ReceiveSnapshot) {
-    let relay = TxRelayState::new_with_network(network);
-    let peer_manager = PeerManager::new(default_peer_runtime_config(network, peer_count.max(1)));
-    let outboxes: Mutex<HashMap<String, PeerOutbox>> = Mutex::new(HashMap::new());
-    for idx in 0..peer_count {
-        let addr = format!("peer-{idx}:8333");
-        let _ = peer_manager.add_peer(build_peer_state(addr.clone()));
-        outboxes
-            .lock()
-            .expect("peer outboxes")
-            .insert(addr, PeerOutbox::default());
-    }
-    let sync_engine = sync_engine_for(network);
-
-    let first_result = handle_received_tx(
-        tx_bytes,
-        &sync_engine,
-        &relay,
-        &peer_manager,
-        "peer-0:8333",
-        "local:8333",
-        &outboxes,
-    );
-    let first_outboxes = outboxes
-        .lock()
-        .expect("peer outboxes")
-        .iter()
-        .map(|(addr, queue)| (addr.clone(), queue.clone()))
-        .collect();
-    let first = ReceiveSnapshot {
-        result: match first_result {
-            Ok(outcome) => format!("ok:{outcome:?}"),
-            Err(err) => format!("{:?}:{}", err.kind(), err),
-        },
-        tx_seen_len: relay.tx_seen.len(),
-        relay_pool_len: relay.relay_pool.len(),
-        outboxes: first_outboxes,
-    };
-
-    let second_result = handle_received_tx(
-        tx_bytes,
-        &sync_engine,
-        &relay,
-        &peer_manager,
-        "peer-0:8333",
-        "local:8333",
-        &outboxes,
-    );
-    let second_outboxes = outboxes
-        .lock()
-        .expect("peer outboxes")
-        .iter()
-        .map(|(addr, queue)| (addr.clone(), queue.clone()))
-        .collect();
-    let second = ReceiveSnapshot {
-        result: match second_result {
-            Ok(outcome) => format!("ok:{outcome:?}"),
-            Err(err) => format!("{:?}:{}", err.kind(), err),
-        },
-        tx_seen_len: relay.tx_seen.len(),
-        relay_pool_len: relay.relay_pool.len(),
-        outboxes: second_outboxes,
-    };
-    (first, second)
+fn run_twice_same_state(
+    network: &str,
+    peer_count: usize,
+    tx_bytes: &[u8],
+) -> (ReceiveSnapshot, ReceiveSnapshot) {
+    let fixture = ReceiveFixture::new(network, peer_count);
+    (fixture.receive(tx_bytes), fixture.receive(tx_bytes))
 }
 
 fuzz_target!(|data: &[u8]| {
@@ -174,40 +137,47 @@ fuzz_target!(|data: &[u8]| {
         return;
     }
 
-    let peer_count = usize::from(data[0] % (MAX_PEERS as u8 + 1));
+    let peer_count = usize::from(data[0] % (MAX_PEERS_TAG + 1));
     let network = selected_network(data[1]);
     let mode = data[2];
     let tx_bytes = sample_tx_bytes(mode, &data[3..]);
 
-    let first = run_once(network, peer_count, &tx_bytes);
-    let second = run_once(network, peer_count, &tx_bytes);
-    assert_eq!(first, second, "handle_received_tx must be deterministic on fresh state");
+    let first = ReceiveFixture::new(network, peer_count).receive(&tx_bytes);
+    let second = ReceiveFixture::new(network, peer_count).receive(&tx_bytes);
+    assert_eq!(
+        first, second,
+        "handle_received_tx must be deterministic on fresh state"
+    );
 
     if mode % 4 == 2 {
-        // Truncated tx: must surface as MalformedParse (ban-worthy per
-        // Go's `peer.handleTx` parse-fail / `bumpBan(10, ...)` parity),
-        // never plain "ok:Relayed".
-        assert!(
-            first.result.starts_with("ok:MalformedParse")
-                || first.result.starts_with("ok:Oversized")
-                || !first.result.starts_with("ok:"),
-            "truncated tx must not be accepted: {}",
-            first.result
-        );
-        assert_eq!(first.tx_seen_len, 0);
-        assert_eq!(first.relay_pool_len, 0);
-        assert!(first.outboxes.values().all(PeerOutbox::is_empty));
+        assert_truncated_tx_not_accepted(&first);
     }
 
     let (before, after) = run_twice_same_state(network, peer_count, &tx_bytes);
     assert_eq!(after.tx_seen_len, before.tx_seen_len);
     assert_eq!(after.relay_pool_len, before.relay_pool_len);
     assert_eq!(after.outboxes, before.outboxes);
+    assert_outbox_accounting(&after);
+});
 
-    for queue in after.outboxes.values() {
+fn assert_truncated_tx_not_accepted(snapshot: &ReceiveSnapshot) {
+    assert!(
+        snapshot.result.starts_with("ok:MalformedParse")
+            || snapshot.result.starts_with("ok:Oversized")
+            || !snapshot.result.starts_with("ok:"),
+        "truncated tx must not be accepted: {}",
+        snapshot.result
+    );
+    assert_eq!(snapshot.tx_seen_len, 0);
+    assert_eq!(snapshot.relay_pool_len, 0);
+    assert!(snapshot.outboxes.values().all(PeerOutbox::is_empty));
+}
+
+fn assert_outbox_accounting(snapshot: &ReceiveSnapshot) {
+    for queue in snapshot.outboxes.values() {
         let frame_bytes: usize = queue.frames().iter().map(Vec::len).sum();
         assert_eq!(queue.total_bytes(), frame_bytes);
         assert!(queue.len() <= 1);
         assert!(queue.total_bytes() <= (1 << 20));
     }
-});
+}


### PR DESCRIPTION
Invariant:
Reduce Codacy Lizard rows in test/fuzz-only Rust surfaces without changing runtime, consensus, fixture, or public behavior.

Layer:
tests / fuzz

Files changed:
- clients/rust/crates/rubin-consensus/src/coverage_hotspots_tests.rs
- clients/rust/fuzz/fuzz_targets/tx_relay_receive.rs

Tests:
- lizard_medium_rows.py on both touched files: PASS, 0 target rows
- cargo fmt --check in clients/rust: PASS
- cargo test -p rubin-consensus coverage_hotspots -- --nocapture: PASS, 17 passed
- cargo test -p rubin-consensus: PASS, 716 unit tests plus integration/fuzz-style tests passed
- cargo check --bin tx_relay_receive in clients/rust/fuzz: PASS
- rubin-precommit-one-review: PASS
- one isolated stock code-review subagent: No findings
- rubin-push with test/fuzz-only no-coverage reason: PASS

Behavior impact:
No production/runtime behavior change. Test and fuzz scaffolding only.

Compatibility impact:
No fixture, conformance, API, wire, or consensus compatibility impact.

Known non-goals:
No production consensus refactor, no runtime policy change, no Cargo.lock cleanup, no fixture changes.


<!-- rubin-agent-meta actor=unknown action=pr-create via=cl branch=codex/RUB-269-test-fuzz-codacy wt=rubin-protocol-codex-RUB-269 utc=2026-05-16T11:56:44Z -->
