### PR TITLE
RUB-384: stage remote DA relay after admission

### DIFF
--- a/clients/rust/crates/rubin-node/src/da_relay.rs
+++ b/clients/rust/crates/rubin-node/src/da_relay.rs
@@ -741,7 +741,7 @@ fn validate_da_chunk(chunk: &DaRelayChunk) -> DaRelayResult {
     Ok(())
 }
 
-fn relay_da_tx_kind_prefix(tx_bytes: &[u8]) -> Option<u8> {
+pub(crate) fn relay_da_tx_kind_prefix(tx_bytes: &[u8]) -> Option<u8> {
     let version = u32::from_le_bytes(tx_bytes.get(..4)?.try_into().ok()?);
     let kind = tx_bytes.get(4).copied()?;
     (version == TX_WIRE_VERSION).then_some(kind)

--- a/clients/rust/crates/rubin-node/src/da_relay.rs
+++ b/clients/rust/crates/rubin-node/src/da_relay.rs
@@ -3,7 +3,10 @@ use std::collections::BTreeSet;
 use std::net::{IpAddr, Ipv6Addr};
 use std::sync::Arc;
 
-use rubin_consensus::constants::{CHUNK_BYTES, MAX_DA_CHUNK_COUNT};
+use rubin_consensus::constants::{
+    CHUNK_BYTES, COV_TYPE_DA_COMMIT, MAX_DA_CHUNK_COUNT, TX_WIRE_VERSION,
+};
+use rubin_consensus::{parse_tx, Tx};
 use sha3::{Digest, Sha3_256};
 
 pub const DA_ORPHAN_POOL_BYTES: u64 = 64 << 20;
@@ -394,6 +397,75 @@ impl DaRelayState {
             && self.sets_by_da_id.is_empty()
     }
 
+    pub(crate) fn validate_relay_da_tx_for_admission(tx_bytes: &[u8]) -> DaRelayResult {
+        if relay_da_tx_kind_prefix(tx_bytes) != Some(0x02) {
+            return Ok(());
+        }
+        let (tx, _txid, _wtxid, consumed) =
+            parse_tx(tx_bytes).map_err(|_| DaRelayError::InvalidWireBytes)?;
+        if consumed != tx_bytes.len() {
+            return Err(DaRelayError::InvalidWireBytes);
+        }
+        let wire_bytes =
+            u64::try_from(tx_bytes.len()).map_err(|_| DaRelayError::AccountingOverflow)?;
+        validate_relay_da_chunk_for_admission(&tx, wire_bytes)
+    }
+
+    #[rustfmt::skip]
+    pub(crate) fn stage_relay_da_tx_bytes(&mut self, peer_addr: &str, tx_bytes: Vec<u8>) -> DaRelayResult {
+        let wire_bytes =
+            u64::try_from(tx_bytes.len()).map_err(|_| DaRelayError::AccountingOverflow)?;
+        let (tx, _txid, _wtxid, consumed) =
+            parse_tx(&tx_bytes).map_err(|_| DaRelayError::InvalidWireBytes)?;
+        if consumed != tx_bytes.len() {
+            return Err(DaRelayError::InvalidWireBytes);
+        }
+        match tx.tx_kind {
+            0x01 => {
+                let Some(core) = tx.da_commit_core.as_ref() else {
+                    return Ok(());
+                };
+                let Some(payload_commitment) = relay_da_commit_payload_commitment(&tx) else {
+                    return Ok(());
+                };
+                self.stage_incomplete_da_commit(
+                    peer_addr,
+                    DaRelayCommit {
+                        da_id: core.da_id,
+                        payload_commitment,
+                        peer_quota_key: PeerQuotaKey::from_peer_addr(peer_addr),
+                        chunk_count: core.chunk_count,
+                        wire_bytes,
+                        tx_bytes: Arc::from(tx_bytes.into_boxed_slice()),
+                    },
+                )
+            }
+            0x02 => {
+                validate_relay_da_chunk_for_admission(&tx, wire_bytes)?;
+                let Some(core) = tx.da_chunk_core.as_ref() else {
+                    return Ok(());
+                };
+                self.stage_incomplete_da_chunk(
+                    peer_addr,
+                    DaRelayChunk {
+                        da_id: core.da_id,
+                        chunk_hash: core.chunk_hash,
+                        peer_quota_key: PeerQuotaKey::from_peer_addr(peer_addr),
+                        chunk_index: core.chunk_index,
+                        payload: Arc::from(tx.da_payload.into_boxed_slice()),
+                        wire_bytes,
+                        tx_bytes: Arc::from(tx_bytes.into_boxed_slice()),
+                    },
+                )
+            }
+            _ => Ok(()),
+        }
+    }
+
+    #[cfg(test)]
+    #[rustfmt::skip]
+    pub(crate) fn test_record_summary(&self, da_id: [u8; 32]) -> Option<(bool, usize, u64)> { let record = self.sets_by_da_id.get(&da_id)?; Some((record.commit.is_some(), record.chunks.len(), record.wire_bytes)) }
+
     pub(crate) fn complete_set_eviction_candidates(
         &self,
         max_payload_bytes: u64,
@@ -652,6 +724,50 @@ fn validate_da_chunk(chunk: &DaRelayChunk) -> DaRelayResult {
     Ok(())
 }
 
+fn relay_da_tx_kind_prefix(tx_bytes: &[u8]) -> Option<u8> {
+    let version = u32::from_le_bytes(tx_bytes.get(..4)?.try_into().ok()?);
+    let kind = tx_bytes.get(4).copied()?;
+    (version == TX_WIRE_VERSION).then_some(kind)
+}
+
+fn validate_relay_da_chunk_for_admission(tx: &Tx, wire_bytes: u64) -> DaRelayResult {
+    if tx.tx_kind != 0x02 {
+        return Ok(());
+    }
+    let Some(core) = tx.da_chunk_core.as_ref() else {
+        return Ok(());
+    };
+    let payload_len =
+        u64::try_from(tx.da_payload.len()).map_err(|_| DaRelayError::AccountingOverflow)?;
+    if u64::from(core.chunk_index) >= MAX_DA_CHUNK_COUNT {
+        return Err(DaRelayError::ChunkIndexOutOfRange);
+    }
+    if payload_len == 0 || payload_len > CHUNK_BYTES {
+        return Err(DaRelayError::ChunkPayloadSizeInvalid);
+    }
+    if wire_bytes < payload_len {
+        return Err(DaRelayError::InvalidWireBytes);
+    }
+    if sha3_256(&tx.da_payload) != core.chunk_hash {
+        return Err(DaRelayError::ChunkHashMismatch);
+    }
+    Ok(())
+}
+
+fn relay_da_commit_payload_commitment(tx: &Tx) -> Option<[u8; 32]> {
+    let mut outputs = tx
+        .outputs
+        .iter()
+        .filter(|output| output.covenant_type == COV_TYPE_DA_COMMIT);
+    let output = outputs.next()?;
+    if output.covenant_data.len() != 32 || outputs.next().is_some() {
+        return None;
+    }
+    let mut commitment = [0u8; 32];
+    commitment.copy_from_slice(&output.covenant_data);
+    Some(commitment)
+}
+
 fn checked_add(left: u64, right: u64) -> DaRelayResult<u64> {
     left.checked_add(right)
         .ok_or(DaRelayError::AccountingOverflow)
@@ -716,6 +832,28 @@ mod tests {
         assert!(state.is_empty());
         state.next_received_time = 1;
         assert!(state.is_empty());
+    }
+
+    #[rustfmt::skip]
+    fn relay_test_tx(tx_kind: u8, outputs: Vec<rubin_consensus::TxOutput>, da_commit_core: Option<rubin_consensus::DaCommitCore>, da_chunk_core: Option<rubin_consensus::DaChunkCore>, da_payload: Vec<u8>) -> Vec<u8> { rubin_consensus::marshal_tx(&rubin_consensus::Tx { version: rubin_consensus::constants::TX_WIRE_VERSION, tx_kind, tx_nonce: 7, inputs: Vec::new(), outputs, locktime: 0, da_commit_core, da_chunk_core, witness: Vec::new(), da_payload }).expect("marshal relay test tx") }
+
+    #[rustfmt::skip]
+    fn relay_commit_core(da_id: [u8; 32], chunk_count: u16) -> rubin_consensus::DaCommitCore { rubin_consensus::DaCommitCore { da_id, chunk_count, retl_domain_id: [0x10; 32], batch_number: 1, tx_data_root: [0x11; 32], state_root: [0x12; 32], withdrawals_root: [0x13; 32], batch_sig_suite: 0, batch_sig: Vec::new() } }
+
+    #[rustfmt::skip]
+    fn relay_chunk_core(da_id: [u8; 32], chunk_index: u16, payload: &[u8]) -> rubin_consensus::DaChunkCore { rubin_consensus::DaChunkCore { da_id, chunk_index, chunk_hash: sha3_256(payload) } }
+
+    #[rustfmt::skip]
+    fn da_commit_output(commitment: [u8; 32]) -> rubin_consensus::TxOutput { rubin_consensus::TxOutput { value: 0, covenant_type: rubin_consensus::constants::COV_TYPE_DA_COMMIT, covenant_data: commitment.to_vec() } }
+
+    #[test]
+    #[rustfmt::skip]
+    fn stage_relay_da_tx_bytes_contract_matrix() {
+        let peer = "peer-a:8333"; let mut state = DaRelayState::new(DaRelayCaps::default()).unwrap(); let non_da = relay_test_tx(0x00, Vec::new(), None, None, Vec::new()); state.stage_relay_da_tx_bytes(peer, non_da).unwrap(); assert!(state.is_empty());
+        let da_id = [1u8; 32]; let commitment = [2u8; 32]; let commit_tx = relay_test_tx(0x01, vec![da_commit_output(commitment)], Some(relay_commit_core(da_id, 1)), None, Vec::new()); state.stage_relay_da_tx_bytes(peer, commit_tx.clone()).unwrap(); let commit = state.sets_by_da_id[&da_id].commit.as_ref().unwrap(); assert_eq!(commit.payload_commitment, commitment); assert_eq!(commit.tx_bytes.as_ref(), commit_tx.as_slice());
+        let payload = b"relay chunk".to_vec(); let mut bad_core = relay_chunk_core([6u8; 32], 0, &payload); bad_core.chunk_hash = [7u8; 32]; let bad_chunk = relay_test_tx(0x02, Vec::new(), None, Some(bad_core), payload.clone()); let mut reject_state = DaRelayState::new(DaRelayCaps::default()).unwrap(); assert_eq!(DaRelayState::validate_relay_da_tx_for_admission(&bad_chunk), Err(ChunkHashMismatch)); assert_eq!(reject_state.stage_relay_da_tx_bytes(peer, bad_chunk), Err(ChunkHashMismatch)); assert!(reject_state.is_empty());
+        let good_tx = relay_test_tx(0x02, Vec::new(), None, Some(relay_chunk_core([7u8; 32], 0, &payload)), payload.clone()); reject_state.stage_relay_da_tx_bytes(peer, good_tx.clone()).unwrap(); assert_eq!(reject_state.test_record_summary([7u8; 32]), Some((false, 1, good_tx.len() as u64))); assert_eq!(reject_state.sets_by_da_id[&[7u8; 32]].chunks[&0].tx_bytes.as_ref(), good_tx.as_slice());
+        let caps = DaRelayCaps { orphan_pool_per_peer_bytes: good_tx.len() as u64 + payload.len() as u64 - 1, ..DaRelayCaps::default() }; let mut cap_state = DaRelayState::new(caps).unwrap(); assert_eq!(cap_state.stage_relay_da_tx_bytes(peer, good_tx), Err(AccountingCapExceeded)); assert!(cap_state.is_empty());
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/da_relay.rs
+++ b/clients/rust/crates/rubin-node/src/da_relay.rs
@@ -411,7 +411,10 @@ impl DaRelayState {
     }
 
     #[rustfmt::skip]
-    pub(crate) fn stage_relay_da_tx_bytes(&mut self, peer_addr: &str, tx_bytes: Vec<u8>) -> DaRelayResult {
+    pub(crate) fn stage_relay_da_tx_bytes(&mut self, peer_addr: &str, tx_bytes: Vec<u8>) -> DaRelayResult { self.stage_relay_da_tx_bytes_checked(peer_addr, tx_bytes, false) }
+
+    #[rustfmt::skip]
+    pub(crate) fn stage_relay_da_tx_bytes_checked(&mut self, peer_addr: &str, tx_bytes: Vec<u8>, chunk_hash_prevalidated: bool) -> DaRelayResult {
         let wire_bytes = u64::try_from(tx_bytes.len()).map_err(|_| DaRelayError::AccountingOverflow)?;
         let (tx, _txid, _wtxid, consumed) = parse_tx(&tx_bytes).map_err(|_| DaRelayError::InvalidWireBytes)?;
         if consumed != tx_bytes.len() {
@@ -441,7 +444,7 @@ impl DaRelayState {
                 let Some(core) = tx.da_chunk_core.as_ref() else {
                     return Ok(());
                 };
-                self.stage_incomplete_da_chunk(
+                self.stage_incomplete_da_chunk_inner(
                     peer_addr,
                     DaRelayChunk {
                         da_id: core.da_id,
@@ -452,6 +455,7 @@ impl DaRelayState {
                         wire_bytes,
                         tx_bytes: Arc::from(tx_bytes.into_boxed_slice()),
                     },
+                    chunk_hash_prevalidated,
                 )
             }
             _ => Ok(()),
@@ -510,18 +514,17 @@ impl DaRelayState {
         record.prune_chunks_outside_commit();
         self.prepare_and_apply_record(record, CompletionMismatchAction::DropMatchingChunks)
     }
-    pub(crate) fn stage_incomplete_da_chunk(
-        &mut self,
-        peer_addr: &str,
-        chunk: DaRelayChunk,
-    ) -> DaRelayResult {
+    #[rustfmt::skip]
+    pub(crate) fn stage_incomplete_da_chunk(&mut self, peer_addr: &str, chunk: DaRelayChunk) -> DaRelayResult { self.stage_incomplete_da_chunk_inner(peer_addr, chunk, false) }
+    #[rustfmt::skip]
+    fn stage_incomplete_da_chunk_inner(&mut self, peer_addr: &str, chunk: DaRelayChunk, chunk_hash_prevalidated: bool) -> DaRelayResult {
         let mut chunk = chunk;
         validate_da_chunk(&chunk)?;
         let current = self.sets_by_da_id.get(&chunk.da_id);
         if let Some(record) = current {
             record.validate_chunk_insert(chunk.chunk_index)?;
         }
-        if sha3_256(chunk.payload.as_ref()) != chunk.chunk_hash {
+        if !chunk_hash_prevalidated && sha3_256(chunk.payload.as_ref()) != chunk.chunk_hash {
             return Err(DaRelayError::ChunkHashMismatch);
         }
         let chunk_index = chunk.chunk_index;

--- a/clients/rust/crates/rubin-node/src/da_relay.rs
+++ b/clients/rust/crates/rubin-node/src/da_relay.rs
@@ -413,10 +413,18 @@ impl DaRelayState {
 
     #[rustfmt::skip]
     pub(crate) fn stage_relay_da_tx_bytes(&mut self, peer_addr: &str, tx_bytes: Vec<u8>) -> DaRelayResult {
-        let wire_bytes =
-            u64::try_from(tx_bytes.len()).map_err(|_| DaRelayError::AccountingOverflow)?;
-        let (tx, _txid, _wtxid, consumed) =
-            parse_tx(&tx_bytes).map_err(|_| DaRelayError::InvalidWireBytes)?;
+        self.stage_relay_da_tx_bytes_inner(peer_addr, tx_bytes, false)
+    }
+
+    #[rustfmt::skip]
+    pub(crate) fn stage_admitted_relay_da_tx_bytes(&mut self, peer_addr: &str, tx_bytes: Vec<u8>) -> DaRelayResult {
+        self.stage_relay_da_tx_bytes_inner(peer_addr, tx_bytes, true)
+    }
+
+    #[rustfmt::skip]
+    fn stage_relay_da_tx_bytes_inner(&mut self, peer_addr: &str, tx_bytes: Vec<u8>, chunk_hash_checked: bool) -> DaRelayResult {
+        let wire_bytes = u64::try_from(tx_bytes.len()).map_err(|_| DaRelayError::AccountingOverflow)?;
+        let (tx, _txid, _wtxid, consumed) = parse_tx(&tx_bytes).map_err(|_| DaRelayError::InvalidWireBytes)?;
         if consumed != tx_bytes.len() {
             return Err(DaRelayError::InvalidWireBytes);
         }
@@ -441,11 +449,10 @@ impl DaRelayState {
                 )
             }
             0x02 => {
-                validate_relay_da_chunk_for_admission(&tx, wire_bytes)?;
                 let Some(core) = tx.da_chunk_core.as_ref() else {
                     return Ok(());
                 };
-                self.stage_incomplete_da_chunk(
+                self.stage_incomplete_da_chunk_inner(
                     peer_addr,
                     DaRelayChunk {
                         da_id: core.da_id,
@@ -456,6 +463,7 @@ impl DaRelayState {
                         wire_bytes,
                         tx_bytes: Arc::from(tx_bytes.into_boxed_slice()),
                     },
+                    chunk_hash_checked,
                 )
             }
             _ => Ok(()),
@@ -517,14 +525,23 @@ impl DaRelayState {
     pub(crate) fn stage_incomplete_da_chunk(
         &mut self,
         peer_addr: &str,
+        chunk: DaRelayChunk,
+    ) -> DaRelayResult {
+        self.stage_incomplete_da_chunk_inner(peer_addr, chunk, false)
+    }
+
+    fn stage_incomplete_da_chunk_inner(
+        &mut self,
+        peer_addr: &str,
         mut chunk: DaRelayChunk,
+        hash_checked: bool,
     ) -> DaRelayResult {
         validate_da_chunk(&chunk)?;
         let current = self.sets_by_da_id.get(&chunk.da_id);
         if let Some(record) = current {
             record.validate_chunk_insert(chunk.chunk_index)?;
         }
-        if sha3_256(chunk.payload.as_ref()) != chunk.chunk_hash {
+        if !hash_checked && sha3_256(chunk.payload.as_ref()) != chunk.chunk_hash {
             return Err(DaRelayError::ChunkHashMismatch);
         }
         let chunk_index = chunk.chunk_index;
@@ -849,10 +866,13 @@ mod tests {
     #[test]
     #[rustfmt::skip]
     fn stage_relay_da_tx_bytes_contract_matrix() {
-        let peer = "peer-a:8333"; let mut state = DaRelayState::new(DaRelayCaps::default()).unwrap(); let non_da = relay_test_tx(0x00, Vec::new(), None, None, Vec::new()); state.stage_relay_da_tx_bytes(peer, non_da).unwrap(); assert!(state.is_empty());
+        let peer = "peer-a:8333"; let mut state = DaRelayState::new(DaRelayCaps::default()).unwrap(); let non_da = relay_test_tx(0x00, Vec::new(), None, None, Vec::new()); state.stage_relay_da_tx_bytes(peer, non_da.clone()).unwrap(); let (non_da_tx, _, _, _) = parse_tx(&non_da).unwrap(); assert_eq!(validate_relay_da_chunk_for_admission(&non_da_tx, non_da.len() as u64), Ok(())); assert!(state.is_empty());
+        let bad_commit_output = rubin_consensus::TxOutput { value: 0, covenant_type: rubin_consensus::constants::COV_TYPE_DA_COMMIT, covenant_data: vec![4u8; 31] }; let bad_commit = relay_test_tx(0x01, vec![bad_commit_output], Some(relay_commit_core([4u8; 32], 1)), None, Vec::new()); state.stage_relay_da_tx_bytes(peer, bad_commit).unwrap(); assert!(state.is_empty());
         let da_id = [1u8; 32]; let commitment = [2u8; 32]; let commit_tx = relay_test_tx(0x01, vec![da_commit_output(commitment)], Some(relay_commit_core(da_id, 1)), None, Vec::new()); state.stage_relay_da_tx_bytes(peer, commit_tx.clone()).unwrap(); let commit = state.sets_by_da_id[&da_id].commit.as_ref().unwrap(); assert_eq!(commit.payload_commitment, commitment); assert_eq!(commit.tx_bytes.as_ref(), commit_tx.as_slice());
         let payload = b"relay chunk".to_vec(); let mut bad_core = relay_chunk_core([6u8; 32], 0, &payload); bad_core.chunk_hash = [7u8; 32]; let bad_chunk = relay_test_tx(0x02, Vec::new(), None, Some(bad_core), payload.clone()); let mut reject_state = DaRelayState::new(DaRelayCaps::default()).unwrap(); assert_eq!(DaRelayState::validate_relay_da_tx_for_admission(&bad_chunk), Err(ChunkHashMismatch)); assert_eq!(reject_state.stage_relay_da_tx_bytes(peer, bad_chunk), Err(ChunkHashMismatch)); assert!(reject_state.is_empty());
+        let mut trailing_chunk = relay_test_tx(0x02, Vec::new(), None, Some(relay_chunk_core([8u8; 32], 0, &payload)), payload.clone()); trailing_chunk.push(0); assert_eq!(DaRelayState::validate_relay_da_tx_for_admission(&trailing_chunk), Err(InvalidWireBytes)); assert_eq!(reject_state.stage_relay_da_tx_bytes(peer, trailing_chunk), Err(InvalidWireBytes)); assert!(reject_state.is_empty());
         let good_tx = relay_test_tx(0x02, Vec::new(), None, Some(relay_chunk_core([7u8; 32], 0, &payload)), payload.clone()); reject_state.stage_relay_da_tx_bytes(peer, good_tx.clone()).unwrap(); assert_eq!(reject_state.test_record_summary([7u8; 32]), Some((false, 1, good_tx.len() as u64))); assert_eq!(reject_state.sets_by_da_id[&[7u8; 32]].chunks[&0].tx_bytes.as_ref(), good_tx.as_slice());
+        let (good_chunk_tx, _, _, _) = parse_tx(&good_tx).unwrap(); let mut edge_tx = good_chunk_tx.clone(); edge_tx.da_chunk_core.as_mut().unwrap().chunk_index = MAX_DA_CHUNK_COUNT as u16; assert_eq!(validate_relay_da_chunk_for_admission(&edge_tx, good_tx.len() as u64), Err(ChunkIndexOutOfRange)); edge_tx.da_chunk_core.as_mut().unwrap().chunk_index = 0; edge_tx.da_payload.clear(); assert_eq!(validate_relay_da_chunk_for_admission(&edge_tx, good_tx.len() as u64), Err(ChunkPayloadSizeInvalid)); edge_tx.da_payload = payload.clone(); assert_eq!(validate_relay_da_chunk_for_admission(&edge_tx, 0), Err(InvalidWireBytes));
         let caps = DaRelayCaps { orphan_pool_per_peer_bytes: good_tx.len() as u64 + payload.len() as u64 - 1, ..DaRelayCaps::default() }; let mut cap_state = DaRelayState::new(caps).unwrap(); assert_eq!(cap_state.stage_relay_da_tx_bytes(peer, good_tx), Err(AccountingCapExceeded)); assert!(cap_state.is_empty());
     }
 

--- a/clients/rust/crates/rubin-node/src/da_relay.rs
+++ b/clients/rust/crates/rubin-node/src/da_relay.rs
@@ -3,9 +3,8 @@ use std::collections::BTreeSet;
 use std::net::{IpAddr, Ipv6Addr};
 use std::sync::Arc;
 
-use rubin_consensus::constants::{
-    CHUNK_BYTES, COV_TYPE_DA_COMMIT, MAX_DA_CHUNK_COUNT, TX_WIRE_VERSION,
-};
+use rubin_consensus::constants::{CHUNK_BYTES, MAX_DA_CHUNK_COUNT};
+use rubin_consensus::constants::{COV_TYPE_DA_COMMIT, TX_WIRE_VERSION};
 use rubin_consensus::{parse_tx, Tx};
 use sha3::{Digest, Sha3_256};
 
@@ -413,16 +412,6 @@ impl DaRelayState {
 
     #[rustfmt::skip]
     pub(crate) fn stage_relay_da_tx_bytes(&mut self, peer_addr: &str, tx_bytes: Vec<u8>) -> DaRelayResult {
-        self.stage_relay_da_tx_bytes_inner(peer_addr, tx_bytes, false)
-    }
-
-    #[rustfmt::skip]
-    pub(crate) fn stage_admitted_relay_da_tx_bytes(&mut self, peer_addr: &str, tx_bytes: Vec<u8>) -> DaRelayResult {
-        self.stage_relay_da_tx_bytes_inner(peer_addr, tx_bytes, true)
-    }
-
-    #[rustfmt::skip]
-    fn stage_relay_da_tx_bytes_inner(&mut self, peer_addr: &str, tx_bytes: Vec<u8>, chunk_hash_checked: bool) -> DaRelayResult {
         let wire_bytes = u64::try_from(tx_bytes.len()).map_err(|_| DaRelayError::AccountingOverflow)?;
         let (tx, _txid, _wtxid, consumed) = parse_tx(&tx_bytes).map_err(|_| DaRelayError::InvalidWireBytes)?;
         if consumed != tx_bytes.len() {
@@ -452,7 +441,7 @@ impl DaRelayState {
                 let Some(core) = tx.da_chunk_core.as_ref() else {
                     return Ok(());
                 };
-                self.stage_incomplete_da_chunk_inner(
+                self.stage_incomplete_da_chunk(
                     peer_addr,
                     DaRelayChunk {
                         da_id: core.da_id,
@@ -463,7 +452,6 @@ impl DaRelayState {
                         wire_bytes,
                         tx_bytes: Arc::from(tx_bytes.into_boxed_slice()),
                     },
-                    chunk_hash_checked,
                 )
             }
             _ => Ok(()),
@@ -527,21 +515,13 @@ impl DaRelayState {
         peer_addr: &str,
         chunk: DaRelayChunk,
     ) -> DaRelayResult {
-        self.stage_incomplete_da_chunk_inner(peer_addr, chunk, false)
-    }
-
-    fn stage_incomplete_da_chunk_inner(
-        &mut self,
-        peer_addr: &str,
-        mut chunk: DaRelayChunk,
-        hash_checked: bool,
-    ) -> DaRelayResult {
+        let mut chunk = chunk;
         validate_da_chunk(&chunk)?;
         let current = self.sets_by_da_id.get(&chunk.da_id);
         if let Some(record) = current {
             record.validate_chunk_insert(chunk.chunk_index)?;
         }
-        if !hash_checked && sha3_256(chunk.payload.as_ref()) != chunk.chunk_hash {
+        if sha3_256(chunk.payload.as_ref()) != chunk.chunk_hash {
             return Err(DaRelayError::ChunkHashMismatch);
         }
         let chunk_index = chunk.chunk_index;

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -228,7 +228,28 @@ pub struct PeerRelayContext<'a> {
     pub da_relay: &'a std::sync::Mutex<crate::da_relay::DaRelayState>,
 }
 
-pub(crate) type PendingDaRelayStaging = (String, Vec<u8>, bool);
+pub(crate) type PendingDaRelayStaging = (String, Vec<u8>);
+
+fn should_skip_relay_da_admission_precheck(
+    tx_bytes: &[u8],
+    relay_state: &crate::tx_relay::TxRelayState,
+    tx_pool: &Mutex<crate::txpool::TxPool>,
+) -> bool {
+    if crate::da_relay::relay_da_tx_kind_prefix(tx_bytes) != Some(0x02) {
+        return false;
+    }
+    let Ok(txid) = crate::tx_relay::canonical_txid(tx_bytes) else {
+        return false;
+    };
+    if !relay_state.tx_seen.has(&txid) {
+        return false;
+    }
+    let Ok(pool) = tx_pool.lock() else {
+        return false;
+    };
+    pool.tx_by_id(&txid)
+        .is_some_and(|admitted_tx| admitted_tx == tx_bytes)
+}
 
 #[derive(Debug, Default)]
 pub struct LiveMessageOutcome {
@@ -442,8 +463,8 @@ impl PeerSession {
     }
 
     #[rustfmt::skip]
-    fn stash_pending_da_relay_staging(&mut self, peer_addr: &str, tx_bytes: Vec<u8>, hash_checked: bool) {
-        self.pending_da_relay_staging = Some((peer_addr.to_string(), tx_bytes, hash_checked));
+    fn stash_pending_da_relay_staging(&mut self, peer_addr: &str, tx_bytes: Vec<u8>) {
+        self.pending_da_relay_staging = Some((peer_addr.to_string(), tx_bytes));
     }
 
     pub(crate) fn apply_pending_da_relay_staging(
@@ -451,19 +472,14 @@ impl PeerSession {
         da_relay: &std::sync::Mutex<crate::da_relay::DaRelayState>,
         pending: Option<PendingDaRelayStaging>,
     ) {
-        let Some((peer_addr, tx_bytes, hash_checked)) = pending else {
+        let Some((peer_addr, tx_bytes)) = pending else {
             return;
         };
         let Ok(mut da_relay) = da_relay.lock() else {
             self.peer.last_error = "da relay state poisoned; peer-tx staging skipped".to_string();
             return;
         };
-        let result = if hash_checked {
-            da_relay.stage_admitted_relay_da_tx_bytes(&peer_addr, tx_bytes)
-        } else {
-            da_relay.stage_relay_da_tx_bytes(&peer_addr, tx_bytes)
-        };
-        if let Err(err) = result {
+        if let Err(err) = da_relay.stage_relay_da_tx_bytes(&peer_addr, tx_bytes) {
             self.peer.last_error = format!("DA relay tx staging failed: {err:?}");
         }
     }
@@ -746,20 +762,27 @@ impl PeerSession {
             MESSAGE_BLOCKTXN => self.handle_blocktxn(&msg.payload, sync_engine),
             MESSAGE_TX => {
                 if let Some(ctx) = relay_ctx {
-                    if let Err(err) =
-                        crate::da_relay::DaRelayState::validate_relay_da_tx_for_admission(
-                            &msg.payload,
-                        )
-                    {
-                        let reason = format!("DA relay tx admission validation failed: {err:?}");
-                        self.bump_ban(10, &reason);
-                        if self.peer.ban_score >= self.cfg.ban_threshold {
-                            return Err(io::Error::new(io::ErrorKind::InvalidData, reason));
+                    if !should_skip_relay_da_admission_precheck(
+                        &msg.payload,
+                        ctx.relay_state,
+                        ctx.tx_pool,
+                    ) {
+                        if let Err(err) =
+                            crate::da_relay::DaRelayState::validate_relay_da_tx_for_admission(
+                                &msg.payload,
+                            )
+                        {
+                            let reason =
+                                format!("DA relay tx admission validation failed: {err:?}");
+                            self.bump_ban(10, &reason);
+                            if self.peer.ban_score >= self.cfg.ban_threshold {
+                                return Err(io::Error::new(io::ErrorKind::InvalidData, reason));
+                            }
+                            return Ok(LiveMessageOutcome {
+                                responses: Vec::new(),
+                                tx_pool_cleanup: TxPoolCleanupPlan::default(),
+                            });
                         }
-                        return Ok(LiveMessageOutcome {
-                            responses: Vec::new(),
-                            tx_pool_cleanup: TxPoolCleanupPlan::default(),
-                        });
                     }
                     let outcome = crate::tx_relay::handle_received_tx(
                         &msg.payload,
@@ -770,84 +793,8 @@ impl PeerSession {
                         ctx.local_addr,
                         ctx.peer_writers,
                     )?;
-                    // RUB-173 / GitHub #1420: canonical TxPool admission
-                    // seam with source-aware classification. Peer-relayed
-                    // transactions admit via
-                    // `add_tx_with_source(..., TxSource::Remote, ...)`,
-                    // matching Go's `Mempool.AddRemoteTx`
-                    // (`clients/go/node/mempool.go:416`). Go's p2p
-                    // production path reaches `AddRemoteTx` indirectly:
-                    // `handlers_tx.go::handleTx` calls
-                    // `cfg.TxPool.Put` (the `TxPool` interface), which
-                    // production wiring
-                    // (`clients/go/cmd/rubin-node/main.go:489`,
-                    // `NewCanonicalMempoolTxPool(mempool)`) routes
-                    // through `CanonicalMempoolTxPool.Put`
-                    // (`clients/go/node/p2p/mempool.go:45-54`); line 53
-                    // is `p.mempool.AddRemoteTx(raw)`.
-                    //
-                    // Only fires after `handle_received_tx` returns
-                    // `RelayTxOutcome::Relayed`, which means the peer tx
-                    // already passed parse, dedup, and `relay_metadata`
-                    // (rolling fee floor). Source is recorded on
-                    // `TxPoolEntry.source` for observability and
-                    // downstream filtering; per `add_tx_with_source` doc,
-                    // source does NOT affect validation, admission
-                    // ordering, or capacity-eviction priority — admission
-                    // is source-blind, only provenance differs.
-                    //
-                    // RUB-178 / GitHub #1438 introduced this seam first
-                    // using the legacy `pool.admit(...)` entrypoint
-                    // (which records `TxSource::Local`) as an explicit
-                    // Class C lifecycle prerequisite; this slice (RUB-173)
-                    // is the Class B replacement that flips source
-                    // classification to `Remote`. The production-path
-                    // test below pins
-                    // `pool.entry_source(&txid) == Some(TxSource::Remote)`
-                    // as the Go/Rust source-provenance parity anchor.
-                    //
-                    // Admission Result is intentionally discarded — it
-                    // does NOT change `RelayTxOutcome` and does NOT
-                    // contribute to ban-score policy (per RUB-178 issue's
-                    // failure_modes: "preserve existing txpool caller
-                    // error class; no new policy ordering"). The
-                    // relay-cache leg has already accepted the tx, and
-                    // the seam's invariant is now "seam admits with
-                    // Remote source", not "every peer tx admits". Future
-                    // divergence observability is a separate change.
-                    //
-                    // Lock poisoning is a separate concern from admission
-                    // failure: a poisoned `tx_pool` Mutex means a prior
-                    // panic mid-mutation leaves the pool's internal
-                    // invariants potentially broken. Per existing
-                    // production precedent in
-                    // `clients/rust/crates/rubin-node/src/devnet_rpc.rs`'s
-                    // `handle_submit_tx` (which surfaces
-                    // `TxPoolAdmitErrorKind::Unavailable` on poisoned
-                    // lock) and `handle_mine_next` (which returns 503),
-                    // poison must be observable rather than silently
-                    // swallowed. The seam therefore matches the lock
-                    // result explicitly: on `Err(_)` it records an
-                    // explicit signal on `self.peer.last_error` so the
-                    // condition is not silent, while still preserving
-                    // the relay-only path (no `Err(...)` is returned
-                    // from `collect_live_responses`).
-                    //
-                    // Lock-ordering precedent: this is engine→pool nested.
-                    // The caller in
-                    // `clients/rust/crates/rubin-node/src/p2p_service.rs`
-                    // (`handle_peer`) holds
-                    // `shared.sync_engine.lock()` while calling
-                    // `collect_live_responses`, so the seam acquires
-                    // `ctx.tx_pool.lock()` while engine remains held; both
-                    // are dropped at the end of the caller's scope. This
-                    // matches the engine→pool nested ordering used by
-                    // `clients/rust/crates/rubin-node/src/devnet_rpc.rs`'s
-                    // `handle_mine_next`, NOT the engine-snapshot-then-drop
-                    // pattern in `apply_tx_pool_cleanup`. The seam does
-                    // not re-acquire the engine, so no deadlock from self.
-                    // DA relay staging is only stashed here; the service
-                    // loop applies it after releasing the engine lock.
+                    // Stash DA relay staging here; the service loop applies it
+                    // after releasing the sync engine lock.
                     use crate::tx_relay::RelayTxOutcome::{DuplicateSeen, Relayed};
                     let relay_da_tx = matches!(
                         crate::da_relay::relay_da_tx_kind_prefix(&msg.payload),
@@ -880,12 +827,8 @@ impl PeerSession {
                         }
                         if relay_da_tx {
                             if let Some(tx_bytes) = admitted_tx {
-                                let hash_checked = tx_bytes == msg.payload;
-                                self.stash_pending_da_relay_staging(
-                                    ctx.peer_registered_addr,
-                                    tx_bytes,
-                                    hash_checked,
-                                );
+                                #[rustfmt::skip]
+                                self.stash_pending_da_relay_staging(ctx.peer_registered_addr, tx_bytes);
                             }
                         }
                     }
@@ -6208,7 +6151,8 @@ mod tests {
             canonical_tx_pool.lock().unwrap().add_tx_with_source(&admitted_tx, &engine.chain_state, engine.block_store.as_ref(), engine.cfg.chain_id, crate::txpool::TxSource::Local).expect("pre-admit DA tx"); assert!(relay_state.tx_seen.add(txid)); session.collect_live_responses(WireMessage { command: MESSAGE_TX.to_string(), payload: admitted_tx.clone() }, &mut engine, Some(&relay_ctx)).expect("already-seen DA tx dispatch"); assert_eq!(canonical_tx_pool.lock().unwrap().entry_source(&txid), Some(crate::txpool::TxSource::Local)); assert_eq!(da_relay.lock().unwrap().test_record_summary(da_id), None); let pending_da_staging = session.take_pending_da_relay_staging(); assert!(pending_da_staging.is_some()); session.apply_pending_da_relay_staging(&da_relay, pending_da_staging); assert_eq!(da_relay.lock().unwrap().test_record_summary(da_id), Some((false, 1, admitted_tx.len() as u64)));
             let (mut bad_seen_tx, _, _, _) = parse_tx(&admitted_tx).expect("parse already-seen DA tx"); bad_seen_tx.da_payload = b"bad already-seen da chunk".to_vec(); let bad_seen_bytes = rubin_consensus::marshal_tx(&bad_seen_tx).expect("marshal bad already-seen DA tx"); assert_eq!(parse_tx(&bad_seen_bytes).unwrap().1, txid); session.collect_live_responses(WireMessage { command: MESSAGE_TX.to_string(), payload: bad_seen_bytes }, &mut engine, Some(&relay_ctx)).expect("already-seen bad DA chunk is sub-threshold peer-neutral"); assert_eq!(session.state().ban_score, 20); assert_eq!(canonical_tx_pool.lock().unwrap().tx_by_id(&txid), Some(admitted_tx.clone())); assert!(session.take_pending_da_relay_staging().is_none()); assert_eq!(da_relay.lock().unwrap().test_record_summary(da_id), Some((false, 1, admitted_tx.len() as u64)));
             let (_, conflicting_txid, _, _) = parse_tx(&conflicting_tx).expect("parse conflicting DA tx");
-            let (mut bad_pool_tx, _, _, _) = parse_tx(&conflicting_tx).expect("parse bad-pool DA tx"); bad_pool_tx.da_payload = b"bad pool-resident da chunk".to_vec(); let bad_pool_bytes = rubin_consensus::marshal_tx(&bad_pool_tx).expect("marshal bad-pool DA tx"); assert_eq!(parse_tx(&bad_pool_bytes).unwrap().1, conflicting_txid); canonical_tx_pool.lock().unwrap().inject_test_entry(conflicting_txid, bad_pool_bytes); assert!(relay_state.tx_seen.add(conflicting_txid)); session.collect_live_responses(WireMessage { command: MESSAGE_TX.to_string(), payload: conflicting_tx }, &mut engine, Some(&relay_ctx)).expect("valid peer variant does not bless bad pool bytes"); let pending_bad_pool = session.take_pending_da_relay_staging(); assert!(pending_bad_pool.is_some()); session.apply_pending_da_relay_staging(&da_relay, pending_bad_pool); assert_eq!(da_relay.lock().unwrap().test_record_summary(conflict_da_id), None);
+            let (mut bad_pool_tx, _, _, _) = parse_tx(&conflicting_tx).expect("parse bad-pool DA tx"); bad_pool_tx.da_payload = b"bad pool-resident da chunk".to_vec(); let bad_pool_bytes = rubin_consensus::marshal_tx(&bad_pool_tx).expect("marshal bad-pool DA tx"); assert_eq!(parse_tx(&bad_pool_bytes).unwrap().1, conflicting_txid); let local_relay_state = crate::tx_relay::TxRelayState::new(); let local_peer_outboxes: Mutex<HashMap<String, crate::tx_relay::PeerOutbox>> = Mutex::new(HashMap::new()); assert!(crate::tx_relay::announce_tx(&bad_pool_bytes, crate::txpool::RelayTxMetadata { fee: 1, size: bad_pool_bytes.len() }, &local_relay_state, &peer_manager, "local:8333", &local_peer_outboxes).is_err()); assert!(!local_relay_state.tx_seen.has(&conflicting_txid)); canonical_tx_pool.lock().unwrap().inject_test_entry(conflicting_txid, bad_pool_bytes.clone()); assert!(relay_state.tx_seen.add(conflicting_txid)); session.collect_live_responses(WireMessage { command: MESSAGE_TX.to_string(), payload: bad_pool_bytes }, &mut engine, Some(&relay_ctx)).expect("same bad pool bytes skip precheck but not staging hash check"); let pending_same_bad_pool = session.take_pending_da_relay_staging(); assert!(pending_same_bad_pool.is_some()); session.apply_pending_da_relay_staging(&da_relay, pending_same_bad_pool); assert_eq!(da_relay.lock().unwrap().test_record_summary(conflict_da_id), None);
+            session.collect_live_responses(WireMessage { command: MESSAGE_TX.to_string(), payload: conflicting_tx }, &mut engine, Some(&relay_ctx)).expect("valid peer variant does not bless bad pool bytes"); let pending_bad_pool = session.take_pending_da_relay_staging(); assert!(pending_bad_pool.is_some()); session.apply_pending_da_relay_staging(&da_relay, pending_bad_pool); assert_eq!(da_relay.lock().unwrap().test_record_summary(conflict_da_id), None);
         });
         let _client = TcpStream::connect(addr).expect("connect"); server.join().expect("server join");
     }

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -853,18 +853,18 @@ impl PeerSession {
                         crate::da_relay::relay_da_tx_kind_prefix(&msg.payload),
                         Some(0x01 | 0x02)
                     );
-                    if matches!(outcome, Relayed { .. })
-                        || (relay_da_tx && matches!(outcome, DuplicateSeen { .. }))
+                    if matches!(&outcome, Relayed { .. })
+                        || (relay_da_tx && matches!(&outcome, DuplicateSeen { .. }))
                     {
                         let mut admitted_tx = None;
                         match ctx.tx_pool.lock() {
                             Ok(mut pool) => {
                                 if relay_da_tx {
-                                    if let Relayed { txid } | DuplicateSeen { txid } = outcome {
-                                        admitted_tx = pool.tx_by_id(&txid);
+                                    if let Relayed { txid } | DuplicateSeen { txid } = &outcome {
+                                        admitted_tx = pool.tx_by_id(txid);
                                     }
                                 }
-                                if admitted_tx.is_none() && matches!(outcome, Relayed { .. }) {
+                                if admitted_tx.is_none() && matches!(&outcome, Relayed { .. }) {
                                     #[rustfmt::skip]
                                     let add_remote = pool.add_tx_with_source(&msg.payload, &sync_engine.chain_state, sync_engine.block_store.as_ref(), sync_engine.cfg.chain_id, crate::txpool::TxSource::Remote).ok().and_then(|(txid, _meta)| pool.tx_by_id(&txid));
                                     if relay_da_tx {

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -228,6 +228,8 @@ pub struct PeerRelayContext<'a> {
     pub da_relay: &'a std::sync::Mutex<crate::da_relay::DaRelayState>,
 }
 
+pub(crate) type PendingDaRelayStaging = (String, Vec<u8>, bool);
+
 #[derive(Debug, Default)]
 pub struct LiveMessageOutcome {
     pub responses: Vec<WireMessage>,
@@ -287,6 +289,7 @@ pub struct PeerSession {
     peer: PeerState,
     orphans: OrphanBlockPool,
     pending_tx_pool_cleanup: TxPoolCleanupPlan,
+    pending_da_relay_staging: Option<PendingDaRelayStaging>,
     prefetched_read_byte: Option<u8>,
     remote_compact_mode: CompactModeSnapshot,
     compact_outstanding: Option<CompactOutstandingRequest>,
@@ -409,6 +412,7 @@ impl PeerSession {
             },
             orphans: OrphanBlockPool::new(DEFAULT_ORPHAN_LIMIT, DEFAULT_ORPHAN_BYTE_LIMIT),
             pending_tx_pool_cleanup: TxPoolCleanupPlan::default(),
+            pending_da_relay_staging: None,
             prefetched_read_byte: None,
             remote_compact_mode: CompactModeSnapshot::default(),
             compact_outstanding: None,
@@ -425,12 +429,43 @@ impl PeerSession {
         std::mem::take(&mut self.pending_tx_pool_cleanup)
     }
 
+    pub(crate) fn take_pending_da_relay_staging(&mut self) -> Option<PendingDaRelayStaging> {
+        self.pending_da_relay_staging.take()
+    }
+
     fn stash_pending_tx_pool_cleanup(&mut self, cleanup: TxPoolCleanupPlan) {
         if cleanup.is_empty() {
             return;
         }
         let pending = self.take_pending_tx_pool_cleanup();
         self.pending_tx_pool_cleanup = pending.merge(cleanup);
+    }
+
+    #[rustfmt::skip]
+    fn stash_pending_da_relay_staging(&mut self, peer_addr: &str, tx_bytes: Vec<u8>, hash_checked: bool) {
+        self.pending_da_relay_staging = Some((peer_addr.to_string(), tx_bytes, hash_checked));
+    }
+
+    pub(crate) fn apply_pending_da_relay_staging(
+        &mut self,
+        da_relay: &std::sync::Mutex<crate::da_relay::DaRelayState>,
+        pending: Option<PendingDaRelayStaging>,
+    ) {
+        let Some((peer_addr, tx_bytes, hash_checked)) = pending else {
+            return;
+        };
+        let Ok(mut da_relay) = da_relay.lock() else {
+            self.peer.last_error = "da relay state poisoned; peer-tx staging skipped".to_string();
+            return;
+        };
+        let result = if hash_checked {
+            da_relay.stage_admitted_relay_da_tx_bytes(&peer_addr, tx_bytes)
+        } else {
+            da_relay.stage_relay_da_tx_bytes(&peer_addr, tx_bytes)
+        };
+        if let Err(err) = result {
+            self.peer.last_error = format!("DA relay tx staging failed: {err:?}");
+        }
     }
 
     pub fn read_message(&mut self) -> io::Result<WireMessage> {
@@ -811,15 +846,19 @@ impl PeerSession {
                     // `handle_mine_next`, NOT the engine-snapshot-then-drop
                     // pattern in `apply_tx_pool_cleanup`. The seam does
                     // not re-acquire the engine, so no deadlock from self.
+                    // DA relay staging is only stashed here; the service
+                    // loop applies it after releasing the engine lock.
                     use crate::tx_relay::RelayTxOutcome::{DuplicateSeen, Relayed};
-                    let relayed = matches!(outcome, Relayed);
-                    if relayed || matches!(outcome, DuplicateSeen) {
-                        #[rustfmt::skip]
-                        let relay_txid = parse_tx(&msg.payload).ok().and_then(|(_, txid, _, consumed)| (consumed == msg.payload.len()).then_some(txid));
+                    let relayed = matches!(outcome, Relayed { .. });
+                    let relay_txid = match &outcome {
+                        Relayed { txid } | DuplicateSeen { txid } => Some(*txid),
+                        _ => None,
+                    };
+                    if let Some(relay_txid) = relay_txid {
                         let mut admitted_tx = None;
                         match ctx.tx_pool.lock() {
                             Ok(mut pool) => {
-                                let existing_tx = relay_txid.and_then(|txid| pool.tx_by_id(&txid));
+                                let existing_tx = pool.tx_by_id(&relay_txid);
                                 admitted_tx = existing_tx;
                                 if admitted_tx.is_none() && relayed {
                                     #[rustfmt::skip]
@@ -834,21 +873,12 @@ impl PeerSession {
                             }
                         }
                         if let Some(tx_bytes) = admitted_tx {
-                            match ctx.da_relay.lock() {
-                                Ok(mut da_relay) => {
-                                    if let Err(err) = da_relay
-                                        .stage_relay_da_tx_bytes(ctx.peer_registered_addr, tx_bytes)
-                                    {
-                                        self.peer.last_error =
-                                            format!("DA relay tx staging failed: {err:?}");
-                                    }
-                                }
-                                Err(_) => {
-                                    self.peer.last_error =
-                                        "da relay state poisoned; peer-tx staging skipped"
-                                            .to_string();
-                                }
-                            }
+                            let hash_checked = tx_bytes == msg.payload;
+                            self.stash_pending_da_relay_staging(
+                                ctx.peer_registered_addr,
+                                tx_bytes,
+                                hash_checked,
+                            );
                         }
                     }
                     // Mirror Go's `peer.handleTx` parse-fail policy: parse
@@ -927,6 +957,10 @@ impl PeerSession {
         relay_ctx: Option<&PeerRelayContext<'_>>,
     ) -> io::Result<TxPoolCleanupPlan> {
         let outcome = self.collect_live_responses(msg, sync_engine, relay_ctx)?;
+        let pending_da_relay_staging = self.take_pending_da_relay_staging();
+        if let Some(ctx) = relay_ctx {
+            self.apply_pending_da_relay_staging(ctx.da_relay, pending_da_relay_staging);
+        }
         for response in outcome.responses {
             self.write_message(&response)?;
         }
@@ -6157,11 +6191,12 @@ mod tests {
             let mut engine = crate::sync::SyncEngine::new(chain_state, None, sync_cfg).expect("sync engine"); let relay_state = crate::tx_relay::TxRelayState::new(); let peer_manager = PeerManager::new(default_peer_runtime_config("devnet", 64)); let peer_outboxes: Mutex<HashMap<String, crate::tx_relay::PeerOutbox>> = Mutex::new(HashMap::new()); let canonical_tx_pool = Mutex::new(TxPool::new()); let da_relay = Mutex::new(crate::da_relay::DaRelayState::new(crate::da_relay::DaRelayCaps::default()).expect("valid DA relay caps"));
             let relay_ctx = PeerRelayContext { relay_state: &relay_state, peer_manager: &peer_manager, local_addr: "local:8333", peer_registered_addr: "sender:8333", peer_writers: &peer_outboxes, tx_pool: &canonical_tx_pool, da_relay: &da_relay };
             let (_, bad_txid, _, _) = parse_tx(&bad_tx).expect("parse bad DA tx");
-            session.collect_live_responses(WireMessage { command: MESSAGE_TX.to_string(), payload: bad_tx }, &mut engine, Some(&relay_ctx)).expect("sub-threshold malformed DA tx is peer-neutral"); assert_eq!(session.state().ban_score, 10); assert!(!relay_state.tx_seen.has(&bad_txid)); assert_eq!(da_relay.lock().unwrap().test_record_summary(bad_da_id), None);
+            session.collect_live_responses(WireMessage { command: MESSAGE_TX.to_string(), payload: bad_tx }, &mut engine, Some(&relay_ctx)).expect("sub-threshold malformed DA tx is peer-neutral"); assert_eq!(session.state().ban_score, 10); assert!(!relay_state.tx_seen.has(&bad_txid)); assert!(session.take_pending_da_relay_staging().is_none()); assert_eq!(da_relay.lock().unwrap().test_record_summary(bad_da_id), None);
             let (_, txid, _, _) = parse_tx(&admitted_tx).expect("parse admitted DA tx");
-            canonical_tx_pool.lock().unwrap().add_tx_with_source(&admitted_tx, &engine.chain_state, engine.block_store.as_ref(), engine.cfg.chain_id, crate::txpool::TxSource::Local).expect("pre-admit DA tx"); assert!(relay_state.tx_seen.add(txid)); session.collect_live_responses(WireMessage { command: MESSAGE_TX.to_string(), payload: admitted_tx.clone() }, &mut engine, Some(&relay_ctx)).expect("already-seen DA tx dispatch"); assert_eq!(canonical_tx_pool.lock().unwrap().entry_source(&txid), Some(crate::txpool::TxSource::Local)); assert_eq!(da_relay.lock().unwrap().test_record_summary(da_id), Some((false, 1, admitted_tx.len() as u64)));
+            canonical_tx_pool.lock().unwrap().add_tx_with_source(&admitted_tx, &engine.chain_state, engine.block_store.as_ref(), engine.cfg.chain_id, crate::txpool::TxSource::Local).expect("pre-admit DA tx"); assert!(relay_state.tx_seen.add(txid)); session.collect_live_responses(WireMessage { command: MESSAGE_TX.to_string(), payload: admitted_tx.clone() }, &mut engine, Some(&relay_ctx)).expect("already-seen DA tx dispatch"); assert_eq!(canonical_tx_pool.lock().unwrap().entry_source(&txid), Some(crate::txpool::TxSource::Local)); assert_eq!(da_relay.lock().unwrap().test_record_summary(da_id), None); let pending_da_staging = session.take_pending_da_relay_staging(); assert!(pending_da_staging.is_some()); session.apply_pending_da_relay_staging(&da_relay, pending_da_staging); assert_eq!(da_relay.lock().unwrap().test_record_summary(da_id), Some((false, 1, admitted_tx.len() as u64)));
+            let (mut bad_seen_tx, _, _, _) = parse_tx(&admitted_tx).expect("parse already-seen DA tx"); bad_seen_tx.da_payload = b"bad already-seen da chunk".to_vec(); let bad_seen_bytes = rubin_consensus::marshal_tx(&bad_seen_tx).expect("marshal bad already-seen DA tx"); assert_eq!(parse_tx(&bad_seen_bytes).unwrap().1, txid); session.collect_live_responses(WireMessage { command: MESSAGE_TX.to_string(), payload: bad_seen_bytes }, &mut engine, Some(&relay_ctx)).expect("already-seen bad DA chunk is sub-threshold peer-neutral"); assert_eq!(session.state().ban_score, 20); assert_eq!(canonical_tx_pool.lock().unwrap().tx_by_id(&txid), Some(admitted_tx.clone())); assert!(session.take_pending_da_relay_staging().is_none()); assert_eq!(da_relay.lock().unwrap().test_record_summary(da_id), Some((false, 1, admitted_tx.len() as u64)));
             let (_, conflicting_txid, _, _) = parse_tx(&conflicting_tx).expect("parse conflicting DA tx");
-            session.collect_live_responses(WireMessage { command: MESSAGE_TX.to_string(), payload: conflicting_tx }, &mut engine, Some(&relay_ctx)).expect("txpool-rejected DA tx preserves relay outcome"); assert!(relay_state.tx_seen.has(&conflicting_txid)); assert_eq!(da_relay.lock().unwrap().test_record_summary(conflict_da_id), None);
+            let (mut bad_pool_tx, _, _, _) = parse_tx(&conflicting_tx).expect("parse bad-pool DA tx"); bad_pool_tx.da_payload = b"bad pool-resident da chunk".to_vec(); let bad_pool_bytes = rubin_consensus::marshal_tx(&bad_pool_tx).expect("marshal bad-pool DA tx"); assert_eq!(parse_tx(&bad_pool_bytes).unwrap().1, conflicting_txid); canonical_tx_pool.lock().unwrap().inject_test_entry(conflicting_txid, bad_pool_bytes); assert!(relay_state.tx_seen.add(conflicting_txid)); session.collect_live_responses(WireMessage { command: MESSAGE_TX.to_string(), payload: conflicting_tx }, &mut engine, Some(&relay_ctx)).expect("valid peer variant does not bless bad pool bytes"); let pending_bad_pool = session.take_pending_da_relay_staging(); assert!(pending_bad_pool.is_some()); session.apply_pending_da_relay_staging(&da_relay, pending_bad_pool); assert_eq!(da_relay.lock().unwrap().test_record_summary(conflict_da_id), None);
         });
         let _client = TcpStream::connect(addr).expect("connect"); server.join().expect("server join");
     }

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -225,6 +225,7 @@ pub struct PeerRelayContext<'a> {
     /// (`clients/go/node/p2p/mempool.go:45-54`); that method's last
     /// statement (line 53) is `p.mempool.AddRemoteTx(raw)`.
     pub tx_pool: &'a std::sync::Mutex<crate::txpool::TxPool>,
+    pub da_relay: &'a std::sync::Mutex<crate::da_relay::DaRelayState>,
 }
 
 #[derive(Debug, Default)]
@@ -710,6 +711,21 @@ impl PeerSession {
             MESSAGE_BLOCKTXN => self.handle_blocktxn(&msg.payload, sync_engine),
             MESSAGE_TX => {
                 if let Some(ctx) = relay_ctx {
+                    if let Err(err) =
+                        crate::da_relay::DaRelayState::validate_relay_da_tx_for_admission(
+                            &msg.payload,
+                        )
+                    {
+                        let reason = format!("DA relay tx admission validation failed: {err:?}");
+                        self.bump_ban(10, &reason);
+                        if self.peer.ban_score >= self.cfg.ban_threshold {
+                            return Err(io::Error::new(io::ErrorKind::InvalidData, reason));
+                        }
+                        return Ok(LiveMessageOutcome {
+                            responses: Vec::new(),
+                            tx_pool_cleanup: TxPoolCleanupPlan::default(),
+                        });
+                    }
                     let outcome = crate::tx_relay::handle_received_tx(
                         &msg.payload,
                         sync_engine,
@@ -795,21 +811,43 @@ impl PeerSession {
                     // `handle_mine_next`, NOT the engine-snapshot-then-drop
                     // pattern in `apply_tx_pool_cleanup`. The seam does
                     // not re-acquire the engine, so no deadlock from self.
-                    if matches!(outcome, crate::tx_relay::RelayTxOutcome::Relayed) {
+                    use crate::tx_relay::RelayTxOutcome::{DuplicateSeen, Relayed};
+                    let relayed = matches!(outcome, Relayed);
+                    if relayed || matches!(outcome, DuplicateSeen) {
+                        #[rustfmt::skip]
+                        let relay_txid = parse_tx(&msg.payload).ok().and_then(|(_, txid, _, consumed)| (consumed == msg.payload.len()).then_some(txid));
+                        let mut admitted_tx = None;
                         match ctx.tx_pool.lock() {
                             Ok(mut pool) => {
-                                let _ = pool.add_tx_with_source(
-                                    &msg.payload,
-                                    &sync_engine.chain_state,
-                                    sync_engine.block_store.as_ref(),
-                                    sync_engine.cfg.chain_id,
-                                    crate::txpool::TxSource::Remote,
-                                );
+                                let existing_tx = relay_txid.and_then(|txid| pool.tx_by_id(&txid));
+                                admitted_tx = existing_tx;
+                                if admitted_tx.is_none() && relayed {
+                                    #[rustfmt::skip]
+                                    let add_remote = pool.add_tx_with_source(&msg.payload, &sync_engine.chain_state, sync_engine.block_store.as_ref(), sync_engine.cfg.chain_id, crate::txpool::TxSource::Remote).ok().and_then(|(txid, _meta)| pool.tx_by_id(&txid));
+                                    admitted_tx = add_remote;
+                                }
                             }
                             Err(_) => {
                                 self.peer.last_error =
                                     "canonical tx_pool poisoned; peer-tx admission skipped"
                                         .to_string();
+                            }
+                        }
+                        if let Some(tx_bytes) = admitted_tx {
+                            match ctx.da_relay.lock() {
+                                Ok(mut da_relay) => {
+                                    if let Err(err) = da_relay
+                                        .stage_relay_da_tx_bytes(ctx.peer_registered_addr, tx_bytes)
+                                    {
+                                        self.peer.last_error =
+                                            format!("DA relay tx staging failed: {err:?}");
+                                    }
+                                }
+                                Err(_) => {
+                                    self.peer.last_error =
+                                        "da relay state poisoned; peer-tx staging skipped"
+                                            .to_string();
+                                }
                             }
                         }
                     }
@@ -3402,6 +3440,15 @@ mod tests {
     use serde::Deserialize;
 
     static NEXT_TEST_ROOT_ID: AtomicU64 = AtomicU64::new(1);
+
+    #[expect(clippy::type_complexity)]
+    #[rustfmt::skip]
+    fn signed_conflicting_da_chunk_state_and_txs() -> (ChainState, Vec<u8>, Vec<u8>, Vec<u8>, [u8; 32], [u8; 32], [u8; 32]) {
+        let keypair = rubin_consensus::Mldsa87Keypair::generate().expect("OpenSSL signer"); let pubkey = keypair.pubkey_bytes(); let outpoint = rubin_consensus::Outpoint { txid: [0xA1; 32], vout: 0 }; let mut state = ChainState::new();
+        state.utxos.insert(outpoint.clone(), rubin_consensus::UtxoEntry { value: 20_000, covenant_type: rubin_consensus::constants::COV_TYPE_P2PK, covenant_data: rubin_consensus::p2pk_covenant_data_for_pubkey(&pubkey), creation_height: 0, created_by_coinbase: false }); let utxos = state.utxos.clone();
+        let build = |nonce: u64, da_id: [u8; 32], payload: &[u8], valid_hash: bool| { let mut tx = rubin_consensus::Tx { version: rubin_consensus::constants::TX_WIRE_VERSION, tx_kind: 0x02, tx_nonce: nonce, inputs: vec![rubin_consensus::TxInput { prev_txid: outpoint.txid, prev_vout: outpoint.vout, script_sig: Vec::new(), sequence: 0 }], outputs: vec![rubin_consensus::TxOutput { value: 10, covenant_type: rubin_consensus::constants::COV_TYPE_P2PK, covenant_data: rubin_consensus::p2pk_covenant_data_for_pubkey(&vec![nonce as u8; 2592]) }], locktime: 0, da_commit_core: None, da_chunk_core: Some(rubin_consensus::DaChunkCore { da_id, chunk_index: 0, chunk_hash: if valid_hash { Sha3_256::digest(payload).into() } else { [0xE1; 32] } }), witness: Vec::new(), da_payload: payload.to_vec() }; rubin_consensus::sign_transaction(&mut tx, &utxos, devnet_genesis_chain_id(), &keypair).expect("sign DA chunk tx"); rubin_consensus::marshal_tx(&tx).expect("marshal DA chunk tx") };
+        let admitted_da_id = [0xD1; 32]; let conflicting_da_id = [0xD2; 32]; let bad_da_id = [0xD3; 32]; let admitted = build(7, admitted_da_id, b"admitted da chunk", true); let conflicting = build(8, conflicting_da_id, b"conflicting da chunk", true); let bad = build(9, bad_da_id, b"bad da chunk", false); (state, admitted, conflicting, bad, admitted_da_id, conflicting_da_id, bad_da_id)
+    }
 
     #[derive(Deserialize)]
     struct SharedRuntimeVectors {
@@ -6021,6 +6068,10 @@ mod tests {
                 crate::tx_relay::PeerOutbox::default(),
             );
             let canonical_tx_pool: Mutex<TxPool> = Mutex::new(TxPool::new());
+            let da_relay_state = Mutex::new(
+                crate::da_relay::DaRelayState::new(crate::da_relay::DaRelayCaps::default())
+                    .expect("valid DA relay caps"),
+            );
 
             let relay_ctx = PeerRelayContext {
                 relay_state: &relay_state,
@@ -6029,6 +6080,7 @@ mod tests {
                 peer_registered_addr: "sender:8333",
                 peer_writers: &peer_outboxes,
                 tx_pool: &canonical_tx_pool,
+                da_relay: &da_relay_state,
             };
 
             let msg = WireMessage {
@@ -6090,6 +6142,28 @@ mod tests {
 
         let _client = TcpStream::connect(addr).expect("connect");
         server.join().expect("server join");
+    }
+
+    #[test]
+    #[rustfmt::skip]
+    fn collect_live_responses_message_tx_stages_da_after_remote_admission() {
+        use std::collections::HashMap; use std::sync::Mutex;
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind"); let addr = listener.local_addr().expect("addr");
+        let server = thread::spawn(move || {
+            let (stream, _) = listener.accept().expect("accept"); let mut session = PeerSession::new(stream, default_peer_runtime_config("devnet", 8)).expect("session");
+            let (chain_state, admitted_tx, conflicting_tx, bad_tx, da_id, conflict_da_id, bad_da_id) = signed_conflicting_da_chunk_state_and_txs();
+            let mut sync_cfg = crate::sync::default_sync_config(None, crate::genesis::devnet_genesis_chain_id(), None);
+            sync_cfg.core_ext_deployments = rubin_consensus::CoreExtDeploymentProfiles::empty();
+            let mut engine = crate::sync::SyncEngine::new(chain_state, None, sync_cfg).expect("sync engine"); let relay_state = crate::tx_relay::TxRelayState::new(); let peer_manager = PeerManager::new(default_peer_runtime_config("devnet", 64)); let peer_outboxes: Mutex<HashMap<String, crate::tx_relay::PeerOutbox>> = Mutex::new(HashMap::new()); let canonical_tx_pool = Mutex::new(TxPool::new()); let da_relay = Mutex::new(crate::da_relay::DaRelayState::new(crate::da_relay::DaRelayCaps::default()).expect("valid DA relay caps"));
+            let relay_ctx = PeerRelayContext { relay_state: &relay_state, peer_manager: &peer_manager, local_addr: "local:8333", peer_registered_addr: "sender:8333", peer_writers: &peer_outboxes, tx_pool: &canonical_tx_pool, da_relay: &da_relay };
+            let (_, bad_txid, _, _) = parse_tx(&bad_tx).expect("parse bad DA tx");
+            session.collect_live_responses(WireMessage { command: MESSAGE_TX.to_string(), payload: bad_tx }, &mut engine, Some(&relay_ctx)).expect("sub-threshold malformed DA tx is peer-neutral"); assert_eq!(session.state().ban_score, 10); assert!(!relay_state.tx_seen.has(&bad_txid)); assert_eq!(da_relay.lock().unwrap().test_record_summary(bad_da_id), None);
+            let (_, txid, _, _) = parse_tx(&admitted_tx).expect("parse admitted DA tx");
+            canonical_tx_pool.lock().unwrap().add_tx_with_source(&admitted_tx, &engine.chain_state, engine.block_store.as_ref(), engine.cfg.chain_id, crate::txpool::TxSource::Local).expect("pre-admit DA tx"); assert!(relay_state.tx_seen.add(txid)); session.collect_live_responses(WireMessage { command: MESSAGE_TX.to_string(), payload: admitted_tx.clone() }, &mut engine, Some(&relay_ctx)).expect("already-seen DA tx dispatch"); assert_eq!(canonical_tx_pool.lock().unwrap().entry_source(&txid), Some(crate::txpool::TxSource::Local)); assert_eq!(da_relay.lock().unwrap().test_record_summary(da_id), Some((false, 1, admitted_tx.len() as u64)));
+            let (_, conflicting_txid, _, _) = parse_tx(&conflicting_tx).expect("parse conflicting DA tx");
+            session.collect_live_responses(WireMessage { command: MESSAGE_TX.to_string(), payload: conflicting_tx }, &mut engine, Some(&relay_ctx)).expect("txpool-rejected DA tx preserves relay outcome"); assert!(relay_state.tx_seen.has(&conflicting_txid)); assert_eq!(da_relay.lock().unwrap().test_record_summary(conflict_da_id), None);
+        });
+        let _client = TcpStream::connect(addr).expect("connect"); server.join().expect("server join");
     }
 
     /// RUB-178 smoke test for the `relay_ctx = None` branch of
@@ -6223,6 +6297,10 @@ mod tests {
                 canonical_tx_pool.is_poisoned(),
                 "Mutex must be poisoned before exercising the seam"
             );
+            let da_relay_state = Mutex::new(
+                crate::da_relay::DaRelayState::new(crate::da_relay::DaRelayCaps::default())
+                    .expect("valid DA relay caps"),
+            );
 
             let relay_ctx = PeerRelayContext {
                 relay_state: &relay_state,
@@ -6231,6 +6309,7 @@ mod tests {
                 peer_registered_addr: "sender:8333",
                 peer_writers: &peer_outboxes,
                 tx_pool: &canonical_tx_pool,
+                da_relay: &da_relay_state,
             };
 
             let msg = WireMessage {

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -228,9 +228,10 @@ pub struct PeerRelayContext<'a> {
     pub da_relay: &'a std::sync::Mutex<crate::da_relay::DaRelayState>,
 }
 
-pub(crate) type PendingDaRelayStaging = (String, Vec<u8>);
+pub(crate) type PendingDaRelayStaging = (String, Vec<u8>, bool);
 
-fn should_skip_relay_da_admission_precheck(
+#[rustfmt::skip]
+fn skip_da(
     tx_bytes: &[u8],
     relay_state: &crate::tx_relay::TxRelayState,
     tx_pool: &Mutex<crate::txpool::TxPool>,
@@ -241,14 +242,7 @@ fn should_skip_relay_da_admission_precheck(
     let Ok(txid) = crate::tx_relay::canonical_txid(tx_bytes) else {
         return false;
     };
-    if !relay_state.tx_seen.has(&txid) {
-        return false;
-    }
-    let Ok(pool) = tx_pool.lock() else {
-        return false;
-    };
-    pool.tx_by_id(&txid)
-        .is_some_and(|admitted_tx| admitted_tx == tx_bytes)
+    relay_state.tx_seen.has(&txid) && tx_pool.lock().ok().and_then(|pool| pool.tx_by_id(&txid)).is_some_and(|admitted_tx| admitted_tx == tx_bytes)
 }
 
 #[derive(Debug, Default)]
@@ -463,23 +457,24 @@ impl PeerSession {
     }
 
     #[rustfmt::skip]
-    fn stash_pending_da_relay_staging(&mut self, peer_addr: &str, tx_bytes: Vec<u8>) {
-        self.pending_da_relay_staging = Some((peer_addr.to_string(), tx_bytes));
+    fn stash_da_staging(&mut self, peer_addr: &str, tx_bytes: Vec<u8>, chunk_hash_prevalidated: bool) {
+        self.pending_da_relay_staging = Some((peer_addr.to_string(), tx_bytes, chunk_hash_prevalidated));
     }
 
+    #[rustfmt::skip]
     pub(crate) fn apply_pending_da_relay_staging(
         &mut self,
         da_relay: &std::sync::Mutex<crate::da_relay::DaRelayState>,
         pending: Option<PendingDaRelayStaging>,
     ) {
-        let Some((peer_addr, tx_bytes)) = pending else {
+        let Some((peer_addr, tx_bytes, chunk_hash_prevalidated)) = pending else {
             return;
         };
         let Ok(mut da_relay) = da_relay.lock() else {
             self.peer.last_error = "da relay state poisoned; peer-tx staging skipped".to_string();
             return;
         };
-        if let Err(err) = da_relay.stage_relay_da_tx_bytes(&peer_addr, tx_bytes) {
+        if let Err(err) = da_relay.stage_relay_da_tx_bytes_checked(&peer_addr, tx_bytes, chunk_hash_prevalidated) {
             self.peer.last_error = format!("DA relay tx staging failed: {err:?}");
         }
     }
@@ -762,11 +757,8 @@ impl PeerSession {
             MESSAGE_BLOCKTXN => self.handle_blocktxn(&msg.payload, sync_engine),
             MESSAGE_TX => {
                 if let Some(ctx) = relay_ctx {
-                    if !should_skip_relay_da_admission_precheck(
-                        &msg.payload,
-                        ctx.relay_state,
-                        ctx.tx_pool,
-                    ) {
+                    let hash_checked = !skip_da(&msg.payload, ctx.relay_state, ctx.tx_pool);
+                    if hash_checked {
                         if let Err(err) =
                             crate::da_relay::DaRelayState::validate_relay_da_tx_for_admission(
                                 &msg.payload,
@@ -793,12 +785,10 @@ impl PeerSession {
                         ctx.local_addr,
                         ctx.peer_writers,
                     )?;
-                    // Stash DA relay staging here; the service loop applies it
-                    // after releasing the sync engine lock.
                     use crate::tx_relay::RelayTxOutcome::{DuplicateSeen, Relayed};
                     let relay_da_tx = matches!(
                         crate::da_relay::relay_da_tx_kind_prefix(&msg.payload),
-                        Some(0x01 | 0x02)
+                        Some(0x01) | Some(0x02)
                     );
                     if matches!(&outcome, Relayed { .. })
                         || (relay_da_tx && matches!(&outcome, DuplicateSeen { .. }))
@@ -827,8 +817,9 @@ impl PeerSession {
                         }
                         if relay_da_tx {
                             if let Some(tx_bytes) = admitted_tx {
-                                #[rustfmt::skip]
-                                self.stash_pending_da_relay_staging(ctx.peer_registered_addr, tx_bytes);
+                                let prevalid = hash_checked && tx_bytes == msg.payload;
+                                let peer_addr = ctx.peer_registered_addr;
+                                self.stash_da_staging(peer_addr, tx_bytes, prevalid);
                             }
                         }
                     }

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -849,21 +849,27 @@ impl PeerSession {
                     // DA relay staging is only stashed here; the service
                     // loop applies it after releasing the engine lock.
                     use crate::tx_relay::RelayTxOutcome::{DuplicateSeen, Relayed};
-                    let relayed = matches!(outcome, Relayed { .. });
-                    let relay_txid = match &outcome {
-                        Relayed { txid } | DuplicateSeen { txid } => Some(*txid),
-                        _ => None,
-                    };
-                    if let Some(relay_txid) = relay_txid {
+                    let relay_da_tx = matches!(
+                        crate::da_relay::relay_da_tx_kind_prefix(&msg.payload),
+                        Some(0x01 | 0x02)
+                    );
+                    if matches!(outcome, Relayed { .. })
+                        || (relay_da_tx && matches!(outcome, DuplicateSeen { .. }))
+                    {
                         let mut admitted_tx = None;
                         match ctx.tx_pool.lock() {
                             Ok(mut pool) => {
-                                let existing_tx = pool.tx_by_id(&relay_txid);
-                                admitted_tx = existing_tx;
-                                if admitted_tx.is_none() && relayed {
+                                if relay_da_tx {
+                                    if let Relayed { txid } | DuplicateSeen { txid } = outcome {
+                                        admitted_tx = pool.tx_by_id(&txid);
+                                    }
+                                }
+                                if admitted_tx.is_none() && matches!(outcome, Relayed { .. }) {
                                     #[rustfmt::skip]
                                     let add_remote = pool.add_tx_with_source(&msg.payload, &sync_engine.chain_state, sync_engine.block_store.as_ref(), sync_engine.cfg.chain_id, crate::txpool::TxSource::Remote).ok().and_then(|(txid, _meta)| pool.tx_by_id(&txid));
-                                    admitted_tx = add_remote;
+                                    if relay_da_tx {
+                                        admitted_tx = add_remote;
+                                    }
                                 }
                             }
                             Err(_) => {
@@ -872,13 +878,15 @@ impl PeerSession {
                                         .to_string();
                             }
                         }
-                        if let Some(tx_bytes) = admitted_tx {
-                            let hash_checked = tx_bytes == msg.payload;
-                            self.stash_pending_da_relay_staging(
-                                ctx.peer_registered_addr,
-                                tx_bytes,
-                                hash_checked,
-                            );
+                        if relay_da_tx {
+                            if let Some(tx_bytes) = admitted_tx {
+                                let hash_checked = tx_bytes == msg.payload;
+                                self.stash_pending_da_relay_staging(
+                                    ctx.peer_registered_addr,
+                                    tx_bytes,
+                                    hash_checked,
+                                );
+                            }
                         }
                     }
                     // Mirror Go's `peer.handleTx` parse-fail policy: parse
@@ -6125,6 +6133,10 @@ mod tests {
             let _ = session
                 .collect_live_responses(msg, &mut engine, Some(&relay_ctx))
                 .expect("collect_live_responses MESSAGE_TX must succeed for floor-compliant tx");
+            assert!(
+                session.take_pending_da_relay_staging().is_none(),
+                "non-DA MESSAGE_TX must not queue DA relay staging work"
+            );
 
             let (_, txid, _, _consumed) = parse_tx(&tx_bytes).expect("parse tx for txid");
 

--- a/clients/rust/crates/rubin-node/src/p2p_service.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_service.rs
@@ -888,20 +888,24 @@ fn handle_peer(
             // Lock scope minimized: engine lock held only during
             // collect_live_responses.  Payload size check above ensures
             // no unbounded deserialization under lock.
-            let (responses, tx_pool_cleanup) = {
+            let (responses, tx_pool_cleanup, pending_da_relay_staging) = {
                 let mut engine = shared
                     .sync_engine
                     .lock()
                     .map_err(|_| "sync engine unavailable".to_string())?;
                 let outcome = session.collect_live_responses(msg, &mut engine, Some(&relay_ctx));
                 let pending_cleanup = session.take_pending_tx_pool_cleanup();
+                let pending_da_relay_staging = session.take_pending_da_relay_staging();
                 drop(engine);
-                finalize_live_message_outcome(&shared, outcome, pending_cleanup)?
+                let (responses, tx_pool_cleanup) =
+                    finalize_live_message_outcome(&shared, outcome, pending_cleanup)?;
+                (responses, tx_pool_cleanup, pending_da_relay_staging)
             };
             log_tx_pool_cleanup_requeue_failure(&maybe_apply_tx_pool_cleanup(
                 &shared,
                 tx_pool_cleanup,
             )?);
+            session.apply_pending_da_relay_staging(&shared.da_relay, pending_da_relay_staging);
             responses
         };
         for outbound in outbound_messages {

--- a/clients/rust/crates/rubin-node/src/p2p_service.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_service.rs
@@ -8,6 +8,7 @@ use std::time::{Duration, Instant};
 
 use std::collections::HashMap;
 
+use crate::da_relay::{DaRelayCaps, DaRelayState};
 use crate::p2p_runtime::{
     perform_version_handshake, LiveMessageOutcome, PeerManager, PeerRelayContext,
     PeerRuntimeConfig, VersionPayloadV1, WireMessage,
@@ -63,6 +64,7 @@ struct SharedServiceState {
     peer_manager: Arc<PeerManager>,
     sync_engine: Arc<Mutex<SyncEngine>>,
     tx_pool: Arc<Mutex<TxPool>>,
+    da_relay: Arc<Mutex<DaRelayState>>,
     bootstrap_peers: Arc<Vec<String>>,
     bootstrap_rotate_idx: Arc<AtomicUsize>,
     in_flight_dials: Arc<Mutex<HashSet<String>>>,
@@ -154,6 +156,9 @@ pub fn start_node_p2p_service(cfg: NodeP2PServiceConfig) -> Result<RunningNodeP2
         .to_string();
     let stop = Arc::new(AtomicBool::new(false));
     let relay_state = Arc::new(TxRelayState::new_with_network(&cfg.runtime_cfg.network));
+    let da_relay = Arc::new(Mutex::new(
+        DaRelayState::new(DaRelayCaps::default()).map_err(|err| format!("{err:?}"))?,
+    ));
     let shared = SharedServiceState {
         stop: Arc::clone(&stop),
         runtime_cfg: cfg.runtime_cfg,
@@ -162,6 +167,7 @@ pub fn start_node_p2p_service(cfg: NodeP2PServiceConfig) -> Result<RunningNodeP2
         peer_manager: cfg.peer_manager,
         sync_engine: cfg.sync_engine,
         tx_pool: cfg.tx_pool,
+        da_relay,
         bootstrap_peers: Arc::new(cfg.bootstrap_peers),
         bootstrap_rotate_idx: Arc::new(AtomicUsize::new(0)),
         in_flight_dials: Arc::new(Mutex::new(HashSet::new())),
@@ -828,6 +834,7 @@ fn handle_peer(
         peer_registered_addr: &peer_addr,
         peer_writers: &shared.peer_outboxes,
         tx_pool: &shared.tx_pool,
+        da_relay: &shared.da_relay,
     };
 
     {
@@ -1193,6 +1200,10 @@ mod tests {
             peer_manager: Arc::new(PeerManager::new(runtime_cfg)),
             sync_engine,
             tx_pool: Arc::new(Mutex::new(TxPool::new())),
+            da_relay: Arc::new(Mutex::new(
+                crate::da_relay::DaRelayState::new(crate::da_relay::DaRelayCaps::default())
+                    .expect("valid DA relay caps"),
+            )),
             bootstrap_peers: Arc::new(bootstrap_peers),
             bootstrap_rotate_idx: Arc::new(AtomicUsize::new(0)),
             in_flight_dials: Arc::new(Mutex::new(HashSet::new())),

--- a/clients/rust/crates/rubin-node/src/tx_relay.rs
+++ b/clients/rust/crates/rubin-node/src/tx_relay.rs
@@ -496,8 +496,8 @@ fn broadcast_inv_to_addrs(
 
 /// Announce a transaction after successful mempool admission.
 ///
-/// Full flow: parse tx → compute txid → store in relay pool → mark seen →
-/// broadcast INV to peers. Matches Go `AnnounceTx`.
+/// Full flow: parse tx → compute txid → validate DA relay admission → store in
+/// relay pool → mark seen → broadcast INV to peers. Matches Go `AnnounceTx`.
 pub fn announce_tx(
     tx_bytes: &[u8],
     meta: crate::txpool::RelayTxMetadata,
@@ -507,6 +507,8 @@ pub fn announce_tx(
     peer_writers: &Mutex<HashMap<String, PeerOutbox>>,
 ) -> Result<(), String> {
     let txid = canonical_txid(tx_bytes)?;
+    crate::da_relay::DaRelayState::validate_relay_da_tx_for_admission(tx_bytes)
+        .map_err(|err| format!("DA relay tx admission validation failed: {err:?}"))?;
 
     // RPC path already passed mempool admission, so preserve the validated
     // relay metadata for relay-pool priority instead of degrading to zero fee.
@@ -683,7 +685,7 @@ pub fn handle_received_tx(
 }
 
 /// Extract the canonical txid from raw tx bytes using consensus parsing.
-fn canonical_txid(tx_bytes: &[u8]) -> Result<[u8; 32], String> {
+pub(crate) fn canonical_txid(tx_bytes: &[u8]) -> Result<[u8; 32], String> {
     let (_tx, txid, _wtxid, consumed) =
         rubin_consensus::parse_tx(tx_bytes).map_err(|e| e.to_string())?;
     if consumed != tx_bytes.len() {

--- a/clients/rust/crates/rubin-node/src/tx_relay.rs
+++ b/clients/rust/crates/rubin-node/src/tx_relay.rs
@@ -580,9 +580,9 @@ pub fn announce_block(
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RelayTxOutcome {
     /// Tx was parsed, admitted to relay pool, and re-announced.
-    Relayed,
+    Relayed { txid: [u8; 32] },
     /// Tx was already seen — silently ignored.
-    DuplicateSeen,
+    DuplicateSeen { txid: [u8; 32] },
     /// Relay-metadata derivation failed (fee/policy); marked seen so peers
     /// don't churn INV/GETDATA, but peer session is not penalized.
     MetadataRejected,
@@ -640,7 +640,7 @@ pub fn handle_received_tx(
 
     // Mark seen BEFORE pool admission (matches Go).
     if !relay_state.tx_seen.add(txid) {
-        return Ok(RelayTxOutcome::DuplicateSeen);
+        return Ok(RelayTxOutcome::DuplicateSeen { txid });
     }
 
     let relay_cfg = crate::txpool::TxPoolConfig {
@@ -679,7 +679,7 @@ pub fn handle_received_tx(
         local_addr,
         peer_writers,
     );
-    Ok(RelayTxOutcome::Relayed)
+    Ok(RelayTxOutcome::Relayed { txid })
 }
 
 /// Extract the canonical txid from raw tx bytes using consensus parsing.


### PR DESCRIPTION
Linear: RUB-384

Scope:
- Rust remote peer MESSAGE_TX DA relay staging after canonical remote admission.
- DA commit/chunk relay records stage from canonical pool-owned bytes after the tx relay and txpool boundary.
- Malformed DA chunk payloads are rejected before DA relay state mutation.
- Duplicate-seen remote DA txs stage only from canonical bytes already present in the pool.

Non-scope:
- No local RPC /submit_tx DA staging; owned by RUB-419.
- No DA orphan TTL runtime wiring or helper work; owned by RUB-420/RUB-401.
- No disconnect quota release runtime wiring or helper work; owned by RUB-421/RUB-402.
- No provider, miner, prefetch, getdachunk, Go, spec, fixture, conformance, or consensus changes.

Go/Rust parity matrix:
| Required parity case | Go reference / callsite | Rust entrypoint | Rust mirror-test evidence |
| --- | --- | --- | --- |
| case: relay success and remote TxPool admission gate DA staging | clients/go/node/p2p/handlers_tx.go::handleTx canonical TxPool admission before DA relay staging | clients/rust/crates/rubin-node/src/p2p_runtime.rs::PeerSession::collect_live_responses MESSAGE_TX branch | p2p_runtime::tests::collect_live_responses_message_tx_stages_da_after_remote_admission |
| case: DA commit bytes classify and stage through existing DA relay state | clients/go/node/p2p/da_relay_ingest.go::stageRelayDATx -> stageRelayDACommitTx | clients/rust/crates/rubin-node/src/da_relay.rs::DaRelayState::stage_relay_da_tx_bytes for tx_kind 0x01 | da_relay::tests::stage_relay_da_tx_bytes_contract_matrix |
| case: DA chunk bytes precheck before retained state mutation | clients/go/node/p2p/da_relay_ingest.go::validateRelayDATxForAdmission -> stageRelayDAChunkTx | clients/rust/crates/rubin-node/src/da_relay.rs::DaRelayState::validate_relay_da_tx_for_admission and stage_relay_da_tx_bytes for tx_kind 0x02 | da_relay::tests::stage_relay_da_tx_bytes_contract_matrix |
| case: TxPool rejection does not stage sibling DA state | clients/go/node/p2p/handlers_tx.go::handleTx canonical admission boundary | clients/rust/crates/rubin-node/src/p2p_runtime.rs::PeerSession::collect_live_responses MESSAGE_TX branch | p2p_runtime::tests::collect_live_responses_message_tx_stages_da_after_remote_admission |

Evidence:
- Rust validation: PASS.
- Rust coverage: PASS; diff coverage 96.59% (85/88), variation +0.02%.
