### PR TITLE
[RUB-335] Apply Go equal-work fork-choice tie-break

### DIFF
--- a/clients/go/node/sync_reorg.go
+++ b/clients/go/node/sync_reorg.go
@@ -36,7 +36,7 @@ func (s *SyncEngine) ApplyBlockWithReorg(blockBytes []byte, prevTimestamps []uin
 	if !switchToBranch {
 		return s.storeSideBlockAndSummary(blockBytes, blockHash, pb, candidateHeight, prevTimestamps)
 	}
-	return s.applyHeavierBranch(branch, commonAncestorHeight)
+	return s.applyPreferredBranch(branch, commonAncestorHeight)
 }
 
 func parseReorgBlock(blockBytes []byte) (*consensus.ParsedBlock, [32]byte, error) {
@@ -144,7 +144,9 @@ func (s *SyncEngine) shouldSwitchToBranch(
 	}
 }
 
-func (s *SyncEngine) applyHeavierBranch(
+// applyPreferredBranch applies the candidate branch selected by fork choice:
+// greater ChainWork, or equal ChainWork with a lexicographically lower tip hash.
+func (s *SyncEngine) applyPreferredBranch(
 	branch []reorgBranchBlock,
 	commonAncestorHeight uint64,
 ) (*ChainStateConnectSummary, error) {
@@ -152,7 +154,7 @@ func (s *SyncEngine) applyHeavierBranch(
 	if err != nil {
 		return nil, err
 	}
-	disconnectedBlocks, reorgDepth, err := s.prepareHeavierBranch(branch, commonAncestorHeight, rollbackState)
+	disconnectedBlocks, reorgDepth, err := s.preparePreferredBranch(branch, commonAncestorHeight, rollbackState)
 	if err != nil {
 		return nil, err
 	}
@@ -199,7 +201,7 @@ func (s *SyncEngine) rollbackBranchBlockApply(
 	return rollbackErr
 }
 
-func (s *SyncEngine) prepareHeavierBranch(
+func (s *SyncEngine) preparePreferredBranch(
 	branch []reorgBranchBlock,
 	commonAncestorHeight uint64,
 	rollbackState syncRollbackState,

--- a/clients/go/node/sync_reorg.go
+++ b/clients/go/node/sync_reorg.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"math/big"
@@ -106,6 +107,9 @@ func (s *SyncEngine) shouldSwitchToBranch(
 	commonAncestorHash [32]byte,
 	commonAncestorHeight uint64,
 ) (bool, uint64, error) {
+	if len(branch) == 0 {
+		return false, commonAncestorHeight, errors.New("empty side branch")
+	}
 	_, currentTipHash, err := s.currentCanonicalTip()
 	if err != nil {
 		return false, 0, err
@@ -129,7 +133,15 @@ func (s *SyncEngine) shouldSwitchToBranch(
 	}
 	candidateWork := new(big.Int).Add(new(big.Int).Set(ancestorWork), branchWork)
 	candidateHeight := commonAncestorHeight + uint64(len(branch))
-	return candidateWork.Cmp(currentWork) > 0, candidateHeight, nil
+	switch candidateWork.Cmp(currentWork) {
+	case 1:
+		return true, candidateHeight, nil
+	case -1:
+		return false, candidateHeight, nil
+	default:
+		candidateTipHash := branch[len(branch)-1].hash
+		return bytes.Compare(candidateTipHash[:], currentTipHash[:]) < 0, candidateHeight, nil
+	}
 }
 
 func (s *SyncEngine) applyHeavierBranch(

--- a/clients/go/node/sync_reorg_test.go
+++ b/clients/go/node/sync_reorg_test.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"bytes"
+	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"os"
@@ -1044,14 +1045,6 @@ func TestApplyBlockWithReorgRollbackRestoresMempoolAfterPersistFailure(t *testin
 
 	subsidyA101 := consensus.BlockSubsidy(101, alreadyGenerated)
 	blockA101 := buildSingleTxBlock(t, prevHash, target, 202, reorgTestCoinbaseForAddress(t, 101, subsidyA101, sourceAddress))
-	summaryA101, err := engine.ApplyBlock(blockA101, nil)
-	if err != nil {
-		t.Fatalf("ApplyBlock(A101): %v", err)
-	}
-	if got := mempool.Len(); got != 1 {
-		t.Fatalf("mempool len after A101=%d, want 1", got)
-	}
-
 	subsidyB101 := consensus.BlockSubsidy(101, alreadyGenerated)
 	blockB101 := buildMultiTxBlock(
 		t,
@@ -1061,12 +1054,23 @@ func TestApplyBlockWithReorgRollbackRestoresMempoolAfterPersistFailure(t *testin
 		reorgTestCoinbaseForWtxids(t, 101, subsidyB101+100_000, destAddress, [][32]byte{{}, spendWtxid}),
 		spendTx,
 	)
+	blockA101, blockA101Hash, blockB101, blockB101Hash := orderedEqualWorkBlockVariants(t, blockA101, blockB101)
+	summaryA101, err := engine.ApplyBlock(blockA101, nil)
+	if err != nil {
+		t.Fatalf("ApplyBlock(A101): %v", err)
+	}
+	if summaryA101.BlockHash != blockA101Hash {
+		t.Fatalf("A101 hash=%x, want %x", summaryA101.BlockHash, blockA101Hash)
+	}
+	if got := mempool.Len(); got != 1 {
+		t.Fatalf("mempool len after A101=%d, want 1", got)
+	}
+
 	if _, err := engine.ApplyBlockWithReorg(blockB101, nil); err != nil {
 		t.Fatalf("ApplyBlockWithReorg(B101): %v", err)
 	}
-	blockB101Hash, err := consensus.BlockHash(blockHeaderBytes(t, blockB101))
-	if err != nil {
-		t.Fatalf("BlockHash(B101): %v", err)
+	if engine.chainState.TipHash != blockA101Hash {
+		t.Fatalf("B101 equal-work side branch changed canonical tip to %x, want A101 %x", engine.chainState.TipHash, blockA101Hash)
 	}
 
 	subsidyB102 := consensus.BlockSubsidy(102, alreadyGenerated+subsidyB101)
@@ -1209,6 +1213,13 @@ func TestSyncReorgHelperCoveragePaths(t *testing.T) {
 	if height, _, err := engine.currentCanonicalTip(); err != nil || height != 1 {
 		t.Fatalf("currentCanonicalTip()=(%d,%v), want height=1", height, err)
 	}
+	switchBranch, height, err := engine.shouldSwitchToBranch(nil, devnetGenesisBlockHash, 0)
+	if err == nil {
+		t.Fatalf("shouldSwitchToBranch(empty branch) err=nil, want error")
+	}
+	if switchBranch || height != 0 {
+		t.Fatalf("shouldSwitchToBranch(empty branch)=(%v,%d), want (false,0)", switchBranch, height)
+	}
 }
 
 func TestApplyBlockWithReorgAdditionalErrorPaths(t *testing.T) {
@@ -1263,6 +1274,85 @@ func TestApplyBlockWithReorgKeepsLighterSideBranchOffCanonicalTip(t *testing.T) 
 	}
 	if _, err := store.GetBlockByHash(sideHash); err != nil {
 		t.Fatalf("GetBlockByHash(B1): %v", err)
+	}
+}
+
+func TestApplyBlockWithReorgSwitchesToLowerTipOnEqualWork(t *testing.T) {
+	engine, store, target := newReorgTestEngine(t)
+	lowerBlock, lowerHash, higherBlock, higherHash := equalWorkCompetingHeightOneBlocks(t, target)
+
+	higherSummary, err := engine.ApplyBlock(higherBlock, nil)
+	if err != nil {
+		t.Fatalf("ApplyBlock(higher): %v", err)
+	}
+	if higherSummary.BlockHash != higherHash {
+		t.Fatalf("higher block hash=%x, want %x", higherSummary.BlockHash, higherHash)
+	}
+
+	before := engine.BlockApplyCounts()
+	lowerSummary, err := engine.ApplyBlockWithReorg(lowerBlock, nil)
+	if err != nil {
+		t.Fatalf("ApplyBlockWithReorg(lower equal-work): %v", err)
+	}
+	if lowerSummary.BlockHash != lowerHash {
+		t.Fatalf("lower summary hash=%x, want %x", lowerSummary.BlockHash, lowerHash)
+	}
+	if engine.chainState.Height != 1 || engine.chainState.TipHash != lowerHash {
+		t.Fatalf("canonical tip=%d/%x, want 1/%x", engine.chainState.Height, engine.chainState.TipHash, lowerHash)
+	}
+	if depth := engine.LastReorgDepth(); depth != 1 {
+		t.Fatalf("LastReorgDepth()=%d, want 1", depth)
+	}
+	if count := engine.ReorgCount(); count != 1 {
+		t.Fatalf("ReorgCount()=%d, want 1", count)
+	}
+	if after := engine.BlockApplyCounts(); after.Accepted != before.Accepted+1 || after.Rejected != before.Rejected {
+		t.Fatalf("equal-work reorg counts=%+v, want accepted=%d rejected=%d", after, before.Accepted+1, before.Rejected)
+	}
+	canonicalHash, ok, err := store.CanonicalHash(1)
+	if err != nil || !ok {
+		t.Fatalf("CanonicalHash(1): ok=%v err=%v", ok, err)
+	}
+	if canonicalHash != lowerHash {
+		t.Fatalf("canonical height 1 hash=%x, want lower %x; higher was %x", canonicalHash, lowerHash, higherHash)
+	}
+}
+
+func TestApplyBlockWithReorgKeepsLowerTipOnEqualWorkHigherSideBranch(t *testing.T) {
+	engine, store, target := newReorgTestEngine(t)
+	lowerBlock, lowerHash, higherBlock, higherHash := equalWorkCompetingHeightOneBlocks(t, target)
+
+	lowerSummary, err := engine.ApplyBlock(lowerBlock, nil)
+	if err != nil {
+		t.Fatalf("ApplyBlock(lower): %v", err)
+	}
+	if lowerSummary.BlockHash != lowerHash {
+		t.Fatalf("lower block hash=%x, want %x", lowerSummary.BlockHash, lowerHash)
+	}
+
+	before := engine.BlockApplyCounts()
+	higherSummary, err := engine.ApplyBlockWithReorg(higherBlock, nil)
+	if err != nil {
+		t.Fatalf("ApplyBlockWithReorg(higher equal-work): %v", err)
+	}
+	if after := engine.BlockApplyCounts(); after != before {
+		t.Fatalf("higher equal-work side branch changed BlockApplyCounts from %+v to %+v", before, after)
+	}
+	if higherSummary.BlockHeight != 1 || higherSummary.BlockHash != higherHash {
+		t.Fatalf("higher side summary=%d/%x, want 1/%x", higherSummary.BlockHeight, higherSummary.BlockHash, higherHash)
+	}
+	if engine.chainState.Height != 1 || engine.chainState.TipHash != lowerHash {
+		t.Fatalf("canonical tip=%d/%x, want 1/%x", engine.chainState.Height, engine.chainState.TipHash, lowerHash)
+	}
+	canonicalHash, ok, err := store.CanonicalHash(1)
+	if err != nil || !ok {
+		t.Fatalf("CanonicalHash(1): ok=%v err=%v", ok, err)
+	}
+	if canonicalHash != lowerHash {
+		t.Fatalf("canonical height 1 hash=%x, want lower %x; higher was %x", canonicalHash, lowerHash, higherHash)
+	}
+	if _, err := store.GetBlockByHash(higherHash); err != nil {
+		t.Fatalf("GetBlockByHash(higher side): %v", err)
 	}
 }
 
@@ -1430,6 +1520,75 @@ func newReorgTestEngine(t *testing.T) (*SyncEngine, *BlockStore, [32]byte) {
 		t.Fatalf("ApplyBlock(genesis): %v", err)
 	}
 	return engine, store, target
+}
+
+func equalWorkCompetingHeightOneBlocks(t *testing.T, target [32]byte) ([]byte, [32]byte, []byte, [32]byte) {
+	t.Helper()
+	subsidy := consensus.BlockSubsidy(1, 0)
+	base := buildSingleTxBlock(
+		t,
+		devnetGenesisBlockHash,
+		target,
+		reorgTestTimestamp(1),
+		coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 1, subsidy),
+	)
+
+	var firstBlock []byte
+	var firstHash [32]byte
+	for nonce := uint64(1); nonce <= 64; nonce++ {
+		block := blockWithHeaderNonce(t, base, nonce)
+		hash, err := consensus.BlockHash(blockHeaderBytes(t, block))
+		if err != nil {
+			t.Fatalf("BlockHash(nonce=%d): %v", nonce, err)
+		}
+		if firstBlock == nil {
+			firstBlock = block
+			firstHash = hash
+			continue
+		}
+		if hash == firstHash {
+			continue
+		}
+		if bytes.Compare(hash[:], firstHash[:]) < 0 {
+			return block, hash, firstBlock, firstHash
+		}
+		return firstBlock, firstHash, block, hash
+	}
+	t.Fatalf("failed to build distinct equal-work competing blocks")
+	return nil, [32]byte{}, nil, [32]byte{}
+}
+
+func blockWithHeaderNonce(t *testing.T, block []byte, nonce uint64) []byte {
+	t.Helper()
+	if len(block) < consensus.BLOCK_HEADER_BYTES {
+		t.Fatalf("block length=%d, want at least header length %d", len(block), consensus.BLOCK_HEADER_BYTES)
+	}
+	out := append([]byte(nil), block...)
+	binary.LittleEndian.PutUint64(out[consensus.BLOCK_HEADER_BYTES-8:consensus.BLOCK_HEADER_BYTES], nonce)
+	return out
+}
+
+func orderedEqualWorkBlockVariants(t *testing.T, lowerBase []byte, higherBase []byte) ([]byte, [32]byte, []byte, [32]byte) {
+	t.Helper()
+	for lowerNonce := uint64(1); lowerNonce <= 64; lowerNonce++ {
+		lowerBlock := blockWithHeaderNonce(t, lowerBase, lowerNonce)
+		lowerHash, err := consensus.BlockHash(blockHeaderBytes(t, lowerBlock))
+		if err != nil {
+			t.Fatalf("BlockHash(lower nonce=%d): %v", lowerNonce, err)
+		}
+		for higherNonce := uint64(1); higherNonce <= 64; higherNonce++ {
+			higherBlock := blockWithHeaderNonce(t, higherBase, higherNonce)
+			higherHash, err := consensus.BlockHash(blockHeaderBytes(t, higherBlock))
+			if err != nil {
+				t.Fatalf("BlockHash(higher nonce=%d): %v", higherNonce, err)
+			}
+			if bytes.Compare(lowerHash[:], higherHash[:]) < 0 {
+				return lowerBlock, lowerHash, higherBlock, higherHash
+			}
+		}
+	}
+	t.Fatalf("failed to order equal-work block variants by tip hash")
+	return nil, [32]byte{}, nil, [32]byte{}
 }
 
 func testValidateIncomingChainID(blockHeight uint64, chainID [32]byte) error {


### PR DESCRIPTION
Invariant:
Go SyncEngine live fork choice selects the valid competing branch with maximal ChainWork, and when ChainWork is equal selects the lexicographically smaller tip block hash.

Layer:
implementation, consensus-adjacent, tests

Linear Task:
RUB-335

Files changed:
- clients/go/node/sync_reorg.go
- clients/go/node/sync_reorg_test.go

Behavior impact:
- Equal-work lower-tip side branch can become canonical.
- Equal-work higher-tip side branch remains non-canonical.
- Existing heavier-branch reorg path remains unchanged.

Compatibility impact:
No block validity, PoW, wire format, conformance fixture, or canonical spec changes.

Release gate:
- This PR is Go-only per Linear RUB-335 and must not be used to claim mixed Go/Rust client readiness by itself.
- Mixed-client devnet/release use of the equal-work fork-choice behavior is blocked until RUB-337 lands Rust runtime parity.
- RUB-337 is the required follow-up for Rust `SyncEngine` equal-work lower-tip behavior.

Known non-goals:
- Rust parity implementation; tracked separately as RUB-337.
- S008 side-branch MTP work.
- Conformance fixture regeneration.
- Consensus spec edits.

Tests:
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node -run "TestSyncReorgHelperCoveragePaths|TestApplyBlockWithReorg(SwitchesToLowerTipOnEqualWork|KeepsLowerTipOnEqualWorkHigherSideBranch)$" -count=1' — PASS
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node ./consensus -count=1' — PASS
- scripts/dev-env.sh -- python3 conformance/runner/run_cv_bundle.py --only-gates CV-FORK-CHOICE — PASS, 16 vectors
- rubin-precommit-one-review with base origin/main and base diff — PASS
- stock isolated code-review subagent — No findings; agent closed
- rubin-push with coverage command 'scripts/dev-env.sh -- ./scripts/preflight-codacy-coverage.sh' — PASS; diff coverage 100.00% (11/11), variation +0.01%

WAVE-ZERO VERDICT: PASS
Evidence:
- Linear RUB-335 live-read before PR create.
- One invariant: Go SyncEngine equal-work lower-tip fork choice.
- Changed files limited to Go SyncEngine reorg code and tests.
- Generated artifacts and conformance fixtures were not edited.

Known risks:
- Rust runtime parity remains out of scope for this PR and is tracked in RUB-337.

Not checked:
- Full conformance bundle was not run in this PR pass; CV-FORK-CHOICE targeted gate was run.
- Full Rust workspace test was not run as a standalone command for this PR pass.

Refs #1746


<!-- rubin-agent-meta actor=unknown action=pr-create via=cl branch=codex/RUB-335-go-fork-choice-tiebreak wt=rubin-protocol-codex-RUB-335 utc=2026-05-21T18:57:36Z -->



<!-- rubin-agent-meta actor=unknown action=pr-edit via=cl branch=codex/RUB-335-go-fork-choice-tiebreak wt=rubin-protocol-codex-RUB-335 utc=2026-05-21T19:23:51Z -->
