### PR TITLE
[Q-GO-P2P-DA-MINER-COMPLETE-SET-PROVIDER-01] Expose immutable complete DA set candidates

### DIFF
--- a/clients/go/node/miner_da_provider.go
+++ b/clients/go/node/miner_da_provider.go
@@ -1,0 +1,20 @@
+package node
+
+// CompleteDASetProvider exposes relay-complete DA set candidates to miner code.
+type CompleteDASetProvider interface {
+	CompleteDASetCandidates() []CompleteDASetCandidate
+}
+
+// CompleteDASetCandidate is an immutable miner-facing COMPLETE_SET snapshot.
+type CompleteDASetCandidate struct {
+	DAID         [32]byte
+	PayloadBytes uint64
+	CommitTx     []byte
+	Chunks       []CompleteDASetChunkCandidate
+}
+
+// CompleteDASetChunkCandidate carries one DA_CHUNK_TX snapshot in chunk_index order.
+type CompleteDASetChunkCandidate struct {
+	Index uint16
+	Tx    []byte
+}

--- a/clients/go/node/miner_da_provider.go
+++ b/clients/go/node/miner_da_provider.go
@@ -2,7 +2,7 @@ package node
 
 // CompleteDASetProvider exposes relay-complete DA set candidates to miner code.
 type CompleteDASetProvider interface {
-	CompleteDASetCandidates() []CompleteDASetCandidate
+	CompleteDASetCandidates(maxPayloadBytes uint64) []CompleteDASetCandidate
 }
 
 // CompleteDASetCandidate is an immutable miner-facing COMPLETE_SET snapshot.

--- a/clients/go/node/p2p/da_relay_ingest.go
+++ b/clients/go/node/p2p/da_relay_ingest.go
@@ -13,15 +13,15 @@ func (s *Service) stageRelayDATx(peerAddr string, txBytes []byte, tx *consensus.
 	wireBytes := uint64(len(txBytes))
 	switch tx.TxKind {
 	case 0x01:
-		return s.stageRelayDACommitTx(peerAddr, wireBytes, tx)
+		return s.stageRelayDACommitTx(peerAddr, txBytes, wireBytes, tx)
 	case 0x02:
-		return s.stageRelayDAChunkTx(peerAddr, wireBytes, tx)
+		return s.stageRelayDAChunkTx(peerAddr, txBytes, wireBytes, tx)
 	default:
 		return nil
 	}
 }
 
-func (s *Service) stageRelayDACommitTx(peerAddr string, wireBytes uint64, tx *consensus.Tx) error {
+func (s *Service) stageRelayDACommitTx(peerAddr string, txBytes []byte, wireBytes uint64, tx *consensus.Tx) error {
 	if tx.DaCommitCore == nil {
 		return nil
 	}
@@ -34,11 +34,12 @@ func (s *Service) stageRelayDACommitTx(peerAddr string, wireBytes uint64, tx *co
 		payloadCommitment: commitment,
 		chunkCount:        tx.DaCommitCore.ChunkCount,
 		wireBytes:         wireBytes,
+		txBytes:           txBytes,
 	})
 	return s.finishDAPrefetch(peerAddr, tx.DaCommitCore.DaID, record, err)
 }
 
-func (s *Service) stageRelayDAChunkTx(peerAddr string, wireBytes uint64, tx *consensus.Tx) error {
+func (s *Service) stageRelayDAChunkTx(peerAddr string, txBytes []byte, wireBytes uint64, tx *consensus.Tx) error {
 	if tx.DaChunkCore == nil {
 		return nil
 	}
@@ -48,6 +49,7 @@ func (s *Service) stageRelayDAChunkTx(peerAddr string, wireBytes uint64, tx *con
 		chunkIndex: tx.DaChunkCore.ChunkIndex,
 		payload:    tx.DaPayload,
 		wireBytes:  wireBytes,
+		txBytes:    txBytes,
 	})
 	return s.finishDAPrefetch(peerAddr, tx.DaChunkCore.DaID, record, err)
 }

--- a/clients/go/node/p2p/da_relay_provider.go
+++ b/clients/go/node/p2p/da_relay_provider.go
@@ -8,32 +8,28 @@ import (
 )
 
 // CompleteDASetCandidates returns immutable snapshots of relay-complete DA sets.
