### PR TITLE
RUB-395: defend Rust compact expiry fallback

### DIFF
--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -425,7 +425,9 @@ impl PeerSession {
         if self.prefetched_read_byte.is_some() {
             return Ok(true);
         }
-        self.send_expired_compact_outstanding_fallback()?;
+        if self.send_expired_compact_outstanding_fallback()? {
+            return Ok(false);
+        }
         let timeout =
             compact_expiry_bounded_read_timeout(self.compact_outstanding_expiry(), timeout);
         self.stream

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -452,6 +452,9 @@ impl PeerSession {
     }
 
     pub fn read_message_with_timeout(&mut self, timeout: Duration) -> io::Result<WireMessage> {
+        if self.prefetched_read_byte.is_some() {
+            self.send_expired_compact_outstanding_fallback()?;
+        }
         while self.prefetched_read_byte.is_none() {
             let had_outstanding = self.compact_outstanding.is_some();
             if self.poll_read_ready(timeout)? {
@@ -4188,12 +4191,16 @@ mod tests {
             .set_read_timeout(Some(Duration::from_secs(1)))
             .expect("client read timeout");
         let block_hash = [0xbb; 32];
-        let mut req = compact_outstanding_test_request(block_hash);
-        req.expires_at = Instant::now() - Duration::from_secs(1);
+        let req = compact_outstanding_test_request(block_hash);
         session.compact_outstanding = Some(req);
         let header =
             build_envelope_header(network_magic("devnet"), "ping", &[]).expect("ping header");
         client.write_all(&header).expect("write ready ping");
+        assert!(session
+            .poll_read_ready(Duration::from_secs(1))
+            .expect("prefetch first byte"));
+        session.compact_outstanding.as_mut().unwrap().expires_at =
+            Instant::now() - Duration::from_secs(1);
 
         let msg = session.read_message().expect("read ready ping");
         assert_eq!(msg.command, "ping");

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -444,15 +444,7 @@ impl PeerSession {
                     io::ErrorKind::TimedOut | io::ErrorKind::WouldBlock
                 ) =>
             {
-                if let Some(block_hash) = self
-                    .compact_outstanding
-                    .as_ref()
-                    .filter(|req| Instant::now() >= req.expires_at)
-                    .map(|req| req.block_hash)
-                {
-                    self.compact_outstanding = None;
-                    self.write_message(&compact_full_block_fallback_message(block_hash)?)?;
-                }
+                self.send_expired_compact_outstanding_fallback()?;
                 Ok(false)
             }
             Err(err) => Err(err),
@@ -1151,10 +1143,33 @@ impl PeerSession {
             self.compact_outstanding = None;
         }
     }
-    fn clear_expired_compact_outstanding_request(&mut self) {
-        if matches!(&self.compact_outstanding, Some(req) if Instant::now() >= req.expires_at) {
-            self.compact_outstanding = None;
+    fn pop_expired_compact_outstanding_block_hash_and_payload_cap(
+        &mut self,
+    ) -> Option<([u8; 32], u64)> {
+        if self
+            .compact_outstanding_expiry()
+            .is_none_or(|expiry| Instant::now() < expiry)
+        {
+            return None;
         }
+        self.compact_outstanding
+            .take()
+            .map(|req| (req.block_hash, req.blocktxn_payload_cap))
+    }
+    fn send_expired_compact_outstanding_fallback(&mut self) -> io::Result<bool> {
+        let Some((block_hash, _payload_cap)) =
+            self.pop_expired_compact_outstanding_block_hash_and_payload_cap()
+        else {
+            return Ok(false);
+        };
+        self.write_message(&compact_full_block_fallback_message(block_hash)?)?;
+        Ok(true)
+    }
+    fn clear_expired_compact_outstanding_request(&mut self) {
+        let _ = self.pop_expired_compact_outstanding_block_hash_and_payload_cap();
+    }
+    fn compact_outstanding_expiry(&self) -> Option<Instant> {
+        self.compact_outstanding.as_ref().map(|req| req.expires_at)
     }
     fn compact_receive_active(&self) -> bool {
         self.cfg.enable_compact_receive
@@ -4057,6 +4072,89 @@ mod tests {
                 .map(|req| req.block_hash),
             Some(active_hash),
             "stale fallback cleared unrelated outstanding compact request"
+        );
+    }
+
+    #[test]
+    fn compact_fallback_expiry_go_parity_matrix() {
+        let (mut session, mut client) = test_peer_session();
+        let active_hash = [0x77; 32];
+        session.compact_outstanding = Some(compact_outstanding_test_request(active_hash));
+        assert!(session.compact_outstanding_expiry().is_some());
+        assert!(!session
+            .send_expired_compact_outstanding_fallback()
+            .expect("nonexpired fallback"));
+        assert_eq!(
+            session
+                .compact_outstanding
+                .as_ref()
+                .map(|req| req.block_hash),
+            Some(active_hash)
+        );
+
+        let expired_hash = [0x88; 32];
+        let mut expired_req = compact_outstanding_test_request(expired_hash);
+        expired_req.blocktxn_payload_cap = 123;
+        expired_req.expires_at = Instant::now() - Duration::from_secs(1);
+        session.compact_outstanding = Some(expired_req);
+        let (got_hash, got_cap) = session
+            .pop_expired_compact_outstanding_block_hash_and_payload_cap()
+            .expect("expired pop");
+        assert_eq!(got_hash, expired_hash);
+        assert_eq!(got_cap, 123);
+        assert!(session.compact_outstanding.is_none());
+        assert!(session
+            .pop_expired_compact_outstanding_block_hash_and_payload_cap()
+            .is_none());
+
+        session.compact_outstanding = Some(compact_outstanding_test_request(expired_hash));
+        session.compact_outstanding.as_mut().unwrap().expires_at =
+            Instant::now() - Duration::from_secs(1);
+        assert!(session
+            .send_expired_compact_outstanding_fallback()
+            .expect("expired fallback"));
+        assert!(session.compact_outstanding.is_none());
+        let _ = read_message_from(&mut client, network_magic("devnet"), MAX_RELAY_MSG_BYTES)
+            .expect("read direct fallback getdata");
+        assert!(!session
+            .send_expired_compact_outstanding_fallback()
+            .expect("duplicate fallback"));
+
+        let (mut failed_session, _failed_client) = test_peer_session();
+        let mut failed_req = compact_outstanding_test_request([0x99; 32]);
+        failed_req.expires_at = Instant::now() - Duration::from_secs(1);
+        failed_session.compact_outstanding = Some(failed_req);
+        failed_session
+            .stream
+            .shutdown(std::net::Shutdown::Both)
+            .expect("shutdown stream");
+        assert!(failed_session
+            .send_expired_compact_outstanding_fallback()
+            .is_err());
+        assert!(failed_session.compact_outstanding.is_none());
+    }
+
+    #[test]
+    fn compact_fallback_poll_read_ready_emits_expired_fallback() {
+        let (mut session, mut client) = test_peer_session();
+        let block_hash = [0xaa; 32];
+        let mut req = compact_outstanding_test_request(block_hash);
+        req.expires_at = Instant::now() - Duration::from_secs(1);
+        session.compact_outstanding = Some(req);
+
+        assert!(!session
+            .poll_read_ready(Duration::from_millis(10))
+            .expect("poll read ready"));
+        assert!(session.compact_outstanding.is_none());
+        let msg = read_message_from(&mut client, network_magic("devnet"), MAX_RELAY_MSG_BYTES)
+            .expect("read idle fallback getdata");
+        assert_eq!(msg.command, MESSAGE_GETDATA);
+        assert_eq!(
+            decode_inventory_vectors(&msg.payload).expect("decode idle fallback inventory"),
+            vec![InventoryVector {
+                kind: MSG_BLOCK,
+                hash: block_hash
+            }]
         );
     }
 

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -4251,22 +4251,23 @@ mod tests {
         session.compact_outstanding = Some(req);
         client.write_all(b"x").expect("write ready byte");
 
-        let mut reader = CompactFallbackFrameReader {
-            stream: &mut session.stream,
-            prefetched_read_byte: None,
-            compact_outstanding: &mut session.compact_outstanding,
-            read_timeout: Duration::from_secs(1),
-            write_timeout: session.cfg.write_deadline,
-            network_magic: network_magic(&session.cfg.network),
-        };
-        let mut empty = [];
-        assert_eq!(reader.read(&mut empty).expect("zero-length read"), 0);
-        assert!(reader.compact_outstanding.is_some());
+        {
+            let mut reader = CompactFallbackFrameReader {
+                stream: &mut session.stream,
+                prefetched_read_byte: None,
+                compact_outstanding: &mut session.compact_outstanding,
+                read_timeout: Duration::from_secs(1),
+                write_timeout: session.cfg.write_deadline,
+                network_magic: network_magic(&session.cfg.network),
+            };
+            let mut empty = [];
+            assert_eq!(reader.read(&mut empty).expect("zero-length read"), 0);
+            assert!(reader.compact_outstanding.is_some());
 
-        let mut buf = [0u8; 1];
-        assert_eq!(reader.read(&mut buf).expect("read ready byte"), 1);
-        assert_eq!(buf[0], b'x');
-        drop(reader);
+            let mut buf = [0u8; 1];
+            assert_eq!(reader.read(&mut buf).expect("read ready byte"), 1);
+            assert_eq!(buf[0], b'x');
+        }
 
         assert!(session.compact_outstanding.is_none());
         assert_fallback_getdata(&mut client, block_hash);

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -425,6 +425,8 @@ impl PeerSession {
         if self.prefetched_read_byte.is_some() {
             return Ok(true);
         }
+        self.send_expired_compact_outstanding_fallback()?;
+        let timeout = self.compact_expiry_bounded_read_timeout(timeout);
         self.stream
             .set_read_timeout(Some(timeout))
             .map_err(io::Error::other)?;
@@ -438,12 +440,7 @@ impl PeerSession {
                 self.prefetched_read_byte = Some(probe[0]);
                 Ok(true)
             }
-            Err(err)
-                if matches!(
-                    err.kind(),
-                    io::ErrorKind::TimedOut | io::ErrorKind::WouldBlock
-                ) =>
-            {
+            Err(err) if is_socket_read_timeout(&err) => {
                 self.send_expired_compact_outstanding_fallback()?;
                 Ok(false)
             }
@@ -452,10 +449,11 @@ impl PeerSession {
     }
 
     pub fn read_message_with_timeout(&mut self, timeout: Duration) -> io::Result<WireMessage> {
+        self.send_expired_compact_outstanding_fallback()?;
+        let timeout = self.compact_expiry_bounded_read_timeout(timeout);
         self.stream
             .set_read_timeout(Some(timeout))
             .map_err(io::Error::other)?;
-        self.send_expired_compact_outstanding_fallback()?;
         let compact_receive = self.compact_receive_active();
         let mut reader = PrefetchedReader {
             stream: &mut self.stream,
@@ -493,12 +491,19 @@ impl PeerSession {
         // ban-score policy at the higher layer; that is intentionally
         // out of scope for this Q-* task (which only aligns the
         // malformed/parse-fail surface).
-        read_message_from_with_payload_limit(
+        match read_message_from_with_payload_limit(
             &mut reader,
             network_magic(&self.cfg.network),
             MAX_RELAY_MSG_BYTES,
             &payload_cap,
-        )
+        ) {
+            Ok(message) => Ok(message),
+            Err(err) if is_socket_read_timeout(&err) => {
+                self.send_expired_compact_outstanding_fallback()?;
+                Err(err)
+            }
+            Err(err) => Err(err),
+        }
     }
 
     pub fn write_message(&mut self, msg: &WireMessage) -> io::Result<()> {
@@ -1172,6 +1177,18 @@ impl PeerSession {
     fn compact_outstanding_expiry(&self) -> Option<Instant> {
         self.compact_outstanding.as_ref().map(|req| req.expires_at)
     }
+    fn compact_expiry_bounded_read_timeout(&self, timeout: Duration) -> Duration {
+        self.compact_outstanding_expiry()
+            .map(|expiry| {
+                let remaining = expiry.saturating_duration_since(Instant::now());
+                if remaining.is_zero() {
+                    Duration::from_millis(1).min(timeout)
+                } else {
+                    remaining.min(timeout)
+                }
+            })
+            .unwrap_or(timeout)
+    }
     fn compact_receive_active(&self) -> bool {
         self.cfg.enable_compact_receive
             && self.remote_compact_mode.version == COMPACT_RELAY_VERSION
@@ -1657,6 +1674,13 @@ fn read_message_from<R: Read>(
         expected_magic,
         max_payload_bytes,
         &runtime_payload_cap,
+    )
+}
+
+fn is_socket_read_timeout(err: &io::Error) -> bool {
+    matches!(
+        err.kind(),
+        io::ErrorKind::TimedOut | io::ErrorKind::WouldBlock
     )
 }
 
@@ -4181,6 +4205,41 @@ mod tests {
         assert_eq!(fallback.command, MESSAGE_GETDATA);
         assert_eq!(
             decode_inventory_vectors(&fallback.payload).expect("decode ready fallback inventory"),
+            vec![InventoryVector {
+                kind: MSG_BLOCK,
+                hash: block_hash
+            }]
+        );
+    }
+
+    #[test]
+    fn compact_fallback_read_message_timeout_is_bounded_by_expiry() {
+        let (mut session, mut client) = test_peer_session();
+        client
+            .set_read_timeout(Some(Duration::from_secs(1)))
+            .expect("client read timeout");
+        let block_hash = [0xcc; 32];
+        let mut req = compact_outstanding_test_request(block_hash);
+        req.expires_at = Instant::now() + Duration::from_millis(30);
+        session.compact_outstanding = Some(req);
+
+        let started = Instant::now();
+        let err = match session.read_message_with_timeout(Duration::from_secs(2)) {
+            Ok(_) => panic!("read unexpectedly succeeded before compact expiry fallback"),
+            Err(err) => err,
+        };
+        assert!(is_socket_read_timeout(&err));
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "read used the full peer read timeout instead of compact expiry"
+        );
+        assert!(session.compact_outstanding.is_none());
+        let fallback = read_message_from(&mut client, network_magic("devnet"), MAX_RELAY_MSG_BYTES)
+            .expect("read expiry-bounded fallback getdata");
+        assert_eq!(fallback.command, MESSAGE_GETDATA);
+        assert_eq!(
+            decode_inventory_vectors(&fallback.payload)
+                .expect("decode expiry-bounded fallback inventory"),
             vec![InventoryVector {
                 kind: MSG_BLOCK,
                 hash: block_hash

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -1512,15 +1512,17 @@ impl CompactFallbackFrameReader<'_> {
 
 impl Read for CompactFallbackFrameReader<'_> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
         if let Some(first_byte) = self.prefetched_read_byte.take() {
-            if buf.is_empty() {
-                self.prefetched_read_byte = Some(first_byte);
-                return Ok(0);
-            }
             buf[0] = first_byte;
             return Ok(1);
         }
         loop {
+            if self.send_expired_compact_outstanding_fallback()? {
+                continue;
+            }
             let expiry = self.compact_outstanding.as_ref().map(|req| req.expires_at);
             let timeout = compact_expiry_bounded_read_timeout(expiry, self.read_timeout);
             self.stream
@@ -4235,6 +4237,39 @@ mod tests {
             .write_all(&header[1..])
             .expect("write ping after fallback");
         reader.join().expect("read_message thread");
+    }
+
+    #[test]
+    fn compact_fallback_frame_reader_sends_expired_fallback_before_ready_read() {
+        let (mut session, mut client) = test_peer_session();
+        client
+            .set_read_timeout(Some(Duration::from_secs(1)))
+            .expect("client read timeout");
+        let block_hash = [0xdd; 32];
+        let mut req = compact_outstanding_test_request(block_hash);
+        req.expires_at = Instant::now() - Duration::from_secs(1);
+        session.compact_outstanding = Some(req);
+        client.write_all(b"x").expect("write ready byte");
+
+        let mut reader = CompactFallbackFrameReader {
+            stream: &mut session.stream,
+            prefetched_read_byte: None,
+            compact_outstanding: &mut session.compact_outstanding,
+            read_timeout: Duration::from_secs(1),
+            write_timeout: session.cfg.write_deadline,
+            network_magic: network_magic(&session.cfg.network),
+        };
+        let mut empty = [];
+        assert_eq!(reader.read(&mut empty).expect("zero-length read"), 0);
+        assert!(reader.compact_outstanding.is_some());
+
+        let mut buf = [0u8; 1];
+        assert_eq!(reader.read(&mut buf).expect("read ready byte"), 1);
+        assert_eq!(buf[0], b'x');
+        drop(reader);
+
+        assert!(session.compact_outstanding.is_none());
+        assert_fallback_getdata(&mut client, block_hash);
     }
 
     fn large_blocktxn_test_tx_bytes(test_tag: u64) -> Vec<u8> {

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -455,6 +455,7 @@ impl PeerSession {
         self.stream
             .set_read_timeout(Some(timeout))
             .map_err(io::Error::other)?;
+        self.send_expired_compact_outstanding_fallback()?;
         let compact_receive = self.compact_receive_active();
         let mut reader = PrefetchedReader {
             stream: &mut self.stream,
@@ -4151,6 +4152,35 @@ mod tests {
         assert_eq!(msg.command, MESSAGE_GETDATA);
         assert_eq!(
             decode_inventory_vectors(&msg.payload).expect("decode idle fallback inventory"),
+            vec![InventoryVector {
+                kind: MSG_BLOCK,
+                hash: block_hash
+            }]
+        );
+    }
+
+    #[test]
+    fn compact_fallback_read_message_with_ready_frame_emits_expired_fallback() {
+        let (mut session, mut client) = test_peer_session();
+        client
+            .set_read_timeout(Some(Duration::from_secs(1)))
+            .expect("client read timeout");
+        let block_hash = [0xbb; 32];
+        let mut req = compact_outstanding_test_request(block_hash);
+        req.expires_at = Instant::now() - Duration::from_secs(1);
+        session.compact_outstanding = Some(req);
+        let header =
+            build_envelope_header(network_magic("devnet"), "ping", &[]).expect("ping header");
+        client.write_all(&header).expect("write ready ping");
+
+        let msg = session.read_message().expect("read ready ping");
+        assert_eq!(msg.command, "ping");
+        assert!(session.compact_outstanding.is_none());
+        let fallback = read_message_from(&mut client, network_magic("devnet"), MAX_RELAY_MSG_BYTES)
+            .expect("read ready-frame fallback getdata");
+        assert_eq!(fallback.command, MESSAGE_GETDATA);
+        assert_eq!(
+            decode_inventory_vectors(&fallback.payload).expect("decode ready fallback inventory"),
             vec![InventoryVector {
                 kind: MSG_BLOCK,
                 hash: block_hash

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -449,8 +449,16 @@ impl PeerSession {
     }
 
     pub fn read_message_with_timeout(&mut self, timeout: Duration) -> io::Result<WireMessage> {
-        self.send_expired_compact_outstanding_fallback()?;
-        let timeout = self.compact_expiry_bounded_read_timeout(timeout);
+        while self.prefetched_read_byte.is_none() {
+            let had_outstanding = self.compact_outstanding.is_some();
+            if self.poll_read_ready(timeout)? {
+                break;
+            }
+            if had_outstanding && self.compact_outstanding.is_none() {
+                continue;
+            }
+            return Err(io::Error::new(io::ErrorKind::TimedOut, "peer read timeout"));
+        }
         self.stream
             .set_read_timeout(Some(timeout))
             .map_err(io::Error::other)?;
@@ -491,19 +499,12 @@ impl PeerSession {
         // ban-score policy at the higher layer; that is intentionally
         // out of scope for this Q-* task (which only aligns the
         // malformed/parse-fail surface).
-        match read_message_from_with_payload_limit(
+        read_message_from_with_payload_limit(
             &mut reader,
             network_magic(&self.cfg.network),
             MAX_RELAY_MSG_BYTES,
             &payload_cap,
-        ) {
-            Ok(message) => Ok(message),
-            Err(err) if is_socket_read_timeout(&err) => {
-                self.send_expired_compact_outstanding_fallback()?;
-                Err(err)
-            }
-            Err(err) => Err(err),
-        }
+        )
     }
 
     pub fn write_message(&mut self, msg: &WireMessage) -> io::Result<()> {
@@ -4213,7 +4214,7 @@ mod tests {
     }
 
     #[test]
-    fn compact_fallback_read_message_timeout_is_bounded_by_expiry() {
+    fn compact_fallback_read_message_continues_after_expiry_fallback() {
         let (mut session, mut client) = test_peer_session();
         client
             .set_read_timeout(Some(Duration::from_secs(1)))
@@ -4223,17 +4224,14 @@ mod tests {
         req.expires_at = Instant::now() + Duration::from_millis(30);
         session.compact_outstanding = Some(req);
 
-        let started = Instant::now();
-        let err = match session.read_message_with_timeout(Duration::from_secs(2)) {
-            Ok(_) => panic!("read unexpectedly succeeded before compact expiry fallback"),
-            Err(err) => err,
-        };
-        assert!(is_socket_read_timeout(&err));
-        assert!(
-            started.elapsed() < Duration::from_secs(1),
-            "read used the full peer read timeout instead of compact expiry"
-        );
-        assert!(session.compact_outstanding.is_none());
+        let reader = thread::spawn(move || {
+            let msg = session
+                .read_message_with_timeout(Duration::from_secs(2))
+                .expect("continue reading after compact expiry fallback");
+            assert_eq!(msg.command, "ping");
+            assert!(session.compact_outstanding.is_none());
+        });
+
         let fallback = read_message_from(&mut client, network_magic("devnet"), MAX_RELAY_MSG_BYTES)
             .expect("read expiry-bounded fallback getdata");
         assert_eq!(fallback.command, MESSAGE_GETDATA);
@@ -4245,6 +4243,12 @@ mod tests {
                 hash: block_hash
             }]
         );
+        let header =
+            build_envelope_header(network_magic("devnet"), "ping", &[]).expect("ping header");
+        client
+            .write_all(&header)
+            .expect("write ping after fallback");
+        reader.join().expect("read_message thread");
     }
 
     fn large_blocktxn_test_tx_bytes(test_tag: u64) -> Vec<u8> {

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -426,7 +426,8 @@ impl PeerSession {
             return Ok(true);
         }
         self.send_expired_compact_outstanding_fallback()?;
-        let timeout = self.compact_expiry_bounded_read_timeout(timeout);
+        let timeout =
+            compact_expiry_bounded_read_timeout(self.compact_outstanding_expiry(), timeout);
         self.stream
             .set_read_timeout(Some(timeout))
             .map_err(io::Error::other)?;
@@ -459,19 +460,20 @@ impl PeerSession {
             }
             return Err(io::Error::new(io::ErrorKind::TimedOut, "peer read timeout"));
         }
-        self.stream
-            .set_read_timeout(Some(timeout))
-            .map_err(io::Error::other)?;
         let compact_receive = self.compact_receive_active();
-        let mut reader = PrefetchedReader {
-            stream: &mut self.stream,
-            prefetched_read_byte: self.prefetched_read_byte.take(),
-        };
         let blocktxn_payload_cap = self
             .compact_outstanding
             .as_ref()
             .filter(|req| Instant::now() < req.expires_at)
             .map(|req| req.blocktxn_payload_cap.min(MAX_RELAY_MSG_BYTES));
+        let mut reader = CompactFallbackFrameReader {
+            stream: &mut self.stream,
+            prefetched_read_byte: self.prefetched_read_byte.take(),
+            compact_outstanding: &mut self.compact_outstanding,
+            read_timeout: timeout,
+            write_timeout: self.cfg.write_deadline,
+            network_magic: network_magic(&self.cfg.network),
+        };
         let payload_cap = move |command: &str| match command {
             "cmpctblock" if compact_receive => MAX_RELAY_MSG_BYTES,
             MESSAGE_GETBLOCKTXN if compact_receive => MAX_GETBLOCKTXN_PAYLOAD_BYTES,
@@ -524,11 +526,7 @@ impl PeerSession {
         };
         let header =
             build_envelope_header(network_magic(&self.cfg.network), &msg.command, &msg.payload)?;
-        self.stream.write_all(&header)?;
-        if !msg.payload.is_empty() {
-            self.stream.write_all(&msg.payload)?;
-        }
-        self.stream.flush()?;
+        write_wire_message_to_stream(&mut self.stream, self.cfg.write_deadline, &header, msg)?;
         if let Some(block_hash) = compact_announcement {
             self.mark_compact_block_announced(block_hash);
         }
@@ -1153,15 +1151,7 @@ impl PeerSession {
     fn pop_expired_compact_outstanding_block_hash_and_payload_cap(
         &mut self,
     ) -> Option<([u8; 32], u64)> {
-        if self
-            .compact_outstanding_expiry()
-            .is_none_or(|expiry| Instant::now() < expiry)
-        {
-            return None;
-        }
-        self.compact_outstanding
-            .take()
-            .map(|req| (req.block_hash, req.blocktxn_payload_cap))
+        pop_expired_compact_outstanding(&mut self.compact_outstanding)
     }
     fn send_expired_compact_outstanding_fallback(&mut self) -> io::Result<bool> {
         let Some((block_hash, _payload_cap)) =
@@ -1177,18 +1167,6 @@ impl PeerSession {
     }
     fn compact_outstanding_expiry(&self) -> Option<Instant> {
         self.compact_outstanding.as_ref().map(|req| req.expires_at)
-    }
-    fn compact_expiry_bounded_read_timeout(&self, timeout: Duration) -> Duration {
-        self.compact_outstanding_expiry()
-            .map(|expiry| {
-                let remaining = expiry.saturating_duration_since(Instant::now());
-                if remaining.is_zero() {
-                    Duration::from_millis(1).min(timeout)
-                } else {
-                    remaining.min(timeout)
-                }
-            })
-            .unwrap_or(timeout)
     }
     fn compact_receive_active(&self) -> bool {
         self.cfg.enable_compact_receive
@@ -1504,12 +1482,30 @@ impl Read for DeadlineReader {
     }
 }
 
-struct PrefetchedReader<'a> {
+struct CompactFallbackFrameReader<'a> {
     stream: &'a mut TcpStream,
     prefetched_read_byte: Option<u8>,
+    compact_outstanding: &'a mut Option<CompactOutstandingRequest>,
+    read_timeout: Duration,
+    write_timeout: Duration,
+    network_magic: [u8; 4],
 }
 
-impl Read for PrefetchedReader<'_> {
+impl CompactFallbackFrameReader<'_> {
+    fn send_expired_compact_outstanding_fallback(&mut self) -> io::Result<bool> {
+        let Some((block_hash, _payload_cap)) =
+            pop_expired_compact_outstanding(self.compact_outstanding)
+        else {
+            return Ok(false);
+        };
+        let msg = compact_full_block_fallback_message(block_hash)?;
+        let header = build_envelope_header(self.network_magic, &msg.command, &msg.payload)?;
+        write_wire_message_to_stream(self.stream, self.write_timeout, &header, &msg)?;
+        Ok(true)
+    }
+}
+
+impl Read for CompactFallbackFrameReader<'_> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         if let Some(first_byte) = self.prefetched_read_byte.take() {
             if buf.is_empty() {
@@ -1517,13 +1513,24 @@ impl Read for PrefetchedReader<'_> {
                 return Ok(0);
             }
             buf[0] = first_byte;
-            if buf.len() == 1 {
-                return Ok(1);
-            }
-            let read = self.stream.read(&mut buf[1..])?;
-            return Ok(read + 1);
+            return Ok(1);
         }
-        self.stream.read(buf)
+        loop {
+            let expiry = self.compact_outstanding.as_ref().map(|req| req.expires_at);
+            let timeout = compact_expiry_bounded_read_timeout(expiry, self.read_timeout);
+            self.stream
+                .set_read_timeout(Some(timeout))
+                .map_err(io::Error::other)?;
+            match self.stream.read(buf) {
+                Err(err) if is_socket_read_timeout(&err) => {
+                    if self.send_expired_compact_outstanding_fallback()? {
+                        continue;
+                    }
+                    return Err(err);
+                }
+                result => return result,
+            }
+        }
     }
 }
 
@@ -1683,6 +1690,49 @@ fn is_socket_read_timeout(err: &io::Error) -> bool {
         err.kind(),
         io::ErrorKind::TimedOut | io::ErrorKind::WouldBlock
     )
+}
+
+fn compact_expiry_bounded_read_timeout(expiry: Option<Instant>, timeout: Duration) -> Duration {
+    expiry
+        .map(|expiry| {
+            let remaining = expiry.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                Duration::from_millis(1).min(timeout)
+            } else {
+                remaining.min(timeout)
+            }
+        })
+        .unwrap_or(timeout)
+}
+
+fn pop_expired_compact_outstanding(
+    compact_outstanding: &mut Option<CompactOutstandingRequest>,
+) -> Option<([u8; 32], u64)> {
+    if compact_outstanding
+        .as_ref()
+        .is_none_or(|req| Instant::now() < req.expires_at)
+    {
+        return None;
+    }
+    compact_outstanding
+        .take()
+        .map(|req| (req.block_hash, req.blocktxn_payload_cap))
+}
+
+fn write_wire_message_to_stream(
+    stream: &mut TcpStream,
+    write_timeout: Duration,
+    header: &[u8; WIRE_HEADER_SIZE],
+    msg: &WireMessage,
+) -> io::Result<()> {
+    stream
+        .set_write_timeout(Some(write_timeout))
+        .map_err(io::Error::other)?;
+    stream.write_all(header)?;
+    if !msg.payload.is_empty() {
+        stream.write_all(&msg.payload)?;
+    }
+    stream.flush()
 }
 
 fn read_message_from_with_payload_limit<R: Read>(
@@ -4032,6 +4082,19 @@ mod tests {
         }
     }
 
+    fn assert_fallback_getdata(client: &mut TcpStream, block_hash: [u8; 32]) {
+        let msg = read_message_from(client, network_magic("devnet"), MAX_RELAY_MSG_BYTES)
+            .expect("read fallback getdata");
+        assert_eq!(msg.command, MESSAGE_GETDATA);
+        assert_eq!(
+            decode_inventory_vectors(&msg.payload).expect("decode fallback inventory"),
+            vec![InventoryVector {
+                kind: MSG_BLOCK,
+                hash: block_hash
+            }]
+        );
+    }
+
     #[test]
     fn compact_outstanding_clear_go_parity_matrix() {
         let (mut session, _client) = test_peer_session();
@@ -4102,65 +4165,6 @@ mod tests {
     }
 
     #[test]
-    fn compact_fallback_expiry_go_parity_matrix() {
-        let (mut session, mut client) = test_peer_session();
-        let active_hash = [0x77; 32];
-        session.compact_outstanding = Some(compact_outstanding_test_request(active_hash));
-        assert!(session.compact_outstanding_expiry().is_some());
-        assert!(!session
-            .send_expired_compact_outstanding_fallback()
-            .expect("nonexpired fallback"));
-        assert_eq!(
-            session
-                .compact_outstanding
-                .as_ref()
-                .map(|req| req.block_hash),
-            Some(active_hash)
-        );
-
-        let expired_hash = [0x88; 32];
-        let mut expired_req = compact_outstanding_test_request(expired_hash);
-        expired_req.blocktxn_payload_cap = 123;
-        expired_req.expires_at = Instant::now() - Duration::from_secs(1);
-        session.compact_outstanding = Some(expired_req);
-        let (got_hash, got_cap) = session
-            .pop_expired_compact_outstanding_block_hash_and_payload_cap()
-            .expect("expired pop");
-        assert_eq!(got_hash, expired_hash);
-        assert_eq!(got_cap, 123);
-        assert!(session.compact_outstanding.is_none());
-        assert!(session
-            .pop_expired_compact_outstanding_block_hash_and_payload_cap()
-            .is_none());
-
-        session.compact_outstanding = Some(compact_outstanding_test_request(expired_hash));
-        session.compact_outstanding.as_mut().unwrap().expires_at =
-            Instant::now() - Duration::from_secs(1);
-        assert!(session
-            .send_expired_compact_outstanding_fallback()
-            .expect("expired fallback"));
-        assert!(session.compact_outstanding.is_none());
-        let _ = read_message_from(&mut client, network_magic("devnet"), MAX_RELAY_MSG_BYTES)
-            .expect("read direct fallback getdata");
-        assert!(!session
-            .send_expired_compact_outstanding_fallback()
-            .expect("duplicate fallback"));
-
-        let (mut failed_session, _failed_client) = test_peer_session();
-        let mut failed_req = compact_outstanding_test_request([0x99; 32]);
-        failed_req.expires_at = Instant::now() - Duration::from_secs(1);
-        failed_session.compact_outstanding = Some(failed_req);
-        failed_session
-            .stream
-            .shutdown(std::net::Shutdown::Both)
-            .expect("shutdown stream");
-        assert!(failed_session
-            .send_expired_compact_outstanding_fallback()
-            .is_err());
-        assert!(failed_session.compact_outstanding.is_none());
-    }
-
-    #[test]
     fn compact_fallback_poll_read_ready_emits_expired_fallback() {
         let (mut session, mut client) = test_peer_session();
         let block_hash = [0xaa; 32];
@@ -4172,16 +4176,7 @@ mod tests {
             .poll_read_ready(Duration::from_millis(10))
             .expect("poll read ready"));
         assert!(session.compact_outstanding.is_none());
-        let msg = read_message_from(&mut client, network_magic("devnet"), MAX_RELAY_MSG_BYTES)
-            .expect("read idle fallback getdata");
-        assert_eq!(msg.command, MESSAGE_GETDATA);
-        assert_eq!(
-            decode_inventory_vectors(&msg.payload).expect("decode idle fallback inventory"),
-            vec![InventoryVector {
-                kind: MSG_BLOCK,
-                hash: block_hash
-            }]
-        );
+        assert_fallback_getdata(&mut client, block_hash);
     }
 
     #[test]
@@ -4201,16 +4196,7 @@ mod tests {
         let msg = session.read_message().expect("read ready ping");
         assert_eq!(msg.command, "ping");
         assert!(session.compact_outstanding.is_none());
-        let fallback = read_message_from(&mut client, network_magic("devnet"), MAX_RELAY_MSG_BYTES)
-            .expect("read ready-frame fallback getdata");
-        assert_eq!(fallback.command, MESSAGE_GETDATA);
-        assert_eq!(
-            decode_inventory_vectors(&fallback.payload).expect("decode ready fallback inventory"),
-            vec![InventoryVector {
-                kind: MSG_BLOCK,
-                hash: block_hash
-            }]
-        );
+        assert_fallback_getdata(&mut client, block_hash);
     }
 
     #[test]
@@ -4223,6 +4209,9 @@ mod tests {
         let mut req = compact_outstanding_test_request(block_hash);
         req.expires_at = Instant::now() + Duration::from_millis(30);
         session.compact_outstanding = Some(req);
+        let header =
+            build_envelope_header(network_magic("devnet"), "ping", &[]).expect("ping header");
+        client.write_all(&header[..1]).expect("write partial ping");
 
         let reader = thread::spawn(move || {
             let msg = session
@@ -4232,21 +4221,9 @@ mod tests {
             assert!(session.compact_outstanding.is_none());
         });
 
-        let fallback = read_message_from(&mut client, network_magic("devnet"), MAX_RELAY_MSG_BYTES)
-            .expect("read expiry-bounded fallback getdata");
-        assert_eq!(fallback.command, MESSAGE_GETDATA);
-        assert_eq!(
-            decode_inventory_vectors(&fallback.payload)
-                .expect("decode expiry-bounded fallback inventory"),
-            vec![InventoryVector {
-                kind: MSG_BLOCK,
-                hash: block_hash
-            }]
-        );
-        let header =
-            build_envelope_header(network_magic("devnet"), "ping", &[]).expect("ping header");
+        assert_fallback_getdata(&mut client, block_hash);
         client
-            .write_all(&header)
+            .write_all(&header[1..])
             .expect("write ping after fallback");
         reader.join().expect("read_message thread");
     }


### PR DESCRIPTION
Scope
- RUB-395 only.
- File: `clients/rust/crates/rubin-node/src/p2p_runtime.rs`.
- Invariant: an expired active compact request sends a `getdata` fallback for `MSG_BLOCK`, clears active outstanding state, and keeps the read loop able to receive the fallback response without losing a partially consumed frame.
- Non-scope: late `blocktxn` classification is RUB-396; DA/getdachunk is RUB-403.

Matrix
| Required parity case | Go reference | Go callsite | Rust entrypoint | Rust mirror test evidence |
| --- | --- | --- | --- | --- |
| idle expiry fallback | `handleExpiredCompactOutstanding` / `sendExpiredCompactOutstandingFallback` | Go peer loop checks fallback before frame read | `poll_read_ready` at `clients/rust/crates/rubin-node/src/p2p_runtime.rs:424` | `compact_fallback_poll_read_ready_emits_expired_fallback` at `clients/rust/crates/rubin-node/src/p2p_runtime.rs:4175`. |
| prefetched byte expires before frame consumption | `recordExpiredFallback` around Go frame handling | Go peer loop checks fallback before/around each frame | `read_message_with_timeout` at `clients/rust/crates/rubin-node/src/p2p_runtime.rs:454` | `compact_fallback_read_message_with_ready_frame_emits_expired_fallback` at `clients/rust/crates/rubin-node/src/p2p_runtime.rs:4190`. |
| expiry after first byte while frame continues | `compactFallbackReader.Read` | Go reader emits fallback on timeout and continues after partial progress | `CompactFallbackFrameReader` at `clients/rust/crates/rubin-node/src/p2p_runtime.rs:1490` | `compact_fallback_read_message_continues_after_expiry_fallback` at `clients/rust/crates/rubin-node/src/p2p_runtime.rs:4214`. |
| ready readable frame after expiry | `recordExpiredFallback` before Go frame read | Go reader checks expiry before each frame read | `CompactFallbackFrameReader::read` at `clients/rust/crates/rubin-node/src/p2p_runtime.rs:1513` | `compact_fallback_frame_reader_sends_expired_fallback_before_ready_read` at `clients/rust/crates/rubin-node/src/p2p_runtime.rs:4243`. |
| state clear on expiry fallback | `popExpiredCompactOutstandingBlockHashAndPayloadCap` | Go fallback pop clears active outstanding request | `pop_expired_compact_outstanding` at `clients/rust/crates/rubin-node/src/p2p_runtime.rs:1715` | compact fallback tests assert cleared active state after fallback. |
| no duplicate post-fallback wait | Go reader continues with one normal read deadline after fallback | unresponsive peer should not consume two full read deadlines after fallback | `poll_read_ready` returns immediately when it sends fallback at `clients/rust/crates/rubin-node/src/p2p_runtime.rs:428` | `compact_fallback_poll_read_ready_emits_expired_fallback` covers immediate `false` after fallback. |
| no late blocktxn policy | RUB-396 reference matrix owns late `blocktxn` | late frame classification after fallback | not changed in RUB-395 | RUB-395 diff does not add late `blocktxn` handling; RUB-396 owns that thread. |

Evidence
- Head: `deea80e9d861e44880185962dbfbbfd91fc5838d`.
- PR delta against `origin/main`: `clients/rust/crates/rubin-node/src/p2p_runtime.rs`, 254 insertions / 41 deletions.
- `scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test -p rubin-node compact_fallback --lib'` PASS.
- `scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo fmt --check'` PASS.
- `scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo clippy --workspace --all-targets -- -D warnings'` PASS.
- `git diff --check` PASS.
- `scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test -p rubin-node --lib'` PASS.
- `scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test --workspace'` PASS.
- `RUBIN_LINEAR_ISSUE=RUB-395 python3 common-preflight/rubin_parity_matrix_gate.py --mode pre-push` PASS.
- `RUBIN_LINEAR_ISSUE=RUB-395 python3 common-preflight/rubin_parity_matrix_gate.py --mode pr-body` PASS.
- `rubin-precommit-one-review --base-ref origin/main --include-base-diff` PASS.
- `rubin-push --small-fix-fast-path -- origin HEAD` PASS; local coverage preflight variation -0.01%, diff coverage 100.00%, Codacy baseline parity PASS.