### PR TITLE
RUB-281 rust: split block weight helpers

### DIFF
--- a/clients/rust/crates/rubin-consensus/src/block_basic.rs
+++ b/clients/rust/crates/rubin-consensus/src/block_basic.rs
@@ -1,11 +1,7 @@
 use crate::block::{BlockHeader, BLOCK_HEADER_BYTES};
-use crate::constants::{
-    COV_TYPE_DA_COMMIT, MAX_ANCHOR_BYTES_PER_BLOCK, MAX_BLOCK_WEIGHT, MAX_DA_BYTES_PER_BLOCK,
-    ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES, SUITE_ID_ML_DSA_87, SUITE_ID_SENTINEL,
-    VERIFY_COST_ML_DSA_87, VERIFY_COST_UNKNOWN_SUITE, WITNESS_DISCOUNT_DIVISOR,
-};
+use crate::constants::{MAX_ANCHOR_BYTES_PER_BLOCK, MAX_BLOCK_WEIGHT, MAX_DA_BYTES_PER_BLOCK};
 use crate::error::{ErrorCode, TxError};
-use crate::tx::{da_core_fields_bytes, Tx};
+use crate::tx::Tx;
 
 mod coinbase;
 mod da_set;
@@ -13,14 +9,17 @@ mod header;
 mod orchestration;
 mod parser;
 mod txs;
+mod weight;
 
 use self::da_set::validate_da_set_integrity;
 pub(crate) use self::orchestration::validate_parsed_block_basic_with_context_at_height;
 use self::parser::parse_block_bytes_impl;
 use self::txs::BlockTxStats;
+use self::weight::tx_weight_and_stats;
 
 pub(crate) use self::coinbase::{validate_coinbase_apply_outputs, validate_coinbase_value_bound};
 pub(crate) use self::header::median_time_past;
+pub use self::weight::{tx_weight_and_stats_at_height, tx_weight_and_stats_public};
 
 #[derive(Clone, Debug)]
 pub struct ParsedBlock {
@@ -140,181 +139,4 @@ fn validate_block_resource_limits(stats: BlockTxStats) -> Result<(), TxError> {
         ));
     }
     Ok(())
