### PR TITLE
RUB-315 add blocktxn compact codec

### DIFF
--- a/clients/go/node/p2p/compact_wire.go
+++ b/clients/go/node/p2p/compact_wire.go
@@ -120,9 +120,13 @@ func encodeBlockTxnPayload(p blockTxnPayload) ([]byte, error) {
 	}
 	var totalTxBytes uint64
 	for _, tx := range p.Transactions {
-		nextTotal, err := validateBlockTxnTransactionBytes(tx, totalTxBytes)
+		nextTotal, err := validateBlockTxnTransactionSize(uint64(len(tx)), totalTxBytes)
 		if err != nil {
 			return nil, err
+		}
+		_, _, _, consumed, err := consensus.ParseTx(tx)
+		if err != nil || consumed != len(tx) {
+			return nil, errors.New("blocktxn transaction is non-canonical")
 		}
 		totalTxBytes = nextTotal
 	}
@@ -157,7 +161,7 @@ func decodeBlockTxnPayload(payload []byte) (blockTxnPayload, error) {
 		if err != nil {
 			return blockTxnPayload{}, err
 		}
-		transactions = append(transactions, tx)
+		transactions = append(transactions, append([]byte(nil), tx...))
 		offset += n
 		totalTxBytes = nextTotal
 	}
@@ -175,22 +179,7 @@ func decodeBlockTxnTransaction(payload []byte, totalTxBytes uint64) ([]byte, int
 	}
 	txLen := uint64(consumed) // #nosec G115 -- consumed is non-negative and bounded by len(payload).
 	nextTotal, err := validateBlockTxnTransactionSize(txLen, totalTxBytes)
