### PR TITLE
RUB-376: bound DA provider miner work

### DIFF
--- a/clients/go/node/miner.go
+++ b/clients/go/node/miner.go
@@ -450,7 +450,8 @@ func (m *Miner) selectCandidateTransactions(candidateTxs [][]byte, utxos map[con
 			parsed = append(parsed, candidate.minedCandidate)
 		}
 	}
-	if m.cfg.CompleteDASetProvider == nil || maxSelected == 0 {
+	if m.cfg.CompleteDASetProvider == nil || maxSelected == 0 ||
+		len(parsed) >= maxSelected || selectedWeight >= remainingWeight {
 		return parsed, nil
 	}
 	validationCtx, err := m.providerConsensusContext(nextHeight)
@@ -466,6 +467,10 @@ func (m *Miner) selectCandidateTransactions(candidateTxs [][]byte, utxos map[con
 	for _, set := range m.cfg.CompleteDASetProvider.CompleteDASetCandidates(providerBudget) {
 		if len(parsed) >= maxSelected || len(selectedDAIDs) >= consensus.MAX_DA_BATCHES_PER_BLOCK {
 			break
+		}
+		remainingSlots := maxSelected - len(parsed)
+		if len(set.Chunks) >= remainingSlots {
+			continue
 		}
 		group, ok, err := m.parseCompleteDASetCandidate(set)
 		if err != nil {

--- a/clients/go/node/miner_da_flat_filter_test.go
+++ b/clients/go/node/miner_da_flat_filter_test.go
@@ -91,6 +91,74 @@ type minerTestCompleteDASetProvider []CompleteDASetCandidate
 func (p minerTestCompleteDASetProvider) CompleteDASetCandidates(uint64) []CompleteDASetCandidate {
 	return p
 }
+
+type countingMinerTestCompleteDASetProvider struct {
+	calls int
+	sets  []CompleteDASetCandidate
+}
+
+func (p *countingMinerTestCompleteDASetProvider) CompleteDASetCandidates(uint64) []CompleteDASetCandidate {
+	p.calls++
+	return p.sets
+}
+
+func TestMinerCompleteDASetProviderRuntimeBounds(t *testing.T) {
+	nonDA := minerFlatTestNonDA(0x90)
+	for _, tc := range []struct {
+		name            string
+		flat            [][]byte
+		remainingWeight uint64
+		wantSelected    int
+	}{
+		{
+			name:            "slots full",
+			flat:            [][]byte{nonDA},
+			remainingWeight: ^uint64(0),
+			wantSelected:    1,
+		},
+		{
+			name:            "no remaining weight",
+			remainingWeight: 0,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			provider := &countingMinerTestCompleteDASetProvider{}
+			miner := &Miner{cfg: MinerConfig{CompleteDASetProvider: provider, MaxTxPerBlock: 2}}
+			selected, err := miner.selectCandidateTransactions(tc.flat, nil, 1, tc.remainingWeight)
+			if err != nil {
+				t.Fatalf("selectCandidateTransactions: %v", err)
+			}
+			if len(selected) != tc.wantSelected {
+				t.Fatalf("selected=%d, want %d", len(selected), tc.wantSelected)
+			}
+			if provider.calls != 0 {
+				t.Fatalf("provider calls=%d, want 0", provider.calls)
+			}
+		})
+	}
+}
+
+func TestMinerCompleteDASetProviderSkipsUnfittableSetBeforeParsing(t *testing.T) {
+	badRaw := append(daCommitTxBytesForMinerPolicyTest(1, []byte("manifest")), 0)
+	provider := &countingMinerTestCompleteDASetProvider{
+		sets: []CompleteDASetCandidate{{
+			CommitTx: badRaw,
+			Chunks:   []CompleteDASetChunkCandidate{{Index: 0, Tx: badRaw}},
+		}},
+	}
+	miner := &Miner{cfg: MinerConfig{CompleteDASetProvider: provider, MaxTxPerBlock: 2}}
+	selected, err := miner.selectCandidateTransactions(nil, nil, 1, ^uint64(0))
+	if err != nil {
+		t.Fatalf("selectCandidateTransactions: %v", err)
+	}
+	if len(selected) != 0 {
+		t.Fatalf("selected=%d, want 0", len(selected))
+	}
+	if provider.calls != 1 {
+		t.Fatalf("provider calls=%d, want 1", provider.calls)
+	}
+}
+
 func TestMinerCompleteDASetProviderValidity(t *testing.T) {
 	fixture := newMinerProviderTestFixture(t)
 	daID := [32]byte{0x81}


### PR DESCRIPTION
Invariant:
Provider-backed DA mining avoids provider parse/hash work when transaction slots or block weight already prove a COMPLETE_SET cannot be included.

Layer:
implementation / policy / tests

Files changed:
- clients/go/node/miner.go
- clients/go/node/miner_da_flat_filter_test.go

Tests:
- cd clients/go && go test ./node -run "TestMinerCompleteDASetProviderRuntimeBounds|TestMinerCompleteDASetProviderSkipsUnfittableSetBeforeParsing" -count=1 - PASS
- cd clients/go && go test ./node -run "CompleteDASet|FlatDA|Miner|Template" -count=1 - PASS
- git diff --check - PASS
- Local coverage gate - PASS, diff coverage 100.00%, variation +0.00%
- Local isolated diff review - PASS, no findings

Behavior impact:
- If flat selection already fills transaction slots, the provider is not called.
- If no block weight remains, the provider is not called.
- Provider groups that cannot fit the remaining transaction slots are skipped before parsing malformed or oversized group bytes.

Compatibility impact:
No consensus, wire, Rust, conformance, spec, or runtime wiring change.

Known non-goals:
- No provider validity/cardinality changes.
- No cmd/rubin-node provider wiring.
- No P2P relay state-machine changes.
- No fee-market redesign.

Closes #1830