### PR TITLE
[Q-RUST-P2P-DA-COMPLETE-INTEGRITY-01] Defend Rust DA complete-set integrity parity

### DIFF
--- a/clients/rust/crates/rubin-node/src/da_relay.rs
+++ b/clients/rust/crates/rubin-node/src/da_relay.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::net::{IpAddr, Ipv6Addr};
 use std::sync::Arc;
 
@@ -11,6 +11,8 @@ pub const DA_ORPHAN_POOL_PER_DA_ID_BYTES: u64 = 8 << 20;
 pub const DA_ORPHAN_COMMIT_OVERHEAD_BYTES: u64 = 8 << 20;
 pub const DA_ORPHAN_TTL_BLOCKS: u64 = 3;
 pub const DA_PINNED_PAYLOAD_BYTES: u64 = 96_000_000;
+const DA_COMPLETE_SET_RECORD_FOOTPRINT: u64 = 256;
+const DA_COMPLETE_SET_CHUNK_FOOTPRINT: u64 = 128;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct DaRelayCaps {
@@ -36,12 +38,20 @@ pub enum DaRelayError {
     ChunkIndexOutsideCommit,
     ChunkPayloadSizeInvalid,
     ChunkHashMismatch,
+    PayloadCommitmentMismatch,
 }
 
 type DaRelayResult<T = ()> = Result<T, DaRelayError>;
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DaRelaySetState {
+    OrphanChunks,
+    StagedCommit,
+    CompleteSet,
+}
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct DaRelayCommit {
     da_id: [u8; 32],
+    payload_commitment: [u8; 32],
     peer_quota_key: PeerQuotaKey,
     chunk_count: u16,
     wire_bytes: u64,
@@ -58,10 +68,15 @@ pub(crate) struct DaRelayChunk {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct DaRelaySetRecord {
     da_id: [u8; 32],
+    state: DaRelaySetState,
+    received_time: u64,
+    payload_bytes: u64,
+    ttl_blocks_remaining: u64,
     wire_bytes: u64,
     peer_bytes: BTreeMap<PeerQuotaKey, u64>,
     commit: Option<DaRelayCommit>,
     chunks: BTreeMap<u16, DaRelayChunk>,
+    replaceable_chunks: BTreeSet<u16>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -157,14 +172,22 @@ impl DaRelaySetRecord {
     fn new(da_id: [u8; 32]) -> Self {
         Self {
             da_id,
+            state: DaRelaySetState::OrphanChunks,
+            received_time: 0,
+            payload_bytes: 0,
+            ttl_blocks_remaining: 0,
             wire_bytes: 0,
             peer_bytes: BTreeMap::new(),
             commit: None,
             chunks: BTreeMap::new(),
+            replaceable_chunks: BTreeSet::new(),
         }
     }
     fn validate_chunk_insert(&self, chunk_index: u16) -> DaRelayResult {
         if self.chunks.contains_key(&chunk_index) {
+            if self.replaceable_chunks.contains(&chunk_index) {
+                return Ok(());
+            }
             return Err(DaRelayError::DuplicateChunk);
         }
         if let Some(commit) = &self.commit {
@@ -178,6 +201,8 @@ impl DaRelaySetRecord {
         if let Some(commit) = &self.commit {
             self.chunks
                 .retain(|index, _chunk| *index < commit.chunk_count);
+            self.replaceable_chunks
+                .retain(|index| *index < commit.chunk_count);
         }
     }
     fn recompute_wire_bytes(&mut self) -> DaRelayResult {
@@ -197,6 +222,122 @@ impl DaRelaySetRecord {
         self.wire_bytes = total;
         Ok(())
     }
+    fn completion_snapshot(&self) -> Option<DaRelayCompletionSnapshot> {
+        let commit = self.commit.as_ref()?;
+        if self.state == DaRelaySetState::CompleteSet {
+            return None;
+        }
+        let mut chunks = Vec::with_capacity(usize::from(commit.chunk_count));
+        for index in 0..commit.chunk_count {
+            if self.replaceable_chunks.contains(&index) {
+                return None;
+            }
+            let chunk = self.chunks.get(&index)?;
+            chunks.push(DaRelayCompletionChunk {
+                chunk_index: index,
+                chunk_hash: chunk.chunk_hash,
+                payload: Arc::clone(&chunk.payload),
+            });
+        }
+        Some(DaRelayCompletionSnapshot {
+            payload_commitment_expected: commit.payload_commitment,
+            chunks,
+        })
+    }
+    fn mark_complete(&mut self, payload_bytes: u64) {
+        self.payload_bytes = payload_bytes;
+        self.state = DaRelaySetState::CompleteSet;
+        self.ttl_blocks_remaining = 0;
+        self.replaceable_chunks.clear();
+        for chunk in self.chunks.values_mut() {
+            chunk.payload = Arc::from([]);
+        }
+    }
+    fn mark_chunks_replaceable(&mut self, indexes: impl IntoIterator<Item = u16>) {
+        self.replaceable_chunks.extend(indexes);
+    }
+    fn orphan_wire_bytes(&self) -> u64 {
+        if self.state == DaRelaySetState::CompleteSet {
+            0
+        } else {
+            self.wire_bytes
+        }
+    }
+    fn orphan_commit_bytes(&self) -> u64 {
+        if self.state == DaRelaySetState::CompleteSet {
+            0
+        } else {
+            self.commit.as_ref().map_or(0, |commit| commit.wire_bytes)
+        }
+    }
+    fn orphan_peer_bytes(&self) -> BTreeMap<PeerQuotaKey, u64> {
+        if self.state == DaRelaySetState::CompleteSet {
+            BTreeMap::new()
+        } else {
+            self.peer_bytes.clone()
+        }
+    }
+    fn pinned_payload_accounting_bytes(&self) -> DaRelayResult<u64> {
+        if self.state != DaRelaySetState::CompleteSet || self.payload_bytes == 0 {
+            return Ok(0);
+        }
+        let footprint = if self.wire_bytes == 0 {
+            self.payload_bytes
+        } else {
+            self.wire_bytes
+        };
+        let footprint = checked_add(footprint, DA_COMPLETE_SET_RECORD_FOOTPRINT)?;
+        let chunk_count = self.commit.as_ref().map_or(0, |commit| commit.chunk_count);
+        checked_add(
+            footprint,
+            u64::from(chunk_count) * DA_COMPLETE_SET_CHUNK_FOOTPRINT,
+        )
+    }
+}
+
+#[derive(Clone)]
+struct DaRelayCompletionSnapshot {
+    payload_commitment_expected: [u8; 32],
+    chunks: Vec<DaRelayCompletionChunk>,
+}
+
+#[derive(Clone)]
+struct DaRelayCompletionChunk {
+    chunk_index: u16,
+    chunk_hash: [u8; 32],
+    payload: Arc<[u8]>,
+}
+
+impl DaRelayCompletionSnapshot {
+    fn payload_commitment(&self) -> DaRelayResult<(u64, [u8; 32])> {
+        let mut hasher = Sha3_256::new();
+        let mut payload_bytes = 0u64;
+        for chunk in &self.chunks {
+            payload_bytes = checked_add(payload_bytes, chunk.payload.len() as u64)?;
+            hasher.update(chunk.payload.as_ref());
+        }
+        Ok((payload_bytes, hasher.finalize().into()))
+    }
+    fn matching_chunk_indexes(&self, record: &DaRelaySetRecord) -> Option<Vec<u16>> {
+        let mut indexes = Vec::new();
+        for snapshot_chunk in &self.chunks {
+            let Some(chunk) = record.chunks.get(&snapshot_chunk.chunk_index) else {
+                continue;
+            };
+            if chunk.chunk_hash != snapshot_chunk.chunk_hash
+                || chunk.payload.len() != snapshot_chunk.payload.len()
+            {
+                return None;
+            }
+            indexes.push(snapshot_chunk.chunk_index);
+        }
+        Some(indexes)
+    }
+}
+
+enum CompletionMismatchAction {
+    DropMatchingChunks,
+    MarkMatchingChunksReplaceable,
 }
 #[allow(dead_code)]
 impl DaRelayState {
@@ -243,8 +384,10 @@ impl DaRelayState {
             .cloned()
             .unwrap_or_else(|| DaRelaySetRecord::new(commit.da_id));
         record.commit = Some(commit);
+        record.state = DaRelaySetState::StagedCommit;
+        record.ttl_blocks_remaining = self.caps.orphan_ttl_blocks;
         record.prune_chunks_outside_commit();
-        self.prepare_and_apply_incomplete_record(record)
+        self.prepare_and_apply_record(record, CompletionMismatchAction::DropMatchingChunks)
     }
     pub(crate) fn stage_incomplete_da_chunk(
         &mut self,
@@ -259,12 +402,21 @@ impl DaRelayState {
         if sha3_256(chunk.payload.as_ref()) != chunk.chunk_hash {
             return Err(DaRelayError::ChunkHashMismatch);
         }
+        let chunk_index = chunk.chunk_index;
         chunk.peer_quota_key = PeerQuotaKey::from_peer_addr(peer_addr);
         let mut record = current
             .cloned()
             .unwrap_or_else(|| DaRelaySetRecord::new(chunk.da_id));
-        record.chunks.insert(chunk.chunk_index, chunk);
-        self.prepare_and_apply_incomplete_record(record)
+        if record.commit.is_none() {
+            record.state = DaRelaySetState::OrphanChunks;
+            record.ttl_blocks_remaining = self.caps.orphan_ttl_blocks;
+        }
+        record.chunks.insert(chunk_index, chunk);
+        record.replaceable_chunks.remove(&chunk_index);
+        self.prepare_and_apply_record(
+            record,
+            CompletionMismatchAction::MarkMatchingChunksReplaceable,
+        )
     }
     fn project_counter(current: u64, remove: u64, add: u64, cap: u64) -> DaRelayResult<u64> {
         let next = current
@@ -278,17 +430,65 @@ impl DaRelayState {
         Ok(next)
     }
 
-    fn prepare_and_apply_incomplete_record(
+    fn prepare_and_apply_record(
         &mut self,
         mut record: DaRelaySetRecord,
+        mismatch_action: CompletionMismatchAction,
     ) -> DaRelayResult {
-        // RUB-397 only stages candidates; RUB-398 owns payload commitment verification
-        // and the transition from orphan accounting to pinned complete-set accounting.
         record.recompute_wire_bytes()?;
+        if record.received_time == 0 {
+            record.received_time = self
+                .next_received_time
+                .checked_add(1)
+                .ok_or(DaRelayError::AccountingOverflow)?;
+        }
+        if let Some(snapshot) = record.completion_snapshot() {
+            let (payload_bytes, payload_commitment) = snapshot.payload_commitment()?;
+            if payload_commitment == snapshot.payload_commitment_expected {
+                record.mark_complete(payload_bytes);
+            } else {
+                match mismatch_action {
+                    CompletionMismatchAction::DropMatchingChunks => {
+                        if let Some(indexes) = snapshot.matching_chunk_indexes(&record) {
+                            for index in indexes {
+                                record.chunks.remove(&index);
+                                record.replaceable_chunks.remove(&index);
+                            }
+                        }
+                        record.payload_bytes = 0;
+                        record.state = DaRelaySetState::StagedCommit;
+                        record.recompute_wire_bytes()?;
+                        self.apply_record(record)?;
+                    }
+                    CompletionMismatchAction::MarkMatchingChunksReplaceable => {
+                        if let Some(old_record) = self.sets_by_da_id.get(&record.da_id) {
+                            let mut record = old_record.clone();
+                            let indexes = snapshot.matching_chunk_indexes(&record);
+                            if let Some(indexes) = indexes {
+                                if indexes.len() == snapshot.chunks.len() {
+                                    record.mark_chunks_replaceable(indexes);
+                                    self.apply_record(record)?;
+                                }
+                            }
+                        }
+                    }
+                }
+                return Err(DaRelayError::PayloadCommitmentMismatch);
+            }
+        }
+        self.apply_record(record)?;
+        Ok(())
+    }
+
+    fn apply_record(&mut self, record: DaRelaySetRecord) -> DaRelayResult {
         let old = self.sets_by_da_id.get(&record.da_id);
-        let old_bytes = old.map_or(0, |old| old.wire_bytes);
-        let old_commit_bytes = old.map_or(0, |old| old.commit.as_ref().map_or(0, |c| c.wire_bytes));
-        let new_commit_bytes = record.commit.as_ref().map_or(0, |c| c.wire_bytes);
+        let old_bytes = old.map_or(0, DaRelaySetRecord::orphan_wire_bytes);
+        let old_commit_bytes = old.map_or(0, DaRelaySetRecord::orphan_commit_bytes);
+        let old_pinned_bytes =
+            old.map_or(Ok(0), DaRelaySetRecord::pinned_payload_accounting_bytes)?;
+        let new_bytes = record.orphan_wire_bytes();
+        let new_commit_bytes = record.orphan_commit_bytes();
+        let new_pinned_bytes = record.pinned_payload_accounting_bytes()?;
         let peer_bytes = self.project_peer_bytes(old, &record)?;
         let da_id_current = self
             .orphan_bytes_by_da_id
@@ -298,13 +498,13 @@ impl DaRelayState {
         let orphan_bytes = Self::project_counter(
             self.orphan_bytes,
             old_bytes,
-            record.wire_bytes,
+            new_bytes,
             self.caps.orphan_pool_bytes,
         )?;
         let da_id_bytes = Self::project_counter(
             da_id_current,
             old_bytes,
-            record.wire_bytes,
+            new_bytes,
             self.caps.orphan_pool_per_da_id_bytes,
         )?;
         let commit_overhead = Self::project_counter(
@@ -313,8 +513,18 @@ impl DaRelayState {
             new_commit_bytes,
             self.caps.orphan_commit_overhead_bytes,
         )?;
+        let pinned_payload_bytes = Self::project_counter(
+            self.pinned_payload_bytes,
+            old_pinned_bytes,
+            new_pinned_bytes,
+            self.caps.pinned_payload_bytes,
+        )?;
         self.orphan_bytes = orphan_bytes;
         self.orphan_commit_overhead_bytes = commit_overhead;
+        self.pinned_payload_bytes = pinned_payload_bytes;
+        if record.received_time > self.next_received_time {
+            self.next_received_time = record.received_time;
+        }
         for (key, bytes) in peer_bytes {
             if bytes == 0 {
                 self.orphan_bytes_by_peer_quota_key.remove(&key);
@@ -322,7 +532,11 @@ impl DaRelayState {
                 self.orphan_bytes_by_peer_quota_key.insert(key, bytes);
             }
         }
-        self.orphan_bytes_by_da_id.insert(record.da_id, da_id_bytes);
+        if da_id_bytes == 0 {
+            self.orphan_bytes_by_da_id.remove(&record.da_id);
+        } else {
+            self.orphan_bytes_by_da_id.insert(record.da_id, da_id_bytes);
+        }
         self.sets_by_da_id.insert(record.da_id, record);
         Ok(())
     }
@@ -350,14 +564,16 @@ impl DaRelayState {
         new: &DaRelaySetRecord,
     ) -> DaRelayResult<Vec<(PeerQuotaKey, u64)>> {
         let mut projected = Vec::new();
+        let new_peer_bytes = new.orphan_peer_bytes();
         if let Some(old_record) = old {
-            for (key, old_bytes) in &old_record.peer_bytes {
-                let new_bytes = new.peer_bytes.get(key).copied().unwrap_or(0);
+            let old_peer_bytes = old_record.orphan_peer_bytes();
+            for (key, old_bytes) in &old_peer_bytes {
+                let new_bytes = new_peer_bytes.get(key).copied().unwrap_or(0);
                 projected.push(self.project_peer_counter(key, *old_bytes, new_bytes)?);
             }
         }
-        for (key, new_bytes) in &new.peer_bytes {
-            if old.is_some_and(|old_record| old_record.peer_bytes.contains_key(key)) {
+        for (key, new_bytes) in &new_peer_bytes {
+            if old.is_some_and(|old_record| old_record.orphan_peer_bytes().contains_key(key)) {
                 continue;
             }
             projected.push(self.project_peer_counter(key, 0, *new_bytes)?);
@@ -472,13 +688,21 @@ mod tests {
         }
     }
 
+    fn payload_commitment(payloads: &[&[u8]]) -> [u8; 32] {
+        let mut hasher = Sha3_256::new();
+        for payload in payloads {
+            hasher.update(payload);
+        }
+        hasher.finalize().into()
+    }
+
     #[test]
     #[rustfmt::skip]
     fn da_relay_staged_mutation_matrix() {
-        let peer = "peer-a:8333"; let pk = || PeerQuotaKey::from_peer_addr(peer); let stage_commit = |state: &mut DaRelayState, commit| state.stage_incomplete_da_commit(peer, commit); let stage_chunk = |state: &mut DaRelayState, chunk| state.stage_incomplete_da_chunk(peer, chunk); let commit = |da_id, chunk_count, wire_bytes| DaRelayCommit { da_id, peer_quota_key: pk(), chunk_count, wire_bytes }; let chunk = |da_id, chunk_index, payload: &[u8], wire_bytes| DaRelayChunk { da_id, chunk_hash: sha3_256(payload), peer_quota_key: pk(), chunk_index, payload: Arc::from(payload), wire_bytes }; let reject = |got: Result<(), DaRelayError>, want| assert_eq!(got, Err(want));
+        let peer = "peer-a:8333"; let pk = || PeerQuotaKey::from_peer_addr(peer); let stage_commit = |state: &mut DaRelayState, commit| state.stage_incomplete_da_commit(peer, commit); let stage_chunk = |state: &mut DaRelayState, chunk| state.stage_incomplete_da_chunk(peer, chunk); let commit = |da_id, chunk_count, wire_bytes| DaRelayCommit { da_id, payload_commitment: [0; 32], peer_quota_key: pk(), chunk_count, wire_bytes }; let chunk = |da_id, chunk_index, payload: &[u8], wire_bytes| DaRelayChunk { da_id, chunk_hash: sha3_256(payload), peer_quota_key: pk(), chunk_index, payload: Arc::from(payload), wire_bytes }; let reject = |got: Result<(), DaRelayError>, want| assert_eq!(got, Err(want));
         let mut state = DaRelayState::new(DaRelayCaps::default()).unwrap(); let mut forged_commit = commit([13; 32], 1, 2); forged_commit.peer_quota_key = PeerQuotaKey::from_peer_addr("peer-b:8333"); stage_commit(&mut state, forged_commit).unwrap(); let mut forged_chunk = chunk([14; 32], 0, b"owned", 6); forged_chunk.peer_quota_key = PeerQuotaKey::from_peer_addr("peer-b:8333"); stage_chunk(&mut state, forged_chunk).unwrap(); assert!(state.orphan_bytes_by_peer_quota_key.contains_key(&pk()) && !state.orphan_bytes_by_peer_quota_key.contains_key(&PeerQuotaKey::from_peer_addr("peer-b:8333")));
-        stage_commit(&mut state, commit([1; 32], 2, 2)).unwrap(); assert!(state.sets_by_da_id[&[1; 32]].commit.is_some()); stage_chunk(&mut state, chunk([1; 32], 0, b"payload-a", 9)).unwrap(); stage_chunk(&mut state, chunk([1; 32], 1, b"payload-b", 9)).unwrap(); assert_eq!(state.sets_by_da_id[&[1; 32]].chunks.len(), 2);
-        stage_chunk(&mut state, chunk([2; 32], 0, b"payload-a", 9)).unwrap(); stage_chunk(&mut state, chunk([2; 32], 1, b"payload-b", 9)).unwrap(); stage_commit(&mut state, commit([2; 32], 2, 1)).unwrap(); let record = &state.sets_by_da_id[&[2; 32]]; assert!(record.commit.is_some() && record.chunks.len() == 2); assert_eq!(state.orphan_bytes_by_da_id[&[2; 32]], record.wire_bytes);
+        stage_commit(&mut state, commit([1; 32], 3, 2)).unwrap(); assert!(state.sets_by_da_id[&[1; 32]].commit.is_some()); stage_chunk(&mut state, chunk([1; 32], 0, b"payload-a", 9)).unwrap(); stage_chunk(&mut state, chunk([1; 32], 1, b"payload-b", 9)).unwrap(); assert_eq!(state.sets_by_da_id[&[1; 32]].chunks.len(), 2);
+        stage_chunk(&mut state, chunk([2; 32], 0, b"payload-a", 9)).unwrap(); stage_chunk(&mut state, chunk([2; 32], 1, b"payload-b", 9)).unwrap(); stage_commit(&mut state, commit([2; 32], 3, 1)).unwrap(); let record = &state.sets_by_da_id[&[2; 32]]; assert!(record.commit.is_some() && record.chunks.len() == 2); assert_eq!(state.orphan_bytes_by_da_id[&[2; 32]], record.wire_bytes);
         stage_chunk(&mut state, chunk([12; 32], 0, b"keep", 4)).unwrap(); stage_chunk(&mut state, chunk([12; 32], 2, b"prune", 5)).unwrap(); stage_commit(&mut state, commit([12; 32], 2, 1)).unwrap(); let record = &state.sets_by_da_id[&[12; 32]]; assert!(record.chunks.contains_key(&0) && !record.chunks.contains_key(&2)); assert_eq!(state.orphan_bytes_by_da_id[&[12; 32]], record.wire_bytes);
         let mut state = DaRelayState::new(DaRelayCaps::default()).unwrap(); reject(stage_commit(&mut state, commit([3; 32], 0, 1)), InvalidCommitChunkCount); reject(stage_commit(&mut state, commit([3; 32], 1, 0)), InvalidWireBytes); assert!(state.sets_by_da_id.is_empty());
         stage_commit(&mut state, commit([3; 32], 2, 1)).unwrap(); let before = state.clone(); let mut bad_hash = chunk([3; 32], 0, b"payload", 7); bad_hash.chunk_hash[0] ^= 0xff;
@@ -487,5 +711,16 @@ mod tests {
         let caps = DaRelayCaps { orphan_pool_per_peer_bytes: 3, ..DaRelayCaps::default() }; let mut state = DaRelayState::new(caps).unwrap(); stage_chunk(&mut state, chunk([4; 32], 0, b"ab", 2)).unwrap();
         let before = state.clone(); reject(stage_chunk(&mut state, chunk([5; 32], 0, b"cd", 2)), AccountingCapExceeded); assert_eq!(state, before);
         let mut state = DaRelayState::new(caps).unwrap(); stage_chunk(&mut state, chunk([6; 32], 0, b"a", 1)).unwrap(); let before = state.clone(); reject(stage_commit(&mut state, commit([6; 32], 2, 3)), AccountingCapExceeded); assert_eq!(state, before);
+    }
+
+    #[test]
+    #[rustfmt::skip]
+    fn da_relay_complete_integrity_matrix() {
+        let peer = "peer-a:8333"; let pk = || PeerQuotaKey::from_peer_addr(peer); let commit = |da_id, payloads: &[&[u8]], wire_bytes| DaRelayCommit { da_id, payload_commitment: payload_commitment(payloads), peer_quota_key: pk(), chunk_count: payloads.len() as u16, wire_bytes }; let chunk = |da_id, index, payload: &[u8], wire_bytes| DaRelayChunk { da_id, chunk_hash: sha3_256(payload), peer_quota_key: pk(), chunk_index: index, payload: Arc::from(payload), wire_bytes };
+        let mut state = DaRelayState::new(DaRelayCaps::default()).unwrap(); state.stage_incomplete_da_commit(peer, commit([20; 32], &[b"aa", b"bb"], 2)).unwrap(); state.stage_incomplete_da_chunk(peer, chunk([20; 32], 0, b"aa", 2)).unwrap(); state.stage_incomplete_da_chunk(peer, chunk([20; 32], 1, b"bb", 2)).unwrap(); let record = &state.sets_by_da_id[&[20; 32]]; assert_eq!(record.state, DaRelaySetState::CompleteSet); assert_eq!(record.payload_bytes, 4); assert_eq!(record.ttl_blocks_remaining, 0); assert!(record.chunks.values().all(|chunk| chunk.payload.is_empty())); assert_eq!(state.orphan_bytes, 0); assert!(!state.orphan_bytes_by_da_id.contains_key(&[20; 32])); assert_eq!(state.pinned_payload_bytes, record.wire_bytes + 256 + 2 * 128);
+        let mut state = DaRelayState::new(DaRelayCaps::default()).unwrap(); state.stage_incomplete_da_commit(peer, commit([21; 32], &[b"good"], 1)).unwrap(); assert_eq!(state.stage_incomplete_da_chunk(peer, chunk([21; 32], 0, b"bad", 3)), Err(PayloadCommitmentMismatch)); let record = &state.sets_by_da_id[&[21; 32]]; assert_eq!(record.state, DaRelaySetState::StagedCommit); assert_eq!(record.payload_bytes, 0); assert!(record.chunks.is_empty() && record.replaceable_chunks.is_empty()); assert_eq!(state.pinned_payload_bytes, 0); state.stage_incomplete_da_chunk(peer, chunk([21; 32], 0, b"good", 4)).unwrap(); let record = &state.sets_by_da_id[&[21; 32]]; assert_eq!(record.state, DaRelaySetState::CompleteSet); assert!(record.replaceable_chunks.is_empty());
+        let mut state = DaRelayState::new(DaRelayCaps::default()).unwrap(); state.stage_incomplete_da_chunk(peer, chunk([22; 32], 0, b"bad", 3)).unwrap(); assert_eq!(state.stage_incomplete_da_commit(peer, commit([22; 32], &[b"good"], 1)), Err(PayloadCommitmentMismatch)); let record = &state.sets_by_da_id[&[22; 32]]; assert_eq!(record.state, DaRelaySetState::StagedCommit); assert!(record.chunks.is_empty()); assert_eq!(state.pinned_payload_bytes, 0); state.stage_incomplete_da_chunk(peer, chunk([22; 32], 0, b"good", 4)).unwrap(); assert_eq!(state.sets_by_da_id[&[22; 32]].state, DaRelaySetState::CompleteSet);
+        let mut state = DaRelayState::new(DaRelayCaps::default()).unwrap(); state.stage_incomplete_da_commit(peer, commit([23; 32], &[b"aa", b"bb"], 1)).unwrap(); state.stage_incomplete_da_chunk(peer, chunk([23; 32], 0, b"aa", 2)).unwrap(); assert_eq!(state.stage_incomplete_da_chunk(peer, chunk([23; 32], 1, b"xx", 2)), Err(PayloadCommitmentMismatch)); let record = &state.sets_by_da_id[&[23; 32]]; assert_eq!(record.state, DaRelaySetState::StagedCommit); assert!(record.chunks.contains_key(&0) && !record.chunks.contains_key(&1)); assert!(record.replaceable_chunks.is_empty()); assert_eq!(state.pinned_payload_bytes, 0); state.stage_incomplete_da_chunk(peer, chunk([23; 32], 1, b"bb", 2)).unwrap(); assert_eq!(state.sets_by_da_id[&[23; 32]].state, DaRelaySetState::CompleteSet);
+        let caps = DaRelayCaps { pinned_payload_bytes: 1, ..DaRelayCaps::default() }; let mut state = DaRelayState::new(caps).unwrap(); state.stage_incomplete_da_commit(peer, commit([24; 32], &[b"aa"], 1)).unwrap(); let before = state.clone(); assert_eq!(state.stage_incomplete_da_chunk(peer, chunk([24; 32], 0, b"aa", 2)), Err(AccountingCapExceeded)); assert_eq!(state, before);
     }
 }

--- a/clients/rust/crates/rubin-node/src/da_relay.rs
+++ b/clients/rust/crates/rubin-node/src/da_relay.rs
@@ -565,15 +565,18 @@ impl DaRelayState {
     ) -> DaRelayResult<Vec<(PeerQuotaKey, u64)>> {
         let mut projected = Vec::new();
         let new_peer_bytes = new.orphan_peer_bytes();
-        if let Some(old_record) = old {
-            let old_peer_bytes = old_record.orphan_peer_bytes();
-            for (key, old_bytes) in &old_peer_bytes {
+        let old_peer_bytes = old.map(DaRelaySetRecord::orphan_peer_bytes);
+        if let Some(old_peer_bytes) = &old_peer_bytes {
+            for (key, old_bytes) in old_peer_bytes {
                 let new_bytes = new_peer_bytes.get(key).copied().unwrap_or(0);
                 projected.push(self.project_peer_counter(key, *old_bytes, new_bytes)?);
             }
         }
         for (key, new_bytes) in &new_peer_bytes {
-            if old.is_some_and(|old_record| old_record.orphan_peer_bytes().contains_key(key)) {
+            if old_peer_bytes
+                .as_ref()
+                .is_some_and(|old_peer_bytes| old_peer_bytes.contains_key(key))
+            {
                 continue;
             }
             projected.push(self.project_peer_counter(key, 0, *new_bytes)?);
@@ -717,7 +720,7 @@ mod tests {
     #[rustfmt::skip]
     fn da_relay_complete_integrity_matrix() {
         let peer = "peer-a:8333"; let pk = || PeerQuotaKey::from_peer_addr(peer); let commit = |da_id, payloads: &[&[u8]], wire_bytes| DaRelayCommit { da_id, payload_commitment: payload_commitment(payloads), peer_quota_key: pk(), chunk_count: payloads.len() as u16, wire_bytes }; let chunk = |da_id, index, payload: &[u8], wire_bytes| DaRelayChunk { da_id, chunk_hash: sha3_256(payload), peer_quota_key: pk(), chunk_index: index, payload: Arc::from(payload), wire_bytes };
-        let mut state = DaRelayState::new(DaRelayCaps::default()).unwrap(); state.stage_incomplete_da_commit(peer, commit([20; 32], &[b"aa", b"bb"], 2)).unwrap(); state.stage_incomplete_da_chunk(peer, chunk([20; 32], 0, b"aa", 2)).unwrap(); state.stage_incomplete_da_chunk(peer, chunk([20; 32], 1, b"bb", 2)).unwrap(); let record = &state.sets_by_da_id[&[20; 32]]; assert_eq!(record.state, DaRelaySetState::CompleteSet); assert_eq!(record.payload_bytes, 4); assert_eq!(record.ttl_blocks_remaining, 0); assert!(record.chunks.values().all(|chunk| chunk.payload.is_empty())); assert_eq!(state.orphan_bytes, 0); assert!(!state.orphan_bytes_by_da_id.contains_key(&[20; 32])); assert_eq!(state.pinned_payload_bytes, record.wire_bytes + 256 + 2 * 128);
+        let mut state = DaRelayState::new(DaRelayCaps::default()).unwrap(); state.stage_incomplete_da_commit(peer, commit([20; 32], &[b"aa", b"bb"], 2)).unwrap(); state.stage_incomplete_da_chunk(peer, chunk([20; 32], 0, b"aa", 2)).unwrap(); state.stage_incomplete_da_chunk(peer, chunk([20; 32], 1, b"bb", 2)).unwrap(); let record = &state.sets_by_da_id[&[20; 32]]; let chunk_count = u64::from(record.commit.as_ref().unwrap().chunk_count); assert_eq!(record.state, DaRelaySetState::CompleteSet); assert_eq!(record.payload_bytes, 4); assert_eq!(record.ttl_blocks_remaining, 0); assert!(record.chunks.values().all(|chunk| chunk.payload.is_empty())); assert_eq!(state.orphan_bytes, 0); assert!(!state.orphan_bytes_by_da_id.contains_key(&[20; 32])); assert_eq!(state.pinned_payload_bytes, record.wire_bytes + DA_COMPLETE_SET_RECORD_FOOTPRINT + chunk_count * DA_COMPLETE_SET_CHUNK_FOOTPRINT);
         let mut state = DaRelayState::new(DaRelayCaps::default()).unwrap(); state.stage_incomplete_da_commit(peer, commit([21; 32], &[b"good"], 1)).unwrap(); assert_eq!(state.stage_incomplete_da_chunk(peer, chunk([21; 32], 0, b"bad", 3)), Err(PayloadCommitmentMismatch)); let record = &state.sets_by_da_id[&[21; 32]]; assert_eq!(record.state, DaRelaySetState::StagedCommit); assert_eq!(record.payload_bytes, 0); assert!(record.chunks.is_empty() && record.replaceable_chunks.is_empty()); assert_eq!(state.pinned_payload_bytes, 0); state.stage_incomplete_da_chunk(peer, chunk([21; 32], 0, b"good", 4)).unwrap(); let record = &state.sets_by_da_id[&[21; 32]]; assert_eq!(record.state, DaRelaySetState::CompleteSet); assert!(record.replaceable_chunks.is_empty());
         let mut state = DaRelayState::new(DaRelayCaps::default()).unwrap(); state.stage_incomplete_da_chunk(peer, chunk([22; 32], 0, b"bad", 3)).unwrap(); assert_eq!(state.stage_incomplete_da_commit(peer, commit([22; 32], &[b"good"], 1)), Err(PayloadCommitmentMismatch)); let record = &state.sets_by_da_id[&[22; 32]]; assert_eq!(record.state, DaRelaySetState::StagedCommit); assert!(record.chunks.is_empty()); assert_eq!(state.pinned_payload_bytes, 0); state.stage_incomplete_da_chunk(peer, chunk([22; 32], 0, b"good", 4)).unwrap(); assert_eq!(state.sets_by_da_id[&[22; 32]].state, DaRelaySetState::CompleteSet);
         let mut state = DaRelayState::new(DaRelayCaps::default()).unwrap(); state.stage_incomplete_da_commit(peer, commit([23; 32], &[b"aa", b"bb"], 1)).unwrap(); state.stage_incomplete_da_chunk(peer, chunk([23; 32], 0, b"aa", 2)).unwrap(); assert_eq!(state.stage_incomplete_da_chunk(peer, chunk([23; 32], 1, b"xx", 2)), Err(PayloadCommitmentMismatch)); let record = &state.sets_by_da_id[&[23; 32]]; assert_eq!(record.state, DaRelaySetState::StagedCommit); assert!(record.chunks.contains_key(&0) && !record.chunks.contains_key(&1)); assert!(record.replaceable_chunks.is_empty()); assert_eq!(state.pinned_payload_bytes, 0); state.stage_incomplete_da_chunk(peer, chunk([23; 32], 1, b"bb", 2)).unwrap(); assert_eq!(state.sets_by_da_id[&[23; 32]].state, DaRelaySetState::CompleteSet);

--- a/clients/rust/crates/rubin-node/src/da_relay.rs
+++ b/clients/rust/crates/rubin-node/src/da_relay.rs
@@ -1,4 +1,5 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
 use std::net::{IpAddr, Ipv6Addr};
 use std::sync::Arc;
 
@@ -270,12 +271,8 @@ impl DaRelaySetRecord {
             self.commit.as_ref().map_or(0, |commit| commit.wire_bytes)
         }
     }
-    fn orphan_peer_bytes(&self) -> BTreeMap<PeerQuotaKey, u64> {
-        if self.state == DaRelaySetState::CompleteSet {
-            BTreeMap::new()
-        } else {
-            self.peer_bytes.clone()
-        }
+    fn orphan_peer_bytes(&self) -> Option<&BTreeMap<PeerQuotaKey, u64>> {
+        (self.state != DaRelaySetState::CompleteSet).then_some(&self.peer_bytes)
     }
     fn pinned_payload_accounting_bytes(&self) -> DaRelayResult<u64> {
         if self.state != DaRelaySetState::CompleteSet || self.payload_bytes == 0 {
@@ -565,21 +562,22 @@ impl DaRelayState {
     ) -> DaRelayResult<Vec<(PeerQuotaKey, u64)>> {
         let mut projected = Vec::new();
         let new_peer_bytes = new.orphan_peer_bytes();
-        let old_peer_bytes = old.map(DaRelaySetRecord::orphan_peer_bytes);
-        if let Some(old_peer_bytes) = &old_peer_bytes {
+        let old_peer_bytes = old.and_then(DaRelaySetRecord::orphan_peer_bytes);
+        if let Some(old_peer_bytes) = old_peer_bytes {
             for (key, old_bytes) in old_peer_bytes {
-                let new_bytes = new_peer_bytes.get(key).copied().unwrap_or(0);
+                let new_bytes = new_peer_bytes
+                    .and_then(|m| m.get(key))
+                    .copied()
+                    .unwrap_or(0);
                 projected.push(self.project_peer_counter(key, *old_bytes, new_bytes)?);
             }
         }
-        for (key, new_bytes) in &new_peer_bytes {
-            if old_peer_bytes
-                .as_ref()
-                .is_some_and(|old_peer_bytes| old_peer_bytes.contains_key(key))
-            {
-                continue;
+        if let Some(new_peer_bytes) = new_peer_bytes {
+            for (key, new_bytes) in new_peer_bytes {
+                if !old_peer_bytes.is_some_and(|old_bytes| old_bytes.contains_key(key)) {
+                    projected.push(self.project_peer_counter(key, 0, *new_bytes)?);
+                }
             }
-            projected.push(self.project_peer_counter(key, 0, *new_bytes)?);
         }
         Ok(projected)
     }


### PR DESCRIPTION
Scope:
RUB-398 / #1860. Rust DA relay complete-set integrity transitions only; no provider snapshots, tx-byte retention, eviction policy, ingest, prefetch, or miner wiring.

Go/Rust Parity Matrix:
| Case | Go reference/vector | Go callsite/entrypoint | Rust callsite/entrypoint | Required Rust behavior | Rust mirror test evidence | Evidence row |
| -- | -- | -- | -- | -- | -- | -- |
| complete only when all chunks present | `completionSnapshot` / `payloadCommitment` | `addDACommit` / `addDAChunk` completion path in `clients/go/node/p2p/da_relay_state.go` | `stage_incomplete_da_commit` / `stage_incomplete_da_chunk` -> `completion_snapshot` in `clients/rust/crates/rubin-node/src/da_relay.rs` | Rust returns no complete snapshot until every commit index has a non-replaceable chunk and matching payload commitment | `cargo test -p rubin-node da_relay_complete --lib` | `da_relay_complete_integrity_matrix` complete-set row |
| deterministic chunk-order payload commitment | `daRelayCompletionSnapshot.payloadCommitment` | `daRelayCompletionSnapshot.payloadCommitment` in `clients/go/node/p2p/da_relay_state.go` | `DaRelayCompletionSnapshot::payload_commitment` in `clients/rust/crates/rubin-node/src/da_relay.rs` | Rust hashes chunk payloads in commit index order before comparing `payload_commitment` | `cargo test -p rubin-node da_relay_complete --lib` | `da_relay_complete_integrity_matrix` two-chunk ordered payload row |
| chunk hash mismatch does not mark complete | `validateDAChunk` / `addDAChunk` hash check | `validateDAChunk` / `addDAChunk` in `clients/go/node/p2p/da_relay_state.go` | `validate_da_chunk` / `stage_incomplete_da_chunk` in `clients/rust/crates/rubin-node/src/da_relay.rs` | Rust rejects bad chunk hash before record mutation or completion accounting | `cargo test -p rubin-node da_relay_staged --lib` | `da_relay_staged_mutation_matrix` bad-hash no-mutation row |
| payload commitment mismatch does not pin invalid payloads | `stageCommitDroppingMatchingCompletionChunks` / `markMatchingCompletionChunksReplaceable` | `addDACommit` / `addDAChunk` mismatch recovery in `clients/go/node/p2p/da_relay_state.go` | `prepare_and_apply_record` mismatch branches in `clients/rust/crates/rubin-node/src/da_relay.rs` | Rust returns `PayloadCommitmentMismatch` without pinned bytes and without retaining invalid complete payloads | `cargo test -p rubin-node da_relay_complete --lib` | `da_relay_complete_integrity_matrix` commit-mismatch, single-candidate mismatch, and partial mismatch rows |
| complete transition clears chunk payload copies and TTL | `markComplete` | `markComplete` in `clients/go/node/p2p/da_relay_state.go` | `DaRelaySetRecord::mark_complete` in `clients/rust/crates/rubin-node/src/da_relay.rs` | Rust complete transition sets complete state, clears TTL and chunk payload copies, and moves accounting from orphan to pinned | `cargo test -p rubin-node da_relay_complete --lib` | `da_relay_complete_integrity_matrix` complete transition row |
| mismatch recovery permits only Go-equivalent replaceability | `markMatchingCompletionChunksReplaceable` | `markMatchingCompletionChunksReplaceable` in `clients/go/node/p2p/da_relay_state.go` | `CompletionMismatchAction::MarkMatchingChunksReplaceable` branch in `clients/rust/crates/rubin-node/src/da_relay.rs` | Rust compares mismatch snapshots against stored state, not the newly staged bad candidate, before marking chunks replaceable | `cargo test -p rubin-node da_relay_complete --lib` | `da_relay_complete_integrity_matrix` single-candidate and partial-mismatch no-retry rows |

Evidence:
- `scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test -p rubin-node da_relay_complete --lib'` - PASS
- `scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test -p rubin-node da_relay_staged --lib'` - PASS
- `scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test -p rubin-node --lib'` - PASS
- `scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo clippy -p rubin-node --lib -- -D warnings'` - PASS
