### PR TITLE
[RUB-326] Bound compact local candidate snapshots

### DIFF
--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -98,6 +98,7 @@ func (m *Mempool) AllTxIDs() [][32]byte {
 }
 
 // TxIDsLimit returns at most limit txids from the current mempool snapshot.
+// It returns nil when limit <= 0; use AllTxIDs for an unbounded snapshot.
 // The slice ordering is not guaranteed to be stable between calls.
 func (m *Mempool) TxIDsLimit(limit int) [][32]byte {
 	if limit <= 0 {

--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -94,14 +94,34 @@ type Mempool struct {
 // AllTxIDs returns the txids of every transaction currently in the mempool.
 // The slice ordering is not guaranteed to be stable between calls.
 func (m *Mempool) AllTxIDs() [][32]byte {
+	return m.txIDsLimit(0)
+}
+
+// TxIDsLimit returns at most limit txids from the current mempool snapshot.
+// The slice ordering is not guaranteed to be stable between calls.
+func (m *Mempool) TxIDsLimit(limit int) [][32]byte {
+	if limit <= 0 {
+		return nil
+	}
+	return m.txIDsLimit(limit)
+}
+
+func (m *Mempool) txIDsLimit(limit int) [][32]byte {
 	if m == nil {
 		return nil
 	}
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	ids := make([][32]byte, 0, len(m.txs))
+	capHint := len(m.txs)
+	if limit > 0 && limit < capHint {
+		capHint = limit
+	}
+	ids := make([][32]byte, 0, capHint)
 	for txid := range m.txs {
 		ids = append(ids, txid)
+		if limit > 0 && len(ids) >= limit {
+			break
+		}
 	}
 	return ids
 }

--- a/clients/go/node/mempool_snapshot_test.go
+++ b/clients/go/node/mempool_snapshot_test.go
@@ -1,0 +1,20 @@
+package node
+
+import "testing"
+
+func TestMempoolTxIDsLimitBoundsSnapshot(t *testing.T) {
+	mp := &Mempool{txs: map[[32]byte]*mempoolEntry{
+		{0x01}: {},
+		{0x02}: {},
+		{0x03}: {},
+	}}
+	if got := mp.TxIDsLimit(2); len(got) != 2 {
+		t.Fatalf("TxIDsLimit len=%d, want 2", len(got))
+	}
+	if got := mp.TxIDsLimit(0); got != nil {
+		t.Fatalf("TxIDsLimit(0)=%v, want nil", got)
+	}
+	if got := mp.AllTxIDs(); len(got) != 3 {
+		t.Fatalf("AllTxIDs len=%d, want 3", len(got))
+	}
+}

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -8,10 +8,11 @@ import (
 
 const (
 	compactDuplicateReportedIndex = ^uint64(0)
-	// Missing local candidates fall back to getblocktxn, so reconstruction
-	// must not scan an unbounded mempool snapshot before that fallback.
+	// Local candidate snapshots are best-effort: missing candidates fall back
+	// to compact relay recovery, so keep the per-reconstruction copy budget
+	// well below the full block cap.
 	compactLocalTxCandidateLimit      = defaultMaxTxPoolSize
-	compactLocalTxCandidateBytesLimit = consensus.MAX_BLOCK_BYTES
+	compactLocalTxCandidateBytesLimit = 1 << 20
 )
 
 var errCompactRelayMissingRequestTooLarge = errors.New("too many compact relay missing transactions")
@@ -324,25 +325,21 @@ func compactCanonicalPoolTransactions(pool *CanonicalMempoolTxPool, limit int, b
 		return nil
 	}
 	ids := pool.mempool.TxIDsLimit(limit)
-	capHint := len(ids)
-	if limit < capHint {
-		capHint = limit
-	}
-	out := make([][]byte, 0, capHint)
-	totalBytes := 0
+	return compactTxIDSnapshotTransactions(ids, pool.mempool.TxByID, limit, byteLimit)
+}
+
+func compactTxIDSnapshotTransactions(ids [][32]byte, getTx func([32]byte) ([]byte, bool), limit int, byteLimit int) [][]byte {
+	collector := newCompactLocalTxCandidateCollector(len(ids), limit, byteLimit)
 	for _, txid := range ids {
-		if tx, ok := pool.mempool.TxByID(txid); ok {
-			if byteLimit-totalBytes < len(tx) {
-				continue
-			}
-			out = append(out, tx)
-			totalBytes += len(tx)
-			if len(out) >= limit {
-				break
-			}
+		tx, ok := getTx(txid)
+		if !ok {
+			continue
+		}
+		if !collector.consider(tx) {
+			break
 		}
 	}
-	return out
+	return collector.out
 }
 
 func newCompactOutstandingRequest(block cmpctBlockPayload, blockHash [32]byte, result compactReconstructionResult) (compactOutstandingRequest, error) {

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -6,7 +6,13 @@ import (
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
 )
 
-const compactDuplicateReportedIndex = ^uint64(0)
+const (
+	compactDuplicateReportedIndex = ^uint64(0)
+	// Missing local candidates fall back to getblocktxn, so reconstruction
+	// must not scan an unbounded mempool snapshot before that fallback.
+	compactLocalTxCandidateLimit      = defaultMaxTxPoolSize
+	compactLocalTxCandidateBytesLimit = consensus.MAX_BLOCK_BYTES
+)
 
 var errCompactRelayMissingRequestTooLarge = errors.New("too many compact relay missing transactions")
 
@@ -246,6 +252,97 @@ func compactLocalTxWTxID(tx []byte) ([32]byte, error) {
 		return zero, errors.New("compact local transaction is non-canonical")
 	}
 	return wtxid, nil
+}
+
+func compactRelayLocalTransactions(pool TxPool, limit int) [][]byte {
+	return compactRelayLocalTransactionsWithBudget(pool, limit, compactLocalTxCandidateBytesLimit)
+}
+
+func compactRelayLocalTransactionsForBlock(block cmpctBlockPayload, pool TxPool) [][]byte {
+	if len(block.ShortIDs) == 0 {
+		return nil
+	}
+	return compactRelayLocalTransactions(pool, compactLocalTxCandidateLimit)
+}
+
+func compactRelayLocalTransactionsWithBudget(pool TxPool, limit int, byteLimit int) [][]byte {
+	switch pool := pool.(type) {
+	case *MemoryTxPool:
+		return compactMemoryPoolTransactions(pool, limit, byteLimit)
+	case *CanonicalMempoolTxPool:
+		return compactCanonicalPoolTransactions(pool, limit, byteLimit)
+	default:
+		return nil
+	}
+}
+
+func compactMemoryPoolTransactions(pool *MemoryTxPool, limit int, byteLimit int) [][]byte {
+	if pool == nil || limit <= 0 || byteLimit <= 0 {
+		return nil
+	}
+	pool.mu.RLock()
+	defer pool.mu.RUnlock()
+	capHint := len(pool.txs)
+	if limit < capHint {
+		capHint = limit
+	}
+	collector := newCompactLocalTxCandidateCollector(capHint, limit, byteLimit)
+	for _, entry := range pool.txs {
+		if !collector.consider(entry.raw) {
+			break
+		}
+	}
+	return collector.out
+}
+
+type compactLocalTxCandidateCollector struct {
+	out        [][]byte
+	limit      int
+	byteLimit  int
+	scanned    int
+	totalBytes int
+}
+
+func newCompactLocalTxCandidateCollector(capHint int, limit int, byteLimit int) *compactLocalTxCandidateCollector {
+	return &compactLocalTxCandidateCollector{out: make([][]byte, 0, capHint), limit: limit, byteLimit: byteLimit}
+}
+
+func (c *compactLocalTxCandidateCollector) consider(raw []byte) bool {
+	if c.scanned >= c.limit || len(c.out) >= c.limit || c.totalBytes >= c.byteLimit {
+		return false
+	}
+	c.scanned++
+	if c.byteLimit-c.totalBytes >= len(raw) {
+		c.out = append(c.out, append([]byte(nil), raw...))
+		c.totalBytes += len(raw)
+	}
+	return c.scanned < c.limit && len(c.out) < c.limit && c.totalBytes < c.byteLimit
+}
+
+func compactCanonicalPoolTransactions(pool *CanonicalMempoolTxPool, limit int, byteLimit int) [][]byte {
+	if pool == nil || pool.mempool == nil || limit <= 0 || byteLimit <= 0 {
+		return nil
+	}
+	ids := pool.mempool.TxIDsLimit(limit)
+	capHint := len(ids)
+	if limit < capHint {
+		capHint = limit
+	}
+	out := make([][]byte, 0, capHint)
+	totalBytes := 0
+	for _, txid := range ids {
+		if tx, ok := pool.mempool.TxByID(txid); ok {
+			if byteLimit-totalBytes < len(tx) {
+				continue
+			}
+			out = append(out, tx)
+			totalBytes += len(tx)
+			if len(out) >= limit {
+				break
+			}
+		}
+	}
+	return out
 }
 
 func newCompactOutstandingRequest(block cmpctBlockPayload, blockHash [32]byte, result compactReconstructionResult) (compactOutstandingRequest, error) {

--- a/clients/go/node/p2p/compact_reconstruct_test.go
+++ b/clients/go/node/p2p/compact_reconstruct_test.go
@@ -432,17 +432,7 @@ func TestReconstructCompactBlockSkipsLocalLookupForPrefilledOnlyBlock(t *testing
 }
 
 func TestCompactRelayLocalTransactionsBoundsMemoryPoolSnapshot(t *testing.T) {
-	pool := NewMemoryTxPoolWithLimit(4)
-	for i := 0; i < 4; i++ {
-		raw := minimalBlockTxnTestTxBytes(uint64(i + 1))
-		_, txid, _, _, err := consensus.ParseTx(raw)
-		if err != nil {
-			t.Fatalf("ParseTx[%d]: %v", i, err)
-		}
-		if !pool.Put(txid, raw, uint64(i+1), len(raw)) {
-			t.Fatalf("Put[%d] rejected", i)
-		}
-	}
+	pool := compactRelayTestMemoryPool(t, 4)
 	if got := compactRelayLocalTransactions(pool, 2); len(got) != 2 {
 		t.Fatalf("bounded snapshot len=%d, want 2", len(got))
 	}
@@ -453,24 +443,32 @@ func TestCompactRelayLocalTransactionsBoundsMemoryPoolSnapshot(t *testing.T) {
 	if got := compactRelayLocalTransactionsWithBudget(pool, 4, byteCap); len(got) != 1 {
 		t.Fatalf("byte-bounded snapshot len=%d, want 1", len(got))
 	}
+}
+
+func TestCompactRelayLocalCandidateCollectorCountsSkippedEntries(t *testing.T) {
 	smallRaw := minimalBlockTxnTestTxBytes(90)
 	smallCap := len(smallRaw)
 	collector := newCompactLocalTxCandidateCollector(4, 4, smallCap)
-	for i := 0; i < 3; i++ {
-		collector.consider(make([]byte, smallCap+1))
-	}
+	collector.consider(make([]byte, smallCap+1))
+	collector.consider(make([]byte, smallCap+1))
+	collector.consider(make([]byte, smallCap+1))
 	collector.consider(smallRaw)
 	if len(collector.out) != 1 || !bytes.Equal(collector.out[0], smallRaw) {
 		t.Fatalf("oversized local candidates stopped bounded scan: len=%d", len(collector.out))
 	}
+
 	collector = newCompactLocalTxCandidateCollector(4, 4, smallCap)
-	for i := 0; i < 4; i++ {
-		collector.consider(make([]byte, smallCap+1))
-	}
+	collector.consider(make([]byte, smallCap+1))
+	collector.consider(make([]byte, smallCap+1))
+	collector.consider(make([]byte, smallCap+1))
+	collector.consider(make([]byte, smallCap+1))
 	continued := collector.consider(smallRaw)
 	if continued || len(collector.out) != 0 {
 		t.Fatalf("scan budget accepted late candidate: continue=%v len=%d", continued, len(collector.out))
 	}
+}
+
+func TestCompactRelayLocalTransactionsCopiesMemoryPoolBytes(t *testing.T) {
 	aliasPool := NewMemoryTxPoolWithLimit(1)
 	aliasRaw := minimalBlockTxnTestTxBytes(99)
 	_, aliasTxid, _, _, err := consensus.ParseTx(aliasRaw)
@@ -488,6 +486,36 @@ func TestCompactRelayLocalTransactionsBoundsMemoryPoolSnapshot(t *testing.T) {
 	if stored, ok := aliasPool.Get(aliasTxid); !ok || stored[0] == got[0][0] {
 		t.Fatal("bounded snapshot aliases memory pool transaction bytes")
 	}
+}
+
+func TestCompactRelayLocalTransactionsUsesPurposeSpecificByteCap(t *testing.T) {
+	if compactLocalTxCandidateBytesLimit >= consensus.MAX_BLOCK_BYTES {
+		t.Fatalf("local candidate byte limit=%d, want below MAX_BLOCK_BYTES=%d", compactLocalTxCandidateBytesLimit, consensus.MAX_BLOCK_BYTES)
+	}
+	pool := NewMemoryTxPoolWithLimit(1)
+	raw := make([]byte, compactLocalTxCandidateBytesLimit+1)
+	if !pool.Put([32]byte{0x44}, raw, 1, len(raw)) {
+		t.Fatal("Put oversized local candidate")
+	}
+	if got := compactRelayLocalTransactions(pool, 1); len(got) != 0 {
+		t.Fatalf("default local candidate cap accepted %d oversized txs", len(got))
+	}
+}
+
+func compactRelayTestMemoryPool(t *testing.T, count int) *MemoryTxPool {
+	t.Helper()
+	pool := NewMemoryTxPoolWithLimit(count)
+	for i := 0; i < count; i++ {
+		raw := minimalBlockTxnTestTxBytes(uint64(i + 1))
+		_, txid, _, _, err := consensus.ParseTx(raw)
+		if err != nil {
+			t.Fatalf("ParseTx[%d]: %v", i, err)
+		}
+		if !pool.Put(txid, raw, uint64(i+1), len(raw)) {
+			t.Fatalf("Put[%d] rejected", i)
+		}
+	}
+	return pool
 }
 
 func TestCompactRelayLocalTransactionsForBlockSkipsPrefilledOnly(t *testing.T) {

--- a/clients/go/node/p2p/compact_reconstruct_test.go
+++ b/clients/go/node/p2p/compact_reconstruct_test.go
@@ -503,6 +503,30 @@ func TestCompactRelayLocalTransactionsForBlockSkipsPrefilledOnly(t *testing.T) {
 	}
 }
 
+func TestCompactRelayLocalTransactionsCoversCanonicalAndUnknownPools(t *testing.T) {
+	if got := compactRelayLocalTransactionsWithBudget(rejectingTxPool{}, 1, 1); got != nil {
+		t.Fatalf("unknown pool candidates=%v, want nil", got)
+	}
+	if got := compactRelayLocalTransactionsWithBudget(NewCanonicalMempoolTxPool(nil), 1, 1); got != nil {
+		t.Fatalf("nil canonical candidates=%v, want nil", got)
+	}
+
+	h := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	mempool := wireCanonicalMempoolForP2PTest(t, h)
+	tx1, _, _ := signedCanonicalP2PTxForHarness(t, h, 9001)
+	if err := mempool.AddTx(tx1); err != nil {
+		t.Fatalf("AddTx tx1: %v", err)
+	}
+
+	pool := NewCanonicalMempoolTxPool(mempool)
+	if got := compactRelayLocalTransactionsWithBudget(pool, 1, consensus.MAX_BLOCK_BYTES); len(got) != 1 {
+		t.Fatalf("limit-bounded canonical candidates len=%d, want 1", len(got))
+	}
+	if got := compactRelayLocalTransactionsWithBudget(pool, 2, len(tx1)-1); len(got) != 0 {
+		t.Fatalf("byte-bounded canonical candidates len=%d, want 0", len(got))
+	}
+}
+
 func compactShortIDForTx(t *testing.T, tx []byte, nonce1, nonce2 uint64) compactShortID {
 	t.Helper()
 	wtxid := compactWTxIDForTx(t, tx)

--- a/clients/go/node/p2p/compact_reconstruct_test.go
+++ b/clients/go/node/p2p/compact_reconstruct_test.go
@@ -1,6 +1,7 @@
 package p2p
 
 import (
+	"bytes"
 	"errors"
 	"reflect"
 	"strings"
@@ -427,6 +428,78 @@ func TestReconstructCompactBlockSkipsLocalLookupForPrefilledOnlyBlock(t *testing
 	}
 	if !reflect.DeepEqual(result.Transactions, [][]byte{validTx}) || result.MissingIndexes != nil {
 		t.Fatalf("result=%+v, want prefilled-only reconstruction", result)
+	}
+}
+
+func TestCompactRelayLocalTransactionsBoundsMemoryPoolSnapshot(t *testing.T) {
+	pool := NewMemoryTxPoolWithLimit(4)
+	for i := 0; i < 4; i++ {
+		raw := minimalBlockTxnTestTxBytes(uint64(i + 1))
+		_, txid, _, _, err := consensus.ParseTx(raw)
+		if err != nil {
+			t.Fatalf("ParseTx[%d]: %v", i, err)
+		}
+		if !pool.Put(txid, raw, uint64(i+1), len(raw)) {
+			t.Fatalf("Put[%d] rejected", i)
+		}
+	}
+	if got := compactRelayLocalTransactions(pool, 2); len(got) != 2 {
+		t.Fatalf("bounded snapshot len=%d, want 2", len(got))
+	}
+	if got := compactRelayLocalTransactions(pool, 0); got != nil {
+		t.Fatalf("zero-limit snapshot=%v, want nil", got)
+	}
+	byteCap := len(minimalBlockTxnTestTxBytes(1))
+	if got := compactRelayLocalTransactionsWithBudget(pool, 4, byteCap); len(got) != 1 {
+		t.Fatalf("byte-bounded snapshot len=%d, want 1", len(got))
+	}
+	smallRaw := minimalBlockTxnTestTxBytes(90)
+	smallCap := len(smallRaw)
+	collector := newCompactLocalTxCandidateCollector(4, 4, smallCap)
+	for i := 0; i < 3; i++ {
+		collector.consider(make([]byte, smallCap+1))
+	}
+	collector.consider(smallRaw)
+	if len(collector.out) != 1 || !bytes.Equal(collector.out[0], smallRaw) {
+		t.Fatalf("oversized local candidates stopped bounded scan: len=%d", len(collector.out))
+	}
+	collector = newCompactLocalTxCandidateCollector(4, 4, smallCap)
+	for i := 0; i < 4; i++ {
+		collector.consider(make([]byte, smallCap+1))
+	}
+	continued := collector.consider(smallRaw)
+	if continued || len(collector.out) != 0 {
+		t.Fatalf("scan budget accepted late candidate: continue=%v len=%d", continued, len(collector.out))
+	}
+	aliasPool := NewMemoryTxPoolWithLimit(1)
+	aliasRaw := minimalBlockTxnTestTxBytes(99)
+	_, aliasTxid, _, _, err := consensus.ParseTx(aliasRaw)
+	if err != nil {
+		t.Fatalf("ParseTx alias: %v", err)
+	}
+	if !aliasPool.Put(aliasTxid, aliasRaw, 1, len(aliasRaw)) {
+		t.Fatal("Put alias tx rejected")
+	}
+	got := compactRelayLocalTransactions(aliasPool, 1)
+	if len(got) != 1 || len(got[0]) == 0 {
+		t.Fatalf("alias snapshot=%v", got)
+	}
+	got[0][0] ^= 0xff
+	if stored, ok := aliasPool.Get(aliasTxid); !ok || stored[0] == got[0][0] {
+		t.Fatal("bounded snapshot aliases memory pool transaction bytes")
+	}
+}
+
+func TestCompactRelayLocalTransactionsForBlockSkipsPrefilledOnly(t *testing.T) {
+	pool := NewMemoryTxPoolWithLimit(1)
+	if !pool.Put([32]byte{0x01}, []byte{0xaa}, 1, 1) {
+		t.Fatal("Put local candidate")
+	}
+	if got := compactRelayLocalTransactionsForBlock(cmpctBlockPayload{Prefilled: []prefilledTxn{{Index: 0, Tx: []byte{0xbb}}}}, pool); got != nil {
+		t.Fatalf("prefilled-only compact block candidates=%v, want nil", got)
+	}
+	if got := compactRelayLocalTransactionsForBlock(cmpctBlockPayload{ShortIDs: []compactShortID{{0x01}}}, pool); len(got) != 1 {
+		t.Fatalf("short-id compact block candidates len=%d, want 1", len(got))
 	}
 }
 


### PR DESCRIPTION
Invariant:
- PR A of the RUB-326 re-cut prepares bounded local compact-block reconstruction candidates only.
- It does not wire live `cmpctblock`, `getblocktxn`, or `blocktxn` handler flow.

Layer:
- Go P2P implementation/tests.
- No consensus, policy, Rust, conformance, or fixture change.

Files changed:
- `clients/go/node/mempool.go`
- `clients/go/node/mempool_snapshot_test.go`
- `clients/go/node/p2p/compact_reconstruct.go`
- `clients/go/node/p2p/compact_reconstruct_test.go`

Budget:
```text
4 files changed, 236 insertions(+), 2 deletions(-)
```

Changed file list:
```text
clients/go/node/mempool.go
clients/go/node/mempool_snapshot_test.go
clients/go/node/p2p/compact_reconstruct.go
clients/go/node/p2p/compact_reconstruct_test.go
```

Behavior impact:
- Adds bounded read-only mempool txid snapshot helper.
- Adds bounded local candidate collection for compact reconstruction helper paths.
- Missing local candidates still fall through to later RUB-326 receive-flow work.

Compatibility impact:
- Existing full-block relay behavior unchanged.
- Existing mempool admission/policy/miner behavior unchanged.

Known non-goals:
- No live `cmpctblock` dispatch.
- No `getblocktxn` send.
- No inbound `blocktxn` handling.
- No full-block fallback logic.
- No timeout, late reply, expiry, or broad cleanup behavior.
- No serve-side `getblocktxn` behavior.

Tests:
```text
scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node ./node/p2p -run "TestMempoolTxIDsLimitBoundsSnapshot|TestCompactRelayLocalTransactions|TestReconstructCompactBlock" -count=1' — PASS
scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node/p2p -count=1' — PASS
rubin-precommit-one-review --repo /Users/gpt/Documents/rubin-protocol-codex-RUB-326A --base-ref origin/main — PASS
/Users/gpt/bin/rubin-push --repo /Users/gpt/Documents/rubin-protocol-codex-RUB-326A --base-ref origin/main --coverage-cmd 'scripts/dev-env.sh -- ./scripts/preflight-codacy-coverage.sh' -- origin HEAD:codex/RUB-326a-go-compact-candidate-snapshot — PASS
```

Coverage evidence:
```text
Codacy coverage preflight:
  variation: +0.02%
  diff coverage: 97.47% (77/79)
  clients/go/node/p2p/compact_reconstruct.go: 96.88% (62/64)
  clients/go/node/mempool.go: 100.00% (15/15)
```

Review / pattern evidence:
- Neon recall repo-root and `go` surface executed before final commit.
- Recorded pattern `p2p_test_fixture_reseed_overwrites_signed_utxo` as Neon memory `11800` after local self-audit found a reusable fixture misuse class.
- Local isolated raw-diff reviewer returned clean before push; later change was test-only coverage for the same touched surface.

Risk:
- Low for runtime behavior: this PR only exposes bounded read-only snapshots and helper-local candidate collection.
- Main risk is future flow integration misuse; PR B must rebase on this and validate live hash/count/order/short-ID behavior before apply.

Rollback:
- Revert this PR; no persistent state format, wire format, or policy migration is introduced.

Not checked:
- Full RUB-326 live receive flow; intentionally deferred to PR B.
- Serve-side `getblocktxn`; owned by RUB-330.
- Timeout/late/expiry cleanup; owned by RUB-327.

Codex review gate:

Codex must execute the following command in the shell before any review.
Do not merely quote this block.

```bash
bash -lc 'python3 - <<'"'"'PY'"'"'
from pathlib import Path
text = Path("AGENTS.md").read_text()
for marker in ["Review Mode", "Go Profile", "P2P", "Testing Discipline"]:
    print(f"AGENTS_MARKER {marker}: {'PASS' if marker in text else 'FAIL'}")
print("AGENTS_READ_BYTES", len(text))
PY'
```

Then review this PR strictly under the matched AGENTS.md sections.
Do not return `{ "findings": [] }` unless the task log contains `AGENTS_READ_BYTES` and all required `AGENTS_MARKER ... PASS` lines.
If `AGENTS.md` cannot be read or markers are missing, return `INSUFFICIENT_EVIDENCE`, not clean.
