### PR TITLE
Q-CODACY-GO-CCN-MEMPOOL-01: reduce mempool CCN complexity — helper extraction

### DIFF
--- a/clients/go/node/mempolicy_helpers.go
+++ b/clients/go/node/mempolicy_helpers.go
@@ -1,0 +1,144 @@
+package node
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+)
+
+// validateChainSnapshot validates chain state snapshot and extracts next height
+func validateChainSnapshot(snapshot *chainStateAdmissionSnapshot) (uint64, error) {
+	if snapshot == nil {
+		return 0, txAdmitUnavailable("nil chainstate")
+	}
+	nextHeight, _, err := nextBlockContextFromFields(snapshot.hasTip, snapshot.height, snapshot.tipHash)
+	if err != nil {
+		return 0, txAdmitUnavailable(err.Error())
+	}
+	return nextHeight, nil
+}
+
+// buildPolicyInputSnapshotIfNeeded (mempool_precheck.go) replaced the old preparePolicyUtxos; callers use it directly.
+
+// validateTransactionWithConsensus performs consensus validation with configured profiles
+func (m *Mempool) validateTransactionWithConsensus(
+	txBytes []byte,
+	tx *consensus.Tx,
+	txid [32]byte,
+	wtxid [32]byte,
+	snapshot *chainStateAdmissionSnapshot,
+	nextHeight uint64,
+	blockMTP uint64,
+	policy MempoolConfig,
+) (*consensus.CheckedTransaction, error) {
+	checked, err := consensus.CheckParsedTransactionWithOwnedUtxoSetAndCoreExtProfilesAndSuiteContext(
+		txBytes,
+		tx,
+		txid,
+		wtxid,
+		snapshot.utxos,
+		nextHeight,
+		blockMTP,
+		m.chainID,
+		policy.CoreExtProfiles,
+		policy.RotationProvider,
+		policy.SuiteRegistry,
+	)
+	if err != nil {
+		return nil, txAdmitRejected(err.Error())
+	}
+	return checked, nil
+}
+
+// extractTxInputs extracts outpoints from checked transaction
+func extractTxInputs(checked *consensus.CheckedTransaction) []consensus.Outpoint {
+	inputs := make([]consensus.Outpoint, 0, len(checked.Tx.Inputs))
+	for _, in := range checked.Tx.Inputs {
+		inputs = append(inputs, consensus.Outpoint{Txid: in.PrevTxid, Vout: in.PrevVout})
+	}
+	return inputs
+}
+
+// applyPolicyAgainstStateDA handles DA fee policy application
+func applyPolicyAgainstStateDA(checked *consensus.CheckedTransaction, policy MempoolConfig, utxos map[consensus.Outpoint]consensus.UtxoEntry) error {
+	// Stage C DA fee policy: only enter the helper for DA-bearing tx when
+	// the DA-side floor is configured (MinDaFeeRate > 0) or a per-byte
+	// surcharge applies. Non-DA tx skip the helper entirely on the hot
+	// admit path; their relay-floor handling remains in
+	// validateFeeFloorLocked.
+	//
+	// The mempool admit path enforces the rolling relay-fee floor through
+	// validateFeeFloorLocked (TxAdmitUnavailable — transient/retryable),
+	// so this caller intentionally passes currentMempoolMinFeeRate=0 so
+	// max(relay_fee_floor, da_required_fee) collapses to da_required_fee.
+	// Without the zero override, a DA tx that pays the DA-side floor but
+	// not the rolling relay floor would surface here as TxAdmitRejected
+	// ("DA fee below Stage C floor ... relay_fee_floor=...") instead of
+	// the symmetric TxAdmitUnavailable that non-DA tx receive from
+	// validateFeeFloorLocked. With currentMin=0 the helper enforces only
+	// the DA-specific terms and validateFeeFloorLocked owns relay-floor
+	// classification uniformly for both DA and non-DA admissions.
+	//
+	// The miner caller (rejectCandidate) keeps using the live rolling
+	// floor because it has no validateFeeFloorLocked equivalent — the
+	// miner template needs to skip a tx whenever it fails any floor.
+	if checked.DaBytes > 0 && (policy.MinDaFeeRate > 0 || policy.PolicyDaSurchargePerByte > 0) {
+		reject, _, reason, err := RejectDaAnchorTxPolicy(
+			checked.Tx,
+			utxos,
+			0,
+			policy.MinDaFeeRate,
+			policy.PolicyDaSurchargePerByte,
+		)
+		if err != nil {
+			return txAdmitRejected(fmt.Sprintf("%s: %v", reason, err))
+		}
+		if reject {
+			return txAdmitRejected(reason)
+		}
+	}
+	return nil
+}
+
+// applyPolicyAgainstStateCoreExt handles CoreExt policy application
+func applyPolicyAgainstStateCoreExt(checked *consensus.CheckedTransaction, utxos map[consensus.Outpoint]consensus.UtxoEntry, nextHeight uint64, policy MempoolConfig) error {
+	if policy.PolicyRejectCoreExtPreActivation {
+		reject, reason, err := RejectCoreExtTxPreActivation(checked.Tx, utxos, nextHeight, policy.CoreExtProfiles)
+		if err != nil {
+			return err
+		}
+		if reject {
+			return errors.New(reason)
+		}
+	}
+	return nil
+}
+
+// applyPolicyAgainstStatePayload handles payload size policy application
+func applyPolicyAgainstStatePayload(checked *consensus.CheckedTransaction, policy MempoolConfig) error {
+	if policy.PolicyMaxExtPayloadBytes > 0 {
+		reject, reason, err := RejectCoreExtTxOversizedPayload(checked.Tx, policy.PolicyMaxExtPayloadBytes)
+		if err != nil {
+			return err
+		}
+		if reject {
+			return errors.New(reason)
+		}
+	}
+	return nil
+}
+
+// applyPolicyAgainstStateAnchor handles non-coinbase anchor output policy application
+func applyPolicyAgainstStateAnchor(checked *consensus.CheckedTransaction, policy MempoolConfig) error {
+	if policy.PolicyRejectNonCoinbaseAnchorOutputs {
+		reject, reason, err := RejectNonCoinbaseAnchorOutputs(checked.Tx)
+		if err != nil {
+			return err
+		}
+		if reject {
+			return errors.New(reason)
+		}
+	}
+	return nil
+}

