### PR TITLE
RUB-382: retain Rust DA relay tx bytes

### DIFF
--- a/clients/rust/crates/rubin-node/src/da_relay.rs
+++ b/clients/rust/crates/rubin-node/src/da_relay.rs
@@ -56,6 +56,7 @@ pub(crate) struct DaRelayCommit {
     peer_quota_key: PeerQuotaKey,
     chunk_count: u16,
     wire_bytes: u64,
+    tx_bytes: Arc<[u8]>,
 }
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct DaRelayChunk {
@@ -65,6 +66,7 @@ pub(crate) struct DaRelayChunk {
     chunk_index: u16,
     payload: Arc<[u8]>,
     wire_bytes: u64,
+    tx_bytes: Arc<[u8]>,
 }
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct DaRelaySetRecord {
@@ -218,15 +220,18 @@ impl DaRelaySetRecord {
         self.peer_bytes.clear();
         let mut total = 0;
         if let Some(commit) = &self.commit {
-            total = commit.wire_bytes;
-            self.peer_bytes
-                .insert(commit.peer_quota_key.clone(), commit.wire_bytes);
+            total = retained_tx_accounting_bytes(commit.wire_bytes, &commit.tx_bytes);
+            self.peer_bytes.insert(commit.peer_quota_key.clone(), total);
         }
         let peer_bytes = &mut self.peer_bytes;
         for chunk in self.chunks.values() {
-            total = checked_add(total, chunk.wire_bytes)?;
+            total = checked_add(
+                total,
+                retained_tx_accounting_bytes(chunk.wire_bytes, &chunk.tx_bytes),
+            )?;
+            let chunk_bytes = orphan_chunk_accounting_bytes(chunk)?;
             let entry = peer_bytes.entry(chunk.peer_quota_key.clone()).or_default();
-            *entry = checked_add(*entry, chunk.wire_bytes)?;
+            *entry = checked_add(*entry, chunk_bytes)?;
         }
         self.wire_bytes = total;
         Ok(())
@@ -265,18 +270,22 @@ impl DaRelaySetRecord {
     fn mark_chunks_replaceable(&mut self, indexes: impl IntoIterator<Item = u16>) {
         self.replaceable_chunks.extend(indexes);
     }
-    fn orphan_wire_bytes(&self) -> u64 {
+    fn orphan_wire_bytes(&self) -> DaRelayResult<u64> {
         if self.state == DaRelaySetState::CompleteSet {
-            0
+            Ok(0)
         } else {
-            self.wire_bytes
+            self.peer_bytes
+                .values()
+                .try_fold(0u64, |total, bytes| checked_add(total, *bytes))
         }
     }
     fn orphan_commit_bytes(&self) -> u64 {
         if self.state == DaRelaySetState::CompleteSet {
             0
         } else {
-            self.commit.as_ref().map_or(0, |commit| commit.wire_bytes)
+            self.commit.as_ref().map_or(0, |commit| {
+                retained_tx_accounting_bytes(commit.wire_bytes, &commit.tx_bytes)
+            })
         }
     }
     fn orphan_peer_bytes(&self) -> Option<&BTreeMap<PeerQuotaKey, u64>> {
@@ -293,10 +302,10 @@ impl DaRelaySetRecord {
         };
         let footprint = checked_add(footprint, DA_COMPLETE_SET_RECORD_FOOTPRINT)?;
         let chunk_count = self.commit.as_ref().map_or(0, |commit| commit.chunk_count);
-        checked_add(
-            footprint,
-            u64::from(chunk_count) * DA_COMPLETE_SET_CHUNK_FOOTPRINT,
-        )
+        let chunk_footprint = u64::from(chunk_count)
+            .checked_mul(DA_COMPLETE_SET_CHUNK_FOOTPRINT)
+            .ok_or(DaRelayError::AccountingOverflow)?;
+        checked_add(footprint, chunk_footprint)
     }
 
     pub(crate) fn eviction_accounting(&self) -> Option<DaRelayEvictionAccounting> {
@@ -526,11 +535,11 @@ impl DaRelayState {
 
     fn apply_record(&mut self, record: DaRelaySetRecord) -> DaRelayResult {
         let old = self.sets_by_da_id.get(&record.da_id);
-        let old_bytes = old.map_or(0, DaRelaySetRecord::orphan_wire_bytes);
+        let old_bytes = old.map_or(Ok(0), DaRelaySetRecord::orphan_wire_bytes)?;
         let old_commit_bytes = old.map_or(0, DaRelaySetRecord::orphan_commit_bytes);
         let old_pinned_bytes =
             old.map_or(Ok(0), DaRelaySetRecord::pinned_payload_accounting_bytes)?;
-        let new_bytes = record.orphan_wire_bytes();
+        let new_bytes = record.orphan_wire_bytes()?;
         let new_commit_bytes = record.orphan_commit_bytes();
         let new_pinned_bytes = record.pinned_payload_accounting_bytes()?;
         let peer_bytes = self.project_peer_bytes(old, &record)?;
@@ -648,6 +657,22 @@ fn checked_add(left: u64, right: u64) -> DaRelayResult<u64> {
         .ok_or(DaRelayError::AccountingOverflow)
 }
 
+fn retained_tx_accounting_bytes(wire_bytes: u64, tx_bytes: &[u8]) -> u64 {
+    if tx_bytes.is_empty() {
+        wire_bytes
+    } else {
+        tx_bytes.len() as u64
+    }
+}
+
+fn orphan_chunk_accounting_bytes(chunk: &DaRelayChunk) -> DaRelayResult<u64> {
+    let mut bytes = retained_tx_accounting_bytes(chunk.wire_bytes, &chunk.tx_bytes);
+    if !chunk.tx_bytes.is_empty() && !chunk.payload.is_empty() {
+        bytes = checked_add(bytes, chunk.payload.len() as u64)?;
+    }
+    Ok(bytes)
+}
+
 fn sha3_256(input: &[u8]) -> [u8; 32] {
     Sha3_256::digest(input).into()
 }
@@ -747,7 +772,7 @@ mod tests {
     #[test]
     #[rustfmt::skip]
     fn da_relay_staged_mutation_matrix() {
-        let peer = "peer-a:8333"; let pk = || PeerQuotaKey::from_peer_addr(peer); let stage_commit = |state: &mut DaRelayState, commit| state.stage_incomplete_da_commit(peer, commit); let stage_chunk = |state: &mut DaRelayState, chunk| state.stage_incomplete_da_chunk(peer, chunk); let commit = |da_id, chunk_count, wire_bytes| DaRelayCommit { da_id, payload_commitment: [0; 32], peer_quota_key: pk(), chunk_count, wire_bytes }; let chunk = |da_id, chunk_index, payload: &[u8], wire_bytes| DaRelayChunk { da_id, chunk_hash: sha3_256(payload), peer_quota_key: pk(), chunk_index, payload: Arc::from(payload), wire_bytes }; let reject = |got: Result<(), DaRelayError>, want| assert_eq!(got, Err(want));
+        let peer = "peer-a:8333"; let pk = || PeerQuotaKey::from_peer_addr(peer); let stage_commit = |state: &mut DaRelayState, commit| state.stage_incomplete_da_commit(peer, commit); let stage_chunk = |state: &mut DaRelayState, chunk| state.stage_incomplete_da_chunk(peer, chunk); let commit = |da_id, chunk_count, wire_bytes| DaRelayCommit { da_id, payload_commitment: [0; 32], peer_quota_key: pk(), chunk_count, wire_bytes, tx_bytes: Arc::from([]) }; let chunk = |da_id, chunk_index, payload: &[u8], wire_bytes| DaRelayChunk { da_id, chunk_hash: sha3_256(payload), peer_quota_key: pk(), chunk_index, payload: Arc::from(payload), wire_bytes, tx_bytes: Arc::from([]) }; let reject = |got: Result<(), DaRelayError>, want| assert_eq!(got, Err(want));
         let mut state = DaRelayState::new(DaRelayCaps::default()).unwrap(); let mut forged_commit = commit([13; 32], 1, 2); forged_commit.peer_quota_key = PeerQuotaKey::from_peer_addr("peer-b:8333"); stage_commit(&mut state, forged_commit).unwrap(); let mut forged_chunk = chunk([14; 32], 0, b"owned", 6); forged_chunk.peer_quota_key = PeerQuotaKey::from_peer_addr("peer-b:8333"); stage_chunk(&mut state, forged_chunk).unwrap(); assert!(state.orphan_bytes_by_peer_quota_key.contains_key(&pk()) && !state.orphan_bytes_by_peer_quota_key.contains_key(&PeerQuotaKey::from_peer_addr("peer-b:8333")));
         stage_commit(&mut state, commit([1; 32], 3, 2)).unwrap(); assert!(state.sets_by_da_id[&[1; 32]].commit.is_some()); stage_chunk(&mut state, chunk([1; 32], 0, b"payload-a", 9)).unwrap(); stage_chunk(&mut state, chunk([1; 32], 1, b"payload-b", 9)).unwrap(); assert_eq!(state.sets_by_da_id[&[1; 32]].chunks.len(), 2);
         stage_chunk(&mut state, chunk([2; 32], 0, b"payload-a", 9)).unwrap(); stage_chunk(&mut state, chunk([2; 32], 1, b"payload-b", 9)).unwrap(); stage_commit(&mut state, commit([2; 32], 3, 1)).unwrap(); let record = &state.sets_by_da_id[&[2; 32]]; assert!(record.commit.is_some() && record.chunks.len() == 2); assert_eq!(state.orphan_bytes_by_da_id[&[2; 32]], record.wire_bytes);
@@ -772,6 +797,7 @@ mod tests {
             peer_quota_key: PeerQuotaKey::from_peer_addr("forged:8333"),
             chunk_count: payloads.len() as u16,
             wire_bytes,
+            tx_bytes: Arc::from([]),
         };
         let chunk = |da_id, index, payload: &[u8], wire_bytes| DaRelayChunk {
             da_id,
@@ -780,6 +806,7 @@ mod tests {
             chunk_index: index,
             payload: Arc::from(payload),
             wire_bytes,
+            tx_bytes: Arc::from([]),
         };
 
         let mut state = DaRelayState::new(DaRelayCaps::default()).unwrap();
@@ -830,9 +857,166 @@ mod tests {
     }
 
     #[test]
+    fn da_relay_retained_tx_byte_accounting_matrix() {
+        let peer_commit = "commit-peer:8333";
+        let peer_chunk = "chunk-peer:8333";
+        let peer_dup = "duplicate-peer:8333";
+        let payload = b"retained-payload";
+        let payload_wire = payload.len() as u64;
+        let commit_tx = b"canonical-commit-tx";
+        let chunk_tx = b"canonical-chunk-tx";
+        let commit = |da_id, payloads: &[&[u8]], wire_bytes, tx_bytes: &[u8]| DaRelayCommit {
+            da_id,
+            payload_commitment: payload_commitment(payloads),
+            peer_quota_key: PeerQuotaKey::from_peer_addr("forged:8333"),
+            chunk_count: payloads.len() as u16,
+            wire_bytes,
+            tx_bytes: Arc::from(tx_bytes),
+        };
+        let chunk = |da_id, index, payload: &[u8], wire_bytes, tx_bytes: &[u8]| DaRelayChunk {
+            da_id,
+            chunk_hash: sha3_256(payload),
+            peer_quota_key: PeerQuotaKey::from_peer_addr("forged:8333"),
+            chunk_index: index,
+            payload: Arc::from(payload),
+            wire_bytes,
+            tx_bytes: Arc::from(tx_bytes),
+        };
+
+        let mut state = DaRelayState::new(DaRelayCaps::default()).unwrap();
+        let invalid_commit = commit([68; 32], &[payload], 0, b"invalid-commit-tx");
+        assert_eq!(
+            state.stage_incomplete_da_commit(peer_commit, invalid_commit),
+            Err(InvalidWireBytes)
+        );
+
+        let mut invalid_hash = chunk([69; 32], 0, payload, payload_wire, b"invalid-chunk-tx");
+        invalid_hash.chunk_hash[0] ^= 0xff;
+        assert_eq!(
+            state.stage_incomplete_da_chunk(peer_chunk, invalid_hash),
+            Err(ChunkHashMismatch)
+        );
+        assert!(state.sets_by_da_id.is_empty());
+
+        let mut state = DaRelayState::new(DaRelayCaps::default()).unwrap();
+        state
+            .stage_incomplete_da_commit(
+                peer_commit,
+                commit([70; 32], &[payload, b"tail"], 1, commit_tx),
+            )
+            .unwrap();
+        state
+            .stage_incomplete_da_chunk(
+                peer_chunk,
+                chunk([70; 32], 0, payload, payload_wire, chunk_tx),
+            )
+            .unwrap();
+        let record = &state.sets_by_da_id[&[70; 32]];
+        let retained_wire = (commit_tx.len() + chunk_tx.len()) as u64;
+        assert_eq!(record.wire_bytes, retained_wire);
+        assert_eq!(state.orphan_commit_overhead_bytes, commit_tx.len() as u64);
+        assert_eq!(state.orphan_bytes, retained_wire + payload.len() as u64);
+        assert_eq!(state.orphan_bytes_by_da_id[&[70; 32]], state.orphan_bytes);
+        assert_eq!(
+            record.peer_bytes[&PeerQuotaKey::from_peer_addr(peer_commit)],
+            commit_tx.len() as u64
+        );
+        assert_eq!(
+            record.peer_bytes[&PeerQuotaKey::from_peer_addr(peer_chunk)],
+            (chunk_tx.len() + payload.len()) as u64
+        );
+
+        let before = state.clone();
+        assert_eq!(
+            state.stage_incomplete_da_commit(
+                peer_dup,
+                commit([70; 32], &[b"other"], 99, b"duplicate-commit-tx"),
+            ),
+            Err(DuplicateCommit)
+        );
+        assert_eq!(state, before);
+
+        let mut duplicate_chunk = chunk([70; 32], 0, b"conflict", 99, b"duplicate-chunk-tx");
+        duplicate_chunk.chunk_hash[0] ^= 0xff;
+        assert_eq!(
+            state.stage_incomplete_da_chunk(peer_dup, duplicate_chunk),
+            Err(DuplicateChunk)
+        );
+        assert_eq!(state, before);
+
+        let mut state = DaRelayState::new(DaRelayCaps::default()).unwrap();
+        state
+            .stage_incomplete_da_commit(peer_commit, commit([71; 32], &[payload], 1, commit_tx))
+            .unwrap();
+        state
+            .stage_incomplete_da_chunk(
+                peer_chunk,
+                chunk([71; 32], 0, payload, payload_wire, chunk_tx),
+            )
+            .unwrap();
+        let record = &state.sets_by_da_id[&[71; 32]];
+        assert_eq!(record.state, DaRelaySetState::CompleteSet);
+        let chunk_count = u64::from(record.commit.as_ref().unwrap().chunk_count);
+        assert!(record.chunks.values().all(|chunk| chunk.payload.is_empty()));
+        let pinned = retained_wire
+            + DA_COMPLETE_SET_RECORD_FOOTPRINT
+            + chunk_count * DA_COMPLETE_SET_CHUNK_FOOTPRINT;
+        assert_eq!(state.pinned_payload_bytes, pinned);
+        assert_eq!(state.orphan_bytes, 0);
+
+        let tight_caps = DaRelayCaps {
+            orphan_commit_overhead_bytes: 1,
+            ..DaRelayCaps::default()
+        };
+        let mut state = DaRelayState::new(tight_caps).unwrap();
+        state
+            .stage_incomplete_da_chunk(peer_chunk, chunk([74; 32], 0, b"x", 1, &[]))
+            .unwrap();
+        state
+            .stage_incomplete_da_commit(peer_commit, commit([74; 32], &[b"x"], 1, commit_tx))
+            .unwrap();
+        assert_eq!(
+            state.sets_by_da_id[&[74; 32]].state,
+            DaRelaySetState::CompleteSet
+        );
+
+        let caps = DaRelayCaps {
+            pinned_payload_bytes: 1,
+            ..DaRelayCaps::default()
+        };
+        let mut state = DaRelayState::new(caps).unwrap();
+        state
+            .stage_incomplete_da_commit(peer_commit, commit([72; 32], &[payload], 1, commit_tx))
+            .unwrap();
+        let before = state.clone();
+        assert_eq!(
+            state.stage_incomplete_da_chunk(
+                peer_chunk,
+                chunk([72; 32], 0, payload, payload_wire, chunk_tx)
+            ),
+            Err(AccountingCapExceeded)
+        );
+        assert_eq!(state, before);
+
+        let mut state = DaRelayState::new(caps).unwrap();
+        state
+            .stage_incomplete_da_chunk(peer_chunk, chunk([73; 32], 0, payload, payload_wire, &[]))
+            .unwrap();
+        let before = state.clone();
+        assert_eq!(
+            state.stage_incomplete_da_commit(
+                peer_commit,
+                commit([73; 32], &[payload], 1, commit_tx),
+            ),
+            Err(AccountingCapExceeded)
+        );
+        assert_eq!(state, before);
+    }
+
+    #[test]
     #[rustfmt::skip]
     fn da_relay_complete_integrity_matrix() {
-        let peer = "peer-a:8333"; let pk = || PeerQuotaKey::from_peer_addr(peer); let commit = |da_id, payloads: &[&[u8]], wire_bytes| DaRelayCommit { da_id, payload_commitment: payload_commitment(payloads), peer_quota_key: pk(), chunk_count: payloads.len() as u16, wire_bytes }; let chunk = |da_id, index, payload: &[u8], wire_bytes| DaRelayChunk { da_id, chunk_hash: sha3_256(payload), peer_quota_key: pk(), chunk_index: index, payload: Arc::from(payload), wire_bytes };
+        let peer = "peer-a:8333"; let pk = || PeerQuotaKey::from_peer_addr(peer); let commit = |da_id, payloads: &[&[u8]], wire_bytes| DaRelayCommit { da_id, payload_commitment: payload_commitment(payloads), peer_quota_key: pk(), chunk_count: payloads.len() as u16, wire_bytes, tx_bytes: Arc::from([]) }; let chunk = |da_id, index, payload: &[u8], wire_bytes| DaRelayChunk { da_id, chunk_hash: sha3_256(payload), peer_quota_key: pk(), chunk_index: index, payload: Arc::from(payload), wire_bytes, tx_bytes: Arc::from([]) };
         let mut state = DaRelayState::new(DaRelayCaps::default()).unwrap(); state.stage_incomplete_da_commit(peer, commit([20; 32], &[b"aa", b"bb"], 2)).unwrap(); state.stage_incomplete_da_chunk(peer, chunk([20; 32], 0, b"aa", 2)).unwrap(); state.stage_incomplete_da_chunk(peer, chunk([20; 32], 1, b"bb", 2)).unwrap(); let record = &state.sets_by_da_id[&[20; 32]]; let chunk_count = u64::from(record.commit.as_ref().unwrap().chunk_count); assert_eq!(record.state, DaRelaySetState::CompleteSet); assert_eq!(record.payload_bytes, 4); assert_eq!(record.ttl_blocks_remaining, 0); assert!(record.chunks.values().all(|chunk| chunk.payload.is_empty())); assert_eq!(state.orphan_bytes, 0); assert!(!state.orphan_bytes_by_da_id.contains_key(&[20; 32])); assert_eq!(state.pinned_payload_bytes, record.wire_bytes + DA_COMPLETE_SET_RECORD_FOOTPRINT + chunk_count * DA_COMPLETE_SET_CHUNK_FOOTPRINT);
         let mut state = DaRelayState::new(DaRelayCaps::default()).unwrap(); state.stage_incomplete_da_commit(peer, commit([21; 32], &[b"good"], 1)).unwrap(); assert_eq!(state.stage_incomplete_da_chunk(peer, chunk([21; 32], 0, b"bad", 3)), Err(PayloadCommitmentMismatch)); let record = &state.sets_by_da_id[&[21; 32]]; assert_eq!(record.state, DaRelaySetState::StagedCommit); assert_eq!(record.payload_bytes, 0); assert!(record.chunks.is_empty() && record.replaceable_chunks.is_empty()); assert_eq!(state.pinned_payload_bytes, 0); state.stage_incomplete_da_chunk(peer, chunk([21; 32], 0, b"good", 4)).unwrap(); let record = &state.sets_by_da_id[&[21; 32]]; assert_eq!(record.state, DaRelaySetState::CompleteSet); assert!(record.replaceable_chunks.is_empty());
         let mut state = DaRelayState::new(DaRelayCaps::default()).unwrap(); state.stage_incomplete_da_chunk(peer, chunk([22; 32], 0, b"bad", 3)).unwrap(); assert_eq!(state.stage_incomplete_da_commit(peer, commit([22; 32], &[b"good"], 1)), Err(PayloadCommitmentMismatch)); let record = &state.sets_by_da_id[&[22; 32]]; assert_eq!(record.state, DaRelaySetState::StagedCommit); assert!(record.chunks.is_empty()); assert_eq!(state.pinned_payload_bytes, 0); state.stage_incomplete_da_chunk(peer, chunk([22; 32], 0, b"good", 4)).unwrap(); assert_eq!(state.sets_by_da_id[&[22; 32]].state, DaRelaySetState::CompleteSet);
@@ -850,6 +1034,7 @@ mod tests {
             peer_quota_key: pk(),
             chunk_count: payloads.len() as u16,
             wire_bytes,
+            tx_bytes: Arc::from([]),
         };
         let chunk = |da_id, index, payload: &[u8], wire_bytes| DaRelayChunk {
             da_id,
@@ -858,6 +1043,7 @@ mod tests {
             chunk_index: index,
             payload: Arc::from(payload),
             wire_bytes,
+            tx_bytes: Arc::from([]),
         };
         let mut state = DaRelayState::new(DaRelayCaps::default()).unwrap();
         state


### PR DESCRIPTION
Scope:
- Fixes #1844 / RUB-382.
- Adds Rust DA relay retained `tx_bytes` accounting in `clients/rust/crates/rubin-node/src/da_relay.rs`.
- Retains canonical commit/chunk transaction bytes only through accepted DA relay state transitions, then accounts retained bytes for incomplete orphan state and complete-set pinned memory.
- Keeps P2P tx ingestion hooks, provider API, miner selection, stale provider pruning, DA prefetch planner, `getdachunk`, and consensus crate changes out of scope.

Parity Matrix:
| Vector / case | Go reference | Go callsite / entrypoint | Rust behavior | Rust callsite / entrypoint | Rust mirror-test evidence |
| --- | --- | --- | --- | --- | --- |
| retained_tx_bytes_after_validation | `addDACommit`, `addDAChunk`, and `cloneRetainedTxBytes` retain `txBytes` only after invalid wire/hash and duplicate checks reject | `clients/go/node/p2p/da_relay_state.go`: `addDACommit`, `addDAChunk`, `stageDACommitRecordLocked`, `stageDAChunkRecordLocked` | `tx_bytes` is retained on accepted `DaRelayCommit` and `DaRelayChunk`; invalid wire/hash and duplicate commit/chunk paths leave state unchanged | `DaRelayState::stage_incomplete_da_commit`, `DaRelayState::stage_incomplete_da_chunk` | `da_relay_retained_tx_byte_accounting_matrix` invalid and duplicate rows |
| retained_tx_accounting_split | `retainedTxAccountingBytes`, `recomputeOrphanTotals`, and `orphanAccounting` use retained tx length when present and add chunk payload bytes for incomplete chunk orphan accounting | `clients/go/node/p2p/da_relay_state.go`: `recomputeOrphanTotals`, `orphanAccounting`, `projectOrphanAccountingDeltaLocked` | record `wire_bytes` uses retained tx lengths; incomplete chunk orphan global, per-da_id, and per-peer bytes add retained tx length plus payload bytes | `DaRelaySetRecord::recompute_wire_bytes`, `orphan_chunk_accounting_bytes`, `DaRelayState::apply_record` | `da_relay_retained_tx_byte_accounting_matrix` retained incomplete accounting rows |
| complete_set_pinned_footprint | `markComplete` clears retained payloads and `pinnedPayloadAccountingBytes` charges retained record wire bytes plus record and chunk footprint | `clients/go/node/p2p/da_relay_state.go`: `addDACommit`, `addDAChunk`, `markComplete`, `pinnedPayloadAccountingBytes` | complete sets clear chunk payload buffers, charge retained wire bytes plus `DA_COMPLETE_SET_RECORD_FOOTPRINT` plus `chunk_count * DA_COMPLETE_SET_CHUNK_FOOTPRINT`, and leave orphan accounting at zero | `DaRelaySetRecord::mark_complete`, `DaRelaySetRecord::pinned_payload_accounting_bytes`, `DaRelayState::apply_record` | `da_relay_retained_tx_byte_accounting_matrix` complete retained pinned row |
| completion_transient_orphan_cap | Go complete paths check final complete-set accounting instead of failing on transient incomplete orphan commit overhead | `clients/go/node/p2p/da_relay_state.go`: `stageDACommitRecordLocked`, `addDACommit`, `checkDASetRecordCapsLocked` | a tight `orphan_commit_overhead_bytes` cap still permits a valid transition to `CompleteSet` when final orphan accounting is zero | `DaRelayState::prepare_and_apply_record`, `DaRelaySetRecord::orphan_commit_bytes` | `da_relay_retained_tx_byte_accounting_matrix` tight `orphan_commit_overhead_bytes` row |
| pinned_cap_failure_before_mutation | `checkDASetRecordCapsLocked` and `projectPinnedPayloadDeltaLocked` reject pinned cap failures before replacing prior staged/orphan state | `clients/go/node/p2p/da_relay_state.go`: `addDACommit`, `addDAChunk`, `checkDASetRecordCapsLocked`, `projectPinnedPayloadDeltaLocked` | chunk-completion and commit-completion pinned cap failures return `AccountingCapExceeded` before mutating the previous state snapshot | `DaRelayState::prepare_and_apply_record`, `DaRelayState::apply_record`, `DaRelayState::project_counter` | `da_relay_retained_tx_byte_accounting_matrix` pinned cap rows |
| complete_eviction_accounting_retains_existing_contract | `evictionAccounting` and `completeSetCandidates` expose complete-set accounting only and do not treat incomplete retained tx-byte state as eviction candidates | `clients/go/node/p2p/da_relay_state.go`: `evictionAccounting`, `completeSetCandidates` | eviction accounting remains complete-set-only and bounded; incomplete/orphan and zero-field records still suppress candidates | `DaRelaySetRecord::eviction_accounting`, `DaRelayState::complete_set_eviction_candidates` | `da_relay_eviction_accounting_matrix` |

Evidence:
- `scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test -p rubin-node da_relay --lib'` - PASS
- `scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test --workspace'` - PASS
- `scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo clippy -p rubin-node --lib -- -D warnings'` - PASS
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./node/p2p -run "DARelay(AccountingUsesRetainedTxByteLengths|CompletionIgnoresTransientOrphanCapsForRetainedTxBytes|RejectsDuplicatesBeforeMutation|RejectsIntegrityAndPinnedCapSafely|PinnedPayloadDeltaKeepsOverflowAndCapErrorsDistinct|CompleteSetCandidates)" -count=1'` - PASS
- Coverage: diff 100.00% (28/28), variation +0.01%.
