### PR TITLE
RUB-394: defend Rust compact outstanding clear

### DIFF
--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -1260,6 +1260,7 @@ impl PeerSession {
     ) -> io::Result<TxPoolCleanupPlan> {
         let parsed = parse_block_bytes(block_bytes).map_err(io::Error::other)?;
         let block_hash_bytes = block_hash(&parsed.header_bytes).map_err(io::Error::other)?;
+        self.clear_compact_outstanding_request_for_block(block_hash_bytes);
         if sync_engine
             .has_block(block_hash_bytes)
             .map_err(io::Error::other)?
@@ -3975,6 +3976,88 @@ mod tests {
         out.extend(test_tag.to_le_bytes());
         out.extend([0; 8]);
         out
+    }
+
+    fn compact_outstanding_test_request(block_hash: [u8; 32]) -> CompactOutstandingRequest {
+        CompactOutstandingRequest {
+            block_hash,
+            header: [0u8; BLOCK_HEADER_BYTES],
+            missing_indexes: vec![0],
+            missing_short_ids: vec![[0x01; COMPACT_SHORT_ID_BYTES]],
+            partial_transactions: vec![None],
+            nonces: [0, 0],
+            blocktxn_payload_cap: 64,
+            expires_at: Instant::now() + DEFAULT_READ_DEADLINE,
+        }
+    }
+
+    #[test]
+    fn compact_outstanding_clear_go_parity_matrix() {
+        let (mut session, _client) = test_peer_session();
+        let mut engine = test_sync_engine_with_genesis();
+        let block = devnet_genesis_block_bytes();
+        let block_hash = block_hash(&block[..BLOCK_HEADER_BYTES]).expect("genesis hash");
+
+        session.compact_outstanding = Some(compact_outstanding_test_request(block_hash));
+        session
+            .handle_block(&block, &mut engine)
+            .expect("already-have full block");
+        assert!(
+            session.compact_outstanding.is_none(),
+            "matching full block did not clear outstanding compact request"
+        );
+
+        let active_hash = [0x55; 32];
+        session.compact_outstanding = Some(compact_outstanding_test_request(active_hash));
+        session
+            .handle_block(&block, &mut engine)
+            .expect("nonmatching full block");
+        assert_eq!(
+            session
+                .compact_outstanding
+                .as_ref()
+                .map(|req| req.block_hash),
+            Some(active_hash),
+            "nonmatching full block cleared unrelated outstanding compact request"
+        );
+
+        session.clear_compact_outstanding_request_for_block([0x66; 32]);
+        assert_eq!(
+            session
+                .compact_outstanding
+                .as_ref()
+                .map(|req| req.block_hash),
+            Some(active_hash),
+            "nonmatching explicit clear corrupted outstanding compact request"
+        );
+        session.clear_compact_outstanding_request_for_block(active_hash);
+        session.clear_compact_outstanding_request_for_block(active_hash);
+        assert!(
+            session.compact_outstanding.is_none(),
+            "matching explicit clear was not idempotent"
+        );
+
+        session.compact_outstanding = Some(compact_outstanding_test_request(block_hash));
+        session
+            .request_compact_full_block_fallback(block_hash)
+            .expect("matching fallback");
+        assert!(
+            session.compact_outstanding.is_none(),
+            "matching fallback left outstanding compact request active"
+        );
+
+        session.compact_outstanding = Some(compact_outstanding_test_request(active_hash));
+        session
+            .request_compact_full_block_fallback(block_hash)
+            .expect("stale fallback");
+        assert_eq!(
+            session
+                .compact_outstanding
+                .as_ref()
+                .map(|req| req.block_hash),
+            Some(active_hash),
+            "stale fallback cleared unrelated outstanding compact request"
+        );
     }
 
     fn large_blocktxn_test_tx_bytes(test_tag: u64) -> Vec<u8> {


### PR DESCRIPTION
## Scope

RUB-394 changes only Rust compact outstanding state handling in `clients/rust/crates/rubin-node/src/p2p_runtime.rs`.

The invariant is that a matching full-block receipt or fallback takeover clears one active compact outstanding request without clearing unrelated outstanding state.

Non-scope: timeout fallback send, late `blocktxn`, DA, miner, scripts.

## Go-Rust Parity Matrix

| Required parity case | Go reference / vector | Rust evidence / test |
| -- | -- | -- |
| one active outstanding request | `setCompactOutstandingRequest` / `activateCompactOutstandingRequest` | `compact_outstanding_clear_go_parity_matrix` installs one `compact_outstanding` request per session before each checked path |
| matching full block receipt | `clearCompactOutstandingRequestForBlock` clears matching `BlockHash` | `compact_outstanding_clear_go_parity_matrix` asserts `handle_block` clears a matching full block |
| nonmatching full block receipt | `clearCompactOutstandingRequestForBlock` preserves unrelated `BlockHash` | `compact_outstanding_clear_go_parity_matrix` asserts nonmatching `handle_block` keeps `active_hash` |
| fallback takeover | `requestCompactFullBlockFallback` clears matching outstanding state | `compact_outstanding_clear_go_parity_matrix` asserts matching `request_compact_full_block_fallback` clears state |
| idempotent clear | repeated `clearCompactOutstandingRequestForBlock` is safe | `compact_outstanding_clear_go_parity_matrix` calls the Rust clear helper twice and asserts no state is resurrected |
| no timeout send | RUB-395 owns timeout fallback send | no timeout send path changed; `compact_outstanding_clear_go_parity_matrix` uses direct helper and block receipt paths only |
| no late blocktxn | RUB-396 owns late `blocktxn` classification | no `handle_blocktxn` late-body classification path changed |

## Evidence

- `scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test -p rubin-node compact_outstanding_clear_go_parity_matrix --lib'` PASS
- `scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test -p rubin-node compact_outstanding --lib'` PASS
- `scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo fmt --check'` PASS
- `scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo clippy -p rubin-node --lib -- -D warnings'` PASS
- `scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test -p rubin-node --lib'` PASS
- `scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test --workspace'` PASS
- `rubin-precommit-one-review --repo <repo> --base-ref origin/main --include-base-diff` PASS
- isolated stock code-review pass: PASS, no findings
- `rubin-push --repo <repo> --base-ref origin/main --coverage-cmd 'scripts/dev-env.sh -- ./scripts/preflight-codacy-coverage.sh' -- origin HEAD` PASS
