### PR TITLE
RUB-276: reduce Rust utxo basic safe shape rows

### DIFF
--- a/clients/rust/crates/rubin-consensus/src/utxo_basic.rs
+++ b/clients/rust/crates/rubin-consensus/src/utxo_basic.rs
@@ -614,7 +614,7 @@ fn apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles_and_suite_c
             height,
             "CORE_VAULT",
             &mut sighash_cache,
-            sig_queue.as_deref_mut(),
+            sig_queue,
             rotation,
             registry,
         )?;

--- a/clients/rust/crates/rubin-consensus/src/utxo_basic.rs
+++ b/clients/rust/crates/rubin-consensus/src/utxo_basic.rs
@@ -45,6 +45,19 @@ pub struct UtxoApplySummary {
     pub utxo_count: u64,
 }
 
+struct UtxoApplyImplContext<'a> {
+    tx: &'a Tx,
+    txid: [u8; 32],
+    utxo_set: &'a HashMap<Outpoint, UtxoEntry>,
+    height: u64,
+    block_timestamp: u64,
+    block_mtp: u64,
+    chain_id: [u8; 32],
+    core_ext_profiles_at_height: &'a CoreExtProfiles,
+    rotation: Option<&'a dyn RotationProvider>,
+    registry: Option<&'a SuiteRegistry>,
+}
+
 pub fn apply_non_coinbase_tx_basic_update(
     tx: &Tx,
     txid: [u8; 32],
@@ -124,16 +137,18 @@ pub fn apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles_and_sui
     registry: Option<&SuiteRegistry>,
 ) -> Result<(HashMap<Outpoint, UtxoEntry>, UtxoApplySummary), TxError> {
     apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles_and_suite_context_impl(
-        tx,
-        txid,
-        utxo_set,
-        height,
-        block_timestamp,
-        block_mtp,
-        chain_id,
-        core_ext_profiles_at_height,
-        rotation,
-        registry,
+        UtxoApplyImplContext {
+            tx,
+            txid,
+            utxo_set,
+            height,
+            block_timestamp,
+            block_mtp,
+            chain_id,
+            core_ext_profiles_at_height,
+            rotation,
+            registry,
+        },
         None,
     )
 }
@@ -153,16 +168,18 @@ pub(crate) fn apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles_
     sig_queue: &mut SigCheckQueue,
 ) -> Result<(HashMap<Outpoint, UtxoEntry>, UtxoApplySummary), TxError> {
     apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles_and_suite_context_impl(
-        tx,
-        txid,
-        utxo_set,
-        height,
-        block_timestamp,
-        block_mtp,
-        chain_id,
-        core_ext_profiles_at_height,
-        rotation,
-        registry,
+        UtxoApplyImplContext {
+            tx,
+            txid,
+            utxo_set,
+            height,
+            block_timestamp,
+            block_mtp,
+            chain_id,
+            core_ext_profiles_at_height,
+            rotation,
+            registry,
+        },
         Some(sig_queue),
     )
 }
@@ -207,20 +224,22 @@ pub fn apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles_and_sui
     Ok((work, summary))
 }
 
-#[allow(clippy::too_many_arguments)]
 fn apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles_and_suite_context_impl(
-    tx: &Tx,
-    txid: [u8; 32],
-    utxo_set: &HashMap<Outpoint, UtxoEntry>,
-    height: u64,
-    block_timestamp: u64,
-    block_mtp: u64,
-    chain_id: [u8; 32],
-    core_ext_profiles_at_height: &CoreExtProfiles,
-    rotation: Option<&dyn RotationProvider>,
-    registry: Option<&SuiteRegistry>,
+    ctx: UtxoApplyImplContext<'_>,
     sig_queue: Option<&mut SigCheckQueue>,
 ) -> Result<(HashMap<Outpoint, UtxoEntry>, UtxoApplySummary), TxError> {
+    let UtxoApplyImplContext {
+        tx,
+        txid,
+        utxo_set,
+        height,
+        block_timestamp,
+        block_mtp,
+        chain_id,
+        core_ext_profiles_at_height,
+        rotation,
+        registry,
+    } = ctx;
     let _ = block_timestamp;
     let mut sig_queue = sig_queue;
     if tx.inputs.is_empty() {
@@ -372,65 +391,35 @@ fn apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles_and_suite_c
                         "CORE_P2PK witness_slots must be 1",
                     ));
                 }
