### PR TITLE
RUB-370: expose complete DA set provider

### DIFF
--- a/clients/go/node/miner_da_provider.go
+++ b/clients/go/node/miner_da_provider.go
@@ -1,0 +1,20 @@
+package node
+
+// CompleteDASetProvider exposes caller-owned COMPLETE_SET DA relay snapshots.
+type CompleteDASetProvider interface {
+	CompleteDASetCandidates(maxPayloadBytes uint64) []CompleteDASetCandidate
+}
+
+// CompleteDASetCandidate is a caller-owned snapshot of one relay-complete DA set.
+type CompleteDASetCandidate struct {
+	DAID         [32]byte
+	PayloadBytes uint64
+	CommitTx     []byte
+	Chunks       []CompleteDASetChunkCandidate
+}
+
+// CompleteDASetChunkCandidate is a caller-owned DA chunk transaction snapshot.
+type CompleteDASetChunkCandidate struct {
+	Index uint16
+	Tx    []byte
+}

--- a/clients/go/node/p2p/da_relay_provider.go
+++ b/clients/go/node/p2p/da_relay_provider.go
@@ -1,0 +1,80 @@
+package p2p
+
+import (
+	"bytes"
+	"sort"
+
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/node"
+)
+
+// CompleteDASetCandidates returns caller-owned COMPLETE_SET snapshots up to maxPayloadBytes.
+func (s *Service) CompleteDASetCandidates(maxPayloadBytes uint64) []node.CompleteDASetCandidate {
+	if s == nil {
+		return nil
+	}
+	return s.daRelay.completeSetCandidates(maxPayloadBytes)
+}
+
+func (s *daRelayState) completeSetCandidates(maxPayloadBytes uint64) []node.CompleteDASetCandidate {
+	if s == nil || maxPayloadBytes == 0 {
+		return nil
+	}
+	var candidates []node.CompleteDASetCandidate
+	var payloadBytes uint64
+	for _, record := range s.completeSetCandidateRecordsSnapshot() {
+		if record.payloadBytes > maxPayloadBytes-payloadBytes {
+			continue
+		}
+		candidate, ok := record.completeSetCandidate()
+		if !ok {
+			continue
+		}
+		candidates = append(candidates, candidate)
+		payloadBytes += record.payloadBytes
+	}
+	return candidates
+}
+
+func (s *daRelayState) completeSetCandidateRecordsSnapshot() []daRelaySetRecord {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	daIDs := make([][32]byte, 0, len(s.sets))
+	for daID, record := range s.sets {
+		if record.state == daRelayStateCompleteSet {
+			daIDs = append(daIDs, daID)
+		}
+	}
+	sort.Slice(daIDs, func(i, j int) bool {
+		return bytes.Compare(daIDs[i][:], daIDs[j][:]) < 0
+	})
+
+	records := make([]daRelaySetRecord, 0, len(daIDs))
+	for _, daID := range daIDs {
+		records = append(records, s.sets[daID].cloneForStateMutation())
+	}
+	return records
+}
+
+func (r daRelaySetRecord) completeSetCandidate() (node.CompleteDASetCandidate, bool) {
+	if r.commit.chunkCount == 0 || len(r.commit.txBytes) == 0 {
+		return node.CompleteDASetCandidate{}, false
+	}
+	chunks := make([]node.CompleteDASetChunkCandidate, 0, r.commit.chunkCount)
+	for i := uint16(0); i < r.commit.chunkCount; i++ {
+		chunk, ok := r.chunks[i]
+		if !ok || len(chunk.txBytes) == 0 {
+			return node.CompleteDASetCandidate{}, false
+		}
+		chunks = append(chunks, node.CompleteDASetChunkCandidate{
+			Index: i,
+			Tx:    cloneBytes(chunk.txBytes),
+		})
+	}
+	return node.CompleteDASetCandidate{
+		DAID:         r.daID,
+		PayloadBytes: r.payloadBytes,
+		CommitTx:     cloneBytes(r.commit.txBytes),
+		Chunks:       chunks,
+	}, true
+}

--- a/clients/go/node/p2p/da_relay_state_test.go
+++ b/clients/go/node/p2p/da_relay_state_test.go
@@ -938,6 +938,69 @@ func TestDARelayCommitCompletesOrphanChunks(t *testing.T) {
 	}
 }
 
