### PR TITLE
RUB-368: define DA chunk request-wire boundary

### DIFF
--- a/clients/go/node/p2p/compact_runtime.go
+++ b/clients/go/node/p2p/compact_runtime.go
@@ -70,6 +70,11 @@ func parseSendCmpctRuntimePayload(payload []byte) (sendCmpctPayload, error) {
 	return out, nil
 }
 
+func (*peer) handleGetDAChunk(payload []byte) error {
+	_, err := decodeGetDAChunkPayload(payload)
+	return err
+}
+
 func (p *peer) setRemoteCompactMode(mode compactModeSnapshot) {
 	p.compactMu.Lock()
 	p.compact.remoteMode = mode

--- a/clients/go/node/p2p/compact_wire.go
+++ b/clients/go/node/p2p/compact_wire.go
@@ -8,17 +8,21 @@ import (
 )
 
 const (
-	messageSendCmpct                 = "sendcmpct"
-	messageCmpctBlock                = "cmpctblock"
-	messageGetBlockTxn               = "getblocktxn"
-	messageBlockTxn                  = "blocktxn"
-	compactRelayVersion       uint64 = 1
-	sendCmpctPayloadBytes            = 9
-	compactShortIDBytes              = 6
-	compactRelayIndexBytes           = 4
-	maxCompactRelayEntries           = maxInventoryVectors
-	maxCmpctBlockEntries             = consensus.MAX_BLOCK_BYTES
-	maxCompactRelayIndexValue        = consensus.MAX_BLOCK_BYTES - 1
+	messageSendCmpct                    = "sendcmpct"
+	messageCmpctBlock                   = "cmpctblock"
+	messageGetBlockTxn                  = "getblocktxn"
+	messageBlockTxn                     = "blocktxn"
+	messageGetDAChunk                   = "getdachunk"
+	compactRelayVersion          uint64 = 1
+	daChunkRequestVersion        uint64 = 1
+	sendCmpctPayloadBytes               = 9
+	compactShortIDBytes                 = 6
+	compactRelayIndexBytes              = 4
+	daChunkIndexBytes                   = 2
+	getDAChunkPayloadPrefixBytes        = 8 + 32
+	maxCompactRelayEntries              = maxInventoryVectors
+	maxCmpctBlockEntries                = consensus.MAX_BLOCK_BYTES
+	maxCompactRelayIndexValue           = consensus.MAX_BLOCK_BYTES - 1
 )
 
 type sendCmpctPayload struct {
@@ -29,6 +33,12 @@ type sendCmpctPayload struct {
 type getBlockTxnPayload struct {
 	BlockHash [32]byte
 	Indexes   []uint64
+}
+
+type getDAChunkPayload struct {
+	Version uint64
+	DAID    [32]byte
+	Indexes []uint16
 }
 
 type blockTxnPayload struct {
@@ -123,6 +133,96 @@ func decodeGetBlockTxnPayload(payload []byte) (getBlockTxnPayload, error) {
 	}
 	out.Indexes = indexes
 	return out, nil
+}
+
+func getDAChunkPayloadCap() uint32 {
+	return uint32(getDAChunkPayloadPrefixBytes + maxCompactSizeBytes + int(consensus.MAX_DA_CHUNK_COUNT)*daChunkIndexBytes)
+}
+
+func encodeGetDAChunkPayload(p getDAChunkPayload) ([]byte, error) {
+	if p.Version != daChunkRequestVersion {
+		return nil, errors.New("unsupported DA chunk request version")
+	}
+	if err := validateDAChunkRequestIndexCount(uint64(len(p.Indexes))); err != nil {
+		return nil, err
+	}
+	out := make([]byte, 0, getDAChunkPayloadCap())
+	out = consensus.AppendU64le(out, p.Version)
+	out = append(out, p.DAID[:]...)
+	out = consensus.AppendCompactSize(out, uint64(len(p.Indexes)))
+	var prev uint16
+	for i, idx := range p.Indexes {
+		if err := validateDAChunkRequestIndex(uint64(i), idx, prev); err != nil {
+			return nil, err
+		}
+		out = consensus.AppendU16le(out, idx)
+		prev = idx
+	}
+	return out, nil
+}
+
+func decodeGetDAChunkPayload(payload []byte) (getDAChunkPayload, error) {
+	var out getDAChunkPayload
+	if len(payload) < getDAChunkPayloadPrefixBytes {
+		return out, errors.New("getdachunk payload missing version or da_id")
+	}
+	out.Version = binary.LittleEndian.Uint64(payload[:8])
+	if out.Version != daChunkRequestVersion {
+		return getDAChunkPayload{}, errors.New("unsupported DA chunk request version")
+	}
+	copy(out.DAID[:], payload[8:getDAChunkPayloadPrefixBytes])
+	count, consumed, err := consensus.DecodeCompactSize(payload[getDAChunkPayloadPrefixBytes:])
+	if err != nil {
+		return getDAChunkPayload{}, err
+	}
+	if err := validateDAChunkRequestIndexCount(count); err != nil {
+		return getDAChunkPayload{}, err
+	}
+	offset := getDAChunkPayloadPrefixBytes + consumed
+	indexes, offset, err := decodeGetDAChunkIndexes(payload, offset, count)
+	if err != nil {
+		return getDAChunkPayload{}, err
+	}
+	if offset != len(payload) {
+		return getDAChunkPayload{}, errors.New("getdachunk payload has trailing bytes")
+	}
+	out.Indexes = indexes
+	return out, nil
+}
+
+func decodeGetDAChunkIndexes(payload []byte, offset int, count uint64) ([]uint16, int, error) {
+	indexes := make([]uint16, 0, int(count)) // #nosec G115 -- count is capped at MAX_DA_CHUNK_COUNT before this helper.
+	var prev uint16
+	for i := uint64(0); i < count; i++ {
+		if len(payload[offset:]) < daChunkIndexBytes {
+			return nil, 0, errors.New("getdachunk payload truncated index")
+		}
+		idx := binary.LittleEndian.Uint16(payload[offset:])
+		offset += daChunkIndexBytes
+		if err := validateDAChunkRequestIndex(i, idx, prev); err != nil {
+			return nil, 0, err
+		}
+		indexes = append(indexes, idx)
+		prev = idx
+	}
+	return indexes, offset, nil
+}
+
+func validateDAChunkRequestIndexCount(count uint64) error {
+	if count == 0 || count > consensus.MAX_DA_CHUNK_COUNT {
+		return errors.New("invalid DA chunk request index count")
+	}
+	return nil
+}
+
+func validateDAChunkRequestIndex(pos uint64, idx uint16, prev uint16) error {
+	if uint64(idx) >= consensus.MAX_DA_CHUNK_COUNT {
+		return errors.New("DA chunk request index out of range")
+	}
+	if pos > 0 && idx <= prev {
+		return errors.New("DA chunk request indexes not strictly increasing")
+	}
+	return nil
 }
 
 func encodeBlockTxnPayload(p blockTxnPayload) ([]byte, error) {

--- a/clients/go/node/p2p/compact_wire_test.go
+++ b/clients/go/node/p2p/compact_wire_test.go
@@ -10,12 +10,13 @@ import (
 
 func TestCompactWireCommandConstantsAndPayloadCaps(t *testing.T) {
 	liveCaps := postHandshakePayloadCap(defaultLocatorLimit, 512)
-	commands := []string{messageSendCmpct, messageGetBlockTxn, messageCmpctBlock, messageBlockTxn}
+	commands := []string{messageSendCmpct, messageGetBlockTxn, messageCmpctBlock, messageBlockTxn, messageGetDAChunk}
 	caps := []uint32{
 		sendCmpctPayloadBytes,
 		uint32(32 + maxCompactSizeBytes + maxCompactRelayEntries*compactRelayIndexBytes),
 		uint32(consensus.MAX_RELAY_MSG_BYTES),
 		uint32(consensus.MAX_BLOCK_BYTES + 32 + maxCompactSizeBytes + maxCompactRelayEntries*maxCompactSizeBytes),
+		getDAChunkPayloadCap(),
 	}
 	for i, command := range commands {
 		if _, err := encodeWireCommand(command); err != nil {
@@ -52,6 +53,34 @@ func TestGetBlockTxnPayloadCodec(t *testing.T) {
 	}
 	if got.BlockHash != want.BlockHash || !reflect.DeepEqual(got.Indexes, want.Indexes) {
 		t.Fatalf("getblocktxn roundtrip got=%+v want=%+v", got, want)
+	}
+}
+
+func TestGetDAChunkPayloadCodec(t *testing.T) {
+	want := getDAChunkPayload{
+		Version: daChunkRequestVersion,
+		DAID:    [32]byte{0xaa, 0xbb, 0xcc},
+		Indexes: []uint16{0, 2, uint16(consensus.MAX_DA_CHUNK_COUNT - 1)},
+	}
+	raw, err := encodeGetDAChunkPayload(want)
+	if err != nil {
+		t.Fatalf("encodeGetDAChunkPayload: %v", err)
+	}
+	wantWire := consensus.AppendU64le(nil, daChunkRequestVersion)
+	wantWire = append(wantWire, want.DAID[:]...)
+	wantWire = consensus.AppendCompactSize(wantWire, uint64(len(want.Indexes)))
+	for _, idx := range want.Indexes {
+		wantWire = consensus.AppendU16le(wantWire, idx)
+	}
+	if !reflect.DeepEqual(raw, wantWire) {
+		t.Fatalf("getdachunk wire=%x, want %x", raw, wantWire)
+	}
+	got, err := decodeGetDAChunkPayload(raw)
+	if err != nil {
+		t.Fatalf("decodeGetDAChunkPayload: %v", err)
+	}
+	if got.Version != want.Version || got.DAID != want.DAID || !reflect.DeepEqual(got.Indexes, want.Indexes) {
+		t.Fatalf("getdachunk roundtrip got=%+v want=%+v", got, want)
 	}
 }
 
@@ -359,6 +388,58 @@ func TestGetBlockTxnPayloadRejectsMalformed(t *testing.T) {
 	}
 }
 
+func TestGetDAChunkPayloadRejectsMalformed(t *testing.T) {
+	tooMany := make([]uint16, consensus.MAX_DA_CHUNK_COUNT+1)
+	for i := range tooMany {
+		tooMany[i] = uint16(i)
+	}
+	for _, tc := range []struct {
+		name    string
+		in      getDAChunkPayload
+		wantErr string
+	}{
+		{name: "version", in: getDAChunkPayload{Version: daChunkRequestVersion + 1, Indexes: []uint16{0}}, wantErr: "unsupported DA chunk request version"},
+		{name: "empty", in: getDAChunkPayload{Version: daChunkRequestVersion}, wantErr: "invalid DA chunk request index count"},
+		{name: "too_many", in: getDAChunkPayload{Version: daChunkRequestVersion, Indexes: tooMany}, wantErr: "invalid DA chunk request index count"},
+		{name: "unsorted", in: getDAChunkPayload{Version: daChunkRequestVersion, Indexes: []uint16{2, 1}}, wantErr: "DA chunk request indexes not strictly increasing"},
+		{name: "duplicate", in: getDAChunkPayload{Version: daChunkRequestVersion, Indexes: []uint16{1, 1}}, wantErr: "DA chunk request indexes not strictly increasing"},
+		{name: "range", in: getDAChunkPayload{Version: daChunkRequestVersion, Indexes: []uint16{uint16(consensus.MAX_DA_CHUNK_COUNT)}}, wantErr: "DA chunk request index out of range"},
+	} {
+		_, err := encodeGetDAChunkPayload(tc.in)
+		if err == nil {
+			t.Fatalf("%s: expected encode failure", tc.name)
+		}
+		if !strings.Contains(err.Error(), tc.wantErr) {
+			t.Fatalf("%s: encode error=%q, want %q", tc.name, err, tc.wantErr)
+		}
+	}
+
+	for _, tc := range []struct {
+		name    string
+		raw     []byte
+		wantErr string
+	}{
+		{name: "short_prefix", raw: make([]byte, 39), wantErr: "getdachunk payload missing version or da_id"},
+		{name: "version", raw: getDAChunkTestPayload(daChunkRequestVersion+1, []byte{1, 0, 0}), wantErr: "unsupported DA chunk request version"},
+		{name: "nonminimal_count", raw: getDAChunkTestPayload(daChunkRequestVersion, []byte{0xfd, 0x00, 0x00}), wantErr: "non-minimal"},
+		{name: "empty", raw: getDAChunkTestPayload(daChunkRequestVersion, []byte{0}), wantErr: "invalid DA chunk request index count"},
+		{name: "count_too_large", raw: getDAChunkTestPayload(daChunkRequestVersion, consensus.AppendCompactSize(nil, consensus.MAX_DA_CHUNK_COUNT+1)), wantErr: "invalid DA chunk request index count"},
+		{name: "truncated_index", raw: getDAChunkTestPayload(daChunkRequestVersion, []byte{1, 0x01}), wantErr: "getdachunk payload truncated index"},
+		{name: "unsorted", raw: getDAChunkIndexedPayload(2, 1), wantErr: "DA chunk request indexes not strictly increasing"},
+		{name: "duplicate", raw: getDAChunkIndexedPayload(1, 1), wantErr: "DA chunk request indexes not strictly increasing"},
+		{name: "range", raw: getDAChunkIndexedPayload(uint16(consensus.MAX_DA_CHUNK_COUNT)), wantErr: "DA chunk request index out of range"},
+		{name: "trailing", raw: append(getDAChunkIndexedPayload(0), 0x00), wantErr: "getdachunk payload has trailing bytes"},
+	} {
+		_, err := decodeGetDAChunkPayload(tc.raw)
+		if err == nil {
+			t.Fatalf("%s: expected decode failure", tc.name)
+		}
+		if !strings.Contains(err.Error(), tc.wantErr) {
+			t.Fatalf("%s: decode error=%q, want %q", tc.name, err, tc.wantErr)
+		}
+	}
+}
+
 func getBlockTxnTestPayload(tail []byte) []byte {
 	return append(make([]byte, 32), tail...)
 }
@@ -378,6 +459,20 @@ func mustEncodeGetBlockTxnPayload(t *testing.T, indexes []uint64) []byte {
 		t.Fatalf("encodeGetBlockTxnPayload: %v", err)
 	}
 	return raw
+}
+
+func getDAChunkTestPayload(version uint64, tail []byte) []byte {
+	out := consensus.AppendU64le(nil, version)
+	out = append(out, make([]byte, 32)...)
+	return append(out, tail...)
+}
+
+func getDAChunkIndexedPayload(indexes ...uint16) []byte {
+	tail := consensus.AppendCompactSize(nil, uint64(len(indexes)))
+	for _, idx := range indexes {
+		tail = consensus.AppendU16le(tail, idx)
+	}
+	return getDAChunkTestPayload(daChunkRequestVersion, tail)
 }
 
 func TestSendCmpctPayloadCodec(t *testing.T) {

--- a/clients/go/node/p2p/peer_runtime.go
+++ b/clients/go/node/p2p/peer_runtime.go
@@ -290,31 +290,30 @@ func (p *peer) postHandshakePayloadCap() payloadLimitFn {
 	base := postHandshakePayloadCap(p.service.cfg.LocatorLimit, p.service.cfg.SyncConfig.HeaderBatchLimit)
 	return func(command string) uint32 {
 		switch command {
-		case messageCmpctBlock:
+		case messageCmpctBlock, messageGetBlockTxn, messageGetDAChunk:
 			if p.acceptsCompactBlocks() {
 				return compactRelayPayloadCap(command)
 			}
 			return 0
 		case messageBlockTxn:
-			if !p.compactReceiveEnabled() {
-				return 0
-			}
-			if cap := p.blockTxnPayloadCap(); cap != 0 {
-				return cap
-			}
-			if p.acceptsCompactBlocks() {
-				return blockTxnHashPayloadBytes
-			}
-			return 0
-		case messageGetBlockTxn:
-			if p.acceptsCompactBlocks() {
-				return compactRelayPayloadCap(command)
-			}
-			return 0
+			return p.blockTxnPostHandshakePayloadCap()
 		default:
 			return base(command)
 		}
 	}
+}
+
+func (p *peer) blockTxnPostHandshakePayloadCap() uint32 {
+	if !p.compactReceiveEnabled() {
+		return 0
+	}
+	if cap := p.blockTxnPayloadCap(); cap != 0 {
+		return cap
+	}
+	if p.acceptsCompactBlocks() {
+		return blockTxnHashPayloadBytes
+	}
+	return 0
 }
 
 func (p *peer) compactReceiveEnabled() bool {
@@ -387,7 +386,7 @@ func normalizeReadError(err error) error {
 
 func (p *peer) handleMessage(frame message) error {
 	switch frame.Command {
-	case messageInv, messageGetData, messageBlock, messageTx, messageGetBlk, messageCmpctBlock, messageGetBlockTxn, messageBlockTxn:
+	case messageInv, messageGetData, messageBlock, messageTx, messageGetBlk, messageCmpctBlock, messageGetBlockTxn, messageBlockTxn, messageGetDAChunk:
 		return p.handleRelayMessage(frame)
 	case messageSendCmpct:
 		return p.handleSendCmpct(frame.Payload)
@@ -408,6 +407,11 @@ func (p *peer) handleRelayMessage(frame message) error {
 	switch frame.Command {
 	case messageInv, messageGetData:
 		return p.handleInventoryRelayMessage(frame)
+	case messageGetDAChunk:
+		if !p.acceptsCompactBlocks() {
+			return postHandshakeUnknownCommandError{command: frame.Command}
+		}
+		return p.handleGetDAChunk(frame.Payload)
 	case messageBlock, messageTx, messageGetBlk, messageCmpctBlock, messageGetBlockTxn, messageBlockTxn:
 		return p.handleObjectRelayMessage(frame)
 	default:

--- a/clients/go/node/p2p/peer_runtime_test.go
+++ b/clients/go/node/p2p/peer_runtime_test.go
@@ -39,6 +39,7 @@ func (c *expiryWakeConn) Read(p []byte) (int, error) {
 	}
 	return c.scriptedConn.Read(p)
 }
+
 func (c *expiryWakeConn) expireOnRead(ck *clock, readCount int) {
 	c.onRead = func(n int) {
 		if n == readCount {
@@ -182,10 +183,10 @@ func TestShouldIgnoreAndNormalizeReadError(t *testing.T) {
 	}
 }
 
-func TestCompactObjectCapsStayClosedUntilParityReceiveExists(t *testing.T) {
+func TestCompactObjectCapsStayClosedUntilReceiveEnabled(t *testing.T) {
 	p := newPeerRuntimeTestPeer(t)
 	limiter := p.postHandshakePayloadCap()
-	for _, command := range []string{messageCmpctBlock, messageGetBlockTxn, messageBlockTxn} {
+	for _, command := range []string{messageCmpctBlock, messageGetBlockTxn, messageBlockTxn, messageGetDAChunk} {
 		if got := limiter(command); got != 0 {
 			t.Fatalf("pre-negotiation %s cap=%d, want 0", command, got)
 		}
@@ -194,9 +195,9 @@ func TestCompactObjectCapsStayClosedUntilParityReceiveExists(t *testing.T) {
 	p.setRemoteCompactMode(compactModeSnapshot{Mode: 1, Version: compactRelayVersion})
 	limiter = p.postHandshakePayloadCap()
 	p.setCompactOutstandingRequest(compactOutstandingRequest{BlockTxnPayloadCap: compactRelayPayloadCap(messageBlockTxn) + 1})
-	for _, command := range []string{messageCmpctBlock, messageGetBlockTxn, messageBlockTxn} {
+	for _, command := range []string{messageCmpctBlock, messageGetBlockTxn, messageBlockTxn, messageGetDAChunk} {
 		if got := limiter(command); got != 0 {
-			t.Fatalf("negotiated %s cap=%d, want 0 until handler slice", command, got)
+			t.Fatalf("negotiated %s cap=%d, want 0 while compact receive is disabled", command, got)
 		}
 	}
 }
@@ -205,7 +206,7 @@ func TestCompactObjectCapsOpenOnlyForEnabledNegotiatedReceive(t *testing.T) {
 	p := newPeerRuntimeTestPeer(t)
 	p.service.cfg.EnableCompactReceive = true
 	limiter := p.postHandshakePayloadCap()
-	for _, command := range []string{messageCmpctBlock, messageGetBlockTxn, messageBlockTxn} {
+	for _, command := range []string{messageCmpctBlock, messageGetBlockTxn, messageBlockTxn, messageGetDAChunk} {
 		if got := limiter(command); got != 0 {
 			t.Fatalf("pre-negotiation %s cap=%d, want 0", command, got)
 		}
@@ -217,6 +218,9 @@ func TestCompactObjectCapsOpenOnlyForEnabledNegotiatedReceive(t *testing.T) {
 	}
 	if got, want := limiter(messageGetBlockTxn), compactRelayPayloadCap(messageGetBlockTxn); got != want {
 		t.Fatalf("inbound getblocktxn cap=%d, want %d", got, want)
+	}
+	if got, want := limiter(messageGetDAChunk), getDAChunkPayloadCap(); got != want {
+		t.Fatalf("inbound getdachunk cap=%d, want %d", got, want)
 	}
 	if got := limiter(messageBlockTxn); got != blockTxnHashPayloadBytes {
 		t.Fatalf("blocktxn cap without outstanding=%d, want hash-only cap %d", got, blockTxnHashPayloadBytes)
@@ -231,6 +235,9 @@ func TestCompactObjectCapsOpenOnlyForEnabledNegotiatedReceive(t *testing.T) {
 	}
 	if got := limiter(messageGetBlockTxn); got != 0 {
 		t.Fatalf("disabled getblocktxn cap=%d, want 0", got)
+	}
+	if got := limiter(messageGetDAChunk); got != 0 {
+		t.Fatalf("disabled getdachunk cap=%d, want 0", got)
 	}
 	if got := limiter(messageBlockTxn); got != 64 {
 		t.Fatalf("disabled-mode blocktxn cap with outstanding=%d, want 64", got)
@@ -1145,7 +1152,8 @@ func TestRunDisconnectsOnPayloadTimeoutBeforeFakeFrame(t *testing.T) {
 			if tc.prefixBytes > 0 {
 				reads = append(reads, scriptedRead{data: payload[:tc.prefixBytes]})
 			}
-			reads = append(reads,
+			reads = append(
+				reads,
 				scriptedRead{err: timeoutErr{}},
 				scriptedRead{data: fakeValidFrame},
 			)
@@ -1188,6 +1196,35 @@ func TestHandleMessageRejectsInvalidKinds(t *testing.T) {
 	}
 	if err := p.handleMessage(message{Command: "unknown"}); err == nil || !strings.Contains(err.Error(), "unknown message type") {
 		t.Fatalf("expected unknown-kind rejection, got %v", err)
+	}
+}
+
+func TestHandleGetDAChunkRequiresCompactReceiveAndDecodesPayload(t *testing.T) {
+	var daID [32]byte
+	daID[0] = 0x37
+	payload, err := encodeGetDAChunkPayload(getDAChunkPayload{
+		Version: daChunkRequestVersion,
+		DAID:    daID,
+		Indexes: []uint16{0, 2},
+	})
+	if err != nil {
+		t.Fatalf("encodeGetDAChunkPayload: %v", err)
+	}
+
+	p := newPeerRuntimeTestPeer(t)
+	err = p.handleMessage(message{Command: messageGetDAChunk, Payload: payload})
+	var unknown postHandshakeUnknownCommandError
+	if !errors.As(err, &unknown) || unknown.command != messageGetDAChunk {
+		t.Fatalf("closed getdachunk err=%v, want unknown command", err)
+	}
+
+	p.service.cfg.EnableCompactReceive = true
+	p.setRemoteCompactMode(compactModeSnapshot{Mode: 1, Version: compactRelayVersion})
+	if err := p.handleMessage(message{Command: messageGetDAChunk, Payload: payload}); err != nil {
+		t.Fatalf("valid getdachunk: %v", err)
+	}
+	if err := p.handleMessage(message{Command: messageGetDAChunk, Payload: payload[:1]}); err == nil || !strings.Contains(err.Error(), "getdachunk payload missing") {
+		t.Fatalf("malformed getdachunk err=%v, want decode rejection", err)
 	}
 }
 

--- a/clients/go/node/p2p/wire_payload_limits.go
+++ b/clients/go/node/p2p/wire_payload_limits.go
@@ -37,6 +37,9 @@ func compactRelayPayloadCap(command string) uint32 {
 	if command == messageBlockTxn {
 		return uint32(consensus.MAX_BLOCK_BYTES + 32 + maxCompactSizeBytes + maxCompactRelayEntries*maxCompactSizeBytes)
 	}
+	if command == messageGetDAChunk {
+		return getDAChunkPayloadCap()
+	}
 	return 0
 }
 


### PR DESCRIPTION
Invariant:
DA chunk requests have an explicit bounded Go P2P wire/runtime decode surface before prefetch scheduling uses it.

Layer:
Implementation / tests.

Files changed:
- clients/go/node/p2p/compact_wire.go
- clients/go/node/p2p/wire_payload_limits.go
- clients/go/node/p2p/compact_runtime.go
- clients/go/node/p2p/peer_runtime.go
- clients/go/node/p2p/compact_wire_test.go
- clients/go/node/p2p/peer_runtime_test.go

Tests:
- P2P getdachunk/compact/request targeted tests: PASS
- RUB-368 required P2P request/wire/compact gate: PASS
- P2P package tests: PASS
- Go pre-push tooling: PASS
- Core quality gate: PASS
- Go-only coverage gate: PASS, variation +0.03%, diff coverage 100.00%

Behavior impact:
Adds bounded getdachunk request parsing and negotiated runtime decode. Valid requests are decoded only; response scheduling remains outside this PR.

Compatibility impact:
getblocktxn and blocktxn compact-block reconstruction semantics are unchanged.

Known non-goals:
No DA tx ingest, prefetch scheduler, rate limiter, peer scoring, miner/template inclusion, consensus validity change, conformance change, or Rust implementation.

Spec authority:
2tbmz9y2xt-lang/rubin-spec#248

Closes #1815
