### PR TITLE
RUB-227: expose Rust orphan pool metrics

### DIFF
--- a/clients/rust/crates/rubin-node/src/devnet_rpc.rs
+++ b/clients/rust/crates/rubin-node/src/devnet_rpc.rs
@@ -9,7 +9,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use serde::{Deserialize, Serialize};
 
 use crate::miner::{Miner, MinerConfig};
-use crate::p2p_runtime::PeerManager;
+use crate::p2p_runtime::{orphan_pool_metrics_snapshot, PeerManager};
 use crate::txpool::TxSource;
 use crate::{BlockStore, SyncEngine, TxPool, TxPoolAdmitErrorKind, TxPoolConfig};
 
@@ -1990,6 +1990,7 @@ fn render_prometheus_metrics(state: &DevnetRPCState) -> String {
         Err(_) => 0,
     };
     let peer_count = state.peer_manager.snapshot().len() as u64;
+    let orphan_metrics = orphan_pool_metrics_snapshot();
     let (route_status, submit_results) = state.metrics.snapshot();
 
     let mut lines = vec![
@@ -2015,6 +2016,20 @@ fn render_prometheus_metrics(state: &DevnetRPCState) -> String {
         "# HELP rubin_node_peer_count Currently tracked peers.".to_string(),
         "# TYPE rubin_node_peer_count gauge".to_string(),
         format!("rubin_node_peer_count {peer_count}"),
+        "# HELP rubin_node_p2p_orphan_pool_blocks Live Rust P2P orphan blocks retained in memory across peer sessions."
+            .to_string(),
+        "# TYPE rubin_node_p2p_orphan_pool_blocks gauge".to_string(),
+        format!(
+            "rubin_node_p2p_orphan_pool_blocks {}",
+            orphan_metrics.live_blocks
+        ),
+        "# HELP rubin_node_p2p_orphan_pool_bytes Live Rust P2P orphan block bytes retained in memory across peer sessions."
+            .to_string(),
+        "# TYPE rubin_node_p2p_orphan_pool_bytes gauge".to_string(),
+        format!(
+            "rubin_node_p2p_orphan_pool_bytes {}",
+            orphan_metrics.live_bytes
+        ),
         "# HELP rubin_node_mempool_txs Number of transactions currently in the mempool."
             .to_string(),
         "# TYPE rubin_node_mempool_txs gauge".to_string(),
@@ -4981,6 +4996,8 @@ mod tests {
             "rubin_node_reorg_total",
             "rubin_node_last_reorg_depth",
             "rubin_node_peer_count",
+            "rubin_node_p2p_orphan_pool_blocks",
+            "rubin_node_p2p_orphan_pool_bytes",
             "rubin_node_mempool_txs",
             "rubin_node_rpc_requests_total",
             "rubin_node_submit_tx_total",

--- a/clients/rust/crates/rubin-node/src/devnet_rpc.rs
+++ b/clients/rust/crates/rubin-node/src/devnet_rpc.rs
@@ -4971,6 +4971,8 @@ mod tests {
 
     #[test]
     fn metrics_render_includes_v1_names() {
+        let _orphan_guard = crate::p2p_runtime::orphan_pool_metrics_test_guard();
+        crate::p2p_runtime::reset_orphan_pool_metrics_for_test();
         let (state, dir) = build_state(true);
         let _ = route_request(
             &state,
@@ -5041,6 +5043,15 @@ mod tests {
         assert!(body.contains(r#"rubin_pv_mode{mode="off"} 1"#));
         assert!(body.contains("rubin_node_reorg_total 0"), "{body}");
         assert!(body.contains("rubin_node_last_reorg_depth 0"), "{body}");
+        assert!(
+            body.contains("rubin_node_p2p_orphan_pool_blocks 0"),
+            "{body}"
+        );
+        assert!(
+            body.contains("rubin_node_p2p_orphan_pool_bytes 0"),
+            "{body}"
+        );
+        crate::p2p_runtime::reset_orphan_pool_metrics_for_test();
         fs::remove_dir_all(dir).expect("cleanup");
     }
 

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::io::{self, Cursor, Read, Write};
 use std::net::TcpStream;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::RwLock;
+use std::sync::{Mutex, RwLock};
 use std::time::{Duration, Instant};
 
 use rubin_consensus::{
@@ -62,10 +62,22 @@ const MAX_HEADERS_PAYLOAD_BYTES: u64 =
     MAX_HEADERS_BATCH * (rubin_consensus::BLOCK_HEADER_BYTES as u64);
 const STREAM_READ_CHUNK_BYTES: usize = 32 * 1024;
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct OrphanPoolMetricsSnapshot {
+    pub live_blocks: usize,
+    pub live_bytes: usize,
+}
+
 static GLOBAL_ORPHAN_TOTAL_BYTES: AtomicUsize = AtomicUsize::new(0);
-static GLOBAL_ORPHAN_TOTAL_BLOCKS: AtomicUsize = AtomicUsize::new(0);
+static GLOBAL_ORPHAN_METRICS: Mutex<OrphanPoolMetricsSnapshot> =
+    Mutex::new(OrphanPoolMetricsSnapshot {
+        live_blocks: 0,
+        live_bytes: 0,
+    });
 #[cfg(test)]
 static GLOBAL_ORPHAN_BYTE_LIMIT_OVERRIDE: AtomicUsize = AtomicUsize::new(0);
+#[cfg(test)]
+static ORPHAN_POOL_TEST_LOCK: Mutex<()> = Mutex::new(());
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct WireMessage {
@@ -194,19 +206,45 @@ pub struct PeerManager {
     cfg: PeerRuntimeConfig,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) struct OrphanPoolMetricsSnapshot {
-    pub live_blocks: usize,
-    pub live_bytes: usize,
-}
-
 /// Live Rust P2P orphan-pool observability for `/metrics`.
 /// This is not consensus state and is not mixed-client readiness evidence.
 pub(crate) fn orphan_pool_metrics_snapshot() -> OrphanPoolMetricsSnapshot {
-    OrphanPoolMetricsSnapshot {
-        live_blocks: GLOBAL_ORPHAN_TOTAL_BLOCKS.load(Ordering::Acquire),
-        live_bytes: GLOBAL_ORPHAN_TOTAL_BYTES.load(Ordering::Acquire),
-    }
+    with_orphan_pool_metrics(|metrics| *metrics)
+}
+
+fn with_orphan_pool_metrics<R>(f: impl FnOnce(&mut OrphanPoolMetricsSnapshot) -> R) -> R {
+    let mut metrics = GLOBAL_ORPHAN_METRICS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    f(&mut metrics)
+}
+
+fn orphan_pool_metrics_add(blocks: usize, bytes: usize) {
+    with_orphan_pool_metrics(|metrics| {
+        metrics.live_blocks = metrics.live_blocks.saturating_add(blocks);
+        metrics.live_bytes = metrics.live_bytes.saturating_add(bytes);
+    });
+}
+
+fn orphan_pool_metrics_sub(blocks: usize, bytes: usize) {
+    with_orphan_pool_metrics(|metrics| {
+        metrics.live_blocks = metrics.live_blocks.saturating_sub(blocks);
+        metrics.live_bytes = metrics.live_bytes.saturating_sub(bytes);
+    });
+}
+
+#[cfg(test)]
+pub(crate) fn orphan_pool_metrics_test_guard() -> std::sync::MutexGuard<'static, ()> {
+    ORPHAN_POOL_TEST_LOCK
+        .lock()
+        .expect("lock orphan metrics tests")
+}
+
+#[cfg(test)]
+pub(crate) fn reset_orphan_pool_metrics_for_test() {
+    with_orphan_pool_metrics(|metrics| *metrics = OrphanPoolMetricsSnapshot::default());
+    GLOBAL_ORPHAN_TOTAL_BYTES.store(0, Ordering::SeqCst);
+    GLOBAL_ORPHAN_BYTE_LIMIT_OVERRIDE.store(0, Ordering::SeqCst);
 }
 
 pub fn default_peer_runtime_config(network: &str, max_peers: usize) -> PeerRuntimeConfig {
@@ -1800,7 +1838,7 @@ impl OrphanBlockPool {
                 size: block_bytes.len(),
             },
         );
-        GLOBAL_ORPHAN_TOTAL_BLOCKS.fetch_add(1, Ordering::AcqRel);
+        orphan_pool_metrics_add(1, block_bytes.len());
         self.total_bytes = self.total_bytes.saturating_add(block_bytes.len());
         self.fifo.push_back(block_hash);
         // Evict until under limits, but remove at least MIN_EVICT_BATCH entries
@@ -1836,7 +1874,7 @@ impl OrphanBlockPool {
         for child in &children {
             if let Some(meta) = self.by_hash.remove(&child.block_hash) {
                 self.total_bytes = self.total_bytes.saturating_sub(meta.size);
-                GLOBAL_ORPHAN_TOTAL_BLOCKS.fetch_sub(1, Ordering::AcqRel);
+                orphan_pool_metrics_sub(1, meta.size);
                 GLOBAL_ORPHAN_TOTAL_BYTES.fetch_sub(meta.size, Ordering::AcqRel);
             }
         }
@@ -1855,7 +1893,7 @@ impl OrphanBlockPool {
                 continue;
             };
             self.total_bytes = self.total_bytes.saturating_sub(meta.size);
-            GLOBAL_ORPHAN_TOTAL_BLOCKS.fetch_sub(1, Ordering::AcqRel);
+            orphan_pool_metrics_sub(1, meta.size);
             GLOBAL_ORPHAN_TOTAL_BYTES.fetch_sub(meta.size, Ordering::AcqRel);
             let mut remove_parent = false;
             if let Some(children) = self.pool.get_mut(&meta.parent_hash) {
@@ -1875,7 +1913,7 @@ impl OrphanBlockPool {
 
 impl Drop for OrphanBlockPool {
     fn drop(&mut self) {
-        GLOBAL_ORPHAN_TOTAL_BLOCKS.fetch_sub(self.by_hash.len(), Ordering::AcqRel);
+        orphan_pool_metrics_sub(self.by_hash.len(), self.total_bytes);
         GLOBAL_ORPHAN_TOTAL_BYTES.fetch_sub(self.total_bytes, Ordering::AcqRel);
     }
 }
@@ -1911,7 +1949,6 @@ mod tests {
     use std::net::{TcpListener, TcpStream};
     use std::path::PathBuf;
     use std::sync::atomic::{AtomicU64, Ordering};
-    use std::sync::Mutex;
     use std::thread;
     use std::time::Duration;
 
@@ -1932,15 +1969,7 @@ mod tests {
     };
     use serde::Deserialize;
 
-    static ORPHAN_POOL_TEST_LOCK: Mutex<()> = Mutex::new(());
-
     static NEXT_TEST_ROOT_ID: AtomicU64 = AtomicU64::new(1);
-
-    fn reset_orphan_pool_metrics_for_test() {
-        GLOBAL_ORPHAN_TOTAL_BLOCKS.store(0, Ordering::SeqCst);
-        GLOBAL_ORPHAN_TOTAL_BYTES.store(0, Ordering::SeqCst);
-        GLOBAL_ORPHAN_BYTE_LIMIT_OVERRIDE.store(0, Ordering::SeqCst);
-    }
 
     #[derive(Deserialize)]
     struct SharedRuntimeVectors {
@@ -2664,7 +2693,7 @@ mod tests {
 
     #[test]
     fn handle_block_retains_orphan_until_parent_arrives() {
-        let _guard = ORPHAN_POOL_TEST_LOCK.lock().expect("lock orphan tests");
+        let _guard = orphan_pool_metrics_test_guard();
         reset_orphan_pool_metrics_for_test();
 
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
@@ -2736,7 +2765,7 @@ mod tests {
 
     #[test]
     fn handle_block_surfaces_invalid_orphan_after_parent_arrives() {
-        let _guard = ORPHAN_POOL_TEST_LOCK.lock().expect("lock orphan tests");
+        let _guard = orphan_pool_metrics_test_guard();
         reset_orphan_pool_metrics_for_test();
 
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
@@ -2824,7 +2853,7 @@ mod tests {
 
     #[test]
     fn orphan_pool_metrics_start_zero_and_track_take_children() {
-        let _guard = ORPHAN_POOL_TEST_LOCK.lock().expect("lock orphan tests");
+        let _guard = orphan_pool_metrics_test_guard();
         reset_orphan_pool_metrics_for_test();
 
         assert_eq!(
@@ -2862,7 +2891,7 @@ mod tests {
 
     #[test]
     fn orphan_pool_replaces_local_oldest_when_global_limit_reached() {
-        let _guard = ORPHAN_POOL_TEST_LOCK.lock().expect("lock orphan tests");
+        let _guard = orphan_pool_metrics_test_guard();
         reset_orphan_pool_metrics_for_test();
         GLOBAL_ORPHAN_BYTE_LIMIT_OVERRIDE.store(1024, Ordering::SeqCst);
 
@@ -2905,7 +2934,7 @@ mod tests {
 
     #[test]
     fn orphan_pool_enforces_global_byte_limit_across_sessions() {
-        let _guard = ORPHAN_POOL_TEST_LOCK.lock().expect("lock orphan tests");
+        let _guard = orphan_pool_metrics_test_guard();
         reset_orphan_pool_metrics_for_test();
         GLOBAL_ORPHAN_BYTE_LIMIT_OVERRIDE.store(1024, Ordering::SeqCst);
 
@@ -2923,7 +2952,13 @@ mod tests {
             "second session should be capped by global limit"
         );
         assert_eq!(GLOBAL_ORPHAN_TOTAL_BYTES.load(Ordering::SeqCst), 800);
-        assert_eq!(GLOBAL_ORPHAN_TOTAL_BLOCKS.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            orphan_pool_metrics_snapshot(),
+            OrphanPoolMetricsSnapshot {
+                live_blocks: 1,
+                live_bytes: 800
+            }
+        );
 
         drop(pool_a);
         drop(pool_b);

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -63,6 +63,7 @@ const MAX_HEADERS_PAYLOAD_BYTES: u64 =
 const STREAM_READ_CHUNK_BYTES: usize = 32 * 1024;
 
 static GLOBAL_ORPHAN_TOTAL_BYTES: AtomicUsize = AtomicUsize::new(0);
+static GLOBAL_ORPHAN_TOTAL_BLOCKS: AtomicUsize = AtomicUsize::new(0);
 #[cfg(test)]
 static GLOBAL_ORPHAN_BYTE_LIMIT_OVERRIDE: AtomicUsize = AtomicUsize::new(0);
 
@@ -191,6 +192,21 @@ pub struct PeerSession {
 pub struct PeerManager {
     peers: RwLock<HashMap<String, PeerState>>,
     cfg: PeerRuntimeConfig,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct OrphanPoolMetricsSnapshot {
+    pub live_blocks: usize,
+    pub live_bytes: usize,
+}
+
+/// Live Rust P2P orphan-pool observability for `/metrics`.
+/// This is not consensus state and is not mixed-client readiness evidence.
+pub(crate) fn orphan_pool_metrics_snapshot() -> OrphanPoolMetricsSnapshot {
+    OrphanPoolMetricsSnapshot {
+        live_blocks: GLOBAL_ORPHAN_TOTAL_BLOCKS.load(Ordering::Acquire),
+        live_bytes: GLOBAL_ORPHAN_TOTAL_BYTES.load(Ordering::Acquire),
+    }
 }
 
 pub fn default_peer_runtime_config(network: &str, max_peers: usize) -> PeerRuntimeConfig {
@@ -1784,6 +1800,7 @@ impl OrphanBlockPool {
                 size: block_bytes.len(),
             },
         );
+        GLOBAL_ORPHAN_TOTAL_BLOCKS.fetch_add(1, Ordering::AcqRel);
         self.total_bytes = self.total_bytes.saturating_add(block_bytes.len());
         self.fifo.push_back(block_hash);
         // Evict until under limits, but remove at least MIN_EVICT_BATCH entries
@@ -1819,6 +1836,7 @@ impl OrphanBlockPool {
         for child in &children {
             if let Some(meta) = self.by_hash.remove(&child.block_hash) {
                 self.total_bytes = self.total_bytes.saturating_sub(meta.size);
+                GLOBAL_ORPHAN_TOTAL_BLOCKS.fetch_sub(1, Ordering::AcqRel);
                 GLOBAL_ORPHAN_TOTAL_BYTES.fetch_sub(meta.size, Ordering::AcqRel);
             }
         }
@@ -1837,6 +1855,7 @@ impl OrphanBlockPool {
                 continue;
             };
             self.total_bytes = self.total_bytes.saturating_sub(meta.size);
+            GLOBAL_ORPHAN_TOTAL_BLOCKS.fetch_sub(1, Ordering::AcqRel);
             GLOBAL_ORPHAN_TOTAL_BYTES.fetch_sub(meta.size, Ordering::AcqRel);
             let mut remove_parent = false;
             if let Some(children) = self.pool.get_mut(&meta.parent_hash) {
@@ -1856,6 +1875,7 @@ impl OrphanBlockPool {
 
 impl Drop for OrphanBlockPool {
     fn drop(&mut self) {
+        GLOBAL_ORPHAN_TOTAL_BLOCKS.fetch_sub(self.by_hash.len(), Ordering::AcqRel);
         GLOBAL_ORPHAN_TOTAL_BYTES.fetch_sub(self.total_bytes, Ordering::AcqRel);
     }
 }
@@ -1915,6 +1935,12 @@ mod tests {
     static ORPHAN_POOL_TEST_LOCK: Mutex<()> = Mutex::new(());
 
     static NEXT_TEST_ROOT_ID: AtomicU64 = AtomicU64::new(1);
+
+    fn reset_orphan_pool_metrics_for_test() {
+        GLOBAL_ORPHAN_TOTAL_BLOCKS.store(0, Ordering::SeqCst);
+        GLOBAL_ORPHAN_TOTAL_BYTES.store(0, Ordering::SeqCst);
+        GLOBAL_ORPHAN_BYTE_LIMIT_OVERRIDE.store(0, Ordering::SeqCst);
+    }
 
     #[derive(Deserialize)]
     struct SharedRuntimeVectors {
@@ -2638,6 +2664,9 @@ mod tests {
 
     #[test]
     fn handle_block_retains_orphan_until_parent_arrives() {
+        let _guard = ORPHAN_POOL_TEST_LOCK.lock().expect("lock orphan tests");
+        reset_orphan_pool_metrics_for_test();
+
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
         let addr = listener.local_addr().expect("addr");
 
@@ -2662,6 +2691,14 @@ mod tests {
             session
                 .handle_block(&block2, &mut engine)
                 .expect("orphan block should be retained");
+            assert_eq!(
+                orphan_pool_metrics_snapshot(),
+                OrphanPoolMetricsSnapshot {
+                    live_blocks: 1,
+                    live_bytes: block2.len()
+                },
+                "retained orphan must be visible in live observability only"
+            );
             assert_eq!(engine.chain_state.height, 0, "orphan must not advance tip");
             assert_eq!(
                 engine.chain_state.tip_hash, genesis_hash,
@@ -2679,6 +2716,14 @@ mod tests {
                 .expect("parent block should connect and resolve orphan");
 
             assert_eq!(session.orphans.len(), 0, "orphan pool should drain");
+            assert_eq!(
+                orphan_pool_metrics_snapshot(),
+                OrphanPoolMetricsSnapshot {
+                    live_blocks: 0,
+                    live_bytes: 0
+                },
+                "resolved orphan must drain live observability"
+            );
             assert!(engine.has_block(block1_hash).expect("block1 applied"));
             assert!(engine.has_block(block2_hash).expect("block2 resolved"));
             assert_eq!(engine.chain_state.height, 2);
@@ -2686,10 +2731,14 @@ mod tests {
 
         let _client = TcpStream::connect(addr).expect("connect");
         server.join().expect("server join");
+        reset_orphan_pool_metrics_for_test();
     }
 
     #[test]
     fn handle_block_surfaces_invalid_orphan_after_parent_arrives() {
+        let _guard = ORPHAN_POOL_TEST_LOCK.lock().expect("lock orphan tests");
+        reset_orphan_pool_metrics_for_test();
+
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
         let addr = listener.local_addr().expect("addr");
 
@@ -2715,6 +2764,14 @@ mod tests {
             session
                 .handle_block(&block2, &mut engine)
                 .expect("orphan should be retained until parent arrives");
+            assert_eq!(
+                orphan_pool_metrics_snapshot(),
+                OrphanPoolMetricsSnapshot {
+                    live_blocks: 1,
+                    live_bytes: block2.len()
+                },
+                "invalid orphan remains live only until its parent arrives"
+            );
             assert!(
                 !engine
                     .has_block(block2_hash)
@@ -2727,6 +2784,14 @@ mod tests {
             let pending_cleanup = session.take_pending_tx_pool_cleanup();
 
             assert_eq!(session.orphans.len(), 0, "invalid orphan should be dropped");
+            assert_eq!(
+                orphan_pool_metrics_snapshot(),
+                OrphanPoolMetricsSnapshot {
+                    live_blocks: 0,
+                    live_bytes: 0
+                },
+                "invalid orphan must not remain counted after surfacing"
+            );
             assert_eq!(
                 engine.chain_state.height, 1,
                 "parent block must remain connected"
@@ -2754,12 +2819,51 @@ mod tests {
 
         let _client = TcpStream::connect(addr).expect("connect");
         server.join().expect("server join");
+        reset_orphan_pool_metrics_for_test();
+    }
+
+    #[test]
+    fn orphan_pool_metrics_start_zero_and_track_take_children() {
+        let _guard = ORPHAN_POOL_TEST_LOCK.lock().expect("lock orphan tests");
+        reset_orphan_pool_metrics_for_test();
+
+        assert_eq!(
+            orphan_pool_metrics_snapshot(),
+            OrphanPoolMetricsSnapshot {
+                live_blocks: 0,
+                live_bytes: 0
+            }
+        );
+
+        let mut pool = OrphanBlockPool::new(16, usize::MAX);
+        let block = vec![7u8; 123];
+        let block_hash = [1u8; 32];
+        let parent_hash = [2u8; 32];
+
+        pool.add(block_hash, parent_hash, &block, global_orphan_byte_limit());
+        assert_eq!(
+            orphan_pool_metrics_snapshot(),
+            OrphanPoolMetricsSnapshot {
+                live_blocks: 1,
+                live_bytes: block.len()
+            }
+        );
+
+        let children = pool.take_children(parent_hash);
+        assert_eq!(children.len(), 1);
+        assert_eq!(
+            orphan_pool_metrics_snapshot(),
+            OrphanPoolMetricsSnapshot {
+                live_blocks: 0,
+                live_bytes: 0
+            }
+        );
     }
 
     #[test]
     fn orphan_pool_replaces_local_oldest_when_global_limit_reached() {
         let _guard = ORPHAN_POOL_TEST_LOCK.lock().expect("lock orphan tests");
-        GLOBAL_ORPHAN_TOTAL_BYTES.store(0, Ordering::SeqCst);
+        reset_orphan_pool_metrics_for_test();
         GLOBAL_ORPHAN_BYTE_LIMIT_OVERRIDE.store(1024, Ordering::SeqCst);
 
         let mut pool = OrphanBlockPool::new(16, usize::MAX);
@@ -2770,6 +2874,13 @@ mod tests {
         pool.add([3u8; 32], [4u8; 32], &second, global_orphan_byte_limit());
 
         assert_eq!(pool.len(), 1, "global cap should still permit local churn");
+        assert_eq!(
+            orphan_pool_metrics_snapshot(),
+            OrphanPoolMetricsSnapshot {
+                live_blocks: 1,
+                live_bytes: 800
+            }
+        );
         assert!(
             pool.by_hash.contains_key(&[3u8; 32]),
             "new orphan should be retained"
@@ -2781,14 +2892,21 @@ mod tests {
         assert_eq!(GLOBAL_ORPHAN_TOTAL_BYTES.load(Ordering::SeqCst), 800);
 
         drop(pool);
-        GLOBAL_ORPHAN_BYTE_LIMIT_OVERRIDE.store(0, Ordering::SeqCst);
-        assert_eq!(GLOBAL_ORPHAN_TOTAL_BYTES.load(Ordering::SeqCst), 0);
+        assert_eq!(
+            orphan_pool_metrics_snapshot(),
+            OrphanPoolMetricsSnapshot {
+                live_blocks: 0,
+                live_bytes: 0
+            },
+            "dropping the orphan pool must drain live observability"
+        );
+        reset_orphan_pool_metrics_for_test();
     }
 
     #[test]
     fn orphan_pool_enforces_global_byte_limit_across_sessions() {
         let _guard = ORPHAN_POOL_TEST_LOCK.lock().expect("lock orphan tests");
-        GLOBAL_ORPHAN_TOTAL_BYTES.store(0, Ordering::SeqCst);
+        reset_orphan_pool_metrics_for_test();
         GLOBAL_ORPHAN_BYTE_LIMIT_OVERRIDE.store(1024, Ordering::SeqCst);
 
         let mut pool_a = OrphanBlockPool::new(16, usize::MAX);
@@ -2805,11 +2923,19 @@ mod tests {
             "second session should be capped by global limit"
         );
         assert_eq!(GLOBAL_ORPHAN_TOTAL_BYTES.load(Ordering::SeqCst), 800);
+        assert_eq!(GLOBAL_ORPHAN_TOTAL_BLOCKS.load(Ordering::SeqCst), 1);
 
         drop(pool_a);
         drop(pool_b);
-        GLOBAL_ORPHAN_BYTE_LIMIT_OVERRIDE.store(0, Ordering::SeqCst);
-        assert_eq!(GLOBAL_ORPHAN_TOTAL_BYTES.load(Ordering::SeqCst), 0);
+        assert_eq!(
+            orphan_pool_metrics_snapshot(),
+            OrphanPoolMetricsSnapshot {
+                live_blocks: 0,
+                live_bytes: 0
+            },
+            "dropping all sessions must drain live observability"
+        );
+        reset_orphan_pool_metrics_for_test();
     }
 
     #[test]


### PR DESCRIPTION
Invariant:
Expose live Rust P2P orphan-pool observability without changing orphan admission, resolution, eviction, P2P wire behavior, consensus behavior, Go code, or devnet report schemas.

Layer:
implementation / observability / tests

Files changed:
- clients/rust/crates/rubin-node/src/p2p_runtime.rs
- clients/rust/crates/rubin-node/src/devnet_rpc.rs

Tests:
- cargo fmt --check — PASS
- cargo test -p rubin-node orphan — PASS
- cargo test -p rubin-node metrics — PASS
- cargo test -p rubin-node — PASS
- cargo clippy -p rubin-node --all-targets -- -D warnings — PASS
- tooling-check.sh --new-only --mode rust-deep — PASS
- git diff --check and git diff --check origin/main...HEAD — PASS
- rubin-precommit-one-review --include-base-diff — PASS
- rubin-push with cargo test -p rubin-node coverage command — PASS

Behavior impact:
Adds two read-only Rust /metrics gauges for live in-memory P2P orphan blocks and bytes. No consensus, wire, orphan admission, resolution, or eviction behavior change.

Compatibility impact:
No Go changes. No schema/report/harness changes.

### Parity exemption justification
This is Rust-only observability. Go has orphan-pool internals but no matching /metrics gauge for p2p orphan pool blocks or bytes in the current codebase. This PR does not claim Go/Rust metric parity.

Known non-goals:
- No reorg metrics changes.
- No mixed-client readiness proof.
- No conformance fixture changes.
- No devnet report generator changes.

<!-- rubin-agent-meta actor=unknown action=pr-create via=cl branch=codex/RUB-227-rust-p2p-orphan-metrics wt=rubin-protocol-codex-RUB-227-rust-p2p-orphan-metrics utc=2026-05-18T21:38:48Z -->
