### PR TITLE
RUB-260: reduce Go CORE crypto CCN rows

### DIFF
--- a/clients/go/consensus/core_ext_binding.go
+++ b/clients/go/consensus/core_ext_binding.go
@@ -151,38 +151,58 @@ func ParseCoreExtOpenSSLDigest32BindingDescriptor(raw []byte) (CoreExtOpenSSLDig
 		return CoreExtOpenSSLDigest32BindingDescriptor{}, fmt.Errorf("bad core_ext binding_descriptor")
 	}
 	off := len(coreExtOpenSSLDigest32BindingDescriptorPrefix)
-	algLenU64, _, err := readCompactSize(raw, &off)
+	algBytes, err := readCoreExtOpenSSLBindingAlg(raw, &off)
 	if err != nil {
-		return CoreExtOpenSSLDigest32BindingDescriptor{}, fmt.Errorf("bad core_ext binding_descriptor")
+		return CoreExtOpenSSLDigest32BindingDescriptor{}, err
 	}
-	if algLenU64 > uint64(math.MaxInt) {
-		return CoreExtOpenSSLDigest32BindingDescriptor{}, fmt.Errorf("bad core_ext binding_descriptor")
-	}
-	algBytes, err := readBytes(raw, &off, int(algLenU64))
+	pubkeyLen, sigLen, err := readCoreExtOpenSSLBindingLengths(raw, &off)
 	if err != nil {
-		return CoreExtOpenSSLDigest32BindingDescriptor{}, fmt.Errorf("bad core_ext binding_descriptor")
-	}
-	pubkeyLenU64, _, err := readCompactSize(raw, &off)
-	if err != nil {
-		return CoreExtOpenSSLDigest32BindingDescriptor{}, fmt.Errorf("bad core_ext binding_descriptor")
-	}
-	sigLenU64, _, err := readCompactSize(raw, &off)
-	if err != nil {
-		return CoreExtOpenSSLDigest32BindingDescriptor{}, fmt.Errorf("bad core_ext binding_descriptor")
-	}
-	if off != len(raw) || pubkeyLenU64 > uint64(math.MaxInt) || sigLenU64 > uint64(math.MaxInt) {
-		return CoreExtOpenSSLDigest32BindingDescriptor{}, fmt.Errorf("bad core_ext binding_descriptor")
+		return CoreExtOpenSSLDigest32BindingDescriptor{}, err
 	}
 
 	desc := CoreExtOpenSSLDigest32BindingDescriptor{
 		OpenSSLAlg: string(algBytes),
-		PubkeyLen:  int(pubkeyLenU64),
-		SigLen:     int(sigLenU64),
+		PubkeyLen:  pubkeyLen,
+		SigLen:     sigLen,
 	}
 	if err := validateCoreExtOpenSSLBindingDescriptor(desc.OpenSSLAlg, desc.PubkeyLen, desc.SigLen); err != nil {
 		return CoreExtOpenSSLDigest32BindingDescriptor{}, err
 	}
 	return desc, nil
