### PR TITLE
[RUB-343/2] Harden compact receive runtime edges

### DIFF
--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -257,8 +257,14 @@ func compactLocalTxWTxID(tx []byte) ([32]byte, error) {
 }
 
 func (p *peer) handleCmpctBlock(payload []byte) error {
+	if err := p.validateCmpctBlockReceiveHeader(payload); err != nil {
+		return err
+	}
 	block, err := decodeCmpctBlockPayload(payload)
 	if err != nil {
+		if errors.Is(err, errCmpctBlockShortIDCountTooLarge) {
+			return p.requestOversizedCompactBlockFallback(payload)
+		}
 		p.bumpBan(10, err.Error())
 		return err
 	}
@@ -271,9 +277,6 @@ func (p *peer) handleCmpctBlock(payload []byte) error {
 	if have {
 		p.clearCompactOutstandingRequestForBlock(blockHash)
 		return nil
-	}
-	if err := p.validateCompactBlockHeader(block.Header); err != nil {
-		return err
 	}
 	localTxs := compactRelayLocalTransactionsForBlock(block, p.service.cfg.TxPool)
 	result, err := reconstructCompactBlock(block, localTxs)
@@ -290,6 +293,46 @@ func (p *peer) handleCmpctBlock(payload []byte) error {
 		return p.processCompactTransactions(blockHash, block.Header, result.Transactions, len(block.ShortIDs) > 0)
 	}
 	return p.requestMissingCompactTransactions(block, blockHash, result)
+}
+
+func (p *peer) validateCmpctBlockReceiveHeader(payload []byte) error {
+	header, ok := cmpctBlockReceiveHeader(payload)
+	if !ok {
+		return nil
+	}
+	return p.validateCompactBlockHeader(header)
+}
+
+func cmpctBlockReceiveHeader(payload []byte) ([consensus.BLOCK_HEADER_BYTES]byte, bool) {
+	var header [consensus.BLOCK_HEADER_BYTES]byte
+	if len(payload) < consensus.BLOCK_HEADER_BYTES+16 {
+		return header, false
+	}
+	copy(header[:], payload[:consensus.BLOCK_HEADER_BYTES])
+	return header, true
+}
+
+func (p *peer) requestOversizedCompactBlockFallback(payload []byte) error {
+	if len(payload) < consensus.BLOCK_HEADER_BYTES {
+		p.bumpBan(10, errCmpctBlockShortIDCountTooLarge.Error())
+		return errCmpctBlockShortIDCountTooLarge
+	}
+	var header [consensus.BLOCK_HEADER_BYTES]byte
+	copy(header[:], payload[:consensus.BLOCK_HEADER_BYTES])
+	if err := p.validateCompactBlockHeader(header); err != nil {
+		return err
+	}
+	blockHash, _ := consensus.BlockHash(header[:]) // fixed-size header slice cannot hit the length error path
+	have, err := p.service.hasBlock(blockHash)
+	if err != nil {
+		p.clearCompactOutstandingRequestForBlock(blockHash)
+		return err
+	}
+	if have {
+		p.clearCompactOutstandingRequestForBlock(blockHash)
+		return nil
+	}
+	return p.requestCompactFullBlockFallback(blockHash)
 }
 
 func (p *peer) validateCompactBlockHeader(header [consensus.BLOCK_HEADER_BYTES]byte) error {
@@ -323,12 +366,27 @@ func (p *peer) handleBlockTxn(payload []byte) error {
 	}
 	var responseHash [32]byte
 	copy(responseHash[:], payload[:32])
+	blockHash, ok := p.compactOutstandingBlockHash()
+	if !ok {
+		p.setLastError("ignored unexpected blocktxn response")
+		return nil
+	}
+	if responseHash != blockHash {
+		if len(payload) > blockTxnHashPayloadBytes {
+			return errors.New("stale blocktxn response has body")
+		}
+		p.setLastError("ignored stale blocktxn response")
+		return nil
+	}
 	req, ok := p.compactOutstandingRequestSnapshot()
 	if !ok {
-		return p.rejectBlockTxn("unexpected blocktxn response")
+		p.setLastError("ignored unexpected blocktxn response")
+		return nil
 	}
-	if responseHash != req.BlockHash {
-		return p.rejectBlockTxn("blocktxn block hash mismatch")
+	if uint64(len(payload)) > uint64(req.BlockTxnPayloadCap) {
+		p.clearCompactOutstandingRequestForBlock(req.BlockHash)
+		p.bumpBan(10, "blocktxn payload exceeds outstanding cap")
+		return errors.New("blocktxn payload exceeds outstanding cap")
 	}
 	response, err := decodeBlockTxnRuntimePayload(payload)
 	if err != nil {

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/node"
 )
 
 const (
@@ -253,6 +254,211 @@ func compactLocalTxWTxID(tx []byte) ([32]byte, error) {
 		return zero, errors.New("compact local transaction is non-canonical")
 	}
 	return wtxid, nil
+}
+
+func (p *peer) handleCmpctBlock(payload []byte) error {
+	block, err := decodeCmpctBlockPayload(payload)
+	if err != nil {
+		p.bumpBan(10, err.Error())
+		return err
+	}
+	blockHash, _ := consensus.BlockHash(block.Header[:]) // fixed-size header slice cannot hit the length error path
+	have, err := p.service.hasBlock(blockHash)
+	if err != nil {
+		p.clearCompactOutstandingRequestForBlock(blockHash)
+		return err
+	}
+	if have {
+		p.clearCompactOutstandingRequestForBlock(blockHash)
+		return nil
+	}
+	if err := p.validateCompactBlockHeader(block.Header); err != nil {
+		return err
+	}
+	localTxs := compactRelayLocalTransactionsForBlock(block, p.service.cfg.TxPool)
+	result, err := reconstructCompactBlock(block, localTxs)
+	if errors.Is(err, errCompactRelayMissingRequestTooLarge) {
+		return p.requestCompactFullBlockFallback(blockHash)
+	}
+	if err != nil {
+		if len(block.ShortIDs) > 0 {
+			return p.requestCompactFullBlockFallback(blockHash)
+		}
+		return err
+	}
+	if result.Transactions != nil {
+		return p.processCompactTransactions(blockHash, block.Header, result.Transactions, len(block.ShortIDs) > 0)
+	}
+	return p.requestMissingCompactTransactions(block, blockHash, result)
+}
+
+func (p *peer) validateCompactBlockHeader(header [consensus.BLOCK_HEADER_BYTES]byte) error {
+	parsed, _ := consensus.ParseBlockHeaderBytes(header[:]) // fixed-size header slice cannot hit the length error path
+	if err := consensus.PowCheck(header[:], parsed.Target); err != nil {
+		p.bumpBan(100, err.Error())
+		return err
+	}
+	if expected := p.service.cfg.SyncConfig.ExpectedTarget; expected != nil && parsed.Target != *expected {
+		err := &consensus.TxError{Code: consensus.BLOCK_ERR_TARGET_INVALID, Msg: "target mismatch"}
+		p.bumpBan(100, err.Error())
+		return err
+	}
+	return nil
+}
+
+func (p *peer) requestMissingCompactTransactions(block cmpctBlockPayload, blockHash [32]byte, result compactReconstructionResult) error {
+	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
+		return p.requestCompactFullBlockFallback(blockHash)
+	}
+	req, err := newCompactOutstandingRequest(block, blockHash, result)
+	if err != nil {
+		return err
+	}
+	return p.sendCompactOutstandingRequest(req)
+}
+
+func (p *peer) handleBlockTxn(payload []byte) error {
+	if len(payload) < 32 {
+		return p.rejectBlockTxn("blocktxn payload missing block hash")
+	}
+	var responseHash [32]byte
+	copy(responseHash[:], payload[:32])
+	req, ok := p.compactOutstandingRequestSnapshot()
+	if !ok {
+		return p.rejectBlockTxn("unexpected blocktxn response")
+	}
+	if responseHash != req.BlockHash {
+		return p.rejectBlockTxn("blocktxn block hash mismatch")
+	}
+	response, err := decodeBlockTxnRuntimePayload(payload)
+	if err != nil {
+		p.clearCompactOutstandingRequestForBlock(req.BlockHash)
+		p.bumpBan(10, err.Error())
+		return err
+	}
+	p.clearCompactOutstandingRequestForBlock(req.BlockHash)
+	txs, err := compactFillResponseTransactions(req, response)
+	if err != nil {
+		return p.requestCompactFullBlockFallback(req.BlockHash)
+	}
+	return p.processCompactTransactions(req.BlockHash, req.Header, txs, true)
+}
+
+func (p *peer) rejectBlockTxn(msg string) error {
+	p.bumpBan(10, msg)
+	return errors.New(msg)
+}
+
+func (p *peer) processCompactTransactions(blockHash [32]byte, header [consensus.BLOCK_HEADER_BYTES]byte, txs [][]byte, fallbackOnApply bool) error {
+	blockBytes, err := compactBlockBytes(header, txs)
+	if err != nil {
+		if fallbackOnApply {
+			return p.requestCompactFullBlockFallback(blockHash)
+		}
+		p.bumpBan(10, err.Error())
+		return err
+	}
+	if !fallbackOnApply {
+		return p.handleBlock(blockBytes)
+	}
+	fallback, accepted, err := p.processCompactRelayedBlockWithFallback(blockHash, blockBytes, fallbackOnApply)
+	if fallback {
+		return p.requestCompactFullBlockFallback(blockHash)
+	}
+	if err != nil {
+		return err
+	}
+	if accepted {
+		return p.service.requestBlocksIfBehind(p)
+	}
+	return nil
+}
+
+func (p *peer) processCompactRelayedBlockWithFallback(expectedHash [32]byte, blockBytes []byte, fallbackOnApply bool) (bool, bool, error) {
+	pb, blockHash, err := parseRelayedBlock(blockBytes)
+	if err != nil || pb == nil || blockHash != expectedHash {
+		return true, false, err
+	}
+	have, err := p.service.hasBlock(blockHash)
+	if err != nil {
+		p.clearCompactOutstandingRequestForBlock(blockHash)
+		return false, false, err
+	}
+	if have {
+		p.clearCompactOutstandingRequestForBlock(blockHash)
+		return false, true, nil
+	}
+	p.service.chainMu.Lock()
+	summary, err := p.service.cfg.SyncEngine.ApplyBlockWithReorg(blockBytes, nil)
+	p.service.chainMu.Unlock()
+	if err != nil {
+		return p.compactApplyErrorFallback(pb, blockHash, blockBytes, err, fallbackOnApply)
+	}
+	if summary == nil {
+		return false, false, errors.New("compact block apply returned nil summary")
+	}
+	have, err = p.service.hasBlock(blockHash)
+	if err != nil {
+		return false, false, err
+	}
+	if !have {
+		return false, false, errors.New("compact block apply succeeded without accepting block")
+	}
+	p.clearCompactOutstandingRequestForBlock(blockHash)
+	p.acceptedRelayedBlock(blockHash, summary)
+	return false, true, nil
+}
+
+func (p *peer) compactApplyErrorFallback(pb *consensus.ParsedBlock, blockHash [32]byte, blockBytes []byte, err error, fallbackOnApply bool) (bool, bool, error) {
+	p.clearCompactOutstandingRequestForBlock(blockHash)
+	if errors.Is(err, node.ErrParentNotFound) {
+		if fallbackOnApply {
+			p.setLastError(err.Error())
+			return true, false, nil
+		}
+		if _, retainErr := p.retainRelayedOrphanIfValid(pb, blockHash, blockBytes); retainErr != nil {
+			return false, false, retainErr
+		}
+		return false, false, nil
+	}
+	if fallbackOnApply && isConsensusApplyBlockError(err) {
+		p.setLastError(err.Error())
+		return true, false, nil
+	}
+	p.recordRelayedBlockApplyError(err)
+	return false, false, err
+}
+
+func (p *peer) requestCompactFullBlockFallback(blockHash [32]byte) error {
+	body, err := encodeInventoryVectors([]InventoryVector{{Type: MSG_BLOCK, Hash: blockHash}})
+	if err != nil {
+		return err
+	}
+	return p.send(messageGetData, body)
+}
+
+func compactBlockBytes(header [consensus.BLOCK_HEADER_BYTES]byte, txs [][]byte) ([]byte, error) {
+	if len(txs) == 0 {
+		return nil, errors.New("compact block has no transactions")
+	}
+	out := append([]byte(nil), header[:]...)
+	out = consensus.AppendCompactSize(out, uint64(len(txs)))
+	var totalTxBytes uint64
+	for _, tx := range txs {
+		if tx == nil {
+			return nil, errors.New("compact block transaction missing")
+		}
+		nextTotal, err := validateBlockTxnTransactionSize(uint64(len(tx)), totalTxBytes)
+		if err != nil {
+			return nil, err
+		}
+		if len(out) > consensus.MAX_BLOCK_BYTES-len(tx) {
+			return nil, errors.New("compact block exceeds block size")
+		}
+		out = append(out, tx...)
+		totalTxBytes = nextTotal
+	}
+	return out, nil
 }
 
 func compactRelayLocalTransactions(pool TxPool, limit int) [][]byte {

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -265,9 +265,6 @@ func (p *peer) handleCmpctBlock(payload []byte) error {
 	}
 	block, err := decodeCmpctBlockPayload(payload)
 	if err != nil {
-		if errors.Is(err, errCmpctBlockShortIDCountTooLarge) {
-			return p.requestOversizedCompactBlockFallback(payload)
-		}
 		p.bumpBan(10, err.Error())
 		return err
 	}
@@ -304,29 +301,6 @@ func (p *peer) validateCmpctBlockReceiveHeader(payload []byte) error {
 		return nil
 	}
 	return p.validateCompactBlockHeader(header)
-}
-
-func (p *peer) requestOversizedCompactBlockFallback(payload []byte) error {
-	if len(payload) < consensus.BLOCK_HEADER_BYTES {
-		p.bumpBan(10, errCmpctBlockShortIDCountTooLarge.Error())
-		return errCmpctBlockShortIDCountTooLarge
-	}
-	var header [consensus.BLOCK_HEADER_BYTES]byte
-	copy(header[:], payload[:consensus.BLOCK_HEADER_BYTES])
-	if err := p.validateCompactBlockHeader(header); err != nil {
-		return err
-	}
-	blockHash, _ := consensus.BlockHash(header[:]) // fixed-size header slice cannot hit the length error path
-	have, err := p.service.hasBlock(blockHash)
-	if err != nil {
-		p.clearCompactOutstandingRequestForBlock(blockHash)
-		return err
-	}
-	if have {
-		p.clearCompactOutstandingRequestForBlock(blockHash)
-		return nil
-	}
-	return p.requestCompactFullBlockFallback(blockHash)
 }
 
 func (p *peer) validateCompactBlockHeader(header [consensus.BLOCK_HEADER_BYTES]byte) error {

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -260,8 +260,14 @@ func compactLocalTxWTxID(tx []byte) ([32]byte, error) {
 }
 
 func (p *peer) handleCmpctBlock(payload []byte) error {
+	if err := p.validateCmpctBlockReceiveHeader(payload); err != nil {
+		return err
+	}
 	block, err := decodeCmpctBlockPayload(payload)
 	if err != nil {
+		if errors.Is(err, errCmpctBlockShortIDCountTooLarge) {
+			return p.requestOversizedCompactBlockFallback(payload)
+		}
 		p.bumpBan(10, err.Error())
 		return err
 	}
@@ -274,9 +280,6 @@ func (p *peer) handleCmpctBlock(payload []byte) error {
 	if have {
 		p.clearCompactOutstandingRequestForBlock(blockHash)
 		return nil
-	}
-	if err := p.validateCompactBlockHeader(block.Header); err != nil {
-		return err
 	}
 	localTxs := compactRelayLocalTransactionsForBlock(block, p.service.cfg.TxPool)
 	result, err := reconstructCompactBlock(block, localTxs)
@@ -293,6 +296,37 @@ func (p *peer) handleCmpctBlock(payload []byte) error {
 		return p.processCompactTransactions(blockHash, block.Header, result.Transactions, len(block.ShortIDs) > 0)
 	}
 	return p.requestMissingCompactTransactions(block, blockHash, result)
+}
+
+func (p *peer) validateCmpctBlockReceiveHeader(payload []byte) error {
+	header, ok := cmpctBlockHeaderValidationCandidate(payload)
+	if !ok {
+		return nil
+	}
+	return p.validateCompactBlockHeader(header)
+}
+
+func (p *peer) requestOversizedCompactBlockFallback(payload []byte) error {
+	if len(payload) < consensus.BLOCK_HEADER_BYTES {
+		p.bumpBan(10, errCmpctBlockShortIDCountTooLarge.Error())
+		return errCmpctBlockShortIDCountTooLarge
+	}
+	var header [consensus.BLOCK_HEADER_BYTES]byte
+	copy(header[:], payload[:consensus.BLOCK_HEADER_BYTES])
+	if err := p.validateCompactBlockHeader(header); err != nil {
+		return err
+	}
+	blockHash, _ := consensus.BlockHash(header[:]) // fixed-size header slice cannot hit the length error path
+	have, err := p.service.hasBlock(blockHash)
+	if err != nil {
+		p.clearCompactOutstandingRequestForBlock(blockHash)
+		return err
+	}
+	if have {
+		p.clearCompactOutstandingRequestForBlock(blockHash)
+		return nil
+	}
+	return p.requestCompactFullBlockFallback(blockHash)
 }
 
 func (p *peer) validateCompactBlockHeader(header [consensus.BLOCK_HEADER_BYTES]byte) error {
@@ -326,12 +360,27 @@ func (p *peer) handleBlockTxn(payload []byte) error {
 	}
 	var responseHash [32]byte
 	copy(responseHash[:], payload[:32])
+	blockHash, ok := p.compactOutstandingBlockHash()
+	if !ok {
+		p.setLastError("ignored unexpected blocktxn response")
+		return nil
+	}
+	if responseHash != blockHash {
+		if len(payload) > blockTxnHashPayloadBytes {
+			return errors.New("stale blocktxn response has body")
+		}
+		p.setLastError("ignored stale blocktxn response")
+		return nil
+	}
 	req, ok := p.compactOutstandingRequestSnapshot()
 	if !ok {
-		return p.rejectBlockTxn("unexpected blocktxn response")
+		p.setLastError("ignored unexpected blocktxn response")
+		return nil
 	}
-	if responseHash != req.BlockHash {
-		return p.rejectBlockTxn("blocktxn block hash mismatch")
+	if uint64(len(payload)) > uint64(req.BlockTxnPayloadCap) {
+		p.clearCompactOutstandingRequestForBlock(req.BlockHash)
+		p.bumpBan(10, "blocktxn payload exceeds outstanding cap")
+		return errors.New("blocktxn payload exceeds outstanding cap")
 	}
 	response, err := decodeBlockTxnRuntimePayload(payload)
 	if err != nil {

--- a/clients/go/node/p2p/compact_reconstruct_test.go
+++ b/clients/go/node/p2p/compact_reconstruct_test.go
@@ -2,12 +2,14 @@ package p2p
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/node"
 )
 
 func TestReconstructCompactBlockCompletesExactPositionsFromWTxID(t *testing.T) {
@@ -431,6 +433,380 @@ func TestReconstructCompactBlockSkipsLocalLookupForPrefilledOnlyBlock(t *testing
 	}
 }
 
+func TestInternalHandleBlockTxnCompletesOutstandingBlock(t *testing.T) {
+	header, blockHash, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
+	p := newPeerRuntimeTestPeer(t)
+	if err := p.handleBlockTxn(nil); err == nil || !strings.Contains(err.Error(), "missing block hash") || p.snapshotState().BanScore == 0 {
+		t.Fatalf("short blocktxn err=%v state=%+v", err, p.snapshotState())
+	}
+
+	p = newPeerRuntimeTestPeer(t)
+	if err := p.handleBlockTxn(make([]byte, 32)); err == nil || !strings.Contains(err.Error(), "unexpected blocktxn response") || p.snapshotState().BanScore == 0 {
+		t.Fatalf("unexpected blocktxn err=%v state=%+v", err, p.snapshotState())
+	}
+
+	p = newCompactScriptedPeer(t)
+	setCompactTestOutstanding(p, blockHash, header, compactShortIDForTx(t, txs[0], 201, 202), 201, 202)
+	if err := p.handleBlockTxn(make([]byte, 32)); err == nil || !strings.Contains(err.Error(), "block hash mismatch") {
+		t.Fatalf("wrong hash blocktxn err=%v", err)
+	}
+
+	p = newCompactScriptedPeer(t)
+	setCompactTestOutstanding(p, blockHash, header, compactShortIDForTx(t, txs[0], 201, 202), 201, 202)
+	malformed := append(blockHash[:], 0xff)
+	if err := p.handleBlockTxn(malformed); err == nil || p.snapshotState().BanScore == 0 {
+		t.Fatalf("malformed blocktxn err=%v state=%+v", err, p.snapshotState())
+	}
+	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatal("malformed blocktxn did not clear matching outstanding request")
+	}
+
+	p = newCompactScriptedPeer(t)
+	setCompactTestOutstanding(p, blockHash, header, compactShortIDForTx(t, txs[0], 201, 202), 201, 202)
+	valid, err := encodeBlockTxnPayload(blockTxnPayload{BlockHash: blockHash, Transactions: [][]byte{txs[0]}})
+	requireNoCompactErr(t, err, "encode blocktxn")
+	requireNoCompactErr(t, p.handleBlockTxn(valid), "handle blocktxn")
+	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatal("outstanding request was not cleared")
+	}
+	if have, err := p.service.hasBlock(blockHash); err != nil || !have {
+		t.Fatalf("hasBlock=%v err=%v", have, err)
+	}
+}
+
+func TestHandleCmpctBlockValidationAndFallbackEdges(t *testing.T) {
+	header, blockHash, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
+	full := mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{Header: header, Prefilled: []prefilledTxn{{Index: 0, Tx: txs[0]}}})
+	missing := mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{Header: header, ShortIDs: []compactShortID{{0xaa}}})
+
+	p := newCompactScriptedPeer(t)
+	requireNoCompactErr(t, p.handleBlock(node.DevnetGenesisBlockBytes()), "seed existing block")
+	setCompactTestOutstanding(p, blockHash, header, compactShortIDForTx(t, txs[0], 201, 202), 201, 202)
+	requireNoCompactErr(t, p.handleCmpctBlock(full), "already-have compact block")
+	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatal("already-have compact block did not clear matching outstanding request")
+	}
+	if p.conn.(*scriptedConn).Buffer.Len() != 0 {
+		t.Fatal("already-have compact block sent fallback")
+	}
+
+	tinyTarget := [32]byte{}
+	tinyTarget[31] = 0x01
+	powInvalidHeader := compactHeaderWithTarget(header, tinyTarget)
+	p = newCompactScriptedPeer(t)
+	err := p.handleCmpctBlock(mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{Header: powInvalidHeader, Prefilled: []prefilledTxn{{Index: 0, Tx: txs[0]}}}))
+	if err == nil || !strings.Contains(err.Error(), "pow invalid") || p.snapshotState().BanScore == 0 {
+		t.Fatalf("pow-invalid compact header err=%v state=%+v", err, p.snapshotState())
+	}
+
+	wrongExpected := compactFilledTarget(0xee)
+	p = newCompactScriptedPeer(t)
+	p.service.cfg.SyncConfig.ExpectedTarget = &wrongExpected
+	err = p.handleCmpctBlock(full)
+	if err == nil || !strings.Contains(err.Error(), "target mismatch") || p.snapshotState().BanScore == 0 {
+		t.Fatalf("target-mismatch compact header err=%v state=%+v", err, p.snapshotState())
+	}
+
+	pool := NewMemoryTxPool()
+	pool.txs[[32]byte{0x42}] = &relayTxEntry{raw: []byte{0x01}, size: 1}
+	p = newCompactScriptedPeer(t)
+	p.service.cfg.TxPool = pool
+	requireNoCompactErr(t, p.handleCmpctBlock(missing), "malformed local candidate fallback")
+	requireCompactFrame(t, p, messageGetData)
+	if p.snapshotState().BanScore != 0 {
+		t.Fatalf("malformed local candidate ban_score=%d, want no ban", p.snapshotState().BanScore)
+	}
+
+	p = newCompactScriptedPeer(t)
+	setCompactTestOutstanding(p, blockHash, header, compactShortIDForTx(t, txs[0], 301, 302), 301, 302)
+	requireNoCompactErr(t, p.handleCmpctBlock(missing), "missing compact block with existing outstanding")
+	requireCompactFrame(t, p, messageGetData)
+
+	p = newCompactScriptedPeer(t)
+	err = p.requestMissingCompactTransactions(cmpctBlockPayload{Header: header}, blockHash, compactReconstructionResult{
+		PartialTransactions: [][]byte{nil},
+		MissingIndexes:      []uint64{1},
+		MissingShortIDs:     []compactShortID{{0x01}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "compact relay index out of range") {
+		t.Fatalf("invalid missing request err=%v, want index out of range", err)
+	}
+}
+
+func TestCompactProcessErrorEdges(t *testing.T) {
+	header, blockHash, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
+
+	p := newCompactScriptedPeer(t)
+	requireNoCompactErr(t, p.processCompactTransactions(blockHash, header, nil, true), "short-id assembly fallback")
+	requireCompactFrame(t, p, messageGetData)
+	if p.snapshotState().BanScore != 0 {
+		t.Fatalf("short-id assembly state=%+v, want no ban fallback", p.snapshotState())
+	}
+
+	p = newCompactScriptedPeer(t)
+	if err := p.processCompactTransactions(blockHash, header, nil, false); err == nil || !strings.Contains(err.Error(), "compact block has no transactions") || p.snapshotState().BanScore == 0 {
+		t.Fatalf("prefilled empty compact transactions err=%v state=%+v", err, p.snapshotState())
+	}
+
+	p = newCompactScriptedPeer(t)
+	if fallback, accepted, err := p.processCompactRelayedBlockWithFallback([32]byte{0x99}, node.DevnetGenesisBlockBytes(), true); !fallback || accepted || err != nil {
+		t.Fatalf("mismatched expected hash fallback=%v accepted=%v err=%v", fallback, accepted, err)
+	}
+
+	p = newCompactScriptedPeer(t)
+	setCompactTestOutstanding(p, blockHash, header, compactShortIDForTx(t, txs[0], 401, 402), 401, 402)
+	p.service.cfg.BlockStore = nil
+	if fallback, accepted, err := p.processCompactRelayedBlockWithFallback(blockHash, node.DevnetGenesisBlockBytes(), true); fallback || accepted || err == nil {
+		t.Fatalf("hasBlock error fallback=%v accepted=%v err=%v", fallback, accepted, err)
+	}
+	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatal("hasBlock error did not clear matching compact outstanding request")
+	}
+}
+
+func TestCompactApplyErrorFallbackEdges(t *testing.T) {
+	source := newTestHarness(t, 2, "127.0.0.1:0", nil)
+	blockHash, blockBytes := testHarnessBlockAtHeight(t, source, 1)
+	pb, parsedHash, err := parseRelayedBlock(blockBytes)
+	requireNoCompactErr(t, err, "parse relayed block")
+	if parsedHash != blockHash {
+		t.Fatalf("parsed block hash=%x, want %x", parsedHash, blockHash)
+	}
+
+	p := newCompactScriptedPeer(t)
+	fallback, accepted, err := p.compactApplyErrorFallback(pb, blockHash, blockBytes, node.ErrParentNotFound, false)
+	requireNoCompactErr(t, err, "parent-not-found retain")
+	if fallback || accepted || p.service.orphans.Len() != 1 {
+		t.Fatalf("parent-not-found fallback=%v accepted=%v orphans=%d", fallback, accepted, p.service.orphans.Len())
+	}
+
+	p = newCompactScriptedPeer(t)
+	applyErr := &consensus.TxError{Code: consensus.BLOCK_ERR_MERKLE_INVALID, Msg: "merkle mismatch"}
+	fallback, accepted, err = p.compactApplyErrorFallback(pb, blockHash, blockBytes, applyErr, true)
+	requireNoCompactErr(t, err, "consensus apply fallback")
+	if !fallback || accepted || !strings.Contains(p.snapshotState().LastError, "merkle mismatch") {
+		t.Fatalf("consensus fallback=%v accepted=%v state=%+v", fallback, accepted, p.snapshotState())
+	}
+
+	p = newCompactScriptedPeer(t)
+	errBoom := errors.New("local apply failure")
+	fallback, accepted, err = p.compactApplyErrorFallback(pb, blockHash, blockBytes, errBoom, false)
+	if fallback || accepted || !errors.Is(err, errBoom) || !strings.Contains(p.snapshotState().LastError, "local apply failure") {
+		t.Fatalf("local apply fallback=%v accepted=%v err=%v state=%+v", fallback, accepted, err, p.snapshotState())
+	}
+}
+
+func TestCompactBlockBytesRejectsInvalidAssembly(t *testing.T) {
+	header, _, _ := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
+	cases := []struct {
+		name string
+		txs  [][]byte
+		want string
+	}{
+		{name: "empty", txs: nil, want: "compact block has no transactions"},
+		{name: "missing", txs: [][]byte{nil}, want: "compact block transaction missing"},
+		{name: "empty_tx", txs: [][]byte{{}}, want: "blocktxn transaction is empty"},
+		{name: "oversize_block", txs: [][]byte{make([]byte, consensus.MAX_BLOCK_BYTES)}, want: "compact block exceeds block size"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := compactBlockBytes(header, tc.txs)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("compactBlockBytes err=%v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestCompactPrefilledParentNotFoundRetainsOrphanWithoutFallback(t *testing.T) {
+	source := newTestHarness(t, 2, "127.0.0.1:0", nil)
+	blockHash, blockBytes := testHarnessBlockAtHeight(t, source, 1)
+	header, gotHash, txs := compactPartsFromBlockBytes(t, blockBytes)
+	if gotHash != blockHash {
+		t.Fatalf("block hash=%x, want %x", gotHash, blockHash)
+	}
+
+	p := newCompactScriptedPeer(t)
+	requireNoCompactErr(t, p.processCompactTransactions(blockHash, header, txs, false), "parent-not-found prefilled compact apply")
+	if got := p.service.orphans.Len(); got != 1 {
+		t.Fatalf("orphans.Len()=%d, want 1", got)
+	}
+	if p.conn.(*scriptedConn).Buffer.Len() != 0 {
+		t.Fatal("parent-not-found compact apply sent full-block fallback")
+	}
+}
+
+func TestCompactShortIDParentNotFoundFallsBackWithoutBlockSeen(t *testing.T) {
+	source := newTestHarness(t, 2, "127.0.0.1:0", nil)
+	blockHash, blockBytes := testHarnessBlockAtHeight(t, source, 1)
+	header, gotHash, txs := compactPartsFromBlockBytes(t, blockBytes)
+	if gotHash != blockHash {
+		t.Fatalf("block hash=%x, want %x", gotHash, blockHash)
+	}
+
+	p := newCompactScriptedPeer(t)
+	requireNoCompactErr(t, p.processCompactTransactions(blockHash, header, txs, true), "parent-not-found short-id compact apply")
+	requireCompactFrame(t, p, messageGetData)
+	if got := p.service.orphans.Len(); got != 0 {
+		t.Fatalf("orphans.Len()=%d, want 0 for short-id reconstructed bytes", got)
+	}
+	if p.service.blockSeen.Has(blockHash) {
+		t.Fatal("short-id reconstructed orphan poisoned blockSeen")
+	}
+}
+
+func TestRunRoutesNegotiatedCmpctBlock(t *testing.T) {
+	header, blockHash, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
+	payload := mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{Header: header, Prefilled: []prefilledTxn{{Index: 0, Tx: txs[0]}}})
+	p := newPeerRuntimeTestPeer(t)
+	p.service.cfg.EnableCompactReceive = true
+	p.setRemoteCompactMode(compactModeSnapshot{Mode: 1, Version: compactRelayVersion})
+	p.conn = &scriptedConn{reads: []scriptedRead{{data: mustPeerRuntimeFrameBytes(t, p, message{Command: messageCmpctBlock, Payload: payload})}}}
+
+	requireNoCompactErr(t, p.run(context.Background()), "run cmpctblock")
+	if have, err := p.service.hasBlock(blockHash); err != nil || !have {
+		t.Fatalf("hasBlock=%v err=%v", have, err)
+	}
+}
+
+func TestRunRoutesOutstandingBlockTxn(t *testing.T) {
+	header, blockHash, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
+	payload, err := encodeBlockTxnPayload(blockTxnPayload{BlockHash: blockHash, Transactions: [][]byte{txs[0]}})
+	requireNoCompactErr(t, err, "encode blocktxn")
+	p := newPeerRuntimeTestPeer(t)
+	p.service.cfg.EnableCompactReceive = true
+	setCompactTestOutstanding(p, blockHash, header, compactShortIDForTx(t, txs[0], 201, 202), 201, 202)
+	p.conn = &scriptedConn{reads: []scriptedRead{{data: mustPeerRuntimeFrameBytes(t, p, message{Command: messageBlockTxn, Payload: payload})}}}
+
+	requireNoCompactErr(t, p.run(context.Background()), "run blocktxn")
+	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatal("outstanding request was not cleared")
+	}
+	if have, err := p.service.hasBlock(blockHash); err != nil || !have {
+		t.Fatalf("hasBlock=%v err=%v", have, err)
+	}
+}
+
+func TestHandleBlockTxnFallsBackWithoutBanOnShortIDMismatch(t *testing.T) {
+	header, blockHash, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
+	p := newCompactScriptedPeer(t)
+	setCompactTestOutstanding(p, blockHash, header, compactShortID{0xbb}, 301, 302)
+	valid, err := encodeBlockTxnPayload(blockTxnPayload{BlockHash: blockHash, Transactions: [][]byte{txs[0]}})
+	requireNoCompactErr(t, err, "encode blocktxn")
+	requireNoCompactErr(t, p.handleBlockTxn(valid), "mismatched blocktxn fallback")
+	requireCompactFrame(t, p, messageGetData)
+	if p.snapshotState().BanScore != 0 {
+		t.Fatalf("mismatched blocktxn state=%+v, want no ban", p.snapshotState())
+	}
+}
+
+func TestInternalCompactReceiveMissingAndFallbackBranches(t *testing.T) {
+	header, blockHash, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
+	missing := mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{Header: header, ShortIDs: []compactShortID{{0xaa}}})
+	full := mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{Header: header, Prefilled: []prefilledTxn{{Index: 0, Tx: txs[0]}}})
+
+	p := newCompactScriptedPeer(t)
+	if err := p.handleCmpctBlock(nil); err == nil || p.snapshotState().BanScore == 0 {
+		t.Fatalf("malformed cmpctblock err=%v state=%+v", err, p.snapshotState())
+	}
+
+	p = newCompactScriptedPeer(t)
+	setCompactTestOutstanding(p, blockHash, header, compactShortIDForTx(t, txs[0], 801, 802), 801, 802)
+	p.service.cfg.BlockStore = nil
+	if err := p.handleCmpctBlock(full); err == nil || !strings.Contains(err.Error(), "nil blockstore") {
+		t.Fatalf("hasBlock cmpctblock err=%v, want nil blockstore", err)
+	}
+	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatal("hasBlock error did not clear matching compact outstanding request")
+	}
+
+	p = newCompactScriptedPeer(t)
+	requireNoCompactErr(t, p.handleCmpctBlock(missing), "missing compact block")
+	requireCompactFrame(t, p, messageGetBlockTxn)
+	if snap, ok := p.compactOutstandingRequestSnapshot(); !ok || snap.BlockHash != blockHash || snap.BlockTxnPayloadCap == 0 {
+		t.Fatalf("outstanding=%+v ok=%v", snap, ok)
+	}
+
+	p = newCompactScriptedPeer(t)
+	tooMany := mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{Header: header, ShortIDs: make([]compactShortID, maxCompactRelayEntries+1)})
+	requireNoCompactErr(t, p.handleCmpctBlock(tooMany), "missing overflow fallback")
+	requireCompactFrame(t, p, messageGetData)
+
+	p = newCompactScriptedPeer(t)
+	requireNoCompactErr(t, p.handleCmpctBlock(full), "prefilled compact block")
+	if have, err := p.service.hasBlock(blockHash); err != nil || !have {
+		t.Fatalf("hasBlock=%v err=%v", have, err)
+	}
+}
+
+func TestInternalCompactApplySuccessClearsMatchingOutstanding(t *testing.T) {
+	header, blockHash, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
+	p := newCompactScriptedPeer(t)
+	setCompactTestOutstanding(p, blockHash, header, compactShortIDForTx(t, txs[0], 601, 602), 601, 602)
+	fallback, accepted, err := p.processCompactRelayedBlockWithFallback(blockHash, node.DevnetGenesisBlockBytes(), true)
+	requireNoCompactErr(t, err, "compact apply success")
+	if fallback || !accepted {
+		t.Fatalf("compact apply success fallback=%v accepted=%v, want accepted without fallback", fallback, accepted)
+	}
+	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatal("compact apply success did not clear matching compact outstanding request")
+	}
+}
+
+func TestInternalCompactApplyEarlyHaveClearsMatchingOutstanding(t *testing.T) {
+	header, blockHash, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
+	p := newCompactScriptedPeer(t)
+	requireNoCompactErr(t, p.handleBlock(node.DevnetGenesisBlockBytes()), "seed existing block")
+	setCompactTestOutstanding(p, blockHash, header, compactShortIDForTx(t, txs[0], 701, 702), 701, 702)
+	fallback, accepted, err := p.processCompactRelayedBlockWithFallback(blockHash, node.DevnetGenesisBlockBytes(), true)
+	requireNoCompactErr(t, err, "compact apply early-have")
+	if fallback || !accepted {
+		t.Fatalf("compact apply early-have fallback=%v accepted=%v, want accepted without fallback", fallback, accepted)
+	}
+	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatal("compact apply early-have did not clear matching compact outstanding request")
+	}
+}
+
+func TestProcessCompactTransactionsRejectsAcceptedBlockMissingAfterApply(t *testing.T) {
+	header, blockHash, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
+	p := newCompactScriptedPeer(t)
+	otherStore, err := node.OpenBlockStore(node.BlockStorePath(t.TempDir()))
+	requireNoCompactErr(t, err, "open alternate blockstore")
+	p.service.cfg.BlockStore = otherStore
+
+	err = p.processCompactTransactions(blockHash, header, txs, true)
+	if err == nil || !strings.Contains(err.Error(), "compact block apply succeeded without accepting block") {
+		t.Fatalf("processCompactTransactions err=%v, want explicit missing accepted block error", err)
+	}
+	if p.service.blockSeen.Has(blockHash) {
+		t.Fatal("accepted-but-missing compact block marked blockSeen before storage verification")
+	}
+	if p.conn.(*scriptedConn).Buffer.Len() != 0 {
+		t.Fatal("accepted-but-missing compact block path sent fallback instead of returning an error")
+	}
+}
+
+func TestCompactPartsFromBlockBytesDecodesCompactSizeTxCountWidth(t *testing.T) {
+	const txCount = 253
+	genesis := node.DevnetGenesisBlockBytes()
+	block := append([]byte(nil), genesis[:consensus.BLOCK_HEADER_BYTES]...)
+	block = consensus.AppendCompactSize(block, txCount)
+	firstTx := minimalBlockTxnTestTxBytes(1000)
+	block = append(block, firstTx...)
+	for i := uint64(1); i < txCount; i++ {
+		block = append(block, minimalBlockTxnTestTxBytes(1000+i)...)
+	}
+
+	_, _, txs := compactPartsFromBlockBytes(t, block)
+	if len(txs) != txCount {
+		t.Fatalf("tx count=%d, want %d", len(txs), txCount)
+	}
+	if !bytes.Equal(txs[0], firstTx) {
+		t.Fatalf("first tx was sliced from the wrong offset")
+	}
+}
+
 func TestCompactRelayLocalTransactionsBoundsMemoryPoolSnapshot(t *testing.T) {
 	pool := compactRelayTestMemoryPool(t, 4)
 	if got := compactRelayLocalTransactions(pool, 2); len(got) != 2 {
@@ -568,4 +944,93 @@ func compactWTxIDForTx(t *testing.T, tx []byte) [32]byte {
 		t.Fatalf("ParseTx: consumed=%d err=%v", consumed, err)
 	}
 	return wtxid
+}
+
+func mustEncodeCmpctBlockPayload(t *testing.T, in cmpctBlockPayload) []byte {
+	t.Helper()
+	raw, err := encodeCmpctBlockPayload(in)
+	requireNoCompactErr(t, err, "encode cmpctblock")
+	return raw
+}
+
+func newCompactScriptedPeer(t *testing.T) *peer {
+	t.Helper()
+	p := newPeerRuntimeTestPeer(t)
+	p.conn = &scriptedConn{}
+	return p
+}
+
+func setCompactTestOutstanding(p *peer, blockHash [32]byte, header [consensus.BLOCK_HEADER_BYTES]byte, shortID compactShortID, nonce1, nonce2 uint64) {
+	p.activateCompactOutstandingRequest(compactOutstandingRequest{
+		BlockHash:          blockHash,
+		Header:             header,
+		MissingIndexes:     []uint64{0},
+		MissingShortIDs:    []compactShortID{shortID},
+		Transactions:       [][]byte{nil},
+		Nonce1:             nonce1,
+		Nonce2:             nonce2,
+		BlockTxnPayloadCap: compactRelayPayloadCap(messageBlockTxn),
+	})
+}
+
+func compactPartsFromBlockBytes(t *testing.T, block []byte) ([consensus.BLOCK_HEADER_BYTES]byte, [32]byte, [][]byte) {
+	t.Helper()
+	if len(block) < consensus.BLOCK_HEADER_BYTES+1 {
+		t.Fatalf("block too short: %d", len(block))
+	}
+	var header [consensus.BLOCK_HEADER_BYTES]byte
+	copy(header[:], block[:consensus.BLOCK_HEADER_BYTES])
+	blockHash, _ := consensus.BlockHash(header[:])
+	txCount, countLen, err := consensus.DecodeCompactSize(block[consensus.BLOCK_HEADER_BYTES:])
+	if err != nil {
+		t.Fatalf("decode tx_count: %v", err)
+	}
+	offset := consensus.BLOCK_HEADER_BYTES + countLen
+	txs := make([][]byte, 0)
+	for i := uint64(0); i < txCount; i++ {
+		_, _, _, consumed, err := consensus.ParseTx(block[offset:])
+		if err != nil {
+			t.Fatalf("parse tx[%d]: %v", i, err)
+		}
+		if consumed <= 0 || offset+consumed > len(block) {
+			t.Fatalf("parse tx[%d] consumed invalid length %d at offset %d", i, consumed, offset)
+		}
+		txs = append(txs, append([]byte(nil), block[offset:offset+consumed]...))
+		offset += consumed
+	}
+	if offset != len(block) {
+		t.Fatalf("block has trailing bytes after tx list: %d", len(block)-offset)
+	}
+	return header, blockHash, txs
+}
+
+func requireCompactFrame(t *testing.T, p *peer, command string) {
+	t.Helper()
+	conn := p.conn.(*scriptedConn)
+	frame, err := readFrame(bytes.NewReader(conn.Buffer.Bytes()), networkMagic(p.service.cfg.PeerRuntimeConfig.Network), p.service.cfg.PeerRuntimeConfig.MaxMessageSize)
+	conn.Buffer.Reset()
+	if err != nil || frame.Command != command {
+		t.Fatalf("compact frame=%+v err=%v want %s", frame, err, command)
+	}
+}
+
+func requireNoCompactErr(t *testing.T, err error, label string) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("%s: %v", label, err)
+	}
+}
+
+func compactHeaderWithTarget(header [consensus.BLOCK_HEADER_BYTES]byte, target [32]byte) [consensus.BLOCK_HEADER_BYTES]byte {
+	const targetOffset = 4 + 32 + 32 + 8
+	copy(header[targetOffset:targetOffset+32], target[:])
+	return header
+}
+
+func compactFilledTarget(fill byte) [32]byte {
+	var out [32]byte
+	for i := range out {
+		out[i] = fill
+	}
+	return out
 }

