### PR TITLE
RUB-378: Stabilize mixed evidence schema diagnostics tests

### DIFF
--- a/tools/tests/test_validate_mixed_client_evidence.py
+++ b/tools/tests/test_validate_mixed_client_evidence.py
@@ -48,6 +48,33 @@ def _assert_one(testcase: unittest.TestCase, errors: list[str], *needles: str) -
     )
 
 
+def _schema_node_for_path(path: tuple[str, ...]) -> dict:
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    node = schema
+    for key in path:
+        node = node["properties"][key]
+    return node
+
+
+def _assert_min_length_field_error(
+    testcase: unittest.TestCase,
+    errors: list[str],
+    path: tuple[str, ...],
+    min_length: int = 1,
+) -> None:
+    field = ".".join(path)
+    testcase.assertEqual(
+        _schema_node_for_path(path).get("minLength"),
+        min_length,
+        f"{field} schema minLength drifted",
+    )
+    testcase.assertTrue(errors, "expected validation errors but got none")
+    testcase.assertTrue(
+        any(e.startswith(f"{field}: ") for e in errors),
+        f"expected schema-owned {field} error; got {errors}",
+    )
+
+
 class CommittedFixtureTests(unittest.TestCase):
     def test_committed_valid_minimal_mixed_passes(self):
         errors = validator.validate(
@@ -471,7 +498,7 @@ class SchemaOwnedTests(unittest.TestCase):
             data["verdict"] = "FAIL"
             data["failure_reason"] = ""
             errors = _validate_dict(Path(td), data)
-            _assert_one(self, errors, "failure_reason", "too short")
+            _assert_min_length_field_error(self, errors, ("failure_reason",))
             self.assertFalse(
                 any(
                     "required when verdict=FAIL" in e
@@ -487,7 +514,7 @@ class SchemaOwnedTests(unittest.TestCase):
             data = _load_committed_valid()
             data["scenario"] = ""
             errors = _validate_dict(Path(td), data)
-            _assert_one(self, errors, "scenario", "too short")
+            _assert_min_length_field_error(self, errors, ("scenario",))
 
     def test_scenario_too_long_schema_owned_only(self):
         """`scenario` longer than `maxLength: 200` is rejected by the
@@ -1094,11 +1121,7 @@ class RestartReorgSchemaOwnedTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             data = _valid_with_restart(stopped="")
             errors = _validate_dict(Path(td), data)
-            self.assertTrue(errors)
-            self.assertTrue(
-                any("stopped_node" in e and "too short" in e for e in errors),
-                f"expected schema minLength violation; got {errors}",
-            )
+            _assert_min_length_field_error(self, errors, ("restart", "stopped_node"))
 
     def test_reorg_final_state_missing_tip_schema_owned_only(self):
         """reorg.final_state without `tip` is schema-rejected (RUB-207

--- a/tools/tests/test_validate_mixed_client_evidence.py
+++ b/tools/tests/test_validate_mixed_client_evidence.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import contextlib
 import copy
+import functools
 import io
 import json
 import shutil
@@ -48,9 +49,25 @@ def _assert_one(testcase: unittest.TestCase, errors: list[str], *needles: str) -
     )
 
 
+@functools.lru_cache(maxsize=1)
+def _committed_schema() -> dict:
+    try:
+        raw_schema = SCHEMA_PATH.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise AssertionError(f"could not read committed schema: {SCHEMA_PATH}") from exc
+    try:
+        schema = json.loads(raw_schema)
+    except json.JSONDecodeError as exc:
+        raise AssertionError(
+            f"committed schema is invalid JSON at line {exc.lineno}, column {exc.colno}: {exc.msg}"
+        ) from exc
+    if not isinstance(schema, dict):
+        raise AssertionError("committed schema root is not an object")
+    return schema
+
+
 def _schema_node_for_path(path: tuple[str, ...]) -> dict:
-    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
-    node = schema
+    node = _committed_schema()
     walked: list[str] = []
     for key in path:
         walked.append(key)

--- a/tools/tests/test_validate_mixed_client_evidence.py
+++ b/tools/tests/test_validate_mixed_client_evidence.py
@@ -51,8 +51,18 @@ def _assert_one(testcase: unittest.TestCase, errors: list[str], *needles: str) -
 def _schema_node_for_path(path: tuple[str, ...]) -> dict:
     schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
     node = schema
+    walked: list[str] = []
     for key in path:
-        node = node["properties"][key]
+        walked.append(key)
+        props = node.get("properties")
+        if not isinstance(props, dict) or key not in props:
+            raise AssertionError(
+                f"{'.'.join(walked)} schema path missing under {'.'.join(walked[:-1]) or '<root>'}"
+            )
+        child = props[key]
+        if not isinstance(child, dict):
+            raise AssertionError(f"{'.'.join(walked)} schema node is not an object")
+        node = child
     return node
 
 
@@ -72,6 +82,10 @@ def _assert_min_length_field_error(
     testcase.assertTrue(
         any(e.startswith(f"{field}: ") for e in errors),
         f"expected schema-owned {field} error; got {errors}",
+    )
+    testcase.assertFalse(
+        any("not in participants" in e for e in errors),
+        f"cross-field membership must not mask schema minLength for {field}; got {errors}",
     )
 
 


### PR DESCRIPTION
Invariant:
- Mixed-client evidence validator tests assert semantic schema-owned `minLength` failures instead of exact jsonschema wording.

Layer:
- Tests / Python tooling.

Files changed:
- `tools/tests/test_validate_mixed_client_evidence.py`

Tests:
- `scripts/dev-env.sh -- python3 tools/tests/test_validate_mixed_client_evidence.py` — PASS
- `scripts/dev-env.sh -- scripts/devnet/test_mixed_client_mesh_check_report.sh` — PASS
- `scripts/dev-env.sh -- scripts/devnet/test_mixed_client_devnet_soak_report.sh` — PASS
- `scripts/dev-env.sh -- python3 -m py_compile tools/tests/test_validate_mixed_client_evidence.py` — PASS
- `scripts/dev-env.sh -- ruff check tools/tests/test_validate_mixed_client_evidence.py` — PASS
- `scripts/dev-env.sh -- bandit -q tools/tests/test_validate_mixed_client_evidence.py` — PASS
- `scripts/dev-env.sh -- vulture --min-confidence 100 tools/tests/test_validate_mixed_client_evidence.py` — PASS
- `scripts/dev-env.sh -- semgrep --config auto --error --quiet tools/tests/test_validate_mixed_client_evidence.py` — PASS
- `git diff --check` — PASS

Behavior impact:
- No validator acceptance behavior changes.
- No schema changes.
- The affected tests now require the committed schema field to keep `minLength: 1` and require a validation error for that field path.

Compatibility impact:
- No Go, Rust, consensus, P2P, or mixed-client runtime semantics are changed.

Known non-goals:
- No weakening of `scripts/devnet/validate_mixed_client_evidence.py`.
- No broadening of accepted evidence shapes.
- No generated artifact edits.

Risk:
- Low; this is a test assertion stabilization for jsonschema wording drift.

Rollback:
- Revert this PR to restore the prior exact wording assertions.

Not checked:
- GitHub CI after PR creation.

Closes #1838
