### PR TITLE
p2p: ingest DA relay transactions into state

### DIFF
--- a/clients/go/node/p2p/da_relay_ingest.go
+++ b/clients/go/node/p2p/da_relay_ingest.go
@@ -1,0 +1,65 @@
+package p2p
+
+import "github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+
+func (s *Service) stageRelayDATx(peerAddr string, txBytes []byte, tx *consensus.Tx) error {
+	if s == nil || s.daRelay == nil || tx == nil {
+		return nil
+	}
+	wireBytes := uint64(len(txBytes))
+	switch tx.TxKind {
+	case 0x01:
+		return s.stageRelayDACommitTx(peerAddr, wireBytes, tx)
+	case 0x02:
+		return s.stageRelayDAChunkTx(peerAddr, wireBytes, tx)
+	default:
+		return nil
+	}
+}
+
+func (s *Service) stageRelayDACommitTx(peerAddr string, wireBytes uint64, tx *consensus.Tx) error {
+	if tx.DaCommitCore == nil {
+		return nil
+	}
+	commitment, ok := daRelayCommitPayloadCommitment(tx)
+	if !ok {
+		return nil
+	}
+	_, err := s.daRelay.addDACommit(peerAddr, daRelayCommit{
+		daID:              tx.DaCommitCore.DaID,
+		payloadCommitment: commitment,
+		chunkCount:        tx.DaCommitCore.ChunkCount,
+		wireBytes:         wireBytes,
+	})
+	return err
+}
+
+func (s *Service) stageRelayDAChunkTx(peerAddr string, wireBytes uint64, tx *consensus.Tx) error {
+	if tx.DaChunkCore == nil {
+		return nil
+	}
+	_, err := s.daRelay.addDAChunk(peerAddr, daRelayChunk{
+		daID:       tx.DaChunkCore.DaID,
+		chunkHash:  tx.DaChunkCore.ChunkHash,
+		chunkIndex: tx.DaChunkCore.ChunkIndex,
+		payload:    tx.DaPayload,
+		wireBytes:  wireBytes,
+	})
+	return err
+}
+
+func daRelayCommitPayloadCommitment(tx *consensus.Tx) ([32]byte, bool) {
+	var commitment [32]byte
+	count := 0
+	for _, output := range tx.Outputs {
+		if output.CovenantType != consensus.COV_TYPE_DA_COMMIT {
+			continue
+		}
+		if len(output.CovenantData) != len(commitment) {
+			return [32]byte{}, false
+		}
+		count++
+		copy(commitment[:], output.CovenantData)
+	}
+	return commitment, count == 1
+}

--- a/clients/go/node/p2p/handlers_tx.go
+++ b/clients/go/node/p2p/handlers_tx.go
@@ -22,7 +22,7 @@ func (p *peer) handleTx(txBytes []byte) error {
 		}
 		return nil
 	}
