### PR TITLE
RUB-412: add gated Rust compact receive flow

### DIFF
--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -140,6 +140,7 @@ pub struct CompactReconstructionResult {
     pub transactions: Vec<Vec<u8>>,
     pub partial_transactions: Vec<Option<Vec<u8>>>,
     pub missing_indexes: Vec<u64>,
+    pub missing_short_ids: Vec<CompactShortId>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
@@ -160,6 +161,7 @@ pub struct PeerRuntimeConfig {
     pub read_deadline: Duration,
     pub write_deadline: Duration,
     pub ban_threshold: i32,
+    pub enable_compact_receive: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
@@ -209,6 +211,7 @@ pub struct PeerRelayContext<'a> {
     pub tx_pool: &'a std::sync::Mutex<crate::txpool::TxPool>,
 }
 
+#[derive(Debug, Default)]
 pub struct LiveMessageOutcome {
     pub responses: Vec<WireMessage>,
     pub tx_pool_cleanup: TxPoolCleanupPlan,
@@ -220,6 +223,17 @@ struct CompactModeSnapshot {
     version: u64,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct CompactOutstandingRequest {
+    block_hash: [u8; 32],
+    header: [u8; BLOCK_HEADER_BYTES],
+    missing_indexes: Vec<u64>,
+    missing_short_ids: Vec<CompactShortId>,
+    partial_transactions: Vec<Option<Vec<u8>>>,
+    nonces: [u64; 2],
+    blocktxn_payload_cap: u64,
+    expires_at: Instant,
+}
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct OrphanBlockEntry {
     block_hash: [u8; 32],
@@ -251,6 +265,7 @@ pub struct PeerSession {
     pending_tx_pool_cleanup: TxPoolCleanupPlan,
     prefetched_read_byte: Option<u8>,
     remote_compact_mode: CompactModeSnapshot,
+    compact_outstanding: Option<CompactOutstandingRequest>,
 }
 
 pub struct PeerManager {
@@ -307,6 +322,7 @@ pub fn default_peer_runtime_config(network: &str, max_peers: usize) -> PeerRunti
         read_deadline: DEFAULT_READ_DEADLINE,
         write_deadline: DEFAULT_WRITE_DEADLINE,
         ban_threshold: DEFAULT_BAN_THRESHOLD,
+        enable_compact_receive: false,
     }
 }
 
@@ -369,6 +385,7 @@ impl PeerSession {
             pending_tx_pool_cleanup: TxPoolCleanupPlan::default(),
             prefetched_read_byte: None,
             remote_compact_mode: CompactModeSnapshot::default(),
+            compact_outstanding: None,
         })
     }
 
@@ -419,6 +436,15 @@ impl PeerSession {
                     io::ErrorKind::TimedOut | io::ErrorKind::WouldBlock
                 ) =>
             {
+                if let Some(block_hash) = self
+                    .compact_outstanding
+                    .as_ref()
+                    .filter(|req| Instant::now() >= req.expires_at)
+                    .map(|req| req.block_hash)
+                {
+                    self.compact_outstanding = None;
+                    self.write_message(&compact_full_block_fallback_message(block_hash)?)?;
+                }
                 Ok(false)
             }
             Err(err) => Err(err),
@@ -429,9 +455,25 @@ impl PeerSession {
         self.stream
             .set_read_timeout(Some(timeout))
             .map_err(io::Error::other)?;
+        let compact_receive_enabled = self.cfg.enable_compact_receive;
         let mut reader = PrefetchedReader {
             stream: &mut self.stream,
             prefetched_read_byte: self.prefetched_read_byte.take(),
+        };
+        let compact_mode = self.remote_compact_mode;
+        let blocktxn_payload_cap = self
+            .compact_outstanding
+            .as_ref()
+            .filter(|req| Instant::now() < req.expires_at)
+            .map(|req| req.blocktxn_payload_cap.min(MAX_RELAY_MSG_BYTES));
+        let compact_receive = compact_receive_enabled
+            && compact_mode.version == COMPACT_RELAY_VERSION
+            && compact_mode.mode != 0;
+        let payload_cap = move |command: &str| match command {
+            "cmpctblock" if compact_receive => MAX_RELAY_MSG_BYTES,
+            "blocktxn" if compact_receive => blocktxn_payload_cap.unwrap_or(32),
+            "blocktxn" => 0,
+            _ => runtime_payload_cap(command),
         };
         // NOTE on tx-oversize ban policy (parity gap with Go's
         // `peer.handleTx`):
@@ -452,10 +494,11 @@ impl PeerSession {
         // ban-score policy at the higher layer; that is intentionally
         // out of scope for this Q-* task (which only aligns the
         // malformed/parse-fail surface).
-        read_message_from(
+        read_message_from_with_payload_limit(
             &mut reader,
             network_magic(&self.cfg.network),
             MAX_RELAY_MSG_BYTES,
+            &payload_cap,
         )
     }
 
@@ -630,6 +673,8 @@ impl PeerSession {
                     tx_pool_cleanup,
                 })
             }
+            "cmpctblock" => self.handle_cmpctblock(&msg.payload, sync_engine, relay_ctx),
+            "blocktxn" => self.handle_blocktxn(&msg.payload, sync_engine),
             MESSAGE_TX => {
                 if let Some(ctx) = relay_ctx {
                     let outcome = crate::tx_relay::handle_received_tx(
@@ -826,6 +871,224 @@ impl PeerSession {
         Ok(())
     }
 
+    fn handle_cmpctblock(
+        &mut self,
+        payload: &[u8],
+        sync_engine: &mut SyncEngine,
+        relay_ctx: Option<&PeerRelayContext<'_>>,
+    ) -> io::Result<LiveMessageOutcome> {
+        if !self.cfg.enable_compact_receive
+            || self.remote_compact_mode.version != COMPACT_RELAY_VERSION
+            || self.remote_compact_mode.mode == 0
+        {
+            return Err(invalid_data("compact receive disabled"));
+        }
+        self.clear_expired_compact_outstanding_request();
+        let block = match decode_cmpctblock_payload(payload) {
+            Ok(block) => block,
+            Err(err) => {
+                self.bump_ban(10, &err.to_string());
+                return Err(err);
+            }
+        };
+        let parsed_header =
+            rubin_consensus::parse_block_header_bytes(&block.header).map_err(io::Error::other)?;
+        if let Err(err) = rubin_consensus::pow_check(&block.header, parsed_header.target) {
+            self.bump_ban(100, &err.to_string());
+            return Err(io::Error::new(io::ErrorKind::InvalidData, err.to_string()));
+        }
+        if matches!(sync_engine.cfg.expected_target, Some(expected) if parsed_header.target != expected)
+        {
+            self.bump_ban(100, "target mismatch");
+            return Err(invalid_data("target mismatch"));
+        }
+        let block_hash = block_hash(&block.header).map_err(io::Error::other)?;
+        if sync_engine
+            .has_block(block_hash)
+            .map_err(io::Error::other)?
+        {
+            self.clear_compact_outstanding_request_for_block(block_hash);
+            return Ok(LiveMessageOutcome::default());
+        }
+        let local_txs = match relay_ctx.and_then(|ctx| ctx.tx_pool.lock().ok()) {
+            Some(pool) => pool.select_transactions(
+                COMPACT_LOCAL_TX_CANDIDATE_LIMIT,
+                COMPACT_LOCAL_TX_CANDIDATE_BYTES_LIMIT,
+            ),
+            None => Vec::new(),
+        };
+        let result = match reconstruct_compact_block(&block, &local_txs) {
+            Ok(result) => result,
+            Err(_err) if !block.short_ids.is_empty() => {
+                return self.request_compact_full_block_fallback(block_hash);
+            }
+            Err(err) => return Err(err),
+        };
+        if !result.transactions.is_empty() {
+            return self.process_compact_transactions(
+                block_hash,
+                block.header,
+                &result.transactions,
+                sync_engine,
+                !block.short_ids.is_empty(),
+            );
+        }
+        self.request_missing_compact_transactions(block, block_hash, result)
+    }
+    fn request_missing_compact_transactions(
+        &mut self,
+        block: CmpctBlockPayload,
+        block_hash: [u8; 32],
+        result: CompactReconstructionResult,
+    ) -> io::Result<LiveMessageOutcome> {
+        if self.compact_outstanding.is_some() {
+            return self.request_compact_full_block_fallback(block_hash);
+        }
+        let present_bytes = result
+            .partial_transactions
+            .iter()
+            .filter_map(Option::as_ref)
+            .try_fold(0u64, |total, tx| {
+                validate_blocktxn_transaction_size(tx.len() as u64, total)
+            })?;
+        let blocktxn_payload_cap =
+            32 + compact_size_wire_len(result.missing_indexes.len() as u64) + MAX_BLOCK_BYTES
+                - present_bytes
+                + result.missing_indexes.len() as u64 * MAX_COMPACT_SIZE_BYTES as u64;
+        let payload = encode_getblocktxn_payload(GetBlockTxnPayload {
+            block_hash,
+            indexes: result.missing_indexes.clone(),
+        })?;
+        self.compact_outstanding = Some(CompactOutstandingRequest {
+            block_hash,
+            header: block.header,
+            missing_indexes: result.missing_indexes,
+            missing_short_ids: result.missing_short_ids,
+            partial_transactions: result.partial_transactions,
+            nonces: [block.nonce1, block.nonce2],
+            blocktxn_payload_cap,
+            expires_at: Instant::now() + DEFAULT_READ_DEADLINE,
+        });
+        Ok(LiveMessageOutcome {
+            responses: vec![WireMessage {
+                command: "getblocktxn".to_string(),
+                payload,
+            }],
+            ..Default::default()
+        })
+    }
+    fn handle_blocktxn(
+        &mut self,
+        payload: &[u8],
+        sync_engine: &mut SyncEngine,
+    ) -> io::Result<LiveMessageOutcome> {
+        if !self.cfg.enable_compact_receive {
+            return Ok(LiveMessageOutcome::default());
+        }
+        if payload.len() < 32 {
+            self.bump_ban(10, "blocktxn payload missing block hash");
+            return Err(invalid_data("blocktxn payload missing block hash"));
+        }
+        self.clear_expired_compact_outstanding_request();
+        let mut response_hash = [0u8; 32];
+        response_hash.copy_from_slice(&payload[..32]);
+        let Some(req) = self.compact_outstanding.as_ref() else {
+            return Ok(LiveMessageOutcome::default());
+        };
+        if response_hash != req.block_hash {
+            return if payload.len() > 32 {
+                Err(invalid_data("stale blocktxn response"))
+            } else {
+                Ok(LiveMessageOutcome::default())
+            };
+        }
+        if payload.len() as u64 > req.blocktxn_payload_cap {
+            self.compact_outstanding = None;
+            self.bump_ban(10, "blocktxn payload exceeds outstanding cap");
+            return Err(invalid_data("blocktxn payload exceeds outstanding cap"));
+        }
+        let req = self
+            .compact_outstanding
+            .take()
+            .expect("compact outstanding checked");
+        let response = match decode_blocktxn_payload(payload) {
+            Ok(response) => response,
+            Err(err) => {
+                self.bump_ban(10, &err.to_string());
+                return Err(err);
+            }
+        };
+        let txs = match compact_fill_response_transactions(&req, response) {
+            Ok(txs) => txs,
+            Err(err)
+                if err
+                    .to_string()
+                    .contains("blocktxn transaction short id mismatch") =>
+            {
+                return self.request_compact_full_block_fallback(req.block_hash);
+            }
+            Err(err) => {
+                self.bump_ban(10, &err.to_string());
+                return Err(err);
+            }
+        };
+        self.process_compact_transactions(req.block_hash, req.header, &txs, sync_engine, true)
+    }
+    fn process_compact_transactions(
+        &mut self,
+        expected_hash: [u8; 32],
+        header: [u8; BLOCK_HEADER_BYTES],
+        txs: &[Vec<u8>],
+        sync_engine: &mut SyncEngine,
+        fallback_on_apply_error: bool,
+    ) -> io::Result<LiveMessageOutcome> {
+        let block_bytes = match compact_block_bytes(header, txs) {
+            Ok(block_bytes) => block_bytes,
+            Err(_err) => {
+                return self.request_compact_full_block_fallback(expected_hash);
+            }
+        };
+        match self.handle_block(&block_bytes, sync_engine) {
+            Ok(tx_pool_cleanup) => {
+                self.clear_compact_outstanding_request_for_block(expected_hash);
+                Ok(LiveMessageOutcome {
+                    responses: self
+                        .prepare_block_request_if_behind(sync_engine)?
+                        .into_iter()
+                        .collect(),
+                    tx_pool_cleanup,
+                })
+            }
+            Err(err) => {
+                self.peer.last_error = err.to_string();
+                if fallback_on_apply_error {
+                    self.request_compact_full_block_fallback(expected_hash)
+                } else {
+                    Err(err)
+                }
+            }
+        }
+    }
+    fn request_compact_full_block_fallback(
+        &mut self,
+        block_hash: [u8; 32],
+    ) -> io::Result<LiveMessageOutcome> {
+        self.clear_compact_outstanding_request_for_block(block_hash);
+        Ok(LiveMessageOutcome {
+            responses: vec![compact_full_block_fallback_message(block_hash)?],
+            ..Default::default()
+        })
+    }
+    fn clear_compact_outstanding_request_for_block(&mut self, block_hash: [u8; 32]) {
+        if self.compact_outstanding.as_ref().map(|req| req.block_hash) == Some(block_hash) {
+            self.compact_outstanding = None;
+        }
+    }
+    fn clear_expired_compact_outstanding_request(&mut self) {
+        if matches!(&self.compact_outstanding, Some(req) if Instant::now() >= req.expires_at) {
+            self.compact_outstanding = None;
+        }
+    }
     // Historically used by the inline run_block_sync_loop match; preserved under
     // #[cfg(test)] so the original behavioral test keeps documenting the
     // follow-up getblocks path. Production dispatch routes through
@@ -1174,7 +1437,7 @@ pub fn perform_version_handshake(
             &mut deadline_reader,
             network_magic(&session.cfg.network),
             MAX_RELAY_MSG_BYTES,
-            pre_handshake_payload_cap,
+            &pre_handshake_payload_cap,
         )?;
         match msg.command.as_str() {
             "version" => {
@@ -1287,7 +1550,7 @@ fn read_message_from<R: Read>(
         reader,
         expected_magic,
         max_payload_bytes,
-        runtime_payload_cap,
+        &runtime_payload_cap,
     )
 }
 
@@ -1295,7 +1558,7 @@ fn read_message_from_with_payload_limit<R: Read>(
     reader: &mut R,
     expected_magic: [u8; 4],
     max_payload_bytes: u64,
-    payload_cap: fn(&str) -> u64,
+    payload_cap: &dyn Fn(&str) -> u64,
 ) -> io::Result<WireMessage> {
     let mut header = [0u8; WIRE_HEADER_SIZE];
     reader.read_exact(&mut header)?;
@@ -1730,9 +1993,8 @@ pub fn reconstruct_compact_block(
     for entry in &payload.prefilled {
         partial[entry.index as usize] = Some(entry.tx.clone());
     }
-    let missing_indexes =
-        compact_missing(Some(&mut partial), total_entries, payload, &local_index)?;
-    if missing_indexes.is_empty() {
+    let missing = compact_missing(Some(&mut partial), total_entries, payload, &local_index)?;
+    if missing.0.is_empty() {
         compact_validate_present_transactions(partial.iter().filter_map(Option::as_deref))?;
         return Ok(CompactReconstructionResult {
             transactions: partial
@@ -1744,7 +2006,8 @@ pub fn reconstruct_compact_block(
     }
     Ok(CompactReconstructionResult {
         partial_transactions: partial,
-        missing_indexes,
+        missing_indexes: missing.0,
+        missing_short_ids: missing.1,
         ..Default::default()
     })
 }
@@ -1805,8 +2068,8 @@ fn compact_missing(
     total_entries: usize,
     payload: &CmpctBlockPayload,
     local_index: &CompactLocalIndex,
-) -> io::Result<Vec<u64>> {
-    let mut missing_indexes = Vec::new();
+) -> io::Result<(Vec<u64>, Vec<CompactShortId>)> {
+    let mut missing = (Vec::new(), Vec::new());
     let mut first_hit = HashMap::new();
     let mut short_pos = 0usize;
     let mut prefilled_pos = 0usize;
@@ -1830,9 +2093,9 @@ fn compact_missing(
                             txs[first_index as usize] = None;
                         }
                         first_hit.insert(short_id, u64::MAX);
-                        compact_push_missing(&mut missing_indexes, first_index)?;
+                        compact_push_missing(&mut missing, first_index, short_id)?;
                     }
-                    compact_push_missing(&mut missing_indexes, absolute_index as u64)?;
+                    compact_push_missing(&mut missing, absolute_index as u64, short_id)?;
                 } else {
                     first_hit.insert(short_id, absolute_index as u64);
                     if let Some(txs) = txs.as_deref_mut() {
@@ -1840,19 +2103,24 @@ fn compact_missing(
                     }
                 }
             }
-            None => compact_push_missing(&mut missing_indexes, absolute_index as u64)?,
+            None => compact_push_missing(&mut missing, absolute_index as u64, short_id)?,
         }
         short_pos += 1;
     }
     if let Some(txs) = txs {
         compact_validate_present_transactions(txs.iter().filter_map(Option::as_deref))?;
     }
-    Ok(missing_indexes)
+    Ok(missing)
 }
 
-fn compact_push_missing(missing: &mut Vec<u64>, index: u64) -> io::Result<()> {
-    missing.push(index);
-    (missing.len() <= MAX_COMPACT_RELAY_ENTRIES)
+fn compact_push_missing(
+    missing: &mut (Vec<u64>, Vec<CompactShortId>),
+    index: u64,
+    short_id: CompactShortId,
+) -> io::Result<()> {
+    missing.0.push(index);
+    missing.1.push(short_id);
+    (missing.0.len() <= MAX_COMPACT_RELAY_ENTRIES)
         .then_some(())
         .ok_or_else(|| invalid_data("too many compact relay missing transactions"))
 }
@@ -1962,6 +2230,68 @@ fn validate_compact_relay_transactions(
         total_payload_bytes += payload_add;
     }
     Ok(total_payload_bytes)
+}
+
+fn compact_full_block_fallback_message(block_hash: [u8; 32]) -> io::Result<WireMessage> {
+    Ok(WireMessage {
+        command: MESSAGE_GETDATA.to_string(),
+        payload: encode_inventory_vectors(&[InventoryVector {
+            kind: MSG_BLOCK,
+            hash: block_hash,
+        }])?,
+    })
+}
+fn compact_fill_response_transactions(
+    req: &CompactOutstandingRequest,
+    response: BlockTxnPayload,
+) -> io::Result<Vec<Vec<u8>>> {
+    if response.transactions.len() != req.missing_indexes.len() {
+        return Err(invalid_data("blocktxn transaction count mismatch"));
+    }
+    let mut txs = req.partial_transactions.clone();
+    for ((&index, want_short_id), tx) in req
+        .missing_indexes
+        .iter()
+        .zip(&req.missing_short_ids)
+        .zip(&response.transactions)
+    {
+        let slot = txs
+            .get_mut(index as usize)
+            .ok_or_else(|| invalid_data("blocktxn transaction index out of range"))?;
+        if slot.is_some() {
+            return Err(invalid_data(
+                "blocktxn transaction duplicates prefilled slot",
+            ));
+        }
+        let (_, _, wtxid, consumed) =
+            parse_tx(tx).map_err(|_| invalid_data("blocktxn transaction is non-canonical"))?;
+        if consumed != tx.len() {
+            return Err(invalid_data("blocktxn transaction is non-canonical"));
+        }
+        if compact_shortid(wtxid, req.nonces[0], req.nonces[1]) != *want_short_id {
+            return Err(invalid_data("blocktxn transaction short id mismatch"));
+        }
+        *slot = Some(tx.clone());
+    }
+    let txs = txs
+        .into_iter()
+        .map(|tx| tx.ok_or_else(|| invalid_data("compact block transaction missing")))
+        .collect::<io::Result<Vec<_>>>()?;
+    Ok(txs)
+}
+fn compact_block_bytes(header: [u8; BLOCK_HEADER_BYTES], txs: &[Vec<u8>]) -> io::Result<Vec<u8>> {
+    let mut out = Vec::with_capacity(BLOCK_HEADER_BYTES + MAX_COMPACT_SIZE_BYTES);
+    out.extend_from_slice(&header);
+    encode_compact_size(txs.len() as u64, &mut out);
+    let mut total_tx_bytes = 0u64;
+    for tx in txs {
+        total_tx_bytes = validate_blocktxn_transaction_size(tx.len() as u64, total_tx_bytes)?;
+        if tx.len() > (MAX_BLOCK_BYTES as usize).saturating_sub(out.len()) {
+            return Err(invalid_data("compact block exceeds block size"));
+        }
+        out.extend_from_slice(tx);
+    }
+    Ok(out)
 }
 
 fn compact_size_wire_len(n: u64) -> u64 {
@@ -2174,7 +2504,7 @@ fn unmarshal_wire_message(
         &header,
         expected_magic,
         max_message_size,
-        runtime_payload_cap,
+        &runtime_payload_cap,
     )?;
     let total_len = WIRE_HEADER_SIZE + envelope.payload_len;
     if raw.len() < total_len {
@@ -2207,7 +2537,7 @@ fn parse_envelope_header(
     header: &[u8; WIRE_HEADER_SIZE],
     expected_magic: [u8; 4],
     max_message_size: u64,
-    payload_cap: fn(&str) -> u64,
+    payload_cap: &dyn Fn(&str) -> u64,
 ) -> io::Result<ParsedEnvelopeHeader> {
     if header[0..4] != expected_magic {
         return Err(io::Error::new(
@@ -3101,9 +3431,30 @@ mod tests {
             vec![compact_reconstruct_short_id_for_tx(&prefilled)],
             base.prefilled,
         );
-        assert_reconstruct_missing(&prefilled_collision, &[prefilled], &[1]);
+        assert_reconstruct_missing(&prefilled_collision, std::slice::from_ref(&prefilled), &[1]);
         let valid_tx = minimal_blocktxn_test_tx_bytes(131);
         let short_id = compact_reconstruct_short_id_for_tx(&valid_tx);
+        let req = CompactOutstandingRequest {
+            block_hash: [9u8; 32],
+            header: [0u8; BLOCK_HEADER_BYTES],
+            missing_indexes: vec![1],
+            missing_short_ids: vec![short_id],
+            partial_transactions: vec![Some(prefilled.clone()), None],
+            nonces: [0, 0],
+            blocktxn_payload_cap: MAX_RELAY_MSG_BYTES,
+            expires_at: Instant::now() + DEFAULT_READ_DEADLINE,
+        };
+        assert_eq!(
+            compact_fill_response_transactions(
+                &req,
+                BlockTxnPayload {
+                    block_hash: req.block_hash,
+                    transactions: vec![valid_tx.clone()]
+                }
+            )
+            .unwrap(),
+            vec![prefilled.clone(), valid_tx.clone()]
+        );
         let cases = [
             (
                 vec![short_id],
@@ -4230,8 +4581,7 @@ mod tests {
                 &mut engine,
                 None,
             )
-            .err()
-            .expect("future version must fail before future-mode validation");
+            .expect_err("future version must fail before future-mode validation");
         assert!(err
             .to_string()
             .contains("unsupported compact relay version"));
@@ -4252,8 +4602,7 @@ mod tests {
                 &mut engine,
                 None,
             )
-            .err()
-            .expect("short sendcmpct payload must fail");
+            .expect_err("short sendcmpct payload must fail");
         assert!(err.to_string().contains("sendcmpct payload width mismatch"));
         assert_eq!(
             second_session.remote_compact_mode,
@@ -4271,8 +4620,7 @@ mod tests {
                 &mut engine,
                 None,
             )
-            .err()
-            .expect("current-version unknown mode must fail");
+            .expect_err("current-version unknown mode must fail");
         assert!(err.to_string().contains("unsupported compact relay mode"));
         assert_eq!(
             second_session.remote_compact_mode,


### PR DESCRIPTION
Scope:
RUB-412 Rust-only compact-block receive flow in `clients/rust/crates/rubin-node/src/p2p_runtime.rs`.

Go/Rust Parity Matrix:

| Go/reference/vector | Rust evidence | Tests |
| --- | --- | --- |
| `getblocktxn` block hash, CompactSize count, little-endian indexes | `getblocktxn_payload_codec_matches_go_wire`; invalid-wire/bounds tests | `cargo test -p rubin-node --lib` - PASS |
| `blocktxn` block hash, CompactSize transaction count, canonical transaction envelopes | `blocktxn_payload_codec_matches_go_wire`; malformed/capped input tests | `cargo test -p rubin-node --lib` - PASS |
| `cmpctblock` header, nonce pair, short IDs, prefilled transactions | `cmpctblock_payload_codec_matches_go_wire`; malformed/capped input tests | `cargo test -p rubin-node --lib` - PASS |
| Compact reconstruction and matching `blocktxn` response | `compact_reconstruct_go_parity_matrix` covers complete reconstruction, missing-index discovery, matching fill, duplicate/collision errors, local candidate caps, malformed local-candidate skip | `cargo test -p rubin-node compact_reconstruct_go_parity_matrix --lib` - PASS; `cargo test -p rubin-node --lib` - PASS |

Evidence:
- `cargo test -p rubin-node compact_reconstruct_go_parity_matrix --lib` - PASS
- `cargo clippy -p rubin-node --lib --tests -- -D warnings` - PASS
- `cargo test -p rubin-node --lib` - PASS (695/695)
- `rubin_common_preflight.py --repo . --base-ref origin/main --lane core --allow-rust` - PASS
- `rubin-precommit-one-review --repo . --base-ref origin/main --include-base-diff` - PASS
- `rubin_parity_matrix_gate.py --repo . --base-ref origin/main --mode pre-push` - PASS
- `rubin-push --repo . --base-ref origin/main --coverage-cmd 'scripts/dev-env.sh -- ./scripts/preflight-codacy-coverage.sh' -- origin HEAD` - PASS
- `rubin-stack-codacy-coverage.sh . origin/main` - PASS
- GitHub checks on PR #1887 - PASS
- Bot review gate on PR #1887 - PASS
- GraphQL `reviewThreads` on PR #1887 - 0 threads

Non-goals:
- `getblocktxn` serving / inbound request handling (RUB-413)
- late `blocktxn` drain or after-fallback cleanup semantics (RUB-396)
- malformed `cmpctblock` precheck expansion (RUB-395)
- Go, spec, fixture, service, DA, miner, provider, and script changes