-                match sig_queue.as_mut() {
-                    Some(queue) => validate_p2pk_spend_q(
-                        entry,
-                        &assigned[0],
-                        input_index as u32,
-                        entry.value,
-                        chain_id,
-                        height,
-                        &mut sighash_cache,
-                        Some(&mut **queue),
-                        rotation,
-                        registry,
-                    )?,
-                    None => validate_p2pk_spend_q(
-                        entry,
-                        &assigned[0],
-                        input_index as u32,
-                        entry.value,
-                        chain_id,
-                        height,
-                        &mut sighash_cache,
-                        None,
-                        rotation,
-                        registry,
-                    )?,
-                }
+                validate_p2pk_spend_q(
+                    entry,
+                    &assigned[0],
+                    input_index as u32,
+                    entry.value,
+                    chain_id,
+                    height,
+                    &mut sighash_cache,
+                    sig_queue.as_deref_mut(),
+                    rotation,
+                    registry,
+                )?;
             }
             COV_TYPE_MULTISIG => {
                 let m = parse_multisig_covenant_data(&entry.covenant_data)?;
-                match sig_queue.as_mut() {
-                    Some(queue) => validate_threshold_sig_spend_q(
-                        &m.keys,
-                        m.threshold,
-                        assigned,
-                        input_index as u32,
-                        entry.value,
-                        chain_id,
-                        height,
-                        "CORE_MULTISIG",
-                        &mut sighash_cache,
-                        Some(&mut **queue),
-                        rotation,
-                        registry,
-                    )?,
-                    None => validate_threshold_sig_spend_q(
-                        &m.keys,
-                        m.threshold,
-                        assigned,
-                        input_index as u32,
-                        entry.value,
-                        chain_id,
-                        height,
-                        "CORE_MULTISIG",
-                        &mut sighash_cache,
-                        None,
-                        rotation,
-                        registry,
-                    )?,
-                }
+                validate_threshold_sig_spend_q(
+                    &m.keys,
+                    m.threshold,
+                    assigned,
+                    input_index as u32,
+                    entry.value,
+                    chain_id,
+                    height,
+                    "CORE_MULTISIG",
+                    &mut sighash_cache,
+                    sig_queue.as_deref_mut(),
+                    rotation,
+                    registry,
+                )?;
             }
             COV_TYPE_VAULT => {
                 let v = parse_vault_covenant_data_for_spend(&entry.covenant_data)?;
@@ -452,36 +441,20 @@ fn apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles_and_suite_c
                         "CORE_HTLC witness_slots must be 2",
                     ));
                 }
-                match sig_queue.as_mut() {
-                    Some(queue) => validate_htlc_spend_q(
-                        entry,
-                        &assigned[0],
-                        &assigned[1],
-                        input_index as u32,
-                        entry.value,
-                        chain_id,
-                        height,
-                        block_mtp,
-                        &mut sighash_cache,
-                        Some(&mut **queue),
-                        rotation,
-                        registry,
-                    )?,
-                    None => validate_htlc_spend_q(
-                        entry,
-                        &assigned[0],
-                        &assigned[1],
-                        input_index as u32,
-                        entry.value,
-                        chain_id,
-                        height,
-                        block_mtp,
-                        &mut sighash_cache,
-                        None,
-                        rotation,
-                        registry,
-                    )?,
-                }
+                validate_htlc_spend_q(
+                    entry,
+                    &assigned[0],
+                    &assigned[1],
+                    input_index as u32,
+                    entry.value,
+                    chain_id,
+                    height,
+                    block_mtp,
+                    &mut sighash_cache,
+                    sig_queue.as_deref_mut(),
+                    rotation,
+                    registry,
+                )?;
             }
             COV_TYPE_CORE_EXT => {
                 if assigned.len() != 1 {
@@ -490,36 +463,20 @@ fn apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles_and_suite_c
                         "CORE_EXT witness_slots must be 1",
                     ));
                 }
