### PR TITLE
[RUB-336] Derive Go side-branch MTP context before store

### DIFF
--- a/clients/go/node/p2p/service_test.go
+++ b/clients/go/node/p2p/service_test.go
@@ -2,9 +2,11 @@ package p2p
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"net"
+	"os"
 	"testing"
 	"time"
 
@@ -493,6 +495,44 @@ func TestAcceptedRelayedBlockBroadcastsResolvedOrphans(t *testing.T) {
 	})
 }
 
+func TestProcessRelayedBlockRejectsSideBranchTimestampBeforeAcceptedInventory(t *testing.T) {
+	sink := newTestHarness(t, 3, "127.0.0.1:0", nil)
+	_, block1Bytes := testHarnessBlockAtHeight(t, sink, 1)
+	genesisParsed, err := consensus.ParseBlockBytes(node.DevnetGenesisBlockBytes())
+	if err != nil {
+		t.Fatalf("ParseBlockBytes(genesis): %v", err)
+	}
+	sideBlock := blockWithHeaderTimestamp(t, block1Bytes, genesisParsed.Header.Timestamp)
+	_, sideHash, err := parseRelayedBlock(sideBlock)
+	if err != nil {
+		t.Fatalf("parseRelayedBlock(side): %v", err)
+	}
+
+	readFrames, closeProbe := registerRelayFrameProbe(t, sink.service, "relay-peer")
+	defer closeProbe()
+
+	peer := testPeerForService(sink.service, "remote", 3)
+	before := sink.syncEngine.BlockApplyCounts()
+	summary, err := peer.processRelayedBlock(sideBlock)
+	if err == nil {
+		t.Fatalf("expected timestamp-invalid side block rejection")
+	}
+	if summary != nil {
+		t.Fatalf("summary=%v, want nil", summary)
+	}
+	requireP2PConsensusTxErrCode(t, err, consensus.BLOCK_ERR_TIMESTAMP_OLD)
+	if after := sink.syncEngine.BlockApplyCounts(); after != before {
+		t.Fatalf("timestamp-invalid side block changed BlockApplyCounts from %+v to %+v", before, after)
+	}
+	if sink.service.blockSeen.Has(sideHash) {
+		t.Fatalf("timestamp-invalid side block must not be marked seen")
+	}
+	assertNoRelayFrame(t, readFrames, "timestamp-invalid side block")
+	if _, err := sink.blockStore.GetBlockByHash(sideHash); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("GetBlockByHash(timestamp-invalid side) err=%v, want not-exist", err)
+	}
+}
+
 func TestHandshakeSlotNilServiceAndChannel(t *testing.T) {
 	var nilSvc *Service
 	if !nilSvc.tryAcquireHandshakeSlot() {
@@ -659,6 +699,66 @@ func testHarnessBlockAtHeight(t *testing.T, h *testHarness, height uint64) ([32]
 		t.Fatalf("GetBlockByHash(height %d): %v", height, err)
 	}
 	return hash, blockBytes
+}
+
+func blockWithHeaderTimestamp(t *testing.T, block []byte, timestamp uint64) []byte {
+	t.Helper()
+	const timestampOffset = 4 + 32 + 32
+	if len(block) < consensus.BLOCK_HEADER_BYTES {
+		t.Fatalf("block length=%d, want at least header length %d", len(block), consensus.BLOCK_HEADER_BYTES)
+	}
+	out := append([]byte(nil), block...)
+	binary.LittleEndian.PutUint64(out[timestampOffset:timestampOffset+8], timestamp)
+	return out
+}
+
+func requireP2PConsensusTxErrCode(t *testing.T, err error, want consensus.ErrorCode) {
+	t.Helper()
+	var txErr *consensus.TxError
+	if !errors.As(err, &txErr) {
+		t.Fatalf("err=%T %v, want consensus.TxError code %s", err, err, want)
+	}
+	if txErr.Code != want {
+		t.Fatalf("err code=%s, want %s", txErr.Code, want)
+	}
+}
+
+func registerRelayFrameProbe(t *testing.T, svc *Service, addr string) (<-chan message, func()) {
+	t.Helper()
+
+	remotePeer := newPeerRuntimeTestPeer(t)
+	remotePeer.service = svc
+	remotePeer.state.Addr = addr
+	local, remote := net.Pipe()
+	remotePeer.conn = local
+	closeBoth := func() {
+		_ = local.Close()
+		_ = remote.Close()
+	}
+	t.Cleanup(closeBoth)
+
+	svc.peersMu.Lock()
+	svc.peers[remotePeer.addr()] = remotePeer
+	svc.peersMu.Unlock()
+
+	frames := make(chan message, 1)
+	go func() {
+		frame, err := readFrame(remote, networkMagic(svc.cfg.PeerRuntimeConfig.Network), svc.cfg.PeerRuntimeConfig.MaxMessageSize)
+		if err == nil {
+			frames <- frame
+		}
+	}()
+	return frames, closeBoth
+}
+
+func assertNoRelayFrame(t *testing.T, frames <-chan message, label string) {
+	t.Helper()
+	select {
+	case frame := <-frames:
+		t.Fatalf("unexpected relay frame for %s: command=%q", label, frame.Command)
+	case <-time.After(100 * time.Millisecond):
+		return
+	}
 }
 
 func testPeerForService(svc *Service, userAgent string, bestHeight uint64) *peer {

--- a/clients/go/node/sync_helpers_test.go
+++ b/clients/go/node/sync_helpers_test.go
@@ -85,12 +85,19 @@ func TestRecordAppliedBlock(t *testing.T) {
 	s.mu.RUnlock()
 }
 
-func TestStoreSideBlockAndSummaryInvalidBlock(t *testing.T) {
+func TestStoreSideBlockAndSummaryRejectsEmptyBranch(t *testing.T) {
 	bs := &BlockStore{}
 	s := &SyncEngine{blockStore: bs, cfg: SyncConfig{}}
-	_, err := s.storeSideBlockAndSummary([]byte{}, [32]byte{}, &consensus.ParsedBlock{}, 1, nil)
+	_, err := s.storeSideBlockAndSummary(nil, 0, 1)
 	if err == nil {
-		t.Fatal("expected validation error for empty block")
+		t.Fatal("expected validation error for empty branch")
+	}
+}
+
+func TestSideBranchPrevTimestampsRejectsNilStore(t *testing.T) {
+	_, err := sideBranchPrevTimestamps(nil, []reorgBranchBlock{{}}, 0)
+	if err == nil {
+		t.Fatal("expected timestamp context error for nil blockstore")
 	}
 }
 

--- a/clients/go/node/sync_reorg.go
+++ b/clients/go/node/sync_reorg.go
@@ -34,7 +34,7 @@ func (s *SyncEngine) ApplyBlockWithReorg(blockBytes []byte, prevTimestamps []uin
 		return nil, err
 	}
 	if !switchToBranch {
-		return s.storeSideBlockAndSummary(blockBytes, blockHash, pb, candidateHeight, prevTimestamps)
+		return s.storeSideBlockAndSummary(branch, commonAncestorHeight, candidateHeight)
 	}
 	return s.applyPreferredBranch(branch, commonAncestorHeight)
 }
@@ -70,14 +70,39 @@ func (s *SyncEngine) evaluateSideBranch(
 	return branch, commonAncestorHeight, switchToBranch, candidateHeight, nil
 }
 
-func (s *SyncEngine) storeSideBlockAndSummary(blockBytes []byte, blockHash [32]byte, pb *consensus.ParsedBlock, candidateHeight uint64, prevTimestamps []uint64) (*ChainStateConnectSummary, error) {
-	if _, err := consensus.ValidateBlockBasicWithContextAtHeight(blockBytes, &pb.Header.PrevBlockHash, s.cfg.ExpectedTarget, candidateHeight, prevTimestamps); err != nil {
+func (s *SyncEngine) storeSideBlockAndSummary(branch []reorgBranchBlock, commonAncestorHeight uint64, candidateHeight uint64) (*ChainStateConnectSummary, error) {
+	if len(branch) == 0 {
+		return nil, errors.New("empty side branch")
+	}
+	candidate := branch[len(branch)-1]
+	prevTimestamps, err := sideBranchPrevTimestamps(s.blockStore, branch, commonAncestorHeight)
+	if err != nil {
 		return nil, err
 	}
-	if err := s.blockStore.StoreBlock(blockHash, pb.HeaderBytes, blockBytes); err != nil {
+	if _, err := consensus.ValidateBlockBasicWithContextAtHeight(candidate.blockBytes, &candidate.header.PrevBlockHash, s.cfg.ExpectedTarget, candidateHeight, prevTimestamps); err != nil {
 		return nil, err
 	}
-	return s.syntheticSideChainSummary(candidateHeight, blockHash), nil
+	if err := s.blockStore.StoreBlock(candidate.hash, candidate.parsed.HeaderBytes, candidate.blockBytes); err != nil {
+		return nil, err
+	}
+	return s.syntheticSideChainSummary(candidateHeight, candidate.hash), nil
+}
+
+func sideBranchPrevTimestamps(store *BlockStore, branch []reorgBranchBlock, commonAncestorHeight uint64) ([]uint64, error) {
+	if len(branch) == 0 {
+		return nil, errors.New("empty side branch")
+	}
+	if store == nil {
+		return nil, errors.New("missing blockstore for side branch timestamp context")
+	}
+	prevTimestamps, err := prevTimestampsFromStore(store, commonAncestorHeight+1)
+	if err != nil {
+		return nil, err
+	}
+	for _, item := range branch[:len(branch)-1] {
+		prevTimestamps = advancePrevTimestamps(prevTimestamps, item.header.Timestamp)
+	}
+	return prevTimestamps, nil
 }
 
 func (s *SyncEngine) applyDirectBlockIfPossible(

--- a/clients/go/node/sync_reorg_test.go
+++ b/clients/go/node/sync_reorg_test.go
@@ -177,6 +177,17 @@ func blockHeaderBytes(t *testing.T, blockBytes []byte) []byte {
 	return pb.HeaderBytes
 }
 
+func requireConsensusTxErrCode(t *testing.T, err error, want consensus.ErrorCode) {
+	t.Helper()
+	var txErr *consensus.TxError
+	if !errors.As(err, &txErr) {
+		t.Fatalf("err=%T %v, want consensus.TxError code %s", err, err, want)
+	}
+	if txErr.Code != want {
+		t.Fatalf("err code=%s, want %s", txErr.Code, want)
+	}
+}
+
 func TestApplyBlockWithReorgRejectsMissingParent(t *testing.T) {
 	engine, _, target := newReorgTestEngine(t)
 	before := engine.BlockApplyCounts()
@@ -195,7 +206,7 @@ func TestApplyBlockWithReorgRejectsInvalidNonHeavierSideBranch(t *testing.T) {
 	engine, store, target := newReorgTestEngine(t)
 
 	subsidy1 := consensus.BlockSubsidy(1, 0)
-	blockA1 := buildSingleTxBlock(t, devnetGenesisBlockHash, target, 2, coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 1, subsidy1))
+	blockA1 := buildSingleTxBlock(t, devnetGenesisBlockHash, target, reorgTestTimestamp(1), coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 1, subsidy1))
 	summaryA1, err := engine.ApplyBlock(blockA1, nil)
 	if err != nil {
 		t.Fatalf("ApplyBlock(A1): %v", err)
@@ -224,6 +235,72 @@ func TestApplyBlockWithReorgRejectsInvalidNonHeavierSideBranch(t *testing.T) {
 	}
 }
 
+func TestApplyBlockWithReorgRejectsSideBranchTimestampContextBeforeStore(t *testing.T) {
+	engine, store, target := newReorgTestEngine(t)
+	genesisParsed, err := consensus.ParseBlockBytes(devnetGenesisBlockBytes)
+	if err != nil {
+		t.Fatalf("ParseBlockBytes(genesis): %v", err)
+	}
+
+	subsidy1 := consensus.BlockSubsidy(1, 0)
+	blockA1 := buildSingleTxBlock(t, devnetGenesisBlockHash, target, reorgTestTimestamp(1), coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 1, subsidy1))
+	summaryA1, err := engine.ApplyBlock(blockA1, nil)
+	if err != nil {
+		t.Fatalf("ApplyBlock(A1): %v", err)
+	}
+	subsidy2 := consensus.BlockSubsidy(2, subsidy1)
+	blockA2 := buildSingleTxBlock(t, summaryA1.BlockHash, target, reorgTestTimestamp(2), coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 2, subsidy2))
+	summaryA2, err := engine.ApplyBlock(blockA2, nil)
+	if err != nil {
+		t.Fatalf("ApplyBlock(A2): %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		timestamp uint64
+		wantCode  consensus.ErrorCode
+	}{
+		{
+			name:      "timestamp_old",
+			timestamp: genesisParsed.Header.Timestamp,
+			wantCode:  consensus.BLOCK_ERR_TIMESTAMP_OLD,
+		},
+		{
+			name:      "timestamp_future",
+			timestamp: genesisParsed.Header.Timestamp + consensus.MAX_FUTURE_DRIFT + 1,
+			wantCode:  consensus.BLOCK_ERR_TIMESTAMP_FUTURE,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sideBlock := buildSingleTxBlock(t, devnetGenesisBlockHash, target, tc.timestamp, coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 1, subsidy1))
+			sideHash, err := consensus.BlockHash(blockHeaderBytes(t, sideBlock))
+			if err != nil {
+				t.Fatalf("BlockHash(side): %v", err)
+			}
+
+			before := engine.BlockApplyCounts()
+			summary, err := engine.ApplyBlockWithReorg(sideBlock, nil)
+			if err == nil {
+				t.Fatalf("expected timestamp-invalid side branch rejection")
+			}
+			if summary != nil {
+				t.Fatalf("summary=%v, want nil for rejected side branch", summary)
+			}
+			requireConsensusTxErrCode(t, err, tc.wantCode)
+			if after := engine.BlockApplyCounts(); after != before {
+				t.Fatalf("timestamp-invalid side branch changed BlockApplyCounts from %+v to %+v", before, after)
+			}
+			if engine.chainState.Height != 2 || engine.chainState.TipHash != summaryA2.BlockHash {
+				t.Fatalf("canonical tip changed after timestamp-invalid side branch")
+			}
+			if _, err := store.GetBlockByHash(sideHash); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("GetBlockByHash(timestamp-invalid side) err=%v, want not-exist", err)
+			}
+		})
+	}
+}
+
 func TestApplyBlockWithReorgRollbackRestoresCanonicalIndexAndChainstateFile(t *testing.T) {
 	dir := t.TempDir()
 	chainStatePath := ChainStatePath(dir)
@@ -241,7 +318,7 @@ func TestApplyBlockWithReorgRollbackRestoresCanonicalIndexAndChainstateFile(t *t
 	}
 
 	subsidy1 := consensus.BlockSubsidy(1, 0)
-	blockA1 := buildSingleTxBlock(t, devnetGenesisBlockHash, target, 2, coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 1, subsidy1))
+	blockA1 := buildSingleTxBlock(t, devnetGenesisBlockHash, target, reorgTestTimestamp(1), coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 1, subsidy1))
 	summaryA1, err := engine.ApplyBlock(blockA1, nil)
 	if err != nil {
 		t.Fatalf("ApplyBlock(A1): %v", err)
@@ -251,7 +328,7 @@ func TestApplyBlockWithReorgRollbackRestoresCanonicalIndexAndChainstateFile(t *t
 		t.Fatalf("stateToDisk(before): %v", err)
 	}
 
-	sideB1 := buildSingleTxBlock(t, devnetGenesisBlockHash, target, 3, coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 1, subsidy1))
+	sideB1 := buildSingleTxBlock(t, devnetGenesisBlockHash, target, reorgTestTimestamp(2), coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 1, subsidy1))
 	sideB1Hash, err := consensus.BlockHash(blockHeaderBytes(t, sideB1))
 	if err != nil {
 		t.Fatalf("BlockHash(B1): %v", err)
@@ -261,7 +338,7 @@ func TestApplyBlockWithReorgRollbackRestoresCanonicalIndexAndChainstateFile(t *t
 	}
 
 	subsidy2 := consensus.BlockSubsidy(2, subsidy1)
-	sideB2 := buildSingleTxBlock(t, sideB1Hash, target, 4, coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 2, subsidy2))
+	sideB2 := buildSingleTxBlock(t, sideB1Hash, target, reorgTestTimestamp(3), coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 2, subsidy2))
 
 	prevWrite := writeFileAtomicFn
 	t.Cleanup(func() { writeFileAtomicFn = prevWrite })
