### PR TITLE
RUB-271 reduce Go node policy helper Codacy rows

### DIFF
--- a/clients/go/node/mine_address.go
+++ b/clients/go/node/mine_address.go
@@ -44,7 +44,6 @@ func ParseMineAddress(value string) ([]byte, error) {
 	if strings.HasPrefix(trimmed, "0x") || strings.HasPrefix(trimmed, "0X") {
 		trimmed = trimmed[2:]
 	}
-
 	if len(trimmed)%2 != 0 {
 		return nil, fmt.Errorf("mine_address: odd-length hex")
 	}
@@ -52,6 +51,10 @@ func ParseMineAddress(value string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("mine_address: %w", err)
 	}
+	return parseMineAddressRaw(raw)
+}
+
+func parseMineAddressRaw(raw []byte) ([]byte, error) {
 	switch len(raw) {
 	case mineAddressKeyIDBytes:
 		out := make([]byte, 0, consensus.MAX_P2PK_COVENANT_DATA)

--- a/clients/go/node/policy_core_ext.go
+++ b/clients/go/node/policy_core_ext.go
@@ -99,7 +99,15 @@ func RejectCoreExtTxPreActivation(
 			return reject, reason, err
 		}
 	}
+	return rejectCoreExtSpendsPreActivation(tx, utxos, height, profiles)
+}
 
