### PR TITLE
[RUB-355] Drain late blocktxn after fallback

### DIFF
--- a/clients/go/node/p2p/compact_runtime.go
+++ b/clients/go/node/p2p/compact_runtime.go
@@ -287,11 +287,18 @@ func (p *peer) blockTxnPayloadCap() uint32 {
 }
 
 func (p *peer) handleExpiredCompactOutstanding(ctx context.Context) (bool, error) {
-	expired, err := p.sendExpiredCompactOutstandingFallback(ctx)
-	if err != nil {
-		return false, err
+	if peerRunContextDone(ctx) {
+		return false, nil
 	}
-	return expired != nil, nil
+	blockHash, _, ok := p.popExpiredCompactOutstandingBlockHashAndPayloadCap()
+	if !ok {
+		return false, nil
+	}
+	if peerRunContextDone(ctx) {
+		return false, nil
+	}
+	body := append([]byte{MSG_BLOCK}, blockHash[:]...)
+	return true, p.send(messageGetData, body)
 }
 
 func (p *peer) compactOutstandingExpiry() (time.Time, bool) {

--- a/clients/go/node/p2p/compact_runtime.go
+++ b/clients/go/node/p2p/compact_runtime.go
@@ -287,18 +287,11 @@ func (p *peer) blockTxnPayloadCap() uint32 {
 }
 
 func (p *peer) handleExpiredCompactOutstanding(ctx context.Context) (bool, error) {
-	if peerRunContextDone(ctx) {
-		return false, nil
+	expired, err := p.sendExpiredCompactOutstandingFallback(ctx)
+	if err != nil {
+		return false, err
 	}
-	blockHash, _, ok := p.popExpiredCompactOutstandingBlockHashAndPayloadCap()
-	if !ok {
-		return false, nil
-	}
-	if peerRunContextDone(ctx) {
-		return false, nil
-	}
-	body := append([]byte{MSG_BLOCK}, blockHash[:]...)
-	return true, p.send(messageGetData, body)
+	return expired != nil, nil
 }
 
 func (p *peer) compactOutstandingExpiry() (time.Time, bool) {

--- a/clients/go/node/p2p/peer_runtime.go
+++ b/clients/go/node/p2p/peer_runtime.go
@@ -93,9 +93,14 @@ func (p *peer) readPostHandshakeFrame(ctx context.Context, frameStart time.Time,
 	if err != nil {
 		return frame, lateBlockTxn, err
 	}
-	if header.Command == messageBlockTxn && (lateBlockTxn != nil || p.acceptsBlockTxnResponses()) {
-		frame, err := p.readBlockTxnFrame(header, lateBlockTxn)
-		return frame, nil, err
+	if header.Command == messageBlockTxn {
+		if lateBlockTxn != nil {
+			return p.readLateBlockTxnFrame(header, lateBlockTxn)
+		}
+		if p.acceptsBlockTxnResponses() {
+			frame, err := p.readBlockTxnFrame(header)
+			return frame, nil, err
+		}
 	}
 	if err := p.setReadDeadlineAt(frameStart, true); err != nil {
 		return frame, lateBlockTxn, err
@@ -105,6 +110,9 @@ func (p *peer) readPostHandshakeFrame(ctx context.Context, frameStart time.Time,
 		return frame, lateBlockTxn, commandPayloadCapError{command: header.Command}
 	}
 	payload, err := readPayloadWithChecksum(reader, header.Size, header.Checksum)
+	if reader.lateBlockTxn != nil {
+		lateBlockTxn = reader.lateBlockTxn
+	}
 	if err != nil {
 		return frame, lateBlockTxn, err
 	}
@@ -167,10 +175,7 @@ func (p *peer) sendExpiredCompactOutstandingFallback(ctx context.Context) (*comp
 	return &compactOutstandingRequest{BlockHash: blockHash, BlockTxnPayloadCap: payloadCap}, nil
 }
 
-func (p *peer) readBlockTxnFrame(header frameHeader, lateBlockTxn *compactOutstandingRequest) (message, error) {
-	if lateBlockTxn != nil {
-		return p.readLateBlockTxnFrame(header, *lateBlockTxn)
-	}
+func (p *peer) readBlockTxnFrame(header frameHeader) (message, error) {
 	cap := p.blockTxnPayloadCap()
 	if cap == 0 {
 		return p.readUnexpectedBlockTxnFrame(header)
@@ -187,48 +192,42 @@ func (p *peer) readBlockTxnFrame(header frameHeader, lateBlockTxn *compactOutsta
 	return p.readFullCommandFramePayload(header)
 }
 
-func (p *peer) readLateBlockTxnFrame(header frameHeader, lateBlockTxn compactOutstandingRequest) (message, error) {
-	cap := lateBlockTxn.BlockTxnPayloadCap
-	if maxCap := compactRelayPayloadCap(messageBlockTxn); cap > maxCap {
-		cap = maxCap
-	}
-	if header.Size > cap {
+func (p *peer) readLateBlockTxnFrame(header frameHeader, lateBlockTxn *compactOutstandingRequest) (message, *compactOutstandingRequest, error) {
+	if header.Size > lateBlockTxn.BlockTxnPayloadCap || header.Size > compactRelayPayloadCap(messageBlockTxn) {
 		prefix, err := readPayloadPrefix(p.conn, header.Size, blockTxnHashPayloadBytes)
 		if err != nil {
-			return message{}, err
+			return message{}, nil, err
 		}
 		if p.blockTxnPrefixMatchesOutstanding(prefix) {
 			if activeCap := p.blockTxnPayloadCap(); activeCap == 0 || header.Size > activeCap {
-				return message{}, commandPayloadCapError{command: header.Command}
+				return message{}, lateBlockTxn, commandPayloadCapError{command: header.Command}
 			}
 			payload, err := readPayloadWithChecksum(io.MultiReader(bytes.NewReader(prefix), p.conn), header.Size, header.Checksum)
 			if err != nil {
-				return message{}, err
+				return message{}, lateBlockTxn, err
 			}
-			return message{Command: header.Command, Payload: payload}, nil
+			return message{Command: header.Command, Payload: payload}, lateBlockTxn, nil
 		}
-		return message{}, commandPayloadCapError{command: header.Command}
+		return message{}, nil, commandPayloadCapError{command: header.Command}
 	}
 	payload, err := readPayloadWithChecksum(p.conn, header.Size, header.Checksum)
 	if err != nil {
-		return message{}, err
+		return message{}, nil, err
 	}
 	if len(payload) < blockTxnHashPayloadBytes {
-		return message{}, errors.New("blocktxn payload missing block hash")
+		return message{}, nil, errors.New("blocktxn payload missing block hash")
 	}
-	var responseHash [32]byte
-	copy(responseHash[:], payload[:blockTxnHashPayloadBytes])
-	if responseHash == lateBlockTxn.BlockHash {
-		return message{}, errLateBlockTxnIgnored
+	if bytes.Equal(payload[:blockTxnHashPayloadBytes], lateBlockTxn.BlockHash[:]) {
+		return message{}, nil, errLateBlockTxnIgnored
 	}
 	if p.blockTxnPrefixMatchesOutstanding(payload) {
-		return message{Command: header.Command, Payload: payload}, nil
+		return message{Command: header.Command, Payload: payload}, lateBlockTxn, nil
 	}
 	if len(payload) > blockTxnHashPayloadBytes {
-		return message{}, blockTxnStaleBodyError{}
+		return message{}, nil, blockTxnStaleBodyError{}
 	}
 	p.setLastError("ignored stale blocktxn response")
-	return message{}, errLateBlockTxnIgnored
+	return message{}, nil, errLateBlockTxnIgnored
 }
 
 func (p *peer) readOversizedBlockTxnStaleHash(header frameHeader) (bool, error) {

--- a/clients/go/node/p2p/peer_runtime.go
+++ b/clients/go/node/p2p/peer_runtime.go
@@ -30,6 +30,8 @@ func (e blockTxnStaleBodyError) Error() string {
 	return "stale blocktxn response has body"
 }
 
+var errLateBlockTxnIgnored = errors.New("ignored late blocktxn response")
+
 func (p *peer) run(ctx context.Context) error {
 	var lateBlockTxn *compactOutstandingRequest
 	recordExpiredFallback := func() error {
@@ -57,7 +59,7 @@ func (p *peer) run(ctx context.Context) error {
 		frame, nextLateBlockTxn, err := p.readPostHandshakeFrame(ctx, frameStart, lateBlockTxn)
 		lateBlockTxn = nextLateBlockTxn
 		if err != nil {
-			if err.Error() == "ignored late blocktxn response" || shouldIgnoreReadError(err) {
+			if errors.Is(err, errLateBlockTxnIgnored) || shouldIgnoreReadError(err) {
 				continue
 			}
 			return normalizeReadError(err)
@@ -83,11 +85,9 @@ const blockTxnHashPayloadBytes = 32
 
 func (p *peer) readPostHandshakeFrame(ctx context.Context, frameStart time.Time, lateBlockTxn *compactOutstandingRequest) (message, *compactOutstandingRequest, error) {
 	var frame message
-	reader := &compactFallbackReader{peer: p, ctx: ctx, frameStart: frameStart}
+	reader := &compactFallbackReader{peer: p, ctx: ctx, frameStart: frameStart, lateBlockTxn: lateBlockTxn}
 	header, err := readFrameHeader(reader, networkMagic(p.service.cfg.PeerRuntimeConfig.Network), p.service.cfg.PeerRuntimeConfig.MaxMessageSize)
-	if reader.lateBlockTxn != nil {
-		lateBlockTxn = reader.lateBlockTxn
-	}
+	lateBlockTxn = reader.lateBlockTxn
 	if err != nil {
 		return frame, lateBlockTxn, err
 	}
@@ -108,9 +108,7 @@ func (p *peer) readPostHandshakeFrame(ctx context.Context, frameStart time.Time,
 		return frame, lateBlockTxn, commandPayloadCapError{command: header.Command}
 	}
 	payload, err := readPayloadWithChecksum(reader, header.Size, header.Checksum)
-	if reader.lateBlockTxn != nil {
-		lateBlockTxn = reader.lateBlockTxn
-	}
+	lateBlockTxn = reader.lateBlockTxn
 	if err != nil {
 		return frame, lateBlockTxn, err
 	}
@@ -188,14 +186,7 @@ func (p *peer) readLateBlockTxnFrame(header frameHeader, lateBlockTxn *compactOu
 	}
 	payloadReader := io.MultiReader(bytes.NewReader(prefix), p.conn)
 	if p.blockTxnPrefixMatchesOutstanding(prefix) {
-		if activeCap := p.blockTxnPayloadCap(); activeCap == 0 || header.Size > activeCap {
-			return message{}, lateBlockTxn, commandPayloadCapError{command: header.Command}
-		}
-		payload, err := readPayloadWithChecksum(payloadReader, header.Size, header.Checksum)
-		if err != nil {
-			return message{}, lateBlockTxn, err
-		}
-		return message{Command: header.Command, Payload: payload}, lateBlockTxn, nil
+		return p.readActiveBlockTxnFrame(header, payloadReader, lateBlockTxn)
 	}
 	if header.Size > lateBlockTxn.BlockTxnPayloadCap || header.Size > compactRelayPayloadCap(messageBlockTxn) {
 		if p.blockTxnPayloadCap() == 0 && bytes.Equal(prefix, lateBlockTxn.BlockHash[:]) {
@@ -207,21 +198,36 @@ func (p *peer) readLateBlockTxnFrame(header frameHeader, lateBlockTxn *compactOu
 	if err != nil {
 		return message{}, nil, err
 	}
+	return p.classifyLateBlockTxnPayload(payload, lateBlockTxn, header.Command)
+}
+
+func (p *peer) readActiveBlockTxnFrame(header frameHeader, payloadReader io.Reader, lateBlockTxn *compactOutstandingRequest) (message, *compactOutstandingRequest, error) {
+	if activeCap := p.blockTxnPayloadCap(); activeCap == 0 || header.Size > activeCap {
+		return message{}, lateBlockTxn, commandPayloadCapError{command: header.Command}
+	}
+	payload, err := readPayloadWithChecksum(payloadReader, header.Size, header.Checksum)
+	if err != nil {
+		return message{}, lateBlockTxn, err
+	}
+	return message{Command: header.Command, Payload: payload}, lateBlockTxn, nil
+}
+
+func (p *peer) classifyLateBlockTxnPayload(payload []byte, lateBlockTxn *compactOutstandingRequest, command string) (message, *compactOutstandingRequest, error) {
 	if len(payload) < blockTxnHashPayloadBytes {
 		if p.blockTxnPayloadCap() != 0 {
-			return message{Command: header.Command, Payload: payload}, lateBlockTxn, nil
+			return message{Command: command, Payload: payload}, lateBlockTxn, nil
 		}
 		return message{}, nil, errors.New("blocktxn payload missing block hash")
 	}
 	if bytes.Equal(payload[:blockTxnHashPayloadBytes], lateBlockTxn.BlockHash[:]) {
-		p.setLastError("ignored late blocktxn response")
-		return message{}, nil, errors.New("ignored late blocktxn response")
+		p.setLastError(errLateBlockTxnIgnored.Error())
+		return message{}, nil, errLateBlockTxnIgnored
 	}
 	if len(payload) > blockTxnHashPayloadBytes {
 		return message{}, nil, blockTxnStaleBodyError{}
 	}
 	p.setLastError("ignored stale blocktxn response")
-	return message{}, nil, errors.New("ignored late blocktxn response")
+	return message{}, nil, errLateBlockTxnIgnored
 }
 
 func (p *peer) readOversizedBlockTxnStaleHash(header frameHeader) (bool, error) {

--- a/clients/go/node/p2p/peer_runtime.go
+++ b/clients/go/node/p2p/peer_runtime.go
@@ -193,24 +193,25 @@ func (p *peer) readBlockTxnFrame(header frameHeader) (message, error) {
 }
 
 func (p *peer) readLateBlockTxnFrame(header frameHeader, lateBlockTxn *compactOutstandingRequest) (message, *compactOutstandingRequest, error) {
-	if header.Size > lateBlockTxn.BlockTxnPayloadCap || header.Size > compactRelayPayloadCap(messageBlockTxn) {
-		prefix, err := readPayloadPrefix(p.conn, header.Size, blockTxnHashPayloadBytes)
+	prefix, err := readPayloadPrefix(p.conn, header.Size, blockTxnHashPayloadBytes)
+	if err != nil {
+		return message{}, nil, err
+	}
+	payloadReader := io.MultiReader(bytes.NewReader(prefix), p.conn)
+	if p.blockTxnPrefixMatchesOutstanding(prefix) {
+		if activeCap := p.blockTxnPayloadCap(); activeCap == 0 || header.Size > activeCap {
+			return message{}, lateBlockTxn, commandPayloadCapError{command: header.Command}
+		}
+		payload, err := readPayloadWithChecksum(payloadReader, header.Size, header.Checksum)
 		if err != nil {
-			return message{}, nil, err
+			return message{}, lateBlockTxn, err
 		}
-		if p.blockTxnPrefixMatchesOutstanding(prefix) {
-			if activeCap := p.blockTxnPayloadCap(); activeCap == 0 || header.Size > activeCap {
-				return message{}, lateBlockTxn, commandPayloadCapError{command: header.Command}
-			}
-			payload, err := readPayloadWithChecksum(io.MultiReader(bytes.NewReader(prefix), p.conn), header.Size, header.Checksum)
-			if err != nil {
-				return message{}, lateBlockTxn, err
-			}
-			return message{Command: header.Command, Payload: payload}, lateBlockTxn, nil
-		}
+		return message{Command: header.Command, Payload: payload}, lateBlockTxn, nil
+	}
+	if header.Size > lateBlockTxn.BlockTxnPayloadCap || header.Size > compactRelayPayloadCap(messageBlockTxn) {
 		return message{}, nil, commandPayloadCapError{command: header.Command}
 	}
-	payload, err := readPayloadWithChecksum(p.conn, header.Size, header.Checksum)
+	payload, err := readPayloadWithChecksum(payloadReader, header.Size, header.Checksum)
 	if err != nil {
 		return message{}, nil, err
 	}

--- a/clients/go/node/p2p/peer_runtime.go
+++ b/clients/go/node/p2p/peer_runtime.go
@@ -30,8 +30,6 @@ func (e blockTxnStaleBodyError) Error() string {
 	return "stale blocktxn response has body"
 }
 
-var errLateBlockTxnIgnored = errors.New("ignored late blocktxn response")
-
 func (p *peer) run(ctx context.Context) error {
 	var lateBlockTxn *compactOutstandingRequest
 	recordExpiredFallback := func() error {
@@ -59,7 +57,7 @@ func (p *peer) run(ctx context.Context) error {
 		frame, nextLateBlockTxn, err := p.readPostHandshakeFrame(ctx, frameStart, lateBlockTxn)
 		lateBlockTxn = nextLateBlockTxn
 		if err != nil {
-			if errors.Is(err, errLateBlockTxnIgnored) || shouldIgnoreReadError(err) {
+			if err.Error() == "ignored late blocktxn response" || shouldIgnoreReadError(err) {
 				continue
 			}
 			return normalizeReadError(err)
@@ -216,14 +214,14 @@ func (p *peer) readLateBlockTxnFrame(header frameHeader, lateBlockTxn *compactOu
 		return message{}, nil, errors.New("blocktxn payload missing block hash")
 	}
 	if bytes.Equal(payload[:blockTxnHashPayloadBytes], lateBlockTxn.BlockHash[:]) {
-		p.setLastError(errLateBlockTxnIgnored.Error())
-		return message{}, nil, errLateBlockTxnIgnored
+		p.setLastError("ignored late blocktxn response")
+		return message{}, nil, errors.New("ignored late blocktxn response")
 	}
 	if len(payload) > blockTxnHashPayloadBytes {
 		return message{}, nil, blockTxnStaleBodyError{}
 	}
 	p.setLastError("ignored stale blocktxn response")
-	return message{}, nil, errLateBlockTxnIgnored
+	return message{}, nil, errors.New("ignored late blocktxn response")
 }
 
 func (p *peer) readOversizedBlockTxnStaleHash(header frameHeader) (bool, error) {

--- a/clients/go/node/p2p/peer_runtime.go
+++ b/clients/go/node/p2p/peer_runtime.go
@@ -32,19 +32,14 @@ func (e blockTxnStaleBodyError) Error() string {
 
 var errLateBlockTxnIgnored = errors.New("ignored late blocktxn response")
 
-type expiredCompactBlockTxnContext struct {
-	blockHash  [32]byte
-	payloadCap uint32
-}
-
 func (p *peer) run(ctx context.Context) error {
-	var lateBlockTxn *expiredCompactBlockTxnContext
+	var lateBlockTxn *compactOutstandingRequest
 	recordExpiredFallback := func() error {
-		expired, sent, err := p.sendExpiredCompactOutstandingFallback(ctx)
+		expired, err := p.sendExpiredCompactOutstandingFallback(ctx)
 		if err != nil {
 			return err
 		}
-		if sent {
+		if expired != nil {
 			lateBlockTxn = expired
 		}
 		return nil
@@ -57,15 +52,12 @@ func (p *peer) run(ctx context.Context) error {
 			return err
 		}
 		frameStart := time.Now()
-		if err := p.setReadDeadlineAt(frameStart, lateBlockTxn == nil); err != nil {
+		_, activeCompact := p.compactOutstandingExpiry()
+		if err := p.setReadDeadlineAt(frameStart, lateBlockTxn == nil || activeCompact); err != nil {
 			return err
 		}
-		frame, expired, consumedLateBlockTxn, err := p.readPostHandshakeFrame(ctx, frameStart, lateBlockTxn)
-		if expired != nil {
-			lateBlockTxn = expired
-		} else if consumedLateBlockTxn {
-			lateBlockTxn = nil
-		}
+		frame, nextLateBlockTxn, err := p.readPostHandshakeFrame(ctx, frameStart, lateBlockTxn)
+		lateBlockTxn = nextLateBlockTxn
 		if err != nil {
 			if errors.Is(err, errLateBlockTxnIgnored) || shouldIgnoreReadError(err) {
 				continue
@@ -91,36 +83,32 @@ func (p *peer) run(ctx context.Context) error {
 
 const blockTxnHashPayloadBytes = 32
 
-func (p *peer) readPostHandshakeFrame(ctx context.Context, frameStart time.Time, lateBlockTxn *expiredCompactBlockTxnContext) (message, *expiredCompactBlockTxnContext, bool, error) {
+func (p *peer) readPostHandshakeFrame(ctx context.Context, frameStart time.Time, lateBlockTxn *compactOutstandingRequest) (message, *compactOutstandingRequest, error) {
 	var frame message
 	reader := &compactFallbackReader{peer: p, ctx: ctx, frameStart: frameStart}
 	header, err := p.readPostHandshakeFrameHeader(reader)
-	if err != nil {
-		return frame, reader.lateBlockTxn, false, err
-	}
 	if reader.lateBlockTxn != nil {
 		lateBlockTxn = reader.lateBlockTxn
 	}
+	if err != nil {
+		return frame, lateBlockTxn, err
+	}
 	if header.Command == messageBlockTxn && (lateBlockTxn != nil || p.acceptsBlockTxnResponses()) {
 		frame, err := p.readBlockTxnFrame(header, lateBlockTxn)
-		return frame, nil, lateBlockTxn != nil, err
+		return frame, nil, err
 	}
 	if err := p.setReadDeadlineAt(frameStart, true); err != nil {
-		return frame, reader.lateBlockTxn, false, err
+		return frame, lateBlockTxn, err
 	}
 	limit := p.postHandshakePayloadCap()
 	if header.Size > limit(header.Command) {
-		return frame, reader.lateBlockTxn, false, commandPayloadCapError{command: header.Command}
+		return frame, lateBlockTxn, commandPayloadCapError{command: header.Command}
 	}
-	payloadReader := io.Reader(p.conn)
-	if _, ok := p.compactOutstandingExpiry(); ok {
-		payloadReader = reader
-	}
-	payload, err := readPayloadWithChecksum(payloadReader, header.Size, header.Checksum)
+	payload, err := readPayloadWithChecksum(reader, header.Size, header.Checksum)
 	if err != nil {
-		return frame, reader.lateBlockTxn, false, err
+		return frame, lateBlockTxn, err
 	}
-	return message{Command: header.Command, Payload: payload}, reader.lateBlockTxn, false, nil
+	return message{Command: header.Command, Payload: payload}, lateBlockTxn, nil
 }
 
 func (p *peer) readPostHandshakeFrameHeader(reader *compactFallbackReader) (frameHeader, error) {
@@ -137,7 +125,7 @@ type compactFallbackReader struct {
 	ctx          context.Context
 	frameStart   time.Time
 	sent         bool
-	lateBlockTxn *expiredCompactBlockTxnContext
+	lateBlockTxn *compactOutstandingRequest
 }
 
 func (r *compactFallbackReader) Read(p []byte) (int, error) {
@@ -149,11 +137,11 @@ func (r *compactFallbackReader) Read(p []byte) (int, error) {
 		if !isReadTimeout(err) || r.sent {
 			return n, err
 		}
-		lateBlockTxn, sent, sendErr := r.peer.sendExpiredCompactOutstandingFallback(r.ctx)
+		lateBlockTxn, sendErr := r.peer.sendExpiredCompactOutstandingFallback(r.ctx)
 		if sendErr != nil {
 			return 0, sendErr
 		}
-		if !sent {
+		if lateBlockTxn == nil {
 			return n, err
 		}
 		r.sent = true
@@ -164,25 +152,22 @@ func (r *compactFallbackReader) Read(p []byte) (int, error) {
 	}
 }
 
-func (p *peer) sendExpiredCompactOutstandingFallback(ctx context.Context) (*expiredCompactBlockTxnContext, bool, error) {
+func (p *peer) sendExpiredCompactOutstandingFallback(ctx context.Context) (*compactOutstandingRequest, error) {
 	if peerRunContextDone(ctx) {
-		return nil, false, nil
+		return nil, nil
 	}
 	blockHash, payloadCap, ok := p.popExpiredCompactOutstandingBlockHashAndPayloadCap()
-	if !ok {
-		return nil, false, nil
-	}
-	if peerRunContextDone(ctx) {
-		return nil, false, nil
+	if !ok || peerRunContextDone(ctx) {
+		return nil, nil
 	}
 	body := append([]byte{MSG_BLOCK}, blockHash[:]...)
 	if err := p.send(messageGetData, body); err != nil {
-		return nil, true, err
+		return nil, err
 	}
-	return &expiredCompactBlockTxnContext{blockHash: blockHash, payloadCap: payloadCap}, true, nil
+	return &compactOutstandingRequest{BlockHash: blockHash, BlockTxnPayloadCap: payloadCap}, nil
 }
 
-func (p *peer) readBlockTxnFrame(header frameHeader, lateBlockTxn *expiredCompactBlockTxnContext) (message, error) {
+func (p *peer) readBlockTxnFrame(header frameHeader, lateBlockTxn *compactOutstandingRequest) (message, error) {
 	if lateBlockTxn != nil {
 		return p.readLateBlockTxnFrame(header, *lateBlockTxn)
 	}
@@ -202,12 +187,26 @@ func (p *peer) readBlockTxnFrame(header frameHeader, lateBlockTxn *expiredCompac
 	return p.readFullCommandFramePayload(header)
 }
 
-func (p *peer) readLateBlockTxnFrame(header frameHeader, lateBlockTxn expiredCompactBlockTxnContext) (message, error) {
-	cap := lateBlockTxn.payloadCap
+func (p *peer) readLateBlockTxnFrame(header frameHeader, lateBlockTxn compactOutstandingRequest) (message, error) {
+	cap := lateBlockTxn.BlockTxnPayloadCap
 	if maxCap := compactRelayPayloadCap(messageBlockTxn); cap > maxCap {
 		cap = maxCap
 	}
 	if header.Size > cap {
+		prefix, err := readPayloadPrefix(p.conn, header.Size, blockTxnHashPayloadBytes)
+		if err != nil {
+			return message{}, err
+		}
+		if p.blockTxnPrefixMatchesOutstanding(prefix) {
+			if activeCap := p.blockTxnPayloadCap(); activeCap == 0 || header.Size > activeCap {
+				return message{}, commandPayloadCapError{command: header.Command}
+			}
+			payload, err := readPayloadWithChecksum(io.MultiReader(bytes.NewReader(prefix), p.conn), header.Size, header.Checksum)
+			if err != nil {
+				return message{}, err
+			}
+			return message{Command: header.Command, Payload: payload}, nil
+		}
 		return message{}, commandPayloadCapError{command: header.Command}
 	}
 	payload, err := readPayloadWithChecksum(p.conn, header.Size, header.Checksum)
@@ -219,7 +218,7 @@ func (p *peer) readLateBlockTxnFrame(header frameHeader, lateBlockTxn expiredCom
 	}
 	var responseHash [32]byte
 	copy(responseHash[:], payload[:blockTxnHashPayloadBytes])
-	if responseHash == lateBlockTxn.blockHash {
+	if responseHash == lateBlockTxn.BlockHash {
 		return message{}, errLateBlockTxnIgnored
 	}
 	if p.blockTxnPrefixMatchesOutstanding(payload) {

--- a/clients/go/node/p2p/peer_runtime.go
+++ b/clients/go/node/p2p/peer_runtime.go
@@ -30,28 +30,51 @@ func (e blockTxnStaleBodyError) Error() string {
 	return "stale blocktxn response has body"
 }
 
+var errLateBlockTxnIgnored = errors.New("ignored late blocktxn response")
+
+type expiredCompactBlockTxnContext struct {
+	blockHash  [32]byte
+	payloadCap uint32
+}
+
 func (p *peer) run(ctx context.Context) error {
+	var lateBlockTxn *expiredCompactBlockTxnContext
+	recordExpiredFallback := func() error {
+		expired, sent, err := p.sendExpiredCompactOutstandingFallback(ctx)
+		if err != nil {
+			return err
+		}
+		if sent {
+			lateBlockTxn = expired
+		}
+		return nil
+	}
 	for {
 		if peerRunContextDone(ctx) {
 			return nil
 		}
-		if _, err := p.handleExpiredCompactOutstanding(ctx); err != nil {
+		if err := recordExpiredFallback(); err != nil {
 			return err
 		}
 		frameStart := time.Now()
-		if err := p.setReadDeadlineAt(frameStart, true); err != nil {
+		if err := p.setReadDeadlineAt(frameStart, lateBlockTxn == nil); err != nil {
 			return err
 		}
-		frame, err := p.readPostHandshakeFrame(ctx, frameStart)
+		frame, expired, consumedLateBlockTxn, err := p.readPostHandshakeFrame(ctx, frameStart, lateBlockTxn)
+		if expired != nil {
+			lateBlockTxn = expired
+		} else if consumedLateBlockTxn {
+			lateBlockTxn = nil
+		}
 		if err != nil {
-			if shouldIgnoreReadError(err) {
+			if errors.Is(err, errLateBlockTxnIgnored) || shouldIgnoreReadError(err) {
 				continue
 			}
 			return normalizeReadError(err)
 		}
 		fallbackBeforeMessage := frame.Command == messagePing || frame.Command == messagePong || frame.Command == messageHeaders || frame.Command == messageCmpctBlock
 		if fallbackBeforeMessage {
-			if _, err := p.handleExpiredCompactOutstanding(ctx); err != nil {
+			if err := recordExpiredFallback(); err != nil {
 				return err
 			}
 		}
@@ -59,7 +82,7 @@ func (p *peer) run(ctx context.Context) error {
 			return err
 		}
 		if !fallbackBeforeMessage {
-			if _, err := p.handleExpiredCompactOutstanding(ctx); err != nil {
+			if err := recordExpiredFallback(); err != nil {
 				return err
 			}
 		}
@@ -68,43 +91,53 @@ func (p *peer) run(ctx context.Context) error {
 
 const blockTxnHashPayloadBytes = 32
 
-func (p *peer) readPostHandshakeFrame(ctx context.Context, frameStart time.Time) (message, error) {
+func (p *peer) readPostHandshakeFrame(ctx context.Context, frameStart time.Time, lateBlockTxn *expiredCompactBlockTxnContext) (message, *expiredCompactBlockTxnContext, bool, error) {
 	var frame message
-	header, err := p.readPostHandshakeFrameHeader(ctx, frameStart)
+	reader := &compactFallbackReader{peer: p, ctx: ctx, frameStart: frameStart}
+	header, err := p.readPostHandshakeFrameHeader(reader)
 	if err != nil {
-		return frame, err
+		return frame, reader.lateBlockTxn, false, err
 	}
-	if header.Command == messageBlockTxn && p.acceptsBlockTxnResponses() {
-		return p.readBlockTxnFrame(header)
+	if reader.lateBlockTxn != nil {
+		lateBlockTxn = reader.lateBlockTxn
+	}
+	if header.Command == messageBlockTxn && (lateBlockTxn != nil || p.acceptsBlockTxnResponses()) {
+		frame, err := p.readBlockTxnFrame(header, lateBlockTxn)
+		return frame, nil, lateBlockTxn != nil, err
 	}
 	if err := p.setReadDeadlineAt(frameStart, true); err != nil {
-		return frame, err
+		return frame, reader.lateBlockTxn, false, err
 	}
 	limit := p.postHandshakePayloadCap()
 	if header.Size > limit(header.Command) {
-		return frame, commandPayloadCapError{command: header.Command}
+		return frame, reader.lateBlockTxn, false, commandPayloadCapError{command: header.Command}
 	}
-	payload, err := readPayloadWithChecksum(&compactFallbackReader{peer: p, ctx: ctx, frameStart: frameStart}, header.Size, header.Checksum)
+	payloadReader := io.Reader(p.conn)
+	if _, ok := p.compactOutstandingExpiry(); ok {
+		payloadReader = reader
+	}
+	payload, err := readPayloadWithChecksum(payloadReader, header.Size, header.Checksum)
 	if err != nil {
-		return frame, err
+		return frame, reader.lateBlockTxn, false, err
 	}
-	return message{Command: header.Command, Payload: payload}, nil
+	return message{Command: header.Command, Payload: payload}, reader.lateBlockTxn, false, nil
 }
 
-func (p *peer) readPostHandshakeFrameHeader(ctx context.Context, frameStart time.Time) (frameHeader, error) {
+func (p *peer) readPostHandshakeFrameHeader(reader *compactFallbackReader) (frameHeader, error) {
 	magic := networkMagic(p.service.cfg.PeerRuntimeConfig.Network)
 	maxSize := p.service.cfg.PeerRuntimeConfig.MaxMessageSize
 	if _, ok := p.compactOutstandingExpiry(); !ok {
 		return readFrameHeader(p.conn, magic, maxSize)
 	}
-	return readFrameHeader(&compactFallbackReader{peer: p, ctx: ctx, frameStart: frameStart}, magic, maxSize)
+	return readFrameHeader(reader, magic, maxSize)
 }
 
 type compactFallbackReader struct {
-	peer       *peer
-	ctx        context.Context
-	frameStart time.Time
-	sent       bool
+	peer         *peer
+	ctx          context.Context
+	frameStart   time.Time
+	sent         bool
+	lateBlockTxn *expiredCompactBlockTxnContext
 }
 
 func (r *compactFallbackReader) Read(p []byte) (int, error) {
@@ -116,7 +149,7 @@ func (r *compactFallbackReader) Read(p []byte) (int, error) {
 		if !isReadTimeout(err) || r.sent {
 			return n, err
 		}
-		sent, sendErr := r.peer.handleExpiredCompactOutstanding(r.ctx)
+		lateBlockTxn, sent, sendErr := r.peer.sendExpiredCompactOutstandingFallback(r.ctx)
 		if sendErr != nil {
 			return 0, sendErr
 		}
@@ -124,13 +157,35 @@ func (r *compactFallbackReader) Read(p []byte) (int, error) {
 			return n, err
 		}
 		r.sent = true
+		r.lateBlockTxn = lateBlockTxn
 		if err := r.peer.setReadDeadlineAt(r.frameStart, false); err != nil {
 			return 0, err
 		}
 	}
 }
 
-func (p *peer) readBlockTxnFrame(header frameHeader) (message, error) {
+func (p *peer) sendExpiredCompactOutstandingFallback(ctx context.Context) (*expiredCompactBlockTxnContext, bool, error) {
+	if peerRunContextDone(ctx) {
+		return nil, false, nil
+	}
+	blockHash, payloadCap, ok := p.popExpiredCompactOutstandingBlockHashAndPayloadCap()
+	if !ok {
+		return nil, false, nil
+	}
+	if peerRunContextDone(ctx) {
+		return nil, false, nil
+	}
+	body := append([]byte{MSG_BLOCK}, blockHash[:]...)
+	if err := p.send(messageGetData, body); err != nil {
+		return nil, true, err
+	}
+	return &expiredCompactBlockTxnContext{blockHash: blockHash, payloadCap: payloadCap}, true, nil
+}
+
+func (p *peer) readBlockTxnFrame(header frameHeader, lateBlockTxn *expiredCompactBlockTxnContext) (message, error) {
+	if lateBlockTxn != nil {
+		return p.readLateBlockTxnFrame(header, *lateBlockTxn)
+	}
 	cap := p.blockTxnPayloadCap()
 	if cap == 0 {
 		return p.readUnexpectedBlockTxnFrame(header)
@@ -145,6 +200,36 @@ func (p *peer) readBlockTxnFrame(header frameHeader) (message, error) {
 		return p.readMatchedBlockTxnFrame(header)
 	}
 	return p.readFullCommandFramePayload(header)
+}
+
+func (p *peer) readLateBlockTxnFrame(header frameHeader, lateBlockTxn expiredCompactBlockTxnContext) (message, error) {
+	cap := lateBlockTxn.payloadCap
+	if maxCap := compactRelayPayloadCap(messageBlockTxn); cap > maxCap {
+		cap = maxCap
+	}
+	if header.Size > cap {
+		return message{}, commandPayloadCapError{command: header.Command}
+	}
+	payload, err := readPayloadWithChecksum(p.conn, header.Size, header.Checksum)
+	if err != nil {
+		return message{}, err
+	}
+	if len(payload) < blockTxnHashPayloadBytes {
+		return message{}, errors.New("blocktxn payload missing block hash")
+	}
+	var responseHash [32]byte
+	copy(responseHash[:], payload[:blockTxnHashPayloadBytes])
+	if responseHash == lateBlockTxn.blockHash {
+		return message{}, errLateBlockTxnIgnored
+	}
+	if p.blockTxnPrefixMatchesOutstanding(payload) {
+		return message{Command: header.Command, Payload: payload}, nil
+	}
+	if len(payload) > blockTxnHashPayloadBytes {
+		return message{}, blockTxnStaleBodyError{}
+	}
+	p.setLastError("ignored stale blocktxn response")
+	return message{}, errLateBlockTxnIgnored
 }
 
 func (p *peer) readOversizedBlockTxnStaleHash(header frameHeader) (bool, error) {

--- a/clients/go/node/p2p/peer_runtime.go
+++ b/clients/go/node/p2p/peer_runtime.go
@@ -216,6 +216,7 @@ func (p *peer) readLateBlockTxnFrame(header frameHeader, lateBlockTxn *compactOu
 		return message{}, nil, errors.New("blocktxn payload missing block hash")
 	}
 	if bytes.Equal(payload[:blockTxnHashPayloadBytes], lateBlockTxn.BlockHash[:]) {
+		p.setLastError(errLateBlockTxnIgnored.Error())
 		return message{}, nil, errLateBlockTxnIgnored
 	}
 	if len(payload) > blockTxnHashPayloadBytes {

--- a/clients/go/node/p2p/peer_runtime.go
+++ b/clients/go/node/p2p/peer_runtime.go
@@ -209,7 +209,10 @@ func (p *peer) readLateBlockTxnFrame(header frameHeader, lateBlockTxn *compactOu
 		return message{Command: header.Command, Payload: payload}, lateBlockTxn, nil
 	}
 	if header.Size > lateBlockTxn.BlockTxnPayloadCap || header.Size > compactRelayPayloadCap(messageBlockTxn) {
-		return message{}, nil, commandPayloadCapError{command: header.Command}
+		if p.blockTxnPayloadCap() == 0 && bytes.Equal(prefix, lateBlockTxn.BlockHash[:]) {
+			return message{}, nil, commandPayloadCapError{command: header.Command}
+		}
+		return message{}, nil, blockTxnStaleBodyError{}
 	}
 	payload, err := readPayloadWithChecksum(payloadReader, header.Size, header.Checksum)
 	if err != nil {
@@ -220,9 +223,6 @@ func (p *peer) readLateBlockTxnFrame(header frameHeader, lateBlockTxn *compactOu
 	}
 	if bytes.Equal(payload[:blockTxnHashPayloadBytes], lateBlockTxn.BlockHash[:]) {
 		return message{}, nil, errLateBlockTxnIgnored
-	}
-	if p.blockTxnPrefixMatchesOutstanding(payload) {
-		return message{Command: header.Command, Payload: payload}, lateBlockTxn, nil
 	}
 	if len(payload) > blockTxnHashPayloadBytes {
 		return message{}, nil, blockTxnStaleBodyError{}

--- a/clients/go/node/p2p/peer_runtime.go
+++ b/clients/go/node/p2p/peer_runtime.go
@@ -86,7 +86,7 @@ const blockTxnHashPayloadBytes = 32
 func (p *peer) readPostHandshakeFrame(ctx context.Context, frameStart time.Time, lateBlockTxn *compactOutstandingRequest) (message, *compactOutstandingRequest, error) {
 	var frame message
 	reader := &compactFallbackReader{peer: p, ctx: ctx, frameStart: frameStart}
-	header, err := p.readPostHandshakeFrameHeader(reader)
+	header, err := readFrameHeader(reader, networkMagic(p.service.cfg.PeerRuntimeConfig.Network), p.service.cfg.PeerRuntimeConfig.MaxMessageSize)
 	if reader.lateBlockTxn != nil {
 		lateBlockTxn = reader.lateBlockTxn
 	}
@@ -117,15 +117,6 @@ func (p *peer) readPostHandshakeFrame(ctx context.Context, frameStart time.Time,
 		return frame, lateBlockTxn, err
 	}
 	return message{Command: header.Command, Payload: payload}, lateBlockTxn, nil
-}
-
-func (p *peer) readPostHandshakeFrameHeader(reader *compactFallbackReader) (frameHeader, error) {
-	magic := networkMagic(p.service.cfg.PeerRuntimeConfig.Network)
-	maxSize := p.service.cfg.PeerRuntimeConfig.MaxMessageSize
-	if _, ok := p.compactOutstandingExpiry(); !ok {
-		return readFrameHeader(p.conn, magic, maxSize)
-	}
-	return readFrameHeader(reader, magic, maxSize)
 }
 
 type compactFallbackReader struct {
@@ -219,6 +210,9 @@ func (p *peer) readLateBlockTxnFrame(header frameHeader, lateBlockTxn *compactOu
 		return message{}, nil, err
 	}
 	if len(payload) < blockTxnHashPayloadBytes {
+		if p.blockTxnPayloadCap() != 0 {
+			return message{Command: header.Command, Payload: payload}, lateBlockTxn, nil
+		}
 		return message{}, nil, errors.New("blocktxn payload missing block hash")
 	}
 	if bytes.Equal(payload[:blockTxnHashPayloadBytes], lateBlockTxn.BlockHash[:]) {

--- a/clients/go/node/p2p/peer_runtime_test.go
+++ b/clients/go/node/p2p/peer_runtime_test.go
@@ -886,6 +886,18 @@ func TestRunDrainsLateBlockTxnBodyAfterExpiryFallback(t *testing.T) {
 		t.Fatalf("run err=%v, want next frame after drained late blocktxn", err)
 	}
 	requireFirstGetDataBlock(t, p, conn.Bytes(), blockHash)
+
+	p, ck := setupCompactFallbackPeer(t)
+	frameBytes := mustPeerRuntimeFrameBytes(t, p, message{Command: messageHeaders, Payload: []byte{0x01}})
+	lateFrame := mustPeerRuntimeFrameBytes(t, p, message{Command: messageBlockTxn, Payload: payload})
+	wakeConn := &expiryWakeConn{scriptedConn: scriptedConn{reads: []scriptedRead{
+		{data: frameBytes[:wireHeaderSize]}, {err: timeoutErr{}}, {data: frameBytes[wireHeaderSize:]}, {data: lateFrame}, {data: mustPeerRuntimeFrameBytes(t, p, message{Command: messageVersion})},
+	}}}
+	wakeConn.expireOnRead(ck, 2)
+	p.conn = wakeConn
+	if err := p.run(context.Background()); err == nil || !strings.Contains(err.Error(), "invalid version message after handshake") {
+		t.Fatalf("payload-expiry run err=%v, want next frame after drained late blocktxn", err)
+	}
 }
 
 func TestRunCapsLateBlockTxnBodyAfterExpiryFallbackByOutstandingRequest(t *testing.T) {
@@ -971,24 +983,28 @@ func TestReadLateBlockTxnKeepsNewActiveOutstandingResponse(t *testing.T) {
 	p := newPeerRuntimeTestPeer(t)
 	oldHash := [32]byte{0x15}
 	activeHash := [32]byte{0x35}
-	p.setCompactOutstandingRequest(compactOutstandingTestRequest(activeHash))
-	payload := append(activeHash[:], 0x01)
-	rawHeader, err := buildEnvelopeHeader(networkMagic(p.service.cfg.PeerRuntimeConfig.Network), messageBlockTxn, payload)
-	if err != nil {
-		t.Fatalf("buildEnvelopeHeader: %v", err)
-	}
-	header, err := readFrameHeader(bytes.NewReader(rawHeader[:]), networkMagic(p.service.cfg.PeerRuntimeConfig.Network), p.service.cfg.PeerRuntimeConfig.MaxMessageSize)
-	if err != nil {
-		t.Fatalf("readFrameHeader: %v", err)
-	}
-	p.conn = &scriptedConn{reads: []scriptedRead{{data: payload}}}
+	p.setCompactOutstandingRequest(compactOutstandingRequest{BlockHash: activeHash, BlockTxnPayloadCap: 128})
+	activePayload := append(activeHash[:], bytes.Repeat([]byte{0x01}, 33)...)
+	oldPayload := append(oldHash[:], 0x01)
+	p.conn = &scriptedConn{reads: []scriptedRead{
+		{data: mustPeerRuntimeFrameBytes(t, p, message{Command: messageBlockTxn, Payload: activePayload})},
+		{data: mustPeerRuntimeFrameBytes(t, p, message{Command: messageBlockTxn, Payload: oldPayload})},
+	}}
+	lateCtx := &compactOutstandingRequest{BlockHash: oldHash, BlockTxnPayloadCap: 64}
 
-	frame, err := p.readLateBlockTxnFrame(header, compactOutstandingRequest{BlockHash: oldHash, BlockTxnPayloadCap: blockTxnHashPayloadBytes})
+	frame, lateCtx, err := p.readPostHandshakeFrame(context.Background(), time.Now(), lateCtx)
 	if err != nil {
 		t.Fatalf("read late blocktxn with active response: %v", err)
 	}
-	if frame.Command != messageBlockTxn || !bytes.Equal(frame.Payload, payload) {
+	if lateCtx == nil {
+		t.Fatal("active response cleared stale late blocktxn context")
+	}
+	if frame.Command != messageBlockTxn || !bytes.Equal(frame.Payload, activePayload) {
 		t.Fatalf("frame=%+v, want active blocktxn payload", frame)
+	}
+	_, lateCtx, err = p.readPostHandshakeFrame(context.Background(), time.Now(), lateCtx)
+	if !errors.Is(err, errLateBlockTxnIgnored) || lateCtx != nil {
+		t.Fatalf("stale late read err=%v lateCtx=%+v, want ignored late blocktxn and cleared context", err, lateCtx)
 	}
 }
 
@@ -1011,35 +1027,25 @@ func TestRunIgnoresHashOnlyStaleLateBlockTxnAfterExpiryFallback(t *testing.T) {
 func TestRunRejectsBadChecksumLateBlockTxnAfterExpiryFallback(t *testing.T) {
 	blockHash := [32]byte{0x17}
 	staleHash := [32]byte{0x27}
-	req := compactOutstandingTestRequest(blockHash)
-	payload := append(staleHash[:], 0x01)
-	p, conn, err := runExpiredLateBadChecksumBlockTxnFrame(t, req, payload)
-
-	if err == nil || err.Error() != "invalid envelope checksum" {
-		t.Fatalf("run err=%v, want checksum failure before stale semantics", err)
-	}
-	requireFirstGetDataBlock(t, p, conn.Bytes(), blockHash)
+	requireBadChecksumLateBlockTxn(t, blockHash, append(staleHash[:], 0x01))
 }
 
 func TestRunRejectsBadChecksumShortLateBlockTxnAfterExpiryFallback(t *testing.T) {
 	blockHash := [32]byte{0x18}
-	req := compactOutstandingTestRequest(blockHash)
-	p, conn, err := runExpiredLateBadChecksumBlockTxnFrame(t, req, blockHash[:blockTxnHashPayloadBytes-1])
-
-	if err == nil || err.Error() != "invalid envelope checksum" {
-		t.Fatalf("run err=%v, want checksum failure before short payload classification", err)
-	}
-	requireFirstGetDataBlock(t, p, conn.Bytes(), blockHash)
+	requireBadChecksumLateBlockTxn(t, blockHash, blockHash[:blockTxnHashPayloadBytes-1])
 }
 
 func TestRunRejectsBadChecksumHashOnlyStaleLateBlockTxnAfterExpiryFallback(t *testing.T) {
 	blockHash := [32]byte{0x19}
 	staleHash := [32]byte{0x29}
-	req := compactOutstandingTestRequest(blockHash)
-	p, conn, err := runExpiredLateBadChecksumBlockTxnFrame(t, req, staleHash[:])
+	requireBadChecksumLateBlockTxn(t, blockHash, staleHash[:])
+}
 
+func requireBadChecksumLateBlockTxn(t *testing.T, blockHash [32]byte, payload []byte) {
+	t.Helper()
+	p, conn, err := runExpiredLateBadChecksumBlockTxnFrame(t, compactOutstandingTestRequest(blockHash), payload)
 	if err == nil || err.Error() != "invalid envelope checksum" {
-		t.Fatalf("run err=%v, want checksum failure before hash-only stale classification", err)
+		t.Fatalf("payload len=%d err=%v, want checksum failure before semantic classification", len(payload), err)
 	}
 	requireFirstGetDataBlock(t, p, conn.Bytes(), blockHash)
 }

--- a/clients/go/node/p2p/peer_runtime_test.go
+++ b/clients/go/node/p2p/peer_runtime_test.go
@@ -925,6 +925,26 @@ func TestRunResetsReadDeadlineBeforeLateBlockTxnDrainAfterExpiryFallback(t *test
 	}
 }
 
+func TestRunKeepsActiveCompactDeadlineWithStaleLateBlockTxnContext(t *testing.T) {
+	p, ck := setupCompactFallbackPeer(t)
+	ck.advance(compactOutstandingRequestTTL + time.Second)
+	p.service.cfg.PeerRuntimeConfig.ReadDeadline = time.Hour
+	conn := &scriptedConn{
+		reads: []scriptedRead{{data: mustPeerRuntimeFrameBytes(t, p, message{Command: messageVersion})}},
+		writeHook: func(int) {
+			p.activateCompactOutstandingRequest(compactOutstandingTestRequest([32]byte{0x23}))
+		},
+	}
+	p.conn = conn
+
+	if err := p.run(context.Background()); err == nil {
+		t.Fatal("run succeeded, want post-handshake version stop")
+	}
+	if len(conn.readDeadlines) == 0 || conn.readDeadlines[0].After(time.Now().Add(time.Minute)) {
+		t.Fatalf("read deadlines=%v, want active compact expiry before normal read deadline", conn.readDeadlines)
+	}
+}
+
 func TestRunRejectsShortLateBlockTxnAfterExpiryFallback(t *testing.T) {
 	blockHash := [32]byte{0x14}
 	req := compactOutstandingTestRequest(blockHash)
@@ -963,7 +983,7 @@ func TestReadLateBlockTxnKeepsNewActiveOutstandingResponse(t *testing.T) {
 	}
 	p.conn = &scriptedConn{reads: []scriptedRead{{data: payload}}}
 
-	frame, err := p.readLateBlockTxnFrame(header, expiredCompactBlockTxnContext{blockHash: oldHash, payloadCap: 64})
+	frame, err := p.readLateBlockTxnFrame(header, compactOutstandingRequest{BlockHash: oldHash, BlockTxnPayloadCap: blockTxnHashPayloadBytes})
 	if err != nil {
 		t.Fatalf("read late blocktxn with active response: %v", err)
 	}

--- a/clients/go/node/p2p/peer_runtime_test.go
+++ b/clients/go/node/p2p/peer_runtime_test.go
@@ -859,6 +859,9 @@ func TestRunDrainsLateBlockTxnBodyAfterExpiryFallback(t *testing.T) {
 		t.Fatalf("run err=%v, want next frame after drained late blocktxn", err)
 	}
 	requireFirstGetDataBlock(t, p, conn.Bytes(), blockHash)
+	if state := p.snapshotState(); state.BanScore != 0 || !strings.Contains(state.LastError, "ignored late blocktxn response") {
+		t.Fatalf("state=%+v, want ignored late blocktxn diagnostic without ban", state)
+	}
 	p, ck := setupCompactFallbackPeer(t)
 	frameBytes := mustPeerRuntimeFrameBytes(t, p, message{Command: messageHeaders, Payload: []byte{0x01}})
 	lateFrame := mustPeerRuntimeFrameBytes(t, p, message{Command: messageBlockTxn, Payload: payload})

--- a/clients/go/node/p2p/peer_runtime_test.go
+++ b/clients/go/node/p2p/peer_runtime_test.go
@@ -89,7 +89,6 @@ func runExpiredLateBlockTxnFrame(t *testing.T, req compactOutstandingRequest, pa
 	p, ck := setupCompactFallbackPeer(t)
 	p.activateCompactOutstandingRequest(req)
 	ck.advance(compactOutstandingRequestTTL + time.Second)
-
 	reads := []scriptedRead{{data: mustPeerRuntimeFrameBytes(t, p, message{Command: messageBlockTxn, Payload: payload})}}
 	for _, frame := range tail {
 		reads = append(reads, scriptedRead{data: mustPeerRuntimeFrameBytes(t, p, frame)})
@@ -854,18 +853,12 @@ func TestRunDrainsLateBlockTxnBodyAfterExpiryFallback(t *testing.T) {
 	blockHash := [32]byte{0x11}
 	req := compactOutstandingTestRequest(blockHash)
 	payload := append(blockHash[:], 0x01)
-	p, conn, err := runExpiredLateBlockTxnFrame(
-		t,
-		req,
-		payload,
-		message{Command: messageVersion},
-	)
+	p, conn, err := runExpiredLateBlockTxnFrame(t, req, payload, message{Command: messageVersion})
 
 	if err == nil || !strings.Contains(err.Error(), "invalid version message after handshake") {
 		t.Fatalf("run err=%v, want next frame after drained late blocktxn", err)
 	}
 	requireFirstGetDataBlock(t, p, conn.Bytes(), blockHash)
-
 	p, ck := setupCompactFallbackPeer(t)
 	frameBytes := mustPeerRuntimeFrameBytes(t, p, message{Command: messageHeaders, Payload: []byte{0x01}})
 	lateFrame := mustPeerRuntimeFrameBytes(t, p, message{Command: messageBlockTxn, Payload: payload})
@@ -883,8 +876,7 @@ func TestRunCapsLateBlockTxnBodyAfterExpiryFallbackByOutstandingRequest(t *testi
 	blockHash := [32]byte{0x12}
 	req := compactOutstandingTestRequest(blockHash)
 	req.BlockTxnPayloadCap = blockTxnHashPayloadBytes
-	payload := append(blockHash[:], 0x01)
-	p, conn, err := runExpiredLateBlockTxnFrame(t, req, payload)
+	p, conn, err := runExpiredLateBlockTxnFrame(t, req, append(blockHash[:], 0x01))
 
 	if err == nil || err.Error() != "message exceeds command cap" {
 		t.Fatalf("run err=%v, want expired outstanding cap error", err)
@@ -895,9 +887,8 @@ func TestRunCapsLateBlockTxnBodyAfterExpiryFallbackByOutstandingRequest(t *testi
 func TestRunResetsReadDeadlineBeforeLateBlockTxnDrainAfterExpiryFallback(t *testing.T) {
 	blockHash := [32]byte{0x13}
 	req := compactOutstandingTestRequest(blockHash)
-	payload := append(blockHash[:], 0x01)
 	beforeRun := time.Now()
-	p, conn, err := runExpiredLateBlockTxnFrame(t, req, payload, message{Command: messageVersion})
+	p, conn, err := runExpiredLateBlockTxnFrame(t, req, append(blockHash[:], 0x01), message{Command: messageVersion})
 
 	if err == nil || !strings.Contains(err.Error(), "invalid version message after handshake") {
 		t.Fatalf("run err=%v, want next frame after late blocktxn drain", err)
@@ -941,8 +932,7 @@ func TestRunRejectsWrongHashLateBlockTxnBodyAfterExpiryFallback(t *testing.T) {
 	blockHash := [32]byte{0x15}
 	staleHash := [32]byte{0x25}
 	req := compactOutstandingTestRequest(blockHash)
-	payload := append(staleHash[:], 0x01)
-	p, conn, err := runExpiredLateBlockTxnFrame(t, req, payload)
+	p, conn, err := runExpiredLateBlockTxnFrame(t, req, append(staleHash[:], 0x01))
 
 	requireBlockTxnStaleBodyError(t, err)
 	requireFirstGetDataBlock(t, p, conn.Bytes(), blockHash)
@@ -975,7 +965,6 @@ func TestReadLateBlockTxnKeepsNewActiveOutstandingResponse(t *testing.T) {
 	if !errors.Is(err, errLateBlockTxnIgnored) || lateCtx != nil {
 		t.Fatalf("stale late read err=%v lateCtx=%+v, want ignored late blocktxn and cleared context", err, lateCtx)
 	}
-
 	p = newPeerRuntimeTestPeer(t)
 	p.setCompactOutstandingRequest(compactOutstandingRequest{BlockHash: activeHash, BlockTxnPayloadCap: 64})
 	p.conn = &scriptedConn{reads: []scriptedRead{{data: mustPeerRuntimeFrameBytes(t, p, message{Command: messageBlockTxn, Payload: activePayload})}}}
@@ -1000,6 +989,18 @@ func TestReadLateBlockTxnKeepsNewActiveOutstandingResponse(t *testing.T) {
 	if state := p.snapshotState(); state.BanScore != 0 || p.blockTxnPayloadCap() == 0 {
 		t.Fatalf("state=%+v activeCap=%d, want stale late cap not active ban/clear", state, p.blockTxnPayloadCap())
 	}
+
+	p = newPeerRuntimeTestPeer(t)
+	p.service.cfg.EnableCompactReceive = true
+	p.setCompactOutstandingRequest(compactOutstandingTestRequest(activeHash))
+	p.conn = &scriptedConn{reads: []scriptedRead{{data: mustPeerRuntimeFrameBytes(t, p, message{Command: messageBlockTxn, Payload: activeHash[:blockTxnHashPayloadBytes-1]})}}}
+	frame, lateCtx, err = p.readPostHandshakeFrame(context.Background(), time.Now(), &compactOutstandingRequest{BlockHash: oldHash, BlockTxnPayloadCap: 64})
+	if err != nil || lateCtx == nil {
+		t.Fatalf("short active err=%v lateCtx=%+v, want active validation frame", err, lateCtx)
+	}
+	if err := p.handleMessage(frame); err == nil || p.snapshotState().BanScore == 0 {
+		t.Fatalf("short active handle err=%v state=%+v, want active blocktxn reject/ban", err, p.snapshotState())
+	}
 }
 
 func TestRunIgnoresHashOnlyStaleLateBlockTxnAfterExpiryFallback(t *testing.T) {
@@ -1012,8 +1013,7 @@ func TestRunIgnoresHashOnlyStaleLateBlockTxnAfterExpiryFallback(t *testing.T) {
 		t.Fatalf("run hash-only stale late blocktxn: %v", err)
 	}
 	requireFirstGetDataBlock(t, p, conn.Bytes(), blockHash)
-	state := p.snapshotState()
-	if state.BanScore != 0 || !strings.Contains(state.LastError, "ignored stale blocktxn response") {
+	if state := p.snapshotState(); state.BanScore != 0 || !strings.Contains(state.LastError, "ignored stale blocktxn response") {
 		t.Fatalf("state=%+v, want ignored stale late blocktxn without ban", state)
 	}
 }
@@ -1042,8 +1042,7 @@ func requireBadChecksumLateBlockTxn(t *testing.T, blockHash [32]byte, payload []
 	ck.advance(compactOutstandingRequestTTL + time.Second)
 	raw := mustPeerRuntimeFrameBytes(t, p, message{Command: messageBlockTxn, Payload: payload})
 	raw[20] ^= 0xff
-	conn := &scriptedConn{reads: []scriptedRead{{data: raw}}}
-	p.conn = conn
+	p.conn = &scriptedConn{reads: []scriptedRead{{data: raw}}}
 	err := p.run(context.Background())
 	if err == nil || err.Error() != "invalid envelope checksum" {
 		t.Fatalf("payload len=%d err=%v, want checksum failure before semantic classification", len(payload), err)

--- a/clients/go/node/p2p/peer_runtime_test.go
+++ b/clients/go/node/p2p/peer_runtime_test.go
@@ -934,18 +934,13 @@ func TestRunRejectsWrongHashLateBlockTxnBodyAfterExpiryFallback(t *testing.T) {
 	requireFirstGetDataBlock(t, p, conn.Bytes(), blockHash)
 }
 
-func TestReadLateBlockTxnKeepsNewActiveOutstandingResponse(t *testing.T) {
-	p := newPeerRuntimeTestPeer(t)
+func TestReadLateBlockTxnKeepsActiveResponseAndThenIgnoresLateContext(t *testing.T) {
 	oldHash := [32]byte{0x15}
 	activeHash := [32]byte{0x35}
-	p.setCompactOutstandingRequest(compactOutstandingRequest{BlockHash: activeHash, BlockTxnPayloadCap: 128})
-	activePayload := append(activeHash[:], bytes.Repeat([]byte{0x01}, 33)...)
-	oldPayload := append(oldHash[:], 0x01)
-	p.conn = &scriptedConn{reads: []scriptedRead{
-		{data: mustPeerRuntimeFrameBytes(t, p, message{Command: messageBlockTxn, Payload: activePayload})},
-		{data: mustPeerRuntimeFrameBytes(t, p, message{Command: messageBlockTxn, Payload: oldPayload})},
-	}}
-	lateCtx := &compactOutstandingRequest{BlockHash: oldHash, BlockTxnPayloadCap: 64}
+	activePayload := makePeerRuntimeBlockTxnPayload(activeHash, 33, 0x01)
+	oldPayload := makePeerRuntimeBlockTxnPayload(oldHash, 1, 0x01)
+	p := setupLateBlockTxnReadPeer(t, compactOutstandingRequest{BlockHash: activeHash, BlockTxnPayloadCap: 128}, activePayload, oldPayload)
+	lateCtx := lateBlockTxnReadContext(oldHash, 64)
 
 	frame, lateCtx, err := p.readPostHandshakeFrame(context.Background(), time.Now(), lateCtx)
 	if err != nil {
@@ -961,42 +956,79 @@ func TestReadLateBlockTxnKeepsNewActiveOutstandingResponse(t *testing.T) {
 	if !errors.Is(err, errLateBlockTxnIgnored) || lateCtx != nil {
 		t.Fatalf("stale late read err=%v lateCtx=%+v, want ignored late blocktxn and cleared context", err, lateCtx)
 	}
-	p = newPeerRuntimeTestPeer(t)
-	p.setCompactOutstandingRequest(compactOutstandingRequest{BlockHash: activeHash, BlockTxnPayloadCap: 64})
-	p.conn = &scriptedConn{reads: []scriptedRead{{data: mustPeerRuntimeFrameBytes(t, p, message{Command: messageBlockTxn, Payload: activePayload})}}}
-	_, lateCtx, err = p.readPostHandshakeFrame(context.Background(), time.Now(), &compactOutstandingRequest{BlockHash: oldHash, BlockTxnPayloadCap: 128})
+}
+
+func TestReadLateBlockTxnActiveCapErrorPreservesLateContext(t *testing.T) {
+	oldHash := [32]byte{0x15}
+	activeHash := [32]byte{0x35}
+	activePayload := makePeerRuntimeBlockTxnPayload(activeHash, 33, 0x01)
+	p := setupLateBlockTxnReadPeer(t, compactOutstandingRequest{BlockHash: activeHash, BlockTxnPayloadCap: 64}, activePayload)
+
+	_, lateCtx, err := p.readPostHandshakeFrame(context.Background(), time.Now(), lateBlockTxnReadContext(oldHash, 128))
 	if err == nil || err.Error() != "message exceeds command cap" || lateCtx == nil {
 		t.Fatalf("active cap err=%v lateCtx=%+v, want cap error preserving late context", err, lateCtx)
 	}
-	p = newPeerRuntimeTestPeer(t)
-	p.setCompactOutstandingRequest(compactOutstandingRequest{BlockHash: oldHash, BlockTxnPayloadCap: 128})
-	p.conn = &scriptedConn{reads: []scriptedRead{{data: mustPeerRuntimeFrameBytes(t, p, message{Command: messageBlockTxn, Payload: oldPayload})}}}
-	frame, lateCtx, err = p.readPostHandshakeFrame(context.Background(), time.Now(), &compactOutstandingRequest{BlockHash: oldHash, BlockTxnPayloadCap: 64})
+}
+
+func TestReadLateBlockTxnSameHashActiveResponseWinsOverLateContext(t *testing.T) {
+	oldHash := [32]byte{0x15}
+	oldPayload := makePeerRuntimeBlockTxnPayload(oldHash, 1, 0x01)
+	p := setupLateBlockTxnReadPeer(t, compactOutstandingRequest{BlockHash: oldHash, BlockTxnPayloadCap: 128}, oldPayload)
+
+	frame, lateCtx, err := p.readPostHandshakeFrame(context.Background(), time.Now(), lateBlockTxnReadContext(oldHash, 64))
 	if err != nil || lateCtx == nil || !bytes.Equal(frame.Payload, oldPayload) {
 		t.Fatalf("same-hash active frame=%+v err=%v lateCtx=%+v, want active response before late ignore", frame, err, lateCtx)
 	}
+}
 
-	p = newPeerRuntimeTestPeer(t)
-	p.setCompactOutstandingRequest(compactOutstandingTestRequest(activeHash))
-	p.conn = &scriptedConn{reads: []scriptedRead{{data: mustPeerRuntimeFrameBytes(t, p, message{Command: messageBlockTxn, Payload: append(oldHash[:], bytes.Repeat([]byte{0x02}, 33)...)})}}}
-	_, _, err = p.readPostHandshakeFrame(context.Background(), time.Now(), &compactOutstandingRequest{BlockHash: oldHash, BlockTxnPayloadCap: blockTxnHashPayloadBytes})
+func TestReadLateBlockTxnStaleBodyDoesNotBanActiveOutstanding(t *testing.T) {
+	oldHash := [32]byte{0x15}
+	activeHash := [32]byte{0x35}
+	p := setupLateBlockTxnReadPeer(t, compactOutstandingTestRequest(activeHash), makePeerRuntimeBlockTxnPayload(oldHash, 33, 0x02))
+
+	_, _, err := p.readPostHandshakeFrame(context.Background(), time.Now(), lateBlockTxnReadContext(oldHash, blockTxnHashPayloadBytes))
 	requireBlockTxnStaleBodyError(t, err)
 	p.applyPostHandshakeDisconnectError(err)
 	if state := p.snapshotState(); state.BanScore != 0 || p.blockTxnPayloadCap() == 0 {
 		t.Fatalf("state=%+v activeCap=%d, want stale late cap not active ban/clear", state, p.blockTxnPayloadCap())
 	}
+}
 
-	p = newPeerRuntimeTestPeer(t)
+func TestReadLateBlockTxnShortActiveResponseStillUsesActiveValidation(t *testing.T) {
+	oldHash := [32]byte{0x15}
+	activeHash := [32]byte{0x35}
+	p := setupLateBlockTxnReadPeer(t, compactOutstandingTestRequest(activeHash), activeHash[:blockTxnHashPayloadBytes-1])
 	p.service.cfg.EnableCompactReceive = true
-	p.setCompactOutstandingRequest(compactOutstandingTestRequest(activeHash))
-	p.conn = &scriptedConn{reads: []scriptedRead{{data: mustPeerRuntimeFrameBytes(t, p, message{Command: messageBlockTxn, Payload: activeHash[:blockTxnHashPayloadBytes-1]})}}}
-	frame, lateCtx, err = p.readPostHandshakeFrame(context.Background(), time.Now(), &compactOutstandingRequest{BlockHash: oldHash, BlockTxnPayloadCap: 64})
+
+	frame, lateCtx, err := p.readPostHandshakeFrame(context.Background(), time.Now(), lateBlockTxnReadContext(oldHash, 64))
 	if err != nil || lateCtx == nil {
 		t.Fatalf("short active err=%v lateCtx=%+v, want active validation frame", err, lateCtx)
 	}
 	if err := p.handleMessage(frame); err == nil || p.snapshotState().BanScore == 0 {
 		t.Fatalf("short active handle err=%v state=%+v, want active blocktxn reject/ban", err, p.snapshotState())
 	}
+}
+
+func makePeerRuntimeBlockTxnPayload(hash [32]byte, extraLen int, fill byte) []byte {
+	payload := append([]byte{}, hash[:]...)
+	return append(payload, bytes.Repeat([]byte{fill}, extraLen)...)
+}
+
+func lateBlockTxnReadContext(hash [32]byte, payloadCap uint32) *compactOutstandingRequest {
+	return &compactOutstandingRequest{BlockHash: hash, BlockTxnPayloadCap: payloadCap}
+}
+
+func setupLateBlockTxnReadPeer(t *testing.T, active compactOutstandingRequest, payloads ...[]byte) *peer {
+	t.Helper()
+	p := newPeerRuntimeTestPeer(t)
+	p.setCompactOutstandingRequest(active)
+	reads := make([]scriptedRead, 0, len(payloads))
+	for _, payload := range payloads {
+		frame := message{Command: messageBlockTxn, Payload: payload}
+		reads = append(reads, scriptedRead{data: mustPeerRuntimeFrameBytes(t, p, frame)})
+	}
+	p.conn = &scriptedConn{reads: reads}
+	return p
 }
 
 func TestRunIgnoresHashOnlyStaleLateBlockTxnAfterExpiryFallback(t *testing.T) {

--- a/clients/go/node/p2p/peer_runtime_test.go
+++ b/clients/go/node/p2p/peer_runtime_test.go
@@ -854,14 +854,11 @@ func TestRunDrainsLateBlockTxnBodyAfterExpiryFallback(t *testing.T) {
 	req := compactOutstandingTestRequest(blockHash)
 	payload := append(blockHash[:], 0x01)
 	p, conn, err := runExpiredLateBlockTxnFrame(t, req, payload, message{Command: messageVersion})
-
-	if err == nil || !strings.Contains(err.Error(), "invalid version message after handshake") {
-		t.Fatalf("run err=%v, want next frame after drained late blocktxn", err)
+	state := p.snapshotState()
+	if err == nil || !strings.Contains(err.Error(), "invalid version message after handshake") || state.BanScore != 0 || !strings.Contains(state.LastError, "ignored late blocktxn response") {
+		t.Fatalf("run err=%v state=%+v, want next frame after drained late blocktxn with diagnostic", err, state)
 	}
 	requireFirstGetDataBlock(t, p, conn.Bytes(), blockHash)
-	if state := p.snapshotState(); state.BanScore != 0 || !strings.Contains(state.LastError, "ignored late blocktxn response") {
-		t.Fatalf("state=%+v, want ignored late blocktxn diagnostic without ban", state)
-	}
 	p, ck := setupCompactFallbackPeer(t)
 	frameBytes := mustPeerRuntimeFrameBytes(t, p, message{Command: messageHeaders, Payload: []byte{0x01}})
 	lateFrame := mustPeerRuntimeFrameBytes(t, p, message{Command: messageBlockTxn, Payload: payload})
@@ -880,7 +877,6 @@ func TestRunCapsLateBlockTxnBodyAfterExpiryFallbackByOutstandingRequest(t *testi
 	req := compactOutstandingTestRequest(blockHash)
 	req.BlockTxnPayloadCap = blockTxnHashPayloadBytes
 	p, conn, err := runExpiredLateBlockTxnFrame(t, req, append(blockHash[:], 0x01))
-
 	if err == nil || err.Error() != "message exceeds command cap" {
 		t.Fatalf("run err=%v, want expired outstanding cap error", err)
 	}
@@ -924,7 +920,6 @@ func TestRunRejectsShortLateBlockTxnAfterExpiryFallback(t *testing.T) {
 	blockHash := [32]byte{0x14}
 	req := compactOutstandingTestRequest(blockHash)
 	p, conn, err := runExpiredLateBlockTxnFrame(t, req, blockHash[:blockTxnHashPayloadBytes-1])
-
 	if err == nil || !strings.Contains(err.Error(), "blocktxn payload missing block hash") {
 		t.Fatalf("run err=%v, want short late blocktxn rejection", err)
 	}
@@ -965,7 +960,7 @@ func TestReadLateBlockTxnKeepsNewActiveOutstandingResponse(t *testing.T) {
 		t.Fatalf("frame=%+v, want active blocktxn payload", frame)
 	}
 	_, lateCtx, err = p.readPostHandshakeFrame(context.Background(), time.Now(), lateCtx)
-	if !errors.Is(err, errLateBlockTxnIgnored) || lateCtx != nil {
+	if err == nil || err.Error() != "ignored late blocktxn response" || lateCtx != nil {
 		t.Fatalf("stale late read err=%v lateCtx=%+v, want ignored late blocktxn and cleared context", err, lateCtx)
 	}
 	p = newPeerRuntimeTestPeer(t)

--- a/clients/go/node/p2p/peer_runtime_test.go
+++ b/clients/go/node/p2p/peer_runtime_test.go
@@ -888,7 +888,6 @@ func TestRunResetsReadDeadlineBeforeLateBlockTxnDrainAfterExpiryFallback(t *test
 	req := compactOutstandingTestRequest(blockHash)
 	beforeRun := time.Now()
 	p, conn, err := runExpiredLateBlockTxnFrame(t, req, append(blockHash[:], 0x01), message{Command: messageVersion})
-
 	if err == nil || !strings.Contains(err.Error(), "invalid version message after handshake") {
 		t.Fatalf("run err=%v, want next frame after late blocktxn drain", err)
 	}
@@ -931,7 +930,6 @@ func TestRunRejectsWrongHashLateBlockTxnBodyAfterExpiryFallback(t *testing.T) {
 	staleHash := [32]byte{0x25}
 	req := compactOutstandingTestRequest(blockHash)
 	p, conn, err := runExpiredLateBlockTxnFrame(t, req, append(staleHash[:], 0x01))
-
 	requireBlockTxnStaleBodyError(t, err)
 	requireFirstGetDataBlock(t, p, conn.Bytes(), blockHash)
 }
@@ -960,7 +958,7 @@ func TestReadLateBlockTxnKeepsNewActiveOutstandingResponse(t *testing.T) {
 		t.Fatalf("frame=%+v, want active blocktxn payload", frame)
 	}
 	_, lateCtx, err = p.readPostHandshakeFrame(context.Background(), time.Now(), lateCtx)
-	if err == nil || err.Error() != "ignored late blocktxn response" || lateCtx != nil {
+	if !errors.Is(err, errLateBlockTxnIgnored) || lateCtx != nil {
 		t.Fatalf("stale late read err=%v lateCtx=%+v, want ignored late blocktxn and cleared context", err, lateCtx)
 	}
 	p = newPeerRuntimeTestPeer(t)
@@ -1006,7 +1004,6 @@ func TestRunIgnoresHashOnlyStaleLateBlockTxnAfterExpiryFallback(t *testing.T) {
 	staleHash := [32]byte{0x26}
 	req := compactOutstandingTestRequest(blockHash)
 	p, conn, err := runExpiredLateBlockTxnFrame(t, req, staleHash[:])
-
 	if err != nil {
 		t.Fatalf("run hash-only stale late blocktxn: %v", err)
 	}

--- a/clients/go/node/p2p/peer_runtime_test.go
+++ b/clients/go/node/p2p/peer_runtime_test.go
@@ -935,12 +935,11 @@ func TestRunRejectsWrongHashLateBlockTxnBodyAfterExpiryFallback(t *testing.T) {
 }
 
 func TestReadLateBlockTxnKeepsActiveResponseAndThenIgnoresLateContext(t *testing.T) {
-	oldHash := [32]byte{0x15}
-	activeHash := [32]byte{0x35}
-	activePayload := makePeerRuntimeBlockTxnPayload(activeHash, 33, 0x01)
-	oldPayload := makePeerRuntimeBlockTxnPayload(oldHash, 1, 0x01)
+	oldHash, activeHash := [32]byte{0x15}, [32]byte{0x35}
+	activePayload := append(activeHash[:], bytes.Repeat([]byte{0x01}, 33)...)
+	oldPayload := append(oldHash[:], 0x01)
 	p := setupLateBlockTxnReadPeer(t, compactOutstandingRequest{BlockHash: activeHash, BlockTxnPayloadCap: 128}, activePayload, oldPayload)
-	lateCtx := lateBlockTxnReadContext(oldHash, 64)
+	lateCtx := &compactOutstandingRequest{BlockHash: oldHash, BlockTxnPayloadCap: 64}
 
 	frame, lateCtx, err := p.readPostHandshakeFrame(context.Background(), time.Now(), lateCtx)
 	if err != nil {
@@ -959,63 +958,27 @@ func TestReadLateBlockTxnKeepsActiveResponseAndThenIgnoresLateContext(t *testing
 }
 
 func TestReadLateBlockTxnActiveCapErrorPreservesLateContext(t *testing.T) {
-	oldHash := [32]byte{0x15}
-	activeHash := [32]byte{0x35}
-	activePayload := makePeerRuntimeBlockTxnPayload(activeHash, 33, 0x01)
+	oldHash, activeHash := [32]byte{0x15}, [32]byte{0x35}
+	activePayload := append(activeHash[:], bytes.Repeat([]byte{0x01}, 33)...)
 	p := setupLateBlockTxnReadPeer(t, compactOutstandingRequest{BlockHash: activeHash, BlockTxnPayloadCap: 64}, activePayload)
 
-	_, lateCtx, err := p.readPostHandshakeFrame(context.Background(), time.Now(), lateBlockTxnReadContext(oldHash, 128))
+	_, lateCtx, err := p.readPostHandshakeFrame(context.Background(), time.Now(), &compactOutstandingRequest{BlockHash: oldHash, BlockTxnPayloadCap: 128})
 	if err == nil || err.Error() != "message exceeds command cap" || lateCtx == nil {
 		t.Fatalf("active cap err=%v lateCtx=%+v, want cap error preserving late context", err, lateCtx)
 	}
 }
 
-func TestReadLateBlockTxnSameHashActiveResponseWinsOverLateContext(t *testing.T) {
-	oldHash := [32]byte{0x15}
-	oldPayload := makePeerRuntimeBlockTxnPayload(oldHash, 1, 0x01)
-	p := setupLateBlockTxnReadPeer(t, compactOutstandingRequest{BlockHash: oldHash, BlockTxnPayloadCap: 128}, oldPayload)
-
-	frame, lateCtx, err := p.readPostHandshakeFrame(context.Background(), time.Now(), lateBlockTxnReadContext(oldHash, 64))
-	if err != nil || lateCtx == nil || !bytes.Equal(frame.Payload, oldPayload) {
-		t.Fatalf("same-hash active frame=%+v err=%v lateCtx=%+v, want active response before late ignore", frame, err, lateCtx)
-	}
-}
-
 func TestReadLateBlockTxnStaleBodyDoesNotBanActiveOutstanding(t *testing.T) {
-	oldHash := [32]byte{0x15}
-	activeHash := [32]byte{0x35}
-	p := setupLateBlockTxnReadPeer(t, compactOutstandingTestRequest(activeHash), makePeerRuntimeBlockTxnPayload(oldHash, 33, 0x02))
+	oldHash, activeHash := [32]byte{0x15}, [32]byte{0x35}
+	stalePayload := append(oldHash[:], bytes.Repeat([]byte{0x02}, 33)...)
+	p := setupLateBlockTxnReadPeer(t, compactOutstandingTestRequest(activeHash), stalePayload)
 
-	_, _, err := p.readPostHandshakeFrame(context.Background(), time.Now(), lateBlockTxnReadContext(oldHash, blockTxnHashPayloadBytes))
+	_, _, err := p.readPostHandshakeFrame(context.Background(), time.Now(), &compactOutstandingRequest{BlockHash: oldHash, BlockTxnPayloadCap: blockTxnHashPayloadBytes})
 	requireBlockTxnStaleBodyError(t, err)
 	p.applyPostHandshakeDisconnectError(err)
 	if state := p.snapshotState(); state.BanScore != 0 || p.blockTxnPayloadCap() == 0 {
 		t.Fatalf("state=%+v activeCap=%d, want stale late cap not active ban/clear", state, p.blockTxnPayloadCap())
 	}
-}
-
-func TestReadLateBlockTxnShortActiveResponseStillUsesActiveValidation(t *testing.T) {
-	oldHash := [32]byte{0x15}
-	activeHash := [32]byte{0x35}
-	p := setupLateBlockTxnReadPeer(t, compactOutstandingTestRequest(activeHash), activeHash[:blockTxnHashPayloadBytes-1])
-	p.service.cfg.EnableCompactReceive = true
-
-	frame, lateCtx, err := p.readPostHandshakeFrame(context.Background(), time.Now(), lateBlockTxnReadContext(oldHash, 64))
-	if err != nil || lateCtx == nil {
-		t.Fatalf("short active err=%v lateCtx=%+v, want active validation frame", err, lateCtx)
-	}
-	if err := p.handleMessage(frame); err == nil || p.snapshotState().BanScore == 0 {
-		t.Fatalf("short active handle err=%v state=%+v, want active blocktxn reject/ban", err, p.snapshotState())
-	}
-}
-
-func makePeerRuntimeBlockTxnPayload(hash [32]byte, extraLen int, fill byte) []byte {
-	payload := append([]byte{}, hash[:]...)
-	return append(payload, bytes.Repeat([]byte{fill}, extraLen)...)
-}
-
-func lateBlockTxnReadContext(hash [32]byte, payloadCap uint32) *compactOutstandingRequest {
-	return &compactOutstandingRequest{BlockHash: hash, BlockTxnPayloadCap: payloadCap}
 }
 
 func setupLateBlockTxnReadPeer(t *testing.T, active compactOutstandingRequest, payloads ...[]byte) *peer {

--- a/clients/go/node/p2p/peer_runtime_test.go
+++ b/clients/go/node/p2p/peer_runtime_test.go
@@ -84,6 +84,42 @@ func requireBlockTxnStaleBodyError(t *testing.T, err error) {
 	}
 }
 
+func mustBadChecksumPeerRuntimeFrameBytes(t *testing.T, p *peer, frame message) []byte {
+	t.Helper()
+	raw := mustPeerRuntimeFrameBytes(t, p, frame)
+	raw[20] ^= 0xff
+	return raw
+}
+
+func runExpiredLateBlockTxnFrame(t *testing.T, req compactOutstandingRequest, payload []byte, tail ...message) (*peer, *scriptedConn, error) {
+	t.Helper()
+	p, ck := setupCompactFallbackPeer(t)
+	p.activateCompactOutstandingRequest(req)
+	ck.advance(compactOutstandingRequestTTL + time.Second)
+
+	reads := []scriptedRead{{
+		data: mustPeerRuntimeFrameBytes(t, p, message{Command: messageBlockTxn, Payload: payload}),
+	}}
+	for _, frame := range tail {
+		reads = append(reads, scriptedRead{data: mustPeerRuntimeFrameBytes(t, p, frame)})
+	}
+	conn := &scriptedConn{reads: reads}
+	p.conn = conn
+	return p, conn, p.run(context.Background())
+}
+
+func runExpiredLateBadChecksumBlockTxnFrame(t *testing.T, req compactOutstandingRequest, payload []byte) (*peer, *scriptedConn, error) {
+	t.Helper()
+	p, ck := setupCompactFallbackPeer(t)
+	p.activateCompactOutstandingRequest(req)
+	ck.advance(compactOutstandingRequestTTL + time.Second)
+	conn := &scriptedConn{reads: []scriptedRead{{
+		data: mustBadChecksumPeerRuntimeFrameBytes(t, p, message{Command: messageBlockTxn, Payload: payload}),
+	}}}
+	p.conn = conn
+	return p, conn, p.run(context.Background())
+}
+
 type scriptedRead struct {
 	data []byte
 	err  error
@@ -97,6 +133,7 @@ type scriptedConn struct {
 	writeErr        error
 	writeErrAt      int
 	readDeadlineErr error
+	readDeadlines   []time.Time
 }
 
 func (c *scriptedConn) Read(p []byte) (int, error) {
@@ -130,11 +167,14 @@ func (c *scriptedConn) Write(p []byte) (int, error) {
 	}
 	return n, err
 }
-func (c *scriptedConn) Close() error                     { return nil }
-func (c *scriptedConn) LocalAddr() net.Addr              { return stubAddr("local") }
-func (c *scriptedConn) RemoteAddr() net.Addr             { return stubAddr("remote") }
-func (c *scriptedConn) SetDeadline(time.Time) error      { return nil }
-func (c *scriptedConn) SetReadDeadline(time.Time) error  { return c.readDeadlineErr }
+func (c *scriptedConn) Close() error                { return nil }
+func (c *scriptedConn) LocalAddr() net.Addr         { return stubAddr("local") }
+func (c *scriptedConn) RemoteAddr() net.Addr        { return stubAddr("remote") }
+func (c *scriptedConn) SetDeadline(time.Time) error { return nil }
+func (c *scriptedConn) SetReadDeadline(t time.Time) error {
+	c.readDeadlines = append(c.readDeadlines, t)
+	return c.readDeadlineErr
+}
 func (c *scriptedConn) SetWriteDeadline(time.Time) error { return nil }
 
 func TestShouldIgnoreAndNormalizeReadError(t *testing.T) {
@@ -828,6 +868,176 @@ func TestRunFallsBackAndClearsExpiredCompactOutstandingOnIdleTimeout(t *testing.
 	p.conn = &scriptedConn{}
 	if sent, err := p.handleExpiredCompactOutstanding(ctx); sent || err != nil || p.conn.(*scriptedConn).Len() != 0 {
 		t.Fatalf("cancel-after-pop sent=%v err=%v bytes=%d", sent, err, p.conn.(*scriptedConn).Len())
+	}
+}
+
+func TestRunDrainsLateBlockTxnBodyAfterExpiryFallback(t *testing.T) {
+	blockHash := [32]byte{0x11}
+	req := compactOutstandingTestRequest(blockHash)
+	payload := append(blockHash[:], 0x01)
+	p, conn, err := runExpiredLateBlockTxnFrame(
+		t,
+		req,
+		payload,
+		message{Command: messageVersion},
+	)
+
+	if err == nil || !strings.Contains(err.Error(), "invalid version message after handshake") {
+		t.Fatalf("run err=%v, want next frame after drained late blocktxn", err)
+	}
+	requireFirstGetDataBlock(t, p, conn.Bytes(), blockHash)
+}
+
+func TestRunCapsLateBlockTxnBodyAfterExpiryFallbackByOutstandingRequest(t *testing.T) {
+	blockHash := [32]byte{0x12}
+	req := compactOutstandingTestRequest(blockHash)
+	req.BlockTxnPayloadCap = blockTxnHashPayloadBytes
+	payload := append(blockHash[:], 0x01)
+	p, conn, err := runExpiredLateBlockTxnFrame(t, req, payload)
+
+	if err == nil || err.Error() != "message exceeds command cap" {
+		t.Fatalf("run err=%v, want expired outstanding cap error", err)
+	}
+	requireFirstGetDataBlock(t, p, conn.Bytes(), blockHash)
+}
+
+func TestRunResetsReadDeadlineBeforeLateBlockTxnDrainAfterExpiryFallback(t *testing.T) {
+	blockHash := [32]byte{0x13}
+	req := compactOutstandingTestRequest(blockHash)
+	payload := append(blockHash[:], 0x01)
+	beforeRun := time.Now()
+	p, conn, err := runExpiredLateBlockTxnFrame(t, req, payload, message{Command: messageVersion})
+
+	if err == nil || !strings.Contains(err.Error(), "invalid version message after handshake") {
+		t.Fatalf("run err=%v, want next frame after late blocktxn drain", err)
+	}
+	requireFirstGetDataBlock(t, p, conn.Bytes(), blockHash)
+	if len(conn.readDeadlines) == 0 {
+		t.Fatal("no read deadline was set before late blocktxn drain")
+	}
+	firstDeadline := conn.readDeadlines[0]
+	if readDeadline := p.service.cfg.PeerRuntimeConfig.ReadDeadline; readDeadline > 0 {
+		if !firstDeadline.After(beforeRun.Add(readDeadline / 2)) {
+			t.Fatalf("first read deadline=%v, want reset normal deadline after expired compact wake", firstDeadline)
+		}
+	} else if !firstDeadline.IsZero() {
+		t.Fatalf("first read deadline=%v, want cleared deadline without normal read deadline", firstDeadline)
+	}
+}
+
+func TestRunRejectsShortLateBlockTxnAfterExpiryFallback(t *testing.T) {
+	blockHash := [32]byte{0x14}
+	req := compactOutstandingTestRequest(blockHash)
+	p, conn, err := runExpiredLateBlockTxnFrame(t, req, blockHash[:blockTxnHashPayloadBytes-1])
+
+	if err == nil || !strings.Contains(err.Error(), "blocktxn payload missing block hash") {
+		t.Fatalf("run err=%v, want short late blocktxn rejection", err)
+	}
+	requireFirstGetDataBlock(t, p, conn.Bytes(), blockHash)
+}
+
+func TestRunRejectsWrongHashLateBlockTxnBodyAfterExpiryFallback(t *testing.T) {
+	blockHash := [32]byte{0x15}
+	staleHash := [32]byte{0x25}
+	req := compactOutstandingTestRequest(blockHash)
+	payload := append(staleHash[:], 0x01)
+	p, conn, err := runExpiredLateBlockTxnFrame(t, req, payload)
+
+	requireBlockTxnStaleBodyError(t, err)
+	requireFirstGetDataBlock(t, p, conn.Bytes(), blockHash)
+}
+
+func TestReadLateBlockTxnKeepsNewActiveOutstandingResponse(t *testing.T) {
+	p := newPeerRuntimeTestPeer(t)
+	oldHash := [32]byte{0x15}
+	activeHash := [32]byte{0x35}
+	p.setCompactOutstandingRequest(compactOutstandingTestRequest(activeHash))
+	payload := append(activeHash[:], 0x01)
+	rawHeader, err := buildEnvelopeHeader(networkMagic(p.service.cfg.PeerRuntimeConfig.Network), messageBlockTxn, payload)
+	if err != nil {
+		t.Fatalf("buildEnvelopeHeader: %v", err)
+	}
+	header, err := readFrameHeader(bytes.NewReader(rawHeader[:]), networkMagic(p.service.cfg.PeerRuntimeConfig.Network), p.service.cfg.PeerRuntimeConfig.MaxMessageSize)
+	if err != nil {
+		t.Fatalf("readFrameHeader: %v", err)
+	}
+	p.conn = &scriptedConn{reads: []scriptedRead{{data: payload}}}
+
+	frame, err := p.readLateBlockTxnFrame(header, expiredCompactBlockTxnContext{blockHash: oldHash, payloadCap: 64})
+	if err != nil {
+		t.Fatalf("read late blocktxn with active response: %v", err)
+	}
+	if frame.Command != messageBlockTxn || !bytes.Equal(frame.Payload, payload) {
+		t.Fatalf("frame=%+v, want active blocktxn payload", frame)
+	}
+}
+
+func TestRunIgnoresHashOnlyStaleLateBlockTxnAfterExpiryFallback(t *testing.T) {
+	blockHash := [32]byte{0x16}
+	staleHash := [32]byte{0x26}
+	req := compactOutstandingTestRequest(blockHash)
+	p, conn, err := runExpiredLateBlockTxnFrame(t, req, staleHash[:])
+
+	if err != nil {
+		t.Fatalf("run hash-only stale late blocktxn: %v", err)
+	}
+	requireFirstGetDataBlock(t, p, conn.Bytes(), blockHash)
+	state := p.snapshotState()
+	if state.BanScore != 0 || !strings.Contains(state.LastError, "ignored stale blocktxn response") {
+		t.Fatalf("state=%+v, want ignored stale late blocktxn without ban", state)
+	}
+}
+
+func TestRunRejectsBadChecksumLateBlockTxnAfterExpiryFallback(t *testing.T) {
+	blockHash := [32]byte{0x17}
+	staleHash := [32]byte{0x27}
+	req := compactOutstandingTestRequest(blockHash)
+	payload := append(staleHash[:], 0x01)
+	p, conn, err := runExpiredLateBadChecksumBlockTxnFrame(t, req, payload)
+
+	if err == nil || err.Error() != "invalid envelope checksum" {
+		t.Fatalf("run err=%v, want checksum failure before stale semantics", err)
+	}
+	requireFirstGetDataBlock(t, p, conn.Bytes(), blockHash)
+}
+
+func TestRunRejectsBadChecksumShortLateBlockTxnAfterExpiryFallback(t *testing.T) {
+	blockHash := [32]byte{0x18}
+	req := compactOutstandingTestRequest(blockHash)
+	p, conn, err := runExpiredLateBadChecksumBlockTxnFrame(t, req, blockHash[:blockTxnHashPayloadBytes-1])
+
+	if err == nil || err.Error() != "invalid envelope checksum" {
+		t.Fatalf("run err=%v, want checksum failure before short payload classification", err)
+	}
+	requireFirstGetDataBlock(t, p, conn.Bytes(), blockHash)
+}
+
+func TestRunRejectsBadChecksumHashOnlyStaleLateBlockTxnAfterExpiryFallback(t *testing.T) {
+	blockHash := [32]byte{0x19}
+	staleHash := [32]byte{0x29}
+	req := compactOutstandingTestRequest(blockHash)
+	p, conn, err := runExpiredLateBadChecksumBlockTxnFrame(t, req, staleHash[:])
+
+	if err == nil || err.Error() != "invalid envelope checksum" {
+		t.Fatalf("run err=%v, want checksum failure before hash-only stale classification", err)
+	}
+	requireFirstGetDataBlock(t, p, conn.Bytes(), blockHash)
+}
+
+func TestRunDoesNotSendExpiredCompactFallbackAfterContextCancelDuringBlockTxn(t *testing.T) {
+	p, ck := setupCompactFallbackPeer(t)
+	ck.advance(compactOutstandingRequestTTL + time.Second)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	p.conn = &scriptedConn{reads: []scriptedRead{{
+		data: mustPeerRuntimeFrameBytes(t, p, message{Command: messageBlockTxn, Payload: make([]byte, blockTxnHashPayloadBytes)}),
+	}}}
+
+	if err := p.run(ctx); err != nil {
+		t.Fatalf("canceled run err=%v", err)
+	}
+	if p.conn.(*scriptedConn).Len() != 0 {
+		t.Fatal("canceled blocktxn run wrote compact fallback")
 	}
 }
 

--- a/clients/go/node/p2p/peer_runtime_test.go
+++ b/clients/go/node/p2p/peer_runtime_test.go
@@ -108,18 +108,6 @@ func runExpiredLateBlockTxnFrame(t *testing.T, req compactOutstandingRequest, pa
 	return p, conn, p.run(context.Background())
 }
 
-func runExpiredLateBadChecksumBlockTxnFrame(t *testing.T, req compactOutstandingRequest, payload []byte) (*peer, *scriptedConn, error) {
-	t.Helper()
-	p, ck := setupCompactFallbackPeer(t)
-	p.activateCompactOutstandingRequest(req)
-	ck.advance(compactOutstandingRequestTTL + time.Second)
-	conn := &scriptedConn{reads: []scriptedRead{{
-		data: mustBadChecksumPeerRuntimeFrameBytes(t, p, message{Command: messageBlockTxn, Payload: payload}),
-	}}}
-	p.conn = conn
-	return p, conn, p.run(context.Background())
-}
-
 type scriptedRead struct {
 	data []byte
 	err  error
@@ -924,16 +912,8 @@ func TestRunResetsReadDeadlineBeforeLateBlockTxnDrainAfterExpiryFallback(t *test
 		t.Fatalf("run err=%v, want next frame after late blocktxn drain", err)
 	}
 	requireFirstGetDataBlock(t, p, conn.Bytes(), blockHash)
-	if len(conn.readDeadlines) == 0 {
-		t.Fatal("no read deadline was set before late blocktxn drain")
-	}
-	firstDeadline := conn.readDeadlines[0]
-	if readDeadline := p.service.cfg.PeerRuntimeConfig.ReadDeadline; readDeadline > 0 {
-		if !firstDeadline.After(beforeRun.Add(readDeadline / 2)) {
-			t.Fatalf("first read deadline=%v, want reset normal deadline after expired compact wake", firstDeadline)
-		}
-	} else if !firstDeadline.IsZero() {
-		t.Fatalf("first read deadline=%v, want cleared deadline without normal read deadline", firstDeadline)
+	if len(conn.readDeadlines) == 0 || !conn.readDeadlines[0].After(beforeRun.Add(p.service.cfg.PeerRuntimeConfig.ReadDeadline/2)) {
+		t.Fatalf("read deadlines=%v, want reset normal deadline after expired compact wake", conn.readDeadlines)
 	}
 }
 
@@ -942,10 +922,8 @@ func TestRunKeepsActiveCompactDeadlineWithStaleLateBlockTxnContext(t *testing.T)
 	ck.advance(compactOutstandingRequestTTL + time.Second)
 	p.service.cfg.PeerRuntimeConfig.ReadDeadline = time.Hour
 	conn := &scriptedConn{
-		reads: []scriptedRead{{data: mustPeerRuntimeFrameBytes(t, p, message{Command: messageVersion})}},
-		writeHook: func(int) {
-			p.activateCompactOutstandingRequest(compactOutstandingTestRequest([32]byte{0x23}))
-		},
+		reads:     []scriptedRead{{data: mustPeerRuntimeFrameBytes(t, p, message{Command: messageVersion})}},
+		writeHook: func(int) { p.activateCompactOutstandingRequest(compactOutstandingTestRequest([32]byte{0x23})) },
 	}
 	p.conn = conn
 
@@ -1006,6 +984,21 @@ func TestReadLateBlockTxnKeepsNewActiveOutstandingResponse(t *testing.T) {
 	if !errors.Is(err, errLateBlockTxnIgnored) || lateCtx != nil {
 		t.Fatalf("stale late read err=%v lateCtx=%+v, want ignored late blocktxn and cleared context", err, lateCtx)
 	}
+
+	p = newPeerRuntimeTestPeer(t)
+	p.setCompactOutstandingRequest(compactOutstandingRequest{BlockHash: activeHash, BlockTxnPayloadCap: 64})
+	p.conn = &scriptedConn{reads: []scriptedRead{{data: mustPeerRuntimeFrameBytes(t, p, message{Command: messageBlockTxn, Payload: activePayload})}}}
+	_, lateCtx, err = p.readPostHandshakeFrame(context.Background(), time.Now(), &compactOutstandingRequest{BlockHash: oldHash, BlockTxnPayloadCap: 128})
+	if err == nil || err.Error() != "message exceeds command cap" || lateCtx == nil {
+		t.Fatalf("active cap err=%v lateCtx=%+v, want cap error preserving late context", err, lateCtx)
+	}
+	p = newPeerRuntimeTestPeer(t)
+	p.setCompactOutstandingRequest(compactOutstandingRequest{BlockHash: oldHash, BlockTxnPayloadCap: 128})
+	p.conn = &scriptedConn{reads: []scriptedRead{{data: mustPeerRuntimeFrameBytes(t, p, message{Command: messageBlockTxn, Payload: oldPayload})}}}
+	frame, lateCtx, err = p.readPostHandshakeFrame(context.Background(), time.Now(), &compactOutstandingRequest{BlockHash: oldHash, BlockTxnPayloadCap: 64})
+	if err != nil || lateCtx == nil || !bytes.Equal(frame.Payload, oldPayload) {
+		t.Fatalf("same-hash active frame=%+v err=%v lateCtx=%+v, want active response before late ignore", frame, err, lateCtx)
+	}
 }
 
 func TestRunIgnoresHashOnlyStaleLateBlockTxnAfterExpiryFallback(t *testing.T) {
@@ -1043,7 +1036,12 @@ func TestRunRejectsBadChecksumHashOnlyStaleLateBlockTxnAfterExpiryFallback(t *te
 
 func requireBadChecksumLateBlockTxn(t *testing.T, blockHash [32]byte, payload []byte) {
 	t.Helper()
-	p, conn, err := runExpiredLateBadChecksumBlockTxnFrame(t, compactOutstandingTestRequest(blockHash), payload)
+	p, ck := setupCompactFallbackPeer(t)
+	p.activateCompactOutstandingRequest(compactOutstandingTestRequest(blockHash))
+	ck.advance(compactOutstandingRequestTTL + time.Second)
+	conn := &scriptedConn{reads: []scriptedRead{{data: mustBadChecksumPeerRuntimeFrameBytes(t, p, message{Command: messageBlockTxn, Payload: payload})}}}
+	p.conn = conn
+	err := p.run(context.Background())
 	if err == nil || err.Error() != "invalid envelope checksum" {
 		t.Fatalf("payload len=%d err=%v, want checksum failure before semantic classification", len(payload), err)
 	}

--- a/clients/go/node/p2p/peer_runtime_test.go
+++ b/clients/go/node/p2p/peer_runtime_test.go
@@ -84,22 +84,13 @@ func requireBlockTxnStaleBodyError(t *testing.T, err error) {
 	}
 }
 
-func mustBadChecksumPeerRuntimeFrameBytes(t *testing.T, p *peer, frame message) []byte {
-	t.Helper()
-	raw := mustPeerRuntimeFrameBytes(t, p, frame)
-	raw[20] ^= 0xff
-	return raw
-}
-
 func runExpiredLateBlockTxnFrame(t *testing.T, req compactOutstandingRequest, payload []byte, tail ...message) (*peer, *scriptedConn, error) {
 	t.Helper()
 	p, ck := setupCompactFallbackPeer(t)
 	p.activateCompactOutstandingRequest(req)
 	ck.advance(compactOutstandingRequestTTL + time.Second)
 
-	reads := []scriptedRead{{
-		data: mustPeerRuntimeFrameBytes(t, p, message{Command: messageBlockTxn, Payload: payload}),
-	}}
+	reads := []scriptedRead{{data: mustPeerRuntimeFrameBytes(t, p, message{Command: messageBlockTxn, Payload: payload})}}
 	for _, frame := range tail {
 		reads = append(reads, scriptedRead{data: mustPeerRuntimeFrameBytes(t, p, frame)})
 	}
@@ -999,6 +990,16 @@ func TestReadLateBlockTxnKeepsNewActiveOutstandingResponse(t *testing.T) {
 	if err != nil || lateCtx == nil || !bytes.Equal(frame.Payload, oldPayload) {
 		t.Fatalf("same-hash active frame=%+v err=%v lateCtx=%+v, want active response before late ignore", frame, err, lateCtx)
 	}
+
+	p = newPeerRuntimeTestPeer(t)
+	p.setCompactOutstandingRequest(compactOutstandingTestRequest(activeHash))
+	p.conn = &scriptedConn{reads: []scriptedRead{{data: mustPeerRuntimeFrameBytes(t, p, message{Command: messageBlockTxn, Payload: append(oldHash[:], bytes.Repeat([]byte{0x02}, 33)...)})}}}
+	_, _, err = p.readPostHandshakeFrame(context.Background(), time.Now(), &compactOutstandingRequest{BlockHash: oldHash, BlockTxnPayloadCap: blockTxnHashPayloadBytes})
+	requireBlockTxnStaleBodyError(t, err)
+	p.applyPostHandshakeDisconnectError(err)
+	if state := p.snapshotState(); state.BanScore != 0 || p.blockTxnPayloadCap() == 0 {
+		t.Fatalf("state=%+v activeCap=%d, want stale late cap not active ban/clear", state, p.blockTxnPayloadCap())
+	}
 }
 
 func TestRunIgnoresHashOnlyStaleLateBlockTxnAfterExpiryFallback(t *testing.T) {
@@ -1039,13 +1040,14 @@ func requireBadChecksumLateBlockTxn(t *testing.T, blockHash [32]byte, payload []
 	p, ck := setupCompactFallbackPeer(t)
 	p.activateCompactOutstandingRequest(compactOutstandingTestRequest(blockHash))
 	ck.advance(compactOutstandingRequestTTL + time.Second)
-	conn := &scriptedConn{reads: []scriptedRead{{data: mustBadChecksumPeerRuntimeFrameBytes(t, p, message{Command: messageBlockTxn, Payload: payload})}}}
+	raw := mustPeerRuntimeFrameBytes(t, p, message{Command: messageBlockTxn, Payload: payload})
+	raw[20] ^= 0xff
+	conn := &scriptedConn{reads: []scriptedRead{{data: raw}}}
 	p.conn = conn
 	err := p.run(context.Background())
 	if err == nil || err.Error() != "invalid envelope checksum" {
 		t.Fatalf("payload len=%d err=%v, want checksum failure before semantic classification", len(payload), err)
 	}
-	requireFirstGetDataBlock(t, p, conn.Bytes(), blockHash)
 }
 
 func TestRunDoesNotSendExpiredCompactFallbackAfterContextCancelDuringBlockTxn(t *testing.T) {


### PR DESCRIPTION
Invariant:
After compact expiry fallback, Go P2P consumes or rejects a late blocktxn frame using the expired request context without dispatching stale data as a current response or leaving unread bytes to corrupt the next frame.

Layer:
Implementation and tests only. Non-consensus Go P2P compact relay runtime.

Files changed:
- clients/go/node/p2p/peer_runtime.go
- clients/go/node/p2p/peer_runtime_test.go

Tests:
- git diff --check
- gofmt -l clients/go/node/p2p/peer_runtime.go clients/go/node/p2p/peer_runtime_test.go
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node/p2p -run "TestRunDrainsLateBlockTxnBodyAfterExpiryFallback|TestRunCapsLateBlockTxnBodyAfterExpiryFallbackByOutstandingRequest|TestRunResetsReadDeadlineBeforeLateBlockTxnDrainAfterExpiryFallback|TestRunKeepsActiveCompactDeadlineWithStaleLateBlockTxnContext|TestRunRejectsShortLateBlockTxnAfterExpiryFallback|TestRunRejectsWrongHashLateBlockTxnBodyAfterExpiryFallback|TestReadLateBlockTxnKeepsNewActiveOutstandingResponse|TestRunIgnoresHashOnlyStaleLateBlockTxnAfterExpiryFallback|TestRunRejectsBadChecksumLateBlockTxnAfterExpiryFallback|TestRunRejectsBadChecksumShortLateBlockTxnAfterExpiryFallback|TestRunRejectsBadChecksumHashOnlyStaleLateBlockTxnAfterExpiryFallback|TestRunDoesNotSendExpiredCompactFallbackAfterContextCancelDuringBlockTxn" -count=1'
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -race ./node/p2p -run "TestRunDrainsLateBlockTxnBodyAfterExpiryFallback|TestRunCapsLateBlockTxnBodyAfterExpiryFallbackByOutstandingRequest|TestRunResetsReadDeadlineBeforeLateBlockTxnDrainAfterExpiryFallback|TestRunKeepsActiveCompactDeadlineWithStaleLateBlockTxnContext|TestRunRejectsShortLateBlockTxnAfterExpiryFallback|TestRunRejectsWrongHashLateBlockTxnBodyAfterExpiryFallback|TestReadLateBlockTxnKeepsNewActiveOutstandingResponse|TestRunIgnoresHashOnlyStaleLateBlockTxnAfterExpiryFallback|TestRunRejectsBadChecksumLateBlockTxnAfterExpiryFallback|TestRunRejectsBadChecksumShortLateBlockTxnAfterExpiryFallback|TestRunRejectsBadChecksumHashOnlyStaleLateBlockTxnAfterExpiryFallback|TestRunDoesNotSendExpiredCompactFallbackAfterContextCancelDuringBlockTxn|TestRunKeepsIdleTimeoutAndCompleteFrameValid|TestCompactOutstandingRequestUsesDedicatedTTL" -count=1'
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node/p2p -run "Compact|BlockTxn|Fallback" -count=1'
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node/p2p -count=1'
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./... -count=1'
- rubin-precommit-one-review with base-ref origin/main and include-base-diff
- rubin-push with stack-aware Codacy coverage wrapper, base-ref origin/main, origin HEAD

Coverage:
- Local stack-aware coverage selected stack=go.
- Variation: -0.02%.
- Diff coverage: 94.68%.

Behavior impact:
Late blocktxn responses after expired compact fallback are bounded by the expired request cap, checksum-validated before semantic ignore/reject, and routed away from active response handling unless the current active request owns the frame.

Compatibility impact:
Go P2P receive behavior only. No wire-format, consensus, Rust, conformance, policy, docs, YAML, or generated artifact changes.

Known non-goals:
- Helper-only outstanding cleanup owned by RUB-353.
- Runtime wakeup/deadline selection owned by RUB-354, except the narrow late-drain deadline reset required here.
- Serve-side getblocktxn behavior.
- Rust parity work.

Risk:
This touches compact relay post-handshake blocktxn dispatch and deadline handling. The PR includes targeted, race, node/p2p, full Go, and local Codacy coverage gates.

Rollback:
Revert this PR to restore the previous compact fallback/blocktxn dispatch behavior.

Not checked:
- Rust tests, because RUB-355 is Go-only and does not touch Rust files.
- Conformance bundle, because this PR does not change consensus or conformance fixtures.


<!-- rubin-agent-meta actor=unknown action=pr-create via=cl branch=codex/RUB-355-compact-late-blocktxn wt=rubin-protocol-codex-RUB-355 utc=2026-05-24T10:58:25Z -->