--- a/clients/go/node/p2p/compact_reconstruct_test.go
+++ b/clients/go/node/p2p/compact_reconstruct_test.go
@@ -866,16 +866,10 @@ func TestCompactOversizedFallbackSkipsAlreadyStoredBlock(t *testing.T) {
 
 func TestCompactOversizedFallbackValidatesHeaderAndShape(t *testing.T) {
 	header, _, _ := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
-
-	p := newCompactScriptedPeer(t)
-	if err := p.requestOversizedCompactBlockFallback(nil); !errors.Is(err, errCmpctBlockShortIDCountTooLarge) || p.snapshotState().BanScore == 0 {
-		t.Fatalf("short oversized fallback err=%v state=%+v", err, p.snapshotState())
-	}
-
-	p = newCompactScriptedPeer(t)
 	tinyTarget := [32]byte{}
 	tinyTarget[31] = 0x01
 	powInvalidHeader := compactHeaderWithTarget(header, tinyTarget)
+	p := newCompactScriptedPeer(t)
 	if err := p.handleCmpctBlock(oversizedCmpctBlockShortIDPayload(powInvalidHeader)); err == nil || !strings.Contains(err.Error(), "pow invalid") || p.snapshotState().BanScore == 0 {
 		t.Fatalf("invalid oversized fallback header err=%v state=%+v", err, p.snapshotState())
 	}
@@ -922,7 +916,7 @@ func TestHandleCmpctBlockRejectsMalformedTailBeforeHeaderValidation(t *testing.T
 	}
 }
 
-func TestHandleCmpctBlockRejectsNonCanonicalPrefilledBeforeHeaderValidation(t *testing.T) {
+func TestHandleCmpctBlockValidatesHeaderBeforeNonCanonicalPrefilledDecode(t *testing.T) {
 	header, _, _ := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
 	tinyTarget := [32]byte{}
 	tinyTarget[31] = 0x01
@@ -931,11 +925,11 @@ func TestHandleCmpctBlockRejectsNonCanonicalPrefilledBeforeHeaderValidation(t *t
 
 	p := newCompactScriptedPeer(t)
 	err := p.handleCmpctBlock(payload)
-	if err == nil || !strings.Contains(err.Error(), "cmpctblock prefilled transaction is non-canonical") || p.snapshotState().BanScore == 0 {
-		t.Fatalf("non-canonical compact tail err=%v state=%+v", err, p.snapshotState())
+	if err == nil || !strings.Contains(err.Error(), "pow invalid") || p.snapshotState().BanScore == 0 {
+		t.Fatalf("non-canonical compact tail err=%v state=%+v, want header validation first", err, p.snapshotState())
 	}
-	if strings.Contains(p.snapshotState().LastError, "pow invalid") {
-		t.Fatalf("state=%+v, want non-canonical tail rejected before PoW", p.snapshotState())
+	if strings.Contains(p.snapshotState().LastError, "cmpctblock prefilled transaction is non-canonical") {
+		t.Fatalf("state=%+v, want structural preflight without transaction parse", p.snapshotState())
 	}
 	if p.conn.(*scriptedConn).Buffer.Len() != 0 {
 		t.Fatal("non-canonical compact tail sent fallback")

--- a/clients/go/node/p2p/compact_reconstruct_test.go
+++ b/clients/go/node/p2p/compact_reconstruct_test.go
@@ -433,7 +433,7 @@ func TestReconstructCompactBlockSkipsLocalLookupForPrefilledOnlyBlock(t *testing
 	}
 }
 
-func TestInternalHandleBlockTxnCompletesOutstandingBlock(t *testing.T) {
+func TestHandleBlockTxnMalformedAndLateResponses(t *testing.T) {
 	header, blockHash, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
 	p := newPeerRuntimeTestPeer(t)
 	if err := p.handleBlockTxn(nil); err == nil || !strings.Contains(err.Error(), "missing block hash") || p.snapshotState().BanScore == 0 {
@@ -441,14 +441,20 @@ func TestInternalHandleBlockTxnCompletesOutstandingBlock(t *testing.T) {
 	}
 
 	p = newPeerRuntimeTestPeer(t)
-	if err := p.handleBlockTxn(make([]byte, 32)); err == nil || !strings.Contains(err.Error(), "unexpected blocktxn response") || p.snapshotState().BanScore == 0 {
-		t.Fatalf("unexpected blocktxn err=%v state=%+v", err, p.snapshotState())
+	if err := p.handleBlockTxn(make([]byte, 32)); err != nil || p.snapshotState().BanScore != 0 || !strings.Contains(p.snapshotState().LastError, "ignored unexpected blocktxn") {
+		t.Fatalf("unexpected blocktxn err=%v state=%+v, want diagnostic without ban", err, p.snapshotState())
 	}
 
 	p = newCompactScriptedPeer(t)
 	setCompactTestOutstanding(p, blockHash, header, compactShortIDForTx(t, txs[0], 201, 202), 201, 202)
-	if err := p.handleBlockTxn(make([]byte, 32)); err == nil || !strings.Contains(err.Error(), "block hash mismatch") {
-		t.Fatalf("wrong hash blocktxn err=%v", err)
+	if err := p.handleBlockTxn(make([]byte, 32)); err != nil || p.snapshotState().BanScore != 0 || !strings.Contains(p.snapshotState().LastError, "ignored stale blocktxn") {
+		t.Fatalf("wrong hash blocktxn err=%v state=%+v, want stale diagnostic without ban", err, p.snapshotState())
+	}
+	if _, ok := p.compactOutstandingRequestSnapshot(); !ok {
+		t.Fatal("stale blocktxn response cleared active outstanding request")
+	}
+	if p.conn.(*scriptedConn).Buffer.Len() != 0 {
+		t.Fatal("stale blocktxn response sent fallback")
 	}
 
 	p = newCompactScriptedPeer(t)
@@ -460,8 +466,50 @@ func TestInternalHandleBlockTxnCompletesOutstandingBlock(t *testing.T) {
 	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
 		t.Fatal("malformed blocktxn did not clear matching outstanding request")
 	}
+}
 
-	p = newCompactScriptedPeer(t)
+func TestHandleBlockTxnStaleBodyDisconnectsWithoutBan(t *testing.T) {
+	header, blockHash, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
+	p := newCompactScriptedPeer(t)
+	setCompactTestOutstanding(p, blockHash, header, compactShortIDForTx(t, txs[0], 201, 202), 201, 202)
+	p.compact.outstanding.Transactions = [][]byte{txs[0]}
+	txAlias := p.compact.outstanding.Transactions[0]
+	stale := make([]byte, int(p.blockTxnPayloadCap()))
+	if err := p.handleBlockTxn(stale); err == nil || err.Error() != "stale blocktxn response has body" || p.snapshotState().BanScore != 0 {
+		t.Fatalf("near-cap stale blocktxn err=%v state=%+v, want no-ban disconnect", err, p.snapshotState())
+	}
+	if p.blockTxnPayloadCap() == 0 {
+		t.Fatal("near-cap stale blocktxn lost active blocktxn payload cap")
+	}
+	if &txs[0][0] != &txAlias[0] {
+		t.Fatal("near-cap stale blocktxn cloned outstanding transaction bytes")
+	}
+	if p.conn.(*scriptedConn).Buffer.Len() != 0 {
+		t.Fatal("near-cap stale blocktxn sent fallback")
+	}
+}
+
+func TestHandleBlockTxnMatchingPayloadCapOverflowBans(t *testing.T) {
+	header, blockHash, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
+	p := newCompactScriptedPeer(t)
+	setCompactTestOutstanding(p, blockHash, header, compactShortIDForTx(t, txs[0], 201, 202), 201, 202)
+	p.compact.outstanding.BlockTxnPayloadCap = 64
+	payload := append(blockHash[:], make([]byte, 33)...)
+	if err := p.handleBlockTxn(payload); err == nil || err.Error() != "blocktxn payload exceeds outstanding cap" {
+		t.Fatalf("handleBlockTxn err=%v, want outstanding cap error", err)
+	}
+	state := p.snapshotState()
+	if state.BanScore == 0 || !strings.Contains(state.LastError, "blocktxn payload exceeds outstanding cap") {
+		t.Fatalf("state=%+v, want outstanding cap ban", state)
+	}
+	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatal("matching payload cap overflow left outstanding request")
+	}
+}
+
+func TestInternalHandleBlockTxnCompletesOutstandingBlock(t *testing.T) {
+	header, blockHash, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
+	p := newCompactScriptedPeer(t)
 	setCompactTestOutstanding(p, blockHash, header, compactShortIDForTx(t, txs[0], 201, 202), 201, 202)
 	valid, err := encodeBlockTxnPayload(blockTxnPayload{BlockHash: blockHash, Transactions: [][]byte{txs[0]}})
 	requireNoCompactErr(t, err, "encode blocktxn")
@@ -561,6 +609,13 @@ func TestCompactProcessErrorEdges(t *testing.T) {
 	}
 	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
 		t.Fatal("hasBlock error did not clear matching compact outstanding request")
+	}
+
+	p = newCompactScriptedPeer(t)
+	p.service.cfg.BlockStore = nil
+	err := p.processCompactTransactions(blockHash, header, txs, true)
+	if err == nil || !strings.Contains(err.Error(), "nil blockstore") {
+		t.Fatalf("process compact transactions hasBlock err=%v, want nil blockstore", err)
 	}
 }
 
@@ -675,6 +730,7 @@ func TestRunRoutesOutstandingBlockTxn(t *testing.T) {
 	requireNoCompactErr(t, err, "encode blocktxn")
 	p := newPeerRuntimeTestPeer(t)
 	p.service.cfg.EnableCompactReceive = true
+	p.setRemoteCompactMode(compactModeSnapshot{Mode: 1, Version: compactRelayVersion})
 	setCompactTestOutstanding(p, blockHash, header, compactShortIDForTx(t, txs[0], 201, 202), 201, 202)
 	p.conn = &scriptedConn{reads: []scriptedRead{{data: mustPeerRuntimeFrameBytes(t, p, message{Command: messageBlockTxn, Payload: payload})}}}
 
@@ -684,6 +740,29 @@ func TestRunRoutesOutstandingBlockTxn(t *testing.T) {
 	}
 	if have, err := p.service.hasBlock(blockHash); err != nil || !have {
 		t.Fatalf("hasBlock=%v err=%v", have, err)
+	}
+}
+
+func TestRunRoutesOutstandingBlockTxnAfterCompactModeDisabled(t *testing.T) {
+	header, blockHash, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
+	payload, err := encodeBlockTxnPayload(blockTxnPayload{BlockHash: blockHash, Transactions: [][]byte{txs[0]}})
+	requireNoCompactErr(t, err, "encode blocktxn")
+	p := newPeerRuntimeTestPeer(t)
+	p.service.cfg.EnableCompactReceive = true
+	p.setRemoteCompactMode(compactModeSnapshot{Mode: 1, Version: compactRelayVersion})
+	setCompactTestOutstanding(p, blockHash, header, compactShortIDForTx(t, txs[0], 201, 202), 201, 202)
+	p.setRemoteCompactMode(compactModeSnapshot{Mode: 0, Version: compactRelayVersion})
+	p.conn = &scriptedConn{reads: []scriptedRead{{data: mustPeerRuntimeFrameBytes(t, p, message{Command: messageBlockTxn, Payload: payload})}}}
+
+	requireNoCompactErr(t, p.run(context.Background()), "run blocktxn after compact mode disabled")
+	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatal("outstanding request was not cleared")
+	}
+	if have, err := p.service.hasBlock(blockHash); err != nil || !have {
+		t.Fatalf("hasBlock=%v err=%v", have, err)
+	}
+	if state := p.snapshotState(); state.BanScore != 0 {
+		t.Fatalf("state=%+v, want no ban for valid outstanding blocktxn after mode 0", state)
 	}
 }
 
@@ -728,14 +807,95 @@ func TestInternalCompactReceiveMissingAndFallbackBranches(t *testing.T) {
 	}
 
 	p = newCompactScriptedPeer(t)
-	tooMany := mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{Header: header, ShortIDs: make([]compactShortID, maxCompactRelayEntries+1)})
+	tooMany := oversizedCmpctBlockShortIDPayload(header)
 	requireNoCompactErr(t, p.handleCmpctBlock(tooMany), "missing overflow fallback")
 	requireCompactFrame(t, p, messageGetData)
+
+	p = newCompactScriptedPeer(t)
+	truncatedTooMany := oversizedCmpctBlockShortIDCountPayload(header)
+	if err := p.handleCmpctBlock(truncatedTooMany); err == nil || !strings.Contains(err.Error(), "cmpctblock payload truncated short IDs") {
+		t.Fatalf("truncated oversized short IDs err=%v, want malformed truncated short IDs", err)
+	}
+	if p.conn.(*scriptedConn).Buffer.Len() != 0 {
+		t.Fatal("truncated oversized short IDs sent fallback")
+	}
 
 	p = newCompactScriptedPeer(t)
 	requireNoCompactErr(t, p.handleCmpctBlock(full), "prefilled compact block")
 	if have, err := p.service.hasBlock(blockHash); err != nil || !have {
 		t.Fatalf("hasBlock=%v err=%v", have, err)
+	}
+}
+
+func TestCompactOversizedFallbackSkipsAlreadyStoredBlock(t *testing.T) {
+	header, blockHash, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
+	p := newCompactScriptedPeer(t)
+	requireNoCompactErr(t, p.handleBlock(node.DevnetGenesisBlockBytes()), "seed existing block")
+	setCompactTestOutstanding(p, blockHash, header, compactShortIDForTx(t, txs[0], 901, 902), 901, 902)
+	requireNoCompactErr(t, p.handleCmpctBlock(oversizedCmpctBlockShortIDPayload(header)), "already-have oversized compact fallback")
+	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatal("already-have oversized compact fallback did not clear matching outstanding request")
+	}
+	if p.conn.(*scriptedConn).Buffer.Len() != 0 {
+		t.Fatal("already-have oversized compact fallback sent getdata")
+	}
+}
+
+func TestCompactOversizedFallbackValidatesHeaderAndShape(t *testing.T) {
+	header, _, _ := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
+
+	p := newCompactScriptedPeer(t)
+	if err := p.requestOversizedCompactBlockFallback(nil); !errors.Is(err, errCmpctBlockShortIDCountTooLarge) || p.snapshotState().BanScore == 0 {
+		t.Fatalf("short oversized fallback err=%v state=%+v", err, p.snapshotState())
+	}
+
+	p = newCompactScriptedPeer(t)
+	tinyTarget := [32]byte{}
+	tinyTarget[31] = 0x01
+	powInvalidHeader := compactHeaderWithTarget(header, tinyTarget)
+	if err := p.handleCmpctBlock(oversizedCmpctBlockShortIDPayload(powInvalidHeader)); err == nil || !strings.Contains(err.Error(), "pow invalid") || p.snapshotState().BanScore == 0 {
+		t.Fatalf("invalid oversized fallback header err=%v state=%+v", err, p.snapshotState())
+	}
+	if p.conn.(*scriptedConn).Buffer.Len() != 0 {
+		t.Fatal("invalid oversized compact header sent fallback")
+	}
+}
+
+func TestHandleCmpctBlockValidatesHeaderBeforeBlockstore(t *testing.T) {
+	header, _, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
+	tinyTarget := [32]byte{}
+	tinyTarget[31] = 0x01
+	powInvalidHeader := compactHeaderWithTarget(header, tinyTarget)
+	payload := mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{Header: powInvalidHeader, Prefilled: []prefilledTxn{{Index: 0, Tx: txs[0]}}})
+
+	p := newCompactScriptedPeer(t)
+	p.service.cfg.BlockStore = nil
+	err := p.handleCmpctBlock(payload)
+	if err == nil || !strings.Contains(err.Error(), "pow invalid") || p.snapshotState().BanScore == 0 {
+		t.Fatalf("pow-invalid compact header err=%v state=%+v", err, p.snapshotState())
+	}
+	if !strings.Contains(p.snapshotState().LastError, "pow invalid") {
+		t.Fatalf("state=%+v, want PoW failure before nil blockstore access", p.snapshotState())
+	}
+}
+
+func TestHandleCmpctBlockValidatesHeaderBeforeTailDecode(t *testing.T) {
+	header, _, _ := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
+	tinyTarget := [32]byte{}
+	tinyTarget[31] = 0x01
+	powInvalidHeader := compactHeaderWithTarget(header, tinyTarget)
+	payload := cmpctBlockMissingPrefilledTailPayload(powInvalidHeader, maxCompactRelayEntries)
+
+	p := newCompactScriptedPeer(t)
+	err := p.handleCmpctBlock(payload)
+	if err == nil || !strings.Contains(err.Error(), "pow invalid") || p.snapshotState().BanScore == 0 {
+		t.Fatalf("pow-invalid compact header err=%v state=%+v", err, p.snapshotState())
+	}
+	if strings.Contains(p.snapshotState().LastError, "truncated prefilled index") {
+		t.Fatalf("state=%+v, decoded compact tail before rejecting invalid header", p.snapshotState())
+	}
+	if p.conn.(*scriptedConn).Buffer.Len() != 0 {
+		t.Fatal("invalid compact header sent fallback")
 	}
 }
 
@@ -951,6 +1111,28 @@ func mustEncodeCmpctBlockPayload(t *testing.T, in cmpctBlockPayload) []byte {
 	raw, err := encodeCmpctBlockPayload(in)
 	requireNoCompactErr(t, err, "encode cmpctblock")
 	return raw
+}
+
+func oversizedCmpctBlockShortIDPayload(header [consensus.BLOCK_HEADER_BYTES]byte) []byte {
+	raw := oversizedCmpctBlockShortIDCountPayload(header)
+	raw = append(raw, make([]byte, (maxCompactRelayEntries+1)*compactShortIDBytes)...)
+	return consensus.AppendCompactSize(raw, 0)
+}
+
+func oversizedCmpctBlockShortIDCountPayload(header [consensus.BLOCK_HEADER_BYTES]byte) []byte {
+	raw := append([]byte(nil), header[:]...)
+	raw = consensus.AppendU64le(raw, 1)
+	raw = consensus.AppendU64le(raw, 2)
+	return consensus.AppendCompactSize(raw, maxCompactRelayEntries+1)
+}
+
+func cmpctBlockMissingPrefilledTailPayload(header [consensus.BLOCK_HEADER_BYTES]byte, shortCount int) []byte {
+	raw := append([]byte(nil), header[:]...)
+	raw = consensus.AppendU64le(raw, 1)
+	raw = consensus.AppendU64le(raw, 2)
+	raw = consensus.AppendCompactSize(raw, uint64(shortCount))
+	raw = append(raw, make([]byte, shortCount*compactShortIDBytes)...)
+	return consensus.AppendCompactSize(raw, 1)
 }
 
 func newCompactScriptedPeer(t *testing.T) *peer {

--- a/clients/go/node/p2p/compact_reconstruct_test.go
+++ b/clients/go/node/p2p/compact_reconstruct_test.go
@@ -433,7 +433,7 @@ func TestReconstructCompactBlockSkipsLocalLookupForPrefilledOnlyBlock(t *testing
 	}
 }
 
-func TestInternalHandleBlockTxnCompletesOutstandingBlock(t *testing.T) {
+func TestHandleBlockTxnMalformedAndLateResponses(t *testing.T) {
 	header, blockHash, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
 	p := newPeerRuntimeTestPeer(t)
 	if err := p.handleBlockTxn(nil); err == nil || !strings.Contains(err.Error(), "missing block hash") || p.snapshotState().BanScore == 0 {
@@ -441,14 +441,20 @@ func TestInternalHandleBlockTxnCompletesOutstandingBlock(t *testing.T) {
 	}
 
 	p = newPeerRuntimeTestPeer(t)
-	if err := p.handleBlockTxn(make([]byte, 32)); err == nil || !strings.Contains(err.Error(), "unexpected blocktxn response") || p.snapshotState().BanScore == 0 {
-		t.Fatalf("unexpected blocktxn err=%v state=%+v", err, p.snapshotState())
+	if err := p.handleBlockTxn(make([]byte, 32)); err != nil || p.snapshotState().BanScore != 0 || !strings.Contains(p.snapshotState().LastError, "ignored unexpected blocktxn") {
+		t.Fatalf("unexpected blocktxn err=%v state=%+v, want diagnostic without ban", err, p.snapshotState())
 	}
 
 	p = newCompactScriptedPeer(t)
 	setCompactTestOutstanding(p, blockHash, header, compactShortIDForTx(t, txs[0], 201, 202), 201, 202)
-	if err := p.handleBlockTxn(make([]byte, 32)); err == nil || !strings.Contains(err.Error(), "block hash mismatch") {
-		t.Fatalf("wrong hash blocktxn err=%v", err)
+	if err := p.handleBlockTxn(make([]byte, 32)); err != nil || p.snapshotState().BanScore != 0 || !strings.Contains(p.snapshotState().LastError, "ignored stale blocktxn") {
+		t.Fatalf("wrong hash blocktxn err=%v state=%+v, want stale diagnostic without ban", err, p.snapshotState())
+	}
+	if _, ok := p.compactOutstandingRequestSnapshot(); !ok {
+		t.Fatal("stale blocktxn response cleared active outstanding request")
+	}
+	if p.conn.(*scriptedConn).Buffer.Len() != 0 {
+		t.Fatal("stale blocktxn response sent fallback")
 	}
 
 	p = newCompactScriptedPeer(t)
@@ -460,8 +466,50 @@ func TestInternalHandleBlockTxnCompletesOutstandingBlock(t *testing.T) {
 	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
 		t.Fatal("malformed blocktxn did not clear matching outstanding request")
 	}
+}
 
-	p = newCompactScriptedPeer(t)
+func TestHandleBlockTxnStaleBodyDisconnectsWithoutBan(t *testing.T) {
+	header, blockHash, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
+	p := newCompactScriptedPeer(t)
+	setCompactTestOutstanding(p, blockHash, header, compactShortIDForTx(t, txs[0], 201, 202), 201, 202)
+	p.compact.outstanding.Transactions = [][]byte{txs[0]}
+	txAlias := p.compact.outstanding.Transactions[0]
+	stale := make([]byte, int(p.blockTxnPayloadCap()))
+	if err := p.handleBlockTxn(stale); err == nil || err.Error() != "stale blocktxn response has body" || p.snapshotState().BanScore != 0 {
+		t.Fatalf("near-cap stale blocktxn err=%v state=%+v, want no-ban disconnect", err, p.snapshotState())
+	}
+	if p.blockTxnPayloadCap() == 0 {
+		t.Fatal("near-cap stale blocktxn lost active blocktxn payload cap")
+	}
+	if &txs[0][0] != &txAlias[0] {
+		t.Fatal("near-cap stale blocktxn cloned outstanding transaction bytes")
+	}
+	if p.conn.(*scriptedConn).Buffer.Len() != 0 {
+		t.Fatal("near-cap stale blocktxn sent fallback")
+	}
+}
+
+func TestHandleBlockTxnMatchingPayloadCapOverflowBans(t *testing.T) {
+	header, blockHash, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
+	p := newCompactScriptedPeer(t)
+	setCompactTestOutstanding(p, blockHash, header, compactShortIDForTx(t, txs[0], 201, 202), 201, 202)
+	p.compact.outstanding.BlockTxnPayloadCap = 64
+	payload := append(blockHash[:], make([]byte, 33)...)
+	if err := p.handleBlockTxn(payload); err == nil || err.Error() != "blocktxn payload exceeds outstanding cap" {
+		t.Fatalf("handleBlockTxn err=%v, want outstanding cap error", err)
+	}
+	state := p.snapshotState()
+	if state.BanScore == 0 || !strings.Contains(state.LastError, "blocktxn payload exceeds outstanding cap") {
+		t.Fatalf("state=%+v, want outstanding cap ban", state)
+	}
+	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatal("matching payload cap overflow left outstanding request")
+	}
+}
+
+func TestInternalHandleBlockTxnCompletesOutstandingBlock(t *testing.T) {
+	header, blockHash, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
+	p := newCompactScriptedPeer(t)
 	setCompactTestOutstanding(p, blockHash, header, compactShortIDForTx(t, txs[0], 201, 202), 201, 202)
 	valid, err := encodeBlockTxnPayload(blockTxnPayload{BlockHash: blockHash, Transactions: [][]byte{txs[0]}})
 	requireNoCompactErr(t, err, "encode blocktxn")
@@ -561,6 +609,13 @@ func TestCompactProcessErrorEdges(t *testing.T) {
 	}
 	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
 		t.Fatal("hasBlock error did not clear matching compact outstanding request")
+	}
+
+	p = newCompactScriptedPeer(t)
+	p.service.cfg.BlockStore = nil
+	err := p.processCompactTransactions(blockHash, header, txs, true)
+	if err == nil || !strings.Contains(err.Error(), "nil blockstore") {
+		t.Fatalf("process compact transactions hasBlock err=%v, want nil blockstore", err)
 	}
 }
 
@@ -675,6 +730,7 @@ func TestRunRoutesOutstandingBlockTxn(t *testing.T) {
 	requireNoCompactErr(t, err, "encode blocktxn")
 	p := newPeerRuntimeTestPeer(t)
 	p.service.cfg.EnableCompactReceive = true
+	p.setRemoteCompactMode(compactModeSnapshot{Mode: 1, Version: compactRelayVersion})
 	setCompactTestOutstanding(p, blockHash, header, compactShortIDForTx(t, txs[0], 201, 202), 201, 202)
 	p.conn = &scriptedConn{reads: []scriptedRead{{data: mustPeerRuntimeFrameBytes(t, p, message{Command: messageBlockTxn, Payload: payload})}}}
 
@@ -684,6 +740,29 @@ func TestRunRoutesOutstandingBlockTxn(t *testing.T) {
 	}
 	if have, err := p.service.hasBlock(blockHash); err != nil || !have {
 		t.Fatalf("hasBlock=%v err=%v", have, err)
+	}
+}
+
+func TestRunRoutesOutstandingBlockTxnAfterCompactModeDisabled(t *testing.T) {
+	header, blockHash, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
+	payload, err := encodeBlockTxnPayload(blockTxnPayload{BlockHash: blockHash, Transactions: [][]byte{txs[0]}})
+	requireNoCompactErr(t, err, "encode blocktxn")
+	p := newPeerRuntimeTestPeer(t)
+	p.service.cfg.EnableCompactReceive = true
+	p.setRemoteCompactMode(compactModeSnapshot{Mode: 1, Version: compactRelayVersion})
+	setCompactTestOutstanding(p, blockHash, header, compactShortIDForTx(t, txs[0], 201, 202), 201, 202)
+	p.setRemoteCompactMode(compactModeSnapshot{Mode: 0, Version: compactRelayVersion})
+	p.conn = &scriptedConn{reads: []scriptedRead{{data: mustPeerRuntimeFrameBytes(t, p, message{Command: messageBlockTxn, Payload: payload})}}}
+
+	requireNoCompactErr(t, p.run(context.Background()), "run blocktxn after compact mode disabled")
+	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatal("outstanding request was not cleared")
+	}
+	if have, err := p.service.hasBlock(blockHash); err != nil || !have {
+		t.Fatalf("hasBlock=%v err=%v", have, err)
+	}
+	if state := p.snapshotState(); state.BanScore != 0 {
+		t.Fatalf("state=%+v, want no ban for valid outstanding blocktxn after mode 0", state)
 	}
 }
 
@@ -751,14 +830,115 @@ func TestInternalCompactReceiveMissingAndFallbackBranches(t *testing.T) {
 	}
 
 	p = newCompactScriptedPeer(t)
-	tooMany := mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{Header: header, ShortIDs: make([]compactShortID, maxCompactRelayEntries+1)})
+	tooMany := oversizedCmpctBlockShortIDPayload(header)
 	requireNoCompactErr(t, p.handleCmpctBlock(tooMany), "missing overflow fallback")
 	requireCompactFrame(t, p, messageGetData)
+
+	p = newCompactScriptedPeer(t)
+	truncatedTooMany := oversizedCmpctBlockShortIDCountPayload(header)
+	if err := p.handleCmpctBlock(truncatedTooMany); err == nil || !strings.Contains(err.Error(), "cmpctblock payload truncated short IDs") {
+		t.Fatalf("truncated oversized short IDs err=%v, want malformed truncated short IDs", err)
+	}
+	if p.conn.(*scriptedConn).Buffer.Len() != 0 {
+		t.Fatal("truncated oversized short IDs sent fallback")
+	}
 
 	p = newCompactScriptedPeer(t)
 	requireNoCompactErr(t, p.handleCmpctBlock(full), "prefilled compact block")
 	if have, err := p.service.hasBlock(blockHash); err != nil || !have {
 		t.Fatalf("hasBlock=%v err=%v", have, err)
+	}
+}
+
+func TestCompactOversizedFallbackSkipsAlreadyStoredBlock(t *testing.T) {
+	header, blockHash, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
+	p := newCompactScriptedPeer(t)
+	requireNoCompactErr(t, p.handleBlock(node.DevnetGenesisBlockBytes()), "seed existing block")
+	setCompactTestOutstanding(p, blockHash, header, compactShortIDForTx(t, txs[0], 901, 902), 901, 902)
+	requireNoCompactErr(t, p.handleCmpctBlock(oversizedCmpctBlockShortIDPayload(header)), "already-have oversized compact fallback")
+	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatal("already-have oversized compact fallback did not clear matching outstanding request")
+	}
+	if p.conn.(*scriptedConn).Buffer.Len() != 0 {
+		t.Fatal("already-have oversized compact fallback sent getdata")
+	}
+}
+
+func TestCompactOversizedFallbackValidatesHeaderAndShape(t *testing.T) {
+	header, _, _ := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
+
+	p := newCompactScriptedPeer(t)
+	if err := p.requestOversizedCompactBlockFallback(nil); !errors.Is(err, errCmpctBlockShortIDCountTooLarge) || p.snapshotState().BanScore == 0 {
+		t.Fatalf("short oversized fallback err=%v state=%+v", err, p.snapshotState())
+	}
+
+	p = newCompactScriptedPeer(t)
+	tinyTarget := [32]byte{}
+	tinyTarget[31] = 0x01
+	powInvalidHeader := compactHeaderWithTarget(header, tinyTarget)
+	if err := p.handleCmpctBlock(oversizedCmpctBlockShortIDPayload(powInvalidHeader)); err == nil || !strings.Contains(err.Error(), "pow invalid") || p.snapshotState().BanScore == 0 {
+		t.Fatalf("invalid oversized fallback header err=%v state=%+v", err, p.snapshotState())
+	}
+	if p.conn.(*scriptedConn).Buffer.Len() != 0 {
+		t.Fatal("invalid oversized compact header sent fallback")
+	}
+}
+
+func TestHandleCmpctBlockValidatesHeaderBeforeBlockstore(t *testing.T) {
+	header, _, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
+	tinyTarget := [32]byte{}
+	tinyTarget[31] = 0x01
+	powInvalidHeader := compactHeaderWithTarget(header, tinyTarget)
+	payload := mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{Header: powInvalidHeader, Prefilled: []prefilledTxn{{Index: 0, Tx: txs[0]}}})
+
+	p := newCompactScriptedPeer(t)
+	p.service.cfg.BlockStore = nil
+	err := p.handleCmpctBlock(payload)
+	if err == nil || !strings.Contains(err.Error(), "pow invalid") || p.snapshotState().BanScore == 0 {
+		t.Fatalf("pow-invalid compact header err=%v state=%+v", err, p.snapshotState())
+	}
+	if !strings.Contains(p.snapshotState().LastError, "pow invalid") {
+		t.Fatalf("state=%+v, want PoW failure before nil blockstore access", p.snapshotState())
+	}
+}
+
+func TestHandleCmpctBlockRejectsMalformedTailBeforeHeaderValidation(t *testing.T) {
+	header, _, _ := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
+	tinyTarget := [32]byte{}
+	tinyTarget[31] = 0x01
+	powInvalidHeader := compactHeaderWithTarget(header, tinyTarget)
+	payload := cmpctBlockMissingPrefilledTailPayload(powInvalidHeader, maxCompactRelayEntries)
+
+	p := newCompactScriptedPeer(t)
+	err := p.handleCmpctBlock(payload)
+	if err == nil || !strings.Contains(err.Error(), "cmpctblock payload truncated prefilled index") || p.snapshotState().BanScore == 0 {
+		t.Fatalf("malformed compact tail err=%v state=%+v", err, p.snapshotState())
+	}
+	if strings.Contains(p.snapshotState().LastError, "pow invalid") {
+		t.Fatalf("state=%+v, want malformed shape rejected before PoW", p.snapshotState())
+	}
+	if p.conn.(*scriptedConn).Buffer.Len() != 0 {
+		t.Fatal("malformed compact tail sent fallback")
+	}
+}
+
+func TestHandleCmpctBlockRejectsNonCanonicalPrefilledBeforeHeaderValidation(t *testing.T) {
+	header, _, _ := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
+	tinyTarget := [32]byte{}
+	tinyTarget[31] = 0x01
+	powInvalidHeader := compactHeaderWithTarget(header, tinyTarget)
+	payload := cmpctBlockNonCanonicalPrefilledPayload(powInvalidHeader, append(minimalBlockTxnTestTxBytes(77), 0x00))
+
+	p := newCompactScriptedPeer(t)
+	err := p.handleCmpctBlock(payload)
+	if err == nil || !strings.Contains(err.Error(), "cmpctblock prefilled transaction is non-canonical") || p.snapshotState().BanScore == 0 {
+		t.Fatalf("non-canonical compact tail err=%v state=%+v", err, p.snapshotState())
+	}
+	if strings.Contains(p.snapshotState().LastError, "pow invalid") {
+		t.Fatalf("state=%+v, want non-canonical tail rejected before PoW", p.snapshotState())
+	}
+	if p.conn.(*scriptedConn).Buffer.Len() != 0 {
+		t.Fatal("non-canonical compact tail sent fallback")
 	}
 }
 