+func rejectCoreExtSpendsPreActivation(
+	tx *consensus.Tx,
+	utxos map[consensus.Outpoint]consensus.UtxoEntry,
+	height uint64,
+	profiles consensus.CoreExtProfileProvider,
+) (reject bool, reason string, err error) {
 	if utxos == nil {
 		return false, "", nil
 	}

--- a/clients/go/node/policy_da_anchor.go
+++ b/clients/go/node/policy_da_anchor.go
@@ -87,27 +87,17 @@ func RejectDaAnchorTxPolicy(
 		// DA-specific term to non-DA transactions.
 		return false, 0, "", nil
 	}
-	relayFloor, err := mulU64NoOverflow(weight, currentMempoolMinFeeRate)
+	floor, reason, err := computeDaAnchorRequiredFee(
+		weight,
+		daBytes,
+		currentMempoolMinFeeRate,
+		minDaFeeRate,
+		daSurchargePerByte,
+	)
 	if err != nil {
-		return true, daBytes, fmt.Sprintf("relay fee floor overflow (weight=%d current_mempool_min_fee_rate=%d)", weight, currentMempoolMinFeeRate), err
+		return true, daBytes, reason, err
 	}
-	daFloor, err := mulU64NoOverflow(daBytes, minDaFeeRate)
-	if err != nil {
-		return true, daBytes, fmt.Sprintf("DA fee floor overflow (da_payload_len=%d min_da_fee_rate=%d)", daBytes, minDaFeeRate), err
-	}
-	daSurcharge, err := mulU64NoOverflow(daBytes, daSurchargePerByte)
-	if err != nil {
-		return true, daBytes, fmt.Sprintf("DA surcharge overflow (da_payload_len=%d surcharge_per_byte=%d)", daBytes, daSurchargePerByte), err
-	}
-	daRequired := daFloor
-	if err := addU64NoOverflow(&daRequired, daSurcharge); err != nil {
-		return true, daBytes, fmt.Sprintf("DA required fee overflow (da_fee_floor=%d da_surcharge=%d)", daFloor, daSurcharge), err
-	}
-	required := relayFloor
-	if daRequired > required {
-		required = daRequired
-	}
-	if required == 0 {
+	if floor.required == 0 {
 		// DA tx but every Stage C rate-derived fee term is zero: the
 		// relay-floor term is zero and both DA-side terms are zero.
 		// Nothing to enforce; admit without fee compute.
@@ -117,13 +107,62 @@ func RejectDaAnchorTxPolicy(
 	if err != nil {
 		return true, daBytes, "cannot compute fee for DA tx (policy)", err
 	}
-	if fee < required {
+	if fee < floor.required {
 		return true, daBytes, fmt.Sprintf(
 			"DA fee below Stage C floor (fee=%d required_fee=%d relay_fee_floor=%d da_fee_floor=%d da_surcharge=%d weight=%d da_payload_len=%d)",
-			fee, required, relayFloor, daFloor, daSurcharge, weight, daBytes,
+			fee, floor.required, floor.relayFloor, floor.daFloor, floor.daSurcharge, weight, daBytes,
 		), nil
 	}
 	return false, daBytes, "", nil
+}
+
+type daAnchorRequiredFee struct {
+	relayFloor  uint64
+	daFloor     uint64
+	daSurcharge uint64
+	required    uint64
+}
+
+func computeDaAnchorRequiredFee(
+	weight uint64,
+	daBytes uint64,
+	currentMempoolMinFeeRate uint64,
+	minDaFeeRate uint64,
+	daSurchargePerByte uint64,
+) (daAnchorRequiredFee, string, error) {
+	relayFloor, err := mulU64NoOverflow(weight, currentMempoolMinFeeRate)
+	if err != nil {
+		return daAnchorRequiredFee{}, fmt.Sprintf("relay fee floor overflow (weight=%d current_mempool_min_fee_rate=%d)", weight, currentMempoolMinFeeRate), err
+	}
+	daFloor, err := mulU64NoOverflow(daBytes, minDaFeeRate)
+	if err != nil {
+		return daAnchorRequiredFee{}, fmt.Sprintf("DA fee floor overflow (da_payload_len=%d min_da_fee_rate=%d)", daBytes, minDaFeeRate), err
+	}
+	daSurcharge, err := mulU64NoOverflow(daBytes, daSurchargePerByte)
+	if err != nil {
+		return daAnchorRequiredFee{}, fmt.Sprintf("DA surcharge overflow (da_payload_len=%d surcharge_per_byte=%d)", daBytes, daSurchargePerByte), err
+	}
+	required, err := maxDaAnchorRequiredFee(relayFloor, daFloor, daSurcharge)
+	if err != nil {
+		return daAnchorRequiredFee{}, fmt.Sprintf("DA required fee overflow (da_fee_floor=%d da_surcharge=%d)", daFloor, daSurcharge), err
+	}
+	return daAnchorRequiredFee{
+		relayFloor:  relayFloor,
+		daFloor:     daFloor,
+		daSurcharge: daSurcharge,
+		required:    required,
+	}, "", nil
+}
+
+func maxDaAnchorRequiredFee(relayFloor uint64, daFloor uint64, daSurcharge uint64) (uint64, error) {
+	daRequired := daFloor
+	if err := addU64NoOverflow(&daRequired, daSurcharge); err != nil {
+		return 0, err
+	}
+	if daRequired > relayFloor {
+		return daRequired, nil
+	}
+	return relayFloor, nil
 }
 
 func computeFeeNoVerify(tx *consensus.Tx, utxos map[consensus.Outpoint]consensus.UtxoEntry) (uint64, error) {
@@ -136,6 +175,21 @@ func computeFeeNoVerify(tx *consensus.Tx, utxos map[consensus.Outpoint]consensus
 	if utxos == nil {
 		return 0, errors.New("nil utxo set")
 	}
+	sumIn, err := sumInputValueNoVerify(tx, utxos)
+	if err != nil {
+		return 0, err
+	}
+	sumOut, err := sumOutputValueNoVerify(tx)
+	if err != nil {
+		return 0, err
+	}
+	if sumOut > sumIn {
+		return 0, errors.New("overspend")
+	}
+	return sumIn - sumOut, nil
+}
+
+func sumInputValueNoVerify(tx *consensus.Tx, utxos map[consensus.Outpoint]consensus.UtxoEntry) (uint64, error) {
 	var sumIn uint64
 	for _, in := range tx.Inputs {
 		op := consensus.Outpoint{Txid: in.PrevTxid, Vout: in.PrevVout}
@@ -149,6 +203,10 @@ func computeFeeNoVerify(tx *consensus.Tx, utxos map[consensus.Outpoint]consensus
 		}
 		sumIn = next
 	}
+	return sumIn, nil
+}
+
+func sumOutputValueNoVerify(tx *consensus.Tx) (uint64, error) {
 	var sumOut uint64
 	for _, out := range tx.Outputs {
 		next := sumOut + out.Value
@@ -157,10 +215,7 @@ func computeFeeNoVerify(tx *consensus.Tx, utxos map[consensus.Outpoint]consensus
 		}
 		sumOut = next
 	}
-	if sumOut > sumIn {
-		return 0, errors.New("overspend")
-	}
-	return sumIn - sumOut, nil
+	return sumOut, nil
 }
 
 func mulU64NoOverflow(a uint64, b uint64) (uint64, error) {

--- a/clients/go/node/production_rotation_schedule.go
+++ b/clients/go/node/production_rotation_schedule.go
@@ -74,39 +74,16 @@ func loadCompiledProductionRotationScheduleFromJSONWithRegistry(
 	if err := decodeSingleJSONValue(raw, &wire); err != nil {
 		return nil, nil, productionRotationScheduleError("parse embedded artifact: %w", err)
 	}
-	if wire.Version != productionRotationScheduleVersion {
-		return nil, nil, productionRotationScheduleError(
-			"unsupported version %d (want %d)",
-			wire.Version,
-			productionRotationScheduleVersion,
-		)
-	}
-	for key := range wire.Networks {
-		if key != "mainnet" && key != "testnet" {
-			return nil, nil, productionRotationScheduleError(
-				"unknown networks.%s entry",
-				key,
-			)
-		}
+	if err := validateProductionRotationScheduleWire(wire); err != nil {
+		return nil, nil, err
 	}
 	schedule := &productionRotationSchedule{
 		Version:  wire.Version,
 		Networks: make(map[string]*consensus.CryptoRotationDescriptor, len(wire.Networks)),
 	}
-	parsedDescriptors := make(map[string]*RotationConfigJSON, len(wire.Networks))
-	for _, network := range []string{"mainnet", "testnet"} {
-		entryRaw, ok := wire.Networks[network]
-		if !ok {
-			return nil, nil, productionRotationScheduleError(
-				"networks.%s missing",
-				network,
-			)
-		}
-		descriptorJSON, err := parseProductionRotationScheduleDescriptorJSON(entryRaw, network)
-		if err != nil {
-			return nil, nil, err
-		}
-		parsedDescriptors[network] = descriptorJSON
+	parsedDescriptors, err := parseProductionRotationScheduleDescriptors(wire.Networks)
+	if err != nil {
+		return nil, nil, err
 	}
 	// The compiled production schedule is activation-only authority. When the
 	// caller does not supply an explicit canonical registry contract, fail
@@ -116,17 +93,47 @@ func loadCompiledProductionRotationScheduleFromJSONWithRegistry(
 		registry = consensus.DefaultSuiteRegistry()
 	}
 	for _, network := range []string{"mainnet", "testnet"} {
-		desc, err := buildProductionRotationScheduleDescriptor(
-			parsedDescriptors[network],
-			network,
-			registry,
-		)
+		desc, err := buildProductionRotationScheduleDescriptor(parsedDescriptors[network], network, registry)
 		if err != nil {
 			return nil, nil, err
 		}
 		schedule.Networks[network] = desc
 	}
 	return schedule, registry, nil
+}
+
+func validateProductionRotationScheduleWire(wire productionRotationScheduleWire) error {
+	if wire.Version != productionRotationScheduleVersion {
+		return productionRotationScheduleError(
+			"unsupported version %d (want %d)",
+			wire.Version,
+			productionRotationScheduleVersion,
+		)
+	}
+	for key := range wire.Networks {
+		if key != "mainnet" && key != "testnet" {
+			return productionRotationScheduleError("unknown networks.%s entry", key)
+		}
+	}
+	return nil
+}
+
+func parseProductionRotationScheduleDescriptors(
+	networks map[string]json.RawMessage,
+) (map[string]*RotationConfigJSON, error) {
+	parsedDescriptors := make(map[string]*RotationConfigJSON, len(networks))
+	for _, network := range []string{"mainnet", "testnet"} {
+		entryRaw, ok := networks[network]
+		if !ok {
+			return nil, productionRotationScheduleError("networks.%s missing", network)
+		}
+		descriptorJSON, err := parseProductionRotationScheduleDescriptorJSON(entryRaw, network)
+		if err != nil {
+			return nil, err
+		}
+		parsedDescriptors[network] = descriptorJSON
+	}
+	return parsedDescriptors, nil
 }
 
 func parseProductionRotationScheduleDescriptorJSON(
@@ -174,44 +181,67 @@ func buildProductionRotationScheduleDescriptor(
 }
 
 func (wire productionRotationDescriptorWire) toRotationConfigJSON() (RotationConfigJSON, error) {
-	name, err := requireProductionRotationScheduleField("name", wire.Name)
+	fields, err := wire.requiredFields()
 	if err != nil {
 		return RotationConfigJSON{}, err
-	}
-	oldSuiteID, err := requireProductionRotationScheduleField("old_suite_id", wire.OldSuiteID)
-	if err != nil {
-		return RotationConfigJSON{}, err
-	}
-	newSuiteID, err := requireProductionRotationScheduleField("new_suite_id", wire.NewSuiteID)
-	if err != nil {
-		return RotationConfigJSON{}, err
-	}
-	if err := rejectSentinelProductionRotationScheduleSuiteID("old_suite_id", oldSuiteID); err != nil {
-		return RotationConfigJSON{}, err
-	}
-	if err := rejectSentinelProductionRotationScheduleSuiteID("new_suite_id", newSuiteID); err != nil {
-		return RotationConfigJSON{}, err
-	}
-	createHeight, err := requireProductionRotationScheduleField("create_height", wire.CreateHeight)
-	if err != nil {
-		return RotationConfigJSON{}, err
-	}
-	spendHeight, err := requireProductionRotationScheduleField("spend_height", wire.SpendHeight)
-	if err != nil {
-		return RotationConfigJSON{}, err
-	}
-	var sunsetHeight uint64
-	if wire.SunsetHeight != nil {
-		sunsetHeight = *wire.SunsetHeight
 	}
 	return RotationConfigJSON{
-		Name:         name,
-		OldSuiteID:   oldSuiteID,
-		NewSuiteID:   newSuiteID,
-		CreateHeight: createHeight,
-		SpendHeight:  spendHeight,
-		SunsetHeight: sunsetHeight,
+		Name:         fields.name,
+		OldSuiteID:   fields.oldSuiteID,
+		NewSuiteID:   fields.newSuiteID,
+		CreateHeight: fields.createHeight,
+		SpendHeight:  fields.spendHeight,
+		SunsetHeight: fields.sunsetHeight,
 	}, nil
+}
+
+type productionRotationRequiredFields struct {
+	name         string
+	oldSuiteID   uint8
+	newSuiteID   uint8
+	createHeight uint64
+	spendHeight  uint64
+	sunsetHeight uint64
+}
+
+func (wire productionRotationDescriptorWire) requiredFields() (productionRotationRequiredFields, error) {
+	fields, err := requireProductionRotationScheduleIdentityFields(wire)
+	if err != nil {
+		return productionRotationRequiredFields{}, err
+	}
+	if err := rejectSentinelProductionRotationScheduleSuiteID("old_suite_id", fields.oldSuiteID); err != nil {
+		return productionRotationRequiredFields{}, err
+	}
+	if err := rejectSentinelProductionRotationScheduleSuiteID("new_suite_id", fields.newSuiteID); err != nil {
+		return productionRotationRequiredFields{}, err
+	}
+	if fields.createHeight, err = requireProductionRotationScheduleField("create_height", wire.CreateHeight); err != nil {
+		return productionRotationRequiredFields{}, err
+	}
+	if fields.spendHeight, err = requireProductionRotationScheduleField("spend_height", wire.SpendHeight); err != nil {
+		return productionRotationRequiredFields{}, err
+	}
+	if wire.SunsetHeight != nil {
+		fields.sunsetHeight = *wire.SunsetHeight
+	}
+	return fields, nil
+}
+
+func requireProductionRotationScheduleIdentityFields(
+	wire productionRotationDescriptorWire,
+) (productionRotationRequiredFields, error) {
+	var fields productionRotationRequiredFields
+	var err error
+	if fields.name, err = requireProductionRotationScheduleField("name", wire.Name); err != nil {
+		return productionRotationRequiredFields{}, err
+	}
+	if fields.oldSuiteID, err = requireProductionRotationScheduleField("old_suite_id", wire.OldSuiteID); err != nil {
+		return productionRotationRequiredFields{}, err
+	}
+	if fields.newSuiteID, err = requireProductionRotationScheduleField("new_suite_id", wire.NewSuiteID); err != nil {
+		return productionRotationRequiredFields{}, err
+	}
+	return fields, nil
 }
 
 func rejectSentinelProductionRotationScheduleSuiteID(field string, suiteID uint8) error {

--- a/clients/go/node/production_rotation_schedule_test.go
+++ b/clients/go/node/production_rotation_schedule_test.go
@@ -183,6 +183,7 @@ func TestLoadCompiledProductionRotationScheduleRejectsReservedSentinelSuiteID(t 
 		field      string
 		oldSuiteID int
 		newSuiteID int
+		fields     string
 		want       string
 	}{
 		{
@@ -190,6 +191,7 @@ func TestLoadCompiledProductionRotationScheduleRejectsReservedSentinelSuiteID(t 
 			field:      "old_suite_id",
 			oldSuiteID: 0,
 			newSuiteID: 66,
+			fields:     "",
 			want:       `production_rotation_schedule: networks.mainnet: old_suite_id 0x00 is the sentinel suite_id`,
 		},
 		{
@@ -197,6 +199,7 @@ func TestLoadCompiledProductionRotationScheduleRejectsReservedSentinelSuiteID(t 
 			field:      "new_suite_id",
 			oldSuiteID: 1,
 			newSuiteID: 0,
+			fields:     `, "create_height": 10, "spend_height": 20, "sunset_height": 30`,
 			want:       `production_rotation_schedule: networks.mainnet: new_suite_id 0x00 is the sentinel suite_id`,
 		},
 	}
@@ -210,10 +213,7 @@ func TestLoadCompiledProductionRotationScheduleRejectsReservedSentinelSuiteID(t 
 					"mainnet": {
 						"name": "rotation-v1",
 						"old_suite_id": `+strconv.Itoa(tc.oldSuiteID)+`,
-						"new_suite_id": `+strconv.Itoa(tc.newSuiteID)+`,
-						"create_height": 10,
-						"spend_height": 20,
-						"sunset_height": 30
+						"new_suite_id": `+strconv.Itoa(tc.newSuiteID)+tc.fields+`
 					},
 					"testnet": null
 				}


### PR DESCRIPTION
Refs: Q-CODACY-GO-NODE-RUNTIME-POLICY-HELPER-CLEANUP-01

## Summary

Linear: RUB-271

Invariant: reduce Go node runtime-policy helper Codacy rows without changing policy/runtime behavior.

Layer: implementation / policy.

## Scope

Files changed:
- clients/go/node/mine_address.go
- clients/go/node/policy_core_ext.go
- clients/go/node/policy_da_anchor.go
- clients/go/node/production_rotation_schedule.go
- clients/go/node/production_rotation_schedule_test.go

Boundary:
- Consensus rules unchanged: YES
- SECTION_HASHES.json unchanged: YES

Validation:
- gofmt via rubin-precommit-one-review
- git diff --check via rubin-precommit-one-review
- rubin learned-pattern gate PASS
- local lizard medium rows: 0 rows across changed files
- focused go test ./node policy/helper subset PASS
- full go test -v ./node -count=1 PASS
- one isolated stock code-review PASS after fixing validation-order finding

Non-goals:
- no consensus/conformance/Rust changes
- no policy behavior change
- no mempool/miner/sync/persistence redesign


<!-- rubin-agent-meta actor=unknown action=pr-edit via=cl branch=codex/RUB-271-go-node-policy-helper-cleanup wt=rubin-protocol-codex-RUB-271 utc=2026-05-16T15:40:46Z -->
