### PR TITLE
RUB-364: Pin DA duplicate commit first-seen state

### DIFF
--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -478,6 +478,15 @@ func TestDARelayRejectsDuplicatesBeforeMutation(t *testing.T) {
 	if state.sets[daID].commit.wireBytes != record.commit.wireBytes || state.orphanBytes != record.wireBytes {
 		t.Fatalf("duplicate commit mutated state: commit=%d orphan=%d want commit=%d orphan=%d", state.sets[daID].commit.wireBytes, state.orphanBytes, record.commit.wireBytes, record.wireBytes)
 	}
+	if got := state.sets[daID].commit.peerQuotaKey; got != peerQuotaKey("peer-a") {
+		t.Fatalf("duplicate commit peer=%q, want first peer", got)
+	}
+	if got := state.orphanBytesForPeer("peer-b"); got != 0 {
+		t.Fatalf("duplicate commit credited duplicate peer bytes=%d", got)
+	}
+	if got := state.sets[daID].receivedTime; got != record.receivedTime {
+		t.Fatalf("duplicate commit received_time=%d, want first-seen %d", got, record.receivedTime)
+	}
 
 	chunk := daRelayTestChunk(daID, 0, 7)
 	record = mustAddDAChunk(t, state, "peer-c", chunk)
@@ -486,6 +495,30 @@ func TestDARelayRejectsDuplicatesBeforeMutation(t *testing.T) {
 	requireDAErr(t, err, errDARelayDuplicateChunk)
 	if len(state.sets[daID].chunks) != 1 || state.orphanBytes != record.wireBytes {
 		t.Fatalf("duplicate chunk mutated state: chunks=%d orphan=%d want orphan=%d", len(state.sets[daID].chunks), state.orphanBytes, record.wireBytes)
+	}
+}
+
+func TestDARelayDuplicateCommitAfterOrphanChunksKeepsFirstSeenState(t *testing.T) {
+	daID := daRelayTestID(92)
+	state := newDARelayStateForTest(t, defaultDARelayCaps())
+
+	mustAddDAChunk(t, state, "peer-a", daRelayTestChunk(daID, 0, 7))
+	record := mustAddDACommit(t, state, "peer-b", daRelayTestCommit(daID, 2, 3))
+
+	_, err := state.addDACommit("peer-c", daRelayTestCommit(daID, 2, 11))
+	requireDAErr(t, err, errDARelayDuplicateCommit)
+	stored := state.sets[daID]
+	if stored.commit.wireBytes != record.commit.wireBytes || stored.commit.peerQuotaKey != peerQuotaKey("peer-b") {
+		t.Fatalf("duplicate commit replaced first commit: wire=%d peer=%q", stored.commit.wireBytes, stored.commit.peerQuotaKey)
+	}
+	if stored.receivedTime != record.receivedTime || state.nextReceivedTime != record.receivedTime {
+		t.Fatalf("duplicate commit time record=%d state=%d want %d", stored.receivedTime, state.nextReceivedTime, record.receivedTime)
+	}
+	if _, ok := stored.chunks[0]; !ok {
+		t.Fatal("duplicate commit dropped first-seen orphan chunk")
+	}
+	if got := state.orphanBytesForPeer("peer-c"); got != 0 {
+		t.Fatalf("duplicate commit credited duplicate peer bytes=%d", got)
 	}
 }
 


### PR DESCRIPTION
Invariant:
- DA duplicate commits must not replace the first accepted commit state for a da_id.

Layer:
- Tests.

Files changed:
- clients/go/node/p2p/da_relay_state_test.go

Tests:
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node/p2p -run "DA|Da|Relay|Duplicate" -count=1' - PASS
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./...' - PASS
- rubin-precommit-one-review --repo . --base-ref origin/main --include-base-diff - PASS
- rubin-push --repo . --base-ref origin/main --no-coverage-reason "tests-only Go diff; no coverable production Go/Rust changes" -- -u origin codex/RUB-364-da-dup-commit-first-seen - PASS

Behavior impact:
- No production behavior change; this PR adds regression coverage only.

Compatibility impact:
- None.

Known non-goals:
- DA TTL expiry cleanup.
- DA disconnect cleanup.
- DA wire/service peer scoring.

Follow-ups:
- RUB-365 owns TTL expiry cleanup.
- RUB-366 owns disconnect cleanup.

Risk:
- Low; test-only diff.

Rollback:
- Revert the test commit.

Not checked:
- Coverage generation was skipped because the diff is tests-only and has no coverable production Go or Rust changes.


<!-- rubin-agent-meta actor=gpt5 action=pr-create via=cl branch=codex/RUB-364-da-dup-commit-first-seen wt=rubin-protocol utc=2026-05-25T20:51:20Z -->
