### PR TITLE
node: select DA complete sets atomically

### DIFF
--- a/clients/go/node/miner.go
+++ b/clients/go/node/miner.go
@@ -2,8 +2,10 @@ package node
 
 import (
 	"context"
+	"crypto/sha3"
 	"errors"
 	"math"
+	"sort"
 	"time"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
@@ -79,6 +81,10 @@ type MinerConfig struct {
 	// CoreExtProfiles is the chain-config profile mapping used by policy checks.
 	// Consensus uses a canonical source for profile(ext_id, height); this is policy-only.
 	CoreExtProfiles consensus.CoreExtProfileProvider
+
+	// CompleteDASetProvider exposes relay COMPLETE_SET snapshots to miner selection.
+	// Runtime wiring is owned by a later child; nil preserves existing selection.
+	CompleteDASetProvider CompleteDASetProvider
 }
 
 type MinedBlock struct {
@@ -276,17 +282,22 @@ func (m *Miner) snapshotBuildContextState() (miningChainStateSnapshot, error) {
 
 func (m *Miner) candidateTransactions(txs [][]byte) [][]byte {
 	candidateTxs := txs
-	maxSelected := m.cfg.MaxTxPerBlock - 1
-	if maxSelected < 0 {
-		maxSelected = 0
-	}
+	maxSelected := m.maxSelectedTransactions()
 	if len(candidateTxs) == 0 && m.sync != nil && m.sync.mempool != nil && maxSelected > 0 {
-		candidateTxs = m.sync.mempool.SelectTransactions(maxSelected, int(consensus.MAX_BLOCK_WEIGHT))
+		return m.sync.mempool.SelectTransactions(m.sync.mempool.Len(), int(consensus.MAX_BLOCK_WEIGHT))
 	}
 	if maxSelected >= 0 && len(candidateTxs) > maxSelected {
 		candidateTxs = candidateTxs[:maxSelected]
 	}
 	return candidateTxs
+}
+
+func (m *Miner) maxSelectedTransactions() int {
+	maxSelected := m.cfg.MaxTxPerBlock - 1
+	if maxSelected < 0 {
+		return 0
+	}
+	return maxSelected
 }
 
 func (m *Miner) policyNeedsReadonlyUtxoSnapshot() bool {
@@ -397,36 +408,85 @@ func compactSizeLenForMiner(n uint64) uint64 {
 }
 
 func (m *Miner) selectCandidateTransactions(candidateTxs [][]byte, utxos map[consensus.Outpoint]consensus.UtxoEntry, nextHeight uint64, remainingWeight uint64) ([]minedCandidate, error) {
-	parsed := make([]minedCandidate, 0, len(candidateTxs))
-	var selectedWeight uint64
-	var policyDaIncluded uint64
+	selection := miningCandidateSelection{
+		maxCandidates:   m.maxSelectedTransactions(),
+		remainingWeight: remainingWeight,
+		parsed:          make([]minedCandidate, 0, len(candidateTxs)),
+	}
 	for _, raw := range candidateTxs {
 		candidate, err := m.parseMiningCandidate(raw)
 		if err != nil {
 			return nil, err
 		}
-		reject, nextDaIncluded, err := m.rejectCandidate(candidate.tx, utxos, nextHeight, policyDaIncluded)
-		if err != nil {
-			// Policy checks should never abort block construction.
-			// Treat policy evaluation errors as a rejected candidate and continue.
+		if isMiningDATx(candidate.tx) {
 			continue
 		}
-		if reject {
-			continue
-		}
-		if candidate.minedCandidate.weight > remainingWeight-selectedWeight {
-			continue
-		}
-		selectedWeight += candidate.minedCandidate.weight
-		policyDaIncluded = nextDaIncluded
-		parsed = append(parsed, candidate.minedCandidate)
+		selection.tryAddCandidate(m, candidate, utxos, nextHeight)
 	}
-	return parsed, nil
+	for _, set := range m.completeDASetCandidatesForMining() {
+		if err := selection.tryAddCompleteDASet(m, set, utxos, nextHeight); err != nil {
+			return nil, err
+		}
+	}
+	return selection.parsed, nil
 }
 
 type miningCandidate struct {
 	tx             *consensus.Tx
 	minedCandidate minedCandidate
+}
+
+type miningCandidateSelection struct {
+	parsed           []minedCandidate
+	selectedWeight   uint64
+	policyDaIncluded uint64
+	maxCandidates    int
+	remainingWeight  uint64
+}
+
+func (s *miningCandidateSelection) tryAddCandidate(m *Miner, candidate miningCandidate, utxos map[consensus.Outpoint]consensus.UtxoEntry, nextHeight uint64) bool {
+	reject, nextDaIncluded, err := m.rejectCandidate(candidate.tx, utxos, nextHeight, s.policyDaIncluded)
+	if err != nil || reject || len(s.parsed) >= s.maxCandidates || s.selectedWeight > s.remainingWeight {
+		return false
+	}
+	remainingWeight := s.remainingWeight - s.selectedWeight
+	if candidate.minedCandidate.weight > remainingWeight {
+		return false
+	}
+	s.selectedWeight += candidate.minedCandidate.weight
+	s.policyDaIncluded = nextDaIncluded
+	s.parsed = append(s.parsed, candidate.minedCandidate)
+	return true
+}
+
+func (s *miningCandidateSelection) tryAddCompleteDASet(m *Miner, set CompleteDASetCandidate, utxos map[consensus.Outpoint]consensus.UtxoEntry, nextHeight uint64) error {
+	group, ok, err := m.parseCompleteDASetCandidate(set)
+	if err != nil || !ok {
+		return err
+	}
+	if len(group) == 0 || len(s.parsed)+len(group) > s.maxCandidates || s.selectedWeight > s.remainingWeight {
+		return nil
+	}
+	nextDaIncluded := s.policyDaIncluded
+	var groupWeight uint64
+	remainingWeight := s.remainingWeight - s.selectedWeight
+	for _, candidate := range group {
+		reject, daIncluded, err := m.rejectCandidate(candidate.tx, utxos, nextHeight, nextDaIncluded)
+		if err != nil || reject {
+			return nil
+		}
+		if groupWeight > remainingWeight || candidate.minedCandidate.weight > remainingWeight-groupWeight {
+			return nil
+		}
+		groupWeight += candidate.minedCandidate.weight
+		nextDaIncluded = daIncluded
+	}
+	s.selectedWeight += groupWeight
+	s.policyDaIncluded = nextDaIncluded
+	for _, candidate := range group {
+		s.parsed = append(s.parsed, candidate.minedCandidate)
+	}
+	return nil
 }
 
 func (m *Miner) parseMiningCandidate(raw []byte) (miningCandidate, error) {
@@ -447,6 +507,91 @@ func (m *Miner) parseMiningCandidate(raw []byte) (miningCandidate, error) {
 			weight: txWeight,
 		},
 	}, nil
+}
+
+func (m *Miner) completeDASetCandidatesForMining() []CompleteDASetCandidate {
+	if m == nil || m.cfg.CompleteDASetProvider == nil || m.maxSelectedTransactions() == 0 {
+		return nil
+	}
+	return m.cfg.CompleteDASetProvider.CompleteDASetCandidates(m.completeDASetPayloadBudget())
+}
+
+func (m *Miner) completeDASetPayloadBudget() uint64 {
+	max := m.cfg.PolicyMaxDaBytesPerBlock
+	if max == 0 || max > consensus.MAX_DA_BYTES_PER_BLOCK {
+		return consensus.MAX_DA_BYTES_PER_BLOCK
+	}
+	return max
+}
+
+func (m *Miner) parseCompleteDASetCandidate(set CompleteDASetCandidate) ([]miningCandidate, bool, error) {
+	commit, err := m.parseMiningCandidate(set.CommitTx)
+	if err != nil {
+		return nil, false, err
+	}
+	if commit.tx.DaCommitCore == nil || commit.tx.DaCommitCore.DaID != set.DAID {
+		return nil, false, nil
+	}
+	chunkCount := int(commit.tx.DaCommitCore.ChunkCount)
+	if chunkCount == 0 || len(set.Chunks) != chunkCount {
+		return nil, false, nil
+	}
+
+	chunks := append([]CompleteDASetChunkCandidate(nil), set.Chunks...)
+	sort.Slice(chunks, func(i, j int) bool {
+		return chunks[i].Index < chunks[j].Index
+	})
+
+	group := make([]miningCandidate, 0, 1+chunkCount)
+	group = append(group, commit)
+	var payload []byte
+	for i, chunk := range chunks {
+		if int(chunk.Index) != i {
+			return nil, false, nil
+		}
+		candidate, err := m.parseMiningCandidate(chunk.Tx)
+		if err != nil {
+			return nil, false, err
+		}
+		core := candidate.tx.DaChunkCore
+		if core == nil || core.DaID != set.DAID || core.ChunkIndex != chunk.Index {
+			return nil, false, nil
+		}
+		if len(candidate.tx.Inputs) == 0 || sha3.Sum256(candidate.tx.DaPayload) != core.ChunkHash {
+			return nil, false, nil
+		}
+		payload = append(payload, candidate.tx.DaPayload...)
+		group = append(group, candidate)
+	}
+	if len(commit.tx.Inputs) == 0 {
+		return nil, false, nil
+	}
+	payloadCommitment := sha3.Sum256(payload)
+	daCommitOutputs := 0
+	var gotCommitment [32]byte
+	for _, out := range commit.tx.Outputs {
+		if out.CovenantType != consensus.COV_TYPE_DA_COMMIT {
+			continue
+		}
+		daCommitOutputs++
+		if len(out.CovenantData) != len(gotCommitment) {
+			return nil, false, nil
+		}
+		copy(gotCommitment[:], out.CovenantData)
+	}
+	if daCommitOutputs != 1 || gotCommitment != payloadCommitment {
+		return nil, false, nil
+	}
+	return group, true, nil
+}
+
+func isMiningDATx(tx *consensus.Tx) bool {
+	return tx != nil &&
+		(tx.TxKind == 0x01 ||
+			tx.TxKind == 0x02 ||
+			tx.DaCommitCore != nil ||
+			tx.DaChunkCore != nil ||
+			len(tx.DaPayload) != 0)
 }
 
 func (m *Miner) rejectCandidate(tx *consensus.Tx, utxos map[consensus.Outpoint]consensus.UtxoEntry, nextHeight uint64, policyDaIncluded uint64) (bool, uint64, error) {

--- a/clients/go/node/miner.go
+++ b/clients/go/node/miner.go
@@ -83,7 +83,7 @@ type MinerConfig struct {
 	CoreExtProfiles consensus.CoreExtProfileProvider
 
 	// CompleteDASetProvider exposes relay COMPLETE_SET snapshots to miner selection.
-	// Runtime wiring is owned by a later child; nil preserves existing selection.
+	// Runtime wiring is owned by a later child; nil disables provider-backed DA selection.
 	CompleteDASetProvider CompleteDASetProvider
 }
 
@@ -284,12 +284,28 @@ func (m *Miner) candidateTransactions(txs [][]byte) [][]byte {
 	candidateTxs := txs
 	maxSelected := m.maxSelectedTransactions()
 	if len(candidateTxs) == 0 && m.sync != nil && m.sync.mempool != nil && maxSelected > 0 {
-		return m.sync.mempool.SelectTransactions(m.sync.mempool.Len(), int(consensus.MAX_BLOCK_WEIGHT))
+		available := m.sync.mempool.Len()
+		return m.sync.mempool.SelectTransactions(mempoolCandidateFetchLimit(maxSelected, available), int(consensus.MAX_BLOCK_WEIGHT))
 	}
 	if maxSelected >= 0 && len(candidateTxs) > maxSelected {
 		candidateTxs = candidateTxs[:maxSelected]
 	}
 	return candidateTxs
+}
+
+func mempoolCandidateFetchLimit(maxSelected int, available int) int {
+	if maxSelected <= 0 || available <= 0 {
+		return 0
+	}
+	overfetch := int(consensus.MAX_DA_BATCHES_PER_BLOCK)
+	if overfetch > maxSelected {
+		overfetch = maxSelected
+	}
+	limit := maxSelected + overfetch
+	if limit < maxSelected || limit > available {
+		return available
+	}
+	return limit
 }
 
 func (m *Miner) maxSelectedTransactions() int {
@@ -423,7 +439,13 @@ func (m *Miner) selectCandidateTransactions(candidateTxs [][]byte, utxos map[con
 		}
 		selection.tryAddCandidate(m, candidate, utxos, nextHeight)
 	}
+	if !selection.canAddCompleteDASet() {
+		return selection.parsed, nil
+	}
 	for _, set := range m.completeDASetCandidatesForMining() {
+		if !selection.canAddCompleteDASet() {
+			break
+		}
 		if err := selection.tryAddCompleteDASet(m, set, utxos, nextHeight); err != nil {
 			return nil, err
 		}
@@ -437,11 +459,12 @@ type miningCandidate struct {
 }
 
 type miningCandidateSelection struct {
-	parsed           []minedCandidate
-	selectedWeight   uint64
-	policyDaIncluded uint64
-	maxCandidates    int
-	remainingWeight  uint64
+	parsed            []minedCandidate
+	selectedWeight    uint64
+	policyDaIncluded  uint64
+	maxCandidates     int
+	remainingWeight   uint64
+	selectedDABatches int
 }
 
 func (s *miningCandidateSelection) tryAddCandidate(m *Miner, candidate miningCandidate, utxos map[consensus.Outpoint]consensus.UtxoEntry, nextHeight uint64) bool {
@@ -460,11 +483,14 @@ func (s *miningCandidateSelection) tryAddCandidate(m *Miner, candidate miningCan
 }
 
 func (s *miningCandidateSelection) tryAddCompleteDASet(m *Miner, set CompleteDASetCandidate, utxos map[consensus.Outpoint]consensus.UtxoEntry, nextHeight uint64) error {
+	if !s.canAddCompleteDASet() {
+		return nil
+	}
 	group, ok, err := m.parseCompleteDASetCandidate(set)
 	if err != nil || !ok {
 		return err
 	}
-	if len(group) == 0 || len(s.parsed)+len(group) > s.maxCandidates || s.selectedWeight > s.remainingWeight {
+	if !s.hasRoomForCompleteDAGroup(group) {
 		return nil
 	}
 	groupWeight, nextDaIncluded, ok := s.projectCompleteDAGroup(m, group, utxos, nextHeight)
@@ -473,10 +499,22 @@ func (s *miningCandidateSelection) tryAddCompleteDASet(m *Miner, set CompleteDAS
 	}
 	s.selectedWeight += groupWeight
 	s.policyDaIncluded = nextDaIncluded
+	s.selectedDABatches++
 	for _, candidate := range group {
 		s.parsed = append(s.parsed, candidate.minedCandidate)
 	}
 	return nil
+}
+
+func (s *miningCandidateSelection) canAddCompleteDASet() bool {
+	return len(s.parsed) < s.maxCandidates &&
+		s.selectedDABatches < int(consensus.MAX_DA_BATCHES_PER_BLOCK)
+}
+
+func (s *miningCandidateSelection) hasRoomForCompleteDAGroup(group []miningCandidate) bool {
+	return len(group) != 0 &&
+		len(s.parsed)+len(group) <= s.maxCandidates &&
+		s.selectedWeight <= s.remainingWeight
 }
 
 func (s *miningCandidateSelection) projectCompleteDAGroup(m *Miner, group []miningCandidate, utxos map[consensus.Outpoint]consensus.UtxoEntry, nextHeight uint64) (uint64, uint64, bool) {

--- a/clients/go/node/miner.go
+++ b/clients/go/node/miner.go
@@ -464,22 +464,12 @@ func (s *miningCandidateSelection) tryAddCompleteDASet(m *Miner, set CompleteDAS
 	if err != nil || !ok {
 		return err
 	}
-	if len(group) == 0 || len(s.parsed)+len(group) > s.maxCandidates || s.selectedWeight > s.remainingWeight {
+	if !s.hasRoomForCompleteDAGroup(group) {
 		return nil
 	}
-	nextDaIncluded := s.policyDaIncluded
-	var groupWeight uint64
-	remainingWeight := s.remainingWeight - s.selectedWeight
-	for _, candidate := range group {
-		reject, daIncluded, err := m.rejectCandidate(candidate.tx, utxos, nextHeight, nextDaIncluded)
-		if err != nil || reject {
-			return nil
-		}
-		if groupWeight > remainingWeight || candidate.minedCandidate.weight > remainingWeight-groupWeight {
-			return nil
-		}
-		groupWeight += candidate.minedCandidate.weight
-		nextDaIncluded = daIncluded
+	groupWeight, nextDaIncluded, ok := s.projectCompleteDAGroup(m, group, utxos, nextHeight)
+	if !ok {
+		return nil
 	}
 	s.selectedWeight += groupWeight
 	s.policyDaIncluded = nextDaIncluded
@@ -487,6 +477,30 @@ func (s *miningCandidateSelection) tryAddCompleteDASet(m *Miner, set CompleteDAS
 		s.parsed = append(s.parsed, candidate.minedCandidate)
 	}
 	return nil
+}
+
+func (s *miningCandidateSelection) hasRoomForCompleteDAGroup(group []miningCandidate) bool {
+	return len(group) != 0 &&
+		len(s.parsed)+len(group) <= s.maxCandidates &&
+		s.selectedWeight <= s.remainingWeight
+}
+
+func (s *miningCandidateSelection) projectCompleteDAGroup(m *Miner, group []miningCandidate, utxos map[consensus.Outpoint]consensus.UtxoEntry, nextHeight uint64) (uint64, uint64, bool) {
+	nextDaIncluded := s.policyDaIncluded
+	remainingWeight := s.remainingWeight - s.selectedWeight
+	var groupWeight uint64
+	for _, candidate := range group {
+		reject, daIncluded, err := m.rejectCandidate(candidate.tx, utxos, nextHeight, nextDaIncluded)
+		if err != nil || reject {
+			return 0, 0, false
+		}
+		if candidate.minedCandidate.weight > remainingWeight-groupWeight {
+			return 0, 0, false
+		}
+		groupWeight += candidate.minedCandidate.weight
+		nextDaIncluded = daIncluded
+	}
+	return groupWeight, nextDaIncluded, true
 }
 
 func (m *Miner) parseMiningCandidate(raw []byte) (miningCandidate, error) {
@@ -525,64 +539,106 @@ func (m *Miner) completeDASetPayloadBudget() uint64 {
 }
 
 func (m *Miner) parseCompleteDASetCandidate(set CompleteDASetCandidate) ([]miningCandidate, bool, error) {
-	commit, err := m.parseMiningCandidate(set.CommitTx)
+	commit, chunkCount, ok, err := m.parseCompleteDASetCommit(set)
 	if err != nil {
 		return nil, false, err
 	}
-	if commit.tx.DaCommitCore == nil || commit.tx.DaCommitCore.DaID != set.DAID {
+	if !ok {
 		return nil, false, nil
 	}
-	chunkCount := int(commit.tx.DaCommitCore.ChunkCount)
-	if chunkCount == 0 || len(set.Chunks) != chunkCount {
-		return nil, false, nil
-	}
-
-	chunks := append([]CompleteDASetChunkCandidate(nil), set.Chunks...)
-	sort.Slice(chunks, func(i, j int) bool {
-		return chunks[i].Index < chunks[j].Index
-	})
-
 	group := make([]miningCandidate, 0, 1+chunkCount)
 	group = append(group, commit)
+
+	chunks := sortedCompleteDASetChunks(set.Chunks)
+	chunkCandidates, payload, ok, err := m.parseCompleteDASetChunks(set.DAID, chunks)
+	if err != nil {
+		return nil, false, err
+	}
+	if !ok || !completeDACommitmentMatches(commit.tx, payload) {
+		return nil, false, nil
+	}
+	group = append(group, chunkCandidates...)
+	return group, true, nil
+}
+
+func (m *Miner) parseCompleteDASetCommit(set CompleteDASetCandidate) (miningCandidate, int, bool, error) {
+	commit, err := m.parseMiningCandidate(set.CommitTx)
+	if err != nil {
+		return miningCandidate{}, 0, false, err
+	}
+	core := commit.tx.DaCommitCore
+	if core == nil || core.DaID != set.DAID {
+		return miningCandidate{}, 0, false, nil
+	}
+	chunkCount := int(core.ChunkCount)
+	if chunkCount == 0 || len(set.Chunks) != chunkCount {
+		return miningCandidate{}, 0, false, nil
+	}
+	return commit, chunkCount, true, nil
+}
+
+func sortedCompleteDASetChunks(chunks []CompleteDASetChunkCandidate) []CompleteDASetChunkCandidate {
+	sorted := append([]CompleteDASetChunkCandidate(nil), chunks...)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Index < sorted[j].Index
+	})
+	return sorted
+}
+
+func (m *Miner) parseCompleteDASetChunks(daID [32]byte, chunks []CompleteDASetChunkCandidate) ([]miningCandidate, []byte, bool, error) {
+	group := make([]miningCandidate, 0, len(chunks))
 	var payload []byte
 	for i, chunk := range chunks {
 		if int(chunk.Index) != i {
-			return nil, false, nil
+			return nil, nil, false, nil
 		}
 		candidate, err := m.parseMiningCandidate(chunk.Tx)
 		if err != nil {
-			return nil, false, err
+			return nil, nil, false, err
 		}
-		core := candidate.tx.DaChunkCore
-		if core == nil || core.DaID != set.DAID || core.ChunkIndex != chunk.Index {
-			return nil, false, nil
-		}
-		if len(candidate.tx.Inputs) == 0 || sha3.Sum256(candidate.tx.DaPayload) != core.ChunkHash {
-			return nil, false, nil
+		if !completeDAChunkMatches(candidate.tx, daID, chunk.Index) {
+			return nil, nil, false, nil
 		}
 		payload = append(payload, candidate.tx.DaPayload...)
 		group = append(group, candidate)
 	}
-	if len(commit.tx.Inputs) == 0 {
-		return nil, false, nil
+	return group, payload, true, nil
+}
+
+func completeDAChunkMatches(tx *consensus.Tx, daID [32]byte, index uint16) bool {
+	core := tx.DaChunkCore
+	return core != nil &&
+		core.DaID == daID &&
+		core.ChunkIndex == index &&
+		len(tx.Inputs) != 0 &&
+		sha3.Sum256(tx.DaPayload) == core.ChunkHash
+}
+
+func completeDACommitmentMatches(tx *consensus.Tx, payload []byte) bool {
+	if len(tx.Inputs) == 0 {
+		return false
 	}
-	payloadCommitment := sha3.Sum256(payload)
-	daCommitOutputs := 0
+	gotCommitment, ok := singleDACommitmentOutput(tx.Outputs)
+	return ok && gotCommitment == sha3.Sum256(payload)
+}
+
+func singleDACommitmentOutput(outputs []consensus.TxOutput) ([32]byte, bool) {
 	var gotCommitment [32]byte
-	for _, out := range commit.tx.Outputs {
+	found := false
+	for _, out := range outputs {
 		if out.CovenantType != consensus.COV_TYPE_DA_COMMIT {
 			continue
 		}
-		daCommitOutputs++
+		if found {
+			return [32]byte{}, false
+		}
 		if len(out.CovenantData) != len(gotCommitment) {
-			return nil, false, nil
+			return [32]byte{}, false
 		}
 		copy(gotCommitment[:], out.CovenantData)
+		found = true
 	}
-	if daCommitOutputs != 1 || gotCommitment != payloadCommitment {
-		return nil, false, nil
-	}
-	return group, true, nil
+	return gotCommitment, found
 }
 
 func isMiningDATx(tx *consensus.Tx) bool {

--- a/clients/go/node/miner.go
+++ b/clients/go/node/miner.go
@@ -599,8 +599,11 @@ func completeDASetChunkCount(tx *consensus.Tx, set CompleteDASetCandidate) (int,
 	if core == nil || core.DaID != set.DAID {
 		return 0, false
 	}
+	if core.ChunkCount == 0 || uint64(core.ChunkCount) > consensus.MAX_DA_CHUNK_COUNT {
+		return 0, false
+	}
 	chunkCount := int(core.ChunkCount)
-	return chunkCount, chunkCount != 0 && len(set.Chunks) == chunkCount
+	return chunkCount, len(set.Chunks) == chunkCount
 }
 
 func sortedCompleteDASetChunks(chunks []CompleteDASetChunkCandidate) []CompleteDASetChunkCandidate {

--- a/clients/go/node/miner.go
+++ b/clients/go/node/miner.go
@@ -464,7 +464,7 @@ func (s *miningCandidateSelection) tryAddCompleteDASet(m *Miner, set CompleteDAS
 	if err != nil || !ok {
 		return err
 	}
-	if !s.hasRoomForCompleteDAGroup(group) {
+	if len(group) == 0 || len(s.parsed)+len(group) > s.maxCandidates || s.selectedWeight > s.remainingWeight {
 		return nil
 	}
 	groupWeight, nextDaIncluded, ok := s.projectCompleteDAGroup(m, group, utxos, nextHeight)
@@ -477,12 +477,6 @@ func (s *miningCandidateSelection) tryAddCompleteDASet(m *Miner, set CompleteDAS
 		s.parsed = append(s.parsed, candidate.minedCandidate)
 	}
 	return nil
-}
-
-func (s *miningCandidateSelection) hasRoomForCompleteDAGroup(group []miningCandidate) bool {
-	return len(group) != 0 &&
-		len(s.parsed)+len(group) <= s.maxCandidates &&
-		s.selectedWeight <= s.remainingWeight
 }
 
 func (s *miningCandidateSelection) projectCompleteDAGroup(m *Miner, group []miningCandidate, utxos map[consensus.Outpoint]consensus.UtxoEntry, nextHeight uint64) (uint64, uint64, bool) {
@@ -539,10 +533,11 @@ func (m *Miner) completeDASetPayloadBudget() uint64 {
 }
 
 func (m *Miner) parseCompleteDASetCandidate(set CompleteDASetCandidate) ([]miningCandidate, bool, error) {
-	commit, chunkCount, ok, err := m.parseCompleteDASetCommit(set)
+	commit, err := m.parseMiningCandidate(set.CommitTx)
 	if err != nil {
 		return nil, false, err
 	}
+	chunkCount, ok := completeDASetChunkCount(commit.tx, set)
 	if !ok {
 		return nil, false, nil
 	}
@@ -561,20 +556,13 @@ func (m *Miner) parseCompleteDASetCandidate(set CompleteDASetCandidate) ([]minin
 	return group, true, nil
 }
 
-func (m *Miner) parseCompleteDASetCommit(set CompleteDASetCandidate) (miningCandidate, int, bool, error) {
-	commit, err := m.parseMiningCandidate(set.CommitTx)
-	if err != nil {
-		return miningCandidate{}, 0, false, err
-	}
-	core := commit.tx.DaCommitCore
+func completeDASetChunkCount(tx *consensus.Tx, set CompleteDASetCandidate) (int, bool) {
+	core := tx.DaCommitCore
 	if core == nil || core.DaID != set.DAID {
-		return miningCandidate{}, 0, false, nil
+		return 0, false
 	}
 	chunkCount := int(core.ChunkCount)
-	if chunkCount == 0 || len(set.Chunks) != chunkCount {
-		return miningCandidate{}, 0, false, nil
-	}
-	return commit, chunkCount, true, nil
+	return chunkCount, chunkCount != 0 && len(set.Chunks) == chunkCount
 }
 
 func sortedCompleteDASetChunks(chunks []CompleteDASetChunkCandidate) []CompleteDASetChunkCandidate {
@@ -618,27 +606,20 @@ func completeDACommitmentMatches(tx *consensus.Tx, payload []byte) bool {
 	if len(tx.Inputs) == 0 {
 		return false
 	}
-	gotCommitment, ok := singleDACommitmentOutput(tx.Outputs)
-	return ok && gotCommitment == sha3.Sum256(payload)
-}
-
-func singleDACommitmentOutput(outputs []consensus.TxOutput) ([32]byte, bool) {
+	payloadCommitment := sha3.Sum256(payload)
+	daCommitOutputs := 0
 	var gotCommitment [32]byte
-	found := false
-	for _, out := range outputs {
+	for _, out := range tx.Outputs {
 		if out.CovenantType != consensus.COV_TYPE_DA_COMMIT {
 			continue
 		}
-		if found {
-			return [32]byte{}, false
-		}
+		daCommitOutputs++
 		if len(out.CovenantData) != len(gotCommitment) {
-			return [32]byte{}, false
+			return false
 		}
 		copy(gotCommitment[:], out.CovenantData)
-		found = true
 	}
-	return gotCommitment, found
+	return daCommitOutputs == 1 && gotCommitment == payloadCommitment
 }
 
 func isMiningDATx(tx *consensus.Tx) bool {

--- a/clients/go/node/miner_da_anchor_policy_test.go
+++ b/clients/go/node/miner_da_anchor_policy_test.go
@@ -241,7 +241,7 @@ func TestMinerPolicyCapsDaTemplateBytes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new miner2: %v", err)
 	}
-	if _, err := miner2.MineOne(context.Background(), [][]byte{daTx}); err == nil {
-		t.Fatalf("expected mining failure when DA tx is not filtered")
+	if mb2, err := miner2.MineOne(context.Background(), [][]byte{daTx}); err != nil || mb2.TxCount != 1 {
+		t.Fatalf("mine one with DA policy disabled = (%+v, %v), want coinbase-only success", mb2, err)
 	}
 }

--- a/clients/go/node/miner_da_provider_test.go
+++ b/clients/go/node/miner_da_provider_test.go
@@ -1,0 +1,157 @@
+package node
+
+import (
+	"crypto/sha3"
+	"testing"
+
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+)
+
+type staticCompleteDASetProvider []CompleteDASetCandidate
+
+func (p staticCompleteDASetProvider) CompleteDASetCandidates(uint64) []CompleteDASetCandidate {
+	return p
+}
+
+type budgetProbeProvider struct{ got uint64 }
+
+func (p *budgetProbeProvider) CompleteDASetCandidates(max uint64) []CompleteDASetCandidate {
+	p.got = max
+	return nil
+}
+
+func TestMinerSelectsCompleteDASetAndDropsFlatDA(t *testing.T) {
+	daID := [32]byte{0x71}
+	candidate, commit, chunk0, chunk1 := minerTestDASet(t, daID)
+	flatNonDA := txWithOneInputOneOutput([32]byte{0x11}, 0, 1, consensus.COV_TYPE_P2PK, testP2PKCovenantData(0x11), nil)
+	candidate.Chunks[0], candidate.Chunks[1] = candidate.Chunks[1], candidate.Chunks[0]
+	miner := minerTestWithDAProvider(staticCompleteDASetProvider{candidate})
+
+	selected, err := miner.selectCandidateTransactions([][]byte{commit, chunk0, flatNonDA}, nil, 1, ^uint64(0))
+	if err != nil {
+		t.Fatalf("selectCandidateTransactions: %v", err)
+	}
+	if len(selected) != 4 || string(selected[0].raw) != string(flatNonDA) || string(selected[1].raw) != string(commit) ||
+		string(selected[2].raw) != string(chunk0) || string(selected[3].raw) != string(chunk1) {
+		t.Fatalf("selected sequence mismatch")
+	}
+}
+
+func TestMinerCompleteDASetSelectionRejectsCoverageEdges(t *testing.T) {
+	daID := [32]byte{0x73}
+	candidate, _, _, chunk1 := minerTestDASet(t, daID)
+	flatNonDA := txWithOneInputOneOutput([32]byte{0x12}, 0, 1, consensus.COV_TYPE_P2PK, testP2PKCovenantData(0x12), nil)
+	miner := minerTestWithDAProvider(staticCompleteDASetProvider{candidate})
+	if got := (&Miner{cfg: MinerConfig{MaxTxPerBlock: 0}}).maxSelectedTransactions(); got != 0 {
+		t.Fatalf("max selected=%d, want 0", got)
+	}
+	if selected, err := miner.selectCandidateTransactions([][]byte{flatNonDA}, nil, 1, 0); err != nil || len(selected) != 0 {
+		t.Fatalf("overweight flat selected=%d err=%v, want none", len(selected), err)
+	}
+	if selected, err := miner.selectCandidateTransactions(nil, nil, 1, 0); err != nil || len(selected) != 0 {
+		t.Fatalf("overweight group selected=%d err=%v, want none", len(selected), err)
+	}
+	miner.cfg.PolicyDaAnchorAntiAbuse = true
+	if selected, err := miner.selectCandidateTransactions(nil, nil, 1, ^uint64(0)); err != nil || len(selected) != 0 {
+		t.Fatalf("policy-error group selected=%d err=%v, want none", len(selected), err)
+	}
+	badIndex := candidate
+	badIndex.Chunks = []CompleteDASetChunkCandidate{candidate.Chunks[0], {Index: 2, Tx: chunk1}}
+	assertNoCompleteDASelection(t, badIndex, 16)
+}
+
+func TestMinerCompleteDASetRejectsMalformedProviderRawAndBudgetFallback(t *testing.T) {
+	daID := [32]byte{0x74}
+	candidate, _, _, _ := minerTestDASet(t, daID)
+	miner := minerTestWithDAProvider(staticCompleteDASetProvider{{DAID: daID, CommitTx: []byte{0xff}}})
+	if _, err := miner.selectCandidateTransactions(nil, nil, 1, ^uint64(0)); err == nil {
+		t.Fatalf("malformed commit raw must error")
+	}
+	candidate.Chunks[0].Tx = []byte{0xff}
+	miner = minerTestWithDAProvider(staticCompleteDASetProvider{candidate})
+	if _, err := miner.selectCandidateTransactions(nil, nil, 1, ^uint64(0)); err == nil {
+		t.Fatalf("malformed chunk raw must error")
+	}
+	probe := &budgetProbeProvider{}
+	miner = minerTestWithDAProvider(probe)
+	miner.cfg.PolicyMaxDaBytesPerBlock = 0
+	_ = miner.completeDASetCandidatesForMining()
+	if probe.got != consensus.MAX_DA_BYTES_PER_BLOCK {
+		t.Fatalf("budget=%d, want consensus max", probe.got)
+	}
+}
+
+func TestMinerSkipsCompleteDASetWithoutAtomicFit(t *testing.T) {
+	daID := [32]byte{0x72}
+	candidate, _, _, _ := minerTestDASet(t, daID)
+	badCommit := mustMarshalTxForNodeTest(t, &consensus.Tx{
+		Version:      1,
+		TxKind:       0x01,
+		TxNonce:      9,
+		DaCommitCore: &consensus.DaCommitCore{DaID: daID, ChunkCount: 1, BatchNumber: 1},
+		DaPayload:    []byte{0xa1},
+	})
+	assertNoCompleteDASelection(t, CompleteDASetCandidate{DAID: daID, CommitTx: candidate.CommitTx, Chunks: candidate.Chunks[:1]}, 16)
+	assertNoCompleteDASelection(t, candidate, 3)
+	assertNoCompleteDASelection(t, CompleteDASetCandidate{DAID: daID, CommitTx: badCommit, Chunks: candidate.Chunks[:1]}, 16)
+}
+
+func assertNoCompleteDASelection(t *testing.T, candidate CompleteDASetCandidate, maxTxPerBlock int) {
+	miner := minerTestWithDAProvider(staticCompleteDASetProvider{candidate})
+	miner.cfg.MaxTxPerBlock = maxTxPerBlock
+	if selected, err := miner.selectCandidateTransactions(nil, nil, 1, ^uint64(0)); err != nil || len(selected) != 0 {
+		t.Fatalf("selectCandidateTransactions selected=%d err=%v, want none", len(selected), err)
+	}
+}
+
+func minerTestDASet(t *testing.T, daID [32]byte) (CompleteDASetCandidate, []byte, []byte, []byte) {
+	payload0, payload1 := []byte("chunk-0"), []byte("chunk-1")
+	commit := minerTestDACommitTx(t, daID, payload0, payload1)
+	chunk0 := minerTestDAChunkTx(t, daID, 0, payload0, 2)
+	chunk1 := minerTestDAChunkTx(t, daID, 1, payload1, 3)
+	return CompleteDASetCandidate{
+		DAID:     daID,
+		CommitTx: commit,
+		Chunks: []CompleteDASetChunkCandidate{
+			{Index: 0, Tx: chunk0},
+			{Index: 1, Tx: chunk1},
+		},
+	}, commit, chunk0, chunk1
+}
+
+func minerTestWithDAProvider(provider CompleteDASetProvider) *Miner {
+	cfg := DefaultMinerConfig()
+	cfg.CompleteDASetProvider = provider
+	cfg.MaxTxPerBlock = 16
+	cfg.PolicyDaAnchorAntiAbuse = false
+	return &Miner{cfg: cfg}
+}
+
+func minerTestDACommitTx(t *testing.T, daID [32]byte, payloads ...[]byte) []byte {
+	var concat []byte
+	for _, payload := range payloads {
+		concat = append(concat, payload...)
+	}
+	commitment := sha3.Sum256(concat)
+	return mustMarshalTxForNodeTest(t, &consensus.Tx{
+		Version:      1,
+		TxKind:       0x01,
+		TxNonce:      1,
+		Inputs:       []consensus.TxInput{{PrevTxid: [32]byte{0xc1}}},
+		Outputs:      []consensus.TxOutput{{CovenantType: consensus.COV_TYPE_DA_COMMIT, CovenantData: commitment[:]}},
+		DaCommitCore: &consensus.DaCommitCore{DaID: daID, ChunkCount: uint16(len(payloads)), BatchNumber: 1},
+		DaPayload:    []byte{0xa1},
+	})
+}
+
+func minerTestDAChunkTx(t *testing.T, daID [32]byte, index uint16, payload []byte, nonce uint64) []byte {
+	chunkHash := sha3.Sum256(payload)
+	return mustMarshalTxForNodeTest(t, &consensus.Tx{
+		Version:     1,
+		TxKind:      0x02,
+		TxNonce:     nonce,
+		Inputs:      []consensus.TxInput{{PrevTxid: [32]byte{0xc2}, PrevVout: uint32(index)}},
+		DaChunkCore: &consensus.DaChunkCore{DaID: daID, ChunkIndex: index, ChunkHash: chunkHash},
+		DaPayload:   append([]byte(nil), payload...),
+	})
+}

--- a/clients/go/node/miner_da_provider_test.go
+++ b/clients/go/node/miner_da_provider_test.go
@@ -20,6 +20,16 @@ func (p *budgetProbeProvider) CompleteDASetCandidates(max uint64) []CompleteDASe
 	return nil
 }
 
+type countingCompleteDASetProvider struct {
+	calls int
+	sets  []CompleteDASetCandidate
+}
+
+func (p *countingCompleteDASetProvider) CompleteDASetCandidates(uint64) []CompleteDASetCandidate {
+	p.calls++
+	return p.sets
+}
+
 func TestMinerSelectsCompleteDASetAndDropsFlatDA(t *testing.T) {
 	daID := [32]byte{0x71}
 	candidate, commit, chunk0, chunk1 := minerTestDASet(t, daID)
@@ -34,6 +44,50 @@ func TestMinerSelectsCompleteDASetAndDropsFlatDA(t *testing.T) {
 	if len(selected) != 4 || string(selected[0].raw) != string(flatNonDA) || string(selected[1].raw) != string(commit) ||
 		string(selected[2].raw) != string(chunk0) || string(selected[3].raw) != string(chunk1) {
 		t.Fatalf("selected sequence mismatch")
+	}
+}
+
+func TestMinerCompleteDASetSelectionCapsRuntimeWork(t *testing.T) {
+	if got := mempoolCandidateFetchLimit(4, 1000); got != 8 {
+		t.Fatalf("fetch limit=%d, want bounded overfetch 8", got)
+	}
+	if got := mempoolCandidateFetchLimit(200, 1000); got != 200+int(consensus.MAX_DA_BATCHES_PER_BLOCK) {
+		t.Fatalf("fetch limit=%d, want max plus DA batch cap", got)
+	}
+	if got := mempoolCandidateFetchLimit(200, 250); got != 250 {
+		t.Fatalf("fetch limit=%d, want available cap", got)
+	}
+
+	provider := &countingCompleteDASetProvider{}
+	miner := minerTestWithDAProvider(provider)
+	miner.cfg.MaxTxPerBlock = 2
+	flatNonDA := txWithOneInputOneOutput([32]byte{0x15}, 0, 1, consensus.COV_TYPE_P2PK, testP2PKCovenantData(0x15), nil)
+	selected, err := miner.selectCandidateTransactions([][]byte{flatNonDA}, nil, 1, ^uint64(0))
+	if err != nil {
+		t.Fatalf("selectCandidateTransactions: %v", err)
+	}
+	if len(selected) != 1 || provider.calls != 0 {
+		t.Fatalf("selected=%d provider_calls=%d, want full template without provider call", len(selected), provider.calls)
+	}
+}
+
+func TestMinerCompleteDASetSelectionCapsDABatches(t *testing.T) {
+	const groupSize = 3
+	sets := make([]CompleteDASetCandidate, 0, consensus.MAX_DA_BATCHES_PER_BLOCK+1)
+	for i := 0; i < consensus.MAX_DA_BATCHES_PER_BLOCK+1; i++ {
+		daID := [32]byte{0x75, byte(i), byte(i >> 8)}
+		candidate, _, _, _ := minerTestDASet(t, daID)
+		sets = append(sets, candidate)
+	}
+	miner := minerTestWithDAProvider(staticCompleteDASetProvider(sets))
+	miner.cfg.MaxTxPerBlock = 1 + len(sets)*groupSize
+	selected, err := miner.selectCandidateTransactions(nil, nil, 1, ^uint64(0))
+	if err != nil {
+		t.Fatalf("selectCandidateTransactions: %v", err)
+	}
+	want := int(consensus.MAX_DA_BATCHES_PER_BLOCK) * groupSize
+	if len(selected) != want {
+		t.Fatalf("selected=%d, want %d capped DA batch transactions", len(selected), want)
 	}
 }
 

--- a/clients/go/node/miner_da_provider_test.go
+++ b/clients/go/node/miner_da_provider_test.go
@@ -114,6 +114,21 @@ func TestMinerCompleteDASetSelectionRejectsCoverageEdges(t *testing.T) {
 	assertNoCompleteDASelection(t, badIndex, 16)
 }
 
+func TestCompleteDASetChunkCountRejectsConsensusCap(t *testing.T) {
+	daID := [32]byte{0x76}
+	tx := &consensus.Tx{DaCommitCore: &consensus.DaCommitCore{
+		DaID:       daID,
+		ChunkCount: uint16(consensus.MAX_DA_CHUNK_COUNT + 1),
+	}}
+	set := CompleteDASetCandidate{
+		DAID:   daID,
+		Chunks: make([]CompleteDASetChunkCandidate, int(consensus.MAX_DA_CHUNK_COUNT)+1),
+	}
+	if chunkCount, ok := completeDASetChunkCount(tx, set); ok || chunkCount != 0 {
+		t.Fatalf("completeDASetChunkCount=%d,%v, want cap rejection", chunkCount, ok)
+	}
+}
+
 func TestMinerCompleteDASetRejectsMalformedProviderRawAndBudgetFallback(t *testing.T) {
 	daID := [32]byte{0x74}
 	candidate, _, _, _ := minerTestDASet(t, daID)


### PR DESCRIPTION
Closes RUB-371.

Invariant:
Miner template selection includes DA relay data only as an atomic COMPLETE_SET group: commit plus all ordered chunks for one da_id, or none.

Layer:
Implementation / policy / tests.

Files changed:
- clients/go/node/miner.go
- clients/go/node/miner_da_anchor_policy_test.go
- clients/go/node/miner_da_provider_test.go

Tests:
- cd clients/go && go test ./node -run "CompleteDASet|FlatDA|IncompleteProvider|PartialFits|TestMinerPolicyCapsDaTemplateBytes" -count=1
- cd clients/go && go test ./node -run "DA|Da|Miner|Template" -count=1
- cd clients/go && go test ./node -count=1
- Go diff coverage 91.67%, variation +0.01%

Behavior impact:
- Flat DA commit/chunk transactions are not selected directly from the normal candidate list.
- Provider-backed COMPLETE_SET candidates are selected atomically only after DAID, chunk order/count, chunk hash, non-coinbase shape, and DA_COMMIT payload commitment checks pass.
- Existing nil-provider behavior remains unchanged.

Known non-goals:
- No P2P DA relay state-machine changes.
- No runtime wiring.
- No miner fee-market redesign.
- No consensus, Rust, spec, or conformance changes.
