### PR TITLE
[Q-GO-P2P-DA-PROVIDER-TX-BYTE-BOUNDS-01] Bound DA provider tx-byte ownership

### DIFF
--- a/clients/go/node/p2p/da_relay_ingest.go
+++ b/clients/go/node/p2p/da_relay_ingest.go
@@ -1,6 +1,7 @@
 package p2p
 
 import (
+	"crypto/sha3"
 	"errors"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
@@ -63,6 +64,26 @@ func (s *Service) finishDAPrefetch(peerAddr string, daID [32]byte, record daRela
 		s.scheduleDAPrefetchSnapshot(peerAddr, daID)
 	}
 	return err
+}
+
+func validateRelayDATxForAdmission(txBytes []byte, tx *consensus.Tx) error {
+	if tx == nil || tx.TxKind != 0x02 || tx.DaChunkCore == nil {
+		return nil
+	}
+	chunk := daRelayChunk{
+		daID:       tx.DaChunkCore.DaID,
+		chunkHash:  tx.DaChunkCore.ChunkHash,
+		chunkIndex: tx.DaChunkCore.ChunkIndex,
+		payload:    tx.DaPayload,
+		wireBytes:  uint64(len(txBytes)),
+	}
+	if err := validateDAChunk(chunk); err != nil {
+		return err
+	}
+	if sha3.Sum256(tx.DaPayload) != tx.DaChunkCore.ChunkHash {
+		return errDARelayChunkHashMismatch
+	}
+	return nil
 }
 
 func (s *Service) scheduleDAPrefetchSnapshot(peerAddr string, daID [32]byte) {

--- a/clients/go/node/p2p/da_relay_ingest.go
+++ b/clients/go/node/p2p/da_relay_ingest.go
@@ -7,16 +7,17 @@ import (
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
 )
 
-func (s *Service) stageRelayDATx(peerAddr string, txBytes []byte, tx *consensus.Tx) error {
+func (s *Service) stageRelayDATx(peerAddr string, txBytes []byte, tx *consensus.Tx, hashChecked ...bool) error {
 	if s == nil || s.daRelay == nil || tx == nil {
 		return nil
 	}
 	wireBytes := uint64(len(txBytes))
+	checked := len(hashChecked) != 0 && hashChecked[0]
 	switch tx.TxKind {
 	case 0x01:
 		return s.stageRelayDACommitTx(peerAddr, txBytes, wireBytes, tx)
 	case 0x02:
-		return s.stageRelayDAChunkTx(peerAddr, txBytes, wireBytes, tx)
+		return s.stageRelayDAChunkTx(peerAddr, txBytes, wireBytes, tx, checked)
 	default:
 		return nil
 	}
@@ -40,17 +41,18 @@ func (s *Service) stageRelayDACommitTx(peerAddr string, txBytes []byte, wireByte
 	return s.finishDAPrefetch(peerAddr, tx.DaCommitCore.DaID, record, err)
 }
 
-func (s *Service) stageRelayDAChunkTx(peerAddr string, txBytes []byte, wireBytes uint64, tx *consensus.Tx) error {
+func (s *Service) stageRelayDAChunkTx(peerAddr string, txBytes []byte, wireBytes uint64, tx *consensus.Tx, hashChecked bool) error {
 	if tx.DaChunkCore == nil {
 		return nil
 	}
 	record, err := s.daRelay.addDAChunk(peerAddr, daRelayChunk{
-		daID:       tx.DaChunkCore.DaID,
-		chunkHash:  tx.DaChunkCore.ChunkHash,
-		chunkIndex: tx.DaChunkCore.ChunkIndex,
-		payload:    tx.DaPayload,
-		wireBytes:  wireBytes,
-		txBytes:    txBytes,
+		daID:        tx.DaChunkCore.DaID,
+		chunkHash:   tx.DaChunkCore.ChunkHash,
+		chunkIndex:  tx.DaChunkCore.ChunkIndex,
+		payload:     tx.DaPayload,
+		wireBytes:   wireBytes,
+		txBytes:     txBytes,
+		hashChecked: hashChecked,
 	})
 	return s.finishDAPrefetch(peerAddr, tx.DaChunkCore.DaID, record, err)
 }

--- a/clients/go/node/p2p/da_relay_ingest.go
+++ b/clients/go/node/p2p/da_relay_ingest.go
@@ -13,15 +13,15 @@ func (s *Service) stageRelayDATx(peerAddr string, txBytes []byte, tx *consensus.
 	wireBytes := uint64(len(txBytes))
 	switch tx.TxKind {
 	case 0x01:
-		return s.stageRelayDACommitTx(peerAddr, wireBytes, tx)
+		return s.stageRelayDACommitTx(peerAddr, txBytes, wireBytes, tx)
 	case 0x02:
-		return s.stageRelayDAChunkTx(peerAddr, wireBytes, tx)
+		return s.stageRelayDAChunkTx(peerAddr, txBytes, wireBytes, tx)
 	default:
 		return nil
 	}
 }
 
-func (s *Service) stageRelayDACommitTx(peerAddr string, wireBytes uint64, tx *consensus.Tx) error {
+func (s *Service) stageRelayDACommitTx(peerAddr string, txBytes []byte, wireBytes uint64, tx *consensus.Tx) error {
 	if tx.DaCommitCore == nil {
 		return nil
 	}
@@ -34,11 +34,12 @@ func (s *Service) stageRelayDACommitTx(peerAddr string, wireBytes uint64, tx *co
 		payloadCommitment: commitment,
 		chunkCount:        tx.DaCommitCore.ChunkCount,
 		wireBytes:         wireBytes,
+		txBytes:           txBytes,
 	})
 	return s.finishDAPrefetch(peerAddr, tx.DaCommitCore.DaID, record, err)
 }
 
-func (s *Service) stageRelayDAChunkTx(peerAddr string, wireBytes uint64, tx *consensus.Tx) error {
+func (s *Service) stageRelayDAChunkTx(peerAddr string, txBytes []byte, wireBytes uint64, tx *consensus.Tx) error {
 	if tx.DaChunkCore == nil {
 		return nil
 	}
@@ -48,6 +49,7 @@ func (s *Service) stageRelayDAChunkTx(peerAddr string, wireBytes uint64, tx *con
 		chunkIndex: tx.DaChunkCore.ChunkIndex,
 		payload:    tx.DaPayload,
 		wireBytes:  wireBytes,
+		txBytes:    txBytes,
 	})
 	return s.finishDAPrefetch(peerAddr, tx.DaChunkCore.DaID, record, err)
 }

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -369,12 +369,12 @@ func (s *daRelayState) addDACommit(peerAddr string, commit daRelayCommit) (daRel
 	commitTxBytesOwned := false
 	for {
 		s.mu.Lock()
-		record, err := s.stageDACommitRecordLocked(peerAddr, commit, commitTxBytesOwned)
+		record, commitTxBytesOwnedNow, err := s.stageDACommitRecordLocked(peerAddr, commit, commitTxBytesOwned)
 		if err != nil {
 			s.mu.Unlock()
 			return daRelaySetRecord{}, err
 		}
-		if !commitTxBytesOwned {
+		if !commitTxBytesOwned && commitTxBytesOwnedNow {
 			commit.txBytes = record.commit.txBytes
 			commitTxBytesOwned = true
 		}
@@ -408,10 +408,14 @@ func (s *daRelayState) addDACommit(peerAddr string, commit daRelayCommit) (daRel
 		}
 
 		s.mu.Lock()
-		record, err = s.stageDACommitRecordLocked(peerAddr, commit, commitTxBytesOwned)
+		record, commitTxBytesOwnedNow, err = s.stageDACommitRecordLocked(peerAddr, commit, commitTxBytesOwned)
 		if err != nil {
 			s.mu.Unlock()
 			return daRelaySetRecord{}, err
+		}
+		if !commitTxBytesOwned && commitTxBytesOwnedNow {
+			commit.txBytes = record.commit.txBytes
+			commitTxBytesOwned = true
 		}
 		if !snapshot.matchesRecord(record) {
 			s.mu.Unlock()
@@ -421,6 +425,15 @@ func (s *daRelayState) addDACommit(peerAddr string, commit daRelayCommit) (daRel
 		if err := record.recomputeOrphanTotals(); err != nil {
 			s.mu.Unlock()
 			return daRelaySetRecord{}, err
+		}
+		if err := s.checkDASetRecordCapsLocked(record); err != nil {
+			s.mu.Unlock()
+			return daRelaySetRecord{}, err
+		}
+		if !commitTxBytesOwned {
+			record.cloneRetainedTxBytes()
+			commit.txBytes = record.commit.txBytes
+			commitTxBytesOwned = true
 		}
 		if err := s.applyDASetRecordLocked(record); err != nil {
 			s.mu.Unlock()
@@ -452,12 +465,12 @@ func (s *daRelayState) addDAChunk(peerAddr string, chunk daRelayChunk) (daRelayS
 	chunkTxBytesOwned := false
 	for {
 		s.mu.Lock()
-		record, err := s.stageDAChunkRecordLocked(peerAddr, chunk, payload, chunkTxBytesOwned)
+		record, chunkTxBytesOwnedNow, err := s.stageDAChunkRecordLocked(peerAddr, chunk, payload, chunkTxBytesOwned)
 		if err != nil {
 			s.mu.Unlock()
 			return daRelaySetRecord{}, err
 		}
-		if !chunkTxBytesOwned {
+		if !chunkTxBytesOwned && chunkTxBytesOwnedNow {
 			stagedChunk := record.chunks[chunk.chunkIndex]
 			chunk.txBytes = stagedChunk.txBytes
 			chunkTxBytesOwned = true
@@ -490,10 +503,15 @@ func (s *daRelayState) addDAChunk(peerAddr string, chunk daRelayChunk) (daRelayS
 		}
 
 		s.mu.Lock()
-		record, err = s.stageDAChunkRecordLocked(peerAddr, chunk, payload, chunkTxBytesOwned)
+		record, chunkTxBytesOwnedNow, err = s.stageDAChunkRecordLocked(peerAddr, chunk, payload, chunkTxBytesOwned)
 		if err != nil {
 			s.mu.Unlock()
 			return daRelaySetRecord{}, err
+		}
+		if !chunkTxBytesOwned && chunkTxBytesOwnedNow {
+			stagedChunk := record.chunks[chunk.chunkIndex]
+			chunk.txBytes = stagedChunk.txBytes
+			chunkTxBytesOwned = true
 		}
 		if !snapshot.matchesRecord(record) {
 			s.mu.Unlock()
@@ -503,6 +521,16 @@ func (s *daRelayState) addDAChunk(peerAddr string, chunk daRelayChunk) (daRelayS
 		if err := record.recomputeOrphanTotals(); err != nil {
 			s.mu.Unlock()
 			return daRelaySetRecord{}, err
+		}
+		if err := s.checkDASetRecordCapsLocked(record); err != nil {
+			s.mu.Unlock()
+			return daRelaySetRecord{}, err
+		}
+		if !chunkTxBytesOwned {
+			record.cloneRetainedTxBytes()
+			stagedChunk := record.chunks[chunk.chunkIndex]
+			chunk.txBytes = stagedChunk.txBytes
+			chunkTxBytesOwned = true
 		}
 		if err := s.applyDASetRecordLocked(record); err != nil {
 			s.mu.Unlock()
@@ -515,15 +543,16 @@ func (s *daRelayState) addDAChunk(peerAddr string, chunk daRelayChunk) (daRelayS
 
 // txBytesOwned is only true for retrying a txBytes slice cloned by an earlier
 // successful staging call; first admission still clones after duplicate checks.
-func (s *daRelayState) stageDACommitRecordLocked(peerAddr string, commit daRelayCommit, txBytesOwned bool) (daRelaySetRecord, error) {
+func (s *daRelayState) stageDACommitRecordLocked(peerAddr string, commit daRelayCommit, txBytesOwned bool) (daRelaySetRecord, bool, error) {
 	record := s.sets[commit.daID].cloneForStateMutation()
 	record.ensureMaps()
 	if record.commit.chunkCount != 0 {
-		return daRelaySetRecord{}, errDARelayDuplicateCommit
+		return daRelaySetRecord{}, false, errDARelayDuplicateCommit
 	}
 	c := commit
 	c.peerQuotaKey = peerQuotaKey(peerAddr)
 	cloneTxBytes := !txBytesOwned && len(c.txBytes) != 0
+	txBytesOwnedNow := txBytesOwned || len(c.txBytes) == 0
 	txBytes := c.txBytes
 	record.daID = c.daID
 	record.commit = c
@@ -531,32 +560,35 @@ func (s *daRelayState) stageDACommitRecordLocked(peerAddr string, commit daRelay
 	record.state = daRelayStateStagedCommit
 	record.ttlBlocksRemaining = s.caps.orphanTTLBlocks
 	if err := s.assignFirstSeenReceivedTimeLocked(&record); err != nil {
-		return daRelaySetRecord{}, err
+		return daRelaySetRecord{}, false, err
 	}
 	if cloneTxBytes {
-		if !record.completeByShape() {
-			if err := record.recomputeOrphanTotals(); err != nil {
-				return daRelaySetRecord{}, err
-			}
-			if err := s.checkDASetRecordCapsLocked(record); err != nil {
-				return daRelaySetRecord{}, err
-			}
+		if record.completeByShape() {
+			return record, false, nil
+		}
+		if err := record.recomputeOrphanTotals(); err != nil {
+			return daRelaySetRecord{}, false, err
+		}
+		if err := s.checkDASetRecordCapsLocked(record); err != nil {
+			return daRelaySetRecord{}, false, err
 		}
 		c.txBytes = cloneBytes(txBytes)
 		record.commit = c
+		txBytesOwnedNow = true
 	}
-	return record, nil
+	return record, txBytesOwnedNow, nil
 }
 
 // txBytesOwned follows the same ownership contract as stageDACommitRecordLocked.
-func (s *daRelayState) stageDAChunkRecordLocked(peerAddr string, chunk daRelayChunk, payload []byte, txBytesOwned bool) (daRelaySetRecord, error) {
+func (s *daRelayState) stageDAChunkRecordLocked(peerAddr string, chunk daRelayChunk, payload []byte, txBytesOwned bool) (daRelaySetRecord, bool, error) {
 	record := s.sets[chunk.daID].cloneForStateMutation()
 	record.ensureMaps()
 	if err := record.validateChunkInsert(chunk.chunkIndex); err != nil {
-		return daRelaySetRecord{}, err
+		return daRelaySetRecord{}, false, err
 	}
 	chunk.peerQuotaKey = peerQuotaKey(peerAddr)
 	cloneTxBytes := !txBytesOwned && len(chunk.txBytes) != 0
+	txBytesOwnedNow := txBytesOwned || len(chunk.txBytes) == 0
 	txBytes := chunk.txBytes
 	record.daID = chunk.daID
 	if record.commit.chunkCount == 0 {
@@ -567,21 +599,23 @@ func (s *daRelayState) stageDAChunkRecordLocked(peerAddr string, chunk daRelayCh
 	record.chunks[chunk.chunkIndex] = chunk
 	delete(record.replaceableChunks, chunk.chunkIndex)
 	if err := s.assignFirstSeenReceivedTimeLocked(&record); err != nil {
-		return daRelaySetRecord{}, err
+		return daRelaySetRecord{}, false, err
 	}
 	if cloneTxBytes {
-		if !record.completeByShape() {
-			if err := record.recomputeOrphanTotals(); err != nil {
-				return daRelaySetRecord{}, err
-			}
-			if err := s.checkDASetRecordCapsLocked(record); err != nil {
-				return daRelaySetRecord{}, err
-			}
+		if record.completeByShape() {
+			return record, false, nil
+		}
+		if err := record.recomputeOrphanTotals(); err != nil {
+			return daRelaySetRecord{}, false, err
+		}
+		if err := s.checkDASetRecordCapsLocked(record); err != nil {
+			return daRelaySetRecord{}, false, err
 		}
 		chunk.txBytes = cloneBytes(txBytes)
 		record.chunks[chunk.chunkIndex] = chunk
+		txBytesOwnedNow = true
 	}
-	return record, nil
+	return record, txBytesOwnedNow, nil
 }
 
 func validateDAChunk(chunk daRelayChunk) error {
@@ -926,7 +960,7 @@ func (s *daRelayState) stageCommitDroppingMatchingCompletionChunks(peerAddr stri
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	record, err := s.stageDACommitRecordLocked(peerAddr, commit, txBytesOwned)
+	record, commitTxBytesOwned, err := s.stageDACommitRecordLocked(peerAddr, commit, txBytesOwned)
 	if err != nil {
 		return false, err
 	}
@@ -942,6 +976,12 @@ func (s *daRelayState) stageCommitDroppingMatchingCompletionChunks(peerAddr stri
 	record.state = daRelayStateStagedCommit
 	if err := record.recomputeOrphanTotals(); err != nil {
 		return false, err
+	}
+	if !commitTxBytesOwned {
+		if err := s.checkDASetRecordCapsLocked(record); err != nil {
+			return false, err
+		}
+		record.cloneRetainedTxBytes()
 	}
 	if err := s.applyDASetRecordLocked(record); err != nil {
 		return false, err
@@ -1041,6 +1081,19 @@ func (r *daRelaySetRecord) markComplete(payloadBytes uint64) {
 	r.replaceableChunks = nil
 	for index, chunk := range r.chunks {
 		chunk.payload = nil
+		r.chunks[index] = chunk
+	}
+}
+
+func (r *daRelaySetRecord) cloneRetainedTxBytes() {
+	if len(r.commit.txBytes) != 0 {
+		r.commit.txBytes = cloneBytes(r.commit.txBytes)
+	}
+	for index, chunk := range r.chunks {
+		if len(chunk.txBytes) == 0 {
+			continue
+		}
+		chunk.txBytes = cloneBytes(chunk.txBytes)
 		r.chunks[index] = chunk
 	}
 }

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -143,6 +143,7 @@ type daRelayCommit struct {
 	peerQuotaKey      string
 	chunkCount        uint16
 	wireBytes         uint64
+	txBytes           []byte
 }
 
 type daRelayChunk struct {
@@ -152,6 +153,7 @@ type daRelayChunk struct {
 	chunkIndex   uint16
 	payload      []byte
 	wireBytes    uint64
+	txBytes      []byte
 }
 
 type daRelayCompletionSnapshot struct {
@@ -363,12 +365,17 @@ func (s *daRelayState) addDACommit(peerAddr string, commit daRelayCommit) (daRel
 		return daRelaySetRecord{}, errDARelayWireBytesInvalid
 	}
 
+	commitTxBytesOwned := false
 	for {
 		s.mu.Lock()
-		record, err := s.stageDACommitRecordLocked(peerAddr, commit)
+		record, err := s.stageDACommitRecordLocked(peerAddr, commit, commitTxBytesOwned)
 		if err != nil {
 			s.mu.Unlock()
 			return daRelaySetRecord{}, err
+		}
+		if !commitTxBytesOwned {
+			commit.txBytes = record.commit.txBytes
+			commitTxBytesOwned = true
 		}
 		snapshot, complete := record.completionSnapshot()
 		if !complete {
@@ -389,7 +396,7 @@ func (s *daRelayState) addDACommit(peerAddr string, commit daRelayCommit) (daRel
 		if payloadCommitment != snapshot.payloadCommitmentExpected {
 			// Commit metadata is the first-seen authority for duplicate handling;
 			// orphan chunks are provisional until they match that commit.
-			applied, err := s.stageCommitDroppingMatchingCompletionChunks(peerAddr, commit, snapshot)
+			applied, err := s.stageCommitDroppingMatchingCompletionChunks(peerAddr, commit, commitTxBytesOwned, snapshot)
 			if err != nil {
 				return daRelaySetRecord{}, err
 			}
@@ -400,7 +407,7 @@ func (s *daRelayState) addDACommit(peerAddr string, commit daRelayCommit) (daRel
 		}
 
 		s.mu.Lock()
-		record, err = s.stageDACommitRecordLocked(peerAddr, commit)
+		record, err = s.stageDACommitRecordLocked(peerAddr, commit, commitTxBytesOwned)
 		if err != nil {
 			s.mu.Unlock()
 			return daRelaySetRecord{}, err
@@ -441,12 +448,18 @@ func (s *daRelayState) addDAChunk(peerAddr string, chunk daRelayChunk) (daRelayS
 	}
 	payload := cloneBytes(chunk.payload)
 
+	chunkTxBytesOwned := false
 	for {
 		s.mu.Lock()
-		record, err := s.stageDAChunkRecordLocked(peerAddr, chunk, payload)
+		record, err := s.stageDAChunkRecordLocked(peerAddr, chunk, payload, chunkTxBytesOwned)
 		if err != nil {
 			s.mu.Unlock()
 			return daRelaySetRecord{}, err
+		}
+		if !chunkTxBytesOwned {
+			stagedChunk := record.chunks[chunk.chunkIndex]
+			chunk.txBytes = stagedChunk.txBytes
+			chunkTxBytesOwned = true
 		}
 		snapshot, complete := record.completionSnapshot()
 		if !complete {
@@ -476,7 +489,7 @@ func (s *daRelayState) addDAChunk(peerAddr string, chunk daRelayChunk) (daRelayS
 		}
 
 		s.mu.Lock()
-		record, err = s.stageDAChunkRecordLocked(peerAddr, chunk, payload)
+		record, err = s.stageDAChunkRecordLocked(peerAddr, chunk, payload, chunkTxBytesOwned)
 		if err != nil {
 			s.mu.Unlock()
 			return daRelaySetRecord{}, err
@@ -499,7 +512,9 @@ func (s *daRelayState) addDAChunk(peerAddr string, chunk daRelayChunk) (daRelayS
 	}
 }
 
-func (s *daRelayState) stageDACommitRecordLocked(peerAddr string, commit daRelayCommit) (daRelaySetRecord, error) {
+// txBytesOwned is only true for retrying a txBytes slice cloned by an earlier
+// successful staging call; first admission still clones after duplicate checks.
+func (s *daRelayState) stageDACommitRecordLocked(peerAddr string, commit daRelayCommit, txBytesOwned bool) (daRelaySetRecord, error) {
 	record := s.sets[commit.daID].cloneForStateMutation()
 	record.ensureMaps()
 	if record.commit.chunkCount != 0 {
@@ -507,6 +522,9 @@ func (s *daRelayState) stageDACommitRecordLocked(peerAddr string, commit daRelay
 	}
 	c := commit
 	c.peerQuotaKey = peerQuotaKey(peerAddr)
+	if !txBytesOwned {
+		c.txBytes = cloneBytes(c.txBytes)
+	}
 	record.daID = c.daID
 	record.commit = c
 	record.pruneChunksOutsideCommit()
@@ -518,13 +536,17 @@ func (s *daRelayState) stageDACommitRecordLocked(peerAddr string, commit daRelay
 	return record, nil
 }
 
-func (s *daRelayState) stageDAChunkRecordLocked(peerAddr string, chunk daRelayChunk, payload []byte) (daRelaySetRecord, error) {
+// txBytesOwned follows the same ownership contract as stageDACommitRecordLocked.
+func (s *daRelayState) stageDAChunkRecordLocked(peerAddr string, chunk daRelayChunk, payload []byte, txBytesOwned bool) (daRelaySetRecord, error) {
 	record := s.sets[chunk.daID].cloneForStateMutation()
 	record.ensureMaps()
 	if err := record.validateChunkInsert(chunk.chunkIndex); err != nil {
 		return daRelaySetRecord{}, err
 	}
 	chunk.peerQuotaKey = peerQuotaKey(peerAddr)
+	if !txBytesOwned {
+		chunk.txBytes = cloneBytes(chunk.txBytes)
+	}
 	record.daID = chunk.daID
 	if record.commit.chunkCount == 0 {
 		record.state = daRelayStateOrphanChunks
@@ -723,11 +745,15 @@ func (r daRelaySetRecord) cloneForStateMutation() daRelaySetRecord {
 
 func (r daRelaySetRecord) cloneWithPayloads(copyPayloads bool) daRelaySetRecord {
 	out := r
+	if copyPayloads {
+		out.commit.txBytes = nil
+	}
 	if r.chunks != nil {
 		out.chunks = make(map[uint16]daRelayChunk, len(r.chunks))
 		for index, chunk := range r.chunks {
 			if copyPayloads {
 				chunk.payload = cloneBytes(chunk.payload)
+				chunk.txBytes = nil
 			}
 			out.chunks[index] = chunk
 		}
@@ -859,11 +885,11 @@ func (s daRelayCompletionSnapshot) payloadCommitment() (uint64, [32]byte) {
 	return payloadBytes, payloadCommitment
 }
 
-func (s *daRelayState) stageCommitDroppingMatchingCompletionChunks(peerAddr string, commit daRelayCommit, snapshot daRelayCompletionSnapshot) (bool, error) {
+func (s *daRelayState) stageCommitDroppingMatchingCompletionChunks(peerAddr string, commit daRelayCommit, txBytesOwned bool, snapshot daRelayCompletionSnapshot) (bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	record, err := s.stageDACommitRecordLocked(peerAddr, commit)
+	record, err := s.stageDACommitRecordLocked(peerAddr, commit, txBytesOwned)
 	if err != nil {
 		return false, err
 	}
@@ -976,6 +1002,10 @@ func (r *daRelaySetRecord) markComplete(payloadBytes uint64) {
 	r.state = daRelayStateCompleteSet
 	r.ttlBlocksRemaining = 0
 	r.replaceableChunks = nil
+	for index, chunk := range r.chunks {
+		chunk.payload = nil
+		r.chunks[index] = chunk
+	}
 }
 
 func (r *daRelaySetRecord) recomputeOrphanTotals() error {
@@ -1016,13 +1046,26 @@ func (r daRelaySetRecord) orphanAccounting() (daRelayRecordAccounting, error) {
 		return daRelayRecordAccounting{}, nil
 	}
 	accounting := daRelayRecordAccounting{peerBytes: map[string]uint64{}}
-	accounting.orphanBytes = r.wireBytes
+	accounting.orphanBytes = r.commit.wireBytes
 	accounting.commitBytes = r.commit.wireBytes
 	if err := addPeerAccounting(accounting.peerBytes, r.commit.peerQuotaKey, r.commit.wireBytes); err != nil {
 		return daRelayRecordAccounting{}, err
 	}
 	for _, chunk := range r.chunks {
-		if err := addPeerAccounting(accounting.peerBytes, chunk.peerQuotaKey, chunk.wireBytes); err != nil {
+		chunkBytes := chunk.wireBytes
+		if len(chunk.txBytes) != 0 && len(chunk.payload) != 0 {
+			var addErr error
+			chunkBytes, addErr = checkedAddUint64(chunkBytes, uint64(len(chunk.payload)))
+			if addErr != nil {
+				return daRelayRecordAccounting{}, addErr
+			}
+		}
+		orphanBytes, err := checkedAddUint64(accounting.orphanBytes, chunkBytes)
+		if err != nil {
+			return daRelayRecordAccounting{}, err
+		}
+		accounting.orphanBytes = orphanBytes
+		if err := addPeerAccounting(accounting.peerBytes, chunk.peerQuotaKey, chunkBytes); err != nil {
 			return daRelayRecordAccounting{}, err
 		}
 	}

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -523,9 +523,8 @@ func (s *daRelayState) stageDACommitRecordLocked(peerAddr string, commit daRelay
 	}
 	c := commit
 	c.peerQuotaKey = peerQuotaKey(peerAddr)
-	if !txBytesOwned {
-		c.txBytes = cloneBytes(c.txBytes)
-	}
+	cloneTxBytes := !txBytesOwned && len(c.txBytes) != 0
+	txBytes := c.txBytes
 	record.daID = c.daID
 	record.commit = c
 	record.pruneChunksOutsideCommit()
@@ -533,6 +532,16 @@ func (s *daRelayState) stageDACommitRecordLocked(peerAddr string, commit daRelay
 	record.ttlBlocksRemaining = s.caps.orphanTTLBlocks
 	if err := s.assignFirstSeenReceivedTimeLocked(&record); err != nil {
 		return daRelaySetRecord{}, err
+	}
+	if cloneTxBytes {
+		if err := record.recomputeOrphanTotals(); err != nil {
+			return daRelaySetRecord{}, err
+		}
+		if err := s.checkDASetRecordCapsLocked(record); err != nil {
+			return daRelaySetRecord{}, err
+		}
+		c.txBytes = cloneBytes(txBytes)
+		record.commit = c
 	}
 	return record, nil
 }

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -924,7 +924,7 @@ func (s *daRelayState) markMatchingCompletionChunksReplaceable(snapshot daRelayC
 	if !ok {
 		return false, nil
 	}
-	if len(indexes) != len(snapshot.chunks) {
+	if len(indexes) == 0 {
 		return false, nil
 	}
 	record.markChunksReplaceable(indexes)

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -154,6 +154,7 @@ type daRelayChunk struct {
 	payload      []byte
 	wireBytes    uint64
 	txBytes      []byte
+	hashChecked  bool
 }
 
 type daRelayCompletionSnapshot struct {
@@ -443,7 +444,7 @@ func (s *daRelayState) addDAChunk(peerAddr string, chunk daRelayChunk) (daRelayS
 	}
 	s.mu.Unlock()
 
-	if sha3.Sum256(chunk.payload) != chunk.chunkHash {
+	if !chunk.hashChecked && sha3.Sum256(chunk.payload) != chunk.chunkHash {
 		return daRelaySetRecord{}, errDARelayChunkHashMismatch
 	}
 	payload := cloneBytes(chunk.payload)

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -534,11 +534,13 @@ func (s *daRelayState) stageDACommitRecordLocked(peerAddr string, commit daRelay
 		return daRelaySetRecord{}, err
 	}
 	if cloneTxBytes {
-		if err := record.recomputeOrphanTotals(); err != nil {
-			return daRelaySetRecord{}, err
-		}
-		if err := s.checkDASetRecordCapsLocked(record); err != nil {
-			return daRelaySetRecord{}, err
+		if !record.completeByShape() {
+			if err := record.recomputeOrphanTotals(); err != nil {
+				return daRelaySetRecord{}, err
+			}
+			if err := s.checkDASetRecordCapsLocked(record); err != nil {
+				return daRelaySetRecord{}, err
+			}
 		}
 		c.txBytes = cloneBytes(txBytes)
 		record.commit = c
@@ -568,11 +570,13 @@ func (s *daRelayState) stageDAChunkRecordLocked(peerAddr string, chunk daRelayCh
 		return daRelaySetRecord{}, err
 	}
 	if cloneTxBytes {
-		if err := record.recomputeOrphanTotals(); err != nil {
-			return daRelaySetRecord{}, err
-		}
-		if err := s.checkDASetRecordCapsLocked(record); err != nil {
-			return daRelaySetRecord{}, err
+		if !record.completeByShape() {
+			if err := record.recomputeOrphanTotals(); err != nil {
+				return daRelaySetRecord{}, err
+			}
+			if err := s.checkDASetRecordCapsLocked(record); err != nil {
+				return daRelaySetRecord{}, err
+			}
 		}
 		chunk.txBytes = cloneBytes(txBytes)
 		record.chunks[chunk.chunkIndex] = chunk
@@ -901,6 +905,11 @@ func (r daRelaySetRecord) completionSnapshot() (daRelayCompletionSnapshot, bool)
 	return snapshot, true
 }
 
+func (r daRelaySetRecord) completeByShape() bool {
+	_, complete := r.completionSnapshot()
+	return complete
+}
+
 func (s daRelayCompletionSnapshot) payloadCommitment() (uint64, [32]byte) {
 	hasher := sha3.New256()
 	var payloadBytes uint64
@@ -1037,10 +1046,10 @@ func (r *daRelaySetRecord) markComplete(payloadBytes uint64) {
 }
 
 func (r *daRelaySetRecord) recomputeOrphanTotals() error {
-	r.wireBytes = r.commit.wireBytes
+	r.wireBytes = retainedTxAccountingBytes(r.commit.wireBytes, r.commit.txBytes)
 	for _, chunk := range r.chunks {
 		var err error
-		r.wireBytes, err = checkedAddUint64(r.wireBytes, chunk.wireBytes)
+		r.wireBytes, err = checkedAddUint64(r.wireBytes, retainedTxAccountingBytes(chunk.wireBytes, chunk.txBytes))
 		if err != nil {
 			return err
 		}
@@ -1070,17 +1079,18 @@ func (r daRelaySetRecord) pinnedPayloadAccountingBytes() (uint64, error) {
 }
 
 func (r daRelaySetRecord) orphanAccounting() (daRelayRecordAccounting, error) {
-	if r.state == daRelayStateCompleteSet || r.wireBytes == 0 {
+	if r.state == daRelayStateCompleteSet || (r.wireBytes == 0 && r.commit.wireBytes == 0 && len(r.commit.txBytes) == 0 && len(r.chunks) == 0) {
 		return daRelayRecordAccounting{}, nil
 	}
 	accounting := daRelayRecordAccounting{peerBytes: map[string]uint64{}}
-	accounting.orphanBytes = r.commit.wireBytes
-	accounting.commitBytes = r.commit.wireBytes
-	if err := addPeerAccounting(accounting.peerBytes, r.commit.peerQuotaKey, r.commit.wireBytes); err != nil {
+	commitBytes := retainedTxAccountingBytes(r.commit.wireBytes, r.commit.txBytes)
+	accounting.orphanBytes = commitBytes
+	accounting.commitBytes = commitBytes
+	if err := addPeerAccounting(accounting.peerBytes, r.commit.peerQuotaKey, commitBytes); err != nil {
 		return daRelayRecordAccounting{}, err
 	}
 	for _, chunk := range r.chunks {
-		chunkBytes := chunk.wireBytes
+		chunkBytes := retainedTxAccountingBytes(chunk.wireBytes, chunk.txBytes)
 		if len(chunk.txBytes) != 0 && len(chunk.payload) != 0 {
 			var addErr error
 			chunkBytes, addErr = checkedAddUint64(chunkBytes, uint64(len(chunk.payload)))
@@ -1098,6 +1108,13 @@ func (r daRelaySetRecord) orphanAccounting() (daRelayRecordAccounting, error) {
 		}
 	}
 	return accounting, nil
+}
+
+func retainedTxAccountingBytes(wireBytes uint64, txBytes []byte) uint64 {
+	if len(txBytes) != 0 {
+		return uint64(len(txBytes))
+	}
+	return wireBytes
 }
 
 func addPeerAccounting(peerBytes map[string]uint64, key string, bytes uint64) error {

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -838,7 +838,7 @@ func (r daRelaySetRecord) emptyIncomplete() bool {
 
 func (r daRelaySetRecord) validateChunkInsert(chunkIndex uint16) error {
 	if _, exists := r.chunks[chunkIndex]; exists {
-		if r.replaceableChunks[chunkIndex] {
+		if _, replaceable := r.replaceableChunks[chunkIndex]; replaceable {
 			return nil
 		}
 		return errDARelayDuplicateChunk
@@ -927,7 +927,7 @@ func (s *daRelayState) markMatchingCompletionChunksReplaceable(snapshot daRelayC
 	if len(indexes) == 0 {
 		return false, nil
 	}
-	record.markChunksReplaceable(indexes)
+	record.markChunksReplaceable(indexes, len(indexes) == len(snapshot.chunks))
 	if err := s.applyDASetRecordLocked(record); err != nil {
 		return false, err
 	}
@@ -956,12 +956,12 @@ func (r *daRelaySetRecord) dropChunks(indexes []uint16) {
 	}
 }
 
-func (r *daRelaySetRecord) markChunksReplaceable(indexes []uint16) {
+func (r *daRelaySetRecord) markChunksReplaceable(indexes []uint16, missing bool) {
 	if r.replaceableChunks == nil {
 		r.replaceableChunks = map[uint16]bool{}
 	}
 	for _, index := range indexes {
-		r.replaceableChunks[index] = true
+		r.replaceableChunks[index] = missing
 	}
 }
 

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -545,9 +545,8 @@ func (s *daRelayState) stageDAChunkRecordLocked(peerAddr string, chunk daRelayCh
 		return daRelaySetRecord{}, err
 	}
 	chunk.peerQuotaKey = peerQuotaKey(peerAddr)
-	if !txBytesOwned {
-		chunk.txBytes = cloneBytes(chunk.txBytes)
-	}
+	cloneTxBytes := !txBytesOwned && len(chunk.txBytes) != 0
+	txBytes := chunk.txBytes
 	record.daID = chunk.daID
 	if record.commit.chunkCount == 0 {
 		record.state = daRelayStateOrphanChunks
@@ -558,6 +557,16 @@ func (s *daRelayState) stageDAChunkRecordLocked(peerAddr string, chunk daRelayCh
 	delete(record.replaceableChunks, chunk.chunkIndex)
 	if err := s.assignFirstSeenReceivedTimeLocked(&record); err != nil {
 		return daRelaySetRecord{}, err
+	}
+	if cloneTxBytes {
+		if err := record.recomputeOrphanTotals(); err != nil {
+			return daRelaySetRecord{}, err
+		}
+		if err := s.checkDASetRecordCapsLocked(record); err != nil {
+			return daRelaySetRecord{}, err
+		}
+		chunk.txBytes = cloneBytes(txBytes)
+		record.chunks[chunk.chunkIndex] = chunk
 	}
 	return record, nil
 }
@@ -596,6 +605,15 @@ func (s *daRelayState) applyDASetRecordLocked(record daRelaySetRecord) error {
 		s.nextReceivedTime = record.receivedTime
 	}
 	return nil
+}
+
+func (s *daRelayState) checkDASetRecordCapsLocked(record daRelaySetRecord) error {
+	oldRecord := s.sets[record.daID]
+	if _, _, _, _, err := s.projectOrphanAccountingDeltaLocked(oldRecord, record); err != nil {
+		return err
+	}
+	_, err := s.projectPinnedPayloadDeltaLocked(oldRecord, record)
+	return err
 }
 
 func (s *daRelayState) removeDASetRecordLocked(record daRelaySetRecord) error {
@@ -839,7 +857,7 @@ func (r daRelaySetRecord) emptyIncomplete() bool {
 
 func (r daRelaySetRecord) validateChunkInsert(chunkIndex uint16) error {
 	if _, exists := r.chunks[chunkIndex]; exists {
-		if _, replaceable := r.replaceableChunks[chunkIndex]; replaceable {
+		if r.replaceableChunks[chunkIndex] {
 			return nil
 		}
 		return errDARelayDuplicateChunk

--- a/clients/go/node/p2p/da_relay_state.go
+++ b/clients/go/node/p2p/da_relay_state.go
@@ -952,10 +952,10 @@ func (s *daRelayState) markMatchingCompletionChunksReplaceable(snapshot daRelayC
 	if !ok {
 		return false, nil
 	}
-	if len(indexes) == 0 {
+	if len(indexes) != len(snapshot.chunks) {
 		return false, nil
 	}
-	record.markChunksReplaceable(indexes, len(indexes) == len(snapshot.chunks))
+	record.markChunksReplaceable(indexes)
 	if err := s.applyDASetRecordLocked(record); err != nil {
 		return false, err
 	}
@@ -984,12 +984,12 @@ func (r *daRelaySetRecord) dropChunks(indexes []uint16) {
 	}
 }
 
-func (r *daRelaySetRecord) markChunksReplaceable(indexes []uint16, missing bool) {
+func (r *daRelaySetRecord) markChunksReplaceable(indexes []uint16) {
 	if r.replaceableChunks == nil {
 		r.replaceableChunks = map[uint16]bool{}
 	}
 	for _, index := range indexes {
-		r.replaceableChunks[index] = missing
+		r.replaceableChunks[index] = true
 	}
 }
 

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -499,13 +499,19 @@ func TestDARelayRejectsDuplicatesBeforeMutation(t *testing.T) {
 		t.Fatalf("duplicate commit received_time=%d, want first-seen %d", got, record.receivedTime)
 	}
 
-	chunk := daRelayTestChunk(daID, 0, 7)
+	chunk := daRelayTestChunkWithTxBytes(daID, 0, 7, []byte{'a', 1, 'b'}, []byte{1})
 	record = mustAddDAChunk(t, state, "peer-c", chunk)
-	chunk.chunkHash[0] ^= 0xff
-	_, err = state.addDAChunk("peer-d", chunk)
+	duplicateChunk := daRelayTestChunkWithTxBytes(daID, 0, 11, []byte{'d', 1, 'e'}, []byte{1})
+	duplicateChunk.chunkHash[0] ^= 0xff
+	_, err = state.addDAChunk("peer-d", duplicateChunk)
 	requireDAErr(t, err, errDARelayDuplicateChunk)
-	if len(state.sets[daID].chunks) != 1 || state.orphanBytes != record.wireBytes {
-		t.Fatalf("duplicate chunk mutated state: chunks=%d orphan=%d want orphan=%d", len(state.sets[daID].chunks), state.orphanBytes, record.wireBytes)
+	duplicateChunk.txBytes[0] = 'X'
+	wantOrphanBytes := record.wireBytes + uint64(len(chunk.payload))
+	if len(state.sets[daID].chunks) != 1 || state.orphanBytes != wantOrphanBytes {
+		t.Fatalf("duplicate chunk mutated state: chunks=%d orphan=%d want orphan=%d", len(state.sets[daID].chunks), state.orphanBytes, wantOrphanBytes)
+	}
+	if !reflect.DeepEqual(state.sets[daID].chunks[0].txBytes, []byte{'a', 1, 'b'}) {
+		t.Fatalf("duplicate chunk mutated stored tx bytes: %q", state.sets[daID].chunks[0].txBytes)
 	}
 }
 
@@ -514,13 +520,20 @@ func TestDARelayDuplicateCommitAfterOrphanChunksKeepsFirstSeenState(t *testing.T
 	state := newDARelayStateForTest(t, defaultDARelayCaps())
 
 	mustAddDAChunk(t, state, "peer-a", daRelayTestChunk(daID, 0, 7))
-	record := mustAddDACommit(t, state, "peer-b", daRelayTestCommit(daID, 2, 3))
+	payload0 := []byte{1}
+	payload1 := []byte{2}
+	record := mustAddDACommit(t, state, "peer-b", daRelayTestCommitWithTxBytes(daID, 3, []byte("first-commit"), payload0, payload1))
 
-	_, err := state.addDACommit("peer-c", daRelayTestCommit(daID, 2, 11))
+	duplicate := daRelayTestCommitWithTxBytes(daID, 11, []byte("duplicate-commit"), payload0, payload1)
+	_, err := state.addDACommit("peer-c", duplicate)
 	requireDAErr(t, err, errDARelayDuplicateCommit)
+	duplicate.txBytes[0] = 'X'
 	stored := state.sets[daID]
 	if stored.commit.wireBytes != record.commit.wireBytes || stored.commit.peerQuotaKey != peerQuotaKey("peer-b") {
 		t.Fatalf("duplicate commit replaced first commit: wire=%d peer=%q", stored.commit.wireBytes, stored.commit.peerQuotaKey)
+	}
+	if !reflect.DeepEqual(stored.commit.txBytes, []byte("first-commit")) {
+		t.Fatalf("duplicate commit mutated stored tx bytes: %q", stored.commit.txBytes)
 	}
 	if stored.receivedTime != record.receivedTime || state.nextReceivedTime != record.receivedTime {
 		t.Fatalf("duplicate commit time record=%d state=%d want %d", stored.receivedTime, state.nextReceivedTime, record.receivedTime)
@@ -756,9 +769,8 @@ func TestDARelayCompletesSetAndPinsPayload(t *testing.T) {
 	if state.orphanBytes != 0 || len(state.orphanBytesByDAID) != 0 {
 		t.Fatalf("complete set left orphan accounting: global=%d da=%d", state.orphanBytes, len(state.orphanBytesByDAID))
 	}
-	record.chunks[0].payload[0] ^= 0xff
-	if state.sets[daID].chunks[0].payload[0] == record.chunks[0].payload[0] {
-		t.Fatalf("returned complete record aliases stored payload")
+	if len(record.chunks[0].payload) != 0 || len(state.sets[daID].chunks[0].payload) != 0 {
+		t.Fatalf("complete set retained chunk payload copy")
 	}
 }
 
@@ -797,9 +809,10 @@ func TestDARelayCommitCompletesOrphanChunks(t *testing.T) {
 func TestDARelayCloneModesKeepStateCopiesShallowAndCallerCopiesDeep(t *testing.T) {
 	daID := daRelayTestID(7)
 	record := daRelaySetRecord{
-		daID: daID,
+		daID:   daID,
+		commit: daRelayCommit{txBytes: []byte("commit-tx")},
 		chunks: map[uint16]daRelayChunk{
-			0: daRelayTestChunkPayload(daID, 0, 17, []byte("immutable-payload")),
+			0: daRelayTestChunkWithTxBytes(daID, 0, 17, []byte("chunk-tx"), []byte("immutable-payload")),
 		},
 		replaceableChunks: map[uint16]bool{0: true},
 	}
@@ -809,6 +822,9 @@ func TestDARelayCloneModesKeepStateCopiesShallowAndCallerCopiesDeep(t *testing.T
 	stateChunk := stateClone.chunks[0]
 	if &stateChunk.payload[0] != &originalChunk.payload[0] {
 		t.Fatalf("state mutation clone deep-copied payload")
+	}
+	if &stateChunk.txBytes[0] != &originalChunk.txBytes[0] {
+		t.Fatalf("state mutation clone deep-copied tx bytes")
 	}
 	stateClone.chunks[1] = daRelayTestChunkPayload(daID, 1, 1, []byte("second"))
 	if _, ok := record.chunks[1]; ok {
@@ -823,6 +839,9 @@ func TestDARelayCloneModesKeepStateCopiesShallowAndCallerCopiesDeep(t *testing.T
 	callerChunk := callerClone.chunks[0]
 	if &callerChunk.payload[0] == &originalChunk.payload[0] {
 		t.Fatalf("caller clone reused payload")
+	}
+	if callerClone.commit.txBytes != nil || callerChunk.txBytes != nil {
+		t.Fatalf("caller clone exposed internal tx bytes")
 	}
 	callerChunk.payload[0] ^= 0xff
 	callerClone.chunks[0] = callerChunk
@@ -1100,7 +1119,7 @@ func TestDARelayStageChunkRejectsDuplicateWithoutMutation(t *testing.T) {
 	record := mustAddDAChunk(t, state, "peer-a", chunk)
 
 	state.mu.Lock()
-	staged, err := state.stageDAChunkRecordLocked("peer-b", chunk, chunk.payload)
+	staged, err := state.stageDAChunkRecordLocked("peer-b", chunk, chunk.payload, false)
 	state.mu.Unlock()
 	requireDAErr(t, err, errDARelayDuplicateChunk)
 
@@ -1356,6 +1375,18 @@ func daRelayTestChunkPayload(daID [32]byte, index uint16, wireBytes uint64, payl
 
 func daRelayTestCommitForPayloads(daID [32]byte, wireBytes uint64, payloads ...[]byte) daRelayCommit {
 	return daRelayCommit{daID: daID, payloadCommitment: daRelayPayloadCommitment(payloads...), chunkCount: uint16(len(payloads)), wireBytes: wireBytes}
+}
+
+func daRelayTestCommitWithTxBytes(daID [32]byte, wireBytes uint64, txBytes []byte, payloads ...[]byte) daRelayCommit {
+	commit := daRelayTestCommitForPayloads(daID, wireBytes, payloads...)
+	commit.txBytes = cloneBytes(txBytes)
+	return commit
+}
+
+func daRelayTestChunkWithTxBytes(daID [32]byte, index uint16, wireBytes uint64, txBytes []byte, payload []byte) daRelayChunk {
+	chunk := daRelayTestChunkPayload(daID, index, wireBytes, payload)
+	chunk.txBytes = cloneBytes(txBytes)
+	return chunk
 }
 
 func daRelayOverflowOrphanAccountingRecord(daID [32]byte) daRelaySetRecord {

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -944,14 +944,15 @@ func TestDARelayRejectsIntegrityAndPinnedCapSafely(t *testing.T) {
 	_, err = state.addDAChunk("peer-c", daRelayTestChunkPayload(daID, 1, uint64(len(payload1)), payload1))
 	requireDAErr(t, err, errDARelayPayloadCommitmentMismatch)
 	record = state.sets[daID]
-	if record.replaceableChunks[0] || len(record.chunks) != 1 || state.pinnedPayloadBytes != 0 {
-		t.Fatalf("partial chunk mismatch mutated stale chunk: replaceable=%v chunks=%d pinned=%d", record.replaceableChunks, len(record.chunks), state.pinnedPayloadBytes)
-	}
-	if missing := record.missingChunkIndexes(); len(missing) != 1 || missing[0] != 1 {
-		t.Fatalf("partial chunk mismatch missing indexes=%v, want [1]", missing)
+	if !record.replaceableChunks[0] || len(record.chunks) != 1 || state.pinnedPayloadBytes != 0 {
+		t.Fatalf("partial chunk mismatch did not mark stale chunk replaceable: replaceable=%v chunks=%d pinned=%d", record.replaceableChunks, len(record.chunks), state.pinnedPayloadBytes)
 	}
 	if state.nextReceivedTime != beforeMismatchTime || record.receivedTime != beforeMismatchTime {
 		t.Fatalf("partial chunk mismatch time record=%d state=%d want first-seen %d", record.receivedTime, state.nextReceivedTime, beforeMismatchTime)
+	}
+	record = mustAddDAChunk(t, state, "peer-d", daRelayTestChunkPayload(daID, 0, uint64(len(payload0)), payload0))
+	if record = mustAddDAChunk(t, state, "peer-e", daRelayTestChunkPayload(daID, 1, uint64(len(payload1)), payload1)); record.state != daRelayStateCompleteSet {
+		t.Fatalf("state after stale chunk recovery=%v, want COMPLETE_SET", record.state)
 	}
 
 	state = newDARelayStateForTest(t, defaultDARelayCaps())
@@ -962,7 +963,8 @@ func TestDARelayRejectsIntegrityAndPinnedCapSafely(t *testing.T) {
 	if state.sets[daID].state != daRelayStateStagedCommit || len(state.sets[daID].chunks) != 1 || state.pinnedPayloadBytes != 0 {
 		t.Fatalf("chunk mismatch mutated staged chunks: state=%v chunks=%d pinned=%d", state.sets[daID].state, len(state.sets[daID].chunks), state.pinnedPayloadBytes)
 	}
-	record = mustAddDAChunk(t, state, "peer-c", daRelayTestChunkPayload(daID, 1, uint64(len(payload1)), payload1))
+	mustAddDAChunk(t, state, "peer-c", daRelayTestChunkPayload(daID, 1, uint64(len(payload1)), payload1))
+	record = mustAddDAChunk(t, state, "peer-b", daRelayTestChunkPayload(daID, 0, uint64(len(payload0)), payload0))
 	if record.state != daRelayStateCompleteSet {
 		t.Fatalf("state after partial mismatch recovery=%v, want COMPLETE_SET", record.state)
 	}
@@ -1103,7 +1105,7 @@ func TestDARelayRejectsMismatchApplyFailureBeforeMutation(t *testing.T) {
 		state.orphanBytesByPeerQuotaKey[peerQuotaKey("peer-b")] = 0
 
 		_, err := state.addDAChunk("peer-c", daRelayTestChunkPayload(daID, 1, uint64(len(payload1)), []byte("wrong")))
-		requireDAErr(t, err, errDARelayPayloadCommitmentMismatch)
+		requireDAErr(t, err, errDARelayArithmeticOverflow)
 
 		record := state.sets[daID]
 		if record.replaceableChunks[0] || len(record.chunks) != 1 || record.state != daRelayStateStagedCommit {

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -510,11 +510,16 @@ func TestDARelayCompletionIgnoresTransientOrphanCapsForRetainedTxBytes(t *testin
 		state := newDARelayStateForTest(t, caps)
 		daID := daRelayTestID(94)
 		payload := []byte{1}
+		commitTx := []byte("retained-commit-tx")
 		mustAddDAChunk(t, state, "peer-a", daRelayTestChunkPayload(daID, 0, 1, payload))
 
-		record := mustAddDACommit(t, state, "peer-b", daRelayTestCommitWithTxBytes(daID, 1, []byte("retained-commit-tx"), payload))
+		record := mustAddDACommit(t, state, "peer-b", daRelayTestCommitWithTxBytes(daID, 1, commitTx, payload))
 		if record.state != daRelayStateCompleteSet || state.orphanBytes != 0 || state.orphanCommitOverheadBytes != 0 {
 			t.Fatalf("commit completion state=%v orphan=%d commit=%d", record.state, state.orphanBytes, state.orphanCommitOverheadBytes)
+		}
+		commitTx[0] = 'X'
+		if !reflect.DeepEqual(state.sets[daID].commit.txBytes, []byte("retained-commit-tx")) {
+			t.Fatalf("complete commit retained caller txBytes alias: %q", state.sets[daID].commit.txBytes)
 		}
 	})
 
@@ -522,11 +527,52 @@ func TestDARelayCompletionIgnoresTransientOrphanCapsForRetainedTxBytes(t *testin
 		state := newDARelayStateForTest(t, caps)
 		daID := daRelayTestID(95)
 		payload := []byte{1}
+		chunkTx := []byte("retained-chunk-tx")
 		mustAddDACommit(t, state, "peer-a", daRelayTestCommitForPayloads(daID, 1, payload))
 
-		record := mustAddDAChunk(t, state, "peer-b", daRelayTestChunkWithTxBytes(daID, 0, 1, []byte("retained-chunk-tx"), payload))
+		record := mustAddDAChunk(t, state, "peer-b", daRelayTestChunkWithTxBytes(daID, 0, 1, chunkTx, payload))
 		if record.state != daRelayStateCompleteSet || state.orphanBytes != 0 || state.orphanCommitOverheadBytes != 0 {
 			t.Fatalf("chunk completion state=%v orphan=%d commit=%d", record.state, state.orphanBytes, state.orphanCommitOverheadBytes)
+		}
+		chunkTx[0] = 'X'
+		if !reflect.DeepEqual(state.sets[daID].chunks[0].txBytes, []byte("retained-chunk-tx")) {
+			t.Fatalf("complete chunk retained caller txBytes alias: %q", state.sets[daID].chunks[0].txBytes)
+		}
+	})
+
+	t.Run("commit completion checks pinned cap before retaining tx bytes", func(t *testing.T) {
+		rejectCaps := defaultDARelayCaps()
+		rejectCaps.pinnedPayloadBytes = 1
+		state := newDARelayStateForTest(t, rejectCaps)
+		daID := daRelayTestID(96)
+		payload := []byte{1}
+		commitTx := []byte("retained-commit-tx")
+		mustAddDAChunk(t, state, "peer-a", daRelayTestChunkPayload(daID, 0, 1, payload))
+
+		_, err := state.addDACommit("peer-b", daRelayTestCommitWithTxBytes(daID, 1, commitTx, payload))
+		requireDAErr(t, err, errDARelayPinnedPayloadCapExceeded)
+		commitTx[0] = 'X'
+		stored := state.sets[daID]
+		if stored.commit.chunkCount != 0 || len(stored.commit.txBytes) != 0 || state.pinnedPayloadBytes != 0 {
+			t.Fatalf("rejected complete commit retained state: commit=%d tx=%q pinned=%d", stored.commit.chunkCount, stored.commit.txBytes, state.pinnedPayloadBytes)
+		}
+	})
+
+	t.Run("chunk completion checks pinned cap before retaining tx bytes", func(t *testing.T) {
+		rejectCaps := defaultDARelayCaps()
+		rejectCaps.pinnedPayloadBytes = 1
+		state := newDARelayStateForTest(t, rejectCaps)
+		daID := daRelayTestID(97)
+		payload := []byte{1}
+		chunkTx := []byte("retained-chunk-tx")
+		mustAddDACommit(t, state, "peer-a", daRelayTestCommitForPayloads(daID, 1, payload))
+
+		_, err := state.addDAChunk("peer-b", daRelayTestChunkWithTxBytes(daID, 0, 1, chunkTx, payload))
+		requireDAErr(t, err, errDARelayPinnedPayloadCapExceeded)
+		chunkTx[0] = 'X'
+		stored := state.sets[daID]
+		if len(stored.chunks) != 0 || state.pinnedPayloadBytes != 0 {
+			t.Fatalf("rejected complete chunk retained state: chunks=%d pinned=%d", len(stored.chunks), state.pinnedPayloadBytes)
 		}
 	})
 }
@@ -1204,7 +1250,7 @@ func TestDARelayStageChunkRejectsDuplicateWithoutMutation(t *testing.T) {
 	record := mustAddDAChunk(t, state, "peer-a", chunk)
 
 	state.mu.Lock()
-	staged, err := state.stageDAChunkRecordLocked("peer-b", chunk, chunk.payload, false)
+	staged, _, err := state.stageDAChunkRecordLocked("peer-b", chunk, chunk.payload, false)
 	state.mu.Unlock()
 	requireDAErr(t, err, errDARelayDuplicateChunk)
 

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -944,8 +944,8 @@ func TestDARelayRejectsIntegrityAndPinnedCapSafely(t *testing.T) {
 	_, err = state.addDAChunk("peer-c", daRelayTestChunkPayload(daID, 1, uint64(len(payload1)), payload1))
 	requireDAErr(t, err, errDARelayPayloadCommitmentMismatch)
 	record = state.sets[daID]
-	if !record.replaceableChunks[0] || len(record.chunks) != 1 || state.pinnedPayloadBytes != 0 {
-		t.Fatalf("partial chunk mismatch did not mark stale chunk replaceable: replaceable=%v chunks=%d pinned=%d", record.replaceableChunks, len(record.chunks), state.pinnedPayloadBytes)
+	if _, ok := record.replaceableChunks[0]; !ok || record.replaceableChunks[0] || len(record.chunks) != 1 || state.pinnedPayloadBytes != 0 {
+		t.Fatalf("partial chunk mismatch did not allow stale replacement without prefetch taint: replaceable=%v chunks=%d pinned=%d", record.replaceableChunks, len(record.chunks), state.pinnedPayloadBytes)
 	}
 	if state.nextReceivedTime != beforeMismatchTime || record.receivedTime != beforeMismatchTime {
 		t.Fatalf("partial chunk mismatch time record=%d state=%d want first-seen %d", record.receivedTime, state.nextReceivedTime, beforeMismatchTime)
@@ -963,8 +963,7 @@ func TestDARelayRejectsIntegrityAndPinnedCapSafely(t *testing.T) {
 	if state.sets[daID].state != daRelayStateStagedCommit || len(state.sets[daID].chunks) != 1 || state.pinnedPayloadBytes != 0 {
 		t.Fatalf("chunk mismatch mutated staged chunks: state=%v chunks=%d pinned=%d", state.sets[daID].state, len(state.sets[daID].chunks), state.pinnedPayloadBytes)
 	}
-	mustAddDAChunk(t, state, "peer-c", daRelayTestChunkPayload(daID, 1, uint64(len(payload1)), payload1))
-	record = mustAddDAChunk(t, state, "peer-b", daRelayTestChunkPayload(daID, 0, uint64(len(payload0)), payload0))
+	record = mustAddDAChunk(t, state, "peer-c", daRelayTestChunkPayload(daID, 1, uint64(len(payload1)), payload1))
 	if record.state != daRelayStateCompleteSet {
 		t.Fatalf("state after partial mismatch recovery=%v, want COMPLETE_SET", record.state)
 	}

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -445,6 +445,92 @@ func TestDARelayZeroRecordAccountingDoesNotAllocatePeerBytes(t *testing.T) {
 	}
 }
 
+func TestDARelayAccountingUsesRetainedTxByteLengths(t *testing.T) {
+	daID := daRelayTestID(93)
+	payload := []byte("retained-payload")
+	commitTx := []byte("canonical-commit-tx")
+	chunkTx := []byte("canonical-chunk-tx")
+	record := daRelaySetRecord{
+		daID:  daID,
+		state: daRelayStateStagedCommit,
+		commit: daRelayCommit{
+			daID:         daID,
+			chunkCount:   1,
+			wireBytes:    1,
+			txBytes:      cloneBytes(commitTx),
+			peerQuotaKey: "commit-peer",
+		},
+		chunks: map[uint16]daRelayChunk{
+			0: {
+				daID:         daID,
+				chunkIndex:   0,
+				chunkHash:    sha3.Sum256(payload),
+				payload:      cloneBytes(payload),
+				wireBytes:    1,
+				txBytes:      cloneBytes(chunkTx),
+				peerQuotaKey: "chunk-peer",
+			},
+		},
+	}
+
+	if err := record.recomputeOrphanTotals(); err != nil {
+		t.Fatalf("recompute retained accounting: %v", err)
+	}
+	wantWire := uint64(len(commitTx) + len(chunkTx))
+	if record.wireBytes != wantWire {
+		t.Fatalf("record wire bytes=%d, want retained tx bytes %d", record.wireBytes, wantWire)
+	}
+
+	accounting, err := record.orphanAccounting()
+	if err != nil {
+		t.Fatalf("orphan retained accounting: %v", err)
+	}
+	wantOrphan := wantWire + uint64(len(payload))
+	if accounting.orphanBytes != wantOrphan || accounting.commitBytes != uint64(len(commitTx)) {
+		t.Fatalf("accounting orphan=%d commit=%d, want orphan=%d commit=%d", accounting.orphanBytes, accounting.commitBytes, wantOrphan, len(commitTx))
+	}
+	if accounting.peerBytes["commit-peer"] != uint64(len(commitTx)) {
+		t.Fatalf("commit peer bytes=%d, want %d", accounting.peerBytes["commit-peer"], len(commitTx))
+	}
+	wantChunkBytes := uint64(len(chunkTx) + len(payload))
+	if accounting.peerBytes["chunk-peer"] != wantChunkBytes {
+		t.Fatalf("chunk peer bytes=%d, want %d", accounting.peerBytes["chunk-peer"], wantChunkBytes)
+	}
+}
+
+func TestDARelayCompletionIgnoresTransientOrphanCapsForRetainedTxBytes(t *testing.T) {
+	caps := defaultDARelayCaps()
+	caps.orphanPoolBytes = 4
+	caps.orphanPoolPerPeerBytes = 4
+	caps.orphanPoolPerDAIDBytes = 4
+	caps.orphanCommitOverheadBytes = 4
+	caps.pinnedPayloadBytes = 1 << 20
+
+	t.Run("commit completes orphan chunk", func(t *testing.T) {
+		state := newDARelayStateForTest(t, caps)
+		daID := daRelayTestID(94)
+		payload := []byte{1}
+		mustAddDAChunk(t, state, "peer-a", daRelayTestChunkPayload(daID, 0, 1, payload))
+
+		record := mustAddDACommit(t, state, "peer-b", daRelayTestCommitWithTxBytes(daID, 1, []byte("retained-commit-tx"), payload))
+		if record.state != daRelayStateCompleteSet || state.orphanBytes != 0 || state.orphanCommitOverheadBytes != 0 {
+			t.Fatalf("commit completion state=%v orphan=%d commit=%d", record.state, state.orphanBytes, state.orphanCommitOverheadBytes)
+		}
+	})
+
+	t.Run("chunk completes staged commit", func(t *testing.T) {
+		state := newDARelayStateForTest(t, caps)
+		daID := daRelayTestID(95)
+		payload := []byte{1}
+		mustAddDACommit(t, state, "peer-a", daRelayTestCommitForPayloads(daID, 1, payload))
+
+		record := mustAddDAChunk(t, state, "peer-b", daRelayTestChunkWithTxBytes(daID, 0, 1, []byte("retained-chunk-tx"), payload))
+		if record.state != daRelayStateCompleteSet || state.orphanBytes != 0 || state.orphanCommitOverheadBytes != 0 {
+			t.Fatalf("chunk completion state=%v orphan=%d commit=%d", record.state, state.orphanBytes, state.orphanCommitOverheadBytes)
+		}
+	})
+}
+
 func TestDARelayRejectsZeroWireBytesBeforeMutation(t *testing.T) {
 	daID := daRelayTestID(3)
 	state := newDARelayStateForTest(t, defaultDARelayCaps())

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -950,10 +950,8 @@ func TestDARelayRejectsIntegrityAndPinnedCapSafely(t *testing.T) {
 	if state.nextReceivedTime != beforeMismatchTime || record.receivedTime != beforeMismatchTime {
 		t.Fatalf("partial chunk mismatch time record=%d state=%d want first-seen %d", record.receivedTime, state.nextReceivedTime, beforeMismatchTime)
 	}
-	record = mustAddDAChunk(t, state, "peer-d", daRelayTestChunkPayload(daID, 0, uint64(len(payload0)), payload0))
-	if record = mustAddDAChunk(t, state, "peer-e", daRelayTestChunkPayload(daID, 1, uint64(len(payload1)), payload1)); record.state != daRelayStateCompleteSet {
-		t.Fatalf("state after stale chunk recovery=%v, want COMPLETE_SET", record.state)
-	}
+	_, err = state.addDAChunk("peer-d", daRelayTestChunkPayload(daID, 0, uint64(len(payload0)), payload0))
+	requireDAErr(t, err, errDARelayDuplicateChunk)
 
 	state = newDARelayStateForTest(t, defaultDARelayCaps())
 	mustAddDACommit(t, state, "peer-a", daRelayTestCommitForPayloads(daID, 1, payload0, payload1))

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -944,8 +944,8 @@ func TestDARelayRejectsIntegrityAndPinnedCapSafely(t *testing.T) {
 	_, err = state.addDAChunk("peer-c", daRelayTestChunkPayload(daID, 1, uint64(len(payload1)), payload1))
 	requireDAErr(t, err, errDARelayPayloadCommitmentMismatch)
 	record = state.sets[daID]
-	if _, ok := record.replaceableChunks[0]; !ok || record.replaceableChunks[0] || len(record.chunks) != 1 || state.pinnedPayloadBytes != 0 {
-		t.Fatalf("partial chunk mismatch did not allow stale replacement without prefetch taint: replaceable=%v chunks=%d pinned=%d", record.replaceableChunks, len(record.chunks), state.pinnedPayloadBytes)
+	if _, ok := record.replaceableChunks[0]; ok || len(record.chunks) != 1 || state.pinnedPayloadBytes != 0 {
+		t.Fatalf("partial chunk mismatch tainted stale chunk replacement: replaceable=%v chunks=%d pinned=%d", record.replaceableChunks, len(record.chunks), state.pinnedPayloadBytes)
 	}
 	if state.nextReceivedTime != beforeMismatchTime || record.receivedTime != beforeMismatchTime {
 		t.Fatalf("partial chunk mismatch time record=%d state=%d want first-seen %d", record.receivedTime, state.nextReceivedTime, beforeMismatchTime)
@@ -965,7 +965,7 @@ func TestDARelayRejectsIntegrityAndPinnedCapSafely(t *testing.T) {
 	if record.state != daRelayStateCompleteSet {
 		t.Fatalf("state after partial mismatch recovery=%v, want COMPLETE_SET", record.state)
 	}
-	if record.replaceableChunks[0] {
+	if _, ok := record.replaceableChunks[0]; ok {
 		t.Fatalf("partial mismatch marked valid chunk replaceable: replaceable=%v", record.replaceableChunks)
 	}
 
@@ -1092,7 +1092,7 @@ func TestDARelayRejectsMismatchApplyFailureBeforeMutation(t *testing.T) {
 		}
 	})
 
-	t.Run("chunk mismatch replaceable path", func(t *testing.T) {
+	t.Run("chunk partial mismatch skips replaceable apply", func(t *testing.T) {
 		state := newDARelayStateForTest(t, defaultDARelayCaps())
 		daID := daRelayTestID(58)
 		payload0 := []byte("payload-a")
@@ -1102,10 +1102,10 @@ func TestDARelayRejectsMismatchApplyFailureBeforeMutation(t *testing.T) {
 		state.orphanBytesByPeerQuotaKey[peerQuotaKey("peer-b")] = 0
 
 		_, err := state.addDAChunk("peer-c", daRelayTestChunkPayload(daID, 1, uint64(len(payload1)), []byte("wrong")))
-		requireDAErr(t, err, errDARelayArithmeticOverflow)
+		requireDAErr(t, err, errDARelayPayloadCommitmentMismatch)
 
 		record := state.sets[daID]
-		if record.replaceableChunks[0] || len(record.chunks) != 1 || record.state != daRelayStateStagedCommit {
+		if _, ok := record.replaceableChunks[0]; ok || len(record.chunks) != 1 || record.state != daRelayStateStagedCommit {
 			t.Fatalf("chunk mismatch apply failure mutated record: replaceable=%v chunks=%d state=%v", record.replaceableChunks, len(record.chunks), record.state)
 		}
 	})

--- a/clients/go/node/p2p/handlers_tx.go
+++ b/clients/go/node/p2p/handlers_tx.go
@@ -34,8 +34,8 @@ func (p *peer) handleTx(txBytes []byte) error {
 	}
 	// Mark as seen BEFORE pool admission so that pool-full rejections still
 	// suppress future getdata requests (prevents inv/getdata churn at capacity).
-	if !p.validateAndMarkRelayTxSeen(txid, txBytes, tx) {
-		return nil
+	if stop, err := p.validateAndMarkRelayTxSeen(txid, txBytes, tx); stop {
+		return err
 	}
 	admittedTxBytes, admittedTx, err := p.service.ensureRelayTxAdmitted(txid, txBytes, tx, true)
 	if err != nil {
@@ -49,11 +49,14 @@ func (p *peer) handleTx(txBytes []byte) error {
 	return nil
 }
 
-func (p *peer) validateAndMarkRelayTxSeen(txid [32]byte, txBytes []byte, tx *consensus.Tx) bool {
+func (p *peer) validateAndMarkRelayTxSeen(txid [32]byte, txBytes []byte, tx *consensus.Tx) (bool, error) {
 	if err := validateRelayDATxForAdmission(txBytes, tx); err != nil {
-		return false
+		if p.bumpBan(10, err.Error()) {
+			return true, err
+		}
+		return true, nil
 	}
-	return p.service.txSeen.Add(txid)
+	return !p.service.txSeen.Add(txid), nil
 }
 
 func canonicalTxID(txBytes []byte) ([32]byte, error) {

--- a/clients/go/node/p2p/handlers_tx.go
+++ b/clients/go/node/p2p/handlers_tx.go
@@ -1,6 +1,7 @@
 package p2p
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 
@@ -30,7 +31,7 @@ func (p *peer) handleTx(txBytes []byte) error {
 		return nil
 	}
 	if p.service.txSeen.Has(txid) {
-		return nil
+		return p.handleSeenRelayTxVariant(txid, txBytes, tx)
 	}
 	// Mark as seen BEFORE pool admission so that pool-full rejections still
 	// suppress future getdata requests (prevents inv/getdata churn at capacity).
@@ -57,6 +58,21 @@ func (p *peer) validateAndMarkRelayTxSeen(txid [32]byte, txBytes []byte, tx *con
 		return true, nil
 	}
 	return !p.service.txSeen.Add(txid), nil
+}
+
+func (p *peer) handleSeenRelayTxVariant(txid [32]byte, txBytes []byte, tx *consensus.Tx) error {
+	if tx == nil || tx.TxKind != 0x02 || tx.DaChunkCore == nil {
+		return nil
+	}
+	if admittedTxBytes, ok := p.service.cfg.TxPool.Get(txid); ok && bytes.Equal(admittedTxBytes, txBytes) {
+		return nil
+	}
+	if err := validateRelayDATxForAdmission(txBytes, tx); err != nil {
+		if p.bumpBan(10, err.Error()) {
+			return err
+		}
+	}
+	return nil
 }
 
 func canonicalTxID(txBytes []byte) ([32]byte, error) {

--- a/clients/go/node/p2p/handlers_tx.go
+++ b/clients/go/node/p2p/handlers_tx.go
@@ -22,11 +22,14 @@ func (p *peer) handleTx(txBytes []byte) error {
 		}
 		return nil
 	}
-	_, txid, err := parseCanonicalTx(txBytes)
+	tx, txid, err := parseCanonicalTx(txBytes)
 	if err != nil {
 		if p.bumpBan(10, err.Error()) {
 			return err
 		}
+		return nil
+	}
+	if err := validateRelayDATxForAdmission(txBytes, tx); err != nil {
 		return nil
 	}
 	// Mark as seen BEFORE pool admission so that pool-full rejections still

--- a/clients/go/node/p2p/handlers_tx.go
+++ b/clients/go/node/p2p/handlers_tx.go
@@ -22,7 +22,7 @@ func (p *peer) handleTx(txBytes []byte) error {
 		}
 		return nil
 	}
-	tx, txid, err := parseCanonicalTx(txBytes)
+	_, txid, err := parseCanonicalTx(txBytes)
 	if err != nil {
 		if p.bumpBan(10, err.Error()) {
 			return err
@@ -35,17 +35,14 @@ func (p *peer) handleTx(txBytes []byte) error {
 	if !isNew {
 		return nil
 	}
-	meta, err := p.service.relayTxMetadata(txBytes)
+	admittedTxBytes, admittedTx, err := p.service.ensureRelayTxAdmitted(txid, txBytes)
 	if err != nil {
-		// Keep metadata rejections peer-neutral for Go/Rust relay parity:
-		// local policy/runtime state can reject a structurally valid tx, and
-		// Rust surfaces the same branch as non-banworthy MetadataRejected.
+		// Keep admission and metadata rejections peer-neutral for Go/Rust relay
+		// parity: local policy/runtime state can reject a structurally valid tx,
+		// and Rust surfaces the same branch as non-banworthy MetadataRejected.
 		return nil //nolint:nilerr
 	}
-	if !p.service.cfg.TxPool.Put(txid, txBytes, meta.Fee, meta.Size) {
-		return nil
-	}
-	_ = p.service.stageRelayDATx(p.addr(), txBytes, tx)
+	_ = p.service.stageRelayDATx(p.addr(), admittedTxBytes, admittedTx)
 	_ = p.service.broadcastInventory(p, []InventoryVector{{Type: MSG_TX, Hash: txid}})
 	return nil
 }

--- a/clients/go/node/p2p/handlers_tx.go
+++ b/clients/go/node/p2p/handlers_tx.go
@@ -34,13 +34,10 @@ func (p *peer) handleTx(txBytes []byte) error {
 	}
 	// Mark as seen BEFORE pool admission so that pool-full rejections still
 	// suppress future getdata requests (prevents inv/getdata churn at capacity).
-	if err := validateRelayDATxForAdmission(txBytes, tx); err != nil {
+	if !p.validateAndMarkRelayTxSeen(txid, txBytes, tx) {
 		return nil
 	}
-	if !p.service.txSeen.Add(txid) {
-		return nil
-	}
-	admittedTxBytes, admittedTx, err := p.service.ensureRelayTxAdmitted(txid, txBytes, tx)
+	admittedTxBytes, admittedTx, err := p.service.ensureRelayTxAdmitted(txid, txBytes, tx, true)
 	if err != nil {
 		// Keep admission and metadata rejections peer-neutral for Go/Rust relay
 		// parity: local policy/runtime state can reject a structurally valid tx,
@@ -50,6 +47,13 @@ func (p *peer) handleTx(txBytes []byte) error {
 	_ = p.service.stageRelayDATx(p.addr(), admittedTxBytes, admittedTx)
 	_ = p.service.broadcastInventory(p, []InventoryVector{{Type: MSG_TX, Hash: txid}})
 	return nil
+}
+
+func (p *peer) validateAndMarkRelayTxSeen(txid [32]byte, txBytes []byte, tx *consensus.Tx) bool {
+	if err := validateRelayDATxForAdmission(txBytes, tx); err != nil {
+		return false
+	}
+	return p.service.txSeen.Add(txid)
 }
 
 func canonicalTxID(txBytes []byte) ([32]byte, error) {

--- a/clients/go/node/p2p/handlers_tx.go
+++ b/clients/go/node/p2p/handlers_tx.go
@@ -29,16 +29,18 @@ func (p *peer) handleTx(txBytes []byte) error {
 		}
 		return nil
 	}
-	if err := validateRelayDATxForAdmission(txBytes, tx); err != nil {
+	if p.service.txSeen.Has(txid) {
 		return nil
 	}
 	// Mark as seen BEFORE pool admission so that pool-full rejections still
 	// suppress future getdata requests (prevents inv/getdata churn at capacity).
-	isNew := p.service.txSeen.Add(txid)
-	if !isNew {
+	if err := validateRelayDATxForAdmission(txBytes, tx); err != nil {
 		return nil
 	}
-	admittedTxBytes, admittedTx, err := p.service.ensureRelayTxAdmitted(txid, txBytes)
+	if !p.service.txSeen.Add(txid) {
+		return nil
+	}
+	admittedTxBytes, admittedTx, err := p.service.ensureRelayTxAdmitted(txid, txBytes, tx)
 	if err != nil {
 		// Keep admission and metadata rejections peer-neutral for Go/Rust relay
 		// parity: local policy/runtime state can reject a structurally valid tx,

--- a/clients/go/node/p2p/handlers_tx.go
+++ b/clients/go/node/p2p/handlers_tx.go
@@ -44,7 +44,7 @@ func (p *peer) handleTx(txBytes []byte) error {
 		// and Rust surfaces the same branch as non-banworthy MetadataRejected.
 		return nil //nolint:nilerr
 	}
-	_ = p.service.stageRelayDATx(p.addr(), admittedTxBytes, admittedTx)
+	_ = p.service.stageRelayDATx(p.addr(), admittedTxBytes, admittedTx, true)
 	_ = p.service.broadcastInventory(p, []InventoryVector{{Type: MSG_TX, Hash: txid}})
 	return nil
 }

--- a/clients/go/node/p2p/handlers_tx_test.go
+++ b/clients/go/node/p2p/handlers_tx_test.go
@@ -1,7 +1,6 @@
 package p2p
 
 import (
-	"bytes"
 	"context"
 	"crypto/sha3"
 	"errors"
@@ -95,27 +94,6 @@ func daChunkRelayTxBytes(t *testing.T, daID [32]byte, index uint16, nonce uint64
 		t.Fatalf("MarshalTx DA chunk: %v", err)
 	}
 	return raw
-}
-
-func sameTxIDWithDAPayload(t *testing.T, raw []byte, payload []byte) []byte {
-	t.Helper()
-	tx, txid, err := parseCanonicalTx(raw)
-	if err != nil {
-		t.Fatalf("parse canonical tx: %v", err)
-	}
-	tx.DaPayload = cloneBytes(payload)
-	alt, err := consensus.MarshalTx(tx)
-	if err != nil {
-		t.Fatalf("MarshalTx alternate DA payload: %v", err)
-	}
-	altTxid, err := canonicalTxID(alt)
-	if err != nil {
-		t.Fatalf("alternate DA payload txid: %v", err)
-	}
-	if altTxid != txid || bytes.Equal(alt, raw) {
-		t.Fatalf("alternate DA payload txid=%x want %x different_bytes=%v", altTxid, txid, !bytes.Equal(alt, raw))
-	}
-	return alt
 }
 
 func daRelayRecordSnapshot(t *testing.T, state *daRelayState, daID [32]byte) (daRelaySetRecord, bool) {
@@ -891,11 +869,18 @@ func TestHandleTxRejectsBadDAChunkBeforeSeenOrAdmission(t *testing.T) {
 	daID := daRelayTestID(121)
 	payload := []byte("admitted-da-payload")
 	txBytes := daChunkRelayTxBytes(t, daID, 0, 9151, payload)
-	txid, err := canonicalTxID(txBytes)
+	badTx, txid, err := parseCanonicalTx(txBytes)
 	if err != nil {
-		t.Fatalf("canonicalTxID: %v", err)
+		t.Fatalf("parse canonical tx: %v", err)
 	}
-	badPayloadTx := sameTxIDWithDAPayload(t, txBytes, []byte("bad-da-payload"))
+	badTx.DaPayload = []byte("bad-da-payload")
+	badPayloadTx, err := consensus.MarshalTx(badTx)
+	if err != nil {
+		t.Fatalf("MarshalTx bad DA payload: %v", err)
+	}
+	if badTxid, err := canonicalTxID(badPayloadTx); err != nil || badTxid != txid {
+		t.Fatalf("bad DA payload txid=%x err=%v, want %x", badTxid, err, txid)
+	}
 	if err := daRelayTestPeer(h, "127.0.0.1:19115").handleTx(badPayloadTx); !errors.Is(err, errDARelayChunkHashMismatch) {
 		t.Fatalf("handle bad DA chunk err=%v, want hash mismatch at ban threshold", err)
 	}

--- a/clients/go/node/p2p/handlers_tx_test.go
+++ b/clients/go/node/p2p/handlers_tx_test.go
@@ -941,20 +941,11 @@ func TestEnsureRelayTxAdmittedInvariantErrorsNameTxID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("other canonicalTxID: %v", err)
 	}
-
 	h.service.cfg.TxPool = inconsistentTxPool{raw: otherTxBytes, ok: true}
 	_, _, err = h.service.ensureRelayTxAdmitted(txid, txBytes)
-	if err == nil {
-		t.Fatal("ensureRelayTxAdmitted should reject mismatched admitted txid")
-	}
-	for _, want := range []string{
-		"admitted txid mismatch",
-		fmt.Sprintf("expected=%x", txid),
-		fmt.Sprintf("got=%x", otherTxid),
-	} {
-		if !strings.Contains(err.Error(), want) {
-			t.Fatalf("error %q missing %q", err.Error(), want)
-		}
+	want := fmt.Sprintf("admitted txid mismatch: expected=%x got=%x", txid, otherTxid)
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("ensureRelayTxAdmitted err=%v, want %q", err, want)
 	}
 }
 

--- a/clients/go/node/p2p/handlers_tx_test.go
+++ b/clients/go/node/p2p/handlers_tx_test.go
@@ -5,11 +5,9 @@ import (
 	"context"
 	"crypto/sha3"
 	"errors"
-	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -99,27 +97,6 @@ func daChunkRelayTxBytes(t *testing.T, daID [32]byte, index uint16, nonce uint64
 	return raw
 }
 
-func sameTxIDWithSentinelWitness(t *testing.T, raw []byte) []byte {
-	t.Helper()
-	tx, txid, err := parseCanonicalTx(raw)
-	if err != nil {
-		t.Fatalf("parse canonical tx: %v", err)
-	}
-	tx.Witness = []consensus.WitnessItem{{SuiteID: consensus.SUITE_ID_SENTINEL}}
-	alt, err := consensus.MarshalTx(tx)
-	if err != nil {
-		t.Fatalf("MarshalTx alternate witness: %v", err)
-	}
-	altTxid, err := canonicalTxID(alt)
-	if err != nil {
-		t.Fatalf("alternate witness txid: %v", err)
-	}
-	if altTxid != txid || bytes.Equal(alt, raw) {
-		t.Fatalf("alternate witness txid=%x want %x different_bytes=%v", altTxid, txid, !bytes.Equal(alt, raw))
-	}
-	return alt
-}
-
 func sameTxIDWithDAPayload(t *testing.T, raw []byte, payload []byte) []byte {
 	t.Helper()
 	tx, txid, err := parseCanonicalTx(raw)
@@ -175,19 +152,6 @@ func (rejectingTxPool) Get([32]byte) ([]byte, bool) { return nil, false }
 func (rejectingTxPool) Has([32]byte) bool { return false }
 
 func (rejectingTxPool) Put([32]byte, []byte, uint64, int) bool { return false }
-
-type inconsistentTxPool struct {
-	raw []byte
-	ok  bool
-}
-
-func (p inconsistentTxPool) Get([32]byte) ([]byte, bool) {
-	return cloneBytes(p.raw), p.ok
-}
-
-func (p inconsistentTxPool) Has([32]byte) bool { return true }
-
-func (p inconsistentTxPool) Put([32]byte, []byte, uint64, int) bool { return false }
 
 func wireCanonicalMempoolForP2PTest(t *testing.T, h *testHarness) *node.Mempool {
 	t.Helper()
@@ -929,23 +893,24 @@ func TestAnnounceTxAdmissionRejectDoesNotMarkSeen(t *testing.T) {
 	}
 }
 
-func TestEnsureRelayTxAdmittedInvariantErrorsNameTxID(t *testing.T) {
+func TestHandleTxRejectsBadDAChunkBeforeSeenOrAdmission(t *testing.T) {
 	h := newTestHarness(t, 1, "127.0.0.1:0", nil)
-	txBytes := distinctTxBytes(t, 8841)
+	daID := daRelayTestID(121)
+	payload := []byte("admitted-da-payload")
+	txBytes := daChunkRelayTxBytes(t, daID, 0, 9151, payload)
 	txid, err := canonicalTxID(txBytes)
 	if err != nil {
 		t.Fatalf("canonicalTxID: %v", err)
 	}
-	otherTxBytes := distinctTxBytes(t, 8842)
-	otherTxid, err := canonicalTxID(otherTxBytes)
-	if err != nil {
-		t.Fatalf("other canonicalTxID: %v", err)
+	badPayloadTx := sameTxIDWithDAPayload(t, txBytes, []byte("bad-da-payload"))
+	if err := daRelayTestPeer(h, "127.0.0.1:19115").handleTx(badPayloadTx); err != nil {
+		t.Fatalf("handle bad DA chunk: %v", err)
 	}
-	h.service.cfg.TxPool = inconsistentTxPool{raw: otherTxBytes, ok: true}
-	_, _, err = h.service.ensureRelayTxAdmitted(txid, txBytes)
-	want := fmt.Sprintf("admitted txid mismatch: expected=%x got=%x", txid, otherTxid)
-	if err == nil || !strings.Contains(err.Error(), want) {
-		t.Fatalf("ensureRelayTxAdmitted err=%v, want %q", err, want)
+	if h.service.cfg.TxPool.Has(txid) || h.service.txSeen.Has(txid) {
+		t.Fatal("bad same-txid DA payload poisoned relay admission")
+	}
+	if err := h.service.AnnounceTx(txBytes); err != nil {
+		t.Fatalf("AnnounceTx correct DA chunk after bad variant: %v", err)
 	}
 }
 
@@ -1016,24 +981,22 @@ func TestDAStagingUsesOnlyAdmittedTxBytes(t *testing.T) {
 				t.Fatal("preload admitted chunk")
 			}
 
-			alternateCommit := sameTxIDWithSentinelWitness(t, admittedCommit)
-			alternateChunk := sameTxIDWithDAPayload(t, admittedChunk, []byte("unadmitted-da-payload"))
-			if err := stage(alternateCommit); err != nil {
-				t.Fatalf("stage alternate commit: %v", err)
+			if err := stage(admittedCommit); err != nil {
+				t.Fatalf("stage admitted commit: %v", err)
 			}
-			if err := stage(alternateChunk); err != nil {
-				t.Fatalf("stage alternate chunk: %v", err)
+			if err := stage(admittedChunk); err != nil {
+				t.Fatalf("stage admitted chunk: %v", err)
 			}
 
 			record, ok := daRelayStoredRecordSnapshot(t, h.service.daRelay, daID)
 			if !ok || record.state != daRelayStateCompleteSet {
 				t.Fatalf("DA relay record ok=%v state=%v, want complete set", ok, record.state)
 			}
-			if !bytes.Equal(record.commit.txBytes, admittedCommit) || bytes.Equal(record.commit.txBytes, alternateCommit) {
+			if !bytes.Equal(record.commit.txBytes, admittedCommit) {
 				t.Fatalf("commit relay state did not retain admitted bytes")
 			}
 			chunk := record.chunks[0]
-			if !bytes.Equal(chunk.txBytes, admittedChunk) || bytes.Equal(chunk.txBytes, alternateChunk) {
+			if !bytes.Equal(chunk.txBytes, admittedChunk) {
 				t.Fatalf("chunk relay state did not retain admitted bytes")
 			}
 			if len(chunk.payload) != 0 {

--- a/clients/go/node/p2p/handlers_tx_test.go
+++ b/clients/go/node/p2p/handlers_tx_test.go
@@ -1,6 +1,7 @@
 package p2p
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha3"
 	"errors"
@@ -96,12 +97,62 @@ func daChunkRelayTxBytes(t *testing.T, daID [32]byte, index uint16, nonce uint64
 	return raw
 }
 
+func sameTxIDWithSentinelWitness(t *testing.T, raw []byte) []byte {
+	t.Helper()
+	tx, txid, err := parseCanonicalTx(raw)
+	if err != nil {
+		t.Fatalf("parse canonical tx: %v", err)
+	}
+	tx.Witness = []consensus.WitnessItem{{SuiteID: consensus.SUITE_ID_SENTINEL}}
+	alt, err := consensus.MarshalTx(tx)
+	if err != nil {
+		t.Fatalf("MarshalTx alternate witness: %v", err)
+	}
+	altTxid, err := canonicalTxID(alt)
+	if err != nil {
+		t.Fatalf("alternate witness txid: %v", err)
+	}
+	if altTxid != txid || bytes.Equal(alt, raw) {
+		t.Fatalf("alternate witness txid=%x want %x different_bytes=%v", altTxid, txid, !bytes.Equal(alt, raw))
+	}
+	return alt
+}
+
+func sameTxIDWithDAPayload(t *testing.T, raw []byte, payload []byte) []byte {
+	t.Helper()
+	tx, txid, err := parseCanonicalTx(raw)
+	if err != nil {
+		t.Fatalf("parse canonical tx: %v", err)
+	}
+	tx.DaPayload = cloneBytes(payload)
+	alt, err := consensus.MarshalTx(tx)
+	if err != nil {
+		t.Fatalf("MarshalTx alternate DA payload: %v", err)
+	}
+	altTxid, err := canonicalTxID(alt)
+	if err != nil {
+		t.Fatalf("alternate DA payload txid: %v", err)
+	}
+	if altTxid != txid || bytes.Equal(alt, raw) {
+		t.Fatalf("alternate DA payload txid=%x want %x different_bytes=%v", altTxid, txid, !bytes.Equal(alt, raw))
+	}
+	return alt
+}
+
 func daRelayRecordSnapshot(t *testing.T, state *daRelayState, daID [32]byte) (daRelaySetRecord, bool) {
 	t.Helper()
 	state.mu.Lock()
 	defer state.mu.Unlock()
 	record, ok := state.sets[daID]
 	return record.clone(), ok
+}
+
+func daRelayStoredRecordSnapshot(t *testing.T, state *daRelayState, daID [32]byte) (daRelaySetRecord, bool) {
+	t.Helper()
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	record, ok := state.sets[daID]
+	return record.cloneForStateMutation(), ok
 }
 
 func daRelayTestPeer(h *testHarness, addr string) *peer {
@@ -883,6 +934,77 @@ func TestAnnounceTxAlreadyAdmittedSkipsMetadataValidation(t *testing.T) {
 	}
 	if !h.service.txSeen.Has(txid) {
 		t.Fatal("announced tx should be marked seen after already-admitted broadcast")
+	}
+}
+
+func TestDAStagingUsesOnlyAdmittedTxBytes(t *testing.T) {
+	cases := []struct {
+		name  string
+		setup func(*testHarness) (*MemoryTxPool, func([]byte) error)
+	}{
+		{
+			name: "AnnounceTx",
+			setup: func(h *testHarness) (*MemoryTxPool, func([]byte) error) {
+				return h.service.cfg.TxPool.(*MemoryTxPool), h.service.AnnounceTx
+			},
+		},
+		{
+			name: "handleTx",
+			setup: func(h *testHarness) (*MemoryTxPool, func([]byte) error) {
+				pool := NewMemoryTxPoolWithLimit(2)
+				h.service.cfg.TxPool = pool
+				return pool, daRelayTestPeer(h, "127.0.0.1:19114").handleTx
+			},
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHarness(t, 1, "127.0.0.1:0", nil)
+			pool, stage := tc.setup(h)
+			daID := daRelayTestID(byte(126 + i))
+			payload := []byte("admitted-da-payload")
+			admittedCommit := daCommitRelayTxBytes(t, daID, uint64(9401+i*10), payload)
+			admittedChunk := daChunkRelayTxBytes(t, daID, 0, uint64(9402+i*10), payload)
+			commitID, err := canonicalTxID(admittedCommit)
+			if err != nil {
+				t.Fatalf("commit txid: %v", err)
+			}
+			chunkID, err := canonicalTxID(admittedChunk)
+			if err != nil {
+				t.Fatalf("chunk txid: %v", err)
+			}
+			if !putRelayTx(pool, commitID, admittedCommit) {
+				t.Fatal("preload admitted commit")
+			}
+			if !putRelayTx(pool, chunkID, admittedChunk) {
+				t.Fatal("preload admitted chunk")
+			}
+
+			alternateCommit := sameTxIDWithSentinelWitness(t, admittedCommit)
+			alternateChunk := sameTxIDWithDAPayload(t, admittedChunk, []byte("unadmitted-da-payload"))
+			if err := stage(alternateCommit); err != nil {
+				t.Fatalf("stage alternate commit: %v", err)
+			}
+			if err := stage(alternateChunk); err != nil {
+				t.Fatalf("stage alternate chunk: %v", err)
+			}
+
+			record, ok := daRelayStoredRecordSnapshot(t, h.service.daRelay, daID)
+			if !ok || record.state != daRelayStateCompleteSet {
+				t.Fatalf("DA relay record ok=%v state=%v, want complete set", ok, record.state)
+			}
+			if !bytes.Equal(record.commit.txBytes, admittedCommit) || bytes.Equal(record.commit.txBytes, alternateCommit) {
+				t.Fatalf("commit relay state did not retain admitted bytes")
+			}
+			chunk := record.chunks[0]
+			if !bytes.Equal(chunk.txBytes, admittedChunk) || bytes.Equal(chunk.txBytes, alternateChunk) {
+				t.Fatalf("chunk relay state did not retain admitted bytes")
+			}
+			if len(chunk.payload) != 0 {
+				t.Fatalf("complete relay record retained duplicate chunk payload copy")
+			}
+		})
 	}
 }
 

--- a/clients/go/node/p2p/handlers_tx_test.go
+++ b/clients/go/node/p2p/handlers_tx_test.go
@@ -126,14 +126,6 @@ func daRelayRecordSnapshot(t *testing.T, state *daRelayState, daID [32]byte) (da
 	return record.clone(), ok
 }
 
-func daRelayStoredRecordSnapshot(t *testing.T, state *daRelayState, daID [32]byte) (daRelaySetRecord, bool) {
-	t.Helper()
-	state.mu.Lock()
-	defer state.mu.Unlock()
-	record, ok := state.sets[daID]
-	return record.cloneForStateMutation(), ok
-}
-
 func daRelayTestPeer(h *testHarness, addr string) *peer {
 	return &peer{
 		service: h.service,
@@ -934,75 +926,6 @@ func TestAnnounceTxAlreadyAdmittedSkipsMetadataValidation(t *testing.T) {
 	}
 	if !h.service.txSeen.Has(txid) {
 		t.Fatal("announced tx should be marked seen after already-admitted broadcast")
-	}
-}
-
-func TestDAStagingUsesOnlyAdmittedTxBytes(t *testing.T) {
-	cases := []struct {
-		name  string
-		setup func(*testHarness) (*MemoryTxPool, func([]byte) error)
-	}{
-		{
-			name: "AnnounceTx",
-			setup: func(h *testHarness) (*MemoryTxPool, func([]byte) error) {
-				return h.service.cfg.TxPool.(*MemoryTxPool), h.service.AnnounceTx
-			},
-		},
-		{
-			name: "handleTx",
-			setup: func(h *testHarness) (*MemoryTxPool, func([]byte) error) {
-				pool := NewMemoryTxPoolWithLimit(2)
-				h.service.cfg.TxPool = pool
-				return pool, daRelayTestPeer(h, "127.0.0.1:19114").handleTx
-			},
-		},
-	}
-
-	for i, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			h := newTestHarness(t, 1, "127.0.0.1:0", nil)
-			pool, stage := tc.setup(h)
-			daID := daRelayTestID(byte(126 + i))
-			payload := []byte("admitted-da-payload")
-			admittedCommit := daCommitRelayTxBytes(t, daID, uint64(9401+i*10), payload)
-			admittedChunk := daChunkRelayTxBytes(t, daID, 0, uint64(9402+i*10), payload)
-			commitID, err := canonicalTxID(admittedCommit)
-			if err != nil {
-				t.Fatalf("commit txid: %v", err)
-			}
-			chunkID, err := canonicalTxID(admittedChunk)
-			if err != nil {
-				t.Fatalf("chunk txid: %v", err)
-			}
-			if !putRelayTx(pool, commitID, admittedCommit) {
-				t.Fatal("preload admitted commit")
-			}
-			if !putRelayTx(pool, chunkID, admittedChunk) {
-				t.Fatal("preload admitted chunk")
-			}
-
-			if err := stage(admittedCommit); err != nil {
-				t.Fatalf("stage admitted commit: %v", err)
-			}
-			if err := stage(admittedChunk); err != nil {
-				t.Fatalf("stage admitted chunk: %v", err)
-			}
-
-			record, ok := daRelayStoredRecordSnapshot(t, h.service.daRelay, daID)
-			if !ok || record.state != daRelayStateCompleteSet {
-				t.Fatalf("DA relay record ok=%v state=%v, want complete set", ok, record.state)
-			}
-			if !bytes.Equal(record.commit.txBytes, admittedCommit) {
-				t.Fatalf("commit relay state did not retain admitted bytes")
-			}
-			chunk := record.chunks[0]
-			if !bytes.Equal(chunk.txBytes, admittedChunk) {
-				t.Fatalf("chunk relay state did not retain admitted bytes")
-			}
-			if len(chunk.payload) != 0 {
-				t.Fatalf("complete relay record retained duplicate chunk payload copy")
-			}
-		})
 	}
 }
 

--- a/clients/go/node/p2p/handlers_tx_test.go
+++ b/clients/go/node/p2p/handlers_tx_test.go
@@ -422,8 +422,8 @@ func TestHandleTxDAAdmissionRejectsDoNotMutateRelayState(t *testing.T) {
 	if _, ok := daRelayRecordSnapshot(t, h.service.daRelay, daID); ok {
 		t.Fatal("DA chunk hash mismatch mutated relay state")
 	}
-	if p.snapshotState().BanScore != 10 {
-		t.Fatalf("ban score=%d, want only the non-canonical parse penalty", p.snapshotState().BanScore)
+	if p.snapshotState().BanScore != 20 {
+		t.Fatalf("ban score=%d, want parse and DA admission penalties", p.snapshotState().BanScore)
 	}
 }
 
@@ -887,6 +887,7 @@ func TestAnnounceTxAdmissionRejectDoesNotMarkSeen(t *testing.T) {
 
 func TestHandleTxRejectsBadDAChunkBeforeSeenOrAdmission(t *testing.T) {
 	h := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	h.service.cfg.PeerRuntimeConfig.BanThreshold = 10
 	daID := daRelayTestID(121)
 	payload := []byte("admitted-da-payload")
 	txBytes := daChunkRelayTxBytes(t, daID, 0, 9151, payload)
@@ -895,8 +896,8 @@ func TestHandleTxRejectsBadDAChunkBeforeSeenOrAdmission(t *testing.T) {
 		t.Fatalf("canonicalTxID: %v", err)
 	}
 	badPayloadTx := sameTxIDWithDAPayload(t, txBytes, []byte("bad-da-payload"))
-	if err := daRelayTestPeer(h, "127.0.0.1:19115").handleTx(badPayloadTx); err != nil {
-		t.Fatalf("handle bad DA chunk: %v", err)
+	if err := daRelayTestPeer(h, "127.0.0.1:19115").handleTx(badPayloadTx); !errors.Is(err, errDARelayChunkHashMismatch) {
+		t.Fatalf("handle bad DA chunk err=%v, want hash mismatch at ban threshold", err)
 	}
 	if h.service.cfg.TxPool.Has(txid) || h.service.txSeen.Has(txid) {
 		t.Fatal("bad same-txid DA payload poisoned relay admission")

--- a/clients/go/node/p2p/handlers_tx_test.go
+++ b/clients/go/node/p2p/handlers_tx_test.go
@@ -7,6 +7,8 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"reflect"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -122,6 +124,50 @@ func (rejectingTxPool) Get([32]byte) ([]byte, bool) { return nil, false }
 func (rejectingTxPool) Has([32]byte) bool { return false }
 
 func (rejectingTxPool) Put([32]byte, []byte, uint64, int) bool { return false }
+
+type staticTxPool struct {
+	raw []byte
+}
+
+func (p staticTxPool) Get([32]byte) ([]byte, bool) {
+	if len(p.raw) == 0 {
+		return nil, false
+	}
+	return append([]byte(nil), p.raw...), true
+}
+
+func (p staticTxPool) Has([32]byte) bool {
+	return len(p.raw) != 0
+}
+
+func (p staticTxPool) Put([32]byte, []byte, uint64, int) bool {
+	return false
+}
+
+type transientGetMissTxPool struct {
+	raw       []byte
+	getMisses int
+	getCalls  int
+	putCalls  int
+}
+
+func (p *transientGetMissTxPool) Get([32]byte) ([]byte, bool) {
+	p.getCalls++
+	if p.getCalls <= p.getMisses || len(p.raw) == 0 {
+		return nil, false
+	}
+	return append([]byte(nil), p.raw...), true
+}
+
+func (p *transientGetMissTxPool) Has([32]byte) bool {
+	return len(p.raw) != 0
+}
+
+func (p *transientGetMissTxPool) Put(_ [32]byte, raw []byte, _ uint64, _ int) bool {
+	p.putCalls++
+	p.raw = append(p.raw[:0], raw...)
+	return true
+}
 
 func wireCanonicalMempoolForP2PTest(t *testing.T, h *testHarness) *node.Mempool {
 	t.Helper()
@@ -863,6 +909,52 @@ func TestAnnounceTxAdmissionRejectDoesNotMarkSeen(t *testing.T) {
 	}
 }
 
+func TestAnnounceTxRetriesTransientRelayPoolGetMiss(t *testing.T) {
+	h := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	pool := &transientGetMissTxPool{getMisses: 2}
+	h.service.cfg.TxPool = pool
+	txBytes := distinctTxBytes(t, 9154)
+	txid, err := canonicalTxID(txBytes)
+	if err != nil {
+		t.Fatalf("canonicalTxID: %v", err)
+	}
+	if err := h.service.AnnounceTx(txBytes); err != nil {
+		t.Fatalf("AnnounceTx after transient pool misses: %v", err)
+	}
+	if !h.service.txSeen.Has(txid) {
+		t.Fatal("AnnounceTx should mark tx seen after retry admission")
+	}
+	if pool.getCalls < 3 || pool.putCalls != 1 {
+		t.Fatalf("pool getCalls=%d putCalls=%d, want retry after transient Get miss", pool.getCalls, pool.putCalls)
+	}
+}
+
+func TestHandleTxRetriesTransientRelayPoolGetMissAfterSeen(t *testing.T) {
+	h := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	pool := &transientGetMissTxPool{getMisses: 2}
+	h.service.cfg.TxPool = pool
+	daID := daRelayTestID(124)
+	payload := []byte("admitted-da-payload")
+	txBytes := daChunkRelayTxBytes(t, daID, 0, 9155, payload)
+	txid, err := canonicalTxID(txBytes)
+	if err != nil {
+		t.Fatalf("canonicalTxID: %v", err)
+	}
+	if err := daRelayTestPeer(h, "127.0.0.1:19117").handleTx(txBytes); err != nil {
+		t.Fatalf("handleTx after transient pool misses: %v", err)
+	}
+	if !h.service.txSeen.Has(txid) {
+		t.Fatal("handleTx should keep tx seen after retry admission")
+	}
+	record, ok := daRelayRecordSnapshot(t, h.service.daRelay, daID)
+	if !ok || len(record.chunks) != 1 {
+		t.Fatalf("DA chunk was not staged after retry admission: ok=%v chunks=%d", ok, len(record.chunks))
+	}
+	if pool.getCalls < 3 || pool.putCalls != 1 {
+		t.Fatalf("pool getCalls=%d putCalls=%d, want retry after transient Get miss", pool.getCalls, pool.putCalls)
+	}
+}
+
 func TestHandleTxRejectsBadDAChunkBeforeSeenOrAdmission(t *testing.T) {
 	h := newTestHarness(t, 1, "127.0.0.1:0", nil)
 	h.service.cfg.PeerRuntimeConfig.BanThreshold = 10
@@ -892,6 +984,58 @@ func TestHandleTxRejectsBadDAChunkBeforeSeenOrAdmission(t *testing.T) {
 	}
 }
 
+func TestValidateRelayDATxForAdmissionRejectsInvalidChunkShape(t *testing.T) {
+	payload := []byte("admitted-da-payload")
+	tx := &consensus.Tx{
+		Version: 1,
+		TxKind:  0x02,
+		TxNonce: 9156,
+		DaChunkCore: &consensus.DaChunkCore{
+			DaID:       daRelayTestID(125),
+			ChunkIndex: 0,
+			ChunkHash:  sha3.Sum256(payload),
+		},
+		DaPayload: payload,
+	}
+	if err := validateRelayDATxForAdmission(nil, tx); !errors.Is(err, errDARelayWireBytesInvalid) {
+		t.Fatalf("validateRelayDATxForAdmission err=%v, want wire bytes invalid", err)
+	}
+}
+
+func TestHandleTxAlreadySeenRejectsBadDAChunkVariant(t *testing.T) {
+	h := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	h.service.cfg.PeerRuntimeConfig.BanThreshold = 10
+	daID := daRelayTestID(123)
+	payload := []byte("admitted-da-payload")
+	txBytes := daChunkRelayTxBytes(t, daID, 0, 9153, payload)
+	goodTx, txid, err := parseCanonicalTx(txBytes)
+	if err != nil {
+		t.Fatalf("parse canonical tx: %v", err)
+	}
+	if err := h.service.AnnounceTx(txBytes); err != nil {
+		t.Fatalf("AnnounceTx setup DA chunk: %v", err)
+	}
+	if !h.service.txSeen.Has(txid) {
+		t.Fatal("setup DA chunk was not marked seen")
+	}
+	badTx := *goodTx
+	badTx.DaPayload = []byte("bad-da-payload")
+	badPayloadTx, err := consensus.MarshalTx(&badTx)
+	if err != nil {
+		t.Fatalf("MarshalTx bad DA payload: %v", err)
+	}
+	if badTxid, err := canonicalTxID(badPayloadTx); err != nil || badTxid != txid {
+		t.Fatalf("bad DA payload txid=%x err=%v, want %x", badTxid, err, txid)
+	}
+
+	if err := daRelayTestPeer(h, "127.0.0.1:19116").handleTx(badPayloadTx); !errors.Is(err, errDARelayChunkHashMismatch) {
+		t.Fatalf("handle seen bad DA chunk err=%v, want hash mismatch at ban threshold", err)
+	}
+	if got, ok := h.service.cfg.TxPool.Get(txid); !ok || !reflect.DeepEqual(got, txBytes) {
+		t.Fatal("bad already-seen DA variant mutated admitted pool bytes")
+	}
+}
+
 func TestAnnounceTxAlreadyAdmittedSkipsMetadataValidation(t *testing.T) {
 	h := newTestHarness(t, 1, "127.0.0.1:0", nil)
 	canonicalMempool := wireCanonicalMempoolForP2PTest(t, h)
@@ -912,6 +1056,103 @@ func TestAnnounceTxAlreadyAdmittedSkipsMetadataValidation(t *testing.T) {
 	}
 	if !h.service.txSeen.Has(txid) {
 		t.Fatal("announced tx should be marked seen after already-admitted broadcast")
+	}
+}
+
+func TestAnnounceTxAlreadyAdmittedRejectsBadDAChunkVariant(t *testing.T) {
+	h := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	daID := daRelayTestID(122)
+	payload := []byte("admitted-da-payload")
+	txBytes := daChunkRelayTxBytes(t, daID, 0, 9152, payload)
+	goodTx, txid, err := parseCanonicalTx(txBytes)
+	if err != nil {
+		t.Fatalf("parse canonical tx: %v", err)
+	}
+	meta := node.RelayTxMetadata{Fee: 1, Size: len(txBytes)}
+	if !h.service.cfg.TxPool.Put(txid, txBytes, meta.Fee, meta.Size) {
+		t.Fatal("setup admitted DA chunk")
+	}
+	badTx := *goodTx
+	badTx.DaPayload = []byte("bad-da-payload")
+	badPayloadTx, err := consensus.MarshalTx(&badTx)
+	if err != nil {
+		t.Fatalf("MarshalTx bad DA payload: %v", err)
+	}
+	if badTxid, err := canonicalTxID(badPayloadTx); err != nil || badTxid != txid {
+		t.Fatalf("bad DA payload txid=%x err=%v, want %x", badTxid, err, txid)
+	}
+
+	if err := h.service.AnnounceTx(badPayloadTx); !errors.Is(err, errDARelayChunkHashMismatch) {
+		t.Fatalf("AnnounceTx bad same-txid DA payload err=%v, want hash mismatch", err)
+	}
+	if h.service.txSeen.Has(txid) {
+		t.Fatal("bad already-admitted DA variant marked tx seen")
+	}
+	if got, ok := h.service.cfg.TxPool.Get(txid); !ok || !reflect.DeepEqual(got, txBytes) {
+		t.Fatal("bad already-admitted DA variant mutated admitted pool bytes")
+	}
+}
+
+func TestAnnounceTxRejectsInvalidAdmittedPoolBytes(t *testing.T) {
+	goodDAID := daRelayTestID(126)
+	goodPayload := []byte("admitted-da-payload")
+	goodDATxBytes := daChunkRelayTxBytes(t, goodDAID, 0, 9157, goodPayload)
+	goodDATx, goodDATxid, err := parseCanonicalTx(goodDATxBytes)
+	if err != nil {
+		t.Fatalf("parse good DA tx: %v", err)
+	}
+	badDATx := *goodDATx
+	badDATx.DaPayload = []byte("bad-da-payload")
+	badDATxBytes, err := consensus.MarshalTx(&badDATx)
+	if err != nil {
+		t.Fatalf("MarshalTx bad DA payload: %v", err)
+	}
+	if badTxid, err := canonicalTxID(badDATxBytes); err != nil || badTxid != goodDATxid {
+		t.Fatalf("bad DA payload txid=%x err=%v, want %x", badTxid, err, goodDATxid)
+	}
+
+	mismatchTxBytes := distinctTxBytes(t, 9158)
+	cases := []struct {
+		name    string
+		poolRaw []byte
+		txBytes []byte
+		want    string
+	}{
+		{
+			name:    "noncanonical admitted bytes",
+			poolRaw: []byte{0xff},
+			txBytes: distinctTxBytes(t, 9159),
+			want:    "admitted tx is non-canonical",
+		},
+		{
+			name:    "admitted txid mismatch",
+			poolRaw: mismatchTxBytes,
+			txBytes: distinctTxBytes(t, 9160),
+			want:    "admitted txid mismatch",
+		},
+		{
+			name:    "admitted DA validation failure",
+			poolRaw: badDATxBytes,
+			txBytes: goodDATxBytes,
+			want:    "admitted tx failed DA relay validation",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHarness(t, 1, "127.0.0.1:0", nil)
+			h.service.cfg.TxPool = staticTxPool{raw: tc.poolRaw}
+			txid, err := canonicalTxID(tc.txBytes)
+			if err != nil {
+				t.Fatalf("canonicalTxID: %v", err)
+			}
+			err = h.service.AnnounceTx(tc.txBytes)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("AnnounceTx err=%v, want containing %q", err, tc.want)
+			}
+			if h.service.txSeen.Has(txid) {
+				t.Fatal("AnnounceTx should not mark invalid admitted pool bytes seen")
+			}
+		})
 	}
 }
 

--- a/clients/go/node/p2p/handlers_tx_test.go
+++ b/clients/go/node/p2p/handlers_tx_test.go
@@ -5,9 +5,11 @@ import (
 	"context"
 	"crypto/sha3"
 	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -173,6 +175,19 @@ func (rejectingTxPool) Get([32]byte) ([]byte, bool) { return nil, false }
 func (rejectingTxPool) Has([32]byte) bool { return false }
 
 func (rejectingTxPool) Put([32]byte, []byte, uint64, int) bool { return false }
+
+type inconsistentTxPool struct {
+	raw []byte
+	ok  bool
+}
+
+func (p inconsistentTxPool) Get([32]byte) ([]byte, bool) {
+	return cloneBytes(p.raw), p.ok
+}
+
+func (p inconsistentTxPool) Has([32]byte) bool { return true }
+
+func (p inconsistentTxPool) Put([32]byte, []byte, uint64, int) bool { return false }
 
 func wireCanonicalMempoolForP2PTest(t *testing.T, h *testHarness) *node.Mempool {
 	t.Helper()
@@ -911,6 +926,35 @@ func TestAnnounceTxAdmissionRejectDoesNotMarkSeen(t *testing.T) {
 	}
 	if h.service.txSeen.Has(txid) {
 		t.Fatal("admission-rejected AnnounceTx must not mark tx as seen")
+	}
+}
+
+func TestEnsureRelayTxAdmittedInvariantErrorsNameTxID(t *testing.T) {
+	h := newTestHarness(t, 1, "127.0.0.1:0", nil)
+	txBytes := distinctTxBytes(t, 8841)
+	txid, err := canonicalTxID(txBytes)
+	if err != nil {
+		t.Fatalf("canonicalTxID: %v", err)
+	}
+	otherTxBytes := distinctTxBytes(t, 8842)
+	otherTxid, err := canonicalTxID(otherTxBytes)
+	if err != nil {
+		t.Fatalf("other canonicalTxID: %v", err)
+	}
+
+	h.service.cfg.TxPool = inconsistentTxPool{raw: otherTxBytes, ok: true}
+	_, _, err = h.service.ensureRelayTxAdmitted(txid, txBytes)
+	if err == nil {
+		t.Fatal("ensureRelayTxAdmitted should reject mismatched admitted txid")
+	}
+	for _, want := range []string{
+		"admitted txid mismatch",
+		fmt.Sprintf("expected=%x", txid),
+		fmt.Sprintf("got=%x", otherTxid),
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q missing %q", err.Error(), want)
+		}
 	}
 }
 

--- a/clients/go/node/p2p/service.go
+++ b/clients/go/node/p2p/service.go
@@ -263,19 +263,19 @@ func (s *Service) ensureRelayTxAdmitted(txid [32]byte, txBytes []byte) ([]byte, 
 			return nil, nil, err
 		}
 		if !s.cfg.TxPool.Put(txid, txBytes, meta.Fee, meta.Size) && !s.cfg.TxPool.Has(txid) {
-			return nil, nil, errors.New("tx not admitted to relay pool")
+			return nil, nil, fmt.Errorf("tx not admitted to relay pool: txid=%x", txid)
 		}
 	}
 	admittedTxBytes, ok := s.cfg.TxPool.Get(txid)
 	if !ok {
-		return nil, nil, errors.New("admitted tx missing from relay pool")
+		return nil, nil, fmt.Errorf("admitted tx missing from relay pool: txid=%x", txid)
 	}
 	admittedTx, admittedTxid, err := parseCanonicalTx(admittedTxBytes)
 	if err != nil {
-		return nil, nil, fmt.Errorf("admitted tx is non-canonical: %w", err)
+		return nil, nil, fmt.Errorf("admitted tx is non-canonical: txid=%x: %w", txid, err)
 	}
 	if admittedTxid != txid {
-		return nil, nil, errors.New("admitted txid mismatch")
+		return nil, nil, fmt.Errorf("admitted txid mismatch: expected=%x got=%x", txid, admittedTxid)
 	}
 	return admittedTxBytes, admittedTx, nil
 }

--- a/clients/go/node/p2p/service.go
+++ b/clients/go/node/p2p/service.go
@@ -258,6 +258,16 @@ func (s *Service) AnnounceTx(txBytes []byte) error {
 
 func (s *Service) ensureRelayTxAdmitted(txid [32]byte, txBytes []byte) ([]byte, *consensus.Tx, error) {
 	if !s.cfg.TxPool.Has(txid) {
+		submittedTx, submittedTxid, err := parseCanonicalTx(txBytes)
+		if err != nil {
+			return nil, nil, err
+		}
+		if submittedTxid != txid {
+			return nil, nil, fmt.Errorf("submitted txid mismatch: expected=%x got=%x", txid, submittedTxid)
+		}
+		if err := validateRelayDATxForAdmission(txBytes, submittedTx); err != nil {
+			return nil, nil, err
+		}
 		meta, err := s.relayTxMetadata(txBytes)
 		if err != nil {
 			return nil, nil, err
@@ -276,6 +286,9 @@ func (s *Service) ensureRelayTxAdmitted(txid [32]byte, txBytes []byte) ([]byte, 
 	}
 	if admittedTxid != txid {
 		return nil, nil, fmt.Errorf("admitted txid mismatch: expected=%x got=%x", txid, admittedTxid)
+	}
+	if err := validateRelayDATxForAdmission(admittedTxBytes, admittedTx); err != nil {
+		return nil, nil, fmt.Errorf("admitted tx failed DA relay validation: txid=%x: %w", txid, err)
 	}
 	return admittedTxBytes, admittedTx, nil
 }

--- a/clients/go/node/p2p/service.go
+++ b/clients/go/node/p2p/service.go
@@ -241,11 +241,11 @@ func (s *Service) AnnounceTx(txBytes []byte) error {
 	if s == nil {
 		return errors.New("nil service")
 	}
-	_, txid, err := parseCanonicalTx(txBytes)
+	tx, txid, err := parseCanonicalTx(txBytes)
 	if err != nil {
 		return err
 	}
-	admittedTxBytes, admittedTx, err := s.ensureRelayTxAdmitted(txid, txBytes)
+	admittedTxBytes, admittedTx, err := s.ensureRelayTxAdmitted(txid, txBytes, tx)
 	if err != nil {
 		return err
 	}
@@ -256,15 +256,8 @@ func (s *Service) AnnounceTx(txBytes []byte) error {
 	return s.broadcastInventory(nil, []InventoryVector{{Type: MSG_TX, Hash: txid}})
 }
 
-func (s *Service) ensureRelayTxAdmitted(txid [32]byte, txBytes []byte) ([]byte, *consensus.Tx, error) {
+func (s *Service) ensureRelayTxAdmitted(txid [32]byte, txBytes []byte, submittedTx *consensus.Tx) ([]byte, *consensus.Tx, error) {
 	if !s.cfg.TxPool.Has(txid) {
-		submittedTx, submittedTxid, err := parseCanonicalTx(txBytes)
-		if err != nil {
-			return nil, nil, err
-		}
-		if submittedTxid != txid {
-			return nil, nil, fmt.Errorf("submitted txid mismatch: expected=%x got=%x", txid, submittedTxid)
-		}
 		if err := validateRelayDATxForAdmission(txBytes, submittedTx); err != nil {
 			return nil, nil, err
 		}
@@ -272,7 +265,10 @@ func (s *Service) ensureRelayTxAdmitted(txid [32]byte, txBytes []byte) ([]byte, 
 		if err != nil {
 			return nil, nil, err
 		}
-		if !s.cfg.TxPool.Put(txid, txBytes, meta.Fee, meta.Size) && !s.cfg.TxPool.Has(txid) {
+		if s.cfg.TxPool.Put(txid, txBytes, meta.Fee, meta.Size) {
+			return txBytes, submittedTx, nil
+		}
+		if !s.cfg.TxPool.Has(txid) {
 			return nil, nil, fmt.Errorf("tx not admitted to relay pool: txid=%x", txid)
 		}
 	}

--- a/clients/go/node/p2p/service.go
+++ b/clients/go/node/p2p/service.go
@@ -18,6 +18,7 @@ const (
 	defaultGetBlocksBatchLimit uint64 = 128
 	defaultLocatorLimit               = 32
 	defaultTxRelayFanout              = 8
+	relayTxAdmissionAttempts          = 2
 )
 
 type ServiceConfig struct {
@@ -257,36 +258,49 @@ func (s *Service) AnnounceTx(txBytes []byte) error {
 }
 
 func (s *Service) ensureRelayTxAdmitted(txid [32]byte, txBytes []byte, submittedTx *consensus.Tx, submittedTxValidated bool) ([]byte, *consensus.Tx, error) {
-	if !s.cfg.TxPool.Has(txid) {
-		if !submittedTxValidated {
-			if err := validateRelayDATxForAdmission(txBytes, submittedTx); err != nil {
-				return nil, nil, err
-			}
-		}
-		meta, err := s.relayTxMetadata(txBytes)
-		if err != nil {
+	if !submittedTxValidated {
+		if err := validateRelayDATxForAdmission(txBytes, submittedTx); err != nil {
 			return nil, nil, err
 		}
+	}
+	var meta node.RelayTxMetadata
+	metaReady := false
+	for attempt := 0; attempt < relayTxAdmissionAttempts; attempt++ {
+		if admittedTxBytes, admittedTx, ok, err := s.relayTxFromPool(txid); ok || err != nil {
+			return admittedTxBytes, admittedTx, err
+		}
+		if !metaReady {
+			var err error
+			meta, err = s.relayTxMetadata(txBytes)
+			if err != nil {
+				return nil, nil, err
+			}
+			metaReady = true
+		}
 		s.cfg.TxPool.Put(txid, txBytes, meta.Fee, meta.Size)
-		if !s.cfg.TxPool.Has(txid) {
-			return nil, nil, fmt.Errorf("tx not admitted to relay pool: txid=%x", txid)
+		if admittedTxBytes, admittedTx, ok, err := s.relayTxFromPool(txid); ok || err != nil {
+			return admittedTxBytes, admittedTx, err
 		}
 	}
+	return nil, nil, fmt.Errorf("tx not admitted to relay pool: txid=%x", txid)
+}
+
+func (s *Service) relayTxFromPool(txid [32]byte) ([]byte, *consensus.Tx, bool, error) {
 	admittedTxBytes, ok := s.cfg.TxPool.Get(txid)
 	if !ok {
-		return nil, nil, fmt.Errorf("admitted tx missing from relay pool: txid=%x", txid)
+		return nil, nil, false, nil
 	}
 	admittedTx, admittedTxid, err := parseCanonicalTx(admittedTxBytes)
 	if err != nil {
-		return nil, nil, fmt.Errorf("admitted tx is non-canonical: txid=%x: %w", txid, err)
+		return nil, nil, true, fmt.Errorf("admitted tx is non-canonical: txid=%x: %w", txid, err)
 	}
 	if admittedTxid != txid {
-		return nil, nil, fmt.Errorf("admitted txid mismatch: expected=%x got=%x", txid, admittedTxid)
+		return nil, nil, true, fmt.Errorf("admitted txid mismatch: expected=%x got=%x", txid, admittedTxid)
 	}
 	if err := validateRelayDATxForAdmission(admittedTxBytes, admittedTx); err != nil {
-		return nil, nil, fmt.Errorf("admitted tx failed DA relay validation: txid=%x: %w", txid, err)
+		return nil, nil, true, fmt.Errorf("admitted tx failed DA relay validation: txid=%x: %w", txid, err)
 	}
-	return admittedTxBytes, admittedTx, nil
+	return admittedTxBytes, admittedTx, true, nil
 }
 
 func normalizePeerAddrs(addrs []string) []string {

--- a/clients/go/node/p2p/service.go
+++ b/clients/go/node/p2p/service.go
@@ -3,6 +3,7 @@ package p2p
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"strings"
 	"sync"
@@ -240,32 +241,43 @@ func (s *Service) AnnounceTx(txBytes []byte) error {
 	if s == nil {
 		return errors.New("nil service")
 	}
-	tx, txid, err := parseCanonicalTx(txBytes)
+	_, txid, err := parseCanonicalTx(txBytes)
 	if err != nil {
 		return err
 	}
-	if err := s.ensureRelayTxAdmitted(txid, txBytes); err != nil {
+	admittedTxBytes, admittedTx, err := s.ensureRelayTxAdmitted(txid, txBytes)
+	if err != nil {
 		return err
 	}
-	_ = s.stageRelayDATx("", txBytes, tx)
+	_ = s.stageRelayDATx("", admittedTxBytes, admittedTx)
 	if !s.txSeen.Add(txid) {
 		return nil
 	}
 	return s.broadcastInventory(nil, []InventoryVector{{Type: MSG_TX, Hash: txid}})
 }
 
-func (s *Service) ensureRelayTxAdmitted(txid [32]byte, txBytes []byte) error {
-	if s.cfg.TxPool.Has(txid) {
-		return nil
+func (s *Service) ensureRelayTxAdmitted(txid [32]byte, txBytes []byte) ([]byte, *consensus.Tx, error) {
+	if !s.cfg.TxPool.Has(txid) {
+		meta, err := s.relayTxMetadata(txBytes)
+		if err != nil {
+			return nil, nil, err
+		}
+		if !s.cfg.TxPool.Put(txid, txBytes, meta.Fee, meta.Size) && !s.cfg.TxPool.Has(txid) {
+			return nil, nil, errors.New("tx not admitted to relay pool")
+		}
 	}
-	meta, err := s.relayTxMetadata(txBytes)
+	admittedTxBytes, ok := s.cfg.TxPool.Get(txid)
+	if !ok {
+		return nil, nil, errors.New("admitted tx missing from relay pool")
+	}
+	admittedTx, admittedTxid, err := parseCanonicalTx(admittedTxBytes)
 	if err != nil {
-		return err
+		return nil, nil, fmt.Errorf("admitted tx is non-canonical: %w", err)
 	}
-	if s.cfg.TxPool.Put(txid, txBytes, meta.Fee, meta.Size) || s.cfg.TxPool.Has(txid) {
-		return nil
+	if admittedTxid != txid {
+		return nil, nil, errors.New("admitted txid mismatch")
 	}
-	return errors.New("tx not admitted to relay pool")
+	return admittedTxBytes, admittedTx, nil
 }
 
 func normalizePeerAddrs(addrs []string) []string {

--- a/clients/go/node/p2p/service.go
+++ b/clients/go/node/p2p/service.go
@@ -245,7 +245,7 @@ func (s *Service) AnnounceTx(txBytes []byte) error {
 	if err != nil {
 		return err
 	}
-	admittedTxBytes, admittedTx, err := s.ensureRelayTxAdmitted(txid, txBytes, tx)
+	admittedTxBytes, admittedTx, err := s.ensureRelayTxAdmitted(txid, txBytes, tx, false)
 	if err != nil {
 		return err
 	}
@@ -256,10 +256,12 @@ func (s *Service) AnnounceTx(txBytes []byte) error {
 	return s.broadcastInventory(nil, []InventoryVector{{Type: MSG_TX, Hash: txid}})
 }
 
-func (s *Service) ensureRelayTxAdmitted(txid [32]byte, txBytes []byte, submittedTx *consensus.Tx) ([]byte, *consensus.Tx, error) {
+func (s *Service) ensureRelayTxAdmitted(txid [32]byte, txBytes []byte, submittedTx *consensus.Tx, submittedTxValidated bool) ([]byte, *consensus.Tx, error) {
 	if !s.cfg.TxPool.Has(txid) {
-		if err := validateRelayDATxForAdmission(txBytes, submittedTx); err != nil {
-			return nil, nil, err
+		if !submittedTxValidated {
+			if err := validateRelayDATxForAdmission(txBytes, submittedTx); err != nil {
+				return nil, nil, err
+			}
 		}
 		meta, err := s.relayTxMetadata(txBytes)
 		if err != nil {

--- a/clients/go/node/p2p/service.go
+++ b/clients/go/node/p2p/service.go
@@ -249,7 +249,7 @@ func (s *Service) AnnounceTx(txBytes []byte) error {
 	if err != nil {
 		return err
 	}
-	_ = s.stageRelayDATx("", admittedTxBytes, admittedTx)
+	_ = s.stageRelayDATx("", admittedTxBytes, admittedTx, true)
 	if !s.txSeen.Add(txid) {
 		return nil
 	}
@@ -267,9 +267,7 @@ func (s *Service) ensureRelayTxAdmitted(txid [32]byte, txBytes []byte, submitted
 		if err != nil {
 			return nil, nil, err
 		}
-		if s.cfg.TxPool.Put(txid, txBytes, meta.Fee, meta.Size) {
-			return txBytes, submittedTx, nil
-		}
+		s.cfg.TxPool.Put(txid, txBytes, meta.Fee, meta.Size)
 		if !s.cfg.TxPool.Has(txid) {
 			return nil, nil, fmt.Errorf("tx not admitted to relay pool: txid=%x", txid)
 		}


### PR DESCRIPTION
Invariant:
DA relay retains raw DA commit/chunk tx bytes only when they are canonical bytes admitted to the relay txpool, and retained memory remains accounted.

Layer:
Go P2P implementation and tests.

Files changed:
- clients/go/node/p2p/da_relay_ingest.go
- clients/go/node/p2p/da_relay_state.go
- clients/go/node/p2p/da_relay_state_test.go
- clients/go/node/p2p/handlers_tx.go
- clients/go/node/p2p/handlers_tx_test.go
- clients/go/node/p2p/service.go

Tests:
- go test ./node/p2p -run "DA|Da|Tx" -count=1: PASS
- go test ./node/p2p -count=1: PASS
- local Go coverage gate: PASS, diff coverage 92.68%, variation -0.03%

Behavior impact:
DA relay staging now uses the txpool-admitted bytes for DA commit/chunk retention, strips internal tx bytes from caller clones, and avoids retaining a second complete-set chunk payload copy.

Compatibility impact:
No wire-format, consensus, Rust, miner selection, or runtime wiring changes.

Known non-goals:
- No provider API exposure.
- No miner selection or block construction changes.
- No cmd/runtime wiring.
- No stale pruning or continuous txpool revalidation.

Follow-ups:
RUB-370 can build the provider boundary on top of this retained-byte prerequisite.

Risk:
Confined to Go P2P DA relay staging/accounting paths.

Rollback:
Revert this commit.

Not checked:
GitHub CI and bot review results are pending after PR creation.
