### PR TITLE
RUB-305 reduce stealth spend helper parameter shape

### DIFF
--- a/clients/go/consensus/stealth.go
+++ b/clients/go/consensus/stealth.go
@@ -25,45 +25,67 @@ func validateCoreStealthSpend(entry UtxoEntry, w WitnessItem, tx *Tx, inputIndex
 }
 
 func validateCoreStealthSpendWithCache(entry UtxoEntry, w WitnessItem, tx *Tx, inputIndex uint32, inputValue uint64, chainID [32]byte, blockHeight uint64, cache *SighashV1PrehashCache) error {
-	return validateCoreStealthSpendAtHeight(entry, w, tx, inputIndex, inputValue, chainID, blockHeight, cache, nil, nil)
+	return validateCoreStealthSpendAtHeight(coreStealthSpendValidation{
+		entry:       entry,
+		w:           w,
+		tx:          tx,
+		inputIndex:  inputIndex,
+		inputValue:  inputValue,
+		chainID:     chainID,
+		blockHeight: blockHeight,
+		cache:       cache,
+	})
+}
+
+type coreStealthSpendValidation struct {
+	entry       UtxoEntry
+	w           WitnessItem
+	tx          *Tx
+	inputIndex  uint32
+	inputValue  uint64
+	chainID     [32]byte
+	blockHeight uint64
+	cache       *SighashV1PrehashCache
+	rotation    RotationProvider
+	registry    *SuiteRegistry
 }
 
 // validateCoreStealthSpendAtHeight validates a stealth spend using the suite
 // registry and rotation provider. When rotation or registry is nil, defaults
 // are used (ML-DSA-87 genesis set).
