### PR TITLE
RUB-257: Reduce Go compact helper complexity

### DIFF
--- a/clients/go/consensus/compact_relay.go
+++ b/clients/go/consensus/compact_relay.go
@@ -32,38 +32,10 @@ func siphash24(msg []byte, k0, k1 uint64) uint64 {
 
 	i := 0
 	for ; i+8 <= len(msg); i += 8 {
-		m := binary.LittleEndian.Uint64(msg[i : i+8])
-		v3 ^= m
-		v0, v1, v2, v3 = sipRound(v0, v1, v2, v3)
-		v0, v1, v2, v3 = sipRound(v0, v1, v2, v3)
-		v0 ^= m
+		siphashBlock(&v0, &v1, &v2, &v3, binary.LittleEndian.Uint64(msg[i:i+8]))
 	}
 
-	var b uint64 = uint64(len(msg)) << 56
-	rem := msg[i:]
-	switch len(rem) {
-	case 7:
-		b |= uint64(rem[6]) << 48
-		fallthrough
-	case 6:
-		b |= uint64(rem[5]) << 40
-		fallthrough
-	case 5:
-		b |= uint64(rem[4]) << 32
-		fallthrough
-	case 4:
-		b |= uint64(rem[3]) << 24
-		fallthrough
-	case 3:
-		b |= uint64(rem[2]) << 16
-		fallthrough
-	case 2:
-		b |= uint64(rem[1]) << 8
-		fallthrough
-	case 1:
-		b |= uint64(rem[0])
-	}
-
+	b := siphashFinalBlock(msg, i)
 	v3 ^= b
 	v0, v1, v2, v3 = sipRound(v0, v1, v2, v3)
 	v0, v1, v2, v3 = sipRound(v0, v1, v2, v3)
@@ -75,6 +47,21 @@ func siphash24(msg []byte, k0, k1 uint64) uint64 {
 	}
 
 	return v0 ^ v1 ^ v2 ^ v3
+}
+
+func siphashBlock(v0, v1, v2, v3 *uint64, m uint64) {
+	*v3 ^= m
+	*v0, *v1, *v2, *v3 = sipRound(*v0, *v1, *v2, *v3)
+	*v0, *v1, *v2, *v3 = sipRound(*v0, *v1, *v2, *v3)
+	*v0 ^= m
+}
+
+func siphashFinalBlock(msg []byte, off int) uint64 {
+	b := uint64(len(msg)) << 56
+	for shift := uint(0); off < len(msg); off, shift = off+1, shift+8 {
+		b |= uint64(msg[off]) << shift
+	}
+	return b
 }
 
 // CompactShortID computes a 6-byte short ID from WTXID using SipHash-2-4.