-	if err != nil {
-		return nil, 0, totalTxBytes, err
-	}
-	return append([]byte(nil), payload[:consumed]...), consumed, nextTotal, nil
-}
-
-func validateBlockTxnTransactionBytes(tx []byte, totalTxBytes uint64) (uint64, error) {
-	nextTotal, err := validateBlockTxnTransactionSize(uint64(len(tx)), totalTxBytes)
-	if err != nil {
-		return totalTxBytes, err
-	}
-	_, _, _, consumed, err := consensus.ParseTx(tx)
-	if err != nil || consumed != len(tx) {
-		return totalTxBytes, errors.New("blocktxn transaction is non-canonical")
-	}
-	return nextTotal, nil
+	return payload[:consumed], consumed, nextTotal, err
 }
 
 func validateBlockTxnTransactionSize(txLen, totalTxBytes uint64) (uint64, error) {

--- a/clients/go/node/p2p/compact_wire.go
+++ b/clients/go/node/p2p/compact_wire.go
@@ -120,24 +120,17 @@ func encodeBlockTxnPayload(p blockTxnPayload) ([]byte, error) {
 	}
 	var totalTxBytes uint64
 	for _, tx := range p.Transactions {
-		txLen := uint64(len(tx))
-		if txLen == 0 {
-			return nil, errors.New("blocktxn transaction is empty")
+		nextTotal, err := validateBlockTxnTransactionBytes(tx, totalTxBytes)
+		if err != nil {
+			return nil, err
 		}
-		if txLen > consensus.MAX_BLOCK_BYTES {
-			return nil, errors.New("blocktxn transaction too large")
-		}
-		if totalTxBytes > consensus.MAX_BLOCK_BYTES-txLen {
-			return nil, errors.New("blocktxn transactions exceed block size")
-		}
-		totalTxBytes += txLen
+		totalTxBytes = nextTotal
 	}
-	capHint := 32 + maxCompactSizeBytes + len(p.Transactions)*maxCompactSizeBytes + int(totalTxBytes) // #nosec G115 -- totalTxBytes is capped at consensus.MAX_BLOCK_BYTES above.
+	capHint := 32 + maxCompactSizeBytes + int(totalTxBytes) // #nosec G115 -- totalTxBytes is capped at consensus.MAX_BLOCK_BYTES above.
 	out := make([]byte, 0, capHint)
 	out = append(out, p.BlockHash[:]...)
 	out = consensus.AppendCompactSize(out, uint64(len(p.Transactions)))
 	for _, tx := range p.Transactions {
-		out = consensus.AppendCompactSize(out, uint64(len(tx)))
 		out = append(out, tx...)
 	}
 	return out, nil
@@ -176,24 +169,41 @@ func decodeBlockTxnPayload(payload []byte) (blockTxnPayload, error) {
 }
 
 func decodeBlockTxnTransaction(payload []byte, totalTxBytes uint64) ([]byte, int, uint64, error) {
-	txLen, consumed, err := consensus.DecodeCompactSize(payload)
+	_, _, _, consumed, err := consensus.ParseTx(payload)
 	if err != nil {
 		return nil, 0, totalTxBytes, err
 	}
+	txLen := uint64(consumed) // #nosec G115 -- consumed is non-negative and bounded by len(payload).
+	nextTotal, err := validateBlockTxnTransactionSize(txLen, totalTxBytes)
+	if err != nil {
+		return nil, 0, totalTxBytes, err
+	}
+	return append([]byte(nil), payload[:consumed]...), consumed, nextTotal, nil
+}
+
+func validateBlockTxnTransactionBytes(tx []byte, totalTxBytes uint64) (uint64, error) {
+	nextTotal, err := validateBlockTxnTransactionSize(uint64(len(tx)), totalTxBytes)
+	if err != nil {
+		return totalTxBytes, err
+	}
+	_, _, _, consumed, err := consensus.ParseTx(tx)
+	if err != nil || consumed != len(tx) {
+		return totalTxBytes, errors.New("blocktxn transaction is non-canonical")
+	}
+	return nextTotal, nil
+}
+
+func validateBlockTxnTransactionSize(txLen, totalTxBytes uint64) (uint64, error) {
 	if txLen == 0 {
-		return nil, 0, totalTxBytes, errors.New("blocktxn transaction is empty")
+		return totalTxBytes, errors.New("blocktxn transaction is empty")
 	}
 	if txLen > consensus.MAX_BLOCK_BYTES {
-		return nil, 0, totalTxBytes, errors.New("blocktxn transaction too large")
+		return totalTxBytes, errors.New("blocktxn transaction too large")
 	}
 	if totalTxBytes > consensus.MAX_BLOCK_BYTES-txLen {
-		return nil, 0, totalTxBytes, errors.New("blocktxn transactions exceed block size")
+		return totalTxBytes, errors.New("blocktxn transactions exceed block size")
 	}
-	txLenInt := int(txLen) // #nosec G115 -- txLen is capped at consensus.MAX_BLOCK_BYTES above.
-	if txLenInt > len(payload)-consumed {
-		return nil, 0, totalTxBytes, errors.New("blocktxn transaction truncated")
-	}
-	return append([]byte(nil), payload[consumed:consumed+txLenInt]...), consumed + txLenInt, totalTxBytes + txLen, nil
+	return totalTxBytes + txLen, nil
 }
 
 func getBlockTxnAbsoluteIndex(prev, delta uint64, first bool) (uint64, error) {

--- a/clients/go/node/p2p/compact_wire.go
+++ b/clients/go/node/p2p/compact_wire.go
@@ -29,6 +29,11 @@ type getBlockTxnPayload struct {
 	Indexes   []uint64
 }
 
+type blockTxnPayload struct {
+	BlockHash    [32]byte
+	Transactions [][]byte
+}
+
 func encodeSendCmpctPayload(p sendCmpctPayload) ([]byte, error) {
 	if p.Mode > 2 {
 		return nil, errors.New("unsupported compact relay mode")
@@ -107,6 +112,88 @@ func decodeGetBlockTxnPayload(payload []byte) (getBlockTxnPayload, error) {
 	}
 	out.Indexes = indexes
 	return out, nil
+}
+
+func encodeBlockTxnPayload(p blockTxnPayload) ([]byte, error) {
+	if len(p.Transactions) > maxCompactRelayEntries {
+		return nil, errors.New("too many compact relay transactions")
+	}
+	var totalTxBytes uint64
+	for _, tx := range p.Transactions {
+		txLen := uint64(len(tx))
+		if txLen == 0 {
+			return nil, errors.New("blocktxn transaction is empty")
+		}
+		if txLen > consensus.MAX_BLOCK_BYTES {
+			return nil, errors.New("blocktxn transaction too large")
+		}
+		if totalTxBytes > consensus.MAX_BLOCK_BYTES-txLen {
+			return nil, errors.New("blocktxn transactions exceed block size")
+		}
+		totalTxBytes += txLen
+	}
+	capHint := 32 + maxCompactSizeBytes + len(p.Transactions)*maxCompactSizeBytes + int(totalTxBytes) // #nosec G115 -- totalTxBytes is capped at consensus.MAX_BLOCK_BYTES above.
+	out := make([]byte, 0, capHint)
+	out = append(out, p.BlockHash[:]...)
+	out = consensus.AppendCompactSize(out, uint64(len(p.Transactions)))
+	for _, tx := range p.Transactions {
+		out = consensus.AppendCompactSize(out, uint64(len(tx)))
+		out = append(out, tx...)
+	}
+	return out, nil
+}
+
+func decodeBlockTxnPayload(payload []byte) (blockTxnPayload, error) {
+	var out blockTxnPayload
+	if len(payload) < 32 {
+		return out, errors.New("blocktxn payload missing block hash")
+	}
+	copy(out.BlockHash[:], payload[:32])
+	count, consumed, err := consensus.DecodeCompactSize(payload[32:])
+	if err != nil {
+		return blockTxnPayload{}, err
+	}
+	if count > maxCompactRelayEntries {
+		return blockTxnPayload{}, errors.New("too many compact relay transactions")
+	}
+	offset := 32 + consumed
+	transactions := make([][]byte, 0, int(count)) // #nosec G115 -- count is capped at maxCompactRelayEntries above.
+	var totalTxBytes uint64
+	for i := uint64(0); i < count; i++ {
+		tx, n, nextTotal, err := decodeBlockTxnTransaction(payload[offset:], totalTxBytes)
+		if err != nil {
+			return blockTxnPayload{}, err
+		}
+		transactions = append(transactions, tx)
+		offset += n
+		totalTxBytes = nextTotal
+	}
+	if offset != len(payload) {
+		return blockTxnPayload{}, errors.New("blocktxn payload has trailing bytes")
+	}
+	out.Transactions = transactions
+	return out, nil
+}
+
+func decodeBlockTxnTransaction(payload []byte, totalTxBytes uint64) ([]byte, int, uint64, error) {
+	txLen, consumed, err := consensus.DecodeCompactSize(payload)
+	if err != nil {
+		return nil, 0, totalTxBytes, err
+	}
+	if txLen == 0 {
+		return nil, 0, totalTxBytes, errors.New("blocktxn transaction is empty")
+	}
+	if txLen > consensus.MAX_BLOCK_BYTES {
+		return nil, 0, totalTxBytes, errors.New("blocktxn transaction too large")
+	}
+	if totalTxBytes > consensus.MAX_BLOCK_BYTES-txLen {
+		return nil, 0, totalTxBytes, errors.New("blocktxn transactions exceed block size")
+	}
+	txLenInt := int(txLen) // #nosec G115 -- txLen is capped at consensus.MAX_BLOCK_BYTES above.
+	if txLenInt > len(payload)-consumed {
+		return nil, 0, totalTxBytes, errors.New("blocktxn transaction truncated")
+	}
+	return append([]byte(nil), payload[consumed:consumed+txLenInt]...), consumed + txLenInt, totalTxBytes + txLen, nil
 }
 
 func getBlockTxnAbsoluteIndex(prev, delta uint64, first bool) (uint64, error) {

--- a/clients/go/node/p2p/compact_wire_test.go
+++ b/clients/go/node/p2p/compact_wire_test.go
@@ -2,6 +2,7 @@ package p2p
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
@@ -51,6 +52,91 @@ func TestGetBlockTxnPayloadCodec(t *testing.T) {
 	if got.BlockHash != want.BlockHash || !reflect.DeepEqual(got.Indexes, want.Indexes) {
 		t.Fatalf("getblocktxn roundtrip got=%+v want=%+v", got, want)
 	}
+}
+
+func TestBlockTxnPayloadCodec(t *testing.T) {
+	want := blockTxnPayload{
+		BlockHash:    [32]byte{0x04, 0x05, 0x06},
+		Transactions: [][]byte{{0x01, 0x02}, {0x03}},
+	}
+	raw, err := encodeBlockTxnPayload(want)
+	if err != nil {
+		t.Fatalf("encodeBlockTxnPayload: %v", err)
+	}
+	if gotEntries := raw[32:]; !reflect.DeepEqual(gotEntries, []byte{2, 2, 1, 2, 1, 3}) {
+		t.Fatalf("blocktxn entries=%x, want 020201020103", gotEntries)
+	}
+	got, err := decodeBlockTxnPayload(raw)
+	if err != nil {
+		t.Fatalf("decodeBlockTxnPayload: %v", err)
+	}
+	if got.BlockHash != want.BlockHash || !reflect.DeepEqual(got.Transactions, want.Transactions) {
+		t.Fatalf("blocktxn roundtrip got=%+v want=%+v", got, want)
+	}
+}
+
+func TestBlockTxnPayloadRejectsMalformed(t *testing.T) {
+	tooMany := make([][]byte, maxCompactRelayEntries+1)
+	tooLarge := make([]byte, consensus.MAX_BLOCK_BYTES+1)
+	for _, tc := range []struct {
+		name    string
+		in      blockTxnPayload
+		wantErr string
+	}{
+		{name: "too_many", in: blockTxnPayload{Transactions: tooMany}, wantErr: "too many compact relay transactions"},
+		{name: "empty", in: blockTxnPayload{Transactions: [][]byte{{}}}, wantErr: "blocktxn transaction is empty"},
+		{name: "too_large", in: blockTxnPayload{Transactions: [][]byte{tooLarge}}, wantErr: "blocktxn transaction too large"},
+	} {
+		_, err := encodeBlockTxnPayload(tc.in)
+		if err == nil {
+			t.Fatalf("%s: expected encode failure", tc.name)
+		}
+		if !strings.Contains(err.Error(), tc.wantErr) {
+			t.Fatalf("%s: encode error=%q, want %q", tc.name, err, tc.wantErr)
+		}
+	}
+
+	for _, tc := range []struct {
+		name    string
+		raw     []byte
+		wantErr string
+	}{
+		{name: "short_hash", raw: make([]byte, 31), wantErr: "blocktxn payload missing block hash"},
+		{name: "nonminimal_count", raw: blockTxnTestPayload([]byte{0xfd, 0x00, 0x00}), wantErr: "non-minimal"},
+		{name: "count_too_large", raw: blockTxnTestPayload(consensus.AppendCompactSize(nil, maxCompactRelayEntries+1)), wantErr: "too many compact relay transactions"},
+		{name: "empty_tx", raw: blockTxnSizedPayload(0), wantErr: "blocktxn transaction is empty"},
+		{name: "tx_too_large", raw: blockTxnSizedPayload(consensus.MAX_BLOCK_BYTES + 1), wantErr: "blocktxn transaction too large"},
+		{name: "truncated_tx_len", raw: blockTxnTestPayload([]byte{1, 0xfd}), wantErr: "unexpected EOF"},
+		{name: "truncated_tx", raw: blockTxnTestPayload([]byte{1, 2, 0xaa}), wantErr: "blocktxn transaction truncated"},
+		{name: "trailing", raw: append(mustEncodeBlockTxnPayload(t, [][]byte{{0xaa}}), 0x00), wantErr: "blocktxn payload has trailing bytes"},
+	} {
+		_, err := decodeBlockTxnPayload(tc.raw)
+		if err == nil {
+			t.Fatalf("%s: expected decode failure", tc.name)
+		}
+		if !strings.Contains(err.Error(), tc.wantErr) {
+			t.Fatalf("%s: decode error=%q, want %q", tc.name, err, tc.wantErr)
+		}
+	}
+}
+
+func blockTxnTestPayload(tail []byte) []byte {
+	return append(make([]byte, 32), tail...)
+}
+
+func blockTxnSizedPayload(txLen uint64) []byte {
+	tail := consensus.AppendCompactSize(nil, 1)
+	tail = consensus.AppendCompactSize(tail, txLen)
+	return blockTxnTestPayload(tail)
+}
+
+func mustEncodeBlockTxnPayload(t *testing.T, txs [][]byte) []byte {
+	t.Helper()
+	raw, err := encodeBlockTxnPayload(blockTxnPayload{Transactions: txs})
+	if err != nil {
+		t.Fatalf("encodeBlockTxnPayload: %v", err)
+	}
+	return raw
 }
 
 func TestGetBlockTxnPayloadAllowsIndexesAboveRequestCountCap(t *testing.T) {

--- a/clients/go/node/p2p/compact_wire_test.go
+++ b/clients/go/node/p2p/compact_wire_test.go
@@ -55,16 +55,20 @@ func TestGetBlockTxnPayloadCodec(t *testing.T) {
 }
 
 func TestBlockTxnPayloadCodec(t *testing.T) {
+	tx1 := minimalBlockTxnTestTxBytes(1)
+	tx2 := minimalBlockTxnTestTxBytes(2)
 	want := blockTxnPayload{
 		BlockHash:    [32]byte{0x04, 0x05, 0x06},
-		Transactions: [][]byte{{0x01, 0x02}, {0x03}},
+		Transactions: [][]byte{tx1, tx2},
 	}
 	raw, err := encodeBlockTxnPayload(want)
 	if err != nil {
 		t.Fatalf("encodeBlockTxnPayload: %v", err)
 	}
-	if gotEntries := raw[32:]; !reflect.DeepEqual(gotEntries, []byte{2, 2, 1, 2, 1, 3}) {
-		t.Fatalf("blocktxn entries=%x, want 020201020103", gotEntries)
+	wantEntries := append(consensus.AppendCompactSize(nil, 2), tx1...)
+	wantEntries = append(wantEntries, tx2...)
+	if gotEntries := raw[32:]; !reflect.DeepEqual(gotEntries, wantEntries) {
+		t.Fatalf("blocktxn entries=%x, want %x", gotEntries, wantEntries)
 	}
 	got, err := decodeBlockTxnPayload(raw)
 	if err != nil {
@@ -78,6 +82,7 @@ func TestBlockTxnPayloadCodec(t *testing.T) {
 func TestBlockTxnPayloadRejectsMalformed(t *testing.T) {
 	tooMany := make([][]byte, maxCompactRelayEntries+1)
 	tooLarge := make([]byte, consensus.MAX_BLOCK_BYTES+1)
+	validWithTrailing := append(minimalBlockTxnTestTxBytes(3), 0x00)
 	for _, tc := range []struct {
 		name    string
 		in      blockTxnPayload
@@ -86,6 +91,8 @@ func TestBlockTxnPayloadRejectsMalformed(t *testing.T) {
 		{name: "too_many", in: blockTxnPayload{Transactions: tooMany}, wantErr: "too many compact relay transactions"},
 		{name: "empty", in: blockTxnPayload{Transactions: [][]byte{{}}}, wantErr: "blocktxn transaction is empty"},
 		{name: "too_large", in: blockTxnPayload{Transactions: [][]byte{tooLarge}}, wantErr: "blocktxn transaction too large"},
+		{name: "malformed_nonempty", in: blockTxnPayload{Transactions: [][]byte{{0x01}}}, wantErr: "blocktxn transaction is non-canonical"},
+		{name: "valid_with_trailing", in: blockTxnPayload{Transactions: [][]byte{validWithTrailing}}, wantErr: "blocktxn transaction is non-canonical"},
 	} {
 		_, err := encodeBlockTxnPayload(tc.in)
 		if err == nil {
@@ -104,11 +111,9 @@ func TestBlockTxnPayloadRejectsMalformed(t *testing.T) {
 		{name: "short_hash", raw: make([]byte, 31), wantErr: "blocktxn payload missing block hash"},
 		{name: "nonminimal_count", raw: blockTxnTestPayload([]byte{0xfd, 0x00, 0x00}), wantErr: "non-minimal"},
 		{name: "count_too_large", raw: blockTxnTestPayload(consensus.AppendCompactSize(nil, maxCompactRelayEntries+1)), wantErr: "too many compact relay transactions"},
-		{name: "empty_tx", raw: blockTxnSizedPayload(0), wantErr: "blocktxn transaction is empty"},
-		{name: "tx_too_large", raw: blockTxnSizedPayload(consensus.MAX_BLOCK_BYTES + 1), wantErr: "blocktxn transaction too large"},
-		{name: "truncated_tx_len", raw: blockTxnTestPayload([]byte{1, 0xfd}), wantErr: "unexpected EOF"},
-		{name: "truncated_tx", raw: blockTxnTestPayload([]byte{1, 2, 0xaa}), wantErr: "blocktxn transaction truncated"},
-		{name: "trailing", raw: append(mustEncodeBlockTxnPayload(t, [][]byte{{0xaa}}), 0x00), wantErr: "blocktxn payload has trailing bytes"},
+		{name: "empty_tx", raw: blockTxnTestPayload([]byte{1}), wantErr: "unexpected EOF"},
+		{name: "truncated_tx", raw: blockTxnTestPayload([]byte{1, 1}), wantErr: "unexpected EOF"},
+		{name: "trailing", raw: append(mustEncodeBlockTxnPayload(t, [][]byte{minimalBlockTxnTestTxBytes(4)}), 0x00), wantErr: "blocktxn payload has trailing bytes"},
 	} {
 		_, err := decodeBlockTxnPayload(tc.raw)
 		if err == nil {
@@ -120,14 +125,20 @@ func TestBlockTxnPayloadRejectsMalformed(t *testing.T) {
 	}
 }
 
-func blockTxnTestPayload(tail []byte) []byte {
-	return append(make([]byte, 32), tail...)
+func minimalBlockTxnTestTxBytes(nonce uint64) []byte {
+	out := consensus.AppendU32le(nil, consensus.TX_WIRE_VERSION)
+	out = append(out, 0x00) // tx_kind
+	out = consensus.AppendU64le(out, nonce)
+	out = consensus.AppendCompactSize(out, 0) // input_count
+	out = consensus.AppendCompactSize(out, 0) // output_count
+	out = consensus.AppendU32le(out, 0)       // locktime
+	out = consensus.AppendCompactSize(out, 0) // witness_count
+	out = consensus.AppendCompactSize(out, 0) // da_payload_len
+	return out
 }
 
-func blockTxnSizedPayload(txLen uint64) []byte {
-	tail := consensus.AppendCompactSize(nil, 1)
-	tail = consensus.AppendCompactSize(tail, txLen)
-	return blockTxnTestPayload(tail)
+func blockTxnTestPayload(tail []byte) []byte {
+	return append(make([]byte, 32), tail...)
 }
 
 func mustEncodeBlockTxnPayload(t *testing.T, txs [][]byte) []byte {


### PR DESCRIPTION
Invariant:
Go P2P has a bounded `blocktxn` compact relay payload codec only.

Layer:
implementation / tests

Files changed:
- `clients/go/node/p2p/compact_wire.go`
- `clients/go/node/p2p/compact_wire_test.go`

Tests:
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node/p2p -run "BlockTxn|Compact|Wire" -count=1'` — PASS
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node/p2p -count=1'` — PASS
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go vet ./node/p2p'` — PASS
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && gosec ./node/p2p'` — PASS
- `python3 /Users/gpt/.agents/skills/rubin-codacy/scripts/lizard_medium_rows.py clients/go/node/p2p/compact_wire.go clients/go/node/p2p/*compact*_test.go` — PASS
- `/Users/gpt/bin/rubin-common-preflight --lane coverage --repo /Users/gpt/Documents/rubin-protocol-codex-RUB-315` — PASS
- `/Users/gpt/bin/rubin-push --repo /Users/gpt/Documents/rubin-protocol-codex-RUB-315 --base-ref origin/main --coverage-cmd "scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node/p2p -count=1'" -- origin HEAD` — PASS

Behavior impact:
Adds unexported `blocktxn` encode/decode helpers. Live compact relay runtime dispatch remains disabled.

Compatibility impact:
No consensus, policy, conformance, Rust, mempool, miner, wallet, API, or RPC changes.

Known non-goals:
No `sendcmpct` peer-mode state, no `cmpctblock` reconstruction handler, no `getblocktxn` runtime request flow, no `peer_runtime` dispatch, and no DA relay state machine.

Risk:
Malformed P2P payload bounds. Covered by count cap, canonical self-delimiting TxBytes checks, aggregate tx-byte cap, truncation/trailing-byte tests, `gosec`, and one final isolated stock raw-diff reviewer with no findings.

Not checked:
Full `clients/go/...` suite and live compact relay runtime, because RUB-315 is codec-only.