-}
-
-/// Shared weight-computation skeleton. `sig_cost_fn` receives each witness item
-/// and returns its verification cost (same pattern as Go `txWeightComponents`).
-fn tx_weight_components<F>(tx: &Tx, sig_cost_fn: F) -> Result<(u64, u64, u64), TxError>
-where
-    F: Fn(&crate::tx::WitnessItem) -> Result<u64, TxError>,
-{
-    let mut base_size: u64 = 4 + 1 + 8;
-    base_size = base_size
-        .checked_add(compact_size_len(tx.inputs.len() as u64))
-        .ok_or_else(|| TxError::new(ErrorCode::TxErrParse, "u64 overflow"))?;
-    for i in &tx.inputs {
-        base_size = base_size
-            .checked_add(32 + 4)
-            .ok_or_else(|| TxError::new(ErrorCode::TxErrParse, "u64 overflow"))?;
-        base_size = base_size
-            .checked_add(compact_size_len(i.script_sig.len() as u64))
-            .ok_or_else(|| TxError::new(ErrorCode::TxErrParse, "u64 overflow"))?;
-        base_size = base_size
-            .checked_add(i.script_sig.len() as u64)
-            .ok_or_else(|| TxError::new(ErrorCode::TxErrParse, "u64 overflow"))?;
-        base_size = base_size
-            .checked_add(4)
-            .ok_or_else(|| TxError::new(ErrorCode::TxErrParse, "u64 overflow"))?;
-    }
-    base_size = base_size
-        .checked_add(compact_size_len(tx.outputs.len() as u64))
-        .ok_or_else(|| TxError::new(ErrorCode::TxErrParse, "u64 overflow"))?;
-    let mut anchor_bytes: u64 = 0;
-    for o in &tx.outputs {
-        base_size = base_size
-            .checked_add(8 + 2)
-            .ok_or_else(|| TxError::new(ErrorCode::TxErrParse, "u64 overflow"))?;
-        let cov_len = o.covenant_data.len() as u64;
-        base_size = base_size
-            .checked_add(compact_size_len(cov_len))
-            .ok_or_else(|| TxError::new(ErrorCode::TxErrParse, "u64 overflow"))?;
-        base_size = base_size
-            .checked_add(cov_len)
-            .ok_or_else(|| TxError::new(ErrorCode::TxErrParse, "u64 overflow"))?;
-        if o.covenant_type == crate::constants::COV_TYPE_ANCHOR
-            || o.covenant_type == COV_TYPE_DA_COMMIT
-        {
-            anchor_bytes = anchor_bytes
-                .checked_add(cov_len)
-                .ok_or_else(|| TxError::new(ErrorCode::TxErrParse, "u64 overflow"))?;
-        }
-    }
-    base_size = base_size
-        .checked_add(4)
-        .ok_or_else(|| TxError::new(ErrorCode::TxErrParse, "u64 overflow"))?;
-    base_size = base_size
-        .checked_add(da_core_fields_bytes(tx)?.len() as u64)
-        .ok_or_else(|| TxError::new(ErrorCode::TxErrParse, "u64 overflow"))?;
-
-    let mut witness_size: u64 = compact_size_len(tx.witness.len() as u64);
-    let mut sig_cost: u64 = 0;
-    for w in &tx.witness {
-        witness_size = witness_size
-            .checked_add(1)
-            .ok_or_else(|| TxError::new(ErrorCode::TxErrParse, "u64 overflow"))?;
-        witness_size = witness_size
-            .checked_add(compact_size_len(w.pubkey.len() as u64))
-            .ok_or_else(|| TxError::new(ErrorCode::TxErrParse, "u64 overflow"))?;
-        witness_size = witness_size
-            .checked_add(w.pubkey.len() as u64)
-            .ok_or_else(|| TxError::new(ErrorCode::TxErrParse, "u64 overflow"))?;
-        witness_size = witness_size
-            .checked_add(compact_size_len(w.signature.len() as u64))
-            .ok_or_else(|| TxError::new(ErrorCode::TxErrParse, "u64 overflow"))?;
-        witness_size = witness_size
-            .checked_add(w.signature.len() as u64)
-            .ok_or_else(|| TxError::new(ErrorCode::TxErrParse, "u64 overflow"))?;
-
-        let cost = sig_cost_fn(w)?;
-        sig_cost = sig_cost
-            .checked_add(cost)
-            .ok_or_else(|| TxError::new(ErrorCode::TxErrParse, "u64 overflow"))?;
-    }
-
-    let da_len = tx.da_payload.len() as u64;
-    let da_size = compact_size_len(da_len)
-        .checked_add(da_len)
-        .ok_or_else(|| TxError::new(ErrorCode::TxErrParse, "u64 overflow"))?;
-    let da_bytes = if tx.tx_kind != 0x00 { da_len } else { 0 };
-
-    let weight = WITNESS_DISCOUNT_DIVISOR
-        .checked_mul(base_size)
-        .and_then(|v| v.checked_add(witness_size))
-        .and_then(|v| v.checked_add(da_size))
-        .and_then(|v| v.checked_add(sig_cost))
-        .ok_or_else(|| TxError::new(ErrorCode::TxErrParse, "u64 overflow"))?;
-
-    Ok((weight, da_bytes, anchor_bytes))
-}
-
-/// Legacy weight with hardcoded per-suite costs.
-fn tx_weight_and_stats(tx: &Tx) -> Result<(u64, u64, u64), TxError> {
-    tx_weight_components(tx, |w| match w.suite_id {
-        SUITE_ID_SENTINEL => Ok(0),
-        SUITE_ID_ML_DSA_87 => {
-            if w.pubkey.len() as u64 == ML_DSA_87_PUBKEY_BYTES
-                && w.signature.len() as u64 == ML_DSA_87_SIG_BYTES + 1
-            {
-                Ok(VERIFY_COST_ML_DSA_87)
-            } else {
-                Ok(0)
-            }
-        }
-        _ => Ok(VERIFY_COST_UNKNOWN_SUITE),
-    })
-}
-
-pub fn tx_weight_and_stats_public(tx: &Tx) -> Result<(u64, u64, u64), TxError> {
-    tx_weight_and_stats(tx)
-}
-
-/// Suite-aware weight calculation using registry verify costs and
-/// rotation-aware native spend suites. Parity with Go
-/// `TxWeightAndStatsAtHeight`. When rotation or registry is None,
-/// falls back to the legacy hardcoded calculation.
-pub fn tx_weight_and_stats_at_height(
-    tx: &crate::tx::Tx,
-    height: u64,
-    rotation: Option<&dyn crate::suite_registry::RotationProvider>,
-    registry: Option<&crate::suite_registry::SuiteRegistry>,
-) -> Result<(u64, u64, u64), TxError> {
-    let (rotation, registry) = match (rotation, registry) {
-        (Some(r), Some(reg)) => (r, reg),
-        _ => return tx_weight_and_stats(tx),
-    };
-
-    let native_spend = rotation.native_spend_suites(height);
-
-    tx_weight_components(tx, |w| {
-        if w.suite_id == SUITE_ID_SENTINEL {
-            return Ok(0);
-        }
-        if native_spend.contains(w.suite_id) {
-            if let Some(params) = registry.lookup(w.suite_id) {
-                if w.pubkey.len() as u64 == params.pubkey_len
-                    && w.signature.len() as u64 == params.sig_len + 1
-                {
-                    return Ok(params.verify_cost);
-                }
-                return Ok(0);
-            }
-            // In native spend set but not registered — unknown.
-            return Ok(VERIFY_COST_UNKNOWN_SUITE);
-        }
-        // Not in native spend set — unknown suite floor.
-        Ok(VERIFY_COST_UNKNOWN_SUITE)
-    })
-}
-
-fn compact_size_len(n: u64) -> u64 {
-    match n {
-        0x00..=0xfc => 1,
-        0xfd..=0xffff => 3,
-        0x1_0000..=0xffff_ffff => 5,
-        _ => 9,
-    }
-}
-
-#[cfg(kani)]
-mod verification {
-    use super::compact_size_len;
-    use crate::compactsize::encode_compact_size;
-
-    #[kani::proof]
-    fn verify_compact_size_len_matches_encode() {
-        let n: u64 = kani::any();
-        let mut buf = Vec::new();
-        encode_compact_size(n, &mut buf);
-        assert_eq!(compact_size_len(n), buf.len() as u64);
-    }
 }

