### PR TITLE
RUB-421 release DA quota after final Rust peer disconnect

### DIFF
--- a/clients/rust/crates/rubin-node/src/da_relay.rs
+++ b/clients/rust/crates/rubin-node/src/da_relay.rs
@@ -518,6 +518,29 @@ impl DaRelayState {
     #[rustfmt::skip]
     pub(crate) fn test_record_summary(&self, da_id: [u8; 32]) -> Option<(bool, usize, u64)> { let record = self.sets_by_da_id.get(&da_id)?; Some((record.commit.is_some(), record.chunks.len(), record.wire_bytes)) }
 
+    #[cfg(test)]
+    pub(crate) fn test_stage_incomplete_da_chunk(
+        &mut self,
+        peer_addr: &str,
+        da_id: [u8; 32],
+        chunk_index: u16,
+        payload: &[u8],
+        wire_bytes: u64,
+    ) -> DaRelayResult {
+        self.stage_incomplete_da_chunk(
+            peer_addr,
+            DaRelayChunk {
+                da_id,
+                chunk_hash: sha3_256(payload),
+                peer_quota_key: PeerQuotaKey::from_peer_addr(peer_addr),
+                chunk_index,
+                payload: Arc::from(payload),
+                wire_bytes,
+                tx_bytes: Arc::from([]),
+            },
+        )
+    }
+
     pub(crate) fn complete_set_eviction_candidates(
         &self,
         max_payload_bytes: u64,

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -397,11 +397,11 @@ impl PeerManager {
         Ok(())
     }
 
-    pub fn remove_peer(&self, addr: &str) {
+    pub fn remove_peer(&self, addr: &str) -> bool {
         let Ok(mut peers) = self.peers.write() else {
-            return;
+            return false;
         };
-        peers.remove(addr);
+        peers.remove(addr).is_some()
     }
 
     pub fn snapshot(&self) -> Vec<PeerState> {

--- a/clients/rust/crates/rubin-node/src/p2p_service.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_service.rs
@@ -1,12 +1,10 @@
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::io;
 use std::net::{TcpListener, TcpStream};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
-
-use std::collections::HashMap;
 
 use crate::da_relay::{DaRelayCaps, DaRelayState, PeerQuotaKey};
 use crate::p2p_runtime::{
@@ -17,6 +15,8 @@ use crate::sync_reorg::TxPoolCleanupPlan;
 use crate::tx_relay::{PeerOutbox, TxRelayState};
 use crate::{SyncEngine, TxPool};
 
+type PeerQuotaLockMap = BTreeMap<PeerQuotaKey, Arc<PeerQuotaLockEntry>>;
+type PeerQuotaLocks = Arc<Mutex<PeerQuotaLockMap>>;
 const ACCEPT_LOOP_SLEEP: Duration = Duration::from_millis(100);
 const RECONNECT_LOOP_SLEEP: Duration = Duration::from_millis(250);
 const RECONNECT_INTERVAL: Duration = Duration::from_secs(5);
@@ -63,6 +63,7 @@ struct SharedServiceState {
     worker_handles: Arc<Mutex<Vec<JoinHandle<()>>>>,
     peer_manager: Arc<PeerManager>,
     peer_lifecycle: Arc<Mutex<()>>,
+    peer_quota_locks: PeerQuotaLocks,
     sync_engine: Arc<Mutex<SyncEngine>>,
     tx_pool: Arc<Mutex<TxPool>>,
     da_relay: Arc<Mutex<DaRelayState>>,
@@ -167,6 +168,7 @@ pub fn start_node_p2p_service(cfg: NodeP2PServiceConfig) -> Result<RunningNodeP2
         worker_handles: Arc::new(Mutex::new(Vec::new())),
         peer_manager: cfg.peer_manager,
         peer_lifecycle: Arc::new(Mutex::new(())),
+        peer_quota_locks: Arc::new(Mutex::new(BTreeMap::new())),
         sync_engine: cfg.sync_engine,
         tx_pool: cfg.tx_pool,
         da_relay,
@@ -818,6 +820,8 @@ fn handle_peer(
         peer_state.addr = addr.clone();
     }
     let peer_addr = peer_state.addr.clone();
+    let peer_quota_lock = PeerQuotaLockHandle::acquire(&shared.peer_quota_locks, &peer_addr);
+    let peer_quota_guard = peer_quota_lock.lock();
 
     // Register before peer visibility so local block announce cannot snapshot
     // a connected peer without an outbox. Declaration order makes it drop last.
@@ -830,7 +834,7 @@ fn handle_peer(
             .add_peer(peer_state)
             .map_err(|err| format!("peer register: {err}"))?;
     }
-
+    drop(peer_quota_guard);
     // Declaration order is critical: Rust drops locals in REVERSE
     // declaration order, so guards declared earlier outlive guards
     // declared later. We need the alias to stay registered until AFTER
@@ -849,6 +853,7 @@ fn handle_peer(
 
     let _peer_guard = PeerGuard {
         peer_lifecycle: Arc::clone(&shared.peer_lifecycle),
+        peer_quota_locks: Arc::clone(&shared.peer_quota_locks),
         peer_manager: Arc::clone(&shared.peer_manager),
         da_relay: Arc::clone(&shared.da_relay),
         addr: peer_addr.clone(),
@@ -1072,6 +1077,7 @@ fn service_local_version(
 
 struct PeerGuard {
     peer_lifecycle: Arc<Mutex<()>>,
+    peer_quota_locks: PeerQuotaLocks,
     peer_manager: Arc<PeerManager>,
     da_relay: Arc<Mutex<DaRelayState>>,
     addr: String,
@@ -1079,15 +1085,81 @@ struct PeerGuard {
 
 impl Drop for PeerGuard {
     fn drop(&mut self) {
-        let _peer_lifecycle_guard = lock_peer_lifecycle(&self.peer_lifecycle);
-        if self.peer_manager.remove_peer(&self.addr) {
+        let peer_quota_lock = PeerQuotaLockHandle::acquire(&self.peer_quota_locks, &self.addr);
+        let _peer_quota_guard = peer_quota_lock.lock();
+        let removed = {
+            let _peer_lifecycle_guard = lock_peer_lifecycle(&self.peer_lifecycle);
+            self.peer_manager.remove_peer(&self.addr)
+        };
+        if removed {
             release_da_quota_if_inactive(&self.peer_manager, &self.da_relay, &self.addr);
+        }
+    }
+}
+
+#[derive(Default)]
+struct PeerQuotaLockEntry {
+    refs: AtomicUsize,
+    lock: Mutex<()>,
+}
+
+struct PeerQuotaLockHandle {
+    peer_quota_locks: PeerQuotaLocks,
+    quota_key: PeerQuotaKey,
+    entry: Arc<PeerQuotaLockEntry>,
+}
+
+impl PeerQuotaLockHandle {
+    fn acquire(peer_quota_locks: &PeerQuotaLocks, addr: &str) -> Self {
+        let quota_key = PeerQuotaKey::from_peer_addr(addr);
+        let entry = {
+            let mut locks = lock_peer_quota_locks(peer_quota_locks);
+            Arc::clone(
+                locks
+                    .entry(quota_key.clone())
+                    .or_insert_with(|| Arc::new(PeerQuotaLockEntry::default())),
+            )
+        };
+        entry.refs.fetch_add(1, Ordering::AcqRel);
+        Self {
+            peer_quota_locks: Arc::clone(peer_quota_locks),
+            quota_key,
+            entry,
+        }
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, ()> {
+        self.entry
+            .lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+impl Drop for PeerQuotaLockHandle {
+    fn drop(&mut self) {
+        if self.entry.refs.fetch_sub(1, Ordering::AcqRel) == 1 {
+            let mut locks = lock_peer_quota_locks(&self.peer_quota_locks);
+            if locks
+                .get(&self.quota_key)
+                .is_some_and(|entry| Arc::ptr_eq(entry, &self.entry))
+            {
+                locks.remove(&self.quota_key);
+            }
         }
     }
 }
 
 fn lock_peer_lifecycle(peer_lifecycle: &Mutex<()>) -> std::sync::MutexGuard<'_, ()> {
     peer_lifecycle
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+fn lock_peer_quota_locks(
+    peer_quota_locks: &Mutex<PeerQuotaLockMap>,
+) -> std::sync::MutexGuard<'_, PeerQuotaLockMap> {
+    peer_quota_locks
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
@@ -1201,7 +1273,7 @@ mod tests {
         maybe_apply_tx_pool_cleanup, outbound_connect_timeout, reconnect_missing_bootstrap_peers,
         register_peer_alias, register_peer_outbox, should_skip_outbound_dial,
         start_node_p2p_service, wait_for_service_shutdown, NodeP2PServiceConfig, PeerAliasGuard,
-        PeerGuard, SharedServiceState,
+        PeerGuard, PeerQuotaLockHandle, SharedServiceState,
     };
     use crate::genesis::{devnet_genesis_block_bytes, devnet_genesis_chain_id};
     use crate::interop::local_version;
@@ -1271,6 +1343,7 @@ mod tests {
             worker_handles: Arc::new(Mutex::new(Vec::new())),
             peer_manager: Arc::new(PeerManager::new(runtime_cfg)),
             peer_lifecycle: Arc::new(Mutex::new(())),
+            peer_quota_locks: Arc::new(Mutex::new(Default::default())),
             sync_engine,
             tx_pool: Arc::new(Mutex::new(TxPool::new())),
             da_relay: Arc::new(Mutex::new(
@@ -1300,6 +1373,7 @@ mod tests {
             .expect("register test peer");
         PeerGuard {
             peer_lifecycle: Arc::clone(&shared.peer_lifecycle),
+            peer_quota_locks: Arc::clone(&shared.peer_quota_locks),
             peer_manager: Arc::clone(&shared.peer_manager),
             da_relay: Arc::clone(&shared.da_relay),
             addr: addr.to_string(),
@@ -2582,6 +2656,74 @@ mod tests {
             let da_relay = shared.da_relay.lock().unwrap();
             assert_eq!(da_relay.test_record_summary([81; 32]), None);
         }
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn peer_guard_drop_preserves_da_quota_for_pending_same_key_registration() {
+        let (sync_engine, dir) = test_engine("rubin-node-p2p-da-pending-peer-release");
+        let shared = test_shared_state(
+            default_peer_runtime_config("devnet", 8),
+            vec![],
+            sync_engine,
+        );
+        let peer_a = "10.9.0.2:19111";
+
+        {
+            let mut da_relay = shared.da_relay.lock().unwrap();
+            da_relay
+                .test_stage_incomplete_da_chunk(peer_a, [82; 32], 0, b"pending-owned", 13)
+                .unwrap();
+        }
+
+        let guard_a = register_test_peer(&shared, peer_a);
+        let quota_lock = PeerQuotaLockHandle::acquire(&shared.peer_quota_locks, "10.9.0.2:29111");
+        let quota_guard = quota_lock.lock();
+        let drop_handle = thread::spawn(move || drop(guard_a));
+        let _guard_b = register_test_peer(&shared, "10.9.0.2:29111");
+        drop(quota_guard);
+        drop_handle.join().expect("drop old same-key peer");
+        {
+            let da_relay = shared.da_relay.lock().unwrap();
+            assert_eq!(da_relay.test_record_summary([82; 32]), Some((false, 1, 13)));
+        }
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn peer_guard_drop_does_not_hold_lifecycle_while_releasing_da_quota() {
+        let (sync_engine, dir) = test_engine("rubin-node-p2p-da-release-outside-lifecycle");
+        let shared = test_shared_state(
+            default_peer_runtime_config("devnet", 8),
+            vec![],
+            sync_engine,
+        );
+        let peer = "10.9.0.4:19111";
+
+        {
+            let mut da_relay = shared.da_relay.lock().unwrap();
+            da_relay
+                .test_stage_incomplete_da_chunk(peer, [84; 32], 0, b"blocked-cleanup", 17)
+                .unwrap();
+        }
+        let peer_guard = register_test_peer(&shared, peer);
+        let da_relay_guard = shared.da_relay.lock().unwrap();
+        let drop_handle = thread::spawn(move || drop(peer_guard));
+
+        wait_until(Instant::now() + Duration::from_secs(2), || {
+            !shared
+                .peer_manager
+                .snapshot()
+                .iter()
+                .any(|state| state.addr == peer)
+        });
+        assert!(
+            shared.peer_lifecycle.try_lock().is_ok(),
+            "DA quota cleanup must not block peer lifecycle registration/removal"
+        );
+
+        drop(da_relay_guard);
+        drop_handle.join().expect("drop peer guard");
         fs::remove_dir_all(dir).expect("cleanup");
     }
 

--- a/clients/rust/crates/rubin-node/src/p2p_service.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_service.rs
@@ -15,7 +15,7 @@ use crate::sync_reorg::TxPoolCleanupPlan;
 use crate::tx_relay::{PeerOutbox, TxRelayState};
 use crate::{SyncEngine, TxPool};
 
-type PeerQuotaLockMap = BTreeMap<PeerQuotaKey, Arc<PeerQuotaLockEntry>>;
+type PeerQuotaLockMap = BTreeMap<PeerQuotaKey, PeerQuotaLockEntry>;
 type PeerQuotaLocks = Arc<Mutex<PeerQuotaLockMap>>;
 const ACCEPT_LOOP_SLEEP: Duration = Duration::from_millis(100);
 const RECONNECT_LOOP_SLEEP: Duration = Duration::from_millis(250);
@@ -1099,38 +1099,34 @@ impl Drop for PeerGuard {
 
 #[derive(Default)]
 struct PeerQuotaLockEntry {
-    refs: AtomicUsize,
-    lock: Mutex<()>,
+    refs: usize,
+    lock: Arc<Mutex<()>>,
 }
 
 struct PeerQuotaLockHandle {
     peer_quota_locks: PeerQuotaLocks,
     quota_key: PeerQuotaKey,
-    entry: Arc<PeerQuotaLockEntry>,
+    lock: Arc<Mutex<()>>,
 }
 
 impl PeerQuotaLockHandle {
     fn acquire(peer_quota_locks: &PeerQuotaLocks, addr: &str) -> Self {
         let quota_key = PeerQuotaKey::from_peer_addr(addr);
-        let entry = {
+        let lock = {
             let mut locks = lock_peer_quota_locks(peer_quota_locks);
-            Arc::clone(
-                locks
-                    .entry(quota_key.clone())
-                    .or_insert_with(|| Arc::new(PeerQuotaLockEntry::default())),
-            )
+            let entry = locks.entry(quota_key.clone()).or_default();
+            entry.refs += 1;
+            Arc::clone(&entry.lock)
         };
-        entry.refs.fetch_add(1, Ordering::AcqRel);
         Self {
             peer_quota_locks: Arc::clone(peer_quota_locks),
             quota_key,
-            entry,
+            lock,
         }
     }
 
     fn lock(&self) -> std::sync::MutexGuard<'_, ()> {
-        self.entry
-            .lock
+        self.lock
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
@@ -1138,14 +1134,16 @@ impl PeerQuotaLockHandle {
 
 impl Drop for PeerQuotaLockHandle {
     fn drop(&mut self) {
-        if self.entry.refs.fetch_sub(1, Ordering::AcqRel) == 1 {
-            let mut locks = lock_peer_quota_locks(&self.peer_quota_locks);
-            if locks
-                .get(&self.quota_key)
-                .is_some_and(|entry| Arc::ptr_eq(entry, &self.entry))
-            {
-                locks.remove(&self.quota_key);
+        let mut locks = lock_peer_quota_locks(&self.peer_quota_locks);
+        let should_remove = locks.get_mut(&self.quota_key).is_some_and(|entry| {
+            if !Arc::ptr_eq(&entry.lock, &self.lock) || entry.refs == 0 {
+                return false;
             }
+            entry.refs -= 1;
+            entry.refs == 0
+        });
+        if should_remove {
+            locks.remove(&self.quota_key);
         }
     }
 }
@@ -2688,6 +2686,40 @@ mod tests {
             assert_eq!(da_relay.test_record_summary([82; 32]), Some((false, 1, 13)));
         }
         fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn peer_quota_lock_refcounts_stay_with_map_entry() {
+        let locks = Arc::new(Mutex::new(Default::default()));
+        let quota_key = crate::da_relay::PeerQuotaKey::from_peer_addr("10.9.0.3:19111");
+
+        let first = PeerQuotaLockHandle::acquire(&locks, "10.9.0.3:19111");
+        {
+            let guard = locks.lock().unwrap();
+            let entry = guard.get(&quota_key).expect("quota lock entry");
+            assert_eq!(entry.refs, 1);
+            assert!(Arc::ptr_eq(&entry.lock, &first.lock));
+        }
+
+        let second = PeerQuotaLockHandle::acquire(&locks, "10.9.0.3:29111");
+        {
+            let guard = locks.lock().unwrap();
+            let entry = guard.get(&quota_key).expect("quota lock entry");
+            assert_eq!(entry.refs, 2);
+            assert!(Arc::ptr_eq(&entry.lock, &first.lock));
+            assert!(Arc::ptr_eq(&entry.lock, &second.lock));
+        }
+
+        drop(first);
+        {
+            let guard = locks.lock().unwrap();
+            let entry = guard.get(&quota_key).expect("quota lock entry");
+            assert_eq!(entry.refs, 1);
+            assert!(Arc::ptr_eq(&entry.lock, &second.lock));
+        }
+
+        drop(second);
+        assert!(!locks.lock().unwrap().contains_key(&quota_key));
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/p2p_service.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_service.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, Instant};
 
 use std::collections::HashMap;
 
-use crate::da_relay::{DaRelayCaps, DaRelayState};
+use crate::da_relay::{DaRelayCaps, DaRelayState, PeerQuotaKey};
 use crate::p2p_runtime::{
     perform_version_handshake, LiveMessageOutcome, PeerManager, PeerRelayContext,
     PeerRuntimeConfig, VersionPayloadV1, WireMessage,
@@ -62,6 +62,7 @@ struct SharedServiceState {
     active_sessions: Arc<AtomicUsize>,
     worker_handles: Arc<Mutex<Vec<JoinHandle<()>>>>,
     peer_manager: Arc<PeerManager>,
+    peer_lifecycle: Arc<Mutex<()>>,
     sync_engine: Arc<Mutex<SyncEngine>>,
     tx_pool: Arc<Mutex<TxPool>>,
     da_relay: Arc<Mutex<DaRelayState>>,
@@ -165,6 +166,7 @@ pub fn start_node_p2p_service(cfg: NodeP2PServiceConfig) -> Result<RunningNodeP2
         active_sessions: Arc::new(AtomicUsize::new(0)),
         worker_handles: Arc::new(Mutex::new(Vec::new())),
         peer_manager: cfg.peer_manager,
+        peer_lifecycle: Arc::new(Mutex::new(())),
         sync_engine: cfg.sync_engine,
         tx_pool: cfg.tx_pool,
         da_relay,
@@ -821,10 +823,13 @@ fn handle_peer(
     // a connected peer without an outbox. Declaration order makes it drop last.
     let _outbox_guard = register_peer_outbox(&shared.peer_outboxes, &peer_addr)?;
 
-    shared
-        .peer_manager
-        .add_peer(peer_state)
-        .map_err(|err| format!("peer register: {err}"))?;
+    {
+        let _peer_lifecycle_guard = lock_peer_lifecycle(&shared.peer_lifecycle);
+        shared
+            .peer_manager
+            .add_peer(peer_state)
+            .map_err(|err| format!("peer register: {err}"))?;
+    }
 
     // Declaration order is critical: Rust drops locals in REVERSE
     // declaration order, so guards declared earlier outlive guards
@@ -843,7 +848,9 @@ fn handle_peer(
     let _alias_guard = register_peer_alias(&shared, &remote_raw_addr, &peer_addr);
 
     let _peer_guard = PeerGuard {
+        peer_lifecycle: Arc::clone(&shared.peer_lifecycle),
         peer_manager: Arc::clone(&shared.peer_manager),
+        da_relay: Arc::clone(&shared.da_relay),
         addr: peer_addr.clone(),
     };
 
@@ -1064,14 +1071,44 @@ fn service_local_version(
 }
 
 struct PeerGuard {
+    peer_lifecycle: Arc<Mutex<()>>,
     peer_manager: Arc<PeerManager>,
+    da_relay: Arc<Mutex<DaRelayState>>,
     addr: String,
 }
 
 impl Drop for PeerGuard {
     fn drop(&mut self) {
-        self.peer_manager.remove_peer(&self.addr);
+        let _peer_lifecycle_guard = lock_peer_lifecycle(&self.peer_lifecycle);
+        if self.peer_manager.remove_peer(&self.addr) {
+            release_da_quota_if_inactive(&self.peer_manager, &self.da_relay, &self.addr);
+        }
     }
+}
+
+fn lock_peer_lifecycle(peer_lifecycle: &Mutex<()>) -> std::sync::MutexGuard<'_, ()> {
+    peer_lifecycle
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+fn release_da_quota_if_inactive(
+    peer_manager: &PeerManager,
+    da_relay: &Mutex<DaRelayState>,
+    addr: &str,
+) {
+    let quota_key = PeerQuotaKey::from_peer_addr(addr);
+    let active_same_key = peer_manager
+        .snapshot()
+        .iter()
+        .any(|peer| PeerQuotaKey::from_peer_addr(&peer.addr) == quota_key);
+    if active_same_key {
+        return;
+    }
+    let mut da_relay = da_relay
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let _ = da_relay.release_peer_quota_key(&quota_key);
 }
 
 struct PeerOutboxGuard {
@@ -1231,6 +1268,7 @@ mod tests {
             active_sessions: Arc::new(AtomicUsize::new(0)),
             worker_handles: Arc::new(Mutex::new(Vec::new())),
             peer_manager: Arc::new(PeerManager::new(runtime_cfg)),
+            peer_lifecycle: Arc::new(Mutex::new(())),
             sync_engine,
             tx_pool: Arc::new(Mutex::new(TxPool::new())),
             da_relay: Arc::new(Mutex::new(
@@ -1246,6 +1284,23 @@ mod tests {
             peer_outboxes: Arc::new(Mutex::new(HashMap::new())),
             peer_aliases: Arc::new(Mutex::new(HashMap::new())),
             local_addr: "127.0.0.1:0".to_string(),
+        }
+    }
+
+    fn register_test_peer(shared: &SharedServiceState, addr: &str) -> PeerGuard {
+        let _peer_lifecycle_guard = super::lock_peer_lifecycle(&shared.peer_lifecycle);
+        shared
+            .peer_manager
+            .add_peer(crate::p2p_runtime::PeerState {
+                addr: addr.to_string(),
+                ..Default::default()
+            })
+            .expect("register test peer");
+        PeerGuard {
+            peer_lifecycle: Arc::clone(&shared.peer_lifecycle),
+            peer_manager: Arc::clone(&shared.peer_manager),
+            da_relay: Arc::clone(&shared.da_relay),
+            addr: addr.to_string(),
         }
     }
 
@@ -2469,18 +2524,8 @@ mod tests {
 
         let outbox_guard =
             register_peer_outbox(&shared.peer_outboxes, &primary).expect("register outbox");
-        shared
-            .peer_manager
-            .add_peer(crate::p2p_runtime::PeerState {
-                addr: primary.clone(),
-                ..Default::default()
-            })
-            .expect("register primary");
+        let peer_guard = register_test_peer(&shared, &primary);
         let alias_guard = register_peer_alias(&shared, alias, &primary).expect("register alias");
-        let peer_guard = PeerGuard {
-            peer_manager: Arc::clone(&shared.peer_manager),
-            addr: primary.clone(),
-        };
 
         assert!(is_connected_with_alias(&shared, &primary));
         assert!(is_connected_with_alias(&shared, alias));
@@ -2503,6 +2548,69 @@ mod tests {
 
         drop(outbox_guard);
         assert!(!shared.peer_outboxes.lock().unwrap().contains_key(&primary));
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn peer_guard_drop_releases_da_quota_only_after_final_same_key_peer() {
+        let (sync_engine, dir) = test_engine("rubin-node-p2p-da-final-peer-release");
+        let runtime_cfg = default_peer_runtime_config("devnet", 8);
+        let shared = test_shared_state(runtime_cfg, vec![], sync_engine);
+        let peer_a = "10.9.0.1:19111";
+        let peer_a_same_key = "10.9.0.1:29111";
+
+        {
+            let mut da_relay = shared.da_relay.lock().unwrap();
+            da_relay
+                .test_stage_incomplete_da_chunk(peer_a, [81; 32], 0, b"owned-chunk", 11)
+                .unwrap();
+        }
+
+        let guard_a = register_test_peer(&shared, peer_a);
+        let guard_a_same_key = register_test_peer(&shared, peer_a_same_key);
+
+        drop(guard_a);
+        {
+            let da_relay = shared.da_relay.lock().unwrap();
+            assert_eq!(da_relay.test_record_summary([81; 32]), Some((false, 1, 11)));
+        }
+
+        drop(guard_a_same_key);
+        {
+            let da_relay = shared.da_relay.lock().unwrap();
+            assert_eq!(da_relay.test_record_summary([81; 32]), None);
+        }
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn peer_guard_drop_recovers_poisoned_da_relay_lock_without_peer_leak() {
+        let (sync_engine, dir) = test_engine("rubin-node-p2p-da-poison-release");
+        let runtime_cfg = default_peer_runtime_config("devnet", 8);
+        let shared = test_shared_state(runtime_cfg, vec![], sync_engine);
+        let peer = "10.9.0.3:19111";
+        let peer_guard = register_test_peer(&shared, peer);
+
+        let da_relay = Arc::clone(&shared.da_relay);
+        let poison = std::panic::catch_unwind(move || {
+            let _guard = da_relay.lock().unwrap();
+            panic!("poison DA relay lock");
+        });
+        assert!(poison.is_err());
+        assert!(shared.da_relay.lock().is_err());
+
+        let drop_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            drop(peer_guard);
+        }));
+        assert!(drop_result.is_ok());
+        assert!(
+            !shared
+                .peer_manager
+                .snapshot()
+                .iter()
+                .any(|state| state.addr == peer),
+            "peer manager cleanup must not be skipped when DA relay lock is poisoned",
+        );
         fs::remove_dir_all(dir).expect("cleanup");
     }
 

--- a/clients/rust/crates/rubin-node/src/p2p_service.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_service.rs
@@ -1108,7 +1108,9 @@ fn release_da_quota_if_inactive(
     let mut da_relay = da_relay
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
-    let _ = da_relay.release_peer_quota_key(&quota_key);
+    if let Err(err) = da_relay.release_peer_quota_key(&quota_key) {
+        eprintln!("p2p: DA peer quota release failed for {quota_key:?}: {err:?}");
+    }
 }
 
 struct PeerOutboxGuard {

--- a/clients/rust/crates/rubin-node/src/p2p_service.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_service.rs
@@ -1106,6 +1106,7 @@ impl Drop for PeerGuard {
 #[derive(Default)]
 struct PeerQuotaLockEntry {
     refs: usize,
+    closing: bool,
     lock: Arc<Mutex<()>>,
 }
 
@@ -1118,16 +1119,26 @@ struct PeerQuotaLockHandle {
 impl PeerQuotaLockHandle {
     fn acquire(peer_quota_locks: &PeerQuotaLocks, addr: &str) -> Self {
         let quota_key = PeerQuotaKey::from_peer_addr(addr);
-        let lock = {
-            let mut locks = lock_peer_quota_locks(peer_quota_locks);
-            let entry = locks.entry(quota_key.clone()).or_default();
-            entry.refs += 1;
-            Arc::clone(&entry.lock)
-        };
-        Self {
-            peer_quota_locks: Arc::clone(peer_quota_locks),
-            quota_key,
-            lock,
+        loop {
+            let wait_lock = {
+                let mut locks = lock_peer_quota_locks(peer_quota_locks);
+                let entry = locks.entry(quota_key.clone()).or_default();
+                if !entry.closing {
+                    entry.refs += 1;
+                    let lock = Arc::clone(&entry.lock);
+                    return Self {
+                        peer_quota_locks: Arc::clone(peer_quota_locks),
+                        quota_key,
+                        lock,
+                    };
+                }
+                Arc::clone(&entry.lock)
+            };
+            drop(
+                wait_lock
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner()),
+            );
         }
     }
 
@@ -1244,16 +1255,23 @@ fn release_da_quota_if_inactive_and_unqueued(
     peer_manager: &PeerManager,
     da_relay: &Mutex<DaRelayState>,
 ) {
-    // Hold the lock-map mutex through the no-queued check and DA cleanup so a
-    // new same-key registration cannot publish a ref between them.
-    let locks = lock_peer_quota_locks(&peer_quota_lock.peer_quota_locks);
-    if locks
-        .get(&peer_quota_lock.quota_key)
-        .is_none_or(|entry| !Arc::ptr_eq(&entry.lock, &peer_quota_lock.lock) || entry.refs > 1)
     {
-        return;
+        let mut locks = lock_peer_quota_locks(&peer_quota_lock.peer_quota_locks);
+        let Some(entry) = locks.get_mut(&peer_quota_lock.quota_key) else {
+            return;
+        };
+        if !Arc::ptr_eq(&entry.lock, &peer_quota_lock.lock) || entry.refs > 1 {
+            return;
+        }
+        entry.closing = true;
     }
     release_da_quota_if_inactive(peer_manager, da_relay, &peer_quota_lock.quota_key);
+    let mut locks = lock_peer_quota_locks(&peer_quota_lock.peer_quota_locks);
+    if let Some(entry) = locks.get_mut(&peer_quota_lock.quota_key) {
+        if Arc::ptr_eq(&entry.lock, &peer_quota_lock.lock) {
+            entry.closing = false;
+        }
+    }
 }
 
 struct PeerOutboxGuard {
@@ -1621,6 +1639,12 @@ mod tests {
         let quota_key = crate::da_relay::PeerQuotaKey::from_peer_addr(addr);
         let locks = super::lock_peer_quota_locks(&shared.peer_quota_locks);
         locks.get(&quota_key).map_or(0, |entry| entry.refs)
+    }
+
+    fn peer_quota_entry_closing(shared: &SharedServiceState, addr: &str) -> bool {
+        let quota_key = crate::da_relay::PeerQuotaKey::from_peer_addr(addr);
+        let locks = super::lock_peer_quota_locks(&shared.peer_quota_locks);
+        locks.get(&quota_key).is_some_and(|entry| entry.closing)
     }
 
     /// Under LLVM coverage (tarpaulin), the first TCP handshake attempt on Darwin
@@ -2898,7 +2922,7 @@ mod tests {
     }
 
     #[test]
-    fn peer_guard_drop_blocks_same_key_ref_acquire_until_da_release_decision_finishes() {
+    fn peer_guard_drop_blocks_same_key_ref_but_not_unrelated_keys_during_da_release() {
         let (sync_engine, dir) = test_engine("rubin-node-p2p-da-ref-release-atomic");
         let shared = test_shared_state(
             default_peer_runtime_config("devnet", 8),
@@ -2926,11 +2950,23 @@ mod tests {
                 .any(|state| state.addr == peer_a)
         });
         wait_until(Instant::now() + Duration::from_secs(2), || {
-            matches!(
-                shared.peer_quota_locks.try_lock(),
-                Err(std::sync::TryLockError::WouldBlock)
-            )
+            peer_quota_entry_closing(&shared, peer_a)
         });
+
+        let (unrelated_ready_tx, unrelated_ready_rx) = std::sync::mpsc::channel();
+        let unrelated_shared = shared.clone();
+        let unrelated_handle = thread::spawn(move || {
+            let unrelated_lock =
+                PeerQuotaLockHandle::acquire(&unrelated_shared.peer_quota_locks, "10.9.99.1:19111");
+            unrelated_ready_tx
+                .send(())
+                .expect("signal unrelated quota ref");
+            let _unrelated_guard = unrelated_lock.lock();
+        });
+        unrelated_ready_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("unrelated quota key must not wait for DA release");
+        unrelated_handle.join().expect("unrelated quota ref");
 
         let (pending_ready_tx, pending_ready_rx) = std::sync::mpsc::channel();
         let pending_shared = shared.clone();
@@ -2952,7 +2988,7 @@ mod tests {
         drop_handle.join().expect("drop old peer");
         pending_ready_rx
             .recv_timeout(Duration::from_secs(2))
-            .expect("pending ref after cleanup releases map lock");
+            .expect("pending ref after cleanup releases same-key closing state");
         pending_handle.join().expect("pending quota ref");
         {
             let da_relay = shared.da_relay.lock().unwrap();

--- a/clients/rust/crates/rubin-node/src/p2p_service.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_service.rs
@@ -787,14 +787,6 @@ fn handle_peer(
     )
     .map_err(|err| format!("handshake: {err}"))?;
 
-    // Clear in-flight marker after handshake completes (outbound only).
-    // Marker was kept through TCP connect + handshake to prevent duplicate dials.
-    // Now that handshake succeeded, active_sessions takes over slot accounting.
-    if let Some(ref addr) = outbound_addr {
-        let mut guard = lock_in_flight_dials(&shared);
-        guard.remove(addr);
-    }
-
     // Acquire session slot AFTER handshake succeeds for BOTH inbound and outbound.
     // No pre-handshake reservation — prevents unauthenticated/malicious peers
     // from holding slots during slow handshakes.
@@ -820,8 +812,13 @@ fn handle_peer(
         peer_state.addr = addr.clone();
     }
     let peer_addr = peer_state.addr.clone();
-    let peer_quota_lock = PeerQuotaLockHandle::acquire(&shared.peer_quota_locks, &peer_addr);
-    let peer_quota_guard = peer_quota_lock.lock();
+    let mut peer_registration = PendingPeerRegistration::new(
+        &shared.peer_quota_locks,
+        Arc::clone(&shared.peer_manager),
+        Arc::clone(&shared.da_relay),
+        &peer_addr,
+    );
+    let peer_quota_guard = peer_registration.lock()?;
 
     // Register before peer visibility so local block announce cannot snapshot
     // a connected peer without an outbox. Declaration order makes it drop last.
@@ -835,6 +832,10 @@ fn handle_peer(
             .map_err(|err| format!("peer register: {err}"))?;
     }
     drop(peer_quota_guard);
+    if let Some(ref addr) = outbound_addr {
+        let mut guard = lock_in_flight_dials(&shared);
+        guard.remove(addr);
+    }
     // Declaration order is critical: Rust drops locals in REVERSE
     // declaration order, so guards declared earlier outlive guards
     // declared later. We need the alias to stay registered until AFTER
@@ -858,6 +859,7 @@ fn handle_peer(
         da_relay: Arc::clone(&shared.da_relay),
         addr: peer_addr.clone(),
     };
+    peer_registration.finish();
 
     // Build relay context for message loop. RUB-178 / GitHub #1438
     // introduced the lifecycle plumbing; `tx_pool` threads the existing
@@ -1092,7 +1094,11 @@ impl Drop for PeerGuard {
             self.peer_manager.remove_peer(&self.addr)
         };
         if removed {
-            release_da_quota_if_inactive(&self.peer_manager, &self.da_relay, &self.addr);
+            release_da_quota_if_inactive_and_unqueued(
+                &peer_quota_lock,
+                &self.peer_manager,
+                &self.da_relay,
+            );
         }
     }
 }
@@ -1132,6 +1138,57 @@ impl PeerQuotaLockHandle {
     }
 }
 
+struct PendingPeerRegistration {
+    peer_quota_locks: PeerQuotaLocks,
+    peer_manager: Arc<PeerManager>,
+    da_relay: Arc<Mutex<DaRelayState>>,
+    addr: String,
+    peer_quota_lock: Option<PeerQuotaLockHandle>,
+}
+
+impl PendingPeerRegistration {
+    fn new(
+        peer_quota_locks: &PeerQuotaLocks,
+        peer_manager: Arc<PeerManager>,
+        da_relay: Arc<Mutex<DaRelayState>>,
+        addr: &str,
+    ) -> Self {
+        Self {
+            peer_quota_locks: Arc::clone(peer_quota_locks),
+            peer_manager,
+            da_relay,
+            addr: addr.to_string(),
+            peer_quota_lock: Some(PeerQuotaLockHandle::acquire(peer_quota_locks, addr)),
+        }
+    }
+
+    fn lock(&self) -> Result<std::sync::MutexGuard<'_, ()>, String> {
+        let Some(peer_quota_lock) = self.peer_quota_lock.as_ref() else {
+            return Err("peer quota registration handle missing".to_string());
+        };
+        Ok(peer_quota_lock.lock())
+    }
+
+    fn finish(&mut self) {
+        self.peer_quota_lock.take();
+    }
+}
+
+impl Drop for PendingPeerRegistration {
+    fn drop(&mut self) {
+        if let Some(peer_quota_lock) = self.peer_quota_lock.take() {
+            drop(peer_quota_lock);
+            let cleanup_lock = PeerQuotaLockHandle::acquire(&self.peer_quota_locks, &self.addr);
+            let _cleanup_guard = cleanup_lock.lock();
+            release_da_quota_if_inactive_and_unqueued(
+                &cleanup_lock,
+                &self.peer_manager,
+                &self.da_relay,
+            );
+        }
+    }
+}
+
 impl Drop for PeerQuotaLockHandle {
     fn drop(&mut self) {
         let mut locks = lock_peer_quota_locks(&self.peer_quota_locks);
@@ -1165,22 +1222,38 @@ fn lock_peer_quota_locks(
 fn release_da_quota_if_inactive(
     peer_manager: &PeerManager,
     da_relay: &Mutex<DaRelayState>,
-    addr: &str,
+    quota_key: &PeerQuotaKey,
 ) {
-    let quota_key = PeerQuotaKey::from_peer_addr(addr);
     let active_same_key = peer_manager
         .snapshot()
         .iter()
-        .any(|peer| PeerQuotaKey::from_peer_addr(&peer.addr) == quota_key);
+        .any(|peer| PeerQuotaKey::from_peer_addr(&peer.addr) == *quota_key);
     if active_same_key {
         return;
     }
     let mut da_relay = da_relay
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
-    if let Err(err) = da_relay.release_peer_quota_key(&quota_key) {
+    if let Err(err) = da_relay.release_peer_quota_key(quota_key) {
         eprintln!("p2p: DA peer quota release failed for {quota_key:?}: {err:?}");
     }
+}
+
+fn release_da_quota_if_inactive_and_unqueued(
+    peer_quota_lock: &PeerQuotaLockHandle,
+    peer_manager: &PeerManager,
+    da_relay: &Mutex<DaRelayState>,
+) {
+    // Hold the lock-map mutex through the no-queued check and DA cleanup so a
+    // new same-key registration cannot publish a ref between them.
+    let locks = lock_peer_quota_locks(&peer_quota_lock.peer_quota_locks);
+    if locks
+        .get(&peer_quota_lock.quota_key)
+        .is_none_or(|entry| !Arc::ptr_eq(&entry.lock, &peer_quota_lock.lock) || entry.refs > 1)
+    {
+        return;
+    }
+    release_da_quota_if_inactive(peer_manager, da_relay, &peer_quota_lock.quota_key);
 }
 
 struct PeerOutboxGuard {
@@ -1271,7 +1344,7 @@ mod tests {
         maybe_apply_tx_pool_cleanup, outbound_connect_timeout, reconnect_missing_bootstrap_peers,
         register_peer_alias, register_peer_outbox, should_skip_outbound_dial,
         start_node_p2p_service, wait_for_service_shutdown, NodeP2PServiceConfig, PeerAliasGuard,
-        PeerGuard, PeerQuotaLockHandle, SharedServiceState,
+        PeerGuard, PeerQuotaLockHandle, PendingPeerRegistration, SharedServiceState,
     };
     use crate::genesis::{devnet_genesis_block_bytes, devnet_genesis_chain_id};
     use crate::interop::local_version;
@@ -1361,14 +1434,18 @@ mod tests {
     }
 
     fn register_test_peer(shared: &SharedServiceState, addr: &str) -> PeerGuard {
-        let _peer_lifecycle_guard = super::lock_peer_lifecycle(&shared.peer_lifecycle);
-        shared
-            .peer_manager
-            .add_peer(crate::p2p_runtime::PeerState {
-                addr: addr.to_string(),
-                ..Default::default()
-            })
-            .expect("register test peer");
+        {
+            let peer_quota_lock = PeerQuotaLockHandle::acquire(&shared.peer_quota_locks, addr);
+            let _peer_quota_guard = peer_quota_lock.lock();
+            let _peer_lifecycle_guard = super::lock_peer_lifecycle(&shared.peer_lifecycle);
+            shared
+                .peer_manager
+                .add_peer(crate::p2p_runtime::PeerState {
+                    addr: addr.to_string(),
+                    ..Default::default()
+                })
+                .expect("register test peer");
+        }
         PeerGuard {
             peer_lifecycle: Arc::clone(&shared.peer_lifecycle),
             peer_quota_locks: Arc::clone(&shared.peer_quota_locks),
@@ -1538,6 +1615,12 @@ mod tests {
             thread::sleep(Duration::from_millis(25));
         }
         panic!("condition not reached before deadline");
+    }
+
+    fn peer_quota_ref_count(shared: &SharedServiceState, addr: &str) -> usize {
+        let quota_key = crate::da_relay::PeerQuotaKey::from_peer_addr(addr);
+        let locks = super::lock_peer_quota_locks(&shared.peer_quota_locks);
+        locks.get(&quota_key).map_or(0, |entry| entry.refs)
     }
 
     /// Under LLVM coverage (tarpaulin), the first TCP handshake attempt on Darwin
@@ -2675,15 +2758,205 @@ mod tests {
         }
 
         let guard_a = register_test_peer(&shared, peer_a);
-        let quota_lock = PeerQuotaLockHandle::acquire(&shared.peer_quota_locks, "10.9.0.2:29111");
-        let quota_guard = quota_lock.lock();
-        let drop_handle = thread::spawn(move || drop(guard_a));
+        let pending_quota_ref =
+            PeerQuotaLockHandle::acquire(&shared.peer_quota_locks, "10.9.0.2:29111");
+        drop(guard_a);
         let _guard_b = register_test_peer(&shared, "10.9.0.2:29111");
-        drop(quota_guard);
-        drop_handle.join().expect("drop old same-key peer");
         {
             let da_relay = shared.da_relay.lock().unwrap();
             assert_eq!(da_relay.test_record_summary([82; 32]), Some((false, 1, 13)));
+        }
+        drop(pending_quota_ref);
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn peer_guard_drop_treats_waiting_same_key_quota_ref_as_active() {
+        let (sync_engine, dir) = test_engine("rubin-node-p2p-da-waiting-peer-release");
+        let shared = test_shared_state(
+            default_peer_runtime_config("devnet", 8),
+            vec![],
+            sync_engine,
+        );
+        let peer_a = "10.9.0.5:19111";
+        let peer_a_same_key = "10.9.0.5:29111";
+
+        {
+            let mut da_relay = shared.da_relay.lock().unwrap();
+            da_relay
+                .test_stage_incomplete_da_chunk(peer_a, [85; 32], 0, b"waiting-owned", 19)
+                .unwrap();
+        }
+
+        let guard_a = register_test_peer(&shared, peer_a);
+        let lifecycle_guard = super::lock_peer_lifecycle(&shared.peer_lifecycle);
+        let drop_handle = thread::spawn(move || drop(guard_a));
+        wait_until(Instant::now() + Duration::from_secs(2), || {
+            peer_quota_ref_count(&shared, peer_a) >= 1
+        });
+
+        let (pending_ready_tx, pending_ready_rx) = std::sync::mpsc::channel();
+        let (pending_release_tx, pending_release_rx) = std::sync::mpsc::channel();
+        let pending_shared = shared.clone();
+        let pending_addr = peer_a_same_key.to_string();
+        let pending_handle = thread::spawn(move || {
+            let pending_lock =
+                PeerQuotaLockHandle::acquire(&pending_shared.peer_quota_locks, &pending_addr);
+            pending_ready_tx.send(()).expect("signal pending quota ref");
+            let _pending_guard = pending_lock.lock();
+            pending_release_rx
+                .recv()
+                .expect("release pending quota ref");
+        });
+        pending_ready_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("pending same-key registration acquired quota ref");
+        assert!(
+            peer_quota_ref_count(&shared, peer_a) >= 2,
+            "pending same-key quota ref must be visible before cleanup release"
+        );
+
+        drop(lifecycle_guard);
+        drop_handle.join().expect("drop old same-key peer");
+        {
+            let da_relay = shared.da_relay.lock().unwrap();
+            assert_eq!(da_relay.test_record_summary([85; 32]), Some((false, 1, 19)));
+        }
+
+        pending_release_tx
+            .send(())
+            .expect("release pending quota ref");
+        pending_handle.join().expect("pending quota thread");
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn pending_same_key_registration_failure_releases_deferred_da_quota() {
+        let (sync_engine, dir) = test_engine("rubin-node-p2p-da-pending-fail-release");
+        let shared = test_shared_state(
+            default_peer_runtime_config("devnet", 8),
+            vec![],
+            sync_engine,
+        );
+        let peer_a = "10.9.0.6:19111";
+
+        {
+            let mut da_relay = shared.da_relay.lock().unwrap();
+            da_relay
+                .test_stage_incomplete_da_chunk(peer_a, [86; 32], 0, b"pending-fail", 23)
+                .unwrap();
+        }
+
+        let _old_outbox_guard =
+            register_peer_outbox(&shared.peer_outboxes, peer_a).expect("old outbox");
+        let guard_a = register_test_peer(&shared, peer_a);
+        let lifecycle_guard = super::lock_peer_lifecycle(&shared.peer_lifecycle);
+        let drop_handle = thread::spawn(move || drop(guard_a));
+        wait_until(Instant::now() + Duration::from_secs(2), || {
+            peer_quota_ref_count(&shared, peer_a) >= 1
+        });
+
+        let (pending_ready_tx, pending_ready_rx) = std::sync::mpsc::channel();
+        let pending_shared = shared.clone();
+        let pending_addr = peer_a.to_string();
+        let pending_handle = thread::spawn(move || {
+            let pending_registration = PendingPeerRegistration::new(
+                &pending_shared.peer_quota_locks,
+                Arc::clone(&pending_shared.peer_manager),
+                Arc::clone(&pending_shared.da_relay),
+                &pending_addr,
+            );
+            pending_ready_tx
+                .send(())
+                .expect("signal pending registration ref");
+            let _pending_guard = pending_registration
+                .lock()
+                .expect("pending registration lock");
+            assert!(
+                register_peer_outbox(&pending_shared.peer_outboxes, &pending_addr).is_err(),
+                "duplicate outbox must make pending registration fail before PeerGuard"
+            );
+        });
+        pending_ready_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("pending same-key registration acquired quota ref");
+        assert!(
+            peer_quota_ref_count(&shared, peer_a) >= 2,
+            "old cleanup plus pending registration refs must overlap"
+        );
+
+        drop(lifecycle_guard);
+        drop_handle.join().expect("drop old same-key peer");
+        pending_handle
+            .join()
+            .expect("pending registration failure cleanup");
+        {
+            let da_relay = shared.da_relay.lock().unwrap();
+            assert_eq!(da_relay.test_record_summary([86; 32]), None);
+        }
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn peer_guard_drop_blocks_same_key_ref_acquire_until_da_release_decision_finishes() {
+        let (sync_engine, dir) = test_engine("rubin-node-p2p-da-ref-release-atomic");
+        let shared = test_shared_state(
+            default_peer_runtime_config("devnet", 8),
+            vec![],
+            sync_engine,
+        );
+        let peer_a = "10.9.0.7:19111";
+        let peer_a_same_key = "10.9.0.7:29111";
+
+        {
+            let mut da_relay = shared.da_relay.lock().unwrap();
+            da_relay
+                .test_stage_incomplete_da_chunk(peer_a, [87; 32], 0, b"atomic-release", 29)
+                .unwrap();
+        }
+
+        let guard_a = register_test_peer(&shared, peer_a);
+        let da_relay_guard = shared.da_relay.lock().unwrap();
+        let drop_handle = thread::spawn(move || drop(guard_a));
+        wait_until(Instant::now() + Duration::from_secs(2), || {
+            !shared
+                .peer_manager
+                .snapshot()
+                .iter()
+                .any(|state| state.addr == peer_a)
+        });
+        wait_until(Instant::now() + Duration::from_secs(2), || {
+            matches!(
+                shared.peer_quota_locks.try_lock(),
+                Err(std::sync::TryLockError::WouldBlock)
+            )
+        });
+
+        let (pending_ready_tx, pending_ready_rx) = std::sync::mpsc::channel();
+        let pending_shared = shared.clone();
+        let pending_addr = peer_a_same_key.to_string();
+        let pending_handle = thread::spawn(move || {
+            let pending_lock =
+                PeerQuotaLockHandle::acquire(&pending_shared.peer_quota_locks, &pending_addr);
+            pending_ready_tx.send(()).expect("signal pending ref");
+            let _pending_guard = pending_lock.lock();
+        });
+        assert!(
+            pending_ready_rx
+                .recv_timeout(Duration::from_millis(100))
+                .is_err(),
+            "new same-key ref must not publish between no-queued check and DA release"
+        );
+
+        drop(da_relay_guard);
+        drop_handle.join().expect("drop old peer");
+        pending_ready_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("pending ref after cleanup releases map lock");
+        pending_handle.join().expect("pending quota ref");
+        {
+            let da_relay = shared.da_relay.lock().unwrap();
+            assert_eq!(da_relay.test_record_summary([87; 32]), None);
         }
         fs::remove_dir_all(dir).expect("cleanup");
     }
@@ -3003,6 +3276,68 @@ mod tests {
 
         barrier.wait();
         super::join_all_service_workers(&shared);
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn outbound_in_flight_marker_survives_quota_lock_wait_until_registration() {
+        let (sync_engine, dir) = test_engine("rubin-node-inflight-quota-wait");
+        let mut runtime_cfg = default_peer_runtime_config("devnet", 8);
+        runtime_cfg.read_deadline = Duration::from_secs(1);
+        runtime_cfg.write_deadline = Duration::from_secs(1);
+        let shared = test_shared_state(runtime_cfg.clone(), vec![], sync_engine);
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind listener");
+        let dial_addr = listener.local_addr().expect("listener addr").to_string();
+
+        lock_in_flight_dials(&shared).insert(dial_addr.clone());
+        let blocking_lock = PeerQuotaLockHandle::acquire(&shared.peer_quota_locks, &dial_addr);
+        let blocking_guard = blocking_lock.lock();
+        let handler_shared = shared.clone();
+        let handler_addr = dial_addr.clone();
+        let handler = thread::spawn(move || {
+            let (stream, _) = listener.accept().expect("accept peer");
+            super::handle_peer(stream, Some(handler_addr), handler_shared)
+        });
+
+        let stream = TcpStream::connect(&dial_addr).expect("connect service");
+        let local = local_version(0).expect("local version");
+        let chain_id = local.chain_id;
+        let genesis_hash = local.genesis_hash;
+        let client_session =
+            perform_version_handshake(stream, runtime_cfg, local, chain_id, genesis_hash)
+                .expect("client handshake");
+
+        wait_until(Instant::now() + Duration::from_secs(2), || {
+            peer_quota_ref_count(&shared, &dial_addr) >= 2
+        });
+        assert!(
+            lock_in_flight_dials(&shared).contains(&dial_addr),
+            "outbound marker must remain while registration is queued on quota lock"
+        );
+        assert!(
+            !shared
+                .peer_manager
+                .snapshot()
+                .iter()
+                .any(|peer| peer.addr == dial_addr),
+            "peer must not be visible before quota-locked registration completes"
+        );
+
+        drop(blocking_guard);
+        wait_until(Instant::now() + Duration::from_secs(2), || {
+            shared
+                .peer_manager
+                .snapshot()
+                .iter()
+                .any(|peer| peer.addr == dial_addr)
+        });
+        wait_until(Instant::now() + Duration::from_secs(2), || {
+            !lock_in_flight_dials(&shared).contains(&dial_addr)
+        });
+
+        shared.stop.store(true, Ordering::SeqCst);
+        drop(client_session);
+        let _ = handler.join().expect("handler thread");
         fs::remove_dir_all(dir).expect("cleanup");
     }
 


### PR DESCRIPTION
Invariant:
Rust P2P peer disconnect releases peer-owned incomplete DA relay quota only after the final active or queued connection path for the same peer quota key is gone.

Scope:
- Wire `PeerGuard` drop cleanup to release incomplete DA relay records for the disconnected peer quota key.
- Preserve same-key multi-connection ownership, including active peers, queued reconnects, and registration failure before `PeerGuard` construction.
- Keep outbound reconnects marked in-flight until quota-locked registration makes the peer visible.
- Keep DA helper semantics idempotent and limited to incomplete peer-owned records.
- Keep DA orphan cleanup outside global peer lifecycle and global quota-map critical sections.

Parity matrix:
| Case | Go reference | Rust required behavior | Evidence required | Go callsite | Rust callsite | Mirror test |
| --- | --- | --- | --- | --- | --- | --- |
| Final active peer disconnect releases incomplete peer-owned DA records | Go connection removal releases peer-scoped relay state when no same-key peer remains | `PeerGuard::drop` removes the peer and releases quota for `PeerQuotaKey::from_peer_addr(addr)` when no active same-key peer remains | Rust runtime disconnect test | `unregisterPeer`, `releaseDAQuotaIfInactiveLocked` | `PeerGuard::drop`, `DaRelayState::release_peer_quota_key` | `peer_guard_drop_releases_da_quota_only_after_final_same_key_peer` |
| Same-key active peer prevents release | Go keeps peer-scoped relay state while an equivalent active peer remains | Rust scans active peers by quota key before release | Rust same-key retention test | `hasActivePeerQuotaKeyLocked` | `release_da_quota_if_inactive` | `peer_guard_drop_releases_da_quota_only_after_final_same_key_peer` |
| Queued same-key registration prevents premature release | Go serializes register/unregister with `lockPeerQuotaKey` | Rust serializes `add_peer` and disconnect release with a per-`PeerQuotaKey` lock | Rust overlapping reconnect test | `registerPeer`, `unregisterPeer`, `lockPeerQuotaKey` | `PeerQuotaLockHandle`, `PeerGuard::drop` | `peer_guard_drop_preserves_da_quota_for_pending_same_key_registration` |
| Waiting same-key ref is active for release decisions | Go ref is visible before waiting on the per-key mutex | Rust treats visible same-key quota refs as pending lifecycle ownership | Rust waiting-ref test | `lockPeerQuotaKey` | `PeerQuotaLockHandle`, `release_da_quota_if_inactive_and_unqueued` | `peer_guard_drop_treats_waiting_same_key_quota_ref_as_active` |
| Pending registration failure releases deferred quota | Go failed `registerPeer` drops the per-key lock before old unregister can release | Rust failure cleanup drops the queued ref, rechecks active/queued same-key state, then releases inactive DA quota | Rust failure-before-guard test | `registerPeer`, `unregisterPeer` | `PendingPeerRegistration`, `release_da_quota_if_inactive_and_unqueued` | `pending_same_key_registration_failure_releases_deferred_da_quota` |
| Same-key release exclusion does not block unrelated quota keys | Go scopes DA cleanup serialization to the peer quota key, not to the global quota-lock map | Rust marks the same-key entry closing under `peer_quota_locks`, drops the map lock during DA cleanup, blocks same-key acquires until cleanup finishes, and lets unrelated keys acquire | Rust same-key and unrelated-key lock test | `lockPeerQuotaKey`, `releaseDAQuotaIfInactiveLocked` | `PeerQuotaLockHandle::acquire`, `release_da_quota_if_inactive_and_unqueued` | `peer_guard_drop_blocks_same_key_ref_but_not_unrelated_keys_during_da_release` |
| Outbound in-flight marker covers quota-locked registration | Go reconnect reset happens after successful registration | Rust removes `in_flight_dials` only after quota-locked registration completes and peer visibility is established | Rust outbound queued-registration test | `registerPeer`, `resetReconnect` | `handle_peer`, `in_flight_dials` | `outbound_in_flight_marker_survives_quota_lock_wait_until_registration` |
| Per-key lock-map refs stay synchronized with map entry | Go increments/decrements `peerQuotaLock.refs` while holding `peerQuotaLocksMu` | Rust increments/decrements refs while holding `peer_quota_locks`, so a cloned same-key handle cannot be orphaned by final-holder cleanup | Rust lock-map refcount test | `lockPeerQuotaKey` | `PeerQuotaLockHandle::acquire`, `PeerQuotaLockHandle::drop` | `peer_quota_lock_refcounts_stay_with_map_entry` |
| DA cleanup does not hold global peer lifecycle lock | Go scopes serialization to the peer quota key rather than a global lifecycle scan lock | Rust drops `peer_lifecycle` before `release_peer_quota_key` can scan DA orphan indexes | Rust blocked-DA-lock lifecycle test | `releaseDAQuotaIfInactiveLocked`, `daRelay.releasePeerQuotaKey` | `PeerGuard::drop`, `release_da_quota_if_inactive_and_unqueued` | `peer_guard_drop_does_not_hold_lifecycle_while_releasing_da_quota` |
| Unrelated peer records retained | Go cleanup is scoped to the disconnected peer key | Rust release helper does not remove other peer-owned records | DA relay helper test | `daRelay.releasePeerQuotaKey` | `DaRelayState::release_peer_quota_key` | `da_relay_peer_quota_release_helper_releases_peer_owned_incomplete_records_only` |
| Complete sets retained | Go complete DA sets are not removed by disconnect cleanup | Rust release helper removes only incomplete sets | DA relay helper test | `daRelay.releasePeerQuotaKey` | `DaRelayState::release_peer_quota_key` | `da_relay_peer_quota_release_helper_releases_peer_owned_incomplete_records_only` |
| Repeated disconnect cleanup is idempotent | Go repeated peer removal does not double-release unrelated state | Rust only releases when `PeerManager::remove_peer` actually removes the peer | Idempotent helper/removal evidence | `PeerManager.RemovePeer` | `PeerManager::remove_peer`, `PeerGuard::drop` | `da_relay_peer_quota_release_helper_releases_peer_owned_incomplete_records_only` |
| Poisoned DA relay lock does not panic live peer lifecycle | Go runtime peer cleanup must not panic and must still remove the peer | Rust recovers poisoned DA relay lock during drop cleanup and preserves peer removal | Rust poison test | Go peer cleanup error handling | `release_da_quota_if_inactive` | `peer_guard_drop_recovers_poisoned_da_relay_lock_without_peer_leak` |

Evidence:
- `cargo test -p rubin-node peer_guard_drop_releases_da_quota_only_after_final_same_key_peer --lib`
- `cargo test -p rubin-node peer_guard_drop_preserves_da_quota_for_pending_same_key_registration --lib`
- `cargo test -p rubin-node peer_guard_drop_treats_waiting_same_key_quota_ref_as_active --lib`
- `cargo test -p rubin-node pending_same_key_registration_failure_releases_deferred_da_quota --lib`
- `cargo test -p rubin-node peer_guard_drop_blocks_same_key_ref_but_not_unrelated_keys_during_da_release --lib`
- `cargo test -p rubin-node outbound_in_flight_marker_survives_quota_lock_wait_until_registration --lib`
- `cargo test -p rubin-node p2p_service --lib`
- `cargo test -p rubin-node da_relay --lib`
- `cargo test -p rubin-node p2p_runtime --lib`
- `cargo test -p rubin-node --lib`
- `cargo clippy -p rubin-node --lib --tests -- -D warnings`

Non-scope:
- DA TTL expiry.
- Accepted-block DA wiring.
- Remote or local transaction ingest/staging.
- Provider snapshot, miner selection, prefetch scheduler, or getdachunk runtime behavior.
- Go client, consensus, spec, or wire-format changes.