--- a/clients/go/consensus/compactsize.go
+++ b/clients/go/consensus/compactsize.go
@@ -6,39 +6,58 @@ func readCompactSize(b []byte, off *int) (uint64, int, error) {
 	if err != nil {
 		return 0, 0, err
 	}
-
-	switch {
-	case tag < 0xfd:
-		return uint64(tag), *off - start, nil
-	case tag == 0xfd:
-		v, err := readU16le(b, off)
-		if err != nil {
-			return 0, 0, err
-		}
-		if v < 0xfd {
-			return 0, 0, txerr(TX_ERR_PARSE, "non-minimal CompactSize (0xfd)")
-		}
-		return uint64(v), *off - start, nil
-	case tag == 0xfe:
-		v, err := readU32le(b, off)
-		if err != nil {
-			return 0, 0, err
-		}
-		if v <= 0xffff {
-			return 0, 0, txerr(TX_ERR_PARSE, "non-minimal CompactSize (0xfe)")
-		}
-		return uint64(v), *off - start, nil
-	case tag == 0xff:
-		v, err := readU64le(b, off)
-		if err != nil {
-			return 0, 0, err
-		}
-		if v <= 0xffff_ffff {
-			return 0, 0, txerr(TX_ERR_PARSE, "non-minimal CompactSize (0xff)")
-		}
-		return v, *off - start, nil
-	default:
-		// unreachable
-		return 0, 0, txerr(TX_ERR_PARSE, "invalid CompactSize tag")
+	v, err := readCompactSizeTagged(tag, b, off)
+	if err != nil {
+		return 0, 0, err
 	}
+	return v, *off - start, nil
+}
+
+func readCompactSizeTagged(tag byte, b []byte, off *int) (uint64, error) {
+	if tag < 0xfd {
+		return uint64(tag), nil
+	}
+	switch tag {
+	case 0xfd:
+		return readCompactSize16(b, off)
+	case 0xfe:
+		return readCompactSize32(b, off)
+	case 0xff:
+		return readCompactSize64(b, off)
+	default:
+		return 0, txerr(TX_ERR_PARSE, "invalid CompactSize tag")
+	}
+}
+
+func readCompactSize16(b []byte, off *int) (uint64, error) {
+	v, err := readU16le(b, off)
+	if err != nil {
+		return 0, err
+	}
+	if v < 0xfd {
+		return 0, txerr(TX_ERR_PARSE, "non-minimal CompactSize (0xfd)")
+	}
+	return uint64(v), nil
+}
+
+func readCompactSize32(b []byte, off *int) (uint64, error) {
+	v, err := readU32le(b, off)
+	if err != nil {
+		return 0, err
+	}
+	if v <= 0xffff {
+		return 0, txerr(TX_ERR_PARSE, "non-minimal CompactSize (0xfe)")
+	}
+	return uint64(v), nil
+}
+
+func readCompactSize64(b []byte, off *int) (uint64, error) {
+	v, err := readU64le(b, off)
+	if err != nil {
+		return 0, err
+	}
+	if v <= 0xffff_ffff {
+		return 0, txerr(TX_ERR_PARSE, "non-minimal CompactSize (0xff)")
+	}
+	return v, nil
 }


### PR DESCRIPTION
Invariant:
- Reduce live Codacy/lizard complexity rows in Go consensus CompactSize and compact-relay helpers without changing wire parsing, public error strings, consumed-length accounting, SipHash output, CompactShortID truncation, fixtures, or Rust behavior.

Layer:
- consensus-adjacent implementation refactor only.

Files changed:
- `clients/go/consensus/compact_relay.go`
- `clients/go/consensus/compactsize.go`

Behavior impact:
- No intended behavior change.
- Private helper extraction only; exported APIs are unchanged.

Compatibility impact:
- No fixture, conformance, Rust, formal, generated artifact, or public API changes.

### Parity exemption justification
This is a Go-only mechanical helper extraction. Rust behavior is intentionally unchanged because the PR does not alter the CompactSize encoding contract or compact relay SipHash/short-ID output. Targeted Go tests and an isolated raw-diff review checked that output/error semantics remain unchanged.

### Fixture exemption justification
This PR does not change expected fixture behavior. It preserves CompactSize minimality/truncation errors and SipHash reference-vector output; therefore no conformance fixture update is required.

Tests:
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -v ./consensus -run "TestSiphash24_ReferenceVectors|TestCompactShortID_Vector|TestCompactSize|TestDecodeCompactSize|TestEncodeCompactSize" -count=1'` — PASS
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -v ./consensus -run "Test.*Block|Test.*Coinbase|Test.*Compact|Test.*Weight|Test.*DA" -count=1'` — PASS
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./consensus -count=1'` — PASS
- `scripts/dev-env.sh -- python3 tools/check_map_iteration_determinism.py` — PASS
- `python3 /Users/gpt/.agents/skills/rubin-codacy/scripts/lizard_medium_rows.py clients/go/consensus/compact_relay.go clients/go/consensus/compactsize.go` — PASS, 0 metric rows
- `/Users/gpt/bin/rubin-precommit-one-review --repo /Users/gpt/Documents/rubin-protocol-codex-RUB-257-go-block-basic-ccn --base-ref origin/main --include-base-diff` — PASS
- One isolated stock code-review pass — No findings
- `/Users/gpt/bin/rubin-push --repo /Users/gpt/Documents/rubin-protocol-codex-RUB-257-go-block-basic-ccn --base-ref origin/main --no-coverage-reason 'helper-only Go consensus refactor; no new executable behavior or coverable branch added; targeted Go consensus tests and lizard rows ran' -- origin HEAD` — PASS

Not checked:
- Full `cd clients/go && go test ./...` was attempted as extra evidence without `-v`, produced partial package PASS output, then was stopped after a long silent period. It is not used as required evidence for this PR.

Known non-goals:
- No consensus rule change.
- No fixture or conformance update.
- No Rust parity implementation change.
- No broad block-basic cleanup.
