### PR TITLE
[RUB-326] Wire Go compact blocktxn flow

### DIFF
--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -22,6 +22,9 @@ func reconstructCompactBlock(p cmpctBlockPayload, localTxs [][]byte) (compactRec
 	if err != nil {
 		return compactReconstructionResult{}, err
 	}
+	if totalEntries > maxCompactRelayEntries {
+		return compactReconstructionResult{}, errCompactRelayMissingRequestTooLarge
+	}
 	prefilledShortIDs, _, err := compactPrefilledShortIDs(p.Prefilled, totalEntries, p.Nonce1, p.Nonce2)
 	if err != nil {
 		return compactReconstructionResult{}, err
@@ -254,7 +257,7 @@ func (p *peer) handleCmpctBlock(payload []byte) error {
 		return err
 	}
 	if result.Transactions != nil {
-		return p.processCompactTransactions(block.Header, result.Transactions)
+		return p.processCompactTransactions(blockHash, block.Header, result.Transactions)
 	}
 	req, err := newCompactOutstandingRequest(block, blockHash, result)
 	if err != nil {
@@ -322,8 +325,8 @@ func (p *peer) handleBlockTxn(payload []byte) error {
 	if err != nil {
 		return p.requestCompactFullBlockFallback(req.BlockHash)
 	}
-	if err := p.processCompactTransactions(req.Header, txs); err != nil {
-		return p.requestCompactFullBlockFallback(req.BlockHash)
+	if err := p.processCompactTransactions(req.BlockHash, req.Header, txs); err != nil {
+		return err
 	}
 	return nil
 }
@@ -401,16 +404,45 @@ func compactFillResponseTransactions(req compactOutstandingRequest, responseTxs 
 	return txs, nil
 }
 
-func (p *peer) processCompactTransactions(header [consensus.BLOCK_HEADER_BYTES]byte, txs [][]byte) error {
+func (p *peer) processCompactTransactions(blockHash [32]byte, header [consensus.BLOCK_HEADER_BYTES]byte, txs [][]byte) error {
 	blockBytes, err := compactBlockBytes(header, txs)
 	if err != nil {
-		return err
+		return p.requestCompactFullBlockFallback(blockHash)
 	}
-	summary, err := p.processRelayedBlock(blockBytes)
-	if err != nil || summary == nil {
-		return err
+	accepted, err := p.processCompactRelayedBlock(blockHash, blockBytes)
+	if err != nil {
+		return p.requestCompactFullBlockFallback(blockHash)
+	}
+	if !accepted {
+		return nil
 	}
 	return p.service.requestBlocksIfBehind(p)
+}
+
+func (p *peer) processCompactRelayedBlock(expectedHash [32]byte, blockBytes []byte) (bool, error) {
+	pb, blockHash, err := parseRelayedBlock(blockBytes)
+	if err != nil {
+		return false, err
+	}
+	if pb == nil {
+		return false, errors.New("nil parsed block")
+	}
+	if blockHash != expectedHash {
+		return false, errors.New("compact block hash mismatch")
+	}
+	have, err := p.service.hasBlock(blockHash)
+	if err != nil || have {
+		return false, err
+	}
+
+	p.service.chainMu.Lock()
+	summary, err := p.service.cfg.SyncEngine.ApplyBlockWithReorg(blockBytes, nil)
+	p.service.chainMu.Unlock()
+	if err != nil {
+		return false, err
+	}
+	p.acceptedRelayedBlock(blockHash, summary)
+	return true, nil
 }
 
 func (p *peer) requestCompactFullBlockFallbackForOutstanding(cause error) error {

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -248,7 +248,7 @@ func (p *peer) handleCmpctBlock(payload []byte) error {
 	}
 	result, err := reconstructCompactBlock(block, compactRelayLocalTransactions(p.service.cfg.TxPool))
 	if errors.Is(err, errCompactRelayMissingRequestTooLarge) {
-		return nil
+		return p.requestCompactFullBlockFallback(blockHash)
 	}
 	if err != nil {
 		return err
@@ -299,20 +299,23 @@ func (p *peer) handleGetBlockTxn(payload []byte) error {
 func (p *peer) handleBlockTxn(payload []byte) error {
 	response, err := decodeBlockTxnRuntimePayload(payload)
 	if err != nil {
-		return err
+		return p.requestCompactFullBlockFallbackForOutstanding(err)
 	}
-	req, ok := p.takeCompactOutstandingRequest(response.BlockHash)
+	req, ok := p.popCompactOutstandingRequest()
 	if !ok {
 		return errors.New("unexpected blocktxn response")
 	}
-	if len(response.Transactions) != len(req.MissingIndexes) {
-		return errors.New("blocktxn transaction count mismatch")
+	if response.BlockHash != req.BlockHash {
+		return p.requestCompactFullBlockFallback(req.BlockHash)
 	}
 	txs, err := compactFillResponseTransactions(req, response.Transactions, response.WTxIDs)
 	if err != nil {
-		return err
+		return p.requestCompactFullBlockFallback(req.BlockHash)
 	}
-	return p.processCompactTransactions(req.Header, txs)
+	if err := p.processCompactTransactions(req.Header, txs); err != nil {
+		return p.requestCompactFullBlockFallback(req.BlockHash)
+	}
+	return nil
 }
 
 func newCompactOutstandingRequest(block cmpctBlockPayload, blockHash [32]byte, result compactReconstructionResult) (compactOutstandingRequest, error) {
@@ -372,6 +375,22 @@ func (p *peer) processCompactTransactions(header [consensus.BLOCK_HEADER_BYTES]b
 		return err
 	}
 	return p.service.requestBlocksIfBehind(p)
+}
+
+func (p *peer) requestCompactFullBlockFallbackForOutstanding(cause error) error {
+	req, ok := p.popCompactOutstandingRequest()
+	if !ok {
+		return cause
+	}
+	return p.requestCompactFullBlockFallback(req.BlockHash)
+}
+
+func (p *peer) requestCompactFullBlockFallback(blockHash [32]byte) error {
+	body, err := encodeInventoryVectors([]InventoryVector{{Type: MSG_BLOCK, Hash: blockHash}})
+	if err != nil {
+		return err
+	}
+	return p.send(messageGetData, body)
 }
 
 func compactBlockBytes(header [consensus.BLOCK_HEADER_BYTES]byte, txs [][]byte) ([]byte, error) {
@@ -523,7 +542,7 @@ func (p *peer) clearCompactOutstandingRequest() {
 	p.compactMu.Unlock()
 }
 
-func (p *peer) takeCompactOutstandingRequest(blockHash [32]byte) (compactOutstandingRequest, bool) {
+func (p *peer) popCompactOutstandingRequest() (compactOutstandingRequest, bool) {
 	p.compactMu.Lock()
 	defer p.compactMu.Unlock()
 	if p.compact.outstanding == nil {
@@ -531,7 +550,7 @@ func (p *peer) takeCompactOutstandingRequest(blockHash [32]byte) (compactOutstan
 	}
 	req := cloneCompactOutstandingRequest(*p.compact.outstanding)
 	p.compact.outstanding = nil
-	return req, req.BlockHash == blockHash
+	return req, true
 }
 
 func (p *peer) compactOutstandingRequestSnapshot() (compactOutstandingRequest, bool) {

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -242,12 +242,12 @@ func (p *peer) handleCmpctBlock(payload []byte) error {
 	if err := p.validateCompactBlockHeader(header); err != nil {
 		return err
 	}
-	have, err := p.service.hasBlock(blockHash)
-	if err != nil || have {
-		return err
-	}
 	block, err := decodeCmpctBlockPayload(payload)
 	if err != nil {
+		return err
+	}
+	have, err := p.service.hasBlock(blockHash)
+	if err != nil || have {
 		return err
 	}
 	result, err := reconstructCompactBlock(block, compactRelayLocalTransactions(p.service.cfg.TxPool))

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -931,6 +931,9 @@ func (p *peer) setLateBlockTxnReply(req compactOutstandingRequest) {
 		return
 	}
 	p.compactMu.Lock()
+	if p.compact.lateBlockTxnReply != nil && p.compact.lateBlockTxnReply.Cap > cap {
+		cap = p.compact.lateBlockTxnReply.Cap
+	}
 	p.compact.lateBlockTxnReply = &compactLateBlockTxnReply{
 		BlockHash: req.BlockHash,
 		Cap:       cap,
@@ -949,6 +952,7 @@ func (p *peer) clearKnownCompactOutstandingRequest() error {
 		return err
 	}
 	if have {
+		p.setLateBlockTxnReply(req)
 		p.clearCompactOutstandingRequestForHash(req.BlockHash)
 	}
 	return nil
@@ -960,10 +964,6 @@ func (p *peer) clearCompactOutstandingRequestForHash(blockHash [32]byte) bool {
 	cleared := false
 	if p.compact.outstanding != nil && p.compact.outstanding.BlockHash == blockHash {
 		p.compact.outstanding = nil
-		cleared = true
-	}
-	if p.compact.lateBlockTxnReply != nil && p.compact.lateBlockTxnReply.BlockHash == blockHash {
-		p.compact.lateBlockTxnReply = nil
 		cleared = true
 	}
 	return cleared

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -231,19 +231,19 @@ type compactOutstandingRequest struct {
 }
 
 func (p *peer) handleCmpctBlock(payload []byte) error {
-	block, err := decodeCmpctBlockPayload(payload)
+	header, blockHash, err := compactBlockHeaderAndHash(payload)
 	if err != nil {
 		return err
 	}
-	blockHash, err := consensus.BlockHash(block.Header[:])
-	if err != nil {
-		return err
-	}
-	if err := p.validateCompactBlockHeader(block.Header); err != nil {
+	if err := p.validateCompactBlockHeader(header); err != nil {
 		return err
 	}
 	have, err := p.service.hasBlock(blockHash)
 	if err != nil || have {
+		return err
+	}
+	block, err := decodeCmpctBlockPayload(payload)
+	if err != nil {
 		return err
 	}
 	result, err := reconstructCompactBlock(block, compactRelayLocalTransactions(p.service.cfg.TxPool))
@@ -259,6 +259,9 @@ func (p *peer) handleCmpctBlock(payload []byte) error {
 	req, err := newCompactOutstandingRequest(block, blockHash, result)
 	if err != nil {
 		return err
+	}
+	if p.hasCompactOutstandingRequest() {
+		return p.requestCompactFullBlockFallback(blockHash)
 	}
 	body, err := encodeGetBlockTxnPayload(getBlockTxnPayload{BlockHash: blockHash, Indexes: req.MissingIndexes})
 	if err != nil {
@@ -277,15 +280,14 @@ func (p *peer) handleGetBlockTxn(payload []byte) error {
 	if err != nil {
 		return err
 	}
+	if err := validateCompactRequestedIndexShape(req.Indexes); err != nil {
+		return err
+	}
 	blockBytes, ok, err := p.blockBytes(req.BlockHash)
 	if err != nil || !ok {
 		return err
 	}
-	_, txs, err := compactBlockTransactions(blockBytes)
-	if err != nil {
-		return err
-	}
-	responseTxs, err := compactRequestedTransactions(txs, req.Indexes)
+	responseTxs, err := compactRequestedTransactionsFromBlock(blockBytes, req.Indexes)
 	if err != nil {
 		return err
 	}
@@ -297,16 +299,24 @@ func (p *peer) handleGetBlockTxn(payload []byte) error {
 }
 
 func (p *peer) handleBlockTxn(payload []byte) error {
+	req, ok := p.compactOutstandingRequestSnapshot()
+	if !ok {
+		return errors.New("unexpected blocktxn response")
+	}
+	responseHash, err := compactBlockTxnPayloadHash(payload)
+	if err != nil {
+		return p.requestCompactFullBlockFallbackForOutstanding(err)
+	}
+	if responseHash != req.BlockHash {
+		return p.requestCompactFullBlockFallbackForOutstanding(errors.New("unexpected blocktxn response"))
+	}
 	response, err := decodeBlockTxnRuntimePayload(payload)
 	if err != nil {
 		return p.requestCompactFullBlockFallbackForOutstanding(err)
 	}
-	req, ok := p.popCompactOutstandingRequest()
+	req, ok = p.popCompactOutstandingRequest()
 	if !ok {
 		return errors.New("unexpected blocktxn response")
-	}
-	if response.BlockHash != req.BlockHash {
-		return p.requestCompactFullBlockFallback(req.BlockHash)
 	}
 	txs, err := compactFillResponseTransactions(req, response.Transactions, response.WTxIDs)
 	if err != nil {
@@ -333,6 +343,23 @@ func newCompactOutstandingRequest(block cmpctBlockPayload, blockHash [32]byte, r
 	}, nil
 }
 
+func compactBlockHeaderAndHash(payload []byte) ([consensus.BLOCK_HEADER_BYTES]byte, [32]byte, error) {
+	var header [consensus.BLOCK_HEADER_BYTES]byte
+	var blockHash [32]byte
+	if len(payload) > consensus.MAX_RELAY_MSG_BYTES {
+		return header, blockHash, errors.New("cmpctblock payload too large")
+	}
+	if len(payload) < consensus.BLOCK_HEADER_BYTES {
+		return header, blockHash, errors.New("cmpctblock payload missing header or nonce")
+	}
+	copy(header[:], payload[:consensus.BLOCK_HEADER_BYTES])
+	hash, err := consensus.BlockHash(header[:])
+	if err != nil {
+		return header, blockHash, err
+	}
+	return header, hash, nil
+}
+
 func (p *peer) validateCompactBlockHeader(header [consensus.BLOCK_HEADER_BYTES]byte) error {
 	parsed, err := consensus.ParseBlockHeaderBytes(header[:])
 	if err != nil {
@@ -344,6 +371,15 @@ func (p *peer) validateCompactBlockHeader(header [consensus.BLOCK_HEADER_BYTES]b
 		return err
 	}
 	return nil
+}
+
+func compactBlockTxnPayloadHash(payload []byte) ([32]byte, error) {
+	var blockHash [32]byte
+	if len(payload) < 32 {
+		return blockHash, errors.New("blocktxn payload missing block hash")
+	}
+	copy(blockHash[:], payload[:32])
+	return blockHash, nil
 }
 
 func compactFillResponseTransactions(req compactOutstandingRequest, responseTxs [][]byte, responseWTxIDs [][32]byte) ([][]byte, error) {
@@ -447,33 +483,73 @@ func compactBlockTransactions(blockBytes []byte) ([consensus.BLOCK_HEADER_BYTES]
 	return header, txs, nil
 }
 
-func compactRequestedTransactions(txs [][]byte, indexes []uint64) ([][]byte, error) {
-	if err := validateCompactRequestedTransactionIndexes(txs, indexes); err != nil {
+func compactRequestedTransactionsFromBlock(blockBytes []byte, indexes []uint64) ([][]byte, error) {
+	if err := validateCompactRequestedIndexShape(indexes); err != nil {
 		return nil, err
 	}
+	if len(indexes) == 0 {
+		return [][]byte{}, nil
+	}
+	txCount, offset, err := compactBlockTransactionCount(blockBytes)
+	if err != nil {
+		return nil, err
+	}
+	requested := make(map[uint64]int, len(indexes))
+	var maxRequested uint64
+	for pos, idx := range indexes {
+		if idx >= txCount {
+			return nil, errors.New("compact relay index out of range")
+		}
+		requested[idx] = pos
+		if idx > maxRequested {
+			maxRequested = idx
+		}
+	}
 	out := make([][]byte, 0, len(indexes))
-	for _, idx := range indexes {
-		out = append(out, append([]byte(nil), txs[int(idx)]...)) // #nosec G115 -- idx is bounded by len(txs) above.
+	for range indexes {
+		out = append(out, nil)
+	}
+	var totalTxBytes uint64
+	for idx := uint64(0); idx <= maxRequested; idx++ {
+		_, _, _, consumed, err := consensus.ParseTx(blockBytes[offset:])
+		if err != nil {
+			return nil, err
+		}
+		if pos, ok := requested[idx]; ok {
+			nextTotal, err := validateBlockTxnTransactionSize(uint64(consumed), totalTxBytes)
+			if err != nil {
+				return nil, err
+			}
+			out[pos] = append([]byte(nil), blockBytes[offset:offset+consumed]...)
+			totalTxBytes = nextTotal
+		}
+		offset += consumed
 	}
 	return out, nil
 }
 
-func validateCompactRequestedTransactionIndexes(txs [][]byte, indexes []uint64) error {
+func compactBlockTransactionCount(blockBytes []byte) (uint64, int, error) {
+	if len(blockBytes) < consensus.BLOCK_HEADER_BYTES+1 {
+		return 0, 0, errors.New("block too short")
+	}
+	offset := consensus.BLOCK_HEADER_BYTES
+	txCount, consumed, err := consensus.DecodeCompactSize(blockBytes[offset:])
+	if err != nil {
+		return 0, 0, err
+	}
+	if txCount == 0 || txCount > maxCmpctBlockEntries {
+		return 0, 0, errors.New("invalid compact relay entry count")
+	}
+	return txCount, offset + consumed, nil
+}
+
+func validateCompactRequestedIndexShape(indexes []uint64) error {
 	seen := make(map[uint64]struct{}, len(indexes))
-	var totalTxBytes uint64
 	for _, idx := range indexes {
-		if idx >= uint64(len(txs)) {
-			return errors.New("compact relay index out of range")
-		}
 		if _, ok := seen[idx]; ok {
 			return errors.New("duplicate compact relay index")
 		}
 		seen[idx] = struct{}{}
-		nextTotal, err := validateBlockTxnTransactionSize(uint64(len(txs[int(idx)])), totalTxBytes) // #nosec G115 -- idx is bounded by len(txs) above.
-		if err != nil {
-			return err
-		}
-		totalTxBytes = nextTotal
 	}
 	return nil
 }
@@ -534,6 +610,20 @@ func (p *peer) setCompactOutstandingRequest(req compactOutstandingRequest) {
 	clone := cloneCompactOutstandingRequest(req)
 	p.compact.outstanding = &clone
 	p.compactMu.Unlock()
+}
+
+func (p *peer) hasCompactOutstandingRequest() bool {
+	p.compactMu.Lock()
+	defer p.compactMu.Unlock()
+	return p.compact.outstanding != nil
+}
+
+func (p *peer) fallbackCompactOutstandingRequest() error {
+	req, ok := p.popCompactOutstandingRequest()
+	if !ok {
+		return nil
+	}
+	return p.requestCompactFullBlockFallback(req.BlockHash)
 }
 
 func (p *peer) clearCompactOutstandingRequest() {

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -313,6 +313,7 @@ func (p *peer) handleGetBlockTxn(payload []byte) error {
 func (p *peer) handleBlockTxn(payload []byte) error {
 	req, ok := p.compactOutstandingRequestSnapshot()
 	if !ok {
+		p.clearLateBlockTxnReply()
 		return nil
 	}
 	responseHash, err := compactBlockTxnPayloadHash(payload)
@@ -558,6 +559,11 @@ func (p *peer) requestCompactFullBlockFallbackForOutstanding(cause error) error 
 	return p.requestCompactFullBlockFallback(req.BlockHash)
 }
 
+func (p *peer) requestCompactFullBlockFallbackForAbandonedOutstanding(req compactOutstandingRequest) error {
+	p.setLateBlockTxnReply(req)
+	return p.requestCompactFullBlockFallback(req.BlockHash)
+}
+
 func (p *peer) requestCompactFullBlockFallback(blockHash [32]byte) error {
 	body, err := encodeInventoryVectors([]InventoryVector{{Type: MSG_BLOCK, Hash: blockHash}})
 	if err != nil {
@@ -767,6 +773,7 @@ func (p *peer) setCompactOutstandingRequest(req compactOutstandingRequest) {
 	clone := cloneCompactOutstandingRequest(req)
 	clone.ExpiresAt = p.compactOutstandingExpiry()
 	p.compact.outstanding = &clone
+	p.compact.lateBlockTxnReply = nil
 	p.compactMu.Unlock()
 }
 
@@ -783,7 +790,7 @@ func (p *peer) expireCompactOutstandingRequest() error {
 	if !ok {
 		return nil
 	}
-	return p.requestCompactFullBlockFallback(req.BlockHash)
+	return p.requestCompactFullBlockFallbackForAbandonedOutstanding(req)
 }
 
 func (p *peer) expiredCompactOutstandingRequest() (compactOutstandingRequest, bool) {
@@ -830,12 +837,13 @@ func (p *peer) fallbackCompactOutstandingRequest() error {
 	if !ok {
 		return nil
 	}
-	return p.requestCompactFullBlockFallback(req.BlockHash)
+	return p.requestCompactFullBlockFallbackForAbandonedOutstanding(req)
 }
 
 func (p *peer) clearCompactOutstandingRequest() {
 	p.compactMu.Lock()
 	p.compact.outstanding = nil
+	p.compact.lateBlockTxnReply = nil
 	p.compactMu.Unlock()
 }
 
@@ -864,4 +872,42 @@ func cloneCompactOutstandingRequest(req compactOutstandingRequest) compactOutsta
 	req.MissingShortIDs = append([]compactShortID(nil), req.MissingShortIDs...)
 	req.Transactions = cloneCompactTransactions(req.Transactions)
 	return req
+}
+
+func (p *peer) blockTxnPayloadCap() uint32 {
+	p.compactMu.Lock()
+	defer p.compactMu.Unlock()
+	if p.compact.outstanding != nil {
+		return compactBlockTxnResponsePayloadCap(len(p.compact.outstanding.MissingIndexes))
+	}
+	if p.compact.lateBlockTxnReply != nil {
+		return p.compact.lateBlockTxnReply.Cap
+	}
+	return 0
+}
+
+func compactBlockTxnResponsePayloadCap(txCount int) uint32 {
+	if txCount <= 0 {
+		return 0
+	}
+	return uint32(32 + maxCompactSizeBytes + consensus.MAX_BLOCK_BYTES + uint64(txCount)*maxCompactSizeBytes)
+}
+
+func (p *peer) setLateBlockTxnReply(req compactOutstandingRequest) {
+	cap := compactBlockTxnResponsePayloadCap(len(req.MissingIndexes))
+	if cap == 0 {
+		return
+	}
+	p.compactMu.Lock()
+	p.compact.lateBlockTxnReply = &compactLateBlockTxnReply{Cap: cap}
+	p.compactMu.Unlock()
+}
+
+func (p *peer) clearLateBlockTxnReply() {
+	p.compactMu.Lock()
+	defer p.compactMu.Unlock()
+	if p.compact.lateBlockTxnReply == nil {
+		return
+	}
+	p.compact.lateBlockTxnReply = nil
 }

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -413,6 +413,11 @@ func (p *peer) validateCompactBlockHeader(header [consensus.BLOCK_HEADER_BYTES]b
 		p.bumpBan(100, err.Error())
 		return err
 	}
+	if expected := p.service.cfg.SyncConfig.ExpectedTarget; expected != nil && parsed.Target != *expected {
+		err := &consensus.TxError{Code: consensus.BLOCK_ERR_TARGET_INVALID, Msg: "target mismatch"}
+		p.bumpBan(100, err.Error())
+		return err
+	}
 	return nil
 }
 

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -9,9 +9,10 @@ import (
 const compactDuplicateReportedIndex = ^uint64(0)
 
 type compactReconstructionResult struct {
-	Transactions    [][]byte
-	MissingIndexes  []uint64
-	MissingShortIDs []compactShortID
+	Transactions        [][]byte
+	PartialTransactions [][]byte
+	MissingIndexes      []uint64
+	MissingShortIDs     []compactShortID
 }
 
 func reconstructCompactBlock(p cmpctBlockPayload, localTxs [][]byte) (compactReconstructionResult, error) {
@@ -19,7 +20,7 @@ func reconstructCompactBlock(p cmpctBlockPayload, localTxs [][]byte) (compactRec
 	if err != nil {
 		return compactReconstructionResult{}, err
 	}
-	prefilledShortIDs, prefilledTxBytes, err := compactPrefilledShortIDs(p.Prefilled, totalEntries, p.Nonce1, p.Nonce2)
+	prefilledShortIDs, _, err := compactPrefilledShortIDs(p.Prefilled, totalEntries, p.Nonce1, p.Nonce2)
 	if err != nil {
 		return compactReconstructionResult{}, err
 	}
@@ -33,16 +34,23 @@ func reconstructCompactBlock(p cmpctBlockPayload, localTxs [][]byte) (compactRec
 		return compactReconstructionResult{}, err
 	}
 
-	missingIndexes, missingShortIDs := compactMissingShortIDIndexes(totalEntries, p.Prefilled, p.ShortIDs, index, prefilledShortIDs)
-	if len(missingIndexes) > 0 {
-		return compactReconstructionResult{MissingIndexes: missingIndexes, MissingShortIDs: missingShortIDs}, nil
-	}
 	txs := make([][]byte, totalEntries)
 	compactFillPrefilledTransactions(txs, p.Prefilled)
-	if err := compactFillShortIDTransactions(txs, totalEntries, p.Prefilled, p.ShortIDs, index, prefilledTxBytes); err != nil {
+	missingIndexes, missingShortIDs, err := compactResolveShortIDTransactions(txs, totalEntries, p.Prefilled, p.ShortIDs, index, prefilledShortIDs)
+	if err != nil {
 		return compactReconstructionResult{}, err
 	}
-	return compactReconstructionResult{Transactions: txs}, nil
+	if len(missingIndexes) > 0 {
+		return compactReconstructionResult{
+			PartialTransactions: cloneCompactTransactions(txs),
+			MissingIndexes:      missingIndexes,
+			MissingShortIDs:     missingShortIDs,
+		}, nil
+	}
+	if err := compactValidateTransactionTotal(txs); err != nil {
+		return compactReconstructionResult{}, err
+	}
+	return compactReconstructionResult{Transactions: cloneCompactTransactions(txs)}, nil
 }
 
 func compactReconstructionEntryCount(shortIDCount int, prefilled []prefilledTxn) (int, error) {
@@ -85,25 +93,14 @@ func compactFillPrefilledTransactions(txs [][]byte, prefilled []prefilledTxn) {
 	}
 }
 
-func compactFillShortIDTransactions(txs [][]byte, totalEntries int, prefilled []prefilledTxn, shortIDs []compactShortID, index map[compactShortID][]byte, totalTxBytes uint64) error {
-	shortPos, prefilledPos := 0, 0
-	for absoluteIndex := 0; absoluteIndex < totalEntries && shortPos < len(shortIDs); absoluteIndex++ {
-		if compactIndexIsPrefilled(uint64(absoluteIndex), prefilled, &prefilledPos) {
-			continue
-		}
-		tx := index[shortIDs[shortPos]]
-		nextTotal, err := validateBlockTxnTransactionSize(uint64(len(tx)), totalTxBytes)
-		if err != nil {
-			return err
-		}
-		txs[absoluteIndex] = append([]byte(nil), tx...)
-		totalTxBytes = nextTotal
-		shortPos++
-	}
-	return nil
-}
-
-func compactMissingShortIDIndexes(totalEntries int, prefilled []prefilledTxn, shortIDs []compactShortID, index map[compactShortID][]byte, blocked map[compactShortID]bool) ([]uint64, []compactShortID) {
+func compactResolveShortIDTransactions(
+	txs [][]byte,
+	totalEntries int,
+	prefilled []prefilledTxn,
+	shortIDs []compactShortID,
+	index map[compactShortID][]byte,
+	blocked map[compactShortID]bool,
+) ([]uint64, []compactShortID, error) {
 	missing := make([]uint64, 0)
 	missingShortIDs := make([]compactShortID, 0)
 	firstHit := make(map[compactShortID]uint64)
@@ -113,13 +110,23 @@ func compactMissingShortIDIndexes(totalEntries int, prefilled []prefilledTxn, sh
 			continue
 		}
 		shortID := shortIDs[shortPos]
-		missing, missingShortIDs = compactAppendMissingIndex(missing, missingShortIDs, firstHit, shortID, uint64(absoluteIndex), index[shortID], blocked[shortID])
-		if len(missing) >= maxCompactRelayEntries {
-			return missing[:maxCompactRelayEntries], missingShortIDs[:maxCompactRelayEntries]
+		var err error
+		missing, missingShortIDs, err = compactAppendResolvedShortID(
+			txs,
+			missing,
+			missingShortIDs,
+			firstHit,
+			shortID,
+			uint64(absoluteIndex),
+			index[shortID],
+			blocked[shortID],
+		)
+		if err != nil {
+			return nil, nil, err
 		}
 		shortPos++
 	}
-	return missing, missingShortIDs
+	return missing, missingShortIDs, nil
 }
 
 func compactIndexIsPrefilled(index uint64, prefilled []prefilledTxn, pos *int) bool {
@@ -130,7 +137,8 @@ func compactIndexIsPrefilled(index uint64, prefilled []prefilledTxn, pos *int) b
 	return false
 }
 
-func compactAppendMissingIndex(
+func compactAppendResolvedShortID(
+	txs [][]byte,
 	missing []uint64,
 	missingShortIDs []compactShortID,
 	firstHit map[compactShortID]uint64,
@@ -138,20 +146,29 @@ func compactAppendMissingIndex(
 	absoluteIndex uint64,
 	tx []byte,
 	blocked bool,
-) ([]uint64, []compactShortID) {
+) ([]uint64, []compactShortID, error) {
 	if tx == nil || blocked {
-		return append(missing, absoluteIndex), append(missingShortIDs, shortID)
+		return compactAppendMissingIndex(missing, missingShortIDs, absoluteIndex, shortID)
 	}
 	if firstIndex, ok := firstHit[shortID]; ok {
 		if firstIndex != compactDuplicateReportedIndex {
+			txs[int(firstIndex)] = nil // #nosec G115 -- firstIndex was captured from bounded loop index.
 			missing = append(missing, firstIndex)
 			missingShortIDs = append(missingShortIDs, shortID)
 			firstHit[shortID] = compactDuplicateReportedIndex
 		}
-		return append(missing, absoluteIndex), append(missingShortIDs, shortID)
+		return compactAppendMissingIndex(missing, missingShortIDs, absoluteIndex, shortID)
 	}
 	firstHit[shortID] = absoluteIndex
-	return missing, missingShortIDs
+	txs[int(absoluteIndex)] = tx // #nosec G115 -- absoluteIndex is bounded by totalEntries loop.
+	return missing, missingShortIDs, nil
+}
+
+func compactAppendMissingIndex(missing []uint64, missingShortIDs []compactShortID, absoluteIndex uint64, shortID compactShortID) ([]uint64, []compactShortID, error) {
+	if len(missing) >= maxCompactRelayEntries {
+		return nil, nil, errors.New("too many compact relay missing indexes")
+	}
+	return append(missing, absoluteIndex), append(missingShortIDs, shortID), nil
 }
 
 func compactLocalTxIndex(localTxs [][]byte, nonce1, nonce2 uint64) (map[compactShortID][]byte, error) {
@@ -183,6 +200,21 @@ func compactLocalTxWTxID(tx []byte) ([32]byte, error) {
 	return wtxid, nil
 }
 
+func compactValidateTransactionTotal(txs [][]byte) error {
+	var totalTxBytes uint64
+	for _, tx := range txs {
+		if tx == nil {
+			return errors.New("compact block transaction missing")
+		}
+		nextTotal, err := validateBlockTxnTransactionSize(uint64(len(tx)), totalTxBytes)
+		if err != nil {
+			return err
+		}
+		totalTxBytes = nextTotal
+	}
+	return nil
+}
+
 type compactOutstandingRequest struct {
 	BlockHash       [32]byte
 	Header          [consensus.BLOCK_HEADER_BYTES]byte
@@ -200,6 +232,9 @@ func (p *peer) handleCmpctBlock(payload []byte) error {
 	}
 	blockHash, err := consensus.BlockHash(block.Header[:])
 	if err != nil {
+		return err
+	}
+	if err := p.validateCompactBlockHeader(block.Header); err != nil {
 		return err
 	}
 	have, err := p.service.hasBlock(blockHash)
@@ -273,24 +308,31 @@ func (p *peer) handleBlockTxn(payload []byte) error {
 }
 
 func newCompactOutstandingRequest(block cmpctBlockPayload, blockHash [32]byte, result compactReconstructionResult) (compactOutstandingRequest, error) {
-	totalEntries, err := compactReconstructionEntryCount(len(block.ShortIDs), block.Prefilled)
-	if err != nil {
-		return compactOutstandingRequest{}, err
-	}
 	if len(result.MissingIndexes) == 0 || len(result.MissingIndexes) != len(result.MissingShortIDs) {
 		return compactOutstandingRequest{}, errors.New("compact reconstruction missing request mismatch")
 	}
-	txs := make([][]byte, totalEntries)
-	compactFillPrefilledTransactions(txs, block.Prefilled)
 	return compactOutstandingRequest{
 		BlockHash:       blockHash,
 		Header:          block.Header,
 		MissingIndexes:  append([]uint64(nil), result.MissingIndexes...),
 		MissingShortIDs: append([]compactShortID(nil), result.MissingShortIDs...),
-		Transactions:    cloneCompactTransactions(txs),
+		Transactions:    cloneCompactTransactions(result.PartialTransactions),
 		Nonce1:          block.Nonce1,
 		Nonce2:          block.Nonce2,
 	}, nil
+}
+
+func (p *peer) validateCompactBlockHeader(header [consensus.BLOCK_HEADER_BYTES]byte) error {
+	parsed, err := consensus.ParseBlockHeaderBytes(header[:])
+	if err != nil {
+		p.bumpBan(10, err.Error())
+		return err
+	}
+	if err := consensus.PowCheck(header[:], parsed.Target); err != nil {
+		p.bumpBan(100, err.Error())
+		return err
+	}
+	return nil
 }
 
 func compactFillResponseTransactions(req compactOutstandingRequest, responseTxs [][]byte, responseWTxIDs [][32]byte) ([][]byte, error) {

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -2,12 +2,15 @@ package p2p
 
 import (
 	"errors"
+	"time"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/node"
 )
 
 const compactDuplicateReportedIndex = ^uint64(0)
+
+const defaultCompactOutstandingTTL = 15 * time.Second
 
 var errCompactRelayMissingRequestTooLarge = errors.New("too many compact relay missing indexes")
 
@@ -232,6 +235,7 @@ type compactOutstandingRequest struct {
 	Transactions    [][]byte
 	Nonce1          uint64
 	Nonce2          uint64
+	ExpiresAt       time.Time
 }
 
 func (p *peer) handleCmpctBlock(payload []byte) error {
@@ -240,6 +244,10 @@ func (p *peer) handleCmpctBlock(payload []byte) error {
 		return err
 	}
 	if err := p.validateCompactBlockHeader(header); err != nil {
+		return err
+	}
+	fallback, err := p.preflightCompactBlockRuntimeEntries(payload, blockHash)
+	if err != nil || fallback {
 		return err
 	}
 	block, err := decodeCmpctBlockPayload(payload)
@@ -262,6 +270,9 @@ func (p *peer) handleCmpctBlock(payload []byte) error {
 	}
 	req, err := newCompactOutstandingRequest(block, blockHash, result)
 	if err != nil {
+		return err
+	}
+	if err := p.expireCompactOutstandingRequest(); err != nil {
 		return err
 	}
 	if p.hasCompactOutstandingRequest() {
@@ -362,6 +373,49 @@ func compactBlockHeaderAndHash(payload []byte) ([consensus.BLOCK_HEADER_BYTES]by
 		return header, blockHash, err
 	}
 	return header, hash, nil
+}
+
+func (p *peer) preflightCompactBlockRuntimeEntries(payload []byte, blockHash [32]byte) (bool, error) {
+	_, err := compactBlockRuntimeEntryCount(payload)
+	if !errors.Is(err, errCompactRelayMissingRequestTooLarge) {
+		return false, err
+	}
+	have, haveErr := p.service.hasBlock(blockHash)
+	if haveErr != nil || have {
+		return true, haveErr
+	}
+	return true, p.requestCompactFullBlockFallback(blockHash)
+}
+
+func compactBlockRuntimeEntryCount(payload []byte) (uint64, error) {
+	if len(payload) > consensus.MAX_RELAY_MSG_BYTES {
+		return 0, errors.New("cmpctblock payload too large")
+	}
+	if len(payload) < consensus.BLOCK_HEADER_BYTES+16 {
+		return 0, errors.New("cmpctblock payload missing header or nonce")
+	}
+	offset := consensus.BLOCK_HEADER_BYTES + 16
+	shortCount, consumed, err := consensus.DecodeCompactSize(payload[offset:])
+	if err != nil {
+		return 0, err
+	}
+	offset += consumed
+	if shortCount > uint64(len(payload[offset:]))/compactShortIDBytes {
+		return 0, errors.New("cmpctblock payload truncated short IDs")
+	}
+	shortIDEnd := offset + int(shortCount)*compactShortIDBytes // #nosec G115 -- shortCount is bounded by remaining payload width above.
+	prefilledCount, _, err := consensus.DecodeCompactSize(payload[shortIDEnd:])
+	if err != nil {
+		return 0, err
+	}
+	totalEntries, err := validateCmpctBlockEntryCount(shortCount, prefilledCount)
+	if err != nil {
+		return 0, errors.New("invalid compact relay entry count")
+	}
+	if totalEntries > maxCompactRelayEntries {
+		return totalEntries, errCompactRelayMissingRequestTooLarge
+	}
+	return totalEntries, nil
 }
 
 func (p *peer) validateCompactBlockHeader(header [consensus.BLOCK_HEADER_BYTES]byte) error {
@@ -645,8 +699,50 @@ func cloneCompactTransactions(txs [][]byte) [][]byte {
 func (p *peer) setCompactOutstandingRequest(req compactOutstandingRequest) {
 	p.compactMu.Lock()
 	clone := cloneCompactOutstandingRequest(req)
+	clone.ExpiresAt = p.compactOutstandingExpiry()
 	p.compact.outstanding = &clone
 	p.compactMu.Unlock()
+}
+
+func (p *peer) expireCompactOutstandingRequest() error {
+	req, ok := p.expiredCompactOutstandingRequest()
+	if !ok {
+		return nil
+	}
+	return p.requestCompactFullBlockFallback(req.BlockHash)
+}
+
+func (p *peer) expiredCompactOutstandingRequest() (compactOutstandingRequest, bool) {
+	p.compactMu.Lock()
+	defer p.compactMu.Unlock()
+	if p.compact.outstanding == nil || !p.compactOutstandingExpired(*p.compact.outstanding) {
+		return compactOutstandingRequest{}, false
+	}
+	req := cloneCompactOutstandingRequest(*p.compact.outstanding)
+	p.compact.outstanding = nil
+	return req, true
+}
+
+func (p *peer) compactOutstandingExpired(req compactOutstandingRequest) bool {
+	return !req.ExpiresAt.IsZero() && !p.compactNow().Before(req.ExpiresAt)
+}
+
+func (p *peer) compactOutstandingExpiry() time.Time {
+	return p.compactNow().Add(p.compactOutstandingTTL())
+}
+
+func (p *peer) compactOutstandingTTL() time.Duration {
+	if p != nil && p.service != nil && p.service.cfg.PeerRuntimeConfig.ReadDeadline > 0 {
+		return p.service.cfg.PeerRuntimeConfig.ReadDeadline
+	}
+	return defaultCompactOutstandingTTL
+}
+
+func (p *peer) compactNow() time.Time {
+	if p != nil && p.service != nil && p.service.cfg.Now != nil {
+		return p.service.cfg.Now()
+	}
+	return time.Now()
 }
 
 func (p *peer) hasCompactOutstandingRequest() bool {

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -313,7 +313,7 @@ func (p *peer) handleGetBlockTxn(payload []byte) error {
 func (p *peer) handleBlockTxn(payload []byte) error {
 	req, ok := p.compactOutstandingRequestSnapshot()
 	if !ok {
-		return errors.New("unexpected blocktxn response")
+		return nil
 	}
 	responseHash, err := compactBlockTxnPayloadHash(payload)
 	if err != nil {
@@ -328,7 +328,7 @@ func (p *peer) handleBlockTxn(payload []byte) error {
 	}
 	req, ok = p.popCompactOutstandingRequest()
 	if !ok {
-		return errors.New("unexpected blocktxn response")
+		return nil
 	}
 	txs, err := compactFillResponseTransactions(req, response.Transactions, response.WTxIDs)
 	if err != nil {

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/node"
 )
 
 const compactDuplicateReportedIndex = ^uint64(0)
@@ -12,6 +13,7 @@ const compactDuplicateReportedIndex = ^uint64(0)
 const defaultCompactOutstandingTTL = 15 * time.Second
 
 var errCompactRelayMissingRequestTooLarge = errors.New("too many compact relay missing indexes")
+var errCompactFullBlockFallbackRequired = errors.New("compact full-block fallback required")
 
 type compactReconstructionResult struct {
 	Transactions        [][]byte
@@ -466,6 +468,9 @@ func (p *peer) processCompactTransactions(blockHash [32]byte, header [consensus.
 	}
 	accepted, err := p.processCompactRelayedBlock(blockHash, blockBytes)
 	if err != nil {
+		if !errors.Is(err, errCompactFullBlockFallbackRequired) {
+			return err
+		}
 		return p.requestCompactFullBlockFallback(blockHash)
 	}
 	if !accepted {
@@ -477,13 +482,13 @@ func (p *peer) processCompactTransactions(blockHash [32]byte, header [consensus.
 func (p *peer) processCompactRelayedBlock(expectedHash [32]byte, blockBytes []byte) (bool, error) {
 	pb, blockHash, err := parseRelayedBlock(blockBytes)
 	if err != nil {
-		return false, err
+		return false, compactFullBlockFallbackError(err)
 	}
 	if pb == nil {
-		return false, errors.New("nil parsed block")
+		return false, compactFullBlockFallbackError(errors.New("nil parsed block"))
 	}
 	if blockHash != expectedHash {
-		return false, errors.New("compact block hash mismatch")
+		return false, compactFullBlockFallbackError(errors.New("compact block hash mismatch"))
 	}
 	have, err := p.service.hasBlock(blockHash)
 	if err != nil || have {
@@ -494,10 +499,28 @@ func (p *peer) processCompactRelayedBlock(expectedHash [32]byte, blockBytes []by
 	summary, err := p.service.cfg.SyncEngine.ApplyBlockWithReorg(blockBytes, nil)
 	p.service.chainMu.Unlock()
 	if err != nil {
+		if compactApplyErrorNeedsFallback(err) {
+			return false, compactFullBlockFallbackError(err)
+		}
 		return false, err
 	}
 	p.acceptedRelayedBlock(blockHash, summary)
 	return true, nil
+}
+
+func compactFullBlockFallbackError(cause error) error {
+	if cause == nil {
+		return errCompactFullBlockFallbackRequired
+	}
+	return errors.Join(errCompactFullBlockFallbackRequired, cause)
+}
+
+func compactApplyErrorNeedsFallback(err error) bool {
+	if errors.Is(err, node.ErrParentNotFound) {
+		return true
+	}
+	var txErr *consensus.TxError
+	return errors.As(err, &txErr)
 }
 
 func (p *peer) requestCompactFullBlockFallbackForOutstanding(cause error) error {
@@ -633,6 +656,9 @@ func compactBlockTransactionCount(blockBytes []byte) (uint64, int, error) {
 func validateCompactRequestedIndexShape(indexes []uint64) error {
 	seen := make(map[uint64]struct{}, len(indexes))
 	for _, idx := range indexes {
+		if idx >= maxCompactRelayEntries {
+			return errors.New("compact relay index exceeds runtime cap")
+		}
 		if _, ok := seen[idx]; ok {
 			return errors.New("duplicate compact relay index")
 		}

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
-	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/node"
 )
 
 const compactDuplicateReportedIndex = ^uint64(0)
@@ -287,6 +286,7 @@ func (p *peer) handleCmpctBlock(payload []byte) error {
 		p.clearCompactOutstandingRequest()
 		return err
 	}
+	p.refreshCompactOutstandingExpiry()
 	return nil
 }
 
@@ -494,10 +494,6 @@ func (p *peer) processCompactRelayedBlock(expectedHash [32]byte, blockBytes []by
 	summary, err := p.service.cfg.SyncEngine.ApplyBlockWithReorg(blockBytes, nil)
 	p.service.chainMu.Unlock()
 	if err != nil {
-		if errors.Is(err, node.ErrParentNotFound) {
-			_, retainErr := p.retainRelayedOrphanIfValid(pb, blockHash, blockBytes)
-			return false, retainErr
-		}
 		return false, err
 	}
 	p.acceptedRelayedBlock(blockHash, summary)
@@ -701,6 +697,14 @@ func (p *peer) setCompactOutstandingRequest(req compactOutstandingRequest) {
 	clone := cloneCompactOutstandingRequest(req)
 	clone.ExpiresAt = p.compactOutstandingExpiry()
 	p.compact.outstanding = &clone
+	p.compactMu.Unlock()
+}
+
+func (p *peer) refreshCompactOutstandingExpiry() {
+	p.compactMu.Lock()
+	if p.compact.outstanding != nil {
+		p.compact.outstanding.ExpiresAt = p.compactOutstandingExpiry()
+	}
 	p.compactMu.Unlock()
 }
 

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -58,9 +58,6 @@ func reconstructCompactBlock(p cmpctBlockPayload, localTxs [][]byte) (compactRec
 			MissingShortIDs:     missingShortIDs,
 		}, nil
 	}
-	if err := compactValidateTransactionTotal(txs); err != nil {
-		return compactReconstructionResult{}, err
-	}
 	return compactReconstructionResult{Transactions: cloneCompactTransactions(txs)}, nil
 }
 
@@ -212,21 +209,6 @@ func compactLocalTxWTxID(tx []byte) ([32]byte, error) {
 		return zero, errors.New("compact local transaction is non-canonical")
 	}
 	return wtxid, nil
-}
-
-func compactValidateTransactionTotal(txs [][]byte) error {
-	var totalTxBytes uint64
-	for _, tx := range txs {
-		if tx == nil {
-			return errors.New("compact block transaction missing")
-		}
-		nextTotal, err := validateBlockTxnTransactionSize(uint64(len(tx)), totalTxBytes)
-		if err != nil {
-			return err
-		}
-		totalTxBytes = nextTotal
-	}
-	return nil
 }
 
 type compactOutstandingRequest struct {
@@ -684,7 +666,7 @@ func compactBlockTransactionCount(blockBytes []byte) (uint64, int, error) {
 func validateCompactRequestedIndexShape(indexes []uint64) error {
 	seen := make(map[uint64]struct{}, len(indexes))
 	for _, idx := range indexes {
-		if idx >= maxCompactRelayEntries {
+		if idx > maxCompactRelayIndexValue {
 			return errors.New("compact relay index exceeds runtime cap")
 		}
 		if _, ok := seen[idx]; ok {

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -223,23 +223,8 @@ type compactOutstandingRequest struct {
 }
 
 func (p *peer) handleCmpctBlock(payload []byte) error {
-	header, blockHash, err := compactBlockHeaderAndHash(payload)
-	if err != nil {
-		return err
-	}
-	if err := p.validateCompactBlockHeader(header); err != nil {
-		return err
-	}
-	fallback, err := p.preflightCompactBlockRuntimeEntries(payload, blockHash)
-	if err != nil || fallback {
-		return err
-	}
-	block, err := decodeCmpctBlockPayload(payload)
-	if err != nil {
-		return err
-	}
-	have, err := p.service.hasBlock(blockHash)
-	if err != nil || have {
+	block, blockHash, done, err := p.prepareCmpctBlock(payload)
+	if err != nil || done {
 		return err
 	}
 	result, err := reconstructCompactBlock(block, compactRelayLocalTransactions(p.service.cfg.TxPool))
@@ -252,6 +237,33 @@ func (p *peer) handleCmpctBlock(payload []byte) error {
 	if result.Transactions != nil {
 		return p.processCompactTransactions(blockHash, block.Header, result.Transactions)
 	}
+	return p.requestMissingCompactTransactions(block, blockHash, result)
+}
+
+func (p *peer) prepareCmpctBlock(payload []byte) (cmpctBlockPayload, [32]byte, bool, error) {
+	header, blockHash, err := compactBlockHeaderAndHash(payload)
+	if err != nil {
+		return cmpctBlockPayload{}, blockHash, false, err
+	}
+	if err := p.validateCompactBlockHeader(header); err != nil {
+		return cmpctBlockPayload{}, blockHash, false, err
+	}
+	fallback, err := p.preflightCompactBlockRuntimeEntries(payload, blockHash)
+	if err != nil || fallback {
+		return cmpctBlockPayload{}, blockHash, true, err
+	}
+	block, err := decodeCmpctBlockPayload(payload)
+	if err != nil {
+		return cmpctBlockPayload{}, blockHash, false, err
+	}
+	have, err := p.service.hasBlock(blockHash)
+	if err != nil || have {
+		return cmpctBlockPayload{}, blockHash, true, err
+	}
+	return block, blockHash, false, nil
+}
+
+func (p *peer) requestMissingCompactTransactions(block cmpctBlockPayload, blockHash [32]byte, result compactReconstructionResult) error {
 	req, err := newCompactOutstandingRequest(block, blockHash, result)
 	if err != nil {
 		return err
@@ -619,21 +631,30 @@ func compactRequestedTransactionsFromBlock(blockBytes []byte, indexes []uint64) 
 	if err != nil {
 		return nil, err
 	}
+	requested, maxRequested, err := compactRequestedIndexPositions(indexes, txCount)
+	if err != nil {
+		return nil, err
+	}
+	return compactScanRequestedTransactions(blockBytes, offset, maxRequested, requested, len(indexes))
+}
+
+func compactRequestedIndexPositions(indexes []uint64, txCount uint64) (map[uint64]int, uint64, error) {
 	requested := make(map[uint64]int, len(indexes))
 	var maxRequested uint64
 	for pos, idx := range indexes {
 		if idx >= txCount {
-			return nil, errors.New("compact relay index out of range")
+			return nil, 0, errors.New("compact relay index out of range")
 		}
 		requested[idx] = pos
 		if idx > maxRequested {
 			maxRequested = idx
 		}
 	}
-	out := make([][]byte, 0, len(indexes))
-	for range indexes {
-		out = append(out, nil)
-	}
+	return requested, maxRequested, nil
+}
+
+func compactScanRequestedTransactions(blockBytes []byte, offset int, maxRequested uint64, requested map[uint64]int, count int) ([][]byte, error) {
+	out := make([][]byte, count)
 	var totalTxBytes uint64
 	for idx := uint64(0); idx <= maxRequested; idx++ {
 		_, _, _, consumed, err := consensus.ParseTx(blockBytes[offset:])
@@ -685,31 +706,39 @@ func validateCompactRequestedIndexShape(indexes []uint64) error {
 func compactRelayLocalTransactions(pool TxPool) [][]byte {
 	switch pool := pool.(type) {
 	case *MemoryTxPool:
-		if pool == nil {
-			return nil
-		}
-		pool.mu.RLock()
-		defer pool.mu.RUnlock()
-		out := make([][]byte, 0, len(pool.txs))
-		for _, entry := range pool.txs {
-			out = append(out, entry.raw)
-		}
-		return out
+		return compactRelayMemoryPoolTransactions(pool)
 	case *CanonicalMempoolTxPool:
-		if pool == nil || pool.mempool == nil {
-			return nil
-		}
-		ids := pool.mempool.AllTxIDs()
-		out := make([][]byte, 0, len(ids))
-		for _, txid := range ids {
-			if tx, ok := pool.mempool.TxByID(txid); ok {
-				out = append(out, tx)
-			}
-		}
-		return out
+		return compactRelayCanonicalPoolTransactions(pool)
 	default:
 		return nil
 	}
+}
+
+func compactRelayMemoryPoolTransactions(pool *MemoryTxPool) [][]byte {
+	if pool == nil {
+		return nil
+	}
+	pool.mu.RLock()
+	defer pool.mu.RUnlock()
+	out := make([][]byte, 0, len(pool.txs))
+	for _, entry := range pool.txs {
+		out = append(out, entry.raw)
+	}
+	return out
+}
+
+func compactRelayCanonicalPoolTransactions(pool *CanonicalMempoolTxPool) [][]byte {
+	if pool == nil || pool.mempool == nil {
+		return nil
+	}
+	ids := pool.mempool.AllTxIDs()
+	out := make([][]byte, 0, len(ids))
+	for _, txid := range ids {
+		if tx, ok := pool.mempool.TxByID(txid); ok {
+			out = append(out, tx)
+		}
+	}
+	return out
 }
 
 func compactTransactionShortID(tx []byte, nonce1, nonce2 uint64) (compactShortID, error) {

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -271,6 +271,9 @@ func (p *peer) requestMissingCompactTransactions(block cmpctBlockPayload, blockH
 	if err := p.expireCompactOutstandingRequest(); err != nil {
 		return err
 	}
+	if err := p.clearKnownCompactOutstandingRequest(); err != nil {
+		return err
+	}
 	if p.hasCompactOutstandingRequest() {
 		return p.requestCompactFullBlockFallback(blockHash)
 	}
@@ -803,6 +806,18 @@ func (p *peer) expireCompactOutstandingRequest() error {
 	if !ok {
 		return nil
 	}
+	have, err := p.service.hasBlock(req.BlockHash)
+	if err != nil {
+		return err
+	}
+	if have {
+		p.clearCompactOutstandingRequestForHash(req.BlockHash)
+		return nil
+	}
+	req, ok = p.popCompactOutstandingRequestForHash(req.BlockHash)
+	if !ok {
+		return nil
+	}
 	return p.requestCompactFullBlockFallbackForAbandonedOutstanding(req)
 }
 
@@ -812,9 +827,7 @@ func (p *peer) expiredCompactOutstandingRequest() (compactOutstandingRequest, bo
 	if p.compact.outstanding == nil || !p.compactOutstandingExpired(*p.compact.outstanding) {
 		return compactOutstandingRequest{}, false
 	}
-	req := cloneCompactOutstandingRequest(*p.compact.outstanding)
-	p.compact.outstanding = nil
-	return req, true
+	return cloneCompactOutstandingRequest(*p.compact.outstanding), true
 }
 
 func (p *peer) compactOutstandingExpired(req compactOutstandingRequest) bool {
@@ -846,7 +859,10 @@ func (p *peer) hasCompactOutstandingRequest() bool {
 }
 
 func (p *peer) fallbackCompactOutstandingRequest() error {
-	req, ok := p.popCompactOutstandingRequest()
+	req, ok, err := p.popCompactOutstandingRequestForFallback()
+	if err != nil {
+		return err
+	}
 	if !ok {
 		return nil
 	}
@@ -871,6 +887,34 @@ func (p *peer) popCompactOutstandingRequest() (compactOutstandingRequest, bool) 
 	return req, true
 }
 
+func (p *peer) popCompactOutstandingRequestForHash(blockHash [32]byte) (compactOutstandingRequest, bool) {
+	p.compactMu.Lock()
+	defer p.compactMu.Unlock()
+	if p.compact.outstanding == nil || p.compact.outstanding.BlockHash != blockHash {
+		return compactOutstandingRequest{}, false
+	}
+	req := cloneCompactOutstandingRequest(*p.compact.outstanding)
+	p.compact.outstanding = nil
+	return req, true
+}
+
+func (p *peer) popCompactOutstandingRequestForFallback() (compactOutstandingRequest, bool, error) {
+	req, ok := p.compactOutstandingRequestSnapshot()
+	if !ok {
+		return compactOutstandingRequest{}, false, nil
+	}
+	have, err := p.service.hasBlock(req.BlockHash)
+	if err != nil {
+		return compactOutstandingRequest{}, false, err
+	}
+	if have {
+		p.clearCompactOutstandingRequestForHash(req.BlockHash)
+		return compactOutstandingRequest{}, false, nil
+	}
+	req, ok = p.popCompactOutstandingRequestForHash(req.BlockHash)
+	return req, ok, nil
+}
+
 func (p *peer) compactOutstandingRequestSnapshot() (compactOutstandingRequest, bool) {
 	p.compactMu.Lock()
 	defer p.compactMu.Unlock()
@@ -888,6 +932,7 @@ func cloneCompactOutstandingRequest(req compactOutstandingRequest) compactOutsta
 }
 
 func (p *peer) blockTxnPayloadCap() uint32 {
+	p.clearKnownCompactOutstandingRequestBestEffort()
 	now := p.compactNow()
 	p.compactMu.Lock()
 	defer p.compactMu.Unlock()
@@ -921,6 +966,40 @@ func (p *peer) setLateBlockTxnReply(req compactOutstandingRequest) {
 		ExpiresAt: p.compactOutstandingExpiry(),
 	}
 	p.compactMu.Unlock()
+}
+
+func (p *peer) clearKnownCompactOutstandingRequest() error {
+	req, ok := p.compactOutstandingRequestSnapshot()
+	if !ok {
+		return nil
+	}
+	have, err := p.service.hasBlock(req.BlockHash)
+	if err != nil {
+		return err
+	}
+	if have {
+		p.clearCompactOutstandingRequestForHash(req.BlockHash)
+	}
+	return nil
+}
+
+func (p *peer) clearKnownCompactOutstandingRequestBestEffort() {
+	_ = p.clearKnownCompactOutstandingRequest()
+}
+
+func (p *peer) clearCompactOutstandingRequestForHash(blockHash [32]byte) bool {
+	p.compactMu.Lock()
+	defer p.compactMu.Unlock()
+	cleared := false
+	if p.compact.outstanding != nil && p.compact.outstanding.BlockHash == blockHash {
+		p.compact.outstanding = nil
+		cleared = true
+	}
+	if p.compact.lateBlockTxnReply != nil && p.compact.lateBlockTxnReply.BlockHash == blockHash {
+		p.compact.lateBlockTxnReply = nil
+		cleared = true
+	}
+	return cleared
 }
 
 func (p *peer) clearLateBlockTxnReplyForHash(blockHash [32]byte, hasHash bool) bool {

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -802,19 +802,10 @@ func (p *peer) refreshCompactOutstandingExpiry() {
 }
 
 func (p *peer) expireCompactOutstandingRequest() error {
-	req, ok := p.expiredCompactOutstandingRequest()
-	if !ok {
-		return nil
-	}
-	have, err := p.service.hasBlock(req.BlockHash)
-	if err != nil {
+	if err := p.clearKnownCompactOutstandingRequest(); err != nil {
 		return err
 	}
-	if have {
-		p.clearCompactOutstandingRequestForHash(req.BlockHash)
-		return nil
-	}
-	req, ok = p.popCompactOutstandingRequestForHash(req.BlockHash)
+	req, ok := p.expiredCompactOutstandingRequest()
 	if !ok {
 		return nil
 	}
@@ -827,7 +818,9 @@ func (p *peer) expiredCompactOutstandingRequest() (compactOutstandingRequest, bo
 	if p.compact.outstanding == nil || !p.compactOutstandingExpired(*p.compact.outstanding) {
 		return compactOutstandingRequest{}, false
 	}
-	return cloneCompactOutstandingRequest(*p.compact.outstanding), true
+	req := cloneCompactOutstandingRequest(*p.compact.outstanding)
+	p.compact.outstanding = nil
+	return req, true
 }
 
 func (p *peer) compactOutstandingExpired(req compactOutstandingRequest) bool {
@@ -859,10 +852,10 @@ func (p *peer) hasCompactOutstandingRequest() bool {
 }
 
 func (p *peer) fallbackCompactOutstandingRequest() error {
-	req, ok, err := p.popCompactOutstandingRequestForFallback()
-	if err != nil {
+	if err := p.clearKnownCompactOutstandingRequest(); err != nil {
 		return err
 	}
+	req, ok := p.popCompactOutstandingRequest()
 	if !ok {
 		return nil
 	}
@@ -887,34 +880,6 @@ func (p *peer) popCompactOutstandingRequest() (compactOutstandingRequest, bool) 
 	return req, true
 }
 
-func (p *peer) popCompactOutstandingRequestForHash(blockHash [32]byte) (compactOutstandingRequest, bool) {
-	p.compactMu.Lock()
-	defer p.compactMu.Unlock()
-	if p.compact.outstanding == nil || p.compact.outstanding.BlockHash != blockHash {
-		return compactOutstandingRequest{}, false
-	}
-	req := cloneCompactOutstandingRequest(*p.compact.outstanding)
-	p.compact.outstanding = nil
-	return req, true
-}
-
-func (p *peer) popCompactOutstandingRequestForFallback() (compactOutstandingRequest, bool, error) {
-	req, ok := p.compactOutstandingRequestSnapshot()
-	if !ok {
-		return compactOutstandingRequest{}, false, nil
-	}
-	have, err := p.service.hasBlock(req.BlockHash)
-	if err != nil {
-		return compactOutstandingRequest{}, false, err
-	}
-	if have {
-		p.clearCompactOutstandingRequestForHash(req.BlockHash)
-		return compactOutstandingRequest{}, false, nil
-	}
-	req, ok = p.popCompactOutstandingRequestForHash(req.BlockHash)
-	return req, ok, nil
-}
-
 func (p *peer) compactOutstandingRequestSnapshot() (compactOutstandingRequest, bool) {
 	p.compactMu.Lock()
 	defer p.compactMu.Unlock()
@@ -932,7 +897,7 @@ func cloneCompactOutstandingRequest(req compactOutstandingRequest) compactOutsta
 }
 
 func (p *peer) blockTxnPayloadCap() uint32 {
-	p.clearKnownCompactOutstandingRequestBestEffort()
+	_ = p.clearKnownCompactOutstandingRequest()
 	now := p.compactNow()
 	p.compactMu.Lock()
 	defer p.compactMu.Unlock()
@@ -981,10 +946,6 @@ func (p *peer) clearKnownCompactOutstandingRequest() error {
 		p.clearCompactOutstandingRequestForHash(req.BlockHash)
 	}
 	return nil
-}
-
-func (p *peer) clearKnownCompactOutstandingRequestBestEffort() {
-	_ = p.clearKnownCompactOutstandingRequest()
 }
 
 func (p *peer) clearCompactOutstandingRequestForHash(blockHash [32]byte) bool {

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -9,8 +9,9 @@ import (
 const compactDuplicateReportedIndex = ^uint64(0)
 
 type compactReconstructionResult struct {
-	Transactions   [][]byte
-	MissingIndexes []uint64
+	Transactions    [][]byte
+	MissingIndexes  []uint64
+	MissingShortIDs []compactShortID
 }
 
 func reconstructCompactBlock(p cmpctBlockPayload, localTxs [][]byte) (compactReconstructionResult, error) {
@@ -32,9 +33,9 @@ func reconstructCompactBlock(p cmpctBlockPayload, localTxs [][]byte) (compactRec
 		return compactReconstructionResult{}, err
 	}
 
-	missing := compactMissingShortIDIndexes(totalEntries, p.Prefilled, p.ShortIDs, index, prefilledShortIDs)
-	if len(missing) > 0 {
-		return compactReconstructionResult{MissingIndexes: missing}, nil
+	missingIndexes, missingShortIDs := compactMissingShortIDIndexes(totalEntries, p.Prefilled, p.ShortIDs, index, prefilledShortIDs)
+	if len(missingIndexes) > 0 {
+		return compactReconstructionResult{MissingIndexes: missingIndexes, MissingShortIDs: missingShortIDs}, nil
 	}
 	txs := make([][]byte, totalEntries)
 	compactFillPrefilledTransactions(txs, p.Prefilled)
@@ -102,8 +103,9 @@ func compactFillShortIDTransactions(txs [][]byte, totalEntries int, prefilled []
 	return nil
 }
 
-func compactMissingShortIDIndexes(totalEntries int, prefilled []prefilledTxn, shortIDs []compactShortID, index map[compactShortID][]byte, blocked map[compactShortID]bool) []uint64 {
+func compactMissingShortIDIndexes(totalEntries int, prefilled []prefilledTxn, shortIDs []compactShortID, index map[compactShortID][]byte, blocked map[compactShortID]bool) ([]uint64, []compactShortID) {
 	missing := make([]uint64, 0)
+	missingShortIDs := make([]compactShortID, 0)
 	firstHit := make(map[compactShortID]uint64)
 	shortPos, prefilledPos := 0, 0
 	for absoluteIndex := 0; absoluteIndex < totalEntries && shortPos < len(shortIDs); absoluteIndex++ {
@@ -111,13 +113,13 @@ func compactMissingShortIDIndexes(totalEntries int, prefilled []prefilledTxn, sh
 			continue
 		}
 		shortID := shortIDs[shortPos]
-		missing = compactAppendMissingIndex(missing, firstHit, shortID, uint64(absoluteIndex), index[shortID], blocked[shortID])
+		missing, missingShortIDs = compactAppendMissingIndex(missing, missingShortIDs, firstHit, shortID, uint64(absoluteIndex), index[shortID], blocked[shortID])
 		if len(missing) >= maxCompactRelayEntries {
-			return missing[:maxCompactRelayEntries]
+			return missing[:maxCompactRelayEntries], missingShortIDs[:maxCompactRelayEntries]
 		}
 		shortPos++
 	}
-	return missing
+	return missing, missingShortIDs
 }
 
 func compactIndexIsPrefilled(index uint64, prefilled []prefilledTxn, pos *int) bool {
@@ -128,19 +130,28 @@ func compactIndexIsPrefilled(index uint64, prefilled []prefilledTxn, pos *int) b
 	return false
 }
 
-func compactAppendMissingIndex(missing []uint64, firstHit map[compactShortID]uint64, shortID compactShortID, absoluteIndex uint64, tx []byte, blocked bool) []uint64 {
+func compactAppendMissingIndex(
+	missing []uint64,
+	missingShortIDs []compactShortID,
+	firstHit map[compactShortID]uint64,
+	shortID compactShortID,
+	absoluteIndex uint64,
+	tx []byte,
+	blocked bool,
+) ([]uint64, []compactShortID) {
 	if tx == nil || blocked {
-		return append(missing, absoluteIndex)
+		return append(missing, absoluteIndex), append(missingShortIDs, shortID)
 	}
 	if firstIndex, ok := firstHit[shortID]; ok {
 		if firstIndex != compactDuplicateReportedIndex {
 			missing = append(missing, firstIndex)
+			missingShortIDs = append(missingShortIDs, shortID)
 			firstHit[shortID] = compactDuplicateReportedIndex
 		}
-		return append(missing, absoluteIndex)
+		return append(missing, absoluteIndex), append(missingShortIDs, shortID)
 	}
 	firstHit[shortID] = absoluteIndex
-	return missing
+	return missing, missingShortIDs
 }
 
 func compactLocalTxIndex(localTxs [][]byte, nonce1, nonce2 uint64) (map[compactShortID][]byte, error) {
@@ -170,4 +181,301 @@ func compactLocalTxWTxID(tx []byte) ([32]byte, error) {
 		return zero, errors.New("compact local transaction is non-canonical")
 	}
 	return wtxid, nil
+}
+
+type compactOutstandingRequest struct {
+	BlockHash       [32]byte
+	Header          [consensus.BLOCK_HEADER_BYTES]byte
+	MissingIndexes  []uint64
+	MissingShortIDs []compactShortID
+	Transactions    [][]byte
+	Nonce1          uint64
+	Nonce2          uint64
+}
+
+func (p *peer) handleCmpctBlock(payload []byte) error {
+	block, err := decodeCmpctBlockPayload(payload)
+	if err != nil {
+		return err
+	}
+	blockHash, err := consensus.BlockHash(block.Header[:])
+	if err != nil {
+		return err
+	}
+	have, err := p.service.hasBlock(blockHash)
+	if err != nil || have {
+		return err
+	}
+	result, err := reconstructCompactBlock(block, compactRelayLocalTransactions(p.service.cfg.TxPool))
+	if err != nil {
+		return err
+	}
+	if result.Transactions != nil {
+		return p.processCompactTransactions(block.Header, result.Transactions)
+	}
+	req, err := newCompactOutstandingRequest(block, blockHash, result)
+	if err != nil {
+		return err
+	}
+	body, err := encodeGetBlockTxnPayload(getBlockTxnPayload{BlockHash: blockHash, Indexes: req.MissingIndexes})
+	if err != nil {
+		return err
+	}
+	p.setCompactOutstandingRequest(req)
+	if err := p.send(messageGetBlockTxn, body); err != nil {
+		p.clearCompactOutstandingRequest()
+		return err
+	}
+	return nil
+}
+
+func (p *peer) handleGetBlockTxn(payload []byte) error {
+	req, err := decodeGetBlockTxnPayload(payload)
+	if err != nil {
+		return err
+	}
+	blockBytes, ok, err := p.blockBytes(req.BlockHash)
+	if err != nil || !ok {
+		return err
+	}
+	_, txs, err := compactBlockTransactions(blockBytes)
+	if err != nil {
+		return err
+	}
+	responseTxs, err := compactRequestedTransactions(txs, req.Indexes)
+	if err != nil {
+		return err
+	}
+	body, err := encodeBlockTxnPayload(blockTxnPayload{BlockHash: req.BlockHash, Transactions: responseTxs})
+	if err != nil {
+		return err
+	}
+	return p.send(messageBlockTxn, body)
+}
+
+func (p *peer) handleBlockTxn(payload []byte) error {
+	response, err := decodeBlockTxnRuntimePayload(payload)
+	if err != nil {
+		return err
+	}
+	req, ok := p.takeCompactOutstandingRequest(response.BlockHash)
+	if !ok {
+		return errors.New("unexpected blocktxn response")
+	}
+	if len(response.Transactions) != len(req.MissingIndexes) {
+		return errors.New("blocktxn transaction count mismatch")
+	}
+	txs, err := compactFillResponseTransactions(req, response.Transactions, response.WTxIDs)
+	if err != nil {
+		return err
+	}
+	return p.processCompactTransactions(req.Header, txs)
+}
+
+func newCompactOutstandingRequest(block cmpctBlockPayload, blockHash [32]byte, result compactReconstructionResult) (compactOutstandingRequest, error) {
+	totalEntries, err := compactReconstructionEntryCount(len(block.ShortIDs), block.Prefilled)
+	if err != nil {
+		return compactOutstandingRequest{}, err
+	}
+	if len(result.MissingIndexes) == 0 || len(result.MissingIndexes) != len(result.MissingShortIDs) {
+		return compactOutstandingRequest{}, errors.New("compact reconstruction missing request mismatch")
+	}
+	txs := make([][]byte, totalEntries)
+	compactFillPrefilledTransactions(txs, block.Prefilled)
+	return compactOutstandingRequest{
+		BlockHash:       blockHash,
+		Header:          block.Header,
+		MissingIndexes:  append([]uint64(nil), result.MissingIndexes...),
+		MissingShortIDs: append([]compactShortID(nil), result.MissingShortIDs...),
+		Transactions:    cloneCompactTransactions(txs),
+		Nonce1:          block.Nonce1,
+		Nonce2:          block.Nonce2,
+	}, nil
+}
+
+func compactFillResponseTransactions(req compactOutstandingRequest, responseTxs [][]byte, responseWTxIDs [][32]byte) ([][]byte, error) {
+	if len(req.MissingIndexes) != len(req.MissingShortIDs) || len(responseTxs) != len(req.MissingIndexes) || len(responseWTxIDs) != len(responseTxs) {
+		return nil, errors.New("blocktxn transaction count mismatch")
+	}
+	txs := cloneCompactTransactions(req.Transactions)
+	for i, tx := range responseTxs {
+		shortID := compactShortID(consensus.CompactShortID(responseWTxIDs[i], req.Nonce1, req.Nonce2))
+		if shortID != req.MissingShortIDs[i] {
+			return nil, errors.New("blocktxn transaction short id mismatch")
+		}
+		idx := req.MissingIndexes[i]
+		if idx >= uint64(len(txs)) {
+			return nil, errors.New("compact relay index out of range")
+		}
+		txs[int(idx)] = append([]byte(nil), tx...) // #nosec G115 -- idx is bounded by len(txs) above.
+	}
+	return txs, nil
+}
+
+func (p *peer) processCompactTransactions(header [consensus.BLOCK_HEADER_BYTES]byte, txs [][]byte) error {
+	blockBytes, err := compactBlockBytes(header, txs)
+	if err != nil {
+		return err
+	}
+	summary, err := p.processRelayedBlock(blockBytes)
+	if err != nil || summary == nil {
+		return err
+	}
+	return p.service.requestBlocksIfBehind(p)
+}
+
+func compactBlockBytes(header [consensus.BLOCK_HEADER_BYTES]byte, txs [][]byte) ([]byte, error) {
+	if len(txs) == 0 {
+		return nil, errors.New("compact block has no transactions")
+	}
+	out := append([]byte(nil), header[:]...)
+	out = consensus.AppendCompactSize(out, uint64(len(txs)))
+	var totalTxBytes uint64
+	for _, tx := range txs {
+		if tx == nil {
+			return nil, errors.New("compact block transaction missing")
+		}
+		nextTotal, err := validateBlockTxnTransactionSize(uint64(len(tx)), totalTxBytes)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, tx...)
+		totalTxBytes = nextTotal
+		if len(out) > consensus.MAX_BLOCK_BYTES {
+			return nil, errors.New("compact block exceeds block size")
+		}
+	}
+	return out, nil
+}
+
+func compactBlockTransactions(blockBytes []byte) ([consensus.BLOCK_HEADER_BYTES]byte, [][]byte, error) {
+	var header [consensus.BLOCK_HEADER_BYTES]byte
+	if len(blockBytes) < consensus.BLOCK_HEADER_BYTES+1 {
+		return header, nil, errors.New("block too short")
+	}
+	copy(header[:], blockBytes[:consensus.BLOCK_HEADER_BYTES])
+	offset := consensus.BLOCK_HEADER_BYTES
+	txCount, consumed, err := consensus.DecodeCompactSize(blockBytes[offset:])
+	if err != nil {
+		return header, nil, err
+	}
+	if txCount == 0 || txCount > maxCmpctBlockEntries {
+		return header, nil, errors.New("invalid compact relay entry count")
+	}
+	offset += consumed
+	txs := make([][]byte, 0, int(txCount)) // #nosec G115 -- txCount is capped at maxCmpctBlockEntries above.
+	for i := uint64(0); i < txCount; i++ {
+		_, _, _, txConsumed, err := consensus.ParseTx(blockBytes[offset:])
+		if err != nil {
+			return header, nil, err
+		}
+		txs = append(txs, append([]byte(nil), blockBytes[offset:offset+txConsumed]...))
+		offset += txConsumed
+	}
+	if offset != len(blockBytes) {
+		return header, nil, errors.New("trailing bytes after tx list")
+	}
+	return header, txs, nil
+}
+
+func compactRequestedTransactions(txs [][]byte, indexes []uint64) ([][]byte, error) {
+	out := make([][]byte, 0, len(indexes))
+	for _, idx := range indexes {
+		if idx >= uint64(len(txs)) {
+			return nil, errors.New("compact relay index out of range")
+		}
+		out = append(out, append([]byte(nil), txs[int(idx)]...)) // #nosec G115 -- idx is bounded by len(txs) above.
+	}
+	return out, nil
+}
+
+func compactRelayLocalTransactions(pool TxPool) [][]byte {
+	switch pool := pool.(type) {
+	case *MemoryTxPool:
+		if pool == nil {
+			return nil
+		}
+		pool.mu.RLock()
+		defer pool.mu.RUnlock()
+		out := make([][]byte, 0, len(pool.txs))
+		for _, entry := range pool.txs {
+			out = append(out, entry.raw)
+		}
+		return out
+	case *CanonicalMempoolTxPool:
+		if pool == nil || pool.mempool == nil {
+			return nil
+		}
+		ids := pool.mempool.AllTxIDs()
+		out := make([][]byte, 0, len(ids))
+		for _, txid := range ids {
+			if tx, ok := pool.mempool.TxByID(txid); ok {
+				out = append(out, tx)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func compactTransactionShortID(tx []byte, nonce1, nonce2 uint64) (compactShortID, error) {
+	wtxid, err := compactLocalTxWTxID(tx)
+	if err != nil {
+		return compactShortID{}, err
+	}
+	return compactShortID(consensus.CompactShortID(wtxid, nonce1, nonce2)), nil
+}
+
+func cloneCompactTransactions(txs [][]byte) [][]byte {
+	if txs == nil {
+		return nil
+	}
+	out := make([][]byte, len(txs))
+	for i, tx := range txs {
+		if tx != nil {
+			out[i] = append([]byte(nil), tx...)
+		}
+	}
+	return out
+}
+
+func (p *peer) setCompactOutstandingRequest(req compactOutstandingRequest) {
+	p.compactMu.Lock()
+	clone := cloneCompactOutstandingRequest(req)
+	p.compact.outstanding = &clone
+	p.compactMu.Unlock()
+}
+
+func (p *peer) clearCompactOutstandingRequest() {
+	p.compactMu.Lock()
+	p.compact.outstanding = nil
+	p.compactMu.Unlock()
+}
+
+func (p *peer) takeCompactOutstandingRequest(blockHash [32]byte) (compactOutstandingRequest, bool) {
+	p.compactMu.Lock()
+	defer p.compactMu.Unlock()
+	if p.compact.outstanding == nil {
+		return compactOutstandingRequest{}, false
+	}
+	req := cloneCompactOutstandingRequest(*p.compact.outstanding)
+	p.compact.outstanding = nil
+	return req, req.BlockHash == blockHash
+}
+
+func (p *peer) compactOutstandingRequestSnapshot() (compactOutstandingRequest, bool) {
+	p.compactMu.Lock()
+	defer p.compactMu.Unlock()
+	if p.compact.outstanding == nil {
+		return compactOutstandingRequest{}, false
+	}
+	return cloneCompactOutstandingRequest(*p.compact.outstanding), true
+}
+
+func cloneCompactOutstandingRequest(req compactOutstandingRequest) compactOutstandingRequest {
+	req.MissingIndexes = append([]uint64(nil), req.MissingIndexes...)
+	req.MissingShortIDs = append([]compactShortID(nil), req.MissingShortIDs...)
+	req.Transactions = cloneCompactTransactions(req.Transactions)
+	return req
 }

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -346,14 +346,17 @@ func (p *peer) handleBlockTxn(payload []byte) error {
 func (p *peer) compactOutstandingForBlockTxn(responseHash [32]byte, hasHash bool) (compactOutstandingRequest, bool, error) {
 	req, ok := p.compactOutstandingRequestSnapshot()
 	if !ok {
-		p.clearLateBlockTxnReplyForHash(responseHash, hasHash)
+		p.consumeLateBlockTxnReply()
 		return compactOutstandingRequest{}, false, nil
 	}
-	if !hasHash || responseHash == req.BlockHash {
+	if hasHash && responseHash == req.BlockHash {
 		return req, true, nil
 	}
-	if p.clearLateBlockTxnReplyForHash(responseHash, true) {
+	if p.consumeLateBlockTxnReply() {
 		return compactOutstandingRequest{}, false, nil
+	}
+	if !hasHash {
+		return req, true, nil
 	}
 	return req, true, errors.New("unexpected blocktxn response")
 }
@@ -393,6 +396,9 @@ func compactBlockHeaderAndHash(payload []byte) ([consensus.BLOCK_HEADER_BYTES]by
 func (p *peer) preflightCompactBlockRuntimeEntries(payload []byte, blockHash [32]byte) (bool, error) {
 	_, err := compactBlockRuntimeEntryCount(payload)
 	if !errors.Is(err, errCompactRelayMissingRequestTooLarge) {
+		return false, err
+	}
+	if _, err := decodeCmpctBlockPayload(payload); err != nil {
 		return false, err
 	}
 	have, haveErr := p.service.hasBlock(blockHash)
@@ -963,7 +969,7 @@ func (p *peer) clearCompactOutstandingRequestForHash(blockHash [32]byte) bool {
 	return cleared
 }
 
-func (p *peer) clearLateBlockTxnReplyForHash(blockHash [32]byte, hasHash bool) bool {
+func (p *peer) consumeLateBlockTxnReply() bool {
 	now := p.compactNow()
 	p.compactMu.Lock()
 	defer p.compactMu.Unlock()
@@ -971,11 +977,8 @@ func (p *peer) clearLateBlockTxnReplyForHash(blockHash [32]byte, hasHash bool) b
 	if p.compact.lateBlockTxnReply == nil {
 		return false
 	}
-	if !hasHash || p.compact.lateBlockTxnReply.BlockHash == blockHash {
-		p.compact.lateBlockTxnReply = nil
-		return true
-	}
-	return false
+	p.compact.lateBlockTxnReply = nil
+	return true
 }
 
 func (p *peer) clearExpiredLateBlockTxnReplyLocked(now time.Time) {

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -311,17 +311,16 @@ func (p *peer) handleGetBlockTxn(payload []byte) error {
 }
 
 func (p *peer) handleBlockTxn(payload []byte) error {
-	req, ok := p.compactOutstandingRequestSnapshot()
+	responseHash, err := compactBlockTxnPayloadHash(payload)
+	req, ok, mismatchErr := p.compactOutstandingForBlockTxn(responseHash, err == nil)
 	if !ok {
-		p.clearLateBlockTxnReply()
 		return nil
 	}
-	responseHash, err := compactBlockTxnPayloadHash(payload)
 	if err != nil {
 		return p.requestCompactFullBlockFallbackForOutstanding(err)
 	}
-	if responseHash != req.BlockHash {
-		return p.requestCompactFullBlockFallbackForOutstanding(errors.New("unexpected blocktxn response"))
+	if mismatchErr != nil {
+		return p.requestCompactFullBlockFallbackForOutstanding(mismatchErr)
 	}
 	response, err := decodeBlockTxnRuntimePayload(payload)
 	if err != nil {
@@ -339,6 +338,21 @@ func (p *peer) handleBlockTxn(payload []byte) error {
 		return err
 	}
 	return nil
+}
+
+func (p *peer) compactOutstandingForBlockTxn(responseHash [32]byte, hasHash bool) (compactOutstandingRequest, bool, error) {
+	req, ok := p.compactOutstandingRequestSnapshot()
+	if !ok {
+		p.clearLateBlockTxnReplyForHash(responseHash, hasHash)
+		return compactOutstandingRequest{}, false, nil
+	}
+	if !hasHash || responseHash == req.BlockHash {
+		return req, true, nil
+	}
+	if p.clearLateBlockTxnReplyForHash(responseHash, true) {
+		return compactOutstandingRequest{}, false, nil
+	}
+	return req, true, errors.New("unexpected blocktxn response")
 }
 
 func newCompactOutstandingRequest(block cmpctBlockPayload, blockHash [32]byte, result compactReconstructionResult) (compactOutstandingRequest, error) {
@@ -773,7 +787,6 @@ func (p *peer) setCompactOutstandingRequest(req compactOutstandingRequest) {
 	clone := cloneCompactOutstandingRequest(req)
 	clone.ExpiresAt = p.compactOutstandingExpiry()
 	p.compact.outstanding = &clone
-	p.compact.lateBlockTxnReply = nil
 	p.compactMu.Unlock()
 }
 
@@ -875,15 +888,18 @@ func cloneCompactOutstandingRequest(req compactOutstandingRequest) compactOutsta
 }
 
 func (p *peer) blockTxnPayloadCap() uint32 {
+	now := p.compactNow()
 	p.compactMu.Lock()
 	defer p.compactMu.Unlock()
+	p.clearExpiredLateBlockTxnReplyLocked(now)
+	var cap uint32
 	if p.compact.outstanding != nil {
-		return compactBlockTxnResponsePayloadCap(len(p.compact.outstanding.MissingIndexes))
+		cap = compactBlockTxnResponsePayloadCap(len(p.compact.outstanding.MissingIndexes))
 	}
-	if p.compact.lateBlockTxnReply != nil {
-		return p.compact.lateBlockTxnReply.Cap
+	if p.compact.lateBlockTxnReply != nil && p.compact.lateBlockTxnReply.Cap > cap {
+		cap = p.compact.lateBlockTxnReply.Cap
 	}
-	return 0
+	return cap
 }
 
 func compactBlockTxnResponsePayloadCap(txCount int) uint32 {
@@ -899,15 +915,34 @@ func (p *peer) setLateBlockTxnReply(req compactOutstandingRequest) {
 		return
 	}
 	p.compactMu.Lock()
-	p.compact.lateBlockTxnReply = &compactLateBlockTxnReply{Cap: cap}
+	p.compact.lateBlockTxnReply = &compactLateBlockTxnReply{
+		BlockHash: req.BlockHash,
+		Cap:       cap,
+		ExpiresAt: p.compactOutstandingExpiry(),
+	}
 	p.compactMu.Unlock()
 }
 
-func (p *peer) clearLateBlockTxnReply() {
+func (p *peer) clearLateBlockTxnReplyForHash(blockHash [32]byte, hasHash bool) bool {
+	now := p.compactNow()
 	p.compactMu.Lock()
 	defer p.compactMu.Unlock()
+	p.clearExpiredLateBlockTxnReplyLocked(now)
+	if p.compact.lateBlockTxnReply == nil {
+		return false
+	}
+	if !hasHash || p.compact.lateBlockTxnReply.BlockHash == blockHash {
+		p.compact.lateBlockTxnReply = nil
+		return true
+	}
+	return false
+}
+
+func (p *peer) clearExpiredLateBlockTxnReplyLocked(now time.Time) {
 	if p.compact.lateBlockTxnReply == nil {
 		return
 	}
-	p.compact.lateBlockTxnReply = nil
+	if !p.compact.lateBlockTxnReply.ExpiresAt.IsZero() && !now.Before(p.compact.lateBlockTxnReply.ExpiresAt) {
+		p.compact.lateBlockTxnReply = nil
+	}
 }

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -2,6 +2,7 @@ package p2p
 
 import (
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
@@ -502,6 +503,7 @@ func (p *peer) processCompactRelayedBlock(expectedHash [32]byte, blockBytes []by
 		if compactApplyErrorNeedsFallback(err) {
 			return false, compactFullBlockFallbackError(err)
 		}
+		p.recordRelayedBlockApplyError(err)
 		return false, err
 	}
 	p.acceptedRelayedBlock(blockHash, summary)
@@ -520,7 +522,33 @@ func compactApplyErrorNeedsFallback(err error) bool {
 		return true
 	}
 	var txErr *consensus.TxError
-	return errors.As(err, &txErr)
+	if !errors.As(err, &txErr) {
+		return false
+	}
+	return compactTxErrorNeedsFallback(txErr.Code)
+}
+
+func compactTxErrorNeedsFallback(code consensus.ErrorCode) bool {
+	if strings.HasPrefix(string(code), "TX_ERR_") {
+		return true
+	}
+	switch code {
+	case consensus.BLOCK_ERR_PARSE,
+		consensus.BLOCK_ERR_WEIGHT_EXCEEDED,
+		consensus.BLOCK_ERR_ANCHOR_BYTES_EXCEEDED,
+		consensus.BLOCK_ERR_MERKLE_INVALID,
+		consensus.BLOCK_ERR_WITNESS_COMMITMENT,
+		consensus.BLOCK_ERR_COINBASE_INVALID,
+		consensus.BLOCK_ERR_SUBSIDY_EXCEEDED,
+		consensus.BLOCK_ERR_DA_INCOMPLETE,
+		consensus.BLOCK_ERR_DA_CHUNK_HASH_INVALID,
+		consensus.BLOCK_ERR_DA_SET_INVALID,
+		consensus.BLOCK_ERR_DA_PAYLOAD_COMMIT_INVALID,
+		consensus.BLOCK_ERR_DA_BATCH_EXCEEDED:
+		return true
+	default:
+		return false
+	}
 }
 
 func (p *peer) requestCompactFullBlockFallbackForOutstanding(cause error) error {

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -8,6 +8,8 @@ import (
 
 const compactDuplicateReportedIndex = ^uint64(0)
 
+var errCompactRelayMissingRequestTooLarge = errors.New("too many compact relay missing indexes")
+
 type compactReconstructionResult struct {
 	Transactions        [][]byte
 	PartialTransactions [][]byte
@@ -153,8 +155,11 @@ func compactAppendResolvedShortID(
 	if firstIndex, ok := firstHit[shortID]; ok {
 		if firstIndex != compactDuplicateReportedIndex {
 			txs[int(firstIndex)] = nil // #nosec G115 -- firstIndex was captured from bounded loop index.
-			missing = append(missing, firstIndex)
-			missingShortIDs = append(missingShortIDs, shortID)
+			var err error
+			missing, missingShortIDs, err = compactAppendMissingIndex(missing, missingShortIDs, firstIndex, shortID)
+			if err != nil {
+				return nil, nil, err
+			}
 			firstHit[shortID] = compactDuplicateReportedIndex
 		}
 		return compactAppendMissingIndex(missing, missingShortIDs, absoluteIndex, shortID)
@@ -166,7 +171,7 @@ func compactAppendResolvedShortID(
 
 func compactAppendMissingIndex(missing []uint64, missingShortIDs []compactShortID, absoluteIndex uint64, shortID compactShortID) ([]uint64, []compactShortID, error) {
 	if len(missing) >= maxCompactRelayEntries {
-		return nil, nil, errors.New("too many compact relay missing indexes")
+		return nil, nil, errCompactRelayMissingRequestTooLarge
 	}
 	return append(missing, absoluteIndex), append(missingShortIDs, shortID), nil
 }
@@ -242,6 +247,9 @@ func (p *peer) handleCmpctBlock(payload []byte) error {
 		return err
 	}
 	result, err := reconstructCompactBlock(block, compactRelayLocalTransactions(p.service.cfg.TxPool))
+	if errors.Is(err, errCompactRelayMissingRequestTooLarge) {
+		return nil
+	}
 	if err != nil {
 		return err
 	}
@@ -421,14 +429,34 @@ func compactBlockTransactions(blockBytes []byte) ([consensus.BLOCK_HEADER_BYTES]
 }
 
 func compactRequestedTransactions(txs [][]byte, indexes []uint64) ([][]byte, error) {
+	if err := validateCompactRequestedTransactionIndexes(txs, indexes); err != nil {
+		return nil, err
+	}
 	out := make([][]byte, 0, len(indexes))
 	for _, idx := range indexes {
-		if idx >= uint64(len(txs)) {
-			return nil, errors.New("compact relay index out of range")
-		}
 		out = append(out, append([]byte(nil), txs[int(idx)]...)) // #nosec G115 -- idx is bounded by len(txs) above.
 	}
 	return out, nil
+}
+
+func validateCompactRequestedTransactionIndexes(txs [][]byte, indexes []uint64) error {
+	seen := make(map[uint64]struct{}, len(indexes))
+	var totalTxBytes uint64
+	for _, idx := range indexes {
+		if idx >= uint64(len(txs)) {
+			return errors.New("compact relay index out of range")
+		}
+		if _, ok := seen[idx]; ok {
+			return errors.New("duplicate compact relay index")
+		}
+		seen[idx] = struct{}{}
+		nextTotal, err := validateBlockTxnTransactionSize(uint64(len(txs[int(idx)])), totalTxBytes) // #nosec G115 -- idx is bounded by len(txs) above.
+		if err != nil {
+			return err
+		}
+		totalTxBytes = nextTotal
+	}
+	return nil
 }
 
 func compactRelayLocalTransactions(pool TxPool) [][]byte {

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/node"
 )
 
 const compactDuplicateReportedIndex = ^uint64(0)
@@ -439,6 +440,10 @@ func (p *peer) processCompactRelayedBlock(expectedHash [32]byte, blockBytes []by
 	summary, err := p.service.cfg.SyncEngine.ApplyBlockWithReorg(blockBytes, nil)
 	p.service.chainMu.Unlock()
 	if err != nil {
+		if errors.Is(err, node.ErrParentNotFound) {
+			_, retainErr := p.retainRelayedOrphanIfValid(pb, blockHash, blockBytes)
+			return false, retainErr
+		}
 		return false, err
 	}
 	p.acceptedRelayedBlock(blockHash, summary)

--- a/clients/go/node/p2p/compact_reconstruct_test.go
+++ b/clients/go/node/p2p/compact_reconstruct_test.go
@@ -223,6 +223,18 @@ func TestCompactRequestedTransactionsRejectsDuplicateBeforeBlockScan(t *testing.
 	}
 }
 
+func TestCompactRequestedTransactionsRejectsRuntimeIndexCapBeforeScan(t *testing.T) {
+	var header [consensus.BLOCK_HEADER_BYTES]byte
+	blockBytes, err := compactBlockBytes(header, [][]byte{minimalBlockTxnTestTxBytes(73)})
+	if err != nil {
+		t.Fatalf("compactBlockBytes: %v", err)
+	}
+	_, err = compactRequestedTransactionsFromBlock(blockBytes, []uint64{maxCompactRelayEntries})
+	if err == nil || !strings.Contains(err.Error(), "compact relay index exceeds runtime cap") {
+		t.Fatalf("compactRequestedTransactionsFromBlock high index err=%v, want runtime cap rejection", err)
+	}
+}
+
 func TestCompactLocalTxIndexUsesBoundedPerCandidateValidation(t *testing.T) {
 	nonce1, nonce2 := uint64(51), uint64(52)
 	validTx := minimalBlockTxnTestTxBytes(53)

--- a/clients/go/node/p2p/compact_reconstruct_test.go
+++ b/clients/go/node/p2p/compact_reconstruct_test.go
@@ -205,10 +205,21 @@ func TestReconstructCompactBlockRejectsMissingAboveRequestCap(t *testing.T) {
 }
 
 func TestCompactValidateTransactionTotalRejectsCumulativeOversize(t *testing.T) {
-	txs := [][]byte{make([]byte, consensus.MAX_BLOCK_BYTES), {0x01}}
+	txs := [][]byte{make([]byte, consensus.MAX_BLOCK_BYTES), []byte{0x01}}
 	err := compactValidateTransactionTotal(txs)
 	if err == nil || !strings.Contains(err.Error(), "blocktxn transactions exceed block size") {
 		t.Fatalf("compactValidateTransactionTotal err=%v, want cumulative size failure", err)
+	}
+}
+
+func TestCompactRequestedTransactionsRejectsDuplicateAndCumulativeOversize(t *testing.T) {
+	txs := [][]byte{minimalBlockTxnTestTxBytes(71), minimalBlockTxnTestTxBytes(72)}
+	if _, err := compactRequestedTransactions(txs, []uint64{0, 0}); err == nil || !strings.Contains(err.Error(), "duplicate compact relay index") {
+		t.Fatalf("compactRequestedTransactions duplicate err=%v, want duplicate rejection", err)
+	}
+	oversize := [][]byte{make([]byte, consensus.MAX_BLOCK_BYTES), []byte{0x01}}
+	if _, err := compactRequestedTransactions(oversize, []uint64{0, 1}); err == nil || !strings.Contains(err.Error(), "blocktxn transactions exceed block size") {
+		t.Fatalf("compactRequestedTransactions oversize err=%v, want cumulative size rejection", err)
 	}
 }
 

--- a/clients/go/node/p2p/compact_reconstruct_test.go
+++ b/clients/go/node/p2p/compact_reconstruct_test.go
@@ -206,14 +206,6 @@ func TestReconstructCompactBlockRejectsMissingAboveRequestCap(t *testing.T) {
 	}
 }
 
-func TestCompactValidateTransactionTotalRejectsCumulativeOversize(t *testing.T) {
-	txs := [][]byte{make([]byte, consensus.MAX_BLOCK_BYTES), []byte{0x01}}
-	err := compactValidateTransactionTotal(txs)
-	if err == nil || !strings.Contains(err.Error(), "blocktxn transactions exceed block size") {
-		t.Fatalf("compactValidateTransactionTotal err=%v, want cumulative size failure", err)
-	}
-}
-
 func TestCompactReconstructionHelperErrorBranches(t *testing.T) {
 	validTx := minimalBlockTxnTestTxBytes(81)
 	shortID := compactShortIDForTx(t, validTx, 1, 2)
@@ -276,9 +268,6 @@ func TestCompactReconstructionHelperErrorBranches(t *testing.T) {
 		t.Fatalf("compactResolveShortIDTransactions blocked short id should become missing without error: %v", err)
 	}
 
-	if err := compactValidateTransactionTotal([][]byte{nil}); err == nil || !strings.Contains(err.Error(), "compact block transaction missing") {
-		t.Fatalf("compactValidateTransactionTotal nil err=%v, want missing tx", err)
-	}
 }
 
 func TestCompactBlockByteAndTransactionHelperErrors(t *testing.T) {
@@ -350,6 +339,18 @@ func TestCompactBlockByteAndTransactionHelperErrors(t *testing.T) {
 	}
 	if got, err := compactRequestedTransactionsFromBlock(twoTxBlock, []uint64{1}); err != nil || !reflect.DeepEqual(got, [][]byte{secondTx}) {
 		t.Fatalf("compactRequestedTransactionsFromBlock index 1=%x err=%v, want second tx", got, err)
+	}
+	manyTxs := make([][]byte, maxCompactRelayEntries+1)
+	for i := range manyTxs {
+		manyTxs[i] = minimalBlockTxnTestTxBytes(uint64(1000 + i))
+	}
+	manyTxBlock, err := compactBlockBytes(header, manyTxs)
+	if err != nil {
+		t.Fatalf("compactBlockBytes(many): %v", err)
+	}
+	highIndexTxs, err := compactRequestedTransactionsFromBlock(manyTxBlock, []uint64{maxCompactRelayEntries})
+	if err != nil || !reflect.DeepEqual(highIndexTxs, [][]byte{manyTxs[maxCompactRelayEntries]}) {
+		t.Fatalf("compactRequestedTransactionsFromBlock high valid index=%x err=%v, want tx at request-count cap", highIndexTxs, err)
 	}
 }
 
@@ -442,16 +443,28 @@ func TestCompactRequestedTransactionsRejectsDuplicateBeforeBlockScan(t *testing.
 	}
 }
 
-func TestCompactRequestedTransactionsRejectsRuntimeIndexCapBeforeScan(t *testing.T) {
+func TestCompactRequestedTransactionsRejectsWireIndexCapBeforeScan(t *testing.T) {
 	var header [consensus.BLOCK_HEADER_BYTES]byte
 	blockBytes, err := compactBlockBytes(header, [][]byte{minimalBlockTxnTestTxBytes(73)})
 	if err != nil {
 		t.Fatalf("compactBlockBytes: %v", err)
 	}
-	_, err = compactRequestedTransactionsFromBlock(blockBytes, []uint64{maxCompactRelayEntries})
+	_, err = compactRequestedTransactionsFromBlock(blockBytes, []uint64{maxCompactRelayIndexValue + 1})
 	if err == nil || !strings.Contains(err.Error(), "compact relay index exceeds runtime cap") {
 		t.Fatalf("compactRequestedTransactionsFromBlock high index err=%v, want runtime cap rejection", err)
 	}
+}
+
+func TestProcessCompactTransactionsAssemblyFailureRequestsFullBlockFallback(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	conn := &scriptedConn{}
+	p.conn = conn
+	hash := [32]byte{0x91}
+	var header [consensus.BLOCK_HEADER_BYTES]byte
+	if err := p.processCompactTransactions(hash, header, [][]byte{nil}); err != nil {
+		t.Fatalf("processCompactTransactions assembly failure: %v", err)
+	}
+	assertCompactFullBlockRequest(t, p, conn, hash)
 }
 
 func TestCompactLocalTxIndexUsesBoundedPerCandidateValidation(t *testing.T) {

--- a/clients/go/node/p2p/compact_reconstruct_test.go
+++ b/clients/go/node/p2p/compact_reconstruct_test.go
@@ -195,38 +195,20 @@ func TestReconstructCompactBlockRejectsMalformedInputs(t *testing.T) {
 	}
 }
 
-func TestReconstructCompactBlockReportsBoundedMissingForLargeCodecValidPayload(t *testing.T) {
-	result, err := reconstructCompactBlock(cmpctBlockPayload{
+func TestReconstructCompactBlockRejectsMissingAboveRequestCap(t *testing.T) {
+	_, err := reconstructCompactBlock(cmpctBlockPayload{
 		ShortIDs: make([]compactShortID, maxCompactRelayEntries+1),
 	}, nil)
-	if err != nil {
-		t.Fatalf("reconstructCompactBlock: %v", err)
-	}
-	if result.Transactions != nil || len(result.MissingIndexes) != maxCompactRelayEntries {
-		t.Fatalf("result=%+v, want bounded missing indexes", result)
-	}
-	if result.MissingIndexes[0] != 0 || result.MissingIndexes[len(result.MissingIndexes)-1] != maxCompactRelayEntries-1 {
-		t.Fatalf("missing bounds got first=%d last=%d", result.MissingIndexes[0], result.MissingIndexes[len(result.MissingIndexes)-1])
+	if err == nil || !strings.Contains(err.Error(), "too many compact relay missing indexes") {
+		t.Fatalf("reconstructCompactBlock err=%v, want missing cap rejection", err)
 	}
 }
 
-func TestCompactFillShortIDTransactionsRejectsCumulativeOversize(t *testing.T) {
-	tx := minimalBlockTxnTestTxBytes(51)
-	shortID := compactShortID{0x51}
-	txs := make([][]byte, 1)
-	err := compactFillShortIDTransactions(
-		txs,
-		1,
-		nil,
-		[]compactShortID{shortID},
-		map[compactShortID][]byte{shortID: tx},
-		uint64(consensus.MAX_BLOCK_BYTES-len(tx)+1),
-	)
+func TestCompactValidateTransactionTotalRejectsCumulativeOversize(t *testing.T) {
+	txs := [][]byte{make([]byte, consensus.MAX_BLOCK_BYTES), {0x01}}
+	err := compactValidateTransactionTotal(txs)
 	if err == nil || !strings.Contains(err.Error(), "blocktxn transactions exceed block size") {
-		t.Fatalf("compactFillShortIDTransactions err=%v, want cumulative size failure", err)
-	}
-	if txs[0] != nil {
-		t.Fatalf("compactFillShortIDTransactions mutated txs before validation: %x", txs[0])
+		t.Fatalf("compactValidateTransactionTotal err=%v, want cumulative size failure", err)
 	}
 }
 

--- a/clients/go/node/p2p/compact_reconstruct_test.go
+++ b/clients/go/node/p2p/compact_reconstruct_test.go
@@ -212,14 +212,14 @@ func TestCompactValidateTransactionTotalRejectsCumulativeOversize(t *testing.T) 
 	}
 }
 
-func TestCompactRequestedTransactionsRejectsDuplicateAndCumulativeOversize(t *testing.T) {
-	txs := [][]byte{minimalBlockTxnTestTxBytes(71), minimalBlockTxnTestTxBytes(72)}
-	if _, err := compactRequestedTransactions(txs, []uint64{0, 0}); err == nil || !strings.Contains(err.Error(), "duplicate compact relay index") {
-		t.Fatalf("compactRequestedTransactions duplicate err=%v, want duplicate rejection", err)
+func TestCompactRequestedTransactionsRejectsDuplicateBeforeBlockScan(t *testing.T) {
+	var header [consensus.BLOCK_HEADER_BYTES]byte
+	blockBytes, err := compactBlockBytes(header, [][]byte{minimalBlockTxnTestTxBytes(71), minimalBlockTxnTestTxBytes(72)})
+	if err != nil {
+		t.Fatalf("compactBlockBytes: %v", err)
 	}
-	oversize := [][]byte{make([]byte, consensus.MAX_BLOCK_BYTES), []byte{0x01}}
-	if _, err := compactRequestedTransactions(oversize, []uint64{0, 1}); err == nil || !strings.Contains(err.Error(), "blocktxn transactions exceed block size") {
-		t.Fatalf("compactRequestedTransactions oversize err=%v, want cumulative size rejection", err)
+	if _, err := compactRequestedTransactionsFromBlock(blockBytes, []uint64{0, 0}); err == nil || !strings.Contains(err.Error(), "duplicate compact relay index") {
+		t.Fatalf("compactRequestedTransactionsFromBlock duplicate err=%v, want duplicate rejection", err)
 	}
 }
 

--- a/clients/go/node/p2p/compact_reconstruct_test.go
+++ b/clients/go/node/p2p/compact_reconstruct_test.go
@@ -1,9 +1,11 @@
 package p2p
 
 import (
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
 )
@@ -212,6 +214,223 @@ func TestCompactValidateTransactionTotalRejectsCumulativeOversize(t *testing.T) 
 	}
 }
 
+func TestCompactReconstructionHelperErrorBranches(t *testing.T) {
+	validTx := minimalBlockTxnTestTxBytes(81)
+	shortID := compactShortIDForTx(t, validTx, 1, 2)
+
+	if _, _, err := compactBlockHeaderAndHash(make([]byte, consensus.MAX_RELAY_MSG_BYTES+1)); err == nil || !strings.Contains(err.Error(), "cmpctblock payload too large") {
+		t.Fatalf("compactBlockHeaderAndHash oversized err=%v, want payload cap", err)
+	}
+	if _, _, err := compactBlockHeaderAndHash(make([]byte, consensus.BLOCK_HEADER_BYTES-1)); err == nil || !strings.Contains(err.Error(), "cmpctblock payload missing header or nonce") {
+		t.Fatalf("compactBlockHeaderAndHash short err=%v, want missing header", err)
+	}
+
+	for _, tc := range []struct {
+		name    string
+		payload []byte
+		wantErr string
+	}{
+		{
+			name:    "oversized",
+			payload: make([]byte, consensus.MAX_RELAY_MSG_BYTES+1),
+			wantErr: "cmpctblock payload too large",
+		},
+		{
+			name:    "missing nonce",
+			payload: make([]byte, consensus.BLOCK_HEADER_BYTES+15),
+			wantErr: "cmpctblock payload missing header or nonce",
+		},
+		{
+			name:    "short count varint",
+			payload: append(make([]byte, consensus.BLOCK_HEADER_BYTES+16), 0xfd),
+			wantErr: "EOF",
+		},
+		{
+			name:    "truncated short ids",
+			payload: append(make([]byte, consensus.BLOCK_HEADER_BYTES+16), 0x02, 1, 2, 3, 4, 5),
+			wantErr: "cmpctblock payload truncated short IDs",
+		},
+		{
+			name:    "prefilled count varint",
+			payload: append(make([]byte, consensus.BLOCK_HEADER_BYTES+16), 0x00, 0xfd),
+			wantErr: "EOF",
+		},
+		{
+			name:    "zero entries",
+			payload: append(make([]byte, consensus.BLOCK_HEADER_BYTES+16), 0x00, 0x00),
+			wantErr: "invalid compact relay entry count",
+		},
+	} {
+		if _, err := compactBlockRuntimeEntryCount(tc.payload); err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+			t.Fatalf("%s: compactBlockRuntimeEntryCount err=%v, want %q", tc.name, err, tc.wantErr)
+		}
+	}
+
+	if _, _, err := compactAppendMissingIndex(make([]uint64, maxCompactRelayEntries), nil, 0, shortID); !errors.Is(err, errCompactRelayMissingRequestTooLarge) {
+		t.Fatalf("compactAppendMissingIndex cap err=%v, want missing request cap", err)
+	}
+	if _, _, err := compactAppendResolvedShortID(make([][]byte, 1), make([]uint64, maxCompactRelayEntries), nil, map[compactShortID]uint64{shortID: 0}, shortID, 0, validTx, false); !errors.Is(err, errCompactRelayMissingRequestTooLarge) {
+		t.Fatalf("compactAppendResolvedShortID duplicate cap err=%v, want missing request cap", err)
+	}
+	if _, _, err := compactResolveShortIDTransactions(make([][]byte, 1), 1, nil, []compactShortID{shortID}, map[compactShortID][]byte{shortID: validTx}, map[compactShortID]bool{shortID: true}); err != nil {
+		t.Fatalf("compactResolveShortIDTransactions blocked short id should become missing without error: %v", err)
+	}
+
+	if err := compactValidateTransactionTotal([][]byte{nil}); err == nil || !strings.Contains(err.Error(), "compact block transaction missing") {
+		t.Fatalf("compactValidateTransactionTotal nil err=%v, want missing tx", err)
+	}
+}
+
+func TestCompactBlockByteAndTransactionHelperErrors(t *testing.T) {
+	var header [consensus.BLOCK_HEADER_BYTES]byte
+	validTx := minimalBlockTxnTestTxBytes(82)
+	validBlock, err := compactBlockBytes(header, [][]byte{validTx})
+	if err != nil {
+		t.Fatalf("compactBlockBytes(valid): %v", err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		txs  [][]byte
+		want string
+	}{
+		{name: "empty", txs: nil, want: "compact block has no transactions"},
+		{name: "nil tx", txs: [][]byte{nil}, want: "compact block transaction missing"},
+		{name: "tx too large", txs: [][]byte{make([]byte, consensus.MAX_BLOCK_BYTES+1)}, want: "blocktxn transaction too large"},
+		{name: "block too large", txs: [][]byte{make([]byte, consensus.MAX_BLOCK_BYTES)}, want: "compact block exceeds block size"},
+	} {
+		if _, err := compactBlockBytes(header, tc.txs); err == nil || !strings.Contains(err.Error(), tc.want) {
+			t.Fatalf("%s: compactBlockBytes err=%v, want %q", tc.name, err, tc.want)
+		}
+	}
+
+	for _, tc := range []struct {
+		name  string
+		block []byte
+		want  string
+	}{
+		{name: "short", block: make([]byte, consensus.BLOCK_HEADER_BYTES), want: "block too short"},
+		{name: "bad varint", block: append(make([]byte, consensus.BLOCK_HEADER_BYTES), 0xfd), want: "EOF"},
+		{name: "zero tx count", block: append(make([]byte, consensus.BLOCK_HEADER_BYTES), 0x00), want: "invalid compact relay entry count"},
+		{name: "bad tx", block: append(make([]byte, consensus.BLOCK_HEADER_BYTES), 0x01, 0x00), want: "unexpected EOF"},
+		{name: "trailing", block: append(append([]byte(nil), validBlock...), 0xff), want: "trailing bytes after tx list"},
+	} {
+		if _, _, err := compactBlockTransactions(tc.block); err == nil || !strings.Contains(err.Error(), tc.want) {
+			t.Fatalf("%s: compactBlockTransactions err=%v, want %q", tc.name, err, tc.want)
+		}
+	}
+
+	for _, tc := range []struct {
+		name  string
+		block []byte
+		want  string
+	}{
+		{name: "short", block: make([]byte, consensus.BLOCK_HEADER_BYTES), want: "block too short"},
+		{name: "bad varint", block: append(make([]byte, consensus.BLOCK_HEADER_BYTES), 0xfd), want: "EOF"},
+		{name: "zero tx count", block: append(make([]byte, consensus.BLOCK_HEADER_BYTES), 0x00), want: "invalid compact relay entry count"},
+	} {
+		if _, _, err := compactBlockTransactionCount(tc.block); err == nil || !strings.Contains(err.Error(), tc.want) {
+			t.Fatalf("%s: compactBlockTransactionCount err=%v, want %q", tc.name, err, tc.want)
+		}
+	}
+
+	if got, err := compactRequestedTransactionsFromBlock(validBlock, nil); err != nil || len(got) != 0 {
+		t.Fatalf("compactRequestedTransactionsFromBlock empty indexes=%x err=%v, want empty", got, err)
+	}
+	if _, err := compactRequestedTransactionsFromBlock(validBlock, []uint64{1}); err == nil || !strings.Contains(err.Error(), "compact relay index out of range") {
+		t.Fatalf("compactRequestedTransactionsFromBlock high in-block index err=%v, want out of range", err)
+	}
+	if _, err := compactRequestedTransactionsFromBlock(append(make([]byte, consensus.BLOCK_HEADER_BYTES), 0x01, 0x00), []uint64{0}); err == nil || !strings.Contains(err.Error(), "unexpected EOF") {
+		t.Fatalf("compactRequestedTransactionsFromBlock bad tx err=%v, want parse error", err)
+	}
+	secondTx := minimalBlockTxnTestTxBytes(83)
+	twoTxBlock, err := compactBlockBytes(header, [][]byte{validTx, secondTx})
+	if err != nil {
+		t.Fatalf("compactBlockBytes(two): %v", err)
+	}
+	if got, err := compactRequestedTransactionsFromBlock(twoTxBlock, []uint64{1}); err != nil || !reflect.DeepEqual(got, [][]byte{secondTx}) {
+		t.Fatalf("compactRequestedTransactionsFromBlock index 1=%x err=%v, want second tx", got, err)
+	}
+}
+
+func TestCompactFallbackAndOutstandingHelperBranches(t *testing.T) {
+	if !errors.Is(compactFullBlockFallbackError(nil), errCompactFullBlockFallbackRequired) {
+		t.Fatal("compactFullBlockFallbackError(nil) did not preserve fallback sentinel")
+	}
+	if !compactTxErrorNeedsFallback(consensus.ErrorCode("TX_ERR_TEST")) {
+		t.Fatal("TX_ERR_* should require compact full-block fallback")
+	}
+	if !compactTxErrorNeedsFallback(consensus.BLOCK_ERR_DA_BATCH_EXCEEDED) {
+		t.Fatal("DA body error should require compact full-block fallback")
+	}
+	if compactTxErrorNeedsFallback(consensus.BLOCK_ERR_TARGET_INVALID) {
+		t.Fatal("header-context target error must not be hidden by full-block fallback")
+	}
+
+	p := newPeerRuntimeTestPeer(t)
+	cause := errors.New("test cause")
+	if got := p.requestCompactFullBlockFallbackForOutstanding(cause); got != cause {
+		t.Fatalf("requestCompactFullBlockFallbackForOutstanding no outstanding=%v, want original cause", got)
+	}
+	p.setCompactOutstandingRequest(compactOutstandingRequest{
+		BlockHash:       [32]byte{0x01},
+		MissingIndexes:  []uint64{0},
+		MissingShortIDs: []compactShortID{{0x01}},
+		Transactions:    make([][]byte, 1),
+	})
+	p.clearCompactOutstandingRequest()
+	if outstanding, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatalf("clearCompactOutstandingRequest left outstanding=%+v", outstanding)
+	}
+
+	bare := &peer{}
+	if bare.compactOutstandingTTL() != defaultCompactOutstandingTTL {
+		t.Fatalf("bare peer TTL=%s, want default", bare.compactOutstandingTTL())
+	}
+	if bare.compactNow().Before(time.Unix(1, 0)) {
+		t.Fatalf("bare peer compactNow returned invalid timestamp")
+	}
+
+	if got := compactRelayLocalTransactions((*MemoryTxPool)(nil)); got != nil {
+		t.Fatalf("nil MemoryTxPool local txs=%x, want nil", got)
+	}
+	if got := compactRelayLocalTransactions((*CanonicalMempoolTxPool)(nil)); got != nil {
+		t.Fatalf("nil CanonicalMempoolTxPool local txs=%x, want nil", got)
+	}
+	if got := compactRelayLocalTransactions(&CanonicalMempoolTxPool{}); got != nil {
+		t.Fatalf("empty CanonicalMempoolTxPool local txs=%x, want nil", got)
+	}
+	if got := compactRelayLocalTransactions(compactNoopTxPool{}); got != nil {
+		t.Fatalf("unsupported TxPool local txs=%x, want nil", got)
+	}
+	if _, err := compactTransactionShortID([]byte{0x00}, 1, 2); err == nil || !strings.Contains(err.Error(), "compact local transaction is non-canonical") {
+		t.Fatalf("compactTransactionShortID malformed err=%v, want canonical error", err)
+	}
+}
+
+func TestCompactOutstandingRequestValidationBranches(t *testing.T) {
+	if _, err := newCompactOutstandingRequest(cmpctBlockPayload{}, [32]byte{}, compactReconstructionResult{}); err == nil || !strings.Contains(err.Error(), "compact reconstruction missing request mismatch") {
+		t.Fatalf("newCompactOutstandingRequest empty err=%v, want mismatch", err)
+	}
+	tx := minimalBlockTxnTestTxBytes(84)
+	shortID, err := compactTransactionShortID(tx, 0, 0)
+	if err != nil {
+		t.Fatalf("compactTransactionShortID: %v", err)
+	}
+	_, _, wtxid, consumed, err := consensus.ParseTx(tx)
+	if err != nil || consumed != len(tx) {
+		t.Fatalf("ParseTx: consumed=%d err=%v", consumed, err)
+	}
+	req := compactOutstandingRequest{
+		MissingIndexes:  []uint64{1},
+		MissingShortIDs: []compactShortID{shortID},
+		Transactions:    make([][]byte, 1),
+	}
+	if _, err := compactFillResponseTransactions(req, [][]byte{tx}, [][32]byte{wtxid}); err == nil || !strings.Contains(err.Error(), "compact relay index out of range") {
+		t.Fatalf("compactFillResponseTransactions out-of-range err=%v, want range error", err)
+	}
+}
+
 func TestCompactRequestedTransactionsRejectsDuplicateBeforeBlockScan(t *testing.T) {
 	var header [consensus.BLOCK_HEADER_BYTES]byte
 	blockBytes, err := compactBlockBytes(header, [][]byte{minimalBlockTxnTestTxBytes(71), minimalBlockTxnTestTxBytes(72)})
@@ -271,4 +490,12 @@ func compactShortIDForTx(t *testing.T, tx []byte, nonce1, nonce2 uint64) compact
 		t.Fatalf("ParseTx: consumed=%d err=%v", consumed, err)
 	}
 	return compactShortID(consensus.CompactShortID(wtxid, nonce1, nonce2))
+}
+
+type compactNoopTxPool struct{}
+
+func (compactNoopTxPool) Get([32]byte) ([]byte, bool) { return nil, false }
+func (compactNoopTxPool) Has([32]byte) bool           { return false }
+func (compactNoopTxPool) Put([32]byte, []byte, uint64, int) bool {
+	return false
 }

--- a/clients/go/node/p2p/compact_runtime.go
+++ b/clients/go/node/p2p/compact_runtime.go
@@ -51,6 +51,9 @@ func (p *peer) remoteCompactMode() compactModeSnapshot {
 }
 
 func (p *peer) compactRelayEnabled() bool {
+	if p == nil || p.service == nil || !p.service.cfg.CompactRelayObjectsEnabled {
+		return false
+	}
 	mode := p.remoteCompactMode()
 	return mode.Version == compactRelayVersion && mode.Mode > 0
 }

--- a/clients/go/node/p2p/compact_runtime.go
+++ b/clients/go/node/p2p/compact_runtime.go
@@ -3,6 +3,7 @@ package p2p
 import (
 	"encoding/binary"
 	"errors"
+	"time"
 )
 
 type compactModeSnapshot struct {
@@ -17,7 +18,9 @@ type peerCompactRelayState struct {
 }
 
 type compactLateBlockTxnReply struct {
-	Cap uint32
+	BlockHash [32]byte
+	Cap       uint32
+	ExpiresAt time.Time
 }
 
 func (p *peer) handleSendCmpct(payload []byte) error {

--- a/clients/go/node/p2p/compact_runtime.go
+++ b/clients/go/node/p2p/compact_runtime.go
@@ -49,3 +49,8 @@ func (p *peer) remoteCompactMode() compactModeSnapshot {
 	defer p.compactMu.Unlock()
 	return p.compact.remoteMode
 }
+
+func (p *peer) compactRelayEnabled() bool {
+	mode := p.remoteCompactMode()
+	return mode.Version == compactRelayVersion && mode.Mode > 0
+}

--- a/clients/go/node/p2p/compact_runtime.go
+++ b/clients/go/node/p2p/compact_runtime.go
@@ -11,7 +11,8 @@ type compactModeSnapshot struct {
 }
 
 type peerCompactRelayState struct {
-	remoteMode compactModeSnapshot
+	remoteMode  compactModeSnapshot
+	outstanding *compactOutstandingRequest
 }
 
 func (p *peer) handleSendCmpct(payload []byte) error {

--- a/clients/go/node/p2p/compact_runtime.go
+++ b/clients/go/node/p2p/compact_runtime.go
@@ -11,8 +11,13 @@ type compactModeSnapshot struct {
 }
 
 type peerCompactRelayState struct {
-	remoteMode  compactModeSnapshot
-	outstanding *compactOutstandingRequest
+	remoteMode        compactModeSnapshot
+	outstanding       *compactOutstandingRequest
+	lateBlockTxnReply *compactLateBlockTxnReply
+}
+
+type compactLateBlockTxnReply struct {
+	Cap uint32
 }
 
 func (p *peer) handleSendCmpct(payload []byte) error {

--- a/clients/go/node/p2p/compact_wire.go
+++ b/clients/go/node/p2p/compact_wire.go
@@ -36,6 +36,12 @@ type blockTxnPayload struct {
 	Transactions [][]byte
 }
 
+type blockTxnRuntimePayload struct {
+	BlockHash    [32]byte
+	Transactions [][]byte
+	WTxIDs       [][32]byte
+}
+
 type compactShortID [compactShortIDBytes]byte
 
 type prefilledTxn struct {
@@ -141,40 +147,49 @@ func encodeBlockTxnPayload(p blockTxnPayload) ([]byte, error) {
 }
 
 func decodeBlockTxnPayload(payload []byte) (blockTxnPayload, error) {
+	runtimePayload, err := decodeBlockTxnRuntimePayload(payload)
+	if err != nil {
+		return blockTxnPayload{}, err
+	}
+	return blockTxnPayload{BlockHash: runtimePayload.BlockHash, Transactions: runtimePayload.Transactions}, nil
+}
+
+func decodeBlockTxnRuntimePayload(payload []byte) (blockTxnRuntimePayload, error) {
 	var out blockTxnPayload
 	if len(payload) < 32 {
-		return out, errors.New("blocktxn payload missing block hash")
+		return blockTxnRuntimePayload{}, errors.New("blocktxn payload missing block hash")
 	}
 	copy(out.BlockHash[:], payload[:32])
 	count, consumed, err := consensus.DecodeCompactSize(payload[32:])
 	if err != nil {
-		return blockTxnPayload{}, err
+		return blockTxnRuntimePayload{}, err
 	}
 	if count > maxCompactRelayEntries {
-		return blockTxnPayload{}, errors.New("too many compact relay transactions")
+		return blockTxnRuntimePayload{}, errors.New("too many compact relay transactions")
 	}
 	offset := 32 + consumed
 	transactions := make([][]byte, 0, int(count)) // #nosec G115 -- count is capped at maxCompactRelayEntries above.
+	wtxids := make([][32]byte, 0, int(count))     // #nosec G115 -- count is capped at maxCompactRelayEntries above.
 	var totalTxBytes uint64
 	for i := uint64(0); i < count; i++ {
 		txLen, n, err := consensus.DecodeCompactSize(payload[offset:])
 		if err != nil {
-			return blockTxnPayload{}, err
+			return blockTxnRuntimePayload{}, err
 		}
 		offset += n
-		tx, txConsumed, nextTotal, err := decodeCompactRelayTxEnvelope(payload[offset:], txLen, totalTxBytes, "blocktxn transaction is non-canonical")
+		tx, wtxid, txConsumed, nextTotal, err := decodeCompactRelayTxEnvelope(payload[offset:], txLen, totalTxBytes, "blocktxn transaction is non-canonical")
 		if err != nil {
-			return blockTxnPayload{}, err
+			return blockTxnRuntimePayload{}, err
 		}
 		transactions = append(transactions, append([]byte(nil), tx...))
+		wtxids = append(wtxids, wtxid)
 		offset += txConsumed
 		totalTxBytes = nextTotal
 	}
 	if offset != len(payload) {
-		return blockTxnPayload{}, errors.New("blocktxn payload has trailing bytes")
+		return blockTxnRuntimePayload{}, errors.New("blocktxn payload has trailing bytes")
 	}
-	out.Transactions = transactions
-	return out, nil
+	return blockTxnRuntimePayload{BlockHash: out.BlockHash, Transactions: transactions, WTxIDs: wtxids}, nil
 }
 
 func encodeCmpctBlockPayload(p cmpctBlockPayload) ([]byte, error) {
@@ -282,7 +297,7 @@ func decodeCmpctBlockPrefilled(payload []byte, offset int, entryPos, prev, total
 		return prefilledTxn{}, 0, totalTxBytes, err
 	}
 	offset += n
-	tx, txConsumed, nextTotal, err := decodeCompactRelayTxEnvelope(payload[offset:], txLen, totalTxBytes, "cmpctblock prefilled transaction is non-canonical")
+	tx, _, txConsumed, nextTotal, err := decodeCompactRelayTxEnvelope(payload[offset:], txLen, totalTxBytes, "cmpctblock prefilled transaction is non-canonical")
 	if err != nil {
 		return prefilledTxn{}, 0, totalTxBytes, err
 	}
@@ -338,20 +353,21 @@ func validateCmpctBlockEntryCount(shortCount, prefilledCount uint64) (uint64, er
 	return totalEntries, nil
 }
 
-func decodeCompactRelayTxEnvelope(payload []byte, txLen, totalTxBytes uint64, nonCanonicalErr string) ([]byte, int, uint64, error) {
+func decodeCompactRelayTxEnvelope(payload []byte, txLen, totalTxBytes uint64, nonCanonicalErr string) ([]byte, [32]byte, int, uint64, error) {
+	var zero [32]byte
 	if txLen > uint64(len(payload)) {
-		return nil, 0, totalTxBytes, errors.New("compact relay transaction truncated")
+		return nil, zero, 0, totalTxBytes, errors.New("compact relay transaction truncated")
 	}
 	tx := payload[:int(txLen)] // #nosec G115 -- txLen is bounded by len(payload) above.
 	nextTotal, err := validateBlockTxnTransactionSize(txLen, totalTxBytes)
 	if err != nil {
-		return nil, 0, totalTxBytes, err
+		return nil, zero, 0, totalTxBytes, err
 	}
-	_, _, _, consumed, err := consensus.ParseTx(tx)
+	_, _, wtxid, consumed, err := consensus.ParseTx(tx)
 	if err != nil || consumed != len(tx) {
-		return nil, 0, totalTxBytes, errors.New(nonCanonicalErr)
+		return nil, zero, 0, totalTxBytes, errors.New(nonCanonicalErr)
 	}
-	return tx, len(tx), nextTotal, nil
+	return tx, wtxid, len(tx), nextTotal, nil
 }
 
 func finishCmpctBlockPayload(out cmpctBlockPayload, offset, payloadLen int) (cmpctBlockPayload, error) {

--- a/clients/go/node/p2p/compact_wire.go
+++ b/clients/go/node/p2p/compact_wire.go
@@ -155,11 +155,11 @@ func decodeBlockTxnPayload(payload []byte) (blockTxnPayload, error) {
 }
 
 func decodeBlockTxnRuntimePayload(payload []byte) (blockTxnRuntimePayload, error) {
-	var out blockTxnPayload
+	var blockHash [32]byte
 	if len(payload) < 32 {
 		return blockTxnRuntimePayload{}, errors.New("blocktxn payload missing block hash")
 	}
-	copy(out.BlockHash[:], payload[:32])
+	copy(blockHash[:], payload[:32])
 	count, consumed, err := consensus.DecodeCompactSize(payload[32:])
 	if err != nil {
 		return blockTxnRuntimePayload{}, err
@@ -189,7 +189,7 @@ func decodeBlockTxnRuntimePayload(payload []byte) (blockTxnRuntimePayload, error
 	if offset != len(payload) {
 		return blockTxnRuntimePayload{}, errors.New("blocktxn payload has trailing bytes")
 	}
-	return blockTxnRuntimePayload{BlockHash: out.BlockHash, Transactions: transactions, WTxIDs: wtxids}, nil
+	return blockTxnRuntimePayload{BlockHash: blockHash, Transactions: transactions, WTxIDs: wtxids}, nil
 }
 
 func encodeCmpctBlockPayload(p cmpctBlockPayload) ([]byte, error) {

--- a/clients/go/node/p2p/compact_wire_test.go
+++ b/clients/go/node/p2p/compact_wire_test.go
@@ -27,14 +27,8 @@ func TestCompactWireCommandConstantsAndPayloadCaps(t *testing.T) {
 		if (command == messageCmpctBlock || command == messageBlockTxn) && caps[i] <= uint32(consensus.MAX_BLOCK_BYTES) {
 			t.Fatalf("%s explicit cap=%d, want above MAX_BLOCK_BYTES", command, caps[i])
 		}
-		if command == messageSendCmpct {
-			if got := liveCaps(command); got != sendCmpctPayloadBytes {
-				t.Fatalf("%s live cap=%d, want %d", command, got, sendCmpctPayloadBytes)
-			}
-			continue
-		}
-		if got := liveCaps(command); got != 0 {
-			t.Fatalf("%s live cap=%d, want 0 until runtime handler slice", command, got)
+		if got := liveCaps(command); got != caps[i] {
+			t.Fatalf("%s live cap=%d, want %d", command, got, caps[i])
 		}
 	}
 }

--- a/clients/go/node/p2p/handlers_compact_test.go
+++ b/clients/go/node/p2p/handlers_compact_test.go
@@ -256,6 +256,40 @@ func TestGetBlockTxnRespondsWithRequestedTransactions(t *testing.T) {
 	}
 }
 
+func TestGetBlockTxnRejectsDuplicateIndexesBeforeResponse(t *testing.T) {
+	source := newTestHarness(t, 2, "127.0.0.1:0", nil)
+	blockHash, _ := testHarnessBlockAtHeight(t, source, 1)
+	p, conn := compactTestPeerWithConn(source)
+
+	err := p.handleMessage(message{Command: messageGetBlockTxn, Payload: mustEncodeGetBlockTxnForHash(t, blockHash, []uint64{0, 0})})
+	if err == nil || !strings.Contains(err.Error(), "duplicate compact relay index") {
+		t.Fatalf("handleMessage(getblocktxn duplicate) err=%v, want duplicate rejection", err)
+	}
+	if conn.Buffer.Len() != 0 {
+		t.Fatalf("duplicate getblocktxn wrote %d bytes, want no response", conn.Buffer.Len())
+	}
+}
+
+func TestCmpctBlockMissingAboveRequestCapDefersFallbackWithoutRequest(t *testing.T) {
+	source := newTestHarness(t, 2, "127.0.0.1:0", nil)
+	sink := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	_, blockBytes := testHarnessBlockAtHeight(t, source, 1)
+	block := compactTestPayloadFromBlock(t, blockBytes, 51, 52)
+	block.ShortIDs = make([]compactShortID, maxCompactRelayEntries+1)
+
+	p, conn := compactTestPeerWithConn(sink)
+	if err := p.handleMessage(message{Command: messageCmpctBlock, Payload: mustEncodeCmpctBlockPayload(t, block)}); err != nil {
+		t.Fatalf("handleMessage(cmpctblock many missing): %v", err)
+	}
+	if conn.Buffer.Len() != 0 {
+		t.Fatalf("many-missing cmpctblock wrote %d bytes, want no getblocktxn in RUB-326", conn.Buffer.Len())
+	}
+	if outstanding, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatalf("many-missing cmpctblock left outstanding: %+v", outstanding)
+	}
+	assertHarnessTip(t, sink, 0, nodeGenesisHash(t, sink))
+}
+
 func compactTestMinedBlockWithSpend(t *testing.T) (*testHarness, *testHarness, [32]byte, []byte, []byte) {
 	t.Helper()
 	source := newTestHarness(t, 1, "127.0.0.1:0", nil)

--- a/clients/go/node/p2p/handlers_compact_test.go
+++ b/clients/go/node/p2p/handlers_compact_test.go
@@ -651,6 +651,10 @@ func TestCompactOutstandingClearsWhenBlockIsLearnedExternally(t *testing.T) {
 		t.Fatalf("external ApplyBlock(A): %v", err)
 	}
 	assertHarnessTip(t, sink, 1, hashA)
+	assertCompactCommandCapEnabled(t, p.postHandshakePayloadCap(), messageBlockTxn)
+	if err := p.handleMessage(message{Command: messageBlockTxn, Payload: mustEncodeBlockTxnForHash(t, hashA, [][]byte{minimalBlockTxnTestTxBytes(108)})}); err != nil {
+		t.Fatalf("known-block in-flight blocktxn A: %v", err)
+	}
 	assertCompactCommandCap(t, p.postHandshakePayloadCap(), messageBlockTxn, 0)
 	assertNoCompactOutstanding(t, p, "externally learned block")
 
@@ -676,6 +680,10 @@ func TestCompactOutstandingKnownBlockCleanupBranches(t *testing.T) {
 	knownReq := compactOutstandingRequest{BlockHash: node.DevnetGenesisBlockHash(), MissingIndexes: []uint64{0}, MissingShortIDs: []compactShortID{{0x01}}, Transactions: make([][]byte, 1)}
 	p.setCompactOutstandingRequest(knownReq)
 	p.setLateBlockTxnReply(knownReq)
+	assertCompactCommandCapEnabled(t, p.postHandshakePayloadCap(), messageBlockTxn)
+	if err := p.handleMessage(message{Command: messageBlockTxn, Payload: mustEncodeBlockTxnForHash(t, knownReq.BlockHash, [][]byte{minimalBlockTxnTestTxBytes(107)})}); err != nil {
+		t.Fatalf("known-block late blocktxn: %v", err)
+	}
 	assertCompactCommandCap(t, p.postHandshakePayloadCap(), messageBlockTxn, 0)
 	assertNoCompactOutstanding(t, p, "known block cap cleanup")
 

--- a/clients/go/node/p2p/handlers_compact_test.go
+++ b/clients/go/node/p2p/handlers_compact_test.go
@@ -612,6 +612,73 @@ func TestCompactOutstandingClearsWhenBlockIsLearnedExternally(t *testing.T) {
 	assertCompactOutstandingHash(t, p, hashB)
 }
 
+func TestCompactOutstandingKnownBlockCleanupBranches(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	conn := &scriptedConn{}
+	p.conn = conn
+	enableCompactRelayForTest(p)
+	if _, err := p.service.cfg.SyncEngine.ApplyBlock(node.DevnetGenesisBlockBytes(), nil); err != nil {
+		t.Fatalf("ApplyBlock(genesis): %v", err)
+	}
+	knownReq := compactOutstandingRequest{BlockHash: node.DevnetGenesisBlockHash(), MissingIndexes: []uint64{0}, MissingShortIDs: []compactShortID{{0x01}}, Transactions: make([][]byte, 1)}
+	p.setCompactOutstandingRequest(knownReq)
+	p.setLateBlockTxnReply(knownReq)
+	assertCompactCommandCap(t, p.postHandshakePayloadCap(), messageBlockTxn, 0)
+	assertNoCompactOutstanding(t, p, "known block cap cleanup")
+
+	unknownReq := compactOutstandingRequest{BlockHash: [32]byte{0x77}, MissingIndexes: []uint64{0}, MissingShortIDs: []compactShortID{{0x02}}, Transactions: make([][]byte, 1)}
+	p.setCompactOutstandingRequest(unknownReq)
+	if err := p.clearKnownCompactOutstandingRequest(); err != nil {
+		t.Fatalf("clear unknown outstanding: %v", err)
+	}
+	assertCompactOutstandingHash(t, p, unknownReq.BlockHash)
+	if !p.clearCompactOutstandingRequestForHash(unknownReq.BlockHash) {
+		t.Fatal("clearCompactOutstandingRequestForHash did not clear matching outstanding")
+	}
+
+	p.setCompactOutstandingRequest(knownReq)
+	if err := p.fallbackCompactOutstandingRequest(); err != nil {
+		t.Fatalf("fallback known outstanding: %v", err)
+	}
+	if conn.Buffer.Len() != 0 {
+		t.Fatalf("known fallback wrote %d bytes, want no fallback request", conn.Buffer.Len())
+	}
+	assertNoCompactOutstanding(t, p, "known block fallback cleanup")
+}
+
+func TestCompactPrepareRejectsShortAndSkipsKnownBlock(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	p.conn = &scriptedConn{}
+	if _, _, _, err := p.prepareCmpctBlock([]byte{0x01}); err == nil || !strings.Contains(err.Error(), "cmpctblock payload missing header") {
+		t.Fatalf("prepare short cmpctblock err=%v, want missing header", err)
+	}
+	if _, err := p.service.cfg.SyncEngine.ApplyBlock(node.DevnetGenesisBlockBytes(), nil); err != nil {
+		t.Fatalf("ApplyBlock(genesis): %v", err)
+	}
+	block := compactTestPayloadFromBlock(t, node.DevnetGenesisBlockBytes(), 71, 72)
+	_, blockHash, done, err := p.prepareCmpctBlock(mustEncodeCmpctBlockPayload(t, block))
+	if err != nil || !done || blockHash != node.DevnetGenesisBlockHash() {
+		t.Fatalf("prepare known block hash=%x done=%v err=%v, want known genesis done", blockHash, done, err)
+	}
+}
+
+func TestRequestMissingCompactTransactionsRejectsInvalidShape(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	p.conn = &scriptedConn{}
+	if err := p.requestMissingCompactTransactions(cmpctBlockPayload{}, [32]byte{0x51}, compactReconstructionResult{}); err == nil || !strings.Contains(err.Error(), "missing request mismatch") {
+		t.Fatalf("request missing invalid shape err=%v, want mismatch", err)
+	}
+}
+
+func TestRequestMissingCompactTransactionsRejectsTooManyIndexes(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	p.conn = &scriptedConn{}
+	missing := make([]uint64, maxCompactRelayEntries+1)
+	if err := p.requestMissingCompactTransactions(cmpctBlockPayload{}, [32]byte{0x52}, compactReconstructionResult{MissingIndexes: missing, MissingShortIDs: make([]compactShortID, len(missing))}); err == nil || !strings.Contains(err.Error(), "too many compact relay indexes") {
+		t.Fatalf("request missing too many indexes err=%v, want encode rejection", err)
+	}
+}
+
 func TestBlockTxnRejectsResponseOrderMismatch(t *testing.T) {
 	p := newPeerRuntimeTestPeer(t)
 	enableCompactRelayForTest(p)

--- a/clients/go/node/p2p/handlers_compact_test.go
+++ b/clients/go/node/p2p/handlers_compact_test.go
@@ -577,6 +577,41 @@ func TestBlockTxnLateAllowanceExpires(t *testing.T) {
 	assertCompactCommandCap(t, p.postHandshakePayloadCap(), messageBlockTxn, 0)
 }
 
+func TestCompactOutstandingClearsWhenBlockIsLearnedExternally(t *testing.T) {
+	source := newTestHarness(t, 3, "127.0.0.1:0", nil)
+	sink := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	hashA, bytesA := testHarnessBlockAtHeight(t, source, 1)
+	hashB, bytesB := testHarnessBlockAtHeight(t, source, 2)
+	blockA := compactTestPayloadFromBlock(t, bytesA, 61, 62)
+	blockB := compactTestPayloadFromBlock(t, bytesB, 63, 64)
+	p, conn := compactTestPeerWithConn(sink)
+
+	if err := p.handleMessage(message{Command: messageCmpctBlock, Payload: mustEncodeCmpctBlockPayload(t, blockA)}); err != nil {
+		t.Fatalf("handleMessage(cmpctblock A): %v", err)
+	}
+	reqA := mustReadCompactGetBlockTxn(t, p, conn)
+	if reqA.BlockHash != hashA {
+		t.Fatalf("request A hash=%x, want %x", reqA.BlockHash, hashA)
+	}
+	assertCompactCommandCapEnabled(t, p.postHandshakePayloadCap(), messageBlockTxn)
+	if _, err := sink.syncEngine.ApplyBlock(bytesA, nil); err != nil {
+		t.Fatalf("external ApplyBlock(A): %v", err)
+	}
+	assertHarnessTip(t, sink, 1, hashA)
+	assertCompactCommandCap(t, p.postHandshakePayloadCap(), messageBlockTxn, 0)
+	assertNoCompactOutstanding(t, p, "externally learned block")
+
+	conn.Buffer.Reset()
+	if err := p.handleMessage(message{Command: messageCmpctBlock, Payload: mustEncodeCmpctBlockPayload(t, blockB)}); err != nil {
+		t.Fatalf("handleMessage(cmpctblock B): %v", err)
+	}
+	reqB := mustReadCompactGetBlockTxn(t, p, conn)
+	if reqB.BlockHash != hashB {
+		t.Fatalf("request B hash=%x, want %x", reqB.BlockHash, hashB)
+	}
+	assertCompactOutstandingHash(t, p, hashB)
+}
+
 func TestBlockTxnRejectsResponseOrderMismatch(t *testing.T) {
 	p := newPeerRuntimeTestPeer(t)
 	enableCompactRelayForTest(p)

--- a/clients/go/node/p2p/handlers_compact_test.go
+++ b/clients/go/node/p2p/handlers_compact_test.go
@@ -253,6 +253,50 @@ func TestCompactReconstructedMissingParentRequestsFullBlockFallback(t *testing.T
 	}
 }
 
+func TestCompactRelayedBlockPropagatesLocalServiceErrors(t *testing.T) {
+	source := newTestHarness(t, 2, "127.0.0.1:0", nil)
+	blockHash, blockBytes := testHarnessBlockAtHeight(t, source, 1)
+	block := compactTestPayloadFromBlock(t, blockBytes, 41, 42)
+	_, txs, err := compactBlockTransactions(blockBytes)
+	if err != nil {
+		t.Fatalf("compactBlockTransactions: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name  string
+		setup func(*Service)
+		want  string
+	}{
+		{
+			name: "hasBlock error",
+			setup: func(s *Service) {
+				s.cfg.BlockStore = nil
+			},
+			want: "nil blockstore",
+		},
+		{
+			name: "sync engine error",
+			setup: func(s *Service) {
+				s.cfg.SyncEngine = nil
+			},
+			want: "sync engine is not initialized",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sink := newTestHarness(t, 1, "127.0.0.1:0", nil)
+			p, conn := compactTestPeerWithConn(sink)
+			tc.setup(p.service)
+			err := p.processCompactTransactions(blockHash, block.Header, txs)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("processCompactTransactions err=%v, want %q", err, tc.want)
+			}
+			if conn.Buffer.Len() != 0 {
+				t.Fatalf("local %s wrote %d fallback bytes, want none", tc.name, conn.Buffer.Len())
+			}
+		})
+	}
+}
+
 func TestCmpctBlockWithPendingRequestFallsBackNewBlockWithoutOverwrite(t *testing.T) {
 	source := newTestHarness(t, 3, "127.0.0.1:0", nil)
 	sink := newTestHarness(t, 1, "127.0.0.1:0", nil)
@@ -512,6 +556,20 @@ func TestGetBlockTxnRejectsDuplicateIndexesBeforeResponse(t *testing.T) {
 	}
 	if conn.Buffer.Len() != 0 {
 		t.Fatalf("duplicate getblocktxn wrote %d bytes, want no response", conn.Buffer.Len())
+	}
+}
+
+func TestGetBlockTxnRejectsRuntimeIndexCapBeforeResponse(t *testing.T) {
+	source := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	blockHash := [32]byte{0xef}
+	p, conn := compactTestPeerWithConn(source)
+
+	err := p.handleMessage(message{Command: messageGetBlockTxn, Payload: mustEncodeGetBlockTxnForHash(t, blockHash, []uint64{maxCompactRelayEntries})})
+	if err == nil || !strings.Contains(err.Error(), "compact relay index exceeds runtime cap") {
+		t.Fatalf("handleMessage(getblocktxn high index) err=%v, want runtime cap rejection", err)
+	}
+	if conn.Buffer.Len() != 0 {
+		t.Fatalf("high-index getblocktxn wrote %d bytes, want no response", conn.Buffer.Len())
 	}
 }
 

--- a/clients/go/node/p2p/handlers_compact_test.go
+++ b/clients/go/node/p2p/handlers_compact_test.go
@@ -76,6 +76,68 @@ func TestCmpctBlockUsesLocalTxPoolBeforeRequest(t *testing.T) {
 	}
 }
 
+func TestBlockTxnFlowPreservesLocalMatchesAcrossResponse(t *testing.T) {
+	_, sink, blockHash, blockBytes, localTx := compactTestMinedBlockWithSpend(t)
+	block := compactTestPayloadFromBlock(t, blockBytes, 23, 24)
+	_, txs, err := compactBlockTransactions(blockBytes)
+	if err != nil {
+		t.Fatalf("compactBlockTransactions: %v", err)
+	}
+	if !reflect.DeepEqual(txs[1], localTx) {
+		t.Fatalf("test setup tx[1] does not match local tx")
+	}
+	_, txid, _, consumed, err := consensus.ParseTx(localTx)
+	if err != nil || consumed != len(localTx) {
+		t.Fatalf("ParseTx(local): consumed=%d err=%v", consumed, err)
+	}
+	if !sink.service.cfg.TxPool.Put(txid, localTx, uint64(len(localTx)), len(localTx)) {
+		t.Fatalf("Put local compact tx failed")
+	}
+
+	p, conn := compactTestPeerWithConn(sink)
+	if err := p.handleMessage(message{Command: messageCmpctBlock, Payload: mustEncodeCmpctBlockPayload(t, block)}); err != nil {
+		t.Fatalf("handleMessage(cmpctblock): %v", err)
+	}
+	req := mustReadCompactGetBlockTxn(t, p, conn)
+	if !reflect.DeepEqual(req.Indexes, []uint64{0}) {
+		t.Fatalf("getblocktxn indexes=%v, want only missing coinbase index 0", req.Indexes)
+	}
+	outstanding, ok := p.compactOutstandingRequestSnapshot()
+	if !ok || outstanding.Transactions[0] != nil || !reflect.DeepEqual(outstanding.Transactions[1], localTx) {
+		t.Fatalf("outstanding partial txs=%+v ok=%v, want nil/local tx", outstanding.Transactions, ok)
+	}
+	if err := p.handleMessage(message{Command: messageBlockTxn, Payload: mustEncodeBlockTxnForHash(t, blockHash, txs[:1])}); err != nil {
+		t.Fatalf("handleMessage(blocktxn): %v", err)
+	}
+	assertHarnessTip(t, sink, 1, blockHash)
+}
+
+func TestCmpctBlockRejectsInvalidHeaderBeforeRequest(t *testing.T) {
+	source := newTestHarness(t, 2, "127.0.0.1:0", nil)
+	sink := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	_, blockBytes := testHarnessBlockAtHeight(t, source, 1)
+	block := compactTestPayloadFromBlock(t, blockBytes, 25, 26)
+	const targetOffset = 4 + 32 + 32 + 8
+	for i := range block.Header[targetOffset : targetOffset+32] {
+		block.Header[targetOffset+i] = 0
+	}
+
+	p, conn := compactTestPeerWithConn(sink)
+	err := p.handleMessage(message{Command: messageCmpctBlock, Payload: mustEncodeCmpctBlockPayload(t, block)})
+	if err == nil || !strings.Contains(err.Error(), "target out of range") {
+		t.Fatalf("handleMessage(cmpctblock invalid header) err=%v, want target rejection", err)
+	}
+	if conn.Buffer.Len() != 0 {
+		t.Fatalf("invalid compact header wrote %d bytes, want no request", conn.Buffer.Len())
+	}
+	if outstanding, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatalf("invalid compact header left outstanding: %+v", outstanding)
+	}
+	if p.snapshotState().BanScore == 0 {
+		t.Fatalf("invalid compact header did not bump ban score")
+	}
+}
+
 func TestBlockTxnRejectsUnsolicitedWrongHashAndCount(t *testing.T) {
 	source := newTestHarness(t, 2, "127.0.0.1:0", nil)
 	sink := newTestHarness(t, 1, "127.0.0.1:0", nil)
@@ -194,6 +256,32 @@ func TestGetBlockTxnRespondsWithRequestedTransactions(t *testing.T) {
 	}
 }
 
+func compactTestMinedBlockWithSpend(t *testing.T) (*testHarness, *testHarness, [32]byte, []byte, []byte) {
+	t.Helper()
+	source := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	sink := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	txBytes, _, utxos := signedCanonicalP2PTxWithoutSeeding(t, 326)
+	seedHarnessUtxos(source, utxos)
+	seedHarnessUtxos(sink, utxos)
+	mempool := wireCanonicalMempoolForP2PTest(t, source)
+	if err := mempool.AddTx(txBytes); err != nil {
+		t.Fatalf("AddTx(local spend): %v", err)
+	}
+	blockBytes := source.mineNextBlockBytes(t)
+	blockHash, err := consensus.BlockHash(blockBytes[:consensus.BLOCK_HEADER_BYTES])
+	if err != nil {
+		t.Fatalf("BlockHash: %v", err)
+	}
+	_, txs, err := compactBlockTransactions(blockBytes)
+	if err != nil {
+		t.Fatalf("compactBlockTransactions: %v", err)
+	}
+	if len(txs) != 2 {
+		t.Fatalf("mined tx count=%d, want coinbase + spend", len(txs))
+	}
+	return source, sink, blockHash, blockBytes, txBytes
+}
+
 func compactTestPayloadFromBlock(t *testing.T, blockBytes []byte, nonce1, nonce2 uint64) cmpctBlockPayload {
 	t.Helper()
 	header, txs, err := compactBlockTransactions(blockBytes)
@@ -225,6 +313,19 @@ func readCompactTestFrame(t *testing.T, p *peer, conn *scriptedConn) message {
 		t.Fatalf("readFrame: %v", err)
 	}
 	return frame
+}
+
+func mustReadCompactGetBlockTxn(t *testing.T, p *peer, conn *scriptedConn) getBlockTxnPayload {
+	t.Helper()
+	frame := readCompactTestFrame(t, p, conn)
+	if frame.Command != messageGetBlockTxn {
+		t.Fatalf("command=%q, want getblocktxn", frame.Command)
+	}
+	req, err := decodeGetBlockTxnPayload(frame.Payload)
+	if err != nil {
+		t.Fatalf("decodeGetBlockTxnPayload: %v", err)
+	}
+	return req
 }
 
 func mustEncodeCmpctBlockPayload(t *testing.T, block cmpctBlockPayload) []byte {

--- a/clients/go/node/p2p/handlers_compact_test.go
+++ b/clients/go/node/p2p/handlers_compact_test.go
@@ -104,31 +104,24 @@ func TestCompactRelayObjectCommandsRequireNegotiation(t *testing.T) {
 	p := newPeerRuntimeTestPeer(t)
 	p.conn = &scriptedConn{}
 	capFn := p.postHandshakePayloadCap()
-	if got := capFn(messageSendCmpct); got != sendCmpctPayloadBytes {
-		t.Fatalf("sendcmpct cap=%d, want %d", got, sendCmpctPayloadBytes)
-	}
+	assertCompactCommandCap(t, capFn, messageSendCmpct, sendCmpctPayloadBytes)
 	for _, command := range []string{messageCmpctBlock, messageGetBlockTxn, messageBlockTxn} {
-		if got := capFn(command); got != 0 {
-			t.Fatalf("non-negotiated %s cap=%d, want 0", command, got)
-		}
+		assertCompactCommandCap(t, capFn, command, 0)
 		err := p.handleMessage(message{Command: command, Payload: nil})
 		if err == nil || !strings.Contains(err.Error(), "compact relay not negotiated") {
 			t.Fatalf("handleMessage(%s) err=%v, want negotiation rejection", command, err)
 		}
 	}
-	if outstanding, ok := p.compactOutstandingRequestSnapshot(); ok {
-		t.Fatalf("non-negotiated compact command left outstanding: %+v", outstanding)
-	}
+	assertNoCompactOutstanding(t, p, "non-negotiated compact command")
 	p.setRemoteCompactMode(compactModeSnapshot{Mode: 2, Version: compactRelayVersion})
-	if got := capFn(messageCmpctBlock); got != 0 {
-		t.Fatalf("disabled compact object cap=%d, want 0 before local enable", got)
-	}
+	assertCompactCommandCap(t, capFn, messageCmpctBlock, 0)
 	enableCompactRelayForTest(p)
-	for _, command := range []string{messageCmpctBlock, messageGetBlockTxn, messageBlockTxn} {
-		if got := capFn(command); got == 0 {
-			t.Fatalf("negotiated %s cap=0, want enabled compact cap", command)
-		}
+	for _, command := range []string{messageCmpctBlock, messageGetBlockTxn} {
+		assertCompactCommandCapEnabled(t, capFn, command)
 	}
+	assertCompactCommandCap(t, capFn, messageBlockTxn, 0)
+	p.setCompactOutstandingRequest(compactOutstandingRequest{BlockHash: [32]byte{0x01}, MissingIndexes: []uint64{0}})
+	assertBoundedBlockTxnCap(t, p)
 }
 
 func TestCmpctBlockKnownBlockStillValidatesFullPayloadShape(t *testing.T) {
@@ -438,6 +431,9 @@ func TestBlockTxnIgnoresUnsolicitedWithoutOutstanding(t *testing.T) {
 	}
 
 	p, conn := compactTestPeerWithConn(sink)
+	if got := p.postHandshakePayloadCap()(messageBlockTxn); got != 0 {
+		t.Fatalf("unsolicited blocktxn cap=%d, want 0", got)
+	}
 	if err := p.handleMessage(message{Command: messageBlockTxn, Payload: mustEncodeBlockTxnForHash(t, blockHash, txs[:1])}); err != nil {
 		t.Fatalf("unsolicited blocktxn: %v", err)
 	}
@@ -496,10 +492,7 @@ func TestBlockTxnLateAfterExpiredOutstandingIsIgnored(t *testing.T) {
 	p.service.cfg.PeerRuntimeConfig.ReadDeadline = time.Second
 	hash := [32]byte{0xd1}
 	tx := minimalBlockTxnTestTxBytes(104)
-	shortID, err := compactTransactionShortID(tx, 45, 46)
-	if err != nil {
-		t.Fatalf("compactTransactionShortID: %v", err)
-	}
+	shortID := mustCompactTransactionShortID(t, tx, 45, 46)
 	p.setCompactOutstandingRequest(compactOutstandingRequest{
 		BlockHash:       hash,
 		MissingIndexes:  []uint64{0},
@@ -508,15 +501,19 @@ func TestBlockTxnLateAfterExpiredOutstandingIsIgnored(t *testing.T) {
 		Nonce1:          45,
 		Nonce2:          46,
 	})
+	activeCap := assertBoundedBlockTxnCap(t, p)
 
 	now = now.Add(time.Second)
+	if err := p.expireCompactOutstandingRequest(); err != nil {
+		t.Fatalf("expire compact outstanding: %v", err)
+	}
+	assertCompactFullBlockRequest(t, p, conn, hash)
+	assertNoCompactOutstanding(t, p, "expired compact request")
+	assertCompactCommandCap(t, p.postHandshakePayloadCap(), messageBlockTxn, activeCap)
 	if err := p.handleMessage(message{Command: messageBlockTxn, Payload: mustEncodeBlockTxnForHash(t, hash, [][]byte{tx})}); err != nil {
 		t.Fatalf("late blocktxn after fallback: %v", err)
 	}
-	assertCompactFullBlockRequest(t, p, conn, hash)
-	if outstanding, ok := p.compactOutstandingRequestSnapshot(); ok {
-		t.Fatalf("expired compact request still outstanding: %+v", outstanding)
-	}
+	assertCompactCommandCap(t, p.postHandshakePayloadCap(), messageBlockTxn, 0)
 }
 
 func TestBlockTxnRejectsResponseOrderMismatch(t *testing.T) {
@@ -785,6 +782,45 @@ func compactTestPeerWithConn(h *testHarness) (*peer, *scriptedConn) {
 func enableCompactRelayForTest(p *peer) {
 	p.service.cfg.CompactRelayObjectsEnabled = true
 	p.setRemoteCompactMode(compactModeSnapshot{Mode: 2, Version: compactRelayVersion})
+}
+
+func assertCompactCommandCap(t *testing.T, capFn payloadLimitFn, command string, want uint32) {
+	t.Helper()
+	if got := capFn(command); got != want {
+		t.Fatalf("%s cap=%d, want %d", command, got, want)
+	}
+}
+
+func assertCompactCommandCapEnabled(t *testing.T, capFn payloadLimitFn, command string) {
+	t.Helper()
+	if got := capFn(command); got == 0 {
+		t.Fatalf("%s cap=0, want enabled compact cap", command)
+	}
+}
+
+func assertBoundedBlockTxnCap(t *testing.T, p *peer) uint32 {
+	t.Helper()
+	got := p.postHandshakePayloadCap()(messageBlockTxn)
+	if got == 0 || got >= compactRelayPayloadCap(messageBlockTxn) {
+		t.Fatalf("blocktxn cap=%d, want bounded non-zero cap", got)
+	}
+	return got
+}
+
+func assertNoCompactOutstanding(t *testing.T, p *peer, context string) {
+	t.Helper()
+	if outstanding, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatalf("%s left outstanding: %+v", context, outstanding)
+	}
+}
+
+func mustCompactTransactionShortID(t *testing.T, tx []byte, nonce1, nonce2 uint64) compactShortID {
+	t.Helper()
+	shortID, err := compactTransactionShortID(tx, nonce1, nonce2)
+	if err != nil {
+		t.Fatalf("compactTransactionShortID: %v", err)
+	}
+	return shortID
 }
 
 func readCompactTestFrame(t *testing.T, p *peer, conn *scriptedConn) message {

--- a/clients/go/node/p2p/handlers_compact_test.go
+++ b/clients/go/node/p2p/handlers_compact_test.go
@@ -594,14 +594,14 @@ func TestGetBlockTxnRejectsDuplicateIndexesBeforeResponse(t *testing.T) {
 	}
 }
 
-func TestGetBlockTxnRejectsRuntimeIndexCapBeforeResponse(t *testing.T) {
+func TestGetBlockTxnRejectsOutOfRangeIndexBeforeResponse(t *testing.T) {
 	source := newTestHarness(t, 1, "127.0.0.1:0", nil)
-	blockHash := [32]byte{0xef}
+	blockHash, _ := testHarnessBlockAtHeight(t, source, 0)
 	p, conn := compactTestPeerWithConn(source)
 
 	err := p.handleMessage(message{Command: messageGetBlockTxn, Payload: mustEncodeGetBlockTxnForHash(t, blockHash, []uint64{maxCompactRelayEntries})})
-	if err == nil || !strings.Contains(err.Error(), "compact relay index exceeds runtime cap") {
-		t.Fatalf("handleMessage(getblocktxn high index) err=%v, want runtime cap rejection", err)
+	if err == nil || !strings.Contains(err.Error(), "compact relay index out of range") {
+		t.Fatalf("handleMessage(getblocktxn high index) err=%v, want out-of-range rejection", err)
 	}
 	if conn.Buffer.Len() != 0 {
 		t.Fatalf("high-index getblocktxn wrote %d bytes, want no response", conn.Buffer.Len())

--- a/clients/go/node/p2p/handlers_compact_test.go
+++ b/clients/go/node/p2p/handlers_compact_test.go
@@ -112,6 +112,29 @@ func TestBlockTxnFlowPreservesLocalMatchesAcrossResponse(t *testing.T) {
 	assertHarnessTip(t, sink, 1, blockHash)
 }
 
+func TestCmpctBlockWithPendingRequestFallsBackNewBlockWithoutOverwrite(t *testing.T) {
+	source := newTestHarness(t, 3, "127.0.0.1:0", nil)
+	sink := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	firstHash, firstBytes := testHarnessBlockAtHeight(t, source, 1)
+	secondHash, secondBytes := testHarnessBlockAtHeight(t, source, 2)
+	first := compactTestPayloadFromBlock(t, firstBytes, 25, 26)
+	second := compactTestPayloadFromBlock(t, secondBytes, 27, 28)
+
+	p, conn := compactTestPeerWithConn(sink)
+	if err := p.handleMessage(message{Command: messageCmpctBlock, Payload: mustEncodeCmpctBlockPayload(t, first)}); err != nil {
+		t.Fatalf("handleMessage(first cmpctblock): %v", err)
+	}
+	_ = mustReadCompactGetBlockTxn(t, p, conn)
+	if err := p.handleMessage(message{Command: messageCmpctBlock, Payload: mustEncodeCmpctBlockPayload(t, second)}); err != nil {
+		t.Fatalf("handleMessage(second cmpctblock): %v", err)
+	}
+	assertCompactFullBlockRequest(t, p, conn, secondHash)
+	outstanding, ok := p.compactOutstandingRequestSnapshot()
+	if !ok || outstanding.BlockHash != firstHash {
+		t.Fatalf("outstanding after second cmpctblock=%+v ok=%v, want first block %x", outstanding, ok, firstHash)
+	}
+}
+
 func TestCmpctBlockRejectsInvalidHeaderBeforeRequest(t *testing.T) {
 	source := newTestHarness(t, 2, "127.0.0.1:0", nil)
 	sink := newTestHarness(t, 1, "127.0.0.1:0", nil)
@@ -122,8 +145,9 @@ func TestCmpctBlockRejectsInvalidHeaderBeforeRequest(t *testing.T) {
 		block.Header[targetOffset+i] = 0
 	}
 
+	payload := append(mustEncodeCmpctBlockPayload(t, block), 0xff)
 	p, conn := compactTestPeerWithConn(sink)
-	err := p.handleMessage(message{Command: messageCmpctBlock, Payload: mustEncodeCmpctBlockPayload(t, block)})
+	err := p.handleMessage(message{Command: messageCmpctBlock, Payload: payload})
 	if err == nil || !strings.Contains(err.Error(), "target out of range") {
 		t.Fatalf("handleMessage(cmpctblock invalid header) err=%v, want target rejection", err)
 	}
@@ -161,7 +185,9 @@ func TestBlockTxnRejectsUnsolicitedWrongHashAndCount(t *testing.T) {
 	_ = mustReadCompactGetBlockTxn(t, p, conn)
 	wrongHash := blockHash
 	wrongHash[0] ^= 0xff
-	if err := p.handleMessage(message{Command: messageBlockTxn, Payload: mustEncodeBlockTxnForHash(t, wrongHash, txs[:1])}); err != nil {
+	malformedWrongHash := append([]byte(nil), wrongHash[:]...)
+	malformedWrongHash = append(malformedWrongHash, 0xff)
+	if err := p.handleMessage(message{Command: messageBlockTxn, Payload: malformedWrongHash}); err != nil {
 		t.Fatalf("wrong-hash blocktxn fallback: %v", err)
 	}
 	assertCompactFullBlockRequest(t, p, conn, blockHash)
@@ -256,9 +282,11 @@ func TestBlockTxnMalformedAndProcessFailureFallback(t *testing.T) {
 
 func TestCompactOutstandingRequestClearsOnReadTimeout(t *testing.T) {
 	p := newPeerRuntimeTestPeer(t)
-	p.conn = &scriptedConn{reads: []scriptedRead{{err: timeoutErr{}}, {err: io.EOF}}}
+	conn := &scriptedConn{reads: []scriptedRead{{err: timeoutErr{}}, {err: io.EOF}}}
+	p.conn = conn
+	hash := [32]byte{0xcd}
 	p.setCompactOutstandingRequest(compactOutstandingRequest{
-		BlockHash:       [32]byte{0xcd},
+		BlockHash:       hash,
 		MissingIndexes:  []uint64{0},
 		MissingShortIDs: []compactShortID{{0x01}},
 		Transactions:    make([][]byte, 1),
@@ -270,6 +298,7 @@ func TestCompactOutstandingRequestClearsOnReadTimeout(t *testing.T) {
 	if outstanding, ok := p.compactOutstandingRequestSnapshot(); ok {
 		t.Fatalf("read timeout did not clear outstanding request: %+v", outstanding)
 	}
+	assertCompactFullBlockRequest(t, p, conn, hash)
 }
 
 func TestGetBlockTxnRespondsWithRequestedTransactions(t *testing.T) {
@@ -298,8 +327,8 @@ func TestGetBlockTxnRespondsWithRequestedTransactions(t *testing.T) {
 }
 
 func TestGetBlockTxnRejectsDuplicateIndexesBeforeResponse(t *testing.T) {
-	source := newTestHarness(t, 2, "127.0.0.1:0", nil)
-	blockHash, _ := testHarnessBlockAtHeight(t, source, 1)
+	source := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	blockHash := [32]byte{0xee}
 	p, conn := compactTestPeerWithConn(source)
 
 	err := p.handleMessage(message{Command: messageGetBlockTxn, Payload: mustEncodeGetBlockTxnForHash(t, blockHash, []uint64{0, 0})})

--- a/clients/go/node/p2p/handlers_compact_test.go
+++ b/clients/go/node/p2p/handlers_compact_test.go
@@ -68,11 +68,31 @@ func TestCompactRelayObjectCommandsRequireNegotiation(t *testing.T) {
 	if outstanding, ok := p.compactOutstandingRequestSnapshot(); ok {
 		t.Fatalf("non-negotiated compact command left outstanding: %+v", outstanding)
 	}
+	p.setRemoteCompactMode(compactModeSnapshot{Mode: 2, Version: compactRelayVersion})
+	if got := capFn(messageCmpctBlock); got != 0 {
+		t.Fatalf("disabled compact object cap=%d, want 0 before local enable", got)
+	}
 	enableCompactRelayForTest(p)
 	for _, command := range []string{messageCmpctBlock, messageGetBlockTxn, messageBlockTxn} {
 		if got := capFn(command); got == 0 {
 			t.Fatalf("negotiated %s cap=0, want enabled compact cap", command)
 		}
+	}
+}
+
+func TestCmpctBlockKnownBlockStillValidatesFullPayloadShape(t *testing.T) {
+	h := newTestHarness(t, 2, "127.0.0.1:0", nil)
+	_, blockBytes := testHarnessBlockAtHeight(t, h, 1)
+	block := compactTestPayloadFromBlock(t, blockBytes, 13, 14)
+	payload := append(mustEncodeCmpctBlockPayload(t, block), 0xff)
+
+	p, conn := compactTestPeerWithConn(h)
+	err := p.handleMessage(message{Command: messageCmpctBlock, Payload: payload})
+	if err == nil || !strings.Contains(err.Error(), "cmpctblock payload has trailing bytes") {
+		t.Fatalf("known-block malformed cmpctblock err=%v, want full payload validation", err)
+	}
+	if conn.Buffer.Len() != 0 {
+		t.Fatalf("known-block malformed cmpctblock wrote %d bytes, want none", conn.Buffer.Len())
 	}
 }
 
@@ -473,6 +493,7 @@ func compactTestPeerWithConn(h *testHarness) (*peer, *scriptedConn) {
 }
 
 func enableCompactRelayForTest(p *peer) {
+	p.service.cfg.CompactRelayObjectsEnabled = true
 	p.setRemoteCompactMode(compactModeSnapshot{Mode: 2, Version: compactRelayVersion})
 }
 

--- a/clients/go/node/p2p/handlers_compact_test.go
+++ b/clients/go/node/p2p/handlers_compact_test.go
@@ -49,6 +49,20 @@ func TestCompactBlockTxnFlowRequestsAndAcceptsMatchingResponse(t *testing.T) {
 	}
 }
 
+func TestCompactRelayObjectCommandsRequireNegotiation(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	p.conn = &scriptedConn{}
+	for _, command := range []string{messageCmpctBlock, messageGetBlockTxn, messageBlockTxn} {
+		err := p.handleMessage(message{Command: command, Payload: nil})
+		if err == nil || !strings.Contains(err.Error(), "compact relay not negotiated") {
+			t.Fatalf("handleMessage(%s) err=%v, want negotiation rejection", command, err)
+		}
+	}
+	if outstanding, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatalf("non-negotiated compact command left outstanding: %+v", outstanding)
+	}
+}
+
 func TestCmpctBlockUsesLocalTxPoolBeforeRequest(t *testing.T) {
 	source := newTestHarness(t, 2, "127.0.0.1:0", nil)
 	sink := newTestHarness(t, 1, "127.0.0.1:0", nil)
@@ -213,6 +227,7 @@ func TestBlockTxnRejectsUnsolicitedWrongHashAndCount(t *testing.T) {
 
 func TestBlockTxnRejectsResponseOrderMismatch(t *testing.T) {
 	p := newPeerRuntimeTestPeer(t)
+	enableCompactRelayForTest(p)
 	conn := &scriptedConn{}
 	p.conn = conn
 	txA := minimalBlockTxnTestTxBytes(101)
@@ -249,6 +264,7 @@ func TestBlockTxnRejectsResponseOrderMismatch(t *testing.T) {
 func TestBlockTxnMalformedAndProcessFailureFallback(t *testing.T) {
 	hash := [32]byte{0xbe}
 	p := newPeerRuntimeTestPeer(t)
+	enableCompactRelayForTest(p)
 	conn := &scriptedConn{}
 	p.conn = conn
 	p.setCompactOutstandingRequest(compactOutstandingRequest{BlockHash: hash})
@@ -258,6 +274,7 @@ func TestBlockTxnMalformedAndProcessFailureFallback(t *testing.T) {
 	assertCompactFullBlockRequest(t, p, conn, hash)
 
 	p = newPeerRuntimeTestPeer(t)
+	enableCompactRelayForTest(p)
 	conn = &scriptedConn{}
 	p.conn = conn
 	tx := minimalBlockTxnTestTxBytes(103)
@@ -405,7 +422,12 @@ func compactTestPeerWithConn(h *testHarness) (*peer, *scriptedConn) {
 	conn := &scriptedConn{}
 	p := testPeerForService(h.service, "rubin-go/test-peer", 1)
 	p.conn = conn
+	enableCompactRelayForTest(p)
 	return p, conn
+}
+
+func enableCompactRelayForTest(p *peer) {
+	p.setRemoteCompactMode(compactModeSnapshot{Mode: 2, Version: compactRelayVersion})
 }
 
 func readCompactTestFrame(t *testing.T, p *peer, conn *scriptedConn) message {

--- a/clients/go/node/p2p/handlers_compact_test.go
+++ b/clients/go/node/p2p/handlers_compact_test.go
@@ -2,6 +2,7 @@ package p2p
 
 import (
 	"context"
+	"encoding/binary"
 	"io"
 	"reflect"
 	"strings"
@@ -382,6 +383,51 @@ func TestCmpctBlockRejectsInvalidHeaderBeforeRequest(t *testing.T) {
 	}
 }
 
+func TestCmpctBlockRejectsWrongTargetBeforeMissingRequest(t *testing.T) {
+	source := newTestHarness(t, 2, "127.0.0.1:0", nil)
+	sink := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	_, blockBytes := testHarnessBlockAtHeight(t, source, 1)
+	block := compactTestPayloadWithWrongHeaderTarget(t, compactTestPayloadFromBlock(t, blockBytes, 57, 58))
+
+	p, conn := compactTestPeerWithConn(sink)
+	err := p.handleMessage(message{Command: messageCmpctBlock, Payload: mustEncodeCmpctBlockPayload(t, block)})
+	if err == nil || !strings.Contains(err.Error(), string(consensus.BLOCK_ERR_TARGET_INVALID)) {
+		t.Fatalf("handleMessage(cmpctblock wrong target) err=%v, want target rejection", err)
+	}
+	if conn.Buffer.Len() != 0 {
+		t.Fatalf("wrong-target compact header wrote %d bytes, want no getblocktxn request", conn.Buffer.Len())
+	}
+	if outstanding, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatalf("wrong-target compact header left outstanding: %+v", outstanding)
+	}
+	if state := p.snapshotState(); state.BanScore < 100 {
+		t.Fatalf("ban_score=%d, want >= 100 for wrong compact target", state.BanScore)
+	}
+}
+
+func TestCmpctBlockRejectsWrongTargetBeforeOversizedFallback(t *testing.T) {
+	source := newTestHarness(t, 2, "127.0.0.1:0", nil)
+	sink := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	_, blockBytes := testHarnessBlockAtHeight(t, source, 1)
+	block := compactTestPayloadWithWrongHeaderTarget(t, compactTestPayloadFromBlock(t, blockBytes, 59, 60))
+	block.ShortIDs = make([]compactShortID, maxCompactRelayEntries+1)
+
+	p, conn := compactTestPeerWithConn(sink)
+	err := p.handleMessage(message{Command: messageCmpctBlock, Payload: mustEncodeCmpctBlockPayload(t, block)})
+	if err == nil || !strings.Contains(err.Error(), string(consensus.BLOCK_ERR_TARGET_INVALID)) {
+		t.Fatalf("handleMessage(oversized cmpctblock wrong target) err=%v, want target rejection", err)
+	}
+	if conn.Buffer.Len() != 0 {
+		t.Fatalf("wrong-target oversized compact block wrote %d bytes, want no fallback request", conn.Buffer.Len())
+	}
+	if outstanding, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatalf("wrong-target oversized compact block left outstanding: %+v", outstanding)
+	}
+	if state := p.snapshotState(); state.BanScore < 100 {
+		t.Fatalf("ban_score=%d, want >= 100 for wrong compact target", state.BanScore)
+	}
+}
+
 func TestBlockTxnRejectsUnsolicitedWrongHashAndCount(t *testing.T) {
 	source := newTestHarness(t, 2, "127.0.0.1:0", nil)
 	sink := newTestHarness(t, 1, "127.0.0.1:0", nil)
@@ -667,6 +713,23 @@ func compactTestPayloadFromBlock(t *testing.T, blockBytes []byte, nonce1, nonce2
 		shortIDs = append(shortIDs, shortID)
 	}
 	return cmpctBlockPayload{Header: header, Nonce1: nonce1, Nonce2: nonce2, ShortIDs: shortIDs}
+}
+
+func compactTestPayloadWithWrongHeaderTarget(t *testing.T, block cmpctBlockPayload) cmpctBlockPayload {
+	t.Helper()
+	const targetOffset = 4 + 32 + 32 + 8
+	const nonceOffset = targetOffset + 32
+	target := consensus.POW_LIMIT
+	target[0] = 0xfe
+	copy(block.Header[targetOffset:nonceOffset], target[:])
+	for nonce := uint64(0); nonce < 1_000_000; nonce++ {
+		binary.LittleEndian.PutUint64(block.Header[nonceOffset:], nonce)
+		if err := consensus.PowCheck(block.Header[:], target); err == nil {
+			return block
+		}
+	}
+	t.Fatal("failed to mine wrong-target compact test header")
+	return cmpctBlockPayload{}
 }
 
 func compactTestPeerWithConn(h *testHarness) (*peer, *scriptedConn) {

--- a/clients/go/node/p2p/handlers_compact_test.go
+++ b/clients/go/node/p2p/handlers_compact_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
 )
@@ -93,6 +94,23 @@ func TestCmpctBlockKnownBlockStillValidatesFullPayloadShape(t *testing.T) {
 	}
 	if conn.Buffer.Len() != 0 {
 		t.Fatalf("known-block malformed cmpctblock wrote %d bytes, want none", conn.Buffer.Len())
+	}
+}
+
+func TestCmpctBlockOversizedEntriesFallbackBeforeFullDecode(t *testing.T) {
+	source := newTestHarness(t, 2, "127.0.0.1:0", nil)
+	sink := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	blockHash, blockBytes := testHarnessBlockAtHeight(t, source, 1)
+	block := compactTestPayloadFromBlock(t, blockBytes, 15, 16)
+	block.ShortIDs = make([]compactShortID, maxCompactRelayEntries+1)
+
+	p, conn := compactTestPeerWithConn(sink)
+	if err := p.handleMessage(message{Command: messageCmpctBlock, Payload: mustEncodeCmpctBlockPayload(t, block)}); err != nil {
+		t.Fatalf("handleMessage(oversized cmpctblock): %v", err)
+	}
+	assertCompactFullBlockRequest(t, p, conn, blockHash)
+	if outstanding, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatalf("oversized cmpctblock left outstanding: %+v", outstanding)
 	}
 }
 
@@ -382,6 +400,31 @@ func TestCompactOutstandingRequestClearsOnReadTimeout(t *testing.T) {
 		t.Fatalf("read timeout did not clear outstanding request: %+v", outstanding)
 	}
 	assertCompactFullBlockRequest(t, p, conn, hash)
+}
+
+func TestCompactOutstandingRequestExpiresBeforeUnrelatedFrame(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	conn := &scriptedConn{}
+	p.conn = conn
+	now := time.Unix(1_777_000_000, 0)
+	p.service.cfg.Now = func() time.Time { return now }
+	p.service.cfg.PeerRuntimeConfig.ReadDeadline = time.Second
+	hash := [32]byte{0xce}
+	p.setCompactOutstandingRequest(compactOutstandingRequest{
+		BlockHash:       hash,
+		MissingIndexes:  []uint64{0},
+		MissingShortIDs: []compactShortID{{0x02}},
+		Transactions:    make([][]byte, 1),
+	})
+
+	now = now.Add(time.Second)
+	if err := p.handleMessage(message{Command: messagePing}); err != nil {
+		t.Fatalf("handleMessage(ping after compact expiry): %v", err)
+	}
+	assertCompactFullBlockRequest(t, p, conn, hash)
+	if outstanding, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatalf("expired compact request still outstanding: %+v", outstanding)
+	}
 }
 
 func TestGetBlockTxnRespondsWithRequestedTransactions(t *testing.T) {

--- a/clients/go/node/p2p/handlers_compact_test.go
+++ b/clients/go/node/p2p/handlers_compact_test.go
@@ -157,6 +157,27 @@ func TestCmpctBlockOversizedEntriesFallbackBeforeFullDecode(t *testing.T) {
 	}
 }
 
+func TestCmpctBlockOversizedMalformedPrefixRejectsBeforeFallback(t *testing.T) {
+	source := newTestHarness(t, 2, "127.0.0.1:0", nil)
+	sink := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	_, blockBytes := testHarnessBlockAtHeight(t, source, 1)
+	block := compactTestPayloadFromBlock(t, blockBytes, 15, 16)
+	payload := append([]byte{}, block.Header[:]...)
+	payload = consensus.AppendU64le(payload, block.Nonce1)
+	payload = consensus.AppendU64le(payload, block.Nonce2)
+	payload = consensus.AppendCompactSize(payload, 0)
+	payload = consensus.AppendCompactSize(payload, maxCompactRelayEntries+1)
+
+	p, conn := compactTestPeerWithConn(sink)
+	err := p.handleMessage(message{Command: messageCmpctBlock, Payload: payload})
+	if err == nil || !strings.Contains(err.Error(), "cmpctblock payload truncated prefilled index") {
+		t.Fatalf("handleMessage(malformed oversized cmpctblock) err=%v, want truncated prefilled rejection", err)
+	}
+	if conn.Buffer.Len() != 0 {
+		t.Fatalf("malformed oversized cmpctblock wrote %d bytes, want no fallback request", conn.Buffer.Len())
+	}
+}
+
 func TestCmpctBlockUsesLocalTxPoolBeforeRequest(t *testing.T) {
 	source := newTestHarness(t, 2, "127.0.0.1:0", nil)
 	sink := newTestHarness(t, 1, "127.0.0.1:0", nil)
@@ -574,6 +595,38 @@ func TestBlockTxnLateAllowanceExpires(t *testing.T) {
 	assertCompactFullBlockRequest(t, p, conn, hash)
 	assertCompactCommandCap(t, p.postHandshakePayloadCap(), messageBlockTxn, activeCap)
 	now = now.Add(time.Second)
+	assertCompactCommandCap(t, p.postHandshakePayloadCap(), messageBlockTxn, 0)
+}
+
+func TestBlockTxnLateAllowanceConsumesWrongHash(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	enableCompactRelayForTest(p)
+	conn := &scriptedConn{}
+	p.conn = conn
+	now := time.Unix(1_777_000_350, 0)
+	p.service.cfg.Now = func() time.Time { return now }
+	p.service.cfg.PeerRuntimeConfig.ReadDeadline = time.Second
+	hash := [32]byte{0xd3}
+	tx := minimalBlockTxnTestTxBytes(106)
+	shortID := mustCompactTransactionShortID(t, tx, 49, 50)
+	p.setCompactOutstandingRequest(compactOutstandingRequest{
+		BlockHash:       hash,
+		MissingIndexes:  []uint64{0},
+		MissingShortIDs: []compactShortID{shortID},
+		Transactions:    make([][]byte, 1),
+		Nonce1:          49,
+		Nonce2:          50,
+	})
+
+	now = now.Add(time.Second)
+	if err := p.expireCompactOutstandingRequest(); err != nil {
+		t.Fatalf("expire compact outstanding: %v", err)
+	}
+	assertCompactFullBlockRequest(t, p, conn, hash)
+	assertCompactCommandCapEnabled(t, p.postHandshakePayloadCap(), messageBlockTxn)
+	if err := p.handleMessage(message{Command: messageBlockTxn, Payload: mustEncodeBlockTxnForHash(t, [32]byte{0xee}, [][]byte{tx})}); err != nil {
+		t.Fatalf("wrong-hash late blocktxn: %v", err)
+	}
 	assertCompactCommandCap(t, p.postHandshakePayloadCap(), messageBlockTxn, 0)
 }
 

--- a/clients/go/node/p2p/handlers_compact_test.go
+++ b/clients/go/node/p2p/handlers_compact_test.go
@@ -516,6 +516,67 @@ func TestBlockTxnLateAfterExpiredOutstandingIsIgnored(t *testing.T) {
 	assertCompactCommandCap(t, p.postHandshakePayloadCap(), messageBlockTxn, 0)
 }
 
+func TestBlockTxnLateAllowanceSurvivesNextOutstanding(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	enableCompactRelayForTest(p)
+	conn := &scriptedConn{}
+	p.conn = conn
+	now := time.Unix(1_777_000_200, 0)
+	p.service.cfg.Now = func() time.Time { return now }
+	p.service.cfg.PeerRuntimeConfig.ReadDeadline = time.Second
+	hashA := [32]byte{0xa1}
+	hashB := [32]byte{0xb2}
+	txA := minimalBlockTxnTestTxBytes(105)
+	shortA := mustCompactTransactionShortID(t, txA, 47, 48)
+	p.setCompactOutstandingRequest(compactOutstandingRequest{
+		BlockHash:       hashA,
+		MissingIndexes:  []uint64{0, 1},
+		MissingShortIDs: []compactShortID{shortA, compactShortID{0x02}},
+		Transactions:    make([][]byte, 2),
+		Nonce1:          47,
+		Nonce2:          48,
+	})
+	lateCap := assertBoundedBlockTxnCap(t, p)
+
+	now = now.Add(time.Second)
+	if err := p.expireCompactOutstandingRequest(); err != nil {
+		t.Fatalf("expire compact outstanding A: %v", err)
+	}
+	assertCompactFullBlockRequest(t, p, conn, hashA)
+	p.setCompactOutstandingRequest(compactOutstandingRequest{BlockHash: hashB, MissingIndexes: []uint64{0}})
+	assertCompactCommandCap(t, p.postHandshakePayloadCap(), messageBlockTxn, lateCap)
+	if err := p.handleMessage(message{Command: messageBlockTxn, Payload: mustEncodeBlockTxnForHash(t, hashA, [][]byte{txA})}); err != nil {
+		t.Fatalf("late blocktxn A while B outstanding: %v", err)
+	}
+	assertCompactCommandCap(t, p.postHandshakePayloadCap(), messageBlockTxn, compactBlockTxnResponsePayloadCap(1))
+	assertCompactOutstandingHash(t, p, hashB)
+	if conn.Buffer.Len() != 0 {
+		t.Fatalf("late blocktxn A wrote %d bytes, want no fallback for B", conn.Buffer.Len())
+	}
+}
+
+func TestBlockTxnLateAllowanceExpires(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	enableCompactRelayForTest(p)
+	conn := &scriptedConn{}
+	p.conn = conn
+	now := time.Unix(1_777_000_300, 0)
+	p.service.cfg.Now = func() time.Time { return now }
+	p.service.cfg.PeerRuntimeConfig.ReadDeadline = time.Second
+	hash := [32]byte{0xd2}
+	p.setCompactOutstandingRequest(compactOutstandingRequest{BlockHash: hash, MissingIndexes: []uint64{0}})
+	activeCap := assertBoundedBlockTxnCap(t, p)
+
+	now = now.Add(time.Second)
+	if err := p.expireCompactOutstandingRequest(); err != nil {
+		t.Fatalf("expire compact outstanding: %v", err)
+	}
+	assertCompactFullBlockRequest(t, p, conn, hash)
+	assertCompactCommandCap(t, p.postHandshakePayloadCap(), messageBlockTxn, activeCap)
+	now = now.Add(time.Second)
+	assertCompactCommandCap(t, p.postHandshakePayloadCap(), messageBlockTxn, 0)
+}
+
 func TestBlockTxnRejectsResponseOrderMismatch(t *testing.T) {
 	p := newPeerRuntimeTestPeer(t)
 	enableCompactRelayForTest(p)
@@ -811,6 +872,14 @@ func assertNoCompactOutstanding(t *testing.T, p *peer, context string) {
 	t.Helper()
 	if outstanding, ok := p.compactOutstandingRequestSnapshot(); ok {
 		t.Fatalf("%s left outstanding: %+v", context, outstanding)
+	}
+}
+
+func assertCompactOutstandingHash(t *testing.T, p *peer, want [32]byte) {
+	t.Helper()
+	outstanding, ok := p.compactOutstandingRequestSnapshot()
+	if !ok || outstanding.BlockHash != want {
+		t.Fatalf("outstanding=%+v ok=%v, want block %x", outstanding, ok, want)
 	}
 }
 

--- a/clients/go/node/p2p/handlers_compact_test.go
+++ b/clients/go/node/p2p/handlers_compact_test.go
@@ -154,27 +154,31 @@ func TestBlockTxnRejectsUnsolicitedWrongHashAndCount(t *testing.T) {
 	}
 	assertHarnessTip(t, sink, 0, nodeGenesisHash(t, sink))
 
-	p, _ = compactTestPeerWithConn(sink)
+	p, conn := compactTestPeerWithConn(sink)
 	if err := p.handleMessage(message{Command: messageCmpctBlock, Payload: mustEncodeCmpctBlockPayload(t, block)}); err != nil {
 		t.Fatalf("handleMessage(cmpctblock): %v", err)
 	}
+	_ = mustReadCompactGetBlockTxn(t, p, conn)
 	wrongHash := blockHash
 	wrongHash[0] ^= 0xff
-	if err := p.handleMessage(message{Command: messageBlockTxn, Payload: mustEncodeBlockTxnForHash(t, wrongHash, txs[:1])}); err == nil || !strings.Contains(err.Error(), "unexpected blocktxn response") {
-		t.Fatalf("wrong-hash blocktxn err=%v, want unexpected response", err)
+	if err := p.handleMessage(message{Command: messageBlockTxn, Payload: mustEncodeBlockTxnForHash(t, wrongHash, txs[:1])}); err != nil {
+		t.Fatalf("wrong-hash blocktxn fallback: %v", err)
 	}
+	assertCompactFullBlockRequest(t, p, conn, blockHash)
 	if outstanding, ok := p.compactOutstandingRequestSnapshot(); ok {
 		t.Fatalf("wrong-hash blocktxn did not clear outstanding: %+v", outstanding)
 	}
 	assertHarnessTip(t, sink, 0, nodeGenesisHash(t, sink))
 
-	p, _ = compactTestPeerWithConn(sink)
+	p, conn = compactTestPeerWithConn(sink)
 	if err := p.handleMessage(message{Command: messageCmpctBlock, Payload: mustEncodeCmpctBlockPayload(t, block)}); err != nil {
 		t.Fatalf("handleMessage(cmpctblock): %v", err)
 	}
-	if err := p.handleMessage(message{Command: messageBlockTxn, Payload: mustEncodeBlockTxnForHash(t, blockHash, nil)}); err == nil || !strings.Contains(err.Error(), "blocktxn transaction count mismatch") {
-		t.Fatalf("count-mismatch blocktxn err=%v, want count mismatch", err)
+	_ = mustReadCompactGetBlockTxn(t, p, conn)
+	if err := p.handleMessage(message{Command: messageBlockTxn, Payload: mustEncodeBlockTxnForHash(t, blockHash, nil)}); err != nil {
+		t.Fatalf("count-mismatch blocktxn fallback: %v", err)
 	}
+	assertCompactFullBlockRequest(t, p, conn, blockHash)
 	if outstanding, ok := p.compactOutstandingRequestSnapshot(); ok {
 		t.Fatalf("count-mismatch blocktxn did not clear outstanding: %+v", outstanding)
 	}
@@ -183,6 +187,8 @@ func TestBlockTxnRejectsUnsolicitedWrongHashAndCount(t *testing.T) {
 
 func TestBlockTxnRejectsResponseOrderMismatch(t *testing.T) {
 	p := newPeerRuntimeTestPeer(t)
+	conn := &scriptedConn{}
+	p.conn = conn
 	txA := minimalBlockTxnTestTxBytes(101)
 	txB := minimalBlockTxnTestTxBytes(102)
 	nonce1, nonce2 := uint64(41), uint64(42)
@@ -205,12 +211,47 @@ func TestBlockTxnRejectsResponseOrderMismatch(t *testing.T) {
 	})
 
 	err = p.handleMessage(message{Command: messageBlockTxn, Payload: mustEncodeBlockTxnForHash(t, hash, [][]byte{txB, txA})})
-	if err == nil || !strings.Contains(err.Error(), "blocktxn transaction short id mismatch") {
-		t.Fatalf("order-mismatch blocktxn err=%v, want short id mismatch", err)
+	if err != nil {
+		t.Fatalf("order-mismatch blocktxn fallback: %v", err)
 	}
+	assertCompactFullBlockRequest(t, p, conn, hash)
 	if outstanding, ok := p.compactOutstandingRequestSnapshot(); ok {
 		t.Fatalf("order-mismatch blocktxn did not clear outstanding: %+v", outstanding)
 	}
+}
+
+func TestBlockTxnMalformedAndProcessFailureFallback(t *testing.T) {
+	hash := [32]byte{0xbe}
+	p := newPeerRuntimeTestPeer(t)
+	conn := &scriptedConn{}
+	p.conn = conn
+	p.setCompactOutstandingRequest(compactOutstandingRequest{BlockHash: hash})
+	if err := p.handleMessage(message{Command: messageBlockTxn, Payload: []byte{0x01}}); err != nil {
+		t.Fatalf("malformed blocktxn fallback: %v", err)
+	}
+	assertCompactFullBlockRequest(t, p, conn, hash)
+
+	p = newPeerRuntimeTestPeer(t)
+	conn = &scriptedConn{}
+	p.conn = conn
+	tx := minimalBlockTxnTestTxBytes(103)
+	nonce1, nonce2 := uint64(43), uint64(44)
+	shortID, err := compactTransactionShortID(tx, nonce1, nonce2)
+	if err != nil {
+		t.Fatalf("compactTransactionShortID: %v", err)
+	}
+	p.setCompactOutstandingRequest(compactOutstandingRequest{
+		BlockHash:       hash,
+		MissingIndexes:  []uint64{0},
+		MissingShortIDs: []compactShortID{shortID},
+		Transactions:    make([][]byte, 1),
+		Nonce1:          nonce1,
+		Nonce2:          nonce2,
+	})
+	if err := p.handleMessage(message{Command: messageBlockTxn, Payload: mustEncodeBlockTxnForHash(t, hash, [][]byte{tx})}); err != nil {
+		t.Fatalf("process-failure blocktxn fallback: %v", err)
+	}
+	assertCompactFullBlockRequest(t, p, conn, hash)
 }
 
 func TestCompactOutstandingRequestClearsOnReadTimeout(t *testing.T) {
@@ -270,10 +311,10 @@ func TestGetBlockTxnRejectsDuplicateIndexesBeforeResponse(t *testing.T) {
 	}
 }
 
-func TestCmpctBlockMissingAboveRequestCapDefersFallbackWithoutRequest(t *testing.T) {
+func TestCmpctBlockMissingAboveRequestCapRequestsFullBlockFallback(t *testing.T) {
 	source := newTestHarness(t, 2, "127.0.0.1:0", nil)
 	sink := newTestHarness(t, 1, "127.0.0.1:0", nil)
-	_, blockBytes := testHarnessBlockAtHeight(t, source, 1)
+	blockHash, blockBytes := testHarnessBlockAtHeight(t, source, 1)
 	block := compactTestPayloadFromBlock(t, blockBytes, 51, 52)
 	block.ShortIDs = make([]compactShortID, maxCompactRelayEntries+1)
 
@@ -281,9 +322,7 @@ func TestCmpctBlockMissingAboveRequestCapDefersFallbackWithoutRequest(t *testing
 	if err := p.handleMessage(message{Command: messageCmpctBlock, Payload: mustEncodeCmpctBlockPayload(t, block)}); err != nil {
 		t.Fatalf("handleMessage(cmpctblock many missing): %v", err)
 	}
-	if conn.Buffer.Len() != 0 {
-		t.Fatalf("many-missing cmpctblock wrote %d bytes, want no getblocktxn in RUB-326", conn.Buffer.Len())
-	}
+	assertCompactFullBlockRequest(t, p, conn, blockHash)
 	if outstanding, ok := p.compactOutstandingRequestSnapshot(); ok {
 		t.Fatalf("many-missing cmpctblock left outstanding: %+v", outstanding)
 	}
@@ -360,6 +399,22 @@ func mustReadCompactGetBlockTxn(t *testing.T, p *peer, conn *scriptedConn) getBl
 		t.Fatalf("decodeGetBlockTxnPayload: %v", err)
 	}
 	return req
+}
+
+func assertCompactFullBlockRequest(t *testing.T, p *peer, conn *scriptedConn, blockHash [32]byte) {
+	t.Helper()
+	frame := readCompactTestFrame(t, p, conn)
+	if frame.Command != messageGetData {
+		t.Fatalf("command=%q, want getdata full-block fallback", frame.Command)
+	}
+	items, err := decodeInventoryVectors(frame.Payload)
+	if err != nil {
+		t.Fatalf("decodeInventoryVectors: %v", err)
+	}
+	want := []InventoryVector{{Type: MSG_BLOCK, Hash: blockHash}}
+	if !reflect.DeepEqual(items, want) {
+		t.Fatalf("fallback inventory=%+v, want %+v", items, want)
+	}
 }
 
 func mustEncodeCmpctBlockPayload(t *testing.T, block cmpctBlockPayload) []byte {

--- a/clients/go/node/p2p/handlers_compact_test.go
+++ b/clients/go/node/p2p/handlers_compact_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/node"
 )
 
 func TestCompactBlockTxnFlowRequestsAndAcceptsMatchingResponse(t *testing.T) {
@@ -294,6 +295,40 @@ func TestCompactRelayedBlockPropagatesLocalServiceErrors(t *testing.T) {
 				t.Fatalf("local %s wrote %d fallback bytes, want none", tc.name, conn.Buffer.Len())
 			}
 		})
+	}
+}
+
+func TestCompactRelayedBlockRecordsHeaderContextConsensusErrors(t *testing.T) {
+	source := newTestHarness(t, 2, "127.0.0.1:0", nil)
+	sink := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	blockHash, blockBytes := testHarnessBlockAtHeight(t, source, 1)
+	block := compactTestPayloadFromBlock(t, blockBytes, 43, 44)
+	_, txs, err := compactBlockTransactions(blockBytes)
+	if err != nil {
+		t.Fatalf("compactBlockTransactions: %v", err)
+	}
+	wrongTarget := consensus.POW_LIMIT
+	wrongTarget[0] = 0x7f
+	syncEngine, err := node.NewSyncEngine(
+		sink.chainState,
+		sink.blockStore,
+		node.DefaultSyncConfig(&wrongTarget, node.DevnetGenesisChainID(), node.ChainStatePath(t.TempDir())),
+	)
+	if err != nil {
+		t.Fatalf("NewSyncEngine(wrong target): %v", err)
+	}
+	sink.service.cfg.SyncEngine = syncEngine
+
+	p, conn := compactTestPeerWithConn(sink)
+	err = p.processCompactTransactions(blockHash, block.Header, txs)
+	if err == nil || !strings.Contains(err.Error(), string(consensus.BLOCK_ERR_TARGET_INVALID)) {
+		t.Fatalf("processCompactTransactions err=%v, want target invalid", err)
+	}
+	if conn.Buffer.Len() != 0 {
+		t.Fatalf("target-invalid compact block wrote %d fallback bytes, want none", conn.Buffer.Len())
+	}
+	if state := p.snapshotState(); state.BanScore < 100 {
+		t.Fatalf("ban_score=%d, want >= 100 for header-context consensus error", state.BanScore)
 	}
 }
 

--- a/clients/go/node/p2p/handlers_compact_test.go
+++ b/clients/go/node/p2p/handlers_compact_test.go
@@ -1,0 +1,264 @@
+package p2p
+
+import (
+	"context"
+	"io"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+)
+
+func TestCompactBlockTxnFlowRequestsAndAcceptsMatchingResponse(t *testing.T) {
+	source := newTestHarness(t, 2, "127.0.0.1:0", nil)
+	sink := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	blockHash, blockBytes := testHarnessBlockAtHeight(t, source, 1)
+	block := compactTestPayloadFromBlock(t, blockBytes, 11, 12)
+
+	p, conn := compactTestPeerWithConn(sink)
+	if err := p.handleMessage(message{Command: messageCmpctBlock, Payload: mustEncodeCmpctBlockPayload(t, block)}); err != nil {
+		t.Fatalf("handleMessage(cmpctblock): %v", err)
+	}
+
+	frame := readCompactTestFrame(t, p, conn)
+	if frame.Command != messageGetBlockTxn {
+		t.Fatalf("command=%q, want getblocktxn", frame.Command)
+	}
+	req, err := decodeGetBlockTxnPayload(frame.Payload)
+	if err != nil {
+		t.Fatalf("decodeGetBlockTxnPayload: %v", err)
+	}
+	if req.BlockHash != blockHash || !reflect.DeepEqual(req.Indexes, []uint64{0}) {
+		t.Fatalf("getblocktxn=%+v, want block %x index [0]", req, blockHash)
+	}
+	if outstanding, ok := p.compactOutstandingRequestSnapshot(); !ok || outstanding.BlockHash != blockHash {
+		t.Fatalf("outstanding=%+v ok=%v, want block %x", outstanding, ok, blockHash)
+	}
+
+	_, txs, err := compactBlockTransactions(blockBytes)
+	if err != nil {
+		t.Fatalf("compactBlockTransactions: %v", err)
+	}
+	if err := p.handleMessage(message{Command: messageBlockTxn, Payload: mustEncodeBlockTxnForHash(t, blockHash, txs[:1])}); err != nil {
+		t.Fatalf("handleMessage(blocktxn): %v", err)
+	}
+	assertHarnessTip(t, sink, 1, blockHash)
+	if outstanding, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatalf("outstanding survived matching blocktxn: %+v", outstanding)
+	}
+}
+
+func TestCmpctBlockUsesLocalTxPoolBeforeRequest(t *testing.T) {
+	source := newTestHarness(t, 2, "127.0.0.1:0", nil)
+	sink := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	blockHash, blockBytes := testHarnessBlockAtHeight(t, source, 1)
+	block := compactTestPayloadFromBlock(t, blockBytes, 21, 22)
+	_, txs, err := compactBlockTransactions(blockBytes)
+	if err != nil {
+		t.Fatalf("compactBlockTransactions: %v", err)
+	}
+	_, txid, _, consumed, err := consensus.ParseTx(txs[0])
+	if err != nil || consumed != len(txs[0]) {
+		t.Fatalf("ParseTx: consumed=%d err=%v", consumed, err)
+	}
+	if !sink.service.cfg.TxPool.Put(txid, txs[0], uint64(len(txs[0])), len(txs[0])) {
+		t.Fatalf("Put local compact tx failed")
+	}
+
+	p, conn := compactTestPeerWithConn(sink)
+	if err := p.handleMessage(message{Command: messageCmpctBlock, Payload: mustEncodeCmpctBlockPayload(t, block)}); err != nil {
+		t.Fatalf("handleMessage(cmpctblock): %v", err)
+	}
+	assertHarnessTip(t, sink, 1, blockHash)
+	if conn.Buffer.Len() != 0 {
+		t.Fatalf("local reconstruction wrote %d response bytes, want none", conn.Buffer.Len())
+	}
+}
+
+func TestBlockTxnRejectsUnsolicitedWrongHashAndCount(t *testing.T) {
+	source := newTestHarness(t, 2, "127.0.0.1:0", nil)
+	sink := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	blockHash, blockBytes := testHarnessBlockAtHeight(t, source, 1)
+	block := compactTestPayloadFromBlock(t, blockBytes, 31, 32)
+	_, txs, err := compactBlockTransactions(blockBytes)
+	if err != nil {
+		t.Fatalf("compactBlockTransactions: %v", err)
+	}
+
+	p, _ := compactTestPeerWithConn(sink)
+	if err := p.handleMessage(message{Command: messageBlockTxn, Payload: mustEncodeBlockTxnForHash(t, blockHash, txs[:1])}); err == nil || !strings.Contains(err.Error(), "unexpected blocktxn response") {
+		t.Fatalf("unsolicited blocktxn err=%v, want unexpected response", err)
+	}
+	assertHarnessTip(t, sink, 0, nodeGenesisHash(t, sink))
+
+	p, _ = compactTestPeerWithConn(sink)
+	if err := p.handleMessage(message{Command: messageCmpctBlock, Payload: mustEncodeCmpctBlockPayload(t, block)}); err != nil {
+		t.Fatalf("handleMessage(cmpctblock): %v", err)
+	}
+	wrongHash := blockHash
+	wrongHash[0] ^= 0xff
+	if err := p.handleMessage(message{Command: messageBlockTxn, Payload: mustEncodeBlockTxnForHash(t, wrongHash, txs[:1])}); err == nil || !strings.Contains(err.Error(), "unexpected blocktxn response") {
+		t.Fatalf("wrong-hash blocktxn err=%v, want unexpected response", err)
+	}
+	if outstanding, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatalf("wrong-hash blocktxn did not clear outstanding: %+v", outstanding)
+	}
+	assertHarnessTip(t, sink, 0, nodeGenesisHash(t, sink))
+
+	p, _ = compactTestPeerWithConn(sink)
+	if err := p.handleMessage(message{Command: messageCmpctBlock, Payload: mustEncodeCmpctBlockPayload(t, block)}); err != nil {
+		t.Fatalf("handleMessage(cmpctblock): %v", err)
+	}
+	if err := p.handleMessage(message{Command: messageBlockTxn, Payload: mustEncodeBlockTxnForHash(t, blockHash, nil)}); err == nil || !strings.Contains(err.Error(), "blocktxn transaction count mismatch") {
+		t.Fatalf("count-mismatch blocktxn err=%v, want count mismatch", err)
+	}
+	if outstanding, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatalf("count-mismatch blocktxn did not clear outstanding: %+v", outstanding)
+	}
+	assertHarnessTip(t, sink, 0, nodeGenesisHash(t, sink))
+}
+
+func TestBlockTxnRejectsResponseOrderMismatch(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	txA := minimalBlockTxnTestTxBytes(101)
+	txB := minimalBlockTxnTestTxBytes(102)
+	nonce1, nonce2 := uint64(41), uint64(42)
+	hash := [32]byte{0xab}
+	shortA, err := compactTransactionShortID(txA, nonce1, nonce2)
+	if err != nil {
+		t.Fatalf("short A: %v", err)
+	}
+	shortB, err := compactTransactionShortID(txB, nonce1, nonce2)
+	if err != nil {
+		t.Fatalf("short B: %v", err)
+	}
+	p.setCompactOutstandingRequest(compactOutstandingRequest{
+		BlockHash:       hash,
+		MissingIndexes:  []uint64{0, 1},
+		MissingShortIDs: []compactShortID{shortA, shortB},
+		Transactions:    make([][]byte, 2),
+		Nonce1:          nonce1,
+		Nonce2:          nonce2,
+	})
+
+	err = p.handleMessage(message{Command: messageBlockTxn, Payload: mustEncodeBlockTxnForHash(t, hash, [][]byte{txB, txA})})
+	if err == nil || !strings.Contains(err.Error(), "blocktxn transaction short id mismatch") {
+		t.Fatalf("order-mismatch blocktxn err=%v, want short id mismatch", err)
+	}
+	if outstanding, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatalf("order-mismatch blocktxn did not clear outstanding: %+v", outstanding)
+	}
+}
+
+func TestCompactOutstandingRequestClearsOnReadTimeout(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	p.conn = &scriptedConn{reads: []scriptedRead{{err: timeoutErr{}}, {err: io.EOF}}}
+	p.setCompactOutstandingRequest(compactOutstandingRequest{
+		BlockHash:       [32]byte{0xcd},
+		MissingIndexes:  []uint64{0},
+		MissingShortIDs: []compactShortID{{0x01}},
+		Transactions:    make([][]byte, 1),
+	})
+
+	if err := p.run(context.Background()); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if outstanding, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatalf("read timeout did not clear outstanding request: %+v", outstanding)
+	}
+}
+
+func TestGetBlockTxnRespondsWithRequestedTransactions(t *testing.T) {
+	source := newTestHarness(t, 2, "127.0.0.1:0", nil)
+	blockHash, blockBytes := testHarnessBlockAtHeight(t, source, 1)
+	_, txs, err := compactBlockTransactions(blockBytes)
+	if err != nil {
+		t.Fatalf("compactBlockTransactions: %v", err)
+	}
+
+	p, conn := compactTestPeerWithConn(source)
+	if err := p.handleMessage(message{Command: messageGetBlockTxn, Payload: mustEncodeGetBlockTxnForHash(t, blockHash, []uint64{0})}); err != nil {
+		t.Fatalf("handleMessage(getblocktxn): %v", err)
+	}
+	frame := readCompactTestFrame(t, p, conn)
+	if frame.Command != messageBlockTxn {
+		t.Fatalf("command=%q, want blocktxn", frame.Command)
+	}
+	response, err := decodeBlockTxnPayload(frame.Payload)
+	if err != nil {
+		t.Fatalf("decodeBlockTxnPayload: %v", err)
+	}
+	if response.BlockHash != blockHash || !reflect.DeepEqual(response.Transactions, txs[:1]) {
+		t.Fatalf("blocktxn=%+v, want block %x tx0", response, blockHash)
+	}
+}
+
+func compactTestPayloadFromBlock(t *testing.T, blockBytes []byte, nonce1, nonce2 uint64) cmpctBlockPayload {
+	t.Helper()
+	header, txs, err := compactBlockTransactions(blockBytes)
+	if err != nil {
+		t.Fatalf("compactBlockTransactions: %v", err)
+	}
+	shortIDs := make([]compactShortID, 0, len(txs))
+	for _, tx := range txs {
+		shortID, err := compactTransactionShortID(tx, nonce1, nonce2)
+		if err != nil {
+			t.Fatalf("compactTransactionShortID: %v", err)
+		}
+		shortIDs = append(shortIDs, shortID)
+	}
+	return cmpctBlockPayload{Header: header, Nonce1: nonce1, Nonce2: nonce2, ShortIDs: shortIDs}
+}
+
+func compactTestPeerWithConn(h *testHarness) (*peer, *scriptedConn) {
+	conn := &scriptedConn{}
+	p := testPeerForService(h.service, "rubin-go/test-peer", 1)
+	p.conn = conn
+	return p, conn
+}
+
+func readCompactTestFrame(t *testing.T, p *peer, conn *scriptedConn) message {
+	t.Helper()
+	frame, err := readFrame(&conn.Buffer, networkMagic(p.service.cfg.PeerRuntimeConfig.Network), p.service.cfg.PeerRuntimeConfig.MaxMessageSize)
+	if err != nil {
+		t.Fatalf("readFrame: %v", err)
+	}
+	return frame
+}
+
+func mustEncodeCmpctBlockPayload(t *testing.T, block cmpctBlockPayload) []byte {
+	t.Helper()
+	raw, err := encodeCmpctBlockPayload(block)
+	if err != nil {
+		t.Fatalf("encodeCmpctBlockPayload: %v", err)
+	}
+	return raw
+}
+
+func mustEncodeBlockTxnForHash(t *testing.T, blockHash [32]byte, txs [][]byte) []byte {
+	t.Helper()
+	raw, err := encodeBlockTxnPayload(blockTxnPayload{BlockHash: blockHash, Transactions: txs})
+	if err != nil {
+		t.Fatalf("encodeBlockTxnPayload: %v", err)
+	}
+	return raw
+}
+
+func mustEncodeGetBlockTxnForHash(t *testing.T, blockHash [32]byte, indexes []uint64) []byte {
+	t.Helper()
+	raw, err := encodeGetBlockTxnPayload(getBlockTxnPayload{BlockHash: blockHash, Indexes: indexes})
+	if err != nil {
+		t.Fatalf("encodeGetBlockTxnPayload: %v", err)
+	}
+	return raw
+}
+
+func nodeGenesisHash(t *testing.T, h *testHarness) [32]byte {
+	t.Helper()
+	_, hash, ok, err := h.blockStore.Tip()
+	if err != nil || !ok {
+		t.Fatalf("tip: ok=%v err=%v", ok, err)
+	}
+	return hash
+}

--- a/clients/go/node/p2p/handlers_compact_test.go
+++ b/clients/go/node/p2p/handlers_compact_test.go
@@ -428,21 +428,30 @@ func TestCmpctBlockRejectsWrongTargetBeforeOversizedFallback(t *testing.T) {
 	}
 }
 
-func TestBlockTxnRejectsUnsolicitedWrongHashAndCount(t *testing.T) {
+func TestBlockTxnIgnoresUnsolicitedWithoutOutstanding(t *testing.T) {
 	source := newTestHarness(t, 2, "127.0.0.1:0", nil)
 	sink := newTestHarness(t, 1, "127.0.0.1:0", nil)
 	blockHash, blockBytes := testHarnessBlockAtHeight(t, source, 1)
-	block := compactTestPayloadFromBlock(t, blockBytes, 31, 32)
 	_, txs, err := compactBlockTransactions(blockBytes)
 	if err != nil {
 		t.Fatalf("compactBlockTransactions: %v", err)
 	}
 
-	p, _ := compactTestPeerWithConn(sink)
-	if err := p.handleMessage(message{Command: messageBlockTxn, Payload: mustEncodeBlockTxnForHash(t, blockHash, txs[:1])}); err == nil || !strings.Contains(err.Error(), "unexpected blocktxn response") {
-		t.Fatalf("unsolicited blocktxn err=%v, want unexpected response", err)
+	p, conn := compactTestPeerWithConn(sink)
+	if err := p.handleMessage(message{Command: messageBlockTxn, Payload: mustEncodeBlockTxnForHash(t, blockHash, txs[:1])}); err != nil {
+		t.Fatalf("unsolicited blocktxn: %v", err)
+	}
+	if conn.Buffer.Len() != 0 {
+		t.Fatalf("unsolicited blocktxn wrote %d bytes, want none", conn.Buffer.Len())
 	}
 	assertHarnessTip(t, sink, 0, nodeGenesisHash(t, sink))
+}
+
+func TestBlockTxnRejectsWrongHashAndCount(t *testing.T) {
+	source := newTestHarness(t, 2, "127.0.0.1:0", nil)
+	sink := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	blockHash, blockBytes := testHarnessBlockAtHeight(t, source, 1)
+	block := compactTestPayloadFromBlock(t, blockBytes, 31, 32)
 
 	p, conn := compactTestPeerWithConn(sink)
 	if err := p.handleMessage(message{Command: messageCmpctBlock, Payload: mustEncodeCmpctBlockPayload(t, block)}); err != nil {
@@ -475,6 +484,39 @@ func TestBlockTxnRejectsUnsolicitedWrongHashAndCount(t *testing.T) {
 		t.Fatalf("count-mismatch blocktxn did not clear outstanding: %+v", outstanding)
 	}
 	assertHarnessTip(t, sink, 0, nodeGenesisHash(t, sink))
+}
+
+func TestBlockTxnLateAfterExpiredOutstandingIsIgnored(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	enableCompactRelayForTest(p)
+	conn := &scriptedConn{}
+	p.conn = conn
+	now := time.Unix(1_777_000_100, 0)
+	p.service.cfg.Now = func() time.Time { return now }
+	p.service.cfg.PeerRuntimeConfig.ReadDeadline = time.Second
+	hash := [32]byte{0xd1}
+	tx := minimalBlockTxnTestTxBytes(104)
+	shortID, err := compactTransactionShortID(tx, 45, 46)
+	if err != nil {
+		t.Fatalf("compactTransactionShortID: %v", err)
+	}
+	p.setCompactOutstandingRequest(compactOutstandingRequest{
+		BlockHash:       hash,
+		MissingIndexes:  []uint64{0},
+		MissingShortIDs: []compactShortID{shortID},
+		Transactions:    make([][]byte, 1),
+		Nonce1:          45,
+		Nonce2:          46,
+	})
+
+	now = now.Add(time.Second)
+	if err := p.handleMessage(message{Command: messageBlockTxn, Payload: mustEncodeBlockTxnForHash(t, hash, [][]byte{tx})}); err != nil {
+		t.Fatalf("late blocktxn after fallback: %v", err)
+	}
+	assertCompactFullBlockRequest(t, p, conn, hash)
+	if outstanding, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatalf("expired compact request still outstanding: %+v", outstanding)
+	}
 }
 
 func TestBlockTxnRejectsResponseOrderMismatch(t *testing.T) {

--- a/clients/go/node/p2p/handlers_compact_test.go
+++ b/clients/go/node/p2p/handlers_compact_test.go
@@ -50,6 +50,54 @@ func TestCompactBlockTxnFlowRequestsAndAcceptsMatchingResponse(t *testing.T) {
 	}
 }
 
+func TestCmpctBlockRefreshesOutstandingExpiryAfterSend(t *testing.T) {
+	source := newTestHarness(t, 2, "127.0.0.1:0", nil)
+	sink := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	blockHash, blockBytes := testHarnessBlockAtHeight(t, source, 1)
+	block := compactTestPayloadFromBlock(t, blockBytes, 11, 12)
+	start := time.Unix(1_777_000_010, 0)
+	now := start
+	sink.service.cfg.Now = func() time.Time { return now }
+	sink.service.cfg.PeerRuntimeConfig.ReadDeadline = time.Second
+
+	conn := &compactAdvancingConn{onWrite: func() {
+		now = start.Add(500 * time.Millisecond)
+	}}
+	p := testPeerForService(sink.service, "rubin-go/test-peer", 1)
+	p.conn = conn
+	enableCompactRelayForTest(p)
+	if err := p.handleMessage(message{Command: messageCmpctBlock, Payload: mustEncodeCmpctBlockPayload(t, block)}); err != nil {
+		t.Fatalf("handleMessage(cmpctblock): %v", err)
+	}
+	frame, err := readFrame(&conn.Buffer, networkMagic(p.service.cfg.PeerRuntimeConfig.Network), p.service.cfg.PeerRuntimeConfig.MaxMessageSize)
+	if err != nil {
+		t.Fatalf("readFrame: %v", err)
+	}
+	if frame.Command != messageGetBlockTxn {
+		t.Fatalf("command=%q, want getblocktxn", frame.Command)
+	}
+	outstanding, ok := p.compactOutstandingRequestSnapshot()
+	if !ok || outstanding.BlockHash != blockHash {
+		t.Fatalf("outstanding=%+v ok=%v, want block %x", outstanding, ok, blockHash)
+	}
+	wantExpiry := start.Add(1500 * time.Millisecond)
+	if !outstanding.ExpiresAt.Equal(wantExpiry) {
+		t.Fatalf("outstanding expiry=%s, want refreshed expiry %s", outstanding.ExpiresAt, wantExpiry)
+	}
+}
+
+type compactAdvancingConn struct {
+	scriptedConn
+	onWrite func()
+}
+
+func (c *compactAdvancingConn) Write(p []byte) (int, error) {
+	if c.onWrite != nil {
+		c.onWrite()
+	}
+	return c.scriptedConn.Write(p)
+}
+
 func TestCompactRelayObjectCommandsRequireNegotiation(t *testing.T) {
 	p := newPeerRuntimeTestPeer(t)
 	p.conn = &scriptedConn{}
@@ -177,7 +225,7 @@ func TestBlockTxnFlowPreservesLocalMatchesAcrossResponse(t *testing.T) {
 	assertHarnessTip(t, sink, 1, blockHash)
 }
 
-func TestCompactReconstructedMissingParentIsRetainedAsOrphan(t *testing.T) {
+func TestCompactReconstructedMissingParentRequestsFullBlockFallback(t *testing.T) {
 	source := newTestHarness(t, 3, "127.0.0.1:0", nil)
 	sink := newTestHarness(t, 1, "127.0.0.1:0", nil)
 	blockHash, blockBytes := testHarnessBlockAtHeight(t, source, 2)
@@ -195,12 +243,13 @@ func TestCompactReconstructedMissingParentIsRetainedAsOrphan(t *testing.T) {
 	if err := p.handleMessage(message{Command: messageBlockTxn, Payload: mustEncodeBlockTxnForHash(t, blockHash, txs)}); err != nil {
 		t.Fatalf("handleMessage(blocktxn): %v", err)
 	}
-	assertOrphanPoolLen(t, sink.service, 1)
-	if conn.Buffer.Len() != 0 {
-		t.Fatalf("orphan compact reconstruction wrote %d fallback bytes, want none", conn.Buffer.Len())
+	assertCompactFullBlockRequest(t, p, conn, blockHash)
+	assertOrphanPoolLen(t, sink.service, 0)
+	if sink.service.blockSeen.Has(blockHash) {
+		t.Fatalf("compact reconstructed missing-parent block must not mark blockSeen before full-block validation")
 	}
 	if got := p.snapshotState().BanScore; got != 0 {
-		t.Fatalf("orphan compact reconstruction ban score=%d, want 0", got)
+		t.Fatalf("missing-parent compact reconstruction ban score=%d, want 0", got)
 	}
 }
 

--- a/clients/go/node/p2p/handlers_compact_test.go
+++ b/clients/go/node/p2p/handlers_compact_test.go
@@ -52,7 +52,14 @@ func TestCompactBlockTxnFlowRequestsAndAcceptsMatchingResponse(t *testing.T) {
 func TestCompactRelayObjectCommandsRequireNegotiation(t *testing.T) {
 	p := newPeerRuntimeTestPeer(t)
 	p.conn = &scriptedConn{}
+	capFn := p.postHandshakePayloadCap()
+	if got := capFn(messageSendCmpct); got != sendCmpctPayloadBytes {
+		t.Fatalf("sendcmpct cap=%d, want %d", got, sendCmpctPayloadBytes)
+	}
 	for _, command := range []string{messageCmpctBlock, messageGetBlockTxn, messageBlockTxn} {
+		if got := capFn(command); got != 0 {
+			t.Fatalf("non-negotiated %s cap=%d, want 0", command, got)
+		}
 		err := p.handleMessage(message{Command: command, Payload: nil})
 		if err == nil || !strings.Contains(err.Error(), "compact relay not negotiated") {
 			t.Fatalf("handleMessage(%s) err=%v, want negotiation rejection", command, err)
@@ -60,6 +67,12 @@ func TestCompactRelayObjectCommandsRequireNegotiation(t *testing.T) {
 	}
 	if outstanding, ok := p.compactOutstandingRequestSnapshot(); ok {
 		t.Fatalf("non-negotiated compact command left outstanding: %+v", outstanding)
+	}
+	enableCompactRelayForTest(p)
+	for _, command := range []string{messageCmpctBlock, messageGetBlockTxn, messageBlockTxn} {
+		if got := capFn(command); got == 0 {
+			t.Fatalf("negotiated %s cap=0, want enabled compact cap", command)
+		}
 	}
 }
 
@@ -272,6 +285,9 @@ func TestBlockTxnMalformedAndProcessFailureFallback(t *testing.T) {
 		t.Fatalf("malformed blocktxn fallback: %v", err)
 	}
 	assertCompactFullBlockRequest(t, p, conn, hash)
+	if got := p.snapshotState().BanScore; got != 0 {
+		t.Fatalf("malformed compact response ban score=%d, want fallback without ban", got)
+	}
 
 	p = newPeerRuntimeTestPeer(t)
 	enableCompactRelayForTest(p)
@@ -295,6 +311,9 @@ func TestBlockTxnMalformedAndProcessFailureFallback(t *testing.T) {
 		t.Fatalf("process-failure blocktxn fallback: %v", err)
 	}
 	assertCompactFullBlockRequest(t, p, conn, hash)
+	if got := p.snapshotState().BanScore; got != 0 {
+		t.Fatalf("compact reconstruction failure ban score=%d, want fallback without ban", got)
+	}
 }
 
 func TestCompactOutstandingRequestClearsOnReadTimeout(t *testing.T) {

--- a/clients/go/node/p2p/handlers_compact_test.go
+++ b/clients/go/node/p2p/handlers_compact_test.go
@@ -139,6 +139,33 @@ func TestBlockTxnFlowPreservesLocalMatchesAcrossResponse(t *testing.T) {
 	assertHarnessTip(t, sink, 1, blockHash)
 }
 
+func TestCompactReconstructedMissingParentIsRetainedAsOrphan(t *testing.T) {
+	source := newTestHarness(t, 3, "127.0.0.1:0", nil)
+	sink := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	blockHash, blockBytes := testHarnessBlockAtHeight(t, source, 2)
+	block := compactTestPayloadFromBlock(t, blockBytes, 23, 24)
+	_, txs, err := compactBlockTransactions(blockBytes)
+	if err != nil {
+		t.Fatalf("compactBlockTransactions: %v", err)
+	}
+
+	p, conn := compactTestPeerWithConn(sink)
+	if err := p.handleMessage(message{Command: messageCmpctBlock, Payload: mustEncodeCmpctBlockPayload(t, block)}); err != nil {
+		t.Fatalf("handleMessage(cmpctblock): %v", err)
+	}
+	_ = mustReadCompactGetBlockTxn(t, p, conn)
+	if err := p.handleMessage(message{Command: messageBlockTxn, Payload: mustEncodeBlockTxnForHash(t, blockHash, txs)}); err != nil {
+		t.Fatalf("handleMessage(blocktxn): %v", err)
+	}
+	assertOrphanPoolLen(t, sink.service, 1)
+	if conn.Buffer.Len() != 0 {
+		t.Fatalf("orphan compact reconstruction wrote %d fallback bytes, want none", conn.Buffer.Len())
+	}
+	if got := p.snapshotState().BanScore; got != 0 {
+		t.Fatalf("orphan compact reconstruction ban score=%d, want 0", got)
+	}
+}
+
 func TestCmpctBlockWithPendingRequestFallsBackNewBlockWithoutOverwrite(t *testing.T) {
 	source := newTestHarness(t, 3, "127.0.0.1:0", nil)
 	sink := newTestHarness(t, 1, "127.0.0.1:0", nil)

--- a/clients/go/node/p2p/peer_runtime.go
+++ b/clients/go/node/p2p/peer_runtime.go
@@ -39,6 +39,7 @@ func (p *peer) run(ctx context.Context) error {
 		)
 		if err != nil {
 			if shouldIgnoreReadError(err) {
+				p.clearCompactOutstandingRequest()
 				continue
 			}
 			return normalizeReadError(err)
@@ -84,7 +85,7 @@ func normalizeReadError(err error) error {
 
 func (p *peer) handleMessage(frame message) error {
 	switch frame.Command {
-	case messageInv, messageGetData, messageBlock, messageTx, messageGetBlk:
+	case messageInv, messageGetData, messageBlock, messageTx, messageGetBlk, messageCmpctBlock, messageGetBlockTxn, messageBlockTxn:
 		return p.handleRelayMessage(frame)
 	case messageSendCmpct:
 		return p.handleSendCmpct(frame.Payload)
@@ -105,7 +106,7 @@ func (p *peer) handleRelayMessage(frame message) error {
 	switch frame.Command {
 	case messageInv, messageGetData:
 		return p.handleInventoryRelayMessage(frame)
-	case messageBlock, messageTx, messageGetBlk:
+	case messageBlock, messageTx, messageGetBlk, messageCmpctBlock, messageGetBlockTxn, messageBlockTxn:
 		return p.handleObjectRelayMessage(frame)
 	default:
 		return postHandshakeUnknownCommandError{command: frame.Command}
@@ -131,6 +132,12 @@ func (p *peer) handleObjectRelayMessage(frame message) error {
 		return p.handleTx(frame.Payload)
 	case messageGetBlk:
 		return p.handleGetBlocks(frame.Payload)
+	case messageCmpctBlock:
+		return p.handleCmpctBlock(frame.Payload)
+	case messageGetBlockTxn:
+		return p.handleGetBlockTxn(frame.Payload)
+	case messageBlockTxn:
+		return p.handleBlockTxn(frame.Payload)
 	default:
 		return postHandshakeUnknownCommandError{command: frame.Command}
 	}

--- a/clients/go/node/p2p/peer_runtime.go
+++ b/clients/go/node/p2p/peer_runtime.go
@@ -35,7 +35,7 @@ func (p *peer) run(ctx context.Context) error {
 			p.conn,
 			networkMagic(p.service.cfg.PeerRuntimeConfig.Network),
 			p.service.cfg.PeerRuntimeConfig.MaxMessageSize,
-			postHandshakePayloadCap(p.service.cfg.LocatorLimit, p.service.cfg.SyncConfig.HeaderBatchLimit),
+			p.postHandshakePayloadCap(),
 		)
 		if err != nil {
 			if shouldIgnoreReadError(err) {
@@ -49,6 +49,19 @@ func (p *peer) run(ctx context.Context) error {
 		if err := p.handleMessage(frame); err != nil {
 			return err
 		}
+	}
+}
+
+func (p *peer) postHandshakePayloadCap() payloadLimitFn {
+	limiter := postHandshakePayloadLimiter{
+		locatorLimit:     p.service.cfg.LocatorLimit,
+		headerBatchLimit: p.service.cfg.SyncConfig.HeaderBatchLimit,
+	}
+	return func(command string) uint32 {
+		if isCompactRelayObjectCommand(command) && !p.compactRelayEnabled() {
+			return 0
+		}
+		return limiter.cap(command)
 	}
 }
 

--- a/clients/go/node/p2p/peer_runtime.go
+++ b/clients/go/node/p2p/peer_runtime.go
@@ -39,7 +39,9 @@ func (p *peer) run(ctx context.Context) error {
 		)
 		if err != nil {
 			if shouldIgnoreReadError(err) {
-				p.clearCompactOutstandingRequest()
+				if err := p.fallbackCompactOutstandingRequest(); err != nil {
+					return err
+				}
 				continue
 			}
 			return normalizeReadError(err)

--- a/clients/go/node/p2p/peer_runtime.go
+++ b/clients/go/node/p2p/peer_runtime.go
@@ -127,6 +127,9 @@ func (p *peer) handleInventoryRelayMessage(frame message) error {
 }
 
 func (p *peer) handleObjectRelayMessage(frame message) error {
+	if isCompactRelayObjectCommand(frame.Command) && !p.compactRelayEnabled() {
+		return errors.New("compact relay not negotiated")
+	}
 	switch frame.Command {
 	case messageBlock:
 		return p.handleBlock(frame.Payload)
@@ -142,6 +145,15 @@ func (p *peer) handleObjectRelayMessage(frame message) error {
 		return p.handleBlockTxn(frame.Payload)
 	default:
 		return postHandshakeUnknownCommandError{command: frame.Command}
+	}
+}
+
+func isCompactRelayObjectCommand(command string) bool {
+	switch command {
+	case messageCmpctBlock, messageGetBlockTxn, messageBlockTxn:
+		return true
+	default:
+		return false
 	}
 }
 

--- a/clients/go/node/p2p/peer_runtime.go
+++ b/clients/go/node/p2p/peer_runtime.go
@@ -99,6 +99,9 @@ func normalizeReadError(err error) error {
 }
 
 func (p *peer) handleMessage(frame message) error {
+	if err := p.expireCompactOutstandingRequest(); err != nil {
+		return err
+	}
 	switch frame.Command {
 	case messageInv, messageGetData, messageBlock, messageTx, messageGetBlk, messageCmpctBlock, messageGetBlockTxn, messageBlockTxn:
 		return p.handleRelayMessage(frame)

--- a/clients/go/node/p2p/peer_runtime.go
+++ b/clients/go/node/p2p/peer_runtime.go
@@ -61,6 +61,9 @@ func (p *peer) postHandshakePayloadCap() payloadLimitFn {
 		if isCompactRelayObjectCommand(command) && !p.compactRelayEnabled() {
 			return 0
 		}
+		if command == messageBlockTxn {
+			return p.blockTxnPayloadCap()
+		}
 		return limiter.cap(command)
 	}
 }

--- a/clients/go/node/p2p/peer_runtime_test.go
+++ b/clients/go/node/p2p/peer_runtime_test.go
@@ -88,6 +88,29 @@ func TestShouldIgnoreAndNormalizeReadError(t *testing.T) {
 	}
 }
 
+func TestBlockTxnCapRejectsUnsolicitedBeforePayloadRead(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	enableCompactRelayForTest(p)
+	payload := []byte{0x01}
+	header, err := buildEnvelopeHeader(networkMagic("devnet"), messageBlockTxn, payload)
+	if err != nil {
+		t.Fatalf("buildEnvelopeHeader: %v", err)
+	}
+	reader := io.MultiReader(
+		bytes.NewReader(header[:]),
+		&failingReader{err: errors.New("payload should not be read")},
+	)
+	_, err = readFrameWithPayloadLimit(
+		reader,
+		networkMagic("devnet"),
+		p.service.cfg.PeerRuntimeConfig.MaxMessageSize,
+		p.postHandshakePayloadCap(),
+	)
+	if err == nil || err.Error() != "message exceeds command cap" {
+		t.Fatalf("unsolicited blocktxn cap err=%v, want command cap rejection", err)
+	}
+}
+
 func TestRunDisconnectsOnPartialHeaderTimeoutBeforeFakeFrame(t *testing.T) {
 	p := newPeerRuntimeTestPeer(t)
 	p.service.cfg.PeerRuntimeConfig.ReadDeadline = time.Millisecond

--- a/clients/go/node/p2p/service.go
+++ b/clients/go/node/p2p/service.go
@@ -35,6 +35,11 @@ type ServiceConfig struct {
 	TxPool             TxPool
 	TxMetadataFunc     func([]byte) (node.RelayTxMetadata, error)
 	Now                func() time.Time
+	// CompactRelayObjectsEnabled gates Go-only compact object commands until
+	// the Rust runtime lands the matching cmpctblock/getblocktxn/blocktxn
+	// handlers. sendcmpct parsing remains active, but object payload caps and
+	// dispatch stay closed by default for mixed-client parity.
+	CompactRelayObjectsEnabled bool
 }
 
 type Service struct {

--- a/clients/go/node/p2p/wire_payload_limits.go
+++ b/clients/go/node/p2p/wire_payload_limits.go
@@ -41,26 +41,54 @@ func compactRelayPayloadCap(command string) uint32 {
 }
 
 func postHandshakePayloadCap(locatorLimit int, headerBatchLimit uint64) payloadLimitFn {
-	return func(command string) uint32 {
-		switch command {
-		case messageVersion:
-			return versionPayloadBytes
-		case messageVerAck, messageGetAddr, messagePing, messagePong:
-			return 0
-		case messageSendCmpct:
-			return compactRelayPayloadCap(command)
-		case messageInv, messageGetData:
-			return inventoryPayloadCap()
-		case messageAddr:
-			return addrPayloadCap()
-		case messageGetBlk:
-			return getBlocksPayloadCap(locatorLimit)
-		case messageHeaders:
-			return headersPayloadCap(headerBatchLimit)
-		case messageBlock, messageTx:
-			return uint32(consensus.MAX_BLOCK_BYTES)
-		default:
-			return 0
-		}
+	limiter := postHandshakePayloadLimiter{locatorLimit: locatorLimit, headerBatchLimit: headerBatchLimit}
+	return limiter.cap
+}
+
+type postHandshakePayloadLimiter struct {
+	locatorLimit     int
+	headerBatchLimit uint64
+}
+
+func (l postHandshakePayloadLimiter) cap(command string) uint32 {
+	if cap, ok := compactPostHandshakePayloadCap(command); ok {
+		return cap
+	}
+	if cap, ok := fixedPostHandshakePayloadCap(command); ok {
+		return cap
+	}
+	return l.variablePostHandshakePayloadCap(command)
+}
+
+func compactPostHandshakePayloadCap(command string) (uint32, bool) {
+	cap := compactRelayPayloadCap(command)
+	return cap, cap != 0
+}
+
+func fixedPostHandshakePayloadCap(command string) (uint32, bool) {
+	switch command {
+	case messageVersion:
+		return versionPayloadBytes, true
+	case messageVerAck, messageGetAddr, messagePing, messagePong:
+		return 0, true
+	default:
+		return 0, false
+	}
+}
+
+func (l postHandshakePayloadLimiter) variablePostHandshakePayloadCap(command string) uint32 {
+	switch command {
+	case messageInv, messageGetData:
+		return inventoryPayloadCap()
+	case messageAddr:
+		return addrPayloadCap()
+	case messageGetBlk:
+		return getBlocksPayloadCap(l.locatorLimit)
+	case messageHeaders:
+		return headersPayloadCap(l.headerBatchLimit)
+	case messageBlock, messageTx:
+		return uint32(consensus.MAX_BLOCK_BYTES)
+	default:
+		return 0
 	}
 }


### PR DESCRIPTION
Invariant:
Go compact relay object flow (`cmpctblock` / `getblocktxn` / `blocktxn`) is implemented behind an explicit local gate, with bounded fallback/recovery and without enabling mixed-client compact objects by default.

Layer:
implementation, tests

Files changed:
- `clients/go/node/p2p/compact_reconstruct.go`
- `clients/go/node/p2p/compact_reconstruct_test.go`
- `clients/go/node/p2p/compact_runtime.go`
- `clients/go/node/p2p/compact_wire.go`
- `clients/go/node/p2p/compact_wire_test.go`
- `clients/go/node/p2p/handlers_compact_test.go`
- `clients/go/node/p2p/peer_runtime.go`
- `clients/go/node/p2p/service.go`
- `clients/go/node/p2p/wire_payload_limits.go`

Tests:
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node/p2p -count=1 && go vet ./node/p2p'`
- `rubin-common-preflight --lane core --repo .`
- `rubin-precommit-one-review --repo . --base-ref origin/main`
- `rubin-push --repo . --base-ref origin/main --coverage-cmd "... scripts/preflight-codacy-coverage.sh" -- origin HEAD:codex/RUB-326-go-compact-blocktxn-flow`

Behavior impact:
- Compact object commands remain locally disabled by default.
- When enabled, Go peers use negotiated compact blocktxn flow with bounded fallback.
- Compact reconstructed missing-parent blocks request full-block fallback without orphan/blockSeen mutation.
- Non-recoverable local/header-context errors are propagated/recorded instead of hidden by fallback.

Compatibility impact:
No wire codec compatibility change; runtime serving applies local safety checks.

Known non-goals:
- No Rust compact runtime object handlers.
- No consensus rule changes.
- No default enablement for mixed-client compact object relay.
- No public API changes outside the P2P service config gate.

Risk:
Go-only runtime path is gated default-off until Rust parity handlers land.

Rollback:
Revert this PR; default-off gate means inactive deployments keep existing full-block relay behavior.

Not checked:
- Cross-client compact object relay runtime, because Rust handlers are not in this PR.


<!-- rubin-agent-meta actor=unknown action=pr-create via=cl branch=codex/RUB-326-go-compact-blocktxn-flow wt=rubin-protocol-codex-RUB-326 utc=2026-05-20T03:45:11Z -->