@@ -314,19 +391,19 @@ func TestApplyBlockWithReorgRejectsInvalidHeavierBranchBeforeDisconnectingCanoni
 	engine, store, target := newReorgTestEngine(t)
 
 	subsidy1 := consensus.BlockSubsidy(1, 0)
-	blockA1 := buildSingleTxBlock(t, devnetGenesisBlockHash, target, 2, coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 1, subsidy1))
+	blockA1 := buildSingleTxBlock(t, devnetGenesisBlockHash, target, reorgTestTimestamp(1), coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 1, subsidy1))
 	summaryA1, err := engine.ApplyBlock(blockA1, nil)
 	if err != nil {
 		t.Fatalf("ApplyBlock(A1): %v", err)
 	}
 	subsidy2 := consensus.BlockSubsidy(2, subsidy1)
-	blockA2 := buildSingleTxBlock(t, summaryA1.BlockHash, target, 3, coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 2, subsidy2))
+	blockA2 := buildSingleTxBlock(t, summaryA1.BlockHash, target, reorgTestTimestamp(2), coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 2, subsidy2))
 	summaryA2, err := engine.ApplyBlock(blockA2, nil)
 	if err != nil {
 		t.Fatalf("ApplyBlock(A2): %v", err)
 	}
 
-	blockB1 := buildSingleTxBlock(t, devnetGenesisBlockHash, target, 10, coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 1, subsidy1))
+	blockB1 := buildSingleTxBlock(t, devnetGenesisBlockHash, target, reorgTestTimestamp(10), coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 1, subsidy1))
 	if _, err := engine.ApplyBlockWithReorg(blockB1, nil); err != nil {
 		t.Fatalf("ApplyBlockWithReorg(B1): %v", err)
 	}
