### PR TITLE
[Q-RUST-P2P-DA-STATE-CONTAINER-CAPS-01] Add Rust DA relay state container and caps foundation

### DIFF
--- a/clients/rust/crates/rubin-node/src/da_relay.rs
+++ b/clients/rust/crates/rubin-node/src/da_relay.rs
@@ -1,0 +1,239 @@
+use std::collections::BTreeMap;
+
+use rubin_consensus::constants::MAX_DA_BATCHES_PER_BLOCK;
+
+pub const DA_ORPHAN_POOL_BYTES: u64 = 64 << 20;
+pub const DA_ORPHAN_POOL_PER_PEER_BYTES: u64 = 4 << 20;
+pub const DA_ORPHAN_POOL_PER_DA_ID_BYTES: u64 = 8 << 20;
+pub const DA_ORPHAN_COMMIT_OVERHEAD_BYTES: u64 = 8 << 20;
+pub const DA_ORPHAN_TTL_BLOCKS: u64 = 3;
+pub const DA_PINNED_PAYLOAD_BYTES: u64 = 96_000_000;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DaRelayCaps {
+    pub orphan_pool_bytes: u64,
+    pub orphan_pool_per_peer_bytes: u64,
+    pub orphan_pool_per_da_id_bytes: u64,
+    pub orphan_commit_overhead_bytes: u64,
+    pub orphan_ttl_blocks: u64,
+    pub pinned_payload_bytes: u64,
+    pub max_complete_sets: u64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DaRelayError {
+    OrphanPoolBytesZero,
+    OrphanPoolPerPeerBytesZero,
+    OrphanPoolPerDaIdBytesZero,
+    OrphanCommitOverheadBytesZero,
+    OrphanTtlBlocksZero,
+    PinnedPayloadBytesZero,
+    MaxCompleteSetsZero,
+    OrphanPoolPerPeerExceedsGlobal,
+    OrphanPoolPerDaIdExceedsGlobal,
+    OrphanCommitOverheadExceedsGlobal,
+    AccountingUnderflow,
+    AccountingOverflow,
+    AccountingCapExceeded,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DaRelayState {
+    pub caps: DaRelayCaps,
+    next_received_time: u64,
+    orphan_bytes: u64,
+    orphan_bytes_by_peer: BTreeMap<Vec<u8>, u64>,
+    orphan_bytes_by_da_id: BTreeMap<[u8; 32], u64>,
+    orphan_commit_overhead_bytes: u64,
+    pinned_payload_bytes: u64,
+    sets_by_da_id: BTreeMap<[u8; 32], ()>,
+}
+
+impl Default for DaRelayCaps {
+    fn default() -> Self {
+        Self {
+            orphan_pool_bytes: DA_ORPHAN_POOL_BYTES,
+            orphan_pool_per_peer_bytes: DA_ORPHAN_POOL_PER_PEER_BYTES,
+            orphan_pool_per_da_id_bytes: DA_ORPHAN_POOL_PER_DA_ID_BYTES,
+            orphan_commit_overhead_bytes: DA_ORPHAN_COMMIT_OVERHEAD_BYTES,
+            orphan_ttl_blocks: DA_ORPHAN_TTL_BLOCKS,
+            pinned_payload_bytes: DA_PINNED_PAYLOAD_BYTES,
+            max_complete_sets: MAX_DA_BATCHES_PER_BLOCK,
+        }
+    }
+}
+
+impl DaRelayCaps {
+    pub fn validate(self) -> Result<(), DaRelayError> {
+        macro_rules! reject_zero {
+            ($field:ident, $err:expr) => {
+                if self.$field == 0 {
+                    return Err($err);
+                }
+            };
+        }
+        reject_zero!(orphan_pool_bytes, DaRelayError::OrphanPoolBytesZero);
+        reject_zero!(
+            orphan_pool_per_peer_bytes,
+            DaRelayError::OrphanPoolPerPeerBytesZero
+        );
+        reject_zero!(
+            orphan_pool_per_da_id_bytes,
+            DaRelayError::OrphanPoolPerDaIdBytesZero
+        );
+        reject_zero!(
+            orphan_commit_overhead_bytes,
+            DaRelayError::OrphanCommitOverheadBytesZero
+        );
+        reject_zero!(orphan_ttl_blocks, DaRelayError::OrphanTtlBlocksZero);
+        reject_zero!(pinned_payload_bytes, DaRelayError::PinnedPayloadBytesZero);
+        reject_zero!(max_complete_sets, DaRelayError::MaxCompleteSetsZero);
+        if self.orphan_pool_per_peer_bytes > self.orphan_pool_bytes {
+            return Err(DaRelayError::OrphanPoolPerPeerExceedsGlobal);
+        }
+        if self.orphan_pool_per_da_id_bytes > self.orphan_pool_bytes {
+            return Err(DaRelayError::OrphanPoolPerDaIdExceedsGlobal);
+        }
+        if self.orphan_commit_overhead_bytes > self.orphan_pool_bytes {
+            return Err(DaRelayError::OrphanCommitOverheadExceedsGlobal);
+        }
+        Ok(())
+    }
+}
+
+impl DaRelayState {
+    pub fn new(caps: DaRelayCaps) -> Result<Self, DaRelayError> {
+        caps.validate()?;
+        Ok(Self {
+            caps,
+            next_received_time: 0,
+            orphan_bytes: 0,
+            orphan_bytes_by_peer: BTreeMap::new(),
+            orphan_bytes_by_da_id: BTreeMap::new(),
+            orphan_commit_overhead_bytes: 0,
+            pinned_payload_bytes: 0,
+            sets_by_da_id: BTreeMap::new(),
+        })
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.next_received_time == 0
+            && self.orphan_bytes == 0
+            && self.orphan_bytes_by_peer.is_empty()
+            && self.orphan_bytes_by_da_id.is_empty()
+            && self.orphan_commit_overhead_bytes == 0
+            && self.pinned_payload_bytes == 0
+            && self.sets_by_da_id.is_empty()
+    }
+
+    pub fn project_counter(
+        current: u64,
+        remove: u64,
+        add: u64,
+        cap: u64,
+    ) -> Result<u64, DaRelayError> {
+        let after_remove = current
+            .checked_sub(remove)
+            .ok_or(DaRelayError::AccountingUnderflow)?;
+        let next = after_remove
+            .checked_add(add)
+            .ok_or(DaRelayError::AccountingOverflow)?;
+        if next > cap {
+            return Err(DaRelayError::AccountingCapExceeded);
+        }
+        Ok(next)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn da_relay_default_caps_match_go_reference() {
+        let caps = DaRelayCaps::default();
+
+        assert_eq!(caps.orphan_pool_bytes, 64 << 20);
+        assert_eq!(caps.orphan_pool_per_peer_bytes, 4 << 20);
+        assert_eq!(caps.orphan_pool_per_da_id_bytes, 8 << 20);
+        assert_eq!(caps.orphan_commit_overhead_bytes, 8 << 20);
+        assert_eq!(caps.orphan_ttl_blocks, 3);
+        assert_eq!(caps.pinned_payload_bytes, 96_000_000);
+        assert_eq!(caps.max_complete_sets, MAX_DA_BATCHES_PER_BLOCK);
+    }
+
+    #[test]
+    fn da_relay_rejects_invalid_caps() {
+        macro_rules! invalid {
+            ($field:ident = $value:expr, $expected:expr) => {{
+                let mut caps = DaRelayCaps::default();
+                caps.$field = $value;
+                let expected = $expected;
+                assert_eq!(caps.validate(), Err(expected));
+                assert_eq!(DaRelayState::new(caps), Err(expected));
+            }};
+        }
+
+        invalid!(orphan_pool_bytes = 0, DaRelayError::OrphanPoolBytesZero);
+        invalid!(
+            orphan_pool_per_peer_bytes = 0,
+            DaRelayError::OrphanPoolPerPeerBytesZero
+        );
+        invalid!(
+            orphan_pool_per_da_id_bytes = 0,
+            DaRelayError::OrphanPoolPerDaIdBytesZero
+        );
+        invalid!(
+            orphan_commit_overhead_bytes = 0,
+            DaRelayError::OrphanCommitOverheadBytesZero
+        );
+        invalid!(orphan_ttl_blocks = 0, DaRelayError::OrphanTtlBlocksZero);
+        invalid!(
+            pinned_payload_bytes = 0,
+            DaRelayError::PinnedPayloadBytesZero
+        );
+        invalid!(max_complete_sets = 0, DaRelayError::MaxCompleteSetsZero);
+        invalid!(
+            orphan_pool_per_peer_bytes = DA_ORPHAN_POOL_BYTES + 1,
+            DaRelayError::OrphanPoolPerPeerExceedsGlobal
+        );
+        invalid!(
+            orphan_pool_per_da_id_bytes = DA_ORPHAN_POOL_BYTES + 1,
+            DaRelayError::OrphanPoolPerDaIdExceedsGlobal
+        );
+        invalid!(
+            orphan_commit_overhead_bytes = DA_ORPHAN_POOL_BYTES + 1,
+            DaRelayError::OrphanCommitOverheadExceedsGlobal
+        );
+    }
+
+    #[test]
+    fn da_relay_state_initializes_empty_accounting_maps() {
+        let caps = DaRelayCaps::default();
+        let state = DaRelayState::new(caps).expect("valid caps");
+
+        assert_eq!(state.caps, caps);
+        assert!(state.is_empty());
+    }
+
+    #[test]
+    fn da_relay_accounting_projection_fails_closed() {
+        for (current, remove, add, cap, expected) in [
+            (0, 1, 0, 10, Err(DaRelayError::AccountingUnderflow)),
+            (
+                u64::MAX,
+                0,
+                1,
+                u64::MAX,
+                Err(DaRelayError::AccountingOverflow),
+            ),
+            (9, 0, 2, 10, Err(DaRelayError::AccountingCapExceeded)),
+            (9, 4, 2, 10, Ok(7)),
+        ] {
+            assert_eq!(
+                DaRelayState::project_counter(current, remove, add, cap),
+                expected
+            );
+        }
+    }
+}

--- a/clients/rust/crates/rubin-node/src/da_relay.rs
+++ b/clients/rust/crates/rubin-node/src/da_relay.rs
@@ -42,7 +42,7 @@ pub struct DaRelayState {
     caps: DaRelayCaps,
     next_received_time: u64,
     orphan_bytes: u64,
-    orphan_bytes_by_peer: BTreeMap<String, u64>,
+    orphan_bytes_by_peer_quota_key: BTreeMap<String, u64>,
     orphan_bytes_by_da_id: BTreeMap<[u8; 32], u64>,
     orphan_commit_overhead_bytes: u64,
     pinned_payload_bytes: u64,
@@ -108,7 +108,7 @@ impl DaRelayState {
             caps,
             next_received_time: 0,
             orphan_bytes: 0,
-            orphan_bytes_by_peer: BTreeMap::new(),
+            orphan_bytes_by_peer_quota_key: BTreeMap::new(),
             orphan_bytes_by_da_id: BTreeMap::new(),
             orphan_commit_overhead_bytes: 0,
             pinned_payload_bytes: 0,
@@ -123,7 +123,7 @@ impl DaRelayState {
     pub fn is_empty(&self) -> bool {
         self.next_received_time == 0
             && self.orphan_bytes == 0
-            && self.orphan_bytes_by_peer.is_empty()
+            && self.orphan_bytes_by_peer_quota_key.is_empty()
             && self.orphan_bytes_by_da_id.is_empty()
             && self.orphan_commit_overhead_bytes == 0
             && self.pinned_payload_bytes == 0

--- a/clients/rust/crates/rubin-node/src/da_relay.rs
+++ b/clients/rust/crates/rubin-node/src/da_relay.rs
@@ -39,7 +39,7 @@ pub enum DaRelayError {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DaRelayState {
-    pub caps: DaRelayCaps,
+    caps: DaRelayCaps,
     next_received_time: u64,
     orphan_bytes: u64,
     orphan_bytes_by_peer: BTreeMap<Vec<u8>, u64>,
@@ -116,6 +116,10 @@ impl DaRelayState {
         })
     }
 
+    pub fn caps(&self) -> DaRelayCaps {
+        self.caps
+    }
+
     pub fn is_empty(&self) -> bool {
         self.next_received_time == 0
             && self.orphan_bytes == 0
@@ -148,6 +152,7 @@ impl DaRelayState {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use DaRelayError::*;
 
     #[test]
     fn da_relay_default_caps_match_go_reference() {
@@ -174,36 +179,27 @@ mod tests {
             }};
         }
 
-        invalid!(orphan_pool_bytes = 0, DaRelayError::OrphanPoolBytesZero);
-        invalid!(
-            orphan_pool_per_peer_bytes = 0,
-            DaRelayError::OrphanPoolPerPeerBytesZero
-        );
-        invalid!(
-            orphan_pool_per_da_id_bytes = 0,
-            DaRelayError::OrphanPoolPerDaIdBytesZero
-        );
+        invalid!(orphan_pool_bytes = 0, OrphanPoolBytesZero);
+        invalid!(orphan_pool_per_peer_bytes = 0, OrphanPoolPerPeerBytesZero);
+        invalid!(orphan_pool_per_da_id_bytes = 0, OrphanPoolPerDaIdBytesZero);
         invalid!(
             orphan_commit_overhead_bytes = 0,
-            DaRelayError::OrphanCommitOverheadBytesZero
+            OrphanCommitOverheadBytesZero
         );
-        invalid!(orphan_ttl_blocks = 0, DaRelayError::OrphanTtlBlocksZero);
-        invalid!(
-            pinned_payload_bytes = 0,
-            DaRelayError::PinnedPayloadBytesZero
-        );
-        invalid!(max_complete_sets = 0, DaRelayError::MaxCompleteSetsZero);
+        invalid!(orphan_ttl_blocks = 0, OrphanTtlBlocksZero);
+        invalid!(pinned_payload_bytes = 0, PinnedPayloadBytesZero);
+        invalid!(max_complete_sets = 0, MaxCompleteSetsZero);
         invalid!(
             orphan_pool_per_peer_bytes = DA_ORPHAN_POOL_BYTES + 1,
-            DaRelayError::OrphanPoolPerPeerExceedsGlobal
+            OrphanPoolPerPeerExceedsGlobal
         );
         invalid!(
             orphan_pool_per_da_id_bytes = DA_ORPHAN_POOL_BYTES + 1,
-            DaRelayError::OrphanPoolPerDaIdExceedsGlobal
+            OrphanPoolPerDaIdExceedsGlobal
         );
         invalid!(
             orphan_commit_overhead_bytes = DA_ORPHAN_POOL_BYTES + 1,
-            DaRelayError::OrphanCommitOverheadExceedsGlobal
+            OrphanCommitOverheadExceedsGlobal
         );
     }
 
@@ -212,22 +208,16 @@ mod tests {
         let caps = DaRelayCaps::default();
         let state = DaRelayState::new(caps).expect("valid caps");
 
-        assert_eq!(state.caps, caps);
+        assert_eq!(state.caps(), caps);
         assert!(state.is_empty());
     }
 
     #[test]
     fn da_relay_accounting_projection_fails_closed() {
         for (current, remove, add, cap, expected) in [
-            (0, 1, 0, 10, Err(DaRelayError::AccountingUnderflow)),
-            (
-                u64::MAX,
-                0,
-                1,
-                u64::MAX,
-                Err(DaRelayError::AccountingOverflow),
-            ),
-            (9, 0, 2, 10, Err(DaRelayError::AccountingCapExceeded)),
+            (0, 1, 0, 10, Err(AccountingUnderflow)),
+            (u64::MAX, 0, 1, u64::MAX, Err(AccountingOverflow)),
+            (9, 0, 2, 10, Err(AccountingCapExceeded)),
             (9, 4, 2, 10, Ok(7)),
         ] {
             assert_eq!(

--- a/clients/rust/crates/rubin-node/src/da_relay.rs
+++ b/clients/rust/crates/rubin-node/src/da_relay.rs
@@ -37,12 +37,15 @@ pub enum DaRelayError {
     AccountingCapExceeded,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct PeerQuotaKey(String);
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DaRelayState {
     caps: DaRelayCaps,
     next_received_time: u64,
     orphan_bytes: u64,
-    orphan_bytes_by_peer_quota_key: BTreeMap<String, u64>,
+    orphan_bytes_by_peer_quota_key: BTreeMap<PeerQuotaKey, u64>,
     orphan_bytes_by_da_id: BTreeMap<[u8; 32], u64>,
     orphan_commit_overhead_bytes: u64,
     pinned_payload_bytes: u64,
@@ -99,6 +102,41 @@ impl DaRelayCaps {
         }
         Ok(())
     }
+}
+
+impl PeerQuotaKey {
+    #[allow(dead_code)]
+    fn from_peer_addr(addr: &str) -> Self {
+        if addr.is_empty() {
+            return Self(String::new());
+        }
+        let host = addr
+            .parse::<std::net::SocketAddr>()
+            .map(|socket_addr| socket_addr.ip().to_string())
+            .unwrap_or_else(|_| split_peer_host(addr).to_owned());
+        let host = strip_ipv6_zone(&host);
+        host.parse::<std::net::IpAddr>()
+            .map(|ip| Self(ip.to_string()))
+            .unwrap_or_else(|_| Self(host.to_owned()))
+    }
+}
+
+#[allow(dead_code)]
+fn split_peer_host(addr: &str) -> &str {
+    if let Some(rest) = addr.strip_prefix('[') {
+        if let Some((host, _port)) = rest.split_once("]:") {
+            return host;
+        }
+    }
+    if addr.matches(':').count() == 1 {
+        return addr.rsplit_once(':').map_or(addr, |(host, _port)| host);
+    }
+    addr
+}
+
+#[allow(dead_code)]
+fn strip_ipv6_zone(host: &str) -> &str {
+    host.split_once('%').map_or(host, |(addr, _zone)| addr)
 }
 
 impl DaRelayState {
@@ -210,6 +248,26 @@ mod tests {
 
         assert_eq!(state.caps(), caps);
         assert!(state.is_empty());
+    }
+
+    #[test]
+    fn peer_quota_key_normalizes_port_variants() {
+        assert_eq!(
+            PeerQuotaKey::from_peer_addr("127.0.0.1:8333"),
+            PeerQuotaKey::from_peer_addr("127.0.0.1:9444")
+        );
+        assert_eq!(
+            PeerQuotaKey::from_peer_addr("[::1]:8333"),
+            PeerQuotaKey("::1".to_owned())
+        );
+        assert_eq!(
+            PeerQuotaKey::from_peer_addr("example.com:8333"),
+            PeerQuotaKey("example.com".to_owned())
+        );
+        assert_eq!(
+            PeerQuotaKey::from_peer_addr(""),
+            PeerQuotaKey(String::new())
+        );
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/da_relay.rs
+++ b/clients/rust/crates/rubin-node/src/da_relay.rs
@@ -171,7 +171,6 @@ mod tests {
             ($($field:ident = $value:expr),+ $(,)?) => {$({
                 let mut caps = DaRelayCaps::default();
                 caps.$field = $value;
-                assert_eq!(caps.validate(), Err(InvalidCaps));
                 assert_eq!(DaRelayState::new(caps), Err(InvalidCaps));
             })+};
         }
@@ -190,9 +189,16 @@ mod tests {
     }
 
     #[test]
-    fn da_relay_state_initializes_empty_accounting_maps() {
-        let mut state = DaRelayState::new(DaRelayCaps::default()).expect("valid caps");
-        assert_eq!(state.next_received_time, 0);
+    fn da_relay_default_caps_match_go_reference() {
+        let caps = DaRelayCaps::default();
+        assert_eq!(caps.orphan_pool_bytes, 64 << 20);
+        assert_eq!(caps.orphan_pool_per_peer_bytes, 4 << 20);
+        assert_eq!(caps.orphan_pool_per_da_id_bytes, 8 << 20);
+        assert_eq!(caps.orphan_commit_overhead_bytes, 8 << 20);
+        assert_eq!(caps.orphan_ttl_blocks, 3);
+        assert_eq!(caps.pinned_payload_bytes, 96_000_000);
+        assert_eq!(caps.max_complete_sets, MAX_DA_BATCHES_PER_BLOCK);
+        let mut state = DaRelayState::new(caps).expect("valid caps");
         assert!(state.is_empty());
         state.next_received_time = 1;
         assert!(state.is_empty());
@@ -210,10 +216,8 @@ mod tests {
             ("fe80::1%en0", "fe80::1"),
             ("[fe80::1%en0]:8333", "fe80::1"),
             ("example.com:8333", "example.com"),
-            ("[example.com]:8333", "example.com"),
             ("example.com", "example.com"),
             ("example.com%zone:8333", "example.com%zone"),
-            ("[example.com%zone]:8333", "example.com%zone"),
             ("example.com%zone", "example.com%zone"),
         ] {
             assert_eq!(PeerQuotaKey::from_peer_addr(addr).0, expected);
@@ -222,16 +226,14 @@ mod tests {
 
     #[test]
     fn da_relay_accounting_projection_fails_closed() {
+        let project_counter = DaRelayState::project_counter;
         for (current, remove, add, cap, expected) in [
             (0, 1, 0, 10, Err(AccountingUnderflow)),
             (u64::MAX, 0, 1, u64::MAX, Err(AccountingOverflow)),
             (9, 0, 2, 10, Err(AccountingCapExceeded)),
             (9, 4, 2, 10, Ok(7)),
         ] {
-            assert_eq!(
-                DaRelayState::project_counter(current, remove, add, cap),
-                expected
-            );
+            assert_eq!(project_counter(current, remove, add, cap), expected);
         }
     }
 }

--- a/clients/rust/crates/rubin-node/src/da_relay.rs
+++ b/clients/rust/crates/rubin-node/src/da_relay.rs
@@ -42,7 +42,7 @@ pub struct DaRelayState {
     caps: DaRelayCaps,
     next_received_time: u64,
     orphan_bytes: u64,
-    orphan_bytes_by_peer: BTreeMap<Vec<u8>, u64>,
+    orphan_bytes_by_peer: BTreeMap<String, u64>,
     orphan_bytes_by_da_id: BTreeMap<[u8; 32], u64>,
     orphan_commit_overhead_bytes: u64,
     pinned_payload_bytes: u64,

--- a/clients/rust/crates/rubin-node/src/da_relay.rs
+++ b/clients/rust/crates/rubin-node/src/da_relay.rs
@@ -88,7 +88,7 @@ impl PeerQuotaKey {
 fn split_peer_host(addr: &str) -> &str {
     if let Some(rest) = addr.strip_prefix('[') {
         if let Some((host, port)) = rest.rsplit_once("]:") {
-            if !host.contains(']') && !port.contains(':') && !port.contains(['[', ']']) {
+            if !host.contains(['[', ']']) && !port.contains(':') && !port.contains(['[', ']']) {
                 return host;
             }
         }
@@ -216,6 +216,7 @@ mod tests {
             ("[fe80::1%en0]:", "fe80::1"),
             ("[fe80::1%]:8333", "fe80::1%"),
             ("[example.com%zone]:8333", "example.com%zone"),
+            ("[a[b]:8333", "[a[b]:8333"),
             ("example[.com]:8333", "example[.com]:8333"),
             ("example.com%zone:8333", "example.com%zone"),
         ] {

--- a/clients/rust/crates/rubin-node/src/da_relay.rs
+++ b/clients/rust/crates/rubin-node/src/da_relay.rs
@@ -38,7 +38,7 @@ pub enum DaRelayError {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
-struct PeerQuotaKey(String);
+pub struct PeerQuotaKey(String);
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DaRelayState {
@@ -105,8 +105,7 @@ impl DaRelayCaps {
 }
 
 impl PeerQuotaKey {
-    #[allow(dead_code)]
-    fn from_peer_addr(addr: &str) -> Self {
+    pub fn from_peer_addr(addr: &str) -> Self {
         if addr.is_empty() {
             return Self(String::new());
         }
@@ -121,7 +120,6 @@ impl PeerQuotaKey {
     }
 }
 
-#[allow(dead_code)]
 fn split_peer_host(addr: &str) -> &str {
     if let Some(rest) = addr.strip_prefix('[') {
         if let Some((host, _port)) = rest.split_once("]:") {
@@ -134,7 +132,6 @@ fn split_peer_host(addr: &str) -> &str {
     addr
 }
 
-#[allow(dead_code)]
 fn strip_ipv6_zone(host: &str) -> &str {
     host.split_once('%').map_or(host, |(addr, _zone)| addr)
 }

--- a/clients/rust/crates/rubin-node/src/da_relay.rs
+++ b/clients/rust/crates/rubin-node/src/da_relay.rs
@@ -258,7 +258,19 @@ mod tests {
             PeerQuotaKey("::1".to_owned())
         );
         assert_eq!(
+            PeerQuotaKey::from_peer_addr("[fe80::1%en0]:8333"),
+            PeerQuotaKey("fe80::1".to_owned())
+        );
+        assert_eq!(
+            PeerQuotaKey::from_peer_addr("fe80::1%en0"),
+            PeerQuotaKey("fe80::1".to_owned())
+        );
+        assert_eq!(
             PeerQuotaKey::from_peer_addr("example.com:8333"),
+            PeerQuotaKey("example.com".to_owned())
+        );
+        assert_eq!(
+            PeerQuotaKey::from_peer_addr("example.com"),
             PeerQuotaKey("example.com".to_owned())
         );
         assert_eq!(

--- a/clients/rust/crates/rubin-node/src/da_relay.rs
+++ b/clients/rust/crates/rubin-node/src/da_relay.rs
@@ -1,7 +1,5 @@
 use std::collections::BTreeMap;
-use std::net::{IpAddr, SocketAddr};
-
-use rubin_consensus::constants::MAX_DA_BATCHES_PER_BLOCK;
+use std::net::{IpAddr, Ipv6Addr};
 
 pub const DA_ORPHAN_POOL_BYTES: u64 = 64 << 20;
 pub const DA_ORPHAN_POOL_PER_PEER_BYTES: u64 = 4 << 20;
@@ -12,13 +10,12 @@ pub const DA_PINNED_PAYLOAD_BYTES: u64 = 96_000_000;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct DaRelayCaps {
-    pub orphan_pool_bytes: u64,
-    pub orphan_pool_per_peer_bytes: u64,
-    pub orphan_pool_per_da_id_bytes: u64,
-    pub orphan_commit_overhead_bytes: u64,
-    pub orphan_ttl_blocks: u64,
-    pub pinned_payload_bytes: u64,
-    pub max_complete_sets: u64,
+    orphan_pool_bytes: u64,
+    orphan_pool_per_peer_bytes: u64,
+    orphan_pool_per_da_id_bytes: u64,
+    orphan_commit_overhead_bytes: u64,
+    orphan_ttl_blocks: u64,
+    pinned_payload_bytes: u64,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -32,6 +29,7 @@ pub enum DaRelayError {
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct PeerQuotaKey(String);
 
+/// Foundation container; future mutation paths need exclusive access or owner-side synchronization.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DaRelayState {
     caps: DaRelayCaps,
@@ -53,7 +51,6 @@ impl Default for DaRelayCaps {
             orphan_commit_overhead_bytes: DA_ORPHAN_COMMIT_OVERHEAD_BYTES,
             orphan_ttl_blocks: DA_ORPHAN_TTL_BLOCKS,
             pinned_payload_bytes: DA_PINNED_PAYLOAD_BYTES,
-            max_complete_sets: MAX_DA_BATCHES_PER_BLOCK,
         }
     }
 }
@@ -67,7 +64,6 @@ impl DaRelayCaps {
             self.orphan_commit_overhead_bytes,
             self.orphan_ttl_blocks,
             self.pinned_payload_bytes,
-            self.max_complete_sets,
         ]
         .contains(&0)
             || self.orphan_pool_per_peer_bytes > self.orphan_pool_bytes
@@ -85,22 +81,23 @@ impl PeerQuotaKey {
         if addr.is_empty() {
             return Self(String::new());
         }
-        let host = addr
-            .parse::<SocketAddr>()
-            .map(|socket_addr| socket_addr.ip().to_string())
-            .unwrap_or_else(|_| split_peer_host(addr).to_owned());
-        Self(normalize_peer_host(&host))
+        Self(normalize_peer_host(split_peer_host(addr)))
     }
 }
 
 fn split_peer_host(addr: &str) -> &str {
     if let Some(rest) = addr.strip_prefix('[') {
-        if let Some((host, _port)) = rest.split_once("]:") {
-            return host;
+        if let Some((host, port)) = rest.rsplit_once("]:") {
+            if !host.contains(']') && !port.contains(':') && !port.contains(['[', ']']) {
+                return host;
+            }
         }
+        return addr;
     }
-    if addr.matches(':').count() == 1 {
-        return addr.rsplit_once(':').map_or(addr, |(host, _port)| host);
+    if let Some((host, _port)) = addr.rsplit_once(':').filter(|(host, port)| {
+        !host.contains(':') && !host.contains(['[', ']']) && !port.contains(['[', ']'])
+    }) {
+        return host;
     }
     addr
 }
@@ -109,11 +106,9 @@ fn normalize_peer_host(host: &str) -> String {
     if let Ok(ip) = host.parse::<IpAddr>() {
         return ip.to_string();
     }
-    if host.contains(':') {
-        if let Some((without_zone, _zone)) = host.split_once('%') {
-            if let Ok(ip) = without_zone.parse::<IpAddr>() {
-                return ip.to_string();
-            }
+    if let Some((without_zone, _zone)) = host.split_once('%').filter(|(_, zone)| !zone.is_empty()) {
+        if let Ok(ip) = without_zone.parse::<Ipv6Addr>() {
+            return ip.to_string();
         }
     }
     host.to_owned()
@@ -143,12 +138,8 @@ impl DaRelayState {
             && self.sets_by_da_id.is_empty()
     }
 
-    pub fn project_counter(
-        current: u64,
-        remove: u64,
-        add: u64,
-        cap: u64,
-    ) -> Result<u64, DaRelayError> {
+    #[allow(dead_code)]
+    fn project_counter(current: u64, remove: u64, add: u64, cap: u64) -> Result<u64, DaRelayError> {
         let next = current
             .checked_sub(remove)
             .ok_or(DaRelayError::AccountingUnderflow)?
@@ -181,7 +172,6 @@ mod tests {
             orphan_commit_overhead_bytes = 0,
             orphan_ttl_blocks = 0,
             pinned_payload_bytes = 0,
-            max_complete_sets = 0,
             orphan_pool_per_peer_bytes = DA_ORPHAN_POOL_BYTES + 1,
             orphan_pool_per_da_id_bytes = DA_ORPHAN_POOL_BYTES + 1,
             orphan_commit_overhead_bytes = DA_ORPHAN_POOL_BYTES + 1,
@@ -197,7 +187,6 @@ mod tests {
         assert_eq!(caps.orphan_commit_overhead_bytes, 8 << 20);
         assert_eq!(caps.orphan_ttl_blocks, 3);
         assert_eq!(caps.pinned_payload_bytes, 96_000_000);
-        assert_eq!(caps.max_complete_sets, MAX_DA_BATCHES_PER_BLOCK);
         let mut state = DaRelayState::new(caps).expect("valid caps");
         assert!(state.is_empty());
         state.next_received_time = 1;
@@ -209,16 +198,26 @@ mod tests {
         for (addr, expected) in [
             ("", ""),
             ("127.0.0.1:8333", "127.0.0.1"),
-            ("127.0.0.1:9444", "127.0.0.1"),
+            ("127.0.0.1:65536", "127.0.0.1"),
             ("127.0.0.1%zone:8333", "127.0.0.1%zone"),
-            ("[::1]:8333", "::1"),
-            ("fe80::1", "fe80::1"),
-            ("fe80::1%en0", "fe80::1"),
-            ("[fe80::1%en0]:8333", "fe80::1"),
+            (":8333", ""),
             ("example.com:8333", "example.com"),
-            ("example.com", "example.com"),
+            ("example.com:", "example.com"),
+            ("[::1]:8333", "::1"),
+            ("[::1]:", "::1"),
+            ("[::1]:https", "::1"),
+            ("[::1]:65536", "::1"),
+            ("[::1]:8333:extra", "[::1]:8333:extra"),
+            ("[::1]:8333]", "[::1]:8333]"),
+            ("fe80::1%en0", "fe80::1"),
+            ("fe80::1%", "fe80::1%"),
+            ("fe80::1%en0:8333", "fe80::1"),
+            ("[fe80::1%en0]:8333", "fe80::1"),
+            ("[fe80::1%en0]:", "fe80::1"),
+            ("[fe80::1%]:8333", "fe80::1%"),
+            ("[example.com%zone]:8333", "example.com%zone"),
+            ("example[.com]:8333", "example[.com]:8333"),
             ("example.com%zone:8333", "example.com%zone"),
-            ("example.com%zone", "example.com%zone"),
         ] {
             assert_eq!(PeerQuotaKey::from_peer_addr(addr).0, expected);
         }

--- a/clients/rust/crates/rubin-node/src/da_relay.rs
+++ b/clients/rust/crates/rubin-node/src/da_relay.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::net::{IpAddr, SocketAddr};
 
 use rubin_consensus::constants::MAX_DA_BATCHES_PER_BLOCK;
 
@@ -22,16 +23,7 @@ pub struct DaRelayCaps {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum DaRelayError {
-    OrphanPoolBytesZero,
-    OrphanPoolPerPeerBytesZero,
-    OrphanPoolPerDaIdBytesZero,
-    OrphanCommitOverheadBytesZero,
-    OrphanTtlBlocksZero,
-    PinnedPayloadBytesZero,
-    MaxCompleteSetsZero,
-    OrphanPoolPerPeerExceedsGlobal,
-    OrphanPoolPerDaIdExceedsGlobal,
-    OrphanCommitOverheadExceedsGlobal,
+    InvalidCaps,
     AccountingUnderflow,
     AccountingOverflow,
     AccountingCapExceeded,
@@ -68,37 +60,21 @@ impl Default for DaRelayCaps {
 
 impl DaRelayCaps {
     pub fn validate(self) -> Result<(), DaRelayError> {
-        macro_rules! reject_zero {
-            ($field:ident, $err:expr) => {
-                if self.$field == 0 {
-                    return Err($err);
-                }
-            };
-        }
-        reject_zero!(orphan_pool_bytes, DaRelayError::OrphanPoolBytesZero);
-        reject_zero!(
-            orphan_pool_per_peer_bytes,
-            DaRelayError::OrphanPoolPerPeerBytesZero
-        );
-        reject_zero!(
-            orphan_pool_per_da_id_bytes,
-            DaRelayError::OrphanPoolPerDaIdBytesZero
-        );
-        reject_zero!(
-            orphan_commit_overhead_bytes,
-            DaRelayError::OrphanCommitOverheadBytesZero
-        );
-        reject_zero!(orphan_ttl_blocks, DaRelayError::OrphanTtlBlocksZero);
-        reject_zero!(pinned_payload_bytes, DaRelayError::PinnedPayloadBytesZero);
-        reject_zero!(max_complete_sets, DaRelayError::MaxCompleteSetsZero);
-        if self.orphan_pool_per_peer_bytes > self.orphan_pool_bytes {
-            return Err(DaRelayError::OrphanPoolPerPeerExceedsGlobal);
-        }
-        if self.orphan_pool_per_da_id_bytes > self.orphan_pool_bytes {
-            return Err(DaRelayError::OrphanPoolPerDaIdExceedsGlobal);
-        }
-        if self.orphan_commit_overhead_bytes > self.orphan_pool_bytes {
-            return Err(DaRelayError::OrphanCommitOverheadExceedsGlobal);
+        if [
+            self.orphan_pool_bytes,
+            self.orphan_pool_per_peer_bytes,
+            self.orphan_pool_per_da_id_bytes,
+            self.orphan_commit_overhead_bytes,
+            self.orphan_ttl_blocks,
+            self.pinned_payload_bytes,
+            self.max_complete_sets,
+        ]
+        .contains(&0)
+            || self.orphan_pool_per_peer_bytes > self.orphan_pool_bytes
+            || self.orphan_pool_per_da_id_bytes > self.orphan_pool_bytes
+            || self.orphan_commit_overhead_bytes > self.orphan_pool_bytes
+        {
+            return Err(DaRelayError::InvalidCaps);
         }
         Ok(())
     }
@@ -110,13 +86,10 @@ impl PeerQuotaKey {
             return Self(String::new());
         }
         let host = addr
-            .parse::<std::net::SocketAddr>()
+            .parse::<SocketAddr>()
             .map(|socket_addr| socket_addr.ip().to_string())
             .unwrap_or_else(|_| split_peer_host(addr).to_owned());
-        let host = strip_ipv6_zone(&host);
-        host.parse::<std::net::IpAddr>()
-            .map(|ip| Self(ip.to_string()))
-            .unwrap_or_else(|_| Self(host.to_owned()))
+        Self(normalize_peer_host(&host))
     }
 }
 
@@ -132,8 +105,18 @@ fn split_peer_host(addr: &str) -> &str {
     addr
 }
 
-fn strip_ipv6_zone(host: &str) -> &str {
-    host.split_once('%').map_or(host, |(addr, _zone)| addr)
+fn normalize_peer_host(host: &str) -> String {
+    if let Ok(ip) = host.parse::<IpAddr>() {
+        return ip.to_string();
+    }
+    if host.contains(':') {
+        if let Some((without_zone, _zone)) = host.split_once('%') {
+            if let Ok(ip) = without_zone.parse::<IpAddr>() {
+                return ip.to_string();
+            }
+        }
+    }
+    host.to_owned()
 }
 
 impl DaRelayState {
@@ -151,13 +134,8 @@ impl DaRelayState {
         })
     }
 
-    pub fn caps(&self) -> DaRelayCaps {
-        self.caps
-    }
-
     pub fn is_empty(&self) -> bool {
-        self.next_received_time == 0
-            && self.orphan_bytes == 0
+        self.orphan_bytes == 0
             && self.orphan_bytes_by_peer_quota_key.is_empty()
             && self.orphan_bytes_by_da_id.is_empty()
             && self.orphan_commit_overhead_bytes == 0
@@ -171,10 +149,9 @@ impl DaRelayState {
         add: u64,
         cap: u64,
     ) -> Result<u64, DaRelayError> {
-        let after_remove = current
+        let next = current
             .checked_sub(remove)
-            .ok_or(DaRelayError::AccountingUnderflow)?;
-        let next = after_remove
+            .ok_or(DaRelayError::AccountingUnderflow)?
             .checked_add(add)
             .ok_or(DaRelayError::AccountingOverflow)?;
         if next > cap {
@@ -186,97 +163,61 @@ impl DaRelayState {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use DaRelayError::*;
-
-    #[test]
-    fn da_relay_default_caps_match_go_reference() {
-        let caps = DaRelayCaps::default();
-
-        assert_eq!(caps.orphan_pool_bytes, 64 << 20);
-        assert_eq!(caps.orphan_pool_per_peer_bytes, 4 << 20);
-        assert_eq!(caps.orphan_pool_per_da_id_bytes, 8 << 20);
-        assert_eq!(caps.orphan_commit_overhead_bytes, 8 << 20);
-        assert_eq!(caps.orphan_ttl_blocks, 3);
-        assert_eq!(caps.pinned_payload_bytes, 96_000_000);
-        assert_eq!(caps.max_complete_sets, MAX_DA_BATCHES_PER_BLOCK);
-    }
+    use super::{DaRelayError::*, *};
 
     #[test]
     fn da_relay_rejects_invalid_caps() {
-        macro_rules! invalid {
-            ($field:ident = $value:expr, $expected:expr) => {{
+        macro_rules! invalid_caps {
+            ($($field:ident = $value:expr),+ $(,)?) => {$({
                 let mut caps = DaRelayCaps::default();
                 caps.$field = $value;
-                let expected = $expected;
-                assert_eq!(caps.validate(), Err(expected));
-                assert_eq!(DaRelayState::new(caps), Err(expected));
-            }};
+                assert_eq!(caps.validate(), Err(InvalidCaps));
+                assert_eq!(DaRelayState::new(caps), Err(InvalidCaps));
+            })+};
         }
-
-        invalid!(orphan_pool_bytes = 0, OrphanPoolBytesZero);
-        invalid!(orphan_pool_per_peer_bytes = 0, OrphanPoolPerPeerBytesZero);
-        invalid!(orphan_pool_per_da_id_bytes = 0, OrphanPoolPerDaIdBytesZero);
-        invalid!(
+        invalid_caps!(
+            orphan_pool_bytes = 0,
+            orphan_pool_per_peer_bytes = 0,
+            orphan_pool_per_da_id_bytes = 0,
             orphan_commit_overhead_bytes = 0,
-            OrphanCommitOverheadBytesZero
-        );
-        invalid!(orphan_ttl_blocks = 0, OrphanTtlBlocksZero);
-        invalid!(pinned_payload_bytes = 0, PinnedPayloadBytesZero);
-        invalid!(max_complete_sets = 0, MaxCompleteSetsZero);
-        invalid!(
+            orphan_ttl_blocks = 0,
+            pinned_payload_bytes = 0,
+            max_complete_sets = 0,
             orphan_pool_per_peer_bytes = DA_ORPHAN_POOL_BYTES + 1,
-            OrphanPoolPerPeerExceedsGlobal
-        );
-        invalid!(
             orphan_pool_per_da_id_bytes = DA_ORPHAN_POOL_BYTES + 1,
-            OrphanPoolPerDaIdExceedsGlobal
-        );
-        invalid!(
             orphan_commit_overhead_bytes = DA_ORPHAN_POOL_BYTES + 1,
-            OrphanCommitOverheadExceedsGlobal
         );
     }
 
     #[test]
     fn da_relay_state_initializes_empty_accounting_maps() {
-        let caps = DaRelayCaps::default();
-        let state = DaRelayState::new(caps).expect("valid caps");
-
-        assert_eq!(state.caps(), caps);
+        let mut state = DaRelayState::new(DaRelayCaps::default()).expect("valid caps");
+        assert_eq!(state.next_received_time, 0);
+        assert!(state.is_empty());
+        state.next_received_time = 1;
         assert!(state.is_empty());
     }
 
     #[test]
-    fn peer_quota_key_normalizes_port_variants() {
-        assert_eq!(
-            PeerQuotaKey::from_peer_addr("127.0.0.1:8333"),
-            PeerQuotaKey::from_peer_addr("127.0.0.1:9444")
-        );
-        assert_eq!(
-            PeerQuotaKey::from_peer_addr("[::1]:8333"),
-            PeerQuotaKey("::1".to_owned())
-        );
-        assert_eq!(
-            PeerQuotaKey::from_peer_addr("[fe80::1%en0]:8333"),
-            PeerQuotaKey("fe80::1".to_owned())
-        );
-        assert_eq!(
-            PeerQuotaKey::from_peer_addr("fe80::1%en0"),
-            PeerQuotaKey("fe80::1".to_owned())
-        );
-        assert_eq!(
-            PeerQuotaKey::from_peer_addr("example.com:8333"),
-            PeerQuotaKey("example.com".to_owned())
-        );
-        assert_eq!(
-            PeerQuotaKey::from_peer_addr("example.com"),
-            PeerQuotaKey("example.com".to_owned())
-        );
-        assert_eq!(
-            PeerQuotaKey::from_peer_addr(""),
-            PeerQuotaKey(String::new())
-        );
+    fn peer_quota_key_normalizes_hostile_matrix() {
+        for (addr, expected) in [
+            ("", ""),
+            ("127.0.0.1:8333", "127.0.0.1"),
+            ("127.0.0.1:9444", "127.0.0.1"),
+            ("127.0.0.1%zone:8333", "127.0.0.1%zone"),
+            ("[::1]:8333", "::1"),
+            ("fe80::1", "fe80::1"),
+            ("fe80::1%en0", "fe80::1"),
+            ("[fe80::1%en0]:8333", "fe80::1"),
+            ("example.com:8333", "example.com"),
+            ("[example.com]:8333", "example.com"),
+            ("example.com", "example.com"),
+            ("example.com%zone:8333", "example.com%zone"),
+            ("[example.com%zone]:8333", "example.com%zone"),
+            ("example.com%zone", "example.com%zone"),
+        ] {
+            assert_eq!(PeerQuotaKey::from_peer_addr(addr).0, expected);
+        }
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/lib.rs
+++ b/clients/rust/crates/rubin-node/src/lib.rs
@@ -2,6 +2,7 @@ pub mod blockstore;
 pub mod chainstate;
 mod chainstate_recovery;
 pub mod coinbase;
+pub mod da_relay;
 pub mod devnet_rpc;
 pub mod genesis;
 pub mod interop;


### PR DESCRIPTION
## Issue Scope

RUB-414 / GitHub #1876: Rust DA relay state/caps foundation only.

Non-scope: add-commit/add-chunk mutation behavior, complete-set transition, tx-byte retention, TTL cleanup, P2P ingest, getdachunk, prefetch, provider, miner, scripts, specs, fixtures, and Go changes.

## Scope Matrix

| Case | Go reference | Rust target / callsite | Required behavior | Rust mirror | Scope |
| -- | -- | -- | -- | -- | -- |
| default caps accepted | `clients/go/node/p2p/da_relay_state.go`, `defaultDARelayCaps` | `DaRelayCaps::default`, `DaRelayState::new` | Rust defaults mirror Go orphan/global/per-peer/per-DA/TTL/pinned caps | `da_relay_default_caps_match_go_reference` | In scope |
| zero caps rejected | `daRelayCaps.validatePositiveCaps` | `DaRelayCaps::validate`, `DaRelayState::new` | Zero global, per-peer, per-DA, commit-overhead, TTL, and pinned-payload caps fail before state construction | `da_relay_rejects_invalid_caps` | In scope |
| relative caps rejected | `daRelayCaps.validateRelativeCaps` | `DaRelayCaps::validate`, `DaRelayState::new` | Per-peer, per-DA, and commit-overhead caps above the global orphan cap are rejected | `da_relay_rejects_invalid_caps` | In scope |
| per-peer quota key normalized | `peerQuotaKey(addr)` / `orphanBytesByPeerQuotaKey` | `PeerQuotaKey::from_peer_addr`, `orphan_bytes_by_peer_quota_key` | Per-peer accounting keys mirror Go host extraction: `SplitHostPort`-style ports removed, unparseable host strings preserved, IPv6 zones stripped after IP parsing, and non-IP `%` labels preserved | `peer_quota_key_normalizes_hostile_matrix` | In scope |
| empty state accounting initialized | `newDARelayState` | `DaRelayState::new`, `DaRelayState::is_empty` | Constructor initializes owned DAID map, per-peer quota-key map, per-DA map, counters, and set map empty; `is_empty` reflects stored accounting/maps/sets, not monotonic received-time | `da_relay_default_caps_match_go_reference` | In scope |
| accounting projection fails closed | Go checked accounting projection paths in `da_relay_state.go` | `DaRelayState::project_counter` | Counter underflow, overflow, and cap exceed return typed errors without state mutation | `da_relay_accounting_projection_fails_closed` | In scope |
| max complete sets zero rejected | No `daRelayCaps` field; complete-set transition is forbidden in RUB-414 | No Rust cap | Non-scope for this foundation slice; owned by staged/complete-set behavior issue if needed | N/A | Non-scope |
| add commit/chunk behavior | RUB-397 owner issue | No Rust runtime mutation callsite added | Not implemented here | No mutation/runtime DA relay behavior added | Non-scope |
