### PR TITLE
RUB-342: split compact outstanding lifecycle

### DIFF
--- a/clients/go/node/p2p/compact_runtime.go
+++ b/clients/go/node/p2p/compact_runtime.go
@@ -3,9 +3,12 @@ package p2p
 import (
 	"encoding/binary"
 	"errors"
+	"time"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
 )
+
+const compactOutstandingRequestTTL = 15 * time.Second
 
 type compactModeSnapshot struct {
 	Mode    uint8
@@ -26,6 +29,7 @@ type compactOutstandingRequest struct {
 	Nonce1             uint64
 	Nonce2             uint64
 	BlockTxnPayloadCap uint32
+	ExpiresAt          time.Time
 }
 
 func (p *peer) handleSendCmpct(payload []byte) error {
@@ -70,9 +74,34 @@ func (p *peer) setCompactOutstandingRequest(req compactOutstandingRequest) {
 	p.compactMu.Unlock()
 }
 
+func (p *peer) activateCompactOutstandingRequest(req compactOutstandingRequest) {
+	req.ExpiresAt = p.service.cfg.Now().Add(compactOutstandingRequestTTL)
+	p.setCompactOutstandingRequest(req)
+}
+
+func (p *peer) sendCompactOutstandingRequest(req compactOutstandingRequest) error {
+	payload, err := encodeGetBlockTxnPayload(getBlockTxnPayload{
+		BlockHash: req.BlockHash,
+		Indexes:   req.MissingIndexes,
+	})
+	if err != nil {
+		return err
+	}
+	if err := p.send(messageGetBlockTxn, payload); err != nil {
+		return err
+	}
+	p.activateCompactOutstandingRequest(req)
+	return nil
+}
+
 func (p *peer) compactOutstandingRequestSnapshot() (compactOutstandingRequest, bool) {
 	p.compactMu.Lock()
 	if p.compact.outstanding == nil {
+		p.compactMu.Unlock()
+		return compactOutstandingRequest{}, false
+	}
+	if p.compactOutstandingRequestExpiredLocked() {
+		p.compact.outstanding = nil
 		p.compactMu.Unlock()
 		return compactOutstandingRequest{}, false
 	}
@@ -88,11 +117,31 @@ func (p *peer) popCompactOutstandingRequest() (compactOutstandingRequest, bool) 
 		p.compactMu.Unlock()
 		return compactOutstandingRequest{}, false
 	}
+	if p.compactOutstandingRequestExpiredLocked() {
+		p.compact.outstanding = nil
+		p.compactMu.Unlock()
+		return compactOutstandingRequest{}, false
+	}
 	// Stored outstanding requests are immutable; keep large tx-byte cloning outside compactMu.
 	req := *p.compact.outstanding
 	p.compact.outstanding = nil
 	p.compactMu.Unlock()
 	return cloneCompactOutstandingRequest(req), true
+}
+
+func (p *peer) clearCompactOutstandingRequestForBlock(blockHash [32]byte) {
+	p.compactMu.Lock()
+	if p.compact.outstanding != nil && p.compact.outstanding.BlockHash == blockHash {
+		p.compact.outstanding = nil
+	}
+	p.compactMu.Unlock()
+}
+
+func (p *peer) compactOutstandingRequestExpiredLocked() bool {
+	if p.compact.outstanding == nil || p.compact.outstanding.ExpiresAt.IsZero() {
+		return false
+	}
+	return !p.service.cfg.Now().Before(p.compact.outstanding.ExpiresAt)
 }
 
 func cloneCompactOutstandingRequest(req compactOutstandingRequest) compactOutstandingRequest {
@@ -106,6 +155,10 @@ func (p *peer) blockTxnPayloadCap() uint32 {
 	p.compactMu.Lock()
 	defer p.compactMu.Unlock()
 	if p.compact.outstanding == nil {
+		return 0
+	}
+	if p.compactOutstandingRequestExpiredLocked() {
+		p.compact.outstanding = nil
 		return 0
 	}
 	if maxCap := compactRelayPayloadCap(messageBlockTxn); p.compact.outstanding.BlockTxnPayloadCap > maxCap {

--- a/clients/go/node/p2p/handlers_block.go
+++ b/clients/go/node/p2p/handlers_block.go
@@ -63,6 +63,7 @@ func (p *peer) processRelayedBlock(blockBytes []byte) (*node.ChainStateConnectSu
 	}
 	have, err := p.service.hasBlock(blockHash)
 	if err != nil {
+		p.clearCompactOutstandingRequestForBlock(blockHash)
 		return nil, err
 	}
 	if have {
@@ -87,6 +88,7 @@ func (p *peer) handleRelayedBlockApplyError(
 	blockBytes []byte,
 	err error,
 ) (*node.ChainStateConnectSummary, error) {
+	p.clearCompactOutstandingRequestForBlock(blockHash)
 	if errors.Is(err, node.ErrParentNotFound) {
 		return p.retainRelayedOrphanIfValid(pb, blockHash, blockBytes)
 	}
@@ -103,7 +105,6 @@ func (p *peer) retainRelayedOrphanIfValid(
 		p.bumpBan(100, err.Error())
 		return nil, err
 	}
-	p.clearCompactOutstandingRequestForBlock(blockHash)
 	p.service.retainOrResolveOrphan(p, blockHash, pb.Header.PrevBlockHash, blockBytes)
 	return nil, nil
 }

--- a/clients/go/node/p2p/handlers_block.go
+++ b/clients/go/node/p2p/handlers_block.go
@@ -62,8 +62,12 @@ func (p *peer) processRelayedBlock(blockBytes []byte) (*node.ChainStateConnectSu
 		return nil, errors.New("nil parsed block")
 	}
 	have, err := p.service.hasBlock(blockHash)
-	if err != nil || have {
+	if err != nil {
 		return nil, err
+	}
+	if have {
+		p.clearCompactOutstandingRequestForBlock(blockHash)
+		return nil, nil
 	}
 
 	p.service.chainMu.Lock()
@@ -72,6 +76,7 @@ func (p *peer) processRelayedBlock(blockBytes []byte) (*node.ChainStateConnectSu
 	if err != nil {
 		return p.handleRelayedBlockApplyError(pb, blockHash, blockBytes, err)
 	}
+	p.clearCompactOutstandingRequestForBlock(blockHash)
 	p.acceptedRelayedBlock(blockHash, summary)
 	return summary, nil
 }
@@ -98,6 +103,7 @@ func (p *peer) retainRelayedOrphanIfValid(
 		p.bumpBan(100, err.Error())
 		return nil, err
 	}
+	p.clearCompactOutstandingRequestForBlock(blockHash)
 	p.service.retainOrResolveOrphan(p, blockHash, pb.Header.PrevBlockHash, blockBytes)
 	return nil, nil
 }

--- a/clients/go/node/p2p/peer_runtime_test.go
+++ b/clients/go/node/p2p/peer_runtime_test.go
@@ -302,6 +302,23 @@ func TestAlreadyHaveFullBlockClearsMatchingCompactOutstanding(t *testing.T) {
 	}
 }
 
+func TestHasBlockErrorFullBlockClearsMatchingCompactOutstanding(t *testing.T) {
+	h := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	p := testPeerForService(h.service, "remote", 0)
+	_, blockHash, err := parseRelayedBlock(node.DevnetGenesisBlockBytes())
+	if err != nil {
+		t.Fatalf("parse genesis block: %v", err)
+	}
+	p.activateCompactOutstandingRequest(compactOutstandingTestRequest(blockHash))
+	p.service.cfg.BlockStore = nil
+	if _, err := p.processRelayedBlock(node.DevnetGenesisBlockBytes()); err == nil {
+		t.Fatal("processRelayedBlock with nil blockstore unexpectedly succeeded")
+	}
+	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatal("has-block error full block did not clear matching compact outstanding request")
+	}
+}
+
 func TestOrphanFullBlockClearsMatchingCompactOutstanding(t *testing.T) {
 	source := newTestHarness(t, 3, "127.0.0.1:0", nil)
 	sink := newTestHarness(t, 0, "127.0.0.1:0", nil)
@@ -317,6 +334,28 @@ func TestOrphanFullBlockClearsMatchingCompactOutstanding(t *testing.T) {
 	}
 	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
 		t.Fatal("retained full-block orphan did not clear matching compact outstanding request")
+	}
+}
+
+func TestApplyErrorFullBlockClearsMatchingCompactOutstanding(t *testing.T) {
+	source := newTestHarness(t, 2, "127.0.0.1:0", nil)
+	sink := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	_, blockBytes := testHarnessBlockAtHeight(t, source, 1)
+	corrupted := append([]byte(nil), blockBytes...)
+	for i := 36; i < 68; i++ {
+		corrupted[i] = 0xff
+	}
+	_, blockHash, err := parseRelayedBlock(corrupted)
+	if err != nil {
+		t.Fatalf("parse corrupted block: %v", err)
+	}
+	p := testPeerForService(sink.service, "remote", 1)
+	p.activateCompactOutstandingRequest(compactOutstandingTestRequest(blockHash))
+	if _, err := p.processRelayedBlock(corrupted); err == nil {
+		t.Fatal("processRelayedBlock(corrupted) unexpectedly succeeded")
+	}
+	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatal("apply-error full block did not clear matching compact outstanding request")
 	}
 }
 

--- a/clients/go/node/p2p/peer_runtime_test.go
+++ b/clients/go/node/p2p/peer_runtime_test.go
@@ -143,6 +143,193 @@ func TestBlockTxnPayloadCapIsOutstandingBounded(t *testing.T) {
 	}
 }
 
