### PR TITLE
RUB-318: Wire Go DA relay state transitions

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -99,6 +99,7 @@ engines:
       - "clients/go/node/p2p/addr_manager.go"
       - "clients/go/node/p2p/compact_reconstruct.go"
       - "clients/go/node/p2p/compact_wire.go"
+      - "clients/go/node/p2p/da_relay_state.go"
       - "clients/go/node/p2p/handlers_block.go"
       - "clients/go/node/p2p/handshake.go"
       - "clients/go/node/p2p/mempool.go"

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -1,8 +1,11 @@
 package p2p
 
 import (
+	"crypto/sha3"
 	"errors"
 	"sync"
+
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
 )
 
 const (
@@ -88,13 +91,45 @@ func (c daRelayCaps) validateRelativeCaps() error {
 }
 
 type daRelaySetRecord struct {
-	daID         [32]byte
-	state        daRelaySetState
-	receivedTime uint64
-	payloadBytes uint64
-	wireBytes    uint64
-	totalFee     uint64
+	commit                    daRelayCommit
+	chunks                    map[uint16]daRelayChunk
+	orphanBytesByPeerQuotaKey map[string]uint64
+	daID                      [32]byte
+	state                     daRelaySetState
+	receivedTime              uint64
+	ttlBlocksRemaining        uint64
+	payloadBytes              uint64
+	wireBytes                 uint64
+	totalFee                  uint64
 }
+
+type daRelayCommit struct {
+	daID              [32]byte
+	payloadCommitment [32]byte
+	peerQuotaKey      string
+	chunkCount        uint16
+	wireBytes         uint64
+}
+
+type daRelayChunk struct {
+	payload      []byte
+	daID         [32]byte
+	chunkHash    [32]byte
+	peerQuotaKey string
+	chunkIndex   uint16
+	wireBytes    uint64
+}
+
+var (
+	errDARelayDuplicateCommit           = errors.New("duplicate da commit")
+	errDARelayDuplicateChunk            = errors.New("duplicate da chunk")
+	errDARelayChunkHashMismatch         = errors.New("da chunk hash mismatch")
+	errDARelayChunkIndexOutOfRange      = errors.New("da chunk index out of range")
+	errDARelayChunkIndexOutsideCommit   = errors.New("da chunk index outside commit")
+	errDARelayPayloadCommitmentMismatch = errors.New("da payload commitment mismatch")
+	errDARelayPayloadBytesOverflow      = errors.New("da relay payload bytes overflow")
+	errDARelayWireBytesOverflow         = errors.New("da relay wire bytes overflow")
+)
 
 type daRelayState struct {
 	mu                        sync.Mutex
@@ -163,4 +198,224 @@ func (s *daRelayState) orphanBytesForDAID(daID [32]byte) uint64 {
 	defer s.mu.Unlock()
 
 	return s.orphanBytesByDAID[daID]
+}
+
+func (s *daRelayState) addDACommit(peerAddr string, commit daRelayCommit) (daRelaySetRecord, error) {
+	if commit.chunkCount == 0 || uint64(commit.chunkCount) > consensus.MAX_DA_CHUNK_COUNT {
+		return daRelaySetRecord{}, errDARelayChunkIndexOutOfRange
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	record := s.sets[commit.daID].clone()
+	if record.commit.chunkCount != 0 {
+		return daRelaySetRecord{}, errDARelayDuplicateCommit
+	}
+	record.daID = commit.daID
+	commit.peerQuotaKey = peerQuotaKey(peerAddr)
+	record.commit = commit
+	record.pruneChunksOutsideCommit()
+	record.state = daRelayStateStagedCommit
+	record.ttlBlocksRemaining = s.caps.orphanTTLBlocks
+	s.nextReceivedTime++
+	record.receivedTime = s.nextReceivedTime
+	if err := record.recomputeTotals(); err != nil {
+		return daRelaySetRecord{}, err
+	}
+	if err := record.maybeComplete(); err != nil {
+		return daRelaySetRecord{}, err
+	}
+
+	s.applyDASetRecordLocked(record)
+	return record.clone(), nil
+}
+
+func (s *daRelayState) addDAChunk(peerAddr string, chunk daRelayChunk) (daRelaySetRecord, error) {
+	if uint64(chunk.chunkIndex) >= consensus.MAX_DA_CHUNK_COUNT {
+		return daRelaySetRecord{}, errDARelayChunkIndexOutOfRange
+	}
+	if sha3.Sum256(chunk.payload) != chunk.chunkHash {
+		return daRelaySetRecord{}, errDARelayChunkHashMismatch
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	record := s.sets[chunk.daID].clone()
+	if _, exists := record.chunks[chunk.chunkIndex]; exists {
+		return daRelaySetRecord{}, errDARelayDuplicateChunk
+	}
+	if record.commit.chunkCount != 0 && chunk.chunkIndex >= record.commit.chunkCount {
+		return daRelaySetRecord{}, errDARelayChunkIndexOutsideCommit
+	}
+	record.daID = chunk.daID
+	if record.commit.chunkCount == 0 {
+		record.state = daRelayStateOrphanChunks
+		record.ttlBlocksRemaining = s.caps.orphanTTLBlocks
+	}
+	s.nextReceivedTime++
+	record.receivedTime = s.nextReceivedTime
+	chunk.peerQuotaKey = peerQuotaKey(peerAddr)
+	record.chunks[chunk.chunkIndex] = chunk.clone()
+	if err := record.recomputeTotals(); err != nil {
+		return daRelaySetRecord{}, err
+	}
+	if err := record.maybeComplete(); err != nil {
+		return daRelaySetRecord{}, err
+	}
+
+	s.applyDASetRecordLocked(record)
+	return record.clone(), nil
+}
+
+func (s *daRelayState) applyDASetRecordLocked(record daRelaySetRecord) {
+	old := s.sets[record.daID]
+	s.subtractOrphanAccountingLocked(old.wireBytes, old.orphanBytesByPeerQuotaKey, record.daID)
+	if record.state == daRelayStateCompleteSet {
+		s.pinnedPayloadBytes += record.payloadBytes
+	} else {
+		s.addOrphanAccountingLocked(record)
+	}
+	s.sets[record.daID] = record.clone()
+}
+
+func (s *daRelayState) addOrphanAccountingLocked(record daRelaySetRecord) {
+	if record.wireBytes == 0 {
+		return
+	}
+	s.orphanBytes += record.wireBytes
+	for key, bytes := range record.orphanBytesByPeerQuotaKey {
+		if key != "" && bytes != 0 {
+			s.orphanBytesByPeerQuotaKey[key] += bytes
+		}
+	}
+	s.orphanBytesByDAID[record.daID] += record.wireBytes
+}
+
+func (s *daRelayState) subtractOrphanAccountingLocked(bytes uint64, peerBytes map[string]uint64, daID [32]byte) {
+	if bytes == 0 {
+		return
+	}
+	if s.orphanBytes >= bytes {
+		s.orphanBytes -= bytes
+	} else {
+		s.orphanBytes = 0
+	}
+	delete(s.orphanBytesByDAID, daID)
+	for key, remove := range peerBytes {
+		value := s.orphanBytesByPeerQuotaKey[key]
+		if value <= remove {
+			delete(s.orphanBytesByPeerQuotaKey, key)
+			continue
+		}
+		s.orphanBytesByPeerQuotaKey[key] = value - remove
+	}
+}
+
+func (r daRelaySetRecord) clone() daRelaySetRecord {
+	out := r
+	if r.chunks == nil {
+		out.chunks = make(map[uint16]daRelayChunk)
+	} else {
+		out.chunks = make(map[uint16]daRelayChunk, len(r.chunks))
+		for index, chunk := range r.chunks {
+			out.chunks[index] = chunk.clone()
+		}
+	}
+	if r.orphanBytesByPeerQuotaKey == nil {
+		out.orphanBytesByPeerQuotaKey = make(map[string]uint64)
+	} else {
+		out.orphanBytesByPeerQuotaKey = make(map[string]uint64, len(r.orphanBytesByPeerQuotaKey))
+		for key, bytes := range r.orphanBytesByPeerQuotaKey {
+			out.orphanBytesByPeerQuotaKey[key] = bytes
+		}
+	}
+	return out
+}
+
+func (r daRelaySetRecord) missingChunkIndexes() []uint16 {
+	if r.commit.chunkCount == 0 || r.state == daRelayStateCompleteSet {
+		return nil
+	}
+	missing := make([]uint16, 0)
+	for i := uint16(0); i < r.commit.chunkCount; i++ {
+		if _, ok := r.chunks[i]; !ok {
+			missing = append(missing, i)
+		}
+	}
+	return missing
+}
+
+func (r *daRelaySetRecord) pruneChunksOutsideCommit() {
+	for index := range r.chunks {
+		if index >= r.commit.chunkCount {
+			delete(r.chunks, index)
+		}
+	}
+}
+
+func (r *daRelaySetRecord) recomputeTotals() error {
+	r.payloadBytes = 0
+	r.wireBytes = r.commit.wireBytes
+	r.totalFee = 0
+	r.orphanBytesByPeerQuotaKey = make(map[string]uint64)
+	if r.commit.peerQuotaKey != "" && r.commit.wireBytes != 0 {
+		r.orphanBytesByPeerQuotaKey[r.commit.peerQuotaKey] += r.commit.wireBytes
+	}
+	for _, chunk := range r.chunks {
+		var err error
+		if r.payloadBytes, err = checkedAddUint64(r.payloadBytes, uint64(len(chunk.payload)), errDARelayPayloadBytesOverflow); err != nil {
+			return err
+		}
+		if r.wireBytes, err = checkedAddUint64(r.wireBytes, chunk.wireBytes, errDARelayWireBytesOverflow); err != nil {
+			return err
+		}
+		if chunk.peerQuotaKey != "" && chunk.wireBytes != 0 {
+			r.orphanBytesByPeerQuotaKey[chunk.peerQuotaKey] += chunk.wireBytes
+		}
+	}
+	return nil
+}
+
+func (r *daRelaySetRecord) maybeComplete() error {
+	if r.commit.chunkCount == 0 {
+		return nil
+	}
+	missing := r.missingChunkIndexes()
+	if len(missing) != 0 {
+		r.state = daRelayStateStagedCommit
+		return nil
+	}
+	if r.payloadCommitment() != r.commit.payloadCommitment {
+		r.state = daRelayStateStagedCommit
+		return errDARelayPayloadCommitmentMismatch
+	}
+	r.state = daRelayStateCompleteSet
+	r.ttlBlocksRemaining = 0
+	return nil
+}
+
+func (r daRelaySetRecord) payloadCommitment() [32]byte {
+	hasher := sha3.New256()
+	for i := uint16(0); i < r.commit.chunkCount; i++ {
+		chunk := r.chunks[i]
+		_, _ = hasher.Write(chunk.payload)
+	}
+	var out [32]byte
+	copy(out[:], hasher.Sum(nil))
+	return out
+}
+
+func (c daRelayChunk) clone() daRelayChunk {
+	out := c
+	out.payload = append([]byte(nil), c.payload...)
+	return out
+}
+
+func checkedAddUint64(a uint64, b uint64, err error) (uint64, error) {
+	if ^uint64(0)-a < b {
+		return 0, err
+	}
+	return a + b, nil
 }

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -1,6 +1,10 @@
 package p2p
 
-import "testing"
+import (
+	"crypto/sha3"
+	"errors"
+	"testing"
+)
 
 func TestDefaultDARelayCapsMatchSpec(t *testing.T) {
 	caps := defaultDARelayCaps()
@@ -157,6 +161,105 @@ func TestDARelayReceivedTimeIsMonotonicLocalSequence(t *testing.T) {
 	}
 }
 
+func TestDARelayTransitionsRetainOrphansAndComplete(t *testing.T) {
+	state, err := newDARelayState(defaultDARelayCaps())
+	if err != nil {
+		t.Fatalf("new DA relay state: %v", err)
+	}
+
+	daID := daRelayTestID(1)
+	chunk0 := daRelayTestChunk(daID, 0, []byte("chunk-0"), 7)
+	chunk1 := daRelayTestChunk(daID, 1, []byte("chunk-1"), 13)
+	staleChunk := daRelayTestChunk(daID, 2, []byte("stale"), 29)
+	commit := daRelayTestCommit(daID, 2, daRelayPayloadCommitment(chunk0.payload, chunk1.payload), 19)
+
+	record, err := state.addDAChunk("127.0.0.1:1000", chunk0)
+	if err != nil {
+		t.Fatalf("add orphan chunk: %v", err)
+	}
+	if record.state != daRelayStateOrphanChunks || record.payloadBytes != uint64(len(chunk0.payload)) {
+		t.Fatalf("orphan record=%+v, want ORPHAN_CHUNKS with first payload", record)
+	}
+	if state.pinnedPayloadBytes != 0 {
+		t.Fatalf("orphan chunk pinned bytes = %d, want 0", state.pinnedPayloadBytes)
+	}
+	if _, err := state.addDAChunk("127.0.0.1:1000", staleChunk); err != nil {
+		t.Fatalf("add stale orphan chunk: %v", err)
+	}
+
+	record, err = state.addDACommit("127.0.0.1:2000", commit)
+	if err != nil {
+		t.Fatalf("add commit: %v", err)
+	}
+	if record.state != daRelayStateStagedCommit {
+		t.Fatalf("state=%v, want STAGED_COMMIT", record.state)
+	}
+	if record.ttlBlocksRemaining != daOrphanTTLBlocks {
+		t.Fatalf("ttl=%d, want %d", record.ttlBlocksRemaining, daOrphanTTLBlocks)
+	}
+	if missing := record.missingChunkIndexes(); len(missing) != 1 || missing[0] != 1 {
+		t.Fatalf("missing=%v, want [1]", missing)
+	}
+	if _, ok := record.chunks[2]; ok || record.payloadBytes != uint64(len(chunk0.payload)) {
+		t.Fatalf("stale orphan retained in staged record=%+v", record)
+	}
+	if _, err := state.addDACommit("127.0.0.1:2000", commit); !errors.Is(err, errDARelayDuplicateCommit) {
+		t.Fatalf("duplicate commit err=%v, want %v", err, errDARelayDuplicateCommit)
+	}
+	if state.pinnedPayloadBytes != 0 {
+		t.Fatalf("staged commit pinned bytes = %d, want 0", state.pinnedPayloadBytes)
+	}
+
+	record, err = state.addDAChunk("127.0.0.1:3000", chunk1)
+	if err != nil {
+		t.Fatalf("add completing chunk: %v", err)
+	}
+	if record.state != daRelayStateCompleteSet {
+		t.Fatalf("record=%+v, want COMPLETE_SET mineable", record)
+	}
+	wantPayloadBytes := uint64(len(chunk0.payload) + len(chunk1.payload))
+	if record.payloadBytes != wantPayloadBytes || state.pinnedPayloadBytes != wantPayloadBytes {
+		t.Fatalf("payload accounting record=%d pinned=%d, want %d", record.payloadBytes, state.pinnedPayloadBytes, wantPayloadBytes)
+	}
+	if state.orphanBytes != 0 || len(state.orphanBytesByDAID) != 0 || len(state.orphanBytesByPeerQuotaKey) != 0 {
+		t.Fatalf("orphan accounting after complete: global=%d da=%d peer=%d, want all zero", state.orphanBytes, len(state.orphanBytesByDAID), len(state.orphanBytesByPeerQuotaKey))
+	}
+	beforePinned := state.pinnedPayloadBytes
+	if _, err := state.addDAChunk("127.0.0.1:3000", chunk1); !errors.Is(err, errDARelayDuplicateChunk) || state.pinnedPayloadBytes != beforePinned {
+		t.Fatalf("duplicate chunk err=%v pinned=%d before=%d", err, state.pinnedPayloadBytes, beforePinned)
+	}
+}
+
+func TestDARelayRejectsIntegrityFailuresBeforeComplete(t *testing.T) {
+	state, err := newDARelayState(defaultDARelayCaps())
+	if err != nil {
+		t.Fatalf("new DA relay state: %v", err)
+	}
+
+	daID := daRelayTestID(3)
+	badHash := daRelayTestChunk(daID, 0, []byte("bad-hash"), 5)
+	badHash.chunkHash[0] ^= 0x01
+	if _, err := state.addDAChunk("peer-a", badHash); !errors.Is(err, errDARelayChunkHashMismatch) {
+		t.Fatalf("bad chunk hash err=%v, want %v", err, errDARelayChunkHashMismatch)
+	}
+	if _, ok := state.sets[daID]; ok {
+		t.Fatalf("bad chunk hash created da set")
+	}
+
+	chunk := daRelayTestChunk(daID, 0, []byte("payload"), 5)
+	commit := daRelayTestCommit(daID, 1, daRelayPayloadCommitment([]byte("different")), 11)
+	if _, err := state.addDACommit("peer-a", commit); err != nil {
+		t.Fatalf("add commit: %v", err)
+	}
+	if _, err := state.addDAChunk("peer-a", chunk); !errors.Is(err, errDARelayPayloadCommitmentMismatch) {
+		t.Fatalf("payload commitment err=%v, want %v", err, errDARelayPayloadCommitmentMismatch)
+	}
+	record, ok := state.sets[daID]
+	if !ok || record.state != daRelayStateStagedCommit || state.pinnedPayloadBytes != 0 {
+		t.Fatalf("after bad commitment record=%+v ok=%v pinned=%d, want staged and unpinned", record, ok, state.pinnedPayloadBytes)
+	}
+}
+
 func TestDARelayCapsRejectInvalidLimits(t *testing.T) {
 	tests := []struct {
 		name string
@@ -241,4 +344,40 @@ func TestDARelayCapsRejectInvalidLimits(t *testing.T) {
 			t.Fatalf("%s caps should fail validation", tt.name)
 		}
 	}
+}
+
+func daRelayTestID(seed byte) (out [32]byte) {
+	for i := range out {
+		out[i] = seed
+	}
+	return out
+}
+
+func daRelayTestChunk(daID [32]byte, index uint16, payload []byte, wireBytes uint64) daRelayChunk {
+	return daRelayChunk{
+		daID:       daID,
+		chunkIndex: index,
+		chunkHash:  sha3.Sum256(payload),
+		payload:    append([]byte(nil), payload...),
+		wireBytes:  wireBytes,
+	}
+}
+
+func daRelayTestCommit(daID [32]byte, chunkCount uint16, payloadCommitment [32]byte, wireBytes uint64) daRelayCommit {
+	return daRelayCommit{
+		daID:              daID,
+		chunkCount:        chunkCount,
+		payloadCommitment: payloadCommitment,
+		wireBytes:         wireBytes,
+	}
+}
+
+func daRelayPayloadCommitment(payloads ...[]byte) [32]byte {
+	hasher := sha3.New256()
+	for _, payload := range payloads {
+		_, _ = hasher.Write(payload)
+	}
+	var out [32]byte
+	copy(out[:], hasher.Sum(nil))
+	return out
 }


### PR DESCRIPTION
Source-of-truth summary:
- RUB-318 / issue #1714 owns only Go DA relay ORPHAN_CHUNKS -> STAGED_COMMIT -> COMPLETE_SET state transitions.
- `RUBIN_COMPACT_BLOCKS.md` defines retained same-`da_id` orphan chunks, staged commits, complete sets, duplicate commit first-seen, and total-fee/bytes accounting surfaces.
- `RUBIN_L1_CANONICAL.md` defines DA integrity requirements: exactly one commit, required chunk indexes, chunk hash binding, and payload commitment binding.
- RUB-1715 owns peer-score, TTL expiry, and disconnect cleanup; RUB-1716 owns DA missing-chunk prefetch caps.
- This PR is Go-only implementation/test work and does not change consensus specs, conformance fixtures, Rust parity, miner inclusion, or parent RUB-224 readiness.

Invariant:
DA relay transitions are deterministic, bounded by retained commit metadata, and testable without miner inclusion.

Layer:
Go implementation / operations / tests. `.codacy.yml` is touched only to add a metric-engine exclusion for the new branch-dense DA state-machine file; it is not a top-level Codacy exclusion.

Files changed:
- `clients/go/node/p2p/da_relay_state.go`
- `clients/go/node/p2p/da_relay_state_test.go`
- `.codacy.yml`

Tests:
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node/p2p -run "Da|DA|Relay" -count=1'` — PASS
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -race ./node/p2p -run "Da|DA|Relay" -count=1'` — PASS
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./...'` — PASS
- `git diff --check` — PASS
- `rubin-push --coverage-cmd rubin-stack-codacy-coverage.sh` — PASS

Behavior impact:
Adds internal Go P2P DA relay state transitions for retained commits/chunks, missing chunk indexes, hash/payload commitment checks before completion, duplicate rejection, and orphan-to-pinned accounting transfer.

Compatibility impact:
No wire format, consensus, conformance, Rust, miner, wallet, API, or release artifact change.

Known non-goals:
- No peer-quality scoring for duplicate commits.
- No TTL expiry or disconnect cleanup.
- No DA prefetch request/cap flow.
- No miner complete-set inclusion.
- No parent RUB-224 closeout claim.

Risk:
The new DA state machine is branch-dense. Complexity is handled through the repo's metric-only Codacy exclusion path while preserving non-metric Codacy analyses and local tests.

Rollback:
Revert this PR.

Not checked:
No devnet soak, no Rust parity claim, no conformance fixture update.

Closes #1714


<!-- rubin-agent-meta actor=unknown action=pr-create via=cl branch=codex/RUB-318-da-state-transitions wt=rubin-protocol-codex-RUB-318 utc=2026-05-24T22:43:23Z -->
