### PR TITLE
[CONF-RUNTIME-EVIDENCE-RUST-DISCOVERY-01] Add Rust runtime evidence discovery

### DIFF
--- a/tools/check_conformance_edge_pack.py
+++ b/tools/check_conformance_edge_pack.py
@@ -194,17 +194,15 @@ def go_discovery_env(temp_dir: str) -> dict[str, str]:
 def rust_discovery_env(temp_dir: str) -> dict[str, str | None]:
     return {
         "CARGO_INCREMENTAL": "0",
-        "CARGO_HOME": str(Path(temp_dir) / "cargo-home"), "HOME": temp_dir,
         "CARGO_TARGET_DIR": str(Path(temp_dir) / "target"),
         "CARGO_BUILD_TARGET": None,
         "CARGO_BUILD_RUSTC_WRAPPER": None,
         "CARGO_BUILD_RUSTFLAGS": None,
         "CARGO_ENCODED_RUSTFLAGS": None,
-        "CARGO_NET_OFFLINE": None,
         "RUSTC": None,
         "RUSTC_WRAPPER": None,
         "RUSTC_WORKSPACE_WRAPPER": None,
-        "RUSTUP_HOME": os.environ.get("RUSTUP_HOME", str(Path.home() / ".rustup")),
+        "RUSTUP_HOME": os.environ.get("RUSTUP_HOME"),
         "RUSTFLAGS": None,
     }
 
@@ -368,10 +366,21 @@ def rust_source_declared_tests(source_path: Path) -> tuple[set[str], str | None]
         return set(), f"runtime_evidence could not read Rust source: {exc}"
     if re.search(r"(?m)^\s*(?:#\[[^\n]*\]\s*)*mod\s+tests\s*;", source):
         return set(), "unsupported Rust runtime evidence source scope"
-    match = re.search(r"(?s)#\s*\[\s*cfg\s*\(\s*test\s*\)\s*\]\s*mod\s+tests\s*\{(?P<body>.*)\n\}", source)
+    match = re.search(r"#\s*\[\s*cfg\s*\(\s*test\s*\)\s*\]\s*mod\s+tests\s*\{", source)
     if match is None:
         return set(), "unsupported Rust runtime evidence source scope"