+}
+
+func badCoreExtBindingDescriptorError() error {
+	return fmt.Errorf("bad core_ext binding_descriptor")
+}
+
+func readCoreExtOpenSSLBindingAlg(raw []byte, off *int) ([]byte, error) {
+	algLenU64, _, err := readCompactSize(raw, off)
+	if err != nil {
+		return nil, badCoreExtBindingDescriptorError()
+	}
+	if algLenU64 > uint64(math.MaxInt) {
+		return nil, badCoreExtBindingDescriptorError()
+	}
+	algBytes, err := readBytes(raw, off, int(algLenU64))
+	if err != nil {
+		return nil, badCoreExtBindingDescriptorError()
+	}
+	return algBytes, nil
+}
+
+func readCoreExtOpenSSLBindingLengths(raw []byte, off *int) (int, int, error) {
+	pubkeyLenU64, _, err := readCompactSize(raw, off)
+	if err != nil {
+		return 0, 0, badCoreExtBindingDescriptorError()
+	}
+	sigLenU64, _, err := readCompactSize(raw, off)
+	if err != nil {
+		return 0, 0, badCoreExtBindingDescriptorError()
+	}
+	if *off != len(raw) || pubkeyLenU64 > uint64(math.MaxInt) || sigLenU64 > uint64(math.MaxInt) {
+		return 0, 0, badCoreExtBindingDescriptorError()
+	}
+	return int(pubkeyLenU64), int(sigLenU64), nil
 }
 
 func validateCoreExtOpenSSLBindingDescriptor(opensslAlg string, pubkeyLen int, sigLen int) error {

--- a/clients/go/consensus/openssl_signer.go
+++ b/clients/go/consensus/openssl_signer.go
@@ -245,29 +245,8 @@ func signOpenSSLDigest32(pkey *C.EVP_PKEY, digest [32]byte, maxSigBytes int, exa
 	if err := ensureOpenSSLBootstrap(); err != nil {
 		return nil, err
 	}
-	// Reject three classes of unusable inputs at this package-local FFI
-	// boundary so a degenerate caller cannot reach the make([]byte, ...)
-	// allocation, the C-pointer take-address site, or the C helper with
-	// inputs the call cannot satisfy: nil pkey (which the C helper would
-	// dereference), non-positive maxSigBytes (which the take-address site
-	// cannot index), and exactSigBytes greater than maxSigBytes (which
-	// the C helper cannot satisfy because it writes at most maxSigBytes
-	// and the post-call length check then rejects). Mirrors the
-	// conformance-only path's nil/zero-receiver guard. Covered by
-	// TestSignOpenSSLDigest32_NilPKeyErrors,
-	// TestSignOpenSSLDigest32_NonPositiveMaxSigBytesErrors, and
-	// TestSignOpenSSLDigest32_ExactGreaterThanMaxErrors.
-	if pkey == nil {
-		return nil, fmt.Errorf("nil openssl key")
-	}
-	if maxSigBytes <= 0 {
-		return nil, fmt.Errorf("openssl maxSigBytes must be positive, got %d", maxSigBytes)
-	}
-	if exactSigBytes > maxSigBytes {
-		return nil, fmt.Errorf(
-			"openssl exactSigBytes=%d exceeds maxSigBytes=%d",
-			exactSigBytes, maxSigBytes,
-		)
+	if err := validateSignOpenSSLDigest32Inputs(pkey, maxSigBytes, exactSigBytes); err != nil {
+		return nil, err
 	}
 
 	errBuf := newOpenSSLErrorBuffer()
@@ -288,15 +267,47 @@ func signOpenSSLDigest32(pkey *C.EVP_PKEY, digest [32]byte, maxSigBytes int, exa
 		return nil, fmt.Errorf("openssl sign failed: %s", cStringTrim0(errBuf))
 	}
 
-	if exactSigBytes > 0 {
-		if int(signatureLen) != exactSigBytes {
-			return nil, fmt.Errorf("openssl sig length=%d, want %d", int(signatureLen), exactSigBytes)
-		}
-	} else if signatureLen == 0 || int(signatureLen) > maxSigBytes {
-		return nil, fmt.Errorf("openssl sig length=%d, want 1..%d", int(signatureLen), maxSigBytes)
+	if err := validateSignOpenSSLSignatureLen(signatureLen, maxSigBytes, exactSigBytes); err != nil {
+		return nil, err
 	}
 
 	return signature[:int(signatureLen)], nil
+}
+
+// Reject three classes of unusable inputs at this package-local FFI boundary so
+// a degenerate caller cannot reach the allocation, C-pointer take-address site,
+// or C helper with inputs the call cannot satisfy. Covered by
+// TestSignOpenSSLDigest32_NilPKeyErrors,
+// TestSignOpenSSLDigest32_NonPositiveMaxSigBytesErrors, and
+// TestSignOpenSSLDigest32_ExactGreaterThanMaxErrors.
+func validateSignOpenSSLDigest32Inputs(pkey *C.EVP_PKEY, maxSigBytes int, exactSigBytes int) error {
+	if pkey == nil {
+		return fmt.Errorf("nil openssl key")
+	}
+	if maxSigBytes <= 0 {
+		return fmt.Errorf("openssl maxSigBytes must be positive, got %d", maxSigBytes)
+	}
+	if exactSigBytes > maxSigBytes {
+		return fmt.Errorf(
+			"openssl exactSigBytes=%d exceeds maxSigBytes=%d",
+			exactSigBytes, maxSigBytes,
+		)
+	}
+	return nil
+}
+
+func validateSignOpenSSLSignatureLen(signatureLen C.size_t, maxSigBytes int, exactSigBytes int) error {
+	got := int(signatureLen)
+	if exactSigBytes > 0 {
+		if got != exactSigBytes {
+			return fmt.Errorf("openssl sig length=%d, want %d", got, exactSigBytes)
+		}
+		return nil
+	}
+	if signatureLen == 0 || got > maxSigBytes {
+		return fmt.Errorf("openssl sig length=%d, want 1..%d", got, maxSigBytes)
+	}
+	return nil
 }
 
 // MLDSA87Keypair is a non-consensus helper used by tests and conformance tooling

--- a/clients/go/consensus/verify_sig_openssl.go
+++ b/clients/go/consensus/verify_sig_openssl.go
@@ -326,17 +326,8 @@ func parseOpenSSLErrorBuffer(errBuf []byte, fallback string) error {
 }
 
 func opensslVerifySigOneShot(alg string, pubkey []byte, signature []byte, msg []byte) (bool, error) {
-	if alg == "" {
-		return false, fmt.Errorf("openssl: empty algorithm")
-	}
-	if len(pubkey) == 0 {
-		return false, fmt.Errorf("openssl: empty pubkey")
-	}
-	if len(signature) == 0 {
-		return false, fmt.Errorf("openssl: empty signature")
-	}
-	if len(msg) == 0 {
-		return false, fmt.Errorf("openssl: empty message")
+	if err := validateOpenSSLVerifySigOneShotInputs(alg, pubkey, signature, msg); err != nil {
+		return false, err
 	}
 
 	cAlg := C.CString(alg)
@@ -360,12 +351,32 @@ func opensslVerifySigOneShot(alg string, pubkey []byte, signature []byte, msg []
 	case 0:
 		return false, nil
 	default:
-		n := 0
-		for n < len(errBuf) && errBuf[n] != 0 {
-			n++
-		}
-		return false, fmt.Errorf("openssl verify failed: %s", string(errBuf[:n]))
+		return false, openSSLVerifySigOneShotError(errBuf)
 	}
+}
+
+func validateOpenSSLVerifySigOneShotInputs(alg string, pubkey []byte, signature []byte, msg []byte) error {
+	if alg == "" {
+		return fmt.Errorf("openssl: empty algorithm")
+	}
+	if len(pubkey) == 0 {
+		return fmt.Errorf("openssl: empty pubkey")
+	}
+	if len(signature) == 0 {
+		return fmt.Errorf("openssl: empty signature")
+	}
+	if len(msg) == 0 {
+		return fmt.Errorf("openssl: empty message")
+	}
+	return nil
+}
+
+func openSSLVerifySigOneShotError(errBuf []byte) error {
+	n := 0
+	for n < len(errBuf) && errBuf[n] != 0 {
+		n++
+	}
+	return fmt.Errorf("openssl verify failed: %s", string(errBuf[:n]))
 }
 
 // verifySig is the legacy single-suite dispatcher kept alongside the


### PR DESCRIPTION
Refs: Q-CODACY-GO-CCN-CONSENSUS-CORE-CRYPTO-01

## Summary

Reduce the three current Codacy CCN rows in Go CORE_EXT/OpenSSL consensus-adjacent helper code by extracting local helpers only.

## Scope

Changed files:
- `clients/go/consensus/core_ext_binding.go`
- `clients/go/consensus/openssl_signer.go`
- `clients/go/consensus/verify_sig_openssl.go`

Boundary:
- Consensus rules unchanged: YES
- `SECTION_HASHES.json` unchanged: YES

Layer:
- consensus-adjacent implementation refactor

## Behavior impact

No intended behavior change.

Preserved boundaries:
- CORE_EXT binding descriptor parsing keeps the same prefix, CompactSize, overflow, trailing-byte, and descriptor validation order.
- OpenSSL signing keeps `ensureOpenSSLBootstrap()` before input guards and preserves existing error strings.
- OpenSSL one-shot verification keeps empty input guards before C pointer address-taking and preserves verify result/error mapping.

## Compatibility impact

No public API shape change and no fixture/schema change.

## Known non-goals

- No Go/Rust parity behavior change.
- No conformance vector update.
- No OpenSSL backend policy change.
- No crypto algorithm or signature semantics change.

### Parity exemption justification

This PR changes only Go helper structure for three Codacy CCN rows. It does not change wire format, signature inputs, descriptor bytes, validation outcomes, or Go/Rust parity expectations. Rust code is intentionally untouched.

### Fixture exemption justification

No fixture expectations change. The touched CORE_EXT descriptor parser and OpenSSL signer/verifier behavior remain covered by existing malformed descriptor, OpenSSL guard, and verification tests.

## Tests

- `gocyclo -over 8 clients/go/consensus/core_ext_binding.go clients/go/consensus/openssl_signer.go clients/go/consensus/verify_sig_openssl.go` — PASS, no rows.
- `python3 .../rubin-codacy/scripts/lizard_medium_rows.py clients/go/consensus/core_ext_binding.go clients/go/consensus/openssl_signer.go clients/go/consensus/verify_sig_openssl.go` — PASS, 0 metric issues.
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -v ./consensus -run "Test.*CoreExt|Test.*OpenSSL|Test.*Binding" -count=1'` — PASS.
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -v ./...'` — PASS.
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -v -coverprofile=/tmp/rub260-go-consensus.cover ./consensus'` — PASS, 93.8% statement coverage.
- `rubin-precommit-one-review --repo <task-worktree> --base-ref origin/main --include-base-diff` — PASS.
- One isolated stock raw-diff code-review subagent — No findings.
- `rubin-push --repo <task-worktree> --base-ref origin/main --coverage-cmd "scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -v -coverprofile=/tmp/rub260-go-consensus.cover ./consensus'" -- origin HEAD` — PASS.

## Risk

Consensus-adjacent parser/crypto code. Mitigation is mechanical helper extraction only, existing behavior tests, full Go tests, coverage, and raw-diff review.

## Rollback

Revert commit `eaa644f4451e75d60843866f4afc0c5201a73679`.

## Not checked

- No new conformance vectors were run because no vector behavior changed.


<!-- rubin-agent-meta actor=unknown action=pr-edit via=cl branch=codex/RUB-260-go-core-crypto-ccn wt=rubin-protocol-codex-RUB-260-go-core-crypto-ccn utc=2026-05-18T22:04:30Z -->