@@ -334,7 +411,7 @@ func TestApplyBlockWithReorgRejectsInvalidHeavierBranchBeforeDisconnectingCanoni
 	if err != nil {
 		t.Fatalf("BlockHash(B1): %v", err)
 	}
-	blockB2 := buildSingleTxBlock(t, blockB1Hash, target, 11, coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 2, subsidy2))
+	blockB2 := buildSingleTxBlock(t, blockB1Hash, target, reorgTestTimestamp(11), coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 2, subsidy2))
 	if _, err := engine.ApplyBlockWithReorg(blockB2, nil); err != nil {
 		t.Fatalf("ApplyBlockWithReorg(B2): %v", err)
 	}
@@ -344,7 +421,7 @@ func TestApplyBlockWithReorgRejectsInvalidHeavierBranchBeforeDisconnectingCanoni
 	}
 
 	subsidy3 := consensus.BlockSubsidy(3, subsidy1+subsidy2)
-	validB3 := buildSingleTxBlock(t, blockB2Hash, target, 12, coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 3, subsidy3))
+	validB3 := buildSingleTxBlock(t, blockB2Hash, target, reorgTestTimestamp(12), coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 3, subsidy3))
 	invalidB3 := append([]byte(nil), validB3...)
 	invalidB3[len(invalidB3)-1] ^= 0x01
 
