### PR TITLE
RUB-412: add Rust compact receive flow

### DIFF
--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -47,6 +47,8 @@ const MAX_COMPACT_RELAY_ENTRIES: usize = MAX_INVENTORY_VECTORS;
 const MAX_COMPACT_RELAY_INDEX_VALUE: u64 = MAX_BLOCK_BYTES - 1;
 const COMPACT_LOCAL_TX_CANDIDATE_LIMIT: usize = 1000;
 const COMPACT_LOCAL_TX_CANDIDATE_BYTES_LIMIT: usize = 1 << 20;
+const COMPACT_PREFETCHED_FRAME_DRAIN_GRACE: Duration = Duration::from_millis(50);
+const STALE_BLOCKTXN_RESPONSE_ERR: &str = "stale blocktxn response";
 type CompactShortId = [u8; COMPACT_SHORT_ID_BYTES];
 type CompactLocalIndex = HashMap<CompactShortId, Option<Vec<u8>>>;
 pub const MSG_BLOCK: u8 = 0x01;
@@ -209,12 +211,32 @@ pub struct PeerRelayContext<'a> {
     /// (`clients/go/node/p2p/mempool.go:45-54`); that method's last
     /// statement (line 53) is `p.mempool.AddRemoteTx(raw)`.
     pub tx_pool: &'a std::sync::Mutex<crate::txpool::TxPool>,
+    pub compact_local_txs: Option<&'a [Vec<u8>]>,
 }
 
 #[derive(Debug, Default)]
 pub struct LiveMessageOutcome {
     pub responses: Vec<WireMessage>,
     pub tx_pool_cleanup: TxPoolCleanupPlan,
+    pub disconnect_after_responses: Option<String>,
+}
+
+pub(crate) fn snapshot_compact_local_tx_candidates(
+    tx_pool: &std::sync::Mutex<crate::txpool::TxPool>,
+) -> Vec<Vec<u8>> {
+    match tx_pool.lock() {
+        Ok(pool) => pool.select_transactions(
+            COMPACT_LOCAL_TX_CANDIDATE_LIMIT,
+            COMPACT_LOCAL_TX_CANDIDATE_BYTES_LIMIT,
+        ),
+        Err(_) => Vec::new(),
+    }
+}
+
+fn prepend_compact_fallback(outcome: &mut LiveMessageOutcome, fallback: Option<WireMessage>) {
+    if let Some(fallback) = fallback {
+        outcome.responses.insert(0, fallback);
+    }
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -421,14 +443,42 @@ impl PeerSession {
         self.cfg.read_deadline
     }
 
+    pub fn compact_receive_ready(&self) -> bool {
+        self.cfg.enable_compact_receive
+            && self.remote_compact_mode.version == COMPACT_RELAY_VERSION
+            && self.remote_compact_mode.mode != 0
+    }
+
+    pub fn cmpctblock_needs_local_tx_snapshot(
+        &self,
+        payload: &[u8],
+        sync_engine: &SyncEngine,
+    ) -> io::Result<bool> {
+        if !self.compact_receive_ready()
+            || !cmpctblock_receive_header_precheck_passes(payload, sync_engine.cfg.expected_target)
+        {
+            return Ok(false);
+        }
+        let Ok(block) = decode_cmpctblock_payload(payload) else {
+            return Ok(false);
+        };
+        if block.short_ids.is_empty() {
+            return Ok(false);
+        }
+        let block_hash = block_hash(&block.header).map_err(io::Error::other)?;
+        Ok(!sync_engine
+            .has_block(block_hash)
+            .map_err(io::Error::other)?)
+    }
+
     pub fn poll_read_ready(&mut self, timeout: Duration) -> io::Result<bool> {
+        if self.prefetched_read_byte.is_some() {
+            return Ok(true);
+        }
         if self.send_expired_compact_fallback()? {
             return Ok(false);
         }
         self.clear_expired_compact_late_blocktxn();
-        if self.prefetched_read_byte.is_some() {
-            return Ok(true);
-        }
         let timeout = self.compact_read_timeout(timeout);
         if timeout.is_zero() {
             self.send_expired_compact_fallback()?;
@@ -462,14 +512,22 @@ impl PeerSession {
     }
 
     pub fn read_message_with_timeout(&mut self, timeout: Duration) -> io::Result<WireMessage> {
-        self.send_expired_compact_fallback()?;
+        let prefetched_frame_in_progress = self.prefetched_read_byte.is_some();
+        if !prefetched_frame_in_progress {
+            self.send_expired_compact_fallback()?;
+        }
         self.clear_expired_compact_late_blocktxn();
-        let read_deadline = self.compact_read_deadline(timeout);
+        let read_deadline = if prefetched_frame_in_progress {
+            Instant::now() + self.compact_prefetched_read_timeout(timeout)
+        } else {
+            self.compact_read_deadline(timeout)
+        };
         let compact_mode = self.remote_compact_mode;
+        let now = Instant::now();
         let active_blocktxn_payload_cap = self
             .compact_outstanding
             .as_ref()
-            .filter(|req| Instant::now() < req.expires_at)
+            .filter(|req| prefetched_frame_in_progress || now < req.expires_at)
             .map(|req| req.blocktxn_payload_cap.min(MAX_RELAY_MSG_BYTES));
         let late_blocktxn_payload_cap = self
             .compact_late_blocktxn
@@ -536,6 +594,14 @@ impl PeerSession {
             .checked_duration_since(Instant::now())
             .unwrap_or(Duration::ZERO)
             .min(timeout)
+    }
+
+    fn compact_prefetched_read_timeout(&self, timeout: Duration) -> Duration {
+        let compact_timeout = self.compact_read_timeout(timeout);
+        if !compact_timeout.is_zero() {
+            return compact_timeout;
+        }
+        timeout.min(COMPACT_PREFETCHED_FRAME_DRAIN_GRACE)
     }
 
     fn compact_read_deadline(&self, timeout: Duration) -> Instant {
@@ -685,6 +751,7 @@ impl PeerSession {
                     Ok(LiveMessageOutcome {
                         responses: Vec::new(),
                         tx_pool_cleanup: TxPoolCleanupPlan::default(),
+                        ..Default::default()
                     })
                 } else {
                     Ok(LiveMessageOutcome {
@@ -693,6 +760,7 @@ impl PeerSession {
                             payload: encode_inventory_vectors(&requests)?,
                         }],
                         tx_pool_cleanup: TxPoolCleanupPlan::default(),
+                        ..Default::default()
                     })
                 }
             }
@@ -703,6 +771,7 @@ impl PeerSession {
                     relay_ctx.map(|c| c.relay_state),
                 )?,
                 tx_pool_cleanup: TxPoolCleanupPlan::default(),
+                ..Default::default()
             }),
             MESSAGE_GETBLOCKS => {
                 let items = self.handle_getblocks(&msg.payload, sync_engine)?;
@@ -710,6 +779,7 @@ impl PeerSession {
                     Ok(LiveMessageOutcome {
                         responses: Vec::new(),
                         tx_pool_cleanup: TxPoolCleanupPlan::default(),
+                        ..Default::default()
                     })
                 } else {
                     Ok(LiveMessageOutcome {
@@ -718,6 +788,7 @@ impl PeerSession {
                             payload: encode_inventory_vectors(&items)?,
                         }],
                         tx_pool_cleanup: TxPoolCleanupPlan::default(),
+                        ..Default::default()
                     })
                 }
             }
@@ -729,6 +800,7 @@ impl PeerSession {
                         .into_iter()
                         .collect(),
                     tx_pool_cleanup,
+                    ..Default::default()
                 })
             }
             "cmpctblock" => self.handle_cmpctblock(&msg.payload, sync_engine, relay_ctx),
