### PR TITLE
[RUB-326] Gate compact blocktxn receive state

### DIFF
--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -12,11 +12,13 @@ const (
 	// Local candidate snapshots are best-effort: missing candidates fall back
 	// to compact relay recovery, so keep the per-reconstruction copy budget
 	// well below the full block cap.
-	compactLocalTxCandidateLimit      = defaultMaxTxPoolSize
-	compactLocalTxCandidateBytesLimit = 1 << 20
+	compactLocalTxCandidateLimit         = defaultMaxTxPoolSize
+	compactLocalTxCandidateBytesLimit    = 1 << 20
+	compactOutstandingRetainedBytesLimit = compactLocalTxCandidateBytesLimit
 )
 
 var errCompactRelayMissingRequestTooLarge = errors.New("too many compact relay missing transactions")
+var errCompactOutstandingRetainedBytesTooLarge = errors.New("compact outstanding retained bytes too large")
 
 type compactReconstructionResult struct {
 	Transactions        [][]byte
@@ -303,6 +305,9 @@ func (p *peer) requestMissingCompactTransactions(block cmpctBlockPayload, blockH
 		return p.requestCompactFullBlockFallback(blockHash)
 	}
 	req, err := newCompactOutstandingRequest(block, blockHash, result)
+	if errors.Is(err, errCompactOutstandingRetainedBytesTooLarge) {
+		return p.requestCompactFullBlockFallback(blockHash)
+	}
 	if err != nil {
 		return err
 	}
@@ -310,11 +315,10 @@ func (p *peer) requestMissingCompactTransactions(block cmpctBlockPayload, blockH
 	if err != nil {
 		return err
 	}
-	p.setCompactOutstandingRequest(req)
 	if err := p.send(messageGetBlockTxn, body); err != nil {
-		p.popCompactOutstandingRequest()
 		return err
 	}
+	p.activateCompactOutstandingRequest(req)
 	return nil
 }
 
@@ -333,11 +337,11 @@ func (p *peer) handleBlockTxn(payload []byte) error {
 	}
 	response, err := decodeBlockTxnRuntimePayload(payload)
 	if err != nil {
-		p.popCompactOutstandingRequest()
+		p.clearCompactOutstandingRequestForBlock(req.BlockHash)
 		p.bumpBan(10, err.Error())
 		return err
 	}
-	req, _ = p.popCompactOutstandingRequest() // snapshot above guarantees presence in the single-reader peer loop.
+	p.clearCompactOutstandingRequestForBlock(req.BlockHash)
 	txs, err := compactFillResponseTransactions(req, response)
 	if err != nil {
 		return p.requestCompactFullBlockFallback(req.BlockHash)
@@ -533,6 +537,13 @@ func newCompactOutstandingRequest(block cmpctBlockPayload, blockHash [32]byte, r
 	if err := compactValidateOutstandingShape(result.PartialTransactions, result.MissingIndexes); err != nil {
 		return compactOutstandingRequest{}, err
 	}
+	retainedBytes, err := compactPresentTransactionBytes(result.PartialTransactions)
+	if err != nil {
+		return compactOutstandingRequest{}, err
+	}
+	if retainedBytes > compactOutstandingRetainedBytesLimit {
+		return compactOutstandingRequest{}, errCompactOutstandingRetainedBytesTooLarge
+	}
 	payloadCap, err := compactBlockTxnResponsePayloadCap(result.PartialTransactions, len(result.MissingIndexes))
 	if err != nil {
 		return compactOutstandingRequest{}, err
@@ -547,6 +558,7 @@ func newCompactOutstandingRequest(block cmpctBlockPayload, blockHash [32]byte, r
 		Nonce1:             block.Nonce1,
 		Nonce2:             block.Nonce2,
 		BlockTxnPayloadCap: payloadCap,
+		RetainedBytes:      retainedBytes,
 	}, nil
 }
 

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -266,8 +266,12 @@ func (p *peer) handleCmpctBlock(payload []byte) error {
 	}
 	blockHash, _ := consensus.BlockHash(block.Header[:]) // fixed-size header slice cannot hit the length error path
 	have, err := p.service.hasBlock(blockHash)
-	if err != nil || have {
+	if err != nil {
 		return err
+	}
+	if have {
+		p.clearCompactOutstandingRequestForBlock(blockHash)
+		return nil
 	}
 	if err := p.validateCompactBlockHeader(block.Header); err != nil {
 		return err

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -387,8 +387,12 @@ func (p *peer) processCompactRelayedBlockWithFallback(expectedHash [32]byte, blo
 		return true, err
 	}
 	have, err := p.service.hasBlock(blockHash)
-	if err != nil || have {
+	if err != nil {
 		return false, err
+	}
+	if have {
+		p.clearCompactOutstandingRequestForBlock(blockHash)
+		return false, nil
 	}
 	p.service.chainMu.Lock()
 	summary, err := p.service.cfg.SyncEngine.ApplyBlockWithReorg(blockBytes, nil)
@@ -396,6 +400,7 @@ func (p *peer) processCompactRelayedBlockWithFallback(expectedHash [32]byte, blo
 	if err != nil {
 		return p.compactApplyErrorFallback(pb, blockHash, blockBytes, err, fallbackOnApply)
 	}
+	p.clearCompactOutstandingRequestForBlock(blockHash)
 	p.acceptedRelayedBlock(blockHash, summary)
 	return false, nil
 }

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/node"
 )
 
 const (
@@ -253,6 +254,189 @@ func compactLocalTxWTxID(tx []byte) ([32]byte, error) {
 		return zero, errors.New("compact local transaction is non-canonical")
 	}
 	return wtxid, nil
+}
+
+func (p *peer) handleCmpctBlock(payload []byte) error {
+	block, err := decodeCmpctBlockPayload(payload)
+	if err != nil {
+		p.bumpBan(10, err.Error())
+		return err
+	}
+	blockHash, _ := consensus.BlockHash(block.Header[:]) // fixed-size header slice cannot hit the length error path
+	have, err := p.service.hasBlock(blockHash)
+	if err != nil || have {
+		return err
+	}
+	if err := p.validateCompactBlockHeader(block.Header); err != nil {
+		return err
+	}
+	localTxs := compactRelayLocalTransactionsForBlock(block, p.service.cfg.TxPool)
+	result, err := reconstructCompactBlock(block, localTxs)
+	if errors.Is(err, errCompactRelayMissingRequestTooLarge) {
+		return p.requestCompactFullBlockFallback(blockHash)
+	}
+	if err != nil {
+		return err
+	}
+	if result.Transactions != nil {
+		return p.processCompactTransactions(blockHash, block.Header, result.Transactions, len(block.ShortIDs) > 0)
+	}
+	return p.requestMissingCompactTransactions(block, blockHash, result)
+}
+
+func (p *peer) validateCompactBlockHeader(header [consensus.BLOCK_HEADER_BYTES]byte) error {
+	parsed, _ := consensus.ParseBlockHeaderBytes(header[:]) // fixed-size header slice cannot hit the length error path
+	if err := consensus.PowCheck(header[:], parsed.Target); err != nil {
+		p.bumpBan(100, err.Error())
+		return err
+	}
+	if expected := p.service.cfg.SyncConfig.ExpectedTarget; expected != nil && parsed.Target != *expected {
+		err := &consensus.TxError{Code: consensus.BLOCK_ERR_TARGET_INVALID, Msg: "target mismatch"}
+		p.bumpBan(100, err.Error())
+		return err
+	}
+	return nil
+}
+
+func (p *peer) requestMissingCompactTransactions(block cmpctBlockPayload, blockHash [32]byte, result compactReconstructionResult) error {
+	if p.hasCompactOutstandingRequest() {
+		return p.requestCompactFullBlockFallback(blockHash)
+	}
+	req, err := newCompactOutstandingRequest(block, blockHash, result)
+	if err != nil {
+		return err
+	}
+	body, err := encodeGetBlockTxnPayload(getBlockTxnPayload{BlockHash: blockHash, Indexes: req.MissingIndexes})
+	if err != nil {
+		return err
+	}
+	p.setCompactOutstandingRequest(req)
+	if err := p.send(messageGetBlockTxn, body); err != nil {
+		p.popCompactOutstandingRequest()
+		return err
+	}
+	return nil
+}
+
+func (p *peer) handleBlockTxn(payload []byte) error {
+	if len(payload) < 32 {
+		return p.rejectBlockTxn("blocktxn payload missing block hash")
+	}
+	var responseHash [32]byte
+	copy(responseHash[:], payload[:32])
+	req, ok := p.compactOutstandingRequestSnapshot()
+	if !ok {
+		return p.rejectBlockTxn("unexpected blocktxn response")
+	}
+	if responseHash != req.BlockHash {
+		return p.rejectBlockTxn("blocktxn block hash mismatch")
+	}
+	response, err := decodeBlockTxnRuntimePayload(payload)
+	if err != nil {
+		p.popCompactOutstandingRequest()
+		p.bumpBan(10, err.Error())
+		return err
+	}
+	req, _ = p.popCompactOutstandingRequest() // snapshot above guarantees presence in the single-reader peer loop.
+	txs, err := compactFillResponseTransactions(req, response)
+	if err != nil {
+		return p.requestCompactFullBlockFallback(req.BlockHash)
+	}
+	return p.processCompactTransactions(req.BlockHash, req.Header, txs, true)
+}
+
+func (p *peer) rejectBlockTxn(msg string) error {
+	p.bumpBan(10, msg)
+	return errors.New(msg)
+}
+
+func (p *peer) processCompactTransactions(blockHash [32]byte, header [consensus.BLOCK_HEADER_BYTES]byte, txs [][]byte, fallbackOnApply bool) error {
+	blockBytes, err := compactBlockBytes(header, txs)
+	if err != nil {
+		p.bumpBan(10, err.Error())
+		return err
+	}
+	if !fallbackOnApply {
+		return p.handleBlock(blockBytes)
+	}
+	fallback, err := p.processCompactRelayedBlockWithFallback(blockHash, blockBytes, fallbackOnApply)
+	if fallback {
+		return p.requestCompactFullBlockFallback(blockHash)
+	}
+	if err != nil {
+		return err
+	}
+	have, err := p.service.hasBlock(blockHash)
+	if err != nil || !have {
+		return err
+	}
+	return p.service.requestBlocksIfBehind(p)
+}
+
+func (p *peer) processCompactRelayedBlockWithFallback(expectedHash [32]byte, blockBytes []byte, fallbackOnApply bool) (bool, error) {
+	pb, blockHash, err := parseRelayedBlock(blockBytes)
+	if err != nil || pb == nil || blockHash != expectedHash {
+		return true, err
+	}
+	have, err := p.service.hasBlock(blockHash)
+	if err != nil || have {
+		return false, err
+	}
+	p.service.chainMu.Lock()
+	summary, err := p.service.cfg.SyncEngine.ApplyBlockWithReorg(blockBytes, nil)
+	p.service.chainMu.Unlock()
+	if err != nil {
+		return p.compactApplyErrorFallback(pb, blockHash, blockBytes, err, fallbackOnApply)
+	}
+	p.acceptedRelayedBlock(blockHash, summary)
+	return false, nil
+}
+
+func (p *peer) compactApplyErrorFallback(pb *consensus.ParsedBlock, blockHash [32]byte, blockBytes []byte, err error, fallbackOnApply bool) (bool, error) {
+	if errors.Is(err, node.ErrParentNotFound) {
+		if _, retainErr := p.retainRelayedOrphanIfValid(pb, blockHash, blockBytes); retainErr != nil {
+			return false, retainErr
+		}
+		return false, nil
+	}
+	if fallbackOnApply && isConsensusApplyBlockError(err) {
+		p.setLastError(err.Error())
+		return true, nil
+	}
+	p.recordRelayedBlockApplyError(err)
+	return false, err
+}
+
+func (p *peer) requestCompactFullBlockFallback(blockHash [32]byte) error {
+	body, err := encodeInventoryVectors([]InventoryVector{{Type: MSG_BLOCK, Hash: blockHash}})
+	if err != nil {
+		return err
+	}
+	return p.send(messageGetData, body)
+}
+
+func compactBlockBytes(header [consensus.BLOCK_HEADER_BYTES]byte, txs [][]byte) ([]byte, error) {
+	if len(txs) == 0 {
+		return nil, errors.New("compact block has no transactions")
+	}
+	out := append([]byte(nil), header[:]...)
+	out = consensus.AppendCompactSize(out, uint64(len(txs)))
+	var totalTxBytes uint64
+	for _, tx := range txs {
+		if tx == nil {
+			return nil, errors.New("compact block transaction missing")
+		}
+		nextTotal, err := validateBlockTxnTransactionSize(uint64(len(tx)), totalTxBytes)
+		if err != nil {
+			return nil, err
+		}
+		if len(out) > consensus.MAX_BLOCK_BYTES-len(tx) {
+			return nil, errors.New("compact block exceeds block size")
+		}
+		out = append(out, tx...)
+		totalTxBytes = nextTotal
+	}
+	return out, nil
 }
 
 func compactRelayLocalTransactions(pool TxPool, limit int) [][]byte {

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/node"
 )
 
 const (
@@ -253,6 +254,192 @@ func compactLocalTxWTxID(tx []byte) ([32]byte, error) {
 		return zero, errors.New("compact local transaction is non-canonical")
 	}
 	return wtxid, nil
+}
+
+func (p *peer) handleCmpctBlock(payload []byte) error {
+	block, err := decodeCmpctBlockPayload(payload)
+	if err != nil {
+		p.bumpBan(10, err.Error())
+		return err
+	}
+	blockHash, _ := consensus.BlockHash(block.Header[:]) // fixed-size header slice cannot hit the length error path
+	have, err := p.service.hasBlock(blockHash)
+	if err != nil || have {
+		return err
+	}
+	if err := p.validateCompactBlockHeader(block.Header); err != nil {
+		return err
+	}
+	localTxs := compactRelayLocalTransactionsForBlock(block, p.service.cfg.TxPool)
+	result, err := reconstructCompactBlock(block, localTxs)
+	if errors.Is(err, errCompactRelayMissingRequestTooLarge) {
+		return p.requestCompactFullBlockFallback(blockHash)
+	}
+	if err != nil {
+		return err
+	}
+	if result.Transactions != nil {
+		return p.processCompactTransactions(blockHash, block.Header, result.Transactions, len(block.ShortIDs) > 0)
+	}
+	return p.requestMissingCompactTransactions(block, blockHash, result)
+}
+
+func (p *peer) validateCompactBlockHeader(header [consensus.BLOCK_HEADER_BYTES]byte) error {
+	parsed, _ := consensus.ParseBlockHeaderBytes(header[:]) // fixed-size header slice cannot hit the length error path
+	if err := consensus.PowCheck(header[:], parsed.Target); err != nil {
+		p.bumpBan(100, err.Error())
+		return err
+	}
+	if expected := p.service.cfg.SyncConfig.ExpectedTarget; expected != nil && parsed.Target != *expected {
+		err := &consensus.TxError{Code: consensus.BLOCK_ERR_TARGET_INVALID, Msg: "target mismatch"}
+		p.bumpBan(100, err.Error())
+		return err
+	}
+	return nil
+}
+
+func (p *peer) requestMissingCompactTransactions(block cmpctBlockPayload, blockHash [32]byte, result compactReconstructionResult) error {
+	if p.hasCompactOutstandingRequest() {
+		return p.requestCompactFullBlockFallback(blockHash)
+	}
+	req, err := newCompactOutstandingRequest(block, blockHash, result)
+	if err != nil {
+		return err
+	}
+	body, err := encodeGetBlockTxnPayload(getBlockTxnPayload{BlockHash: blockHash, Indexes: req.MissingIndexes})
+	if err != nil {
+		return err
+	}
+	p.setCompactOutstandingRequest(req)
+	if err := p.send(messageGetBlockTxn, body); err != nil {
+		p.popCompactOutstandingRequest()
+		return err
+	}
+	return nil
+}
+
+func (p *peer) handleBlockTxn(payload []byte) error {
+	if len(payload) < 32 {
+		return p.rejectBlockTxn("blocktxn payload missing block hash")
+	}
+	var responseHash [32]byte
+	copy(responseHash[:], payload[:32])
+	req, ok := p.compactOutstandingRequestSnapshot()
+	if !ok {
+		return p.rejectBlockTxn("unexpected blocktxn response")
+	}
+	if responseHash != req.BlockHash {
+		return p.rejectBlockTxn("blocktxn block hash mismatch")
+	}
+	response, err := decodeBlockTxnRuntimePayload(payload)
+	if err != nil {
+		p.popCompactOutstandingRequest()
+		p.bumpBan(10, err.Error())
+		return err
+	}
+	req, _ = p.popCompactOutstandingRequest() // snapshot above guarantees presence in the single-reader peer loop.
+	txs, err := compactFillResponseTransactions(req, response)
+	if err != nil {
+		return p.requestCompactFullBlockFallback(req.BlockHash)
+	}
+	return p.processCompactTransactions(req.BlockHash, req.Header, txs, true)
+}
+
+func (p *peer) rejectBlockTxn(msg string) error {
+	p.bumpBan(10, msg)
+	return errors.New(msg)
+}
+
+func (p *peer) processCompactTransactions(blockHash [32]byte, header [consensus.BLOCK_HEADER_BYTES]byte, txs [][]byte, fallbackOnApply bool) error {
+	blockBytes, err := compactBlockBytes(header, txs)
+	if err != nil {
+		p.bumpBan(10, err.Error())
+		return err
+	}
+	if !fallbackOnApply {
+		return p.handleBlock(blockBytes)
+	}
+	fallback, err := p.processCompactRelayedBlockWithFallback(blockHash, blockBytes, fallbackOnApply)
+	if fallback {
+		return p.requestCompactFullBlockFallback(blockHash)
+	}
+	if err != nil {
+		return err
+	}
+	have, err := p.service.hasBlock(blockHash)
+	if err != nil || !have {
+		return err
+	}
+	return p.service.requestBlocksIfBehind(p)
+}
+
+func (p *peer) processCompactRelayedBlockWithFallback(expectedHash [32]byte, blockBytes []byte, fallbackOnApply bool) (bool, error) {
+	pb, blockHash, err := parseRelayedBlock(blockBytes)
+	if err != nil || pb == nil || blockHash != expectedHash {
+		return true, err
+	}
+	have, err := p.service.hasBlock(blockHash)
+	if err != nil || have {
+		return false, err
+	}
+	p.service.chainMu.Lock()
+	summary, err := p.service.cfg.SyncEngine.ApplyBlockWithReorg(blockBytes, nil)
+	p.service.chainMu.Unlock()
+	if err != nil {
+		return p.compactApplyErrorFallback(pb, blockHash, blockBytes, err, fallbackOnApply)
+	}
+	p.acceptedRelayedBlock(blockHash, summary)
+	return false, nil
+}
+
+func (p *peer) compactApplyErrorFallback(pb *consensus.ParsedBlock, blockHash [32]byte, blockBytes []byte, err error, fallbackOnApply bool) (bool, error) {
+	if errors.Is(err, node.ErrParentNotFound) {
+		if fallbackOnApply {
+			return true, nil
+		}
+		if _, retainErr := p.retainRelayedOrphanIfValid(pb, blockHash, blockBytes); retainErr != nil {
+			return false, retainErr
+		}
+		return false, nil
+	}
+	if fallbackOnApply && isConsensusApplyBlockError(err) {
+		p.setLastError(err.Error())
+		return true, nil
+	}
+	p.recordRelayedBlockApplyError(err)
+	return false, err
+}
+
+func (p *peer) requestCompactFullBlockFallback(blockHash [32]byte) error {
+	body, err := encodeInventoryVectors([]InventoryVector{{Type: MSG_BLOCK, Hash: blockHash}})
+	if err != nil {
+		return err
+	}
+	return p.send(messageGetData, body)
+}
+
+func compactBlockBytes(header [consensus.BLOCK_HEADER_BYTES]byte, txs [][]byte) ([]byte, error) {
+	if len(txs) == 0 {
+		return nil, errors.New("compact block has no transactions")
+	}
+	out := append([]byte(nil), header[:]...)
+	out = consensus.AppendCompactSize(out, uint64(len(txs)))
+	var totalTxBytes uint64
+	for _, tx := range txs {
+		if tx == nil {
+			return nil, errors.New("compact block transaction missing")
+		}
+		nextTotal, err := validateBlockTxnTransactionSize(uint64(len(tx)), totalTxBytes)
+		if err != nil {
+			return nil, err
+		}
+		if len(out) > consensus.MAX_BLOCK_BYTES-len(tx) {
+			return nil, errors.New("compact block exceeds block size")
+		}
+		out = append(out, tx...)
+		totalTxBytes = nextTotal
+	}
+	return out, nil
 }
 
 func compactRelayLocalTransactions(pool TxPool, limit int) [][]byte {

--- a/clients/go/node/p2p/compact_reconstruct_test.go
+++ b/clients/go/node/p2p/compact_reconstruct_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/node"
 )
 
 func TestReconstructCompactBlockCompletesExactPositionsFromWTxID(t *testing.T) {
@@ -431,6 +432,123 @@ func TestReconstructCompactBlockSkipsLocalLookupForPrefilledOnlyBlock(t *testing
 	}
 }
 
+func TestHandleBlockTxnCompletesOutstandingBlock(t *testing.T) {
+	header, blockHash, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
+	p := newPeerRuntimeTestPeer(t)
+	if err := p.handleBlockTxn(nil); err == nil || !strings.Contains(err.Error(), "missing block hash") || p.snapshotState().BanScore == 0 {
+		t.Fatalf("short blocktxn err=%v state=%+v", err, p.snapshotState())
+	}
+	requireBlockTxnMessageBan(t, newPeerRuntimeTestPeer(t), make([]byte, 32), "unexpected")
+	p = newCompactScriptedPeer(t)
+	p.setRemoteCompactMode(compactModeSnapshot{Mode: 1, Version: compactRelayVersion})
+	setCompactTestOutstanding(p, blockHash, header, compactShortIDForTx(t, txs[0], 201, 202), 201, 202)
+	if err := p.handleBlockTxn(make([]byte, 32)); err == nil || !strings.Contains(err.Error(), "block hash mismatch") {
+		t.Fatalf("wrong hash blocktxn err=%v", err)
+	}
+	setCompactTestOutstanding(p, blockHash, header, compactShortIDForTx(t, txs[0], 201, 202), 201, 202)
+	truncatedCount := append(append([]byte{}, blockHash[:]...), 0xfd)
+	if err := p.handleBlockTxn(truncatedCount); err == nil || !strings.Contains(err.Error(), "unexpected EOF") || p.snapshotState().BanScore == 0 {
+		t.Fatalf("truncated blocktxn err=%v state=%+v", err, p.snapshotState())
+	}
+	setCompactTestOutstanding(p, blockHash, header, compactShortIDForTx(t, txs[0], 201, 202), 201, 202)
+	valid, err := encodeBlockTxnPayload(blockTxnPayload{BlockHash: blockHash, Transactions: [][]byte{txs[0]}})
+	requireNoCompactErr(t, err, "encode blocktxn")
+	requireNoCompactErr(t, p.handleMessage(message{Command: messageBlockTxn, Payload: valid}), "handle blocktxn")
+	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatal("outstanding request was not cleared")
+	}
+	if have, err := p.service.hasBlock(blockHash); err != nil || !have {
+		t.Fatalf("hasBlock=%v err=%v", have, err)
+	}
+}
+
+func TestCompactApplyParentNotFoundRetainsOrphanWithoutFallback(t *testing.T) {
+	source := newTestHarness(t, 2, "127.0.0.1:0", nil)
+	blockHash, blockBytes := testHarnessBlockAtHeight(t, source, 1)
+	header, gotHash, txs := compactPartsFromBlockBytes(t, blockBytes)
+	if gotHash != blockHash {
+		t.Fatalf("block hash=%x, want %x", gotHash, blockHash)
+	}
+
+	p := newCompactScriptedPeer(t)
+	requireNoCompactErr(t, p.processCompactTransactions(blockHash, header, txs, true), "parent-not-found compact apply")
+	if got := p.service.orphans.Len(); got != 1 {
+		t.Fatalf("orphans.Len()=%d, want 1", got)
+	}
+	if p.conn.(*scriptedConn).Buffer.Len() != 0 {
+		t.Fatal("parent-not-found compact apply sent full-block fallback")
+	}
+}
+
+func TestHandleBlockTxnFallsBackWithoutBanOnShortIDMismatch(t *testing.T) {
+	header, blockHash, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
+	p := newCompactScriptedPeer(t)
+	setCompactTestOutstanding(p, blockHash, header, compactShortID{0xbb}, 301, 302)
+	valid, err := encodeBlockTxnPayload(blockTxnPayload{BlockHash: blockHash, Transactions: [][]byte{txs[0]}})
+	requireNoCompactErr(t, err, "encode blocktxn")
+	requireNoCompactErr(t, p.handleBlockTxn(valid), "mismatched blocktxn fallback")
+	requireCompactFrame(t, p, messageGetData)
+	if p.snapshotState().BanScore != 0 {
+		t.Fatalf("mismatched blocktxn state=%+v, want no ban", p.snapshotState())
+	}
+}
+
+func TestCompactReceiveErrorBranches(t *testing.T) {
+	header, blockHash, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
+	full := mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{Header: header, Prefilled: []prefilledTxn{{Index: 0, Tx: txs[0]}}})
+	missing := mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{Header: header, ShortIDs: []compactShortID{{0xaa}}})
+	p := newCompactScriptedPeer(t)
+	if err := p.handleCmpctBlock(nil); err == nil || p.snapshotState().BanScore == 0 {
+		t.Fatalf("malformed cmpctblock err=%v state=%+v", err, p.snapshotState())
+	}
+	p = newCompactScriptedPeer(t)
+	requireNoCompactErr(t, p.handleCmpctBlock(missing), "missing compact block")
+	requireCompactFrame(t, p, messageGetBlockTxn)
+	if snap, ok := p.compactOutstandingRequestSnapshot(); !ok || snap.BlockHash != blockHash || snap.BlockTxnPayloadCap == 0 {
+		t.Fatalf("outstanding=%+v ok=%v", snap, ok)
+	}
+	p = newCompactScriptedPeer(t)
+	requireCompactErrContains(t, p.handleObjectRelayMessage(message{Command: messageCmpctBlock}), "compact relay not negotiated")
+	p.setRemoteCompactMode(compactModeSnapshot{Mode: 1, Version: compactRelayVersion})
+	requireNoCompactErr(t, p.handleObjectRelayMessage(message{Command: messageCmpctBlock, Payload: full}), "object cmpctblock")
+	requireNoCompactErr(t, p.handleCmpctBlock(full), "duplicate compact block")
+	p = newCompactScriptedPeer(t)
+	p.setCompactOutstandingRequest(compactOutstandingRequest{BlockHash: [32]byte{0x01}})
+	requireNoCompactErr(t, p.handleCmpctBlock(missing), "concurrent outstanding")
+	requireCompactFrame(t, p, messageGetData)
+	p = newCompactScriptedPeer(t)
+	p.service.cfg.PeerRuntimeConfig.MaxMessageSize = 1
+	requireCompactErrContains(t, p.handleCmpctBlock(missing), "message exceeds cap")
+	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatal("send failure left compact outstanding request")
+	}
+	p = newCompactScriptedPeer(t)
+	tooMany := mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{Header: header, ShortIDs: make([]compactShortID, maxCompactRelayEntries+1)})
+	requireNoCompactErr(t, p.handleCmpctBlock(tooMany), "missing overflow fallback")
+	badHeader := header
+	for i := 76; i < 108; i++ {
+		badHeader[i] = 0
+	}
+	requireCompactErrContains(t, newCompactScriptedPeer(t).handleCmpctBlock(mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{Header: badHeader, Prefilled: []prefilledTxn{{Index: 0, Tx: txs[0]}}})), "")
+	p = newCompactScriptedPeer(t)
+	wrongTarget := [32]byte{0xee}
+	p.service.cfg.SyncConfig.ExpectedTarget = &wrongTarget
+	requireCompactErrContains(t, p.handleCmpctBlock(full), "target mismatch")
+	requireCompactErrContains(t, newCompactScriptedPeer(t).processCompactTransactions(blockHash, header, nil, true), "no transactions")
+	p = newCompactScriptedPeer(t)
+	requireNoCompactErr(t, p.processCompactTransactions([32]byte{0x99}, header, txs, true), "hash mismatch fallback")
+	requireCompactFrame(t, p, messageGetData)
+	p = newCompactScriptedPeer(t)
+	p.service.cfg.BlockStore = nil
+	requireCompactErrContains(t, p.processCompactTransactions(blockHash, header, txs, true), "nil blockstore")
+	p = newCompactScriptedPeer(t)
+	badPool := NewMemoryTxPoolWithLimit(1)
+	_ = badPool.Put([32]byte{0x01}, []byte{0xff}, 1, 1)
+	p.service.cfg.TxPool = badPool
+	requireCompactErrContains(t, p.handleCmpctBlock(missing), "non-canonical")
+	requireCompactErrContains(t, p.requestMissingCompactTransactions(cmpctBlockPayload{Header: header}, blockHash, compactReconstructionResult{}), "")
+}
+
 func TestCompactRelayLocalTransactionsBoundsMemoryPoolSnapshot(t *testing.T) {
 	pool := compactRelayTestMemoryPool(t, 4)
 	if got := compactRelayLocalTransactions(pool, 2); len(got) != 2 {
@@ -568,4 +686,60 @@ func compactWTxIDForTx(t *testing.T, tx []byte) [32]byte {
 		t.Fatalf("ParseTx: consumed=%d err=%v", consumed, err)
 	}
 	return wtxid
+}
+
+func mustEncodeCmpctBlockPayload(t *testing.T, in cmpctBlockPayload) []byte {
+	raw, err := encodeCmpctBlockPayload(in)
+	requireNoCompactErr(t, err, "encode cmpctblock")
+	return raw
+}
+
+func newCompactScriptedPeer(t *testing.T) *peer {
+	t.Helper()
+	p := newPeerRuntimeTestPeer(t)
+	p.conn = &scriptedConn{}
+	return p
+}
+
+func setCompactTestOutstanding(p *peer, blockHash [32]byte, header [consensus.BLOCK_HEADER_BYTES]byte, shortID compactShortID, nonce1, nonce2 uint64) {
+	p.setCompactOutstandingRequest(compactOutstandingRequest{blockHash, header, []uint64{0}, []compactShortID{shortID}, [][]byte{nil}, nonce1, nonce2, compactRelayPayloadCap(messageBlockTxn)})
+}
+
+func compactPartsFromBlockBytes(t *testing.T, block []byte) ([consensus.BLOCK_HEADER_BYTES]byte, [32]byte, [][]byte) {
+	var header [consensus.BLOCK_HEADER_BYTES]byte
+	copy(header[:], block[:consensus.BLOCK_HEADER_BYTES])
+	blockHash, _ := consensus.BlockHash(header[:])
+	return header, blockHash, [][]byte{append([]byte(nil), block[consensus.BLOCK_HEADER_BYTES+1:]...)}
+}
+
+func requireCompactFrame(t *testing.T, p *peer, command string) {
+	t.Helper()
+	conn := p.conn.(*scriptedConn)
+	frame, err := readFrame(bytes.NewReader(conn.Buffer.Bytes()), networkMagic(p.service.cfg.PeerRuntimeConfig.Network), p.service.cfg.PeerRuntimeConfig.MaxMessageSize)
+	conn.Buffer.Reset()
+	if err != nil || frame.Command != command {
+		t.Fatalf("compact frame=%+v err=%v want %s", frame, err, command)
+	}
+}
+
+func requireNoCompactErr(t *testing.T, err error, label string) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("%s: %v", label, err)
+	}
+}
+
+func requireCompactErrContains(t *testing.T, err error, want string) {
+	t.Helper()
+	if err == nil || (want != "" && !strings.Contains(err.Error(), want)) {
+		t.Fatalf("err=%v want %q", err, want)
+	}
+}
+
+func requireBlockTxnMessageBan(t *testing.T, p *peer, payload []byte, want string) {
+	t.Helper()
+	err := p.handleMessage(message{Command: messageBlockTxn, Payload: payload})
+	if err == nil || !strings.Contains(err.Error(), want) || p.snapshotState().BanScore == 0 {
+		t.Fatalf("blocktxn message err=%v state=%+v want %q with ban", err, p.snapshotState(), want)
+	}
 }

