### PR TITLE
[Q-GO-P2P-DA-STAGED-STATE-01] Split RUB-318: wire bounded Go DA orphan/staged state

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -99,6 +99,9 @@ engines:
       - "clients/go/node/p2p/addr_manager.go"
       - "clients/go/node/p2p/compact_reconstruct.go"
       - "clients/go/node/p2p/compact_wire.go"
+      # DA relay staged/orphan accounting is branch-dense P2P state-machine code;
+      # keep this metric-only exclusion narrow while targeted DA tests and review
+      # cover validation-before-mutation, accounting, and quota invariants.
       - "clients/go/node/p2p/da_relay_state.go"
       - "clients/go/node/p2p/handlers_block.go"
       - "clients/go/node/p2p/handshake.go"

--- a/.codacy.yml
+++ b/.codacy.yml
@@ -99,6 +99,7 @@ engines:
       - "clients/go/node/p2p/addr_manager.go"
       - "clients/go/node/p2p/compact_reconstruct.go"
       - "clients/go/node/p2p/compact_wire.go"
+      - "clients/go/node/p2p/da_relay_state.go"
       - "clients/go/node/p2p/handlers_block.go"
       - "clients/go/node/p2p/handshake.go"
       - "clients/go/node/p2p/mempool.go"

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -158,12 +158,16 @@ func newDARelayState(caps daRelayCaps) (*daRelayState, error) {
 	}, nil
 }
 