--- a/clients/rust/crates/rubin-consensus/src/block_basic/txs.rs
+++ b/clients/rust/crates/rubin-consensus/src/block_basic/txs.rs
@@ -67,7 +67,9 @@ pub(super) fn validate_block_tx_semantics(
 mod tests {
     use super::*;
     use crate::block::BlockHeader;
-    use crate::constants::{COV_TYPE_ANCHOR, COV_TYPE_DA_COMMIT, COV_TYPE_P2PK, TX_WIRE_VERSION};
+    use crate::constants::{
+        COV_TYPE_ANCHOR, COV_TYPE_DA_COMMIT, COV_TYPE_P2PK, SUITE_ID_SENTINEL, TX_WIRE_VERSION,
+    };
     use crate::hash::sha3_256;
     use crate::tx::{DaChunkCore, TxInput, TxOutput, WitnessItem};
     use crate::tx_helpers::p2pk_covenant_data_for_pubkey;

--- a/clients/rust/crates/rubin-consensus/src/block_basic/weight.rs
+++ b/clients/rust/crates/rubin-consensus/src/block_basic/weight.rs
@@ -1,0 +1,200 @@
+use crate::constants::{
+    COV_TYPE_ANCHOR, COV_TYPE_DA_COMMIT, ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES,
+    SUITE_ID_ML_DSA_87, SUITE_ID_SENTINEL, VERIFY_COST_ML_DSA_87, VERIFY_COST_UNKNOWN_SUITE,
+    WITNESS_DISCOUNT_DIVISOR,
+};
+use crate::error::{ErrorCode, TxError};
+use crate::suite_registry::{RotationProvider, SuiteRegistry};
+use crate::tx::{da_core_fields_bytes, Tx, TxInput, TxOutput, WitnessItem};
+
+/// Shared weight-computation skeleton. `sig_cost_fn` receives each witness item
+/// and returns its verification cost (same pattern as Go `txWeightComponents`).
+fn tx_weight_components<F>(tx: &Tx, sig_cost_fn: F) -> Result<(u64, u64, u64), TxError>
+where
+    F: Fn(&WitnessItem) -> Result<u64, TxError>,
+{
+    let (base_size, anchor_bytes) = tx_base_size(tx)?;
+    let (witness_size, sig_cost) = tx_witness_size_and_sig_cost(tx, sig_cost_fn)?;
+    let (da_size, da_bytes) = tx_da_size_and_bytes(tx)?;
+    let weight = tx_weight(base_size, witness_size, da_size, sig_cost)?;
+    Ok((weight, da_bytes, anchor_bytes))
+}
+
+fn tx_base_size(tx: &Tx) -> Result<(u64, u64), TxError> {
+    let mut base_size = checked_add(4 + 1 + 8, compact_size_len(tx.inputs.len() as u64))?;
+    base_size = add_input_sizes(base_size, &tx.inputs)?;
+    base_size = checked_add(base_size, compact_size_len(tx.outputs.len() as u64))?;
+    let (base_size, anchor_bytes) = add_output_sizes(base_size, &tx.outputs)?;
+    let base_size = checked_add(base_size, 4)?;
+    let base_size = checked_add(base_size, da_core_fields_bytes(tx)?.len() as u64)?;
+    Ok((base_size, anchor_bytes))
+}
+
+fn add_input_sizes(mut base_size: u64, inputs: &[TxInput]) -> Result<u64, TxError> {
+    for input in inputs {
+        base_size = checked_add(base_size, 32 + 4)?;
+        base_size = checked_add(base_size, compact_size_len(input.script_sig.len() as u64))?;
+        base_size = checked_add(base_size, input.script_sig.len() as u64)?;
+        base_size = checked_add(base_size, 4)?;
+    }
+    Ok(base_size)
+}
+
+fn add_output_sizes(mut base_size: u64, outputs: &[TxOutput]) -> Result<(u64, u64), TxError> {
+    let mut anchor_bytes = 0;
+    for output in outputs {
+        base_size = checked_add(base_size, 8 + 2)?;
+        let covenant_len = output.covenant_data.len() as u64;
+        base_size = checked_add(base_size, compact_size_len(covenant_len))?;
+        base_size = checked_add(base_size, covenant_len)?;
+        if is_anchor_counted_output(output) {
+            anchor_bytes = checked_add(anchor_bytes, covenant_len)?;
+        }
+    }
+    Ok((base_size, anchor_bytes))
+}
+
+fn is_anchor_counted_output(output: &TxOutput) -> bool {
+    matches!(output.covenant_type, COV_TYPE_ANCHOR | COV_TYPE_DA_COMMIT)
+}
+
+fn tx_witness_size_and_sig_cost<F>(tx: &Tx, sig_cost_fn: F) -> Result<(u64, u64), TxError>
+where
+    F: Fn(&WitnessItem) -> Result<u64, TxError>,
+{
+    let mut witness_size = compact_size_len(tx.witness.len() as u64);
+    let mut sig_cost = 0;
+    for witness in &tx.witness {
+        witness_size = add_witness_item_size(witness_size, witness)?;
+        sig_cost = checked_add(sig_cost, sig_cost_fn(witness)?)?;
+    }
+    Ok((witness_size, sig_cost))
+}
+
+fn add_witness_item_size(mut witness_size: u64, witness: &WitnessItem) -> Result<u64, TxError> {
+    witness_size = checked_add(witness_size, 1)?;
+    witness_size = checked_add(witness_size, compact_size_len(witness.pubkey.len() as u64))?;
+    witness_size = checked_add(witness_size, witness.pubkey.len() as u64)?;
+    witness_size = checked_add(
+        witness_size,
+        compact_size_len(witness.signature.len() as u64),
+    )?;
+    checked_add(witness_size, witness.signature.len() as u64)
+}
+
+fn tx_da_size_and_bytes(tx: &Tx) -> Result<(u64, u64), TxError> {
+    let da_len = tx.da_payload.len() as u64;
+    let da_size = checked_add(compact_size_len(da_len), da_len)?;
+    let da_bytes = if tx.tx_kind != 0x00 { da_len } else { 0 };
+    Ok((da_size, da_bytes))
+}
+
+fn tx_weight(
+    base_size: u64,
+    witness_size: u64,
+    da_size: u64,
+    sig_cost: u64,
+) -> Result<u64, TxError> {
+    let base_weight = WITNESS_DISCOUNT_DIVISOR
+        .checked_mul(base_size)
+        .ok_or_else(weight_overflow)?;
+    let weight = checked_add(base_weight, witness_size)?;
+    let weight = checked_add(weight, da_size)?;
+    checked_add(weight, sig_cost)
+}
+
+/// Legacy weight with hardcoded per-suite costs.
+pub(super) fn tx_weight_and_stats(tx: &Tx) -> Result<(u64, u64, u64), TxError> {
+    tx_weight_components(tx, legacy_sig_cost)
+}
+
+fn legacy_sig_cost(witness: &WitnessItem) -> Result<u64, TxError> {
+    Ok(match witness.suite_id {
+        SUITE_ID_SENTINEL => 0,
+        SUITE_ID_ML_DSA_87 if has_expected_mldsa87_shape(witness) => VERIFY_COST_ML_DSA_87,
+        SUITE_ID_ML_DSA_87 => 0,
+        _ => VERIFY_COST_UNKNOWN_SUITE,
+    })
+}
+
+pub fn tx_weight_and_stats_public(tx: &Tx) -> Result<(u64, u64, u64), TxError> {
+    tx_weight_and_stats(tx)
+}
+
+/// Suite-aware weight calculation using registry verify costs and
+/// rotation-aware native spend suites. Parity with Go
+/// `TxWeightAndStatsAtHeight`. When rotation or registry is None,
+/// falls back to the legacy hardcoded calculation.
+pub fn tx_weight_and_stats_at_height(
+    tx: &Tx,
+    height: u64,
+    rotation: Option<&dyn RotationProvider>,
+    registry: Option<&SuiteRegistry>,
+) -> Result<(u64, u64, u64), TxError> {
+    let (rotation, registry) = match (rotation, registry) {
+        (Some(r), Some(reg)) => (r, reg),
+        _ => return tx_weight_and_stats(tx),
+    };
+    let native_spend = rotation.native_spend_suites(height);
+    tx_weight_components(tx, |witness| {
+        registry_sig_cost(witness, &native_spend, registry)
+    })
+}
+
+fn registry_sig_cost(
+    witness: &WitnessItem,
+    native_spend: &crate::suite_registry::NativeSuiteSet,
+    registry: &SuiteRegistry,
+) -> Result<u64, TxError> {
+    if witness.suite_id == SUITE_ID_SENTINEL {
+        return Ok(0);
+    }
+    if !native_spend.contains(witness.suite_id) {
+        return Ok(VERIFY_COST_UNKNOWN_SUITE);
+    }
+    let Some(params) = registry.lookup(witness.suite_id) else {
+        return Ok(VERIFY_COST_UNKNOWN_SUITE);
+    };
+    if witness.pubkey.len() as u64 == params.pubkey_len
+        && witness.signature.len() as u64 == params.sig_len + 1
+    {
+        return Ok(params.verify_cost);
+    }
+    Ok(0)
+}
+
+fn has_expected_mldsa87_shape(witness: &WitnessItem) -> bool {
+    witness.pubkey.len() as u64 == ML_DSA_87_PUBKEY_BYTES
+        && witness.signature.len() as u64 == ML_DSA_87_SIG_BYTES + 1
+}
+
+fn compact_size_len(n: u64) -> u64 {
+    match n {
+        0x00..=0xfc => 1,
+        0xfd..=0xffff => 3,
+        0x1_0000..=0xffff_ffff => 5,
+        _ => 9,
+    }
+}
+
+fn checked_add(a: u64, b: u64) -> Result<u64, TxError> {
+    a.checked_add(b).ok_or_else(weight_overflow)
+}
+
+fn weight_overflow() -> TxError {
+    TxError::new(ErrorCode::TxErrParse, "u64 overflow")
+}
+
+#[cfg(kani)]
+mod verification {
+    use super::compact_size_len;
+    use crate::compactsize::encode_compact_size;
+
+    #[kani::proof]
+    fn verify_compact_size_len_matches_encode() {
+        let n: u64 = kani::any();
+        let mut buf = Vec::new();
+        encode_compact_size(n, &mut buf);
+        assert_eq!(compact_size_len(n), buf.len() as u64);
+    }
+}


### PR DESCRIPTION
Refs: RUB-281

Summary:
- Moves Rust block weight accounting helpers from `block_basic.rs` into `block_basic/weight.rs`.
- Preserves the existing weight, DA byte, anchor byte, suite-cost, and public `tx_weight_and_stats*` entrypoint behavior.

Scope:
- Rust consensus source-shape refactor only.
- Changed files are `clients/rust/crates/rubin-consensus/src/block_basic.rs`, `clients/rust/crates/rubin-consensus/src/block_basic/txs.rs`, and `clients/rust/crates/rubin-consensus/src/block_basic/weight.rs`.
- No Go, Cargo, conformance fixture, generated artifact, or runtime policy changes.

### Parity exemption justification
Rust-only refactor of the existing Rust weight helper shape. No one-sided behavioral parity change is introduced; the public Rust weight entrypoints remain the same.

### Fixture exemption justification
No conformance fixture, schema, generated artifact, or consensus-validity expectation changes are included.

Validation:
- `git diff --check`
- local Codacy/lizard medium-row check for touched Rust files
- `scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo fmt --check'`
- `scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test -p rubin-consensus tx_weight -- --nocapture'`
- `scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test -p rubin-consensus block_basic -- --nocapture'`
- `scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo clippy -p rubin-consensus --all-targets -- -D warnings'`
- `python3 tools/check_map_iteration_determinism.py`


<!-- rubin-agent-meta actor=unknown action=pr-create via=cl branch=codex/RUB-281-rust-weight-shape wt=rubin-protocol-codex-RUB-281 utc=2026-05-17T22:23:27Z -->