@@ -1240,20 +1317,20 @@ func TestApplyBlockWithReorgKeepsLighterSideBranchOffCanonicalTip(t *testing.T) 
 	engine, store, target := newReorgTestEngine(t)
 
 	subsidy1 := consensus.BlockSubsidy(1, 0)
-	blockA1 := buildSingleTxBlock(t, devnetGenesisBlockHash, target, 2, coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 1, subsidy1))
+	blockA1 := buildSingleTxBlock(t, devnetGenesisBlockHash, target, reorgTestTimestamp(1), coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 1, subsidy1))
 	summaryA1, err := engine.ApplyBlock(blockA1, nil)
 	if err != nil {
 		t.Fatalf("ApplyBlock(A1): %v", err)
 	}
 
 	subsidy2 := consensus.BlockSubsidy(2, subsidy1)
-	blockA2 := buildSingleTxBlock(t, summaryA1.BlockHash, target, 3, coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 2, subsidy2))
+	blockA2 := buildSingleTxBlock(t, summaryA1.BlockHash, target, reorgTestTimestamp(2), coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 2, subsidy2))
 	summaryA2, err := engine.ApplyBlock(blockA2, nil)
 	if err != nil {
 		t.Fatalf("ApplyBlock(A2): %v", err)
 	}
 