--- a/clients/go/node/p2p/compact_reconstruct_test.go
+++ b/clients/go/node/p2p/compact_reconstruct_test.go
@@ -651,6 +651,26 @@ func TestInternalCompactApplyEarlyHaveClearsMatchingOutstanding(t *testing.T) {
 	}
 }
 
+func TestCompactPartsFromBlockBytesDecodesCompactSizeTxCountWidth(t *testing.T) {
+	const txCount = 253
+	genesis := node.DevnetGenesisBlockBytes()
+	block := append([]byte(nil), genesis[:consensus.BLOCK_HEADER_BYTES]...)
+	block = consensus.AppendCompactSize(block, txCount)
+	firstTx := minimalBlockTxnTestTxBytes(1000)
+	block = append(block, firstTx...)
+	for i := uint64(1); i < txCount; i++ {
+		block = append(block, minimalBlockTxnTestTxBytes(1000+i)...)
+	}
+
+	_, _, txs := compactPartsFromBlockBytes(t, block)
+	if len(txs) != txCount {
+		t.Fatalf("tx count=%d, want %d", len(txs), txCount)
+	}
+	if !bytes.Equal(txs[0], firstTx) {
+		t.Fatalf("first tx was sliced from the wrong offset")
+	}
+}
+
 func TestCompactRelayLocalTransactionsBoundsMemoryPoolSnapshot(t *testing.T) {
 	pool := compactRelayTestMemoryPool(t, 4)
 	if got := compactRelayLocalTransactions(pool, 2); len(got) != 2 {
@@ -817,10 +837,34 @@ func setCompactTestOutstanding(p *peer, blockHash [32]byte, header [consensus.BL
 }
 
 func compactPartsFromBlockBytes(t *testing.T, block []byte) ([consensus.BLOCK_HEADER_BYTES]byte, [32]byte, [][]byte) {
+	t.Helper()
+	if len(block) < consensus.BLOCK_HEADER_BYTES+1 {
+		t.Fatalf("block too short: %d", len(block))
+	}
 	var header [consensus.BLOCK_HEADER_BYTES]byte
 	copy(header[:], block[:consensus.BLOCK_HEADER_BYTES])
 	blockHash, _ := consensus.BlockHash(header[:])
-	return header, blockHash, [][]byte{append([]byte(nil), block[consensus.BLOCK_HEADER_BYTES+1:]...)}
+	txCount, countLen, err := consensus.DecodeCompactSize(block[consensus.BLOCK_HEADER_BYTES:])
+	if err != nil {
+		t.Fatalf("decode tx_count: %v", err)
+	}
+	offset := consensus.BLOCK_HEADER_BYTES + countLen
+	txs := make([][]byte, 0)
+	for i := uint64(0); i < txCount; i++ {
+		_, _, _, consumed, err := consensus.ParseTx(block[offset:])
+		if err != nil {
+			t.Fatalf("parse tx[%d]: %v", i, err)
+		}
+		if consumed <= 0 || offset+consumed > len(block) {
+			t.Fatalf("parse tx[%d] consumed invalid length %d at offset %d", i, consumed, offset)
+		}
+		txs = append(txs, append([]byte(nil), block[offset:offset+consumed]...))
+		offset += consumed
+	}
+	if offset != len(block) {
+		t.Fatalf("block has trailing bytes after tx list: %d", len(block)-offset)
+	}
+	return header, blockHash, txs
 }
 
 func requireCompactFrame(t *testing.T, p *peer, command string) {

--- a/clients/go/node/p2p/compact_reconstruct_test.go
+++ b/clients/go/node/p2p/compact_reconstruct_test.go
@@ -548,9 +548,9 @@ func TestInternalCompactReceiveErrorBranches(t *testing.T) {
 		t.Fatalf("outstanding=%+v ok=%v", snap, ok)
 	}
 	p = newCompactScriptedPeer(t)
-	requireCompactErrContains(t, p.handleObjectRelayMessage(message{Command: messageCmpctBlock}), "compact relay not negotiated")
+	requireCompactErrContains(t, p.handleObjectRelayMessage(message{Command: messageCmpctBlock}), "compact relay receive disabled")
 	p.setRemoteCompactMode(compactModeSnapshot{Mode: 1, Version: compactRelayVersion})
-	requireCompactErrContains(t, p.handleObjectRelayMessage(message{Command: messageCmpctBlock, Payload: full}), "compact relay not negotiated")
+	requireCompactErrContains(t, p.handleObjectRelayMessage(message{Command: messageCmpctBlock, Payload: full}), "compact relay receive disabled")
 	requireNoCompactErr(t, p.handleCmpctBlock(full), "direct cmpctblock")
 	p = newCompactScriptedPeer(t)
 	p.setCompactOutstandingRequest(compactOutstandingRequest{BlockHash: [32]byte{0x01}})
@@ -607,6 +607,18 @@ func TestFullBlockClearsMatchingCompactOutstanding(t *testing.T) {
 	requireNoCompactErr(t, p.handleBlock(node.DevnetGenesisBlockBytes()), "full block")
 	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
 		t.Fatal("full block did not clear matching compact outstanding request")
+	}
+}
+
+func TestInternalHandleCmpctBlockAlreadyHaveClearsMatchingOutstanding(t *testing.T) {
+	header, blockHash, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
+	full := mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{Header: header, Prefilled: []prefilledTxn{{Index: 0, Tx: txs[0]}}})
+	p := newCompactScriptedPeer(t)
+	requireNoCompactErr(t, p.handleBlock(node.DevnetGenesisBlockBytes()), "seed existing block")
+	setCompactTestOutstanding(p, blockHash, header, compactShortIDForTx(t, txs[0], 501, 502), 501, 502)
+	requireNoCompactErr(t, p.handleCmpctBlock(full), "already-have cmpctblock")
+	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatal("already-have cmpctblock did not clear matching compact outstanding request")
 	}
 }
 

--- a/clients/go/node/p2p/compact_reconstruct_test.go
+++ b/clients/go/node/p2p/compact_reconstruct_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/node"
 )
 
 func TestReconstructCompactBlockCompletesExactPositionsFromWTxID(t *testing.T) {
@@ -431,6 +432,107 @@ func TestReconstructCompactBlockSkipsLocalLookupForPrefilledOnlyBlock(t *testing
 	}
 }
 
