### PR TITLE
RUB-365: defend DA TTL expiry cleanup

### DIFF
--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -268,11 +268,8 @@ func (s *daRelayState) advanceOrphanTTL() ([]daRelayExpiredSet, error) {
 	defer s.mu.Unlock()
 
 	var expired []daRelayExpiredSet
-	for _, daID := range s.sortedDAIDsLocked() {
+	for _, daID := range s.sortedIncompleteDAIDsLocked() {
 		record := s.sets[daID]
-		if record.state == daRelayStateCompleteSet {
-			continue
-		}
 		if record.ttlBlocksRemaining > 1 {
 			record.ttlBlocksRemaining--
 			s.sets[daID] = record
@@ -291,9 +288,13 @@ func (s *daRelayState) advanceOrphanTTL() ([]daRelayExpiredSet, error) {
 	return expired, nil
 }
 
-func (s *daRelayState) sortedDAIDsLocked() [][32]byte {
-	daIDs := make([][32]byte, 0, len(s.sets))
-	for daID := range s.sets {
+func (s *daRelayState) sortedIncompleteDAIDsLocked() [][32]byte {
+	var daIDs [][32]byte
+	for daID := range s.orphanBytesByDAID {
+		record, ok := s.sets[daID]
+		if !ok || record.state == daRelayStateCompleteSet {
+			continue
+		}
 		daIDs = append(daIDs, daID)
 	}
 	sort.Slice(daIDs, func(i, j int) bool {

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -275,9 +275,7 @@ func (s *daRelayState) advanceOrphanTTL() ([]daRelayExpiredSet, error) {
 		}
 		if record.ttlBlocksRemaining > 1 {
 			record.ttlBlocksRemaining--
-			if err := s.applyDASetRecordLocked(record); err != nil {
-				return nil, err
-			}
+			s.sets[daID] = record
 			continue
 		}
 		if err := s.removeDASetRecordLocked(record); err != nil {

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -1,8 +1,10 @@
 package p2p
 
 import (
+	"bytes"
 	"crypto/sha3"
 	"errors"
+	"sort"
 	"sync"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
@@ -109,6 +111,13 @@ type daRelayEvictionAccounting struct {
 	payloadBytes uint64
 	wireBytes    uint64
 	receivedTime uint64
+}
+
+type daRelayExpiredSet struct {
+	daID               [32]byte
+	state              daRelaySetState
+	commitPeerQuotaKey string
+	receivedTime       uint64
 }
 
 type daRelayCommit struct {
@@ -252,6 +261,47 @@ func (s *daRelayState) orphanBytesForDAID(daID [32]byte) uint64 {
 	defer s.mu.Unlock()
 
 	return s.orphanBytesByDAID[daID]
+}
+
+func (s *daRelayState) advanceOrphanTTL() ([]daRelayExpiredSet, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var expired []daRelayExpiredSet
+	for _, daID := range s.sortedDAIDsLocked() {
+		record := s.sets[daID]
+		if record.state == daRelayStateCompleteSet {
+			continue
+		}
+		if record.ttlBlocksRemaining > 1 {
+			record.ttlBlocksRemaining--
+			if err := s.applyDASetRecordLocked(record); err != nil {
+				return nil, err
+			}
+			continue
+		}
+		if err := s.removeDASetRecordLocked(record); err != nil {
+			return nil, err
+		}
+		expired = append(expired, daRelayExpiredSet{
+			daID:               record.daID,
+			state:              record.state,
+			commitPeerQuotaKey: record.commit.peerQuotaKey,
+			receivedTime:       record.receivedTime,
+		})
+	}
+	return expired, nil
+}
+
+func (s *daRelayState) sortedDAIDsLocked() [][32]byte {
+	daIDs := make([][32]byte, 0, len(s.sets))
+	for daID := range s.sets {
+		daIDs = append(daIDs, daID)
+	}
+	sort.Slice(daIDs, func(i, j int) bool {
+		return bytes.Compare(daIDs[i][:], daIDs[j][:]) < 0
+	})
+	return daIDs
 }
 
 func (s *daRelayState) addDACommit(peerAddr string, commit daRelayCommit) (daRelaySetRecord, error) {
@@ -471,6 +521,25 @@ func (s *daRelayState) applyDASetRecordLocked(record daRelaySetRecord) error {
 	if record.receivedTime > s.nextReceivedTime {
 		s.nextReceivedTime = record.receivedTime
 	}
+	return nil
+}
+
+func (s *daRelayState) removeDASetRecordLocked(record daRelaySetRecord) error {
+	emptyRecord := daRelaySetRecord{daID: record.daID}
+	orphanBytes, peerBytes, daBytes, commitBytes, err := s.projectOrphanAccountingDeltaLocked(record, emptyRecord)
+	if err != nil {
+		return err
+	}
+	pinnedBytes, err := s.projectPinnedPayloadDeltaLocked(record, emptyRecord)
+	if err != nil {
+		return err
+	}
+	delete(s.sets, record.daID)
+	s.orphanBytes = orphanBytes
+	s.applyProjectedPeerBytes(peerBytes)
+	s.applyProjectedDAIDBytes(record.daID, daBytes)
+	s.orphanCommitOverheadBytes = commitBytes
+	s.pinnedPayloadBytes = pinnedBytes
 	return nil
 }
 

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -522,6 +522,126 @@ func TestDARelayDuplicateCommitAfterOrphanChunksKeepsFirstSeenState(t *testing.T
 	}
 }
 
+func TestDARelayAdvanceOrphanTTLExpiresOrphanChunksAtomically(t *testing.T) {
+	caps := defaultDARelayCaps()
+	caps.orphanTTLBlocks = 1
+	state := newDARelayStateForTest(t, caps)
+	daID := daRelayTestID(93)
+
+	first := mustAddDAChunk(t, state, "peer-a", daRelayTestChunk(daID, 0, 7))
+	second := mustAddDAChunk(t, state, "peer-b", daRelayTestChunk(daID, 1, 11))
+	wantBytes := first.wireBytes + second.chunks[1].wireBytes
+	if state.orphanBytes != wantBytes || state.orphanBytesForDAID(daID) != wantBytes {
+		t.Fatalf("setup accounting global=%d da=%d want %d", state.orphanBytes, state.orphanBytesForDAID(daID), wantBytes)
+	}
+
+	expired, err := state.advanceOrphanTTL()
+	if err != nil {
+		t.Fatalf("advance ttl: %v", err)
+	}
+	if len(expired) != 1 || expired[0].daID != daID || expired[0].state != daRelayStateOrphanChunks || expired[0].commitPeerQuotaKey != "" {
+		t.Fatalf("expired=%+v, want orphan da_id without commit attribution", expired)
+	}
+	if _, ok := state.sets[daID]; ok {
+		t.Fatalf("expired orphan da_id record was retained")
+	}
+	if state.orphanBytes != 0 || state.orphanBytesForDAID(daID) != 0 || state.orphanCommitOverheadBytes != 0 {
+		t.Fatalf("expiry left accounting global=%d da=%d commit=%d", state.orphanBytes, state.orphanBytesForDAID(daID), state.orphanCommitOverheadBytes)
+	}
+	if got := state.orphanBytesForPeer("peer-a"); got != 0 {
+		t.Fatalf("expiry left peer-a bytes=%d", got)
+	}
+	if got := state.orphanBytesForPeer("peer-b"); got != 0 {
+		t.Fatalf("expiry left peer-b bytes=%d", got)
+	}
+	if expired, err = state.advanceOrphanTTL(); err != nil || len(expired) != 0 {
+		t.Fatalf("second ttl advance expired=%+v err=%v, want no-op", expired, err)
+	}
+}
+
+func TestDARelayAdvanceOrphanTTLExpiresStagedCommitAccounting(t *testing.T) {
+	caps := defaultDARelayCaps()
+	caps.orphanTTLBlocks = 1
+	state := newDARelayStateForTest(t, caps)
+	daID := daRelayTestID(94)
+
+	mustAddDAChunk(t, state, "peer-a", daRelayTestChunk(daID, 0, 7))
+	record := mustAddDACommit(t, state, "peer-b", daRelayTestCommit(daID, 3, 13))
+	if record.state != daRelayStateStagedCommit {
+		t.Fatalf("setup state=%v, want staged commit", record.state)
+	}
+	record.ttlBlocksRemaining = 0
+	state.sets[daID] = record
+	if state.orphanCommitOverheadBytes != record.commit.wireBytes {
+		t.Fatalf("setup commit overhead=%d, want %d", state.orphanCommitOverheadBytes, record.commit.wireBytes)
+	}
+
+	expired, err := state.advanceOrphanTTL()
+	if err != nil {
+		t.Fatalf("advance ttl: %v", err)
+	}
+	if len(expired) != 1 || expired[0].daID != daID || expired[0].state != daRelayStateStagedCommit || expired[0].commitPeerQuotaKey != peerQuotaKey("peer-b") {
+		t.Fatalf("expired=%+v, want staged commit attribution to peer-b", expired)
+	}
+	if _, ok := state.sets[daID]; ok {
+		t.Fatalf("expired staged commit da_id record was retained")
+	}
+	if state.orphanBytes != 0 || state.orphanBytesForDAID(daID) != 0 || state.orphanCommitOverheadBytes != 0 {
+		t.Fatalf("expiry left accounting global=%d da=%d commit=%d", state.orphanBytes, state.orphanBytesForDAID(daID), state.orphanCommitOverheadBytes)
+	}
+	if got := state.orphanBytesForPeer("peer-a"); got != 0 {
+		t.Fatalf("expiry left chunk peer bytes=%d", got)
+	}
+	if got := state.orphanBytesForPeer("peer-b"); got != 0 {
+		t.Fatalf("expiry left commit peer bytes=%d", got)
+	}
+}
+
+func TestDARelayAdvanceOrphanTTLDecrementsAndPreservesCompleteSets(t *testing.T) {
+	caps := defaultDARelayCaps()
+	caps.orphanTTLBlocks = 2
+	state := newDARelayStateForTest(t, caps)
+	stagedID := daRelayTestID(95)
+	completeID := daRelayTestID(96)
+	payload := []byte("complete-payload")
+
+	staged := mustAddDACommit(t, state, "peer-a", daRelayTestCommit(stagedID, 2, 5))
+	mustAddDACommit(t, state, "peer-b", daRelayTestCommitForPayloads(completeID, 3, payload))
+	complete := mustAddDAChunk(t, state, "peer-c", daRelayTestChunkPayload(completeID, 0, uint64(len(payload)), payload))
+	wantPinned := state.pinnedPayloadBytes
+	if complete.state != daRelayStateCompleteSet || wantPinned == 0 {
+		t.Fatalf("setup complete state=%v pinned=%d", complete.state, wantPinned)
+	}
+
+	expired, err := state.advanceOrphanTTL()
+	if err != nil {
+		t.Fatalf("first advance ttl: %v", err)
+	}
+	if len(expired) != 0 {
+		t.Fatalf("first ttl advance expired=%+v, want none", expired)
+	}
+	if got := state.sets[stagedID].ttlBlocksRemaining; got != staged.ttlBlocksRemaining-1 {
+		t.Fatalf("staged ttl after first tick=%d, want %d", got, staged.ttlBlocksRemaining-1)
+	}
+	if _, ok := state.sets[completeID]; !ok || state.pinnedPayloadBytes != wantPinned {
+		t.Fatalf("first tick mutated complete set ok=%v pinned=%d want %d", ok, state.pinnedPayloadBytes, wantPinned)
+	}
+
+	expired, err = state.advanceOrphanTTL()
+	if err != nil {
+		t.Fatalf("second advance ttl: %v", err)
+	}
+	if len(expired) != 1 || expired[0].daID != stagedID {
+		t.Fatalf("second ttl advance expired=%+v, want staged da_id", expired)
+	}
+	if _, ok := state.sets[stagedID]; ok {
+		t.Fatalf("expired staged record was retained")
+	}
+	if got := state.sets[completeID]; got.state != daRelayStateCompleteSet || state.pinnedPayloadBytes != wantPinned {
+		t.Fatalf("second tick mutated complete set state=%v pinned=%d want %d", got.state, state.pinnedPayloadBytes, wantPinned)
+	}
+}
+
 func TestDARelayRejectedCandidatesDoNotMutateStoredChunks(t *testing.T) {
 	daID := daRelayTestID(5)
 	state := newDARelayStateForTest(t, defaultDARelayCaps())

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -650,10 +650,15 @@ func TestDARelayAdvanceOrphanTTLReturnsProjectionErrorsWithoutMutation(t *testin
 	decrementRecord := daRelayOverflowOrphanAccountingRecord(decrementID)
 	decrementRecord.ttlBlocksRemaining = 2
 	state.sets[decrementID] = decrementRecord
-	_, err := state.advanceOrphanTTL()
-	requireDAErr(t, err, errDARelayArithmeticOverflow)
-	if got := state.sets[decrementID].ttlBlocksRemaining; got != 2 {
-		t.Fatalf("failed ttl decrement mutated ttl=%d, want 2", got)
+	expired, err := state.advanceOrphanTTL()
+	if err != nil {
+		t.Fatalf("ttl-only decrement should skip accounting projection: %v", err)
+	}
+	if len(expired) != 0 {
+		t.Fatalf("ttl-only decrement expired=%+v, want none", expired)
+	}
+	if got := state.sets[decrementID].ttlBlocksRemaining; got != 1 {
+		t.Fatalf("ttl-only decrement ttl=%d, want 1", got)
 	}
 
 	delete(state.sets, decrementID)

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -642,6 +642,51 @@ func TestDARelayAdvanceOrphanTTLDecrementsAndPreservesCompleteSets(t *testing.T)
 	}
 }
 
+func TestDARelayAdvanceOrphanTTLReturnsProjectionErrorsWithoutMutation(t *testing.T) {
+	state := newDARelayStateForTest(t, defaultDARelayCaps())
+	decrementID := daRelayTestID(97)
+	expireID := daRelayTestID(98)
+
+	decrementRecord := daRelayOverflowOrphanAccountingRecord(decrementID)
+	decrementRecord.ttlBlocksRemaining = 2
+	state.sets[decrementID] = decrementRecord
+	_, err := state.advanceOrphanTTL()
+	requireDAErr(t, err, errDARelayArithmeticOverflow)
+	if got := state.sets[decrementID].ttlBlocksRemaining; got != 2 {
+		t.Fatalf("failed ttl decrement mutated ttl=%d, want 2", got)
+	}
+
+	delete(state.sets, decrementID)
+	expireRecord := daRelayOverflowOrphanAccountingRecord(expireID)
+	expireRecord.ttlBlocksRemaining = 1
+	state.sets[expireID] = expireRecord
+	_, err = state.advanceOrphanTTL()
+	requireDAErr(t, err, errDARelayArithmeticOverflow)
+	if _, ok := state.sets[expireID]; !ok {
+		t.Fatal("failed ttl expiry deleted corrupt record")
+	}
+}
+
+func TestDARelayRemoveSetRecordReturnsPinnedProjectionErrorWithoutMutation(t *testing.T) {
+	state := newDARelayStateForTest(t, defaultDARelayCaps())
+	daID := daRelayTestID(99)
+	record := daRelaySetRecord{
+		daID:         daID,
+		state:        daRelayStateCompleteSet,
+		payloadBytes: 1,
+		wireBytes:    ^uint64(0),
+	}
+	state.sets[daID] = record
+
+	state.mu.Lock()
+	err := state.removeDASetRecordLocked(record)
+	state.mu.Unlock()
+	requireDAErr(t, err, errDARelayArithmeticOverflow)
+	if _, ok := state.sets[daID]; !ok {
+		t.Fatal("failed remove deleted corrupt complete record")
+	}
+}
+
 func TestDARelayRejectedCandidatesDoNotMutateStoredChunks(t *testing.T) {
 	daID := daRelayTestID(5)
 	state := newDARelayStateForTest(t, defaultDARelayCaps())
@@ -1292,6 +1337,30 @@ func daRelayTestChunkPayload(daID [32]byte, index uint16, wireBytes uint64, payl
 
 func daRelayTestCommitForPayloads(daID [32]byte, wireBytes uint64, payloads ...[]byte) daRelayCommit {
 	return daRelayCommit{daID: daID, payloadCommitment: daRelayPayloadCommitment(payloads...), chunkCount: uint16(len(payloads)), wireBytes: wireBytes}
+}
+
+func daRelayOverflowOrphanAccountingRecord(daID [32]byte) daRelaySetRecord {
+	return daRelaySetRecord{
+		daID:               daID,
+		state:              daRelayStateStagedCommit,
+		wireBytes:          ^uint64(0),
+		ttlBlocksRemaining: 1,
+		commit: daRelayCommit{
+			daID:         daID,
+			peerQuotaKey: "peer-overflow",
+			chunkCount:   2,
+			wireBytes:    ^uint64(0),
+		},
+		chunks: map[uint16]daRelayChunk{
+			0: {
+				daID:         daID,
+				peerQuotaKey: "peer-overflow",
+				chunkIndex:   0,
+				payload:      []byte{1},
+				wireBytes:    1,
+			},
+		},
+	}
 }
 
 func daRelayPayloadCommitment(payloads ...[]byte) [32]byte {

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -650,6 +650,7 @@ func TestDARelayAdvanceOrphanTTLReturnsProjectionErrorsWithoutMutation(t *testin
 	decrementRecord := daRelayOverflowOrphanAccountingRecord(decrementID)
 	decrementRecord.ttlBlocksRemaining = 2
 	state.sets[decrementID] = decrementRecord
+	state.orphanBytesByDAID[decrementID] = decrementRecord.wireBytes
 	expired, err := state.advanceOrphanTTL()
 	if err != nil {
 		t.Fatalf("ttl-only decrement should skip accounting projection: %v", err)
@@ -662,9 +663,11 @@ func TestDARelayAdvanceOrphanTTLReturnsProjectionErrorsWithoutMutation(t *testin
 	}
 
 	delete(state.sets, decrementID)
+	delete(state.orphanBytesByDAID, decrementID)
 	expireRecord := daRelayOverflowOrphanAccountingRecord(expireID)
 	expireRecord.ttlBlocksRemaining = 1
 	state.sets[expireID] = expireRecord
+	state.orphanBytesByDAID[expireID] = expireRecord.wireBytes
 	_, err = state.advanceOrphanTTL()
 	requireDAErr(t, err, errDARelayArithmeticOverflow)
 	if _, ok := state.sets[expireID]; !ok {

--- a/clients/go/node/p2p/handlers_block.go
+++ b/clients/go/node/p2p/handlers_block.go
@@ -140,19 +140,21 @@ func parseRelayedBlock(blockBytes []byte) (*consensus.ParsedBlock, [32]byte, err
 func (p *peer) acceptedRelayedBlock(blockHash [32]byte, summary *node.ChainStateConnectSummary) {
 	if err := p.service.noteAcceptedBlock(p, blockHash, summary); err != nil {
 		p.setLastError(err.Error())
-		return
 	}
 	p.service.resolveOrphans(p, blockHash)
 }
 
 func (s *Service) noteAcceptedBlock(skip *peer, blockHash [32]byte, summary *node.ChainStateConnectSummary) error {
-	if err := s.advanceDAOrphanTTL(); err != nil {
-		return err
+	if summary != nil {
+		s.cfg.SyncEngine.RecordBestKnownHeight(summary.BlockHeight)
 	}
-	s.cfg.SyncEngine.RecordBestKnownHeight(summary.BlockHeight)
 	s.blockSeen.Add(blockHash)
-	_ = s.broadcastInventory(skip, []InventoryVector{{Type: MSG_BLOCK, Hash: blockHash}})
-	return nil
+	_ = s.broadcastAcceptedBlock(skip, blockHash)
+	return s.advanceDAOrphanTTL()
+}
+
+func (s *Service) broadcastAcceptedBlock(skip *peer, blockHash [32]byte) error {
+	return s.broadcastInventory(skip, []InventoryVector{{Type: MSG_BLOCK, Hash: blockHash}})
 }
 
 func (s *Service) advanceDAOrphanTTL() error {
@@ -226,7 +228,9 @@ func (s *Service) resolveOrphans(skip *peer, blockHash [32]byte) {
 				continue
 			}
 			if err := s.noteAcceptedBlock(skip, childHash, summary); err != nil {
-				return
+				if skip != nil {
+					skip.setLastError(err.Error())
+				}
 			}
 			queue = append(queue, childHash)
 		}

--- a/clients/go/node/p2p/handlers_block.go
+++ b/clients/go/node/p2p/handlers_block.go
@@ -138,10 +138,29 @@ func parseRelayedBlock(blockBytes []byte) (*consensus.ParsedBlock, [32]byte, err
 }
 
 func (p *peer) acceptedRelayedBlock(blockHash [32]byte, summary *node.ChainStateConnectSummary) {
-	p.service.cfg.SyncEngine.RecordBestKnownHeight(summary.BlockHeight)
-	p.service.blockSeen.Add(blockHash)
-	_ = p.service.broadcastInventory(p, []InventoryVector{{Type: MSG_BLOCK, Hash: blockHash}})
+	if err := p.service.noteAcceptedBlock(p, blockHash, summary); err != nil {
+		p.setLastError(err.Error())
+		return
+	}
 	p.service.resolveOrphans(p, blockHash)
+}
+
+func (s *Service) noteAcceptedBlock(skip *peer, blockHash [32]byte, summary *node.ChainStateConnectSummary) error {
+	if err := s.advanceDAOrphanTTL(); err != nil {
+		return err
+	}
+	s.cfg.SyncEngine.RecordBestKnownHeight(summary.BlockHeight)
+	s.blockSeen.Add(blockHash)
+	_ = s.broadcastInventory(skip, []InventoryVector{{Type: MSG_BLOCK, Hash: blockHash}})
+	return nil
+}
+
+func (s *Service) advanceDAOrphanTTL() error {
+	if s == nil || s.daRelay == nil {
+		return nil
+	}
+	_, err := s.daRelay.advanceOrphanTTL()
+	return err
 }
 
 func (s *Service) retainOrResolveOrphan(skip *peer, blockHash, parentHash [32]byte, blockBytes []byte) {
@@ -206,9 +225,9 @@ func (s *Service) resolveOrphans(skip *peer, blockHash [32]byte) {
 				// re-advertisement of known-invalid blocks.
 				continue
 			}
-			s.cfg.SyncEngine.RecordBestKnownHeight(summary.BlockHeight)
-			s.blockSeen.Add(childHash)
-			_ = s.broadcastInventory(skip, []InventoryVector{{Type: MSG_BLOCK, Hash: childHash}})
+			if err := s.noteAcceptedBlock(skip, childHash, summary); err != nil {
+				return
+			}
 			queue = append(queue, childHash)
 		}
 	}

--- a/clients/go/node/p2p/reconnect_test.go
+++ b/clients/go/node/p2p/reconnect_test.go
@@ -202,6 +202,7 @@ func TestReconnectDuePeersDialsDuePeer(t *testing.T) {
 
 	h.service.reconnectDuePeers()
 	<-acceptedDone
+	h.service.loopWG.Wait()
 	if got := accepted.Load(); got != 1 {
 		t.Fatalf("accepted=%d, want 1", got)
 	}

--- a/clients/go/node/p2p/service.go
+++ b/clients/go/node/p2p/service.go
@@ -220,7 +220,12 @@ func (s *Service) AnnounceBlock(blockBytes []byte) error {
 	if !s.blockSeen.Add(blockHash) {
 		return nil
 	}
-	return s.broadcastInventory(nil, []InventoryVector{{Type: MSG_BLOCK, Hash: blockHash}})
+	broadcastErr := s.broadcastAcceptedBlock(nil, blockHash)
+	ttlErr := s.advanceDAOrphanTTL()
+	if broadcastErr != nil {
+		return broadcastErr
+	}
+	return ttlErr
 }
 
 func (s *Service) AnnounceTx(txBytes []byte) error {

--- a/clients/go/node/p2p/service.go
+++ b/clients/go/node/p2p/service.go
@@ -82,6 +82,7 @@ type Service struct {
 	blockSeen *boundedHashSet
 	txSeen    *boundedHashSet
 	orphans   *orphanPool
+	daRelay   *daRelayState
 
 	// peerLifecycleExits counts peer lifecycle exits at the single
 	// canonical removal boundary inside unregisterPeer. The counter is
@@ -119,6 +120,10 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 	outboundAddrs := normalizeDialTargets(cfg.BootstrapPeers)
 	addrMgr := newAddrManager(cfg.Now)
 	seedAddrManagerFromBootstrap(addrMgr, outboundAddrs)
+	daRelay, err := newDARelayState(defaultDARelayCaps())
+	if err != nil {
+		return nil, err
+	}
 	return &Service{
 		cfg:            cfg,
 		peers:          make(map[string]*peer),
@@ -130,6 +135,7 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 		blockSeen:      newBoundedHashSet(defaultBlockSeenCapacity),
 		txSeen:         newBoundedHashSet(defaultTxSeenCapacity),
 		orphans:        newOrphanPool(500),
+		daRelay:        daRelay,
 	}, nil
 }
 

--- a/clients/go/node/p2p/service_test.go
+++ b/clients/go/node/p2p/service_test.go
@@ -280,6 +280,40 @@ func TestOrphanResolution(t *testing.T) {
 	assertHarnessTip(t, sink, 2, height2Hash)
 }
 
+func TestProcessRelayedBlockAdvancesDARelayTTL(t *testing.T) {
+	sink := newTestHarness(t, 0, "127.0.0.1:0", nil)
+	caps := defaultDARelayCaps()
+	caps.orphanTTLBlocks = 1
+	sink.service.daRelay = newDARelayStateForTest(t, caps)
+
+	daID := daRelayTestID(100)
+	mustAddDAChunk(t, sink.service.daRelay, "peer-a", daRelayTestChunk(daID, 0, 7))
+	if got := sink.service.daRelay.orphanBytes; got == 0 {
+		t.Fatalf("orphanBytes=%d, want staged orphan bytes before block accept", got)
+	}
+
+	peer := testPeerForService(sink.service, "remote", 1)
+	summary, err := peer.processRelayedBlock(node.DevnetGenesisBlockBytes())
+	if err != nil {
+		t.Fatalf("processRelayedBlock(genesis): %v", err)
+	}
+	if summary == nil || summary.BlockHeight != 0 {
+		t.Fatalf("summary=%v, want height 0", summary)
+	}
+	if _, ok := sink.service.daRelay.sets[daID]; ok {
+		t.Fatalf("DA set %x still present after accepted block TTL expiry", daID)
+	}
+	if got := sink.service.daRelay.orphanBytes; got != 0 {
+		t.Fatalf("orphanBytes=%d, want 0 after accepted block TTL expiry", got)
+	}
+	if got := sink.service.daRelay.orphanBytesForPeer("peer-a"); got != 0 {
+		t.Fatalf("orphanBytesForPeer(peer-a)=%d, want 0", got)
+	}
+	if got := sink.service.daRelay.orphanBytesForDAID(daID); got != 0 {
+		t.Fatalf("orphanBytesForDAID=%d, want 0", got)
+	}
+}
+
 func TestHandleBlockRequestsMoreBlocksAfterAccept(t *testing.T) {
 	sink := newTestHarness(t, 0, "127.0.0.1:0", nil)
 	peer := &peer{

--- a/clients/go/node/p2p/service_test.go
+++ b/clients/go/node/p2p/service_test.go
@@ -280,6 +280,37 @@ func TestOrphanResolution(t *testing.T) {
 	assertHarnessTip(t, sink, 2, height2Hash)
 }
 
+func TestAcceptedBlockKeepsResolvingOrphansWhenDATTLExpiryFails(t *testing.T) {
+	source := newTestHarness(t, 3, "127.0.0.1:0", nil)
+	sink := newTestHarness(t, 0, "127.0.0.1:0", nil)
+	sink.service.daRelay = newDARelayStateForTest(t, defaultDARelayCaps())
+	overflowID := daRelayTestID(102)
+	overflowRecord := daRelayOverflowOrphanAccountingRecord(overflowID)
+	overflowRecord.ttlBlocksRemaining = 2
+	sink.service.daRelay.sets[overflowID] = overflowRecord
+	sink.service.daRelay.orphanBytesByDAID[overflowID] = overflowRecord.wireBytes
+
+	genesisBytes := node.DevnetGenesisBlockBytes()
+	_, block1Bytes := testHarnessBlockAtHeight(t, source, 1)
+	height2Hash, block2Bytes := testHarnessBlockAtHeight(t, source, 2)
+	peer := testPeerForService(sink.service, "remote", 2)
+
+	assertRelayedBlockIsOrphan(t, peer, block2Bytes, "block2")
+	assertRelayedBlockIsOrphan(t, peer, block1Bytes, "block1")
+	summary, err := peer.processRelayedBlock(genesisBytes)
+	if err != nil {
+		t.Fatalf("processRelayedBlock(genesis): %v", err)
+	}
+	if summary == nil || summary.BlockHeight != 0 {
+		t.Fatalf("genesis summary=%v, want height 0", summary)
+	}
+	if peer.snapshotState().LastError == "" {
+		t.Fatalf("expected DA TTL cleanup error to be recorded")
+	}
+	assertOrphanPoolLen(t, sink.service, 0)
+	assertHarnessTip(t, sink, 2, height2Hash)
+}
+
 func TestProcessRelayedBlockAdvancesDARelayTTL(t *testing.T) {
 	sink := newTestHarness(t, 0, "127.0.0.1:0", nil)
 	caps := defaultDARelayCaps()
@@ -310,6 +341,32 @@ func TestProcessRelayedBlockAdvancesDARelayTTL(t *testing.T) {
 		t.Fatalf("orphanBytesForPeer(peer-a)=%d, want 0", got)
 	}
 	if got := sink.service.daRelay.orphanBytesForDAID(daID); got != 0 {
+		t.Fatalf("orphanBytesForDAID=%d, want 0", got)
+	}
+}
+
+func TestAnnounceBlockAdvancesDARelayTTL(t *testing.T) {
+	h := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	caps := defaultDARelayCaps()
+	caps.orphanTTLBlocks = 1
+	h.service.daRelay = newDARelayStateForTest(t, caps)
+
+	daID := daRelayTestID(101)
+	mustAddDAChunk(t, h.service.daRelay, "peer-a", daRelayTestChunk(daID, 0, 7))
+	blockBytes := h.mineNextBlockBytes(t)
+	if err := h.service.AnnounceBlock(blockBytes); err != nil {
+		t.Fatalf("AnnounceBlock: %v", err)
+	}
+	if _, ok := h.service.daRelay.sets[daID]; ok {
+		t.Fatalf("DA set %x still present after local block announce TTL expiry", daID)
+	}
+	if got := h.service.daRelay.orphanBytes; got != 0 {
+		t.Fatalf("orphanBytes=%d, want 0 after local block announce TTL expiry", got)
+	}
+	if got := h.service.daRelay.orphanBytesForPeer("peer-a"); got != 0 {
+		t.Fatalf("orphanBytesForPeer(peer-a)=%d, want 0", got)
+	}
+	if got := h.service.daRelay.orphanBytesForDAID(daID); got != 0 {
 		t.Fatalf("orphanBytesForDAID=%d, want 0", got)
 	}
 }


### PR DESCRIPTION
Invariant:
Incomplete DA relay records expire atomically by TTL without leaving orphan, commit, per-peer, per-da_id, or pinned payload accounting behind.

Layer:
Go P2P implementation and tests.

Files changed:
- Go DA relay state
- Go P2P accepted-block bookkeeping
- Focused Go P2P tests

Tests:
- Targeted DA TTL expiry tests - PASS
- Accepted-block DA TTL integration test - PASS
- Focused DA/relay/TTL test slice - PASS
- Focused compact relay regression slice - PASS
- Go P2P package tests - PASS
- Whitespace/diff check - PASS

Behavior impact:
Adds TTL cleanup for incomplete DA relay records and wires the TTL advance to the accepted-block path. Complete DA sets remain outside orphan TTL expiry. Projection errors do not delete or mutate the stored DA record.

Compatibility impact:
No wire format, consensus, Rust, conformance fixture, or spec change.

Known non-goals:
Disconnect cleanup, missing-chunk prefetch, miner/template inclusion, Rust parity, conformance/spec changes.

Risk:
Bounded to Go P2P DA relay in-memory cleanup and accepted-block bookkeeping.

Rollback:
Revert this PR.
