### PR TITLE
ci: use documented Codacy duplication threshold

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -136,15 +136,15 @@ engines:
   duplication:
     # CLI dispatchers, fixture generators, and node integration code contain
     # inherent structural repetition (dispatch boilerplate, tx-building
-    # templates, IBD vs sequential paths) that cannot be eliminated without
-    # sacrificing readability.  Raise the minimum clone threshold so only
-    # substantive duplications (>35 lines) are reported.
+    # templates, IBD vs sequential paths) that cannot be eliminated safely.
+    # Codacy's documented duplication knob is token-based (`minTokenMatch`),
+    # not line-based; keep the threshold aligned with the local `.jscpd.json`
+    # informational PR check (`minTokens: 100`).
     exclude_paths:
       - "clients/go/cmd/**"
       - "clients/rust/crates/rubin-consensus-cli/**"
       - "clients/go/node/**"
-    config:
-      minLines: 35
+    minTokenMatch: 100
 
 languages:
   # Product code lives in Go/Rust. Everything below is docs/tooling/fixtures or


### PR DESCRIPTION
Invariant:
Codacy duplication configuration must use a documented Codacy key so duplication analysis can be scheduled and reported instead of silently carrying an unsupported nested setting.

Layer:
CI / Codacy configuration.

Files changed:
- `.codacy.yml`

What changed:
- Replaced unsupported `engines.duplication.config.minLines` with documented `engines.duplication.minTokenMatch`.
- Updated the nearby comment to avoid claiming a line-based Codacy threshold.
- Kept duplication exclusions scoped to existing CLI/node paths only.

Behavior impact:
No runtime, consensus, policy, or test behavior change.

Compatibility impact:
Codacy should now receive a documented token-based duplication threshold aligned with local `.jscpd.json` `minTokens: 100`.

Tests:
- YAML parse and duplication-key assertions — PASS
- `git diff --check` — PASS
- `rubin-precommit-one-review --include-base-diff --light-python` — PASS
- `rubin-push --no-coverage-reason "config-only Codacy YAML change; no executable coverage surface"` — PASS

Not checked:
- Codacy Cloud duplication reset/reanalysis; this PR only fixes the config shape. If dashboard still shows `Duplication: -`, Codacy Cloud support/reset is still required.


<!-- rubin-agent-meta actor=unknown action=pr-create via=cl branch=codex/codacy-duplication-config-fix wt=rubin-protocol utc=2026-05-19T14:00:22Z -->
