### PR TITLE
RUB-384: stage Rust DA relay txs after admission

### DIFF
--- a/clients/rust/crates/rubin-node/src/da_relay.rs
+++ b/clients/rust/crates/rubin-node/src/da_relay.rs
@@ -398,12 +398,13 @@ impl DaRelayState {
     }
 
     #[rustfmt::skip]
-    pub(crate) fn validate_relay_da_tx_for_admission(tx_bytes: &[u8]) -> DaRelayResult {
-        if relay_da_tx_kind_prefix(tx_bytes) != Some(0x02) { return Ok(()); }
-        let Ok((tx, _txid, _wtxid, consumed)) = parse_tx(tx_bytes) else { return Ok(()); };
-        if consumed != tx_bytes.len() { return Ok(()); }
+    pub(crate) fn validate_relay_da_tx_for_admission(tx_bytes: &[u8]) -> DaRelayResult<Option<[u8; 32]>> {
+        if relay_da_tx_kind_prefix(tx_bytes) != Some(0x02) { return Ok(None); }
+        let Ok((tx, txid, _wtxid, consumed)) = parse_tx(tx_bytes) else { return Ok(None); };
+        if consumed != tx_bytes.len() { return Ok(None); }
         let wire_bytes = u64::try_from(tx_bytes.len()).map_err(|_| DaRelayError::AccountingOverflow)?;
-        validate_relay_da_chunk_for_admission(&tx, wire_bytes)
+        validate_relay_da_chunk_for_admission(&tx, wire_bytes)?;
+        Ok(Some(txid))
     }
 
     pub(crate) fn stage_relay_da_tx_bytes(
@@ -869,11 +870,11 @@ mod tests {
     fn validate_relay_da_tx_for_admission_fast_paths_non_chunk_prefixes() {
         let non_da = relay_test_tx(0x00, Vec::new(), None, None, &[]);
         assert_eq!(relay_da_tx_kind_prefix(&non_da), Some(0x00));
-        DaRelayState::validate_relay_da_tx_for_admission(&non_da).unwrap();
+        assert_eq!(DaRelayState::validate_relay_da_tx_for_admission(&non_da).unwrap(), None);
 
         let commit = relay_test_tx(0x01, vec![da_commit_output([2u8; 32])], Some(relay_commit_core([3u8; 32], 1)), None, &[]);
         assert_eq!(relay_da_tx_kind_prefix(&commit), Some(0x01));
-        DaRelayState::validate_relay_da_tx_for_admission(&commit).unwrap();
+        assert_eq!(DaRelayState::validate_relay_da_tx_for_admission(&commit).unwrap(), None);
 
         assert_eq!(relay_da_tx_kind_prefix(&[0u8; 4]), None);
         assert_eq!(relay_da_tx_kind_prefix(&[0xff, 0, 0, 0, 0x02]), None);

--- a/clients/rust/crates/rubin-node/src/da_relay.rs
+++ b/clients/rust/crates/rubin-node/src/da_relay.rs
@@ -3,7 +3,8 @@ use std::collections::BTreeSet;
 use std::net::{IpAddr, Ipv6Addr};
 use std::sync::Arc;
 
-use rubin_consensus::constants::{CHUNK_BYTES, MAX_DA_CHUNK_COUNT};
+use rubin_consensus::constants::{CHUNK_BYTES, COV_TYPE_DA_COMMIT, MAX_DA_CHUNK_COUNT};
+use rubin_consensus::{parse_tx, Tx};
 use sha3::{Digest, Sha3_256};
 
 pub const DA_ORPHAN_POOL_BYTES: u64 = 64 << 20;
@@ -394,6 +395,88 @@ impl DaRelayState {
             && self.sets_by_da_id.is_empty()
     }
 
+    #[rustfmt::skip]
+    pub(crate) fn validate_relay_da_tx_for_admission(tx_bytes: &[u8]) -> DaRelayResult {
+        let Ok((tx, _txid, _wtxid, consumed)) = parse_tx(tx_bytes) else { return Ok(()); };
+        if consumed != tx_bytes.len() { return Ok(()); }
+        let wire_bytes = u64::try_from(tx_bytes.len()).map_err(|_| DaRelayError::AccountingOverflow)?;
+        validate_relay_da_chunk_for_admission(&tx, wire_bytes)
+    }
+
+    pub(crate) fn stage_relay_da_tx_bytes(
+        &mut self,
+        peer_addr: &str,
+        tx_bytes: &[u8],
+    ) -> DaRelayResult {
+        let wire_bytes =
+            u64::try_from(tx_bytes.len()).map_err(|_| DaRelayError::AccountingOverflow)?;
+        if wire_bytes == 0 {
+            return Err(DaRelayError::InvalidWireBytes);
+        }
+        let (tx, _txid, _wtxid, consumed) =
+            parse_tx(tx_bytes).map_err(|_| DaRelayError::InvalidWireBytes)?;
+        if consumed != tx_bytes.len() {
+            return Err(DaRelayError::InvalidWireBytes);
+        }
+        match tx.tx_kind {
+            0x01 => {
+                let Some(core) = tx.da_commit_core.as_ref() else {
+                    return Ok(());
+                };
+                let Some(payload_commitment) = relay_da_commit_payload_commitment(&tx) else {
+                    return Ok(());
+                };
+                if core.chunk_count == 0 || u64::from(core.chunk_count) > MAX_DA_CHUNK_COUNT {
+                    return Err(DaRelayError::InvalidCommitChunkCount);
+                }
+                if self
+                    .sets_by_da_id
+                    .get(&core.da_id)
+                    .is_some_and(|record| record.commit.is_some())
+                {
+                    return Err(DaRelayError::DuplicateCommit);
+                }
+                self.stage_incomplete_da_commit(
+                    peer_addr,
+                    DaRelayCommit {
+                        da_id: core.da_id,
+                        payload_commitment,
+                        peer_quota_key: PeerQuotaKey::from_peer_addr(peer_addr),
+                        chunk_count: core.chunk_count,
+                        wire_bytes,
+                        tx_bytes: Arc::from(tx_bytes),
+                    },
+                )
+            }
+            0x02 => {
+                let Some(core) = tx.da_chunk_core.as_ref() else {
+                    return Ok(());
+                };
+                validate_relay_da_chunk_for_admission(&tx, wire_bytes)?;
+                if let Some(record) = self.sets_by_da_id.get(&core.da_id) {
+                    record.validate_chunk_insert(core.chunk_index)?;
+                }
+                self.stage_incomplete_da_chunk(
+                    peer_addr,
+                    DaRelayChunk {
+                        da_id: core.da_id,
+                        chunk_hash: core.chunk_hash,
+                        peer_quota_key: PeerQuotaKey::from_peer_addr(peer_addr),
+                        chunk_index: core.chunk_index,
+                        payload: Arc::from(tx.da_payload.as_slice()),
+                        wire_bytes,
+                        tx_bytes: Arc::from(tx_bytes),
+                    },
+                )
+            }
+            _ => Ok(()),
+        }
+    }
+
+    #[cfg(test)]
+    #[rustfmt::skip]
+    pub(crate) fn test_record_summary(&self, da_id: [u8; 32]) -> Option<(bool, usize, u64)> { let record = self.sets_by_da_id.get(&da_id)?; Some((record.commit.is_some(), record.chunks.len(), record.wire_bytes)) }
+
     pub(crate) fn complete_set_eviction_candidates(
         &self,
         max_payload_bytes: u64,
@@ -638,6 +721,29 @@ impl DaRelayState {
         Ok(projected)
     }
 }
+
+#[rustfmt::skip]
+fn validate_relay_da_chunk_for_admission(tx: &Tx, wire_bytes: u64) -> DaRelayResult {
+    if tx.tx_kind != 0x02 { return Ok(()); }
+    let Some(core) = tx.da_chunk_core.as_ref() else { return Ok(()); };
+    let payload_len = u64::try_from(tx.da_payload.len()).map_err(|_| DaRelayError::AccountingOverflow)?;
+    if u64::from(core.chunk_index) >= MAX_DA_CHUNK_COUNT { return Err(DaRelayError::ChunkIndexOutOfRange); }
+    if payload_len == 0 || payload_len > CHUNK_BYTES { return Err(DaRelayError::ChunkPayloadSizeInvalid); }
+    if wire_bytes < payload_len { return Err(DaRelayError::InvalidWireBytes); }
+    if sha3_256(&tx.da_payload) != core.chunk_hash { return Err(DaRelayError::ChunkHashMismatch); }
+    Ok(())
+}
+
+#[rustfmt::skip]
+fn relay_da_commit_payload_commitment(tx: &Tx) -> Option<[u8; 32]> {
+    let mut found = None;
+    for output in tx.outputs.iter().filter(|output| output.covenant_type == COV_TYPE_DA_COMMIT) {
+        if output.covenant_data.len() != 32 || found.is_some() { return None; }
+        let mut payload_commitment = [0u8; 32]; payload_commitment.copy_from_slice(&output.covenant_data); found = Some(payload_commitment);
+    }
+    found
+}
+
 fn validate_da_chunk(chunk: &DaRelayChunk) -> DaRelayResult {
     if u64::from(chunk.chunk_index) >= MAX_DA_CHUNK_COUNT {
         return Err(DaRelayError::ChunkIndexOutOfRange);
@@ -716,6 +822,35 @@ mod tests {
         assert!(state.is_empty());
         state.next_received_time = 1;
         assert!(state.is_empty());
+    }
+
+    #[rustfmt::skip]
+    fn relay_test_tx(tx_kind: u8, outputs: Vec<rubin_consensus::TxOutput>, da_commit_core: Option<rubin_consensus::DaCommitCore>, da_chunk_core: Option<rubin_consensus::DaChunkCore>, da_payload: &[u8]) -> Vec<u8> { rubin_consensus::marshal_tx(&rubin_consensus::Tx { version: rubin_consensus::constants::TX_WIRE_VERSION, tx_kind, tx_nonce: 7, inputs: Vec::new(), outputs, locktime: 0, da_commit_core, da_chunk_core, witness: Vec::new(), da_payload: da_payload.to_vec() }).expect("marshal relay test tx") }
+
+    #[rustfmt::skip]
+    fn relay_commit_core(da_id: [u8; 32], chunk_count: u16) -> rubin_consensus::DaCommitCore { rubin_consensus::DaCommitCore { da_id, chunk_count, retl_domain_id: [0x10; 32], batch_number: 1, tx_data_root: [0x11; 32], state_root: [0x12; 32], withdrawals_root: [0x13; 32], batch_sig_suite: 0, batch_sig: Vec::new() } }
+
+    #[rustfmt::skip]
+    fn relay_chunk_core(da_id: [u8; 32], chunk_index: u16, payload: &[u8]) -> rubin_consensus::DaChunkCore { rubin_consensus::DaChunkCore { da_id, chunk_index, chunk_hash: sha3_256(payload) } }
+
+    #[rustfmt::skip]
+    fn da_commit_output(payload_commitment: [u8; 32]) -> rubin_consensus::TxOutput { rubin_consensus::TxOutput { value: 0, covenant_type: rubin_consensus::constants::COV_TYPE_DA_COMMIT, covenant_data: payload_commitment.to_vec() } }
+
+    #[test]
+    #[rustfmt::skip]
+    fn stage_relay_da_tx_bytes_contract_matrix() {
+        let peer = "peer-a:8333"; let mut state = DaRelayState::new(DaRelayCaps::default()).unwrap();
+        let non_da = relay_test_tx(0x00, Vec::new(), None, None, &[]); state.stage_relay_da_tx_bytes(peer, &non_da).unwrap();
+        let mut trailing = non_da; trailing.push(0); assert_eq!(state.stage_relay_da_tx_bytes(peer, &trailing), Err(InvalidWireBytes)); assert!(state.is_empty());
+
+        let da_id = [1u8; 32]; let payload_commitment = [2u8; 32];
+        let raw = relay_test_tx(0x01, vec![da_commit_output(payload_commitment)], Some(relay_commit_core(da_id, 1)), None, &[]); state.stage_relay_da_tx_bytes(peer, &raw).unwrap(); let record = state.sets_by_da_id.get(&da_id).unwrap();
+        assert_eq!((record.commit.is_some(), record.chunks.len(), record.wire_bytes), (true, 0, raw.len() as u64));
+        let commit = state.sets_by_da_id[&da_id].commit.as_ref().unwrap(); assert_eq!(commit.payload_commitment, payload_commitment); assert_eq!(commit.tx_bytes.as_ref(), raw.as_slice());
+        let before = state.clone(); assert_eq!(state.stage_relay_da_tx_bytes(peer, &raw), Err(DuplicateCommit)); assert_eq!(state, before);
+
+        let mut reject_state = DaRelayState::new(DaRelayCaps::default()).unwrap(); let payload = b"relay chunk"; let mut bad_core = relay_chunk_core([6u8; 32], 0, payload); bad_core.chunk_hash = [7u8; 32];
+        let bad = relay_test_tx(0x02, Vec::new(), None, Some(bad_core), payload); assert_eq!(reject_state.stage_relay_da_tx_bytes(peer, &bad), Err(ChunkHashMismatch)); assert!(reject_state.is_empty());
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/da_relay.rs
+++ b/clients/rust/crates/rubin-node/src/da_relay.rs
@@ -729,6 +729,10 @@ impl DaRelayState {
     }
 }
 
+pub(crate) fn stages_relay_da_tx_bytes(tx_bytes: &[u8]) -> bool {
+    matches!(relay_da_tx_kind_prefix(tx_bytes), Some(0x01 | 0x02))
+}
+
 fn relay_da_tx_kind_prefix(tx_bytes: &[u8]) -> Option<u8> {
     let version = u32::from_le_bytes(tx_bytes.get(..4)?.try_into().ok()?);
     if version != TX_WIRE_VERSION {

--- a/clients/rust/crates/rubin-node/src/da_relay.rs
+++ b/clients/rust/crates/rubin-node/src/da_relay.rs
@@ -3,7 +3,9 @@ use std::collections::BTreeSet;
 use std::net::{IpAddr, Ipv6Addr};
 use std::sync::Arc;
 
-use rubin_consensus::constants::{CHUNK_BYTES, COV_TYPE_DA_COMMIT, MAX_DA_CHUNK_COUNT};
+use rubin_consensus::constants::{
+    CHUNK_BYTES, COV_TYPE_DA_COMMIT, MAX_DA_CHUNK_COUNT, TX_WIRE_VERSION,
+};
 use rubin_consensus::{parse_tx, Tx};
 use sha3::{Digest, Sha3_256};
 
@@ -397,6 +399,7 @@ impl DaRelayState {
 
     #[rustfmt::skip]
     pub(crate) fn validate_relay_da_tx_for_admission(tx_bytes: &[u8]) -> DaRelayResult {
+        if relay_da_tx_kind_prefix(tx_bytes) != Some(0x02) { return Ok(()); }
         let Ok((tx, _txid, _wtxid, consumed)) = parse_tx(tx_bytes) else { return Ok(()); };
         if consumed != tx_bytes.len() { return Ok(()); }
         let wire_bytes = u64::try_from(tx_bytes.len()).map_err(|_| DaRelayError::AccountingOverflow)?;
@@ -722,6 +725,14 @@ impl DaRelayState {
     }
 }
 
+fn relay_da_tx_kind_prefix(tx_bytes: &[u8]) -> Option<u8> {
+    let version = u32::from_le_bytes(tx_bytes.get(..4)?.try_into().ok()?);
+    if version != TX_WIRE_VERSION {
+        return None;
+    }
+    tx_bytes.get(4).copied()
+}
+
 #[rustfmt::skip]
 fn validate_relay_da_chunk_for_admission(tx: &Tx, wire_bytes: u64) -> DaRelayResult {
     if tx.tx_kind != 0x02 { return Ok(()); }
@@ -851,6 +862,26 @@ mod tests {
 
         let mut reject_state = DaRelayState::new(DaRelayCaps::default()).unwrap(); let payload = b"relay chunk"; let mut bad_core = relay_chunk_core([6u8; 32], 0, payload); bad_core.chunk_hash = [7u8; 32];
         let bad = relay_test_tx(0x02, Vec::new(), None, Some(bad_core), payload); assert_eq!(reject_state.stage_relay_da_tx_bytes(peer, &bad), Err(ChunkHashMismatch)); assert!(reject_state.is_empty());
+    }
+
+    #[test]
+    #[rustfmt::skip]
+    fn validate_relay_da_tx_for_admission_fast_paths_non_chunk_prefixes() {
+        let non_da = relay_test_tx(0x00, Vec::new(), None, None, &[]);
+        assert_eq!(relay_da_tx_kind_prefix(&non_da), Some(0x00));
+        DaRelayState::validate_relay_da_tx_for_admission(&non_da).unwrap();
+
+        let commit = relay_test_tx(0x01, vec![da_commit_output([2u8; 32])], Some(relay_commit_core([3u8; 32], 1)), None, &[]);
+        assert_eq!(relay_da_tx_kind_prefix(&commit), Some(0x01));
+        DaRelayState::validate_relay_da_tx_for_admission(&commit).unwrap();
+
+        assert_eq!(relay_da_tx_kind_prefix(&[0u8; 4]), None);
+        assert_eq!(relay_da_tx_kind_prefix(&[0xff, 0, 0, 0, 0x02]), None);
+
+        let payload = b"relay chunk"; let mut bad_core = relay_chunk_core([4u8; 32], 0, payload); bad_core.chunk_hash = [5u8; 32];
+        let bad_chunk = relay_test_tx(0x02, Vec::new(), None, Some(bad_core), payload);
+        assert_eq!(relay_da_tx_kind_prefix(&bad_chunk), Some(0x02));
+        assert_eq!(DaRelayState::validate_relay_da_tx_for_admission(&bad_chunk), Err(ChunkHashMismatch));
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/da_relay.rs
+++ b/clients/rust/crates/rubin-node/src/da_relay.rs
@@ -294,6 +294,41 @@ impl DaRelaySetRecord {
     fn orphan_peer_bytes(&self) -> Option<&BTreeMap<PeerQuotaKey, u64>> {
         (self.state != DaRelaySetState::CompleteSet).then_some(&self.peer_bytes)
     }
+
+    #[rustfmt::skip]
+    fn orphan_peer_bytes_with_retained_tx_bytes(&self, retained: RetainedTxBytes<'_>) -> DaRelayResult<Option<BTreeMap<PeerQuotaKey, u64>>> {
+        if self.state == DaRelaySetState::CompleteSet { return Ok(None); }
+        let mut peer_bytes = BTreeMap::new();
+        if let Some(commit) = &self.commit { peer_bytes.insert(commit.peer_quota_key.clone(), commit_orphan_bytes_with_retained_tx_bytes(commit, retained)); }
+        for chunk in self.chunks.values() { let entry = peer_bytes.entry(chunk.peer_quota_key.clone()).or_default(); *entry = checked_add(*entry, chunk_orphan_bytes_with_retained_tx_bytes(chunk, retained)?)?; }
+        Ok(Some(peer_bytes))
+    }
+
+    #[rustfmt::skip]
+    fn orphan_wire_bytes_with_retained_tx_bytes(&self, retained: RetainedTxBytes<'_>) -> DaRelayResult<u64> {
+        if self.state == DaRelaySetState::CompleteSet { return Ok(0); }
+        let Some(peer_bytes) = self.orphan_peer_bytes_with_retained_tx_bytes(retained)? else { return Ok(0); };
+        peer_bytes.values().try_fold(0u64, |total, bytes| checked_add(total, *bytes))
+    }
+
+    #[rustfmt::skip]
+    fn orphan_commit_bytes_with_retained_tx_bytes(&self, retained: RetainedTxBytes<'_>) -> u64 {
+        if self.state == DaRelaySetState::CompleteSet { 0 } else { self.commit.as_ref().map_or(0, |commit| commit_orphan_bytes_with_retained_tx_bytes(commit, retained)) }
+    }
+
+    #[rustfmt::skip]
+    fn without_peer_quota_key(&self, key: &PeerQuotaKey) -> DaRelayResult<(Self, bool)> {
+        let mut updated = self.clone(); let had_commit = updated.commit.as_ref().is_some_and(|commit| &commit.peer_quota_key == key);
+        if had_commit { updated.commit = None; updated.replaceable_chunks.clear(); }
+        let before_chunks = updated.chunks.len(); updated.chunks.retain(|_index, chunk| &chunk.peer_quota_key != key); updated.replaceable_chunks.retain(|index| updated.chunks.contains_key(index));
+        let changed = had_commit || before_chunks != updated.chunks.len();
+        if changed { if updated.commit.is_none() { updated.state = DaRelaySetState::OrphanChunks; } else if updated.state != DaRelaySetState::CompleteSet { updated.state = DaRelaySetState::StagedCommit; } updated.payload_bytes = 0; updated.recompute_wire_bytes()?; }
+        Ok((updated, changed))
+    }
+
+    #[rustfmt::skip]
+    fn empty_incomplete(&self) -> bool { self.state != DaRelaySetState::CompleteSet && self.commit.is_none() && self.chunks.is_empty() }
+
     fn pinned_payload_accounting_bytes(&self) -> DaRelayResult<u64> {
         if self.state != DaRelaySetState::CompleteSet || self.payload_bytes == 0 {
             return Ok(0);
@@ -372,6 +407,49 @@ enum CompletionMismatchAction {
     DropMatchingChunks,
     MarkMatchingChunksReplaceable,
 }
+
+#[derive(Clone, Copy)]
+enum RetainedTxBytes<'a> {
+    None,
+    Commit {
+        da_id: [u8; 32],
+        tx_bytes: &'a [u8],
+    },
+    Chunk {
+        da_id: [u8; 32],
+        chunk_index: u16,
+        tx_bytes: &'a [u8],
+    },
+}
+
+#[rustfmt::skip]
+impl<'a> RetainedTxBytes<'a> {
+    fn is_none(self) -> bool {
+        matches!(self, Self::None)
+    }
+
+    fn commit_len(self, commit: &DaRelayCommit) -> Option<u64> {
+        match self { Self::Commit { da_id, tx_bytes } if da_id == commit.da_id => Some(tx_bytes.len() as u64), _ => None }
+    }
+
+    fn chunk_len(self, chunk: &DaRelayChunk) -> Option<u64> {
+        match self { Self::Chunk { da_id, chunk_index, tx_bytes } if da_id == chunk.da_id && chunk_index == chunk.chunk_index => Some(tx_bytes.len() as u64), _ => None }
+    }
+
+    fn attach(self, record: &mut DaRelaySetRecord) -> DaRelayResult {
+        match self {
+            Self::None => return Ok(()),
+            Self::Commit { da_id, tx_bytes } => {
+                if let Some(commit) = record.commit.as_mut().filter(|commit| commit.da_id == da_id) { commit.tx_bytes = Arc::from(tx_bytes); }
+            }
+            Self::Chunk { da_id, chunk_index, tx_bytes } => {
+                if let Some(chunk) = record.chunks.get_mut(&chunk_index).filter(|chunk| chunk.da_id == da_id) { chunk.tx_bytes = Arc::from(tx_bytes); }
+            }
+        }
+        record.recompute_wire_bytes()
+    }
+}
+
 #[allow(dead_code)]
 impl DaRelayState {
     pub fn new(caps: DaRelayCaps) -> DaRelayResult<Self> {
@@ -436,7 +514,7 @@ impl DaRelayState {
                 {
                     return Err(DaRelayError::DuplicateCommit);
                 }
-                self.stage_incomplete_da_commit(
+                self.stage_incomplete_da_commit_retaining_tx_bytes(
                     peer_addr,
                     DaRelayCommit {
                         da_id: core.da_id,
@@ -444,8 +522,9 @@ impl DaRelayState {
                         peer_quota_key: PeerQuotaKey::from_peer_addr(peer_addr),
                         chunk_count: core.chunk_count,
                         wire_bytes,
-                        tx_bytes: Arc::from(tx_bytes),
+                        tx_bytes: Arc::from([]),
                     },
+                    tx_bytes,
                 )
             }
             0x02 => {
@@ -459,7 +538,7 @@ impl DaRelayState {
                     record.validate_chunk_insert(core.chunk_index)?;
                 }
                 let payload = Arc::from(tx.da_payload);
-                self.stage_incomplete_da_chunk(
+                self.stage_incomplete_da_chunk_retaining_tx_bytes(
                     peer_addr,
                     DaRelayChunk {
                         da_id,
@@ -468,12 +547,17 @@ impl DaRelayState {
                         chunk_index,
                         payload,
                         wire_bytes,
-                        tx_bytes: Arc::from(tx_bytes),
+                        tx_bytes: Arc::from([]),
                     },
+                    tx_bytes,
                 )
             }
             _ => Ok(()),
         }
+    }
+
+    pub fn advance_orphan_ttl_for_accepted_block(&mut self) -> Result<usize, DaRelayError> {
+        self.advance_orphan_ttl()
     }
 
     pub(crate) fn advance_orphan_ttl(&mut self) -> DaRelayResult<usize> {
@@ -508,6 +592,19 @@ impl DaRelayState {
     #[rustfmt::skip]
     pub(crate) fn test_record_summary(&self, da_id: [u8; 32]) -> Option<(bool, usize, u64)> { let record = self.sets_by_da_id.get(&da_id)?; Some((record.commit.is_some(), record.chunks.len(), record.wire_bytes)) }
 
+    #[cfg(test)]
+    pub(crate) fn test_orphan_bytes_for_peer(&self, peer_addr: &str) -> u64 {
+        self.orphan_bytes_by_peer_quota_key
+            .get(&PeerQuotaKey::from_peer_addr(peer_addr))
+            .copied()
+            .unwrap_or(0)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_orphan_bytes_for_da_id(&self, da_id: [u8; 32]) -> u64 {
+        self.orphan_bytes_by_da_id.get(&da_id).copied().unwrap_or(0)
+    }
+
     pub(crate) fn complete_set_eviction_candidates(
         &self,
         max_payload_bytes: u64,
@@ -534,7 +631,30 @@ impl DaRelayState {
     pub(crate) fn stage_incomplete_da_commit(
         &mut self,
         peer_addr: &str,
+        commit: DaRelayCommit,
+    ) -> DaRelayResult {
+        self.stage_incomplete_da_commit_inner(peer_addr, commit, RetainedTxBytes::None)
+    }
+
+    fn stage_incomplete_da_commit_retaining_tx_bytes(
+        &mut self,
+        peer_addr: &str,
+        commit: DaRelayCommit,
+        tx_bytes: &[u8],
+    ) -> DaRelayResult {
+        let da_id = commit.da_id;
+        self.stage_incomplete_da_commit_inner(
+            peer_addr,
+            commit,
+            RetainedTxBytes::Commit { da_id, tx_bytes },
+        )
+    }
+
+    fn stage_incomplete_da_commit_inner(
+        &mut self,
+        peer_addr: &str,
         mut commit: DaRelayCommit,
+        retained_tx_bytes: RetainedTxBytes<'_>,
     ) -> DaRelayResult {
         if commit.chunk_count == 0 || u64::from(commit.chunk_count) > MAX_DA_CHUNK_COUNT {
             return Err(DaRelayError::InvalidCommitChunkCount);
@@ -554,12 +674,45 @@ impl DaRelayState {
         record.state = DaRelaySetState::StagedCommit;
         record.ttl_blocks_remaining = self.caps.orphan_ttl_blocks;
         record.prune_chunks_outside_commit();
-        self.prepare_and_apply_record(record, CompletionMismatchAction::DropMatchingChunks)
+        self.prepare_and_apply_record(
+            record,
+            CompletionMismatchAction::DropMatchingChunks,
+            retained_tx_bytes,
+        )
     }
+
     pub(crate) fn stage_incomplete_da_chunk(
         &mut self,
         peer_addr: &str,
+        chunk: DaRelayChunk,
+    ) -> DaRelayResult {
+        self.stage_incomplete_da_chunk_inner(peer_addr, chunk, RetainedTxBytes::None)
+    }
+
+    fn stage_incomplete_da_chunk_retaining_tx_bytes(
+        &mut self,
+        peer_addr: &str,
+        chunk: DaRelayChunk,
+        tx_bytes: &[u8],
+    ) -> DaRelayResult {
+        let da_id = chunk.da_id;
+        let chunk_index = chunk.chunk_index;
+        self.stage_incomplete_da_chunk_inner(
+            peer_addr,
+            chunk,
+            RetainedTxBytes::Chunk {
+                da_id,
+                chunk_index,
+                tx_bytes,
+            },
+        )
+    }
+
+    fn stage_incomplete_da_chunk_inner(
+        &mut self,
+        peer_addr: &str,
         mut chunk: DaRelayChunk,
+        retained_tx_bytes: RetainedTxBytes<'_>,
     ) -> DaRelayResult {
         validate_da_chunk(&chunk)?;
         let current = self.sets_by_da_id.get(&chunk.da_id);
@@ -583,8 +736,47 @@ impl DaRelayState {
         self.prepare_and_apply_record(
             record,
             CompletionMismatchAction::MarkMatchingChunksReplaceable,
+            retained_tx_bytes,
         )
     }
+
+    pub(crate) fn release_peer_quota_key(&mut self, key: &PeerQuotaKey) -> DaRelayResult {
+        if self
+            .orphan_bytes_by_peer_quota_key
+            .get(key)
+            .copied()
+            .unwrap_or(0)
+            == 0
+        {
+            return Ok(());
+        }
+        for da_id in self
+            .orphan_bytes_by_da_id
+            .keys()
+            .copied()
+            .collect::<Vec<_>>()
+        {
+            let Some(record) = self.sets_by_da_id.get(&da_id).cloned() else {
+                continue;
+            };
+            if record.state == DaRelaySetState::CompleteSet {
+                continue;
+            }
+            let (updated, changed) = record.without_peer_quota_key(key)?;
+            if !changed {
+                continue;
+            }
+            if updated.empty_incomplete() {
+                if let Some(record) = self.sets_by_da_id.remove(&da_id) {
+                    self.remove_record(record)?;
+                }
+            } else {
+                self.apply_record(updated)?;
+            }
+        }
+        Ok(())
+    }
+
     fn project_counter(current: u64, remove: u64, add: u64, cap: u64) -> DaRelayResult<u64> {
         let next = current
             .checked_sub(remove)
@@ -601,6 +793,7 @@ impl DaRelayState {
         &mut self,
         mut record: DaRelaySetRecord,
         mismatch_action: CompletionMismatchAction,
+        retained_tx_bytes: RetainedTxBytes<'_>,
     ) -> DaRelayResult {
         record.recompute_wire_bytes()?;
         if record.received_time == 0 {
@@ -625,7 +818,7 @@ impl DaRelayState {
                         record.payload_bytes = 0;
                         record.state = DaRelaySetState::StagedCommit;
                         record.recompute_wire_bytes()?;
-                        self.apply_record(record)?;
+                        self.apply_record_retaining_tx_bytes(record, retained_tx_bytes)?;
                     }
                     CompletionMismatchAction::MarkMatchingChunksReplaceable => {
                         if let Some(old_record) = self.sets_by_da_id.get(&record.da_id) {
@@ -643,7 +836,33 @@ impl DaRelayState {
                 return Err(DaRelayError::PayloadCommitmentMismatch);
             }
         }
-        self.apply_record(record)?;
+        self.apply_record_retaining_tx_bytes(record, retained_tx_bytes)?;
+        Ok(())
+    }
+
+    fn apply_record_retaining_tx_bytes(
+        &mut self,
+        mut record: DaRelaySetRecord,
+        retained_tx_bytes: RetainedTxBytes<'_>,
+    ) -> DaRelayResult {
+        if !retained_tx_bytes.is_none() {
+            self.check_record_caps_with_retained_tx_bytes(&record, retained_tx_bytes)?;
+            retained_tx_bytes.attach(&mut record)?;
+        }
+        self.apply_record(record)
+    }
+
+    #[rustfmt::skip]
+    fn check_record_caps_with_retained_tx_bytes(
+        &self,
+        record: &DaRelaySetRecord,
+        retained_tx_bytes: RetainedTxBytes<'_>,
+    ) -> DaRelayResult {
+        let old = self.sets_by_da_id.get(&record.da_id); let old_bytes = old.map_or(Ok(0), DaRelaySetRecord::orphan_wire_bytes)?; let old_commit_bytes = old.map_or(0, DaRelaySetRecord::orphan_commit_bytes); let old_pinned_bytes = old.map_or(Ok(0), DaRelaySetRecord::pinned_payload_accounting_bytes)?;
+        let new_bytes = record.orphan_wire_bytes_with_retained_tx_bytes(retained_tx_bytes)?; let new_commit_bytes = record.orphan_commit_bytes_with_retained_tx_bytes(retained_tx_bytes); let new_pinned_bytes = record.pinned_payload_accounting_bytes()?; let new_peer_bytes = record.orphan_peer_bytes_with_retained_tx_bytes(retained_tx_bytes)?;
+        let _peer_bytes = self.project_peer_bytes_from_maps(old.and_then(DaRelaySetRecord::orphan_peer_bytes), new_peer_bytes.as_ref())?; let da_id_current = self.orphan_bytes_by_da_id.get(&record.da_id).copied().unwrap_or(0);
+        Self::project_counter(self.orphan_bytes, old_bytes, new_bytes, self.caps.orphan_pool_bytes)?; Self::project_counter(da_id_current, old_bytes, new_bytes, self.caps.orphan_pool_per_da_id_bytes)?;
+        Self::project_counter(self.orphan_commit_overhead_bytes, old_commit_bytes, new_commit_bytes, self.caps.orphan_commit_overhead_bytes)?; Self::project_counter(self.pinned_payload_bytes, old_pinned_bytes, new_pinned_bytes, self.caps.pinned_payload_bytes)?;
         Ok(())
     }
 
@@ -761,9 +980,18 @@ impl DaRelayState {
         old: Option<&DaRelaySetRecord>,
         new: &DaRelaySetRecord,
     ) -> DaRelayResult<Vec<(PeerQuotaKey, u64)>> {
+        self.project_peer_bytes_from_maps(
+            old.and_then(DaRelaySetRecord::orphan_peer_bytes),
+            new.orphan_peer_bytes(),
+        )
+    }
+
+    fn project_peer_bytes_from_maps(
+        &self,
+        old_peer_bytes: Option<&BTreeMap<PeerQuotaKey, u64>>,
+        new_peer_bytes: Option<&BTreeMap<PeerQuotaKey, u64>>,
+    ) -> DaRelayResult<Vec<(PeerQuotaKey, u64)>> {
         let mut projected = Vec::new();
-        let new_peer_bytes = new.orphan_peer_bytes();
-        let old_peer_bytes = old.and_then(DaRelaySetRecord::orphan_peer_bytes);
         if let Some(old_peer_bytes) = old_peer_bytes {
             for (key, old_bytes) in old_peer_bytes {
                 let new_bytes = new_peer_bytes
@@ -785,7 +1013,7 @@ impl DaRelayState {
 }
 
 pub fn stages_relay_da_tx_bytes(tx_bytes: &[u8]) -> bool {
-    matches!(relay_da_tx_kind_prefix(tx_bytes), Some(0x01 | 0x02))
+    matches!(relay_da_tx_kind_prefix(tx_bytes), Some(0x01) | Some(0x02))
 }
 
 fn relay_da_tx_kind_prefix(tx_bytes: &[u8]) -> Option<u8> {
@@ -843,6 +1071,29 @@ fn retained_tx_accounting_bytes(wire_bytes: u64, tx_bytes: &[u8]) -> u64 {
     } else {
         tx_bytes.len() as u64
     }
+}
+
+fn commit_orphan_bytes_with_retained_tx_bytes(
+    commit: &DaRelayCommit,
+    retained_tx_bytes: RetainedTxBytes<'_>,
+) -> u64 {
+    retained_tx_bytes
+        .commit_len(commit)
+        .unwrap_or_else(|| retained_tx_accounting_bytes(commit.wire_bytes, &commit.tx_bytes))
+}
+
+fn chunk_orphan_bytes_with_retained_tx_bytes(
+    chunk: &DaRelayChunk,
+    retained_tx_bytes: RetainedTxBytes<'_>,
+) -> DaRelayResult<u64> {
+    let retained_len = retained_tx_bytes.chunk_len(chunk);
+    let mut bytes = retained_len
+        .unwrap_or_else(|| retained_tx_accounting_bytes(chunk.wire_bytes, &chunk.tx_bytes));
+    let has_retained_tx_bytes = retained_len.is_some() || !chunk.tx_bytes.is_empty();
+    if has_retained_tx_bytes && !chunk.payload.is_empty() {
+        bytes = checked_add(bytes, chunk.payload.len() as u64)?;
+    }
+    Ok(bytes)
 }
 
 fn orphan_chunk_accounting_bytes(chunk: &DaRelayChunk) -> DaRelayResult<u64> {
@@ -919,12 +1170,16 @@ mod tests {
 
         let da_id = [1u8; 32]; let payload_commitment = [2u8; 32];
         let raw = relay_test_tx(0x01, vec![da_commit_output(payload_commitment)], Some(relay_commit_core(da_id, 1)), None, &[]); state.stage_relay_da_tx_bytes(peer, &raw).unwrap(); let record = state.sets_by_da_id.get(&da_id).unwrap();
+        assert!(stages_relay_da_tx_bytes(&raw));
         assert_eq!((record.commit.is_some(), record.chunks.len(), record.wire_bytes), (true, 0, raw.len() as u64));
         let commit = state.sets_by_da_id[&da_id].commit.as_ref().unwrap(); assert_eq!(commit.payload_commitment, payload_commitment); assert_eq!(commit.tx_bytes.as_ref(), raw.as_slice());
         let before = state.clone(); assert_eq!(state.stage_relay_da_tx_bytes(peer, &raw), Err(DuplicateCommit)); assert_eq!(state, before);
 
         let mut reject_state = DaRelayState::new(DaRelayCaps::default()).unwrap(); let payload = b"relay chunk"; let mut bad_core = relay_chunk_core([6u8; 32], 0, payload); bad_core.chunk_hash = [7u8; 32];
         let bad = relay_test_tx(0x02, Vec::new(), None, Some(bad_core), payload); assert_eq!(reject_state.stage_relay_da_tx_bytes(peer, &bad), Err(ChunkHashMismatch)); assert!(reject_state.is_empty());
+        let good = relay_test_tx(0x02, Vec::new(), None, Some(relay_chunk_core([7u8; 32], 0, payload)), payload); assert!(stages_relay_da_tx_bytes(&good)); reject_state.stage_relay_da_tx_bytes(peer, &good).unwrap(); assert_eq!(reject_state.test_record_summary([7u8; 32]), Some((false, 1, good.len() as u64))); assert_eq!(reject_state.sets_by_da_id[&[7u8; 32]].chunks[&0].tx_bytes.as_ref(), good.as_slice());
+        let non_da = relay_test_tx(0x00, Vec::new(), None, None, &[]); assert!(!stages_relay_da_tx_bytes(&non_da)); let kind_three = [TX_WIRE_VERSION.to_le_bytes().as_slice(), &[0x03]].concat(); assert!(!stages_relay_da_tx_bytes(&kind_three));
+        let caps = DaRelayCaps { orphan_pool_per_peer_bytes: good.len() as u64 + payload.len() as u64 - 1, ..DaRelayCaps::default() }; let mut cap_state = DaRelayState::new(caps).unwrap(); assert_eq!(cap_state.stage_relay_da_tx_bytes(peer, &good), Err(AccountingCapExceeded)); assert!(cap_state.is_empty());
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/da_relay.rs
+++ b/clients/rust/crates/rubin-node/src/da_relay.rs
@@ -400,18 +400,14 @@ impl DaRelayState {
     #[rustfmt::skip]
     pub(crate) fn validate_relay_da_tx_for_admission(tx_bytes: &[u8]) -> DaRelayResult<Option<[u8; 32]>> {
         if relay_da_tx_kind_prefix(tx_bytes) != Some(0x02) { return Ok(None); }
-        let Ok((tx, txid, _wtxid, consumed)) = parse_tx(tx_bytes) else { return Ok(None); };
-        if consumed != tx_bytes.len() { return Ok(None); }
+        let (tx, txid, _wtxid, consumed) = parse_tx(tx_bytes).map_err(|_| DaRelayError::InvalidWireBytes)?;
+        if consumed != tx_bytes.len() { return Err(DaRelayError::InvalidWireBytes); }
         let wire_bytes = u64::try_from(tx_bytes.len()).map_err(|_| DaRelayError::AccountingOverflow)?;
         validate_relay_da_chunk_for_admission(&tx, wire_bytes)?;
         Ok(Some(txid))
     }
 
-    pub(crate) fn stage_relay_da_tx_bytes(
-        &mut self,
-        peer_addr: &str,
-        tx_bytes: &[u8],
-    ) -> DaRelayResult {
+    pub fn stage_relay_da_tx_bytes(&mut self, peer_addr: &str, tx_bytes: &[u8]) -> DaRelayResult {
         let wire_bytes =
             u64::try_from(tx_bytes.len()).map_err(|_| DaRelayError::AccountingOverflow)?;
         if wire_bytes == 0 {
@@ -478,6 +474,34 @@ impl DaRelayState {
             }
             _ => Ok(()),
         }
+    }
+
+    pub(crate) fn advance_orphan_ttl(&mut self) -> DaRelayResult<usize> {
+        let mut expired = 0usize;
+        for da_id in self
+            .orphan_bytes_by_da_id
+            .keys()
+            .copied()
+            .collect::<Vec<_>>()
+        {
+            let Some(record) = self.sets_by_da_id.get_mut(&da_id) else {
+                continue;
+            };
+            if record.state == DaRelaySetState::CompleteSet {
+                continue;
+            }
+            if record.ttl_blocks_remaining > 1 {
+                record.ttl_blocks_remaining -= 1;
+                continue;
+            }
+            if let Some(record) = self.sets_by_da_id.remove(&da_id) {
+                self.remove_record(record)?;
+                expired = expired
+                    .checked_add(1)
+                    .ok_or(DaRelayError::AccountingOverflow)?;
+            }
+        }
+        Ok(expired)
     }
 
     #[cfg(test)]
@@ -684,6 +708,37 @@ impl DaRelayState {
         Ok(())
     }
 
+    fn remove_record(&mut self, record: DaRelaySetRecord) -> DaRelayResult {
+        let old_bytes = record.orphan_wire_bytes()?;
+        let old_commit_bytes = record.orphan_commit_bytes();
+        let old_pinned_bytes = record.pinned_payload_accounting_bytes()?;
+        let empty = DaRelaySetRecord::new(record.da_id);
+        let peer_bytes = self.project_peer_bytes(Some(&record), &empty)?;
+        self.orphan_bytes =
+            Self::project_counter(self.orphan_bytes, old_bytes, 0, self.caps.orphan_pool_bytes)?;
+        self.orphan_commit_overhead_bytes = Self::project_counter(
+            self.orphan_commit_overhead_bytes,
+            old_commit_bytes,
+            0,
+            self.caps.orphan_commit_overhead_bytes,
+        )?;
+        self.pinned_payload_bytes = Self::project_counter(
+            self.pinned_payload_bytes,
+            old_pinned_bytes,
+            0,
+            self.caps.pinned_payload_bytes,
+        )?;
+        for (key, bytes) in peer_bytes {
+            if bytes == 0 {
+                self.orphan_bytes_by_peer_quota_key.remove(&key);
+            } else {
+                self.orphan_bytes_by_peer_quota_key.insert(key, bytes);
+            }
+        }
+        self.orphan_bytes_by_da_id.remove(&record.da_id);
+        Ok(())
+    }
+
     fn project_peer_counter(
         &self,
         key: &PeerQuotaKey,
@@ -729,7 +784,7 @@ impl DaRelayState {
     }
 }
 
-pub(crate) fn stages_relay_da_tx_bytes(tx_bytes: &[u8]) -> bool {
+pub fn stages_relay_da_tx_bytes(tx_bytes: &[u8]) -> bool {
     matches!(relay_da_tx_kind_prefix(tx_bytes), Some(0x01 | 0x02))
 }
 
@@ -885,11 +940,26 @@ mod tests {
 
         assert_eq!(relay_da_tx_kind_prefix(&[0u8; 4]), None);
         assert_eq!(relay_da_tx_kind_prefix(&[0xff, 0, 0, 0, 0x02]), None);
+        let malformed_chunk_prefix = [TX_WIRE_VERSION.to_le_bytes().as_slice(), &[0x02]].concat();
+        assert_eq!(relay_da_tx_kind_prefix(&malformed_chunk_prefix), Some(0x02));
+        assert_eq!(DaRelayState::validate_relay_da_tx_for_admission(&malformed_chunk_prefix), Err(InvalidWireBytes));
 
         let payload = b"relay chunk"; let mut bad_core = relay_chunk_core([4u8; 32], 0, payload); bad_core.chunk_hash = [5u8; 32];
         let bad_chunk = relay_test_tx(0x02, Vec::new(), None, Some(bad_core), payload);
         assert_eq!(relay_da_tx_kind_prefix(&bad_chunk), Some(0x02));
         assert_eq!(DaRelayState::validate_relay_da_tx_for_admission(&bad_chunk), Err(ChunkHashMismatch));
+    }
+
+    #[test]
+    #[rustfmt::skip]
+    fn da_relay_orphan_ttl_advances_and_expires_incomplete_sets() {
+        let caps = DaRelayCaps { orphan_ttl_blocks: 2, ..DaRelayCaps::default() }; let mut state = DaRelayState::new(caps).unwrap();
+        state.stage_incomplete_da_chunk("peer-a:8333", DaRelayChunk { da_id: [9; 32], chunk_hash: sha3_256(b"chunk"), peer_quota_key: PeerQuotaKey::from_peer_addr("peer-a:8333"), chunk_index: 0, payload: Arc::from(&b"chunk"[..]), wire_bytes: 5, tx_bytes: Arc::from([]) }).unwrap();
+        assert_eq!(state.sets_by_da_id[&[9; 32]].ttl_blocks_remaining, 2);
+        assert_eq!(state.advance_orphan_ttl().unwrap(), 0);
+        assert_eq!(state.sets_by_da_id[&[9; 32]].ttl_blocks_remaining, 1);
+        assert_eq!(state.advance_orphan_ttl().unwrap(), 1);
+        assert!(state.is_empty());
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/da_relay.rs
+++ b/clients/rust/crates/rubin-node/src/da_relay.rs
@@ -457,17 +457,20 @@ impl DaRelayState {
                     return Ok(());
                 };
                 validate_relay_da_chunk_for_admission(&tx, wire_bytes)?;
+                let (da_id, chunk_index, chunk_hash) =
+                    (core.da_id, core.chunk_index, core.chunk_hash);
                 if let Some(record) = self.sets_by_da_id.get(&core.da_id) {
                     record.validate_chunk_insert(core.chunk_index)?;
                 }
+                let payload = Arc::from(tx.da_payload);
                 self.stage_incomplete_da_chunk(
                     peer_addr,
                     DaRelayChunk {
-                        da_id: core.da_id,
-                        chunk_hash: core.chunk_hash,
+                        da_id,
+                        chunk_hash,
                         peer_quota_key: PeerQuotaKey::from_peer_addr(peer_addr),
-                        chunk_index: core.chunk_index,
-                        payload: Arc::from(tx.da_payload.as_slice()),
+                        chunk_index,
+                        payload,
                         wire_bytes,
                         tx_bytes: Arc::from(tx_bytes),
                     },

--- a/clients/rust/crates/rubin-node/src/main.rs
+++ b/clients/rust/crates/rubin-node/src/main.rs
@@ -483,10 +483,16 @@ fn run(args: &[String], stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
 
     let announce_tx: Option<rubin_node::devnet_rpc::AnnounceTxFn> = {
         let relay_state = p2p_service.relay_state();
+        let da_relay = p2p_service.da_relay_state();
         let pm = Arc::clone(&peer_manager);
         let pw = p2p_service.peer_outboxes();
         let local = p2p_service.addr().to_string();
         Some(Arc::new(move |tx_bytes: &[u8], meta| {
+            if rubin_node::da_relay::stages_relay_da_tx_bytes(tx_bytes) {
+                if let Ok(mut da_relay) = da_relay.lock() {
+                    let _ = da_relay.stage_relay_da_tx_bytes("", tx_bytes);
+                }
+            }
             rubin_node::tx_relay::announce_tx(tx_bytes, meta, &relay_state, &pm, &local, &pw)
         }))
     };

--- a/clients/rust/crates/rubin-node/src/main.rs
+++ b/clients/rust/crates/rubin-node/src/main.rs
@@ -7,8 +7,8 @@ use std::sync::{mpsc, Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use rubin_consensus::{
-    canonical_rotation_network_name_normalized, normalized_rotation_network_name,
-    SUPPORTED_ROTATION_NETWORK_NAMES_CSV,
+    block_hash, canonical_rotation_network_name_normalized, normalized_rotation_network_name,
+    parse_block_bytes, SUPPORTED_ROTATION_NETWORK_NAMES_CSV,
 };
 use rubin_node::devnet_rpc::{
     attach_shutdown_signal_to_devnet_rpc_state, RPC_READINESS_TRANSITION_FAILED,
@@ -498,11 +498,19 @@ fn run(args: &[String], stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
     };
     let announce_block: Option<rubin_node::devnet_rpc::AnnounceBlockFn> = {
         let relay_state = p2p_service.relay_state();
+        let da_relay = p2p_service.da_relay_state();
         let pm = Arc::clone(&peer_manager);
         let pw = p2p_service.peer_outboxes();
         let local = p2p_service.addr().to_string();
         Some(Arc::new(move |block_bytes: &[u8]| {
-            rubin_node::tx_relay::announce_block(block_bytes, &relay_state, &pm, &local, &pw)
+            announce_block_and_advance_da_ttl(
+                block_bytes,
+                &relay_state,
+                &pm,
+                &local,
+                &pw,
+                &da_relay,
+            )
         }))
     };
     let state = attach_shutdown_signal_to_devnet_rpc_state(
@@ -1254,24 +1262,59 @@ fn validate_peer_addr(addr: &str) -> Result<(), String> {
     validate_addr("peer", addr)
 }
 
+#[rustfmt::skip]
+fn announce_block_and_advance_da_ttl(
+    block_bytes: &[u8],
+    relay_state: &rubin_node::tx_relay::TxRelayState,
+    peer_manager: &rubin_node::p2p_runtime::PeerManager,
+    local_addr: &str,
+    peer_writers: &Mutex<std::collections::HashMap<String, rubin_node::tx_relay::PeerOutbox>>,
+    da_relay: &Arc<Mutex<rubin_node::da_relay::DaRelayState>>,
+) -> Result<(), String> {
+    let parsed = parse_block_bytes(block_bytes).map_err(|err| err.to_string())?; let hash = block_hash(&parsed.header_bytes).map_err(|err| err.to_string())?; let advance_da_ttl = !relay_state.block_seen.has(&hash);
+    rubin_node::tx_relay::announce_block(block_bytes, relay_state, peer_manager, local_addr, peer_writers)?;
+    if !advance_da_ttl {
+        return Ok(());
+    }
+    let _ = relay_state.block_seen.add(hash);
+    da_relay
+        .lock()
+        .map_err(|_| "da relay state lock poisoned".to_string())
+        .and_then(|mut da_relay| {
+            da_relay
+                .advance_orphan_ttl_for_accepted_block()
+                .map(|_| ())
+                .map_err(|err| format!("da relay orphan ttl: {err:?}"))
+        })
+}
+
 #[cfg(test)]
 mod tests {
     use std::fs;
     use std::io;
     use std::path::PathBuf;
+    use std::sync::{Arc, Mutex};
     use std::{cell::RefCell, rc::Rc};
 
     use super::{
-        format_peer_slots_banner, handle_rpc_start_error_after_maybe_stop, legacy_exposure_hooks,
+        announce_block_and_advance_da_ttl, format_peer_slots_banner,
+        handle_rpc_start_error_after_maybe_stop, legacy_exposure_hooks,
         maybe_shutdown_if_requested, parse_args, run, runtime_genesis_hash, stop_signal_pair,
         validate_config, wait_for_stop_and_shutdown, LegacyExposureReport,
         PRODUCTION_STOP_SIGNAL_SET, RPC_READINESS_TRANSITION_FAILED,
     };
     use rubin_consensus::constants::{
-        ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES, SUITE_ID_ML_DSA_87, VERIFY_COST_ML_DSA_87,
+        ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES, SUITE_ID_ML_DSA_87, TX_WIRE_VERSION,
+        VERIFY_COST_ML_DSA_87,
     };
+    use rubin_consensus::{block_hash, marshal_tx, parse_block_bytes, DaChunkCore, Tx};
+    use rubin_node::da_relay::{DaRelayCaps, DaRelayState};
+    use rubin_node::genesis::devnet_genesis_block_bytes;
+    use rubin_node::p2p_runtime::{default_peer_runtime_config, PeerManager, PeerState};
+    use rubin_node::tx_relay::{PeerOutbox, TxRelayState};
     use rubin_node::{load_genesis_config, PRODUCTION_LOCAL_ROTATION_DESCRIPTOR_ERR};
     use serde_json::Value;
+    use sha3::{Digest, Sha3_256};
 
     #[derive(serde::Deserialize)]
     struct LegacyExposureHookVectorsDoc {
@@ -1354,6 +1397,36 @@ mod tests {
             .next()
             .expect("first JSON value")
             .expect("json parse")
+    }
+
+    #[rustfmt::skip]
+    fn local_da_chunk_tx(da_id: [u8; 32], payload: &[u8]) -> Vec<u8> {
+        marshal_tx(&Tx { version: TX_WIRE_VERSION, tx_kind: 0x02, tx_nonce: 1, inputs: Vec::new(), outputs: Vec::new(), locktime: 0, da_commit_core: None, da_chunk_core: Some(DaChunkCore { da_id, chunk_index: 0, chunk_hash: Sha3_256::digest(payload).into() }), witness: Vec::new(), da_payload: payload.to_vec() }).expect("marshal local DA chunk tx")
+    }
+
+    fn test_block_hash(block: &[u8]) -> [u8; 32] {
+        let parsed = parse_block_bytes(block).expect("parse test block");
+        block_hash(&parsed.header_bytes).expect("hash test block")
+    }
+
+    #[rustfmt::skip]
+    #[test]
+    fn local_block_announce_advances_da_orphan_ttl_once() {
+        let relay_state = TxRelayState::new(); let peer_manager = PeerManager::new(default_peer_runtime_config("devnet", 8)); let peer_writers = Mutex::new(std::collections::HashMap::<String, PeerOutbox>::new()); let da_relay = Arc::new(Mutex::new(DaRelayState::new(DaRelayCaps::default()).expect("da relay state")));
+        let mut blocks = vec![devnet_genesis_block_bytes(); 3]; blocks[1][0] ^= 0x01; blocks[2][0] ^= 0x02;
+        let first_tx = local_da_chunk_tx([0x91; 32], b"local-da-one"); da_relay.lock().unwrap().stage_relay_da_tx_bytes("peer-a:8333", &first_tx).expect("stage first DA chunk");
+        for block in &blocks { announce_block_and_advance_da_ttl(block, &relay_state, &peer_manager, "local:8333", &peer_writers, &da_relay).expect("advance local block"); }
+        assert!(da_relay.lock().unwrap().is_empty());
+        let second_tx = local_da_chunk_tx([0x92; 32], b"local-da-two"); da_relay.lock().unwrap().stage_relay_da_tx_bytes("peer-a:8333", &second_tx).expect("stage second DA chunk");
+        announce_block_and_advance_da_ttl(&blocks[2], &relay_state, &peer_manager, "local:8333", &peer_writers, &da_relay).expect("duplicate local block should not advance TTL");
+        assert!(!da_relay.lock().unwrap().is_empty());
+        let relay_state = TxRelayState::new(); let peer_manager = PeerManager::new(default_peer_runtime_config("devnet", 8)); let peer_writers = Mutex::new(std::collections::HashMap::<String, PeerOutbox>::new()); let da_relay = Arc::new(Mutex::new(DaRelayState::new(DaRelayCaps::default()).expect("da relay state")));
+        peer_manager.add_peer(PeerState { addr: "missing:8333".to_string(), ..Default::default() }).expect("register peer without outbox");
+        let block = devnet_genesis_block_bytes(); let hash = test_block_hash(&block); let tx = local_da_chunk_tx([0x93; 32], b"local-da-failed-announce"); da_relay.lock().unwrap().stage_relay_da_tx_bytes("peer-a:8333", &tx).expect("stage DA chunk");
+        let err = announce_block_and_advance_da_ttl(&block, &relay_state, &peer_manager, "local:8333", &peer_writers, &da_relay).expect_err("missing outbox should keep announce retryable");
+        assert!(err.contains("peer outbox missing for missing:8333"));
+        assert!(!relay_state.block_seen.has(&hash));
+        assert!(!da_relay.lock().unwrap().is_empty());
     }
 
     struct FailingWriter;

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -711,54 +711,46 @@ impl PeerSession {
             MESSAGE_BLOCKTXN => self.handle_blocktxn(&msg.payload, sync_engine),
             MESSAGE_TX => {
                 if let Some(ctx) = relay_ctx {
-                    let (outcome, relay_txid) = if msg.payload.len() > MAX_RELAY_MSG_BYTES as usize
-                    {
-                        (crate::tx_relay::RelayTxOutcome::Oversized, None)
-                    } else {
-                        let validated_da_txid =
-                            match crate::da_relay::DaRelayState::validate_relay_da_tx_for_admission(
-                                &msg.payload,
-                            ) {
-                                Ok(txid) => txid,
-                                Err(err) => {
-                                    let reason =
-                                        format!("DA relay tx admission validation failed: {err:?}");
-                                    self.bump_ban(10, &reason);
-                                    if self.peer.ban_score >= self.cfg.ban_threshold {
-                                        return Err(io::Error::new(
-                                            io::ErrorKind::InvalidData,
-                                            reason,
-                                        ));
-                                    }
-                                    return Ok(LiveMessageOutcome {
-                                        responses: Vec::new(),
-                                        tx_pool_cleanup: TxPoolCleanupPlan::default(),
-                                    });
+                    let validated_da_txid =
+                        match crate::da_relay::DaRelayState::validate_relay_da_tx_for_admission(
+                            &msg.payload,
+                        ) {
+                            Ok(txid) => txid,
+                            Err(err) => {
+                                let reason =
+                                    format!("DA relay tx admission validation failed: {err:?}");
+                                self.bump_ban(10, &reason);
+                                if self.peer.ban_score >= self.cfg.ban_threshold {
+                                    return Err(io::Error::new(io::ErrorKind::InvalidData, reason));
                                 }
-                            };
-                        let txid = match validated_da_txid {
-                            Some(txid) => Ok(txid),
-                            None => crate::tx_relay::canonical_txid(&msg.payload),
+                                return Ok(LiveMessageOutcome {
+                                    responses: Vec::new(),
+                                    tx_pool_cleanup: TxPoolCleanupPlan::default(),
+                                });
+                            }
                         };
-                        match txid {
-                            Ok(txid) => (
-                                crate::tx_relay::handle_received_tx_with_canonical_txid(
-                                    &msg.payload,
-                                    txid,
-                                    sync_engine,
-                                    ctx.relay_state,
-                                    ctx.peer_manager,
-                                    ctx.peer_registered_addr,
-                                    ctx.local_addr,
-                                    ctx.peer_writers,
-                                )?,
-                                Some(txid),
-                            ),
-                            Err(reason) => (
-                                crate::tx_relay::RelayTxOutcome::MalformedParse(reason),
-                                None,
-                            ),
-                        }
+                    let txid = match validated_da_txid {
+                        Some(txid) => Ok(txid),
+                        None => crate::tx_relay::canonical_txid(&msg.payload),
+                    };
+                    let (outcome, relay_txid) = match txid {
+                        Ok(txid) => (
+                            crate::tx_relay::handle_received_tx_with_canonical_txid(
+                                &msg.payload,
+                                txid,
+                                sync_engine,
+                                ctx.relay_state,
+                                ctx.peer_manager,
+                                ctx.peer_registered_addr,
+                                ctx.local_addr,
+                                ctx.peer_writers,
+                            )?,
+                            Some(txid),
+                        ),
+                        Err(reason) => (
+                            crate::tx_relay::RelayTxOutcome::MalformedParse(reason),
+                            None,
+                        ),
                     };
                     if matches!(
                         outcome,

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -225,6 +225,7 @@ pub struct PeerRelayContext<'a> {
     /// (`clients/go/node/p2p/mempool.go:45-54`); that method's last
     /// statement (line 53) is `p.mempool.AddRemoteTx(raw)`.
     pub tx_pool: &'a std::sync::Mutex<crate::txpool::TxPool>,
+    pub da_relay: &'a std::sync::Mutex<crate::da_relay::DaRelayState>,
 }
 
 #[derive(Debug, Default)]
@@ -710,6 +711,21 @@ impl PeerSession {
             MESSAGE_BLOCKTXN => self.handle_blocktxn(&msg.payload, sync_engine),
             MESSAGE_TX => {
                 if let Some(ctx) = relay_ctx {
+                    if let Err(err) =
+                        crate::da_relay::DaRelayState::validate_relay_da_tx_for_admission(
+                            &msg.payload,
+                        )
+                    {
+                        let reason = format!("DA relay tx admission validation failed: {err:?}");
+                        self.bump_ban(10, &reason);
+                        if self.peer.ban_score >= self.cfg.ban_threshold {
+                            return Err(io::Error::new(io::ErrorKind::InvalidData, reason));
+                        }
+                        return Ok(LiveMessageOutcome {
+                            responses: Vec::new(),
+                            tx_pool_cleanup: TxPoolCleanupPlan::default(),
+                        });
+                    }
                     let outcome = crate::tx_relay::handle_received_tx(
                         &msg.payload,
                         sync_engine,
@@ -719,97 +735,52 @@ impl PeerSession {
                         ctx.local_addr,
                         ctx.peer_writers,
                     )?;
-                    // RUB-173 / GitHub #1420: canonical TxPool admission
-                    // seam with source-aware classification. Peer-relayed
-                    // transactions admit via
-                    // `add_tx_with_source(..., TxSource::Remote, ...)`,
-                    // matching Go's `Mempool.AddRemoteTx`
-                    // (`clients/go/node/mempool.go:416`). Go's p2p
-                    // production path reaches `AddRemoteTx` indirectly:
-                    // `handlers_tx.go::handleTx` calls
-                    // `cfg.TxPool.Put` (the `TxPool` interface), which
-                    // production wiring
-                    // (`clients/go/cmd/rubin-node/main.go:489`,
-                    // `NewCanonicalMempoolTxPool(mempool)`) routes
-                    // through `CanonicalMempoolTxPool.Put`
-                    // (`clients/go/node/p2p/mempool.go:45-54`); line 53
-                    // is `p.mempool.AddRemoteTx(raw)`.
-                    //
-                    // Only fires after `handle_received_tx` returns
-                    // `RelayTxOutcome::Relayed`, which means the peer tx
-                    // already passed parse, dedup, and `relay_metadata`
-                    // (rolling fee floor). Source is recorded on
-                    // `TxPoolEntry.source` for observability and
-                    // downstream filtering; per `add_tx_with_source` doc,
-                    // source does NOT affect validation, admission
-                    // ordering, or capacity-eviction priority — admission
-                    // is source-blind, only provenance differs.
-                    //
-                    // RUB-178 / GitHub #1438 introduced this seam first
-                    // using the legacy `pool.admit(...)` entrypoint
-                    // (which records `TxSource::Local`) as an explicit
-                    // Class C lifecycle prerequisite; this slice (RUB-173)
-                    // is the Class B replacement that flips source
-                    // classification to `Remote`. The production-path
-                    // test below pins
-                    // `pool.entry_source(&txid) == Some(TxSource::Remote)`
-                    // as the Go/Rust source-provenance parity anchor.
-                    //
-                    // Admission Result is intentionally discarded — it
-                    // does NOT change `RelayTxOutcome` and does NOT
-                    // contribute to ban-score policy (per RUB-178 issue's
-                    // failure_modes: "preserve existing txpool caller
-                    // error class; no new policy ordering"). The
-                    // relay-cache leg has already accepted the tx, and
-                    // the seam's invariant is now "seam admits with
-                    // Remote source", not "every peer tx admits". Future
-                    // divergence observability is a separate change.
-                    //
-                    // Lock poisoning is a separate concern from admission
-                    // failure: a poisoned `tx_pool` Mutex means a prior
-                    // panic mid-mutation leaves the pool's internal
-                    // invariants potentially broken. Per existing
-                    // production precedent in
-                    // `clients/rust/crates/rubin-node/src/devnet_rpc.rs`'s
-                    // `handle_submit_tx` (which surfaces
-                    // `TxPoolAdmitErrorKind::Unavailable` on poisoned
-                    // lock) and `handle_mine_next` (which returns 503),
-                    // poison must be observable rather than silently
-                    // swallowed. The seam therefore matches the lock
-                    // result explicitly: on `Err(_)` it records an
-                    // explicit signal on `self.peer.last_error` so the
-                    // condition is not silent, while still preserving
-                    // the relay-only path (no `Err(...)` is returned
-                    // from `collect_live_responses`).
-                    //
-                    // Lock-ordering precedent: this is engine→pool nested.
-                    // The caller in
-                    // `clients/rust/crates/rubin-node/src/p2p_service.rs`
-                    // (`handle_peer`) holds
-                    // `shared.sync_engine.lock()` while calling
-                    // `collect_live_responses`, so the seam acquires
-                    // `ctx.tx_pool.lock()` while engine remains held; both
-                    // are dropped at the end of the caller's scope. This
-                    // matches the engine→pool nested ordering used by
-                    // `clients/rust/crates/rubin-node/src/devnet_rpc.rs`'s
-                    // `handle_mine_next`, NOT the engine-snapshot-then-drop
-                    // pattern in `apply_tx_pool_cleanup`. The seam does
-                    // not re-acquire the engine, so no deadlock from self.
-                    if matches!(outcome, crate::tx_relay::RelayTxOutcome::Relayed) {
+                    if matches!(
+                        outcome,
+                        crate::tx_relay::RelayTxOutcome::Relayed
+                            | crate::tx_relay::RelayTxOutcome::DuplicateSeen
+                    ) {
+                        let mut admitted_da_bytes = None;
                         match ctx.tx_pool.lock() {
                             Ok(mut pool) => {
-                                let _ = pool.add_tx_with_source(
-                                    &msg.payload,
-                                    &sync_engine.chain_state,
-                                    sync_engine.block_store.as_ref(),
-                                    sync_engine.cfg.chain_id,
-                                    crate::txpool::TxSource::Remote,
-                                );
+                                if matches!(outcome, crate::tx_relay::RelayTxOutcome::Relayed)
+                                    && pool
+                                        .add_tx_with_source(
+                                            &msg.payload,
+                                            &sync_engine.chain_state,
+                                            sync_engine.block_store.as_ref(),
+                                            sync_engine.cfg.chain_id,
+                                            crate::txpool::TxSource::Remote,
+                                        )
+                                        .is_ok()
+                                {
+                                    admitted_da_bytes = Some(msg.payload.clone());
+                                }
+                                if admitted_da_bytes.is_none() {
+                                    if let Ok((_tx, txid, _wtxid, consumed)) =
+                                        parse_tx(&msg.payload)
+                                    {
+                                        if consumed == msg.payload.len() {
+                                            admitted_da_bytes = pool.tx_by_id(&txid);
+                                        }
+                                    }
+                                }
                             }
                             Err(_) => {
                                 self.peer.last_error =
                                     "canonical tx_pool poisoned; peer-tx admission skipped"
                                         .to_string();
+                            }
+                        }
+                        if let Some(admitted_da_bytes) = admitted_da_bytes {
+                            if let Ok(mut da_relay) = ctx.da_relay.lock() {
+                                let _ = da_relay.stage_relay_da_tx_bytes(
+                                    ctx.peer_registered_addr,
+                                    &admitted_da_bytes,
+                                );
+                            } else {
+                                self.peer.last_error =
+                                    "da relay state poisoned; peer-tx staging skipped".to_string();
                             }
                         }
                     }
@@ -3381,6 +3352,7 @@ mod tests {
     use std::net::{TcpListener, TcpStream};
     use std::path::PathBuf;
     use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::Mutex;
     use std::thread;
     use std::time::Duration;
 
@@ -3393,11 +3365,12 @@ mod tests {
         block_with_txs, coinbase_only_block_with_gen, signed_conflicting_p2pk_state_and_txs,
     };
     use crate::TxPool;
-    use rubin_consensus::constants::{MAX_FUTURE_DRIFT, POW_LIMIT};
+    use rubin_consensus::constants::{COV_TYPE_P2PK, MAX_FUTURE_DRIFT, POW_LIMIT, TX_WIRE_VERSION};
     use rubin_consensus::merkle::{witness_commitment_hash, witness_merkle_root_wtxids};
     use rubin_consensus::{
-        block_hash, encode_compact_size, merkle_root_txids, parse_block_bytes, parse_tx,
-        BLOCK_HEADER_BYTES,
+        block_hash, encode_compact_size, marshal_tx, merkle_root_txids,
+        p2pk_covenant_data_for_pubkey, parse_block_bytes, parse_tx, sign_transaction, DaChunkCore,
+        Mldsa87Keypair, Outpoint, Tx, TxInput, TxOutput, UtxoEntry, BLOCK_HEADER_BYTES,
     };
     use serde::Deserialize;
 
@@ -3535,6 +3508,25 @@ mod tests {
         };
         (session, client)
     }
+
+    #[rustfmt::skip]
+    fn test_da_relay_state() -> Mutex<crate::da_relay::DaRelayState> { Mutex::new(crate::da_relay::DaRelayState::new(crate::da_relay::DaRelayCaps::default()).expect("da relay state")) }
+
+    #[rustfmt::skip]
+    fn signed_conflicting_da_chunk_state_and_txs(payload: &[u8]) -> (ChainState, Vec<u8>, Vec<u8>, [u8; 32], [u8; 32]) {
+        let keypair = Mldsa87Keypair::generate().expect("OpenSSL signer unavailable"); let pubkey = keypair.pubkey_bytes(); let outpoint = Outpoint { txid: [0x44; 32], vout: 0 }; let mut state = ChainState::new();
+        state.utxos.insert(outpoint.clone(), UtxoEntry { value: 20_000, covenant_type: COV_TYPE_P2PK, covenant_data: p2pk_covenant_data_for_pubkey(&pubkey), creation_height: 0, created_by_coinbase: false });
+        let first_da_id = [0x45; 32]; let second_da_id = [0x46; 32]; let chunk_hash: [u8; 32] = Sha3_256::digest(payload).into();
+        let (first, second) = { let build_tx = |tx_nonce: u64, output_value: u64, da_id: [u8; 32]| -> Vec<u8> {
+            let mut tx = Tx { version: TX_WIRE_VERSION, tx_kind: 0x02, tx_nonce, inputs: vec![TxInput { prev_txid: outpoint.txid, prev_vout: outpoint.vout, script_sig: Vec::new(), sequence: 0 }], outputs: vec![TxOutput { value: output_value, covenant_type: COV_TYPE_P2PK, covenant_data: p2pk_covenant_data_for_pubkey(&vec![tx_nonce as u8; 2592]) }], locktime: 0, da_commit_core: None, da_chunk_core: Some(DaChunkCore { da_id, chunk_index: 0, chunk_hash }), witness: Vec::new(), da_payload: payload.to_vec() };
+            sign_transaction(&mut tx, &state.utxos, devnet_genesis_chain_id(), &keypair).expect("sign da chunk tx");
+            marshal_tx(&tx).expect("marshal da chunk tx")
+        }; (build_tx(17, 10, first_da_id), build_tx(18, 9, second_da_id)) };
+        (state, first, second, first_da_id, second_da_id)
+    }
+
+    #[rustfmt::skip]
+    fn same_txid_da_payload_variant(tx_bytes: &[u8], payload: &[u8]) -> (Vec<u8>, [u8; 32]) { let (mut tx, txid, _, _) = parse_tx(tx_bytes).expect("parse da chunk tx"); tx.da_payload = payload.to_vec(); let variant = marshal_tx(&tx).expect("marshal DA payload variant"); assert_eq!(parse_tx(&variant).expect("parse variant").1, txid); (variant, txid) }
 
     #[test]
     fn getblocktxn_payload_codec_matches_go_wire() {
@@ -5971,6 +5963,7 @@ mod tests {
     ///     if the seam regresses to legacy `pool.admit` (Local) or any
     ///     other source variant.
     #[test]
+    #[rustfmt::skip]
     fn collect_live_responses_message_tx_admits_through_canonical_pool_seam() {
         use std::collections::HashMap;
         use std::sync::Mutex;
@@ -5983,13 +5976,8 @@ mod tests {
             let mut session = PeerSession::new(stream, default_peer_runtime_config("devnet", 8))
                 .expect("session");
 
-            // Build a sync engine + chain state that admits a single
-            // floor-compliant signed P2PK tx (mirrors the existing
-            // tx_relay test pattern, intentionally — same fixture so the
-            // production tx_relay handle_received_tx leg returns
-            // `Relayed` and the canonical seam fires).
-            let (chain_state, tx_bytes, _unused) =
-                signed_conflicting_p2pk_state_and_txs(20_000, 10, 9);
+            let (chain_state, tx_bytes, conflicting_tx, da_id, conflicting_da_id) =
+                signed_conflicting_da_chunk_state_and_txs(b"admitted da chunk");
             let mut sync_cfg = crate::sync::default_sync_config(
                 None,
                 crate::genesis::devnet_genesis_chain_id(),
@@ -6021,6 +6009,7 @@ mod tests {
                 crate::tx_relay::PeerOutbox::default(),
             );
             let canonical_tx_pool: Mutex<TxPool> = Mutex::new(TxPool::new());
+            let da_relay_state = test_da_relay_state();
 
             let relay_ctx = PeerRelayContext {
                 relay_state: &relay_state,
@@ -6029,8 +6018,29 @@ mod tests {
                 peer_registered_addr: "sender:8333",
                 peer_writers: &peer_outboxes,
                 tx_pool: &canonical_tx_pool,
+                da_relay: &da_relay_state,
             };
 
+            let (bad_payload_tx, same_txid) =
+                same_txid_da_payload_variant(&tx_bytes, b"bad-da-payload");
+            session
+                .collect_live_responses(
+                    WireMessage {
+                        command: MESSAGE_TX.to_string(),
+                        payload: bad_payload_tx,
+                    },
+                    &mut engine,
+                    Some(&relay_ctx),
+                )
+                .expect("bad DA payload stays sub-threshold");
+            assert_eq!(session.state().ban_score, 10);
+            assert!(!relay_state.tx_seen.has(&same_txid));
+            assert!(!relay_state.relay_pool.has(&same_txid));
+            assert!(!canonical_tx_pool.lock().unwrap().contains(&same_txid));
+            assert_eq!(
+                da_relay_state.lock().unwrap().test_record_summary(da_id),
+                None
+            );
             let msg = WireMessage {
                 command: MESSAGE_TX.to_string(),
                 payload: tx_bytes.clone(),
@@ -6073,6 +6083,41 @@ mod tests {
                  Go AddRemoteTx"
             );
             drop(pool_guard);
+            assert_eq!(
+                da_relay_state.lock().unwrap().test_record_summary(da_id),
+                Some((false, 1, tx_bytes.len() as u64))
+            );
+            for preseen in [false, true] {
+                let dup_relay_state = crate::tx_relay::TxRelayState::new();
+                if preseen {
+                    dup_relay_state.tx_seen.add(txid);
+                }
+                let dup_da_relay_state = test_da_relay_state();
+                let dup_ctx = PeerRelayContext { relay_state: &dup_relay_state, peer_manager: &peer_manager, local_addr: "local:8333", peer_registered_addr: "sender:8333", peer_writers: &peer_outboxes, tx_pool: &canonical_tx_pool, da_relay: &dup_da_relay_state };
+                session.collect_live_responses(WireMessage { command: MESSAGE_TX.to_string(), payload: tx_bytes.clone() }, &mut engine, Some(&dup_ctx)).expect("already-admitted DA tx should stay peer-neutral");
+                assert_eq!(dup_da_relay_state.lock().unwrap().test_record_summary(da_id), Some((false, 1, tx_bytes.len() as u64)));
+            }
+
+            session
+                .collect_live_responses(
+                    WireMessage {
+                        command: MESSAGE_TX.to_string(),
+                        payload: conflicting_tx.clone(),
+                    },
+                    &mut engine,
+                    Some(&relay_ctx),
+                )
+                .expect("conflicting MESSAGE_TX dispatch must preserve relay outcome");
+            let (_, conflicting_txid, _, _consumed) =
+                parse_tx(&conflicting_tx).expect("parse conflict tx for txid");
+            assert!(relay_state.tx_seen.has(&conflicting_txid));
+            assert_eq!(
+                da_relay_state
+                    .lock()
+                    .unwrap()
+                    .test_record_summary(conflicting_da_id),
+                None
+            );
 
             // 2) relay-cache-only path remains separate: tx_relay's
             //    relay_state still records the tx as well. This proves
@@ -6213,6 +6258,7 @@ mod tests {
             // mirrors the production failure mode where a panic during
             // pool mutation leaves a poisoned shared handle.
             let canonical_tx_pool: Arc<Mutex<TxPool>> = Arc::new(Mutex::new(TxPool::new()));
+            let da_relay_state = test_da_relay_state();
             let poison_pool = Arc::clone(&canonical_tx_pool);
             let _ = thread::spawn(move || {
                 let _guard = poison_pool.lock().unwrap();
@@ -6231,6 +6277,7 @@ mod tests {
                 peer_registered_addr: "sender:8333",
                 peer_writers: &peer_outboxes,
                 tx_pool: &canonical_tx_pool,
+                da_relay: &da_relay_state,
             };
 
             let msg = WireMessage {

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -711,76 +711,101 @@ impl PeerSession {
             MESSAGE_BLOCKTXN => self.handle_blocktxn(&msg.payload, sync_engine),
             MESSAGE_TX => {
                 if let Some(ctx) = relay_ctx {
-                    if let Err(err) =
-                        crate::da_relay::DaRelayState::validate_relay_da_tx_for_admission(
-                            &msg.payload,
-                        )
+                    let (outcome, relay_txid) = if msg.payload.len() > MAX_RELAY_MSG_BYTES as usize
                     {
-                        let reason = format!("DA relay tx admission validation failed: {err:?}");
-                        self.bump_ban(10, &reason);
-                        if self.peer.ban_score >= self.cfg.ban_threshold {
-                            return Err(io::Error::new(io::ErrorKind::InvalidData, reason));
+                        (crate::tx_relay::RelayTxOutcome::Oversized, None)
+                    } else {
+                        let validated_da_txid =
+                            match crate::da_relay::DaRelayState::validate_relay_da_tx_for_admission(
+                                &msg.payload,
+                            ) {
+                                Ok(txid) => txid,
+                                Err(err) => {
+                                    let reason =
+                                        format!("DA relay tx admission validation failed: {err:?}");
+                                    self.bump_ban(10, &reason);
+                                    if self.peer.ban_score >= self.cfg.ban_threshold {
+                                        return Err(io::Error::new(
+                                            io::ErrorKind::InvalidData,
+                                            reason,
+                                        ));
+                                    }
+                                    return Ok(LiveMessageOutcome {
+                                        responses: Vec::new(),
+                                        tx_pool_cleanup: TxPoolCleanupPlan::default(),
+                                    });
+                                }
+                            };
+                        let txid = match validated_da_txid {
+                            Some(txid) => Ok(txid),
+                            None => crate::tx_relay::canonical_txid(&msg.payload),
+                        };
+                        match txid {
+                            Ok(txid) => (
+                                crate::tx_relay::handle_received_tx_with_canonical_txid(
+                                    &msg.payload,
+                                    txid,
+                                    sync_engine,
+                                    ctx.relay_state,
+                                    ctx.peer_manager,
+                                    ctx.peer_registered_addr,
+                                    ctx.local_addr,
+                                    ctx.peer_writers,
+                                )?,
+                                Some(txid),
+                            ),
+                            Err(reason) => (
+                                crate::tx_relay::RelayTxOutcome::MalformedParse(reason),
+                                None,
+                            ),
                         }
-                        return Ok(LiveMessageOutcome {
-                            responses: Vec::new(),
-                            tx_pool_cleanup: TxPoolCleanupPlan::default(),
-                        });
-                    }
-                    let outcome = crate::tx_relay::handle_received_tx(
-                        &msg.payload,
-                        sync_engine,
-                        ctx.relay_state,
-                        ctx.peer_manager,
-                        ctx.peer_registered_addr,
-                        ctx.local_addr,
-                        ctx.peer_writers,
-                    )?;
+                    };
                     if matches!(
                         outcome,
                         crate::tx_relay::RelayTxOutcome::Relayed
                             | crate::tx_relay::RelayTxOutcome::DuplicateSeen
                     ) {
-                        let mut admitted_da_bytes = None;
-                        match ctx.tx_pool.lock() {
-                            Ok(mut pool) => {
-                                if matches!(outcome, crate::tx_relay::RelayTxOutcome::Relayed)
-                                    && pool
-                                        .add_tx_with_source(
-                                            &msg.payload,
-                                            &sync_engine.chain_state,
-                                            sync_engine.block_store.as_ref(),
-                                            sync_engine.cfg.chain_id,
-                                            crate::txpool::TxSource::Remote,
-                                        )
-                                        .is_ok()
-                                {
-                                    admitted_da_bytes = Some(msg.payload.clone());
-                                }
-                                if admitted_da_bytes.is_none() {
-                                    if let Ok((_tx, txid, _wtxid, consumed)) =
-                                        parse_tx(&msg.payload)
+                        if let Some(txid) = relay_txid {
+                            let mut admitted_da_bytes = None;
+                            match ctx.tx_pool.lock() {
+                                Ok(mut pool) => {
+                                    if matches!(outcome, crate::tx_relay::RelayTxOutcome::Relayed)
+                                        && pool
+                                            .add_tx_with_source(
+                                                &msg.payload,
+                                                &sync_engine.chain_state,
+                                                sync_engine.block_store.as_ref(),
+                                                sync_engine.cfg.chain_id,
+                                                crate::txpool::TxSource::Remote,
+                                            )
+                                            .is_ok()
                                     {
-                                        if consumed == msg.payload.len() {
-                                            admitted_da_bytes = pool.tx_by_id(&txid);
-                                        }
+                                        admitted_da_bytes = Some(msg.payload.clone());
+                                    }
+                                    if admitted_da_bytes.is_none() {
+                                        admitted_da_bytes = pool.tx_by_id(&txid);
                                     }
                                 }
+                                Err(_) => {
+                                    self.peer.last_error =
+                                        "canonical tx_pool poisoned; peer-tx admission skipped"
+                                            .to_string();
+                                }
                             }
-                            Err(_) => {
-                                self.peer.last_error =
-                                    "canonical tx_pool poisoned; peer-tx admission skipped"
-                                        .to_string();
-                            }
-                        }
-                        if let Some(admitted_da_bytes) = admitted_da_bytes {
-                            if let Ok(mut da_relay) = ctx.da_relay.lock() {
-                                let _ = da_relay.stage_relay_da_tx_bytes(
-                                    ctx.peer_registered_addr,
-                                    &admitted_da_bytes,
-                                );
-                            } else {
-                                self.peer.last_error =
-                                    "da relay state poisoned; peer-tx staging skipped".to_string();
+                            if let Some(admitted_da_bytes) = admitted_da_bytes {
+                                if let Ok(mut da_relay) = ctx.da_relay.lock() {
+                                    if let Err(err) = da_relay.stage_relay_da_tx_bytes(
+                                        ctx.peer_registered_addr,
+                                        &admitted_da_bytes,
+                                    ) {
+                                        self.peer.last_error =
+                                            format!("DA relay tx staging failed: {err:?}");
+                                    }
+                                } else {
+                                    self.peer.last_error =
+                                        "da relay state poisoned; peer-tx staging skipped"
+                                            .to_string();
+                                }
                             }
                         }
                     }
@@ -6086,6 +6111,14 @@ mod tests {
             assert_eq!(
                 da_relay_state.lock().unwrap().test_record_summary(da_id),
                 Some((false, 1, tx_bytes.len() as u64))
+            );
+            session.collect_live_responses(WireMessage { command: MESSAGE_TX.to_string(), payload: tx_bytes.clone() }, &mut engine, Some(&relay_ctx)).expect("duplicate DA staging diagnostics should stay peer-neutral");
+            assert!(
+                session
+                    .state()
+                    .last_error
+                    .contains("DA relay tx staging failed: DuplicateChunk"),
+                "duplicate DA staging must be observable on peer.last_error"
             );
             for preseen in [false, true] {
                 let dup_relay_state = crate::tx_relay::TxRelayState::new();

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -758,6 +758,8 @@ impl PeerSession {
                             | crate::tx_relay::RelayTxOutcome::DuplicateSeen
                     ) {
                         if let Some(txid) = relay_txid {
+                            let stages_relay_da_tx =
+                                crate::da_relay::stages_relay_da_tx_bytes(&msg.payload);
                             let mut stage_fresh_payload = false;
                             let mut duplicate_da_bytes = None;
                             match ctx.tx_pool.lock() {
@@ -773,9 +775,9 @@ impl PeerSession {
                                             )
                                             .is_ok()
                                     {
-                                        stage_fresh_payload = true;
+                                        stage_fresh_payload = stages_relay_da_tx;
                                     }
-                                    if !stage_fresh_payload {
+                                    if !stage_fresh_payload && stages_relay_da_tx {
                                         duplicate_da_bytes = pool.tx_by_id(&txid);
                                     }
                                 }
@@ -6122,6 +6124,29 @@ mod tests {
 
         let _client = TcpStream::connect(addr).expect("connect");
         server.join().expect("server join");
+    }
+
+    #[test]
+    #[rustfmt::skip]
+    fn collect_live_responses_duplicate_non_da_skips_da_relay_stage() {
+        use std::collections::HashMap; use std::sync::{Arc, Mutex};
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind"); let addr = listener.local_addr().expect("addr");
+        let server = thread::spawn(move || {
+            let (stream, _) = listener.accept().expect("accept"); let mut session = PeerSession::new(stream, default_peer_runtime_config("devnet", 8)).expect("session");
+            let (chain_state, tx_bytes, _unused) = signed_conflicting_p2pk_state_and_txs(20_000, 10, 9); let mut sync_cfg = crate::sync::default_sync_config(None, crate::genesis::devnet_genesis_chain_id(), None); sync_cfg.core_ext_deployments = rubin_consensus::CoreExtDeploymentProfiles::empty();
+            let mut engine = crate::sync::SyncEngine::new(chain_state, None, sync_cfg).expect("sync engine");
+            let relay_state = crate::tx_relay::TxRelayState::new(); let peer_manager = PeerManager::new(default_peer_runtime_config("devnet", 64)); let _ = peer_manager.add_peer(PeerState { addr: "other:8333".to_string(), ..Default::default() });
+            let peer_outboxes: Mutex<HashMap<String, crate::tx_relay::PeerOutbox>> = Mutex::new(HashMap::new()); peer_outboxes.lock().unwrap().insert("sender:8333".to_string(), crate::tx_relay::PeerOutbox::default()); peer_outboxes.lock().unwrap().insert("other:8333".to_string(), crate::tx_relay::PeerOutbox::default());
+            let canonical_tx_pool: Mutex<TxPool> = Mutex::new(TxPool::new()); let da_relay_state = test_da_relay_state();
+            let relay_ctx = PeerRelayContext { relay_state: &relay_state, peer_manager: &peer_manager, local_addr: "local:8333", peer_registered_addr: "sender:8333", peer_writers: &peer_outboxes, tx_pool: &canonical_tx_pool, da_relay: &da_relay_state };
+            session.collect_live_responses(WireMessage { command: MESSAGE_TX.to_string(), payload: tx_bytes.clone() }, &mut engine, Some(&relay_ctx)).expect("first non-DA relay tx must admit");
+            let (_, txid, _, _consumed) = parse_tx(&tx_bytes).expect("parse tx for txid"); assert!(relay_state.tx_seen.has(&txid)); assert!(canonical_tx_pool.lock().unwrap().contains(&txid));
+            let poisoned_da_relay = Arc::new(test_da_relay_state()); let poison_target = Arc::clone(&poisoned_da_relay); let _ = thread::spawn(move || { let _guard = poison_target.lock().unwrap(); panic!("intentional poison for duplicate non-DA DA-stage skip test"); }).join(); assert!(poisoned_da_relay.is_poisoned());
+            session.peer.last_error.clear(); let duplicate_ctx = PeerRelayContext { relay_state: &relay_state, peer_manager: &peer_manager, local_addr: "local:8333", peer_registered_addr: "sender:8333", peer_writers: &peer_outboxes, tx_pool: &canonical_tx_pool, da_relay: poisoned_da_relay.as_ref() };
+            session.collect_live_responses(WireMessage { command: MESSAGE_TX.to_string(), payload: tx_bytes }, &mut engine, Some(&duplicate_ctx)).expect("duplicate non-DA relay tx must stay peer-neutral");
+            assert!(session.state().last_error.is_empty(), "duplicate non-DA tx must not touch DA relay staging: {:?}", session.state().last_error);
+        });
+        let _client = TcpStream::connect(addr).expect("connect"); server.join().expect("server join");
     }
 
     /// RUB-178 smoke test for the `relay_ctx = None` branch of

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -766,7 +766,8 @@ impl PeerSession {
                             | crate::tx_relay::RelayTxOutcome::DuplicateSeen
                     ) {
                         if let Some(txid) = relay_txid {
-                            let mut admitted_da_bytes = None;
+                            let mut stage_fresh_payload = false;
+                            let mut duplicate_da_bytes = None;
                             match ctx.tx_pool.lock() {
                                 Ok(mut pool) => {
                                     if matches!(outcome, crate::tx_relay::RelayTxOutcome::Relayed)
@@ -780,10 +781,10 @@ impl PeerSession {
                                             )
                                             .is_ok()
                                     {
-                                        admitted_da_bytes = Some(msg.payload.clone());
+                                        stage_fresh_payload = true;
                                     }
-                                    if admitted_da_bytes.is_none() {
-                                        admitted_da_bytes = pool.tx_by_id(&txid);
+                                    if !stage_fresh_payload {
+                                        duplicate_da_bytes = pool.tx_by_id(&txid);
                                     }
                                 }
                                 Err(_) => {
@@ -792,11 +793,16 @@ impl PeerSession {
                                             .to_string();
                                 }
                             }
-                            if let Some(admitted_da_bytes) = admitted_da_bytes {
+                            let staged_da_bytes = if stage_fresh_payload {
+                                Some(msg.payload.as_slice())
+                            } else {
+                                duplicate_da_bytes.as_deref()
+                            };
+                            if let Some(staged_da_bytes) = staged_da_bytes {
                                 if let Ok(mut da_relay) = ctx.da_relay.lock() {
                                     if let Err(err) = da_relay.stage_relay_da_tx_bytes(
                                         ctx.peer_registered_addr,
-                                        &admitted_da_bytes,
+                                        staged_da_bytes,
                                     ) {
                                         self.peer.last_error =
                                             format!("DA relay tx staging failed: {err:?}");
@@ -3551,8 +3557,6 @@ mod tests {
     }
 
     #[rustfmt::skip]
-    fn same_txid_da_payload_variant(tx_bytes: &[u8], payload: &[u8]) -> (Vec<u8>, [u8; 32]) { let (mut tx, txid, _, _) = parse_tx(tx_bytes).expect("parse da chunk tx"); tx.da_payload = payload.to_vec(); let variant = marshal_tx(&tx).expect("marshal DA payload variant"); assert_eq!(parse_tx(&variant).expect("parse variant").1, txid); (variant, txid) }
-
     #[test]
     fn getblocktxn_payload_codec_matches_go_wire() {
         let mut block_hash = [0u8; 32];
@@ -6046,26 +6050,6 @@ mod tests {
                 da_relay: &da_relay_state,
             };
 
-            let (bad_payload_tx, same_txid) =
-                same_txid_da_payload_variant(&tx_bytes, b"bad-da-payload");
-            session
-                .collect_live_responses(
-                    WireMessage {
-                        command: MESSAGE_TX.to_string(),
-                        payload: bad_payload_tx,
-                    },
-                    &mut engine,
-                    Some(&relay_ctx),
-                )
-                .expect("bad DA payload stays sub-threshold");
-            assert_eq!(session.state().ban_score, 10);
-            assert!(!relay_state.tx_seen.has(&same_txid));
-            assert!(!relay_state.relay_pool.has(&same_txid));
-            assert!(!canonical_tx_pool.lock().unwrap().contains(&same_txid));
-            assert_eq!(
-                da_relay_state.lock().unwrap().test_record_summary(da_id),
-                None
-            );
             let msg = WireMessage {
                 command: MESSAGE_TX.to_string(),
                 payload: tx_bytes.clone(),
@@ -6120,37 +6104,15 @@ mod tests {
                     .contains("DA relay tx staging failed: DuplicateChunk"),
                 "duplicate DA staging must be observable on peer.last_error"
             );
-            for preseen in [false, true] {
-                let dup_relay_state = crate::tx_relay::TxRelayState::new();
-                if preseen {
-                    dup_relay_state.tx_seen.add(txid);
-                }
-                let dup_da_relay_state = test_da_relay_state();
-                let dup_ctx = PeerRelayContext { relay_state: &dup_relay_state, peer_manager: &peer_manager, local_addr: "local:8333", peer_registered_addr: "sender:8333", peer_writers: &peer_outboxes, tx_pool: &canonical_tx_pool, da_relay: &dup_da_relay_state };
-                session.collect_live_responses(WireMessage { command: MESSAGE_TX.to_string(), payload: tx_bytes.clone() }, &mut engine, Some(&dup_ctx)).expect("already-admitted DA tx should stay peer-neutral");
-                assert_eq!(dup_da_relay_state.lock().unwrap().test_record_summary(da_id), Some((false, 1, tx_bytes.len() as u64)));
-            }
+            let dup_relay_state = crate::tx_relay::TxRelayState::new(); let dup_da_relay_state = test_da_relay_state();
+            let dup_ctx = PeerRelayContext { relay_state: &dup_relay_state, peer_manager: &peer_manager, local_addr: "local:8333", peer_registered_addr: "sender:8333", peer_writers: &peer_outboxes, tx_pool: &canonical_tx_pool, da_relay: &dup_da_relay_state };
+            session.collect_live_responses(WireMessage { command: MESSAGE_TX.to_string(), payload: tx_bytes.clone() }, &mut engine, Some(&dup_ctx)).expect("already-admitted DA tx should stay peer-neutral");
+            assert_eq!(dup_da_relay_state.lock().unwrap().test_record_summary(da_id), Some((false, 1, tx_bytes.len() as u64)));
 
-            session
-                .collect_live_responses(
-                    WireMessage {
-                        command: MESSAGE_TX.to_string(),
-                        payload: conflicting_tx.clone(),
-                    },
-                    &mut engine,
-                    Some(&relay_ctx),
-                )
-                .expect("conflicting MESSAGE_TX dispatch must preserve relay outcome");
-            let (_, conflicting_txid, _, _consumed) =
-                parse_tx(&conflicting_tx).expect("parse conflict tx for txid");
+            session.collect_live_responses(WireMessage { command: MESSAGE_TX.to_string(), payload: conflicting_tx.clone() }, &mut engine, Some(&relay_ctx)).expect("conflicting MESSAGE_TX dispatch must preserve relay outcome");
+            let (_, conflicting_txid, _, _consumed) = parse_tx(&conflicting_tx).expect("parse conflict tx for txid");
             assert!(relay_state.tx_seen.has(&conflicting_txid));
-            assert_eq!(
-                da_relay_state
-                    .lock()
-                    .unwrap()
-                    .test_record_summary(conflicting_da_id),
-                None
-            );
+            assert_eq!(da_relay_state.lock().unwrap().test_record_summary(conflicting_da_id), None);
 
             // 2) relay-cache-only path remains separate: tx_relay's
             //    relay_state still records the tx as well. This proves

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -203,29 +203,9 @@ pub struct PeerRelayContext<'a> {
     /// Outbound relay queues: serialized wire frames enqueued by broadcast,
     /// drained by the peer thread to avoid concurrent TcpStream writes.
     pub peer_writers: &'a std::sync::Mutex<HashMap<String, crate::tx_relay::PeerOutbox>>,
-    /// Canonical TxPool admission seam with source-aware classification
-    /// (RUB-178 / GitHub #1438 introduced the lifecycle plumbing using
-    /// legacy `pool.admit`; RUB-173 / GitHub #1420 swapped the call to
-    /// `add_tx_with_source(..., TxSource::Remote, ...)`).
-    ///
-    /// Threads the existing `shared.tx_pool: Arc<Mutex<TxPool>>` handle
-    /// (introduced in PR #876, commit `ce270e3`, already used by the
-    /// production block-apply cleanup path in `p2p_service.rs`) into the
-    /// peer-tx live message dispatch so peer transactions admit through
-    /// the canonical source-aware entry after relay-cache success. The
-    /// `Remote` provenance matches Go's `Mempool.AddRemoteTx`
-    /// (`clients/go/node/mempool.go:416`). Go's p2p production path
-    /// reaches `AddRemoteTx` through three indirections:
-    /// `clients/go/node/p2p/handlers_tx.go::handleTx` (line 45) calls
-    /// `cfg.TxPool.Put` against the `TxPool` interface, which
-    /// production wiring at
-    /// `clients/go/cmd/rubin-node/main.go:489`
-    /// (`p2p.NewCanonicalMempoolTxPool(mempool)`) routes through
-    /// `CanonicalMempoolTxPool.Put`
-    /// (`clients/go/node/p2p/mempool.go:45-54`); that method's last
-    /// statement (line 53) is `p.mempool.AddRemoteTx(raw)`.
+    /// Canonical TxPool admission seam for peer-relayed txs; the source
+    /// is recorded as `Remote` to match Go's production p2p mempool path.
     pub tx_pool: &'a std::sync::Mutex<crate::txpool::TxPool>,
-    pub da_relay: &'a std::sync::Mutex<crate::da_relay::DaRelayState>,
 }
 
 #[derive(Debug, Default)]
@@ -287,6 +267,8 @@ pub struct PeerSession {
     peer: PeerState,
     orphans: OrphanBlockPool,
     pending_tx_pool_cleanup: TxPoolCleanupPlan,
+    pending_da_relay_stages: Vec<(String, Vec<u8>)>,
+    pending_da_orphan_ttl_advances: u64,
     prefetched_read_byte: Option<u8>,
     remote_compact_mode: CompactModeSnapshot,
     compact_outstanding: Option<CompactOutstandingRequest>,
@@ -409,6 +391,8 @@ impl PeerSession {
             },
             orphans: OrphanBlockPool::new(DEFAULT_ORPHAN_LIMIT, DEFAULT_ORPHAN_BYTE_LIMIT),
             pending_tx_pool_cleanup: TxPoolCleanupPlan::default(),
+            pending_da_relay_stages: Vec::new(),
+            pending_da_orphan_ttl_advances: 0,
             prefetched_read_byte: None,
             remote_compact_mode: CompactModeSnapshot::default(),
             compact_outstanding: None,
@@ -431,6 +415,59 @@ impl PeerSession {
         }
         let pending = self.take_pending_tx_pool_cleanup();
         self.pending_tx_pool_cleanup = pending.merge(cleanup);
+    }
+
+    pub(crate) fn drain_pending_da_relay_stages(
+        &mut self,
+        da_relay: &std::sync::Mutex<crate::da_relay::DaRelayState>,
+    ) {
+        let stages = std::mem::take(&mut self.pending_da_relay_stages);
+        if stages.is_empty() {
+            return;
+        }
+        let Ok(mut da_relay) = da_relay.lock() else {
+            self.peer.last_error = "da relay state poisoned; peer-tx staging skipped".to_string();
+            return;
+        };
+        for (peer_addr, tx_bytes) in stages {
+            if let Err(err) = da_relay.stage_relay_da_tx_bytes(&peer_addr, &tx_bytes) {
+                self.peer.last_error = format!("DA relay tx staging failed: {err:?}");
+            }
+        }
+    }
+
+    pub(crate) fn advance_da_orphan_ttl_for_accepted_blocks(
+        &mut self,
+        da_relay: &std::sync::Mutex<crate::da_relay::DaRelayState>,
+    ) {
+        let advances = std::mem::take(&mut self.pending_da_orphan_ttl_advances);
+        if advances == 0 {
+            return;
+        }
+        let Ok(mut da_relay) = da_relay.lock() else {
+            self.peer.last_error =
+                "da relay state poisoned; DA orphan TTL advance skipped".to_string();
+            return;
+        };
+        for _ in 0..advances {
+            if let Err(err) = da_relay.advance_orphan_ttl() {
+                self.peer.last_error = format!("DA orphan TTL advance failed: {err:?}");
+                return;
+            }
+        }
+    }
+
+    fn queue_da_relay_stage(&mut self, peer_addr: &str, tx_bytes: Vec<u8>) {
+        self.pending_da_relay_stages
+            .push((peer_addr.to_string(), tx_bytes));
+    }
+
+    fn note_accepted_block_for_da_ttl(&mut self) -> io::Result<()> {
+        self.pending_da_orphan_ttl_advances = self
+            .pending_da_orphan_ttl_advances
+            .checked_add(1)
+            .ok_or_else(|| invalid_data("DA orphan TTL advance counter overflow"))?;
+        Ok(())
     }
 
     pub fn read_message(&mut self) -> io::Result<WireMessage> {
@@ -642,20 +679,21 @@ impl PeerSession {
         sync_engine: &mut SyncEngine,
         relay_ctx: Option<&PeerRelayContext<'_>>,
     ) -> io::Result<LiveMessageOutcome> {
-        if msg.payload.len() > MAX_RELAY_MSG_BYTES as usize {
+        let WireMessage { command, payload } = msg;
+        if payload.len() > MAX_RELAY_MSG_BYTES as usize {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!(
                     "message payload too large: {} > {}",
-                    msg.payload.len(),
+                    payload.len(),
                     MAX_RELAY_MSG_BYTES
                 ),
             ));
         }
-        match msg.command.as_str() {
+        match command.as_str() {
             MESSAGE_INV => {
                 let requests =
-                    self.handle_inv(&msg.payload, sync_engine, relay_ctx.map(|c| c.relay_state))?;
+                    self.handle_inv(&payload, sync_engine, relay_ctx.map(|c| c.relay_state))?;
                 if requests.is_empty() {
                     Ok(LiveMessageOutcome {
                         responses: Vec::new(),
@@ -673,14 +711,14 @@ impl PeerSession {
             }
             MESSAGE_GETDATA => Ok(LiveMessageOutcome {
                 responses: self.collect_getdata_responses(
-                    &msg.payload,
+                    &payload,
                     sync_engine,
                     relay_ctx.map(|c| c.relay_state),
                 )?,
                 tx_pool_cleanup: TxPoolCleanupPlan::default(),
             }),
             MESSAGE_GETBLOCKS => {
-                let items = self.handle_getblocks(&msg.payload, sync_engine)?;
+                let items = self.handle_getblocks(&payload, sync_engine)?;
                 if items.is_empty() {
                     Ok(LiveMessageOutcome {
                         responses: Vec::new(),
@@ -697,7 +735,7 @@ impl PeerSession {
                 }
             }
             MESSAGE_BLOCK => {
-                let tx_pool_cleanup = self.handle_block(&msg.payload, sync_engine)?;
+                let tx_pool_cleanup = self.handle_block(&payload, sync_engine)?;
                 Ok(LiveMessageOutcome {
                     responses: self
                         .prepare_block_request_if_behind(sync_engine)?
@@ -706,14 +744,14 @@ impl PeerSession {
                     tx_pool_cleanup,
                 })
             }
-            "cmpctblock" => self.handle_cmpctblock(&msg.payload, sync_engine, relay_ctx),
-            MESSAGE_GETBLOCKTXN => self.handle_getblocktxn(&msg.payload, sync_engine),
-            MESSAGE_BLOCKTXN => self.handle_blocktxn(&msg.payload, sync_engine),
+            "cmpctblock" => self.handle_cmpctblock(&payload, sync_engine, relay_ctx),
+            MESSAGE_GETBLOCKTXN => self.handle_getblocktxn(&payload, sync_engine),
+            MESSAGE_BLOCKTXN => self.handle_blocktxn(&payload, sync_engine),
             MESSAGE_TX => {
                 if let Some(ctx) = relay_ctx {
                     let validated_da_txid =
                         match crate::da_relay::DaRelayState::validate_relay_da_tx_for_admission(
-                            &msg.payload,
+                            &payload,
                         ) {
                             Ok(txid) => txid,
                             Err(err) => {
@@ -731,12 +769,12 @@ impl PeerSession {
                         };
                     let txid = match validated_da_txid {
                         Some(txid) => Ok(txid),
-                        None => crate::tx_relay::canonical_txid(&msg.payload),
+                        None => crate::tx_relay::canonical_txid(&payload),
                     };
                     let (outcome, relay_txid) = match txid {
                         Ok(txid) => (
                             crate::tx_relay::handle_received_tx_with_canonical_txid(
-                                &msg.payload,
+                                &payload,
                                 txid,
                                 sync_engine,
                                 ctx.relay_state,
@@ -752,6 +790,27 @@ impl PeerSession {
                             None,
                         ),
                     };
+                    // Mirror Go's `peer.handleTx` parse-fail policy: parse
+                    // failures bump the peer ban score by 10 and fail the
+                    // session only when the cumulative score crosses the
+                    // ban threshold. Pool/metadata rejections of a valid
+                    // tx stay silent. Wire-level oversize is rejected
+                    // earlier in `parse_envelope_header`; this branch only
+                    // fires for parse failures that reach
+                    // `handle_received_tx` (RPC path or sub-cap garbage).
+                    if outcome.is_banworthy() {
+                        let reason = match &outcome {
+                            crate::tx_relay::RelayTxOutcome::MalformedParse(r) => r.clone(),
+                            crate::tx_relay::RelayTxOutcome::Oversized => {
+                                format!("tx payload exceeds MAX_RELAY_MSG_BYTES: {}", payload.len())
+                            }
+                            _ => String::new(),
+                        };
+                        self.bump_ban(10, &reason);
+                        if self.peer.ban_score >= self.cfg.ban_threshold {
+                            return Err(io::Error::new(io::ErrorKind::InvalidData, reason));
+                        }
+                    }
                     if matches!(
                         outcome,
                         crate::tx_relay::RelayTxOutcome::Relayed
@@ -759,7 +818,7 @@ impl PeerSession {
                     ) {
                         if let Some(txid) = relay_txid {
                             let stages_relay_da_tx =
-                                crate::da_relay::stages_relay_da_tx_bytes(&msg.payload);
+                                crate::da_relay::stages_relay_da_tx_bytes(&payload);
                             let mut stage_fresh_payload = false;
                             let mut duplicate_da_bytes = None;
                             match ctx.tx_pool.lock() {
@@ -767,7 +826,7 @@ impl PeerSession {
                                     if matches!(outcome, crate::tx_relay::RelayTxOutcome::Relayed)
                                         && pool
                                             .add_tx_with_source(
-                                                &msg.payload,
+                                                &payload,
                                                 &sync_engine.chain_state,
                                                 sync_engine.block_store.as_ref(),
                                                 sync_engine.cfg.chain_id,
@@ -787,50 +846,14 @@ impl PeerSession {
                                             .to_string();
                                 }
                             }
-                            let staged_da_bytes = if stage_fresh_payload {
-                                Some(msg.payload.as_slice())
-                            } else {
-                                duplicate_da_bytes.as_deref()
-                            };
-                            if let Some(staged_da_bytes) = staged_da_bytes {
-                                if let Ok(mut da_relay) = ctx.da_relay.lock() {
-                                    if let Err(err) = da_relay.stage_relay_da_tx_bytes(
-                                        ctx.peer_registered_addr,
-                                        staged_da_bytes,
-                                    ) {
-                                        self.peer.last_error =
-                                            format!("DA relay tx staging failed: {err:?}");
-                                    }
-                                } else {
-                                    self.peer.last_error =
-                                        "da relay state poisoned; peer-tx staging skipped"
-                                            .to_string();
-                                }
+                            if stage_fresh_payload {
+                                self.queue_da_relay_stage(ctx.peer_registered_addr, payload);
+                            } else if let Some(staged_da_bytes) = duplicate_da_bytes {
+                                self.queue_da_relay_stage(
+                                    ctx.peer_registered_addr,
+                                    staged_da_bytes,
+                                );
                             }
-                        }
-                    }
-                    // Mirror Go's `peer.handleTx` parse-fail policy: parse
-                    // failures bump the peer ban score by 10 and fail the
-                    // session only when the cumulative score crosses the
-                    // ban threshold. Pool/metadata rejections of a valid
-                    // tx stay silent. Wire-level oversize is rejected
-                    // earlier in `parse_envelope_header`; this branch only
-                    // fires for parse failures that reach
-                    // `handle_received_tx` (RPC path or sub-cap garbage).
-                    if outcome.is_banworthy() {
-                        let reason = match &outcome {
-                            crate::tx_relay::RelayTxOutcome::MalformedParse(r) => r.clone(),
-                            crate::tx_relay::RelayTxOutcome::Oversized => {
-                                format!(
-                                    "tx payload exceeds MAX_RELAY_MSG_BYTES: {}",
-                                    msg.payload.len()
-                                )
-                            }
-                            _ => String::new(),
-                        };
-                        self.bump_ban(10, &reason);
-                        if self.peer.ban_score >= self.cfg.ban_threshold {
-                            return Err(io::Error::new(io::ErrorKind::InvalidData, reason));
                         }
                     }
                 }
@@ -844,7 +867,7 @@ impl PeerSession {
                 tx_pool_cleanup: TxPoolCleanupPlan::default(),
             }),
             MESSAGE_SENDCMPCT => {
-                self.handle_sendcmpct(&msg.payload)?;
+                self.handle_sendcmpct(&payload)?;
                 Ok(LiveMessageOutcome {
                     responses: Vec::new(),
                     tx_pool_cleanup: TxPoolCleanupPlan::default(),
@@ -865,7 +888,7 @@ impl PeerSession {
                 tx_pool_cleanup: TxPoolCleanupPlan::default(),
             }),
             MESSAGE_ADDR => {
-                let _ = unmarshal_addr_payload(&msg.payload)?;
+                let _ = unmarshal_addr_payload(&payload)?;
                 Ok(LiveMessageOutcome {
                     responses: Vec::new(),
                     tx_pool_cleanup: TxPoolCleanupPlan::default(),
@@ -1335,6 +1358,7 @@ impl PeerSession {
         match sync_engine.apply_block_with_reorg(block_bytes, None) {
             Ok(outcome) => {
                 sync_engine.record_best_known_height(outcome.summary.block_height);
+                self.note_accepted_block_for_da_ttl()?;
                 let mut tx_pool_cleanup = outcome.tx_pool_cleanup;
                 if let Err(err) =
                     self.resolve_orphans(block_hash_bytes, sync_engine, &mut tx_pool_cleanup)
@@ -1389,6 +1413,7 @@ impl PeerSession {
             match sync_engine.apply_block_with_reorg(&child.block_bytes, None) {
                 Ok(outcome) => {
                     sync_engine.record_best_known_height(outcome.summary.block_height);
+                    self.note_accepted_block_for_da_ttl()?;
                     *tx_pool_cleanup =
                         std::mem::take(tx_pool_cleanup).merge(outcome.tx_pool_cleanup);
                     ready.extend(self.orphans.take_children(child.block_hash));
@@ -5949,42 +5974,8 @@ mod tests {
         assert!(err.contains("unknown message type: weird"), "got: {err}");
     }
 
-    /// RUB-178 / GitHub #1438 introduced this production-path
-    /// reachability proof for the canonical TxPool admission seam in
-    /// `PeerRelayContext`; RUB-173 / GitHub #1420 paired the seam swap
-    /// to `add_tx_with_source(_, _, _, _, TxSource::Remote)` with an
-    /// `entry_source` parity update from `Local` to `Remote`.
-    ///
-    /// Proof assertion: the `assert_eq!(pool_guard.entry_source(&txid),
-    /// Some(crate::txpool::TxSource::Remote), ...)` near the end of
-    /// this test is the regression anchor that breaks if the seam
-    /// regresses to legacy `pool.admit` (Local) or any other source
-    /// variant.
-    ///
-    /// Why this is not helper-only:
-    ///
-    ///   - The test does NOT call `add_tx_with_source(...)` or
-    ///     `pool.admit(...)` directly. Admission happens through
-    ///     `PeerSession::collect_live_responses`, the exact public
-    ///     method used by the production message loop in
-    ///     `clients/rust/crates/rubin-node/src/p2p_service.rs::handle_peer`
-    ///     (see the `session.collect_live_responses(msg, &mut engine,
-    ///     Some(&relay_ctx))` call in `handle_peer`'s message-loop body).
-    ///   - The test constructs a real `PeerRelayContext` whose `tx_pool`
-    ///     field uses the same `Mutex<TxPool>` shape that
-    ///     `p2p_service.rs::handle_peer` constructs from
-    ///     `&shared.tx_pool` (the canonical pool that already drives the
-    ///     production block-apply cleanup path).
-    ///   - The canonical pool side effect is asserted from outside the
-    ///     dispatch: after `collect_live_responses` returns,
-    ///     `tx_pool.lock()` is taken and `pool.contains(&txid)` plus
-    ///     `pool.entry_source(&txid)` are checked. The seam is the
-    ///     only code path that could put the txid there in this scenario.
-    ///   - Source classification: `entry_source(&txid)` is asserted to
-    ///     equal `Some(TxSource::Remote)` per RUB-173 / GitHub #1420.
-    ///     This matches Go's `Mempool.AddRemoteTx` provenance and breaks
-    ///     if the seam regresses to legacy `pool.admit` (Local) or any
-    ///     other source variant.
+    /// Production-path regression for peer tx admission, Remote provenance,
+    /// and deferred DA staging after `collect_live_responses`.
     #[test]
     #[rustfmt::skip]
     fn collect_live_responses_message_tx_admits_through_canonical_pool_seam() {
@@ -6010,11 +6001,6 @@ mod tests {
             let mut engine =
                 crate::sync::SyncEngine::new(chain_state, None, sync_cfg).expect("sync engine");
 
-            // Production analogue of `shared.relay_state` /
-            // `shared.peer_manager` / `shared.peer_outboxes` /
-            // `shared.tx_pool` — same handles
-            // `clients/rust/crates/rubin-node/src/p2p_service.rs` threads
-            // into `PeerRelayContext`.
             let relay_state = crate::tx_relay::TxRelayState::new();
             let peer_manager = PeerManager::new(default_peer_runtime_config("devnet", 64));
             let _ = peer_manager.add_peer(PeerState {
@@ -6041,7 +6027,6 @@ mod tests {
                 peer_registered_addr: "sender:8333",
                 peer_writers: &peer_outboxes,
                 tx_pool: &canonical_tx_pool,
-                da_relay: &da_relay_state,
             };
 
             let msg = WireMessage {
@@ -6052,31 +6037,16 @@ mod tests {
             let _ = session
                 .collect_live_responses(msg, &mut engine, Some(&relay_ctx))
                 .expect("collect_live_responses MESSAGE_TX must succeed for floor-compliant tx");
+            session.drain_pending_da_relay_stages(&da_relay_state);
 
             let (_, txid, _, _consumed) = parse_tx(&tx_bytes).expect("parse tx for txid");
 
-            // 1) production-path reachability: the canonical pool side
-            //    effect is observable AFTER `collect_live_responses`
-            //    returns. No direct `pool.admit(...)` call from the
-            //    test reached this state; the only path is through
-            //    `collect_live_responses::MESSAGE_TX` -> tx_relay::Relayed
-            //    -> ctx.tx_pool seam.
             let pool_guard = canonical_tx_pool.lock().expect("pool lock");
             assert!(
                 pool_guard.contains(&txid),
                 "canonical TxPool must contain the txid after MESSAGE_TX dispatch — \
                  the seam is the only code path that could place it there in this test"
             );
-            // RUB-173 / GitHub #1420 source-provenance pin: the seam
-            // uses `add_tx_with_source(_, _, _, _, TxSource::Remote)`
-            // which records `Remote` on `TxPoolEntry.source` to match
-            // Go's `Mempool.AddRemoteTx` provenance. Proof assertion:
-            // the `assert_eq!` below comparing
-            // `pool_guard.entry_source(&txid)` against
-            // `Some(crate::txpool::TxSource::Remote)` is the parity
-            // anchor; any regression that drops back to legacy
-            // `pool.admit` (Local) or any other source variant
-            // produces a test failure here.
             assert_eq!(
                 pool_guard.entry_source(&txid),
                 Some(crate::txpool::TxSource::Remote),
@@ -6091,6 +6061,7 @@ mod tests {
                 Some((false, 1, tx_bytes.len() as u64))
             );
             session.collect_live_responses(WireMessage { command: MESSAGE_TX.to_string(), payload: tx_bytes.clone() }, &mut engine, Some(&relay_ctx)).expect("duplicate DA staging diagnostics should stay peer-neutral");
+            session.drain_pending_da_relay_stages(&da_relay_state);
             assert!(
                 session
                     .state()
@@ -6099,8 +6070,9 @@ mod tests {
                 "duplicate DA staging must be observable on peer.last_error"
             );
             let dup_relay_state = crate::tx_relay::TxRelayState::new(); let dup_da_relay_state = test_da_relay_state();
-            let dup_ctx = PeerRelayContext { relay_state: &dup_relay_state, peer_manager: &peer_manager, local_addr: "local:8333", peer_registered_addr: "sender:8333", peer_writers: &peer_outboxes, tx_pool: &canonical_tx_pool, da_relay: &dup_da_relay_state };
+            let dup_ctx = PeerRelayContext { relay_state: &dup_relay_state, peer_manager: &peer_manager, local_addr: "local:8333", peer_registered_addr: "sender:8333", peer_writers: &peer_outboxes, tx_pool: &canonical_tx_pool };
             session.collect_live_responses(WireMessage { command: MESSAGE_TX.to_string(), payload: tx_bytes.clone() }, &mut engine, Some(&dup_ctx)).expect("already-admitted DA tx should stay peer-neutral");
+            session.drain_pending_da_relay_stages(&dup_da_relay_state);
             assert_eq!(dup_da_relay_state.lock().unwrap().test_record_summary(da_id), Some((false, 1, tx_bytes.len() as u64)));
 
             session.collect_live_responses(WireMessage { command: MESSAGE_TX.to_string(), payload: conflicting_tx.clone() }, &mut engine, Some(&relay_ctx)).expect("conflicting MESSAGE_TX dispatch must preserve relay outcome");
@@ -6108,10 +6080,6 @@ mod tests {
             assert!(relay_state.tx_seen.has(&conflicting_txid));
             assert_eq!(da_relay_state.lock().unwrap().test_record_summary(conflicting_da_id), None);
 
-            // 2) relay-cache-only path remains separate: tx_relay's
-            //    relay_state still records the tx as well. This proves
-            //    the seam is additive on top of the relay-only path,
-            //    not a replacement of it.
             assert!(
                 relay_state.tx_seen.has(&txid),
                 "tx_relay relay-cache `tx_seen` must still record the tx"
@@ -6129,7 +6097,7 @@ mod tests {
     #[test]
     #[rustfmt::skip]
     fn collect_live_responses_duplicate_non_da_skips_da_relay_stage() {
-        use std::collections::HashMap; use std::sync::{Arc, Mutex};
+        use std::collections::HashMap; use std::sync::Mutex;
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind"); let addr = listener.local_addr().expect("addr");
         let server = thread::spawn(move || {
             let (stream, _) = listener.accept().expect("accept"); let mut session = PeerSession::new(stream, default_peer_runtime_config("devnet", 8)).expect("session");
@@ -6137,12 +6105,11 @@ mod tests {
             let mut engine = crate::sync::SyncEngine::new(chain_state, None, sync_cfg).expect("sync engine");
             let relay_state = crate::tx_relay::TxRelayState::new(); let peer_manager = PeerManager::new(default_peer_runtime_config("devnet", 64)); let _ = peer_manager.add_peer(PeerState { addr: "other:8333".to_string(), ..Default::default() });
             let peer_outboxes: Mutex<HashMap<String, crate::tx_relay::PeerOutbox>> = Mutex::new(HashMap::new()); peer_outboxes.lock().unwrap().insert("sender:8333".to_string(), crate::tx_relay::PeerOutbox::default()); peer_outboxes.lock().unwrap().insert("other:8333".to_string(), crate::tx_relay::PeerOutbox::default());
-            let canonical_tx_pool: Mutex<TxPool> = Mutex::new(TxPool::new()); let da_relay_state = test_da_relay_state();
-            let relay_ctx = PeerRelayContext { relay_state: &relay_state, peer_manager: &peer_manager, local_addr: "local:8333", peer_registered_addr: "sender:8333", peer_writers: &peer_outboxes, tx_pool: &canonical_tx_pool, da_relay: &da_relay_state };
+            let canonical_tx_pool: Mutex<TxPool> = Mutex::new(TxPool::new());
+            let relay_ctx = PeerRelayContext { relay_state: &relay_state, peer_manager: &peer_manager, local_addr: "local:8333", peer_registered_addr: "sender:8333", peer_writers: &peer_outboxes, tx_pool: &canonical_tx_pool };
             session.collect_live_responses(WireMessage { command: MESSAGE_TX.to_string(), payload: tx_bytes.clone() }, &mut engine, Some(&relay_ctx)).expect("first non-DA relay tx must admit");
             let (_, txid, _, _consumed) = parse_tx(&tx_bytes).expect("parse tx for txid"); assert!(relay_state.tx_seen.has(&txid)); assert!(canonical_tx_pool.lock().unwrap().contains(&txid));
-            let poisoned_da_relay = Arc::new(test_da_relay_state()); let poison_target = Arc::clone(&poisoned_da_relay); let _ = thread::spawn(move || { let _guard = poison_target.lock().unwrap(); panic!("intentional poison for duplicate non-DA DA-stage skip test"); }).join(); assert!(poisoned_da_relay.is_poisoned());
-            session.peer.last_error.clear(); let duplicate_ctx = PeerRelayContext { relay_state: &relay_state, peer_manager: &peer_manager, local_addr: "local:8333", peer_registered_addr: "sender:8333", peer_writers: &peer_outboxes, tx_pool: &canonical_tx_pool, da_relay: poisoned_da_relay.as_ref() };
+            session.peer.last_error.clear(); let duplicate_ctx = PeerRelayContext { relay_state: &relay_state, peer_manager: &peer_manager, local_addr: "local:8333", peer_registered_addr: "sender:8333", peer_writers: &peer_outboxes, tx_pool: &canonical_tx_pool };
             session.collect_live_responses(WireMessage { command: MESSAGE_TX.to_string(), payload: tx_bytes }, &mut engine, Some(&duplicate_ctx)).expect("duplicate non-DA relay tx must stay peer-neutral");
             assert!(session.state().last_error.is_empty(), "duplicate non-DA tx must not touch DA relay staging: {:?}", session.state().last_error);
         });
@@ -6270,7 +6237,6 @@ mod tests {
             // mirrors the production failure mode where a panic during
             // pool mutation leaves a poisoned shared handle.
             let canonical_tx_pool: Arc<Mutex<TxPool>> = Arc::new(Mutex::new(TxPool::new()));
-            let da_relay_state = test_da_relay_state();
             let poison_pool = Arc::clone(&canonical_tx_pool);
             let _ = thread::spawn(move || {
                 let _guard = poison_pool.lock().unwrap();
@@ -6289,7 +6255,6 @@ mod tests {
                 peer_registered_addr: "sender:8333",
                 peer_writers: &peer_outboxes,
                 tx_pool: &canonical_tx_pool,
-                da_relay: &da_relay_state,
             };
 
             let msg = WireMessage {

--- a/clients/rust/crates/rubin-node/src/p2p_service.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_service.rs
@@ -210,6 +210,10 @@ impl RunningNodeP2PService {
         Arc::clone(&self.shared.peer_outboxes)
     }
 
+    pub fn da_relay_state(&self) -> Arc<Mutex<DaRelayState>> {
+        Arc::clone(&self.shared.da_relay)
+    }
+
     pub fn close(&mut self) {
         self.stop.store(true, Ordering::SeqCst);
         let _ = TcpStream::connect(&self.addr);
@@ -819,15 +823,7 @@ fn handle_peer(
         addr: peer_addr.clone(),
     };
 
-    // Build relay context for message loop. RUB-178 / GitHub #1438
-    // introduced the lifecycle plumbing; `tx_pool` threads the existing
-    // `shared.tx_pool` handle (already used by the block-apply cleanup
-    // path in `apply_tx_pool_cleanup`) into the peer-tx dispatch so
-    // peer transactions reach canonical admission via the seam in
-    // `collect_live_responses`. RUB-173 / GitHub #1420 then swapped that
-    // seam to `add_tx_with_source(..., TxSource::Remote, ...)` for
-    // source-aware classification. No new lifecycle ownership: this is
-    // the same `Arc<Mutex<TxPool>>` introduced for cleanup in PR #876.
+    // Build relay context for message-loop tx admission and broadcast.
     let relay_ctx = PeerRelayContext {
         relay_state: &shared.relay_state,
         peer_manager: &shared.peer_manager,
@@ -835,7 +831,6 @@ fn handle_peer(
         peer_registered_addr: &peer_addr,
         peer_writers: &shared.peer_outboxes,
         tx_pool: &shared.tx_pool,
-        da_relay: &shared.da_relay,
     };
 
     {
@@ -897,6 +892,8 @@ fn handle_peer(
                 let outcome = session.collect_live_responses(msg, &mut engine, Some(&relay_ctx));
                 let pending_cleanup = session.take_pending_tx_pool_cleanup();
                 drop(engine);
+                session.advance_da_orphan_ttl_for_accepted_blocks(&shared.da_relay);
+                session.drain_pending_da_relay_stages(&shared.da_relay);
                 finalize_live_message_outcome(&shared, outcome, pending_cleanup)?
             };
             log_tx_pool_cleanup_requeue_failure(&maybe_apply_tx_pool_cleanup(

--- a/clients/rust/crates/rubin-node/src/p2p_service.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_service.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, Instant};
 
 use std::collections::HashMap;
 
-use crate::da_relay::{DaRelayCaps, DaRelayState};
+use crate::da_relay::{DaRelayCaps, DaRelayState, PeerQuotaKey};
 use crate::p2p_runtime::{
     perform_version_handshake, LiveMessageOutcome, PeerManager, PeerRelayContext,
     PeerRuntimeConfig, VersionPayloadV1, WireMessage,
@@ -820,6 +820,7 @@ fn handle_peer(
 
     let _peer_guard = PeerGuard {
         peer_manager: Arc::clone(&shared.peer_manager),
+        da_relay: Arc::clone(&shared.da_relay),
         addr: peer_addr.clone(),
     };
 
@@ -1030,12 +1031,24 @@ fn service_local_version(
 
 struct PeerGuard {
     peer_manager: Arc<PeerManager>,
+    da_relay: Arc<Mutex<DaRelayState>>,
     addr: String,
 }
 
 impl Drop for PeerGuard {
     fn drop(&mut self) {
+        let quota_key = PeerQuotaKey::from_peer_addr(&self.addr);
         self.peer_manager.remove_peer(&self.addr);
+        let quota_key_still_active = self
+            .peer_manager
+            .snapshot()
+            .iter()
+            .any(|peer| PeerQuotaKey::from_peer_addr(&peer.addr) == quota_key);
+        if !quota_key_still_active {
+            if let Ok(mut da_relay) = self.da_relay.lock() {
+                let _ = da_relay.release_peer_quota_key(&quota_key);
+            }
+        }
     }
 }
 
@@ -1119,7 +1132,12 @@ mod tests {
     use std::thread;
     use std::time::{Duration, Instant};
 
-    use rubin_consensus::{block_hash, constants::POW_LIMIT, parse_tx, BLOCK_HEADER_BYTES};
+    use rubin_consensus::{
+        block_hash,
+        constants::{POW_LIMIT, TX_WIRE_VERSION},
+        marshal_tx, parse_tx, DaChunkCore, Tx, BLOCK_HEADER_BYTES,
+    };
+    use sha3::{Digest, Sha3_256};
 
     use super::{
         apply_tx_pool_cleanup, connect_with_timeout, finalize_live_message_outcome,
@@ -2413,6 +2431,7 @@ mod tests {
         let alias_guard = register_peer_alias(&shared, alias, &primary).expect("register alias");
         let peer_guard = PeerGuard {
             peer_manager: Arc::clone(&shared.peer_manager),
+            da_relay: Arc::clone(&shared.da_relay),
             addr: primary.clone(),
         };
 
@@ -2437,6 +2456,23 @@ mod tests {
 
         drop(outbox_guard);
         assert!(!shared.peer_outboxes.lock().unwrap().contains_key(&primary));
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[rustfmt::skip]
+    #[test]
+    fn peer_guard_drop_releases_inactive_da_quota_key() {
+        let (sync_engine, dir) = test_engine("rubin-node-p2p-da-quota-release"); let shared = test_shared_state(default_peer_runtime_config("devnet", 8), vec![], sync_engine);
+        let peer = "127.0.0.1:19111"; let da_id = [0x87; 32]; let payload = b"owned";
+        shared.peer_manager.add_peer(crate::p2p_runtime::PeerState { addr: peer.to_string(), ..Default::default() }).expect("register peer");
+        let tx = marshal_tx(&Tx { version: TX_WIRE_VERSION, tx_kind: 0x02, tx_nonce: 1, inputs: Vec::new(), outputs: Vec::new(), locktime: 0, da_commit_core: None, da_chunk_core: Some(DaChunkCore { da_id, chunk_index: 0, chunk_hash: Sha3_256::digest(payload).into() }), witness: Vec::new(), da_payload: payload.to_vec() }).expect("marshal da chunk tx");
+        shared.da_relay.lock().unwrap().stage_relay_da_tx_bytes(peer, &tx).expect("stage da chunk");
+        let guard = PeerGuard { peer_manager: Arc::clone(&shared.peer_manager), da_relay: Arc::clone(&shared.da_relay), addr: peer.to_string() };
+        drop(guard);
+        let da_relay = shared.da_relay.lock().unwrap();
+        assert_eq!(da_relay.test_orphan_bytes_for_peer(peer), 0);
+        assert_eq!(da_relay.test_orphan_bytes_for_da_id(da_id), 0);
+        assert_eq!(da_relay.test_record_summary(da_id), None);
         fs::remove_dir_all(dir).expect("cleanup");
     }
 

--- a/clients/rust/crates/rubin-node/src/p2p_service.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_service.rs
@@ -8,6 +8,7 @@ use std::time::{Duration, Instant};
 
 use std::collections::HashMap;
 
+use crate::da_relay::{DaRelayCaps, DaRelayState};
 use crate::p2p_runtime::{
     perform_version_handshake, LiveMessageOutcome, PeerManager, PeerRelayContext,
     PeerRuntimeConfig, VersionPayloadV1, WireMessage,
@@ -63,6 +64,7 @@ struct SharedServiceState {
     peer_manager: Arc<PeerManager>,
     sync_engine: Arc<Mutex<SyncEngine>>,
     tx_pool: Arc<Mutex<TxPool>>,
+    da_relay: Arc<Mutex<DaRelayState>>,
     bootstrap_peers: Arc<Vec<String>>,
     bootstrap_rotate_idx: Arc<AtomicUsize>,
     in_flight_dials: Arc<Mutex<HashSet<String>>>,
@@ -154,6 +156,10 @@ pub fn start_node_p2p_service(cfg: NodeP2PServiceConfig) -> Result<RunningNodeP2
         .to_string();
     let stop = Arc::new(AtomicBool::new(false));
     let relay_state = Arc::new(TxRelayState::new_with_network(&cfg.runtime_cfg.network));
+    let da_relay = Arc::new(Mutex::new(
+        DaRelayState::new(DaRelayCaps::default())
+            .map_err(|err| format!("da relay state: {err:?}"))?,
+    ));
     let shared = SharedServiceState {
         stop: Arc::clone(&stop),
         runtime_cfg: cfg.runtime_cfg,
@@ -162,6 +168,7 @@ pub fn start_node_p2p_service(cfg: NodeP2PServiceConfig) -> Result<RunningNodeP2
         peer_manager: cfg.peer_manager,
         sync_engine: cfg.sync_engine,
         tx_pool: cfg.tx_pool,
+        da_relay,
         bootstrap_peers: Arc::new(cfg.bootstrap_peers),
         bootstrap_rotate_idx: Arc::new(AtomicUsize::new(0)),
         in_flight_dials: Arc::new(Mutex::new(HashSet::new())),
@@ -828,6 +835,7 @@ fn handle_peer(
         peer_registered_addr: &peer_addr,
         peer_writers: &shared.peer_outboxes,
         tx_pool: &shared.tx_pool,
+        da_relay: &shared.da_relay,
     };
 
     {
@@ -1193,6 +1201,10 @@ mod tests {
             peer_manager: Arc::new(PeerManager::new(runtime_cfg)),
             sync_engine,
             tx_pool: Arc::new(Mutex::new(TxPool::new())),
+            da_relay: Arc::new(Mutex::new(
+                crate::da_relay::DaRelayState::new(crate::da_relay::DaRelayCaps::default())
+                    .expect("da relay state"),
+            )),
             bootstrap_peers: Arc::new(bootstrap_peers),
             bootstrap_rotate_idx: Arc::new(AtomicUsize::new(0)),
             in_flight_dials: Arc::new(Mutex::new(HashSet::new())),

--- a/clients/rust/crates/rubin-node/src/tx_relay.rs
+++ b/clients/rust/crates/rubin-node/src/tx_relay.rs
@@ -638,6 +638,33 @@ pub fn handle_received_tx(
         Err(reason) => return Ok(RelayTxOutcome::MalformedParse(reason)),
     };
 
+    handle_received_tx_with_canonical_txid(
+        tx_bytes,
+        txid,
+        sync_engine,
+        relay_state,
+        peer_manager,
+        skip_addr,
+        local_addr,
+        peer_writers,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn handle_received_tx_with_canonical_txid(
+    tx_bytes: &[u8],
+    txid: [u8; 32],
+    sync_engine: &crate::sync::SyncEngine,
+    relay_state: &TxRelayState,
+    peer_manager: &PeerManager,
+    skip_addr: &str,
+    local_addr: &str,
+    peer_writers: &Mutex<HashMap<String, PeerOutbox>>,
+) -> io::Result<RelayTxOutcome> {
+    if tx_bytes.len() > rubin_consensus::constants::MAX_RELAY_MSG_BYTES as usize {
+        return Ok(RelayTxOutcome::Oversized);
+    }
+
     // Mark seen BEFORE pool admission (matches Go).
     if !relay_state.tx_seen.add(txid) {
         return Ok(RelayTxOutcome::DuplicateSeen);
@@ -683,7 +710,7 @@ pub fn handle_received_tx(
 }
 
 /// Extract the canonical txid from raw tx bytes using consensus parsing.
-fn canonical_txid(tx_bytes: &[u8]) -> Result<[u8; 32], String> {
+pub(crate) fn canonical_txid(tx_bytes: &[u8]) -> Result<[u8; 32], String> {
     let (_tx, txid, _wtxid, consumed) =
         rubin_consensus::parse_tx(tx_bytes).map_err(|e| e.to_string())?;
     if consumed != tx_bytes.len() {


### PR DESCRIPTION
Scope:
- Stage DA commit/chunk relay records only after canonical remote MESSAGE_TX admission, or from already-admitted canonical TxPool bytes for duplicate/preseen MESSAGE_TX.
- Validate DA chunk shape/hash before DA relay state mutation.
- Preserve relay outcome, ban score, TxSource::Remote admission, and txpool rejection behavior.
- Record DA staging failures on peer.last_error without turning them into peer penalties.
- Avoid extra hot-path payload copies for DA chunk staging and freshly admitted MESSAGE_TX bytes.

Parity Matrix:
| Required parity case | Go/reference/vector | Rust entrypoint/callsite | Rust mirror-test evidence |
| --- | --- | --- | --- |
| case: relay success and remote TxPool admission gate DA staging | Go handleTx canonical TxPool admission before DA relay staging | PeerSession::collect_live_responses MESSAGE_TX path calls add_tx_with_source(... TxSource::Remote) before stage_relay_da_tx_bytes | collect_live_responses_message_tx_admits_through_canonical_pool_seam |
| case: DA commit bytes classify and stage through existing DA relay state | Go stageRelayDATx dispatches tx_kind 0x01 into stageRelayDACommitTx | DaRelayState::stage_relay_da_tx_bytes classifies tx_kind 0x01 and records exactly one DA commit covenant commitment plus tx bytes | stage_relay_da_tx_bytes_contract_matrix |
| case: DA chunk bytes precheck before retained state mutation | Go validateRelayDATxForAdmission/stageRelayDAChunkTx rejects malformed chunk shape/hash before retained state mutation | DaRelayState::validate_relay_da_tx_for_admission runs before txpool/relay staging; stage_relay_da_tx_bytes validates chunk hash before mutation | stage_relay_da_tx_bytes_contract_matrix; collect_live_responses_message_tx_admits_through_canonical_pool_seam |
| case: non-chunk MESSAGE_TX skips DA chunk admission parse | Go validateRelayDATxForAdmission applies chunk precheck only to tx_kind 0x02 | validate_relay_da_tx_for_admission peeks canonical version/tx_kind prefix and returns before parse unless tx_kind is 0x02 | validate_relay_da_tx_for_admission_fast_paths_non_chunk_prefixes |
| case: DA chunk precheck txid is reused on tx relay path | Go parse/admission boundary avoids duplicate work on the same canonical bytes | validate_relay_da_tx_for_admission returns the chunk txid and MESSAGE_TX passes it into handle_received_tx_with_canonical_txid | collect_live_responses_message_tx_admits_through_canonical_pool_seam |
| case: TxPool rejection does not stage sibling DA state | Go rejects non-admitted remote txs before DA retained-state mutation | MESSAGE_TX conflict/rejection path preserves relay outcome and skips DaRelayState mutation | collect_live_responses_message_tx_admits_through_canonical_pool_seam |
| case: duplicate/preseen MESSAGE_TX stages canonical pool bytes | Go canonical pool duplicate path uses already-admitted tx bytes | MESSAGE_TX duplicate/preseen path loads TxPool::tx_by_id by txid and stages canonical pool bytes | collect_live_responses_message_tx_admits_through_canonical_pool_seam |
| case: DA staging failures are observable without peer penalty | Go DA retained-state staging errors remain diagnostic, not relay ban-score events | stage_relay_da_tx_bytes errors update peer.last_error while preserving peer-neutral relay outcome | collect_live_responses_message_tx_admits_through_canonical_pool_seam |
| case: non-DA txs do not mutate DA relay state | Go stageRelayDATx ignores non-DA tx kinds | DaRelayState::stage_relay_da_tx_bytes returns no-op for non-0x01/0x02 tx_kind | stage_relay_da_tx_bytes_contract_matrix |

Not in scope:
- No provider, miner, prefetch, getdachunk, script, Go, spec, formal, conformance, or workflow changes.
- No DA TTL expiry, peer disconnect cleanup, complete-set provider snapshots, or live miner wiring.
