### PR TITLE
RUB-366: DA disconnect accounting cleanup

### DIFF
--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -288,6 +288,40 @@ func (s *daRelayState) advanceOrphanTTL() ([]daRelayExpiredSet, error) {
 	return expired, nil
 }
 
+func (s *daRelayState) releasePeerQuotaKey(key string) error {
+	if s == nil {
+		return nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.orphanBytesByPeerQuotaKey[key] == 0 {
+		return nil
+	}
+
+	for _, daID := range s.sortedIncompleteDAIDsLocked() {
+		record := s.sets[daID]
+		updated, changed, err := record.withoutPeerQuotaKey(key)
+		if err != nil {
+			return err
+		}
+		if !changed {
+			continue
+		}
+		if updated.emptyIncomplete() {
+			if err := s.removeDASetRecordLocked(record); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := s.applyDASetRecordLocked(updated); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (s *daRelayState) sortedIncompleteDAIDsLocked() [][32]byte {
 	var daIDs [][32]byte
 	for daID := range s.orphanBytesByDAID {
@@ -702,6 +736,60 @@ func (r *daRelaySetRecord) pruneChunksOutsideCommit() {
 			delete(r.replaceableChunks, index)
 		}
 	}
+}
+
+func (r daRelaySetRecord) withoutPeerQuotaKey(key string) (daRelaySetRecord, bool, error) {
+	if r.state == daRelayStateCompleteSet || r.wireBytes == 0 {
+		return r, false, nil
+	}
+
+	out := r.cloneForStateMutation()
+	changed := out.dropCommitForPeerQuotaKey(key)
+	if out.dropChunksForPeerQuotaKey(key) {
+		changed = true
+	}
+	if !changed {
+		return r, false, nil
+	}
+	out.payloadBytes = 0
+	if out.commit.chunkCount == 0 {
+		out.state = daRelayStateOrphanChunks
+		out.replaceableChunks = nil
+	}
+	if out.emptyIncomplete() {
+		out.wireBytes = 0
+		return out, true, nil
+	}
+	if err := out.recomputeOrphanTotals(); err != nil {
+		return daRelaySetRecord{}, false, err
+	}
+	return out, true, nil
+}
+
+func (r *daRelaySetRecord) dropCommitForPeerQuotaKey(key string) bool {
+	if r.commit.wireBytes == 0 || r.commit.peerQuotaKey != key {
+		return false
+	}
+	r.commit = daRelayCommit{}
+	r.replaceableChunks = nil
+	return true
+}
+
+func (r *daRelaySetRecord) dropChunksForPeerQuotaKey(key string) bool {
+	changed := false
+	for index, chunk := range r.chunks {
+		if chunk.wireBytes == 0 || chunk.peerQuotaKey != key {
+			continue
+		}
+		delete(r.chunks, index)
+		delete(r.replaceableChunks, index)
+		changed = true
+	}
+	return changed
+}
+
+func (r daRelaySetRecord) emptyIncomplete() bool {
+	return r.state != daRelayStateCompleteSet && r.commit.chunkCount == 0 && len(r.chunks) == 0
 }
 
 func (r daRelaySetRecord) validateChunkInsert(chunkIndex uint16) error {

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -165,6 +165,17 @@ func TestDARelayPeerQuotaKeyPreventsPortHopping(t *testing.T) {
 	})
 }
 
+func TestDARelayReleasePeerQuotaKeySkipsUnchargedPeer(t *testing.T) {
+	state := newDARelayStateForTest(t, defaultDARelayCaps())
+	record := mustAddDAChunk(t, state, "peer-a", daRelayTestChunk(daRelayTestID(112), 0, 7))
+	if err := state.releasePeerQuotaKey("peer-b"); err != nil {
+		t.Fatalf("release uncharged peer: %v", err)
+	}
+	if got := state.orphanBytesForPeer("peer-a"); got != record.wireBytes {
+		t.Fatalf("charged peer bytes after unrelated release = %d, want %d", got, record.wireBytes)
+	}
+}
+
 func TestDARelayEmptyPeerQuotaKeyIsCapped(t *testing.T) {
 	t.Run("chunk only", func(t *testing.T) {
 		caps := defaultDARelayCaps()

--- a/clients/go/node/p2p/service.go
+++ b/clients/go/node/p2p/service.go
@@ -46,8 +46,10 @@ type Service struct {
 	cancel   context.CancelFunc
 	listener net.Listener
 
-	peersMu sync.RWMutex
-	peers   map[string]*peer
+	peersMu          sync.RWMutex
+	peers            map[string]*peer
+	peerQuotaLocksMu sync.Mutex
+	peerQuotaLocks   map[string]*peerQuotaLock
 	// closed is set to true by Close. A Service instance is single-use: once
 	// Close has returned, Start refuses to restart the same Service and the
 	// accept/reconnect loops must not be revived. Guarded by peersMu.
@@ -99,6 +101,11 @@ type Service struct {
 	peerLifecycleExits atomic.Uint64
 }
 
+type peerQuotaLock struct {
+	mu   sync.Mutex
+	refs int
+}
+
 type peer struct {
 	conn    net.Conn
 	service *Service
@@ -127,6 +134,7 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 	return &Service{
 		cfg:            cfg,
 		peers:          make(map[string]*peer),
+		peerQuotaLocks: make(map[string]*peerQuotaLock),
 		inFlightDial:   make(map[string]struct{}),
 		reconnectState: make(map[string]*reconnectEntry),
 		outboundAddrs:  outboundAddrs,

--- a/clients/go/node/p2p/service_peer_lifecycle.go
+++ b/clients/go/node/p2p/service_peer_lifecycle.go
@@ -100,9 +100,12 @@ func (s *Service) unregisterPeer(p *peer) {
 	}
 	addr := p.addr()
 	quotaKey := peerQuotaKey(addr)
+	unlockQuota := s.lockPeerQuotaKey(quotaKey)
+	defer unlockQuota()
 	remove := s.removePeerEntries(p)
 	if remove {
-		if err := s.releaseDAQuotaIfInactive(quotaKey); err != nil {
+		s.cfg.PeerManager.RemovePeer(addr)
+		if err := s.releaseDAQuotaIfInactiveLocked(quotaKey); err != nil {
 			p.setLastError(err.Error())
 		}
 	}
@@ -115,7 +118,6 @@ func (s *Service) unregisterPeer(p *peer) {
 		// safe to call without peersMu (the lock has been released
 		// above) because the counter is independent of peer-map state.
 		s.peerLifecycleExits.Add(1)
-		s.cfg.PeerManager.RemovePeer(addr)
 	}
 	if remove && s.isOutboundAddr(addr) {
 		s.scheduleReconnect(addr)
@@ -136,11 +138,15 @@ func (s *Service) removePeerEntries(p *peer) bool {
 }
 
 func (s *Service) releaseDAQuotaIfInactive(quotaKey string) error {
+	unlockQuota := s.lockPeerQuotaKey(quotaKey)
+	defer unlockQuota()
+	return s.releaseDAQuotaIfInactiveLocked(quotaKey)
+}
+
+func (s *Service) releaseDAQuotaIfInactiveLocked(quotaKey string) error {
 	if s.daRelay == nil {
 		return nil
 	}
-	unlockQuota := s.lockPeerQuotaKey(quotaKey)
-	defer unlockQuota()
 	s.peersMu.RLock()
 	active := s.hasActivePeerQuotaKeyLocked(quotaKey)
 	s.peersMu.RUnlock()
@@ -152,6 +158,9 @@ func (s *Service) releaseDAQuotaIfInactive(quotaKey string) error {
 
 func (s *Service) lockPeerQuotaKey(quotaKey string) func() {
 	s.peerQuotaLocksMu.Lock()
+	if s.peerQuotaLocks == nil {
+		s.peerQuotaLocks = make(map[string]*peerQuotaLock)
+	}
 	quotaLock := s.peerQuotaLocks[quotaKey]
 	if quotaLock == nil {
 		quotaLock = &peerQuotaLock{}

--- a/clients/go/node/p2p/service_peer_lifecycle.go
+++ b/clients/go/node/p2p/service_peer_lifecycle.go
@@ -77,6 +77,8 @@ func (s *Service) sendPostHandshakeAnnouncements(current *peer) error {
 }
 
 func (s *Service) registerPeer(p *peer) error {
+	unlockQuota := s.lockPeerQuotaKey(peerQuotaKey(p.addr()))
+	defer unlockQuota()
 	if err := s.cfg.PeerManager.AddPeer(&p.state); err != nil {
 		return err
 	}
@@ -97,16 +99,13 @@ func (s *Service) unregisterPeer(p *peer) {
 		return
 	}
 	addr := p.addr()
-	remove := false
-	s.peersMu.Lock()
-	for key, current := range s.peers {
-		if current != p {
-			continue
+	quotaKey := peerQuotaKey(addr)
+	remove := s.removePeerEntries(p)
+	if remove {
+		if err := s.releaseDAQuotaIfInactive(quotaKey); err != nil {
+			p.setLastError(err.Error())
 		}
-		delete(s.peers, key)
-		remove = true
 	}
-	s.peersMu.Unlock()
 	if remove {
 		// Lifecycle-exit counter increments here, exactly once per
 		// unregisterPeer call that actually deleted peer entries from
@@ -121,6 +120,65 @@ func (s *Service) unregisterPeer(p *peer) {
 	if remove && s.isOutboundAddr(addr) {
 		s.scheduleReconnect(addr)
 	}
+}
+
+func (s *Service) removePeerEntries(p *peer) bool {
+	s.peersMu.Lock()
+	defer s.peersMu.Unlock()
+	remove := false
+	for key, current := range s.peers {
+		if current == p {
+			delete(s.peers, key)
+			remove = true
+		}
+	}
+	return remove
+}
+
+func (s *Service) releaseDAQuotaIfInactive(quotaKey string) error {
+	if s.daRelay == nil {
+		return nil
+	}
+	unlockQuota := s.lockPeerQuotaKey(quotaKey)
+	defer unlockQuota()
+	s.peersMu.RLock()
+	active := s.hasActivePeerQuotaKeyLocked(quotaKey)
+	s.peersMu.RUnlock()
+	if active {
+		return nil
+	}
+	return s.daRelay.releasePeerQuotaKey(quotaKey)
+}
+
+func (s *Service) lockPeerQuotaKey(quotaKey string) func() {
+	s.peerQuotaLocksMu.Lock()
+	quotaLock := s.peerQuotaLocks[quotaKey]
+	if quotaLock == nil {
+		quotaLock = &peerQuotaLock{}
+		s.peerQuotaLocks[quotaKey] = quotaLock
+	}
+	quotaLock.refs++
+	s.peerQuotaLocksMu.Unlock()
+
+	quotaLock.mu.Lock()
+	return func() {
+		quotaLock.mu.Unlock()
+		s.peerQuotaLocksMu.Lock()
+		quotaLock.refs--
+		if quotaLock.refs == 0 {
+			delete(s.peerQuotaLocks, quotaKey)
+		}
+		s.peerQuotaLocksMu.Unlock()
+	}
+}
+
+func (s *Service) hasActivePeerQuotaKeyLocked(quotaKey string) bool {
+	for _, current := range s.peers {
+		if current != nil && peerQuotaKey(current.addr()) == quotaKey {
+			return true
+		}
+	}
+	return false
 }
 
 // PeerLifecycleExits returns the monotonic count of peer lifecycle

--- a/clients/go/node/p2p/service_test.go
+++ b/clients/go/node/p2p/service_test.go
@@ -484,6 +484,74 @@ func TestUnregisterPeerKeepsDAAccountingForActiveQuotaKey(t *testing.T) {
 	}
 }
 
+func TestUnregisterPeerHoldsQuotaLockThroughPeerManagerRemoval(t *testing.T) {
+	h := newTestHarness(t, 0, "127.0.0.1:0", nil)
+	runtimeCfg := node.DefaultPeerRuntimeConfig("devnet", 1)
+	h.peerManager = node.NewPeerManager(runtimeCfg)
+	h.service.cfg.PeerManager = h.peerManager
+	h.service.cfg.PeerRuntimeConfig = runtimeCfg
+	h.service.daRelay = newDARelayStateForTest(t, defaultDARelayCaps())
+	daID := daRelayTestID(112)
+	oldPeer := &peer{service: h.service, state: node.PeerState{Addr: "127.0.0.1:19111"}}
+	newPeer := &peer{service: h.service, state: node.PeerState{Addr: "127.0.0.1:19112"}}
+	if err := h.service.registerPeer(oldPeer); err != nil {
+		t.Fatalf("register old peer: %v", err)
+	}
+	mustAddDAChunk(t, h.service.daRelay, oldPeer.addr(), daRelayTestChunk(daID, 0, 9))
+
+	h.service.daRelay.mu.Lock()
+	unregistered := make(chan struct{})
+	go func() {
+		h.service.unregisterPeer(oldPeer)
+		close(unregistered)
+	}()
+	waitFor(t, time.Second, func() bool {
+		return h.service.cfg.PeerManager.Count() == 0
+	})
+
+	registered := make(chan error, 1)
+	go func() { registered <- h.service.registerPeer(newPeer) }()
+	select {
+	case err := <-registered:
+		h.service.daRelay.mu.Unlock()
+		t.Fatalf("register new peer completed while unregister held DA relay lock: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	h.service.daRelay.mu.Unlock()
+	<-unregistered
+	if err := <-registered; err != nil {
+		t.Fatalf("register new peer: %v", err)
+	}
+	if got := h.service.cfg.PeerManager.Count(); got != 1 {
+		t.Fatalf("peer manager count after replacement register = %d, want 1", got)
+	}
+}
+
+func TestLockPeerQuotaKeyInitializesNilMap(t *testing.T) {
+	s := &Service{}
+	unlock := s.lockPeerQuotaKey("127.0.0.1")
+	unlock()
+	if s.peerQuotaLocks == nil {
+		t.Fatalf("peer quota locks map was not initialized")
+	}
+	if got := len(s.peerQuotaLocks); got != 0 {
+		t.Fatalf("peer quota locks after unlock = %d, want 0", got)
+	}
+}
+
+func TestReleaseDAQuotaIfInactiveHandlesNilRelay(t *testing.T) {
+	s := &Service{}
+	if err := s.releaseDAQuotaIfInactive("127.0.0.1"); err != nil {
+		t.Fatalf("release DA quota with nil relay: %v", err)
+	}
+	if s.peerQuotaLocks == nil {
+		t.Fatalf("peer quota locks map was not initialized")
+	}
+	if got := len(s.peerQuotaLocks); got != 0 {
+		t.Fatalf("peer quota locks after release = %d, want 0", got)
+	}
+}
+
 func TestHandleBlockRequestsMoreBlocksAfterAccept(t *testing.T) {
 	sink := newTestHarness(t, 0, "127.0.0.1:0", nil)
 	peer := &peer{

--- a/clients/go/node/p2p/service_test.go
+++ b/clients/go/node/p2p/service_test.go
@@ -371,6 +371,119 @@ func TestAnnounceBlockAdvancesDARelayTTL(t *testing.T) {
 	}
 }
 
+func TestUnregisterPeerReleasesDAChunkPeerAccountingAndDropsOwnedChunk(t *testing.T) {
+	h := newTestHarness(t, 0, "127.0.0.1:0", nil)
+	caps := defaultDARelayCaps()
+	caps.orphanPoolPerPeerBytes = 10
+	h.service.daRelay = newDARelayStateForTest(t, caps)
+	daID := daRelayTestID(106)
+	completeID := daRelayTestID(111)
+	payload := []byte("complete-payload")
+	mustAddDAChunk(t, h.service.daRelay, "127.0.0.1:19111", daRelayTestChunk(daID, 0, 7))
+	mustAddDACommit(t, h.service.daRelay, "127.0.0.1:19111", daRelayTestCommitForPayloads(completeID, 3, payload))
+	complete := mustAddDAChunk(t, h.service.daRelay, "127.0.0.1:19111", daRelayTestChunkPayload(completeID, 0, uint64(len(payload)), payload))
+	if complete.state != daRelayStateCompleteSet || h.service.daRelay.pinnedPayloadBytes == 0 {
+		t.Fatalf("setup complete state=%v pinned=%d", complete.state, h.service.daRelay.pinnedPayloadBytes)
+	}
+	wantPinned := h.service.daRelay.pinnedPayloadBytes
+	peer := &peer{service: h.service, state: node.PeerState{Addr: "127.0.0.1:19111"}}
+	if err := h.service.registerPeer(peer); err != nil {
+		t.Fatalf("register peer: %v", err)
+	}
+
+	h.service.unregisterPeer(peer)
+	if got := h.service.daRelay.orphanBytesForPeer("127.0.0.1:19111"); got != 0 {
+		t.Fatalf("peer orphan bytes after unregister = %d, want 0", got)
+	}
+	if got := h.service.daRelay.orphanBytes; got != 0 {
+		t.Fatalf("global orphan bytes after unregister = %d, want 0", got)
+	}
+	if got := h.service.daRelay.orphanBytesForDAID(daID); got != 0 {
+		t.Fatalf("da_id orphan bytes after unregister = %d, want 0", got)
+	}
+	if _, ok := h.service.daRelay.sets[daID]; ok {
+		t.Fatalf("DA record %x retained after owner disconnect", daID)
+	}
+	if got := h.service.daRelay.sets[completeID]; got.state != daRelayStateCompleteSet || h.service.daRelay.pinnedPayloadBytes != wantPinned {
+		t.Fatalf("complete set after unregister state=%v pinned=%d want %d", got.state, h.service.daRelay.pinnedPayloadBytes, wantPinned)
+	}
+}
+
+func TestUnregisterPeerReleasesDACommitPeerAccountingAndPreservesOtherChunks(t *testing.T) {
+	h := newTestHarness(t, 0, "127.0.0.1:0", nil)
+	caps := defaultDARelayCaps()
+	caps.orphanPoolPerPeerBytes = 10
+	h.service.daRelay = newDARelayStateForTest(t, caps)
+	daID := daRelayTestID(109)
+	otherChunk := mustAddDAChunk(t, h.service.daRelay, "127.0.0.2:19112", daRelayTestChunk(daID, 0, 3))
+	mustAddDACommit(t, h.service.daRelay, "127.0.0.1:19111", daRelayTestCommit(daID, 2, 7))
+	peer := &peer{service: h.service, state: node.PeerState{Addr: "127.0.0.1:19111"}}
+	if err := h.service.registerPeer(peer); err != nil {
+		t.Fatalf("register peer: %v", err)
+	}
+
+	h.service.unregisterPeer(peer)
+	if got := h.service.daRelay.orphanBytesForPeer("127.0.0.1:19111"); got != 0 {
+		t.Fatalf("peer orphan bytes after unregister = %d, want 0", got)
+	}
+	if got := h.service.daRelay.orphanBytesForPeer("127.0.0.2:19112"); got != otherChunk.wireBytes {
+		t.Fatalf("other peer orphan bytes after unregister = %d, want %d", got, otherChunk.wireBytes)
+	}
+	if got := h.service.daRelay.orphanBytes; got != otherChunk.wireBytes {
+		t.Fatalf("global orphan bytes after unregister = %d, want %d", got, otherChunk.wireBytes)
+	}
+	if got := h.service.daRelay.orphanBytesForDAID(daID); got != otherChunk.wireBytes {
+		t.Fatalf("da_id orphan bytes after unregister = %d, want %d", got, otherChunk.wireBytes)
+	}
+	if got := h.service.daRelay.orphanCommitOverheadBytes; got != 0 {
+		t.Fatalf("commit overhead after unregister = %d, want 0", got)
+	}
+	gotRecord := h.service.daRelay.sets[daID]
+	if gotRecord.state != daRelayStateOrphanChunks || gotRecord.commit.chunkCount != 0 || len(gotRecord.chunks) != 1 {
+		t.Fatalf("record after unregister state=%v commit_count=%d chunks=%d", gotRecord.state, gotRecord.commit.chunkCount, len(gotRecord.chunks))
+	}
+	if _, ok := gotRecord.chunks[0]; !ok {
+		t.Fatalf("other peer chunk missing after unregister")
+	}
+}
+
+func TestUnregisterPeerKeepsDAAccountingForActiveQuotaKey(t *testing.T) {
+	h := newTestHarness(t, 0, "127.0.0.1:0", nil)
+	h.service.daRelay = newDARelayStateForTest(t, defaultDARelayCaps())
+	daID := daRelayTestID(107)
+	record := mustAddDAChunk(t, h.service.daRelay, "127.0.0.1:19112", daRelayTestChunk(daID, 0, 9))
+	oldPeer := &peer{service: h.service, state: node.PeerState{Addr: "127.0.0.1:19111"}}
+	newPeer := &peer{service: h.service, state: node.PeerState{Addr: "127.0.0.1:19112"}}
+	if err := h.service.registerPeer(oldPeer); err != nil {
+		t.Fatalf("register old peer: %v", err)
+	}
+	unlockQuota := h.service.lockPeerQuotaKey(peerQuotaKey(newPeer.addr()))
+	registered := make(chan error, 1)
+	go func() { registered <- h.service.registerPeer(newPeer) }()
+	select {
+	case err := <-registered:
+		unlockQuota()
+		t.Fatalf("register new peer completed while quota locked: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	if got := h.service.cfg.PeerManager.Count(); got != 1 {
+		unlockQuota()
+		t.Fatalf("peer manager count while quota locked = %d, want 1", got)
+	}
+	unlockQuota()
+	if err := <-registered; err != nil {
+		t.Fatalf("register new peer: %v", err)
+	}
+
+	h.service.unregisterPeer(oldPeer)
+	if got := h.service.daRelay.orphanBytesForPeer("127.0.0.1:19112"); got != record.wireBytes {
+		t.Fatalf("active quota key orphan bytes = %d, want %d", got, record.wireBytes)
+	}
+	if got := h.service.peers["127.0.0.1:19112"]; got != newPeer {
+		t.Fatalf("active peer was not retained")
+	}
+}
+
 func TestHandleBlockRequestsMoreBlocksAfterAccept(t *testing.T) {
 	sink := newTestHarness(t, 0, "127.0.0.1:0", nil)
 	peer := &peer{

--- a/clients/go/node/p2p/service_test.go
+++ b/clients/go/node/p2p/service_test.go
@@ -460,11 +460,12 @@ func TestUnregisterPeerKeepsDAAccountingForActiveQuotaKey(t *testing.T) {
 	unlockQuota := h.service.lockPeerQuotaKey(peerQuotaKey(newPeer.addr()))
 	registered := make(chan error, 1)
 	go func() { registered <- h.service.registerPeer(newPeer) }()
+	waitForPeerQuotaLockRefs(t, h.service, peerQuotaKey(newPeer.addr()), 2)
 	select {
 	case err := <-registered:
 		unlockQuota()
 		t.Fatalf("register new peer completed while quota locked: %v", err)
-	case <-time.After(50 * time.Millisecond):
+	default:
 	}
 	if got := h.service.cfg.PeerManager.Count(); got != 1 {
 		unlockQuota()
@@ -481,6 +482,75 @@ func TestUnregisterPeerKeepsDAAccountingForActiveQuotaKey(t *testing.T) {
 	}
 	if got := h.service.peers["127.0.0.1:19112"]; got != newPeer {
 		t.Fatalf("active peer was not retained")
+	}
+}
+
+func TestUnregisterPeerHoldsQuotaLockThroughPeerManagerRemoval(t *testing.T) {
+	h := newTestHarness(t, 0, "127.0.0.1:0", nil)
+	runtimeCfg := node.DefaultPeerRuntimeConfig("devnet", 1)
+	h.peerManager = node.NewPeerManager(runtimeCfg)
+	h.service.cfg.PeerManager = h.peerManager
+	h.service.cfg.PeerRuntimeConfig = runtimeCfg
+	h.service.daRelay = newDARelayStateForTest(t, defaultDARelayCaps())
+	daID := daRelayTestID(112)
+	oldPeer := &peer{service: h.service, state: node.PeerState{Addr: "127.0.0.1:19111"}}
+	newPeer := &peer{service: h.service, state: node.PeerState{Addr: "127.0.0.1:19112"}}
+	if err := h.service.registerPeer(oldPeer); err != nil {
+		t.Fatalf("register old peer: %v", err)
+	}
+	mustAddDAChunk(t, h.service.daRelay, oldPeer.addr(), daRelayTestChunk(daID, 0, 9))
+
+	h.service.daRelay.mu.Lock()
+	unregistered := make(chan struct{})
+	go func() {
+		h.service.unregisterPeer(oldPeer)
+		close(unregistered)
+	}()
+	waitFor(t, time.Second, func() bool {
+		return h.service.cfg.PeerManager.Count() == 0
+	})
+
+	registered := make(chan error, 1)
+	go func() { registered <- h.service.registerPeer(newPeer) }()
+	waitForPeerQuotaLockRefs(t, h.service, peerQuotaKey(newPeer.addr()), 2)
+	select {
+	case err := <-registered:
+		h.service.daRelay.mu.Unlock()
+		t.Fatalf("register new peer completed while unregister held DA relay lock: %v", err)
+	default:
+	}
+	h.service.daRelay.mu.Unlock()
+	<-unregistered
+	if err := <-registered; err != nil {
+		t.Fatalf("register new peer: %v", err)
+	}
+	if got := h.service.cfg.PeerManager.Count(); got != 1 {
+		t.Fatalf("peer manager count after replacement register = %d, want 1", got)
+	}
+}
+
+func TestLockPeerQuotaKeyInitializesNilMap(t *testing.T) {
+	s := &Service{}
+	unlock := s.lockPeerQuotaKey("127.0.0.1")
+	unlock()
+	if s.peerQuotaLocks == nil {
+		t.Fatalf("peer quota locks map was not initialized")
+	}
+	if got := len(s.peerQuotaLocks); got != 0 {
+		t.Fatalf("peer quota locks after unlock = %d, want 0", got)
+	}
+}
+
+func TestReleaseDAQuotaIfInactiveHandlesNilRelay(t *testing.T) {
+	s := &Service{}
+	if err := s.releaseDAQuotaIfInactive("127.0.0.1"); err != nil {
+		t.Fatalf("release DA quota with nil relay: %v", err)
+	}
+	if s.peerQuotaLocks == nil {
+		t.Fatalf("peer quota locks map was not initialized")
+	}
+	if got := len(s.peerQuotaLocks); got != 0 {
+		t.Fatalf("peer quota locks after release = %d, want 0", got)
 	}
 }
 
@@ -1141,6 +1211,16 @@ func waitFor(t *testing.T, timeout time.Duration, predicate func() bool) {
 		time.Sleep(25 * time.Millisecond)
 	}
 	t.Fatalf("condition not met within %s", timeout)
+}
+
+func waitForPeerQuotaLockRefs(t *testing.T, s *Service, quotaKey string, want int) {
+	t.Helper()
+	waitFor(t, time.Second, func() bool {
+		s.peerQuotaLocksMu.Lock()
+		defer s.peerQuotaLocksMu.Unlock()
+		quotaLock := s.peerQuotaLocks[quotaKey]
+		return quotaLock != nil && quotaLock.refs == want
+	})
 }
 
 func TestRetainOrResolveOrphanClearsSeenForEvictedOrphan(t *testing.T) {


### PR DESCRIPTION
Refs RUB-366.
Closes #1810.

Invariant:
Peer disconnect cleanup releases or reattributes DA per-peer orphan accounting without deleting valid DA state owned by other peers or complete DA sets.

Layer:
Go P2P implementation and tests.

Files changed:
- clients/go/node/p2p/da_relay_state.go
- clients/go/node/p2p/service.go
- clients/go/node/p2p/service_peer_lifecycle.go
- clients/go/node/p2p/da_relay_state_test.go
- clients/go/node/p2p/service_test.go

Tests:
- go test ./node/p2p -run "TestUnregisterPeerKeepsDAAccountingForActiveQuotaKey|TestDARelayReleasePeerQuotaKeySkipsUnchargedPeer|TestUnregisterPeer|DA|Da|Relay|Disconnect|Lifecycle|Cleanup" -count=1 — PASS
- go test ./node/p2p -count=1 — PASS
- git diff --check — PASS
- gofumpt -l clients/go/node/p2p/service_test.go — PASS

Behavior impact:
Disconnecting an inactive peer now drops that peer's incomplete DA commit/chunk contributions, preserves active same-quota peer accounting, and preserves complete DA payloads.

Compatibility impact:
No wire format, consensus, Rust parity, or conformance fixture changes.

Known non-goals:
TTL expiry, duplicate commit handling, missing-chunk prefetch, miner/template inclusion, Rust parity, conformance fixtures, DA wire format.