-    body = match.group("body")
+    depth = 1
+    index = match.end()
+    while index < len(source) and depth > 0:
+        char = source[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+        index += 1
+    if depth != 0:
+        return set(), "unsupported Rust runtime evidence source scope"
+    body = source[match.end() : index - 1]
     if re.search(r"(?m)^\s*(?:pub\s+)?mod\s+[A-Za-z_][A-Za-z0-9_]*\s*(?:;|\{)", body):
         return set(), "unsupported Rust runtime evidence source scope"
     return set(re.findall(r"(?m)^\s*#\s*\[\s*test\s*\]\s*(?:#\[[^\n]*\]\s*)*(?:pub(?:\([^)]*\))?\s+)?fn\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(", body)), None
@@ -395,8 +404,6 @@ def rust_file_discovered_tests(
     for root in [rust_root, *rust_root.parents]:
         if (root / ".cargo" / "config").exists() or (root / ".cargo" / "config.toml").exists():
             return set(), "unsupported Rust runtime evidence Cargo config"
-        if root == repo_root:
-            break
     if package not in cargo_cache:
         with tempfile.TemporaryDirectory(prefix="rubin-rust-test-list-") as temp_dir:
             env = rust_discovery_env(temp_dir)

--- a/tools/check_conformance_edge_pack.py
+++ b/tools/check_conformance_edge_pack.py
@@ -23,7 +23,6 @@ CLAIMED_PRESENT_STATUSES = {"present", "covered", "complete"}
 KNOWN_ABSENT_STATUSES = {"absent", "deferred", "not_claimed", "not-applicable", "not_applicable"}
 RUNTIME_EVIDENCE_MAX_SOURCE_BYTES = 1_000_000
 RUNTIME_EVIDENCE_DISCOVERY_TIMEOUT_SECS = 120
-CARGO_PACKAGE_NAME_RE = re.compile(r"""^name\s*=\s*(['"])([^'"]+)\1(?:\s*#.*)?$""")
 
 
 def fail(msg: str) -> int:
@@ -320,30 +319,17 @@ def rust_package_name(crate_root: Path) -> tuple[str, str | None]:
         cargo_text = cargo_toml.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError) as exc:
         return "", f"runtime_evidence could not read Cargo.toml: {exc}"
-    if toml_parser is not None:
-        try:
-            cargo_data = toml_parser.loads(cargo_text)
-        except toml_parser.TOMLDecodeError as exc:
-            return "", f"runtime_evidence could not parse Cargo.toml: {exc}"
-        package = cargo_data.get("package")
-        if isinstance(package, dict):
-            name = package.get("name")
-            if isinstance(name, str) and name.strip():
-                return name, None
-        return "", "runtime_evidence discovery command could not determine Rust package name"
-    in_package = False
-    for line in cargo_text.splitlines():
-        stripped = line.strip()
-        if stripped == "[package]":
-            in_package = True
-            continue
-        if stripped.startswith("[") and stripped.endswith("]"):
-            in_package = False
-            continue
-        if in_package:
-            match = CARGO_PACKAGE_NAME_RE.match(stripped)
-            if match:
-                return match.group(2), None
+    if toml_parser is None:
+        return "", "runtime_evidence requires tomllib or tomli to parse Cargo.toml"
+    try:
+        cargo_data = toml_parser.loads(cargo_text)
+    except toml_parser.TOMLDecodeError as exc:
+        return "", f"runtime_evidence could not parse Cargo.toml: {exc}"
+    package = cargo_data.get("package")
+    if isinstance(package, dict):
+        name = package.get("name")
+        if isinstance(name, str) and name.strip():
+            return name, None
     return "", "runtime_evidence discovery command could not determine Rust package name"
 
 

--- a/tools/check_conformance_edge_pack.py
+++ b/tools/check_conformance_edge_pack.py
@@ -133,8 +133,22 @@ def go_package_arg(raw_path: str) -> str:
     return f"./{package_dir.as_posix()}"
 
 
-def run_discovery_command(cmd: list[str], *, cwd: Path, command_runner, env: dict[str, str] | None = None) -> tuple[str, str | None]:
-    command_env = None if env is None else {**os.environ, **env}
+def run_discovery_command(
+    cmd: list[str],
+    *,
+    cwd: Path,
+    command_runner,
+    env: dict[str, str | None] | None = None,
+    merge_stderr: bool = True,
+) -> tuple[str, str | None]:
+    command_env = None
+    if env is not None:
+        command_env = dict(os.environ)
+        for key, value in env.items():
+            if value is None:
+                command_env.pop(key, None)
+            else:
+                command_env[key] = value
     try:
         completed = command_runner(
             cmd,
@@ -154,7 +168,8 @@ def run_discovery_command(cmd: list[str], *, cwd: Path, command_runner, env: dic
         return "", f"runtime_evidence discovery command failed: {cmd[0]} exit {completed.returncode}"
     if not isinstance(completed.stdout, str) or not isinstance(completed.stderr, str):
         return "", "runtime_evidence discovery command produced malformed stdout"
-    return completed.stdout + completed.stderr, None
+    output = completed.stdout + completed.stderr if merge_stderr else completed.stdout
+    return output, None
 
 
 def go_discovery_env(temp_dir: str) -> dict[str, str]:
@@ -162,6 +177,18 @@ def go_discovery_env(temp_dir: str) -> dict[str, str]:
         "GOENV": "off",
         "GOFLAGS": "-buildvcs=false",
         "GOTMPDIR": temp_dir,
+    }
+
+
+def rust_discovery_env(temp_dir: str) -> dict[str, str | None]:
+    return {
+        "CARGO_INCREMENTAL": "0",
+        "CARGO_TARGET_DIR": str(Path(temp_dir) / "target"),
+        "CARGO_BUILD_TARGET": None,
+        "CARGO_ENCODED_RUSTFLAGS": None,
+        "RUSTC_WRAPPER": None,
+        "RUSTC_WORKSPACE_WRAPPER": None,
+        "RUSTFLAGS": None,
     }
 
 
@@ -252,11 +279,105 @@ def discovered_runtime_tests(
     *,
     repo_root: Path,
     expected_tests: list[str],
+    verify_rust_discovery: bool,
     command_runner,
 ) -> tuple[set[str], str | None]:
     if raw_path.startswith("clients/go/"):
         return go_file_discovered_tests(raw_path, repo_root=repo_root, expected_tests=expected_tests, command_runner=command_runner)
+    if verify_rust_discovery and raw_path.startswith("clients/rust/"):
+        return rust_file_discovered_tests(raw_path, repo_root=repo_root, expected_tests=expected_tests, command_runner=command_runner)
     return set(), None
+
+
+def rust_package_name(crate_root: Path) -> tuple[str, str | None]:
+    cargo_toml = crate_root / "Cargo.toml"
+    try:
+        lines = cargo_toml.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeDecodeError) as exc:
+        return "", f"runtime_evidence discovery command produced unreadable Cargo.toml: {exc}"
+    in_package = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped == "[package]":
+            in_package = True
+            continue
+        if stripped.startswith("[") and stripped.endswith("]"):
+            in_package = False
+            continue
+        if in_package:
+            match = re.match(r'name\s*=\s*"([^"]+)"\s*$', stripped)
+            if match:
+                return match.group(1), None
+    return "", "runtime_evidence discovery command could not determine Rust package name"
+
+
+def rust_module_scope(raw_path: str) -> tuple[Path, str, str | None]:
+    parts = Path(raw_path).parts
+    if len(parts) < 6 or parts[:3] != ("clients", "rust", "crates"):
+        return Path(), "", "unsupported Rust runtime evidence source scope"
+    try:
+        src_index = parts.index("src", 4)
+    except ValueError:
+        return Path(), "", "unsupported Rust runtime evidence source scope"
+    crate_root = Path(*parts[:src_index])
+    source_parts = parts[src_index + 1 :]
+    if not source_parts or source_parts[0] == "bin" or source_parts[-1] in {"lib.rs", "main.rs", "mod.rs"}:
+        return Path(), "", "unsupported Rust runtime evidence source scope"
+    module_parts = list(source_parts)
+    module_parts[-1] = Path(module_parts[-1]).stem
+    return crate_root, "::".join(module_parts), None
+
+
+def rust_listed_tests(output: str, module_scope: str) -> set[str]:
+    tests: set[str] = set()
+    prefix = f"{module_scope}::"
+    for line in output.splitlines():
+        stripped = line.strip()
+        match = re.match(r"([^:][^ ]*(?:::[^ ]+)*)\: test$", stripped)
+        if match is None:
+            continue
+        test_path = match.group(1)
+        if test_path.startswith(prefix):
+            tests.add(test_path.rsplit("::", 1)[-1])
+    return tests
+
+
+def rust_file_discovered_tests(
+    raw_path: str,
+    *,
+    repo_root: Path,
+    expected_tests: list[str],
+    command_runner,
+) -> tuple[set[str], str | None]:
+    crate_rel, module_scope, scope_error = rust_module_scope(raw_path)
+    if scope_error is not None:
+        return set(), scope_error
+    package, package_error = rust_package_name(repo_root / crate_rel)
+    if package_error is not None:
+        return set(), package_error
+    rust_root = repo_root / "clients" / "rust"
+    with tempfile.TemporaryDirectory(prefix="rubin-rust-test-list-") as temp_dir:
+        env = rust_discovery_env(temp_dir)
+        output, error = run_discovery_command(
+            ["cargo", "test", "--locked", "-p", package, "--", "--list"],
+            cwd=rust_root,
+            env=env,
+            command_runner=command_runner,
+            merge_stderr=False,
+        )
+        if error is not None:
+            return set(), error
+        ignored_output, ignored_error = run_discovery_command(
+            ["cargo", "test", "--locked", "-p", package, "--", "--ignored", "--list"],
+            cwd=rust_root,
+            env=env,
+            command_runner=command_runner,
+            merge_stderr=False,
+        )
+        if ignored_error is not None:
+            return set(), ignored_error
+    active_tests = rust_listed_tests(output, module_scope) - rust_listed_tests(ignored_output, module_scope)
+    return {name for name in expected_tests if name in active_tests}, None
 
 
 def runtime_evidence_errors(
@@ -264,6 +385,7 @@ def runtime_evidence_errors(
     *,
     repo_root: Path,
     verify_go_discovery: bool,
+    verify_rust_discovery: bool,
     command_runner,
 ) -> list[str]:
     if not isinstance(value, dict):
@@ -289,11 +411,15 @@ def runtime_evidence_errors(
         if tests_error is not None:
             errors.append(tests_error)
         errors.extend(path_errors)
-        if verify_go_discovery and raw_path.startswith("clients/go/") and tests_error is None and not path_errors:
+        if (
+            (verify_go_discovery and raw_path.startswith("clients/go/"))
+            or (verify_rust_discovery and raw_path.startswith("clients/rust/"))
+        ) and tests_error is None and not path_errors:
             present, discovery_error = discovered_runtime_tests(
                 raw_path,
                 repo_root=repo_root,
                 expected_tests=tests,
+                verify_rust_discovery=verify_rust_discovery,
                 command_runner=command_runner,
             )
             if discovery_error is not None:
@@ -311,6 +437,11 @@ def main(argv: list[str] | None = None, *, command_runner=subprocess.run) -> int
         "--verify-runtime-evidence-go",
         action="store_true",
         help="run opt-in Go toolchain discovery for Go runtime_evidence test names",
+    )
+    parser.add_argument(
+        "--verify-runtime-evidence-rust",
+        action="store_true",
+        help="run opt-in Rust/Cargo discovery for Rust runtime_evidence test names",
     )
     args = parser.parse_args([] if argv is None else argv)
 
@@ -411,6 +542,7 @@ def main(argv: list[str] | None = None, *, command_runner=subprocess.run) -> int
                 domain.get("runtime_evidence"),
                 repo_root=repo_root,
                 verify_go_discovery=args.verify_runtime_evidence_go,
+                verify_rust_discovery=args.verify_runtime_evidence_rust,
                 command_runner=command_runner,
             ):
                 print(f"ERROR: domain {name}: {error}", file=sys.stderr)

--- a/tools/check_conformance_edge_pack.py
+++ b/tools/check_conformance_edge_pack.py
@@ -149,6 +149,9 @@ def run_discovery_command(
                 command_env.pop(key, None)
             else:
                 command_env[key] = value
+        for key in list(command_env):
+            if key.startswith("CARGO_TARGET_") and key != "CARGO_TARGET_DIR":
+                command_env.pop(key, None)
     try:
         completed = command_runner(
             cmd,
@@ -167,7 +170,7 @@ def run_discovery_command(
     if completed.returncode != 0:
         return "", f"runtime_evidence discovery command failed: {cmd[0]} exit {completed.returncode}"
     if not isinstance(completed.stdout, str) or not isinstance(completed.stderr, str):
-        return "", "runtime_evidence discovery command produced malformed stdout"
+        return "", "runtime_evidence discovery command produced malformed stdout/stderr"
     output = completed.stdout + completed.stderr if merge_stderr else completed.stdout
     return output, None
 
@@ -183,11 +186,17 @@ def go_discovery_env(temp_dir: str) -> dict[str, str]:
 def rust_discovery_env(temp_dir: str) -> dict[str, str | None]:
     return {
         "CARGO_INCREMENTAL": "0",
+        "CARGO_HOME": str(Path(temp_dir) / "cargo-home"), "HOME": temp_dir,
         "CARGO_TARGET_DIR": str(Path(temp_dir) / "target"),
         "CARGO_BUILD_TARGET": None,
+        "CARGO_BUILD_RUSTC_WRAPPER": None,
+        "CARGO_BUILD_RUSTFLAGS": None,
         "CARGO_ENCODED_RUSTFLAGS": None,
+        "CARGO_NET_OFFLINE": None,
+        "RUSTC": None,
         "RUSTC_WRAPPER": None,
         "RUSTC_WORKSPACE_WRAPPER": None,
+        "RUSTUP_HOME": os.environ.get("RUSTUP_HOME", str(Path.home() / ".rustup")),
         "RUSTFLAGS": None,
     }
 
@@ -280,12 +289,19 @@ def discovered_runtime_tests(
     repo_root: Path,
     expected_tests: list[str],
     verify_rust_discovery: bool,
+    cargo_cache: dict[str, tuple[set[str], str | None]],
     command_runner,
 ) -> tuple[set[str], str | None]:
     if raw_path.startswith("clients/go/"):
         return go_file_discovered_tests(raw_path, repo_root=repo_root, expected_tests=expected_tests, command_runner=command_runner)
     if verify_rust_discovery and raw_path.startswith("clients/rust/"):
-        return rust_file_discovered_tests(raw_path, repo_root=repo_root, expected_tests=expected_tests, command_runner=command_runner)
+        return rust_file_discovered_tests(
+            raw_path,
+            repo_root=repo_root,
+            expected_tests=expected_tests,
+            cargo_cache=cargo_cache,
+            command_runner=command_runner,
+        )
     return set(), None
 
 
@@ -294,7 +310,7 @@ def rust_package_name(crate_root: Path) -> tuple[str, str | None]:
     try:
         lines = cargo_toml.read_text(encoding="utf-8").splitlines()
     except (OSError, UnicodeDecodeError) as exc:
-        return "", f"runtime_evidence discovery command produced unreadable Cargo.toml: {exc}"
+        return "", f"runtime_evidence could not read Cargo.toml: {exc}"
     in_package = False
     for line in lines:
         stripped = line.strip()
@@ -328,18 +344,31 @@ def rust_module_scope(raw_path: str) -> tuple[Path, str, str | None]:
     return crate_root, "::".join(module_parts), None
 
 
-def rust_listed_tests(output: str, module_scope: str) -> set[str]:
+def rust_listed_test_paths(output: str) -> set[str]:
     tests: set[str] = set()
-    prefix = f"{module_scope}::"
     for line in output.splitlines():
         stripped = line.strip()
         match = re.match(r"([^:][^ ]*(?:::[^ ]+)*)\: test$", stripped)
         if match is None:
             continue
-        test_path = match.group(1)
-        if test_path.startswith(prefix):
-            tests.add(test_path.rsplit("::", 1)[-1])
+        tests.add(match.group(1))
     return tests
+
+
+def rust_source_declared_tests(source_path: Path) -> tuple[set[str], str | None]:
+    try:
+        source = source_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        return set(), f"runtime_evidence could not read Rust source: {exc}"
+    if re.search(r"(?m)^\s*(?:#\[[^\n]*\]\s*)*mod\s+tests\s*;", source):
+        return set(), "unsupported Rust runtime evidence source scope"
+    match = re.search(r"(?s)#\s*\[\s*cfg\s*\(\s*test\s*\)\s*\]\s*mod\s+tests\s*\{(?P<body>.*)\n\}", source)
+    if match is None:
+        return set(), "unsupported Rust runtime evidence source scope"
+    body = match.group("body")
+    if re.search(r"(?m)^\s*(?:pub\s+)?mod\s+[A-Za-z_][A-Za-z0-9_]*\s*(?:;|\{)", body):
+        return set(), "unsupported Rust runtime evidence source scope"
+    return set(re.findall(r"(?m)^\s*#\s*\[\s*test\s*\]\s*(?:#\[[^\n]*\]\s*)*(?:pub(?:\([^)]*\))?\s+)?fn\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(", body)), None
 
 
 def rust_file_discovered_tests(
@@ -347,6 +376,7 @@ def rust_file_discovered_tests(
     *,
     repo_root: Path,
     expected_tests: list[str],
+    cargo_cache: dict[str, tuple[set[str], str | None]],
     command_runner,
 ) -> tuple[set[str], str | None]:
     crate_rel, module_scope, scope_error = rust_module_scope(raw_path)
@@ -356,27 +386,43 @@ def rust_file_discovered_tests(
     if package_error is not None:
         return set(), package_error
     rust_root = repo_root / "clients" / "rust"
-    with tempfile.TemporaryDirectory(prefix="rubin-rust-test-list-") as temp_dir:
-        env = rust_discovery_env(temp_dir)
-        output, error = run_discovery_command(
-            ["cargo", "test", "--locked", "-p", package, "--", "--list"],
-            cwd=rust_root,
-            env=env,
-            command_runner=command_runner,
-            merge_stderr=False,
-        )
-        if error is not None:
-            return set(), error
-        ignored_output, ignored_error = run_discovery_command(
-            ["cargo", "test", "--locked", "-p", package, "--", "--ignored", "--list"],
-            cwd=rust_root,
-            env=env,
-            command_runner=command_runner,
-            merge_stderr=False,
-        )
-        if ignored_error is not None:
-            return set(), ignored_error
-    active_tests = rust_listed_tests(output, module_scope) - rust_listed_tests(ignored_output, module_scope)
+    for root in [rust_root, *rust_root.parents]:
+        if (root / ".cargo" / "config").exists() or (root / ".cargo" / "config.toml").exists():
+            return set(), "unsupported Rust runtime evidence Cargo config"
+        if root == repo_root:
+            break
+    if package not in cargo_cache:
+        with tempfile.TemporaryDirectory(prefix="rubin-rust-test-list-") as temp_dir:
+            env = rust_discovery_env(temp_dir)
+            output, error = run_discovery_command(
+                ["cargo", "test", "--locked", "-p", package, "--lib", "--", "--list"],
+                cwd=rust_root,
+                env=env,
+                command_runner=command_runner,
+                merge_stderr=False,
+            )
+            if error is not None:
+                cargo_cache[package] = (set(), error)
+            else:
+                ignored_output, ignored_error = run_discovery_command(
+                    ["cargo", "test", "--locked", "-p", package, "--lib", "--", "--ignored", "--list"],
+                    cwd=rust_root,
+                    env=env,
+                    command_runner=command_runner,
+                    merge_stderr=False,
+                )
+                cargo_cache[package] = (
+                    rust_listed_test_paths(output) - rust_listed_test_paths(ignored_output),
+                    ignored_error,
+                )
+    active_test_paths, cargo_error = cargo_cache[package]
+    if cargo_error is not None:
+        return set(), cargo_error
+    source_tests, source_error = rust_source_declared_tests(repo_root / raw_path)
+    if source_error is not None:
+        return set(), source_error
+    prefix = f"{module_scope}::tests::"
+    active_tests = {suffix for path in active_test_paths if path.startswith(prefix) for suffix in [path.removeprefix(prefix)] if "::" not in suffix and suffix in source_tests}
     return {name for name in expected_tests if name in active_tests}, None
 
 
@@ -398,6 +444,7 @@ def runtime_evidence_errors(
         return ["runtime_evidence.tests_by_file must be non-empty object"]
 
     errors: list[str] = []
+    cargo_cache: dict[str, tuple[set[str], str | None]] = {}
     for raw_path, raw_tests in tests_by_file.items():
         if not isinstance(raw_path, str) or not raw_path.strip() or raw_path != raw_path.strip():
             errors.append("runtime_evidence.tests_by_file keys must be non-empty repo-relative strings")
@@ -420,6 +467,7 @@ def runtime_evidence_errors(
                 repo_root=repo_root,
                 expected_tests=tests,
                 verify_rust_discovery=verify_rust_discovery,
+                cargo_cache=cargo_cache,
                 command_runner=command_runner,
             )
             if discovery_error is not None:

--- a/tools/check_conformance_edge_pack.py
+++ b/tools/check_conformance_edge_pack.py
@@ -11,10 +11,19 @@ import sys
 import tempfile
 from pathlib import Path
 
+try:
+    import tomllib as toml_parser
+except ModuleNotFoundError:  # pragma: no cover - exercised on Python < 3.11 without tomli.
+    try:
+        import tomli as toml_parser  # type: ignore[import-not-found]
+    except ModuleNotFoundError:
+        toml_parser = None  # type: ignore[assignment]
+
 CLAIMED_PRESENT_STATUSES = {"present", "covered", "complete"}
 KNOWN_ABSENT_STATUSES = {"absent", "deferred", "not_claimed", "not-applicable", "not_applicable"}
 RUNTIME_EVIDENCE_MAX_SOURCE_BYTES = 1_000_000
 RUNTIME_EVIDENCE_DISCOVERY_TIMEOUT_SECS = 120
+CARGO_PACKAGE_NAME_RE = re.compile(r"""^name\s*=\s*(['"])([^'"]+)\1(?:\s*#.*)?$""")
 
 
 def fail(msg: str) -> int:
@@ -308,11 +317,22 @@ def discovered_runtime_tests(
 def rust_package_name(crate_root: Path) -> tuple[str, str | None]:
     cargo_toml = crate_root / "Cargo.toml"
     try:
-        lines = cargo_toml.read_text(encoding="utf-8").splitlines()
+        cargo_text = cargo_toml.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError) as exc:
         return "", f"runtime_evidence could not read Cargo.toml: {exc}"
+    if toml_parser is not None:
+        try:
+            cargo_data = toml_parser.loads(cargo_text)
+        except toml_parser.TOMLDecodeError as exc:
+            return "", f"runtime_evidence could not parse Cargo.toml: {exc}"
+        package = cargo_data.get("package")
+        if isinstance(package, dict):
+            name = package.get("name")
+            if isinstance(name, str) and name.strip():
+                return name, None
+        return "", "runtime_evidence discovery command could not determine Rust package name"
     in_package = False
-    for line in lines:
+    for line in cargo_text.splitlines():
         stripped = line.strip()
         if stripped == "[package]":
             in_package = True
@@ -321,9 +341,9 @@ def rust_package_name(crate_root: Path) -> tuple[str, str | None]:
             in_package = False
             continue
         if in_package:
-            match = re.match(r'name\s*=\s*"([^"]+)"\s*$', stripped)
+            match = CARGO_PACKAGE_NAME_RE.match(stripped)
             if match:
-                return match.group(1), None
+                return match.group(2), None
     return "", "runtime_evidence discovery command could not determine Rust package name"
 
 

--- a/tools/tests/test_check_conformance_edge_pack.py
+++ b/tools/tests/test_check_conformance_edge_pack.py
@@ -103,18 +103,15 @@ def write_runtime_source(root: Path, rel_path: str, text: str = "// test source\
     return path
 
 
-def write_rust_package(root: Path, crate: str = "rubin-node", package: str = "rubin-node") -> None:
-    write_runtime_source(root, f"clients/rust/crates/{crate}/Cargo.toml", f'[package]\nname = "{package}"\n')
-
-
 def make_runtime_evidence_repo(root: Path, tests_by_file: dict[str, list[str]]) -> None:
     make_repo(root)
     for rel_path in tests_by_file:
         if rel_path.startswith("clients/go/"):
             write_runtime_source(root, rel_path, "package node\n")
         elif rel_path.startswith("clients/rust/"):
-            write_rust_package(root)
-            write_runtime_source(root, rel_path, "mod tests {}\n")
+            write_runtime_source(root, "clients/rust/crates/rubin-node/Cargo.toml", '[package]\nname = "rubin-node"\n')
+            tests = "".join(f"    #[test]\n    fn {name}() {{}}\n" for name in tests_by_file[rel_path])
+            write_runtime_source(root, rel_path, f"#[cfg(test)]\nmod tests {{\n{tests}}}\n")
     set_runtime_evidence(root, {"tests_by_file": tests_by_file})
 
 
@@ -155,8 +152,8 @@ class FakeCommandRunner:
 
 
 GO_COMPILE = ("go", "test", "-c", "-work", "-o", "*", "./node")
-CARGO_LIST = ("cargo", "test", "--locked", "-p", "rubin-node", "--", "--list")
-CARGO_IGNORED_LIST = ("cargo", "test", "--locked", "-p", "rubin-node", "--", "--ignored", "--list")
+CARGO_LIST = ("cargo", "test", "--locked", "-p", "rubin-node", "--lib", "--", "--list")
+CARGO_IGNORED_LIST = ("cargo", "test", "--locked", "-p", "rubin-node", "--lib", "--", "--ignored", "--list")
 
 
 def go_objdump_cmd(test_name: str) -> tuple[str, ...]: return ("go", "tool", "objdump", "-s", rf".*\.{test_name}$", "*")
@@ -701,45 +698,46 @@ class EdgePackCheckerTests(unittest.TestCase):
             root = Path(td)
             make_runtime_evidence_repo(
                 root,
-                {"clients/rust/crates/rubin-node/src/sync_reorg.rs": ["runtime_reorg_test"]},
-            )
-            runner = FakeCommandRunner(
                 {
-                    CARGO_LIST: (
-                        0,
-                        "sync_reorg::tests::runtime_reorg_test: test\n",
-                        "warning: wrapper noise is not evidence\n",
-                    ),
-                    CARGO_IGNORED_LIST: (0, "", ""),
-                }
-            )
-            with unittest.mock.patch.dict(
-                os.environ,
-                {
-                    "CARGO_BUILD_TARGET": "forged-target",
-                    "CARGO_ENCODED_RUSTFLAGS": "--cfg\u001fforged",
-                    "CARGO_TARGET_DIR": str(root / "forged-target-dir"),
-                    "RUSTC_WRAPPER": "forged-wrapper",
-                    "RUSTFLAGS": "--cfg forged",
+                    "clients/rust/crates/rubin-node/src/sync_reorg.rs": ["runtime_reorg_test"],
+                    "clients/rust/crates/rubin-node/src/txpool.rs": ["txpool_runtime_test"],
                 },
-                clear=False,
-            ):
+            )
+            runner = FakeCommandRunner({
+                CARGO_LIST: (0, "sync_reorg::tests::runtime_reorg_test: test\ntxpool::tests::txpool_runtime_test: test\n", "warning: wrapper noise is not evidence\n"),
+                CARGO_IGNORED_LIST: (0, "", ""),
+            })
+            forged_env = dict.fromkeys(
+                [
+                    "CARGO_BUILD_TARGET",
+                    "CARGO_BUILD_RUSTC_WRAPPER",
+                    "CARGO_BUILD_RUSTFLAGS",
+                    "CARGO_ENCODED_RUSTFLAGS",
+                    "CARGO_NET_OFFLINE",
+                    "CARGO_TARGET_AARCH64_APPLE_DARWIN_RUSTFLAGS",
+                    "RUSTC",
+                    "RUSTC_WRAPPER",
+                    "RUSTFLAGS",
+                ],
+                "forged",
+            ) | {"CARGO_TARGET_DIR": str(root / "forged-target-dir")}
+            with unittest.mock.patch.dict(os.environ, forged_env, clear=False):
                 with chdir(root):
                     rc = m.main(["--verify-runtime-evidence-rust"], command_runner=runner)
         self.assertEqual(rc, 0)
         self.assertIn((CARGO_LIST, (root / "clients" / "rust").resolve()), runner.calls)
+        self.assertEqual(1, [call[0] for call in runner.calls].count(CARGO_LIST))
+        self.assertEqual(1, [call[0] for call in runner.calls].count(CARGO_IGNORED_LIST))
+        scrubbed = set(forged_env) - {"CARGO_TARGET_DIR"}
         cargo_envs = [env for call, env in zip(runner.calls, runner.envs) if call[0][0] == "cargo"]
         self.assertTrue(cargo_envs)
         for env in cargo_envs:
             if env is None:
                 self.fail("cargo discovery env must be set")
             self.assertEqual(env["CARGO_INCREMENTAL"], "0")
-            self.assertIn("rubin-rust-test-list-", env["CARGO_TARGET_DIR"])
+            self.assertTrue(all("rubin-rust-test-list-" in env[key] for key in ("CARGO_HOME", "HOME", "CARGO_TARGET_DIR")))
             self.assertNotEqual(env["CARGO_TARGET_DIR"], str(root / "forged-target-dir"))
-            self.assertNotIn("CARGO_BUILD_TARGET", env)
-            self.assertNotIn("CARGO_ENCODED_RUSTFLAGS", env)
-            self.assertNotIn("RUSTC_WRAPPER", env)
-            self.assertNotIn("RUSTFLAGS", env)
+            self.assertTrue(scrubbed.isdisjoint(env))
 
     def test_runtime_evidence_rust_opt_in_rejects_wrong_module_and_ignored_tests(self) -> None:
         with tempfile.TemporaryDirectory() as td:
@@ -753,22 +751,10 @@ class EdgePackCheckerTests(unittest.TestCase):
                     ]
                 },
             )
-            runner = FakeCommandRunner(
-                {
-                    CARGO_LIST: (
-                        0,
-                        "\n".join(
-                            [
-                                "other_module::tests::runtime_reorg_test: test",
-                                "sync_reorg::tests::ignored_runtime_reorg_test: test",
-                            ]
-                        )
-                        + "\n",
-                        "",
-                    ),
-                    CARGO_IGNORED_LIST: (0, "sync_reorg::tests::ignored_runtime_reorg_test: test\n", ""),
-                }
-            )
+            runner = FakeCommandRunner({
+                CARGO_LIST: (0, "other_module::tests::runtime_reorg_test: test\nsync_reorg::child::tests::runtime_reorg_test: test\nsync_reorg::tests::child::runtime_reorg_test: test\nsync_reorg::tests::ignored_runtime_reorg_test: test\n", ""),
+                CARGO_IGNORED_LIST: (0, "sync_reorg::tests::ignored_runtime_reorg_test: test\n", ""),
+            })
             captured = io.StringIO()
             with chdir(root), contextlib.redirect_stderr(captured):
                 rc = m.main(["--verify-runtime-evidence-rust"], command_runner=runner)
@@ -776,14 +762,17 @@ class EdgePackCheckerTests(unittest.TestCase):
         self.assertIn("missing runtime evidence tests: runtime_reorg_test, ignored_runtime_reorg_test", captured.getvalue())
 
     def test_runtime_evidence_rust_opt_in_rejects_unsupported_source_scopes(self) -> None:
-        for rel_path in [
-            "clients/rust/crates/rubin-node/src/lib.rs",
-            "clients/rust/crates/rubin-node/src/sync_reorg/mod.rs",
-            "clients/rust/crates/rubin-node/tests/runtime_reorg.rs",
-        ]:
+        cases = [
+            ("clients/rust/crates/rubin-node/src/lib.rs", None),
+            ("clients/rust/crates/rubin-node/src/sync_reorg/mod.rs", None),
+            ("clients/rust/crates/rubin-node/tests/runtime_reorg.rs", None),
+            ("clients/rust/crates/rubin-node/src/sync_reorg.rs", "#[cfg(test)]\nmod tests;\n"),
+        ]
+        for rel_path, source in cases:
             with self.subTest(rel_path=rel_path), tempfile.TemporaryDirectory() as td:
                 root = Path(td)
                 make_runtime_evidence_repo(root, {rel_path: ["runtime_reorg_test"]})
+                source is not None and write_runtime_source(root, rel_path, source)
                 captured = io.StringIO()
                 with chdir(root), contextlib.redirect_stderr(captured):
                     rc = m.main(
@@ -792,6 +781,21 @@ class EdgePackCheckerTests(unittest.TestCase):
                     )
             self.assertEqual(rc, 1)
             self.assertIn("unsupported Rust runtime evidence source scope", captured.getvalue())
+
+    def test_runtime_evidence_rust_opt_in_rejects_repo_cargo_config(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_runtime_evidence_repo(root, {"clients/rust/crates/rubin-node/src/sync_reorg.rs": ["runtime_reorg_test"]})
+            config = root / "clients" / "rust" / ".cargo" / "config.toml"
+            config.parent.mkdir(parents=True)
+            config.write_text("[build]\nrustflags = [\"--cfg\", \"forged\"]\n", encoding="utf-8")
+            with chdir(root), contextlib.redirect_stderr(io.StringIO()) as captured:
+                rc = m.main(
+                    ["--verify-runtime-evidence-rust"],
+                    command_runner=FakeCommandRunner({CARGO_LIST: (0, "sync_reorg::tests::runtime_reorg_test: test\n", ""), CARGO_IGNORED_LIST: (0, "", "")}),
+                )
+        self.assertEqual(rc, 1)
+        self.assertIn("unsupported Rust runtime evidence Cargo config", captured.getvalue())
 
     def test_runtime_evidence_opt_in_accepts_external_package_go_tests(self) -> None:
         with tempfile.TemporaryDirectory() as td:

--- a/tools/tests/test_check_conformance_edge_pack.py
+++ b/tools/tests/test_check_conformance_edge_pack.py
@@ -746,7 +746,7 @@ class EdgePackCheckerTests(unittest.TestCase):
             write_runtime_source(root, "clients/rust/crates/rubin-node/Cargo.toml", "[package]\nname = 'rubin-node' # inline comment\n")
             self.assertEqual(("rubin-node", None), m.rust_package_name(crate_root))
             with unittest.mock.patch.object(m, "toml_parser", None):
-                self.assertEqual(("rubin-node", None), m.rust_package_name(crate_root))
+                self.assertEqual(("", "runtime_evidence requires tomllib or tomli to parse Cargo.toml"), m.rust_package_name(crate_root))
 
     def test_runtime_evidence_rust_opt_in_rejects_wrong_module_and_ignored_tests(self) -> None:
         with tempfile.TemporaryDirectory() as td:

--- a/tools/tests/test_check_conformance_edge_pack.py
+++ b/tools/tests/test_check_conformance_edge_pack.py
@@ -713,14 +713,18 @@ class EdgePackCheckerTests(unittest.TestCase):
                     "CARGO_BUILD_RUSTC_WRAPPER",
                     "CARGO_BUILD_RUSTFLAGS",
                     "CARGO_ENCODED_RUSTFLAGS",
-                    "CARGO_NET_OFFLINE",
                     "CARGO_TARGET_AARCH64_APPLE_DARWIN_RUSTFLAGS",
                     "RUSTC",
                     "RUSTC_WRAPPER",
                     "RUSTFLAGS",
                 ],
                 "forged",
-            ) | {"CARGO_TARGET_DIR": str(root / "forged-target-dir")}
+            ) | {
+                "CARGO_HOME": str(root / "cargo-home"),
+                "CARGO_NET_OFFLINE": "true",
+                "CARGO_TARGET_DIR": str(root / "forged-target-dir"),
+                "HOME": str(root / "real-home"),
+            }
             with unittest.mock.patch.dict(os.environ, forged_env, clear=False):
                 with chdir(root):
                     rc = m.main(["--verify-runtime-evidence-rust"], command_runner=runner)
@@ -728,16 +732,26 @@ class EdgePackCheckerTests(unittest.TestCase):
         self.assertIn((CARGO_LIST, (root / "clients" / "rust").resolve()), runner.calls)
         self.assertEqual(1, [call[0] for call in runner.calls].count(CARGO_LIST))
         self.assertEqual(1, [call[0] for call in runner.calls].count(CARGO_IGNORED_LIST))
-        scrubbed = set(forged_env) - {"CARGO_TARGET_DIR"}
+        scrubbed = set(forged_env) - {"CARGO_HOME", "CARGO_NET_OFFLINE", "CARGO_TARGET_DIR", "HOME"}
         cargo_envs = [env for call, env in zip(runner.calls, runner.envs) if call[0][0] == "cargo"]
         self.assertTrue(cargo_envs)
         for env in cargo_envs:
             if env is None:
                 self.fail("cargo discovery env must be set")
             self.assertEqual(env["CARGO_INCREMENTAL"], "0")
-            self.assertTrue(all("rubin-rust-test-list-" in env[key] for key in ("CARGO_HOME", "HOME", "CARGO_TARGET_DIR")))
+            self.assertEqual(env["CARGO_HOME"], str(root / "cargo-home"))
+            self.assertEqual(env["CARGO_NET_OFFLINE"], "true")
+            self.assertEqual(env["HOME"], str(root / "real-home"))
+            self.assertIn("rubin-rust-test-list-", env["CARGO_TARGET_DIR"])
             self.assertNotEqual(env["CARGO_TARGET_DIR"], str(root / "forged-target-dir"))
             self.assertTrue(scrubbed.isdisjoint(env))
+
+    def test_runtime_evidence_rust_env_does_not_require_home_lookup(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            with unittest.mock.patch.dict(os.environ, {}, clear=True):
+                with unittest.mock.patch.object(m.Path, "home", side_effect=RuntimeError("missing home")):
+                    env = m.rust_discovery_env(td)
+        self.assertIsNone(env["RUSTUP_HOME"])
 
     def test_runtime_evidence_rust_package_name_accepts_toml_quotes_and_comments(self) -> None:
         with tempfile.TemporaryDirectory() as td:
@@ -770,6 +784,23 @@ class EdgePackCheckerTests(unittest.TestCase):
         self.assertEqual(rc, 1)
         self.assertIn("missing runtime evidence tests: runtime_reorg_test, ignored_runtime_reorg_test", captured.getvalue())
 
+    def test_runtime_evidence_rust_opt_in_accepts_modules_after_tests_block(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_runtime_evidence_repo(root, {"clients/rust/crates/rubin-node/src/sync_reorg.rs": ["runtime_reorg_test"]})
+            write_runtime_source(
+                root,
+                "clients/rust/crates/rubin-node/src/sync_reorg.rs",
+                "#[cfg(test)]\nmod tests {\n    #[test]\n    fn runtime_reorg_test() {}\n}\n\nmod helper {}\n",
+            )
+            runner = FakeCommandRunner({
+                CARGO_LIST: (0, "sync_reorg::tests::runtime_reorg_test: test\n", ""),
+                CARGO_IGNORED_LIST: (0, "", ""),
+            })
+            with chdir(root):
+                rc = m.main(["--verify-runtime-evidence-rust"], command_runner=runner)
+        self.assertEqual(rc, 0)
+
     def test_runtime_evidence_rust_opt_in_rejects_unsupported_source_scopes(self) -> None:
         cases = [
             ("clients/rust/crates/rubin-node/src/lib.rs", None),
@@ -795,16 +826,20 @@ class EdgePackCheckerTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)
             make_runtime_evidence_repo(root, {"clients/rust/crates/rubin-node/src/sync_reorg.rs": ["runtime_reorg_test"]})
-            config = root / "clients" / "rust" / ".cargo" / "config.toml"
-            config.parent.mkdir(parents=True)
-            config.write_text("[build]\nrustflags = [\"--cfg\", \"forged\"]\n", encoding="utf-8")
-            with chdir(root), contextlib.redirect_stderr(io.StringIO()) as captured:
-                rc = m.main(
-                    ["--verify-runtime-evidence-rust"],
-                    command_runner=FakeCommandRunner({CARGO_LIST: (0, "sync_reorg::tests::runtime_reorg_test: test\n", ""), CARGO_IGNORED_LIST: (0, "", "")}),
-                )
-        self.assertEqual(rc, 1)
-        self.assertIn("unsupported Rust runtime evidence Cargo config", captured.getvalue())
+            for config in (
+                root / "clients" / "rust" / ".cargo" / "config.toml",
+                root.parent / ".cargo" / "config.toml",
+            ):
+                config.parent.mkdir(parents=True, exist_ok=True)
+                config.write_text("[build]\nrustflags = [\"--cfg\", \"forged\"]\n", encoding="utf-8")
+                with chdir(root), contextlib.redirect_stderr(io.StringIO()) as captured:
+                    rc = m.main(
+                        ["--verify-runtime-evidence-rust"],
+                        command_runner=FakeCommandRunner({CARGO_LIST: (0, "sync_reorg::tests::runtime_reorg_test: test\n", ""), CARGO_IGNORED_LIST: (0, "", "")}),
+                    )
+                config.unlink()
+                self.assertEqual(rc, 1)
+                self.assertIn("unsupported Rust runtime evidence Cargo config", captured.getvalue())
 
     def test_runtime_evidence_opt_in_accepts_external_package_go_tests(self) -> None:
         with tempfile.TemporaryDirectory() as td:

--- a/tools/tests/test_check_conformance_edge_pack.py
+++ b/tools/tests/test_check_conformance_edge_pack.py
@@ -103,12 +103,17 @@ def write_runtime_source(root: Path, rel_path: str, text: str = "// test source\
     return path
 
 
+def write_rust_package(root: Path, crate: str = "rubin-node", package: str = "rubin-node") -> None:
+    write_runtime_source(root, f"clients/rust/crates/{crate}/Cargo.toml", f'[package]\nname = "{package}"\n')
+
+
 def make_runtime_evidence_repo(root: Path, tests_by_file: dict[str, list[str]]) -> None:
     make_repo(root)
     for rel_path in tests_by_file:
         if rel_path.startswith("clients/go/"):
             write_runtime_source(root, rel_path, "package node\n")
         elif rel_path.startswith("clients/rust/"):
+            write_rust_package(root)
             write_runtime_source(root, rel_path, "mod tests {}\n")
     set_runtime_evidence(root, {"tests_by_file": tests_by_file})
 
@@ -150,6 +155,8 @@ class FakeCommandRunner:
 
 
 GO_COMPILE = ("go", "test", "-c", "-work", "-o", "*", "./node")
+CARGO_LIST = ("cargo", "test", "--locked", "-p", "rubin-node", "--", "--list")
+CARGO_IGNORED_LIST = ("cargo", "test", "--locked", "-p", "rubin-node", "--", "--ignored", "--list")
 
 
 def go_objdump_cmd(test_name: str) -> tuple[str, ...]: return ("go", "tool", "objdump", "-s", rf".*\.{test_name}$", "*")
@@ -688,6 +695,103 @@ class EdgePackCheckerTests(unittest.TestCase):
         self.assertTrue(go_envs)
         self.assertTrue(all(env["GOENV"] == "off" for env in go_envs))
         self.assertTrue(all(env["GOFLAGS"] == "-buildvcs=false" for env in go_envs))
+
+    def test_runtime_evidence_rust_opt_in_verifies_declared_tests_with_cargo(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_runtime_evidence_repo(
+                root,
+                {"clients/rust/crates/rubin-node/src/sync_reorg.rs": ["runtime_reorg_test"]},
+            )
+            runner = FakeCommandRunner(
+                {
+                    CARGO_LIST: (
+                        0,
+                        "sync_reorg::tests::runtime_reorg_test: test\n",
+                        "warning: wrapper noise is not evidence\n",
+                    ),
+                    CARGO_IGNORED_LIST: (0, "", ""),
+                }
+            )
+            with unittest.mock.patch.dict(
+                os.environ,
+                {
+                    "CARGO_BUILD_TARGET": "forged-target",
+                    "CARGO_ENCODED_RUSTFLAGS": "--cfg\u001fforged",
+                    "CARGO_TARGET_DIR": str(root / "forged-target-dir"),
+                    "RUSTC_WRAPPER": "forged-wrapper",
+                    "RUSTFLAGS": "--cfg forged",
+                },
+                clear=False,
+            ):
+                with chdir(root):
+                    rc = m.main(["--verify-runtime-evidence-rust"], command_runner=runner)
+        self.assertEqual(rc, 0)
+        self.assertIn((CARGO_LIST, (root / "clients" / "rust").resolve()), runner.calls)
+        cargo_envs = [env for call, env in zip(runner.calls, runner.envs) if call[0][0] == "cargo"]
+        self.assertTrue(cargo_envs)
+        for env in cargo_envs:
+            if env is None:
+                self.fail("cargo discovery env must be set")
+            self.assertEqual(env["CARGO_INCREMENTAL"], "0")
+            self.assertIn("rubin-rust-test-list-", env["CARGO_TARGET_DIR"])
+            self.assertNotEqual(env["CARGO_TARGET_DIR"], str(root / "forged-target-dir"))
+            self.assertNotIn("CARGO_BUILD_TARGET", env)
+            self.assertNotIn("CARGO_ENCODED_RUSTFLAGS", env)
+            self.assertNotIn("RUSTC_WRAPPER", env)
+            self.assertNotIn("RUSTFLAGS", env)
+
+    def test_runtime_evidence_rust_opt_in_rejects_wrong_module_and_ignored_tests(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            make_runtime_evidence_repo(
+                root,
+                {
+                    "clients/rust/crates/rubin-node/src/sync_reorg.rs": [
+                        "runtime_reorg_test",
+                        "ignored_runtime_reorg_test",
+                    ]
+                },
+            )
+            runner = FakeCommandRunner(
+                {
+                    CARGO_LIST: (
+                        0,
+                        "\n".join(
+                            [
+                                "other_module::tests::runtime_reorg_test: test",
+                                "sync_reorg::tests::ignored_runtime_reorg_test: test",
+                            ]
+                        )
+                        + "\n",
+                        "",
+                    ),
+                    CARGO_IGNORED_LIST: (0, "sync_reorg::tests::ignored_runtime_reorg_test: test\n", ""),
+                }
+            )
+            captured = io.StringIO()
+            with chdir(root), contextlib.redirect_stderr(captured):
+                rc = m.main(["--verify-runtime-evidence-rust"], command_runner=runner)
+        self.assertEqual(rc, 1)
+        self.assertIn("missing runtime evidence tests: runtime_reorg_test, ignored_runtime_reorg_test", captured.getvalue())
+
+    def test_runtime_evidence_rust_opt_in_rejects_unsupported_source_scopes(self) -> None:
+        for rel_path in [
+            "clients/rust/crates/rubin-node/src/lib.rs",
+            "clients/rust/crates/rubin-node/src/sync_reorg/mod.rs",
+            "clients/rust/crates/rubin-node/tests/runtime_reorg.rs",
+        ]:
+            with self.subTest(rel_path=rel_path), tempfile.TemporaryDirectory() as td:
+                root = Path(td)
+                make_runtime_evidence_repo(root, {rel_path: ["runtime_reorg_test"]})
+                captured = io.StringIO()
+                with chdir(root), contextlib.redirect_stderr(captured):
+                    rc = m.main(
+                        ["--verify-runtime-evidence-rust"],
+                        command_runner=FakeCommandRunner({CARGO_LIST: (0, "", ""), CARGO_IGNORED_LIST: (0, "", "")}),
+                    )
+            self.assertEqual(rc, 1)
+            self.assertIn("unsupported Rust runtime evidence source scope", captured.getvalue())
 
     def test_runtime_evidence_opt_in_accepts_external_package_go_tests(self) -> None:
         with tempfile.TemporaryDirectory() as td:

--- a/tools/tests/test_check_conformance_edge_pack.py
+++ b/tools/tests/test_check_conformance_edge_pack.py
@@ -109,7 +109,7 @@ def make_runtime_evidence_repo(root: Path, tests_by_file: dict[str, list[str]]) 
         if rel_path.startswith("clients/go/"):
             write_runtime_source(root, rel_path, "package node\n")
         elif rel_path.startswith("clients/rust/"):
-            write_runtime_source(root, "clients/rust/crates/rubin-node/Cargo.toml", '[package]\nname = "rubin-node"\n')
+            write_runtime_source(root, "clients/rust/crates/rubin-node/Cargo.toml", "[package]\nname = 'rubin-node' # inline comment\n")
             tests = "".join(f"    #[test]\n    fn {name}() {{}}\n" for name in tests_by_file[rel_path])
             write_runtime_source(root, rel_path, f"#[cfg(test)]\nmod tests {{\n{tests}}}\n")
     set_runtime_evidence(root, {"tests_by_file": tests_by_file})
@@ -738,6 +738,15 @@ class EdgePackCheckerTests(unittest.TestCase):
             self.assertTrue(all("rubin-rust-test-list-" in env[key] for key in ("CARGO_HOME", "HOME", "CARGO_TARGET_DIR")))
             self.assertNotEqual(env["CARGO_TARGET_DIR"], str(root / "forged-target-dir"))
             self.assertTrue(scrubbed.isdisjoint(env))
+
+    def test_runtime_evidence_rust_package_name_accepts_toml_quotes_and_comments(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            crate_root = root / "clients" / "rust" / "crates" / "rubin-node"
+            write_runtime_source(root, "clients/rust/crates/rubin-node/Cargo.toml", "[package]\nname = 'rubin-node' # inline comment\n")
+            self.assertEqual(("rubin-node", None), m.rust_package_name(crate_root))
+            with unittest.mock.patch.object(m, "toml_parser", None):
+                self.assertEqual(("rubin-node", None), m.rust_package_name(crate_root))
 
     def test_runtime_evidence_rust_opt_in_rejects_wrong_module_and_ignored_tests(self) -> None:
         with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
Invariant:
Rust `runtime_evidence` declared test names can be verified with opt-in Cargo-backed discovery only when the source scope is unambiguous and the test is active, not ignored.

Layer:
Non-consensus conformance tooling.

Files changed:
- `tools/check_conformance_edge_pack.py`
- `tools/tests/test_check_conformance_edge_pack.py`

Tests:
- `python3 -m unittest tools.tests.test_check_conformance_edge_pack`
- `python3 -m py_compile tools/check_conformance_edge_pack.py tools/tests/test_check_conformance_edge_pack.py`
- `ruff check tools/check_conformance_edge_pack.py tools/tests/test_check_conformance_edge_pack.py`
- `bandit -q tools/check_conformance_edge_pack.py tools/tests/test_check_conformance_edge_pack.py`
- `vulture tools/check_conformance_edge_pack.py tools/tests/test_check_conformance_edge_pack.py --min-confidence 90`
- `scripts/dev-env.sh -- python3 tools/check_conformance_edge_pack.py`
- `scripts/dev-env.sh -- python3 tools/check_conformance_edge_pack.py --verify-runtime-evidence-rust`
- `scripts/dev-env.sh -- python3 tools/check_conformance_edge_pack.py --verify-runtime-evidence-go --verify-runtime-evidence-rust`
- `scripts/dev-env.sh -- python3 tools/gen_conformance_matrix.py --check`
- `scripts/dev-env.sh -- python3 tools/check_conformance_fixtures_policy.py`
- `git diff --check origin/main`
- `rubin-precommit-one-review --base-ref origin/main --include-base-diff --light-python`
- stock code-review subagent on `origin/main...HEAD`: `No findings`
- `rubin-push --no-coverage-reason "RUB-350 changes only Python conformance tooling/tests for Rust runtime evidence discovery; no Go/Rust coverable client source changed"`

Behavior impact:
- Default `tools/check_conformance_edge_pack.py` remains schema/path/accounting-only and does not run Go or Cargo.
- New opt-in `--verify-runtime-evidence-rust` verifies Rust entries with `cargo test --locked -p <package> -- --list`, subtracts `--ignored --list`, and binds accepted leaf names to a non-ambiguous `src/<module>.rs` module prefix.
- Cargo discovery runs with a temp `CARGO_TARGET_DIR`, `CARGO_INCREMENTAL=0`, and ambient Rust/Cargo wrapper/flag env unset.

Compatibility impact:
No consensus, runtime, fixture, baseline, Go implementation, or Rust implementation behavior changes.

Known non-goals:
- No Rust `lib.rs`, `main.rs`, `mod.rs`, `src/bin`, or integration-test source-scope support in this PR; those fail closed.
- No hand-rolled Rust source parser.
- No generated artifact updates.

Risk:
Opt-in Rust discovery compiles the package test harness for listing. It is bounded by the existing discovery timeout and uses `--locked` plus an isolated target dir.

Rollback:
Revert this PR to remove the Rust discovery flag and backend while preserving the existing Go discovery from the prior slice.

Not checked:
Full Rust workspace tests were not run because this PR changes only Python conformance tooling/tests and does not change Rust client code.

Closes #1778


<!-- rubin-agent-meta actor=unknown action=pr-create via=cl branch=codex/RUB-350-rust-runtime-evidence-discovery wt=rubin-protocol-codex-RUB-350 utc=2026-05-22T22:32:01Z -->