+func TestHandleBlockTxnCompletesOutstandingBlock(t *testing.T) {
+	header, blockHash, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
+	p := newPeerRuntimeTestPeer(t)
+	if err := p.handleBlockTxn(nil); err == nil || !strings.Contains(err.Error(), "missing block hash") || p.snapshotState().BanScore == 0 {
+		t.Fatalf("short blocktxn err=%v state=%+v", err, p.snapshotState())
+	}
+	if err := p.handleBlockTxn(make([]byte, 32)); err == nil || !strings.Contains(err.Error(), "unexpected") || p.snapshotState().BanScore == 0 {
+		t.Fatalf("unsolicited blocktxn err=%v state=%+v", err, p.snapshotState())
+	}
+	p = newCompactScriptedPeer(t)
+	p.setRemoteCompactMode(compactModeSnapshot{Mode: 1, Version: compactRelayVersion})
+	setCompactTestOutstanding(p, blockHash, header, compactShortIDForTx(t, txs[0], 201, 202), 201, 202)
+	if err := p.handleBlockTxn(make([]byte, 32)); err == nil || !strings.Contains(err.Error(), "block hash mismatch") {
+		t.Fatalf("wrong hash blocktxn err=%v", err)
+	}
+	setCompactTestOutstanding(p, blockHash, header, compactShortIDForTx(t, txs[0], 201, 202), 201, 202)
+	truncatedCount := append(append([]byte{}, blockHash[:]...), 0xfd)
+	if err := p.handleBlockTxn(truncatedCount); err == nil || !strings.Contains(err.Error(), "unexpected EOF") || p.snapshotState().BanScore == 0 {
+		t.Fatalf("truncated blocktxn err=%v state=%+v", err, p.snapshotState())
+	}
+	setCompactTestOutstanding(p, blockHash, header, compactShortIDForTx(t, txs[0], 201, 202), 201, 202)
+	valid, err := encodeBlockTxnPayload(blockTxnPayload{BlockHash: blockHash, Transactions: [][]byte{txs[0]}})
+	requireNoCompactErr(t, err, "encode blocktxn")
+	requireNoCompactErr(t, p.handleMessage(message{Command: messageBlockTxn, Payload: valid}), "handle blocktxn")
+	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatal("outstanding request was not cleared")
+	}
+	if have, err := p.service.hasBlock(blockHash); err != nil || !have {
+		t.Fatalf("hasBlock=%v err=%v", have, err)
+	}
+}
+
+func TestHandleBlockTxnFallsBackWithoutBanOnShortIDMismatch(t *testing.T) {
+	header, blockHash, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
+	p := newCompactScriptedPeer(t)
+	setCompactTestOutstanding(p, blockHash, header, compactShortID{0xbb}, 301, 302)
+	valid, err := encodeBlockTxnPayload(blockTxnPayload{BlockHash: blockHash, Transactions: [][]byte{txs[0]}})
+	requireNoCompactErr(t, err, "encode blocktxn")
+	requireNoCompactErr(t, p.handleBlockTxn(valid), "mismatched blocktxn fallback")
+	requireCompactFrame(t, p, messageGetData)
+	if p.snapshotState().BanScore != 0 {
+		t.Fatalf("mismatched blocktxn state=%+v, want no ban", p.snapshotState())
+	}
+}
+
+func TestCompactReceiveErrorBranches(t *testing.T) {
+	header, blockHash, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
+	full := mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{Header: header, Prefilled: []prefilledTxn{{Index: 0, Tx: txs[0]}}})
+	missing := mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{Header: header, ShortIDs: []compactShortID{{0xaa}}})
+	p := newCompactScriptedPeer(t)
+	if err := p.handleCmpctBlock(nil); err == nil || p.snapshotState().BanScore == 0 {
+		t.Fatalf("malformed cmpctblock err=%v state=%+v", err, p.snapshotState())
+	}
+	p = newCompactScriptedPeer(t)
+	requireNoCompactErr(t, p.handleCmpctBlock(missing), "missing compact block")
+	requireCompactFrame(t, p, messageGetBlockTxn)
+	if snap, ok := p.compactOutstandingRequestSnapshot(); !ok || snap.BlockHash != blockHash || snap.BlockTxnPayloadCap == 0 {
+		t.Fatalf("outstanding=%+v ok=%v", snap, ok)
+	}
+	p = newCompactScriptedPeer(t)
+	requireCompactErrContains(t, p.handleObjectRelayMessage(message{Command: messageCmpctBlock}), "compact relay not negotiated")
+	p.setRemoteCompactMode(compactModeSnapshot{Mode: 1, Version: compactRelayVersion})
+	requireNoCompactErr(t, p.handleObjectRelayMessage(message{Command: messageCmpctBlock, Payload: full}), "object cmpctblock")
+	requireNoCompactErr(t, p.handleCmpctBlock(full), "duplicate compact block")
+	p = newCompactScriptedPeer(t)
+	p.setCompactOutstandingRequest(compactOutstandingRequest{BlockHash: [32]byte{0x01}})
+	requireNoCompactErr(t, p.handleCmpctBlock(missing), "concurrent outstanding")
+	requireCompactFrame(t, p, messageGetData)
+	p = newCompactScriptedPeer(t)
+	p.service.cfg.PeerRuntimeConfig.MaxMessageSize = 1
+	requireCompactErrContains(t, p.handleCmpctBlock(missing), "message exceeds cap")
+	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatal("send failure left compact outstanding request")
+	}
+	p = newCompactScriptedPeer(t)
+	tooMany := mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{Header: header, ShortIDs: make([]compactShortID, maxCompactRelayEntries+1)})
+	requireNoCompactErr(t, p.handleCmpctBlock(tooMany), "missing overflow fallback")
+	badHeader := header
+	for i := 76; i < 108; i++ {
+		badHeader[i] = 0
+	}
+	requireCompactErrContains(t, newCompactScriptedPeer(t).handleCmpctBlock(mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{Header: badHeader, Prefilled: []prefilledTxn{{Index: 0, Tx: txs[0]}}})), "")
+	p = newCompactScriptedPeer(t)
+	wrongTarget := [32]byte{0xee}
+	p.service.cfg.SyncConfig.ExpectedTarget = &wrongTarget
+	requireCompactErrContains(t, p.handleCmpctBlock(full), "target mismatch")
+	requireCompactErrContains(t, newCompactScriptedPeer(t).processCompactTransactions(blockHash, header, nil, true), "no transactions")
+	p = newCompactScriptedPeer(t)
+	requireNoCompactErr(t, p.processCompactTransactions([32]byte{0x99}, header, txs, true), "hash mismatch fallback")
+	requireCompactFrame(t, p, messageGetData)
+	p = newCompactScriptedPeer(t)
+	p.service.cfg.BlockStore = nil
+	requireCompactErrContains(t, p.processCompactTransactions(blockHash, header, txs, true), "nil blockstore")
+	p = newCompactScriptedPeer(t)
+	badPool := NewMemoryTxPoolWithLimit(1)
+	_ = badPool.Put([32]byte{0x01}, []byte{0xff}, 1, 1)
+	p.service.cfg.TxPool = badPool
+	requireCompactErrContains(t, p.handleCmpctBlock(missing), "non-canonical")
+	requireCompactErrContains(t, p.requestMissingCompactTransactions(cmpctBlockPayload{Header: header}, blockHash, compactReconstructionResult{}), "")
+}
+
 func TestCompactRelayLocalTransactionsBoundsMemoryPoolSnapshot(t *testing.T) {
 	pool := compactRelayTestMemoryPool(t, 4)
 	if got := compactRelayLocalTransactions(pool, 2); len(got) != 2 {
@@ -568,4 +670,52 @@ func compactWTxIDForTx(t *testing.T, tx []byte) [32]byte {
 		t.Fatalf("ParseTx: consumed=%d err=%v", consumed, err)
 	}
 	return wtxid
+}
+
+func mustEncodeCmpctBlockPayload(t *testing.T, in cmpctBlockPayload) []byte {
+	raw, err := encodeCmpctBlockPayload(in)
+	requireNoCompactErr(t, err, "encode cmpctblock")
+	return raw
+}
+
+func newCompactScriptedPeer(t *testing.T) *peer {
+	t.Helper()
+	p := newPeerRuntimeTestPeer(t)
+	p.conn = &scriptedConn{}
+	return p
+}
+
+func setCompactTestOutstanding(p *peer, blockHash [32]byte, header [consensus.BLOCK_HEADER_BYTES]byte, shortID compactShortID, nonce1, nonce2 uint64) {
+	p.setCompactOutstandingRequest(compactOutstandingRequest{blockHash, header, []uint64{0}, []compactShortID{shortID}, [][]byte{nil}, nonce1, nonce2, compactRelayPayloadCap(messageBlockTxn)})
+}
+
+func compactPartsFromBlockBytes(t *testing.T, block []byte) ([consensus.BLOCK_HEADER_BYTES]byte, [32]byte, [][]byte) {
+	var header [consensus.BLOCK_HEADER_BYTES]byte
+	copy(header[:], block[:consensus.BLOCK_HEADER_BYTES])
+	blockHash, _ := consensus.BlockHash(header[:])
+	return header, blockHash, [][]byte{append([]byte(nil), block[consensus.BLOCK_HEADER_BYTES+1:]...)}
+}
+
+func requireCompactFrame(t *testing.T, p *peer, command string) {
+	t.Helper()
+	conn := p.conn.(*scriptedConn)
+	frame, err := readFrame(bytes.NewReader(conn.Buffer.Bytes()), networkMagic(p.service.cfg.PeerRuntimeConfig.Network), p.service.cfg.PeerRuntimeConfig.MaxMessageSize)
+	conn.Buffer.Reset()
+	if err != nil || frame.Command != command {
+		t.Fatalf("compact frame=%+v err=%v want %s", frame, err, command)
+	}
+}
+
+func requireNoCompactErr(t *testing.T, err error, label string) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("%s: %v", label, err)
+	}
+}
+
+func requireCompactErrContains(t *testing.T, err error, want string) {
+	t.Helper()
+	if err == nil || (want != "" && !strings.Contains(err.Error(), want)) {
+		t.Fatalf("err=%v want %q", err, want)
+	}
 }

