### PR TITLE
[PAUSED][RUB-344] Validate runtime evidence declarations

### DIFF
--- a/conformance/EDGE_PACK_BASELINE.json
+++ b/conformance/EDGE_PACK_BASELINE.json
@@ -114,6 +114,22 @@
           "CV-TS-05",
           "CV-TS-06"
         ]
+      },
+      "runtime_evidence": {
+        "tests_by_file": {
+          "clients/go/node/sync_reorg_test.go": [
+            "TestApplyBlockWithReorgRejectsSideBranchTimestampContextBeforeStore",
+            "TestApplyBlockWithReorgSwitchesToLowerTipOnEqualWork",
+            "TestApplyBlockWithReorgKeepsLowerTipOnEqualWorkHigherSideBranch"
+          ],
+          "clients/rust/crates/rubin-node/src/sync_reorg.rs": [
+            "apply_block_with_reorg_switches_to_lower_tip_on_equal_work",
+            "apply_block_with_reorg_keeps_lower_tip_on_equal_work_higher_side_branch",
+            "apply_block_with_reorg_uses_side_branch_timestamp_context_before_store",
+            "apply_block_with_reorg_advances_side_branch_timestamp_context",
+            "apply_block_with_reorg_rejects_side_branch_timestamp_before_store"
+          ]
+        }
       }
     },
     {

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -74,10 +74,8 @@ by domain:
 - DA fee-floor policy
 
 `runtime_reorg` coverage is not a new consensus fixture gate. The
-`runtime_reorg` edge-pack domain is pinned using evidence from the existing
-`CV-FORK-CHOICE` and `CV-TIMESTAMP` gates, without claiming checker-enforced
-node runtime source/test evidence. Follow-up checker hardening is tracked
-separately for declared runtime source/test validation.
+`runtime_reorg` edge-pack domain is pinned using evidence from the existing `CV-FORK-CHOICE`
+and `CV-TIMESTAMP` gates. Declared runtime source/test names are checker-enforced as declaration-shape evidence only; source-boundary and reachability hardening are tracked separately.
 
 Mempool/DA fee-floor domains are accounting-only here: they cite committed
 executable CV vector IDs and replay evidence, but do not claim fuzz or formal

--- a/tools/check_conformance_edge_pack.py
+++ b/tools/check_conformance_edge_pack.py
@@ -8,17 +8,11 @@ from pathlib import Path
 
 CLAIMED_PRESENT_STATUSES = {"present", "covered", "complete"}
 KNOWN_ABSENT_STATUSES = {"absent", "deferred", "not_claimed", "not-applicable", "not_applicable"}
-GO_TEST_FUNC_RE = re.compile(
-    r"(?m)^func\s+(Test(?:[A-Z0-9_][A-Za-z0-9_]*)?)\s*\(\s*(?:[A-Za-z_][A-Za-z0-9_]*\s+)?"
-    r"\*\s*(?:(?P<pkg>[A-Za-z_][A-Za-z0-9_]*)\.)?T\s*\)\s*\{"
-)
-GO_IMPORT_BLOCK_RE = re.compile(r"^import\s*\(\s*$")
-GO_ANY_SINGLE_IMPORT_RE = re.compile(r'^import\s+(?:(?:[A-Za-z_][A-Za-z0-9_]*|[._])\s+)?(?:"[^"]+"|`[^`]+`)\s*$')
+GO_TEST_FUNC_RE = re.compile(r"(?m)^func\s+(Test(?:[A-Z0-9_][A-Za-z0-9_]*)?)\s*\(\s*(?:[A-Za-z_][A-Za-z0-9_]*\s+)?\*\s*(?:(?P<pkg>[A-Za-z_][A-Za-z0-9_]*)\.)?T\s*,?\s*\)\s*\{")
 GO_IMPORT_SPEC_RE = re.compile(r'^(?:(?P<alias>[A-Za-z_][A-Za-z0-9_]*|[._])\s+)?(?:"testing"|`testing`)\s*$')
-GO_SINGLE_IMPORT_RE = re.compile(r'^import\s+(?:(?P<alias>[A-Za-z_][A-Za-z0-9_]*|[._])\s+)?(?:"testing"|`testing`)\s*$')
 GO_PLATFORM_TAGS = set("386 aix amd64 android arm arm64 darwin dragonfly freebsd illumos ios js linux loong64 mips mips64 mips64le mipsle netbsd openbsd plan9 ppc64 ppc64le riscv64 s390x solaris wasm wasip1 windows zos".split())
 RUST_TEST_ATTR_RE = re.compile(r"^\s*#\s*\[\s*test\s*\]\s*$")
-RUST_FN_RE = re.compile(r"^\s*(?:pub(?:\s*\([^)]*\))?\s+)?fn\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(")
+RUST_FN_RE = re.compile(r"^\s*(?:pub(?:\s*\([^)]*\))?\s+)?fn\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(\s*\)\s*(?:->[^{]+)?\{")
 
 
 def fail(msg: str) -> int:
@@ -83,22 +77,16 @@ def string_list(value: object, *, field_name: str, require_non_empty: bool = Fal
         return [], f"{field_name} entries must be unique"
     return strings, None
 
-
 def mask_non_code(source: str, *, language: str, mask_strings: bool = True) -> str:
     out: list[str] = []
     i = 0
     n = len(source)
-
     def put_masked(ch: str) -> None:
         out.append("\n" if ch == "\n" else " ")
-
     def mask_until(end: str, start: int, *, skip_start: int = 1) -> int:
-        j = start
-        for _ in range(skip_start):
-            if j >= n:
-                return n
-            put_masked(source[j])
-            j += 1
+        j = min(n, start + skip_start)
+        for ch in source[start:j]:
+            put_masked(ch)
         while j < n:
             if source.startswith(end, j):
                 for extra in range(len(end)):
@@ -112,24 +100,9 @@ def mask_non_code(source: str, *, language: str, mask_strings: bool = True) -> s
                 continue
             j += 1
         return n
-
-    def rust_char_literal_end(start: int) -> int | None:
-        j = start + 1
-        if j >= n or source[j] == "\n":
-            return None
-        if source[j] == "\\":
-            j += 2
-            if j < n and source[j - 1] == "u" and source[j] == "{":
-                close = source.find("}", j + 1)
-                if close == -1:
-                    return None
-                j = close + 1
-            return j + 1 if j < n and source[j] == "'" else None
-        return j + 2 if j + 1 < n and source[j + 1] == "'" else None
-
     while i < n:
         if source.startswith("//", i):
-            preserve = language == "go" and (source.startswith("//go:build", i) or source.startswith("// +build", i))
+            preserve = language == "go" and (source.startswith("//go:build", i) or re.match(r"//\s*\+build\b", source[i:]))
             while i < n:
                 ch = source[i]
                 out.append(ch) if preserve else put_masked(ch)
@@ -171,125 +144,85 @@ def mask_non_code(source: str, *, language: str, mask_strings: bool = True) -> s
         if mask_strings and (source[i] == '"' or (language != "rust" and source[i] == "'")):
             i = mask_until(source[i], i)
             continue
-        if mask_strings and language == "rust" and source[i] == "'":
-            end = rust_char_literal_end(i)
-            if end is not None:
-                while i < end:
-                    put_masked(source[i])
-                    i += 1
-                continue
         out.append(source[i])
         i += 1
     return "".join(out)
-
-
 def go_test_names(source: str) -> set[str]:
     masked = mask_non_code(source, language="go")
     if go_has_build_constraint(masked):
         return set()
     aliases = go_testing_aliases(mask_non_code(source, language="go", mask_strings=False))
-    return {
-        match.group(1)
-        for match in GO_TEST_FUNC_RE.finditer(masked)
-        if (match.group("pkg") in aliases if match.group("pkg") else "." in aliases)
-    }
-
-
+    return {m.group(1) for m in GO_TEST_FUNC_RE.finditer(masked) if (m.group("pkg") in aliases if m.group("pkg") else "." in aliases)}
 def go_testing_aliases(source: str) -> set[str]:
     aliases: set[str] = set()
     in_import_block = False
     for raw_line in source.splitlines():
         line = raw_line.lstrip("\ufeff").strip()
-        if not in_import_block:
-            if not line or line.startswith("package "):
-                continue
-            if GO_IMPORT_BLOCK_RE.match(line):
-                in_import_block = True
-                continue
-            match = GO_SINGLE_IMPORT_RE.match(line)
-            if not match:
-                if GO_ANY_SINGLE_IMPORT_RE.match(line):
-                    continue
-                break
-        elif line == ")":
-            in_import_block = False
+        if in_import_block:
+            if line == ")":
+                in_import_block = False
+            else:
+                aliases.update(go_import_aliases([line]))
             continue
-        else:
-            match = GO_IMPORT_SPEC_RE.match(line)
-        if match:
-            alias = match.group("alias") or "testing"
-            if alias != "_":
-                aliases.add(alias)
+        if not line or line.startswith("package "):
+            continue
+        if line == "import (":
+            in_import_block = True
+            continue
+        if line.startswith("import (") and line.endswith(")"):
+            aliases.update(go_import_aliases(line.removeprefix("import (").removesuffix(")").split(";")))
+            continue
+        if line.startswith("import "):
+            aliases.update(go_import_aliases([line.removeprefix("import ")]))
+            continue
+        break
     return aliases
-
-
-def rust_cfg_active_under_test(expr: str) -> bool:
-    def split_args(args: str) -> list[str]:
-        parts: list[str] = []
-        start = depth = 0
-        for idx, ch in enumerate(args):
-            depth += ch == "("
-            depth -= ch == ")"
-            if ch == "," and depth == 0:
-                parts.append(args[start:idx])
-                start = idx + 1
-        parts.append(args[start:])
-        return parts
-
-    def eval_cfg(value: str) -> bool:
-        value = re.sub(r"\s+", "", value)
-        if value == "test":
-            return True
-        if value.startswith("not(") and value.endswith(")"):
-            return not eval_cfg(value[4:-1])
-        if value.startswith("any(") and value.endswith(")"):
-            return any(eval_cfg(part) for part in split_args(value[4:-1]))
-        if value.startswith("all(") and value.endswith(")"):
-            return all(eval_cfg(part) for part in split_args(value[4:-1]))
-        return False
-
-    return eval_cfg(expr)
-
-
-def rust_cfg_attr_condition(attr: str) -> str:
-    body = re.sub(r"^\s*#\s*!?\s*\[\s*cfg_attr\s*\(|\)\s*\]\s*$", "", attr)
-    depth = 0
-    for idx, ch in enumerate(body):
-        depth += ch == "("
-        depth -= ch == ")"
+def go_import_aliases(lines: list[str]) -> set[str]:
+    return {(m.group("alias") or "testing") for line in lines if (m := GO_IMPORT_SPEC_RE.match(line.strip())) and (m.group("alias") or "testing") != "_"}
+def split_cfg_args(args: str) -> list[str]:
+    parts: list[str] = []
+    start = depth = 0
+    for idx, ch in enumerate(args):
+        depth += (ch == "(") - (ch == ")")
         if ch == "," and depth == 0:
-            return body[:idx]
-    return body
-
-
+            parts.append(args[start:idx])
+            start = idx + 1
+    return [part for part in [*parts, args[start:]] if part.strip()]
+def rust_cfg_active_under_test(expr: str) -> bool:
+    expr = re.sub(r"\s+", "", expr)
+    if expr == "test":
+        return True
+    if not (match := re.match(r"(not|any|all)\((.*)\)$", expr)):
+        return False
+    op, body = match.groups()
+    values = [rust_cfg_active_under_test(part) for part in split_cfg_args(body)]
+    return (not values[0]) if op == "not" and values else (any(values) if op == "any" else all(values))
 def rust_attr_inactive(attr: str) -> bool:
     body = re.sub(r"^\s*#\s*!?\s*\[\s*|\s*\]\s*$", "", attr)
     if re.match(r"ignore\b", body):
         return True
     if body.startswith("cfg_attr"):
-        return "ignore" in body and rust_cfg_active_under_test(rust_cfg_attr_condition(attr))
+        return "ignore" in body and rust_cfg_active_under_test(split_cfg_args(body.removeprefix("cfg_attr(").removesuffix(")"))[0])
     return body.startswith("cfg") and not rust_cfg_active_under_test(body[body.find("(") + 1 : body.rfind(")")])
-
-
 def go_has_build_constraint(masked_source: str) -> bool:
     for raw_line in masked_source.splitlines():
         line = raw_line.strip()
         if not line:
             continue
-        if line.startswith("//go:build") or line.startswith("// +build"):
+        if line.startswith("//go:build") or re.match(r"//\s*\+build\b", line):
             return True
         if not line.startswith("//"):
             return False
     return False
-
-
 def rust_test_names(source: str) -> set[str]:
     names: set[str] = set()
     attrs: list[str] = []
     attr = ""
     pending_inactive_mod = False
     inactive_depth = 0
-    for raw_line in mask_non_code(source, language="rust").splitlines():
+    masked_source = mask_non_code(source, language="rust")
+    masked_source = re.sub(r"'(?:\\(?:u\{[0-9A-Fa-f_]+\}|.)|[^\\'\n])'", lambda m: " " * len(m.group(0)), masked_source)
+    for raw_line in masked_source.splitlines():
         line = raw_line.strip()
         if not line:
             continue
@@ -334,7 +267,6 @@ def rust_test_names(source: str) -> set[str]:
                 names.add(match.group(1))
             attrs = []
     return names
-
 
 def validate_runtime_evidence(repo_root: Path, domain_name: str, runtime_evidence: object) -> list[str]:
     if not isinstance(runtime_evidence, dict):
@@ -384,7 +316,6 @@ def validate_runtime_evidence(repo_root: Path, domain_name: str, runtime_evidenc
                 f"domain {domain_name}: {raw_path} missing declared runtime tests: {', '.join(missing)}"
             )
     return errors
-
 
 def main() -> int:
     repo_root = Path(".").resolve()

--- a/tools/check_conformance_edge_pack.py
+++ b/tools/check_conformance_edge_pack.py
@@ -10,11 +10,13 @@ CLAIMED_PRESENT_STATUSES = {"present", "covered", "complete"}
 KNOWN_ABSENT_STATUSES = {"absent", "deferred", "not_claimed", "not-applicable", "not_applicable"}
 GO_TEST_FUNC_RE = re.compile(
     r"(?m)^func\s+(Test[A-Z][A-Za-z0-9_]*)\s*\(\s*(?:[A-Za-z_][A-Za-z0-9_]*\s+)?"
-    r"\*(?P<pkg>[A-Za-z_][A-Za-z0-9_]*)\.T\s*\)\s*\{"
+    r"\*\s*(?P<pkg>[A-Za-z_][A-Za-z0-9_]*)\.T\s*\)\s*\{"
 )
 GO_IMPORT_BLOCK_RE = re.compile(r"^import\s*\(\s*$")
+GO_ANY_SINGLE_IMPORT_RE = re.compile(r'^import\s+(?:(?:[A-Za-z_][A-Za-z0-9_]*|[._])\s+)?(?:"[^"]+"|`[^`]+`)\s*$')
 GO_IMPORT_SPEC_RE = re.compile(r'^(?:(?P<alias>[A-Za-z_][A-Za-z0-9_]*|[._])\s+)?(?:"testing"|`testing`)\s*$')
 GO_SINGLE_IMPORT_RE = re.compile(r'^import\s+(?:(?P<alias>[A-Za-z_][A-Za-z0-9_]*|[._])\s+)?(?:"testing"|`testing`)\s*$')
+GO_PLATFORM_TAGS = set("386 aix amd64 android arm arm64 darwin dragonfly freebsd illumos ios js linux loong64 mips mips64 mips64le mipsle netbsd openbsd plan9 ppc64 ppc64le riscv64 s390x solaris wasm wasip1 windows zos".split())
 RUST_TEST_ATTR_RE = re.compile(r"^\s*#\s*\[\s*test\s*\]\s*$")
 RUST_CFG_TEST_ATTR_RE = re.compile(r"^\s*#\s*!?\s*\[\s*cfg\s*\(\s*test\s*\)\s*\]\s*$")
 RUST_INACTIVE_ATTR_RE = re.compile(r"^\s*#\s*!?\s*\[\s*(?:ignore\b|cfg\s*\(|cfg_attr\s*\([^]]*\bignore\b)")
@@ -183,6 +185,8 @@ def go_testing_aliases(source: str) -> set[str]:
                 continue
             match = GO_SINGLE_IMPORT_RE.match(line)
             if not match:
+                if GO_ANY_SINGLE_IMPORT_RE.match(line):
+                    continue
                 break
         elif line == ")":
             in_import_block = False
@@ -226,21 +230,25 @@ def rust_test_names(source: str) -> set[str]:
                 inactive_depth = max(0, line.count("{") - line.count("}"))
                 pending_inactive_mod = False
             continue
-        if attr or line.startswith(("#[", "#![")):
+        while attr or line.startswith(("#[", "#![")):
             if "]" not in line:
                 attr = f"{attr} {line}".strip()
-                continue
+                line = ""
+                break
             head, line = line.split("]", 1)
             item_attr = f"{attr} {head}]".strip()
             attr = ""
             if item_attr.startswith("#!["):
                 if RUST_INACTIVE_ATTR_RE.match(item_attr) and not RUST_CFG_TEST_ATTR_RE.match(item_attr):
                     inactive_depth = 1
+                    line = ""
                 continue
             attrs.append(item_attr)
             line = line.strip()
             if not line:
-                continue
+                break
+        if not line:
+            continue
         if attrs:
             inactive = any(RUST_INACTIVE_ATTR_RE.match(attr) and not RUST_CFG_TEST_ATTR_RE.match(attr) for attr in attrs)
             if inactive and re.match(r"(?:pub(?:\s*\([^)]*\))?\s+)?mod\s+[A-Za-z_][A-Za-z0-9_]*\b", line):
@@ -289,6 +297,9 @@ def validate_runtime_evidence(repo_root: Path, domain_name: str, runtime_evidenc
         if source_path.suffix == ".go":
             if not source_path.name.endswith("_test.go"):
                 errors.append(f"domain {domain_name}: Go runtime_evidence source {raw_path} must end with _test.go")
+                continue
+            if source_path.stem.split("_")[-2] in GO_PLATFORM_TAGS:
+                errors.append(f"domain {domain_name}: Go runtime_evidence source {raw_path} must not use GOOS/GOARCH file constraints")
                 continue
             present = go_test_names(source)
         elif source_path.suffix == ".rs":

--- a/tools/check_conformance_edge_pack.py
+++ b/tools/check_conformance_edge_pack.py
@@ -13,11 +13,11 @@ GO_TEST_FUNC_RE = re.compile(
     r"\*(?P<pkg>[A-Za-z_][A-Za-z0-9_]*)\.T\s*\)\s*\{"
 )
 GO_IMPORT_BLOCK_RE = re.compile(r"^import\s*\(\s*$")
-GO_IMPORT_SPEC_RE = re.compile(r'^(?:(?P<alias>[A-Za-z_][A-Za-z0-9_]*|[._])\s+)?"testing"\s*$')
-GO_SINGLE_IMPORT_RE = re.compile(r'^import\s+(?:(?P<alias>[A-Za-z_][A-Za-z0-9_]*|[._])\s+)?"testing"\s*$')
+GO_IMPORT_SPEC_RE = re.compile(r'^(?:(?P<alias>[A-Za-z_][A-Za-z0-9_]*|[._])\s+)?(?:"testing"|`testing`)\s*$')
+GO_SINGLE_IMPORT_RE = re.compile(r'^import\s+(?:(?P<alias>[A-Za-z_][A-Za-z0-9_]*|[._])\s+)?(?:"testing"|`testing`)\s*$')
 RUST_TEST_ATTR_RE = re.compile(r"^\s*#\s*\[\s*test\s*\]\s*$")
-RUST_CFG_TEST_ATTR_RE = re.compile(r"^\s*#\s*\[\s*cfg\s*\(\s*test\s*\)\s*\]\s*$")
-RUST_INACTIVE_ATTR_RE = re.compile(r"^\s*#\s*\[\s*(?:ignore\b|cfg\s*\(|cfg_attr\s*\([^]]*\bignore\b)")
+RUST_CFG_TEST_ATTR_RE = re.compile(r"^\s*#\s*!?\s*\[\s*cfg\s*\(\s*test\s*\)\s*\]\s*$")
+RUST_INACTIVE_ATTR_RE = re.compile(r"^\s*#\s*!?\s*\[\s*(?:ignore\b|cfg\s*\(|cfg_attr\s*\([^]]*\bignore\b)")
 RUST_FN_RE = re.compile(r"^\s*(?:pub(?:\s*\([^)]*\))?\s+)?fn\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(")
 
 
@@ -115,9 +115,10 @@ def mask_non_code(source: str, *, language: str, mask_strings: bool = True) -> s
 
     while i < n:
         if source.startswith("//", i):
+            preserve = language == "go" and (source.startswith("//go:build", i) or source.startswith("// +build", i))
             while i < n:
                 ch = source[i]
-                put_masked(ch)
+                out.append(ch) if preserve else put_masked(ch)
                 i += 1
                 if ch == "\n":
                     break
@@ -143,7 +144,7 @@ def mask_non_code(source: str, *, language: str, mask_strings: bool = True) -> s
                 put_masked(source[i])
                 i += 1
             continue
-        if language == "go" and source[i] == "`":
+        if mask_strings and language == "go" and source[i] == "`":
             i = mask_until("`", i)
             continue
         if language == "rust" and source[i] == "r":
@@ -153,7 +154,7 @@ def mask_non_code(source: str, *, language: str, mask_strings: bool = True) -> s
             if j < n and source[j] == '"':
                 i = mask_until('"' + "#" * (j - i - 1), i, skip_start=j - i + 1)
                 continue
-        if mask_strings and source[i] in {'"', "'"}:
+        if mask_strings and (source[i] == '"' or (language != "rust" and source[i] == "'")):
             i = mask_until(source[i], i)
             continue
         out.append(source[i])
@@ -163,7 +164,7 @@ def mask_non_code(source: str, *, language: str, mask_strings: bool = True) -> s
 
 def go_test_names(source: str) -> set[str]:
     masked = mask_non_code(source, language="go")
-    if go_has_build_constraint(source):
+    if go_has_build_constraint(masked):
         return set()
     aliases = go_testing_aliases(mask_non_code(source, language="go", mask_strings=False))
     return {match.group(1) for match in GO_TEST_FUNC_RE.finditer(masked) if match.group("pkg") in aliases}
@@ -175,10 +176,14 @@ def go_testing_aliases(source: str) -> set[str]:
     for raw_line in source.splitlines():
         line = raw_line.strip()
         if not in_import_block:
+            if not line or line.startswith("package "):
+                continue
             if GO_IMPORT_BLOCK_RE.match(line):
                 in_import_block = True
                 continue
             match = GO_SINGLE_IMPORT_RE.match(line)
+            if not match:
+                break
         elif line == ")":
             in_import_block = False
             continue
@@ -221,12 +226,21 @@ def rust_test_names(source: str) -> set[str]:
                 inactive_depth = max(0, line.count("{") - line.count("}"))
                 pending_inactive_mod = False
             continue
-        if attr or line.startswith("#["):
-            attr = f"{attr} {line}".strip()
-            if "]" in line:
-                attrs.append(attr)
-                attr = ""
-            continue
+        if attr or line.startswith(("#[", "#![")):
+            if "]" not in line:
+                attr = f"{attr} {line}".strip()
+                continue
+            head, line = line.split("]", 1)
+            item_attr = f"{attr} {head}]".strip()
+            attr = ""
+            if item_attr.startswith("#!["):
+                if RUST_INACTIVE_ATTR_RE.match(item_attr) and not RUST_CFG_TEST_ATTR_RE.match(item_attr):
+                    inactive_depth = 1
+                continue
+            attrs.append(item_attr)
+            line = line.strip()
+            if not line:
+                continue
         if attrs:
             inactive = any(RUST_INACTIVE_ATTR_RE.match(attr) and not RUST_CFG_TEST_ATTR_RE.match(attr) for attr in attrs)
             if inactive and re.match(r"(?:pub(?:\s*\([^)]*\))?\s+)?mod\s+[A-Za-z_][A-Za-z0-9_]*\b", line):

--- a/tools/check_conformance_edge_pack.py
+++ b/tools/check_conformance_edge_pack.py
@@ -2,11 +2,23 @@
 from __future__ import annotations
 
 import json
+import re
 import sys
 from pathlib import Path
 
 CLAIMED_PRESENT_STATUSES = {"present", "covered", "complete"}
 KNOWN_ABSENT_STATUSES = {"absent", "deferred", "not_claimed", "not-applicable", "not_applicable"}
+GO_TEST_FUNC_RE = re.compile(
+    r"(?m)^func\s+(Test[A-Z][A-Za-z0-9_]*)\s*\(\s*(?:[A-Za-z_][A-Za-z0-9_]*\s+)?"
+    r"\*(?P<pkg>[A-Za-z_][A-Za-z0-9_]*)\.T\s*\)\s*\{"
+)
+GO_IMPORT_BLOCK_RE = re.compile(r"^import\s*\(\s*$")
+GO_IMPORT_SPEC_RE = re.compile(r'^(?:(?P<alias>[A-Za-z_][A-Za-z0-9_]*|[._])\s+)?"testing"\s*$')
+GO_SINGLE_IMPORT_RE = re.compile(r'^import\s+(?:(?P<alias>[A-Za-z_][A-Za-z0-9_]*|[._])\s+)?"testing"\s*$')
+RUST_TEST_ATTR_RE = re.compile(r"^\s*#\s*\[\s*test\s*\]\s*$")
+RUST_CFG_TEST_ATTR_RE = re.compile(r"^\s*#\s*\[\s*cfg\s*\(\s*test\s*\)\s*\]\s*$")
+RUST_INACTIVE_ATTR_RE = re.compile(r"^\s*#\s*\[\s*(?:ignore\b|cfg\s*\(|cfg_attr\s*\([^]]*\bignore\b)")
+RUST_FN_RE = re.compile(r"^\s*(?:pub(?:\s*\([^)]*\))?\s+)?fn\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(")
 
 
 def fail(msg: str) -> int:
@@ -70,6 +82,212 @@ def string_list(value: object, *, field_name: str, require_non_empty: bool = Fal
     if len(set(strings)) != len(strings):
         return [], f"{field_name} entries must be unique"
     return strings, None
+
+
+def mask_non_code(source: str, *, language: str, mask_strings: bool = True) -> str:
+    out: list[str] = []
+    i = 0
+    n = len(source)
+
+    def put_masked(ch: str) -> None:
+        out.append("\n" if ch == "\n" else " ")
+
+    def mask_until(end: str, start: int, *, skip_start: int = 1) -> int:
+        j = start
+        for _ in range(skip_start):
+            if j >= n:
+                return n
+            put_masked(source[j])
+            j += 1
+        while j < n:
+            if source.startswith(end, j):
+                for extra in range(len(end)):
+                    put_masked(source[j + extra])
+                return j + len(end)
+            ch = source[j]
+            put_masked(ch)
+            if ch == "\\" and end in {'"', "'"} and j + 1 < n:
+                put_masked(source[j + 1])
+                j += 2
+                continue
+            j += 1
+        return n
+
+    while i < n:
+        if source.startswith("//", i):
+            while i < n:
+                ch = source[i]
+                put_masked(ch)
+                i += 1
+                if ch == "\n":
+                    break
+            continue
+        if source.startswith("/*", i):
+            depth = 1
+            put_masked(source[i])
+            put_masked(source[i + 1])
+            i += 2
+            while i < n and depth:
+                if language == "rust" and source.startswith("/*", i):
+                    depth += 1
+                    put_masked(source[i])
+                    put_masked(source[i + 1])
+                    i += 2
+                    continue
+                if source.startswith("*/", i):
+                    depth -= 1
+                    put_masked(source[i])
+                    put_masked(source[i + 1])
+                    i += 2
+                    continue
+                put_masked(source[i])
+                i += 1
+            continue
+        if language == "go" and source[i] == "`":
+            i = mask_until("`", i)
+            continue
+        if language == "rust" and source[i] == "r":
+            j = i + 1
+            while j < n and source[j] == "#":
+                j += 1
+            if j < n and source[j] == '"':
+                i = mask_until('"' + "#" * (j - i - 1), i, skip_start=j - i + 1)
+                continue
+        if mask_strings and source[i] in {'"', "'"}:
+            i = mask_until(source[i], i)
+            continue
+        out.append(source[i])
+        i += 1
+    return "".join(out)
+
+
+def go_test_names(source: str) -> set[str]:
+    masked = mask_non_code(source, language="go")
+    if go_has_build_constraint(source):
+        return set()
+    aliases = go_testing_aliases(mask_non_code(source, language="go", mask_strings=False))
+    return {match.group(1) for match in GO_TEST_FUNC_RE.finditer(masked) if match.group("pkg") in aliases}
+
+
+def go_testing_aliases(source: str) -> set[str]:
+    aliases: set[str] = set()
+    in_import_block = False
+    for raw_line in source.splitlines():
+        line = raw_line.strip()
+        if not in_import_block:
+            if GO_IMPORT_BLOCK_RE.match(line):
+                in_import_block = True
+                continue
+            match = GO_SINGLE_IMPORT_RE.match(line)
+        elif line == ")":
+            in_import_block = False
+            continue
+        else:
+            match = GO_IMPORT_SPEC_RE.match(line)
+        if match:
+            alias = match.group("alias") or "testing"
+            if alias not in {".", "_"}:
+                aliases.add(alias)
+    return aliases
+
+
+def go_has_build_constraint(masked_source: str) -> bool:
+    for raw_line in masked_source.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        if line.startswith("//go:build") or line.startswith("// +build"):
+            return True
+        if not line.startswith("//"):
+            return False
+    return False
+
+
+def rust_test_names(source: str) -> set[str]:
+    names: set[str] = set()
+    attrs: list[str] = []
+    attr = ""
+    pending_inactive_mod = False
+    inactive_depth = 0
+    for raw_line in mask_non_code(source, language="rust").splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        if inactive_depth:
+            inactive_depth = max(0, inactive_depth + line.count("{") - line.count("}"))
+            continue
+        if pending_inactive_mod:
+            if "{" in line or ";" in line:
+                inactive_depth = max(0, line.count("{") - line.count("}"))
+                pending_inactive_mod = False
+            continue
+        if attr or line.startswith("#["):
+            attr = f"{attr} {line}".strip()
+            if "]" in line:
+                attrs.append(attr)
+                attr = ""
+            continue
+        if attrs:
+            inactive = any(RUST_INACTIVE_ATTR_RE.match(attr) and not RUST_CFG_TEST_ATTR_RE.match(attr) for attr in attrs)
+            if inactive and re.match(r"(?:pub(?:\s*\([^)]*\))?\s+)?mod\s+[A-Za-z_][A-Za-z0-9_]*\b", line):
+                if "{" in line:
+                    inactive_depth = max(0, line.count("{") - line.count("}"))
+                elif ";" not in line:
+                    pending_inactive_mod = True
+                attrs = []
+                continue
+            match = RUST_FN_RE.match(line)
+            if not inactive and any(RUST_TEST_ATTR_RE.match(attr) for attr in attrs) and match:
+                names.add(match.group(1))
+            attrs = []
+    return names
+
+
+def validate_runtime_evidence(repo_root: Path, domain_name: str, runtime_evidence: object) -> list[str]:
+    if not isinstance(runtime_evidence, dict):
+        return [f"domain {domain_name}: runtime_evidence must be object"]
+    tests_by_file = runtime_evidence.get("tests_by_file")
+    if not isinstance(tests_by_file, dict) or not tests_by_file:
+        return [f"domain {domain_name}: runtime_evidence.tests_by_file must be non-empty object"]
+    errors: list[str] = []
+    for raw_path, raw_names in tests_by_file.items():
+        if not isinstance(raw_path, str) or not raw_path.strip():
+            errors.append(f"domain {domain_name}: runtime_evidence.tests_by_file keys must be non-empty strings")
+            continue
+        names, names_error = string_list(
+            raw_names,
+            field_name=f"runtime_evidence.tests_by_file[{raw_path}]",
+            require_non_empty=True,
+        )
+        if names_error is not None:
+            errors.append(f"domain {domain_name}: {names_error}")
+            continue
+        rel_path = Path(raw_path)
+        if rel_path.is_absolute() or ".." in rel_path.parts:
+            errors.append(f"domain {domain_name}: runtime_evidence path {raw_path} must be repo-relative")
+            continue
+        source_path = repo_root / rel_path
+        try:
+            source = source_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            errors.append(f"domain {domain_name}: cannot read runtime_evidence source {raw_path}: {exc}")
+            continue
+        if source_path.suffix == ".go":
+            if not source_path.name.endswith("_test.go"):
+                errors.append(f"domain {domain_name}: Go runtime_evidence source {raw_path} must end with _test.go")
+                continue
+            present = go_test_names(source)
+        elif source_path.suffix == ".rs":
+            present = rust_test_names(source)
+        else:
+            errors.append(f"domain {domain_name}: unsupported runtime_evidence source type {raw_path}")
+            continue
+        missing = [name for name in names if name not in present]
+        if missing:
+            errors.append(
+                f"domain {domain_name}: {raw_path} missing declared runtime tests: {', '.join(missing)}"
+            )
+    return errors
 
 
 def main() -> int:
@@ -137,6 +355,7 @@ def main() -> int:
         min_vectors_total = domain.get("min_vectors_total")
         required_vectors_by_gate = domain.get("required_vectors_by_gate", {})
         coverage_accounting = domain.get("coverage_accounting")
+        runtime_evidence = domain.get("runtime_evidence")
 
         if not isinstance(name, str) or not name.strip():
             print("ERROR: domain name missing/invalid", file=sys.stderr)
@@ -164,6 +383,10 @@ def main() -> int:
             print(f"ERROR: domain {name}: coverage_accounting must be object", file=sys.stderr)
             failures += 1
             continue
+        if runtime_evidence is not None:
+            for error in validate_runtime_evidence(repo_root, name, runtime_evidence):
+                print(f"ERROR: {error}", file=sys.stderr)
+                failures += 1
 
         total = 0
         missing_gates: list[str] = []

--- a/tools/check_conformance_edge_pack.py
+++ b/tools/check_conformance_edge_pack.py
@@ -2,11 +2,23 @@
 from __future__ import annotations
 
 import json
+import re
 import sys
 from pathlib import Path
 
 CLAIMED_PRESENT_STATUSES = {"present", "covered", "complete"}
 KNOWN_ABSENT_STATUSES = {"absent", "deferred", "not_claimed", "not-applicable", "not_applicable"}
+GO_TEST_FUNC_RE = re.compile(
+    r"(?m)^func\s+(Test[A-Z0-9_][A-Za-z0-9_]*)\s*\(\s*(?:[A-Za-z_][A-Za-z0-9_]*\s+)?"
+    r"\*(?P<pkg>[A-Za-z_][A-Za-z0-9_]*)\.T\s*\)\s*\{"
+)
+GO_IMPORT_BLOCK_RE = re.compile(r"^import\s*\(\s*$")
+GO_IMPORT_SPEC_RE = re.compile(r'^(?:(?P<alias>[A-Za-z_][A-Za-z0-9_]*|[._])\s+)?"testing"\s*$')
+GO_SINGLE_IMPORT_RE = re.compile(r'^import\s+(?:(?P<alias>[A-Za-z_][A-Za-z0-9_]*|[._])\s+)?"testing"\s*$')
+RUST_TEST_ATTR_RE = re.compile(r"^\s*#\s*\[\s*test\s*\]\s*$")
+RUST_CFG_TEST_ATTR_RE = re.compile(r"^\s*#\s*\[\s*cfg\s*\(\s*test\s*\)\s*\]\s*$")
+RUST_INACTIVE_ATTR_RE = re.compile(r"^\s*#\s*\[\s*(?:ignore\b|cfg\s*\(|cfg_attr\s*\([^]]*\bignore\b)")
+RUST_FN_RE = re.compile(r"^\s*(?:pub(?:\s*\([^)]*\))?\s+)?fn\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(")
 
 
 def fail(msg: str) -> int:
@@ -70,6 +82,212 @@ def string_list(value: object, *, field_name: str, require_non_empty: bool = Fal
     if len(set(strings)) != len(strings):
         return [], f"{field_name} entries must be unique"
     return strings, None
+
+
+def mask_non_code(source: str, *, language: str, mask_strings: bool = True) -> str:
+    out: list[str] = []
+    i = 0
+    n = len(source)
+
+    def put_masked(ch: str) -> None:
+        out.append("\n" if ch == "\n" else " ")
+
+    def mask_until(end: str, start: int, *, skip_start: int = 1) -> int:
+        j = start
+        for _ in range(skip_start):
+            if j >= n:
+                return n
+            put_masked(source[j])
+            j += 1
+        while j < n:
+            if source.startswith(end, j):
+                for extra in range(len(end)):
+                    put_masked(source[j + extra])
+                return j + len(end)
+            ch = source[j]
+            put_masked(ch)
+            if ch == "\\" and end in {'"', "'"} and j + 1 < n:
+                put_masked(source[j + 1])
+                j += 2
+                continue
+            j += 1
+        return n
+
+    while i < n:
+        if source.startswith("//", i):
+            while i < n:
+                ch = source[i]
+                put_masked(ch)
+                i += 1
+                if ch == "\n":
+                    break
+            continue
+        if source.startswith("/*", i):
+            depth = 1
+            put_masked(source[i])
+            put_masked(source[i + 1])
+            i += 2
+            while i < n and depth:
+                if language == "rust" and source.startswith("/*", i):
+                    depth += 1
+                    put_masked(source[i])
+                    put_masked(source[i + 1])
+                    i += 2
+                    continue
+                if source.startswith("*/", i):
+                    depth -= 1
+                    put_masked(source[i])
+                    put_masked(source[i + 1])
+                    i += 2
+                    continue
+                put_masked(source[i])
+                i += 1
+            continue
+        if language == "go" and source[i] == "`":
+            i = mask_until("`", i)
+            continue
+        if language == "rust" and source[i] == "r":
+            j = i + 1
+            while j < n and source[j] == "#":
+                j += 1
+            if j < n and source[j] == '"':
+                i = mask_until('"' + "#" * (j - i - 1), i, skip_start=j - i + 1)
+                continue
+        if mask_strings and source[i] in {'"', "'"}:
+            i = mask_until(source[i], i)
+            continue
+        out.append(source[i])
+        i += 1
+    return "".join(out)
+
+
+def go_test_names(source: str) -> set[str]:
+    masked = mask_non_code(source, language="go")
+    if go_has_build_constraint(source):
+        return set()
+    aliases = go_testing_aliases(mask_non_code(source, language="go", mask_strings=False))
+    return {match.group(1) for match in GO_TEST_FUNC_RE.finditer(masked) if match.group("pkg") in aliases}
+
+
+def go_testing_aliases(source: str) -> set[str]:
+    aliases: set[str] = set()
+    in_import_block = False
+    for raw_line in source.splitlines():
+        line = raw_line.strip()
+        if not in_import_block:
+            if GO_IMPORT_BLOCK_RE.match(line):
+                in_import_block = True
+                continue
+            match = GO_SINGLE_IMPORT_RE.match(line)
+        elif line == ")":
+            in_import_block = False
+            continue
+        else:
+            match = GO_IMPORT_SPEC_RE.match(line)
+        if match:
+            alias = match.group("alias") or "testing"
+            if alias not in {".", "_"}:
+                aliases.add(alias)
+    return aliases
+
+
+def go_has_build_constraint(masked_source: str) -> bool:
+    for raw_line in masked_source.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        if line.startswith("//go:build") or line.startswith("// +build"):
+            return True
+        if not line.startswith("//"):
+            return False
+    return False
+
+
+def rust_test_names(source: str) -> set[str]:
+    names: set[str] = set()
+    attrs: list[str] = []
+    attr = ""
+    pending_inactive_mod = False
+    inactive_depth = 0
+    for raw_line in mask_non_code(source, language="rust").splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        if inactive_depth:
+            inactive_depth = max(0, inactive_depth + line.count("{") - line.count("}"))
+            continue
+        if pending_inactive_mod:
+            if "{" in line or ";" in line:
+                inactive_depth = max(0, line.count("{") - line.count("}"))
+                pending_inactive_mod = False
+            continue
+        if attr or line.startswith("#["):
+            attr = f"{attr} {line}".strip()
+            if "]" in line:
+                attrs.append(attr)
+                attr = ""
+            continue
+        if attrs:
+            inactive = any(RUST_INACTIVE_ATTR_RE.match(attr) and not RUST_CFG_TEST_ATTR_RE.match(attr) for attr in attrs)
+            if inactive and re.match(r"(?:pub(?:\s*\([^)]*\))?\s+)?mod\s+[A-Za-z_][A-Za-z0-9_]*\b", line):
+                if "{" in line:
+                    inactive_depth = max(0, line.count("{") - line.count("}"))
+                elif ";" not in line:
+                    pending_inactive_mod = True
+                attrs = []
+                continue
+            match = RUST_FN_RE.match(line)
+            if not inactive and any(RUST_TEST_ATTR_RE.match(attr) for attr in attrs) and match:
+                names.add(match.group(1))
+            attrs = []
+    return names
+
+
+def validate_runtime_evidence(repo_root: Path, domain_name: str, runtime_evidence: object) -> list[str]:
+    if not isinstance(runtime_evidence, dict):
+        return [f"domain {domain_name}: runtime_evidence must be object"]
+    tests_by_file = runtime_evidence.get("tests_by_file")
+    if not isinstance(tests_by_file, dict) or not tests_by_file:
+        return [f"domain {domain_name}: runtime_evidence.tests_by_file must be non-empty object"]
+    errors: list[str] = []
+    for raw_path, raw_names in tests_by_file.items():
+        if not isinstance(raw_path, str) or not raw_path.strip():
+            errors.append(f"domain {domain_name}: runtime_evidence.tests_by_file keys must be non-empty strings")
+            continue
+        names, names_error = string_list(
+            raw_names,
+            field_name=f"runtime_evidence.tests_by_file[{raw_path}]",
+            require_non_empty=True,
+        )
+        if names_error is not None:
+            errors.append(f"domain {domain_name}: {names_error}")
+            continue
+        rel_path = Path(raw_path)
+        if rel_path.is_absolute() or ".." in rel_path.parts:
+            errors.append(f"domain {domain_name}: runtime_evidence path {raw_path} must be repo-relative")
+            continue
+        source_path = repo_root / rel_path
+        try:
+            source = source_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            errors.append(f"domain {domain_name}: cannot read runtime_evidence source {raw_path}: {exc}")
+            continue
+        if source_path.suffix == ".go":
+            if not source_path.name.endswith("_test.go"):
+                errors.append(f"domain {domain_name}: Go runtime_evidence source {raw_path} must end with _test.go")
+                continue
+            present = go_test_names(source)
+        elif source_path.suffix == ".rs":
+            present = rust_test_names(source)
+        else:
+            errors.append(f"domain {domain_name}: unsupported runtime_evidence source type {raw_path}")
+            continue
+        missing = [name for name in names if name not in present]
+        if missing:
+            errors.append(
+                f"domain {domain_name}: {raw_path} missing declared runtime tests: {', '.join(missing)}"
+            )
+    return errors
 
 
 def main() -> int:
@@ -137,6 +355,7 @@ def main() -> int:
         min_vectors_total = domain.get("min_vectors_total")
         required_vectors_by_gate = domain.get("required_vectors_by_gate", {})
         coverage_accounting = domain.get("coverage_accounting")
+        runtime_evidence = domain.get("runtime_evidence")
 
         if not isinstance(name, str) or not name.strip():
             print("ERROR: domain name missing/invalid", file=sys.stderr)
@@ -164,6 +383,10 @@ def main() -> int:
             print(f"ERROR: domain {name}: coverage_accounting must be object", file=sys.stderr)
             failures += 1
             continue
+        if runtime_evidence is not None:
+            for error in validate_runtime_evidence(repo_root, name, runtime_evidence):
+                print(f"ERROR: {error}", file=sys.stderr)
+                failures += 1
 
         total = 0
         missing_gates: list[str] = []

--- a/tools/check_conformance_edge_pack.py
+++ b/tools/check_conformance_edge_pack.py
@@ -9,8 +9,8 @@ from pathlib import Path
 CLAIMED_PRESENT_STATUSES = {"present", "covered", "complete"}
 KNOWN_ABSENT_STATUSES = {"absent", "deferred", "not_claimed", "not-applicable", "not_applicable"}
 GO_TEST_FUNC_RE = re.compile(
-    r"(?m)^func\s+(Test[A-Z][A-Za-z0-9_]*)\s*\(\s*(?:[A-Za-z_][A-Za-z0-9_]*\s+)?"
-    r"\*\s*(?P<pkg>[A-Za-z_][A-Za-z0-9_]*)\.T\s*\)\s*\{"
+    r"(?m)^func\s+(Test(?:[A-Z0-9_][A-Za-z0-9_]*)?)\s*\(\s*(?:[A-Za-z_][A-Za-z0-9_]*\s+)?"
+    r"\*\s*(?:(?P<pkg>[A-Za-z_][A-Za-z0-9_]*)\.)?T\s*\)\s*\{"
 )
 GO_IMPORT_BLOCK_RE = re.compile(r"^import\s*\(\s*$")
 GO_ANY_SINGLE_IMPORT_RE = re.compile(r'^import\s+(?:(?:[A-Za-z_][A-Za-z0-9_]*|[._])\s+)?(?:"[^"]+"|`[^`]+`)\s*$')
@@ -18,8 +18,6 @@ GO_IMPORT_SPEC_RE = re.compile(r'^(?:(?P<alias>[A-Za-z_][A-Za-z0-9_]*|[._])\s+)?
 GO_SINGLE_IMPORT_RE = re.compile(r'^import\s+(?:(?P<alias>[A-Za-z_][A-Za-z0-9_]*|[._])\s+)?(?:"testing"|`testing`)\s*$')
 GO_PLATFORM_TAGS = set("386 aix amd64 android arm arm64 darwin dragonfly freebsd illumos ios js linux loong64 mips mips64 mips64le mipsle netbsd openbsd plan9 ppc64 ppc64le riscv64 s390x solaris wasm wasip1 windows zos".split())
 RUST_TEST_ATTR_RE = re.compile(r"^\s*#\s*\[\s*test\s*\]\s*$")
-RUST_CFG_TEST_ATTR_RE = re.compile(r"^\s*#\s*!?\s*\[\s*cfg\s*\(\s*test\s*\)\s*\]\s*$")
-RUST_INACTIVE_ATTR_RE = re.compile(r"^\s*#\s*!?\s*\[\s*(?:ignore\b|cfg\s*\(|cfg_attr\s*\([^]]*\bignore\b)")
 RUST_FN_RE = re.compile(r"^\s*(?:pub(?:\s*\([^)]*\))?\s+)?fn\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(")
 
 
@@ -115,6 +113,20 @@ def mask_non_code(source: str, *, language: str, mask_strings: bool = True) -> s
             j += 1
         return n
 
+    def rust_char_literal_end(start: int) -> int | None:
+        j = start + 1
+        if j >= n or source[j] == "\n":
+            return None
+        if source[j] == "\\":
+            j += 2
+            if j < n and source[j - 1] == "u" and source[j] == "{":
+                close = source.find("}", j + 1)
+                if close == -1:
+                    return None
+                j = close + 1
+            return j + 1 if j < n and source[j] == "'" else None
+        return j + 2 if j + 1 < n and source[j + 1] == "'" else None
+
     while i < n:
         if source.startswith("//", i):
             preserve = language == "go" and (source.startswith("//go:build", i) or source.startswith("// +build", i))
@@ -159,6 +171,13 @@ def mask_non_code(source: str, *, language: str, mask_strings: bool = True) -> s
         if mask_strings and (source[i] == '"' or (language != "rust" and source[i] == "'")):
             i = mask_until(source[i], i)
             continue
+        if mask_strings and language == "rust" and source[i] == "'":
+            end = rust_char_literal_end(i)
+            if end is not None:
+                while i < end:
+                    put_masked(source[i])
+                    i += 1
+                continue
         out.append(source[i])
         i += 1
     return "".join(out)
@@ -169,14 +188,18 @@ def go_test_names(source: str) -> set[str]:
     if go_has_build_constraint(masked):
         return set()
     aliases = go_testing_aliases(mask_non_code(source, language="go", mask_strings=False))
-    return {match.group(1) for match in GO_TEST_FUNC_RE.finditer(masked) if match.group("pkg") in aliases}
+    return {
+        match.group(1)
+        for match in GO_TEST_FUNC_RE.finditer(masked)
+        if (match.group("pkg") in aliases if match.group("pkg") else "." in aliases)
+    }
 
 
 def go_testing_aliases(source: str) -> set[str]:
     aliases: set[str] = set()
     in_import_block = False
     for raw_line in source.splitlines():
-        line = raw_line.strip()
+        line = raw_line.lstrip("\ufeff").strip()
         if not in_import_block:
             if not line or line.startswith("package "):
                 continue
@@ -195,9 +218,57 @@ def go_testing_aliases(source: str) -> set[str]:
             match = GO_IMPORT_SPEC_RE.match(line)
         if match:
             alias = match.group("alias") or "testing"
-            if alias not in {".", "_"}:
+            if alias != "_":
                 aliases.add(alias)
     return aliases
+
+
+def rust_cfg_active_under_test(expr: str) -> bool:
+    def split_args(args: str) -> list[str]:
+        parts: list[str] = []
+        start = depth = 0
+        for idx, ch in enumerate(args):
+            depth += ch == "("
+            depth -= ch == ")"
+            if ch == "," and depth == 0:
+                parts.append(args[start:idx])
+                start = idx + 1
+        parts.append(args[start:])
+        return parts
+
+    def eval_cfg(value: str) -> bool:
+        value = re.sub(r"\s+", "", value)
+        if value == "test":
+            return True
+        if value.startswith("not(") and value.endswith(")"):
+            return not eval_cfg(value[4:-1])
+        if value.startswith("any(") and value.endswith(")"):
+            return any(eval_cfg(part) for part in split_args(value[4:-1]))
+        if value.startswith("all(") and value.endswith(")"):
+            return all(eval_cfg(part) for part in split_args(value[4:-1]))
+        return False
+
+    return eval_cfg(expr)
+
+
+def rust_cfg_attr_condition(attr: str) -> str:
+    body = re.sub(r"^\s*#\s*!?\s*\[\s*cfg_attr\s*\(|\)\s*\]\s*$", "", attr)
+    depth = 0
+    for idx, ch in enumerate(body):
+        depth += ch == "("
+        depth -= ch == ")"
+        if ch == "," and depth == 0:
+            return body[:idx]
+    return body
+
+
+def rust_attr_inactive(attr: str) -> bool:
+    body = re.sub(r"^\s*#\s*!?\s*\[\s*|\s*\]\s*$", "", attr)
+    if re.match(r"ignore\b", body):
+        return True
+    if body.startswith("cfg_attr"):
+        return "ignore" in body and rust_cfg_active_under_test(rust_cfg_attr_condition(attr))
+    return body.startswith("cfg") and not rust_cfg_active_under_test(body[body.find("(") + 1 : body.rfind(")")])
 
 
 def go_has_build_constraint(masked_source: str) -> bool:
@@ -239,7 +310,7 @@ def rust_test_names(source: str) -> set[str]:
             item_attr = f"{attr} {head}]".strip()
             attr = ""
             if item_attr.startswith("#!["):
-                if RUST_INACTIVE_ATTR_RE.match(item_attr) and not RUST_CFG_TEST_ATTR_RE.match(item_attr):
+                if rust_attr_inactive(item_attr):
                     inactive_depth = 1
                     line = ""
                 continue
@@ -250,7 +321,7 @@ def rust_test_names(source: str) -> set[str]:
         if not line:
             continue
         if attrs:
-            inactive = any(RUST_INACTIVE_ATTR_RE.match(attr) and not RUST_CFG_TEST_ATTR_RE.match(attr) for attr in attrs)
+            inactive = any(rust_attr_inactive(attr) for attr in attrs)
             if inactive and re.match(r"(?:pub(?:\s*\([^)]*\))?\s+)?mod\s+[A-Za-z_][A-Za-z0-9_]*\b", line):
                 if "{" in line:
                     inactive_depth = max(0, line.count("{") - line.count("}"))

--- a/tools/tests/test_check_conformance_edge_pack.py
+++ b/tools/tests/test_check_conformance_edge_pack.py
@@ -183,9 +183,9 @@ class EdgePackCheckerTests(unittest.TestCase):
                 ),
                 (
                     "clients/go/node/sync_reorg_test.go",
-                    "package node\nvar _ = `\nimport \"testing\"\n`\nfunc TestRawImport(t *testing.T) {}\n",
-                    ["TestRawImport"],
-                    "TestRawImport",
+                    "package node\nvar _ = `\nimport \"testing\"\n`\nvar _ = \"\\nimport \\\"testing\\\"\\n\"\nfunc TestRawImport(t *testing.T) {}\nfunc TestStringImport(t *testing.T) {}\n",
+                    ["TestRawImport", "TestStringImport"],
+                    "TestRawImport, TestStringImport",
                 ),
                 (
                     "clients/go/node/sync_reorg_test.go",

--- a/tools/tests/test_check_conformance_edge_pack.py
+++ b/tools/tests/test_check_conformance_edge_pack.py
@@ -123,21 +123,14 @@ class EdgePackCheckerTests(unittest.TestCase):
             rust_path = "clients/rust/crates/rubin-node/src/sync_reorg.rs"
             (root / go_path).parent.mkdir(parents=True, exist_ok=True)
             (root / rust_path).parent.mkdir(parents=True, exist_ok=True)
-            (root / go_path).write_text(
-                "package node\n\nimport tb `testing`\n\nfunc TestRuntimeReorg(t *tb.T) {}\n",
-                encoding="utf-8",
-            )
-            (root / rust_path).write_text(
-                "#[cfg(test)]\nmod tests {\nfn helper<'a>() {}\n#[test] fn runtime_reorg_test() {}\n}\n",
-                encoding="utf-8",
-            )
+            go_source = "package node\n\nimport \"fmt\"\nimport tb `testing`\n\nvar _ = fmt.Sprintf\nfunc TestRuntimeReorg(t * tb.T) {}\n"
+            rust_source = "#[cfg(test)]\nmod tests {\nfn helper<'a>() {}\n#[test] #[should_panic] fn runtime_reorg_test() { panic!() }\n}\n"
+            (root / go_path).write_text(go_source, encoding="utf-8")
+            (root / rust_path).write_text(rust_source, encoding="utf-8")
             baseline_path = root / "conformance" / "EDGE_PACK_BASELINE.json"
             baseline = json.loads(baseline_path.read_text(encoding="utf-8"))
             baseline["domains"][0]["runtime_evidence"] = {
-                "tests_by_file": {
-                    go_path: ["TestRuntimeReorg"],
-                    rust_path: ["runtime_reorg_test"],
-                }
+                "tests_by_file": {go_path: ["TestRuntimeReorg"], rust_path: ["runtime_reorg_test"]}
             }
             write_json(baseline_path, baseline)
             captured = io.StringIO()
@@ -165,40 +158,21 @@ class EdgePackCheckerTests(unittest.TestCase):
             cases = [
                 (
                     "clients/go/node/sync_reorg_test.go",
-                    "package node\n\nfunc Testlower() {}\nfunc Test1Bad(t *testing.T) {}\nfunc Test_Bad(t *testing.T) {}\nfunc TestWrong(t string) {}\nfunc TestExtra(t *testing.T, n int) {}\n",
+                    "package node\n\nimport \"testing\"\n\nfunc Testlower() {}\nfunc Test1Bad(t *testing.T) {}\nfunc Test_Bad(t *testing.T) {}\nfunc TestWrong(t string) {}\nfunc TestExtra(t *testing.T, n int) {}\n",
                     ["Testlower", "Test1Bad", "Test_Bad", "TestWrong", "TestExtra"],
                     "Testlower, Test1Bad, Test_Bad, TestWrong, TestExtra",
                 ),
-                (
-                    "clients/go/node/sync_reorg.go",
-                    "package node\n\nimport \"testing\"\n\nfunc TestWrongFile(t *testing.T) {}\n",
-                    ["TestWrongFile"],
-                    "must end with _test.go",
-                ),
-                (
-                    "clients/go/node/sync_reorg_test.go",
-                    "package node\n/*\nimport \"testing\"\n*/\nfunc TestCommentImport(t *testing.T) {}\n",
-                    ["TestCommentImport"],
-                    "TestCommentImport",
-                ),
+                ("clients/go/node/sync_reorg.go", "package node\n\nimport \"testing\"\n\nfunc TestWrongFile(t *testing.T) {}\n", ["TestWrongFile"], "must end with _test.go"),
+                ("clients/go/node/sync_reorg_test.go", "package node\n/*\nimport \"testing\"\n*/\nfunc TestCommentImport(t *testing.T) {}\n", ["TestCommentImport"], "TestCommentImport"),
                 (
                     "clients/go/node/sync_reorg_test.go",
                     "package node\nvar _ = `\nimport \"testing\"\n`\nvar _ = \"\\nimport \\\"testing\\\"\\n\"\nfunc TestRawImport(t *testing.T) {}\nfunc TestStringImport(t *testing.T) {}\n",
                     ["TestRawImport", "TestStringImport"],
                     "TestRawImport, TestStringImport",
                 ),
-                (
-                    "clients/go/node/sync_reorg_test.go",
-                    "/* lead */\n//go:build never\n\npackage node\n\nimport \"testing\"\n\nfunc TestTaggedOut(t *testing.T) {}\n",
-                    ["TestTaggedOut"],
-                    "TestTaggedOut",
-                ),
-                (
-                    "clients/go/node/sync_reorg_test.go",
-                    "package node\n\nfunc TestNoImport(t *testing.T) {}\n",
-                    ["TestNoImport"],
-                    "TestNoImport",
-                ),
+                ("clients/go/node/sync_reorg_test.go", "/* lead */\n//go:build never\n\npackage node\n\nimport \"testing\"\n\nfunc TestTaggedOut(t *testing.T) {}\n", ["TestTaggedOut"], "TestTaggedOut"),
+                ("clients/go/node/sync_reorg_windows_test.go", "package node\n\nimport \"testing\"\n\nfunc TestTaggedByFileName(t *testing.T) {}\n", ["TestTaggedByFileName"], "must not use GOOS/GOARCH file constraints"),
+                ("clients/go/node/sync_reorg_test.go", "package node\n\nfunc TestNoImport(t *testing.T) {}\n", ["TestNoImport"], "TestNoImport"),
             ]
             for rel_path, source, tests, want in cases:
                 with self.subTest(want=want):

--- a/tools/tests/test_check_conformance_edge_pack.py
+++ b/tools/tests/test_check_conformance_edge_pack.py
@@ -87,6 +87,23 @@ def make_repo(
     )
 
 
+def add_runtime_evidence(root: Path, rel_path: str, tests: list[str]) -> None:
+    baseline_path = root / "conformance" / "EDGE_PACK_BASELINE.json"
+    baseline = json.loads(baseline_path.read_text(encoding="utf-8"))
+    baseline["domains"][0]["runtime_evidence"] = {"tests_by_file": {rel_path: tests}}
+    write_json(baseline_path, baseline)
+
+
+def run_runtime_evidence(root: Path, rel_path: str, source: str, tests: list[str]) -> tuple[int, str]:
+    (root / rel_path).parent.mkdir(parents=True, exist_ok=True)
+    (root / rel_path).write_text(source, encoding="utf-8")
+    add_runtime_evidence(root, rel_path, tests)
+    captured = io.StringIO()
+    with chdir(root), contextlib.redirect_stderr(captured):
+        rc = m.main()
+    return rc, captured.getvalue()
+
+
 class EdgePackCheckerTests(unittest.TestCase):
     def test_clean_accounting_passes_with_deferred_fuzz_formal(self) -> None:
         with tempfile.TemporaryDirectory() as td:
@@ -97,6 +114,144 @@ class EdgePackCheckerTests(unittest.TestCase):
                 rc = m.main()
         self.assertEqual(rc, 0)
         self.assertIn("OK: conformance edge-pack baseline satisfied.", captured.getvalue())
+
+    def test_runtime_evidence_accepts_go_and_rust_test_declarations(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(root)
+            go_path = "clients/go/node/sync_reorg_test.go"
+            rust_path = "clients/rust/crates/rubin-node/src/sync_reorg.rs"
+            (root / go_path).parent.mkdir(parents=True, exist_ok=True)
+            (root / rust_path).parent.mkdir(parents=True, exist_ok=True)
+            (root / go_path).write_text(
+                "package node\n\nimport \"testing\"\n\nfunc TestRuntimeReorg(t *testing.T) {}\n",
+                encoding="utf-8",
+            )
+            (root / rust_path).write_text(
+                "#[cfg(test)]\nmod tests {\n    #[test]\n    fn runtime_reorg_test() {}\n}\n",
+                encoding="utf-8",
+            )
+            baseline_path = root / "conformance" / "EDGE_PACK_BASELINE.json"
+            baseline = json.loads(baseline_path.read_text(encoding="utf-8"))
+            baseline["domains"][0]["runtime_evidence"] = {
+                "tests_by_file": {
+                    go_path: ["TestRuntimeReorg"],
+                    rust_path: ["runtime_reorg_test"],
+                }
+            }
+            write_json(baseline_path, baseline)
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stdout(captured):
+                rc = m.main()
+        self.assertEqual(rc, 0)
+        self.assertIn("OK: conformance edge-pack baseline satisfied.", captured.getvalue())
+
+    def test_runtime_evidence_ignores_comments_and_raw_strings(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(root)
+            rel_path = "clients/rust/crates/rubin-node/src/sync_reorg.rs"
+            rc, stderr = run_runtime_evidence(
+                root,
+                rel_path,
+                '/* #[test] fn fake_comment() {} */\nconst S: &str = r#"#[test]\nfn fake_raw() {}"#;\n',
+                ["fake_comment", "fake_raw"],
+            )
+        self.assertEqual(rc, 1)
+        self.assertIn("fake_comment, fake_raw", stderr)
+
+    def test_runtime_evidence_rejects_non_discoverable_go_tests(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            cases = [
+                (
+                    "clients/go/node/sync_reorg_test.go",
+                    "package node\n\nfunc Testlower() {}\nfunc Test1Bad(t *testing.T) {}\nfunc Test_Bad(t *testing.T) {}\nfunc TestWrong(t string) {}\nfunc TestExtra(t *testing.T, n int) {}\n",
+                    ["Testlower", "Test1Bad", "Test_Bad", "TestWrong", "TestExtra"],
+                    "Testlower, Test1Bad, Test_Bad, TestWrong, TestExtra",
+                ),
+                (
+                    "clients/go/node/sync_reorg.go",
+                    "package node\n\nimport \"testing\"\n\nfunc TestWrongFile(t *testing.T) {}\n",
+                    ["TestWrongFile"],
+                    "must end with _test.go",
+                ),
+                (
+                    "clients/go/node/sync_reorg_test.go",
+                    "package node\n/*\nimport \"testing\"\n*/\nfunc TestCommentImport(t *testing.T) {}\n",
+                    ["TestCommentImport"],
+                    "TestCommentImport",
+                ),
+                (
+                    "clients/go/node/sync_reorg_test.go",
+                    "package node\nvar _ = `\nimport \"testing\"\n`\nfunc TestRawImport(t *testing.T) {}\n",
+                    ["TestRawImport"],
+                    "TestRawImport",
+                ),
+                (
+                    "clients/go/node/sync_reorg_test.go",
+                    "//go:build never\n\npackage node\n\nimport \"testing\"\n\nfunc TestTaggedOut(t *testing.T) {}\n",
+                    ["TestTaggedOut"],
+                    "TestTaggedOut",
+                ),
+                (
+                    "clients/go/node/sync_reorg_test.go",
+                    "package node\n\nfunc TestNoImport(t *testing.T) {}\n",
+                    ["TestNoImport"],
+                    "TestNoImport",
+                ),
+            ]
+            for rel_path, source, tests, want in cases:
+                with self.subTest(want=want):
+                    root = Path(td) / want.split()[0].replace(",", "")
+                    make_repo(root)
+                    rc, stderr = run_runtime_evidence(root, rel_path, source, tests)
+                    self.assertEqual(rc, 1)
+                    self.assertIn(want, stderr)
+
+    def test_runtime_evidence_accepts_aliased_go_testing_import(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(root)
+            rel_path = "clients/go/node/sync_reorg_test.go"
+            (root / rel_path).parent.mkdir(parents=True, exist_ok=True)
+            (root / rel_path).write_text(
+                'package node\n\nimport tb "testing"\n\nfunc TestAliased(t *tb.T) {}\n',
+                encoding="utf-8",
+            )
+            add_runtime_evidence(root, rel_path, ["TestAliased"])
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stdout(captured):
+                rc = m.main()
+        self.assertEqual(rc, 0)
+        self.assertIn("OK: conformance edge-pack baseline satisfied.", captured.getvalue())
+
+    def test_runtime_evidence_rejects_inactive_or_non_plain_rust_tests(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(root)
+            rel_path = "clients/rust/crates/rubin-node/src/sync_reorg.rs"
+            (root / rel_path).parent.mkdir(parents=True, exist_ok=True)
+            (root / rel_path).write_text(
+                "#[test]\n#[ignore]\nfn ignored() {}\n#[ignore]\n#[test]\nfn ignored_before() {}\n"
+                "#[test]\n#[cfg(FALSE)]\nfn cfg_disabled() {}\n#[cfg(FALSE)]\n#[test]\nfn cfg_before() {}\n"
+                "#[cfg(\nFALSE\n)]\n#[test]\nfn cfg_multiline() {}\n#[cfg_attr(\nfeature = \"never\",\nignore\n)]\n#[test]\nfn cfg_attr_multiline() {}\n"
+                "#[cfg(FALSE)]\nmod disabled { #[test]\nfn disabled_module() {} }\n#[cfg(FALSE)]\n#[allow(dead_code)]\nmod disabled_stacked { #[test]\nfn disabled_mod_test() {} }\n"
+                "#[cfg(FALSE)]\nmod disabled_next\n{\n#[test]\nfn disabled_next_line_brace() {}\n}\n#[test]\nconst fn const_test() {}\n#[test]\nunsafe fn unsafe_test() {}\n#[test]\nextern \"C\" fn extern_test() {}\n",
+                encoding="utf-8",
+            )
+            add_runtime_evidence(
+                root,
+                rel_path,
+                (
+                    "ignored ignored_before cfg_disabled cfg_before cfg_multiline cfg_attr_multiline "
+                    "disabled_module disabled_mod_test disabled_next_line_brace const_test unsafe_test extern_test"
+                ).split(),
+            )
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stderr(captured):
+                rc = m.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("disabled_next_line_brace, const_test, unsafe_test, extern_test", captured.getvalue())
 
     def test_missing_required_vector_fails(self) -> None:
         with tempfile.TemporaryDirectory() as td:

--- a/tools/tests/test_check_conformance_edge_pack.py
+++ b/tools/tests/test_check_conformance_edge_pack.py
@@ -87,6 +87,23 @@ def make_repo(
     )
 
 
+def add_runtime_evidence(root: Path, rel_path: str, tests: list[str]) -> None:
+    baseline_path = root / "conformance" / "EDGE_PACK_BASELINE.json"
+    baseline = json.loads(baseline_path.read_text(encoding="utf-8"))
+    baseline["domains"][0]["runtime_evidence"] = {"tests_by_file": {rel_path: tests}}
+    write_json(baseline_path, baseline)
+
+
+def run_runtime_evidence(root: Path, rel_path: str, source: str, tests: list[str]) -> tuple[int, str]:
+    (root / rel_path).parent.mkdir(parents=True, exist_ok=True)
+    (root / rel_path).write_text(source, encoding="utf-8")
+    add_runtime_evidence(root, rel_path, tests)
+    captured = io.StringIO()
+    with chdir(root), contextlib.redirect_stderr(captured):
+        rc = m.main()
+    return rc, captured.getvalue()
+
+
 class EdgePackCheckerTests(unittest.TestCase):
     def test_clean_accounting_passes_with_deferred_fuzz_formal(self) -> None:
         with tempfile.TemporaryDirectory() as td:
@@ -97,6 +114,144 @@ class EdgePackCheckerTests(unittest.TestCase):
                 rc = m.main()
         self.assertEqual(rc, 0)
         self.assertIn("OK: conformance edge-pack baseline satisfied.", captured.getvalue())
+
+    def test_runtime_evidence_accepts_go_and_rust_test_declarations(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(root)
+            go_path = "clients/go/node/sync_reorg_test.go"
+            rust_path = "clients/rust/crates/rubin-node/src/sync_reorg.rs"
+            (root / go_path).parent.mkdir(parents=True, exist_ok=True)
+            (root / rust_path).parent.mkdir(parents=True, exist_ok=True)
+            (root / go_path).write_text(
+                "package node\n\nimport \"testing\"\n\nfunc TestRuntimeReorg(t *testing.T) {}\n",
+                encoding="utf-8",
+            )
+            (root / rust_path).write_text(
+                "#[cfg(test)]\nmod tests {\n    #[test]\n    fn runtime_reorg_test() {}\n}\n",
+                encoding="utf-8",
+            )
+            baseline_path = root / "conformance" / "EDGE_PACK_BASELINE.json"
+            baseline = json.loads(baseline_path.read_text(encoding="utf-8"))
+            baseline["domains"][0]["runtime_evidence"] = {
+                "tests_by_file": {
+                    go_path: ["TestRuntimeReorg"],
+                    rust_path: ["runtime_reorg_test"],
+                }
+            }
+            write_json(baseline_path, baseline)
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stdout(captured):
+                rc = m.main()
+        self.assertEqual(rc, 0)
+        self.assertIn("OK: conformance edge-pack baseline satisfied.", captured.getvalue())
+
+    def test_runtime_evidence_ignores_comments_and_raw_strings(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(root)
+            rel_path = "clients/rust/crates/rubin-node/src/sync_reorg.rs"
+            rc, stderr = run_runtime_evidence(
+                root,
+                rel_path,
+                '/* #[test] fn fake_comment() {} */\nconst S: &str = r#"#[test]\nfn fake_raw() {}"#;\n',
+                ["fake_comment", "fake_raw"],
+            )
+        self.assertEqual(rc, 1)
+        self.assertIn("fake_comment, fake_raw", stderr)
+
+    def test_runtime_evidence_rejects_non_discoverable_go_tests(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            cases = [
+                (
+                    "clients/go/node/sync_reorg_test.go",
+                    "package node\n\nfunc Testlower() {}\nfunc TestWrong(t string) {}\nfunc TestExtra(t *testing.T, n int) {}\n",
+                    ["Testlower", "TestWrong", "TestExtra"],
+                    "Testlower, TestWrong, TestExtra",
+                ),
+                (
+                    "clients/go/node/sync_reorg.go",
+                    "package node\n\nimport \"testing\"\n\nfunc TestWrongFile(t *testing.T) {}\n",
+                    ["TestWrongFile"],
+                    "must end with _test.go",
+                ),
+                (
+                    "clients/go/node/sync_reorg_test.go",
+                    "package node\n/*\nimport \"testing\"\n*/\nfunc TestCommentImport(t *testing.T) {}\n",
+                    ["TestCommentImport"],
+                    "TestCommentImport",
+                ),
+                (
+                    "clients/go/node/sync_reorg_test.go",
+                    "package node\nvar _ = `\nimport \"testing\"\n`\nfunc TestRawImport(t *testing.T) {}\n",
+                    ["TestRawImport"],
+                    "TestRawImport",
+                ),
+                (
+                    "clients/go/node/sync_reorg_test.go",
+                    "//go:build never\n\npackage node\n\nimport \"testing\"\n\nfunc TestTaggedOut(t *testing.T) {}\n",
+                    ["TestTaggedOut"],
+                    "TestTaggedOut",
+                ),
+                (
+                    "clients/go/node/sync_reorg_test.go",
+                    "package node\n\nfunc TestNoImport(t *testing.T) {}\n",
+                    ["TestNoImport"],
+                    "TestNoImport",
+                ),
+            ]
+            for rel_path, source, tests, want in cases:
+                with self.subTest(want=want):
+                    root = Path(td) / want.split()[0].replace(",", "")
+                    make_repo(root)
+                    rc, stderr = run_runtime_evidence(root, rel_path, source, tests)
+                    self.assertEqual(rc, 1)
+                    self.assertIn(want, stderr)
+
+    def test_runtime_evidence_accepts_aliased_go_testing_import(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(root)
+            rel_path = "clients/go/node/sync_reorg_test.go"
+            (root / rel_path).parent.mkdir(parents=True, exist_ok=True)
+            (root / rel_path).write_text(
+                'package node\n\nimport tb "testing"\n\nfunc TestAliased(t *tb.T) {}\n',
+                encoding="utf-8",
+            )
+            add_runtime_evidence(root, rel_path, ["TestAliased"])
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stdout(captured):
+                rc = m.main()
+        self.assertEqual(rc, 0)
+        self.assertIn("OK: conformance edge-pack baseline satisfied.", captured.getvalue())
+
+    def test_runtime_evidence_rejects_inactive_or_non_plain_rust_tests(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(root)
+            rel_path = "clients/rust/crates/rubin-node/src/sync_reorg.rs"
+            (root / rel_path).parent.mkdir(parents=True, exist_ok=True)
+            (root / rel_path).write_text(
+                "#[test]\n#[ignore]\nfn ignored() {}\n#[ignore]\n#[test]\nfn ignored_before() {}\n"
+                "#[test]\n#[cfg(FALSE)]\nfn cfg_disabled() {}\n#[cfg(FALSE)]\n#[test]\nfn cfg_before() {}\n"
+                "#[cfg(\nFALSE\n)]\n#[test]\nfn cfg_multiline() {}\n#[cfg_attr(\nfeature = \"never\",\nignore\n)]\n#[test]\nfn cfg_attr_multiline() {}\n"
+                "#[cfg(FALSE)]\nmod disabled { #[test]\nfn disabled_module() {} }\n#[cfg(FALSE)]\n#[allow(dead_code)]\nmod disabled_stacked { #[test]\nfn disabled_mod_test() {} }\n"
+                "#[cfg(FALSE)]\nmod disabled_next\n{\n#[test]\nfn disabled_next_line_brace() {}\n}\n#[test]\nconst fn const_test() {}\n#[test]\nunsafe fn unsafe_test() {}\n#[test]\nextern \"C\" fn extern_test() {}\n",
+                encoding="utf-8",
+            )
+            add_runtime_evidence(
+                root,
+                rel_path,
+                (
+                    "ignored ignored_before cfg_disabled cfg_before cfg_multiline cfg_attr_multiline "
+                    "disabled_module disabled_mod_test disabled_next_line_brace const_test unsafe_test extern_test"
+                ).split(),
+            )
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stderr(captured):
+                rc = m.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("disabled_next_line_brace, const_test, unsafe_test, extern_test", captured.getvalue())
 
     def test_missing_required_vector_fails(self) -> None:
         with tempfile.TemporaryDirectory() as td:

--- a/tools/tests/test_check_conformance_edge_pack.py
+++ b/tools/tests/test_check_conformance_edge_pack.py
@@ -123,16 +123,16 @@ class EdgePackCheckerTests(unittest.TestCase):
             rust_path = "clients/rust/crates/rubin-node/src/sync_reorg.rs"
             (root / go_path).parent.mkdir(parents=True, exist_ok=True)
             (root / rust_path).parent.mkdir(parents=True, exist_ok=True)
-            go_source = "\ufeffpackage node\n\nimport \"fmt\"\nimport . `testing`\n\nvar _ = fmt.Sprintf\nfunc TestRuntimeReorg(t * T) {}\nfunc Test1Bad(t *T) {}\nfunc Test_Bad(t *T) {}\n"
-            rust_source = "#[cfg(test)]\nmod tests {\nfn helper<'a>() {}\n#[cfg(any(test, feature = \"x\"))]\n#[test] #[should_panic] fn runtime_reorg_test() { panic!() }\n#[cfg_attr(not(test), ignore)]\n#[test] fn runtime_reorg_cfg_attr_test() {}\n}\n"
+            go_source = "\ufeffpackage node\n\nimport (\"fmt\"; . `testing`)\n\nvar _ = fmt.Sprintf\nfunc TestRuntimeReorg(t * T) {}\nfunc TestMultiline(\n    t *T,\n) {}\nfunc Test1Bad(t *T) {}\nfunc Test_Bad(t *T) {}\n"
+            rust_source = "#[cfg(test)]\nmod tests {\nfn helper<'a>() {}\n#[cfg(any(test, feature = \"x\"))]\n#[test] #[should_panic] fn runtime_reorg_test() { panic!() }\n#[cfg(all(test,))]\n#[test] fn runtime_reorg_cfg_trailing_test() {}\n#[cfg_attr(not(test), ignore)]\n#[test] fn runtime_reorg_cfg_attr_test() {}\n}\n"
             (root / go_path).write_text(go_source, encoding="utf-8")
             (root / rust_path).write_text(rust_source, encoding="utf-8")
             baseline_path = root / "conformance" / "EDGE_PACK_BASELINE.json"
             baseline = json.loads(baseline_path.read_text(encoding="utf-8"))
             baseline["domains"][0]["runtime_evidence"] = {
                 "tests_by_file": {
-                    go_path: ["TestRuntimeReorg", "Test1Bad", "Test_Bad"],
-                    rust_path: ["runtime_reorg_test", "runtime_reorg_cfg_attr_test"],
+                    go_path: ["TestRuntimeReorg", "TestMultiline", "Test1Bad", "Test_Bad"],
+                    rust_path: ["runtime_reorg_test", "runtime_reorg_cfg_trailing_test", "runtime_reorg_cfg_attr_test"],
                 }
             }
             write_json(baseline_path, baseline)
@@ -173,7 +173,7 @@ class EdgePackCheckerTests(unittest.TestCase):
                     ["TestRawImport", "TestStringImport"],
                     "TestRawImport, TestStringImport",
                 ),
-                ("clients/go/node/sync_reorg_test.go", "/* lead */\n//go:build never\n\npackage node\n\nimport \"testing\"\n\nfunc TestTaggedOut(t *testing.T) {}\n", ["TestTaggedOut"], "TestTaggedOut"),
+                ("clients/go/node/sync_reorg_test.go", "/* lead */\n//\t+build never\n\npackage node\n\nimport \"testing\"\n\nfunc TestTaggedOut(t *testing.T) {}\n", ["TestTaggedOut"], "TestTaggedOut"),
                 ("clients/go/node/sync_reorg_windows_test.go", "package node\n\nimport \"testing\"\n\nfunc TestTaggedByFileName(t *testing.T) {}\n", ["TestTaggedByFileName"], "must not use GOOS/GOARCH file constraints"),
                 ("clients/go/node/sync_reorg_test.go", "package node\n\nfunc TestNoImport(t *testing.T) {}\n", ["TestNoImport"], "TestNoImport"),
             ]
@@ -198,7 +198,7 @@ class EdgePackCheckerTests(unittest.TestCase):
                 "#[cfg(\nFALSE\n)]\n#[test]\nfn cfg_multiline() {}\n#[cfg_attr(\ntest,\nignore\n)]\n#[test]\nfn cfg_attr_multiline() {}\n"
                 "#[cfg(FALSE)]\nmod disabled { #[test]\nfn disabled_module() {} }\n#[cfg(FALSE)]\n#[allow(dead_code)]\nmod disabled_stacked { #[test]\nfn disabled_mod_test() {} }\n"
                 "#[cfg(FALSE)]\nmod disabled_brace { const C: char = '}'; #[test]\nfn disabled_brace_module() {} }\n"
-                "#[cfg(FALSE)]\nmod disabled_next\n{\n#[test]\nfn disabled_next_line_brace() {}\n}\n#[test]\nconst fn const_test() {}\n#[test]\nunsafe fn unsafe_test() {}\n#[test]\nextern \"C\" fn extern_test() {}\n"
+                "#[cfg(FALSE)]\nmod disabled_next\n{\n#[test]\nfn disabled_next_line_brace() {}\n}\n#[test]\nconst fn const_test() {}\n#[test]\nunsafe fn unsafe_test() {}\n#[test]\nextern \"C\" fn extern_test() {}\n#[test]\nfn arg_test(x: i32) {}\n"
                 "mod inner_disabled {\n#![cfg(FALSE)]\n#[test]\nfn inner_cfg() {}\n}\n",
                 encoding="utf-8",
             )
@@ -208,7 +208,7 @@ class EdgePackCheckerTests(unittest.TestCase):
                 (
                     "ignored ignored_before cfg_disabled cfg_before cfg_nested_not_test cfg_multiline cfg_attr_multiline "
                     "disabled_module disabled_mod_test disabled_brace_module disabled_next_line_brace "
-                    "const_test unsafe_test extern_test inner_cfg"
+                    "const_test unsafe_test extern_test arg_test inner_cfg"
                 ).split(),
             )
             captured = io.StringIO()

--- a/tools/tests/test_check_conformance_edge_pack.py
+++ b/tools/tests/test_check_conformance_edge_pack.py
@@ -123,14 +123,17 @@ class EdgePackCheckerTests(unittest.TestCase):
             rust_path = "clients/rust/crates/rubin-node/src/sync_reorg.rs"
             (root / go_path).parent.mkdir(parents=True, exist_ok=True)
             (root / rust_path).parent.mkdir(parents=True, exist_ok=True)
-            go_source = "package node\n\nimport \"fmt\"\nimport tb `testing`\n\nvar _ = fmt.Sprintf\nfunc TestRuntimeReorg(t * tb.T) {}\n"
-            rust_source = "#[cfg(test)]\nmod tests {\nfn helper<'a>() {}\n#[test] #[should_panic] fn runtime_reorg_test() { panic!() }\n}\n"
+            go_source = "\ufeffpackage node\n\nimport \"fmt\"\nimport . `testing`\n\nvar _ = fmt.Sprintf\nfunc TestRuntimeReorg(t * T) {}\nfunc Test1Bad(t *T) {}\nfunc Test_Bad(t *T) {}\n"
+            rust_source = "#[cfg(test)]\nmod tests {\nfn helper<'a>() {}\n#[cfg(any(test, feature = \"x\"))]\n#[test] #[should_panic] fn runtime_reorg_test() { panic!() }\n#[cfg_attr(not(test), ignore)]\n#[test] fn runtime_reorg_cfg_attr_test() {}\n}\n"
             (root / go_path).write_text(go_source, encoding="utf-8")
             (root / rust_path).write_text(rust_source, encoding="utf-8")
             baseline_path = root / "conformance" / "EDGE_PACK_BASELINE.json"
             baseline = json.loads(baseline_path.read_text(encoding="utf-8"))
             baseline["domains"][0]["runtime_evidence"] = {
-                "tests_by_file": {go_path: ["TestRuntimeReorg"], rust_path: ["runtime_reorg_test"]}
+                "tests_by_file": {
+                    go_path: ["TestRuntimeReorg", "Test1Bad", "Test_Bad"],
+                    rust_path: ["runtime_reorg_test", "runtime_reorg_cfg_attr_test"],
+                }
             }
             write_json(baseline_path, baseline)
             captured = io.StringIO()
@@ -158,9 +161,9 @@ class EdgePackCheckerTests(unittest.TestCase):
             cases = [
                 (
                     "clients/go/node/sync_reorg_test.go",
-                    "package node\n\nimport \"testing\"\n\nfunc Testlower() {}\nfunc Test1Bad(t *testing.T) {}\nfunc Test_Bad(t *testing.T) {}\nfunc TestWrong(t string) {}\nfunc TestExtra(t *testing.T, n int) {}\n",
-                    ["Testlower", "Test1Bad", "Test_Bad", "TestWrong", "TestExtra"],
-                    "Testlower, Test1Bad, Test_Bad, TestWrong, TestExtra",
+                    "package node\n\nimport \"testing\"\n\nfunc Testlower() {}\nfunc TestWrong(t string) {}\nfunc TestExtra(t *testing.T, n int) {}\n",
+                    ["Testlower", "TestWrong", "TestExtra"],
+                    "Testlower, TestWrong, TestExtra",
                 ),
                 ("clients/go/node/sync_reorg.go", "package node\n\nimport \"testing\"\n\nfunc TestWrongFile(t *testing.T) {}\n", ["TestWrongFile"], "must end with _test.go"),
                 ("clients/go/node/sync_reorg_test.go", "package node\n/*\nimport \"testing\"\n*/\nfunc TestCommentImport(t *testing.T) {}\n", ["TestCommentImport"], "TestCommentImport"),
@@ -191,8 +194,10 @@ class EdgePackCheckerTests(unittest.TestCase):
             (root / rel_path).write_text(
                 "#[test]\n#[ignore]\nfn ignored() {}\n#[ignore]\n#[test]\nfn ignored_before() {}\n"
                 "#[test]\n#[cfg(FALSE)]\nfn cfg_disabled() {}\n#[cfg(FALSE)]\n#[test]\nfn cfg_before() {}\n"
-                "#[cfg(\nFALSE\n)]\n#[test]\nfn cfg_multiline() {}\n#[cfg_attr(\nfeature = \"never\",\nignore\n)]\n#[test]\nfn cfg_attr_multiline() {}\n"
+                "#[cfg(any(not(test), feature = \"never\"))]\n#[test]\nfn cfg_nested_not_test() {}\n"
+                "#[cfg(\nFALSE\n)]\n#[test]\nfn cfg_multiline() {}\n#[cfg_attr(\ntest,\nignore\n)]\n#[test]\nfn cfg_attr_multiline() {}\n"
                 "#[cfg(FALSE)]\nmod disabled { #[test]\nfn disabled_module() {} }\n#[cfg(FALSE)]\n#[allow(dead_code)]\nmod disabled_stacked { #[test]\nfn disabled_mod_test() {} }\n"
+                "#[cfg(FALSE)]\nmod disabled_brace { const C: char = '}'; #[test]\nfn disabled_brace_module() {} }\n"
                 "#[cfg(FALSE)]\nmod disabled_next\n{\n#[test]\nfn disabled_next_line_brace() {}\n}\n#[test]\nconst fn const_test() {}\n#[test]\nunsafe fn unsafe_test() {}\n#[test]\nextern \"C\" fn extern_test() {}\n"
                 "mod inner_disabled {\n#![cfg(FALSE)]\n#[test]\nfn inner_cfg() {}\n}\n",
                 encoding="utf-8",
@@ -201,15 +206,16 @@ class EdgePackCheckerTests(unittest.TestCase):
                 root,
                 rel_path,
                 (
-                    "ignored ignored_before cfg_disabled cfg_before cfg_multiline cfg_attr_multiline "
-                    "disabled_module disabled_mod_test disabled_next_line_brace const_test unsafe_test extern_test inner_cfg"
+                    "ignored ignored_before cfg_disabled cfg_before cfg_nested_not_test cfg_multiline cfg_attr_multiline "
+                    "disabled_module disabled_mod_test disabled_brace_module disabled_next_line_brace "
+                    "const_test unsafe_test extern_test inner_cfg"
                 ).split(),
             )
             captured = io.StringIO()
             with chdir(root), contextlib.redirect_stderr(captured):
                 rc = m.main()
         self.assertEqual(rc, 1)
-        self.assertIn("disabled_next_line_brace, const_test, unsafe_test, extern_test", captured.getvalue())
+        self.assertIn("disabled_brace_module, disabled_next_line_brace, const_test", captured.getvalue())
 
     def test_missing_required_vector_fails(self) -> None:
         with tempfile.TemporaryDirectory() as td:

--- a/tools/tests/test_check_conformance_edge_pack.py
+++ b/tools/tests/test_check_conformance_edge_pack.py
@@ -124,11 +124,11 @@ class EdgePackCheckerTests(unittest.TestCase):
             (root / go_path).parent.mkdir(parents=True, exist_ok=True)
             (root / rust_path).parent.mkdir(parents=True, exist_ok=True)
             (root / go_path).write_text(
-                "package node\n\nimport \"testing\"\n\nfunc TestRuntimeReorg(t *testing.T) {}\n",
+                "package node\n\nimport tb `testing`\n\nfunc TestRuntimeReorg(t *tb.T) {}\n",
                 encoding="utf-8",
             )
             (root / rust_path).write_text(
-                "#[cfg(test)]\nmod tests {\n    #[test]\n    fn runtime_reorg_test() {}\n}\n",
+                "#[cfg(test)]\nmod tests {\nfn helper<'a>() {}\n#[test] fn runtime_reorg_test() {}\n}\n",
                 encoding="utf-8",
             )
             baseline_path = root / "conformance" / "EDGE_PACK_BASELINE.json"
@@ -189,7 +189,7 @@ class EdgePackCheckerTests(unittest.TestCase):
                 ),
                 (
                     "clients/go/node/sync_reorg_test.go",
-                    "//go:build never\n\npackage node\n\nimport \"testing\"\n\nfunc TestTaggedOut(t *testing.T) {}\n",
+                    "/* lead */\n//go:build never\n\npackage node\n\nimport \"testing\"\n\nfunc TestTaggedOut(t *testing.T) {}\n",
                     ["TestTaggedOut"],
                     "TestTaggedOut",
                 ),
@@ -208,23 +208,6 @@ class EdgePackCheckerTests(unittest.TestCase):
                     self.assertEqual(rc, 1)
                     self.assertIn(want, stderr)
 
-    def test_runtime_evidence_accepts_aliased_go_testing_import(self) -> None:
-        with tempfile.TemporaryDirectory() as td:
-            root = Path(td)
-            make_repo(root)
-            rel_path = "clients/go/node/sync_reorg_test.go"
-            (root / rel_path).parent.mkdir(parents=True, exist_ok=True)
-            (root / rel_path).write_text(
-                'package node\n\nimport tb "testing"\n\nfunc TestAliased(t *tb.T) {}\n',
-                encoding="utf-8",
-            )
-            add_runtime_evidence(root, rel_path, ["TestAliased"])
-            captured = io.StringIO()
-            with chdir(root), contextlib.redirect_stdout(captured):
-                rc = m.main()
-        self.assertEqual(rc, 0)
-        self.assertIn("OK: conformance edge-pack baseline satisfied.", captured.getvalue())
-
     def test_runtime_evidence_rejects_inactive_or_non_plain_rust_tests(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)
@@ -236,7 +219,8 @@ class EdgePackCheckerTests(unittest.TestCase):
                 "#[test]\n#[cfg(FALSE)]\nfn cfg_disabled() {}\n#[cfg(FALSE)]\n#[test]\nfn cfg_before() {}\n"
                 "#[cfg(\nFALSE\n)]\n#[test]\nfn cfg_multiline() {}\n#[cfg_attr(\nfeature = \"never\",\nignore\n)]\n#[test]\nfn cfg_attr_multiline() {}\n"
                 "#[cfg(FALSE)]\nmod disabled { #[test]\nfn disabled_module() {} }\n#[cfg(FALSE)]\n#[allow(dead_code)]\nmod disabled_stacked { #[test]\nfn disabled_mod_test() {} }\n"
-                "#[cfg(FALSE)]\nmod disabled_next\n{\n#[test]\nfn disabled_next_line_brace() {}\n}\n#[test]\nconst fn const_test() {}\n#[test]\nunsafe fn unsafe_test() {}\n#[test]\nextern \"C\" fn extern_test() {}\n",
+                "#[cfg(FALSE)]\nmod disabled_next\n{\n#[test]\nfn disabled_next_line_brace() {}\n}\n#[test]\nconst fn const_test() {}\n#[test]\nunsafe fn unsafe_test() {}\n#[test]\nextern \"C\" fn extern_test() {}\n"
+                "mod inner_disabled {\n#![cfg(FALSE)]\n#[test]\nfn inner_cfg() {}\n}\n",
                 encoding="utf-8",
             )
             add_runtime_evidence(
@@ -244,7 +228,7 @@ class EdgePackCheckerTests(unittest.TestCase):
                 rel_path,
                 (
                     "ignored ignored_before cfg_disabled cfg_before cfg_multiline cfg_attr_multiline "
-                    "disabled_module disabled_mod_test disabled_next_line_brace const_test unsafe_test extern_test"
+                    "disabled_module disabled_mod_test disabled_next_line_brace const_test unsafe_test extern_test inner_cfg"
                 ).split(),
             )
             captured = io.StringIO()


### PR DESCRIPTION
Refs: RUB-344 / #1764

Invariant:
Runtime evidence declared in EDGE_PACK_BASELINE must fail closed when declared Go/Rust test names are absent from executable-looking declarations in declared files.

Layer:
tests / conformance tooling

Files changed:
- conformance/EDGE_PACK_BASELINE.json
- conformance/README.md
- tools/check_conformance_edge_pack.py
- tools/tests/test_check_conformance_edge_pack.py

Tests:
- python3 -m unittest tools.tests.test_check_conformance_edge_pack — PASS
- scripts/dev-env.sh -- python3 tools/check_conformance_edge_pack.py — PASS
- scripts/dev-env.sh -- python3 tools/gen_conformance_matrix.py --check — PASS
- scripts/dev-env.sh -- python3 tools/check_conformance_fixtures_policy.py — PASS
- scripts/dev-env.sh -- python3 conformance/runner/run_cv_bundle.py — PASS, 604 vectors
- ruff check tools/check_conformance_edge_pack.py tools/tests/test_check_conformance_edge_pack.py — PASS
- bandit -q tools/check_conformance_edge_pack.py tools/tests/test_check_conformance_edge_pack.py — PASS
- vulture tools/check_conformance_edge_pack.py tools/tests/test_check_conformance_edge_pack.py --min-confidence 90 — PASS
- python3 -m py_compile tools/check_conformance_edge_pack.py tools/tests/test_check_conformance_edge_pack.py — PASS
- rubin-precommit-one-review — PASS
- stock pre-push reviewer — No findings
- rubin-push --no-coverage-reason 'Python/JSON/Markdown conformance tooling only; no Go/Rust production or coverable client code changed' — PASS

Behavior impact:
Adds checker enforcement for runtime_evidence declaration shape in the edge-pack baseline. No client runtime behavior changes.

Compatibility impact:
No consensus, fixture validity-vector, Go client, or Rust client behavior change.

Known non-goals:
- No source-boundary/path-containment/module graph hardening.
- No full go test or cargo test listing integration.
- No consensus/runtime code changes.
- No conformance CV validity-vector changes.

Risk:
The scanner is declaration-shape evidence only, not a Rust/Go AST or reachability proof.

Rollback:
Revert this PR to remove runtime_evidence declaration enforcement and the runtime_reorg declaration entries.

Not checked:
Full Go and Rust client test suites; this diff does not touch Go/Rust client code.


<!-- rubin-agent-meta actor=unknown action=pr-create via=cl branch=codex/RUB-344-runtime-evidence-declaration wt=rubin-protocol-codex-RUB-344 utc=2026-05-22T12:21:56Z -->
