### PR TITLE
[RUB-332] Prepare compact receive state

### DIFF
--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -22,7 +22,7 @@ func reconstructCompactBlock(p cmpctBlockPayload, localTxs [][]byte) (compactRec
 	if err != nil {
 		return compactReconstructionResult{}, err
 	}
-	prefilledShortIDs, prefilledTxBytes, err := compactPrefilledShortIDs(p.Prefilled, totalEntries, p.Nonce1, p.Nonce2)
+	prefilledShortIDs, _, err := compactPrefilledShortIDs(p.Prefilled, totalEntries, p.Nonce1, p.Nonce2)
 	if err != nil {
 		return compactReconstructionResult{}, err
 	}
@@ -44,7 +44,6 @@ func reconstructCompactBlock(p cmpctBlockPayload, localTxs [][]byte) (compactRec
 		p.Prefilled,
 		p.ShortIDs,
 		index,
-		prefilledTxBytes,
 		prefilledShortIDs,
 	)
 	if overflow {
@@ -104,7 +103,8 @@ func compactFillPrefilledTransactions(txs [][]byte, prefilled []prefilledTxn) {
 }
 
 func compactFillShortIDTransactions(txs [][]byte, totalEntries int, prefilled []prefilledTxn, shortIDs []compactShortID, index map[compactShortID][]byte, totalTxBytes uint64) error {
-	missing, _, overflow, err := compactFillOrCollectMissing(txs, totalEntries, prefilled, shortIDs, index, totalTxBytes, nil)
+	staged := cloneCompactTransactions(txs)
+	missing, _, overflow, err := compactFillOrCollectMissing(staged, totalEntries, prefilled, shortIDs, index, nil)
 	if overflow {
 		return errCompactRelayMissingRequestTooLarge
 	}
@@ -114,10 +114,14 @@ func compactFillShortIDTransactions(txs [][]byte, totalEntries int, prefilled []
 	if len(missing) > 0 {
 		return errors.New("compact block transaction missing")
 	}
+	if err := compactValidatePresentTransactionsFrom(staged, true, totalTxBytes); err != nil {
+		return err
+	}
+	copy(txs, staged)
 	return nil
 }
 
-func compactFillOrCollectMissing(txs [][]byte, totalEntries int, prefilled []prefilledTxn, shortIDs []compactShortID, index map[compactShortID][]byte, totalTxBytes uint64, blocked map[compactShortID]bool) ([]uint64, []compactShortID, bool, error) {
+func compactFillOrCollectMissing(txs [][]byte, totalEntries int, prefilled []prefilledTxn, shortIDs []compactShortID, index map[compactShortID][]byte, blocked map[compactShortID]bool) ([]uint64, []compactShortID, bool, error) {
 	missing := make([]uint64, 0)
 	missingShortIDs := make([]compactShortID, 0)
 	firstHit := make(map[compactShortID]uint64)
@@ -150,13 +154,11 @@ func compactFillOrCollectMissing(txs [][]byte, totalEntries int, prefilled []pre
 			continue
 		}
 		firstHit[shortID] = uint64(absoluteIndex)
-		nextTotal, err := validateBlockTxnTransactionSize(uint64(len(tx)), totalTxBytes)
-		if err != nil {
-			return nil, nil, false, err
-		}
 		txs[absoluteIndex] = append([]byte(nil), tx...)
-		totalTxBytes = nextTotal
 		shortPos++
+	}
+	if err := compactValidatePresentTransactions(txs, false); err != nil {
+		return nil, nil, false, err
 	}
 	return missing, missingShortIDs, false, nil
 }
@@ -234,7 +236,31 @@ func compactFillResponseTransactions(req compactOutstandingRequest, responseTxs 
 		}
 		txs[int(idx)] = append([]byte(nil), tx...) // #nosec G115 -- idx is bounded by len(txs) above.
 	}
+	if err := compactValidatePresentTransactions(txs, true); err != nil {
+		return nil, err
+	}
 	return txs, nil
+}
+
+func compactValidatePresentTransactions(txs [][]byte, requireComplete bool) error {
+	return compactValidatePresentTransactionsFrom(txs, requireComplete, 0)
+}
+
+func compactValidatePresentTransactionsFrom(txs [][]byte, requireComplete bool, totalTxBytes uint64) error {
+	for _, tx := range txs {
+		if tx == nil {
+			if requireComplete {
+				return errors.New("compact block transaction missing")
+			}
+			continue
+		}
+		nextTotal, err := validateBlockTxnTransactionSize(uint64(len(tx)), totalTxBytes)
+		if err != nil {
+			return err
+		}
+		totalTxBytes = nextTotal
+	}
+	return nil
 }
 
 func cloneCompactTransactions(txs [][]byte) [][]byte {

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -103,7 +103,7 @@ func compactFillPrefilledTransactions(txs [][]byte, prefilled []prefilledTxn) {
 }
 
 func compactFillShortIDTransactions(txs [][]byte, totalEntries int, prefilled []prefilledTxn, shortIDs []compactShortID, index map[compactShortID][]byte) error {
-	staged := cloneCompactTransactions(txs)
+	staged := append([][]byte(nil), txs...)
 	missing, _, overflow, err := compactFillOrCollectMissing(staged, totalEntries, prefilled, shortIDs, index, nil)
 	if overflow {
 		return errCompactRelayMissingRequestTooLarge

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -258,22 +258,44 @@ func compactFillResponseTransactions(req compactOutstandingRequest, responseTxs 
 	if len(req.MissingIndexes) != len(req.MissingShortIDs) || len(responseTxs) != len(req.MissingIndexes) || len(responseWTxIDs) != len(responseTxs) {
 		return nil, errors.New("blocktxn transaction count mismatch")
 	}
-	txs := cloneCompactTransactions(req.Transactions)
+	txs := append([][]byte(nil), req.Transactions...)
 	for i, tx := range responseTxs {
-		shortID := compactShortID(consensus.CompactShortID(responseWTxIDs[i], req.Nonce1, req.Nonce2))
-		if shortID != req.MissingShortIDs[i] {
-			return nil, errors.New("blocktxn transaction short id mismatch")
-		}
 		idx := req.MissingIndexes[i]
 		if idx >= uint64(len(txs)) {
 			return nil, errors.New("compact relay index out of range")
 		}
-		txs[int(idx)] = append([]byte(nil), tx...) // #nosec G115 -- idx is bounded by len(txs) above.
+		txs[int(idx)] = tx // #nosec G115 -- idx is bounded by len(txs) above.
 	}
 	if err := compactValidatePresentTransactions(txs, true); err != nil {
 		return nil, err
 	}
+	for i, tx := range responseTxs {
+		wtxid, err := compactBlockTxnResponseWTxID(tx)
+		if err != nil {
+			return nil, err
+		}
+		if wtxid != responseWTxIDs[i] {
+			return nil, errors.New("blocktxn transaction wtxid mismatch")
+		}
+		shortID := compactShortID(consensus.CompactShortID(wtxid, req.Nonce1, req.Nonce2))
+		if shortID != req.MissingShortIDs[i] {
+			return nil, errors.New("blocktxn transaction short id mismatch")
+		}
+	}
+	cloneCompactTransactionsInPlace(txs)
 	return txs, nil
+}
+
+func compactBlockTxnResponseWTxID(tx []byte) ([32]byte, error) {
+	var zero [32]byte
+	if _, err := validateBlockTxnTransactionSize(uint64(len(tx)), 0); err != nil {
+		return zero, err
+	}
+	_, _, wtxid, consumed, err := consensus.ParseTx(tx)
+	if err != nil || consumed != len(tx) {
+		return zero, errors.New("blocktxn transaction is non-canonical")
+	}
+	return wtxid, nil
 }
 
 func compactValidatePresentTransactions(txs [][]byte, requireComplete bool) error {

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -126,14 +126,10 @@ type compactFillContext struct {
 	missing         []uint64
 	missingShortIDs []compactShortID
 	firstHit        map[compactShortID]uint64
-	totalTxBytes    uint64
 }
 
 func compactFillOrCollectMissing(txs [][]byte, totalEntries int, prefilled []prefilledTxn, shortIDs []compactShortID, index map[compactShortID][]byte, blocked map[compactShortID]bool) ([]uint64, []compactShortID, bool, error) {
-	ctx, err := newCompactFillContext(txs)
-	if err != nil {
-		return nil, nil, false, err
-	}
+	ctx := newCompactFillContext(txs)
 	shortPos, prefilledPos := 0, 0
 	for absoluteIndex := 0; absoluteIndex < totalEntries && shortPos < len(shortIDs); absoluteIndex++ {
 		if compactIndexIsPrefilled(uint64(absoluteIndex), prefilled, &prefilledPos) {
@@ -146,22 +142,20 @@ func compactFillOrCollectMissing(txs [][]byte, totalEntries int, prefilled []pre
 		}
 		shortPos++
 	}
+	if err := compactValidatePresentTransactions(txs, false); err != nil {
+		return nil, nil, false, err
+	}
 	cloneCompactTransactionsInPlace(txs)
 	return ctx.missing, ctx.missingShortIDs, false, nil
 }
 
-func newCompactFillContext(txs [][]byte) (*compactFillContext, error) {
-	totalTxBytes, err := compactPresentTransactionBytes(txs)
-	if err != nil {
-		return nil, err
-	}
+func newCompactFillContext(txs [][]byte) *compactFillContext {
 	return &compactFillContext{
 		txs:             txs,
 		missing:         make([]uint64, 0),
 		missingShortIDs: make([]compactShortID, 0),
 		firstHit:        make(map[compactShortID]uint64),
-		totalTxBytes:    totalTxBytes,
-	}, nil
+	}
 }
 
 func (c *compactFillContext) fill(absoluteIndex uint64, shortID compactShortID, tx []byte, blocked bool) (bool, error) {
@@ -171,12 +165,7 @@ func (c *compactFillContext) fill(absoluteIndex uint64, shortID compactShortID, 
 	if firstIndex, ok := c.firstHit[shortID]; ok {
 		return c.handleDuplicate(firstIndex, absoluteIndex, shortID), nil
 	}
-	nextTotal, err := validateBlockTxnTransactionSize(uint64(len(tx)), c.totalTxBytes)
-	if err != nil {
-		return false, err
-	}
 	c.firstHit[shortID] = absoluteIndex
-	c.totalTxBytes = nextTotal
 	c.txs[int(absoluteIndex)] = tx // #nosec G115 -- absoluteIndex is bounded by totalEntries.
 	return false, nil
 }
@@ -187,8 +176,6 @@ func compactShortIDUnavailable(tx []byte, blocked bool) bool {
 
 func (c *compactFillContext) handleDuplicate(firstIndex uint64, absoluteIndex uint64, shortID compactShortID) bool {
 	if firstIndex != compactDuplicateReportedIndex {
-		firstTx := c.txs[int(firstIndex)] // #nosec G115 -- firstIndex was produced by the bounded fill loop.
-		c.totalTxBytes -= uint64(len(firstTx))
 		c.txs[int(firstIndex)] = nil // #nosec G115 -- firstIndex was produced by the bounded fill loop.
 		c.firstHit[shortID] = compactDuplicateReportedIndex
 		if c.appendMissing(firstIndex, shortID) {

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -102,7 +102,7 @@ func compactFillPrefilledTransactions(txs [][]byte, prefilled []prefilledTxn) {
 	}
 }
 
-func compactFillShortIDTransactions(txs [][]byte, totalEntries int, prefilled []prefilledTxn, shortIDs []compactShortID, index map[compactShortID][]byte, totalTxBytes uint64) error {
+func compactFillShortIDTransactions(txs [][]byte, totalEntries int, prefilled []prefilledTxn, shortIDs []compactShortID, index map[compactShortID][]byte, _ uint64) error {
 	staged := cloneCompactTransactions(txs)
 	missing, _, overflow, err := compactFillOrCollectMissing(staged, totalEntries, prefilled, shortIDs, index, nil)
 	if overflow {
@@ -114,7 +114,7 @@ func compactFillShortIDTransactions(txs [][]byte, totalEntries int, prefilled []
 	if len(missing) > 0 {
 		return errors.New("compact block transaction missing")
 	}
-	if err := compactValidatePresentTransactionsFrom(staged, true, totalTxBytes); err != nil {
+	if err := compactValidatePresentTransactions(staged, true); err != nil {
 		return err
 	}
 	copy(txs, staged)

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -11,8 +11,10 @@ const compactDuplicateReportedIndex = ^uint64(0)
 var errCompactRelayMissingRequestTooLarge = errors.New("too many compact relay missing transactions")
 
 type compactReconstructionResult struct {
-	Transactions   [][]byte
-	MissingIndexes []uint64
+	Transactions        [][]byte
+	PartialTransactions [][]byte
+	MissingIndexes      []uint64
+	MissingShortIDs     []compactShortID
 }
 
 func reconstructCompactBlock(p cmpctBlockPayload, localTxs [][]byte) (compactReconstructionResult, error) {
@@ -34,17 +36,29 @@ func reconstructCompactBlock(p cmpctBlockPayload, localTxs [][]byte) (compactRec
 		return compactReconstructionResult{}, err
 	}
 
-	missing, overflow := compactMissingShortIDIndexes(totalEntries, p.Prefilled, p.ShortIDs, index, prefilledShortIDs)
+	txs := make([][]byte, totalEntries)
+	compactFillPrefilledTransactions(txs, p.Prefilled)
+	missing, missingShortIDs, overflow, err := compactFillOrCollectMissing(
+		txs,
+		totalEntries,
+		p.Prefilled,
+		p.ShortIDs,
+		index,
+		prefilledTxBytes,
+		prefilledShortIDs,
+	)
 	if overflow {
 		return compactReconstructionResult{}, errCompactRelayMissingRequestTooLarge
 	}
-	if len(missing) > 0 {
-		return compactReconstructionResult{MissingIndexes: missing}, nil
-	}
-	txs := make([][]byte, totalEntries)
-	compactFillPrefilledTransactions(txs, p.Prefilled)
-	if err := compactFillShortIDTransactions(txs, totalEntries, p.Prefilled, p.ShortIDs, index, prefilledTxBytes); err != nil {
+	if err != nil {
 		return compactReconstructionResult{}, err
+	}
+	if len(missing) > 0 {
+		return compactReconstructionResult{
+			PartialTransactions: txs,
+			MissingIndexes:      missing,
+			MissingShortIDs:     missingShortIDs,
+		}, nil
 	}
 	return compactReconstructionResult{Transactions: txs}, nil
 }
@@ -90,25 +104,22 @@ func compactFillPrefilledTransactions(txs [][]byte, prefilled []prefilledTxn) {
 }
 
 func compactFillShortIDTransactions(txs [][]byte, totalEntries int, prefilled []prefilledTxn, shortIDs []compactShortID, index map[compactShortID][]byte, totalTxBytes uint64) error {
-	shortPos, prefilledPos := 0, 0
-	for absoluteIndex := 0; absoluteIndex < totalEntries && shortPos < len(shortIDs); absoluteIndex++ {
-		if compactIndexIsPrefilled(uint64(absoluteIndex), prefilled, &prefilledPos) {
-			continue
-		}
-		tx := index[shortIDs[shortPos]]
-		nextTotal, err := validateBlockTxnTransactionSize(uint64(len(tx)), totalTxBytes)
-		if err != nil {
-			return err
-		}
-		txs[absoluteIndex] = append([]byte(nil), tx...)
-		totalTxBytes = nextTotal
-		shortPos++
+	missing, _, overflow, err := compactFillOrCollectMissing(txs, totalEntries, prefilled, shortIDs, index, totalTxBytes, nil)
+	if overflow {
+		return errCompactRelayMissingRequestTooLarge
+	}
+	if err != nil {
+		return err
+	}
+	if len(missing) > 0 {
+		return errors.New("compact block transaction missing")
 	}
 	return nil
 }
 
-func compactMissingShortIDIndexes(totalEntries int, prefilled []prefilledTxn, shortIDs []compactShortID, index map[compactShortID][]byte, blocked map[compactShortID]bool) ([]uint64, bool) {
+func compactFillOrCollectMissing(txs [][]byte, totalEntries int, prefilled []prefilledTxn, shortIDs []compactShortID, index map[compactShortID][]byte, totalTxBytes uint64, blocked map[compactShortID]bool) ([]uint64, []compactShortID, bool, error) {
 	missing := make([]uint64, 0)
+	missingShortIDs := make([]compactShortID, 0)
 	firstHit := make(map[compactShortID]uint64)
 	shortPos, prefilledPos := 0, 0
 	for absoluteIndex := 0; absoluteIndex < totalEntries && shortPos < len(shortIDs); absoluteIndex++ {
@@ -116,13 +127,42 @@ func compactMissingShortIDIndexes(totalEntries int, prefilled []prefilledTxn, sh
 			continue
 		}
 		shortID := shortIDs[shortPos]
-		missing = compactAppendMissingIndex(missing, firstHit, shortID, uint64(absoluteIndex), index[shortID], blocked[shortID])
-		if len(missing) > maxCompactRelayEntries {
-			return missing[:maxCompactRelayEntries], true
+		tx := index[shortID]
+		if tx == nil || blocked[shortID] {
+			missing, missingShortIDs = compactAppendMissing(missing, missingShortIDs, uint64(absoluteIndex), shortID)
+			if len(missing) > maxCompactRelayEntries {
+				return missing, missingShortIDs, true, nil
+			}
+			shortPos++
+			continue
 		}
+		if firstIndex, ok := firstHit[shortID]; ok {
+			if firstIndex != compactDuplicateReportedIndex {
+				missing, missingShortIDs = compactAppendMissing(missing, missingShortIDs, firstIndex, shortID)
+				txs[int(firstIndex)] = nil // #nosec G115 -- firstIndex was produced by this bounded loop.
+				firstHit[shortID] = compactDuplicateReportedIndex
+			}
+			missing, missingShortIDs = compactAppendMissing(missing, missingShortIDs, uint64(absoluteIndex), shortID)
+			if len(missing) > maxCompactRelayEntries {
+				return missing, missingShortIDs, true, nil
+			}
+			shortPos++
+			continue
+		}
+		firstHit[shortID] = uint64(absoluteIndex)
+		nextTotal, err := validateBlockTxnTransactionSize(uint64(len(tx)), totalTxBytes)
+		if err != nil {
+			return nil, nil, false, err
+		}
+		txs[absoluteIndex] = append([]byte(nil), tx...)
+		totalTxBytes = nextTotal
 		shortPos++
 	}
-	return missing, false
+	return missing, missingShortIDs, false, nil
+}
+
+func compactAppendMissing(missing []uint64, missingShortIDs []compactShortID, absoluteIndex uint64, shortID compactShortID) ([]uint64, []compactShortID) {
+	return append(missing, absoluteIndex), append(missingShortIDs, shortID)
 }
 
 func compactIndexIsPrefilled(index uint64, prefilled []prefilledTxn, pos *int) bool {
@@ -131,21 +171,6 @@ func compactIndexIsPrefilled(index uint64, prefilled []prefilledTxn, pos *int) b
 		return true
 	}
 	return false
-}
-
-func compactAppendMissingIndex(missing []uint64, firstHit map[compactShortID]uint64, shortID compactShortID, absoluteIndex uint64, tx []byte, blocked bool) []uint64 {
-	if tx == nil || blocked {
-		return append(missing, absoluteIndex)
-	}
-	if firstIndex, ok := firstHit[shortID]; ok {
-		if firstIndex != compactDuplicateReportedIndex {
-			missing = append(missing, firstIndex)
-			firstHit[shortID] = compactDuplicateReportedIndex
-		}
-		return append(missing, absoluteIndex)
-	}
-	firstHit[shortID] = absoluteIndex
-	return missing
 }
 
 func compactLocalTxIndex(localTxs [][]byte, nonce1, nonce2 uint64) (map[compactShortID][]byte, error) {
@@ -175,4 +200,52 @@ func compactLocalTxWTxID(tx []byte) ([32]byte, error) {
 		return zero, errors.New("compact local transaction is non-canonical")
 	}
 	return wtxid, nil
+}
+
+func newCompactOutstandingRequest(block cmpctBlockPayload, blockHash [32]byte, result compactReconstructionResult) (compactOutstandingRequest, error) {
+	if len(result.MissingIndexes) == 0 || len(result.MissingIndexes) != len(result.MissingShortIDs) {
+		return compactOutstandingRequest{}, errors.New("compact reconstruction missing request mismatch")
+	}
+	return compactOutstandingRequest{
+		BlockHash:          blockHash,
+		Header:             block.Header,
+		MissingIndexes:     append([]uint64(nil), result.MissingIndexes...),
+		MissingShortIDs:    append([]compactShortID(nil), result.MissingShortIDs...),
+		Transactions:       cloneCompactTransactions(result.PartialTransactions),
+		Nonce1:             block.Nonce1,
+		Nonce2:             block.Nonce2,
+		BlockTxnPayloadCap: compactRelayPayloadCap(messageBlockTxn),
+	}, nil
+}
+
+func compactFillResponseTransactions(req compactOutstandingRequest, responseTxs [][]byte, responseWTxIDs [][32]byte) ([][]byte, error) {
+	if len(req.MissingIndexes) != len(req.MissingShortIDs) || len(responseTxs) != len(req.MissingIndexes) || len(responseWTxIDs) != len(responseTxs) {
+		return nil, errors.New("blocktxn transaction count mismatch")
+	}
+	txs := cloneCompactTransactions(req.Transactions)
+	for i, tx := range responseTxs {
+		shortID := compactShortID(consensus.CompactShortID(responseWTxIDs[i], req.Nonce1, req.Nonce2))
+		if shortID != req.MissingShortIDs[i] {
+			return nil, errors.New("blocktxn transaction short id mismatch")
+		}
+		idx := req.MissingIndexes[i]
+		if idx >= uint64(len(txs)) {
+			return nil, errors.New("compact relay index out of range")
+		}
+		txs[int(idx)] = append([]byte(nil), tx...) // #nosec G115 -- idx is bounded by len(txs) above.
+	}
+	return txs, nil
+}
+
+func cloneCompactTransactions(txs [][]byte) [][]byte {
+	if txs == nil {
+		return nil
+	}
+	out := make([][]byte, len(txs))
+	for i, tx := range txs {
+		if tx != nil {
+			out[i] = append([]byte(nil), tx...)
+		}
+	}
+	return out
 }

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -300,7 +300,11 @@ func compactBlockTxnResponsePayloadCap(partial [][]byte, missingCount int) (uint
 	return uint32(capBytes), nil
 }
 
-func compactFillResponseTransactions(req compactOutstandingRequest, responseTxs [][]byte, responseWTxIDs [][32]byte) ([][]byte, error) {
+func compactFillResponseTransactions(req compactOutstandingRequest, response blockTxnRuntimePayload) ([][]byte, error) {
+	if response.BlockHash != req.BlockHash {
+		return nil, errors.New("blocktxn block hash mismatch")
+	}
+	responseTxs, responseWTxIDs := response.Transactions, response.WTxIDs
 	if len(req.MissingIndexes) != len(req.MissingShortIDs) || len(responseTxs) != len(req.MissingIndexes) || len(responseWTxIDs) != len(responseTxs) {
 		return nil, errors.New("blocktxn transaction count mismatch")
 	}

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -102,7 +102,7 @@ func compactFillPrefilledTransactions(txs [][]byte, prefilled []prefilledTxn) {
 	}
 }
 
-func compactFillShortIDTransactions(txs [][]byte, totalEntries int, prefilled []prefilledTxn, shortIDs []compactShortID, index map[compactShortID][]byte, _ uint64) error {
+func compactFillShortIDTransactions(txs [][]byte, totalEntries int, prefilled []prefilledTxn, shortIDs []compactShortID, index map[compactShortID][]byte) error {
 	staged := cloneCompactTransactions(txs)
 	missing, _, overflow, err := compactFillOrCollectMissing(staged, totalEntries, prefilled, shortIDs, index, nil)
 	if overflow {
@@ -121,46 +121,86 @@ func compactFillShortIDTransactions(txs [][]byte, totalEntries int, prefilled []
 	return nil
 }
 
+type compactFillContext struct {
+	txs             [][]byte
+	missing         []uint64
+	missingShortIDs []compactShortID
+	firstHit        map[compactShortID]uint64
+	totalTxBytes    uint64
+}
+
 func compactFillOrCollectMissing(txs [][]byte, totalEntries int, prefilled []prefilledTxn, shortIDs []compactShortID, index map[compactShortID][]byte, blocked map[compactShortID]bool) ([]uint64, []compactShortID, bool, error) {
-	missing := make([]uint64, 0)
-	missingShortIDs := make([]compactShortID, 0)
-	firstHit := make(map[compactShortID]uint64)
+	ctx, err := newCompactFillContext(txs)
+	if err != nil {
+		return nil, nil, false, err
+	}
 	shortPos, prefilledPos := 0, 0
 	for absoluteIndex := 0; absoluteIndex < totalEntries && shortPos < len(shortIDs); absoluteIndex++ {
 		if compactIndexIsPrefilled(uint64(absoluteIndex), prefilled, &prefilledPos) {
 			continue
 		}
 		shortID := shortIDs[shortPos]
-		tx := index[shortID]
-		if tx == nil || blocked[shortID] {
-			missing, missingShortIDs = compactAppendMissing(missing, missingShortIDs, uint64(absoluteIndex), shortID)
-			if len(missing) > maxCompactRelayEntries {
-				return missing, missingShortIDs, true, nil
-			}
-			shortPos++
-			continue
+		overflow, err := ctx.fill(uint64(absoluteIndex), shortID, index[shortID], blocked[shortID])
+		if overflow || err != nil {
+			return ctx.missing, ctx.missingShortIDs, overflow, err
 		}
-		if firstIndex, ok := firstHit[shortID]; ok {
-			if firstIndex != compactDuplicateReportedIndex {
-				missing, missingShortIDs = compactAppendMissing(missing, missingShortIDs, firstIndex, shortID)
-				txs[int(firstIndex)] = nil // #nosec G115 -- firstIndex was produced by this bounded loop.
-				firstHit[shortID] = compactDuplicateReportedIndex
-			}
-			missing, missingShortIDs = compactAppendMissing(missing, missingShortIDs, uint64(absoluteIndex), shortID)
-			if len(missing) > maxCompactRelayEntries {
-				return missing, missingShortIDs, true, nil
-			}
-			shortPos++
-			continue
-		}
-		firstHit[shortID] = uint64(absoluteIndex)
-		txs[absoluteIndex] = append([]byte(nil), tx...)
 		shortPos++
 	}
-	if err := compactValidatePresentTransactions(txs, false); err != nil {
-		return nil, nil, false, err
+	cloneCompactTransactionsInPlace(txs)
+	return ctx.missing, ctx.missingShortIDs, false, nil
+}
+
+func newCompactFillContext(txs [][]byte) (*compactFillContext, error) {
+	totalTxBytes, err := compactPresentTransactionBytes(txs)
+	if err != nil {
+		return nil, err
 	}
-	return missing, missingShortIDs, false, nil
+	return &compactFillContext{
+		txs:             txs,
+		missing:         make([]uint64, 0),
+		missingShortIDs: make([]compactShortID, 0),
+		firstHit:        make(map[compactShortID]uint64),
+		totalTxBytes:    totalTxBytes,
+	}, nil
+}
+
+func (c *compactFillContext) fill(absoluteIndex uint64, shortID compactShortID, tx []byte, blocked bool) (bool, error) {
+	if compactShortIDUnavailable(tx, blocked) {
+		return c.appendMissing(absoluteIndex, shortID), nil
+	}
+	if firstIndex, ok := c.firstHit[shortID]; ok {
+		return c.handleDuplicate(firstIndex, absoluteIndex, shortID), nil
+	}
+	nextTotal, err := validateBlockTxnTransactionSize(uint64(len(tx)), c.totalTxBytes)
+	if err != nil {
+		return false, err
+	}
+	c.firstHit[shortID] = absoluteIndex
+	c.totalTxBytes = nextTotal
+	c.txs[int(absoluteIndex)] = tx // #nosec G115 -- absoluteIndex is bounded by totalEntries.
+	return false, nil
+}
+
+func compactShortIDUnavailable(tx []byte, blocked bool) bool {
+	return tx == nil || blocked
+}
+
+func (c *compactFillContext) handleDuplicate(firstIndex uint64, absoluteIndex uint64, shortID compactShortID) bool {
+	if firstIndex != compactDuplicateReportedIndex {
+		firstTx := c.txs[int(firstIndex)] // #nosec G115 -- firstIndex was produced by the bounded fill loop.
+		c.totalTxBytes -= uint64(len(firstTx))
+		c.txs[int(firstIndex)] = nil // #nosec G115 -- firstIndex was produced by the bounded fill loop.
+		c.firstHit[shortID] = compactDuplicateReportedIndex
+		if c.appendMissing(firstIndex, shortID) {
+			return true
+		}
+	}
+	return c.appendMissing(absoluteIndex, shortID)
+}
+
+func (c *compactFillContext) appendMissing(absoluteIndex uint64, shortID compactShortID) bool {
+	c.missing, c.missingShortIDs = compactAppendMissing(c.missing, c.missingShortIDs, absoluteIndex, shortID)
+	return len(c.missing) > maxCompactRelayEntries
 }
 
 func compactAppendMissing(missing []uint64, missingShortIDs []compactShortID, absoluteIndex uint64, shortID compactShortID) ([]uint64, []compactShortID) {
@@ -247,20 +287,29 @@ func compactValidatePresentTransactions(txs [][]byte, requireComplete bool) erro
 }
 
 func compactValidatePresentTransactionsFrom(txs [][]byte, requireComplete bool, totalTxBytes uint64) error {
+	_, err := compactPresentTransactionBytesFrom(txs, requireComplete, totalTxBytes)
+	return err
+}
+
+func compactPresentTransactionBytes(txs [][]byte) (uint64, error) {
+	return compactPresentTransactionBytesFrom(txs, false, 0)
+}
+
+func compactPresentTransactionBytesFrom(txs [][]byte, requireComplete bool, totalTxBytes uint64) (uint64, error) {
 	for _, tx := range txs {
 		if tx == nil {
 			if requireComplete {
-				return errors.New("compact block transaction missing")
+				return 0, errors.New("compact block transaction missing")
 			}
 			continue
 		}
 		nextTotal, err := validateBlockTxnTransactionSize(uint64(len(tx)), totalTxBytes)
 		if err != nil {
-			return err
+			return 0, err
 		}
 		totalTxBytes = nextTotal
 	}
-	return nil
+	return totalTxBytes, nil
 }
 
 func cloneCompactTransactions(txs [][]byte) [][]byte {
@@ -274,4 +323,12 @@ func cloneCompactTransactions(txs [][]byte) [][]byte {
 		}
 	}
 	return out
+}
+
+func cloneCompactTransactionsInPlace(txs [][]byte) {
+	for i, tx := range txs {
+		if tx != nil {
+			txs[i] = append([]byte(nil), tx...)
+		}
+	}
 }

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -37,7 +37,7 @@ func reconstructCompactBlock(p cmpctBlockPayload, localTxs [][]byte) (compactRec
 	}
 
 	txs := make([][]byte, totalEntries)
-	compactFillPrefilledTransactions(txs, p.Prefilled)
+	compactStagePrefilledTransactions(txs, p.Prefilled)
 	missing, missingShortIDs, overflow, err := compactFillOrCollectMissing(
 		txs,
 		totalEntries,
@@ -99,6 +99,12 @@ func compactPrefilledShortIDs(prefilled []prefilledTxn, totalEntries int, nonce1
 func compactFillPrefilledTransactions(txs [][]byte, prefilled []prefilledTxn) {
 	for _, entry := range prefilled {
 		txs[int(entry.Index)] = append([]byte(nil), entry.Tx...) // #nosec G115 -- compactPrefilledShortIDs bounds-checks prefilled indexes.
+	}
+}
+
+func compactStagePrefilledTransactions(txs [][]byte, prefilled []prefilledTxn) {
+	for _, entry := range prefilled {
+		txs[int(entry.Index)] = entry.Tx // #nosec G115 -- compactPrefilledShortIDs bounds-checks prefilled indexes.
 	}
 }
 
@@ -235,12 +241,13 @@ func newCompactOutstandingRequest(block cmpctBlockPayload, blockHash [32]byte, r
 	if len(result.MissingIndexes) == 0 || len(result.MissingIndexes) != len(result.MissingShortIDs) {
 		return compactOutstandingRequest{}, errors.New("compact reconstruction missing request mismatch")
 	}
+	// Take ownership of reconstruction slices; peer state clones at the mutex boundary.
 	return compactOutstandingRequest{
 		BlockHash:          blockHash,
 		Header:             block.Header,
-		MissingIndexes:     append([]uint64(nil), result.MissingIndexes...),
-		MissingShortIDs:    append([]compactShortID(nil), result.MissingShortIDs...),
-		Transactions:       cloneCompactTransactions(result.PartialTransactions),
+		MissingIndexes:     result.MissingIndexes,
+		MissingShortIDs:    result.MissingShortIDs,
+		Transactions:       result.PartialTransactions,
 		Nonce1:             block.Nonce1,
 		Nonce2:             block.Nonce2,
 		BlockTxnPayloadCap: compactRelayPayloadCap(messageBlockTxn),

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -36,6 +36,11 @@ func reconstructCompactBlock(p cmpctBlockPayload, localTxs [][]byte) (compactRec
 		return compactReconstructionResult{}, err
 	}
 
+	if _, _, overflow, err := compactFillOrCollectMissing(nil, totalEntries, p.Prefilled, p.ShortIDs, index, prefilledShortIDs); overflow {
+		return compactReconstructionResult{}, errCompactRelayMissingRequestTooLarge
+	} else if err != nil {
+		return compactReconstructionResult{}, err
+	}
 	txs := make([][]byte, totalEntries)
 	compactStagePrefilledTransactions(txs, p.Prefilled)
 	missing, missingShortIDs, overflow, err := compactFillOrCollectMissing(
@@ -148,10 +153,12 @@ func compactFillOrCollectMissing(txs [][]byte, totalEntries int, prefilled []pre
 		}
 		shortPos++
 	}
-	if err := compactValidatePresentTransactions(txs, false); err != nil {
-		return nil, nil, false, err
+	if txs != nil {
+		if err := compactValidatePresentTransactions(txs, false); err != nil {
+			return nil, nil, false, err
+		}
+		cloneCompactTransactionsInPlace(txs)
 	}
-	cloneCompactTransactionsInPlace(txs)
 	return ctx.missing, ctx.missingShortIDs, false, nil
 }
 
@@ -172,7 +179,9 @@ func (c *compactFillContext) fill(absoluteIndex uint64, shortID compactShortID, 
 		return c.handleDuplicate(firstIndex, absoluteIndex, shortID), nil
 	}
 	c.firstHit[shortID] = absoluteIndex
-	c.txs[int(absoluteIndex)] = tx // #nosec G115 -- absoluteIndex is bounded by totalEntries.
+	if c.txs != nil {
+		c.txs[int(absoluteIndex)] = tx // #nosec G115 -- absoluteIndex is bounded by totalEntries.
+	}
 	return false, nil
 }
 
@@ -182,7 +191,9 @@ func compactShortIDUnavailable(tx []byte, blocked bool) bool {
 
 func (c *compactFillContext) handleDuplicate(firstIndex uint64, absoluteIndex uint64, shortID compactShortID) bool {
 	if firstIndex != compactDuplicateReportedIndex {
-		c.txs[int(firstIndex)] = nil // #nosec G115 -- firstIndex was produced by the bounded fill loop.
+		if c.txs != nil {
+			c.txs[int(firstIndex)] = nil // #nosec G115 -- firstIndex was produced by the bounded fill loop.
+		}
 		c.firstHit[shortID] = compactDuplicateReportedIndex
 		if c.appendMissing(firstIndex, shortID) {
 			return true
@@ -241,6 +252,13 @@ func newCompactOutstandingRequest(block cmpctBlockPayload, blockHash [32]byte, r
 	if len(result.MissingIndexes) == 0 || len(result.MissingIndexes) != len(result.MissingShortIDs) {
 		return compactOutstandingRequest{}, errors.New("compact reconstruction missing request mismatch")
 	}
+	if err := compactValidateOutstandingShape(result.PartialTransactions, result.MissingIndexes); err != nil {
+		return compactOutstandingRequest{}, err
+	}
+	payloadCap, err := compactBlockTxnResponsePayloadCap(result.PartialTransactions, len(result.MissingIndexes))
+	if err != nil {
+		return compactOutstandingRequest{}, err
+	}
 	// Take ownership of reconstruction slices; peer state clones at the mutex boundary.
 	return compactOutstandingRequest{
 		BlockHash:          blockHash,
@@ -250,8 +268,36 @@ func newCompactOutstandingRequest(block cmpctBlockPayload, blockHash [32]byte, r
 		Transactions:       result.PartialTransactions,
 		Nonce1:             block.Nonce1,
 		Nonce2:             block.Nonce2,
-		BlockTxnPayloadCap: compactRelayPayloadCap(messageBlockTxn),
+		BlockTxnPayloadCap: payloadCap,
 	}, nil
+}
+
+func compactValidateOutstandingShape(partial [][]byte, missing []uint64) error {
+	for _, idx := range missing {
+		if idx >= uint64(len(partial)) {
+			return errors.New("compact relay index out of range")
+		}
+		if partial[int(idx)] != nil { // #nosec G115 -- idx is bounded by len(partial) above.
+			return errors.New("compact reconstruction missing request mismatch")
+		}
+	}
+	return nil
+}
+
+func compactBlockTxnResponsePayloadCap(partial [][]byte, missingCount int) (uint32, error) {
+	if missingCount <= 0 || missingCount > maxCompactRelayEntries {
+		return 0, errors.New("compact reconstruction missing request mismatch")
+	}
+	presentBytes, err := compactPresentTransactionBytes(partial)
+	if err != nil {
+		return 0, err
+	}
+	remainingBytes := uint64(consensus.MAX_BLOCK_BYTES) - presentBytes
+	capBytes := uint64(32+len(consensus.EncodeCompactSize(uint64(missingCount)))) + remainingBytes + uint64(missingCount)*maxCompactSizeBytes
+	if capBytes > uint64(compactRelayPayloadCap(messageBlockTxn)) {
+		return 0, errors.New("blocktxn payload cap overflow")
+	}
+	return uint32(capBytes), nil
 }
 
 func compactFillResponseTransactions(req compactOutstandingRequest, responseTxs [][]byte, responseWTxIDs [][32]byte) ([][]byte, error) {

--- a/clients/go/node/p2p/compact_reconstruct_test.go
+++ b/clients/go/node/p2p/compact_reconstruct_test.go
@@ -367,17 +367,20 @@ func TestCompactBlockTxnResponsePayloadCapUsesRemainingBudget(t *testing.T) {
 }
 
 func TestCompactFillResponseTransactionsValidatesExpectedShortIDs(t *testing.T) {
+	blockHash := [32]byte{0x71}
 	nonce1, nonce2 := uint64(71), uint64(72)
 	tx1 := minimalBlockTxnTestTxBytes(73)
 	tx2 := minimalBlockTxnTestTxBytes(74)
 	req := compactOutstandingRequest{
+		BlockHash:       blockHash,
 		Transactions:    [][]byte{nil, tx2},
 		MissingIndexes:  []uint64{0},
 		MissingShortIDs: []compactShortID{compactShortIDForTx(t, tx1, nonce1, nonce2)},
 		Nonce1:          nonce1,
 		Nonce2:          nonce2,
 	}
-	filled, err := compactFillResponseTransactions(req, [][]byte{tx1}, [][32]byte{compactWTxIDForTx(t, tx1)})
+	response := blockTxnRuntimePayload{BlockHash: blockHash, Transactions: [][]byte{tx1}, WTxIDs: [][32]byte{compactWTxIDForTx(t, tx1)}}
+	filled, err := compactFillResponseTransactions(req, response)
 	if err != nil {
 		t.Fatalf("compactFillResponseTransactions: %v", err)
 	}
@@ -385,11 +388,18 @@ func TestCompactFillResponseTransactionsValidatesExpectedShortIDs(t *testing.T) 
 	if filled[0][0] == tx1[0] {
 		t.Fatal("filled blocktxn response aliases source bytes")
 	}
-	if _, err := compactFillResponseTransactions(req, [][]byte{tx2}, [][32]byte{compactWTxIDForTx(t, tx2)}); err == nil || !strings.Contains(err.Error(), "short id mismatch") {
+	wrongShortIDResponse := blockTxnRuntimePayload{BlockHash: blockHash, Transactions: [][]byte{tx2}, WTxIDs: [][32]byte{compactWTxIDForTx(t, tx2)}}
+	if _, err := compactFillResponseTransactions(req, wrongShortIDResponse); err == nil || !strings.Contains(err.Error(), "short id mismatch") {
 		t.Fatalf("wrong short ID err=%v, want short id mismatch", err)
 	}
-	if _, err := compactFillResponseTransactions(req, [][]byte{tx2}, [][32]byte{compactWTxIDForTx(t, filled[0])}); err == nil || !strings.Contains(err.Error(), "wtxid mismatch") {
+	mismatchedWTxIDResponse := blockTxnRuntimePayload{BlockHash: blockHash, Transactions: [][]byte{tx2}, WTxIDs: [][32]byte{compactWTxIDForTx(t, filled[0])}}
+	if _, err := compactFillResponseTransactions(req, mismatchedWTxIDResponse); err == nil || !strings.Contains(err.Error(), "wtxid mismatch") {
 		t.Fatalf("mismatched response wtxid err=%v, want wtxid mismatch", err)
+	}
+	wrongHashResponse := response
+	wrongHashResponse.BlockHash[0] ^= 0xff
+	if _, err := compactFillResponseTransactions(req, wrongHashResponse); err == nil || !strings.Contains(err.Error(), "block hash mismatch") {
+		t.Fatalf("wrong response block hash err=%v, want block hash mismatch", err)
 	}
 }
 
@@ -403,7 +413,7 @@ func TestCompactFillResponseTransactionsRejectsAggregateOversize(t *testing.T) {
 		Nonce1:          nonce1,
 		Nonce2:          nonce2,
 	}
-	_, err := compactFillResponseTransactions(req, [][]byte{{0x01}}, [][32]byte{wtxid})
+	_, err := compactFillResponseTransactions(req, blockTxnRuntimePayload{Transactions: [][]byte{{0x01}}, WTxIDs: [][32]byte{wtxid}})
 	if err == nil || !strings.Contains(err.Error(), "blocktxn transactions exceed block size") {
 		t.Fatalf("aggregate oversize err=%v, want block size rejection", err)
 	}

--- a/clients/go/node/p2p/compact_reconstruct_test.go
+++ b/clients/go/node/p2p/compact_reconstruct_test.go
@@ -324,7 +324,8 @@ func TestNewCompactOutstandingRequestBuildsPartialState(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newCompactOutstandingRequest: %v", err)
 	}
-	if req.BlockHash != blockHash || req.Header != block.Header || req.Nonce1 != block.Nonce1 || req.Nonce2 != block.Nonce2 || req.BlockTxnPayloadCap != compactRelayPayloadCap(messageBlockTxn) {
+	wantPayloadCap := uint32(32 + len(consensus.EncodeCompactSize(1)) + maxCompactSizeBytes + consensus.MAX_BLOCK_BYTES - len(tx))
+	if req.BlockHash != blockHash || req.Header != block.Header || req.Nonce1 != block.Nonce1 || req.Nonce2 != block.Nonce2 || req.BlockTxnPayloadCap != wantPayloadCap {
 		t.Fatalf("request metadata mismatch: %+v", req)
 	}
 	if !reflect.DeepEqual(req.MissingIndexes, []uint64{0}) || !reflect.DeepEqual(req.MissingShortIDs, []compactShortID{shortID}) || !reflect.DeepEqual(req.Transactions, [][]byte{nil, tx}) {
@@ -335,6 +336,33 @@ func TestNewCompactOutstandingRequestBuildsPartialState(t *testing.T) {
 	}
 	if _, err := newCompactOutstandingRequest(block, blockHash, compactReconstructionResult{MissingIndexes: []uint64{0}}); err == nil {
 		t.Fatal("mismatched missing short-id request should fail")
+	}
+	if _, err := newCompactOutstandingRequest(block, blockHash, compactReconstructionResult{PartialTransactions: [][]byte{tx}, MissingIndexes: []uint64{0}, MissingShortIDs: []compactShortID{shortID}}); err == nil {
+		t.Fatal("non-missing partial slot should fail")
+	}
+}
+
+func TestCompactMissingRequestCapPrecedesPartialTableAllocation(t *testing.T) {
+	shortIDs := make([]compactShortID, maxCompactRelayEntries+1)
+	_, _, overflow, err := compactFillOrCollectMissing(nil, len(shortIDs), nil, shortIDs, nil, nil)
+	if err != nil || !overflow {
+		t.Fatal("missing-heavy compact block should hit request cap before partial table allocation")
+	}
+}
+
+func TestCompactBlockTxnResponsePayloadCapUsesRemainingBudget(t *testing.T) {
+	tx := minimalBlockTxnTestTxBytes(93)
+	cap, err := compactBlockTxnResponsePayloadCap([][]byte{tx, nil}, 1)
+	if err != nil {
+		t.Fatalf("compactBlockTxnResponsePayloadCap: %v", err)
+	}
+	want := uint32(32 + len(consensus.EncodeCompactSize(1)) + maxCompactSizeBytes + consensus.MAX_BLOCK_BYTES - len(tx))
+	if cap != want || cap >= compactRelayPayloadCap(messageBlockTxn) {
+		t.Fatalf("cap=%d want=%d and below global cap %d", cap, want, compactRelayPayloadCap(messageBlockTxn))
+	}
+	wantFull := uint32(32 + len(consensus.EncodeCompactSize(maxCompactRelayEntries)) + maxCompactRelayEntries*maxCompactSizeBytes + consensus.MAX_BLOCK_BYTES)
+	if full, err := compactBlockTxnResponsePayloadCap(nil, maxCompactRelayEntries); err != nil || full != wantFull || full >= compactRelayPayloadCap(messageBlockTxn) {
+		t.Fatalf("full missing cap=%d err=%v want %d below global %d", full, err, wantFull, compactRelayPayloadCap(messageBlockTxn))
 	}
 }
 

--- a/clients/go/node/p2p/compact_reconstruct_test.go
+++ b/clients/go/node/p2p/compact_reconstruct_test.go
@@ -232,6 +232,29 @@ func TestCompactFillShortIDTransactionsRejectsCumulativeOversize(t *testing.T) {
 	}
 }
 
+func TestCompactFillOrCollectMissingRecomputesSizeAfterDuplicateReclassification(t *testing.T) {
+	dup := compactShortID{0x01}
+	later := compactShortID{0x02}
+	txs := make([][]byte, 3)
+	missing, _, overflow, err := compactFillOrCollectMissing(
+		txs,
+		3,
+		nil,
+		[]compactShortID{dup, dup, later},
+		map[compactShortID][]byte{
+			dup:   make([]byte, consensus.MAX_BLOCK_BYTES),
+			later: {0x01},
+		},
+		nil,
+	)
+	if err != nil || overflow {
+		t.Fatalf("compactFillOrCollectMissing duplicate reclassification err=%v overflow=%v", err, overflow)
+	}
+	if !reflect.DeepEqual(missing, []uint64{0, 1}) || txs[0] != nil || !reflect.DeepEqual(txs[2], []byte{0x01}) {
+		t.Fatalf("missing=%v txs[0]=%v txs[2]=%v, want duplicate missing and later tx retained", missing, txs[0], txs[2])
+	}
+}
+
 func TestCompactLocalTxIndexUsesBoundedPerCandidateValidation(t *testing.T) {
 	nonce1, nonce2 := uint64(51), uint64(52)
 	validTx := minimalBlockTxnTestTxBytes(53)
@@ -266,6 +289,22 @@ func TestCompactFillResponseTransactionsValidatesExpectedShortIDs(t *testing.T) 
 	}
 	if _, err := compactFillResponseTransactions(req, [][]byte{tx2}, [][32]byte{compactWTxIDForTx(t, tx2)}); err == nil || !strings.Contains(err.Error(), "short id mismatch") {
 		t.Fatalf("wrong short ID err=%v, want short id mismatch", err)
+	}
+}
+
+func TestCompactFillResponseTransactionsRejectsAggregateOversize(t *testing.T) {
+	nonce1, nonce2 := uint64(81), uint64(82)
+	wtxid := [32]byte{0x01}
+	req := compactOutstandingRequest{
+		Transactions:    [][]byte{make([]byte, consensus.MAX_BLOCK_BYTES), nil},
+		MissingIndexes:  []uint64{1},
+		MissingShortIDs: []compactShortID{compactShortID(consensus.CompactShortID(wtxid, nonce1, nonce2))},
+		Nonce1:          nonce1,
+		Nonce2:          nonce2,
+	}
+	_, err := compactFillResponseTransactions(req, [][]byte{{0x01}}, [][32]byte{wtxid})
+	if err == nil || !strings.Contains(err.Error(), "blocktxn transactions exceed block size") {
+		t.Fatalf("aggregate oversize err=%v, want block size rejection", err)
 	}
 }
 

--- a/clients/go/node/p2p/compact_reconstruct_test.go
+++ b/clients/go/node/p2p/compact_reconstruct_test.go
@@ -250,6 +250,25 @@ func TestCompactLocalTxIndexUsesBoundedPerCandidateValidation(t *testing.T) {
 	}
 }
 
+func TestCompactFillResponseTransactionsValidatesExpectedShortIDs(t *testing.T) {
+	nonce1, nonce2 := uint64(71), uint64(72)
+	tx1 := minimalBlockTxnTestTxBytes(73)
+	tx2 := minimalBlockTxnTestTxBytes(74)
+	req := compactOutstandingRequest{
+		Transactions:    [][]byte{nil, tx2},
+		MissingIndexes:  []uint64{0},
+		MissingShortIDs: []compactShortID{compactShortIDForTx(t, tx1, nonce1, nonce2)},
+		Nonce1:          nonce1,
+		Nonce2:          nonce2,
+	}
+	if _, err := compactFillResponseTransactions(req, [][]byte{tx1}, [][32]byte{compactWTxIDForTx(t, tx1)}); err != nil {
+		t.Fatalf("compactFillResponseTransactions: %v", err)
+	}
+	if _, err := compactFillResponseTransactions(req, [][]byte{tx2}, [][32]byte{compactWTxIDForTx(t, tx2)}); err == nil || !strings.Contains(err.Error(), "short id mismatch") {
+		t.Fatalf("wrong short ID err=%v, want short id mismatch", err)
+	}
+}
+
 func TestReconstructCompactBlockSkipsLocalLookupForPrefilledOnlyBlock(t *testing.T) {
 	validTx := minimalBlockTxnTestTxBytes(61)
 	result, err := reconstructCompactBlock(cmpctBlockPayload{Prefilled: []prefilledTxn{{Index: 0, Tx: validTx}}}, [][]byte{{0xff}})
@@ -263,9 +282,15 @@ func TestReconstructCompactBlockSkipsLocalLookupForPrefilledOnlyBlock(t *testing
 
 func compactShortIDForTx(t *testing.T, tx []byte, nonce1, nonce2 uint64) compactShortID {
 	t.Helper()
+	wtxid := compactWTxIDForTx(t, tx)
+	return compactShortID(consensus.CompactShortID(wtxid, nonce1, nonce2))
+}
+
+func compactWTxIDForTx(t *testing.T, tx []byte) [32]byte {
+	t.Helper()
 	_, _, wtxid, consumed, err := consensus.ParseTx(tx)
 	if err != nil || consumed != len(tx) {
 		t.Fatalf("ParseTx: consumed=%d err=%v", consumed, err)
 	}
-	return compactShortID(consensus.CompactShortID(wtxid, nonce1, nonce2))
+	return wtxid
 }

--- a/clients/go/node/p2p/compact_reconstruct_test.go
+++ b/clients/go/node/p2p/compact_reconstruct_test.go
@@ -248,6 +248,10 @@ func TestCompactFillShortIDTransactionsDoesNotDoubleCountPrefilledBytes(t *testi
 	if !reflect.DeepEqual(txs[1], shortTx) {
 		t.Fatalf("filled tx=%x, want %x", txs[1], shortTx)
 	}
+	prefilledTx[0], shortTx[0] = 0xff, 0xee
+	if txs[0][0] == 0xff || txs[1][0] == 0xee {
+		t.Fatal("filled txs alias source bytes")
+	}
 }
 
 func TestCompactFillShortIDTransactionsRejectsInvalidCompletionShapes(t *testing.T) {

--- a/clients/go/node/p2p/compact_reconstruct_test.go
+++ b/clients/go/node/p2p/compact_reconstruct_test.go
@@ -273,7 +273,7 @@ func TestCompactFillOrCollectMissingRecomputesSizeAfterDuplicateReclassification
 		txs,
 		3,
 		nil,
-		[]compactShortID{dup, dup, later},
+		[]compactShortID{dup, later, dup},
 		map[compactShortID][]byte{
 			dup:   make([]byte, consensus.MAX_BLOCK_BYTES),
 			later: {0x01},
@@ -283,8 +283,8 @@ func TestCompactFillOrCollectMissingRecomputesSizeAfterDuplicateReclassification
 	if err != nil || overflow {
 		t.Fatalf("compactFillOrCollectMissing duplicate reclassification err=%v overflow=%v", err, overflow)
 	}
-	if !reflect.DeepEqual(missing, []uint64{0, 1}) || txs[0] != nil || !reflect.DeepEqual(txs[2], []byte{0x01}) {
-		t.Fatalf("missing=%v txs[0]=%v txs[2]=%v, want duplicate missing and later tx retained", missing, txs[0], txs[2])
+	if !reflect.DeepEqual(missing, []uint64{0, 2}) || txs[0] != nil || !reflect.DeepEqual(txs[1], []byte{0x01}) {
+		t.Fatalf("missing=%v txs[0]=%v txs[1]=%v, want late duplicate missing and intervening tx retained", missing, txs[0], txs[1])
 	}
 }
 

--- a/clients/go/node/p2p/compact_reconstruct_test.go
+++ b/clients/go/node/p2p/compact_reconstruct_test.go
@@ -349,11 +349,19 @@ func TestCompactFillResponseTransactionsValidatesExpectedShortIDs(t *testing.T) 
 		Nonce1:          nonce1,
 		Nonce2:          nonce2,
 	}
-	if _, err := compactFillResponseTransactions(req, [][]byte{tx1}, [][32]byte{compactWTxIDForTx(t, tx1)}); err != nil {
+	filled, err := compactFillResponseTransactions(req, [][]byte{tx1}, [][32]byte{compactWTxIDForTx(t, tx1)})
+	if err != nil {
 		t.Fatalf("compactFillResponseTransactions: %v", err)
+	}
+	tx1[0] ^= 0xff
+	if filled[0][0] == tx1[0] {
+		t.Fatal("filled blocktxn response aliases source bytes")
 	}
 	if _, err := compactFillResponseTransactions(req, [][]byte{tx2}, [][32]byte{compactWTxIDForTx(t, tx2)}); err == nil || !strings.Contains(err.Error(), "short id mismatch") {
 		t.Fatalf("wrong short ID err=%v, want short id mismatch", err)
+	}
+	if _, err := compactFillResponseTransactions(req, [][]byte{tx2}, [][32]byte{compactWTxIDForTx(t, filled[0])}); err == nil || !strings.Contains(err.Error(), "wtxid mismatch") {
+		t.Fatalf("mismatched response wtxid err=%v, want wtxid mismatch", err)
 	}
 }
 

--- a/clients/go/node/p2p/compact_reconstruct_test.go
+++ b/clients/go/node/p2p/compact_reconstruct_test.go
@@ -252,6 +252,21 @@ func TestCompactFillShortIDTransactionsDoesNotDoubleCountPrefilledBytes(t *testi
 	}
 }
 
+func TestCompactFillShortIDTransactionsRejectsInvalidCompletionShapes(t *testing.T) {
+	shortID := compactShortID{0x61}
+	if err := compactFillShortIDTransactions(make([][]byte, 1), 1, nil, []compactShortID{shortID}, nil, 0); err == nil || !strings.Contains(err.Error(), "compact block transaction missing") {
+		t.Fatalf("missing short-id err=%v, want missing", err)
+	}
+	if err := compactFillShortIDTransactions(make([][]byte, maxCompactRelayEntries+1), maxCompactRelayEntries+1, nil, make([]compactShortID, maxCompactRelayEntries+1), nil, 0); !errors.Is(err, errCompactRelayMissingRequestTooLarge) {
+		t.Fatalf("overflow err=%v", err)
+	}
+	txs := make([][]byte, 2)
+	err := compactFillShortIDTransactions(txs, 2, nil, []compactShortID{shortID}, map[compactShortID][]byte{shortID: minimalBlockTxnTestTxBytes(60)}, 0)
+	if err == nil || !strings.Contains(err.Error(), "compact block transaction missing") {
+		t.Fatalf("incomplete staged txs err=%v, want completion failure", err)
+	}
+}
+
 func TestCompactFillOrCollectMissingRecomputesSizeAfterDuplicateReclassification(t *testing.T) {
 	dup := compactShortID{0x01}
 	later := compactShortID{0x02}
@@ -290,6 +305,31 @@ func TestCompactLocalTxIndexUsesBoundedPerCandidateValidation(t *testing.T) {
 	_, err = compactLocalTxIndex([][]byte{append(minimalBlockTxnTestTxBytes(54), 0x00)}, nonce1, nonce2)
 	if err == nil || !strings.Contains(err.Error(), "compact local transaction is non-canonical") {
 		t.Fatalf("compactLocalTxIndex noncanonical err=%v", err)
+	}
+}
+
+func TestNewCompactOutstandingRequestCopiesPartialState(t *testing.T) {
+	tx := minimalBlockTxnTestTxBytes(90)
+	shortID := compactShortIDForTx(t, tx, 91, 92)
+	blockHash := [32]byte{0x33}
+	block := cmpctBlockPayload{Header: [consensus.BLOCK_HEADER_BYTES]byte{0x44}, Nonce1: 91, Nonce2: 92}
+	result := compactReconstructionResult{PartialTransactions: [][]byte{nil, tx}, MissingIndexes: []uint64{0}, MissingShortIDs: []compactShortID{shortID}}
+	req, err := newCompactOutstandingRequest(block, blockHash, result)
+	if err != nil {
+		t.Fatalf("newCompactOutstandingRequest: %v", err)
+	}
+	if req.BlockHash != blockHash || req.Header != block.Header || req.Nonce1 != block.Nonce1 || req.Nonce2 != block.Nonce2 || req.BlockTxnPayloadCap != compactRelayPayloadCap(messageBlockTxn) {
+		t.Fatalf("request metadata mismatch: %+v", req)
+	}
+	result.MissingIndexes[0], result.MissingShortIDs[0], result.PartialTransactions[1][0] = 7, compactShortID{0x55}, 0xff
+	if !reflect.DeepEqual(req.MissingIndexes, []uint64{0}) || !reflect.DeepEqual(req.MissingShortIDs, []compactShortID{shortID}) || req.Transactions[1][0] == 0xff {
+		t.Fatalf("request aliases reconstruction result: %+v", req)
+	}
+	if _, err := newCompactOutstandingRequest(block, blockHash, compactReconstructionResult{}); err == nil {
+		t.Fatal("empty missing request should fail")
+	}
+	if _, err := newCompactOutstandingRequest(block, blockHash, compactReconstructionResult{MissingIndexes: []uint64{0}}); err == nil {
+		t.Fatal("mismatched missing short-id request should fail")
 	}
 }
 

--- a/clients/go/node/p2p/compact_reconstruct_test.go
+++ b/clients/go/node/p2p/compact_reconstruct_test.go
@@ -221,7 +221,6 @@ func TestCompactFillShortIDTransactionsRejectsCumulativeOversize(t *testing.T) {
 		[]prefilledTxn{{Index: 0, Tx: txs[0]}},
 		[]compactShortID{shortID},
 		map[compactShortID][]byte{shortID: {0x01}},
-		0,
 	)
 	if err == nil || !strings.Contains(err.Error(), "blocktxn transactions exceed block size") {
 		t.Fatalf("compactFillShortIDTransactions err=%v, want cumulative size failure", err)
@@ -242,7 +241,6 @@ func TestCompactFillShortIDTransactionsDoesNotDoubleCountPrefilledBytes(t *testi
 		[]prefilledTxn{{Index: 0, Tx: prefilledTx}},
 		[]compactShortID{shortID},
 		map[compactShortID][]byte{shortID: shortTx},
-		uint64(len(prefilledTx)),
 	)
 	if err != nil {
 		t.Fatalf("compactFillShortIDTransactions double-counted prefilled bytes: %v", err)
@@ -254,14 +252,14 @@ func TestCompactFillShortIDTransactionsDoesNotDoubleCountPrefilledBytes(t *testi
 
 func TestCompactFillShortIDTransactionsRejectsInvalidCompletionShapes(t *testing.T) {
 	shortID := compactShortID{0x61}
-	if err := compactFillShortIDTransactions(make([][]byte, 1), 1, nil, []compactShortID{shortID}, nil, 0); err == nil || !strings.Contains(err.Error(), "compact block transaction missing") {
+	if err := compactFillShortIDTransactions(make([][]byte, 1), 1, nil, []compactShortID{shortID}, nil); err == nil || !strings.Contains(err.Error(), "compact block transaction missing") {
 		t.Fatalf("missing short-id err=%v, want missing", err)
 	}
-	if err := compactFillShortIDTransactions(make([][]byte, maxCompactRelayEntries+1), maxCompactRelayEntries+1, nil, make([]compactShortID, maxCompactRelayEntries+1), nil, 0); !errors.Is(err, errCompactRelayMissingRequestTooLarge) {
+	if err := compactFillShortIDTransactions(make([][]byte, maxCompactRelayEntries+1), maxCompactRelayEntries+1, nil, make([]compactShortID, maxCompactRelayEntries+1), nil); !errors.Is(err, errCompactRelayMissingRequestTooLarge) {
 		t.Fatalf("overflow err=%v", err)
 	}
 	txs := make([][]byte, 2)
-	err := compactFillShortIDTransactions(txs, 2, nil, []compactShortID{shortID}, map[compactShortID][]byte{shortID: minimalBlockTxnTestTxBytes(60)}, 0)
+	err := compactFillShortIDTransactions(txs, 2, nil, []compactShortID{shortID}, map[compactShortID][]byte{shortID: minimalBlockTxnTestTxBytes(60)})
 	if err == nil || !strings.Contains(err.Error(), "compact block transaction missing") {
 		t.Fatalf("incomplete staged txs err=%v, want completion failure", err)
 	}

--- a/clients/go/node/p2p/compact_reconstruct_test.go
+++ b/clients/go/node/p2p/compact_reconstruct_test.go
@@ -36,6 +36,10 @@ func TestReconstructCompactBlockCompletesExactPositionsFromWTxID(t *testing.T) {
 	if reflect.DeepEqual(result.Transactions[1], tx2) {
 		t.Fatal("result aliases local transaction bytes")
 	}
+	prefilledTx[0] ^= 0xff
+	if reflect.DeepEqual(result.Transactions[0], prefilledTx) {
+		t.Fatal("result aliases prefilled transaction bytes")
+	}
 }
 
 func TestReconstructCompactBlockReportsAbsoluteMissingIndexes(t *testing.T) {
@@ -310,7 +314,7 @@ func TestCompactLocalTxIndexUsesBoundedPerCandidateValidation(t *testing.T) {
 	}
 }
 
-func TestNewCompactOutstandingRequestCopiesPartialState(t *testing.T) {
+func TestNewCompactOutstandingRequestBuildsPartialState(t *testing.T) {
 	tx := minimalBlockTxnTestTxBytes(90)
 	shortID := compactShortIDForTx(t, tx, 91, 92)
 	blockHash := [32]byte{0x33}
@@ -323,9 +327,8 @@ func TestNewCompactOutstandingRequestCopiesPartialState(t *testing.T) {
 	if req.BlockHash != blockHash || req.Header != block.Header || req.Nonce1 != block.Nonce1 || req.Nonce2 != block.Nonce2 || req.BlockTxnPayloadCap != compactRelayPayloadCap(messageBlockTxn) {
 		t.Fatalf("request metadata mismatch: %+v", req)
 	}
-	result.MissingIndexes[0], result.MissingShortIDs[0], result.PartialTransactions[1][0] = 7, compactShortID{0x55}, 0xff
-	if !reflect.DeepEqual(req.MissingIndexes, []uint64{0}) || !reflect.DeepEqual(req.MissingShortIDs, []compactShortID{shortID}) || req.Transactions[1][0] == 0xff {
-		t.Fatalf("request aliases reconstruction result: %+v", req)
+	if !reflect.DeepEqual(req.MissingIndexes, []uint64{0}) || !reflect.DeepEqual(req.MissingShortIDs, []compactShortID{shortID}) || !reflect.DeepEqual(req.Transactions, [][]byte{nil, tx}) {
+		t.Fatalf("request state mismatch: %+v", req)
 	}
 	if _, err := newCompactOutstandingRequest(block, blockHash, compactReconstructionResult{}); err == nil {
 		t.Fatal("empty missing request should fail")

--- a/clients/go/node/p2p/compact_reconstruct_test.go
+++ b/clients/go/node/p2p/compact_reconstruct_test.go
@@ -213,22 +213,42 @@ func TestReconstructCompactBlockFailsClosedWhenMissingRequestExceedsCap(t *testi
 }
 
 func TestCompactFillShortIDTransactionsRejectsCumulativeOversize(t *testing.T) {
-	tx := minimalBlockTxnTestTxBytes(51)
 	shortID := compactShortID{0x51}
-	txs := make([][]byte, 1)
+	txs := [][]byte{make([]byte, consensus.MAX_BLOCK_BYTES), nil}
 	err := compactFillShortIDTransactions(
 		txs,
-		1,
-		nil,
+		2,
+		[]prefilledTxn{{Index: 0, Tx: txs[0]}},
 		[]compactShortID{shortID},
-		map[compactShortID][]byte{shortID: tx},
-		uint64(consensus.MAX_BLOCK_BYTES-len(tx)+1),
+		map[compactShortID][]byte{shortID: {0x01}},
+		0,
 	)
 	if err == nil || !strings.Contains(err.Error(), "blocktxn transactions exceed block size") {
 		t.Fatalf("compactFillShortIDTransactions err=%v, want cumulative size failure", err)
 	}
-	if txs[0] != nil {
-		t.Fatalf("compactFillShortIDTransactions mutated txs before validation: %x", txs[0])
+	if txs[1] != nil {
+		t.Fatalf("compactFillShortIDTransactions mutated short-id tx before validation: %x", txs[1])
+	}
+}
+
+func TestCompactFillShortIDTransactionsDoesNotDoubleCountPrefilledBytes(t *testing.T) {
+	prefilledTx := minimalBlockTxnTestTxBytes(50)
+	shortTx := minimalBlockTxnTestTxBytes(51)
+	shortID := compactShortID{0x51}
+	txs := [][]byte{prefilledTx, nil}
+	err := compactFillShortIDTransactions(
+		txs,
+		2,
+		[]prefilledTxn{{Index: 0, Tx: prefilledTx}},
+		[]compactShortID{shortID},
+		map[compactShortID][]byte{shortID: shortTx},
+		uint64(len(prefilledTx)),
+	)
+	if err != nil {
+		t.Fatalf("compactFillShortIDTransactions double-counted prefilled bytes: %v", err)
+	}
+	if !reflect.DeepEqual(txs[1], shortTx) {
+		t.Fatalf("filled tx=%x, want %x", txs[1], shortTx)
 	}
 }
 

--- a/clients/go/node/p2p/compact_runtime.go
+++ b/clients/go/node/p2p/compact_runtime.go
@@ -72,22 +72,27 @@ func (p *peer) setCompactOutstandingRequest(req compactOutstandingRequest) {
 
 func (p *peer) compactOutstandingRequestSnapshot() (compactOutstandingRequest, bool) {
 	p.compactMu.Lock()
-	defer p.compactMu.Unlock()
 	if p.compact.outstanding == nil {
+		p.compactMu.Unlock()
 		return compactOutstandingRequest{}, false
 	}
-	return cloneCompactOutstandingRequest(*p.compact.outstanding), true
+	// Stored outstanding requests are immutable; keep large tx-byte cloning outside compactMu.
+	req := *p.compact.outstanding
+	p.compactMu.Unlock()
+	return cloneCompactOutstandingRequest(req), true
 }
 
 func (p *peer) popCompactOutstandingRequest() (compactOutstandingRequest, bool) {
 	p.compactMu.Lock()
-	defer p.compactMu.Unlock()
 	if p.compact.outstanding == nil {
+		p.compactMu.Unlock()
 		return compactOutstandingRequest{}, false
 	}
-	req := cloneCompactOutstandingRequest(*p.compact.outstanding)
+	// Stored outstanding requests are immutable; keep large tx-byte cloning outside compactMu.
+	req := *p.compact.outstanding
 	p.compact.outstanding = nil
-	return req, true
+	p.compactMu.Unlock()
+	return cloneCompactOutstandingRequest(req), true
 }
 
 func cloneCompactOutstandingRequest(req compactOutstandingRequest) compactOutstandingRequest {

--- a/clients/go/node/p2p/compact_runtime.go
+++ b/clients/go/node/p2p/compact_runtime.go
@@ -64,8 +64,9 @@ func (p *peer) remoteCompactMode() compactModeSnapshot {
 }
 
 func (p *peer) setCompactOutstandingRequest(req compactOutstandingRequest) {
+	stored := cloneCompactOutstandingRequest(req)
 	p.compactMu.Lock()
-	p.compact.outstanding = &req
+	p.compact.outstanding = &stored
 	p.compactMu.Unlock()
 }
 
@@ -75,7 +76,7 @@ func (p *peer) compactOutstandingRequestSnapshot() (compactOutstandingRequest, b
 	if p.compact.outstanding == nil {
 		return compactOutstandingRequest{}, false
 	}
-	return *p.compact.outstanding, true
+	return cloneCompactOutstandingRequest(*p.compact.outstanding), true
 }
 
 func (p *peer) popCompactOutstandingRequest() (compactOutstandingRequest, bool) {
@@ -84,9 +85,16 @@ func (p *peer) popCompactOutstandingRequest() (compactOutstandingRequest, bool) 
 	if p.compact.outstanding == nil {
 		return compactOutstandingRequest{}, false
 	}
-	req := *p.compact.outstanding
+	req := cloneCompactOutstandingRequest(*p.compact.outstanding)
 	p.compact.outstanding = nil
 	return req, true
+}
+
+func cloneCompactOutstandingRequest(req compactOutstandingRequest) compactOutstandingRequest {
+	req.MissingIndexes = append([]uint64(nil), req.MissingIndexes...)
+	req.MissingShortIDs = append([]compactShortID(nil), req.MissingShortIDs...)
+	req.Transactions = cloneCompactTransactions(req.Transactions)
+	return req
 }
 
 func (p *peer) blockTxnPayloadCap() uint32 {

--- a/clients/go/node/p2p/compact_runtime.go
+++ b/clients/go/node/p2p/compact_runtime.go
@@ -3,6 +3,8 @@ package p2p
 import (
 	"encoding/binary"
 	"errors"
+
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
 )
 
 type compactModeSnapshot struct {
@@ -17,6 +19,12 @@ type peerCompactRelayState struct {
 
 type compactOutstandingRequest struct {
 	BlockHash          [32]byte
+	Header             [consensus.BLOCK_HEADER_BYTES]byte
+	MissingIndexes     []uint64
+	MissingShortIDs    []compactShortID
+	Transactions       [][]byte
+	Nonce1             uint64
+	Nonce2             uint64
 	BlockTxnPayloadCap uint32
 }
 
@@ -53,6 +61,32 @@ func (p *peer) remoteCompactMode() compactModeSnapshot {
 	p.compactMu.Lock()
 	defer p.compactMu.Unlock()
 	return p.compact.remoteMode
+}
+
+func (p *peer) setCompactOutstandingRequest(req compactOutstandingRequest) {
+	p.compactMu.Lock()
+	p.compact.outstanding = &req
+	p.compactMu.Unlock()
+}
+
+func (p *peer) compactOutstandingRequestSnapshot() (compactOutstandingRequest, bool) {
+	p.compactMu.Lock()
+	defer p.compactMu.Unlock()
+	if p.compact.outstanding == nil {
+		return compactOutstandingRequest{}, false
+	}
+	return *p.compact.outstanding, true
+}
+
+func (p *peer) popCompactOutstandingRequest() (compactOutstandingRequest, bool) {
+	p.compactMu.Lock()
+	defer p.compactMu.Unlock()
+	if p.compact.outstanding == nil {
+		return compactOutstandingRequest{}, false
+	}
+	req := *p.compact.outstanding
+	p.compact.outstanding = nil
+	return req, true
 }
 
 func (p *peer) blockTxnPayloadCap() uint32 {

--- a/clients/go/node/p2p/peer_runtime_test.go
+++ b/clients/go/node/p2p/peer_runtime_test.go
@@ -109,22 +109,33 @@ func TestCompactObjectCapsStayClosedUntilHandlersExist(t *testing.T) {
 
 func TestBlockTxnPayloadCapIsOutstandingBounded(t *testing.T) {
 	p := newPeerRuntimeTestPeer(t)
+	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatal("snapshot without outstanding should be absent")
+	}
+	if _, ok := p.popCompactOutstandingRequest(); ok {
+		t.Fatal("pop without outstanding should be absent")
+	}
 	if got := p.blockTxnPayloadCap(); got != 0 {
 		t.Fatalf("blocktxn cap without outstanding=%d, want 0", got)
 	}
 
-	p.compactMu.Lock()
-	p.compact.outstanding = &compactOutstandingRequest{BlockTxnPayloadCap: 64}
-	p.compactMu.Unlock()
+	p.setCompactOutstandingRequest(compactOutstandingRequest{BlockTxnPayloadCap: 64})
+	if snap, ok := p.compactOutstandingRequestSnapshot(); !ok || snap.BlockTxnPayloadCap != 64 {
+		t.Fatalf("snapshot cap=%+v ok=%v, want 64", snap, ok)
+	}
 	if got := p.blockTxnPayloadCap(); got != 64 {
 		t.Fatalf("blocktxn bounded cap=%d, want 64", got)
 	}
 
-	p.compactMu.Lock()
-	p.compact.outstanding = &compactOutstandingRequest{BlockTxnPayloadCap: compactRelayPayloadCap(messageBlockTxn) + 1}
-	p.compactMu.Unlock()
+	p.setCompactOutstandingRequest(compactOutstandingRequest{BlockTxnPayloadCap: compactRelayPayloadCap(messageBlockTxn) + 1})
 	if got := p.blockTxnPayloadCap(); got != compactRelayPayloadCap(messageBlockTxn) {
 		t.Fatalf("blocktxn oversized cap=%d, want max %d", got, compactRelayPayloadCap(messageBlockTxn))
+	}
+	if popped, ok := p.popCompactOutstandingRequest(); !ok || popped.BlockTxnPayloadCap != compactRelayPayloadCap(messageBlockTxn)+1 {
+		t.Fatalf("popped cap=%+v ok=%v, want oversized request", popped, ok)
+	}
+	if got := p.blockTxnPayloadCap(); got != 0 {
+		t.Fatalf("blocktxn cap after pop=%d, want 0", got)
 	}
 }
 

--- a/clients/go/node/p2p/peer_runtime_test.go
+++ b/clients/go/node/p2p/peer_runtime_test.go
@@ -109,22 +109,26 @@ func TestCompactObjectCapsStayClosedUntilHandlersExist(t *testing.T) {
 
 func TestBlockTxnPayloadCapIsOutstandingBounded(t *testing.T) {
 	p := newPeerRuntimeTestPeer(t)
-	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
-		t.Fatal("snapshot without outstanding should be absent")
-	}
-	if _, ok := p.popCompactOutstandingRequest(); ok {
-		t.Fatal("pop without outstanding should be absent")
-	}
 	if got := p.blockTxnPayloadCap(); got != 0 {
 		t.Fatalf("blocktxn cap without outstanding=%d, want 0", got)
 	}
 
-	p.setCompactOutstandingRequest(compactOutstandingRequest{BlockTxnPayloadCap: 64})
+	tx := minimalBlockTxnTestTxBytes(81)
+	req := compactOutstandingRequest{MissingIndexes: []uint64{1}, MissingShortIDs: []compactShortID{{0x01}}, Transactions: [][]byte{tx}, BlockTxnPayloadCap: 64}
+	p.setCompactOutstandingRequest(req)
+	req.MissingIndexes[0], req.MissingShortIDs[0], req.Transactions[0][0] = 9, compactShortID{0x02}, 0xff
 	if snap, ok := p.compactOutstandingRequestSnapshot(); !ok || snap.BlockTxnPayloadCap != 64 {
 		t.Fatalf("snapshot cap=%+v ok=%v, want 64", snap, ok)
+	} else if snap.MissingIndexes[0] != 1 || snap.MissingShortIDs[0] != (compactShortID{0x01}) || snap.Transactions[0][0] == 0xff {
+		t.Fatalf("snapshot aliases original request: %+v", snap)
+	} else {
+		snap.MissingIndexes[0], snap.Transactions[0][0] = 7, 0xee
 	}
 	if got := p.blockTxnPayloadCap(); got != 64 {
 		t.Fatalf("blocktxn bounded cap=%d, want 64", got)
+	}
+	if snap, ok := p.compactOutstandingRequestSnapshot(); !ok || snap.MissingIndexes[0] != 1 || snap.Transactions[0][0] == 0xee {
+		t.Fatalf("snapshot aliases previous snapshot: %+v ok=%v", snap, ok)
 	}
 
 	p.setCompactOutstandingRequest(compactOutstandingRequest{BlockTxnPayloadCap: compactRelayPayloadCap(messageBlockTxn) + 1})

--- a/clients/go/node/p2p/peer_runtime_test.go
+++ b/clients/go/node/p2p/peer_runtime_test.go
@@ -99,9 +99,7 @@ func TestCompactObjectCapsStayClosedUntilHandlersExist(t *testing.T) {
 
 	p.setRemoteCompactMode(compactModeSnapshot{Mode: 1, Version: compactRelayVersion})
 	limiter = p.postHandshakePayloadCap()
-	p.compactMu.Lock()
-	p.compact.outstanding = &compactOutstandingRequest{BlockTxnPayloadCap: compactRelayPayloadCap(messageBlockTxn) + 1}
-	p.compactMu.Unlock()
+	p.setCompactOutstandingRequest(compactOutstandingRequest{BlockTxnPayloadCap: compactRelayPayloadCap(messageBlockTxn) + 1})
 	for _, command := range []string{messageCmpctBlock, messageGetBlockTxn, messageBlockTxn} {
 		if got := limiter(command); got != 0 {
 			t.Fatalf("negotiated %s cap=%d, want 0 until handler slice", command, got)


### PR DESCRIPTION
Invariant:
Compact receive prep preserves partial reconstruction and peer-local outstanding request metadata without opening live compact object dispatch.

Layer:
implementation / Go P2P compact relay prep

Files changed:
- clients/go/node/p2p/compact_reconstruct.go
- clients/go/node/p2p/compact_reconstruct_test.go
- clients/go/node/p2p/compact_runtime.go
- clients/go/node/p2p/peer_runtime_test.go

Tests:
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node/p2p -run "Compact|CmpctBlock|BlockTxn|Reconstruct"' — PASS
- rubin-precommit-one-review --repo /Users/gpt/Documents/rubin-protocol-codex-RUB-326-receive --base-ref origin/main --include-base-diff — PASS
- stock raw-diff review — No findings
- /Users/gpt/bin/rubin-push --repo /Users/gpt/Documents/rubin-protocol-codex-RUB-326-receive --base-ref origin/main --coverage-cmd 'scripts/preflight-codacy-coverage.sh' — PASS

Coverage:
- variation: +0.00%
- diff coverage: 94.44%

Behavior impact:
No live compact object dispatch is opened. No outbound getblocktxn, inbound blocktxn apply, fallback, timeout, or serve-side getblocktxn behavior is added.

Compatibility impact:
Go internal prep only. Rust behavior unchanged; live Go/Rust parity is deferred to downstream RUB-326/RUB-327 chain.

Known non-goals:
- cmpctblock live dispatch
- getblocktxn send/serve
- blocktxn apply
- fallback/late/timeout cleanup
- Rust/conformance/consensus/policy changes

Risk:
Bounded to helper/state prep; aggregate byte caps are validated after duplicate reclassification and response fill.

Rollback:
Revert this PR; no live wire behavior depends on it until downstream RUB-326.

Not checked:
Process-level compact relay smoke; owned by downstream live-flow tasks.

Refs: RUB-332