--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -508,54 +508,37 @@ func (m *Mempool) checkParsedTransactionWithSnapshot(
 	snapshot *chainStateAdmissionSnapshot,
 	policy MempoolConfig,
 ) (*consensus.CheckedTransaction, []consensus.Outpoint, error) {
-	if snapshot == nil {
-		return nil, nil, txAdmitUnavailable("nil chainstate")
-	}
-	nextHeight, _, err := nextBlockContextFromFields(snapshot.hasTip, snapshot.height, snapshot.tipHash)
+	// Validate chain snapshot and extract next height
+	nextHeight, err := validateChainSnapshot(snapshot)
 	if err != nil {
-		return nil, nil, txAdmitUnavailable(err.Error())
+		return nil, nil, err
 	}
 
+	// Get block MTP
 	blockMTP, err := m.nextBlockMTP(nextHeight)
 	if err != nil {
 		return nil, nil, txAdmitUnavailable(err.Error())
 	}
 
-	var policyUtxos map[consensus.Outpoint]consensus.UtxoEntry
-	needs, err := policyNeedsInputSnapshotForTx(tx, policy)
+	// Prepare policy UTXOs if needed
+	policyUtxos, err := buildPolicyInputSnapshotIfNeeded(tx, snapshot, policy)
 	if err != nil {
-		return nil, nil, txAdmitRejected(err.Error())
-	}
-	if needs {
-		policyUtxos, err = policyInputSnapshot(tx, snapshot.utxos)
-		if err != nil {
-			return nil, nil, txAdmitRejected(err.Error())
-		}
+		return nil, nil, err
 	}
 
-	checked, err := consensus.CheckParsedTransactionWithOwnedUtxoSetAndCoreExtProfilesAndSuiteContext(
-		txBytes,
-		tx,
-		txid,
-		wtxid,
-		snapshot.utxos,
-		nextHeight,
-		blockMTP,
-		m.chainID,
-		policy.CoreExtProfiles,
-		policy.RotationProvider,
-		policy.SuiteRegistry,
-	)
+	// Perform consensus validation
+	checked, err := m.validateTransactionWithConsensus(txBytes, tx, txid, wtxid, snapshot, nextHeight, blockMTP, policy)
 	if err != nil {
-		return nil, nil, txAdmitRejected(err.Error())
+		return nil, nil, err
 	}
+
+	// Apply policy validation
 	if err := m.applyPolicyAgainstState(checked, nextHeight, policyUtxos, policy); err != nil {
 		return nil, nil, txAdmitRejected(err.Error())
 	}
-	inputs := make([]consensus.Outpoint, 0, len(checked.Tx.Inputs))
-	for _, in := range checked.Tx.Inputs {
-		inputs = append(inputs, consensus.Outpoint{Txid: in.PrevTxid, Vout: in.PrevVout})
-	}
+
+	// Extract inputs and return
+	inputs := extractTxInputs(checked)
 	return checked, inputs, nil
 }
 
