### PR TITLE
[RUB-341] Split compact command caps and inbound diagnostics

### DIFF
--- a/clients/go/node/p2p/peer_runtime.go
+++ b/clients/go/node/p2p/peer_runtime.go
@@ -209,7 +209,7 @@ func (p *peer) applyPostHandshakeDisconnectError(err error) {
 	if err == nil {
 		return
 	}
-	if reason, ok := compactBlockTxnCommandCapPolicyReason(err); ok {
+	if reason, ok := compactBlockTxnCapPolicyReason(err); ok {
 		p.bumpBan(10, reason)
 		return
 	}
@@ -217,21 +217,21 @@ func (p *peer) applyPostHandshakeDisconnectError(err error) {
 		p.setLastError(reason)
 		return
 	}
-	if reason, ok := commandPayloadCapDiagnosticReason(err); ok {
+	if reason, ok := payloadCapDiagnosticReason(err); ok {
 		p.setLastError(reason)
 		return
 	}
 	p.setLastError(err.Error())
 }
 
-func compactBlockTxnCommandCapPolicyReason(err error) (string, bool) {
+func compactBlockTxnCapPolicyReason(err error) (string, bool) {
 	if command, ok := capErrorCommand(err); ok && command == messageBlockTxn {
 		return "unexpected blocktxn", true
 	}
 	return "", false
 }
 
-func commandPayloadCapDiagnosticReason(err error) (string, bool) {
+func payloadCapDiagnosticReason(err error) (string, bool) {
 	command, ok := capErrorCommand(err)
 	if !ok || command == "" {
 		return "", false

--- a/clients/go/node/p2p/peer_runtime.go
+++ b/clients/go/node/p2p/peer_runtime.go
@@ -209,11 +209,46 @@ func (p *peer) applyPostHandshakeDisconnectError(err error) {
 	if err == nil {
 		return
 	}
+	if reason, ok := compactBlockTxnCommandCapPolicyReason(err); ok {
+		p.bumpBan(10, reason)
+		return
+	}
 	if reason, ok := unknownCommandPolicyReason(err); ok {
 		p.setLastError(reason)
 		return
 	}
+	if reason, ok := commandPayloadCapDiagnosticReason(err); ok {
+		p.setLastError(reason)
+		return
+	}
 	p.setLastError(err.Error())
+}
+
+func compactBlockTxnCommandCapPolicyReason(err error) (string, bool) {
+	if command, ok := capErrorCommand(err); ok && command == messageBlockTxn {
+		return "unexpected blocktxn", true
+	}
+	return "", false
+}
+
+func commandPayloadCapDiagnosticReason(err error) (string, bool) {
+	command, ok := capErrorCommand(err)
+	if !ok || command == "" {
+		return "", false
+	}
+	return fmt.Sprintf("%s: %s", err.Error(), command), true
+}
+
+func capErrorCommand(err error) (string, bool) {
+	var commandCapErr commandPayloadCapError
+	if errors.As(err, &commandCapErr) {
+		return commandCapErr.command, true
+	}
+	var messageCapErr inboundMessagePayloadCapError
+	if errors.As(err, &messageCapErr) {
+		return messageCapErr.command, true
+	}
+	return "", false
 }
 
 func (p *peer) bumpBan(delta int, reason string) bool {

--- a/clients/go/node/p2p/peer_runtime_test.go
+++ b/clients/go/node/p2p/peer_runtime_test.go
@@ -88,7 +88,7 @@ func TestShouldIgnoreAndNormalizeReadError(t *testing.T) {
 	}
 }
 
-func TestCompactObjectCapsStayClosedUntilHandlersExist(t *testing.T) {
+func TestCompactObjectCapsStayClosedUntilParityReceiveExists(t *testing.T) {
 	p := newPeerRuntimeTestPeer(t)
 	limiter := p.postHandshakePayloadCap()
 	for _, command := range []string{messageCmpctBlock, messageGetBlockTxn, messageBlockTxn} {
@@ -140,6 +140,46 @@ func TestBlockTxnPayloadCapIsOutstandingBounded(t *testing.T) {
 	}
 	if got := p.blockTxnPayloadCap(); got != 0 {
 		t.Fatalf("blocktxn cap after pop=%d, want 0", got)
+	}
+}
+
+func TestRunBansUnexpectedBlockTxnCommandCap(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	p.conn = &scriptedConn{reads: []scriptedRead{{
+		data: mustPeerRuntimeFrameBytes(t, p, message{Command: messageBlockTxn, Payload: make([]byte, 33)}),
+	}}}
+	err := p.run(context.Background())
+	if err == nil || err.Error() != "message exceeds command cap" {
+		t.Fatalf("run err=%v, want command cap error", err)
+	}
+	p.applyPostHandshakeDisconnectError(err)
+	state := p.snapshotState()
+	if state.BanScore == 0 || !strings.Contains(state.LastError, "unexpected blocktxn") {
+		t.Fatalf("state=%+v, want unexpected blocktxn ban", state)
+	}
+}
+
+func TestRunBansUnexpectedBlockTxnMessageCap(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	p.service.cfg.PeerRuntimeConfig.MaxMessageSize = 1
+	header, err := buildEnvelopeHeader(
+		networkMagic(p.service.cfg.PeerRuntimeConfig.Network),
+		messageBlockTxn,
+		[]byte{0x01, 0x02},
+	)
+	if err != nil {
+		t.Fatalf("buildEnvelopeHeader: %v", err)
+	}
+	p.conn = &scriptedConn{reads: []scriptedRead{{data: header[:]}}}
+
+	err = p.run(context.Background())
+	if err == nil || err.Error() != "message exceeds cap" {
+		t.Fatalf("run err=%v, want message cap error", err)
+	}
+	p.applyPostHandshakeDisconnectError(err)
+	state := p.snapshotState()
+	if state.BanScore == 0 || !strings.Contains(state.LastError, "unexpected blocktxn") {
+		t.Fatalf("state=%+v, want unexpected blocktxn ban", state)
 	}
 }
 
@@ -368,6 +408,23 @@ func TestApplyPostHandshakeDisconnectErrorNilAndGenericFallback(t *testing.T) {
 	}
 	if snap.BanScore != 0 {
 		t.Fatalf("ban_score=%d, want 0 for generic runtime error mapping", snap.BanScore)
+	}
+}
+
+func TestApplyPostHandshakeDisconnectErrorCommandCapRecordsCommand(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	err := commandPayloadCapError{command: messagePing}
+	if err.Error() != "message exceeds command cap" {
+		t.Fatalf("error=%q, want public command cap error unchanged", err.Error())
+	}
+
+	p.applyPostHandshakeDisconnectError(err)
+	snap := p.snapshotState()
+	if snap.LastError != "message exceeds command cap: ping" {
+		t.Fatalf("last_error=%q, want command diagnostic", snap.LastError)
+	}
+	if snap.BanScore != 0 {
+		t.Fatalf("ban_score=%d, want 0 for non-blocktxn command cap", snap.BanScore)
 	}
 }
 

--- a/clients/go/node/p2p/wire.go
+++ b/clients/go/node/p2p/wire.go
@@ -52,6 +52,22 @@ type message struct {
 
 type payloadLimitFn func(command string) uint32
 
+type commandPayloadCapError struct {
+	command string
+}
+
+func (e commandPayloadCapError) Error() string {
+	return "message exceeds command cap"
+}
+
+type inboundMessagePayloadCapError struct {
+	command string
+}
+
+func (e inboundMessagePayloadCapError) Error() string {
+	return "message exceeds cap"
+}
+
 type frameHeader struct {
 	Command  string
 	Size     uint32
@@ -105,7 +121,7 @@ func readFrameWithPayloadLimit(r io.Reader, expectedMagic [4]byte, maxMessageSiz
 	}
 	if limit != nil {
 		if header.Size > limit(header.Command) {
-			return frame, errors.New("message exceeds command cap")
+			return frame, commandPayloadCapError{command: header.Command}
 		}
 	}
 	payload, err := readPayloadWithChecksum(r, header.Size, header.Checksum)
@@ -198,7 +214,7 @@ func readFrameHeader(r io.Reader, expectedMagic [4]byte, maxMessageSize uint32) 
 	}
 	size := binary.LittleEndian.Uint32(raw[16:20])
 	if size > maxMessageSize {
-		return header, errors.New("message exceeds cap")
+		return header, inboundMessagePayloadCapError{command: command}
 	}
 	header.Command = command
 	header.Size = size

--- a/clients/go/node/p2p/wire_test.go
+++ b/clients/go/node/p2p/wire_test.go
@@ -75,6 +75,10 @@ func TestReadFrameMessageTooLarge(t *testing.T) {
 	if err == nil || err.Error() != "message exceeds cap" {
 		t.Fatalf("expected cap error, got %v", err)
 	}
+	var capErr inboundMessagePayloadCapError
+	if !errors.As(err, &capErr) || capErr.command != messageTx {
+		t.Fatalf("cap error=%T command=%q, want inbound message cap for %s", err, capErr.command, messageTx)
+	}
 }
 
 func TestReadFrameShortBody(t *testing.T) {
@@ -103,6 +107,10 @@ func TestReadFrameWithPayloadLimitRejectsOversizeVersionBeforePayloadRead(t *tes
 	if err == nil || err.Error() != "message exceeds command cap" {
 		t.Fatalf("expected command cap error, got %v", err)
 	}
+	var capErr commandPayloadCapError
+	if !errors.As(err, &capErr) || capErr.command != messageVersion {
+		t.Fatalf("cap error=%T command=%q, want command cap for %s", err, capErr.command, messageVersion)
+	}
 }
 
 func TestReadFrameWithPayloadLimitRejectsOversizeInvBeforePayloadRead(t *testing.T) {
@@ -117,6 +125,10 @@ func TestReadFrameWithPayloadLimitRejectsOversizeInvBeforePayloadRead(t *testing
 	_, err = readFrameWithPayloadLimit(reader, networkMagic("devnet"), 1024*1024, postHandshakePayloadCap(defaultLocatorLimit, 512))
 	if err == nil || err.Error() != "message exceeds command cap" {
 		t.Fatalf("expected command cap error, got %v", err)
+	}
+	var capErr commandPayloadCapError
+	if !errors.As(err, &capErr) || capErr.command != messageInv {
+		t.Fatalf("cap error=%T command=%q, want command cap for %s", err, capErr.command, messageInv)
 	}
 }
 


### PR DESCRIPTION
Invariant:
Post-handshake compact command cap and inbound max-message-size rejection preserve the offending command for diagnostics and blocktxn misbehavior accounting while keeping public error strings stable.

Layer:
Go P2P runtime diagnostics, non-consensus.

Files changed:
- clients/go/node/p2p/wire.go
- clients/go/node/p2p/wire_test.go
- clients/go/node/p2p/peer_runtime.go
- clients/go/node/p2p/peer_runtime_test.go

Tests:
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node/p2p -run "RunBansUnexpectedBlockTxn(Message|Command)Cap|ApplyPostHandshakeDisconnectErrorCommandCapRecordsCommand|ReadFrameMessageTooLarge|ReadFrameWithPayloadLimitRejectsOversizeInvBeforePayloadRead|CompactObjectCapsStayClosedUntilParityReceiveExists" -count=1' - PASS
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node/p2p -count=1' - PASS
- python3 -m lizard clients/go/node/p2p/wire.go clients/go/node/p2p/wire_test.go clients/go/node/p2p/peer_runtime.go clients/go/node/p2p/peer_runtime_test.go - PASS, no thresholds exceeded
- git diff --check - PASS
- rubin-push core preflight - PASS

Behavior impact:
Public cap error strings remain "message exceeds command cap" and "message exceeds cap". Runtime disconnect handling can unwrap the typed error to record the command, and oversized inbound blocktxn maps to "unexpected blocktxn" misbehavior accounting.

Compatibility impact:
No wire format, consensus, conformance, generated artifact, or Rust client changes.

Known non-goals:
- No compact reconstruction/apply receive flow.
- No outstanding request lifecycle changes.
- No Rust parity implementation or parity claim.
- No consensus or conformance changes.

Risk:
Low; change is limited to local error typing and post-handshake diagnostic mapping.

Rollback:
Revert this commit to return cap rejections to generic error values and generic runtime LastError mapping.

Not checked:
- Full clients/go ./... suite was not run; this child is scoped to clients/go/node/p2p.
- Local coverage rerun was skipped because this changes existing Go P2P cap/diagnostic paths only; PR/Codacy coverage gate remains the coverage evidence surface.

Closes #1753


<!-- rubin-agent-meta actor=unknown action=pr-create via=cl branch=codex/RUB-341-compact-caps-diagnostics wt=rubin-protocol-codex-RUB-341 utc=2026-05-21T19:27:00Z -->