-	sideB1 := buildSingleTxBlock(t, devnetGenesisBlockHash, target, 4, coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 1, subsidy1))
+	sideB1 := buildSingleTxBlock(t, devnetGenesisBlockHash, target, reorgTestTimestamp(3), coinbaseWithWitnessCommitmentAndP2PKValueAtHeight(t, 1, subsidy1))
 	beforeSide := engine.BlockApplyCounts()
 	sideSummary, err := engine.ApplyBlockWithReorg(sideB1, nil)
 	if err != nil {


### PR DESCRIPTION
Invariant:
Non-heavier Go side-branch blocks must derive the timestamp/MTP context from the canonical ancestor plus stored side-branch ancestors, then validate that context before side-block persistence or P2P accepted-inventory side effects.

Layer:
Implementation / Go node runtime / P2P relay. Consensus-adjacent validation callsite only; no consensus rule, spec, conformance fixture, runner, Rust, or generated artifact change.

Files changed:
- clients/go/node/sync_reorg.go
- clients/go/node/sync_reorg_test.go
- clients/go/node/sync_helpers_test.go
- clients/go/node/p2p/service_test.go

Tests:
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node -run "Test.*Reorg|Test.*Side" -count=1' - PASS
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node/p2p -run TestProcessRelayedBlockRejectsSideBranchTimestampBeforeAcceptedInventory -count=1' - PASS
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node ./node/p2p ./consensus -count=1' - PASS
- after merging current origin/main/deaddf5: scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node -run "TestApplyBlockWithReorgRejectsSideBranchTimestampContextBeforeStore|TestApplyBlockWithReorgKeepsLighterSideBranchOffCanonicalTip" -count=1' - PASS
- after merging current origin/main/deaddf5: scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node/p2p -run "TestProcessRelayedBlockRejectsSideBranchTimestampBeforeAcceptedInventory|TestApplyErrorFullBlockClearsMatchingCompactOutstanding|TestAlreadyHaveFullBlockClearsMatchingCompactOutstanding|TestOrphanFullBlockClearsMatchingCompactOutstanding" -count=1' - PASS
- after merging current origin/main/deaddf5: scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node ./node/p2p ./consensus -count=1' - PASS
- rubin-precommit-one-review --repo . --base-ref origin/main --include-base-diff - PASS; fixed one-review result: No findings
- rubin-push --repo . --base-ref origin/main --coverage-cmd 'rubin-stack-codacy-coverage.sh . origin/main' - PASS

Coverage:
Stack-local Codacy coverage preflight on merge-base deaddf52c5b11e72cee374d46ddf0543d20de639:
- base: 92.49% (16806/18171)
- head: 92.44% (16819/18194)
- variation: -0.05%, gate >= -0.10%
- diff coverage: 85.71% (24/28), gate >= 85.00%

Behavior impact:
- Non-heavier side branches now validate ValidateBlockBasicWithContextAtHeight with derived side-branch timestamp context before StoreBlock.
- Timestamp-old and timestamp-future side branches reject with exact consensus error codes and do not mutate apply counters, canonical tip, blockstore, P2P blockSeen, or relay inventory.

Compatibility impact:
No consensus validity change, no canonical/spec update, no fixture or runner update. Rust S008 parity is explicitly out of this PR and remains tracked separately by RUB-338. Mixed-client security/devnet claim must not treat this Go-only PR as closing Rust parity.

Known non-goals:
- no RUB-337/Rust/S006 fork-choice work
- no RUB-338 Rust S008 parity work
- no conformance fixture or runner changes
- no devnet-ready track/blocker graph changes
- no manual Copilot/reviewer request

Risk:
The new helper reconstructs the side-branch timestamp window from canonical ancestor state plus side-branch ancestors. Regression coverage includes old/future timestamp rejection, multi-block side-branch success, P2P reject-before-inventory, and post-origin/main compact-outstanding direct-callee checks.

Rollback:
Revert this PR to restore prior non-heavier side-branch storage behavior.

Not checked:
Rust parity implementation; tracked by RUB-338.


<!-- rubin-agent-meta actor=unknown action=pr-create via=cl branch=codex/RUB-336-go-sidebranch-mtp-context wt=rubin-protocol-codex-RUB-336 utc=2026-05-21T22:47:16Z -->
