### PR TITLE
RUB-314 add getblocktxn compact codec

### DIFF
--- a/clients/go/node/p2p/compact_wire.go
+++ b/clients/go/node/p2p/compact_wire.go
@@ -8,19 +8,25 @@ import (
 )
 
 const (
-	messageSendCmpct              = "sendcmpct"
-	messageCmpctBlock             = "cmpctblock"
-	messageGetBlockTxn            = "getblocktxn"
-	messageBlockTxn               = "blocktxn"
-	compactRelayVersion    uint64 = 1
-	sendCmpctPayloadBytes         = 9
-	compactShortIDBytes           = 6
-	maxCompactRelayEntries        = maxInventoryVectors
+	messageSendCmpct                 = "sendcmpct"
+	messageCmpctBlock                = "cmpctblock"
+	messageGetBlockTxn               = "getblocktxn"
+	messageBlockTxn                  = "blocktxn"
+	compactRelayVersion       uint64 = 1
+	sendCmpctPayloadBytes            = 9
+	compactShortIDBytes              = 6
+	maxCompactRelayEntries           = maxInventoryVectors
+	maxCompactRelayIndexValue        = consensus.MAX_BLOCK_BYTES - 1
 )
 
 type sendCmpctPayload struct {
 	Mode    uint8
 	Version uint64
+}
+
+type getBlockTxnPayload struct {
+	BlockHash [32]byte
+	Indexes   []uint64
 }
 
 func encodeSendCmpctPayload(p sendCmpctPayload) ([]byte, error) {
@@ -40,4 +46,82 @@ func decodeSendCmpctPayload(payload []byte) (sendCmpctPayload, error) {
 	out := sendCmpctPayload{Mode: payload[0], Version: binary.LittleEndian.Uint64(payload[1:])}
 	_, err := encodeSendCmpctPayload(out)
 	return out, err
+}
+
+func encodeGetBlockTxnPayload(p getBlockTxnPayload) ([]byte, error) {
+	if len(p.Indexes) > maxCompactRelayEntries {
+		return nil, errors.New("too many compact relay indexes")
+	}
+	out := make([]byte, 0, 32+maxCompactSizeBytes+len(p.Indexes)*maxCompactSizeBytes)
+	out = append(out, p.BlockHash[:]...)
+	out = consensus.AppendCompactSize(out, uint64(len(p.Indexes)))
+	var prev uint64
+	for i, idx := range p.Indexes {
+		if idx > maxCompactRelayIndexValue {
+			return nil, errors.New("compact relay index out of range")
+		}
+		if i == 0 {
+			out = consensus.AppendCompactSize(out, idx)
+		} else {
+			if idx <= prev {
+				return nil, errors.New("compact relay indexes not strictly increasing")
+			}
+			out = consensus.AppendCompactSize(out, idx-prev-1)
+		}
+		prev = idx
+	}
+	return out, nil
+}
+
+func decodeGetBlockTxnPayload(payload []byte) (getBlockTxnPayload, error) {
+	var out getBlockTxnPayload
+	if len(payload) < 32 {
+		return out, errors.New("getblocktxn payload missing block hash")
+	}
+	copy(out.BlockHash[:], payload[:32])
+	count, consumed, err := consensus.DecodeCompactSize(payload[32:])
+	if err != nil {
+		return getBlockTxnPayload{}, err
+	}
+	if count > maxCompactRelayEntries {
+		return getBlockTxnPayload{}, errors.New("too many compact relay indexes")
+	}
+	offset := 32 + consumed
+	indexes := make([]uint64, 0, int(count)) // #nosec G115 -- count is capped at maxCompactRelayEntries above.
+	var prev uint64
+	for i := uint64(0); i < count; i++ {
+		delta, n, err := consensus.DecodeCompactSize(payload[offset:])
+		if err != nil {
+			return getBlockTxnPayload{}, err
+		}
+		offset += n
+		idx, err := getBlockTxnAbsoluteIndex(prev, delta, i == 0)
+		if err != nil {
+			return getBlockTxnPayload{}, err
+		}
+		indexes = append(indexes, idx)
+		prev = idx
+	}
+	if offset != len(payload) {
+		return getBlockTxnPayload{}, errors.New("getblocktxn payload has trailing bytes")
+	}
+	out.Indexes = indexes
+	return out, nil
+}
+
+func getBlockTxnAbsoluteIndex(prev, delta uint64, first bool) (uint64, error) {
+	if first {
+		if delta > maxCompactRelayIndexValue {
+			return 0, errors.New("compact relay index out of range")
+		}
+		return delta, nil
+	}
+	if delta > ^uint64(0)-prev-1 {
+		return 0, errors.New("compact relay index overflow")
+	}
+	idx := prev + delta + 1
+	if idx > maxCompactRelayIndexValue {
+		return 0, errors.New("compact relay index out of range")
+	}
+	return idx, nil
 }

--- a/clients/go/node/p2p/compact_wire_test.go
+++ b/clients/go/node/p2p/compact_wire_test.go
@@ -1,6 +1,7 @@
 package p2p
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
@@ -29,6 +30,98 @@ func TestCompactWireCommandConstantsAndPayloadCaps(t *testing.T) {
 			t.Fatalf("%s live cap=%d, want 0 until runtime handler slice", command, got)
 		}
 	}
