### PR TITLE
RUB-377: Pin compact DA soak child env

### DIFF
--- a/scripts/devnet-go-compact-da-soak.sh
+++ b/scripts/devnet-go-compact-da-soak.sh
@@ -7,6 +7,7 @@ DEV_ENV="${REPO_ROOT}/scripts/dev-env.sh"
 GO_MODULE_ROOT="${REPO_ROOT}/clients/go"
 COMPACT_SCRIPT="${REPO_ROOT}/scripts/devnet-go-compact-relay.sh"
 DA_SCRIPT="${REPO_ROOT}/scripts/devnet-go-da-relay.sh"
+ENV_BIN="/usr/bin/env"
 : "${KEEP_TMP:=1}"
 export KEEP_TMP
 
@@ -44,6 +45,7 @@ resolve_spec_root() {
 require_executable compact-script "${COMPACT_SCRIPT}"
 require_executable da-script "${DA_SCRIPT}"
 require_executable dev-env "${DEV_ENV}"
+require_executable env "${ENV_BIN}"
 SPEC_ROOT="$(resolve_spec_root)"
 [[ -d "${SPEC_ROOT}" ]] || { echo "missing spec root: ${SPEC_ROOT}" >&2; exit 1; }
 SPEC_ROOT="$(cd "${SPEC_ROOT}" && pwd -P)"
@@ -116,8 +118,9 @@ PY
 
 run_child_soak() {
   local label="$1" script="$2" log="$3"
+  local -a child_cmd=("${ENV_BIN}" KEEP_TMP=1 RUBIN_PROCESS_KEEP_ARTIFACTS=1 RUBIN_PROCESS_ARTIFACT_PARENT="${ARTIFACT_ROOT}" "${script}")
   echo "Running ${label} soak" >&2
-  if ! env KEEP_TMP=1 RUBIN_PROCESS_KEEP_ARTIFACTS=1 RUBIN_PROCESS_ARTIFACT_PARENT="${ARTIFACT_ROOT}" "${script}" >"${log}" 2>&1; then
+  if ! "${child_cmd[@]}" >"${log}" 2>&1; then
     echo "${label} soak failed; log=${log}" >&2
     tail -n 80 "${log}" >&2 || true
     return 1

--- a/scripts/devnet/test_compact_da_soak_env_resolution.sh
+++ b/scripts/devnet/test_compact_da_soak_env_resolution.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SOAK_SCRIPT="${REPO_ROOT}/scripts/devnet-go-compact-da-soak.sh"
+SYSTEM_ENV="/usr/bin/env"
+
+command -v python3 >/dev/null 2>&1 || { echo "python3 is required" >&2; exit 1; }
+[[ -r "${SOAK_SCRIPT}" ]] || { echo "soak script unreadable: ${SOAK_SCRIPT}" >&2; exit 1; }
+[[ -x "${SYSTEM_ENV}" ]] || { echo "system env is not executable: ${SYSTEM_ENV}" >&2; exit 1; }
+
+TMP_PARENT="$(cd -- "${TMPDIR:-/tmp}" && pwd -P)" || { echo "failed to canonicalize TMPDIR=${TMPDIR:-/tmp}" >&2; exit 1; }
+TMP_ROOT="$(mktemp -d "${TMP_PARENT%/}/rubin-compact-da-env.XXXXXX")" || { echo "mktemp failed" >&2; exit 1; }
+cleanup() {
+  rm -rf -- "${TMP_ROOT}"
+}
+trap cleanup EXIT
+
+FAKE_BIN="${TMP_ROOT}/bin"
+mkdir -p "${FAKE_BIN}"
+cat >"${FAKE_BIN}/env" <<'SH'
+#!/usr/bin/env sh
+exit 0
+SH
+chmod +x "${FAKE_BIN}/env"
+
+PATH="${FAKE_BIN}:${PATH}"
+RESOLVED_ENV="$(command -v env)"
+[[ "${RESOLVED_ENV}" == "${FAKE_BIN}/env" ]] || { echo "test setup failed: env did not resolve to fake env" >&2; exit 1; }
+
+python3 - "${SOAK_SCRIPT}" "${SYSTEM_ENV}" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+script_path = Path(sys.argv[1])
+system_env = sys.argv[2]
+text = script_path.read_text(encoding="utf-8")
+
+if f'ENV_BIN="{system_env}"' not in text:
+    raise SystemExit(f"missing pinned ENV_BIN={system_env}")
+
+child_cmd_pattern = re.compile(
+    r'local -a child_cmd=\("\$\{ENV_BIN\}" KEEP_TMP=1 '
+    r'RUBIN_PROCESS_KEEP_ARTIFACTS=1 '
+    r'RUBIN_PROCESS_ARTIFACT_PARENT="\$\{ARTIFACT_ROOT\}" '
+    r'"\$\{script\}"\)'
+)
+if not child_cmd_pattern.search(text):
+    raise SystemExit("missing child_cmd invocation through pinned ENV_BIN")
+
+for line_no, line in enumerate(text.splitlines(), 1):
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#"):
+        continue
+    if "KEEP_TMP=1" not in line or "RUBIN_PROCESS_KEEP_ARTIFACTS=1" not in line:
+        continue
+    if re.search(r'(^|[^\w/.-])env\s+KEEP_TMP=1\s+RUBIN_PROCESS_KEEP_ARTIFACTS=1', line):
+        raise SystemExit(f"bare env child invocation at line {line_no}: {line}")
+
+if '"${child_cmd[@]}"' not in text:
+    raise SystemExit("child command array is not executed")
+PY
+
+echo "PASS: compact+DA soak child env resolution is pinned against PATH shadowing"


### PR DESCRIPTION
Invariant:
- Combined compact/DA soak child execution uses deterministic `/usr/bin/env` resolution, so `PATH` shadowing of `env` cannot intercept child launches or hide child logs.

Layer:
- Operations / shell evidence harness.

Files changed:
- `scripts/devnet-go-compact-da-soak.sh`
- `scripts/devnet/test_compact_da_soak_env_resolution.sh`

Tests:
- `scripts/dev-env.sh -- bash -n scripts/devnet-go-compact-da-soak.sh` — PASS
- `scripts/dev-env.sh -- bash -n scripts/devnet/test_compact_da_soak_env_resolution.sh` — PASS
- `scripts/dev-env.sh -- scripts/devnet/test_compact_da_soak_env_resolution.sh` — PASS
- `scripts/dev-env.sh -- scripts/devnet-go-compact-da-soak.sh` — PASS
- `scripts/dev-env.sh -- scripts/devnet-go-compact-relay.sh` — PASS
- `scripts/dev-env.sh -- scripts/devnet-go-da-relay.sh` — PASS
- `git diff --check` — PASS

Behavior impact:
- The combined wrapper now preflights the pinned env executable and launches child soaks through that pinned path.
- Existing child report extraction and artifact parent propagation are preserved.

Compatibility impact:
- No Go, Rust, consensus, or P2P runtime behavior is changed.

Known non-goals:
- No compact relay behavior changes.
- No DA relay behavior changes.
- No mixed-client semantics changes.
- No broad shell cleanup.

Risk:
- Low; the change is limited to child process invocation in one shell harness plus a regression check.

Rollback:
- Revert this PR to restore the previous child invocation path.

Not checked:
- GitHub CI after PR creation.

Closes #1837
