### PR TITLE
RUB-317: add Go DA relay state container

### DIFF
--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -50,36 +50,39 @@ func (c daRelayCaps) validate() error {
 }
 
 func (c daRelayCaps) validatePositiveCaps() error {
-	if c.orphanPoolBytes == 0 {
-		return errors.New("da orphan pool cap is zero")
+	checks := []struct {
+		value   uint64
+		message string
+	}{
+		{value: c.orphanPoolBytes, message: "da orphan pool cap is zero"},
+		{value: c.orphanPoolPerPeerBytes, message: "da orphan pool per-peer cap is zero"},
+		{value: c.orphanPoolPerDAIDBytes, message: "da orphan pool per-da_id cap is zero"},
+		{value: c.orphanCommitOverheadBytes, message: "da orphan commit overhead cap is zero"},
+		{value: c.orphanTTLBlocks, message: "da orphan ttl is zero"},
+		{value: c.pinnedPayloadBytes, message: "da pinned payload cap is zero"},
 	}
-	if c.orphanPoolPerPeerBytes == 0 {
-		return errors.New("da orphan pool per-peer cap is zero")
-	}
-	if c.orphanPoolPerDAIDBytes == 0 {
-		return errors.New("da orphan pool per-da_id cap is zero")
-	}
-	if c.orphanCommitOverheadBytes == 0 {
-		return errors.New("da orphan commit overhead cap is zero")
-	}
-	if c.orphanTTLBlocks == 0 {
-		return errors.New("da orphan ttl is zero")
-	}
-	if c.pinnedPayloadBytes == 0 {
-		return errors.New("da pinned payload cap is zero")
+	for _, check := range checks {
+		if check.value == 0 {
+			return errors.New(check.message)
+		}
 	}
 	return nil
 }
 
 func (c daRelayCaps) validateRelativeCaps() error {
-	if c.orphanPoolPerPeerBytes > c.orphanPoolBytes {
-		return errors.New("da orphan pool per-peer cap exceeds global cap")
+	checks := []struct {
+		value   uint64
+		limit   uint64
+		message string
+	}{
+		{value: c.orphanPoolPerPeerBytes, limit: c.orphanPoolBytes, message: "da orphan pool per-peer cap exceeds global cap"},
+		{value: c.orphanPoolPerDAIDBytes, limit: c.orphanPoolBytes, message: "da orphan pool per-da_id cap exceeds global cap"},
+		{value: c.orphanCommitOverheadBytes, limit: c.orphanPoolBytes, message: "da orphan commit overhead cap exceeds global cap"},
 	}
-	if c.orphanPoolPerDAIDBytes > c.orphanPoolBytes {
-		return errors.New("da orphan pool per-da_id cap exceeds global cap")
-	}
-	if c.orphanCommitOverheadBytes > c.orphanPoolBytes {
-		return errors.New("da orphan commit overhead cap exceeds global cap")
+	for _, check := range checks {
+		if check.value > check.limit {
+			return errors.New(check.message)
+		}
 	}
 	return nil
 }
@@ -137,4 +140,18 @@ func (s *daRelayState) orphanBytesForPeer(peerAddr string) uint64 {
 	defer s.mu.Unlock()
 
 	return s.orphanBytesByPeerQuotaKey[peerQuotaKey(peerAddr)]
+}
+
+func (s *daRelayState) setOrphanBytesForDAID(daID [32]byte, bytes uint64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.orphanBytesByDAID[daID] = bytes
+}
+
+func (s *daRelayState) orphanBytesForDAID(daID [32]byte) uint64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.orphanBytesByDAID[daID]
 }

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -132,7 +132,12 @@ func (s *daRelayState) setOrphanBytesForPeer(peerAddr string, bytes uint64) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	s.orphanBytesByPeerQuotaKey[peerQuotaKey(peerAddr)] = bytes
+	key := peerQuotaKey(peerAddr)
+	if bytes == 0 {
+		delete(s.orphanBytesByPeerQuotaKey, key)
+		return
+	}
+	s.orphanBytesByPeerQuotaKey[key] = bytes
 }
 
 func (s *daRelayState) orphanBytesForPeer(peerAddr string) uint64 {
@@ -146,6 +151,10 @@ func (s *daRelayState) setOrphanBytesForDAID(daID [32]byte, bytes uint64) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	if bytes == 0 {
+		delete(s.orphanBytesByDAID, daID)
+		return
+	}
 	s.orphanBytesByDAID[daID] = bytes
 }
 

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -98,7 +98,7 @@ type daRelayState struct {
 	caps                      daRelayCaps
 	nextReceivedTime          uint64
 	orphanBytes               uint64
-	orphanBytesByPeer         map[string]uint64
+	orphanBytesByPeerQuotaKey map[string]uint64
 	orphanBytesByDAID         map[[32]byte]uint64
 	orphanCommitOverheadBytes uint64
 	pinnedPayloadBytes        uint64
@@ -110,10 +110,10 @@ func newDARelayState(caps daRelayCaps) (*daRelayState, error) {
 		return nil, err
 	}
 	return &daRelayState{
-		caps:              caps,
-		orphanBytesByPeer: map[string]uint64{},
-		orphanBytesByDAID: map[[32]byte]uint64{},
-		sets:              make(map[[32]byte]daRelaySetRecord),
+		caps:                      caps,
+		orphanBytesByPeerQuotaKey: map[string]uint64{},
+		orphanBytesByDAID:         map[[32]byte]uint64{},
+		sets:                      make(map[[32]byte]daRelaySetRecord),
 	}, nil
 }
 
@@ -123,4 +123,18 @@ func (s *daRelayState) nextMonotonicReceivedTime() uint64 {
 
 	s.nextReceivedTime++
 	return s.nextReceivedTime
+}
+
+func (s *daRelayState) setOrphanBytesForPeer(peerAddr string, bytes uint64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.orphanBytesByPeerQuotaKey[peerQuotaKey(peerAddr)] = bytes
+}
+
+func (s *daRelayState) orphanBytesForPeer(peerAddr string) uint64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.orphanBytesByPeerQuotaKey[peerQuotaKey(peerAddr)]
 }

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -1,0 +1,126 @@
+package p2p
+
+import (
+	"errors"
+	"sync"
+)
+
+const (
+	daOrphanPoolSizeBytes          uint64 = 64 << 20
+	daOrphanPoolPerPeerMaxBytes    uint64 = 4 << 20
+	daOrphanPoolPerDAIDMaxBytes    uint64 = 8 << 20
+	daOrphanCommitOverheadMaxBytes uint64 = 8 << 20
+	daOrphanTTLBlocks              uint64 = 3
+	daMempoolPinnedPayloadMaxBytes uint64 = 96_000_000
+)
+
+type daRelaySetState uint8
+
+const (
+	daRelayStateOrphanChunks daRelaySetState = iota
+	daRelayStateStagedCommit
+	daRelayStateCompleteSet
+)
+
+type daRelayCaps struct {
+	orphanPoolBytes           uint64
+	orphanPoolPerPeerBytes    uint64
+	orphanPoolPerDAIDBytes    uint64
+	orphanCommitOverheadBytes uint64
+	orphanTTLBlocks           uint64
+	pinnedPayloadBytes        uint64
+}
+
+func defaultDARelayCaps() daRelayCaps {
+	return daRelayCaps{
+		orphanPoolBytes:           daOrphanPoolSizeBytes,
+		orphanPoolPerPeerBytes:    daOrphanPoolPerPeerMaxBytes,
+		orphanPoolPerDAIDBytes:    daOrphanPoolPerDAIDMaxBytes,
+		orphanCommitOverheadBytes: daOrphanCommitOverheadMaxBytes,
+		orphanTTLBlocks:           daOrphanTTLBlocks,
+		pinnedPayloadBytes:        daMempoolPinnedPayloadMaxBytes,
+	}
+}
+
+func (c daRelayCaps) validate() error {
+	if err := c.validatePositiveCaps(); err != nil {
+		return err
+	}
+	return c.validateRelativeCaps()
+}
+
+func (c daRelayCaps) validatePositiveCaps() error {
+	if c.orphanPoolBytes == 0 {
+		return errors.New("da orphan pool cap is zero")
+	}
+	if c.orphanPoolPerPeerBytes == 0 {
+		return errors.New("da orphan pool per-peer cap is zero")
+	}
+	if c.orphanPoolPerDAIDBytes == 0 {
+		return errors.New("da orphan pool per-da_id cap is zero")
+	}
+	if c.orphanCommitOverheadBytes == 0 {
+		return errors.New("da orphan commit overhead cap is zero")
+	}
+	if c.orphanTTLBlocks == 0 {
+		return errors.New("da orphan ttl is zero")
+	}
+	if c.pinnedPayloadBytes == 0 {
+		return errors.New("da pinned payload cap is zero")
+	}
+	return nil
+}
+
+func (c daRelayCaps) validateRelativeCaps() error {
+	if c.orphanPoolPerPeerBytes > c.orphanPoolBytes {
+		return errors.New("da orphan pool per-peer cap exceeds global cap")
+	}
+	if c.orphanPoolPerDAIDBytes > c.orphanPoolBytes {
+		return errors.New("da orphan pool per-da_id cap exceeds global cap")
+	}
+	if c.orphanCommitOverheadBytes > c.orphanPoolBytes {
+		return errors.New("da orphan commit overhead cap exceeds global cap")
+	}
+	return nil
+}
+
+type daRelaySetRecord struct {
+	daID         [32]byte
+	state        daRelaySetState
+	receivedTime uint64
+	payloadBytes uint64
+	wireBytes    uint64
+	totalFee     uint64
+}
+
+type daRelayState struct {
+	mu                        sync.Mutex
+	caps                      daRelayCaps
+	nextReceivedTime          uint64
+	orphanBytes               uint64
+	orphanBytesByPeer         map[string]uint64
+	orphanBytesByDAID         map[[32]byte]uint64
+	orphanCommitOverheadBytes uint64
+	pinnedPayloadBytes        uint64
+	sets                      map[[32]byte]daRelaySetRecord
+}
+
+func newDARelayState(caps daRelayCaps) (*daRelayState, error) {
+	if err := caps.validate(); err != nil {
+		return nil, err
+	}
+	return &daRelayState{
+		caps:              caps,
+		orphanBytesByPeer: map[string]uint64{},
+		orphanBytesByDAID: map[[32]byte]uint64{},
+		sets:              make(map[[32]byte]daRelaySetRecord),
+	}, nil
+}
+
+func (s *daRelayState) nextMonotonicReceivedTime() uint64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.nextReceivedTime++
+	return s.nextReceivedTime
+}

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -117,6 +117,29 @@ func TestDARelayPeerAccountingUsesQuotaKey(t *testing.T) {
 	if got := state.orphanBytesForPeer("127.0.0.1:3000"); got != 2 {
 		t.Fatalf("peer accounting bytes = %d, want 2", got)
 	}
+	state.setOrphanBytesForPeer("127.0.0.1:4000", 0)
+	if len(state.orphanBytesByPeerQuotaKey) != 0 {
+		t.Fatalf("peer accounting entries after zero update = %d, want 0", len(state.orphanBytesByPeerQuotaKey))
+	}
+}
+
+func TestDARelayDAIDAccountingDeletesZeroBytes(t *testing.T) {
+	state, err := newDARelayState(defaultDARelayCaps())
+	if err != nil {
+		t.Fatalf("new DA relay state: %v", err)
+	}
+
+	var daID [32]byte
+	daID[0] = 1
+	state.setOrphanBytesForDAID(daID, 2)
+	state.setOrphanBytesForDAID(daID, 0)
+
+	if len(state.orphanBytesByDAID) != 0 {
+		t.Fatalf("da_id accounting entries after zero update = %d, want 0", len(state.orphanBytesByDAID))
+	}
+	if got := state.orphanBytesForDAID(daID); got != 0 {
+		t.Fatalf("da_id accounting bytes = %d, want 0", got)
+	}
 }
 
 func TestDARelayReceivedTimeIsMonotonicLocalSequence(t *testing.T) {

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -69,8 +69,8 @@ func TestNewDARelayStateInitializesEmptyAccounting(t *testing.T) {
 	if state.orphanBytes != 0 {
 		t.Fatalf("orphan bytes = %d, want 0", state.orphanBytes)
 	}
-	if len(state.orphanBytesByPeer) != 0 {
-		t.Fatalf("orphan bytes by peer = %d entries, want 0", len(state.orphanBytesByPeer))
+	if len(state.orphanBytesByPeerQuotaKey) != 0 {
+		t.Fatalf("orphan bytes by peer quota key = %d entries, want 0", len(state.orphanBytesByPeerQuotaKey))
 	}
 	if len(state.orphanBytesByDAID) != 0 {
 		t.Fatalf("orphan bytes by da_id = %d entries, want 0", len(state.orphanBytesByDAID))
@@ -91,14 +91,31 @@ func TestNewDARelayStateInitializesWritableAccountingMaps(t *testing.T) {
 
 	var daID [32]byte
 	daID[0] = 1
-	state.orphanBytesByPeer["peer"] = 1
+	state.setOrphanBytesForPeer("peer", 1)
 	state.orphanBytesByDAID[daID] = 2
 
-	if state.orphanBytesByPeer["peer"] != 1 {
+	if state.orphanBytesForPeer("peer") != 1 {
 		t.Fatalf("orphan peer accounting map is not writable")
 	}
 	if state.orphanBytesByDAID[daID] != 2 {
 		t.Fatalf("orphan da_id accounting map is not writable")
+	}
+}
+
+func TestDARelayPeerAccountingUsesQuotaKey(t *testing.T) {
+	state, err := newDARelayState(defaultDARelayCaps())
+	if err != nil {
+		t.Fatalf("new DA relay state: %v", err)
+	}
+
+	state.setOrphanBytesForPeer("127.0.0.1:1000", 1)
+	state.setOrphanBytesForPeer("127.0.0.1:2000", 2)
+
+	if len(state.orphanBytesByPeerQuotaKey) != 1 {
+		t.Fatalf("peer accounting entries = %d, want 1", len(state.orphanBytesByPeerQuotaKey))
+	}
+	if got := state.orphanBytesForPeer("127.0.0.1:3000"); got != 2 {
+		t.Fatalf("peer accounting bytes = %d, want 2", got)
 	}
 }
 

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -92,12 +92,12 @@ func TestNewDARelayStateInitializesWritableAccountingMaps(t *testing.T) {
 	var daID [32]byte
 	daID[0] = 1
 	state.setOrphanBytesForPeer("peer", 1)
-	state.orphanBytesByDAID[daID] = 2
+	state.setOrphanBytesForDAID(daID, 2)
 
 	if state.orphanBytesForPeer("peer") != 1 {
 		t.Fatalf("orphan peer accounting map is not writable")
 	}
-	if state.orphanBytesByDAID[daID] != 2 {
+	if state.orphanBytesForDAID(daID) != 2 {
 		t.Fatalf("orphan da_id accounting map is not writable")
 	}
 }
@@ -152,6 +152,22 @@ func TestDARelayCapsRejectInvalidLimits(t *testing.T) {
 			caps: func() daRelayCaps {
 				caps := defaultDARelayCaps()
 				caps.orphanPoolPerPeerBytes = 0
+				return caps
+			}(),
+		},
+		{
+			name: "zero per da id orphan pool",
+			caps: func() daRelayCaps {
+				caps := defaultDARelayCaps()
+				caps.orphanPoolPerDAIDBytes = 0
+				return caps
+			}(),
+		},
+		{
+			name: "zero commit overhead",
+			caps: func() daRelayCaps {
+				caps := defaultDARelayCaps()
+				caps.orphanCommitOverheadBytes = 0
 				return caps
 			}(),
 		},

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -1,0 +1,188 @@
+package p2p
+
+import "testing"
+
+func TestDefaultDARelayCapsMatchSpec(t *testing.T) {
+	caps := defaultDARelayCaps()
+
+	tests := []struct {
+		name string
+		got  uint64
+		want uint64
+	}{
+		{name: "orphan pool", got: caps.orphanPoolBytes, want: 64 << 20},
+		{name: "per peer orphan pool", got: caps.orphanPoolPerPeerBytes, want: 4 << 20},
+		{name: "per da id orphan pool", got: caps.orphanPoolPerDAIDBytes, want: 8 << 20},
+		{name: "commit overhead", got: caps.orphanCommitOverheadBytes, want: 8 << 20},
+		{name: "ttl blocks", got: caps.orphanTTLBlocks, want: 3},
+		{name: "pinned payload", got: caps.pinnedPayloadBytes, want: 96_000_000},
+	}
+
+	for _, tt := range tests {
+		if tt.got != tt.want {
+			t.Fatalf("%s cap = %d, want %d", tt.name, tt.got, tt.want)
+		}
+	}
+
+	if err := caps.validate(); err != nil {
+		t.Fatalf("default caps should validate: %v", err)
+	}
+}
+
+func TestDARelayStatesAreDistinct(t *testing.T) {
+	states := map[daRelaySetState]bool{
+		daRelayStateOrphanChunks: true,
+		daRelayStateStagedCommit: true,
+		daRelayStateCompleteSet:  true,
+	}
+
+	if len(states) != 3 {
+		t.Fatalf("DA relay states are not distinct: got %d unique states", len(states))
+	}
+}
+
+func TestNewDARelayStateInitializesContainerOnly(t *testing.T) {
+	state, err := newDARelayState(defaultDARelayCaps())
+	if err != nil {
+		t.Fatalf("new DA relay state: %v", err)
+	}
+	if state == nil {
+		t.Fatal("new DA relay state returned nil")
+	}
+	if len(state.sets) != 0 {
+		t.Fatalf("new DA relay state should not contain live entries, got %d", len(state.sets))
+	}
+	if state.nextReceivedTime != 0 {
+		t.Fatalf("new DA relay state sequence = %d, want 0", state.nextReceivedTime)
+	}
+	if state.caps != defaultDARelayCaps() {
+		t.Fatalf("new DA relay state caps = %+v, want %+v", state.caps, defaultDARelayCaps())
+	}
+}
+
+func TestNewDARelayStateInitializesEmptyAccounting(t *testing.T) {
+	state, err := newDARelayState(defaultDARelayCaps())
+	if err != nil {
+		t.Fatalf("new DA relay state: %v", err)
+	}
+
+	if state.orphanBytes != 0 {
+		t.Fatalf("orphan bytes = %d, want 0", state.orphanBytes)
+	}
+	if len(state.orphanBytesByPeer) != 0 {
+		t.Fatalf("orphan bytes by peer = %d entries, want 0", len(state.orphanBytesByPeer))
+	}
+	if len(state.orphanBytesByDAID) != 0 {
+		t.Fatalf("orphan bytes by da_id = %d entries, want 0", len(state.orphanBytesByDAID))
+	}
+	if state.orphanCommitOverheadBytes != 0 {
+		t.Fatalf("orphan commit overhead bytes = %d, want 0", state.orphanCommitOverheadBytes)
+	}
+	if state.pinnedPayloadBytes != 0 {
+		t.Fatalf("pinned payload bytes = %d, want 0", state.pinnedPayloadBytes)
+	}
+}
+
+func TestNewDARelayStateInitializesWritableAccountingMaps(t *testing.T) {
+	state, err := newDARelayState(defaultDARelayCaps())
+	if err != nil {
+		t.Fatalf("new DA relay state: %v", err)
+	}
+
+	var daID [32]byte
+	daID[0] = 1
+	state.orphanBytesByPeer["peer"] = 1
+	state.orphanBytesByDAID[daID] = 2
+
+	if state.orphanBytesByPeer["peer"] != 1 {
+		t.Fatalf("orphan peer accounting map is not writable")
+	}
+	if state.orphanBytesByDAID[daID] != 2 {
+		t.Fatalf("orphan da_id accounting map is not writable")
+	}
+}
+
+func TestDARelayReceivedTimeIsMonotonicLocalSequence(t *testing.T) {
+	state, err := newDARelayState(defaultDARelayCaps())
+	if err != nil {
+		t.Fatalf("new DA relay state: %v", err)
+	}
+
+	first := state.nextMonotonicReceivedTime()
+	second := state.nextMonotonicReceivedTime()
+	third := state.nextMonotonicReceivedTime()
+
+	if first != 1 || second != 2 || third != 3 {
+		t.Fatalf("received_time sequence = %d, %d, %d; want 1, 2, 3", first, second, third)
+	}
+}
+
+func TestDARelayCapsRejectInvalidLimits(t *testing.T) {
+	tests := []struct {
+		name string
+		caps daRelayCaps
+	}{
+		{
+			name: "zero orphan pool",
+			caps: func() daRelayCaps {
+				caps := defaultDARelayCaps()
+				caps.orphanPoolBytes = 0
+				return caps
+			}(),
+		},
+		{
+			name: "zero per peer orphan pool",
+			caps: func() daRelayCaps {
+				caps := defaultDARelayCaps()
+				caps.orphanPoolPerPeerBytes = 0
+				return caps
+			}(),
+		},
+		{
+			name: "per peer exceeds global",
+			caps: func() daRelayCaps {
+				caps := defaultDARelayCaps()
+				caps.orphanPoolPerPeerBytes = caps.orphanPoolBytes + 1
+				return caps
+			}(),
+		},
+		{
+			name: "per da id exceeds global",
+			caps: func() daRelayCaps {
+				caps := defaultDARelayCaps()
+				caps.orphanPoolPerDAIDBytes = caps.orphanPoolBytes + 1
+				return caps
+			}(),
+		},
+		{
+			name: "commit overhead exceeds global",
+			caps: func() daRelayCaps {
+				caps := defaultDARelayCaps()
+				caps.orphanCommitOverheadBytes = caps.orphanPoolBytes + 1
+				return caps
+			}(),
+		},
+		{
+			name: "zero ttl",
+			caps: func() daRelayCaps {
+				caps := defaultDARelayCaps()
+				caps.orphanTTLBlocks = 0
+				return caps
+			}(),
+		},
+		{
+			name: "zero pinned payload",
+			caps: func() daRelayCaps {
+				caps := defaultDARelayCaps()
+				caps.pinnedPayloadBytes = 0
+				return caps
+			}(),
+		},
+	}
+
+	for _, tt := range tests {
+		if err := tt.caps.validate(); err == nil {
+			t.Fatalf("%s caps should fail validation", tt.name)
+		}
+	}
+}


### PR DESCRIPTION
Invariant:
Add the Go P2P DA relay state container and relay caps only. This PR does not wire live DA relay transitions, service admission, miner inclusion, or mempool behavior.

Layer:
Implementation and tests. No consensus change.

Files changed:
- clients/go/node/p2p/da_relay_state.go
- clients/go/node/p2p/da_relay_state_test.go

Tests:
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node/p2p -run "Da|DA|Relay" -count=1' -- PASS\n- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./...' -- PASS\n- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -race ./node/p2p -run "Da|DA|Relay" -count=1' -- PASS\n- git diff --check -- PASS\n- Rubin changed-file lizard medium-row helper -- PASS, 0 metric rows\n- rubin-precommit-one-review -- PASS\n- rubin-push with sanctioned stack-aware Codacy coverage wrapper -- PASS\n\nCoverage evidence:\n- stack-aware wrapper selected Go-only stack\n- variation: +0.04%\n- diff coverage: 97.73%\n- gates: variation >= -0.10%, diff >= 85.00%\n\nBehavior impact:\nAdds unexported DA relay caps, states, accounting container fields, constructor validation, normalized per-peer quota-key accounting helpers, mutex-protected DAID accounting helpers, and monotonic local received_time sequencing. The diff has no production caller outside the new file and tests.\n\nCompatibility impact:\nNo wire format, consensus, Rust, service, miner, or mempool compatibility change.\n\nKnown non-goals:\n- No live DA state transitions\n- No duplicate-commit handling\n- No TTL cleanup\n- No missing chunk prefetch\n- No miner COMPLETE_SET inclusion\n- No process smoke or combined soak claim\n\nRisk:\nSmall Go-only container surface. Main risks are future transition code depending on nil accounting maps, raw peer-address buckets, or unlocked map writes; tests assert initialized writable maps, normalized same-IP/different-port peer accounting, DAID helper access, and explicit zero-cap validation branches.\n\nRollback:\nRevert this PR; no live runtime path depends on the new container yet.\n\nNot checked:\nRust tests were not run because this is a Go-only diff and the stack-aware coverage wrapper selected Go only.\n\nRefs #1713

<!-- rubin-agent-meta actor=unknown action=pr-edit via=cl branch=codex/RUB-317-da-state-container wt=rubin-protocol-codex-RUB-317 utc=2026-05-24T21:25:46Z -->
