### PR TITLE
RUB-316 go p2p add cmpctblock codec

### DIFF
--- a/clients/go/node/p2p/compact_wire.go
+++ b/clients/go/node/p2p/compact_wire.go
@@ -34,6 +34,20 @@ type blockTxnPayload struct {
 	Transactions [][]byte
 }
 
+type compactShortID [compactShortIDBytes]byte
+
+type prefilledTxn struct {
+	Index uint64
+	Tx    []byte
+}
+
+type cmpctBlockPayload struct {
+	Header    [consensus.BLOCK_HEADER_BYTES]byte
+	Nonce     uint64
+	ShortIDs  []compactShortID
+	Prefilled []prefilledTxn
+}
+
 func encodeSendCmpctPayload(p sendCmpctPayload) ([]byte, error) {
 	if p.Mode > 2 {
 		return nil, errors.New("unsupported compact relay mode")
@@ -170,6 +184,100 @@ func decodeBlockTxnPayload(payload []byte) (blockTxnPayload, error) {
 	}
 	out.Transactions = transactions
 	return out, nil
+}
+
+func encodeCmpctBlockPayload(p cmpctBlockPayload) ([]byte, error) {
+	out := make([]byte, 0)
+	out = append(out, p.Header[:]...)
+	out = consensus.AppendU64le(out, p.Nonce)
+	out = consensus.AppendCompactSize(out, uint64(len(p.ShortIDs)))
+	for _, shortID := range p.ShortIDs {
+		out = append(out, shortID[:]...)
+	}
+	out = consensus.AppendCompactSize(out, uint64(len(p.Prefilled)))
+	var prevPlusOne uint64
+	prefilledTxs := make([][]byte, 0, len(p.Prefilled))
+	for _, tx := range p.Prefilled {
+		delta := tx.Index - prevPlusOne
+		out = consensus.AppendCompactSize(out, delta)
+		out = append(out, tx.Tx...)
+		prevPlusOne = tx.Index + 1
+		prefilledTxs = append(prefilledTxs, tx.Tx)
+	}
+	if _, err := encodeBlockTxnPayload(blockTxnPayload{Transactions: prefilledTxs}); err != nil {
+		return nil, err
+	}
+	_, err := decodeCmpctBlockPayload(out)
+	return out, err
+}
+
+func decodeCmpctBlockPayload(payload []byte) (cmpctBlockPayload, error) {
+	out, prefilledCount, totalEntries, offset, err := decodeCmpctBlockPrefix(payload)
+	if err != nil {
+		return cmpctBlockPayload{}, err
+	}
+	out.Prefilled = make([]prefilledTxn, 0, int(prefilledCount)) // #nosec G115 -- totalEntries is capped by decodeCmpctBlockPrefix.
+	var prev uint64
+	var totalTxBytes uint64
+	for i := uint64(0); i < prefilledCount; i++ {
+		delta, n, err := consensus.DecodeCompactSize(payload[offset:])
+		if err != nil {
+			return cmpctBlockPayload{}, err
+		}
+		idx, err := getBlockTxnAbsoluteIndex(prev, delta, i == 0)
+		if err != nil {
+			return cmpctBlockPayload{}, err
+		}
+		if idx >= totalEntries {
+			return cmpctBlockPayload{}, errors.New("compact relay index out of range")
+		}
+		tx, txConsumed, nextTotal, err := decodeBlockTxnTransaction(payload[offset+n:], totalTxBytes)
+		if err != nil {
+			return cmpctBlockPayload{}, err
+		}
+		out.Prefilled = append(out.Prefilled, prefilledTxn{Index: idx, Tx: append([]byte(nil), tx...)})
+		offset += n + txConsumed
+		prev = idx
+		totalTxBytes = nextTotal
+	}
+	if offset != len(payload) {
+		return cmpctBlockPayload{}, errors.New("cmpctblock payload has trailing bytes")
+	}
+	return out, nil
+}
+
+func decodeCmpctBlockPrefix(payload []byte) (cmpctBlockPayload, uint64, uint64, int, error) {
+	var out cmpctBlockPayload
+	if len(payload) < consensus.BLOCK_HEADER_BYTES+8 {
+		return out, 0, 0, 0, errors.New("cmpctblock payload missing header or nonce")
+	}
+	copy(out.Header[:], payload[:consensus.BLOCK_HEADER_BYTES])
+	out.Nonce = binary.LittleEndian.Uint64(payload[consensus.BLOCK_HEADER_BYTES:])
+	offset := consensus.BLOCK_HEADER_BYTES + 8
+	shortCount, consumed, err := consensus.DecodeCompactSize(payload[offset:])
+	if err != nil {
+		return cmpctBlockPayload{}, 0, 0, 0, err
+	}
+	offset += consumed
+	if shortCount > uint64(len(payload[offset:]))/compactShortIDBytes {
+		return cmpctBlockPayload{}, 0, 0, 0, errors.New("cmpctblock payload truncated short IDs")
+	}
+	shortIDEnd := offset + int(shortCount)*compactShortIDBytes // #nosec G115 -- shortCount is bounded by remaining payload width above.
+	prefilledCount, consumed, err := consensus.DecodeCompactSize(payload[shortIDEnd:])
+	if err != nil {
+		return cmpctBlockPayload{}, 0, 0, 0, err
+	}
+	totalEntries := shortCount + prefilledCount
+	if totalEntries > maxCompactRelayEntries || totalEntries < shortCount {
+		return cmpctBlockPayload{}, 0, 0, 0, errors.New("too many compact relay entries")
+	}
+	out.ShortIDs = make([]compactShortID, 0, int(shortCount)) // #nosec G115 -- totalEntries is capped above.
+	for ; offset < shortIDEnd; offset += compactShortIDBytes {
+		var shortID compactShortID
+		copy(shortID[:], payload[offset:offset+compactShortIDBytes])
+		out.ShortIDs = append(out.ShortIDs, shortID)
+	}
+	return out, prefilledCount, totalEntries, shortIDEnd + consumed, nil
 }
 
 func decodeBlockTxnTransaction(payload []byte, totalTxBytes uint64) ([]byte, int, uint64, error) {

--- a/clients/go/node/p2p/compact_wire.go
+++ b/clients/go/node/p2p/compact_wire.go
@@ -34,6 +34,20 @@ type blockTxnPayload struct {
 	Transactions [][]byte
 }
 
+type compactShortID [compactShortIDBytes]byte
+
+type prefilledTxn struct {
+	Index uint64
+	Tx    []byte
+}
+
+type cmpctBlockPayload struct {
+	Header    [consensus.BLOCK_HEADER_BYTES]byte
+	Nonce     uint64
+	ShortIDs  []compactShortID
+	Prefilled []prefilledTxn
+}
+
 func encodeSendCmpctPayload(p sendCmpctPayload) ([]byte, error) {
 	if p.Mode > 2 {
 		return nil, errors.New("unsupported compact relay mode")
@@ -172,6 +186,147 @@ func decodeBlockTxnPayload(payload []byte) (blockTxnPayload, error) {
 	return out, nil
 }
 
+func encodeCmpctBlockPayload(p cmpctBlockPayload) ([]byte, error) {
+	if err := validateCompactRelayEntryCounts(uint64(len(p.ShortIDs)), uint64(len(p.Prefilled))); err != nil {
+		return nil, err
+	}
+	totalTxCount := uint64(len(p.ShortIDs) + len(p.Prefilled))
+	capHint := consensus.BLOCK_HEADER_BYTES + 8 + 2*maxCompactSizeBytes + len(p.ShortIDs)*compactShortIDBytes + len(p.Prefilled)*maxCompactSizeBytes
+	out := make([]byte, 0, capHint)
+	out = append(out, p.Header[:]...)
+	out = consensus.AppendU64le(out, p.Nonce)
+	out = consensus.AppendCompactSize(out, uint64(len(p.ShortIDs)))
+	for _, shortID := range p.ShortIDs {
+		out = append(out, shortID[:]...)
+	}
+	out = consensus.AppendCompactSize(out, uint64(len(p.Prefilled)))
+	return appendEncodedPrefilledTransactions(out, p.Prefilled, totalTxCount)
+}
+
+func appendEncodedPrefilledTransactions(out []byte, prefilled []prefilledTxn, totalTxCount uint64) ([]byte, error) {
+	var prev uint64
+	var totalTxBytes uint64
+	for i, tx := range prefilled {
+		delta, err := compactRelayIndexDelta(prev, tx.Index, i == 0)
+		if err != nil {
+			return nil, err
+		}
+		if err := validateCompactRelayIndexInVector(tx.Index, totalTxCount); err != nil {
+			return nil, err
+		}
+		nextTotal, err := validateBlockTxnTransactionSize(uint64(len(tx.Tx)), totalTxBytes)
+		if err != nil {
+			return nil, err
+		}
+		_, _, _, consumed, err := consensus.ParseTx(tx.Tx)
+		if err != nil || consumed != len(tx.Tx) {
+			return nil, errors.New("cmpctblock prefilled transaction is non-canonical")
+		}
+		out = consensus.AppendCompactSize(out, delta)
+		out = append(out, tx.Tx...)
+		prev = tx.Index
+		totalTxBytes = nextTotal
+	}
+	return out, nil
+}
+
+func decodeCmpctBlockPayload(payload []byte) (cmpctBlockPayload, error) {
+	var out cmpctBlockPayload
+	if len(payload) < consensus.BLOCK_HEADER_BYTES+8 {
+		return out, errors.New("cmpctblock payload missing header or nonce")
+	}
+	copy(out.Header[:], payload[:consensus.BLOCK_HEADER_BYTES])
+	out.Nonce = binary.LittleEndian.Uint64(payload[consensus.BLOCK_HEADER_BYTES:])
+	offset := consensus.BLOCK_HEADER_BYTES + 8
+	shortCount, consumed, err := consensus.DecodeCompactSize(payload[offset:])
+	if err != nil {
+		return cmpctBlockPayload{}, err
+	}
+	offset += consumed
+	shortIDOffset := offset
+	shortIDBytes, err := compactShortIDPayloadBytes(payload[offset:], shortCount)
+	if err != nil {
+		return cmpctBlockPayload{}, err
+	}
+	shortIDEnd := offset + shortIDBytes
+	prefilledCount, consumed, err := consensus.DecodeCompactSize(payload[shortIDEnd:])
+	if err != nil {
+		return cmpctBlockPayload{}, err
+	}
+	offset = shortIDEnd + consumed
+	if err := validateCompactRelayEntryCounts(shortCount, prefilledCount); err != nil {
+		return cmpctBlockPayload{}, err
+	}
+	out.ShortIDs = decodeCompactShortIDs(payload[shortIDOffset:shortIDEnd], shortCount)
+	out.Prefilled, consumed, err = decodePrefilledTransactions(payload[offset:], prefilledCount, shortCount+prefilledCount)
+	if err != nil {
+		return cmpctBlockPayload{}, err
+	}
+	offset += consumed
+	if offset != len(payload) {
+		return cmpctBlockPayload{}, errors.New("cmpctblock payload has trailing bytes")
+	}
+	return out, nil
+}
+
+func compactShortIDPayloadBytes(payload []byte, count uint64) (int, error) {
+	if count > maxCompactRelayEntries {
+		return 0, errors.New("too many compact relay short IDs")
+	}
+	needed := int(count) * compactShortIDBytes // #nosec G115 -- count is capped at maxCompactRelayEntries above.
+	if len(payload) < needed {
+		return 0, errors.New("cmpctblock payload truncated short IDs")
+	}
+	return needed, nil
+}
+
+func decodeCompactShortIDs(payload []byte, count uint64) []compactShortID {
+	shortIDs := make([]compactShortID, 0, int(count)) // #nosec G115 -- count is capped at maxCompactRelayEntries above.
+	for offset := 0; offset < len(payload); offset += compactShortIDBytes {
+		var shortID compactShortID
+		copy(shortID[:], payload[offset:offset+compactShortIDBytes])
+		shortIDs = append(shortIDs, shortID)
+	}
+	return shortIDs
+}
+
+func decodePrefilledTransactions(payload []byte, count, totalTxCount uint64) ([]prefilledTxn, int, error) {
+	prefilled := make([]prefilledTxn, 0, int(count)) // #nosec G115 -- count is aggregate-capped before this helper is called.
+	var offset int
+	var prev uint64
+	var totalTxBytes uint64
+	for i := uint64(0); i < count; i++ {
+		tx, consumed, nextPrev, nextTotal, err := decodePrefilledTransaction(payload[offset:], prev, totalTxCount, totalTxBytes, i == 0)
+		if err != nil {
+			return nil, 0, err
+		}
+		prefilled = append(prefilled, tx)
+		offset += consumed
+		prev = nextPrev
+		totalTxBytes = nextTotal
+	}
+	return prefilled, offset, nil
+}
+
+func decodePrefilledTransaction(payload []byte, prev, totalTxCount, totalTxBytes uint64, first bool) (prefilledTxn, int, uint64, uint64, error) {
+	delta, consumed, err := consensus.DecodeCompactSize(payload)
+	if err != nil {
+		return prefilledTxn{}, 0, prev, totalTxBytes, err
+	}
+	idx, err := getBlockTxnAbsoluteIndex(prev, delta, first)
+	if err != nil {
+		return prefilledTxn{}, 0, prev, totalTxBytes, err
+	}
+	if err := validateCompactRelayIndexInVector(idx, totalTxCount); err != nil {
+		return prefilledTxn{}, 0, prev, totalTxBytes, err
+	}
+	tx, txConsumed, nextTotal, err := decodeBlockTxnTransaction(payload[consumed:], totalTxBytes)
+	if err != nil {
+		return prefilledTxn{}, 0, prev, totalTxBytes, err
+	}
+	return prefilledTxn{Index: idx, Tx: append([]byte(nil), tx...)}, consumed + txConsumed, idx, nextTotal, nil
+}
+
 func decodeBlockTxnTransaction(payload []byte, totalTxBytes uint64) ([]byte, int, uint64, error) {
 	_, _, _, consumed, err := consensus.ParseTx(payload)
 	if err != nil {
@@ -193,6 +348,36 @@ func validateBlockTxnTransactionSize(txLen, totalTxBytes uint64) (uint64, error)
 		return totalTxBytes, errors.New("blocktxn transactions exceed block size")
 	}
 	return totalTxBytes + txLen, nil
+}
+
+func validateCompactRelayEntryCounts(shortCount, prefilledCount uint64) error {
+	if shortCount > maxCompactRelayEntries || prefilledCount > maxCompactRelayEntries {
+		return errors.New("too many compact relay entries")
+	}
+	if shortCount > maxCompactRelayEntries-prefilledCount {
+		return errors.New("too many compact relay entries")
+	}
+	return nil
+}
+
+func validateCompactRelayIndexInVector(idx, totalTxCount uint64) error {
+	if idx >= totalTxCount {
+		return errors.New("compact relay index out of range")
+	}
+	return nil
+}
+
+func compactRelayIndexDelta(prev, idx uint64, first bool) (uint64, error) {
+	if idx > maxCompactRelayIndexValue {
+		return 0, errors.New("compact relay index out of range")
+	}
+	if first {
+		return idx, nil
+	}
+	if idx <= prev {
+		return 0, errors.New("compact relay indexes not strictly increasing")
+	}
+	return idx - prev - 1, nil
 }
 
 func getBlockTxnAbsoluteIndex(prev, delta uint64, first bool) (uint64, error) {

--- a/clients/go/node/p2p/compact_wire.go
+++ b/clients/go/node/p2p/compact_wire.go
@@ -8,16 +8,15 @@ import (
 )
 
 const (
-	messageSendCmpct                   = "sendcmpct"
-	messageCmpctBlock                  = "cmpctblock"
-	messageGetBlockTxn                 = "getblocktxn"
-	messageBlockTxn                    = "blocktxn"
-	compactRelayVersion         uint64 = 1
-	sendCmpctPayloadBytes              = 9
-	compactShortIDBytes                = 6
-	maxCompactRelayEntries             = maxInventoryVectors
-	maxCompactBlockTransactions        = consensus.MAX_BLOCK_BYTES
-	maxCompactRelayIndexValue          = consensus.MAX_BLOCK_BYTES - 1
+	messageSendCmpct                 = "sendcmpct"
+	messageCmpctBlock                = "cmpctblock"
+	messageGetBlockTxn               = "getblocktxn"
+	messageBlockTxn                  = "blocktxn"
+	compactRelayVersion       uint64 = 1
+	sendCmpctPayloadBytes            = 9
+	compactShortIDBytes              = 6
+	maxCompactRelayEntries           = maxInventoryVectors
+	maxCompactRelayIndexValue        = consensus.MAX_BLOCK_BYTES - 1
 )
 
 type sendCmpctPayload struct {
@@ -183,7 +182,7 @@ func decodeBlockTxnPayload(payload []byte) (blockTxnPayload, error) {
 }
 
 func encodeCmpctBlockPayload(p cmpctBlockPayload) ([]byte, error) {
-	if len(p.ShortIDs) > maxCompactBlockTransactions-len(p.Prefilled) {
+	if len(p.ShortIDs) > consensus.MAX_BLOCK_BYTES-len(p.Prefilled) {
 		return nil, errors.New("too many compact block transactions")
 	}
 	prefilledTxs := make([][]byte, 0, len(p.Prefilled))
@@ -193,7 +192,11 @@ func encodeCmpctBlockPayload(p cmpctBlockPayload) ([]byte, error) {
 	if err := validateCompactRelayTransactions(prefilledTxs, "cmpctblock prefilled transaction is non-canonical"); err != nil {
 		return nil, err
 	}
-	out := make([]byte, 0)
+	capHint, ok := cmpctBlockPayloadByteLen(uint64(len(p.ShortIDs)), p.Prefilled)
+	if !ok {
+		return nil, errors.New("cmpctblock payload too large")
+	}
+	out := make([]byte, 0, int(capHint)) // #nosec G115 -- cmpctBlockPayloadByteLen caps capHint at MAX_RELAY_MSG_BYTES.
 	out = append(out, p.Header[:]...)
 	out = consensus.AppendU64le(out, p.Nonce)
 	out = consensus.AppendCompactSize(out, uint64(len(p.ShortIDs)))
@@ -213,6 +216,9 @@ func encodeCmpctBlockPayload(p cmpctBlockPayload) ([]byte, error) {
 }
 
 func decodeCmpctBlockPayload(payload []byte) (cmpctBlockPayload, error) {
+	if len(payload) > consensus.MAX_RELAY_MSG_BYTES {
+		return cmpctBlockPayload{}, errors.New("cmpctblock payload too large")
+	}
 	out, prefilledCount, totalEntries, offset, err := decodeCmpctBlockPrefix(payload)
 	if err != nil {
 		return cmpctBlockPayload{}, err
@@ -240,10 +246,7 @@ func decodeCmpctBlockPayload(payload []byte) (cmpctBlockPayload, error) {
 		prev = idx
 		totalTxBytes = nextTotal
 	}
-	if offset != len(payload) {
-		return cmpctBlockPayload{}, errors.New("cmpctblock payload has trailing bytes")
-	}
-	return out, nil
+	return finishCmpctBlockPayload(out, offset, len(payload))
 }
 
 func decodeCmpctBlockPrefix(payload []byte) (cmpctBlockPayload, uint64, uint64, int, error) {
@@ -268,7 +271,7 @@ func decodeCmpctBlockPrefix(payload []byte) (cmpctBlockPayload, uint64, uint64, 
 		return cmpctBlockPayload{}, 0, 0, 0, err
 	}
 	totalEntries := shortCount + prefilledCount
-	if totalEntries > maxCompactBlockTransactions || totalEntries < shortCount {
+	if totalEntries > consensus.MAX_BLOCK_BYTES || totalEntries < shortCount {
 		return cmpctBlockPayload{}, 0, 0, 0, errors.New("too many compact relay entries")
 	}
 	out.ShortIDs = make([]compactShortID, 0, int(shortCount)) // #nosec G115 -- totalEntries is capped above.
@@ -317,6 +320,33 @@ func validateCompactRelayTransactions(transactions [][]byte, nonCanonicalErr str
 		totalTxBytes = nextTotal
 	}
 	return nil
+}
+
+func finishCmpctBlockPayload(out cmpctBlockPayload, offset, payloadLen int) (cmpctBlockPayload, error) {
+	if offset != payloadLen {
+		return cmpctBlockPayload{}, errors.New("cmpctblock payload has trailing bytes")
+	}
+	return out, nil
+}
+
+func cmpctBlockPayloadByteLen(shortCount uint64, prefilled []prefilledTxn) (uint64, bool) {
+	limit := uint64(consensus.MAX_RELAY_MSG_BYTES)
+	total := uint64(consensus.BLOCK_HEADER_BYTES + 8 + len(consensus.EncodeCompactSize(shortCount)) + len(consensus.EncodeCompactSize(uint64(len(prefilled)))))
+	if shortCount > (limit-total)/compactShortIDBytes {
+		return 0, false
+	}
+	total += shortCount * compactShortIDBytes
+	var prevPlusOne uint64
+	for _, tx := range prefilled {
+		delta := tx.Index - prevPlusOne
+		add := uint64(len(consensus.EncodeCompactSize(delta)) + len(tx.Tx))
+		if add > limit-total {
+			return 0, false
+		}
+		total += add
+		prevPlusOne = tx.Index + 1
+	}
+	return total, true
 }
 
 func getBlockTxnAbsoluteIndex(prev, delta uint64, first bool) (uint64, error) {

--- a/clients/go/node/p2p/compact_wire_test.go
+++ b/clients/go/node/p2p/compact_wire_test.go
@@ -35,20 +35,17 @@ func TestCompactWireCommandConstantsAndPayloadCaps(t *testing.T) {
 
 func TestCmpctBlockPayloadAllowsShortIDCountAboveInventoryVectorLimit(t *testing.T) {
 	shortIDs := make([]compactShortID, maxCompactRelayEntries+1)
-	for i := range shortIDs {
-		shortIDs[i] = compactShortID{byte(i), byte(i >> 8), byte(i >> 16), byte(i >> 24), 0xaa, 0xbb}
-	}
 	raw, err := encodeCmpctBlockPayload(cmpctBlockPayload{ShortIDs: shortIDs})
 	if err != nil {
 		t.Fatalf("encodeCmpctBlockPayload above inventory vector limit: %v", err)
 	}
-	got, err := decodeCmpctBlockPayload(raw)
-	if err != nil {
-		t.Fatalf("decodeCmpctBlockPayload above inventory vector limit: %v", err)
+	if got, err := decodeCmpctBlockPayload(raw); err != nil || len(got.ShortIDs) != len(shortIDs) {
+		t.Fatalf("decode above inventory vector limit got=%d err=%v", len(got.ShortIDs), err)
 	}
-	if !reflect.DeepEqual(got.ShortIDs, shortIDs) {
-		t.Fatalf("short IDs above inventory vector limit did not roundtrip")
-	}
+}
+
+func TestCmpctBlockPayloadRejectsPayloadAboveWireCap(t *testing.T) {
+	assertCmpctBlockDecodeFails(t, "payload_above_wire_cap", make([]byte, consensus.MAX_RELAY_MSG_BYTES+1), "cmpctblock payload too large")
 }
 
 func TestGetBlockTxnPayloadCodec(t *testing.T) {
@@ -98,19 +95,11 @@ func TestBlockTxnPayloadCodec(t *testing.T) {
 }
 
 func TestCmpctBlockPayloadCodec(t *testing.T) {
-	tx1 := minimalBlockTxnTestTxBytes(10)
-	tx2 := minimalBlockTxnTestTxBytes(11)
 	want := cmpctBlockPayload{
-		Header: [consensus.BLOCK_HEADER_BYTES]byte{0x01, 0x02, 0x03},
-		Nonce:  0x1122334455667788,
-		ShortIDs: []compactShortID{
-			{0x01, 0x02, 0x03, 0x04, 0x05, 0x06},
-			{0x11, 0x12, 0x13, 0x14, 0x15, 0x16},
-		},
-		Prefilled: []prefilledTxn{
-			{Index: 0, Tx: tx1},
-			{Index: 3, Tx: tx2},
-		},
+		Header:    [consensus.BLOCK_HEADER_BYTES]byte{0x01, 0x02, 0x03},
+		Nonce:     0x1122334455667788,
+		ShortIDs:  []compactShortID{{0x01, 0x02, 0x03, 0x04, 0x05, 0x06}},
+		Prefilled: []prefilledTxn{{Index: 0, Tx: minimalBlockTxnTestTxBytes(10)}},
 	}
 	raw, err := encodeCmpctBlockPayload(want)
 	if err != nil {
@@ -120,7 +109,7 @@ func TestCmpctBlockPayloadCodec(t *testing.T) {
 	if err != nil {
 		t.Fatalf("decodeCmpctBlockPayload: %v", err)
 	}
-	if got.Header != want.Header || got.Nonce != want.Nonce || !reflect.DeepEqual(got.ShortIDs, want.ShortIDs) || !reflect.DeepEqual(got.Prefilled, want.Prefilled) {
+	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cmpctblock roundtrip got=%+v want=%+v", got, want)
 	}
 }
@@ -138,10 +127,9 @@ func TestCmpctBlockPayloadRejectsMalformed(t *testing.T) {
 	assertCmpctBlockDecodeFails(t, "nonminimal_short_count", cmpctBlockTestPayload([]byte{0xfd, 0x00, 0x00}), "non-minimal")
 	assertCmpctBlockDecodeFails(t, "truncated_short_ids", cmpctBlockTestPayload([]byte{1, 0x01, 0x02}), "cmpctblock payload truncated short IDs")
 	assertCmpctBlockDecodeFails(t, "nonminimal_prefilled_count", cmpctBlockTestPayload([]byte{0, 0xfd, 0x00, 0x00}), "non-minimal")
-	assertCmpctBlockDecodeFails(t, "huge_prefilled_count_without_entries", cmpctBlockTestPayload(consensus.AppendCompactSize([]byte{0}, maxCompactBlockTransactions)), "EOF")
+	assertCmpctBlockDecodeFails(t, "huge_prefilled_count_without_entries", cmpctBlockTestPayload(consensus.AppendCompactSize([]byte{0}, consensus.MAX_BLOCK_BYTES)), "EOF")
 
 	rangeBeforeTx := consensus.AppendCompactSize(consensus.AppendCompactSize(consensus.AppendCompactSize(nil, 0), 1), 1)
-	rangeBeforeTx = append(rangeBeforeTx, make([]byte, consensus.MAX_BLOCK_BYTES)...)
 	assertCmpctBlockDecodeFails(t, "prefilled_index_range_before_tx", cmpctBlockTestPayload(rangeBeforeTx), "compact relay index out of range")
 	assertCmpctBlockDecodeFails(t, "trailing", append(cmpctBlockTestPayload([]byte{0, 0}), 0x00), "cmpctblock payload has trailing bytes")
 }

--- a/clients/go/node/p2p/compact_wire_test.go
+++ b/clients/go/node/p2p/compact_wire_test.go
@@ -79,6 +79,63 @@ func TestBlockTxnPayloadCodec(t *testing.T) {
 	}
 }
 
+func TestCmpctBlockPayloadCodec(t *testing.T) {
+	tx1 := minimalBlockTxnTestTxBytes(10)
+	tx2 := minimalBlockTxnTestTxBytes(11)
+	want := cmpctBlockPayload{
+		Header: [consensus.BLOCK_HEADER_BYTES]byte{0x01, 0x02, 0x03},
+		Nonce:  0x1122334455667788,
+		ShortIDs: []compactShortID{
+			{0x01, 0x02, 0x03, 0x04, 0x05, 0x06},
+			{0x11, 0x12, 0x13, 0x14, 0x15, 0x16},
+		},
+		Prefilled: []prefilledTxn{
+			{Index: 0, Tx: tx1},
+			{Index: 3, Tx: tx2},
+		},
+	}
+	raw, err := encodeCmpctBlockPayload(want)
+	if err != nil {
+		t.Fatalf("encodeCmpctBlockPayload: %v", err)
+	}
+	got, err := decodeCmpctBlockPayload(raw)
+	if err != nil {
+		t.Fatalf("decodeCmpctBlockPayload: %v", err)
+	}
+	if got.Header != want.Header || got.Nonce != want.Nonce || !reflect.DeepEqual(got.ShortIDs, want.ShortIDs) || !reflect.DeepEqual(got.Prefilled, want.Prefilled) {
+		t.Fatalf("cmpctblock roundtrip got=%+v want=%+v", got, want)
+	}
+}
+
+func TestCmpctBlockPayloadRejectsMalformed(t *testing.T) {
+	validTx := minimalBlockTxnTestTxBytes(12)
+	tooManyShortIDs := make([]compactShortID, maxCompactRelayEntries+1)
+	tooManyPrefilled := make([]prefilledTxn, maxCompactRelayEntries+1)
+	for i := range tooManyPrefilled {
+		tooManyPrefilled[i] = prefilledTxn{Index: uint64(i), Tx: validTx}
+	}
+	assertCmpctBlockEncodeFails(t, "too_many_short_ids", cmpctBlockPayload{ShortIDs: tooManyShortIDs}, "too many compact relay entries")
+	assertCmpctBlockEncodeFails(t, "too_many_prefilled", cmpctBlockPayload{Prefilled: tooManyPrefilled}, "too many compact relay entries")
+	assertCmpctBlockEncodeFails(t, "duplicate_prefilled", cmpctBlockPayload{Prefilled: []prefilledTxn{{Index: 1, Tx: validTx}, {Index: 1, Tx: validTx}}}, "compact relay indexes not strictly increasing")
+	assertCmpctBlockEncodeFails(t, "prefilled_index_outside_vector", cmpctBlockPayload{Prefilled: []prefilledTxn{{Index: 1, Tx: validTx}}}, "compact relay index out of range")
+	assertCmpctBlockEncodeFails(t, "prefilled_index_range", cmpctBlockPayload{Prefilled: []prefilledTxn{{Index: maxCompactRelayIndexValue + 1, Tx: validTx}}}, "compact relay index out of range")
+	assertCmpctBlockEncodeFails(t, "empty_prefilled_tx", cmpctBlockPayload{Prefilled: []prefilledTxn{{Tx: nil}}}, "blocktxn transaction is empty")
+	assertCmpctBlockEncodeFails(t, "trailing_prefilled_tx", cmpctBlockPayload{Prefilled: []prefilledTxn{{Tx: append(validTx, 0x00)}}}, "cmpctblock prefilled transaction is non-canonical")
+
+	assertCmpctBlockDecodeFails(t, "short_header", make([]byte, consensus.BLOCK_HEADER_BYTES+7), "cmpctblock payload missing header or nonce")
+	assertCmpctBlockDecodeFails(t, "nonminimal_short_count", cmpctBlockTestPayload([]byte{0xfd, 0x00, 0x00}), "non-minimal")
+	assertCmpctBlockDecodeFails(t, "too_many_short_ids", cmpctBlockTestPayload(consensus.AppendCompactSize(nil, maxCompactRelayEntries+1)), "too many compact relay short IDs")
+	assertCmpctBlockDecodeFails(t, "truncated_short_ids", cmpctBlockTestPayload([]byte{1, 0x01, 0x02}), "cmpctblock payload truncated short IDs")
+	assertCmpctBlockDecodeFails(t, "nonminimal_prefilled_count", cmpctBlockTestPayload([]byte{0, 0xfd, 0x00, 0x00}), "non-minimal")
+	aggregate := consensus.AppendCompactSize(append(consensus.AppendCompactSize(nil, maxCompactRelayEntries), make([]byte, maxCompactRelayEntries*compactShortIDBytes)...), 1)
+	assertCmpctBlockDecodeFails(t, "aggregate_count", cmpctBlockTestPayload(aggregate), "too many compact relay entries")
+
+	rangeBeforeTx := consensus.AppendCompactSize(consensus.AppendCompactSize(consensus.AppendCompactSize(nil, 0), 1), 1)
+	rangeBeforeTx = append(rangeBeforeTx, make([]byte, consensus.MAX_BLOCK_BYTES)...)
+	assertCmpctBlockDecodeFails(t, "prefilled_index_range_before_tx", cmpctBlockTestPayload(rangeBeforeTx), "compact relay index out of range")
+	assertCmpctBlockDecodeFails(t, "trailing", append(cmpctBlockTestPayload([]byte{0, 0}), 0x00), "cmpctblock payload has trailing bytes")
+}
+
 func TestBlockTxnPayloadRejectsMalformed(t *testing.T) {
 	tooMany := make([][]byte, maxCompactRelayEntries+1)
 	tooLarge := make([]byte, consensus.MAX_BLOCK_BYTES+1)
@@ -148,6 +205,33 @@ func mustEncodeBlockTxnPayload(t *testing.T, txs [][]byte) []byte {
 		t.Fatalf("encodeBlockTxnPayload: %v", err)
 	}
 	return raw
+}
+
+func assertCmpctBlockEncodeFails(t *testing.T, name string, in cmpctBlockPayload, wantErr string) {
+	t.Helper()
+	_, err := encodeCmpctBlockPayload(in)
+	if err == nil {
+		t.Fatalf("%s: expected encode failure", name)
+	}
+	if !strings.Contains(err.Error(), wantErr) {
+		t.Fatalf("%s: encode error=%q, want %q", name, err, wantErr)
+	}
+}
+
+func assertCmpctBlockDecodeFails(t *testing.T, name string, raw []byte, wantErr string) {
+	t.Helper()
+	_, err := decodeCmpctBlockPayload(raw)
+	if err == nil {
+		t.Fatalf("%s: expected decode failure", name)
+	}
+	if !strings.Contains(err.Error(), wantErr) {
+		t.Fatalf("%s: decode error=%q, want %q", name, err, wantErr)
+	}
+}
+
+func cmpctBlockTestPayload(tail []byte) []byte {
+	head := make([]byte, consensus.BLOCK_HEADER_BYTES+8)
+	return append(head, tail...)
 }
 
 func TestGetBlockTxnPayloadAllowsIndexesAboveRequestCountCap(t *testing.T) {

--- a/clients/go/node/p2p/compact_wire_test.go
+++ b/clients/go/node/p2p/compact_wire_test.go
@@ -79,6 +79,67 @@ func TestBlockTxnPayloadCodec(t *testing.T) {
 	}
 }
 
+func TestCmpctBlockPayloadCodec(t *testing.T) {
+	tx1 := minimalBlockTxnTestTxBytes(10)
+	tx2 := minimalBlockTxnTestTxBytes(11)
+	want := cmpctBlockPayload{
+		Header: [consensus.BLOCK_HEADER_BYTES]byte{0x01, 0x02, 0x03},
+		Nonce:  0x1122334455667788,
+		ShortIDs: []compactShortID{
+			{0x01, 0x02, 0x03, 0x04, 0x05, 0x06},
+			{0x11, 0x12, 0x13, 0x14, 0x15, 0x16},
+		},
+		Prefilled: []prefilledTxn{
+			{Index: 0, Tx: tx1},
+			{Index: 3, Tx: tx2},
+		},
+	}
+	raw, err := encodeCmpctBlockPayload(want)
+	if err != nil {
+		t.Fatalf("encodeCmpctBlockPayload: %v", err)
+	}
+	got, err := decodeCmpctBlockPayload(raw)
+	if err != nil {
+		t.Fatalf("decodeCmpctBlockPayload: %v", err)
+	}
+	if got.Header != want.Header || got.Nonce != want.Nonce || !reflect.DeepEqual(got.ShortIDs, want.ShortIDs) || !reflect.DeepEqual(got.Prefilled, want.Prefilled) {
+		t.Fatalf("cmpctblock roundtrip got=%+v want=%+v", got, want)
+	}
+}
+
+func TestCmpctBlockPayloadRejectsMalformed(t *testing.T) {
+	validTx := minimalBlockTxnTestTxBytes(12)
+	tooManyShortIDs := make([]compactShortID, maxCompactRelayEntries+1)
+	tooManyPrefilled := make([]prefilledTxn, maxCompactRelayEntries+1)
+	for i := range tooManyPrefilled {
+		tooManyPrefilled[i] = prefilledTxn{Index: uint64(i), Tx: validTx}
+	}
+	assertCmpctBlockEncodeFails(t, "too_many_short_ids", cmpctBlockPayload{ShortIDs: tooManyShortIDs}, "too many compact relay entries")
+	assertCmpctBlockEncodeFails(t, "too_many_prefilled", cmpctBlockPayload{Prefilled: tooManyPrefilled}, "too many compact relay")
+	assertCmpctBlockEncodeFails(t, "duplicate_prefilled", cmpctBlockPayload{Prefilled: []prefilledTxn{{Index: 1, Tx: validTx}, {Index: 1, Tx: validTx}}}, "compact relay index")
+	assertCmpctBlockEncodeFails(t, "prefilled_index_outside_vector", cmpctBlockPayload{Prefilled: []prefilledTxn{{Index: 1, Tx: validTx}}}, "compact relay index out of range")
+	assertCmpctBlockEncodeFails(t, "prefilled_index_range", cmpctBlockPayload{Prefilled: []prefilledTxn{{Index: maxCompactRelayIndexValue + 1, Tx: validTx}}}, "compact relay index out of range")
+	assertCmpctBlockEncodeFails(t, "empty_prefilled_tx", cmpctBlockPayload{Prefilled: []prefilledTxn{{Tx: nil}}}, "blocktxn transaction is empty")
+	assertCmpctBlockEncodeFails(t, "trailing_prefilled_tx", cmpctBlockPayload{Prefilled: []prefilledTxn{{Tx: append(validTx, 0x00)}}}, "blocktxn transaction is non-canonical")
+	assertCmpctBlockEncodeFails(t, "trailing_prefilled_tx_before_next_delta", cmpctBlockPayload{Prefilled: []prefilledTxn{{Index: 0, Tx: append(validTx, 0x00)}, {Index: 1, Tx: validTx}}}, "blocktxn transaction is non-canonical")
+
+	assertCmpctBlockDecodeFails(t, "short_header", make([]byte, consensus.BLOCK_HEADER_BYTES+7), "cmpctblock payload missing header or nonce")
+	assertCmpctBlockDecodeFails(t, "nonminimal_short_count", cmpctBlockTestPayload([]byte{0xfd, 0x00, 0x00}), "non-minimal")
+	tooManyShortIDPayload := consensus.AppendCompactSize(nil, maxCompactRelayEntries+1)
+	tooManyShortIDPayload = append(tooManyShortIDPayload, make([]byte, (maxCompactRelayEntries+1)*compactShortIDBytes)...)
+	tooManyShortIDPayload = consensus.AppendCompactSize(tooManyShortIDPayload, 0)
+	assertCmpctBlockDecodeFails(t, "too_many_short_ids", cmpctBlockTestPayload(tooManyShortIDPayload), "too many compact relay entries")
+	assertCmpctBlockDecodeFails(t, "truncated_short_ids", cmpctBlockTestPayload([]byte{1, 0x01, 0x02}), "cmpctblock payload truncated short IDs")
+	assertCmpctBlockDecodeFails(t, "nonminimal_prefilled_count", cmpctBlockTestPayload([]byte{0, 0xfd, 0x00, 0x00}), "non-minimal")
+	aggregate := consensus.AppendCompactSize(append(consensus.AppendCompactSize(nil, maxCompactRelayEntries), make([]byte, maxCompactRelayEntries*compactShortIDBytes)...), 1)
+	assertCmpctBlockDecodeFails(t, "aggregate_count", cmpctBlockTestPayload(aggregate), "too many compact relay entries")
+
+	rangeBeforeTx := consensus.AppendCompactSize(consensus.AppendCompactSize(consensus.AppendCompactSize(nil, 0), 1), 1)
+	rangeBeforeTx = append(rangeBeforeTx, make([]byte, consensus.MAX_BLOCK_BYTES)...)
+	assertCmpctBlockDecodeFails(t, "prefilled_index_range_before_tx", cmpctBlockTestPayload(rangeBeforeTx), "compact relay index out of range")
+	assertCmpctBlockDecodeFails(t, "trailing", append(cmpctBlockTestPayload([]byte{0, 0}), 0x00), "cmpctblock payload has trailing bytes")
+}
+
 func TestBlockTxnPayloadRejectsMalformed(t *testing.T) {
 	tooMany := make([][]byte, maxCompactRelayEntries+1)
 	tooLarge := make([]byte, consensus.MAX_BLOCK_BYTES+1)
@@ -148,6 +209,33 @@ func mustEncodeBlockTxnPayload(t *testing.T, txs [][]byte) []byte {
 		t.Fatalf("encodeBlockTxnPayload: %v", err)
 	}
 	return raw
+}
+
+func assertCmpctBlockEncodeFails(t *testing.T, name string, in cmpctBlockPayload, wantErr string) {
+	t.Helper()
+	_, err := encodeCmpctBlockPayload(in)
+	if err == nil {
+		t.Fatalf("%s: expected encode failure", name)
+	}
+	if !strings.Contains(err.Error(), wantErr) {
+		t.Fatalf("%s: encode error=%q, want %q", name, err, wantErr)
+	}
+}
+
+func assertCmpctBlockDecodeFails(t *testing.T, name string, raw []byte, wantErr string) {
+	t.Helper()
+	_, err := decodeCmpctBlockPayload(raw)
+	if err == nil {
+		t.Fatalf("%s: expected decode failure", name)
+	}
+	if !strings.Contains(err.Error(), wantErr) {
+		t.Fatalf("%s: decode error=%q, want %q", name, err, wantErr)
+	}
+}
+
+func cmpctBlockTestPayload(tail []byte) []byte {
+	head := make([]byte, consensus.BLOCK_HEADER_BYTES+8)
+	return append(head, tail...)
 }
 
 func TestGetBlockTxnPayloadAllowsIndexesAboveRequestCountCap(t *testing.T) {


### PR DESCRIPTION
Invariant:
RUB-316 adds a bounded Go cmpctblock compact relay payload codec only.

Layer:
implementation / tests

Files changed:
- clients/go/node/p2p/compact_wire.go
- clients/go/node/p2p/compact_wire_test.go

Tests:
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node/p2p -run "CmpctBlock|Compact|Wire"'\n- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node/p2p'\n- scripts/dev-env.sh -- bash -lc 'cd clients/go && go vet ./node/p2p'\n- scripts/dev-env.sh -- bash -lc 'cd clients/go && gosec ./node/p2p'\n- lizard_medium_rows.py clients/go/node/p2p/compact_wire.go clients/go/node/p2p/*compact*_test.go\n- rubin-precommit-one-review --repo . --base-ref origin/main --include-base-diff\n- rubin-common-preflight --lane coverage\n\nBehavior impact:\nAdds cmpctblock payload encode/decode helpers. Does not enable live runtime dispatch.\n\nCompatibility impact:\nNo consensus, spec, conformance, or Rust changes.\n\nKnown non-goals:\nNo sendcmpct peer-mode state, no peer_runtime dispatch, no reconstruction, no getblocktxn/blocktxn runtime request flow, no DA relay state machine.

<!-- rubin-agent-meta actor=unknown action=pr-create via=cl branch=codex/RUB-316-cmpctblock-codec wt=rubin-protocol-codex-RUB-316 utc=2026-05-19T13:08:28Z -->
