### PR TITLE
RUB-374: filter flat DA miner candidates

### DIFF
--- a/clients/go/node/miner.go
+++ b/clients/go/node/miner.go
@@ -275,18 +275,25 @@ func (m *Miner) snapshotBuildContextState() (miningChainStateSnapshot, error) {
 }
 
 func (m *Miner) candidateTransactions(txs [][]byte) [][]byte {
-	candidateTxs := txs
+	maxSelected := m.maxSelectedTransactions()
+	if maxSelected == 0 {
+		return nil
+	}
+	if len(txs) != 0 {
+		return pickFlatCandidateRaw(txs, maxSelected)
+	}
+	if m.sync == nil || m.sync.mempool == nil {
+		return nil
+	}
+	return m.mempoolCandidateTransactions(maxSelected)
+}
+
+func (m *Miner) maxSelectedTransactions() int {
 	maxSelected := m.cfg.MaxTxPerBlock - 1
 	if maxSelected < 0 {
-		maxSelected = 0
+		return 0
 	}
-	if len(candidateTxs) == 0 && m.sync != nil && m.sync.mempool != nil && maxSelected > 0 {
-		candidateTxs = m.sync.mempool.SelectTransactions(maxSelected, int(consensus.MAX_BLOCK_WEIGHT))
-	}
-	if maxSelected >= 0 && len(candidateTxs) > maxSelected {
-		candidateTxs = candidateTxs[:maxSelected]
-	}
-	return candidateTxs
+	return maxSelected
 }
 
 func (m *Miner) policyNeedsReadonlyUtxoSnapshot() bool {
@@ -397,31 +404,47 @@ func compactSizeLenForMiner(n uint64) uint64 {
 }
 
 func (m *Miner) selectCandidateTransactions(candidateTxs [][]byte, utxos map[consensus.Outpoint]consensus.UtxoEntry, nextHeight uint64, remainingWeight uint64) ([]minedCandidate, error) {
-	parsed := make([]minedCandidate, 0, len(candidateTxs))
+	maxSelected := m.maxSelectedTransactions()
+	parsed := make([]minedCandidate, 0, min(len(candidateTxs), maxSelected))
 	var selectedWeight uint64
 	var policyDaIncluded uint64
 	for _, raw := range candidateTxs {
-		candidate, err := m.parseMiningCandidate(raw)
+		if len(parsed) >= maxSelected {
+			break
+		}
+		candidate, nextDaIncluded, ok, err := m.trySelectFlatCandidate(raw, utxos, nextHeight, selectedWeight, remainingWeight, policyDaIncluded)
 		if err != nil {
 			return nil, err
 		}
-		reject, nextDaIncluded, err := m.rejectCandidate(candidate.tx, utxos, nextHeight, policyDaIncluded)
-		if err != nil {
-			// Policy checks should never abort block construction.
-			// Treat policy evaluation errors as a rejected candidate and continue.
-			continue
+		if ok {
+			selectedWeight += candidate.weight
+			policyDaIncluded = nextDaIncluded
+			parsed = append(parsed, candidate)
 		}
-		if reject {
-			continue
-		}
-		if candidate.minedCandidate.weight > remainingWeight-selectedWeight {
-			continue
-		}
-		selectedWeight += candidate.minedCandidate.weight
-		policyDaIncluded = nextDaIncluded
-		parsed = append(parsed, candidate.minedCandidate)
 	}
 	return parsed, nil
+}
+
+func (m *Miner) trySelectFlatCandidate(raw []byte, utxos map[consensus.Outpoint]consensus.UtxoEntry, nextHeight uint64, selectedWeight uint64, remainingWeight uint64, policyDaIncluded uint64) (minedCandidate, uint64, bool, error) {
+	candidate, err := m.parseMiningCandidate(raw)
+	if err != nil {
+		return minedCandidate{}, policyDaIncluded, false, err
+	}
+	if isMiningDATx(candidate.tx) {
+		return minedCandidate{}, policyDaIncluded, false, nil
+	}
+	reject, nextDaIncluded, err := m.rejectCandidate(candidate.tx, utxos, nextHeight, policyDaIncluded)
+	if err != nil || reject {
+		return minedCandidate{}, policyDaIncluded, false, nil
+	}
+	if selectedWeight >= remainingWeight {
+		return minedCandidate{}, policyDaIncluded, false, nil
+	}
+	availableWeight := remainingWeight - selectedWeight
+	if candidate.minedCandidate.weight > availableWeight {
+		return minedCandidate{}, policyDaIncluded, false, nil
+	}
+	return candidate.minedCandidate, nextDaIncluded, true, nil
 }
 
 type miningCandidate struct {

--- a/clients/go/node/miner_da_anchor_policy_test.go
+++ b/clients/go/node/miner_da_anchor_policy_test.go
@@ -241,7 +241,11 @@ func TestMinerPolicyCapsDaTemplateBytes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new miner2: %v", err)
 	}
-	if _, err := miner2.MineOne(context.Background(), [][]byte{daTx}); err == nil {
-		t.Fatalf("expected mining failure when DA tx is not filtered")
+	mb, err = miner2.MineOne(context.Background(), [][]byte{daTx})
+	if err != nil {
+		t.Fatalf("mine one with DA policy disabled: %v", err)
+	}
+	if mb.TxCount != 1 {
+		t.Fatalf("tx_count=%d, want 1 (coinbase only; standalone DA tx must be filtered)", mb.TxCount)
 	}
 }

--- a/clients/go/node/miner_da_flat_filter_test.go
+++ b/clients/go/node/miner_da_flat_filter_test.go
@@ -1,0 +1,102 @@
+package node
+
+import (
+	"bytes"
+	"crypto/sha3"
+	"testing"
+
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+)
+
+func TestMinerFlatDAFilterPreservesExplicitNonDACandidates(t *testing.T) {
+	daCommit := daCommitTxBytesForMinerPolicyTest(1, []byte("manifest"))
+	daChunk := minerFlatDATestChunk(t, [32]byte{0x71}, 0, []byte("chunk"))
+	nonDA := minerFlatTestNonDA(0x11)
+
+	miner := &Miner{cfg: MinerConfig{MaxTxPerBlock: 2}}
+	candidates := miner.candidateTransactions([][]byte{daCommit, daChunk, nonDA})
+	selected, err := miner.selectCandidateTransactions(candidates, nil, 1, ^uint64(0))
+	if err != nil {
+		t.Fatalf("selectCandidateTransactions: %v", err)
+	}
+	if len(selected) != 1 || !bytes.Equal(selected[0].raw, nonDA) {
+		t.Fatalf("selected=%d, want only trailing non-DA candidate", len(selected))
+	}
+}
+
+func TestMinerMempoolCandidateEntriesSkipFlatDABeforeWindowCap(t *testing.T) {
+	daCommit := daCommitTxBytesForMinerPolicyTest(1, []byte("manifest"))
+	nonDA := minerFlatTestNonDA(0x12)
+	entries := []*mempoolEntry{
+		{raw: daCommit, size: len(daCommit)},
+		{raw: nonDA, size: len(nonDA)},
+		{raw: minerFlatDATestChunk(t, [32]byte{0x72}, 0, []byte("chunk")), size: 1},
+	}
+
+	selected := pickMinerCandidateEntries(entries, 1, 1<<20)
+	if len(selected) != 1 || !bytes.Equal(selected[0], nonDA) {
+		t.Fatalf("selected=%d, want non-DA candidate past skipped flat DA entries", len(selected))
+	}
+}
+
+func TestMinerFlatDAFilterKeepsCapacityBoundedByCandidates(t *testing.T) {
+	nonDA := minerFlatTestNonDA(0x13)
+
+	selected := pickFlatCandidateRaw([][]byte{nonDA}, 1_000_000)
+	if len(selected) != 1 || cap(selected) != 1 {
+		t.Fatalf("explicit selected len/cap=%d/%d, want 1/1", len(selected), cap(selected))
+	}
+
+	entries := []*mempoolEntry{{raw: nonDA, size: len(nonDA)}}
+	selected = pickMinerCandidateEntries(entries, 1_000_000, 1<<20)
+	if len(selected) != 1 || cap(selected) != 1 {
+		t.Fatalf("mempool selected len/cap=%d/%d, want 1/1", len(selected), cap(selected))
+	}
+}
+
+func TestMinerFlatDAFilterSkipsDAInSelectionPath(t *testing.T) {
+	miner := &Miner{cfg: DefaultMinerConfig()}
+	if _, _, ok, err := miner.trySelectFlatCandidate(daCommitTxBytesForMinerPolicyTest(2, []byte("manifest")), nil, 1, 0, ^uint64(0), 0); err != nil || ok {
+		t.Fatalf("DA candidate ok=%v err=%v, want skipped without error", ok, err)
+	}
+}
+
+func TestMinerFlatDAFilterSkipsWeightBudgetRejects(t *testing.T) {
+	nonDA := minerFlatTestNonDA(0x15)
+	miner := &Miner{cfg: DefaultMinerConfig()}
+	if _, _, ok, err := miner.trySelectFlatCandidate(nonDA, nil, 1, 0, 0, 0); err != nil || ok {
+		t.Fatalf("zero remaining weight ok=%v err=%v, want skipped without error", ok, err)
+	}
+	if _, _, ok, err := miner.trySelectFlatCandidate(nonDA, nil, 1, 0, 1, 0); err != nil || ok {
+		t.Fatalf("overweight candidate ok=%v err=%v, want skipped without error", ok, err)
+	}
+}
+
+func TestMinerFlatDAFilterPreservesNonCanonicalInputError(t *testing.T) {
+	badDACommit := append(daCommitTxBytesForMinerPolicyTest(1, []byte("manifest")), 0x00)
+	miner := &Miner{cfg: MinerConfig{MaxTxPerBlock: 2}}
+
+	candidates := miner.candidateTransactions([][]byte{badDACommit})
+	if len(candidates) != 1 {
+		t.Fatalf("candidate count=%d, want malformed DA-shaped input preserved", len(candidates))
+	}
+	if _, err := miner.selectCandidateTransactions(candidates, nil, 1, ^uint64(0)); err == nil {
+		t.Fatalf("expected non-canonical miner input error")
+	}
+}
+
+func minerFlatDATestChunk(t *testing.T, daID [32]byte, index uint16, payload []byte) []byte {
+	t.Helper()
+	chunkHash := sha3.Sum256(payload)
+	return mustMarshalTxForNodeTest(t, &consensus.Tx{
+		Version:     1,
+		TxKind:      0x02,
+		TxNonce:     uint64(index) + 1,
+		DaChunkCore: &consensus.DaChunkCore{DaID: daID, ChunkIndex: index, ChunkHash: chunkHash},
+		DaPayload:   append([]byte(nil), payload...),
+	})
+}
+
+func minerFlatTestNonDA(marker byte) []byte {
+	return txWithOneInputOneOutput([32]byte{marker}, 0, 1, consensus.COV_TYPE_P2PK, testP2PKCovenantData(marker), nil)
+}

--- a/clients/go/node/miner_flat_filter.go
+++ b/clients/go/node/miner_flat_filter.go
@@ -1,0 +1,60 @@
+package node
+
+import "github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+
+func (m *Miner) mempoolCandidateTransactions(maxSelected int) [][]byte {
+	entries := m.sync.mempool.snapshotEntries()
+	sortMempoolEntries(entries)
+	return pickMinerCandidateEntries(entries, maxSelected, int(consensus.MAX_BLOCK_WEIGHT))
+}
+
+func pickFlatCandidateRaw(txs [][]byte, maxCount int) [][]byte {
+	if maxCount <= 0 {
+		return nil
+	}
+	selected := make([][]byte, 0, min(len(txs), maxCount))
+	for _, raw := range txs {
+		if isMiningDATxRaw(raw) {
+			continue
+		}
+		selected = append(selected, raw)
+		if len(selected) >= maxCount {
+			break
+		}
+	}
+	return selected
+}
+
+func pickMinerCandidateEntries(entries []*mempoolEntry, maxCount int, maxBytes int) [][]byte {
+	if maxCount <= 0 || maxBytes <= 0 {
+		return nil
+	}
+	selected := make([][]byte, 0, min(len(entries), maxCount))
+	usedBytes := 0
+	for _, entry := range entries {
+		if entry == nil || isMiningDATxRaw(entry.raw) {
+			continue
+		}
+		if len(selected) >= maxCount {
+			break
+		}
+		if entry.size > maxBytes-usedBytes {
+			continue
+		}
+		selected = append(selected, append([]byte(nil), entry.raw...))
+		usedBytes += entry.size
+	}
+	return selected
+}
+
+func isMiningDATxRaw(raw []byte) bool {
+	tx, _, _, consumed, err := consensus.ParseTx(raw)
+	if err != nil || consumed != len(raw) {
+		return false
+	}
+	return isMiningDATx(tx)
+}
+
+func isMiningDATx(tx *consensus.Tx) bool {
+	return tx != nil && (tx.TxKind == 0x01 || tx.TxKind == 0x02)
+}


### PR DESCRIPTION
Invariant:
Miner candidate selection does not mine standalone DA_COMMIT_TX or DA_CHUNK_TX from flat caller or mempool candidate lists, while preserving non-DA candidate selection order.

Layer:
Go node miner implementation and focused tests.

Files changed:
- clients/go/node/miner.go
- clients/go/node/miner_flat_filter.go
- clients/go/node/miner_da_flat_filter_test.go
- clients/go/node/miner_da_anchor_policy_test.go

Tests:
- go test ./node -run "FlatDA|CompleteDASet|Miner|Template" -count=1
- Go coverage/Codacy preflight: PASS, diff coverage 88.37%, variation -0.03%

Behavior impact:
Standalone flat DA commit/chunk transactions are skipped before they can fill miner selection slots. Malformed DA-shaped raw inputs are still preserved for the canonical miner-input error path.

Compatibility impact:
Non-DA candidate ordering and selection remain unchanged.

Known non-goals:
- No provider COMPLETE_SET selection or validation.
- No duplicate DAID handling.
- No DA-byte budget or streaming hash changes.
- No miner runtime wiring.
- No P2P relay state changes.

Risk:
Low; change is limited to miner candidate filtering before template assembly.

Rollback:
Revert this PR to restore previous flat candidate selection behavior.

Not checked:
- Full Go package sweep beyond the listed targeted test and coverage preflight.
