### PR TITLE
RUB-418: bump GitHub Go toolchain to 1.26.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
           cache: true
           cache-dependency-path: |
             clients/go/go.mod
@@ -272,7 +272,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
           cache: true
           cache-dependency-path: clients/go/go.mod
 
@@ -501,7 +501,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
           cache: true
           cache-dependency-path: clients/go/go.mod
 
@@ -615,7 +615,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
           cache: true
           cache-dependency-path: clients/go/go.mod
 

--- a/.github/workflows/codacy-coverage.yml
+++ b/.github/workflows/codacy-coverage.yml
@@ -59,7 +59,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
           cache: true
           cache-dependency-path: clients/go/go.mod
 

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
           cache: true
           cache-dependency-path: clients/go/go.mod
 

--- a/.github/workflows/runtime-perf-guardrails.yml
+++ b/.github/workflows/runtime-perf-guardrails.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
           cache: true
           cache-dependency-path: |
             clients/go/go.mod

--- a/.github/workflows/security-supply-chain-nightly.yml
+++ b/.github/workflows/security-supply-chain-nightly.yml
@@ -40,7 +40,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
           cache: true
           cache-dependency-path: |
             clients/go/go.mod
@@ -126,7 +126,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
           cache: true
           cache-dependency-path: |
             clients/go/go.mod


### PR DESCRIPTION
Invariant:
GitHub Actions jobs that run Go vulnerability checks use a Go toolchain patch level that contains the current stdlib security fixes required by govulncheck.

Layer:
CI tooling.

Scope:
- Update GitHub Actions `actions/setup-go` pins from `1.26.3` to `1.26.4`.
- Keep the change limited to workflow toolchain selection.

Evidence:
- `go.dev/dl/?mode=json` lists `go1.26.4`.
- `go.dev/dl/go1.26.4.linux-amd64.tar.gz` returns HTTP 200.
- `actionlint` on the five changed workflow files.
- Python YAML parse for workflow files.
- `git diff --check`.
- `rubin-precommit-one-review --base-ref origin/main --include-base-diff`.
- `rubin-push --base-ref origin/main --no-coverage-reason 'workflow-only GitHub Actions Go toolchain pin bump; no production Go/Rust source coverage surface changed' -- origin HEAD`.

Known non-goals:
- No Go, Rust, consensus, P2P, DA relay, spec, fixture, formal, or source behavior changes.
- No govulncheck suppression.