-func (s *Service) CompleteDASetCandidates() []node.CompleteDASetCandidate {
+func (s *Service) CompleteDASetCandidates(maxPayloadBytes uint64) []node.CompleteDASetCandidate {
 	if s == nil || s.daRelay == nil {
 		return nil
 	}
-	return s.daRelay.completeSetCandidates()
+	return s.daRelay.completeSetCandidates(maxPayloadBytes)
 }
 
-func (s *daRelayState) completeSetCandidates() []node.CompleteDASetCandidate {
-	records := s.completeSetCandidateRecords()
-	candidates := make([]node.CompleteDASetCandidate, 0, len(records))
-	for _, record := range records {
+func (s *daRelayState) completeSetCandidates(maxPayloadBytes uint64) []node.CompleteDASetCandidate {
+	if s == nil || maxPayloadBytes == 0 {
+		return nil
+	}
+	var candidates []node.CompleteDASetCandidate
+	for _, record := range s.completeSetCandidateRecords(maxPayloadBytes) {
 		candidate, ok := record.completeSetCandidate()
 		if ok {
 			candidates = append(candidates, candidate)
 		}
 	}
-	if len(candidates) == 0 {
-		return nil
-	}
 	return candidates
 }
 
-func (s *daRelayState) completeSetCandidateRecords() []daRelaySetRecord {
-	if s == nil {
-		return nil
-	}
+func (s *daRelayState) completeSetCandidateRecords(maxPayloadBytes uint64) []daRelaySetRecord {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -48,14 +44,20 @@ func (s *daRelayState) completeSetCandidateRecords() []daRelaySetRecord {
 	})
 
 	records := make([]daRelaySetRecord, 0, len(daIDs))
+	var payloadBytes uint64
 	for _, daID := range daIDs {
-		records = append(records, s.sets[daID].cloneForStateMutation())
+		record := s.sets[daID]
+		if record.payloadBytes > maxPayloadBytes-payloadBytes {
+			break
+		}
+		records = append(records, record.cloneForStateMutation())
+		payloadBytes += record.payloadBytes
 	}
 	return records
 }
 
 func (r daRelaySetRecord) completeSetCandidate() (node.CompleteDASetCandidate, bool) {
-	if r.state != daRelayStateCompleteSet || len(r.commit.txBytes) == 0 {
+	if len(r.commit.txBytes) == 0 {
 		return node.CompleteDASetCandidate{}, false
 	}
 	chunks := make([]node.CompleteDASetChunkCandidate, 0, r.commit.chunkCount)

--- a/clients/go/node/p2p/da_relay_provider.go
+++ b/clients/go/node/p2p/da_relay_provider.go
@@ -48,7 +48,7 @@ func (s *daRelayState) completeSetCandidateRecords(maxPayloadBytes uint64) []daR
 	for _, daID := range daIDs {
 		record := s.sets[daID]
 		if record.payloadBytes > maxPayloadBytes-payloadBytes {
-			break
+			continue
 		}
 		records = append(records, record.cloneForStateMutation())
 		payloadBytes += record.payloadBytes

--- a/clients/go/node/p2p/da_relay_provider.go
+++ b/clients/go/node/p2p/da_relay_provider.go
@@ -1,80 +1,8 @@
 package p2p
 
-import (
-	"bytes"
-	"sort"
-
-	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/node"
-)
+import "github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/node"
 
 // CompleteDASetCandidates returns immutable snapshots of relay-complete DA sets.
 func (s *Service) CompleteDASetCandidates(maxPayloadBytes uint64) []node.CompleteDASetCandidate {
-	if s == nil || s.daRelay == nil {
-		return nil
-	}
-	return s.daRelay.completeSetCandidates(maxPayloadBytes)
-}
-
-func (s *daRelayState) completeSetCandidates(maxPayloadBytes uint64) []node.CompleteDASetCandidate {
-	if s == nil || maxPayloadBytes == 0 {
-		return nil
-	}
-	var candidates []node.CompleteDASetCandidate
-	for _, record := range s.completeSetCandidateRecords(maxPayloadBytes) {
-		candidate, ok := record.completeSetCandidate()
-		if ok {
-			candidates = append(candidates, candidate)
-		}
-	}
-	return candidates
-}
-
-func (s *daRelayState) completeSetCandidateRecords(maxPayloadBytes uint64) []daRelaySetRecord {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	daIDs := make([][32]byte, 0, len(s.sets))
-	for daID, record := range s.sets {
-		if record.state == daRelayStateCompleteSet {
-			daIDs = append(daIDs, daID)
-		}
-	}
-	sort.Slice(daIDs, func(i, j int) bool {
-		return bytes.Compare(daIDs[i][:], daIDs[j][:]) < 0
-	})
-
-	records := make([]daRelaySetRecord, 0, len(daIDs))
-	var payloadBytes uint64
-	for _, daID := range daIDs {
-		record := s.sets[daID]
-		if record.payloadBytes > maxPayloadBytes-payloadBytes {
-			continue
-		}
-		records = append(records, record.cloneForStateMutation())
-		payloadBytes += record.payloadBytes
-	}
-	return records
-}
-
-func (r daRelaySetRecord) completeSetCandidate() (node.CompleteDASetCandidate, bool) {
-	if len(r.commit.txBytes) == 0 {
-		return node.CompleteDASetCandidate{}, false
-	}
-	chunks := make([]node.CompleteDASetChunkCandidate, 0, r.commit.chunkCount)
-	for i := uint16(0); i < r.commit.chunkCount; i++ {
-		chunk, ok := r.chunks[i]
-		if !ok || len(chunk.txBytes) == 0 {
-			return node.CompleteDASetCandidate{}, false
-		}
-		chunks = append(chunks, node.CompleteDASetChunkCandidate{
-			Index: i,
-			Tx:    cloneBytes(chunk.txBytes),
-		})
-	}
-	return node.CompleteDASetCandidate{
-		DAID:         r.daID,
-		PayloadBytes: r.payloadBytes,
-		CommitTx:     cloneBytes(r.commit.txBytes),
-		Chunks:       chunks,
-	}, true
+	return s.completeDASetCandidates(maxPayloadBytes)
 }

--- a/clients/go/node/p2p/da_relay_provider.go
+++ b/clients/go/node/p2p/da_relay_provider.go
@@ -1,0 +1,78 @@
+package p2p
+
+import (
+	"bytes"
+	"sort"
+
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/node"
+)
+
+// CompleteDASetCandidates returns immutable snapshots of relay-complete DA sets.
+func (s *Service) CompleteDASetCandidates() []node.CompleteDASetCandidate {
+	if s == nil || s.daRelay == nil {
+		return nil
+	}
+	return s.daRelay.completeSetCandidates()
+}
+
+func (s *daRelayState) completeSetCandidates() []node.CompleteDASetCandidate {
+	records := s.completeSetCandidateRecords()
+	candidates := make([]node.CompleteDASetCandidate, 0, len(records))
+	for _, record := range records {
+		candidate, ok := record.completeSetCandidate()
+		if ok {
+			candidates = append(candidates, candidate)
+		}
+	}
+	if len(candidates) == 0 {
+		return nil
+	}
+	return candidates
+}
+
+func (s *daRelayState) completeSetCandidateRecords() []daRelaySetRecord {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	daIDs := make([][32]byte, 0, len(s.sets))
+	for daID, record := range s.sets {
+		if record.state == daRelayStateCompleteSet {
+			daIDs = append(daIDs, daID)
+		}
+	}
+	sort.Slice(daIDs, func(i, j int) bool {
+		return bytes.Compare(daIDs[i][:], daIDs[j][:]) < 0
+	})
+
+	records := make([]daRelaySetRecord, 0, len(daIDs))
+	for _, daID := range daIDs {
+		records = append(records, s.sets[daID].cloneForStateMutation())
+	}
+	return records
+}
+
+func (r daRelaySetRecord) completeSetCandidate() (node.CompleteDASetCandidate, bool) {
+	if r.state != daRelayStateCompleteSet || len(r.commit.txBytes) == 0 {
+		return node.CompleteDASetCandidate{}, false
+	}
+	chunks := make([]node.CompleteDASetChunkCandidate, 0, r.commit.chunkCount)
+	for i := uint16(0); i < r.commit.chunkCount; i++ {
+		chunk, ok := r.chunks[i]
+		if !ok || len(chunk.txBytes) == 0 {
+			return node.CompleteDASetCandidate{}, false
+		}
+		chunks = append(chunks, node.CompleteDASetChunkCandidate{
+			Index: i,
+			Tx:    cloneBytes(chunk.txBytes),
+		})
+	}
+	return node.CompleteDASetCandidate{
+		DAID:         r.daID,
+		PayloadBytes: r.payloadBytes,
+		CommitTx:     cloneBytes(r.commit.txBytes),
+		Chunks:       chunks,
+	}, true
+}

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -728,14 +728,14 @@ func (r daRelaySetRecord) cloneForStateMutation() daRelaySetRecord {
 func (r daRelaySetRecord) cloneWithPayloads(copyPayloads bool) daRelaySetRecord {
 	out := r
 	if copyPayloads {
-		out.commit.txBytes = cloneBytes(out.commit.txBytes)
+		out.commit.txBytes = nil
 	}
 	if r.chunks != nil {
 		out.chunks = make(map[uint16]daRelayChunk, len(r.chunks))
 		for index, chunk := range r.chunks {
 			if copyPayloads {
 				chunk.payload = cloneBytes(chunk.payload)
-				chunk.txBytes = cloneBytes(chunk.txBytes)
+				chunk.txBytes = nil
 			}
 			out.chunks[index] = chunk
 		}

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -364,7 +364,6 @@ func (s *daRelayState) addDACommit(peerAddr string, commit daRelayCommit) (daRel
 	if commit.wireBytes == 0 {
 		return daRelaySetRecord{}, errDARelayWireBytesInvalid
 	}
-	commit.txBytes = cloneBytes(commit.txBytes)
 
 	for {
 		s.mu.Lock()
@@ -512,6 +511,7 @@ func (s *daRelayState) stageDACommitRecordLocked(peerAddr string, commit daRelay
 	}
 	c := commit
 	c.peerQuotaKey = peerQuotaKey(peerAddr)
+	c.txBytes = cloneBytes(c.txBytes)
 	record.daID = c.daID
 	record.commit = c
 	record.pruneChunksOutsideCommit()
@@ -985,6 +985,10 @@ func (r *daRelaySetRecord) markComplete(payloadBytes uint64) {
 	r.state = daRelayStateCompleteSet
 	r.ttlBlocksRemaining = 0
 	r.replaceableChunks = nil
+	for index, chunk := range r.chunks {
+		chunk.payload = nil
+		r.chunks[index] = chunk
+	}
 }
 
 func (r *daRelaySetRecord) recomputeOrphanTotals() error {

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -143,6 +143,7 @@ type daRelayCommit struct {
 	peerQuotaKey      string
 	chunkCount        uint16
 	wireBytes         uint64
+	txBytes           []byte
 }
 
 type daRelayChunk struct {
@@ -152,6 +153,7 @@ type daRelayChunk struct {
 	chunkIndex   uint16
 	payload      []byte
 	wireBytes    uint64
+	txBytes      []byte
 }
 
 type daRelayCompletionSnapshot struct {
@@ -362,6 +364,7 @@ func (s *daRelayState) addDACommit(peerAddr string, commit daRelayCommit) (daRel
 	if commit.wireBytes == 0 {
 		return daRelaySetRecord{}, errDARelayWireBytesInvalid
 	}
+	commit.txBytes = cloneBytes(commit.txBytes)
 
 	for {
 		s.mu.Lock()
@@ -440,6 +443,8 @@ func (s *daRelayState) addDAChunk(peerAddr string, chunk daRelayChunk) (daRelayS
 		return daRelaySetRecord{}, errDARelayChunkHashMismatch
 	}
 	payload := cloneBytes(chunk.payload)
+	txBytes := cloneBytes(chunk.txBytes)
+	chunk.txBytes = txBytes
 
 	for {
 		s.mu.Lock()
@@ -723,11 +728,15 @@ func (r daRelaySetRecord) cloneForStateMutation() daRelaySetRecord {
 
 func (r daRelaySetRecord) cloneWithPayloads(copyPayloads bool) daRelaySetRecord {
 	out := r
+	if copyPayloads {
+		out.commit.txBytes = cloneBytes(out.commit.txBytes)
+	}
 	if r.chunks != nil {
 		out.chunks = make(map[uint16]daRelayChunk, len(r.chunks))
 		for index, chunk := range r.chunks {
 			if copyPayloads {
 				chunk.payload = cloneBytes(chunk.payload)
+				chunk.txBytes = cloneBytes(chunk.txBytes)
 			}
 			out.chunks[index] = chunk
 		}

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -5,11 +5,13 @@ import (
 	"crypto/sha3"
 	"errors"
 	"fmt"
+	"reflect"
 	"sort"
 	"sync"
 	"time"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/node"
 )
 
 const (
@@ -357,6 +359,158 @@ func (s *daRelayState) sortedIncompleteDAIDsLocked() [][32]byte {
 	return daIDs
 }
 
+func (s *Service) completeDASetCandidates(maxPayloadBytes uint64) []node.CompleteDASetCandidate {
+	if s == nil || s.daRelay == nil || maxPayloadBytes == 0 {
+		return nil
+	}
+	var candidates []node.CompleteDASetCandidate
+	var staleRecords []daRelaySetRecord
+	var payloadBytes uint64
+	for _, record := range s.daRelay.completeSetCandidateRecordsSnapshot() {
+		if !s.daRelayRecordTxBytesAdmitted(record) {
+			staleRecords = append(staleRecords, record)
+			continue
+		}
+		if record.payloadBytes > maxPayloadBytes-payloadBytes {
+			continue
+		}
+		candidate, ok := record.completeSetCandidate()
+		if ok {
+			candidates = append(candidates, candidate)
+			payloadBytes += record.payloadBytes
+		}
+	}
+	_ = s.pruneStaleCompleteSetRecords(staleRecords)
+	return candidates
+}
+
+func (s *daRelayState) completeSetCandidates(maxPayloadBytes uint64) []node.CompleteDASetCandidate {
+	if s == nil || maxPayloadBytes == 0 {
+		return nil
+	}
+	var candidates []node.CompleteDASetCandidate
+	for _, record := range s.completeSetCandidateRecords(maxPayloadBytes) {
+		candidate, ok := record.completeSetCandidate()
+		if ok {
+			candidates = append(candidates, candidate)
+		}
+	}
+	return candidates
+}
+
+func (s *daRelayState) completeSetCandidateRecords(maxPayloadBytes uint64) []daRelaySetRecord {
+	if maxPayloadBytes == 0 {
+		return nil
+	}
+	var records []daRelaySetRecord
+	var payloadBytes uint64
+	for _, record := range s.completeSetCandidateRecordsSnapshot() {
+		if record.payloadBytes > maxPayloadBytes-payloadBytes {
+			continue
+		}
+		records = append(records, record)
+		payloadBytes += record.payloadBytes
+	}
+	return records
+}
+
+func (s *daRelayState) completeSetCandidateRecordsSnapshot() []daRelaySetRecord {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	daIDs := make([][32]byte, 0, len(s.sets))
+	for daID, record := range s.sets {
+		if record.state == daRelayStateCompleteSet {
+			daIDs = append(daIDs, daID)
+		}
+	}
+	sort.Slice(daIDs, func(i, j int) bool {
+		return bytes.Compare(daIDs[i][:], daIDs[j][:]) < 0
+	})
+
+	records := make([]daRelaySetRecord, 0, len(daIDs))
+	for _, daID := range daIDs {
+		record := s.sets[daID]
+		records = append(records, record.cloneForStateMutation())
+	}
+	return records
+}
+
+func (s *Service) pruneStaleCompleteSetRecords(staleRecords []daRelaySetRecord) error {
+	if s == nil || s.daRelay == nil || len(staleRecords) == 0 {
+		return nil
+	}
+	s.daRelay.mu.Lock()
+	defer s.daRelay.mu.Unlock()
+
+	for _, staleRecord := range staleRecords {
+		current, ok := s.daRelay.sets[staleRecord.daID]
+		if ok && sameCompleteSetGeneration(current, staleRecord) && !s.daRelayRecordTxBytesAdmitted(current) {
+			if err := s.daRelay.removeDASetRecordLocked(current); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func sameCompleteSetGeneration(current, stale daRelaySetRecord) bool {
+	return current.state == daRelayStateCompleteSet &&
+		stale.state == daRelayStateCompleteSet &&
+		reflect.DeepEqual(current, stale)
+}
+
+func (s *Service) daRelayRecordTxBytesAdmitted(record daRelaySetRecord) bool {
+	if !s.daRelayTxBytesAdmitted(record.commit.txBytes) {
+		return false
+	}
+	for i := uint16(0); i < record.commit.chunkCount; i++ {
+		chunk, ok := record.chunks[i]
+		if !ok || !s.daRelayTxBytesAdmitted(chunk.txBytes) {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *Service) daRelayTxBytesAdmitted(txBytes []byte) bool {
+	if s == nil || s.cfg.TxPool == nil || len(txBytes) == 0 {
+		return false
+	}
+	_, txid, err := parseCanonicalTx(txBytes)
+	if err != nil {
+		return false
+	}
+	admittedTxBytes, ok := s.cfg.TxPool.Get(txid)
+	return ok && bytes.Equal(admittedTxBytes, txBytes)
+}
+
+func (r daRelaySetRecord) completeSetCandidate() (node.CompleteDASetCandidate, bool) {
+	if len(r.commit.txBytes) == 0 {
+		return node.CompleteDASetCandidate{}, false
+	}
+	chunks := make([]node.CompleteDASetChunkCandidate, 0, r.commit.chunkCount)
+	for i := uint16(0); i < r.commit.chunkCount; i++ {
+		chunk, ok := r.chunks[i]
+		if !ok || len(chunk.txBytes) == 0 {
+			return node.CompleteDASetCandidate{}, false
+		}
+		chunks = append(chunks, node.CompleteDASetChunkCandidate{
+			Index: i,
+			Tx:    cloneBytes(chunk.txBytes),
+		})
+	}
+	return node.CompleteDASetCandidate{
+		DAID:         r.daID,
+		PayloadBytes: r.payloadBytes,
+		CommitTx:     cloneBytes(r.commit.txBytes),
+		Chunks:       chunks,
+	}, true
+}
+
 func (s *daRelayState) addDACommit(peerAddr string, commit daRelayCommit) (daRelaySetRecord, error) {
 	if commit.chunkCount == 0 || uint64(commit.chunkCount) > consensus.MAX_DA_CHUNK_COUNT {
 		return daRelaySetRecord{}, errDARelayChunkCountInvalid
@@ -365,12 +519,17 @@ func (s *daRelayState) addDACommit(peerAddr string, commit daRelayCommit) (daRel
 		return daRelaySetRecord{}, errDARelayWireBytesInvalid
 	}
 
+	commitTxBytesOwned := false
 	for {
 		s.mu.Lock()
-		record, err := s.stageDACommitRecordLocked(peerAddr, commit)
+		record, err := s.stageDACommitRecordLocked(peerAddr, commit, commitTxBytesOwned)
 		if err != nil {
 			s.mu.Unlock()
 			return daRelaySetRecord{}, err
+		}
+		if !commitTxBytesOwned {
+			commit.txBytes = record.commit.txBytes
+			commitTxBytesOwned = true
 		}
 		snapshot, complete := record.completionSnapshot()
 		if !complete {
@@ -391,7 +550,7 @@ func (s *daRelayState) addDACommit(peerAddr string, commit daRelayCommit) (daRel
 		if payloadCommitment != snapshot.payloadCommitmentExpected {
 			// Commit metadata is the first-seen authority for duplicate handling;
 			// orphan chunks are provisional until they match that commit.
-			applied, err := s.stageCommitDroppingMatchingCompletionChunks(peerAddr, commit, snapshot)
+			applied, err := s.stageCommitDroppingMatchingCompletionChunks(peerAddr, commit, commitTxBytesOwned, snapshot)
 			if err != nil {
 				return daRelaySetRecord{}, err
 			}
@@ -402,7 +561,7 @@ func (s *daRelayState) addDACommit(peerAddr string, commit daRelayCommit) (daRel
 		}
 
 		s.mu.Lock()
-		record, err = s.stageDACommitRecordLocked(peerAddr, commit)
+		record, err = s.stageDACommitRecordLocked(peerAddr, commit, commitTxBytesOwned)
 		if err != nil {
 			s.mu.Unlock()
 			return daRelaySetRecord{}, err
@@ -443,12 +602,18 @@ func (s *daRelayState) addDAChunk(peerAddr string, chunk daRelayChunk) (daRelayS
 	}
 	payload := cloneBytes(chunk.payload)
 
+	chunkTxBytesOwned := false
 	for {
 		s.mu.Lock()
-		record, err := s.stageDAChunkRecordLocked(peerAddr, chunk, payload)
+		record, err := s.stageDAChunkRecordLocked(peerAddr, chunk, payload, chunkTxBytesOwned)
 		if err != nil {
 			s.mu.Unlock()
 			return daRelaySetRecord{}, err
+		}
+		if !chunkTxBytesOwned {
+			stagedChunk := record.chunks[chunk.chunkIndex]
+			chunk.txBytes = stagedChunk.txBytes
+			chunkTxBytesOwned = true
 		}
 		snapshot, complete := record.completionSnapshot()
 		if !complete {
@@ -478,7 +643,7 @@ func (s *daRelayState) addDAChunk(peerAddr string, chunk daRelayChunk) (daRelayS
 		}
 
 		s.mu.Lock()
-		record, err = s.stageDAChunkRecordLocked(peerAddr, chunk, payload)
+		record, err = s.stageDAChunkRecordLocked(peerAddr, chunk, payload, chunkTxBytesOwned)
 		if err != nil {
 			s.mu.Unlock()
 			return daRelaySetRecord{}, err
@@ -501,7 +666,9 @@ func (s *daRelayState) addDAChunk(peerAddr string, chunk daRelayChunk) (daRelayS
 	}
 }
 
-func (s *daRelayState) stageDACommitRecordLocked(peerAddr string, commit daRelayCommit) (daRelaySetRecord, error) {
+// txBytesOwned is only true for retrying a txBytes slice cloned by an earlier
+// successful staging call; first admission still clones after duplicate checks.
+func (s *daRelayState) stageDACommitRecordLocked(peerAddr string, commit daRelayCommit, txBytesOwned bool) (daRelaySetRecord, error) {
 	record := s.sets[commit.daID].cloneForStateMutation()
 	record.ensureMaps()
 	if record.commit.chunkCount != 0 {
@@ -509,7 +676,9 @@ func (s *daRelayState) stageDACommitRecordLocked(peerAddr string, commit daRelay
 	}
 	c := commit
 	c.peerQuotaKey = peerQuotaKey(peerAddr)
-	c.txBytes = cloneBytes(c.txBytes)
+	if !txBytesOwned {
+		c.txBytes = cloneBytes(c.txBytes)
+	}
 	record.daID = c.daID
 	record.commit = c
 	record.pruneChunksOutsideCommit()
@@ -521,14 +690,17 @@ func (s *daRelayState) stageDACommitRecordLocked(peerAddr string, commit daRelay
 	return record, nil
 }
 
-func (s *daRelayState) stageDAChunkRecordLocked(peerAddr string, chunk daRelayChunk, payload []byte) (daRelaySetRecord, error) {
+// txBytesOwned follows the same ownership contract as stageDACommitRecordLocked.
+func (s *daRelayState) stageDAChunkRecordLocked(peerAddr string, chunk daRelayChunk, payload []byte, txBytesOwned bool) (daRelaySetRecord, error) {
 	record := s.sets[chunk.daID].cloneForStateMutation()
 	record.ensureMaps()
 	if err := record.validateChunkInsert(chunk.chunkIndex); err != nil {
 		return daRelaySetRecord{}, err
 	}
 	chunk.peerQuotaKey = peerQuotaKey(peerAddr)
-	chunk.txBytes = cloneBytes(chunk.txBytes)
+	if !txBytesOwned {
+		chunk.txBytes = cloneBytes(chunk.txBytes)
+	}
 	record.daID = chunk.daID
 	if record.commit.chunkCount == 0 {
 		record.state = daRelayStateOrphanChunks
@@ -867,11 +1039,11 @@ func (s daRelayCompletionSnapshot) payloadCommitment() (uint64, [32]byte) {
 	return payloadBytes, payloadCommitment
 }
 
-func (s *daRelayState) stageCommitDroppingMatchingCompletionChunks(peerAddr string, commit daRelayCommit, snapshot daRelayCompletionSnapshot) (bool, error) {
+func (s *daRelayState) stageCommitDroppingMatchingCompletionChunks(peerAddr string, commit daRelayCommit, txBytesOwned bool, snapshot daRelayCompletionSnapshot) (bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	record, err := s.stageDACommitRecordLocked(peerAddr, commit)
+	record, err := s.stageDACommitRecordLocked(peerAddr, commit, txBytesOwned)
 	if err != nil {
 		return false, err
 	}

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -1028,13 +1028,26 @@ func (r daRelaySetRecord) orphanAccounting() (daRelayRecordAccounting, error) {
 		return daRelayRecordAccounting{}, nil
 	}
 	accounting := daRelayRecordAccounting{peerBytes: map[string]uint64{}}
-	accounting.orphanBytes = r.wireBytes
+	accounting.orphanBytes = r.commit.wireBytes
 	accounting.commitBytes = r.commit.wireBytes
 	if err := addPeerAccounting(accounting.peerBytes, r.commit.peerQuotaKey, r.commit.wireBytes); err != nil {
 		return daRelayRecordAccounting{}, err
 	}
 	for _, chunk := range r.chunks {
-		if err := addPeerAccounting(accounting.peerBytes, chunk.peerQuotaKey, chunk.wireBytes); err != nil {
+		chunkBytes := chunk.wireBytes
+		if len(chunk.txBytes) != 0 && len(chunk.payload) != 0 {
+			var addErr error
+			chunkBytes, addErr = checkedAddUint64(chunkBytes, uint64(len(chunk.payload)))
+			if addErr != nil {
+				return daRelayRecordAccounting{}, addErr
+			}
+		}
+		orphanBytes, err := checkedAddUint64(accounting.orphanBytes, chunkBytes)
+		if err != nil {
+			return daRelayRecordAccounting{}, err
+		}
+		accounting.orphanBytes = orphanBytes
+		if err := addPeerAccounting(accounting.peerBytes, chunk.peerQuotaKey, chunkBytes); err != nil {
 			return daRelayRecordAccounting{}, err
 		}
 	}

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -442,8 +442,6 @@ func (s *daRelayState) addDAChunk(peerAddr string, chunk daRelayChunk) (daRelayS
 		return daRelaySetRecord{}, errDARelayChunkHashMismatch
 	}
 	payload := cloneBytes(chunk.payload)
-	txBytes := cloneBytes(chunk.txBytes)
-	chunk.txBytes = txBytes
 
 	for {
 		s.mu.Lock()
@@ -530,6 +528,7 @@ func (s *daRelayState) stageDAChunkRecordLocked(peerAddr string, chunk daRelayCh
 		return daRelaySetRecord{}, err
 	}
 	chunk.peerQuotaKey = peerQuotaKey(peerAddr)
+	chunk.txBytes = cloneBytes(chunk.txBytes)
 	record.daID = chunk.daID
 	if record.commit.chunkCount == 0 {
 		record.state = daRelayStateOrphanChunks

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -514,13 +514,20 @@ func TestDARelayDuplicateCommitAfterOrphanChunksKeepsFirstSeenState(t *testing.T
 	state := newDARelayStateForTest(t, defaultDARelayCaps())
 
 	mustAddDAChunk(t, state, "peer-a", daRelayTestChunk(daID, 0, 7))
-	record := mustAddDACommit(t, state, "peer-b", daRelayTestCommit(daID, 2, 3))
+	payload0 := []byte{1}
+	payload1 := []byte{2}
+	record := mustAddDACommit(t, state, "peer-b", daRelayTestCommitWithTxBytes(daID, 3, []byte("first-commit"), payload0, payload1))
 
-	_, err := state.addDACommit("peer-c", daRelayTestCommit(daID, 2, 11))
+	duplicate := daRelayTestCommitWithTxBytes(daID, 11, []byte("duplicate-commit"), payload0, payload1)
+	_, err := state.addDACommit("peer-c", duplicate)
 	requireDAErr(t, err, errDARelayDuplicateCommit)
+	duplicate.txBytes[0] = 'X'
 	stored := state.sets[daID]
 	if stored.commit.wireBytes != record.commit.wireBytes || stored.commit.peerQuotaKey != peerQuotaKey("peer-b") {
 		t.Fatalf("duplicate commit replaced first commit: wire=%d peer=%q", stored.commit.wireBytes, stored.commit.peerQuotaKey)
+	}
+	if !reflect.DeepEqual(stored.commit.txBytes, []byte("first-commit")) {
+		t.Fatalf("duplicate commit mutated stored tx bytes: %q", stored.commit.txBytes)
 	}
 	if stored.receivedTime != record.receivedTime || state.nextReceivedTime != record.receivedTime {
 		t.Fatalf("duplicate commit time record=%d state=%d want %d", stored.receivedTime, state.nextReceivedTime, record.receivedTime)
@@ -756,9 +763,8 @@ func TestDARelayCompletesSetAndPinsPayload(t *testing.T) {
 	if state.orphanBytes != 0 || len(state.orphanBytesByDAID) != 0 {
 		t.Fatalf("complete set left orphan accounting: global=%d da=%d", state.orphanBytes, len(state.orphanBytesByDAID))
 	}
-	record.chunks[0].payload[0] ^= 0xff
-	if state.sets[daID].chunks[0].payload[0] == record.chunks[0].payload[0] {
-		t.Fatalf("returned complete record aliases stored payload")
+	if len(record.chunks[0].payload) != 0 || len(state.sets[daID].chunks[0].payload) != 0 {
+		t.Fatalf("complete set retained chunk payload copy")
 	}
 }
 
@@ -807,6 +813,16 @@ func TestDARelayCompleteSetCandidatesExposeOnlyCompleteImmutableOrdered(t *testi
 	mustAddDAChunk(t, state, "peer-e", daRelayTestChunkWithTxBytes(lateID, 0, 14, []byte("chunk-late-0"), latePayload))
 	mustAddDAChunk(t, state, "peer-f", daRelayTestChunkWithTxBytes(earlyID, 1, 15, []byte("chunk-early-1"), earlyPayload1))
 	mustAddDAChunk(t, state, "peer-g", daRelayTestChunkWithTxBytes(earlyID, 0, 16, []byte("chunk-early-0"), earlyPayload0))
+	for _, daID := range [][32]byte{earlyID, lateID} {
+		for index, chunk := range state.sets[daID].chunks {
+			if len(chunk.payload) != 0 {
+				t.Fatalf("complete set %x chunk %d retained payload copy", daID, index)
+			}
+			if len(chunk.txBytes) == 0 {
+				t.Fatalf("complete set %x chunk %d lost tx bytes", daID, index)
+			}
+		}
+	}
 
 	candidates := state.completeSetCandidates()
 	if len(candidates) != 2 {

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -794,6 +794,56 @@ func TestDARelayCommitCompletesOrphanChunks(t *testing.T) {
 	}
 }
 
+func TestDARelayCompleteSetCandidatesExposeOnlyCompleteImmutableOrdered(t *testing.T) {
+	state := newDARelayStateForTest(t, defaultDARelayCaps())
+	orphanID, stagedID := daRelayTestID(31), daRelayTestID(32)
+	lateID, earlyID := daRelayTestID(33), daRelayTestID(30)
+	latePayload, earlyPayload0, earlyPayload1 := []byte("late"), []byte("early-zero"), []byte("early-one")
+
+	mustAddDAChunk(t, state, "peer-a", daRelayTestChunkPayload(orphanID, 0, 10, []byte("orphan")))
+	mustAddDACommit(t, state, "peer-b", daRelayTestCommit(stagedID, 1, 11))
+	mustAddDACommit(t, state, "peer-c", daRelayTestCommitWithTxBytes(earlyID, 12, []byte("commit-early"), earlyPayload0, earlyPayload1))
+	mustAddDACommit(t, state, "peer-d", daRelayTestCommitWithTxBytes(lateID, 13, []byte("commit-late"), latePayload))
+	mustAddDAChunk(t, state, "peer-e", daRelayTestChunkWithTxBytes(lateID, 0, 14, []byte("chunk-late-0"), latePayload))
+	mustAddDAChunk(t, state, "peer-f", daRelayTestChunkWithTxBytes(earlyID, 1, 15, []byte("chunk-early-1"), earlyPayload1))
+	mustAddDAChunk(t, state, "peer-g", daRelayTestChunkWithTxBytes(earlyID, 0, 16, []byte("chunk-early-0"), earlyPayload0))
+
+	candidates := state.completeSetCandidates()
+	if len(candidates) != 2 {
+		t.Fatalf("complete candidates=%d, want 2", len(candidates))
+	}
+	if candidates[0].DAID != earlyID || candidates[1].DAID != lateID {
+		t.Fatalf("candidate order=%x,%x want %x,%x", candidates[0].DAID, candidates[1].DAID, earlyID, lateID)
+	}
+	if got := candidates[0].PayloadBytes; got != uint64(len(earlyPayload0)+len(earlyPayload1)) {
+		t.Fatalf("early payload bytes=%d, want %d", got, len(earlyPayload0)+len(earlyPayload1))
+	}
+	if !reflect.DeepEqual(candidates[0].CommitTx, []byte("commit-early")) {
+		t.Fatalf("early commit tx=%q", candidates[0].CommitTx)
+	}
+	if len(candidates[0].Chunks) != 2 || candidates[0].Chunks[0].Index != 0 || candidates[0].Chunks[1].Index != 1 {
+		t.Fatalf("early chunks=%+v, want indexes 0,1", candidates[0].Chunks)
+	}
+	candidates[0].CommitTx[0] = 'X'
+	candidates[0].Chunks[0].Tx[0] = 'Y'
+	again := state.completeSetCandidates()
+	if !reflect.DeepEqual(again[0].CommitTx, []byte("commit-early")) || !reflect.DeepEqual(again[0].Chunks[0].Tx, []byte("chunk-early-0")) {
+		t.Fatalf("candidate snapshot aliases state: commit=%q chunk=%q", again[0].CommitTx, again[0].Chunks[0].Tx)
+	}
+}
+
+func TestServiceCompleteDASetCandidatesNilSafe(t *testing.T) {
+	if got := (*Service)(nil).CompleteDASetCandidates(); got != nil {
+		t.Fatalf("nil service candidates=%v, want nil", got)
+	}
+	if got := (&Service{}).CompleteDASetCandidates(); got != nil {
+		t.Fatalf("service without relay candidates=%v, want nil", got)
+	}
+	if got := (*daRelayState)(nil).completeSetCandidates(); got != nil {
+		t.Fatalf("nil state candidates=%v, want nil", got)
+	}
+}
+
 func TestDARelayCloneModesKeepStateCopiesShallowAndCallerCopiesDeep(t *testing.T) {
 	daID := daRelayTestID(7)
 	record := daRelaySetRecord{
@@ -1356,6 +1406,18 @@ func daRelayTestChunkPayload(daID [32]byte, index uint16, wireBytes uint64, payl
 
 func daRelayTestCommitForPayloads(daID [32]byte, wireBytes uint64, payloads ...[]byte) daRelayCommit {
 	return daRelayCommit{daID: daID, payloadCommitment: daRelayPayloadCommitment(payloads...), chunkCount: uint16(len(payloads)), wireBytes: wireBytes}
+}
+
+func daRelayTestCommitWithTxBytes(daID [32]byte, wireBytes uint64, txBytes []byte, payloads ...[]byte) daRelayCommit {
+	commit := daRelayTestCommitForPayloads(daID, wireBytes, payloads...)
+	commit.txBytes = cloneBytes(txBytes)
+	return commit
+}
+
+func daRelayTestChunkWithTxBytes(daID [32]byte, index uint16, wireBytes uint64, txBytes []byte, payload []byte) daRelayChunk {
+	chunk := daRelayTestChunkPayload(daID, index, wireBytes, payload)
+	chunk.txBytes = cloneBytes(txBytes)
+	return chunk
 }
 
 func daRelayOverflowOrphanAccountingRecord(daID [32]byte) daRelaySetRecord {

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -499,17 +499,18 @@ func TestDARelayRejectsDuplicatesBeforeMutation(t *testing.T) {
 		t.Fatalf("duplicate commit received_time=%d, want first-seen %d", got, record.receivedTime)
 	}
 
-	chunk := daRelayTestChunkWithTxBytes(daID, 0, 7, []byte("first-chunk"), []byte{1})
+	chunk := daRelayTestChunkWithTxBytes(daID, 0, 7, []byte{'a', 1, 'b'}, []byte{1})
 	record = mustAddDAChunk(t, state, "peer-c", chunk)
-	duplicateChunk := daRelayTestChunkWithTxBytes(daID, 0, 11, []byte("duplicate-chunk"), []byte{1})
+	duplicateChunk := daRelayTestChunkWithTxBytes(daID, 0, 11, []byte{'d', 1, 'e'}, []byte{1})
 	duplicateChunk.chunkHash[0] ^= 0xff
 	_, err = state.addDAChunk("peer-d", duplicateChunk)
 	requireDAErr(t, err, errDARelayDuplicateChunk)
 	duplicateChunk.txBytes[0] = 'X'
-	if len(state.sets[daID].chunks) != 1 || state.orphanBytes != record.wireBytes {
-		t.Fatalf("duplicate chunk mutated state: chunks=%d orphan=%d want orphan=%d", len(state.sets[daID].chunks), state.orphanBytes, record.wireBytes)
+	wantOrphanBytes := record.wireBytes + uint64(len(chunk.payload))
+	if len(state.sets[daID].chunks) != 1 || state.orphanBytes != wantOrphanBytes {
+		t.Fatalf("duplicate chunk mutated state: chunks=%d orphan=%d want orphan=%d", len(state.sets[daID].chunks), state.orphanBytes, wantOrphanBytes)
 	}
-	if !reflect.DeepEqual(state.sets[daID].chunks[0].txBytes, []byte("first-chunk")) {
+	if !reflect.DeepEqual(state.sets[daID].chunks[0].txBytes, []byte{'a', 1, 'b'}) {
 		t.Fatalf("duplicate chunk mutated stored tx bytes: %q", state.sets[daID].chunks[0].txBytes)
 	}
 }
@@ -829,7 +830,7 @@ func TestDARelayCompleteSetCandidatesExposeOnlyCompleteImmutableOrdered(t *testi
 		}
 	}
 
-	candidates := state.completeSetCandidates()
+	candidates := state.completeSetCandidates(^uint64(0))
 	if len(candidates) != 2 {
 		t.Fatalf("complete candidates=%d, want 2", len(candidates))
 	}
@@ -847,20 +848,24 @@ func TestDARelayCompleteSetCandidatesExposeOnlyCompleteImmutableOrdered(t *testi
 	}
 	candidates[0].CommitTx[0] = 'X'
 	candidates[0].Chunks[0].Tx[0] = 'Y'
-	again := state.completeSetCandidates()
+	again := state.completeSetCandidates(^uint64(0))
 	if !reflect.DeepEqual(again[0].CommitTx, []byte("commit-early")) || !reflect.DeepEqual(again[0].Chunks[0].Tx, []byte("chunk-early-0")) {
 		t.Fatalf("candidate snapshot aliases state: commit=%q chunk=%q", again[0].CommitTx, again[0].Chunks[0].Tx)
+	}
+	earlyPayloadBytes := uint64(len(earlyPayload0) + len(earlyPayload1))
+	if got := state.completeSetCandidates(earlyPayloadBytes); len(got) != 1 || got[0].DAID != earlyID {
+		t.Fatalf("bounded candidates=%+v, want only early da_id", got)
 	}
 }
 
 func TestServiceCompleteDASetCandidatesNilSafe(t *testing.T) {
-	if got := (*Service)(nil).CompleteDASetCandidates(); got != nil {
+	if got := (*Service)(nil).CompleteDASetCandidates(1); got != nil {
 		t.Fatalf("nil service candidates=%v, want nil", got)
 	}
-	if got := (&Service{}).CompleteDASetCandidates(); got != nil {
+	if got := (&Service{}).CompleteDASetCandidates(1); got != nil {
 		t.Fatalf("service without relay candidates=%v, want nil", got)
 	}
-	if got := (*daRelayState)(nil).completeSetCandidates(); got != nil {
+	if got := (*daRelayState)(nil).completeSetCandidates(1); got != nil {
 		t.Fatalf("nil state candidates=%v, want nil", got)
 	}
 }

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -499,13 +499,18 @@ func TestDARelayRejectsDuplicatesBeforeMutation(t *testing.T) {
 		t.Fatalf("duplicate commit received_time=%d, want first-seen %d", got, record.receivedTime)
 	}
 
-	chunk := daRelayTestChunk(daID, 0, 7)
+	chunk := daRelayTestChunkWithTxBytes(daID, 0, 7, []byte("first-chunk"), []byte{1})
 	record = mustAddDAChunk(t, state, "peer-c", chunk)
-	chunk.chunkHash[0] ^= 0xff
-	_, err = state.addDAChunk("peer-d", chunk)
+	duplicateChunk := daRelayTestChunkWithTxBytes(daID, 0, 11, []byte("duplicate-chunk"), []byte{1})
+	duplicateChunk.chunkHash[0] ^= 0xff
+	_, err = state.addDAChunk("peer-d", duplicateChunk)
 	requireDAErr(t, err, errDARelayDuplicateChunk)
+	duplicateChunk.txBytes[0] = 'X'
 	if len(state.sets[daID].chunks) != 1 || state.orphanBytes != record.wireBytes {
 		t.Fatalf("duplicate chunk mutated state: chunks=%d orphan=%d want orphan=%d", len(state.sets[daID].chunks), state.orphanBytes, record.wireBytes)
+	}
+	if !reflect.DeepEqual(state.sets[daID].chunks[0].txBytes, []byte("first-chunk")) {
+		t.Fatalf("duplicate chunk mutated stored tx bytes: %q", state.sets[daID].chunks[0].txBytes)
 	}
 }
 

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -856,6 +856,10 @@ func TestDARelayCompleteSetCandidatesExposeOnlyCompleteImmutableOrdered(t *testi
 	if got := state.completeSetCandidates(earlyPayloadBytes); len(got) != 1 || got[0].DAID != earlyID {
 		t.Fatalf("bounded candidates=%+v, want only early da_id", got)
 	}
+	latePayloadBytes := uint64(len(latePayload))
+	if got := state.completeSetCandidates(latePayloadBytes); len(got) != 1 || got[0].DAID != lateID {
+		t.Fatalf("oversized early candidate blocked later fit=%+v, want only late da_id", got)
+	}
 }
 
 func TestServiceCompleteDASetCandidatesNilSafe(t *testing.T) {

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -868,9 +868,10 @@ func TestServiceCompleteDASetCandidatesNilSafe(t *testing.T) {
 func TestDARelayCloneModesKeepStateCopiesShallowAndCallerCopiesDeep(t *testing.T) {
 	daID := daRelayTestID(7)
 	record := daRelaySetRecord{
-		daID: daID,
+		daID:   daID,
+		commit: daRelayCommit{txBytes: []byte("commit-tx")},
 		chunks: map[uint16]daRelayChunk{
-			0: daRelayTestChunkPayload(daID, 0, 17, []byte("immutable-payload")),
+			0: daRelayTestChunkWithTxBytes(daID, 0, 17, []byte("chunk-tx"), []byte("immutable-payload")),
 		},
 		replaceableChunks: map[uint16]bool{0: true},
 	}
@@ -880,6 +881,9 @@ func TestDARelayCloneModesKeepStateCopiesShallowAndCallerCopiesDeep(t *testing.T
 	stateChunk := stateClone.chunks[0]
 	if &stateChunk.payload[0] != &originalChunk.payload[0] {
 		t.Fatalf("state mutation clone deep-copied payload")
+	}
+	if &stateChunk.txBytes[0] != &originalChunk.txBytes[0] {
+		t.Fatalf("state mutation clone deep-copied tx bytes")
 	}
 	stateClone.chunks[1] = daRelayTestChunkPayload(daID, 1, 1, []byte("second"))
 	if _, ok := record.chunks[1]; ok {
@@ -894,6 +898,9 @@ func TestDARelayCloneModesKeepStateCopiesShallowAndCallerCopiesDeep(t *testing.T
 	callerChunk := callerClone.chunks[0]
 	if &callerChunk.payload[0] == &originalChunk.payload[0] {
 		t.Fatalf("caller clone reused payload")
+	}
+	if callerClone.commit.txBytes != nil || callerChunk.txBytes != nil {
+		t.Fatalf("caller clone exposed internal tx bytes")
 	}
 	callerChunk.payload[0] ^= 0xff
 	callerClone.chunks[0] = callerChunk

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -1187,7 +1187,7 @@ func TestDARelayStageChunkRejectsDuplicateWithoutMutation(t *testing.T) {
 	record := mustAddDAChunk(t, state, "peer-a", chunk)
 
 	state.mu.Lock()
-	staged, err := state.stageDAChunkRecordLocked("peer-b", chunk, chunk.payload)
+	staged, err := state.stageDAChunkRecordLocked("peer-b", chunk, chunk.payload, false)
 	state.mu.Unlock()
 	requireDAErr(t, err, errDARelayDuplicateChunk)
 

--- a/clients/go/node/p2p/handlers_tx.go
+++ b/clients/go/node/p2p/handlers_tx.go
@@ -22,7 +22,7 @@ func (p *peer) handleTx(txBytes []byte) error {
 		}
 		return nil
 	}
-	tx, txid, err := parseCanonicalTx(txBytes)
+	_, txid, err := parseCanonicalTx(txBytes)
 	if err != nil {
 		if p.bumpBan(10, err.Error()) {
 			return err
@@ -35,17 +35,14 @@ func (p *peer) handleTx(txBytes []byte) error {
 	if !isNew {
 		return nil
 	}
-	meta, err := p.service.relayTxMetadata(txBytes)
+	admittedTxBytes, admittedTx, err := p.service.ensureRelayTxAdmitted(txid, txBytes)
 	if err != nil {
-		// Keep metadata rejections peer-neutral for Go/Rust relay parity:
-		// local policy/runtime state can reject a structurally valid tx, and
-		// Rust surfaces the same branch as non-banworthy MetadataRejected.
+		// Keep admission and metadata rejections peer-neutral for Go/Rust relay
+		// parity: local policy/runtime state can reject a structurally valid tx,
+		// and Rust surfaces the same branch as non-banworthy MetadataRejected.
 		return nil //nolint:nilerr
 	}
-	if !p.service.cfg.TxPool.Put(txid, txBytes, meta.Fee, meta.Size) {
-		return nil
-	}
-	_ = p.service.stageRelayDATx(p.addr(), txBytes, tx)
+	_ = p.service.stageRelayDATx(p.addr(), admittedTxBytes, admittedTx)
 	_ = p.service.broadcastInventory(p, []InventoryVector{{Type: MSG_TX, Hash: txid}})
 	return nil
 }

--- a/clients/go/node/p2p/handlers_tx_test.go
+++ b/clients/go/node/p2p/handlers_tx_test.go
@@ -1,6 +1,7 @@
 package p2p
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha3"
 	"errors"
@@ -94,6 +95,48 @@ func daChunkRelayTxBytes(t *testing.T, daID [32]byte, index uint16, nonce uint64
 		t.Fatalf("MarshalTx DA chunk: %v", err)
 	}
 	return raw
+}
+
+func sameTxIDWithSentinelWitness(t *testing.T, raw []byte) []byte {
+	t.Helper()
+	tx, txid, err := parseCanonicalTx(raw)
+	if err != nil {
+		t.Fatalf("parse canonical tx: %v", err)
+	}
+	tx.Witness = []consensus.WitnessItem{{SuiteID: consensus.SUITE_ID_SENTINEL}}
+	alt, err := consensus.MarshalTx(tx)
+	if err != nil {
+		t.Fatalf("MarshalTx alternate witness: %v", err)
+	}
+	altTxid, err := canonicalTxID(alt)
+	if err != nil {
+		t.Fatalf("alternate witness txid: %v", err)
+	}
+	if altTxid != txid || bytes.Equal(alt, raw) {
+		t.Fatalf("alternate witness txid=%x want %x different_bytes=%v", altTxid, txid, !bytes.Equal(alt, raw))
+	}
+	return alt
+}
+
+func sameTxIDWithDAPayload(t *testing.T, raw []byte, payload []byte) []byte {
+	t.Helper()
+	tx, txid, err := parseCanonicalTx(raw)
+	if err != nil {
+		t.Fatalf("parse canonical tx: %v", err)
+	}
+	tx.DaPayload = cloneBytes(payload)
+	alt, err := consensus.MarshalTx(tx)
+	if err != nil {
+		t.Fatalf("MarshalTx alternate DA payload: %v", err)
+	}
+	altTxid, err := canonicalTxID(alt)
+	if err != nil {
+		t.Fatalf("alternate DA payload txid: %v", err)
+	}
+	if altTxid != txid || bytes.Equal(alt, raw) {
+		t.Fatalf("alternate DA payload txid=%x want %x different_bytes=%v", altTxid, txid, !bytes.Equal(alt, raw))
+	}
+	return alt
 }
 
 func daRelayRecordSnapshot(t *testing.T, state *daRelayState, daID [32]byte) (daRelaySetRecord, bool) {
@@ -883,6 +926,192 @@ func TestAnnounceTxAlreadyAdmittedSkipsMetadataValidation(t *testing.T) {
 	}
 	if !h.service.txSeen.Has(txid) {
 		t.Fatal("announced tx should be marked seen after already-admitted broadcast")
+	}
+}
+
+func TestAnnounceTxStagesOnlyAdmittedDABytes(t *testing.T) {
+	h := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	pool := h.service.cfg.TxPool.(*MemoryTxPool)
+	daID := daRelayTestID(126)
+	payload := []byte("admitted-da-payload")
+	admittedCommit := daCommitRelayTxBytes(t, daID, 9401, payload)
+	admittedChunk := daChunkRelayTxBytes(t, daID, 0, 9402, payload)
+	commitID, err := canonicalTxID(admittedCommit)
+	if err != nil {
+		t.Fatalf("commit txid: %v", err)
+	}
+	chunkID, err := canonicalTxID(admittedChunk)
+	if err != nil {
+		t.Fatalf("chunk txid: %v", err)
+	}
+	if !putRelayTx(pool, commitID, admittedCommit) {
+		t.Fatal("preload admitted commit")
+	}
+	if !putRelayTx(pool, chunkID, admittedChunk) {
+		t.Fatal("preload admitted chunk")
+	}
+
+	alternateCommit := sameTxIDWithSentinelWitness(t, admittedCommit)
+	alternateChunk := sameTxIDWithDAPayload(t, admittedChunk, []byte("unadmitted-da-payload"))
+	if err := h.service.AnnounceTx(alternateCommit); err != nil {
+		t.Fatalf("AnnounceTx alternate commit: %v", err)
+	}
+	if err := h.service.AnnounceTx(alternateChunk); err != nil {
+		t.Fatalf("AnnounceTx alternate chunk: %v", err)
+	}
+
+	candidates := h.service.CompleteDASetCandidates(uint64(len(payload)))
+	if len(candidates) != 1 {
+		t.Fatalf("complete DA candidates=%d, want 1", len(candidates))
+	}
+	candidate := candidates[0]
+	if !bytes.Equal(candidate.CommitTx, admittedCommit) || bytes.Equal(candidate.CommitTx, alternateCommit) {
+		t.Fatalf("commit candidate is not admitted bytes")
+	}
+	if len(candidate.Chunks) != 1 || !bytes.Equal(candidate.Chunks[0].Tx, admittedChunk) || bytes.Equal(candidate.Chunks[0].Tx, alternateChunk) {
+		t.Fatalf("chunk candidate is not admitted bytes: chunks=%d", len(candidate.Chunks))
+	}
+
+	firstPinned := h.service.daRelay.pinnedPayloadBytes
+	if firstPinned == 0 {
+		t.Fatal("complete DA set did not pin provider accounting")
+	}
+	h.service.daRelay.caps.pinnedPayloadBytes = firstPinned
+	pool.Remove(chunkID)
+	if got := h.service.CompleteDASetCandidates(uint64(len(payload))); len(got) != 0 {
+		t.Fatalf("evicted DA chunk candidate still exposed: %d", len(got))
+	}
+	if _, ok := daRelayRecordSnapshot(t, h.service.daRelay, daID); ok || h.service.daRelay.pinnedPayloadBytes != 0 {
+		t.Fatalf("stale complete DA record not pruned ok=%v pinned=%d", ok, h.service.daRelay.pinnedPayloadBytes)
+	}
+
+	replacementID := daRelayTestID(127)
+	replacementCommit := daCommitRelayTxBytes(t, replacementID, 9403, payload)
+	replacementChunk := daChunkRelayTxBytes(t, replacementID, 0, 9404, payload)
+	if err := h.service.AnnounceTx(replacementCommit); err != nil {
+		t.Fatalf("AnnounceTx replacement commit: %v", err)
+	}
+	if err := h.service.AnnounceTx(replacementChunk); err != nil {
+		t.Fatalf("AnnounceTx replacement chunk: %v", err)
+	}
+	replacementCandidates := h.service.CompleteDASetCandidates(uint64(len(payload)))
+	if len(replacementCandidates) != 1 || replacementCandidates[0].DAID != replacementID {
+		t.Fatalf("replacement candidates=%+v, want replacement DAID", replacementCandidates)
+	}
+}
+
+func TestCompleteDASetPruneDoesNotRemoveRegeneratedDAID(t *testing.T) {
+	h := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	pool := h.service.cfg.TxPool.(*MemoryTxPool)
+	daID := daRelayTestID(129)
+	payload := []byte("regenerated-da-payload")
+	firstCommit := daCommitRelayTxBytes(t, daID, 9601, payload)
+	firstChunk := daChunkRelayTxBytes(t, daID, 0, 9602, payload)
+	if err := h.service.AnnounceTx(firstCommit); err != nil {
+		t.Fatalf("AnnounceTx first commit: %v", err)
+	}
+	if err := h.service.AnnounceTx(firstChunk); err != nil {
+		t.Fatalf("AnnounceTx first chunk: %v", err)
+	}
+	staleRecords := h.service.daRelay.completeSetCandidateRecordsSnapshot()
+	if len(staleRecords) != 1 {
+		t.Fatalf("stale snapshot records=%d, want 1", len(staleRecords))
+	}
+	firstCommitID, err := canonicalTxID(firstCommit)
+	if err != nil {
+		t.Fatalf("first commit txid: %v", err)
+	}
+	firstChunkID, err := canonicalTxID(firstChunk)
+	if err != nil {
+		t.Fatalf("first chunk txid: %v", err)
+	}
+	pool.Remove(firstCommitID)
+	pool.Remove(firstChunkID)
+
+	h.service.daRelay.mu.Lock()
+	firstRecord := h.service.daRelay.sets[daID]
+	if err := h.service.daRelay.removeDASetRecordLocked(firstRecord); err != nil {
+		h.service.daRelay.mu.Unlock()
+		t.Fatalf("remove first record: %v", err)
+	}
+	h.service.daRelay.mu.Unlock()
+
+	nextCommit := daCommitRelayTxBytes(t, daID, 9603, payload)
+	nextChunk := daChunkRelayTxBytes(t, daID, 0, 9604, payload)
+	if err := h.service.AnnounceTx(nextCommit); err != nil {
+		t.Fatalf("AnnounceTx next commit: %v", err)
+	}
+	if err := h.service.AnnounceTx(nextChunk); err != nil {
+		t.Fatalf("AnnounceTx next chunk: %v", err)
+	}
+	if err := h.service.pruneStaleCompleteSetRecords(staleRecords); err != nil {
+		t.Fatalf("delayed stale prune: %v", err)
+	}
+
+	candidates := h.service.CompleteDASetCandidates(uint64(len(payload)))
+	if len(candidates) != 1 || candidates[0].DAID != daID || !bytes.Equal(candidates[0].CommitTx, nextCommit) {
+		t.Fatalf("delayed stale prune removed regenerated candidate: %+v", candidates)
+	}
+}
+
+func TestHandleTxStagesOnlyAdmittedDABytes(t *testing.T) {
+	h := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	pool := NewMemoryTxPoolWithLimit(2)
+	h.service.cfg.TxPool = pool
+	p := daRelayTestPeer(h, "127.0.0.1:19114")
+	daID := daRelayTestID(128)
+	payload := []byte("handle-admitted-da-payload")
+	admittedCommit := daCommitRelayTxBytes(t, daID, 9501, payload)
+	admittedChunk := daChunkRelayTxBytes(t, daID, 0, 9502, payload)
+	commitID, err := canonicalTxID(admittedCommit)
+	if err != nil {
+		t.Fatalf("commit txid: %v", err)
+	}
+	chunkID, err := canonicalTxID(admittedChunk)
+	if err != nil {
+		t.Fatalf("chunk txid: %v", err)
+	}
+	if !putRelayTx(pool, commitID, admittedCommit) {
+		t.Fatal("preload admitted commit")
+	}
+	if !putRelayTx(pool, chunkID, admittedChunk) {
+		t.Fatal("preload admitted chunk")
+	}
+
+	alternateCommit := sameTxIDWithSentinelWitness(t, admittedCommit)
+	alternateChunk := sameTxIDWithDAPayload(t, admittedChunk, []byte("handle-unadmitted-da-payload"))
+	if err := p.handleTx(alternateCommit); err != nil {
+		t.Fatalf("handleTx alternate commit: %v", err)
+	}
+	if err := p.handleTx(alternateChunk); err != nil {
+		t.Fatalf("handleTx alternate chunk: %v", err)
+	}
+
+	candidates := h.service.CompleteDASetCandidates(uint64(len(payload)))
+	if len(candidates) != 1 {
+		t.Fatalf("complete DA candidates=%d, want 1", len(candidates))
+	}
+	candidate := candidates[0]
+	if !bytes.Equal(candidate.CommitTx, admittedCommit) || bytes.Equal(candidate.CommitTx, alternateCommit) {
+		t.Fatalf("commit candidate is not admitted bytes")
+	}
+	if len(candidate.Chunks) != 1 || !bytes.Equal(candidate.Chunks[0].Tx, admittedChunk) || bytes.Equal(candidate.Chunks[0].Tx, alternateChunk) {
+		t.Fatalf("chunk candidate is not admitted bytes: chunks=%d", len(candidate.Chunks))
+	}
+
+	evictor := distinctTxBytes(t, 9503)
+	evictorID, err := canonicalTxID(evictor)
+	if err != nil {
+		t.Fatalf("evictor txid: %v", err)
+	}
+	if !pool.Put(evictorID, evictor, uint64(len(evictor))*2, len(evictor)) {
+		t.Fatal("high-priority tx should evict one admitted DA tx")
+	}
+	if got := h.service.CompleteDASetCandidates(uint64(len(payload))); len(got) != 0 {
+		t.Fatalf("capacity-evicted DA candidate still exposed: %d", len(got))
+	}
+	if _, ok := daRelayRecordSnapshot(t, h.service.daRelay, daID); ok || h.service.daRelay.pinnedPayloadBytes != 0 {
+		t.Fatalf("capacity-evicted complete DA record not pruned ok=%v pinned=%d", ok, h.service.daRelay.pinnedPayloadBytes)
 	}
 }
 

--- a/clients/go/node/p2p/service.go
+++ b/clients/go/node/p2p/service.go
@@ -3,6 +3,7 @@ package p2p
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"strings"
 	"sync"
@@ -240,32 +241,43 @@ func (s *Service) AnnounceTx(txBytes []byte) error {
 	if s == nil {
 		return errors.New("nil service")
 	}
-	tx, txid, err := parseCanonicalTx(txBytes)
+	_, txid, err := parseCanonicalTx(txBytes)
 	if err != nil {
 		return err
 	}
-	if err := s.ensureRelayTxAdmitted(txid, txBytes); err != nil {
+	admittedTxBytes, admittedTx, err := s.ensureRelayTxAdmitted(txid, txBytes)
+	if err != nil {
 		return err
 	}
-	_ = s.stageRelayDATx("", txBytes, tx)
+	_ = s.stageRelayDATx("", admittedTxBytes, admittedTx)
 	if !s.txSeen.Add(txid) {
 		return nil
 	}
 	return s.broadcastInventory(nil, []InventoryVector{{Type: MSG_TX, Hash: txid}})
 }
 
-func (s *Service) ensureRelayTxAdmitted(txid [32]byte, txBytes []byte) error {
-	if s.cfg.TxPool.Has(txid) {
-		return nil
+func (s *Service) ensureRelayTxAdmitted(txid [32]byte, txBytes []byte) ([]byte, *consensus.Tx, error) {
+	if !s.cfg.TxPool.Has(txid) {
+		meta, err := s.relayTxMetadata(txBytes)
+		if err != nil {
+			return nil, nil, err
+		}
+		if !s.cfg.TxPool.Put(txid, txBytes, meta.Fee, meta.Size) && !s.cfg.TxPool.Has(txid) {
+			return nil, nil, errors.New("tx not admitted to relay pool")
+		}
 	}
-	meta, err := s.relayTxMetadata(txBytes)
+	admittedTxBytes, ok := s.cfg.TxPool.Get(txid)
+	if !ok {
+		return nil, nil, errors.New("admitted tx missing from relay pool")
+	}
+	admittedTx, admittedTxid, err := parseCanonicalTx(admittedTxBytes)
 	if err != nil {
-		return err
+		return nil, nil, fmt.Errorf("admitted tx is non-canonical: %w", err)
 	}
-	if s.cfg.TxPool.Put(txid, txBytes, meta.Fee, meta.Size) || s.cfg.TxPool.Has(txid) {
-		return nil
+	if admittedTxid != txid {
+		return nil, nil, errors.New("admitted txid mismatch")
 	}
-	return errors.New("tx not admitted to relay pool")
+	return admittedTxBytes, admittedTx, nil
 }
 
 func normalizePeerAddrs(addrs []string) []string {


### PR DESCRIPTION
Linear: RUB-370
Closes #1820

Invariant:
A miner-facing provider observes only immutable COMPLETE_SET DA relay candidates; incomplete ORPHAN_CHUNKS/STAGED_COMMIT state is not exposed as mineable.

Layer:
Go implementation/tests. No consensus change, no Rust parity claim.

Files changed:
- clients/go/node/miner_da_provider.go
- clients/go/node/p2p/da_relay_provider.go
- clients/go/node/p2p/da_relay_ingest.go
- clients/go/node/p2p/da_relay_state.go
- clients/go/node/p2p/da_relay_state_test.go
- clients/go/node/p2p/handlers_tx.go
- clients/go/node/p2p/handlers_tx_test.go
- clients/go/node/p2p/service.go

Tests:
- Focused provider/admission/stale-prune Go tests: PASS
- DA/miner/template focused Go tests: PASS
- p2p package Go tests: PASS
- Local core and Go-only coverage gates: PASS; diff coverage 88.94%, variation -0.07%

Behavior impact:
Adds an immutable provider snapshot surface for complete DA sets only. Provider snapshots are sourced from exact bytes currently admitted in the relay tx pool; stale complete-set records are pruned only when the current relay-state generation still matches the stale snapshot.

Known non-goals:
- No miner candidate selection changes.
- No cmd/rubin-node runtime wiring.
- DA relay admission remains complete-set-only for miner exposure, but retained incomplete chunk payload copies are now counted while raw tx bytes are retained before completion; provider snapshots also require exact current tx-pool admission and prune stale complete-set records after rechecking the same relay-state generation.
- No DA relay TTL, prefetch, consensus, spec, conformance, or Rust changes.
- No consensus, spec, conformance, or Rust changes.

