### PR TITLE
RUB-282: reduce Go spend_verify shape rows

### DIFF
--- a/clients/go/consensus/coverage_hotspots_test.go
+++ b/clients/go/consensus/coverage_hotspots_test.go
@@ -136,8 +136,9 @@ func TestCoverage_SpendVerifyBranches(t *testing.T) {
 	}
 
 	keys := [][32]byte{{0x01}, {0x02}}
+	env := testSpendSigEnv{tx: tx, inputValue: 1, context: "ctx"}
 	ws := []WitnessItem{{SuiteID: SUITE_ID_SENTINEL}}
-	if err := validateThresholdSigSpend(keys, 1, ws, tx, 0, 1, [32]byte{}, 0, "ctx"); err == nil {
+	if err := validateThresholdSigSpend(testThresholdSigSpendCheck(keys, 1, ws, env)); err == nil {
 		t.Fatalf("expected witness slot mismatch")
 	}
 
@@ -145,7 +146,7 @@ func TestCoverage_SpendVerifyBranches(t *testing.T) {
 		{SuiteID: SUITE_ID_SENTINEL, Pubkey: []byte{0x01}},
 		{SuiteID: SUITE_ID_SENTINEL},
 	}
-	if err := validateThresholdSigSpend(keys, 1, ws, tx, 0, 1, [32]byte{}, 0, "ctx"); err == nil {
+	if err := validateThresholdSigSpend(testThresholdSigSpendCheck(keys, 1, ws, env)); err == nil {
 		t.Fatalf("expected sentinel keyless guard")
 	}
 
@@ -153,7 +154,7 @@ func TestCoverage_SpendVerifyBranches(t *testing.T) {
 		{SuiteID: SUITE_ID_SENTINEL},
 		{SuiteID: 0x99},
 	}
-	if err := validateThresholdSigSpend(keys, 1, ws, tx, 0, 1, [32]byte{}, 0, "ctx"); err == nil {
+	if err := validateThresholdSigSpend(testThresholdSigSpendCheck(keys, 1, ws, env)); err == nil {
 		t.Fatalf("expected unknown suite rejection")
 	}
 }

--- a/clients/go/consensus/coverage_sub80_followup_test.go
+++ b/clients/go/consensus/coverage_sub80_followup_test.go
@@ -67,7 +67,8 @@ func TestCoverageResidual_SpendVerifyAndStealthBranches(t *testing.T) {
 
 	keys := [][32]byte{sha3_256(pub)}
 	ws := []WitnessItem{{SuiteID: SUITE_ID_ML_DSA_87, Pubkey: pub, Signature: sig[:len(sig)-1]}}
-	if err := validateThresholdSigSpend(keys, 1, ws, tx, inputIndex, inputValue, chainID, 0, "ctx"); err == nil || mustTxErrCode(t, err) != TX_ERR_SIG_NONCANONICAL {
+	env := testSpendSigEnv{tx: tx, inputIndex: inputIndex, inputValue: inputValue, chainID: chainID, context: "ctx"}
+	if err := validateThresholdSigSpend(testThresholdSigSpendCheck(keys, 1, ws, env)); err == nil || mustTxErrCode(t, err) != TX_ERR_SIG_NONCANONICAL {
 		t.Fatalf("expected threshold noncanonical rejection, got %v", err)
 	}
 

--- a/clients/go/consensus/spend_verify.go
+++ b/clients/go/consensus/spend_verify.go
@@ -43,27 +43,44 @@ func verifyMLDSAKeyAndSig(w WitnessItem, expectedKeyID [32]byte, tx *Tx, inputIn
 }
 
 func verifyMLDSAKeyAndSigWithCache(w WitnessItem, expectedKeyID [32]byte, tx *Tx, inputIndex uint32, inputValue uint64, chainID [32]byte, cache *SighashV1PrehashCache, context string) error {
-	return verifyKeyAndSigWithRegistryCache(w, expectedKeyID, tx, inputIndex, inputValue, chainID, cache, nil, context)
+	return verifyKeyAndSigWithRegistryCache(w, expectedKeyID, spendSigContext{
+		tx:         tx,
+		inputIndex: inputIndex,
+		inputValue: inputValue,
+		chainID:    chainID,
+		cache:      cache,
+		context:    context,
+	})
+}
+
+type spendSigContext struct {
+	tx         *Tx
+	inputIndex uint32
+	inputValue uint64
+	chainID    [32]byte
+	cache      *SighashV1PrehashCache
+	registry   *SuiteRegistry
+	context    string
 }
 
 // verifyKeyAndSigWithRegistryCache verifies a witness item's key binding and
 // cryptographic signature using registry-aware algorithm dispatch. When registry
 // is nil, the canonical default live registry is used; callers do not get a
 // separate implicit legacy verifier path.
-func verifyKeyAndSigWithRegistryCache(w WitnessItem, expectedKeyID [32]byte, tx *Tx, inputIndex uint32, inputValue uint64, chainID [32]byte, cache *SighashV1PrehashCache, registry *SuiteRegistry, context string) error {
+func verifyKeyAndSigWithRegistryCache(w WitnessItem, expectedKeyID [32]byte, ctx spendSigContext) error {
 	if sha3_256(w.Pubkey) != expectedKeyID {
-		return txerr(TX_ERR_SIG_INVALID, context+" key binding mismatch")
+		return txerr(TX_ERR_SIG_INVALID, ctx.context+" key binding mismatch")
 	}
-	cryptoSig, digest, err := extractSigAndDigestWithCache(w, tx, inputIndex, inputValue, chainID, cache)
+	cryptoSig, digest, err := extractSigAndDigestWithCache(w, ctx.tx, ctx.inputIndex, ctx.inputValue, ctx.chainID, ctx.cache)
 	if err != nil {
 		return err
 	}
-	ok, err := verifySigWithRegistry(w.SuiteID, w.Pubkey, cryptoSig, digest, registry)
+	ok, err := verifySigWithRegistry(w.SuiteID, w.Pubkey, cryptoSig, digest, ctx.registry)
 	if err != nil {
 		return err
 	}
 	if !ok {
-		return txerr(TX_ERR_SIG_INVALID, context+" signature invalid")
+		return txerr(TX_ERR_SIG_INVALID, ctx.context+" signature invalid")
 	}
 	return nil
 }
@@ -73,22 +90,48 @@ func validateP2PKSpend(entry UtxoEntry, w WitnessItem, tx *Tx, inputIndex uint32
 }
 
 func validateP2PKSpendWithCache(entry UtxoEntry, w WitnessItem, tx *Tx, inputIndex uint32, inputValue uint64, chainID [32]byte, blockHeight uint64, cache *SighashV1PrehashCache) error {
-	return validateP2PKSpendAtHeight(entry, w, tx, inputIndex, inputValue, chainID, blockHeight, cache, DefaultRotationProvider{}, DefaultSuiteRegistry())
+	return validateP2PKSpendAtHeight(p2pkSpendCheck{
+		entry:       entry,
+		witness:     w,
+		blockHeight: blockHeight,
+		rotation:    DefaultRotationProvider{},
+		sig: spendSigContext{
+			tx:         tx,
+			inputIndex: inputIndex,
+			inputValue: inputValue,
+			chainID:    chainID,
+			cache:      cache,
+			registry:   DefaultSuiteRegistry(),
+		},
+	})
 }
 
-// validateP2PKSpendAtHeight validates a P2PK spend using the suite registry
-// and rotation provider for suite validation, length checks, and signature
-// dispatch. When rotation or registry is nil, defaults are used (ML-DSA-87
-// genesis set).
-func validateP2PKSpendAtHeight(entry UtxoEntry, w WitnessItem, tx *Tx, inputIndex uint32, inputValue uint64, chainID [32]byte, blockHeight uint64, cache *SighashV1PrehashCache, rotation RotationProvider, registry *SuiteRegistry) error {
+type p2pkSpendCheck struct {
+	entry       UtxoEntry
+	witness     WitnessItem
+	sig         spendSigContext
+	blockHeight uint64
+	rotation    RotationProvider
+}
+
+func defaultSpendProviders(rotation RotationProvider, registry *SuiteRegistry) (RotationProvider, *SuiteRegistry) {
 	if rotation == nil {
 		rotation = DefaultRotationProvider{}
 	}
 	if registry == nil {
 		registry = DefaultSuiteRegistry()
 	}
+	return rotation, registry
+}
 
-	nativeSpend := rotation.NativeSpendSuites(blockHeight)
+// validateP2PKSpendAtHeight validates a P2PK spend using the suite registry
+// and rotation provider for suite validation, length checks, and signature
+// dispatch. When rotation or registry is nil, defaults are used (ML-DSA-87
+// genesis set).
+func validateP2PKSpendAtHeight(check p2pkSpendCheck) error {
+	rotation, registry := defaultSpendProviders(check.rotation, check.sig.registry)
+	w := check.witness
+	nativeSpend := rotation.NativeSpendSuites(check.blockHeight)
 	if !nativeSpend.Contains(w.SuiteID) {
 		return txerr(TX_ERR_SIG_ALG_INVALID, "CORE_P2PK suite not in native spend set")
 	}
@@ -102,105 +145,97 @@ func validateP2PKSpendAtHeight(entry UtxoEntry, w WitnessItem, tx *Tx, inputInde
 		return txerr(TX_ERR_SIG_NONCANONICAL, "non-canonical witness item lengths")
 	}
 
-	if len(entry.CovenantData) != MAX_P2PK_COVENANT_DATA || entry.CovenantData[0] != w.SuiteID {
+	if len(check.entry.CovenantData) != MAX_P2PK_COVENANT_DATA || check.entry.CovenantData[0] != w.SuiteID {
 		return txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_P2PK covenant_data invalid")
 	}
 
 	var keyID [32]byte
-	copy(keyID[:], entry.CovenantData[1:33])
-	return verifyKeyAndSigWithRegistryCache(w, keyID, tx, inputIndex, inputValue, chainID, cache, registry, "CORE_P2PK")
+	copy(keyID[:], check.entry.CovenantData[1:33])
+	sig := check.sig
+	sig.registry = registry
+	sig.context = "CORE_P2PK"
+	return verifyKeyAndSigWithRegistryCache(w, keyID, sig)
 }
 
-func validateThresholdSigSpend(
-	keys [][32]byte,
-	threshold uint8,
-	ws []WitnessItem,
-	tx *Tx,
-	inputIndex uint32,
-	inputValue uint64,
-	chainID [32]byte,
-	blockHeight uint64,
-	context string,
-) error {
-	return validateThresholdSigSpendWithCache(keys, threshold, ws, tx, inputIndex, inputValue, chainID, blockHeight, nil, context)
+type thresholdSigSpendCheck struct {
+	keys        [][32]byte
+	threshold   uint8
+	witnesses   []WitnessItem
+	sig         spendSigContext
+	blockHeight uint64
+	rotation    RotationProvider
 }
 
-func validateThresholdSigSpendWithCache(
-	keys [][32]byte,
-	threshold uint8,
-	ws []WitnessItem,
-	tx *Tx,
-	inputIndex uint32,
-	inputValue uint64,
-	chainID [32]byte,
-	blockHeight uint64,
-	cache *SighashV1PrehashCache,
-	context string,
-) error {
-	return validateThresholdSigSpendAtHeight(keys, threshold, ws, tx, inputIndex, inputValue, chainID, blockHeight, cache, DefaultRotationProvider{}, DefaultSuiteRegistry(), context)
+func validateThresholdSigSpend(check thresholdSigSpendCheck) error {
+	if check.rotation == nil {
+		check.rotation = DefaultRotationProvider{}
+	}
+	if check.sig.registry == nil {
+		check.sig.registry = DefaultSuiteRegistry()
+	}
+	return validateThresholdSigSpendAtHeight(check)
 }
 
 // validateThresholdSigSpendAtHeight validates a threshold-sig spend using the
 // suite registry and rotation provider. When rotation or registry is nil,
 // defaults are used (ML-DSA-87 genesis set).
-func validateThresholdSigSpendAtHeight(
-	keys [][32]byte,
-	threshold uint8,
-	ws []WitnessItem,
-	tx *Tx,
-	inputIndex uint32,
-	inputValue uint64,
-	chainID [32]byte,
-	blockHeight uint64,
-	cache *SighashV1PrehashCache,
-	rotation RotationProvider,
-	registry *SuiteRegistry,
-	context string,
-) error {
-	if rotation == nil {
-		rotation = DefaultRotationProvider{}
-	}
-	if registry == nil {
-		registry = DefaultSuiteRegistry()
-	}
-
-	if len(ws) != len(keys) {
+func validateThresholdSigSpendAtHeight(check thresholdSigSpendCheck) error {
+	rotation, registry := defaultSpendProviders(check.rotation, check.sig.registry)
+	if len(check.witnesses) != len(check.keys) {
 		return txerr(TX_ERR_PARSE, "witness slot assignment mismatch")
 	}
 
-	nativeSpend := rotation.NativeSpendSuites(blockHeight)
+	nativeSpend := rotation.NativeSpendSuites(check.blockHeight)
+	sig := check.sig
+	sig.registry = registry
 	valid := 0
 
-	for i := range keys {
-		w := ws[i]
-		if w.SuiteID == SUITE_ID_SENTINEL {
-			if len(w.Pubkey) != 0 || len(w.Signature) != 0 {
-				return txerr(TX_ERR_PARSE, "SENTINEL witness must be keyless")
-			}
-			continue
-		}
-
-		if !nativeSpend.Contains(w.SuiteID) {
-			return txerr(TX_ERR_SIG_ALG_INVALID, context+" suite not in native spend set")
-		}
-
-		params, ok := registry.Lookup(w.SuiteID)
-		if !ok {
-			return txerr(TX_ERR_SIG_ALG_INVALID, context+" suite not registered")
-		}
-
-		if len(w.Pubkey) != params.PubkeyLen || len(w.Signature) != params.SigLen+1 {
-			return txerr(TX_ERR_SIG_NONCANONICAL, "non-canonical witness item lengths")
-		}
-
-		if err := verifyKeyAndSigWithRegistryCache(w, keys[i], tx, inputIndex, inputValue, chainID, cache, registry, context); err != nil {
+	for i := range check.keys {
+		counted, err := validateThresholdWitness(check.witnesses[i], check.keys[i], nativeSpend, registry, sig)
+		if err != nil {
 			return err
 		}
-		valid++
+		if counted {
+			valid++
+		}
 	}
 
-	if valid < int(threshold) {
-		return txerr(TX_ERR_SIG_INVALID, context+" threshold not met")
+	if valid < int(check.threshold) {
+		return txerr(TX_ERR_SIG_INVALID, sig.context+" threshold not met")
 	}
 	return nil
+}
+
+func validateThresholdWitness(w WitnessItem, key [32]byte, nativeSpend *NativeSuiteSet, registry *SuiteRegistry, sig spendSigContext) (bool, error) {
+	if sentinel, err := validateSentinelThresholdWitness(w); sentinel || err != nil {
+		return false, err
+	}
+
+	if !nativeSpend.Contains(w.SuiteID) {
+		return false, txerr(TX_ERR_SIG_ALG_INVALID, sig.context+" suite not in native spend set")
+	}
+
+	params, ok := registry.Lookup(w.SuiteID)
+	if !ok {
+		return false, txerr(TX_ERR_SIG_ALG_INVALID, sig.context+" suite not registered")
+	}
+
+	if len(w.Pubkey) != params.PubkeyLen || len(w.Signature) != params.SigLen+1 {
+		return false, txerr(TX_ERR_SIG_NONCANONICAL, "non-canonical witness item lengths")
+	}
+
+	if err := verifyKeyAndSigWithRegistryCache(w, key, sig); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func validateSentinelThresholdWitness(w WitnessItem) (bool, error) {
+	if w.SuiteID != SUITE_ID_SENTINEL {
+		return false, nil
+	}
+	if len(w.Pubkey) != 0 || len(w.Signature) != 0 {
+		return true, txerr(TX_ERR_PARSE, "SENTINEL witness must be keyless")
+	}
+	return true, nil
 }

--- a/clients/go/consensus/spend_verify_test.go
+++ b/clients/go/consensus/spend_verify_test.go
@@ -19,6 +19,66 @@ func p2pkEntryForPub(t *testing.T, suiteID uint8, pub []byte) UtxoEntry {
 	}
 }
 
+type testSpendSigEnv struct {
+	tx          *Tx
+	inputIndex  uint32
+	inputValue  uint64
+	chainID     [32]byte
+	blockHeight uint64
+	cache       *SighashV1PrehashCache
+	rotation    RotationProvider
+	registry    *SuiteRegistry
+	context     string
+}
+
+func testThresholdSigSpendCheck(keys [][32]byte, threshold uint8, ws []WitnessItem, env testSpendSigEnv) thresholdSigSpendCheck {
+	return thresholdSigSpendCheck{
+		keys:        keys,
+		threshold:   threshold,
+		witnesses:   ws,
+		blockHeight: env.blockHeight,
+		rotation:    env.rotation,
+		sig: spendSigContext{
+			tx:         env.tx,
+			inputIndex: env.inputIndex,
+			inputValue: env.inputValue,
+			chainID:    env.chainID,
+			cache:      env.cache,
+			registry:   env.registry,
+			context:    env.context,
+		},
+	}
+}
+
+func testP2PKSpendCheck(entry UtxoEntry, w WitnessItem, env testSpendSigEnv) p2pkSpendCheck {
+	return p2pkSpendCheck{
+		entry:       entry,
+		witness:     w,
+		blockHeight: env.blockHeight,
+		rotation:    env.rotation,
+		sig: spendSigContext{
+			tx:         env.tx,
+			inputIndex: env.inputIndex,
+			inputValue: env.inputValue,
+			chainID:    env.chainID,
+			cache:      env.cache,
+			registry:   env.registry,
+		},
+	}
+}
+
+func testSpendKeySigContext(env testSpendSigEnv) spendSigContext {
+	return spendSigContext{
+		tx:         env.tx,
+		inputIndex: env.inputIndex,
+		inputValue: env.inputValue,
+		chainID:    env.chainID,
+		cache:      env.cache,
+		registry:   env.registry,
+		context:    env.context,
+	}
+}
+
 func TestValidateP2PKSpend_OkAndFailureModes(t *testing.T) {
 	kp := mustMLDSA87Keypair(t)
 	pub := kp.PubkeyBytes()
@@ -65,45 +125,48 @@ func TestValidateP2PKSpend_OkAndFailureModes(t *testing.T) {
 
 func TestValidateThresholdSigSpend_MismatchAndThresholdLogic(t *testing.T) {
 	tx, inputIndex, inputValue, chainID := testSighashContextTx()
+	env := testSpendSigEnv{tx: tx, inputIndex: inputIndex, inputValue: inputValue, chainID: chainID, context: "ctx"}
+
 	// witness slot assignment mismatch
-	if err := validateThresholdSigSpend([][32]byte{}, 0, []WitnessItem{{SuiteID: SUITE_ID_SENTINEL}}, tx, inputIndex, inputValue, chainID, 0, "ctx"); err == nil || mustTxErrCode(t, err) != TX_ERR_PARSE {
+	if err := validateThresholdSigSpend(testThresholdSigSpendCheck([][32]byte{}, 0, []WitnessItem{{SuiteID: SUITE_ID_SENTINEL}}, env)); err == nil || mustTxErrCode(t, err) != TX_ERR_PARSE {
 		t.Fatalf("expected TX_ERR_PARSE, got %v", err)
 	}
 
 	// unknown suite id branch (should be unreachable at wire level, but must be deterministic)
 	keys := [][32]byte{hashWithPrefix(0x01)}
 	ws := []WitnessItem{{SuiteID: 0x03, Pubkey: []byte{0x01}, Signature: []byte{0x02}}}
-	if err := validateThresholdSigSpend(keys, 1, ws, tx, inputIndex, inputValue, chainID, 0, "ctx"); err == nil || mustTxErrCode(t, err) != TX_ERR_SIG_ALG_INVALID {
+	if err := validateThresholdSigSpend(testThresholdSigSpendCheck(keys, 1, ws, env)); err == nil || mustTxErrCode(t, err) != TX_ERR_SIG_ALG_INVALID {
 		t.Fatalf("expected TX_ERR_SIG_ALG_INVALID, got %v", err)
 	}
 
 	// sentinel witnesses -> threshold not met
 	keys2 := [][32]byte{hashWithPrefix(0x02), hashWithPrefix(0x03)}
 	ws2 := []WitnessItem{{SuiteID: SUITE_ID_SENTINEL}, {SuiteID: SUITE_ID_SENTINEL}}
-	if err := validateThresholdSigSpend(keys2, 1, ws2, tx, inputIndex, inputValue, chainID, 0, "ctx"); err == nil || mustTxErrCode(t, err) != TX_ERR_SIG_INVALID {
+	if err := validateThresholdSigSpend(testThresholdSigSpendCheck(keys2, 1, ws2, env)); err == nil || mustTxErrCode(t, err) != TX_ERR_SIG_INVALID {
 		t.Fatalf("expected TX_ERR_SIG_INVALID (threshold), got %v", err)
 	}
 }
 
 func TestValidateThresholdSigSpend_SentinelKeylessEnforcement(t *testing.T) {
 	tx, inputIndex, inputValue, chainID := testSighashContextTx()
+	env := testSpendSigEnv{tx: tx, inputIndex: inputIndex, inputValue: inputValue, chainID: chainID, context: "ctx"}
 	keys := [][32]byte{hashWithPrefix(0x01)}
 
 	// SENTINEL with non-empty pubkey must be rejected
 	ws1 := []WitnessItem{{SuiteID: SUITE_ID_SENTINEL, Pubkey: []byte{0x01}}}
-	if err := validateThresholdSigSpend(keys, 1, ws1, tx, inputIndex, inputValue, chainID, 0, "ctx"); err == nil || mustTxErrCode(t, err) != TX_ERR_PARSE {
+	if err := validateThresholdSigSpend(testThresholdSigSpendCheck(keys, 1, ws1, env)); err == nil || mustTxErrCode(t, err) != TX_ERR_PARSE {
 		t.Fatalf("expected TX_ERR_PARSE for sentinel with pubkey, got %v", err)
 	}
 
 	// SENTINEL with non-empty signature must be rejected
 	ws2 := []WitnessItem{{SuiteID: SUITE_ID_SENTINEL, Signature: []byte{0x01}}}
-	if err := validateThresholdSigSpend(keys, 1, ws2, tx, inputIndex, inputValue, chainID, 0, "ctx"); err == nil || mustTxErrCode(t, err) != TX_ERR_PARSE {
+	if err := validateThresholdSigSpend(testThresholdSigSpendCheck(keys, 1, ws2, env)); err == nil || mustTxErrCode(t, err) != TX_ERR_PARSE {
 		t.Fatalf("expected TX_ERR_PARSE for sentinel with signature, got %v", err)
 	}
 
 	// SENTINEL with both non-empty must be rejected
 	ws3 := []WitnessItem{{SuiteID: SUITE_ID_SENTINEL, Pubkey: []byte{0x01}, Signature: []byte{0x02}}}
-	if err := validateThresholdSigSpend(keys, 1, ws3, tx, inputIndex, inputValue, chainID, 0, "ctx"); err == nil || mustTxErrCode(t, err) != TX_ERR_PARSE {
+	if err := validateThresholdSigSpend(testThresholdSigSpendCheck(keys, 1, ws3, env)); err == nil || mustTxErrCode(t, err) != TX_ERR_PARSE {
 		t.Fatalf("expected TX_ERR_PARSE for sentinel with pubkey+sig, got %v", err)
 	}
 }
@@ -112,6 +175,7 @@ func TestValidateThresholdSigSpend_OkWithOneValidAndOneSentinel(t *testing.T) {
 	kp := mustMLDSA87Keypair(t)
 	pub := kp.PubkeyBytes()
 	tx, inputIndex, inputValue, chainID := testSighashContextTx()
+	env := testSpendSigEnv{tx: tx, inputIndex: inputIndex, inputValue: inputValue, chainID: chainID, context: "ctx"}
 	sig := signDigestWithSighashType(t, kp, tx, inputIndex, inputValue, chainID, SIGHASH_ALL)
 
 	key0 := sha3_256(pub)
@@ -121,7 +185,7 @@ func TestValidateThresholdSigSpend_OkWithOneValidAndOneSentinel(t *testing.T) {
 		{SuiteID: SUITE_ID_SENTINEL},
 	}
 
-	if err := validateThresholdSigSpend(keys, 1, ws, tx, inputIndex, inputValue, chainID, 0, "ctx"); err != nil {
+	if err := validateThresholdSigSpend(testThresholdSigSpendCheck(keys, 1, ws, env)); err != nil {
 		t.Fatalf("expected ok, got %v", err)
 	}
 }

--- a/clients/go/consensus/stealth.go
+++ b/clients/go/consensus/stealth.go
@@ -57,5 +57,13 @@ func validateCoreStealthSpendAtHeight(entry UtxoEntry, w WitnessItem, tx *Tx, in
 	if len(w.Pubkey) != params.PubkeyLen || len(w.Signature) != params.SigLen+1 {
 		return txerr(TX_ERR_SIG_NONCANONICAL, "non-canonical witness item lengths")
 	}
-	return verifyKeyAndSigWithRegistryCache(w, c.OneTimeKeyID, tx, inputIndex, inputValue, chainID, cache, registry, "CORE_STEALTH")
+	return verifyKeyAndSigWithRegistryCache(w, c.OneTimeKeyID, spendSigContext{
+		tx:         tx,
+		inputIndex: inputIndex,
+		inputValue: inputValue,
+		chainID:    chainID,
+		cache:      cache,
+		registry:   registry,
+		context:    "CORE_STEALTH",
+	})
 }

--- a/clients/go/consensus/utxo_basic.go
+++ b/clients/go/consensus/utxo_basic.go
@@ -291,7 +291,20 @@ func (ctx *nonCoinbaseApplyContext) validateP2PKInput(inputIndex int, entry Utxo
 	if len(assigned) != 1 {
 		return txerr(TX_ERR_PARSE, "CORE_P2PK witness_slots must be 1")
 	}
-	return validateP2PKSpendAtHeight(entry, assigned[0], ctx.tx, uint32(inputIndex), entry.Value, ctx.chainID, ctx.height, ctx.sighashCache, ctx.rotation, ctx.registry)
+	return validateP2PKSpendAtHeight(p2pkSpendCheck{
+		entry:       entry,
+		witness:     assigned[0],
+		blockHeight: ctx.height,
+		rotation:    ctx.rotation,
+		sig: spendSigContext{
+			tx:         ctx.tx,
+			inputIndex: uint32(inputIndex),
+			inputValue: entry.Value,
+			chainID:    ctx.chainID,
+			cache:      ctx.sighashCache,
+			registry:   ctx.registry,
+		},
+	})
 }
 
 func (ctx *nonCoinbaseApplyContext) validateMultisigInput(inputIndex int, entry UtxoEntry, assigned []WitnessItem) error {
@@ -299,7 +312,22 @@ func (ctx *nonCoinbaseApplyContext) validateMultisigInput(inputIndex int, entry 
 	if err != nil {
 		return err
 	}
-	return validateThresholdSigSpendAtHeight(m.Keys, m.Threshold, assigned, ctx.tx, uint32(inputIndex), entry.Value, ctx.chainID, ctx.height, ctx.sighashCache, ctx.rotation, ctx.registry, "CORE_MULTISIG")
+	return validateThresholdSigSpendAtHeight(thresholdSigSpendCheck{
+		keys:        m.Keys,
+		threshold:   m.Threshold,
+		witnesses:   assigned,
+		blockHeight: ctx.height,
+		rotation:    ctx.rotation,
+		sig: spendSigContext{
+			tx:         ctx.tx,
+			inputIndex: uint32(inputIndex),
+			inputValue: entry.Value,
+			chainID:    ctx.chainID,
+			cache:      ctx.sighashCache,
+			registry:   ctx.registry,
+			context:    "CORE_MULTISIG",
+		},
+	})
 }
 
 func (ctx *nonCoinbaseApplyContext) captureVaultInput(inputIndex int, entry UtxoEntry, assigned []WitnessItem) error {
@@ -466,20 +494,22 @@ func (ctx *nonCoinbaseApplyContext) rejectVaultOutputRecursion() error {
 }
 
 func (ctx *nonCoinbaseApplyContext) validateVaultSpendSignature() error {
-	return validateThresholdSigSpendAtHeight(
-		ctx.spend.vaultSigKeys,
-		ctx.spend.vaultSigThreshold,
-		ctx.spend.vaultSigWitness,
-		ctx.tx,
-		ctx.spend.vaultSigInputIndex,
-		ctx.spend.vaultSigInputValue,
-		ctx.chainID,
-		ctx.height,
-		ctx.sighashCache,
-		ctx.rotation,
-		ctx.registry,
-		"CORE_VAULT",
-	)
+	return validateThresholdSigSpendAtHeight(thresholdSigSpendCheck{
+		keys:        ctx.spend.vaultSigKeys,
+		threshold:   ctx.spend.vaultSigThreshold,
+		witnesses:   ctx.spend.vaultSigWitness,
+		blockHeight: ctx.height,
+		rotation:    ctx.rotation,
+		sig: spendSigContext{
+			tx:         ctx.tx,
+			inputIndex: ctx.spend.vaultSigInputIndex,
+			inputValue: ctx.spend.vaultSigInputValue,
+			chainID:    ctx.chainID,
+			cache:      ctx.sighashCache,
+			registry:   ctx.registry,
+			context:    "CORE_VAULT",
+		},
+	})
 }
 
 func (ctx *nonCoinbaseApplyContext) validateVaultOutputWhitelist() error {

--- a/clients/go/consensus/verify_sig_registry_test.go
+++ b/clients/go/consensus/verify_sig_registry_test.go
@@ -399,7 +399,11 @@ func TestValidateP2PKSpendAtHeight_NilProviders_UseDefaultProviders(t *testing.T
 	entry := UtxoEntry{}
 	tx := &Tx{Version: TX_WIRE_VERSION}
 
-	err := validateP2PKSpendAtHeight(entry, w, tx, 0, 1000, [32]byte{}, 100, nil, nil, nil)
+	err := validateP2PKSpendAtHeight(testP2PKSpendCheck(entry, w, testSpendSigEnv{
+		tx:          tx,
+		inputValue:  1000,
+		blockHeight: 100,
+	}))
 	if err == nil {
 		t.Fatal("expected error for unsupported suite in legacy path")
 	}
@@ -414,7 +418,13 @@ func TestValidateP2PKSpendAtHeight_SuiteNotInSpendSet_RejectsError(t *testing.T)
 	entry := UtxoEntry{}
 	tx := &Tx{Version: TX_WIRE_VERSION}
 
-	err := validateP2PKSpendAtHeight(entry, w, tx, 0, 1000, [32]byte{}, 100, nil, rp, reg)
+	err := validateP2PKSpendAtHeight(testP2PKSpendCheck(entry, w, testSpendSigEnv{
+		tx:          tx,
+		inputValue:  1000,
+		blockHeight: 100,
+		rotation:    rp,
+		registry:    reg,
+	}))
 	if err == nil {
 		t.Fatal("expected error for suite not in spend set")
 	}
@@ -432,7 +442,13 @@ func TestValidateP2PKSpendAtHeight_WrongLengths_Rejects(t *testing.T) {
 	entry := UtxoEntry{}
 	tx := &Tx{Version: TX_WIRE_VERSION}
 
-	err := validateP2PKSpendAtHeight(entry, w, tx, 0, 1000, [32]byte{}, 100, nil, rp, reg)
+	err := validateP2PKSpendAtHeight(testP2PKSpendCheck(entry, w, testSpendSigEnv{
+		tx:          tx,
+		inputValue:  1000,
+		blockHeight: 100,
+		rotation:    rp,
+		registry:    reg,
+	}))
 	if err == nil {
 		t.Fatal("expected error for wrong lengths")
 	}
@@ -447,7 +463,12 @@ func TestValidateThresholdSigSpendAtHeight_NilProviders_FallsBack(t *testing.T) 
 	tx := &Tx{Version: TX_WIRE_VERSION}
 
 	// Sentinel with nil providers → legacy path → threshold not met.
-	err := validateThresholdSigSpendAtHeight(keys, 1, ws, tx, 0, 1000, [32]byte{}, 100, nil, nil, nil, "TEST")
+	err := validateThresholdSigSpendAtHeight(testThresholdSigSpendCheck(keys, 1, ws, testSpendSigEnv{
+		tx:          tx,
+		inputValue:  1000,
+		blockHeight: 100,
+		context:     "TEST",
+	}))
 	if err == nil {
 		t.Fatal("expected threshold-not-met error")
 	}
@@ -465,7 +486,14 @@ func TestValidateThresholdSigSpendAtHeight_SentinelPassthrough(t *testing.T) {
 	tx := &Tx{Version: TX_WIRE_VERSION}
 
 	// Two sentinels, threshold=0 → should pass.
-	err := validateThresholdSigSpendAtHeight(keys, 0, ws, tx, 0, 1000, [32]byte{}, 100, nil, rp, reg, "TEST")
+	err := validateThresholdSigSpendAtHeight(testThresholdSigSpendCheck(keys, 0, ws, testSpendSigEnv{
+		tx:          tx,
+		inputValue:  1000,
+		blockHeight: 100,
+		rotation:    rp,
+		registry:    reg,
+		context:     "TEST",
+	}))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -481,7 +509,14 @@ func TestValidateThresholdSigSpendAtHeight_NonNativeSuiteRejects(t *testing.T) {
 	}
 	tx := &Tx{Version: TX_WIRE_VERSION}
 
-	err := validateThresholdSigSpendAtHeight(keys, 1, ws, tx, 0, 1000, [32]byte{}, 100, nil, rp, reg, "TEST")
+	err := validateThresholdSigSpendAtHeight(testThresholdSigSpendCheck(keys, 1, ws, testSpendSigEnv{
+		tx:          tx,
+		inputValue:  1000,
+		blockHeight: 100,
+		rotation:    rp,
+		registry:    reg,
+		context:     "TEST",
+	}))
 	if err == nil {
 		t.Fatal("expected error for non-native suite")
 	}
@@ -498,7 +533,14 @@ func TestValidateThresholdSigSpendAtHeight_SlotMismatch(t *testing.T) {
 	ws := []WitnessItem{{SuiteID: SUITE_ID_SENTINEL}}
 	tx := &Tx{Version: TX_WIRE_VERSION}
 
-	err := validateThresholdSigSpendAtHeight(keys, 1, ws, tx, 0, 1000, [32]byte{}, 100, nil, rp, reg, "TEST")
+	err := validateThresholdSigSpendAtHeight(testThresholdSigSpendCheck(keys, 1, ws, testSpendSigEnv{
+		tx:          tx,
+		inputValue:  1000,
+		blockHeight: 100,
+		rotation:    rp,
+		registry:    reg,
+		context:     "TEST",
+	}))
 	if err == nil {
 		t.Fatal("expected error for slot mismatch")
 	}
@@ -615,7 +657,13 @@ func TestValidateP2PKSpendAtHeight_ValidSig_Success(t *testing.T) {
 	entry, w, tx, cleanup := buildP2PKTestData(t, SUITE_ID_ML_DSA_87, ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES)
 	defer cleanup()
 
-	err := validateP2PKSpendAtHeight(entry, w, tx, 0, 1000, [32]byte{}, 100, nil, rp, reg)
+	err := validateP2PKSpendAtHeight(testP2PKSpendCheck(entry, w, testSpendSigEnv{
+		tx:          tx,
+		inputValue:  1000,
+		blockHeight: 100,
+		rotation:    rp,
+		registry:    reg,
+	}))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -631,7 +679,13 @@ func TestValidateP2PKSpendAtHeight_BadCovenantData_Rejects(t *testing.T) {
 	// Corrupt covenant data.
 	entry.CovenantData = []byte{0x00}
 
-	err := validateP2PKSpendAtHeight(entry, w, tx, 0, 1000, [32]byte{}, 100, nil, rp, reg)
+	err := validateP2PKSpendAtHeight(testP2PKSpendCheck(entry, w, testSpendSigEnv{
+		tx:          tx,
+		inputValue:  1000,
+		blockHeight: 100,
+		rotation:    rp,
+		registry:    reg,
+	}))
 	if err == nil {
 		t.Fatal("expected error for bad covenant data")
 	}
@@ -652,7 +706,13 @@ func TestValidateP2PKSpendAtHeight_SuiteNotRegistered_Rejects(t *testing.T) {
 	entry := UtxoEntry{}
 	tx := &Tx{Version: TX_WIRE_VERSION}
 
-	err := validateP2PKSpendAtHeight(entry, w, tx, 0, 1000, [32]byte{}, 100, nil, rp, reg)
+	err := validateP2PKSpendAtHeight(testP2PKSpendCheck(entry, w, testSpendSigEnv{
+		tx:          tx,
+		inputValue:  1000,
+		blockHeight: 100,
+		rotation:    rp,
+		registry:    reg,
+	}))
 	if err == nil {
 		t.Fatal("expected error for suite not registered")
 	}
@@ -671,7 +731,13 @@ func TestValidateP2PKSpendAtHeight_KeyBindingMismatch_Rejects(t *testing.T) {
 	// Corrupt key ID in covenant data.
 	entry.CovenantData[1] ^= 0xFF
 
-	err := validateP2PKSpendAtHeight(entry, w, tx, 0, 1000, [32]byte{}, 100, nil, rp, reg)
+	err := validateP2PKSpendAtHeight(testP2PKSpendCheck(entry, w, testSpendSigEnv{
+		tx:          tx,
+		inputValue:  1000,
+		blockHeight: 100,
+		rotation:    rp,
+		registry:    reg,
+	}))
 	if err == nil {
 		t.Fatal("expected error for key binding mismatch")
 	}
@@ -709,7 +775,14 @@ func TestValidateThresholdSigSpendAtHeight_ValidSigs_MeetsThreshold(t *testing.T
 	}
 
 	// threshold=1, one valid sig + one sentinel → should pass.
-	err := validateThresholdSigSpendAtHeight(keys, 1, ws, tx, 0, 1000, [32]byte{}, 100, nil, rp, reg, "TEST")
+	err := validateThresholdSigSpendAtHeight(testThresholdSigSpendCheck(keys, 1, ws, testSpendSigEnv{
+		tx:          tx,
+		inputValue:  1000,
+		blockHeight: 100,
+		rotation:    rp,
+		registry:    reg,
+		context:     "TEST",
+	}))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -727,7 +800,14 @@ func TestValidateThresholdSigSpendAtHeight_ThresholdNotMet(t *testing.T) {
 	tx := &Tx{Version: TX_WIRE_VERSION}
 
 	// threshold=1, two sentinels → threshold not met.
-	err := validateThresholdSigSpendAtHeight(keys, 1, ws, tx, 0, 1000, [32]byte{}, 100, nil, rp, reg, "TEST")
+	err := validateThresholdSigSpendAtHeight(testThresholdSigSpendCheck(keys, 1, ws, testSpendSigEnv{
+		tx:          tx,
+		inputValue:  1000,
+		blockHeight: 100,
+		rotation:    rp,
+		registry:    reg,
+		context:     "TEST",
+	}))
 	if err == nil {
 		t.Fatal("expected threshold-not-met error")
 	}
@@ -746,7 +826,14 @@ func TestValidateThresholdSigSpendAtHeight_SentinelWithPayload_Rejects(t *testin
 	}
 	tx := &Tx{Version: TX_WIRE_VERSION}
 
-	err := validateThresholdSigSpendAtHeight(keys, 0, ws, tx, 0, 1000, [32]byte{}, 100, nil, rp, reg, "TEST")
+	err := validateThresholdSigSpendAtHeight(testThresholdSigSpendCheck(keys, 0, ws, testSpendSigEnv{
+		tx:          tx,
+		inputValue:  1000,
+		blockHeight: 100,
+		rotation:    rp,
+		registry:    reg,
+		context:     "TEST",
+	}))
 	if err == nil {
 		t.Fatal("expected error for sentinel with pubkey")
 	}
@@ -762,7 +849,14 @@ func TestValidateThresholdSigSpendAtHeight_WrongLengths_Rejects(t *testing.T) {
 	}
 	tx := &Tx{Version: TX_WIRE_VERSION}
 
-	err := validateThresholdSigSpendAtHeight(keys, 1, ws, tx, 0, 1000, [32]byte{}, 100, nil, rp, reg, "TEST")
+	err := validateThresholdSigSpendAtHeight(testThresholdSigSpendCheck(keys, 1, ws, testSpendSigEnv{
+		tx:          tx,
+		inputValue:  1000,
+		blockHeight: 100,
+		rotation:    rp,
+		registry:    reg,
+		context:     "TEST",
+	}))
 	if err == nil {
 		t.Fatal("expected error for wrong lengths")
 	}
@@ -782,7 +876,14 @@ func TestValidateThresholdSigSpendAtHeight_NotRegistered_Rejects(t *testing.T) {
 	}
 	tx := &Tx{Version: TX_WIRE_VERSION}
 
-	err := validateThresholdSigSpendAtHeight(keys, 1, ws, tx, 0, 1000, [32]byte{}, 100, nil, rp, reg, "TEST")
+	err := validateThresholdSigSpendAtHeight(testThresholdSigSpendCheck(keys, 1, ws, testSpendSigEnv{
+		tx:          tx,
+		inputValue:  1000,
+		blockHeight: 100,
+		rotation:    rp,
+		registry:    reg,
+		context:     "TEST",
+	}))
 	if err == nil {
 		t.Fatal("expected error for unregistered suite")
 	}
@@ -806,7 +907,12 @@ func TestVerifyKeyAndSigWithRegistryCache_KeyMismatch(t *testing.T) {
 		Outputs: []TxOutput{{Value: 1000, CovenantType: COV_TYPE_P2PK}},
 	}
 
-	err := verifyKeyAndSigWithRegistryCache(w, wrongKeyID, tx, 0, 1000, [32]byte{}, nil, reg, "TEST")
+	err := verifyKeyAndSigWithRegistryCache(w, wrongKeyID, testSpendKeySigContext(testSpendSigEnv{
+		tx:         tx,
+		inputValue: 1000,
+		registry:   reg,
+		context:    "TEST",
+	}))
 	if err == nil {
 		t.Fatal("expected key binding mismatch error")
 	}
@@ -838,7 +944,12 @@ func TestVerifyKeyAndSigWithRegistryCache_SigInvalid(t *testing.T) {
 		Outputs: []TxOutput{{Value: 1000, CovenantType: COV_TYPE_P2PK}},
 	}
 
-	err := verifyKeyAndSigWithRegistryCache(w, keyID, tx, 0, 1000, [32]byte{}, nil, reg, "TEST")
+	err := verifyKeyAndSigWithRegistryCache(w, keyID, testSpendKeySigContext(testSpendSigEnv{
+		tx:         tx,
+		inputValue: 1000,
+		registry:   reg,
+		context:    "TEST",
+	}))
 	if err == nil {
 		t.Fatal("expected sig invalid error")
 	}
@@ -870,7 +981,12 @@ func TestVerifyKeyAndSigWithRegistryCache_OpenSSLError(t *testing.T) {
 		Outputs: []TxOutput{{Value: 1000, CovenantType: COV_TYPE_P2PK}},
 	}
 
-	err := verifyKeyAndSigWithRegistryCache(w, keyID, tx, 0, 1000, [32]byte{}, nil, reg, "TEST")
+	err := verifyKeyAndSigWithRegistryCache(w, keyID, testSpendKeySigContext(testSpendSigEnv{
+		tx:         tx,
+		inputValue: 1000,
+		registry:   reg,
+		context:    "TEST",
+	}))
 	if err == nil {
 		t.Fatal("expected openssl error")
 	}
@@ -894,7 +1010,12 @@ func TestVerifyKeyAndSigWithRegistryCache_BadSighash(t *testing.T) {
 		Outputs: []TxOutput{{Value: 1000, CovenantType: COV_TYPE_P2PK}},
 	}
 
-	err := verifyKeyAndSigWithRegistryCache(w, keyID, tx, 0, 1000, [32]byte{}, nil, reg, "TEST")
+	err := verifyKeyAndSigWithRegistryCache(w, keyID, testSpendKeySigContext(testSpendSigEnv{
+		tx:         tx,
+		inputValue: 1000,
+		registry:   reg,
+		context:    "TEST",
+	}))
 	if err == nil {
 		t.Fatal("expected error for invalid sighash")
 	}
@@ -923,7 +1044,14 @@ func TestValidateThresholdSigSpendAtHeight_SigVerifyError(t *testing.T) {
 		Outputs: []TxOutput{{Value: 1000, CovenantType: COV_TYPE_P2PK}},
 	}
 
-	err := validateThresholdSigSpendAtHeight(keys, 1, ws, tx, 0, 1000, [32]byte{}, 100, nil, rp, reg, "TEST")
+	err := validateThresholdSigSpendAtHeight(testThresholdSigSpendCheck(keys, 1, ws, testSpendSigEnv{
+		tx:          tx,
+		inputValue:  1000,
+		blockHeight: 100,
+		rotation:    rp,
+		registry:    reg,
+		context:     "TEST",
+	}))
 	if err == nil {
 		t.Fatal("expected error from key binding mismatch")
 	}
@@ -955,7 +1083,12 @@ func TestVerifyKeyAndSigWithRegistryCache_Success(t *testing.T) {
 		Outputs: []TxOutput{{Value: 1000, CovenantType: COV_TYPE_P2PK}},
 	}
 
-	err := verifyKeyAndSigWithRegistryCache(w, keyID, tx, 0, 1000, [32]byte{}, nil, reg, "TEST")
+	err := verifyKeyAndSigWithRegistryCache(w, keyID, testSpendKeySigContext(testSpendSigEnv{
+		tx:         tx,
+		inputValue: 1000,
+		registry:   reg,
+		context:    "TEST",
+	}))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/clients/go/consensus/verify_sig_registry_test.go
+++ b/clients/go/consensus/verify_sig_registry_test.go
@@ -405,7 +405,7 @@ func TestValidateP2PKSpendAtHeight_NilProviders_UseDefaultProviders(t *testing.T
 		blockHeight: 100,
 	}))
 	if err == nil {
-		t.Fatal("expected error for unsupported suite in legacy path")
+		t.Fatal("expected error for unsupported suite with default providers")
 	}
 }
 
@@ -462,7 +462,7 @@ func TestValidateThresholdSigSpendAtHeight_NilProviders_FallsBack(t *testing.T) 
 	ws := []WitnessItem{{SuiteID: SUITE_ID_SENTINEL}}
 	tx := &Tx{Version: TX_WIRE_VERSION}
 
-	// Sentinel with nil providers → legacy path → threshold not met.
+	// Sentinel with nil providers uses canonical defaults and still enforces threshold.
 	err := validateThresholdSigSpendAtHeight(testThresholdSigSpendCheck(keys, 1, ws, testSpendSigEnv{
 		tx:          tx,
 		inputValue:  1000,

--- a/clients/go/consensus/verify_sig_registry_test.go
+++ b/clients/go/consensus/verify_sig_registry_test.go
@@ -405,7 +405,7 @@ func TestValidateP2PKSpendAtHeight_NilProviders_UseDefaultProviders(t *testing.T
 		blockHeight: 100,
 	}))
 	if err == nil {
-		t.Fatal("expected error for unsupported suite in legacy path")
+		t.Fatal("expected error for unsupported suite with default providers")
 	}
 }
 
@@ -462,7 +462,7 @@ func TestValidateThresholdSigSpendAtHeight_NilProviders_FallsBack(t *testing.T) 
 	ws := []WitnessItem{{SuiteID: SUITE_ID_SENTINEL}}
 	tx := &Tx{Version: TX_WIRE_VERSION}
 
-	// Sentinel with nil providers → legacy path → threshold not met.
+	// Sentinel with nil providers -> default providers -> threshold not met.
 	err := validateThresholdSigSpendAtHeight(testThresholdSigSpendCheck(keys, 1, ws, testSpendSigEnv{
 		tx:          tx,
 		inputValue:  1000,


### PR DESCRIPTION
Refs: RUB-282

Invariant:
Reduce Go spend_verify Codacy shape rows without changing P2PK, threshold, vault, or CORE_STEALTH signature validation behavior.

Layer:
Go consensus implementation refactor.

Files changed:
- clients/go/consensus/spend_verify.go
- clients/go/consensus/utxo_basic.go
- clients/go/consensus/stealth.go
- focused Go consensus tests

Tests:
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./...'
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./consensus -run "Test.*P2PK|Test.*Threshold|Test.*Spend|Test.*Covenant|Test.*Stealth|Test.*Vault" -count=1'
- lizard_medium_rows.py clients/go/consensus/spend_verify.go
- gocyclo -over 8 clients/go/consensus/spend_verify.go
- git diff --check
- rubin-precommit-one-review --repo . --base-ref origin/main --include-base-diff
- rubin-push --repo . --base-ref origin/main --coverage-cmd "scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./...'" -- origin HEAD

### Parity exemption justification

Go-only refactor of consensus helper signatures and same-package call sites to clear Codacy shape rows. No validation order, public errors, Rust code, fixtures, spec, or wire-format behavior changed.

Behavior impact:
No intended behavior change.

Compatibility impact:
No Rust, fixture, spec, or wire-format changes.

Known non-goals:
RUB-261 htlc/vault rows and existing non-target rows in utxo_basic.go / stealth.go.

<!-- rubin-agent-meta actor=unknown action=pr-edit via=cl branch=codex/RUB-282-go-spend-verify-shape wt=rubin-protocol-codex-RUB-282-spend-verify utc=2026-05-17T21:59:53Z -->
