### PR TITLE
tooling: add local production duplication gate

### DIFF
--- a/.jscpd.json
+++ b/.jscpd.json
@@ -1,12 +1,20 @@
 {
-  "threshold": 5,
-  "minLines": 25,
-  "minTokens": 100,
+  "threshold": 2,
+  "minLines": 20,
+  "minTokens": 80,
+  "maxLines": 5000,
+  "maxSize": "1mb",
+  "format": ["go", "rust"],
   "reporters": ["console"],
   "ignore": [
     "spec/**", "conformance/**", "rubin-formal/**",
     "tools/**", "scripts/**", ".github/**", "analysis/**",
     "**/*_test.go", "**/tests/**", "**/benches/**",
-    "**/*.gen.go", "**/*_generated.rs", "package-lock.json"
+    "**/*_tests.rs", "**/*_tests/**", "**/*_test_support.rs",
+    "clients/rust/fuzz/**",
+    "**/*.gen.go", "**/*_generated.rs", "package-lock.json",
+    "clients/go/cmd/**",
+    "clients/rust/crates/rubin-consensus-cli/**",
+    "clients/go/node/**"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "node": "24.14.0"
   },
   "scripts": {
+    "duplication:check": "python3 tools/check_duplication.py",
     "spec:location": "echo 'Spec moved to private repo: https://github.com/2tbmz9y2xt-lang/rubin-spec'",
     "formal:coverage": "python3 tools/check_formal_coverage.py",
     "formal:bridge": "python3 tools/check_formal_refinement_bridge.py",

--- a/scripts/preflight-codacy-coverage.sh
+++ b/scripts/preflight-codacy-coverage.sh
@@ -3,5 +3,6 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
+python3 "$repo_root/tools/check_duplication.py"
 "$repo_root/scripts/local-codacy-coverage-check.sh" "$@"
 "$repo_root/scripts/local-codacy-variation-parity.sh" "$@"

--- a/tools/check_duplication.py
+++ b/tools/check_duplication.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Run the Rubin production duplication gate with pinned jscpd settings."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_JSCPD_PACKAGE = "jscpd@4.2.3"
+DEFAULT_SOURCE_PATHS = (
+    "clients/go/consensus",
+    "clients/rust/crates/rubin-consensus/src",
+)
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def load_config(root: Path) -> dict[str, Any]:
+    config_path = root / ".jscpd.json"
+    with config_path.open("r", encoding="utf-8") as fh:
+        config = json.load(fh)
+    if not isinstance(config, dict):
+        raise ValueError(".jscpd.json must contain a JSON object")
+    return config
+
+
+def total_stats(report_path: Path) -> dict[str, Any]:
+    with report_path.open("r", encoding="utf-8") as fh:
+        report = json.load(fh)
+    total = report.get("statistics", {}).get("total")
+    if not isinstance(total, dict):
+        raise ValueError(f"{report_path} does not contain statistics.total")
+    duplicates = report.get("duplicates")
+    if not isinstance(duplicates, list):
+        raise ValueError(f"{report_path} does not contain duplicates list")
+    total["duplicates"] = duplicates
+    return total
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        default="/tmp/rubin-jscpd-production-report",
+        help="Directory for the jscpd JSON report.",
+    )
+    parser.add_argument(
+        "--jscpd-package",
+        default=DEFAULT_JSCPD_PACKAGE,
+        help="Pinned npm package spec used by npx.",
+    )
+    parser.add_argument(
+        "--strict-zero-clones",
+        action="store_true",
+        help="Fail on any clone, even when duplicated percentage is under threshold.",
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        default=list(DEFAULT_SOURCE_PATHS),
+        help="Source paths to scan. Defaults to production Go/Rust consensus surfaces.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    root = repo_root()
+    config = load_config(root)
+    output_dir = Path(args.output).expanduser().resolve()
+    shutil.rmtree(output_dir, ignore_errors=True)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", suffix=".json", delete=False) as fh:
+        json.dump(config, fh, indent=2, sort_keys=True)
+        fh.write("\n")
+        temp_config = Path(fh.name)
+
+    cmd = [
+        "npx",
+        "--yes",
+        args.jscpd_package,
+        "--config",
+        str(temp_config),
+        "--reporters",
+        "console,json",
+        "--output",
+        str(output_dir),
+        *args.paths,
+    ]
+
+    try:
+        completed = subprocess.run(cmd, cwd=root, check=False)
+        report_path = output_dir / "jscpd-report.json"
+        if not report_path.exists():
+            print(f"FAIL: jscpd did not write {report_path}", file=sys.stderr)
+            return completed.returncode or 1
+        total = total_stats(report_path)
+        clone_count = int(total.get("clones", 0))
+        percentage = float(total.get("percentage", 0))
+        token_percentage = float(total.get("percentageTokens", 0))
+        print(
+            "RUBIN DUPLICATION GATE: "
+            f"clones={clone_count}, duplicated_lines={total.get('duplicatedLines', 0)}, "
+            f"percentage={percentage:.2f}%, token_percentage={token_percentage:.2f}%"
+        )
+        print(f"Report: {report_path}")
+        if args.strict_zero_clones and clone_count != 0:
+            print("FAIL: strict zero-clone mode found clones", file=sys.stderr)
+            return 1
+        return completed.returncode
+    finally:
+        temp_config.unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Invariant:
Local duplication preflight must provide an operator-controlled production quality gate even when Codacy Cloud duplication metrics are unavailable.

Layer:
tooling

Files changed:
- `.jscpd.json` tightens the local production duplication profile to Go/Rust, 2% threshold, 20 lines / 80 tokens, with Codacy-aligned exclusions for tests, generated artifacts, CLI/devnet/tooling, fuzz targets, and node integration surfaces.
- `tools/check_duplication.py` adds a pinned `jscpd@4.2.3` wrapper that cleans stale reports before each run, emits a stable summary, and supports strict zero-clone mode for audits.
- `scripts/preflight-codacy-coverage.sh` runs duplication before local Codacy coverage preflight.
- `package.json` adds `npm run duplication:check`.

Tests:
- `npm run duplication:check -- --output /tmp/rubin-jscpd-npm-script-check` — PASS, 10 clones, 0.90% duplicated lines, below 2% gate.
- `npm run duplication:check -- --strict-zero-clones --output /tmp/rubin-jscpd-strict-zero-check` — expected FAIL, verifies fail-closed strict mode.
- `python3 -m py_compile tools/check_duplication.py` — PASS.
- `bash -n scripts/preflight-codacy-coverage.sh` — PASS.
- `python3 -m json.tool .jscpd.json` — PASS.
- `python3 -m json.tool package.json` — PASS.
- `git diff --check` — PASS.
- `rubin-preflight-tooling --lane core` — PASS.
- `rubin-preflight-tooling --lane tooling` — PASS.

Behavior impact:
No runtime behavior change. Local preflight now runs duplication before coverage.

Compatibility impact:
Requires network access for `npx --yes jscpd@4.2.3` unless the package is already cached.

Known non-goals:
- Does not fix Codacy Cloud UI duplication metrics.
- Does not make the existing GitHub jscpd check blocking.
- Does not refactor existing accepted Rust duplicate blocks.

Risk:
Low; tooling-only wrapper and config change.

Rollback:
Revert this PR to restore the previous informational `.jscpd.json` threshold and remove the local duplication preflight step.

Not checked:
Full local coverage preflight was not run because this PR only wires the duplication gate before coverage; coverage lane was recorded as tooling-only skip.


<!-- rubin-agent-meta actor=unknown action=pr-create via=cl branch=codex/local-duplication-production-gate wt=rubin-protocol utc=2026-05-19T16:47:12Z -->
