### PR TITLE
[Q-GO-P2P-COMPACT-AUX-WIRE-LAYOUT-PARITY-01] Fix Go compact relay AUX wire layout parity

### DIFF
--- a/clients/go/node/p2p/compact_wire.go
+++ b/clients/go/node/p2p/compact_wire.go
@@ -15,6 +15,7 @@ const (
 	compactRelayVersion       uint64 = 1
 	sendCmpctPayloadBytes            = 9
 	compactShortIDBytes              = 6
+	compactRelayIndexBytes           = 4
 	maxCompactRelayEntries           = maxInventoryVectors
 	maxCmpctBlockEntries             = consensus.MAX_BLOCK_BYTES
 	maxCompactRelayIndexValue        = consensus.MAX_BLOCK_BYTES - 1
@@ -44,7 +45,8 @@ type prefilledTxn struct {
 
 type cmpctBlockPayload struct {
 	Header    [consensus.BLOCK_HEADER_BYTES]byte
-	Nonce     uint64
+	Nonce1    uint64
+	Nonce2    uint64
 	ShortIDs  []compactShortID
 	Prefilled []prefilledTxn
 }
@@ -72,23 +74,14 @@ func encodeGetBlockTxnPayload(p getBlockTxnPayload) ([]byte, error) {
 	if len(p.Indexes) > maxCompactRelayEntries {
 		return nil, errors.New("too many compact relay indexes")
 	}
-	out := make([]byte, 0, 32+maxCompactSizeBytes+len(p.Indexes)*maxCompactSizeBytes)
+	out := make([]byte, 0, 32+maxCompactSizeBytes+len(p.Indexes)*compactRelayIndexBytes)
 	out = append(out, p.BlockHash[:]...)
 	out = consensus.AppendCompactSize(out, uint64(len(p.Indexes)))
-	var prev uint64
-	for i, idx := range p.Indexes {
+	for _, idx := range p.Indexes {
 		if idx > maxCompactRelayIndexValue {
 			return nil, errors.New("compact relay index out of range")
 		}
-		if i == 0 {
-			out = consensus.AppendCompactSize(out, idx)
-		} else {
-			if idx <= prev {
-				return nil, errors.New("compact relay indexes not strictly increasing")
-			}
-			out = consensus.AppendCompactSize(out, idx-prev-1)
-		}
-		prev = idx
+		out = consensus.AppendU32le(out, uint32(idx)) // #nosec G115 -- maxCompactRelayIndexValue is below uint32 max.
 	}
 	return out, nil
 }
@@ -108,19 +101,16 @@ func decodeGetBlockTxnPayload(payload []byte) (getBlockTxnPayload, error) {
 	}
 	offset := 32 + consumed
 	indexes := make([]uint64, 0, int(count)) // #nosec G115 -- count is capped at maxCompactRelayEntries above.
-	var prev uint64
 	for i := uint64(0); i < count; i++ {
-		delta, n, err := consensus.DecodeCompactSize(payload[offset:])
-		if err != nil {
-			return getBlockTxnPayload{}, err
+		if len(payload[offset:]) < compactRelayIndexBytes {
+			return getBlockTxnPayload{}, errors.New("getblocktxn payload truncated index")
 		}
-		offset += n
-		idx, err := getBlockTxnAbsoluteIndex(prev, delta, i == 0)
-		if err != nil {
-			return getBlockTxnPayload{}, err
+		idx := uint64(binary.LittleEndian.Uint32(payload[offset:]))
+		offset += compactRelayIndexBytes
+		if idx > maxCompactRelayIndexValue {
+			return getBlockTxnPayload{}, errors.New("compact relay index out of range")
 		}
 		indexes = append(indexes, idx)
-		prev = idx
 	}
 	if offset != len(payload) {
 		return getBlockTxnPayload{}, errors.New("getblocktxn payload has trailing bytes")
@@ -136,15 +126,15 @@ func encodeBlockTxnPayload(p blockTxnPayload) ([]byte, error) {
 	if err := validateCompactRelayTransactions(p.Transactions, "blocktxn transaction is non-canonical"); err != nil {
 		return nil, err
 	}
-	totalTxBytes := uint64(0)
-	for _, tx := range p.Transactions {
-		totalTxBytes += uint64(len(tx))
+	capHint, err := blockTxnPayloadByteLen(p.Transactions)
+	if err != nil {
+		return nil, err
 	}
-	capHint := 32 + maxCompactSizeBytes + int(totalTxBytes) // #nosec G115 -- totalTxBytes is capped at consensus.MAX_BLOCK_BYTES above.
-	out := make([]byte, 0, capHint)
+	out := make([]byte, 0, int(capHint)) // #nosec G115 -- blockTxnPayloadByteLen caps capHint near MAX_BLOCK_BYTES.
 	out = append(out, p.BlockHash[:]...)
 	out = consensus.AppendCompactSize(out, uint64(len(p.Transactions)))
 	for _, tx := range p.Transactions {
+		out = consensus.AppendCompactSize(out, uint64(len(tx)))
 		out = append(out, tx...)
 	}
 	return out, nil
@@ -167,12 +157,17 @@ func decodeBlockTxnPayload(payload []byte) (blockTxnPayload, error) {
 	transactions := make([][]byte, 0, int(count)) // #nosec G115 -- count is capped at maxCompactRelayEntries above.
 	var totalTxBytes uint64
 	for i := uint64(0); i < count; i++ {
-		tx, n, nextTotal, err := decodeBlockTxnTransaction(payload[offset:], totalTxBytes)
+		txLen, n, err := consensus.DecodeCompactSize(payload[offset:])
+		if err != nil {
+			return blockTxnPayload{}, err
+		}
+		offset += n
+		tx, txConsumed, nextTotal, err := decodeCompactRelayTxEnvelope(payload[offset:], txLen, totalTxBytes, "blocktxn transaction is non-canonical")
 		if err != nil {
 			return blockTxnPayload{}, err
 		}
 		transactions = append(transactions, append([]byte(nil), tx...))
-		offset += n
+		offset += txConsumed
 		totalTxBytes = nextTotal
 	}
 	if offset != len(payload) {
@@ -183,8 +178,8 @@ func decodeBlockTxnPayload(payload []byte) (blockTxnPayload, error) {
 }
 
 func encodeCmpctBlockPayload(p cmpctBlockPayload) ([]byte, error) {
-	if len(p.ShortIDs) > maxCmpctBlockEntries-len(p.Prefilled) {
-		return nil, errors.New("too many compact block transactions")
+	if _, err := validateCmpctBlockEntryCount(uint64(len(p.ShortIDs)), uint64(len(p.Prefilled))); err != nil {
+		return nil, err
 	}
 	capHint, err := cmpctBlockPayloadByteLen(uint64(len(p.ShortIDs)), p.Prefilled)
 	if err != nil {
@@ -199,18 +194,17 @@ func encodeCmpctBlockPayload(p cmpctBlockPayload) ([]byte, error) {
 	}
 	out := make([]byte, 0, int(capHint)) // #nosec G115 -- cmpctBlockPayloadByteLen caps capHint at MAX_RELAY_MSG_BYTES.
 	out = append(out, p.Header[:]...)
-	out = consensus.AppendU64le(out, p.Nonce)
+	out = consensus.AppendU64le(out, p.Nonce1)
+	out = consensus.AppendU64le(out, p.Nonce2)
 	out = consensus.AppendCompactSize(out, uint64(len(p.ShortIDs)))
 	for _, shortID := range p.ShortIDs {
 		out = append(out, shortID[:]...)
 	}
 	out = consensus.AppendCompactSize(out, uint64(len(p.Prefilled)))
-	var prevPlusOne uint64
 	for _, tx := range p.Prefilled {
-		delta := tx.Index - prevPlusOne
-		out = consensus.AppendCompactSize(out, delta)
+		out = consensus.AppendU32le(out, uint32(tx.Index)) // #nosec G115 -- cmpctBlockPayloadByteLen caps Index below MAX_BLOCK_BYTES.
+		out = consensus.AppendCompactSize(out, uint64(len(tx.Tx)))
 		out = append(out, tx.Tx...)
-		prevPlusOne = tx.Index + 1
 	}
 	_, err = decodeCmpctBlockPayload(out)
 	return out, err
@@ -227,24 +221,13 @@ func decodeCmpctBlockPayload(payload []byte) (cmpctBlockPayload, error) {
 	var prev uint64
 	var totalTxBytes uint64
 	for i := uint64(0); i < prefilledCount; i++ {
-		delta, n, err := consensus.DecodeCompactSize(payload[offset:])
+		entry, nextOffset, nextTotal, err := decodeCmpctBlockPrefilled(payload, offset, i, prev, totalEntries, totalTxBytes)
 		if err != nil {
 			return cmpctBlockPayload{}, err
 		}
-		idx, err := getBlockTxnAbsoluteIndex(prev, delta, i == 0)
-		if err != nil {
-			return cmpctBlockPayload{}, err
-		}
-		if idx >= totalEntries {
-			return cmpctBlockPayload{}, errors.New("compact relay index out of range")
-		}
-		tx, txConsumed, nextTotal, err := decodeBlockTxnTransaction(payload[offset+n:], totalTxBytes)
-		if err != nil {
-			return cmpctBlockPayload{}, err
-		}
-		out.Prefilled = append(out.Prefilled, prefilledTxn{Index: idx, Tx: append([]byte(nil), tx...)})
-		offset += n + txConsumed
-		prev = idx
+		out.Prefilled = append(out.Prefilled, entry)
+		offset = nextOffset
+		prev = entry.Index
 		totalTxBytes = nextTotal
 	}
 	return finishCmpctBlockPayload(out, offset, len(payload))
@@ -252,12 +235,13 @@ func decodeCmpctBlockPayload(payload []byte) (cmpctBlockPayload, error) {
 
 func decodeCmpctBlockPrefix(payload []byte) (cmpctBlockPayload, uint64, uint64, int, error) {
 	var out cmpctBlockPayload
-	if len(payload) < consensus.BLOCK_HEADER_BYTES+8 {
+	if len(payload) < consensus.BLOCK_HEADER_BYTES+16 {
 		return out, 0, 0, 0, errors.New("cmpctblock payload missing header or nonce")
 	}
 	copy(out.Header[:], payload[:consensus.BLOCK_HEADER_BYTES])
-	out.Nonce = binary.LittleEndian.Uint64(payload[consensus.BLOCK_HEADER_BYTES:])
-	offset := consensus.BLOCK_HEADER_BYTES + 8
+	out.Nonce1 = binary.LittleEndian.Uint64(payload[consensus.BLOCK_HEADER_BYTES:])
+	out.Nonce2 = binary.LittleEndian.Uint64(payload[consensus.BLOCK_HEADER_BYTES+8:])
+	offset := consensus.BLOCK_HEADER_BYTES + 16
 	shortCount, consumed, err := consensus.DecodeCompactSize(payload[offset:])
 	if err != nil {
 		return cmpctBlockPayload{}, 0, 0, 0, err
@@ -271,8 +255,8 @@ func decodeCmpctBlockPrefix(payload []byte) (cmpctBlockPayload, uint64, uint64, 
 	if err != nil {
 		return cmpctBlockPayload{}, 0, 0, 0, err
 	}
-	totalEntries := shortCount + prefilledCount
-	if totalEntries-1 >= maxCmpctBlockEntries || totalEntries < shortCount {
+	totalEntries, err := validateCmpctBlockEntryCount(shortCount, prefilledCount)
+	if err != nil {
 		return cmpctBlockPayload{}, 0, 0, 0, errors.New("invalid compact relay entry count")
 	}
 	out.ShortIDs = make([]compactShortID, 0, int(shortCount)) // #nosec G115 -- totalEntries is capped above.
@@ -284,14 +268,25 @@ func decodeCmpctBlockPrefix(payload []byte) (cmpctBlockPayload, uint64, uint64, 
 	return out, prefilledCount, totalEntries, shortIDEnd + consumed, nil
 }
 
-func decodeBlockTxnTransaction(payload []byte, totalTxBytes uint64) ([]byte, int, uint64, error) {
-	_, _, _, consumed, err := consensus.ParseTx(payload)
-	if err != nil {
-		return nil, 0, totalTxBytes, err
+func decodeCmpctBlockPrefilled(payload []byte, offset int, entryPos, prev, totalEntries, totalTxBytes uint64) (prefilledTxn, int, uint64, error) {
+	if len(payload[offset:]) < compactRelayIndexBytes {
+		return prefilledTxn{}, 0, totalTxBytes, errors.New("cmpctblock payload truncated prefilled index")
 	}
-	txLen := uint64(consumed) // #nosec G115 -- consumed is non-negative and bounded by len(payload).
-	nextTotal, err := validateBlockTxnTransactionSize(txLen, totalTxBytes)
-	return payload[:consumed], consumed, nextTotal, err
+	idx := uint64(binary.LittleEndian.Uint32(payload[offset:]))
+	offset += compactRelayIndexBytes
+	if (entryPos > 0 && idx <= prev) || idx >= totalEntries {
+		return prefilledTxn{}, 0, totalTxBytes, errors.New("compact relay index out of range")
+	}
+	txLen, n, err := consensus.DecodeCompactSize(payload[offset:])
+	if err != nil {
+		return prefilledTxn{}, 0, totalTxBytes, err
+	}
+	offset += n
+	tx, txConsumed, nextTotal, err := decodeCompactRelayTxEnvelope(payload[offset:], txLen, totalTxBytes, "cmpctblock prefilled transaction is non-canonical")
+	if err != nil {
+		return prefilledTxn{}, 0, totalTxBytes, err
+	}
+	return prefilledTxn{Index: idx, Tx: append([]byte(nil), tx...)}, offset + txConsumed, nextTotal, nil
 }
 
 func validateBlockTxnTransactionSize(txLen, totalTxBytes uint64) (uint64, error) {
@@ -305,6 +300,18 @@ func validateBlockTxnTransactionSize(txLen, totalTxBytes uint64) (uint64, error)
 		return totalTxBytes, errors.New("blocktxn transactions exceed block size")
 	}
 	return totalTxBytes + txLen, nil
+}
+
+func blockTxnPayloadByteLen(transactions [][]byte) (uint64, error) {
+	total := uint64(32 + len(consensus.EncodeCompactSize(uint64(len(transactions)))))
+	for _, tx := range transactions {
+		add := uint64(len(consensus.EncodeCompactSize(uint64(len(tx)))) + len(tx))
+		if add > uint64(consensus.MAX_RELAY_MSG_BYTES)-total {
+			return 0, errors.New("blocktxn payload too large")
+		}
+		total += add
+	}
+	return total, nil
 }
 
 func validateCompactRelayTransactions(transactions [][]byte, nonCanonicalErr string) error {
@@ -323,6 +330,30 @@ func validateCompactRelayTransactions(transactions [][]byte, nonCanonicalErr str
 	return nil
 }
 
+func validateCmpctBlockEntryCount(shortCount, prefilledCount uint64) (uint64, error) {
+	totalEntries := shortCount + prefilledCount
+	if totalEntries < shortCount || totalEntries == 0 || totalEntries > maxCmpctBlockEntries {
+		return 0, errors.New("invalid compact relay entry count")
+	}
+	return totalEntries, nil
+}
+
+func decodeCompactRelayTxEnvelope(payload []byte, txLen, totalTxBytes uint64, nonCanonicalErr string) ([]byte, int, uint64, error) {
+	if txLen > uint64(len(payload)) {
+		return nil, 0, totalTxBytes, errors.New("compact relay transaction truncated")
+	}
+	tx := payload[:int(txLen)] // #nosec G115 -- txLen is bounded by len(payload) above.
+	nextTotal, err := validateBlockTxnTransactionSize(txLen, totalTxBytes)
+	if err != nil {
+		return nil, 0, totalTxBytes, err
+	}
+	_, _, _, consumed, err := consensus.ParseTx(tx)
+	if err != nil || consumed != len(tx) {
+		return nil, 0, totalTxBytes, errors.New(nonCanonicalErr)
+	}
+	return tx, len(tx), nextTotal, nil
+}
+
 func finishCmpctBlockPayload(out cmpctBlockPayload, offset, payloadLen int) (cmpctBlockPayload, error) {
 	if offset != payloadLen {
 		return cmpctBlockPayload{}, errors.New("cmpctblock payload has trailing bytes")
@@ -332,19 +363,21 @@ func finishCmpctBlockPayload(out cmpctBlockPayload, offset, payloadLen int) (cmp
 
 func cmpctBlockPayloadByteLen(shortCount uint64, prefilled []prefilledTxn) (uint64, error) {
 	limit := uint64(consensus.MAX_RELAY_MSG_BYTES)
-	total := uint64(consensus.BLOCK_HEADER_BYTES + 8 + len(consensus.EncodeCompactSize(shortCount)) + len(consensus.EncodeCompactSize(uint64(len(prefilled)))))
+	total := uint64(consensus.BLOCK_HEADER_BYTES + 16 + len(consensus.EncodeCompactSize(shortCount)) + len(consensus.EncodeCompactSize(uint64(len(prefilled)))))
 	if shortCount > (limit-total)/compactShortIDBytes {
 		return 0, errors.New("cmpctblock payload too large")
 	}
 	total += shortCount * compactShortIDBytes
-	totalEntries := shortCount + uint64(len(prefilled))
+	totalEntries, err := validateCmpctBlockEntryCount(shortCount, uint64(len(prefilled)))
+	if err != nil {
+		return 0, err
+	}
 	var prevPlusOne uint64
 	for _, tx := range prefilled {
 		if tx.Index < prevPlusOne || tx.Index >= totalEntries {
 			return 0, errors.New("compact relay index out of range")
 		}
-		delta := tx.Index - prevPlusOne
-		add := uint64(len(consensus.EncodeCompactSize(delta)) + len(tx.Tx))
+		add := uint64(compactRelayIndexBytes + len(consensus.EncodeCompactSize(uint64(len(tx.Tx)))) + len(tx.Tx))
 		if add > limit-total {
 			return 0, errors.New("cmpctblock payload too large")
 		}
@@ -352,21 +385,4 @@ func cmpctBlockPayloadByteLen(shortCount uint64, prefilled []prefilledTxn) (uint
 		prevPlusOne = tx.Index + 1
 	}
 	return total, nil
-}
-
-func getBlockTxnAbsoluteIndex(prev, delta uint64, first bool) (uint64, error) {
-	if first {
-		if delta > maxCompactRelayIndexValue {
-			return 0, errors.New("compact relay index out of range")
-		}
-		return delta, nil
-	}
-	if delta > ^uint64(0)-prev-1 {
-		return 0, errors.New("compact relay index overflow")
-	}
-	idx := prev + delta + 1
-	if idx > maxCompactRelayIndexValue {
-		return 0, errors.New("compact relay index out of range")
-	}
-	return idx, nil
 }

--- a/clients/go/node/p2p/compact_wire.go
+++ b/clients/go/node/p2p/compact_wire.go
@@ -34,6 +34,20 @@ type blockTxnPayload struct {
 	Transactions [][]byte
 }
 
+type compactShortID [compactShortIDBytes]byte
+
+type prefilledTxn struct {
+	Index uint64
+	Tx    []byte
+}
+
+type cmpctBlockPayload struct {
+	Header    [consensus.BLOCK_HEADER_BYTES]byte
+	Nonce     uint64
+	ShortIDs  []compactShortID
+	Prefilled []prefilledTxn
+}
+
 func encodeSendCmpctPayload(p sendCmpctPayload) ([]byte, error) {
 	if p.Mode > 2 {
 		return nil, errors.New("unsupported compact relay mode")
@@ -170,6 +184,100 @@ func decodeBlockTxnPayload(payload []byte) (blockTxnPayload, error) {
 	}
 	out.Transactions = transactions
 	return out, nil
+}
+
+func encodeCmpctBlockPayload(p cmpctBlockPayload) ([]byte, error) {
+	out := make([]byte, 0)
+	out = append(out, p.Header[:]...)
+	out = consensus.AppendU64le(out, p.Nonce)
+	out = consensus.AppendCompactSize(out, uint64(len(p.ShortIDs)))
+	for _, shortID := range p.ShortIDs {
+		out = append(out, shortID[:]...)
+	}
+	out = consensus.AppendCompactSize(out, uint64(len(p.Prefilled)))
+	var prevPlusOne uint64
+	prefilledTxs := make([][]byte, 0, len(p.Prefilled))
+	for _, tx := range p.Prefilled {
+		delta := tx.Index - prevPlusOne
+		out = consensus.AppendCompactSize(out, delta)
+		out = append(out, tx.Tx...)
+		prevPlusOne = tx.Index + 1
+		prefilledTxs = append(prefilledTxs, tx.Tx)
+	}
+	if _, err := encodeBlockTxnPayload(blockTxnPayload{Transactions: prefilledTxs}); err != nil {
+		return nil, err
+	}
+	_, err := decodeCmpctBlockPayload(out)
+	return out, err
+}
+
+func decodeCmpctBlockPayload(payload []byte) (cmpctBlockPayload, error) {
+	out, prefilledCount, totalEntries, offset, err := decodeCmpctBlockPrefix(payload)
+	if err != nil {
+		return cmpctBlockPayload{}, err
+	}
+	out.Prefilled = make([]prefilledTxn, 0, int(prefilledCount)) // #nosec G115 -- totalEntries is capped by decodeCmpctBlockPrefix.
+	var prev uint64
+	var totalTxBytes uint64
+	for i := uint64(0); i < prefilledCount; i++ {
+		delta, n, err := consensus.DecodeCompactSize(payload[offset:])
+		if err != nil {
+			return cmpctBlockPayload{}, err
+		}
+		idx, err := getBlockTxnAbsoluteIndex(prev, delta, i == 0)
+		if err != nil {
+			return cmpctBlockPayload{}, err
+		}
+		if idx >= totalEntries {
+			return cmpctBlockPayload{}, errors.New("compact relay index out of range")
+		}
+		tx, txConsumed, nextTotal, err := decodeBlockTxnTransaction(payload[offset+n:], totalTxBytes)
+		if err != nil {
+			return cmpctBlockPayload{}, err
+		}
+		out.Prefilled = append(out.Prefilled, prefilledTxn{Index: idx, Tx: append([]byte(nil), tx...)})
+		offset += n + txConsumed
+		prev = idx
+		totalTxBytes = nextTotal
+	}
+	if offset != len(payload) {
+		return cmpctBlockPayload{}, errors.New("cmpctblock payload has trailing bytes")
+	}
+	return out, nil
+}
+
+func decodeCmpctBlockPrefix(payload []byte) (cmpctBlockPayload, uint64, uint64, int, error) {
+	var out cmpctBlockPayload
+	if len(payload) < consensus.BLOCK_HEADER_BYTES+8 {
+		return out, 0, 0, 0, errors.New("cmpctblock payload missing header or nonce")
+	}
+	copy(out.Header[:], payload[:consensus.BLOCK_HEADER_BYTES])
+	out.Nonce = binary.LittleEndian.Uint64(payload[consensus.BLOCK_HEADER_BYTES:])
+	offset := consensus.BLOCK_HEADER_BYTES + 8
+	shortCount, consumed, err := consensus.DecodeCompactSize(payload[offset:])
+	if err != nil {
+		return cmpctBlockPayload{}, 0, 0, 0, err
+	}
+	offset += consumed
+	if shortCount > uint64(len(payload[offset:]))/compactShortIDBytes {
+		return cmpctBlockPayload{}, 0, 0, 0, errors.New("cmpctblock payload truncated short IDs")
+	}
+	shortIDEnd := offset + int(shortCount)*compactShortIDBytes // #nosec G115 -- shortCount is bounded by remaining payload width above.
+	prefilledCount, consumed, err := consensus.DecodeCompactSize(payload[shortIDEnd:])
+	if err != nil {
+		return cmpctBlockPayload{}, 0, 0, 0, err
+	}
+	totalEntries := shortCount + prefilledCount
+	if totalEntries > maxCompactRelayEntries || totalEntries < shortCount {
+		return cmpctBlockPayload{}, 0, 0, 0, errors.New("too many compact relay entries")
+	}
+	out.ShortIDs = make([]compactShortID, 0, int(shortCount)) // #nosec G115 -- totalEntries is capped above.
+	for ; offset < shortIDEnd; offset += compactShortIDBytes {
+		var shortID compactShortID
+		copy(shortID[:], payload[offset:offset+compactShortIDBytes])
+		out.ShortIDs = append(out.ShortIDs, shortID)
+	}
+	return out, prefilledCount, totalEntries, shortIDEnd + consumed, nil
 }
 
 func decodeBlockTxnTransaction(payload []byte, totalTxBytes uint64) ([]byte, int, uint64, error) {

--- a/clients/go/node/p2p/compact_wire.go
+++ b/clients/go/node/p2p/compact_wire.go
@@ -34,6 +34,20 @@ type blockTxnPayload struct {
 	Transactions [][]byte
 }
 
+type compactShortID [compactShortIDBytes]byte
+
+type prefilledTxn struct {
+	Index uint64
+	Tx    []byte
+}
+
+type cmpctBlockPayload struct {
+	Header    [consensus.BLOCK_HEADER_BYTES]byte
+	Nonce     uint64
+	ShortIDs  []compactShortID
+	Prefilled []prefilledTxn
+}
+
 func encodeSendCmpctPayload(p sendCmpctPayload) ([]byte, error) {
 	if p.Mode > 2 {
 		return nil, errors.New("unsupported compact relay mode")
@@ -172,6 +186,147 @@ func decodeBlockTxnPayload(payload []byte) (blockTxnPayload, error) {
 	return out, nil
 }
 
+func encodeCmpctBlockPayload(p cmpctBlockPayload) ([]byte, error) {
+	if err := validateCompactRelayEntryCounts(uint64(len(p.ShortIDs)), uint64(len(p.Prefilled))); err != nil {
+		return nil, err
+	}
+	totalTxCount := uint64(len(p.ShortIDs) + len(p.Prefilled))
+	capHint := consensus.BLOCK_HEADER_BYTES + 8 + 2*maxCompactSizeBytes + len(p.ShortIDs)*compactShortIDBytes + len(p.Prefilled)*maxCompactSizeBytes
+	out := make([]byte, 0, capHint)
+	out = append(out, p.Header[:]...)
+	out = consensus.AppendU64le(out, p.Nonce)
+	out = consensus.AppendCompactSize(out, uint64(len(p.ShortIDs)))
+	for _, shortID := range p.ShortIDs {
+		out = append(out, shortID[:]...)
+	}
+	out = consensus.AppendCompactSize(out, uint64(len(p.Prefilled)))
+	return appendEncodedPrefilledTransactions(out, p.Prefilled, totalTxCount)
+}
+
+func appendEncodedPrefilledTransactions(out []byte, prefilled []prefilledTxn, totalTxCount uint64) ([]byte, error) {
+	var prev uint64
+	var totalTxBytes uint64
+	for i, tx := range prefilled {
+		delta, err := compactRelayIndexDelta(prev, tx.Index, i == 0)
+		if err != nil {
+			return nil, err
+		}
+		if err := validateCompactRelayIndexInVector(tx.Index, totalTxCount); err != nil {
+			return nil, err
+		}
+		nextTotal, err := validateBlockTxnTransactionSize(uint64(len(tx.Tx)), totalTxBytes)
+		if err != nil {
+			return nil, err
+		}
+		_, _, _, consumed, err := consensus.ParseTx(tx.Tx)
+		if err != nil || consumed != len(tx.Tx) {
+			return nil, errors.New("cmpctblock prefilled transaction is non-canonical")
+		}
+		out = consensus.AppendCompactSize(out, delta)
+		out = append(out, tx.Tx...)
+		prev = tx.Index
+		totalTxBytes = nextTotal
+	}
+	return out, nil
+}
+
+func decodeCmpctBlockPayload(payload []byte) (cmpctBlockPayload, error) {
+	var out cmpctBlockPayload
+	if len(payload) < consensus.BLOCK_HEADER_BYTES+8 {
+		return out, errors.New("cmpctblock payload missing header or nonce")
+	}
+	copy(out.Header[:], payload[:consensus.BLOCK_HEADER_BYTES])
+	out.Nonce = binary.LittleEndian.Uint64(payload[consensus.BLOCK_HEADER_BYTES:])
+	offset := consensus.BLOCK_HEADER_BYTES + 8
+	shortCount, consumed, err := consensus.DecodeCompactSize(payload[offset:])
+	if err != nil {
+		return cmpctBlockPayload{}, err
+	}
+	offset += consumed
+	shortIDOffset := offset
+	shortIDBytes, err := compactShortIDPayloadBytes(payload[offset:], shortCount)
+	if err != nil {
+		return cmpctBlockPayload{}, err
+	}
+	shortIDEnd := offset + shortIDBytes
+	prefilledCount, consumed, err := consensus.DecodeCompactSize(payload[shortIDEnd:])
+	if err != nil {
+		return cmpctBlockPayload{}, err
+	}
+	offset = shortIDEnd + consumed
+	if err := validateCompactRelayEntryCounts(shortCount, prefilledCount); err != nil {
+		return cmpctBlockPayload{}, err
+	}
+	out.ShortIDs = decodeCompactShortIDs(payload[shortIDOffset:shortIDEnd], shortCount)
+	out.Prefilled, consumed, err = decodePrefilledTransactions(payload[offset:], prefilledCount, shortCount+prefilledCount)
+	if err != nil {
+		return cmpctBlockPayload{}, err
+	}
+	offset += consumed
+	if offset != len(payload) {
+		return cmpctBlockPayload{}, errors.New("cmpctblock payload has trailing bytes")
+	}
+	return out, nil
+}
+
+func compactShortIDPayloadBytes(payload []byte, count uint64) (int, error) {
+	if count > maxCompactRelayEntries {
+		return 0, errors.New("too many compact relay short IDs")
+	}
+	needed := int(count) * compactShortIDBytes // #nosec G115 -- count is capped at maxCompactRelayEntries above.
+	if len(payload) < needed {
+		return 0, errors.New("cmpctblock payload truncated short IDs")
+	}
+	return needed, nil
+}
+
+func decodeCompactShortIDs(payload []byte, count uint64) []compactShortID {
+	shortIDs := make([]compactShortID, 0, int(count)) // #nosec G115 -- count is capped at maxCompactRelayEntries above.
+	for offset := 0; offset < len(payload); offset += compactShortIDBytes {
+		var shortID compactShortID
+		copy(shortID[:], payload[offset:offset+compactShortIDBytes])
+		shortIDs = append(shortIDs, shortID)
+	}
+	return shortIDs
+}
+
+func decodePrefilledTransactions(payload []byte, count, totalTxCount uint64) ([]prefilledTxn, int, error) {
+	prefilled := make([]prefilledTxn, 0, int(count)) // #nosec G115 -- count is aggregate-capped before this helper is called.
+	var offset int
+	var prev uint64
+	var totalTxBytes uint64
+	for i := uint64(0); i < count; i++ {
+		tx, consumed, nextPrev, nextTotal, err := decodePrefilledTransaction(payload[offset:], prev, totalTxCount, totalTxBytes, i == 0)
+		if err != nil {
+			return nil, 0, err
+		}
+		prefilled = append(prefilled, tx)
+		offset += consumed
+		prev = nextPrev
+		totalTxBytes = nextTotal
+	}
+	return prefilled, offset, nil
+}
+
+func decodePrefilledTransaction(payload []byte, prev, totalTxCount, totalTxBytes uint64, first bool) (prefilledTxn, int, uint64, uint64, error) {
+	delta, consumed, err := consensus.DecodeCompactSize(payload)
+	if err != nil {
+		return prefilledTxn{}, 0, prev, totalTxBytes, err
+	}
+	idx, err := getBlockTxnAbsoluteIndex(prev, delta, first)
+	if err != nil {
+		return prefilledTxn{}, 0, prev, totalTxBytes, err
+	}
+	if err := validateCompactRelayIndexInVector(idx, totalTxCount); err != nil {
+		return prefilledTxn{}, 0, prev, totalTxBytes, err
+	}
+	tx, txConsumed, nextTotal, err := decodeBlockTxnTransaction(payload[consumed:], totalTxBytes)
+	if err != nil {
+		return prefilledTxn{}, 0, prev, totalTxBytes, err
+	}
+	return prefilledTxn{Index: idx, Tx: append([]byte(nil), tx...)}, consumed + txConsumed, idx, nextTotal, nil
+}
+
 func decodeBlockTxnTransaction(payload []byte, totalTxBytes uint64) ([]byte, int, uint64, error) {
 	_, _, _, consumed, err := consensus.ParseTx(payload)
 	if err != nil {
@@ -193,6 +348,36 @@ func validateBlockTxnTransactionSize(txLen, totalTxBytes uint64) (uint64, error)
 		return totalTxBytes, errors.New("blocktxn transactions exceed block size")
 	}
 	return totalTxBytes + txLen, nil
+}
+
+func validateCompactRelayEntryCounts(shortCount, prefilledCount uint64) error {
+	if shortCount > maxCompactRelayEntries || prefilledCount > maxCompactRelayEntries {
+		return errors.New("too many compact relay entries")
+	}
+	if shortCount > maxCompactRelayEntries-prefilledCount {
+		return errors.New("too many compact relay entries")
+	}
+	return nil
+}
+
+func validateCompactRelayIndexInVector(idx, totalTxCount uint64) error {
+	if idx >= totalTxCount {
+		return errors.New("compact relay index out of range")
+	}
+	return nil
+}
+
+func compactRelayIndexDelta(prev, idx uint64, first bool) (uint64, error) {
+	if idx > maxCompactRelayIndexValue {
+		return 0, errors.New("compact relay index out of range")
+	}
+	if first {
+		return idx, nil
+	}
+	if idx <= prev {
+		return 0, errors.New("compact relay indexes not strictly increasing")
+	}
+	return idx - prev - 1, nil
 }
 
 func getBlockTxnAbsoluteIndex(prev, delta uint64, first bool) (uint64, error) {

--- a/clients/go/node/p2p/compact_wire.go
+++ b/clients/go/node/p2p/compact_wire.go
@@ -8,16 +8,16 @@ import (
 )
 
 const (
-	messageSendCmpct                   = "sendcmpct"
-	messageCmpctBlock                  = "cmpctblock"
-	messageGetBlockTxn                 = "getblocktxn"
-	messageBlockTxn                    = "blocktxn"
-	compactRelayVersion         uint64 = 1
-	sendCmpctPayloadBytes              = 9
-	compactShortIDBytes                = 6
-	maxCompactRelayEntries             = maxInventoryVectors
-	maxCompactBlockTransactions        = consensus.MAX_BLOCK_BYTES
-	maxCompactRelayIndexValue          = consensus.MAX_BLOCK_BYTES - 1
+	messageSendCmpct                 = "sendcmpct"
+	messageCmpctBlock                = "cmpctblock"
+	messageGetBlockTxn               = "getblocktxn"
+	messageBlockTxn                  = "blocktxn"
+	compactRelayVersion       uint64 = 1
+	sendCmpctPayloadBytes            = 9
+	compactShortIDBytes              = 6
+	maxCompactRelayEntries           = maxInventoryVectors
+	maxCmpctBlockEntries             = consensus.MAX_BLOCK_BYTES
+	maxCompactRelayIndexValue        = consensus.MAX_BLOCK_BYTES - 1
 )
 
 type sendCmpctPayload struct {
@@ -183,8 +183,12 @@ func decodeBlockTxnPayload(payload []byte) (blockTxnPayload, error) {
 }
 
 func encodeCmpctBlockPayload(p cmpctBlockPayload) ([]byte, error) {
-	if len(p.ShortIDs) > maxCompactBlockTransactions-len(p.Prefilled) {
+	if len(p.ShortIDs) > maxCmpctBlockEntries-len(p.Prefilled) {
 		return nil, errors.New("too many compact block transactions")
+	}
+	capHint, err := cmpctBlockPayloadByteLen(uint64(len(p.ShortIDs)), p.Prefilled)
+	if err != nil {
+		return nil, err
 	}
 	prefilledTxs := make([][]byte, 0, len(p.Prefilled))
 	for _, tx := range p.Prefilled {
@@ -193,7 +197,7 @@ func encodeCmpctBlockPayload(p cmpctBlockPayload) ([]byte, error) {
 	if err := validateCompactRelayTransactions(prefilledTxs, "cmpctblock prefilled transaction is non-canonical"); err != nil {
 		return nil, err
 	}
-	out := make([]byte, 0)
+	out := make([]byte, 0, int(capHint)) // #nosec G115 -- cmpctBlockPayloadByteLen caps capHint at MAX_RELAY_MSG_BYTES.
 	out = append(out, p.Header[:]...)
 	out = consensus.AppendU64le(out, p.Nonce)
 	out = consensus.AppendCompactSize(out, uint64(len(p.ShortIDs)))
@@ -208,11 +212,14 @@ func encodeCmpctBlockPayload(p cmpctBlockPayload) ([]byte, error) {
 		out = append(out, tx.Tx...)
 		prevPlusOne = tx.Index + 1
 	}
-	_, err := decodeCmpctBlockPayload(out)
+	_, err = decodeCmpctBlockPayload(out)
 	return out, err
 }
 
 func decodeCmpctBlockPayload(payload []byte) (cmpctBlockPayload, error) {
+	if len(payload) > consensus.MAX_RELAY_MSG_BYTES {
+		return cmpctBlockPayload{}, errors.New("cmpctblock payload too large")
+	}
 	out, prefilledCount, totalEntries, offset, err := decodeCmpctBlockPrefix(payload)
 	if err != nil {
 		return cmpctBlockPayload{}, err
@@ -240,10 +247,7 @@ func decodeCmpctBlockPayload(payload []byte) (cmpctBlockPayload, error) {
 		prev = idx
 		totalTxBytes = nextTotal
 	}
-	if offset != len(payload) {
-		return cmpctBlockPayload{}, errors.New("cmpctblock payload has trailing bytes")
-	}
-	return out, nil
+	return finishCmpctBlockPayload(out, offset, len(payload))
 }
 
 func decodeCmpctBlockPrefix(payload []byte) (cmpctBlockPayload, uint64, uint64, int, error) {
@@ -268,8 +272,8 @@ func decodeCmpctBlockPrefix(payload []byte) (cmpctBlockPayload, uint64, uint64, 
 		return cmpctBlockPayload{}, 0, 0, 0, err
 	}
 	totalEntries := shortCount + prefilledCount
-	if totalEntries > maxCompactBlockTransactions || totalEntries < shortCount {
-		return cmpctBlockPayload{}, 0, 0, 0, errors.New("too many compact relay entries")
+	if totalEntries-1 >= maxCmpctBlockEntries || totalEntries < shortCount {
+		return cmpctBlockPayload{}, 0, 0, 0, errors.New("invalid compact relay entry count")
 	}
 	out.ShortIDs = make([]compactShortID, 0, int(shortCount)) // #nosec G115 -- totalEntries is capped above.
 	for ; offset < shortIDEnd; offset += compactShortIDBytes {
@@ -317,6 +321,37 @@ func validateCompactRelayTransactions(transactions [][]byte, nonCanonicalErr str
 		totalTxBytes = nextTotal
 	}
 	return nil
+}
+
+func finishCmpctBlockPayload(out cmpctBlockPayload, offset, payloadLen int) (cmpctBlockPayload, error) {
+	if offset != payloadLen {
+		return cmpctBlockPayload{}, errors.New("cmpctblock payload has trailing bytes")
+	}
+	return out, nil
+}
+
+func cmpctBlockPayloadByteLen(shortCount uint64, prefilled []prefilledTxn) (uint64, error) {
+	limit := uint64(consensus.MAX_RELAY_MSG_BYTES)
+	total := uint64(consensus.BLOCK_HEADER_BYTES + 8 + len(consensus.EncodeCompactSize(shortCount)) + len(consensus.EncodeCompactSize(uint64(len(prefilled)))))
+	if shortCount > (limit-total)/compactShortIDBytes {
+		return 0, errors.New("cmpctblock payload too large")
+	}
+	total += shortCount * compactShortIDBytes
+	totalEntries := shortCount + uint64(len(prefilled))
+	var prevPlusOne uint64
+	for _, tx := range prefilled {
+		if tx.Index < prevPlusOne || tx.Index >= totalEntries {
+			return 0, errors.New("compact relay index out of range")
+		}
+		delta := tx.Index - prevPlusOne
+		add := uint64(len(consensus.EncodeCompactSize(delta)) + len(tx.Tx))
+		if add > limit-total {
+			return 0, errors.New("cmpctblock payload too large")
+		}
+		total += add
+		prevPlusOne = tx.Index + 1
+	}
+	return total, nil
 }
 
 func getBlockTxnAbsoluteIndex(prev, delta uint64, first bool) (uint64, error) {

--- a/clients/go/node/p2p/compact_wire_test.go
+++ b/clients/go/node/p2p/compact_wire_test.go
@@ -13,7 +13,7 @@ func TestCompactWireCommandConstantsAndPayloadCaps(t *testing.T) {
 	commands := []string{messageSendCmpct, messageGetBlockTxn, messageCmpctBlock, messageBlockTxn}
 	caps := []uint32{
 		sendCmpctPayloadBytes,
-		uint32(32 + maxCompactSizeBytes + maxCompactRelayEntries*maxCompactSizeBytes),
+		uint32(32 + maxCompactSizeBytes + maxCompactRelayEntries*compactRelayIndexBytes),
 		uint32(consensus.MAX_RELAY_MSG_BYTES),
 		uint32(consensus.MAX_BLOCK_BYTES + 32 + maxCompactSizeBytes + maxCompactRelayEntries*maxCompactSizeBytes),
 	}
@@ -42,8 +42,9 @@ func TestGetBlockTxnPayloadCodec(t *testing.T) {
 	if err != nil {
 		t.Fatalf("encodeGetBlockTxnPayload: %v", err)
 	}
-	if gotDeltas := raw[32:]; !reflect.DeepEqual(gotDeltas, []byte{3, 0, 1, 2}) {
-		t.Fatalf("getblocktxn differential indexes=%x, want 03000102", gotDeltas)
+	wantWire := []byte{3, 0, 0, 0, 0, 2, 0, 0, 0, 5, 0, 0, 0}
+	if gotWire := raw[32:]; !reflect.DeepEqual(gotWire, wantWire) {
+		t.Fatalf("getblocktxn absolute index wire=%x, want %x", gotWire, wantWire)
 	}
 	got, err := decodeGetBlockTxnPayload(raw)
 	if err != nil {
@@ -65,8 +66,8 @@ func TestBlockTxnPayloadCodec(t *testing.T) {
 	if err != nil {
 		t.Fatalf("encodeBlockTxnPayload: %v", err)
 	}
-	wantEntries := append(consensus.AppendCompactSize(nil, 2), tx1...)
-	wantEntries = append(wantEntries, tx2...)
+	wantEntries := append(consensus.AppendCompactSize(nil, 2), cmpctBlockTxEnvelope(tx1)...)
+	wantEntries = append(wantEntries, cmpctBlockTxEnvelope(tx2)...)
 	if gotEntries := raw[32:]; !reflect.DeepEqual(gotEntries, wantEntries) {
 		t.Fatalf("blocktxn entries=%x, want %x", gotEntries, wantEntries)
 	}
@@ -80,15 +81,29 @@ func TestBlockTxnPayloadCodec(t *testing.T) {
 }
 
 func TestCmpctBlockPayloadCodec(t *testing.T) {
+	tx := minimalBlockTxnTestTxBytes(10)
 	want := cmpctBlockPayload{
 		Header:    [consensus.BLOCK_HEADER_BYTES]byte{0x01, 0x02, 0x03},
-		Nonce:     0x1122334455667788,
+		Nonce1:    0x1122334455667788,
+		Nonce2:    0x8877665544332211,
 		ShortIDs:  []compactShortID{{0x01, 0x02, 0x03, 0x04, 0x05, 0x06}},
-		Prefilled: []prefilledTxn{{Index: 0, Tx: minimalBlockTxnTestTxBytes(10)}},
+		Prefilled: []prefilledTxn{{Index: 1, Tx: tx}},
 	}
 	raw, err := encodeCmpctBlockPayload(want)
 	if err != nil {
 		t.Fatalf("encodeCmpctBlockPayload: %v", err)
+	}
+	wantRaw := append([]byte(nil), want.Header[:]...)
+	wantRaw = consensus.AppendU64le(wantRaw, want.Nonce1)
+	wantRaw = consensus.AppendU64le(wantRaw, want.Nonce2)
+	wantRaw = consensus.AppendCompactSize(wantRaw, uint64(len(want.ShortIDs)))
+	wantRaw = append(wantRaw, want.ShortIDs[0][:]...)
+	wantRaw = consensus.AppendCompactSize(wantRaw, uint64(len(want.Prefilled)))
+	wantRaw = consensus.AppendU32le(wantRaw, uint32(want.Prefilled[0].Index))
+	wantRaw = consensus.AppendCompactSize(wantRaw, uint64(len(tx)))
+	wantRaw = append(wantRaw, tx...)
+	if !reflect.DeepEqual(raw, wantRaw) {
+		t.Fatalf("cmpctblock wire layout=%x, want %x", raw, wantRaw)
 	}
 	got, err := decodeCmpctBlockPayload(raw)
 	if err != nil {
@@ -117,15 +132,24 @@ func TestCmpctBlockPayloadRejectsMalformed(t *testing.T) {
 	assertCmpctBlockEncodeFails(t, "trailing_prefilled_tx", cmpctBlockPayload{Prefilled: []prefilledTxn{{Tx: append(validTx, 0x00)}}}, "cmpctblock prefilled transaction is non-canonical")
 	assertCmpctBlockEncodeFails(t, "trailing_prefilled_tx_before_next_delta", cmpctBlockPayload{Prefilled: []prefilledTxn{{Index: 0, Tx: append(validTx, 0x00)}, {Index: 1, Tx: validTx}}}, "cmpctblock prefilled transaction is non-canonical")
 
-	assertCmpctBlockDecodeFails(t, "short_header", make([]byte, consensus.BLOCK_HEADER_BYTES+7), "cmpctblock payload missing header or nonce")
+	assertCmpctBlockDecodeFails(t, "short_header", make([]byte, consensus.BLOCK_HEADER_BYTES+15), "cmpctblock payload missing header or nonce")
 	assertCmpctBlockDecodeFails(t, "empty", cmpctBlockTestPayload([]byte{0, 0}), "invalid compact relay entry count")
 	assertCmpctBlockDecodeFails(t, "payload_above_wire_cap", make([]byte, consensus.MAX_RELAY_MSG_BYTES+1), "cmpctblock payload too large")
 	assertCmpctBlockDecodeFails(t, "nonminimal_short_count", cmpctBlockTestPayload([]byte{0xfd, 0x00, 0x00}), "non-minimal")
 	assertCmpctBlockDecodeFails(t, "truncated_short_ids", cmpctBlockTestPayload([]byte{1, 0x01, 0x02}), "cmpctblock payload truncated short IDs")
 	assertCmpctBlockDecodeFails(t, "nonminimal_prefilled_count", cmpctBlockTestPayload([]byte{0, 0xfd, 0x00, 0x00}), "non-minimal")
-	assertCmpctBlockDecodeFails(t, "huge_prefilled_count_without_entries", cmpctBlockTestPayload(consensus.AppendCompactSize([]byte{0}, consensus.MAX_BLOCK_BYTES)), "EOF")
+	assertCmpctBlockDecodeFails(t, "huge_prefilled_count_without_entries", cmpctBlockTestPayload(consensus.AppendCompactSize([]byte{0}, consensus.MAX_BLOCK_BYTES)), "cmpctblock payload truncated prefilled index")
+	assertCmpctBlockDecodeFails(t, "truncated_prefilled_index", cmpctBlockTestPayload([]byte{0, 1, 0x01, 0x02}), "cmpctblock payload truncated prefilled index")
+	assertCmpctBlockDecodeFails(t, "truncated_prefilled_tx", cmpctBlockTestPayload(cmpctBlockPrefilledPayload(0, append(consensus.AppendCompactSize(nil, uint64(len(validTx)+1)), validTx...))), "compact relay transaction truncated")
+	duplicatePrefilled := consensus.AppendCompactSize(nil, 0)
+	duplicatePrefilled = consensus.AppendCompactSize(duplicatePrefilled, 2)
+	duplicatePrefilled = consensus.AppendU32le(duplicatePrefilled, 0)
+	duplicatePrefilled = append(duplicatePrefilled, cmpctBlockTxEnvelope(validTx)...)
+	duplicatePrefilled = consensus.AppendU32le(duplicatePrefilled, 0)
+	duplicatePrefilled = append(duplicatePrefilled, cmpctBlockTxEnvelope(validTx)...)
+	assertCmpctBlockDecodeFails(t, "duplicate_prefilled_index", cmpctBlockTestPayload(duplicatePrefilled), "compact relay index out of range")
 
-	rangeBeforeTx := consensus.AppendCompactSize(consensus.AppendCompactSize(consensus.AppendCompactSize(nil, 0), 1), 1)
+	rangeBeforeTx := consensus.AppendU32le(consensus.AppendCompactSize(consensus.AppendCompactSize(nil, 0), 1), 1)
 	assertCmpctBlockDecodeFails(t, "prefilled_index_range_before_tx", cmpctBlockTestPayload(rangeBeforeTx), "compact relay index out of range")
 	assertCmpctBlockDecodeFails(t, "trailing", append(cmpctBlockTestPayload([]byte{1, 0, 0, 0, 0, 0, 0, 0}), 0x00), "cmpctblock payload has trailing bytes")
 }
@@ -162,8 +186,10 @@ func TestBlockTxnPayloadRejectsMalformed(t *testing.T) {
 		{name: "short_hash", raw: make([]byte, 31), wantErr: "blocktxn payload missing block hash"},
 		{name: "nonminimal_count", raw: blockTxnTestPayload([]byte{0xfd, 0x00, 0x00}), wantErr: "non-minimal"},
 		{name: "count_too_large", raw: blockTxnTestPayload(consensus.AppendCompactSize(nil, maxCompactRelayEntries+1)), wantErr: "too many compact relay transactions"},
-		{name: "empty_tx", raw: blockTxnTestPayload([]byte{1}), wantErr: "unexpected EOF"},
-		{name: "truncated_tx", raw: blockTxnTestPayload([]byte{1, 1}), wantErr: "unexpected EOF"},
+		{name: "missing_tx_len", raw: blockTxnTestPayload([]byte{1}), wantErr: "EOF"},
+		{name: "empty_tx", raw: blockTxnTestPayload([]byte{1, 0}), wantErr: "blocktxn transaction is empty"},
+		{name: "truncated_tx", raw: blockTxnTestPayload(append(consensus.AppendCompactSize([]byte{1}, uint64(len(minimalBlockTxnTestTxBytes(5)))), minimalBlockTxnTestTxBytes(5)[:3]...)), wantErr: "compact relay transaction truncated"},
+		{name: "raw_concatenated_txbytes", raw: blockTxnTestPayload(append(consensus.AppendCompactSize(nil, 2), minimalBlockTxnTestTxBytes(5)...)), wantErr: "blocktxn transaction is non-canonical"},
 		{name: "trailing", raw: append(mustEncodeBlockTxnPayload(t, [][]byte{minimalBlockTxnTestTxBytes(4)}), 0x00), wantErr: "blocktxn payload has trailing bytes"},
 	} {
 		_, err := decodeBlockTxnPayload(tc.raw)
@@ -224,11 +250,23 @@ func assertCmpctBlockDecodeFails(t *testing.T, name string, raw []byte, wantErr 
 }
 
 func cmpctBlockTestPayload(tail []byte) []byte {
-	return append(make([]byte, consensus.BLOCK_HEADER_BYTES+8), tail...)
+	return append(make([]byte, consensus.BLOCK_HEADER_BYTES+16), tail...)
+}
+
+func cmpctBlockPrefilledPayload(index uint32, entry []byte) []byte {
+	tail := consensus.AppendCompactSize(nil, 0)
+	tail = consensus.AppendCompactSize(tail, 1)
+	tail = consensus.AppendU32le(tail, index)
+	return append(tail, entry...)
+}
+
+func cmpctBlockTxEnvelope(tx []byte) []byte {
+	out := consensus.AppendCompactSize(nil, uint64(len(tx)))
+	return append(out, tx...)
 }
 
 func TestGetBlockTxnPayloadAllowsIndexesAboveRequestCountCap(t *testing.T) {
-	want := getBlockTxnPayload{Indexes: []uint64{0, maxCompactRelayEntries, maxCompactRelayEntries + 2}}
+	want := getBlockTxnPayload{Indexes: []uint64{maxCompactRelayEntries + 2, 0, 0, maxCompactRelayEntries}}
 	raw, err := encodeGetBlockTxnPayload(want)
 	if err != nil {
 		t.Fatalf("encodeGetBlockTxnPayload: %v", err)
@@ -247,8 +285,6 @@ func TestGetBlockTxnPayloadRejectsMalformed(t *testing.T) {
 		name string
 		in   getBlockTxnPayload
 	}{
-		{name: "duplicate", in: getBlockTxnPayload{Indexes: []uint64{1, 1}}},
-		{name: "descending", in: getBlockTxnPayload{Indexes: []uint64{2, 1}}},
 		{name: "range", in: getBlockTxnPayload{Indexes: []uint64{maxCompactRelayIndexValue + 1}}},
 		{name: "max", in: getBlockTxnPayload{Indexes: []uint64{^uint64(0)}}},
 	} {
@@ -264,11 +300,8 @@ func TestGetBlockTxnPayloadRejectsMalformed(t *testing.T) {
 		{name: "short_hash", raw: make([]byte, 31)},
 		{name: "nonminimal", raw: getBlockTxnTestPayload([]byte{0xfd, 0x00, 0x00})},
 		{name: "count_too_large", raw: getBlockTxnTestPayload(consensus.AppendCompactSize(nil, maxCompactRelayEntries+1))},
-		{name: "truncated_index", raw: getBlockTxnTestPayload([]byte{1, 0xfd})},
+		{name: "truncated_index", raw: getBlockTxnTestPayload([]byte{1, 0x01, 0x00, 0x00})},
 		{name: "range", raw: getBlockTxnIndexedPayload(maxCompactRelayIndexValue + 1)},
-		{name: "max", raw: getBlockTxnIndexedPayload(^uint64(0))},
-		{name: "range_after_first", raw: getBlockTxnIndexedPayload(0, maxCompactRelayIndexValue)},
-		{name: "overflow_after_first", raw: getBlockTxnIndexedPayload(0, ^uint64(0))},
 		{name: "trailing", raw: append(mustEncodeGetBlockTxnPayload(t, []uint64{0}), 0x00)},
 	} {
 		if _, err := decodeGetBlockTxnPayload(tc.raw); err == nil {
@@ -281,10 +314,10 @@ func getBlockTxnTestPayload(tail []byte) []byte {
 	return append(make([]byte, 32), tail...)
 }
 
-func getBlockTxnIndexedPayload(deltas ...uint64) []byte {
-	tail := consensus.AppendCompactSize(nil, uint64(len(deltas)))
-	for _, delta := range deltas {
-		tail = consensus.AppendCompactSize(tail, delta)
+func getBlockTxnIndexedPayload(indexes ...uint64) []byte {
+	tail := consensus.AppendCompactSize(nil, uint64(len(indexes)))
+	for _, idx := range indexes {
+		tail = consensus.AppendU32le(tail, uint32(idx))
 	}
 	return getBlockTxnTestPayload(tail)
 }

--- a/clients/go/node/p2p/compact_wire_test.go
+++ b/clients/go/node/p2p/compact_wire_test.go
@@ -79,6 +79,63 @@ func TestBlockTxnPayloadCodec(t *testing.T) {
 	}
 }
 
+func TestCmpctBlockPayloadCodec(t *testing.T) {
+	tx1 := minimalBlockTxnTestTxBytes(10)
+	tx2 := minimalBlockTxnTestTxBytes(11)
+	want := cmpctBlockPayload{
+		Header: [consensus.BLOCK_HEADER_BYTES]byte{0x01, 0x02, 0x03},
+		Nonce:  0x1122334455667788,
+		ShortIDs: []compactShortID{
+			{0x01, 0x02, 0x03, 0x04, 0x05, 0x06},
+			{0x11, 0x12, 0x13, 0x14, 0x15, 0x16},
+		},
+		Prefilled: []prefilledTxn{
+			{Index: 0, Tx: tx1},
+			{Index: 3, Tx: tx2},
+		},
+	}
+	raw, err := encodeCmpctBlockPayload(want)
+	if err != nil {
+		t.Fatalf("encodeCmpctBlockPayload: %v", err)
+	}
+	got, err := decodeCmpctBlockPayload(raw)
+	if err != nil {
+		t.Fatalf("decodeCmpctBlockPayload: %v", err)
+	}
+	if got.Header != want.Header || got.Nonce != want.Nonce || !reflect.DeepEqual(got.ShortIDs, want.ShortIDs) || !reflect.DeepEqual(got.Prefilled, want.Prefilled) {
+		t.Fatalf("cmpctblock roundtrip got=%+v want=%+v", got, want)
+	}
+}
+
+func TestCmpctBlockPayloadRejectsMalformed(t *testing.T) {
+	validTx := minimalBlockTxnTestTxBytes(12)
+	tooManyShortIDs := make([]compactShortID, maxCompactRelayEntries+1)
+	tooManyPrefilled := make([]prefilledTxn, maxCompactRelayEntries+1)
+	for i := range tooManyPrefilled {
+		tooManyPrefilled[i] = prefilledTxn{Index: uint64(i), Tx: validTx}
+	}
+	assertCmpctBlockEncodeFails(t, "too_many_short_ids", cmpctBlockPayload{ShortIDs: tooManyShortIDs}, "too many compact relay entries")
+	assertCmpctBlockEncodeFails(t, "too_many_prefilled", cmpctBlockPayload{Prefilled: tooManyPrefilled}, "too many compact relay entries")
+	assertCmpctBlockEncodeFails(t, "duplicate_prefilled", cmpctBlockPayload{Prefilled: []prefilledTxn{{Index: 1, Tx: validTx}, {Index: 1, Tx: validTx}}}, "compact relay indexes not strictly increasing")
+	assertCmpctBlockEncodeFails(t, "prefilled_index_outside_vector", cmpctBlockPayload{Prefilled: []prefilledTxn{{Index: 1, Tx: validTx}}}, "compact relay index out of range")
+	assertCmpctBlockEncodeFails(t, "prefilled_index_range", cmpctBlockPayload{Prefilled: []prefilledTxn{{Index: maxCompactRelayIndexValue + 1, Tx: validTx}}}, "compact relay index out of range")
+	assertCmpctBlockEncodeFails(t, "empty_prefilled_tx", cmpctBlockPayload{Prefilled: []prefilledTxn{{Tx: nil}}}, "blocktxn transaction is empty")
+	assertCmpctBlockEncodeFails(t, "trailing_prefilled_tx", cmpctBlockPayload{Prefilled: []prefilledTxn{{Tx: append(validTx, 0x00)}}}, "cmpctblock prefilled transaction is non-canonical")
+
+	assertCmpctBlockDecodeFails(t, "short_header", make([]byte, consensus.BLOCK_HEADER_BYTES+7), "cmpctblock payload missing header or nonce")
+	assertCmpctBlockDecodeFails(t, "nonminimal_short_count", cmpctBlockTestPayload([]byte{0xfd, 0x00, 0x00}), "non-minimal")
+	assertCmpctBlockDecodeFails(t, "too_many_short_ids", cmpctBlockTestPayload(consensus.AppendCompactSize(nil, maxCompactRelayEntries+1)), "too many compact relay short IDs")
+	assertCmpctBlockDecodeFails(t, "truncated_short_ids", cmpctBlockTestPayload([]byte{1, 0x01, 0x02}), "cmpctblock payload truncated short IDs")
+	assertCmpctBlockDecodeFails(t, "nonminimal_prefilled_count", cmpctBlockTestPayload([]byte{0, 0xfd, 0x00, 0x00}), "non-minimal")
+	aggregate := consensus.AppendCompactSize(append(consensus.AppendCompactSize(nil, maxCompactRelayEntries), make([]byte, maxCompactRelayEntries*compactShortIDBytes)...), 1)
+	assertCmpctBlockDecodeFails(t, "aggregate_count", cmpctBlockTestPayload(aggregate), "too many compact relay entries")
+
+	rangeBeforeTx := consensus.AppendCompactSize(consensus.AppendCompactSize(consensus.AppendCompactSize(nil, 0), 1), 1)
+	rangeBeforeTx = append(rangeBeforeTx, make([]byte, consensus.MAX_BLOCK_BYTES)...)
+	assertCmpctBlockDecodeFails(t, "prefilled_index_range_before_tx", cmpctBlockTestPayload(rangeBeforeTx), "compact relay index out of range")
+	assertCmpctBlockDecodeFails(t, "trailing", append(cmpctBlockTestPayload([]byte{0, 0}), 0x00), "cmpctblock payload has trailing bytes")
+}
+
 func TestBlockTxnPayloadRejectsMalformed(t *testing.T) {
 	tooMany := make([][]byte, maxCompactRelayEntries+1)
 	tooLarge := make([]byte, consensus.MAX_BLOCK_BYTES+1)
@@ -148,6 +205,33 @@ func mustEncodeBlockTxnPayload(t *testing.T, txs [][]byte) []byte {
 		t.Fatalf("encodeBlockTxnPayload: %v", err)
 	}
 	return raw
+}
+
+func assertCmpctBlockEncodeFails(t *testing.T, name string, in cmpctBlockPayload, wantErr string) {
+	t.Helper()
+	_, err := encodeCmpctBlockPayload(in)
+	if err == nil {
+		t.Fatalf("%s: expected encode failure", name)
+	}
+	if !strings.Contains(err.Error(), wantErr) {
+		t.Fatalf("%s: encode error=%q, want %q", name, err, wantErr)
+	}
+}
+
+func assertCmpctBlockDecodeFails(t *testing.T, name string, raw []byte, wantErr string) {
+	t.Helper()
+	_, err := decodeCmpctBlockPayload(raw)
+	if err == nil {
+		t.Fatalf("%s: expected decode failure", name)
+	}
+	if !strings.Contains(err.Error(), wantErr) {
+		t.Fatalf("%s: decode error=%q, want %q", name, err, wantErr)
+	}
+}
+
+func cmpctBlockTestPayload(tail []byte) []byte {
+	head := make([]byte, consensus.BLOCK_HEADER_BYTES+8)
+	return append(head, tail...)
 }
 
 func TestGetBlockTxnPayloadAllowsIndexesAboveRequestCountCap(t *testing.T) {

--- a/clients/go/node/p2p/compact_wire_test.go
+++ b/clients/go/node/p2p/compact_wire_test.go
@@ -79,6 +79,67 @@ func TestBlockTxnPayloadCodec(t *testing.T) {
 	}
 }
 
+func TestCmpctBlockPayloadCodec(t *testing.T) {
+	tx1 := minimalBlockTxnTestTxBytes(10)
+	tx2 := minimalBlockTxnTestTxBytes(11)
+	want := cmpctBlockPayload{
+		Header: [consensus.BLOCK_HEADER_BYTES]byte{0x01, 0x02, 0x03},
+		Nonce:  0x1122334455667788,
+		ShortIDs: []compactShortID{
+			{0x01, 0x02, 0x03, 0x04, 0x05, 0x06},
+			{0x11, 0x12, 0x13, 0x14, 0x15, 0x16},
+		},
+		Prefilled: []prefilledTxn{
+			{Index: 0, Tx: tx1},
+			{Index: 3, Tx: tx2},
+		},
+	}
+	raw, err := encodeCmpctBlockPayload(want)
+	if err != nil {
+		t.Fatalf("encodeCmpctBlockPayload: %v", err)
+	}
+	got, err := decodeCmpctBlockPayload(raw)
+	if err != nil {
+		t.Fatalf("decodeCmpctBlockPayload: %v", err)
+	}
+	if got.Header != want.Header || got.Nonce != want.Nonce || !reflect.DeepEqual(got.ShortIDs, want.ShortIDs) || !reflect.DeepEqual(got.Prefilled, want.Prefilled) {
+		t.Fatalf("cmpctblock roundtrip got=%+v want=%+v", got, want)
+	}
+}
+
+func TestCmpctBlockPayloadRejectsMalformed(t *testing.T) {
+	validTx := minimalBlockTxnTestTxBytes(12)
+	tooManyShortIDs := make([]compactShortID, maxCompactRelayEntries+1)
+	tooManyPrefilled := make([]prefilledTxn, maxCompactRelayEntries+1)
+	for i := range tooManyPrefilled {
+		tooManyPrefilled[i] = prefilledTxn{Index: uint64(i), Tx: validTx}
+	}
+	assertCmpctBlockEncodeFails(t, "too_many_short_ids", cmpctBlockPayload{ShortIDs: tooManyShortIDs}, "too many compact relay entries")
+	assertCmpctBlockEncodeFails(t, "too_many_prefilled", cmpctBlockPayload{Prefilled: tooManyPrefilled}, "too many compact relay")
+	assertCmpctBlockEncodeFails(t, "duplicate_prefilled", cmpctBlockPayload{Prefilled: []prefilledTxn{{Index: 1, Tx: validTx}, {Index: 1, Tx: validTx}}}, "compact relay index")
+	assertCmpctBlockEncodeFails(t, "prefilled_index_outside_vector", cmpctBlockPayload{Prefilled: []prefilledTxn{{Index: 1, Tx: validTx}}}, "compact relay index out of range")
+	assertCmpctBlockEncodeFails(t, "prefilled_index_range", cmpctBlockPayload{Prefilled: []prefilledTxn{{Index: maxCompactRelayIndexValue + 1, Tx: validTx}}}, "compact relay index out of range")
+	assertCmpctBlockEncodeFails(t, "empty_prefilled_tx", cmpctBlockPayload{Prefilled: []prefilledTxn{{Tx: nil}}}, "blocktxn transaction is empty")
+	assertCmpctBlockEncodeFails(t, "trailing_prefilled_tx", cmpctBlockPayload{Prefilled: []prefilledTxn{{Tx: append(validTx, 0x00)}}}, "blocktxn transaction is non-canonical")
+	assertCmpctBlockEncodeFails(t, "trailing_prefilled_tx_before_next_delta", cmpctBlockPayload{Prefilled: []prefilledTxn{{Index: 0, Tx: append(validTx, 0x00)}, {Index: 1, Tx: validTx}}}, "blocktxn transaction is non-canonical")
+
+	assertCmpctBlockDecodeFails(t, "short_header", make([]byte, consensus.BLOCK_HEADER_BYTES+7), "cmpctblock payload missing header or nonce")
+	assertCmpctBlockDecodeFails(t, "nonminimal_short_count", cmpctBlockTestPayload([]byte{0xfd, 0x00, 0x00}), "non-minimal")
+	tooManyShortIDPayload := consensus.AppendCompactSize(nil, maxCompactRelayEntries+1)
+	tooManyShortIDPayload = append(tooManyShortIDPayload, make([]byte, (maxCompactRelayEntries+1)*compactShortIDBytes)...)
+	tooManyShortIDPayload = consensus.AppendCompactSize(tooManyShortIDPayload, 0)
+	assertCmpctBlockDecodeFails(t, "too_many_short_ids", cmpctBlockTestPayload(tooManyShortIDPayload), "too many compact relay entries")
+	assertCmpctBlockDecodeFails(t, "truncated_short_ids", cmpctBlockTestPayload([]byte{1, 0x01, 0x02}), "cmpctblock payload truncated short IDs")
+	assertCmpctBlockDecodeFails(t, "nonminimal_prefilled_count", cmpctBlockTestPayload([]byte{0, 0xfd, 0x00, 0x00}), "non-minimal")
+	aggregate := consensus.AppendCompactSize(append(consensus.AppendCompactSize(nil, maxCompactRelayEntries), make([]byte, maxCompactRelayEntries*compactShortIDBytes)...), 1)
+	assertCmpctBlockDecodeFails(t, "aggregate_count", cmpctBlockTestPayload(aggregate), "too many compact relay entries")
+
+	rangeBeforeTx := consensus.AppendCompactSize(consensus.AppendCompactSize(consensus.AppendCompactSize(nil, 0), 1), 1)
+	rangeBeforeTx = append(rangeBeforeTx, make([]byte, consensus.MAX_BLOCK_BYTES)...)
+	assertCmpctBlockDecodeFails(t, "prefilled_index_range_before_tx", cmpctBlockTestPayload(rangeBeforeTx), "compact relay index out of range")
+	assertCmpctBlockDecodeFails(t, "trailing", append(cmpctBlockTestPayload([]byte{0, 0}), 0x00), "cmpctblock payload has trailing bytes")
+}
+
 func TestBlockTxnPayloadRejectsMalformed(t *testing.T) {
 	tooMany := make([][]byte, maxCompactRelayEntries+1)
 	tooLarge := make([]byte, consensus.MAX_BLOCK_BYTES+1)
@@ -148,6 +209,33 @@ func mustEncodeBlockTxnPayload(t *testing.T, txs [][]byte) []byte {
 		t.Fatalf("encodeBlockTxnPayload: %v", err)
 	}
 	return raw
+}
+
+func assertCmpctBlockEncodeFails(t *testing.T, name string, in cmpctBlockPayload, wantErr string) {
+	t.Helper()
+	_, err := encodeCmpctBlockPayload(in)
+	if err == nil {
+		t.Fatalf("%s: expected encode failure", name)
+	}
+	if !strings.Contains(err.Error(), wantErr) {
+		t.Fatalf("%s: encode error=%q, want %q", name, err, wantErr)
+	}
+}
+
+func assertCmpctBlockDecodeFails(t *testing.T, name string, raw []byte, wantErr string) {
+	t.Helper()
+	_, err := decodeCmpctBlockPayload(raw)
+	if err == nil {
+		t.Fatalf("%s: expected decode failure", name)
+	}
+	if !strings.Contains(err.Error(), wantErr) {
+		t.Fatalf("%s: decode error=%q, want %q", name, err, wantErr)
+	}
+}
+
+func cmpctBlockTestPayload(tail []byte) []byte {
+	head := make([]byte, consensus.BLOCK_HEADER_BYTES+8)
+	return append(head, tail...)
 }
 
 func TestGetBlockTxnPayloadAllowsIndexesAboveRequestCountCap(t *testing.T) {

--- a/clients/go/node/p2p/compact_wire_test.go
+++ b/clients/go/node/p2p/compact_wire_test.go
@@ -33,24 +33,6 @@ func TestCompactWireCommandConstantsAndPayloadCaps(t *testing.T) {
 	}
 }
 
-func TestCmpctBlockPayloadAllowsShortIDCountAboveInventoryVectorLimit(t *testing.T) {
-	shortIDs := make([]compactShortID, maxCompactRelayEntries+1)
-	for i := range shortIDs {
-		shortIDs[i] = compactShortID{byte(i), byte(i >> 8), byte(i >> 16), byte(i >> 24), 0xaa, 0xbb}
-	}
-	raw, err := encodeCmpctBlockPayload(cmpctBlockPayload{ShortIDs: shortIDs})
-	if err != nil {
-		t.Fatalf("encodeCmpctBlockPayload above inventory vector limit: %v", err)
-	}
-	got, err := decodeCmpctBlockPayload(raw)
-	if err != nil {
-		t.Fatalf("decodeCmpctBlockPayload above inventory vector limit: %v", err)
-	}
-	if !reflect.DeepEqual(got.ShortIDs, shortIDs) {
-		t.Fatalf("short IDs above inventory vector limit did not roundtrip")
-	}
-}
-
 func TestGetBlockTxnPayloadCodec(t *testing.T) {
 	want := getBlockTxnPayload{
 		BlockHash: [32]byte{0x01, 0x02, 0x03},
@@ -98,19 +80,11 @@ func TestBlockTxnPayloadCodec(t *testing.T) {
 }
 
 func TestCmpctBlockPayloadCodec(t *testing.T) {
-	tx1 := minimalBlockTxnTestTxBytes(10)
-	tx2 := minimalBlockTxnTestTxBytes(11)
 	want := cmpctBlockPayload{
-		Header: [consensus.BLOCK_HEADER_BYTES]byte{0x01, 0x02, 0x03},
-		Nonce:  0x1122334455667788,
-		ShortIDs: []compactShortID{
-			{0x01, 0x02, 0x03, 0x04, 0x05, 0x06},
-			{0x11, 0x12, 0x13, 0x14, 0x15, 0x16},
-		},
-		Prefilled: []prefilledTxn{
-			{Index: 0, Tx: tx1},
-			{Index: 3, Tx: tx2},
-		},
+		Header:    [consensus.BLOCK_HEADER_BYTES]byte{0x01, 0x02, 0x03},
+		Nonce:     0x1122334455667788,
+		ShortIDs:  []compactShortID{{0x01, 0x02, 0x03, 0x04, 0x05, 0x06}},
+		Prefilled: []prefilledTxn{{Index: 0, Tx: minimalBlockTxnTestTxBytes(10)}},
 	}
 	raw, err := encodeCmpctBlockPayload(want)
 	if err != nil {
@@ -120,13 +94,22 @@ func TestCmpctBlockPayloadCodec(t *testing.T) {
 	if err != nil {
 		t.Fatalf("decodeCmpctBlockPayload: %v", err)
 	}
-	if got.Header != want.Header || got.Nonce != want.Nonce || !reflect.DeepEqual(got.ShortIDs, want.ShortIDs) || !reflect.DeepEqual(got.Prefilled, want.Prefilled) {
+	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cmpctblock roundtrip got=%+v want=%+v", got, want)
+	}
+	shortIDs := make([]compactShortID, maxCompactRelayEntries+1)
+	raw, err = encodeCmpctBlockPayload(cmpctBlockPayload{ShortIDs: shortIDs})
+	if err != nil {
+		t.Fatalf("encodeCmpctBlockPayload above inventory vector limit: %v", err)
+	}
+	if got, err := decodeCmpctBlockPayload(raw); err != nil || len(got.ShortIDs) != len(shortIDs) {
+		t.Fatalf("decode above inventory vector limit got=%d err=%v", len(got.ShortIDs), err)
 	}
 }
 
 func TestCmpctBlockPayloadRejectsMalformed(t *testing.T) {
 	validTx := minimalBlockTxnTestTxBytes(12)
+	assertCmpctBlockEncodeFails(t, "empty", cmpctBlockPayload{}, "invalid compact relay entry count")
 	assertCmpctBlockEncodeFails(t, "duplicate_prefilled", cmpctBlockPayload{Prefilled: []prefilledTxn{{Index: 1, Tx: validTx}, {Index: 1, Tx: validTx}}}, "compact relay index")
 	assertCmpctBlockEncodeFails(t, "prefilled_index_outside_vector", cmpctBlockPayload{Prefilled: []prefilledTxn{{Index: 1, Tx: validTx}}}, "compact relay index out of range")
 	assertCmpctBlockEncodeFails(t, "prefilled_index_range", cmpctBlockPayload{Prefilled: []prefilledTxn{{Index: maxCompactRelayIndexValue + 1, Tx: validTx}}}, "compact relay index out of range")
@@ -135,15 +118,16 @@ func TestCmpctBlockPayloadRejectsMalformed(t *testing.T) {
 	assertCmpctBlockEncodeFails(t, "trailing_prefilled_tx_before_next_delta", cmpctBlockPayload{Prefilled: []prefilledTxn{{Index: 0, Tx: append(validTx, 0x00)}, {Index: 1, Tx: validTx}}}, "cmpctblock prefilled transaction is non-canonical")
 
 	assertCmpctBlockDecodeFails(t, "short_header", make([]byte, consensus.BLOCK_HEADER_BYTES+7), "cmpctblock payload missing header or nonce")
+	assertCmpctBlockDecodeFails(t, "empty", cmpctBlockTestPayload([]byte{0, 0}), "invalid compact relay entry count")
+	assertCmpctBlockDecodeFails(t, "payload_above_wire_cap", make([]byte, consensus.MAX_RELAY_MSG_BYTES+1), "cmpctblock payload too large")
 	assertCmpctBlockDecodeFails(t, "nonminimal_short_count", cmpctBlockTestPayload([]byte{0xfd, 0x00, 0x00}), "non-minimal")
 	assertCmpctBlockDecodeFails(t, "truncated_short_ids", cmpctBlockTestPayload([]byte{1, 0x01, 0x02}), "cmpctblock payload truncated short IDs")
 	assertCmpctBlockDecodeFails(t, "nonminimal_prefilled_count", cmpctBlockTestPayload([]byte{0, 0xfd, 0x00, 0x00}), "non-minimal")
-	assertCmpctBlockDecodeFails(t, "huge_prefilled_count_without_entries", cmpctBlockTestPayload(consensus.AppendCompactSize([]byte{0}, maxCompactBlockTransactions)), "EOF")
+	assertCmpctBlockDecodeFails(t, "huge_prefilled_count_without_entries", cmpctBlockTestPayload(consensus.AppendCompactSize([]byte{0}, consensus.MAX_BLOCK_BYTES)), "EOF")
 
 	rangeBeforeTx := consensus.AppendCompactSize(consensus.AppendCompactSize(consensus.AppendCompactSize(nil, 0), 1), 1)
-	rangeBeforeTx = append(rangeBeforeTx, make([]byte, consensus.MAX_BLOCK_BYTES)...)
 	assertCmpctBlockDecodeFails(t, "prefilled_index_range_before_tx", cmpctBlockTestPayload(rangeBeforeTx), "compact relay index out of range")
-	assertCmpctBlockDecodeFails(t, "trailing", append(cmpctBlockTestPayload([]byte{0, 0}), 0x00), "cmpctblock payload has trailing bytes")
+	assertCmpctBlockDecodeFails(t, "trailing", append(cmpctBlockTestPayload([]byte{1, 0, 0, 0, 0, 0, 0, 0}), 0x00), "cmpctblock payload has trailing bytes")
 }
 
 func TestBlockTxnPayloadRejectsMalformed(t *testing.T) {
@@ -240,8 +224,7 @@ func assertCmpctBlockDecodeFails(t *testing.T, name string, raw []byte, wantErr 
 }
 
 func cmpctBlockTestPayload(tail []byte) []byte {
-	head := make([]byte, consensus.BLOCK_HEADER_BYTES+8)
-	return append(head, tail...)
+	return append(make([]byte, consensus.BLOCK_HEADER_BYTES+8), tail...)
 }
 
 func TestGetBlockTxnPayloadAllowsIndexesAboveRequestCountCap(t *testing.T) {

--- a/clients/go/node/p2p/wire_payload_limits.go
+++ b/clients/go/node/p2p/wire_payload_limits.go
@@ -29,7 +29,7 @@ func compactRelayPayloadCap(command string) uint32 {
 		return sendCmpctPayloadBytes
 	}
 	if command == messageGetBlockTxn {
-		return uint32(32 + maxCompactSizeBytes + maxCompactRelayEntries*maxCompactSizeBytes)
+		return uint32(32 + maxCompactSizeBytes + maxCompactRelayEntries*compactRelayIndexBytes)
 	}
 	if command == messageCmpctBlock {
 		return uint32(consensus.MAX_RELAY_MSG_BYTES)


### PR DESCRIPTION
Linear: RUB-324
GitHub issue: Closes #1723

Invariant:
Go compact relay payload codecs match RUBIN_L1_P2P_AUX.md §4 byte-level layouts before compact relay runtime dispatch proceeds.

Layer:
implementation / tests

Files changed:
- clients/go/node/p2p/compact_wire.go
- clients/go/node/p2p/compact_wire_test.go
- clients/go/node/p2p/wire_payload_limits.go

Behavior impact:
- getblocktxn uses absolute u32le transaction indices.
- blocktxn wraps each transaction as tx_len CompactSize + TxBytes.
- cmpctblock uses nonce1 + nonce2, absolute u32le prefilled indices, and tx_len-delimited prefilled transactions.
- cmpctblock no longer applies the 4096 inventory-vector cap to total block transaction positions.

Compatibility impact:
This changes the compact relay wire layout to match the current AUX specification. This is non-consensus P2P wire behavior.

Known non-goals:
- No sendcmpct peer-mode state.
- No runtime compact relay dispatch.
- No cmpctblock reconstruction.
- No Rust, conformance, consensus, or spec changes.

Wave-zero hostile checks:
- Scope single invariant: PASS.
- Source-of-truth checked: Linear RUB-324 and RUBIN_L1_P2P_AUX.md §4.
- Evidence fail-closed probes: not applicable; this is not an evidence harness PR.
- Schema/cross-field probes: not applicable; no schema or validator changes.
- Shell/tooling probes: not applicable; no shell changes.
- Parity matrix: Go implementation only; Rust is out of scope by RUB-324.
- Generated artifact check: PASS; no generated artifacts changed.
- Claim inventory: implementation/tests only; no runtime readiness claim.

Tests:
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node/p2p -run "CmpctBlock|GetBlockTxn|BlockTxn|Compact|Wire"'\n- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node/p2p'\n- scripts/dev-env.sh -- bash -lc 'cd clients/go && go vet ./node/p2p'\n- scripts/dev-env.sh -- bash -lc 'cd clients/go && gosec ./node/p2p'\n- lizard_medium_rows.py clients/go/node/p2p/compact_wire.go clients/go/node/p2p/*compact*_test.go\n- git diff --check\n- rubin-precommit-one-review --include-base-diff\n- fixed stock code-review pass: no findings\n- rubin-push --coverage-cmd "scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node/p2p'" -- origin HEAD\n\nNot checked:\n- GitHub CI is pending for this PR.

<!-- rubin-agent-meta actor=unknown action=pr-create via=cl branch=codex/RUB-324-aux-wire-layout-parity wt=rubin-protocol-codex-RUB-316 utc=2026-05-19T17:16:02Z -->