-func validateCoreStealthSpendAtHeight(entry UtxoEntry, w WitnessItem, tx *Tx, inputIndex uint32, inputValue uint64, chainID [32]byte, blockHeight uint64, cache *SighashV1PrehashCache, rotation RotationProvider, registry *SuiteRegistry) error {
-	if rotation == nil {
-		rotation = DefaultRotationProvider{}
+func validateCoreStealthSpendAtHeight(input coreStealthSpendValidation) error {
+	if input.rotation == nil {
+		input.rotation = DefaultRotationProvider{}
 	}
-	if registry == nil {
-		registry = DefaultSuiteRegistry()
+	if input.registry == nil {
+		input.registry = DefaultSuiteRegistry()
 	}
 
-	c, err := ParseStealthCovenantData(entry.CovenantData)
+	c, err := ParseStealthCovenantData(input.entry.CovenantData)
 	if err != nil {
 		return err
 	}
 
-	nativeSpend := rotation.NativeSpendSuites(blockHeight)
-	if !nativeSpend.Contains(w.SuiteID) {
+	nativeSpend := input.rotation.NativeSpendSuites(input.blockHeight)
+	if !nativeSpend.Contains(input.w.SuiteID) {
 		return txerr(TX_ERR_SIG_ALG_INVALID, "CORE_STEALTH suite not in native spend set")
 	}
 
-	params, ok := registry.Lookup(w.SuiteID)
+	params, ok := input.registry.Lookup(input.w.SuiteID)
 	if !ok {
 		return txerr(TX_ERR_SIG_ALG_INVALID, "CORE_STEALTH suite not registered")
 	}
 
-	if len(w.Pubkey) != params.PubkeyLen || len(w.Signature) != params.SigLen+1 {
+	if len(input.w.Pubkey) != params.PubkeyLen || len(input.w.Signature) != params.SigLen+1 {
 		return txerr(TX_ERR_SIG_NONCANONICAL, "non-canonical witness item lengths")
 	}
-	return verifyKeyAndSigWithRegistryCache(w, c.OneTimeKeyID, spendSigContext{
-		tx:         tx,
-		inputIndex: inputIndex,
-		inputValue: inputValue,
-		chainID:    chainID,
-		cache:      cache,
-		registry:   registry,
+	return verifyKeyAndSigWithRegistryCache(input.w, c.OneTimeKeyID, spendSigContext{
+		tx:         input.tx,
+		inputIndex: input.inputIndex,
+		inputValue: input.inputValue,
+		chainID:    input.chainID,
+		cache:      input.cache,
+		registry:   input.registry,
 		context:    "CORE_STEALTH",
 	})
 }

--- a/clients/go/consensus/utxo_basic.go
+++ b/clients/go/consensus/utxo_basic.go
@@ -379,7 +379,18 @@ func (ctx *nonCoinbaseApplyContext) validateCoreStealthInput(inputIndex int, ent
 	if len(assigned) != CORE_STEALTH_WITNESS_SLOTS {
 		return txerr(TX_ERR_PARSE, "CORE_STEALTH witness_slots must be 1")
 	}
-	return validateCoreStealthSpendAtHeight(entry, assigned[0], ctx.tx, uint32(inputIndex), entry.Value, ctx.chainID, ctx.height, ctx.sighashCache, ctx.rotation, ctx.registry)
+	return validateCoreStealthSpendAtHeight(coreStealthSpendValidation{
+		entry:       entry,
+		w:           assigned[0],
+		tx:          ctx.tx,
+		inputIndex:  uint32(inputIndex),
+		inputValue:  entry.Value,
+		chainID:     ctx.chainID,
+		blockHeight: ctx.height,
+		cache:       ctx.sighashCache,
+		rotation:    ctx.rotation,
+		registry:    ctx.registry,
+	})
 }
 
 func (ctx *nonCoinbaseApplyContext) addSpendableOutputs() error {


### PR DESCRIPTION
Invariant:
Reduce the private CORE_STEALTH spend helper parameter-count row without changing validation behavior, validation order, public error mapping, sighash context, or public API.

Layer:
consensus-adjacent mechanical refactor

Files changed:
- clients/go/consensus/stealth.go
- clients/go/consensus/utxo_basic.go

What changed:
- Replaced the private `validateCoreStealthSpendAtHeight` argument list with an internal `coreStealthSpendValidation` value.
- Updated the direct private callers with named fields carrying the same values.

Behavior impact:
None intended. Suite checks, registry/default provider behavior, witness length checks, key binding, signature context, sighash cache propagation, and error mapping are unchanged.

Compatibility impact:
No exported API changes.

Known non-goals:
- No Rust changes.
- No conformance, fixture, spec, or formal changes.
- No HTLC, sighash, or exported parameter-count cleanup.

Tests:
- `python3 /Users/gpt/.agents/skills/rubin-codacy/scripts/lizard_medium_rows.py clients/go/consensus/stealth.go clients/go/consensus/utxo_basic.go`
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -v ./consensus -run "TestValidateCoreStealthSpend|TestApplyNonCoinbase|Fuzz" -count=1'`
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -v ./consensus -count=1'`
- `/Users/gpt/bin/rubin-precommit-one-review --repo /Users/gpt/Documents/rubin-protocol-codex-RUB-305-go-stealth-private-context --base-ref origin/main --include-base-diff`
- One isolated stock code-review pass: no findings.
- `/Users/gpt/bin/rubin-push --repo /Users/gpt/Documents/rubin-protocol-codex-RUB-305-go-stealth-private-context --base-ref origin/main --coverage-cmd 'scripts/dev-env.sh -- bash -lc '\''cd clients/go && go test -v -coverprofile=/tmp/rub-305-consensus.cover ./consensus -run "TestValidateCoreStealthSpend|TestApplyNonCoinbase|Fuzz" -count=1'\'' -- origin HEAD:codex/RUB-305-go-stealth-private-context`

### Parity exemption justification
This is a Go-only private helper shape cleanup. It does not change executable consensus behavior, public API, conformance fixtures, or Rust parity obligations.

Linear: RUB-305
