### PR TITLE
[CONF-RUNTIME-EVIDENCE-GO-DISCOVERY-01] Add Go runtime evidence discovery

### DIFF
--- a/tools/check_conformance_edge_pack.py
+++ b/tools/check_conformance_edge_pack.py
@@ -189,14 +189,12 @@ def go_testmain_declared_tests(work_output: str, temp_dir: Path) -> tuple[set[st
     return tests, None
 
 
-def go_objdump_matches_source(stdout: str, source_path: Path) -> bool:
+def go_objdump_matches_source(stdout: str, *, source_path: Path, repo_root: Path) -> bool:
     absolute = source_path.resolve().as_posix()
-    parts = source_path.parts
-    relative = source_path.name
-    for index, part in enumerate(parts[:-1]):
-        if part == "clients" and parts[index + 1] == "go":
-            relative = "/".join(parts[index:])
-            break
+    try:
+        relative = source_path.resolve().relative_to(repo_root.resolve()).as_posix()
+    except ValueError:
+        relative = source_path.name
     for line in stdout.splitlines():
         if not line.startswith("TEXT "):
             continue
@@ -239,11 +237,12 @@ def go_file_discovered_tests(
             objdump_stdout, objdump_error = run_discovery_command(
                 ["go", "tool", "objdump", "-s", symbol_re, str(test_binary)],
                 cwd=go_root,
+                env=go_discovery_env(temp_dir),
                 command_runner=command_runner,
             )
             if objdump_error is not None:
                 return set(), objdump_error
-            if go_objdump_matches_source(objdump_stdout, repo_root / raw_path):
+            if go_objdump_matches_source(objdump_stdout, source_path=repo_root / raw_path, repo_root=repo_root):
                 file_tests.add(test_name)
     return file_tests, None
 

--- a/tools/check_conformance_edge_pack.py
+++ b/tools/check_conformance_edge_pack.py
@@ -1,14 +1,21 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import argparse
 import json
+import re
 import stat
+import subprocess  # nosec B404
 import sys
+import tempfile
 from pathlib import Path
 
 CLAIMED_PRESENT_STATUSES = {"present", "covered", "complete"}
 KNOWN_ABSENT_STATUSES = {"absent", "deferred", "not_claimed", "not-applicable", "not_applicable"}
 RUNTIME_EVIDENCE_MAX_SOURCE_BYTES = 1_000_000
+RUNTIME_EVIDENCE_DISCOVERY_TIMEOUT_SECS = 30
+GO_TEST_LIST_NAME_RE = re.compile(r"^Test[A-Za-z0-9_]*$")
+RUST_PACKAGE_NAME_RE = re.compile(r"""^name\s*=\s*["']([^"']+)["'](?:\s*#.*)?\s*$""")
 
 
 def fail(msg: str) -> int:
@@ -97,6 +104,8 @@ def runtime_source_path_errors(raw_path: str, *, repo_root: Path) -> list[str]:
         return ["Go runtime evidence paths must end with _test.go"]
     if parts[1] == "rust" and not raw_path.endswith(".rs"):
         return ["Rust runtime evidence paths must end with .rs"]
+    if parts[1] == "rust" and "src" not in parts:
+        return ["Rust runtime evidence paths must be under crate src/"]
 
     source_path = repo_root / rel_path
     if path_contains_symlink(repo_root, rel_path):
@@ -121,7 +130,193 @@ def runtime_source_path_errors(raw_path: str, *, repo_root: Path) -> list[str]:
     return []
 
 
-def runtime_evidence_errors(value: object, *, repo_root: Path) -> list[str]:
+def go_package_arg(raw_path: str) -> str:
+    package_dir = Path(raw_path).parent.relative_to("clients/go")
+    if str(package_dir) == ".":
+        return "."
+    return f"./{package_dir.as_posix()}"
+
+
+def rust_package_name(manifest: Path) -> tuple[str, str | None]:
+    try:
+        lines = manifest.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        return "", f"runtime_evidence Rust manifest cannot be read: {exc}"
+    in_package = False
+    for line in lines:
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if stripped.startswith("[") and stripped.endswith("]"):
+            in_package = stripped == "[package]"
+            continue
+        if in_package:
+            match = RUST_PACKAGE_NAME_RE.match(stripped)
+            if match:
+                return match.group(1), None
+    return "", "runtime_evidence Rust manifest has no package.name"
+
+
+def rust_package_and_filter(raw_path: str, *, repo_root: Path) -> tuple[str, str] | str:
+    source_path = repo_root / raw_path
+    rust_root = repo_root / "clients" / "rust"
+    for directory in [source_path.parent, *source_path.parents]:
+        if directory == rust_root:
+            break
+        manifest = directory / "Cargo.toml"
+        if manifest.exists():
+            package_name, package_error = rust_package_name(manifest)
+            if package_error is not None:
+                return package_error
+            try:
+                rel_to_src = source_path.relative_to(directory / "src")
+            except ValueError:
+                return "runtime_evidence Rust source must be under crate src/"
+            if rel_to_src.name == "lib.rs":
+                return "runtime_evidence Rust lib.rs source is not supported by file-bound discovery"
+            module_parts = rel_to_src.parent.parts if rel_to_src.name == "mod.rs" else (*rel_to_src.parent.parts, rel_to_src.stem)
+            if not module_parts:
+                return "runtime_evidence Rust module path is ambiguous"
+            return package_name, "::".join(module_parts)
+    return "runtime_evidence Rust source is not under a package Cargo.toml"
+
+
+def run_discovery_command(cmd: list[str], *, cwd: Path, command_runner) -> tuple[str, str | None]:
+    try:
+        completed = command_runner(
+            cmd,
+            cwd=cwd,
+            text=True,
+            capture_output=True,
+            timeout=RUNTIME_EVIDENCE_DISCOVERY_TIMEOUT_SECS,
+        )
+    except FileNotFoundError:
+        return "", f"runtime_evidence discovery command missing: {cmd[0]}"
+    except subprocess.TimeoutExpired:
+        return "", "runtime_evidence discovery command timed out"
+    if completed.returncode != 0:
+        return "", f"runtime_evidence discovery command failed: {cmd[0]} exit {completed.returncode}"
+    if not isinstance(completed.stdout, str):
+        return "", "runtime_evidence discovery command produced malformed stdout"
+    return completed.stdout, None
+
+
+def parse_go_test_list(stdout: str) -> tuple[set[str], str | None]:
+    names = {line.strip() for line in stdout.splitlines() if GO_TEST_LIST_NAME_RE.fullmatch(line.strip())}
+    return names, None
+
+
+def go_objdump_matches_source(stdout: str, source_path: Path) -> bool:
+    expected = str(source_path.resolve())
+    return any(line.startswith("TEXT ") and line.rsplit(" ", 1)[-1] == expected for line in stdout.splitlines())
+
+
+def go_file_discovered_tests(
+    raw_path: str,
+    *,
+    repo_root: Path,
+    expected_tests: list[str],
+    command_runner,
+) -> tuple[set[str], str | None]:
+    package_arg = go_package_arg(raw_path)
+    go_root = repo_root / "clients" / "go"
+    stdout, error = run_discovery_command(
+        ["go", "test", "-run", "^$", "-list", ".", package_arg],
+        cwd=go_root,
+        command_runner=command_runner,
+    )
+    if error is not None:
+        return set(), error
+    package_tests, _ = parse_go_test_list(stdout)
+
+    with tempfile.TemporaryDirectory(prefix="rubin-go-testbin-") as temp_dir:
+        test_binary = Path(temp_dir) / "package.test"
+        _, compile_error = run_discovery_command(
+            ["go", "test", "-c", "-o", str(test_binary), package_arg],
+            cwd=go_root,
+            command_runner=command_runner,
+        )
+        if compile_error is not None:
+            return set(), compile_error
+        file_tests: set[str] = set()
+        for test_name in sorted(expected_tests):
+            if test_name not in package_tests:
+                continue
+            symbol_re = rf".*\.{re.escape(test_name)}$"
+            objdump_stdout, objdump_error = run_discovery_command(
+                ["go", "tool", "objdump", "-s", symbol_re, str(test_binary)],
+                cwd=go_root,
+                command_runner=command_runner,
+            )
+            if objdump_error is not None:
+                return set(), objdump_error
+            if go_objdump_matches_source(objdump_stdout, repo_root / raw_path):
+                file_tests.add(test_name)
+    return file_tests, None
+
+
+def parse_rust_test_list(stdout: str, module_filter: str) -> tuple[set[str], str | None]:
+    names: set[str] = set()
+    full_by_leaf: dict[str, set[str]] = {}
+    for line in stdout.splitlines():
+        stripped = line.strip()
+        if not stripped.endswith(": test"):
+            continue
+        full_name = stripped.removesuffix(": test")
+        if not full_name.startswith(f"{module_filter}::"):
+            continue
+        leaf = full_name.rsplit("::", 1)[-1]
+        if not leaf:
+            return set(), "runtime_evidence discovery produced malformed Rust test name"
+        names.add(leaf)
+        full_by_leaf.setdefault(leaf, set()).add(full_name)
+    if ambiguous := sorted(name for name, full_names in full_by_leaf.items() if len(full_names) > 1):
+        return set(), f"ambiguous Rust test names from toolchain output: {', '.join(ambiguous)}"
+    return names, None
+
+
+def discovered_runtime_tests(
+    raw_path: str,
+    *,
+    repo_root: Path,
+    expected_tests: list[str],
+    command_runner,
+) -> tuple[set[str], str | None]:
+    if raw_path.startswith("clients/go/"):
+        return go_file_discovered_tests(raw_path, repo_root=repo_root, expected_tests=expected_tests, command_runner=command_runner)
+
+    rust_target = rust_package_and_filter(raw_path, repo_root=repo_root)
+    if isinstance(rust_target, str):
+        return set(), rust_target
+    package_name, module_filter = rust_target
+    cmd = ["cargo", "test", "-p", package_name, "--lib", *([module_filter] if module_filter else []), "--", "--list"]
+    stdout, error = run_discovery_command(cmd, cwd=repo_root / "clients" / "rust", command_runner=command_runner)
+    if error is not None:
+        return set(), error
+    all_tests, parse_error = parse_rust_test_list(stdout, module_filter)
+    if parse_error is not None:
+        return set(), parse_error
+    ignored_cmd = ["cargo", "test", "-p", package_name, "--lib", *([module_filter] if module_filter else []), "--", "--ignored", "--list"]
+    ignored_stdout, ignored_error = run_discovery_command(
+        ignored_cmd,
+        cwd=repo_root / "clients" / "rust",
+        command_runner=command_runner,
+    )
+    if ignored_error is not None:
+        return set(), ignored_error
+    ignored_tests, ignored_parse_error = parse_rust_test_list(ignored_stdout, module_filter)
+    if ignored_parse_error is not None:
+        return set(), ignored_parse_error
+    return all_tests - ignored_tests, None
+
+
+def runtime_evidence_errors(
+    value: object,
+    *,
+    repo_root: Path,
+    verify_discovery: bool,
+    command_runner,
+) -> list[str]:
     if not isinstance(value, dict):
         return ["runtime_evidence must be object"]
     if "tests_by_file" not in value:
@@ -136,18 +331,40 @@ def runtime_evidence_errors(value: object, *, repo_root: Path) -> list[str]:
         if not isinstance(raw_path, str) or not raw_path.strip() or raw_path != raw_path.strip():
             errors.append("runtime_evidence.tests_by_file keys must be non-empty repo-relative strings")
             continue
-        _, tests_error = string_list(
+        tests, tests_error = string_list(
             raw_tests,
             field_name=f"runtime_evidence.tests_by_file[{raw_path}]",
             require_non_empty=True,
         )
+        path_errors = runtime_source_path_errors(raw_path, repo_root=repo_root)
         if tests_error is not None:
             errors.append(tests_error)
-        errors.extend(runtime_source_path_errors(raw_path, repo_root=repo_root))
+        errors.extend(path_errors)
+        if verify_discovery and tests_error is None and not path_errors:
+            present, discovery_error = discovered_runtime_tests(
+                raw_path,
+                repo_root=repo_root,
+                expected_tests=tests,
+                command_runner=command_runner,
+            )
+            if discovery_error is not None:
+                errors.append(discovery_error)
+                continue
+            missing = [name for name in tests if name not in present]
+            if missing:
+                errors.append(f"missing runtime evidence tests: {', '.join(missing)}")
     return errors
 
 
-def main() -> int:
+def main(argv: list[str] | None = None, *, command_runner=subprocess.run) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--verify-runtime-evidence",
+        action="store_true",
+        help="run opt-in Go/Rust toolchain discovery for runtime_evidence test names",
+    )
+    args = parser.parse_args([] if argv is None else argv)
+
     repo_root = Path(".").resolve()
     baseline_path = repo_root / "conformance" / "EDGE_PACK_BASELINE.json"
     fixtures_dir = repo_root / "conformance" / "fixtures"
@@ -241,7 +458,12 @@ def main() -> int:
             continue
 
         if "runtime_evidence" in domain:
-            for error in runtime_evidence_errors(domain.get("runtime_evidence"), repo_root=repo_root):
+            for error in runtime_evidence_errors(
+                domain.get("runtime_evidence"),
+                repo_root=repo_root,
+                verify_discovery=args.verify_runtime_evidence,
+                command_runner=command_runner,
+            ):
                 print(f"ERROR: domain {name}: {error}", file=sys.stderr)
                 failures += 1
 
@@ -420,4 +642,4 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/check_conformance_edge_pack.py
+++ b/tools/check_conformance_edge_pack.py
@@ -1,14 +1,20 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import argparse
 import json
+import os
+import re
 import stat
+import subprocess  # nosec B404
 import sys
+import tempfile
 from pathlib import Path
 
 CLAIMED_PRESENT_STATUSES = {"present", "covered", "complete"}
 KNOWN_ABSENT_STATUSES = {"absent", "deferred", "not_claimed", "not-applicable", "not_applicable"}
 RUNTIME_EVIDENCE_MAX_SOURCE_BYTES = 1_000_000
+RUNTIME_EVIDENCE_DISCOVERY_TIMEOUT_SECS = 120
 
 
 def fail(msg: str) -> int:
@@ -97,7 +103,6 @@ def runtime_source_path_errors(raw_path: str, *, repo_root: Path) -> list[str]:
         return ["Go runtime evidence paths must end with _test.go"]
     if parts[1] == "rust" and not raw_path.endswith(".rs"):
         return ["Rust runtime evidence paths must end with .rs"]
-
     source_path = repo_root / rel_path
     if path_contains_symlink(repo_root, rel_path):
         return ["runtime_evidence source path must not contain symlinks"]
@@ -121,7 +126,147 @@ def runtime_source_path_errors(raw_path: str, *, repo_root: Path) -> list[str]:
     return []
 
 
-def runtime_evidence_errors(value: object, *, repo_root: Path) -> list[str]:
+def go_package_arg(raw_path: str) -> str:
+    package_dir = Path(raw_path).parent.relative_to("clients/go")
+    if str(package_dir) == ".":
+        return "."
+    return f"./{package_dir.as_posix()}"
+
+
+def run_discovery_command(cmd: list[str], *, cwd: Path, command_runner, env: dict[str, str] | None = None) -> tuple[str, str | None]:
+    command_env = None if env is None else {**os.environ, **env}
+    try:
+        completed = command_runner(
+            cmd,
+            cwd=cwd,
+            env=command_env,
+            text=True,
+            capture_output=True,
+            timeout=RUNTIME_EVIDENCE_DISCOVERY_TIMEOUT_SECS,
+        )
+    except FileNotFoundError:
+        return "", f"runtime_evidence discovery command missing: {cmd[0]}"
+    except OSError as exc:
+        return "", f"runtime_evidence discovery command failed to start: {cmd[0]}: {exc}"
+    except subprocess.TimeoutExpired:
+        return "", "runtime_evidence discovery command timed out"
+    if completed.returncode != 0:
+        return "", f"runtime_evidence discovery command failed: {cmd[0]} exit {completed.returncode}"
+    if not isinstance(completed.stdout, str) or not isinstance(completed.stderr, str):
+        return "", "runtime_evidence discovery command produced malformed stdout"
+    return completed.stdout + completed.stderr, None
+
+
+def go_discovery_env(temp_dir: str) -> dict[str, str]:
+    return {
+        "GOENV": "off",
+        "GOFLAGS": "-buildvcs=false",
+        "GOTMPDIR": temp_dir,
+    }
+
+
+def go_testmain_declared_tests(work_output: str, temp_dir: Path) -> tuple[set[str], str | None]:
+    work_root = None
+    for line in work_output.splitlines():
+        if line.startswith("WORK="):
+            work_root = Path(line.removeprefix("WORK=").strip()).resolve()
+            break
+    if work_root is None:
+        return set(), "runtime_evidence discovery command did not report Go work directory"
+    if not work_root.is_relative_to(temp_dir.resolve()):
+        return set(), "runtime_evidence discovery command reported unsafe Go work directory"
+    candidates = sorted(work_root.glob("**/_testmain.go"))
+    if not candidates:
+        return set(), "runtime_evidence discovery command did not produce Go testmain"
+    try:
+        testmain = candidates[0].read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        return set(), f"runtime_evidence discovery command produced unreadable Go testmain: {exc}"
+    tests = set()
+    for match in re.finditer(r'\{"(Test[A-Za-z0-9_]*)",\s*_(x?test)\.(Test[A-Za-z0-9_]*)\}', testmain):
+        if match.group(1) == match.group(3):
+            tests.add(match.group(1))
+    return tests, None
+
+
+def go_objdump_matches_source(stdout: str, source_path: Path) -> bool:
+    absolute = source_path.resolve().as_posix()
+    parts = source_path.parts
+    relative = source_path.name
+    for index, part in enumerate(parts[:-1]):
+        if part == "clients" and parts[index + 1] == "go":
+            relative = "/".join(parts[index:])
+            break
+    for line in stdout.splitlines():
+        if not line.startswith("TEXT "):
+            continue
+        _, separator, emitted = line.rstrip().partition(") ")
+        if not separator:
+            continue
+        emitted = emitted.replace("\\", "/")
+        if emitted == absolute or emitted == relative or emitted.endswith(f"/{relative}"):
+            return True
+    return False
+
+
+def go_file_discovered_tests(
+    raw_path: str,
+    *,
+    repo_root: Path,
+    expected_tests: list[str],
+    command_runner,
+) -> tuple[set[str], str | None]:
+    package_arg = go_package_arg(raw_path)
+    go_root = repo_root / "clients" / "go"
+    with tempfile.TemporaryDirectory(prefix="rubin-go-testbin-") as temp_dir:
+        test_binary = Path(temp_dir) / "package.test"
+        compile_output, compile_error = run_discovery_command(
+            ["go", "test", "-c", "-work", "-o", str(test_binary), package_arg],
+            cwd=go_root,
+            env=go_discovery_env(temp_dir),
+            command_runner=command_runner,
+        )
+        if compile_error is not None:
+            return set(), compile_error
+        registered_tests, registry_error = go_testmain_declared_tests(compile_output, Path(temp_dir))
+        if registry_error is not None:
+            return set(), registry_error
+        file_tests: set[str] = set()
+        for test_name in sorted(expected_tests):
+            if test_name not in registered_tests:
+                continue
+            symbol_re = rf".*\.{re.escape(test_name)}$"
+            objdump_stdout, objdump_error = run_discovery_command(
+                ["go", "tool", "objdump", "-s", symbol_re, str(test_binary)],
+                cwd=go_root,
+                command_runner=command_runner,
+            )
+            if objdump_error is not None:
+                return set(), objdump_error
+            if go_objdump_matches_source(objdump_stdout, repo_root / raw_path):
+                file_tests.add(test_name)
+    return file_tests, None
+
+
+def discovered_runtime_tests(
+    raw_path: str,
+    *,
+    repo_root: Path,
+    expected_tests: list[str],
+    command_runner,
+) -> tuple[set[str], str | None]:
+    if raw_path.startswith("clients/go/"):
+        return go_file_discovered_tests(raw_path, repo_root=repo_root, expected_tests=expected_tests, command_runner=command_runner)
+    return set(), None
+
+
+def runtime_evidence_errors(
+    value: object,
+    *,
+    repo_root: Path,
+    verify_go_discovery: bool,
+    command_runner,
+) -> list[str]:
     if not isinstance(value, dict):
         return ["runtime_evidence must be object"]
     if "tests_by_file" not in value:
@@ -136,18 +281,40 @@ def runtime_evidence_errors(value: object, *, repo_root: Path) -> list[str]:
         if not isinstance(raw_path, str) or not raw_path.strip() or raw_path != raw_path.strip():
             errors.append("runtime_evidence.tests_by_file keys must be non-empty repo-relative strings")
             continue
-        _, tests_error = string_list(
+        tests, tests_error = string_list(
             raw_tests,
             field_name=f"runtime_evidence.tests_by_file[{raw_path}]",
             require_non_empty=True,
         )
+        path_errors = runtime_source_path_errors(raw_path, repo_root=repo_root)
         if tests_error is not None:
             errors.append(tests_error)
-        errors.extend(runtime_source_path_errors(raw_path, repo_root=repo_root))
+        errors.extend(path_errors)
+        if verify_go_discovery and raw_path.startswith("clients/go/") and tests_error is None and not path_errors:
+            present, discovery_error = discovered_runtime_tests(
+                raw_path,
+                repo_root=repo_root,
+                expected_tests=tests,
+                command_runner=command_runner,
+            )
+            if discovery_error is not None:
+                errors.append(discovery_error)
+                continue
+            missing = [name for name in tests if name not in present]
+            if missing:
+                errors.append(f"missing runtime evidence tests: {', '.join(missing)}")
     return errors
 
 
-def main() -> int:
+def main(argv: list[str] | None = None, *, command_runner=subprocess.run) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--verify-runtime-evidence-go",
+        action="store_true",
+        help="run opt-in Go toolchain discovery for Go runtime_evidence test names",
+    )
+    args = parser.parse_args([] if argv is None else argv)
+
     repo_root = Path(".").resolve()
     baseline_path = repo_root / "conformance" / "EDGE_PACK_BASELINE.json"
     fixtures_dir = repo_root / "conformance" / "fixtures"
@@ -241,7 +408,12 @@ def main() -> int:
             continue
 
         if "runtime_evidence" in domain:
-            for error in runtime_evidence_errors(domain.get("runtime_evidence"), repo_root=repo_root):
+            for error in runtime_evidence_errors(
+                domain.get("runtime_evidence"),
+                repo_root=repo_root,
+                verify_go_discovery=args.verify_runtime_evidence_go,
+                command_runner=command_runner,
+            ):
                 print(f"ERROR: domain {name}: {error}", file=sys.stderr)
                 failures += 1
 
@@ -420,4 +592,4 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/tests/test_check_conformance_edge_pack.py
+++ b/tools/tests/test_check_conformance_edge_pack.py
@@ -6,9 +6,11 @@ import contextlib
 import io
 import json
 import os
+import subprocess  # nosec B404
 import sys
 import tempfile
 import unittest
+import unittest.mock
 from pathlib import Path
 
 TOOLS_DIR = Path(__file__).resolve().parents[1]
@@ -99,6 +101,58 @@ def write_runtime_source(root: Path, rel_path: str, text: str = "// test source\
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(text, encoding="utf-8")
     return path
+
+
+def make_runtime_evidence_repo(root: Path, tests_by_file: dict[str, list[str]]) -> None:
+    make_repo(root)
+    for rel_path in tests_by_file:
+        if rel_path.startswith("clients/go/"):
+            write_runtime_source(root, rel_path, "package node\n")
+        elif rel_path.startswith("clients/rust/"):
+            write_runtime_source(root, rel_path, "mod tests {}\n")
+    set_runtime_evidence(root, {"tests_by_file": tests_by_file})
+
+
+class FakeCommandRunner:
+    def __init__(self, outputs: dict[tuple[str, ...], tuple[int, str, str] | BaseException], registered_tests: list[str] | None = None) -> None:
+        self.outputs = outputs
+        self.registered_tests = ["TestRuntimeReorg"] if registered_tests is None else registered_tests
+        self.calls: list[tuple[tuple[str, ...], Path]] = []
+        self.envs: list[dict[str, str] | None] = []
+
+    def __call__(
+        self,
+        cmd: list[str],
+        *,
+        cwd: Path,
+        env: dict[str, str] | None,
+        text: bool,
+        capture_output: bool,
+        timeout: int,
+    ) -> subprocess.CompletedProcess[str]:
+        _ = (text, capture_output, timeout)
+        self.calls.append((tuple(cmd), cwd))
+        self.envs.append(env)
+        output = self.outputs.get(tuple(cmd))
+        if output is None:
+            output = next((candidate for pattern, candidate in self.outputs.items() if len(pattern) == len(cmd) and all(part == "*" or part == actual for part, actual in zip(pattern, cmd))), (127, "", "unexpected command"))
+        if isinstance(output, BaseException):
+            raise output
+        is_go_compile = len(GO_COMPILE) == len(cmd) and all(part == "*" or part == actual for part, actual in zip(GO_COMPILE, cmd))
+        if is_go_compile and env is not None and output[0] == 0:
+            work_dir = Path(env["GOTMPDIR"]) / "go-build-fake" / "b001"
+            work_dir.mkdir(parents=True)
+            entries = "\n".join(f'\t{{"{name}", _test.{name}}},' for name in self.registered_tests)
+            (work_dir / "_testmain.go").write_text(f"package main\nvar tests = []testing.InternalTest{{\n{entries}\n}}\n", encoding="utf-8")
+            output = (output[0], output[1], output[2] + f"WORK={work_dir.parent}\n")
+        rc, stdout, stderr = output
+        return subprocess.CompletedProcess(cmd, rc, stdout, stderr)
+
+
+GO_COMPILE = ("go", "test", "-c", "-work", "-o", "*", "./node")
+
+
+def go_objdump_cmd(test_name: str) -> tuple[str, ...]: return ("go", "tool", "objdump", "-s", rf".*\.{test_name}$", "*")
 
 
 class EdgePackCheckerTests(unittest.TestCase):
@@ -604,6 +658,156 @@ class EdgePackCheckerTests(unittest.TestCase):
                 rc = m.main()
         self.assertEqual(rc, 0)
         self.assertIn("OK: conformance edge-pack baseline satisfied.", captured.getvalue())
+
+    def test_runtime_evidence_opt_in_verifies_declared_tests_with_toolchains(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="rubin path ") as td:
+            root = Path(td)
+            make_runtime_evidence_repo(
+                root,
+                {
+                    "clients/go/node/sync_reorg_test.go": ["TestRuntimeReorg"],
+                    "clients/rust/crates/rubin-node/src/sync_reorg.rs": ["runtime_reorg_test"],
+                },
+            )
+            runner = FakeCommandRunner(
+                {
+                    GO_COMPILE: (0, "", ""),
+                    go_objdump_cmd("TestRuntimeReorg"): (
+                        0,
+                        f"TEXT pkg.TestRuntimeReorg(SB) {(root / 'clients/go/node/sync_reorg_test.go').resolve()}\n",
+                        "",
+                    ),
+                }
+            )
+            with chdir(root):
+                rc = m.main(["--verify-runtime-evidence-go"], command_runner=runner)
+        self.assertEqual(rc, 0)
+        self.assertFalse(any("-list" in call[0] for call in runner.calls))
+        self.assertTrue(all(call[0][0] != "cargo" for call in runner.calls))
+        self.assertEqual(runner.envs[0]["GOENV"], "off")
+        self.assertEqual(runner.envs[0]["GOFLAGS"], "-buildvcs=false")
+
+    def test_runtime_evidence_opt_in_accepts_external_package_go_tests(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_runtime_evidence_repo(root, {"clients/go/node/sync_reorg_test.go": ["TestRuntimeReorg"]})
+            runner = FakeCommandRunner({GO_COMPILE: (0, "", "")}, registered_tests=[])
+
+            def external_testmain(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+                completed = runner(cmd, **kwargs)
+                if tuple(cmd[:4]) == ("go", "test", "-c", "-work"):
+                    work_root = Path(str(completed.stderr).split("WORK=", 1)[1].strip())
+                    (work_root / "b001" / "_testmain.go").write_text(
+                        'package main\nvar tests = []testing.InternalTest{\n\t{"TestRuntimeReorg", _xtest.TestRuntimeReorg},\n}\n',
+                        encoding="utf-8",
+                    )
+                return completed
+
+            runner.outputs[go_objdump_cmd("TestRuntimeReorg")] = (
+                0,
+                f"TEXT pkg.TestRuntimeReorg(SB) {(root / 'clients/go/node/sync_reorg_test.go').resolve()}\n",
+                "",
+            )
+            with chdir(root):
+                rc = m.main(["--verify-runtime-evidence-go"], command_runner=external_testmain)
+        self.assertEqual(rc, 0)
+
+    def test_runtime_evidence_opt_in_sanitizes_ambient_go_flags(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_runtime_evidence_repo(root, {"clients/go/node/sync_reorg_test.go": ["TestRuntimeReorg"]})
+            runner = FakeCommandRunner(
+                {
+                    GO_COMPILE: (0, "", ""),
+                    go_objdump_cmd("TestRuntimeReorg"): (
+                        0,
+                        f"TEXT pkg.TestRuntimeReorg(SB) {(root / 'clients/go/node/sync_reorg_test.go').resolve()}\n",
+                        "",
+                    ),
+                }
+            )
+            with unittest.mock.patch.dict(os.environ, {"GOFLAGS": "-tags=forged", "GOENV": str(root / "forged_goenv")}, clear=False):
+                with chdir(root):
+                    rc = m.main(["--verify-runtime-evidence-go"], command_runner=runner)
+        self.assertEqual(rc, 0)
+        self.assertEqual(runner.envs[0]["GOENV"], "off")
+        self.assertEqual(runner.envs[0]["GOFLAGS"], "-buildvcs=false")
+
+    def test_go_objdump_source_match_accepts_spaces_and_trimpath(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="rubin path ") as td:
+            source = Path(td) / "clients/go/node/sync_reorg_test.go"
+            self.assertTrue(m.go_objdump_matches_source(f"TEXT pkg.TestA(SB) {source}\n", source))
+            self.assertTrue(
+                m.go_objdump_matches_source(
+                    "TEXT pkg.TestA(SB) github.com/rubin/clients/go/node/sync_reorg_test.go\n",
+                    source,
+                )
+            )
+
+    def test_runtime_evidence_opt_in_rejects_missing_exact_or_wrong_file_names(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_runtime_evidence_repo(
+                root,
+                {
+                    "clients/go/node/sync_reorg_test.go": ["TestRuntimeReorg"],
+                    "clients/rust/crates/rubin-node/src/sync_reorg.rs": ["runtime_reorg_test"],
+                },
+            )
+            runner = FakeCommandRunner(
+                {
+                    GO_COMPILE: (0, "", ""),
+                    go_objdump_cmd("TestRuntimeReorg"): (
+                        0,
+                        f"TEXT pkg.TestRuntimeReorg(SB) {(root / 'clients/go/node/config_test.go').resolve()}\n",
+                        "",
+                    ),
+                }
+            )
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stderr(captured):
+                rc = m.main(["--verify-runtime-evidence-go"], command_runner=runner)
+        self.assertEqual(rc, 1)
+        self.assertIn("missing runtime evidence tests: TestRuntimeReorg", captured.getvalue())
+
+    def test_runtime_evidence_opt_in_rejects_compiled_non_test_symbol(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_runtime_evidence_repo(root, {"clients/go/node/sync_reorg_test.go": ["TestRuntimeReorg"]})
+            runner = FakeCommandRunner(
+                {
+                    GO_COMPILE: (0, "", ""),
+                    go_objdump_cmd("TestRuntimeReorg"): (
+                        0,
+                        f"TEXT pkg.TestRuntimeReorg(SB) {(root / 'clients/go/node/sync_reorg_test.go').resolve()}\n",
+                        "",
+                    ),
+                },
+                registered_tests=[],
+            )
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stderr(captured):
+                rc = m.main(["--verify-runtime-evidence-go"], command_runner=runner)
+        self.assertEqual(rc, 1)
+        self.assertIn("missing runtime evidence tests: TestRuntimeReorg", captured.getvalue())
+
+    def test_runtime_evidence_opt_in_fails_closed_for_toolchain_error_and_timeout(self) -> None:
+        def timeout_runner(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            raise subprocess.TimeoutExpired(["go"], 30)
+
+        for runner, expected in [
+            (FakeCommandRunner({GO_COMPILE: (1, "", "go compile failed")}), "failed: go exit 1"),
+            (FakeCommandRunner({GO_COMPILE: PermissionError("not executable")}), "failed to start: go: not executable"),
+            (timeout_runner, "timed out"),
+        ]:
+            with tempfile.TemporaryDirectory() as td:
+                root = Path(td)
+                make_runtime_evidence_repo(root, {"clients/go/node/sync_reorg_test.go": ["TestRuntimeReorg"]})
+                captured = io.StringIO()
+                with chdir(root), contextlib.redirect_stderr(captured):
+                    rc = m.main(["--verify-runtime-evidence-go"], command_runner=runner)
+            self.assertEqual(rc, 1)
+            self.assertIn(f"runtime_evidence discovery command {expected}", captured.getvalue())
 
     def test_runtime_evidence_rejects_schema_path_and_source_boundary_errors(self) -> None:
         def base_runtime_evidence(path: str = "clients/go/node/sync_reorg_test.go") -> dict:

--- a/tools/tests/test_check_conformance_edge_pack.py
+++ b/tools/tests/test_check_conformance_edge_pack.py
@@ -684,8 +684,10 @@ class EdgePackCheckerTests(unittest.TestCase):
         self.assertEqual(rc, 0)
         self.assertFalse(any("-list" in call[0] for call in runner.calls))
         self.assertTrue(all(call[0][0] != "cargo" for call in runner.calls))
-        self.assertEqual(runner.envs[0]["GOENV"], "off")
-        self.assertEqual(runner.envs[0]["GOFLAGS"], "-buildvcs=false")
+        go_envs = [env for call, env in zip(runner.calls, runner.envs) if call[0][0] == "go"]
+        self.assertTrue(go_envs)
+        self.assertTrue(all(env["GOENV"] == "off" for env in go_envs))
+        self.assertTrue(all(env["GOFLAGS"] == "-buildvcs=false" for env in go_envs))
 
     def test_runtime_evidence_opt_in_accepts_external_package_go_tests(self) -> None:
         with tempfile.TemporaryDirectory() as td:
@@ -730,17 +732,21 @@ class EdgePackCheckerTests(unittest.TestCase):
                 with chdir(root):
                     rc = m.main(["--verify-runtime-evidence-go"], command_runner=runner)
         self.assertEqual(rc, 0)
-        self.assertEqual(runner.envs[0]["GOENV"], "off")
-        self.assertEqual(runner.envs[0]["GOFLAGS"], "-buildvcs=false")
+        go_envs = [env for call, env in zip(runner.calls, runner.envs) if call[0][0] == "go"]
+        self.assertTrue(go_envs)
+        self.assertTrue(all(env["GOENV"] == "off" for env in go_envs))
+        self.assertTrue(all(env["GOFLAGS"] == "-buildvcs=false" for env in go_envs))
 
     def test_go_objdump_source_match_accepts_spaces_and_trimpath(self) -> None:
         with tempfile.TemporaryDirectory(prefix="rubin path ") as td:
-            source = Path(td) / "clients/go/node/sync_reorg_test.go"
-            self.assertTrue(m.go_objdump_matches_source(f"TEXT pkg.TestA(SB) {source}\n", source))
+            repo_root = Path(td) / "clients/go/wrapper/repo"
+            source = repo_root / "clients/go/node/sync_reorg_test.go"
+            self.assertTrue(m.go_objdump_matches_source(f"TEXT pkg.TestA(SB) {source}\n", source_path=source, repo_root=repo_root))
             self.assertTrue(
                 m.go_objdump_matches_source(
                     "TEXT pkg.TestA(SB) github.com/rubin/clients/go/node/sync_reorg_test.go\n",
-                    source,
+                    source_path=source,
+                    repo_root=repo_root,
                 )
             )
 

--- a/tools/tests/test_check_conformance_edge_pack.py
+++ b/tools/tests/test_check_conformance_edge_pack.py
@@ -6,6 +6,7 @@ import contextlib
 import io
 import json
 import os
+import subprocess  # nosec B404
 import sys
 import tempfile
 import unittest
@@ -101,6 +102,62 @@ def write_runtime_source(root: Path, rel_path: str, text: str = "// test source\
     return path
 
 
+def write_rust_crate_manifest(root: Path) -> None:
+    write_runtime_source(
+        root,
+        "clients/rust/Cargo.toml",
+        '[workspace]\nmembers = ["crates/rubin-node"]\n',
+    )
+    write_runtime_source(
+        root,
+        "clients/rust/crates/rubin-node/Cargo.toml",
+        '[package]\nname = "rubin-node"\nversion = "0.0.0"\nedition = "2021"\n',
+    )
+
+
+def make_runtime_evidence_repo(root: Path, tests_by_file: dict[str, list[str]]) -> None:
+    make_repo(root)
+    for rel_path in tests_by_file:
+        if rel_path.startswith("clients/go/"):
+            write_runtime_source(root, rel_path, "package node\n")
+        elif rel_path.startswith("clients/rust/"):
+            write_runtime_source(root, rel_path, "mod tests {}\n")
+    if any(path.startswith("clients/rust/") for path in tests_by_file):
+        write_rust_crate_manifest(root)
+    set_runtime_evidence(root, {"tests_by_file": tests_by_file})
+
+
+class FakeCommandRunner:
+    def __init__(self, outputs: dict[tuple[str, ...], tuple[int, str, str]]) -> None:
+        self.outputs = outputs
+        self.calls: list[tuple[tuple[str, ...], Path]] = []
+
+    def __call__(
+        self,
+        cmd: list[str],
+        *,
+        cwd: Path,
+        text: bool,
+        capture_output: bool,
+        timeout: int,
+    ) -> subprocess.CompletedProcess[str]:
+        _ = (text, capture_output, timeout)
+        self.calls.append((tuple(cmd), cwd))
+        output = self.outputs.get(tuple(cmd))
+        if output is None:
+            output = next((candidate for pattern, candidate in self.outputs.items() if len(pattern) == len(cmd) and all(part == "*" or part == actual for part, actual in zip(pattern, cmd))), (127, "", "unexpected command"))
+        rc, stdout, stderr = output
+        return subprocess.CompletedProcess(cmd, rc, stdout, stderr)
+
+
+GO_LIST = ("go", "test", "-run", "^$", "-list", ".", "./node")
+GO_COMPILE = ("go", "test", "-c", "-o", "*", "./node")
+RUST_SYNC_LIST = ("cargo", "test", "-p", "rubin-node", "--lib", "sync_reorg", "--", "--list")
+RUST_SYNC_IGNORED = ("cargo", "test", "-p", "rubin-node", "--lib", "sync_reorg", "--", "--ignored", "--list")
+
+def go_objdump_cmd(test_name: str) -> tuple[str, ...]: return ("go", "tool", "objdump", "-s", rf".*\.{test_name}$", "*")
+
+
 class EdgePackCheckerTests(unittest.TestCase):
     def test_clean_accounting_passes_with_deferred_fuzz_formal(self) -> None:
         with tempfile.TemporaryDirectory() as td:
@@ -110,7 +167,6 @@ class EdgePackCheckerTests(unittest.TestCase):
             with chdir(root), contextlib.redirect_stdout(captured):
                 rc = m.main()
         self.assertEqual(rc, 0)
-        self.assertIn("OK: conformance edge-pack baseline satisfied.", captured.getvalue())
 
     def test_missing_required_vector_fails(self) -> None:
         with tempfile.TemporaryDirectory() as td:
@@ -604,6 +660,112 @@ class EdgePackCheckerTests(unittest.TestCase):
                 rc = m.main()
         self.assertEqual(rc, 0)
         self.assertIn("OK: conformance edge-pack baseline satisfied.", captured.getvalue())
+
+    def test_runtime_evidence_opt_in_verifies_declared_tests_with_toolchains(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_runtime_evidence_repo(
+                root,
+                {
+                    "clients/go/node/sync_reorg_test.go": ["TestRuntimeReorg"],
+                    "clients/rust/crates/rubin-node/src/sync_reorg.rs": ["runtime_reorg_test"],
+                },
+            )
+            runner = FakeCommandRunner(
+                {
+                    GO_LIST: (0, "TestRuntimeReorg\n", ""),
+                    GO_COMPILE: (0, "", ""),
+                    go_objdump_cmd("TestRuntimeReorg"): (
+                        0,
+                        f"TEXT pkg.TestRuntimeReorg(SB) {(root / 'clients/go/node/sync_reorg_test.go').resolve()}\n",
+                        "",
+                    ),
+                    RUST_SYNC_LIST: (
+                        0,
+                        "sync_reorg::tests::runtime_reorg_test: test\n",
+                        "cargo build noise is not parsed as evidence\n",
+                    ),
+                    RUST_SYNC_IGNORED: (0, "", ""),
+                }
+            )
+            with chdir(root):
+                rc = m.main(["--verify-runtime-evidence"], command_runner=runner)
+        self.assertEqual(rc, 0)
+
+    def test_runtime_evidence_opt_in_rejects_missing_exact_or_wrong_file_names(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_runtime_evidence_repo(
+                root,
+                {
+                    "clients/go/node/sync_reorg_test.go": ["TestRuntimeReorg"],
+                    "clients/rust/crates/rubin-node/src/sync_reorg.rs": ["runtime_reorg_test"],
+                },
+            )
+            runner = FakeCommandRunner(
+                {
+                    GO_LIST: (0, "TestRuntimeReorg\n", ""),
+                    GO_COMPILE: (0, "", ""),
+                    go_objdump_cmd("TestRuntimeReorg"): (
+                        0,
+                        f"TEXT pkg.TestRuntimeReorg(SB) {(root / 'clients/go/node/config_test.go').resolve()}\n",
+                        "",
+                    ),
+                    RUST_SYNC_LIST: (
+                        0,
+                        "other::tests::runtime_reorg_test: test\n",
+                        "",
+                    ),
+                    RUST_SYNC_IGNORED: (0, "", ""),
+                }
+            )
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stderr(captured):
+                rc = m.main(["--verify-runtime-evidence"], command_runner=runner)
+        self.assertEqual(rc, 1)
+        self.assertIn("missing runtime evidence tests: TestRuntimeReorg", captured.getvalue())
+        self.assertIn("missing runtime evidence tests: runtime_reorg_test", captured.getvalue())
+
+    def test_runtime_evidence_opt_in_fails_closed_for_toolchain_error_and_timeout(self) -> None:
+        def timeout_runner(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            raise subprocess.TimeoutExpired(["go"], 30)
+
+        for runner, expected in [
+            (FakeCommandRunner({GO_LIST: (1, "", "go list failed")}), "failed: go exit 1"),
+            (timeout_runner, "timed out"),
+        ]:
+            with tempfile.TemporaryDirectory() as td:
+                root = Path(td)
+                make_runtime_evidence_repo(root, {"clients/go/node/sync_reorg_test.go": ["TestRuntimeReorg"]})
+                captured = io.StringIO()
+                with chdir(root), contextlib.redirect_stderr(captured):
+                    rc = m.main(["--verify-runtime-evidence"], command_runner=runner)
+            self.assertEqual(rc, 1)
+            self.assertIn(f"runtime_evidence discovery command {expected}", captured.getvalue())
+
+    def test_runtime_evidence_opt_in_rejects_ignored_rust_tests(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_runtime_evidence_repo(root, {"clients/rust/crates/rubin-node/src/ignored.rs": ["ignored_test"]})
+            runner = FakeCommandRunner(
+                {
+                    ("cargo", "test", "-p", "rubin-node", "--lib", "ignored", "--", "--list"): (
+                        0,
+                        "ignored::tests::ignored_test: test\n",
+                        "",
+                    ),
+                    ("cargo", "test", "-p", "rubin-node", "--lib", "ignored", "--", "--ignored", "--list"): (
+                        0,
+                        "ignored::tests::ignored_test: test\n",
+                        "",
+                    ),
+                }
+            )
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stderr(captured):
+                rc = m.main(["--verify-runtime-evidence"], command_runner=runner)
+        self.assertEqual(rc, 1)
+        self.assertIn("missing runtime evidence tests: ignored_test", captured.getvalue())
 
     def test_runtime_evidence_rejects_schema_path_and_source_boundary_errors(self) -> None:
         def base_runtime_evidence(path: str = "clients/go/node/sync_reorg_test.go") -> dict:


### PR DESCRIPTION
Invariant:
Go runtime_evidence entries for clients/go must be verified by opt-in compile-only Go toolchain evidence: generated _testmain.go registry membership plus objdump source binding for each declared test.

Layer:
Conformance tooling / non-consensus validation.

Files changed:
- tools/check_conformance_edge_pack.py
- tools/tests/test_check_conformance_edge_pack.py

Tests:
- python3 -m unittest tools.tests.test_check_conformance_edge_pack — PASS
- python3 -m py_compile tools/check_conformance_edge_pack.py tools/tests/test_check_conformance_edge_pack.py — PASS
- ruff check tools/check_conformance_edge_pack.py tools/tests/test_check_conformance_edge_pack.py — PASS
- bandit -q tools/check_conformance_edge_pack.py tools/tests/test_check_conformance_edge_pack.py — PASS
- vulture tools/check_conformance_edge_pack.py tools/tests/test_check_conformance_edge_pack.py --min-confidence 90 — PASS
- scripts/dev-env.sh -- python3 tools/check_conformance_edge_pack.py — PASS
- scripts/dev-env.sh -- python3 tools/check_conformance_edge_pack.py --verify-runtime-evidence-go — PASS
- GOFLAGS=-trimpath scripts/dev-env.sh -- python3 tools/check_conformance_edge_pack.py --verify-runtime-evidence-go — PASS
- GOFLAGS=-tags=forged scripts/dev-env.sh -- python3 tools/check_conformance_edge_pack.py --verify-runtime-evidence-go — PASS
- scripts/dev-env.sh -- python3 tools/gen_conformance_matrix.py --check — PASS
- scripts/dev-env.sh -- python3 tools/check_conformance_fixtures_policy.py — PASS
- git diff --check origin/main — PASS
- rubin-precommit-one-review with --include-base-diff --light-python — PASS
- One stock code-review subagent after final candidate — No findings.
- rubin-push with no-coverage reason "RUB-349 changes only Python conformance tooling/tests; no Go/Rust coverable client source changed" — PASS

Behavior impact:
Adds opt-in --verify-runtime-evidence-go. Default checker behavior remains schema/path/accounting-only and does not run Go/Cargo.

Compatibility impact:
No consensus, runtime, fixture, baseline, Go client, or Rust client behavior changes.

Known non-goals:
- Rust runtime evidence discovery is split to RUB-350.
- No conformance vector or baseline declaration changes.
- No RUBIN_L1_CANONICAL or consensus changes.

Risk:
Go discovery shells out to local Go tooling only when explicitly requested. Discovery runs with sanitized Go env: GOENV=off, GOFLAGS=-buildvcs=false, and a controlled GOTMPDIR.

Rollback:
Revert this PR; the default edge-pack checker path remains unchanged unless the new opt-in flag is used.

Not checked:
GitHub-hosted checks are not claimed here; local push evidence above is the checked preflight surface.


<!-- rubin-agent-meta actor=unknown action=pr-edit via=cl branch=codex/RUB-346-runtime-evidence-toolchain-discovery wt=rubin-protocol-codex-RUB-346 utc=2026-05-22T21:42:01Z -->
