### PR TITLE
[RUB-328] Prepare Go compact blocktxn plumbing

### DIFF
--- a/clients/go/node/p2p/compact_runtime.go
+++ b/clients/go/node/p2p/compact_runtime.go
@@ -11,7 +11,13 @@ type compactModeSnapshot struct {
 }
 
 type peerCompactRelayState struct {
-	remoteMode compactModeSnapshot
+	remoteMode  compactModeSnapshot
+	outstanding *compactOutstandingRequest
+}
+
+type compactOutstandingRequest struct {
+	BlockHash          [32]byte
+	BlockTxnPayloadCap uint32
 }
 
 func (p *peer) handleSendCmpct(payload []byte) error {
@@ -47,4 +53,16 @@ func (p *peer) remoteCompactMode() compactModeSnapshot {
 	p.compactMu.Lock()
 	defer p.compactMu.Unlock()
 	return p.compact.remoteMode
+}
+
+func (p *peer) blockTxnPayloadCap() uint32 {
+	p.compactMu.Lock()
+	defer p.compactMu.Unlock()
+	if p.compact.outstanding == nil {
+		return 0
+	}
+	if maxCap := compactRelayPayloadCap(messageBlockTxn); p.compact.outstanding.BlockTxnPayloadCap > maxCap {
+		return maxCap
+	}
+	return p.compact.outstanding.BlockTxnPayloadCap
 }

--- a/clients/go/node/p2p/compact_wire.go
+++ b/clients/go/node/p2p/compact_wire.go
@@ -36,6 +36,12 @@ type blockTxnPayload struct {
 	Transactions [][]byte
 }
 
+type blockTxnRuntimePayload struct {
+	BlockHash    [32]byte
+	Transactions [][]byte
+	WTxIDs       [][32]byte
+}
+
 type compactShortID [compactShortIDBytes]byte
 
 type prefilledTxn struct {
@@ -141,40 +147,49 @@ func encodeBlockTxnPayload(p blockTxnPayload) ([]byte, error) {
 }
 
 func decodeBlockTxnPayload(payload []byte) (blockTxnPayload, error) {
-	var out blockTxnPayload
-	if len(payload) < 32 {
-		return out, errors.New("blocktxn payload missing block hash")
-	}
-	copy(out.BlockHash[:], payload[:32])
-	count, consumed, err := consensus.DecodeCompactSize(payload[32:])
+	runtimePayload, err := decodeBlockTxnRuntimePayload(payload)
 	if err != nil {
 		return blockTxnPayload{}, err
 	}
+	return blockTxnPayload{BlockHash: runtimePayload.BlockHash, Transactions: runtimePayload.Transactions}, nil
+}
+
+func decodeBlockTxnRuntimePayload(payload []byte) (blockTxnRuntimePayload, error) {
+	var blockHash [32]byte
+	if len(payload) < 32 {
+		return blockTxnRuntimePayload{}, errors.New("blocktxn payload missing block hash")
+	}
+	copy(blockHash[:], payload[:32])
+	count, consumed, err := consensus.DecodeCompactSize(payload[32:])
+	if err != nil {
+		return blockTxnRuntimePayload{}, err
+	}
 	if count > maxCompactRelayEntries {
-		return blockTxnPayload{}, errors.New("too many compact relay transactions")
+		return blockTxnRuntimePayload{}, errors.New("too many compact relay transactions")
 	}
 	offset := 32 + consumed
 	transactions := make([][]byte, 0, int(count)) // #nosec G115 -- count is capped at maxCompactRelayEntries above.
+	wtxids := make([][32]byte, 0, int(count))     // #nosec G115 -- count is capped at maxCompactRelayEntries above.
 	var totalTxBytes uint64
 	for i := uint64(0); i < count; i++ {
 		txLen, n, err := consensus.DecodeCompactSize(payload[offset:])
 		if err != nil {
-			return blockTxnPayload{}, err
+			return blockTxnRuntimePayload{}, err
 		}
 		offset += n
-		tx, txConsumed, nextTotal, err := decodeCompactRelayTxEnvelope(payload[offset:], txLen, totalTxBytes, "blocktxn transaction is non-canonical")
+		tx, wtxid, txConsumed, nextTotal, err := decodeCompactRelayTxEnvelope(payload[offset:], txLen, totalTxBytes, "blocktxn transaction is non-canonical")
 		if err != nil {
-			return blockTxnPayload{}, err
+			return blockTxnRuntimePayload{}, err
 		}
 		transactions = append(transactions, append([]byte(nil), tx...))
+		wtxids = append(wtxids, wtxid)
 		offset += txConsumed
 		totalTxBytes = nextTotal
 	}
 	if offset != len(payload) {
-		return blockTxnPayload{}, errors.New("blocktxn payload has trailing bytes")
+		return blockTxnRuntimePayload{}, errors.New("blocktxn payload has trailing bytes")
 	}
-	out.Transactions = transactions
-	return out, nil
+	return blockTxnRuntimePayload{BlockHash: blockHash, Transactions: transactions, WTxIDs: wtxids}, nil
 }
 
 func encodeCmpctBlockPayload(p cmpctBlockPayload) ([]byte, error) {
@@ -282,7 +297,7 @@ func decodeCmpctBlockPrefilled(payload []byte, offset int, entryPos, prev, total
 		return prefilledTxn{}, 0, totalTxBytes, err
 	}
 	offset += n
-	tx, txConsumed, nextTotal, err := decodeCompactRelayTxEnvelope(payload[offset:], txLen, totalTxBytes, "cmpctblock prefilled transaction is non-canonical")
+	tx, _, txConsumed, nextTotal, err := decodeCompactRelayTxEnvelope(payload[offset:], txLen, totalTxBytes, "cmpctblock prefilled transaction is non-canonical")
 	if err != nil {
 		return prefilledTxn{}, 0, totalTxBytes, err
 	}
@@ -338,20 +353,21 @@ func validateCmpctBlockEntryCount(shortCount, prefilledCount uint64) (uint64, er
 	return totalEntries, nil
 }
 
-func decodeCompactRelayTxEnvelope(payload []byte, txLen, totalTxBytes uint64, nonCanonicalErr string) ([]byte, int, uint64, error) {
+func decodeCompactRelayTxEnvelope(payload []byte, txLen, totalTxBytes uint64, nonCanonicalErr string) ([]byte, [32]byte, int, uint64, error) {
+	var zero [32]byte
 	if txLen > uint64(len(payload)) {
-		return nil, 0, totalTxBytes, errors.New("compact relay transaction truncated")
+		return nil, zero, 0, totalTxBytes, errors.New("compact relay transaction truncated")
 	}
 	tx := payload[:int(txLen)] // #nosec G115 -- txLen is bounded by len(payload) above.
 	nextTotal, err := validateBlockTxnTransactionSize(txLen, totalTxBytes)
 	if err != nil {
-		return nil, 0, totalTxBytes, err
+		return nil, zero, 0, totalTxBytes, err
 	}
-	_, _, _, consumed, err := consensus.ParseTx(tx)
+	_, _, wtxid, consumed, err := consensus.ParseTx(tx)
 	if err != nil || consumed != len(tx) {
-		return nil, 0, totalTxBytes, errors.New(nonCanonicalErr)
+		return nil, zero, 0, totalTxBytes, errors.New(nonCanonicalErr)
 	}
-	return tx, len(tx), nextTotal, nil
+	return tx, wtxid, len(tx), nextTotal, nil
 }
 
 func finishCmpctBlockPayload(out cmpctBlockPayload, offset, payloadLen int) (cmpctBlockPayload, error) {

--- a/clients/go/node/p2p/compact_wire_test.go
+++ b/clients/go/node/p2p/compact_wire_test.go
@@ -27,14 +27,8 @@ func TestCompactWireCommandConstantsAndPayloadCaps(t *testing.T) {
 		if (command == messageCmpctBlock || command == messageBlockTxn) && caps[i] <= uint32(consensus.MAX_BLOCK_BYTES) {
 			t.Fatalf("%s explicit cap=%d, want above MAX_BLOCK_BYTES", command, caps[i])
 		}
-		if command == messageSendCmpct {
-			if got := liveCaps(command); got != sendCmpctPayloadBytes {
-				t.Fatalf("%s live cap=%d, want %d", command, got, sendCmpctPayloadBytes)
-			}
-			continue
-		}
-		if got := liveCaps(command); got != 0 {
-			t.Fatalf("%s live cap=%d, want 0 until runtime handler slice", command, got)
+		if got := liveCaps(command); got != caps[i] {
+			t.Fatalf("%s live cap=%d, want %d", command, got, caps[i])
 		}
 	}
 }
@@ -83,6 +77,24 @@ func TestBlockTxnPayloadCodec(t *testing.T) {
 	}
 	if got.BlockHash != want.BlockHash || !reflect.DeepEqual(got.Transactions, want.Transactions) {
 		t.Fatalf("blocktxn roundtrip got=%+v want=%+v", got, want)
+	}
+	runtimePayload, err := decodeBlockTxnRuntimePayload(raw)
+	if err != nil {
+		t.Fatalf("decodeBlockTxnRuntimePayload: %v", err)
+	}
+	_, _, wantWTxID1, _, err := consensus.ParseTx(tx1)
+	if err != nil {
+		t.Fatalf("ParseTx(tx1): %v", err)
+	}
+	_, _, wantWTxID2, _, err := consensus.ParseTx(tx2)
+	if err != nil {
+		t.Fatalf("ParseTx(tx2): %v", err)
+	}
+	if runtimePayload.BlockHash != want.BlockHash || !reflect.DeepEqual(runtimePayload.WTxIDs, [][32]byte{wantWTxID1, wantWTxID2}) {
+		t.Fatalf("runtime blocktxn payload=%+v, want hash %x and WTXIDs", runtimePayload, want.BlockHash)
+	}
+	if !reflect.DeepEqual(runtimePayload.Transactions, want.Transactions) {
+		t.Fatalf("runtime blocktxn transactions=%x, want %x", runtimePayload.Transactions, want.Transactions)
 	}
 }
 

--- a/clients/go/node/p2p/peer_runtime.go
+++ b/clients/go/node/p2p/peer_runtime.go
@@ -35,7 +35,7 @@ func (p *peer) run(ctx context.Context) error {
 			p.conn,
 			networkMagic(p.service.cfg.PeerRuntimeConfig.Network),
 			p.service.cfg.PeerRuntimeConfig.MaxMessageSize,
-			postHandshakePayloadCap(p.service.cfg.LocatorLimit, p.service.cfg.SyncConfig.HeaderBatchLimit),
+			p.postHandshakePayloadCap(),
 		)
 		if err != nil {
 			if shouldIgnoreReadError(err) {
@@ -46,6 +46,16 @@ func (p *peer) run(ctx context.Context) error {
 		if err := p.handleMessage(frame); err != nil {
 			return err
 		}
+	}
+}
+
+func (p *peer) postHandshakePayloadCap() payloadLimitFn {
+	base := postHandshakePayloadCap(p.service.cfg.LocatorLimit, p.service.cfg.SyncConfig.HeaderBatchLimit)
+	return func(command string) uint32 {
+		if isCompactRelayObjectCommand(command) {
+			return 0
+		}
+		return base(command)
 	}
 }
 
@@ -133,6 +143,15 @@ func (p *peer) handleObjectRelayMessage(frame message) error {
 		return p.handleGetBlocks(frame.Payload)
 	default:
 		return postHandshakeUnknownCommandError{command: frame.Command}
+	}
+}
+
+func isCompactRelayObjectCommand(command string) bool {
+	switch command {
+	case messageCmpctBlock, messageGetBlockTxn, messageBlockTxn:
+		return true
+	default:
+		return false
 	}
 }
 

--- a/clients/go/node/p2p/peer_runtime_test.go
+++ b/clients/go/node/p2p/peer_runtime_test.go
@@ -88,6 +88,48 @@ func TestShouldIgnoreAndNormalizeReadError(t *testing.T) {
 	}
 }
 
+func TestCompactObjectCapsStayClosedUntilHandlersExist(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	limiter := p.postHandshakePayloadCap()
+	for _, command := range []string{messageCmpctBlock, messageGetBlockTxn, messageBlockTxn} {
+		if got := limiter(command); got != 0 {
+			t.Fatalf("pre-negotiation %s cap=%d, want 0", command, got)
+		}
+	}
+
+	p.setRemoteCompactMode(compactModeSnapshot{Mode: 1, Version: compactRelayVersion})
+	limiter = p.postHandshakePayloadCap()
+	p.compactMu.Lock()
+	p.compact.outstanding = &compactOutstandingRequest{BlockTxnPayloadCap: compactRelayPayloadCap(messageBlockTxn) + 1}
+	p.compactMu.Unlock()
+	for _, command := range []string{messageCmpctBlock, messageGetBlockTxn, messageBlockTxn} {
+		if got := limiter(command); got != 0 {
+			t.Fatalf("negotiated %s cap=%d, want 0 until handler slice", command, got)
+		}
+	}
+}
+
+func TestBlockTxnPayloadCapIsOutstandingBounded(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	if got := p.blockTxnPayloadCap(); got != 0 {
+		t.Fatalf("blocktxn cap without outstanding=%d, want 0", got)
+	}
+
+	p.compactMu.Lock()
+	p.compact.outstanding = &compactOutstandingRequest{BlockTxnPayloadCap: 64}
+	p.compactMu.Unlock()
+	if got := p.blockTxnPayloadCap(); got != 64 {
+		t.Fatalf("blocktxn bounded cap=%d, want 64", got)
+	}
+
+	p.compactMu.Lock()
+	p.compact.outstanding = &compactOutstandingRequest{BlockTxnPayloadCap: compactRelayPayloadCap(messageBlockTxn) + 1}
+	p.compactMu.Unlock()
+	if got := p.blockTxnPayloadCap(); got != compactRelayPayloadCap(messageBlockTxn) {
+		t.Fatalf("blocktxn oversized cap=%d, want max %d", got, compactRelayPayloadCap(messageBlockTxn))
+	}
+}
+
 func TestRunDisconnectsOnPartialHeaderTimeoutBeforeFakeFrame(t *testing.T) {
 	p := newPeerRuntimeTestPeer(t)
 	p.service.cfg.PeerRuntimeConfig.ReadDeadline = time.Millisecond

--- a/clients/go/node/p2p/wire_payload_limits.go
+++ b/clients/go/node/p2p/wire_payload_limits.go
@@ -42,25 +42,40 @@ func compactRelayPayloadCap(command string) uint32 {
 
 func postHandshakePayloadCap(locatorLimit int, headerBatchLimit uint64) payloadLimitFn {
 	return func(command string) uint32 {
-		switch command {
-		case messageVersion:
-			return versionPayloadBytes
-		case messageVerAck, messageGetAddr, messagePing, messagePong:
-			return 0
-		case messageSendCmpct:
-			return compactRelayPayloadCap(command)
-		case messageInv, messageGetData:
-			return inventoryPayloadCap()
-		case messageAddr:
-			return addrPayloadCap()
-		case messageGetBlk:
-			return getBlocksPayloadCap(locatorLimit)
-		case messageHeaders:
-			return headersPayloadCap(headerBatchLimit)
-		case messageBlock, messageTx:
-			return uint32(consensus.MAX_BLOCK_BYTES)
-		default:
-			return 0
+		if cap, ok := fixedPostHandshakePayloadCap(command); ok {
+			return cap
 		}
+		if cap := compactRelayPayloadCap(command); cap != 0 {
+			return cap
+		}
+		return variablePostHandshakePayloadCap(command, locatorLimit, headerBatchLimit)
+	}
+}
+
+func fixedPostHandshakePayloadCap(command string) (uint32, bool) {
+	switch command {
+	case messageVersion:
+		return versionPayloadBytes, true
+	case messageVerAck, messageGetAddr, messagePing, messagePong:
+		return 0, true
+	default:
+		return 0, false
+	}
+}
+
+func variablePostHandshakePayloadCap(command string, locatorLimit int, headerBatchLimit uint64) uint32 {
+	switch command {
+	case messageInv, messageGetData:
+		return inventoryPayloadCap()
+	case messageAddr:
+		return addrPayloadCap()
+	case messageGetBlk:
+		return getBlocksPayloadCap(locatorLimit)
+	case messageHeaders:
+		return headersPayloadCap(headerBatchLimit)
+	case messageBlock, messageTx:
+		return uint32(consensus.MAX_BLOCK_BYTES)
+	default:
+		return 0
 	}
 }


### PR DESCRIPTION
Invariant:
Prepare bounded Go compact `blocktxn` runtime plumbing without admitting live compact object messages before handler slices exist.

Layer:
implementation / tests

Files changed:
- `clients/go/node/p2p/compact_runtime.go`
- `clients/go/node/p2p/compact_wire.go`
- `clients/go/node/p2p/compact_wire_test.go`
- `clients/go/node/p2p/peer_runtime.go`
- `clients/go/node/p2p/peer_runtime_test.go`
- `clients/go/node/p2p/wire_payload_limits.go`

Summary:
- Add peer-local outstanding request plumbing with bounded `blocktxn` payload cap metadata.
- Decode `blocktxn` runtime payloads with per-transaction WTXIDs while preserving the old payload decoder shape.
- Split static post-handshake payload cap helpers.
- Keep live `cmpctblock` / `getblocktxn` / `blocktxn` peer caps closed until handler PRs wire dispatch.

Tests:
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node/p2p -run "BlockTxn|PayloadCap|Compact.*Gate|RuntimePayload"'`
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node/p2p'`
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go vet ./node/p2p'`
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && TOOLING_GO_RACE=1 go test -race ./node/p2p -run "BlockTxn|PayloadCap|Compact.*Gate|RuntimePayload"'`
- `git diff --check`
- `rubin-precommit-one-review --repo /Users/gpt/Documents/rubin-protocol-codex-RUB-328 --base-ref origin/main --include-base-diff`
- `scripts/dev-env.sh -- ./scripts/preflight-codacy-coverage.sh` — PASS, diff coverage 100.00%, variation +0.02% in push gate.

Behavior impact:
No live getblocktxn/blocktxn flow is enabled in this slice. Live compact object commands remain rejected by peer runtime caps until handler slices exist.

Known non-goals:
- No `handleCmpctBlock` / `handleGetBlockTxn` / `handleBlockTxn` live flow.
- No full-block fallback, timeout cleanup, late reply handling, or expiry behavior.
- No `handlers_compact_test.go` matrix changes.

Linear: RUB-328
