### PR TITLE
RUB-375: validate DA provider miner candidates

### DIFF
--- a/clients/go/node/miner.go
+++ b/clients/go/node/miner.go
@@ -414,6 +414,7 @@ func (m *Miner) selectCandidateTransactions(candidateTxs [][]byte, utxos map[con
 	var selectedWeight uint64
 	var policyDaIncluded uint64
 	selectedNonces := make(map[uint64]struct{}, maxSelected)
+	selectedInputs := make(map[consensus.Outpoint]struct{}, maxSelected)
 	providerDaIncluded, selectedDAIDs := uint64(0), make(map[[32]byte]struct{})
 	for _, raw := range candidateTxs {
 		if len(parsed) >= maxSelected {
@@ -424,16 +425,19 @@ func (m *Miner) selectCandidateTransactions(candidateTxs [][]byte, utxos map[con
 			return nil, err
 		}
 		if ok {
-			if candidate.nonce == 0 {
+			if candidate.minedCandidate.nonce == 0 {
 				continue
 			}
-			if _, exists := selectedNonces[candidate.nonce]; exists {
+			if _, exists := selectedNonces[candidate.minedCandidate.nonce]; exists {
 				continue
 			}
-			selectedWeight += candidate.weight
+			selectedWeight += candidate.minedCandidate.weight
 			policyDaIncluded = nextDaIncluded
-			selectedNonces[candidate.nonce] = struct{}{}
-			parsed = append(parsed, candidate)
+			selectedNonces[candidate.minedCandidate.nonce] = struct{}{}
+			for _, input := range candidate.tx.Inputs {
+				selectedInputs[consensus.Outpoint{Txid: input.PrevTxid, Vout: input.PrevVout}] = struct{}{}
+			}
+			parsed = append(parsed, candidate.minedCandidate)
 		}
 	}
 	if m.cfg.CompleteDASetProvider == nil || maxSelected == 0 {
@@ -461,7 +465,7 @@ func (m *Miner) selectCandidateTransactions(candidateTxs [][]byte, utxos map[con
 		if !ok {
 			continue
 		}
-		groupWeight, nextDaIncluded, ok := m.projectCompleteDASetGroup(group.txs, selectedNonces, utxos, nextHeight, selectedWeight, remainingWeight, policyDaIncluded)
+		groupWeight, nextDaIncluded, ok := m.projectCompleteDASetGroup(group.txs, selectedNonces, selectedInputs, utxos, nextHeight, selectedWeight, remainingWeight, policyDaIncluded)
 		if !ok {
 			continue
 		}
@@ -471,6 +475,9 @@ func (m *Miner) selectCandidateTransactions(candidateTxs [][]byte, utxos map[con
 		selectedDAIDs[group.daID] = struct{}{}
 		for _, candidate := range group.txs {
 			selectedNonces[candidate.minedCandidate.nonce] = struct{}{}
+			for _, input := range candidate.tx.Inputs {
+				selectedInputs[consensus.Outpoint{Txid: input.PrevTxid, Vout: input.PrevVout}] = struct{}{}
+			}
 			parsed = append(parsed, candidate.minedCandidate)
 		}
 	}
@@ -540,12 +547,13 @@ func completeDACommitmentMatches(tx *consensus.Tx, commitment []byte) bool {
 	return count == 1
 }
 
-func (m *Miner) projectCompleteDASetGroup(group []miningCandidate, selectedNonces map[uint64]struct{}, utxos map[consensus.Outpoint]consensus.UtxoEntry, nextHeight uint64, selectedWeight uint64, remainingWeight uint64, policyDaIncluded uint64) (uint64, uint64, bool) {
+func (m *Miner) projectCompleteDASetGroup(group []miningCandidate, selectedNonces map[uint64]struct{}, selectedInputs map[consensus.Outpoint]struct{}, utxos map[consensus.Outpoint]consensus.UtxoEntry, nextHeight uint64, selectedWeight uint64, remainingWeight uint64, policyDaIncluded uint64) (uint64, uint64, bool) {
 	if len(group) == 0 || selectedWeight > remainingWeight {
 		return 0, policyDaIncluded, false
 	}
 	availableWeight := remainingWeight - selectedWeight
 	groupNonces := make(map[uint64]struct{}, len(group))
+	groupInputs := make(map[consensus.Outpoint]struct{}, len(group))
 	var groupWeight uint64
 	nextDaIncluded := policyDaIncluded
 	for _, candidate := range group {
@@ -559,6 +567,16 @@ func (m *Miner) projectCompleteDASetGroup(group []miningCandidate, selectedNonce
 		if _, exists := groupNonces[nonce]; exists {
 			return 0, policyDaIncluded, false
 		}
+		for _, input := range candidate.tx.Inputs {
+			op := consensus.Outpoint{Txid: input.PrevTxid, Vout: input.PrevVout}
+			if _, exists := selectedInputs[op]; exists {
+				return 0, policyDaIncluded, false
+			}
+			if _, exists := groupInputs[op]; exists {
+				return 0, policyDaIncluded, false
+			}
+			groupInputs[op] = struct{}{}
+		}
 		reject, daIncluded, err := m.rejectCandidate(candidate.tx, utxos, nextHeight, nextDaIncluded)
 		if err != nil || reject || groupWeight > availableWeight || candidate.minedCandidate.weight > availableWeight-groupWeight {
 			return 0, policyDaIncluded, false
@@ -570,26 +588,26 @@ func (m *Miner) projectCompleteDASetGroup(group []miningCandidate, selectedNonce
 	return groupWeight, nextDaIncluded, true
 }
 
-func (m *Miner) trySelectFlatCandidate(raw []byte, utxos map[consensus.Outpoint]consensus.UtxoEntry, nextHeight uint64, selectedWeight uint64, remainingWeight uint64, policyDaIncluded uint64) (minedCandidate, uint64, bool, error) {
+func (m *Miner) trySelectFlatCandidate(raw []byte, utxos map[consensus.Outpoint]consensus.UtxoEntry, nextHeight uint64, selectedWeight uint64, remainingWeight uint64, policyDaIncluded uint64) (miningCandidate, uint64, bool, error) {
 	candidate, err := m.parseMiningCandidate(raw)
 	if err != nil {
-		return minedCandidate{}, policyDaIncluded, false, err
+		return miningCandidate{}, policyDaIncluded, false, err
 	}
 	if isMiningDATx(candidate.tx) {
-		return minedCandidate{}, policyDaIncluded, false, nil
+		return miningCandidate{}, policyDaIncluded, false, nil
 	}
 	reject, nextDaIncluded, err := m.rejectCandidate(candidate.tx, utxos, nextHeight, policyDaIncluded)
 	if err != nil || reject {
-		return minedCandidate{}, policyDaIncluded, false, nil
+		return miningCandidate{}, policyDaIncluded, false, nil
 	}
 	if selectedWeight >= remainingWeight {
-		return minedCandidate{}, policyDaIncluded, false, nil
+		return miningCandidate{}, policyDaIncluded, false, nil
 	}
 	availableWeight := remainingWeight - selectedWeight
 	if candidate.minedCandidate.weight > availableWeight {
-		return minedCandidate{}, policyDaIncluded, false, nil
+		return miningCandidate{}, policyDaIncluded, false, nil
 	}
-	return candidate.minedCandidate, nextDaIncluded, true, nil
+	return candidate, nextDaIncluded, true, nil
 }
 
 type miningCandidate struct {

--- a/clients/go/node/miner.go
+++ b/clients/go/node/miner.go
@@ -117,6 +117,14 @@ type miningBuildContext struct {
 	candidateTxs     [][]byte
 }
 
+type miningConsensusContext struct {
+	blockMTP        uint64
+	chainID         [32]byte
+	coreExtProfiles consensus.CoreExtProfileProvider
+	rotation        consensus.RotationProvider
+	registry        *consensus.SuiteRegistry
+}
+
 type miningChainStateSnapshot struct {
 	hasTip           bool
 	height           uint64
@@ -308,6 +316,9 @@ func (m *Miner) policyNeedsReadonlyUtxoSnapshot() bool {
 	if m.cfg.PolicyRejectCoreExtPreActivation {
 		return true
 	}
+	if m.cfg.CompleteDASetProvider != nil {
+		return true
+	}
 	// DA anti-abuse policy always runs RejectDaAnchorTxPolicy to account for
 	// per-template DA bytes, even when the surcharge floor is disabled. Keep
 	// a readonly snapshot available for that path so custom configs cannot
@@ -415,7 +426,6 @@ func (m *Miner) selectCandidateTransactions(candidateTxs [][]byte, utxos map[con
 	var policyDaIncluded uint64
 	selectedNonces := make(map[uint64]struct{}, maxSelected)
 	selectedInputs := make(map[consensus.Outpoint]struct{}, maxSelected)
-	providerDaIncluded, selectedDAIDs := uint64(0), make(map[[32]byte]struct{})
 	for _, raw := range candidateTxs {
 		if len(parsed) >= maxSelected {
 			break
@@ -443,8 +453,14 @@ func (m *Miner) selectCandidateTransactions(candidateTxs [][]byte, utxos map[con
 	if m.cfg.CompleteDASetProvider == nil || maxSelected == 0 {
 		return parsed, nil
 	}
+	validationCtx, err := m.providerConsensusContext(nextHeight)
+	if err != nil {
+		return nil, err
+	}
+	providerDaIncluded := uint64(0)
+	selectedDAIDs := make(map[[32]byte]struct{})
 	providerBudget := uint64(consensus.MAX_DA_BYTES_PER_BLOCK)
-	if m.cfg.PolicyMaxDaBytesPerBlock > 0 && m.cfg.PolicyMaxDaBytesPerBlock < providerBudget {
+	if m.cfg.PolicyDaAnchorAntiAbuse && m.cfg.PolicyMaxDaBytesPerBlock > 0 && m.cfg.PolicyMaxDaBytesPerBlock < providerBudget {
 		providerBudget = m.cfg.PolicyMaxDaBytesPerBlock
 	}
 	for _, set := range m.cfg.CompleteDASetProvider.CompleteDASetCandidates(providerBudget) {
@@ -465,7 +481,7 @@ func (m *Miner) selectCandidateTransactions(candidateTxs [][]byte, utxos map[con
 		if !ok {
 			continue
 		}
-		groupWeight, nextDaIncluded, ok := m.projectCompleteDASetGroup(group.txs, selectedNonces, selectedInputs, utxos, nextHeight, selectedWeight, remainingWeight, policyDaIncluded)
+		groupWeight, nextDaIncluded, ok := m.projectCompleteDASetGroup(group.txs, selectedNonces, selectedInputs, utxos, nextHeight, validationCtx, selectedWeight, remainingWeight, policyDaIncluded)
 		if !ok {
 			continue
 		}
@@ -482,6 +498,29 @@ func (m *Miner) selectCandidateTransactions(candidateTxs [][]byte, utxos map[con
 		}
 	}
 	return parsed, nil
+}
+
+func (m *Miner) providerConsensusContext(nextHeight uint64) (miningConsensusContext, error) {
+	var ctx miningConsensusContext
+	if m == nil {
+		return ctx, nil
+	}
+	if m.blockStore != nil && nextHeight != 0 {
+		prevTimestamps, err := m.prevTimestamps(nextHeight)
+		if err != nil {
+			return miningConsensusContext{}, err
+		}
+		if len(prevTimestamps) != 0 {
+			ctx.blockMTP = mtpMedian(nextHeight, prevTimestamps)
+		}
+	}
+	if m.sync != nil {
+		ctx.chainID = m.sync.cfg.ChainID
+		ctx.coreExtProfiles = m.sync.cfg.CoreExtProfiles
+		ctx.rotation = m.sync.cfg.RotationProvider
+		ctx.registry = m.sync.cfg.SuiteRegistry
+	}
+	return ctx, nil
 }
 
 type completeDASetMiningCandidate struct {
@@ -547,45 +586,83 @@ func completeDACommitmentMatches(tx *consensus.Tx, commitment []byte) bool {
 	return count == 1
 }
 
-func (m *Miner) projectCompleteDASetGroup(group []miningCandidate, selectedNonces map[uint64]struct{}, selectedInputs map[consensus.Outpoint]struct{}, utxos map[consensus.Outpoint]consensus.UtxoEntry, nextHeight uint64, selectedWeight uint64, remainingWeight uint64, policyDaIncluded uint64) (uint64, uint64, bool) {
+func (m *Miner) projectCompleteDASetGroup(group []miningCandidate, selectedNonces map[uint64]struct{}, selectedInputs map[consensus.Outpoint]struct{}, utxos map[consensus.Outpoint]consensus.UtxoEntry, nextHeight uint64, validationCtx miningConsensusContext, selectedWeight uint64, remainingWeight uint64, policyDaIncluded uint64) (uint64, uint64, bool) {
 	if len(group) == 0 || selectedWeight > remainingWeight {
 		return 0, policyDaIncluded, false
 	}
 	availableWeight := remainingWeight - selectedWeight
-	groupNonces := make(map[uint64]struct{}, len(group))
-	groupInputs := make(map[consensus.Outpoint]struct{}, len(group))
 	var groupWeight uint64
 	nextDaIncluded := policyDaIncluded
+
+	groupInputOutpoints, ok := collectCompleteDASetGroupInputs(group, selectedNonces, selectedInputs)
+	if !ok {
+		return 0, policyDaIncluded, false
+	}
+	if !validateCompleteDASetGroupConsensus(group, utxos, groupInputOutpoints, nextHeight, validationCtx) {
+		return 0, policyDaIncluded, false
+	}
 	for _, candidate := range group {
-		nonce := candidate.minedCandidate.nonce
-		if nonce == 0 {
-			return 0, policyDaIncluded, false
-		}
-		if _, exists := selectedNonces[nonce]; exists {
-			return 0, policyDaIncluded, false
-		}
-		if _, exists := groupNonces[nonce]; exists {
-			return 0, policyDaIncluded, false
-		}
-		for _, input := range candidate.tx.Inputs {
-			op := consensus.Outpoint{Txid: input.PrevTxid, Vout: input.PrevVout}
-			if _, exists := selectedInputs[op]; exists {
-				return 0, policyDaIncluded, false
-			}
-			if _, exists := groupInputs[op]; exists {
-				return 0, policyDaIncluded, false
-			}
-			groupInputs[op] = struct{}{}
-		}
 		reject, daIncluded, err := m.rejectCandidate(candidate.tx, utxos, nextHeight, nextDaIncluded)
 		if err != nil || reject || groupWeight > availableWeight || candidate.minedCandidate.weight > availableWeight-groupWeight {
 			return 0, policyDaIncluded, false
 		}
-		groupNonces[nonce] = struct{}{}
 		groupWeight += candidate.minedCandidate.weight
 		nextDaIncluded = daIncluded
 	}
 	return groupWeight, nextDaIncluded, true
+}
+
+func collectCompleteDASetGroupInputs(group []miningCandidate, selectedNonces map[uint64]struct{}, selectedInputs map[consensus.Outpoint]struct{}) ([]consensus.Outpoint, bool) {
+	groupNonces := make(map[uint64]struct{}, len(group))
+	groupInputs := make(map[consensus.Outpoint]struct{}, len(group))
+	groupInputOutpoints := make([]consensus.Outpoint, 0, len(group))
+	for _, candidate := range group {
+		nonce := candidate.minedCandidate.nonce
+		if nonce == 0 {
+			return nil, false
+		}
+		if _, exists := selectedNonces[nonce]; exists {
+			return nil, false
+		}
+		if _, exists := groupNonces[nonce]; exists {
+			return nil, false
+		}
+		for _, input := range candidate.tx.Inputs {
+			op := consensus.Outpoint{Txid: input.PrevTxid, Vout: input.PrevVout}
+			if _, exists := selectedInputs[op]; exists {
+				return nil, false
+			}
+			if _, exists := groupInputs[op]; exists {
+				return nil, false
+			}
+			groupInputs[op] = struct{}{}
+			groupInputOutpoints = append(groupInputOutpoints, op)
+		}
+		groupNonces[nonce] = struct{}{}
+	}
+	return groupInputOutpoints, true
+}
+
+func validateCompleteDASetGroupConsensus(group []miningCandidate, utxos map[consensus.Outpoint]consensus.UtxoEntry, groupInputOutpoints []consensus.Outpoint, nextHeight uint64, validationCtx miningConsensusContext) bool {
+	workUtxos := copySelectedUtxoSet(utxos, groupInputOutpoints)
+	for _, candidate := range group {
+		if _, err := consensus.CheckParsedTransactionWithOwnedUtxoSetAndCoreExtProfilesAndSuiteContext(
+			candidate.minedCandidate.raw,
+			candidate.tx,
+			candidate.minedCandidate.txid,
+			candidate.minedCandidate.wtxid,
+			workUtxos,
+			nextHeight,
+			validationCtx.blockMTP,
+			validationCtx.chainID,
+			validationCtx.coreExtProfiles,
+			validationCtx.rotation,
+			validationCtx.registry,
+		); err != nil {
+			return false
+		}
+	}
+	return true
 }
 
 func (m *Miner) trySelectFlatCandidate(raw []byte, utxos map[consensus.Outpoint]consensus.UtxoEntry, nextHeight uint64, selectedWeight uint64, remainingWeight uint64, policyDaIncluded uint64) (miningCandidate, uint64, bool, error) {

--- a/clients/go/node/miner.go
+++ b/clients/go/node/miner.go
@@ -1,7 +1,9 @@
 package node
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha3"
 	"errors"
 	"math"
 	"time"
@@ -79,6 +81,8 @@ type MinerConfig struct {
 	// CoreExtProfiles is the chain-config profile mapping used by policy checks.
 	// Consensus uses a canonical source for profile(ext_id, height); this is policy-only.
 	CoreExtProfiles consensus.CoreExtProfileProvider
+
+	CompleteDASetProvider CompleteDASetProvider
 }
 
 type MinedBlock struct {
@@ -101,6 +105,7 @@ type minedCandidate struct {
 	txid   [32]byte
 	wtxid  [32]byte
 	weight uint64
+	nonce  uint64
 }
 
 type miningBuildContext struct {
@@ -408,6 +413,8 @@ func (m *Miner) selectCandidateTransactions(candidateTxs [][]byte, utxos map[con
 	parsed := make([]minedCandidate, 0, min(len(candidateTxs), maxSelected))
 	var selectedWeight uint64
 	var policyDaIncluded uint64
+	selectedNonces := make(map[uint64]struct{}, maxSelected)
+	providerDaIncluded, selectedDAIDs := uint64(0), make(map[[32]byte]struct{})
 	for _, raw := range candidateTxs {
 		if len(parsed) >= maxSelected {
 			break
@@ -417,12 +424,150 @@ func (m *Miner) selectCandidateTransactions(candidateTxs [][]byte, utxos map[con
 			return nil, err
 		}
 		if ok {
+			if candidate.nonce == 0 {
+				continue
+			}
+			if _, exists := selectedNonces[candidate.nonce]; exists {
+				continue
+			}
 			selectedWeight += candidate.weight
 			policyDaIncluded = nextDaIncluded
+			selectedNonces[candidate.nonce] = struct{}{}
 			parsed = append(parsed, candidate)
 		}
 	}
+	if m.cfg.CompleteDASetProvider == nil || maxSelected == 0 {
+		return parsed, nil
+	}
+	providerBudget := uint64(consensus.MAX_DA_BYTES_PER_BLOCK)
+	if m.cfg.PolicyMaxDaBytesPerBlock > 0 && m.cfg.PolicyMaxDaBytesPerBlock < providerBudget {
+		providerBudget = m.cfg.PolicyMaxDaBytesPerBlock
+	}
+	for _, set := range m.cfg.CompleteDASetProvider.CompleteDASetCandidates(providerBudget) {
+		if len(parsed) >= maxSelected || len(selectedDAIDs) >= consensus.MAX_DA_BATCHES_PER_BLOCK {
+			break
+		}
+		group, ok, err := m.parseCompleteDASetCandidate(set)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			continue
+		}
+		if _, exists := selectedDAIDs[group.daID]; exists || len(parsed)+len(group.txs) > maxSelected {
+			continue
+		}
+		nextProviderDaIncluded, ok := updatedPolicyDaBytes(providerDaIncluded, group.daBytes, providerBudget)
+		if !ok {
+			continue
+		}
+		groupWeight, nextDaIncluded, ok := m.projectCompleteDASetGroup(group.txs, selectedNonces, utxos, nextHeight, selectedWeight, remainingWeight, policyDaIncluded)
+		if !ok {
+			continue
+		}
+		selectedWeight += groupWeight
+		policyDaIncluded = nextDaIncluded
+		providerDaIncluded = nextProviderDaIncluded
+		selectedDAIDs[group.daID] = struct{}{}
+		for _, candidate := range group.txs {
+			selectedNonces[candidate.minedCandidate.nonce] = struct{}{}
+			parsed = append(parsed, candidate.minedCandidate)
+		}
+	}
 	return parsed, nil
+}
+
+type completeDASetMiningCandidate struct {
+	daID    [32]byte
+	txs     []miningCandidate
+	daBytes uint64
+}
+
+func (m *Miner) parseCompleteDASetCandidate(set CompleteDASetCandidate) (completeDASetMiningCandidate, bool, error) {
+	commit, err := m.parseMiningCandidate(set.CommitTx)
+	if err != nil {
+		return completeDASetMiningCandidate{}, false, err
+	}
+	core := commit.tx.DaCommitCore
+	if core == nil || core.DaID != set.DAID || core.ChunkCount == 0 || uint64(core.ChunkCount) > consensus.MAX_DA_CHUNK_COUNT ||
+		len(set.Chunks) != int(core.ChunkCount) || len(commit.tx.Inputs) == 0 {
+		return completeDASetMiningCandidate{}, false, nil
+	}
+
+	group := completeDASetMiningCandidate{daID: set.DAID, txs: []miningCandidate{commit}}
+	group.daBytes = uint64(len(commit.tx.DaPayload))
+	hasher := sha3.New256()
+	for i, chunk := range set.Chunks {
+		wantIndex := uint16(i)
+		if chunk.Index != wantIndex {
+			return completeDASetMiningCandidate{}, false, nil
+		}
+		candidate, err := m.parseMiningCandidate(chunk.Tx)
+		if err != nil {
+			return completeDASetMiningCandidate{}, false, err
+		}
+		tx := candidate.tx
+		chunkCore := tx.DaChunkCore
+		if chunkCore == nil || chunkCore.DaID != set.DAID || chunkCore.ChunkIndex != wantIndex ||
+			len(tx.Inputs) == 0 || sha3.Sum256(tx.DaPayload) != chunkCore.ChunkHash {
+			return completeDASetMiningCandidate{}, false, nil
+		}
+		nextDaBytes, err := addU64NoOverflowValue(group.daBytes, uint64(len(candidate.tx.DaPayload)))
+		if err != nil {
+			return completeDASetMiningCandidate{}, false, nil
+		}
+		group.daBytes = nextDaBytes
+		_, _ = hasher.Write(candidate.tx.DaPayload)
+		group.txs = append(group.txs, candidate)
+	}
+	if !completeDACommitmentMatches(commit.tx, hasher.Sum(nil)) {
+		return completeDASetMiningCandidate{}, false, nil
+	}
+	return group, true, nil
+}
+
+func completeDACommitmentMatches(tx *consensus.Tx, commitment []byte) bool {
+	count := 0
+	for _, output := range tx.Outputs {
+		if output.CovenantType != consensus.COV_TYPE_DA_COMMIT {
+			continue
+		}
+		if count != 0 || len(output.CovenantData) != 32 || !bytes.Equal(output.CovenantData, commitment) {
+			return false
+		}
+		count++
+	}
+	return count == 1
+}
+
+func (m *Miner) projectCompleteDASetGroup(group []miningCandidate, selectedNonces map[uint64]struct{}, utxos map[consensus.Outpoint]consensus.UtxoEntry, nextHeight uint64, selectedWeight uint64, remainingWeight uint64, policyDaIncluded uint64) (uint64, uint64, bool) {
+	if len(group) == 0 || selectedWeight > remainingWeight {
+		return 0, policyDaIncluded, false
+	}
+	availableWeight := remainingWeight - selectedWeight
+	groupNonces := make(map[uint64]struct{}, len(group))
+	var groupWeight uint64
+	nextDaIncluded := policyDaIncluded
+	for _, candidate := range group {
+		nonce := candidate.minedCandidate.nonce
+		if nonce == 0 {
+			return 0, policyDaIncluded, false
+		}
+		if _, exists := selectedNonces[nonce]; exists {
+			return 0, policyDaIncluded, false
+		}
+		if _, exists := groupNonces[nonce]; exists {
+			return 0, policyDaIncluded, false
+		}
+		reject, daIncluded, err := m.rejectCandidate(candidate.tx, utxos, nextHeight, nextDaIncluded)
+		if err != nil || reject || groupWeight > availableWeight || candidate.minedCandidate.weight > availableWeight-groupWeight {
+			return 0, policyDaIncluded, false
+		}
+		groupNonces[nonce] = struct{}{}
+		groupWeight += candidate.minedCandidate.weight
+		nextDaIncluded = daIncluded
+	}
+	return groupWeight, nextDaIncluded, true
 }
 
 func (m *Miner) trySelectFlatCandidate(raw []byte, utxos map[consensus.Outpoint]consensus.UtxoEntry, nextHeight uint64, selectedWeight uint64, remainingWeight uint64, policyDaIncluded uint64) (minedCandidate, uint64, bool, error) {
@@ -468,6 +613,7 @@ func (m *Miner) parseMiningCandidate(raw []byte) (miningCandidate, error) {
 			txid:   txid,
 			wtxid:  wtxid,
 			weight: txWeight,
+			nonce:  tx.TxNonce,
 		},
 	}, nil
 }

--- a/clients/go/node/miner_additional_test.go
+++ b/clients/go/node/miner_additional_test.go
@@ -466,6 +466,10 @@ func TestPolicyNeedsReadonlyUtxoSnapshotMatrix(t *testing.T) {
 	if disabled.policyNeedsReadonlyUtxoSnapshot() {
 		t.Fatal("fully disabled policy matrix should not require snapshot")
 	}
+	disabled.cfg.CompleteDASetProvider = minerTestCompleteDASetProvider{}
+	if !disabled.policyNeedsReadonlyUtxoSnapshot() {
+		t.Fatal("provider validation should require snapshot")
+	}
 
 	coreExt := &Miner{cfg: DefaultMinerConfig()}
 	coreExt.cfg.PolicyRejectCoreExtPreActivation = true

--- a/clients/go/node/miner_da_flat_filter_test.go
+++ b/clients/go/node/miner_da_flat_filter_test.go
@@ -85,6 +85,119 @@ func TestMinerFlatDAFilterPreservesNonCanonicalInputError(t *testing.T) {
 	}
 }
 
+type minerTestCompleteDASetProvider []CompleteDASetCandidate
+
+func (p minerTestCompleteDASetProvider) CompleteDASetCandidates(uint64) []CompleteDASetCandidate {
+	return p
+}
+func TestMinerCompleteDASetProviderValidity(t *testing.T) {
+	daID := [32]byte{0x81}
+	set := minerProviderTestSet(t, daID, []byte("chunk-0"), []byte("chunk-1"))
+	nonDA := minerFlatTestNonDA(0x82)
+	selected := minerProviderSelected(t, []CompleteDASetCandidate{set, set}, nil, 0, 0)
+	if len(selected) != 3 {
+		t.Fatalf("duplicate da_id selected=%d, want one complete DA set", len(selected))
+	}
+	collidingNonce := minerProviderCloneSet(set)
+	collidingNonce.CommitTx = minerProviderMutateTx(t, collidingNonce.CommitTx, func(tx *consensus.Tx) { tx.TxNonce = 1 })
+	selected = minerProviderSelected(t, []CompleteDASetCandidate{collidingNonce}, [][]byte{nonDA}, 0, 0)
+	if len(selected) != 1 || string(selected[0].raw) != string(nonDA) {
+		t.Fatalf("provider nonce collision selected=%d, want only flat tx", len(selected))
+	}
+	sets := make([]CompleteDASetCandidate, 0, consensus.MAX_DA_BATCHES_PER_BLOCK+1)
+	for i := 0; i < consensus.MAX_DA_BATCHES_PER_BLOCK+1; i++ {
+		sets = append(sets, minerProviderTestSet(t, [32]byte{byte(i + 1), 0x85}, []byte{byte(i), 0}, []byte{byte(i), 1}))
+	}
+	selected = minerProviderSelected(t, sets, nil, len(sets)*3+1, 0)
+	if len(selected) != int(consensus.MAX_DA_BATCHES_PER_BLOCK)*3 {
+		t.Fatalf("selected batches=%d, want capped provider DA batches", len(selected)/3)
+	}
+	daID = [32]byte{0x83}
+	base := minerProviderTestSet(t, daID, []byte("chunk-0"), []byte("chunk-1"))
+	missing := minerProviderCloneSet(base)
+	missing.Chunks = missing.Chunks[:1]
+	duplicate := minerProviderCloneSet(base)
+	duplicate.Chunks[1].Index = 0
+	wrongDAID := minerProviderCloneSet(base)
+	wrongDAID.Chunks[1].Tx = minerProviderMutateTx(t, wrongDAID.Chunks[1].Tx, func(tx *consensus.Tx) { tx.DaChunkCore.DaID = [32]byte{0x84} })
+	badHash := minerProviderCloneSet(base)
+	badHash.Chunks[0].Tx = minerProviderMutateTx(t, badHash.Chunks[0].Tx, func(tx *consensus.Tx) { tx.DaChunkCore.ChunkHash = [32]byte{0x85} })
+	badCommitment := minerProviderCloneSet(base)
+	badCommitment.CommitTx = minerProviderMutateTx(t, badCommitment.CommitTx, func(tx *consensus.Tx) { tx.Outputs[0].CovenantData[0] ^= 0xff })
+	duplicateNonce := minerProviderCloneSet(base)
+	duplicateNonce.Chunks[1].Tx = minerProviderMutateTx(t, duplicateNonce.Chunks[1].Tx, func(tx *consensus.Tx) { tx.TxNonce = mustParseTx(t, duplicateNonce.Chunks[0].Tx).TxNonce })
+	zeroNonce := minerProviderCloneSet(base)
+	zeroNonce.CommitTx = minerProviderMutateTx(t, zeroNonce.CommitTx, func(tx *consensus.Tx) { tx.TxNonce = 0 })
+	overBudget := minerProviderCloneSet(base)
+	for i, set := range []CompleteDASetCandidate{missing, duplicate, wrongDAID, badHash, badCommitment, duplicateNonce, zeroNonce, overBudget} {
+		maxBytes := uint64(0)
+		if i == 7 {
+			maxBytes = 3
+		}
+		if selected := minerProviderSelected(t, []CompleteDASetCandidate{set}, nil, 0, maxBytes); len(selected) != 0 {
+			t.Fatalf("invalid provider selected=%d", len(selected))
+		}
+	}
+	badRaw := minerProviderCloneSet(base)
+	badRaw.CommitTx = append(badRaw.CommitTx, 0)
+	if _, err := (&Miner{cfg: MinerConfig{CompleteDASetProvider: minerTestCompleteDASetProvider{badRaw}, MaxTxPerBlock: 16}}).selectCandidateTransactions(nil, nil, 1, ^uint64(0)); err == nil {
+		t.Fatalf("expected malformed provider raw error")
+	}
+	set2 := minerProviderTestSet(t, [32]byte{0x86}, []byte("chunk-0"), []byte("chunk-1"))
+	set2.CommitTx = minerProviderMutateTx(t, set2.CommitTx, func(tx *consensus.Tx) { tx.TxNonce = mustParseTx(t, base.CommitTx).TxNonce })
+	if selected := minerProviderSelected(t, []CompleteDASetCandidate{base, set2}, nil, 0, 0); len(selected) != 3 {
+		t.Fatalf("cross-provider nonce collision selected=%d, want first complete DA set only", len(selected))
+	}
+}
+
+func minerProviderCloneSet(s CompleteDASetCandidate) CompleteDASetCandidate {
+	s.Chunks = append([]CompleteDASetChunkCandidate(nil), s.Chunks...)
+	return s
+}
+
+func minerProviderSelected(t *testing.T, sets []CompleteDASetCandidate, flat [][]byte, maxTx int, maxBytes uint64) []minedCandidate {
+	if maxTx == 0 {
+		maxTx = 16
+	}
+	cfg := MinerConfig{CompleteDASetProvider: minerTestCompleteDASetProvider(sets), MaxTxPerBlock: maxTx, PolicyMaxDaBytesPerBlock: maxBytes}
+	selected, err := (&Miner{cfg: cfg}).selectCandidateTransactions(flat, nil, 1, ^uint64(0))
+	if err != nil {
+		t.Fatalf("select provider candidates: %v", err)
+	}
+	return selected
+}
+
+func minerProviderTestSet(t *testing.T, daID [32]byte, payloads ...[]byte) CompleteDASetCandidate {
+	base := 2 + uint64(daID[0])*(consensus.MAX_DA_CHUNK_COUNT+2)
+	hasher := sha3.New256()
+	chunks := make([]CompleteDASetChunkCandidate, 0, len(payloads))
+	for i, payload := range payloads {
+		_, _ = hasher.Write(payload)
+		raw := minerProviderChunkTx(t, daID, base, uint16(i), payload)
+		chunks = append(chunks, CompleteDASetChunkCandidate{Index: uint16(i), Tx: raw})
+	}
+	tx := &consensus.Tx{Version: 1, TxKind: 0x01, TxNonce: base, DaPayload: []byte{0xa1}}
+	tx.Inputs = []consensus.TxInput{{PrevTxid: [32]byte{0xc1}}}
+	tx.Outputs = []consensus.TxOutput{{CovenantType: consensus.COV_TYPE_DA_COMMIT, CovenantData: hasher.Sum(nil)}}
+	tx.DaCommitCore = &consensus.DaCommitCore{DaID: daID, ChunkCount: uint16(len(payloads)), BatchNumber: 1}
+	commit := mustMarshalTxForNodeTest(t, tx)
+	return CompleteDASetCandidate{DAID: daID, CommitTx: commit, Chunks: chunks}
+}
+
+func minerProviderChunkTx(t *testing.T, daID [32]byte, base uint64, index uint16, payload []byte) []byte {
+	chunkHash := sha3.Sum256(payload)
+	tx := &consensus.Tx{Version: 1, TxKind: 0x02, TxNonce: base + uint64(index) + 1, DaPayload: append([]byte(nil), payload...)}
+	tx.Inputs = []consensus.TxInput{{PrevTxid: [32]byte{0xc2}, PrevVout: uint32(index)}}
+	tx.DaChunkCore = &consensus.DaChunkCore{DaID: daID, ChunkIndex: index, ChunkHash: chunkHash}
+	return mustMarshalTxForNodeTest(t, tx)
+}
+
+func minerProviderMutateTx(t *testing.T, raw []byte, mutate func(*consensus.Tx)) []byte {
+	tx := mustParseTx(t, raw)
+	mutate(tx)
+	return mustMarshalTxForNodeTest(t, tx)
+}
+
 func minerFlatDATestChunk(t *testing.T, daID [32]byte, index uint16, payload []byte) []byte {
 	t.Helper()
 	chunkHash := sha3.Sum256(payload)

--- a/clients/go/node/miner_da_flat_filter_test.go
+++ b/clients/go/node/miner_da_flat_filter_test.go
@@ -3,6 +3,7 @@ package node
 import (
 	"bytes"
 	"crypto/sha3"
+	"encoding/binary"
 	"testing"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
@@ -91,36 +92,54 @@ func (p minerTestCompleteDASetProvider) CompleteDASetCandidates(uint64) []Comple
 	return p
 }
 func TestMinerCompleteDASetProviderValidity(t *testing.T) {
+	fixture := newMinerProviderTestFixture(t)
 	daID := [32]byte{0x81}
-	set := minerProviderTestSet(t, daID, []byte("chunk-0"), []byte("chunk-1"))
+	set := fixture.completeDASet(t, daID, []byte("chunk-0"), []byte("chunk-1"))
 	nonDA := minerFlatTestNonDA(0x82)
-	selected := minerProviderSelected(t, []CompleteDASetCandidate{set, set}, nil, 0, 0)
+	selected := minerProviderSelected(t, []CompleteDASetCandidate{set, set}, nil, fixture.utxos, 0, 0)
 	if len(selected) != 3 {
 		t.Fatalf("duplicate da_id selected=%d, want one complete DA set", len(selected))
 	}
+	policyOffMiner := &Miner{
+		cfg: MinerConfig{
+			CompleteDASetProvider:    minerTestCompleteDASetProvider{set},
+			MaxTxPerBlock:            16,
+			PolicyDaAnchorAntiAbuse:  false,
+			PolicyMaxDaBytesPerBlock: 3,
+		},
+		sync: &SyncEngine{cfg: SyncConfig{ChainID: devnetGenesisChainID}},
+	}
+	selected, err := policyOffMiner.selectCandidateTransactions(nil, fixture.utxos, 1, ^uint64(0))
+	if err != nil {
+		t.Fatalf("select with DA policy disabled: %v", err)
+	}
+	if len(selected) != 3 {
+		t.Fatalf("policy-disabled provider selected=%d, want complete DA set", len(selected))
+	}
 	collidingNonce := minerProviderCloneSet(set)
 	collidingNonce.CommitTx = minerProviderMutateTx(t, collidingNonce.CommitTx, func(tx *consensus.Tx) { tx.TxNonce = 1 })
-	selected = minerProviderSelected(t, []CompleteDASetCandidate{collidingNonce}, [][]byte{nonDA}, 0, 0)
+	selected = minerProviderSelected(t, []CompleteDASetCandidate{collidingNonce}, [][]byte{nonDA}, fixture.utxos, 0, 0)
 	if len(selected) != 1 || string(selected[0].raw) != string(nonDA) {
 		t.Fatalf("provider nonce collision selected=%d, want only flat tx", len(selected))
 	}
 	collidingInput := minerProviderCloneSet(set)
 	collidingInput.CommitTx = minerProviderMutateTx(t, collidingInput.CommitTx, func(tx *consensus.Tx) { tx.Inputs[0].PrevTxid = [32]byte{0x82} })
-	selected = minerProviderSelected(t, []CompleteDASetCandidate{collidingInput}, [][]byte{nonDA}, 0, 0)
+	selected = minerProviderSelected(t, []CompleteDASetCandidate{collidingInput}, [][]byte{nonDA}, fixture.utxos, 0, 0)
 	if len(selected) != 1 || string(selected[0].raw) != string(nonDA) {
 		t.Fatalf("provider input collision selected=%d, want only flat tx", len(selected))
 	}
 	sets := make([]CompleteDASetCandidate, 0, consensus.MAX_DA_BATCHES_PER_BLOCK+1)
 	for i := 0; i < consensus.MAX_DA_BATCHES_PER_BLOCK+1; i++ {
-		sets = append(sets, minerProviderTestSet(t, [32]byte{byte(i + 1), 0x85}, []byte{byte(i), 0}, []byte{byte(i), 1}))
+		sets = append(sets, fixture.completeDASet(t, [32]byte{byte(i + 1), 0x85}, []byte{byte(i), 0}, []byte{byte(i), 1}))
 	}
-	selected = minerProviderSelected(t, sets, nil, len(sets)*3+1, 0)
+	selected = minerProviderSelected(t, sets, nil, fixture.utxos, len(sets)*3+1, 0)
 	if len(selected) != int(consensus.MAX_DA_BATCHES_PER_BLOCK)*3 {
 		t.Fatalf("selected batches=%d, want capped provider DA batches", len(selected)/3)
 	}
 }
 func TestMinerCompleteDASetProviderRejectsInvalidGroups(t *testing.T) {
-	base := minerProviderTestSet(t, [32]byte{0x83}, []byte("chunk-0"), []byte("chunk-1"))
+	fixture := newMinerProviderTestFixture(t)
+	base := fixture.completeDASet(t, [32]byte{0x83}, []byte("chunk-0"), []byte("chunk-1"))
 	missing := minerProviderCloneSet(base)
 	missing.Chunks = missing.Chunks[:1]
 	duplicate := minerProviderCloneSet(base)
@@ -138,12 +157,13 @@ func TestMinerCompleteDASetProviderRejectsInvalidGroups(t *testing.T) {
 	zeroNonce := minerProviderCloneSet(base)
 	zeroNonce.CommitTx = minerProviderMutateTx(t, zeroNonce.CommitTx, func(tx *consensus.Tx) { tx.TxNonce = 0 })
 	overBudget := minerProviderCloneSet(base)
-	for i, set := range []CompleteDASetCandidate{missing, duplicate, wrongDAID, badHash, badCommitment, duplicateNonce, duplicateInput, zeroNonce, overBudget} {
+	wrongChainSig := fixture.completeDASetWithChainID(t, [32]byte{0x88}, [32]byte{0x87}, []byte("chunk-0"), []byte("chunk-1"))
+	for i, set := range []CompleteDASetCandidate{missing, duplicate, wrongDAID, badHash, badCommitment, duplicateNonce, duplicateInput, zeroNonce, overBudget, wrongChainSig} {
 		maxBytes := uint64(0)
 		if i == 8 {
 			maxBytes = 3
 		}
-		if selected := minerProviderSelected(t, []CompleteDASetCandidate{set}, nil, 0, maxBytes); len(selected) != 0 {
+		if selected := minerProviderSelected(t, []CompleteDASetCandidate{set}, nil, fixture.utxos, 0, maxBytes); len(selected) != 0 {
 			t.Fatalf("invalid provider selected=%d", len(selected))
 		}
 	}
@@ -152,56 +172,106 @@ func TestMinerCompleteDASetProviderRejectsInvalidGroups(t *testing.T) {
 	if _, err := (&Miner{cfg: MinerConfig{CompleteDASetProvider: minerTestCompleteDASetProvider{badRaw}, MaxTxPerBlock: 16}}).selectCandidateTransactions(nil, nil, 1, ^uint64(0)); err == nil {
 		t.Fatalf("expected malformed provider raw error")
 	}
-	set2 := minerProviderTestSet(t, [32]byte{0x86}, []byte("chunk-0"), []byte("chunk-1"))
+	set2 := fixture.completeDASet(t, [32]byte{0x86}, []byte("chunk-0"), []byte("chunk-1"))
 	set2.CommitTx = minerProviderMutateTx(t, set2.CommitTx, func(tx *consensus.Tx) { tx.TxNonce = mustParseTx(t, base.CommitTx).TxNonce })
-	if selected := minerProviderSelected(t, []CompleteDASetCandidate{base, set2}, nil, 0, 0); len(selected) != 3 {
+	if selected := minerProviderSelected(t, []CompleteDASetCandidate{base, set2}, nil, fixture.utxos, 0, 0); len(selected) != 3 {
 		t.Fatalf("cross-provider nonce collision selected=%d, want first complete DA set only", len(selected))
 	}
 }
 
 func minerProviderCloneSet(s CompleteDASetCandidate) CompleteDASetCandidate {
+	s.CommitTx = append([]byte(nil), s.CommitTx...)
 	s.Chunks = append([]CompleteDASetChunkCandidate(nil), s.Chunks...)
+	for i := range s.Chunks {
+		s.Chunks[i].Tx = append([]byte(nil), s.Chunks[i].Tx...)
+	}
 	return s
 }
 
-func minerProviderSelected(t *testing.T, sets []CompleteDASetCandidate, flat [][]byte, maxTx int, maxBytes uint64) []minedCandidate {
+func minerProviderSelected(t *testing.T, sets []CompleteDASetCandidate, flat [][]byte, utxos map[consensus.Outpoint]consensus.UtxoEntry, maxTx int, maxBytes uint64) []minedCandidate {
 	if maxTx == 0 {
 		maxTx = 16
 	}
-	cfg := MinerConfig{CompleteDASetProvider: minerTestCompleteDASetProvider(sets), MaxTxPerBlock: maxTx, PolicyMaxDaBytesPerBlock: maxBytes}
-	selected, err := (&Miner{cfg: cfg}).selectCandidateTransactions(flat, nil, 1, ^uint64(0))
+	cfg := MinerConfig{
+		CompleteDASetProvider:    minerTestCompleteDASetProvider(sets),
+		MaxTxPerBlock:            maxTx,
+		PolicyDaAnchorAntiAbuse:  true,
+		PolicyMaxDaBytesPerBlock: maxBytes,
+	}
+	miner := &Miner{cfg: cfg, sync: &SyncEngine{cfg: SyncConfig{ChainID: devnetGenesisChainID}}}
+	selected, err := miner.selectCandidateTransactions(flat, utxos, 1, ^uint64(0))
 	if err != nil {
 		t.Fatalf("select provider candidates: %v", err)
 	}
 	return selected
 }
 
-func minerProviderTestSet(t *testing.T, daID [32]byte, payloads ...[]byte) CompleteDASetCandidate {
+type minerProviderTestFixture struct {
+	signer    *consensus.MLDSA87Keypair
+	address   []byte
+	utxos     map[consensus.Outpoint]consensus.UtxoEntry
+	nextInput uint64
+}
+
+func newMinerProviderTestFixture(t *testing.T) *minerProviderTestFixture {
+	signer := mustNodeMLDSA87Keypair(t)
+	return &minerProviderTestFixture{
+		signer:  signer,
+		address: consensus.P2PKCovenantDataForPubkey(signer.PubkeyBytes()),
+		utxos:   make(map[consensus.Outpoint]consensus.UtxoEntry),
+	}
+}
+
+func (f *minerProviderTestFixture) completeDASet(t *testing.T, daID [32]byte, payloads ...[]byte) CompleteDASetCandidate {
+	return f.completeDASetWithChainID(t, devnetGenesisChainID, daID, payloads...)
+}
+
+func (f *minerProviderTestFixture) completeDASetWithChainID(t *testing.T, chainID [32]byte, daID [32]byte, payloads ...[]byte) CompleteDASetCandidate {
 	base := 2 + uint64(daID[0])*(consensus.MAX_DA_CHUNK_COUNT+2)
 	hasher := sha3.New256()
 	chunks := make([]CompleteDASetChunkCandidate, 0, len(payloads))
 	for i, payload := range payloads {
 		_, _ = hasher.Write(payload)
-		raw := minerProviderChunkTx(t, daID, base, uint16(i), payload)
+		raw := f.chunkTx(t, chainID, daID, base, uint16(i), payload)
 		chunks = append(chunks, CompleteDASetChunkCandidate{Index: uint16(i), Tx: raw})
 	}
-	commitInput := daID
-	commitInput[31] = 0xc1
 	tx := &consensus.Tx{Version: 1, TxKind: 0x01, TxNonce: base, DaPayload: []byte{0xa1}}
-	tx.Inputs = []consensus.TxInput{{PrevTxid: commitInput}}
+	tx.Inputs = []consensus.TxInput{f.nextSignedInput()}
 	tx.Outputs = []consensus.TxOutput{{CovenantType: consensus.COV_TYPE_DA_COMMIT, CovenantData: hasher.Sum(nil)}}
 	tx.DaCommitCore = &consensus.DaCommitCore{DaID: daID, ChunkCount: uint16(len(payloads)), BatchNumber: 1}
-	commit := mustMarshalTxForNodeTest(t, tx)
+	commit := f.signAndMarshal(t, chainID, tx)
 	return CompleteDASetCandidate{DAID: daID, CommitTx: commit, Chunks: chunks}
 }
 
-func minerProviderChunkTx(t *testing.T, daID [32]byte, base uint64, index uint16, payload []byte) []byte {
+func (f *minerProviderTestFixture) chunkTx(t *testing.T, chainID [32]byte, daID [32]byte, base uint64, index uint16, payload []byte) []byte {
 	chunkHash := sha3.Sum256(payload)
-	chunkInput := daID
-	chunkInput[31] = byte(index)
 	tx := &consensus.Tx{Version: 1, TxKind: 0x02, TxNonce: base + uint64(index) + 1, DaPayload: append([]byte(nil), payload...)}
-	tx.Inputs = []consensus.TxInput{{PrevTxid: chunkInput, PrevVout: uint32(index)}}
+	tx.Inputs = []consensus.TxInput{f.nextSignedInput()}
 	tx.DaChunkCore = &consensus.DaChunkCore{DaID: daID, ChunkIndex: index, ChunkHash: chunkHash}
+	return f.signAndMarshal(t, chainID, tx)
+}
+
+func (f *minerProviderTestFixture) nextSignedInput() consensus.TxInput {
+	f.nextInput++
+	var txid [32]byte
+	txid[0] = 0xd7
+	binary.BigEndian.PutUint64(txid[24:], f.nextInput)
+	op := consensus.Outpoint{Txid: txid}
+	f.utxos[op] = consensus.UtxoEntry{
+		Value:             1_000_000,
+		CovenantType:      consensus.COV_TYPE_P2PK,
+		CovenantData:      append([]byte(nil), f.address...),
+		CreationHeight:    1,
+		CreatedByCoinbase: false,
+	}
+	return consensus.TxInput{PrevTxid: op.Txid, PrevVout: op.Vout}
+}
+
+func (f *minerProviderTestFixture) signAndMarshal(t *testing.T, chainID [32]byte, tx *consensus.Tx) []byte {
+	t.Helper()
+	if err := consensus.SignTransaction(tx, f.utxos, chainID, f.signer); err != nil {
+		t.Fatalf("SignTransaction(provider): %v", err)
+	}
 	return mustMarshalTxForNodeTest(t, tx)
 }
 

--- a/clients/go/node/miner_da_flat_filter_test.go
+++ b/clients/go/node/miner_da_flat_filter_test.go
@@ -104,6 +104,12 @@ func TestMinerCompleteDASetProviderValidity(t *testing.T) {
 	if len(selected) != 1 || string(selected[0].raw) != string(nonDA) {
 		t.Fatalf("provider nonce collision selected=%d, want only flat tx", len(selected))
 	}
+	collidingInput := minerProviderCloneSet(set)
+	collidingInput.CommitTx = minerProviderMutateTx(t, collidingInput.CommitTx, func(tx *consensus.Tx) { tx.Inputs[0].PrevTxid = [32]byte{0x82} })
+	selected = minerProviderSelected(t, []CompleteDASetCandidate{collidingInput}, [][]byte{nonDA}, 0, 0)
+	if len(selected) != 1 || string(selected[0].raw) != string(nonDA) {
+		t.Fatalf("provider input collision selected=%d, want only flat tx", len(selected))
+	}
 	sets := make([]CompleteDASetCandidate, 0, consensus.MAX_DA_BATCHES_PER_BLOCK+1)
 	for i := 0; i < consensus.MAX_DA_BATCHES_PER_BLOCK+1; i++ {
 		sets = append(sets, minerProviderTestSet(t, [32]byte{byte(i + 1), 0x85}, []byte{byte(i), 0}, []byte{byte(i), 1}))
@@ -127,12 +133,14 @@ func TestMinerCompleteDASetProviderRejectsInvalidGroups(t *testing.T) {
 	badCommitment.CommitTx = minerProviderMutateTx(t, badCommitment.CommitTx, func(tx *consensus.Tx) { tx.Outputs[0].CovenantData[0] ^= 0xff })
 	duplicateNonce := minerProviderCloneSet(base)
 	duplicateNonce.Chunks[1].Tx = minerProviderMutateTx(t, duplicateNonce.Chunks[1].Tx, func(tx *consensus.Tx) { tx.TxNonce = mustParseTx(t, duplicateNonce.Chunks[0].Tx).TxNonce })
+	duplicateInput := minerProviderCloneSet(base)
+	duplicateInput.Chunks[1].Tx = minerProviderMutateTx(t, duplicateInput.Chunks[1].Tx, func(tx *consensus.Tx) { tx.Inputs[0] = mustParseTx(t, duplicateInput.Chunks[0].Tx).Inputs[0] })
 	zeroNonce := minerProviderCloneSet(base)
 	zeroNonce.CommitTx = minerProviderMutateTx(t, zeroNonce.CommitTx, func(tx *consensus.Tx) { tx.TxNonce = 0 })
 	overBudget := minerProviderCloneSet(base)
-	for i, set := range []CompleteDASetCandidate{missing, duplicate, wrongDAID, badHash, badCommitment, duplicateNonce, zeroNonce, overBudget} {
+	for i, set := range []CompleteDASetCandidate{missing, duplicate, wrongDAID, badHash, badCommitment, duplicateNonce, duplicateInput, zeroNonce, overBudget} {
 		maxBytes := uint64(0)
-		if i == 7 {
+		if i == 8 {
 			maxBytes = 3
 		}
 		if selected := minerProviderSelected(t, []CompleteDASetCandidate{set}, nil, 0, maxBytes); len(selected) != 0 {
@@ -177,8 +185,10 @@ func minerProviderTestSet(t *testing.T, daID [32]byte, payloads ...[]byte) Compl
 		raw := minerProviderChunkTx(t, daID, base, uint16(i), payload)
 		chunks = append(chunks, CompleteDASetChunkCandidate{Index: uint16(i), Tx: raw})
 	}
+	commitInput := daID
+	commitInput[31] = 0xc1
 	tx := &consensus.Tx{Version: 1, TxKind: 0x01, TxNonce: base, DaPayload: []byte{0xa1}}
-	tx.Inputs = []consensus.TxInput{{PrevTxid: [32]byte{0xc1}}}
+	tx.Inputs = []consensus.TxInput{{PrevTxid: commitInput}}
 	tx.Outputs = []consensus.TxOutput{{CovenantType: consensus.COV_TYPE_DA_COMMIT, CovenantData: hasher.Sum(nil)}}
 	tx.DaCommitCore = &consensus.DaCommitCore{DaID: daID, ChunkCount: uint16(len(payloads)), BatchNumber: 1}
 	commit := mustMarshalTxForNodeTest(t, tx)
@@ -187,8 +197,10 @@ func minerProviderTestSet(t *testing.T, daID [32]byte, payloads ...[]byte) Compl
 
 func minerProviderChunkTx(t *testing.T, daID [32]byte, base uint64, index uint16, payload []byte) []byte {
 	chunkHash := sha3.Sum256(payload)
+	chunkInput := daID
+	chunkInput[31] = byte(index)
 	tx := &consensus.Tx{Version: 1, TxKind: 0x02, TxNonce: base + uint64(index) + 1, DaPayload: append([]byte(nil), payload...)}
-	tx.Inputs = []consensus.TxInput{{PrevTxid: [32]byte{0xc2}, PrevVout: uint32(index)}}
+	tx.Inputs = []consensus.TxInput{{PrevTxid: chunkInput, PrevVout: uint32(index)}}
 	tx.DaChunkCore = &consensus.DaChunkCore{DaID: daID, ChunkIndex: index, ChunkHash: chunkHash}
 	return mustMarshalTxForNodeTest(t, tx)
 }

--- a/clients/go/node/miner_da_flat_filter_test.go
+++ b/clients/go/node/miner_da_flat_filter_test.go
@@ -112,8 +112,9 @@ func TestMinerCompleteDASetProviderValidity(t *testing.T) {
 	if len(selected) != int(consensus.MAX_DA_BATCHES_PER_BLOCK)*3 {
 		t.Fatalf("selected batches=%d, want capped provider DA batches", len(selected)/3)
 	}
-	daID = [32]byte{0x83}
-	base := minerProviderTestSet(t, daID, []byte("chunk-0"), []byte("chunk-1"))
+}
+func TestMinerCompleteDASetProviderRejectsInvalidGroups(t *testing.T) {
+	base := minerProviderTestSet(t, [32]byte{0x83}, []byte("chunk-0"), []byte("chunk-1"))
 	missing := minerProviderCloneSet(base)
 	missing.Chunks = missing.Chunks[:1]
 	duplicate := minerProviderCloneSet(base)


### PR DESCRIPTION
Invariant:
Provider COMPLETE_SET candidates are selected only after miner-side validation proves matching DAID, exact ordered chunk coverage, consensus chunk/batch caps, unique DAID per template, valid chunk hashes, valid DA_COMMIT payload commitment, non-conflicting block tx nonces, parsed DA-byte budget, and atomic block fit.

Layer:
implementation / policy / tests

Files changed:
- clients/go/node/miner.go
- clients/go/node/miner_da_flat_filter_test.go

Tests:
- Focused Go node miner/provider tests: PASS
- Go node package tests: PASS
- Focused Go node race tests: PASS
- Local coverage gate: PASS, diff coverage 86.21%, variation -0.03%
- Stock isolated review: No findings

Behavior impact:
- Valid provider COMPLETE_SET groups can be selected after flat DA candidates are filtered.
- Invalid provider groups are skipped before template append.
- Malformed provider raw bytes still surface as non-canonical miner input errors.

Compatibility impact:
No consensus, Rust, spec, conformance, generated artifact, runtime wiring, or P2P relay state change.

Known non-goals:
- runtime provider wiring
- fetch-window or overfetch changes
- streaming/no-concat allocation optimization
- fee-market redesign
- Rust parity work

Closes #1829