@@ -866,17 +938,20 @@ impl PeerSession {
                 Ok(LiveMessageOutcome {
                     responses: Vec::new(),
                     tx_pool_cleanup: TxPoolCleanupPlan::default(),
+                    ..Default::default()
                 })
             }
             "headers" | "pong" => Ok(LiveMessageOutcome {
                 responses: Vec::new(),
                 tx_pool_cleanup: TxPoolCleanupPlan::default(),
+                ..Default::default()
             }),
             MESSAGE_SENDCMPCT => {
                 self.handle_sendcmpct(&msg.payload)?;
                 Ok(LiveMessageOutcome {
                     responses: Vec::new(),
                     tx_pool_cleanup: TxPoolCleanupPlan::default(),
+                    ..Default::default()
                 })
             }
             "ping" => Ok(LiveMessageOutcome {
@@ -885,6 +960,7 @@ impl PeerSession {
                     payload: Vec::new(),
                 }],
                 tx_pool_cleanup: TxPoolCleanupPlan::default(),
+                ..Default::default()
             }),
             MESSAGE_GETADDR => Ok(LiveMessageOutcome {
                 responses: vec![WireMessage {
@@ -892,12 +968,14 @@ impl PeerSession {
                     payload: marshal_empty_addr_payload(),
                 }],
                 tx_pool_cleanup: TxPoolCleanupPlan::default(),
+                ..Default::default()
             }),
             MESSAGE_ADDR => {
                 let _ = unmarshal_addr_payload(&msg.payload)?;
                 Ok(LiveMessageOutcome {
                     responses: Vec::new(),
                     tx_pool_cleanup: TxPoolCleanupPlan::default(),
+                    ..Default::default()
                 })
             }
             other => {
@@ -916,6 +994,9 @@ impl PeerSession {
         let outcome = self.collect_live_responses(msg, sync_engine, relay_ctx)?;
         for response in outcome.responses {
             self.write_message(&response)?;
+        }
+        if let Some(reason) = outcome.disconnect_after_responses {
+            return Err(io::Error::new(io::ErrorKind::InvalidData, reason));
         }
         Ok(outcome.tx_pool_cleanup)
     }
@@ -941,7 +1022,6 @@ impl PeerSession {
         {
             return Err(invalid_data("compact receive disabled"));
         }
-        self.send_expired_compact_fallback()?;
         self.validate_cmpctblock_receive_header(payload, sync_engine)?;
         let block = match decode_cmpctblock_payload(payload) {
             Ok(block) => block,
@@ -958,30 +1038,33 @@ impl PeerSession {
             self.clear_compact_outstanding_request_for_block(block_hash);
             return Ok(LiveMessageOutcome::default());
         }
-        let local_txs = match relay_ctx.and_then(|ctx| ctx.tx_pool.lock().ok()) {
-            Some(pool) => pool.select_transactions(
-                COMPACT_LOCAL_TX_CANDIDATE_LIMIT,
-                COMPACT_LOCAL_TX_CANDIDATE_BYTES_LIMIT,
-            ),
-            None => Vec::new(),
-        };
-        let result = match reconstruct_compact_block(&block, &local_txs) {
+        let expired_fallback = self.take_expired_compact_fallback_message()?;
+        let local_txs = relay_ctx
+            .and_then(|ctx| ctx.compact_local_txs)
+            .unwrap_or(&[]);
+        let result = match reconstruct_compact_block(&block, local_txs) {
             Ok(result) => result,
             Err(_err) if !block.short_ids.is_empty() => {
-                return self.request_compact_full_block_fallback(block_hash);
+                let mut outcome = self.request_compact_full_block_fallback(block_hash)?;
+                prepend_compact_fallback(&mut outcome, expired_fallback);
+                return Ok(outcome);
             }
             Err(err) => return Err(err),
         };
         if !result.transactions.is_empty() {
-            return self.process_compact_transactions(
+            let mut outcome = self.process_compact_transactions(
                 block_hash,
                 block.header,
                 &result.transactions,
                 sync_engine,
                 !block.short_ids.is_empty(),
-            );
+            )?;
+            prepend_compact_fallback(&mut outcome, expired_fallback);
+            return Ok(outcome);
         }
-        self.request_missing_compact_transactions(block, block_hash, result)
+        let mut outcome = self.request_missing_compact_transactions(block, block_hash, result)?;
+        prepend_compact_fallback(&mut outcome, expired_fallback);
+        Ok(outcome)
     }
     fn validate_cmpctblock_receive_header(
         &mut self,
@@ -1064,20 +1147,29 @@ impl PeerSession {
             self.compact_outstanding.as_ref(),
             Some(req) if Instant::now() >= req.expires_at && response_hash != req.block_hash
         ) {
-            self.send_expired_compact_fallback()?;
+            let mut outcome = LiveMessageOutcome::default();
+            prepend_compact_fallback(&mut outcome, self.take_expired_compact_fallback_message()?);
+            if payload.len() > 32 {
+                outcome.disconnect_after_responses = Some(STALE_BLOCKTXN_RESPONSE_ERR.to_string());
+            }
+            return Ok(outcome);
         }
         let Some(req) = self.compact_outstanding.clone() else {
+            let mut outcome = LiveMessageOutcome::default();
             if self.clear_matching_late_blocktxn(response_hash, payload.len() as u64)? {
-                return Ok(LiveMessageOutcome::default());
+                return Ok(outcome);
             }
-            return Ok(LiveMessageOutcome::default());
+            if payload.len() > 32 {
+                outcome.disconnect_after_responses = Some(STALE_BLOCKTXN_RESPONSE_ERR.to_string());
+            }
+            return Ok(outcome);
         };
         if response_hash != req.block_hash {
             if self.clear_matching_late_blocktxn(response_hash, payload.len() as u64)? {
                 return Ok(LiveMessageOutcome::default());
             }
             return if payload.len() > 32 {
-                Err(invalid_data("stale blocktxn response"))
+                Err(invalid_data(STALE_BLOCKTXN_RESPONSE_ERR))
             } else {
                 Ok(LiveMessageOutcome::default())
             };
@@ -1159,6 +1251,7 @@ impl PeerSession {
                         .into_iter()
                         .collect(),
                     tx_pool_cleanup,
+                    ..Default::default()
                 })
             }
             Err(err) => {
@@ -1194,15 +1287,21 @@ impl PeerSession {
         }
     }
     fn send_expired_compact_fallback(&mut self) -> io::Result<bool> {
+        let Some(fallback) = self.take_expired_compact_fallback_message()? else {
+            return Ok(false);
+        };
+        self.write_message(&fallback)?;
+        Ok(true)
+    }
+    fn take_expired_compact_fallback_message(&mut self) -> io::Result<Option<WireMessage>> {
         self.clear_expired_compact_late_blocktxn();
         if !matches!(&self.compact_outstanding, Some(req) if Instant::now() >= req.expires_at) {
-            return Ok(false);
+            return Ok(None);
         }
         let req = self.compact_outstanding.take().expect("checked above");
         let block_hash = req.block_hash;
         self.preserve_compact_request_for_late_blocktxn(req);
-        self.write_message(&compact_full_block_fallback_message(block_hash)?)?;
-        Ok(true)
+        Ok(Some(compact_full_block_fallback_message(block_hash)?))
     }
     fn preserve_compact_request_for_late_blocktxn(&mut self, req: CompactOutstandingRequest) {
         self.compact_late_blocktxn = Some(CompactLateBlockTxnDrain {
@@ -2139,6 +2238,22 @@ fn cmpctblock_header_validation_candidate(payload: &[u8]) -> Option<[u8; BLOCK_H
     let mut header = [0u8; BLOCK_HEADER_BYTES];
     header.copy_from_slice(&payload[..BLOCK_HEADER_BYTES]);
     Some(header)
+}
+
+fn cmpctblock_receive_header_precheck_passes(
+    payload: &[u8],
+    expected_target: Option<[u8; 32]>,
+) -> bool {
+    let Some(header) = cmpctblock_header_validation_candidate(payload) else {
+        return true;
+    };
+    let Ok(parsed_header) = rubin_consensus::parse_block_header_bytes(&header) else {
+        return false;
+    };
+    if rubin_consensus::pow_check(&header, parsed_header.target).is_err() {
+        return false;
+    }
+    !matches!(expected_target, Some(expected) if parsed_header.target != expected)
 }
 
 fn has_cmpctblock_header_validation_shape(payload: &[u8]) -> bool {
@@ -4074,6 +4189,49 @@ mod tests {
         assert_eq!(late.command, "blocktxn");
         session.handle_blocktxn(&late.payload, &mut engine).unwrap();
         assert!(session.compact_late_blocktxn.is_none());
+        let stale_hash = [0x55; 32];
+        session.compact_late_blocktxn = Some(CompactLateBlockTxnDrain {
+            block_hash,
+            blocktxn_payload_cap: MAX_RELAY_MSG_BYTES,
+            expires_at: Instant::now() + DEFAULT_READ_DEADLINE,
+        });
+        let outcome = session
+            .handle_blocktxn(&stale_hash, &mut engine)
+            .expect("hash-only stale blocktxn ignored");
+        assert_eq!(outcome.disconnect_after_responses, None);
+        assert!(session.compact_late_blocktxn.is_some());
+        let stale_body = encode_blocktxn_payload(BlockTxnPayload {
+            block_hash: stale_hash,
+            transactions: vec![tx.clone()],
+        })
+        .unwrap();
+        let outcome = session
+            .handle_blocktxn(&stale_body, &mut engine)
+            .expect("stale body queued for disconnect");
+        assert_eq!(
+            outcome.disconnect_after_responses.as_deref(),
+            Some(STALE_BLOCKTXN_RESPONSE_ERR)
+        );
+        session.compact_late_blocktxn = None;
+        session
+            .handle_cmpctblock(&missing, &mut engine, None)
+            .unwrap();
+        session.compact_outstanding.as_mut().unwrap().expires_at = Instant::now();
+        let err = session
+            .handle_live_message(
+                WireMessage {
+                    command: "blocktxn".to_string(),
+                    payload: stale_body.clone(),
+                },
+                &mut engine,
+                None,
+            )
+            .expect_err("expired mismatched body disconnects after fallback");
+        assert!(err.to_string().contains(STALE_BLOCKTXN_RESPONSE_ERR));
+        let fallback = read_message_from(&mut client, network_magic("devnet"), MAX_RELAY_MSG_BYTES)
+            .expect("read fallback before stale body disconnect");
+        assert_eq!(fallback.command, MESSAGE_GETDATA);
+        session.compact_late_blocktxn = None;
         session
             .handle_cmpctblock(&missing, &mut engine, None)
             .unwrap();
@@ -4081,10 +4239,8 @@ mod tests {
         let outcome = session
             .handle_cmpctblock(&missing, &mut engine, None)
             .expect("expired outstanding cmpctblock sends fallback before replacement");
-        assert_eq!(outcome.responses[0].command, "getblocktxn");
-        let fallback = read_message_from(&mut client, network_magic("devnet"), MAX_RELAY_MSG_BYTES)
-            .expect("read handler fallback");
-        assert_eq!(fallback.command, MESSAGE_GETDATA);
+        assert_eq!(outcome.responses[0].command, MESSAGE_GETDATA);
+        assert_eq!(outcome.responses[1].command, "getblocktxn");
         let response = encode_blocktxn_payload(BlockTxnPayload {
             block_hash,
             transactions: vec![tx.clone()],
@@ -4152,6 +4308,72 @@ mod tests {
     }
 
     #[test]
+    fn compact_snapshot_precheck_requires_valid_unknown_short_ids() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let _client = TcpStream::connect(listener.local_addr().expect("addr")).expect("connect");
+        let (stream, _) = listener.accept().expect("accept");
+        let mut session =
+            PeerSession::new(stream, default_peer_runtime_config("devnet", 8)).expect("session");
+        let engine = test_sync_engine_with_genesis();
+        let genesis = parse_block_bytes(&devnet_genesis_block_bytes()).expect("parse genesis");
+        let genesis_hash = block_hash(&genesis.header_bytes).expect("genesis hash");
+        let block1 = height_one_coinbase_only_block(genesis_hash, genesis.header.timestamp + 1);
+        let header: [u8; BLOCK_HEADER_BYTES] = block1[..BLOCK_HEADER_BYTES].try_into().unwrap();
+        let tx = block1[BLOCK_HEADER_BYTES + 1..].to_vec();
+        let short_id = compact_reconstruct_short_id_for_tx(&tx);
+        let missing = encode_cmpctblock_payload(CmpctBlockPayload {
+            header,
+            nonce1: 0,
+            nonce2: 0,
+            short_ids: vec![short_id],
+            prefilled: Vec::new(),
+        })
+        .expect("cmpctblock");
+
+        assert!(!session
+            .cmpctblock_needs_local_tx_snapshot(&missing, &engine)
+            .expect("disabled precheck"));
+        session.cfg.enable_compact_receive = true;
+        session.remote_compact_mode = CompactModeSnapshot {
+            mode: 1,
+            version: COMPACT_RELAY_VERSION,
+        };
+        assert!(session
+            .cmpctblock_needs_local_tx_snapshot(&missing, &engine)
+            .expect("valid unknown short-id precheck"));
+
+        let mut malformed = missing.clone();
+        malformed.push(0);
+        assert!(!session
+            .cmpctblock_needs_local_tx_snapshot(&malformed, &engine)
+            .expect("malformed precheck"));
+
+        let all_prefilled = encode_cmpctblock_payload(CmpctBlockPayload {
+            header,
+            nonce1: 0,
+            nonce2: 0,
+            short_ids: Vec::new(),
+            prefilled: vec![PrefilledTxn { index: 0, tx }],
+        })
+        .expect("all-prefilled cmpctblock");
+        assert!(!session
+            .cmpctblock_needs_local_tx_snapshot(&all_prefilled, &engine)
+            .expect("all-prefilled precheck"));
+
+        let known = encode_cmpctblock_payload(CmpctBlockPayload {
+            header: genesis.header_bytes,
+            nonce1: 0,
+            nonce2: 0,
+            short_ids: vec![[1u8; COMPACT_SHORT_ID_BYTES]],
+            prefilled: Vec::new(),
+        })
+        .expect("known cmpctblock");
+        assert!(!session
+            .cmpctblock_needs_local_tx_snapshot(&known, &engine)
+            .expect("known block precheck"));
+    }
+
+    #[test]
     fn compact_receive_expiry_clamps_poll_and_prefetched_reads() {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
         let mut client = TcpStream::connect(listener.local_addr().expect("addr")).expect("connect");
@@ -4183,6 +4405,46 @@ mod tests {
         assert!(session.compact_late_blocktxn.is_some());
 
         session.compact_late_blocktxn = None;
+        session.compact_outstanding = Some(CompactOutstandingRequest {
+            block_hash,
+            header: [0u8; BLOCK_HEADER_BYTES],
+            missing_indexes: vec![0],
+            missing_short_ids: vec![[0u8; COMPACT_SHORT_ID_BYTES]],
+            partial_transactions: vec![None],
+            nonces: [0, 0],
+            blocktxn_payload_cap: MAX_RELAY_MSG_BYTES,
+            expires_at: Instant::now() + Duration::from_millis(150),
+        });
+        let matching_blocktxn = encode_blocktxn_payload(BlockTxnPayload {
+            block_hash,
+            transactions: Vec::new(),
+        })
+        .expect("matching blocktxn");
+        client
+            .write_all(
+                &marshal_wire_message(
+                    &WireMessage {
+                        command: "blocktxn".to_string(),
+                        payload: matching_blocktxn.clone(),
+                    },
+                    network_magic("devnet"),
+                    MAX_RELAY_MSG_BYTES,
+                )
+                .unwrap(),
+            )
+            .expect("write matching blocktxn");
+        client.flush().expect("flush matching blocktxn");
+        assert!(session.poll_read_ready(Duration::from_secs(1)).unwrap());
+        session.compact_outstanding.as_mut().unwrap().expires_at =
+            Instant::now() - Duration::from_millis(1);
+        let msg = session
+            .read_message_with_timeout(Duration::from_secs(1))
+            .expect("prefetched matching blocktxn should read before expiry fallback");
+        assert_eq!(msg.command, "blocktxn");
+        assert_eq!(msg.payload, matching_blocktxn);
+        assert!(session.compact_outstanding.is_some());
+        assert!(session.compact_late_blocktxn.is_none());
+
         session.compact_outstanding = Some(CompactOutstandingRequest {
             block_hash,
             header: [0u8; BLOCK_HEADER_BYTES],
@@ -5523,6 +5785,7 @@ mod tests {
                 peer_registered_addr: "sender:8333",
                 peer_writers: &peer_outboxes,
                 tx_pool: &canonical_tx_pool,
+                compact_local_txs: None,
             };
 
             let msg = WireMessage {
@@ -5725,6 +5988,7 @@ mod tests {
                 peer_registered_addr: "sender:8333",
                 peer_writers: &peer_outboxes,
                 tx_pool: &canonical_tx_pool,
+                compact_local_txs: None,
             };
 
             let msg = WireMessage {

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -398,7 +398,7 @@ impl PeerSession {
         self.stream.write_all(data)
     }
 
-    fn new(stream: TcpStream, cfg: PeerRuntimeConfig) -> Result<Self, String> {
+    pub(crate) fn new(stream: TcpStream, cfg: PeerRuntimeConfig) -> Result<Self, String> {
         let addr = stream
             .peer_addr()
             .map(|a| a.to_string())

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -161,6 +161,7 @@ pub struct PeerRuntimeConfig {
     pub read_deadline: Duration,
     pub write_deadline: Duration,
     pub ban_threshold: i32,
+    pub enable_compact_receive: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
@@ -226,9 +227,16 @@ struct CompactModeSnapshot {
 struct CompactOutstandingRequest {
     block_hash: [u8; 32],
     header: [u8; BLOCK_HEADER_BYTES],
+    missing_indexes: Vec<u64>,
     missing_short_ids: Vec<CompactShortId>,
     partial_transactions: Vec<Option<Vec<u8>>>,
     nonces: [u64; 2],
+    blocktxn_payload_cap: u64,
+    expires_at: Instant,
+}
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct CompactLateBlockTxnDrain {
+    block_hash: [u8; 32],
     blocktxn_payload_cap: u64,
     expires_at: Instant,
 }
@@ -264,6 +272,7 @@ pub struct PeerSession {
     prefetched_read_byte: Option<u8>,
     remote_compact_mode: CompactModeSnapshot,
     compact_outstanding: Option<CompactOutstandingRequest>,
+    compact_late_blocktxn: Option<CompactLateBlockTxnDrain>,
 }
 
 pub struct PeerManager {
@@ -320,6 +329,7 @@ pub fn default_peer_runtime_config(network: &str, max_peers: usize) -> PeerRunti
         read_deadline: DEFAULT_READ_DEADLINE,
         write_deadline: DEFAULT_WRITE_DEADLINE,
         ban_threshold: DEFAULT_BAN_THRESHOLD,
+        enable_compact_receive: false,
     }
 }
 
@@ -383,6 +393,7 @@ impl PeerSession {
             prefetched_read_byte: None,
             remote_compact_mode: CompactModeSnapshot::default(),
             compact_outstanding: None,
+            compact_late_blocktxn: None,
         })
     }
 
@@ -411,8 +422,18 @@ impl PeerSession {
     }
 
     pub fn poll_read_ready(&mut self, timeout: Duration) -> io::Result<bool> {
+        if self.send_expired_compact_fallback()? {
+            return Ok(false);
+        }
+        self.clear_expired_compact_late_blocktxn();
         if self.prefetched_read_byte.is_some() {
             return Ok(true);
+        }
+        let timeout = self.compact_read_timeout(timeout);
+        if timeout.is_zero() {
+            self.send_expired_compact_fallback()?;
+            self.clear_expired_compact_late_blocktxn();
+            return Ok(false);
         }
         self.stream
             .set_read_timeout(Some(timeout))
@@ -433,15 +454,7 @@ impl PeerSession {
                     io::ErrorKind::TimedOut | io::ErrorKind::WouldBlock
                 ) =>
             {
-                if let Some(block_hash) = self
-                    .compact_outstanding
-                    .as_ref()
-                    .filter(|req| Instant::now() >= req.expires_at)
-                    .map(|req| req.block_hash)
-                {
-                    self.compact_outstanding = None;
-                    self.write_message(&compact_full_block_fallback_message(block_hash)?)?;
-                }
+                self.send_expired_compact_fallback()?;
                 Ok(false)
             }
             Err(err) => Err(err),
@@ -449,21 +462,29 @@ impl PeerSession {
     }
 
     pub fn read_message_with_timeout(&mut self, timeout: Duration) -> io::Result<WireMessage> {
-        self.stream
-            .set_read_timeout(Some(timeout))
-            .map_err(io::Error::other)?;
-        let mut reader = PrefetchedReader {
-            stream: &mut self.stream,
-            prefetched_read_byte: self.prefetched_read_byte.take(),
-        };
+        self.send_expired_compact_fallback()?;
+        self.clear_expired_compact_late_blocktxn();
+        let read_deadline = self.compact_read_deadline(timeout);
         let compact_mode = self.remote_compact_mode;
-        let blocktxn_payload_cap = self
+        let active_blocktxn_payload_cap = self
             .compact_outstanding
             .as_ref()
             .filter(|req| Instant::now() < req.expires_at)
             .map(|req| req.blocktxn_payload_cap.min(MAX_RELAY_MSG_BYTES));
+        let late_blocktxn_payload_cap = self
+            .compact_late_blocktxn
+            .as_ref()
+            .filter(|late| Instant::now() < late.expires_at)
+            .map(|late| late.blocktxn_payload_cap.min(MAX_RELAY_MSG_BYTES));
+        let blocktxn_payload_cap = active_blocktxn_payload_cap.max(late_blocktxn_payload_cap);
+        let compact_receive_enabled = self.cfg.enable_compact_receive;
         let payload_cap = move |command: &str| {
-            runtime_payload_cap_for_compact_session(command, compact_mode, blocktxn_payload_cap)
+            runtime_payload_cap_for_compact_session(
+                command,
+                compact_receive_enabled,
+                compact_mode,
+                blocktxn_payload_cap,
+            )
         };
         // NOTE on tx-oversize ban policy (parity gap with Go's
         // `peer.handleTx`):
@@ -484,12 +505,59 @@ impl PeerSession {
         // ban-score policy at the higher layer; that is intentionally
         // out of scope for this Q-* task (which only aligns the
         // malformed/parse-fail surface).
-        read_message_from_with_payload_limit(
-            &mut reader,
-            network_magic(&self.cfg.network),
-            MAX_RELAY_MSG_BYTES,
-            &payload_cap,
-        )
+        let result = {
+            let mut reader = PrefetchedReader {
+                stream: &mut self.stream,
+                prefetched_read_byte: self.prefetched_read_byte.take(),
+                read_deadline,
+            };
+            read_message_from_with_payload_limit(
+                &mut reader,
+                network_magic(&self.cfg.network),
+                MAX_RELAY_MSG_BYTES,
+                &payload_cap,
+            )
+        };
+        if matches!(
+            result.as_ref().err().map(|err| err.kind()),
+            Some(io::ErrorKind::TimedOut | io::ErrorKind::WouldBlock)
+        ) {
+            self.send_expired_compact_fallback()?;
+            self.clear_expired_compact_late_blocktxn();
+        }
+        result
+    }
+
+    fn compact_read_timeout(&self, timeout: Duration) -> Duration {
+        let Some(deadline) = self.compact_session_deadline() else {
+            return timeout;
+        };
+        deadline
+            .checked_duration_since(Instant::now())
+            .unwrap_or(Duration::ZERO)
+            .min(timeout)
+    }
+
+    fn compact_read_deadline(&self, timeout: Duration) -> Instant {
+        let timeout_deadline = Instant::now() + timeout;
+        match self.compact_session_deadline() {
+            Some(compact_deadline) if compact_deadline < timeout_deadline => compact_deadline,
+            _ => timeout_deadline,
+        }
+    }
+
+    fn compact_session_deadline(&self) -> Option<Instant> {
+        let active = self.compact_outstanding.as_ref().map(|req| req.expires_at);
+        let late = self
+            .compact_late_blocktxn
+            .as_ref()
+            .map(|late| late.expires_at);
+        match (active, late) {
+            (Some(a), Some(b)) => Some(a.min(b)),
+            (Some(a), None) => Some(a),
+            (None, Some(b)) => Some(b),
+            (None, None) => None,
+        }
     }
 
     pub fn write_message(&mut self, msg: &WireMessage) -> io::Result<()> {
@@ -867,12 +935,14 @@ impl PeerSession {
         sync_engine: &mut SyncEngine,
         relay_ctx: Option<&PeerRelayContext<'_>>,
     ) -> io::Result<LiveMessageOutcome> {
-        if self.remote_compact_mode.version != COMPACT_RELAY_VERSION
+        if !self.cfg.enable_compact_receive
+            || self.remote_compact_mode.version != COMPACT_RELAY_VERSION
             || self.remote_compact_mode.mode == 0
         {
             return Err(invalid_data("compact receive disabled"));
         }
-        self.clear_expired_compact_outstanding_request();
+        self.send_expired_compact_fallback()?;
+        self.validate_cmpctblock_receive_header(payload, sync_engine)?;
         let block = match decode_cmpctblock_payload(payload) {
             Ok(block) => block,
             Err(err) => {
@@ -880,17 +950,6 @@ impl PeerSession {
                 return Err(err);
             }
         };
-        let parsed_header =
-            rubin_consensus::parse_block_header_bytes(&block.header).map_err(io::Error::other)?;
-        if let Err(err) = rubin_consensus::pow_check(&block.header, parsed_header.target) {
-            self.bump_ban(100, &err.to_string());
-            return Err(io::Error::new(io::ErrorKind::InvalidData, err.to_string()));
-        }
-        if matches!(sync_engine.cfg.expected_target, Some(expected) if parsed_header.target != expected)
-        {
-            self.bump_ban(100, "target mismatch");
-            return Err(invalid_data("target mismatch"));
-        }
         let block_hash = block_hash(&block.header).map_err(io::Error::other)?;
         if sync_engine
             .has_block(block_hash)
@@ -919,9 +978,31 @@ impl PeerSession {
                 block.header,
                 &result.transactions,
                 sync_engine,
+                !block.short_ids.is_empty(),
             );
         }
         self.request_missing_compact_transactions(block, block_hash, result)
+    }
+    fn validate_cmpctblock_receive_header(
+        &mut self,
+        payload: &[u8],
+        sync_engine: &SyncEngine,
+    ) -> io::Result<()> {
+        let Some(header) = cmpctblock_header_validation_candidate(payload) else {
+            return Ok(());
+        };
+        let parsed_header =
+            rubin_consensus::parse_block_header_bytes(&header).map_err(io::Error::other)?;
+        if let Err(err) = rubin_consensus::pow_check(&header, parsed_header.target) {
+            self.bump_ban(100, &err.to_string());
+            return Err(io::Error::new(io::ErrorKind::InvalidData, err.to_string()));
+        }
+        if matches!(sync_engine.cfg.expected_target, Some(expected) if parsed_header.target != expected)
+        {
+            self.bump_ban(100, "target mismatch");
+            return Err(invalid_data("target mismatch"));
+        }
+        Ok(())
     }
     fn request_missing_compact_transactions(
         &mut self,
@@ -950,6 +1031,7 @@ impl PeerSession {
         self.compact_outstanding = Some(CompactOutstandingRequest {
             block_hash,
             header: block.header,
+            missing_indexes: result.missing_indexes,
             missing_short_ids: result.missing_short_ids,
             partial_transactions: result.partial_transactions,
             nonces: [block.nonce1, block.nonce2],
@@ -969,17 +1051,31 @@ impl PeerSession {
         payload: &[u8],
         sync_engine: &mut SyncEngine,
     ) -> io::Result<LiveMessageOutcome> {
+        if !self.cfg.enable_compact_receive {
+            return Ok(LiveMessageOutcome::default());
+        }
         if payload.len() < 32 {
             self.bump_ban(10, "blocktxn payload missing block hash");
             return Err(invalid_data("blocktxn payload missing block hash"));
         }
-        self.clear_expired_compact_outstanding_request();
         let mut response_hash = [0u8; 32];
         response_hash.copy_from_slice(&payload[..32]);
+        if matches!(
+            self.compact_outstanding.as_ref(),
+            Some(req) if Instant::now() >= req.expires_at && response_hash != req.block_hash
+        ) {
+            self.send_expired_compact_fallback()?;
+        }
         let Some(req) = self.compact_outstanding.clone() else {
+            if self.clear_matching_late_blocktxn(response_hash, payload.len() as u64)? {
+                return Ok(LiveMessageOutcome::default());
+            }
             return Ok(LiveMessageOutcome::default());
         };
         if response_hash != req.block_hash {
+            if self.clear_matching_late_blocktxn(response_hash, payload.len() as u64)? {
+                return Ok(LiveMessageOutcome::default());
+            }
             return if payload.len() > 32 {
                 Err(invalid_data("stale blocktxn response"))
             } else {
@@ -1014,7 +1110,7 @@ impl PeerSession {
                 return Err(err);
             }
         };
-        self.process_compact_transactions(req.block_hash, req.header, &txs, sync_engine)
+        self.process_compact_transactions(req.block_hash, req.header, &txs, sync_engine, true)
     }
     fn process_compact_transactions(
         &mut self,
@@ -1022,13 +1118,38 @@ impl PeerSession {
         header: [u8; BLOCK_HEADER_BYTES],
         txs: &[Vec<u8>],
         sync_engine: &mut SyncEngine,
+        fallback_on_apply: bool,
     ) -> io::Result<LiveMessageOutcome> {
         let block_bytes = match compact_block_bytes(header, txs) {
             Ok(block_bytes) => block_bytes,
-            Err(_err) => {
-                return self.request_compact_full_block_fallback(expected_hash);
+            Err(err) => {
+                if fallback_on_apply {
+                    return self.request_compact_full_block_fallback(expected_hash);
+                }
+                self.bump_ban(10, &err.to_string());
+                return Err(err);
             }
         };
+        if sync_engine
+            .has_block(expected_hash)
+            .map_err(io::Error::other)?
+        {
+            self.clear_compact_outstanding_request_for_block(expected_hash);
+            return Ok(LiveMessageOutcome::default());
+        }
+        if fallback_on_apply {
+            match compact_parent_missing(&block_bytes, sync_engine) {
+                Ok(true) => {
+                    self.peer.last_error = PARENT_BLOCK_NOT_FOUND_ERR.to_string();
+                    return self.request_compact_full_block_fallback(expected_hash);
+                }
+                Ok(false) => {}
+                Err(err) if compact_error_allows_full_block_fallback(&err) => {
+                    return self.request_compact_full_block_fallback(expected_hash);
+                }
+                Err(err) => return Err(err),
+            }
+        }
         match self.handle_block(&block_bytes, sync_engine) {
             Ok(tx_pool_cleanup) => {
                 self.clear_compact_outstanding_request_for_block(expected_hash);
@@ -1042,7 +1163,10 @@ impl PeerSession {
             }
             Err(err) => {
                 self.peer.last_error = err.to_string();
-                self.request_compact_full_block_fallback(expected_hash)
+                if fallback_on_apply && compact_error_allows_full_block_fallback(&err) {
+                    return self.request_compact_full_block_fallback(expected_hash);
+                }
+                Err(err)
             }
         }
     }
@@ -1060,11 +1184,59 @@ impl PeerSession {
         if self.compact_outstanding.as_ref().map(|req| req.block_hash) == Some(block_hash) {
             self.compact_outstanding = None;
         }
-    }
-    fn clear_expired_compact_outstanding_request(&mut self) {
-        if matches!(&self.compact_outstanding, Some(req) if Instant::now() >= req.expires_at) {
-            self.compact_outstanding = None;
+        if self
+            .compact_late_blocktxn
+            .as_ref()
+            .map(|late| late.block_hash)
+            == Some(block_hash)
+        {
+            self.compact_late_blocktxn = None;
         }
+    }
+    fn send_expired_compact_fallback(&mut self) -> io::Result<bool> {
+        self.clear_expired_compact_late_blocktxn();
+        if !matches!(&self.compact_outstanding, Some(req) if Instant::now() >= req.expires_at) {
+            return Ok(false);
+        }
+        let req = self.compact_outstanding.take().expect("checked above");
+        let block_hash = req.block_hash;
+        self.preserve_compact_request_for_late_blocktxn(req);
+        self.write_message(&compact_full_block_fallback_message(block_hash)?)?;
+        Ok(true)
+    }
+    fn preserve_compact_request_for_late_blocktxn(&mut self, req: CompactOutstandingRequest) {
+        self.compact_late_blocktxn = Some(CompactLateBlockTxnDrain {
+            block_hash: req.block_hash,
+            blocktxn_payload_cap: req.blocktxn_payload_cap,
+            expires_at: Instant::now() + DEFAULT_READ_DEADLINE,
+        });
+    }
+    fn clear_expired_compact_late_blocktxn(&mut self) {
+        if matches!(&self.compact_late_blocktxn, Some(late) if Instant::now() >= late.expires_at) {
+            self.compact_late_blocktxn = None;
+        }
+    }
+    fn clear_matching_late_blocktxn(
+        &mut self,
+        response_hash: [u8; 32],
+        payload_len: u64,
+    ) -> io::Result<bool> {
+        self.clear_expired_compact_late_blocktxn();
+        let Some(late) = self.compact_late_blocktxn.as_ref() else {
+            return Ok(false);
+        };
+        let block_hash = late.block_hash;
+        let payload_cap = late.blocktxn_payload_cap;
+        if response_hash != block_hash {
+            return Ok(false);
+        }
+        if payload_len > payload_cap {
+            self.compact_late_blocktxn = None;
+            self.bump_ban(10, "blocktxn payload exceeds late drain cap");
+            return Err(invalid_data("blocktxn payload exceeds late drain cap"));
+        }
+        self.compact_late_blocktxn = None;
+        Ok(true)
     }
     // Historically used by the inline run_block_sync_loop match; preserved under
     // #[cfg(test)] so the original behavioral test keeps documenting the
@@ -1360,6 +1532,7 @@ impl Read for DeadlineReader {
 struct PrefetchedReader<'a> {
     stream: &'a mut TcpStream,
     prefetched_read_byte: Option<u8>,
+    read_deadline: Instant,
 }
 
 impl Read for PrefetchedReader<'_> {
@@ -1373,10 +1546,30 @@ impl Read for PrefetchedReader<'_> {
             if buf.len() == 1 {
                 return Ok(1);
             }
+            self.refresh_read_timeout()?;
             let read = self.stream.read(&mut buf[1..])?;
             return Ok(read + 1);
         }
+        self.refresh_read_timeout()?;
         self.stream.read(buf)
+    }
+}
+
+impl PrefetchedReader<'_> {
+    fn refresh_read_timeout(&mut self) -> io::Result<()> {
+        let remaining = self
+            .read_deadline
+            .checked_duration_since(Instant::now())
+            .unwrap_or(Duration::ZERO);
+        if remaining.is_zero() {
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "post-handshake read deadline exceeded",
+            ));
+        }
+        self.stream
+            .set_read_timeout(Some(remaining))
+            .map_err(io::Error::other)
     }
 }
 
@@ -1939,6 +2132,96 @@ pub fn decode_cmpctblock_payload(payload: &[u8]) -> io::Result<CmpctBlockPayload
     Ok(out)
 }
 
+fn cmpctblock_header_validation_candidate(payload: &[u8]) -> Option<[u8; BLOCK_HEADER_BYTES]> {
+    if !has_cmpctblock_header_validation_shape(payload) {
+        return None;
+    }
+    let mut header = [0u8; BLOCK_HEADER_BYTES];
+    header.copy_from_slice(&payload[..BLOCK_HEADER_BYTES]);
+    Some(header)
+}
+
+fn has_cmpctblock_header_validation_shape(payload: &[u8]) -> bool {
+    if payload.len() < BLOCK_HEADER_BYTES + 16 {
+        return false;
+    }
+    let mut offset = BLOCK_HEADER_BYTES + 16;
+    let Ok(short_count) = read_compact_size_at(payload, &mut offset) else {
+        return false;
+    };
+    if short_count > (payload.len() - offset) as u64 / COMPACT_SHORT_ID_BYTES as u64 {
+        return false;
+    }
+    let short_id_end = offset + short_count as usize * COMPACT_SHORT_ID_BYTES;
+    let mut prefilled_offset = short_id_end;
+    let Ok(prefilled_count) = read_compact_size_at(payload, &mut prefilled_offset) else {
+        return false;
+    };
+    let Ok(total_entries) = validate_cmpctblock_entry_count(short_count, prefilled_count) else {
+        return false;
+    };
+    validate_cmpctblock_prefilled_shape(payload, prefilled_offset, prefilled_count, total_entries)
+        .is_ok()
+}
+
+fn validate_cmpctblock_prefilled_shape(
+    payload: &[u8],
+    mut offset: usize,
+    prefilled_count: u64,
+    total_entries: u64,
+) -> io::Result<()> {
+    let mut prev = 0u64;
+    let mut total_tx_bytes = 0u64;
+    for entry_pos in 0..prefilled_count {
+        let (index, next_offset, next_total) = scan_cmpctblock_prefilled_shape(
+            payload,
+            offset,
+            entry_pos,
+            prev,
+            total_entries,
+            total_tx_bytes,
+        )?;
+        offset = next_offset;
+        prev = index;
+        total_tx_bytes = next_total;
+    }
+    if offset != payload.len() {
+        return Err(invalid_data("cmpctblock payload has trailing bytes"));
+    }
+    Ok(())
+}
+
+fn scan_cmpctblock_prefilled_shape(
+    payload: &[u8],
+    mut offset: usize,
+    entry_pos: u64,
+    prev: u64,
+    total_entries: u64,
+    total_tx_bytes: u64,
+) -> io::Result<(u64, usize, u64)> {
+    if payload.len().saturating_sub(offset) < COMPACT_RELAY_INDEX_BYTES {
+        return Err(invalid_data("cmpctblock payload truncated prefilled index"));
+    }
+    let index_end = offset + COMPACT_RELAY_INDEX_BYTES;
+    let index = u64::from(u32::from_le_bytes(
+        payload[offset..index_end]
+            .try_into()
+            .map_err(|_| invalid_data("cmpctblock payload truncated prefilled index"))?,
+    ));
+    offset = index_end;
+    if (entry_pos > 0 && index <= prev) || index >= total_entries {
+        return Err(invalid_data("compact relay index out of range"));
+    }
+    let tx_len = read_compact_size_at(payload, &mut offset)?;
+    if tx_len > payload[offset..].len() as u64 {
+        return Err(invalid_data("compact relay transaction truncated"));
+    }
+    let next_total = validate_blocktxn_transaction_size(tx_len, total_tx_bytes)?;
+    let tx_len =
+        usize::try_from(tx_len).map_err(|_| invalid_data("compact relay transaction truncated"))?;
+    Ok((index, offset + tx_len, next_total))
+}
+
 pub fn reconstruct_compact_block(
     payload: &CmpctBlockPayload,
     local_txs: &[Vec<u8>],
@@ -2222,16 +2505,23 @@ fn compact_fill_response_transactions(
     req: &CompactOutstandingRequest,
     response: BlockTxnPayload,
 ) -> io::Result<Vec<Vec<u8>>> {
-    if response.transactions.len() != req.missing_short_ids.len() {
+    if req.missing_indexes.len() != req.missing_short_ids.len()
+        || response.transactions.len() != req.missing_indexes.len()
+    {
         return Err(invalid_data("blocktxn transaction count mismatch"));
     }
     let mut txs = req.partial_transactions.clone();
-    for ((slot, want_short_id), tx) in txs
-        .iter_mut()
-        .filter(|slot| slot.is_none())
+    for ((index, want_short_id), tx) in req
+        .missing_indexes
+        .iter()
         .zip(&req.missing_short_ids)
         .zip(&response.transactions)
     {
+        let index = usize::try_from(*index)
+            .map_err(|_| invalid_data("compact relay index out of range"))?;
+        let slot = txs
+            .get_mut(index)
+            .ok_or_else(|| invalid_data("compact relay index out of range"))?;
         let (_, _, wtxid, consumed) =
             parse_tx(tx).map_err(|_| invalid_data("blocktxn transaction is non-canonical"))?;
         if consumed != tx.len() {
@@ -2261,6 +2551,29 @@ fn compact_block_bytes(header: [u8; BLOCK_HEADER_BYTES], txs: &[Vec<u8>]) -> io:
         out.extend_from_slice(tx);
     }
     Ok(out)
+}
+
+fn compact_parent_missing(block_bytes: &[u8], sync_engine: &SyncEngine) -> io::Result<bool> {
+    let parsed = parse_block_bytes(block_bytes).map_err(io::Error::other)?;
+    if parsed.header.prev_block_hash == [0u8; 32] {
+        return Ok(false);
+    }
+    if sync_engine.chain_state.has_tip
+        && parsed.header.prev_block_hash == sync_engine.chain_state.tip_hash
+    {
+        return Ok(false);
+    }
+    if sync_engine.block_store.is_none() && sync_engine.chain_state.has_tip {
+        return Err(io::Error::other("missing blockstore for side-chain block"));
+    }
+    Ok(!sync_engine
+        .has_block(parsed.header.prev_block_hash)
+        .map_err(io::Error::other)?)
+}
+
+fn compact_error_allows_full_block_fallback(err: &io::Error) -> bool {
+    let text = err.to_string();
+    text.contains("BLOCK_ERR_") || text.contains("TX_ERR_")
 }
 
 fn compact_size_wire_len(n: u64) -> u64 {
@@ -2638,13 +2951,19 @@ fn runtime_payload_cap(command: &str) -> u64 {
 
 fn runtime_payload_cap_for_compact_session(
     command: &str,
+    compact_receive_enabled: bool,
     compact_mode: CompactModeSnapshot,
     blocktxn_payload_cap: Option<u64>,
 ) -> u64 {
-    let compact_receive = compact_mode.version == COMPACT_RELAY_VERSION && compact_mode.mode != 0;
+    let compact_receive = compact_receive_enabled
+        && compact_mode.version == COMPACT_RELAY_VERSION
+        && compact_mode.mode != 0;
     match command {
         "cmpctblock" if compact_receive => MAX_RELAY_MSG_BYTES,
-        "blocktxn" => blocktxn_payload_cap.unwrap_or((compact_receive as u64) * 32),
+        "blocktxn" if compact_receive_enabled => {
+            blocktxn_payload_cap.unwrap_or((compact_receive as u64) * 32)
+        }
+        "blocktxn" => 0,
         _ => runtime_payload_cap(command),
     }
 }
@@ -3599,15 +3918,121 @@ mod tests {
     fn compact_receive_flow_smoke() {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
         let mut client = TcpStream::connect(listener.local_addr().expect("addr")).expect("connect");
+        client
+            .set_read_timeout(Some(Duration::from_secs(1)))
+            .expect("client read timeout");
         let (stream, _) = listener.accept().expect("accept");
         let mut session =
             PeerSession::new(stream, default_peer_runtime_config("devnet", 8)).expect("session");
+        let enabled_remote = CompactModeSnapshot {
+            mode: 1,
+            version: COMPACT_RELAY_VERSION,
+        };
+        assert_eq!(
+            runtime_payload_cap_for_compact_session("cmpctblock", false, enabled_remote, None),
+            0
+        );
+        session.remote_compact_mode = enabled_remote;
+        let mut engine = test_sync_engine_with_genesis();
+        let err = session
+            .handle_cmpctblock(&[], &mut engine, None)
+            .expect_err("local rollout gate must reject cmpctblock");
+        assert!(err.to_string().contains("compact receive disabled"));
+        session.cfg.enable_compact_receive = true;
+
         let genesis = parse_block_bytes(&devnet_genesis_block_bytes()).expect("parse genesis");
         let genesis_hash = block_hash(&genesis.header_bytes).expect("genesis hash");
         let block1 = height_one_coinbase_only_block(genesis_hash, genesis.header.timestamp + 1);
         let header: [u8; BLOCK_HEADER_BYTES] = block1[..BLOCK_HEADER_BYTES].try_into().unwrap();
         let tx = block1[BLOCK_HEADER_BYTES + 1..].to_vec();
         let block_hash = block_hash(&header).expect("block hash");
+        let witness_root = witness_merkle_root_wtxids(&[[0u8; 32]]).expect("witness root");
+        let commitment = witness_commitment_hash(witness_root);
+        let tx2 = build_coinbase_tx(2, 0, &default_mine_address(), commitment).expect("tx2");
+        let tx3 = build_coinbase_tx(3, 0, &default_mine_address(), commitment).expect("tx3");
+        let req = CompactOutstandingRequest {
+            block_hash: [7u8; 32],
+            header: [0u8; BLOCK_HEADER_BYTES],
+            missing_indexes: vec![2, 0],
+            missing_short_ids: vec![
+                compact_reconstruct_short_id_for_tx(&tx3),
+                compact_reconstruct_short_id_for_tx(&tx),
+            ],
+            partial_transactions: vec![None, Some(tx2.clone()), None],
+            nonces: [0, 0],
+            blocktxn_payload_cap: MAX_RELAY_MSG_BYTES,
+            expires_at: Instant::now() + Duration::from_secs(1),
+        };
+        assert_eq!(
+            compact_fill_response_transactions(
+                &req,
+                BlockTxnPayload {
+                    block_hash: req.block_hash,
+                    transactions: vec![tx3.clone(), tx.clone()],
+                },
+            )
+            .expect("fill requested indexes"),
+            vec![tx.clone(), tx2.clone(), tx3]
+        );
+        let invalid_prefilled = encode_cmpctblock_payload(CmpctBlockPayload {
+            header,
+            nonce1: 0,
+            nonce2: 0,
+            short_ids: Vec::new(),
+            prefilled: vec![PrefilledTxn {
+                index: 0,
+                tx: tx2.clone(),
+            }],
+        })
+        .expect("cmpctblock");
+        session
+            .handle_cmpctblock(&invalid_prefilled, &mut engine, None)
+            .expect_err("fully prefilled invalid block must not fallback");
+        let mut invalid_header = header;
+        let target_start = 4 + 32 + 32 + 8;
+        invalid_header[target_start..target_start + 32].copy_from_slice(&[0u8; 32]);
+        let mut structural_tail = encode_cmpctblock_payload(CmpctBlockPayload {
+            header: invalid_header,
+            nonce1: 0,
+            nonce2: 0,
+            short_ids: Vec::new(),
+            prefilled: vec![PrefilledTxn {
+                index: 0,
+                tx: tx.clone(),
+            }],
+        })
+        .expect("cmpctblock");
+        structural_tail.push(0);
+        let ban_before = session.peer.ban_score;
+        let err = session
+            .handle_cmpctblock(&structural_tail, &mut engine, None)
+            .expect_err("structural tail must reject before header validation");
+        assert!(err.to_string().contains("trailing bytes"));
+        assert_eq!(session.peer.ban_score, ban_before + 10);
+        let mut invalid_pow_noncanonical_prefilled = Vec::new();
+        invalid_pow_noncanonical_prefilled.extend_from_slice(&invalid_header);
+        invalid_pow_noncanonical_prefilled.extend_from_slice(&0u64.to_le_bytes());
+        invalid_pow_noncanonical_prefilled.extend_from_slice(&0u64.to_le_bytes());
+        encode_compact_size(0, &mut invalid_pow_noncanonical_prefilled);
+        encode_compact_size(1, &mut invalid_pow_noncanonical_prefilled);
+        invalid_pow_noncanonical_prefilled.extend_from_slice(&0u32.to_le_bytes());
+        encode_compact_size(1, &mut invalid_pow_noncanonical_prefilled);
+        invalid_pow_noncanonical_prefilled.push(0xff);
+        let ban_before = session.peer.ban_score;
+        let err = session
+            .handle_cmpctblock(&invalid_pow_noncanonical_prefilled, &mut engine, None)
+            .expect_err("shape-valid header failure must win before prefilled tx parse");
+        assert!(
+            err.to_string().contains("target out of range")
+                || err.to_string().contains("BLOCK_ERR_TARGET_INVALID"),
+            "got {err}"
+        );
+        assert!(
+            !err.to_string()
+                .contains("prefilled transaction is non-canonical"),
+            "got {err}"
+        );
+        assert_eq!(session.peer.ban_score, ban_before + 100);
         let short_id = compact_reconstruct_short_id_for_tx(&tx);
         let missing = encode_cmpctblock_payload(CmpctBlockPayload {
             header,
@@ -3617,30 +4042,180 @@ mod tests {
             prefilled: Vec::new(),
         })
         .expect("cmpctblock");
-        session.remote_compact_mode = CompactModeSnapshot {
-            mode: 1,
-            version: COMPACT_RELAY_VERSION,
-        };
 
-        let mut engine = test_sync_engine_with_genesis();
         session
             .handle_cmpctblock(&missing, &mut engine, None)
             .unwrap();
         session.compact_outstanding.as_mut().unwrap().expires_at = Instant::now();
+        client
+            .write_all(
+                &marshal_wire_message(
+                    &WireMessage {
+                        command: "blocktxn".to_string(),
+                        payload: encode_blocktxn_payload(BlockTxnPayload {
+                            block_hash,
+                            transactions: vec![tx.clone()],
+                        })
+                        .unwrap(),
+                    },
+                    network_magic("devnet"),
+                    MAX_RELAY_MSG_BYTES,
+                )
+                .unwrap(),
+            )
+            .expect("write stale blocktxn");
+        client.flush().expect("flush stale blocktxn");
         assert!(!session.poll_read_ready(Duration::from_millis(1)).unwrap());
-        let _ = read_message_from(&mut client, network_magic("devnet"), MAX_RELAY_MSG_BYTES)
+        let fallback = read_message_from(&mut client, network_magic("devnet"), MAX_RELAY_MSG_BYTES)
             .expect("read compact fallback");
+        assert_eq!(fallback.command, MESSAGE_GETDATA);
+        assert!(session.compact_late_blocktxn.is_some());
+        let late = session.read_message().expect("read late blocktxn");
+        assert_eq!(late.command, "blocktxn");
+        session.handle_blocktxn(&late.payload, &mut engine).unwrap();
+        assert!(session.compact_late_blocktxn.is_none());
         session
             .handle_cmpctblock(&missing, &mut engine, None)
             .unwrap();
+        session.compact_outstanding.as_mut().unwrap().expires_at = Instant::now();
+        let outcome = session
+            .handle_cmpctblock(&missing, &mut engine, None)
+            .expect("expired outstanding cmpctblock sends fallback before replacement");
+        assert_eq!(outcome.responses[0].command, "getblocktxn");
+        let fallback = read_message_from(&mut client, network_magic("devnet"), MAX_RELAY_MSG_BYTES)
+            .expect("read handler fallback");
+        assert_eq!(fallback.command, MESSAGE_GETDATA);
         let response = encode_blocktxn_payload(BlockTxnPayload {
             block_hash,
             transactions: vec![tx.clone()],
         })
         .unwrap();
+        session.compact_outstanding.as_mut().unwrap().expires_at = Instant::now();
         session.handle_blocktxn(&response, &mut engine).unwrap();
         assert!(engine.has_block(block_hash).unwrap());
+        let side_block = height_one_coinbase_only_block(genesis_hash, genesis.header.timestamp + 3);
+        let side_header: [u8; BLOCK_HEADER_BYTES] =
+            side_block[..BLOCK_HEADER_BYTES].try_into().unwrap();
+        let side_hash = rubin_consensus::block_hash(&side_header).expect("side hash");
+        let side_tx = side_block[BLOCK_HEADER_BYTES + 1..].to_vec();
+        let mut no_store_engine = SyncEngine::new(
+            engine.chain_state.clone(),
+            None,
+            crate::sync::default_sync_config(Some(POW_LIMIT), devnet_genesis_chain_id(), None),
+        )
+        .expect("no-store engine");
+        let err = session
+            .process_compact_transactions(
+                side_hash,
+                side_header,
+                &[side_tx],
+                &mut no_store_engine,
+                true,
+            )
+            .expect_err("side-chain infrastructure error must not fallback");
+        assert!(
+            err.to_string()
+                .contains("missing blockstore for side-chain block"),
+            "got {err}"
+        );
+        let orphan_block = height_one_coinbase_only_block([9u8; 32], genesis.header.timestamp + 2);
+        let orphan_header: [u8; BLOCK_HEADER_BYTES] =
+            orphan_block[..BLOCK_HEADER_BYTES].try_into().unwrap();
+        let orphan_hash = rubin_consensus::block_hash(&orphan_header).expect("orphan hash");
+        let orphan_tx = orphan_block[BLOCK_HEADER_BYTES + 1..].to_vec();
+        let orphan_missing = encode_cmpctblock_payload(CmpctBlockPayload {
+            header: orphan_header,
+            nonce1: 0,
+            nonce2: 0,
+            short_ids: vec![compact_reconstruct_short_id_for_tx(&orphan_tx)],
+            prefilled: Vec::new(),
+        })
+        .expect("orphan cmpctblock");
+        let outcome = session
+            .handle_cmpctblock(&orphan_missing, &mut engine, None)
+            .expect("orphan compact miss");
+        assert_eq!(outcome.responses[0].command, "getblocktxn");
+        let outcome = session
+            .handle_blocktxn(
+                &encode_blocktxn_payload(BlockTxnPayload {
+                    block_hash: orphan_hash,
+                    transactions: vec![orphan_tx],
+                })
+                .unwrap(),
+                &mut engine,
+            )
+            .expect("unknown-parent compact blocktxn falls back");
+        assert_eq!(outcome.responses[0].command, MESSAGE_GETDATA);
+        let fallback = decode_inventory_vectors(&outcome.responses[0].payload).unwrap();
+        assert_eq!(fallback[0].hash, orphan_hash);
+        assert_eq!(session.orphans.len(), 0);
     }
+
+    #[test]
+    fn compact_receive_expiry_clamps_poll_and_prefetched_reads() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let mut client = TcpStream::connect(listener.local_addr().expect("addr")).expect("connect");
+        client
+            .set_read_timeout(Some(Duration::from_secs(1)))
+            .expect("client read timeout");
+        let (stream, _) = listener.accept().expect("accept");
+        let mut session =
+            PeerSession::new(stream, default_peer_runtime_config("devnet", 8)).expect("session");
+        session.cfg.enable_compact_receive = true;
+
+        let block_hash = [0x42; 32];
+        session.compact_outstanding = Some(CompactOutstandingRequest {
+            block_hash,
+            header: [0u8; BLOCK_HEADER_BYTES],
+            missing_indexes: vec![0],
+            missing_short_ids: vec![[0u8; COMPACT_SHORT_ID_BYTES]],
+            partial_transactions: vec![None],
+            nonces: [0, 0],
+            blocktxn_payload_cap: MAX_RELAY_MSG_BYTES,
+            expires_at: Instant::now() + Duration::from_millis(150),
+        });
+        let start = Instant::now();
+        assert!(!session.poll_read_ready(Duration::from_secs(2)).unwrap());
+        assert!(start.elapsed() < Duration::from_secs(1));
+        let fallback = read_message_from(&mut client, network_magic("devnet"), MAX_RELAY_MSG_BYTES)
+            .expect("read poll fallback");
+        assert_eq!(fallback.command, MESSAGE_GETDATA);
+        assert!(session.compact_late_blocktxn.is_some());
+
+        session.compact_late_blocktxn = None;
+        session.compact_outstanding = Some(CompactOutstandingRequest {
+            block_hash,
+            header: [0u8; BLOCK_HEADER_BYTES],
+            missing_indexes: vec![0],
+            missing_short_ids: vec![[0u8; COMPACT_SHORT_ID_BYTES]],
+            partial_transactions: vec![None],
+            nonces: [0, 0],
+            blocktxn_payload_cap: MAX_RELAY_MSG_BYTES,
+            expires_at: Instant::now() + Duration::from_millis(150),
+        });
+        client
+            .write_all(&[network_magic("devnet")[0]])
+            .expect("write partial frame");
+        client.flush().expect("flush partial frame");
+        assert!(session.poll_read_ready(Duration::from_secs(1)).unwrap());
+        let start = Instant::now();
+        let err = session
+            .read_message_with_timeout(Duration::from_secs(2))
+            .expect_err("partial frame must time out at compact expiry");
+        assert!(
+            matches!(
+                err.kind(),
+                io::ErrorKind::TimedOut | io::ErrorKind::WouldBlock
+            ),
+            "got {err}"
+        );
+        assert!(start.elapsed() < Duration::from_secs(1));
+        let fallback = read_message_from(&mut client, network_magic("devnet"), MAX_RELAY_MSG_BYTES)
+            .expect("read read_message fallback");
+        assert_eq!(fallback.command, MESSAGE_GETDATA);
+        assert!(session.compact_late_blocktxn.is_some());
+    }
+
     #[test]
     fn p2p_version_handshake_bidirectional_ok() {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind");

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -140,6 +140,7 @@ pub struct CompactReconstructionResult {
     pub transactions: Vec<Vec<u8>>,
     pub partial_transactions: Vec<Option<Vec<u8>>>,
     pub missing_indexes: Vec<u64>,
+    pub missing_short_ids: Vec<CompactShortId>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
@@ -209,6 +210,7 @@ pub struct PeerRelayContext<'a> {
     pub tx_pool: &'a std::sync::Mutex<crate::txpool::TxPool>,
 }
 
+#[derive(Debug, Default)]
 pub struct LiveMessageOutcome {
     pub responses: Vec<WireMessage>,
     pub tx_pool_cleanup: TxPoolCleanupPlan,
@@ -220,6 +222,16 @@ struct CompactModeSnapshot {
     version: u64,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct CompactOutstandingRequest {
+    block_hash: [u8; 32],
+    header: [u8; BLOCK_HEADER_BYTES],
+    missing_short_ids: Vec<CompactShortId>,
+    partial_transactions: Vec<Option<Vec<u8>>>,
+    nonces: [u64; 2],
+    blocktxn_payload_cap: u64,
+    expires_at: Instant,
+}
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct OrphanBlockEntry {
     block_hash: [u8; 32],
@@ -251,6 +263,7 @@ pub struct PeerSession {
     pending_tx_pool_cleanup: TxPoolCleanupPlan,
     prefetched_read_byte: Option<u8>,
     remote_compact_mode: CompactModeSnapshot,
+    compact_outstanding: Option<CompactOutstandingRequest>,
 }
 
 pub struct PeerManager {
@@ -369,6 +382,7 @@ impl PeerSession {
             pending_tx_pool_cleanup: TxPoolCleanupPlan::default(),
             prefetched_read_byte: None,
             remote_compact_mode: CompactModeSnapshot::default(),
+            compact_outstanding: None,
         })
     }
 
@@ -419,6 +433,15 @@ impl PeerSession {
                     io::ErrorKind::TimedOut | io::ErrorKind::WouldBlock
                 ) =>
             {
+                if let Some(block_hash) = self
+                    .compact_outstanding
+                    .as_ref()
+                    .filter(|req| Instant::now() >= req.expires_at)
+                    .map(|req| req.block_hash)
+                {
+                    self.compact_outstanding = None;
+                    self.write_message(&compact_full_block_fallback_message(block_hash)?)?;
+                }
                 Ok(false)
             }
             Err(err) => Err(err),
@@ -432,6 +455,15 @@ impl PeerSession {
         let mut reader = PrefetchedReader {
             stream: &mut self.stream,
             prefetched_read_byte: self.prefetched_read_byte.take(),
+        };
+        let compact_mode = self.remote_compact_mode;
+        let blocktxn_payload_cap = self
+            .compact_outstanding
+            .as_ref()
+            .filter(|req| Instant::now() < req.expires_at)
+            .map(|req| req.blocktxn_payload_cap.min(MAX_RELAY_MSG_BYTES));
+        let payload_cap = move |command: &str| {
+            runtime_payload_cap_for_compact_session(command, compact_mode, blocktxn_payload_cap)
         };
         // NOTE on tx-oversize ban policy (parity gap with Go's
         // `peer.handleTx`):
@@ -452,10 +484,11 @@ impl PeerSession {
         // ban-score policy at the higher layer; that is intentionally
         // out of scope for this Q-* task (which only aligns the
         // malformed/parse-fail surface).
-        read_message_from(
+        read_message_from_with_payload_limit(
             &mut reader,
             network_magic(&self.cfg.network),
             MAX_RELAY_MSG_BYTES,
+            &payload_cap,
         )
     }
 
@@ -630,6 +663,8 @@ impl PeerSession {
                     tx_pool_cleanup,
                 })
             }
+            "cmpctblock" => self.handle_cmpctblock(&msg.payload, sync_engine, relay_ctx),
+            "blocktxn" => self.handle_blocktxn(&msg.payload, sync_engine),
             MESSAGE_TX => {
                 if let Some(ctx) = relay_ctx {
                     let outcome = crate::tx_relay::handle_received_tx(
@@ -826,6 +861,211 @@ impl PeerSession {
         Ok(())
     }
 
+    fn handle_cmpctblock(
+        &mut self,
+        payload: &[u8],
+        sync_engine: &mut SyncEngine,
+        relay_ctx: Option<&PeerRelayContext<'_>>,
+    ) -> io::Result<LiveMessageOutcome> {
+        if self.remote_compact_mode.version != COMPACT_RELAY_VERSION
+            || self.remote_compact_mode.mode == 0
+        {
+            return Err(invalid_data("compact receive disabled"));
+        }
+        self.clear_expired_compact_outstanding_request();
+        let block = match decode_cmpctblock_payload(payload) {
+            Ok(block) => block,
+            Err(err) => {
+                self.bump_ban(10, &err.to_string());
+                return Err(err);
+            }
+        };
+        let parsed_header =
+            rubin_consensus::parse_block_header_bytes(&block.header).map_err(io::Error::other)?;
+        if let Err(err) = rubin_consensus::pow_check(&block.header, parsed_header.target) {
+            self.bump_ban(100, &err.to_string());
+            return Err(io::Error::new(io::ErrorKind::InvalidData, err.to_string()));
+        }
+        if matches!(sync_engine.cfg.expected_target, Some(expected) if parsed_header.target != expected)
+        {
+            self.bump_ban(100, "target mismatch");
+            return Err(invalid_data("target mismatch"));
+        }
+        let block_hash = block_hash(&block.header).map_err(io::Error::other)?;
+        if sync_engine
+            .has_block(block_hash)
+            .map_err(io::Error::other)?
+        {
+            self.clear_compact_outstanding_request_for_block(block_hash);
+            return Ok(LiveMessageOutcome::default());
+        }
+        let local_txs = match relay_ctx.and_then(|ctx| ctx.tx_pool.lock().ok()) {
+            Some(pool) => pool.select_transactions(
+                COMPACT_LOCAL_TX_CANDIDATE_LIMIT,
+                COMPACT_LOCAL_TX_CANDIDATE_BYTES_LIMIT,
+            ),
+            None => Vec::new(),
+        };
+        let result = match reconstruct_compact_block(&block, &local_txs) {
+            Ok(result) => result,
+            Err(_err) if !block.short_ids.is_empty() => {
+                return self.request_compact_full_block_fallback(block_hash);
+            }
+            Err(err) => return Err(err),
+        };
+        if !result.transactions.is_empty() {
+            return self.process_compact_transactions(
+                block_hash,
+                block.header,
+                &result.transactions,
+                sync_engine,
+            );
+        }
+        self.request_missing_compact_transactions(block, block_hash, result)
+    }
+    fn request_missing_compact_transactions(
+        &mut self,
+        block: CmpctBlockPayload,
+        block_hash: [u8; 32],
+        result: CompactReconstructionResult,
+    ) -> io::Result<LiveMessageOutcome> {
+        if self.compact_outstanding.is_some() {
+            return self.request_compact_full_block_fallback(block_hash);
+        }
+        let present_bytes = result
+            .partial_transactions
+            .iter()
+            .filter_map(Option::as_ref)
+            .try_fold(0u64, |total, tx| {
+                validate_blocktxn_transaction_size(tx.len() as u64, total)
+            })?;
+        let blocktxn_payload_cap =
+            32 + compact_size_wire_len(result.missing_indexes.len() as u64) + MAX_BLOCK_BYTES
+                - present_bytes
+                + result.missing_indexes.len() as u64 * MAX_COMPACT_SIZE_BYTES as u64;
+        let payload = encode_getblocktxn_payload(GetBlockTxnPayload {
+            block_hash,
+            indexes: result.missing_indexes.clone(),
+        })?;
+        self.compact_outstanding = Some(CompactOutstandingRequest {
+            block_hash,
+            header: block.header,
+            missing_short_ids: result.missing_short_ids,
+            partial_transactions: result.partial_transactions,
+            nonces: [block.nonce1, block.nonce2],
+            blocktxn_payload_cap,
+            expires_at: Instant::now() + DEFAULT_READ_DEADLINE,
+        });
+        Ok(LiveMessageOutcome {
+            responses: vec![WireMessage {
+                command: "getblocktxn".to_string(),
+                payload,
+            }],
+            ..Default::default()
+        })
+    }
+    fn handle_blocktxn(
+        &mut self,
+        payload: &[u8],
+        sync_engine: &mut SyncEngine,
+    ) -> io::Result<LiveMessageOutcome> {
+        if payload.len() < 32 {
+            self.bump_ban(10, "blocktxn payload missing block hash");
+            return Err(invalid_data("blocktxn payload missing block hash"));
+        }
+        self.clear_expired_compact_outstanding_request();
+        let mut response_hash = [0u8; 32];
+        response_hash.copy_from_slice(&payload[..32]);
+        let Some(req) = self.compact_outstanding.clone() else {
+            return Ok(LiveMessageOutcome::default());
+        };
+        if response_hash != req.block_hash {
+            return if payload.len() > 32 {
+                Err(invalid_data("stale blocktxn response"))
+            } else {
+                Ok(LiveMessageOutcome::default())
+            };
+        }
+        if payload.len() as u64 > req.blocktxn_payload_cap {
+            self.clear_compact_outstanding_request_for_block(req.block_hash);
+            self.bump_ban(10, "blocktxn payload exceeds outstanding cap");
+            return Err(invalid_data("blocktxn payload exceeds outstanding cap"));
+        }
+        let response = match decode_blocktxn_payload(payload) {
+            Ok(response) => response,
+            Err(err) => {
+                self.clear_compact_outstanding_request_for_block(req.block_hash);
+                self.bump_ban(10, &err.to_string());
+                return Err(err);
+            }
+        };
+        self.clear_compact_outstanding_request_for_block(req.block_hash);
+        let txs = match compact_fill_response_transactions(&req, response) {
+            Ok(txs) => txs,
+            Err(err)
+                if err
+                    .to_string()
+                    .contains("blocktxn transaction short id mismatch") =>
+            {
+                return self.request_compact_full_block_fallback(req.block_hash);
+            }
+            Err(err) => {
+                self.bump_ban(10, &err.to_string());
+                return Err(err);
+            }
+        };
+        self.process_compact_transactions(req.block_hash, req.header, &txs, sync_engine)
+    }
+    fn process_compact_transactions(
+        &mut self,
+        expected_hash: [u8; 32],
+        header: [u8; BLOCK_HEADER_BYTES],
+        txs: &[Vec<u8>],
+        sync_engine: &mut SyncEngine,
+    ) -> io::Result<LiveMessageOutcome> {
+        let block_bytes = match compact_block_bytes(header, txs) {
+            Ok(block_bytes) => block_bytes,
+            Err(_err) => {
+                return self.request_compact_full_block_fallback(expected_hash);
+            }
+        };
+        match self.handle_block(&block_bytes, sync_engine) {
+            Ok(tx_pool_cleanup) => {
+                self.clear_compact_outstanding_request_for_block(expected_hash);
+                Ok(LiveMessageOutcome {
+                    responses: self
+                        .prepare_block_request_if_behind(sync_engine)?
+                        .into_iter()
+                        .collect(),
+                    tx_pool_cleanup,
+                })
+            }
+            Err(err) => {
+                self.peer.last_error = err.to_string();
+                self.request_compact_full_block_fallback(expected_hash)
+            }
+        }
+    }
+    fn request_compact_full_block_fallback(
+        &mut self,
+        block_hash: [u8; 32],
+    ) -> io::Result<LiveMessageOutcome> {
+        self.clear_compact_outstanding_request_for_block(block_hash);
+        Ok(LiveMessageOutcome {
+            responses: vec![compact_full_block_fallback_message(block_hash)?],
+            ..Default::default()
+        })
+    }
+    fn clear_compact_outstanding_request_for_block(&mut self, block_hash: [u8; 32]) {
+        if self.compact_outstanding.as_ref().map(|req| req.block_hash) == Some(block_hash) {
+            self.compact_outstanding = None;
+        }
+    }
+    fn clear_expired_compact_outstanding_request(&mut self) {
+        if matches!(&self.compact_outstanding, Some(req) if Instant::now() >= req.expires_at) {
+            self.compact_outstanding = None;
+        }
+    }
     // Historically used by the inline run_block_sync_loop match; preserved under
     // #[cfg(test)] so the original behavioral test keeps documenting the
     // follow-up getblocks path. Production dispatch routes through
@@ -1174,7 +1414,7 @@ pub fn perform_version_handshake(
             &mut deadline_reader,
             network_magic(&session.cfg.network),
             MAX_RELAY_MSG_BYTES,
-            pre_handshake_payload_cap,
+            &pre_handshake_payload_cap,
         )?;
         match msg.command.as_str() {
             "version" => {
@@ -1287,7 +1527,7 @@ fn read_message_from<R: Read>(
         reader,
         expected_magic,
         max_payload_bytes,
-        runtime_payload_cap,
+        &runtime_payload_cap,
     )
 }
 
@@ -1295,7 +1535,7 @@ fn read_message_from_with_payload_limit<R: Read>(
     reader: &mut R,
     expected_magic: [u8; 4],
     max_payload_bytes: u64,
-    payload_cap: fn(&str) -> u64,
+    payload_cap: &dyn Fn(&str) -> u64,
 ) -> io::Result<WireMessage> {
     let mut header = [0u8; WIRE_HEADER_SIZE];
     reader.read_exact(&mut header)?;
@@ -1730,9 +1970,8 @@ pub fn reconstruct_compact_block(
     for entry in &payload.prefilled {
         partial[entry.index as usize] = Some(entry.tx.clone());
     }
-    let missing_indexes =
-        compact_missing(Some(&mut partial), total_entries, payload, &local_index)?;
-    if missing_indexes.is_empty() {
+    let missing = compact_missing(Some(&mut partial), total_entries, payload, &local_index)?;
+    if missing.0.is_empty() {
         compact_validate_present_transactions(partial.iter().filter_map(Option::as_deref))?;
         return Ok(CompactReconstructionResult {
             transactions: partial
@@ -1744,7 +1983,8 @@ pub fn reconstruct_compact_block(
     }
     Ok(CompactReconstructionResult {
         partial_transactions: partial,
-        missing_indexes,
+        missing_indexes: missing.0,
+        missing_short_ids: missing.1,
         ..Default::default()
     })
 }
@@ -1805,8 +2045,8 @@ fn compact_missing(
     total_entries: usize,
     payload: &CmpctBlockPayload,
     local_index: &CompactLocalIndex,
-) -> io::Result<Vec<u64>> {
-    let mut missing_indexes = Vec::new();
+) -> io::Result<(Vec<u64>, Vec<CompactShortId>)> {
+    let mut missing = (Vec::new(), Vec::new());
     let mut first_hit = HashMap::new();
     let mut short_pos = 0usize;
     let mut prefilled_pos = 0usize;
@@ -1830,9 +2070,9 @@ fn compact_missing(
                             txs[first_index as usize] = None;
                         }
                         first_hit.insert(short_id, u64::MAX);
-                        compact_push_missing(&mut missing_indexes, first_index)?;
+                        compact_push_missing(&mut missing, first_index, short_id)?;
                     }
-                    compact_push_missing(&mut missing_indexes, absolute_index as u64)?;
+                    compact_push_missing(&mut missing, absolute_index as u64, short_id)?;
                 } else {
                     first_hit.insert(short_id, absolute_index as u64);
                     if let Some(txs) = txs.as_deref_mut() {
@@ -1840,19 +2080,24 @@ fn compact_missing(
                     }
                 }
             }
-            None => compact_push_missing(&mut missing_indexes, absolute_index as u64)?,
+            None => compact_push_missing(&mut missing, absolute_index as u64, short_id)?,
         }
         short_pos += 1;
     }
     if let Some(txs) = txs {
         compact_validate_present_transactions(txs.iter().filter_map(Option::as_deref))?;
     }
-    Ok(missing_indexes)
+    Ok(missing)
 }
 
-fn compact_push_missing(missing: &mut Vec<u64>, index: u64) -> io::Result<()> {
-    missing.push(index);
-    (missing.len() <= MAX_COMPACT_RELAY_ENTRIES)
+fn compact_push_missing(
+    missing: &mut (Vec<u64>, Vec<CompactShortId>),
+    index: u64,
+    short_id: CompactShortId,
+) -> io::Result<()> {
+    missing.0.push(index);
+    missing.1.push(short_id);
+    (missing.0.len() <= MAX_COMPACT_RELAY_ENTRIES)
         .then_some(())
         .ok_or_else(|| invalid_data("too many compact relay missing transactions"))
 }
@@ -1962,6 +2207,60 @@ fn validate_compact_relay_transactions(
         total_payload_bytes += payload_add;
     }
     Ok(total_payload_bytes)
+}
+
+fn compact_full_block_fallback_message(block_hash: [u8; 32]) -> io::Result<WireMessage> {
+    Ok(WireMessage {
+        command: MESSAGE_GETDATA.to_string(),
+        payload: encode_inventory_vectors(&[InventoryVector {
+            kind: MSG_BLOCK,
+            hash: block_hash,
+        }])?,
+    })
+}
+fn compact_fill_response_transactions(
+    req: &CompactOutstandingRequest,
+    response: BlockTxnPayload,
+) -> io::Result<Vec<Vec<u8>>> {
+    if response.transactions.len() != req.missing_short_ids.len() {
+        return Err(invalid_data("blocktxn transaction count mismatch"));
+    }
+    let mut txs = req.partial_transactions.clone();
+    for ((slot, want_short_id), tx) in txs
+        .iter_mut()
+        .filter(|slot| slot.is_none())
+        .zip(&req.missing_short_ids)
+        .zip(&response.transactions)
+    {
+        let (_, _, wtxid, consumed) =
+            parse_tx(tx).map_err(|_| invalid_data("blocktxn transaction is non-canonical"))?;
+        if consumed != tx.len() {
+            return Err(invalid_data("blocktxn transaction is non-canonical"));
+        }
+        if compact_shortid(wtxid, req.nonces[0], req.nonces[1]) != *want_short_id {
+            return Err(invalid_data("blocktxn transaction short id mismatch"));
+        }
+        *slot = Some(tx.clone());
+    }
+    let txs = txs
+        .into_iter()
+        .map(|tx| tx.ok_or_else(|| invalid_data("compact block transaction missing")))
+        .collect::<io::Result<Vec<_>>>()?;
+    Ok(txs)
+}
+fn compact_block_bytes(header: [u8; BLOCK_HEADER_BYTES], txs: &[Vec<u8>]) -> io::Result<Vec<u8>> {
+    let mut out = Vec::with_capacity(BLOCK_HEADER_BYTES + MAX_COMPACT_SIZE_BYTES);
+    out.extend_from_slice(&header);
+    encode_compact_size(txs.len() as u64, &mut out);
+    let mut total_tx_bytes = 0u64;
+    for tx in txs {
+        total_tx_bytes = validate_blocktxn_transaction_size(tx.len() as u64, total_tx_bytes)?;
+        if tx.len() > (MAX_BLOCK_BYTES as usize).saturating_sub(out.len()) {
+            return Err(invalid_data("compact block exceeds block size"));
+        }
+        out.extend_from_slice(tx);
+    }
+    Ok(out)
 }
 
 fn compact_size_wire_len(n: u64) -> u64 {
@@ -2174,7 +2473,7 @@ fn unmarshal_wire_message(
         &header,
         expected_magic,
         max_message_size,
-        runtime_payload_cap,
+        &runtime_payload_cap,
     )?;
     let total_len = WIRE_HEADER_SIZE + envelope.payload_len;
     if raw.len() < total_len {
@@ -2207,7 +2506,7 @@ fn parse_envelope_header(
     header: &[u8; WIRE_HEADER_SIZE],
     expected_magic: [u8; 4],
     max_message_size: u64,
-    payload_cap: fn(&str) -> u64,
+    payload_cap: &dyn Fn(&str) -> u64,
 ) -> io::Result<ParsedEnvelopeHeader> {
     if header[0..4] != expected_magic {
         return Err(io::Error::new(
@@ -2334,6 +2633,19 @@ fn runtime_payload_cap(command: &str) -> u64 {
         MESSAGE_BLOCK | MESSAGE_TX => MAX_BLOCK_BYTES,
         "headers" => MAX_HEADERS_PAYLOAD_BYTES,
         _ => 0,
+    }
+}
+
+fn runtime_payload_cap_for_compact_session(
+    command: &str,
+    compact_mode: CompactModeSnapshot,
+    blocktxn_payload_cap: Option<u64>,
+) -> u64 {
+    let compact_receive = compact_mode.version == COMPACT_RELAY_VERSION && compact_mode.mode != 0;
+    match command {
+        "cmpctblock" if compact_receive => MAX_RELAY_MSG_BYTES,
+        "blocktxn" => blocktxn_payload_cap.unwrap_or((compact_receive as u64) * 32),
+        _ => runtime_payload_cap(command),
     }
 }
 
@@ -3187,7 +3499,6 @@ mod tests {
         let err = got.expect_err("cmpctblock operation succeeded").to_string();
         assert!(err.contains(want_err), "got {err}, want {want_err}");
     }
-
     fn cmpctblock_test_payload(tail: &[u8]) -> Vec<u8> {
         let mut payload = vec![0u8; BLOCK_HEADER_BYTES + 16];
         payload.extend_from_slice(tail);
@@ -3284,6 +3595,52 @@ mod tests {
         build_block_bytes(prev_hash, merkle_root, POW_LIMIT, timestamp, &[coinbase])
     }
 
+    #[test]
+    fn compact_receive_flow_smoke() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let mut client = TcpStream::connect(listener.local_addr().expect("addr")).expect("connect");
+        let (stream, _) = listener.accept().expect("accept");
+        let mut session =
+            PeerSession::new(stream, default_peer_runtime_config("devnet", 8)).expect("session");
+        let genesis = parse_block_bytes(&devnet_genesis_block_bytes()).expect("parse genesis");
+        let genesis_hash = block_hash(&genesis.header_bytes).expect("genesis hash");
+        let block1 = height_one_coinbase_only_block(genesis_hash, genesis.header.timestamp + 1);
+        let header: [u8; BLOCK_HEADER_BYTES] = block1[..BLOCK_HEADER_BYTES].try_into().unwrap();
+        let tx = block1[BLOCK_HEADER_BYTES + 1..].to_vec();
+        let block_hash = block_hash(&header).expect("block hash");
+        let short_id = compact_reconstruct_short_id_for_tx(&tx);
+        let missing = encode_cmpctblock_payload(CmpctBlockPayload {
+            header,
+            nonce1: 0,
+            nonce2: 0,
+            short_ids: vec![short_id],
+            prefilled: Vec::new(),
+        })
+        .expect("cmpctblock");
+        session.remote_compact_mode = CompactModeSnapshot {
+            mode: 1,
+            version: COMPACT_RELAY_VERSION,
+        };
+
+        let mut engine = test_sync_engine_with_genesis();
+        session
+            .handle_cmpctblock(&missing, &mut engine, None)
+            .unwrap();
+        session.compact_outstanding.as_mut().unwrap().expires_at = Instant::now();
+        assert!(!session.poll_read_ready(Duration::from_millis(1)).unwrap());
+        let _ = read_message_from(&mut client, network_magic("devnet"), MAX_RELAY_MSG_BYTES)
+            .expect("read compact fallback");
+        session
+            .handle_cmpctblock(&missing, &mut engine, None)
+            .unwrap();
+        let response = encode_blocktxn_payload(BlockTxnPayload {
+            block_hash,
+            transactions: vec![tx.clone()],
+        })
+        .unwrap();
+        session.handle_blocktxn(&response, &mut engine).unwrap();
+        assert!(engine.has_block(block_hash).unwrap());
+    }
     #[test]
     fn p2p_version_handshake_bidirectional_ok() {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
@@ -4230,8 +4587,7 @@ mod tests {
                 &mut engine,
                 None,
             )
-            .err()
-            .expect("future version must fail before future-mode validation");
+            .unwrap_err();
         assert!(err
             .to_string()
             .contains("unsupported compact relay version"));
@@ -4252,8 +4608,7 @@ mod tests {
                 &mut engine,
                 None,
             )
-            .err()
-            .expect("short sendcmpct payload must fail");
+            .unwrap_err();
         assert!(err.to_string().contains("sendcmpct payload width mismatch"));
         assert_eq!(
             second_session.remote_compact_mode,
@@ -4271,8 +4626,7 @@ mod tests {
                 &mut engine,
                 None,
             )
-            .err()
-            .expect("current-version unknown mode must fail");
+            .unwrap_err();
         assert!(err.to_string().contains("unsupported compact relay mode"));
         assert_eq!(
             second_session.remote_compact_mode,

--- a/clients/rust/crates/rubin-node/src/p2p_service.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_service.rs
@@ -9,8 +9,8 @@ use std::time::{Duration, Instant};
 use std::collections::HashMap;
 
 use crate::p2p_runtime::{
-    perform_version_handshake, LiveMessageOutcome, PeerManager, PeerRelayContext,
-    PeerRuntimeConfig, VersionPayloadV1, WireMessage,
+    perform_version_handshake, snapshot_compact_local_tx_candidates, LiveMessageOutcome,
+    PeerManager, PeerRelayContext, PeerRuntimeConfig, VersionPayloadV1, WireMessage,
 };
 use crate::sync_reorg::TxPoolCleanupPlan;
 use crate::tx_relay::{PeerOutbox, TxRelayState};
@@ -812,24 +812,6 @@ fn handle_peer(
         addr: peer_addr.clone(),
     };
 
-    // Build relay context for message loop. RUB-178 / GitHub #1438
-    // introduced the lifecycle plumbing; `tx_pool` threads the existing
-    // `shared.tx_pool` handle (already used by the block-apply cleanup
-    // path in `apply_tx_pool_cleanup`) into the peer-tx dispatch so
-    // peer transactions reach canonical admission via the seam in
-    // `collect_live_responses`. RUB-173 / GitHub #1420 then swapped that
-    // seam to `add_tx_with_source(..., TxSource::Remote, ...)` for
-    // source-aware classification. No new lifecycle ownership: this is
-    // the same `Arc<Mutex<TxPool>>` introduced for cleanup in PR #876.
-    let relay_ctx = PeerRelayContext {
-        relay_state: &shared.relay_state,
-        peer_manager: &shared.peer_manager,
-        local_addr: &shared.local_addr,
-        peer_registered_addr: &peer_addr,
-        peer_writers: &shared.peer_outboxes,
-        tx_pool: &shared.tx_pool,
-    };
-
     {
         let mut engine = shared
             .sync_engine
@@ -869,7 +851,7 @@ fn handle_peer(
         let msg = session
             .read_message()
             .map_err(|err| format!("read message: {err}"))?;
-        let outbound_messages = {
+        let (outbound_messages, disconnect_after_responses) = {
             // Validate payload size before acquiring engine lock.
             if msg.payload.len() > rubin_consensus::constants::MAX_RELAY_MSG_BYTES as usize {
                 return Err(format!(
@@ -878,10 +860,38 @@ fn handle_peer(
                     rubin_consensus::constants::MAX_RELAY_MSG_BYTES,
                 ));
             }
+            let compact_local_txs = if msg.command == "cmpctblock" {
+                let needs_snapshot = {
+                    let engine = shared
+                        .sync_engine
+                        .lock()
+                        .map_err(|_| "sync engine unavailable".to_string())?;
+                    session
+                        .cmpctblock_needs_local_tx_snapshot(&msg.payload, &engine)
+                        .map_err(|err| format!("precheck cmpctblock: {err}"))?
+                };
+                if needs_snapshot {
+                    Some(snapshot_compact_local_tx_candidates(&shared.tx_pool))
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
+            let relay_ctx = PeerRelayContext {
+                relay_state: &shared.relay_state,
+                peer_manager: &shared.peer_manager,
+                local_addr: &shared.local_addr,
+                peer_registered_addr: &peer_addr,
+                peer_writers: &shared.peer_outboxes,
+                tx_pool: &shared.tx_pool,
+                compact_local_txs: compact_local_txs.as_deref(),
+            };
             // Lock scope minimized: engine lock held only during
             // collect_live_responses.  Payload size check above ensures
-            // no unbounded deserialization under lock.
-            let (responses, tx_pool_cleanup) = {
+            // no unbounded deserialization under lock; compact mempool
+            // candidate snapshots are prevalidated above and taken before this lock.
+            let (responses, tx_pool_cleanup, disconnect_after_responses) = {
                 let mut engine = shared
                     .sync_engine
                     .lock()
@@ -895,7 +905,7 @@ fn handle_peer(
                 &shared,
                 tx_pool_cleanup,
             )?);
-            responses
+            (responses, disconnect_after_responses)
         };
         for outbound in outbound_messages {
             session
@@ -903,6 +913,9 @@ fn handle_peer(
                 .map_err(|err| format!("handle live message: {err}"))?;
         }
         flush_peer_outbox(&shared, &peer_addr, |frame| session.write_raw(frame))?;
+        if let Some(reason) = disconnect_after_responses {
+            return Err(format!("handle live message: {reason}"));
+        }
     }
     Ok(())
 }
@@ -991,11 +1004,12 @@ fn finalize_live_message_outcome(
     shared: &SharedServiceState,
     outcome: io::Result<LiveMessageOutcome>,
     pending_cleanup: TxPoolCleanupPlan,
-) -> Result<(Vec<WireMessage>, TxPoolCleanupPlan), String> {
+) -> Result<(Vec<WireMessage>, TxPoolCleanupPlan, Option<String>), String> {
     match outcome {
         Ok(outcome) => Ok((
             outcome.responses,
             outcome.tx_pool_cleanup.merge(pending_cleanup),
+            outcome.disconnect_after_responses,
         )),
         Err(err) => {
             log_tx_pool_cleanup_requeue_failure(&maybe_apply_tx_pool_cleanup(
@@ -1602,14 +1616,16 @@ mod tests {
                 payload: Vec::new(),
             }],
             tx_pool_cleanup: TxPoolCleanupPlan::default(),
+            ..Default::default()
         };
         let pending =
             TxPoolCleanupPlan::from_parts_for_test(vec![[0x22; 32]], Vec::new(), Vec::new());
 
-        let (responses, merged_cleanup) =
+        let (responses, merged_cleanup, disconnect_after_responses) =
             finalize_live_message_outcome(&shared, Ok(outcome), pending).expect("success path");
 
         assert_eq!(responses.len(), 1);
+        assert_eq!(disconnect_after_responses, None);
         assert!(
             !merged_cleanup.is_empty(),
             "pending cleanup must survive the success path"

--- a/clients/rust/crates/rubin-node/src/p2p_service.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_service.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 
 use crate::p2p_runtime::{
     perform_version_handshake, snapshot_compact_local_tx_candidates, LiveMessageOutcome,
-    PeerManager, PeerRelayContext, PeerRuntimeConfig, VersionPayloadV1, WireMessage,
+    PeerManager, PeerRelayContext, PeerRuntimeConfig, PeerSession, VersionPayloadV1, WireMessage,
 };
 use crate::sync_reorg::TxPoolCleanupPlan;
 use crate::tx_relay::{PeerOutbox, TxRelayState};
@@ -860,24 +860,8 @@ fn handle_peer(
                     rubin_consensus::constants::MAX_RELAY_MSG_BYTES,
                 ));
             }
-            let compact_local_txs = if msg.command == "cmpctblock" {
-                let needs_snapshot = {
-                    let engine = shared
-                        .sync_engine
-                        .lock()
-                        .map_err(|_| "sync engine unavailable".to_string())?;
-                    session
-                        .cmpctblock_needs_local_tx_snapshot(&msg.payload, &engine)
-                        .map_err(|err| format!("precheck cmpctblock: {err}"))?
-                };
-                if needs_snapshot {
-                    Some(snapshot_compact_local_tx_candidates(&shared.tx_pool))
-                } else {
-                    None
-                }
-            } else {
-                None
-            };
+            let compact_local_txs =
+                maybe_snapshot_compact_local_txs(&msg.command, &msg.payload, &session, &shared)?;
             let relay_ctx = PeerRelayContext {
                 relay_state: &shared.relay_state,
                 peer_manager: &shared.peer_manager,
@@ -913,9 +897,7 @@ fn handle_peer(
                 .map_err(|err| format!("handle live message: {err}"))?;
         }
         flush_peer_outbox(&shared, &peer_addr, |frame| session.write_raw(frame))?;
-        if let Some(reason) = disconnect_after_responses {
-            return Err(format!("handle live message: {reason}"));
-        }
+        disconnect_after_live_responses(disconnect_after_responses)?;
     }
     Ok(())
 }
@@ -1018,6 +1000,37 @@ fn finalize_live_message_outcome(
             )?);
             Err(format!("handle live message: {err}"))
         }
+    }
+}
+
+fn maybe_snapshot_compact_local_txs(
+    command: &str,
+    payload: &[u8],
+    session: &PeerSession,
+    shared: &SharedServiceState,
+) -> Result<Option<Vec<Vec<u8>>>, String> {
+    if command != "cmpctblock" {
+        return Ok(None);
+    }
+    let needs_snapshot = {
+        let engine = shared
+            .sync_engine
+            .lock()
+            .map_err(|_| "sync engine unavailable".to_string())?;
+        session
+            .cmpctblock_needs_local_tx_snapshot(payload, &engine)
+            .map_err(|err| format!("precheck cmpctblock: {err}"))?
+    };
+    if !needs_snapshot {
+        return Ok(None);
+    }
+    Ok(Some(snapshot_compact_local_tx_candidates(&shared.tx_pool)))
+}
+
+fn disconnect_after_live_responses(reason: Option<String>) -> Result<(), String> {
+    match reason {
+        Some(reason) => Err(format!("handle live message: {reason}")),
+        None => Ok(()),
     }
 }
 
@@ -1131,22 +1144,27 @@ mod tests {
     use rubin_consensus::{block_hash, constants::POW_LIMIT, parse_tx, BLOCK_HEADER_BYTES};
 
     use super::{
-        apply_tx_pool_cleanup, connect_with_timeout, finalize_live_message_outcome,
-        flush_peer_outbox, is_connected_with_alias, join_all_service_workers, lock_in_flight_dials,
-        maybe_apply_tx_pool_cleanup, outbound_connect_timeout, reconnect_missing_bootstrap_peers,
-        register_peer_alias, register_peer_outbox, should_skip_outbound_dial,
-        start_node_p2p_service, wait_for_service_shutdown, NodeP2PServiceConfig, PeerAliasGuard,
-        PeerGuard, SharedServiceState,
+        apply_tx_pool_cleanup, connect_with_timeout, disconnect_after_live_responses,
+        finalize_live_message_outcome, flush_peer_outbox, is_connected_with_alias,
+        join_all_service_workers, lock_in_flight_dials, maybe_apply_tx_pool_cleanup,
+        maybe_snapshot_compact_local_txs, outbound_connect_timeout,
+        reconnect_missing_bootstrap_peers, register_peer_alias, register_peer_outbox,
+        should_skip_outbound_dial, start_node_p2p_service, wait_for_service_shutdown,
+        NodeP2PServiceConfig, PeerAliasGuard, PeerGuard, SharedServiceState,
     };
     use crate::genesis::{devnet_genesis_block_bytes, devnet_genesis_chain_id};
     use crate::interop::local_version;
     use crate::p2p_runtime::{
         build_envelope_header, decode_inventory_vectors, default_peer_runtime_config,
-        encode_inventory_vectors, network_magic, perform_version_handshake, InventoryVector,
-        LiveMessageOutcome, PeerManager, PeerRuntimeConfig, VersionPayloadV1, WireMessage, MSG_TX,
+        encode_cmpctblock_payload, encode_inventory_vectors, network_magic,
+        perform_version_handshake, CmpctBlockPayload, InventoryVector, LiveMessageOutcome,
+        PeerManager, PeerRuntimeConfig, PeerSession, VersionPayloadV1, WireMessage, MSG_TX,
     };
     use crate::sync_reorg::TxPoolCleanupPlan;
-    use crate::test_helpers::{block_with_txs, signed_conflicting_p2pk_state_and_txs};
+    use crate::test_helpers::{
+        block_with_txs, genesis_info, height_one_coinbase_only_block,
+        signed_conflicting_p2pk_state_and_txs,
+    };
     use crate::tx_relay::PeerOutbox;
     use crate::tx_relay::TxRelayState;
     use crate::txpool::TxSource;
@@ -1654,6 +1672,93 @@ mod tests {
         );
 
         fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn compact_local_snapshot_precheck_covers_known_and_unknown_cmpctblock() {
+        let (sync_engine, dir) = test_engine("rubin-node-p2p-compact-snapshot-precheck");
+        {
+            let mut engine = sync_engine.lock().expect("sync engine");
+            let genesis = devnet_genesis_block_bytes();
+            engine
+                .apply_block_with_reorg(&genesis, None)
+                .expect("apply genesis");
+        }
+        let mut runtime_cfg = default_peer_runtime_config("devnet", 8);
+        runtime_cfg.enable_compact_receive = true;
+        let shared = test_shared_state(runtime_cfg.clone(), Vec::new(), sync_engine);
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind listener");
+        let _client = TcpStream::connect(listener.local_addr().expect("addr")).expect("connect");
+        let (stream, _) = listener.accept().expect("accept");
+        let mut session = PeerSession::new(stream, runtime_cfg).expect("session");
+        {
+            let mut engine = shared.sync_engine.lock().expect("sync engine");
+            session
+                .handle_live_message(
+                    WireMessage {
+                        command: "sendcmpct".to_string(),
+                        payload: sendcmpct_payload(1),
+                    },
+                    &mut engine,
+                    None,
+                )
+                .expect("enable compact receive");
+        }
+
+        let (genesis_bytes, genesis_hash, genesis_ts) = genesis_info();
+        let known_header: [u8; BLOCK_HEADER_BYTES] =
+            genesis_bytes[..BLOCK_HEADER_BYTES].try_into().unwrap();
+        let known = encode_cmpctblock_payload(CmpctBlockPayload {
+            header: known_header,
+            nonce1: 0,
+            nonce2: 0,
+            short_ids: vec![[1u8; 6]],
+            prefilled: Vec::new(),
+        })
+        .expect("known cmpctblock");
+        assert!(
+            maybe_snapshot_compact_local_txs("cmpctblock", &known, &session, &shared)
+                .expect("known precheck")
+                .is_none()
+        );
+
+        let block1 = height_one_coinbase_only_block(genesis_hash, genesis_ts + 1);
+        let unknown_header: [u8; BLOCK_HEADER_BYTES] =
+            block1[..BLOCK_HEADER_BYTES].try_into().unwrap();
+        let unknown = encode_cmpctblock_payload(CmpctBlockPayload {
+            header: unknown_header,
+            nonce1: 0,
+            nonce2: 0,
+            short_ids: vec![[2u8; 6]],
+            prefilled: Vec::new(),
+        })
+        .expect("unknown cmpctblock");
+        let snapshot = maybe_snapshot_compact_local_txs("cmpctblock", &unknown, &session, &shared)
+            .expect("unknown precheck")
+            .expect("unknown short-id cmpctblock snapshots the tx pool");
+        assert!(snapshot.is_empty());
+        assert!(
+            maybe_snapshot_compact_local_txs("ping", &[], &session, &shared)
+                .expect("non compact command")
+                .is_none()
+        );
+
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn disconnect_after_live_responses_formats_reason() {
+        disconnect_after_live_responses(None).expect("no disconnect reason");
+        let err = disconnect_after_live_responses(Some("stale blocktxn response".to_string()))
+            .expect_err("disconnect reason should surface");
+        assert_eq!(err, "handle live message: stale blocktxn response");
+    }
+
+    fn sendcmpct_payload(mode: u8) -> Vec<u8> {
+        let mut payload = Vec::with_capacity(9);
+        payload.push(mode);
+        payload.extend_from_slice(&1u64.to_le_bytes());
+        payload
     }
 
     fn test_wire_frame(runtime_cfg: &PeerRuntimeConfig, command: &str, payload: &[u8]) -> Vec<u8> {


### PR DESCRIPTION
Invariant:
Rust compact receive flow handles inbound cmpctblock by either applying a fully reconstructable local block or issuing a bounded getblocktxn request, and accepts blocktxn only when it matches the outstanding compact-block request.

Layer:
implementation/tests

Files changed:
- clients/rust/crates/rubin-node/src/p2p_runtime.rs
- clients/rust/crates/rubin-node/src/p2p_service.rs

Go/Rust parity matrix:
| Row | Reference surface | Rust evidence/tests |
| --- | --- | --- |
| Go | No Go files changed in this PR; RUB-412 is Rust receive-side only. | cargo test -p rubin-node compact_receive --lib -- PASS; cargo test -p rubin-node --lib -- PASS |
| Reference | Issue scope: inbound cmpctblock becomes local apply or bounded getblocktxn, and blocktxn is accepted only for the outstanding request. Serve-side getblocktxn remains out of scope for RUB-413. | compact_receive test group covers reconstruct, missing-index request, matched response apply, stale response handling, and fallback behavior. |
| Vector | No conformance fixture/vector changes in this PR. | Rust unit coverage and Codacy diff coverage cover changed service/runtime lines: diff coverage 100.00% (31/31). |

Tests:
- RUBIN_LINEAR_ISSUE=RUB-412 scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo fmt -p rubin-node && cargo test -p rubin-node compact_local_snapshot_precheck --lib && cargo test -p rubin-node disconnect_after_live_responses --lib' -- PASS
- RUBIN_LINEAR_ISSUE=RUB-412 scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test -p rubin-node compact_receive --lib && cargo test -p rubin-node --lib && cargo clippy -p rubin-node --lib -- -D warnings' -- PASS
- RUBIN_LINEAR_ISSUE=RUB-412 scripts/dev-env.sh -- ./scripts/preflight-codacy-coverage.sh -- PASS: base 92.89% (28354/30525), head 92.90% (28377/30547), variation +0.01%, diff coverage 100.00% (31/31)
- rubin-precommit-one-review --base-ref origin/main --include-base-diff -- PASS
- Isolated stock reviewer on HEAD c203228280c96323c636f8eb5a916ae236cbf44a and branch diff hash 9234bfbd1a022c5b3ac82ed10c18d54aa8bf1d758cc1555d69d7024776ba5388 -- PASS
- rubin-push --base-ref origin/main --coverage-cmd 'RUBIN_LINEAR_ISSUE=RUB-412 scripts/dev-env.sh -- ./scripts/preflight-codacy-coverage.sh' -- origin HEAD:codex/RUB-412-compact-receive-flow -- PASS
- GitHub checks on HEAD c203228280c96323c636f8eb5a916ae236cbf44a -- PASS: Codacy Static, Codacy Coverage Variation, Codacy Diff Coverage, CodeQL, CodeQL Analysis (go, autobuild), CodeQL Analysis (rust, none), Kani Proof Check, coverage, runtime-perf, test, validator, policy, security_ai, formal, formal_refinement, Go node race gate, dependency-review, dependency-submission, sanity, workflow-hygiene, Duplication check, Conformance fixtures drift check, semgrep-cloud-platform/scan; refresh-bot-review-gate is SKIPPED.
- GraphQL review-thread audit on HEAD c203228280c96323c636f8eb5a916ae236cbf44a -- PASS: no unresolved review threads.

Behavior impact:
- Rust peers can now receive cmpctblock messages, reconstruct when all short IDs are locally available, request missing transactions with getblocktxn, and apply only matching blocktxn responses.
- Stale blocktxn with a body after fallback is disconnected after the fallback block request is queued.

Compatibility impact:
- Rust P2P receive-side behavior changes only; no wire-format, consensus, Go, spec, fixture, or generated-artifact changes.

Known non-goals:
- Serve-side getblocktxn handling.
- Malformed cmpctblock wire coverage beyond this receive flow.
- DA, miner, provider, scripts, specs, fixtures, and Go changes.

Follow-ups:
- RUB-413 covers serve-side getblocktxn.
- RUB-395 covers malformed cmpctblock wire handling.
- RUB-396 covers late blocktxn expiry/fallback cleanup.

Risk:
- P2P runtime receive path now keeps per-peer compact-block request state; tests cover reconstruct, bounded missing indexes, matched blocktxn apply, stale-body disconnect, and service-side snapshot/disconnect routing.
- Branch-wide diff is 2 files changed, 1386 insertions, 72 deletions against origin/main.

Rollback:
- Revert this PR to return Rust compact-block receive handling to the previous no-op receive behavior.

Not checked:
- Merge was not performed.
