### PR TITLE
node: wire DA complete-set provider into live miner

### DIFF
--- a/clients/go/cmd/rubin-node/main.go
+++ b/clients/go/cmd/rubin-node/main.go
@@ -514,6 +514,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 		if mineAddrErr == nil {
 			minerCfg.CoreExtProfiles = genesisCfg.CoreExtProfiles
 			minerCfg.CurrentMempoolMinFeeRateFn = mempool.CurrentMinFeeRateSnapshot
+			minerCfg.CompleteDASetProvider = p2pService
 			var err error
 			liveMiner, err = newMinerFn(chainState, blockStore, syncEngine, minerCfg)
 			if err != nil {

--- a/clients/go/cmd/rubin-node/main_test.go
+++ b/clients/go/cmd/rubin-node/main_test.go
@@ -2089,6 +2089,9 @@ func TestRunMineBlocksPassesMineAddressToMiner(t *testing.T) {
 	if got := captured.CurrentMempoolMinFeeRateFn(); got != offlineMinerSentinelFloor {
 		t.Fatalf("offline-mining provider returned %d, want sentinel %d; closure is not bound to the live mempool snapshot", got, offlineMinerSentinelFloor)
 	}
+	if captured.CompleteDASetProvider != nil {
+		t.Fatal("offline-mining miner cfg should not receive a DA complete-set provider without a p2p service")
+	}
 }
 
 func TestRunMainnetFailsWithoutGenesisFileBeforeExplicitTargetCheck(t *testing.T) {
@@ -2639,6 +2642,10 @@ func TestRunDevnetWithRPCBindLiveMinerHasCurrentMempoolMinFeeRateFn(t *testing.T
 				_, _ = fmt.Fprintf(os.Stderr, "T-D regression: provider returned %d, want sentinel %d (closure not bound to live mempool snapshot)\n", got, liveMinerSentinelFloor)
 				os.Exit(35)
 			}
+			if cfg.CompleteDASetProvider == nil {
+				_, _ = fmt.Fprintln(os.Stderr, "DA provider regression: live miner cfg.CompleteDASetProvider=nil")
+				os.Exit(36)
+			}
 			return nil, errors.New("test deliberate miner init abort to unblock SIGINT")
 		}
 		dir := t.TempDir()
@@ -2675,6 +2682,9 @@ func TestRunDevnetWithRPCBindLiveMinerHasCurrentMempoolMinFeeRateFn(t *testing.T
 		}
 		if errors.As(err, &ee) && ee.ExitCode() == 35 {
 			t.Fatalf("T-D regression: live miner CurrentMempoolMinFeeRateFn does not observe the live mempool snapshot (sentinel mismatch); the closure may be a static fallback that bypasses the rolling rolling-floor source (stderr=%s)", stderr.String())
+		}
+		if errors.As(err, &ee) && ee.ExitCode() == 36 {
+			t.Fatalf("DA provider regression: live miner cfg.CompleteDASetProvider is nil; production wiring missing in main.go around `liveMiner, err = newMinerFn(...)` (stderr=%s)", stderr.String())
 		}
 		t.Fatalf("unexpected child error: %v (stderr=%s)", err, stderr.String())
 	}


### PR DESCRIPTION
Invariant:
Production devnet live miner construction receives the p2p COMPLETE_SET provider through the existing explicit miner config boundary.

Layer:
implementation / runtime wiring / tests

Files changed:
- clients/go/cmd/rubin-node/main.go
- clients/go/cmd/rubin-node/main_test.go

Tests:
- go test ./cmd/rubin-node -run "TestRunMineBlocksPassesMineAddressToMiner|TestRunDevnetWithRPCBindLiveMinerHasCurrentMempoolMinFeeRateFn" -count=1
- go test ./cmd/rubin-node ./node ./node/p2p -run "DA|Da|Miner|Template" -count=1
- Coverage gate: diff coverage 100.00%, coverage variation +0.00%

Behavior impact:
- Devnet live RPC miners receive the already-started p2p service as CompleteDASetProvider.
- Offline --mine-blocks miner construction remains nil-provider safe when no p2p service exists.

Compatibility impact:
- No consensus, wire format, spec, conformance, Rust, provider snapshot, or miner selection semantic change.

Known non-goals:
- No provider snapshot semantic changes.
- No miner selection semantic changes.
- No RPC, wallet, or API redesign.
- No parent RUB-321 or RUB-224 closeout claim.

Closes #1822