### PR TITLE
RUB-285 go: trim CORE_EXT spend parameter shape

### DIFF
--- a/clients/go/consensus/core_ext.go
+++ b/clients/go/consensus/core_ext.go
@@ -193,34 +193,46 @@ func cloneAllowedSuites(allowed map[uint8]struct{}) map[uint8]struct{} {
 	return out
 }
 
-func wrapCoreExtVerifySigExtWithTxContext(fn CoreExtVerifySigExtFunc) CoreExtVerifySigExtTxContextFunc {
-	if fn == nil {
-		return nil
-	}
-	return func(
-		extID uint16,
-		suiteID uint8,
-		pubkey []byte,
-		signature []byte,
-		digest32 [32]byte,
-		extPayload []byte,
-		_ *TxContextBase,
-		_ *TxContextContinuing,
-		_ uint64,
-	) (bool, error) {
-		return fn(extID, suiteID, pubkey, signature, digest32, extPayload)
-	}
+type coreExtVerifySigExtTxContextCall struct {
+	extID          uint16
+	suiteID        uint8
+	pubkey         []byte
+	signature      []byte
+	digest32       [32]byte
+	extPayload     []byte
+	ctxBase        *TxContextBase
+	ctxContinuing  *TxContextContinuing
+	selfInputValue uint64
 }
 
 func hasCoreExtVerifySigExtBinding(profile CoreExtDeploymentProfile) bool {
 	return profile.VerifySigExtFn != nil || profile.VerifySigExtTxContextFn != nil
 }
 
-func coreExtVerifySigExtTxContextFn(profile CoreExtProfile) CoreExtVerifySigExtTxContextFunc {
+func hasCoreExtVerifySigExtProfileBinding(profile CoreExtProfile) bool {
+	return profile.VerifySigExtFn != nil || profile.VerifySigExtTxContextFn != nil
+}
+
+func verifyCoreExtProfileTxContext(profile CoreExtProfile, call coreExtVerifySigExtTxContextCall) (bool, bool, error) {
 	if profile.VerifySigExtTxContextFn != nil {
-		return profile.VerifySigExtTxContextFn
+		ok, err := profile.VerifySigExtTxContextFn(
+			call.extID,
+			call.suiteID,
+			call.pubkey,
+			call.signature,
+			call.digest32,
+			call.extPayload,
+			call.ctxBase,
+			call.ctxContinuing,
+			call.selfInputValue,
+		)
+		return ok, true, err
 	}
-	return wrapCoreExtVerifySigExtWithTxContext(profile.VerifySigExtFn)
+	if profile.VerifySigExtFn != nil {
+		ok, err := profile.VerifySigExtFn(call.extID, call.suiteID, call.pubkey, call.signature, call.digest32, call.extPayload)
+		return ok, true, err
+	}
+	return false, false, nil
 }
 
 func sortedAllowedSuites(allowed map[uint8]struct{}) []uint8 {
@@ -392,8 +404,7 @@ func validateCoreExtWitnessAtHeight(
 		return err
 	}
 	if profile.TxContextEnabled {
-		verifyTxContextFn := coreExtVerifySigExtTxContextFn(profile)
-		if verifyTxContextFn == nil {
+		if !hasCoreExtVerifySigExtProfileBinding(profile) {
 			return txerr(TX_ERR_SIG_ALG_INVALID, "CORE_EXT verify_sig_ext unsupported")
 		}
 		if txContext == nil || txContext.Base == nil {
@@ -403,17 +414,17 @@ func validateCoreExtWitnessAtHeight(
 		if !ok || ctxContinuing == nil {
 			return txerr(TX_ERR_SIG_INVALID, "CORE_EXT txcontext continuing bundle missing")
 		}
-		ok, err := verifyTxContextFn(
-			cd.ExtID,
-			w.SuiteID,
-			w.Pubkey,
-			cryptoSig,
-			digest,
-			cd.ExtPayload,
-			txContext.Base,
-			ctxContinuing,
-			inputValue,
-		)
+		ok, _, err := verifyCoreExtProfileTxContext(profile, coreExtVerifySigExtTxContextCall{
+			extID:          cd.ExtID,
+			suiteID:        w.SuiteID,
+			pubkey:         w.Pubkey,
+			signature:      cryptoSig,
+			digest32:       digest,
+			extPayload:     cd.ExtPayload,
+			ctxBase:        txContext.Base,
+			ctxContinuing:  ctxContinuing,
+			selfInputValue: inputValue,
+		})
 		if err != nil {
 			return txerr(TX_ERR_SIG_ALG_INVALID, "CORE_EXT verify_sig_ext error")
 		}
@@ -435,32 +446,34 @@ func validateCoreExtWitnessAtHeight(
 	return nil
 }
 
-func validateCoreExtSpendWithCache(
-	entry UtxoEntry,
-	w WitnessItem,
-	tx *Tx,
-	inputIndex uint32,
-	inputValue uint64,
-	chainID [32]byte,
-	blockHeight uint64,
-	sighashCache *SighashV1PrehashCache,
-	coreExtProfiles CoreExtProfileProvider,
-	rotation RotationProvider,
-	registry *SuiteRegistry,
-	txContext *TxContextBundle,
-) error {
-	cd, err := ParseCoreExtCovenantData(entry.CovenantData)
+type coreExtSpendValidation struct {
+	entry           UtxoEntry
+	w               WitnessItem
+	tx              *Tx
+	inputIndex      uint32
+	inputValue      uint64
+	chainID         [32]byte
+	blockHeight     uint64
+	sighashCache    *SighashV1PrehashCache
+	coreExtProfiles CoreExtProfileProvider
+	rotation        RotationProvider
+	registry        *SuiteRegistry
+	txContext       *TxContextBundle
+}
+
+func validateCoreExtSpendWithCache(check coreExtSpendValidation) error {
+	cd, err := ParseCoreExtCovenantData(check.entry.CovenantData)
 	if err != nil {
 		return err
 	}
 
-	if coreExtProfiles == nil {
+	if check.coreExtProfiles == nil {
 		return txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_EXT profile provider missing")
 	}
 
 	profile := CoreExtProfile{}
 	active := false
-	resolved, ok, err := coreExtProfiles.LookupCoreExtProfile(cd.ExtID, blockHeight)
+	resolved, ok, err := check.coreExtProfiles.LookupCoreExtProfile(cd.ExtID, check.blockHeight)
 	if err != nil {
 		return txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_EXT profile lookup failure")
 	}
@@ -475,16 +488,16 @@ func validateCoreExtSpendWithCache(
 	return validateCoreExtWitnessAtHeight(
 		cd,
 		profile,
-		w,
-		tx,
-		inputIndex,
-		inputValue,
-		chainID,
-		blockHeight,
-		sighashCache,
-		rotation,
-		registry,
-		txContext,
+		check.w,
+		check.tx,
+		check.inputIndex,
+		check.inputValue,
+		check.chainID,
+		check.blockHeight,
+		check.sighashCache,
+		check.rotation,
+		check.registry,
+		check.txContext,
 		nil,
 	)
 }

--- a/clients/go/consensus/core_ext.go
+++ b/clients/go/consensus/core_ext.go
@@ -209,13 +209,9 @@ func hasCoreExtVerifySigExtBinding(profile CoreExtDeploymentProfile) bool {
 	return profile.VerifySigExtFn != nil || profile.VerifySigExtTxContextFn != nil
 }
 
-func hasCoreExtVerifySigExtProfileBinding(profile CoreExtProfile) bool {
-	return profile.VerifySigExtFn != nil || profile.VerifySigExtTxContextFn != nil
-}
-
-func verifyCoreExtProfileTxContext(profile CoreExtProfile, call coreExtVerifySigExtTxContextCall) (bool, bool, error) {
+func verifyCoreExtProfileTxContext(profile CoreExtProfile, call coreExtVerifySigExtTxContextCall) (bool, error) {
 	if profile.VerifySigExtTxContextFn != nil {
-		ok, err := profile.VerifySigExtTxContextFn(
+		return profile.VerifySigExtTxContextFn(
 			call.extID,
 			call.suiteID,
 			call.pubkey,
@@ -226,13 +222,11 @@ func verifyCoreExtProfileTxContext(profile CoreExtProfile, call coreExtVerifySig
 			call.ctxContinuing,
 			call.selfInputValue,
 		)
-		return ok, true, err
 	}
 	if profile.VerifySigExtFn != nil {
-		ok, err := profile.VerifySigExtFn(call.extID, call.suiteID, call.pubkey, call.signature, call.digest32, call.extPayload)
-		return ok, true, err
+		return profile.VerifySigExtFn(call.extID, call.suiteID, call.pubkey, call.signature, call.digest32, call.extPayload)
 	}
-	return false, false, nil
+	return false, nil
 }
 
 func sortedAllowedSuites(allowed map[uint8]struct{}) []uint8 {
@@ -404,7 +398,7 @@ func validateCoreExtWitnessAtHeight(
 		return err
 	}
 	if profile.TxContextEnabled {
-		if !hasCoreExtVerifySigExtProfileBinding(profile) {
+		if profile.VerifySigExtFn == nil && profile.VerifySigExtTxContextFn == nil {
 			return txerr(TX_ERR_SIG_ALG_INVALID, "CORE_EXT verify_sig_ext unsupported")
 		}
 		if txContext == nil || txContext.Base == nil {
@@ -414,7 +408,7 @@ func validateCoreExtWitnessAtHeight(
 		if !ok || ctxContinuing == nil {
 			return txerr(TX_ERR_SIG_INVALID, "CORE_EXT txcontext continuing bundle missing")
 		}
-		ok, _, err := verifyCoreExtProfileTxContext(profile, coreExtVerifySigExtTxContextCall{
+		ok, err := verifyCoreExtProfileTxContext(profile, coreExtVerifySigExtTxContextCall{
 			extID:          cd.ExtID,
 			suiteID:        w.SuiteID,
 			pubkey:         w.Pubkey,

--- a/clients/go/consensus/core_ext_test.go
+++ b/clients/go/consensus/core_ext_test.go
@@ -203,132 +203,28 @@ func TestStaticCoreExtProfileProviderNilReceiverAndUnknownExtID(t *testing.T) {
 	}
 }
 
-func TestWrapCoreExtVerifySigExtWithTxContextNilAndForwarding(t *testing.T) {
-	if wrapCoreExtVerifySigExtWithTxContext(nil) != nil {
-		t.Fatalf("nil verify_sig_ext function must stay nil after wrapping")
-	}
-
-	digest := [32]byte{0: 0xaa, 31: 0x55}
-	pubkey := []byte{0x01, 0x02}
-	signature := []byte{0x03, 0x04}
-	extPayload := []byte{0x05, 0x06}
-
+func TestVerifyCoreExtProfileTxContextLegacyFallback(t *testing.T) {
 	called := false
-	wrapped := wrapCoreExtVerifySigExtWithTxContext(func(
-		extID uint16,
-		suiteID uint8,
-		gotPubkey []byte,
-		gotSignature []byte,
-		gotDigest [32]byte,
-		gotPayload []byte,
-	) (bool, error) {
-		called = true
-		if extID != 7 || suiteID != 3 {
-			t.Fatalf("unexpected ext dispatch: ext_id=%d suite_id=%d", extID, suiteID)
-		}
-		if string(gotPubkey) != string(pubkey) {
-			t.Fatalf("unexpected pubkey: %x", gotPubkey)
-		}
-		if string(gotSignature) != string(signature) {
-			t.Fatalf("unexpected signature: %x", gotSignature)
-		}
-		if gotDigest != digest {
-			t.Fatalf("unexpected digest: %x", gotDigest)
-		}
-		if string(gotPayload) != string(extPayload) {
-			t.Fatalf("unexpected payload: %x", gotPayload)
-		}
-		return true, nil
-	})
-	if wrapped == nil {
-		t.Fatalf("expected wrapped verifier")
-	}
-	ok, err := wrapped(
-		7,
-		3,
-		pubkey,
-		signature,
-		digest,
-		extPayload,
-		&TxContextBase{},
-		&TxContextContinuing{},
-		42,
-	)
-	if err != nil {
-		t.Fatalf("wrapped verifier error: %v", err)
-	}
-	if !ok {
-		t.Fatalf("wrapped verifier must preserve legacy success result")
-	}
-	if !called {
-		t.Fatalf("wrapped verifier did not call legacy verifier")
-	}
-}
-
-func TestCoreExtVerifySigExtTxContextFnPrefersExplicitBinding(t *testing.T) {
-	explicitCalled := false
-	legacyCalled := false
-	explicitFn := func(
-		uint16,
-		uint8,
-		[]byte,
-		[]byte,
-		[32]byte,
-		[]byte,
-		*TxContextBase,
-		*TxContextContinuing,
-		uint64,
-	) (bool, error) {
-		explicitCalled = true
-		return true, nil
-	}
-	legacyFn := func(uint16, uint8, []byte, []byte, [32]byte, []byte) (bool, error) {
-		legacyCalled = true
-		return true, nil
-	}
-
-	preferred := coreExtVerifySigExtTxContextFn(CoreExtProfile{
-		VerifySigExtFn:          legacyFn,
-		VerifySigExtTxContextFn: explicitFn,
-	})
-	if preferred == nil {
-		t.Fatalf("expected explicit txcontext verifier")
-	}
-	ok, err := preferred(7, 3, nil, nil, [32]byte{}, nil, &TxContextBase{}, &TxContextContinuing{}, 1)
-	if err != nil {
-		t.Fatalf("preferred verifier error: %v", err)
-	}
-	if !ok {
-		t.Fatalf("preferred verifier must return explicit success result")
-	}
-	if !explicitCalled {
-		t.Fatalf("explicit txcontext verifier not called")
-	}
-	if legacyCalled {
-		t.Fatalf("legacy verifier must not be used when explicit txcontext binding exists")
-	}
-
-	explicitCalled = false
-	legacyCalled = false
-	fallback := coreExtVerifySigExtTxContextFn(CoreExtProfile{VerifySigExtFn: legacyFn})
-	if fallback == nil {
-		t.Fatalf("expected wrapped legacy verifier fallback")
-	}
-	ok, err = fallback(7, 3, nil, nil, [32]byte{}, nil, &TxContextBase{}, &TxContextContinuing{}, 2)
-	if err != nil {
-		t.Fatalf("fallback verifier error: %v", err)
-	}
-	if !ok {
-		t.Fatalf("fallback verifier must preserve legacy success result")
-	}
-	if !legacyCalled {
-		t.Fatalf("legacy verifier fallback not called")
-	}
-	if explicitCalled {
-		t.Fatalf("explicit verifier state leaked into fallback path")
-	}
-	if coreExtVerifySigExtTxContextFn(CoreExtProfile{}) != nil {
-		t.Fatalf("empty profile must not synthesize verify_sig_ext binding")
+	ok, handled, err := verifyCoreExtProfileTxContext(CoreExtProfile{
+		VerifySigExtFn: func(uint16, uint8, []byte, []byte, [32]byte, []byte) (bool, error) {
+			called = true
+			return true, nil
+		},
+	}, coreExtVerifySigExtTxContextCall{})
+	got := struct {
+		ok      bool
+		handled bool
+		called  bool
+		err     error
+	}{ok: ok, handled: handled, called: called, err: err}
+	want := struct {
+		ok      bool
+		handled bool
+		called  bool
+		err     error
+	}{ok: true, handled: true, called: true}
+	if got != want {
+		t.Fatalf("legacy fallback result=%+v", got)
 	}
 }
 
@@ -643,10 +539,15 @@ func TestValidateCoreExtWitnessAtHeight_TxContextEnabledDispatchesNineParam(t *t
 	}
 
 	called := false
+	legacyCalled := false
 	profile := CoreExtProfile{
 		Active:           true,
 		TxContextEnabled: true,
 		AllowedSuites:    map[uint8]struct{}{0x42: {}},
+		VerifySigExtFn: func(uint16, uint8, []byte, []byte, [32]byte, []byte) (bool, error) {
+			legacyCalled = true
+			return false, nil
+		},
 		VerifySigExtTxContextFn: func(
 			extID uint16,
 			suiteID uint8,
@@ -705,6 +606,9 @@ func TestValidateCoreExtWitnessAtHeight_TxContextEnabledDispatchesNineParam(t *t
 	}
 	if !called {
 		t.Fatalf("expected 9-parameter verifier to run")
+	}
+	if legacyCalled {
+		t.Fatalf("legacy verifier must not run when explicit txcontext verifier is present")
 	}
 }
 

--- a/clients/go/consensus/core_ext_test.go
+++ b/clients/go/consensus/core_ext_test.go
@@ -1,6 +1,7 @@
 package consensus
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"strings"
@@ -205,26 +206,59 @@ func TestStaticCoreExtProfileProviderNilReceiverAndUnknownExtID(t *testing.T) {
 
 func TestVerifyCoreExtProfileTxContextLegacyFallback(t *testing.T) {
 	called := false
-	ok, handled, err := verifyCoreExtProfileTxContext(CoreExtProfile{
-		VerifySigExtFn: func(uint16, uint8, []byte, []byte, [32]byte, []byte) (bool, error) {
+	call := testCoreExtVerifySigExtTxContextCall()
+	var forwarded coreExtVerifySigExtTxContextCall
+	ok, err := verifyCoreExtProfileTxContext(CoreExtProfile{
+		VerifySigExtFn: func(extID uint16, suiteID uint8, pubkey []byte, signature []byte, digest32 [32]byte, extPayload []byte) (bool, error) {
 			called = true
+			forwarded = coreExtVerifySigExtTxContextCall{
+				extID:      extID,
+				suiteID:    suiteID,
+				pubkey:     pubkey,
+				signature:  signature,
+				digest32:   digest32,
+				extPayload: extPayload,
+			}
 			return true, nil
 		},
-	}, coreExtVerifySigExtTxContextCall{})
+	}, call)
 	got := struct {
-		ok      bool
-		handled bool
-		called  bool
-		err     error
-	}{ok: ok, handled: handled, called: called, err: err}
+		ok     bool
+		called bool
+		err    error
+	}{ok: ok, called: called, err: err}
 	want := struct {
-		ok      bool
-		handled bool
-		called  bool
-		err     error
-	}{ok: true, handled: true, called: true}
+		ok     bool
+		called bool
+		err    error
+	}{ok: true, called: true}
 	if got != want {
 		t.Fatalf("legacy fallback result=%+v", got)
+	}
+	assertCoreExtVerifySigExtCall(t, forwarded, call)
+}
+
+func testCoreExtVerifySigExtTxContextCall() coreExtVerifySigExtTxContextCall {
+	var digest [32]byte
+	digest[0] = 0xd1
+	digest[31] = 0xd2
+	return coreExtVerifySigExtTxContextCall{
+		extID:          0x0a0b,
+		suiteID:        0x0c,
+		pubkey:         []byte{0x01, 0x02},
+		signature:      []byte{0x03, 0x04},
+		digest32:       digest,
+		extPayload:     []byte{0x05, 0x06},
+		ctxBase:        &TxContextBase{Height: 7},
+		ctxContinuing:  &TxContextContinuing{ContinuingOutputCount: 1},
+		selfInputValue: 11,
+	}
+}
+
+func assertCoreExtVerifySigExtCall(t *testing.T, got, want coreExtVerifySigExtTxContextCall) {
+	t.Helper()
+	if got.extID != want.extID || got.suiteID != want.suiteID || !bytes.Equal(got.pubkey, want.pubkey) || !bytes.Equal(got.signature, want.signature) || got.digest32 != want.digest32 || !bytes.Equal(got.extPayload, want.extPayload) {
+		t.Fatalf("verify_sig_ext forwarded call=%+v, want %+v", got, want)
 	}
 }
 
@@ -563,8 +597,21 @@ func TestValidateCoreExtWitnessAtHeight_TxContextEnabledDispatchesNineParam(t *t
 			if extID != 7 || suiteID != 0x42 {
 				t.Fatalf("extID/suiteID=%d/%d", extID, suiteID)
 			}
+			if !bytes.Equal(pubkey, []byte{0x01, 0x02, 0x03}) {
+				t.Fatalf("pubkey=%x", pubkey)
+			}
+			if !bytes.Equal(signature, []byte{0x04}) {
+				t.Fatalf("signature=%x", signature)
+			}
 			if string(extPayload) != string([]byte{0xaa}) {
 				t.Fatalf("extPayload=%x", extPayload)
+			}
+			wantDigest, err := SighashV1DigestWithCache(sighashCache, 0, 100, [32]byte{0: 0x55}, SIGHASH_ALL)
+			if err != nil {
+				t.Fatalf("SighashV1DigestWithCache: %v", err)
+			}
+			if digest32 != wantDigest {
+				t.Fatalf("digest32=%x, want %x", digest32, wantDigest)
 			}
 			if ctxBase == nil || ctxBase.TotalIn != (Uint128{Lo: 100, Hi: 0}) || ctxBase.TotalOut != (Uint128{Lo: 90, Hi: 0}) || ctxBase.Height != 55 {
 				t.Fatalf("ctxBase=%+v", ctxBase)
@@ -578,9 +625,6 @@ func TestValidateCoreExtWitnessAtHeight_TxContextEnabledDispatchesNineParam(t *t
 			if selfInputValue != 100 {
 				t.Fatalf("selfInputValue=%d", selfInputValue)
 			}
-			_ = pubkey
-			_ = signature
-			_ = digest32
 			return true, nil
 		},
 		BindingDescriptor: []byte{0xa1},

--- a/clients/go/consensus/utxo_basic.go
+++ b/clients/go/consensus/utxo_basic.go
@@ -357,7 +357,20 @@ func (ctx *nonCoinbaseApplyContext) validateCoreExtInput(inputIndex int, entry U
 	if len(assigned) != CORE_EXT_WITNESS_SLOTS {
 		return txerr(TX_ERR_PARSE, "CORE_EXT witness_slots must be 1")
 	}
-	return validateCoreExtSpendWithCache(entry, assigned[0], ctx.tx, uint32(inputIndex), entry.Value, ctx.chainID, ctx.height, ctx.sighashCache, ctx.coreExtProfiles, ctx.rotation, ctx.registry, ctx.txContext)
+	return validateCoreExtSpendWithCache(coreExtSpendValidation{
+		entry:           entry,
+		w:               assigned[0],
+		tx:              ctx.tx,
+		inputIndex:      uint32(inputIndex),
+		inputValue:      entry.Value,
+		chainID:         ctx.chainID,
+		blockHeight:     ctx.height,
+		sighashCache:    ctx.sighashCache,
+		coreExtProfiles: ctx.coreExtProfiles,
+		rotation:        ctx.rotation,
+		registry:        ctx.registry,
+		txContext:       ctx.txContext,
+	})
 }
 
 func (ctx *nonCoinbaseApplyContext) validateCoreStealthInput(inputIndex int, entry UtxoEntry, assigned []WitnessItem) error {


### PR DESCRIPTION
Refs: Q-CODACY-GO-CORE-EXT-SPEND-CONTEXT-SHAPE-01
Closes #1648

## Summary

Private Go CORE_EXT parameter-shape refactor for RUB-285.

## Scope

- `clients/go/consensus/core_ext.go`
- `clients/go/consensus/core_ext_test.go`
- `clients/go/consensus/utxo_basic.go`
- No Rust changes.
- No fixture changes.
- No spec/formal changes.
- No witness-heavy RUB-284 cleanup.

Consensus rules unchanged: YES
SECTION_HASHES.json unchanged: YES

## Validation

- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./consensus -run "Test.*CoreExt|Test.*ValidateTxLocal_CoreExt|Test.*ValidateCoreExtSpendQ" -count=1'`
- `scripts/dev-env.sh -- python3 conformance/runner/run_cv_bundle.py --only-gates CV-TXCTX CV-EXT CV-UTXO-BASIC`
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./...'`
- `git diff --check origin/main...HEAD`

### Parity exemption justification

Go-only private parameter-shape refactor. Exported CORE_EXT function types are unchanged. Targeted CV-TXCTX/CV-EXT/CV-UTXO-BASIC gates passed.

### Fixture exemption justification

No conformance fixture semantics changed. Targeted conformance gates passed without fixture edits.


<!-- rubin-agent-meta actor=unknown action=pr-edit via=cl branch=codex/RUB-285-go-core-ext-spend-context wt=rubin-protocol-codex-RUB-285-core-ext-spend-context utc=2026-05-18T01:02:50Z -->
