### PR TITLE
RUB-303 reduce covenant genesis validation shape

### DIFF
--- a/clients/go/consensus/covenant_genesis.go
+++ b/clients/go/consensus/covenant_genesis.go
@@ -13,82 +13,122 @@ func ValidateTxCovenantsGenesis(tx *Tx, blockHeight uint64, rotation RotationPro
 	}
 
 	for _, out := range tx.Outputs {
-		switch out.CovenantType {
-		case COV_TYPE_P2PK:
-			if out.Value == 0 {
-				return txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_P2PK value must be > 0")
-			}
-			if len(out.CovenantData) != MAX_P2PK_COVENANT_DATA {
-				return txerr(TX_ERR_COVENANT_TYPE_INVALID, "invalid CORE_P2PK covenant_data length")
-			}
-			suiteID := out.CovenantData[0]
-			if !rotation.NativeCreateSuites(blockHeight).Contains(suiteID) {
-				return txerr(TX_ERR_SIG_ALG_INVALID, "CORE_P2PK suite not in native create set")
-			}
-
-		case COV_TYPE_ANCHOR:
-			if out.Value != 0 {
-				return txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_ANCHOR value must be 0")
-			}
-			covLen := len(out.CovenantData)
-			if covLen == 0 || covLen > MAX_ANCHOR_PAYLOAD_SIZE {
-				return txerr(TX_ERR_COVENANT_TYPE_INVALID, "invalid CORE_ANCHOR covenant_data length")
-			}
-
-		case COV_TYPE_VAULT:
-			if out.Value == 0 {
-				return txerr(TX_ERR_VAULT_PARAMS_INVALID, "CORE_VAULT value must be > 0")
-			}
-			if _, err := ParseVaultCovenantData(out.CovenantData); err != nil {
-				return err
-			}
-		case COV_TYPE_MULTISIG:
-			if out.Value == 0 {
-				return txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_MULTISIG value must be > 0")
-			}
-			if _, err := ParseMultisigCovenantData(out.CovenantData); err != nil {
-				return err
-			}
-		case COV_TYPE_HTLC:
-			if out.Value == 0 {
-				return txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_HTLC value must be > 0")
-			}
-			if _, err := ParseHTLCCovenantData(out.CovenantData); err != nil {
-				return err
-			}
-
-		case COV_TYPE_CORE_EXT:
-			if out.Value == 0 {
-				return txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_EXT value must be > 0")
-			}
-			if _, err := ParseCoreExtCovenantData(out.CovenantData); err != nil {
-				return err
-			}
-		case COV_TYPE_CORE_STEALTH:
-			if out.Value == 0 {
-				return txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_STEALTH value must be > 0")
-			}
-			if _, err := ParseStealthCovenantData(out.CovenantData); err != nil {
-				return err
-			}
-
-		case COV_TYPE_DA_COMMIT:
-			if tx.TxKind != 0x01 {
-				return txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_DA_COMMIT allowed only in tx_kind=0x01")
-			}
-			if out.Value != 0 {
-				return txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_DA_COMMIT value must be 0")
-			}
-			if len(out.CovenantData) != 32 {
-				return txerr(TX_ERR_COVENANT_TYPE_INVALID, "invalid CORE_DA_COMMIT covenant_data length")
-			}
-		case COV_TYPE_RESERVED_FUTURE:
-			return txerr(TX_ERR_COVENANT_TYPE_INVALID, "reserved covenant_type")
-
-		default:
-			return txerr(TX_ERR_COVENANT_TYPE_INVALID, "unknown covenant_type")
+		if err := validateTxOutputCovenantGenesis(tx.TxKind, out, blockHeight, rotation); err != nil {
+			return err
 		}
 	}
 
+	return nil
+}
+
+func validateTxOutputCovenantGenesis(txKind byte, out TxOutput, blockHeight uint64, rotation RotationProvider) error {
+	switch out.CovenantType {
+	case COV_TYPE_P2PK:
+		return validateP2PKGenesisOutput(out, blockHeight, rotation)
+	case COV_TYPE_ANCHOR:
+		return validateAnchorGenesisOutput(out)
+	case COV_TYPE_DA_COMMIT:
+		return validateDACommitGenesisOutput(txKind, out)
+	case COV_TYPE_VAULT, COV_TYPE_MULTISIG, COV_TYPE_HTLC, COV_TYPE_CORE_EXT, COV_TYPE_CORE_STEALTH:
+		return validateParsedValueGenesisOutput(out)
+	case COV_TYPE_RESERVED_FUTURE:
+		return txerr(TX_ERR_COVENANT_TYPE_INVALID, "reserved covenant_type")
+	default:
+		return txerr(TX_ERR_COVENANT_TYPE_INVALID, "unknown covenant_type")
+	}
+}
+
+func validateP2PKGenesisOutput(out TxOutput, blockHeight uint64, rotation RotationProvider) error {
+	if out.Value == 0 {
+		return txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_P2PK value must be > 0")
+	}
+	if len(out.CovenantData) != MAX_P2PK_COVENANT_DATA {
+		return txerr(TX_ERR_COVENANT_TYPE_INVALID, "invalid CORE_P2PK covenant_data length")
+	}
+	suiteID := out.CovenantData[0]
+	if !rotation.NativeCreateSuites(blockHeight).Contains(suiteID) {
+		return txerr(TX_ERR_SIG_ALG_INVALID, "CORE_P2PK suite not in native create set")
+	}
+	return nil
+}
+
+func validateAnchorGenesisOutput(out TxOutput) error {
+	if out.Value != 0 {
+		return txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_ANCHOR value must be 0")
+	}
+	covLen := len(out.CovenantData)
+	if covLen == 0 || covLen > MAX_ANCHOR_PAYLOAD_SIZE {
+		return txerr(TX_ERR_COVENANT_TYPE_INVALID, "invalid CORE_ANCHOR covenant_data length")
+	}
+	return nil
+}
+
+func validateParsedValueGenesisOutput(out TxOutput) error {
+	switch out.CovenantType {
+	case COV_TYPE_VAULT:
+		return validateVaultGenesisOutput(out)
+	case COV_TYPE_MULTISIG:
+		return validateMultisigGenesisOutput(out)
+	case COV_TYPE_HTLC:
+		return validateHTLCGenesisOutput(out)
+	case COV_TYPE_CORE_EXT:
+		return validateCoreExtGenesisOutput(out)
+	case COV_TYPE_CORE_STEALTH:
+		return validateCoreStealthGenesisOutput(out)
+	default:
+		return txerr(TX_ERR_COVENANT_TYPE_INVALID, "unknown covenant_type")
+	}
+}
+
+func validateVaultGenesisOutput(out TxOutput) error {
+	if out.Value == 0 {
+		return txerr(TX_ERR_VAULT_PARAMS_INVALID, "CORE_VAULT value must be > 0")
+	}
+	_, err := ParseVaultCovenantData(out.CovenantData)
+	return err
+}
+
+func validateMultisigGenesisOutput(out TxOutput) error {
+	if out.Value == 0 {
+		return txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_MULTISIG value must be > 0")
+	}
+	_, err := ParseMultisigCovenantData(out.CovenantData)
+	return err
+}
+
+func validateHTLCGenesisOutput(out TxOutput) error {
+	if out.Value == 0 {
+		return txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_HTLC value must be > 0")
+	}
+	_, err := ParseHTLCCovenantData(out.CovenantData)
+	return err
+}
+
+func validateCoreExtGenesisOutput(out TxOutput) error {
+	if out.Value == 0 {
+		return txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_EXT value must be > 0")
+	}
+	_, err := ParseCoreExtCovenantData(out.CovenantData)
+	return err
+}
+
+func validateCoreStealthGenesisOutput(out TxOutput) error {
+	if out.Value == 0 {
+		return txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_STEALTH value must be > 0")
+	}
+	_, err := ParseStealthCovenantData(out.CovenantData)
+	return err
+}
+
+func validateDACommitGenesisOutput(txKind byte, out TxOutput) error {
+	if txKind != 0x01 {
+		return txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_DA_COMMIT allowed only in tx_kind=0x01")
+	}
+	if out.Value != 0 {
+		return txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_DA_COMMIT value must be 0")
+	}
+	if len(out.CovenantData) != 32 {
+		return txerr(TX_ERR_COVENANT_TYPE_INVALID, "invalid CORE_DA_COMMIT covenant_data length")
+	}
 	return nil
 }


