### PR TITLE
[RUB-330] Serve Go compact getblocktxn requests

### DIFF
--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -374,6 +374,89 @@ func (p *peer) handleBlockTxn(payload []byte) error {
 	return p.processCompactTransactions(req.BlockHash, req.Header, txs, true)
 }
 
+func (p *peer) handleGetBlockTxn(payload []byte) error {
+	req, err := decodeGetBlockTxnPayload(payload)
+	if err != nil {
+		return err
+	}
+	if err := compactValidateUniqueGetBlockTxnIndexes(req.Indexes); err != nil {
+		return err
+	}
+	block, ok, err := p.blockBytes(req.BlockHash)
+	if err != nil || !ok {
+		return err
+	}
+	txs, err := compactBlockTransactionsByIndex(block, req.Indexes)
+	if err != nil {
+		return err
+	}
+	response, err := encodeBlockTxnPayload(blockTxnPayload{BlockHash: req.BlockHash, Transactions: txs})
+	if err != nil {
+		return err
+	}
+	return p.send(messageBlockTxn, response)
+}
+
+func compactValidateUniqueGetBlockTxnIndexes(indexes []uint64) error {
+	if len(indexes) < 2 {
+		return nil
+	}
+	seen := make(map[uint64]struct{}, len(indexes))
+	for _, idx := range indexes {
+		if _, ok := seen[idx]; ok {
+			return errors.New("duplicate getblocktxn index")
+		}
+		seen[idx] = struct{}{}
+	}
+	return nil
+}
+
+func compactBlockTransactionsByIndex(block []byte, indexes []uint64) ([][]byte, error) {
+	txCount, offset, err := compactBlockTransactionCount(block)
+	if err != nil {
+		return nil, err
+	}
+	for _, idx := range indexes {
+		if idx >= txCount {
+			return nil, errors.New("getblocktxn index out of range")
+		}
+	}
+	if len(indexes) == 0 {
+		return [][]byte{}, nil
+	}
+
+	positions := make(map[uint64]int, len(indexes))
+	for pos, idx := range indexes {
+		positions[idx] = pos
+	}
+	txs := make([][]byte, len(indexes))
+	for txIndex := uint64(0); txIndex < txCount; txIndex++ {
+		_, _, _, consumed, err := consensus.ParseTx(block[offset:])
+		if err != nil || consumed <= 0 || offset+consumed > len(block) {
+			return nil, errors.New("stored block transaction is non-canonical")
+		}
+		if pos, ok := positions[txIndex]; ok {
+			txs[pos] = append([]byte(nil), block[offset:offset+consumed]...)
+		}
+		offset += consumed
+	}
+	if offset != len(block) {
+		return nil, errors.New("stored block has trailing bytes after transactions")
+	}
+	return txs, nil
+}
+
+func compactBlockTransactionCount(block []byte) (uint64, int, error) {
+	if len(block) < consensus.BLOCK_HEADER_BYTES {
+		return 0, 0, errors.New("stored block missing header")
+	}
+	txCount, countLen, err := consensus.DecodeCompactSize(block[consensus.BLOCK_HEADER_BYTES:])
+	if err != nil {
+		return 0, 0, err
+	}
+	return txCount, consensus.BLOCK_HEADER_BYTES + countLen, nil
+}
+
 func (p *peer) rejectBlockTxn(msg string) error {
 	p.bumpBan(10, msg)
 	return errors.New(msg)

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -383,6 +383,11 @@ func (p *peer) handleGetBlockTxn(payload []byte) error {
 	if err := compactValidateUniqueGetBlockTxnIndexes(req.Indexes); err != nil {
 		return p.rejectGetBlockTxn(err.Error())
 	}
+	p.compactSendBarrier()
+	if !p.consumeCompactBlockAnnouncement(req.BlockHash) {
+		p.setLastError("ignored unannounced getblocktxn request")
+		return nil
+	}
 	block, ok, err := p.blockBytes(req.BlockHash)
 	if err != nil || !ok {
 		return err

--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -19,6 +19,7 @@ const (
 var (
 	errCompactRelayMissingRequestTooLarge = errors.New("too many compact relay missing transactions")
 	errBlockTxnTransactionShortIDMismatch = errors.New("blocktxn transaction short id mismatch")
+	errGetBlockTxnIndexOutOfRange         = errors.New("getblocktxn index out of range")
 )
 
 type compactReconstructionResult struct {
@@ -377,10 +378,10 @@ func (p *peer) handleBlockTxn(payload []byte) error {
 func (p *peer) handleGetBlockTxn(payload []byte) error {
 	req, err := decodeGetBlockTxnPayload(payload)
 	if err != nil {
-		return err
+		return p.rejectGetBlockTxn(err.Error())
 	}
 	if err := compactValidateUniqueGetBlockTxnIndexes(req.Indexes); err != nil {
-		return err
+		return p.rejectGetBlockTxn(err.Error())
 	}
 	block, ok, err := p.blockBytes(req.BlockHash)
 	if err != nil || !ok {
@@ -388,6 +389,9 @@ func (p *peer) handleGetBlockTxn(payload []byte) error {
 	}
 	txs, err := compactBlockTransactionsByIndex(block, req.Indexes)
 	if err != nil {
+		if errors.Is(err, errGetBlockTxnIndexOutOfRange) {
+			return p.rejectGetBlockTxn(err.Error())
+		}
 		return err
 	}
 	response, err := encodeBlockTxnPayload(blockTxnPayload{BlockHash: req.BlockHash, Transactions: txs})
@@ -418,7 +422,7 @@ func compactBlockTransactionsByIndex(block []byte, indexes []uint64) ([][]byte, 
 	}
 	for _, idx := range indexes {
 		if idx >= txCount {
-			return nil, errors.New("getblocktxn index out of range")
+			return nil, errGetBlockTxnIndexOutOfRange
 		}
 	}
 	if len(indexes) == 0 {
@@ -426,11 +430,15 @@ func compactBlockTransactionsByIndex(block []byte, indexes []uint64) ([][]byte, 
 	}
 
 	positions := make(map[uint64]int, len(indexes))
+	var maxIndex uint64
 	for pos, idx := range indexes {
 		positions[idx] = pos
+		if idx > maxIndex {
+			maxIndex = idx
+		}
 	}
 	txs := make([][]byte, len(indexes))
-	for txIndex := uint64(0); txIndex < txCount; txIndex++ {
+	for txIndex := uint64(0); txIndex <= maxIndex; txIndex++ {
 		_, _, _, consumed, err := consensus.ParseTx(block[offset:])
 		if err != nil || consumed <= 0 || offset+consumed > len(block) {
 			return nil, errors.New("stored block transaction is non-canonical")
@@ -440,7 +448,7 @@ func compactBlockTransactionsByIndex(block []byte, indexes []uint64) ([][]byte, 
 		}
 		offset += consumed
 	}
-	if offset != len(block) {
+	if maxIndex == txCount-1 && offset != len(block) {
 		return nil, errors.New("stored block has trailing bytes after transactions")
 	}
 	return txs, nil
@@ -458,6 +466,11 @@ func compactBlockTransactionCount(block []byte) (uint64, int, error) {
 }
 
 func (p *peer) rejectBlockTxn(msg string) error {
+	p.bumpBan(10, msg)
+	return errors.New(msg)
+}
+
+func (p *peer) rejectGetBlockTxn(msg string) error {
 	p.bumpBan(10, msg)
 	return errors.New(msg)
 }

--- a/clients/go/node/p2p/compact_reconstruct_test.go
+++ b/clients/go/node/p2p/compact_reconstruct_test.go
@@ -506,6 +506,133 @@ func TestHandleBlockTxnMatchingPayloadCapOverflowBans(t *testing.T) {
 	}
 }
 
+func TestRunRoutesNegotiatedGetBlockTxn(t *testing.T) {
+	_, blockHash, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
+	p := newPeerRuntimeTestPeer(t)
+	p.service.cfg.EnableCompactReceive = true
+	p.setRemoteCompactMode(compactModeSnapshot{Mode: 1, Version: compactRelayVersion})
+	requireNoCompactErr(t, p.handleBlock(node.DevnetGenesisBlockBytes()), "seed existing block")
+	payload := mustEncodeGetBlockTxnRequest(t, blockHash, []uint64{0})
+	p.conn = &scriptedConn{reads: []scriptedRead{{data: mustPeerRuntimeFrameBytes(t, p, message{Command: messageGetBlockTxn, Payload: payload})}}}
+
+	requireNoCompactErr(t, p.run(context.Background()), "run getblocktxn")
+	frame := requireCompactFrame(t, p, messageBlockTxn)
+	got, err := decodeBlockTxnPayload(frame.Payload)
+	requireNoCompactErr(t, err, "decode served blocktxn")
+	if got.BlockHash != blockHash || len(got.Transactions) != 1 || !bytes.Equal(got.Transactions[0], txs[0]) {
+		t.Fatalf("served blocktxn=%+v, want hash %x and requested tx", got, blockHash)
+	}
+}
+
+func TestHandleGetBlockTxnRejectsDuplicateBeforeBlockLookup(t *testing.T) {
+	p := newCompactScriptedPeer(t)
+	p.service.cfg.BlockStore = nil
+	payload := mustEncodeGetBlockTxnRequest(t, [32]byte{0x42}, []uint64{0, 0})
+
+	err := p.handleGetBlockTxn(payload)
+	if err == nil || !strings.Contains(err.Error(), "duplicate getblocktxn index") {
+		t.Fatalf("handleGetBlockTxn duplicate err=%v, want duplicate index", err)
+	}
+	if p.conn.(*scriptedConn).Buffer.Len() != 0 {
+		t.Fatal("duplicate getblocktxn sent a response")
+	}
+}
+
+func TestHandleGetBlockTxnMalformedAndMissingBlock(t *testing.T) {
+	p := newCompactScriptedPeer(t)
+	if err := p.handleGetBlockTxn(make([]byte, 31)); err == nil || !strings.Contains(err.Error(), "getblocktxn payload missing block hash") {
+		t.Fatalf("short getblocktxn err=%v, want missing block hash", err)
+	}
+	if p.conn.(*scriptedConn).Buffer.Len() != 0 {
+		t.Fatal("malformed getblocktxn sent a response")
+	}
+
+	p = newCompactScriptedPeer(t)
+	payload := mustEncodeGetBlockTxnRequest(t, [32]byte{0x99}, []uint64{0})
+	if err := p.handleGetBlockTxn(payload); err != nil {
+		t.Fatalf("missing block getblocktxn err=%v, want nil", err)
+	}
+	if p.conn.(*scriptedConn).Buffer.Len() != 0 {
+		t.Fatal("missing block getblocktxn sent a response")
+	}
+}
+
+func TestHandleGetBlockTxnRejectsOutOfRangeAfterBlockCount(t *testing.T) {
+	_, blockHash, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
+	p := newCompactScriptedPeer(t)
+	requireNoCompactErr(t, p.handleBlock(node.DevnetGenesisBlockBytes()), "seed existing block")
+	payload := mustEncodeGetBlockTxnRequest(t, blockHash, []uint64{uint64(len(txs))})
+
+	err := p.handleGetBlockTxn(payload)
+	if err == nil || !strings.Contains(err.Error(), "getblocktxn index out of range") {
+		t.Fatalf("handleGetBlockTxn out-of-range err=%v, want range error", err)
+	}
+	if p.conn.(*scriptedConn).Buffer.Len() != 0 {
+		t.Fatal("out-of-range getblocktxn sent a response")
+	}
+}
+
+func TestCompactValidateUniqueGetBlockTxnIndexesAcceptsDistinct(t *testing.T) {
+	if err := compactValidateUniqueGetBlockTxnIndexes([]uint64{2, 0, 1}); err != nil {
+		t.Fatalf("compactValidateUniqueGetBlockTxnIndexes: %v", err)
+	}
+}
+
+func TestCompactBlockTransactionsByIndexPreservesRequestOrder(t *testing.T) {
+	txs := [][]byte{
+		minimalBlockTxnTestTxBytes(301),
+		minimalBlockTxnTestTxBytes(302),
+		minimalBlockTxnTestTxBytes(303),
+	}
+	block := compactTestBlockBytesWithTxs(t, txs)
+
+	got, err := compactBlockTransactionsByIndex(block, []uint64{2, 0, 1})
+	requireNoCompactErr(t, err, "slice compact block transactions")
+	want := [][]byte{txs[2], txs[0], txs[1]}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ordered txs=%x, want %x", got, want)
+	}
+}
+
+func TestCompactBlockTransactionsByIndexHandlesEmptyRequest(t *testing.T) {
+	got, err := compactBlockTransactionsByIndex(node.DevnetGenesisBlockBytes(), nil)
+	requireNoCompactErr(t, err, "empty getblocktxn request")
+	if len(got) != 0 {
+		t.Fatalf("empty request returned %d txs, want 0", len(got))
+	}
+}
+
+func TestCompactBlockTransactionsByIndexRejectsRangeBeforeScanningTx(t *testing.T) {
+	genesis := node.DevnetGenesisBlockBytes()
+	block := append([]byte(nil), genesis[:consensus.BLOCK_HEADER_BYTES]...)
+	block = consensus.AppendCompactSize(block, 1)
+	block = append(block, 0xff)
+
+	_, err := compactBlockTransactionsByIndex(block, []uint64{1})
+	if err == nil || !strings.Contains(err.Error(), "getblocktxn index out of range") {
+		t.Fatalf("compactBlockTransactionsByIndex err=%v, want range before tx parse", err)
+	}
+}
+
+func TestCompactBlockTransactionsByIndexRejectsMalformedStoredBlocks(t *testing.T) {
+	txs := [][]byte{minimalBlockTxnTestTxBytes(401)}
+	for _, tc := range []struct {
+		name string
+		raw  []byte
+		want string
+	}{
+		{name: "short_header", raw: make([]byte, consensus.BLOCK_HEADER_BYTES-1), want: "stored block missing header"},
+		{name: "bad_count", raw: append(make([]byte, consensus.BLOCK_HEADER_BYTES), 0xfd), want: "TX_ERR_PARSE"},
+		{name: "bad_tx", raw: compactTestBlockBytesWithRawTxTail(t, [][]byte{{0xff}}, nil), want: "stored block transaction is non-canonical"},
+		{name: "trailing", raw: compactTestBlockBytesWithRawTxTail(t, txs, []byte{0x00}), want: "stored block has trailing bytes after transactions"},
+	} {
+		_, err := compactBlockTransactionsByIndex(tc.raw, []uint64{0})
+		if err == nil || !strings.Contains(err.Error(), tc.want) {
+			t.Fatalf("%s err=%v, want %q", tc.name, err, tc.want)
+		}
+	}
+}
+
 func TestHandleCmpctBlockIgnoresMalformedLocalCandidates(t *testing.T) {
 	header, blockHash, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
 	shortID := compactShortIDForTx(t, txs[0], 201, 202)
@@ -1215,6 +1342,31 @@ func cmpctBlockNonCanonicalPrefilledPayload(header [consensus.BLOCK_HEADER_BYTES
 	return append(raw, tx...)
 }
 
+func mustEncodeGetBlockTxnRequest(t *testing.T, blockHash [32]byte, indexes []uint64) []byte {
+	t.Helper()
+	raw, err := encodeGetBlockTxnPayload(getBlockTxnPayload{BlockHash: blockHash, Indexes: indexes})
+	if err != nil {
+		t.Fatalf("encodeGetBlockTxnPayload: %v", err)
+	}
+	return raw
+}
+
+func compactTestBlockBytesWithTxs(t *testing.T, txs [][]byte) []byte {
+	t.Helper()
+	return compactTestBlockBytesWithRawTxTail(t, txs, nil)
+}
+
+func compactTestBlockBytesWithRawTxTail(t *testing.T, txs [][]byte, tail []byte) []byte {
+	t.Helper()
+	genesis := node.DevnetGenesisBlockBytes()
+	raw := append([]byte(nil), genesis[:consensus.BLOCK_HEADER_BYTES]...)
+	raw = consensus.AppendCompactSize(raw, uint64(len(txs)))
+	for _, tx := range txs {
+		raw = append(raw, tx...)
+	}
+	return append(raw, tail...)
+}
+
 func newCompactScriptedPeer(t *testing.T) *peer {
 	t.Helper()
 	p := newPeerRuntimeTestPeer(t)
@@ -1266,7 +1418,7 @@ func compactPartsFromBlockBytes(t *testing.T, block []byte) ([consensus.BLOCK_HE
 	return header, blockHash, txs
 }
 
-func requireCompactFrame(t *testing.T, p *peer, command string) {
+func requireCompactFrame(t *testing.T, p *peer, command string) message {
 	t.Helper()
 	conn := p.conn.(*scriptedConn)
 	frame, err := readFrame(bytes.NewReader(conn.Buffer.Bytes()), networkMagic(p.service.cfg.PeerRuntimeConfig.Network), p.service.cfg.PeerRuntimeConfig.MaxMessageSize)
@@ -1274,6 +1426,7 @@ func requireCompactFrame(t *testing.T, p *peer, command string) {
 	if err != nil || frame.Command != command {
 		t.Fatalf("compact frame=%+v err=%v want %s", frame, err, command)
 	}
+	return frame
 }
 
 func requireNoCompactErr(t *testing.T, err error, label string) {

--- a/clients/go/node/p2p/compact_reconstruct_test.go
+++ b/clients/go/node/p2p/compact_reconstruct_test.go
@@ -512,6 +512,7 @@ func TestRunRoutesNegotiatedGetBlockTxn(t *testing.T) {
 	p.service.cfg.EnableCompactReceive = true
 	p.setRemoteCompactMode(compactModeSnapshot{Mode: 1, Version: compactRelayVersion})
 	requireNoCompactErr(t, p.handleBlock(node.DevnetGenesisBlockBytes()), "seed existing block")
+	p.markCompactBlockAnnounced(blockHash)
 	payload := mustEncodeGetBlockTxnRequest(t, blockHash, []uint64{0})
 	p.conn = &scriptedConn{reads: []scriptedRead{{data: mustPeerRuntimeFrameBytes(t, p, message{Command: messageGetBlockTxn, Payload: payload})}}}
 
@@ -555,6 +556,7 @@ func TestHandleGetBlockTxnMalformedAndMissingBlock(t *testing.T) {
 
 	p = newCompactScriptedPeer(t)
 	payload := mustEncodeGetBlockTxnRequest(t, [32]byte{0x99}, []uint64{0})
+	p.markCompactBlockAnnounced([32]byte{0x99})
 	if err := p.handleGetBlockTxn(payload); err != nil {
 		t.Fatalf("missing block getblocktxn err=%v, want nil", err)
 	}
@@ -570,6 +572,7 @@ func TestHandleGetBlockTxnRejectsOutOfRangeAfterBlockCount(t *testing.T) {
 	_, blockHash, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
 	p := newCompactScriptedPeer(t)
 	requireNoCompactErr(t, p.handleBlock(node.DevnetGenesisBlockBytes()), "seed existing block")
+	p.markCompactBlockAnnounced(blockHash)
 	payload := mustEncodeGetBlockTxnRequest(t, blockHash, []uint64{uint64(len(txs))})
 
 	err := p.handleGetBlockTxn(payload)
@@ -581,6 +584,55 @@ func TestHandleGetBlockTxnRejectsOutOfRangeAfterBlockCount(t *testing.T) {
 	}
 	if p.conn.(*scriptedConn).Buffer.Len() != 0 {
 		t.Fatal("out-of-range getblocktxn sent a response")
+	}
+}
+
+func TestHandleGetBlockTxnRequiresCompactAnnouncement(t *testing.T) {
+	_, blockHash, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
+	payload := mustEncodeGetBlockTxnRequest(t, blockHash, []uint64{0})
+	p := newCompactScriptedPeer(t)
+	requireNoCompactErr(t, p.handleBlock(node.DevnetGenesisBlockBytes()), "seed existing block")
+
+	if err := p.handleGetBlockTxn(payload); err != nil {
+		t.Fatalf("unannounced getblocktxn err=%v, want nil", err)
+	}
+	state := p.snapshotState()
+	if state.BanScore != 0 || !strings.Contains(state.LastError, "ignored unannounced getblocktxn request") {
+		t.Fatalf("unannounced getblocktxn state=%+v, want no-ban diagnostic", state)
+	}
+	if p.conn.(*scriptedConn).Buffer.Len() != 0 {
+		t.Fatal("unannounced getblocktxn sent a response")
+	}
+
+	p.markCompactBlockAnnounced(blockHash)
+	requireNoCompactErr(t, p.handleGetBlockTxn(payload), "announced getblocktxn")
+	frame := requireCompactFrame(t, p, messageBlockTxn)
+	got, err := decodeBlockTxnPayload(frame.Payload)
+	requireNoCompactErr(t, err, "decode announced blocktxn")
+	if got.BlockHash != blockHash || len(got.Transactions) != 1 || !bytes.Equal(got.Transactions[0], txs[0]) {
+		t.Fatalf("announced blocktxn=%+v, want hash %x and requested tx", got, blockHash)
+	}
+
+	p.conn.(*scriptedConn).Buffer.Reset()
+	requireNoCompactErr(t, p.handleGetBlockTxn(payload), "consumed getblocktxn announcement")
+	if p.conn.(*scriptedConn).Buffer.Len() != 0 {
+		t.Fatal("consumed getblocktxn announcement allowed a repeated response")
+	}
+}
+
+func TestHandleGetBlockTxnIgnoresUnannouncedBeforeBlockLookup(t *testing.T) {
+	p := newCompactScriptedPeer(t)
+	p.service.cfg.BlockStore = nil
+	payload := mustEncodeGetBlockTxnRequest(t, [32]byte{0x42}, []uint64{0})
+
+	if err := p.handleGetBlockTxn(payload); err != nil {
+		t.Fatalf("unannounced getblocktxn with nil blockstore err=%v, want nil before lookup", err)
+	}
+	if p.snapshotState().BanScore != 0 {
+		t.Fatalf("unannounced getblocktxn ban_score=%d, want 0", p.snapshotState().BanScore)
+	}
+	if p.conn.(*scriptedConn).Buffer.Len() != 0 {
+		t.Fatal("unannounced getblocktxn with nil blockstore sent a response")
 	}
 }
 

--- a/clients/go/node/p2p/compact_reconstruct_test.go
+++ b/clients/go/node/p2p/compact_reconstruct_test.go
@@ -533,6 +533,9 @@ func TestHandleGetBlockTxnRejectsDuplicateBeforeBlockLookup(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "duplicate getblocktxn index") {
 		t.Fatalf("handleGetBlockTxn duplicate err=%v, want duplicate index", err)
 	}
+	if p.snapshotState().BanScore == 0 {
+		t.Fatal("duplicate getblocktxn did not bump ban before block lookup")
+	}
 	if p.conn.(*scriptedConn).Buffer.Len() != 0 {
 		t.Fatal("duplicate getblocktxn sent a response")
 	}
@@ -543,6 +546,9 @@ func TestHandleGetBlockTxnMalformedAndMissingBlock(t *testing.T) {
 	if err := p.handleGetBlockTxn(make([]byte, 31)); err == nil || !strings.Contains(err.Error(), "getblocktxn payload missing block hash") {
 		t.Fatalf("short getblocktxn err=%v, want missing block hash", err)
 	}
+	if p.snapshotState().BanScore == 0 {
+		t.Fatal("malformed getblocktxn did not bump ban")
+	}
 	if p.conn.(*scriptedConn).Buffer.Len() != 0 {
 		t.Fatal("malformed getblocktxn sent a response")
 	}
@@ -551,6 +557,9 @@ func TestHandleGetBlockTxnMalformedAndMissingBlock(t *testing.T) {
 	payload := mustEncodeGetBlockTxnRequest(t, [32]byte{0x99}, []uint64{0})
 	if err := p.handleGetBlockTxn(payload); err != nil {
 		t.Fatalf("missing block getblocktxn err=%v, want nil", err)
+	}
+	if p.snapshotState().BanScore != 0 {
+		t.Fatalf("missing block ban_score=%d, want 0", p.snapshotState().BanScore)
 	}
 	if p.conn.(*scriptedConn).Buffer.Len() != 0 {
 		t.Fatal("missing block getblocktxn sent a response")
@@ -566,6 +575,9 @@ func TestHandleGetBlockTxnRejectsOutOfRangeAfterBlockCount(t *testing.T) {
 	err := p.handleGetBlockTxn(payload)
 	if err == nil || !strings.Contains(err.Error(), "getblocktxn index out of range") {
 		t.Fatalf("handleGetBlockTxn out-of-range err=%v, want range error", err)
+	}
+	if p.snapshotState().BanScore == 0 {
+		t.Fatal("out-of-range getblocktxn did not bump ban")
 	}
 	if p.conn.(*scriptedConn).Buffer.Len() != 0 {
 		t.Fatal("out-of-range getblocktxn sent a response")
@@ -611,6 +623,17 @@ func TestCompactBlockTransactionsByIndexRejectsRangeBeforeScanningTx(t *testing.
 	_, err := compactBlockTransactionsByIndex(block, []uint64{1})
 	if err == nil || !strings.Contains(err.Error(), "getblocktxn index out of range") {
 		t.Fatalf("compactBlockTransactionsByIndex err=%v, want range before tx parse", err)
+	}
+}
+
+func TestCompactBlockTransactionsByIndexStopsAfterHighestRequested(t *testing.T) {
+	txs := [][]byte{minimalBlockTxnTestTxBytes(501), []byte{0xff}}
+	block := compactTestBlockBytesWithRawTxTail(t, txs, nil)
+
+	got, err := compactBlockTransactionsByIndex(block, []uint64{0})
+	requireNoCompactErr(t, err, "slice early requested tx")
+	if len(got) != 1 || !bytes.Equal(got[0], txs[0]) {
+		t.Fatalf("early requested tx=%x, want %x", got, txs[0])
 	}
 }
 

--- a/clients/go/node/p2p/compact_runtime.go
+++ b/clients/go/node/p2p/compact_runtime.go
@@ -8,7 +8,10 @@ import (
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
 )
 
-const compactOutstandingRequestTTL = 15 * time.Second
+const (
+	compactOutstandingRequestTTL = 15 * time.Second
+	compactAnnouncedBlockLimit   = 16
+)
 
 type compactModeSnapshot struct {
 	Mode    uint8
@@ -18,6 +21,12 @@ type compactModeSnapshot struct {
 type peerCompactRelayState struct {
 	remoteMode  compactModeSnapshot
 	outstanding *compactOutstandingRequest
+	announced   []compactBlockAnnouncement
+}
+
+type compactBlockAnnouncement struct {
+	blockHash [32]byte
+	sent      bool
 }
 
 type compactOutstandingRequest struct {
@@ -65,6 +74,87 @@ func (p *peer) remoteCompactMode() compactModeSnapshot {
 	p.compactMu.Lock()
 	defer p.compactMu.Unlock()
 	return p.compact.remoteMode
+}
+
+func compactAnnouncementHashForSentMessage(command string, payload []byte) ([32]byte, bool) {
+	var zero [32]byte
+	if command != messageCmpctBlock {
+		return zero, false
+	}
+	header, ok := cmpctBlockHeaderValidationCandidate(payload)
+	if !ok {
+		return zero, false
+	}
+	blockHash, _ := consensus.BlockHash(header[:]) // fixed-size header slice cannot hit the length error path
+	return blockHash, true
+}
+
+func (p *peer) markCompactBlockAnnounced(blockHash [32]byte) {
+	p.compactMu.Lock()
+	defer p.compactMu.Unlock()
+	p.appendCompactBlockAnnouncementLocked(blockHash, true)
+	p.trimCompactBlockAnnouncementsLocked()
+}
+
+func (p *peer) beginCompactBlockAnnouncementSend(blockHash [32]byte) {
+	p.compactMu.Lock()
+	defer p.compactMu.Unlock()
+	p.appendCompactBlockAnnouncementLocked(blockHash, false)
+}
+
+func (p *peer) finishCompactBlockAnnouncementSend(blockHash [32]byte, sendErr error) {
+	p.compactMu.Lock()
+	defer p.compactMu.Unlock()
+	if sendErr != nil {
+		p.removeCompactBlockAnnouncementBySentLocked(blockHash, false)
+		return
+	}
+	p.publishCompactBlockAnnouncementLocked(blockHash)
+	p.trimCompactBlockAnnouncementsLocked()
+}
+
+func (p *peer) appendCompactBlockAnnouncementLocked(blockHash [32]byte, sent bool) {
+	p.compact.announced = append(p.compact.announced, compactBlockAnnouncement{blockHash: blockHash, sent: sent})
+}
+
+func (p *peer) publishCompactBlockAnnouncementLocked(blockHash [32]byte) {
+	for idx := len(p.compact.announced) - 1; idx >= 0; idx-- {
+		if p.compact.announced[idx].blockHash == blockHash {
+			p.compact.announced[idx].sent = true
+			return
+		}
+	}
+}
+
+func (p *peer) trimCompactBlockAnnouncementsLocked() {
+	for len(p.compact.announced) > compactAnnouncedBlockLimit {
+		copy(p.compact.announced, p.compact.announced[1:])
+		p.compact.announced[len(p.compact.announced)-1] = compactBlockAnnouncement{}
+		p.compact.announced = p.compact.announced[:len(p.compact.announced)-1]
+	}
+}
+
+func (p *peer) consumeCompactBlockAnnouncement(blockHash [32]byte) bool {
+	p.compactMu.Lock()
+	defer p.compactMu.Unlock()
+	return p.removeCompactBlockAnnouncementLocked(blockHash)
+}
+
+func (p *peer) removeCompactBlockAnnouncementLocked(blockHash [32]byte) bool {
+	return p.removeCompactBlockAnnouncementBySentLocked(blockHash, true)
+}
+
+func (p *peer) removeCompactBlockAnnouncementBySentLocked(blockHash [32]byte, sent bool) bool {
+	for idx := len(p.compact.announced) - 1; idx >= 0; idx-- {
+		if p.compact.announced[idx].blockHash != blockHash || p.compact.announced[idx].sent != sent {
+			continue
+		}
+		copy(p.compact.announced[idx:], p.compact.announced[idx+1:])
+		p.compact.announced[len(p.compact.announced)-1] = compactBlockAnnouncement{}
+		p.compact.announced = p.compact.announced[:len(p.compact.announced)-1]
+		return true
+	}
+	return false
 }
 
 func (p *peer) setCompactOutstandingRequest(req compactOutstandingRequest) {

--- a/clients/go/node/p2p/compact_runtime_test.go
+++ b/clients/go/node/p2p/compact_runtime_test.go
@@ -1,8 +1,13 @@
 package p2p
 
 import (
+	"bytes"
 	"encoding/binary"
+	"errors"
 	"testing"
+	"time"
+
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/node"
 )
 
 func TestSendCmpctPostHandshakeCommandPathRecordsPeerMode(t *testing.T) {
@@ -29,6 +34,168 @@ func TestSendCmpctPostHandshakeCommandPathRecordsPeerMode(t *testing.T) {
 	}
 	if err := p.handleMessage(message{Command: messageSendCmpct, Payload: sendCmpctRuntimePayload(t, 3, compactRelayVersion)}); err == nil {
 		t.Fatal("unknown sendcmpct mode must fail")
+	}
+}
+
+func TestSentCmpctBlockRecordsOneShotAnnouncement(t *testing.T) {
+	header, blockHash, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
+	payload := mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{
+		Header: header,
+		Prefilled: []prefilledTxn{
+			{Index: 0, Tx: txs[0]},
+		},
+	})
+	p := newCompactScriptedPeer(t)
+
+	if err := p.send(messageCmpctBlock, payload); err != nil {
+		t.Fatalf("send cmpctblock: %v", err)
+	}
+	if !p.consumeCompactBlockAnnouncement(blockHash) {
+		t.Fatal("sent cmpctblock did not record getblocktxn announcement")
+	}
+	if p.consumeCompactBlockAnnouncement(blockHash) {
+		t.Fatal("compact block announcement was not one-shot")
+	}
+
+	p = newCompactScriptedPeer(t)
+	p.service.cfg.PeerRuntimeConfig.MaxMessageSize = 1
+	if err := p.send(messageCmpctBlock, payload); err == nil {
+		t.Fatal("oversized cmpctblock send should fail")
+	}
+	if p.consumeCompactBlockAnnouncement(blockHash) {
+		t.Fatal("failed cmpctblock send recorded an announcement")
+	}
+
+	p = newCompactScriptedPeer(t)
+	p.markCompactBlockAnnounced(blockHash)
+	p.service.cfg.PeerRuntimeConfig.MaxMessageSize = 1
+	if err := p.send(messageCmpctBlock, payload); err == nil {
+		t.Fatal("oversized duplicate cmpctblock send should fail")
+	}
+	if !p.consumeCompactBlockAnnouncement(blockHash) {
+		t.Fatal("failed duplicate cmpctblock send removed an existing announcement")
+	}
+}
+
+func TestGetBlockTxnCanRaceWithInFlightCmpctBlockSend(t *testing.T) {
+	header, blockHash, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
+	cmpctPayload := mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{
+		Header: header,
+		Prefilled: []prefilledTxn{
+			{Index: 0, Tx: txs[0]},
+		},
+	})
+	getBlockTxnPayload := mustEncodeGetBlockTxnRequest(t, blockHash, []uint64{0})
+	p := newCompactScriptedPeer(t)
+	requireNoCompactErr(t, p.handleBlock(node.DevnetGenesisBlockBytes()), "seed existing block")
+
+	done := make(chan error, 1)
+	p.conn = &scriptedConn{writeHook: func(writeCount int) {
+		if writeCount != 2 {
+			return
+		}
+		go func() {
+			done <- p.handleGetBlockTxn(getBlockTxnPayload)
+		}()
+	}}
+
+	requireNoCompactErr(t, p.send(messageCmpctBlock, cmpctPayload), "send cmpctblock")
+	select {
+	case err := <-done:
+		requireNoCompactErr(t, err, "racing getblocktxn")
+	case <-time.After(time.Second):
+		t.Fatal("racing getblocktxn did not complete")
+	}
+
+	reader := bytes.NewReader(p.conn.(*scriptedConn).Buffer.Bytes())
+	sentCmpctBlock, err := readFrame(reader, networkMagic(p.service.cfg.PeerRuntimeConfig.Network), p.service.cfg.PeerRuntimeConfig.MaxMessageSize)
+	requireNoCompactErr(t, err, "read sent cmpctblock")
+	if sentCmpctBlock.Command != messageCmpctBlock {
+		t.Fatalf("first frame command=%q, want %q", sentCmpctBlock.Command, messageCmpctBlock)
+	}
+	sentBlockTxn, err := readFrame(reader, networkMagic(p.service.cfg.PeerRuntimeConfig.Network), p.service.cfg.PeerRuntimeConfig.MaxMessageSize)
+	requireNoCompactErr(t, err, "read racing blocktxn response")
+	if sentBlockTxn.Command != messageBlockTxn {
+		t.Fatalf("second frame command=%q, want %q", sentBlockTxn.Command, messageBlockTxn)
+	}
+	response, err := decodeBlockTxnPayload(sentBlockTxn.Payload)
+	requireNoCompactErr(t, err, "decode racing blocktxn response")
+	if response.BlockHash != blockHash || len(response.Transactions) != 1 || !bytes.Equal(response.Transactions[0], txs[0]) {
+		t.Fatalf("racing blocktxn=%+v, want hash %x and requested tx", response, blockHash)
+	}
+}
+
+func TestFailedCmpctBlockSendDoesNotAuthorizeRacingGetBlockTxn(t *testing.T) {
+	header, blockHash, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
+	cmpctPayload := mustEncodeCmpctBlockPayload(t, cmpctBlockPayload{
+		Header: header,
+		Prefilled: []prefilledTxn{
+			{Index: 0, Tx: txs[0]},
+		},
+	})
+	getBlockTxnPayload := mustEncodeGetBlockTxnRequest(t, blockHash, []uint64{0})
+	p := newCompactScriptedPeer(t)
+	requireNoCompactErr(t, p.handleBlock(node.DevnetGenesisBlockBytes()), "seed existing block")
+
+	done := make(chan error, 1)
+	writeErr := errors.New("write failed")
+	p.conn = &scriptedConn{
+		writeErr:   writeErr,
+		writeErrAt: 2,
+		writeHook: func(writeCount int) {
+			if writeCount != 2 {
+				return
+			}
+			go func() {
+				done <- p.handleGetBlockTxn(getBlockTxnPayload)
+			}()
+		},
+	}
+
+	if err := p.send(messageCmpctBlock, cmpctPayload); !errors.Is(err, writeErr) {
+		t.Fatalf("send cmpctblock err=%v, want %v", err, writeErr)
+	}
+	select {
+	case err := <-done:
+		requireNoCompactErr(t, err, "racing getblocktxn")
+	case <-time.After(time.Second):
+		t.Fatal("racing getblocktxn did not complete")
+	}
+	if p.consumeCompactBlockAnnouncement(blockHash) {
+		t.Fatal("failed cmpctblock send left consumable announcement")
+	}
+	if p.conn.(*scriptedConn).writeCount != 2 {
+		t.Fatalf("failed in-flight cmpctblock send reached %d writes, want only cmpctblock header and payload", p.conn.(*scriptedConn).writeCount)
+	}
+}
+
+func TestCompactAnnouncementSendFinishRollbackAndTrim(t *testing.T) {
+	p := newCompactScriptedPeer(t)
+	firstHash := [32]byte{0x01}
+	for i := 0; i < compactAnnouncedBlockLimit; i++ {
+		p.markCompactBlockAnnounced([32]byte{byte(i + 1)})
+	}
+	newHash := [32]byte{0xfe}
+	p.beginCompactBlockAnnouncementSend(newHash)
+	p.finishCompactBlockAnnouncementSend(newHash, errors.New("boom"))
+	if !p.consumeCompactBlockAnnouncement(firstHash) {
+		t.Fatal("failed in-flight send evicted existing compact announcement")
+	}
+	if p.consumeCompactBlockAnnouncement(newHash) {
+		t.Fatal("failed in-flight send left new compact announcement")
+	}
+
+	p = newCompactScriptedPeer(t)
+	for i := 0; i < compactAnnouncedBlockLimit; i++ {
+		p.markCompactBlockAnnounced([32]byte{byte(i + 1)})
+	}
+	p.beginCompactBlockAnnouncementSend(newHash)
+	p.finishCompactBlockAnnouncementSend(newHash, nil)
+	if p.consumeCompactBlockAnnouncement(firstHash) {
+		t.Fatal("successful over-limit compact announcement did not trim the oldest hash")
+	}
+	if !p.consumeCompactBlockAnnouncement(newHash) {
+		t.Fatal("successful over-limit compact announcement dropped the new hash")
 	}
 }
 

--- a/clients/go/node/p2p/peer_runtime.go
+++ b/clients/go/node/p2p/peer_runtime.go
@@ -331,14 +331,31 @@ func unknownCommandPolicyReason(err error) (string, bool) {
 }
 
 func (p *peer) send(command string, payload []byte) error {
+	announcementHash, hasAnnouncement := compactAnnouncementHashForSentMessage(command, payload)
 	p.writeMu.Lock()
-	defer p.writeMu.Unlock()
 	if deadline := p.service.cfg.PeerRuntimeConfig.WriteDeadline; deadline > 0 {
 		if err := p.conn.SetWriteDeadline(time.Now().Add(deadline)); err != nil {
+			p.writeMu.Unlock()
 			return err
 		}
 	}
-	return writeFrame(p.conn, networkMagic(p.service.cfg.PeerRuntimeConfig.Network), message{Command: command, Payload: payload}, p.service.cfg.PeerRuntimeConfig.MaxMessageSize)
+	if hasAnnouncement {
+		p.beginCompactBlockAnnouncementSend(announcementHash)
+	}
+	err := writeFrame(p.conn, networkMagic(p.service.cfg.PeerRuntimeConfig.Network), message{Command: command, Payload: payload}, p.service.cfg.PeerRuntimeConfig.MaxMessageSize)
+	if hasAnnouncement {
+		p.finishCompactBlockAnnouncementSend(announcementHash, err)
+	}
+	p.writeMu.Unlock()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (p *peer) compactSendBarrier() {
+	p.writeMu.Lock()
+	p.writeMu.Unlock()
 }
 
 func (p *peer) addr() string {

--- a/clients/go/node/p2p/peer_runtime.go
+++ b/clients/go/node/p2p/peer_runtime.go
@@ -171,6 +171,9 @@ func (p *peer) postHandshakePayloadCap() payloadLimitFn {
 			}
 			return 0
 		case messageGetBlockTxn:
+			if p.acceptsCompactBlocks() {
+				return compactRelayPayloadCap(command)
+			}
 			return 0
 		default:
 			return base(command)
@@ -232,7 +235,7 @@ func normalizeReadError(err error) error {
 
 func (p *peer) handleMessage(frame message) error {
 	switch frame.Command {
-	case messageInv, messageGetData, messageBlock, messageTx, messageGetBlk, messageCmpctBlock, messageBlockTxn:
+	case messageInv, messageGetData, messageBlock, messageTx, messageGetBlk, messageCmpctBlock, messageGetBlockTxn, messageBlockTxn:
 		return p.handleRelayMessage(frame)
 	case messageSendCmpct:
 		return p.handleSendCmpct(frame.Payload)
@@ -253,7 +256,7 @@ func (p *peer) handleRelayMessage(frame message) error {
 	switch frame.Command {
 	case messageInv, messageGetData:
 		return p.handleInventoryRelayMessage(frame)
-	case messageBlock, messageTx, messageGetBlk, messageCmpctBlock, messageBlockTxn:
+	case messageBlock, messageTx, messageGetBlk, messageCmpctBlock, messageGetBlockTxn, messageBlockTxn:
 		return p.handleObjectRelayMessage(frame)
 	default:
 		return postHandshakeUnknownCommandError{command: frame.Command}
@@ -284,6 +287,11 @@ func (p *peer) handleObjectRelayMessage(frame message) error {
 			return postHandshakeUnknownCommandError{command: frame.Command}
 		}
 		return p.handleCmpctBlock(frame.Payload)
+	case messageGetBlockTxn:
+		if !p.acceptsCompactBlocks() {
+			return postHandshakeUnknownCommandError{command: frame.Command}
+		}
+		return p.handleGetBlockTxn(frame.Payload)
 	case messageBlockTxn:
 		if !p.acceptsBlockTxnResponses() {
 			return postHandshakeUnknownCommandError{command: frame.Command}

--- a/clients/go/node/p2p/peer_runtime_test.go
+++ b/clients/go/node/p2p/peer_runtime_test.go
@@ -37,6 +37,10 @@ type scriptedRead struct {
 type scriptedConn struct {
 	reads []scriptedRead
 	bytes.Buffer
+	writeCount int
+	writeHook  func(int)
+	writeErr   error
+	writeErrAt int
 }
 
 func (c *scriptedConn) Read(p []byte) (int, error) {
@@ -59,7 +63,17 @@ func (c *scriptedConn) Read(p []byte) (int, error) {
 	return 0, err
 }
 
-func (c *scriptedConn) Write(p []byte) (int, error) { return c.Buffer.Write(p) }
+func (c *scriptedConn) Write(p []byte) (int, error) {
+	n, err := c.Buffer.Write(p)
+	c.writeCount++
+	if c.writeHook != nil {
+		c.writeHook(c.writeCount)
+	}
+	if c.writeErr != nil && (c.writeErrAt == 0 || c.writeCount == c.writeErrAt) {
+		return n, c.writeErr
+	}
+	return n, err
+}
 func (c *scriptedConn) Close() error                { return nil }
 func (c *scriptedConn) LocalAddr() net.Addr         { return stubAddr("local") }
 func (c *scriptedConn) RemoteAddr() net.Addr        { return stubAddr("remote") }

--- a/clients/go/node/p2p/peer_runtime_test.go
+++ b/clients/go/node/p2p/peer_runtime_test.go
@@ -129,8 +129,8 @@ func TestCompactObjectCapsOpenOnlyForEnabledNegotiatedReceive(t *testing.T) {
 	if got := limiter(messageCmpctBlock); got != uint32(consensus.MAX_RELAY_MSG_BYTES) {
 		t.Fatalf("negotiated cmpctblock cap=%d, want %d", got, consensus.MAX_RELAY_MSG_BYTES)
 	}
-	if got := limiter(messageGetBlockTxn); got != 0 {
-		t.Fatalf("inbound getblocktxn cap=%d, want closed until responder exists", got)
+	if got, want := limiter(messageGetBlockTxn), compactRelayPayloadCap(messageGetBlockTxn); got != want {
+		t.Fatalf("inbound getblocktxn cap=%d, want %d", got, want)
 	}
 	if got := limiter(messageBlockTxn); got != blockTxnHashPayloadBytes {
 		t.Fatalf("blocktxn cap without outstanding=%d, want hash-only cap %d", got, blockTxnHashPayloadBytes)
@@ -142,6 +142,9 @@ func TestCompactObjectCapsOpenOnlyForEnabledNegotiatedReceive(t *testing.T) {
 	p.setRemoteCompactMode(compactModeSnapshot{Mode: 0, Version: compactRelayVersion})
 	if got := limiter(messageCmpctBlock); got != 0 {
 		t.Fatalf("disabled cmpctblock cap=%d, want 0", got)
+	}
+	if got := limiter(messageGetBlockTxn); got != 0 {
+		t.Fatalf("disabled getblocktxn cap=%d, want 0", got)
 	}
 	if got := limiter(messageBlockTxn); got != 64 {
 		t.Fatalf("disabled-mode blocktxn cap with outstanding=%d, want 64", got)
@@ -834,7 +837,7 @@ func TestHandleMessageRejectsInvalidKinds(t *testing.T) {
 
 func TestHandleObjectRelayMessageKeepsCompactObjectsClosed(t *testing.T) {
 	p := newPeerRuntimeTestPeer(t)
-	for _, command := range []string{messageCmpctBlock, messageBlockTxn} {
+	for _, command := range []string{messageCmpctBlock, messageGetBlockTxn, messageBlockTxn} {
 		err := p.handleObjectRelayMessage(message{Command: command})
 		var unknown postHandshakeUnknownCommandError
 		if !errors.As(err, &unknown) || unknown.command != command {


### PR DESCRIPTION
Invariant:
Go P2P serves negotiated peer getblocktxn requests only for per-peer announced compact blocks, with requested absolute indexes validated before block transaction scanning and bounded blocktxn responses returned in request order.

Layer:
implementation, tests

Files changed:
- clients/go/node/p2p/compact_reconstruct.go
- clients/go/node/p2p/compact_reconstruct_test.go
- clients/go/node/p2p/compact_runtime.go
- clients/go/node/p2p/compact_runtime_test.go
- clients/go/node/p2p/peer_runtime.go
- clients/go/node/p2p/peer_runtime_test.go

Tests:
- cd clients/go && go test ./node/p2p -run "TestGetBlockTxnCanRaceWithInFlightCmpctBlockSend|TestFailedCmpctBlockSendDoesNotAuthorizeRacingGetBlockTxn|TestSentCmpctBlockRecordsOneShotAnnouncement|TestCompactAnnouncementSendFinishRollbackAndTrim|TestHandleGetBlockTxn" -count=1 — PASS
- cd clients/go && go test ./node/p2p -run "Compact|GetBlockTxn|BlockTxn|Reconstruct" -count=1 — PASS
- cd clients/go && go test ./node/p2p -count=1 — PASS
- git diff --check — PASS
- rubin-precommit-one-review --base-ref origin/main --include-base-diff — PASS
- rubin-push --coverage-cmd rubin-stack-codacy-coverage.sh — PASS; Go-only stack, coverage variation +0.04%, diff coverage 97.14%

Behavior impact:
- Opens inbound getblocktxn cap and dispatch only for negotiated compact receive peers.
- Tracks per-peer cmpctblock announcements and ignores unannounced getblocktxn requests before BlockStore lookup.
- Returns blocktxn with only requested transaction bytes in request order after validation.
- Rejects malformed, duplicate, corrupt-block, and out-of-range requests before sending a response; missing local blocks stay silent/no-ban.

Compatibility impact:
Go-only P2P compact relay implementation slice. No Rust, conformance, consensus, policy, docs, or generated artifacts changed.

Known non-goals:
- Incoming blocktxn response handling beyond existing reconstruction flow.
- Compact relay full-block fallback changes.
- Rust parity implementation.

Risk:
Low implementation-scope risk; new behavior is gated by existing compact receive negotiation, bounded payload caps, and per-peer compact announcement state.

Rollback:
Revert this PR to close getblocktxn inbound dispatch/cap and remove serve-side handler/tests.

Not checked:
- Final GitHub CI quiet-window check after this metadata-only PR body update.

<!-- rubin-agent-meta actor=unknown action=pr-edit via=cl branch=codex/RUB-330-go-compact-getblocktxn-serve wt=rubin-protocol-codex-RUB-330 utc=2026-05-22T18:49:28Z -->
