### PR TITLE
RUB-284: split Go CORE_EXT witness validation shape

### DIFF
--- a/clients/go/consensus/core_ext.go
+++ b/clients/go/consensus/core_ext.go
@@ -331,106 +331,149 @@ func validateCoreExtNativeWitness(w WitnessItem, params SuiteParams) error {
 	return nil
 }
 
-func validateCoreExtWitnessAtHeight(
-	cd *CoreExtCovenantData,
-	profile CoreExtProfile,
-	w WitnessItem,
-	tx *Tx,
-	inputIndex uint32,
-	inputValue uint64,
-	chainID [32]byte,
-	blockHeight uint64,
-	sighashCache *SighashV1PrehashCache,
-	rotation RotationProvider,
-	registry *SuiteRegistry,
-	txContext *TxContextBundle,
-	sigQueue *SigCheckQueue,
-) error {
-	rotation, registry = normalizeCoreExtSuiteContext(rotation, registry)
-	if !hasSuite(profile.AllowedSuites, w.SuiteID) {
+type coreExtWitnessValidation struct {
+	cd           *CoreExtCovenantData
+	profile      CoreExtProfile
+	w            WitnessItem
+	tx           *Tx
+	inputIndex   uint32
+	inputValue   uint64
+	chainID      [32]byte
+	blockHeight  uint64
+	sighashCache *SighashV1PrehashCache
+	rotation     RotationProvider
+	registry     *SuiteRegistry
+	txContext    *TxContextBundle
+	sigQueue     *SigCheckQueue
+}
+
+func validateCoreExtWitnessAtHeight(check coreExtWitnessValidation) error {
+	check.rotation, check.registry = normalizeCoreExtSuiteContext(check.rotation, check.registry)
+	if !hasSuite(check.profile.AllowedSuites, check.w.SuiteID) {
 		return txerr(TX_ERR_SIG_ALG_INVALID, "CORE_EXT suite disallowed under ACTIVE profile")
 	}
-	if w.SuiteID == SUITE_ID_SENTINEL {
+	if check.w.SuiteID == SUITE_ID_SENTINEL {
 		return txerr(TX_ERR_SIG_ALG_INVALID, "CORE_EXT sentinel forbidden under ACTIVE profile")
 	}
 
-	extractSigDigest := func() ([]byte, [32]byte, error) {
-		return extractSigAndDigestWithCache(w, tx, inputIndex, inputValue, chainID, sighashCache)
-	}
-
-	nativeSpendSuites := rotation.NativeSpendSuites(blockHeight)
-	params, nativeRegistered := registry.Lookup(w.SuiteID)
+	nativeSpendSuites := check.rotation.NativeSpendSuites(check.blockHeight)
+	params, nativeRegistered := check.registry.Lookup(check.w.SuiteID)
 
 	// Per CANONICAL §12.5 / §23.2.2, registry-known native suites stay on the
 	// native path only while currently spend-permitted at this height; suites
 	// outside the current native spend set reject here and never fall through to
 	// verify_sig_ext.
 	if nativeRegistered {
-		if !nativeSpendSuites.Contains(w.SuiteID) {
+		if !nativeSpendSuites.Contains(check.w.SuiteID) {
 			return txerr(TX_ERR_SIG_ALG_INVALID, "CORE_EXT registered native suite not spend-permitted at this height")
 		}
-		if err := validateCoreExtNativeWitness(w, params); err != nil {
-			return err
-		}
-		cryptoSig, digest, err := extractSigDigest()
-		if err != nil {
-			return err
-		}
-		if sigQueue != nil {
-			sigQueue.Push(w.SuiteID, w.Pubkey, cryptoSig, digest, txerr(TX_ERR_SIG_INVALID, "CORE_EXT signature invalid"))
-			return nil
-		}
-		ok, err := verifySigWithRegistry(w.SuiteID, w.Pubkey, cryptoSig, digest, registry)
-		if err != nil {
-			return err
-		}
-		if !ok {
-			return txerr(TX_ERR_SIG_INVALID, "CORE_EXT signature invalid")
-		}
-		return nil
+		return check.validateCoreExtNativeWitnessPath(params)
 	}
-	if nativeSpendSuites.Contains(w.SuiteID) {
+	if nativeSpendSuites.Contains(check.w.SuiteID) {
 		return txerr(TX_ERR_SIG_ALG_INVALID, "CORE_EXT registered native suite missing from registry")
 	}
 
-	cryptoSig, digest, err := extractSigDigest()
+	return check.validateCoreExtProfilePath()
+}
+
+func (check coreExtWitnessValidation) extractSigDigest() ([]byte, [32]byte, error) {
+	return extractSigAndDigestWithCache(
+		check.w,
+		check.tx,
+		check.inputIndex,
+		check.inputValue,
+		check.chainID,
+		check.sighashCache,
+	)
+}
+
+func (check coreExtWitnessValidation) validateCoreExtNativeWitnessPath(params SuiteParams) error {
+	if err := validateCoreExtNativeWitness(check.w, params); err != nil {
+		return err
+	}
+	cryptoSig, digest, err := check.extractSigDigest()
 	if err != nil {
 		return err
 	}
-	if profile.TxContextEnabled {
-		if profile.VerifySigExtFn == nil && profile.VerifySigExtTxContextFn == nil {
-			return txerr(TX_ERR_SIG_ALG_INVALID, "CORE_EXT verify_sig_ext unsupported")
-		}
-		if txContext == nil || txContext.Base == nil {
-			return txerr(TX_ERR_SIG_INVALID, "CORE_EXT txcontext bundle missing")
-		}
-		ctxContinuing, ok := txContext.Continuing(cd.ExtID)
-		if !ok || ctxContinuing == nil {
-			return txerr(TX_ERR_SIG_INVALID, "CORE_EXT txcontext continuing bundle missing")
-		}
-		ok, err := verifyCoreExtProfileTxContext(profile, coreExtVerifySigExtTxContextCall{
-			extID:          cd.ExtID,
-			suiteID:        w.SuiteID,
-			pubkey:         w.Pubkey,
-			signature:      cryptoSig,
-			digest32:       digest,
-			extPayload:     cd.ExtPayload,
-			ctxBase:        txContext.Base,
-			ctxContinuing:  ctxContinuing,
-			selfInputValue: inputValue,
-		})
-		if err != nil {
-			return txerr(TX_ERR_SIG_ALG_INVALID, "CORE_EXT verify_sig_ext error")
-		}
-		if !ok {
-			return txerr(TX_ERR_SIG_INVALID, "CORE_EXT signature invalid")
-		}
+	if check.sigQueue != nil {
+		check.sigQueue.Push(check.w.SuiteID, check.w.Pubkey, cryptoSig, digest, txerr(TX_ERR_SIG_INVALID, "CORE_EXT signature invalid"))
 		return nil
 	}
-	if profile.VerifySigExtFn == nil {
+	ok, err := verifySigWithRegistry(check.w.SuiteID, check.w.Pubkey, cryptoSig, digest, check.registry)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return txerr(TX_ERR_SIG_INVALID, "CORE_EXT signature invalid")
+	}
+	return nil
+}
+
+func (check coreExtWitnessValidation) validateCoreExtProfilePath() error {
+	cryptoSig, digest, err := check.extractSigDigest()
+	if err != nil {
+		return err
+	}
+	if check.profile.TxContextEnabled {
+		return check.validateCoreExtTxContextVerifier(cryptoSig, digest)
+	}
+	return check.validateCoreExtLegacyVerifier(cryptoSig, digest)
+}
+
+func (check coreExtWitnessValidation) validateCoreExtTxContextVerifier(cryptoSig []byte, digest [32]byte) error {
+	if coreExtTxContextVerifierUnsupported(check.profile) {
 		return txerr(TX_ERR_SIG_ALG_INVALID, "CORE_EXT verify_sig_ext unsupported")
 	}
-	ok, err := profile.VerifySigExtFn(cd.ExtID, w.SuiteID, w.Pubkey, cryptoSig, digest, cd.ExtPayload)
+	ctxBase, ctxContinuing, err := check.txContextVerifierBundles()
+	if err != nil {
+		return err
+	}
+	ok, err := verifyCoreExtProfileTxContext(check.profile, coreExtVerifySigExtTxContextCall{
+		extID:          check.cd.ExtID,
+		suiteID:        check.w.SuiteID,
+		pubkey:         check.w.Pubkey,
+		signature:      cryptoSig,
+		digest32:       digest,
+		extPayload:     check.cd.ExtPayload,
+		ctxBase:        ctxBase,
+		ctxContinuing:  ctxContinuing,
+		selfInputValue: check.inputValue,
+	})
+	if err != nil {
+		return txerr(TX_ERR_SIG_ALG_INVALID, "CORE_EXT verify_sig_ext error")
+	}
+	if !ok {
+		return txerr(TX_ERR_SIG_INVALID, "CORE_EXT signature invalid")
+	}
+	return nil
+}
+
+func coreExtTxContextVerifierUnsupported(profile CoreExtProfile) bool {
+	return profile.VerifySigExtFn == nil && profile.VerifySigExtTxContextFn == nil
+}
+
+func (check coreExtWitnessValidation) txContextVerifierBundles() (*TxContextBase, *TxContextContinuing, error) {
+	if check.txContext == nil {
+		return nil, nil, txerr(TX_ERR_SIG_INVALID, "CORE_EXT txcontext bundle missing")
+	}
+	if check.txContext.Base == nil {
+		return nil, nil, txerr(TX_ERR_SIG_INVALID, "CORE_EXT txcontext bundle missing")
+	}
+	ctxContinuing, ok := check.txContext.Continuing(check.cd.ExtID)
+	if !ok {
+		return nil, nil, txerr(TX_ERR_SIG_INVALID, "CORE_EXT txcontext continuing bundle missing")
+	}
+	if ctxContinuing == nil {
+		return nil, nil, txerr(TX_ERR_SIG_INVALID, "CORE_EXT txcontext continuing bundle missing")
+	}
+	return check.txContext.Base, ctxContinuing, nil
+}
+
+func (check coreExtWitnessValidation) validateCoreExtLegacyVerifier(cryptoSig []byte, digest [32]byte) error {
+	if check.profile.VerifySigExtFn == nil {
+		return txerr(TX_ERR_SIG_ALG_INVALID, "CORE_EXT verify_sig_ext unsupported")
+	}
+	ok, err := check.profile.VerifySigExtFn(check.cd.ExtID, check.w.SuiteID, check.w.Pubkey, cryptoSig, digest, check.cd.ExtPayload)
 	if err != nil {
 		return txerr(TX_ERR_SIG_ALG_INVALID, "CORE_EXT verify_sig_ext error")
 	}
@@ -479,19 +522,18 @@ func validateCoreExtSpendWithCache(check coreExtSpendValidation) error {
 		return nil
 	}
 
-	return validateCoreExtWitnessAtHeight(
-		cd,
-		profile,
-		check.w,
-		check.tx,
-		check.inputIndex,
-		check.inputValue,
-		check.chainID,
-		check.blockHeight,
-		check.sighashCache,
-		check.rotation,
-		check.registry,
-		check.txContext,
-		nil,
-	)
+	return validateCoreExtWitnessAtHeight(coreExtWitnessValidation{
+		cd:           cd,
+		profile:      profile,
+		w:            check.w,
+		tx:           check.tx,
+		inputIndex:   check.inputIndex,
+		inputValue:   check.inputValue,
+		chainID:      check.chainID,
+		blockHeight:  check.blockHeight,
+		sighashCache: check.sighashCache,
+		rotation:     check.rotation,
+		registry:     check.registry,
+		txContext:    check.txContext,
+	})
 }

--- a/clients/go/consensus/core_ext_test.go
+++ b/clients/go/consensus/core_ext_test.go
@@ -412,21 +412,20 @@ func TestValidateCoreExtWitnessAtHeightMixedProfileNativeSuiteUsesNativePath(t *
 		AlgName:    "ML-DSA-87",
 	}})
 	queue := NewSigCheckQueue(0).WithRegistry(registry)
-	if err := validateCoreExtWitnessAtHeight(
-		&CoreExtCovenantData{ExtID: 7, ExtPayload: []byte{0x99}},
-		profile,
-		w,
-		tx,
-		0,
-		100,
-		[32]byte{0: 0x42},
-		0,
-		cache,
-		nativeRotationProvider{},
-		registry,
-		nil,
-		queue,
-	); err != nil {
+	if err := validateCoreExtWitnessAtHeight(coreExtWitnessValidation{
+		cd:           &CoreExtCovenantData{ExtID: 7, ExtPayload: []byte{0x99}},
+		profile:      profile,
+		w:            w,
+		tx:           tx,
+		inputIndex:   0,
+		inputValue:   100,
+		chainID:      [32]byte{0: 0x42},
+		blockHeight:  0,
+		sighashCache: cache,
+		rotation:     nativeRotationProvider{},
+		registry:     registry,
+		sigQueue:     queue,
+	}); err != nil {
 		t.Fatalf("validateCoreExtWitnessAtHeight: %v", err)
 	}
 	if called {
@@ -459,21 +458,19 @@ func TestValidateCoreExtWitnessAtHeightNativeSuiteMissingRegistryFailsClosed(t *
 		Pubkey:    []byte{0x01, 0x02, 0x03, 0x04},
 		Signature: []byte{0x05, 0x06, 0x07, 0x01},
 	}
-	err = validateCoreExtWitnessAtHeight(
-		&CoreExtCovenantData{ExtID: 7, ExtPayload: []byte{0x99}},
-		profile,
-		w,
-		tx,
-		0,
-		100,
-		[32]byte{0: 0x43},
-		0,
-		cache,
-		nativeRotationProvider{},
-		NewSuiteRegistryFromParams(nil),
-		nil,
-		nil,
-	)
+	err = validateCoreExtWitnessAtHeight(coreExtWitnessValidation{
+		cd:           &CoreExtCovenantData{ExtID: 7, ExtPayload: []byte{0x99}},
+		profile:      profile,
+		w:            w,
+		tx:           tx,
+		inputIndex:   0,
+		inputValue:   100,
+		chainID:      [32]byte{0: 0x43},
+		blockHeight:  0,
+		sighashCache: cache,
+		rotation:     nativeRotationProvider{},
+		registry:     NewSuiteRegistryFromParams(nil),
+	})
 	if err == nil {
 		t.Fatalf("expected error")
 	}
@@ -510,27 +507,25 @@ func TestValidateCoreExtWitnessAtHeightRegisteredNativeSuiteOutsideSpendSetRejec
 		Pubkey:    []byte{0x01, 0x02, 0x03, 0x04},
 		Signature: []byte{0x05, 0x06, 0x07, 0x01},
 	}
-	err = validateCoreExtWitnessAtHeight(
-		&CoreExtCovenantData{ExtID: 7, ExtPayload: []byte{0x99}},
-		profile,
-		w,
-		tx,
-		0,
-		100,
-		[32]byte{0: 0x44},
-		0,
-		cache,
-		sunsetNativeRotationProvider{},
-		NewSuiteRegistryFromParams([]SuiteParams{{
+	err = validateCoreExtWitnessAtHeight(coreExtWitnessValidation{
+		cd:           &CoreExtCovenantData{ExtID: 7, ExtPayload: []byte{0x99}},
+		profile:      profile,
+		w:            w,
+		tx:           tx,
+		inputIndex:   0,
+		inputValue:   100,
+		chainID:      [32]byte{0: 0x44},
+		blockHeight:  0,
+		sighashCache: cache,
+		rotation:     sunsetNativeRotationProvider{},
+		registry: NewSuiteRegistryFromParams([]SuiteParams{{
 			SuiteID:    0x02,
 			PubkeyLen:  len(w.Pubkey),
 			SigLen:     len(w.Signature) - 1,
 			VerifyCost: 1,
 			AlgName:    "ML-DSA-87",
 		}}),
-		nil,
-		nil,
-	)
+	})
 	if err == nil {
 		t.Fatalf("expected error")
 	}
@@ -631,21 +626,19 @@ func TestValidateCoreExtWitnessAtHeight_TxContextEnabledDispatchesNineParam(t *t
 		ExtPayloadSchema:  []byte{0xb2},
 	}
 
-	if err := validateCoreExtWitnessAtHeight(
-		&CoreExtCovenantData{ExtID: 7, ExtPayload: []byte{0xaa}},
-		profile,
-		tx.Witness[0],
-		tx,
-		0,
-		100,
-		[32]byte{0: 0x55},
-		55,
-		sighashCache,
-		nativeRotationProvider{},
-		nil,
-		txContext,
-		nil,
-	); err != nil {
+	if err := validateCoreExtWitnessAtHeight(coreExtWitnessValidation{
+		cd:           &CoreExtCovenantData{ExtID: 7, ExtPayload: []byte{0xaa}},
+		profile:      profile,
+		w:            tx.Witness[0],
+		tx:           tx,
+		inputIndex:   0,
+		inputValue:   100,
+		chainID:      [32]byte{0: 0x55},
+		blockHeight:  55,
+		sighashCache: sighashCache,
+		rotation:     nativeRotationProvider{},
+		txContext:    txContext,
+	}); err != nil {
 		t.Fatalf("validateCoreExtWitnessAtHeight: %v", err)
 	}
 	if !called {
@@ -684,21 +677,18 @@ func TestValidateCoreExtWitnessAtHeight_TxContextEnabledNilBundleFailsClosed(t *
 		ExtPayloadSchema:  []byte{0xb2},
 	}
 
-	err = validateCoreExtWitnessAtHeight(
-		&CoreExtCovenantData{ExtID: 7, ExtPayload: []byte{0xaa}},
-		profile,
-		tx.Witness[0],
-		tx,
-		0,
-		100,
-		[32]byte{0: 0x56},
-		55,
-		sighashCache,
-		nativeRotationProvider{},
-		nil,
-		nil,
-		nil,
-	)
+	err = validateCoreExtWitnessAtHeight(coreExtWitnessValidation{
+		cd:           &CoreExtCovenantData{ExtID: 7, ExtPayload: []byte{0xaa}},
+		profile:      profile,
+		w:            tx.Witness[0],
+		tx:           tx,
+		inputIndex:   0,
+		inputValue:   100,
+		chainID:      [32]byte{0: 0x56},
+		blockHeight:  55,
+		sighashCache: sighashCache,
+		rotation:     nativeRotationProvider{},
+	})
 	if err == nil {
 		t.Fatalf("expected error")
 	}

--- a/clients/go/consensus/tx_validate_worker.go
+++ b/clients/go/consensus/tx_validate_worker.go
@@ -331,11 +331,21 @@ func validateCoreExtSpendQWithEnv(check txInputSpendCheck, w WitnessItem, env tx
 	case !ok || !profile.Active:
 		return nil
 	default:
-		return validateCoreExtWitnessAtHeight(
-			cd, profile, w, check.tx, check.inputIndex, check.inputValue,
-			env.chainID, env.blockHeight, env.sighashCache, env.rotation,
-			env.registry, env.txContext, env.sigQueue,
-		)
+		return validateCoreExtWitnessAtHeight(coreExtWitnessValidation{
+			cd:           cd,
+			profile:      profile,
+			w:            w,
+			tx:           check.tx,
+			inputIndex:   check.inputIndex,
+			inputValue:   check.inputValue,
+			chainID:      env.chainID,
+			blockHeight:  env.blockHeight,
+			sighashCache: env.sighashCache,
+			rotation:     env.rotation,
+			registry:     env.registry,
+			txContext:    env.txContext,
+			sigQueue:     env.sigQueue,
+		})
 	}
 }
 


### PR DESCRIPTION
Refs: Q-CODACY-GO-CORE-EXT-WITNESS-SHAPE-01

## Summary

This PR reduces the Go CORE_EXT witness validation Codacy shape row by replacing the private 13-argument helper call shape with a private validation context and branch-local helpers.

No intended behavior change: suite gating, native-vs-verify_sig_ext dispatch, txcontext requirements, sighash digest inputs, queued signature behavior, and public tx error mapping are preserved.

## Scope

Files changed:
- clients/go/consensus/core_ext.go
- clients/go/consensus/core_ext_test.go
- clients/go/consensus/tx_validate_worker.go

Layer:
- consensus-adjacent implementation refactor only.

Boundary:
- Consensus rules unchanged: YES
- SECTION_HASHES.json unchanged: YES
- Public API unchanged: YES
- Rust unchanged: YES
- Fixtures unchanged: YES
- Formal unchanged: YES

## Tests

- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -v ./consensus -run "Test.*CoreExt|Test.*ValidateTxLocal_CoreExt|Test.*ValidateCoreExtSpendQ" -count=1'` — PASS
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -v ./...'` — PASS
- `rubin-codacy lizard medium-row check for clients/go/consensus/core_ext.go` — PASS, 0 rows
- `gocyclo -over 8 clients/go/consensus/core_ext.go` — PASS, no output
- `git diff --check` — PASS
- One isolated stock raw-diff reviewer — PASS, no findings

## Behavior Impact

No intended behavior change. This is a private helper-shape refactor only.

## Compatibility Impact

No public API change.

## Known Non-Goals

- No Rust changes.
- No conformance, fixture, formal, or spec changes.
- No CORE_EXT policy or validation semantic change.
- No unrelated Codacy rows.

## Risk

CORE_EXT routing drift from helper extraction. Mitigated by focused CORE_EXT tests, full Go tests, local Codacy/lizard check, and one isolated raw-diff reviewer pass.

## Rollback

Revert this commit to restore the previous private helper shape.

## Not Checked

- GitHub CI and Codacy PR analysis are still authoritative for remote status.

### Parity exemption justification

This PR is a Go-only private helper shape refactor for an existing CORE_EXT validation path. It does not change wire bytes, fixtures, replay operations, Rust behavior, or Go/Rust conformance expectations. Focused CORE_EXT Go behavior tests and full Go tests passed locally.

### Fixture exemption justification

This PR does not add, remove, or change consensus behavior or conformance fixture expectations. No fixture or runner update is required for a private helper shape refactor.


<!-- rubin-agent-meta actor=unknown action=pr-edit via=cl branch=codex/RUB-284-go-core-ext-witness wt=rubin-protocol-codex-RUB-284-go-core-ext-witness utc=2026-05-18T21:27:26Z -->
