### PR TITLE
p2p: add DA peer quota release helper

### DIFF
--- a/clients/rust/crates/rubin-node/src/da_relay.rs
+++ b/clients/rust/crates/rubin-node/src/da_relay.rs
@@ -304,31 +304,28 @@ impl DaRelaySetRecord {
         if self.state == DaRelaySetState::CompleteSet || self.wire_bytes == 0 {
             return Ok((self.clone(), false));
         }
-        let mut updated = self.clone();
-        let mut changed = false;
-        if updated
+        let drop_commit = self
             .commit
             .as_ref()
-            .is_some_and(|commit| commit.wire_bytes != 0 && &commit.peer_quota_key == key)
-        {
-            updated.commit = None;
-            updated.replaceable_chunks.clear();
-            changed = true;
-        }
-        let indexes = updated
+            .is_some_and(|commit| commit.wire_bytes != 0 && &commit.peer_quota_key == key);
+        let indexes = self
             .chunks
             .iter()
             .filter_map(|(index, chunk)| {
                 (chunk.wire_bytes != 0 && &chunk.peer_quota_key == key).then_some(*index)
             })
             .collect::<Vec<_>>();
+        if !drop_commit && indexes.is_empty() {
+            return Ok((self.clone(), false));
+        }
+        let mut updated = self.clone();
+        if drop_commit {
+            updated.commit = None;
+            updated.replaceable_chunks.clear();
+        }
         for index in &indexes {
             updated.chunks.remove(index);
             updated.replaceable_chunks.remove(index);
-        }
-        changed |= !indexes.is_empty();
-        if !changed {
-            return Ok((self.clone(), false));
         }
         updated.payload_bytes = 0;
         if updated.commit.is_none() {

--- a/clients/rust/crates/rubin-node/src/da_relay.rs
+++ b/clients/rust/crates/rubin-node/src/da_relay.rs
@@ -305,10 +305,28 @@ impl DaRelaySetRecord {
             return Ok((self.clone(), false));
         }
         let mut updated = self.clone();
-        let mut changed = updated.drop_commit_for_peer_quota_key(key);
-        if updated.drop_chunks_for_peer_quota_key(key) {
+        let mut changed = false;
+        if updated
+            .commit
+            .as_ref()
+            .is_some_and(|commit| commit.wire_bytes != 0 && &commit.peer_quota_key == key)
+        {
+            updated.commit = None;
+            updated.replaceable_chunks.clear();
             changed = true;
         }
+        let indexes = updated
+            .chunks
+            .iter()
+            .filter_map(|(index, chunk)| {
+                (chunk.wire_bytes != 0 && &chunk.peer_quota_key == key).then_some(*index)
+            })
+            .collect::<Vec<_>>();
+        for index in &indexes {
+            updated.chunks.remove(index);
+            updated.replaceable_chunks.remove(index);
+        }
+        changed |= !indexes.is_empty();
         if !changed {
             return Ok((self.clone(), false));
         }
@@ -324,31 +342,6 @@ impl DaRelaySetRecord {
         }
         updated.recompute_wire_bytes()?;
         Ok((updated, true))
-    }
-    fn drop_commit_for_peer_quota_key(&mut self, key: &PeerQuotaKey) -> bool {
-        let Some(commit) = &self.commit else {
-            return false;
-        };
-        if commit.wire_bytes == 0 || &commit.peer_quota_key != key {
-            return false;
-        }
-        self.commit = None;
-        self.replaceable_chunks.clear();
-        true
-    }
-    fn drop_chunks_for_peer_quota_key(&mut self, key: &PeerQuotaKey) -> bool {
-        let indexes = self
-            .chunks
-            .iter()
-            .filter_map(|(index, chunk)| {
-                (chunk.wire_bytes != 0 && &chunk.peer_quota_key == key).then_some(*index)
-            })
-            .collect::<Vec<_>>();
-        for index in &indexes {
-            self.chunks.remove(index);
-            self.replaceable_chunks.remove(index);
-        }
-        !indexes.is_empty()
     }
     fn empty_incomplete(&self) -> bool {
         self.state != DaRelaySetState::CompleteSet
@@ -603,20 +596,13 @@ impl DaRelayState {
     }
 
     pub(crate) fn release_peer_quota_key(&mut self, key: &PeerQuotaKey) -> DaRelayResult {
-        if self
-            .orphan_bytes_by_peer_quota_key
-            .get(key)
-            .copied()
-            .unwrap_or(0)
-            == 0
-        {
+        if matches!(
+            self.orphan_bytes_by_peer_quota_key.get(key),
+            None | Some(&0)
+        ) {
             return Ok(());
         }
-        let da_ids = self
-            .orphan_bytes_by_da_id
-            .keys()
-            .copied()
-            .collect::<Vec<_>>();
+        let da_ids: Vec<_> = self.orphan_bytes_by_da_id.keys().copied().collect();
         for da_id in da_ids {
             let (updated, changed) = {
                 let Some(record) = self.sets_by_da_id.get(&da_id) else {
@@ -1457,6 +1443,12 @@ mod tests {
         state
             .stage_incomplete_da_chunk(peer_a, chunk([84; 32], 0, b"complete", 8))
             .unwrap();
+        state
+            .stage_incomplete_da_commit(peer_b, commit([85; 32], &[b"stay", b"drop"], 11))
+            .unwrap();
+        state
+            .stage_incomplete_da_chunk(peer_a, chunk([85; 32], 1, b"drop", 13))
+            .unwrap();
         let complete_before = state.sets_by_da_id[&[84; 32]].clone();
         let peer_b_before = state.orphan_bytes_by_peer_quota_key[&key_b];
 
@@ -1475,6 +1467,18 @@ mod tests {
             key_b
         );
         assert_eq!(state.sets_by_da_id[&[84; 32]], complete_before);
+        let reverse_mixed = &state.sets_by_da_id[&[85; 32]];
+        assert_eq!(reverse_mixed.state, DaRelaySetState::StagedCommit);
+        assert_eq!(
+            reverse_mixed
+                .commit
+                .as_ref()
+                .map(|commit| &commit.peer_quota_key),
+            Some(&key_b)
+        );
+        assert!(reverse_mixed.chunks.is_empty());
+        assert_eq!(reverse_mixed.peer_bytes.len(), 1);
+        assert_eq!(reverse_mixed.peer_bytes[&key_b], 11);
         assert!(!state.orphan_bytes_by_da_id.contains_key(&[84; 32]));
         assert!(!state.orphan_bytes_by_peer_quota_key.contains_key(&key_a));
         assert_eq!(state.orphan_bytes_by_peer_quota_key[&key_b], peer_b_before);
@@ -1482,6 +1486,7 @@ mod tests {
             state.orphan_bytes,
             state.sets_by_da_id[&[82; 32]].orphan_wire_bytes().unwrap()
                 + state.sets_by_da_id[&[83; 32]].orphan_wire_bytes().unwrap()
+                + state.sets_by_da_id[&[85; 32]].orphan_wire_bytes().unwrap()
         );
         let after = state.clone();
         state.release_peer_quota_key(&key_a).unwrap();

--- a/clients/rust/crates/rubin-node/src/da_relay.rs
+++ b/clients/rust/crates/rubin-node/src/da_relay.rs
@@ -300,9 +300,9 @@ impl DaRelaySetRecord {
     fn orphan_peer_bytes(&self) -> Option<&BTreeMap<PeerQuotaKey, u64>> {
         (self.state != DaRelaySetState::CompleteSet).then_some(&self.peer_bytes)
     }
-    fn without_peer_quota_key(&self, key: &PeerQuotaKey) -> DaRelayResult<(Self, bool)> {
+    fn without_peer_quota_key(&self, key: &PeerQuotaKey) -> DaRelayResult<Option<Self>> {
         if self.state == DaRelaySetState::CompleteSet || self.wire_bytes == 0 {
-            return Ok((self.clone(), false));
+            return Ok(None);
         }
         let drop_commit = self
             .commit
@@ -316,7 +316,7 @@ impl DaRelaySetRecord {
             })
             .collect::<Vec<_>>();
         if !drop_commit && indexes.is_empty() {
-            return Ok((self.clone(), false));
+            return Ok(None);
         }
         let mut updated = self.clone();
         if drop_commit {
@@ -335,10 +335,10 @@ impl DaRelaySetRecord {
         if updated.empty_incomplete() {
             updated.wire_bytes = 0;
             updated.peer_bytes.clear();
-            return Ok((updated, true));
+            return Ok(Some(updated));
         }
         updated.recompute_wire_bytes()?;
-        Ok((updated, true))
+        Ok(Some(updated))
     }
     fn empty_incomplete(&self) -> bool {
         self.state != DaRelaySetState::CompleteSet
@@ -601,18 +601,18 @@ impl DaRelayState {
         }
         let da_ids: Vec<_> = self.orphan_bytes_by_da_id.keys().copied().collect();
         for da_id in da_ids {
-            let (updated, changed) = {
+            let updated = {
                 let Some(record) = self.sets_by_da_id.get(&da_id) else {
                     continue;
                 };
                 if record.state == DaRelaySetState::CompleteSet {
                     continue;
                 }
-                record.without_peer_quota_key(key)?
+                let Some(updated) = record.without_peer_quota_key(key)? else {
+                    continue;
+                };
+                updated
             };
-            if !changed {
-                continue;
-            }
             if updated.empty_incomplete() {
                 let old = self
                     .sets_by_da_id

--- a/clients/rust/crates/rubin-node/src/da_relay.rs
+++ b/clients/rust/crates/rubin-node/src/da_relay.rs
@@ -300,6 +300,61 @@ impl DaRelaySetRecord {
     fn orphan_peer_bytes(&self) -> Option<&BTreeMap<PeerQuotaKey, u64>> {
         (self.state != DaRelaySetState::CompleteSet).then_some(&self.peer_bytes)
     }
+    fn without_peer_quota_key(&self, key: &PeerQuotaKey) -> DaRelayResult<(Self, bool)> {
+        if self.state == DaRelaySetState::CompleteSet || self.wire_bytes == 0 {
+            return Ok((self.clone(), false));
+        }
+        let mut updated = self.clone();
+        let mut changed = updated.drop_commit_for_peer_quota_key(key);
+        if updated.drop_chunks_for_peer_quota_key(key) {
+            changed = true;
+        }
+        if !changed {
+            return Ok((self.clone(), false));
+        }
+        updated.payload_bytes = 0;
+        if updated.commit.is_none() {
+            updated.state = DaRelaySetState::OrphanChunks;
+            updated.replaceable_chunks.clear();
+        }
+        if updated.empty_incomplete() {
+            updated.wire_bytes = 0;
+            updated.peer_bytes.clear();
+            return Ok((updated, true));
+        }
+        updated.recompute_wire_bytes()?;
+        Ok((updated, true))
+    }
+    fn drop_commit_for_peer_quota_key(&mut self, key: &PeerQuotaKey) -> bool {
+        let Some(commit) = &self.commit else {
+            return false;
+        };
+        if commit.wire_bytes == 0 || &commit.peer_quota_key != key {
+            return false;
+        }
+        self.commit = None;
+        self.replaceable_chunks.clear();
+        true
+    }
+    fn drop_chunks_for_peer_quota_key(&mut self, key: &PeerQuotaKey) -> bool {
+        let indexes = self
+            .chunks
+            .iter()
+            .filter_map(|(index, chunk)| {
+                (chunk.wire_bytes != 0 && &chunk.peer_quota_key == key).then_some(*index)
+            })
+            .collect::<Vec<_>>();
+        for index in &indexes {
+            self.chunks.remove(index);
+            self.replaceable_chunks.remove(index);
+        }
+        !indexes.is_empty()
+    }
+    fn empty_incomplete(&self) -> bool {
+        self.state != DaRelaySetState::CompleteSet
+            && self.commit.is_none()
+            && self.chunks.is_empty()
+    }
     fn pinned_payload_accounting_bytes(&self) -> DaRelayResult<u64> {
         if self.state != DaRelaySetState::CompleteSet || self.payload_bytes == 0 {
             return Ok(0);
@@ -545,6 +600,49 @@ impl DaRelayState {
         };
         self.apply_ttl_expiry_projection(projection, expiring_records);
         Ok(expired)
+    }
+
+    pub(crate) fn release_peer_quota_key(&mut self, key: &PeerQuotaKey) -> DaRelayResult {
+        if self
+            .orphan_bytes_by_peer_quota_key
+            .get(key)
+            .copied()
+            .unwrap_or(0)
+            == 0
+        {
+            return Ok(());
+        }
+        let da_ids = self
+            .orphan_bytes_by_da_id
+            .keys()
+            .copied()
+            .collect::<Vec<_>>();
+        for da_id in da_ids {
+            let (updated, changed) = {
+                let Some(record) = self.sets_by_da_id.get(&da_id) else {
+                    continue;
+                };
+                if record.state == DaRelaySetState::CompleteSet {
+                    continue;
+                }
+                record.without_peer_quota_key(key)?
+            };
+            if !changed {
+                continue;
+            }
+            if updated.empty_incomplete() {
+                let old = self
+                    .sets_by_da_id
+                    .get(&da_id)
+                    .cloned()
+                    .ok_or(DaRelayError::AccountingUnderflow)?;
+                let projection = self.project_ttl_expiry(std::slice::from_ref(&old))?;
+                self.apply_ttl_expiry_projection(projection, vec![old]);
+            } else {
+                self.apply_record(updated)?;
+            }
+        }
+        Ok(())
     }
 
     pub(crate) fn stage_incomplete_da_commit(
@@ -1311,6 +1409,83 @@ mod tests {
         assert_eq!(state.advance_orphan_ttl(), Err(AccountingUnderflow)); assert_eq!(state, before);
         let mut state = DaRelayState::new(DaRelayCaps::default()).unwrap(); state.stage_incomplete_da_chunk(peer, chunk([4; 32], 0, b"early", 5)).unwrap(); state.stage_incomplete_da_chunk(peer, chunk([5; 32], 0, b"late", 7)).unwrap(); state.sets_by_da_id.get_mut(&[4; 32]).unwrap().ttl_blocks_remaining = 1; state.sets_by_da_id.get_mut(&[5; 32]).unwrap().ttl_blocks_remaining = 1; state.orphan_bytes_by_da_id.insert([5; 32], 0); let before = state.clone();
         assert_eq!(state.advance_orphan_ttl(), Err(AccountingUnderflow)); assert_eq!(state, before);
+    }
+
+    #[test]
+    fn da_relay_peer_quota_release_helper_releases_peer_owned_incomplete_records_only() {
+        let peer_a = "peer-a:8333";
+        let peer_b = "peer-b:8333";
+        let key_a = PeerQuotaKey::from_peer_addr(peer_a);
+        let key_b = PeerQuotaKey::from_peer_addr(peer_b);
+        let commit = |da_id, payloads: &[&[u8]], wire_bytes| DaRelayCommit {
+            da_id,
+            payload_commitment: payload_commitment(payloads),
+            peer_quota_key: PeerQuotaKey::from_peer_addr("forged:8333"),
+            chunk_count: payloads.len() as u16,
+            wire_bytes,
+            tx_bytes: Arc::from([]),
+        };
+        let chunk = |da_id, index, payload: &[u8], wire_bytes| DaRelayChunk {
+            da_id,
+            chunk_hash: sha3_256(payload),
+            peer_quota_key: PeerQuotaKey::from_peer_addr("forged:8333"),
+            chunk_index: index,
+            payload: Arc::from(payload),
+            wire_bytes,
+            tx_bytes: Arc::from([]),
+        };
+
+        let mut state = DaRelayState::new(DaRelayCaps::default()).unwrap();
+        state
+            .stage_incomplete_da_commit(peer_a, commit([80; 32], &[b"owned"], 5))
+            .unwrap();
+        state
+            .stage_incomplete_da_chunk(peer_a, chunk([81; 32], 0, b"owned", 5))
+            .unwrap();
+        state
+            .stage_incomplete_da_commit(peer_a, commit([82; 32], &[b"keep", b"tail"], 6))
+            .unwrap();
+        state
+            .stage_incomplete_da_chunk(peer_b, chunk([82; 32], 0, b"keep", 7))
+            .unwrap();
+        state
+            .stage_incomplete_da_chunk(peer_b, chunk([83; 32], 0, b"unrelated", 9))
+            .unwrap();
+        state
+            .stage_incomplete_da_commit(peer_a, commit([84; 32], &[b"complete"], 8))
+            .unwrap();
+        state
+            .stage_incomplete_da_chunk(peer_a, chunk([84; 32], 0, b"complete", 8))
+            .unwrap();
+        let complete_before = state.sets_by_da_id[&[84; 32]].clone();
+        let peer_b_before = state.orphan_bytes_by_peer_quota_key[&key_b];
+
+        state.release_peer_quota_key(&key_a).unwrap();
+
+        assert!(!state.sets_by_da_id.contains_key(&[80; 32]));
+        assert!(!state.sets_by_da_id.contains_key(&[81; 32]));
+        let mixed = &state.sets_by_da_id[&[82; 32]];
+        assert_eq!(mixed.state, DaRelaySetState::OrphanChunks);
+        assert!(mixed.commit.is_none());
+        assert_eq!(mixed.chunks[&0].peer_quota_key, key_b);
+        assert_eq!(mixed.peer_bytes.len(), 1);
+        assert_eq!(mixed.peer_bytes[&key_b], 7);
+        assert_eq!(
+            state.sets_by_da_id[&[83; 32]].chunks[&0].peer_quota_key,
+            key_b
+        );
+        assert_eq!(state.sets_by_da_id[&[84; 32]], complete_before);
+        assert!(!state.orphan_bytes_by_da_id.contains_key(&[84; 32]));
+        assert!(!state.orphan_bytes_by_peer_quota_key.contains_key(&key_a));
+        assert_eq!(state.orphan_bytes_by_peer_quota_key[&key_b], peer_b_before);
+        assert_eq!(
+            state.orphan_bytes,
+            state.sets_by_da_id[&[82; 32]].orphan_wire_bytes().unwrap()
+                + state.sets_by_da_id[&[83; 32]].orphan_wire_bytes().unwrap()
+        );
+        let after = state.clone();
+        state.release_peer_quota_key(&key_a).unwrap();
+        assert_eq!(state, after);
     }
 
     #[test]


### PR DESCRIPTION
Refs: RUB-402 / #1864

## Scope
Invariant: Rust DA relay state helper releases incomplete DA records owned by a disconnected peer quota key without touching complete sets or unrelated peer accounting.

Changed surface: `clients/rust/crates/rubin-node/src/da_relay.rs`.

## Non-goals
- No live P2P service lifecycle wiring.
- No provider, miner, or prefetch changes.
- No TTL expiry behavior changes.
- No Go, spec, or conformance fixture changes.

## reference_function_parity_matrix
| Case | Go reference | Rust required behavior | Evidence required | Go callsite/entrypoint | Rust callsite/entrypoint | Rust mirror-test evidence |
| -- | -- | -- | -- | -- | -- | -- |
| peer-owned incomplete records released | `releasePeerQuotaKey` / `withoutPeerQuotaKey` | Remove incomplete commit/chunk entries charged to the disconnected `PeerQuotaKey`; remove the record when it becomes empty | Owned commit and owned orphan chunk removal | `clients/go/node/p2p/da_relay_state.go`: `releasePeerQuotaKey` -> `withoutPeerQuotaKey` | `clients/rust/crates/rubin-node/src/da_relay.rs`: `DaRelayState::release_peer_quota_key` -> `DaRelaySetRecord::without_peer_quota_key` | `cargo test -p rubin-node da_relay_peer_quota_release_helper --lib` / `da_relay_peer_quota_release_helper_releases_peer_owned_incomplete_records_only` |
| unrelated peer records retained | `withoutPeerQuotaKey` | Preserve incomplete records and per-peer accounting for non-matching `PeerQuotaKey` | Peer-b orphan record and peer-b accounting retention | `clients/go/node/p2p/da_relay_state.go`: `dropChunksForPeerQuotaKey` non-match branch | `clients/rust/crates/rubin-node/src/da_relay.rs`: `without_peer_quota_key` non-matching chunk filter branch | `cargo test -p rubin-node da_relay_peer_quota_release_helper --lib` / `da_relay_peer_quota_release_helper_releases_peer_owned_incomplete_records_only` |
| complete sets retained | `withoutPeerQuotaKey` | Leave `CompleteSet` records and pinned payload accounting untouched | Complete set equality and missing orphan index | `clients/go/node/p2p/da_relay_state.go`: `withoutPeerQuotaKey` complete-set guard | `clients/rust/crates/rubin-node/src/da_relay.rs`: `without_peer_quota_key` complete-set guard | `cargo test -p rubin-node da_relay_peer_quota_release_helper --lib` / `da_relay_peer_quota_release_helper_releases_peer_owned_incomplete_records_only` |
| repeated cleanup idempotent | `releasePeerQuotaKey` | A second release for the same key is a no-op after peer accounting reaches zero | Full state comparison after repeated cleanup | `clients/go/node/p2p/da_relay_state.go`: `orphanBytesByPeerQuotaKey[key] == 0` early return | `clients/rust/crates/rubin-node/src/da_relay.rs`: zero/absent peer accounting early return | `cargo test -p rubin-node da_relay_peer_quota_release_helper --lib` / `da_relay_peer_quota_release_helper_releases_peer_owned_incomplete_records_only` |
| accounting recomputed after cleanup | `withoutPeerQuotaKey` / `recomputeOrphanTotals` | Recompute record `wire_bytes`, `peer_bytes`, global orphan bytes, per-DA bytes, and per-peer bytes after filtering | Mixed ownership records cover both retained chunk and retained commit paths | `clients/go/node/p2p/da_relay_state.go`: `recomputeOrphanTotals` then `applyDASetRecordLocked` | `clients/rust/crates/rubin-node/src/da_relay.rs`: `recompute_wire_bytes` then `apply_record` | `cargo test -p rubin-node da_relay_peer_quota_release_helper --lib` / `da_relay_peer_quota_release_helper_releases_peer_owned_incomplete_records_only` |
| no live peer lifecycle wiring in this PR | Issue #1864 scope guard; live wiring belongs to the next lifecycle child | Add only the state helper and isolated helper test seam; do not modify P2P service/provider/miner/prefetch surfaces | Diff evidence shows only `clients/rust/crates/rubin-node/src/da_relay.rs` changes | Go reference lifecycle `unregisterPeerLocked -> releaseDAQuotaIfInactiveLocked -> releasePeerQuotaKey` remains read-only reference | Rust callsite in this child is `DaRelayState::release_peer_quota_key`; service wiring is intentionally absent from this diff | `git diff --name-only origin/main...HEAD` plus `cargo test -p rubin-node da_relay_peer_quota_release_helper --lib` |

## Evidence
- `cargo fmt --check`
- `cargo test -p rubin-node da_relay_peer_quota_release_helper_releases_peer_owned_incomplete_records_only --lib`
- `cargo test -p rubin-node da_relay --lib`
- `cargo test -p rubin-node --lib`
- `cargo clippy -p rubin-node --lib --tests -- -D warnings`
- Rust coverage: diff coverage 94.64%, variation +0.00%