-                match sig_queue.as_mut() {
-                    Some(queue) => validate_core_ext_spend_with_cache_and_suite_context_q(
-                        entry,
-                        &assigned[0],
-                        input_index as u32,
-                        entry.value,
-                        chain_id,
-                        height,
-                        core_ext_profiles_at_height,
-                        rotation,
-                        registry,
-                        tx_context.as_ref(),
-                        Some(&mut **queue),
-                        &mut sighash_cache,
-                    )?,
-                    None => validate_core_ext_spend_with_cache_and_suite_context_q(
-                        entry,
-                        &assigned[0],
-                        input_index as u32,
-                        entry.value,
-                        chain_id,
-                        height,
-                        core_ext_profiles_at_height,
-                        rotation,
-                        registry,
-                        tx_context.as_ref(),
-                        None,
-                        &mut sighash_cache,
-                    )?,
-                }
+                validate_core_ext_spend_with_cache_and_suite_context_q(
+                    entry,
+                    &assigned[0],
+                    input_index as u32,
+                    entry.value,
+                    chain_id,
+                    height,
+                    core_ext_profiles_at_height,
+                    rotation,
+                    registry,
+                    tx_context.as_ref(),
+                    sig_queue.as_deref_mut(),
+                    &mut sighash_cache,
+                )?;
             }
             COV_TYPE_CORE_STEALTH => {
                 if assigned.len() != 1 {
@@ -528,32 +485,18 @@ fn apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles_and_suite_c
                         "CORE_STEALTH witness_slots must be 1",
                     ));
                 }
-                match sig_queue.as_mut() {
-                    Some(queue) => validate_stealth_spend_q(
-                        entry,
-                        &assigned[0],
-                        input_index as u32,
-                        entry.value,
-                        chain_id,
-                        height,
-                        &mut sighash_cache,
-                        Some(&mut **queue),
-                        rotation,
-                        registry,
-                    )?,
-                    None => validate_stealth_spend_q(
-                        entry,
-                        &assigned[0],
-                        input_index as u32,
-                        entry.value,
-                        chain_id,
-                        height,
-                        &mut sighash_cache,
-                        None,
-                        rotation,
-                        registry,
-                    )?,
-                }
+                validate_stealth_spend_q(
+                    entry,
+                    &assigned[0],
+                    input_index as u32,
+                    entry.value,
+                    chain_id,
+                    height,
+                    &mut sighash_cache,
+                    sig_queue.as_deref_mut(),
+                    rotation,
+                    registry,
+                )?;
             }
             _ => {}
         }
@@ -661,36 +604,20 @@ fn apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles_and_suite_c
             Some(range) => &tx.witness[range.clone()],
             None => unreachable!("vault witness range must exist when have_vault_sig is true"),
         };