+}
+
+func TestGetBlockTxnPayloadCodec(t *testing.T) {
+	want := getBlockTxnPayload{
+		BlockHash: [32]byte{0x01, 0x02, 0x03},
+		Indexes:   []uint64{0, 2, 5},
+	}
+	raw, err := encodeGetBlockTxnPayload(want)
+	if err != nil {
+		t.Fatalf("encodeGetBlockTxnPayload: %v", err)
+	}
+	if gotDeltas := raw[32:]; !reflect.DeepEqual(gotDeltas, []byte{3, 0, 1, 2}) {
+		t.Fatalf("getblocktxn differential indexes=%x, want 03000102", gotDeltas)
+	}
+	got, err := decodeGetBlockTxnPayload(raw)
+	if err != nil {
+		t.Fatalf("decodeGetBlockTxnPayload: %v", err)
+	}
+	if got.BlockHash != want.BlockHash || !reflect.DeepEqual(got.Indexes, want.Indexes) {
+		t.Fatalf("getblocktxn roundtrip got=%+v want=%+v", got, want)
+	}
+}
+
+func TestGetBlockTxnPayloadAllowsIndexesAboveRequestCountCap(t *testing.T) {
+	want := getBlockTxnPayload{Indexes: []uint64{0, maxCompactRelayEntries, maxCompactRelayEntries + 2}}
+	raw, err := encodeGetBlockTxnPayload(want)
+	if err != nil {
+		t.Fatalf("encodeGetBlockTxnPayload: %v", err)
+	}
+	got, err := decodeGetBlockTxnPayload(raw)
+	if err != nil {
+		t.Fatalf("decodeGetBlockTxnPayload: %v", err)
+	}
+	if !reflect.DeepEqual(got.Indexes, want.Indexes) {
+		t.Fatalf("indexes=%v, want %v", got.Indexes, want.Indexes)
+	}
+}
+
+func TestGetBlockTxnPayloadRejectsMalformed(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   getBlockTxnPayload
+	}{
+		{name: "duplicate", in: getBlockTxnPayload{Indexes: []uint64{1, 1}}},
+		{name: "descending", in: getBlockTxnPayload{Indexes: []uint64{2, 1}}},
+		{name: "range", in: getBlockTxnPayload{Indexes: []uint64{maxCompactRelayIndexValue + 1}}},
+		{name: "max", in: getBlockTxnPayload{Indexes: []uint64{^uint64(0)}}},
+	} {
+		if _, err := encodeGetBlockTxnPayload(tc.in); err == nil {
+			t.Fatalf("%s: expected encode failure", tc.name)
+		}
+	}
+
+	for _, tc := range []struct {
+		name string
+		raw  []byte
+	}{
+		{name: "short_hash", raw: make([]byte, 31)},
+		{name: "nonminimal", raw: getBlockTxnTestPayload([]byte{0xfd, 0x00, 0x00})},
+		{name: "count_too_large", raw: getBlockTxnTestPayload(consensus.AppendCompactSize(nil, maxCompactRelayEntries+1))},
+		{name: "truncated_index", raw: getBlockTxnTestPayload([]byte{1, 0xfd})},
+		{name: "range", raw: getBlockTxnIndexedPayload(maxCompactRelayIndexValue + 1)},
+		{name: "max", raw: getBlockTxnIndexedPayload(^uint64(0))},
+		{name: "range_after_first", raw: getBlockTxnIndexedPayload(0, maxCompactRelayIndexValue)},
+		{name: "overflow_after_first", raw: getBlockTxnIndexedPayload(0, ^uint64(0))},
+		{name: "trailing", raw: append(mustEncodeGetBlockTxnPayload(t, []uint64{0}), 0x00)},
+	} {
+		if _, err := decodeGetBlockTxnPayload(tc.raw); err == nil {
+			t.Fatalf("%s: expected decode failure", tc.name)
+		}
+	}
+}
+
+func getBlockTxnTestPayload(tail []byte) []byte {
+	return append(make([]byte, 32), tail...)
+}
+
+func getBlockTxnIndexedPayload(deltas ...uint64) []byte {
+	tail := consensus.AppendCompactSize(nil, uint64(len(deltas)))
+	for _, delta := range deltas {
+		tail = consensus.AppendCompactSize(tail, delta)
+	}
+	return getBlockTxnTestPayload(tail)
+}
+
+func mustEncodeGetBlockTxnPayload(t *testing.T, indexes []uint64) []byte {
+	t.Helper()
+	raw, err := encodeGetBlockTxnPayload(getBlockTxnPayload{Indexes: indexes})
+	if err != nil {
+		t.Fatalf("encodeGetBlockTxnPayload: %v", err)
+	}
+	return raw
 }
 
 func TestSendCmpctPayloadCodec(t *testing.T) {


### PR DESCRIPTION
Invariant:
Go P2P has a bounded getblocktxn compact relay payload codec without enabling live compact relay dispatch.

Layer:
implementation / tests

Files changed:
- clients/go/node/p2p/compact_wire.go
- clients/go/node/p2p/compact_wire_test.go

Tests:
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node/p2p -run "GetBlockTxn|Compact|Wire" -count=1' — PASS
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node/p2p -count=1' — PASS
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go vet ./node/p2p' — PASS
- scripts/dev-env.sh -- bash -lc 'cd clients/go && gosec ./node/p2p' — PASS
- python3 /Users/gpt/.agents/skills/rubin-codacy/scripts/lizard_medium_rows.py clients/go/node/p2p/compact_wire.go clients/go/node/p2p/*compact*_test.go — PASS
- git diff --check and git diff --check origin/main...HEAD — PASS
- /Users/gpt/bin/rubin-precommit-one-review --repo /Users/gpt/Documents/rubin-protocol-codex-RUB-314 --base-ref origin/main --include-base-diff — PASS
- one isolated stock code-review reviewer — No findings after repair
- /Users/gpt/bin/rubin-common-preflight --lane coverage --repo /Users/gpt/Documents/rubin-protocol-codex-RUB-314 — PASS
- /Users/gpt/bin/rubin-push --repo /Users/gpt/Documents/rubin-protocol-codex-RUB-314 --base-ref origin/main --coverage-cmd '/Users/gpt/bin/rubin-common-preflight --lane coverage --repo /Users/gpt/Documents/rubin-protocol-codex-RUB-314' -- origin HEAD — PASS

Behavior impact:
Adds unexported getblocktxn payload encode/decode helpers and tests only. No live compact relay dispatch is enabled.

Compatibility impact:
No consensus, conformance, Rust, RPC, mempool, miner, or runtime negotiation change.

Known non-goals:
- No sendcmpct peer-mode state.
- No cmpctblock reconstruction handler.
- No blocktxn runtime request flow.
- No DA relay state machine.

Risk:
Low. Remaining validation of requested indexes against a concrete block tx_count belongs to the later handler/reconstruction slice.

Not checked:
- Full clients/go ./... was not run for this p2p-only codec slice.


### Parity exemption justification
This is a Go-only P2P wire-codec slice. The diff adds unexported getblocktxn encode/decode helpers and Go tests; it does not change consensus, conformance fixtures, Rust behavior, or live runtime dispatch.
