### PR TITLE
RUB-278 reduce small Rust consensus complexity

### DIFF
--- a/clients/rust/crates/rubin-consensus/src/stealth.rs
+++ b/clients/rust/crates/rubin-consensus/src/stealth.rs
@@ -4,7 +4,9 @@ use crate::hash::sha3_256;
 use crate::sig_queue::{queue_or_verify_signature, SigCheckQueue};
 use crate::sighash::{sighash_v1_digest_with_cache, SighashV1PrehashCache};
 use crate::spend_verify::extract_crypto_sig_and_sighash;
-use crate::suite_registry::{DefaultRotationProvider, RotationProvider, SuiteRegistry};
+use crate::suite_registry::{
+    DefaultRotationProvider, RotationProvider, SuiteParams, SuiteRegistry,
+};
 use crate::tx::{Tx, WitnessItem};
 use crate::utxo_basic::UtxoEntry;
 
@@ -114,6 +116,48 @@ pub(crate) fn validate_stealth_spend_at_height(
     )
 }
 
+fn stealth_suite_params<'a>(
+    rotation: &dyn RotationProvider,
+    registry: &'a SuiteRegistry,
+    suite_id: u8,
+    block_height: u64,
+) -> Result<&'a SuiteParams, TxError> {
+    let native_spend = rotation.native_spend_suites(block_height);
+    if !native_spend.contains(suite_id) {
+        return Err(TxError::new(
+            ErrorCode::TxErrSigAlgInvalid,
+            "CORE_STEALTH suite not in native spend set",
+        ));
+    }
+    registry.lookup(suite_id).ok_or_else(|| {
+        TxError::new(
+            ErrorCode::TxErrSigAlgInvalid,
+            "CORE_STEALTH suite not registered",
+        )
+    })
+}
+
+fn validate_stealth_witness_shape(w: &WitnessItem, params: &SuiteParams) -> Result<(), TxError> {
+    if w.pubkey.len() as u64 != params.pubkey_len || w.signature.len() as u64 != params.sig_len + 1
+    {
+        return Err(TxError::new(
+            ErrorCode::TxErrSigNoncanonical,
+            "non-canonical witness item lengths",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_stealth_key_binding(w: &WitnessItem, cov: &StealthCovenant) -> Result<(), TxError> {
+    if sha3_256(&w.pubkey) != cov.one_time_key_id {
+        return Err(TxError::new(
+            ErrorCode::TxErrSigInvalid,
+            "CORE_STEALTH key binding mismatch",
+        ));
+    }
+    Ok(())
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn validate_stealth_spend_q(
     entry: &UtxoEntry,
@@ -136,35 +180,9 @@ pub(crate) fn validate_stealth_spend_q(
     let cov = parse_stealth_covenant_data(&entry.covenant_data)?;
     let _ = cov.ciphertext;
 
-    let native_spend = rp.native_spend_suites(block_height);
-    if !native_spend.contains(w.suite_id) {
-        return Err(TxError::new(
-            ErrorCode::TxErrSigAlgInvalid,
-            "CORE_STEALTH suite not in native spend set",
-        ));
-    }
-
-    let params = reg.lookup(w.suite_id).ok_or_else(|| {
-        TxError::new(
-            ErrorCode::TxErrSigAlgInvalid,
-            "CORE_STEALTH suite not registered",
-        )
-    })?;
-
-    if w.pubkey.len() as u64 != params.pubkey_len || w.signature.len() as u64 != params.sig_len + 1
-    {
-        return Err(TxError::new(
-            ErrorCode::TxErrSigNoncanonical,
-            "non-canonical witness item lengths",
-        ));
-    }
-
-    if sha3_256(&w.pubkey) != cov.one_time_key_id {
-        return Err(TxError::new(
-            ErrorCode::TxErrSigInvalid,
-            "CORE_STEALTH key binding mismatch",
-        ));
-    }
+    let params = stealth_suite_params(rp, reg, w.suite_id, block_height)?;
+    validate_stealth_witness_shape(w, params)?;
+    validate_stealth_key_binding(w, &cov)?;
 
     let (crypto_sig, sighash_type) = extract_crypto_sig_and_sighash(w)?;
     let digest =

--- a/clients/rust/crates/rubin-consensus/src/tx_dep_graph.rs
+++ b/clients/rust/crates/rubin-consensus/src/tx_dep_graph.rs
@@ -89,6 +89,78 @@ fn compute_tx_dep_level_order(contexts: &[TxValidationContext], levels: &[usize]
     order
 }
 
+fn txid_index(contexts: &[TxValidationContext]) -> HashMap<[u8; 32], usize> {
+    let mut txid_to_idx = HashMap::with_capacity(contexts.len());
+    for (idx, ctx) in contexts.iter().enumerate() {
+        txid_to_idx.insert(ctx.txid, idx);
+    }
+    txid_to_idx
+}
+
+fn parent_child_edge(
+    txid_to_idx: &HashMap<[u8; 32], usize>,
+    consumer_idx: usize,
+    outpoint: &Outpoint,
+) -> Option<TxDepEdge> {
+    let producer_idx = *txid_to_idx.get(&outpoint.txid)?;
+    (producer_idx < consumer_idx).then_some(TxDepEdge {
+        producer_idx,
+        consumer_idx,
+        kind: TxDepEdgeKind::ParentChild,
+    })
+}
+
+fn push_same_prevout_edge(
+    outpoint_first_consumer: &mut HashMap<Outpoint, usize>,
+    edges: &mut Vec<TxDepEdge>,
+    consumer_idx: usize,
+    outpoint: &Outpoint,
+) {
+    match outpoint_first_consumer.get(outpoint).copied() {
+        Some(first_idx) if first_idx != consumer_idx => {
+            let (producer_idx, consumer_idx) = if first_idx < consumer_idx {
+                (first_idx, consumer_idx)
+            } else {
+                (consumer_idx, first_idx)
+            };
+            edges.push(TxDepEdge {
+                producer_idx,
+                consumer_idx,
+                kind: TxDepEdgeKind::SamePrevout,
+            });
+        }
+        None => {
+            outpoint_first_consumer.insert(outpoint.clone(), consumer_idx);
+        }
+        Some(_) => {}
+    }
+}
+
+fn collect_tx_dep_edges(
+    contexts: &[TxValidationContext],
+    txid_to_idx: &HashMap<[u8; 32], usize>,
+) -> Vec<TxDepEdge> {
+    let mut outpoint_first_consumer: HashMap<Outpoint, usize> = HashMap::new();
+    let mut edges = Vec::new();
+
+    for (consumer_idx, ctx) in contexts.iter().enumerate() {
+        for outpoint in &ctx.input_outpoints {
+            if let Some(edge) = parent_child_edge(txid_to_idx, consumer_idx, outpoint) {
+                edges.push(edge);
+                continue;
+            }
+            push_same_prevout_edge(
+                &mut outpoint_first_consumer,
+                &mut edges,
+                consumer_idx,
+                outpoint,
+            );
+        }
+    }
+
+    edges
+}
+
 /// Build the deterministic dependency graph over non-coinbase transactions.
 ///
 /// The graph detects:
@@ -105,48 +177,8 @@ pub fn build_tx_dep_graph(contexts: &[TxValidationContext]) -> TxDepGraph {
         return TxDepGraph::default();
     }
 
-    let mut txid_to_idx = HashMap::with_capacity(tx_count);
-    for (idx, ctx) in contexts.iter().enumerate() {
-        txid_to_idx.insert(ctx.txid, idx);
-    }
-
-    let mut outpoint_first_consumer: HashMap<Outpoint, usize> = HashMap::new();
-    let mut edges = Vec::new();
-
-    for (consumer_idx, ctx) in contexts.iter().enumerate() {
-        for outpoint in &ctx.input_outpoints {
-            if let Some(&producer_idx) = txid_to_idx.get(&outpoint.txid) {
-                if producer_idx < consumer_idx {
-                    edges.push(TxDepEdge {
-                        producer_idx,
-                        consumer_idx,
-                        kind: TxDepEdgeKind::ParentChild,
-                    });
-                    continue;
-                }
-            }
-
-            match outpoint_first_consumer.get(outpoint).copied() {
-                Some(first_idx) if first_idx != consumer_idx => {
-                    let (producer_idx, consumer_idx) = if first_idx < consumer_idx {
-                        (first_idx, consumer_idx)
-                    } else {
-                        (consumer_idx, first_idx)
-                    };
-                    edges.push(TxDepEdge {
-                        producer_idx,
-                        consumer_idx,
-                        kind: TxDepEdgeKind::SamePrevout,
-                    });
-                }
-                None => {
-                    outpoint_first_consumer.insert(outpoint.clone(), consumer_idx);
-                }
-                Some(_) => {}
-            }
-        }
-    }
-
+    let txid_to_idx = txid_index(contexts);
+    let mut edges = collect_tx_dep_edges(contexts, &txid_to_idx);
     sort_tx_dep_edges(&mut edges);
     let (levels, max_level) = compute_tx_dep_levels(tx_count, &edges);
     let level_order = compute_tx_dep_level_order(contexts, &levels);

--- a/clients/rust/crates/rubin-consensus/src/tx_validate_worker.rs
+++ b/clients/rust/crates/rubin-consensus/src/tx_validate_worker.rs
@@ -45,6 +45,104 @@ pub struct TxValidationResult {
     pub fee: u64,
 }
 
+struct TxLocalSpendContext<'a> {
+    chain_id: [u8; 32],
+    block_height: u64,
+    block_mtp: u64,
+    core_ext_profiles: &'a CoreExtProfiles,
+    rotation: &'a dyn RotationProvider,
+    registry: &'a SuiteRegistry,
+    tx_context: Option<&'a TxContextBundle>,
+}
+
+fn pending_tx_validation_result(ptc: &PrecomputedTxContext) -> TxValidationResult {
+    TxValidationResult {
+        tx_index: ptc.tx_index,
+        valid: false,
+        err: None,
+        sig_count: 0,
+        fee: ptc.fee,
+    }
+}
+
+fn tx_validation_error_result(ptc: &PrecomputedTxContext, err: TxError) -> TxValidationResult {
+    let mut result = pending_tx_validation_result(ptc);
+    result.err = Some(err);
+    result
+}
+
+fn sig_queue_with_optional_cache(
+    registry: &SuiteRegistry,
+    sig_cache: Option<&SigCache>,
+) -> SigCheckQueue {
+    let sig_queue = SigCheckQueue::new(1).with_registry(registry);
+    match sig_cache {
+        Some(sig_cache) => sig_queue.with_cache(sig_cache.clone()),
+        None => sig_queue,
+    }
+}
+
+fn assigned_worker_witness(
+    tx: &Tx,
+    witness_cursor: usize,
+    slots: usize,
+    witness_end: usize,
+) -> Result<&[WitnessItem], TxError> {
+    let next_cursor = witness_cursor + slots;
+    if next_cursor > witness_end {
+        return Err(TxError::new(
+            ErrorCode::TxErrParse,
+            "witness underflow in worker",
+        ));
+    }
+    Ok(&tx.witness[witness_cursor..next_cursor])
+}
+
+fn validate_worker_inputs(
+    ptc: &PrecomputedTxContext,
+    tx: &Tx,
+    ctx: &TxLocalSpendContext<'_>,
+    sighash_cache: &mut SighashV1PrehashCache<'_>,
+    sig_queue: &mut SigCheckQueue,
+) -> Result<usize, TxError> {
+    let mut witness_cursor = ptc.witness_start;
+    for (input_index, entry) in ptc.resolved_inputs.iter().enumerate() {
+        let slots = witness_slots(entry.covenant_type, &entry.covenant_data)?;
+        let assigned = assigned_worker_witness(tx, witness_cursor, slots, ptc.witness_end)?;
+
+        validate_input_spend(
+            entry,
+            assigned,
+            input_index as u32,
+            entry.value,
+            ctx.chain_id,
+            ctx.block_height,
+            ctx.block_mtp,
+            sighash_cache,
+            ctx.core_ext_profiles,
+            ctx.rotation,
+            ctx.registry,
+            ctx.tx_context,
+            Some(&mut *sig_queue),
+        )?;
+
+        witness_cursor += slots;
+    }
+    Ok(witness_cursor)
+}
+
+fn build_tx_local_preflight<'a>(
+    tx: &'a Tx,
+    resolved_inputs: &[UtxoEntry],
+    block_height: u64,
+    core_ext_profiles: &CoreExtProfiles,
+) -> Result<(SighashV1PrehashCache<'a>, Option<TxContextBundle>), TxError> {
+    let sighash_cache = SighashV1PrehashCache::new(tx)?;
+    let tx_context =
+        build_tx_context_if_needed(tx, resolved_inputs, block_height, core_ext_profiles)?;
+    Ok((sighash_cache, tx_context))
+}
+
 /// Validate a single non-coinbase transaction using read-only precomputed
 /// context. Iterates resolved inputs, dispatches per-covenant-type spend
 /// validators, and counts signature verifications.
@@ -65,91 +163,41 @@ pub fn validate_tx_local(
     core_ext_profiles: &CoreExtProfiles,
     sig_cache: Option<&SigCache>,
 ) -> TxValidationResult {
-    let mut result = TxValidationResult {
-        tx_index: ptc.tx_index,
-        valid: false,
-        err: None,
-        sig_count: 0,
-        fee: ptc.fee,
-    };
-
     let tx = &pb.txs[ptc.tx_block_idx];
 
-    // Build sighash cache for this transaction.
-    let mut sighash_cache = match SighashV1PrehashCache::new(tx) {
-        Ok(c) => c,
-        Err(e) => {
-            result.err = Some(e);
-            return result;
-        }
-    };
-
-    // Build TxContext if any input requires CORE_EXT context.
-    let tx_context =
-        match build_tx_context_if_needed(tx, &ptc.resolved_inputs, block_height, core_ext_profiles)
-        {
-            Ok(ctx) => ctx,
-            Err(e) => {
-                result.err = Some(e);
-                return result;
-            }
+    let (mut sighash_cache, tx_context) =
+        match build_tx_local_preflight(tx, &ptc.resolved_inputs, block_height, core_ext_profiles) {
+            Ok(preflight) => preflight,
+            Err(e) => return tx_validation_error_result(ptc, e),
         };
 
     let rotation = DefaultRotationProvider;
     let registry = SuiteRegistry::default_registry();
-    let mut sig_queue = SigCheckQueue::new(1).with_registry(&registry);
-    if let Some(sig_cache) = sig_cache {
-        sig_queue = sig_queue.with_cache(sig_cache.clone());
-    }
+    let mut sig_queue = sig_queue_with_optional_cache(&registry, sig_cache);
+    let spend_context = TxLocalSpendContext {
+        chain_id,
+        block_height,
+        block_mtp,
+        core_ext_profiles,
+        rotation: &rotation,
+        registry: &registry,
+        tx_context: tx_context.as_ref(),
+    };
 
-    let mut witness_cursor = ptc.witness_start;
-    for (input_index, entry) in ptc.resolved_inputs.iter().enumerate() {
-        let slots = match witness_slots(entry.covenant_type, &entry.covenant_data) {
-            Ok(s) => s,
-            Err(e) => {
-                result.err = Some(e);
-                return result;
-            }
+    let witness_cursor =
+        match validate_worker_inputs(ptc, tx, &spend_context, &mut sighash_cache, &mut sig_queue) {
+            Ok(witness_cursor) => witness_cursor,
+            Err(e) => return tx_validation_error_result(ptc, e),
         };
-        if witness_cursor + slots > ptc.witness_end {
-            result.err = Some(TxError::new(
-                ErrorCode::TxErrParse,
-                "witness underflow in worker",
-            ));
-            return result;
-        }
-        let assigned = &tx.witness[witness_cursor..witness_cursor + slots];
-
-        if let Err(e) = validate_input_spend(
-            entry,
-            assigned,
-            input_index as u32,
-            entry.value,
-            chain_id,
-            block_height,
-            block_mtp,
-            &mut sighash_cache,
-            core_ext_profiles,
-            &rotation,
-            &registry,
-            tx_context.as_ref(),
-            Some(&mut sig_queue),
-        ) {
-            result.err = Some(e);
-            return result;
-        }
-
-        witness_cursor += slots;
-    }
 
     if witness_cursor != ptc.witness_end {
-        result.err = Some(TxError::new(
-            ErrorCode::TxErrParse,
-            "witness_count mismatch",
-        ));
-        return result;
+        return tx_validation_error_result(
+            ptc,
+            TxError::new(ErrorCode::TxErrParse, "witness_count mismatch"),
+        );
     }
 
+    let mut result = pending_tx_validation_result(ptc);
     result.sig_count = sig_queue.len();
     if let Err(e) = sig_queue.flush() {
         result.err = Some(e);

--- a/clients/rust/crates/rubin-consensus/src/vault.rs
+++ b/clients/rust/crates/rubin-consensus/src/vault.rs
@@ -135,16 +135,7 @@ fn parse_vault_covenant_data_inner(
     })
 }
 
-pub fn parse_multisig_covenant_data(covenant_data: &[u8]) -> Result<MultisigCovenant, TxError> {
-    if covenant_data.len() < 34 {
-        return Err(TxError::new(
-            ErrorCode::TxErrCovenantTypeInvalid,
-            "CORE_MULTISIG covenant_data too short",
-        ));
-    }
-
-    let threshold = covenant_data[0];
-    let key_count = covenant_data[1];
+fn validate_multisig_counts(threshold: u8, key_count: u8) -> Result<(), TxError> {
     if key_count == 0 || key_count > MAX_MULTISIG_KEYS {
         return Err(TxError::new(
             ErrorCode::TxErrCovenantTypeInvalid,
@@ -157,15 +148,14 @@ pub fn parse_multisig_covenant_data(covenant_data: &[u8]) -> Result<MultisigCove
             "CORE_MULTISIG threshold out of range",
         ));
     }
+    Ok(())
+}
 
-    let expected_len = 2 + (key_count as usize) * 32;
-    if covenant_data.len() != expected_len {
-        return Err(TxError::new(
-            ErrorCode::TxErrCovenantTypeInvalid,
-            "CORE_MULTISIG covenant_data length mismatch",
-        ));
-    }
+fn multisig_expected_len(key_count: u8) -> usize {
+    2 + (key_count as usize) * 32
+}
 
+fn parse_multisig_keys(covenant_data: &[u8], key_count: u8) -> Vec<[u8; 32]> {
     let mut keys = Vec::with_capacity(key_count as usize);
     let mut offset = 2usize;
     for _ in 0..key_count {
@@ -174,6 +164,30 @@ pub fn parse_multisig_covenant_data(covenant_data: &[u8]) -> Result<MultisigCove
         offset += 32;
         keys.push(k);
     }
+    keys
+}
+
+pub fn parse_multisig_covenant_data(covenant_data: &[u8]) -> Result<MultisigCovenant, TxError> {
+    if covenant_data.len() < 34 {
+        return Err(TxError::new(
+            ErrorCode::TxErrCovenantTypeInvalid,
+            "CORE_MULTISIG covenant_data too short",
+        ));
+    }
+
+    let threshold = covenant_data[0];
+    let key_count = covenant_data[1];
+    validate_multisig_counts(threshold, key_count)?;
+
+    let expected_len = multisig_expected_len(key_count);
+    if covenant_data.len() != expected_len {
+        return Err(TxError::new(
+            ErrorCode::TxErrCovenantTypeInvalid,
+            "CORE_MULTISIG covenant_data length mismatch",
+        ));
+    }
+
+    let keys = parse_multisig_keys(covenant_data, key_count);
     if !strictly_sorted_unique_32(&keys) {
         return Err(TxError::new(
             ErrorCode::TxErrCovenantTypeInvalid,


### PR DESCRIPTION
Refs: Q-CODACY-RUST-SMALL-CCN-BATCH-02

## Summary

Reduce the selected small Rust consensus Codacy medium-complexity rows without changing consensus behavior.

## Scope

Changed files:
- clients/rust/crates/rubin-consensus/src/tx_dep_graph.rs
- clients/rust/crates/rubin-consensus/src/vault.rs
- clients/rust/crates/rubin-consensus/src/stealth.rs
- clients/rust/crates/rubin-consensus/src/tx_validate_worker.rs

Consensus rules unchanged: YES
SECTION_HASHES.json unchanged: YES

Layer: implementation / cleanup, consensus-adjacent shape refactor only.

Non-goals:
- No consensus behavior change.
- No validation order or public error mapping change.
- No txid, wtxid, sighash, serialization, fixture, generated artifact, Cargo, CI, or workflow changes.

### Parity exemption justification

This PR is Rust-only because it is a shape refactor for selected Rust Codacy medium-complexity rows. It does not change executable consensus semantics or Go/Rust parity expectations. The touched Rust code preserves validation order, public error codes/messages, hash/sighash inputs, transaction dependency ordering, and `TxValidationResult` fields.

Validation:
- python3 /Users/gpt/.agents/skills/rubin-codacy/scripts/lizard_medium_rows.py clients/rust/crates/rubin-consensus/src/tx_dep_graph.rs clients/rust/crates/rubin-consensus/src/vault.rs clients/rust/crates/rubin-consensus/src/stealth.rs clients/rust/crates/rubin-consensus/src/tx_validate_worker.rs
- scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo fmt --check'
- scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test -p rubin-consensus -- --nocapture'
- scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo clippy --workspace --all-targets -- -D warnings'
- scripts/dev-env.sh -- python3 conformance/runner/run_cv_bundle.py
- /Users/gpt/bin/rubin-precommit-one-review --repo /Users/gpt/Documents/rubin-protocol-codex-RUB-278 --base-ref origin/main --include-base-diff
- one isolated stock code-review pass: No findings
- /Users/gpt/bin/rubin-push --repo /Users/gpt/Documents/rubin-protocol-codex-RUB-278 --base-ref origin/main --coverage-cmd "scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test -p rubin-consensus -- --nocapture'" -- origin HEAD

Linear: RUB-278