-        match sig_queue.as_mut() {
-            Some(queue) => validate_threshold_sig_spend_q(
-                &vault_sig_keys,
-                vault_sig_threshold,
-                vault_sig_witness,
-                vault_sig_input_index,
-                vault_sig_input_value,
-                chain_id,
-                height,
-                "CORE_VAULT",
-                &mut sighash_cache,
-                Some(&mut **queue),
-                rotation,
-                registry,
-            )?,
-            None => validate_threshold_sig_spend_q(
-                &vault_sig_keys,
-                vault_sig_threshold,
-                vault_sig_witness,
-                vault_sig_input_index,
-                vault_sig_input_value,
-                chain_id,
-                height,
-                "CORE_VAULT",
-                &mut sighash_cache,
-                None,
-                rotation,
-                registry,
-            )?,
-        }
+        validate_threshold_sig_spend_q(
+            &vault_sig_keys,
+            vault_sig_threshold,
+            vault_sig_witness,
+            vault_sig_input_index,
+            vault_sig_input_value,
+            chain_id,
+            height,
+            "CORE_VAULT",
+            &mut sighash_cache,
+            sig_queue.as_deref_mut(),
+            rotation,
+            registry,
+        )?;
 
         // Whitelist enforcement: all outputs must be whitelisted.
         for out in &tx.outputs {
@@ -810,33 +737,33 @@ fn non_vault_inputs_owned_by(
 
 #[allow(dead_code)]
 fn check_spend_covenant(covenant_type: u16, covenant_data: &[u8]) -> Result<(), TxError> {
-    if covenant_type == COV_TYPE_P2PK {
-        return Ok(());
+    match covenant_type {
+        COV_TYPE_P2PK => Ok(()),
+        COV_TYPE_CORE_EXT => {
+            let _ = crate::core_ext::parse_core_ext_covenant_data(covenant_data)?;
+            Ok(())
+        }
+        COV_TYPE_CORE_STEALTH => {
+            let _ = parse_stealth_covenant_data(covenant_data)?;
+            Ok(())
+        }
+        COV_TYPE_VAULT => {
+            parse_vault_covenant_data_for_spend(covenant_data)?;
+            Ok(())
+        }
+        COV_TYPE_MULTISIG => {
+            parse_multisig_covenant_data(covenant_data)?;
+            Ok(())
+        }
+        COV_TYPE_HTLC => {
+            parse_htlc_covenant_data(covenant_data)?;
+            Ok(())
+        }
+        _ => Err(TxError::new(
+            ErrorCode::TxErrCovenantTypeInvalid,
+            "unsupported covenant in basic apply",
+        )),
     }
-    if covenant_type == COV_TYPE_CORE_EXT {
-        let _ = crate::core_ext::parse_core_ext_covenant_data(covenant_data)?;
-        return Ok(());
-    }
-    if covenant_type == COV_TYPE_CORE_STEALTH {
-        let _ = parse_stealth_covenant_data(covenant_data)?;
-        return Ok(());
-    }
-    if covenant_type == COV_TYPE_VAULT {
-        parse_vault_covenant_data_for_spend(covenant_data)?;
-        return Ok(());
-    }
-    if covenant_type == COV_TYPE_MULTISIG {
-        parse_multisig_covenant_data(covenant_data)?;
-        return Ok(());
-    }
-    if covenant_type == COV_TYPE_HTLC {
-        parse_htlc_covenant_data(covenant_data)?;
-        return Ok(());
-    }
-    Err(TxError::new(
-        ErrorCode::TxErrCovenantTypeInvalid,
-        "unsupported covenant in basic apply",
-    ))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Invariant:
Reduce safe Codacy/Lizard shape rows in Rust `utxo_basic.rs` without changing UTXO validation behavior, public error mapping, serialization, hashes, txid/wtxid/sighash behavior, or Go/Rust parity.

Layer:
Implementation-only Rust refactor.

Files changed:
- `clients/rust/crates/rubin-consensus/src/utxo_basic.rs`

What changed:
- Replaced the private apply implementation parameter list with a private context struct; public `apply_*` signatures are unchanged.
- Collapsed duplicated queued/non-queued signature validation calls into single calls using the same `Option<&mut SigCheckQueue>` contract.
- Rewrote `check_spend_covenant` as an equivalent `match` to remove its local complexity row.

Behavior impact:
- No intended runtime, consensus, wire, hash, or public error behavior change.
- `UtxoApplySummary` remains built from the final mutated `work` state.

### Parity exemption justification
This PR changes only Rust source shape in `clients/rust/crates/rubin-consensus/src/utxo_basic.rs`.
It does not change public validation behavior, public error mapping, serialization, hashes, txid/wtxid/sighash behavior, conformance fixtures, or replay output.
No matching Go change is needed because the change is a Rust-only refactor of existing logic, with public `apply_*` signatures preserved.

Codacy/Lizard evidence:
- Local medium rows moved from 8 rows before this slice to 6 rows after this slice.
- Remaining rows require separate scoped work: public high-parameter APIs, file NLOC/test-module split, and larger main implementation extraction.

Tests:
- `python3 /Users/gpt/.agents/skills/rubin-codacy/scripts/lizard_medium_rows.py clients/rust/crates/rubin-consensus/src/utxo_basic.rs`
- `scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo fmt --check'`
- `scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test -p rubin-consensus utxo_basic -- --nocapture'`
- `scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test -p rubin-consensus --lib -- --nocapture'`
- `scripts/dev-env.sh -- python3 conformance/runner/run_cv_bundle.py`
- `/Users/gpt/bin/rubin-precommit-one-review --repo /Users/gpt/Documents/rubin-protocol-codex-RUB-276 --base-ref origin/main --include-base-diff`
- one isolated stock code-review pass: `No findings.`
- `/Users/gpt/bin/rubin-push --repo /Users/gpt/Documents/rubin-protocol-codex-RUB-276 --base-ref origin/main --coverage-cmd '/Users/gpt/bin/rubin-common-preflight --lane coverage --repo /Users/gpt/Documents/rubin-protocol-codex-RUB-276' -- origin HEAD`