--- a/clients/go/node/p2p/compact_reconstruct_test.go
+++ b/clients/go/node/p2p/compact_reconstruct_test.go
@@ -622,6 +622,35 @@ func TestInternalHandleCmpctBlockAlreadyHaveClearsMatchingOutstanding(t *testing
 	}
 }
 
+func TestInternalCompactApplySuccessClearsMatchingOutstanding(t *testing.T) {
+	header, blockHash, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
+	p := newCompactScriptedPeer(t)
+	setCompactTestOutstanding(p, blockHash, header, compactShortIDForTx(t, txs[0], 601, 602), 601, 602)
+	fallback, err := p.processCompactRelayedBlockWithFallback(blockHash, node.DevnetGenesisBlockBytes(), true)
+	requireNoCompactErr(t, err, "compact apply success")
+	if fallback {
+		t.Fatal("compact apply success requested fallback")
+	}
+	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatal("compact apply success did not clear matching compact outstanding request")
+	}
+}
+
+func TestInternalCompactApplyEarlyHaveClearsMatchingOutstanding(t *testing.T) {
+	header, blockHash, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
+	p := newCompactScriptedPeer(t)
+	requireNoCompactErr(t, p.handleBlock(node.DevnetGenesisBlockBytes()), "seed existing block")
+	setCompactTestOutstanding(p, blockHash, header, compactShortIDForTx(t, txs[0], 701, 702), 701, 702)
+	fallback, err := p.processCompactRelayedBlockWithFallback(blockHash, node.DevnetGenesisBlockBytes(), true)
+	requireNoCompactErr(t, err, "compact apply early-have")
+	if fallback {
+		t.Fatal("compact apply early-have requested fallback")
+	}
+	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatal("compact apply early-have did not clear matching compact outstanding request")
+	}
+}
+
 func TestCompactRelayLocalTransactionsBoundsMemoryPoolSnapshot(t *testing.T) {
 	pool := compactRelayTestMemoryPool(t, 4)
 	if got := compactRelayLocalTransactions(pool, 2); len(got) != 2 {

--- a/clients/go/node/p2p/compact_reconstruct_test.go
+++ b/clients/go/node/p2p/compact_reconstruct_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/node"
@@ -330,6 +331,9 @@ func TestNewCompactOutstandingRequestBuildsPartialState(t *testing.T) {
 	if req.BlockHash != blockHash || req.Header != block.Header || req.Nonce1 != block.Nonce1 || req.Nonce2 != block.Nonce2 || req.BlockTxnPayloadCap != wantPayloadCap {
 		t.Fatalf("request metadata mismatch: %+v", req)
 	}
+	if req.RetainedBytes != uint64(len(tx)) {
+		t.Fatalf("retained bytes=%d want %d", req.RetainedBytes, len(tx))
+	}
 	if !reflect.DeepEqual(req.MissingIndexes, []uint64{0}) || !reflect.DeepEqual(req.MissingShortIDs, []compactShortID{shortID}) || !reflect.DeepEqual(req.Transactions, [][]byte{nil, tx}) {
 		t.Fatalf("request state mismatch: %+v", req)
 	}
@@ -341,6 +345,13 @@ func TestNewCompactOutstandingRequestBuildsPartialState(t *testing.T) {
 	}
 	if _, err := newCompactOutstandingRequest(block, blockHash, compactReconstructionResult{PartialTransactions: [][]byte{tx}, MissingIndexes: []uint64{0}, MissingShortIDs: []compactShortID{shortID}}); err == nil {
 		t.Fatal("non-missing partial slot should fail")
+	}
+	if _, err := newCompactOutstandingRequest(block, blockHash, compactReconstructionResult{
+		PartialTransactions: [][]byte{make([]byte, compactOutstandingRetainedBytesLimit+1), nil},
+		MissingIndexes:      []uint64{1},
+		MissingShortIDs:     []compactShortID{shortID},
+	}); !errors.Is(err, errCompactOutstandingRetainedBytesTooLarge) {
+		t.Fatalf("oversized retained request err=%v, want retained byte cap", err)
 	}
 }
 
@@ -432,7 +443,7 @@ func TestReconstructCompactBlockSkipsLocalLookupForPrefilledOnlyBlock(t *testing
 	}
 }
 
-func TestHandleBlockTxnCompletesOutstandingBlock(t *testing.T) {
+func TestInternalHandleBlockTxnCompletesOutstandingBlock(t *testing.T) {
 	header, blockHash, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
 	p := newPeerRuntimeTestPeer(t)
 	if err := p.handleBlockTxn(nil); err == nil || !strings.Contains(err.Error(), "missing block hash") || p.snapshotState().BanScore == 0 {
@@ -440,7 +451,6 @@ func TestHandleBlockTxnCompletesOutstandingBlock(t *testing.T) {
 	}
 	requireBlockTxnMessageBan(t, newPeerRuntimeTestPeer(t), make([]byte, 32), "unexpected")
 	p = newCompactScriptedPeer(t)
-	p.setRemoteCompactMode(compactModeSnapshot{Mode: 1, Version: compactRelayVersion})
 	setCompactTestOutstanding(p, blockHash, header, compactShortIDForTx(t, txs[0], 201, 202), 201, 202)
 	if err := p.handleBlockTxn(make([]byte, 32)); err == nil || !strings.Contains(err.Error(), "block hash mismatch") {
 		t.Fatalf("wrong hash blocktxn err=%v", err)
@@ -453,12 +463,42 @@ func TestHandleBlockTxnCompletesOutstandingBlock(t *testing.T) {
 	setCompactTestOutstanding(p, blockHash, header, compactShortIDForTx(t, txs[0], 201, 202), 201, 202)
 	valid, err := encodeBlockTxnPayload(blockTxnPayload{BlockHash: blockHash, Transactions: [][]byte{txs[0]}})
 	requireNoCompactErr(t, err, "encode blocktxn")
-	requireNoCompactErr(t, p.handleMessage(message{Command: messageBlockTxn, Payload: valid}), "handle blocktxn")
+	requireNoCompactErr(t, p.handleBlockTxn(valid), "handle blocktxn")
 	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
 		t.Fatal("outstanding request was not cleared")
 	}
 	if have, err := p.service.hasBlock(blockHash); err != nil || !have {
 		t.Fatalf("hasBlock=%v err=%v", have, err)
+	}
+}
+
+func TestInternalHandleBlockTxnKeepsSnapshotAcrossExpiryRace(t *testing.T) {
+	header, blockHash, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
+	p := newCompactScriptedPeer(t)
+	now := time.Unix(1000, 0)
+	p.service.cfg.Now = func() time.Time {
+		defer func() { now = now.Add(time.Second) }()
+		return now
+	}
+	p.setCompactOutstandingRequest(compactOutstandingRequest{
+		BlockHash:          blockHash,
+		Header:             header,
+		MissingIndexes:     []uint64{0},
+		MissingShortIDs:    []compactShortID{compactShortIDForTx(t, txs[0], 201, 202)},
+		Transactions:       [][]byte{nil},
+		Nonce1:             201,
+		Nonce2:             202,
+		BlockTxnPayloadCap: compactRelayPayloadCap(messageBlockTxn),
+		ExpiresAt:          time.Unix(1001, 0),
+	})
+	valid, err := encodeBlockTxnPayload(blockTxnPayload{BlockHash: blockHash, Transactions: [][]byte{txs[0]}})
+	requireNoCompactErr(t, err, "encode blocktxn")
+	requireNoCompactErr(t, p.handleBlockTxn(valid), "handle blocktxn")
+	if have, err := p.service.hasBlock(blockHash); err != nil || !have {
+		t.Fatalf("hasBlock=%v err=%v, want accepted block from snapshot", have, err)
+	}
+	if p.conn.(*scriptedConn).Buffer.Len() != 0 {
+		t.Fatal("expiry race sent full-block fallback")
 	}
 }
 
@@ -493,7 +533,7 @@ func TestHandleBlockTxnFallsBackWithoutBanOnShortIDMismatch(t *testing.T) {
 	}
 }
 
-func TestCompactReceiveErrorBranches(t *testing.T) {
+func TestInternalCompactReceiveErrorBranches(t *testing.T) {
 	header, blockHash, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
 	full := mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{Header: header, Prefilled: []prefilledTxn{{Index: 0, Tx: txs[0]}}})
 	missing := mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{Header: header, ShortIDs: []compactShortID{{0xaa}}})
@@ -510,8 +550,8 @@ func TestCompactReceiveErrorBranches(t *testing.T) {
 	p = newCompactScriptedPeer(t)
 	requireCompactErrContains(t, p.handleObjectRelayMessage(message{Command: messageCmpctBlock}), "compact relay not negotiated")
 	p.setRemoteCompactMode(compactModeSnapshot{Mode: 1, Version: compactRelayVersion})
-	requireNoCompactErr(t, p.handleObjectRelayMessage(message{Command: messageCmpctBlock, Payload: full}), "object cmpctblock")
-	requireNoCompactErr(t, p.handleCmpctBlock(full), "duplicate compact block")
+	requireCompactErrContains(t, p.handleObjectRelayMessage(message{Command: messageCmpctBlock, Payload: full}), "compact relay not negotiated")
+	requireNoCompactErr(t, p.handleCmpctBlock(full), "direct cmpctblock")
 	p = newCompactScriptedPeer(t)
 	p.setCompactOutstandingRequest(compactOutstandingRequest{BlockHash: [32]byte{0x01}})
 	requireNoCompactErr(t, p.handleCmpctBlock(missing), "concurrent outstanding")
@@ -521,6 +561,17 @@ func TestCompactReceiveErrorBranches(t *testing.T) {
 	requireCompactErrContains(t, p.handleCmpctBlock(missing), "message exceeds cap")
 	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
 		t.Fatal("send failure left compact outstanding request")
+	}
+	p = newCompactScriptedPeer(t)
+	oversizedRetained := compactReconstructionResult{
+		PartialTransactions: [][]byte{make([]byte, compactOutstandingRetainedBytesLimit+1), nil},
+		MissingIndexes:      []uint64{1},
+		MissingShortIDs:     []compactShortID{{0xaa}},
+	}
+	requireNoCompactErr(t, p.requestMissingCompactTransactions(cmpctBlockPayload{Header: header}, blockHash, oversizedRetained), "oversized retained compact request")
+	requireCompactFrame(t, p, messageGetData)
+	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatal("oversized retained compact request left outstanding state")
 	}
 	p = newCompactScriptedPeer(t)
 	tooMany := mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{Header: header, ShortIDs: make([]compactShortID, maxCompactRelayEntries+1)})
@@ -547,6 +598,16 @@ func TestCompactReceiveErrorBranches(t *testing.T) {
 	p.service.cfg.TxPool = badPool
 	requireCompactErrContains(t, p.handleCmpctBlock(missing), "non-canonical")
 	requireCompactErrContains(t, p.requestMissingCompactTransactions(cmpctBlockPayload{Header: header}, blockHash, compactReconstructionResult{}), "")
+}
+
+func TestFullBlockClearsMatchingCompactOutstanding(t *testing.T) {
+	header, blockHash, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
+	p := newCompactScriptedPeer(t)
+	setCompactTestOutstanding(p, blockHash, header, compactShortIDForTx(t, txs[0], 401, 402), 401, 402)
+	requireNoCompactErr(t, p.handleBlock(node.DevnetGenesisBlockBytes()), "full block")
+	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatal("full block did not clear matching compact outstanding request")
+	}
 }
 
 func TestCompactRelayLocalTransactionsBoundsMemoryPoolSnapshot(t *testing.T) {
@@ -702,7 +763,16 @@ func newCompactScriptedPeer(t *testing.T) *peer {
 }
 
 func setCompactTestOutstanding(p *peer, blockHash [32]byte, header [consensus.BLOCK_HEADER_BYTES]byte, shortID compactShortID, nonce1, nonce2 uint64) {
-	p.setCompactOutstandingRequest(compactOutstandingRequest{blockHash, header, []uint64{0}, []compactShortID{shortID}, [][]byte{nil}, nonce1, nonce2, compactRelayPayloadCap(messageBlockTxn)})
+	p.activateCompactOutstandingRequest(compactOutstandingRequest{
+		BlockHash:          blockHash,
+		Header:             header,
+		MissingIndexes:     []uint64{0},
+		MissingShortIDs:    []compactShortID{shortID},
+		Transactions:       [][]byte{nil},
+		Nonce1:             nonce1,
+		Nonce2:             nonce2,
+		BlockTxnPayloadCap: compactRelayPayloadCap(messageBlockTxn),
+	})
 }
 
 func compactPartsFromBlockBytes(t *testing.T, block []byte) ([consensus.BLOCK_HEADER_BYTES]byte, [32]byte, [][]byte) {

--- a/clients/go/node/p2p/compact_runtime.go
+++ b/clients/go/node/p2p/compact_runtime.go
@@ -8,6 +8,8 @@ import (
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
 )
 
+const compactOutstandingRequestTTL = 15 * time.Second
+
 type compactModeSnapshot struct {
 	Mode    uint8
 	Version uint64
@@ -74,7 +76,7 @@ func (p *peer) setCompactOutstandingRequest(req compactOutstandingRequest) {
 }
 
 func (p *peer) activateCompactOutstandingRequest(req compactOutstandingRequest) {
-	req.ExpiresAt = p.service.cfg.Now().Add(p.service.cfg.PeerRuntimeConfig.ReadDeadline)
+	req.ExpiresAt = p.service.cfg.Now().Add(compactOutstandingRequestTTL)
 	p.setCompactOutstandingRequest(req)
 }
 

--- a/clients/go/node/p2p/compact_runtime.go
+++ b/clients/go/node/p2p/compact_runtime.go
@@ -82,6 +82,12 @@ func (p *peer) compactOutstandingRequestSnapshot() (compactOutstandingRequest, b
 	return cloneCompactOutstandingRequest(req), true
 }
 
+func (p *peer) hasCompactOutstandingRequest() bool {
+	p.compactMu.Lock()
+	defer p.compactMu.Unlock()
+	return p.compact.outstanding != nil
+}
+
 func (p *peer) popCompactOutstandingRequest() (compactOutstandingRequest, bool) {
 	p.compactMu.Lock()
 	if p.compact.outstanding == nil {

--- a/clients/go/node/p2p/compact_runtime.go
+++ b/clients/go/node/p2p/compact_runtime.go
@@ -3,6 +3,7 @@ package p2p
 import (
 	"encoding/binary"
 	"errors"
+	"time"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
 )
@@ -26,6 +27,8 @@ type compactOutstandingRequest struct {
 	Nonce1             uint64
 	Nonce2             uint64
 	BlockTxnPayloadCap uint32
+	RetainedBytes      uint64
+	ExpiresAt          time.Time
 }
 
 func (p *peer) handleSendCmpct(payload []byte) error {
@@ -70,9 +73,19 @@ func (p *peer) setCompactOutstandingRequest(req compactOutstandingRequest) {
 	p.compactMu.Unlock()
 }
 
+func (p *peer) activateCompactOutstandingRequest(req compactOutstandingRequest) {
+	req.ExpiresAt = p.service.cfg.Now().Add(p.service.cfg.PeerRuntimeConfig.ReadDeadline)
+	p.setCompactOutstandingRequest(req)
+}
+
 func (p *peer) compactOutstandingRequestSnapshot() (compactOutstandingRequest, bool) {
 	p.compactMu.Lock()
 	if p.compact.outstanding == nil {
+		p.compactMu.Unlock()
+		return compactOutstandingRequest{}, false
+	}
+	if p.compactOutstandingRequestExpiredLocked() {
+		p.compact.outstanding = nil
 		p.compactMu.Unlock()
 		return compactOutstandingRequest{}, false
 	}
@@ -85,6 +98,10 @@ func (p *peer) compactOutstandingRequestSnapshot() (compactOutstandingRequest, b
 func (p *peer) hasCompactOutstandingRequest() bool {
 	p.compactMu.Lock()
 	defer p.compactMu.Unlock()
+	if p.compactOutstandingRequestExpiredLocked() {
+		p.compact.outstanding = nil
+		return false
+	}
 	return p.compact.outstanding != nil
 }
 
@@ -94,11 +111,31 @@ func (p *peer) popCompactOutstandingRequest() (compactOutstandingRequest, bool) 
 		p.compactMu.Unlock()
 		return compactOutstandingRequest{}, false
 	}
+	if p.compactOutstandingRequestExpiredLocked() {
+		p.compact.outstanding = nil
+		p.compactMu.Unlock()
+		return compactOutstandingRequest{}, false
+	}
 	// Stored outstanding requests are immutable; keep large tx-byte cloning outside compactMu.
 	req := *p.compact.outstanding
 	p.compact.outstanding = nil
 	p.compactMu.Unlock()
 	return cloneCompactOutstandingRequest(req), true
+}
+
+func (p *peer) clearCompactOutstandingRequestForBlock(blockHash [32]byte) {
+	p.compactMu.Lock()
+	if p.compact.outstanding != nil && p.compact.outstanding.BlockHash == blockHash {
+		p.compact.outstanding = nil
+	}
+	p.compactMu.Unlock()
+}
+
+func (p *peer) compactOutstandingRequestExpiredLocked() bool {
+	if p.compact.outstanding == nil || p.compact.outstanding.ExpiresAt.IsZero() {
+		return false
+	}
+	return !p.service.cfg.Now().Before(p.compact.outstanding.ExpiresAt)
 }
 
 func cloneCompactOutstandingRequest(req compactOutstandingRequest) compactOutstandingRequest {
@@ -112,6 +149,10 @@ func (p *peer) blockTxnPayloadCap() uint32 {
 	p.compactMu.Lock()
 	defer p.compactMu.Unlock()
 	if p.compact.outstanding == nil {
+		return 0
+	}
+	if p.compactOutstandingRequestExpiredLocked() {
+		p.compact.outstanding = nil
 		return 0
 	}
 	if maxCap := compactRelayPayloadCap(messageBlockTxn); p.compact.outstanding.BlockTxnPayloadCap > maxCap {

--- a/clients/go/node/p2p/handlers_block.go
+++ b/clients/go/node/p2p/handlers_block.go
@@ -62,8 +62,12 @@ func (p *peer) processRelayedBlock(blockBytes []byte) (*node.ChainStateConnectSu
 		return nil, errors.New("nil parsed block")
 	}
 	have, err := p.service.hasBlock(blockHash)
-	if err != nil || have {
+	if err != nil {
 		return nil, err
+	}
+	if have {
+		p.clearCompactOutstandingRequestForBlock(blockHash)
+		return nil, nil
 	}
 
 	p.service.chainMu.Lock()
@@ -72,6 +76,7 @@ func (p *peer) processRelayedBlock(blockBytes []byte) (*node.ChainStateConnectSu
 	if err != nil {
 		return p.handleRelayedBlockApplyError(pb, blockHash, blockBytes, err)
 	}
+	p.clearCompactOutstandingRequestForBlock(blockHash)
 	p.acceptedRelayedBlock(blockHash, summary)
 	return summary, nil
 }
@@ -99,6 +104,7 @@ func (p *peer) retainRelayedOrphanIfValid(
 		return nil, err
 	}
 	p.service.retainOrResolveOrphan(p, blockHash, pb.Header.PrevBlockHash, blockBytes)
+	p.clearCompactOutstandingRequestForBlock(blockHash)
 	return nil, nil
 }
 

--- a/clients/go/node/p2p/peer_runtime.go
+++ b/clients/go/node/p2p/peer_runtime.go
@@ -138,7 +138,7 @@ func (p *peer) handleObjectRelayMessage(frame message) error {
 		if frame.Command == messageBlockTxn {
 			return p.rejectBlockTxn("unexpected blocktxn")
 		}
-		return errors.New("compact relay not negotiated")
+		return errors.New("compact relay receive disabled")
 	}
 	switch frame.Command {
 	case messageBlock:

--- a/clients/go/node/p2p/peer_runtime.go
+++ b/clients/go/node/p2p/peer_runtime.go
@@ -52,7 +52,13 @@ func (p *peer) run(ctx context.Context) error {
 func (p *peer) postHandshakePayloadCap() payloadLimitFn {
 	base := postHandshakePayloadCap(p.service.cfg.LocatorLimit, p.service.cfg.SyncConfig.HeaderBatchLimit)
 	return func(command string) uint32 {
-		if isCompactRelayObjectCommand(command) {
+		if command == messageGetBlockTxn {
+			return 0
+		}
+		if command == messageBlockTxn {
+			return p.blockTxnPayloadCap()
+		}
+		if isCompactRelayObjectCommand(command) && !p.compactRelayEnabled() {
 			return 0
 		}
 		return base(command)
@@ -94,7 +100,7 @@ func normalizeReadError(err error) error {
 
 func (p *peer) handleMessage(frame message) error {
 	switch frame.Command {
-	case messageInv, messageGetData, messageBlock, messageTx, messageGetBlk:
+	case messageInv, messageGetData, messageBlock, messageTx, messageGetBlk, messageCmpctBlock, messageBlockTxn:
 		return p.handleRelayMessage(frame)
 	case messageSendCmpct:
 		return p.handleSendCmpct(frame.Payload)
@@ -115,7 +121,7 @@ func (p *peer) handleRelayMessage(frame message) error {
 	switch frame.Command {
 	case messageInv, messageGetData:
 		return p.handleInventoryRelayMessage(frame)
-	case messageBlock, messageTx, messageGetBlk:
+	case messageBlock, messageTx, messageGetBlk, messageCmpctBlock, messageBlockTxn:
 		return p.handleObjectRelayMessage(frame)
 	default:
 		return postHandshakeUnknownCommandError{command: frame.Command}
@@ -134,6 +140,9 @@ func (p *peer) handleInventoryRelayMessage(frame message) error {
 }
 
 func (p *peer) handleObjectRelayMessage(frame message) error {
+	if isCompactRelayObjectCommand(frame.Command) && !p.compactRelayObjectAllowed(frame.Command) {
+		return errors.New("compact relay not negotiated")
+	}
 	switch frame.Command {
 	case messageBlock:
 		return p.handleBlock(frame.Payload)
@@ -141,6 +150,10 @@ func (p *peer) handleObjectRelayMessage(frame message) error {
 		return p.handleTx(frame.Payload)
 	case messageGetBlk:
 		return p.handleGetBlocks(frame.Payload)
+	case messageCmpctBlock:
+		return p.handleCmpctBlock(frame.Payload)
+	case messageBlockTxn:
+		return p.handleBlockTxn(frame.Payload)
 	default:
 		return postHandshakeUnknownCommandError{command: frame.Command}
 	}
@@ -153,6 +166,18 @@ func isCompactRelayObjectCommand(command string) bool {
 	default:
 		return false
 	}
+}
+
+func (p *peer) compactRelayEnabled() bool {
+	mode := p.remoteCompactMode()
+	return mode.Version == compactRelayVersion && mode.Mode > 0
+}
+
+func (p *peer) compactRelayObjectAllowed(command string) bool {
+	if command == messageBlockTxn && p.blockTxnPayloadCap() > 0 {
+		return true
+	}
+	return p.compactRelayEnabled()
 }
 
 func (p *peer) handleAddressMessage(frame message) error {

--- a/clients/go/node/p2p/peer_runtime.go
+++ b/clients/go/node/p2p/peer_runtime.go
@@ -231,19 +231,30 @@ func (p *peer) applyPostHandshakeDisconnectError(err error) {
 }
 
 func compactBlockTxnCommandCapPolicyReason(err error) (string, bool) {
-	var capErr commandPayloadCapError
-	if errors.As(err, &capErr) && capErr.command == messageBlockTxn {
+	if command, ok := capErrorCommand(err); ok && command == messageBlockTxn {
 		return "unexpected blocktxn", true
 	}
 	return "", false
 }
 
 func commandPayloadCapDiagnosticReason(err error) (string, bool) {
-	var capErr commandPayloadCapError
-	if !errors.As(err, &capErr) || capErr.command == "" {
+	command, ok := capErrorCommand(err)
+	if !ok || command == "" {
 		return "", false
 	}
-	return fmt.Sprintf("%s: %s", err.Error(), capErr.command), true
+	return fmt.Sprintf("%s: %s", err.Error(), command), true
+}
+
+func capErrorCommand(err error) (string, bool) {
+	var commandCapErr commandPayloadCapError
+	if errors.As(err, &commandCapErr) {
+		return commandCapErr.command, true
+	}
+	var messageCapErr inboundMessagePayloadCapError
+	if errors.As(err, &messageCapErr) {
+		return messageCapErr.command, true
+	}
+	return "", false
 }
 
 func (p *peer) bumpBan(delta int, reason string) bool {

--- a/clients/go/node/p2p/peer_runtime.go
+++ b/clients/go/node/p2p/peer_runtime.go
@@ -223,6 +223,10 @@ func (p *peer) applyPostHandshakeDisconnectError(err error) {
 		p.setLastError(reason)
 		return
 	}
+	if reason, ok := commandPayloadCapDiagnosticReason(err); ok {
+		p.setLastError(reason)
+		return
+	}
 	p.setLastError(err.Error())
 }
 
@@ -232,6 +236,14 @@ func compactBlockTxnCommandCapPolicyReason(err error) (string, bool) {
 		return "unexpected blocktxn", true
 	}
 	return "", false
+}
+
+func commandPayloadCapDiagnosticReason(err error) (string, bool) {
+	var capErr commandPayloadCapError
+	if !errors.As(err, &capErr) || capErr.command == "" {
+		return "", false
+	}
+	return fmt.Sprintf("%s: %s", err.Error(), capErr.command), true
 }
 
 func (p *peer) bumpBan(delta int, reason string) bool {

--- a/clients/go/node/p2p/peer_runtime.go
+++ b/clients/go/node/p2p/peer_runtime.go
@@ -52,7 +52,13 @@ func (p *peer) run(ctx context.Context) error {
 func (p *peer) postHandshakePayloadCap() payloadLimitFn {
 	base := postHandshakePayloadCap(p.service.cfg.LocatorLimit, p.service.cfg.SyncConfig.HeaderBatchLimit)
 	return func(command string) uint32 {
-		if isCompactRelayObjectCommand(command) {
+		if command == messageGetBlockTxn {
+			return 0
+		}
+		if command == messageBlockTxn {
+			return p.blockTxnPayloadCap()
+		}
+		if isCompactRelayObjectCommand(command) && !p.compactRelayEnabled() {
 			return 0
 		}
 		return base(command)
@@ -94,7 +100,7 @@ func normalizeReadError(err error) error {
 
 func (p *peer) handleMessage(frame message) error {
 	switch frame.Command {
-	case messageInv, messageGetData, messageBlock, messageTx, messageGetBlk:
+	case messageInv, messageGetData, messageBlock, messageTx, messageGetBlk, messageCmpctBlock, messageBlockTxn:
 		return p.handleRelayMessage(frame)
 	case messageSendCmpct:
 		return p.handleSendCmpct(frame.Payload)
@@ -115,7 +121,7 @@ func (p *peer) handleRelayMessage(frame message) error {
 	switch frame.Command {
 	case messageInv, messageGetData:
 		return p.handleInventoryRelayMessage(frame)
-	case messageBlock, messageTx, messageGetBlk:
+	case messageBlock, messageTx, messageGetBlk, messageCmpctBlock, messageBlockTxn:
 		return p.handleObjectRelayMessage(frame)
 	default:
 		return postHandshakeUnknownCommandError{command: frame.Command}
@@ -134,6 +140,12 @@ func (p *peer) handleInventoryRelayMessage(frame message) error {
 }
 
 func (p *peer) handleObjectRelayMessage(frame message) error {
+	if isCompactRelayObjectCommand(frame.Command) && !p.compactRelayObjectAllowed(frame.Command) {
+		if frame.Command == messageBlockTxn {
+			return p.rejectBlockTxn("unexpected blocktxn")
+		}
+		return errors.New("compact relay not negotiated")
+	}
 	switch frame.Command {
 	case messageBlock:
 		return p.handleBlock(frame.Payload)
@@ -141,6 +153,10 @@ func (p *peer) handleObjectRelayMessage(frame message) error {
 		return p.handleTx(frame.Payload)
 	case messageGetBlk:
 		return p.handleGetBlocks(frame.Payload)
+	case messageCmpctBlock:
+		return p.handleCmpctBlock(frame.Payload)
+	case messageBlockTxn:
+		return p.handleBlockTxn(frame.Payload)
 	default:
 		return postHandshakeUnknownCommandError{command: frame.Command}
 	}
@@ -153,6 +169,18 @@ func isCompactRelayObjectCommand(command string) bool {
 	default:
 		return false
 	}
+}
+
+func (p *peer) compactRelayEnabled() bool {
+	mode := p.remoteCompactMode()
+	return mode.Version == compactRelayVersion && mode.Mode > 0
+}
+
+func (p *peer) compactRelayObjectAllowed(command string) bool {
+	if command == messageBlockTxn && p.blockTxnPayloadCap() > 0 {
+		return true
+	}
+	return p.compactRelayEnabled()
 }
 
 func (p *peer) handleAddressMessage(frame message) error {

--- a/clients/go/node/p2p/peer_runtime.go
+++ b/clients/go/node/p2p/peer_runtime.go
@@ -52,13 +52,7 @@ func (p *peer) run(ctx context.Context) error {
 func (p *peer) postHandshakePayloadCap() payloadLimitFn {
 	base := postHandshakePayloadCap(p.service.cfg.LocatorLimit, p.service.cfg.SyncConfig.HeaderBatchLimit)
 	return func(command string) uint32 {
-		if command == messageGetBlockTxn {
-			return 0
-		}
-		if command == messageBlockTxn {
-			return p.blockTxnPayloadCap()
-		}
-		if isCompactRelayObjectCommand(command) && !p.compactRelayEnabled() {
+		if isCompactRelayObjectCommand(command) {
 			return 0
 		}
 		return base(command)
@@ -140,7 +134,7 @@ func (p *peer) handleInventoryRelayMessage(frame message) error {
 }
 
 func (p *peer) handleObjectRelayMessage(frame message) error {
-	if isCompactRelayObjectCommand(frame.Command) && !p.compactRelayObjectAllowed(frame.Command) {
+	if isCompactRelayObjectCommand(frame.Command) {
 		if frame.Command == messageBlockTxn {
 			return p.rejectBlockTxn("unexpected blocktxn")
 		}
@@ -153,10 +147,6 @@ func (p *peer) handleObjectRelayMessage(frame message) error {
 		return p.handleTx(frame.Payload)
 	case messageGetBlk:
 		return p.handleGetBlocks(frame.Payload)
-	case messageCmpctBlock:
-		return p.handleCmpctBlock(frame.Payload)
-	case messageBlockTxn:
-		return p.handleBlockTxn(frame.Payload)
 	default:
 		return postHandshakeUnknownCommandError{command: frame.Command}
 	}
@@ -169,18 +159,6 @@ func isCompactRelayObjectCommand(command string) bool {
 	default:
 		return false
 	}
-}
-
-func (p *peer) compactRelayEnabled() bool {
-	mode := p.remoteCompactMode()
-	return mode.Version == compactRelayVersion && mode.Mode > 0
-}
-
-func (p *peer) compactRelayObjectAllowed(command string) bool {
-	if command == messageBlockTxn && p.blockTxnPayloadCap() > 0 {
-		return true
-	}
-	return p.compactRelayEnabled()
 }
 
 func (p *peer) handleAddressMessage(frame message) error {
@@ -237,11 +215,23 @@ func (p *peer) applyPostHandshakeDisconnectError(err error) {
 	if err == nil {
 		return
 	}
+	if reason, ok := compactBlockTxnCommandCapPolicyReason(err); ok {
+		p.bumpBan(10, reason)
+		return
+	}
 	if reason, ok := unknownCommandPolicyReason(err); ok {
 		p.setLastError(reason)
 		return
 	}
 	p.setLastError(err.Error())
+}
+
+func compactBlockTxnCommandCapPolicyReason(err error) (string, bool) {
+	var capErr commandPayloadCapError
+	if errors.As(err, &capErr) && capErr.command == messageBlockTxn {
+		return "unexpected blocktxn", true
+	}
+	return "", false
 }
 
 func (p *peer) bumpBan(delta int, reason string) bool {

--- a/clients/go/node/p2p/peer_runtime_test.go
+++ b/clients/go/node/p2p/peer_runtime_test.go
@@ -168,7 +168,7 @@ func TestCompactOutstandingRequestExpires(t *testing.T) {
 	}
 }
 
-func TestCompactOutstandingRequestDoesNotExpireWhenReadDeadlineDisabled(t *testing.T) {
+func TestCompactOutstandingRequestUsesDedicatedTTLWhenReadDeadlineDisabled(t *testing.T) {
 	p := newPeerRuntimeTestPeer(t)
 	now := time.Unix(1000, 0)
 	p.service.cfg.Now = func() time.Time { return now }
@@ -428,6 +428,23 @@ func TestApplyPostHandshakeDisconnectErrorNilAndGenericFallback(t *testing.T) {
 	}
 	if snap.BanScore != 0 {
 		t.Fatalf("ban_score=%d, want 0 for generic runtime error mapping", snap.BanScore)
+	}
+}
+
+func TestApplyPostHandshakeDisconnectErrorCommandCapRecordsCommand(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	err := commandPayloadCapError{command: messagePing}
+	if err.Error() != "message exceeds command cap" {
+		t.Fatalf("error=%q, want public command cap error unchanged", err.Error())
+	}
+
+	p.applyPostHandshakeDisconnectError(err)
+	snap := p.snapshotState()
+	if snap.LastError != "message exceeds command cap: ping" {
+		t.Fatalf("last_error=%q, want command diagnostic", snap.LastError)
+	}
+	if snap.BanScore != 0 {
+		t.Fatalf("ban_score=%d, want 0 for non-blocktxn command cap", snap.BanScore)
 	}
 }
 

--- a/clients/go/node/p2p/peer_runtime_test.go
+++ b/clients/go/node/p2p/peer_runtime_test.go
@@ -154,17 +154,36 @@ func TestCompactOutstandingRequestExpires(t *testing.T) {
 	p := newPeerRuntimeTestPeer(t)
 	now := time.Unix(1000, 0)
 	p.service.cfg.Now = func() time.Time { return now }
-	p.service.cfg.PeerRuntimeConfig.ReadDeadline = time.Second
+	p.service.cfg.PeerRuntimeConfig.ReadDeadline = compactOutstandingRequestTTL + time.Second
 	p.activateCompactOutstandingRequest(compactOutstandingRequest{BlockTxnPayloadCap: 64})
 	if got := p.blockTxnPayloadCap(); got != 64 {
 		t.Fatalf("fresh blocktxn cap=%d, want 64", got)
 	}
-	now = now.Add(time.Second)
+	now = now.Add(compactOutstandingRequestTTL)
 	if got := p.blockTxnPayloadCap(); got != 0 {
 		t.Fatalf("expired blocktxn cap=%d, want 0", got)
 	}
 	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
 		t.Fatal("expired outstanding request was not cleared")
+	}
+}
+
+func TestCompactOutstandingRequestDoesNotExpireWhenReadDeadlineDisabled(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	now := time.Unix(1000, 0)
+	p.service.cfg.Now = func() time.Time { return now }
+	p.service.cfg.PeerRuntimeConfig.ReadDeadline = 0
+	p.activateCompactOutstandingRequest(compactOutstandingRequest{BlockTxnPayloadCap: 64})
+	if got := p.blockTxnPayloadCap(); got != 64 {
+		t.Fatalf("disabled-deadline blocktxn cap=%d, want 64", got)
+	}
+	now = now.Add(compactOutstandingRequestTTL - time.Nanosecond)
+	if got := p.blockTxnPayloadCap(); got != 64 {
+		t.Fatalf("disabled-deadline early blocktxn cap=%d, want 64", got)
+	}
+	now = now.Add(time.Nanosecond)
+	if got := p.blockTxnPayloadCap(); got != 0 {
+		t.Fatalf("disabled-deadline expired blocktxn cap=%d, want 0", got)
 	}
 }
 

--- a/clients/go/node/p2p/peer_runtime_test.go
+++ b/clients/go/node/p2p/peer_runtime_test.go
@@ -88,7 +88,7 @@ func TestShouldIgnoreAndNormalizeReadError(t *testing.T) {
 	}
 }
 
-func TestCompactObjectCapsStayClosedUntilHandlersExist(t *testing.T) {
+func TestCompactObjectCapsStayClosedUntilParityReceiveExists(t *testing.T) {
 	p := newPeerRuntimeTestPeer(t)
 	limiter := p.postHandshakePayloadCap()
 	for _, command := range []string{messageCmpctBlock, messageGetBlockTxn, messageBlockTxn} {
@@ -99,8 +99,8 @@ func TestCompactObjectCapsStayClosedUntilHandlersExist(t *testing.T) {
 
 	p.setRemoteCompactMode(compactModeSnapshot{Mode: 1, Version: compactRelayVersion})
 	limiter = p.postHandshakePayloadCap()
-	if got := limiter(messageCmpctBlock); got != compactRelayPayloadCap(messageCmpctBlock) {
-		t.Fatalf("negotiated cmpctblock cap=%d, want %d", got, compactRelayPayloadCap(messageCmpctBlock))
+	if got := limiter(messageCmpctBlock); got != 0 {
+		t.Fatalf("negotiated cmpctblock cap=%d, want 0 until Rust parity", got)
 	}
 	if got := limiter(messageGetBlockTxn); got != 0 {
 		t.Fatalf("getblocktxn serve-side cap=%d, want 0", got)
@@ -109,8 +109,8 @@ func TestCompactObjectCapsStayClosedUntilHandlersExist(t *testing.T) {
 		t.Fatalf("blocktxn cap without outstanding=%d, want 0", got)
 	}
 	p.setCompactOutstandingRequest(compactOutstandingRequest{BlockTxnPayloadCap: 64})
-	if got := limiter(messageBlockTxn); got != 64 {
-		t.Fatalf("blocktxn outstanding cap=%d, want 64", got)
+	if got := limiter(messageBlockTxn); got != 0 {
+		t.Fatalf("live blocktxn outstanding cap=%d, want 0 until Rust parity", got)
 	}
 }
 
@@ -147,6 +147,40 @@ func TestBlockTxnPayloadCapIsOutstandingBounded(t *testing.T) {
 	}
 	if got := p.blockTxnPayloadCap(); got != 0 {
 		t.Fatalf("blocktxn cap after pop=%d, want 0", got)
+	}
+}
+
+func TestCompactOutstandingRequestExpires(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	now := time.Unix(1000, 0)
+	p.service.cfg.Now = func() time.Time { return now }
+	p.service.cfg.PeerRuntimeConfig.ReadDeadline = time.Second
+	p.activateCompactOutstandingRequest(compactOutstandingRequest{BlockTxnPayloadCap: 64})
+	if got := p.blockTxnPayloadCap(); got != 64 {
+		t.Fatalf("fresh blocktxn cap=%d, want 64", got)
+	}
+	now = now.Add(time.Second)
+	if got := p.blockTxnPayloadCap(); got != 0 {
+		t.Fatalf("expired blocktxn cap=%d, want 0", got)
+	}
+	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatal("expired outstanding request was not cleared")
+	}
+}
+
+func TestRunBansUnexpectedBlockTxnCommandCap(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	p.conn = &scriptedConn{reads: []scriptedRead{{
+		data: mustPeerRuntimeFrameBytes(t, p, message{Command: messageBlockTxn, Payload: make([]byte, 33)}),
+	}}}
+	err := p.run(context.Background())
+	if err == nil || err.Error() != "message exceeds command cap" {
+		t.Fatalf("run err=%v, want command cap error", err)
+	}
+	p.applyPostHandshakeDisconnectError(err)
+	state := p.snapshotState()
+	if state.BanScore == 0 || !strings.Contains(state.LastError, "unexpected blocktxn") {
+		t.Fatalf("state=%+v, want unexpected blocktxn ban", state)
 	}
 }
 

--- a/clients/go/node/p2p/peer_runtime_test.go
+++ b/clients/go/node/p2p/peer_runtime_test.go
@@ -99,11 +99,18 @@ func TestCompactObjectCapsStayClosedUntilHandlersExist(t *testing.T) {
 
 	p.setRemoteCompactMode(compactModeSnapshot{Mode: 1, Version: compactRelayVersion})
 	limiter = p.postHandshakePayloadCap()
-	p.setCompactOutstandingRequest(compactOutstandingRequest{BlockTxnPayloadCap: compactRelayPayloadCap(messageBlockTxn) + 1})
-	for _, command := range []string{messageCmpctBlock, messageGetBlockTxn, messageBlockTxn} {
-		if got := limiter(command); got != 0 {
-			t.Fatalf("negotiated %s cap=%d, want 0 until handler slice", command, got)
-		}
+	if got := limiter(messageCmpctBlock); got != compactRelayPayloadCap(messageCmpctBlock) {
+		t.Fatalf("negotiated cmpctblock cap=%d, want %d", got, compactRelayPayloadCap(messageCmpctBlock))
+	}
+	if got := limiter(messageGetBlockTxn); got != 0 {
+		t.Fatalf("getblocktxn serve-side cap=%d, want 0", got)
+	}
+	if got := limiter(messageBlockTxn); got != 0 {
+		t.Fatalf("blocktxn cap without outstanding=%d, want 0", got)
+	}
+	p.setCompactOutstandingRequest(compactOutstandingRequest{BlockTxnPayloadCap: 64})
+	if got := limiter(messageBlockTxn); got != 64 {
+		t.Fatalf("blocktxn outstanding cap=%d, want 64", got)
 	}
 }
 

--- a/clients/go/node/p2p/peer_runtime_test.go
+++ b/clients/go/node/p2p/peer_runtime_test.go
@@ -203,6 +203,30 @@ func TestRunBansUnexpectedBlockTxnCommandCap(t *testing.T) {
 	}
 }
 
+func TestRunBansUnexpectedBlockTxnMessageCap(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	p.service.cfg.PeerRuntimeConfig.MaxMessageSize = 1
+	header, err := buildEnvelopeHeader(
+		networkMagic(p.service.cfg.PeerRuntimeConfig.Network),
+		messageBlockTxn,
+		[]byte{0x01, 0x02},
+	)
+	if err != nil {
+		t.Fatalf("buildEnvelopeHeader: %v", err)
+	}
+	p.conn = &scriptedConn{reads: []scriptedRead{{data: header[:]}}}
+
+	err = p.run(context.Background())
+	if err == nil || err.Error() != "message exceeds cap" {
+		t.Fatalf("run err=%v, want message cap error", err)
+	}
+	p.applyPostHandshakeDisconnectError(err)
+	state := p.snapshotState()
+	if state.BanScore == 0 || !strings.Contains(state.LastError, "unexpected blocktxn") {
+		t.Fatalf("state=%+v, want unexpected blocktxn ban", state)
+	}
+}
+
 func TestRunDisconnectsOnPartialHeaderTimeoutBeforeFakeFrame(t *testing.T) {
 	p := newPeerRuntimeTestPeer(t)
 	p.service.cfg.PeerRuntimeConfig.ReadDeadline = time.Millisecond

--- a/clients/go/node/p2p/wire.go
+++ b/clients/go/node/p2p/wire.go
@@ -52,6 +52,14 @@ type message struct {
 
 type payloadLimitFn func(command string) uint32
 
+type commandPayloadCapError struct {
+	command string
+}
+
+func (e commandPayloadCapError) Error() string {
+	return "message exceeds command cap"
+}
+
 type frameHeader struct {
 	Command  string
 	Size     uint32
@@ -105,7 +113,7 @@ func readFrameWithPayloadLimit(r io.Reader, expectedMagic [4]byte, maxMessageSiz
 	}
 	if limit != nil {
 		if header.Size > limit(header.Command) {
-			return frame, errors.New("message exceeds command cap")
+			return frame, commandPayloadCapError{command: header.Command}
 		}
 	}
 	payload, err := readPayloadWithChecksum(r, header.Size, header.Checksum)

--- a/clients/go/node/p2p/wire.go
+++ b/clients/go/node/p2p/wire.go
@@ -60,6 +60,14 @@ func (e commandPayloadCapError) Error() string {
 	return "message exceeds command cap"
 }
 
+type inboundMessagePayloadCapError struct {
+	command string
+}
+
+func (e inboundMessagePayloadCapError) Error() string {
+	return "message exceeds cap"
+}
+
 type frameHeader struct {
 	Command  string
 	Size     uint32
@@ -206,7 +214,7 @@ func readFrameHeader(r io.Reader, expectedMagic [4]byte, maxMessageSize uint32) 
 	}
 	size := binary.LittleEndian.Uint32(raw[16:20])
 	if size > maxMessageSize {
-		return header, errors.New("message exceeds cap")
+		return header, inboundMessagePayloadCapError{command: command}
 	}
 	header.Command = command
 	header.Size = size

--- a/clients/go/node/p2p/wire_test.go
+++ b/clients/go/node/p2p/wire_test.go
@@ -75,6 +75,10 @@ func TestReadFrameMessageTooLarge(t *testing.T) {
 	if err == nil || err.Error() != "message exceeds cap" {
 		t.Fatalf("expected cap error, got %v", err)
 	}
+	var capErr inboundMessagePayloadCapError
+	if !errors.As(err, &capErr) || capErr.command != messageTx {
+		t.Fatalf("cap error=%T command=%q, want inbound message cap for %s", err, capErr.command, messageTx)
+	}
 }
 
 func TestReadFrameShortBody(t *testing.T) {


### PR DESCRIPTION
Invariant:
Go P2P compact-block receive preparation remains bounded and non-live: internal reconstruction/blocktxn state is capped and tested, while live compact relay object commands stay closed until Rust parity exists.

Layer:
Implementation and tests. No consensus, policy, Rust, conformance fixture, mixed-client, or serve-side getblocktxn changes.

Files changed:
- clients/go/node/p2p/compact_reconstruct.go
- clients/go/node/p2p/compact_reconstruct_test.go
- clients/go/node/p2p/compact_runtime.go
- clients/go/node/p2p/handlers_block.go
- clients/go/node/p2p/peer_runtime.go
- clients/go/node/p2p/peer_runtime_test.go
- clients/go/node/p2p/wire.go

Tests:
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node/p2p -run "InternalHandleBlockTxn|InternalCompactReceive|CompactObjectCaps|RunBansUnexpectedBlockTxnCommandCap"'
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node/p2p -run "Compact|CmpctBlock|BlockTxn|Reconstruct|FullBlock|CommandCap"'
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node/p2p'
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./...'
- python3 -m lizard clients/go/node/p2p/compact_reconstruct.go clients/go/node/p2p/compact_reconstruct_test.go clients/go/node/p2p/compact_runtime.go clients/go/node/p2p/peer_runtime.go clients/go/node/p2p/peer_runtime_test.go clients/go/node/p2p/handlers_block.go clients/go/node/p2p/service.go clients/go/node/p2p/wire.go clients/go/node/p2p/wire_test.go
- git diff --check
- no-limit Neon Go/general pattern self-audit: 201 patterns loaded after recording 11805
- M3_AGENT=gpt5-codex-desktop-rub326b-receive-flow /Users/gpt/bin/rubin-precommit-one-review --repo /Users/gpt/Documents/rubin-protocol-codex-RUB-326B2 --base-ref origin/main --include-base-diff
- Stock isolated reviewer: no findings
- M3_AGENT=gpt5-codex-desktop-rub326b-receive-flow /Users/gpt/bin/rubin-push --repo /Users/gpt/Documents/rubin-protocol-codex-RUB-326B2 --base-ref origin/main --coverage-cmd 'scripts/dev-env.sh -- ./scripts/preflight-codacy-coverage.sh'

Behavior impact:
- Live `cmpctblock`, `getblocktxn`, and `blocktxn` object commands remain capped at 0 at post-handshake ingress until Rust parity is added.
- Unexpected `blocktxn` remains on the misbehavior path, including command-cap rejection accounting.
- Internal compact reconstruction state retains bounded local candidate snapshots, bounded outstanding retained bytes, TTL cleanup, matching blocktxn response handling, and full-block fallback for non-completion.
- `node.ErrParentNotFound` from compact apply now retains the reconstructed block as an orphan instead of requesting the same full block again.
- Matching full-block/orphan/accepted paths clear matching compact outstanding state.

Compatibility impact:
- No mixed-client behavior is activated by this PR.
- Rust remains unchanged; Rust compact object receive parity is a follow-up before live enablement.

Known non-goals:
- No Rust P2P compact receive implementation.
- No mixed Go/Rust devnet-ready compact relay claim.
- No serve-side getblocktxn implementation.
- No conformance fixture update.
- No consensus or policy changes.

Follow-ups:
- Rust parity for compact relay object receive once the Go internal behavior is fixed.
- Mixed-client/devnet enablement after both clients share the same wire/runtime behavior.
- Serve-side getblocktxn if reciprocal serving is required.

Risk:
This is still internal Go preparation plus closed live gates. The primary risk is future accidental live enablement before Rust parity; `TestCompactObjectCapsStayClosedUntilParityReceiveExists` pins that boundary.

Rollback:
Revert this PR to return compact receive preparation to the previous closed/unsupported state.

Not checked:
- Rust workspace was not run as a separate targeted command; Rust coverage tests ran inside the sanctioned coverage gate.
- Conformance bundle was not run because this PR does not change consensus, fixtures, or Rust parity behavior.

<!-- rubin-agent-meta actor=gpt5-codex-desktop-rub326b-receive-flow action=pr-update branch=codex/RUB-326b-go-compact-receive-flow wt=rubin-protocol-codex-RUB-326B2 head=943ba1ebb61ccadc6f423788200801c33e22a4c5 -->