### PR DESCRIPTION
Invariant:
Reduce the Go covenant genesis validation Codacy/Lizard CCN/NLOC row without changing public validation behavior, validation order, parser calls, error code/message mapping, consensus validity, or public API.

Layer:
Consensus-adjacent implementation shape cleanup only.

Files changed:
- clients/go/consensus/covenant_genesis.go

What changed:
- Kept `ValidateTxCovenantsGenesis` as the public entrypoint.
- Split the existing switch body into private per-covenant helper functions.
- Preserved existing checks and parser calls for P2PK, ANCHOR, VAULT, MULTISIG, HTLC, CORE_EXT, CORE_STEALTH, DA_COMMIT, reserved, and unknown covenant types.

Behavior impact:
None intended. This is a private helper extraction only.

Compatibility impact:
No public API changes.

### Parity exemption justification

This PR changes only Go private helper structure in `clients/go/consensus/covenant_genesis.go`. It does not change public validation behavior, parser calls, error code/message mapping, validation order, wire encoding, hash/preimage behavior, fixtures, or conformance expectations. A Rust consensus implementation change would be inappropriate because there is no semantic parity delta to mirror.

Tests:
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -v ./consensus -run "TestValidateTxCovenantsGenesis|FuzzValidateTxCovenantsGenesis" -count=1'` — PASS
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -v ./consensus -count=1'` — PASS
- `python3 /Users/gpt/.agents/skills/rubin-codacy/scripts/lizard_medium_rows.py clients/go/consensus/covenant_genesis.go` — 0 rows
- `rubin-precommit-one-review --repo /Users/gpt/Documents/rubin-protocol-codex-RUB-303-go-covenant-genesis-shape --base-ref origin/main --include-base-diff` — PASS
- One isolated stock raw-diff reviewer — No findings
- `/Users/gpt/bin/rubin-push ...` with focused Go coverage command — PASS

Known non-goals:
- No Rust changes.
- No conformance, fixture, formal, or spec changes.
- No sighash, HTLC, UTXO, stealth, or parameter-count cleanup.
- No behavior or error remapping.

Linear:
RUB-303
