### PR TITLE
RUB-420: Advance Rust DA orphan TTL from accepted blocks

### DIFF
--- a/clients/rust/crates/rubin-node/src/da_relay.rs
+++ b/clients/rust/crates/rubin-node/src/da_relay.rs
@@ -496,7 +496,15 @@ impl DaRelayState {
             })
     }
 
-    pub fn advance_orphan_ttl(&mut self) -> DaRelayResult<Vec<[u8; 32]>> {
+    pub(crate) fn advance_orphan_ttl(&mut self) -> DaRelayResult<Vec<[u8; 32]>> {
+        self.advance_orphan_ttl_by(1)
+    }
+
+    pub(crate) fn advance_orphan_ttl_by(&mut self, blocks: usize) -> DaRelayResult<Vec<[u8; 32]>> {
+        if blocks == 0 {
+            return Ok(Vec::new());
+        }
+        let blocks = blocks as u64;
         let mut decrementing_da_ids = Vec::new();
         let mut expiring_records = Vec::new();
         for da_id in self.orphan_bytes_by_da_id.keys().copied() {
@@ -506,34 +514,35 @@ impl DaRelayState {
             if record.state == DaRelaySetState::CompleteSet {
                 continue;
             }
-            if record.ttl_blocks_remaining > 1 {
+            if record.ttl_blocks_remaining > blocks {
                 decrementing_da_ids.push(da_id);
             } else {
                 expiring_records.push(record.clone());
             }
         }
 
-        if expiring_records.is_empty() {
-            for da_id in decrementing_da_ids {
-                self.sets_by_da_id
-                    .get_mut(&da_id)
-                    .ok_or(DaRelayError::AccountingUnderflow)?
-                    .ttl_blocks_remaining -= 1;
-            }
-            return Ok(Vec::new());
-        }
-
-        let projection = self.project_ttl_expiry(&expiring_records)?;
+        let projection = if expiring_records.is_empty() {
+            None
+        } else {
+            Some(self.project_ttl_expiry(&expiring_records)?)
+        };
         let expired = expiring_records
             .iter()
             .map(|record| record.da_id)
             .collect::<Vec<_>>();
         for da_id in decrementing_da_ids {
-            self.sets_by_da_id
+            let record = self
+                .sets_by_da_id
                 .get_mut(&da_id)
-                .ok_or(DaRelayError::AccountingUnderflow)?
-                .ttl_blocks_remaining -= 1;
+                .ok_or(DaRelayError::AccountingUnderflow)?;
+            record.ttl_blocks_remaining = record
+                .ttl_blocks_remaining
+                .checked_sub(blocks)
+                .ok_or(DaRelayError::AccountingUnderflow)?;
         }
+        let Some(projection) = projection else {
+            return Ok(Vec::new());
+        };
         self.apply_ttl_expiry_projection(projection, expiring_records);
         Ok(expired)
     }
@@ -1294,6 +1303,7 @@ mod tests {
         let chunk = |da_id, index, payload: &[u8], wire_bytes| DaRelayChunk { da_id, chunk_hash: sha3_256(payload), peer_quota_key: pk.clone(), chunk_index: index, payload: Arc::from(payload), wire_bytes, tx_bytes: Arc::from([]) };
         let mut state = DaRelayState::new(DaRelayCaps::default()).unwrap(); state.stage_incomplete_da_chunk(peer, chunk([3; 32], 0, b"orphan", 6)).unwrap(); state.stage_incomplete_da_commit(peer, commit([2; 32], &[b"staged"], 7)).unwrap(); state.stage_incomplete_da_commit(peer, commit([1; 32], &[b"complete"], 8)).unwrap(); state.stage_incomplete_da_chunk(peer, chunk([1; 32], 0, b"complete", 8)).unwrap();
         let complete_before = state.sets_by_da_id[&[1; 32]].clone(); let orphan_before = state.orphan_bytes; assert!(state.advance_orphan_ttl().unwrap().is_empty()); assert_eq!(state.sets_by_da_id[&[3; 32]].ttl_blocks_remaining, 2); assert_eq!(state.sets_by_da_id[&[2; 32]].ttl_blocks_remaining, 2); assert_eq!(state.sets_by_da_id[&[1; 32]], complete_before); assert_eq!(state.orphan_bytes, orphan_before);
+        let mut batch = DaRelayState::new(DaRelayCaps::default()).unwrap(); batch.stage_incomplete_da_chunk(peer, chunk([6; 32], 0, b"batch", 5)).unwrap(); assert!(batch.advance_orphan_ttl_by(0).unwrap().is_empty()); assert_eq!(batch.sets_by_da_id[&[6; 32]].ttl_blocks_remaining, 3); assert!(batch.advance_orphan_ttl_by(2).unwrap().is_empty()); assert_eq!(batch.sets_by_da_id[&[6; 32]].ttl_blocks_remaining, 1); assert_eq!(batch.advance_orphan_ttl_by(2).unwrap(), vec![[6; 32]]); assert!(batch.is_empty());
         state.sets_by_da_id.get_mut(&[3; 32]).unwrap().ttl_blocks_remaining = 1; state.sets_by_da_id.get_mut(&[2; 32]).unwrap().ttl_blocks_remaining = 0; let expired = state.advance_orphan_ttl().unwrap();
         assert_eq!(expired, vec![[2; 32], [3; 32]]);
         assert_eq!(state.sets_by_da_id.get(&[1; 32]), Some(&complete_before)); assert!(!state.sets_by_da_id.contains_key(&[2; 32])); assert!(!state.sets_by_da_id.contains_key(&[3; 32])); assert_eq!(state.orphan_bytes, 0); assert!(state.orphan_bytes_by_da_id.is_empty()); assert!(state.orphan_bytes_by_peer_quota_key.is_empty()); assert_eq!(state.orphan_commit_overhead_bytes, 0); assert_eq!(state.pinned_payload_bytes, complete_before.pinned_payload_accounting_bytes().unwrap()); let before_noop = state.clone(); assert!(state.advance_orphan_ttl().unwrap().is_empty()); assert_eq!(state, before_noop);

--- a/clients/rust/crates/rubin-node/src/da_relay.rs
+++ b/clients/rust/crates/rubin-node/src/da_relay.rs
@@ -496,7 +496,7 @@ impl DaRelayState {
             })
     }
 
-    pub(crate) fn advance_orphan_ttl(&mut self) -> DaRelayResult<Vec<[u8; 32]>> {
+    pub fn advance_orphan_ttl(&mut self) -> DaRelayResult<Vec<[u8; 32]>> {
         let mut decrementing_da_ids = Vec::new();
         let mut expiring_records = Vec::new();
         for da_id in self.orphan_bytes_by_da_id.keys().copied() {

--- a/clients/rust/crates/rubin-node/src/devnet_rpc.rs
+++ b/clients/rust/crates/rubin-node/src/devnet_rpc.rs
@@ -54,7 +54,7 @@ pub struct DevnetRPCState {
     now_unix: fn() -> u64,
     announce_tx: Option<AnnounceTxFn>,
     announce_block: Option<AnnounceBlockFn>,
-    pub accepted_block: Option<AcceptedBlockFn>,
+    accepted_block: Option<AcceptedBlockFn>,
     /// Serializes mutating devnet RPC (submit_tx + mine_next).
     rpc_op_lock: Arc<Mutex<()>>,
     /// When set, POST `/mine_next` mines one block using this config (devnet + loopback RPC only).
@@ -538,6 +538,12 @@ pub fn new_devnet_rpc_state_with_tx_pool(
         // `GET /ready` cannot report 200 before the node is actually
         // serving requests.
         readiness: Arc::new(ReadinessGate::default()),
+    }
+}
+
+impl DevnetRPCState {
+    pub fn set_accepted_block_hook(&mut self, accepted_block: AcceptedBlockFn) {
+        self.accepted_block = Some(accepted_block);
     }
 }
 
@@ -3371,7 +3377,7 @@ mod tests {
         let hook_lock_order = Arc::new(Mutex::new((false, false)));
         let announced_clone = Arc::clone(&announced);
         let accepted_order = Arc::clone(&hook_lock_order); let accepted_lock = Arc::clone(&state.rpc_op_lock);
-        state.accepted_block = Some(Arc::new(move |_| { accepted_order.lock().expect("order lock").0 = accepted_lock.try_lock().is_err(); Err("accepted hook test error".to_string()) }));
+        state.set_accepted_block_hook(Arc::new(move |_| { accepted_order.lock().expect("order lock").0 = accepted_lock.try_lock().is_err(); Err("accepted hook test error".to_string()) }));
         let announce_order = Arc::clone(&hook_lock_order); let announce_lock = Arc::clone(&state.rpc_op_lock);
         state.announce_block = Some(Arc::new(move |block_bytes: &[u8]| { *announced_clone.lock().expect("announce lock") = Some(block_bytes.to_vec()); announce_order.lock().expect("order lock").1 = announce_lock.try_lock().is_ok(); Ok(()) }));
 

--- a/clients/rust/crates/rubin-node/src/devnet_rpc.rs
+++ b/clients/rust/crates/rubin-node/src/devnet_rpc.rs
@@ -3371,16 +3371,33 @@ mod tests {
     }
 
     #[test]
-    #[rustfmt::skip]
     fn mine_next_announces_mined_block_on_success() {
         let (mut state, dir) = build_state_with_live_mining(true);
         let announced = Arc::new(Mutex::new(None::<Vec<u8>>));
         let hook_lock_order = Arc::new(Mutex::new((false, false, false, false)));
         let announced_clone = Arc::clone(&announced);
-        let accepted_order = Arc::clone(&hook_lock_order); let accepted_lock = Arc::clone(&state.rpc_op_lock); let accepted_engine = Arc::clone(&state.sync_engine); let accepted_pool = Arc::clone(&state.tx_pool);
-        state.set_accepted_block_hook(Arc::new(move |_| { let rpc_op_held = accepted_lock.try_lock().is_err(); let engine_free = accepted_engine.try_lock().is_ok(); let pool_free = accepted_pool.try_lock().is_ok(); *accepted_order.lock().expect("order lock") = (rpc_op_held, false, engine_free, pool_free); Err("accepted hook test error".to_string()) }));
-        let announce_order = Arc::clone(&hook_lock_order); let announce_lock = Arc::clone(&state.rpc_op_lock);
-        state.announce_block = Some(Arc::new(move |block_bytes: &[u8]| { *announced_clone.lock().expect("announce lock") = Some(block_bytes.to_vec()); announce_order.lock().expect("order lock").1 = announce_lock.try_lock().is_ok(); Ok(()) }));
+        let accepted_order = Arc::clone(&hook_lock_order);
+        let accepted_lock = Arc::clone(&state.rpc_op_lock);
+        let accepted_engine = Arc::clone(&state.sync_engine);
+        let accepted_pool = Arc::clone(&state.tx_pool);
+        state.set_accepted_block_hook(Arc::new(move |_| {
+            let rpc_op_held = accepted_lock.try_lock().is_err();
+            let engine_free = accepted_engine.try_lock().is_ok();
+            let pool_free = accepted_pool.try_lock().is_ok();
+            // Proof assertion: capture accepted-hook lock state before announce runs.
+            let mut order = accepted_order.lock().expect("order lock");
+            order.0 = rpc_op_held;
+            order.2 = engine_free;
+            order.3 = pool_free;
+            Err("accepted hook test error".to_string())
+        }));
+        let announce_order = Arc::clone(&hook_lock_order);
+        let announce_lock = Arc::clone(&state.rpc_op_lock);
+        state.announce_block = Some(Arc::new(move |block_bytes: &[u8]| {
+            *announced_clone.lock().expect("announce lock") = Some(block_bytes.to_vec());
+            announce_order.lock().expect("order lock").1 = announce_lock.try_lock().is_ok();
+            Ok(())
+        }));
 
         let response = post_mine_next(&state);
 
@@ -3403,7 +3420,9 @@ mod tests {
         let parsed = parse_block_bytes(&block_bytes).expect("parse announced block");
         let announced_hash = block_hash(&parsed.header_bytes).expect("announced block hash");
         assert_eq!(hex::encode(announced_hash), expected_hash);
-        assert_eq!(*hook_lock_order.lock().expect("order lock"), (true, true, true, true));
+        // Proof assertion: accepted hook sees RPC held; announce hook sees it released.
+        let observed_order = *hook_lock_order.lock().expect("order lock");
+        assert_eq!(observed_order, (true, true, true, true));
         fs::remove_dir_all(dir).expect("cleanup");
     }
 

--- a/clients/rust/crates/rubin-node/src/devnet_rpc.rs
+++ b/clients/rust/crates/rubin-node/src/devnet_rpc.rs
@@ -1590,14 +1590,15 @@ fn handle_mine_next(state: &DevnetRPCState, method: &str, _body: &[u8]) -> HttpR
             )
         }
     };
-    if let Some(ref accepted) = state.accepted_block {
-        if let Err(err) = accepted(mined.hash) {
-            eprintln!("rpc: accepted-block: {err}");
-        }
-    }
+    let mined_hash = mined.hash;
     drop(miner);
     drop(pool);
     drop(sync_engine);
+    if let Some(ref accepted) = state.accepted_block {
+        if let Err(err) = accepted(mined_hash) {
+            eprintln!("rpc: accepted-block: {err}");
+        }
+    }
     drop(_rpc_op);
     let block_bytes = match block_store {
         Some(store) => match store.get_block_by_hash(mined.hash) {
@@ -3374,10 +3375,10 @@ mod tests {
     fn mine_next_announces_mined_block_on_success() {
         let (mut state, dir) = build_state_with_live_mining(true);
         let announced = Arc::new(Mutex::new(None::<Vec<u8>>));
-        let hook_lock_order = Arc::new(Mutex::new((false, false)));
+        let hook_lock_order = Arc::new(Mutex::new((false, false, false, false)));
         let announced_clone = Arc::clone(&announced);
-        let accepted_order = Arc::clone(&hook_lock_order); let accepted_lock = Arc::clone(&state.rpc_op_lock);
-        state.set_accepted_block_hook(Arc::new(move |_| { accepted_order.lock().expect("order lock").0 = accepted_lock.try_lock().is_err(); Err("accepted hook test error".to_string()) }));
+        let accepted_order = Arc::clone(&hook_lock_order); let accepted_lock = Arc::clone(&state.rpc_op_lock); let accepted_engine = Arc::clone(&state.sync_engine); let accepted_pool = Arc::clone(&state.tx_pool);
+        state.set_accepted_block_hook(Arc::new(move |_| { let rpc_op_held = accepted_lock.try_lock().is_err(); let engine_free = accepted_engine.try_lock().is_ok(); let pool_free = accepted_pool.try_lock().is_ok(); *accepted_order.lock().expect("order lock") = (rpc_op_held, false, engine_free, pool_free); Err("accepted hook test error".to_string()) }));
         let announce_order = Arc::clone(&hook_lock_order); let announce_lock = Arc::clone(&state.rpc_op_lock);
         state.announce_block = Some(Arc::new(move |block_bytes: &[u8]| { *announced_clone.lock().expect("announce lock") = Some(block_bytes.to_vec()); announce_order.lock().expect("order lock").1 = announce_lock.try_lock().is_ok(); Ok(()) }));
 
@@ -3402,7 +3403,7 @@ mod tests {
         let parsed = parse_block_bytes(&block_bytes).expect("parse announced block");
         let announced_hash = block_hash(&parsed.header_bytes).expect("announced block hash");
         assert_eq!(hex::encode(announced_hash), expected_hash);
-        assert_eq!(*hook_lock_order.lock().expect("order lock"), (true, true));
+        assert_eq!(*hook_lock_order.lock().expect("order lock"), (true, true, true, true));
         fs::remove_dir_all(dir).expect("cleanup");
     }
 

--- a/clients/rust/crates/rubin-node/src/devnet_rpc.rs
+++ b/clients/rust/crates/rubin-node/src/devnet_rpc.rs
@@ -42,6 +42,7 @@ pub const RPC_READINESS_TRANSITION_FAILED: &str =
 pub type AnnounceTxFn =
     Arc<dyn Fn(&[u8], crate::txpool::RelayTxMetadata) -> Result<(), String> + Send + Sync>;
 pub type AnnounceBlockFn = Arc<dyn Fn(&[u8]) -> Result<(), String> + Send + Sync>;
+pub type AcceptedBlockFn = Arc<dyn Fn([u8; 32]) -> Result<(), String> + Send + Sync>;
 
 #[derive(Clone)]
 pub struct DevnetRPCState {
@@ -53,6 +54,7 @@ pub struct DevnetRPCState {
     now_unix: fn() -> u64,
     announce_tx: Option<AnnounceTxFn>,
     announce_block: Option<AnnounceBlockFn>,
+    pub accepted_block: Option<AcceptedBlockFn>,
     /// Serializes mutating devnet RPC (submit_tx + mine_next).
     rpc_op_lock: Arc<Mutex<()>>,
     /// When set, POST `/mine_next` mines one block using this config (devnet + loopback RPC only).
@@ -527,12 +529,13 @@ pub fn new_devnet_rpc_state_with_tx_pool(
         now_unix: current_unix,
         announce_tx,
         announce_block,
+        accepted_block: None,
         rpc_op_lock: Arc::new(Mutex::new(())),
         live_mining_cfg,
         // RUB-10 / GitHub #1151: gate starts in `NotReady`. The
         // `try_mark_ready_on_startup` transition runs inside
         // `start_devnet_rpc_server` after the listener is bound, so
-        // `/ready` cannot report 200 before the node is actually
+        // `GET /ready` cannot report 200 before the node is actually
         // serving requests.
         readiness: Arc::new(ReadinessGate::default()),
     }
@@ -1581,6 +1584,11 @@ fn handle_mine_next(state: &DevnetRPCState, method: &str, _body: &[u8]) -> HttpR
             )
         }
     };
+    if let Some(ref accepted) = state.accepted_block {
+        if let Err(err) = accepted(mined.hash) {
+            eprintln!("rpc: accepted-block: {err}");
+        }
+    }
     drop(miner);
     drop(pool);
     drop(sync_engine);
@@ -3104,6 +3112,7 @@ mod tests {
             now_unix: super::current_unix,
             announce_tx: None,
             announce_block: None,
+            accepted_block: None,
             rpc_op_lock: Arc::new(Mutex::new(())),
             live_mining_cfg: None,
             // RUB-10 / GitHub #1151: this helper bypasses the public
@@ -3355,14 +3364,16 @@ mod tests {
     }
 
     #[test]
+    #[rustfmt::skip]
     fn mine_next_announces_mined_block_on_success() {
         let (mut state, dir) = build_state_with_live_mining(true);
         let announced = Arc::new(Mutex::new(None::<Vec<u8>>));
+        let hook_lock_order = Arc::new(Mutex::new((false, false)));
         let announced_clone = Arc::clone(&announced);
-        state.announce_block = Some(Arc::new(move |block_bytes: &[u8]| {
-            *announced_clone.lock().expect("announce lock") = Some(block_bytes.to_vec());
-            Ok(())
-        }));
+        let accepted_order = Arc::clone(&hook_lock_order); let accepted_lock = Arc::clone(&state.rpc_op_lock);
+        state.accepted_block = Some(Arc::new(move |_| { accepted_order.lock().expect("order lock").0 = accepted_lock.try_lock().is_err(); Err("accepted hook test error".to_string()) }));
+        let announce_order = Arc::clone(&hook_lock_order); let announce_lock = Arc::clone(&state.rpc_op_lock);
+        state.announce_block = Some(Arc::new(move |block_bytes: &[u8]| { *announced_clone.lock().expect("announce lock") = Some(block_bytes.to_vec()); announce_order.lock().expect("order lock").1 = announce_lock.try_lock().is_ok(); Ok(()) }));
 
         let response = post_mine_next(&state);
 
@@ -3385,6 +3396,7 @@ mod tests {
         let parsed = parse_block_bytes(&block_bytes).expect("parse announced block");
         let announced_hash = block_hash(&parsed.header_bytes).expect("announced block hash");
         assert_eq!(hex::encode(announced_hash), expected_hash);
+        assert_eq!(*hook_lock_order.lock().expect("order lock"), (true, true));
         fs::remove_dir_all(dir).expect("cleanup");
     }
 
@@ -4956,6 +4968,7 @@ mod tests {
             now_unix: || 0,
             announce_tx: None,
             announce_block: None,
+            accepted_block: None,
             rpc_op_lock: Arc::new(Mutex::new(())),
             live_mining_cfg: None,
             // RUB-10 / GitHub #1151: render_prometheus_metrics test does

--- a/clients/rust/crates/rubin-node/src/main.rs
+++ b/clients/rust/crates/rubin-node/src/main.rs
@@ -499,39 +499,33 @@ fn run(args: &[String], stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
             )
         }))
     };
+    let da_ttl_relay = p2p_service.da_relay_state();
+    let da_ttl_seen = Arc::new(rubin_node::tx_seen::BoundedHashSet::new(
+        rubin_node::tx_seen::DEFAULT_BLOCK_SEEN_CAPACITY,
+    ));
     let announce_block: Option<rubin_node::devnet_rpc::AnnounceBlockFn> = {
         let relay_state = p2p_service.relay_state();
-        let da_relay = p2p_service.da_relay_state();
-        let ttl_seen = Arc::new(rubin_node::tx_seen::BoundedHashSet::new(
-            rubin_node::tx_seen::DEFAULT_BLOCK_SEEN_CAPACITY,
-        ));
         let pm = Arc::clone(&peer_manager);
         let pw = p2p_service.peer_outboxes();
         let local = p2p_service.addr().to_string();
         Some(Arc::new(move |block_bytes: &[u8]| {
-            announce_block_after_local_acceptance(
-                block_bytes,
-                &relay_state,
-                &pm,
-                &local,
-                &pw,
-                &da_relay,
-                &ttl_seen,
-            )
+            rubin_node::tx_relay::announce_block(block_bytes, &relay_state, &pm, &local, &pw)
         }))
     };
-    let state = attach_shutdown_signal_to_devnet_rpc_state(
-        new_devnet_rpc_state_with_tx_pool(
-            Arc::clone(&sync_engine),
-            Some(block_store),
-            Arc::clone(&tx_pool),
-            Arc::clone(&peer_manager),
-            announce_tx,
-            announce_block,
-            live_mining_cfg,
-        ),
-        stop_signal.shutdown_requested_flag(),
+    let mut state = new_devnet_rpc_state_with_tx_pool(
+        Arc::clone(&sync_engine),
+        Some(block_store),
+        Arc::clone(&tx_pool),
+        Arc::clone(&peer_manager),
+        announce_tx,
+        announce_block,
+        live_mining_cfg,
     );
+    state.accepted_block = Some(Arc::new(move |hash| {
+        advance_da_ttl_for_block(hash, &da_ttl_relay, &da_ttl_seen)
+    }));
+    let state =
+        attach_shutdown_signal_to_devnet_rpc_state(state, stop_signal.shutdown_requested_flag());
     if !cfg.rpc_bind_addr.trim().is_empty() {
         server = match start_devnet_rpc_server(&cfg.rpc_bind_addr, state) {
             Ok(server) => Some(server),
@@ -1289,38 +1283,21 @@ fn announce_tx_after_local_admission(
     )
 }
 
-fn announce_block_after_local_acceptance(
-    block_bytes: &[u8],
-    relay_state: &rubin_node::tx_relay::TxRelayState,
-    peer_manager: &rubin_node::p2p_runtime::PeerManager,
-    local_addr: &str,
-    peer_writers: &Mutex<std::collections::HashMap<String, rubin_node::tx_relay::PeerOutbox>>,
+fn advance_da_ttl_for_block(
+    hash: [u8; 32],
     da_relay: &Arc<Mutex<rubin_node::da_relay::DaRelayState>>,
     ttl_seen: &rubin_node::tx_seen::BoundedHashSet,
 ) -> Result<(), String> {
-    let parsed = rubin_consensus::parse_block_bytes(block_bytes).map_err(|err| err.to_string())?;
-    let hash = rubin_consensus::block_hash(&parsed.header_bytes).map_err(|err| err.to_string())?;
-    let announce_result = rubin_node::tx_relay::announce_block(
-        block_bytes,
-        relay_state,
-        peer_manager,
-        local_addr,
-        peer_writers,
-    );
-    let ttl_result = if ttl_seen.add(hash) {
-        da_relay
-            .lock()
-            .map_err(|_| "DA relay lock poisoned during local block TTL advance".to_string())
-            .and_then(|mut da_relay| {
-                da_relay
-                    .advance_orphan_ttl()
-                    .map(|_| ())
-                    .map_err(|err| format!("DA relay TTL advance failed: {err:?}"))
-            })
-    } else {
-        Ok(())
-    };
-    announce_result.and(ttl_result)
+    if !ttl_seen.add(hash) {
+        return Ok(());
+    }
+    let mut da_relay = da_relay
+        .lock()
+        .map_err(|_| "DA relay lock poisoned during local block TTL advance".to_string())?;
+    da_relay
+        .advance_orphan_ttl()
+        .map(|_| ())
+        .map_err(|err| format!("DA relay TTL advance failed: {err:?}"))
 }
 
 #[cfg(test)]
@@ -1333,8 +1310,8 @@ mod tests {
     use std::{cell::RefCell, rc::Rc};
 
     use super::{
-        announce_block_after_local_acceptance, announce_tx_after_local_admission,
-        format_peer_slots_banner, handle_rpc_start_error_after_maybe_stop, legacy_exposure_hooks,
+        advance_da_ttl_for_block, announce_tx_after_local_admission, format_peer_slots_banner,
+        handle_rpc_start_error_after_maybe_stop, legacy_exposure_hooks,
         maybe_shutdown_if_requested, parse_args, run, runtime_genesis_hash, stop_signal_pair,
         validate_config, wait_for_stop_and_shutdown, LegacyExposureReport,
         PRODUCTION_STOP_SIGNAL_SET, RPC_READINESS_TRANSITION_FAILED,
@@ -1420,12 +1397,6 @@ mod tests {
         marshal_tx(&Tx { version: TX_WIRE_VERSION, tx_kind: 0x00, tx_nonce: 3, inputs: Vec::new(), outputs: Vec::new(), locktime: 0, da_commit_core: None, da_chunk_core: None, witness: Vec::new(), da_payload: Vec::new() }).expect("marshal local non-DA tx")
     }
 
-    fn local_block_variant(nonce: u64) -> Vec<u8> {
-        let mut block = rubin_node::devnet_genesis_block_bytes();
-        block[108..116].copy_from_slice(&nonce.to_le_bytes());
-        block
-    }
-
     struct LocalDaTestContext {
         relay: TxRelayState,
         peers: rubin_node::PeerManager,
@@ -1447,18 +1418,6 @@ mod tests {
                 "local:8333",
                 &self.outboxes,
                 &self.da_relay,
-            )
-        }
-
-        fn announce_block(&self, block_bytes: &[u8]) -> Result<(), String> {
-            announce_block_after_local_acceptance(
-                block_bytes,
-                &self.relay,
-                &self.peers,
-                "local:8333",
-                &self.outboxes,
-                &self.da_relay,
-                &self.ttl_seen,
             )
         }
     }
@@ -1509,13 +1468,12 @@ mod tests {
 
     #[test]
     #[rustfmt::skip]
-    fn local_block_announce_advances_da_ttl_after_success_only() {
+    fn local_accepted_block_advances_da_ttl_without_broadcast_coupling() {
         let da_id = [0x51; 32]; let chunk_tx = local_da_chunk_tx(da_id, b"local-block-ttl");
         let ctx = local_da_test_context_with_peers(&["peer:8333"]); ctx.announce(&chunk_tx).expect("stage local DA orphan");
-        ctx.announce_block(&local_block_variant(1)).expect("local block announce"); ctx.announce_block(&local_block_variant(1)).expect("duplicate block announce"); ctx.announce_block(&local_block_variant(2)).expect("second local block announce"); assert!(!ctx.da_relay.lock().unwrap().is_empty()); ctx.announce_block(&local_block_variant(3)).expect("third local block announce"); assert!(ctx.da_relay.lock().unwrap().is_empty());
-        let ctx = local_da_test_context(); ctx.announce(&chunk_tx).expect("stage no-peer DA orphan"); ctx.announce_block(&local_block_variant(10)).expect("no-peer local block"); ctx.announce_block(&local_block_variant(10)).expect("duplicate no-peer local block"); ctx.announce_block(&local_block_variant(11)).expect("second no-peer local block"); assert!(!ctx.da_relay.lock().unwrap().is_empty()); ctx.announce_block(&local_block_variant(12)).expect("third no-peer local block"); assert!(ctx.da_relay.lock().unwrap().is_empty());
-        let ctx = local_da_test_context_with_peers(&["healthy:8333"]); ctx.announce(&chunk_tx).expect("stage failed-announce DA orphan"); ctx.peers.add_peer(rubin_node::p2p_runtime::PeerState { addr: "missing:8333".to_string(), ..Default::default() }).expect("add missing peer"); let failed = local_block_variant(20); let failed_hash = rubin_consensus::block_hash(&rubin_consensus::parse_block_bytes(&failed).unwrap().header_bytes).unwrap();
-        assert!(ctx.announce_block(&failed).is_err()); assert!(ctx.announce_block(&failed).is_err()); assert!(!ctx.relay.block_seen.has(&failed_hash)); assert!(!ctx.da_relay.lock().unwrap().is_empty()); assert!(ctx.announce_block(&local_block_variant(21)).is_err()); assert!(!ctx.da_relay.lock().unwrap().is_empty()); assert!(ctx.announce_block(&local_block_variant(22)).is_err()); assert!(ctx.da_relay.lock().unwrap().is_empty());
+        advance_da_ttl_for_block([1; 32], &ctx.da_relay, &ctx.ttl_seen).expect("local block accepted"); advance_da_ttl_for_block([1; 32], &ctx.da_relay, &ctx.ttl_seen).expect("duplicate accepted block"); advance_da_ttl_for_block([2; 32], &ctx.da_relay, &ctx.ttl_seen).expect("second accepted block"); assert!(!ctx.da_relay.lock().unwrap().is_empty()); advance_da_ttl_for_block([3; 32], &ctx.da_relay, &ctx.ttl_seen).expect("third accepted block"); assert!(ctx.da_relay.lock().unwrap().is_empty());
+        let ctx = local_da_test_context_with_peers(&["healthy:8333"]); ctx.announce(&chunk_tx).expect("stage failed-announce DA orphan"); ctx.peers.add_peer(rubin_node::p2p_runtime::PeerState { addr: "missing:8333".to_string(), ..Default::default() }).expect("add missing peer"); let failed = rubin_node::devnet_genesis_block_bytes(); let failed_hash = rubin_consensus::block_hash(&rubin_consensus::parse_block_bytes(&failed).unwrap().header_bytes).unwrap();
+        advance_da_ttl_for_block(failed_hash, &ctx.da_relay, &ctx.ttl_seen).expect("failed announce block accepted"); assert!(rubin_node::tx_relay::announce_block(&failed, &ctx.relay, &ctx.peers, "local:8333", &ctx.outboxes).is_err()); assert!(rubin_node::tx_relay::announce_block(&failed, &ctx.relay, &ctx.peers, "local:8333", &ctx.outboxes).is_err()); assert!(!ctx.relay.block_seen.has(&failed_hash)); assert!(!ctx.da_relay.lock().unwrap().is_empty()); advance_da_ttl_for_block([21; 32], &ctx.da_relay, &ctx.ttl_seen).expect("second failed block accepted"); assert!(!ctx.da_relay.lock().unwrap().is_empty()); advance_da_ttl_for_block([22; 32], &ctx.da_relay, &ctx.ttl_seen).expect("third failed block accepted"); assert!(ctx.da_relay.lock().unwrap().is_empty());
     }
 
     /// RUB-13 / GitHub #1157: stdout helper for tests that parse the

--- a/clients/rust/crates/rubin-node/src/main.rs
+++ b/clients/rust/crates/rubin-node/src/main.rs
@@ -1291,13 +1291,7 @@ fn advance_da_ttl_for_block(
     if !ttl_seen.add(hash) {
         return Ok(());
     }
-    let mut da_relay = da_relay
-        .lock()
-        .map_err(|_| "DA relay lock poisoned during local block TTL advance".to_string())?;
-    da_relay
-        .advance_orphan_ttl()
-        .map(|_| ())
-        .map_err(|err| format!("DA relay TTL advance failed: {err:?}"))
+    rubin_node::p2p_service::advance_da_orphan_ttl_for_accepted_block(da_relay)
 }
 
 #[cfg(test)]

--- a/clients/rust/crates/rubin-node/src/main.rs
+++ b/clients/rust/crates/rubin-node/src/main.rs
@@ -501,11 +501,23 @@ fn run(args: &[String], stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
     };
     let announce_block: Option<rubin_node::devnet_rpc::AnnounceBlockFn> = {
         let relay_state = p2p_service.relay_state();
+        let da_relay = p2p_service.da_relay_state();
+        let ttl_seen = Arc::new(rubin_node::tx_seen::BoundedHashSet::new(
+            rubin_node::tx_seen::DEFAULT_BLOCK_SEEN_CAPACITY,
+        ));
         let pm = Arc::clone(&peer_manager);
         let pw = p2p_service.peer_outboxes();
         let local = p2p_service.addr().to_string();
         Some(Arc::new(move |block_bytes: &[u8]| {
-            rubin_node::tx_relay::announce_block(block_bytes, &relay_state, &pm, &local, &pw)
+            announce_block_after_local_acceptance(
+                block_bytes,
+                &relay_state,
+                &pm,
+                &local,
+                &pw,
+                &da_relay,
+                &ttl_seen,
+            )
         }))
     };
     let state = attach_shutdown_signal_to_devnet_rpc_state(
@@ -1277,6 +1289,40 @@ fn announce_tx_after_local_admission(
     )
 }
 
+fn announce_block_after_local_acceptance(
+    block_bytes: &[u8],
+    relay_state: &rubin_node::tx_relay::TxRelayState,
+    peer_manager: &rubin_node::p2p_runtime::PeerManager,
+    local_addr: &str,
+    peer_writers: &Mutex<std::collections::HashMap<String, rubin_node::tx_relay::PeerOutbox>>,
+    da_relay: &Arc<Mutex<rubin_node::da_relay::DaRelayState>>,
+    ttl_seen: &rubin_node::tx_seen::BoundedHashSet,
+) -> Result<(), String> {
+    let parsed = rubin_consensus::parse_block_bytes(block_bytes).map_err(|err| err.to_string())?;
+    let hash = rubin_consensus::block_hash(&parsed.header_bytes).map_err(|err| err.to_string())?;
+    let announce_result = rubin_node::tx_relay::announce_block(
+        block_bytes,
+        relay_state,
+        peer_manager,
+        local_addr,
+        peer_writers,
+    );
+    let ttl_result = if ttl_seen.add(hash) {
+        da_relay
+            .lock()
+            .map_err(|_| "DA relay lock poisoned during local block TTL advance".to_string())
+            .and_then(|mut da_relay| {
+                da_relay
+                    .advance_orphan_ttl()
+                    .map(|_| ())
+                    .map_err(|err| format!("DA relay TTL advance failed: {err:?}"))
+            })
+    } else {
+        Ok(())
+    };
+    announce_result.and(ttl_result)
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
@@ -1287,8 +1333,8 @@ mod tests {
     use std::{cell::RefCell, rc::Rc};
 
     use super::{
-        announce_tx_after_local_admission, format_peer_slots_banner,
-        handle_rpc_start_error_after_maybe_stop, legacy_exposure_hooks,
+        announce_block_after_local_acceptance, announce_tx_after_local_admission,
+        format_peer_slots_banner, handle_rpc_start_error_after_maybe_stop, legacy_exposure_hooks,
         maybe_shutdown_if_requested, parse_args, run, runtime_genesis_hash, stop_signal_pair,
         validate_config, wait_for_stop_and_shutdown, LegacyExposureReport,
         PRODUCTION_STOP_SIGNAL_SET, RPC_READINESS_TRANSITION_FAILED,
@@ -1374,11 +1420,18 @@ mod tests {
         marshal_tx(&Tx { version: TX_WIRE_VERSION, tx_kind: 0x00, tx_nonce: 3, inputs: Vec::new(), outputs: Vec::new(), locktime: 0, da_commit_core: None, da_chunk_core: None, witness: Vec::new(), da_payload: Vec::new() }).expect("marshal local non-DA tx")
     }
 
+    fn local_block_variant(nonce: u64) -> Vec<u8> {
+        let mut block = rubin_node::devnet_genesis_block_bytes();
+        block[108..116].copy_from_slice(&nonce.to_le_bytes());
+        block
+    }
+
     struct LocalDaTestContext {
         relay: TxRelayState,
         peers: rubin_node::PeerManager,
         outboxes: Mutex<HashMap<String, PeerOutbox>>,
         da_relay: Arc<Mutex<DaRelayState>>,
+        ttl_seen: rubin_node::tx_seen::BoundedHashSet,
     }
 
     impl LocalDaTestContext {
@@ -1396,19 +1449,29 @@ mod tests {
                 &self.da_relay,
             )
         }
+
+        fn announce_block(&self, block_bytes: &[u8]) -> Result<(), String> {
+            announce_block_after_local_acceptance(
+                block_bytes,
+                &self.relay,
+                &self.peers,
+                "local:8333",
+                &self.outboxes,
+                &self.da_relay,
+                &self.ttl_seen,
+            )
+        }
     }
 
     fn local_da_test_context() -> LocalDaTestContext {
-        LocalDaTestContext {
-            relay: TxRelayState::new(),
-            peers: rubin_node::PeerManager::new(rubin_node::default_peer_runtime_config(
-                "devnet", 8,
-            )),
-            outboxes: Mutex::new(HashMap::new()),
-            da_relay: Arc::new(Mutex::new(
-                DaRelayState::new(DaRelayCaps::default()).expect("valid DA relay caps"),
-            )),
-        }
+        local_da_test_context_with_peers(&[])
+    }
+
+    #[rustfmt::skip]
+    fn local_da_test_context_with_peers(addrs: &[&str]) -> LocalDaTestContext {
+        let peers = rubin_node::PeerManager::new(rubin_node::default_peer_runtime_config("devnet", 8)); let outboxes = Mutex::new(HashMap::new());
+        for addr in addrs { peers.add_peer(rubin_node::p2p_runtime::PeerState { addr: (*addr).to_string(), ..Default::default() }).expect("add peer"); outboxes.lock().unwrap().insert((*addr).to_string(), PeerOutbox::default()); }
+        LocalDaTestContext { relay: TxRelayState::new(), peers, outboxes, da_relay: Arc::new(Mutex::new(DaRelayState::new(DaRelayCaps::default()).expect("valid DA relay caps"))), ttl_seen: rubin_node::tx_seen::BoundedHashSet::new(rubin_node::tx_seen::DEFAULT_BLOCK_SEEN_CAPACITY) }
     }
 
     #[test]
@@ -1442,6 +1505,17 @@ mod tests {
             .expect_err("bad local DA chunk must not relay");
         assert!(err.contains("ChunkHashMismatch"), "{err}");
         assert!(ctx.da_relay.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    #[rustfmt::skip]
+    fn local_block_announce_advances_da_ttl_after_success_only() {
+        let da_id = [0x51; 32]; let chunk_tx = local_da_chunk_tx(da_id, b"local-block-ttl");
+        let ctx = local_da_test_context_with_peers(&["peer:8333"]); ctx.announce(&chunk_tx).expect("stage local DA orphan");
+        ctx.announce_block(&local_block_variant(1)).expect("local block announce"); ctx.announce_block(&local_block_variant(1)).expect("duplicate block announce"); ctx.announce_block(&local_block_variant(2)).expect("second local block announce"); assert!(!ctx.da_relay.lock().unwrap().is_empty()); ctx.announce_block(&local_block_variant(3)).expect("third local block announce"); assert!(ctx.da_relay.lock().unwrap().is_empty());
+        let ctx = local_da_test_context(); ctx.announce(&chunk_tx).expect("stage no-peer DA orphan"); ctx.announce_block(&local_block_variant(10)).expect("no-peer local block"); ctx.announce_block(&local_block_variant(10)).expect("duplicate no-peer local block"); ctx.announce_block(&local_block_variant(11)).expect("second no-peer local block"); assert!(!ctx.da_relay.lock().unwrap().is_empty()); ctx.announce_block(&local_block_variant(12)).expect("third no-peer local block"); assert!(ctx.da_relay.lock().unwrap().is_empty());
+        let ctx = local_da_test_context_with_peers(&["healthy:8333"]); ctx.announce(&chunk_tx).expect("stage failed-announce DA orphan"); ctx.peers.add_peer(rubin_node::p2p_runtime::PeerState { addr: "missing:8333".to_string(), ..Default::default() }).expect("add missing peer"); let failed = local_block_variant(20); let failed_hash = rubin_consensus::block_hash(&rubin_consensus::parse_block_bytes(&failed).unwrap().header_bytes).unwrap();
+        assert!(ctx.announce_block(&failed).is_err()); assert!(ctx.announce_block(&failed).is_err()); assert!(!ctx.relay.block_seen.has(&failed_hash)); assert!(!ctx.da_relay.lock().unwrap().is_empty()); assert!(ctx.announce_block(&local_block_variant(21)).is_err()); assert!(!ctx.da_relay.lock().unwrap().is_empty()); assert!(ctx.announce_block(&local_block_variant(22)).is_err()); assert!(ctx.da_relay.lock().unwrap().is_empty());
     }
 
     /// RUB-13 / GitHub #1157: stdout helper for tests that parse the

--- a/clients/rust/crates/rubin-node/src/main.rs
+++ b/clients/rust/crates/rubin-node/src/main.rs
@@ -521,7 +521,7 @@ fn run(args: &[String], stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
         announce_block,
         live_mining_cfg,
     );
-    state.accepted_block = Some(Arc::new(move |hash| {
+    state.set_accepted_block_hook(Arc::new(move |hash| {
         advance_da_ttl_for_block(hash, &da_ttl_relay, &da_ttl_seen)
     }));
     let state =

--- a/clients/rust/crates/rubin-node/src/main.rs
+++ b/clients/rust/crates/rubin-node/src/main.rs
@@ -1420,11 +1420,33 @@ mod tests {
         local_da_test_context_with_peers(&[])
     }
 
-    #[rustfmt::skip]
     fn local_da_test_context_with_peers(addrs: &[&str]) -> LocalDaTestContext {
-        let peers = rubin_node::PeerManager::new(rubin_node::default_peer_runtime_config("devnet", 8)); let outboxes = Mutex::new(HashMap::new());
-        for addr in addrs { peers.add_peer(rubin_node::p2p_runtime::PeerState { addr: (*addr).to_string(), ..Default::default() }).expect("add peer"); outboxes.lock().unwrap().insert((*addr).to_string(), PeerOutbox::default()); }
-        LocalDaTestContext { relay: TxRelayState::new(), peers, outboxes, da_relay: Arc::new(Mutex::new(DaRelayState::new(DaRelayCaps::default()).expect("valid DA relay caps"))), ttl_seen: rubin_node::tx_seen::BoundedHashSet::new(rubin_node::tx_seen::DEFAULT_BLOCK_SEEN_CAPACITY) }
+        let peers =
+            rubin_node::PeerManager::new(rubin_node::default_peer_runtime_config("devnet", 8));
+        let outboxes = Mutex::new(HashMap::new());
+        for addr in addrs {
+            peers
+                .add_peer(rubin_node::p2p_runtime::PeerState {
+                    addr: (*addr).to_string(),
+                    ..Default::default()
+                })
+                .expect("add peer");
+            outboxes
+                .lock()
+                .unwrap()
+                .insert((*addr).to_string(), PeerOutbox::default());
+        }
+        LocalDaTestContext {
+            relay: TxRelayState::new(),
+            peers,
+            outboxes,
+            da_relay: Arc::new(Mutex::new(
+                DaRelayState::new(DaRelayCaps::default()).expect("valid DA relay caps"),
+            )),
+            ttl_seen: rubin_node::tx_seen::BoundedHashSet::new(
+                rubin_node::tx_seen::DEFAULT_BLOCK_SEEN_CAPACITY,
+            ),
+        }
     }
 
     #[test]
@@ -1461,13 +1483,69 @@ mod tests {
     }
 
     #[test]
-    #[rustfmt::skip]
     fn local_accepted_block_advances_da_ttl_without_broadcast_coupling() {
-        let da_id = [0x51; 32]; let chunk_tx = local_da_chunk_tx(da_id, b"local-block-ttl");
-        let ctx = local_da_test_context_with_peers(&["peer:8333"]); ctx.announce(&chunk_tx).expect("stage local DA orphan");
-        advance_da_ttl_for_block([1; 32], &ctx.da_relay, &ctx.ttl_seen).expect("local block accepted"); advance_da_ttl_for_block([1; 32], &ctx.da_relay, &ctx.ttl_seen).expect("duplicate accepted block"); advance_da_ttl_for_block([2; 32], &ctx.da_relay, &ctx.ttl_seen).expect("second accepted block"); assert!(!ctx.da_relay.lock().unwrap().is_empty()); advance_da_ttl_for_block([3; 32], &ctx.da_relay, &ctx.ttl_seen).expect("third accepted block"); assert!(ctx.da_relay.lock().unwrap().is_empty());
-        let ctx = local_da_test_context_with_peers(&["healthy:8333"]); ctx.announce(&chunk_tx).expect("stage failed-announce DA orphan"); ctx.peers.add_peer(rubin_node::p2p_runtime::PeerState { addr: "missing:8333".to_string(), ..Default::default() }).expect("add missing peer"); let failed = rubin_node::devnet_genesis_block_bytes(); let failed_hash = rubin_consensus::block_hash(&rubin_consensus::parse_block_bytes(&failed).unwrap().header_bytes).unwrap();
-        advance_da_ttl_for_block(failed_hash, &ctx.da_relay, &ctx.ttl_seen).expect("failed announce block accepted"); assert!(rubin_node::tx_relay::announce_block(&failed, &ctx.relay, &ctx.peers, "local:8333", &ctx.outboxes).is_err()); assert!(rubin_node::tx_relay::announce_block(&failed, &ctx.relay, &ctx.peers, "local:8333", &ctx.outboxes).is_err()); assert!(!ctx.relay.block_seen.has(&failed_hash)); assert!(!ctx.da_relay.lock().unwrap().is_empty()); advance_da_ttl_for_block([21; 32], &ctx.da_relay, &ctx.ttl_seen).expect("second failed block accepted"); assert!(!ctx.da_relay.lock().unwrap().is_empty()); advance_da_ttl_for_block([22; 32], &ctx.da_relay, &ctx.ttl_seen).expect("third failed block accepted"); assert!(ctx.da_relay.lock().unwrap().is_empty());
+        let da_id = [0x51; 32];
+        let chunk_tx = local_da_chunk_tx(da_id, b"local-block-ttl");
+
+        let ctx = local_da_test_context_with_peers(&["peer:8333"]);
+        ctx.announce(&chunk_tx).expect("stage local DA orphan");
+        for (hash, label) in [
+            ([1; 32], "local block accepted"),
+            ([1; 32], "duplicate accepted block"),
+            ([2; 32], "second accepted block"),
+        ] {
+            advance_da_ttl_for_block(hash, &ctx.da_relay, &ctx.ttl_seen).expect(label);
+        }
+        assert!(!ctx.da_relay.lock().unwrap().is_empty());
+        advance_da_ttl_for_block([3; 32], &ctx.da_relay, &ctx.ttl_seen)
+            .expect("third accepted block");
+        assert!(ctx.da_relay.lock().unwrap().is_empty());
+
+        let ctx = local_da_test_context_with_peers(&["healthy:8333"]);
+        ctx.announce(&chunk_tx)
+            .expect("stage failed-announce DA orphan");
+        ctx.peers
+            .add_peer(rubin_node::p2p_runtime::PeerState {
+                addr: "missing:8333".to_string(),
+                ..Default::default()
+            })
+            .expect("add missing peer");
+        let failed = rubin_node::devnet_genesis_block_bytes();
+        let failed_hash = rubin_consensus::block_hash(
+            &rubin_consensus::parse_block_bytes(&failed)
+                .unwrap()
+                .header_bytes,
+        )
+        .unwrap();
+
+        advance_da_ttl_for_block(failed_hash, &ctx.da_relay, &ctx.ttl_seen)
+            .expect("failed announce block accepted");
+        assert!(rubin_node::tx_relay::announce_block(
+            &failed,
+            &ctx.relay,
+            &ctx.peers,
+            "local:8333",
+            &ctx.outboxes
+        )
+        .is_err());
+        assert!(rubin_node::tx_relay::announce_block(
+            &failed,
+            &ctx.relay,
+            &ctx.peers,
+            "local:8333",
+            &ctx.outboxes
+        )
+        .is_err());
+        assert!(!ctx.relay.block_seen.has(&failed_hash));
+        assert!(!ctx.da_relay.lock().unwrap().is_empty());
+        for (hash, label, remains) in [
+            ([21; 32], "second failed block accepted", true),
+            ([22; 32], "third failed block accepted", false),
+        ] {
+            advance_da_ttl_for_block(hash, &ctx.da_relay, &ctx.ttl_seen).expect(label);
+            assert_eq!(!ctx.da_relay.lock().unwrap().is_empty(), remains);
+        }
+        assert!(ctx.da_relay.lock().unwrap().is_empty());
     }
 
     /// RUB-13 / GitHub #1157: stdout helper for tests that parse the

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -251,6 +251,12 @@ pub struct LiveMessageOutcome {
     pub tx_pool_cleanup: TxPoolCleanupPlan,
 }
 
+#[derive(Debug, Default)]
+struct RelayedBlockOutcome {
+    tx_pool_cleanup: TxPoolCleanupPlan,
+    accepted_blocks: usize,
+}
+
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 struct CompactModeSnapshot {
     mode: u8,
@@ -743,18 +749,20 @@ impl PeerSession {
                 }
             }
             MESSAGE_BLOCK => {
-                let tx_pool_cleanup = self.handle_block(&msg.payload, sync_engine)?;
+                let block =
+                    self.handle_block_with_acceptance(&msg.payload, sync_engine, relay_ctx)?;
+                self.advance_da_orphan_ttl_for_accepted_blocks(relay_ctx, block.accepted_blocks);
                 Ok(LiveMessageOutcome {
                     responses: self
                         .prepare_block_request_if_behind(sync_engine)?
                         .into_iter()
                         .collect(),
-                    tx_pool_cleanup,
+                    tx_pool_cleanup: block.tx_pool_cleanup,
                 })
             }
             "cmpctblock" => self.handle_cmpctblock(&msg.payload, sync_engine, relay_ctx),
             MESSAGE_GETBLOCKTXN => self.handle_getblocktxn(&msg.payload, sync_engine),
-            MESSAGE_BLOCKTXN => self.handle_blocktxn(&msg.payload, sync_engine),
+            MESSAGE_BLOCKTXN => self.handle_blocktxn(&msg.payload, sync_engine, relay_ctx),
             MESSAGE_TX => {
                 if let Some(ctx) = relay_ctx {
                     let hash_checked = !skip_da(&msg.payload, ctx.relay_state, ctx.tx_pool);
@@ -978,6 +986,7 @@ impl PeerSession {
                 &result.transactions,
                 sync_engine,
                 !block.short_ids.is_empty(),
+                relay_ctx,
             );
         }
         self.request_missing_compact_transactions(block, block_hash, result)
@@ -1080,6 +1089,7 @@ impl PeerSession {
         &mut self,
         payload: &[u8],
         sync_engine: &mut SyncEngine,
+        relay_ctx: Option<&PeerRelayContext<'_>>,
     ) -> io::Result<LiveMessageOutcome> {
         if !self.cfg.enable_compact_receive {
             return Ok(LiveMessageOutcome::default());
@@ -1151,7 +1161,14 @@ impl PeerSession {
                 return Err(err);
             }
         };
-        self.process_compact_transactions(req.block_hash, req.header, &txs, sync_engine, true)
+        self.process_compact_transactions(
+            req.block_hash,
+            req.header,
+            &txs,
+            sync_engine,
+            true,
+            relay_ctx,
+        )
     }
     fn process_compact_transactions(
         &mut self,
@@ -1160,6 +1177,7 @@ impl PeerSession {
         txs: &[Vec<u8>],
         sync_engine: &mut SyncEngine,
         fallback_on_apply_error: bool,
+        relay_ctx: Option<&PeerRelayContext<'_>>,
     ) -> io::Result<LiveMessageOutcome> {
         let block_bytes = match compact_block_bytes(header, txs) {
             Ok(block_bytes) => block_bytes,
@@ -1167,15 +1185,16 @@ impl PeerSession {
                 return self.request_compact_full_block_fallback(expected_hash);
             }
         };
-        match self.handle_block(&block_bytes, sync_engine) {
-            Ok(tx_pool_cleanup) => {
+        match self.handle_block_with_acceptance(&block_bytes, sync_engine, relay_ctx) {
+            Ok(block) => {
+                self.advance_da_orphan_ttl_for_accepted_blocks(relay_ctx, block.accepted_blocks);
                 self.clear_compact_outstanding_request_for_block(expected_hash);
                 Ok(LiveMessageOutcome {
                     responses: self
                         .prepare_block_request_if_behind(sync_engine)?
                         .into_iter()
                         .collect(),
-                    tx_pool_cleanup,
+                    tx_pool_cleanup: block.tx_pool_cleanup,
                 })
             }
             Err(err) => {
@@ -1329,6 +1348,17 @@ impl PeerSession {
         block_bytes: &[u8],
         sync_engine: &mut SyncEngine,
     ) -> io::Result<TxPoolCleanupPlan> {
+        Ok(self
+            .handle_block_with_acceptance(block_bytes, sync_engine, None)?
+            .tx_pool_cleanup)
+    }
+
+    fn handle_block_with_acceptance(
+        &mut self,
+        block_bytes: &[u8],
+        sync_engine: &mut SyncEngine,
+        relay_ctx: Option<&PeerRelayContext<'_>>,
+    ) -> io::Result<RelayedBlockOutcome> {
         let parsed = parse_block_bytes(block_bytes).map_err(io::Error::other)?;
         let block_hash_bytes = block_hash(&parsed.header_bytes).map_err(io::Error::other)?;
         self.clear_compact_outstanding_request_for_block(block_hash_bytes);
@@ -1336,7 +1366,7 @@ impl PeerSession {
             .has_block(block_hash_bytes)
             .map_err(io::Error::other)?
         {
-            return Ok(TxPoolCleanupPlan::default());
+            return Ok(RelayedBlockOutcome::default());
         }
         if parsed.header.prev_block_hash != [0u8; 32]
             && !sync_engine
@@ -1348,19 +1378,28 @@ impl PeerSession {
                 parsed.header.prev_block_hash,
                 block_bytes,
                 sync_engine,
+                relay_ctx,
             );
         }
         match sync_engine.apply_block_with_reorg(block_bytes, None) {
             Ok(outcome) => {
                 sync_engine.record_best_known_height(outcome.summary.block_height);
                 let mut tx_pool_cleanup = outcome.tx_pool_cleanup;
-                if let Err(err) =
-                    self.resolve_orphans(block_hash_bytes, sync_engine, &mut tx_pool_cleanup)
-                {
+                let mut accepted_blocks = 1;
+                if let Err(err) = self.resolve_orphans(
+                    block_hash_bytes,
+                    sync_engine,
+                    &mut tx_pool_cleanup,
+                    &mut accepted_blocks,
+                ) {
                     self.stash_pending_tx_pool_cleanup(tx_pool_cleanup);
+                    self.advance_da_orphan_ttl_for_accepted_blocks(relay_ctx, accepted_blocks);
                     return Err(err);
                 }
-                Ok(tx_pool_cleanup)
+                Ok(RelayedBlockOutcome {
+                    tx_pool_cleanup,
+                    accepted_blocks,
+                })
             }
             Err(err) if is_parent_not_found_err(&err) => Err(io::Error::other(format!(
                 "unexpected missing-parent after precheck: {err}"
@@ -1375,7 +1414,8 @@ impl PeerSession {
         parent_hash: [u8; 32],
         block_bytes: &[u8],
         sync_engine: &mut SyncEngine,
-    ) -> io::Result<TxPoolCleanupPlan> {
+        relay_ctx: Option<&PeerRelayContext<'_>>,
+    ) -> io::Result<RelayedBlockOutcome> {
         self.orphans.add(
             block_hash,
             parent_hash,
@@ -1387,13 +1427,23 @@ impl PeerSession {
             .map_err(io::Error::other)?
         {
             let mut tx_pool_cleanup = TxPoolCleanupPlan::default();
-            if let Err(err) = self.resolve_orphans(parent_hash, sync_engine, &mut tx_pool_cleanup) {
+            let mut accepted_blocks = 0;
+            if let Err(err) = self.resolve_orphans(
+                parent_hash,
+                sync_engine,
+                &mut tx_pool_cleanup,
+                &mut accepted_blocks,
+            ) {
                 self.stash_pending_tx_pool_cleanup(tx_pool_cleanup);
+                self.advance_da_orphan_ttl_for_accepted_blocks(relay_ctx, accepted_blocks);
                 return Err(err);
             }
-            return Ok(tx_pool_cleanup);
+            return Ok(RelayedBlockOutcome {
+                tx_pool_cleanup,
+                accepted_blocks,
+            });
         }
-        Ok(TxPoolCleanupPlan::default())
+        Ok(RelayedBlockOutcome::default())
     }
 
     fn resolve_orphans(
@@ -1401,6 +1451,7 @@ impl PeerSession {
         parent_hash: [u8; 32],
         sync_engine: &mut SyncEngine,
         tx_pool_cleanup: &mut TxPoolCleanupPlan,
+        accepted_blocks: &mut usize,
     ) -> io::Result<()> {
         let mut ready = self.orphans.take_children(parent_hash);
         while let Some(child) = ready.pop() {
@@ -1409,6 +1460,7 @@ impl PeerSession {
                     sync_engine.record_best_known_height(outcome.summary.block_height);
                     *tx_pool_cleanup =
                         std::mem::take(tx_pool_cleanup).merge(outcome.tx_pool_cleanup);
+                    *accepted_blocks = accepted_blocks.saturating_add(1);
                     ready.extend(self.orphans.take_children(child.block_hash));
                 }
                 Err(err) if is_parent_not_found_err(&err) => {
@@ -1426,6 +1478,27 @@ impl PeerSession {
             }
         }
         Ok(())
+    }
+
+    fn advance_da_orphan_ttl_for_accepted_blocks(
+        &mut self,
+        relay_ctx: Option<&PeerRelayContext<'_>>,
+        accepted_blocks: usize,
+    ) {
+        let (Some(ctx), true) = (relay_ctx, accepted_blocks > 0) else {
+            return;
+        };
+        let Ok(mut da_relay) = ctx.da_relay.lock() else {
+            self.peer.last_error =
+                "DA relay lock poisoned during accepted-block TTL advance".into();
+            return;
+        };
+        for _ in 0..accepted_blocks {
+            if let Err(err) = da_relay.advance_orphan_ttl() {
+                self.peer.last_error = format!("DA relay TTL advance failed: {err:?}");
+                break;
+            }
+        }
     }
 
     // Historically used by the inline run_block_sync_loop match; preserved
@@ -3426,6 +3499,11 @@ mod tests {
         let admitted_da_id = [0xD1; 32]; let conflicting_da_id = [0xD2; 32]; let bad_da_id = [0xD3; 32]; let admitted = build(7, admitted_da_id, b"admitted da chunk", true); let conflicting = build(8, conflicting_da_id, b"conflicting da chunk", true); let bad = build(9, bad_da_id, b"bad da chunk", false); (state, admitted, conflicting, bad, admitted_da_id, conflicting_da_id, bad_da_id)
     }
 
+    #[rustfmt::skip]
+    fn relay_da_chunk_tx(da_id: [u8; 32], payload: &[u8]) -> Vec<u8> {
+        rubin_consensus::marshal_tx(&rubin_consensus::Tx { version: rubin_consensus::constants::TX_WIRE_VERSION, tx_kind: 0x02, tx_nonce: 11, inputs: Vec::new(), outputs: Vec::new(), locktime: 0, da_commit_core: None, da_chunk_core: Some(rubin_consensus::DaChunkCore { da_id, chunk_index: 0, chunk_hash: Sha3_256::digest(payload).into() }), witness: Vec::new(), da_payload: payload.to_vec() }).expect("marshal DA chunk tx")
+    }
+
     #[derive(Deserialize)]
     struct SharedRuntimeVectors {
         version_payload_v1: SharedVersionPayloadV1,
@@ -4623,7 +4701,7 @@ mod tests {
         assert_eq!(session.peer.ban_score, 0);
         assert_eq!(session.peer.last_error, "ignored late blocktxn response");
         session
-            .handle_blocktxn(&block_hash, &mut test_sync_engine_with_genesis())
+            .handle_blocktxn(&block_hash, &mut test_sync_engine_with_genesis(), None)
             .expect("duplicate hash-only blocktxn");
 
         let stale_hash = [0xe2; 32];
@@ -5391,6 +5469,7 @@ mod tests {
     }
 
     #[test]
+    #[rustfmt::skip]
     fn handle_block_surfaces_invalid_orphan_after_parent_arrives() {
         let _guard = orphan_pool_metrics_test_guard();
         reset_orphan_pool_metrics_for_test();
@@ -5416,6 +5495,9 @@ mod tests {
             );
             block2[36] ^= 0xff; // corrupt merkle root while keeping the block parseable
             let block2_hash = block_hash(&block2[..BLOCK_HEADER_BYTES]).expect("block2 hash");
+            let relay_state = crate::tx_relay::TxRelayState::new(); let peer_manager = PeerManager::new(default_peer_runtime_config("devnet", 8)); let peer_outboxes: Mutex<HashMap<String, crate::tx_relay::PeerOutbox>> = Mutex::new(HashMap::new()); let canonical_tx_pool = Mutex::new(TxPool::new()); let da_relay = Mutex::new(crate::da_relay::DaRelayState::new(crate::da_relay::DaRelayCaps::default()).expect("valid DA relay caps"));
+            let da_id = [0x62; 32]; da_relay.lock().unwrap().stage_relay_da_tx_bytes("peer:8333", relay_da_chunk_tx(da_id, b"peer-partial-error-ttl")).expect("stage DA orphan");
+            let relay_ctx = PeerRelayContext { relay_state: &relay_state, peer_manager: &peer_manager, local_addr: "local:8333", peer_registered_addr: "peer:8333", peer_writers: &peer_outboxes, tx_pool: &canonical_tx_pool, da_relay: &da_relay };
 
             session
                 .handle_block(&block2, &mut engine)
@@ -5435,7 +5517,14 @@ mod tests {
                 "invalid orphan should remain memory-only until parent arrives"
             );
             let err = session
-                .handle_block(&block1, &mut engine)
+                .collect_live_responses(
+                    WireMessage {
+                        command: MESSAGE_BLOCK.to_string(),
+                        payload: block1.clone(),
+                    },
+                    &mut engine,
+                    Some(&relay_ctx),
+                )
                 .expect_err("invalid orphan should surface after parent arrives");
             let pending_cleanup = session.take_pending_tx_pool_cleanup();
 
@@ -5460,6 +5549,11 @@ mod tests {
                 session.take_pending_tx_pool_cleanup().is_empty(),
                 "pending cleanup should drain once observed"
             );
+            let block3 = coinbase_only_block_with_gen(2, subsidy1, block1_hash, genesis.header.timestamp + 3); let block3_hash = block_hash(&block3[..BLOCK_HEADER_BYTES]).expect("block3 hash"); let subsidy2 = rubin_consensus::subsidy::block_subsidy(2, u128::from(subsidy1)); let block4 = coinbase_only_block_with_gen(3, subsidy1 + subsidy2, block3_hash, genesis.header.timestamp + 4);
+            for block in [block3, block4] {
+                session.collect_live_responses(WireMessage { command: MESSAGE_BLOCK.to_string(), payload: block }, &mut engine, Some(&relay_ctx)).expect("accepted descendant dispatch");
+            }
+            assert_eq!(da_relay.lock().unwrap().test_record_summary(da_id), None, "accepted parent must advance DA TTL even when later orphan resolution errors");
             assert_eq!(
                 session.state().ban_score,
                 0,
@@ -5476,6 +5570,24 @@ mod tests {
         let _client = TcpStream::connect(addr).expect("connect");
         server.join().expect("server join");
         reset_orphan_pool_metrics_for_test();
+    }
+
+    #[test]
+    #[rustfmt::skip]
+    fn collect_live_responses_message_block_advances_da_ttl_once_per_new_block() {
+        let (mut session, _client) = test_peer_session(); let mut engine = test_sync_engine_with_genesis(); let genesis = parse_block_bytes(&devnet_genesis_block_bytes()).expect("parse genesis"); let genesis_hash = block_hash(&genesis.header_bytes).expect("genesis hash");
+        let block1 = height_one_coinbase_only_block(genesis_hash, genesis.header.timestamp + 1); let block1_hash = block_hash(&block1[..BLOCK_HEADER_BYTES]).expect("block1 hash"); let subsidy1 = rubin_consensus::subsidy::block_subsidy(1, 0);
+        let block2 = coinbase_only_block_with_gen(2, subsidy1, block1_hash, genesis.header.timestamp + 2); let block2_hash = block_hash(&block2[..BLOCK_HEADER_BYTES]).expect("block2 hash"); let subsidy2 = rubin_consensus::subsidy::block_subsidy(2, u128::from(subsidy1));
+        let block3 = coinbase_only_block_with_gen(3, subsidy1 + subsidy2, block2_hash, genesis.header.timestamp + 3);
+        let relay_state = crate::tx_relay::TxRelayState::new(); let peer_manager = PeerManager::new(default_peer_runtime_config("devnet", 8)); let peer_outboxes: Mutex<HashMap<String, crate::tx_relay::PeerOutbox>> = Mutex::new(HashMap::new()); let canonical_tx_pool = Mutex::new(TxPool::new()); let da_relay = Mutex::new(crate::da_relay::DaRelayState::new(crate::da_relay::DaRelayCaps::default()).expect("valid DA relay caps"));
+        let da_id = [0x61; 32]; let chunk_tx = relay_da_chunk_tx(da_id, b"peer-block-ttl"); let chunk_len = chunk_tx.len() as u64; da_relay.lock().unwrap().stage_relay_da_tx_bytes("peer:8333", chunk_tx).expect("stage DA orphan");
+        let relay_ctx = PeerRelayContext { relay_state: &relay_state, peer_manager: &peer_manager, local_addr: "local:8333", peer_registered_addr: "peer:8333", peer_writers: &peer_outboxes, tx_pool: &canonical_tx_pool, da_relay: &da_relay };
+        for block in [&block1, &block2, &block2] {
+            session.collect_live_responses(WireMessage { command: MESSAGE_BLOCK.to_string(), payload: (*block).clone() }, &mut engine, Some(&relay_ctx)).expect("accepted block dispatch");
+        }
+        assert_eq!(da_relay.lock().unwrap().test_record_summary(da_id), Some((false, 1, chunk_len)), "duplicate block must not consume DA orphan TTL");
+        session.collect_live_responses(WireMessage { command: MESSAGE_BLOCK.to_string(), payload: block3 }, &mut engine, Some(&relay_ctx)).expect("third accepted block dispatch");
+        assert_eq!(da_relay.lock().unwrap().test_record_summary(da_id), None);
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -3496,9 +3496,40 @@ mod tests {
         let admitted_da_id = [0xD1; 32]; let conflicting_da_id = [0xD2; 32]; let bad_da_id = [0xD3; 32]; let admitted = build(7, admitted_da_id, b"admitted da chunk", true); let conflicting = build(8, conflicting_da_id, b"conflicting da chunk", true); let bad = build(9, bad_da_id, b"bad da chunk", false); (state, admitted, conflicting, bad, admitted_da_id, conflicting_da_id, bad_da_id)
     }
 
-    #[rustfmt::skip]
     fn relay_da_chunk_tx(da_id: [u8; 32], payload: &[u8]) -> Vec<u8> {
-        rubin_consensus::marshal_tx(&rubin_consensus::Tx { version: rubin_consensus::constants::TX_WIRE_VERSION, tx_kind: 0x02, tx_nonce: 11, inputs: Vec::new(), outputs: Vec::new(), locktime: 0, da_commit_core: None, da_chunk_core: Some(rubin_consensus::DaChunkCore { da_id, chunk_index: 0, chunk_hash: Sha3_256::digest(payload).into() }), witness: Vec::new(), da_payload: payload.to_vec() }).expect("marshal DA chunk tx")
+        let tx = rubin_consensus::Tx {
+            version: rubin_consensus::constants::TX_WIRE_VERSION,
+            tx_kind: 0x02,
+            tx_nonce: 11,
+            inputs: Vec::new(),
+            outputs: Vec::new(),
+            locktime: 0,
+            da_commit_core: None,
+            da_chunk_core: Some(rubin_consensus::DaChunkCore {
+                da_id,
+                chunk_index: 0,
+                chunk_hash: Sha3_256::digest(payload).into(),
+            }),
+            witness: Vec::new(),
+            da_payload: payload.to_vec(),
+        };
+        rubin_consensus::marshal_tx(&tx).expect("marshal DA chunk tx")
+    }
+
+    fn collect_block_message(
+        session: &mut PeerSession,
+        engine: &mut SyncEngine,
+        relay_ctx: &PeerRelayContext<'_>,
+        payload: Vec<u8>,
+    ) -> io::Result<LiveMessageOutcome> {
+        session.collect_live_responses(
+            WireMessage {
+                command: MESSAGE_BLOCK.to_string(),
+                payload,
+            },
+            engine,
+            Some(relay_ctx),
+        )
     }
 
     #[derive(Deserialize)]
@@ -5466,7 +5497,6 @@ mod tests {
     }
 
     #[test]
-    #[rustfmt::skip]
     fn handle_block_surfaces_invalid_orphan_after_parent_arrives() {
         let _guard = orphan_pool_metrics_test_guard();
         reset_orphan_pool_metrics_for_test();
@@ -5492,9 +5522,31 @@ mod tests {
             );
             block2[36] ^= 0xff; // corrupt merkle root while keeping the block parseable
             let block2_hash = block_hash(&block2[..BLOCK_HEADER_BYTES]).expect("block2 hash");
-            let relay_state = crate::tx_relay::TxRelayState::new(); let peer_manager = PeerManager::new(default_peer_runtime_config("devnet", 8)); let peer_outboxes: Mutex<HashMap<String, crate::tx_relay::PeerOutbox>> = Mutex::new(HashMap::new()); let canonical_tx_pool = Mutex::new(TxPool::new()); let da_relay = Mutex::new(crate::da_relay::DaRelayState::new(crate::da_relay::DaRelayCaps::default()).expect("valid DA relay caps"));
-            let da_id = [0x62; 32]; da_relay.lock().unwrap().stage_relay_da_tx_bytes("peer:8333", relay_da_chunk_tx(da_id, b"peer-partial-error-ttl")).expect("stage DA orphan");
-            let relay_ctx = PeerRelayContext { relay_state: &relay_state, peer_manager: &peer_manager, local_addr: "local:8333", peer_registered_addr: "peer:8333", peer_writers: &peer_outboxes, tx_pool: &canonical_tx_pool, da_relay: &da_relay };
+            let relay_state = crate::tx_relay::TxRelayState::new();
+            let peer_manager = PeerManager::new(default_peer_runtime_config("devnet", 8));
+            let peer_outboxes: Mutex<HashMap<String, crate::tx_relay::PeerOutbox>> =
+                Mutex::new(HashMap::new());
+            let canonical_tx_pool = Mutex::new(TxPool::new());
+            let da_relay = Mutex::new(
+                crate::da_relay::DaRelayState::new(crate::da_relay::DaRelayCaps::default())
+                    .expect("valid DA relay caps"),
+            );
+            let da_id = [0x62; 32];
+            let da_tx = relay_da_chunk_tx(da_id, b"peer-partial-error-ttl");
+            da_relay
+                .lock()
+                .unwrap()
+                .stage_relay_da_tx_bytes("peer:8333", da_tx)
+                .expect("stage DA orphan");
+            let relay_ctx = PeerRelayContext {
+                relay_state: &relay_state,
+                peer_manager: &peer_manager,
+                local_addr: "local:8333",
+                peer_registered_addr: "peer:8333",
+                peer_writers: &peer_outboxes,
+                tx_pool: &canonical_tx_pool,
+                da_relay: &da_relay,
+            };
 
             session
                 .handle_block(&block2, &mut engine)
@@ -5513,7 +5565,8 @@ mod tests {
                     .expect("invalid orphan must not persist before parent"),
                 "invalid orphan should remain memory-only until parent arrives"
             );
-            let err = session.collect_live_responses(WireMessage { command: MESSAGE_BLOCK.to_string(), payload: block1.clone() }, &mut engine, Some(&relay_ctx)).expect_err("invalid orphan should surface after parent arrives");
+            let err = collect_block_message(&mut session, &mut engine, &relay_ctx, block1.clone())
+                .expect_err("invalid orphan should surface after parent arrives");
             let pending_cleanup = session.take_pending_tx_pool_cleanup();
 
             assert_eq!(session.orphans.len(), 0, "invalid orphan should be dropped");
@@ -5537,9 +5590,40 @@ mod tests {
                 session.take_pending_tx_pool_cleanup().is_empty(),
                 "pending cleanup should drain once observed"
             );
-            session.collect_live_responses(WireMessage { command: MESSAGE_BLOCK.to_string(), payload: block1.clone() }, &mut engine, Some(&relay_ctx)).expect("duplicate parent dispatch");
-            let block3 = coinbase_only_block_with_gen(2, subsidy1, block1_hash, genesis.header.timestamp + 3); let block3_hash = block_hash(&block3[..BLOCK_HEADER_BYTES]).expect("block3 hash"); session.collect_live_responses(WireMessage { command: MESSAGE_BLOCK.to_string(), payload: block3 }, &mut engine, Some(&relay_ctx)).expect("accepted descendant dispatch"); assert!(da_relay.lock().unwrap().test_record_summary(da_id).is_some(), "duplicate parent must not consume DA orphan TTL"); let subsidy2 = rubin_consensus::subsidy::block_subsidy(2, u128::from(subsidy1)); let block4 = coinbase_only_block_with_gen(3, subsidy1 + subsidy2, block3_hash, genesis.header.timestamp + 4); session.collect_live_responses(WireMessage { command: MESSAGE_BLOCK.to_string(), payload: block4 }, &mut engine, Some(&relay_ctx)).expect("accepted descendant dispatch");
-            assert_eq!(da_relay.lock().unwrap().test_record_summary(da_id), None, "accepted parent must advance DA TTL even when later orphan resolution errors");
+            collect_block_message(&mut session, &mut engine, &relay_ctx, block1.clone())
+                .expect("duplicate parent dispatch");
+            let block3 = coinbase_only_block_with_gen(
+                2,
+                subsidy1,
+                block1_hash,
+                genesis.header.timestamp + 3,
+            );
+            let block3_hash = block_hash(&block3[..BLOCK_HEADER_BYTES]).expect("block3 hash");
+            collect_block_message(&mut session, &mut engine, &relay_ctx, block3)
+                .expect("accepted descendant dispatch");
+            assert!(
+                da_relay
+                    .lock()
+                    .unwrap()
+                    .test_record_summary(da_id)
+                    .is_some(),
+                "duplicate parent must not consume DA orphan TTL"
+            );
+
+            let subsidy2 = rubin_consensus::subsidy::block_subsidy(2, u128::from(subsidy1));
+            let block4 = coinbase_only_block_with_gen(
+                3,
+                subsidy1 + subsidy2,
+                block3_hash,
+                genesis.header.timestamp + 4,
+            );
+            collect_block_message(&mut session, &mut engine, &relay_ctx, block4)
+                .expect("accepted descendant dispatch");
+            assert_eq!(
+                da_relay.lock().unwrap().test_record_summary(da_id),
+                None,
+                "accepted parent must advance DA TTL even when later orphan resolution errors"
+            );
             assert_eq!(
                 session.state().ban_score,
                 0,

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -5516,16 +5516,7 @@ mod tests {
                     .expect("invalid orphan must not persist before parent"),
                 "invalid orphan should remain memory-only until parent arrives"
             );
-            let err = session
-                .collect_live_responses(
-                    WireMessage {
-                        command: MESSAGE_BLOCK.to_string(),
-                        payload: block1.clone(),
-                    },
-                    &mut engine,
-                    Some(&relay_ctx),
-                )
-                .expect_err("invalid orphan should surface after parent arrives");
+            let err = session.collect_live_responses(WireMessage { command: MESSAGE_BLOCK.to_string(), payload: block1.clone() }, &mut engine, Some(&relay_ctx)).expect_err("invalid orphan should surface after parent arrives");
             let pending_cleanup = session.take_pending_tx_pool_cleanup();
 
             assert_eq!(session.orphans.len(), 0, "invalid orphan should be dropped");
@@ -5549,10 +5540,8 @@ mod tests {
                 session.take_pending_tx_pool_cleanup().is_empty(),
                 "pending cleanup should drain once observed"
             );
-            let block3 = coinbase_only_block_with_gen(2, subsidy1, block1_hash, genesis.header.timestamp + 3); let block3_hash = block_hash(&block3[..BLOCK_HEADER_BYTES]).expect("block3 hash"); let subsidy2 = rubin_consensus::subsidy::block_subsidy(2, u128::from(subsidy1)); let block4 = coinbase_only_block_with_gen(3, subsidy1 + subsidy2, block3_hash, genesis.header.timestamp + 4);
-            for block in [block3, block4] {
-                session.collect_live_responses(WireMessage { command: MESSAGE_BLOCK.to_string(), payload: block }, &mut engine, Some(&relay_ctx)).expect("accepted descendant dispatch");
-            }
+            session.collect_live_responses(WireMessage { command: MESSAGE_BLOCK.to_string(), payload: block1.clone() }, &mut engine, Some(&relay_ctx)).expect("duplicate parent dispatch");
+            let block3 = coinbase_only_block_with_gen(2, subsidy1, block1_hash, genesis.header.timestamp + 3); let block3_hash = block_hash(&block3[..BLOCK_HEADER_BYTES]).expect("block3 hash"); session.collect_live_responses(WireMessage { command: MESSAGE_BLOCK.to_string(), payload: block3 }, &mut engine, Some(&relay_ctx)).expect("accepted descendant dispatch"); assert!(da_relay.lock().unwrap().test_record_summary(da_id).is_some(), "duplicate parent must not consume DA orphan TTL"); let subsidy2 = rubin_consensus::subsidy::block_subsidy(2, u128::from(subsidy1)); let block4 = coinbase_only_block_with_gen(3, subsidy1 + subsidy2, block3_hash, genesis.header.timestamp + 4); session.collect_live_responses(WireMessage { command: MESSAGE_BLOCK.to_string(), payload: block4 }, &mut engine, Some(&relay_ctx)).expect("accepted descendant dispatch");
             assert_eq!(da_relay.lock().unwrap().test_record_summary(da_id), None, "accepted parent must advance DA TTL even when later orphan resolution errors");
             assert_eq!(
                 session.state().ban_score,
@@ -5570,24 +5559,6 @@ mod tests {
         let _client = TcpStream::connect(addr).expect("connect");
         server.join().expect("server join");
         reset_orphan_pool_metrics_for_test();
-    }
-
-    #[test]
-    #[rustfmt::skip]
-    fn collect_live_responses_message_block_advances_da_ttl_once_per_new_block() {
-        let (mut session, _client) = test_peer_session(); let mut engine = test_sync_engine_with_genesis(); let genesis = parse_block_bytes(&devnet_genesis_block_bytes()).expect("parse genesis"); let genesis_hash = block_hash(&genesis.header_bytes).expect("genesis hash");
-        let block1 = height_one_coinbase_only_block(genesis_hash, genesis.header.timestamp + 1); let block1_hash = block_hash(&block1[..BLOCK_HEADER_BYTES]).expect("block1 hash"); let subsidy1 = rubin_consensus::subsidy::block_subsidy(1, 0);
-        let block2 = coinbase_only_block_with_gen(2, subsidy1, block1_hash, genesis.header.timestamp + 2); let block2_hash = block_hash(&block2[..BLOCK_HEADER_BYTES]).expect("block2 hash"); let subsidy2 = rubin_consensus::subsidy::block_subsidy(2, u128::from(subsidy1));
-        let block3 = coinbase_only_block_with_gen(3, subsidy1 + subsidy2, block2_hash, genesis.header.timestamp + 3);
-        let relay_state = crate::tx_relay::TxRelayState::new(); let peer_manager = PeerManager::new(default_peer_runtime_config("devnet", 8)); let peer_outboxes: Mutex<HashMap<String, crate::tx_relay::PeerOutbox>> = Mutex::new(HashMap::new()); let canonical_tx_pool = Mutex::new(TxPool::new()); let da_relay = Mutex::new(crate::da_relay::DaRelayState::new(crate::da_relay::DaRelayCaps::default()).expect("valid DA relay caps"));
-        let da_id = [0x61; 32]; let chunk_tx = relay_da_chunk_tx(da_id, b"peer-block-ttl"); let chunk_len = chunk_tx.len() as u64; da_relay.lock().unwrap().stage_relay_da_tx_bytes("peer:8333", chunk_tx).expect("stage DA orphan");
-        let relay_ctx = PeerRelayContext { relay_state: &relay_state, peer_manager: &peer_manager, local_addr: "local:8333", peer_registered_addr: "peer:8333", peer_writers: &peer_outboxes, tx_pool: &canonical_tx_pool, da_relay: &da_relay };
-        for block in [&block1, &block2, &block2] {
-            session.collect_live_responses(WireMessage { command: MESSAGE_BLOCK.to_string(), payload: (*block).clone() }, &mut engine, Some(&relay_ctx)).expect("accepted block dispatch");
-        }
-        assert_eq!(da_relay.lock().unwrap().test_record_summary(da_id), Some((false, 1, chunk_len)), "duplicate block must not consume DA orphan TTL");
-        session.collect_live_responses(WireMessage { command: MESSAGE_BLOCK.to_string(), payload: block3 }, &mut engine, Some(&relay_ctx)).expect("third accepted block dispatch");
-        assert_eq!(da_relay.lock().unwrap().test_record_summary(da_id), None);
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -1493,11 +1493,8 @@ impl PeerSession {
                 "DA relay lock poisoned during accepted-block TTL advance".into();
             return;
         };
-        for _ in 0..accepted_blocks {
-            if let Err(err) = da_relay.advance_orphan_ttl() {
-                self.peer.last_error = format!("DA relay TTL advance failed: {err:?}");
-                break;
-            }
+        if let Err(err) = da_relay.advance_orphan_ttl_by(accepted_blocks) {
+            self.peer.last_error = format!("DA relay TTL advance failed: {err:?}");
         }
     }
 

--- a/clients/rust/crates/rubin-node/src/p2p_service.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_service.rs
@@ -249,6 +249,18 @@ pub fn stage_local_da_relay_tx_bytes(da_relay: &Arc<Mutex<DaRelayState>>, tx_byt
     let _ = da_relay.stage_relay_da_tx_bytes("", tx_bytes.to_vec());
 }
 
+pub fn advance_da_orphan_ttl_for_accepted_block(
+    da_relay: &Arc<Mutex<DaRelayState>>,
+) -> Result<(), String> {
+    let mut da_relay = da_relay
+        .lock()
+        .map_err(|_| "DA relay lock poisoned during accepted-block TTL advance".to_string())?;
+    da_relay
+        .advance_orphan_ttl()
+        .map(|_| ())
+        .map_err(|err| format!("DA relay TTL advance failed: {err:?}"))
+}
+
 fn run_accept_loop(listener: TcpListener, shared: SharedServiceState) {
     let mut error_backoff = ACCEPT_ERROR_BACKOFF_INIT;
     while !shared.stop.load(Ordering::SeqCst) {

--- a/clients/rust/crates/rubin-node/src/tx_seen.rs
+++ b/clients/rust/crates/rubin-node/src/tx_seen.rs
@@ -28,6 +28,12 @@ struct BoundedHashSetInner {
 }
 
 impl BoundedHashSet {
+    fn lock_inner(&self) -> std::sync::MutexGuard<'_, BoundedHashSetInner> {
+        self.inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
     pub fn new(capacity: usize) -> Self {
         let cap = if capacity == 0 {
             DEFAULT_TX_SEEN_CAPACITY
@@ -48,9 +54,7 @@ impl BoundedHashSet {
     /// `false` if it was already present. Evicts the oldest entry (FIFO) when
     /// the set is at capacity.
     pub fn add(&self, hash: [u8; 32]) -> bool {
-        let Ok(mut inner) = self.inner.lock() else {
-            return false;
-        };
+        let mut inner = self.lock_inner();
         if inner.items.contains_key(&hash) {
             return false;
         }
@@ -74,17 +78,13 @@ impl BoundedHashSet {
 
     /// Returns `true` if hash is in the set.
     pub fn has(&self, hash: &[u8; 32]) -> bool {
-        let Ok(inner) = self.inner.lock() else {
-            return false;
-        };
+        let inner = self.lock_inner();
         inner.items.contains_key(hash)
     }
 
     /// Returns the current number of entries in the set.
     pub fn len(&self) -> usize {
-        let Ok(inner) = self.inner.lock() else {
-            return 0;
-        };
+        let inner = self.lock_inner();
         inner.items.len()
     }
 
@@ -172,11 +172,13 @@ mod tests {
     }
 
     #[test]
+    #[rustfmt::skip]
     fn is_empty_works() {
         let set = BoundedHashSet::new(10);
         assert!(set.is_empty());
         set.add([1u8; 32]);
         assert!(!set.is_empty());
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| { let _guard = set.inner.lock().expect("lock"); panic!("poison set lock"); })); let hash = [9u8; 32]; assert!(set.add(hash)); assert!(set.has(&hash)); assert_eq!(set.len(), 2);
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/tx_seen.rs
+++ b/clients/rust/crates/rubin-node/src/tx_seen.rs
@@ -172,13 +172,20 @@ mod tests {
     }
 
     #[test]
-    #[rustfmt::skip]
     fn is_empty_works() {
         let set = BoundedHashSet::new(10);
         assert!(set.is_empty());
         set.add([1u8; 32]);
         assert!(!set.is_empty());
-        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| { let _guard = set.inner.lock().expect("lock"); panic!("poison set lock"); })); let hash = [9u8; 32]; assert!(set.add(hash)); assert!(set.has(&hash)); assert_eq!(set.len(), 2);
+
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = set.inner.lock().expect("lock");
+            panic!("poison set lock");
+        }));
+        let hash = [9u8; 32];
+        assert!(set.add(hash));
+        assert!(set.has(&hash));
+        assert_eq!(set.len(), 2);
     }
 
     #[test]


### PR DESCRIPTION
Scope:
- Advance Rust DA orphan TTL from accepted block runtime paths.
- Cover peer `MESSAGE_BLOCK`, compact-reconstructed accepted blocks, and locally accepted `/mine_next` blocks.
- Preserve relay retryability when local block broadcast fails.

Go/Rust Parity Matrix:
| case | go_reference | go_callsite | rust_callsite | rust_required_behavior | mirror_test_required | evidence_required |
| -- | -- | -- | -- | -- | -- | -- |
| peer accepted block advances TTL once | `acceptedRelayedBlock -> noteAcceptedBlock -> advanceDAOrphanTTL` | `clients/go/node/p2p/handlers_block.go:acceptedRelayedBlock` | `clients/rust/crates/rubin-node/src/p2p_runtime.rs:handle_block_with_acceptance` | `MESSAGE_BLOCK` accepted path advances DA orphan TTL once per newly accepted block | `p2p_runtime::tests::handle_block_surfaces_invalid_orphan_after_parent_arrives` | `cd clients/rust && cargo test -p rubin-node handle_block_surfaces_invalid_orphan_after_parent_arrives --lib` |
| compact accepted block advances TTL once | Go accepted block processing calls DA TTL after accepted relay block state changes | `clients/go/node/p2p/handlers_block.go:acceptedRelayedBlock` | `clients/rust/crates/rubin-node/src/p2p_runtime.rs:process_compact_transactions` and `handle_blocktxn` | compact reconstruction and blocktxn orphan resolution advance DA orphan TTL once per newly accepted block, not on fallback or missing-data paths | `p2p_runtime::tests::handle_block_surfaces_invalid_orphan_after_parent_arrives` | `cd clients/rust && cargo test -p rubin-node p2p_runtime --lib` |
| local accepted block advances TTL once | `Service.AnnounceBlock -> advanceDAOrphanTTL` | `clients/go/node/p2p/service.go:AnnounceBlock` | `clients/rust/crates/rubin-node/src/devnet_rpc.rs:handle_mine_next` and `clients/rust/crates/rubin-node/src/main.rs:advance_da_ttl_for_block` | `/mine_next` accepted-block hook advances DA orphan TTL once while local mining is still serialized; block broadcast retryability remains separate | `devnet_rpc::tests::mine_next_announces_mined_block_on_success` and `tests::local_accepted_block_advances_da_ttl_without_broadcast_coupling` | `cd clients/rust && cargo test -p rubin-node mine_next_announces_mined_block_on_success --lib` and `cd clients/rust && cargo test -p rubin-node --bin rubin-node local_accepted_block_advances_da_ttl_without_broadcast_coupling` |
| duplicate block does not advance TTL | Go accepted-block path is not re-entered for already-known block state | `clients/go/node/p2p/handlers_block.go:processRelayedBlock` | `clients/rust/crates/rubin-node/src/p2p_runtime.rs:handle_block_with_acceptance` and `clients/rust/crates/rubin-node/src/main.rs:advance_da_ttl_for_block` | peer duplicate block and local duplicate accepted-block dedupe return without DA TTL advance | `p2p_runtime::tests::handle_block_surfaces_invalid_orphan_after_parent_arrives` and `local_accepted_block_advances_da_ttl_without_broadcast_coupling` | `cd clients/rust && cargo test -p rubin-node handle_block_surfaces_invalid_orphan_after_parent_arrives --lib` and `cd clients/rust && cargo test -p rubin-node --bin rubin-node local_accepted_block_advances_da_ttl_without_broadcast_coupling` |
| failed local announce does not mark relay block_seen but accepted block advances TTL once | Go `AnnounceBlock` advances DA TTL after accepted local block while relay retryability stays separate | `clients/go/node/p2p/service.go:AnnounceBlock` | `clients/rust/crates/rubin-node/src/devnet_rpc.rs:handle_mine_next` and `clients/rust/crates/rubin-node/src/main.rs:advance_da_ttl_for_block` | failed local block broadcast leaves relay `block_seen` unset but DA TTL still advances once for the accepted local block | `tests::local_accepted_block_advances_da_ttl_without_broadcast_coupling` | `cd clients/rust && cargo test -p rubin-node --bin rubin-node local_accepted_block_advances_da_ttl_without_broadcast_coupling` |
| complete set retention remains owned by [2tbmz9y2xt-lang/rubin-protocol#1863](<https://linear.app/rubinp/issue/RUB-401/q-rust-p2p-da-ttl-expiry-01-add-rust-da-orphan-ttl-expiry-only>) helper behavior | `advanceDAOrphanTTL` delegates complete-set retention to DA relay helper | `clients/go/node/p2p/service.go:advanceDAOrphanTTL` | `clients/rust/crates/rubin-node/src/da_relay.rs:advance_orphan_ttl` | This issue does not change helper semantics; complete sets remain retained by `DaRelayState::advance_orphan_ttl` | `da_relay::tests::da_relay_ttl_expiry_matrix` | `cd clients/rust && cargo test -p rubin-node da_relay --lib` |

Evidence:
- `cd clients/rust && cargo test -p rubin-node handle_block_surfaces_invalid_orphan_after_parent_arrives --lib`
- `cd clients/rust && cargo fmt --check`
- `cd clients/rust && cargo test -p rubin-node mine_next_announces_mined_block_on_success --lib`
- `cd clients/rust && cargo test -p rubin-node --bin rubin-node local_accepted_block_advances_da_ttl_without_broadcast_coupling`
- `cd clients/rust && cargo test -p rubin-node p2p_runtime --lib`
- `cd clients/rust && cargo test -p rubin-node da_relay --lib`
- `cd clients/rust && cargo test -p rubin-node --lib`
- `cd clients/rust && cargo clippy -p rubin-node --lib --tests -- -D warnings`

Non-goals:
- No tx ingest or local `submit_tx` staging changes.
- No peer disconnect cleanup changes.
- No provider, miner selection, prefetch, getdachunk, spec, conformance, Go, or consensus changes.
