### PR TITLE
[Q-GO-P2P-DA-COMPLETE-INTEGRITY-01] Split RUB-318: wire Go DA complete-set integrity and pinned cap

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -99,6 +99,7 @@ engines:
       - "clients/go/node/p2p/addr_manager.go"
       - "clients/go/node/p2p/compact_reconstruct.go"
       - "clients/go/node/p2p/compact_wire.go"
+      - "clients/go/node/p2p/da_relay_state.go"
       - "clients/go/node/p2p/handlers_block.go"
       - "clients/go/node/p2p/handshake.go"
       - "clients/go/node/p2p/mempool.go"

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -158,12 +158,16 @@ func newDARelayState(caps daRelayCaps) (*daRelayState, error) {
 	}, nil
 }
 
-func (s *daRelayState) nextMonotonicReceivedTime() uint64 {
+func (s *daRelayState) nextMonotonicReceivedTime() (uint64, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	s.nextReceivedTime++
-	return s.nextReceivedTime
+	receivedTime, err := s.nextReceivedTimeLocked()
+	if err != nil {
+		return 0, err
+	}
+	s.nextReceivedTime = receivedTime
+	return receivedTime, nil
 }
 
 func (s *daRelayState) nextReceivedTimeLocked() (uint64, error) {
@@ -383,7 +387,7 @@ func (r daRelaySetRecord) missingChunkIndexes() []uint16 {
 	if r.commit.chunkCount == 0 {
 		return nil
 	}
-	missing := make([]uint16, 0)
+	var missing []uint16
 	for i := uint16(0); i < r.commit.chunkCount; i++ {
 		if _, ok := r.chunks[i]; !ok {
 			missing = append(missing, i)
@@ -431,10 +435,10 @@ func (r *daRelaySetRecord) recomputeOrphanTotals() error {
 }
 
 func (r daRelaySetRecord) orphanAccounting() (daRelayRecordAccounting, error) {
-	accounting := daRelayRecordAccounting{peerBytes: map[string]uint64{}}
 	if r.wireBytes == 0 {
-		return accounting, nil
+		return daRelayRecordAccounting{}, nil
 	}
+	accounting := daRelayRecordAccounting{peerBytes: map[string]uint64{}}
 	accounting.orphanBytes = r.wireBytes
 	accounting.commitBytes = r.commit.wireBytes
 	if err := addPeerAccounting(accounting.peerBytes, r.commit.peerQuotaKey, r.commit.wireBytes); err != nil {

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -259,21 +259,27 @@ func (s *daRelayState) addDAChunk(peerAddr string, chunk daRelayChunk) (daRelayS
 	if chunk.wireBytes == 0 || chunk.wireBytes < uint64(payloadLen) {
 		return daRelaySetRecord{}, errDARelayWireBytesInvalid
 	}
-	payload := cloneBytes(chunk.payload)
-	if sha3.Sum256(payload) != chunk.chunkHash {
+
+	s.mu.Lock()
+	record := s.sets[chunk.daID]
+	if err := record.validateChunkInsert(chunk.chunkIndex); err != nil {
+		s.mu.Unlock()
+		return daRelaySetRecord{}, err
+	}
+	s.mu.Unlock()
+
+	if sha3.Sum256(chunk.payload) != chunk.chunkHash {
 		return daRelaySetRecord{}, errDARelayChunkHashMismatch
 	}
+	payload := cloneBytes(chunk.payload)
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	record := s.sets[chunk.daID].cloneForStateMutation()
+	record = s.sets[chunk.daID].cloneForStateMutation()
 	record.ensureMaps()
-	if _, exists := record.chunks[chunk.chunkIndex]; exists {
-		return daRelaySetRecord{}, errDARelayDuplicateChunk
-	}
-	if record.commit.chunkCount != 0 && chunk.chunkIndex >= record.commit.chunkCount {
-		return daRelaySetRecord{}, errDARelayChunkIndexOutsideCommit
+	if err := record.validateChunkInsert(chunk.chunkIndex); err != nil {
+		return daRelaySetRecord{}, err
 	}
 	chunk.peerQuotaKey = peerQuotaKey(peerAddr)
 	record.daID = chunk.daID
@@ -453,6 +459,16 @@ func (r *daRelaySetRecord) pruneChunksOutsideCommit() {
 			delete(r.chunks, index)
 		}
 	}
+}
+
+func (r daRelaySetRecord) validateChunkInsert(chunkIndex uint16) error {
+	if _, exists := r.chunks[chunkIndex]; exists {
+		return errDARelayDuplicateChunk
+	}
+	if r.commit.chunkCount != 0 && chunkIndex >= r.commit.chunkCount {
+		return errDARelayChunkIndexOutsideCommit
+	}
+	return nil
 }
 
 func (r *daRelaySetRecord) tryComplete(dropChunksOnCommitMismatch bool) error {

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -346,11 +346,11 @@ func (s *daRelayState) addDAChunk(peerAddr string, chunk daRelayChunk) (daRelayS
 
 		payloadBytes, payloadCommitment := snapshot.payloadCommitment()
 		if payloadCommitment != snapshot.payloadCommitmentExpected {
-			applied, err := s.markMatchingCompletionChunksReplaceable(snapshot)
+			retry, err := s.markMatchingCompletionChunksReplaceable(snapshot)
 			if err != nil {
 				return daRelaySetRecord{}, err
 			}
-			if !applied {
+			if retry {
 				continue
 			}
 			return daRelaySetRecord{}, errDARelayPayloadCommitmentMismatch
@@ -684,16 +684,19 @@ func (s *daRelayState) stageCommitDroppingMatchingCompletionChunks(peerAddr stri
 	return true, nil
 }
 
-func (s *daRelayState) markMatchingCompletionChunksReplaceable(snapshot daRelayCompletionSnapshot) (bool, error) {
+func (s *daRelayState) markMatchingCompletionChunksReplaceable(snapshot daRelayCompletionSnapshot) (retry bool, err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	record := s.sets[snapshot.daID].cloneForStateMutation()
 	if record.state == daRelayStateCompleteSet || record.commit.chunkCount != snapshot.chunkCount || record.commit.payloadCommitment != snapshot.payloadCommitmentExpected {
-		return false, nil
+		return true, nil
 	}
 	indexes, ok := record.matchingCompletionChunkIndexes(snapshot)
-	if !ok || len(indexes) == 0 {
+	if !ok {
+		return true, nil
+	}
+	if len(indexes) == 0 {
 		return false, nil
 	}
 	record.markChunksReplaceable(indexes)
@@ -705,7 +708,7 @@ func (s *daRelayState) markMatchingCompletionChunksReplaceable(snapshot daRelayC
 	if err := s.applyDASetRecordLocked(record); err != nil {
 		return false, err
 	}
-	return true, nil
+	return false, nil
 }
 
 func (r daRelaySetRecord) matchingCompletionChunkIndexes(snapshot daRelayCompletionSnapshot) ([]uint16, bool) {

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -15,6 +15,8 @@ const (
 	daOrphanCommitOverheadMaxBytes uint64 = 8 << 20
 	daOrphanTTLBlocks              uint64 = 3
 	daMempoolPinnedPayloadMaxBytes uint64 = 96_000_000
+	daCompleteSetRecordFootprint   uint64 = 256
+	daCompleteSetChunkFootprint    uint64 = 128
 )
 
 type daRelaySetState uint8
@@ -368,7 +370,15 @@ func (s *daRelayState) projectOrphanAccountingDeltaLocked(oldRecord, newRecord d
 }
 
 func (s *daRelayState) projectPinnedPayloadDeltaLocked(oldRecord, newRecord daRelaySetRecord) (uint64, error) {
-	pinnedBytes, err := checkedApplyUint64Delta(s.pinnedPayloadBytes, oldRecord.pinnedPayloadAccountingBytes(), newRecord.pinnedPayloadAccountingBytes())
+	oldPinnedBytes, err := oldRecord.pinnedPayloadAccountingBytes()
+	if err != nil {
+		return 0, err
+	}
+	newPinnedBytes, err := newRecord.pinnedPayloadAccountingBytes()
+	if err != nil {
+		return 0, err
+	}
+	pinnedBytes, err := checkedApplyUint64Delta(s.pinnedPayloadBytes, oldPinnedBytes, newPinnedBytes)
 	if err != nil {
 		return 0, err
 	}
@@ -534,11 +544,25 @@ func (r *daRelaySetRecord) recomputeOrphanTotals() error {
 	return nil
 }
 
-func (r daRelaySetRecord) pinnedPayloadAccountingBytes() uint64 {
+func (r daRelaySetRecord) pinnedPayloadAccountingBytes() (uint64, error) {
 	if r.state != daRelayStateCompleteSet || r.payloadBytes == 0 {
-		return 0
+		return 0, nil
 	}
-	return r.payloadBytes
+	footprint := r.wireBytes
+	if footprint == 0 {
+		footprint = r.payloadBytes
+	}
+	var err error
+	footprint, err = checkedAddUint64(footprint, daCompleteSetRecordFootprint)
+	if err != nil {
+		return 0, err
+	}
+	chunkFootprint := uint64(r.commit.chunkCount) * daCompleteSetChunkFootprint
+	footprint, err = checkedAddUint64(footprint, chunkFootprint)
+	if err != nil {
+		return 0, err
+	}
+	return footprint, nil
 }
 
 func (r daRelaySetRecord) orphanAccounting() (daRelayRecordAccounting, error) {

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -557,7 +557,8 @@ func (r daRelaySetRecord) missingChunkIndexes() []uint16 {
 	}
 	var missing []uint16
 	for i := uint16(0); i < r.commit.chunkCount; i++ {
-		if _, ok := r.chunks[i]; !ok {
+		_, ok := r.chunks[i]
+		if !ok || r.replaceableChunks[i] {
 			missing = append(missing, i)
 		}
 	}
@@ -696,7 +697,11 @@ func (s *daRelayState) markMatchingCompletionChunksReplaceable(snapshot daRelayC
 		return false, nil
 	}
 	record.markChunksReplaceable(indexes)
-	record.receivedTime = s.nextReceivedTime + 1
+	receivedTime, err := s.nextReceivedTimeLocked()
+	if err != nil {
+		return false, err
+	}
+	record.receivedTime = receivedTime
 	if err := s.applyDASetRecordLocked(record); err != nil {
 		return false, err
 	}

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -223,7 +223,7 @@ func (s *daRelayState) addDACommit(peerAddr string, commit daRelayCommit) (daRel
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	record := s.sets[commit.daID].clone()
+	record := s.sets[commit.daID].cloneForStateMutation()
 	record.ensureMaps()
 	if record.commit.chunkCount != 0 {
 		return daRelaySetRecord{}, errDARelayDuplicateCommit
@@ -267,7 +267,7 @@ func (s *daRelayState) addDAChunk(peerAddr string, chunk daRelayChunk) (daRelayS
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	record := s.sets[chunk.daID].clone()
+	record := s.sets[chunk.daID].cloneForStateMutation()
 	record.ensureMaps()
 	if _, exists := record.chunks[chunk.chunkIndex]; exists {
 		return daRelaySetRecord{}, errDARelayDuplicateChunk
@@ -306,7 +306,7 @@ func (s *daRelayState) applyDASetRecordLocked(record daRelaySetRecord) error {
 	if err != nil {
 		return err
 	}
-	s.sets[record.daID] = record.clone()
+	s.sets[record.daID] = record.cloneForStateMutation()
 	s.orphanBytes = orphanBytes
 	s.applyProjectedPeerBytes(peerBytes)
 	s.applyProjectedDAIDBytes(record.daID, daBytes)
@@ -421,11 +421,21 @@ func (r daRelaySetRecord) missingChunkIndexes() []uint16 {
 }
 
 func (r daRelaySetRecord) clone() daRelaySetRecord {
+	return r.cloneWithPayloads(true)
+}
+
+func (r daRelaySetRecord) cloneForStateMutation() daRelaySetRecord {
+	return r.cloneWithPayloads(false)
+}
+
+func (r daRelaySetRecord) cloneWithPayloads(copyPayloads bool) daRelaySetRecord {
 	r.ensureMaps()
 	out := r
 	out.chunks = make(map[uint16]daRelayChunk, len(r.chunks))
 	for index, chunk := range r.chunks {
-		chunk.payload = cloneBytes(chunk.payload)
+		if copyPayloads {
+			chunk.payload = cloneBytes(chunk.payload)
+		}
 		out.chunks[index] = chunk
 	}
 	return out
@@ -455,12 +465,6 @@ func (r *daRelaySetRecord) tryComplete(dropChunksOnCommitMismatch bool) error {
 	var payloadBytes uint64
 	for i := uint16(0); i < r.commit.chunkCount; i++ {
 		chunk := r.chunks[i]
-		if sha3.Sum256(chunk.payload) != chunk.chunkHash {
-			delete(r.chunks, i)
-			r.payloadBytes = 0
-			r.state = daRelayStateStagedCommit
-			return errDARelayChunkHashMismatch
-		}
 		var err error
 		payloadBytes, err = checkedAddUint64(payloadBytes, uint64(len(chunk.payload)))
 		if err != nil {

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -361,7 +361,10 @@ func (s *daRelayState) projectOrphanAccountingDeltaLocked(oldRecord, newRecord d
 
 func (s *daRelayState) projectPinnedPayloadDeltaLocked(oldRecord, newRecord daRelaySetRecord) (uint64, error) {
 	pinnedBytes, err := checkedApplyUint64Delta(s.pinnedPayloadBytes, oldRecord.pinnedPayloadAccountingBytes(), newRecord.pinnedPayloadAccountingBytes())
-	if err != nil || pinnedBytes > s.caps.pinnedPayloadBytes {
+	if err != nil {
+		return 0, err
+	}
+	if pinnedBytes > s.caps.pinnedPayloadBytes {
 		return 0, errDARelayPinnedPayloadCapExceeded
 	}
 	return pinnedBytes, nil
@@ -484,7 +487,7 @@ func (r *daRelaySetRecord) tryComplete(dropChunksOnCommitMismatch bool) error {
 		var err error
 		payloadBytes, err = checkedAddUint64(payloadBytes, uint64(len(chunk.payload)))
 		if err != nil {
-			return errDARelayPinnedPayloadCapExceeded
+			return err
 		}
 		_, _ = hasher.Write(chunk.payload)
 	}

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -1,6 +1,7 @@
 package p2p
 
 import (
+	"crypto/sha3"
 	"errors"
 	"sync"
 
@@ -102,29 +103,37 @@ type daRelaySetRecord struct {
 }
 
 type daRelayCommit struct {
-	daID         [32]byte
-	peerQuotaKey string
-	chunkCount   uint16
-	wireBytes    uint64
+	daID              [32]byte
+	payloadCommitment [32]byte
+	peerQuotaKey      string
+	chunkCount        uint16
+	wireBytes         uint64
 }
 
 type daRelayChunk struct {
 	daID         [32]byte
+	chunkHash    [32]byte
 	peerQuotaKey string
 	chunkIndex   uint16
+	payload      []byte
 	wireBytes    uint64
 }
 
 var (
-	errDARelayDuplicateCommit         = errors.New("duplicate da commit")
-	errDARelayDuplicateChunk          = errors.New("duplicate da chunk")
-	errDARelayChunkCountInvalid       = errors.New("da commit chunk count invalid")
-	errDARelayChunkIndexOutOfRange    = errors.New("da chunk index out of range")
-	errDARelayChunkIndexOutsideCommit = errors.New("da chunk index outside commit")
-	errDARelayOrphanPoolCapExceeded   = errors.New("da orphan pool cap exceeded")
-	errDARelayOrphanPeerCapExceeded   = errors.New("da orphan pool per-peer cap exceeded")
-	errDARelayOrphanDAIDCapExceeded   = errors.New("da orphan pool per-da_id cap exceeded")
-	errDARelayOrphanCommitCapExceeded = errors.New("da orphan commit overhead cap exceeded")
+	errDARelayDuplicateCommit           = errors.New("duplicate da commit")
+	errDARelayDuplicateChunk            = errors.New("duplicate da chunk")
+	errDARelayChunkCountInvalid         = errors.New("da commit chunk count invalid")
+	errDARelayChunkIndexOutOfRange      = errors.New("da chunk index out of range")
+	errDARelayChunkIndexOutsideCommit   = errors.New("da chunk index outside commit")
+	errDARelayOrphanPoolCapExceeded     = errors.New("da orphan pool cap exceeded")
+	errDARelayOrphanPeerCapExceeded     = errors.New("da orphan pool per-peer cap exceeded")
+	errDARelayOrphanDAIDCapExceeded     = errors.New("da orphan pool per-da_id cap exceeded")
+	errDARelayOrphanCommitCapExceeded   = errors.New("da orphan commit overhead cap exceeded")
+	errDARelayChunkHashMismatch         = errors.New("da chunk hash mismatch")
+	errDARelayChunkPayloadSizeInvalid   = errors.New("da chunk payload size invalid")
+	errDARelayPayloadCommitmentMismatch = errors.New("da payload commitment mismatch")
+	errDARelayWireBytesInvalid          = errors.New("da relay wire bytes invalid")
+	errDARelayPinnedPayloadCapExceeded  = errors.New("da pinned payload cap exceeded")
 )
 
 type daRelayState struct {
@@ -200,6 +209,9 @@ func (s *daRelayState) addDACommit(peerAddr string, commit daRelayCommit) (daRel
 	if commit.chunkCount == 0 || uint64(commit.chunkCount) > consensus.MAX_DA_CHUNK_COUNT {
 		return daRelaySetRecord{}, errDARelayChunkCountInvalid
 	}
+	if commit.wireBytes == 0 {
+		return daRelaySetRecord{}, errDARelayWireBytesInvalid
+	}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -217,6 +229,9 @@ func (s *daRelayState) addDACommit(peerAddr string, commit daRelayCommit) (daRel
 	record.state = daRelayStateStagedCommit
 	record.ttlBlocksRemaining = s.caps.orphanTTLBlocks
 	record.receivedTime = s.nextReceivedTime + 1
+	if err := record.tryComplete(true); err != nil {
+		return daRelaySetRecord{}, err
+	}
 	if err := record.recomputeOrphanTotals(); err != nil {
 		return daRelaySetRecord{}, err
 	}
@@ -229,6 +244,17 @@ func (s *daRelayState) addDACommit(peerAddr string, commit daRelayCommit) (daRel
 func (s *daRelayState) addDAChunk(peerAddr string, chunk daRelayChunk) (daRelaySetRecord, error) {
 	if uint64(chunk.chunkIndex) >= consensus.MAX_DA_CHUNK_COUNT {
 		return daRelaySetRecord{}, errDARelayChunkIndexOutOfRange
+	}
+	payloadLen := len(chunk.payload)
+	if payloadLen == 0 || uint64(payloadLen) > consensus.CHUNK_BYTES {
+		return daRelaySetRecord{}, errDARelayChunkPayloadSizeInvalid
+	}
+	if chunk.wireBytes < uint64(payloadLen) {
+		return daRelaySetRecord{}, errDARelayWireBytesInvalid
+	}
+	payload := cloneBytes(chunk.payload)
+	if sha3.Sum256(payload) != chunk.chunkHash {
+		return daRelaySetRecord{}, errDARelayChunkHashMismatch
 	}
 
 	s.mu.Lock()
@@ -248,8 +274,12 @@ func (s *daRelayState) addDAChunk(peerAddr string, chunk daRelayChunk) (daRelayS
 		record.state = daRelayStateOrphanChunks
 		record.ttlBlocksRemaining = s.caps.orphanTTLBlocks
 	}
+	chunk.payload = payload
 	record.chunks[chunk.chunkIndex] = chunk
 	record.receivedTime = s.nextReceivedTime + 1
+	if err := record.tryComplete(false); err != nil {
+		return daRelaySetRecord{}, err
+	}
 	if err := record.recomputeOrphanTotals(); err != nil {
 		return daRelaySetRecord{}, err
 	}
@@ -270,11 +300,16 @@ func (s *daRelayState) applyDASetRecordLocked(record daRelaySetRecord) error {
 	if err != nil {
 		return err
 	}
+	pinnedBytes, err := s.projectPinnedPayloadLocked(records)
+	if err != nil {
+		return err
+	}
 	s.sets = records
 	s.orphanBytes = orphanBytes
 	s.orphanBytesByPeerQuotaKey = peerBytes
 	s.orphanBytesByDAID = daBytes
 	s.orphanCommitOverheadBytes = commitBytes
+	s.pinnedPayloadBytes = pinnedBytes
 	s.nextReceivedTime = record.receivedTime
 	return nil
 }
@@ -313,6 +348,21 @@ func (s *daRelayState) projectOrphanAccountingLocked(records map[[32]byte]daRela
 	return orphanBytes, peerBytes, daBytes, commitBytes, nil
 }
 
+func (s *daRelayState) projectPinnedPayloadLocked(records map[[32]byte]daRelaySetRecord) (uint64, error) {
+	var pinnedBytes uint64
+	for _, record := range records {
+		if record.state != daRelayStateCompleteSet || record.payloadBytes == 0 {
+			continue
+		}
+		var err error
+		pinnedBytes, err = checkedAddUint64(pinnedBytes, record.payloadBytes)
+		if err != nil || pinnedBytes > s.caps.pinnedPayloadBytes {
+			return 0, errDARelayPinnedPayloadCapExceeded
+		}
+	}
+	return pinnedBytes, nil
+}
+
 func (s *daRelayState) addProjectedPeerBytes(peerBytes map[string]uint64, key string, bytes uint64) error {
 	if key == "" || bytes == 0 {
 		return nil
@@ -343,6 +393,7 @@ func (r daRelaySetRecord) clone() daRelaySetRecord {
 	out := r
 	out.chunks = make(map[uint16]daRelayChunk, len(r.chunks))
 	for index, chunk := range r.chunks {
+		chunk.payload = cloneBytes(chunk.payload)
 		out.chunks[index] = chunk
 	}
 	return out
@@ -362,6 +413,50 @@ func (r *daRelaySetRecord) pruneChunksOutsideCommit() {
 	}
 }
 
+func (r *daRelaySetRecord) tryComplete(dropChunksOnCommitMismatch bool) error {
+	if r.commit.chunkCount == 0 || len(r.missingChunkIndexes()) != 0 {
+		r.payloadBytes = 0
+		return nil
+	}
+
+	hasher := sha3.New256()
+	var payloadBytes uint64
+	for i := uint16(0); i < r.commit.chunkCount; i++ {
+		chunk := r.chunks[i]
+		if sha3.Sum256(chunk.payload) != chunk.chunkHash {
+			delete(r.chunks, i)
+			r.payloadBytes = 0
+			r.state = daRelayStateStagedCommit
+			return errDARelayChunkHashMismatch
+		}
+		var err error
+		payloadBytes, err = checkedAddUint64(payloadBytes, uint64(len(chunk.payload)))
+		if err != nil {
+			return errDARelayPinnedPayloadCapExceeded
+		}
+		_, _ = hasher.Write(chunk.payload)
+	}
+	var payloadCommitment [32]byte
+	copy(payloadCommitment[:], hasher.Sum(nil))
+	if payloadCommitment != r.commit.payloadCommitment {
+		if !dropChunksOnCommitMismatch {
+			r.payloadBytes = 0
+			r.state = daRelayStateStagedCommit
+			return errDARelayPayloadCommitmentMismatch
+		}
+		for i := uint16(0); i < r.commit.chunkCount; i++ {
+			delete(r.chunks, i)
+		}
+		r.payloadBytes = 0
+		r.state = daRelayStateStagedCommit
+		return nil
+	}
+	r.payloadBytes = payloadBytes
+	r.state = daRelayStateCompleteSet
+	r.ttlBlocksRemaining = 0
+	return nil
+}
+
 func (r *daRelaySetRecord) recomputeOrphanTotals() error {
 	r.wireBytes = r.commit.wireBytes
 	for _, chunk := range r.chunks {
@@ -379,4 +474,11 @@ func checkedAddUint64(a uint64, b uint64) (uint64, error) {
 		return 0, errDARelayOrphanPoolCapExceeded
 	}
 	return a + b, nil
+}
+
+func cloneBytes(in []byte) []byte {
+	if len(in) == 0 {
+		return nil
+	}
+	return append([]byte(nil), in...)
 }

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -121,6 +121,19 @@ type daRelayChunk struct {
 	wireBytes    uint64
 }
 
+type daRelayCompletionSnapshot struct {
+	daID                      [32]byte
+	payloadCommitmentExpected [32]byte
+	chunkCount                uint16
+	chunks                    []daRelayCompletionChunkSnapshot
+}
+
+type daRelayCompletionChunkSnapshot struct {
+	chunkHash  [32]byte
+	chunkIndex uint16
+	payload    []byte
+}
+
 var (
 	errDARelayDuplicateCommit           = errors.New("duplicate da commit")
 	errDARelayDuplicateChunk            = errors.New("duplicate da chunk")
@@ -222,36 +235,64 @@ func (s *daRelayState) addDACommit(peerAddr string, commit daRelayCommit) (daRel
 		return daRelaySetRecord{}, errDARelayWireBytesInvalid
 	}
 
-	s.mu.Lock()
+	for {
+		s.mu.Lock()
+		record, err := s.stageDACommitRecordLocked(peerAddr, commit)
+		if err != nil {
+			s.mu.Unlock()
+			return daRelaySetRecord{}, err
+		}
+		snapshot, complete := record.completionSnapshot()
+		if !complete {
+			if err := record.recomputeOrphanTotals(); err != nil {
+				s.mu.Unlock()
+				return daRelaySetRecord{}, err
+			}
+			if err := s.applyDASetRecordLocked(record); err != nil {
+				s.mu.Unlock()
+				return daRelaySetRecord{}, err
+			}
+			s.mu.Unlock()
+			return record.clone(), nil
+		}
+		s.mu.Unlock()
 
-	record := s.sets[commit.daID].cloneForStateMutation()
-	record.ensureMaps()
-	if record.commit.chunkCount != 0 {
+		payloadBytes, payloadCommitment := snapshot.payloadCommitment()
+		if payloadCommitment != snapshot.payloadCommitmentExpected {
+			// Commit metadata is the first-seen authority for duplicate handling;
+			// orphan chunks are provisional until they match that commit.
+			applied, err := s.stageCommitDroppingMatchingCompletionChunks(peerAddr, commit, snapshot)
+			if err != nil {
+				return daRelaySetRecord{}, err
+			}
+			if !applied {
+				continue
+			}
+			return daRelaySetRecord{}, errDARelayPayloadCommitmentMismatch
+		}
+
+		s.mu.Lock()
+		record, err = s.stageDACommitRecordLocked(peerAddr, commit)
+		if err != nil {
+			s.mu.Unlock()
+			return daRelaySetRecord{}, err
+		}
+		if !snapshot.matchesRecord(record) {
+			s.mu.Unlock()
+			continue
+		}
+		record.markComplete(payloadBytes)
+		if err := record.recomputeOrphanTotals(); err != nil {
+			s.mu.Unlock()
+			return daRelaySetRecord{}, err
+		}
+		if err := s.applyDASetRecordLocked(record); err != nil {
+			s.mu.Unlock()
+			return daRelaySetRecord{}, err
+		}
 		s.mu.Unlock()
-		return daRelaySetRecord{}, errDARelayDuplicateCommit
+		return record.clone(), nil
 	}
-	c := commit
-	c.peerQuotaKey = peerQuotaKey(peerAddr)
-	record.daID = c.daID
-	record.commit = c
-	record.pruneChunksOutsideCommit()
-	record.state = daRelayStateStagedCommit
-	record.ttlBlocksRemaining = s.caps.orphanTTLBlocks
-	record.receivedTime = s.nextReceivedTime + 1
-	if err := record.tryComplete(false); err != nil {
-		s.mu.Unlock()
-		return daRelaySetRecord{}, err
-	}
-	if err := record.recomputeOrphanTotals(); err != nil {
-		s.mu.Unlock()
-		return daRelaySetRecord{}, err
-	}
-	if err := s.applyDASetRecordLocked(record); err != nil {
-		s.mu.Unlock()
-		return daRelaySetRecord{}, err
-	}
-	s.mu.Unlock()
-	return record.clone(), nil
 }
 
 func (s *daRelayState) addDAChunk(peerAddr string, chunk daRelayChunk) (daRelaySetRecord, error) {
@@ -279,12 +320,78 @@ func (s *daRelayState) addDAChunk(peerAddr string, chunk daRelayChunk) (daRelayS
 	}
 	payload := cloneBytes(chunk.payload)
 
-	s.mu.Lock()
+	for {
+		s.mu.Lock()
+		record, err := s.stageDAChunkRecordLocked(peerAddr, chunk, payload)
+		if err != nil {
+			s.mu.Unlock()
+			return daRelaySetRecord{}, err
+		}
+		snapshot, complete := record.completionSnapshot()
+		if !complete {
+			if err := record.recomputeOrphanTotals(); err != nil {
+				s.mu.Unlock()
+				return daRelaySetRecord{}, err
+			}
+			if err := s.applyDASetRecordLocked(record); err != nil {
+				s.mu.Unlock()
+				return daRelaySetRecord{}, err
+			}
+			s.mu.Unlock()
+			return record.clone(), nil
+		}
+		s.mu.Unlock()
 
-	record = s.sets[chunk.daID].cloneForStateMutation()
+		payloadBytes, payloadCommitment := snapshot.payloadCommitment()
+		if payloadCommitment != snapshot.payloadCommitmentExpected {
+			return daRelaySetRecord{}, errDARelayPayloadCommitmentMismatch
+		}
+
+		s.mu.Lock()
+		record, err = s.stageDAChunkRecordLocked(peerAddr, chunk, payload)
+		if err != nil {
+			s.mu.Unlock()
+			return daRelaySetRecord{}, err
+		}
+		if !snapshot.matchesRecord(record) {
+			s.mu.Unlock()
+			continue
+		}
+		record.markComplete(payloadBytes)
+		if err := record.recomputeOrphanTotals(); err != nil {
+			s.mu.Unlock()
+			return daRelaySetRecord{}, err
+		}
+		if err := s.applyDASetRecordLocked(record); err != nil {
+			s.mu.Unlock()
+			return daRelaySetRecord{}, err
+		}
+		s.mu.Unlock()
+		return record.clone(), nil
+	}
+}
+
+func (s *daRelayState) stageDACommitRecordLocked(peerAddr string, commit daRelayCommit) (daRelaySetRecord, error) {
+	record := s.sets[commit.daID].cloneForStateMutation()
+	record.ensureMaps()
+	if record.commit.chunkCount != 0 {
+		return daRelaySetRecord{}, errDARelayDuplicateCommit
+	}
+	c := commit
+	c.peerQuotaKey = peerQuotaKey(peerAddr)
+	record.daID = c.daID
+	record.commit = c
+	record.pruneChunksOutsideCommit()
+	record.state = daRelayStateStagedCommit
+	record.ttlBlocksRemaining = s.caps.orphanTTLBlocks
+	record.receivedTime = s.nextReceivedTime + 1
+	return record, nil
+}
+
+func (s *daRelayState) stageDAChunkRecordLocked(peerAddr string, chunk daRelayChunk, payload []byte) (daRelaySetRecord, error) {
+	record := s.sets[chunk.daID].cloneForStateMutation()
 	record.ensureMaps()
 	if err := record.validateChunkInsert(chunk.chunkIndex); err != nil {
-		s.mu.Unlock()
 		return daRelaySetRecord{}, err
 	}
 	chunk.peerQuotaKey = peerQuotaKey(peerAddr)
@@ -296,20 +403,7 @@ func (s *daRelayState) addDAChunk(peerAddr string, chunk daRelayChunk) (daRelayS
 	chunk.payload = payload
 	record.chunks[chunk.chunkIndex] = chunk
 	record.receivedTime = s.nextReceivedTime + 1
-	if err := record.tryComplete(false); err != nil {
-		s.mu.Unlock()
-		return daRelaySetRecord{}, err
-	}
-	if err := record.recomputeOrphanTotals(); err != nil {
-		s.mu.Unlock()
-		return daRelaySetRecord{}, err
-	}
-	if err := s.applyDASetRecordLocked(record); err != nil {
-		s.mu.Unlock()
-		return daRelaySetRecord{}, err
-	}
-	s.mu.Unlock()
-	return record.clone(), nil
+	return record, nil
 }
 
 func (s *daRelayState) applyDASetRecordLocked(record daRelaySetRecord) error {
@@ -494,42 +588,119 @@ func (r daRelaySetRecord) validateChunkInsert(chunkIndex uint16) error {
 	return nil
 }
 
-func (r *daRelaySetRecord) tryComplete(dropChunksOnCommitMismatch bool) error {
-	if r.commit.chunkCount == 0 || len(r.missingChunkIndexes()) != 0 {
-		r.payloadBytes = 0
-		return nil
+func (r daRelaySetRecord) completionSnapshot() (daRelayCompletionSnapshot, bool) {
+	if r.commit.chunkCount == 0 || r.state == daRelayStateCompleteSet || len(r.missingChunkIndexes()) != 0 {
+		return daRelayCompletionSnapshot{}, false
 	}
+	snapshot := daRelayCompletionSnapshot{
+		daID:                      r.daID,
+		payloadCommitmentExpected: r.commit.payloadCommitment,
+		chunkCount:                r.commit.chunkCount,
+		chunks:                    make([]daRelayCompletionChunkSnapshot, 0, r.commit.chunkCount),
+	}
+	for i := uint16(0); i < r.commit.chunkCount; i++ {
+		chunk, ok := r.chunks[i]
+		if !ok {
+			return daRelayCompletionSnapshot{}, false
+		}
+		snapshot.chunks = append(snapshot.chunks, daRelayCompletionChunkSnapshot{
+			chunkHash:  chunk.chunkHash,
+			chunkIndex: i,
+			payload:    chunk.payload,
+		})
+	}
+	return snapshot, true
+}
 
+func (s daRelayCompletionSnapshot) payloadCommitment() (uint64, [32]byte) {
 	hasher := sha3.New256()
 	var payloadBytes uint64
-	for i := uint16(0); i < r.commit.chunkCount; i++ {
-		chunk := r.chunks[i]
-		var err error
-		payloadBytes, err = checkedAddUint64(payloadBytes, uint64(len(chunk.payload)))
-		if err != nil {
-			return err
-		}
+	for _, chunk := range s.chunks {
+		payloadBytes += uint64(len(chunk.payload))
 		_, _ = hasher.Write(chunk.payload)
 	}
 	var payloadCommitment [32]byte
 	copy(payloadCommitment[:], hasher.Sum(nil))
-	if payloadCommitment != r.commit.payloadCommitment {
-		if !dropChunksOnCommitMismatch {
-			r.payloadBytes = 0
-			r.state = daRelayStateStagedCommit
-			return errDARelayPayloadCommitmentMismatch
-		}
-		for i := uint16(0); i < r.commit.chunkCount; i++ {
-			delete(r.chunks, i)
-		}
-		r.payloadBytes = 0
-		r.state = daRelayStateStagedCommit
-		return nil
+	return payloadBytes, payloadCommitment
+}
+
+func (s *daRelayState) stageCommitDroppingMatchingCompletionChunks(peerAddr string, commit daRelayCommit, snapshot daRelayCompletionSnapshot) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	record, err := s.stageDACommitRecordLocked(peerAddr, commit)
+	if err != nil {
+		return false, err
 	}
+	if !snapshot.matchesRecord(record) {
+		return false, nil
+	}
+	indexesToDrop, ok := record.matchingCompletionChunkIndexes(snapshot)
+	if !ok {
+		return false, nil
+	}
+	record.dropChunks(indexesToDrop)
+	record.payloadBytes = 0
+	record.state = daRelayStateStagedCommit
+	if err := record.recomputeOrphanTotals(); err != nil {
+		return false, err
+	}
+	if err := s.applyDASetRecordLocked(record); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (r daRelaySetRecord) matchingCompletionChunkIndexes(snapshot daRelayCompletionSnapshot) ([]uint16, bool) {
+	indexes := make([]uint16, 0, len(snapshot.chunks))
+	for _, snapshotChunk := range snapshot.chunks {
+		chunk, ok := r.chunks[snapshotChunk.chunkIndex]
+		if !ok {
+			continue
+		}
+		if chunk.chunkHash != snapshotChunk.chunkHash || len(chunk.payload) != len(snapshotChunk.payload) {
+			return nil, false
+		}
+		indexes = append(indexes, snapshotChunk.chunkIndex)
+	}
+	return indexes, true
+}
+
+func (r *daRelaySetRecord) dropChunks(indexes []uint16) {
+	for _, index := range indexes {
+		delete(r.chunks, index)
+	}
+}
+
+func (s daRelayCompletionSnapshot) matchesRecord(r daRelaySetRecord) bool {
+	current, ok := r.completionSnapshot()
+	if !ok {
+		return false
+	}
+	if current.daID != s.daID || current.payloadCommitmentExpected != s.payloadCommitmentExpected || current.chunkCount != s.chunkCount {
+		return false
+	}
+	if len(current.chunks) != len(s.chunks) {
+		return false
+	}
+	for i := range s.chunks {
+		if current.chunks[i].chunkIndex != s.chunks[i].chunkIndex {
+			return false
+		}
+		if current.chunks[i].chunkHash != s.chunks[i].chunkHash {
+			return false
+		}
+		if len(current.chunks[i].payload) != len(s.chunks[i].payload) {
+			return false
+		}
+	}
+	return true
+}
+
+func (r *daRelaySetRecord) markComplete(payloadBytes uint64) {
 	r.payloadBytes = payloadBytes
 	r.state = daRelayStateCompleteSet
 	r.ttlBlocksRemaining = 0
-	return nil
 }
 
 func (r *daRelaySetRecord) recomputeOrphanTotals() error {

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -21,7 +21,6 @@ type daRelaySetState uint8
 const (
 	daRelayStateOrphanChunks daRelaySetState = iota
 	daRelayStateStagedCommit
-	daRelayStateCompleteSet
 )
 
 type daRelayCaps struct {
@@ -372,7 +371,7 @@ func (s *daRelayState) applyProjectedDAIDBytes(daID [32]byte, bytes uint64) {
 }
 
 func (r daRelaySetRecord) missingChunkIndexes() []uint16 {
-	if r.commit.chunkCount == 0 || r.state == daRelayStateCompleteSet {
+	if r.commit.chunkCount == 0 {
 		return nil
 	}
 	missing := make([]uint16, 0)
@@ -424,7 +423,7 @@ func (r *daRelaySetRecord) recomputeOrphanTotals() error {
 
 func (r daRelaySetRecord) orphanAccounting() (daRelayRecordAccounting, error) {
 	accounting := daRelayRecordAccounting{peerBytes: map[string]uint64{}}
-	if r.state == daRelayStateCompleteSet || r.wireBytes == 0 {
+	if r.wireBytes == 0 {
 		return accounting, nil
 	}
 	accounting.orphanBytes = r.wireBytes

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -3,6 +3,8 @@ package p2p
 import (
 	"errors"
 	"sync"
+
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
 )
 
 const (
@@ -88,13 +90,42 @@ func (c daRelayCaps) validateRelativeCaps() error {
 }
 
 type daRelaySetRecord struct {
-	daID         [32]byte
-	state        daRelaySetState
-	receivedTime uint64
-	payloadBytes uint64
-	wireBytes    uint64
-	totalFee     uint64
+	daID               [32]byte
+	state              daRelaySetState
+	receivedTime       uint64
+	payloadBytes       uint64
+	wireBytes          uint64
+	totalFee           uint64
+	ttlBlocksRemaining uint64
+	commit             daRelayCommit
+	chunks             map[uint16]daRelayChunk
 }
+
+type daRelayCommit struct {
+	daID         [32]byte
+	peerQuotaKey string
+	chunkCount   uint16
+	wireBytes    uint64
+}
+
+type daRelayChunk struct {
+	daID         [32]byte
+	peerQuotaKey string
+	chunkIndex   uint16
+	wireBytes    uint64
+}
+
+var (
+	errDARelayDuplicateCommit         = errors.New("duplicate da commit")
+	errDARelayDuplicateChunk          = errors.New("duplicate da chunk")
+	errDARelayChunkCountInvalid       = errors.New("da commit chunk count invalid")
+	errDARelayChunkIndexOutOfRange    = errors.New("da chunk index out of range")
+	errDARelayChunkIndexOutsideCommit = errors.New("da chunk index outside commit")
+	errDARelayOrphanPoolCapExceeded   = errors.New("da orphan pool cap exceeded")
+	errDARelayOrphanPeerCapExceeded   = errors.New("da orphan pool per-peer cap exceeded")
+	errDARelayOrphanDAIDCapExceeded   = errors.New("da orphan pool per-da_id cap exceeded")
+	errDARelayOrphanCommitCapExceeded = errors.New("da orphan commit overhead cap exceeded")
+)
 
 type daRelayState struct {
 	mu                        sync.Mutex
@@ -163,4 +194,189 @@ func (s *daRelayState) orphanBytesForDAID(daID [32]byte) uint64 {
 	defer s.mu.Unlock()
 
 	return s.orphanBytesByDAID[daID]
+}
+
+func (s *daRelayState) addDACommit(peerAddr string, commit daRelayCommit) (daRelaySetRecord, error) {
+	if commit.chunkCount == 0 || uint64(commit.chunkCount) > consensus.MAX_DA_CHUNK_COUNT {
+		return daRelaySetRecord{}, errDARelayChunkCountInvalid
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	record := s.sets[commit.daID].clone()
+	record.ensureMaps()
+	if record.commit.chunkCount != 0 {
+		return daRelaySetRecord{}, errDARelayDuplicateCommit
+	}
+	c := commit
+	c.peerQuotaKey = peerQuotaKey(peerAddr)
+	record.daID = c.daID
+	record.commit = c
+	record.pruneChunksOutsideCommit()
+	record.state = daRelayStateStagedCommit
+	record.ttlBlocksRemaining = s.caps.orphanTTLBlocks
+	record.receivedTime = s.nextReceivedTime + 1
+	if err := record.recomputeOrphanTotals(); err != nil {
+		return daRelaySetRecord{}, err
+	}
+	if err := s.applyDASetRecordLocked(record); err != nil {
+		return daRelaySetRecord{}, err
+	}
+	return record.clone(), nil
+}
+
+func (s *daRelayState) addDAChunk(peerAddr string, chunk daRelayChunk) (daRelaySetRecord, error) {
+	if uint64(chunk.chunkIndex) >= consensus.MAX_DA_CHUNK_COUNT {
+		return daRelaySetRecord{}, errDARelayChunkIndexOutOfRange
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	record := s.sets[chunk.daID].clone()
+	record.ensureMaps()
+	if _, exists := record.chunks[chunk.chunkIndex]; exists {
+		return daRelaySetRecord{}, errDARelayDuplicateChunk
+	}
+	if record.commit.chunkCount != 0 && chunk.chunkIndex >= record.commit.chunkCount {
+		return daRelaySetRecord{}, errDARelayChunkIndexOutsideCommit
+	}
+	chunk.peerQuotaKey = peerQuotaKey(peerAddr)
+	record.daID = chunk.daID
+	if record.commit.chunkCount == 0 {
+		record.state = daRelayStateOrphanChunks
+		record.ttlBlocksRemaining = s.caps.orphanTTLBlocks
+	}
+	record.chunks[chunk.chunkIndex] = chunk
+	record.receivedTime = s.nextReceivedTime + 1
+	if err := record.recomputeOrphanTotals(); err != nil {
+		return daRelaySetRecord{}, err
+	}
+	if err := s.applyDASetRecordLocked(record); err != nil {
+		return daRelaySetRecord{}, err
+	}
+	return record.clone(), nil
+}
+
+func (s *daRelayState) applyDASetRecordLocked(record daRelaySetRecord) error {
+	records := make(map[[32]byte]daRelaySetRecord, len(s.sets)+1)
+	for daID, existing := range s.sets {
+		records[daID] = existing
+	}
+	records[record.daID] = record.clone()
+
+	orphanBytes, peerBytes, daBytes, commitBytes, err := s.projectOrphanAccountingLocked(records)
+	if err != nil {
+		return err
+	}
+	s.sets = records
+	s.orphanBytes = orphanBytes
+	s.orphanBytesByPeerQuotaKey = peerBytes
+	s.orphanBytesByDAID = daBytes
+	s.orphanCommitOverheadBytes = commitBytes
+	s.nextReceivedTime = record.receivedTime
+	return nil
+}
+
+func (s *daRelayState) projectOrphanAccountingLocked(records map[[32]byte]daRelaySetRecord) (uint64, map[string]uint64, map[[32]byte]uint64, uint64, error) {
+	peerBytes := map[string]uint64{}
+	daBytes := map[[32]byte]uint64{}
+	var orphanBytes uint64
+	var commitBytes uint64
+	for daID, record := range records {
+		if record.state == daRelayStateCompleteSet || record.wireBytes == 0 {
+			continue
+		}
+		var err error
+		orphanBytes, err = checkedAddUint64(orphanBytes, record.wireBytes)
+		if err != nil || orphanBytes > s.caps.orphanPoolBytes {
+			return 0, nil, nil, 0, errDARelayOrphanPoolCapExceeded
+		}
+		daBytes[daID], err = checkedAddUint64(daBytes[daID], record.wireBytes)
+		if err != nil || daBytes[daID] > s.caps.orphanPoolPerDAIDBytes {
+			return 0, nil, nil, 0, errDARelayOrphanDAIDCapExceeded
+		}
+		commitBytes, err = checkedAddUint64(commitBytes, record.commit.wireBytes)
+		if err != nil || commitBytes > s.caps.orphanCommitOverheadBytes {
+			return 0, nil, nil, 0, errDARelayOrphanCommitCapExceeded
+		}
+		if err := s.addProjectedPeerBytes(peerBytes, record.commit.peerQuotaKey, record.commit.wireBytes); err != nil {
+			return 0, nil, nil, 0, err
+		}
+		for _, chunk := range record.chunks {
+			if err := s.addProjectedPeerBytes(peerBytes, chunk.peerQuotaKey, chunk.wireBytes); err != nil {
+				return 0, nil, nil, 0, err
+			}
+		}
+	}
+	return orphanBytes, peerBytes, daBytes, commitBytes, nil
+}
+
+func (s *daRelayState) addProjectedPeerBytes(peerBytes map[string]uint64, key string, bytes uint64) error {
+	if key == "" || bytes == 0 {
+		return nil
+	}
+	var err error
+	peerBytes[key], err = checkedAddUint64(peerBytes[key], bytes)
+	if err != nil || peerBytes[key] > s.caps.orphanPoolPerPeerBytes {
+		return errDARelayOrphanPeerCapExceeded
+	}
+	return nil
+}
+
+func (r daRelaySetRecord) missingChunkIndexes() []uint16 {
+	if r.commit.chunkCount == 0 || r.state == daRelayStateCompleteSet {
+		return nil
+	}
+	missing := make([]uint16, 0)
+	for i := uint16(0); i < r.commit.chunkCount; i++ {
+		if _, ok := r.chunks[i]; !ok {
+			missing = append(missing, i)
+		}
+	}
+	return missing
+}
+
+func (r daRelaySetRecord) clone() daRelaySetRecord {
+	r.ensureMaps()
+	out := r
+	out.chunks = make(map[uint16]daRelayChunk, len(r.chunks))
+	for index, chunk := range r.chunks {
+		out.chunks[index] = chunk
+	}
+	return out
+}
+
+func (r *daRelaySetRecord) ensureMaps() {
+	if r.chunks == nil {
+		r.chunks = map[uint16]daRelayChunk{}
+	}
+}
+
+func (r *daRelaySetRecord) pruneChunksOutsideCommit() {
+	for index := range r.chunks {
+		if index >= r.commit.chunkCount {
+			delete(r.chunks, index)
+		}
+	}
+}
+
+func (r *daRelaySetRecord) recomputeOrphanTotals() error {
+	r.wireBytes = r.commit.wireBytes
+	for _, chunk := range r.chunks {
+		var err error
+		r.wireBytes, err = checkedAddUint64(r.wireBytes, chunk.wireBytes)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func checkedAddUint64(a uint64, b uint64) (uint64, error) {
+	if ^uint64(0)-a < b {
+		return 0, errDARelayOrphanPoolCapExceeded
+	}
+	return a + b, nil
 }

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -221,11 +221,11 @@ func (s *daRelayState) addDACommit(peerAddr string, commit daRelayCommit) (daRel
 	}
 
 	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	record := s.sets[commit.daID].cloneForStateMutation()
 	record.ensureMaps()
 	if record.commit.chunkCount != 0 {
+		s.mu.Unlock()
 		return daRelaySetRecord{}, errDARelayDuplicateCommit
 	}
 	c := commit
@@ -236,15 +236,19 @@ func (s *daRelayState) addDACommit(peerAddr string, commit daRelayCommit) (daRel
 	record.state = daRelayStateStagedCommit
 	record.ttlBlocksRemaining = s.caps.orphanTTLBlocks
 	record.receivedTime = s.nextReceivedTime + 1
-	if err := record.tryComplete(true); err != nil {
+	if err := record.tryComplete(false); err != nil {
+		s.mu.Unlock()
 		return daRelaySetRecord{}, err
 	}
 	if err := record.recomputeOrphanTotals(); err != nil {
+		s.mu.Unlock()
 		return daRelaySetRecord{}, err
 	}
 	if err := s.applyDASetRecordLocked(record); err != nil {
+		s.mu.Unlock()
 		return daRelaySetRecord{}, err
 	}
+	s.mu.Unlock()
 	return record.clone(), nil
 }
 
@@ -274,11 +278,11 @@ func (s *daRelayState) addDAChunk(peerAddr string, chunk daRelayChunk) (daRelayS
 	payload := cloneBytes(chunk.payload)
 
 	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	record = s.sets[chunk.daID].cloneForStateMutation()
 	record.ensureMaps()
 	if err := record.validateChunkInsert(chunk.chunkIndex); err != nil {
+		s.mu.Unlock()
 		return daRelaySetRecord{}, err
 	}
 	chunk.peerQuotaKey = peerQuotaKey(peerAddr)
@@ -291,14 +295,18 @@ func (s *daRelayState) addDAChunk(peerAddr string, chunk daRelayChunk) (daRelayS
 	record.chunks[chunk.chunkIndex] = chunk
 	record.receivedTime = s.nextReceivedTime + 1
 	if err := record.tryComplete(false); err != nil {
+		s.mu.Unlock()
 		return daRelaySetRecord{}, err
 	}
 	if err := record.recomputeOrphanTotals(); err != nil {
+		s.mu.Unlock()
 		return daRelaySetRecord{}, err
 	}
 	if err := s.applyDASetRecordLocked(record); err != nil {
+		s.mu.Unlock()
 		return daRelaySetRecord{}, err
 	}
+	s.mu.Unlock()
 	return record.clone(), nil
 }
 

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -166,6 +166,10 @@ func (s *daRelayState) nextMonotonicReceivedTime() uint64 {
 	return s.nextReceivedTime
 }
 
+func (s *daRelayState) nextReceivedTimeLocked() (uint64, error) {
+	return checkedAddUint64(s.nextReceivedTime, 1)
+}
+
 func (s *daRelayState) setOrphanBytesForPeer(peerAddr string, bytes uint64) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -226,8 +230,7 @@ func (s *daRelayState) addDACommit(peerAddr string, commit daRelayCommit) (daRel
 	record.pruneChunksOutsideCommit()
 	record.state = daRelayStateStagedCommit
 	record.ttlBlocksRemaining = s.caps.orphanTTLBlocks
-	record.receivedTime = s.nextReceivedTime + 1
-	if err := record.recomputeOrphanTotals(); err != nil {
+	if err := s.prepareDASetRecordLocked(&record); err != nil {
 		return daRelaySetRecord{}, err
 	}
 	if err := s.applyDASetRecordLocked(record); err != nil {
@@ -259,8 +262,7 @@ func (s *daRelayState) addDAChunk(peerAddr string, chunk daRelayChunk) (daRelayS
 		record.ttlBlocksRemaining = s.caps.orphanTTLBlocks
 	}
 	record.chunks[chunk.chunkIndex] = chunk
-	record.receivedTime = s.nextReceivedTime + 1
-	if err := record.recomputeOrphanTotals(); err != nil {
+	if err := s.prepareDASetRecordLocked(&record); err != nil {
 		return daRelaySetRecord{}, err
 	}
 	if err := s.applyDASetRecordLocked(record); err != nil {
@@ -277,6 +279,15 @@ func validateDAChunk(chunk daRelayChunk) error {
 		return errDARelayWireBytesInvalid
 	}
 	return nil
+}
+
+func (s *daRelayState) prepareDASetRecordLocked(record *daRelaySetRecord) error {
+	receivedTime, err := s.nextReceivedTimeLocked()
+	if err != nil {
+		return err
+	}
+	record.receivedTime = receivedTime
+	return record.recomputeOrphanTotals()
 }
 
 func (s *daRelayState) applyDASetRecordLocked(record daRelaySetRecord) error {
@@ -438,7 +449,7 @@ func (r daRelaySetRecord) orphanAccounting() (daRelayRecordAccounting, error) {
 }
 
 func addPeerAccounting(peerBytes map[string]uint64, key string, bytes uint64) error {
-	if key == "" || bytes == 0 {
+	if bytes == 0 {
 		return nil
 	}
 	var err error

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -279,7 +279,7 @@ func (s *daRelayState) applyDASetRecordLocked(record daRelaySetRecord) error {
 	if err != nil {
 		return err
 	}
-	s.sets[record.daID] = record.clone()
+	s.sets[record.daID] = record
 	s.orphanBytes = orphanBytes
 	s.applyProjectedPeerBytes(peerBytes)
 	s.applyProjectedDAIDBytes(record.daID, daBytes)
@@ -385,8 +385,10 @@ func (r daRelaySetRecord) missingChunkIndexes() []uint16 {
 }
 
 func (r daRelaySetRecord) clone() daRelaySetRecord {
-	r.ensureMaps()
 	out := r
+	if r.chunks == nil {
+		return out
+	}
 	out.chunks = make(map[uint16]daRelayChunk, len(r.chunks))
 	for index, chunk := range r.chunks {
 		out.chunks[index] = chunk

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -747,24 +747,31 @@ func (s daRelayCompletionSnapshot) matchesRecord(r daRelaySetRecord) bool {
 	if !ok {
 		return false
 	}
-	if current.daID != s.daID || current.payloadCommitmentExpected != s.payloadCommitmentExpected || current.chunkCount != s.chunkCount {
+	return s.matchesHeader(current) && completionChunksMatch(s.chunks, current.chunks)
+}
+
+func (s daRelayCompletionSnapshot) matchesHeader(current daRelayCompletionSnapshot) bool {
+	return current.daID == s.daID &&
+		current.payloadCommitmentExpected == s.payloadCommitmentExpected &&
+		current.chunkCount == s.chunkCount
+}
+
+func completionChunksMatch(expected, current []daRelayCompletionChunkSnapshot) bool {
+	if len(current) != len(expected) {
 		return false
 	}
-	if len(current.chunks) != len(s.chunks) {
-		return false
-	}
-	for i := range s.chunks {
-		if current.chunks[i].chunkIndex != s.chunks[i].chunkIndex {
-			return false
-		}
-		if current.chunks[i].chunkHash != s.chunks[i].chunkHash {
-			return false
-		}
-		if len(current.chunks[i].payload) != len(s.chunks[i].payload) {
+	for i := range expected {
+		if !completionChunkMatches(expected[i], current[i]) {
 			return false
 		}
 	}
 	return true
+}
+
+func completionChunkMatches(expected, current daRelayCompletionChunkSnapshot) bool {
+	return current.chunkIndex == expected.chunkIndex &&
+		current.chunkHash == expected.chunkHash &&
+		len(current.payload) == len(expected.payload)
 }
 
 func (r *daRelaySetRecord) markComplete(payloadBytes uint64) {

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -237,11 +237,8 @@ func (s *daRelayState) addDACommit(peerAddr string, commit daRelayCommit) (daRel
 }
 
 func (s *daRelayState) addDAChunk(peerAddr string, chunk daRelayChunk) (daRelaySetRecord, error) {
-	if uint64(chunk.chunkIndex) >= consensus.MAX_DA_CHUNK_COUNT {
-		return daRelaySetRecord{}, errDARelayChunkIndexOutOfRange
-	}
-	if chunk.wireBytes == 0 {
-		return daRelaySetRecord{}, errDARelayWireBytesInvalid
+	if err := validateDAChunk(chunk); err != nil {
+		return daRelaySetRecord{}, err
 	}
 
 	s.mu.Lock()
@@ -272,6 +269,16 @@ func (s *daRelayState) addDAChunk(peerAddr string, chunk daRelayChunk) (daRelayS
 	return record.clone(), nil
 }
 
+func validateDAChunk(chunk daRelayChunk) error {
+	if uint64(chunk.chunkIndex) >= consensus.MAX_DA_CHUNK_COUNT {
+		return errDARelayChunkIndexOutOfRange
+	}
+	if chunk.wireBytes == 0 {
+		return errDARelayWireBytesInvalid
+	}
+	return nil
+}
+
 func (s *daRelayState) applyDASetRecordLocked(record daRelaySetRecord) error {
 	oldRecord := s.sets[record.daID]
 	orphanBytes, peerBytes, daBytes, commitBytes, err := s.projectOrphanAccountingDeltaLocked(oldRecord, record)
@@ -296,26 +303,17 @@ func (s *daRelayState) projectOrphanAccountingDeltaLocked(oldRecord, newRecord d
 	if err != nil {
 		return 0, nil, 0, 0, err
 	}
-	orphanBytes, err := checkedApplyUint64Delta(s.orphanBytes, oldAccounting.orphanBytes, newAccounting.orphanBytes)
+	orphanBytes, err := checkedApplyUint64DeltaCap(s.orphanBytes, oldAccounting.orphanBytes, newAccounting.orphanBytes, s.caps.orphanPoolBytes, errDARelayOrphanPoolCapExceeded)
 	if err != nil {
 		return 0, nil, 0, 0, err
 	}
-	if orphanBytes > s.caps.orphanPoolBytes {
-		return 0, nil, 0, 0, errDARelayOrphanPoolCapExceeded
-	}
-	daBytes, err := checkedApplyUint64Delta(s.orphanBytesByDAID[newRecord.daID], oldAccounting.orphanBytes, newAccounting.orphanBytes)
+	daBytes, err := checkedApplyUint64DeltaCap(s.orphanBytesByDAID[newRecord.daID], oldAccounting.orphanBytes, newAccounting.orphanBytes, s.caps.orphanPoolPerDAIDBytes, errDARelayOrphanDAIDCapExceeded)
 	if err != nil {
 		return 0, nil, 0, 0, err
 	}
-	if daBytes > s.caps.orphanPoolPerDAIDBytes {
-		return 0, nil, 0, 0, errDARelayOrphanDAIDCapExceeded
-	}
-	commitBytes, err := checkedApplyUint64Delta(s.orphanCommitOverheadBytes, oldAccounting.commitBytes, newAccounting.commitBytes)
+	commitBytes, err := checkedApplyUint64DeltaCap(s.orphanCommitOverheadBytes, oldAccounting.commitBytes, newAccounting.commitBytes, s.caps.orphanCommitOverheadBytes, errDARelayOrphanCommitCapExceeded)
 	if err != nil {
 		return 0, nil, 0, 0, err
-	}
-	if commitBytes > s.caps.orphanCommitOverheadBytes {
-		return 0, nil, 0, 0, errDARelayOrphanCommitCapExceeded
 	}
 	peerBytes, err := s.projectPeerAccountingDeltaLocked(oldAccounting.peerBytes, newAccounting.peerBytes)
 	if err != nil {
@@ -446,6 +444,17 @@ func addPeerAccounting(peerBytes map[string]uint64, key string, bytes uint64) er
 	var err error
 	peerBytes[key], err = checkedAddUint64(peerBytes[key], bytes)
 	return err
+}
+
+func checkedApplyUint64DeltaCap(current, remove, add, limit uint64, capErr error) (uint64, error) {
+	value, err := checkedApplyUint64Delta(current, remove, add)
+	if err != nil {
+		return 0, err
+	}
+	if value > limit {
+		return 0, capErr
+	}
+	return value, nil
 }
 
 func checkedApplyUint64Delta(current uint64, remove uint64, add uint64) (uint64, error) {

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -125,7 +125,15 @@ var (
 	errDARelayOrphanPeerCapExceeded   = errors.New("da orphan pool per-peer cap exceeded")
 	errDARelayOrphanDAIDCapExceeded   = errors.New("da orphan pool per-da_id cap exceeded")
 	errDARelayOrphanCommitCapExceeded = errors.New("da orphan commit overhead cap exceeded")
+	errDARelayWireBytesInvalid        = errors.New("da relay wire bytes invalid")
+	errDARelayArithmeticOverflow      = errors.New("da relay arithmetic overflow")
 )
+
+type daRelayRecordAccounting struct {
+	orphanBytes uint64
+	commitBytes uint64
+	peerBytes   map[string]uint64
+}
 
 type daRelayState struct {
 	mu                        sync.Mutex
@@ -200,6 +208,9 @@ func (s *daRelayState) addDACommit(peerAddr string, commit daRelayCommit) (daRel
 	if commit.chunkCount == 0 || uint64(commit.chunkCount) > consensus.MAX_DA_CHUNK_COUNT {
 		return daRelaySetRecord{}, errDARelayChunkCountInvalid
 	}
+	if commit.wireBytes == 0 {
+		return daRelaySetRecord{}, errDARelayWireBytesInvalid
+	}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -229,6 +240,9 @@ func (s *daRelayState) addDACommit(peerAddr string, commit daRelayCommit) (daRel
 func (s *daRelayState) addDAChunk(peerAddr string, chunk daRelayChunk) (daRelaySetRecord, error) {
 	if uint64(chunk.chunkIndex) >= consensus.MAX_DA_CHUNK_COUNT {
 		return daRelaySetRecord{}, errDARelayChunkIndexOutOfRange
+	}
+	if chunk.wireBytes == 0 {
+		return daRelaySetRecord{}, errDARelayWireBytesInvalid
 	}
 
 	s.mu.Lock()
@@ -260,69 +274,101 @@ func (s *daRelayState) addDAChunk(peerAddr string, chunk daRelayChunk) (daRelayS
 }
 
 func (s *daRelayState) applyDASetRecordLocked(record daRelaySetRecord) error {
-	records := make(map[[32]byte]daRelaySetRecord, len(s.sets)+1)
-	for daID, existing := range s.sets {
-		records[daID] = existing
-	}
-	records[record.daID] = record.clone()
-
-	orphanBytes, peerBytes, daBytes, commitBytes, err := s.projectOrphanAccountingLocked(records)
+	oldRecord := s.sets[record.daID]
+	orphanBytes, peerBytes, daBytes, commitBytes, err := s.projectOrphanAccountingDeltaLocked(oldRecord, record)
 	if err != nil {
 		return err
 	}
-	s.sets = records
+	s.sets[record.daID] = record.clone()
 	s.orphanBytes = orphanBytes
-	s.orphanBytesByPeerQuotaKey = peerBytes
-	s.orphanBytesByDAID = daBytes
+	s.applyProjectedPeerBytes(peerBytes)
+	s.applyProjectedDAIDBytes(record.daID, daBytes)
 	s.orphanCommitOverheadBytes = commitBytes
 	s.nextReceivedTime = record.receivedTime
 	return nil
 }
 
-func (s *daRelayState) projectOrphanAccountingLocked(records map[[32]byte]daRelaySetRecord) (uint64, map[string]uint64, map[[32]byte]uint64, uint64, error) {
-	peerBytes := map[string]uint64{}
-	daBytes := map[[32]byte]uint64{}
-	var orphanBytes uint64
-	var commitBytes uint64
-	for daID, record := range records {
-		if record.state == daRelayStateCompleteSet || record.wireBytes == 0 {
-			continue
-		}
-		var err error
-		orphanBytes, err = checkedAddUint64(orphanBytes, record.wireBytes)
-		if err != nil || orphanBytes > s.caps.orphanPoolBytes {
-			return 0, nil, nil, 0, errDARelayOrphanPoolCapExceeded
-		}
-		daBytes[daID], err = checkedAddUint64(daBytes[daID], record.wireBytes)
-		if err != nil || daBytes[daID] > s.caps.orphanPoolPerDAIDBytes {
-			return 0, nil, nil, 0, errDARelayOrphanDAIDCapExceeded
-		}
-		commitBytes, err = checkedAddUint64(commitBytes, record.commit.wireBytes)
-		if err != nil || commitBytes > s.caps.orphanCommitOverheadBytes {
-			return 0, nil, nil, 0, errDARelayOrphanCommitCapExceeded
-		}
-		if err := s.addProjectedPeerBytes(peerBytes, record.commit.peerQuotaKey, record.commit.wireBytes); err != nil {
-			return 0, nil, nil, 0, err
-		}
-		for _, chunk := range record.chunks {
-			if err := s.addProjectedPeerBytes(peerBytes, chunk.peerQuotaKey, chunk.wireBytes); err != nil {
-				return 0, nil, nil, 0, err
-			}
-		}
+func (s *daRelayState) projectOrphanAccountingDeltaLocked(oldRecord, newRecord daRelaySetRecord) (uint64, map[string]uint64, uint64, uint64, error) {
+	oldAccounting, err := oldRecord.orphanAccounting()
+	if err != nil {
+		return 0, nil, 0, 0, err
+	}
+	newAccounting, err := newRecord.orphanAccounting()
+	if err != nil {
+		return 0, nil, 0, 0, err
+	}
+	orphanBytes, err := checkedApplyUint64Delta(s.orphanBytes, oldAccounting.orphanBytes, newAccounting.orphanBytes)
+	if err != nil {
+		return 0, nil, 0, 0, err
+	}
+	if orphanBytes > s.caps.orphanPoolBytes {
+		return 0, nil, 0, 0, errDARelayOrphanPoolCapExceeded
+	}
+	daBytes, err := checkedApplyUint64Delta(s.orphanBytesByDAID[newRecord.daID], oldAccounting.orphanBytes, newAccounting.orphanBytes)
+	if err != nil {
+		return 0, nil, 0, 0, err
+	}
+	if daBytes > s.caps.orphanPoolPerDAIDBytes {
+		return 0, nil, 0, 0, errDARelayOrphanDAIDCapExceeded
+	}
+	commitBytes, err := checkedApplyUint64Delta(s.orphanCommitOverheadBytes, oldAccounting.commitBytes, newAccounting.commitBytes)
+	if err != nil {
+		return 0, nil, 0, 0, err
+	}
+	if commitBytes > s.caps.orphanCommitOverheadBytes {
+		return 0, nil, 0, 0, errDARelayOrphanCommitCapExceeded
+	}
+	peerBytes, err := s.projectPeerAccountingDeltaLocked(oldAccounting.peerBytes, newAccounting.peerBytes)
+	if err != nil {
+		return 0, nil, 0, 0, err
 	}
 	return orphanBytes, peerBytes, daBytes, commitBytes, nil
 }
 
-func (s *daRelayState) addProjectedPeerBytes(peerBytes map[string]uint64, key string, bytes uint64) error {
-	if key == "" || bytes == 0 {
-		return nil
+func (s *daRelayState) projectPeerAccountingDeltaLocked(oldPeerBytes, newPeerBytes map[string]uint64) (map[string]uint64, error) {
+	projected := map[string]uint64{}
+	for key, oldBytes := range oldPeerBytes {
+		value, err := checkedApplyUint64Delta(s.orphanBytesByPeerQuotaKey[key], oldBytes, newPeerBytes[key])
+		if err != nil {
+			return nil, err
+		}
+		if value > s.caps.orphanPoolPerPeerBytes {
+			return nil, errDARelayOrphanPeerCapExceeded
+		}
+		projected[key] = value
 	}
-	var err error
-	peerBytes[key], err = checkedAddUint64(peerBytes[key], bytes)
-	if err != nil || peerBytes[key] > s.caps.orphanPoolPerPeerBytes {
-		return errDARelayOrphanPeerCapExceeded
+	for key, newBytes := range newPeerBytes {
+		if _, seen := oldPeerBytes[key]; seen {
+			continue
+		}
+		value, err := checkedApplyUint64Delta(s.orphanBytesByPeerQuotaKey[key], 0, newBytes)
+		if err != nil {
+			return nil, err
+		}
+		if value > s.caps.orphanPoolPerPeerBytes {
+			return nil, errDARelayOrphanPeerCapExceeded
+		}
+		projected[key] = value
 	}
-	return nil
+	return projected, nil
+}
+
+func (s *daRelayState) applyProjectedPeerBytes(projected map[string]uint64) {
+	for key, bytes := range projected {
+		if bytes == 0 {
+			delete(s.orphanBytesByPeerQuotaKey, key)
+			continue
+		}
+		s.orphanBytesByPeerQuotaKey[key] = bytes
+	}
+}
+
+func (s *daRelayState) applyProjectedDAIDBytes(daID [32]byte, bytes uint64) {
+	if bytes == 0 {
+		delete(s.orphanBytesByDAID, daID)
+		return
+	}
+	s.orphanBytesByDAID[daID] = bytes
 }
 
 func (r daRelaySetRecord) missingChunkIndexes() []uint16 {
@@ -374,9 +420,43 @@ func (r *daRelaySetRecord) recomputeOrphanTotals() error {
 	return nil
 }
 
+func (r daRelaySetRecord) orphanAccounting() (daRelayRecordAccounting, error) {
+	accounting := daRelayRecordAccounting{peerBytes: map[string]uint64{}}
+	if r.state == daRelayStateCompleteSet || r.wireBytes == 0 {
+		return accounting, nil
+	}
+	accounting.orphanBytes = r.wireBytes
+	accounting.commitBytes = r.commit.wireBytes
+	if err := addPeerAccounting(accounting.peerBytes, r.commit.peerQuotaKey, r.commit.wireBytes); err != nil {
+		return daRelayRecordAccounting{}, err
+	}
+	for _, chunk := range r.chunks {
+		if err := addPeerAccounting(accounting.peerBytes, chunk.peerQuotaKey, chunk.wireBytes); err != nil {
+			return daRelayRecordAccounting{}, err
+		}
+	}
+	return accounting, nil
+}
+
+func addPeerAccounting(peerBytes map[string]uint64, key string, bytes uint64) error {
+	if key == "" || bytes == 0 {
+		return nil
+	}
+	var err error
+	peerBytes[key], err = checkedAddUint64(peerBytes[key], bytes)
+	return err
+}
+
+func checkedApplyUint64Delta(current uint64, remove uint64, add uint64) (uint64, error) {
+	if current < remove {
+		return 0, errDARelayArithmeticOverflow
+	}
+	return checkedAddUint64(current-remove, add)
+}
+
 func checkedAddUint64(a uint64, b uint64) (uint64, error) {
 	if ^uint64(0)-a < b {
-		return 0, errDARelayOrphanPoolCapExceeded
+		return 0, errDARelayArithmeticOverflow
 	}
 	return a + b, nil
 }

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -694,7 +694,7 @@ func (s *daRelayState) markMatchingCompletionChunksReplaceable(snapshot daRelayC
 	}
 	indexes, ok := record.matchingCompletionChunkIndexes(snapshot)
 	if !ok {
-		return true, nil
+		return false, nil
 	}
 	if len(indexes) == 0 {
 		return false, nil

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -1,6 +1,11 @@
 package p2p
 
-import "testing"
+import (
+	"errors"
+	"testing"
+
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+)
 
 func TestDefaultDARelayCapsMatchSpec(t *testing.T) {
 	caps := defaultDARelayCaps()
@@ -157,6 +162,110 @@ func TestDARelayReceivedTimeIsMonotonicLocalSequence(t *testing.T) {
 	}
 }
 
+func TestDARelayStagesCommitAndRetainsBoundedOrphans(t *testing.T) {
+	state := newDARelayStateForTest(t, defaultDARelayCaps())
+	daID := daRelayTestID(1)
+
+	mustAddDAChunk(t, state, "peer-a", daRelayTestChunk(daID, 0, 7))
+	mustAddDAChunk(t, state, "peer-b", daRelayTestChunk(daID, 2, 11))
+
+	record := mustAddDACommit(t, state, "peer-c", daRelayTestCommit(daID, 2, 13))
+	if record.state != daRelayStateStagedCommit {
+		t.Fatalf("state=%v, want STAGED_COMMIT", record.state)
+	}
+	if record.ttlBlocksRemaining != daOrphanTTLBlocks {
+		t.Fatalf("ttl=%d, want %d", record.ttlBlocksRemaining, daOrphanTTLBlocks)
+	}
+	if missing := record.missingChunkIndexes(); len(missing) != 1 || missing[0] != 1 {
+		t.Fatalf("missing=%v, want [1]", missing)
+	}
+	if _, ok := record.chunks[2]; ok {
+		t.Fatalf("orphan chunk outside commit count was retained")
+	}
+	if state.orphanBytes != record.wireBytes || state.orphanBytesByDAID[daID] != record.wireBytes {
+		t.Fatalf("orphan accounting global=%d da=%d record=%d", state.orphanBytes, state.orphanBytesByDAID[daID], record.wireBytes)
+	}
+	record.chunks[7] = daRelayTestChunk(daID, 7, 1)
+	if _, ok := state.sets[daID].chunks[7]; ok {
+		t.Fatalf("returned record aliases stored chunks")
+	}
+}
+
+func TestDARelayRejectsStagedIndexAndCapFailuresBeforeMutation(t *testing.T) {
+	daID := daRelayTestID(2)
+	for _, tt := range []struct {
+		patch func(*daRelayCaps)
+		want  error
+	}{
+		{
+			patch: func(caps *daRelayCaps) {
+				caps.orphanPoolBytes, caps.orphanPoolPerPeerBytes = 4, 4
+				caps.orphanPoolPerDAIDBytes, caps.orphanCommitOverheadBytes = 4, 4
+			},
+			want: errDARelayOrphanPoolCapExceeded,
+		},
+		{
+			patch: func(caps *daRelayCaps) { caps.orphanPoolPerPeerBytes = 4 },
+			want:  errDARelayOrphanPeerCapExceeded,
+		},
+		{
+			patch: func(caps *daRelayCaps) { caps.orphanPoolPerDAIDBytes = 4 },
+			want:  errDARelayOrphanDAIDCapExceeded,
+		},
+	} {
+		caps := defaultDARelayCaps()
+		tt.patch(&caps)
+		state := newDARelayStateForTest(t, caps)
+		_, err := state.addDAChunk("peer-a", daRelayTestChunk(daID, 0, 5))
+		requireDAErr(t, err, tt.want)
+		if len(state.sets) != 0 || state.orphanBytes != 0 {
+			t.Fatalf("rejection mutated state: sets=%d orphan=%d", len(state.sets), state.orphanBytes)
+		}
+	}
+
+	state := newDARelayStateForTest(t, defaultDARelayCaps())
+	mustAddDACommit(t, state, "peer-a", daRelayTestCommit(daID, 1, 1))
+	_, err := state.addDAChunk("peer-a", daRelayTestChunk(daID, 1, 1))
+	requireDAErr(t, err, errDARelayChunkIndexOutsideCommit)
+	_, err = state.addDACommit("peer-a", daRelayTestCommit(daID, 0, 1))
+	requireDAErr(t, err, errDARelayChunkCountInvalid)
+	_, err = state.addDAChunk("peer-a", daRelayTestChunk(daID, uint16(consensus.MAX_DA_CHUNK_COUNT), 1))
+	requireDAErr(t, err, errDARelayChunkIndexOutOfRange)
+
+	caps := defaultDARelayCaps()
+	caps.orphanPoolBytes, caps.orphanPoolPerPeerBytes = ^uint64(0), ^uint64(0)
+	caps.orphanPoolPerDAIDBytes = ^uint64(0)
+	overflowState := newDARelayStateForTest(t, caps)
+	mustAddDAChunk(t, overflowState, "peer-a", daRelayTestChunk(daID, 0, ^uint64(0)))
+	_, err = overflowState.addDACommit("peer-a", daRelayTestCommit(daID, 2, 1))
+	requireDAErr(t, err, errDARelayOrphanPoolCapExceeded)
+}
+
+func TestDARelayRejectedCandidatesDoNotMutateStoredChunks(t *testing.T) {
+	daID := daRelayTestID(4)
+	state := newDARelayStateForTest(t, defaultDARelayCaps())
+	mustAddDAChunk(t, state, "peer-a", daRelayTestChunk(daID, 0, 1))
+	mustAddDAChunk(t, state, "peer-a", daRelayTestChunk(daID, 2, 1))
+	state.caps.orphanCommitOverheadBytes = 1
+	_, err := state.addDACommit("peer-b", daRelayTestCommit(daID, 1, 2))
+	requireDAErr(t, err, errDARelayOrphanCommitCapExceeded)
+	if _, ok := state.sets[daID].chunks[2]; !ok {
+		t.Fatalf("failed commit pruned stored orphan chunk")
+	}
+	if state.orphanCommitOverheadBytes != 0 {
+		t.Fatalf("commit overhead after rejected commit = %d, want 0", state.orphanCommitOverheadBytes)
+	}
+
+	state = newDARelayStateForTest(t, defaultDARelayCaps())
+	mustAddDACommit(t, state, "peer-a", daRelayTestCommit(daID, 2, 1))
+	state.caps.orphanPoolPerDAIDBytes = state.orphanBytes
+	_, err = state.addDAChunk("peer-b", daRelayTestChunk(daID, 1, 1))
+	requireDAErr(t, err, errDARelayOrphanDAIDCapExceeded)
+	if _, ok := state.sets[daID].chunks[1]; ok {
+		t.Fatalf("failed chunk insert mutated stored staged record")
+	}
+}
+
 func TestDARelayCapsRejectInvalidLimits(t *testing.T) {
 	tests := []struct {
 		name string
@@ -240,5 +349,52 @@ func TestDARelayCapsRejectInvalidLimits(t *testing.T) {
 		if err := tt.caps.validate(); err == nil {
 			t.Fatalf("%s caps should fail validation", tt.name)
 		}
+	}
+}
+
+func daRelayTestID(seed byte) (out [32]byte) {
+	out[0] = seed
+	return out
+}
+
+func daRelayTestChunk(daID [32]byte, index uint16, wireBytes uint64) daRelayChunk {
+	return daRelayChunk{daID: daID, chunkIndex: index, wireBytes: wireBytes}
+}
+
+func daRelayTestCommit(daID [32]byte, chunkCount uint16, wireBytes uint64) daRelayCommit {
+	return daRelayCommit{daID: daID, chunkCount: chunkCount, wireBytes: wireBytes}
+}
+
+func newDARelayStateForTest(t *testing.T, caps daRelayCaps) *daRelayState {
+	t.Helper()
+	state, err := newDARelayState(caps)
+	if err != nil {
+		t.Fatalf("new DA relay state: %v", err)
+	}
+	return state
+}
+
+func mustAddDAChunk(t *testing.T, state *daRelayState, peer string, chunk daRelayChunk) daRelaySetRecord {
+	t.Helper()
+	record, err := state.addDAChunk(peer, chunk)
+	if err != nil {
+		t.Fatalf("add DA chunk: %v", err)
+	}
+	return record
+}
+
+func mustAddDACommit(t *testing.T, state *daRelayState, peer string, commit daRelayCommit) daRelaySetRecord {
+	t.Helper()
+	record, err := state.addDACommit(peer, commit)
+	if err != nil {
+		t.Fatalf("add DA commit: %v", err)
+	}
+	return record
+}
+
+func requireDAErr(t *testing.T, got error, want error) {
+	t.Helper()
+	if !errors.Is(got, want) {
+		t.Fatalf("err=%v, want %v", got, want)
 	}
 }

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -38,10 +38,9 @@ func TestDARelayStatesAreDistinct(t *testing.T) {
 	states := map[daRelaySetState]bool{
 		daRelayStateOrphanChunks: true,
 		daRelayStateStagedCommit: true,
-		daRelayStateCompleteSet:  true,
 	}
 
-	if len(states) != 3 {
+	if len(states) != 2 {
 		t.Fatalf("DA relay states are not distinct: got %d unique states", len(states))
 	}
 }

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -416,6 +416,31 @@ func TestDARelayRejectsReceivedTimeOverflowBeforeMutation(t *testing.T) {
 	if len(commitState.sets) != 0 || commitState.nextReceivedTime != ^uint64(0) {
 		t.Fatalf("commit time overflow mutated state: sets=%d time=%d", len(commitState.sets), commitState.nextReceivedTime)
 	}
+
+	replaceableState := newDARelayStateForTest(t, defaultDARelayCaps())
+	replaceableID := daRelayTestID(54)
+	replaceableRecord := daRelaySetRecord{
+		daID:   replaceableID,
+		state:  daRelayStateStagedCommit,
+		commit: daRelayTestCommitForPayloads(replaceableID, 1, []byte("good")),
+		chunks: map[uint16]daRelayChunk{
+			0: daRelayTestChunkPayload(replaceableID, 0, 3, []byte("bad")),
+		},
+	}
+	if err := replaceableRecord.recomputeOrphanTotals(); err != nil {
+		t.Fatalf("recompute replaceable record: %v", err)
+	}
+	snapshot, complete := replaceableRecord.completionSnapshot()
+	if !complete {
+		t.Fatalf("replaceable overflow setup did not produce a complete snapshot")
+	}
+	replaceableState.sets[replaceableID] = replaceableRecord
+	replaceableState.nextReceivedTime = ^uint64(0)
+	applied, err := replaceableState.markMatchingCompletionChunksReplaceable(snapshot)
+	requireDAErr(t, err, errDARelayArithmeticOverflow)
+	if applied || replaceableState.sets[replaceableID].replaceableChunks[0] || replaceableState.nextReceivedTime != ^uint64(0) {
+		t.Fatalf("replaceable time overflow mutated state: applied=%v replaceable=%v time=%d", applied, replaceableState.sets[replaceableID].replaceableChunks, replaceableState.nextReceivedTime)
+	}
 }
 
 func TestDARelayRejectsDuplicatesBeforeMutation(t *testing.T) {
@@ -621,6 +646,9 @@ func TestDARelayRejectsIntegrityAndPinnedCapSafely(t *testing.T) {
 	if !record.replaceableChunks[0] || len(record.chunks) != 1 || state.pinnedPayloadBytes != 0 {
 		t.Fatalf("chunk mismatch did not mark stale chunk replaceable: replaceable=%v chunks=%d pinned=%d", record.replaceableChunks, len(record.chunks), state.pinnedPayloadBytes)
 	}
+	if missing := record.missingChunkIndexes(); len(missing) != 2 || missing[0] != 0 || missing[1] != 1 {
+		t.Fatalf("replaceable chunk missing indexes=%v, want [0 1]", missing)
+	}
 	if state.nextReceivedTime <= beforeMismatchTime || record.receivedTime != state.nextReceivedTime {
 		t.Fatalf("replaceable mark time record=%d state=%d before=%d", record.receivedTime, state.nextReceivedTime, beforeMismatchTime)
 	}
@@ -642,6 +670,10 @@ func TestDARelayRejectsIntegrityAndPinnedCapSafely(t *testing.T) {
 		t.Fatalf("chunk mismatch mutated staged chunks: state=%v chunks=%d pinned=%d", state.sets[daID].state, len(state.sets[daID].chunks), state.pinnedPayloadBytes)
 	}
 	record = mustAddDAChunk(t, state, "peer-c", daRelayTestChunkPayload(daID, 1, uint64(len(payload1)), payload1))
+	if record.state != daRelayStateStagedCommit || !record.replaceableChunks[0] {
+		t.Fatalf("staged recovery should still require replacing marked chunk: state=%v replaceable=%v", record.state, record.replaceableChunks)
+	}
+	record = mustAddDAChunk(t, state, "peer-b", daRelayTestChunkPayload(daID, 0, uint64(len(payload0)), payload0))
 	if record.state != daRelayStateCompleteSet {
 		t.Fatalf("state after staged recovery=%v, want COMPLETE_SET", record.state)
 	}

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -1,6 +1,7 @@
 package p2p
 
 import (
+	"crypto/sha3"
 	"errors"
 	"testing"
 
@@ -266,6 +267,82 @@ func TestDARelayRejectedCandidatesDoNotMutateStoredChunks(t *testing.T) {
 	}
 }
 
+func TestDARelayCompletesSetAndPinsPayload(t *testing.T) {
+	state := newDARelayStateForTest(t, defaultDARelayCaps())
+	daID := daRelayTestID(5)
+	payload0 := []byte("chunk-zero")
+	payload1 := []byte("chunk-one")
+
+	mustAddDACommit(t, state, "peer-a", daRelayTestCommitForPayloads(daID, 3, payload0, payload1))
+	mustAddDAChunk(t, state, "peer-b", daRelayTestChunkPayload(daID, 0, uint64(len(payload0)), payload0))
+	record := mustAddDAChunk(t, state, "peer-c", daRelayTestChunkPayload(daID, 1, uint64(len(payload1)), payload1))
+
+	if record.state != daRelayStateCompleteSet {
+		t.Fatalf("state=%v, want COMPLETE_SET", record.state)
+	}
+	if record.payloadBytes != uint64(len(payload0)+len(payload1)) || state.pinnedPayloadBytes != record.payloadBytes {
+		t.Fatalf("payload bytes record=%d pinned=%d", record.payloadBytes, state.pinnedPayloadBytes)
+	}
+	if state.orphanBytes != 0 || len(state.orphanBytesByDAID) != 0 {
+		t.Fatalf("complete set left orphan accounting: global=%d da=%d", state.orphanBytes, len(state.orphanBytesByDAID))
+	}
+	record.chunks[0].payload[0] ^= 0xff
+	if state.sets[daID].chunks[0].payload[0] == record.chunks[0].payload[0] {
+		t.Fatalf("returned complete record aliases stored payload")
+	}
+}
+
+func TestDARelayRejectsIntegrityAndPinnedCapBeforeMutation(t *testing.T) {
+	daID := daRelayTestID(6)
+	state := newDARelayStateForTest(t, defaultDARelayCaps())
+	badChunk := daRelayTestChunkPayload(daID, 0, 3, []byte("bad"))
+	badChunk.chunkHash[0] ^= 0xff
+	_, err := state.addDAChunk("peer-a", badChunk)
+	requireDAErr(t, err, errDARelayChunkHashMismatch)
+	if len(state.sets) != 0 {
+		t.Fatalf("hash mismatch mutated state")
+	}
+	_, err = state.addDAChunk("peer-a", daRelayTestChunkPayload(daID, 0, 1, nil))
+	requireDAErr(t, err, errDARelayChunkPayloadSizeInvalid)
+	_, err = state.addDAChunk("peer-a", daRelayTestChunkPayload(daID, 0, 1, make([]byte, consensus.CHUNK_BYTES+1)))
+	requireDAErr(t, err, errDARelayChunkPayloadSizeInvalid)
+	_, err = state.addDAChunk("peer-a", daRelayTestChunkPayload(daID, 0, 1, []byte("underreported")))
+	requireDAErr(t, err, errDARelayWireBytesInvalid)
+	_, err = state.addDACommit("peer-a", daRelayTestCommit(daID, 1, 0))
+	requireDAErr(t, err, errDARelayWireBytesInvalid)
+	if len(state.sets) != 0 {
+		t.Fatalf("shape rejection mutated state")
+	}
+
+	payload0 := []byte("payload-a")
+	payload1 := []byte("payload-b")
+	mustAddDAChunk(t, state, "peer-a", daRelayTestChunkPayload(daID, 0, uint64(len(payload0)), payload0))
+	mustAddDAChunk(t, state, "peer-a", daRelayTestChunkPayload(daID, 1, uint64(len(payload1)), payload1))
+	record := mustAddDACommit(t, state, "peer-b", daRelayTestCommitForPayloads(daID, 1, payload1, payload0))
+	if record.state != daRelayStateStagedCommit || len(record.chunks) != 0 || state.pinnedPayloadBytes != 0 {
+		t.Fatalf("commitment mismatch state=%v chunks=%d pinned=%d", record.state, len(record.chunks), state.pinnedPayloadBytes)
+	}
+
+	state = newDARelayStateForTest(t, defaultDARelayCaps())
+	mustAddDACommit(t, state, "peer-a", daRelayTestCommitForPayloads(daID, 1, payload0, payload1))
+	mustAddDAChunk(t, state, "peer-b", daRelayTestChunkPayload(daID, 0, uint64(len(payload0)), payload0))
+	_, err = state.addDAChunk("peer-c", daRelayTestChunkPayload(daID, 1, uint64(len(payload1)), []byte("payload-x")))
+	requireDAErr(t, err, errDARelayPayloadCommitmentMismatch)
+	if len(state.sets[daID].chunks) != 1 || state.pinnedPayloadBytes != 0 {
+		t.Fatalf("chunk mismatch mutated state: chunks=%d pinned=%d", len(state.sets[daID].chunks), state.pinnedPayloadBytes)
+	}
+
+	caps := defaultDARelayCaps()
+	caps.pinnedPayloadBytes = 1
+	state = newDARelayStateForTest(t, caps)
+	mustAddDACommit(t, state, "peer-a", daRelayTestCommitForPayloads(daID, 1, payload0))
+	_, err = state.addDAChunk("peer-b", daRelayTestChunkPayload(daID, 0, uint64(len(payload0)), payload0))
+	requireDAErr(t, err, errDARelayPinnedPayloadCapExceeded)
+	if state.sets[daID].state != daRelayStateStagedCommit || len(state.sets[daID].chunks) != 0 || state.pinnedPayloadBytes != 0 {
+		t.Fatalf("pinned cap rejection mutated state: state=%v chunks=%d pinned=%d", state.sets[daID].state, len(state.sets[daID].chunks), state.pinnedPayloadBytes)
+	}
+}
+
 func TestDARelayCapsRejectInvalidLimits(t *testing.T) {
 	tests := []struct {
 		name string
@@ -358,11 +435,29 @@ func daRelayTestID(seed byte) (out [32]byte) {
 }
 
 func daRelayTestChunk(daID [32]byte, index uint16, wireBytes uint64) daRelayChunk {
-	return daRelayChunk{daID: daID, chunkIndex: index, wireBytes: wireBytes}
+	return daRelayTestChunkPayload(daID, index, wireBytes, []byte{byte(index + 1)})
 }
 
 func daRelayTestCommit(daID [32]byte, chunkCount uint16, wireBytes uint64) daRelayCommit {
 	return daRelayCommit{daID: daID, chunkCount: chunkCount, wireBytes: wireBytes}
+}
+
+func daRelayTestChunkPayload(daID [32]byte, index uint16, wireBytes uint64, payload []byte) daRelayChunk {
+	return daRelayChunk{daID: daID, chunkHash: sha3.Sum256(payload), chunkIndex: index, payload: cloneBytes(payload), wireBytes: wireBytes}
+}
+
+func daRelayTestCommitForPayloads(daID [32]byte, wireBytes uint64, payloads ...[]byte) daRelayCommit {
+	return daRelayCommit{daID: daID, payloadCommitment: daRelayPayloadCommitment(payloads...), chunkCount: uint16(len(payloads)), wireBytes: wireBytes}
+}
+
+func daRelayPayloadCommitment(payloads ...[]byte) [32]byte {
+	hasher := sha3.New256()
+	for _, payload := range payloads {
+		_, _ = hasher.Write(payload)
+	}
+	var out [32]byte
+	copy(out[:], hasher.Sum(nil))
+	return out
 }
 
 func newDARelayStateForTest(t *testing.T, caps daRelayCaps) *daRelayState {

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -127,6 +127,39 @@ func TestDARelayPeerAccountingUsesQuotaKey(t *testing.T) {
 	}
 }
 
+func TestDARelayPeerQuotaKeyPreventsPortHopping(t *testing.T) {
+	t.Run("chunk only", func(t *testing.T) {
+		caps := defaultDARelayCaps()
+		caps.orphanPoolPerPeerBytes = 10
+		state := newDARelayStateForTest(t, caps)
+		firstID := daRelayTestID(41)
+		secondID := daRelayTestID(42)
+
+		record := mustAddDAChunk(t, state, "127.0.0.1:1000", daRelayTestChunk(firstID, 0, 6))
+		_, err := state.addDAChunk("127.0.0.1:2000", daRelayTestChunk(secondID, 0, 5))
+		requireDAErr(t, err, errDARelayOrphanPeerCapExceeded)
+
+		requirePortHopRejectedWithoutMutation(t, state, secondID, record.wireBytes)
+	})
+
+	t.Run("staged commit", func(t *testing.T) {
+		caps := defaultDARelayCaps()
+		caps.orphanPoolPerPeerBytes = 10
+		state := newDARelayStateForTest(t, caps)
+		firstID := daRelayTestID(43)
+		secondID := daRelayTestID(44)
+
+		record := mustAddDACommit(t, state, "127.0.0.1:1000", daRelayTestCommit(firstID, 2, 6))
+		_, err := state.addDACommit("127.0.0.1:2000", daRelayTestCommit(secondID, 2, 5))
+		requireDAErr(t, err, errDARelayOrphanPeerCapExceeded)
+
+		requirePortHopRejectedWithoutMutation(t, state, secondID, record.wireBytes)
+		if state.orphanCommitOverheadBytes != record.commit.wireBytes {
+			t.Fatalf("commit overhead = %d, want %d", state.orphanCommitOverheadBytes, record.commit.wireBytes)
+		}
+	})
+}
+
 func TestDARelayDAIDAccountingDeletesZeroBytes(t *testing.T) {
 	state, err := newDARelayState(defaultDARelayCaps())
 	if err != nil {
@@ -429,5 +462,21 @@ func requireDAErr(t *testing.T, got error, want error) {
 	t.Helper()
 	if !errors.Is(got, want) {
 		t.Fatalf("err=%v, want %v", got, want)
+	}
+}
+
+func requirePortHopRejectedWithoutMutation(t *testing.T, state *daRelayState, rejectedID [32]byte, wantPeerBytes uint64) {
+	t.Helper()
+	if got := state.orphanBytesForPeer("127.0.0.1:3000"); got != wantPeerBytes {
+		t.Fatalf("peer quota bytes = %d, want %d", got, wantPeerBytes)
+	}
+	if got := state.orphanBytes; got != wantPeerBytes {
+		t.Fatalf("global orphan bytes = %d, want %d", got, wantPeerBytes)
+	}
+	if _, ok := state.sets[rejectedID]; ok {
+		t.Fatalf("rejected port-hop candidate mutated state")
+	}
+	if got := state.orphanBytesForDAID(rejectedID); got != 0 {
+		t.Fatalf("rejected da_id accounting = %d, want 0", got)
 	}
 }

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -309,6 +309,11 @@ func TestDARelayMissingChunkIndexesReturnsNilWhenComplete(t *testing.T) {
 	if missing := record.missingChunkIndexes(); missing != nil {
 		t.Fatalf("missing chunk indexes = %v, want nil", missing)
 	}
+	record.state = daRelayStateCompleteSet
+	record.chunks = map[uint16]daRelayChunk{}
+	if missing := record.missingChunkIndexes(); missing != nil {
+		t.Fatalf("complete-set missing chunk indexes = %v, want nil", missing)
+	}
 }
 
 func TestDARelayRejectsStagedIndexAndCapFailuresBeforeMutation(t *testing.T) {
@@ -699,6 +704,187 @@ func TestDARelayRejectsIntegrityAndPinnedCapSafely(t *testing.T) {
 	}
 }
 
+func TestDARelayRejectsCompletionOverflowBeforeMutation(t *testing.T) {
+	caps := defaultDARelayCaps()
+	caps.orphanPoolBytes = ^uint64(0)
+	caps.orphanPoolPerPeerBytes = ^uint64(0)
+	caps.orphanPoolPerDAIDBytes = ^uint64(0)
+	caps.orphanCommitOverheadBytes = ^uint64(0)
+	caps.pinnedPayloadBytes = ^uint64(0)
+
+	t.Run("commit completes orphan chunk", func(t *testing.T) {
+		state := newDARelayStateForTest(t, caps)
+		daID := daRelayTestID(55)
+		payload := []byte{1}
+		mustAddDAChunk(t, state, "peer-a", daRelayTestChunkPayload(daID, 0, ^uint64(0), payload))
+
+		_, err := state.addDACommit("peer-b", daRelayTestCommitForPayloads(daID, 1, payload))
+		requireDAErr(t, err, errDARelayArithmeticOverflow)
+
+		record := state.sets[daID]
+		if record.commit.chunkCount != 0 || record.state != daRelayStateOrphanChunks || len(record.chunks) != 1 {
+			t.Fatalf("commit completion overflow mutated record: state=%v commit=%d chunks=%d", record.state, record.commit.chunkCount, len(record.chunks))
+		}
+	})
+
+	t.Run("chunk completes staged commit", func(t *testing.T) {
+		state := newDARelayStateForTest(t, caps)
+		daID := daRelayTestID(56)
+		payload := []byte{1}
+		mustAddDACommit(t, state, "peer-a", daRelayTestCommitForPayloads(daID, ^uint64(0), payload))
+
+		_, err := state.addDAChunk("peer-b", daRelayTestChunkPayload(daID, 0, 1, payload))
+		requireDAErr(t, err, errDARelayArithmeticOverflow)
+
+		record := state.sets[daID]
+		if record.state != daRelayStateStagedCommit || len(record.chunks) != 0 || state.pinnedPayloadBytes != 0 {
+			t.Fatalf("chunk completion overflow mutated record: state=%v chunks=%d pinned=%d", record.state, len(record.chunks), state.pinnedPayloadBytes)
+		}
+	})
+}
+
+func TestDARelayRejectsMismatchApplyFailureBeforeMutation(t *testing.T) {
+	t.Run("commit mismatch drop path", func(t *testing.T) {
+		state := newDARelayStateForTest(t, defaultDARelayCaps())
+		daID := daRelayTestID(57)
+		payload0 := []byte("payload-a")
+		payload1 := []byte("payload-b")
+		mustAddDAChunk(t, state, "peer-a", daRelayTestChunkPayload(daID, 0, uint64(len(payload0)), payload0))
+		mustAddDAChunk(t, state, "peer-a", daRelayTestChunkPayload(daID, 1, uint64(len(payload1)), payload1))
+		state.orphanBytesByPeerQuotaKey[peerQuotaKey("peer-a")] = 0
+
+		_, err := state.addDACommit("peer-b", daRelayTestCommitForPayloads(daID, 1, payload1, payload0))
+		requireDAErr(t, err, errDARelayArithmeticOverflow)
+
+		record := state.sets[daID]
+		if record.commit.chunkCount != 0 || len(record.chunks) != 2 {
+			t.Fatalf("commit mismatch apply failure mutated record: commit=%d chunks=%d", record.commit.chunkCount, len(record.chunks))
+		}
+	})
+
+	t.Run("chunk mismatch replaceable path", func(t *testing.T) {
+		state := newDARelayStateForTest(t, defaultDARelayCaps())
+		daID := daRelayTestID(58)
+		payload0 := []byte("payload-a")
+		payload1 := []byte("payload-b")
+		mustAddDACommit(t, state, "peer-a", daRelayTestCommitForPayloads(daID, 1, payload0, payload1))
+		mustAddDAChunk(t, state, "peer-b", daRelayTestChunkPayload(daID, 0, uint64(len(payload0)), payload0))
+		state.orphanBytesByPeerQuotaKey[peerQuotaKey("peer-b")] = 0
+
+		_, err := state.addDAChunk("peer-c", daRelayTestChunkPayload(daID, 1, uint64(len(payload1)), []byte("wrong")))
+		requireDAErr(t, err, errDARelayArithmeticOverflow)
+
+		record := state.sets[daID]
+		if record.replaceableChunks[0] || len(record.chunks) != 1 || record.state != daRelayStateStagedCommit {
+			t.Fatalf("chunk mismatch apply failure mutated record: replaceable=%v chunks=%d state=%v", record.replaceableChunks, len(record.chunks), record.state)
+		}
+	})
+}
+
+func TestDARelayStageChunkRejectsDuplicateWithoutMutation(t *testing.T) {
+	state := newDARelayStateForTest(t, defaultDARelayCaps())
+	daID := daRelayTestID(59)
+	chunk := daRelayTestChunk(daID, 0, 1)
+	record := mustAddDAChunk(t, state, "peer-a", chunk)
+
+	state.mu.Lock()
+	staged, err := state.stageDAChunkRecordLocked("peer-b", chunk, chunk.payload)
+	state.mu.Unlock()
+	requireDAErr(t, err, errDARelayDuplicateChunk)
+
+	if len(staged.chunks) != 0 || len(state.sets[daID].chunks) != len(record.chunks) || state.orphanBytes != record.wireBytes {
+		t.Fatalf("duplicate stage mutated state: staged=%d stored=%d orphan=%d", len(staged.chunks), len(state.sets[daID].chunks), state.orphanBytes)
+	}
+}
+
+func TestDARelayCompletionSnapshotRejectsMismatches(t *testing.T) {
+	daID := daRelayTestID(60)
+	payload0 := []byte("payload-a")
+	payload1 := []byte("payload-b")
+	record := daRelaySetRecord{
+		daID:   daID,
+		state:  daRelayStateStagedCommit,
+		commit: daRelayTestCommitForPayloads(daID, 1, payload0, payload1),
+		chunks: map[uint16]daRelayChunk{
+			0: daRelayTestChunkPayload(daID, 0, uint64(len(payload0)), payload0),
+			1: daRelayTestChunkPayload(daID, 1, uint64(len(payload1)), payload1),
+		},
+	}
+	snapshot, complete := record.completionSnapshot()
+	if !complete {
+		t.Fatalf("snapshot setup did not complete")
+	}
+	if !snapshot.matchesRecord(record) {
+		t.Fatalf("snapshot should match original record")
+	}
+
+	if snapshot.matchesRecord(daRelaySetRecord{}) {
+		t.Fatalf("snapshot matched incomplete record")
+	}
+	mismatched := snapshot
+	mismatched.daID = daRelayTestID(61)
+	if mismatched.matchesRecord(record) {
+		t.Fatalf("snapshot matched wrong da_id")
+	}
+	mismatched = snapshot
+	mismatched.chunks = mismatched.chunks[:1]
+	if mismatched.matchesRecord(record) {
+		t.Fatalf("snapshot matched wrong chunk length")
+	}
+	mismatched = snapshot
+	mismatched.chunks = append([]daRelayCompletionChunkSnapshot(nil), snapshot.chunks...)
+	mismatched.chunks[0].chunkIndex = 1
+	if mismatched.matchesRecord(record) {
+		t.Fatalf("snapshot matched wrong chunk index")
+	}
+	mismatched = snapshot
+	mismatched.chunks = append([]daRelayCompletionChunkSnapshot(nil), snapshot.chunks...)
+	mismatched.chunks[0].chunkHash[0] ^= 0xff
+	if mismatched.matchesRecord(record) {
+		t.Fatalf("snapshot matched wrong chunk hash")
+	}
+	mismatched = snapshot
+	mismatched.chunks = append([]daRelayCompletionChunkSnapshot(nil), snapshot.chunks...)
+	mismatched.chunks[0].payload = append(cloneBytes(mismatched.chunks[0].payload), 0)
+	if mismatched.matchesRecord(record) {
+		t.Fatalf("snapshot matched wrong payload length")
+	}
+}
+
+func TestDARelayMarkMatchingChunksRejectsNoopSnapshots(t *testing.T) {
+	state := newDARelayStateForTest(t, defaultDARelayCaps())
+	daID := daRelayTestID(62)
+	payload := []byte("payload")
+	sourceRecord := daRelaySetRecord{
+		daID:   daID,
+		state:  daRelayStateStagedCommit,
+		commit: daRelayTestCommitForPayloads(daID, 1, payload),
+		chunks: map[uint16]daRelayChunk{
+			0: daRelayTestChunkPayload(daID, 0, uint64(len(payload)), payload),
+		},
+	}
+	snapshot, complete := sourceRecord.completionSnapshot()
+	if !complete {
+		t.Fatalf("snapshot setup did not complete")
+	}
+	completeRecord := sourceRecord
+	completeRecord.state = daRelayStateCompleteSet
+	state.sets[daID] = completeRecord
+	applied, err := state.markMatchingCompletionChunksReplaceable(snapshot)
+	if err != nil || applied {
+		t.Fatalf("complete record mark applied=%v err=%v, want false nil", applied, err)
+	}
+
+	stagedRecord := completeRecord
+	stagedRecord.state = daRelayStateStagedCommit
+	stagedRecord.chunks = map[uint16]daRelayChunk{}
+	state.sets[daID] = stagedRecord
+	applied, err = state.markMatchingCompletionChunksReplaceable(snapshot)
+	if err != nil || applied {
+		t.Fatalf("empty matching mark applied=%v err=%v, want false nil", applied, err)
+	}
+}
+
 func TestDARelayPinnedPayloadDeltaKeepsOverflowAndCapErrorsDistinct(t *testing.T) {
 	caps := defaultDARelayCaps()
 	caps.pinnedPayloadBytes = 1
@@ -720,6 +906,30 @@ func TestDARelayPinnedPayloadDeltaKeepsOverflowAndCapErrorsDistinct(t *testing.T
 	)
 	state.mu.Unlock()
 	requireDAErr(t, err, errDARelayPinnedPayloadCapExceeded)
+
+	_, err = (daRelaySetRecord{state: daRelayStateCompleteSet, payloadBytes: 1, wireBytes: ^uint64(0)}).pinnedPayloadAccountingBytes()
+	requireDAErr(t, err, errDARelayArithmeticOverflow)
+
+	_, err = (daRelaySetRecord{
+		state:        daRelayStateCompleteSet,
+		payloadBytes: 1,
+		wireBytes:    ^uint64(0) - daCompleteSetRecordFootprint,
+		commit:       daRelayCommit{chunkCount: 1},
+	}).pinnedPayloadAccountingBytes()
+	requireDAErr(t, err, errDARelayArithmeticOverflow)
+
+	_, err = (daRelaySetRecord{
+		state:     daRelayStateStagedCommit,
+		wireBytes: ^uint64(0),
+		commit: daRelayCommit{
+			peerQuotaKey: "peer-a",
+			wireBytes:    ^uint64(0),
+		},
+		chunks: map[uint16]daRelayChunk{
+			0: {peerQuotaKey: "peer-a", wireBytes: 1},
+		},
+	}).orphanAccounting()
+	requireDAErr(t, err, errDARelayArithmeticOverflow)
 }
 
 func TestDARelayCapsRejectInvalidLimits(t *testing.T) {

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -269,6 +269,7 @@ func TestDARelayRejectsDuplicatesBeforeMutation(t *testing.T) {
 
 	chunk := daRelayTestChunk(daID, 0, 7)
 	record = mustAddDAChunk(t, state, "peer-c", chunk)
+	chunk.chunkHash[0] ^= 0xff
 	_, err = state.addDAChunk("peer-d", chunk)
 	requireDAErr(t, err, errDARelayDuplicateChunk)
 	if len(state.sets[daID].chunks) != 1 || state.orphanBytes != record.wireBytes {
@@ -294,11 +295,16 @@ func TestDARelayRejectedCandidatesDoNotMutateStoredChunks(t *testing.T) {
 	state = newDARelayStateForTest(t, defaultDARelayCaps())
 	mustAddDACommit(t, state, "peer-a", daRelayTestCommit(daID, 2, 1))
 	state.caps.orphanPoolPerDAIDBytes = state.orphanBytes
-	_, err = state.addDAChunk("peer-b", daRelayTestChunk(daID, 1, 1))
+	chunk := daRelayTestChunk(daID, 1, 1)
+	_, err = state.addDAChunk("peer-b", chunk)
 	requireDAErr(t, err, errDARelayOrphanDAIDCapExceeded)
 	if _, ok := state.sets[daID].chunks[1]; ok {
 		t.Fatalf("failed chunk insert mutated stored staged record")
 	}
+	chunk.chunkIndex = 2
+	chunk.chunkHash[0] ^= 0xff
+	_, err = state.addDAChunk("peer-b", chunk)
+	requireDAErr(t, err, errDARelayChunkIndexOutsideCommit)
 }
 
 func TestDARelayCompletesSetAndPinsPayload(t *testing.T) {

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -225,12 +225,43 @@ func TestDARelayReceivedTimeIsMonotonicLocalSequence(t *testing.T) {
 		t.Fatalf("new DA relay state: %v", err)
 	}
 
-	first := state.nextMonotonicReceivedTime()
-	second := state.nextMonotonicReceivedTime()
-	third := state.nextMonotonicReceivedTime()
+	first, err := state.nextMonotonicReceivedTime()
+	if err != nil {
+		t.Fatalf("next received time: %v", err)
+	}
+	second, err := state.nextMonotonicReceivedTime()
+	if err != nil {
+		t.Fatalf("next received time: %v", err)
+	}
+	third, err := state.nextMonotonicReceivedTime()
+	if err != nil {
+		t.Fatalf("next received time: %v", err)
+	}
 
 	if first != 1 || second != 2 || third != 3 {
 		t.Fatalf("received_time sequence = %d, %d, %d; want 1, 2, 3", first, second, third)
+	}
+}
+
+func TestDARelayReceivedTimeMonotonicAcrossMutationPaths(t *testing.T) {
+	state := newDARelayStateForTest(t, defaultDARelayCaps())
+
+	first, err := state.nextMonotonicReceivedTime()
+	if err != nil {
+		t.Fatalf("next received time: %v", err)
+	}
+	chunkRecord := mustAddDAChunk(t, state, "peer-a", daRelayTestChunk(daRelayTestID(51), 0, 1))
+	second, err := state.nextMonotonicReceivedTime()
+	if err != nil {
+		t.Fatalf("next received time: %v", err)
+	}
+	commitRecord := mustAddDACommit(t, state, "peer-b", daRelayTestCommit(daRelayTestID(52), 2, 1))
+
+	if !(first < chunkRecord.receivedTime && chunkRecord.receivedTime < second && second < commitRecord.receivedTime) {
+		t.Fatalf("received_time order first=%d chunk=%d second=%d commit=%d", first, chunkRecord.receivedTime, second, commitRecord.receivedTime)
+	}
+	if state.nextReceivedTime != commitRecord.receivedTime {
+		t.Fatalf("state received_time=%d, want %d", state.nextReceivedTime, commitRecord.receivedTime)
 	}
 }
 
@@ -260,6 +291,21 @@ func TestDARelayStagesCommitAndRetainsBoundedOrphans(t *testing.T) {
 	record.chunks[7] = daRelayTestChunk(daID, 7, 1)
 	if _, ok := state.sets[daID].chunks[7]; ok {
 		t.Fatalf("returned record aliases stored chunks")
+	}
+}
+
+func TestDARelayMissingChunkIndexesReturnsNilWhenComplete(t *testing.T) {
+	daID := daRelayTestID(53)
+	record := daRelaySetRecord{
+		commit: daRelayTestCommit(daID, 2, 1),
+		chunks: map[uint16]daRelayChunk{
+			0: daRelayTestChunk(daID, 0, 1),
+			1: daRelayTestChunk(daID, 1, 1),
+		},
+	}
+
+	if missing := record.missingChunkIndexes(); missing != nil {
+		t.Fatalf("missing chunk indexes = %v, want nil", missing)
 	}
 }
 
@@ -301,6 +347,8 @@ func TestDARelayRejectsStagedIndexAndCapFailuresBeforeMutation(t *testing.T) {
 	requireDAErr(t, err, errDARelayChunkIndexOutsideCommit)
 	_, err = state.addDACommit("peer-a", daRelayTestCommit(daID, 0, 1))
 	requireDAErr(t, err, errDARelayChunkCountInvalid)
+	_, err = state.addDACommit("peer-a", daRelayTestCommit(daID, uint16(consensus.MAX_DA_CHUNK_COUNT+1), 1))
+	requireDAErr(t, err, errDARelayChunkCountInvalid)
 	_, err = state.addDAChunk("peer-a", daRelayTestChunk(daID, uint16(consensus.MAX_DA_CHUNK_COUNT), 1))
 	requireDAErr(t, err, errDARelayChunkIndexOutOfRange)
 
@@ -311,6 +359,27 @@ func TestDARelayRejectsStagedIndexAndCapFailuresBeforeMutation(t *testing.T) {
 	mustAddDAChunk(t, overflowState, "peer-a", daRelayTestChunk(daID, 0, ^uint64(0)))
 	_, err = overflowState.addDACommit("peer-a", daRelayTestCommit(daID, 2, 1))
 	requireDAErr(t, err, errDARelayArithmeticOverflow)
+
+	chunkOnlyOverflowState := newDARelayStateForTest(t, caps)
+	mustAddDAChunk(t, chunkOnlyOverflowState, "peer-a", daRelayTestChunk(daID, 0, ^uint64(0)))
+	_, err = chunkOnlyOverflowState.addDAChunk("peer-a", daRelayTestChunk(daID, 1, 1))
+	requireDAErr(t, err, errDARelayArithmeticOverflow)
+	if len(chunkOnlyOverflowState.sets[daID].chunks) != 1 {
+		t.Fatalf("chunk overflow mutated chunk set: got %d chunks", len(chunkOnlyOverflowState.sets[daID].chunks))
+	}
+}
+
+func TestDARelayZeroRecordAccountingDoesNotAllocatePeerBytes(t *testing.T) {
+	accounting, err := (daRelaySetRecord{}).orphanAccounting()
+	if err != nil {
+		t.Fatalf("zero record accounting: %v", err)
+	}
+	if accounting.orphanBytes != 0 || accounting.commitBytes != 0 {
+		t.Fatalf("zero accounting totals orphan=%d commit=%d, want 0", accounting.orphanBytes, accounting.commitBytes)
+	}
+	if accounting.peerBytes != nil {
+		t.Fatalf("zero accounting peer map = %#v, want nil", accounting.peerBytes)
+	}
 }
 
 func TestDARelayRejectsZeroWireBytesBeforeMutation(t *testing.T) {

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -711,22 +711,36 @@ func TestDARelayRejectsSingleCandidateMismatchWithoutRetry(t *testing.T) {
 	payload := []byte("payload")
 	mustAddDACommit(t, state, "peer-a", daRelayTestCommitForPayloads(daID, 1, []byte("different")))
 
-	errCh := make(chan error, 1)
-	go func() {
-		_, err := state.addDAChunk("peer-b", daRelayTestChunkPayload(daID, 0, uint64(len(payload)), payload))
-		errCh <- err
-	}()
-
-	select {
-	case err := <-errCh:
-		requireDAErr(t, err, errDARelayPayloadCommitmentMismatch)
-	case <-time.After(2 * time.Second):
-		t.Fatal("single-candidate commitment mismatch did not return")
-	}
+	requireAddDAChunkErrWithin(t, state, "peer-b", daRelayTestChunkPayload(daID, 0, uint64(len(payload)), payload), errDARelayPayloadCommitmentMismatch)
 
 	record := state.sets[daID]
 	if record.state != daRelayStateStagedCommit || len(record.chunks) != 0 || state.pinnedPayloadBytes != 0 {
 		t.Fatalf("single-candidate mismatch mutated state: state=%v chunks=%d pinned=%d", record.state, len(record.chunks), state.pinnedPayloadBytes)
+	}
+}
+
+func TestDARelayRejectsBadReplaceableReplacementWithoutRetry(t *testing.T) {
+	state := newDARelayStateForTest(t, defaultDARelayCaps())
+	daID := daRelayTestID(64)
+	payload0 := []byte("payload-a")
+	payload1 := []byte("payload-b")
+	mustAddDACommit(t, state, "peer-a", daRelayTestCommitForPayloads(daID, 1, payload0, payload1))
+	mustAddDAChunk(t, state, "peer-b", daRelayTestChunkPayload(daID, 0, uint64(len(payload0)), []byte("stale")))
+	_, err := state.addDAChunk("peer-c", daRelayTestChunkPayload(daID, 1, uint64(len(payload1)), payload1))
+	requireDAErr(t, err, errDARelayPayloadCommitmentMismatch)
+	if !state.sets[daID].replaceableChunks[0] {
+		t.Fatalf("setup did not mark stale chunk replaceable")
+	}
+	record := mustAddDAChunk(t, state, "peer-c", daRelayTestChunkPayload(daID, 1, uint64(len(payload1)), payload1))
+	if record.state != daRelayStateStagedCommit || !record.replaceableChunks[0] || len(record.chunks) != 2 {
+		t.Fatalf("setup did not retain replaceable stale chunk with other chunk present: state=%v replaceable=%v chunks=%d", record.state, record.replaceableChunks, len(record.chunks))
+	}
+
+	requireAddDAChunkErrWithin(t, state, "peer-d", daRelayTestChunkPayload(daID, 0, uint64(len(payload0)), []byte("also-bad")), errDARelayPayloadCommitmentMismatch)
+
+	record = state.sets[daID]
+	if !record.replaceableChunks[0] || len(record.chunks) != 2 || state.pinnedPayloadBytes != 0 {
+		t.Fatalf("bad replacement mismatch mutated state: replaceable=%v chunks=%d pinned=%d", record.replaceableChunks, len(record.chunks), state.pinnedPayloadBytes)
 	}
 }
 
@@ -908,6 +922,13 @@ func TestDARelayMarkMatchingChunksRejectsNoopSnapshots(t *testing.T) {
 	retry, err = state.markMatchingCompletionChunksReplaceable(snapshot)
 	if err != nil || retry {
 		t.Fatalf("empty matching mark retry=%v err=%v, want false nil", retry, err)
+	}
+
+	stagedRecord.chunks[0] = daRelayTestChunkPayload(daID, 0, uint64(len(payload)), []byte("wrong"))
+	state.sets[daID] = stagedRecord
+	retry, err = state.markMatchingCompletionChunksReplaceable(snapshot)
+	if err != nil || retry {
+		t.Fatalf("mismatched matching mark retry=%v err=%v, want false nil", retry, err)
 	}
 }
 
@@ -1106,6 +1127,21 @@ func requireDAErr(t *testing.T, got error, want error) {
 	t.Helper()
 	if !errors.Is(got, want) {
 		t.Fatalf("err=%v, want %v", got, want)
+	}
+}
+
+func requireAddDAChunkErrWithin(t *testing.T, state *daRelayState, peer string, chunk daRelayChunk, want error) {
+	t.Helper()
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := state.addDAChunk(peer, chunk)
+		errCh <- err
+	}()
+	select {
+	case err := <-errCh:
+		requireDAErr(t, err, want)
+	case <-time.After(2 * time.Second):
+		t.Fatal("add DA chunk did not return")
 	}
 }
 

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -160,6 +160,46 @@ func TestDARelayPeerQuotaKeyPreventsPortHopping(t *testing.T) {
 	})
 }
 
+func TestDARelayEmptyPeerQuotaKeyIsCapped(t *testing.T) {
+	t.Run("chunk only", func(t *testing.T) {
+		caps := defaultDARelayCaps()
+		caps.orphanPoolPerPeerBytes = 10
+		state := newDARelayStateForTest(t, caps)
+		firstID := daRelayTestID(45)
+		secondID := daRelayTestID(46)
+
+		record := mustAddDAChunk(t, state, "", daRelayTestChunk(firstID, 0, 6))
+		_, err := state.addDAChunk("", daRelayTestChunk(secondID, 0, 5))
+		requireDAErr(t, err, errDARelayOrphanPeerCapExceeded)
+
+		if got := state.orphanBytesForPeer(""); got != record.wireBytes {
+			t.Fatalf("empty peer quota bytes = %d, want %d", got, record.wireBytes)
+		}
+		if _, ok := state.sets[secondID]; ok {
+			t.Fatalf("empty-peer cap rejection mutated state")
+		}
+	})
+
+	t.Run("staged commit", func(t *testing.T) {
+		caps := defaultDARelayCaps()
+		caps.orphanPoolPerPeerBytes = 10
+		state := newDARelayStateForTest(t, caps)
+		firstID := daRelayTestID(47)
+		secondID := daRelayTestID(48)
+
+		record := mustAddDACommit(t, state, "", daRelayTestCommit(firstID, 2, 6))
+		_, err := state.addDACommit("", daRelayTestCommit(secondID, 2, 5))
+		requireDAErr(t, err, errDARelayOrphanPeerCapExceeded)
+
+		if got := state.orphanBytesForPeer(""); got != record.wireBytes {
+			t.Fatalf("empty peer quota bytes = %d, want %d", got, record.wireBytes)
+		}
+		if _, ok := state.sets[secondID]; ok {
+			t.Fatalf("empty-peer commit cap rejection mutated state")
+		}
+	})
+}
+
 func TestDARelayDAIDAccountingDeletesZeroBytes(t *testing.T) {
 	state, err := newDARelayState(defaultDARelayCaps())
 	if err != nil {
@@ -284,6 +324,26 @@ func TestDARelayRejectsZeroWireBytesBeforeMutation(t *testing.T) {
 
 	if len(state.sets) != 0 || state.orphanBytes != 0 || state.orphanCommitOverheadBytes != 0 {
 		t.Fatalf("zero wire rejection mutated state: sets=%d orphan=%d commit=%d", len(state.sets), state.orphanBytes, state.orphanCommitOverheadBytes)
+	}
+}
+
+func TestDARelayRejectsReceivedTimeOverflowBeforeMutation(t *testing.T) {
+	chunkState := newDARelayStateForTest(t, defaultDARelayCaps())
+	chunkState.nextReceivedTime = ^uint64(0)
+	chunkID := daRelayTestID(49)
+	_, err := chunkState.addDAChunk("peer-a", daRelayTestChunk(chunkID, 0, 1))
+	requireDAErr(t, err, errDARelayArithmeticOverflow)
+	if len(chunkState.sets) != 0 || chunkState.nextReceivedTime != ^uint64(0) {
+		t.Fatalf("chunk time overflow mutated state: sets=%d time=%d", len(chunkState.sets), chunkState.nextReceivedTime)
+	}
+
+	commitState := newDARelayStateForTest(t, defaultDARelayCaps())
+	commitState.nextReceivedTime = ^uint64(0)
+	commitID := daRelayTestID(50)
+	_, err = commitState.addDACommit("peer-a", daRelayTestCommit(commitID, 2, 1))
+	requireDAErr(t, err, errDARelayArithmeticOverflow)
+	if len(commitState.sets) != 0 || commitState.nextReceivedTime != ^uint64(0) {
+		t.Fatalf("commit time overflow mutated state: sets=%d time=%d", len(commitState.sets), commitState.nextReceivedTime)
 	}
 }
 

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha3"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
 )
@@ -441,10 +442,10 @@ func TestDARelayRejectsReceivedTimeOverflowBeforeMutation(t *testing.T) {
 	}
 	replaceableState.sets[replaceableID] = replaceableRecord
 	replaceableState.nextReceivedTime = ^uint64(0)
-	applied, err := replaceableState.markMatchingCompletionChunksReplaceable(snapshot)
+	retry, err := replaceableState.markMatchingCompletionChunksReplaceable(snapshot)
 	requireDAErr(t, err, errDARelayArithmeticOverflow)
-	if applied || replaceableState.sets[replaceableID].replaceableChunks[0] || replaceableState.nextReceivedTime != ^uint64(0) {
-		t.Fatalf("replaceable time overflow mutated state: applied=%v replaceable=%v time=%d", applied, replaceableState.sets[replaceableID].replaceableChunks, replaceableState.nextReceivedTime)
+	if retry || replaceableState.sets[replaceableID].replaceableChunks[0] || replaceableState.nextReceivedTime != ^uint64(0) {
+		t.Fatalf("replaceable time overflow mutated state: retry=%v replaceable=%v time=%d", retry, replaceableState.sets[replaceableID].replaceableChunks, replaceableState.nextReceivedTime)
 	}
 }
 
@@ -704,6 +705,31 @@ func TestDARelayRejectsIntegrityAndPinnedCapSafely(t *testing.T) {
 	}
 }
 
+func TestDARelayRejectsSingleCandidateMismatchWithoutRetry(t *testing.T) {
+	state := newDARelayStateForTest(t, defaultDARelayCaps())
+	daID := daRelayTestID(63)
+	payload := []byte("payload")
+	mustAddDACommit(t, state, "peer-a", daRelayTestCommitForPayloads(daID, 1, []byte("different")))
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := state.addDAChunk("peer-b", daRelayTestChunkPayload(daID, 0, uint64(len(payload)), payload))
+		errCh <- err
+	}()
+
+	select {
+	case err := <-errCh:
+		requireDAErr(t, err, errDARelayPayloadCommitmentMismatch)
+	case <-time.After(2 * time.Second):
+		t.Fatal("single-candidate commitment mismatch did not return")
+	}
+
+	record := state.sets[daID]
+	if record.state != daRelayStateStagedCommit || len(record.chunks) != 0 || state.pinnedPayloadBytes != 0 {
+		t.Fatalf("single-candidate mismatch mutated state: state=%v chunks=%d pinned=%d", record.state, len(record.chunks), state.pinnedPayloadBytes)
+	}
+}
+
 func TestDARelayRejectsCompletionOverflowBeforeMutation(t *testing.T) {
 	caps := defaultDARelayCaps()
 	caps.orphanPoolBytes = ^uint64(0)
@@ -870,18 +896,18 @@ func TestDARelayMarkMatchingChunksRejectsNoopSnapshots(t *testing.T) {
 	completeRecord := sourceRecord
 	completeRecord.state = daRelayStateCompleteSet
 	state.sets[daID] = completeRecord
-	applied, err := state.markMatchingCompletionChunksReplaceable(snapshot)
-	if err != nil || applied {
-		t.Fatalf("complete record mark applied=%v err=%v, want false nil", applied, err)
+	retry, err := state.markMatchingCompletionChunksReplaceable(snapshot)
+	if err != nil || !retry {
+		t.Fatalf("complete record mark retry=%v err=%v, want true nil", retry, err)
 	}
 
 	stagedRecord := completeRecord
 	stagedRecord.state = daRelayStateStagedCommit
 	stagedRecord.chunks = map[uint16]daRelayChunk{}
 	state.sets[daID] = stagedRecord
-	applied, err = state.markMatchingCompletionChunksReplaceable(snapshot)
-	if err != nil || applied {
-		t.Fatalf("empty matching mark applied=%v err=%v, want false nil", applied, err)
+	retry, err = state.markMatchingCompletionChunksReplaceable(snapshot)
+	if err != nil || retry {
+		t.Fatalf("empty matching mark retry=%v err=%v, want false nil", retry, err)
 	}
 }
 

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -283,7 +283,7 @@ func TestDARelayRejectedCandidatesDoNotMutateStoredChunks(t *testing.T) {
 	mustAddDAChunk(t, state, "peer-a", daRelayTestChunk(daID, 0, 1))
 	mustAddDAChunk(t, state, "peer-a", daRelayTestChunk(daID, 2, 1))
 	state.caps.orphanCommitOverheadBytes = 1
-	_, err := state.addDACommit("peer-b", daRelayTestCommit(daID, 1, 2))
+	_, err := state.addDACommit("peer-b", daRelayTestCommit(daID, 2, 2))
 	requireDAErr(t, err, errDARelayOrphanCommitCapExceeded)
 	if _, ok := state.sets[daID].chunks[2]; !ok {
 		t.Fatalf("failed commit pruned stored orphan chunk")
@@ -390,9 +390,12 @@ func TestDARelayRejectsIntegrityAndPinnedCapBeforeMutation(t *testing.T) {
 	payload1 := []byte("payload-b")
 	mustAddDAChunk(t, state, "peer-a", daRelayTestChunkPayload(daID, 0, uint64(len(payload0)), payload0))
 	mustAddDAChunk(t, state, "peer-a", daRelayTestChunkPayload(daID, 1, uint64(len(payload1)), payload1))
-	record := mustAddDACommit(t, state, "peer-b", daRelayTestCommitForPayloads(daID, 1, payload1, payload0))
-	if record.state != daRelayStateStagedCommit || len(record.chunks) != 0 || state.pinnedPayloadBytes != 0 {
-		t.Fatalf("commitment mismatch state=%v chunks=%d pinned=%d", record.state, len(record.chunks), state.pinnedPayloadBytes)
+	beforeOrphanBytes := state.orphanBytes
+	_, err = state.addDACommit("peer-b", daRelayTestCommitForPayloads(daID, 1, payload1, payload0))
+	requireDAErr(t, err, errDARelayPayloadCommitmentMismatch)
+	record := state.sets[daID]
+	if record.commit.chunkCount != 0 || len(record.chunks) != 2 || state.orphanBytes != beforeOrphanBytes || state.pinnedPayloadBytes != 0 {
+		t.Fatalf("commitment mismatch mutated state: commit=%d chunks=%d orphan=%d want orphan=%d pinned=%d", record.commit.chunkCount, len(record.chunks), state.orphanBytes, beforeOrphanBytes, state.pinnedPayloadBytes)
 	}
 
 	state = newDARelayStateForTest(t, defaultDARelayCaps())

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -320,8 +320,9 @@ func TestDARelayCompletesSetAndPinsPayload(t *testing.T) {
 	if record.state != daRelayStateCompleteSet {
 		t.Fatalf("state=%v, want COMPLETE_SET", record.state)
 	}
-	if record.payloadBytes != uint64(len(payload0)+len(payload1)) || state.pinnedPayloadBytes != record.payloadBytes {
-		t.Fatalf("payload bytes record=%d pinned=%d", record.payloadBytes, state.pinnedPayloadBytes)
+	wantPinned := mustPinnedPayloadAccounting(t, record)
+	if record.payloadBytes != uint64(len(payload0)+len(payload1)) || state.pinnedPayloadBytes != wantPinned {
+		t.Fatalf("payload bytes record=%d pinned=%d want pinned=%d", record.payloadBytes, state.pinnedPayloadBytes, wantPinned)
 	}
 	if state.orphanBytes != 0 || len(state.orphanBytesByDAID) != 0 {
 		t.Fatalf("complete set left orphan accounting: global=%d da=%d", state.orphanBytes, len(state.orphanBytesByDAID))
@@ -415,6 +416,16 @@ func TestDARelayRejectsIntegrityAndPinnedCapBeforeMutation(t *testing.T) {
 	requireDAErr(t, err, errDARelayPinnedPayloadCapExceeded)
 	if state.sets[daID].state != daRelayStateStagedCommit || len(state.sets[daID].chunks) != 0 || state.pinnedPayloadBytes != 0 {
 		t.Fatalf("pinned cap rejection mutated state: state=%v chunks=%d pinned=%d", state.sets[daID].state, len(state.sets[daID].chunks), state.pinnedPayloadBytes)
+	}
+
+	caps = defaultDARelayCaps()
+	caps.pinnedPayloadBytes = uint64(len(payload0))
+	state = newDARelayStateForTest(t, caps)
+	mustAddDACommit(t, state, "peer-a", daRelayTestCommitForPayloads(daID, 1, payload0))
+	_, err = state.addDAChunk("peer-b", daRelayTestChunkPayload(daID, 0, uint64(len(payload0)), payload0))
+	requireDAErr(t, err, errDARelayPinnedPayloadCapExceeded)
+	if state.sets[daID].state != daRelayStateStagedCommit || state.pinnedPayloadBytes != 0 {
+		t.Fatalf("footprint cap rejection mutated state: state=%v pinned=%d", state.sets[daID].state, state.pinnedPayloadBytes)
 	}
 }
 
@@ -590,4 +601,13 @@ func requireDAErr(t *testing.T, got error, want error) {
 	if !errors.Is(got, want) {
 		t.Fatalf("err=%v, want %v", got, want)
 	}
+}
+
+func mustPinnedPayloadAccounting(t *testing.T, record daRelaySetRecord) uint64 {
+	t.Helper()
+	bytes, err := record.pinnedPayloadAccountingBytes()
+	if err != nil {
+		t.Fatalf("pinned payload accounting: %v", err)
+	}
+	return bytes
 }

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -326,6 +326,38 @@ func TestDARelayCompletesSetAndPinsPayload(t *testing.T) {
 	}
 }
 
+func TestDARelayCloneModesKeepStateCopiesShallowAndCallerCopiesDeep(t *testing.T) {
+	daID := daRelayTestID(6)
+	record := daRelaySetRecord{
+		daID: daID,
+		chunks: map[uint16]daRelayChunk{
+			0: daRelayTestChunkPayload(daID, 0, 17, []byte("immutable-payload")),
+		},
+	}
+
+	stateClone := record.cloneForStateMutation()
+	originalChunk := record.chunks[0]
+	stateChunk := stateClone.chunks[0]
+	if &stateChunk.payload[0] != &originalChunk.payload[0] {
+		t.Fatalf("state mutation clone deep-copied payload")
+	}
+	stateClone.chunks[1] = daRelayTestChunkPayload(daID, 1, 1, []byte("second"))
+	if _, ok := record.chunks[1]; ok {
+		t.Fatalf("state mutation clone aliases chunk map")
+	}
+
+	callerClone := record.clone()
+	callerChunk := callerClone.chunks[0]
+	if &callerChunk.payload[0] == &originalChunk.payload[0] {
+		t.Fatalf("caller clone reused payload")
+	}
+	callerChunk.payload[0] ^= 0xff
+	callerClone.chunks[0] = callerChunk
+	if record.chunks[0].payload[0] == callerClone.chunks[0].payload[0] {
+		t.Fatalf("caller clone aliases stored payload")
+	}
+}
+
 func TestDARelayRejectsIntegrityAndPinnedCapBeforeMutation(t *testing.T) {
 	daID := daRelayTestID(6)
 	state := newDARelayStateForTest(t, defaultDARelayCaps())

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -333,8 +333,40 @@ func TestDARelayCompletesSetAndPinsPayload(t *testing.T) {
 	}
 }
 
-func TestDARelayCloneModesKeepStateCopiesShallowAndCallerCopiesDeep(t *testing.T) {
+func TestDARelayCommitCompletesOrphanChunks(t *testing.T) {
 	daID := daRelayTestID(6)
+	payload0 := []byte("orphan-zero")
+	payload1 := []byte("orphan-one")
+
+	state := newDARelayStateForTest(t, defaultDARelayCaps())
+	mustAddDAChunk(t, state, "peer-a", daRelayTestChunkPayload(daID, 0, uint64(len(payload0)), payload0))
+	mustAddDAChunk(t, state, "peer-b", daRelayTestChunkPayload(daID, 1, uint64(len(payload1)), payload1))
+	record := mustAddDACommit(t, state, "peer-c", daRelayTestCommitForPayloads(daID, 1, payload0, payload1))
+
+	if record.state != daRelayStateCompleteSet {
+		t.Fatalf("state=%v, want COMPLETE_SET", record.state)
+	}
+	if record.payloadBytes != uint64(len(payload0)+len(payload1)) {
+		t.Fatalf("payload bytes=%d, want %d", record.payloadBytes, len(payload0)+len(payload1))
+	}
+	wantPinned := mustPinnedPayloadAccounting(t, record)
+	if state.pinnedPayloadBytes != wantPinned || state.orphanBytes != 0 || state.orphanCommitOverheadBytes != 0 {
+		t.Fatalf("accounting pinned=%d orphan=%d commit=%d want pinned=%d", state.pinnedPayloadBytes, state.orphanBytes, state.orphanCommitOverheadBytes, wantPinned)
+	}
+
+	caps := defaultDARelayCaps()
+	caps.pinnedPayloadBytes = 1
+	cappedState := newDARelayStateForTest(t, caps)
+	mustAddDAChunk(t, cappedState, "peer-a", daRelayTestChunkPayload(daID, 0, uint64(len(payload0)), payload0))
+	_, err := cappedState.addDACommit("peer-c", daRelayTestCommitForPayloads(daID, 1, payload0))
+	requireDAErr(t, err, errDARelayPinnedPayloadCapExceeded)
+	if cappedState.sets[daID].commit.chunkCount != 0 || cappedState.pinnedPayloadBytes != 0 {
+		t.Fatalf("pinned cap rejection mutated commit=%d pinned=%d", cappedState.sets[daID].commit.chunkCount, cappedState.pinnedPayloadBytes)
+	}
+}
+
+func TestDARelayCloneModesKeepStateCopiesShallowAndCallerCopiesDeep(t *testing.T) {
+	daID := daRelayTestID(7)
 	record := daRelaySetRecord{
 		daID: daID,
 		chunks: map[uint16]daRelayChunk{
@@ -365,8 +397,8 @@ func TestDARelayCloneModesKeepStateCopiesShallowAndCallerCopiesDeep(t *testing.T
 	}
 }
 
-func TestDARelayRejectsIntegrityAndPinnedCapBeforeMutation(t *testing.T) {
-	daID := daRelayTestID(6)
+func TestDARelayRejectsIntegrityAndPinnedCapSafely(t *testing.T) {
+	daID := daRelayTestID(8)
 	state := newDARelayStateForTest(t, defaultDARelayCaps())
 	badChunk := daRelayTestChunkPayload(daID, 0, 3, []byte("bad"))
 	badChunk.chunkHash[0] ^= 0xff
@@ -391,12 +423,21 @@ func TestDARelayRejectsIntegrityAndPinnedCapBeforeMutation(t *testing.T) {
 	payload1 := []byte("payload-b")
 	mustAddDAChunk(t, state, "peer-a", daRelayTestChunkPayload(daID, 0, uint64(len(payload0)), payload0))
 	mustAddDAChunk(t, state, "peer-a", daRelayTestChunkPayload(daID, 1, uint64(len(payload1)), payload1))
-	beforeOrphanBytes := state.orphanBytes
 	_, err = state.addDACommit("peer-b", daRelayTestCommitForPayloads(daID, 1, payload1, payload0))
 	requireDAErr(t, err, errDARelayPayloadCommitmentMismatch)
 	record := state.sets[daID]
-	if record.commit.chunkCount != 0 || len(record.chunks) != 2 || state.orphanBytes != beforeOrphanBytes || state.pinnedPayloadBytes != 0 {
-		t.Fatalf("commitment mismatch mutated state: commit=%d chunks=%d orphan=%d want orphan=%d pinned=%d", record.commit.chunkCount, len(record.chunks), state.orphanBytes, beforeOrphanBytes, state.pinnedPayloadBytes)
+	if record.state != daRelayStateStagedCommit || record.commit.chunkCount != 2 || len(record.chunks) != 0 || state.orphanBytes != record.wireBytes || state.pinnedPayloadBytes != 0 {
+		t.Fatalf("commitment mismatch failed to preserve first commit cleanly: state=%v commit=%d chunks=%d orphan=%d record=%d pinned=%d", record.state, record.commit.chunkCount, len(record.chunks), state.orphanBytes, record.wireBytes, state.pinnedPayloadBytes)
+	}
+	_, err = state.addDACommit("peer-d", daRelayTestCommitForPayloads(daID, 1, payload0, payload1))
+	requireDAErr(t, err, errDARelayDuplicateCommit)
+	record = mustAddDAChunk(t, state, "peer-a", daRelayTestChunkPayload(daID, 0, uint64(len(payload1)), payload1))
+	record = mustAddDAChunk(t, state, "peer-a", daRelayTestChunkPayload(daID, 1, uint64(len(payload0)), payload0))
+	if record.state != daRelayStateCompleteSet {
+		t.Fatalf("state after orphan recovery=%v, want COMPLETE_SET", record.state)
+	}
+	if record.commit.payloadCommitment != daRelayPayloadCommitment(payload1, payload0) {
+		t.Fatalf("complete set did not retain first commit")
 	}
 
 	state = newDARelayStateForTest(t, defaultDARelayCaps())
@@ -404,8 +445,12 @@ func TestDARelayRejectsIntegrityAndPinnedCapBeforeMutation(t *testing.T) {
 	mustAddDAChunk(t, state, "peer-b", daRelayTestChunkPayload(daID, 0, uint64(len(payload0)), payload0))
 	_, err = state.addDAChunk("peer-c", daRelayTestChunkPayload(daID, 1, uint64(len(payload1)), []byte("payload-x")))
 	requireDAErr(t, err, errDARelayPayloadCommitmentMismatch)
-	if len(state.sets[daID].chunks) != 1 || state.pinnedPayloadBytes != 0 {
-		t.Fatalf("chunk mismatch mutated state: chunks=%d pinned=%d", len(state.sets[daID].chunks), state.pinnedPayloadBytes)
+	if state.sets[daID].state != daRelayStateStagedCommit || len(state.sets[daID].chunks) != 1 || state.pinnedPayloadBytes != 0 {
+		t.Fatalf("chunk mismatch mutated staged chunks: state=%v chunks=%d pinned=%d", state.sets[daID].state, len(state.sets[daID].chunks), state.pinnedPayloadBytes)
+	}
+	record = mustAddDAChunk(t, state, "peer-c", daRelayTestChunkPayload(daID, 1, uint64(len(payload1)), payload1))
+	if record.state != daRelayStateCompleteSet {
+		t.Fatalf("state after staged recovery=%v, want COMPLETE_SET", record.state)
 	}
 
 	caps := defaultDARelayCaps()

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -238,11 +238,45 @@ func TestDARelayRejectsStagedIndexAndCapFailuresBeforeMutation(t *testing.T) {
 	overflowState := newDARelayStateForTest(t, caps)
 	mustAddDAChunk(t, overflowState, "peer-a", daRelayTestChunk(daID, 0, ^uint64(0)))
 	_, err = overflowState.addDACommit("peer-a", daRelayTestCommit(daID, 2, 1))
-	requireDAErr(t, err, errDARelayOrphanPoolCapExceeded)
+	requireDAErr(t, err, errDARelayArithmeticOverflow)
+}
+
+func TestDARelayRejectsZeroWireBytesBeforeMutation(t *testing.T) {
+	daID := daRelayTestID(3)
+	state := newDARelayStateForTest(t, defaultDARelayCaps())
+
+	_, err := state.addDACommit("peer-a", daRelayTestCommit(daID, 1, 0))
+	requireDAErr(t, err, errDARelayWireBytesInvalid)
+	_, err = state.addDAChunk("peer-a", daRelayTestChunk(daID, 0, 0))
+	requireDAErr(t, err, errDARelayWireBytesInvalid)
+
+	if len(state.sets) != 0 || state.orphanBytes != 0 || state.orphanCommitOverheadBytes != 0 {
+		t.Fatalf("zero wire rejection mutated state: sets=%d orphan=%d commit=%d", len(state.sets), state.orphanBytes, state.orphanCommitOverheadBytes)
+	}
+}
+
+func TestDARelayRejectsDuplicatesBeforeMutation(t *testing.T) {
+	daID := daRelayTestID(4)
+	state := newDARelayStateForTest(t, defaultDARelayCaps())
+
+	record := mustAddDACommit(t, state, "peer-a", daRelayTestCommit(daID, 2, 3))
+	_, err := state.addDACommit("peer-b", daRelayTestCommit(daID, 2, 5))
+	requireDAErr(t, err, errDARelayDuplicateCommit)
+	if state.sets[daID].commit.wireBytes != record.commit.wireBytes || state.orphanBytes != record.wireBytes {
+		t.Fatalf("duplicate commit mutated state: commit=%d orphan=%d want commit=%d orphan=%d", state.sets[daID].commit.wireBytes, state.orphanBytes, record.commit.wireBytes, record.wireBytes)
+	}
+
+	chunk := daRelayTestChunk(daID, 0, 7)
+	record = mustAddDAChunk(t, state, "peer-c", chunk)
+	_, err = state.addDAChunk("peer-d", chunk)
+	requireDAErr(t, err, errDARelayDuplicateChunk)
+	if len(state.sets[daID].chunks) != 1 || state.orphanBytes != record.wireBytes {
+		t.Fatalf("duplicate chunk mutated state: chunks=%d orphan=%d want orphan=%d", len(state.sets[daID].chunks), state.orphanBytes, record.wireBytes)
+	}
 }
 
 func TestDARelayRejectedCandidatesDoNotMutateStoredChunks(t *testing.T) {
-	daID := daRelayTestID(4)
+	daID := daRelayTestID(5)
 	state := newDARelayStateForTest(t, defaultDARelayCaps())
 	mustAddDAChunk(t, state, "peer-a", daRelayTestChunk(daID, 0, 1))
 	mustAddDAChunk(t, state, "peer-a", daRelayTestChunk(daID, 2, 1))

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -415,6 +415,29 @@ func TestDARelayRejectsIntegrityAndPinnedCapBeforeMutation(t *testing.T) {
 	}
 }
 
+func TestDARelayPinnedPayloadDeltaKeepsOverflowAndCapErrorsDistinct(t *testing.T) {
+	caps := defaultDARelayCaps()
+	caps.pinnedPayloadBytes = 1
+	state := newDARelayStateForTest(t, caps)
+
+	state.pinnedPayloadBytes = 1
+	state.mu.Lock()
+	_, err := state.projectPinnedPayloadDeltaLocked(
+		daRelaySetRecord{state: daRelayStateCompleteSet, payloadBytes: 2},
+		daRelaySetRecord{},
+	)
+	state.mu.Unlock()
+	requireDAErr(t, err, errDARelayArithmeticOverflow)
+
+	state.mu.Lock()
+	_, err = state.projectPinnedPayloadDeltaLocked(
+		daRelaySetRecord{},
+		daRelaySetRecord{state: daRelayStateCompleteSet, payloadBytes: 2},
+	)
+	state.mu.Unlock()
+	requireDAErr(t, err, errDARelayPinnedPayloadCapExceeded)
+}
+
 func TestDARelayCapsRejectInvalidLimits(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
Invariant:
A DA set becomes COMPLETE_SET only when retained commit metadata and all required chunks agree, and pinned payload accounting remains bounded before mutation.

Layer:
Go P2P DA relay implementation / operations / tests. No consensus change. No Rust parity claim.

Stack:
Base PR: #1804 / RUB-361. This PR is intended to be reviewed as codex/RUB-361-da-staged-state...codex/RUB-362-da-complete-integrity.

Files changed:
- clients/go/node/p2p/da_relay_state.go
- clients/go/node/p2p/da_relay_state_test.go

Tests:
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node/p2p -run "Da|DA|Relay" -count=1'\n- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -race ./node/p2p -run "Da|DA|Relay" -count=1'\n- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./...'\n- rubin-precommit-one-review --base-ref codex/RUB-361-da-staged-state --include-base-diff\n- rubin-push --base-ref codex/RUB-361-da-staged-state --coverage-cmd rubin-stack-codacy-coverage.sh -- origin HEAD\n\nBehavior impact:\nAdds DA relay complete-set admission with chunk hash checks, aggregate payload commitment checks, payload ownership cloning, pinned payload cap projection, and fail-closed malformed payload/wire-byte rejection.\n\nCompatibility impact:\nGo-only internal P2P DA relay state surface. Does not change consensus validity, wire encoding, conformance fixtures, or Rust behavior.\n\nKnown non-goals:\n- DA fee / eviction scoring\n- Consensus validity change\n- Canonical spec, conformance fixture, or Rust changes\n- Parent RUB-318 or RUB-224 closeout claim\n\nFollow-ups:\nRUB-363 owns fee and eviction accounting.\n\nRisk:\nMain risk is state mutation before integrity/pinned-cap validation; this PR projects candidate state and rejects malformed/mismatching chunks before applying.\n\nRollback:\nRevert this PR after reverting or retargeting dependent stack children.\n\nNot checked:\nExternal GitHub CI and bot review threads were not available before opening this PR.

<!-- rubin-agent-meta actor=unknown action=pr-create via=cl branch=codex/RUB-362-da-complete-integrity wt=rubin-protocol-codex-RUB-318 utc=2026-05-25T00:18:10Z -->
