### PR TITLE
RUB-248 rust: split tx helper signing shape

### DIFF
--- a/clients/rust/crates/rubin-consensus/src/tx_helpers.rs
+++ b/clients/rust/crates/rubin-consensus/src/tx_helpers.rs
@@ -8,7 +8,7 @@ use crate::constants::{
 use crate::error::{ErrorCode, TxError};
 use crate::hash::sha3_256;
 use crate::sighash::{sighash_v1_digest_with_cache, SighashV1PrehashCache};
-use crate::tx::{da_core_fields_bytes, Tx, WitnessItem};
+use crate::tx::{da_core_fields_bytes, Tx, TxInput, WitnessItem};
 use crate::utxo_basic::{Outpoint, UtxoEntry};
 
 pub trait DigestSigner {
@@ -66,6 +66,80 @@ pub fn marshal_tx(tx: &Tx) -> Result<Vec<u8>, TxError> {
     Ok(out)
 }
 
+fn signing_pubkey_key_id(pubkey: &[u8]) -> Result<[u8; 32], TxError> {
+    if pubkey.len() as u64 != ML_DSA_87_PUBKEY_BYTES {
+        return Err(TxError::new(
+            ErrorCode::TxErrSigNoncanonical,
+            "non-canonical ML-DSA public key length",
+        ));
+    }
+    Ok(sha3_256(pubkey))
+}
+
+fn signing_outpoint(input: &TxInput) -> Outpoint {
+    Outpoint {
+        txid: input.prev_txid,
+        vout: input.prev_vout,
+    }
+}
+
+fn signing_entry<'a>(
+    utxo_set: &'a HashMap<Outpoint, UtxoEntry>,
+    input: &TxInput,
+    key_id: &[u8; 32],
+) -> Result<&'a UtxoEntry, TxError> {
+    let outpoint = signing_outpoint(input);
+    let entry = utxo_set
+        .get(&outpoint)
+        .ok_or_else(|| TxError::new(ErrorCode::TxErrMissingUtxo, "utxo not found for signing"))?;
+    validate_signing_entry(entry, key_id)?;
+    Ok(entry)
+}
+
+fn validate_signing_entry(entry: &UtxoEntry, key_id: &[u8; 32]) -> Result<(), TxError> {
+    if entry.covenant_type != COV_TYPE_P2PK {
+        return Err(TxError::new(
+            ErrorCode::TxErrCovenantTypeInvalid,
+            "unsupported covenant type for signing",
+        ));
+    }
+    if entry.covenant_data.len() as u64 != MAX_P2PK_COVENANT_DATA
+        || entry.covenant_data[0] != SUITE_ID_ML_DSA_87
+    {
+        return Err(TxError::new(
+            ErrorCode::TxErrCovenantTypeInvalid,
+            "CORE_P2PK covenant_data invalid",
+        ));
+    }
+    if entry.covenant_data[1..33] != key_id[..] {
+        return Err(TxError::new(
+            ErrorCode::TxErrSigInvalid,
+            "signer key binding mismatch",
+        ));
+    }
+    Ok(())
+}
+
+fn signed_witness_item(
+    signer: &impl DigestSigner,
+    pubkey: &[u8],
+    digest: [u8; 32],
+) -> Result<WitnessItem, TxError> {
+    let mut signature = signer.sign_digest32(digest)?;
+    if signature.len() as u64 != ML_DSA_87_SIG_BYTES {
+        return Err(TxError::new(
+            ErrorCode::TxErrSigNoncanonical,
+            "non-canonical ML-DSA signature length",
+        ));
+    }
+    signature.push(SIGHASH_ALL);
+    Ok(WitnessItem {
+        suite_id: SUITE_ID_ML_DSA_87,
+        pubkey: pubkey.to_vec(),
+        signature,
+    })
+}
+
 pub fn sign_transaction(
     tx: &mut Tx,
     utxo_set: &HashMap<Outpoint, UtxoEntry>,
@@ -80,45 +154,12 @@ pub fn sign_transaction(
     }
 
     let pubkey = signer.pubkey_bytes();
-    if pubkey.len() as u64 != ML_DSA_87_PUBKEY_BYTES {
-        return Err(TxError::new(
-            ErrorCode::TxErrSigNoncanonical,
-            "non-canonical ML-DSA public key length",
-        ));
-    }
-    let key_id = sha3_256(&pubkey);
+    let key_id = signing_pubkey_key_id(&pubkey)?;
 
     let mut sighash_cache = SighashV1PrehashCache::new(tx)?;
     let mut witness = Vec::with_capacity(tx.inputs.len());
     for (idx, input) in tx.inputs.iter().enumerate() {
-        let outpoint = Outpoint {
-            txid: input.prev_txid,
-            vout: input.prev_vout,
-        };
-        let entry = utxo_set.get(&outpoint).ok_or_else(|| {
-            TxError::new(ErrorCode::TxErrMissingUtxo, "utxo not found for signing")
-        })?;
-        if entry.covenant_type != COV_TYPE_P2PK {
-            return Err(TxError::new(
-                ErrorCode::TxErrCovenantTypeInvalid,
-                "unsupported covenant type for signing",
-            ));
-        }
-        if entry.covenant_data.len() as u64 != MAX_P2PK_COVENANT_DATA
-            || entry.covenant_data[0] != SUITE_ID_ML_DSA_87
-        {
-            return Err(TxError::new(
-                ErrorCode::TxErrCovenantTypeInvalid,
-                "CORE_P2PK covenant_data invalid",
-            ));
-        }
-        if entry.covenant_data[1..33] != key_id {
-            return Err(TxError::new(
-                ErrorCode::TxErrSigInvalid,
-                "signer key binding mismatch",
-            ));
-        }
-
+        let entry = signing_entry(utxo_set, input, &key_id)?;
         let digest = sighash_v1_digest_with_cache(
             &mut sighash_cache,
             idx as u32,
@@ -126,19 +167,7 @@ pub fn sign_transaction(
             chain_id,
             SIGHASH_ALL,
         )?;
-        let mut signature = signer.sign_digest32(digest)?;
-        if signature.len() as u64 != ML_DSA_87_SIG_BYTES {
-            return Err(TxError::new(
-                ErrorCode::TxErrSigNoncanonical,
-                "non-canonical ML-DSA signature length",
-            ));
-        }
-        signature.push(SIGHASH_ALL);
-        witness.push(WitnessItem {
-            suite_id: SUITE_ID_ML_DSA_87,
-            pubkey: pubkey.clone(),
-            signature,
-        });
+        witness.push(signed_witness_item(signer, &pubkey, digest)?);
     }
 
     tx.witness = witness;
@@ -146,414 +175,8 @@ pub fn sign_transaction(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::constants::{ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES, TX_WIRE_VERSION};
-    use crate::tx::{parse_tx, Tx, TxInput, TxOutput};
-
-    struct StubSigner {
-        pubkey: Vec<u8>,
-        signature: Vec<u8>,
-    }
-
-    impl DigestSigner for StubSigner {
-        fn pubkey_bytes(&self) -> Vec<u8> {
-            self.pubkey.clone()
-        }
-
-        fn sign_digest32(&self, _digest32: [u8; 32]) -> Result<Vec<u8>, TxError> {
-            Ok(self.signature.clone())
-        }
-    }
-
-    struct ErrorSigner;
-
-    impl DigestSigner for ErrorSigner {
-        fn pubkey_bytes(&self) -> Vec<u8> {
-            test_pubkey(0x77)
-        }
-
-        fn sign_digest32(&self, _digest32: [u8; 32]) -> Result<Vec<u8>, TxError> {
-            Err(TxError::new(
-                ErrorCode::TxErrSigInvalid,
-                "signer backend failure",
-            ))
-        }
-    }
-
-    fn test_pubkey(byte: u8) -> Vec<u8> {
-        vec![byte; ML_DSA_87_PUBKEY_BYTES as usize]
-    }
-
-    fn test_signature(byte: u8) -> Vec<u8> {
-        vec![byte; ML_DSA_87_SIG_BYTES as usize]
-    }
-
-    fn test_tx() -> Tx {
-        Tx {
-            version: TX_WIRE_VERSION,
-            tx_kind: 0x00,
-            tx_nonce: 7,
-            inputs: vec![TxInput {
-                prev_txid: [0x11; 32],
-                prev_vout: 0,
-                script_sig: Vec::new(),
-                sequence: 0,
-            }],
-            outputs: vec![TxOutput {
-                value: 9,
-                covenant_type: COV_TYPE_P2PK,
-                covenant_data: p2pk_covenant_data_for_pubkey(&test_pubkey(0x22)),
-            }],
-            locktime: 0,
-            da_commit_core: None,
-            da_chunk_core: None,
-            witness: Vec::new(),
-            da_payload: Vec::new(),
-        }
-    }
-
-    fn da_commit_tx() -> Tx {
-        Tx {
-            version: TX_WIRE_VERSION,
-            tx_kind: 0x01,
-            tx_nonce: 7,
-            inputs: Vec::new(),
-            outputs: vec![TxOutput {
-                value: 0,
-                covenant_type: COV_TYPE_P2PK,
-                covenant_data: Vec::new(),
-            }],
-            locktime: 0,
-            da_commit_core: Some(crate::tx::DaCommitCore {
-                da_id: [0x10; 32],
-                chunk_count: 1,
-                retl_domain_id: [0x20; 32],
-                batch_number: 9,
-                tx_data_root: [0x30; 32],
-                state_root: [0x40; 32],
-                withdrawals_root: [0x50; 32],
-                batch_sig_suite: 0x00,
-                batch_sig: vec![0xaa, 0xbb],
-            }),
-            da_chunk_core: None,
-            witness: Vec::new(),
-            da_payload: vec![0xde, 0xad, 0xbe, 0xef],
-        }
-    }
-
-    fn da_chunk_tx() -> Tx {
-        Tx {
-            version: TX_WIRE_VERSION,
-            tx_kind: 0x02,
-            tx_nonce: 9,
-            inputs: Vec::new(),
-            outputs: vec![TxOutput {
-                value: 0,
-                covenant_type: COV_TYPE_P2PK,
-                covenant_data: Vec::new(),
-            }],
-            locktime: 0,
-            da_commit_core: None,
-            da_chunk_core: Some(crate::tx::DaChunkCore {
-                da_id: [0x11; 32],
-                chunk_index: 0,
-                chunk_hash: [0x22; 32],
-            }),
-            witness: Vec::new(),
-            da_payload: vec![0x01],
-        }
-    }
-
-    fn test_utxos(pubkey: &[u8]) -> HashMap<Outpoint, UtxoEntry> {
-        HashMap::from([(
-            Outpoint {
-                txid: [0x11; 32],
-                vout: 0,
-            },
-            UtxoEntry {
-                value: 10,
-                covenant_type: COV_TYPE_P2PK,
-                covenant_data: p2pk_covenant_data_for_pubkey(pubkey),
-                creation_height: 0,
-                created_by_coinbase: false,
-            },
-        )])
-    }
-
-    #[test]
-    fn p2pk_covenant_data_for_pubkey_emits_canonical_shape_and_is_deterministic() {
-        let pubkey = b"rubin-p2pk-shape";
-        let covenant_data = p2pk_covenant_data_for_pubkey(pubkey);
-        let repeated = p2pk_covenant_data_for_pubkey(pubkey);
-
-        assert_eq!(covenant_data.len(), MAX_P2PK_COVENANT_DATA as usize);
-        assert_eq!(covenant_data[0], SUITE_ID_ML_DSA_87);
-        assert_eq!(covenant_data[1..33], sha3_256(pubkey));
-        assert_eq!(covenant_data, repeated);
-    }
-
-    #[test]
-    fn marshal_tx_roundtrips_via_parse_tx() {
-        let tx = test_tx();
-        let bytes = marshal_tx(&tx).expect("marshal");
-        let (parsed, _, _, consumed) = parse_tx(&bytes).expect("parse");
-        assert_eq!(consumed, bytes.len());
-        assert_eq!(parsed, tx);
-    }
-
-    #[test]
-    fn marshal_tx_with_inputs_outputs_roundtrips() {
-        let mut tx = test_tx();
-        tx.tx_nonce = 42;
-        tx.inputs[0].prev_txid[0..3].copy_from_slice(&[0x01, 0x02, 0x03]);
-        tx.inputs[0].prev_vout = 7;
-        tx.inputs[0].script_sig = vec![0xaa, 0xbb];
-        tx.inputs[0].sequence = u32::MAX;
-        tx.outputs = vec![
-            TxOutput {
-                value: 50_000,
-                covenant_type: 0,
-                covenant_data: Vec::new(),
-            },
-            TxOutput {
-                value: 10_000,
-                covenant_type: 1,
-                covenant_data: vec![0xcc],
-            },
-        ];
-        tx.locktime = 100;
-
-        let bytes = marshal_tx(&tx).expect("marshal");
-        let (parsed, _, _, consumed) = parse_tx(&bytes).expect("parse");
-        assert_eq!(consumed, bytes.len());
-        assert_eq!(parsed.inputs.len(), 1);
-        assert_eq!(parsed.inputs[0].prev_txid, tx.inputs[0].prev_txid);
-        assert_eq!(parsed.outputs.len(), 2);
-        assert_eq!(parsed.outputs[0].value, 50_000);
-        assert_eq!(parsed.locktime, 100);
-    }
-
-    #[test]
-    fn marshal_tx_empty_da_payload_roundtrips() {
-        let tx = Tx {
-            version: TX_WIRE_VERSION,
-            tx_kind: 0x00,
-            tx_nonce: 0,
-            inputs: Vec::new(),
-            outputs: Vec::new(),
-            locktime: 0,
-            da_commit_core: None,
-            da_chunk_core: None,
-            witness: Vec::new(),
-            da_payload: Vec::new(),
-        };
-
-        let bytes = marshal_tx(&tx).expect("marshal");
-        let (parsed, _, _, consumed) = parse_tx(&bytes).expect("parse");
-        assert_eq!(consumed, bytes.len());
-        assert!(parsed.da_payload.is_empty());
-    }
-
-    #[test]
-    fn marshal_tx_da_commit_roundtrips() {
-        let tx = da_commit_tx();
-        let bytes = marshal_tx(&tx).expect("marshal commit");
-        let (parsed, _, _, consumed) = parse_tx(&bytes).expect("parse commit");
-        assert_eq!(consumed, bytes.len());
-        assert_eq!(parsed.da_commit_core, tx.da_commit_core);
-        assert_eq!(parsed.da_payload, tx.da_payload);
-    }
-
-    #[test]
-    fn marshal_tx_da_chunk_roundtrips() {
-        let tx = da_chunk_tx();
-        let bytes = marshal_tx(&tx).expect("marshal chunk");
-        let (parsed, _, _, consumed) = parse_tx(&bytes).expect("parse chunk");
-        assert_eq!(consumed, bytes.len());
-        assert_eq!(parsed.da_chunk_core, tx.da_chunk_core);
-        assert_eq!(parsed.da_payload, tx.da_payload);
-    }
-
-    #[test]
-    fn marshal_tx_da_kind_missing_core_errors() {
-        let tx_commit = Tx {
-            version: TX_WIRE_VERSION,
-            tx_kind: 0x01,
-            tx_nonce: 0,
-            inputs: Vec::new(),
-            outputs: Vec::new(),
-            locktime: 0,
-            da_commit_core: None,
-            da_chunk_core: None,
-            witness: Vec::new(),
-            da_payload: vec![0x01],
-        };
-        let err = marshal_tx(&tx_commit).expect_err("missing commit core must fail");
-        assert_eq!(err.code, ErrorCode::TxErrParse);
-
-        let tx_chunk = Tx {
-            version: TX_WIRE_VERSION,
-            tx_kind: 0x02,
-            tx_nonce: 0,
-            inputs: Vec::new(),
-            outputs: Vec::new(),
-            locktime: 0,
-            da_commit_core: None,
-            da_chunk_core: None,
-            witness: Vec::new(),
-            da_payload: vec![0x01],
-        };
-        let err = marshal_tx(&tx_chunk).expect_err("missing chunk core must fail");
-        assert_eq!(err.code, ErrorCode::TxErrParse);
-    }
-
-    #[test]
-    fn sign_transaction_populates_canonical_mldsa_witness() {
-        let pubkey = test_pubkey(0x33);
-        let signer = StubSigner {
-            pubkey: pubkey.clone(),
-            signature: test_signature(0x44),
-        };
-        let mut tx = test_tx();
-        let chain_id = [0x55; 32];
-
-        sign_transaction(&mut tx, &test_utxos(&pubkey), chain_id, &signer).expect("sign");
-
-        assert_eq!(tx.witness.len(), 1);
-        let item = &tx.witness[0];
-        assert_eq!(item.suite_id, SUITE_ID_ML_DSA_87);
-        assert_eq!(item.pubkey, pubkey);
-        assert_eq!(item.signature.len(), (ML_DSA_87_SIG_BYTES + 1) as usize);
-        assert_eq!(item.signature.last(), Some(&SIGHASH_ALL));
-
-        let bytes = marshal_tx(&tx).expect("marshal signed tx");
-        let (parsed, _, _, consumed) = parse_tx(&bytes).expect("parse signed tx");
-        assert_eq!(consumed, bytes.len());
-        assert_eq!(parsed, tx);
-    }
-
-    #[test]
-    fn sign_transaction_rejects_utxo_key_binding_mismatch() {
-        let signer = StubSigner {
-            pubkey: test_pubkey(0x33),
-            signature: test_signature(0x44),
-        };
-        let mut tx = test_tx();
-        let err = sign_transaction(&mut tx, &test_utxos(&test_pubkey(0x22)), [0u8; 32], &signer)
-            .expect_err("key mismatch must fail");
-        assert_eq!(err.code, ErrorCode::TxErrSigInvalid);
-    }
-
-    #[test]
-    fn sign_transaction_rejects_noncanonical_signer_lengths() {
-        let signer = StubSigner {
-            pubkey: vec![0u8; (ML_DSA_87_PUBKEY_BYTES as usize) - 1],
-            signature: test_signature(0x44),
-        };
-        let mut tx = test_tx();
-        let err = sign_transaction(&mut tx, &test_utxos(&test_pubkey(0x33)), [0u8; 32], &signer)
-            .expect_err("bad pubkey len must fail");
-        assert_eq!(err.code, ErrorCode::TxErrSigNoncanonical);
-    }
-
-    #[test]
-    fn sign_transaction_rejects_empty_input_list() {
-        let signer = StubSigner {
-            pubkey: test_pubkey(0x33),
-            signature: test_signature(0x44),
-        };
-        let mut tx = test_tx();
-        tx.inputs.clear();
-        let err =
-            sign_transaction(&mut tx, &HashMap::new(), [0u8; 32], &signer).expect_err("empty");
-        assert_eq!(err.code, ErrorCode::TxErrParse);
-    }
-
-    #[test]
-    fn sign_transaction_rejects_missing_utxo() {
-        let signer = StubSigner {
-            pubkey: test_pubkey(0x33),
-            signature: test_signature(0x44),
-        };
-        let mut tx = test_tx();
-        let err =
-            sign_transaction(&mut tx, &HashMap::new(), [0u8; 32], &signer).expect_err("missing");
-        assert_eq!(err.code, ErrorCode::TxErrMissingUtxo);
-    }
-
-    #[test]
-    fn sign_transaction_rejects_non_p2pk_signing_entry() {
-        let signer = StubSigner {
-            pubkey: test_pubkey(0x33),
-            signature: test_signature(0x44),
-        };
-        let mut tx = test_tx();
-        let utxos = HashMap::from([(
-            Outpoint {
-                txid: [0x11; 32],
-                vout: 0,
-            },
-            UtxoEntry {
-                value: 10,
-                covenant_type: 0x0104,
-                covenant_data: vec![1, 1],
-                creation_height: 0,
-                created_by_coinbase: false,
-            },
-        )]);
-        let err =
-            sign_transaction(&mut tx, &utxos, [0u8; 32], &signer).expect_err("non-p2pk must fail");
-        assert_eq!(err.code, ErrorCode::TxErrCovenantTypeInvalid);
-    }
-
-    #[test]
-    fn sign_transaction_rejects_invalid_p2pk_covenant_data() {
-        let signer = StubSigner {
-            pubkey: test_pubkey(0x33),
-            signature: test_signature(0x44),
-        };
-        let mut tx = test_tx();
-        let utxos = HashMap::from([(
-            Outpoint {
-                txid: [0x11; 32],
-                vout: 0,
-            },
-            UtxoEntry {
-                value: 10,
-                covenant_type: COV_TYPE_P2PK,
-                covenant_data: vec![SUITE_ID_ML_DSA_87; 32],
-                creation_height: 0,
-                created_by_coinbase: false,
-            },
-        )]);
-        let err = sign_transaction(&mut tx, &utxos, [0u8; 32], &signer)
-            .expect_err("invalid covenant data");
-        assert_eq!(err.code, ErrorCode::TxErrCovenantTypeInvalid);
-    }
-
-    #[test]
-    fn sign_transaction_rejects_noncanonical_signature_length() {
-        let pubkey = test_pubkey(0x33);
-        let signer = StubSigner {
-            pubkey: pubkey.clone(),
-            signature: vec![0x44; (ML_DSA_87_SIG_BYTES as usize) - 1],
-        };
-        let mut tx = test_tx();
-        let err =
-            sign_transaction(&mut tx, &test_utxos(&pubkey), [0u8; 32], &signer).expect_err("sig");
-        assert_eq!(err.code, ErrorCode::TxErrSigNoncanonical);
-    }
-
-    #[test]
-    fn sign_transaction_propagates_signer_errors() {
-        let pubkey = test_pubkey(0x77);
-        let mut tx = test_tx();
-        let err = sign_transaction(&mut tx, &test_utxos(&pubkey), [0u8; 32], &ErrorSigner)
-            .expect_err("signer error");
-        assert_eq!(err.code, ErrorCode::TxErrSigInvalid);
-    }
-}
+#[path = "tx_helpers_tests/mod.rs"]
+mod tx_helpers_tests;
 
 #[cfg(kani)]
 mod verification {

--- a/clients/rust/crates/rubin-consensus/src/tx_helpers_tests/marshal.rs.inc
+++ b/clients/rust/crates/rubin-consensus/src/tx_helpers_tests/marshal.rs.inc
@@ -1,0 +1,126 @@
+#[test]
+fn p2pk_covenant_data_for_pubkey_emits_canonical_shape_and_is_deterministic() {
+    let pubkey = b"rubin-p2pk-shape";
+    let covenant_data = p2pk_covenant_data_for_pubkey(pubkey);
+    let repeated = p2pk_covenant_data_for_pubkey(pubkey);
+
+    assert_eq!(covenant_data.len(), MAX_P2PK_COVENANT_DATA as usize);
+    assert_eq!(covenant_data[0], SUITE_ID_ML_DSA_87);
+    assert_eq!(covenant_data[1..33], sha3_256(pubkey));
+    assert_eq!(covenant_data, repeated);
+}
+
+#[test]
+fn marshal_tx_roundtrips_via_parse_tx() {
+    let tx = test_tx();
+    let bytes = marshal_tx(&tx).expect("marshal");
+    let (parsed, _, _, consumed) = parse_tx(&bytes).expect("parse");
+    assert_eq!(consumed, bytes.len());
+    assert_eq!(parsed, tx);
+}
+
+#[test]
+fn marshal_tx_with_inputs_outputs_roundtrips() {
+    let mut tx = test_tx();
+    tx.tx_nonce = 42;
+    tx.inputs[0].prev_txid[0..3].copy_from_slice(&[0x01, 0x02, 0x03]);
+    tx.inputs[0].prev_vout = 7;
+    tx.inputs[0].script_sig = vec![0xaa, 0xbb];
+    tx.inputs[0].sequence = u32::MAX;
+    tx.outputs = vec![
+        TxOutput {
+            value: 50_000,
+            covenant_type: 0,
+            covenant_data: Vec::new(),
+        },
+        TxOutput {
+            value: 10_000,
+            covenant_type: 1,
+            covenant_data: vec![0xcc],
+        },
+    ];
+    tx.locktime = 100;
+
+    let bytes = marshal_tx(&tx).expect("marshal");
+    let (parsed, _, _, consumed) = parse_tx(&bytes).expect("parse");
+    assert_eq!(consumed, bytes.len());
+    assert_eq!(parsed.inputs.len(), 1);
+    assert_eq!(parsed.inputs[0].prev_txid, tx.inputs[0].prev_txid);
+    assert_eq!(parsed.outputs.len(), 2);
+    assert_eq!(parsed.outputs[0].value, 50_000);
+    assert_eq!(parsed.locktime, 100);
+}
+
+#[test]
+fn marshal_tx_empty_da_payload_roundtrips() {
+    let tx = Tx {
+        version: TX_WIRE_VERSION,
+        tx_kind: 0x00,
+        tx_nonce: 0,
+        inputs: Vec::new(),
+        outputs: Vec::new(),
+        locktime: 0,
+        da_commit_core: None,
+        da_chunk_core: None,
+        witness: Vec::new(),
+        da_payload: Vec::new(),
+    };
+
+    let bytes = marshal_tx(&tx).expect("marshal");
+    let (parsed, _, _, consumed) = parse_tx(&bytes).expect("parse");
+    assert_eq!(consumed, bytes.len());
+    assert!(parsed.da_payload.is_empty());
+}
+
+#[test]
+fn marshal_tx_da_commit_roundtrips() {
+    let tx = da_commit_tx();
+    let bytes = marshal_tx(&tx).expect("marshal commit");
+    let (parsed, _, _, consumed) = parse_tx(&bytes).expect("parse commit");
+    assert_eq!(consumed, bytes.len());
+    assert_eq!(parsed.da_commit_core, tx.da_commit_core);
+    assert_eq!(parsed.da_payload, tx.da_payload);
+}
+
+#[test]
+fn marshal_tx_da_chunk_roundtrips() {
+    let tx = da_chunk_tx();
+    let bytes = marshal_tx(&tx).expect("marshal chunk");
+    let (parsed, _, _, consumed) = parse_tx(&bytes).expect("parse chunk");
+    assert_eq!(consumed, bytes.len());
+    assert_eq!(parsed.da_chunk_core, tx.da_chunk_core);
+    assert_eq!(parsed.da_payload, tx.da_payload);
+}
+
+#[test]
+fn marshal_tx_da_kind_missing_core_errors() {
+    let tx_commit = Tx {
+        version: TX_WIRE_VERSION,
+        tx_kind: 0x01,
+        tx_nonce: 0,
+        inputs: Vec::new(),
+        outputs: Vec::new(),
+        locktime: 0,
+        da_commit_core: None,
+        da_chunk_core: None,
+        witness: Vec::new(),
+        da_payload: vec![0x01],
+    };
+    let err = marshal_tx(&tx_commit).expect_err("missing commit core must fail");
+    assert_eq!(err.code, ErrorCode::TxErrParse);
+
+    let tx_chunk = Tx {
+        version: TX_WIRE_VERSION,
+        tx_kind: 0x02,
+        tx_nonce: 0,
+        inputs: Vec::new(),
+        outputs: Vec::new(),
+        locktime: 0,
+        da_commit_core: None,
+        da_chunk_core: None,
+        witness: Vec::new(),
+        da_payload: vec![0x01],
+    };
+    let err = marshal_tx(&tx_chunk).expect_err("missing chunk core must fail");
+    assert_eq!(err.code, ErrorCode::TxErrParse);
+}

--- a/clients/rust/crates/rubin-consensus/src/tx_helpers_tests/mod.rs
+++ b/clients/rust/crates/rubin-consensus/src/tx_helpers_tests/mod.rs
@@ -1,0 +1,143 @@
+use super::*;
+use crate::constants::{ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES, TX_WIRE_VERSION};
+use crate::tx::{parse_tx, Tx, TxInput, TxOutput};
+
+struct StubSigner {
+    pubkey: Vec<u8>,
+    signature: Vec<u8>,
+}
+
+impl DigestSigner for StubSigner {
+    fn pubkey_bytes(&self) -> Vec<u8> {
+        self.pubkey.clone()
+    }
+
+    fn sign_digest32(&self, _digest32: [u8; 32]) -> Result<Vec<u8>, TxError> {
+        Ok(self.signature.clone())
+    }
+}
+
+struct ErrorSigner;
+
+impl DigestSigner for ErrorSigner {
+    fn pubkey_bytes(&self) -> Vec<u8> {
+        test_pubkey(0x77)
+    }
+
+    fn sign_digest32(&self, _digest32: [u8; 32]) -> Result<Vec<u8>, TxError> {
+        Err(TxError::new(
+            ErrorCode::TxErrSigInvalid,
+            "signer backend failure",
+        ))
+    }
+}
+
+fn test_pubkey(byte: u8) -> Vec<u8> {
+    vec![byte; ML_DSA_87_PUBKEY_BYTES as usize]
+}
+
+fn test_signature(byte: u8) -> Vec<u8> {
+    vec![byte; ML_DSA_87_SIG_BYTES as usize]
+}
+
+fn test_tx() -> Tx {
+    Tx {
+        version: TX_WIRE_VERSION,
+        tx_kind: 0x00,
+        tx_nonce: 7,
+        inputs: vec![TxInput {
+            prev_txid: [0x11; 32],
+            prev_vout: 0,
+            script_sig: Vec::new(),
+            sequence: 0,
+        }],
+        outputs: vec![TxOutput {
+            value: 9,
+            covenant_type: COV_TYPE_P2PK,
+            covenant_data: p2pk_covenant_data_for_pubkey(&test_pubkey(0x22)),
+        }],
+        locktime: 0,
+        da_commit_core: None,
+        da_chunk_core: None,
+        witness: Vec::new(),
+        da_payload: Vec::new(),
+    }
+}
+
+fn da_commit_tx() -> Tx {
+    Tx {
+        version: TX_WIRE_VERSION,
+        tx_kind: 0x01,
+        tx_nonce: 7,
+        inputs: Vec::new(),
+        outputs: vec![TxOutput {
+            value: 0,
+            covenant_type: COV_TYPE_P2PK,
+            covenant_data: Vec::new(),
+        }],
+        locktime: 0,
+        da_commit_core: Some(crate::tx::DaCommitCore {
+            da_id: [0x10; 32],
+            chunk_count: 1,
+            retl_domain_id: [0x20; 32],
+            batch_number: 9,
+            tx_data_root: [0x30; 32],
+            state_root: [0x40; 32],
+            withdrawals_root: [0x50; 32],
+            batch_sig_suite: 0x00,
+            batch_sig: vec![0xaa, 0xbb],
+        }),
+        da_chunk_core: None,
+        witness: Vec::new(),
+        da_payload: vec![0xde, 0xad, 0xbe, 0xef],
+    }
+}
+
+fn da_chunk_tx() -> Tx {
+    Tx {
+        version: TX_WIRE_VERSION,
+        tx_kind: 0x02,
+        tx_nonce: 9,
+        inputs: Vec::new(),
+        outputs: vec![TxOutput {
+            value: 0,
+            covenant_type: COV_TYPE_P2PK,
+            covenant_data: Vec::new(),
+        }],
+        locktime: 0,
+        da_commit_core: None,
+        da_chunk_core: Some(crate::tx::DaChunkCore {
+            da_id: [0x11; 32],
+            chunk_index: 0,
+            chunk_hash: [0x22; 32],
+        }),
+        witness: Vec::new(),
+        da_payload: vec![0x01],
+    }
+}
+
+fn test_utxos(pubkey: &[u8]) -> HashMap<Outpoint, UtxoEntry> {
+    HashMap::from([(
+        Outpoint {
+            txid: [0x11; 32],
+            vout: 0,
+        },
+        UtxoEntry {
+            value: 10,
+            covenant_type: COV_TYPE_P2PK,
+            covenant_data: p2pk_covenant_data_for_pubkey(pubkey),
+            creation_height: 0,
+            created_by_coinbase: false,
+        },
+    )])
+}
+
+mod marshal {
+    use super::*;
+    include!("marshal.rs.inc");
+}
+
+mod signing {
+    use super::*;
+    include!("signing.rs.inc");
+}

--- a/clients/rust/crates/rubin-consensus/src/tx_helpers_tests/signing.rs.inc
+++ b/clients/rust/crates/rubin-consensus/src/tx_helpers_tests/signing.rs.inc
@@ -1,0 +1,145 @@
+#[test]
+fn sign_transaction_populates_canonical_mldsa_witness() {
+    let pubkey = test_pubkey(0x33);
+    let signer = StubSigner {
+        pubkey: pubkey.clone(),
+        signature: test_signature(0x44),
+    };
+    let mut tx = test_tx();
+    let chain_id = [0x55; 32];
+
+    sign_transaction(&mut tx, &test_utxos(&pubkey), chain_id, &signer).expect("sign");
+
+    assert_eq!(tx.witness.len(), 1);
+    let item = &tx.witness[0];
+    assert_eq!(item.suite_id, SUITE_ID_ML_DSA_87);
+    assert_eq!(item.pubkey, pubkey);
+    assert_eq!(item.signature.len(), (ML_DSA_87_SIG_BYTES + 1) as usize);
+    assert_eq!(item.signature.last(), Some(&SIGHASH_ALL));
+
+    let bytes = marshal_tx(&tx).expect("marshal signed tx");
+    let (parsed, _, _, consumed) = parse_tx(&bytes).expect("parse signed tx");
+    assert_eq!(consumed, bytes.len());
+    assert_eq!(parsed, tx);
+}
+
+#[test]
+fn sign_transaction_rejects_utxo_key_binding_mismatch() {
+    let signer = StubSigner {
+        pubkey: test_pubkey(0x33),
+        signature: test_signature(0x44),
+    };
+    let mut tx = test_tx();
+    let err = sign_transaction(&mut tx, &test_utxos(&test_pubkey(0x22)), [0u8; 32], &signer)
+        .expect_err("key mismatch must fail");
+    assert_eq!(err.code, ErrorCode::TxErrSigInvalid);
+}
+
+#[test]
+fn sign_transaction_rejects_noncanonical_signer_lengths() {
+    let signer = StubSigner {
+        pubkey: vec![0u8; (ML_DSA_87_PUBKEY_BYTES as usize) - 1],
+        signature: test_signature(0x44),
+    };
+    let mut tx = test_tx();
+    let err = sign_transaction(&mut tx, &test_utxos(&test_pubkey(0x33)), [0u8; 32], &signer)
+        .expect_err("bad pubkey len must fail");
+    assert_eq!(err.code, ErrorCode::TxErrSigNoncanonical);
+}
+
+#[test]
+fn sign_transaction_rejects_empty_input_list() {
+    let signer = StubSigner {
+        pubkey: test_pubkey(0x33),
+        signature: test_signature(0x44),
+    };
+    let mut tx = test_tx();
+    tx.inputs.clear();
+    let err =
+        sign_transaction(&mut tx, &HashMap::new(), [0u8; 32], &signer).expect_err("empty");
+    assert_eq!(err.code, ErrorCode::TxErrParse);
+}
+
+#[test]
+fn sign_transaction_rejects_missing_utxo() {
+    let signer = StubSigner {
+        pubkey: test_pubkey(0x33),
+        signature: test_signature(0x44),
+    };
+    let mut tx = test_tx();
+    let err =
+        sign_transaction(&mut tx, &HashMap::new(), [0u8; 32], &signer).expect_err("missing");
+    assert_eq!(err.code, ErrorCode::TxErrMissingUtxo);
+}
+
+#[test]
+fn sign_transaction_rejects_non_p2pk_signing_entry() {
+    let signer = StubSigner {
+        pubkey: test_pubkey(0x33),
+        signature: test_signature(0x44),
+    };
+    let mut tx = test_tx();
+    let utxos = HashMap::from([(
+        Outpoint {
+            txid: [0x11; 32],
+            vout: 0,
+        },
+        UtxoEntry {
+            value: 10,
+            covenant_type: 0x0104,
+            covenant_data: vec![1, 1],
+            creation_height: 0,
+            created_by_coinbase: false,
+        },
+    )]);
+    let err =
+        sign_transaction(&mut tx, &utxos, [0u8; 32], &signer).expect_err("non-p2pk must fail");
+    assert_eq!(err.code, ErrorCode::TxErrCovenantTypeInvalid);
+}
+
+#[test]
+fn sign_transaction_rejects_invalid_p2pk_covenant_data() {
+    let signer = StubSigner {
+        pubkey: test_pubkey(0x33),
+        signature: test_signature(0x44),
+    };
+    let mut tx = test_tx();
+    let utxos = HashMap::from([(
+        Outpoint {
+            txid: [0x11; 32],
+            vout: 0,
+        },
+        UtxoEntry {
+            value: 10,
+            covenant_type: COV_TYPE_P2PK,
+            covenant_data: vec![SUITE_ID_ML_DSA_87; 32],
+            creation_height: 0,
+            created_by_coinbase: false,
+        },
+    )]);
+    let err = sign_transaction(&mut tx, &utxos, [0u8; 32], &signer)
+        .expect_err("invalid covenant data");
+    assert_eq!(err.code, ErrorCode::TxErrCovenantTypeInvalid);
+}
+
+#[test]
+fn sign_transaction_rejects_noncanonical_signature_length() {
+    let pubkey = test_pubkey(0x33);
+    let signer = StubSigner {
+        pubkey: pubkey.clone(),
+        signature: vec![0x44; (ML_DSA_87_SIG_BYTES as usize) - 1],
+    };
+    let mut tx = test_tx();
+    let err =
+        sign_transaction(&mut tx, &test_utxos(&pubkey), [0u8; 32], &signer).expect_err("sig");
+    assert_eq!(err.code, ErrorCode::TxErrSigNoncanonical);
+}
+
+#[test]
+fn sign_transaction_propagates_signer_errors() {
+    let pubkey = test_pubkey(0x77);
+    let mut tx = test_tx();
+    let err = sign_transaction(&mut tx, &test_utxos(&pubkey), [0u8; 32], &ErrorSigner)
+        .expect_err("signer error");
+    assert_eq!(err.code, ErrorCode::TxErrSigInvalid);
+}


### PR DESCRIPTION
Invariant:
Keep tx helper signing/marshal behavior unchanged while reducing Codacy NLOC/complexity rows for `tx_helpers.rs`.

Layer:
Rust consensus-adjacent refactor only.

Files changed:
- `clients/rust/crates/rubin-consensus/src/tx_helpers.rs`
- `clients/rust/crates/rubin-consensus/src/tx_helpers_tests/mod.rs`
- `clients/rust/crates/rubin-consensus/src/tx_helpers_tests/marshal.rs.inc`
- `clients/rust/crates/rubin-consensus/src/tx_helpers_tests/signing.rs.inc`

Tests:
- `lizard_medium_rows.py` on the changed Rust files
- `git diff --check`
- `cd clients/rust && cargo fmt --check`
- `cd clients/rust && cargo test -p rubin-consensus tx_helpers -- --nocapture`
- `cd clients/rust && cargo test -p rubin-consensus`
- `rubin-precommit-one-review --include-base-diff`
- one isolated stock code-review subagent: No findings
- `rubin-push` with `cargo test -p rubin-consensus` coverage command

### Parity exemption justification

This is a Rust-only mechanical refactor of `tx_helpers.rs` and its tests. Public Rust APIs are unchanged, `sign_transaction` preserves the existing validation order, public error codes/messages, sighash inputs, witness shape, and final `tx.witness` assignment timing. No Go change is required because the PR does not intentionally change executable consensus behavior.

### Fixture exemption justification

This PR moves existing Rust tx helper tests into a split test module and extracts private signing helpers. The `marshal_tx` implementation and wire/parse/hash behavior are unchanged. Existing marshal/parse roundtrip tests still execute, and no conformance fixture expectation changes are required.

Behavior impact:
No intended runtime behavior change. Public Rust APIs are unchanged.

Compatibility impact:
No Go, conformance, formal, fixture, Cargo, or generated artifact changes.

Known non-goals:
Does not close all RUB-248 Codacy inventory; this is only the `tx_helpers.rs` slice.


<!-- rubin-agent-meta actor=unknown action=pr-edit via=cl branch=codex/RUB-248-rust-tx-helpers-shape wt=rubin-protocol-codex-RUB-248-tx-helpers-shape utc=2026-05-18T13:28:43Z -->
