### PR TITLE
RUB-401: Add Rust DA orphan TTL expiry

### DIFF
--- a/clients/rust/crates/rubin-node/src/da_relay.rs
+++ b/clients/rust/crates/rubin-node/src/da_relay.rs
@@ -92,6 +92,13 @@ pub(crate) struct DaRelayEvictionAccounting {
     pub(crate) received_time: u64,
 }
 
+struct DaRelayTtlExpiryProjection {
+    orphan_bytes: u64,
+    orphan_commit_overhead_bytes: u64,
+    peer_bytes: Vec<(PeerQuotaKey, u64)>,
+    da_id_bytes: Vec<([u8; 32], u64)>,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct PeerQuotaKey(String);
 
@@ -490,34 +497,44 @@ impl DaRelayState {
     }
 
     pub(crate) fn advance_orphan_ttl(&mut self) -> DaRelayResult<Vec<[u8; 32]>> {
-        let da_ids: Vec<_> = self
-            .orphan_bytes_by_da_id
-            .keys()
-            .copied()
-            .filter(|da_id| {
-                self.sets_by_da_id
-                    .get(da_id)
-                    .is_some_and(|record| record.state != DaRelaySetState::CompleteSet)
-            })
-            .collect();
-        let mut staged = self.clone();
-        let mut expired = Vec::new();
-        for da_id in da_ids {
-            let Some(record) = staged.sets_by_da_id.get(&da_id).cloned() else {
+        let mut decrementing_da_ids = Vec::new();
+        let mut expiring_records = Vec::new();
+        for da_id in self.orphan_bytes_by_da_id.keys().copied() {
+            let Some(record) = self.sets_by_da_id.get(&da_id) else {
                 continue;
             };
+            if record.state == DaRelaySetState::CompleteSet {
+                continue;
+            }
             if record.ttl_blocks_remaining > 1 {
-                staged
-                    .sets_by_da_id
+                decrementing_da_ids.push(da_id);
+            } else {
+                expiring_records.push(record.clone());
+            }
+        }
+
+        if expiring_records.is_empty() {
+            for da_id in decrementing_da_ids {
+                self.sets_by_da_id
                     .get_mut(&da_id)
                     .ok_or(DaRelayError::AccountingUnderflow)?
                     .ttl_blocks_remaining -= 1;
-                continue;
             }
-            expired.push(record.da_id);
-            staged.remove_record(&record)?;
+            return Ok(Vec::new());
         }
-        *self = staged;
+
+        let projection = self.project_ttl_expiry(&expiring_records)?;
+        let expired = expiring_records
+            .iter()
+            .map(|record| record.da_id)
+            .collect::<Vec<_>>();
+        for da_id in decrementing_da_ids {
+            self.sets_by_da_id
+                .get_mut(&da_id)
+                .ok_or(DaRelayError::AccountingUnderflow)?
+                .ttl_blocks_remaining -= 1;
+        }
+        self.apply_ttl_expiry_projection(projection, expiring_records);
         Ok(expired)
     }
 
@@ -742,54 +759,87 @@ impl DaRelayState {
         Ok(projected)
     }
 
-    fn remove_record(&mut self, record: &DaRelaySetRecord) -> DaRelayResult {
-        let empty = DaRelaySetRecord::new(record.da_id);
-        let orphan_wire_bytes = record.orphan_wire_bytes()?;
-        let orphan_bytes = Self::project_counter(
-            self.orphan_bytes,
-            orphan_wire_bytes,
-            0,
-            self.caps.orphan_pool_bytes,
-        )?;
-        let da_id_bytes = Self::project_counter(
-            self.orphan_bytes_by_da_id
-                .get(&record.da_id)
-                .copied()
-                .unwrap_or(0),
-            orphan_wire_bytes,
-            0,
-            self.caps.orphan_pool_per_da_id_bytes,
-        )?;
-        let commit_overhead = Self::project_counter(
-            self.orphan_commit_overhead_bytes,
-            record.orphan_commit_bytes(),
-            0,
-            self.caps.orphan_commit_overhead_bytes,
-        )?;
-        let pinned_payload_bytes = Self::project_counter(
-            self.pinned_payload_bytes,
-            record.pinned_payload_accounting_bytes()?,
-            0,
-            self.caps.pinned_payload_bytes,
-        )?;
-        let peer_bytes = self.project_peer_bytes(Some(record), &empty)?;
-        self.orphan_bytes = orphan_bytes;
-        self.orphan_commit_overhead_bytes = commit_overhead;
-        self.pinned_payload_bytes = pinned_payload_bytes;
-        for (key, bytes) in peer_bytes {
+    fn project_ttl_expiry(
+        &self,
+        records: &[DaRelaySetRecord],
+    ) -> DaRelayResult<DaRelayTtlExpiryProjection> {
+        let mut remove_orphan_bytes = 0u64;
+        let mut remove_commit_overhead_bytes = 0u64;
+        let mut remove_peer_bytes = BTreeMap::new();
+        let mut da_id_bytes = Vec::with_capacity(records.len());
+        for record in records {
+            let orphan_wire_bytes = record.orphan_wire_bytes()?;
+            remove_orphan_bytes = checked_add(remove_orphan_bytes, orphan_wire_bytes)?;
+            remove_commit_overhead_bytes =
+                checked_add(remove_commit_overhead_bytes, record.orphan_commit_bytes())?;
+            da_id_bytes.push((
+                record.da_id,
+                Self::project_counter(
+                    self.orphan_bytes_by_da_id
+                        .get(&record.da_id)
+                        .copied()
+                        .unwrap_or(0),
+                    orphan_wire_bytes,
+                    0,
+                    self.caps.orphan_pool_per_da_id_bytes,
+                )?,
+            ));
+            if let Some(peer_bytes) = record.orphan_peer_bytes() {
+                for (key, bytes) in peer_bytes {
+                    let entry = remove_peer_bytes.entry(key.clone()).or_default();
+                    *entry = checked_add(*entry, *bytes)?;
+                }
+            }
+        }
+        let peer_bytes = remove_peer_bytes
+            .into_iter()
+            .map(|(key, bytes)| {
+                let projected = self.project_peer_counter(&key, bytes, 0)?.1;
+                Ok((key, projected))
+            })
+            .collect::<DaRelayResult<_>>()?;
+        Ok(DaRelayTtlExpiryProjection {
+            orphan_bytes: Self::project_counter(
+                self.orphan_bytes,
+                remove_orphan_bytes,
+                0,
+                self.caps.orphan_pool_bytes,
+            )?,
+            orphan_commit_overhead_bytes: Self::project_counter(
+                self.orphan_commit_overhead_bytes,
+                remove_commit_overhead_bytes,
+                0,
+                self.caps.orphan_commit_overhead_bytes,
+            )?,
+            peer_bytes,
+            da_id_bytes,
+        })
+    }
+
+    fn apply_ttl_expiry_projection(
+        &mut self,
+        projection: DaRelayTtlExpiryProjection,
+        records: Vec<DaRelaySetRecord>,
+    ) {
+        self.orphan_bytes = projection.orphan_bytes;
+        self.orphan_commit_overhead_bytes = projection.orphan_commit_overhead_bytes;
+        for (key, bytes) in projection.peer_bytes {
             if bytes == 0 {
                 self.orphan_bytes_by_peer_quota_key.remove(&key);
             } else {
                 self.orphan_bytes_by_peer_quota_key.insert(key, bytes);
             }
         }
-        if da_id_bytes == 0 {
-            self.orphan_bytes_by_da_id.remove(&record.da_id);
-        } else {
-            self.orphan_bytes_by_da_id.insert(record.da_id, da_id_bytes);
+        for (da_id, bytes) in projection.da_id_bytes {
+            if bytes == 0 {
+                self.orphan_bytes_by_da_id.remove(&da_id);
+            } else {
+                self.orphan_bytes_by_da_id.insert(da_id, bytes);
+            }
         }
-        self.sets_by_da_id.remove(&record.da_id);
-        Ok(())
+        for record in records {
+            self.sets_by_da_id.remove(&record.da_id);
+        }
     }
 }
 fn validate_da_chunk(chunk: &DaRelayChunk) -> DaRelayResult {

--- a/clients/rust/crates/rubin-node/src/da_relay.rs
+++ b/clients/rust/crates/rubin-node/src/da_relay.rs
@@ -489,6 +489,38 @@ impl DaRelayState {
             })
     }
 
+    pub(crate) fn advance_orphan_ttl(&mut self) -> DaRelayResult<Vec<[u8; 32]>> {
+        let da_ids: Vec<_> = self
+            .orphan_bytes_by_da_id
+            .keys()
+            .copied()
+            .filter(|da_id| {
+                self.sets_by_da_id
+                    .get(da_id)
+                    .is_some_and(|record| record.state != DaRelaySetState::CompleteSet)
+            })
+            .collect();
+        let mut staged = self.clone();
+        let mut expired = Vec::new();
+        for da_id in da_ids {
+            let Some(record) = staged.sets_by_da_id.get(&da_id).cloned() else {
+                continue;
+            };
+            if record.ttl_blocks_remaining > 1 {
+                staged
+                    .sets_by_da_id
+                    .get_mut(&da_id)
+                    .ok_or(DaRelayError::AccountingUnderflow)?
+                    .ttl_blocks_remaining -= 1;
+                continue;
+            }
+            expired.push(record.da_id);
+            staged.remove_record(&record)?;
+        }
+        *self = staged;
+        Ok(expired)
+    }
+
     pub(crate) fn stage_incomplete_da_commit(
         &mut self,
         peer_addr: &str,
@@ -708,6 +740,56 @@ impl DaRelayState {
             }
         }
         Ok(projected)
+    }
+
+    fn remove_record(&mut self, record: &DaRelaySetRecord) -> DaRelayResult {
+        let empty = DaRelaySetRecord::new(record.da_id);
+        let orphan_wire_bytes = record.orphan_wire_bytes()?;
+        let orphan_bytes = Self::project_counter(
+            self.orphan_bytes,
+            orphan_wire_bytes,
+            0,
+            self.caps.orphan_pool_bytes,
+        )?;
+        let da_id_bytes = Self::project_counter(
+            self.orphan_bytes_by_da_id
+                .get(&record.da_id)
+                .copied()
+                .unwrap_or(0),
+            orphan_wire_bytes,
+            0,
+            self.caps.orphan_pool_per_da_id_bytes,
+        )?;
+        let commit_overhead = Self::project_counter(
+            self.orphan_commit_overhead_bytes,
+            record.orphan_commit_bytes(),
+            0,
+            self.caps.orphan_commit_overhead_bytes,
+        )?;
+        let pinned_payload_bytes = Self::project_counter(
+            self.pinned_payload_bytes,
+            record.pinned_payload_accounting_bytes()?,
+            0,
+            self.caps.pinned_payload_bytes,
+        )?;
+        let peer_bytes = self.project_peer_bytes(Some(record), &empty)?;
+        self.orphan_bytes = orphan_bytes;
+        self.orphan_commit_overhead_bytes = commit_overhead;
+        self.pinned_payload_bytes = pinned_payload_bytes;
+        for (key, bytes) in peer_bytes {
+            if bytes == 0 {
+                self.orphan_bytes_by_peer_quota_key.remove(&key);
+            } else {
+                self.orphan_bytes_by_peer_quota_key.insert(key, bytes);
+            }
+        }
+        if da_id_bytes == 0 {
+            self.orphan_bytes_by_da_id.remove(&record.da_id);
+        } else {
+            self.orphan_bytes_by_da_id.insert(record.da_id, da_id_bytes);
+        }
+        self.sets_by_da_id.remove(&record.da_id);
+        Ok(())
     }
 }
 fn validate_da_chunk(chunk: &DaRelayChunk) -> DaRelayResult {
@@ -1152,6 +1234,23 @@ mod tests {
             Err(AccountingCapExceeded)
         );
         assert_eq!(state, before);
+    }
+
+    #[test]
+    #[rustfmt::skip]
+    fn da_relay_ttl_expiry_matrix() {
+        let peer = "peer-a:8333"; let pk = PeerQuotaKey::from_peer_addr(peer);
+        let commit = |da_id, payloads: &[&[u8]], wire_bytes| DaRelayCommit { da_id, payload_commitment: payload_commitment(payloads), peer_quota_key: pk.clone(), chunk_count: payloads.len() as u16, wire_bytes, tx_bytes: Arc::from([]) };
+        let chunk = |da_id, index, payload: &[u8], wire_bytes| DaRelayChunk { da_id, chunk_hash: sha3_256(payload), peer_quota_key: pk.clone(), chunk_index: index, payload: Arc::from(payload), wire_bytes, tx_bytes: Arc::from([]) };
+        let mut state = DaRelayState::new(DaRelayCaps::default()).unwrap(); state.stage_incomplete_da_chunk(peer, chunk([3; 32], 0, b"orphan", 6)).unwrap(); state.stage_incomplete_da_commit(peer, commit([2; 32], &[b"staged"], 7)).unwrap(); state.stage_incomplete_da_commit(peer, commit([1; 32], &[b"complete"], 8)).unwrap(); state.stage_incomplete_da_chunk(peer, chunk([1; 32], 0, b"complete", 8)).unwrap();
+        let complete_before = state.sets_by_da_id[&[1; 32]].clone(); let orphan_before = state.orphan_bytes; assert!(state.advance_orphan_ttl().unwrap().is_empty()); assert_eq!(state.sets_by_da_id[&[3; 32]].ttl_blocks_remaining, 2); assert_eq!(state.sets_by_da_id[&[2; 32]].ttl_blocks_remaining, 2); assert_eq!(state.sets_by_da_id[&[1; 32]], complete_before); assert_eq!(state.orphan_bytes, orphan_before);
+        state.sets_by_da_id.get_mut(&[3; 32]).unwrap().ttl_blocks_remaining = 1; state.sets_by_da_id.get_mut(&[2; 32]).unwrap().ttl_blocks_remaining = 0; let expired = state.advance_orphan_ttl().unwrap();
+        assert_eq!(expired, vec![[2; 32], [3; 32]]);
+        assert_eq!(state.sets_by_da_id.get(&[1; 32]), Some(&complete_before)); assert!(!state.sets_by_da_id.contains_key(&[2; 32])); assert!(!state.sets_by_da_id.contains_key(&[3; 32])); assert_eq!(state.orphan_bytes, 0); assert!(state.orphan_bytes_by_da_id.is_empty()); assert!(state.orphan_bytes_by_peer_quota_key.is_empty()); assert_eq!(state.orphan_commit_overhead_bytes, 0); assert_eq!(state.pinned_payload_bytes, complete_before.pinned_payload_accounting_bytes().unwrap()); let before_noop = state.clone(); assert!(state.advance_orphan_ttl().unwrap().is_empty()); assert_eq!(state, before_noop);
+        state.stage_incomplete_da_chunk(peer, chunk([4; 32], 0, b"corrupt", 7)).unwrap(); state.sets_by_da_id.get_mut(&[4; 32]).unwrap().ttl_blocks_remaining = 1; state.orphan_bytes = 0; let before = state.clone();
+        assert_eq!(state.advance_orphan_ttl(), Err(AccountingUnderflow)); assert_eq!(state, before);
+        let mut state = DaRelayState::new(DaRelayCaps::default()).unwrap(); state.stage_incomplete_da_chunk(peer, chunk([4; 32], 0, b"early", 5)).unwrap(); state.stage_incomplete_da_chunk(peer, chunk([5; 32], 0, b"late", 7)).unwrap(); state.sets_by_da_id.get_mut(&[4; 32]).unwrap().ttl_blocks_remaining = 1; state.sets_by_da_id.get_mut(&[5; 32]).unwrap().ttl_blocks_remaining = 1; state.orphan_bytes_by_da_id.insert([5; 32], 0); let before = state.clone();
+        assert_eq!(state.advance_orphan_ttl(), Err(AccountingUnderflow)); assert_eq!(state, before);
     }
 
     #[test]


### PR DESCRIPTION
## Scope

Closes #1863.

Rust DA relay state now expires incomplete orphan/staged DA records after the configured block TTL while retaining complete sets.

Out of scope: peer disconnect cleanup, accepted-block runtime wiring, provider/miner/prefetch behavior, Go/spec/conformance changes.

## Matrix

| Case | Go reference | Go callsite | Rust callsite | Rust mirror-test evidence |
| -- | -- | -- | -- | -- |
| incomplete orphan expires after configured block TTL | `advanceOrphanTTL`; `TestDARelayAdvanceOrphanTTLExpiresOrphanChunksAtomically` | `clients/go/node/p2p/da_relay_state.go::advanceOrphanTTL` | `clients/rust/crates/rubin-node/src/da_relay.rs::DaRelayState::advance_orphan_ttl` | `da_relay_ttl_expiry_matrix` removes orphan record and releases orphan/DA/peer accounting |
| incomplete staged record expires after TTL | `advanceOrphanTTL`; `TestDARelayAdvanceOrphanTTLExpiresStagedCommitAccounting` | `clients/go/node/p2p/da_relay_state.go::advanceOrphanTTL` | `clients/rust/crates/rubin-node/src/da_relay.rs::DaRelayState::advance_orphan_ttl` | `da_relay_ttl_expiry_matrix` removes staged commit and releases commit overhead/accounting |
| complete set is retained | `advanceOrphanTTL`; `TestDARelayAdvanceOrphanTTLDecrementsAndPreservesCompleteSets` | `clients/go/node/p2p/da_relay_state.go::advanceOrphanTTL` | `clients/rust/crates/rubin-node/src/da_relay.rs::DaRelayState::advance_orphan_ttl` | `da_relay_ttl_expiry_matrix` preserves complete record and pinned payload accounting |
| TTL decrement is deterministic | `advanceOrphanTTL`; `TestDARelayAdvanceOrphanTTLDecrementsAndPreservesCompleteSets`; `TestDARelayAdvanceOrphanTTLReturnsProjectionErrorsWithoutMutation` | `clients/go/node/p2p/da_relay_state.go::advanceOrphanTTL` | `clients/rust/crates/rubin-node/src/da_relay.rs::DaRelayState::advance_orphan_ttl` | `da_relay_ttl_expiry_matrix` decrements incomplete TTL from 3 to 2 without expiry |
| zero/no-op advance does not mutate unexpectedly | `advanceOrphanTTL`; second advance in `TestDARelayAdvanceOrphanTTLExpiresOrphanChunksAtomically` | `clients/go/node/p2p/da_relay_state.go::advanceOrphanTTL` | `clients/rust/crates/rubin-node/src/da_relay.rs::DaRelayState::advance_orphan_ttl` | `da_relay_ttl_expiry_matrix` asserts empty result and exact state equality |
| accounting recomputed after expiry | `advanceOrphanTTL`; `removeDASetRecordLocked`; TTL expiry tests | `clients/go/node/p2p/da_relay_state.go::advanceOrphanTTL`; `clients/go/node/p2p/da_relay_state.go::removeDASetRecordLocked` | `clients/rust/crates/rubin-node/src/da_relay.rs::DaRelayState::advance_orphan_ttl`; `clients/rust/crates/rubin-node/src/da_relay.rs::remove_record` | `da_relay_ttl_expiry_matrix` asserts orphan/staged counters and maps are cleared after expiry |
| expiry projection error is fail-closed | `advanceOrphanTTL`; `TestDARelayAdvanceOrphanTTLReturnsProjectionErrorsWithoutMutation` | `clients/go/node/p2p/da_relay_state.go::advanceOrphanTTL` | `clients/rust/crates/rubin-node/src/da_relay.rs::DaRelayState::advance_orphan_ttl`; `clients/rust/crates/rubin-node/src/da_relay.rs::remove_record` | `da_relay_ttl_expiry_matrix` asserts `AccountingUnderflow` leaves state unchanged, including later-record failure after earlier expiry candidate |

## Evidence

- `cd clients/rust && cargo fmt --check`
- `cd clients/rust && cargo test -p rubin-node da_relay_ttl --lib`
- `cd clients/rust && cargo test -p rubin-node da_relay --lib`
- `cd clients/rust && cargo test -p rubin-node --lib`
- `cd clients/rust && cargo clippy -p rubin-node --lib --tests -- -D warnings`
- Coverage: diff 96.23% (51/53), variation +0.02%