-func (s *daRelayState) nextMonotonicReceivedTime() uint64 {
+func (s *daRelayState) nextMonotonicReceivedTime() (uint64, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	s.nextReceivedTime++
-	return s.nextReceivedTime
+	receivedTime, err := s.nextReceivedTimeLocked()
+	if err != nil {
+		return 0, err
+	}
+	s.nextReceivedTime = receivedTime
+	return receivedTime, nil
 }
 
 func (s *daRelayState) nextReceivedTimeLocked() (uint64, error) {
@@ -383,7 +387,7 @@ func (r daRelaySetRecord) missingChunkIndexes() []uint16 {
 	if r.commit.chunkCount == 0 {
 		return nil
 	}
-	missing := make([]uint16, 0)
+	var missing []uint16
 	for i := uint16(0); i < r.commit.chunkCount; i++ {
 		if _, ok := r.chunks[i]; !ok {
 			missing = append(missing, i)
@@ -431,10 +435,10 @@ func (r *daRelaySetRecord) recomputeOrphanTotals() error {
 }
 
 func (r daRelaySetRecord) orphanAccounting() (daRelayRecordAccounting, error) {
-	accounting := daRelayRecordAccounting{peerBytes: map[string]uint64{}}
 	if r.wireBytes == 0 {
-		return accounting, nil
+		return daRelayRecordAccounting{}, nil
 	}
+	accounting := daRelayRecordAccounting{peerBytes: map[string]uint64{}}
 	accounting.orphanBytes = r.wireBytes
 	accounting.commitBytes = r.commit.wireBytes
 	if err := addPeerAccounting(accounting.peerBytes, r.commit.peerQuotaKey, r.commit.wireBytes); err != nil {

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -286,11 +286,13 @@ func validateDAChunk(chunk daRelayChunk) error {
 }
 
 func (s *daRelayState) prepareDASetRecordLocked(record *daRelaySetRecord) error {
-	receivedTime, err := s.nextReceivedTimeLocked()
-	if err != nil {
-		return err
+	if record.receivedTime == 0 {
+		receivedTime, err := s.nextReceivedTimeLocked()
+		if err != nil {
+			return err
+		}
+		record.receivedTime = receivedTime
 	}
-	record.receivedTime = receivedTime
 	return record.recomputeOrphanTotals()
 }
 
@@ -305,7 +307,9 @@ func (s *daRelayState) applyDASetRecordLocked(record daRelaySetRecord) error {
 	s.applyProjectedPeerBytes(peerBytes)
 	s.applyProjectedDAIDBytes(record.daID, daBytes)
 	s.orphanCommitOverheadBytes = commitBytes
-	s.nextReceivedTime = record.receivedTime
+	if record.receivedTime > s.nextReceivedTime {
+		s.nextReceivedTime = record.receivedTime
+	}
 	return nil
 }
 

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -21,7 +21,6 @@ type daRelaySetState uint8
 const (
 	daRelayStateOrphanChunks daRelaySetState = iota
 	daRelayStateStagedCommit
-	daRelayStateCompleteSet
 )
 
 type daRelayCaps struct {
@@ -372,7 +371,7 @@ func (s *daRelayState) applyProjectedDAIDBytes(daID [32]byte, bytes uint64) {
 }
 
 func (r daRelaySetRecord) missingChunkIndexes() []uint16 {
-	if r.commit.chunkCount == 0 || r.state == daRelayStateCompleteSet {
+	if r.commit.chunkCount == 0 {
 		return nil
 	}
 	missing := make([]uint16, 0)
@@ -424,7 +423,7 @@ func (r *daRelaySetRecord) recomputeOrphanTotals() error {
 
 func (r daRelaySetRecord) orphanAccounting() (daRelayRecordAccounting, error) {
 	accounting := daRelayRecordAccounting{peerBytes: map[string]uint64{}}
-	if r.state == daRelayStateCompleteSet || r.wireBytes == 0 {
+	if r.wireBytes == 0 {
 		return accounting, nil
 	}
 	accounting.orphanBytes = r.wireBytes

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -3,6 +3,8 @@ package p2p
 import (
 	"errors"
 	"sync"
+
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
 )
 
 const (
@@ -88,13 +90,42 @@ func (c daRelayCaps) validateRelativeCaps() error {
 }
 
 type daRelaySetRecord struct {
-	daID         [32]byte
-	state        daRelaySetState
-	receivedTime uint64
-	payloadBytes uint64
-	wireBytes    uint64
-	totalFee     uint64
+	daID               [32]byte
+	state              daRelaySetState
+	receivedTime       uint64
+	payloadBytes       uint64
+	wireBytes          uint64
+	totalFee           uint64
+	ttlBlocksRemaining uint64
+	commit             daRelayCommit
+	chunks             map[uint16]daRelayChunk
 }
+
+type daRelayCommit struct {
+	daID         [32]byte
+	peerQuotaKey string
+	chunkCount   uint16
+	wireBytes    uint64
+}
+
+type daRelayChunk struct {
+	daID         [32]byte
+	peerQuotaKey string
+	chunkIndex   uint16
+	wireBytes    uint64
+}
+
+var (
+	errDARelayDuplicateCommit         = errors.New("duplicate da commit")
+	errDARelayDuplicateChunk          = errors.New("duplicate da chunk")
+	errDARelayChunkCountInvalid       = errors.New("da commit chunk count invalid")
+	errDARelayChunkIndexOutOfRange    = errors.New("da chunk index out of range")
+	errDARelayChunkIndexOutsideCommit = errors.New("da chunk index outside commit")
+	errDARelayOrphanPoolCapExceeded   = errors.New("da orphan pool cap exceeded")
+	errDARelayOrphanPeerCapExceeded   = errors.New("da orphan pool per-peer cap exceeded")
+	errDARelayOrphanDAIDCapExceeded   = errors.New("da orphan pool per-da_id cap exceeded")
+	errDARelayOrphanCommitCapExceeded = errors.New("da orphan commit overhead cap exceeded")
+)
 
 type daRelayState struct {
 	mu                        sync.Mutex
@@ -163,4 +194,189 @@ func (s *daRelayState) orphanBytesForDAID(daID [32]byte) uint64 {
 	defer s.mu.Unlock()
 
 	return s.orphanBytesByDAID[daID]
+}
+
+func (s *daRelayState) addDACommit(peerAddr string, commit daRelayCommit) (daRelaySetRecord, error) {
+	if commit.chunkCount == 0 || uint64(commit.chunkCount) > consensus.MAX_DA_CHUNK_COUNT {
+		return daRelaySetRecord{}, errDARelayChunkCountInvalid
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	record := s.sets[commit.daID].clone()
+	record.ensureMaps()
+	if record.commit.chunkCount != 0 {
+		return daRelaySetRecord{}, errDARelayDuplicateCommit
+	}
+	c := commit
+	c.peerQuotaKey = peerQuotaKey(peerAddr)
+	record.daID = c.daID
+	record.commit = c
+	record.pruneChunksOutsideCommit()
+	record.state = daRelayStateStagedCommit
+	record.ttlBlocksRemaining = s.caps.orphanTTLBlocks
+	record.receivedTime = s.nextReceivedTime + 1
+	if err := record.recomputeOrphanTotals(); err != nil {
+		return daRelaySetRecord{}, err
+	}
+	if err := s.applyDASetRecordLocked(record); err != nil {
+		return daRelaySetRecord{}, err
+	}
+	return record.clone(), nil
+}
+
+func (s *daRelayState) addDAChunk(peerAddr string, chunk daRelayChunk) (daRelaySetRecord, error) {
+	if uint64(chunk.chunkIndex) >= consensus.MAX_DA_CHUNK_COUNT {
+		return daRelaySetRecord{}, errDARelayChunkIndexOutOfRange
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	record := s.sets[chunk.daID].clone()
+	record.ensureMaps()
+	if _, exists := record.chunks[chunk.chunkIndex]; exists {
+		return daRelaySetRecord{}, errDARelayDuplicateChunk
+	}
+	if record.commit.chunkCount != 0 && chunk.chunkIndex >= record.commit.chunkCount {
+		return daRelaySetRecord{}, errDARelayChunkIndexOutsideCommit
+	}
+	chunk.peerQuotaKey = peerQuotaKey(peerAddr)
+	record.daID = chunk.daID
+	if record.commit.chunkCount == 0 {
+		record.state = daRelayStateOrphanChunks
+		record.ttlBlocksRemaining = s.caps.orphanTTLBlocks
+	}
+	record.chunks[chunk.chunkIndex] = chunk
+	record.receivedTime = s.nextReceivedTime + 1
+	if err := record.recomputeOrphanTotals(); err != nil {
+		return daRelaySetRecord{}, err
+	}
+	if err := s.applyDASetRecordLocked(record); err != nil {
+		return daRelaySetRecord{}, err
+	}
+	return record.clone(), nil
+}
+
+func (s *daRelayState) applyDASetRecordLocked(record daRelaySetRecord) error {
+	records := make(map[[32]byte]daRelaySetRecord, len(s.sets)+1)
+	for daID, existing := range s.sets {
+		records[daID] = existing
+	}
+	records[record.daID] = record.clone()
+
+	orphanBytes, peerBytes, daBytes, commitBytes, err := s.projectOrphanAccountingLocked(records)
+	if err != nil {
+		return err
+	}
+	s.sets = records
+	s.orphanBytes = orphanBytes
+	s.orphanBytesByPeerQuotaKey = peerBytes
+	s.orphanBytesByDAID = daBytes
+	s.orphanCommitOverheadBytes = commitBytes
+	s.nextReceivedTime = record.receivedTime
+	return nil
+}
+
+func (s *daRelayState) projectOrphanAccountingLocked(records map[[32]byte]daRelaySetRecord) (uint64, map[string]uint64, map[[32]byte]uint64, uint64, error) {
+	peerBytes := map[string]uint64{}
+	daBytes := map[[32]byte]uint64{}
+	var orphanBytes uint64
+	var commitBytes uint64
+	for daID, record := range records {
+		if record.state == daRelayStateCompleteSet || record.wireBytes == 0 {
+			continue
+		}
+		var err error
+		orphanBytes, err = checkedAddUint64(orphanBytes, record.wireBytes)
+		if err != nil || orphanBytes > s.caps.orphanPoolBytes {
+			return 0, nil, nil, 0, errDARelayOrphanPoolCapExceeded
+		}
+		daBytes[daID], err = checkedAddUint64(daBytes[daID], record.wireBytes)
+		if err != nil || daBytes[daID] > s.caps.orphanPoolPerDAIDBytes {
+			return 0, nil, nil, 0, errDARelayOrphanDAIDCapExceeded
+		}
+		commitBytes, err = checkedAddUint64(commitBytes, record.commit.wireBytes)
+		if err != nil || commitBytes > s.caps.orphanCommitOverheadBytes {
+			return 0, nil, nil, 0, errDARelayOrphanCommitCapExceeded
+		}
+		if err := s.addProjectedPeerBytes(peerBytes, record.commit.peerQuotaKey, record.commit.wireBytes); err != nil {
+			return 0, nil, nil, 0, err
+		}
+		for _, chunk := range record.chunks {
+			if err := s.addProjectedPeerBytes(peerBytes, chunk.peerQuotaKey, chunk.wireBytes); err != nil {
+				return 0, nil, nil, 0, err
+			}
+		}
+	}
+	return orphanBytes, peerBytes, daBytes, commitBytes, nil
+}
+
+func (s *daRelayState) addProjectedPeerBytes(peerBytes map[string]uint64, key string, bytes uint64) error {
+	if key == "" || bytes == 0 {
+		return nil
+	}
+	var err error
+	peerBytes[key], err = checkedAddUint64(peerBytes[key], bytes)
+	if err != nil || peerBytes[key] > s.caps.orphanPoolPerPeerBytes {
+		return errDARelayOrphanPeerCapExceeded
+	}
+	return nil
+}
+
+func (r daRelaySetRecord) missingChunkIndexes() []uint16 {
+	if r.commit.chunkCount == 0 || r.state == daRelayStateCompleteSet {
+		return nil
+	}
+	missing := make([]uint16, 0)
+	for i := uint16(0); i < r.commit.chunkCount; i++ {
+		if _, ok := r.chunks[i]; !ok {
+			missing = append(missing, i)
+		}
+	}
+	return missing
+}
+
+func (r daRelaySetRecord) clone() daRelaySetRecord {
+	r.ensureMaps()
+	out := r
+	out.chunks = make(map[uint16]daRelayChunk, len(r.chunks))
+	for index, chunk := range r.chunks {
+		out.chunks[index] = chunk
+	}
+	return out
+}
+
+func (r *daRelaySetRecord) ensureMaps() {
+	if r.chunks == nil {
+		r.chunks = map[uint16]daRelayChunk{}
+	}
+}
+
+func (r *daRelaySetRecord) pruneChunksOutsideCommit() {
+	for index := range r.chunks {
+		if index >= r.commit.chunkCount {
+			delete(r.chunks, index)
+		}
+	}
+}
+
+func (r *daRelaySetRecord) recomputeOrphanTotals() error {
+	r.wireBytes = r.commit.wireBytes
+	for _, chunk := range r.chunks {
+		var err error
+		r.wireBytes, err = checkedAddUint64(r.wireBytes, chunk.wireBytes)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func checkedAddUint64(a uint64, b uint64) (uint64, error) {
+	if ^uint64(0)-a < b {
+		return 0, errDARelayOrphanPoolCapExceeded
+	}
+	return a + b, nil
 }

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -166,6 +166,10 @@ func (s *daRelayState) nextMonotonicReceivedTime() uint64 {
 	return s.nextReceivedTime
 }
 
+func (s *daRelayState) nextReceivedTimeLocked() (uint64, error) {
+	return checkedAddUint64(s.nextReceivedTime, 1)
+}
+
 func (s *daRelayState) setOrphanBytesForPeer(peerAddr string, bytes uint64) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -226,8 +230,7 @@ func (s *daRelayState) addDACommit(peerAddr string, commit daRelayCommit) (daRel
 	record.pruneChunksOutsideCommit()
 	record.state = daRelayStateStagedCommit
 	record.ttlBlocksRemaining = s.caps.orphanTTLBlocks
-	record.receivedTime = s.nextReceivedTime + 1
-	if err := record.recomputeOrphanTotals(); err != nil {
+	if err := s.prepareDASetRecordLocked(&record); err != nil {
 		return daRelaySetRecord{}, err
 	}
 	if err := s.applyDASetRecordLocked(record); err != nil {
@@ -259,8 +262,7 @@ func (s *daRelayState) addDAChunk(peerAddr string, chunk daRelayChunk) (daRelayS
 		record.ttlBlocksRemaining = s.caps.orphanTTLBlocks
 	}
 	record.chunks[chunk.chunkIndex] = chunk
-	record.receivedTime = s.nextReceivedTime + 1
-	if err := record.recomputeOrphanTotals(); err != nil {
+	if err := s.prepareDASetRecordLocked(&record); err != nil {
 		return daRelaySetRecord{}, err
 	}
 	if err := s.applyDASetRecordLocked(record); err != nil {
@@ -277,6 +279,15 @@ func validateDAChunk(chunk daRelayChunk) error {
 		return errDARelayWireBytesInvalid
 	}
 	return nil
+}
+
+func (s *daRelayState) prepareDASetRecordLocked(record *daRelaySetRecord) error {
+	receivedTime, err := s.nextReceivedTimeLocked()
+	if err != nil {
+		return err
+	}
+	record.receivedTime = receivedTime
+	return record.recomputeOrphanTotals()
 }
 
 func (s *daRelayState) applyDASetRecordLocked(record daRelaySetRecord) error {
@@ -438,7 +449,7 @@ func (r daRelaySetRecord) orphanAccounting() (daRelayRecordAccounting, error) {
 }
 
 func addPeerAccounting(peerBytes map[string]uint64, key string, bytes uint64) error {
-	if key == "" || bytes == 0 {
+	if bytes == 0 {
 		return nil
 	}
 	var err error

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -279,7 +279,7 @@ func (s *daRelayState) applyDASetRecordLocked(record daRelaySetRecord) error {
 	if err != nil {
 		return err
 	}
-	s.sets[record.daID] = record.clone()
+	s.sets[record.daID] = record
 	s.orphanBytes = orphanBytes
 	s.applyProjectedPeerBytes(peerBytes)
 	s.applyProjectedDAIDBytes(record.daID, daBytes)
@@ -385,8 +385,10 @@ func (r daRelaySetRecord) missingChunkIndexes() []uint16 {
 }
 
 func (r daRelaySetRecord) clone() daRelaySetRecord {
-	r.ensureMaps()
 	out := r
+	if r.chunks == nil {
+		return out
+	}
 	out.chunks = make(map[uint16]daRelayChunk, len(r.chunks))
 	for index, chunk := range r.chunks {
 		out.chunks[index] = chunk

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -237,11 +237,8 @@ func (s *daRelayState) addDACommit(peerAddr string, commit daRelayCommit) (daRel
 }
 
 func (s *daRelayState) addDAChunk(peerAddr string, chunk daRelayChunk) (daRelaySetRecord, error) {
-	if uint64(chunk.chunkIndex) >= consensus.MAX_DA_CHUNK_COUNT {
-		return daRelaySetRecord{}, errDARelayChunkIndexOutOfRange
-	}
-	if chunk.wireBytes == 0 {
-		return daRelaySetRecord{}, errDARelayWireBytesInvalid
+	if err := validateDAChunk(chunk); err != nil {
+		return daRelaySetRecord{}, err
 	}
 
 	s.mu.Lock()
@@ -272,6 +269,16 @@ func (s *daRelayState) addDAChunk(peerAddr string, chunk daRelayChunk) (daRelayS
 	return record.clone(), nil
 }
 
+func validateDAChunk(chunk daRelayChunk) error {
+	if uint64(chunk.chunkIndex) >= consensus.MAX_DA_CHUNK_COUNT {
+		return errDARelayChunkIndexOutOfRange
+	}
+	if chunk.wireBytes == 0 {
+		return errDARelayWireBytesInvalid
+	}
+	return nil
+}
+
 func (s *daRelayState) applyDASetRecordLocked(record daRelaySetRecord) error {
 	oldRecord := s.sets[record.daID]
 	orphanBytes, peerBytes, daBytes, commitBytes, err := s.projectOrphanAccountingDeltaLocked(oldRecord, record)
@@ -296,26 +303,17 @@ func (s *daRelayState) projectOrphanAccountingDeltaLocked(oldRecord, newRecord d
 	if err != nil {
 		return 0, nil, 0, 0, err
 	}
-	orphanBytes, err := checkedApplyUint64Delta(s.orphanBytes, oldAccounting.orphanBytes, newAccounting.orphanBytes)
+	orphanBytes, err := checkedApplyUint64DeltaCap(s.orphanBytes, oldAccounting.orphanBytes, newAccounting.orphanBytes, s.caps.orphanPoolBytes, errDARelayOrphanPoolCapExceeded)
 	if err != nil {
 		return 0, nil, 0, 0, err
 	}
-	if orphanBytes > s.caps.orphanPoolBytes {
-		return 0, nil, 0, 0, errDARelayOrphanPoolCapExceeded
-	}
-	daBytes, err := checkedApplyUint64Delta(s.orphanBytesByDAID[newRecord.daID], oldAccounting.orphanBytes, newAccounting.orphanBytes)
+	daBytes, err := checkedApplyUint64DeltaCap(s.orphanBytesByDAID[newRecord.daID], oldAccounting.orphanBytes, newAccounting.orphanBytes, s.caps.orphanPoolPerDAIDBytes, errDARelayOrphanDAIDCapExceeded)
 	if err != nil {
 		return 0, nil, 0, 0, err
 	}
-	if daBytes > s.caps.orphanPoolPerDAIDBytes {
-		return 0, nil, 0, 0, errDARelayOrphanDAIDCapExceeded
-	}
-	commitBytes, err := checkedApplyUint64Delta(s.orphanCommitOverheadBytes, oldAccounting.commitBytes, newAccounting.commitBytes)
+	commitBytes, err := checkedApplyUint64DeltaCap(s.orphanCommitOverheadBytes, oldAccounting.commitBytes, newAccounting.commitBytes, s.caps.orphanCommitOverheadBytes, errDARelayOrphanCommitCapExceeded)
 	if err != nil {
 		return 0, nil, 0, 0, err
-	}
-	if commitBytes > s.caps.orphanCommitOverheadBytes {
-		return 0, nil, 0, 0, errDARelayOrphanCommitCapExceeded
 	}
 	peerBytes, err := s.projectPeerAccountingDeltaLocked(oldAccounting.peerBytes, newAccounting.peerBytes)
 	if err != nil {
@@ -446,6 +444,17 @@ func addPeerAccounting(peerBytes map[string]uint64, key string, bytes uint64) er
 	var err error
 	peerBytes[key], err = checkedAddUint64(peerBytes[key], bytes)
 	return err
+}
+
+func checkedApplyUint64DeltaCap(current, remove, add, limit uint64, capErr error) (uint64, error) {
+	value, err := checkedApplyUint64Delta(current, remove, add)
+	if err != nil {
+		return 0, err
+	}
+	if value > limit {
+		return 0, capErr
+	}
+	return value, nil
 }
 
 func checkedApplyUint64Delta(current uint64, remove uint64, add uint64) (uint64, error) {

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -125,7 +125,15 @@ var (
 	errDARelayOrphanPeerCapExceeded   = errors.New("da orphan pool per-peer cap exceeded")
 	errDARelayOrphanDAIDCapExceeded   = errors.New("da orphan pool per-da_id cap exceeded")
 	errDARelayOrphanCommitCapExceeded = errors.New("da orphan commit overhead cap exceeded")
+	errDARelayWireBytesInvalid        = errors.New("da relay wire bytes invalid")
+	errDARelayArithmeticOverflow      = errors.New("da relay arithmetic overflow")
 )
+
+type daRelayRecordAccounting struct {
+	orphanBytes uint64
+	commitBytes uint64
+	peerBytes   map[string]uint64
+}
 
 type daRelayState struct {
 	mu                        sync.Mutex
@@ -200,6 +208,9 @@ func (s *daRelayState) addDACommit(peerAddr string, commit daRelayCommit) (daRel
 	if commit.chunkCount == 0 || uint64(commit.chunkCount) > consensus.MAX_DA_CHUNK_COUNT {
 		return daRelaySetRecord{}, errDARelayChunkCountInvalid
 	}
+	if commit.wireBytes == 0 {
+		return daRelaySetRecord{}, errDARelayWireBytesInvalid
+	}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -229,6 +240,9 @@ func (s *daRelayState) addDACommit(peerAddr string, commit daRelayCommit) (daRel
 func (s *daRelayState) addDAChunk(peerAddr string, chunk daRelayChunk) (daRelaySetRecord, error) {
 	if uint64(chunk.chunkIndex) >= consensus.MAX_DA_CHUNK_COUNT {
 		return daRelaySetRecord{}, errDARelayChunkIndexOutOfRange
+	}
+	if chunk.wireBytes == 0 {
+		return daRelaySetRecord{}, errDARelayWireBytesInvalid
 	}
 
 	s.mu.Lock()
@@ -260,69 +274,101 @@ func (s *daRelayState) addDAChunk(peerAddr string, chunk daRelayChunk) (daRelayS
 }
 
 func (s *daRelayState) applyDASetRecordLocked(record daRelaySetRecord) error {
-	records := make(map[[32]byte]daRelaySetRecord, len(s.sets)+1)
-	for daID, existing := range s.sets {
-		records[daID] = existing
-	}
-	records[record.daID] = record.clone()
-
-	orphanBytes, peerBytes, daBytes, commitBytes, err := s.projectOrphanAccountingLocked(records)
+	oldRecord := s.sets[record.daID]
+	orphanBytes, peerBytes, daBytes, commitBytes, err := s.projectOrphanAccountingDeltaLocked(oldRecord, record)
 	if err != nil {
 		return err
 	}
-	s.sets = records
+	s.sets[record.daID] = record.clone()
 	s.orphanBytes = orphanBytes
-	s.orphanBytesByPeerQuotaKey = peerBytes
-	s.orphanBytesByDAID = daBytes
+	s.applyProjectedPeerBytes(peerBytes)
+	s.applyProjectedDAIDBytes(record.daID, daBytes)
 	s.orphanCommitOverheadBytes = commitBytes
 	s.nextReceivedTime = record.receivedTime
 	return nil
 }
 
-func (s *daRelayState) projectOrphanAccountingLocked(records map[[32]byte]daRelaySetRecord) (uint64, map[string]uint64, map[[32]byte]uint64, uint64, error) {
-	peerBytes := map[string]uint64{}
-	daBytes := map[[32]byte]uint64{}
-	var orphanBytes uint64
-	var commitBytes uint64
-	for daID, record := range records {
-		if record.state == daRelayStateCompleteSet || record.wireBytes == 0 {
-			continue
-		}
-		var err error
-		orphanBytes, err = checkedAddUint64(orphanBytes, record.wireBytes)
-		if err != nil || orphanBytes > s.caps.orphanPoolBytes {
-			return 0, nil, nil, 0, errDARelayOrphanPoolCapExceeded
-		}
-		daBytes[daID], err = checkedAddUint64(daBytes[daID], record.wireBytes)
-		if err != nil || daBytes[daID] > s.caps.orphanPoolPerDAIDBytes {
-			return 0, nil, nil, 0, errDARelayOrphanDAIDCapExceeded
-		}
-		commitBytes, err = checkedAddUint64(commitBytes, record.commit.wireBytes)
-		if err != nil || commitBytes > s.caps.orphanCommitOverheadBytes {
-			return 0, nil, nil, 0, errDARelayOrphanCommitCapExceeded
-		}
-		if err := s.addProjectedPeerBytes(peerBytes, record.commit.peerQuotaKey, record.commit.wireBytes); err != nil {
-			return 0, nil, nil, 0, err
-		}
-		for _, chunk := range record.chunks {
-			if err := s.addProjectedPeerBytes(peerBytes, chunk.peerQuotaKey, chunk.wireBytes); err != nil {
-				return 0, nil, nil, 0, err
-			}
-		}
+func (s *daRelayState) projectOrphanAccountingDeltaLocked(oldRecord, newRecord daRelaySetRecord) (uint64, map[string]uint64, uint64, uint64, error) {
+	oldAccounting, err := oldRecord.orphanAccounting()
+	if err != nil {
+		return 0, nil, 0, 0, err
+	}
+	newAccounting, err := newRecord.orphanAccounting()
+	if err != nil {
+		return 0, nil, 0, 0, err
+	}
+	orphanBytes, err := checkedApplyUint64Delta(s.orphanBytes, oldAccounting.orphanBytes, newAccounting.orphanBytes)
+	if err != nil {
+		return 0, nil, 0, 0, err
+	}
+	if orphanBytes > s.caps.orphanPoolBytes {
+		return 0, nil, 0, 0, errDARelayOrphanPoolCapExceeded
+	}
+	daBytes, err := checkedApplyUint64Delta(s.orphanBytesByDAID[newRecord.daID], oldAccounting.orphanBytes, newAccounting.orphanBytes)
+	if err != nil {
+		return 0, nil, 0, 0, err
+	}
+	if daBytes > s.caps.orphanPoolPerDAIDBytes {
+		return 0, nil, 0, 0, errDARelayOrphanDAIDCapExceeded
+	}
+	commitBytes, err := checkedApplyUint64Delta(s.orphanCommitOverheadBytes, oldAccounting.commitBytes, newAccounting.commitBytes)
+	if err != nil {
+		return 0, nil, 0, 0, err
+	}
+	if commitBytes > s.caps.orphanCommitOverheadBytes {
+		return 0, nil, 0, 0, errDARelayOrphanCommitCapExceeded
+	}
+	peerBytes, err := s.projectPeerAccountingDeltaLocked(oldAccounting.peerBytes, newAccounting.peerBytes)
+	if err != nil {
+		return 0, nil, 0, 0, err
 	}
 	return orphanBytes, peerBytes, daBytes, commitBytes, nil
 }
 
-func (s *daRelayState) addProjectedPeerBytes(peerBytes map[string]uint64, key string, bytes uint64) error {
-	if key == "" || bytes == 0 {
-		return nil
+func (s *daRelayState) projectPeerAccountingDeltaLocked(oldPeerBytes, newPeerBytes map[string]uint64) (map[string]uint64, error) {
+	projected := map[string]uint64{}
+	for key, oldBytes := range oldPeerBytes {
+		value, err := checkedApplyUint64Delta(s.orphanBytesByPeerQuotaKey[key], oldBytes, newPeerBytes[key])
+		if err != nil {
+			return nil, err
+		}
+		if value > s.caps.orphanPoolPerPeerBytes {
+			return nil, errDARelayOrphanPeerCapExceeded
+		}
+		projected[key] = value
 	}
-	var err error
-	peerBytes[key], err = checkedAddUint64(peerBytes[key], bytes)
-	if err != nil || peerBytes[key] > s.caps.orphanPoolPerPeerBytes {
-		return errDARelayOrphanPeerCapExceeded
+	for key, newBytes := range newPeerBytes {
+		if _, seen := oldPeerBytes[key]; seen {
+			continue
+		}
+		value, err := checkedApplyUint64Delta(s.orphanBytesByPeerQuotaKey[key], 0, newBytes)
+		if err != nil {
+			return nil, err
+		}
+		if value > s.caps.orphanPoolPerPeerBytes {
+			return nil, errDARelayOrphanPeerCapExceeded
+		}
+		projected[key] = value
 	}
-	return nil
+	return projected, nil
+}
+
+func (s *daRelayState) applyProjectedPeerBytes(projected map[string]uint64) {
+	for key, bytes := range projected {
+		if bytes == 0 {
+			delete(s.orphanBytesByPeerQuotaKey, key)
+			continue
+		}
+		s.orphanBytesByPeerQuotaKey[key] = bytes
+	}
+}
+
+func (s *daRelayState) applyProjectedDAIDBytes(daID [32]byte, bytes uint64) {
+	if bytes == 0 {
+		delete(s.orphanBytesByDAID, daID)
+		return
+	}
+	s.orphanBytesByDAID[daID] = bytes
 }
 
 func (r daRelaySetRecord) missingChunkIndexes() []uint16 {
@@ -374,9 +420,43 @@ func (r *daRelaySetRecord) recomputeOrphanTotals() error {
 	return nil
 }
 
+func (r daRelaySetRecord) orphanAccounting() (daRelayRecordAccounting, error) {
+	accounting := daRelayRecordAccounting{peerBytes: map[string]uint64{}}
+	if r.state == daRelayStateCompleteSet || r.wireBytes == 0 {
+		return accounting, nil
+	}
+	accounting.orphanBytes = r.wireBytes
+	accounting.commitBytes = r.commit.wireBytes
+	if err := addPeerAccounting(accounting.peerBytes, r.commit.peerQuotaKey, r.commit.wireBytes); err != nil {
+		return daRelayRecordAccounting{}, err
+	}
+	for _, chunk := range r.chunks {
+		if err := addPeerAccounting(accounting.peerBytes, chunk.peerQuotaKey, chunk.wireBytes); err != nil {
+			return daRelayRecordAccounting{}, err
+		}
+	}
+	return accounting, nil
+}
+
+func addPeerAccounting(peerBytes map[string]uint64, key string, bytes uint64) error {
+	if key == "" || bytes == 0 {
+		return nil
+	}
+	var err error
+	peerBytes[key], err = checkedAddUint64(peerBytes[key], bytes)
+	return err
+}
+
+func checkedApplyUint64Delta(current uint64, remove uint64, add uint64) (uint64, error) {
+	if current < remove {
+		return 0, errDARelayArithmeticOverflow
+	}
+	return checkedAddUint64(current-remove, add)
+}
+
 func checkedAddUint64(a uint64, b uint64) (uint64, error) {
 	if ^uint64(0)-a < b {
-		return 0, errDARelayOrphanPoolCapExceeded
+		return 0, errDARelayArithmeticOverflow
 	}
 	return a + b, nil
 }

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -1,6 +1,11 @@
 package p2p
 
-import "testing"
+import (
+	"errors"
+	"testing"
+
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+)
 
 func TestDefaultDARelayCapsMatchSpec(t *testing.T) {
 	caps := defaultDARelayCaps()
@@ -157,6 +162,110 @@ func TestDARelayReceivedTimeIsMonotonicLocalSequence(t *testing.T) {
 	}
 }
 
+func TestDARelayStagesCommitAndRetainsBoundedOrphans(t *testing.T) {
+	state := newDARelayStateForTest(t, defaultDARelayCaps())
+	daID := daRelayTestID(1)
+
+	mustAddDAChunk(t, state, "peer-a", daRelayTestChunk(daID, 0, 7))
+	mustAddDAChunk(t, state, "peer-b", daRelayTestChunk(daID, 2, 11))
+
+	record := mustAddDACommit(t, state, "peer-c", daRelayTestCommit(daID, 2, 13))
+	if record.state != daRelayStateStagedCommit {
+		t.Fatalf("state=%v, want STAGED_COMMIT", record.state)
+	}
+	if record.ttlBlocksRemaining != daOrphanTTLBlocks {
+		t.Fatalf("ttl=%d, want %d", record.ttlBlocksRemaining, daOrphanTTLBlocks)
+	}
+	if missing := record.missingChunkIndexes(); len(missing) != 1 || missing[0] != 1 {
+		t.Fatalf("missing=%v, want [1]", missing)
+	}
+	if _, ok := record.chunks[2]; ok {
+		t.Fatalf("orphan chunk outside commit count was retained")
+	}
+	if state.orphanBytes != record.wireBytes || state.orphanBytesByDAID[daID] != record.wireBytes {
+		t.Fatalf("orphan accounting global=%d da=%d record=%d", state.orphanBytes, state.orphanBytesByDAID[daID], record.wireBytes)
+	}
+	record.chunks[7] = daRelayTestChunk(daID, 7, 1)
+	if _, ok := state.sets[daID].chunks[7]; ok {
+		t.Fatalf("returned record aliases stored chunks")
+	}
+}
+
+func TestDARelayRejectsStagedIndexAndCapFailuresBeforeMutation(t *testing.T) {
+	daID := daRelayTestID(2)
+	for _, tt := range []struct {
+		patch func(*daRelayCaps)
+		want  error
+	}{
+		{
+			patch: func(caps *daRelayCaps) {
+				caps.orphanPoolBytes, caps.orphanPoolPerPeerBytes = 4, 4
+				caps.orphanPoolPerDAIDBytes, caps.orphanCommitOverheadBytes = 4, 4
+			},
+			want: errDARelayOrphanPoolCapExceeded,
+		},
+		{
+			patch: func(caps *daRelayCaps) { caps.orphanPoolPerPeerBytes = 4 },
+			want:  errDARelayOrphanPeerCapExceeded,
+		},
+		{
+			patch: func(caps *daRelayCaps) { caps.orphanPoolPerDAIDBytes = 4 },
+			want:  errDARelayOrphanDAIDCapExceeded,
+		},
+	} {
+		caps := defaultDARelayCaps()
+		tt.patch(&caps)
+		state := newDARelayStateForTest(t, caps)
+		_, err := state.addDAChunk("peer-a", daRelayTestChunk(daID, 0, 5))
+		requireDAErr(t, err, tt.want)
+		if len(state.sets) != 0 || state.orphanBytes != 0 {
+			t.Fatalf("rejection mutated state: sets=%d orphan=%d", len(state.sets), state.orphanBytes)
+		}
+	}
+
+	state := newDARelayStateForTest(t, defaultDARelayCaps())
+	mustAddDACommit(t, state, "peer-a", daRelayTestCommit(daID, 1, 1))
+	_, err := state.addDAChunk("peer-a", daRelayTestChunk(daID, 1, 1))
+	requireDAErr(t, err, errDARelayChunkIndexOutsideCommit)
+	_, err = state.addDACommit("peer-a", daRelayTestCommit(daID, 0, 1))
+	requireDAErr(t, err, errDARelayChunkCountInvalid)
+	_, err = state.addDAChunk("peer-a", daRelayTestChunk(daID, uint16(consensus.MAX_DA_CHUNK_COUNT), 1))
+	requireDAErr(t, err, errDARelayChunkIndexOutOfRange)
+
+	caps := defaultDARelayCaps()
+	caps.orphanPoolBytes, caps.orphanPoolPerPeerBytes = ^uint64(0), ^uint64(0)
+	caps.orphanPoolPerDAIDBytes = ^uint64(0)
+	overflowState := newDARelayStateForTest(t, caps)
+	mustAddDAChunk(t, overflowState, "peer-a", daRelayTestChunk(daID, 0, ^uint64(0)))
+	_, err = overflowState.addDACommit("peer-a", daRelayTestCommit(daID, 2, 1))
+	requireDAErr(t, err, errDARelayOrphanPoolCapExceeded)
+}
+
+func TestDARelayRejectedCandidatesDoNotMutateStoredChunks(t *testing.T) {
+	daID := daRelayTestID(4)
+	state := newDARelayStateForTest(t, defaultDARelayCaps())
+	mustAddDAChunk(t, state, "peer-a", daRelayTestChunk(daID, 0, 1))
+	mustAddDAChunk(t, state, "peer-a", daRelayTestChunk(daID, 2, 1))
+	state.caps.orphanCommitOverheadBytes = 1
+	_, err := state.addDACommit("peer-b", daRelayTestCommit(daID, 1, 2))
+	requireDAErr(t, err, errDARelayOrphanCommitCapExceeded)
+	if _, ok := state.sets[daID].chunks[2]; !ok {
+		t.Fatalf("failed commit pruned stored orphan chunk")
+	}
+	if state.orphanCommitOverheadBytes != 0 {
+		t.Fatalf("commit overhead after rejected commit = %d, want 0", state.orphanCommitOverheadBytes)
+	}
+
+	state = newDARelayStateForTest(t, defaultDARelayCaps())
+	mustAddDACommit(t, state, "peer-a", daRelayTestCommit(daID, 2, 1))
+	state.caps.orphanPoolPerDAIDBytes = state.orphanBytes
+	_, err = state.addDAChunk("peer-b", daRelayTestChunk(daID, 1, 1))
+	requireDAErr(t, err, errDARelayOrphanDAIDCapExceeded)
+	if _, ok := state.sets[daID].chunks[1]; ok {
+		t.Fatalf("failed chunk insert mutated stored staged record")
+	}
+}
+
 func TestDARelayCapsRejectInvalidLimits(t *testing.T) {
 	tests := []struct {
 		name string
@@ -240,5 +349,52 @@ func TestDARelayCapsRejectInvalidLimits(t *testing.T) {
 		if err := tt.caps.validate(); err == nil {
 			t.Fatalf("%s caps should fail validation", tt.name)
 		}
+	}
+}
+
+func daRelayTestID(seed byte) (out [32]byte) {
+	out[0] = seed
+	return out
+}
+
+func daRelayTestChunk(daID [32]byte, index uint16, wireBytes uint64) daRelayChunk {
+	return daRelayChunk{daID: daID, chunkIndex: index, wireBytes: wireBytes}
+}
+
+func daRelayTestCommit(daID [32]byte, chunkCount uint16, wireBytes uint64) daRelayCommit {
+	return daRelayCommit{daID: daID, chunkCount: chunkCount, wireBytes: wireBytes}
+}
+
+func newDARelayStateForTest(t *testing.T, caps daRelayCaps) *daRelayState {
+	t.Helper()
+	state, err := newDARelayState(caps)
+	if err != nil {
+		t.Fatalf("new DA relay state: %v", err)
+	}
+	return state
+}
+
+func mustAddDAChunk(t *testing.T, state *daRelayState, peer string, chunk daRelayChunk) daRelaySetRecord {
+	t.Helper()
+	record, err := state.addDAChunk(peer, chunk)
+	if err != nil {
+		t.Fatalf("add DA chunk: %v", err)
+	}
+	return record
+}
+
+func mustAddDACommit(t *testing.T, state *daRelayState, peer string, commit daRelayCommit) daRelaySetRecord {
+	t.Helper()
+	record, err := state.addDACommit(peer, commit)
+	if err != nil {
+		t.Fatalf("add DA commit: %v", err)
+	}
+	return record
+}
+
+func requireDAErr(t *testing.T, got error, want error) {
+	t.Helper()
+	if !errors.Is(got, want) {
+		t.Fatalf("err=%v, want %v", got, want)
 	}
 }

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -38,10 +38,9 @@ func TestDARelayStatesAreDistinct(t *testing.T) {
 	states := map[daRelaySetState]bool{
 		daRelayStateOrphanChunks: true,
 		daRelayStateStagedCommit: true,
-		daRelayStateCompleteSet:  true,
 	}
 
-	if len(states) != 3 {
+	if len(states) != 2 {
 		t.Fatalf("DA relay states are not distinct: got %d unique states", len(states))
 	}
 }

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -127,6 +127,39 @@ func TestDARelayPeerAccountingUsesQuotaKey(t *testing.T) {
 	}
 }
 
+func TestDARelayPeerQuotaKeyPreventsPortHopping(t *testing.T) {
+	t.Run("chunk only", func(t *testing.T) {
+		caps := defaultDARelayCaps()
+		caps.orphanPoolPerPeerBytes = 10
+		state := newDARelayStateForTest(t, caps)
+		firstID := daRelayTestID(41)
+		secondID := daRelayTestID(42)
+
+		record := mustAddDAChunk(t, state, "127.0.0.1:1000", daRelayTestChunk(firstID, 0, 6))
+		_, err := state.addDAChunk("127.0.0.1:2000", daRelayTestChunk(secondID, 0, 5))
+		requireDAErr(t, err, errDARelayOrphanPeerCapExceeded)
+
+		requirePortHopRejectedWithoutMutation(t, state, secondID, record.wireBytes)
+	})
+
+	t.Run("staged commit", func(t *testing.T) {
+		caps := defaultDARelayCaps()
+		caps.orphanPoolPerPeerBytes = 10
+		state := newDARelayStateForTest(t, caps)
+		firstID := daRelayTestID(43)
+		secondID := daRelayTestID(44)
+
+		record := mustAddDACommit(t, state, "127.0.0.1:1000", daRelayTestCommit(firstID, 2, 6))
+		_, err := state.addDACommit("127.0.0.1:2000", daRelayTestCommit(secondID, 2, 5))
+		requireDAErr(t, err, errDARelayOrphanPeerCapExceeded)
+
+		requirePortHopRejectedWithoutMutation(t, state, secondID, record.wireBytes)
+		if state.orphanCommitOverheadBytes != record.commit.wireBytes {
+			t.Fatalf("commit overhead = %d, want %d", state.orphanCommitOverheadBytes, record.commit.wireBytes)
+		}
+	})
+}
+
 func TestDARelayDAIDAccountingDeletesZeroBytes(t *testing.T) {
 	state, err := newDARelayState(defaultDARelayCaps())
 	if err != nil {
@@ -429,5 +462,21 @@ func requireDAErr(t *testing.T, got error, want error) {
 	t.Helper()
 	if !errors.Is(got, want) {
 		t.Fatalf("err=%v, want %v", got, want)
+	}
+}
+
+func requirePortHopRejectedWithoutMutation(t *testing.T, state *daRelayState, rejectedID [32]byte, wantPeerBytes uint64) {
+	t.Helper()
+	if got := state.orphanBytesForPeer("127.0.0.1:3000"); got != wantPeerBytes {
+		t.Fatalf("peer quota bytes = %d, want %d", got, wantPeerBytes)
+	}
+	if got := state.orphanBytes; got != wantPeerBytes {
+		t.Fatalf("global orphan bytes = %d, want %d", got, wantPeerBytes)
+	}
+	if _, ok := state.sets[rejectedID]; ok {
+		t.Fatalf("rejected port-hop candidate mutated state")
+	}
+	if got := state.orphanBytesForDAID(rejectedID); got != 0 {
+		t.Fatalf("rejected da_id accounting = %d, want 0", got)
 	}
 }

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -225,12 +225,43 @@ func TestDARelayReceivedTimeIsMonotonicLocalSequence(t *testing.T) {
 		t.Fatalf("new DA relay state: %v", err)
 	}
 
-	first := state.nextMonotonicReceivedTime()
-	second := state.nextMonotonicReceivedTime()
-	third := state.nextMonotonicReceivedTime()
+	first, err := state.nextMonotonicReceivedTime()
+	if err != nil {
+		t.Fatalf("next received time: %v", err)
+	}
+	second, err := state.nextMonotonicReceivedTime()
+	if err != nil {
+		t.Fatalf("next received time: %v", err)
+	}
+	third, err := state.nextMonotonicReceivedTime()
+	if err != nil {
+		t.Fatalf("next received time: %v", err)
+	}
 
 	if first != 1 || second != 2 || third != 3 {
 		t.Fatalf("received_time sequence = %d, %d, %d; want 1, 2, 3", first, second, third)
+	}
+}
+
+func TestDARelayReceivedTimeMonotonicAcrossMutationPaths(t *testing.T) {
+	state := newDARelayStateForTest(t, defaultDARelayCaps())
+
+	first, err := state.nextMonotonicReceivedTime()
+	if err != nil {
+		t.Fatalf("next received time: %v", err)
+	}
+	chunkRecord := mustAddDAChunk(t, state, "peer-a", daRelayTestChunk(daRelayTestID(51), 0, 1))
+	second, err := state.nextMonotonicReceivedTime()
+	if err != nil {
+		t.Fatalf("next received time: %v", err)
+	}
+	commitRecord := mustAddDACommit(t, state, "peer-b", daRelayTestCommit(daRelayTestID(52), 2, 1))
+
+	if !(first < chunkRecord.receivedTime && chunkRecord.receivedTime < second && second < commitRecord.receivedTime) {
+		t.Fatalf("received_time order first=%d chunk=%d second=%d commit=%d", first, chunkRecord.receivedTime, second, commitRecord.receivedTime)
+	}
+	if state.nextReceivedTime != commitRecord.receivedTime {
+		t.Fatalf("state received_time=%d, want %d", state.nextReceivedTime, commitRecord.receivedTime)
 	}
 }
 
@@ -260,6 +291,21 @@ func TestDARelayStagesCommitAndRetainsBoundedOrphans(t *testing.T) {
 	record.chunks[7] = daRelayTestChunk(daID, 7, 1)
 	if _, ok := state.sets[daID].chunks[7]; ok {
 		t.Fatalf("returned record aliases stored chunks")
+	}
+}
+
+func TestDARelayMissingChunkIndexesReturnsNilWhenComplete(t *testing.T) {
+	daID := daRelayTestID(53)
+	record := daRelaySetRecord{
+		commit: daRelayTestCommit(daID, 2, 1),
+		chunks: map[uint16]daRelayChunk{
+			0: daRelayTestChunk(daID, 0, 1),
+			1: daRelayTestChunk(daID, 1, 1),
+		},
+	}
+
+	if missing := record.missingChunkIndexes(); missing != nil {
+		t.Fatalf("missing chunk indexes = %v, want nil", missing)
 	}
 }
 
@@ -301,6 +347,8 @@ func TestDARelayRejectsStagedIndexAndCapFailuresBeforeMutation(t *testing.T) {
 	requireDAErr(t, err, errDARelayChunkIndexOutsideCommit)
 	_, err = state.addDACommit("peer-a", daRelayTestCommit(daID, 0, 1))
 	requireDAErr(t, err, errDARelayChunkCountInvalid)
+	_, err = state.addDACommit("peer-a", daRelayTestCommit(daID, uint16(consensus.MAX_DA_CHUNK_COUNT+1), 1))
+	requireDAErr(t, err, errDARelayChunkCountInvalid)
 	_, err = state.addDAChunk("peer-a", daRelayTestChunk(daID, uint16(consensus.MAX_DA_CHUNK_COUNT), 1))
 	requireDAErr(t, err, errDARelayChunkIndexOutOfRange)
 
@@ -311,6 +359,27 @@ func TestDARelayRejectsStagedIndexAndCapFailuresBeforeMutation(t *testing.T) {
 	mustAddDAChunk(t, overflowState, "peer-a", daRelayTestChunk(daID, 0, ^uint64(0)))
 	_, err = overflowState.addDACommit("peer-a", daRelayTestCommit(daID, 2, 1))
 	requireDAErr(t, err, errDARelayArithmeticOverflow)
+
+	chunkOnlyOverflowState := newDARelayStateForTest(t, caps)
+	mustAddDAChunk(t, chunkOnlyOverflowState, "peer-a", daRelayTestChunk(daID, 0, ^uint64(0)))
+	_, err = chunkOnlyOverflowState.addDAChunk("peer-a", daRelayTestChunk(daID, 1, 1))
+	requireDAErr(t, err, errDARelayArithmeticOverflow)
+	if len(chunkOnlyOverflowState.sets[daID].chunks) != 1 {
+		t.Fatalf("chunk overflow mutated chunk set: got %d chunks", len(chunkOnlyOverflowState.sets[daID].chunks))
+	}
+}
+
+func TestDARelayZeroRecordAccountingDoesNotAllocatePeerBytes(t *testing.T) {
+	accounting, err := (daRelaySetRecord{}).orphanAccounting()
+	if err != nil {
+		t.Fatalf("zero record accounting: %v", err)
+	}
+	if accounting.orphanBytes != 0 || accounting.commitBytes != 0 {
+		t.Fatalf("zero accounting totals orphan=%d commit=%d, want 0", accounting.orphanBytes, accounting.commitBytes)
+	}
+	if accounting.peerBytes != nil {
+		t.Fatalf("zero accounting peer map = %#v, want nil", accounting.peerBytes)
+	}
 }
 
 func TestDARelayRejectsZeroWireBytesBeforeMutation(t *testing.T) {

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -160,6 +160,46 @@ func TestDARelayPeerQuotaKeyPreventsPortHopping(t *testing.T) {
 	})
 }
 
+func TestDARelayEmptyPeerQuotaKeyIsCapped(t *testing.T) {
+	t.Run("chunk only", func(t *testing.T) {
+		caps := defaultDARelayCaps()
+		caps.orphanPoolPerPeerBytes = 10
+		state := newDARelayStateForTest(t, caps)
+		firstID := daRelayTestID(45)
+		secondID := daRelayTestID(46)
+
+		record := mustAddDAChunk(t, state, "", daRelayTestChunk(firstID, 0, 6))
+		_, err := state.addDAChunk("", daRelayTestChunk(secondID, 0, 5))
+		requireDAErr(t, err, errDARelayOrphanPeerCapExceeded)
+
+		if got := state.orphanBytesForPeer(""); got != record.wireBytes {
+			t.Fatalf("empty peer quota bytes = %d, want %d", got, record.wireBytes)
+		}
+		if _, ok := state.sets[secondID]; ok {
+			t.Fatalf("empty-peer cap rejection mutated state")
+		}
+	})
+
+	t.Run("staged commit", func(t *testing.T) {
+		caps := defaultDARelayCaps()
+		caps.orphanPoolPerPeerBytes = 10
+		state := newDARelayStateForTest(t, caps)
+		firstID := daRelayTestID(47)
+		secondID := daRelayTestID(48)
+
+		record := mustAddDACommit(t, state, "", daRelayTestCommit(firstID, 2, 6))
+		_, err := state.addDACommit("", daRelayTestCommit(secondID, 2, 5))
+		requireDAErr(t, err, errDARelayOrphanPeerCapExceeded)
+
+		if got := state.orphanBytesForPeer(""); got != record.wireBytes {
+			t.Fatalf("empty peer quota bytes = %d, want %d", got, record.wireBytes)
+		}
+		if _, ok := state.sets[secondID]; ok {
+			t.Fatalf("empty-peer commit cap rejection mutated state")
+		}
+	})
+}
+
 func TestDARelayDAIDAccountingDeletesZeroBytes(t *testing.T) {
 	state, err := newDARelayState(defaultDARelayCaps())
 	if err != nil {
@@ -284,6 +324,26 @@ func TestDARelayRejectsZeroWireBytesBeforeMutation(t *testing.T) {
 
 	if len(state.sets) != 0 || state.orphanBytes != 0 || state.orphanCommitOverheadBytes != 0 {
 		t.Fatalf("zero wire rejection mutated state: sets=%d orphan=%d commit=%d", len(state.sets), state.orphanBytes, state.orphanCommitOverheadBytes)
+	}
+}
+
+func TestDARelayRejectsReceivedTimeOverflowBeforeMutation(t *testing.T) {
+	chunkState := newDARelayStateForTest(t, defaultDARelayCaps())
+	chunkState.nextReceivedTime = ^uint64(0)
+	chunkID := daRelayTestID(49)
+	_, err := chunkState.addDAChunk("peer-a", daRelayTestChunk(chunkID, 0, 1))
+	requireDAErr(t, err, errDARelayArithmeticOverflow)
+	if len(chunkState.sets) != 0 || chunkState.nextReceivedTime != ^uint64(0) {
+		t.Fatalf("chunk time overflow mutated state: sets=%d time=%d", len(chunkState.sets), chunkState.nextReceivedTime)
+	}
+
+	commitState := newDARelayStateForTest(t, defaultDARelayCaps())
+	commitState.nextReceivedTime = ^uint64(0)
+	commitID := daRelayTestID(50)
+	_, err = commitState.addDACommit("peer-a", daRelayTestCommit(commitID, 2, 1))
+	requireDAErr(t, err, errDARelayArithmeticOverflow)
+	if len(commitState.sets) != 0 || commitState.nextReceivedTime != ^uint64(0) {
+		t.Fatalf("commit time overflow mutated state: sets=%d time=%d", len(commitState.sets), commitState.nextReceivedTime)
 	}
 }
 

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -265,6 +265,48 @@ func TestDARelayReceivedTimeMonotonicAcrossMutationPaths(t *testing.T) {
 	}
 }
 
+func TestDARelayReceivedTimeStaysFirstSeenForExistingRecord(t *testing.T) {
+	t.Run("chunk then commit", func(t *testing.T) {
+		state := newDARelayStateForTest(t, defaultDARelayCaps())
+		daID := daRelayTestID(54)
+
+		firstRecord := mustAddDAChunk(t, state, "peer-a", daRelayTestChunk(daID, 0, 1))
+		otherRecord := mustAddDAChunk(t, state, "peer-b", daRelayTestChunk(daRelayTestID(55), 0, 1))
+		updatedRecord := mustAddDACommit(t, state, "peer-c", daRelayTestCommit(daID, 2, 1))
+
+		if updatedRecord.receivedTime != firstRecord.receivedTime {
+			t.Fatalf("updated received_time=%d, want first-seen %d", updatedRecord.receivedTime, firstRecord.receivedTime)
+		}
+		if state.nextReceivedTime != otherRecord.receivedTime {
+			t.Fatalf("state received_time=%d, want latest new-record time %d", state.nextReceivedTime, otherRecord.receivedTime)
+		}
+		nextRecord := mustAddDAChunk(t, state, "peer-d", daRelayTestChunk(daRelayTestID(56), 0, 1))
+		if nextRecord.receivedTime != otherRecord.receivedTime+1 {
+			t.Fatalf("next received_time=%d, want %d", nextRecord.receivedTime, otherRecord.receivedTime+1)
+		}
+	})
+
+	t.Run("commit then chunk", func(t *testing.T) {
+		state := newDARelayStateForTest(t, defaultDARelayCaps())
+		daID := daRelayTestID(57)
+
+		firstRecord := mustAddDACommit(t, state, "peer-a", daRelayTestCommit(daID, 2, 1))
+		otherRecord := mustAddDAChunk(t, state, "peer-b", daRelayTestChunk(daRelayTestID(58), 0, 1))
+		updatedRecord := mustAddDAChunk(t, state, "peer-c", daRelayTestChunk(daID, 0, 1))
+
+		if updatedRecord.receivedTime != firstRecord.receivedTime {
+			t.Fatalf("updated received_time=%d, want first-seen %d", updatedRecord.receivedTime, firstRecord.receivedTime)
+		}
+		if state.nextReceivedTime != otherRecord.receivedTime {
+			t.Fatalf("state received_time=%d, want latest new-record time %d", state.nextReceivedTime, otherRecord.receivedTime)
+		}
+		nextRecord := mustAddDACommit(t, state, "peer-d", daRelayTestCommit(daRelayTestID(59), 2, 1))
+		if nextRecord.receivedTime != otherRecord.receivedTime+1 {
+			t.Fatalf("next received_time=%d, want %d", nextRecord.receivedTime, otherRecord.receivedTime+1)
+		}
+	})
+}
+
 func TestDARelayStagesCommitAndRetainsBoundedOrphans(t *testing.T) {
 	state := newDARelayStateForTest(t, defaultDARelayCaps())
 	daID := daRelayTestID(1)

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -238,11 +238,45 @@ func TestDARelayRejectsStagedIndexAndCapFailuresBeforeMutation(t *testing.T) {
 	overflowState := newDARelayStateForTest(t, caps)
 	mustAddDAChunk(t, overflowState, "peer-a", daRelayTestChunk(daID, 0, ^uint64(0)))
 	_, err = overflowState.addDACommit("peer-a", daRelayTestCommit(daID, 2, 1))
-	requireDAErr(t, err, errDARelayOrphanPoolCapExceeded)
+	requireDAErr(t, err, errDARelayArithmeticOverflow)
+}
+
+func TestDARelayRejectsZeroWireBytesBeforeMutation(t *testing.T) {
+	daID := daRelayTestID(3)
+	state := newDARelayStateForTest(t, defaultDARelayCaps())
+
+	_, err := state.addDACommit("peer-a", daRelayTestCommit(daID, 1, 0))
+	requireDAErr(t, err, errDARelayWireBytesInvalid)
+	_, err = state.addDAChunk("peer-a", daRelayTestChunk(daID, 0, 0))
+	requireDAErr(t, err, errDARelayWireBytesInvalid)
+
+	if len(state.sets) != 0 || state.orphanBytes != 0 || state.orphanCommitOverheadBytes != 0 {
+		t.Fatalf("zero wire rejection mutated state: sets=%d orphan=%d commit=%d", len(state.sets), state.orphanBytes, state.orphanCommitOverheadBytes)
+	}
+}
+
+func TestDARelayRejectsDuplicatesBeforeMutation(t *testing.T) {
+	daID := daRelayTestID(4)
+	state := newDARelayStateForTest(t, defaultDARelayCaps())
+
+	record := mustAddDACommit(t, state, "peer-a", daRelayTestCommit(daID, 2, 3))
+	_, err := state.addDACommit("peer-b", daRelayTestCommit(daID, 2, 5))
+	requireDAErr(t, err, errDARelayDuplicateCommit)
+	if state.sets[daID].commit.wireBytes != record.commit.wireBytes || state.orphanBytes != record.wireBytes {
+		t.Fatalf("duplicate commit mutated state: commit=%d orphan=%d want commit=%d orphan=%d", state.sets[daID].commit.wireBytes, state.orphanBytes, record.commit.wireBytes, record.wireBytes)
+	}
+
+	chunk := daRelayTestChunk(daID, 0, 7)
+	record = mustAddDAChunk(t, state, "peer-c", chunk)
+	_, err = state.addDAChunk("peer-d", chunk)
+	requireDAErr(t, err, errDARelayDuplicateChunk)
+	if len(state.sets[daID].chunks) != 1 || state.orphanBytes != record.wireBytes {
+		t.Fatalf("duplicate chunk mutated state: chunks=%d orphan=%d want orphan=%d", len(state.sets[daID].chunks), state.orphanBytes, record.wireBytes)
+	}
 }
 
 func TestDARelayRejectedCandidatesDoNotMutateStoredChunks(t *testing.T) {
-	daID := daRelayTestID(4)
+	daID := daRelayTestID(5)
 	state := newDARelayStateForTest(t, defaultDARelayCaps())
 	mustAddDAChunk(t, state, "peer-a", daRelayTestChunk(daID, 0, 1))
 	mustAddDAChunk(t, state, "peer-a", daRelayTestChunk(daID, 2, 1))


### PR DESCRIPTION
Invariant:
DA relay orphan/staged records retain first-seen commits and account bounded orphan bytes without completing or pinning DA sets.

Layer:
Go P2P DA relay implementation / operations / tests. No consensus change. No Rust parity claim.

Files changed:
- .codacy.yml
- clients/go/node/p2p/da_relay_state.go
- clients/go/node/p2p/da_relay_state_test.go

Tests:
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node/p2p -run "Da|DA|Relay" -count=1'\n- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -race ./node/p2p -run "Da|DA|Relay" -count=1'\n- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./...'\n- rubin-precommit-one-review --base-ref origin/main --include-base-diff\n- rubin-push --base-ref origin/main --coverage-cmd rubin-stack-codacy-coverage.sh -- origin HEAD\n\nBehavior impact:\nAdds Go DA relay staged/orphan record mutation through private candidate records, projected orphan accounting caps, commit/chunk index rejection, and missing-index calculation for staged records.\n\nCompatibility impact:\nGo-only internal P2P DA relay state surface. Does not change consensus validity, wire encoding, conformance fixtures, or Rust behavior.\n\nKnown non-goals:\n- COMPLETE_SET admission\n- Payload commitment/hash validation\n- Pinned payload accounting\n- DA fee / eviction scoring\n- Parent RUB-318 or RUB-224 closeout claim\n\nFollow-ups:\nRUB-362 owns complete-set integrity and pinned cap. RUB-363 owns fee and eviction accounting.\n\nRisk:\nMain risk is DA relay state mutation before validation; this PR uses cloned candidate records and tests rejected commit/chunk paths leave stored state unchanged.\n\nRollback:\nRevert this PR to remove the new DA relay staged/orphan mutation surface.\n\nNot checked:\nExternal GitHub CI and bot review threads were not available before opening this PR.

<!-- rubin-agent-meta actor=unknown action=pr-create via=cl branch=codex/RUB-361-da-staged-state wt=rubin-protocol-codex-RUB-318 utc=2026-05-24T23:44:28Z -->
