### PR TITLE
RUB-410: pin Rust sendcmpct peer-mode parity

### DIFF
--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -3879,6 +3879,38 @@ mod tests {
             }
         );
 
+        let second_listener = TcpListener::bind("127.0.0.1:0").expect("bind second");
+        let second_client = TcpStream::connect(second_listener.local_addr().expect("second addr"))
+            .expect("connect second");
+        let (second_stream, _) = second_listener.accept().expect("accept second");
+        let mut second_session =
+            PeerSession::new(second_stream, default_peer_runtime_config("devnet", 8))
+                .expect("second session");
+        second_session
+            .collect_live_responses(
+                WireMessage {
+                    command: MESSAGE_SENDCMPCT.to_string(),
+                    payload: sendcmpct_runtime_payload(1, COMPACT_RELAY_VERSION),
+                },
+                &mut engine,
+                None,
+            )
+            .expect("second peer sendcmpct");
+        assert_eq!(
+            session.remote_compact_mode,
+            CompactModeSnapshot {
+                mode: 2,
+                version: COMPACT_RELAY_VERSION
+            }
+        );
+        assert_eq!(
+            second_session.remote_compact_mode,
+            CompactModeSnapshot {
+                mode: 1,
+                version: COMPACT_RELAY_VERSION
+            }
+        );
+
         let err = session
             .collect_live_responses(
                 WireMessage {
@@ -3901,7 +3933,7 @@ mod tests {
             }
         );
 
-        let err = session
+        let err = second_session
             .collect_live_responses(
                 WireMessage {
                     command: MESSAGE_SENDCMPCT.to_string(),
@@ -3913,7 +3945,14 @@ mod tests {
             .err()
             .expect("short sendcmpct payload must fail");
         assert!(err.to_string().contains("sendcmpct payload width mismatch"));
-        let err = session
+        assert_eq!(
+            second_session.remote_compact_mode,
+            CompactModeSnapshot {
+                mode: 1,
+                version: COMPACT_RELAY_VERSION
+            }
+        );
+        let err = second_session
             .collect_live_responses(
                 WireMessage {
                     command: MESSAGE_SENDCMPCT.to_string(),
@@ -3925,6 +3964,39 @@ mod tests {
             .err()
             .expect("current-version unknown mode must fail");
         assert!(err.to_string().contains("unsupported compact relay mode"));
+        assert_eq!(
+            second_session.remote_compact_mode,
+            CompactModeSnapshot {
+                mode: 1,
+                version: COMPACT_RELAY_VERSION
+            }
+        );
+
+        session
+            .collect_live_responses(
+                WireMessage {
+                    command: MESSAGE_SENDCMPCT.to_string(),
+                    payload: sendcmpct_runtime_payload(0, COMPACT_RELAY_VERSION),
+                },
+                &mut engine,
+                None,
+            )
+            .expect("sendcmpct mode downgrade to disabled");
+        assert_eq!(
+            session.remote_compact_mode,
+            CompactModeSnapshot {
+                mode: 0,
+                version: COMPACT_RELAY_VERSION
+            }
+        );
+        assert_eq!(
+            second_session.remote_compact_mode,
+            CompactModeSnapshot {
+                mode: 1,
+                version: COMPACT_RELAY_VERSION
+            }
+        );
+        drop(second_client);
         drop(client);
     }
 


### PR DESCRIPTION
Invariant:
Rust `sendcmpct` runtime state records compact-relay mode per peer, only after a valid `sendcmpct` payload is parsed.

Layer:
Tests / Rust P2P runtime parity evidence.

Files changed:
- `clients/rust/crates/rubin-node/src/p2p_runtime.rs`

Go/Rust parity matrix:
| Go/reference/vector case | Rust evidence/test |
| --- | --- |
| Valid nonzero `sendcmpct` modes are peer-local | `sendcmpct_live_dispatch_records_peer_mode` asserts peer A mode 2 and peer B mode 1 are recorded independently. |
| Peer-local compact mode isolation | The same test uses two `PeerSession`s and verifies invalid input for one peer does not mutate the other peer. |
| Unsupported version rejection preserves prior mode | The test keeps peer A at mode 2 and verifies an unsupported version does not downgrade it. |
| Short payload rejection preserves prior mode | The test keeps peer B at mode 1 and verifies a short payload does not mutate it. |
| Unsupported current-version mode rejection preserves prior mode | The test keeps peer B at mode 1 and verifies mode 3 is rejected without mutation. |
| Valid mode 0 downgrade remains allowed | The test verifies a valid mode 0 update clears peer A without changing peer B. |

Tests:
- `cargo test -p rubin-node sendcmpct --lib` — PASS
- `cargo fmt --check` — PASS
- `git diff --check` — PASS

Behavior impact:
No production behavior change. This is a test-only parity evidence update.

Compatibility impact:
No wire, API, storage, consensus, or runtime compatibility impact.

Known non-goals:
- No `getblocktxn`, `blocktxn`, or `cmpctblock` runtime changes.
- No compact reconstruction, fallback, timeout, or peer penalty semantics.
- No DA relay, miner, provider, Go, spec, conformance, or process harness changes.

Follow-ups:
None.

Risk:
Low; this only strengthens an existing Rust P2P runtime test.

Rollback:
Revert the test-only commit.

Not checked:
- No full network/devnet process run; this PR does not change production runtime behavior.

Closes #1872