### PR TITLE
[RUB-353] Clear compact fallback outstanding state

### DIFF
--- a/clients/go/node/p2p/compact_reconstruct.go
+++ b/clients/go/node/p2p/compact_reconstruct.go
@@ -567,6 +567,7 @@ func (p *peer) compactApplyErrorFallback(pb *consensus.ParsedBlock, blockHash [3
 }
 
 func (p *peer) requestCompactFullBlockFallback(blockHash [32]byte) error {
+	p.clearCompactOutstandingRequestForBlock(blockHash)
 	body, err := encodeInventoryVectors([]InventoryVector{{Type: MSG_BLOCK, Hash: blockHash}})
 	if err != nil {
 		return err

--- a/clients/go/node/p2p/compact_reconstruct_test.go
+++ b/clients/go/node/p2p/compact_reconstruct_test.go
@@ -831,6 +831,31 @@ func TestCompactProcessErrorEdges(t *testing.T) {
 	}
 }
 
+func TestRequestCompactFullBlockFallbackClearsOnlyMatchingOutstanding(t *testing.T) {
+	header, blockHash, txs := compactPartsFromBlockBytes(t, node.DevnetGenesisBlockBytes())
+	p := newCompactScriptedPeer(t)
+	setCompactTestOutstanding(p, blockHash, header, compactShortIDForTx(t, txs[0], 901, 902), 901, 902)
+
+	requireNoCompactErr(t, p.requestCompactFullBlockFallback(blockHash), "matching compact fallback")
+	frame := requireCompactFrame(t, p, messageGetData)
+	items, err := decodeInventoryVectors(frame.Payload)
+	requireNoCompactErr(t, err, "decode matching fallback getdata")
+	if len(items) != 1 || items[0].Type != MSG_BLOCK || items[0].Hash != blockHash {
+		t.Fatalf("matching fallback inventory=%+v, want MSG_BLOCK %x", items, blockHash)
+	}
+	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatal("matching compact fallback left outstanding request active")
+	}
+
+	activeHash := [32]byte{0x81}
+	p = newCompactScriptedPeer(t)
+	p.activateCompactOutstandingRequest(compactOutstandingTestRequest(activeHash))
+	requireNoCompactErr(t, p.requestCompactFullBlockFallback(blockHash), "stale compact fallback")
+	if snap, ok := p.compactOutstandingRequestSnapshot(); !ok || snap.BlockHash != activeHash {
+		t.Fatalf("stale compact fallback corrupted outstanding=%+v ok=%v", snap, ok)
+	}
+}
+
 func TestCompactApplyErrorFallbackEdges(t *testing.T) {
 	source := newTestHarness(t, 2, "127.0.0.1:0", nil)
 	blockHash, blockBytes := testHarnessBlockAtHeight(t, source, 1)

--- a/clients/go/node/p2p/compact_runtime.go
+++ b/clients/go/node/p2p/compact_runtime.go
@@ -232,6 +232,18 @@ func (p *peer) popCompactOutstandingRequest() (compactOutstandingRequest, bool) 
 	return cloneCompactOutstandingRequest(req), true
 }
 
+func (p *peer) popExpiredCompactOutstandingBlockHash() ([32]byte, uint32, bool) {
+	p.compactMu.Lock()
+	defer p.compactMu.Unlock()
+	if p.compact.outstanding == nil || !p.compactOutstandingRequestExpiredLocked() {
+		return [32]byte{}, 0, false
+	}
+	blockHash := p.compact.outstanding.BlockHash
+	blockTxnPayloadCap := p.compact.outstanding.BlockTxnPayloadCap
+	p.compact.outstanding = nil
+	return blockHash, blockTxnPayloadCap, true
+}
+
 func (p *peer) clearCompactOutstandingRequestForBlock(blockHash [32]byte) {
 	p.compactMu.Lock()
 	if p.compact.outstanding != nil && p.compact.outstanding.BlockHash == blockHash {

--- a/clients/go/node/p2p/compact_runtime.go
+++ b/clients/go/node/p2p/compact_runtime.go
@@ -232,7 +232,7 @@ func (p *peer) popCompactOutstandingRequest() (compactOutstandingRequest, bool) 
 	return cloneCompactOutstandingRequest(req), true
 }
 
-func (p *peer) popExpiredCompactOutstandingBlockHash() ([32]byte, uint32, bool) {
+func (p *peer) popExpiredCompactOutstandingBlockHashAndPayloadCap() ([32]byte, uint32, bool) {
 	p.compactMu.Lock()
 	defer p.compactMu.Unlock()
 	if p.compact.outstanding == nil || !p.compactOutstandingRequestExpiredLocked() {

--- a/clients/go/node/p2p/compact_runtime_test.go
+++ b/clients/go/node/p2p/compact_runtime_test.go
@@ -169,14 +169,14 @@ func TestFailedCmpctBlockSendDoesNotAuthorizeRacingGetBlockTxn(t *testing.T) {
 	}
 }
 
-func TestPopExpiredCompactOutstandingBlockHashClearsOnlyExpired(t *testing.T) {
+func TestPopExpiredCompactOutstandingBlockHashAndPayloadCapClearsOnlyExpired(t *testing.T) {
 	p := newPeerRuntimeTestPeer(t)
 	now := time.Unix(1000, 0)
 	p.service.cfg.Now = func() time.Time { return now }
 	blockHash := [32]byte{0x41}
 	p.activateCompactOutstandingRequest(compactOutstandingTestRequest(blockHash))
 
-	if gotHash, gotCap, ok := p.popExpiredCompactOutstandingBlockHash(); ok {
+	if gotHash, gotCap, ok := p.popExpiredCompactOutstandingBlockHashAndPayloadCap(); ok {
 		t.Fatalf("pre-expiry pop hash=%x cap=%d ok=%v, want no pop", gotHash, gotCap, ok)
 	}
 	if snap, ok := p.compactOutstandingRequestSnapshot(); !ok || snap.BlockHash != blockHash {
@@ -184,7 +184,7 @@ func TestPopExpiredCompactOutstandingBlockHashClearsOnlyExpired(t *testing.T) {
 	}
 
 	now = now.Add(compactOutstandingRequestTTL)
-	gotHash, gotCap, ok := p.popExpiredCompactOutstandingBlockHash()
+	gotHash, gotCap, ok := p.popExpiredCompactOutstandingBlockHashAndPayloadCap()
 	if !ok || gotHash != blockHash || gotCap != 64 {
 		t.Fatalf("expired pop hash=%x cap=%d ok=%v, want hash %x cap 64", gotHash, gotCap, ok, blockHash)
 	}

--- a/clients/go/node/p2p/compact_runtime_test.go
+++ b/clients/go/node/p2p/compact_runtime_test.go
@@ -169,6 +169,30 @@ func TestFailedCmpctBlockSendDoesNotAuthorizeRacingGetBlockTxn(t *testing.T) {
 	}
 }
 
+func TestPopExpiredCompactOutstandingBlockHashClearsOnlyExpired(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	now := time.Unix(1000, 0)
+	p.service.cfg.Now = func() time.Time { return now }
+	blockHash := [32]byte{0x41}
+	p.activateCompactOutstandingRequest(compactOutstandingTestRequest(blockHash))
+
+	if gotHash, gotCap, ok := p.popExpiredCompactOutstandingBlockHash(); ok {
+		t.Fatalf("pre-expiry pop hash=%x cap=%d ok=%v, want no pop", gotHash, gotCap, ok)
+	}
+	if snap, ok := p.compactOutstandingRequestSnapshot(); !ok || snap.BlockHash != blockHash {
+		t.Fatalf("pre-expiry pop corrupted outstanding=%+v ok=%v", snap, ok)
+	}
+
+	now = now.Add(compactOutstandingRequestTTL)
+	gotHash, gotCap, ok := p.popExpiredCompactOutstandingBlockHash()
+	if !ok || gotHash != blockHash || gotCap != 64 {
+		t.Fatalf("expired pop hash=%x cap=%d ok=%v, want hash %x cap 64", gotHash, gotCap, ok, blockHash)
+	}
+	if _, ok := p.compactOutstandingRequestSnapshot(); ok {
+		t.Fatal("expired pop left outstanding request active")
+	}
+}
+
 func TestCompactAnnouncementSendFinishRollbackAndTrim(t *testing.T) {
 	p := newCompactScriptedPeer(t)
 	firstHash := [32]byte{0x01}


### PR DESCRIPTION
Invariant:
Compact full-block fallback clears only the matching peer-local outstanding compact request, and expired outstanding extraction clears only expired state while returning the expired request hash and payload cap.

Layer:
Implementation + tests. Go P2P only. Non-consensus.

Files changed:
- clients/go/node/p2p/compact_reconstruct.go
- clients/go/node/p2p/compact_runtime.go
- clients/go/node/p2p/compact_reconstruct_test.go
- clients/go/node/p2p/compact_runtime_test.go

Tests:
- Test-only pre-production check failed before the production helper existed, proving the new test exercised the missing expiry helper path.
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node/p2p -run "TestRequestCompactFullBlockFallbackClearsOnlyMatchingOutstanding|TestPopExpiredCompactOutstandingBlockHashAndPayloadCapClearsOnlyExpired|TestCompactOutstanding" -count=1'` — PASS
- `TOOLING_GO_RACE=1 scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -race ./node/p2p -run "TestRequestCompactFullBlockFallbackClearsOnlyMatchingOutstanding|TestPopExpiredCompactOutstandingBlockHashAndPayloadCapClearsOnlyExpired|TestCompactOutstanding" -count=1'` — PASS
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node/p2p -run "Compact|Reconstruct|Fallback" -count=1'` — PASS
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node/p2p -count=1'` — PASS
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./... -count=1'` — PASS
- `git diff --check` — PASS
- `gofmt -l` on changed Go files — PASS
- `rubin-precommit-one-review --base-ref origin/main --include-base-diff` — PASS
- `rubin-push --base-ref origin/main --coverage-cmd rubin-stack-codacy-coverage.sh -- origin HEAD` — PASS before PR update; stack-aware wrapper selected Go-only coverage.
- GitHub PR checks on head `79b5a0a` — PASS.
- GraphQL reviewThreads on head `79b5a0a`: 3 total, 0 unresolved.

Behavior impact:
- `requestCompactFullBlockFallback` now clears only the matching outstanding request before sending full-block `getdata`.
- `popExpiredCompactOutstandingBlockHashAndPayloadCap` returns the expired request hash and payload cap while clearing that expired request.

Compatibility impact:
Go P2P internal behavior only.

Known non-goals:
- No peer runtime timeout dispatch.
- No socket read deadline behavior.
- No late `blocktxn` drain/checksum/hash validation.
- No Rust, conformance, consensus, policy, docs, YAML, JSON, or generated artifact changes.

Risk:
Low and local to peer compact request state cleanup.

Rollback:
Revert this PR.

Not checked:
- Merge was not performed.

<!-- rubin-agent-meta actor=unknown action=pr-edit via=cl branch=codex/RUB-353-compact-fallback-expiry wt=rubin-protocol-codex-RUB-353 utc=2026-05-22T23:16:27Z -->
