### PR TITLE
RUB-261 go: split htlc vault codacy helpers

### DIFF
--- a/clients/go/consensus/htlc.go
+++ b/clients/go/consensus/htlc.go
@@ -78,78 +78,136 @@ func ValidateHTLCSpendAtHeight(
 	rotation RotationProvider,
 	registry *SuiteRegistry,
 ) error {
-	if rotation == nil {
-		rotation = DefaultRotationProvider{}
-	}
-	if registry == nil {
-		registry = DefaultSuiteRegistry()
-	}
+	rotation, registry = resolveHTLCSpendProviders(rotation, registry)
 
 	c, err := ParseHTLCCovenantData(entry.CovenantData)
 	if err != nil {
 		return err
 	}
 
-	var expectedKeyID [32]byte
+	expectedKeyID, err := expectedHTLCSpendKeyID(c, pathItem, blockHeight, blockMTP)
+	if err != nil {
+		return err
+	}
+
+	if err := validateHTLCSignaturePrecheck(sigItem, expectedKeyID, blockHeight, rotation, registry); err != nil {
+		return err
+	}
+
+	cryptoSig, digest, err := extractSigAndDigestWithCache(sigItem, tx, inputIndex, inputValue, chainID, cache)
+	if err != nil {
+		return err
+	}
+	ok, err := verifySigWithRegistry(sigItem.SuiteID, sigItem.Pubkey, cryptoSig, digest, registry)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return txerr(TX_ERR_SIG_INVALID, "CORE_HTLC signature invalid")
+	}
+	return nil
+}
+
+func resolveHTLCSpendProviders(rotation RotationProvider, registry *SuiteRegistry) (RotationProvider, *SuiteRegistry) {
+	if rotation == nil {
+		rotation = DefaultRotationProvider{}
+	}
+	if registry == nil {
+		registry = DefaultSuiteRegistry()
+	}
+	return rotation, registry
+}
+
+func expectedHTLCSpendKeyID(
+	c *HTLCCovenant,
+	pathItem WitnessItem,
+	blockHeight uint64,
+	blockMTP uint64,
+) ([32]byte, error) {
+	pathSig, pathKeyID, pathID, err := parseHTLCSelector(pathItem)
+	if err != nil {
+		return [32]byte{}, err
+	}
+	switch pathID {
+	case 0x00:
+		return validateHTLCClaimPath(c, pathSig, pathKeyID)
+	case 0x01:
+		return validateHTLCRefundPath(c, pathSig, pathKeyID, blockHeight, blockMTP)
+	default:
+		return [32]byte{}, txerr(TX_ERR_PARSE, "CORE_HTLC unknown spend path")
+	}
+}
+
+func parseHTLCSelector(pathItem WitnessItem) ([]byte, [32]byte, byte, error) {
 	if pathItem.SuiteID != SUITE_ID_SENTINEL {
-		return txerr(TX_ERR_PARSE, "CORE_HTLC selector suite_id invalid")
+		return nil, [32]byte{}, 0, txerr(TX_ERR_PARSE, "CORE_HTLC selector suite_id invalid")
 	}
 	pathSig := pathItem.Signature
 	if len(pathItem.Pubkey) != 32 {
-		return txerr(TX_ERR_PARSE, "CORE_HTLC selector key_id length invalid")
+		return nil, [32]byte{}, 0, txerr(TX_ERR_PARSE, "CORE_HTLC selector key_id length invalid")
 	}
 	if len(pathSig) < 1 {
-		return txerr(TX_ERR_PARSE, "CORE_HTLC selector payload too short")
+		return nil, [32]byte{}, 0, txerr(TX_ERR_PARSE, "CORE_HTLC selector payload too short")
 	}
-	pathID := pathSig[0]
-	switch pathID {
-	case 0x00: // claim
-		var pathKeyID [32]byte
-		copy(pathKeyID[:], pathItem.Pubkey)
-		if pathKeyID != c.ClaimKeyID {
-			return txerr(TX_ERR_SIG_INVALID, "CORE_HTLC claim key_id mismatch")
-		}
-		if len(pathSig) < 3 {
-			return txerr(TX_ERR_PARSE, "CORE_HTLC claim payload too short")
-		}
-		preLen := int(binary.LittleEndian.Uint16(pathSig[1:3]))
-		if preLen < MIN_HTLC_PREIMAGE_BYTES {
-			return txerr(TX_ERR_PARSE, "CORE_HTLC preimage_len must be >= 16")
-		}
-		if preLen > MAX_HTLC_PREIMAGE_BYTES {
-			return txerr(TX_ERR_PARSE, "CORE_HTLC preimage length overflow")
-		}
-		if len(pathSig) != 3+preLen {
-			return txerr(TX_ERR_PARSE, "CORE_HTLC claim payload length mismatch")
-		}
-		preimage := pathSig[3:]
-		if sha3_256(preimage) != c.Hash {
-			return txerr(TX_ERR_SIG_INVALID, "CORE_HTLC claim preimage hash mismatch")
-		}
-		expectedKeyID = c.ClaimKeyID
+	var pathKeyID [32]byte
+	copy(pathKeyID[:], pathItem.Pubkey)
+	return pathSig, pathKeyID, pathSig[0], nil
+}
 
-	case 0x01: // refund
-		if len(pathSig) != 1 {
-			return txerr(TX_ERR_PARSE, "CORE_HTLC refund payload length mismatch")
-		}
-		var pathKeyID [32]byte
-		copy(pathKeyID[:], pathItem.Pubkey)
-		if pathKeyID != c.RefundKeyID {
-			return txerr(TX_ERR_SIG_INVALID, "CORE_HTLC refund key_id mismatch")
-		}
-		if c.LockMode == LOCK_MODE_HEIGHT {
-			if blockHeight < c.LockValue {
-				return txerr(TX_ERR_TIMELOCK_NOT_MET, "CORE_HTLC height lock not met")
-			}
-		} else if blockMTP < c.LockValue {
-			return txerr(TX_ERR_TIMELOCK_NOT_MET, "CORE_HTLC timestamp lock not met")
-		}
-		expectedKeyID = c.RefundKeyID
-
-	default:
-		return txerr(TX_ERR_PARSE, "CORE_HTLC unknown spend path")
+func validateHTLCClaimPath(c *HTLCCovenant, pathSig []byte, pathKeyID [32]byte) ([32]byte, error) {
+	if pathKeyID != c.ClaimKeyID {
+		return [32]byte{}, txerr(TX_ERR_SIG_INVALID, "CORE_HTLC claim key_id mismatch")
 	}
+	if len(pathSig) < 3 {
+		return [32]byte{}, txerr(TX_ERR_PARSE, "CORE_HTLC claim payload too short")
+	}
+	preLen := int(binary.LittleEndian.Uint16(pathSig[1:3]))
+	if preLen < MIN_HTLC_PREIMAGE_BYTES {
+		return [32]byte{}, txerr(TX_ERR_PARSE, "CORE_HTLC preimage_len must be >= 16")
+	}
+	if preLen > MAX_HTLC_PREIMAGE_BYTES {
+		return [32]byte{}, txerr(TX_ERR_PARSE, "CORE_HTLC preimage length overflow")
+	}
+	if len(pathSig) != 3+preLen {
+		return [32]byte{}, txerr(TX_ERR_PARSE, "CORE_HTLC claim payload length mismatch")
+	}
+	preimage := pathSig[3:]
+	if sha3_256(preimage) != c.Hash {
+		return [32]byte{}, txerr(TX_ERR_SIG_INVALID, "CORE_HTLC claim preimage hash mismatch")
+	}
+	return c.ClaimKeyID, nil
+}
 
+func validateHTLCRefundPath(
+	c *HTLCCovenant,
+	pathSig []byte,
+	pathKeyID [32]byte,
+	blockHeight uint64,
+	blockMTP uint64,
+) ([32]byte, error) {
+	if len(pathSig) != 1 {
+		return [32]byte{}, txerr(TX_ERR_PARSE, "CORE_HTLC refund payload length mismatch")
+	}
+	if pathKeyID != c.RefundKeyID {
+		return [32]byte{}, txerr(TX_ERR_SIG_INVALID, "CORE_HTLC refund key_id mismatch")
+	}
+	if c.LockMode == LOCK_MODE_HEIGHT {
+		if blockHeight < c.LockValue {
+			return [32]byte{}, txerr(TX_ERR_TIMELOCK_NOT_MET, "CORE_HTLC height lock not met")
+		}
+	} else if blockMTP < c.LockValue {
+		return [32]byte{}, txerr(TX_ERR_TIMELOCK_NOT_MET, "CORE_HTLC timestamp lock not met")
+	}
+	return c.RefundKeyID, nil
+}
+
+func validateHTLCSignaturePrecheck(
+	sigItem WitnessItem,
+	expectedKeyID [32]byte,
+	blockHeight uint64,
+	rotation RotationProvider,
+	registry *SuiteRegistry,
+) error {
 	nativeSpend := rotation.NativeSpendSuites(blockHeight)
 	if !nativeSpend.Contains(sigItem.SuiteID) {
 		return txerr(TX_ERR_SIG_ALG_INVALID, "CORE_HTLC suite not in native spend set")
@@ -166,18 +224,6 @@ func ValidateHTLCSpendAtHeight(
 
 	if sha3_256(sigItem.Pubkey) != expectedKeyID {
 		return txerr(TX_ERR_SIG_INVALID, "CORE_HTLC signature key binding mismatch")
-	}
-
-	cryptoSig, digest, err := extractSigAndDigestWithCache(sigItem, tx, inputIndex, inputValue, chainID, cache)
-	if err != nil {
-		return err
-	}
-	ok, err = verifySigWithRegistry(sigItem.SuiteID, sigItem.Pubkey, cryptoSig, digest, registry)
-	if err != nil {
-		return err
-	}
-	if !ok {
-		return txerr(TX_ERR_SIG_INVALID, "CORE_HTLC signature invalid")
 	}
 	return nil
 }

--- a/clients/go/consensus/vault.go
+++ b/clients/go/consensus/vault.go
@@ -30,8 +30,32 @@ func ParseVaultCovenantDataForSpend(covData []byte) (*VaultCovenant, error) {
 }
 
 func parseVaultCovenantData(covData []byte, enforceWhitelistCanonical bool) (*VaultCovenant, error) {
+	v, offset, err := parseVaultHeader(covData)
+	if err != nil {
+		return nil, err
+	}
+
+	v.Keys, offset, err = parseVaultKeys(covData, offset, v.KeyCount)
+	if err != nil {
+		return nil, err
+	}
+	if !strictlySortedUnique32(v.Keys) {
+		return nil, txerr(TX_ERR_VAULT_KEYS_NOT_CANONICAL, "CORE_VAULT keys not strictly sorted")
+	}
+
+	v.Whitelist, v.WhitelistCount, err = parseVaultWhitelist(covData, offset, v.KeyCount)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateVaultWhitelist(v, enforceWhitelistCanonical); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func parseVaultHeader(covData []byte) (*VaultCovenant, int, error) {
 	if len(covData) < 34 {
-		return nil, txerr(TX_ERR_VAULT_MALFORMED, "CORE_VAULT covenant_data too short")
+		return nil, 0, txerr(TX_ERR_VAULT_MALFORMED, "CORE_VAULT covenant_data too short")
 	}
 
 	var v VaultCovenant
@@ -39,56 +63,76 @@ func parseVaultCovenantData(covData []byte, enforceWhitelistCanonical bool) (*Va
 	v.Threshold = covData[32]
 	v.KeyCount = covData[33]
 	if v.KeyCount < 1 || v.KeyCount > MAX_VAULT_KEYS {
-		return nil, txerr(TX_ERR_VAULT_PARAMS_INVALID, "CORE_VAULT key_count out of range")
+		return nil, 0, txerr(TX_ERR_VAULT_PARAMS_INVALID, "CORE_VAULT key_count out of range")
 	}
 	if v.Threshold < 1 || v.Threshold > v.KeyCount {
-		return nil, txerr(TX_ERR_VAULT_PARAMS_INVALID, "CORE_VAULT threshold out of range")
+		return nil, 0, txerr(TX_ERR_VAULT_PARAMS_INVALID, "CORE_VAULT threshold out of range")
 	}
+	return &v, 34, nil
+}
 
-	offset := 34
-	v.Keys = make([][32]byte, int(v.KeyCount))
-	for i := 0; i < int(v.KeyCount); i++ {
+func parseVaultKeys(covData []byte, offset int, keyCount uint8) ([][32]byte, int, error) {
+	keys := make([][32]byte, int(keyCount))
+	for i := 0; i < int(keyCount); i++ {
 		if offset+32 > len(covData) {
-			return nil, txerr(TX_ERR_VAULT_MALFORMED, "CORE_VAULT truncated keys")
+			return nil, 0, txerr(TX_ERR_VAULT_MALFORMED, "CORE_VAULT truncated keys")
 		}
-		copy(v.Keys[i][:], covData[offset:offset+32])
+		copy(keys[i][:], covData[offset:offset+32])
 		offset += 32
 	}
-	if !strictlySortedUnique32(v.Keys) {
-		return nil, txerr(TX_ERR_VAULT_KEYS_NOT_CANONICAL, "CORE_VAULT keys not strictly sorted")
-	}
+	return keys, offset, nil
+}
 
+func parseVaultWhitelist(covData []byte, offset int, keyCount uint8) ([][32]byte, uint16, error) {
 	if offset+2 > len(covData) {
-		return nil, txerr(TX_ERR_VAULT_MALFORMED, "CORE_VAULT missing whitelist_count")
+		return nil, 0, txerr(TX_ERR_VAULT_MALFORMED, "CORE_VAULT missing whitelist_count")
 	}
-	v.WhitelistCount = binary.LittleEndian.Uint16(covData[offset : offset+2])
+	whitelistCount := binary.LittleEndian.Uint16(covData[offset : offset+2])
 	offset += 2
-	if v.WhitelistCount < 1 || v.WhitelistCount > MAX_VAULT_WHITELIST_ENTRIES {
-		return nil, txerr(TX_ERR_VAULT_PARAMS_INVALID, "CORE_VAULT whitelist_count out of range")
+	if whitelistCount < 1 || whitelistCount > MAX_VAULT_WHITELIST_ENTRIES {
+		return nil, 0, txerr(TX_ERR_VAULT_PARAMS_INVALID, "CORE_VAULT whitelist_count out of range")
 	}
 
-	expectedLen := 32 + 1 + 1 + int(v.KeyCount)*32 + 2 + int(v.WhitelistCount)*32
+	expectedLen := 32 + 1 + 1 + int(keyCount)*32 + 2 + int(whitelistCount)*32
 	if len(covData) != expectedLen {
-		return nil, txerr(TX_ERR_VAULT_MALFORMED, "CORE_VAULT covenant_data length mismatch")
+		return nil, 0, txerr(TX_ERR_VAULT_MALFORMED, "CORE_VAULT covenant_data length mismatch")
 	}
 
-	v.Whitelist = make([][32]byte, int(v.WhitelistCount))
-	for i := 0; i < int(v.WhitelistCount); i++ {
-		copy(v.Whitelist[i][:], covData[offset:offset+32])
+	whitelist := make([][32]byte, int(whitelistCount))
+	for i := 0; i < int(whitelistCount); i++ {
+		copy(whitelist[i][:], covData[offset:offset+32])
 		offset += 32
 	}
-	if enforceWhitelistCanonical {
-		if !strictlySortedUnique32(v.Whitelist) {
-			return nil, txerr(TX_ERR_VAULT_WHITELIST_NOT_CANONICAL, "CORE_VAULT whitelist not strictly sorted")
-		}
-		if HashInSorted32(v.Whitelist, v.OwnerLockID) {
-			return nil, txerr(TX_ERR_VAULT_OWNER_DESTINATION_FORBIDDEN, "CORE_VAULT whitelist contains owner_lock_id")
-		}
+	return whitelist, whitelistCount, nil
+}
+
+func validateVaultWhitelist(v *VaultCovenant, enforceWhitelistCanonical bool) error {
+	if !enforceWhitelistCanonical {
+		return nil
 	}
-	return &v, nil
+	if !strictlySortedUnique32(v.Whitelist) {
+		return txerr(TX_ERR_VAULT_WHITELIST_NOT_CANONICAL, "CORE_VAULT whitelist not strictly sorted")
+	}
+	if HashInSorted32(v.Whitelist, v.OwnerLockID) {
+		return txerr(TX_ERR_VAULT_OWNER_DESTINATION_FORBIDDEN, "CORE_VAULT whitelist contains owner_lock_id")
+	}
+	return nil
 }
 
 func ParseMultisigCovenantData(covData []byte) (*MultisigCovenant, error) {
+	m, err := parseMultisigHeader(covData)
+	if err != nil {
+		return nil, err
+	}
+
+	m.Keys = copyFixed32List(covData, 2, int(m.KeyCount))
+	if !strictlySortedUnique32(m.Keys) {
+		return nil, txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_MULTISIG keys not strictly sorted")
+	}
+	return m, nil
+}
+
+func parseMultisigHeader(covData []byte) (*MultisigCovenant, error) {
 	if len(covData) < 34 {
 		return nil, txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_MULTISIG covenant_data too short")
 	}
@@ -106,17 +150,16 @@ func ParseMultisigCovenantData(covData []byte) (*MultisigCovenant, error) {
 	if len(covData) != expectedLen {
 		return nil, txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_MULTISIG covenant_data length mismatch")
 	}
+	return &m, nil
+}
 
-	m.Keys = make([][32]byte, int(m.KeyCount))
-	offset := 2
-	for i := 0; i < int(m.KeyCount); i++ {
-		copy(m.Keys[i][:], covData[offset:offset+32])
+func copyFixed32List(data []byte, offset int, count int) [][32]byte {
+	items := make([][32]byte, count)
+	for i := 0; i < count; i++ {
+		copy(items[i][:], data[offset:offset+32])
 		offset += 32
 	}
-	if !strictlySortedUnique32(m.Keys) {
-		return nil, txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_MULTISIG keys not strictly sorted")
-	}
-	return &m, nil
+	return items
 }
 
 // OutputDescriptorBytes returns canonical output serialization used for CORE_VAULT whitelist hashing.
@@ -135,16 +178,9 @@ func WitnessSlots(covenantType uint16, covenantData []byte) (int, error) {
 	case COV_TYPE_P2PK:
 		return 1, nil
 	case COV_TYPE_MULTISIG:
-		if len(covenantData) >= 2 {
-			return int(covenantData[1]), nil
-		}
-		return 1, nil
+		return multisigWitnessSlots(covenantData), nil
 	case COV_TYPE_VAULT:
-		// CORE_VAULT: owner_lock_id[32] || threshold[1] || key_count[1] || ...
-		if len(covenantData) >= 34 {
-			return int(covenantData[33]), nil
-		}
-		return 1, nil
+		return vaultWitnessSlots(covenantData), nil
 	case COV_TYPE_HTLC:
 		return 2, nil
 	case COV_TYPE_CORE_EXT:
@@ -154,6 +190,21 @@ func WitnessSlots(covenantType uint16, covenantData []byte) (int, error) {
 	default:
 		return 0, txerr(TX_ERR_COVENANT_TYPE_INVALID, "unsupported covenant in witness_slots")
 	}
+}
+
+func multisigWitnessSlots(covenantData []byte) int {
+	if len(covenantData) >= 2 {
+		return int(covenantData[1])
+	}
+	return 1
+}
+
+func vaultWitnessSlots(covenantData []byte) int {
+	// CORE_VAULT: owner_lock_id[32] || threshold[1] || key_count[1] || ...
+	if len(covenantData) >= 34 {
+		return int(covenantData[33])
+	}
+	return 1
 }
 
 func HashInSorted32(list [][32]byte, target [32]byte) bool {


### PR DESCRIPTION
Invariant:
Reduce safe Go consensus Codacy shape rows without changing consensus behavior or public typed HTLC APIs.

Layer:
consensus-adjacent refactor only.

Files changed:
- clients/go/consensus/htlc.go
- clients/go/consensus/vault.go

Scope:
- split private HTLC/vault parsing and validation helpers
- preserve exported ValidateHTLCSpend* typed signatures
- preserve validation order, public error classes, and caller contracts

### Parity exemption justification

This is a Go-only private helper extraction for Codacy shape reduction. It does not change consensus semantics, wire format, fixtures, CLI replay output, or public HTLC/vault validation contracts. No Rust change is required because the diff preserves the existing Go behavior and does not introduce a new parity obligation.

Validation:
- lizard medium rows check for htlc.go, vault.go, spend_verify.go — PASS
- go test ./consensus focused HTLC/Vault/Covenant/Witness/Multisig/P2PK/Threshold tests — PASS
- gocyclo -over 8 on touched/related files — PASS
- go vet ./consensus — PASS
- gofmt check — PASS
- git diff --check — PASS
- go test ./... — PASS
- rubin-precommit-one-review — PASS
- one isolated stock code-review pass — No findings
- rubin-common-preflight coverage lane — PASS
- rubin-push — PASS

Known non-goal:
HTLC public parameter-count rows remain intentionally unchanged because removing them safely would require a public API contract change. This PR does not repeat the unsafe PR #1642 args-any/reflection approach.

Refs RUB-261.
