### PR TITLE
RUB-304 reduce UTXO apply helper parameter shape

### DIFF
--- a/clients/go/consensus/connect_block_inmem.go
+++ b/clients/go/consensus/connect_block_inmem.go
@@ -236,17 +236,17 @@ func applyInMemoryNonCoinbaseTxs(
 ) (map[Outpoint]UtxoEntry, uint64, error) {
 	var sumFees uint64
 	for i := 1; i < len(pb.Txs); i++ {
-		nextUtxos, fee, err := applyNonCoinbaseTxBasicWork(
-			pb.Txs[i],
-			pb.Txids[i],
-			workUtxos,
-			blockHeight,
-			blockMTP,
-			validation.chainID,
-			validation.coreExtProfiles,
-			validation.rotation,
-			validation.registry,
-		)
+		nextUtxos, fee, err := applyNonCoinbaseTxBasicWork(nonCoinbaseApplyWorkInput{
+			tx:              pb.Txs[i],
+			txid:            pb.Txids[i],
+			utxoSet:         workUtxos,
+			height:          blockHeight,
+			blockMTP:        blockMTP,
+			chainID:         validation.chainID,
+			coreExtProfiles: validation.coreExtProfiles,
+			rotation:        validation.rotation,
+			registry:        validation.registry,
+		})
 		if err != nil {
 			return nil, 0, err
 		}

--- a/clients/go/consensus/tx_helpers.go
+++ b/clients/go/consensus/tx_helpers.go
@@ -133,17 +133,17 @@ func CheckParsedTransactionWithOwnedUtxoSetAndCoreExtProfilesAndSuiteContext(
 	if err != nil {
 		return nil, err
 	}
-	_, fee, err := applyNonCoinbaseTxBasicWork(
-		tx,
-		txid,
-		workUtxos,
-		height,
-		blockMTP,
-		chainID,
-		coreExtProfiles,
-		rotation,
-		registry,
-	)
+	_, fee, err := applyNonCoinbaseTxBasicWork(nonCoinbaseApplyWorkInput{
+		tx:              tx,
+		txid:            txid,
+		utxoSet:         workUtxos,
+		height:          height,
+		blockMTP:        blockMTP,
+		chainID:         chainID,
+		coreExtProfiles: coreExtProfiles,
+		rotation:        rotation,
+		registry:        registry,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/clients/go/consensus/utxo_basic.go
+++ b/clients/go/consensus/utxo_basic.go
@@ -1,26 +1,28 @@
 package consensus
 
-func applyNonCoinbaseTxBasicWork(
-	tx *Tx,
-	txid [32]byte,
-	utxoSet map[Outpoint]UtxoEntry,
-	height uint64,
-	blockMTP uint64,
-	chainID [32]byte,
-	coreExtProfiles CoreExtProfileProvider,
-	rotation RotationProvider,
-	registry *SuiteRegistry,
-) (map[Outpoint]UtxoEntry, uint64, error) {
+type nonCoinbaseApplyWorkInput struct {
+	tx              *Tx
+	txid            [32]byte
+	utxoSet         map[Outpoint]UtxoEntry
+	height          uint64
+	blockMTP        uint64
+	chainID         [32]byte
+	coreExtProfiles CoreExtProfileProvider
+	rotation        RotationProvider
+	registry        *SuiteRegistry
+}
+
+func applyNonCoinbaseTxBasicWork(input nonCoinbaseApplyWorkInput) (map[Outpoint]UtxoEntry, uint64, error) {
 	return (&nonCoinbaseApplyContext{
-		tx:              tx,
-		txid:            txid,
-		work:            utxoSet,
-		height:          height,
-		blockMTP:        blockMTP,
-		chainID:         chainID,
-		coreExtProfiles: nonCoinbaseCoreExtProfilesOrEmpty(coreExtProfiles),
-		rotation:        rotation,
-		registry:        registry,
+		tx:              input.tx,
+		txid:            input.txid,
+		work:            input.utxoSet,
+		height:          input.height,
+		blockMTP:        input.blockMTP,
+		chainID:         input.chainID,
+		coreExtProfiles: nonCoinbaseCoreExtProfilesOrEmpty(input.coreExtProfiles),
+		rotation:        input.rotation,
+		registry:        input.registry,
 	}).apply()
 }
 

--- a/clients/go/consensus/utxo_basic_additional_test.go
+++ b/clients/go/consensus/utxo_basic_additional_test.go
@@ -86,7 +86,11 @@ func TestApplyNonCoinbaseTxBasicWorkRejectsUnsupportedTxKindViaPrehashCache(t *t
 			Sequence: 0x7FFFFFFF,
 		}},
 	}
-	_, _, err := applyNonCoinbaseTxBasicWork(tx, [32]byte{}, map[Outpoint]UtxoEntry{}, 1, 0, [32]byte{}, nil, nil, nil)
+	_, _, err := applyNonCoinbaseTxBasicWork(nonCoinbaseApplyWorkInput{
+		tx:      tx,
+		utxoSet: map[Outpoint]UtxoEntry{},
+		height:  1,
+	})
 	if err == nil {
 		t.Fatal("expected unsupported tx_kind error")
 	}

--- a/clients/go/consensus/utxo_basic_common.go
+++ b/clients/go/consensus/utxo_basic_common.go
@@ -125,7 +125,17 @@ func ApplyNonCoinbaseTxBasicUpdateWithMTPAndCoreExtProfilesAndSuiteContext(
 		coreExtProfiles = EmptyCoreExtProfileProvider()
 	}
 	work := cloneUtxoSet(utxoSet)
-	work, fee, err := applyNonCoinbaseTxBasicWork(tx, txid, work, height, blockMTP, chainID, coreExtProfiles, rotation, registry)
+	work, fee, err := applyNonCoinbaseTxBasicWork(nonCoinbaseApplyWorkInput{
+		tx:              tx,
+		txid:            txid,
+		utxoSet:         work,
+		height:          height,
+		blockMTP:        blockMTP,
+		chainID:         chainID,
+		coreExtProfiles: coreExtProfiles,
+		rotation:        rotation,
+		registry:        registry,
+	})
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Invariant:
Reduce the private Go UTXO apply helper parameter-count row without changing public validation behavior, validation order, error code/message mapping, UTXO transition semantics, output bytes, consensus validity, or public API.

Layer:
consensus-adjacent implementation cleanup

Files changed:
- clients/go/consensus/utxo_basic.go
- clients/go/consensus/connect_block_inmem.go
- clients/go/consensus/tx_helpers.go
- clients/go/consensus/utxo_basic_common.go
- clients/go/consensus/utxo_basic_additional_test.go

What changed:
- Replaced the private `applyNonCoinbaseTxBasicWork` positional argument list with a private `nonCoinbaseApplyWorkInput` value.
- Updated only direct private call sites to pass the same values by named field.
- Kept all exported/public function signatures unchanged.

Behavior impact:
None intended. This is private call-shape cleanup only.

Compatibility impact:
No public API, fixture, conformance, Rust, formal, spec, or wire/hash/preimage changes.

Known non-goals:
- No exported parameter-count cleanup.
- No HTLC, stealth, sighash, Rust, conformance, fixture, formal, or spec changes.

Risk:
Field mapping mistakes could change consensus-adjacent UTXO transition context. The diff uses named fields and focused/full consensus tests were run.

Tests:
- `git diff --check` — PASS
- `python3 /Users/gpt/.agents/skills/rubin-codacy/scripts/lizard_medium_rows.py clients/go/consensus/utxo_basic.go` — PASS, 0 rows
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -v ./consensus -run "TestApplyNonCoinbase|TestConnectBlock|TestCheckParsedTransaction|Fuzz" -count=1'` — PASS
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -v ./consensus -count=1'` — PASS
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -v -coverprofile=/tmp/rub-304-consensus.cover ./consensus -run "TestApplyNonCoinbase|TestConnectBlock|TestCheckParsedTransaction|Fuzz" -count=1'` — PASS
- `rubin-precommit-one-review --repo /Users/gpt/Documents/rubin-protocol-codex-RUB-304-go-utxo-basic-private-context --base-ref origin/main --include-base-diff` — PASS
- One isolated stock raw-diff reviewer — No findings
- `/Users/gpt/bin/rubin-push ...` — PASS

### Parity exemption justification

This PR is Go-only private helper shape cleanup. It does not change consensus semantics, validation order, public error mapping, exported API, conformance fixtures, wire bytes, txid/wtxid/sighash preimages, or Rust behavior. There is no Rust counterpart change to make; semantic parity remains covered by existing Go/Rust conformance and consensus tests.

Linear: RUB-304
