### PR TITLE
RUB-296: reduce Go SignTransaction shape

### DIFF
--- a/clients/go/consensus/tx_helpers.go
+++ b/clients/go/consensus/tx_helpers.go
@@ -162,20 +162,7 @@ func CheckParsedTransactionWithOwnedUtxoSetAndCoreExtProfilesAndSuiteContext(
 
 // SignTransaction currently supports ML-DSA CORE_P2PK inputs only.
 func SignTransaction(tx *Tx, utxoSet map[Outpoint]UtxoEntry, chainID [32]byte, signer DigestSigner) error {
-	if tx == nil {
-		return txerr(TX_ERR_PARSE, "nil tx")
-	}
-	if len(tx.Inputs) == 0 {
-		return txerr(TX_ERR_PARSE, "non-coinbase must have at least one input")
-	}
-	if signer == nil {
-		return fmt.Errorf("nil signer")
-	}
-	pub, keyID, err := signerBinding(signer)
-	if err != nil {
-		return err
-	}
-	sighashCache, err := NewSighashV1PrehashCache(tx)
+	pub, keyID, sighashCache, err := prepareSignTransaction(tx, signer)
 	if err != nil {
 		return err
 	}
@@ -195,6 +182,27 @@ func SignTransaction(tx *Tx, utxoSet map[Outpoint]UtxoEntry, chainID [32]byte, s
 
 	tx.Witness = witness
 	return nil
+}
+
+func prepareSignTransaction(tx *Tx, signer DigestSigner) ([]byte, [32]byte, *SighashV1PrehashCache, error) {
+	if tx == nil {
+		return nil, [32]byte{}, nil, txerr(TX_ERR_PARSE, "nil tx")
+	}
+	if len(tx.Inputs) == 0 {
+		return nil, [32]byte{}, nil, txerr(TX_ERR_PARSE, "non-coinbase must have at least one input")
+	}
+	if signer == nil {
+		return nil, [32]byte{}, nil, fmt.Errorf("nil signer")
+	}
+	pub, keyID, err := signerBinding(signer)
+	if err != nil {
+		return nil, [32]byte{}, nil, err
+	}
+	sighashCache, err := NewSighashV1PrehashCache(tx)
+	if err != nil {
+		return nil, [32]byte{}, nil, err
+	}
+	return pub, keyID, sighashCache, nil
 }
 
 func signerBinding(signer DigestSigner) ([]byte, [32]byte, error) {


### PR DESCRIPTION
Invariant:
Reduce the `SignTransaction` Codacy CCN row by extracting setup guards into a private helper, without changing signing behavior, validation/error order, witness bytes, sighash/preimage behavior, or public API shape.

Layer:
consensus-adjacent implementation refactor

Files changed:
- `clients/go/consensus/tx_helpers.go`

Tests:
- `python3 /Users/gpt/.agents/skills/rubin-codacy/scripts/lizard_medium_rows.py clients/go/consensus/tx_helpers.go`
- `python3 tools/check_map_iteration_determinism.py`
- `git diff --check`
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -v ./consensus -run "Test.*(Sign|Sighash|Tx|Witness)" -count=1'`
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -v ./consensus -count=1'`
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -v ./consensus -coverprofile=/tmp/rub296-consensus.cover -covermode=atomic -count=1'` — 93.9%
- `/Users/gpt/bin/rubin-precommit-one-review --repo /Users/gpt/Documents/rubin-protocol-codex-RUB-296 --base-ref origin/main --include-base-diff`
- One isolated stock code-review pass — No findings
- `/Users/gpt/bin/rubin-push --repo /Users/gpt/Documents/rubin-protocol-codex-RUB-296 --base-ref origin/main --coverage-cmd "scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -v ./consensus -coverprofile=/tmp/rub296-consensus.cover -covermode=atomic -count=1'" -- origin HEAD`

Behavior impact:
No intended behavior change. `SignTransaction` keeps the same public signature and first-error order.

Compatibility impact:
No public API change.

Known non-goals:
- No parameter-count cleanup.
- No conformance, fixture, generated artifact, or Rust changes.

### Parity exemption justification
This is a Go-only consensus-adjacent refactor that does not change consensus behavior, signing outputs, validation order, fixtures, or Rust parity surface. The change is limited to private helper extraction in `clients/go/consensus/tx_helpers.go`; the existing residual parameter-count Codacy row remains out of scope.
