### PR TITLE
RUB-400: defend DA duplicate first-seen parity

### DIFF
--- a/clients/rust/crates/rubin-node/src/da_relay.rs
+++ b/clients/rust/crates/rubin-node/src/da_relay.rs
@@ -762,6 +762,74 @@ mod tests {
     }
 
     #[test]
+    fn da_relay_duplicate_first_seen_matrix() {
+        let peer_a = "peer-a:8333";
+        let peer_b = "peer-b:8333";
+        let peer_c = "peer-c:8333";
+        let commit = |da_id, payloads: &[&[u8]], wire_bytes| DaRelayCommit {
+            da_id,
+            payload_commitment: payload_commitment(payloads),
+            peer_quota_key: PeerQuotaKey::from_peer_addr("forged:8333"),
+            chunk_count: payloads.len() as u16,
+            wire_bytes,
+        };
+        let chunk = |da_id, index, payload: &[u8], wire_bytes| DaRelayChunk {
+            da_id,
+            chunk_hash: sha3_256(payload),
+            peer_quota_key: PeerQuotaKey::from_peer_addr("forged:8333"),
+            chunk_index: index,
+            payload: Arc::from(payload),
+            wire_bytes,
+        };
+
+        let mut state = DaRelayState::new(DaRelayCaps::default()).unwrap();
+        state
+            .stage_incomplete_da_chunk(peer_a, chunk([60; 32], 0, b"first-chunk", 12))
+            .unwrap();
+        state
+            .stage_incomplete_da_commit(peer_b, commit([60; 32], &[b"first-chunk", b"tail"], 7))
+            .unwrap();
+        let before = state.clone();
+        assert_eq!(
+            state.stage_incomplete_da_commit(peer_c, commit([60; 32], &[b"other"], 99)),
+            Err(DuplicateCommit)
+        );
+        assert_eq!(state, before);
+        let record = &state.sets_by_da_id[&[60; 32]];
+        assert_eq!(
+            record.commit.as_ref().map(|commit| &commit.peer_quota_key),
+            Some(&PeerQuotaKey::from_peer_addr(peer_b))
+        );
+        assert_eq!(record.chunks[&0].payload.as_ref(), b"first-chunk");
+        assert!(!state
+            .orphan_bytes_by_peer_quota_key
+            .contains_key(&PeerQuotaKey::from_peer_addr(peer_c)));
+
+        let mut state = DaRelayState::new(DaRelayCaps::default()).unwrap();
+        state
+            .stage_incomplete_da_chunk(peer_a, chunk([61; 32], 0, b"first", 5))
+            .unwrap();
+        let before = state.clone();
+        let mut duplicate = chunk([61; 32], 0, b"conflict", 8);
+        duplicate.chunk_hash[0] ^= 0xff;
+        assert_eq!(
+            state.stage_incomplete_da_chunk(peer_b, duplicate),
+            Err(DuplicateChunk)
+        );
+        assert_eq!(state, before);
+        let record = &state.sets_by_da_id[&[61; 32]];
+        assert_eq!(record.chunks[&0].payload.as_ref(), b"first");
+        assert_eq!(
+            record.chunks[&0].peer_quota_key,
+            PeerQuotaKey::from_peer_addr(peer_a)
+        );
+        assert!(!record.replaceable_chunks.contains(&0));
+        assert!(!state
+            .orphan_bytes_by_peer_quota_key
+            .contains_key(&PeerQuotaKey::from_peer_addr(peer_b)));
+    }
+
+    #[test]
     #[rustfmt::skip]
     fn da_relay_complete_integrity_matrix() {
         let peer = "peer-a:8333"; let pk = || PeerQuotaKey::from_peer_addr(peer); let commit = |da_id, payloads: &[&[u8]], wire_bytes| DaRelayCommit { da_id, payload_commitment: payload_commitment(payloads), peer_quota_key: pk(), chunk_count: payloads.len() as u16, wire_bytes }; let chunk = |da_id, index, payload: &[u8], wire_bytes| DaRelayChunk { da_id, chunk_hash: sha3_256(payload), peer_quota_key: pk(), chunk_index: index, payload: Arc::from(payload), wire_bytes };


### PR DESCRIPTION
## Scope
- RUB-400 / #1862.
- Adds Rust DA relay coverage for duplicate commit/chunk first-seen behavior.
- Runtime behavior unchanged; test-only change in `clients/rust/crates/rubin-node/src/da_relay.rs`.
- Non-scope: completion mismatch recovery, TTL/disconnect cleanup, tx-byte retention, provider/miner/ingest.

## Parity Matrix
| Case | Go reference | Rust required behavior | Evidence required | Go callsite | Rust callsite | Mirror test required |
| --- | --- | --- | --- | --- | --- | --- |
| this issue's accepted_cases | issue execution contract | only behavior listed in Scope, Done When, and reference_function_parity_matrix is implemented | test-only diff plus duplicate first-seen matrix | issue contract accepted_cases | `clients/rust/crates/rubin-node/src/da_relay.rs` test module | `da_relay_duplicate_first_seen_matrix` |
| this issue's hostile_cases | issue execution contract | duplicate, ordering, and boundary cases named here are covered or left to owner issue when out of scope | duplicate commit/chunk conflict rows plus non-scope row | issue contract hostile_cases | `DaRelayState::stage_incomplete_da_commit`; `DaRelayState::stage_incomplete_da_chunk` | `da_relay_duplicate_first_seen_matrix` |
| this issue's Done When | issue Done When | duplicate commit/chunk tests prove first-seen and no accounting drift | full state equality and no duplicate peer quota entry | issue contract Done When | `DaRelayState` staged DA state | `da_relay_duplicate_first_seen_matrix` |
| the matching Go reference issue / Go reference functions named in `reference_function_parity_matrix` | `addDACommit`; `addDAChunk`; `projectOrphanAccountingDeltaLocked` | Rust duplicate paths mirror Go first-seen/no-accounting-drift behavior | named Rust test maps all three Go references | `clients/go/node/p2p/da_relay_state.go` | `clients/rust/crates/rubin-node/src/da_relay.rs` | `da_relay_duplicate_first_seen_matrix` |
| hidden precondition copied before implementation starts | `addDACommit`; `addDAChunk` duplicate paths | no additional hidden precondition is required for this duplicate-only slice | Go duplicate tests and Rust mirror test use explicit staged records | `clients/go/node/p2p/da_relay_state.go` | Rust staged commit/chunk helpers | `da_relay_duplicate_first_seen_matrix` |
| first commit wins | `addDACommit` duplicate path | existing commit record remains the stored first-seen commit | stored commit peer and full state equality after duplicate rejection | `clients/go/node/p2p/da_relay_state.go:addDACommit` | `DaRelayState::stage_incomplete_da_commit` | `da_relay_duplicate_first_seen_matrix` |
| conflicting duplicate commit rejected without mutation | `addDACommit` duplicate path | later conflicting commit returns `DuplicateCommit` before mutation/accounting | `Err(DuplicateCommit)` and full state equality | `clients/go/node/p2p/da_relay_state.go:stageDACommitRecordLocked` | `DaRelayState::stage_incomplete_da_commit` | `da_relay_duplicate_first_seen_matrix` |
| first chunk wins | `addDAChunk` duplicate path | existing chunk payload and peer quota key remain first-seen | stored orphan payload and peer key remain first-seen | `clients/go/node/p2p/da_relay_state.go:addDAChunk` | `DaRelayState::stage_incomplete_da_chunk` | `da_relay_duplicate_first_seen_matrix` |
| conflicting duplicate chunk rejected without accounting drift | `addDAChunk` duplicate path | later conflicting chunk returns `DuplicateChunk` before hash/accounting mutation | `Err(DuplicateChunk)` and full state equality | `clients/go/node/p2p/da_relay_state.go:stageDAChunkRecordLocked` | `DaRelayState::stage_incomplete_da_chunk` | `da_relay_duplicate_first_seen_matrix` |
| duplicate rejection leaves global/per-peer/per-DA accounting unchanged | `projectOrphanAccountingDeltaLocked` | duplicate rejection must not change global, peer, or DA-id accounting maps | full `DaRelayState` equality and no duplicate peer quota entry | `clients/go/node/p2p/da_relay_state.go:projectOrphanAccountingDeltaLocked` | `DaRelayState::apply_record` is not reached on duplicate rejection | `da_relay_duplicate_first_seen_matrix` |
| duplicate rejection leaves global per-peer and per-DA accounting unchanged | `projectOrphanAccountingDeltaLocked` | duplicate rejection must not change global, peer, or DA-id accounting maps | full `DaRelayState` equality and no duplicate peer quota entry | `clients/go/node/p2p/da_relay_state.go:projectOrphanAccountingDeltaLocked` | `DaRelayState::apply_record` is not reached on duplicate rejection | `da_relay_duplicate_first_seen_matrix` |
| replaceability is forbidden here unless RUB-398 explicitly owns it | RUB-398 complete-integrity owner | this slice does not add replaceability behavior; unmarked duplicate stays rejected | `replaceable_chunks` remains empty; RUB-398 owns mismatch replaceability | `clients/go/node/p2p/da_relay_state.go:stageDAChunkRecordLocked` mismatch path | `DaRelaySetRecord::validate_chunk_insert`; `DaRelayState::stage_incomplete_da_chunk` | `da_relay_duplicate_first_seen_matrix` |
| replaceability forbidden here unless [2tbmz9y2xt-lang/rubin-protocol#1860](<https://linear.app/rubinp/issue/RUB-398/q-rust-p2p-da-complete-integrity-01-add-rust-da-complete-set-integrity>) owns it | RUB-398 complete-integrity owner | this slice does not add replaceability behavior; unmarked duplicate stays rejected | `replaceable_chunks` remains empty; RUB-398 owns mismatch replaceability | `clients/go/node/p2p/da_relay_state.go:stageDAChunkRecordLocked` mismatch path | `DaRelaySetRecord::validate_chunk_insert`; `DaRelayState::stage_incomplete_da_chunk` | `da_relay_duplicate_first_seen_matrix` |

## Evidence
| Check | Result |
| --- | --- |
| `cd clients/rust && cargo test -p rubin-node da_relay_duplicate --lib` | PASS 1/1 |
| `cd clients/rust && cargo test -p rubin-node da_relay --lib` | PASS 9/9 |
| `cd clients/go && go test ./node/p2p -run "DARelayRejectsDuplicatesBeforeMutation|DARelayDuplicateCommitAfterOrphanChunksKeepsFirstSeenState|DARelayStageChunkRejectsDuplicateWithoutMutation" -count=1` | PASS |
| `cd clients/rust && cargo fmt --check -p rubin-node` | PASS |
| `cd clients/rust && cargo clippy -p rubin-node --lib -- -D warnings` | PASS |
| `cd clients/rust && cargo test -p rubin-node --lib` | PASS 714/714 |

Closes #1862