@@ -996,6 +1176,39 @@ func mustEncodeCmpctBlockPayload(t *testing.T, in cmpctBlockPayload) []byte {
 	raw, err := encodeCmpctBlockPayload(in)
 	requireNoCompactErr(t, err, "encode cmpctblock")
 	return raw
+}
+
+func oversizedCmpctBlockShortIDPayload(header [consensus.BLOCK_HEADER_BYTES]byte) []byte {
+	raw := oversizedCmpctBlockShortIDCountPayload(header)
+	raw = append(raw, make([]byte, (maxCompactRelayEntries+1)*compactShortIDBytes)...)
+	return consensus.AppendCompactSize(raw, 0)
+}
+
+func oversizedCmpctBlockShortIDCountPayload(header [consensus.BLOCK_HEADER_BYTES]byte) []byte {
+	raw := append([]byte(nil), header[:]...)
+	raw = consensus.AppendU64le(raw, 1)
+	raw = consensus.AppendU64le(raw, 2)
+	return consensus.AppendCompactSize(raw, maxCompactRelayEntries+1)
+}
+
+func cmpctBlockMissingPrefilledTailPayload(header [consensus.BLOCK_HEADER_BYTES]byte, shortCount int) []byte {
+	raw := append([]byte(nil), header[:]...)
+	raw = consensus.AppendU64le(raw, 1)
+	raw = consensus.AppendU64le(raw, 2)
+	raw = consensus.AppendCompactSize(raw, uint64(shortCount))
+	raw = append(raw, make([]byte, shortCount*compactShortIDBytes)...)
+	return consensus.AppendCompactSize(raw, 1)
+}
+
+func cmpctBlockNonCanonicalPrefilledPayload(header [consensus.BLOCK_HEADER_BYTES]byte, tx []byte) []byte {
+	raw := append([]byte(nil), header[:]...)
+	raw = consensus.AppendU64le(raw, 1)
+	raw = consensus.AppendU64le(raw, 2)
+	raw = consensus.AppendCompactSize(raw, 0)
+	raw = consensus.AppendCompactSize(raw, 1)
+	raw = consensus.AppendU32le(raw, 0)
+	raw = consensus.AppendCompactSize(raw, uint64(len(tx)))
+	return append(raw, tx...)
 }
 
 func newCompactScriptedPeer(t *testing.T) *peer {

--- a/clients/go/node/p2p/compact_runtime.go
+++ b/clients/go/node/p2p/compact_runtime.go
@@ -111,6 +111,19 @@ func (p *peer) compactOutstandingRequestSnapshot() (compactOutstandingRequest, b
 	return cloneCompactOutstandingRequest(req), true
 }
 
+func (p *peer) compactOutstandingBlockHash() ([32]byte, bool) {
+	p.compactMu.Lock()
+	defer p.compactMu.Unlock()
+	if p.compact.outstanding == nil {
+		return [32]byte{}, false
+	}
+	if p.compactOutstandingRequestExpiredLocked() {
+		p.compact.outstanding = nil
+		return [32]byte{}, false
+	}
+	return p.compact.outstanding.BlockHash, true
+}
+
 func (p *peer) popCompactOutstandingRequest() (compactOutstandingRequest, bool) {
 	p.compactMu.Lock()
 	if p.compact.outstanding == nil {
@@ -134,6 +147,12 @@ func (p *peer) clearCompactOutstandingRequestForBlock(blockHash [32]byte) {
 	if p.compact.outstanding != nil && p.compact.outstanding.BlockHash == blockHash {
 		p.compact.outstanding = nil
 	}
+	p.compactMu.Unlock()
+}
+
+func (p *peer) clearCompactOutstandingRequest() {
+	p.compactMu.Lock()
+	p.compact.outstanding = nil
 	p.compactMu.Unlock()
 }
 

--- a/clients/go/node/p2p/compact_wire.go
+++ b/clients/go/node/p2p/compact_wire.go
@@ -21,6 +21,8 @@ const (
 	maxCompactRelayIndexValue        = consensus.MAX_BLOCK_BYTES - 1
 )
 
+var errCmpctBlockShortIDCountTooLarge = errors.New("too many cmpctblock short IDs")
+
 type sendCmpctPayload struct {
 	Mode    uint8
 	Version uint64
@@ -274,34 +276,67 @@ func decodeCmpctBlockPrefix(payload []byte) (cmpctBlockPayload, uint64, uint64, 
 	if err != nil {
 		return cmpctBlockPayload{}, 0, 0, 0, errors.New("invalid compact relay entry count")
 	}
+	prefilledOffset := shortIDEnd + consumed
+	if shortCount > maxCompactRelayEntries {
+		if err := validateCmpctBlockPrefilledTail(payload, prefilledOffset, prefilledCount, totalEntries); err != nil {
+			return cmpctBlockPayload{}, 0, 0, 0, err
+		}
+		return cmpctBlockPayload{}, 0, 0, 0, errCmpctBlockShortIDCountTooLarge
+	}
 	out.ShortIDs = make([]compactShortID, 0, int(shortCount)) // #nosec G115 -- totalEntries is capped above.
 	for ; offset < shortIDEnd; offset += compactShortIDBytes {
 		var shortID compactShortID
 		copy(shortID[:], payload[offset:offset+compactShortIDBytes])
 		out.ShortIDs = append(out.ShortIDs, shortID)
 	}
-	return out, prefilledCount, totalEntries, shortIDEnd + consumed, nil
+	return out, prefilledCount, totalEntries, prefilledOffset, nil
 }
 
 func decodeCmpctBlockPrefilled(payload []byte, offset int, entryPos, prev, totalEntries, totalTxBytes uint64) (prefilledTxn, int, uint64, error) {
+	idx, tx, nextOffset, nextTotal, err := parseCmpctBlockPrefilled(payload, offset, entryPos, prev, totalEntries, totalTxBytes)
+	if err != nil {
+		return prefilledTxn{}, 0, totalTxBytes, err
+	}
+	return prefilledTxn{Index: idx, Tx: append([]byte(nil), tx...)}, nextOffset, nextTotal, nil
+}
+
+func validateCmpctBlockPrefilledTail(payload []byte, offset int, prefilledCount, totalEntries uint64) error {
+	var prev uint64
+	var totalTxBytes uint64
+	for i := uint64(0); i < prefilledCount; i++ {
+		idx, _, nextOffset, nextTotal, err := parseCmpctBlockPrefilled(payload, offset, i, prev, totalEntries, totalTxBytes)
+		if err != nil {
+			return err
+		}
+		offset = nextOffset
+		prev = idx
+		totalTxBytes = nextTotal
+	}
+	if offset != len(payload) {
+		return errors.New("cmpctblock payload has trailing bytes")
+	}
+	return nil
+}
+
+func parseCmpctBlockPrefilled(payload []byte, offset int, entryPos, prev, totalEntries, totalTxBytes uint64) (uint64, []byte, int, uint64, error) {
 	if len(payload[offset:]) < compactRelayIndexBytes {
-		return prefilledTxn{}, 0, totalTxBytes, errors.New("cmpctblock payload truncated prefilled index")
+		return 0, nil, 0, totalTxBytes, errors.New("cmpctblock payload truncated prefilled index")
 	}
 	idx := uint64(binary.LittleEndian.Uint32(payload[offset:]))
 	offset += compactRelayIndexBytes
 	if (entryPos > 0 && idx <= prev) || idx >= totalEntries {
-		return prefilledTxn{}, 0, totalTxBytes, errors.New("compact relay index out of range")
+		return 0, nil, 0, totalTxBytes, errors.New("compact relay index out of range")
 	}
 	txLen, n, err := consensus.DecodeCompactSize(payload[offset:])
 	if err != nil {
-		return prefilledTxn{}, 0, totalTxBytes, err
+		return 0, nil, 0, totalTxBytes, err
 	}
 	offset += n
 	tx, _, txConsumed, nextTotal, err := decodeCompactRelayTxEnvelope(payload[offset:], txLen, totalTxBytes, "cmpctblock prefilled transaction is non-canonical")
 	if err != nil {
-		return prefilledTxn{}, 0, totalTxBytes, err
+		return 0, nil, 0, totalTxBytes, err
 	}
-	return prefilledTxn{Index: idx, Tx: append([]byte(nil), tx...)}, offset + txConsumed, nextTotal, nil
+	return idx, tx, offset + txConsumed, nextTotal, nil
 }
 
 func validateBlockTxnTransactionSize(txLen, totalTxBytes uint64) (uint64, error) {

--- a/clients/go/node/p2p/compact_wire.go
+++ b/clients/go/node/p2p/compact_wire.go
@@ -21,6 +21,8 @@ const (
 	maxCompactRelayIndexValue        = consensus.MAX_BLOCK_BYTES - 1
 )
 
+var errCmpctBlockShortIDCountTooLarge = errors.New("too many cmpctblock short IDs")
+
 type sendCmpctPayload struct {
 	Mode    uint8
 	Version uint64
@@ -274,34 +276,101 @@ func decodeCmpctBlockPrefix(payload []byte) (cmpctBlockPayload, uint64, uint64, 
 	if err != nil {
 		return cmpctBlockPayload{}, 0, 0, 0, errors.New("invalid compact relay entry count")
 	}
+	prefilledOffset := shortIDEnd + consumed
+	if shortCount > maxCompactRelayEntries {
+		if err := validateCmpctBlockPrefilledTail(payload, prefilledOffset, prefilledCount, totalEntries); err != nil {
+			return cmpctBlockPayload{}, 0, 0, 0, err
+		}
+		return cmpctBlockPayload{}, 0, 0, 0, errCmpctBlockShortIDCountTooLarge
+	}
 	out.ShortIDs = make([]compactShortID, 0, int(shortCount)) // #nosec G115 -- totalEntries is capped above.
 	for ; offset < shortIDEnd; offset += compactShortIDBytes {
 		var shortID compactShortID
 		copy(shortID[:], payload[offset:offset+compactShortIDBytes])
 		out.ShortIDs = append(out.ShortIDs, shortID)
 	}
-	return out, prefilledCount, totalEntries, shortIDEnd + consumed, nil
+	return out, prefilledCount, totalEntries, prefilledOffset, nil
+}
+
+func cmpctBlockHeaderValidationCandidate(payload []byte) ([consensus.BLOCK_HEADER_BYTES]byte, bool) {
+	var header [consensus.BLOCK_HEADER_BYTES]byte
+	if !hasCmpctBlockHeaderValidationShape(payload) {
+		return header, false
+	}
+	copy(header[:], payload[:consensus.BLOCK_HEADER_BYTES])
+	return header, true
+}
+
+func hasCmpctBlockHeaderValidationShape(payload []byte) bool {
+	if len(payload) < consensus.BLOCK_HEADER_BYTES+16 {
+		return false
+	}
+	offset := consensus.BLOCK_HEADER_BYTES + 16
+	shortCount, consumed, err := consensus.DecodeCompactSize(payload[offset:])
+	if err != nil {
+		return false
+	}
+	offset += consumed
+	if shortCount > uint64(len(payload[offset:]))/compactShortIDBytes {
+		return false
+	}
+	shortIDEnd := offset + int(shortCount)*compactShortIDBytes // #nosec G115 -- shortCount is bounded by the remaining payload width above.
+	prefilledCount, consumed, err := consensus.DecodeCompactSize(payload[shortIDEnd:])
+	if err != nil {
+		return false
+	}
+	totalEntries, err := validateCmpctBlockEntryCount(shortCount, prefilledCount)
+	if err != nil {
+		return false
+	}
+	return validateCmpctBlockPrefilledTail(payload, shortIDEnd+consumed, prefilledCount, totalEntries) == nil
 }
 
 func decodeCmpctBlockPrefilled(payload []byte, offset int, entryPos, prev, totalEntries, totalTxBytes uint64) (prefilledTxn, int, uint64, error) {
+	idx, tx, nextOffset, nextTotal, err := parseCmpctBlockPrefilled(payload, offset, entryPos, prev, totalEntries, totalTxBytes)
+	if err != nil {
+		return prefilledTxn{}, 0, totalTxBytes, err
+	}
+	return prefilledTxn{Index: idx, Tx: append([]byte(nil), tx...)}, nextOffset, nextTotal, nil
+}
+
+func validateCmpctBlockPrefilledTail(payload []byte, offset int, prefilledCount, totalEntries uint64) error {
+	var prev uint64
+	var totalTxBytes uint64
+	for i := uint64(0); i < prefilledCount; i++ {
+		idx, _, nextOffset, nextTotal, err := parseCmpctBlockPrefilled(payload, offset, i, prev, totalEntries, totalTxBytes)
+		if err != nil {
+			return err
+		}
+		offset = nextOffset
+		prev = idx
+		totalTxBytes = nextTotal
+	}
+	if offset != len(payload) {
+		return errors.New("cmpctblock payload has trailing bytes")
+	}
+	return nil
+}
+
+func parseCmpctBlockPrefilled(payload []byte, offset int, entryPos, prev, totalEntries, totalTxBytes uint64) (uint64, []byte, int, uint64, error) {
 	if len(payload[offset:]) < compactRelayIndexBytes {
-		return prefilledTxn{}, 0, totalTxBytes, errors.New("cmpctblock payload truncated prefilled index")
+		return 0, nil, 0, totalTxBytes, errors.New("cmpctblock payload truncated prefilled index")
 	}
 	idx := uint64(binary.LittleEndian.Uint32(payload[offset:]))
 	offset += compactRelayIndexBytes
 	if (entryPos > 0 && idx <= prev) || idx >= totalEntries {
-		return prefilledTxn{}, 0, totalTxBytes, errors.New("compact relay index out of range")
+		return 0, nil, 0, totalTxBytes, errors.New("compact relay index out of range")
 	}
 	txLen, n, err := consensus.DecodeCompactSize(payload[offset:])
 	if err != nil {
-		return prefilledTxn{}, 0, totalTxBytes, err
+		return 0, nil, 0, totalTxBytes, err
 	}
 	offset += n
 	tx, _, txConsumed, nextTotal, err := decodeCompactRelayTxEnvelope(payload[offset:], txLen, totalTxBytes, "cmpctblock prefilled transaction is non-canonical")
 	if err != nil {
-		return prefilledTxn{}, 0, totalTxBytes, err
+		return 0, nil, 0, totalTxBytes, err
 	}
-	return prefilledTxn{Index: idx, Tx: append([]byte(nil), tx...)}, offset + txConsumed, nextTotal, nil
+	return idx, tx, offset + txConsumed, nextTotal, nil
 }
 
 func validateBlockTxnTransactionSize(txLen, totalTxBytes uint64) (uint64, error) {

--- a/clients/go/node/p2p/compact_wire.go
+++ b/clients/go/node/p2p/compact_wire.go
@@ -21,8 +21,6 @@ const (
 	maxCompactRelayIndexValue        = consensus.MAX_BLOCK_BYTES - 1
 )
 
-var errCmpctBlockShortIDCountTooLarge = errors.New("too many cmpctblock short IDs")
-
 type sendCmpctPayload struct {
 	Mode    uint8
 	Version uint64
@@ -276,20 +274,13 @@ func decodeCmpctBlockPrefix(payload []byte) (cmpctBlockPayload, uint64, uint64, 
 	if err != nil {
 		return cmpctBlockPayload{}, 0, 0, 0, errors.New("invalid compact relay entry count")
 	}
-	prefilledOffset := shortIDEnd + consumed
-	if shortCount > maxCompactRelayEntries {
-		if err := validateCmpctBlockPrefilledTail(payload, prefilledOffset, prefilledCount, totalEntries); err != nil {
-			return cmpctBlockPayload{}, 0, 0, 0, err
-		}
-		return cmpctBlockPayload{}, 0, 0, 0, errCmpctBlockShortIDCountTooLarge
-	}
 	out.ShortIDs = make([]compactShortID, 0, int(shortCount)) // #nosec G115 -- totalEntries is capped above.
 	for ; offset < shortIDEnd; offset += compactShortIDBytes {
 		var shortID compactShortID
 		copy(shortID[:], payload[offset:offset+compactShortIDBytes])
 		out.ShortIDs = append(out.ShortIDs, shortID)
 	}
-	return out, prefilledCount, totalEntries, prefilledOffset, nil
+	return out, prefilledCount, totalEntries, shortIDEnd + consumed, nil
 }
 
 func cmpctBlockHeaderValidationCandidate(payload []byte) ([consensus.BLOCK_HEADER_BYTES]byte, bool) {
@@ -323,7 +314,7 @@ func hasCmpctBlockHeaderValidationShape(payload []byte) bool {
 	if err != nil {
 		return false
 	}
-	return validateCmpctBlockPrefilledTail(payload, shortIDEnd+consumed, prefilledCount, totalEntries) == nil
+	return validateCmpctBlockPrefilledShape(payload, shortIDEnd+consumed, prefilledCount, totalEntries) == nil
 }
 
 func decodeCmpctBlockPrefilled(payload []byte, offset int, entryPos, prev, totalEntries, totalTxBytes uint64) (prefilledTxn, int, uint64, error) {
@@ -334,11 +325,11 @@ func decodeCmpctBlockPrefilled(payload []byte, offset int, entryPos, prev, total
 	return prefilledTxn{Index: idx, Tx: append([]byte(nil), tx...)}, nextOffset, nextTotal, nil
 }
 
-func validateCmpctBlockPrefilledTail(payload []byte, offset int, prefilledCount, totalEntries uint64) error {
+func validateCmpctBlockPrefilledShape(payload []byte, offset int, prefilledCount, totalEntries uint64) error {
 	var prev uint64
 	var totalTxBytes uint64
 	for i := uint64(0); i < prefilledCount; i++ {
-		idx, _, nextOffset, nextTotal, err := parseCmpctBlockPrefilled(payload, offset, i, prev, totalEntries, totalTxBytes)
+		idx, nextOffset, nextTotal, err := scanCmpctBlockPrefilledShape(payload, offset, i, prev, totalEntries, totalTxBytes)
 		if err != nil {
 			return err
 		}
@@ -350,6 +341,30 @@ func validateCmpctBlockPrefilledTail(payload []byte, offset int, prefilledCount,
 		return errors.New("cmpctblock payload has trailing bytes")
 	}
 	return nil
+}
+
+func scanCmpctBlockPrefilledShape(payload []byte, offset int, entryPos, prev, totalEntries, totalTxBytes uint64) (uint64, int, uint64, error) {
+	if len(payload[offset:]) < compactRelayIndexBytes {
+		return 0, 0, totalTxBytes, errors.New("cmpctblock payload truncated prefilled index")
+	}
+	idx := uint64(binary.LittleEndian.Uint32(payload[offset:]))
+	offset += compactRelayIndexBytes
+	if (entryPos > 0 && idx <= prev) || idx >= totalEntries {
+		return 0, 0, totalTxBytes, errors.New("compact relay index out of range")
+	}
+	txLen, n, err := consensus.DecodeCompactSize(payload[offset:])
+	if err != nil {
+		return 0, 0, totalTxBytes, err
+	}
+	offset += n
+	if txLen > uint64(len(payload[offset:])) {
+		return 0, 0, totalTxBytes, errors.New("compact relay transaction truncated")
+	}
+	nextTotal, err := validateBlockTxnTransactionSize(txLen, totalTxBytes)
+	if err != nil {
+		return 0, 0, totalTxBytes, err
+	}
+	return idx, offset + int(txLen), nextTotal, nil // #nosec G115 -- txLen is bounded by len(payload[offset:]) above.
 }
 
 func parseCmpctBlockPrefilled(payload []byte, offset int, entryPos, prev, totalEntries, totalTxBytes uint64) (uint64, []byte, int, uint64, error) {

--- a/clients/go/node/p2p/compact_wire_test.go
+++ b/clients/go/node/p2p/compact_wire_test.go
@@ -130,7 +130,14 @@ func TestCmpctBlockPayloadCodec(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cmpctblock roundtrip got=%+v want=%+v", got, want)
 	}
-	assertCmpctBlockEncodeFails(t, "short_id_count_too_large", cmpctBlockPayload{ShortIDs: make([]compactShortID, maxCompactRelayEntries+1)}, "too many cmpctblock short IDs")
+	shortIDs := make([]compactShortID, maxCompactRelayEntries+1)
+	raw, err = encodeCmpctBlockPayload(cmpctBlockPayload{ShortIDs: shortIDs})
+	if err != nil {
+		t.Fatalf("encodeCmpctBlockPayload above inventory vector limit: %v", err)
+	}
+	if got, err := decodeCmpctBlockPayload(raw); err != nil || len(got.ShortIDs) != len(shortIDs) {
+		t.Fatalf("decode above inventory vector limit got=%d err=%v", len(got.ShortIDs), err)
+	}
 }
 
 func TestCmpctBlockPayloadCapAllowsManyPrefilledBlocks(t *testing.T) {
@@ -165,15 +172,8 @@ func TestCmpctBlockPayloadRejectsMalformed(t *testing.T) {
 	assertCmpctBlockDecodeFails(t, "short_header", make([]byte, consensus.BLOCK_HEADER_BYTES+15), "cmpctblock payload missing header or nonce")
 	assertCmpctBlockDecodeFails(t, "empty", cmpctBlockTestPayload([]byte{0, 0}), "invalid compact relay entry count")
 	assertCmpctBlockDecodeFails(t, "payload_above_wire_cap", make([]byte, consensus.MAX_RELAY_MSG_BYTES+1), "cmpctblock payload too large")
-	assertCmpctBlockDecodeFails(t, "short_id_count_too_large_before_allocation", oversizedCmpctBlockShortIDPayload([consensus.BLOCK_HEADER_BYTES]byte{}), "too many cmpctblock short IDs")
 	assertCmpctBlockDecodeFails(t, "short_id_count_too_large_truncated", oversizedCmpctBlockShortIDCountPayload([consensus.BLOCK_HEADER_BYTES]byte{}), "cmpctblock payload truncated short IDs")
 	assertCmpctBlockDecodeFails(t, "short_id_count_too_large_trailing_tail", append(oversizedCmpctBlockShortIDPayload([consensus.BLOCK_HEADER_BYTES]byte{}), 0x00), "cmpctblock payload has trailing bytes")
-	oversizedWithValidPrefilled := oversizedCmpctBlockShortIDCountPayload([consensus.BLOCK_HEADER_BYTES]byte{})
-	oversizedWithValidPrefilled = append(oversizedWithValidPrefilled, make([]byte, (maxCompactRelayEntries+1)*compactShortIDBytes)...)
-	oversizedWithValidPrefilled = consensus.AppendCompactSize(oversizedWithValidPrefilled, 1)
-	oversizedWithValidPrefilled = consensus.AppendU32le(oversizedWithValidPrefilled, 0)
-	oversizedWithValidPrefilled = append(oversizedWithValidPrefilled, cmpctBlockTxEnvelope(validTx)...)
-	assertCmpctBlockDecodeFails(t, "short_id_count_too_large_valid_prefilled_tail", oversizedWithValidPrefilled, "too many cmpctblock short IDs")
 	assertCmpctBlockDecodeFails(t, "nonminimal_short_count", cmpctBlockTestPayload([]byte{0xfd, 0x00, 0x00}), "non-minimal")
 	assertCmpctBlockDecodeFails(t, "truncated_short_ids", cmpctBlockTestPayload([]byte{1, 0x01, 0x02}), "cmpctblock payload truncated short IDs")
 	assertCmpctBlockDecodeFails(t, "nonminimal_prefilled_count", cmpctBlockTestPayload([]byte{0, 0xfd, 0x00, 0x00}), "non-minimal")

--- a/clients/go/node/p2p/compact_wire_test.go
+++ b/clients/go/node/p2p/compact_wire_test.go
@@ -130,13 +130,25 @@ func TestCmpctBlockPayloadCodec(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cmpctblock roundtrip got=%+v want=%+v", got, want)
 	}
-	shortIDs := make([]compactShortID, maxCompactRelayEntries+1)
-	raw, err = encodeCmpctBlockPayload(cmpctBlockPayload{ShortIDs: shortIDs})
-	if err != nil {
-		t.Fatalf("encodeCmpctBlockPayload above inventory vector limit: %v", err)
+	assertCmpctBlockEncodeFails(t, "short_id_count_too_large", cmpctBlockPayload{ShortIDs: make([]compactShortID, maxCompactRelayEntries+1)}, "too many cmpctblock short IDs")
+}
+
+func TestCmpctBlockPayloadCapAllowsManyPrefilledBlocks(t *testing.T) {
+	const txLen = 1024
+	txCount := (uint64(consensus.MAX_BLOCK_BYTES) - consensus.BLOCK_HEADER_BYTES - uint64(maxCompactSizeBytes)) / txLen
+	for compactFullBlockLenForTest(txCount+1, txLen) <= uint64(consensus.MAX_BLOCK_BYTES) {
+		txCount++
 	}
-	if got, err := decodeCmpctBlockPayload(raw); err != nil || len(got.ShortIDs) != len(shortIDs) {
-		t.Fatalf("decode above inventory vector limit got=%d err=%v", len(got.ShortIDs), err)
+	for compactFullBlockLenForTest(txCount, txLen) > uint64(consensus.MAX_BLOCK_BYTES) {
+		txCount--
+	}
+
+	compactLen := cmpctBlockAllPrefilledLenForTest(txCount, txLen)
+	if compactLen <= uint64(consensus.MAX_BLOCK_BYTES) {
+		t.Fatalf("all-prefilled cmpctblock len=%d, want above MAX_BLOCK_BYTES=%d", compactLen, consensus.MAX_BLOCK_BYTES)
+	}
+	if compactLen > uint64(compactRelayPayloadCap(messageCmpctBlock)) {
+		t.Fatalf("all-prefilled cmpctblock len=%d exceeds cmpctblock cap=%d", compactLen, compactRelayPayloadCap(messageCmpctBlock))
 	}
 }
 
@@ -153,6 +165,15 @@ func TestCmpctBlockPayloadRejectsMalformed(t *testing.T) {
 	assertCmpctBlockDecodeFails(t, "short_header", make([]byte, consensus.BLOCK_HEADER_BYTES+15), "cmpctblock payload missing header or nonce")
 	assertCmpctBlockDecodeFails(t, "empty", cmpctBlockTestPayload([]byte{0, 0}), "invalid compact relay entry count")
 	assertCmpctBlockDecodeFails(t, "payload_above_wire_cap", make([]byte, consensus.MAX_RELAY_MSG_BYTES+1), "cmpctblock payload too large")
+	assertCmpctBlockDecodeFails(t, "short_id_count_too_large_before_allocation", oversizedCmpctBlockShortIDPayload([consensus.BLOCK_HEADER_BYTES]byte{}), "too many cmpctblock short IDs")
+	assertCmpctBlockDecodeFails(t, "short_id_count_too_large_truncated", oversizedCmpctBlockShortIDCountPayload([consensus.BLOCK_HEADER_BYTES]byte{}), "cmpctblock payload truncated short IDs")
+	assertCmpctBlockDecodeFails(t, "short_id_count_too_large_trailing_tail", append(oversizedCmpctBlockShortIDPayload([consensus.BLOCK_HEADER_BYTES]byte{}), 0x00), "cmpctblock payload has trailing bytes")
+	oversizedWithValidPrefilled := oversizedCmpctBlockShortIDCountPayload([consensus.BLOCK_HEADER_BYTES]byte{})
+	oversizedWithValidPrefilled = append(oversizedWithValidPrefilled, make([]byte, (maxCompactRelayEntries+1)*compactShortIDBytes)...)
+	oversizedWithValidPrefilled = consensus.AppendCompactSize(oversizedWithValidPrefilled, 1)
+	oversizedWithValidPrefilled = consensus.AppendU32le(oversizedWithValidPrefilled, 0)
+	oversizedWithValidPrefilled = append(oversizedWithValidPrefilled, cmpctBlockTxEnvelope(validTx)...)
+	assertCmpctBlockDecodeFails(t, "short_id_count_too_large_valid_prefilled_tail", oversizedWithValidPrefilled, "too many cmpctblock short IDs")
 	assertCmpctBlockDecodeFails(t, "nonminimal_short_count", cmpctBlockTestPayload([]byte{0xfd, 0x00, 0x00}), "non-minimal")
 	assertCmpctBlockDecodeFails(t, "truncated_short_ids", cmpctBlockTestPayload([]byte{1, 0x01, 0x02}), "cmpctblock payload truncated short IDs")
 	assertCmpctBlockDecodeFails(t, "nonminimal_prefilled_count", cmpctBlockTestPayload([]byte{0, 0xfd, 0x00, 0x00}), "non-minimal")
@@ -170,6 +191,16 @@ func TestCmpctBlockPayloadRejectsMalformed(t *testing.T) {
 	rangeBeforeTx := consensus.AppendU32le(consensus.AppendCompactSize(consensus.AppendCompactSize(nil, 0), 1), 1)
 	assertCmpctBlockDecodeFails(t, "prefilled_index_range_before_tx", cmpctBlockTestPayload(rangeBeforeTx), "compact relay index out of range")
 	assertCmpctBlockDecodeFails(t, "trailing", append(cmpctBlockTestPayload([]byte{1, 0, 0, 0, 0, 0, 0, 0}), 0x00), "cmpctblock payload has trailing bytes")
+}
+
+func compactFullBlockLenForTest(txCount, txLen uint64) uint64 {
+	return consensus.BLOCK_HEADER_BYTES + uint64(len(consensus.EncodeCompactSize(txCount))) + txCount*txLen
+}
+
+func cmpctBlockAllPrefilledLenForTest(txCount, txLen uint64) uint64 {
+	indexWidth := uint64(compactRelayIndexBytes)
+	entryLen := indexWidth + uint64(maxCompactSizeBytes) + txLen
+	return consensus.BLOCK_HEADER_BYTES + 16 + uint64(len(consensus.EncodeCompactSize(0))) + uint64(len(consensus.EncodeCompactSize(txCount))) + txCount*entryLen
 }
 
 func TestBlockTxnPayloadRejectsMalformed(t *testing.T) {

--- a/clients/go/node/p2p/peer_runtime.go
+++ b/clients/go/node/p2p/peer_runtime.go
@@ -52,11 +52,35 @@ func (p *peer) run(ctx context.Context) error {
 func (p *peer) postHandshakePayloadCap() payloadLimitFn {
 	base := postHandshakePayloadCap(p.service.cfg.LocatorLimit, p.service.cfg.SyncConfig.HeaderBatchLimit)
 	return func(command string) uint32 {
-		if isCompactRelayObjectCommand(command) {
+		switch command {
+		case messageCmpctBlock:
+			if p.acceptsCompactBlocks() {
+				return compactRelayPayloadCap(command)
+			}
 			return 0
+		case messageBlockTxn:
+			if p.compactReceiveEnabled() {
+				return p.blockTxnPayloadCap()
+			}
+			return 0
+		case messageGetBlockTxn:
+			return 0
+		default:
+			return base(command)
 		}
-		return base(command)
 	}
+}
+
+func (p *peer) compactReceiveEnabled() bool {
+	return p != nil && p.service != nil && p.service.cfg.EnableCompactReceive
+}
+
+func (p *peer) acceptsCompactBlocks() bool {
+	if !p.compactReceiveEnabled() {
+		return false
+	}
+	mode := p.remoteCompactMode()
+	return mode.Version == compactRelayVersion && mode.Mode != 0
 }
 
 func peerRunContextDone(ctx context.Context) bool {
@@ -94,7 +118,7 @@ func normalizeReadError(err error) error {
 
 func (p *peer) handleMessage(frame message) error {
 	switch frame.Command {
-	case messageInv, messageGetData, messageBlock, messageTx, messageGetBlk:
+	case messageInv, messageGetData, messageBlock, messageTx, messageGetBlk, messageCmpctBlock, messageBlockTxn:
 		return p.handleRelayMessage(frame)
 	case messageSendCmpct:
 		return p.handleSendCmpct(frame.Payload)
@@ -115,7 +139,7 @@ func (p *peer) handleRelayMessage(frame message) error {
 	switch frame.Command {
 	case messageInv, messageGetData:
 		return p.handleInventoryRelayMessage(frame)
-	case messageBlock, messageTx, messageGetBlk:
+	case messageBlock, messageTx, messageGetBlk, messageCmpctBlock, messageBlockTxn:
 		return p.handleObjectRelayMessage(frame)
 	default:
 		return postHandshakeUnknownCommandError{command: frame.Command}
@@ -141,6 +165,16 @@ func (p *peer) handleObjectRelayMessage(frame message) error {
 		return p.handleTx(frame.Payload)
 	case messageGetBlk:
 		return p.handleGetBlocks(frame.Payload)
+	case messageCmpctBlock:
+		if !p.acceptsCompactBlocks() {
+			return postHandshakeUnknownCommandError{command: frame.Command}
+		}
+		return p.handleCmpctBlock(frame.Payload)
+	case messageBlockTxn:
+		if !p.compactReceiveEnabled() {
+			return postHandshakeUnknownCommandError{command: frame.Command}
+		}
+		return p.handleBlockTxn(frame.Payload)
 	default:
 		return postHandshakeUnknownCommandError{command: frame.Command}
 	}

--- a/clients/go/node/p2p/peer_runtime.go
+++ b/clients/go/node/p2p/peer_runtime.go
@@ -31,12 +31,7 @@ func (p *peer) run(ctx context.Context) error {
 		if err := p.setReadDeadline(); err != nil {
 			return err
 		}
-		frame, err := readFrameWithPayloadLimit(
-			p.conn,
-			networkMagic(p.service.cfg.PeerRuntimeConfig.Network),
-			p.service.cfg.PeerRuntimeConfig.MaxMessageSize,
-			p.postHandshakePayloadCap(),
-		)
+		frame, err := p.readPostHandshakeFrame()
 		if err != nil {
 			if shouldIgnoreReadError(err) {
 				continue
@@ -49,6 +44,77 @@ func (p *peer) run(ctx context.Context) error {
 	}
 }
 
+const blockTxnHashPayloadBytes = 32
+
+func (p *peer) readPostHandshakeFrame() (message, error) {
+	var frame message
+	header, err := readFrameHeader(
+		p.conn,
+		networkMagic(p.service.cfg.PeerRuntimeConfig.Network),
+		p.service.cfg.PeerRuntimeConfig.MaxMessageSize,
+	)
+	if err != nil {
+		return frame, err
+	}
+	if header.Command == messageBlockTxn && p.acceptsBlockTxnResponses() {
+		return p.readBlockTxnFrame(header)
+	}
+	limit := p.postHandshakePayloadCap()
+	if header.Size > limit(header.Command) {
+		return frame, commandPayloadCapError{command: header.Command}
+	}
+	payload, err := readPayloadWithChecksum(p.conn, header.Size, header.Checksum)
+	if err != nil {
+		return frame, err
+	}
+	return message{Command: header.Command, Payload: payload}, nil
+}
+
+func (p *peer) readBlockTxnFrame(header frameHeader) (message, error) {
+	cap := p.blockTxnPayloadCap()
+	if cap == 0 {
+		return p.readUnexpectedBlockTxnFrame(header)
+	}
+	if header.Size > cap {
+		if stale, err := p.readOversizedBlockTxnStaleHash(header); err != nil || stale {
+			return message{}, err
+		}
+		return message{}, commandPayloadCapError{command: header.Command}
+	}
+	return p.readFullCommandFramePayload(header)
+}
+
+func (p *peer) readOversizedBlockTxnStaleHash(header frameHeader) (bool, error) {
+	if header.Size <= blockTxnHashPayloadBytes {
+		return false, nil
+	}
+	var responseHash [32]byte
+	n, err := io.ReadFull(p.conn, responseHash[:])
+	if err != nil {
+		return false, payloadReadError(header.Size, 0, n, err)
+	}
+	blockHash, ok := p.compactOutstandingBlockHash()
+	if !ok || responseHash != blockHash {
+		return true, errors.New("stale blocktxn response has body")
+	}
+	return false, nil
+}
+
+func (p *peer) readUnexpectedBlockTxnFrame(header frameHeader) (message, error) {
+	if header.Size > blockTxnHashPayloadBytes {
+		return message{}, commandPayloadCapError{command: header.Command}
+	}
+	return p.readFullCommandFramePayload(header)
+}
+
+func (p *peer) readFullCommandFramePayload(header frameHeader) (message, error) {
+	payload, err := readPayloadWithChecksum(p.conn, header.Size, header.Checksum)
+	if err != nil {
+		return message{}, err
+	}
+	return message{Command: header.Command, Payload: payload}, nil
+}
+
 func (p *peer) postHandshakePayloadCap() payloadLimitFn {
 	base := postHandshakePayloadCap(p.service.cfg.LocatorLimit, p.service.cfg.SyncConfig.HeaderBatchLimit)
 	return func(command string) uint32 {
@@ -59,8 +125,14 @@ func (p *peer) postHandshakePayloadCap() payloadLimitFn {
 			}
 			return 0
 		case messageBlockTxn:
-			if p.compactReceiveEnabled() {
-				return p.blockTxnPayloadCap()
+			if !p.compactReceiveEnabled() {
+				return 0
+			}
+			if cap := p.blockTxnPayloadCap(); cap != 0 {
+				return cap
+			}
+			if p.acceptsCompactBlocks() {
+				return blockTxnHashPayloadBytes
 			}
 			return 0
 		case messageGetBlockTxn:
@@ -81,6 +153,13 @@ func (p *peer) acceptsCompactBlocks() bool {
 	}
 	mode := p.remoteCompactMode()
 	return mode.Version == compactRelayVersion && mode.Mode != 0
+}
+
+func (p *peer) acceptsBlockTxnResponses() bool {
+	if !p.compactReceiveEnabled() {
+		return false
+	}
+	return p.acceptsCompactBlocks() || p.blockTxnPayloadCap() != 0
 }
 
 func peerRunContextDone(ctx context.Context) bool {
@@ -171,7 +250,7 @@ func (p *peer) handleObjectRelayMessage(frame message) error {
 		}
 		return p.handleCmpctBlock(frame.Payload)
 	case messageBlockTxn:
-		if !p.compactReceiveEnabled() {
+		if !p.acceptsBlockTxnResponses() {
 			return postHandshakeUnknownCommandError{command: frame.Command}
 		}
 		return p.handleBlockTxn(frame.Payload)
@@ -243,8 +322,7 @@ func (p *peer) applyPostHandshakeDisconnectError(err error) {
 	if err == nil {
 		return
 	}
-	if reason, ok := compactBlockTxnCapPolicyReason(err); ok {
-		p.bumpBan(10, reason)
+	if p.applyBlockTxnCapDisconnect(err) {
 		return
 	}
 	if reason, ok := unknownCommandPolicyReason(err); ok {
@@ -258,11 +336,27 @@ func (p *peer) applyPostHandshakeDisconnectError(err error) {
 	p.setLastError(err.Error())
 }
 
-func compactBlockTxnCapPolicyReason(err error) (string, bool) {
-	if command, ok := capErrorCommand(err); ok && command == messageBlockTxn {
-		return "unexpected blocktxn", true
+func (p *peer) applyBlockTxnCapDisconnect(err error) bool {
+	var commandCapErr commandPayloadCapError
+	if errors.As(err, &commandCapErr) && commandCapErr.command == messageBlockTxn {
+		if p.blockTxnPayloadCap() == 0 {
+			p.setLastError("unexpected blocktxn")
+			return true
+		}
+		p.clearCompactOutstandingRequest()
+		p.bumpBan(10, "blocktxn payload exceeds outstanding cap")
+		return true
 	}
-	return "", false
+	var messageCapErr inboundMessagePayloadCapError
+	if errors.As(err, &messageCapErr) && messageCapErr.command == messageBlockTxn {
+		if p.blockTxnPayloadCap() == 0 {
+			p.setLastError("unexpected blocktxn")
+			return true
+		}
+		p.setLastError("message exceeds cap: blocktxn")
+		return true
+	}
+	return false
 }
 
 func payloadCapDiagnosticReason(err error) (string, bool) {

--- a/clients/go/node/p2p/peer_runtime_test.go
+++ b/clients/go/node/p2p/peer_runtime_test.go
@@ -107,6 +107,32 @@ func TestCompactObjectCapsStayClosedUntilParityReceiveExists(t *testing.T) {
 	}
 }
 
+func TestCompactObjectCapsOpenOnlyForEnabledNegotiatedReceive(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	p.service.cfg.EnableCompactReceive = true
+	limiter := p.postHandshakePayloadCap()
+	for _, command := range []string{messageCmpctBlock, messageGetBlockTxn, messageBlockTxn} {
+		if got := limiter(command); got != 0 {
+			t.Fatalf("pre-negotiation %s cap=%d, want 0", command, got)
+		}
+	}
+
+	p.setRemoteCompactMode(compactModeSnapshot{Mode: 1, Version: compactRelayVersion})
+	if got := limiter(messageCmpctBlock); got != compactRelayPayloadCap(messageCmpctBlock) {
+		t.Fatalf("negotiated cmpctblock cap=%d, want %d", got, compactRelayPayloadCap(messageCmpctBlock))
+	}
+	if got := limiter(messageGetBlockTxn); got != 0 {
+		t.Fatalf("inbound getblocktxn cap=%d, want closed until responder exists", got)
+	}
+	if got := limiter(messageBlockTxn); got != 0 {
+		t.Fatalf("blocktxn cap without outstanding=%d, want 0", got)
+	}
+	p.setCompactOutstandingRequest(compactOutstandingRequest{BlockTxnPayloadCap: 64})
+	if got := limiter(messageBlockTxn); got != 64 {
+		t.Fatalf("blocktxn cap with outstanding=%d, want 64", got)
+	}
+}
+
 func TestBlockTxnPayloadCapIsOutstandingBounded(t *testing.T) {
 	p := newPeerRuntimeTestPeer(t)
 	if got := p.blockTxnPayloadCap(); got != 0 {

--- a/clients/go/node/p2p/peer_runtime_test.go
+++ b/clients/go/node/p2p/peer_runtime_test.go
@@ -118,18 +118,25 @@ func TestCompactObjectCapsOpenOnlyForEnabledNegotiatedReceive(t *testing.T) {
 	}
 
 	p.setRemoteCompactMode(compactModeSnapshot{Mode: 1, Version: compactRelayVersion})
-	if got := limiter(messageCmpctBlock); got != compactRelayPayloadCap(messageCmpctBlock) {
-		t.Fatalf("negotiated cmpctblock cap=%d, want %d", got, compactRelayPayloadCap(messageCmpctBlock))
+	if got := limiter(messageCmpctBlock); got != uint32(consensus.MAX_RELAY_MSG_BYTES) {
+		t.Fatalf("negotiated cmpctblock cap=%d, want %d", got, consensus.MAX_RELAY_MSG_BYTES)
 	}
 	if got := limiter(messageGetBlockTxn); got != 0 {
 		t.Fatalf("inbound getblocktxn cap=%d, want closed until responder exists", got)
 	}
-	if got := limiter(messageBlockTxn); got != 0 {
-		t.Fatalf("blocktxn cap without outstanding=%d, want 0", got)
+	if got := limiter(messageBlockTxn); got != blockTxnHashPayloadBytes {
+		t.Fatalf("blocktxn cap without outstanding=%d, want hash-only cap %d", got, blockTxnHashPayloadBytes)
 	}
 	p.setCompactOutstandingRequest(compactOutstandingRequest{BlockTxnPayloadCap: 64})
 	if got := limiter(messageBlockTxn); got != 64 {
 		t.Fatalf("blocktxn cap with outstanding=%d, want 64", got)
+	}
+	p.setRemoteCompactMode(compactModeSnapshot{Mode: 0, Version: compactRelayVersion})
+	if got := limiter(messageCmpctBlock); got != 0 {
+		t.Fatalf("disabled cmpctblock cap=%d, want 0", got)
+	}
+	if got := limiter(messageBlockTxn); got != 64 {
+		t.Fatalf("disabled-mode blocktxn cap with outstanding=%d, want 64", got)
 	}
 }
 
@@ -188,6 +195,11 @@ func TestCompactOutstandingRequestUsesDedicatedTTL(t *testing.T) {
 	}
 	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
 		t.Fatal("expired outstanding request was not cleared")
+	}
+	p.activateCompactOutstandingRequest(compactOutstandingTestRequest([32]byte{0x12}))
+	now = now.Add(compactOutstandingRequestTTL)
+	if _, ok := p.compactOutstandingBlockHash(); ok {
+		t.Fatal("expired outstanding block hash remained visible")
 	}
 }
 
@@ -395,7 +407,7 @@ func compactOutstandingTestRequest(blockHash [32]byte) compactOutstandingRequest
 	}
 }
 
-func TestRunBansUnexpectedBlockTxnCommandCap(t *testing.T) {
+func TestRunDoesNotBanUnexpectedBlockTxnCommandCap(t *testing.T) {
 	p := newPeerRuntimeTestPeer(t)
 	p.conn = &scriptedConn{reads: []scriptedRead{{
 		data: mustPeerRuntimeFrameBytes(t, p, message{Command: messageBlockTxn, Payload: make([]byte, 33)}),
@@ -406,12 +418,65 @@ func TestRunBansUnexpectedBlockTxnCommandCap(t *testing.T) {
 	}
 	p.applyPostHandshakeDisconnectError(err)
 	state := p.snapshotState()
-	if state.BanScore == 0 || !strings.Contains(state.LastError, "unexpected blocktxn") {
-		t.Fatalf("state=%+v, want unexpected blocktxn ban", state)
+	if state.BanScore != 0 || !strings.Contains(state.LastError, "unexpected blocktxn") {
+		t.Fatalf("state=%+v, want unexpected blocktxn diagnostic without ban", state)
 	}
 }
 
-func TestRunBansUnexpectedBlockTxnMessageCap(t *testing.T) {
+func TestRunIgnoresUnexpectedBlockTxnAfterCompactNegotiation(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	p.service.cfg.EnableCompactReceive = true
+	p.setRemoteCompactMode(compactModeSnapshot{Mode: 1, Version: compactRelayVersion})
+	p.conn = &scriptedConn{reads: []scriptedRead{{
+		data: mustPeerRuntimeFrameBytes(t, p, message{Command: messageBlockTxn, Payload: make([]byte, blockTxnHashPayloadBytes)}),
+	}}}
+	if err := p.run(context.Background()); err != nil {
+		t.Fatalf("run unexpected blocktxn: %v", err)
+	}
+	state := p.snapshotState()
+	if state.BanScore != 0 || !strings.Contains(state.LastError, "ignored unexpected blocktxn") {
+		t.Fatalf("state=%+v, want ignored unexpected blocktxn without ban", state)
+	}
+}
+
+func TestRunCapsUnexpectedBlockTxnBodyAfterCompactNegotiation(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	p.service.cfg.EnableCompactReceive = true
+	p.setRemoteCompactMode(compactModeSnapshot{Mode: 1, Version: compactRelayVersion})
+	p.conn = &scriptedConn{reads: []scriptedRead{{
+		data: mustPeerRuntimeFrameBytes(t, p, message{Command: messageBlockTxn, Payload: make([]byte, blockTxnHashPayloadBytes+1)}),
+	}}}
+	err := p.run(context.Background())
+	if err == nil || err.Error() != "message exceeds command cap" {
+		t.Fatalf("run err=%v, want command cap error", err)
+	}
+	p.applyPostHandshakeDisconnectError(err)
+	state := p.snapshotState()
+	if state.BanScore != 0 || !strings.Contains(state.LastError, "unexpected blocktxn") {
+		t.Fatalf("state=%+v, want unexpected blocktxn diagnostic without ban", state)
+	}
+}
+
+func TestRunPropagatesUnexpectedBlockTxnChecksumFailure(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	p.service.cfg.EnableCompactReceive = true
+	p.setRemoteCompactMode(compactModeSnapshot{Mode: 1, Version: compactRelayVersion})
+	payload := make([]byte, blockTxnHashPayloadBytes)
+	header, err := buildEnvelopeHeader(networkMagic(p.service.cfg.PeerRuntimeConfig.Network), messageBlockTxn, payload)
+	if err != nil {
+		t.Fatalf("buildEnvelopeHeader: %v", err)
+	}
+	header[20] ^= 0xff
+	p.conn = &scriptedConn{reads: []scriptedRead{{
+		data: append(header[:], payload...),
+	}}}
+	err = p.run(context.Background())
+	if err == nil || err.Error() != "invalid envelope checksum" {
+		t.Fatalf("run err=%v, want invalid envelope checksum", err)
+	}
+}
+
+func TestRunDoesNotBanUnexpectedBlockTxnMessageCap(t *testing.T) {
 	p := newPeerRuntimeTestPeer(t)
 	p.service.cfg.PeerRuntimeConfig.MaxMessageSize = 1
 	header, err := buildEnvelopeHeader(
@@ -430,8 +495,171 @@ func TestRunBansUnexpectedBlockTxnMessageCap(t *testing.T) {
 	}
 	p.applyPostHandshakeDisconnectError(err)
 	state := p.snapshotState()
-	if state.BanScore == 0 || !strings.Contains(state.LastError, "unexpected blocktxn") {
-		t.Fatalf("state=%+v, want unexpected blocktxn ban", state)
+	if state.BanScore != 0 || !strings.Contains(state.LastError, "unexpected blocktxn") {
+		t.Fatalf("state=%+v, want unexpected blocktxn diagnostic without ban", state)
+	}
+}
+
+func TestRunDoesNotClearActiveBlockTxnOnGlobalMessageCap(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	p.service.cfg.EnableCompactReceive = true
+	p.service.cfg.PeerRuntimeConfig.MaxMessageSize = 1
+	blockHash := [32]byte{0x62}
+	p.setRemoteCompactMode(compactModeSnapshot{Mode: 1, Version: compactRelayVersion})
+	p.setCompactOutstandingRequest(compactOutstandingTestRequest(blockHash))
+	header, err := buildEnvelopeHeader(
+		networkMagic(p.service.cfg.PeerRuntimeConfig.Network),
+		messageBlockTxn,
+		append(blockHash[:], 0x01),
+	)
+	if err != nil {
+		t.Fatalf("buildEnvelopeHeader: %v", err)
+	}
+	p.conn = &scriptedConn{reads: []scriptedRead{{data: header[:]}}}
+
+	err = p.run(context.Background())
+	if err == nil || err.Error() != "message exceeds cap" {
+		t.Fatalf("run err=%v, want message cap error", err)
+	}
+	p.applyPostHandshakeDisconnectError(err)
+	state := p.snapshotState()
+	if state.BanScore != 0 || !strings.Contains(state.LastError, "message exceeds cap: blocktxn") {
+		t.Fatalf("state=%+v, want global cap disconnect without ban", state)
+	}
+	if p.blockTxnPayloadCap() == 0 {
+		t.Fatal("global cap disconnect cleared unclassified active outstanding request")
+	}
+}
+
+func TestRunBansShortOverCapBlockTxn(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	p.service.cfg.EnableCompactReceive = true
+	blockHash := [32]byte{0x65}
+	p.setRemoteCompactMode(compactModeSnapshot{Mode: 1, Version: compactRelayVersion})
+	p.setCompactOutstandingRequest(compactOutstandingRequest{BlockHash: blockHash, BlockTxnPayloadCap: 16})
+	payload := blockHash[:17]
+	p.conn = &scriptedConn{reads: []scriptedRead{{
+		data: mustPeerRuntimeFrameBytes(t, p, message{Command: messageBlockTxn, Payload: payload}),
+	}}}
+	err := p.run(context.Background())
+	if err == nil || err.Error() != "message exceeds command cap" {
+		t.Fatalf("run err=%v, want command cap error", err)
+	}
+	p.applyPostHandshakeDisconnectError(err)
+	state := p.snapshotState()
+	if state.BanScore == 0 || !strings.Contains(state.LastError, "blocktxn payload exceeds outstanding cap") {
+		t.Fatalf("state=%+v, want outstanding cap ban", state)
+	}
+	if p.blockTxnPayloadCap() != 0 {
+		t.Fatal("short over-cap blocktxn left outstanding request")
+	}
+}
+
+func TestRunRejectsOversizedBlockTxnBeforeChecksum(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	p.service.cfg.EnableCompactReceive = true
+	blockHash := [32]byte{0x64}
+	p.setRemoteCompactMode(compactModeSnapshot{Mode: 1, Version: compactRelayVersion})
+	p.setCompactOutstandingRequest(compactOutstandingTestRequest(blockHash))
+	payload := append(blockHash[:], make([]byte, 33)...)
+	header, err := buildEnvelopeHeader(networkMagic(p.service.cfg.PeerRuntimeConfig.Network), messageBlockTxn, payload)
+	if err != nil {
+		t.Fatalf("buildEnvelopeHeader: %v", err)
+	}
+	header[20] ^= 0xff
+	p.conn = &scriptedConn{reads: []scriptedRead{{
+		data: append(header[:], payload...),
+	}}}
+	err = p.run(context.Background())
+	if err == nil || err.Error() != "message exceeds command cap" {
+		t.Fatalf("run err=%v, want command cap error", err)
+	}
+}
+
+func TestRunDisconnectsOversizedStaleBlockTxnWithoutBan(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	p.service.cfg.EnableCompactReceive = true
+	activeHash := [32]byte{0x66}
+	staleHash := [32]byte{0x77}
+	p.setRemoteCompactMode(compactModeSnapshot{Mode: 1, Version: compactRelayVersion})
+	p.setCompactOutstandingRequest(compactOutstandingTestRequest(activeHash))
+	payload := append(staleHash[:], make([]byte, 33)...)
+	p.conn = &scriptedConn{reads: []scriptedRead{{
+		data: mustPeerRuntimeFrameBytes(t, p, message{Command: messageBlockTxn, Payload: payload}),
+	}}}
+	err := p.run(context.Background())
+	if err == nil || err.Error() != "stale blocktxn response has body" {
+		t.Fatalf("run err=%v, want stale blocktxn response has body", err)
+	}
+	p.applyPostHandshakeDisconnectError(err)
+	state := p.snapshotState()
+	if state.BanScore != 0 || !strings.Contains(state.LastError, "stale blocktxn response has body") {
+		t.Fatalf("state=%+v, want stale body disconnect without ban", state)
+	}
+	if p.blockTxnPayloadCap() == 0 {
+		t.Fatal("oversized stale blocktxn cleared active outstanding request")
+	}
+}
+
+func TestRunDisconnectsStaleBlockTxnBodyWithoutBan(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	p.service.cfg.EnableCompactReceive = true
+	activeHash := [32]byte{0x68}
+	staleHash := [32]byte{0x78}
+	p.setRemoteCompactMode(compactModeSnapshot{Mode: 1, Version: compactRelayVersion})
+	p.setCompactOutstandingRequest(compactOutstandingTestRequest(activeHash))
+	payload := append(staleHash[:], 0x01)
+	p.conn = &scriptedConn{reads: []scriptedRead{{
+		data: mustPeerRuntimeFrameBytes(t, p, message{Command: messageBlockTxn, Payload: payload}),
+	}}}
+	err := p.run(context.Background())
+	if err == nil || err.Error() != "stale blocktxn response has body" {
+		t.Fatalf("run err=%v, want stale blocktxn response has body", err)
+	}
+	p.applyPostHandshakeDisconnectError(err)
+	state := p.snapshotState()
+	if state.BanScore != 0 || !strings.Contains(state.LastError, "stale blocktxn response has body") {
+		t.Fatalf("state=%+v, want stale body disconnect without ban", state)
+	}
+	if p.blockTxnPayloadCap() == 0 {
+		t.Fatal("stale body disconnect cleared active outstanding request")
+	}
+}
+
+func TestApplyBlockTxnCapDisconnectBansActiveCommandCap(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	p.setCompactOutstandingRequest(compactOutstandingTestRequest([32]byte{0x63}))
+	p.applyPostHandshakeDisconnectError(commandPayloadCapError{command: messageBlockTxn})
+	state := p.snapshotState()
+	if state.BanScore == 0 || !strings.Contains(state.LastError, "blocktxn payload exceeds outstanding cap") {
+		t.Fatalf("state=%+v, want active command cap ban", state)
+	}
+	if p.blockTxnPayloadCap() != 0 {
+		t.Fatal("active command cap error left outstanding request")
+	}
+}
+
+func TestRunBansActiveBlockTxnCapOverflow(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	p.service.cfg.EnableCompactReceive = true
+	blockHash := [32]byte{0x66}
+	p.setRemoteCompactMode(compactModeSnapshot{Mode: 1, Version: compactRelayVersion})
+	p.setCompactOutstandingRequest(compactOutstandingTestRequest(blockHash))
+	payload := append(blockHash[:], make([]byte, 33)...)
+	p.conn = &scriptedConn{reads: []scriptedRead{{
+		data: mustPeerRuntimeFrameBytes(t, p, message{Command: messageBlockTxn, Payload: payload}),
+	}}}
+	err := p.run(context.Background())
+	if err == nil || err.Error() != "message exceeds command cap" {
+		t.Fatalf("run err=%v, want command cap error", err)
+	}
+	p.applyPostHandshakeDisconnectError(err)
+	state := p.snapshotState()
+	if state.BanScore == 0 || !strings.Contains(state.LastError, "blocktxn payload exceeds outstanding cap") {
+		t.Fatalf("state=%+v, want active blocktxn cap overflow ban", state)
+	}
+	if p.blockTxnPayloadCap() != 0 {
+		t.Fatal("active blocktxn cap overflow left dynamic blocktxn cap open")
 	}
 }
 
@@ -522,6 +750,17 @@ func TestHandleMessageRejectsInvalidKinds(t *testing.T) {
 	}
 	if err := p.handleMessage(message{Command: "unknown"}); err == nil || !strings.Contains(err.Error(), "unknown message type") {
 		t.Fatalf("expected unknown-kind rejection, got %v", err)
+	}
+}
+
+func TestHandleObjectRelayMessageKeepsCompactObjectsClosed(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	for _, command := range []string{messageCmpctBlock, messageBlockTxn} {
+		err := p.handleObjectRelayMessage(message{Command: command})
+		var unknown postHandshakeUnknownCommandError
+		if !errors.As(err, &unknown) || unknown.command != command {
+			t.Fatalf("%s err=%v, want unknown command while compact receive is closed", command, err)
+		}
 	}
 }
 

--- a/clients/go/node/p2p/service.go
+++ b/clients/go/node/p2p/service.go
@@ -27,14 +27,17 @@ type ServiceConfig struct {
 	LocatorLimit       int
 	GetBlocksBatchSize uint64
 	TxRelayFanout      int
-	PeerRuntimeConfig  node.PeerRuntimeConfig
-	PeerManager        *node.PeerManager
-	SyncConfig         node.SyncConfig
-	SyncEngine         *node.SyncEngine
-	BlockStore         *node.BlockStore
-	TxPool             TxPool
-	TxMetadataFunc     func([]byte) (node.RelayTxMetadata, error)
-	Now                func() time.Time
+	// EnableCompactReceive opens Go compact object receive after negotiated sendcmpct.
+	// It defaults false until the controller/parity boundary explicitly enables it.
+	EnableCompactReceive bool
+	PeerRuntimeConfig    node.PeerRuntimeConfig
+	PeerManager          *node.PeerManager
+	SyncConfig           node.SyncConfig
+	SyncEngine           *node.SyncEngine
+	BlockStore           *node.BlockStore
+	TxPool               TxPool
+	TxMetadataFunc       func([]byte) (node.RelayTxMetadata, error)
+	Now                  func() time.Time
 }
 
 type Service struct {


### PR DESCRIPTION
Invariant:
Compact receive blocktxn handling must preserve active outstanding requests across benign mode churn and stale responses while bounding oversized current-response payloads before full-body reads.

Layer:
Go P2P runtime implementation and tests.

Files changed:
- clients/go/node/p2p/compact_reconstruct.go
- clients/go/node/p2p/compact_reconstruct_test.go
- clients/go/node/p2p/compact_runtime.go
- clients/go/node/p2p/compact_wire.go
- clients/go/node/p2p/compact_wire_test.go
- clients/go/node/p2p/peer_runtime.go
- clients/go/node/p2p/peer_runtime_test.go

Tests:
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node/p2p -count=1' — PASS\n- rubin-precommit-one-review --base-ref origin/codex/RUB-343-01-compact-apply-core --include-base-diff — PASS\n- stock one-review on origin/codex/RUB-343-01-compact-apply-core...HEAD — No findings.\n- rubin-stack-codacy-coverage.sh via rubin-push — PASS; variation +0.00%, diff coverage 93.97%.\n\nBehavior impact:\nAdds bounded compact blocktxn receive handling for negotiated compact receive. Active getblocktxn responses remain valid after remote sendcmpct mode 0. Hash-only stale responses stay peer-neutral, stale responses with bodies disconnect without ban, oversized stale bodies are classified by the response hash before active-cap handling, and unclassified global MaxMessageSize cap errors do not clear active compact state.\n\nCompatibility impact:\nGo-only stacked child PR. No Rust, consensus, conformance, generated artifact, or activation change.\n\nKnown non-goals:\n- Rust parity implementation.\n- Consensus or conformance changes.\n- Coverage-script changes.\n- Follow-up blocktxn review fixes, split into the next child PR.\n\nRisk:\nThe changed ingress remains behind EnableCompactReceive and compact relay negotiation or an already active outstanding request. Current-response over-cap stays fail-closed.\n\nRollback:\nRevert this PR.\n\nNot checked:\n- GitHub required checks after PR creation.\n

<!-- rubin-agent-meta actor=unknown action=pr-create via=cl branch=codex/RUB-343-02-compact-receive-hardening wt=rubin-protocol-codex-RUB-343 utc=2026-05-22T11:51:03Z -->