-	txid, err := canonicalTxID(txBytes)
+	tx, txid, err := parseCanonicalTx(txBytes)
 	if err != nil {
 		if p.bumpBan(10, err.Error()) {
 			return err
@@ -45,17 +45,23 @@ func (p *peer) handleTx(txBytes []byte) error {
 	if !p.service.cfg.TxPool.Put(txid, txBytes, meta.Fee, meta.Size) {
 		return nil
 	}
+	_ = p.service.stageRelayDATx(p.addr(), txBytes, tx)
 	_ = p.service.broadcastInventory(p, []InventoryVector{{Type: MSG_TX, Hash: txid}})
 	return nil
 }
 
 func canonicalTxID(txBytes []byte) ([32]byte, error) {
-	_, txid, _, consumed, err := consensus.ParseTx(txBytes)
+	_, txid, err := parseCanonicalTx(txBytes)
+	return txid, err
+}
+
+func parseCanonicalTx(txBytes []byte) (*consensus.Tx, [32]byte, error) {
+	tx, txid, _, consumed, err := consensus.ParseTx(txBytes)
 	if err != nil {
-		return [32]byte{}, err
+		return nil, [32]byte{}, err
 	}
 	if consumed != len(txBytes) {
-		return [32]byte{}, errors.New("non-canonical tx bytes")
+		return nil, [32]byte{}, errors.New("non-canonical tx bytes")
 	}
-	return txid, nil
+	return tx, txid, nil
 }

--- a/clients/go/node/p2p/handlers_tx_test.go
+++ b/clients/go/node/p2p/handlers_tx_test.go
@@ -2,6 +2,7 @@ package p2p
 
 import (
 	"context"
+	"crypto/sha3"
 	"errors"
 	"io/fs"
 	"os"
@@ -45,6 +46,69 @@ func distinctTxBytes(t *testing.T, nonce uint64) []byte {
 		t.Fatalf("MarshalTx nonce=%d: %v", nonce, err)
 	}
 	return raw
+}
+
+func daCommitRelayTxBytes(t *testing.T, daID [32]byte, nonce uint64, payloads ...[]byte) []byte {
+	t.Helper()
+	if len(payloads) == 0 {
+		t.Fatal("DA commit test tx requires at least one payload")
+	}
+	commitment := daRelayPayloadCommitment(payloads...)
+	tx := &consensus.Tx{
+		Version: 1,
+		TxKind:  0x01,
+		TxNonce: nonce,
+		Outputs: []consensus.TxOutput{{
+			Value:        0,
+			CovenantType: consensus.COV_TYPE_DA_COMMIT,
+			CovenantData: append([]byte(nil), commitment[:]...),
+		}},
+		DaCommitCore: &consensus.DaCommitCore{
+			DaID:       daID,
+			ChunkCount: uint16(len(payloads)),
+		},
+	}
+	raw, err := consensus.MarshalTx(tx)
+	if err != nil {
+		t.Fatalf("MarshalTx DA commit: %v", err)
+	}
+	return raw
+}
+
+func daChunkRelayTxBytes(t *testing.T, daID [32]byte, index uint16, nonce uint64, payload []byte) []byte {
+	t.Helper()
+	chunkHash := sha3.Sum256(payload)
+	tx := &consensus.Tx{
+		Version: 1,
+		TxKind:  0x02,
+		TxNonce: nonce,
+		DaChunkCore: &consensus.DaChunkCore{
+			DaID:       daID,
+			ChunkIndex: index,
+			ChunkHash:  chunkHash,
+		},
+		DaPayload: cloneBytes(payload),
+	}
+	raw, err := consensus.MarshalTx(tx)
+	if err != nil {
+		t.Fatalf("MarshalTx DA chunk: %v", err)
+	}
+	return raw
+}
+
+func daRelayRecordSnapshot(t *testing.T, state *daRelayState, daID [32]byte) (daRelaySetRecord, bool) {
+	t.Helper()
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	record, ok := state.sets[daID]
+	return record.clone(), ok
+}
+
+func daRelayTestPeer(h *testHarness, addr string) *peer {
+	return &peer{
+		service: h.service,
+		state:   node.PeerState{Addr: addr, HandshakeComplete: true},
+	}
 }
 
 func putRelayTx(pool *MemoryTxPool, txid [32]byte, raw []byte) bool {
@@ -202,6 +266,89 @@ func TestHandleTxValid(t *testing.T) {
 	}
 }
 
+func TestHandleTxStagesDATxsIntoRelayState(t *testing.T) {
+	h := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	p := daRelayTestPeer(h, "127.0.0.1:19111")
+	daID := daRelayTestID(120)
+	payload := []byte("relay-da-payload")
+	commitTx := daCommitRelayTxBytes(t, daID, 9101, payload)
+	chunkTx := daChunkRelayTxBytes(t, daID, 0, 9102, payload)
+
+	if err := p.handleTx(commitTx); err != nil {
+		t.Fatalf("handleTx DA commit: %v", err)
+	}
+	record, ok := daRelayRecordSnapshot(t, h.service.daRelay, daID)
+	if !ok {
+		t.Fatal("DA commit tx did not create a relay state record")
+	}
+	if record.state != daRelayStateStagedCommit || record.commit.chunkCount != 1 {
+		t.Fatalf("DA commit relay state=%v chunk_count=%d, want staged/1", record.state, record.commit.chunkCount)
+	}
+	if record.commit.payloadCommitment != daRelayPayloadCommitment(payload) {
+		t.Fatal("DA commit relay state stored wrong payload commitment")
+	}
+
+	if err := p.handleTx(chunkTx); err != nil {
+		t.Fatalf("handleTx DA chunk: %v", err)
+	}
+	record, ok = daRelayRecordSnapshot(t, h.service.daRelay, daID)
+	if !ok {
+		t.Fatal("DA chunk tx removed relay state record")
+	}
+	if record.state != daRelayStateCompleteSet {
+		t.Fatalf("DA relay state=%v, want complete set", record.state)
+	}
+	if record.payloadBytes != uint64(len(payload)) || h.service.daRelay.pinnedPayloadBytes == 0 {
+		t.Fatalf("DA complete accounting payload=%d pinned=%d", record.payloadBytes, h.service.daRelay.pinnedPayloadBytes)
+	}
+}
+
+func TestStageRelayDATxIgnoresIncompleteMetadata(t *testing.T) {
+	h := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	daID := daRelayTestID(123)
+	peerAddr := "127.0.0.1:19114"
+
+	var nilService *Service
+	if err := nilService.stageRelayDATx(peerAddr, nil, &consensus.Tx{}); err != nil {
+		t.Fatalf("nil service stageRelayDATx: %v", err)
+	}
+	if err := h.service.stageRelayDATx(peerAddr, nil, nil); err != nil {
+		t.Fatalf("nil tx stageRelayDATx: %v", err)
+	}
+	if err := h.service.stageRelayDATx(peerAddr, []byte{0x01}, &consensus.Tx{TxKind: 0x01}); err != nil {
+		t.Fatalf("DA commit without core: %v", err)
+	}
+	if err := h.service.stageRelayDATx(peerAddr, []byte{0x02}, &consensus.Tx{TxKind: 0x02}); err != nil {
+		t.Fatalf("DA chunk without core: %v", err)
+	}
+
+	wrongCovenant := &consensus.Tx{
+		TxKind: 0x01,
+		Outputs: []consensus.TxOutput{{
+			CovenantType: consensus.COV_TYPE_P2PK,
+		}},
+		DaCommitCore: &consensus.DaCommitCore{DaID: daID, ChunkCount: 1},
+	}
+	if err := h.service.stageRelayDATx(peerAddr, []byte{0x03}, wrongCovenant); err != nil {
+		t.Fatalf("DA commit without DA covenant output: %v", err)
+	}
+
+	badCommitment := &consensus.Tx{
+		TxKind: 0x01,
+		Outputs: []consensus.TxOutput{{
+			CovenantType: consensus.COV_TYPE_DA_COMMIT,
+			CovenantData: []byte{0x01},
+		}},
+		DaCommitCore: &consensus.DaCommitCore{DaID: daID, ChunkCount: 1},
+	}
+	if err := h.service.stageRelayDATx(peerAddr, []byte{0x04}, badCommitment); err != nil {
+		t.Fatalf("DA commit with short commitment: %v", err)
+	}
+	if _, ok := daRelayRecordSnapshot(t, h.service.daRelay, daID); ok {
+		t.Fatal("incomplete DA metadata mutated relay state")
+	}
+}
+
 func TestHandleTxNonCanonical(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -229,6 +376,32 @@ func TestHandleTxNonCanonical(t *testing.T) {
 	}
 	if p.state.BanScore == 0 {
 		t.Fatal("ban score should be > 0 after non-canonical tx")
+	}
+}
+
+func TestHandleTxDAAdmissionRejectsDoNotMutateRelayState(t *testing.T) {
+	h := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	p := daRelayTestPeer(h, "127.0.0.1:19112")
+	daID := daRelayTestID(121)
+	payload := []byte("relay-da-bad-payload")
+	nonCanonical := append(daCommitRelayTxBytes(t, daID, 9201, payload), 0x00)
+	if err := p.handleTx(nonCanonical); err != nil {
+		t.Fatalf("handleTx non-canonical DA commit: %v", err)
+	}
+	if _, ok := daRelayRecordSnapshot(t, h.service.daRelay, daID); ok {
+		t.Fatal("non-canonical DA commit mutated relay state")
+	}
+
+	badChunk := daChunkRelayTxBytes(t, daID, 0, 9202, payload)
+	badChunk[len(badChunk)-1] ^= 0xff
+	if err := p.handleTx(badChunk); err != nil {
+		t.Fatalf("handleTx DA chunk hash mismatch: %v", err)
+	}
+	if _, ok := daRelayRecordSnapshot(t, h.service.daRelay, daID); ok {
+		t.Fatal("DA chunk hash mismatch mutated relay state")
+	}
+	if p.snapshotState().BanScore != 10 {
+		t.Fatalf("ban score=%d, want only the non-canonical parse penalty", p.snapshotState().BanScore)
 	}
 }
 
@@ -277,6 +450,43 @@ func TestAnnounceTx(t *testing.T) {
 	waitFor(t, 5*time.Second, func() bool {
 		return sink.service.cfg.TxPool.Has(txid)
 	})
+}
+
+func TestAnnounceTxStagesDAOnceAcrossLocalAndInbound(t *testing.T) {
+	h := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	p := daRelayTestPeer(h, "127.0.0.1:19113")
+	daID := daRelayTestID(122)
+	payload := []byte("relay-da-local-payload")
+	commitTx := daCommitRelayTxBytes(t, daID, 9301, payload)
+	chunkTx := daChunkRelayTxBytes(t, daID, 0, 9302, payload)
+
+	if err := h.service.AnnounceTx(commitTx); err != nil {
+		t.Fatalf("AnnounceTx DA commit: %v", err)
+	}
+	if err := p.handleTx(commitTx); err != nil {
+		t.Fatalf("handleTx duplicate DA commit: %v", err)
+	}
+	record, ok := daRelayRecordSnapshot(t, h.service.daRelay, daID)
+	if !ok {
+		t.Fatal("local DA commit did not create relay state")
+	}
+	if record.state != daRelayStateStagedCommit || record.receivedTime != 1 {
+		t.Fatalf("after duplicate DA commit state=%v received_time=%d, want staged/1", record.state, record.receivedTime)
+	}
+
+	if err := h.service.AnnounceTx(chunkTx); err != nil {
+		t.Fatalf("AnnounceTx DA chunk: %v", err)
+	}
+	if err := p.handleTx(chunkTx); err != nil {
+		t.Fatalf("handleTx duplicate DA chunk: %v", err)
+	}
+	record, ok = daRelayRecordSnapshot(t, h.service.daRelay, daID)
+	if !ok {
+		t.Fatal("local DA chunk removed relay state")
+	}
+	if record.state != daRelayStateCompleteSet || record.receivedTime != 1 || h.service.daRelay.nextReceivedTime != 1 {
+		t.Fatalf("duplicate local/inbound DA relay state=%v received=%d next=%d, want complete/1/1", record.state, record.receivedTime, h.service.daRelay.nextReceivedTime)
+	}
 }
 
 func TestAnnounceTxRelaysIntoCanonicalMempoolAndMiner(t *testing.T) {
@@ -841,7 +1051,7 @@ func TestBlockBytesIOError(t *testing.T) {
 	if err := os.RemoveAll(blocksDir); err != nil {
 		t.Fatalf("RemoveAll: %v", err)
 	}
-	if err := os.WriteFile(blocksDir, []byte("not-a-dir"), 0644); err != nil {
+	if err := os.WriteFile(blocksDir, []byte("not-a-dir"), 0o644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
 

--- a/clients/go/node/p2p/service.go
+++ b/clients/go/node/p2p/service.go
@@ -240,28 +240,18 @@ func (s *Service) AnnounceTx(txBytes []byte) error {
 	if s == nil {
 		return errors.New("nil service")
 	}
-	txid, err := parseCanonicalTxID(txBytes)
+	tx, txid, err := parseCanonicalTx(txBytes)
 	if err != nil {
 		return err
 	}
 	if err := s.ensureRelayTxAdmitted(txid, txBytes); err != nil {
 		return err
 	}
+	_ = s.stageRelayDATx("", txBytes, tx)
 	if !s.txSeen.Add(txid) {
 		return nil
 	}
 	return s.broadcastInventory(nil, []InventoryVector{{Type: MSG_TX, Hash: txid}})
-}
-
-func parseCanonicalTxID(txBytes []byte) ([32]byte, error) {
-	_, txid, _, consumed, err := consensus.ParseTx(txBytes)
-	if err != nil {
-		return [32]byte{}, err
-	}
-	if consumed != len(txBytes) {
-		return [32]byte{}, errors.New("non-canonical tx bytes")
-	}
-	return txid, nil
 }
 
 func (s *Service) ensureRelayTxAdmitted(txid [32]byte, txBytes []byte) error {


### PR DESCRIPTION
Invariant:
Canonical inbound and local DA_COMMIT_TX / DA_CHUNK_TX transactions stage into the Go DA relay state exactly once after canonical relay admission.

Layer:
Go P2P implementation and tests.

Files changed:
- clients/go/node/p2p/da_relay_ingest.go
- clients/go/node/p2p/handlers_tx.go
- clients/go/node/p2p/service.go
- clients/go/node/p2p/handlers_tx_test.go

Tests:
- Targeted Go P2P DA ingest tests: PASS
- Go P2P DA/relay/tx regex gate: PASS
- Go P2P package tests and Go pre-push checks: PASS
- Stack-local Go coverage preflight: PASS
- Scope, complexity, duplication, and hygiene gates: PASS

Behavior impact:
DA commit/chunk transactions now update daRelayState after successful canonical relay admission. Rejected relay-state admission remains peer-neutral.

Compatibility impact:
No wire command, consensus, Rust, conformance, miner/template, or request-prefetch behavior is changed.

Known non-goals:
DA request-wire semantics, prefetch scheduling/rate caps, peer scoring, Rust parity, conformance fixtures, devnet scripts, and miner/template inclusion.

Follow-ups:
RUB-368 owns DA request-wire boundary. RUB-369 owns prefetch scheduling and caps.

Risk:
Low, scoped to Go P2P relay-state staging after existing relay admission.

Rollback:
Revert this commit.

Not checked:
Remote CI and bot review threads are pending after PR open.