### PR TITLE
[RUB-345] Validate runtime evidence schema and source paths

### DIFF
--- a/tools/check_conformance_edge_pack.py
+++ b/tools/check_conformance_edge_pack.py
@@ -2,11 +2,13 @@
 from __future__ import annotations
 
 import json
+import stat
 import sys
 from pathlib import Path
 
 CLAIMED_PRESENT_STATUSES = {"present", "covered", "complete"}
 KNOWN_ABSENT_STATUSES = {"absent", "deferred", "not_claimed", "not-applicable", "not_applicable"}
+RUNTIME_EVIDENCE_MAX_SOURCE_BYTES = 1_000_000
 
 
 def fail(msg: str) -> int:
@@ -70,6 +72,79 @@ def string_list(value: object, *, field_name: str, require_non_empty: bool = Fal
     if len(set(strings)) != len(strings):
         return [], f"{field_name} entries must be unique"
     return strings, None
+
+
+def path_contains_symlink(repo_root: Path, rel_path: Path) -> bool:
+    current = repo_root
+    for part in rel_path.parts:
+        current /= part
+        if current.is_symlink():
+            return True
+    return False
+
+
+def runtime_source_path_errors(raw_path: str, *, repo_root: Path) -> list[str]:
+    rel_path = Path(raw_path)
+    if rel_path.is_absolute():
+        return ["runtime_evidence source path must be repo-relative"]
+    if ".." in raw_path:
+        return ["runtime_evidence source path must not contain '..'"]
+
+    parts = rel_path.parts
+    if len(parts) < 2 or parts[0] != "clients" or parts[1] not in {"go", "rust"}:
+        return ["runtime_evidence source path must be under clients/go or clients/rust"]
+    if parts[1] == "go" and not raw_path.endswith("_test.go"):
+        return ["Go runtime evidence paths must end with _test.go"]
+    if parts[1] == "rust" and not raw_path.endswith(".rs"):
+        return ["Rust runtime evidence paths must end with .rs"]
+
+    source_path = repo_root / rel_path
+    if path_contains_symlink(repo_root, rel_path):
+        return ["runtime_evidence source path must not contain symlinks"]
+    try:
+        resolved = source_path.resolve(strict=True)
+    except FileNotFoundError:
+        return ["runtime_evidence source path does not exist"]
+    except OSError as exc:
+        return [f"runtime_evidence source path cannot be resolved: {exc}"]
+
+    if not resolved.is_relative_to(repo_root):
+        return ["runtime_evidence source path escapes repo root"]
+    try:
+        source_stat = source_path.stat()
+    except OSError as exc:
+        return [f"runtime_evidence source path cannot be statted: {exc}"]
+    if not stat.S_ISREG(source_stat.st_mode):
+        return ["runtime_evidence source path must be a regular file"]
+    if source_stat.st_size > RUNTIME_EVIDENCE_MAX_SOURCE_BYTES:
+        return ["runtime_evidence source file exceeds max size"]
+    return []
+
+
+def runtime_evidence_errors(value: object, *, repo_root: Path) -> list[str]:
+    if not isinstance(value, dict):
+        return ["runtime_evidence must be object"]
+    if "tests_by_file" not in value:
+        return ["runtime_evidence.tests_by_file must be present"]
+
+    tests_by_file = value.get("tests_by_file")
+    if not isinstance(tests_by_file, dict) or not tests_by_file:
+        return ["runtime_evidence.tests_by_file must be non-empty object"]
+
+    errors: list[str] = []
+    for raw_path, raw_tests in tests_by_file.items():
+        if not isinstance(raw_path, str) or not raw_path.strip() or raw_path != raw_path.strip():
+            errors.append("runtime_evidence.tests_by_file keys must be non-empty repo-relative strings")
+            continue
+        _, tests_error = string_list(
+            raw_tests,
+            field_name=f"runtime_evidence.tests_by_file[{raw_path}]",
+            require_non_empty=True,
+        )
+        if tests_error is not None:
+            errors.append(tests_error)
+        errors.extend(runtime_source_path_errors(raw_path, repo_root=repo_root))
+    return errors
 
 
 def main() -> int:
@@ -164,6 +239,11 @@ def main() -> int:
             print(f"ERROR: domain {name}: coverage_accounting must be object", file=sys.stderr)
             failures += 1
             continue
+
+        if "runtime_evidence" in domain:
+            for error in runtime_evidence_errors(domain.get("runtime_evidence"), repo_root=repo_root):
+                print(f"ERROR: domain {name}: {error}", file=sys.stderr)
+                failures += 1
 
         total = 0
         missing_gates: list[str] = []

--- a/tools/tests/test_check_conformance_edge_pack.py
+++ b/tools/tests/test_check_conformance_edge_pack.py
@@ -87,6 +87,20 @@ def make_repo(
     )
 
 
+def set_runtime_evidence(root: Path, runtime_evidence: object) -> None:
+    baseline_path = root / "conformance" / "EDGE_PACK_BASELINE.json"
+    baseline = json.loads(baseline_path.read_text(encoding="utf-8"))
+    baseline["domains"][0]["runtime_evidence"] = runtime_evidence
+    write_json(baseline_path, baseline)
+
+
+def write_runtime_source(root: Path, rel_path: str, text: str = "// test source\n") -> Path:
+    path = root / rel_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
 class EdgePackCheckerTests(unittest.TestCase):
     def test_clean_accounting_passes_with_deferred_fuzz_formal(self) -> None:
         with tempfile.TemporaryDirectory() as td:
@@ -569,6 +583,147 @@ class EdgePackCheckerTests(unittest.TestCase):
                 rc = m.main()
         self.assertEqual(rc, 1)
         self.assertIn("unknown formal coverage status maybe", captured.getvalue())
+
+    def test_runtime_evidence_schema_path_success_without_test_discovery(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(root)
+            write_runtime_source(root, "clients/go/node/sync_reorg_test.go")
+            write_runtime_source(root, "clients/rust/crates/rubin-node/src/sync_reorg.rs")
+            set_runtime_evidence(
+                root,
+                {
+                    "tests_by_file": {
+                        "clients/go/node/sync_reorg_test.go": ["TestDeclaredButNotScanned"],
+                        "clients/rust/crates/rubin-node/src/sync_reorg.rs": ["declared_but_not_scanned"],
+                    }
+                },
+            )
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stdout(captured):
+                rc = m.main()
+        self.assertEqual(rc, 0)
+        self.assertIn("OK: conformance edge-pack baseline satisfied.", captured.getvalue())
+
+    def test_runtime_evidence_rejects_schema_path_and_source_boundary_errors(self) -> None:
+        def base_runtime_evidence(path: str = "clients/go/node/sync_reorg_test.go") -> dict:
+            return {"tests_by_file": {path: ["TestRuntimeEvidence"]}}
+
+        cases = [
+            ("scalar runtime_evidence", "invalid", None, "runtime_evidence must be object"),
+            (
+                "missing tests_by_file",
+                {},
+                None,
+                "runtime_evidence.tests_by_file must be present",
+            ),
+            (
+                "empty tests_by_file",
+                {"tests_by_file": {}},
+                None,
+                "runtime_evidence.tests_by_file must be non-empty object",
+            ),
+            (
+                "blank path key",
+                {"tests_by_file": {"   ": ["TestRuntimeEvidence"]}},
+                None,
+                "runtime_evidence.tests_by_file keys must be non-empty repo-relative strings",
+            ),
+            (
+                "empty test list",
+                {"tests_by_file": {"clients/go/node/sync_reorg_test.go": []}},
+                None,
+                "runtime_evidence.tests_by_file[clients/go/node/sync_reorg_test.go] must be non-empty list",
+            ),
+            (
+                "duplicate test names",
+                {"tests_by_file": {"clients/go/node/sync_reorg_test.go": ["TestA", "TestA"]}},
+                None,
+                "runtime_evidence.tests_by_file[clients/go/node/sync_reorg_test.go] entries must be unique",
+            ),
+            (
+                "absolute path",
+                base_runtime_evidence("/clients/go/node/sync_reorg_test.go"),
+                None,
+                "runtime_evidence source path must be repo-relative",
+            ),
+            (
+                "traversal path",
+                base_runtime_evidence("clients/go/../node/sync_reorg_test.go"),
+                None,
+                "runtime_evidence source path must not contain '..'",
+            ),
+            (
+                "unsupported root",
+                base_runtime_evidence("scripts/sync_reorg_test.py"),
+                lambda root: write_runtime_source(root, "scripts/sync_reorg_test.py"),
+                "runtime_evidence source path must be under clients/go or clients/rust",
+            ),
+            (
+                "go wrong suffix",
+                base_runtime_evidence("clients/go/node/sync_reorg.go"),
+                lambda root: write_runtime_source(root, "clients/go/node/sync_reorg.go"),
+                "Go runtime evidence paths must end with _test.go",
+            ),
+            (
+                "rust wrong suffix",
+                base_runtime_evidence("clients/rust/crates/rubin-node/src/sync_reorg_test.go"),
+                lambda root: write_runtime_source(root, "clients/rust/crates/rubin-node/src/sync_reorg_test.go"),
+                "Rust runtime evidence paths must end with .rs",
+            ),
+            (
+                "missing source",
+                base_runtime_evidence(),
+                lambda root: None,
+                "runtime_evidence source path does not exist",
+            ),
+            (
+                "directory source",
+                base_runtime_evidence(),
+                lambda root: (root / "clients/go/node/sync_reorg_test.go").mkdir(parents=True),
+                "runtime_evidence source path must be a regular file",
+            ),
+            (
+                "oversize source",
+                base_runtime_evidence(),
+                lambda root: write_runtime_source(
+                    root,
+                    "clients/go/node/sync_reorg_test.go",
+                    "x" * (m.RUNTIME_EVIDENCE_MAX_SOURCE_BYTES + 1),
+                ),
+                "runtime_evidence source file exceeds max size",
+            ),
+        ]
+        for name, runtime_evidence, setup, expected in cases:
+            with self.subTest(name=name), tempfile.TemporaryDirectory() as td:
+                root = Path(td)
+                make_repo(root)
+                if setup is None:
+                    write_runtime_source(root, "clients/go/node/sync_reorg_test.go")
+                else:
+                    setup(root)
+                set_runtime_evidence(root, runtime_evidence)
+                captured = io.StringIO()
+                with chdir(root), contextlib.redirect_stderr(captured):
+                    rc = m.main()
+            self.assertEqual(rc, 1)
+            self.assertIn(expected, captured.getvalue())
+
+    @unittest.skipUnless(hasattr(os, "symlink"), "symlink support unavailable")
+    def test_runtime_evidence_rejects_symlink_sources(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_repo(root)
+            target = write_runtime_source(root, "external.go")
+            link = root / "clients/go/node/sync_reorg_test.go"
+            link.parent.mkdir(parents=True, exist_ok=True)
+            link.symlink_to(target)
+            set_runtime_evidence(root, {"tests_by_file": {"clients/go/node/sync_reorg_test.go": ["TestA"]}})
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stderr(captured):
+                rc = m.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("runtime_evidence source path must not contain symlinks", captured.getvalue())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Invariant:
Validate `runtime_evidence` schema and repo-local source path properties before source content parsing, without proving Go/Rust test declaration reachability.

Layer:
Conformance tooling / non-consensus validation.

Files changed:
- `tools/check_conformance_edge_pack.py`
- `tools/tests/test_check_conformance_edge_pack.py`

Tests:
- `python3 -m unittest tools.tests.test_check_conformance_edge_pack` - PASS
- `python3 -m py_compile tools/check_conformance_edge_pack.py tools/tests/test_check_conformance_edge_pack.py` - PASS
- `ruff check tools/check_conformance_edge_pack.py tools/tests/test_check_conformance_edge_pack.py` - PASS
- `bandit -q tools/check_conformance_edge_pack.py tools/tests/test_check_conformance_edge_pack.py` - PASS
- `vulture tools/check_conformance_edge_pack.py tools/tests/test_check_conformance_edge_pack.py --min-confidence 90` - PASS
- `scripts/dev-env.sh -- python3 tools/check_conformance_edge_pack.py` - PASS
- `scripts/dev-env.sh -- python3 tools/gen_conformance_matrix.py --check` - PASS
- `scripts/dev-env.sh -- python3 tools/check_conformance_fixtures_policy.py` - PASS
- `git diff --check` - PASS
- `rubin-precommit-one-review --include-base-diff --light-python` - PASS
- stock isolated `code-review` subagent - No findings
- `rubin-push` - PASS, no coverage because this diff is Python conformance tooling/tests only

Behavior impact:
- `runtime_evidence` must be an object when present.
- `runtime_evidence.tests_by_file` must be a non-empty object.
- Declared test-name lists must be non-empty unique string lists.
- Declared source paths must be repo-relative, non-traversing, under `clients/go` or `clients/rust`, non-symlink, regular files, and under an explicit size cap.
- Go evidence paths must end in `_test.go`; Rust evidence paths must end in `.rs`.

Compatibility impact:
No consensus, runtime, fixture vector, baseline declaration, or README behavior changes.

Known non-goals:
- No Go/Rust source parser.
- No `go test -list` or `cargo test -- --list` discovery.
- No verification that declared test names exist.
- No `conformance/EDGE_PACK_BASELINE.json` changes.
- No `conformance/README.md` changes.

Follow-ups:
- RUB-346 owns toolchain-backed Go/Rust runtime test discovery.

Risk:
Future runtime evidence declarations outside `clients/go` or `clients/rust` will fail this checker until the contract is explicitly expanded.

Rollback:
Revert this PR; it only affects the conformance edge-pack checker and its tests.

Not checked:
Go/Rust toolchain test discovery, by design. That is RUB-346 scope.

Closes #1765


<!-- rubin-agent-meta actor=unknown action=pr-create via=cl branch=codex/RUB-345-runtime-evidence-schema-path wt=rubin-protocol-codex-RUB-345 utc=2026-05-22T18:41:56Z -->
