### PR TITLE
RUB-311 Wire sendcmpct peer-mode negotiation

### DIFF
--- a/clients/go/node/p2p/compact_runtime.go
+++ b/clients/go/node/p2p/compact_runtime.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 )
 
-const maxHighBandwidthCompactPeers = 3
-
 type compactModeSnapshot struct {
 	Mode    uint8
 	Version uint64
@@ -45,14 +43,7 @@ func (s *Service) advertiseCompactRelayMode(p *peer) error {
 	if p == nil || !s.compactRelayReady() || !s.canAdvertiseCompactRelay(p) {
 		return nil
 	}
-	s.compactMu.Lock()
-	defer s.compactMu.Unlock()
-
-	mode := s.desiredCompactMode(p)
-	if mode == 2 && p.localCompactMode().Mode != 2 && s.localCompactModeCount(2) >= maxHighBandwidthCompactPeers {
-		mode = 1
-	}
-	return p.sendLocalCompactMode(mode)
+	return p.sendLocalCompactMode(0)
 }
 
 func (s *Service) compactRelayReady() bool {
@@ -70,45 +61,9 @@ func (s *Service) canAdvertiseCompactRelay(p *peer) bool {
 	return s.cfg.CompactRelayPeerOK != nil && s.cfg.CompactRelayPeerOK(p.snapshotState())
 }
 
-func (s *Service) desiredCompactMode(p *peer) uint8 {
-	if s.cfg.CompactRelayMode == 0 || !s.cfg.CompactRelayReady {
-		return 0
-	}
-	if s.cfg.CompactMissRatePct > 10.0 && s.cfg.CompactMissBlocks >= 5 {
-		return 0
-	}
-	if s.cfg.CompactMissRatePct > 0.5 {
-		return 1
-	}
-	score := s.cfg.CompactPeerScore(p.snapshotState())
-	if s.cfg.CompactRelayMode >= 2 && score >= 75 {
-		return 2
-	}
-	if score >= 40 {
-		return 1
-	}
-	return 0
-}
-
-func (s *Service) localCompactModeCount(mode uint8) int {
-	s.peersMu.RLock()
-	defer s.peersMu.RUnlock()
-	seen := make(map[*peer]struct{}, len(s.peers))
-	count := 0
-	for _, p := range s.peers {
-		if _, ok := seen[p]; ok {
-			continue
-		}
-		seen[p] = struct{}{}
-		if p.localCompactMode().Mode == mode {
-			count++
-		}
-	}
-	return count
-}
-
 func (p *peer) sendLocalCompactMode(mode uint8) error {
-	if p.localCompactMode().Mode == mode {
+	current := p.localCompactMode()
+	if current.Mode == mode && current.Version == compactRelayVersion {
 		return nil
 	}
 	payload, err := encodeSendCmpctPayload(sendCmpctPayload{Mode: mode, Version: compactRelayVersion})

--- a/clients/go/node/p2p/compact_runtime.go
+++ b/clients/go/node/p2p/compact_runtime.go
@@ -35,7 +35,7 @@ func parseSendCmpctRuntimePayload(payload []byte) (sendCmpctPayload, error) {
 		return sendCmpctPayload{}, errors.New("sendcmpct payload width mismatch")
 	}
 	out := sendCmpctPayload{Mode: payload[0], Version: binary.LittleEndian.Uint64(payload[1:])}
-	if out.Mode > 2 {
+	if out.Version == compactRelayVersion && out.Mode > 2 {
 		return sendCmpctPayload{}, errors.New("unsupported compact relay mode")
 	}
 	return out, nil

--- a/clients/go/node/p2p/compact_runtime.go
+++ b/clients/go/node/p2p/compact_runtime.go
@@ -19,10 +19,6 @@ func (p *peer) handleSendCmpct(payload []byte) error {
 	if err != nil {
 		return err
 	}
-	if msg.Version != compactRelayVersion {
-		p.setRemoteCompactMode(compactModeSnapshot{Mode: 0, Version: msg.Version})
-		return nil
-	}
 	p.setRemoteCompactMode(compactModeSnapshot{Mode: msg.Mode, Version: msg.Version})
 	return nil
 }
@@ -32,7 +28,10 @@ func parseSendCmpctRuntimePayload(payload []byte) (sendCmpctPayload, error) {
 		return sendCmpctPayload{}, errors.New("sendcmpct payload width mismatch")
 	}
 	out := sendCmpctPayload{Mode: payload[0], Version: binary.LittleEndian.Uint64(payload[1:])}
-	if out.Version == compactRelayVersion && out.Mode > 2 {
+	if out.Version != compactRelayVersion {
+		return sendCmpctPayload{}, errors.New("unsupported compact relay version")
+	}
+	if out.Mode > 2 {
 		return sendCmpctPayload{}, errors.New("unsupported compact relay mode")
 	}
 	return out, nil

--- a/clients/go/node/p2p/compact_runtime.go
+++ b/clients/go/node/p2p/compact_runtime.go
@@ -42,7 +42,7 @@ func parseSendCmpctRuntimePayload(payload []byte) (sendCmpctPayload, error) {
 }
 
 func (s *Service) advertiseCompactRelayMode(p *peer) error {
-	if p == nil || !s.compactRelayReady() {
+	if p == nil || !s.compactRelayReady() || !s.canAdvertiseCompactRelay(p) {
 		return nil
 	}
 	s.compactMu.Lock()
@@ -64,6 +64,10 @@ func (s *Service) compactRelayReady() bool {
 		return false
 	}
 	return !s.cfg.SyncEngine.IsInIBD(uint64(now)) // #nosec G115 -- negative Unix times are rejected above.
+}
+
+func (s *Service) canAdvertiseCompactRelay(p *peer) bool {
+	return s.cfg.CompactRelayPeerOK != nil && s.cfg.CompactRelayPeerOK(p.snapshotState())
 }
 
 func (s *Service) desiredCompactMode(p *peer) uint8 {

--- a/clients/go/node/p2p/compact_runtime.go
+++ b/clients/go/node/p2p/compact_runtime.go
@@ -11,7 +11,6 @@ type compactModeSnapshot struct {
 }
 
 type peerCompactRelayState struct {
-	localMode  compactModeSnapshot
 	remoteMode compactModeSnapshot
 }
 
@@ -39,60 +38,10 @@ func parseSendCmpctRuntimePayload(payload []byte) (sendCmpctPayload, error) {
 	return out, nil
 }
 
-func (s *Service) advertiseCompactRelayMode(p *peer) error {
-	if p == nil || !s.compactRelayReady() || !s.canAdvertiseCompactRelay(p) {
-		return nil
-	}
-	return p.sendLocalCompactMode(0)
-}
-
-func (s *Service) compactRelayReady() bool {
-	if s == nil || s.cfg.CompactRelayMode == 0 || s.cfg.Now == nil || s.cfg.SyncEngine == nil {
-		return false
-	}
-	now := s.cfg.Now().Unix()
-	if now < 0 {
-		return false
-	}
-	return !s.cfg.SyncEngine.IsInIBD(uint64(now)) // #nosec G115 -- negative Unix times are rejected above.
-}
-
-func (s *Service) canAdvertiseCompactRelay(p *peer) bool {
-	return s.cfg.CompactRelayPeerOK != nil && s.cfg.CompactRelayPeerOK(p.snapshotState())
-}
-
-func (p *peer) sendLocalCompactMode(mode uint8) error {
-	current := p.localCompactMode()
-	if current.Mode == mode && current.Version == compactRelayVersion {
-		return nil
-	}
-	payload, err := encodeSendCmpctPayload(sendCmpctPayload{Mode: mode, Version: compactRelayVersion})
-	if err != nil {
-		return err
-	}
-	if err := p.send(messageSendCmpct, payload); err != nil {
-		return err
-	}
-	p.setLocalCompactMode(compactModeSnapshot{Mode: mode, Version: compactRelayVersion})
-	return nil
-}
-
 func (p *peer) setRemoteCompactMode(mode compactModeSnapshot) {
 	p.compactMu.Lock()
 	p.compact.remoteMode = mode
 	p.compactMu.Unlock()
-}
-
-func (p *peer) setLocalCompactMode(mode compactModeSnapshot) {
-	p.compactMu.Lock()
-	p.compact.localMode = mode
-	p.compactMu.Unlock()
-}
-
-func (p *peer) localCompactMode() compactModeSnapshot {
-	p.compactMu.Lock()
-	defer p.compactMu.Unlock()
-	return p.compact.localMode
 }
 
 func (p *peer) remoteCompactMode() compactModeSnapshot {

--- a/clients/go/node/p2p/compact_runtime.go
+++ b/clients/go/node/p2p/compact_runtime.go
@@ -1,0 +1,156 @@
+package p2p
+
+import (
+	"encoding/binary"
+	"errors"
+)
+
+const (
+	maxHighBandwidthCompactPeers = 3
+	defaultCompactPeerScore      = 50
+	compactModeOneScore          = 40
+	compactModeTwoScore          = 75
+)
+
+type compactModeSnapshot struct {
+	Mode    uint8
+	Version uint64
+}
+
+type peerCompactRelayState struct {
+	localMode  compactModeSnapshot
+	remoteMode compactModeSnapshot
+	score      int
+	scoreSet   bool
+}
+
+func (p *peer) handleSendCmpct(payload []byte) error {
+	msg, err := parseSendCmpctRuntimePayload(payload)
+	if err != nil {
+		return err
+	}
+	if msg.Version != compactRelayVersion {
+		p.setRemoteCompactMode(compactModeSnapshot{Mode: 0, Version: msg.Version})
+		return nil
+	}
+	p.setRemoteCompactMode(compactModeSnapshot{Mode: msg.Mode, Version: msg.Version})
+	return nil
+}
+
+func parseSendCmpctRuntimePayload(payload []byte) (sendCmpctPayload, error) {
+	if len(payload) != sendCmpctPayloadBytes {
+		return sendCmpctPayload{}, errors.New("sendcmpct payload width mismatch")
+	}
+	out := sendCmpctPayload{Mode: payload[0], Version: binary.LittleEndian.Uint64(payload[1:])}
+	if out.Mode > 2 {
+		return sendCmpctPayload{}, errors.New("unsupported compact relay mode")
+	}
+	return out, nil
+}
+
+func (s *Service) advertiseCompactRelayMode(p *peer) error {
+	if p == nil || !s.compactRelayReady() {
+		return nil
+	}
+	s.compactMu.Lock()
+	defer s.compactMu.Unlock()
+
+	mode := desiredCompactMode(s.cfg.CompactRelayMode, p.compactScore())
+	if mode == 2 && p.localCompactMode().Mode != 2 && s.localCompactModeCount(2) >= maxHighBandwidthCompactPeers {
+		mode = 1
+	}
+	return p.sendLocalCompactMode(mode)
+}
+
+func (s *Service) compactRelayReady() bool {
+	if s == nil || s.cfg.CompactRelayMode == 0 || s.cfg.Now == nil || s.cfg.SyncEngine == nil {
+		return false
+	}
+	now := s.cfg.Now().Unix()
+	if now < 0 {
+		return false
+	}
+	return !s.cfg.SyncEngine.IsInIBD(uint64(now)) // #nosec G115 -- negative Unix times are rejected above.
+}
+
+func (s *Service) localCompactModeCount(mode uint8) int {
+	s.peersMu.RLock()
+	defer s.peersMu.RUnlock()
+	seen := make(map[*peer]struct{}, len(s.peers))
+	count := 0
+	for _, p := range s.peers {
+		if _, ok := seen[p]; ok {
+			continue
+		}
+		seen[p] = struct{}{}
+		if p.localCompactMode().Mode == mode {
+			count++
+		}
+	}
+	return count
+}
+
+func desiredCompactMode(configured uint8, score int) uint8 {
+	if configured == 0 || score < compactModeOneScore {
+		return 0
+	}
+	if configured >= 2 && score >= compactModeTwoScore {
+		return 2
+	}
+	return 1
+}
+
+func (p *peer) sendLocalCompactMode(mode uint8) error {
+	if p.localCompactMode().Mode == mode {
+		return nil
+	}
+	payload, err := encodeSendCmpctPayload(sendCmpctPayload{Mode: mode, Version: compactRelayVersion})
+	if err != nil {
+		return err
+	}
+	if err := p.send(messageSendCmpct, payload); err != nil {
+		return err
+	}
+	p.setLocalCompactMode(compactModeSnapshot{Mode: mode, Version: compactRelayVersion})
+	return nil
+}
+
+func (p *peer) setRemoteCompactMode(mode compactModeSnapshot) {
+	p.compactMu.Lock()
+	p.compact.remoteMode = mode
+	p.compactMu.Unlock()
+}
+
+func (p *peer) setLocalCompactMode(mode compactModeSnapshot) {
+	p.compactMu.Lock()
+	p.compact.localMode = mode
+	p.compactMu.Unlock()
+}
+
+func (p *peer) setCompactQualityScore(score int) {
+	p.compactMu.Lock()
+	p.compact.score = score
+	p.compact.scoreSet = true
+	p.compactMu.Unlock()
+}
+
+func (p *peer) compactScore() int {
+	p.compactMu.Lock()
+	defer p.compactMu.Unlock()
+	if !p.compact.scoreSet {
+		return defaultCompactPeerScore
+	}
+	return p.compact.score
+}
+
+func (p *peer) localCompactMode() compactModeSnapshot {
+	p.compactMu.Lock()
+	defer p.compactMu.Unlock()
+	return p.compact.localMode
+}
+
+func (p *peer) remoteCompactMode() compactModeSnapshot {
+	p.compactMu.Lock()
+	defer p.compactMu.Unlock()
+	return p.compact.remoteMode
+}

--- a/clients/go/node/p2p/compact_runtime.go
+++ b/clients/go/node/p2p/compact_runtime.go
@@ -5,12 +5,7 @@ import (
 	"errors"
 )
 
-const (
-	maxHighBandwidthCompactPeers = 3
-	defaultCompactPeerScore      = 50
-	compactModeOneScore          = 40
-	compactModeTwoScore          = 75
-)
+const maxHighBandwidthCompactPeers = 3
 
 type compactModeSnapshot struct {
 	Mode    uint8
@@ -20,8 +15,6 @@ type compactModeSnapshot struct {
 type peerCompactRelayState struct {
 	localMode  compactModeSnapshot
 	remoteMode compactModeSnapshot
-	score      int
-	scoreSet   bool
 }
 
 func (p *peer) handleSendCmpct(payload []byte) error {
@@ -55,7 +48,7 @@ func (s *Service) advertiseCompactRelayMode(p *peer) error {
 	s.compactMu.Lock()
 	defer s.compactMu.Unlock()
 
-	mode := desiredCompactMode(s.cfg.CompactRelayMode, p.compactScore())
+	mode := s.desiredCompactMode(p)
 	if mode == 2 && p.localCompactMode().Mode != 2 && s.localCompactModeCount(2) >= maxHighBandwidthCompactPeers {
 		mode = 1
 	}
@@ -73,6 +66,26 @@ func (s *Service) compactRelayReady() bool {
 	return !s.cfg.SyncEngine.IsInIBD(uint64(now)) // #nosec G115 -- negative Unix times are rejected above.
 }
 
+func (s *Service) desiredCompactMode(p *peer) uint8 {
+	if s.cfg.CompactRelayMode == 0 || !s.cfg.CompactRelayReady {
+		return 0
+	}
+	if s.cfg.CompactMissRatePct > 10.0 && s.cfg.CompactMissBlocks >= 5 {
+		return 0
+	}
+	if s.cfg.CompactMissRatePct > 0.5 {
+		return 1
+	}
+	score := s.cfg.CompactPeerScore(p.snapshotState())
+	if s.cfg.CompactRelayMode >= 2 && score >= 75 {
+		return 2
+	}
+	if score >= 40 {
+		return 1
+	}
+	return 0
+}
+
 func (s *Service) localCompactModeCount(mode uint8) int {
 	s.peersMu.RLock()
 	defer s.peersMu.RUnlock()
@@ -88,16 +101,6 @@ func (s *Service) localCompactModeCount(mode uint8) int {
 		}
 	}
 	return count
-}
-
-func desiredCompactMode(configured uint8, score int) uint8 {
-	if configured == 0 || score < compactModeOneScore {
-		return 0
-	}
-	if configured >= 2 && score >= compactModeTwoScore {
-		return 2
-	}
-	return 1
 }
 
 func (p *peer) sendLocalCompactMode(mode uint8) error {
@@ -125,22 +128,6 @@ func (p *peer) setLocalCompactMode(mode compactModeSnapshot) {
 	p.compactMu.Lock()
 	p.compact.localMode = mode
 	p.compactMu.Unlock()
-}
-
-func (p *peer) setCompactQualityScore(score int) {
-	p.compactMu.Lock()
-	p.compact.score = score
-	p.compact.scoreSet = true
-	p.compactMu.Unlock()
-}
-
-func (p *peer) compactScore() int {
-	p.compactMu.Lock()
-	defer p.compactMu.Unlock()
-	if !p.compact.scoreSet {
-		return defaultCompactPeerScore
-	}
-	return p.compact.score
 }
 
 func (p *peer) localCompactMode() compactModeSnapshot {

--- a/clients/go/node/p2p/compact_runtime_test.go
+++ b/clients/go/node/p2p/compact_runtime_test.go
@@ -36,41 +36,69 @@ func TestSendCmpctPostHandshakeCommandPathRecordsPeerMode(t *testing.T) {
 	}
 }
 
-func TestPostHandshakeAdvertisesSendCmpctWhenEnabled(t *testing.T) {
-	h := newTestHarness(t, 2, "127.0.0.1:0", nil)
-	h.service.ctx = context.Background()
-	h.service.cfg.CompactRelayMode = 1
-	markCompactRelayReadyNow(t, h)
-
-	local, remote := net.Pipe()
-	defer local.Close()
-	defer remote.Close()
-
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- h.service.handleConn(local, "")
-	}()
-	remoteVersion := testVersionPayload(node.DevnetGenesisChainID(), node.DevnetGenesisBlockHash(), "remote", 0)
-	if err := completeRemoteHandshake(remote, h.service.cfg.PeerRuntimeConfig, remoteVersion); err != nil {
-		t.Fatalf("remote handshake: %v", err)
-	}
-	assertSendCmpctFrame(t, remote, h.service.cfg.PeerRuntimeConfig, 1)
-	_ = remote.Close()
-	select {
-	case <-errCh:
-	case <-time.After(2 * time.Second):
-		t.Fatal("handleConn did not exit after remote close")
+func TestPostHandshakeSendCmpctPhaseGate(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		blocks   int
+		mode     uint8
+		ready    bool
+		missRate float64
+		want     string
+		wantMode uint8
+	}{
+		{"ready mode1 advertises", 2, 1, true, 0.2, messageSendCmpct, 1},
+		{"warmup keeps full block", 2, 2, false, 0.0, messageGetAddr, 0},
+		{"ibd keeps full block", 0, 2, true, 0.2, messageGetBlk, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHarness(t, tc.blocks, "127.0.0.1:0", nil)
+			h.service.ctx = context.Background()
+			h.service.cfg.CompactRelayMode = tc.mode
+			h.service.cfg.CompactRelayReady = tc.ready
+			h.service.cfg.CompactMissRatePct = tc.missRate
+			if tc.blocks > 0 {
+				markCompactRelayReadyNow(t, h)
+			}
+			local, remote := net.Pipe()
+			defer local.Close()
+			defer remote.Close()
+			errCh := make(chan error, 1)
+			go func() { errCh <- h.service.handleConn(local, "") }()
+			remoteVersion := testVersionPayload(node.DevnetGenesisChainID(), node.DevnetGenesisBlockHash(), "remote", 0)
+			if err := completeRemoteHandshake(remote, h.service.cfg.PeerRuntimeConfig, remoteVersion); err != nil {
+				t.Fatalf("remote handshake: %v", err)
+			}
+			frame, err := readFrame(remote, networkMagic(h.service.cfg.PeerRuntimeConfig.Network), h.service.cfg.PeerRuntimeConfig.MaxMessageSize)
+			if err != nil {
+				t.Fatalf("read post-handshake frame: %v", err)
+			}
+			if frame.Command != tc.want {
+				t.Fatalf("first post-handshake command=%q, want %q", frame.Command, tc.want)
+			}
+			if tc.want == messageSendCmpct {
+				assertSendCmpctPayload(t, frame.Payload, tc.wantMode)
+			}
+			_ = remote.Close()
+			select {
+			case <-errCh:
+			case <-time.After(2 * time.Second):
+				t.Fatal("handleConn did not exit after remote close")
+			}
+		})
 	}
 }
 
 func TestCompactModeHighBandwidthCap(t *testing.T) {
 	h := newTestHarness(t, 2, "127.0.0.1:0", nil)
 	h.service.cfg.CompactRelayMode = 2
+	h.service.cfg.CompactRelayReady = true
+	h.service.cfg.CompactMissRatePct = 0.2
+	h.service.cfg.CompactPeerScore = func(node.PeerState) int { return 90 }
 	markCompactRelayReadyNow(t, h)
 
 	sinks := make([]compactFrameSink, 0, 4)
-	for i, score := range []int{90, 89, 88, 87} {
-		sink := registerCompactFrameSink(t, h.service, fmt.Sprintf("compact-peer-%d", i), score)
+	for i := 0; i < 4; i++ {
+		sink := registerCompactFrameSink(t, h.service, fmt.Sprintf("compact-peer-%d", i))
 		sinks = append(sinks, sink)
 		if err := h.service.advertiseCompactRelayMode(sink.peer); err != nil {
 			t.Fatalf("advertiseCompactRelayMode: %v", err)
@@ -91,11 +119,18 @@ func TestCompactModeHighBandwidthCap(t *testing.T) {
 	}
 }
 
-func TestCompactRelayReadyBlocksIBD(t *testing.T) {
-	h := newTestHarness(t, 0, "127.0.0.1:0", nil)
+func TestCompactMissRateDowngradesToFullBlockMode(t *testing.T) {
+	h := newTestHarness(t, 2, "127.0.0.1:0", nil)
 	h.service.cfg.CompactRelayMode = 2
-	if h.service.compactRelayReady() {
-		t.Fatal("compact relay must not advertise while service is still in IBD")
+	h.service.cfg.CompactRelayReady = true
+	h.service.cfg.CompactMissRatePct = 12.0
+	h.service.cfg.CompactMissBlocks = 5
+	h.service.cfg.CompactPeerScore = func(node.PeerState) int { return 90 }
+	markCompactRelayReadyNow(t, h)
+
+	p := testPeerForService(h.service, "compact-peer-miss", 0)
+	if got := h.service.desiredCompactMode(p); got != 0 {
+		t.Fatalf("compact mode after high miss rate=%d, want 0", got)
 	}
 }
 
@@ -105,13 +140,12 @@ type compactFrameSink struct {
 	errs   chan error
 }
 
-func registerCompactFrameSink(t *testing.T, svc *Service, addr string, score int) compactFrameSink {
+func registerCompactFrameSink(t *testing.T, svc *Service, addr string) compactFrameSink {
 	t.Helper()
 	local, remote := net.Pipe()
 	p := testPeerForService(svc, addr, 0)
 	p.state.Addr = addr
 	p.conn = local
-	p.setCompactQualityScore(score)
 	t.Cleanup(func() {
 		_ = local.Close()
 		_ = remote.Close()
@@ -154,16 +188,9 @@ func (s compactFrameSink) read(t *testing.T) sendCmpctPayload {
 	return sendCmpctPayload{}
 }
 
-func assertSendCmpctFrame(t *testing.T, conn net.Conn, cfg node.PeerRuntimeConfig, wantMode uint8) {
+func assertSendCmpctPayload(t *testing.T, payload []byte, wantMode uint8) {
 	t.Helper()
-	frame, err := readFrame(conn, networkMagic(cfg.Network), cfg.MaxMessageSize)
-	if err != nil {
-		t.Fatalf("read sendcmpct: %v", err)
-	}
-	if frame.Command != messageSendCmpct {
-		t.Fatalf("command=%q, want %q", frame.Command, messageSendCmpct)
-	}
-	got, err := decodeSendCmpctPayload(frame.Payload)
+	got, err := decodeSendCmpctPayload(payload)
 	if err != nil {
 		t.Fatalf("decode sendcmpct: %v", err)
 	}

--- a/clients/go/node/p2p/compact_runtime_test.go
+++ b/clients/go/node/p2p/compact_runtime_test.go
@@ -3,7 +3,6 @@ package p2p
 import (
 	"context"
 	"encoding/binary"
-	"fmt"
 	"net"
 	"testing"
 	"time"
@@ -47,25 +46,18 @@ func TestPostHandshakeSendCmpctPhaseGate(t *testing.T) {
 		name     string
 		blocks   int
 		mode     uint8
-		ready    bool
 		peerOK   bool
-		missRate float64
 		want     string
 		wantMode uint8
 	}{
-		{"ready eligible mode1 advertises", 2, 1, true, true, 0.2, messageSendCmpct, 1},
-		{"unknown capability keeps full block", 2, 1, true, false, 0.2, messageGetAddr, 0},
-		{"warmup keeps full block", 2, 2, false, true, 0.0, messageGetAddr, 0},
-		{"ibd keeps full block", 0, 2, true, true, 0.2, messageGetBlk, 0},
-		{"high miss rate keeps full block", 2, 2, true, true, 12.0, messageGetAddr, 0},
+		{"eligible peer advertises full-block mode", 2, 1, true, messageSendCmpct, 0},
+		{"unknown capability keeps full block", 2, 1, false, messageGetAddr, 0},
+		{"ibd keeps full block", 0, 2, true, messageGetBlk, 0},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			h := newTestHarness(t, tc.blocks, "127.0.0.1:0", nil)
 			h.service.ctx = context.Background()
 			h.service.cfg.CompactRelayMode = tc.mode
-			h.service.cfg.CompactRelayReady = tc.ready
-			h.service.cfg.CompactMissRatePct = tc.missRate
-			h.service.cfg.CompactMissBlocks = 5
 			if tc.peerOK {
 				h.service.cfg.CompactRelayPeerOK = func(node.PeerState) bool { return true }
 			}
@@ -99,92 +91,6 @@ func TestPostHandshakeSendCmpctPhaseGate(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestCompactModeHighBandwidthCap(t *testing.T) {
-	h := newTestHarness(t, 2, "127.0.0.1:0", nil)
-	h.service.cfg.CompactRelayMode = 2
-	h.service.cfg.CompactRelayReady = true
-	h.service.cfg.CompactMissRatePct = 0.2
-	h.service.cfg.CompactRelayPeerOK = func(node.PeerState) bool { return true }
-	h.service.cfg.CompactPeerScore = func(node.PeerState) int { return 90 }
-	markCompactRelayReadyNow(t, h)
-
-	sinks := make([]compactFrameSink, 0, 4)
-	for i := 0; i < 4; i++ {
-		sink := registerCompactFrameSink(t, h.service, fmt.Sprintf("compact-peer-%d", i))
-		sinks = append(sinks, sink)
-		if err := h.service.advertiseCompactRelayMode(sink.peer); err != nil {
-			t.Fatalf("advertiseCompactRelayMode: %v", err)
-		}
-	}
-	modeTwo := 0
-	for _, sink := range sinks {
-		frame := sink.read(t)
-		if frame.Mode == 2 {
-			modeTwo++
-		}
-		if frame.Mode != sink.peer.localCompactMode().Mode {
-			t.Fatalf("%s wire mode=%d local mode=%d", sink.peer.addr(), frame.Mode, sink.peer.localCompactMode().Mode)
-		}
-	}
-	if modeTwo != maxHighBandwidthCompactPeers {
-		t.Fatalf("mode=2 peers=%d, want %d", modeTwo, maxHighBandwidthCompactPeers)
-	}
-}
-
-type compactFrameSink struct {
-	peer   *peer
-	frames chan sendCmpctPayload
-	errs   chan error
-}
-
-func registerCompactFrameSink(t *testing.T, svc *Service, addr string) compactFrameSink {
-	t.Helper()
-	local, remote := net.Pipe()
-	p := testPeerForService(svc, addr, 0)
-	p.state.Addr = addr
-	p.conn = local
-	t.Cleanup(func() {
-		_ = local.Close()
-		_ = remote.Close()
-	})
-	svc.peersMu.Lock()
-	svc.peers[p.addr()] = p
-	svc.peersMu.Unlock()
-
-	sink := compactFrameSink{peer: p, frames: make(chan sendCmpctPayload, 1), errs: make(chan error, 1)}
-	go func() {
-		frame, err := readFrame(remote, networkMagic(svc.cfg.PeerRuntimeConfig.Network), svc.cfg.PeerRuntimeConfig.MaxMessageSize)
-		if err != nil {
-			sink.errs <- err
-			return
-		}
-		if frame.Command != messageSendCmpct {
-			sink.errs <- fmt.Errorf("command=%q, want %q", frame.Command, messageSendCmpct)
-			return
-		}
-		payload, err := decodeSendCmpctPayload(frame.Payload)
-		if err != nil {
-			sink.errs <- err
-			return
-		}
-		sink.frames <- payload
-	}()
-	return sink
-}
-
-func (s compactFrameSink) read(t *testing.T) sendCmpctPayload {
-	t.Helper()
-	select {
-	case frame := <-s.frames:
-		return frame
-	case err := <-s.errs:
-		t.Fatalf("read compact frame: %v", err)
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out reading compact frame")
-	}
-	return sendCmpctPayload{}
 }
 
 func assertSendCmpctPayload(t *testing.T, payload []byte, wantMode uint8) {

--- a/clients/go/node/p2p/compact_runtime_test.go
+++ b/clients/go/node/p2p/compact_runtime_test.go
@@ -28,6 +28,12 @@ func TestSendCmpctPostHandshakeCommandPathRecordsPeerMode(t *testing.T) {
 	if got := p.remoteCompactMode(); got.Mode != 0 || got.Version != compactRelayVersion+1 {
 		t.Fatalf("unsupported version mode=%+v, want downgraded", got)
 	}
+	if err := p.handleMessage(message{Command: messageSendCmpct, Payload: sendCmpctRuntimePayload(t, 3, compactRelayVersion+1)}); err != nil {
+		t.Fatalf("future version with future mode should downgrade without disconnect: %v", err)
+	}
+	if got := p.remoteCompactMode(); got.Mode != 0 || got.Version != compactRelayVersion+1 {
+		t.Fatalf("future version/future mode=%+v, want downgraded", got)
+	}
 	if err := p.handleMessage(message{Command: messageSendCmpct, Payload: []byte{1, 2}}); err == nil {
 		t.Fatal("short sendcmpct payload must fail")
 	}

--- a/clients/go/node/p2p/compact_runtime_test.go
+++ b/clients/go/node/p2p/compact_runtime_test.go
@@ -15,17 +15,14 @@ func TestSendCmpctPostHandshakeCommandPathRecordsPeerMode(t *testing.T) {
 		t.Fatalf("remote compact mode=%+v, want mode=2 version=%d", got, compactRelayVersion)
 	}
 
-	if err := p.handleMessage(message{Command: messageSendCmpct, Payload: sendCmpctRuntimePayload(t, 1, compactRelayVersion+1)}); err != nil {
-		t.Fatalf("unsupported version should downgrade without disconnect: %v", err)
+	if err := p.handleMessage(message{Command: messageSendCmpct, Payload: sendCmpctRuntimePayload(t, 1, compactRelayVersion+1)}); err == nil || err.Error() != "unsupported compact relay version" {
+		t.Fatalf("unsupported version err=%v, want version rejection", err)
 	}
-	if got := p.remoteCompactMode(); got.Mode != 0 || got.Version != compactRelayVersion+1 {
-		t.Fatalf("unsupported version mode=%+v, want downgraded", got)
+	if got := p.remoteCompactMode(); got.Mode != 2 || got.Version != compactRelayVersion {
+		t.Fatalf("unsupported version changed remote compact mode: %+v", got)
 	}
-	if err := p.handleMessage(message{Command: messageSendCmpct, Payload: sendCmpctRuntimePayload(t, 3, compactRelayVersion+1)}); err != nil {
-		t.Fatalf("future version with future mode should downgrade without disconnect: %v", err)
-	}
-	if got := p.remoteCompactMode(); got.Mode != 0 || got.Version != compactRelayVersion+1 {
-		t.Fatalf("future version/future mode=%+v, want downgraded", got)
+	if err := p.handleMessage(message{Command: messageSendCmpct, Payload: sendCmpctRuntimePayload(t, 3, compactRelayVersion+1)}); err == nil || err.Error() != "unsupported compact relay version" {
+		t.Fatalf("future version/future mode err=%v, want version rejection", err)
 	}
 	if err := p.handleMessage(message{Command: messageSendCmpct, Payload: []byte{1, 2}}); err == nil {
 		t.Fatal("short sendcmpct payload must fail")

--- a/clients/go/node/p2p/compact_runtime_test.go
+++ b/clients/go/node/p2p/compact_runtime_test.go
@@ -1,0 +1,198 @@
+package p2p
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/node"
+)
+
+func TestSendCmpctPostHandshakeCommandPathRecordsPeerMode(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	payload := sendCmpctRuntimePayload(t, 2, compactRelayVersion)
+	if err := p.handleMessage(message{Command: messageSendCmpct, Payload: payload}); err != nil {
+		t.Fatalf("handleMessage(sendcmpct): %v", err)
+	}
+	if got := p.remoteCompactMode(); got.Mode != 2 || got.Version != compactRelayVersion {
+		t.Fatalf("remote compact mode=%+v, want mode=2 version=%d", got, compactRelayVersion)
+	}
+
+	if err := p.handleMessage(message{Command: messageSendCmpct, Payload: sendCmpctRuntimePayload(t, 1, compactRelayVersion+1)}); err != nil {
+		t.Fatalf("unsupported version should downgrade without disconnect: %v", err)
+	}
+	if got := p.remoteCompactMode(); got.Mode != 0 || got.Version != compactRelayVersion+1 {
+		t.Fatalf("unsupported version mode=%+v, want downgraded", got)
+	}
+	if err := p.handleMessage(message{Command: messageSendCmpct, Payload: []byte{1, 2}}); err == nil {
+		t.Fatal("short sendcmpct payload must fail")
+	}
+	if err := p.handleMessage(message{Command: messageSendCmpct, Payload: sendCmpctRuntimePayload(t, 3, compactRelayVersion)}); err == nil {
+		t.Fatal("unknown sendcmpct mode must fail")
+	}
+}
+
+func TestPostHandshakeAdvertisesSendCmpctWhenEnabled(t *testing.T) {
+	h := newTestHarness(t, 2, "127.0.0.1:0", nil)
+	h.service.ctx = context.Background()
+	h.service.cfg.CompactRelayMode = 1
+	markCompactRelayReadyNow(t, h)
+
+	local, remote := net.Pipe()
+	defer local.Close()
+	defer remote.Close()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- h.service.handleConn(local, "")
+	}()
+	remoteVersion := testVersionPayload(node.DevnetGenesisChainID(), node.DevnetGenesisBlockHash(), "remote", 0)
+	if err := completeRemoteHandshake(remote, h.service.cfg.PeerRuntimeConfig, remoteVersion); err != nil {
+		t.Fatalf("remote handshake: %v", err)
+	}
+	assertSendCmpctFrame(t, remote, h.service.cfg.PeerRuntimeConfig, 1)
+	_ = remote.Close()
+	select {
+	case <-errCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handleConn did not exit after remote close")
+	}
+}
+
+func TestCompactModeHighBandwidthCap(t *testing.T) {
+	h := newTestHarness(t, 2, "127.0.0.1:0", nil)
+	h.service.cfg.CompactRelayMode = 2
+	markCompactRelayReadyNow(t, h)
+
+	sinks := make([]compactFrameSink, 0, 4)
+	for i, score := range []int{90, 89, 88, 87} {
+		sink := registerCompactFrameSink(t, h.service, fmt.Sprintf("compact-peer-%d", i), score)
+		sinks = append(sinks, sink)
+		if err := h.service.advertiseCompactRelayMode(sink.peer); err != nil {
+			t.Fatalf("advertiseCompactRelayMode: %v", err)
+		}
+	}
+	modeTwo := 0
+	for _, sink := range sinks {
+		frame := sink.read(t)
+		if frame.Mode == 2 {
+			modeTwo++
+		}
+		if frame.Mode != sink.peer.localCompactMode().Mode {
+			t.Fatalf("%s wire mode=%d local mode=%d", sink.peer.addr(), frame.Mode, sink.peer.localCompactMode().Mode)
+		}
+	}
+	if modeTwo != maxHighBandwidthCompactPeers {
+		t.Fatalf("mode=2 peers=%d, want %d", modeTwo, maxHighBandwidthCompactPeers)
+	}
+}
+
+func TestCompactRelayReadyBlocksIBD(t *testing.T) {
+	h := newTestHarness(t, 0, "127.0.0.1:0", nil)
+	h.service.cfg.CompactRelayMode = 2
+	if h.service.compactRelayReady() {
+		t.Fatal("compact relay must not advertise while service is still in IBD")
+	}
+}
+
+type compactFrameSink struct {
+	peer   *peer
+	frames chan sendCmpctPayload
+	errs   chan error
+}
+
+func registerCompactFrameSink(t *testing.T, svc *Service, addr string, score int) compactFrameSink {
+	t.Helper()
+	local, remote := net.Pipe()
+	p := testPeerForService(svc, addr, 0)
+	p.state.Addr = addr
+	p.conn = local
+	p.setCompactQualityScore(score)
+	t.Cleanup(func() {
+		_ = local.Close()
+		_ = remote.Close()
+	})
+	svc.peersMu.Lock()
+	svc.peers[p.addr()] = p
+	svc.peersMu.Unlock()
+
+	sink := compactFrameSink{peer: p, frames: make(chan sendCmpctPayload, 1), errs: make(chan error, 1)}
+	go func() {
+		frame, err := readFrame(remote, networkMagic(svc.cfg.PeerRuntimeConfig.Network), svc.cfg.PeerRuntimeConfig.MaxMessageSize)
+		if err != nil {
+			sink.errs <- err
+			return
+		}
+		if frame.Command != messageSendCmpct {
+			sink.errs <- fmt.Errorf("command=%q, want %q", frame.Command, messageSendCmpct)
+			return
+		}
+		payload, err := decodeSendCmpctPayload(frame.Payload)
+		if err != nil {
+			sink.errs <- err
+			return
+		}
+		sink.frames <- payload
+	}()
+	return sink
+}
+
+func (s compactFrameSink) read(t *testing.T) sendCmpctPayload {
+	t.Helper()
+	select {
+	case frame := <-s.frames:
+		return frame
+	case err := <-s.errs:
+		t.Fatalf("read compact frame: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out reading compact frame")
+	}
+	return sendCmpctPayload{}
+}
+
+func assertSendCmpctFrame(t *testing.T, conn net.Conn, cfg node.PeerRuntimeConfig, wantMode uint8) {
+	t.Helper()
+	frame, err := readFrame(conn, networkMagic(cfg.Network), cfg.MaxMessageSize)
+	if err != nil {
+		t.Fatalf("read sendcmpct: %v", err)
+	}
+	if frame.Command != messageSendCmpct {
+		t.Fatalf("command=%q, want %q", frame.Command, messageSendCmpct)
+	}
+	got, err := decodeSendCmpctPayload(frame.Payload)
+	if err != nil {
+		t.Fatalf("decode sendcmpct: %v", err)
+	}
+	if got.Mode != wantMode || got.Version != compactRelayVersion {
+		t.Fatalf("sendcmpct=%+v, want mode=%d version=%d", got, wantMode, compactRelayVersion)
+	}
+}
+
+func markCompactRelayReadyNow(t *testing.T, h *testHarness) {
+	t.Helper()
+	_, hash, ok, err := h.blockStore.Tip()
+	if err != nil || !ok {
+		t.Fatalf("tip: ok=%v err=%v", ok, err)
+	}
+	block, err := h.blockStore.GetBlockByHash(hash)
+	if err != nil {
+		t.Fatalf("GetBlockByHash(tip): %v", err)
+	}
+	parsed, err := consensus.ParseBlockBytes(block)
+	if err != nil {
+		t.Fatalf("ParseBlockBytes(tip): %v", err)
+	}
+	h.service.cfg.Now = func() time.Time { return time.Unix(int64(parsed.Header.Timestamp+1), 0) }
+}
+
+func sendCmpctRuntimePayload(t *testing.T, mode uint8, version uint64) []byte {
+	t.Helper()
+	payload := make([]byte, sendCmpctPayloadBytes)
+	payload[0] = mode
+	binary.LittleEndian.PutUint64(payload[1:], version)
+	return payload
+}

--- a/clients/go/node/p2p/compact_runtime_test.go
+++ b/clients/go/node/p2p/compact_runtime_test.go
@@ -42,13 +42,16 @@ func TestPostHandshakeSendCmpctPhaseGate(t *testing.T) {
 		blocks   int
 		mode     uint8
 		ready    bool
+		peerOK   bool
 		missRate float64
 		want     string
 		wantMode uint8
 	}{
-		{"ready mode1 advertises", 2, 1, true, 0.2, messageSendCmpct, 1},
-		{"warmup keeps full block", 2, 2, false, 0.0, messageGetAddr, 0},
-		{"ibd keeps full block", 0, 2, true, 0.2, messageGetBlk, 0},
+		{"ready eligible mode1 advertises", 2, 1, true, true, 0.2, messageSendCmpct, 1},
+		{"unknown capability keeps full block", 2, 1, true, false, 0.2, messageGetAddr, 0},
+		{"warmup keeps full block", 2, 2, false, true, 0.0, messageGetAddr, 0},
+		{"ibd keeps full block", 0, 2, true, true, 0.2, messageGetBlk, 0},
+		{"high miss rate keeps full block", 2, 2, true, true, 12.0, messageGetAddr, 0},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			h := newTestHarness(t, tc.blocks, "127.0.0.1:0", nil)
@@ -56,6 +59,10 @@ func TestPostHandshakeSendCmpctPhaseGate(t *testing.T) {
 			h.service.cfg.CompactRelayMode = tc.mode
 			h.service.cfg.CompactRelayReady = tc.ready
 			h.service.cfg.CompactMissRatePct = tc.missRate
+			h.service.cfg.CompactMissBlocks = 5
+			if tc.peerOK {
+				h.service.cfg.CompactRelayPeerOK = func(node.PeerState) bool { return true }
+			}
 			if tc.blocks > 0 {
 				markCompactRelayReadyNow(t, h)
 			}
@@ -93,6 +100,7 @@ func TestCompactModeHighBandwidthCap(t *testing.T) {
 	h.service.cfg.CompactRelayMode = 2
 	h.service.cfg.CompactRelayReady = true
 	h.service.cfg.CompactMissRatePct = 0.2
+	h.service.cfg.CompactRelayPeerOK = func(node.PeerState) bool { return true }
 	h.service.cfg.CompactPeerScore = func(node.PeerState) int { return 90 }
 	markCompactRelayReadyNow(t, h)
 
@@ -116,21 +124,6 @@ func TestCompactModeHighBandwidthCap(t *testing.T) {
 	}
 	if modeTwo != maxHighBandwidthCompactPeers {
 		t.Fatalf("mode=2 peers=%d, want %d", modeTwo, maxHighBandwidthCompactPeers)
-	}
-}
-
-func TestCompactMissRateDowngradesToFullBlockMode(t *testing.T) {
-	h := newTestHarness(t, 2, "127.0.0.1:0", nil)
-	h.service.cfg.CompactRelayMode = 2
-	h.service.cfg.CompactRelayReady = true
-	h.service.cfg.CompactMissRatePct = 12.0
-	h.service.cfg.CompactMissBlocks = 5
-	h.service.cfg.CompactPeerScore = func(node.PeerState) int { return 90 }
-	markCompactRelayReadyNow(t, h)
-
-	p := testPeerForService(h.service, "compact-peer-miss", 0)
-	if got := h.service.desiredCompactMode(p); got != 0 {
-		t.Fatalf("compact mode after high miss rate=%d, want 0", got)
 	}
 }
 

--- a/clients/go/node/p2p/compact_runtime_test.go
+++ b/clients/go/node/p2p/compact_runtime_test.go
@@ -1,14 +1,8 @@
 package p2p
 
 import (
-	"context"
 	"encoding/binary"
-	"net"
 	"testing"
-	"time"
-
-	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
-	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/node"
 )
 
 func TestSendCmpctPostHandshakeCommandPathRecordsPeerMode(t *testing.T) {
@@ -39,86 +33,6 @@ func TestSendCmpctPostHandshakeCommandPathRecordsPeerMode(t *testing.T) {
 	if err := p.handleMessage(message{Command: messageSendCmpct, Payload: sendCmpctRuntimePayload(t, 3, compactRelayVersion)}); err == nil {
 		t.Fatal("unknown sendcmpct mode must fail")
 	}
-}
-
-func TestPostHandshakeSendCmpctPhaseGate(t *testing.T) {
-	for _, tc := range []struct {
-		name     string
-		blocks   int
-		mode     uint8
-		peerOK   bool
-		want     string
-		wantMode uint8
-	}{
-		{"eligible peer advertises full-block mode", 2, 1, true, messageSendCmpct, 0},
-		{"unknown capability keeps full block", 2, 1, false, messageGetAddr, 0},
-		{"ibd keeps full block", 0, 2, true, messageGetBlk, 0},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			h := newTestHarness(t, tc.blocks, "127.0.0.1:0", nil)
-			h.service.ctx = context.Background()
-			h.service.cfg.CompactRelayMode = tc.mode
-			if tc.peerOK {
-				h.service.cfg.CompactRelayPeerOK = func(node.PeerState) bool { return true }
-			}
-			if tc.blocks > 0 {
-				markCompactRelayReadyNow(t, h)
-			}
-			local, remote := net.Pipe()
-			defer local.Close()
-			defer remote.Close()
-			errCh := make(chan error, 1)
-			go func() { errCh <- h.service.handleConn(local, "") }()
-			remoteVersion := testVersionPayload(node.DevnetGenesisChainID(), node.DevnetGenesisBlockHash(), "remote", 0)
-			if err := completeRemoteHandshake(remote, h.service.cfg.PeerRuntimeConfig, remoteVersion); err != nil {
-				t.Fatalf("remote handshake: %v", err)
-			}
-			frame, err := readFrame(remote, networkMagic(h.service.cfg.PeerRuntimeConfig.Network), h.service.cfg.PeerRuntimeConfig.MaxMessageSize)
-			if err != nil {
-				t.Fatalf("read post-handshake frame: %v", err)
-			}
-			if frame.Command != tc.want {
-				t.Fatalf("first post-handshake command=%q, want %q", frame.Command, tc.want)
-			}
-			if tc.want == messageSendCmpct {
-				assertSendCmpctPayload(t, frame.Payload, tc.wantMode)
-			}
-			_ = remote.Close()
-			select {
-			case <-errCh:
-			case <-time.After(2 * time.Second):
-				t.Fatal("handleConn did not exit after remote close")
-			}
-		})
-	}
-}
-
-func assertSendCmpctPayload(t *testing.T, payload []byte, wantMode uint8) {
-	t.Helper()
-	got, err := decodeSendCmpctPayload(payload)
-	if err != nil {
-		t.Fatalf("decode sendcmpct: %v", err)
-	}
-	if got.Mode != wantMode || got.Version != compactRelayVersion {
-		t.Fatalf("sendcmpct=%+v, want mode=%d version=%d", got, wantMode, compactRelayVersion)
-	}
-}
-
-func markCompactRelayReadyNow(t *testing.T, h *testHarness) {
-	t.Helper()
-	_, hash, ok, err := h.blockStore.Tip()
-	if err != nil || !ok {
-		t.Fatalf("tip: ok=%v err=%v", ok, err)
-	}
-	block, err := h.blockStore.GetBlockByHash(hash)
-	if err != nil {
-		t.Fatalf("GetBlockByHash(tip): %v", err)
-	}
-	parsed, err := consensus.ParseBlockBytes(block)
-	if err != nil {
-		t.Fatalf("ParseBlockBytes(tip): %v", err)
-	}
-	h.service.cfg.Now = func() time.Time { return time.Unix(int64(parsed.Header.Timestamp+1), 0) }
 }
 
 func sendCmpctRuntimePayload(t *testing.T, mode uint8, version uint64) []byte {

--- a/clients/go/node/p2p/compact_wire_test.go
+++ b/clients/go/node/p2p/compact_wire_test.go
@@ -27,6 +27,12 @@ func TestCompactWireCommandConstantsAndPayloadCaps(t *testing.T) {
 		if (command == messageCmpctBlock || command == messageBlockTxn) && caps[i] <= uint32(consensus.MAX_BLOCK_BYTES) {
 			t.Fatalf("%s explicit cap=%d, want above MAX_BLOCK_BYTES", command, caps[i])
 		}
+		if command == messageSendCmpct {
+			if got := liveCaps(command); got != sendCmpctPayloadBytes {
+				t.Fatalf("%s live cap=%d, want %d", command, got, sendCmpctPayloadBytes)
+			}
+			continue
+		}
 		if got := liveCaps(command); got != 0 {
 			t.Fatalf("%s live cap=%d, want 0 until runtime handler slice", command, got)
 		}

--- a/clients/go/node/p2p/peer_runtime.go
+++ b/clients/go/node/p2p/peer_runtime.go
@@ -86,6 +86,8 @@ func (p *peer) handleMessage(frame message) error {
 	switch frame.Command {
 	case messageInv, messageGetData, messageBlock, messageTx, messageGetBlk:
 		return p.handleRelayMessage(frame)
+	case messageSendCmpct:
+		return p.handleSendCmpct(frame.Payload)
 	case messageGetAddr, messageAddr:
 		return p.handleAddressMessage(frame)
 	case messagePing, messagePong, messageHeaders:

--- a/clients/go/node/p2p/service.go
+++ b/clients/go/node/p2p/service.go
@@ -27,6 +27,7 @@ type ServiceConfig struct {
 	LocatorLimit       int
 	GetBlocksBatchSize uint64
 	TxRelayFanout      int
+	CompactRelayMode   uint8
 	PeerRuntimeConfig  node.PeerRuntimeConfig
 	PeerManager        *node.PeerManager
 	SyncConfig         node.SyncConfig
@@ -74,6 +75,7 @@ type Service struct {
 	outboundAddrs  []string
 	addrMgr        *addrManager
 	handshakeSlots chan struct{}
+	compactMu      sync.Mutex
 
 	chainMu   sync.Mutex
 	blockSeen *boundedHashSet
@@ -103,6 +105,9 @@ type peer struct {
 	state   node.PeerState
 
 	writeMu sync.Mutex
+
+	compactMu sync.Mutex
+	compact   peerCompactRelayState
 }
 
 func NewService(cfg ServiceConfig) (*Service, error) {
@@ -137,6 +142,7 @@ func validateServiceConfig(cfg ServiceConfig) error {
 		{cfg.SyncEngine == nil, "nil sync engine"},
 		{cfg.BlockStore == nil, "nil blockstore"},
 		{cfg.TxMetadataFunc == nil, "nil tx metadata func"},
+		{cfg.CompactRelayMode > 2, "unsupported compact relay mode"},
 	} {
 		if check.invalid {
 			return errors.New(check.err)

--- a/clients/go/node/p2p/service.go
+++ b/clients/go/node/p2p/service.go
@@ -28,6 +28,10 @@ type ServiceConfig struct {
 	GetBlocksBatchSize uint64
 	TxRelayFanout      int
 	CompactRelayMode   uint8
+	CompactRelayReady  bool
+	CompactMissRatePct float64
+	CompactMissBlocks  int
+	CompactPeerScore   func(node.PeerState) int
 	PeerRuntimeConfig  node.PeerRuntimeConfig
 	PeerManager        *node.PeerManager
 	SyncConfig         node.SyncConfig
@@ -143,6 +147,7 @@ func validateServiceConfig(cfg ServiceConfig) error {
 		{cfg.BlockStore == nil, "nil blockstore"},
 		{cfg.TxMetadataFunc == nil, "nil tx metadata func"},
 		{cfg.CompactRelayMode > 2, "unsupported compact relay mode"},
+		{cfg.CompactMissRatePct < 0, "negative compact miss rate"},
 	} {
 		if check.invalid {
 			return errors.New(check.err)
@@ -160,6 +165,9 @@ func normalizeServiceConfig(cfg ServiceConfig) ServiceConfig {
 	cfg.PeerRuntimeConfig = normalizeServicePeerRuntimeConfig(cfg.PeerRuntimeConfig, cfg.SyncConfig.Network)
 	if cfg.TxRelayFanout <= 0 {
 		cfg.TxRelayFanout = defaultTxRelayFanout
+	}
+	if cfg.CompactPeerScore == nil {
+		cfg.CompactPeerScore = func(node.PeerState) int { return 50 }
 	}
 	return cfg
 }

--- a/clients/go/node/p2p/service.go
+++ b/clients/go/node/p2p/service.go
@@ -27,8 +27,6 @@ type ServiceConfig struct {
 	LocatorLimit       int
 	GetBlocksBatchSize uint64
 	TxRelayFanout      int
-	CompactRelayMode   uint8
-	CompactRelayPeerOK func(node.PeerState) bool
 	PeerRuntimeConfig  node.PeerRuntimeConfig
 	PeerManager        *node.PeerManager
 	SyncConfig         node.SyncConfig
@@ -142,7 +140,6 @@ func validateServiceConfig(cfg ServiceConfig) error {
 		{cfg.SyncEngine == nil, "nil sync engine"},
 		{cfg.BlockStore == nil, "nil blockstore"},
 		{cfg.TxMetadataFunc == nil, "nil tx metadata func"},
-		{cfg.CompactRelayMode > 2, "unsupported compact relay mode"},
 	} {
 		if check.invalid {
 			return errors.New(check.err)

--- a/clients/go/node/p2p/service.go
+++ b/clients/go/node/p2p/service.go
@@ -28,11 +28,7 @@ type ServiceConfig struct {
 	GetBlocksBatchSize uint64
 	TxRelayFanout      int
 	CompactRelayMode   uint8
-	CompactRelayReady  bool
-	CompactMissRatePct float64
-	CompactMissBlocks  int
 	CompactRelayPeerOK func(node.PeerState) bool
-	CompactPeerScore   func(node.PeerState) int
 	PeerRuntimeConfig  node.PeerRuntimeConfig
 	PeerManager        *node.PeerManager
 	SyncConfig         node.SyncConfig
@@ -80,7 +76,6 @@ type Service struct {
 	outboundAddrs  []string
 	addrMgr        *addrManager
 	handshakeSlots chan struct{}
-	compactMu      sync.Mutex
 
 	chainMu   sync.Mutex
 	blockSeen *boundedHashSet
@@ -148,7 +143,6 @@ func validateServiceConfig(cfg ServiceConfig) error {
 		{cfg.BlockStore == nil, "nil blockstore"},
 		{cfg.TxMetadataFunc == nil, "nil tx metadata func"},
 		{cfg.CompactRelayMode > 2, "unsupported compact relay mode"},
-		{cfg.CompactMissRatePct < 0, "negative compact miss rate"},
 	} {
 		if check.invalid {
 			return errors.New(check.err)
@@ -166,9 +160,6 @@ func normalizeServiceConfig(cfg ServiceConfig) ServiceConfig {
 	cfg.PeerRuntimeConfig = normalizeServicePeerRuntimeConfig(cfg.PeerRuntimeConfig, cfg.SyncConfig.Network)
 	if cfg.TxRelayFanout <= 0 {
 		cfg.TxRelayFanout = defaultTxRelayFanout
-	}
-	if cfg.CompactPeerScore == nil {
-		cfg.CompactPeerScore = func(node.PeerState) int { return 50 }
 	}
 	return cfg
 }

--- a/clients/go/node/p2p/service.go
+++ b/clients/go/node/p2p/service.go
@@ -31,6 +31,7 @@ type ServiceConfig struct {
 	CompactRelayReady  bool
 	CompactMissRatePct float64
 	CompactMissBlocks  int
+	CompactRelayPeerOK func(node.PeerState) bool
 	CompactPeerScore   func(node.PeerState) int
 	PeerRuntimeConfig  node.PeerRuntimeConfig
 	PeerManager        *node.PeerManager

--- a/clients/go/node/p2p/service_peer_lifecycle.go
+++ b/clients/go/node/p2p/service_peer_lifecycle.go
@@ -51,10 +51,6 @@ func (s *Service) handleConn(conn net.Conn, outboundAddr string) error {
 	defer s.unregisterPeer(current)
 
 	s.cfg.SyncEngine.RecordBestKnownHeight(state.RemoteVersion.BestHeight)
-	if err := s.advertiseCompactRelayMode(current); err != nil {
-		current.setLastError(err.Error())
-		return err
-	}
 	if err := s.requestBlocksIfBehind(current); err != nil {
 		current.setLastError(err.Error())
 		return err

--- a/clients/go/node/p2p/service_peer_lifecycle.go
+++ b/clients/go/node/p2p/service_peer_lifecycle.go
@@ -51,6 +51,10 @@ func (s *Service) handleConn(conn net.Conn, outboundAddr string) error {
 	defer s.unregisterPeer(current)
 
 	s.cfg.SyncEngine.RecordBestKnownHeight(state.RemoteVersion.BestHeight)
+	if err := s.advertiseCompactRelayMode(current); err != nil {
+		current.setLastError(err.Error())
+		return err
+	}
 	if err := s.requestBlocksIfBehind(current); err != nil {
 		current.setLastError(err.Error())
 		return err

--- a/clients/go/node/p2p/wire_payload_limits.go
+++ b/clients/go/node/p2p/wire_payload_limits.go
@@ -47,6 +47,8 @@ func postHandshakePayloadCap(locatorLimit int, headerBatchLimit uint64) payloadL
 			return versionPayloadBytes
 		case messageVerAck, messageGetAddr, messagePing, messagePong:
 			return 0
+		case messageSendCmpct:
+			return compactRelayPayloadCap(command)
 		case messageInv, messageGetData:
 			return inventoryPayloadCap()
 		case messageAddr:

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -37,6 +37,9 @@ const MESSAGE_TX: &str = "tx";
 const MESSAGE_GETBLOCKS: &str = "getblocks";
 const MESSAGE_GETADDR: &str = "getaddr";
 const MESSAGE_ADDR: &str = "addr";
+const MESSAGE_SENDCMPCT: &str = "sendcmpct";
+const COMPACT_RELAY_VERSION: u64 = 1;
+const SENDCMPCT_PAYLOAD_BYTES: u64 = 9;
 pub const MSG_BLOCK: u8 = 0x01;
 pub const MSG_TX: u8 = 0x02;
 const INVENTORY_VECTOR_SIZE: usize = 33;
@@ -169,6 +172,12 @@ pub struct LiveMessageOutcome {
     pub tx_pool_cleanup: TxPoolCleanupPlan,
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct CompactModeSnapshot {
+    mode: u8,
+    version: u64,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct OrphanBlockEntry {
     block_hash: [u8; 32],
@@ -199,6 +208,7 @@ pub struct PeerSession {
     orphans: OrphanBlockPool,
     pending_tx_pool_cleanup: TxPoolCleanupPlan,
     prefetched_read_byte: Option<u8>,
+    remote_compact_mode: CompactModeSnapshot,
 }
 
 pub struct PeerManager {
@@ -316,6 +326,7 @@ impl PeerSession {
             orphans: OrphanBlockPool::new(DEFAULT_ORPHAN_LIMIT, DEFAULT_ORPHAN_BYTE_LIMIT),
             pending_tx_pool_cleanup: TxPoolCleanupPlan::default(),
             prefetched_read_byte: None,
+            remote_compact_mode: CompactModeSnapshot::default(),
         })
     }
 
@@ -458,6 +469,9 @@ impl PeerSession {
                 }
                 "tx" | "block" | "headers" | "getaddr" | "addr" => {
                     // accepted runtime commands (stub)
+                }
+                MESSAGE_SENDCMPCT => {
+                    self.handle_sendcmpct(&msg.payload)?;
                 }
                 other => {
                     self.peer.last_error = format!("unknown command: {other}");
@@ -713,6 +727,13 @@ impl PeerSession {
                 responses: Vec::new(),
                 tx_pool_cleanup: TxPoolCleanupPlan::default(),
             }),
+            MESSAGE_SENDCMPCT => {
+                self.handle_sendcmpct(&msg.payload)?;
+                Ok(LiveMessageOutcome {
+                    responses: Vec::new(),
+                    tx_pool_cleanup: TxPoolCleanupPlan::default(),
+                })
+            }
             "ping" => Ok(LiveMessageOutcome {
                 responses: vec![WireMessage {
                     command: "pong".to_string(),
@@ -752,6 +773,22 @@ impl PeerSession {
             self.write_message(&response)?;
         }
         Ok(outcome.tx_pool_cleanup)
+    }
+
+    fn handle_sendcmpct(&mut self, payload: &[u8]) -> io::Result<()> {
+        let msg = parse_sendcmpct_runtime_payload(payload)?;
+        if msg.version != COMPACT_RELAY_VERSION {
+            self.remote_compact_mode = CompactModeSnapshot {
+                mode: 0,
+                version: msg.version,
+            };
+            return Ok(());
+        }
+        self.remote_compact_mode = CompactModeSnapshot {
+            mode: msg.mode,
+            version: msg.version,
+        };
+        Ok(())
     }
 
     // Historically used by the inline run_block_sync_loop match; preserved under
@@ -1751,12 +1788,35 @@ fn runtime_payload_cap(command: &str) -> u64 {
     match command {
         "version" => VERSION_PAYLOAD_BYTES,
         "verack" | "ping" | "pong" | MESSAGE_GETADDR => 0,
+        MESSAGE_SENDCMPCT => SENDCMPCT_PAYLOAD_BYTES,
         MESSAGE_INV | MESSAGE_GETDATA | MESSAGE_GETBLOCKS => MAX_INVENTORY_PAYLOAD_BYTES,
         MESSAGE_ADDR => MAX_ADDR_PAYLOAD_BYTES,
         MESSAGE_BLOCK | MESSAGE_TX => MAX_BLOCK_BYTES,
         "headers" => MAX_HEADERS_PAYLOAD_BYTES,
         _ => 0,
     }
+}
+
+fn parse_sendcmpct_runtime_payload(payload: &[u8]) -> io::Result<CompactModeSnapshot> {
+    if payload.len() != SENDCMPCT_PAYLOAD_BYTES as usize {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "sendcmpct payload width mismatch",
+        ));
+    }
+    let mut version = [0u8; 8];
+    version.copy_from_slice(&payload[1..]);
+    let out = CompactModeSnapshot {
+        mode: payload[0],
+        version: u64::from_le_bytes(version),
+    };
+    if out.version == COMPACT_RELAY_VERSION && out.mode > 2 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "unsupported compact relay mode",
+        ));
+    }
+    Ok(out)
 }
 
 fn pre_handshake_payload_cap(command: &str) -> u64 {
@@ -2081,6 +2141,13 @@ mod tests {
             .apply_block(&devnet_genesis_block_bytes(), None)
             .expect("apply genesis");
         engine
+    }
+
+    fn sendcmpct_runtime_payload(mode: u8, version: u64) -> Vec<u8> {
+        let mut payload = vec![0u8; SENDCMPCT_PAYLOAD_BYTES as usize];
+        payload[0] = mode;
+        payload[1..].copy_from_slice(&version.to_le_bytes());
+        payload
     }
 
     fn build_block_bytes(
@@ -2983,6 +3050,7 @@ mod tests {
         assert!(runtime_payload_cap(MESSAGE_GETBLOCKS) > 0);
         assert!(runtime_payload_cap(MESSAGE_GETDATA) > 0);
         assert!(runtime_payload_cap(MESSAGE_ADDR) > 0);
+        assert!(runtime_payload_cap(MESSAGE_SENDCMPCT) == SENDCMPCT_PAYLOAD_BYTES);
 
         // headers gets an explicit cap matching MAX_HEADERS_PAYLOAD_BYTES.
         assert_eq!(runtime_payload_cap("headers"), MAX_HEADERS_PAYLOAD_BYTES);
@@ -2992,6 +3060,79 @@ mod tests {
         assert_eq!(runtime_payload_cap("unknown"), 0);
         assert_eq!(runtime_payload_cap("malicious_cmd"), 0);
         assert_eq!(runtime_payload_cap(""), 0);
+    }
+
+    #[test]
+    fn sendcmpct_live_dispatch_records_peer_mode() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let client = TcpStream::connect(listener.local_addr().expect("addr")).expect("connect");
+        let (stream, _) = listener.accept().expect("accept");
+        let mut session =
+            PeerSession::new(stream, default_peer_runtime_config("devnet", 8)).expect("session");
+        let mut engine = test_sync_engine_with_genesis();
+
+        let outcome = session
+            .collect_live_responses(
+                WireMessage {
+                    command: MESSAGE_SENDCMPCT.to_string(),
+                    payload: sendcmpct_runtime_payload(2, COMPACT_RELAY_VERSION),
+                },
+                &mut engine,
+                None,
+            )
+            .expect("current sendcmpct");
+        assert!(outcome.responses.is_empty());
+        assert_eq!(
+            session.remote_compact_mode,
+            CompactModeSnapshot {
+                mode: 2,
+                version: COMPACT_RELAY_VERSION
+            }
+        );
+
+        session
+            .collect_live_responses(
+                WireMessage {
+                    command: MESSAGE_SENDCMPCT.to_string(),
+                    payload: sendcmpct_runtime_payload(3, COMPACT_RELAY_VERSION + 1),
+                },
+                &mut engine,
+                None,
+            )
+            .expect("future version downgrades before future-mode validation");
+        assert_eq!(
+            session.remote_compact_mode,
+            CompactModeSnapshot {
+                mode: 0,
+                version: COMPACT_RELAY_VERSION + 1
+            }
+        );
+
+        let err = session
+            .collect_live_responses(
+                WireMessage {
+                    command: MESSAGE_SENDCMPCT.to_string(),
+                    payload: vec![1, 2],
+                },
+                &mut engine,
+                None,
+            )
+            .err()
+            .expect("short sendcmpct payload must fail");
+        assert!(err.to_string().contains("sendcmpct payload width mismatch"));
+        let err = session
+            .collect_live_responses(
+                WireMessage {
+                    command: MESSAGE_SENDCMPCT.to_string(),
+                    payload: sendcmpct_runtime_payload(3, COMPACT_RELAY_VERSION),
+                },
+                &mut engine,
+                None,
+            )
+            .err()
+            .expect("current-version unknown mode must fail");
+        assert!(err.to_string().contains("unsupported compact relay mode"));
+        drop(client);
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -777,13 +777,6 @@ impl PeerSession {
 
     fn handle_sendcmpct(&mut self, payload: &[u8]) -> io::Result<()> {
         let msg = parse_sendcmpct_runtime_payload(payload)?;
-        if msg.version != COMPACT_RELAY_VERSION {
-            self.remote_compact_mode = CompactModeSnapshot {
-                mode: 0,
-                version: msg.version,
-            };
-            return Ok(());
-        }
         self.remote_compact_mode = CompactModeSnapshot {
             mode: msg.mode,
             version: msg.version,
@@ -1810,7 +1803,13 @@ fn parse_sendcmpct_runtime_payload(payload: &[u8]) -> io::Result<CompactModeSnap
         mode: payload[0],
         version: u64::from_le_bytes(version),
     };
-    if out.version == COMPACT_RELAY_VERSION && out.mode > 2 {
+    if out.version != COMPACT_RELAY_VERSION {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "unsupported compact relay version",
+        ));
+    }
+    if out.mode > 2 {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             "unsupported compact relay mode",
@@ -3090,7 +3089,7 @@ mod tests {
             }
         );
 
-        session
+        let err = session
             .collect_live_responses(
                 WireMessage {
                     command: MESSAGE_SENDCMPCT.to_string(),
@@ -3099,12 +3098,16 @@ mod tests {
                 &mut engine,
                 None,
             )
-            .expect("future version downgrades before future-mode validation");
+            .err()
+            .expect("future version must fail before future-mode validation");
+        assert!(err
+            .to_string()
+            .contains("unsupported compact relay version"));
         assert_eq!(
             session.remote_compact_mode,
             CompactModeSnapshot {
-                mode: 0,
-                version: COMPACT_RELAY_VERSION + 1
+                mode: 2,
+                version: COMPACT_RELAY_VERSION
             }
         );
 


### PR DESCRIPTION
Invariant:
RUB-311 wires peer-local inbound sendcmpct negotiation without enabling compact block traffic.

Source-of-truth:
- RUBIN_L1_P2P_AUX §4.1 defines sendcmpct as 9 bytes: mode u8 + version u64le.
- RUBIN_COMPACT_BLOCKS §3/§9 defines mode 0/1/2 semantics and full-block fallback.
- POLICY_P2P_TRANSPORT_HARDENING §6 treats unsupported compact relay wire version as malformed relay input.
- Existing Go compact codec rejects unsupported sendcmpct versions.

Layer:
implementation / tests; no consensus or policy change.

Files changed:
- Go P2P runtime: accept inbound sendcmpct, record peer-local remote mode, cap payload at 9.
- Rust P2P runtime: minimal inbound parity for the same command/cap/errors.
- Tests: live dispatch, malformed width, unsupported version before mode validation, current-version invalid mode.

Behavior impact:
- Valid sendcmpct version 1 mode 0/1/2 is recorded peer-locally.
- version != 1 rejects with unsupported compact relay version before mode validation.
- current-version mode > 2 rejects with unsupported compact relay mode.
- No outbound sendcmpct is emitted.
- No cmpctblock/getblocktxn/blocktxn runtime handling is added.

Tests:
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node/p2p -count=1'
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -race ./node/p2p -run "SendCmpct|CompactMode|PostHandshake" -count=1'
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go vet ./node/p2p'
- scripts/dev-env.sh -- bash -lc 'cd clients/go && gosec ./node/p2p'
- scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test -p rubin-node runtime_payload_cap_rejects_unknown_commands -- --nocapture'
- scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test -p rubin-node p2p_runtime -- --nocapture'
- scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test -p rubin-node'
- scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo clippy -p rubin-node -- -D warnings'
- git diff --check
- rubin-precommit-one-review --repo . --base-ref origin/main
- rubin-push --repo . --base-ref origin/main --coverage-cmd <same Go/Rust gate set>

Review:
- Stock isolated raw-diff reviewer: No findings.

Risk:
Medium-low: P2P runtime dispatch changes, but compact block traffic remains disabled beyond sendcmpct negotiation.

Non-goals:
- No outbound compact relay advertisement.
- No compact block reconstruction/request handling.
- No consensus, codec, fixture, or policy changes.
