### PR TITLE
RUB-363: defend Go DA eviction accounting surface

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -99,6 +99,7 @@ engines:
       - "clients/go/node/p2p/addr_manager.go"
       - "clients/go/node/p2p/compact_reconstruct.go"
       - "clients/go/node/p2p/compact_wire.go"
+      - "clients/go/node/p2p/da_relay_state.go"
       - "clients/go/node/p2p/handlers_block.go"
       - "clients/go/node/p2p/handshake.go"
       - "clients/go/node/p2p/mempool.go"

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -259,21 +259,27 @@ func (s *daRelayState) addDAChunk(peerAddr string, chunk daRelayChunk) (daRelayS
 	if chunk.wireBytes == 0 || chunk.wireBytes < uint64(payloadLen) {
 		return daRelaySetRecord{}, errDARelayWireBytesInvalid
 	}
-	payload := cloneBytes(chunk.payload)
-	if sha3.Sum256(payload) != chunk.chunkHash {
+
+	s.mu.Lock()
+	record := s.sets[chunk.daID]
+	if err := record.validateChunkInsert(chunk.chunkIndex); err != nil {
+		s.mu.Unlock()
+		return daRelaySetRecord{}, err
+	}
+	s.mu.Unlock()
+
+	if sha3.Sum256(chunk.payload) != chunk.chunkHash {
 		return daRelaySetRecord{}, errDARelayChunkHashMismatch
 	}
+	payload := cloneBytes(chunk.payload)
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	record := s.sets[chunk.daID].cloneForStateMutation()
+	record = s.sets[chunk.daID].cloneForStateMutation()
 	record.ensureMaps()
-	if _, exists := record.chunks[chunk.chunkIndex]; exists {
-		return daRelaySetRecord{}, errDARelayDuplicateChunk
-	}
-	if record.commit.chunkCount != 0 && chunk.chunkIndex >= record.commit.chunkCount {
-		return daRelaySetRecord{}, errDARelayChunkIndexOutsideCommit
+	if err := record.validateChunkInsert(chunk.chunkIndex); err != nil {
+		return daRelaySetRecord{}, err
 	}
 	chunk.peerQuotaKey = peerQuotaKey(peerAddr)
 	record.daID = chunk.daID
@@ -453,6 +459,16 @@ func (r *daRelaySetRecord) pruneChunksOutsideCommit() {
 			delete(r.chunks, index)
 		}
 	}
+}
+
+func (r daRelaySetRecord) validateChunkInsert(chunkIndex uint16) error {
+	if _, exists := r.chunks[chunkIndex]; exists {
+		return errDARelayDuplicateChunk
+	}
+	if r.commit.chunkCount != 0 && chunkIndex >= r.commit.chunkCount {
+		return errDARelayChunkIndexOutsideCommit
+	}
+	return nil
 }
 
 func (r *daRelaySetRecord) tryComplete(dropChunksOnCommitMismatch bool) error {

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -223,7 +223,7 @@ func (s *daRelayState) addDACommit(peerAddr string, commit daRelayCommit) (daRel
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	record := s.sets[commit.daID].clone()
+	record := s.sets[commit.daID].cloneForStateMutation()
 	record.ensureMaps()
 	if record.commit.chunkCount != 0 {
 		return daRelaySetRecord{}, errDARelayDuplicateCommit
@@ -267,7 +267,7 @@ func (s *daRelayState) addDAChunk(peerAddr string, chunk daRelayChunk) (daRelayS
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	record := s.sets[chunk.daID].clone()
+	record := s.sets[chunk.daID].cloneForStateMutation()
 	record.ensureMaps()
 	if _, exists := record.chunks[chunk.chunkIndex]; exists {
 		return daRelaySetRecord{}, errDARelayDuplicateChunk
@@ -306,7 +306,7 @@ func (s *daRelayState) applyDASetRecordLocked(record daRelaySetRecord) error {
 	if err != nil {
 		return err
 	}
-	s.sets[record.daID] = record.clone()
+	s.sets[record.daID] = record.cloneForStateMutation()
 	s.orphanBytes = orphanBytes
 	s.applyProjectedPeerBytes(peerBytes)
 	s.applyProjectedDAIDBytes(record.daID, daBytes)
@@ -421,11 +421,21 @@ func (r daRelaySetRecord) missingChunkIndexes() []uint16 {
 }
 
 func (r daRelaySetRecord) clone() daRelaySetRecord {
+	return r.cloneWithPayloads(true)
+}
+
+func (r daRelaySetRecord) cloneForStateMutation() daRelaySetRecord {
+	return r.cloneWithPayloads(false)
+}
+
+func (r daRelaySetRecord) cloneWithPayloads(copyPayloads bool) daRelaySetRecord {
 	r.ensureMaps()
 	out := r
 	out.chunks = make(map[uint16]daRelayChunk, len(r.chunks))
 	for index, chunk := range r.chunks {
-		chunk.payload = cloneBytes(chunk.payload)
+		if copyPayloads {
+			chunk.payload = cloneBytes(chunk.payload)
+		}
 		out.chunks[index] = chunk
 	}
 	return out
@@ -455,12 +465,6 @@ func (r *daRelaySetRecord) tryComplete(dropChunksOnCommitMismatch bool) error {
 	var payloadBytes uint64
 	for i := uint16(0); i < r.commit.chunkCount; i++ {
 		chunk := r.chunks[i]
-		if sha3.Sum256(chunk.payload) != chunk.chunkHash {
-			delete(r.chunks, i)
-			r.payloadBytes = 0
-			r.state = daRelayStateStagedCommit
-			return errDARelayChunkHashMismatch
-		}
 		var err error
 		payloadBytes, err = checkedAddUint64(payloadBytes, uint64(len(chunk.payload)))
 		if err != nil {

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -361,7 +361,10 @@ func (s *daRelayState) projectOrphanAccountingDeltaLocked(oldRecord, newRecord d
 
 func (s *daRelayState) projectPinnedPayloadDeltaLocked(oldRecord, newRecord daRelaySetRecord) (uint64, error) {
 	pinnedBytes, err := checkedApplyUint64Delta(s.pinnedPayloadBytes, oldRecord.pinnedPayloadAccountingBytes(), newRecord.pinnedPayloadAccountingBytes())
-	if err != nil || pinnedBytes > s.caps.pinnedPayloadBytes {
+	if err != nil {
+		return 0, err
+	}
+	if pinnedBytes > s.caps.pinnedPayloadBytes {
 		return 0, errDARelayPinnedPayloadCapExceeded
 	}
 	return pinnedBytes, nil
@@ -484,7 +487,7 @@ func (r *daRelaySetRecord) tryComplete(dropChunksOnCommitMismatch bool) error {
 		var err error
 		payloadBytes, err = checkedAddUint64(payloadBytes, uint64(len(chunk.payload)))
 		if err != nil {
-			return errDARelayPinnedPayloadCapExceeded
+			return err
 		}
 		_, _ = hasher.Write(chunk.payload)
 	}

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -1,6 +1,7 @@
 package p2p
 
 import (
+	"crypto/sha3"
 	"errors"
 	"sync"
 
@@ -102,29 +103,37 @@ type daRelaySetRecord struct {
 }
 
 type daRelayCommit struct {
-	daID         [32]byte
-	peerQuotaKey string
-	chunkCount   uint16
-	wireBytes    uint64
+	daID              [32]byte
+	payloadCommitment [32]byte
+	peerQuotaKey      string
+	chunkCount        uint16
+	wireBytes         uint64
 }
 
 type daRelayChunk struct {
 	daID         [32]byte
+	chunkHash    [32]byte
 	peerQuotaKey string
 	chunkIndex   uint16
+	payload      []byte
 	wireBytes    uint64
 }
 
 var (
-	errDARelayDuplicateCommit         = errors.New("duplicate da commit")
-	errDARelayDuplicateChunk          = errors.New("duplicate da chunk")
-	errDARelayChunkCountInvalid       = errors.New("da commit chunk count invalid")
-	errDARelayChunkIndexOutOfRange    = errors.New("da chunk index out of range")
-	errDARelayChunkIndexOutsideCommit = errors.New("da chunk index outside commit")
-	errDARelayOrphanPoolCapExceeded   = errors.New("da orphan pool cap exceeded")
-	errDARelayOrphanPeerCapExceeded   = errors.New("da orphan pool per-peer cap exceeded")
-	errDARelayOrphanDAIDCapExceeded   = errors.New("da orphan pool per-da_id cap exceeded")
-	errDARelayOrphanCommitCapExceeded = errors.New("da orphan commit overhead cap exceeded")
+	errDARelayDuplicateCommit           = errors.New("duplicate da commit")
+	errDARelayDuplicateChunk            = errors.New("duplicate da chunk")
+	errDARelayChunkCountInvalid         = errors.New("da commit chunk count invalid")
+	errDARelayChunkIndexOutOfRange      = errors.New("da chunk index out of range")
+	errDARelayChunkIndexOutsideCommit   = errors.New("da chunk index outside commit")
+	errDARelayOrphanPoolCapExceeded     = errors.New("da orphan pool cap exceeded")
+	errDARelayOrphanPeerCapExceeded     = errors.New("da orphan pool per-peer cap exceeded")
+	errDARelayOrphanDAIDCapExceeded     = errors.New("da orphan pool per-da_id cap exceeded")
+	errDARelayOrphanCommitCapExceeded   = errors.New("da orphan commit overhead cap exceeded")
+	errDARelayChunkHashMismatch         = errors.New("da chunk hash mismatch")
+	errDARelayChunkPayloadSizeInvalid   = errors.New("da chunk payload size invalid")
+	errDARelayPayloadCommitmentMismatch = errors.New("da payload commitment mismatch")
+	errDARelayWireBytesInvalid          = errors.New("da relay wire bytes invalid")
+	errDARelayPinnedPayloadCapExceeded  = errors.New("da pinned payload cap exceeded")
 )
 
 type daRelayState struct {
@@ -200,6 +209,9 @@ func (s *daRelayState) addDACommit(peerAddr string, commit daRelayCommit) (daRel
 	if commit.chunkCount == 0 || uint64(commit.chunkCount) > consensus.MAX_DA_CHUNK_COUNT {
 		return daRelaySetRecord{}, errDARelayChunkCountInvalid
 	}
+	if commit.wireBytes == 0 {
+		return daRelaySetRecord{}, errDARelayWireBytesInvalid
+	}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -217,6 +229,9 @@ func (s *daRelayState) addDACommit(peerAddr string, commit daRelayCommit) (daRel
 	record.state = daRelayStateStagedCommit
 	record.ttlBlocksRemaining = s.caps.orphanTTLBlocks
 	record.receivedTime = s.nextReceivedTime + 1
+	if err := record.tryComplete(true); err != nil {
+		return daRelaySetRecord{}, err
+	}
 	if err := record.recomputeOrphanTotals(); err != nil {
 		return daRelaySetRecord{}, err
 	}
@@ -229,6 +244,17 @@ func (s *daRelayState) addDACommit(peerAddr string, commit daRelayCommit) (daRel
 func (s *daRelayState) addDAChunk(peerAddr string, chunk daRelayChunk) (daRelaySetRecord, error) {
 	if uint64(chunk.chunkIndex) >= consensus.MAX_DA_CHUNK_COUNT {
 		return daRelaySetRecord{}, errDARelayChunkIndexOutOfRange
+	}
+	payloadLen := len(chunk.payload)
+	if payloadLen == 0 || uint64(payloadLen) > consensus.CHUNK_BYTES {
+		return daRelaySetRecord{}, errDARelayChunkPayloadSizeInvalid
+	}
+	if chunk.wireBytes < uint64(payloadLen) {
+		return daRelaySetRecord{}, errDARelayWireBytesInvalid
+	}
+	payload := cloneBytes(chunk.payload)
+	if sha3.Sum256(payload) != chunk.chunkHash {
+		return daRelaySetRecord{}, errDARelayChunkHashMismatch
 	}
 
 	s.mu.Lock()
@@ -248,8 +274,12 @@ func (s *daRelayState) addDAChunk(peerAddr string, chunk daRelayChunk) (daRelayS
 		record.state = daRelayStateOrphanChunks
 		record.ttlBlocksRemaining = s.caps.orphanTTLBlocks
 	}
+	chunk.payload = payload
 	record.chunks[chunk.chunkIndex] = chunk
 	record.receivedTime = s.nextReceivedTime + 1
+	if err := record.tryComplete(false); err != nil {
+		return daRelaySetRecord{}, err
+	}
 	if err := record.recomputeOrphanTotals(); err != nil {
 		return daRelaySetRecord{}, err
 	}
@@ -270,11 +300,16 @@ func (s *daRelayState) applyDASetRecordLocked(record daRelaySetRecord) error {
 	if err != nil {
 		return err
 	}
+	pinnedBytes, err := s.projectPinnedPayloadLocked(records)
+	if err != nil {
+		return err
+	}
 	s.sets = records
 	s.orphanBytes = orphanBytes
 	s.orphanBytesByPeerQuotaKey = peerBytes
 	s.orphanBytesByDAID = daBytes
 	s.orphanCommitOverheadBytes = commitBytes
+	s.pinnedPayloadBytes = pinnedBytes
 	s.nextReceivedTime = record.receivedTime
 	return nil
 }
@@ -313,6 +348,21 @@ func (s *daRelayState) projectOrphanAccountingLocked(records map[[32]byte]daRela
 	return orphanBytes, peerBytes, daBytes, commitBytes, nil
 }
 
+func (s *daRelayState) projectPinnedPayloadLocked(records map[[32]byte]daRelaySetRecord) (uint64, error) {
+	var pinnedBytes uint64
+	for _, record := range records {
+		if record.state != daRelayStateCompleteSet || record.payloadBytes == 0 {
+			continue
+		}
+		var err error
+		pinnedBytes, err = checkedAddUint64(pinnedBytes, record.payloadBytes)
+		if err != nil || pinnedBytes > s.caps.pinnedPayloadBytes {
+			return 0, errDARelayPinnedPayloadCapExceeded
+		}
+	}
+	return pinnedBytes, nil
+}
+
 func (s *daRelayState) addProjectedPeerBytes(peerBytes map[string]uint64, key string, bytes uint64) error {
 	if key == "" || bytes == 0 {
 		return nil
@@ -343,6 +393,7 @@ func (r daRelaySetRecord) clone() daRelaySetRecord {
 	out := r
 	out.chunks = make(map[uint16]daRelayChunk, len(r.chunks))
 	for index, chunk := range r.chunks {
+		chunk.payload = cloneBytes(chunk.payload)
 		out.chunks[index] = chunk
 	}
 	return out
@@ -362,6 +413,50 @@ func (r *daRelaySetRecord) pruneChunksOutsideCommit() {
 	}
 }
 
+func (r *daRelaySetRecord) tryComplete(dropChunksOnCommitMismatch bool) error {
+	if r.commit.chunkCount == 0 || len(r.missingChunkIndexes()) != 0 {
+		r.payloadBytes = 0
+		return nil
+	}
+
+	hasher := sha3.New256()
+	var payloadBytes uint64
+	for i := uint16(0); i < r.commit.chunkCount; i++ {
+		chunk := r.chunks[i]
+		if sha3.Sum256(chunk.payload) != chunk.chunkHash {
+			delete(r.chunks, i)
+			r.payloadBytes = 0
+			r.state = daRelayStateStagedCommit
+			return errDARelayChunkHashMismatch
+		}
+		var err error
+		payloadBytes, err = checkedAddUint64(payloadBytes, uint64(len(chunk.payload)))
+		if err != nil {
+			return errDARelayPinnedPayloadCapExceeded
+		}
+		_, _ = hasher.Write(chunk.payload)
+	}
+	var payloadCommitment [32]byte
+	copy(payloadCommitment[:], hasher.Sum(nil))
+	if payloadCommitment != r.commit.payloadCommitment {
+		if !dropChunksOnCommitMismatch {
+			r.payloadBytes = 0
+			r.state = daRelayStateStagedCommit
+			return errDARelayPayloadCommitmentMismatch
+		}
+		for i := uint16(0); i < r.commit.chunkCount; i++ {
+			delete(r.chunks, i)
+		}
+		r.payloadBytes = 0
+		r.state = daRelayStateStagedCommit
+		return nil
+	}
+	r.payloadBytes = payloadBytes
+	r.state = daRelayStateCompleteSet
+	r.ttlBlocksRemaining = 0
+	return nil
+}
+
 func (r *daRelaySetRecord) recomputeOrphanTotals() error {
 	r.wireBytes = r.commit.wireBytes
 	for _, chunk := range r.chunks {
@@ -379,4 +474,11 @@ func checkedAddUint64(a uint64, b uint64) (uint64, error) {
 		return 0, errDARelayOrphanPoolCapExceeded
 	}
 	return a + b, nil
+}
+
+func cloneBytes(in []byte) []byte {
+	if len(in) == 0 {
+		return nil
+	}
+	return append([]byte(nil), in...)
 }

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -3,6 +3,8 @@ package p2p
 import (
 	"errors"
 	"sync"
+
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
 )
 
 const (
@@ -88,13 +90,42 @@ func (c daRelayCaps) validateRelativeCaps() error {
 }
 
 type daRelaySetRecord struct {
-	daID         [32]byte
-	state        daRelaySetState
-	receivedTime uint64
-	payloadBytes uint64
-	wireBytes    uint64
-	totalFee     uint64
+	daID               [32]byte
+	state              daRelaySetState
+	receivedTime       uint64
+	payloadBytes       uint64
+	wireBytes          uint64
+	totalFee           uint64
+	ttlBlocksRemaining uint64
+	commit             daRelayCommit
+	chunks             map[uint16]daRelayChunk
 }
+
+type daRelayCommit struct {
+	daID         [32]byte
+	peerQuotaKey string
+	chunkCount   uint16
+	wireBytes    uint64
+}
+
+type daRelayChunk struct {
+	daID         [32]byte
+	peerQuotaKey string
+	chunkIndex   uint16
+	wireBytes    uint64
+}
+
+var (
+	errDARelayDuplicateCommit         = errors.New("duplicate da commit")
+	errDARelayDuplicateChunk          = errors.New("duplicate da chunk")
+	errDARelayChunkCountInvalid       = errors.New("da commit chunk count invalid")
+	errDARelayChunkIndexOutOfRange    = errors.New("da chunk index out of range")
+	errDARelayChunkIndexOutsideCommit = errors.New("da chunk index outside commit")
+	errDARelayOrphanPoolCapExceeded   = errors.New("da orphan pool cap exceeded")
+	errDARelayOrphanPeerCapExceeded   = errors.New("da orphan pool per-peer cap exceeded")
+	errDARelayOrphanDAIDCapExceeded   = errors.New("da orphan pool per-da_id cap exceeded")
+	errDARelayOrphanCommitCapExceeded = errors.New("da orphan commit overhead cap exceeded")
+)
 
 type daRelayState struct {
 	mu                        sync.Mutex
@@ -163,4 +194,189 @@ func (s *daRelayState) orphanBytesForDAID(daID [32]byte) uint64 {
 	defer s.mu.Unlock()
 
 	return s.orphanBytesByDAID[daID]
+}
+
+func (s *daRelayState) addDACommit(peerAddr string, commit daRelayCommit) (daRelaySetRecord, error) {
+	if commit.chunkCount == 0 || uint64(commit.chunkCount) > consensus.MAX_DA_CHUNK_COUNT {
+		return daRelaySetRecord{}, errDARelayChunkCountInvalid
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	record := s.sets[commit.daID].clone()
+	record.ensureMaps()
+	if record.commit.chunkCount != 0 {
+		return daRelaySetRecord{}, errDARelayDuplicateCommit
+	}
+	c := commit
+	c.peerQuotaKey = peerQuotaKey(peerAddr)
+	record.daID = c.daID
+	record.commit = c
+	record.pruneChunksOutsideCommit()
+	record.state = daRelayStateStagedCommit
+	record.ttlBlocksRemaining = s.caps.orphanTTLBlocks
+	record.receivedTime = s.nextReceivedTime + 1
+	if err := record.recomputeOrphanTotals(); err != nil {
+		return daRelaySetRecord{}, err
+	}
+	if err := s.applyDASetRecordLocked(record); err != nil {
+		return daRelaySetRecord{}, err
+	}
+	return record.clone(), nil
+}
+
+func (s *daRelayState) addDAChunk(peerAddr string, chunk daRelayChunk) (daRelaySetRecord, error) {
+	if uint64(chunk.chunkIndex) >= consensus.MAX_DA_CHUNK_COUNT {
+		return daRelaySetRecord{}, errDARelayChunkIndexOutOfRange
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	record := s.sets[chunk.daID].clone()
+	record.ensureMaps()
+	if _, exists := record.chunks[chunk.chunkIndex]; exists {
+		return daRelaySetRecord{}, errDARelayDuplicateChunk
+	}
+	if record.commit.chunkCount != 0 && chunk.chunkIndex >= record.commit.chunkCount {
+		return daRelaySetRecord{}, errDARelayChunkIndexOutsideCommit
+	}
+	chunk.peerQuotaKey = peerQuotaKey(peerAddr)
+	record.daID = chunk.daID
+	if record.commit.chunkCount == 0 {
+		record.state = daRelayStateOrphanChunks
+		record.ttlBlocksRemaining = s.caps.orphanTTLBlocks
+	}
+	record.chunks[chunk.chunkIndex] = chunk
+	record.receivedTime = s.nextReceivedTime + 1
+	if err := record.recomputeOrphanTotals(); err != nil {
+		return daRelaySetRecord{}, err
+	}
+	if err := s.applyDASetRecordLocked(record); err != nil {
+		return daRelaySetRecord{}, err
+	}
+	return record.clone(), nil
+}
+
+func (s *daRelayState) applyDASetRecordLocked(record daRelaySetRecord) error {
+	records := make(map[[32]byte]daRelaySetRecord, len(s.sets)+1)
+	for daID, existing := range s.sets {
+		records[daID] = existing
+	}
+	records[record.daID] = record.clone()
+
+	orphanBytes, peerBytes, daBytes, commitBytes, err := s.projectOrphanAccountingLocked(records)
+	if err != nil {
+		return err
+	}
+	s.sets = records
+	s.orphanBytes = orphanBytes
+	s.orphanBytesByPeerQuotaKey = peerBytes
+	s.orphanBytesByDAID = daBytes
+	s.orphanCommitOverheadBytes = commitBytes
+	s.nextReceivedTime = record.receivedTime
+	return nil
+}
+
+func (s *daRelayState) projectOrphanAccountingLocked(records map[[32]byte]daRelaySetRecord) (uint64, map[string]uint64, map[[32]byte]uint64, uint64, error) {
+	peerBytes := map[string]uint64{}
+	daBytes := map[[32]byte]uint64{}
+	var orphanBytes uint64
+	var commitBytes uint64
+	for daID, record := range records {
+		if record.state == daRelayStateCompleteSet || record.wireBytes == 0 {
+			continue
+		}
+		var err error
+		orphanBytes, err = checkedAddUint64(orphanBytes, record.wireBytes)
+		if err != nil || orphanBytes > s.caps.orphanPoolBytes {
+			return 0, nil, nil, 0, errDARelayOrphanPoolCapExceeded
+		}
+		daBytes[daID], err = checkedAddUint64(daBytes[daID], record.wireBytes)
+		if err != nil || daBytes[daID] > s.caps.orphanPoolPerDAIDBytes {
+			return 0, nil, nil, 0, errDARelayOrphanDAIDCapExceeded
+		}
+		commitBytes, err = checkedAddUint64(commitBytes, record.commit.wireBytes)
+		if err != nil || commitBytes > s.caps.orphanCommitOverheadBytes {
+			return 0, nil, nil, 0, errDARelayOrphanCommitCapExceeded
+		}
+		if err := s.addProjectedPeerBytes(peerBytes, record.commit.peerQuotaKey, record.commit.wireBytes); err != nil {
+			return 0, nil, nil, 0, err
+		}
+		for _, chunk := range record.chunks {
+			if err := s.addProjectedPeerBytes(peerBytes, chunk.peerQuotaKey, chunk.wireBytes); err != nil {
+				return 0, nil, nil, 0, err
+			}
+		}
+	}
+	return orphanBytes, peerBytes, daBytes, commitBytes, nil
+}
+
+func (s *daRelayState) addProjectedPeerBytes(peerBytes map[string]uint64, key string, bytes uint64) error {
+	if key == "" || bytes == 0 {
+		return nil
+	}
+	var err error
+	peerBytes[key], err = checkedAddUint64(peerBytes[key], bytes)
+	if err != nil || peerBytes[key] > s.caps.orphanPoolPerPeerBytes {
+		return errDARelayOrphanPeerCapExceeded
+	}
+	return nil
+}
+
+func (r daRelaySetRecord) missingChunkIndexes() []uint16 {
+	if r.commit.chunkCount == 0 || r.state == daRelayStateCompleteSet {
+		return nil
+	}
+	missing := make([]uint16, 0)
+	for i := uint16(0); i < r.commit.chunkCount; i++ {
+		if _, ok := r.chunks[i]; !ok {
+			missing = append(missing, i)
+		}
+	}
+	return missing
+}
+
+func (r daRelaySetRecord) clone() daRelaySetRecord {
+	r.ensureMaps()
+	out := r
+	out.chunks = make(map[uint16]daRelayChunk, len(r.chunks))
+	for index, chunk := range r.chunks {
+		out.chunks[index] = chunk
+	}
+	return out
+}
+
+func (r *daRelaySetRecord) ensureMaps() {
+	if r.chunks == nil {
+		r.chunks = map[uint16]daRelayChunk{}
+	}
+}
+
+func (r *daRelaySetRecord) pruneChunksOutsideCommit() {
+	for index := range r.chunks {
+		if index >= r.commit.chunkCount {
+			delete(r.chunks, index)
+		}
+	}
+}
+
+func (r *daRelaySetRecord) recomputeOrphanTotals() error {
+	r.wireBytes = r.commit.wireBytes
+	for _, chunk := range r.chunks {
+		var err error
+		r.wireBytes, err = checkedAddUint64(r.wireBytes, chunk.wireBytes)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func checkedAddUint64(a uint64, b uint64) (uint64, error) {
+	if ^uint64(0)-a < b {
+		return 0, errDARelayOrphanPoolCapExceeded
+	}
+	return a + b, nil
 }

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -125,7 +125,15 @@ var (
 	errDARelayOrphanPeerCapExceeded   = errors.New("da orphan pool per-peer cap exceeded")
 	errDARelayOrphanDAIDCapExceeded   = errors.New("da orphan pool per-da_id cap exceeded")
 	errDARelayOrphanCommitCapExceeded = errors.New("da orphan commit overhead cap exceeded")
+	errDARelayWireBytesInvalid        = errors.New("da relay wire bytes invalid")
+	errDARelayArithmeticOverflow      = errors.New("da relay arithmetic overflow")
 )
+
+type daRelayRecordAccounting struct {
+	orphanBytes uint64
+	commitBytes uint64
+	peerBytes   map[string]uint64
+}
 
 type daRelayState struct {
 	mu                        sync.Mutex
@@ -200,6 +208,9 @@ func (s *daRelayState) addDACommit(peerAddr string, commit daRelayCommit) (daRel
 	if commit.chunkCount == 0 || uint64(commit.chunkCount) > consensus.MAX_DA_CHUNK_COUNT {
 		return daRelaySetRecord{}, errDARelayChunkCountInvalid
 	}
+	if commit.wireBytes == 0 {
+		return daRelaySetRecord{}, errDARelayWireBytesInvalid
+	}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -229,6 +240,9 @@ func (s *daRelayState) addDACommit(peerAddr string, commit daRelayCommit) (daRel
 func (s *daRelayState) addDAChunk(peerAddr string, chunk daRelayChunk) (daRelaySetRecord, error) {
 	if uint64(chunk.chunkIndex) >= consensus.MAX_DA_CHUNK_COUNT {
 		return daRelaySetRecord{}, errDARelayChunkIndexOutOfRange
+	}
+	if chunk.wireBytes == 0 {
+		return daRelaySetRecord{}, errDARelayWireBytesInvalid
 	}
 
 	s.mu.Lock()
@@ -260,69 +274,101 @@ func (s *daRelayState) addDAChunk(peerAddr string, chunk daRelayChunk) (daRelayS
 }
 
 func (s *daRelayState) applyDASetRecordLocked(record daRelaySetRecord) error {
-	records := make(map[[32]byte]daRelaySetRecord, len(s.sets)+1)
-	for daID, existing := range s.sets {
-		records[daID] = existing
-	}
-	records[record.daID] = record.clone()
-
-	orphanBytes, peerBytes, daBytes, commitBytes, err := s.projectOrphanAccountingLocked(records)
+	oldRecord := s.sets[record.daID]
+	orphanBytes, peerBytes, daBytes, commitBytes, err := s.projectOrphanAccountingDeltaLocked(oldRecord, record)
 	if err != nil {
 		return err
 	}
-	s.sets = records
+	s.sets[record.daID] = record.clone()
 	s.orphanBytes = orphanBytes
-	s.orphanBytesByPeerQuotaKey = peerBytes
-	s.orphanBytesByDAID = daBytes
+	s.applyProjectedPeerBytes(peerBytes)
+	s.applyProjectedDAIDBytes(record.daID, daBytes)
 	s.orphanCommitOverheadBytes = commitBytes
 	s.nextReceivedTime = record.receivedTime
 	return nil
 }
 
-func (s *daRelayState) projectOrphanAccountingLocked(records map[[32]byte]daRelaySetRecord) (uint64, map[string]uint64, map[[32]byte]uint64, uint64, error) {
-	peerBytes := map[string]uint64{}
-	daBytes := map[[32]byte]uint64{}
-	var orphanBytes uint64
-	var commitBytes uint64
-	for daID, record := range records {
-		if record.state == daRelayStateCompleteSet || record.wireBytes == 0 {
-			continue
-		}
-		var err error
-		orphanBytes, err = checkedAddUint64(orphanBytes, record.wireBytes)
-		if err != nil || orphanBytes > s.caps.orphanPoolBytes {
-			return 0, nil, nil, 0, errDARelayOrphanPoolCapExceeded
-		}
-		daBytes[daID], err = checkedAddUint64(daBytes[daID], record.wireBytes)
-		if err != nil || daBytes[daID] > s.caps.orphanPoolPerDAIDBytes {
-			return 0, nil, nil, 0, errDARelayOrphanDAIDCapExceeded
-		}
-		commitBytes, err = checkedAddUint64(commitBytes, record.commit.wireBytes)
-		if err != nil || commitBytes > s.caps.orphanCommitOverheadBytes {
-			return 0, nil, nil, 0, errDARelayOrphanCommitCapExceeded
-		}
-		if err := s.addProjectedPeerBytes(peerBytes, record.commit.peerQuotaKey, record.commit.wireBytes); err != nil {
-			return 0, nil, nil, 0, err
-		}
-		for _, chunk := range record.chunks {
-			if err := s.addProjectedPeerBytes(peerBytes, chunk.peerQuotaKey, chunk.wireBytes); err != nil {
-				return 0, nil, nil, 0, err
-			}
-		}
+func (s *daRelayState) projectOrphanAccountingDeltaLocked(oldRecord, newRecord daRelaySetRecord) (uint64, map[string]uint64, uint64, uint64, error) {
+	oldAccounting, err := oldRecord.orphanAccounting()
+	if err != nil {
+		return 0, nil, 0, 0, err
+	}
+	newAccounting, err := newRecord.orphanAccounting()
+	if err != nil {
+		return 0, nil, 0, 0, err
+	}
+	orphanBytes, err := checkedApplyUint64Delta(s.orphanBytes, oldAccounting.orphanBytes, newAccounting.orphanBytes)
+	if err != nil {
+		return 0, nil, 0, 0, err
+	}
+	if orphanBytes > s.caps.orphanPoolBytes {
+		return 0, nil, 0, 0, errDARelayOrphanPoolCapExceeded
+	}
+	daBytes, err := checkedApplyUint64Delta(s.orphanBytesByDAID[newRecord.daID], oldAccounting.orphanBytes, newAccounting.orphanBytes)
+	if err != nil {
+		return 0, nil, 0, 0, err
+	}
+	if daBytes > s.caps.orphanPoolPerDAIDBytes {
+		return 0, nil, 0, 0, errDARelayOrphanDAIDCapExceeded
+	}
+	commitBytes, err := checkedApplyUint64Delta(s.orphanCommitOverheadBytes, oldAccounting.commitBytes, newAccounting.commitBytes)
+	if err != nil {
+		return 0, nil, 0, 0, err
+	}
+	if commitBytes > s.caps.orphanCommitOverheadBytes {
+		return 0, nil, 0, 0, errDARelayOrphanCommitCapExceeded
+	}
+	peerBytes, err := s.projectPeerAccountingDeltaLocked(oldAccounting.peerBytes, newAccounting.peerBytes)
+	if err != nil {
+		return 0, nil, 0, 0, err
 	}
 	return orphanBytes, peerBytes, daBytes, commitBytes, nil
 }
 
-func (s *daRelayState) addProjectedPeerBytes(peerBytes map[string]uint64, key string, bytes uint64) error {
-	if key == "" || bytes == 0 {
-		return nil
+func (s *daRelayState) projectPeerAccountingDeltaLocked(oldPeerBytes, newPeerBytes map[string]uint64) (map[string]uint64, error) {
+	projected := map[string]uint64{}
+	for key, oldBytes := range oldPeerBytes {
+		value, err := checkedApplyUint64Delta(s.orphanBytesByPeerQuotaKey[key], oldBytes, newPeerBytes[key])
+		if err != nil {
+			return nil, err
+		}
+		if value > s.caps.orphanPoolPerPeerBytes {
+			return nil, errDARelayOrphanPeerCapExceeded
+		}
+		projected[key] = value
 	}
-	var err error
-	peerBytes[key], err = checkedAddUint64(peerBytes[key], bytes)
-	if err != nil || peerBytes[key] > s.caps.orphanPoolPerPeerBytes {
-		return errDARelayOrphanPeerCapExceeded
+	for key, newBytes := range newPeerBytes {
+		if _, seen := oldPeerBytes[key]; seen {
+			continue
+		}
+		value, err := checkedApplyUint64Delta(s.orphanBytesByPeerQuotaKey[key], 0, newBytes)
+		if err != nil {
+			return nil, err
+		}
+		if value > s.caps.orphanPoolPerPeerBytes {
+			return nil, errDARelayOrphanPeerCapExceeded
+		}
+		projected[key] = value
 	}
-	return nil
+	return projected, nil
+}
+
+func (s *daRelayState) applyProjectedPeerBytes(projected map[string]uint64) {
+	for key, bytes := range projected {
+		if bytes == 0 {
+			delete(s.orphanBytesByPeerQuotaKey, key)
+			continue
+		}
+		s.orphanBytesByPeerQuotaKey[key] = bytes
+	}
+}
+
+func (s *daRelayState) applyProjectedDAIDBytes(daID [32]byte, bytes uint64) {
+	if bytes == 0 {
+		delete(s.orphanBytesByDAID, daID)
+		return
+	}
+	s.orphanBytesByDAID[daID] = bytes
 }
 
 func (r daRelaySetRecord) missingChunkIndexes() []uint16 {
@@ -374,9 +420,43 @@ func (r *daRelaySetRecord) recomputeOrphanTotals() error {
 	return nil
 }
 
+func (r daRelaySetRecord) orphanAccounting() (daRelayRecordAccounting, error) {
+	accounting := daRelayRecordAccounting{peerBytes: map[string]uint64{}}
+	if r.state == daRelayStateCompleteSet || r.wireBytes == 0 {
+		return accounting, nil
+	}
+	accounting.orphanBytes = r.wireBytes
+	accounting.commitBytes = r.commit.wireBytes
+	if err := addPeerAccounting(accounting.peerBytes, r.commit.peerQuotaKey, r.commit.wireBytes); err != nil {
+		return daRelayRecordAccounting{}, err
+	}
+	for _, chunk := range r.chunks {
+		if err := addPeerAccounting(accounting.peerBytes, chunk.peerQuotaKey, chunk.wireBytes); err != nil {
+			return daRelayRecordAccounting{}, err
+		}
+	}
+	return accounting, nil
+}
+
+func addPeerAccounting(peerBytes map[string]uint64, key string, bytes uint64) error {
+	if key == "" || bytes == 0 {
+		return nil
+	}
+	var err error
+	peerBytes[key], err = checkedAddUint64(peerBytes[key], bytes)
+	return err
+}
+
+func checkedApplyUint64Delta(current uint64, remove uint64, add uint64) (uint64, error) {
+	if current < remove {
+		return 0, errDARelayArithmeticOverflow
+	}
+	return checkedAddUint64(current-remove, add)
+}
+
 func checkedAddUint64(a uint64, b uint64) (uint64, error) {
 	if ^uint64(0)-a < b {
-		return 0, errDARelayOrphanPoolCapExceeded
+		return 0, errDARelayArithmeticOverflow
 	}
 	return a + b, nil
 }

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -96,10 +96,16 @@ type daRelaySetRecord struct {
 	receivedTime       uint64
 	payloadBytes       uint64
 	wireBytes          uint64
-	totalFee           uint64
 	ttlBlocksRemaining uint64
 	commit             daRelayCommit
 	chunks             map[uint16]daRelayChunk
+}
+
+type daRelayEvictionAccounting struct {
+	daID         [32]byte
+	payloadBytes uint64
+	wireBytes    uint64
+	receivedTime uint64
 }
 
 type daRelayCommit struct {
@@ -386,6 +392,18 @@ func (r daRelaySetRecord) missingChunkIndexes() []uint16 {
 		}
 	}
 	return missing
+}
+
+func (r daRelaySetRecord) evictionAccounting() (daRelayEvictionAccounting, bool) {
+	if r.state != daRelayStateCompleteSet || r.payloadBytes == 0 || r.wireBytes == 0 || r.receivedTime == 0 {
+		return daRelayEvictionAccounting{}, false
+	}
+	return daRelayEvictionAccounting{
+		daID:         r.daID,
+		payloadBytes: r.payloadBytes,
+		wireBytes:    r.wireBytes,
+		receivedTime: r.receivedTime,
+	}, true
 }
 
 func (r daRelaySetRecord) clone() daRelaySetRecord {

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -1,6 +1,11 @@
 package p2p
 
-import "testing"
+import (
+	"errors"
+	"testing"
+
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+)
 
 func TestDefaultDARelayCapsMatchSpec(t *testing.T) {
 	caps := defaultDARelayCaps()
@@ -157,6 +162,110 @@ func TestDARelayReceivedTimeIsMonotonicLocalSequence(t *testing.T) {
 	}
 }
 
+func TestDARelayStagesCommitAndRetainsBoundedOrphans(t *testing.T) {
+	state := newDARelayStateForTest(t, defaultDARelayCaps())
+	daID := daRelayTestID(1)
+
+	mustAddDAChunk(t, state, "peer-a", daRelayTestChunk(daID, 0, 7))
+	mustAddDAChunk(t, state, "peer-b", daRelayTestChunk(daID, 2, 11))
+
+	record := mustAddDACommit(t, state, "peer-c", daRelayTestCommit(daID, 2, 13))
+	if record.state != daRelayStateStagedCommit {
+		t.Fatalf("state=%v, want STAGED_COMMIT", record.state)
+	}
+	if record.ttlBlocksRemaining != daOrphanTTLBlocks {
+		t.Fatalf("ttl=%d, want %d", record.ttlBlocksRemaining, daOrphanTTLBlocks)
+	}
+	if missing := record.missingChunkIndexes(); len(missing) != 1 || missing[0] != 1 {
+		t.Fatalf("missing=%v, want [1]", missing)
+	}
+	if _, ok := record.chunks[2]; ok {
+		t.Fatalf("orphan chunk outside commit count was retained")
+	}
+	if state.orphanBytes != record.wireBytes || state.orphanBytesByDAID[daID] != record.wireBytes {
+		t.Fatalf("orphan accounting global=%d da=%d record=%d", state.orphanBytes, state.orphanBytesByDAID[daID], record.wireBytes)
+	}
+	record.chunks[7] = daRelayTestChunk(daID, 7, 1)
+	if _, ok := state.sets[daID].chunks[7]; ok {
+		t.Fatalf("returned record aliases stored chunks")
+	}
+}
+
+func TestDARelayRejectsStagedIndexAndCapFailuresBeforeMutation(t *testing.T) {
+	daID := daRelayTestID(2)
+	for _, tt := range []struct {
+		patch func(*daRelayCaps)
+		want  error
+	}{
+		{
+			patch: func(caps *daRelayCaps) {
+				caps.orphanPoolBytes, caps.orphanPoolPerPeerBytes = 4, 4
+				caps.orphanPoolPerDAIDBytes, caps.orphanCommitOverheadBytes = 4, 4
+			},
+			want: errDARelayOrphanPoolCapExceeded,
+		},
+		{
+			patch: func(caps *daRelayCaps) { caps.orphanPoolPerPeerBytes = 4 },
+			want:  errDARelayOrphanPeerCapExceeded,
+		},
+		{
+			patch: func(caps *daRelayCaps) { caps.orphanPoolPerDAIDBytes = 4 },
+			want:  errDARelayOrphanDAIDCapExceeded,
+		},
+	} {
+		caps := defaultDARelayCaps()
+		tt.patch(&caps)
+		state := newDARelayStateForTest(t, caps)
+		_, err := state.addDAChunk("peer-a", daRelayTestChunk(daID, 0, 5))
+		requireDAErr(t, err, tt.want)
+		if len(state.sets) != 0 || state.orphanBytes != 0 {
+			t.Fatalf("rejection mutated state: sets=%d orphan=%d", len(state.sets), state.orphanBytes)
+		}
+	}
+
+	state := newDARelayStateForTest(t, defaultDARelayCaps())
+	mustAddDACommit(t, state, "peer-a", daRelayTestCommit(daID, 1, 1))
+	_, err := state.addDAChunk("peer-a", daRelayTestChunk(daID, 1, 1))
+	requireDAErr(t, err, errDARelayChunkIndexOutsideCommit)
+	_, err = state.addDACommit("peer-a", daRelayTestCommit(daID, 0, 1))
+	requireDAErr(t, err, errDARelayChunkCountInvalid)
+	_, err = state.addDAChunk("peer-a", daRelayTestChunk(daID, uint16(consensus.MAX_DA_CHUNK_COUNT), 1))
+	requireDAErr(t, err, errDARelayChunkIndexOutOfRange)
+
+	caps := defaultDARelayCaps()
+	caps.orphanPoolBytes, caps.orphanPoolPerPeerBytes = ^uint64(0), ^uint64(0)
+	caps.orphanPoolPerDAIDBytes = ^uint64(0)
+	overflowState := newDARelayStateForTest(t, caps)
+	mustAddDAChunk(t, overflowState, "peer-a", daRelayTestChunk(daID, 0, ^uint64(0)))
+	_, err = overflowState.addDACommit("peer-a", daRelayTestCommit(daID, 2, 1))
+	requireDAErr(t, err, errDARelayOrphanPoolCapExceeded)
+}
+
+func TestDARelayRejectedCandidatesDoNotMutateStoredChunks(t *testing.T) {
+	daID := daRelayTestID(4)
+	state := newDARelayStateForTest(t, defaultDARelayCaps())
+	mustAddDAChunk(t, state, "peer-a", daRelayTestChunk(daID, 0, 1))
+	mustAddDAChunk(t, state, "peer-a", daRelayTestChunk(daID, 2, 1))
+	state.caps.orphanCommitOverheadBytes = 1
+	_, err := state.addDACommit("peer-b", daRelayTestCommit(daID, 1, 2))
+	requireDAErr(t, err, errDARelayOrphanCommitCapExceeded)
+	if _, ok := state.sets[daID].chunks[2]; !ok {
+		t.Fatalf("failed commit pruned stored orphan chunk")
+	}
+	if state.orphanCommitOverheadBytes != 0 {
+		t.Fatalf("commit overhead after rejected commit = %d, want 0", state.orphanCommitOverheadBytes)
+	}
+
+	state = newDARelayStateForTest(t, defaultDARelayCaps())
+	mustAddDACommit(t, state, "peer-a", daRelayTestCommit(daID, 2, 1))
+	state.caps.orphanPoolPerDAIDBytes = state.orphanBytes
+	_, err = state.addDAChunk("peer-b", daRelayTestChunk(daID, 1, 1))
+	requireDAErr(t, err, errDARelayOrphanDAIDCapExceeded)
+	if _, ok := state.sets[daID].chunks[1]; ok {
+		t.Fatalf("failed chunk insert mutated stored staged record")
+	}
+}
+
 func TestDARelayCapsRejectInvalidLimits(t *testing.T) {
 	tests := []struct {
 		name string
@@ -240,5 +349,52 @@ func TestDARelayCapsRejectInvalidLimits(t *testing.T) {
 		if err := tt.caps.validate(); err == nil {
 			t.Fatalf("%s caps should fail validation", tt.name)
 		}
+	}
+}
+
+func daRelayTestID(seed byte) (out [32]byte) {
+	out[0] = seed
+	return out
+}
+
+func daRelayTestChunk(daID [32]byte, index uint16, wireBytes uint64) daRelayChunk {
+	return daRelayChunk{daID: daID, chunkIndex: index, wireBytes: wireBytes}
+}
+
+func daRelayTestCommit(daID [32]byte, chunkCount uint16, wireBytes uint64) daRelayCommit {
+	return daRelayCommit{daID: daID, chunkCount: chunkCount, wireBytes: wireBytes}
+}
+
+func newDARelayStateForTest(t *testing.T, caps daRelayCaps) *daRelayState {
+	t.Helper()
+	state, err := newDARelayState(caps)
+	if err != nil {
+		t.Fatalf("new DA relay state: %v", err)
+	}
+	return state
+}
+
+func mustAddDAChunk(t *testing.T, state *daRelayState, peer string, chunk daRelayChunk) daRelaySetRecord {
+	t.Helper()
+	record, err := state.addDAChunk(peer, chunk)
+	if err != nil {
+		t.Fatalf("add DA chunk: %v", err)
+	}
+	return record
+}
+
+func mustAddDACommit(t *testing.T, state *daRelayState, peer string, commit daRelayCommit) daRelaySetRecord {
+	t.Helper()
+	record, err := state.addDACommit(peer, commit)
+	if err != nil {
+		t.Fatalf("add DA commit: %v", err)
+	}
+	return record
+}
+
+func requireDAErr(t *testing.T, got error, want error) {
+	t.Helper()
+	if !errors.Is(got, want) {
+		t.Fatalf("err=%v, want %v", got, want)
 	}
 }

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -1,6 +1,7 @@
 package p2p
 
 import (
+	"crypto/sha3"
 	"errors"
 	"testing"
 
@@ -266,6 +267,82 @@ func TestDARelayRejectedCandidatesDoNotMutateStoredChunks(t *testing.T) {
 	}
 }
 
+func TestDARelayCompletesSetAndPinsPayload(t *testing.T) {
+	state := newDARelayStateForTest(t, defaultDARelayCaps())
+	daID := daRelayTestID(5)
+	payload0 := []byte("chunk-zero")
+	payload1 := []byte("chunk-one")
+
+	mustAddDACommit(t, state, "peer-a", daRelayTestCommitForPayloads(daID, 3, payload0, payload1))
+	mustAddDAChunk(t, state, "peer-b", daRelayTestChunkPayload(daID, 0, uint64(len(payload0)), payload0))
+	record := mustAddDAChunk(t, state, "peer-c", daRelayTestChunkPayload(daID, 1, uint64(len(payload1)), payload1))
+
+	if record.state != daRelayStateCompleteSet {
+		t.Fatalf("state=%v, want COMPLETE_SET", record.state)
+	}
+	if record.payloadBytes != uint64(len(payload0)+len(payload1)) || state.pinnedPayloadBytes != record.payloadBytes {
+		t.Fatalf("payload bytes record=%d pinned=%d", record.payloadBytes, state.pinnedPayloadBytes)
+	}
+	if state.orphanBytes != 0 || len(state.orphanBytesByDAID) != 0 {
+		t.Fatalf("complete set left orphan accounting: global=%d da=%d", state.orphanBytes, len(state.orphanBytesByDAID))
+	}
+	record.chunks[0].payload[0] ^= 0xff
+	if state.sets[daID].chunks[0].payload[0] == record.chunks[0].payload[0] {
+		t.Fatalf("returned complete record aliases stored payload")
+	}
+}
+
+func TestDARelayRejectsIntegrityAndPinnedCapBeforeMutation(t *testing.T) {
+	daID := daRelayTestID(6)
+	state := newDARelayStateForTest(t, defaultDARelayCaps())
+	badChunk := daRelayTestChunkPayload(daID, 0, 3, []byte("bad"))
+	badChunk.chunkHash[0] ^= 0xff
+	_, err := state.addDAChunk("peer-a", badChunk)
+	requireDAErr(t, err, errDARelayChunkHashMismatch)
+	if len(state.sets) != 0 {
+		t.Fatalf("hash mismatch mutated state")
+	}
+	_, err = state.addDAChunk("peer-a", daRelayTestChunkPayload(daID, 0, 1, nil))
+	requireDAErr(t, err, errDARelayChunkPayloadSizeInvalid)
+	_, err = state.addDAChunk("peer-a", daRelayTestChunkPayload(daID, 0, 1, make([]byte, consensus.CHUNK_BYTES+1)))
+	requireDAErr(t, err, errDARelayChunkPayloadSizeInvalid)
+	_, err = state.addDAChunk("peer-a", daRelayTestChunkPayload(daID, 0, 1, []byte("underreported")))
+	requireDAErr(t, err, errDARelayWireBytesInvalid)
+	_, err = state.addDACommit("peer-a", daRelayTestCommit(daID, 1, 0))
+	requireDAErr(t, err, errDARelayWireBytesInvalid)
+	if len(state.sets) != 0 {
+		t.Fatalf("shape rejection mutated state")
+	}
+
+	payload0 := []byte("payload-a")
+	payload1 := []byte("payload-b")
+	mustAddDAChunk(t, state, "peer-a", daRelayTestChunkPayload(daID, 0, uint64(len(payload0)), payload0))
+	mustAddDAChunk(t, state, "peer-a", daRelayTestChunkPayload(daID, 1, uint64(len(payload1)), payload1))
+	record := mustAddDACommit(t, state, "peer-b", daRelayTestCommitForPayloads(daID, 1, payload1, payload0))
+	if record.state != daRelayStateStagedCommit || len(record.chunks) != 0 || state.pinnedPayloadBytes != 0 {
+		t.Fatalf("commitment mismatch state=%v chunks=%d pinned=%d", record.state, len(record.chunks), state.pinnedPayloadBytes)
+	}
+
+	state = newDARelayStateForTest(t, defaultDARelayCaps())
+	mustAddDACommit(t, state, "peer-a", daRelayTestCommitForPayloads(daID, 1, payload0, payload1))
+	mustAddDAChunk(t, state, "peer-b", daRelayTestChunkPayload(daID, 0, uint64(len(payload0)), payload0))
+	_, err = state.addDAChunk("peer-c", daRelayTestChunkPayload(daID, 1, uint64(len(payload1)), []byte("payload-x")))
+	requireDAErr(t, err, errDARelayPayloadCommitmentMismatch)
+	if len(state.sets[daID].chunks) != 1 || state.pinnedPayloadBytes != 0 {
+		t.Fatalf("chunk mismatch mutated state: chunks=%d pinned=%d", len(state.sets[daID].chunks), state.pinnedPayloadBytes)
+	}
+
+	caps := defaultDARelayCaps()
+	caps.pinnedPayloadBytes = 1
+	state = newDARelayStateForTest(t, caps)
+	mustAddDACommit(t, state, "peer-a", daRelayTestCommitForPayloads(daID, 1, payload0))
+	_, err = state.addDAChunk("peer-b", daRelayTestChunkPayload(daID, 0, uint64(len(payload0)), payload0))
+	requireDAErr(t, err, errDARelayPinnedPayloadCapExceeded)
+	if state.sets[daID].state != daRelayStateStagedCommit || len(state.sets[daID].chunks) != 0 || state.pinnedPayloadBytes != 0 {
+		t.Fatalf("pinned cap rejection mutated state: state=%v chunks=%d pinned=%d", state.sets[daID].state, len(state.sets[daID].chunks), state.pinnedPayloadBytes)
+	}
+}
+
 func TestDARelayCapsRejectInvalidLimits(t *testing.T) {
 	tests := []struct {
 		name string
@@ -358,11 +435,29 @@ func daRelayTestID(seed byte) (out [32]byte) {
 }
 
 func daRelayTestChunk(daID [32]byte, index uint16, wireBytes uint64) daRelayChunk {
-	return daRelayChunk{daID: daID, chunkIndex: index, wireBytes: wireBytes}
+	return daRelayTestChunkPayload(daID, index, wireBytes, []byte{byte(index + 1)})
 }
 
 func daRelayTestCommit(daID [32]byte, chunkCount uint16, wireBytes uint64) daRelayCommit {
 	return daRelayCommit{daID: daID, chunkCount: chunkCount, wireBytes: wireBytes}
+}
+
+func daRelayTestChunkPayload(daID [32]byte, index uint16, wireBytes uint64, payload []byte) daRelayChunk {
+	return daRelayChunk{daID: daID, chunkHash: sha3.Sum256(payload), chunkIndex: index, payload: cloneBytes(payload), wireBytes: wireBytes}
+}
+
+func daRelayTestCommitForPayloads(daID [32]byte, wireBytes uint64, payloads ...[]byte) daRelayCommit {
+	return daRelayCommit{daID: daID, payloadCommitment: daRelayPayloadCommitment(payloads...), chunkCount: uint16(len(payloads)), wireBytes: wireBytes}
+}
+
+func daRelayPayloadCommitment(payloads ...[]byte) [32]byte {
+	hasher := sha3.New256()
+	for _, payload := range payloads {
+		_, _ = hasher.Write(payload)
+	}
+	var out [32]byte
+	copy(out[:], hasher.Sum(nil))
+	return out
 }
 
 func newDARelayStateForTest(t *testing.T, caps daRelayCaps) *daRelayState {

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -269,6 +269,7 @@ func TestDARelayRejectsDuplicatesBeforeMutation(t *testing.T) {
 
 	chunk := daRelayTestChunk(daID, 0, 7)
 	record = mustAddDAChunk(t, state, "peer-c", chunk)
+	chunk.chunkHash[0] ^= 0xff
 	_, err = state.addDAChunk("peer-d", chunk)
 	requireDAErr(t, err, errDARelayDuplicateChunk)
 	if len(state.sets[daID].chunks) != 1 || state.orphanBytes != record.wireBytes {
@@ -294,11 +295,16 @@ func TestDARelayRejectedCandidatesDoNotMutateStoredChunks(t *testing.T) {
 	state = newDARelayStateForTest(t, defaultDARelayCaps())
 	mustAddDACommit(t, state, "peer-a", daRelayTestCommit(daID, 2, 1))
 	state.caps.orphanPoolPerDAIDBytes = state.orphanBytes
-	_, err = state.addDAChunk("peer-b", daRelayTestChunk(daID, 1, 1))
+	chunk := daRelayTestChunk(daID, 1, 1)
+	_, err = state.addDAChunk("peer-b", chunk)
 	requireDAErr(t, err, errDARelayOrphanDAIDCapExceeded)
 	if _, ok := state.sets[daID].chunks[1]; ok {
 		t.Fatalf("failed chunk insert mutated stored staged record")
 	}
+	chunk.chunkIndex = 2
+	chunk.chunkHash[0] ^= 0xff
+	_, err = state.addDAChunk("peer-b", chunk)
+	requireDAErr(t, err, errDARelayChunkIndexOutsideCommit)
 }
 
 func TestDARelayCompletesSetAndPinsPayload(t *testing.T) {

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -326,6 +326,38 @@ func TestDARelayCompletesSetAndPinsPayload(t *testing.T) {
 	}
 }
 
+func TestDARelayCloneModesKeepStateCopiesShallowAndCallerCopiesDeep(t *testing.T) {
+	daID := daRelayTestID(6)
+	record := daRelaySetRecord{
+		daID: daID,
+		chunks: map[uint16]daRelayChunk{
+			0: daRelayTestChunkPayload(daID, 0, 17, []byte("immutable-payload")),
+		},
+	}
+
+	stateClone := record.cloneForStateMutation()
+	originalChunk := record.chunks[0]
+	stateChunk := stateClone.chunks[0]
+	if &stateChunk.payload[0] != &originalChunk.payload[0] {
+		t.Fatalf("state mutation clone deep-copied payload")
+	}
+	stateClone.chunks[1] = daRelayTestChunkPayload(daID, 1, 1, []byte("second"))
+	if _, ok := record.chunks[1]; ok {
+		t.Fatalf("state mutation clone aliases chunk map")
+	}
+
+	callerClone := record.clone()
+	callerChunk := callerClone.chunks[0]
+	if &callerChunk.payload[0] == &originalChunk.payload[0] {
+		t.Fatalf("caller clone reused payload")
+	}
+	callerChunk.payload[0] ^= 0xff
+	callerClone.chunks[0] = callerChunk
+	if record.chunks[0].payload[0] == callerClone.chunks[0].payload[0] {
+		t.Fatalf("caller clone aliases stored payload")
+	}
+}
+
 func TestDARelayRejectsIntegrityAndPinnedCapBeforeMutation(t *testing.T) {
 	daID := daRelayTestID(6)
 	state := newDARelayStateForTest(t, defaultDARelayCaps())

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -3,6 +3,8 @@ package p2p
 import (
 	"crypto/sha3"
 	"errors"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
@@ -292,8 +294,48 @@ func TestDARelayCompletesSetAndPinsPayload(t *testing.T) {
 	}
 }
 
-func TestDARelayRejectsIntegrityAndPinnedCapBeforeMutation(t *testing.T) {
+func TestDARelayEvictionAccountingHidesUnavailableFee(t *testing.T) {
+	state := newDARelayStateForTest(t, defaultDARelayCaps())
 	daID := daRelayTestID(6)
+	payload0 := []byte("chunk-zero")
+	payload1 := []byte("chunk-one")
+
+	mustAddDACommit(t, state, "peer-a", daRelayTestCommitForPayloads(daID, 3, payload0, payload1))
+	mustAddDAChunk(t, state, "peer-b", daRelayTestChunkPayload(daID, 0, uint64(len(payload0)), payload0))
+	record := mustAddDAChunk(t, state, "peer-c", daRelayTestChunkPayload(daID, 1, uint64(len(payload1)), payload1))
+
+	accounting, ok := record.evictionAccounting()
+	if !ok {
+		t.Fatal("complete DA set did not expose eviction accounting")
+	}
+	if accounting.daID != daID {
+		t.Fatalf("eviction da_id=%x, want %x", accounting.daID, daID)
+	}
+	if accounting.payloadBytes != record.payloadBytes || accounting.wireBytes != record.wireBytes || accounting.receivedTime != record.receivedTime {
+		t.Fatalf("eviction accounting = %+v, want payload=%d wire=%d received=%d", accounting, record.payloadBytes, record.wireBytes, record.receivedTime)
+	}
+
+	accountingType := reflect.TypeOf(accounting)
+	for i := 0; i < accountingType.NumField(); i++ {
+		if strings.Contains(strings.ToLower(accountingType.Field(i).Name), "fee") {
+			t.Fatalf("eviction accounting exposes unavailable fee field %q", accountingType.Field(i).Name)
+		}
+	}
+}
+
+func TestDARelayEvictionAccountingRejectsIncompleteSet(t *testing.T) {
+	state := newDARelayStateForTest(t, defaultDARelayCaps())
+	daID := daRelayTestID(7)
+	payload := []byte("chunk-zero")
+
+	record := mustAddDACommit(t, state, "peer-a", daRelayTestCommitForPayloads(daID, 3, payload))
+	if _, ok := record.evictionAccounting(); ok {
+		t.Fatal("incomplete DA set exposed eviction accounting")
+	}
+}
+
+func TestDARelayRejectsIntegrityAndPinnedCapBeforeMutation(t *testing.T) {
+	daID := daRelayTestID(8)
 	state := newDARelayStateForTest(t, defaultDARelayCaps())
 	badChunk := daRelayTestChunkPayload(daID, 0, 3, []byte("bad"))
 	badChunk.chunkHash[0] ^= 0xff

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -238,11 +238,45 @@ func TestDARelayRejectsStagedIndexAndCapFailuresBeforeMutation(t *testing.T) {
 	overflowState := newDARelayStateForTest(t, caps)
 	mustAddDAChunk(t, overflowState, "peer-a", daRelayTestChunk(daID, 0, ^uint64(0)))
 	_, err = overflowState.addDACommit("peer-a", daRelayTestCommit(daID, 2, 1))
-	requireDAErr(t, err, errDARelayOrphanPoolCapExceeded)
+	requireDAErr(t, err, errDARelayArithmeticOverflow)
+}
+
+func TestDARelayRejectsZeroWireBytesBeforeMutation(t *testing.T) {
+	daID := daRelayTestID(3)
+	state := newDARelayStateForTest(t, defaultDARelayCaps())
+
+	_, err := state.addDACommit("peer-a", daRelayTestCommit(daID, 1, 0))
+	requireDAErr(t, err, errDARelayWireBytesInvalid)
+	_, err = state.addDAChunk("peer-a", daRelayTestChunk(daID, 0, 0))
+	requireDAErr(t, err, errDARelayWireBytesInvalid)
+
+	if len(state.sets) != 0 || state.orphanBytes != 0 || state.orphanCommitOverheadBytes != 0 {
+		t.Fatalf("zero wire rejection mutated state: sets=%d orphan=%d commit=%d", len(state.sets), state.orphanBytes, state.orphanCommitOverheadBytes)
+	}
+}
+
+func TestDARelayRejectsDuplicatesBeforeMutation(t *testing.T) {
+	daID := daRelayTestID(4)
+	state := newDARelayStateForTest(t, defaultDARelayCaps())
+
+	record := mustAddDACommit(t, state, "peer-a", daRelayTestCommit(daID, 2, 3))
+	_, err := state.addDACommit("peer-b", daRelayTestCommit(daID, 2, 5))
+	requireDAErr(t, err, errDARelayDuplicateCommit)
+	if state.sets[daID].commit.wireBytes != record.commit.wireBytes || state.orphanBytes != record.wireBytes {
+		t.Fatalf("duplicate commit mutated state: commit=%d orphan=%d want commit=%d orphan=%d", state.sets[daID].commit.wireBytes, state.orphanBytes, record.commit.wireBytes, record.wireBytes)
+	}
+
+	chunk := daRelayTestChunk(daID, 0, 7)
+	record = mustAddDAChunk(t, state, "peer-c", chunk)
+	_, err = state.addDAChunk("peer-d", chunk)
+	requireDAErr(t, err, errDARelayDuplicateChunk)
+	if len(state.sets[daID].chunks) != 1 || state.orphanBytes != record.wireBytes {
+		t.Fatalf("duplicate chunk mutated state: chunks=%d orphan=%d want orphan=%d", len(state.sets[daID].chunks), state.orphanBytes, record.wireBytes)
+	}
 }
 
 func TestDARelayRejectedCandidatesDoNotMutateStoredChunks(t *testing.T) {
-	daID := daRelayTestID(4)
+	daID := daRelayTestID(5)
 	state := newDARelayStateForTest(t, defaultDARelayCaps())
 	mustAddDAChunk(t, state, "peer-a", daRelayTestChunk(daID, 0, 1))
 	mustAddDAChunk(t, state, "peer-a", daRelayTestChunk(daID, 2, 1))

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -415,6 +415,29 @@ func TestDARelayRejectsIntegrityAndPinnedCapBeforeMutation(t *testing.T) {
 	}
 }
 
+func TestDARelayPinnedPayloadDeltaKeepsOverflowAndCapErrorsDistinct(t *testing.T) {
+	caps := defaultDARelayCaps()
+	caps.pinnedPayloadBytes = 1
+	state := newDARelayStateForTest(t, caps)
+
+	state.pinnedPayloadBytes = 1
+	state.mu.Lock()
+	_, err := state.projectPinnedPayloadDeltaLocked(
+		daRelaySetRecord{state: daRelayStateCompleteSet, payloadBytes: 2},
+		daRelaySetRecord{},
+	)
+	state.mu.Unlock()
+	requireDAErr(t, err, errDARelayArithmeticOverflow)
+
+	state.mu.Lock()
+	_, err = state.projectPinnedPayloadDeltaLocked(
+		daRelaySetRecord{},
+		daRelaySetRecord{state: daRelayStateCompleteSet, payloadBytes: 2},
+	)
+	state.mu.Unlock()
+	requireDAErr(t, err, errDARelayPinnedPayloadCapExceeded)
+}
+
 func TestDARelayCapsRejectInvalidLimits(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
Invariant:
Complete DA relay records expose only populated accounting values for eviction use; unavailable fee data is not surfaced as synthetic zero.

Layer:
implementation / operations / tests

Files changed:
- clients/go/node/p2p/da_relay_state.go
- clients/go/node/p2p/da_relay_state_test.go

Tests:
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node/p2p -run "DARelayEvictionAccounting" -count=1'\n- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node/p2p -run "Da|DA|Relay" -count=1'\n- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -race ./node/p2p -run "Da|DA|Relay" -count=1'\n- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./...'\n- rubin-precommit-one-review --base-ref codex/RUB-362-da-complete-integrity --include-base-diff\n- rubin-push --base-ref codex/RUB-362-da-complete-integrity --coverage-cmd rubin-stack-codacy-coverage.sh -- origin HEAD\n\nBehavior impact:\nNo consensus change. Complete DA records expose payload, wire, received-time, and da_id accounting only.\n\nCompatibility impact:\nGo-only Phase-0 relay runtime surface; no Rust parity claim.\n\nKnown non-goals:\n- RBF/CPFP/package relay\n- Fee-market redesign\n- Consensus validity change\n- Canonical spec, conformance fixture, or Rust changes\n\nFollow-ups:\n- Parent RUB-318/RUB-224 closeout remains outside this PR.\n\nRefs: RUB-363, #1803

<!-- rubin-agent-meta actor=unknown action=pr-create via=cl branch=codex/RUB-363-da-fee-eviction wt=rubin-protocol-codex-RUB-318 utc=2026-05-25T00:31:50Z -->