+func TestDARelayCompleteSetCandidatesExposeOnlyCompleteImmutableOrdered(t *testing.T) {
+	state := newDARelayStateForTest(t, defaultDARelayCaps())
+	orphanID, stagedID := daRelayTestID(31), daRelayTestID(32)
+	lateID, earlyID := daRelayTestID(33), daRelayTestID(30)
+	earlyPayload0, earlyPayload1 := []byte("early-0"), []byte("early-1")
+	latePayload := []byte("late")
+
+	mustAddDAChunk(t, state, "peer-o", daRelayTestChunkWithTxBytes(orphanID, 0, 6, []byte("chunk-orphan"), []byte("orphan")))
+	mustAddDACommit(t, state, "peer-s", daRelayTestCommitWithTxBytes(stagedID, 6, []byte("commit-staged"), []byte("staged")))
+	mustAddDACommit(t, state, "peer-l", daRelayTestCommitWithTxBytes(lateID, 7, []byte("commit-late"), latePayload))
+	mustAddDAChunk(t, state, "peer-l", daRelayTestChunkWithTxBytes(lateID, 0, uint64(len(latePayload)), []byte("chunk-late"), latePayload))
+	mustAddDACommit(t, state, "peer-e", daRelayTestCommitWithTxBytes(earlyID, 8, []byte("commit-early"), earlyPayload0, earlyPayload1))
+	for _, chunk := range []daRelayChunk{
+		daRelayTestChunkWithTxBytes(earlyID, 1, uint64(len(earlyPayload1)), []byte("chunk-early-1"), earlyPayload1),
+		daRelayTestChunkWithTxBytes(earlyID, 0, uint64(len(earlyPayload0)), []byte("chunk-early-0"), earlyPayload0),
+	} {
+		mustAddDAChunk(t, state, "peer-e", chunk)
+	}
+
+	candidates := (&Service{daRelay: state}).CompleteDASetCandidates(^uint64(0))
+	if len(candidates) != 2 {
+		t.Fatalf("complete candidates=%d, want 2", len(candidates))
+	}
+	if candidates[0].DAID != earlyID || candidates[1].DAID != lateID {
+		t.Fatalf("candidate order=%x,%x want %x,%x", candidates[0].DAID, candidates[1].DAID, earlyID, lateID)
+	}
+	if got := candidates[0].PayloadBytes; got != uint64(len(earlyPayload0)+len(earlyPayload1)) {
+		t.Fatalf("early payload bytes=%d, want %d", got, len(earlyPayload0)+len(earlyPayload1))
+	}
+	if !reflect.DeepEqual(candidates[0].CommitTx, []byte("commit-early")) {
+		t.Fatalf("early commit tx=%q", candidates[0].CommitTx)
+	}
+	if len(candidates[0].Chunks) != 2 || candidates[0].Chunks[0].Index != 0 || candidates[0].Chunks[1].Index != 1 {
+		t.Fatalf("early chunks=%+v, want indexes 0,1", candidates[0].Chunks)
+	}
+	candidates[0].CommitTx[0] = 'X'
+	candidates[0].Chunks[0].Tx[0] = 'Y'
+	again := state.completeSetCandidates(^uint64(0))
+	if !reflect.DeepEqual(again[0].CommitTx, []byte("commit-early")) || !reflect.DeepEqual(again[0].Chunks[0].Tx, []byte("chunk-early-0")) {
+		t.Fatalf("candidate snapshot aliases state: commit=%q chunk=%q", again[0].CommitTx, again[0].Chunks[0].Tx)
+	}
+	earlyPayloadBytes := uint64(len(earlyPayload0) + len(earlyPayload1))
+	if got := state.completeSetCandidates(earlyPayloadBytes); len(got) != 1 || got[0].DAID != earlyID {
+		t.Fatalf("bounded candidates=%+v, want only early da_id", got)
+	}
+	latePayloadBytes := uint64(len(latePayload))
+	if got := state.completeSetCandidates(latePayloadBytes); len(got) != 1 || got[0].DAID != lateID {
+		t.Fatalf("oversized early candidate blocked later fit=%+v, want only late da_id", got)
+	}
+}
+
+func TestServiceCompleteDASetCandidatesNilSafe(t *testing.T) {
+	if got := (*Service)(nil).CompleteDASetCandidates(1); got != nil {
+		t.Fatalf("nil service candidates=%v, want nil", got)
+	}
+	if got := (&Service{}).CompleteDASetCandidates(1); got != nil {
+		t.Fatalf("service without relay candidates=%v, want nil", got)
+	}
+	if got := (*daRelayState)(nil).completeSetCandidates(1); got != nil {
+		t.Fatalf("nil state candidates=%v, want nil", got)
+	}
+}
+
 func TestDARelayCloneModesKeepStateCopiesShallowAndCallerCopiesDeep(t *testing.T) {
 	daID := daRelayTestID(7)
 	record := daRelaySetRecord{


### PR DESCRIPTION
Invariant:
Expose a miner-facing provider surface that returns caller-owned snapshots of relay COMPLETE_SET DA sets only.

Layer:
Go implementation and tests.

Files changed:
- clients/go/node/miner_da_provider.go: adds CompleteDASetProvider and candidate snapshot types.
- clients/go/node/p2p/da_relay_provider.go: adds the Service adapter and DA relay COMPLETE_SET snapshot builder.
- clients/go/node/p2p/da_relay_state_test.go: covers complete-only exposure, caller-owned snapshots, deterministic ordering, payload budgeting, and nil safety.

Tests:
- cd clients/go && go test ./node/p2p -run "CompleteSetCandidates" -count=1
- cd clients/go && go test ./node/p2p -run "DA|Da|Complete|Miner|Template" -count=1
- cd clients/go && go test ./node -run "DA|Da|Complete|Miner|Template" -count=1
- Local Go coverage preflight: PASS, diff coverage 91.23%, variation -0.00%.

Behavior impact:
P2P Service now exposes immutable COMPLETE_SET DA relay candidates for miner/template callers. Incomplete ORPHAN_CHUNKS and STAGED_COMMIT records remain hidden.

Compatibility impact:
No wire format, consensus, Rust, conformance, runtime wiring, or miner selection changes.

Known non-goals:
- No txpool revalidation or stale COMPLETE_SET pruning.
- No DA relay admission, completion, eviction, TTL, prefetch, or peer quota changes.
- No block-template selection or cmd/runtime wiring.

Risk:
Low: new provider is read-only and returns cloned byte slices.

Rollback:
Revert the provider type, adapter, and tests.

Not checked:
Full clients/go package suite was not rerun outside the local Go coverage preflight.

Closes #1820.