@@ -563,69 +546,26 @@ func (m *Mempool) applyPolicyAgainstState(checked *consensus.CheckedTransaction,
 	if checked == nil || checked.Tx == nil {
 		return errors.New("nil checked transaction")
 	}
-	if policy.PolicyRejectNonCoinbaseAnchorOutputs {
-		reject, reason, err := RejectNonCoinbaseAnchorOutputs(checked.Tx)
-		if err != nil {
-			return err
-		}
-		if reject {
-			return errors.New(reason)
-		}
+	// Apply non-coinbase anchor output policy
+	if err := applyPolicyAgainstStateAnchor(checked, policy); err != nil {
+		return err
 	}
-	// Stage C DA fee policy: only enter the helper for DA-bearing tx when
-	// the DA-side floor is configured (MinDaFeeRate > 0) or a per-byte
-	// surcharge applies. Non-DA tx skip the helper entirely on the hot
-	// admit path; their relay-floor handling remains in
-	// validateFeeFloorLocked.
-	//
-	// The mempool admit path enforces the rolling relay-fee floor through
-	// validateFeeFloorLocked (TxAdmitUnavailable — transient/retryable),
-	// so this caller intentionally passes currentMempoolMinFeeRate=0 so
-	// max(relay_fee_floor, da_required_fee) collapses to da_required_fee.
-	// Without the zero override, a DA tx that pays the DA-side floor but
-	// not the rolling relay floor would surface here as TxAdmitRejected
-	// ("DA fee below Stage C floor ... relay_fee_floor=...") instead of
-	// the symmetric TxAdmitUnavailable that non-DA tx receive from
-	// validateFeeFloorLocked. With currentMin=0 the helper enforces only
-	// the DA-specific terms and validateFeeFloorLocked owns relay-floor
-	// classification uniformly for both DA and non-DA admissions.
-	//
-	// The miner caller (rejectCandidate) keeps using the live rolling
-	// floor because it has no validateFeeFloorLocked equivalent — the
-	// miner template needs to skip a tx whenever it fails any floor.
-	if checked.DaBytes > 0 && (policy.MinDaFeeRate > 0 || policy.PolicyDaSurchargePerByte > 0) {
-		reject, _, reason, err := RejectDaAnchorTxPolicy(
-			checked.Tx,
-			utxos,
-			0,
-			policy.MinDaFeeRate,
-			policy.PolicyDaSurchargePerByte,
-		)
-		if err != nil {
-			return txAdmitRejected(fmt.Sprintf("%s: %v", reason, err))
-		}
-		if reject {
-			return txAdmitRejected(reason)
-		}
+
+	// Apply DA fee policy
+	if err := applyPolicyAgainstStateDA(checked, policy, utxos); err != nil {
+		return err
 	}
-	if policy.PolicyRejectCoreExtPreActivation {
-		reject, reason, err := RejectCoreExtTxPreActivation(checked.Tx, utxos, nextHeight, policy.CoreExtProfiles)
-		if err != nil {
-			return err
-		}
-		if reject {
-			return errors.New(reason)
-		}
+
+	// Apply CoreExt policy
+	if err := applyPolicyAgainstStateCoreExt(checked, utxos, nextHeight, policy); err != nil {
+		return err
 	}
-	if policy.PolicyMaxExtPayloadBytes > 0 {
-		reject, reason, err := RejectCoreExtTxOversizedPayload(checked.Tx, policy.PolicyMaxExtPayloadBytes)
-		if err != nil {
-			return err
-		}
-		if reject {
-			return errors.New(reason)
-		}
+
+	// Apply payload size policy
+	if err := applyPolicyAgainstStatePayload(checked, policy); err != nil {
+		return err
 	}
+
 	return nil
 }
 
@@ -640,22 +580,31 @@ func prevTimestampsFromStore(store *BlockStore, nextHeight uint64) ([]uint64, er
 	out := make([]uint64, 0, k)
 	for i := uint64(0); i < k; i++ {
 		height := nextHeight - 1 - i
-		hash, ok, err := store.CanonicalHash(height)
+		timestamp, err := getBlockTimestamp(store, height, nextHeight)
 		if err != nil {
 			return nil, err
 		}
-		if !ok {
-			return nil, fmt.Errorf("missing canonical hash at height %d for timestamp context (next_height=%d)", height, nextHeight)
-		}
-		headerBytes, err := store.GetHeaderByHash(hash)
-		if err != nil {
-			return nil, err
-		}
-		header, err := consensus.ParseBlockHeaderBytes(headerBytes)
-		if err != nil {
-			return nil, err
-		}
-		out = append(out, header.Timestamp)
+		out = append(out, timestamp)
 	}
 	return out, nil
+}
+
+// getBlockTimestamp retrieves the timestamp from a block at the given height
+func getBlockTimestamp(store *BlockStore, height, nextHeight uint64) (uint64, error) {
+	hash, ok, err := store.CanonicalHash(height)
+	if err != nil {
+		return 0, err
+	}
+	if !ok {
+		return 0, fmt.Errorf("missing canonical hash at height %d for timestamp context (next_height=%d)", height, nextHeight)
+	}
+	headerBytes, err := store.GetHeaderByHash(hash)
+	if err != nil {
+		return 0, err
+	}
+	header, err := consensus.ParseBlockHeaderBytes(headerBytes)
+	if err != nil {
+		return 0, err
+	}
+	return header.Timestamp, nil
 }

--- a/clients/go/node/mempool_precheck.go
+++ b/clients/go/node/mempool_precheck.go
@@ -109,9 +109,6 @@ func (m *Mempool) checkTransactionWithSnapshot(txBytes []byte, snapshot *chainSt
 	if err := m.applyPolicyAgainstState(checked, nextHeight, policyUtxos, policy); err != nil {
 		return nil, nil, txAdmitRejected(err.Error())
 	}
-	inputs := make([]consensus.Outpoint, 0, len(checked.Tx.Inputs))
-	for _, in := range checked.Tx.Inputs {
-		inputs = append(inputs, consensus.Outpoint{Txid: in.PrevTxid, Vout: in.PrevVout})
-	}
+	inputs := extractTxInputs(checked)
 	return checked, inputs, nil
 }

--- a/clients/go/node/mempool_test.go
+++ b/clients/go/node/mempool_test.go
@@ -5157,3 +5157,42 @@ func TestMempoolStatsFeeFloorRejectionDoesNotCount(t *testing.T) {
 		t.Fatalf("EvictedResidentTotal after fee-floor rejection=%d, want 0", got)
 	}
 }
+
+func TestExtractTxInputsReturnsCorrectOutpoints(t *testing.T) {
+	checked := &consensus.CheckedTransaction{
+		Tx: &consensus.Tx{
+			Inputs: []consensus.TxInput{
+				{PrevTxid: [32]byte{0x01}, PrevVout: 7},
+				{PrevTxid: [32]byte{0x02}, PrevVout: 3},
+				{PrevTxid: [32]byte{0xff}, PrevVout: 0},
+			},
+		},
+	}
+	inputs := extractTxInputs(checked)
+	if len(inputs) != 3 {
+		t.Fatalf("got %d inputs, want 3", len(inputs))
+	}
+	for i, want := range []struct {
+		txid [32]byte
+		vout uint32
+	}{
+		{[32]byte{0x01}, 7},
+		{[32]byte{0x02}, 3},
+		{[32]byte{0xff}, 0},
+	} {
+		if inputs[i].Txid != want.txid || inputs[i].Vout != want.vout {
+			t.Fatalf("input[%d] = {%x, %d}, want {%x, %d}", i, inputs[i].Txid, inputs[i].Vout, want.txid, want.vout)
+		}
+	}
+}
+
+func TestValidateChainSnapshotRejectsNil(t *testing.T) {
+	_, err := validateChainSnapshot(nil)
+	if err == nil {
+		t.Fatal("expected error for nil snapshot")
+	}
+	var admit *TxAdmitError
+	if !errors.As(err, &admit) || admit.Kind != TxAdmitUnavailable {
+		t.Fatalf("expected TxAdmitUnavailable, got %T %v", err, err)
+	}
+}


### PR DESCRIPTION
## Overview
Mempool-only CCN refactoring. Extracted helpers into mempolicy_helpers.go.

## CCN Results
| Function | Before | After |
|---|---|---|
| checkParsedTransactionWithSnapshot | 10 | 6 |
| applyPolicyAgainstState | 17 | 7 |
| prevTimestampsFromStore | 9 | 6 |

All target functions ≤8 CCN. All new helpers ≤6 CCN.

## Verification
```bash
cd clients/go
go build ./node
go test ./node -run "Test.*Mempool|Test.*Policy" -count=1
gocyclo -over 8 mempolicy_helpers.go mempool.go mempool_precheck.go
```
