### PR TITLE
[RUB-326] Wire Go compact blocktxn receive flow

### DIFF
--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -94,14 +94,34 @@ type Mempool struct {
 // AllTxIDs returns the txids of every transaction currently in the mempool.
 // The slice ordering is not guaranteed to be stable between calls.
 func (m *Mempool) AllTxIDs() [][32]byte {
+	return m.txIDsLimit(0)
+}
+
+// TxIDsLimit returns at most limit txids from the current mempool snapshot.
+// The slice ordering is not guaranteed to be stable between calls.
+func (m *Mempool) TxIDsLimit(limit int) [][32]byte {
+	if limit <= 0 {
+		return nil
+	}
+	return m.txIDsLimit(limit)
+}
+
+func (m *Mempool) txIDsLimit(limit int) [][32]byte {
 	if m == nil {
 		return nil
 	}
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	ids := make([][32]byte, 0, len(m.txs))
+	capHint := len(m.txs)
+	if limit > 0 && limit < capHint {
+		capHint = limit
+	}
+	ids := make([][32]byte, 0, capHint)
 	for txid := range m.txs {
 		ids = append(ids, txid)
+		if limit > 0 && len(ids) >= limit {
+			break
+		}
 	}
 	return ids
 }

--- a/clients/go/node/mempool_snapshot_test.go
+++ b/clients/go/node/mempool_snapshot_test.go
@@ -1,0 +1,20 @@
+package node
+
+import "testing"
+
+func TestMempoolTxIDsLimitBoundsSnapshot(t *testing.T) {
+	mp := &Mempool{txs: map[[32]byte]*mempoolEntry{
+		{0x01}: {},
+		{0x02}: {},
+		{0x03}: {},
+	}}
+	if got := mp.TxIDsLimit(2); len(got) != 2 {
+		t.Fatalf("TxIDsLimit len=%d, want 2", len(got))
+	}
+	if got := mp.TxIDsLimit(0); got != nil {
+		t.Fatalf("TxIDsLimit(0)=%v, want nil", got)
+	}
+	if got := mp.AllTxIDs(); len(got) != 3 {
+		t.Fatalf("AllTxIDs len=%d, want 3", len(got))
+	}
+}

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -255,11 +255,11 @@ func (p *peer) handleCmpctBlock(payload []byte) error {
 		return err
 	}
 	blockHash, _ := consensus.BlockHash(block.Header[:]) // fixed-size header slice cannot hit the length error path
-	if err := p.validateCompactBlockHeader(block.Header); err != nil {
-		return err
-	}
 	have, err := p.service.hasBlock(blockHash)
 	if err != nil || have {
+		return err
+	}
+	if err := p.validateCompactBlockHeader(block.Header); err != nil {
 		return err
 	}
 	result, err := reconstructCompactBlock(block, compactRelayLocalTransactions(p.service.cfg.TxPool))
@@ -317,10 +317,10 @@ func (p *peer) handleBlockTxn(payload []byte) error {
 	copy(responseHash[:], payload[:32])
 	req, ok := p.compactOutstandingRequestSnapshot()
 	if !ok {
-		return errors.New("unexpected blocktxn response")
+		return p.rejectBlockTxn("unexpected blocktxn response")
 	}
 	if responseHash != req.BlockHash {
-		return errors.New("blocktxn block hash mismatch")
+		return p.rejectBlockTxn("blocktxn block hash mismatch")
 	}
 	response, err := decodeBlockTxnRuntimePayload(payload)
 	if err != nil {
@@ -336,6 +336,8 @@ func (p *peer) handleBlockTxn(payload []byte) error {
 	}
 	return p.processCompactTransactions(req.BlockHash, req.Header, txs, true)
 }
+
+func (p *peer) rejectBlockTxn(msg string) error { p.bumpBan(10, msg); return errors.New(msg) }
 
 func (p *peer) processCompactTransactions(blockHash [32]byte, header [consensus.BLOCK_HEADER_BYTES]byte, txs [][]byte, fallbackOnApply bool) error {
 	blockBytes, err := compactBlockBytes(header, txs)
@@ -368,14 +370,24 @@ func (p *peer) processCompactRelayedBlockWithFallback(expectedHash [32]byte, blo
 	summary, err := p.service.cfg.SyncEngine.ApplyBlockWithReorg(blockBytes, nil)
 	p.service.chainMu.Unlock()
 	if err != nil {
-		if errors.Is(err, node.ErrParentNotFound) || isConsensusApplyBlockError(err) {
-			return true, err
-		}
-		p.recordRelayedBlockApplyError(err)
-		return false, err
+		return p.compactApplyErrorFallback(pb, blockHash, blockBytes, err)
 	}
 	p.acceptedRelayedBlock(blockHash, summary)
 	return false, nil
+}
+
+func (p *peer) compactApplyErrorFallback(pb *consensus.ParsedBlock, blockHash [32]byte, blockBytes []byte, err error) (bool, error) {
+	if errors.Is(err, node.ErrParentNotFound) {
+		if _, retainErr := p.retainRelayedOrphanIfValid(pb, blockHash, blockBytes); retainErr != nil {
+			return false, retainErr
+		}
+		return true, err
+	}
+	if isConsensusApplyBlockError(err) {
+		return true, err
+	}
+	p.recordRelayedBlockApplyError(err)
+	return false, err
 }
 
 func (p *peer) requestCompactFullBlockFallback(blockHash [32]byte) error {
@@ -413,31 +425,39 @@ func compactBlockBytes(header [consensus.BLOCK_HEADER_BYTES]byte, txs [][]byte) 
 func compactRelayLocalTransactions(pool TxPool) [][]byte {
 	switch pool := pool.(type) {
 	case *MemoryTxPool:
-		if pool == nil {
-			return nil
-		}
-		pool.mu.RLock()
-		defer pool.mu.RUnlock()
-		out := make([][]byte, 0, len(pool.txs))
-		for _, entry := range pool.txs {
-			out = append(out, entry.raw)
-		}
-		return out
+		return compactMemoryPoolTransactions(pool)
 	case *CanonicalMempoolTxPool:
-		if pool == nil || pool.mempool == nil {
-			return nil
-		}
-		ids := pool.mempool.AllTxIDs()
-		out := make([][]byte, 0, len(ids))
-		for _, txid := range ids {
-			if tx, ok := pool.mempool.TxByID(txid); ok {
-				out = append(out, tx)
-			}
-		}
-		return out
+		return compactCanonicalPoolTransactions(pool)
 	default:
 		return nil
 	}
+}
+
+func compactMemoryPoolTransactions(pool *MemoryTxPool) [][]byte {
+	if pool == nil {
+		return nil
+	}
+	pool.mu.RLock()
+	defer pool.mu.RUnlock()
+	out := make([][]byte, 0, len(pool.txs))
+	for _, entry := range pool.txs {
+		out = append(out, entry.raw)
+	}
+	return out
+}
+
+func compactCanonicalPoolTransactions(pool *CanonicalMempoolTxPool) [][]byte {
+	if pool == nil || pool.mempool == nil {
+		return nil
+	}
+	ids := pool.mempool.AllTxIDs()
+	out := make([][]byte, 0, len(ids))
+	for _, txid := range ids {
+		if tx, ok := pool.mempool.TxByID(txid); ok {
+			out = append(out, tx)
+		}
+	}
+	return out
 }
 
 func newCompactOutstandingRequest(block cmpctBlockPayload, blockHash [32]byte, result compactReconstructionResult) (compactOutstandingRequest, error) {

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -324,7 +324,8 @@ func (p *peer) handleBlockTxn(payload []byte) error {
 	response, err := decodeBlockTxnRuntimePayload(payload)
 	if err != nil {
 		p.popCompactOutstandingRequest()
-		return p.requestCompactFullBlockFallback(req.BlockHash)
+		p.bumpBan(10, err.Error())
+		return err
 	}
 	req, ok = p.popCompactOutstandingRequest()
 	if !ok {
@@ -332,7 +333,8 @@ func (p *peer) handleBlockTxn(payload []byte) error {
 	}
 	txs, err := compactFillResponseTransactions(req, response)
 	if err != nil {
-		return p.requestCompactFullBlockFallback(req.BlockHash)
+		p.bumpBan(10, err.Error())
+		return err
 	}
 	return p.processCompactTransactions(req.BlockHash, req.Header, txs, true)
 }

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -328,10 +328,7 @@ func (p *peer) handleBlockTxn(payload []byte) error {
 		p.bumpBan(10, err.Error())
 		return err
 	}
-	req, ok = p.popCompactOutstandingRequest()
-	if !ok {
-		return errors.New("unexpected blocktxn response")
-	}
+	req, _ = p.popCompactOutstandingRequest() // snapshot above guarantees presence in the single-reader peer loop.
 	txs, err := compactFillResponseTransactions(req, response)
 	if err != nil {
 		p.bumpBan(10, err.Error())
@@ -345,41 +342,40 @@ func (p *peer) processCompactTransactions(blockHash [32]byte, header [consensus.
 	if err != nil {
 		return p.requestCompactFullBlockFallback(blockHash)
 	}
-	accepted, fallback, err := p.processCompactRelayedBlock(blockHash, blockBytes, fallbackOnApply)
+	if !fallbackOnApply {
+		return p.handleBlock(blockBytes)
+	}
+	fallback, err := p.processCompactRelayedBlockWithFallback(blockHash, blockBytes)
 	if fallback {
 		return p.requestCompactFullBlockFallback(blockHash)
 	}
-	if err != nil || !accepted {
+	if err != nil {
 		return err
 	}
 	return p.service.requestBlocksIfBehind(p)
 }
 
-func (p *peer) processCompactRelayedBlock(expectedHash [32]byte, blockBytes []byte, fallbackOnApply bool) (bool, bool, error) {
+func (p *peer) processCompactRelayedBlockWithFallback(expectedHash [32]byte, blockBytes []byte) (bool, error) {
 	pb, blockHash, err := parseRelayedBlock(blockBytes)
 	if err != nil || pb == nil || blockHash != expectedHash {
-		return false, true, err
+		return true, err
 	}
 	have, err := p.service.hasBlock(blockHash)
 	if err != nil || have {
-		return false, false, err
+		return false, err
 	}
 	p.service.chainMu.Lock()
 	summary, err := p.service.cfg.SyncEngine.ApplyBlockWithReorg(blockBytes, nil)
 	p.service.chainMu.Unlock()
 	if err != nil {
-		if errors.Is(err, node.ErrParentNotFound) && !fallbackOnApply {
-			_, err := p.retainRelayedOrphanIfValid(pb, blockHash, blockBytes)
-			return false, false, err
-		}
-		if fallbackOnApply && (errors.Is(err, node.ErrParentNotFound) || isConsensusApplyBlockError(err)) {
-			return false, true, err
+		if errors.Is(err, node.ErrParentNotFound) || isConsensusApplyBlockError(err) {
+			return true, err
 		}
 		p.recordRelayedBlockApplyError(err)
-		return false, false, err
+		return false, err
 	}
 	p.acceptedRelayedBlock(blockHash, summary)
-	return true, false, nil
+	return false, nil
 }
 
 func (p *peer) requestCompactFullBlockFallback(blockHash [32]byte) error {

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/node"
 )
 
 const compactDuplicateReportedIndex = ^uint64(0)
@@ -246,6 +247,222 @@ func compactLocalTxWTxID(tx []byte) ([32]byte, error) {
 		return zero, errors.New("compact local transaction is non-canonical")
 	}
 	return wtxid, nil
+}
+
+func (p *peer) handleCmpctBlock(payload []byte) error {
+	block, err := decodeCmpctBlockPayload(payload)
+	if err != nil {
+		return err
+	}
+	blockHash, err := consensus.BlockHash(block.Header[:])
+	if err != nil {
+		return err
+	}
+	if err := p.validateCompactBlockHeader(block.Header); err != nil {
+		return err
+	}
+	have, err := p.service.hasBlock(blockHash)
+	if err != nil || have {
+		return err
+	}
+	result, err := reconstructCompactBlock(block, compactRelayLocalTransactions(p.service.cfg.TxPool))
+	if errors.Is(err, errCompactRelayMissingRequestTooLarge) {
+		return p.requestCompactFullBlockFallback(blockHash)
+	}
+	if err != nil {
+		return err
+	}
+	if result.Transactions != nil {
+		return p.processCompactTransactions(blockHash, block.Header, result.Transactions)
+	}
+	return p.requestMissingCompactTransactions(block, blockHash, result)
+}
+
+func (p *peer) validateCompactBlockHeader(header [consensus.BLOCK_HEADER_BYTES]byte) error {
+	parsed, err := consensus.ParseBlockHeaderBytes(header[:])
+	if err != nil {
+		p.bumpBan(10, err.Error())
+		return err
+	}
+	if err := consensus.PowCheck(header[:], parsed.Target); err != nil {
+		p.bumpBan(100, err.Error())
+		return err
+	}
+	if expected := p.service.cfg.SyncConfig.ExpectedTarget; expected != nil && parsed.Target != *expected {
+		err := &consensus.TxError{Code: consensus.BLOCK_ERR_TARGET_INVALID, Msg: "target mismatch"}
+		p.bumpBan(100, err.Error())
+		return err
+	}
+	return nil
+}
+
+func (p *peer) requestMissingCompactTransactions(block cmpctBlockPayload, blockHash [32]byte, result compactReconstructionResult) error {
+	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
+		return p.requestCompactFullBlockFallback(blockHash)
+	}
+	req, err := newCompactOutstandingRequest(block, blockHash, result)
+	if err != nil {
+		return err
+	}
+	body, err := encodeGetBlockTxnPayload(getBlockTxnPayload{BlockHash: blockHash, Indexes: req.MissingIndexes})
+	if err != nil {
+		return err
+	}
+	p.setCompactOutstandingRequest(req)
+	if err := p.send(messageGetBlockTxn, body); err != nil {
+		p.popCompactOutstandingRequest()
+		return err
+	}
+	return nil
+}
+
+func (p *peer) handleBlockTxn(payload []byte) error {
+	responseHash, err := compactBlockTxnPayloadHash(payload)
+	if err != nil {
+		return err
+	}
+	req, ok := p.compactOutstandingRequestSnapshot()
+	if !ok {
+		return errors.New("unexpected blocktxn response")
+	}
+	if responseHash != req.BlockHash {
+		return errors.New("blocktxn block hash mismatch")
+	}
+	response, err := decodeBlockTxnRuntimePayload(payload)
+	if err != nil {
+		p.popCompactOutstandingRequest()
+		return p.requestCompactFullBlockFallback(req.BlockHash)
+	}
+	req, ok = p.popCompactOutstandingRequest()
+	if !ok {
+		return errors.New("unexpected blocktxn response")
+	}
+	txs, err := compactFillResponseTransactions(req, response)
+	if err != nil {
+		return p.requestCompactFullBlockFallback(req.BlockHash)
+	}
+	return p.processCompactTransactions(req.BlockHash, req.Header, txs)
+}
+
+func compactBlockTxnPayloadHash(payload []byte) ([32]byte, error) {
+	var blockHash [32]byte
+	if len(payload) < 32 {
+		return blockHash, errors.New("blocktxn payload missing block hash")
+	}
+	copy(blockHash[:], payload[:32])
+	return blockHash, nil
+}
+
+func (p *peer) processCompactTransactions(blockHash [32]byte, header [consensus.BLOCK_HEADER_BYTES]byte, txs [][]byte) error {
+	blockBytes, err := compactBlockBytes(header, txs)
+	if err != nil {
+		return p.requestCompactFullBlockFallback(blockHash)
+	}
+	accepted, fallback, err := p.processCompactRelayedBlock(blockHash, blockBytes)
+	if fallback {
+		return p.requestCompactFullBlockFallback(blockHash)
+	}
+	if err != nil || !accepted {
+		return err
+	}
+	return p.service.requestBlocksIfBehind(p)
+}
+
+func (p *peer) processCompactRelayedBlock(expectedHash [32]byte, blockBytes []byte) (bool, bool, error) {
+	pb, blockHash, err := parseRelayedBlock(blockBytes)
+	if err != nil || pb == nil || blockHash != expectedHash {
+		return false, true, err
+	}
+	have, err := p.service.hasBlock(blockHash)
+	if err != nil || have {
+		return false, false, err
+	}
+	p.service.chainMu.Lock()
+	summary, err := p.service.cfg.SyncEngine.ApplyBlockWithReorg(blockBytes, nil)
+	p.service.chainMu.Unlock()
+	if err != nil {
+		if compactApplyErrorNeedsFullBlock(err) {
+			return false, true, err
+		}
+		p.recordRelayedBlockApplyError(err)
+		return false, false, err
+	}
+	p.acceptedRelayedBlock(blockHash, summary)
+	return true, false, nil
+}
+
+func compactApplyErrorNeedsFullBlock(err error) bool {
+	return errors.Is(err, node.ErrParentNotFound) || isConsensusApplyBlockError(err)
+}
+
+func (p *peer) requestCompactFullBlockFallback(blockHash [32]byte) error {
+	body, err := encodeInventoryVectors([]InventoryVector{{Type: MSG_BLOCK, Hash: blockHash}})
+	if err != nil {
+		return err
+	}
+	return p.send(messageGetData, body)
+}
+
+func compactBlockBytes(header [consensus.BLOCK_HEADER_BYTES]byte, txs [][]byte) ([]byte, error) {
+	if len(txs) == 0 {
+		return nil, errors.New("compact block has no transactions")
+	}
+	out := append([]byte(nil), header[:]...)
+	out = consensus.AppendCompactSize(out, uint64(len(txs)))
+	var totalTxBytes uint64
+	for _, tx := range txs {
+		if tx == nil {
+			return nil, errors.New("compact block transaction missing")
+		}
+		nextTotal, err := validateBlockTxnTransactionSize(uint64(len(tx)), totalTxBytes)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, tx...)
+		totalTxBytes = nextTotal
+		if len(out) > consensus.MAX_BLOCK_BYTES {
+			return nil, errors.New("compact block exceeds block size")
+		}
+	}
+	return out, nil
+}
+
+func compactRelayLocalTransactions(pool TxPool) [][]byte {
+	switch pool := pool.(type) {
+	case *MemoryTxPool:
+		return compactRelayMemoryPoolTransactions(pool)
+	case *CanonicalMempoolTxPool:
+		return compactRelayCanonicalPoolTransactions(pool)
+	default:
+		return nil
+	}
+}
+
+func compactRelayMemoryPoolTransactions(pool *MemoryTxPool) [][]byte {
+	if pool == nil {
+		return nil
+	}
+	pool.mu.RLock()
+	defer pool.mu.RUnlock()
+	out := make([][]byte, 0, len(pool.txs))
+	for _, entry := range pool.txs {
+		out = append(out, entry.raw)
+	}
+	return out
+}
+
+func compactRelayCanonicalPoolTransactions(pool *CanonicalMempoolTxPool) [][]byte {
+	if pool == nil || pool.mempool == nil {
+		return nil
+	}
+	ids := pool.mempool.AllTxIDs()
+	out := make([][]byte, 0, len(ids))
+	for _, txid := range ids {
+		if tx, ok := pool.mempool.TxByID(txid); ok {
+			out = append(out, tx)
+		}
+	}
+	return out
 }
 
 func newCompactOutstandingRequest(block cmpctBlockPayload, blockHash [32]byte, result compactReconstructionResult) (compactOutstandingRequest, error) {

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -368,6 +368,10 @@ func (p *peer) processCompactRelayedBlock(expectedHash [32]byte, blockBytes []by
 	summary, err := p.service.cfg.SyncEngine.ApplyBlockWithReorg(blockBytes, nil)
 	p.service.chainMu.Unlock()
 	if err != nil {
+		if errors.Is(err, node.ErrParentNotFound) && !fallbackOnApply {
+			_, err := p.retainRelayedOrphanIfValid(pb, blockHash, blockBytes)
+			return false, false, err
+		}
 		if fallbackOnApply && (errors.Is(err, node.ErrParentNotFound) || isConsensusApplyBlockError(err)) {
 			return false, true, err
 		}

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -7,7 +7,12 @@ import (
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/node"
 )
 
-const compactDuplicateReportedIndex = ^uint64(0)
+const (
+	compactDuplicateReportedIndex = ^uint64(0)
+	// Missing local candidates fall back to getblocktxn, so reconstruction
+	// must not scan an unbounded mempool snapshot before that fallback.
+	compactLocalTxCandidateLimit = defaultMaxTxPoolSize
+)
 
 var errCompactRelayMissingRequestTooLarge = errors.New("too many compact relay missing transactions")
 
@@ -255,14 +260,14 @@ func (p *peer) handleCmpctBlock(payload []byte) error {
 		return err
 	}
 	blockHash, _ := consensus.BlockHash(block.Header[:]) // fixed-size header slice cannot hit the length error path
-	if err := p.validateCompactBlockHeader(block.Header); err != nil {
-		return err
-	}
 	have, err := p.service.hasBlock(blockHash)
 	if err != nil || have {
 		return err
 	}
-	result, err := reconstructCompactBlock(block, compactRelayLocalTransactions(p.service.cfg.TxPool))
+	if err := p.validateCompactBlockHeader(block.Header); err != nil {
+		return err
+	}
+	result, err := reconstructCompactBlock(block, compactRelayLocalTransactions(p.service.cfg.TxPool, compactLocalTxCandidateLimit))
 	if errors.Is(err, errCompactRelayMissingRequestTooLarge) {
 		return p.requestCompactFullBlockFallback(blockHash)
 	}
@@ -311,16 +316,16 @@ func (p *peer) requestMissingCompactTransactions(block cmpctBlockPayload, blockH
 
 func (p *peer) handleBlockTxn(payload []byte) error {
 	if len(payload) < 32 {
-		return errors.New("blocktxn payload missing block hash")
+		return p.rejectBlockTxn("blocktxn payload missing block hash")
 	}
 	var responseHash [32]byte
 	copy(responseHash[:], payload[:32])
 	req, ok := p.compactOutstandingRequestSnapshot()
 	if !ok {
-		return errors.New("unexpected blocktxn response")
+		return p.rejectBlockTxn("unexpected blocktxn response")
 	}
 	if responseHash != req.BlockHash {
-		return errors.New("blocktxn block hash mismatch")
+		return p.rejectBlockTxn("blocktxn block hash mismatch")
 	}
 	response, err := decodeBlockTxnRuntimePayload(payload)
 	if err != nil {
@@ -336,6 +341,8 @@ func (p *peer) handleBlockTxn(payload []byte) error {
 	}
 	return p.processCompactTransactions(req.BlockHash, req.Header, txs, true)
 }
+
+func (p *peer) rejectBlockTxn(msg string) error { p.bumpBan(10, msg); return errors.New(msg) }
 
 func (p *peer) processCompactTransactions(blockHash [32]byte, header [consensus.BLOCK_HEADER_BYTES]byte, txs [][]byte, fallbackOnApply bool) error {
 	blockBytes, err := compactBlockBytes(header, txs)
@@ -368,14 +375,25 @@ func (p *peer) processCompactRelayedBlockWithFallback(expectedHash [32]byte, blo
 	summary, err := p.service.cfg.SyncEngine.ApplyBlockWithReorg(blockBytes, nil)
 	p.service.chainMu.Unlock()
 	if err != nil {
-		if errors.Is(err, node.ErrParentNotFound) || isConsensusApplyBlockError(err) {
-			return true, err
-		}
-		p.recordRelayedBlockApplyError(err)
-		return false, err
+		return p.compactApplyErrorFallback(pb, blockHash, blockBytes, err)
 	}
 	p.acceptedRelayedBlock(blockHash, summary)
 	return false, nil
+}
+
+func (p *peer) compactApplyErrorFallback(pb *consensus.ParsedBlock, blockHash [32]byte, blockBytes []byte, err error) (bool, error) {
+	if errors.Is(err, node.ErrParentNotFound) {
+		if _, retainErr := p.retainRelayedOrphanIfValid(pb, blockHash, blockBytes); retainErr != nil {
+			return false, retainErr
+		}
+		return true, err
+	}
+	if isConsensusApplyBlockError(err) {
+		p.recordRelayedBlockApplyError(err)
+		return false, err
+	}
+	p.recordRelayedBlockApplyError(err)
+	return false, err
 }
 
 func (p *peer) requestCompactFullBlockFallback(blockHash [32]byte) error {
@@ -410,34 +428,49 @@ func compactBlockBytes(header [consensus.BLOCK_HEADER_BYTES]byte, txs [][]byte) 
 	return out, nil
 }
 
-func compactRelayLocalTransactions(pool TxPool) [][]byte {
+func compactRelayLocalTransactions(pool TxPool, limit int) [][]byte {
 	switch pool := pool.(type) {
 	case *MemoryTxPool:
-		if pool == nil {
-			return nil
-		}
-		pool.mu.RLock()
-		defer pool.mu.RUnlock()
-		out := make([][]byte, 0, len(pool.txs))
-		for _, entry := range pool.txs {
-			out = append(out, entry.raw)
-		}
-		return out
+		return compactMemoryPoolTransactions(pool, limit)
 	case *CanonicalMempoolTxPool:
-		if pool == nil || pool.mempool == nil {
-			return nil
-		}
-		ids := pool.mempool.AllTxIDs()
-		out := make([][]byte, 0, len(ids))
-		for _, txid := range ids {
-			if tx, ok := pool.mempool.TxByID(txid); ok {
-				out = append(out, tx)
-			}
-		}
-		return out
+		return compactCanonicalPoolTransactions(pool, limit)
 	default:
 		return nil
 	}
+}
+
+func compactMemoryPoolTransactions(pool *MemoryTxPool, limit int) [][]byte {
+	if pool == nil || limit <= 0 {
+		return nil
+	}
+	pool.mu.RLock()
+	defer pool.mu.RUnlock()
+	capHint := len(pool.txs)
+	if limit < capHint {
+		capHint = limit
+	}
+	out := make([][]byte, 0, capHint)
+	for _, entry := range pool.txs {
+		out = append(out, entry.raw)
+		if len(out) >= limit {
+			break
+		}
+	}
+	return out
+}
+
+func compactCanonicalPoolTransactions(pool *CanonicalMempoolTxPool, limit int) [][]byte {
+	if pool == nil || pool.mempool == nil || limit <= 0 {
+		return nil
+	}
+	ids := pool.mempool.TxIDsLimit(limit)
+	out := make([][]byte, 0, len(ids))
+	for _, txid := range ids {
+		if tx, ok := pool.mempool.TxByID(txid); ok {
+			out = append(out, tx)
+		}
+	}
+	return out
 }
 
 func newCompactOutstandingRequest(block cmpctBlockPayload, blockHash [32]byte, result compactReconstructionResult) (compactOutstandingRequest, error) {

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -451,7 +451,7 @@ func compactMemoryPoolTransactions(pool *MemoryTxPool, limit int) [][]byte {
 	}
 	out := make([][]byte, 0, capHint)
 	for _, entry := range pool.txs {
-		out = append(out, entry.raw)
+		out = append(out, append([]byte(nil), entry.raw...))
 		if len(out) >= limit {
 			break
 		}

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -11,7 +11,8 @@ const (
 	compactDuplicateReportedIndex = ^uint64(0)
 	// Missing local candidates fall back to getblocktxn, so reconstruction
 	// must not scan an unbounded mempool snapshot before that fallback.
-	compactLocalTxCandidateLimit = defaultMaxTxPoolSize
+	compactLocalTxCandidateLimit      = defaultMaxTxPoolSize
+	compactLocalTxCandidateBytesLimit = consensus.MAX_BLOCK_BYTES
 )
 
 var errCompactRelayMissingRequestTooLarge = errors.New("too many compact relay missing transactions")
@@ -347,7 +348,8 @@ func (p *peer) rejectBlockTxn(msg string) error { p.bumpBan(10, msg); return err
 func (p *peer) processCompactTransactions(blockHash [32]byte, header [consensus.BLOCK_HEADER_BYTES]byte, txs [][]byte, fallbackOnApply bool) error {
 	blockBytes, err := compactBlockBytes(header, txs)
 	if err != nil {
-		return p.requestCompactFullBlockFallback(blockHash)
+		p.bumpBan(10, err.Error())
+		return err
 	}
 	if !fallbackOnApply {
 		return p.handleBlock(blockBytes)
@@ -388,10 +390,6 @@ func (p *peer) compactApplyErrorFallback(pb *consensus.ParsedBlock, blockHash [3
 		}
 		return true, err
 	}
-	if isConsensusApplyBlockError(err) {
-		p.recordRelayedBlockApplyError(err)
-		return false, err
-	}
 	p.recordRelayedBlockApplyError(err)
 	return false, err
 }
@@ -419,28 +417,32 @@ func compactBlockBytes(header [consensus.BLOCK_HEADER_BYTES]byte, txs [][]byte) 
 		if err != nil {
 			return nil, err
 		}
-		out = append(out, tx...)
-		totalTxBytes = nextTotal
-		if len(out) > consensus.MAX_BLOCK_BYTES {
+		if len(out) > consensus.MAX_BLOCK_BYTES-len(tx) {
 			return nil, errors.New("compact block exceeds block size")
 		}
+		out = append(out, tx...)
+		totalTxBytes = nextTotal
 	}
 	return out, nil
 }
 
 func compactRelayLocalTransactions(pool TxPool, limit int) [][]byte {
+	return compactRelayLocalTransactionsWithBudget(pool, limit, compactLocalTxCandidateBytesLimit)
+}
+
+func compactRelayLocalTransactionsWithBudget(pool TxPool, limit int, byteLimit int) [][]byte {
 	switch pool := pool.(type) {
 	case *MemoryTxPool:
-		return compactMemoryPoolTransactions(pool, limit)
+		return compactMemoryPoolTransactions(pool, limit, byteLimit)
 	case *CanonicalMempoolTxPool:
-		return compactCanonicalPoolTransactions(pool, limit)
+		return compactCanonicalPoolTransactions(pool, limit, byteLimit)
 	default:
 		return nil
 	}
 }
 
-func compactMemoryPoolTransactions(pool *MemoryTxPool, limit int) [][]byte {
-	if pool == nil || limit <= 0 {
+func compactMemoryPoolTransactions(pool *MemoryTxPool, limit int, byteLimit int) [][]byte {
+	if pool == nil || limit <= 0 || byteLimit <= 0 {
 		return nil
 	}
 	pool.mu.RLock()
@@ -450,8 +452,13 @@ func compactMemoryPoolTransactions(pool *MemoryTxPool, limit int) [][]byte {
 		capHint = limit
 	}
 	out := make([][]byte, 0, capHint)
+	totalBytes := 0
 	for _, entry := range pool.txs {
+		if byteLimit-totalBytes < len(entry.raw) {
+			break
+		}
 		out = append(out, append([]byte(nil), entry.raw...))
+		totalBytes += len(entry.raw)
 		if len(out) >= limit {
 			break
 		}
@@ -459,15 +466,20 @@ func compactMemoryPoolTransactions(pool *MemoryTxPool, limit int) [][]byte {
 	return out
 }
 
-func compactCanonicalPoolTransactions(pool *CanonicalMempoolTxPool, limit int) [][]byte {
-	if pool == nil || pool.mempool == nil || limit <= 0 {
+func compactCanonicalPoolTransactions(pool *CanonicalMempoolTxPool, limit int, byteLimit int) [][]byte {
+	if pool == nil || pool.mempool == nil || limit <= 0 || byteLimit <= 0 {
 		return nil
 	}
 	ids := pool.mempool.TxIDsLimit(limit)
 	out := make([][]byte, 0, len(ids))
+	totalBytes := 0
 	for _, txid := range ids {
 		if tx, ok := pool.mempool.TxByID(txid); ok {
+			if byteLimit-totalBytes < len(tx) {
+				break
+			}
 			out = append(out, tx)
+			totalBytes += len(tx)
 		}
 	}
 	return out

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -270,7 +270,7 @@ func (p *peer) handleCmpctBlock(payload []byte) error {
 		return err
 	}
 	if result.Transactions != nil {
-		return p.processCompactTransactions(blockHash, block.Header, result.Transactions)
+		return p.processCompactTransactions(blockHash, block.Header, result.Transactions, len(block.ShortIDs) > 0)
 	}
 	return p.requestMissingCompactTransactions(block, blockHash, result)
 }
@@ -334,7 +334,7 @@ func (p *peer) handleBlockTxn(payload []byte) error {
 	if err != nil {
 		return p.requestCompactFullBlockFallback(req.BlockHash)
 	}
-	return p.processCompactTransactions(req.BlockHash, req.Header, txs)
+	return p.processCompactTransactions(req.BlockHash, req.Header, txs, true)
 }
 
 func compactBlockTxnPayloadHash(payload []byte) ([32]byte, error) {
@@ -346,12 +346,12 @@ func compactBlockTxnPayloadHash(payload []byte) ([32]byte, error) {
 	return blockHash, nil
 }
 
-func (p *peer) processCompactTransactions(blockHash [32]byte, header [consensus.BLOCK_HEADER_BYTES]byte, txs [][]byte) error {
+func (p *peer) processCompactTransactions(blockHash [32]byte, header [consensus.BLOCK_HEADER_BYTES]byte, txs [][]byte, fallbackOnApply bool) error {
 	blockBytes, err := compactBlockBytes(header, txs)
 	if err != nil {
 		return p.requestCompactFullBlockFallback(blockHash)
 	}
-	accepted, fallback, err := p.processCompactRelayedBlock(blockHash, blockBytes)
+	accepted, fallback, err := p.processCompactRelayedBlock(blockHash, blockBytes, fallbackOnApply)
 	if fallback {
 		return p.requestCompactFullBlockFallback(blockHash)
 	}
@@ -361,7 +361,7 @@ func (p *peer) processCompactTransactions(blockHash [32]byte, header [consensus.
 	return p.service.requestBlocksIfBehind(p)
 }
 
-func (p *peer) processCompactRelayedBlock(expectedHash [32]byte, blockBytes []byte) (bool, bool, error) {
+func (p *peer) processCompactRelayedBlock(expectedHash [32]byte, blockBytes []byte, fallbackOnApply bool) (bool, bool, error) {
 	pb, blockHash, err := parseRelayedBlock(blockBytes)
 	if err != nil || pb == nil || blockHash != expectedHash {
 		return false, true, err
@@ -374,7 +374,7 @@ func (p *peer) processCompactRelayedBlock(expectedHash [32]byte, blockBytes []by
 	summary, err := p.service.cfg.SyncEngine.ApplyBlockWithReorg(blockBytes, nil)
 	p.service.chainMu.Unlock()
 	if err != nil {
-		if compactApplyErrorNeedsFullBlock(err) {
+		if fallbackOnApply && compactApplyErrorNeedsFullBlock(err) {
 			return false, true, err
 		}
 		p.recordRelayedBlockApplyError(err)

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -254,10 +254,7 @@ func (p *peer) handleCmpctBlock(payload []byte) error {
 	if err != nil {
 		return err
 	}
-	blockHash, err := consensus.BlockHash(block.Header[:])
-	if err != nil {
-		return err
-	}
+	blockHash, _ := consensus.BlockHash(block.Header[:]) // fixed-size header slice cannot hit the length error path
 	if err := p.validateCompactBlockHeader(block.Header); err != nil {
 		return err
 	}
@@ -279,11 +276,7 @@ func (p *peer) handleCmpctBlock(payload []byte) error {
 }
 
 func (p *peer) validateCompactBlockHeader(header [consensus.BLOCK_HEADER_BYTES]byte) error {
-	parsed, err := consensus.ParseBlockHeaderBytes(header[:])
-	if err != nil {
-		p.bumpBan(10, err.Error())
-		return err
-	}
+	parsed, _ := consensus.ParseBlockHeaderBytes(header[:]) // fixed-size header slice cannot hit the length error path
 	if err := consensus.PowCheck(header[:], parsed.Target); err != nil {
 		p.bumpBan(100, err.Error())
 		return err

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -310,10 +310,11 @@ func (p *peer) requestMissingCompactTransactions(block cmpctBlockPayload, blockH
 }
 
 func (p *peer) handleBlockTxn(payload []byte) error {
-	responseHash, err := compactBlockTxnPayloadHash(payload)
-	if err != nil {
-		return err
+	if len(payload) < 32 {
+		return errors.New("blocktxn payload missing block hash")
 	}
+	var responseHash [32]byte
+	copy(responseHash[:], payload[:32])
 	req, ok := p.compactOutstandingRequestSnapshot()
 	if !ok {
 		return errors.New("unexpected blocktxn response")
@@ -337,15 +338,6 @@ func (p *peer) handleBlockTxn(payload []byte) error {
 		return err
 	}
 	return p.processCompactTransactions(req.BlockHash, req.Header, txs, true)
-}
-
-func compactBlockTxnPayloadHash(payload []byte) ([32]byte, error) {
-	var blockHash [32]byte
-	if len(payload) < 32 {
-		return blockHash, errors.New("blocktxn payload missing block hash")
-	}
-	copy(blockHash[:], payload[:32])
-	return blockHash, nil
 }
 
 func (p *peer) processCompactTransactions(blockHash [32]byte, header [consensus.BLOCK_HEADER_BYTES]byte, txs [][]byte, fallbackOnApply bool) error {
@@ -376,7 +368,7 @@ func (p *peer) processCompactRelayedBlock(expectedHash [32]byte, blockBytes []by
 	summary, err := p.service.cfg.SyncEngine.ApplyBlockWithReorg(blockBytes, nil)
 	p.service.chainMu.Unlock()
 	if err != nil {
-		if fallbackOnApply && compactApplyErrorNeedsFullBlock(err) {
+		if fallbackOnApply && (errors.Is(err, node.ErrParentNotFound) || isConsensusApplyBlockError(err)) {
 			return false, true, err
 		}
 		p.recordRelayedBlockApplyError(err)
@@ -384,10 +376,6 @@ func (p *peer) processCompactRelayedBlock(expectedHash [32]byte, blockBytes []by
 	}
 	p.acceptedRelayedBlock(blockHash, summary)
 	return true, false, nil
-}
-
-func compactApplyErrorNeedsFullBlock(err error) bool {
-	return errors.Is(err, node.ErrParentNotFound) || isConsensusApplyBlockError(err)
 }
 
 func (p *peer) requestCompactFullBlockFallback(blockHash [32]byte) error {
@@ -425,39 +413,31 @@ func compactBlockBytes(header [consensus.BLOCK_HEADER_BYTES]byte, txs [][]byte) 
 func compactRelayLocalTransactions(pool TxPool) [][]byte {
 	switch pool := pool.(type) {
 	case *MemoryTxPool:
-		return compactRelayMemoryPoolTransactions(pool)
+		if pool == nil {
+			return nil
+		}
+		pool.mu.RLock()
+		defer pool.mu.RUnlock()
+		out := make([][]byte, 0, len(pool.txs))
+		for _, entry := range pool.txs {
+			out = append(out, entry.raw)
+		}
+		return out
 	case *CanonicalMempoolTxPool:
-		return compactRelayCanonicalPoolTransactions(pool)
+		if pool == nil || pool.mempool == nil {
+			return nil
+		}
+		ids := pool.mempool.AllTxIDs()
+		out := make([][]byte, 0, len(ids))
+		for _, txid := range ids {
+			if tx, ok := pool.mempool.TxByID(txid); ok {
+				out = append(out, tx)
+			}
+		}
+		return out
 	default:
 		return nil
 	}
-}
-
-func compactRelayMemoryPoolTransactions(pool *MemoryTxPool) [][]byte {
-	if pool == nil {
-		return nil
-	}
-	pool.mu.RLock()
-	defer pool.mu.RUnlock()
-	out := make([][]byte, 0, len(pool.txs))
-	for _, entry := range pool.txs {
-		out = append(out, entry.raw)
-	}
-	return out
-}
-
-func compactRelayCanonicalPoolTransactions(pool *CanonicalMempoolTxPool) [][]byte {
-	if pool == nil || pool.mempool == nil {
-		return nil
-	}
-	ids := pool.mempool.AllTxIDs()
-	out := make([][]byte, 0, len(ids))
-	for _, txid := range ids {
-		if tx, ok := pool.mempool.TxByID(txid); ok {
-			out = append(out, tx)
-		}
-	}
-	return out
 }
 
 func newCompactOutstandingRequest(block cmpctBlockPayload, blockHash [32]byte, result compactReconstructionResult) (compactOutstandingRequest, error) {

--- a/clients/go/node/p2p/compact_reconstruct_test.go
+++ b/clients/go/node/p2p/compact_reconstruct_test.go
@@ -429,7 +429,6 @@ func TestHandleCmpctBlockRuntimeFlowAndEdges(t *testing.T) {
 	if err := newPeerRuntimeTestPeer(t).handleCmpctBlock(bad); err == nil {
 		t.Fatal("invalid compact header should fail")
 	}
-
 	header, blockHash, txs := devnetGenesisCompactParts(t)
 	p := newPeerRuntimeTestPeer(t)
 	p.conn = &scriptedConn{}
@@ -445,7 +444,6 @@ func TestHandleCmpctBlockRuntimeFlowAndEdges(t *testing.T) {
 	if snap, ok := p.compactOutstandingRequestSnapshot(); !ok || snap.BlockHash != blockHash || snap.BlockTxnPayloadCap == 0 {
 		t.Fatalf("outstanding=%+v ok=%v, want stored request", snap, ok)
 	}
-
 	p = newPeerRuntimeTestPeer(t)
 	p.conn = &scriptedConn{}
 	full := mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{Header: header, Prefilled: []prefilledTxn{{Index: 0, Tx: txs[0]}}})
@@ -458,7 +456,15 @@ func TestHandleCmpctBlockRuntimeFlowAndEdges(t *testing.T) {
 	if err := p.handleCmpctBlock(full); err != nil || p.conn.(*scriptedConn).Buffer.Len() != 0 {
 		t.Fatalf("duplicate compact block err=%v writes=%d, want silent skip", err, p.conn.(*scriptedConn).Buffer.Len())
 	}
-
+	p = newPeerRuntimeTestPeer(t)
+	p.conn = &scriptedConn{}
+	badFull := mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{Header: header, Prefilled: []prefilledTxn{{Index: 0, Tx: minimalBlockTxnTestTxBytes(62)}}})
+	if err := p.handleCmpctBlock(badFull); err == nil {
+		t.Fatal("fully prefilled invalid compact block should fail")
+	}
+	if state := p.snapshotState(); state.BanScore < 100 || p.conn.(*scriptedConn).Buffer.Len() != 0 {
+		t.Fatalf("fully prefilled invalid compact state=%+v writes=%d, want ban without fallback", state, p.conn.(*scriptedConn).Buffer.Len())
+	}
 	p = newPeerRuntimeTestPeer(t)
 	p.conn = &scriptedConn{}
 	overflow := mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{Header: header, ShortIDs: make([]compactShortID, maxCompactRelayEntries+1)})
@@ -481,7 +487,6 @@ func TestHandleBlockTxnRuntimeFlowAndEdges(t *testing.T) {
 	if err := p.handleBlockTxn(body); err == nil || !strings.Contains(err.Error(), "mismatch") {
 		t.Fatalf("wrong-hash blocktxn err=%v, want mismatch", err)
 	}
-
 	header, blockHash, txs := devnetGenesisCompactParts(t)
 	p = newPeerRuntimeTestPeer(t)
 	p.conn = &scriptedConn{}
@@ -490,7 +495,6 @@ func TestHandleBlockTxnRuntimeFlowAndEdges(t *testing.T) {
 		t.Fatalf("malformed matching blocktxn should fall back: %v", err)
 	}
 	_ = readScriptedConnFrame(t, p)
-
 	p = newPeerRuntimeTestPeer(t)
 	p.conn = &scriptedConn{}
 	p.setRemoteCompactMode(compactModeSnapshot{Mode: 1, Version: compactRelayVersion})
@@ -508,7 +512,6 @@ func TestHandleBlockTxnRuntimeFlowAndEdges(t *testing.T) {
 	if have, err := p.service.hasBlock(blockHash); err != nil || !have {
 		t.Fatalf("hasBlock=%v err=%v, want applied compact block", have, err)
 	}
-
 	p = newPeerRuntimeTestPeer(t)
 	p.conn = &scriptedConn{}
 	setCompactTestOutstanding(p, blockHash, header, txs[0], compactShortID{0xbb}, 301, 302)

--- a/clients/go/node/p2p/compact_reconstruct_test.go
+++ b/clients/go/node/p2p/compact_reconstruct_test.go
@@ -479,8 +479,10 @@ func TestHandleCmpctBlockRuntimeFlowAndEdges(t *testing.T) {
 		t.Fatal("send failure left outstanding or nil compact pool returned entries")
 	}
 	p = newCompactScriptedPeer(t)
-	requireNoCompactErr(t, p.processCompactTransactions(blockHash, header, nil, true), "empty compact fallback")
-	requireCompactFrame(t, p, messageGetData, "empty compact fallback")
+	err := p.processCompactTransactions(blockHash, header, [][]byte{make([]byte, consensus.MAX_BLOCK_BYTES)}, true)
+	if err == nil || !strings.Contains(err.Error(), "compact block exceeds block size") || p.snapshotState().BanScore == 0 || p.conn.(*scriptedConn).Buffer.Len() != 0 {
+		t.Fatalf("oversize compact err=%v state=%+v writes=%d", err, p.snapshotState(), p.conn.(*scriptedConn).Buffer.Len())
+	}
 	if fallback, err := p.processCompactRelayedBlockWithFallback(blockHash, nil); err == nil || !fallback {
 		t.Fatalf("malformed compact fallback=%v err=%v", fallback, err)
 	}
@@ -559,6 +561,10 @@ func TestCompactRelayLocalTransactionsBoundsMemoryPoolSnapshot(t *testing.T) {
 	}
 	if got := compactRelayLocalTransactions(pool, 0); got != nil {
 		t.Fatalf("zero-limit snapshot=%v, want nil", got)
+	}
+	byteCap := len(minimalBlockTxnTestTxBytes(1))
+	if got := compactRelayLocalTransactionsWithBudget(pool, 4, byteCap); len(got) != 1 {
+		t.Fatalf("byte-bounded snapshot len=%d, want 1", len(got))
 	}
 	aliasPool := NewMemoryTxPoolWithLimit(1)
 	aliasRaw := minimalBlockTxnTestTxBytes(99)

--- a/clients/go/node/p2p/compact_reconstruct_test.go
+++ b/clients/go/node/p2p/compact_reconstruct_test.go
@@ -424,8 +424,8 @@ func TestCompactFillResponseTransactionsRejectsAggregateOversize(t *testing.T) {
 func TestHandleCmpctBlockRuntimeFlowAndEdges(t *testing.T) {
 	header, blockHash, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
 	full := mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{Header: header, Prefilled: []prefilledTxn{{Index: 0, Tx: txs[0]}}})
-	p := newCompactScriptedPeer(t)
 	missing := mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{Header: header, Nonce1: 101, Nonce2: 102, ShortIDs: []compactShortID{{0xaa}}})
+	p := newCompactScriptedPeer(t)
 	requireNoCompactErr(t, p.handleCmpctBlock(missing), "missing compact block")
 	requireCompactFrame(t, p, messageGetBlockTxn, "getblocktxn")
 	if snap, ok := p.compactOutstandingRequestSnapshot(); !ok || snap.BlockHash != blockHash || snap.BlockTxnPayloadCap == 0 {
@@ -433,32 +433,34 @@ func TestHandleCmpctBlockRuntimeFlowAndEdges(t *testing.T) {
 	}
 	p = newCompactScriptedPeer(t)
 	requireNoCompactErr(t, p.handleCmpctBlock(full), "complete compact block")
-	requireNoCompactErr(t, p.handleCmpctBlock(full), "known compact block")
-	p = newCompactScriptedPeer(t)
 	wrongTarget := [32]byte{0xff}
 	p.service.cfg.SyncConfig.ExpectedTarget = &wrongTarget
+	requireNoCompactErr(t, p.handleCmpctBlock(full), "known compact block")
+	if fallback, err := p.processCompactRelayedBlockWithFallback(blockHash, node.DevnetGenesisBlockBytes()); err != nil || fallback {
+		t.Fatalf("known compact block fallback=%v err=%v", fallback, err)
+	}
+	p = newCompactScriptedPeer(t)
+	requireCompactErr(t, p.validateCompactBlockHeader([consensus.BLOCK_HEADER_BYTES]byte{}), "bad compact header pow")
+	p = newCompactScriptedPeer(t)
+	p.service.cfg.SyncConfig.ExpectedTarget = &wrongTarget
 	requireCompactErr(t, p.handleCmpctBlock(full), "target mismatch")
-	var badHeader [consensus.BLOCK_HEADER_BYTES]byte
-	requireCompactErr(t, p.validateCompactBlockHeader(badHeader), "bad pow")
 	p = newCompactScriptedPeer(t)
 	badFull := mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{Header: header, Prefilled: []prefilledTxn{{Index: 0, Tx: minimalBlockTxnTestTxBytes(62)}}})
 	requireCompactErr(t, p.handleCmpctBlock(badFull), "fully prefilled invalid compact block should fail")
 	if state := p.snapshotState(); state.BanScore < 100 || p.conn.(*scriptedConn).Buffer.Len() != 0 {
 		t.Fatalf("bad full state=%+v writes=%d", state, p.conn.(*scriptedConn).Buffer.Len())
 	}
-	p = newPeerRuntimeTestPeer(t)
-	p.service.cfg.TxPool.Put([32]byte{0x77}, []byte{0x01}, 1, 1)
-	requireCompactErr(t, p.handleCmpctBlock(missing), "noncanonical local tx candidate should reject compact reconstruction")
+	p = newCompactScriptedPeer(t)
+	p.service.cfg.TxPool.Put([32]byte{0x77}, append(append([]byte(nil), txs[0]...), 0x00), 1, 1)
+	requireCompactErr(t, p.handleCmpctBlock(missing), "noncanonical local compact candidate")
 	p = newCompactScriptedPeer(t)
 	p.setCompactOutstandingRequest(compactOutstandingRequest{BlockHash: [32]byte{0x01}})
 	requireNoCompactErr(t, p.handleCmpctBlock(missing), "concurrent outstanding")
-	requireCompactFrame(t, p, messageGetData, "concurrent outstanding fallback")
 	p = newCompactScriptedPeer(t)
 	tooMany := mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{Header: header, ShortIDs: make([]compactShortID, maxCompactRelayEntries+1)})
 	requireNoCompactErr(t, p.handleCmpctBlock(tooMany), "missing overflow fallback")
-	requireCompactFrame(t, p, messageGetData, "missing overflow fallback")
 	p = newCompactScriptedPeer(t)
-	requireCompactErr(t, p.requestMissingCompactTransactions(cmpctBlockPayload{Header: header}, blockHash, compactReconstructionResult{MissingIndexes: []uint64{0}}), "mismatched missing request should fail")
+	requireCompactErr(t, p.requestMissingCompactTransactions(cmpctBlockPayload{Header: header}, blockHash, compactReconstructionResult{MissingIndexes: []uint64{0}}), "mismatched missing request")
 	p = newCompactScriptedPeer(t)
 	p.service.cfg.PeerRuntimeConfig.MaxMessageSize = 1
 	requireCompactErr(t, p.requestMissingCompactTransactions(cmpctBlockPayload{Header: header}, blockHash, compactReconstructionResult{PartialTransactions: [][]byte{nil}, MissingIndexes: []uint64{0}, MissingShortIDs: []compactShortID{{0xcc}}}), "send failure should reject missing request")
@@ -466,11 +468,11 @@ func TestHandleCmpctBlockRuntimeFlowAndEdges(t *testing.T) {
 		t.Fatal("send failure left outstanding or nil compact pool returned entries")
 	}
 	p = newCompactScriptedPeer(t)
-	requireNoCompactErr(t, p.processCompactTransactions(blockHash, header, nil, true), "invalid tx fallback")
-	requireCompactFrame(t, p, messageGetData, "invalid tx fallback")
-	p = newCompactScriptedPeer(t)
-	requireNoCompactErr(t, p.processCompactTransactions(blockHash, header, [][]byte{nil}, true), "nil transaction fallback")
-	requireCompactFrame(t, p, messageGetData, "nil transaction fallback")
+	requireNoCompactErr(t, p.processCompactTransactions(blockHash, header, nil, true), "empty compact fallback")
+	requireCompactFrame(t, p, messageGetData, "empty compact fallback")
+	if fallback, err := p.processCompactRelayedBlockWithFallback(blockHash, nil); err == nil || !fallback {
+		t.Fatalf("malformed compact fallback=%v err=%v", fallback, err)
+	}
 	_, orphanBytes := testHarnessBlockAtHeight(t, newTestHarness(t, 3, "127.0.0.1:0", nil), 2)
 	orphanHeader, orphanHash, orphanTxs := compactPartsFromBlockBytes(t, orphanBytes)
 	p = newCompactScriptedPeer(t)
@@ -480,21 +482,22 @@ func TestHandleCmpctBlockRuntimeFlowAndEdges(t *testing.T) {
 	p = newCompactScriptedPeer(t)
 	requireNoCompactErr(t, p.processCompactTransactions(orphanHash, orphanHeader, orphanTxs, true), "apply fallback")
 	requireCompactFrame(t, p, messageGetData, "apply fallback")
-	if fallback, err := p.processCompactRelayedBlockWithFallback(blockHash, nil); err == nil || !fallback {
-		t.Fatalf("parse fallback=%v err=%v", fallback, err)
+	if p.service.orphans.Len() != 1 {
+		t.Fatalf("reconstructed orphan not retained before fallback: %d", p.service.orphans.Len())
 	}
 }
 
 func TestHandleBlockTxnRuntimeFlowAndEdges(t *testing.T) {
-	requireCompactErr(t, newPeerRuntimeTestPeer(t).handleBlockTxn(nil), "short blocktxn should fail")
-	body := make([]byte, 32)
-	if err := newPeerRuntimeTestPeer(t).handleBlockTxn(body); err == nil || !strings.Contains(err.Error(), "unexpected") {
-		t.Fatalf("unsolicited blocktxn err=%v", err)
-	}
 	p := newPeerRuntimeTestPeer(t)
+	requireCompactErr(t, p.handleBlockTxn(nil), "short blocktxn should fail")
+	body := make([]byte, 32)
+	if err := p.handleBlockTxn(body); err == nil || !strings.Contains(err.Error(), "unexpected") || p.snapshotState().BanScore == 0 {
+		t.Fatalf("unsolicited blocktxn err=%v state=%+v", err, p.snapshotState())
+	}
+	p = newPeerRuntimeTestPeer(t)
 	p.setCompactOutstandingRequest(compactOutstandingRequest{BlockHash: [32]byte{0x01}})
-	if err := p.handleBlockTxn(body); err == nil || !strings.Contains(err.Error(), "mismatch") {
-		t.Fatalf("wrong-hash blocktxn err=%v", err)
+	if err := p.handleBlockTxn(body); err == nil || !strings.Contains(err.Error(), "mismatch") || p.snapshotState().BanScore == 0 {
+		t.Fatalf("wrong-hash blocktxn err=%v state=%+v", err, p.snapshotState())
 	}
 	header, blockHash, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
 	p = newCompactScriptedPeer(t)

--- a/clients/go/node/p2p/compact_reconstruct_test.go
+++ b/clients/go/node/p2p/compact_reconstruct_test.go
@@ -421,60 +421,85 @@ func TestCompactFillResponseTransactionsRejectsAggregateOversize(t *testing.T) {
 	}
 }
 
-func TestHandleCmpctBlockRequestsMissingTransactions(t *testing.T) {
+func TestHandleCmpctBlockRuntimeFlowAndEdges(t *testing.T) {
+	if err := newPeerRuntimeTestPeer(t).handleCmpctBlock(nil); err == nil {
+		t.Fatal("malformed cmpctblock should fail")
+	}
+	bad := mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{Prefilled: []prefilledTxn{{Index: 0, Tx: minimalBlockTxnTestTxBytes(61)}}})
+	if err := newPeerRuntimeTestPeer(t).handleCmpctBlock(bad); err == nil {
+		t.Fatal("invalid compact header should fail")
+	}
+
+	header, blockHash, txs := devnetGenesisCompactParts(t)
 	p := newPeerRuntimeTestPeer(t)
 	p.conn = &scriptedConn{}
-	p.setRemoteCompactMode(compactModeSnapshot{Mode: 1, Version: compactRelayVersion})
-	header, blockHash, _ := devnetGenesisCompactParts(t)
-	payload, err := encodeCmpctBlockPayload(cmpctBlockPayload{
-		Header:   header,
-		Nonce1:   101,
-		Nonce2:   102,
-		ShortIDs: []compactShortID{{0xaa}},
-	})
-	if err != nil {
-		t.Fatalf("encodeCmpctBlockPayload: %v", err)
-	}
-	if err := p.handleMessage(message{Command: messageCmpctBlock, Payload: payload}); err != nil {
-		t.Fatalf("handle cmpctblock: %v", err)
+	missing := mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{Header: header, Nonce1: 101, Nonce2: 102, ShortIDs: []compactShortID{{0xaa}}})
+	if err := p.handleCmpctBlock(missing); err != nil {
+		t.Fatalf("missing compact block: %v", err)
 	}
 	frame := readScriptedConnFrame(t, p)
-	if frame.Command != messageGetBlockTxn {
-		t.Fatalf("command=%s, want getblocktxn", frame.Command)
-	}
 	req, err := decodeGetBlockTxnPayload(frame.Payload)
-	if err != nil {
-		t.Fatalf("decode getblocktxn: %v", err)
-	}
-	if req.BlockHash != blockHash || !reflect.DeepEqual(req.Indexes, []uint64{0}) {
-		t.Fatalf("getblocktxn=%+v want hash=%x indexes=[0]", req, blockHash)
+	if err != nil || frame.Command != messageGetBlockTxn || req.BlockHash != blockHash || !reflect.DeepEqual(req.Indexes, []uint64{0}) {
+		t.Fatalf("getblocktxn frame=%+v req=%+v err=%v, want hash=%x indexes=[0]", frame, req, err, blockHash)
 	}
 	if snap, ok := p.compactOutstandingRequestSnapshot(); !ok || snap.BlockHash != blockHash || snap.BlockTxnPayloadCap == 0 {
 		t.Fatalf("outstanding=%+v ok=%v, want stored request", snap, ok)
 	}
+
+	p = newPeerRuntimeTestPeer(t)
+	p.conn = &scriptedConn{}
+	full := mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{Header: header, Prefilled: []prefilledTxn{{Index: 0, Tx: txs[0]}}})
+	if err := p.handleCmpctBlock(full); err != nil {
+		t.Fatalf("complete compact block: %v", err)
+	}
+	if have, err := p.service.hasBlock(blockHash); err != nil || !have {
+		t.Fatalf("hasBlock=%v err=%v, want applied compact block", have, err)
+	}
+	if err := p.handleCmpctBlock(full); err != nil || p.conn.(*scriptedConn).Buffer.Len() != 0 {
+		t.Fatalf("duplicate compact block err=%v writes=%d, want silent skip", err, p.conn.(*scriptedConn).Buffer.Len())
+	}
+
+	p = newPeerRuntimeTestPeer(t)
+	p.conn = &scriptedConn{}
+	overflow := mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{Header: header, ShortIDs: make([]compactShortID, maxCompactRelayEntries+1)})
+	if err := p.handleCmpctBlock(overflow); err != nil {
+		t.Fatalf("overflow compact block: %v", err)
+	}
+	_ = readScriptedConnFrame(t, p)
 }
 
-func TestHandleBlockTxnCompletesOutstandingBlock(t *testing.T) {
+func TestHandleBlockTxnRuntimeFlowAndEdges(t *testing.T) {
+	if err := newPeerRuntimeTestPeer(t).handleBlockTxn(nil); err == nil {
+		t.Fatal("short blocktxn should fail before outstanding lookup")
+	}
+	body := make([]byte, 32)
+	if err := newPeerRuntimeTestPeer(t).handleBlockTxn(body); err == nil || !strings.Contains(err.Error(), "unexpected") {
+		t.Fatalf("unsolicited blocktxn err=%v, want unexpected", err)
+	}
 	p := newPeerRuntimeTestPeer(t)
+	p.setCompactOutstandingRequest(compactOutstandingRequest{BlockHash: [32]byte{0x01}})
+	if err := p.handleBlockTxn(body); err == nil || !strings.Contains(err.Error(), "mismatch") {
+		t.Fatalf("wrong-hash blocktxn err=%v, want mismatch", err)
+	}
+
+	header, blockHash, txs := devnetGenesisCompactParts(t)
+	p = newPeerRuntimeTestPeer(t)
+	p.conn = &scriptedConn{}
+	p.setCompactOutstandingRequest(compactOutstandingRequest{})
+	if err := p.handleBlockTxn(body); err != nil {
+		t.Fatalf("malformed matching blocktxn should fall back: %v", err)
+	}
+	_ = readScriptedConnFrame(t, p)
+
+	p = newPeerRuntimeTestPeer(t)
 	p.conn = &scriptedConn{}
 	p.setRemoteCompactMode(compactModeSnapshot{Mode: 1, Version: compactRelayVersion})
-	header, blockHash, txs := devnetGenesisCompactParts(t)
-	tx := txs[0]
-	p.setCompactOutstandingRequest(compactOutstandingRequest{
-		BlockHash:          blockHash,
-		Header:             header,
-		MissingIndexes:     []uint64{0},
-		MissingShortIDs:    []compactShortID{compactShortIDForTx(t, tx, 201, 202)},
-		Transactions:       [][]byte{nil},
-		Nonce1:             201,
-		Nonce2:             202,
-		BlockTxnPayloadCap: compactRelayPayloadCap(messageBlockTxn),
-	})
-	body, err := encodeBlockTxnPayload(blockTxnPayload{BlockHash: blockHash, Transactions: [][]byte{tx}})
+	setCompactTestOutstanding(p, blockHash, header, txs[0], compactShortIDForTx(t, txs[0], 201, 202), 201, 202)
+	valid, err := encodeBlockTxnPayload(blockTxnPayload{BlockHash: blockHash, Transactions: [][]byte{txs[0]}})
 	if err != nil {
 		t.Fatalf("encode blocktxn: %v", err)
 	}
-	if err := p.handleMessage(message{Command: messageBlockTxn, Payload: body}); err != nil {
+	if err := p.handleMessage(message{Command: messageBlockTxn, Payload: valid}); err != nil {
 		t.Fatalf("handle blocktxn: %v", err)
 	}
 	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
@@ -483,54 +508,21 @@ func TestHandleBlockTxnCompletesOutstandingBlock(t *testing.T) {
 	if have, err := p.service.hasBlock(blockHash); err != nil || !have {
 		t.Fatalf("hasBlock=%v err=%v, want applied compact block", have, err)
 	}
-}
 
-func TestHandleBlockTxnMismatchFallsBackFullBlock(t *testing.T) {
-	p := newPeerRuntimeTestPeer(t)
+	p = newPeerRuntimeTestPeer(t)
 	p.conn = &scriptedConn{}
-	p.setRemoteCompactMode(compactModeSnapshot{Mode: 1, Version: compactRelayVersion})
-	header, blockHash, txs := devnetGenesisCompactParts(t)
-	p.setCompactOutstandingRequest(compactOutstandingRequest{
-		BlockHash:          blockHash,
-		Header:             header,
-		MissingIndexes:     []uint64{0},
-		MissingShortIDs:    []compactShortID{{0xbb}},
-		Transactions:       [][]byte{nil},
-		Nonce1:             301,
-		Nonce2:             302,
-		BlockTxnPayloadCap: compactRelayPayloadCap(messageBlockTxn),
-	})
-	body, err := encodeBlockTxnPayload(blockTxnPayload{BlockHash: blockHash, Transactions: [][]byte{txs[0]}})
-	if err != nil {
-		t.Fatalf("encode blocktxn: %v", err)
-	}
-	if err := p.handleMessage(message{Command: messageBlockTxn, Payload: body}); err != nil {
+	setCompactTestOutstanding(p, blockHash, header, txs[0], compactShortID{0xbb}, 301, 302)
+	if err := p.handleBlockTxn(valid); err != nil {
 		t.Fatalf("handle blocktxn mismatch: %v", err)
 	}
-	frame := readScriptedConnFrame(t, p)
-	if frame.Command != messageGetData {
-		t.Fatalf("fallback command=%s, want getdata", frame.Command)
-	}
-	items, err := decodeInventoryVectors(frame.Payload)
-	if err != nil {
-		t.Fatalf("decode getdata: %v", err)
-	}
-	if len(items) != 1 || items[0] != (InventoryVector{Type: MSG_BLOCK, Hash: blockHash}) {
-		t.Fatalf("fallback items=%+v, want MSG_BLOCK %x", items, blockHash)
+	if frame := readScriptedConnFrame(t, p); frame.Command != messageGetData {
+		t.Fatalf("mismatch fallback command=%s, want getdata", frame.Command)
 	}
 	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
 		t.Fatal("fallback did not clear outstanding request")
 	}
-}
-
-func TestReconstructCompactBlockSkipsLocalLookupForPrefilledOnlyBlock(t *testing.T) {
-	validTx := minimalBlockTxnTestTxBytes(61)
-	result, err := reconstructCompactBlock(cmpctBlockPayload{Prefilled: []prefilledTxn{{Index: 0, Tx: validTx}}}, [][]byte{{0xff}})
-	if err != nil {
-		t.Fatalf("prefilled-only compact block should not index local candidates: %v", err)
-	}
-	if !reflect.DeepEqual(result.Transactions, [][]byte{validTx}) || result.MissingIndexes != nil {
-		t.Fatalf("result=%+v, want prefilled-only reconstruction", result)
+	if !compactApplyErrorNeedsFullBlock(node.ErrParentNotFound) || !compactApplyErrorNeedsFullBlock(&consensus.TxError{Code: consensus.TX_ERR_PARSE, Msg: "bad compact block"}) {
+		t.Fatal("compact apply parent/consensus errors should fall back")
 	}
 }
 
@@ -547,6 +539,22 @@ func compactWTxIDForTx(t *testing.T, tx []byte) [32]byte {
 		t.Fatalf("ParseTx: consumed=%d err=%v", consumed, err)
 	}
 	return wtxid
+}
+
+func mustEncodeCmpctBlockPayload(t *testing.T, in cmpctBlockPayload) []byte {
+	t.Helper()
+	raw, err := encodeCmpctBlockPayload(in)
+	if err != nil {
+		t.Fatalf("encodeCmpctBlockPayload: %v", err)
+	}
+	return raw
+}
+
+func setCompactTestOutstanding(p *peer, blockHash [32]byte, header [consensus.BLOCK_HEADER_BYTES]byte, tx []byte, shortID compactShortID, nonce1, nonce2 uint64) {
+	p.setCompactOutstandingRequest(compactOutstandingRequest{
+		BlockHash: blockHash, Header: header, MissingIndexes: []uint64{0}, MissingShortIDs: []compactShortID{shortID},
+		Transactions: [][]byte{nil}, Nonce1: nonce1, Nonce2: nonce2, BlockTxnPayloadCap: compactRelayPayloadCap(messageBlockTxn),
+	})
 }
 
 func devnetGenesisCompactParts(t *testing.T) ([consensus.BLOCK_HEADER_BYTES]byte, [32]byte, [][]byte) {

--- a/clients/go/node/p2p/compact_reconstruct_test.go
+++ b/clients/go/node/p2p/compact_reconstruct_test.go
@@ -1,12 +1,14 @@
 package p2p
 
 import (
+	"bytes"
 	"errors"
 	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/node"
 )
 
 func TestReconstructCompactBlockCompletesExactPositionsFromWTxID(t *testing.T) {
@@ -419,6 +421,108 @@ func TestCompactFillResponseTransactionsRejectsAggregateOversize(t *testing.T) {
 	}
 }
 
+func TestHandleCmpctBlockRequestsMissingTransactions(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	p.conn = &scriptedConn{}
+	p.setRemoteCompactMode(compactModeSnapshot{Mode: 1, Version: compactRelayVersion})
+	header, blockHash, _ := devnetGenesisCompactParts(t)
+	payload, err := encodeCmpctBlockPayload(cmpctBlockPayload{
+		Header:   header,
+		Nonce1:   101,
+		Nonce2:   102,
+		ShortIDs: []compactShortID{{0xaa}},
+	})
+	if err != nil {
+		t.Fatalf("encodeCmpctBlockPayload: %v", err)
+	}
+	if err := p.handleMessage(message{Command: messageCmpctBlock, Payload: payload}); err != nil {
+		t.Fatalf("handle cmpctblock: %v", err)
+	}
+	frame := readScriptedConnFrame(t, p)
+	if frame.Command != messageGetBlockTxn {
+		t.Fatalf("command=%s, want getblocktxn", frame.Command)
+	}
+	req, err := decodeGetBlockTxnPayload(frame.Payload)
+	if err != nil {
+		t.Fatalf("decode getblocktxn: %v", err)
+	}
+	if req.BlockHash != blockHash || !reflect.DeepEqual(req.Indexes, []uint64{0}) {
+		t.Fatalf("getblocktxn=%+v want hash=%x indexes=[0]", req, blockHash)
+	}
+	if snap, ok := p.compactOutstandingRequestSnapshot(); !ok || snap.BlockHash != blockHash || snap.BlockTxnPayloadCap == 0 {
+		t.Fatalf("outstanding=%+v ok=%v, want stored request", snap, ok)
+	}
+}
+
+func TestHandleBlockTxnCompletesOutstandingBlock(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	p.conn = &scriptedConn{}
+	p.setRemoteCompactMode(compactModeSnapshot{Mode: 1, Version: compactRelayVersion})
+	header, blockHash, txs := devnetGenesisCompactParts(t)
+	tx := txs[0]
+	p.setCompactOutstandingRequest(compactOutstandingRequest{
+		BlockHash:          blockHash,
+		Header:             header,
+		MissingIndexes:     []uint64{0},
+		MissingShortIDs:    []compactShortID{compactShortIDForTx(t, tx, 201, 202)},
+		Transactions:       [][]byte{nil},
+		Nonce1:             201,
+		Nonce2:             202,
+		BlockTxnPayloadCap: compactRelayPayloadCap(messageBlockTxn),
+	})
+	body, err := encodeBlockTxnPayload(blockTxnPayload{BlockHash: blockHash, Transactions: [][]byte{tx}})
+	if err != nil {
+		t.Fatalf("encode blocktxn: %v", err)
+	}
+	if err := p.handleMessage(message{Command: messageBlockTxn, Payload: body}); err != nil {
+		t.Fatalf("handle blocktxn: %v", err)
+	}
+	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatal("outstanding request was not cleared")
+	}
+	if have, err := p.service.hasBlock(blockHash); err != nil || !have {
+		t.Fatalf("hasBlock=%v err=%v, want applied compact block", have, err)
+	}
+}
+
+func TestHandleBlockTxnMismatchFallsBackFullBlock(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	p.conn = &scriptedConn{}
+	p.setRemoteCompactMode(compactModeSnapshot{Mode: 1, Version: compactRelayVersion})
+	header, blockHash, txs := devnetGenesisCompactParts(t)
+	p.setCompactOutstandingRequest(compactOutstandingRequest{
+		BlockHash:          blockHash,
+		Header:             header,
+		MissingIndexes:     []uint64{0},
+		MissingShortIDs:    []compactShortID{{0xbb}},
+		Transactions:       [][]byte{nil},
+		Nonce1:             301,
+		Nonce2:             302,
+		BlockTxnPayloadCap: compactRelayPayloadCap(messageBlockTxn),
+	})
+	body, err := encodeBlockTxnPayload(blockTxnPayload{BlockHash: blockHash, Transactions: [][]byte{txs[0]}})
+	if err != nil {
+		t.Fatalf("encode blocktxn: %v", err)
+	}
+	if err := p.handleMessage(message{Command: messageBlockTxn, Payload: body}); err != nil {
+		t.Fatalf("handle blocktxn mismatch: %v", err)
+	}
+	frame := readScriptedConnFrame(t, p)
+	if frame.Command != messageGetData {
+		t.Fatalf("fallback command=%s, want getdata", frame.Command)
+	}
+	items, err := decodeInventoryVectors(frame.Payload)
+	if err != nil {
+		t.Fatalf("decode getdata: %v", err)
+	}
+	if len(items) != 1 || items[0] != (InventoryVector{Type: MSG_BLOCK, Hash: blockHash}) {
+		t.Fatalf("fallback items=%+v, want MSG_BLOCK %x", items, blockHash)
+	}
+	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatal("fallback did not clear outstanding request")
+	}
+}
+
 func TestReconstructCompactBlockSkipsLocalLookupForPrefilledOnlyBlock(t *testing.T) {
 	validTx := minimalBlockTxnTestTxBytes(61)
 	result, err := reconstructCompactBlock(cmpctBlockPayload{Prefilled: []prefilledTxn{{Index: 0, Tx: validTx}}}, [][]byte{{0xff}})
@@ -443,4 +547,35 @@ func compactWTxIDForTx(t *testing.T, tx []byte) [32]byte {
 		t.Fatalf("ParseTx: consumed=%d err=%v", consumed, err)
 	}
 	return wtxid
+}
+
+func devnetGenesisCompactParts(t *testing.T) ([consensus.BLOCK_HEADER_BYTES]byte, [32]byte, [][]byte) {
+	t.Helper()
+	block := node.DevnetGenesisBlockBytes()
+	pb, err := consensus.ParseBlockBytes(block)
+	if err != nil {
+		t.Fatalf("ParseBlockBytes(genesis): %v", err)
+	}
+	blockHash, err := consensus.BlockHash(pb.HeaderBytes)
+	if err != nil {
+		t.Fatalf("BlockHash(genesis): %v", err)
+	}
+	var header [consensus.BLOCK_HEADER_BYTES]byte
+	copy(header[:], pb.HeaderBytes)
+	offset := consensus.BLOCK_HEADER_BYTES + len(consensus.EncodeCompactSize(pb.TxCount))
+	return header, blockHash, [][]byte{append([]byte(nil), block[offset:]...)}
+}
+
+func readScriptedConnFrame(t *testing.T, p *peer) message {
+	t.Helper()
+	conn, ok := p.conn.(*scriptedConn)
+	if !ok {
+		t.Fatalf("peer conn=%T, want *scriptedConn", p.conn)
+	}
+	frame, err := readFrame(bytes.NewReader(conn.Buffer.Bytes()), networkMagic(p.service.cfg.PeerRuntimeConfig.Network), p.service.cfg.PeerRuntimeConfig.MaxMessageSize)
+	if err != nil {
+		t.Fatalf("readFrame: %v", err)
+	}
+	conn.Buffer.Reset()
+	return frame
 }

--- a/clients/go/node/p2p/compact_reconstruct_test.go
+++ b/clients/go/node/p2p/compact_reconstruct_test.go
@@ -422,80 +422,92 @@ func TestCompactFillResponseTransactionsRejectsAggregateOversize(t *testing.T) {
 }
 
 func TestHandleCmpctBlockRuntimeFlowAndEdges(t *testing.T) {
-	if err := newPeerRuntimeTestPeer(t).handleCmpctBlock(nil); err == nil {
-		t.Fatal("malformed cmpctblock should fail")
-	}
-	bad := mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{Prefilled: []prefilledTxn{{Index: 0, Tx: minimalBlockTxnTestTxBytes(61)}}})
-	if err := newPeerRuntimeTestPeer(t).handleCmpctBlock(bad); err == nil {
-		t.Fatal("invalid compact header should fail")
-	}
 	header, blockHash, txs := devnetGenesisCompactParts(t)
+	full := mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{Header: header, Prefilled: []prefilledTxn{{Index: 0, Tx: txs[0]}}})
 	p := newPeerRuntimeTestPeer(t)
-	p.conn = &scriptedConn{}
+	badTarget := [32]byte{0x01}
+	p.service.cfg.SyncConfig.ExpectedTarget = &badTarget
+	if err := p.handleCmpctBlock(full); err == nil || p.snapshotState().BanScore < 100 {
+		t.Fatalf("target mismatch err=%v state=%+v", err, p.snapshotState())
+	}
+	p = newCompactScriptedPeer(t)
 	missing := mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{Header: header, Nonce1: 101, Nonce2: 102, ShortIDs: []compactShortID{{0xaa}}})
 	if err := p.handleCmpctBlock(missing); err != nil {
 		t.Fatalf("missing compact block: %v", err)
 	}
 	frame := readScriptedConnFrame(t, p)
-	req, err := decodeGetBlockTxnPayload(frame.Payload)
-	if err != nil || frame.Command != messageGetBlockTxn || req.BlockHash != blockHash || !reflect.DeepEqual(req.Indexes, []uint64{0}) {
-		t.Fatalf("getblocktxn frame=%+v req=%+v err=%v, want hash=%x indexes=[0]", frame, req, err, blockHash)
+	if frame.Command != messageGetBlockTxn {
+		t.Fatalf("getblocktxn frame=%+v", frame)
 	}
 	if snap, ok := p.compactOutstandingRequestSnapshot(); !ok || snap.BlockHash != blockHash || snap.BlockTxnPayloadCap == 0 {
-		t.Fatalf("outstanding=%+v ok=%v, want stored request", snap, ok)
+		t.Fatalf("outstanding=%+v ok=%v", snap, ok)
 	}
-	p = newPeerRuntimeTestPeer(t)
-	p.conn = &scriptedConn{}
-	full := mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{Header: header, Prefilled: []prefilledTxn{{Index: 0, Tx: txs[0]}}})
+	p = newCompactScriptedPeer(t)
 	if err := p.handleCmpctBlock(full); err != nil {
 		t.Fatalf("complete compact block: %v", err)
 	}
 	if have, err := p.service.hasBlock(blockHash); err != nil || !have {
-		t.Fatalf("hasBlock=%v err=%v, want applied compact block", have, err)
+		t.Fatalf("hasBlock=%v err=%v", have, err)
 	}
-	if err := p.handleCmpctBlock(full); err != nil || p.conn.(*scriptedConn).Buffer.Len() != 0 {
-		t.Fatalf("duplicate compact block err=%v writes=%d, want silent skip", err, p.conn.(*scriptedConn).Buffer.Len())
-	}
-	p = newPeerRuntimeTestPeer(t)
-	p.conn = &scriptedConn{}
+	p = newCompactScriptedPeer(t)
 	badFull := mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{Header: header, Prefilled: []prefilledTxn{{Index: 0, Tx: minimalBlockTxnTestTxBytes(62)}}})
 	if err := p.handleCmpctBlock(badFull); err == nil {
 		t.Fatal("fully prefilled invalid compact block should fail")
 	}
 	if state := p.snapshotState(); state.BanScore < 100 || p.conn.(*scriptedConn).Buffer.Len() != 0 {
-		t.Fatalf("fully prefilled invalid compact state=%+v writes=%d, want ban without fallback", state, p.conn.(*scriptedConn).Buffer.Len())
+		t.Fatalf("bad full state=%+v writes=%d", state, p.conn.(*scriptedConn).Buffer.Len())
 	}
 	p = newPeerRuntimeTestPeer(t)
-	p.conn = &scriptedConn{}
-	overflow := mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{Header: header, ShortIDs: make([]compactShortID, maxCompactRelayEntries+1)})
-	if err := p.handleCmpctBlock(overflow); err != nil {
-		t.Fatalf("overflow compact block: %v", err)
+	p.service.cfg.TxPool.Put([32]byte{0x77}, []byte{0x01}, 1, 1)
+	if err := p.handleCmpctBlock(missing); err == nil {
+		t.Fatal("noncanonical local tx candidate should reject compact reconstruction")
 	}
-	_ = readScriptedConnFrame(t, p)
+	p = newCompactScriptedPeer(t)
+	p.setCompactOutstandingRequest(compactOutstandingRequest{BlockHash: [32]byte{0x01}})
+	if err := p.handleCmpctBlock(missing); err != nil || readScriptedConnFrame(t, p).Command != messageGetData {
+		t.Fatalf("concurrent outstanding err=%v", err)
+	}
+	p = newCompactScriptedPeer(t)
+	p.service.cfg.PeerRuntimeConfig.MaxMessageSize = 1
+	if err := p.requestMissingCompactTransactions(cmpctBlockPayload{Header: header}, blockHash, compactReconstructionResult{PartialTransactions: [][]byte{nil}, MissingIndexes: []uint64{0}, MissingShortIDs: []compactShortID{{0xcc}}}); err == nil {
+		t.Fatal("send failure should reject missing request")
+	}
+	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatal("send failure left outstanding compact request")
+	}
+	p = newCompactScriptedPeer(t)
+	if err := p.processCompactTransactions(blockHash, header, nil, true); err != nil || readScriptedConnFrame(t, p).Command != messageGetData {
+		t.Fatalf("invalid tx fallback err=%v", err)
+	}
+	p = newCompactScriptedPeer(t)
+	unknownParentHeader := header
+	unknownParentHeader[0] ^= 0x01
+	unknownParentHash, _ := consensus.BlockHash(unknownParentHeader[:])
+	if err := p.processCompactTransactions(unknownParentHash, unknownParentHeader, txs, true); err != nil || readScriptedConnFrame(t, p).Command != messageGetData {
+		t.Fatalf("apply fallback err=%v", err)
+	}
 }
 
 func TestHandleBlockTxnRuntimeFlowAndEdges(t *testing.T) {
 	if err := newPeerRuntimeTestPeer(t).handleBlockTxn(nil); err == nil {
-		t.Fatal("short blocktxn should fail before outstanding lookup")
+		t.Fatal("short blocktxn should fail")
 	}
 	body := make([]byte, 32)
 	if err := newPeerRuntimeTestPeer(t).handleBlockTxn(body); err == nil || !strings.Contains(err.Error(), "unexpected") {
-		t.Fatalf("unsolicited blocktxn err=%v, want unexpected", err)
+		t.Fatalf("unsolicited blocktxn err=%v", err)
 	}
 	p := newPeerRuntimeTestPeer(t)
 	p.setCompactOutstandingRequest(compactOutstandingRequest{BlockHash: [32]byte{0x01}})
 	if err := p.handleBlockTxn(body); err == nil || !strings.Contains(err.Error(), "mismatch") {
-		t.Fatalf("wrong-hash blocktxn err=%v, want mismatch", err)
+		t.Fatalf("wrong-hash blocktxn err=%v", err)
 	}
 	header, blockHash, txs := devnetGenesisCompactParts(t)
-	p = newPeerRuntimeTestPeer(t)
-	p.conn = &scriptedConn{}
+	p = newCompactScriptedPeer(t)
 	p.setCompactOutstandingRequest(compactOutstandingRequest{})
 	if err := p.handleBlockTxn(body); err == nil || p.conn.(*scriptedConn).Buffer.Len() != 0 || p.snapshotState().BanScore == 0 {
-		t.Fatalf("malformed matching blocktxn err=%v state=%+v writes=%d, want reject without fallback", err, p.snapshotState(), p.conn.(*scriptedConn).Buffer.Len())
+		t.Fatalf("malformed blocktxn err=%v state=%+v", err, p.snapshotState())
 	}
-	p = newPeerRuntimeTestPeer(t)
-	p.conn = &scriptedConn{}
+	p = newCompactScriptedPeer(t)
 	p.setRemoteCompactMode(compactModeSnapshot{Mode: 1, Version: compactRelayVersion})
 	setCompactTestOutstanding(p, blockHash, header, txs[0], compactShortIDForTx(t, txs[0], 201, 202), 201, 202)
 	valid, err := encodeBlockTxnPayload(blockTxnPayload{BlockHash: blockHash, Transactions: [][]byte{txs[0]}})
@@ -509,16 +521,12 @@ func TestHandleBlockTxnRuntimeFlowAndEdges(t *testing.T) {
 		t.Fatal("outstanding request was not cleared")
 	}
 	if have, err := p.service.hasBlock(blockHash); err != nil || !have {
-		t.Fatalf("hasBlock=%v err=%v, want applied compact block", have, err)
+		t.Fatalf("hasBlock=%v err=%v", have, err)
 	}
-	p = newPeerRuntimeTestPeer(t)
-	p.conn = &scriptedConn{}
+	p = newCompactScriptedPeer(t)
 	setCompactTestOutstanding(p, blockHash, header, txs[0], compactShortID{0xbb}, 301, 302)
 	if err := p.handleBlockTxn(valid); err == nil || p.conn.(*scriptedConn).Buffer.Len() != 0 || p.snapshotState().BanScore == 0 {
-		t.Fatalf("mismatched blocktxn err=%v state=%+v writes=%d, want reject without fallback", err, p.snapshotState(), p.conn.(*scriptedConn).Buffer.Len())
-	}
-	if !compactApplyErrorNeedsFullBlock(node.ErrParentNotFound) || !compactApplyErrorNeedsFullBlock(&consensus.TxError{Code: consensus.TX_ERR_PARSE, Msg: "bad compact block"}) {
-		t.Fatal("compact apply parent/consensus errors should fall back")
+		t.Fatalf("mismatched blocktxn err=%v state=%+v", err, p.snapshotState())
 	}
 }
 
@@ -541,9 +549,16 @@ func mustEncodeCmpctBlockPayload(t *testing.T, in cmpctBlockPayload) []byte {
 	t.Helper()
 	raw, err := encodeCmpctBlockPayload(in)
 	if err != nil {
-		t.Fatalf("encodeCmpctBlockPayload: %v", err)
+		t.Fatal(err)
 	}
 	return raw
+}
+
+func newCompactScriptedPeer(t *testing.T) *peer {
+	t.Helper()
+	p := newPeerRuntimeTestPeer(t)
+	p.conn = &scriptedConn{}
+	return p
 }
 
 func setCompactTestOutstanding(p *peer, blockHash [32]byte, header [consensus.BLOCK_HEADER_BYTES]byte, tx []byte, shortID compactShortID, nonce1, nonce2 uint64) {
@@ -569,7 +584,7 @@ func readScriptedConnFrame(t *testing.T, p *peer) message {
 	conn := p.conn.(*scriptedConn)
 	frame, err := readFrame(bytes.NewReader(conn.Buffer.Bytes()), networkMagic(p.service.cfg.PeerRuntimeConfig.Network), p.service.cfg.PeerRuntimeConfig.MaxMessageSize)
 	if err != nil {
-		t.Fatalf("readFrame: %v", err)
+		t.Fatal(err)
 	}
 	conn.Buffer.Reset()
 	return frame

--- a/clients/go/node/p2p/compact_reconstruct_test.go
+++ b/clients/go/node/p2p/compact_reconstruct_test.go
@@ -424,13 +424,7 @@ func TestCompactFillResponseTransactionsRejectsAggregateOversize(t *testing.T) {
 func TestHandleCmpctBlockRuntimeFlowAndEdges(t *testing.T) {
 	header, blockHash, txs := devnetGenesisCompactParts(t)
 	full := mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{Header: header, Prefilled: []prefilledTxn{{Index: 0, Tx: txs[0]}}})
-	p := newPeerRuntimeTestPeer(t)
-	badTarget := [32]byte{0x01}
-	p.service.cfg.SyncConfig.ExpectedTarget = &badTarget
-	if err := p.handleCmpctBlock(full); err == nil || p.snapshotState().BanScore < 100 {
-		t.Fatalf("target mismatch err=%v state=%+v", err, p.snapshotState())
-	}
-	p = newCompactScriptedPeer(t)
+	p := newCompactScriptedPeer(t)
 	missing := mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{Header: header, Nonce1: 101, Nonce2: 102, ShortIDs: []compactShortID{{0xaa}}})
 	if err := p.handleCmpctBlock(missing); err != nil {
 		t.Fatalf("missing compact block: %v", err)
@@ -445,9 +439,6 @@ func TestHandleCmpctBlockRuntimeFlowAndEdges(t *testing.T) {
 	p = newCompactScriptedPeer(t)
 	if err := p.handleCmpctBlock(full); err != nil {
 		t.Fatalf("complete compact block: %v", err)
-	}
-	if have, err := p.service.hasBlock(blockHash); err != nil || !have {
-		t.Fatalf("hasBlock=%v err=%v", have, err)
 	}
 	p = newCompactScriptedPeer(t)
 	badFull := mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{Header: header, Prefilled: []prefilledTxn{{Index: 0, Tx: minimalBlockTxnTestTxBytes(62)}}})
@@ -479,11 +470,14 @@ func TestHandleCmpctBlockRuntimeFlowAndEdges(t *testing.T) {
 	if err := p.processCompactTransactions(blockHash, header, nil, true); err != nil || readScriptedConnFrame(t, p).Command != messageGetData {
 		t.Fatalf("invalid tx fallback err=%v", err)
 	}
+	_, orphanBytes := testHarnessBlockAtHeight(t, newTestHarness(t, 3, "127.0.0.1:0", nil), 2)
+	orphanHeader, orphanHash, orphanTxs := compactPartsFromBlockBytes(t, orphanBytes)
 	p = newCompactScriptedPeer(t)
-	unknownParentHeader := header
-	unknownParentHeader[0] ^= 0x01
-	unknownParentHash, _ := consensus.BlockHash(unknownParentHeader[:])
-	if err := p.processCompactTransactions(unknownParentHash, unknownParentHeader, txs, true); err != nil || readScriptedConnFrame(t, p).Command != messageGetData {
+	if err := p.processCompactTransactions(orphanHash, orphanHeader, orphanTxs, false); err != nil || p.service.orphans.Len() != 1 {
+		t.Fatalf("orphan compact err=%v orphans=%d", err, p.service.orphans.Len())
+	}
+	p = newCompactScriptedPeer(t)
+	if err := p.processCompactTransactions(orphanHash, orphanHeader, orphanTxs, true); err != nil || readScriptedConnFrame(t, p).Command != messageGetData {
 		t.Fatalf("apply fallback err=%v", err)
 	}
 }
@@ -567,7 +561,11 @@ func setCompactTestOutstanding(p *peer, blockHash [32]byte, header [consensus.BL
 
 func devnetGenesisCompactParts(t *testing.T) ([consensus.BLOCK_HEADER_BYTES]byte, [32]byte, [][]byte) {
 	t.Helper()
-	block := node.DevnetGenesisBlockBytes()
+	return compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
+}
+
+func compactPartsFromBlockBytes(t *testing.T, block []byte) ([consensus.BLOCK_HEADER_BYTES]byte, [32]byte, [][]byte) {
+	t.Helper()
 	pb, err := consensus.ParseBlockBytes(block)
 	if err != nil {
 		t.Fatalf("ParseBlockBytes(genesis): %v", err)

--- a/clients/go/node/p2p/compact_reconstruct_test.go
+++ b/clients/go/node/p2p/compact_reconstruct_test.go
@@ -560,6 +560,21 @@ func TestCompactRelayLocalTransactionsBoundsMemoryPoolSnapshot(t *testing.T) {
 	if got := compactRelayLocalTransactions(pool, 0); got != nil {
 		t.Fatalf("zero-limit snapshot=%v, want nil", got)
 	}
+	aliasPool := NewMemoryTxPoolWithLimit(1)
+	aliasRaw := minimalBlockTxnTestTxBytes(99)
+	_, aliasTxid, _, _, err := consensus.ParseTx(aliasRaw)
+	requireNoCompactErr(t, err, "ParseTx alias")
+	if !aliasPool.Put(aliasTxid, aliasRaw, 1, len(aliasRaw)) {
+		t.Fatal("Put alias tx rejected")
+	}
+	got := compactRelayLocalTransactions(aliasPool, 1)
+	if len(got) != 1 || len(got[0]) == 0 {
+		t.Fatalf("alias snapshot=%v", got)
+	}
+	got[0][0] ^= 0xff
+	if stored, ok := aliasPool.Get(aliasTxid); !ok || stored[0] == got[0][0] {
+		t.Fatal("bounded snapshot aliases memory pool transaction bytes")
+	}
 }
 
 func compactShortIDForTx(t *testing.T, tx []byte, nonce1, nonce2 uint64) compactShortID {
@@ -603,7 +618,23 @@ func compactPartsFromBlockBytes(t *testing.T, block []byte) ([consensus.BLOCK_HE
 	var header [consensus.BLOCK_HEADER_BYTES]byte
 	copy(header[:], pb.HeaderBytes)
 	offset := consensus.BLOCK_HEADER_BYTES + len(consensus.EncodeCompactSize(pb.TxCount))
-	return header, blockHash, [][]byte{append([]byte(nil), block[offset:]...)}
+	if pb.TxCount > uint64(len(block)) {
+		t.Fatalf("tx count %d exceeds block length %d", pb.TxCount, len(block))
+	}
+	txs := make([][]byte, 0, int(pb.TxCount))
+	for i := uint64(0); i < pb.TxCount; i++ {
+		_, _, _, consumed, err := consensus.ParseTx(block[offset:])
+		requireNoCompactErr(t, err, "ParseTx")
+		if consumed <= 0 || offset+consumed > len(block) {
+			t.Fatalf("ParseTx consumed=%d offset=%d block_len=%d", consumed, offset, len(block))
+		}
+		txs = append(txs, append([]byte(nil), block[offset:offset+consumed]...))
+		offset += consumed
+	}
+	if offset != len(block) {
+		t.Fatalf("trailing block bytes after tx parse: offset=%d len=%d", offset, len(block))
+	}
+	return header, blockHash, txs
 }
 
 func requireCompactFrame(t *testing.T, p *peer, command string, label string) {

--- a/clients/go/node/p2p/compact_reconstruct_test.go
+++ b/clients/go/node/p2p/compact_reconstruct_test.go
@@ -422,54 +422,55 @@ func TestCompactFillResponseTransactionsRejectsAggregateOversize(t *testing.T) {
 }
 
 func TestHandleCmpctBlockRuntimeFlowAndEdges(t *testing.T) {
-	header, blockHash, txs := devnetGenesisCompactParts(t)
+	header, blockHash, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
 	full := mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{Header: header, Prefilled: []prefilledTxn{{Index: 0, Tx: txs[0]}}})
 	p := newCompactScriptedPeer(t)
 	missing := mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{Header: header, Nonce1: 101, Nonce2: 102, ShortIDs: []compactShortID{{0xaa}}})
-	if err := p.handleCmpctBlock(missing); err != nil {
-		t.Fatalf("missing compact block: %v", err)
-	}
-	frame := readScriptedConnFrame(t, p)
-	if frame.Command != messageGetBlockTxn {
-		t.Fatalf("getblocktxn frame=%+v", frame)
-	}
+	requireNoCompactErr(t, p.handleCmpctBlock(missing), "missing compact block")
+	requireCompactFrame(t, p, messageGetBlockTxn, "getblocktxn")
 	if snap, ok := p.compactOutstandingRequestSnapshot(); !ok || snap.BlockHash != blockHash || snap.BlockTxnPayloadCap == 0 {
 		t.Fatalf("outstanding=%+v ok=%v", snap, ok)
 	}
 	p = newCompactScriptedPeer(t)
-	if err := p.handleCmpctBlock(full); err != nil {
-		t.Fatalf("complete compact block: %v", err)
-	}
+	requireNoCompactErr(t, p.handleCmpctBlock(full), "complete compact block")
+	requireNoCompactErr(t, p.handleCmpctBlock(full), "known compact block")
+	p = newCompactScriptedPeer(t)
+	wrongTarget := [32]byte{0xff}
+	p.service.cfg.SyncConfig.ExpectedTarget = &wrongTarget
+	requireCompactErr(t, p.handleCmpctBlock(full), "target mismatch")
+	var badHeader [consensus.BLOCK_HEADER_BYTES]byte
+	requireCompactErr(t, p.validateCompactBlockHeader(badHeader), "bad pow")
 	p = newCompactScriptedPeer(t)
 	badFull := mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{Header: header, Prefilled: []prefilledTxn{{Index: 0, Tx: minimalBlockTxnTestTxBytes(62)}}})
-	if err := p.handleCmpctBlock(badFull); err == nil {
-		t.Fatal("fully prefilled invalid compact block should fail")
-	}
+	requireCompactErr(t, p.handleCmpctBlock(badFull), "fully prefilled invalid compact block should fail")
 	if state := p.snapshotState(); state.BanScore < 100 || p.conn.(*scriptedConn).Buffer.Len() != 0 {
 		t.Fatalf("bad full state=%+v writes=%d", state, p.conn.(*scriptedConn).Buffer.Len())
 	}
 	p = newPeerRuntimeTestPeer(t)
 	p.service.cfg.TxPool.Put([32]byte{0x77}, []byte{0x01}, 1, 1)
-	if err := p.handleCmpctBlock(missing); err == nil {
-		t.Fatal("noncanonical local tx candidate should reject compact reconstruction")
-	}
+	requireCompactErr(t, p.handleCmpctBlock(missing), "noncanonical local tx candidate should reject compact reconstruction")
 	p = newCompactScriptedPeer(t)
 	p.setCompactOutstandingRequest(compactOutstandingRequest{BlockHash: [32]byte{0x01}})
-	if err := p.handleCmpctBlock(missing); err != nil || readScriptedConnFrame(t, p).Command != messageGetData {
-		t.Fatalf("concurrent outstanding err=%v", err)
-	}
+	requireNoCompactErr(t, p.handleCmpctBlock(missing), "concurrent outstanding")
+	requireCompactFrame(t, p, messageGetData, "concurrent outstanding fallback")
+	p = newCompactScriptedPeer(t)
+	tooMany := mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{Header: header, ShortIDs: make([]compactShortID, maxCompactRelayEntries+1)})
+	requireNoCompactErr(t, p.handleCmpctBlock(tooMany), "missing overflow fallback")
+	requireCompactFrame(t, p, messageGetData, "missing overflow fallback")
+	p = newCompactScriptedPeer(t)
+	requireCompactErr(t, p.requestMissingCompactTransactions(cmpctBlockPayload{Header: header}, blockHash, compactReconstructionResult{MissingIndexes: []uint64{0}}), "mismatched missing request should fail")
 	p = newCompactScriptedPeer(t)
 	p.service.cfg.PeerRuntimeConfig.MaxMessageSize = 1
-	if err := p.requestMissingCompactTransactions(cmpctBlockPayload{Header: header}, blockHash, compactReconstructionResult{PartialTransactions: [][]byte{nil}, MissingIndexes: []uint64{0}, MissingShortIDs: []compactShortID{{0xcc}}}); err == nil {
-		t.Fatal("send failure should reject missing request")
-	}
-	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
-		t.Fatal("send failure left outstanding compact request")
+	requireCompactErr(t, p.requestMissingCompactTransactions(cmpctBlockPayload{Header: header}, blockHash, compactReconstructionResult{PartialTransactions: [][]byte{nil}, MissingIndexes: []uint64{0}, MissingShortIDs: []compactShortID{{0xcc}}}), "send failure should reject missing request")
+	if _, ok := p.compactOutstandingRequestSnapshot(); ok || compactRelayLocalTransactions((*MemoryTxPool)(nil)) != nil || compactRelayLocalTransactions((*CanonicalMempoolTxPool)(nil)) != nil {
+		t.Fatal("send failure left outstanding or nil compact pool returned entries")
 	}
 	p = newCompactScriptedPeer(t)
-	if err := p.processCompactTransactions(blockHash, header, nil, true); err != nil || readScriptedConnFrame(t, p).Command != messageGetData {
-		t.Fatalf("invalid tx fallback err=%v", err)
-	}
+	requireNoCompactErr(t, p.processCompactTransactions(blockHash, header, nil, true), "invalid tx fallback")
+	requireCompactFrame(t, p, messageGetData, "invalid tx fallback")
+	p = newCompactScriptedPeer(t)
+	requireNoCompactErr(t, p.processCompactTransactions(blockHash, header, [][]byte{nil}, true), "nil transaction fallback")
+	requireCompactFrame(t, p, messageGetData, "nil transaction fallback")
 	_, orphanBytes := testHarnessBlockAtHeight(t, newTestHarness(t, 3, "127.0.0.1:0", nil), 2)
 	orphanHeader, orphanHash, orphanTxs := compactPartsFromBlockBytes(t, orphanBytes)
 	p = newCompactScriptedPeer(t)
@@ -477,15 +478,15 @@ func TestHandleCmpctBlockRuntimeFlowAndEdges(t *testing.T) {
 		t.Fatalf("orphan compact err=%v orphans=%d", err, p.service.orphans.Len())
 	}
 	p = newCompactScriptedPeer(t)
-	if err := p.processCompactTransactions(orphanHash, orphanHeader, orphanTxs, true); err != nil || readScriptedConnFrame(t, p).Command != messageGetData {
-		t.Fatalf("apply fallback err=%v", err)
+	requireNoCompactErr(t, p.processCompactTransactions(orphanHash, orphanHeader, orphanTxs, true), "apply fallback")
+	requireCompactFrame(t, p, messageGetData, "apply fallback")
+	if fallback, err := p.processCompactRelayedBlockWithFallback(blockHash, nil); err == nil || !fallback {
+		t.Fatalf("parse fallback=%v err=%v", fallback, err)
 	}
 }
 
 func TestHandleBlockTxnRuntimeFlowAndEdges(t *testing.T) {
-	if err := newPeerRuntimeTestPeer(t).handleBlockTxn(nil); err == nil {
-		t.Fatal("short blocktxn should fail")
-	}
+	requireCompactErr(t, newPeerRuntimeTestPeer(t).handleBlockTxn(nil), "short blocktxn should fail")
 	body := make([]byte, 32)
 	if err := newPeerRuntimeTestPeer(t).handleBlockTxn(body); err == nil || !strings.Contains(err.Error(), "unexpected") {
 		t.Fatalf("unsolicited blocktxn err=%v", err)
@@ -495,7 +496,7 @@ func TestHandleBlockTxnRuntimeFlowAndEdges(t *testing.T) {
 	if err := p.handleBlockTxn(body); err == nil || !strings.Contains(err.Error(), "mismatch") {
 		t.Fatalf("wrong-hash blocktxn err=%v", err)
 	}
-	header, blockHash, txs := devnetGenesisCompactParts(t)
+	header, blockHash, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
 	p = newCompactScriptedPeer(t)
 	p.setCompactOutstandingRequest(compactOutstandingRequest{})
 	if err := p.handleBlockTxn(body); err == nil || p.conn.(*scriptedConn).Buffer.Len() != 0 || p.snapshotState().BanScore == 0 {
@@ -505,12 +506,8 @@ func TestHandleBlockTxnRuntimeFlowAndEdges(t *testing.T) {
 	p.setRemoteCompactMode(compactModeSnapshot{Mode: 1, Version: compactRelayVersion})
 	setCompactTestOutstanding(p, blockHash, header, txs[0], compactShortIDForTx(t, txs[0], 201, 202), 201, 202)
 	valid, err := encodeBlockTxnPayload(blockTxnPayload{BlockHash: blockHash, Transactions: [][]byte{txs[0]}})
-	if err != nil {
-		t.Fatalf("encode blocktxn: %v", err)
-	}
-	if err := p.handleMessage(message{Command: messageBlockTxn, Payload: valid}); err != nil {
-		t.Fatalf("handle blocktxn: %v", err)
-	}
+	requireNoCompactErr(t, err, "encode blocktxn")
+	requireNoCompactErr(t, p.handleMessage(message{Command: messageBlockTxn, Payload: valid}), "handle blocktxn")
 	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
 		t.Fatal("outstanding request was not cleared")
 	}
@@ -542,9 +539,7 @@ func compactWTxIDForTx(t *testing.T, tx []byte) [32]byte {
 func mustEncodeCmpctBlockPayload(t *testing.T, in cmpctBlockPayload) []byte {
 	t.Helper()
 	raw, err := encodeCmpctBlockPayload(in)
-	if err != nil {
-		t.Fatal(err)
-	}
+	requireNoCompactErr(t, err, "encode cmpctblock")
 	return raw
 }
 
@@ -559,17 +554,10 @@ func setCompactTestOutstanding(p *peer, blockHash [32]byte, header [consensus.BL
 	p.setCompactOutstandingRequest(compactOutstandingRequest{BlockHash: blockHash, Header: header, MissingIndexes: []uint64{0}, MissingShortIDs: []compactShortID{shortID}, Transactions: [][]byte{nil}, Nonce1: nonce1, Nonce2: nonce2, BlockTxnPayloadCap: compactRelayPayloadCap(messageBlockTxn)})
 }
 
-func devnetGenesisCompactParts(t *testing.T) ([consensus.BLOCK_HEADER_BYTES]byte, [32]byte, [][]byte) {
-	t.Helper()
-	return compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
-}
-
 func compactPartsFromBlockBytes(t *testing.T, block []byte) ([consensus.BLOCK_HEADER_BYTES]byte, [32]byte, [][]byte) {
 	t.Helper()
 	pb, err := consensus.ParseBlockBytes(block)
-	if err != nil {
-		t.Fatalf("ParseBlockBytes(genesis): %v", err)
-	}
+	requireNoCompactErr(t, err, "ParseBlockBytes")
 	blockHash, _ := consensus.BlockHash(pb.HeaderBytes)
 	var header [consensus.BLOCK_HEADER_BYTES]byte
 	copy(header[:], pb.HeaderBytes)
@@ -577,7 +565,7 @@ func compactPartsFromBlockBytes(t *testing.T, block []byte) ([consensus.BLOCK_HE
 	return header, blockHash, [][]byte{append([]byte(nil), block[offset:]...)}
 }
 
-func readScriptedConnFrame(t *testing.T, p *peer) message {
+func requireCompactFrame(t *testing.T, p *peer, command string, label string) {
 	t.Helper()
 	conn := p.conn.(*scriptedConn)
 	frame, err := readFrame(bytes.NewReader(conn.Buffer.Bytes()), networkMagic(p.service.cfg.PeerRuntimeConfig.Network), p.service.cfg.PeerRuntimeConfig.MaxMessageSize)
@@ -585,5 +573,21 @@ func readScriptedConnFrame(t *testing.T, p *peer) message {
 		t.Fatal(err)
 	}
 	conn.Buffer.Reset()
-	return frame
+	if frame.Command != command {
+		t.Fatalf("%s frame=%+v", label, frame)
+	}
+}
+
+func requireNoCompactErr(t *testing.T, err error, label string) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("%s: %v", label, err)
+	}
+}
+
+func requireCompactErr(t *testing.T, err error, label string) {
+	t.Helper()
+	if err == nil {
+		t.Fatal(label)
+	}
 }

--- a/clients/go/node/p2p/compact_reconstruct_test.go
+++ b/clients/go/node/p2p/compact_reconstruct_test.go
@@ -491,10 +491,9 @@ func TestHandleBlockTxnRuntimeFlowAndEdges(t *testing.T) {
 	p = newPeerRuntimeTestPeer(t)
 	p.conn = &scriptedConn{}
 	p.setCompactOutstandingRequest(compactOutstandingRequest{})
-	if err := p.handleBlockTxn(body); err != nil {
-		t.Fatalf("malformed matching blocktxn should fall back: %v", err)
+	if err := p.handleBlockTxn(body); err == nil || p.conn.(*scriptedConn).Buffer.Len() != 0 || p.snapshotState().BanScore == 0 {
+		t.Fatalf("malformed matching blocktxn err=%v state=%+v writes=%d, want reject without fallback", err, p.snapshotState(), p.conn.(*scriptedConn).Buffer.Len())
 	}
-	_ = readScriptedConnFrame(t, p)
 	p = newPeerRuntimeTestPeer(t)
 	p.conn = &scriptedConn{}
 	p.setRemoteCompactMode(compactModeSnapshot{Mode: 1, Version: compactRelayVersion})
@@ -515,14 +514,8 @@ func TestHandleBlockTxnRuntimeFlowAndEdges(t *testing.T) {
 	p = newPeerRuntimeTestPeer(t)
 	p.conn = &scriptedConn{}
 	setCompactTestOutstanding(p, blockHash, header, txs[0], compactShortID{0xbb}, 301, 302)
-	if err := p.handleBlockTxn(valid); err != nil {
-		t.Fatalf("handle blocktxn mismatch: %v", err)
-	}
-	if frame := readScriptedConnFrame(t, p); frame.Command != messageGetData {
-		t.Fatalf("mismatch fallback command=%s, want getdata", frame.Command)
-	}
-	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
-		t.Fatal("fallback did not clear outstanding request")
+	if err := p.handleBlockTxn(valid); err == nil || p.conn.(*scriptedConn).Buffer.Len() != 0 || p.snapshotState().BanScore == 0 {
+		t.Fatalf("mismatched blocktxn err=%v state=%+v writes=%d, want reject without fallback", err, p.snapshotState(), p.conn.(*scriptedConn).Buffer.Len())
 	}
 	if !compactApplyErrorNeedsFullBlock(node.ErrParentNotFound) || !compactApplyErrorNeedsFullBlock(&consensus.TxError{Code: consensus.TX_ERR_PARSE, Msg: "bad compact block"}) {
 		t.Fatal("compact apply parent/consensus errors should fall back")
@@ -554,10 +547,7 @@ func mustEncodeCmpctBlockPayload(t *testing.T, in cmpctBlockPayload) []byte {
 }
 
 func setCompactTestOutstanding(p *peer, blockHash [32]byte, header [consensus.BLOCK_HEADER_BYTES]byte, tx []byte, shortID compactShortID, nonce1, nonce2 uint64) {
-	p.setCompactOutstandingRequest(compactOutstandingRequest{
-		BlockHash: blockHash, Header: header, MissingIndexes: []uint64{0}, MissingShortIDs: []compactShortID{shortID},
-		Transactions: [][]byte{nil}, Nonce1: nonce1, Nonce2: nonce2, BlockTxnPayloadCap: compactRelayPayloadCap(messageBlockTxn),
-	})
+	p.setCompactOutstandingRequest(compactOutstandingRequest{BlockHash: blockHash, Header: header, MissingIndexes: []uint64{0}, MissingShortIDs: []compactShortID{shortID}, Transactions: [][]byte{nil}, Nonce1: nonce1, Nonce2: nonce2, BlockTxnPayloadCap: compactRelayPayloadCap(messageBlockTxn)})
 }
 
 func devnetGenesisCompactParts(t *testing.T) ([consensus.BLOCK_HEADER_BYTES]byte, [32]byte, [][]byte) {
@@ -567,10 +557,7 @@ func devnetGenesisCompactParts(t *testing.T) ([consensus.BLOCK_HEADER_BYTES]byte
 	if err != nil {
 		t.Fatalf("ParseBlockBytes(genesis): %v", err)
 	}
-	blockHash, err := consensus.BlockHash(pb.HeaderBytes)
-	if err != nil {
-		t.Fatalf("BlockHash(genesis): %v", err)
-	}
+	blockHash, _ := consensus.BlockHash(pb.HeaderBytes)
 	var header [consensus.BLOCK_HEADER_BYTES]byte
 	copy(header[:], pb.HeaderBytes)
 	offset := consensus.BLOCK_HEADER_BYTES + len(consensus.EncodeCompactSize(pb.TxCount))
@@ -579,10 +566,7 @@ func devnetGenesisCompactParts(t *testing.T) ([consensus.BLOCK_HEADER_BYTES]byte
 
 func readScriptedConnFrame(t *testing.T, p *peer) message {
 	t.Helper()
-	conn, ok := p.conn.(*scriptedConn)
-	if !ok {
-		t.Fatalf("peer conn=%T, want *scriptedConn", p.conn)
-	}
+	conn := p.conn.(*scriptedConn)
 	frame, err := readFrame(bytes.NewReader(conn.Buffer.Bytes()), networkMagic(p.service.cfg.PeerRuntimeConfig.Network), p.service.cfg.PeerRuntimeConfig.MaxMessageSize)
 	if err != nil {
 		t.Fatalf("readFrame: %v", err)

--- a/clients/go/node/p2p/compact_reconstruct_test.go
+++ b/clients/go/node/p2p/compact_reconstruct_test.go
@@ -159,6 +159,17 @@ func TestReconstructCompactBlockFailsClosedOnPrefilledShortIDCollision(t *testin
 	}
 }
 
+func TestReconstructCompactBlockSkipsLocalLookupForPrefilledOnlyBlock(t *testing.T) {
+	validTx := minimalBlockTxnTestTxBytes(61)
+	result, err := reconstructCompactBlock(cmpctBlockPayload{Prefilled: []prefilledTxn{{Index: 0, Tx: validTx}}}, [][]byte{{0xff}})
+	if err != nil {
+		t.Fatalf("prefilled-only compact block should not index local candidates: %v", err)
+	}
+	if !reflect.DeepEqual(result.Transactions, [][]byte{validTx}) || len(result.MissingIndexes) != 0 {
+		t.Fatalf("result=%+v, want completed prefilled-only block", result)
+	}
+}
+
 func TestReconstructCompactBlockRejectsMalformedInputs(t *testing.T) {
 	validTx := minimalBlockTxnTestTxBytes(41)
 	shortID := compactShortIDForTx(t, validTx, 1, 2)
@@ -424,8 +435,8 @@ func TestCompactFillResponseTransactionsRejectsAggregateOversize(t *testing.T) {
 func TestHandleCmpctBlockRuntimeFlowAndEdges(t *testing.T) {
 	header, blockHash, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
 	full := mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{Header: header, Prefilled: []prefilledTxn{{Index: 0, Tx: txs[0]}}})
-	p := newCompactScriptedPeer(t)
 	missing := mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{Header: header, Nonce1: 101, Nonce2: 102, ShortIDs: []compactShortID{{0xaa}}})
+	p := newCompactScriptedPeer(t)
 	requireNoCompactErr(t, p.handleCmpctBlock(missing), "missing compact block")
 	requireCompactFrame(t, p, messageGetBlockTxn, "getblocktxn")
 	if snap, ok := p.compactOutstandingRequestSnapshot(); !ok || snap.BlockHash != blockHash || snap.BlockTxnPayloadCap == 0 {
@@ -433,44 +444,51 @@ func TestHandleCmpctBlockRuntimeFlowAndEdges(t *testing.T) {
 	}
 	p = newCompactScriptedPeer(t)
 	requireNoCompactErr(t, p.handleCmpctBlock(full), "complete compact block")
-	requireNoCompactErr(t, p.handleCmpctBlock(full), "known compact block")
-	p = newCompactScriptedPeer(t)
 	wrongTarget := [32]byte{0xff}
 	p.service.cfg.SyncConfig.ExpectedTarget = &wrongTarget
+	requireNoCompactErr(t, p.handleCmpctBlock(full), "known compact block")
+	if fallback, err := p.processCompactRelayedBlockWithFallback(blockHash, node.DevnetGenesisBlockBytes()); err != nil || fallback {
+		t.Fatalf("known compact block fallback=%v err=%v", fallback, err)
+	}
+	p = newCompactScriptedPeer(t)
+	requireCompactErr(t, p.validateCompactBlockHeader([consensus.BLOCK_HEADER_BYTES]byte{}), "bad compact header pow")
+	p = newCompactScriptedPeer(t)
+	p.service.cfg.SyncConfig.ExpectedTarget = &wrongTarget
 	requireCompactErr(t, p.handleCmpctBlock(full), "target mismatch")
-	var badHeader [consensus.BLOCK_HEADER_BYTES]byte
-	requireCompactErr(t, p.validateCompactBlockHeader(badHeader), "bad pow")
 	p = newCompactScriptedPeer(t)
 	badFull := mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{Header: header, Prefilled: []prefilledTxn{{Index: 0, Tx: minimalBlockTxnTestTxBytes(62)}}})
 	requireCompactErr(t, p.handleCmpctBlock(badFull), "fully prefilled invalid compact block should fail")
 	if state := p.snapshotState(); state.BanScore < 100 || p.conn.(*scriptedConn).Buffer.Len() != 0 {
 		t.Fatalf("bad full state=%+v writes=%d", state, p.conn.(*scriptedConn).Buffer.Len())
 	}
-	p = newPeerRuntimeTestPeer(t)
-	p.service.cfg.TxPool.Put([32]byte{0x77}, []byte{0x01}, 1, 1)
-	requireCompactErr(t, p.handleCmpctBlock(missing), "noncanonical local tx candidate should reject compact reconstruction")
+	p = newCompactScriptedPeer(t)
+	p.service.cfg.TxPool.Put([32]byte{0x77}, append(append([]byte(nil), txs[0]...), 0x00), 1, 1)
+	requireCompactErr(t, p.handleCmpctBlock(missing), "noncanonical local compact candidate")
 	p = newCompactScriptedPeer(t)
 	p.setCompactOutstandingRequest(compactOutstandingRequest{BlockHash: [32]byte{0x01}})
 	requireNoCompactErr(t, p.handleCmpctBlock(missing), "concurrent outstanding")
-	requireCompactFrame(t, p, messageGetData, "concurrent outstanding fallback")
 	p = newCompactScriptedPeer(t)
 	tooMany := mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{Header: header, ShortIDs: make([]compactShortID, maxCompactRelayEntries+1)})
 	requireNoCompactErr(t, p.handleCmpctBlock(tooMany), "missing overflow fallback")
-	requireCompactFrame(t, p, messageGetData, "missing overflow fallback")
 	p = newCompactScriptedPeer(t)
-	requireCompactErr(t, p.requestMissingCompactTransactions(cmpctBlockPayload{Header: header}, blockHash, compactReconstructionResult{MissingIndexes: []uint64{0}}), "mismatched missing request should fail")
+	requireCompactErr(t, p.requestMissingCompactTransactions(cmpctBlockPayload{Header: header}, blockHash, compactReconstructionResult{MissingIndexes: []uint64{0}}), "mismatched missing request")
 	p = newCompactScriptedPeer(t)
 	p.service.cfg.PeerRuntimeConfig.MaxMessageSize = 1
 	requireCompactErr(t, p.requestMissingCompactTransactions(cmpctBlockPayload{Header: header}, blockHash, compactReconstructionResult{PartialTransactions: [][]byte{nil}, MissingIndexes: []uint64{0}, MissingShortIDs: []compactShortID{{0xcc}}}), "send failure should reject missing request")
-	if _, ok := p.compactOutstandingRequestSnapshot(); ok || compactRelayLocalTransactions((*MemoryTxPool)(nil)) != nil || compactRelayLocalTransactions((*CanonicalMempoolTxPool)(nil)) != nil {
+	if _, ok := p.compactOutstandingRequestSnapshot(); ok || compactRelayLocalTransactions((*MemoryTxPool)(nil), compactLocalTxCandidateLimit) != nil || compactRelayLocalTransactions((*CanonicalMempoolTxPool)(nil), compactLocalTxCandidateLimit) != nil {
 		t.Fatal("send failure left outstanding or nil compact pool returned entries")
 	}
 	p = newCompactScriptedPeer(t)
-	requireNoCompactErr(t, p.processCompactTransactions(blockHash, header, nil, true), "invalid tx fallback")
-	requireCompactFrame(t, p, messageGetData, "invalid tx fallback")
+	requireNoCompactErr(t, p.processCompactTransactions(blockHash, header, nil, true), "empty compact fallback")
+	requireCompactFrame(t, p, messageGetData, "empty compact fallback")
+	if fallback, err := p.processCompactRelayedBlockWithFallback(blockHash, nil); err == nil || !fallback {
+		t.Fatalf("malformed compact fallback=%v err=%v", fallback, err)
+	}
 	p = newCompactScriptedPeer(t)
-	requireNoCompactErr(t, p.processCompactTransactions(blockHash, header, [][]byte{nil}, true), "nil transaction fallback")
-	requireCompactFrame(t, p, messageGetData, "nil transaction fallback")
+	fallback, err := p.compactApplyErrorFallback(nil, blockHash, nil, &consensus.TxError{Code: consensus.TX_ERR_PARSE, Msg: "bad compact block"})
+	if err == nil || fallback || p.snapshotState().BanScore < 100 || p.conn.(*scriptedConn).Buffer.Len() != 0 {
+		t.Fatalf("consensus compact apply fallback=%v err=%v state=%+v writes=%d", fallback, err, p.snapshotState(), p.conn.(*scriptedConn).Buffer.Len())
+	}
 	_, orphanBytes := testHarnessBlockAtHeight(t, newTestHarness(t, 3, "127.0.0.1:0", nil), 2)
 	orphanHeader, orphanHash, orphanTxs := compactPartsFromBlockBytes(t, orphanBytes)
 	p = newCompactScriptedPeer(t)
@@ -480,21 +498,24 @@ func TestHandleCmpctBlockRuntimeFlowAndEdges(t *testing.T) {
 	p = newCompactScriptedPeer(t)
 	requireNoCompactErr(t, p.processCompactTransactions(orphanHash, orphanHeader, orphanTxs, true), "apply fallback")
 	requireCompactFrame(t, p, messageGetData, "apply fallback")
-	if fallback, err := p.processCompactRelayedBlockWithFallback(blockHash, nil); err == nil || !fallback {
-		t.Fatalf("parse fallback=%v err=%v", fallback, err)
+	if p.service.orphans.Len() != 1 {
+		t.Fatalf("reconstructed orphan not retained before fallback: %d", p.service.orphans.Len())
 	}
 }
 
 func TestHandleBlockTxnRuntimeFlowAndEdges(t *testing.T) {
-	requireCompactErr(t, newPeerRuntimeTestPeer(t).handleBlockTxn(nil), "short blocktxn should fail")
-	body := make([]byte, 32)
-	if err := newPeerRuntimeTestPeer(t).handleBlockTxn(body); err == nil || !strings.Contains(err.Error(), "unexpected") {
-		t.Fatalf("unsolicited blocktxn err=%v", err)
-	}
 	p := newPeerRuntimeTestPeer(t)
+	if err := p.handleBlockTxn(nil); err == nil || !strings.Contains(err.Error(), "missing block hash") || p.snapshotState().BanScore == 0 {
+		t.Fatalf("short blocktxn err=%v state=%+v", err, p.snapshotState())
+	}
+	body := make([]byte, 32)
+	if err := p.handleBlockTxn(body); err == nil || !strings.Contains(err.Error(), "unexpected") || p.snapshotState().BanScore == 0 {
+		t.Fatalf("unsolicited blocktxn err=%v state=%+v", err, p.snapshotState())
+	}
+	p = newPeerRuntimeTestPeer(t)
 	p.setCompactOutstandingRequest(compactOutstandingRequest{BlockHash: [32]byte{0x01}})
-	if err := p.handleBlockTxn(body); err == nil || !strings.Contains(err.Error(), "mismatch") {
-		t.Fatalf("wrong-hash blocktxn err=%v", err)
+	if err := p.handleBlockTxn(body); err == nil || !strings.Contains(err.Error(), "mismatch") || p.snapshotState().BanScore == 0 {
+		t.Fatalf("wrong-hash blocktxn err=%v state=%+v", err, p.snapshotState())
 	}
 	header, blockHash, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
 	p = newCompactScriptedPeer(t)
@@ -518,6 +539,26 @@ func TestHandleBlockTxnRuntimeFlowAndEdges(t *testing.T) {
 	setCompactTestOutstanding(p, blockHash, header, txs[0], compactShortID{0xbb}, 301, 302)
 	if err := p.handleBlockTxn(valid); err == nil || p.conn.(*scriptedConn).Buffer.Len() != 0 || p.snapshotState().BanScore == 0 {
 		t.Fatalf("mismatched blocktxn err=%v state=%+v", err, p.snapshotState())
+	}
+}
+
+func TestCompactRelayLocalTransactionsBoundsMemoryPoolSnapshot(t *testing.T) {
+	pool := NewMemoryTxPoolWithLimit(4)
+	for i := 0; i < 4; i++ {
+		raw := minimalBlockTxnTestTxBytes(uint64(i + 1))
+		_, txid, _, _, err := consensus.ParseTx(raw)
+		if err != nil {
+			t.Fatalf("ParseTx[%d]: %v", i, err)
+		}
+		if !pool.Put(txid, raw, uint64(i+1), len(raw)) {
+			t.Fatalf("Put[%d] rejected", i)
+		}
+	}
+	if got := compactRelayLocalTransactions(pool, 2); len(got) != 2 {
+		t.Fatalf("bounded snapshot len=%d, want 2", len(got))
+	}
+	if got := compactRelayLocalTransactions(pool, 0); got != nil {
+		t.Fatalf("zero-limit snapshot=%v, want nil", got)
 	}
 }
 

--- a/clients/go/node/p2p/peer_runtime.go
+++ b/clients/go/node/p2p/peer_runtime.go
@@ -52,8 +52,14 @@ func (p *peer) run(ctx context.Context) error {
 func (p *peer) postHandshakePayloadCap() payloadLimitFn {
 	base := postHandshakePayloadCap(p.service.cfg.LocatorLimit, p.service.cfg.SyncConfig.HeaderBatchLimit)
 	return func(command string) uint32 {
-		if isCompactRelayObjectCommand(command) {
+		if command == messageGetBlockTxn {
 			return 0
+		}
+		if isCompactRelayObjectCommand(command) && !p.compactRelayEnabled() {
+			return 0
+		}
+		if command == messageBlockTxn {
+			return p.blockTxnPayloadCap()
 		}
 		return base(command)
 	}
@@ -94,7 +100,7 @@ func normalizeReadError(err error) error {
 
 func (p *peer) handleMessage(frame message) error {
 	switch frame.Command {
-	case messageInv, messageGetData, messageBlock, messageTx, messageGetBlk:
+	case messageInv, messageGetData, messageBlock, messageTx, messageGetBlk, messageCmpctBlock, messageBlockTxn:
 		return p.handleRelayMessage(frame)
 	case messageSendCmpct:
 		return p.handleSendCmpct(frame.Payload)
@@ -115,7 +121,7 @@ func (p *peer) handleRelayMessage(frame message) error {
 	switch frame.Command {
 	case messageInv, messageGetData:
 		return p.handleInventoryRelayMessage(frame)
-	case messageBlock, messageTx, messageGetBlk:
+	case messageBlock, messageTx, messageGetBlk, messageCmpctBlock, messageBlockTxn:
 		return p.handleObjectRelayMessage(frame)
 	default:
 		return postHandshakeUnknownCommandError{command: frame.Command}
@@ -134,6 +140,9 @@ func (p *peer) handleInventoryRelayMessage(frame message) error {
 }
 
 func (p *peer) handleObjectRelayMessage(frame message) error {
+	if isCompactRelayObjectCommand(frame.Command) && !p.compactRelayEnabled() {
+		return errors.New("compact relay not negotiated")
+	}
 	switch frame.Command {
 	case messageBlock:
 		return p.handleBlock(frame.Payload)
@@ -141,6 +150,10 @@ func (p *peer) handleObjectRelayMessage(frame message) error {
 		return p.handleTx(frame.Payload)
 	case messageGetBlk:
 		return p.handleGetBlocks(frame.Payload)
+	case messageCmpctBlock:
+		return p.handleCmpctBlock(frame.Payload)
+	case messageBlockTxn:
+		return p.handleBlockTxn(frame.Payload)
 	default:
 		return postHandshakeUnknownCommandError{command: frame.Command}
 	}
@@ -153,6 +166,11 @@ func isCompactRelayObjectCommand(command string) bool {
 	default:
 		return false
 	}
+}
+
+func (p *peer) compactRelayEnabled() bool {
+	mode := p.remoteCompactMode()
+	return mode.Version == compactRelayVersion && mode.Mode > 0
 }
 
 func (p *peer) handleAddressMessage(frame message) error {

--- a/clients/go/node/p2p/peer_runtime_test.go
+++ b/clients/go/node/p2p/peer_runtime_test.go
@@ -96,6 +96,9 @@ func TestCompactObjectCapsStayClosedUntilHandlersExist(t *testing.T) {
 			t.Fatalf("pre-negotiation %s cap=%d, want 0", command, got)
 		}
 	}
+	if err := p.handleObjectRelayMessage(message{Command: messageCmpctBlock}); err == nil || !strings.Contains(err.Error(), "not negotiated") {
+		t.Fatalf("unnegotiated compact object err=%v, want not negotiated", err)
+	}
 
 	p.setRemoteCompactMode(compactModeSnapshot{Mode: 1, Version: compactRelayVersion})
 	limiter = p.postHandshakePayloadCap()

--- a/clients/go/node/p2p/peer_runtime_test.go
+++ b/clients/go/node/p2p/peer_runtime_test.go
@@ -99,11 +99,18 @@ func TestCompactObjectCapsStayClosedUntilHandlersExist(t *testing.T) {
 
 	p.setRemoteCompactMode(compactModeSnapshot{Mode: 1, Version: compactRelayVersion})
 	limiter = p.postHandshakePayloadCap()
-	p.setCompactOutstandingRequest(compactOutstandingRequest{BlockTxnPayloadCap: compactRelayPayloadCap(messageBlockTxn) + 1})
-	for _, command := range []string{messageCmpctBlock, messageGetBlockTxn, messageBlockTxn} {
-		if got := limiter(command); got != 0 {
-			t.Fatalf("negotiated %s cap=%d, want 0 until handler slice", command, got)
-		}
+	if got := limiter(messageCmpctBlock); got != compactRelayPayloadCap(messageCmpctBlock) {
+		t.Fatalf("negotiated cmpctblock cap=%d, want %d", got, compactRelayPayloadCap(messageCmpctBlock))
+	}
+	if got := limiter(messageGetBlockTxn); got != 0 {
+		t.Fatalf("getblocktxn serve-side cap=%d, want 0", got)
+	}
+	if got := limiter(messageBlockTxn); got != 0 {
+		t.Fatalf("blocktxn cap without outstanding=%d, want 0", got)
+	}
+	p.setCompactOutstandingRequest(compactOutstandingRequest{BlockTxnPayloadCap: 64})
+	if got := limiter(messageBlockTxn); got != 64 {
+		t.Fatalf("blocktxn outstanding cap=%d, want 64", got)
 	}
 }
 

--- a/clients/go/node/p2p/peer_runtime_test.go
+++ b/clients/go/node/p2p/peer_runtime_test.go
@@ -105,6 +105,9 @@ func TestCompactObjectCapsStayClosedUntilHandlersExist(t *testing.T) {
 	if got := limiter(messageCmpctBlock); got != compactRelayPayloadCap(messageCmpctBlock) {
 		t.Fatalf("negotiated cmpctblock cap=%d, want %d", got, compactRelayPayloadCap(messageCmpctBlock))
 	}
+	if err := p.handleObjectRelayMessage(message{Command: messageCmpctBlock}); err == nil {
+		t.Fatal("negotiated malformed cmpctblock should reach handler and fail")
+	}
 	if got := limiter(messageGetBlockTxn); got != 0 {
 		t.Fatalf("getblocktxn serve-side cap=%d, want 0", got)
 	}


### PR DESCRIPTION
Invariant:
Go receive-side compact relay handles negotiated cmpctblock by requesting bounded missing transactions, completing only matching blocktxn responses, and rejecting malformed/wrong-shape blocktxn responses without full-block fallback.

Layer:
implementation / Go P2P runtime

Files changed:
- clients/go/node/mempool.go
- clients/go/node/mempool_snapshot_test.go
- clients/go/node/p2p/compact_reconstruct.go
- clients/go/node/p2p/compact_reconstruct_test.go
- clients/go/node/p2p/peer_runtime.go
- clients/go/node/p2p/peer_runtime_test.go

Tests:
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node/p2p -run "Compact|CmpctBlock|BlockTxn|Reconstruct|Orphan" -count=1' — PASS
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -race ./node/p2p -run "Compact|CmpctBlock|BlockTxn|Reconstruct|Orphan" -count=1' — PASS
- rubin-precommit-one-review/core receipt — PASS
- isolated stock reviewer — parity finding classified as scope/metadata due explicit go-only issue contract
- rubin-push coverage preflight — PASS; variation -0.02%, diff coverage 87.83%

Behavior impact:
- Enables Go receive-side cmpctblock -> bounded getblocktxn -> matching blocktxn -> apply flow.
- Rejects short, unsolicited, wrong-hash, malformed, count/order/wtxid/shortID-mismatched blocktxn responses.

Compatibility impact:
- Go-only runtime slice; no Rust, conformance, spec, or fixture changes.

Known non-goals:
- no inbound/serve-side getblocktxn
- no timeout/late/expiry/broad cleanup
- no Rust/conformance/spec changes

### Parity exemption justification

RUB-326 / #1727 is an explicit Go-only compact relay slice. The issue has label `go-only`, rejects Rust changes, and defines downstream compact relay work for Rust/parity follow-up. This PR intentionally wires only Go receive-side `cmpctblock -> getblocktxn -> matching blocktxn -> apply` behavior while keeping serve-side `getblocktxn`, timeout/late cleanup, Rust runtime changes, conformance fixtures, and spec changes out of scope. Rust parity is not claimed by this PR.

Reviewer note:
One isolated raw-diff reviewer flagged Go/Rust runtime parity. That is expected for this Go-only slice and is covered by this parity exemption and the issue contract.

Risk:
Medium: Go P2P runtime behavior. Diff is bounded to the RUB-326 receive-side flow and leaves fallback/late cleanup for downstream slices.

Rollback:
Revert this PR; compact object command gates remain negotiated and prior flow is restored.

Not checked:
- External GitHub/Codacy PR checks before PR creation.

Closes #1727


### Codex Review Instruction

Read and apply AGENTS.md before reviewing.

Before returning a clean/empty review, account for unresolved GitHub bot review comments on this PR, especially Copilot comments.

Required result evidence:
- AGENTS.md applied: PASS/FAIL
- GitHub review comments/threads inspected: PASS/FAIL
- Existing Copilot P1/P2 findings classified: CONFIRMED / DOWNGRADED_WITH_EVIDENCE / INSUFFICIENT_EVIDENCE
- Result: FINDINGS / CLEAN / INSUFFICIENT_EVIDENCE

If existing GitHub review comments/threads cannot be inspected, do not return CLEAN.


### Codex review gate

Codex must execute the following command in the shell before any review.
Do not merely quote this block.

```bash
bash -lc 'python3 - <<'"'"'PY'"'"'
from pathlib import Path
text = Path("AGENTS.md").read_text()
for marker in ["Review Mode", "Go Profile", "P2P", "Testing Discipline"]:
    print(f"AGENTS_MARKER {marker}: {'PASS' if marker in text else 'FAIL'}")
print("AGENTS_READ_BYTES", len(text))
PY'
```

Then review this PR strictly under the matched AGENTS.md sections.

Do not return `{"findings":[]}` unless the task log contains `AGENTS_READ_BYTES` and all required `AGENTS_MARKER ... PASS` lines.
If `AGENTS.md` cannot be read or markers are missing, return `INSUFFICIENT_EVIDENCE`, not clean.