+func TestCompactOutstandingRequestUsesDedicatedTTL(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	now := time.Unix(1000, 0)
+	p.service.cfg.Now = func() time.Time { return now }
+	p.service.cfg.PeerRuntimeConfig.ReadDeadline = 0
+	p.activateCompactOutstandingRequest(compactOutstandingTestRequest([32]byte{0x11}))
+	if got := p.blockTxnPayloadCap(); got != 64 {
+		t.Fatalf("disabled-deadline blocktxn cap=%d, want 64", got)
+	}
+	now = now.Add(compactOutstandingRequestTTL - time.Nanosecond)
+	if got := p.blockTxnPayloadCap(); got != 64 {
+		t.Fatalf("pre-expiry blocktxn cap=%d, want 64", got)
+	}
+	now = now.Add(time.Nanosecond)
+	if got := p.blockTxnPayloadCap(); got != 0 {
+		t.Fatalf("expired blocktxn cap=%d, want 0", got)
+	}
+	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatal("expired outstanding request was not cleared")
+	}
+}
+
+func TestCompactOutstandingRequestActivatesAfterSuccessfulSend(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	p.conn = &scriptedConn{}
+	p.service.cfg.PeerRuntimeConfig.MaxMessageSize = 1
+	req := compactOutstandingTestRequest([32]byte{0x22})
+	if err := p.sendCompactOutstandingRequest(req); err == nil {
+		t.Fatal("oversized getblocktxn send should fail")
+	}
+	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatal("failed getblocktxn send left active outstanding request")
+	}
+
+	p = newPeerRuntimeTestPeer(t)
+	p.conn = &scriptedConn{}
+	if err := p.sendCompactOutstandingRequest(req); err != nil {
+		t.Fatalf("sendCompactOutstandingRequest: %v", err)
+	}
+	if snap, ok := p.compactOutstandingRequestSnapshot(); !ok || snap.BlockHash != req.BlockHash {
+		t.Fatalf("outstanding=%+v ok=%v, want sent request", snap, ok)
+	}
+	frame, err := readFrame(bytes.NewReader(p.conn.(*scriptedConn).Buffer.Bytes()), networkMagic(p.service.cfg.PeerRuntimeConfig.Network), p.service.cfg.PeerRuntimeConfig.MaxMessageSize)
+	if err != nil {
+		t.Fatalf("read sent frame: %v", err)
+	}
+	if frame.Command != messageGetBlockTxn {
+		t.Fatalf("sent command=%q, want %q", frame.Command, messageGetBlockTxn)
+	}
+}
+
+func TestCompactOutstandingRequestDoesNotActivateOnEncodeError(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	p.conn = &scriptedConn{}
+	req := compactOutstandingTestRequest([32]byte{0x44})
+	req.MissingIndexes = []uint64{maxCompactRelayIndexValue + 1}
+	if err := p.sendCompactOutstandingRequest(req); err == nil || !strings.Contains(err.Error(), "compact relay index out of range") {
+		t.Fatalf("sendCompactOutstandingRequest err=%v, want compact relay index out of range", err)
+	}
+	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatal("encode failure left active outstanding request")
+	}
+	if got := p.conn.(*scriptedConn).Len(); got != 0 {
+		t.Fatalf("encode failure wrote %d bytes, want 0", got)
+	}
+}
+
+func TestExpiredCompactOutstandingSnapshotAndPopClearState(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	now := time.Unix(1000, 0)
+	p.service.cfg.Now = func() time.Time { return now }
+	req := compactOutstandingTestRequest([32]byte{0x55})
+
+	p.activateCompactOutstandingRequest(req)
+	now = now.Add(compactOutstandingRequestTTL)
+	if snap, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatalf("snapshot=%+v ok=%v, want expired request cleared", snap, ok)
+	}
+	p.compactMu.Lock()
+	snapshotCleared := p.compact.outstanding == nil
+	p.compactMu.Unlock()
+	if !snapshotCleared {
+		t.Fatal("expired snapshot left outstanding request active")
+	}
+
+	p.activateCompactOutstandingRequest(req)
+	now = now.Add(compactOutstandingRequestTTL)
+	if snap, ok := p.popCompactOutstandingRequest(); ok {
+		t.Fatalf("pop=%+v ok=%v, want expired request cleared", snap, ok)
+	}
+	p.compactMu.Lock()
+	popCleared := p.compact.outstanding == nil
+	p.compactMu.Unlock()
+	if !popCleared {
+		t.Fatal("expired pop left outstanding request active")
+	}
+}
+
+func TestPopCompactOutstandingRequestKeepsSnapshotAcrossExpiryRace(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	start := time.Unix(1000, 0)
+	current := start
+	p.service.cfg.Now = func() time.Time { return current }
+	blockHash := [32]byte{0x33}
+	p.activateCompactOutstandingRequest(compactOutstandingTestRequest(blockHash))
+
+	current = start.Add(compactOutstandingRequestTTL - time.Nanosecond)
+	calls := 0
+	p.service.cfg.Now = func() time.Time {
+		calls++
+		if calls == 1 {
+			return current
+		}
+		return current.Add(time.Second)
+	}
+	snap, ok := p.popCompactOutstandingRequest()
+	if !ok || snap.BlockHash != blockHash {
+		t.Fatalf("pop snapshot=%+v ok=%v, want matching request", snap, ok)
+	}
+	if _, still := p.compactOutstandingRequestSnapshot(); still {
+		t.Fatal("popped outstanding request still active")
+	}
+}
+
+func TestFullBlockClearsMatchingCompactOutstanding(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	_, blockHash, err := parseRelayedBlock(node.DevnetGenesisBlockBytes())
+	if err != nil {
+		t.Fatalf("parse genesis block: %v", err)
+	}
+	p.activateCompactOutstandingRequest(compactOutstandingTestRequest(blockHash))
+	if err := p.handleBlock(node.DevnetGenesisBlockBytes()); err != nil {
+		t.Fatalf("handleBlock(genesis): %v", err)
+	}
+	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatal("full-block accept did not clear matching compact outstanding request")
+	}
+}
+
+func TestAlreadyHaveFullBlockClearsMatchingCompactOutstanding(t *testing.T) {
+	h := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	p := testPeerForService(h.service, "remote", 0)
+	_, blockHash, err := parseRelayedBlock(node.DevnetGenesisBlockBytes())
+	if err != nil {
+		t.Fatalf("parse genesis block: %v", err)
+	}
+	p.activateCompactOutstandingRequest(compactOutstandingTestRequest(blockHash))
+	summary, err := p.processRelayedBlock(node.DevnetGenesisBlockBytes())
+	if err != nil {
+		t.Fatalf("processRelayedBlock(existing genesis): %v", err)
+	}
+	if summary != nil {
+		t.Fatalf("summary=%v, want nil for existing block", summary)
+	}
+	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatal("already-have full block did not clear matching compact outstanding request")
+	}
+}
+
+func TestOrphanFullBlockClearsMatchingCompactOutstanding(t *testing.T) {
+	source := newTestHarness(t, 3, "127.0.0.1:0", nil)
+	sink := newTestHarness(t, 0, "127.0.0.1:0", nil)
+	blockHash, blockBytes := testHarnessBlockAtHeight(t, source, 2)
+	p := testPeerForService(sink.service, "remote", 2)
+	p.activateCompactOutstandingRequest(compactOutstandingTestRequest(blockHash))
+	summary, err := p.processRelayedBlock(blockBytes)
+	if err != nil {
+		t.Fatalf("processRelayedBlock(orphan): %v", err)
+	}
+	if summary != nil {
+		t.Fatalf("summary=%v, want nil for retained orphan", summary)
+	}
+	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatal("retained full-block orphan did not clear matching compact outstanding request")
+	}
+}
+
+func compactOutstandingTestRequest(blockHash [32]byte) compactOutstandingRequest {
+	return compactOutstandingRequest{
+		BlockHash:          blockHash,
+		MissingIndexes:     []uint64{0},
+		MissingShortIDs:    []compactShortID{{0x01}},
+		Transactions:       [][]byte{nil},
+		BlockTxnPayloadCap: 64,
+	}
+}
+
 func TestRunBansUnexpectedBlockTxnCommandCap(t *testing.T) {
 	p := newPeerRuntimeTestPeer(t)
 	p.conn = &scriptedConn{reads: []scriptedRead{{


### PR DESCRIPTION
Invariant:
Compact outstanding request state is activated only after a successful getblocktxn send, expires through its dedicated TTL, and is cleared on matching full-block terminal paths.

Layer:
Go P2P runtime state lifecycle and tests.

Files changed:
- clients/go/node/p2p/compact_runtime.go
- clients/go/node/p2p/handlers_block.go
- clients/go/node/p2p/peer_runtime_test.go

Tests:
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node/p2p -run "TestCompactOutstandingRequestDoesNotActivateOnEncodeError|TestExpiredCompactOutstandingSnapshotAndPopClearState" -count=1' — PASS
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node/p2p -count=1' — PASS
- scripts/dev-env.sh -- bash -lc 'cd clients/go && gofmt -l node/p2p/compact_runtime.go node/p2p/handlers_block.go node/p2p/peer_runtime_test.go' — PASS
- git diff --check origin/main...HEAD && git diff --check — PASS
- /Users/gpt/bin/rubin-push --repo /Users/gpt/Documents/rubin-protocol-codex-RUB-342 --base-ref origin/main --coverage-cmd '/Users/gpt/bin/rubin-stack-codacy-coverage.sh /Users/gpt/Documents/rubin-protocol-codex-RUB-342 origin/main' -- origin HEAD — PASS

Behavior impact:
Compact relay outstanding request lifecycle is bounded to the successful send path and terminal full-block paths covered by the changed tests.

Compatibility impact:
No changed files under clients/rust or compact wire encoding/decoding.

Known non-goals:
- Rust parity changes.
- Consensus specification changes.

Risk:
Low; changed surface is Go P2P runtime lifecycle state and associated tests.

Rollback:
Revert commit 9c65a4a3313c611027897a56f453687d536da599.

Not checked:
- GitHub CI/Codacy external checks are pending after PR creation.
