### PR TITLE
RUB-407: bound Rust DA provider miner selection

### DIFF
--- a/clients/rust/crates/rubin-node/src/miner.rs
+++ b/clients/rust/crates/rubin-node/src/miner.rs
@@ -2,8 +2,8 @@ use std::collections::{HashMap, HashSet};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use rubin_consensus::constants::{
-    COV_TYPE_DA_COMMIT, MAX_BLOCK_WEIGHT, MAX_DA_BYTES_PER_BLOCK, MAX_DA_CHUNK_COUNT,
-    MAX_FUTURE_DRIFT, POW_LIMIT,
+    COV_TYPE_DA_COMMIT, MAX_BLOCK_WEIGHT, MAX_DA_BATCHES_PER_BLOCK, MAX_DA_BYTES_PER_BLOCK,
+    MAX_DA_CHUNK_COUNT, MAX_FUTURE_DRIFT, POW_LIMIT,
 };
 use rubin_consensus::merkle::{witness_commitment_hash, witness_merkle_root_wtxids};
 use rubin_consensus::{
@@ -16,7 +16,7 @@ use sha3::{Digest, Sha3_256};
 use crate::coinbase::{
     build_coinbase_tx, default_mine_address, normalize_mine_address, parse_mine_address,
 };
-use crate::da_relay::CompleteDaSetCandidate;
+use crate::da_relay::{CompleteDaSetCandidate, CompleteDaSetProvider};
 use crate::sync::SyncEngine;
 use crate::txpool::{
     apply_policy, TxPool, TxPoolConfig, DEFAULT_MEMPOOL_MIN_FEE_RATE, DEFAULT_MIN_DA_FEE_RATE,
@@ -80,6 +80,7 @@ pub(crate) struct MinedCandidate {
 
 #[derive(Clone, Debug)]
 pub(crate) struct CompleteDaSetMiningCandidate {
+    da_id: [u8; 32],
     txs: Vec<MinedCandidate>,
     da_bytes: u64,
 }
@@ -98,6 +99,7 @@ pub(crate) struct CompleteDaSetGroupProjection<'a> {
 pub struct Miner<'a> {
     sync: &'a mut SyncEngine,
     tx_pool: Option<&'a mut TxPool>,
+    complete_da_set_provider: Option<&'a dyn CompleteDaSetProvider>,
     cfg: MinerConfig,
 }
 
@@ -130,7 +132,16 @@ impl<'a> Miner<'a> {
         if cfg.max_tx_per_block == 0 {
             cfg.max_tx_per_block = 1024;
         }
-        Ok(Self { sync, tx_pool, cfg })
+        Ok(Self {
+            sync,
+            tx_pool,
+            complete_da_set_provider: None,
+            cfg,
+        })
+    }
+
+    pub fn set_complete_da_set_provider(&mut self, provider: &'a dyn CompleteDaSetProvider) {
+        self.complete_da_set_provider = Some(provider);
     }
 
     pub fn mine_n(&mut self, blocks: usize, txs: &[Vec<u8>]) -> Result<Vec<MinedBlock>, String> {
@@ -247,22 +258,127 @@ impl<'a> Miner<'a> {
         next_height: u64,
         remaining_weight: u64,
     ) -> Result<Vec<MinedCandidate>, String> {
-        let mut parsed = Vec::with_capacity(candidate_txs.len());
+        let max_selected = self.cfg.max_tx_per_block.saturating_sub(1);
+        let mut parsed = Vec::with_capacity(candidate_txs.len().min(max_selected));
         let mut selected_weight = 0u64;
         let mut policy_da_included = 0u64;
+        let mut selected_nonces = HashSet::new();
+        let mut selected_inputs = HashSet::new();
         for raw in candidate_txs {
+            if parsed.len() >= max_selected {
+                break;
+            }
             let candidate = parse_mining_candidate(&raw)?;
             let (reject, next_da_included) =
                 self.reject_candidate(&candidate.tx, next_height, policy_da_included)?;
             if reject {
                 continue;
             }
+            if self.complete_da_set_provider.is_some()
+                && (candidate.tx.tx_kind == 0x01 || candidate.tx.tx_kind == 0x02)
+            {
+                continue;
+            }
+            if candidate.tx.tx_nonce == 0 || selected_nonces.contains(&candidate.tx.tx_nonce) {
+                continue;
+            }
             if candidate.weight > remaining_weight.saturating_sub(selected_weight) {
                 continue;
             }
-            selected_weight += candidate.weight;
+            selected_weight = selected_weight
+                .checked_add(candidate.weight)
+                .ok_or_else(|| "selected transaction weight overflow".to_string())?;
             policy_da_included = next_da_included;
+            selected_nonces.insert(candidate.tx.tx_nonce);
+            for input in &candidate.tx.inputs {
+                selected_inputs.insert(Outpoint {
+                    txid: input.prev_txid,
+                    vout: input.prev_vout,
+                });
+            }
             parsed.push(candidate);
+        }
+        let Some(provider) = self.complete_da_set_provider else {
+            return Ok(parsed);
+        };
+        if max_selected == 0 || parsed.len() >= max_selected || selected_weight >= remaining_weight
+        {
+            return Ok(parsed);
+        }
+        let block_mtp = self
+            .sync
+            .prev_timestamps_for_next_block()?
+            .filter(|timestamps| !timestamps.is_empty())
+            .map_or(0, |timestamps| mtp_median(next_height, &timestamps));
+        let mut provider_da_included = 0u64;
+        let mut selected_da_ids = HashSet::new();
+        let mut provider_budget = MAX_DA_BYTES_PER_BLOCK;
+        if self.cfg.policy_da_anchor_anti_abuse
+            && self.cfg.policy_max_da_bytes_per_block > 0
+            && self.cfg.policy_max_da_bytes_per_block < provider_budget
+        {
+            provider_budget = self.cfg.policy_max_da_bytes_per_block;
+        }
+        for set in provider.complete_da_set_candidates(provider_budget) {
+            if parsed.len() >= max_selected
+                || selected_da_ids.len() >= MAX_DA_BATCHES_PER_BLOCK as usize
+            {
+                break;
+            }
+            if set
+                .chunks
+                .len()
+                .checked_add(1)
+                .is_none_or(|group_len| group_len > max_selected - parsed.len())
+            {
+                continue;
+            }
+            let Some(group) = parse_complete_da_set_candidate(&set)? else {
+                continue;
+            };
+            if selected_da_ids.contains(&group.da_id)
+                || parsed
+                    .len()
+                    .checked_add(group.txs.len())
+                    .is_none_or(|len| len > max_selected)
+            {
+                continue;
+            }
+            let Some(next_provider_da_included) =
+                updated_policy_da_bytes(provider_da_included, group.da_bytes, provider_budget)
+            else {
+                continue;
+            };
+            let projection = CompleteDaSetGroupProjection {
+                selected_nonces: &selected_nonces,
+                selected_inputs: &selected_inputs,
+                next_height,
+                block_mtp,
+                selected_weight,
+                remaining_weight,
+                policy_da_included,
+            };
+            let Some((group_weight, next_da_included)) =
+                self.project_complete_da_set_group(&group.txs, projection)?
+            else {
+                continue;
+            };
+            selected_weight = selected_weight
+                .checked_add(group_weight)
+                .ok_or_else(|| "selected transaction weight overflow".to_string())?;
+            policy_da_included = next_da_included;
+            provider_da_included = next_provider_da_included;
+            selected_da_ids.insert(group.da_id);
+            for candidate in group.txs {
+                selected_nonces.insert(candidate.tx.tx_nonce);
+                for input in &candidate.tx.inputs {
+                    selected_inputs.insert(Outpoint {
+                        txid: input.prev_txid,
+                        vout: input.prev_vout,
+                    });
+                }
+                parsed.push(candidate);
+            }
         }
         Ok(parsed)
     }
@@ -486,6 +602,7 @@ pub(crate) fn parse_complete_da_set_candidate(
     }
 
     let mut group = CompleteDaSetMiningCandidate {
+        da_id: set.da_id,
         da_bytes: commit.tx.da_payload.len() as u64,
         txs: vec![commit],
     };
@@ -887,6 +1004,65 @@ mod tests {
         set
     }
 
+    fn signed_miner_da_provider_set(
+        da_id: [u8; 32],
+        payloads: &[&[u8]],
+    ) -> (ProviderSet, HashMap<Outpoint, UtxoEntry>) {
+        let mut set = miner_da_provider_shape_set(da_id, payloads);
+        let keypair = Mldsa87Keypair::generate().expect("provider keypair");
+        let mut utxos = HashMap::new();
+        let mut sign_raw = |raw: &mut Vec<u8>| {
+            let (mut tx, _, _, _) = parse_tx(raw).expect("parse provider tx");
+            let outpoint = Outpoint {
+                txid: tx.inputs[0].prev_txid,
+                vout: tx.inputs[0].prev_vout,
+            };
+            utxos.insert(
+                outpoint,
+                UtxoEntry {
+                    value: 1_000_000,
+                    covenant_type: COV_TYPE_P2PK,
+                    covenant_data: p2pk_covenant_data_for_pubkey(&keypair.pubkey_bytes()),
+                    creation_height: 0,
+                    created_by_coinbase: false,
+                },
+            );
+            sign_transaction(&mut tx, &utxos, devnet_genesis_chain_id(), &keypair)
+                .expect("sign provider tx");
+            *raw = marshal_tx(&tx).expect("marshal provider tx");
+        };
+        sign_raw(&mut set.commit_tx);
+        for chunk in &mut set.chunks {
+            sign_raw(&mut chunk.tx);
+        }
+        (set, utxos)
+    }
+    struct MinerTestCompleteDaSetProvider(Vec<ProviderSet>);
+    impl crate::da_relay::CompleteDaSetProvider for MinerTestCompleteDaSetProvider {
+        fn complete_da_set_candidates(&self, _max_payload_bytes: u64) -> Vec<ProviderSet> {
+            self.0.clone()
+        }
+    }
+    fn select_provider_sets(
+        suffix: &str,
+        sets: Vec<ProviderSet>,
+        utxos: HashMap<Outpoint, UtxoEntry>,
+        cfg: MinerConfig,
+        remaining_weight: u64,
+    ) -> Vec<super::MinedCandidate> {
+        let (dir, _block_store, mut sync) =
+            test_sync(&format!("rubin-rust-miner-da-provider-selection-{suffix}"));
+        sync.chain_state.utxos = utxos;
+        let provider = MinerTestCompleteDaSetProvider(sets);
+        let mut miner = Miner::new(&mut sync, None, cfg).expect("miner");
+        miner.set_complete_da_set_provider(&provider);
+        let selected = miner
+            .select_candidate_transactions(Vec::new(), 1, remaining_weight)
+            .expect("select provider candidates");
+        let _ = fs::remove_dir_all(&dir);
+        selected
+    }
+
     fn expect_bad(set: ProviderSet) {
         assert!(!validate_complete_da_set_candidate_shape(&set).expect("shape validation"));
     }
@@ -941,41 +1117,8 @@ mod tests {
 
     #[test]
     fn miner_da_provider_group_projection_matrix() {
-        let (provider_group, provider_utxos) = {
-            let mut set = miner_da_provider_shape_set([0x91; 32], &[b"chunk"]);
-            let keypair = Mldsa87Keypair::generate().expect("provider keypair");
-            let mut utxos = HashMap::new();
-            let mut sign_raw = |raw: &mut Vec<u8>| {
-                let (mut tx, _, _, _) = parse_tx(raw).expect("parse provider tx");
-                let outpoint = Outpoint {
-                    txid: tx.inputs[0].prev_txid,
-                    vout: tx.inputs[0].prev_vout,
-                };
-                utxos.insert(
-                    outpoint,
-                    UtxoEntry {
-                        value: 1_000_000,
-                        covenant_type: COV_TYPE_P2PK,
-                        covenant_data: p2pk_covenant_data_for_pubkey(&keypair.pubkey_bytes()),
-                        creation_height: 0,
-                        created_by_coinbase: false,
-                    },
-                );
-                sign_transaction(&mut tx, &utxos, devnet_genesis_chain_id(), &keypair)
-                    .expect("sign provider tx");
-                *raw = marshal_tx(&tx).expect("marshal provider tx");
-            };
-            sign_raw(&mut set.commit_tx);
-            for chunk in &mut set.chunks {
-                sign_raw(&mut chunk.tx);
-            }
-            (
-                parse_complete_da_set_candidate(&set)
-                    .expect("parse provider group")
-                    .expect("provider group"),
-                utxos,
-            )
-        };
+        let (set, provider_utxos) = signed_miner_da_provider_set([0x91; 32], &[b"chunk"]);
+        let provider_group = parse_complete_da_set_candidate(&set).unwrap().unwrap();
         let (dir, _block_store, mut sync) = test_sync("rubin-rust-miner-da-provider-group");
         sync.chain_state.utxos = provider_utxos;
         let cfg = MinerConfig {
@@ -1071,6 +1214,43 @@ mod tests {
         let _ = fs::remove_dir_all(&dir);
     }
 
+    #[test]
+    fn miner_da_provider_selection_bounds_matrix() {
+        let (set, utxos) = signed_miner_da_provider_set([0xa1; 32], &[b"chunk"]);
+        let group = parse_complete_da_set_candidate(&set).unwrap().unwrap();
+        let group_len = group.txs.len();
+        let group_weight: u64 = group.txs.iter().map(|candidate| candidate.weight).sum();
+        let cfg = MinerConfig {
+            max_tx_per_block: group_len * 2 + 1,
+            policy_current_mempool_min_fee_rate: 0,
+            policy_min_da_fee_rate: 0,
+            ..MinerConfig::default()
+        };
+        let select = |suffix: &str, sets: Vec<ProviderSet>, cfg: MinerConfig, weight: u64| {
+            select_provider_sets(suffix, sets, utxos.clone(), cfg, weight)
+        };
+        assert_eq!(
+            select("valid", vec![set.clone()], cfg.clone(), MAX_BLOCK_WEIGHT).len(),
+            group_len
+        );
+        let mut slot_cfg = cfg.clone();
+        slot_cfg.max_tx_per_block = group_len;
+        assert!(select("slots", vec![set.clone()], slot_cfg, MAX_BLOCK_WEIGHT).is_empty());
+        assert!(select("weight", vec![set.clone()], cfg.clone(), group_weight - 1).is_empty());
+        let mut da_cfg = cfg.clone();
+        da_cfg.policy_max_da_bytes_per_block = group.da_bytes - 1;
+        assert!(select("da-budget", vec![set.clone()], da_cfg, MAX_BLOCK_WEIGHT).is_empty());
+        assert_eq!(
+            select(
+                "duplicate-daid",
+                vec![set.clone(), set],
+                cfg,
+                MAX_BLOCK_WEIGHT
+            )
+            .len(),
+            group_len
+        );
+    }
     #[test]
     fn miner_da_anchor_master_switch_off_ignores_anchor_subflag() {
         let (dir, _block_store, mut sync) = test_sync("rubin-rust-miner-da-anchor-master-off");
@@ -1510,8 +1690,10 @@ mod tests {
     fn select_candidate_transactions_covers_reject_skip_and_accept_paths() {
         let (dir, _block_store, mut sync) = test_sync("rubin-rust-miner-selection");
         let (state, raw) = signed_p2pk_state_and_tx(20, 10);
+        let (da_set, da_utxos) = signed_miner_da_provider_set([0xb1; 32], &[b"chunk"]);
         sync.chain_state.utxos = state.utxos;
-        let miner = Miner::new(&mut sync, None, MinerConfig::default()).expect("miner");
+        sync.chain_state.utxos.extend(da_utxos);
+        let mut miner = Miner::new(&mut sync, None, MinerConfig::default()).expect("miner");
 
         let rejected = miner
             .select_candidate_transactions(vec![coinbase_bytes(0)], 0, MAX_BLOCK_WEIGHT)
@@ -1524,10 +1706,20 @@ mod tests {
         assert!(overweight.is_empty());
 
         let accepted = miner
-            .select_candidate_transactions(vec![raw], 0, MAX_BLOCK_WEIGHT)
+            .select_candidate_transactions(vec![raw.clone()], 0, MAX_BLOCK_WEIGHT)
             .expect("accept branch");
         assert_eq!(accepted.len(), 1);
         assert!(accepted[0].weight > 0);
+        let flat_da = miner
+            .select_candidate_transactions(vec![da_set.commit_tx.clone()], 0, MAX_BLOCK_WEIGHT)
+            .expect("flat DA without provider");
+        assert_eq!(flat_da.len(), 1);
+        let empty_provider = MinerTestCompleteDaSetProvider(Vec::new());
+        miner.set_complete_da_set_provider(&empty_provider);
+        assert!(miner
+            .select_candidate_transactions(vec![da_set.commit_tx], 0, MAX_BLOCK_WEIGHT)
+            .expect("flat DA skipped with provider")
+            .is_empty());
         let _ = fs::remove_dir_all(&dir);
     }
 }

--- a/clients/rust/crates/rubin-node/src/miner.rs
+++ b/clients/rust/crates/rubin-node/src/miner.rs
@@ -218,6 +218,9 @@ impl<'a> Miner<'a> {
             return Vec::new();
         }
         if !txs.is_empty() {
+            if self.complete_da_set_provider.is_some() {
+                return pick_flat_candidate_raw(txs, max_selected);
+            }
             return txs.iter().take(max_selected).cloned().collect();
         }
         match self.tx_pool.as_deref() {
@@ -274,14 +277,16 @@ impl<'a> Miner<'a> {
             if reject {
                 continue;
             }
-            if self.complete_da_set_provider.is_some()
-                && (candidate.tx.tx_kind == 0x01 || candidate.tx.tx_kind == 0x02)
-            {
+            if self.complete_da_set_provider.is_some() && is_mining_da_tx(&candidate.tx) {
                 continue;
             }
-            if candidate.tx.tx_nonce == 0 || selected_nonces.contains(&candidate.tx.tx_nonce) {
+            let Some(candidate_inputs) = collect_complete_da_set_group_inputs(
+                std::slice::from_ref(&candidate),
+                &selected_nonces,
+                &selected_inputs,
+            ) else {
                 continue;
-            }
+            };
             if candidate.weight > remaining_weight.saturating_sub(selected_weight) {
                 continue;
             }
@@ -290,12 +295,7 @@ impl<'a> Miner<'a> {
                 .ok_or_else(|| "selected transaction weight overflow".to_string())?;
             policy_da_included = next_da_included;
             selected_nonces.insert(candidate.tx.tx_nonce);
-            for input in &candidate.tx.inputs {
-                selected_inputs.insert(Outpoint {
-                    txid: input.prev_txid,
-                    vout: input.prev_vout,
-                });
-            }
+            selected_inputs.extend(candidate_inputs);
             parsed.push(candidate);
         }
         let Some(provider) = self.complete_da_set_provider else {
@@ -564,6 +564,28 @@ pub(crate) fn copy_selected_utxo_set(
     selected
 }
 
+fn pick_flat_candidate_raw(txs: &[Vec<u8>], max_count: usize) -> Vec<Vec<u8>> {
+    let mut selected = Vec::with_capacity(txs.len().min(max_count));
+    for raw in txs {
+        if is_mining_da_tx_raw(raw) {
+            continue;
+        }
+        selected.push(raw.clone());
+        if selected.len() >= max_count {
+            break;
+        }
+    }
+    selected
+}
+
+fn is_mining_da_tx_raw(raw: &[u8]) -> bool {
+    matches!(parse_tx(raw), Ok((tx, _, _, consumed)) if consumed == raw.len() && is_mining_da_tx(&tx))
+}
+
+fn is_mining_da_tx(tx: &Tx) -> bool {
+    tx.tx_kind == 0x01 || tx.tx_kind == 0x02
+}
+
 fn parse_mining_candidate(raw: &[u8]) -> Result<MinedCandidate, String> {
     let (tx, txid, wtxid, consumed) = parse_tx(raw).map_err(|e| e.to_string())?;
     if consumed != raw.len() {
@@ -780,7 +802,7 @@ mod tests {
 
     use rubin_consensus::constants::{
         COV_TYPE_ANCHOR, COV_TYPE_CORE_EXT, COV_TYPE_DA_COMMIT, COV_TYPE_P2PK, MAX_BLOCK_WEIGHT,
-        TX_WIRE_VERSION,
+        MAX_DA_BATCHES_PER_BLOCK, TX_WIRE_VERSION,
     };
     use rubin_consensus::merkle::{witness_commitment_hash, witness_merkle_root_wtxids};
     use rubin_consensus::{
@@ -1039,7 +1061,7 @@ mod tests {
     }
     struct MinerTestCompleteDaSetProvider(Vec<ProviderSet>);
     impl crate::da_relay::CompleteDaSetProvider for MinerTestCompleteDaSetProvider {
-        fn complete_da_set_candidates(&self, _max_payload_bytes: u64) -> Vec<ProviderSet> {
+        fn complete_da_set_candidates(&self, _: u64) -> Vec<ProviderSet> {
             self.0.clone()
         }
     }
@@ -1220,12 +1242,13 @@ mod tests {
         let group = parse_complete_da_set_candidate(&set).unwrap().unwrap();
         let group_len = group.txs.len();
         let group_weight: u64 = group.txs.iter().map(|candidate| candidate.weight).sum();
-        let cfg = MinerConfig {
-            max_tx_per_block: group_len * 2 + 1,
+        let provider_cfg = |max_tx_per_block| MinerConfig {
+            max_tx_per_block,
             policy_current_mempool_min_fee_rate: 0,
             policy_min_da_fee_rate: 0,
             ..MinerConfig::default()
         };
+        let cfg = provider_cfg(group_len * 2 + 1);
         let select = |suffix: &str, sets: Vec<ProviderSet>, cfg: MinerConfig, weight: u64| {
             select_provider_sets(suffix, sets, utxos.clone(), cfg, weight)
         };
@@ -1250,6 +1273,34 @@ mod tests {
             .len(),
             group_len
         );
+        let mut capped_sets = Vec::new();
+        let mut capped_utxos = HashMap::new();
+        let cap_end = MAX_DA_BATCHES_PER_BLOCK as usize;
+        let make_da_id = |index: usize| {
+            let mut da_id = [0xc1; 32];
+            da_id[..8].copy_from_slice(&(index as u64).to_le_bytes());
+            da_id
+        };
+        for index in 0..=cap_end {
+            let payload = [index as u8];
+            let (set, set_utxos) = signed_miner_da_provider_set(make_da_id(index), &[&payload]);
+            capped_sets.push(set);
+            capped_utxos.extend(set_utxos);
+        }
+        let selected = select_provider_sets(
+            "batch-cap",
+            capped_sets.clone(),
+            capped_utxos,
+            provider_cfg(group_len * (cap_end + 1) + 1),
+            MAX_BLOCK_WEIGHT,
+        );
+        let overflow_da_id = make_da_id(cap_end);
+        assert_eq!(selected.len(), cap_end * group_len);
+        assert!(selected.iter().all(|candidate| {
+            candidate.tx.da_commit_core.as_ref().map(|core| core.da_id) != Some(overflow_da_id)
+                && candidate.tx.da_chunk_core.as_ref().map(|core| core.da_id)
+                    != Some(overflow_da_id)
+        }));
     }
     #[test]
     fn miner_da_anchor_master_switch_off_ignores_anchor_subflag() {
@@ -1410,9 +1461,14 @@ mod tests {
             max_tx_per_block: 2,
             ..MinerConfig::default()
         };
-        let miner = Miner::new(&mut sync, None, cfg).expect("miner");
+        let mut miner = Miner::new(&mut sync, None, cfg).expect("miner");
         let selected = miner.candidate_transactions(&[vec![0x01], vec![0x02], vec![0x03]]);
         assert_eq!(selected, vec![vec![0x01]]);
+        let provider = MinerTestCompleteDaSetProvider(Vec::new());
+        miner.set_complete_da_set_provider(&provider);
+        let da_set = miner_da_provider_shape_set([0xd1; 32], &[b"chunk"]);
+        let selected = miner.candidate_transactions(&[da_set.commit_tx, vec![0x02], vec![0x03]]);
+        assert_eq!(selected, vec![vec![0x02]]);
         let _ = fs::remove_dir_all(&dir);
     }
 
@@ -1689,7 +1745,7 @@ mod tests {
     #[test]
     fn select_candidate_transactions_covers_reject_skip_and_accept_paths() {
         let (dir, _block_store, mut sync) = test_sync("rubin-rust-miner-selection");
-        let (state, raw) = signed_p2pk_state_and_tx(20, 10);
+        let (state, raw, conflicting_raw) = signed_conflicting_p2pk_state_and_txs(20, 10, 9);
         let (da_set, da_utxos) = signed_miner_da_provider_set([0xb1; 32], &[b"chunk"]);
         sync.chain_state.utxos = state.utxos;
         sync.chain_state.utxos.extend(da_utxos);
@@ -1706,9 +1762,10 @@ mod tests {
         assert!(overweight.is_empty());
 
         let accepted = miner
-            .select_candidate_transactions(vec![raw.clone()], 0, MAX_BLOCK_WEIGHT)
+            .select_candidate_transactions(vec![raw.clone(), conflicting_raw], 0, MAX_BLOCK_WEIGHT)
             .expect("accept branch");
         assert_eq!(accepted.len(), 1);
+        assert_eq!(accepted[0].tx.tx_nonce, 7);
         assert!(accepted[0].weight > 0);
         let flat_da = miner
             .select_candidate_transactions(vec![da_set.commit_tx.clone()], 0, MAX_BLOCK_WEIGHT)

--- a/clients/rust/crates/rubin-node/src/miner.rs
+++ b/clients/rust/crates/rubin-node/src/miner.rs
@@ -169,8 +169,17 @@ impl<'a> Miner<'a> {
         };
         let remaining_weight = self.remaining_weight_budget(next_height)?;
         let candidate_txs = self.candidate_transactions(txs);
-        let parsed =
-            self.select_candidate_transactions(candidate_txs, next_height, remaining_weight)?;
+        let prev_timestamps = self.sync.prev_timestamps_for_next_block()?;
+        let block_mtp = prev_timestamps
+            .as_deref()
+            .filter(|timestamps| !timestamps.is_empty())
+            .map_or(0, |timestamps| mtp_median(next_height, timestamps));
+        let parsed = self.select_candidate_transactions(
+            candidate_txs,
+            next_height,
+            remaining_weight,
+            block_mtp,
+        )?;
         let witness_commitment = build_witness_commitment(&parsed)?;
         let coinbase = build_coinbase_tx(
             next_height,
@@ -189,7 +198,6 @@ impl<'a> Miner<'a> {
             txids.push(candidate.txid);
         }
         let merkle_root = merkle_root_txids(&txids).map_err(|e| e.to_string())?;
-        let prev_timestamps = self.sync.prev_timestamps_for_next_block()?;
         let timestamp = choose_valid_timestamp(
             next_height,
             prev_timestamps.as_deref().unwrap_or(&[]),
@@ -225,7 +233,7 @@ impl<'a> Miner<'a> {
         }
         match self.tx_pool.as_deref() {
             Some(pool) if self.complete_da_set_provider.is_some() => {
-                pool.select_non_da_transactions(max_selected, MAX_BLOCK_WEIGHT as usize)
+                pool.select_non_da(max_selected, MAX_BLOCK_WEIGHT as usize)
             }
             Some(pool) => pool.select_transactions(max_selected, MAX_BLOCK_WEIGHT as usize),
             None => Vec::new(),
@@ -263,6 +271,7 @@ impl<'a> Miner<'a> {
         candidate_txs: Vec<Vec<u8>>,
         next_height: u64,
         remaining_weight: u64,
+        block_mtp: u64,
     ) -> Result<Vec<MinedCandidate>, String> {
         let max_selected = self.cfg.max_tx_per_block.saturating_sub(1);
         let mut parsed = Vec::with_capacity(candidate_txs.len().min(max_selected));
@@ -280,11 +289,13 @@ impl<'a> Miner<'a> {
             if reject {
                 continue;
             }
-            if self.complete_da_set_provider.is_some() && is_mining_da_tx(&candidate.tx) {
+            let provider_mode = self.complete_da_set_provider.is_some();
+            if provider_mode && is_mining_da_tx(&candidate.tx) {
                 continue;
             }
+            let candidate_slice = std::slice::from_ref(&candidate);
             let Some(candidate_inputs) = collect_complete_da_set_group_inputs(
-                std::slice::from_ref(&candidate),
+                candidate_slice,
                 &selected_nonces,
                 &selected_inputs,
             ) else {
@@ -308,11 +319,6 @@ impl<'a> Miner<'a> {
         {
             return Ok(parsed);
         }
-        let block_mtp = self
-            .sync
-            .prev_timestamps_for_next_block()?
-            .filter(|timestamps| !timestamps.is_empty())
-            .map_or(0, |timestamps| mtp_median(next_height, &timestamps));
         let mut provider_da_included = 0u64;
         let mut selected_da_ids = HashSet::new();
         let mut provider_budget = MAX_DA_BYTES_PER_BLOCK;
@@ -328,12 +334,8 @@ impl<'a> Miner<'a> {
             {
                 break;
             }
-            if set
-                .chunks
-                .len()
-                .checked_add(1)
-                .is_none_or(|group_len| group_len > max_selected - parsed.len())
-            {
+            let group_len = set.chunks.len().saturating_add(1);
+            if group_len > max_selected - parsed.len() {
                 continue;
             }
             let Some(group) = parse_complete_da_set_candidate(&set)? else {
@@ -342,9 +344,9 @@ impl<'a> Miner<'a> {
             if selected_da_ids.contains(&group.da_id) {
                 continue;
             }
-            let Some(next_provider_da_included) =
-                updated_policy_da_bytes(provider_da_included, group.da_bytes, provider_budget)
-            else {
+            let budgeted_da =
+                updated_policy_da_bytes(provider_da_included, group.da_bytes, provider_budget);
+            let Some(next_provider_da_included) = budgeted_da else {
                 continue;
             };
             let projection = CompleteDaSetGroupProjection {
@@ -356,9 +358,8 @@ impl<'a> Miner<'a> {
                 remaining_weight,
                 policy_da_included,
             };
-            let Some((group_weight, next_da_included)) =
-                self.project_complete_da_set_group(&group.txs, projection)?
-            else {
+            let projected = self.project_complete_da_set_group(&group.txs, projection)?;
+            let Some((group_weight, next_da_included)) = projected else {
                 continue;
             };
             selected_weight = selected_weight
@@ -1055,7 +1056,7 @@ mod tests {
             self.0.clone()
         }
     }
-    fn select_provider_sets(
+    fn sel(
         sets: Vec<ProviderSet>,
         utxos: HashMap<Outpoint, UtxoEntry>,
         cfg: MinerConfig,
@@ -1067,7 +1068,7 @@ mod tests {
         let mut miner = Miner::new(&mut sync, None, cfg).expect("miner");
         miner.set_complete_da_set_provider(&provider);
         let selected = miner
-            .select_candidate_transactions(Vec::new(), 1, remaining_weight)
+            .select_candidate_transactions(Vec::new(), 1, remaining_weight, 0)
             .expect("select provider candidates");
         let _ = fs::remove_dir_all(&dir);
         selected
@@ -1119,10 +1120,9 @@ mod tests {
     fn miner_da_provider_shape_malformed_raw_errors() {
         let mut malformed_commit = miner_da_provider_shape_set([0x81; 32], &[b"chunk-0"]);
         malformed_commit.commit_tx.push(0);
-        let err = "non-canonical tx bytes in miner input";
         assert_eq!(
             parse_complete_da_set_candidate(&malformed_commit).unwrap_err(),
-            err
+            "non-canonical tx bytes in miner input"
         );
     }
 
@@ -1237,7 +1237,7 @@ mod tests {
         };
         let cfg = provider_cfg(group_len * 2 + 1);
         let select = |sets: Vec<ProviderSet>, cfg: MinerConfig, weight: u64| {
-            select_provider_sets(sets, utxos.clone(), cfg, weight)
+            sel(sets, utxos.clone(), cfg, weight)
         };
         assert_eq!(
             select(vec![set.clone()], cfg.clone(), MAX_BLOCK_WEIGHT).len(),
@@ -1251,6 +1251,9 @@ mod tests {
         let mut da_cfg = cfg.clone();
         da_cfg.policy_max_da_bytes_per_block = group.da_bytes - 1;
         assert!(select(vec![set.clone()], da_cfg, MAX_BLOCK_WEIGHT).is_empty());
+        let one = vec![set.clone()];
+        let missing_utxo = sel(one, HashMap::new(), cfg.clone(), MAX_BLOCK_WEIGHT);
+        assert!(missing_utxo.is_empty());
         assert!(select(
             vec![mutate_set(&set, |set| set.chunks.clear())],
             cfg.clone(),
@@ -1271,7 +1274,7 @@ mod tests {
             capped_sets.push(set);
             capped_utxos.extend(set_utxos);
         }
-        let selected = select_provider_sets(
+        let selected = sel(
             capped_sets,
             capped_utxos,
             provider_cfg(group_len * (cap_end + 1) + 1),
@@ -1731,21 +1734,30 @@ mod tests {
     fn select_candidate_transactions_covers_reject_skip_and_accept_paths() {
         let (dir, _block_store, mut sync) = test_sync("rubin-rust-miner-selection");
         let (state, raw, conflicting_raw) = signed_conflicting_p2pk_state_and_txs(20, 10, 9);
+        let (provider_set, provider_utxos) = signed_miner_da_provider_set([0xd2; 32], &[b"chunk"]);
         sync.chain_state.utxos = state.utxos;
-        let miner = Miner::new(&mut sync, None, MinerConfig::default()).expect("miner");
+        sync.chain_state.utxos.extend(provider_utxos);
+        let provider = MinerTestCompleteDaSetProvider(Vec::new());
+        let mut miner = Miner::new(&mut sync, None, MinerConfig::default()).expect("miner");
 
         let rejected = miner
-            .select_candidate_transactions(vec![coinbase_bytes(0)], 0, MAX_BLOCK_WEIGHT)
+            .select_candidate_transactions(vec![coinbase_bytes(0)], 0, MAX_BLOCK_WEIGHT, 0)
             .expect("reject branch");
         assert!(rejected.is_empty());
 
         let overweight = miner
-            .select_candidate_transactions(vec![raw.clone()], 0, 0)
+            .select_candidate_transactions(vec![raw.clone()], 0, 0, 0)
             .expect("weight skip");
         assert!(overweight.is_empty());
 
+        miner.set_complete_da_set_provider(&provider);
         let accepted = miner
-            .select_candidate_transactions(vec![raw.clone(), conflicting_raw], 0, MAX_BLOCK_WEIGHT)
+            .select_candidate_transactions(
+                vec![provider_set.commit_tx, raw.clone(), conflicting_raw],
+                0,
+                MAX_BLOCK_WEIGHT,
+                0,
+            )
             .expect("accept branch");
         assert_eq!(accepted.len(), 1);
         assert_eq!(accepted[0].tx.tx_nonce, 7);

--- a/clients/rust/crates/rubin-node/src/miner.rs
+++ b/clients/rust/crates/rubin-node/src/miner.rs
@@ -2,8 +2,8 @@ use std::collections::{HashMap, HashSet};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use rubin_consensus::constants::{
-    COV_TYPE_DA_COMMIT, MAX_BLOCK_WEIGHT, MAX_DA_BYTES_PER_BLOCK, MAX_DA_CHUNK_COUNT,
-    MAX_FUTURE_DRIFT, POW_LIMIT,
+    COV_TYPE_DA_COMMIT, MAX_BLOCK_WEIGHT, MAX_DA_BATCHES_PER_BLOCK, MAX_DA_BYTES_PER_BLOCK,
+    MAX_DA_CHUNK_COUNT, MAX_FUTURE_DRIFT, POW_LIMIT,
 };
 use rubin_consensus::merkle::{witness_commitment_hash, witness_merkle_root_wtxids};
 use rubin_consensus::{
@@ -16,7 +16,7 @@ use sha3::{Digest, Sha3_256};
 use crate::coinbase::{
     build_coinbase_tx, default_mine_address, normalize_mine_address, parse_mine_address,
 };
-use crate::da_relay::CompleteDaSetCandidate;
+use crate::da_relay::{CompleteDaSetCandidate, CompleteDaSetProvider};
 use crate::sync::SyncEngine;
 use crate::txpool::{
     apply_policy, TxPool, TxPoolConfig, DEFAULT_MEMPOOL_MIN_FEE_RATE, DEFAULT_MIN_DA_FEE_RATE,
@@ -80,6 +80,7 @@ pub(crate) struct MinedCandidate {
 
 #[derive(Clone, Debug)]
 pub(crate) struct CompleteDaSetMiningCandidate {
+    da_id: [u8; 32],
     txs: Vec<MinedCandidate>,
     da_bytes: u64,
 }
@@ -98,6 +99,7 @@ pub(crate) struct CompleteDaSetGroupProjection<'a> {
 pub struct Miner<'a> {
     sync: &'a mut SyncEngine,
     tx_pool: Option<&'a mut TxPool>,
+    complete_da_set_provider: Option<&'a dyn CompleteDaSetProvider>,
     cfg: MinerConfig,
 }
 
@@ -130,7 +132,16 @@ impl<'a> Miner<'a> {
         if cfg.max_tx_per_block == 0 {
             cfg.max_tx_per_block = 1024;
         }
-        Ok(Self { sync, tx_pool, cfg })
+        Ok(Self {
+            sync,
+            tx_pool,
+            complete_da_set_provider: None,
+            cfg,
+        })
+    }
+
+    pub fn set_complete_da_set_provider(&mut self, provider: &'a dyn CompleteDaSetProvider) {
+        self.complete_da_set_provider = Some(provider);
     }
 
     pub fn mine_n(&mut self, blocks: usize, txs: &[Vec<u8>]) -> Result<Vec<MinedBlock>, String> {
@@ -247,22 +258,127 @@ impl<'a> Miner<'a> {
         next_height: u64,
         remaining_weight: u64,
     ) -> Result<Vec<MinedCandidate>, String> {
-        let mut parsed = Vec::with_capacity(candidate_txs.len());
+        let max_selected = self.cfg.max_tx_per_block.saturating_sub(1);
+        let mut parsed = Vec::with_capacity(candidate_txs.len().min(max_selected));
         let mut selected_weight = 0u64;
         let mut policy_da_included = 0u64;
+        let mut selected_nonces = HashSet::new();
+        let mut selected_inputs = HashSet::new();
         for raw in candidate_txs {
+            if parsed.len() >= max_selected {
+                break;
+            }
             let candidate = parse_mining_candidate(&raw)?;
             let (reject, next_da_included) =
                 self.reject_candidate(&candidate.tx, next_height, policy_da_included)?;
             if reject {
                 continue;
             }
+            if self.complete_da_set_provider.is_some() && is_mining_da_tx(&candidate.tx) {
+                continue;
+            }
+            let nonce = candidate.tx.tx_nonce;
+            if nonce == 0 || selected_nonces.contains(&nonce) {
+                continue;
+            }
             if candidate.weight > remaining_weight.saturating_sub(selected_weight) {
                 continue;
             }
-            selected_weight += candidate.weight;
+            selected_weight = selected_weight
+                .checked_add(candidate.weight)
+                .ok_or_else(|| "selected transaction weight overflow".to_string())?;
             policy_da_included = next_da_included;
+            selected_nonces.insert(nonce);
+            for input in &candidate.tx.inputs {
+                selected_inputs.insert(Outpoint {
+                    txid: input.prev_txid,
+                    vout: input.prev_vout,
+                });
+            }
             parsed.push(candidate);
+        }
+        let Some(provider) = self.complete_da_set_provider else {
+            return Ok(parsed);
+        };
+        if max_selected == 0 || parsed.len() >= max_selected || selected_weight >= remaining_weight
+        {
+            return Ok(parsed);
+        }
+        let block_mtp = self
+            .sync
+            .prev_timestamps_for_next_block()?
+            .filter(|timestamps| !timestamps.is_empty())
+            .map_or(0, |timestamps| mtp_median(next_height, &timestamps));
+        let mut provider_da_included = 0u64;
+        let mut selected_da_ids = HashSet::new();
+        let mut provider_budget = MAX_DA_BYTES_PER_BLOCK;
+        if self.cfg.policy_da_anchor_anti_abuse
+            && self.cfg.policy_max_da_bytes_per_block > 0
+            && self.cfg.policy_max_da_bytes_per_block < provider_budget
+        {
+            provider_budget = self.cfg.policy_max_da_bytes_per_block;
+        }
+        for set in provider.complete_da_set_candidates(provider_budget) {
+            if parsed.len() >= max_selected
+                || selected_da_ids.len() >= MAX_DA_BATCHES_PER_BLOCK as usize
+            {
+                break;
+            }
+            let remaining_slots = max_selected - parsed.len();
+            if set
+                .chunks
+                .len()
+                .checked_add(1)
+                .is_none_or(|group_len| group_len > remaining_slots)
+            {
+                continue;
+            }
+            let Some(group) = parse_complete_da_set_candidate(&set)? else {
+                continue;
+            };
+            if selected_da_ids.contains(&group.da_id)
+                || parsed
+                    .len()
+                    .checked_add(group.txs.len())
+                    .is_none_or(|len| len > max_selected)
+            {
+                continue;
+            }
+            let Some(next_provider_da_included) =
+                updated_policy_da_bytes(provider_da_included, group.da_bytes, provider_budget)
+            else {
+                continue;
+            };
+            let projection = CompleteDaSetGroupProjection {
+                selected_nonces: &selected_nonces,
+                selected_inputs: &selected_inputs,
+                next_height,
+                block_mtp,
+                selected_weight,
+                remaining_weight,
+                policy_da_included,
+            };
+            let Some((group_weight, next_da_included)) =
+                self.project_complete_da_set_group(&group.txs, projection)?
+            else {
+                continue;
+            };
+            selected_weight = selected_weight
+                .checked_add(group_weight)
+                .ok_or_else(|| "selected transaction weight overflow".to_string())?;
+            policy_da_included = next_da_included;
+            provider_da_included = next_provider_da_included;
+            selected_da_ids.insert(group.da_id);
+            for candidate in group.txs {
+                selected_nonces.insert(candidate.tx.tx_nonce);
+                for input in &candidate.tx.inputs {
+                    selected_inputs.insert(Outpoint {
+                        txid: input.prev_txid,
+                        vout: input.prev_vout,
+                    });
+                }
+                parsed.push(candidate);
+            }
         }
         Ok(parsed)
     }
@@ -463,6 +579,10 @@ fn parse_mining_candidate(raw: &[u8]) -> Result<MinedCandidate, String> {
     })
 }
 
+fn is_mining_da_tx(tx: &Tx) -> bool {
+    tx.tx_kind == 0x01 || tx.tx_kind == 0x02
+}
+
 pub fn validate_complete_da_set_candidate_shape(
     set: &CompleteDaSetCandidate,
 ) -> Result<bool, String> {
@@ -486,6 +606,7 @@ pub(crate) fn parse_complete_da_set_candidate(
     }
 
     let mut group = CompleteDaSetMiningCandidate {
+        da_id: set.da_id,
         da_bytes: commit.tx.da_payload.len() as u64,
         txs: vec![commit],
     };
@@ -887,6 +1008,64 @@ mod tests {
         set
     }
 
+    fn signed_miner_da_provider_set(
+        da_id: [u8; 32],
+        payloads: &[&[u8]],
+    ) -> (ProviderSet, HashMap<Outpoint, UtxoEntry>) {
+        let mut set = miner_da_provider_shape_set(da_id, payloads);
+        let keypair = Mldsa87Keypair::generate().expect("provider keypair");
+        let mut utxos = HashMap::new();
+        let mut sign_raw = |raw: &mut Vec<u8>| {
+            let (mut tx, _, _, _) = parse_tx(raw).expect("parse provider tx");
+            let outpoint = Outpoint {
+                txid: tx.inputs[0].prev_txid,
+                vout: tx.inputs[0].prev_vout,
+            };
+            utxos.insert(
+                outpoint,
+                UtxoEntry {
+                    value: 1_000_000,
+                    covenant_type: COV_TYPE_P2PK,
+                    covenant_data: p2pk_covenant_data_for_pubkey(&keypair.pubkey_bytes()),
+                    creation_height: 0,
+                    created_by_coinbase: false,
+                },
+            );
+            sign_transaction(&mut tx, &utxos, devnet_genesis_chain_id(), &keypair)
+                .expect("sign provider tx");
+            *raw = marshal_tx(&tx).expect("marshal provider tx");
+        };
+        sign_raw(&mut set.commit_tx);
+        for chunk in &mut set.chunks {
+            sign_raw(&mut chunk.tx);
+        }
+        (set, utxos)
+    }
+    struct MinerTestCompleteDaSetProvider(Vec<ProviderSet>);
+    impl crate::da_relay::CompleteDaSetProvider for MinerTestCompleteDaSetProvider {
+        fn complete_da_set_candidates(&self, _max_payload_bytes: u64) -> Vec<ProviderSet> {
+            self.0.clone()
+        }
+    }
+    fn select_provider_sets(
+        prefix: &str,
+        sets: Vec<ProviderSet>,
+        utxos: HashMap<Outpoint, UtxoEntry>,
+        cfg: MinerConfig,
+        remaining_weight: u64,
+    ) -> Vec<super::MinedCandidate> {
+        let (dir, _block_store, mut sync) = test_sync(prefix);
+        sync.chain_state.utxos = utxos;
+        let provider = MinerTestCompleteDaSetProvider(sets);
+        let mut miner = Miner::new(&mut sync, None, cfg).expect("miner");
+        miner.set_complete_da_set_provider(&provider);
+        let selected = miner
+            .select_candidate_transactions(Vec::new(), 1, remaining_weight)
+            .expect("select provider candidates");
+        let _ = fs::remove_dir_all(&dir);
+        selected
+    }
+
     fn expect_bad(set: ProviderSet) {
         assert!(!validate_complete_da_set_candidate_shape(&set).expect("shape validation"));
     }
@@ -941,41 +1120,8 @@ mod tests {
 
     #[test]
     fn miner_da_provider_group_projection_matrix() {
-        let (provider_group, provider_utxos) = {
-            let mut set = miner_da_provider_shape_set([0x91; 32], &[b"chunk"]);
-            let keypair = Mldsa87Keypair::generate().expect("provider keypair");
-            let mut utxos = HashMap::new();
-            let mut sign_raw = |raw: &mut Vec<u8>| {
-                let (mut tx, _, _, _) = parse_tx(raw).expect("parse provider tx");
-                let outpoint = Outpoint {
-                    txid: tx.inputs[0].prev_txid,
-                    vout: tx.inputs[0].prev_vout,
-                };
-                utxos.insert(
-                    outpoint,
-                    UtxoEntry {
-                        value: 1_000_000,
-                        covenant_type: COV_TYPE_P2PK,
-                        covenant_data: p2pk_covenant_data_for_pubkey(&keypair.pubkey_bytes()),
-                        creation_height: 0,
-                        created_by_coinbase: false,
-                    },
-                );
-                sign_transaction(&mut tx, &utxos, devnet_genesis_chain_id(), &keypair)
-                    .expect("sign provider tx");
-                *raw = marshal_tx(&tx).expect("marshal provider tx");
-            };
-            sign_raw(&mut set.commit_tx);
-            for chunk in &mut set.chunks {
-                sign_raw(&mut chunk.tx);
-            }
-            (
-                parse_complete_da_set_candidate(&set)
-                    .expect("parse provider group")
-                    .expect("provider group"),
-                utxos,
-            )
-        };
+        let (set, provider_utxos) = signed_miner_da_provider_set([0x91; 32], &[b"chunk"]);
+        let provider_group = parse_complete_da_set_candidate(&set).unwrap().unwrap();
         let (dir, _block_store, mut sync) = test_sync("rubin-rust-miner-da-provider-group");
         sync.chain_state.utxos = provider_utxos;
         let cfg = MinerConfig {
@@ -1071,6 +1217,50 @@ mod tests {
         let _ = fs::remove_dir_all(&dir);
     }
 
+    #[test]
+    fn miner_da_provider_selection_bounds_matrix() {
+        let (set, utxos) = signed_miner_da_provider_set([0xa1; 32], &[b"chunk"]);
+        let group = parse_complete_da_set_candidate(&set).unwrap().unwrap();
+        let group_len = group.txs.len();
+        let group_weight: u64 = group.txs.iter().map(|candidate| candidate.weight).sum();
+        let cfg = MinerConfig {
+            max_tx_per_block: group_len + 2,
+            policy_max_da_bytes_per_block: 10_000,
+            policy_current_mempool_min_fee_rate: 0,
+            policy_min_da_fee_rate: 0,
+            ..MinerConfig::default()
+        };
+        let select = |suffix: &str, sets: Vec<ProviderSet>, cfg: MinerConfig, weight: u64| {
+            select_provider_sets(
+                &format!("rubin-rust-miner-da-provider-selection-{suffix}"),
+                sets,
+                utxos.clone(),
+                cfg,
+                weight,
+            )
+        };
+        assert_eq!(
+            select("valid", vec![set.clone()], cfg.clone(), MAX_BLOCK_WEIGHT).len(),
+            group_len
+        );
+        let mut slot_cfg = cfg.clone();
+        slot_cfg.max_tx_per_block = group_len;
+        assert!(select("slots", vec![set.clone()], slot_cfg, MAX_BLOCK_WEIGHT).is_empty());
+        assert!(select("weight", vec![set.clone()], cfg.clone(), group_weight - 1).is_empty());
+        let mut da_cfg = cfg.clone();
+        da_cfg.policy_max_da_bytes_per_block = group.da_bytes - 1;
+        assert!(select("da-budget", vec![set.clone()], da_cfg, MAX_BLOCK_WEIGHT).is_empty());
+        assert_eq!(
+            select(
+                "duplicate-daid",
+                vec![set.clone(), set],
+                cfg,
+                MAX_BLOCK_WEIGHT
+            )
+            .len(),
+            group_len
+        );
+    }
     #[test]
     fn miner_da_anchor_master_switch_off_ignores_anchor_subflag() {
         let (dir, _block_store, mut sync) = test_sync("rubin-rust-miner-da-anchor-master-off");
@@ -1510,7 +1700,9 @@ mod tests {
     fn select_candidate_transactions_covers_reject_skip_and_accept_paths() {
         let (dir, _block_store, mut sync) = test_sync("rubin-rust-miner-selection");
         let (state, raw) = signed_p2pk_state_and_tx(20, 10);
+        let (da_set, da_utxos) = signed_miner_da_provider_set([0xb1; 32], &[b"chunk"]);
         sync.chain_state.utxos = state.utxos;
+        sync.chain_state.utxos.extend(da_utxos);
         let miner = Miner::new(&mut sync, None, MinerConfig::default()).expect("miner");
 
         let rejected = miner
@@ -1528,6 +1720,10 @@ mod tests {
             .expect("accept branch");
         assert_eq!(accepted.len(), 1);
         assert!(accepted[0].weight > 0);
+        let flat_da = miner
+            .select_candidate_transactions(vec![da_set.commit_tx], 0, MAX_BLOCK_WEIGHT)
+            .expect("flat DA without provider");
+        assert_eq!(flat_da.len(), 1);
         let _ = fs::remove_dir_all(&dir);
     }
 }

--- a/clients/rust/crates/rubin-node/src/miner.rs
+++ b/clients/rust/crates/rubin-node/src/miner.rs
@@ -218,9 +218,16 @@ impl<'a> Miner<'a> {
             return Vec::new();
         }
         if !txs.is_empty() {
+            if self.complete_da_set_provider.is_some() {
+                return pick_flat_candidate_raw(txs, max_selected);
+            }
             return txs.iter().take(max_selected).cloned().collect();
         }
         match self.tx_pool.as_deref() {
+            Some(pool) if self.complete_da_set_provider.is_some() => pick_flat_candidate_raw(
+                &pool.select_transactions(usize::MAX, usize::MAX),
+                max_selected,
+            ),
             Some(pool) => pool.select_transactions(max_selected, MAX_BLOCK_WEIGHT as usize),
             None => Vec::new(),
         }
@@ -274,14 +281,16 @@ impl<'a> Miner<'a> {
             if reject {
                 continue;
             }
-            if self.complete_da_set_provider.is_some()
-                && (candidate.tx.tx_kind == 0x01 || candidate.tx.tx_kind == 0x02)
-            {
+            if self.complete_da_set_provider.is_some() && is_mining_da_tx(&candidate.tx) {
                 continue;
             }
-            if candidate.tx.tx_nonce == 0 || selected_nonces.contains(&candidate.tx.tx_nonce) {
+            let Some(candidate_inputs) = collect_complete_da_set_group_inputs(
+                std::slice::from_ref(&candidate),
+                &selected_nonces,
+                &selected_inputs,
+            ) else {
                 continue;
-            }
+            };
             if candidate.weight > remaining_weight.saturating_sub(selected_weight) {
                 continue;
             }
@@ -290,12 +299,7 @@ impl<'a> Miner<'a> {
                 .ok_or_else(|| "selected transaction weight overflow".to_string())?;
             policy_da_included = next_da_included;
             selected_nonces.insert(candidate.tx.tx_nonce);
-            for input in &candidate.tx.inputs {
-                selected_inputs.insert(Outpoint {
-                    txid: input.prev_txid,
-                    vout: input.prev_vout,
-                });
-            }
+            selected_inputs.extend(candidate_inputs);
             parsed.push(candidate);
         }
         let Some(provider) = self.complete_da_set_provider else {
@@ -371,12 +375,10 @@ impl<'a> Miner<'a> {
             selected_da_ids.insert(group.da_id);
             for candidate in group.txs {
                 selected_nonces.insert(candidate.tx.tx_nonce);
-                for input in &candidate.tx.inputs {
-                    selected_inputs.insert(Outpoint {
-                        txid: input.prev_txid,
-                        vout: input.prev_vout,
-                    });
-                }
+                selected_inputs.extend(candidate.tx.inputs.iter().map(|input| Outpoint {
+                    txid: input.prev_txid,
+                    vout: input.prev_vout,
+                }));
                 parsed.push(candidate);
             }
         }
@@ -562,6 +564,22 @@ pub(crate) fn copy_selected_utxo_set(
         }
     }
     selected
+}
+
+fn pick_flat_candidate_raw(txs: &[Vec<u8>], max_count: usize) -> Vec<Vec<u8>> {
+    txs.iter()
+        .filter(|raw| !is_mining_da_tx_raw(raw))
+        .take(max_count)
+        .cloned()
+        .collect()
+}
+
+fn is_mining_da_tx_raw(raw: &[u8]) -> bool {
+    matches!(parse_tx(raw), Ok((tx, _, _, consumed)) if consumed == raw.len() && is_mining_da_tx(&tx))
+}
+
+fn is_mining_da_tx(tx: &Tx) -> bool {
+    tx.tx_kind == 0x01 || tx.tx_kind == 0x02
 }
 
 fn parse_mining_candidate(raw: &[u8]) -> Result<MinedCandidate, String> {
@@ -780,7 +798,7 @@ mod tests {
 
     use rubin_consensus::constants::{
         COV_TYPE_ANCHOR, COV_TYPE_CORE_EXT, COV_TYPE_DA_COMMIT, COV_TYPE_P2PK, MAX_BLOCK_WEIGHT,
-        TX_WIRE_VERSION,
+        MAX_DA_BATCHES_PER_BLOCK, TX_WIRE_VERSION,
     };
     use rubin_consensus::merkle::{witness_commitment_hash, witness_merkle_root_wtxids};
     use rubin_consensus::{
@@ -1039,7 +1057,7 @@ mod tests {
     }
     struct MinerTestCompleteDaSetProvider(Vec<ProviderSet>);
     impl crate::da_relay::CompleteDaSetProvider for MinerTestCompleteDaSetProvider {
-        fn complete_da_set_candidates(&self, _max_payload_bytes: u64) -> Vec<ProviderSet> {
+        fn complete_da_set_candidates(&self, _: u64) -> Vec<ProviderSet> {
             self.0.clone()
         }
     }
@@ -1109,9 +1127,16 @@ mod tests {
     fn miner_da_provider_shape_malformed_raw_errors() {
         let mut malformed_commit = miner_da_provider_shape_set([0x81; 32], &[b"chunk-0"]);
         malformed_commit.commit_tx.push(0);
+        let err = "non-canonical tx bytes in miner input";
         assert_eq!(
             parse_complete_da_set_candidate(&malformed_commit).unwrap_err(),
-            "non-canonical tx bytes in miner input"
+            err
+        );
+        let mut malformed_chunk = miner_da_provider_shape_set([0x82; 32], &[b"chunk-0"]);
+        malformed_chunk.chunks[0].tx.push(0);
+        assert_eq!(
+            parse_complete_da_set_candidate(&malformed_chunk).unwrap_err(),
+            err
         );
     }
 
@@ -1127,7 +1152,7 @@ mod tests {
             policy_min_da_fee_rate: 0,
             ..MinerConfig::default()
         };
-        let mut miner = Miner::new(&mut sync, None, cfg).expect("miner");
+        let mut miner = Miner::new(&mut sync, None, cfg.clone()).expect("miner");
         fn projection_context<'a>(
             selected_nonces: &'a HashSet<u64>,
             selected_inputs: &'a HashSet<Outpoint>,
@@ -1220,36 +1245,53 @@ mod tests {
         let group = parse_complete_da_set_candidate(&set).unwrap().unwrap();
         let group_len = group.txs.len();
         let group_weight: u64 = group.txs.iter().map(|candidate| candidate.weight).sum();
-        let cfg = MinerConfig {
-            max_tx_per_block: group_len * 2 + 1,
-            policy_current_mempool_min_fee_rate: 0,
-            policy_min_da_fee_rate: 0,
+        let provider_cfg = |max_tx_per_block| MinerConfig {
+            max_tx_per_block,
+            policy_da_anchor_anti_abuse: true,
             ..MinerConfig::default()
         };
+        let cfg = provider_cfg(group_len * 2 + 1);
         let select = |suffix: &str, sets: Vec<ProviderSet>, cfg: MinerConfig, weight: u64| {
             select_provider_sets(suffix, sets, utxos.clone(), cfg, weight)
         };
-        assert_eq!(
-            select("valid", vec![set.clone()], cfg.clone(), MAX_BLOCK_WEIGHT).len(),
-            group_len
-        );
+        let valid = select("valid", vec![set.clone()], cfg.clone(), MAX_BLOCK_WEIGHT);
+        assert_eq!(valid.len(), group_len);
         let mut slot_cfg = cfg.clone();
         slot_cfg.max_tx_per_block = group_len;
         assert!(select("slots", vec![set.clone()], slot_cfg, MAX_BLOCK_WEIGHT).is_empty());
         assert!(select("weight", vec![set.clone()], cfg.clone(), group_weight - 1).is_empty());
+        assert!(select("zero", Vec::new(), provider_cfg(1), 0).is_empty());
         let mut da_cfg = cfg.clone();
         da_cfg.policy_max_da_bytes_per_block = group.da_bytes - 1;
         assert!(select("da-budget", vec![set.clone()], da_cfg, MAX_BLOCK_WEIGHT).is_empty());
-        assert_eq!(
-            select(
-                "duplicate-daid",
-                vec![set.clone(), set],
-                cfg,
-                MAX_BLOCK_WEIGHT
-            )
-            .len(),
-            group_len
+        let bad_shape = mutate_set(&set, |set| set.chunks.clear());
+        assert!(select("bad-shape", vec![bad_shape], cfg.clone(), MAX_BLOCK_WEIGHT).is_empty());
+        let duplicate = select("dupe", vec![set.clone(), set], cfg, MAX_BLOCK_WEIGHT);
+        assert_eq!(duplicate.len(), group_len);
+        let mut capped_sets = Vec::new();
+        let mut capped_utxos = HashMap::new();
+        let cap_end = MAX_DA_BATCHES_PER_BLOCK as usize;
+        for index in 0..=cap_end {
+            let payload = [index as u8];
+            let da_id = [u8::try_from(index).expect("batch cap fits u8"); 32];
+            let (set, set_utxos) = signed_miner_da_provider_set(da_id, &[&payload]);
+            capped_sets.push(set);
+            capped_utxos.extend(set_utxos);
+        }
+        let selected = select_provider_sets(
+            "batch-cap",
+            capped_sets,
+            capped_utxos,
+            provider_cfg(group_len * (cap_end + 1) + 1),
+            MAX_BLOCK_WEIGHT,
         );
+        let overflow_da_id = [u8::try_from(cap_end).expect("batch cap fits u8"); 32];
+        assert_eq!(selected.len(), cap_end * group_len);
+        assert!(selected.iter().all(|candidate| {
+            candidate.tx.da_commit_core.as_ref().map(|core| core.da_id) != Some(overflow_da_id)
+                && candidate.tx.da_chunk_core.as_ref().map(|core| core.da_id)
+                    != Some(overflow_da_id)
+        }));
     }
     #[test]
     fn miner_da_anchor_master_switch_off_ignores_anchor_subflag() {
@@ -1410,9 +1452,22 @@ mod tests {
             max_tx_per_block: 2,
             ..MinerConfig::default()
         };
-        let miner = Miner::new(&mut sync, None, cfg).expect("miner");
-        let selected = miner.candidate_transactions(&[vec![0x01], vec![0x02], vec![0x03]]);
-        assert_eq!(selected, vec![vec![0x01]]);
+        let mut miner = Miner::new(&mut sync, None, cfg.clone()).expect("miner");
+        let selected = miner.candidate_transactions(&[vec![1], vec![2], vec![3]]);
+        assert_eq!(selected, vec![vec![1]]);
+        let provider = MinerTestCompleteDaSetProvider(Vec::new());
+        miner.set_complete_da_set_provider(&provider);
+        let da_set = miner_da_provider_shape_set([0xd1; 32], &[b"chunk"]);
+        let selected = miner.candidate_transactions(&[da_set.commit_tx.clone(), vec![2], vec![3]]);
+        assert_eq!(selected, vec![vec![2]]);
+        drop(miner);
+        let mut pool = TxPool::new();
+        let raw = vec![0x02; da_set.commit_tx.len() + 1];
+        pool.inject_test_entry([0x00; 32], da_set.commit_tx);
+        pool.inject_test_entry([0xff; 32], raw.clone());
+        let mut miner = Miner::new(&mut sync, Some(&mut pool), cfg).expect("pool miner");
+        miner.set_complete_da_set_provider(&provider);
+        assert_eq!(miner.candidate_transactions(&[]), vec![raw]);
         let _ = fs::remove_dir_all(&dir);
     }
 
@@ -1689,7 +1744,7 @@ mod tests {
     #[test]
     fn select_candidate_transactions_covers_reject_skip_and_accept_paths() {
         let (dir, _block_store, mut sync) = test_sync("rubin-rust-miner-selection");
-        let (state, raw) = signed_p2pk_state_and_tx(20, 10);
+        let (state, raw, conflicting_raw) = signed_conflicting_p2pk_state_and_txs(20, 10, 9);
         let (da_set, da_utxos) = signed_miner_da_provider_set([0xb1; 32], &[b"chunk"]);
         sync.chain_state.utxos = state.utxos;
         sync.chain_state.utxos.extend(da_utxos);
@@ -1706,10 +1761,10 @@ mod tests {
         assert!(overweight.is_empty());
 
         let accepted = miner
-            .select_candidate_transactions(vec![raw.clone()], 0, MAX_BLOCK_WEIGHT)
+            .select_candidate_transactions(vec![raw.clone(), conflicting_raw], 0, MAX_BLOCK_WEIGHT)
             .expect("accept branch");
         assert_eq!(accepted.len(), 1);
-        assert!(accepted[0].weight > 0);
+        assert_eq!(accepted[0].tx.tx_nonce, 7);
         let flat_da = miner
             .select_candidate_transactions(vec![da_set.commit_tx.clone()], 0, MAX_BLOCK_WEIGHT)
             .expect("flat DA without provider");

--- a/clients/rust/crates/rubin-node/src/miner.rs
+++ b/clients/rust/crates/rubin-node/src/miner.rs
@@ -224,10 +224,9 @@ impl<'a> Miner<'a> {
             return txs.iter().take(max_selected).cloned().collect();
         }
         match self.tx_pool.as_deref() {
-            Some(pool) if self.complete_da_set_provider.is_some() => pick_flat_candidate_raw(
-                &pool.select_transactions(usize::MAX, usize::MAX),
-                max_selected,
-            ),
+            Some(pool) if self.complete_da_set_provider.is_some() => {
+                pool.select_non_da_transactions(max_selected, MAX_BLOCK_WEIGHT as usize)
+            }
             Some(pool) => pool.select_transactions(max_selected, MAX_BLOCK_WEIGHT as usize),
             None => Vec::new(),
         }
@@ -340,12 +339,7 @@ impl<'a> Miner<'a> {
             let Some(group) = parse_complete_da_set_candidate(&set)? else {
                 continue;
             };
-            if selected_da_ids.contains(&group.da_id)
-                || parsed
-                    .len()
-                    .checked_add(group.txs.len())
-                    .is_none_or(|len| len > max_selected)
-            {
+            if selected_da_ids.contains(&group.da_id) {
                 continue;
             }
             let Some(next_provider_da_included) =
@@ -1062,14 +1056,12 @@ mod tests {
         }
     }
     fn select_provider_sets(
-        suffix: &str,
         sets: Vec<ProviderSet>,
         utxos: HashMap<Outpoint, UtxoEntry>,
         cfg: MinerConfig,
         remaining_weight: u64,
     ) -> Vec<super::MinedCandidate> {
-        let (dir, _block_store, mut sync) =
-            test_sync(&format!("rubin-rust-miner-da-provider-selection-{suffix}"));
+        let (dir, _block_store, mut sync) = test_sync("rubin-rust-miner-da-provider-selection");
         sync.chain_state.utxos = utxos;
         let provider = MinerTestCompleteDaSetProvider(sets);
         let mut miner = Miner::new(&mut sync, None, cfg).expect("miner");
@@ -1132,12 +1124,6 @@ mod tests {
             parse_complete_da_set_candidate(&malformed_commit).unwrap_err(),
             err
         );
-        let mut malformed_chunk = miner_da_provider_shape_set([0x82; 32], &[b"chunk-0"]);
-        malformed_chunk.chunks[0].tx.push(0);
-        assert_eq!(
-            parse_complete_da_set_candidate(&malformed_chunk).unwrap_err(),
-            err
-        );
     }
 
     #[test]
@@ -1152,7 +1138,7 @@ mod tests {
             policy_min_da_fee_rate: 0,
             ..MinerConfig::default()
         };
-        let mut miner = Miner::new(&mut sync, None, cfg.clone()).expect("miner");
+        let mut miner = Miner::new(&mut sync, None, cfg).expect("miner");
         fn projection_context<'a>(
             selected_nonces: &'a HashSet<u64>,
             selected_inputs: &'a HashSet<Outpoint>,
@@ -1247,51 +1233,51 @@ mod tests {
         let group_weight: u64 = group.txs.iter().map(|candidate| candidate.weight).sum();
         let provider_cfg = |max_tx_per_block| MinerConfig {
             max_tx_per_block,
-            policy_da_anchor_anti_abuse: true,
             ..MinerConfig::default()
         };
         let cfg = provider_cfg(group_len * 2 + 1);
-        let select = |suffix: &str, sets: Vec<ProviderSet>, cfg: MinerConfig, weight: u64| {
-            select_provider_sets(suffix, sets, utxos.clone(), cfg, weight)
+        let select = |sets: Vec<ProviderSet>, cfg: MinerConfig, weight: u64| {
+            select_provider_sets(sets, utxos.clone(), cfg, weight)
         };
-        let valid = select("valid", vec![set.clone()], cfg.clone(), MAX_BLOCK_WEIGHT);
-        assert_eq!(valid.len(), group_len);
+        assert_eq!(
+            select(vec![set.clone()], cfg.clone(), MAX_BLOCK_WEIGHT).len(),
+            group_len
+        );
         let mut slot_cfg = cfg.clone();
         slot_cfg.max_tx_per_block = group_len;
-        assert!(select("slots", vec![set.clone()], slot_cfg, MAX_BLOCK_WEIGHT).is_empty());
-        assert!(select("weight", vec![set.clone()], cfg.clone(), group_weight - 1).is_empty());
-        assert!(select("zero", Vec::new(), provider_cfg(1), 0).is_empty());
+        assert!(select(vec![set.clone()], slot_cfg, MAX_BLOCK_WEIGHT).is_empty());
+        assert!(select(vec![set.clone()], cfg.clone(), group_weight - 1).is_empty());
+        assert!(select(Vec::new(), provider_cfg(1), 0).is_empty());
         let mut da_cfg = cfg.clone();
         da_cfg.policy_max_da_bytes_per_block = group.da_bytes - 1;
-        assert!(select("da-budget", vec![set.clone()], da_cfg, MAX_BLOCK_WEIGHT).is_empty());
-        let bad_shape = mutate_set(&set, |set| set.chunks.clear());
-        assert!(select("bad-shape", vec![bad_shape], cfg.clone(), MAX_BLOCK_WEIGHT).is_empty());
-        let duplicate = select("dupe", vec![set.clone(), set], cfg, MAX_BLOCK_WEIGHT);
-        assert_eq!(duplicate.len(), group_len);
+        assert!(select(vec![set.clone()], da_cfg, MAX_BLOCK_WEIGHT).is_empty());
+        assert!(select(
+            vec![mutate_set(&set, |set| set.chunks.clear())],
+            cfg.clone(),
+            MAX_BLOCK_WEIGHT
+        )
+        .is_empty());
+        assert_eq!(
+            select(vec![set.clone(), set], cfg, MAX_BLOCK_WEIGHT).len(),
+            group_len
+        );
         let mut capped_sets = Vec::new();
         let mut capped_utxos = HashMap::new();
         let cap_end = MAX_DA_BATCHES_PER_BLOCK as usize;
         for index in 0..=cap_end {
-            let payload = [index as u8];
-            let da_id = [u8::try_from(index).expect("batch cap fits u8"); 32];
-            let (set, set_utxos) = signed_miner_da_provider_set(da_id, &[&payload]);
+            let marker = u8::try_from(index).expect("batch cap fits u8");
+            let payload = [marker];
+            let (set, set_utxos) = signed_miner_da_provider_set([marker; 32], &[&payload]);
             capped_sets.push(set);
             capped_utxos.extend(set_utxos);
         }
         let selected = select_provider_sets(
-            "batch-cap",
             capped_sets,
             capped_utxos,
             provider_cfg(group_len * (cap_end + 1) + 1),
             MAX_BLOCK_WEIGHT,
         );
-        let overflow_da_id = [u8::try_from(cap_end).expect("batch cap fits u8"); 32];
         assert_eq!(selected.len(), cap_end * group_len);
-        assert!(selected.iter().all(|candidate| {
-            candidate.tx.da_commit_core.as_ref().map(|core| core.da_id) != Some(overflow_da_id)
-                && candidate.tx.da_chunk_core.as_ref().map(|core| core.da_id)
-                    != Some(overflow_da_id)
-        }));
     }
     #[test]
     fn miner_da_anchor_master_switch_off_ignores_anchor_subflag() {
@@ -1745,10 +1731,8 @@ mod tests {
     fn select_candidate_transactions_covers_reject_skip_and_accept_paths() {
         let (dir, _block_store, mut sync) = test_sync("rubin-rust-miner-selection");
         let (state, raw, conflicting_raw) = signed_conflicting_p2pk_state_and_txs(20, 10, 9);
-        let (da_set, da_utxos) = signed_miner_da_provider_set([0xb1; 32], &[b"chunk"]);
         sync.chain_state.utxos = state.utxos;
-        sync.chain_state.utxos.extend(da_utxos);
-        let mut miner = Miner::new(&mut sync, None, MinerConfig::default()).expect("miner");
+        let miner = Miner::new(&mut sync, None, MinerConfig::default()).expect("miner");
 
         let rejected = miner
             .select_candidate_transactions(vec![coinbase_bytes(0)], 0, MAX_BLOCK_WEIGHT)
@@ -1765,16 +1749,6 @@ mod tests {
             .expect("accept branch");
         assert_eq!(accepted.len(), 1);
         assert_eq!(accepted[0].tx.tx_nonce, 7);
-        let flat_da = miner
-            .select_candidate_transactions(vec![da_set.commit_tx.clone()], 0, MAX_BLOCK_WEIGHT)
-            .expect("flat DA without provider");
-        assert_eq!(flat_da.len(), 1);
-        let empty_provider = MinerTestCompleteDaSetProvider(Vec::new());
-        miner.set_complete_da_set_provider(&empty_provider);
-        assert!(miner
-            .select_candidate_transactions(vec![da_set.commit_tx], 0, MAX_BLOCK_WEIGHT)
-            .expect("flat DA skipped with provider")
-            .is_empty());
         let _ = fs::remove_dir_all(&dir);
     }
 }

--- a/clients/rust/crates/rubin-node/src/txpool.rs
+++ b/clients/rust/crates/rubin-node/src/txpool.rs
@@ -1935,9 +1935,9 @@ fn compare_entries_for_mining(
         },
     }
 }
-
 fn is_mining_da_raw_for_selection(raw: &[u8]) -> bool {
-    matches!(parse_tx(raw), Ok((tx, _, _, consumed)) if consumed == raw.len() && (tx.tx_kind == 0x01 || tx.tx_kind == 0x02))
+    raw.starts_with(&rubin_consensus::constants::TX_WIRE_VERSION.to_le_bytes())
+        && matches!(raw.get(4).copied(), Some(0x01 | 0x02))
 }
 
 #[cfg(test)]

--- a/clients/rust/crates/rubin-node/src/txpool.rs
+++ b/clients/rust/crates/rubin-node/src/txpool.rs
@@ -487,23 +487,12 @@ impl TxPool {
     }
 
     pub fn select_transactions(&self, max_count: usize, max_bytes: usize) -> Vec<Vec<u8>> {
-        self.select_transactions_with(max_count, max_bytes, true)
+        self.select_with(max_count, max_bytes, true)
     }
-
-    pub(crate) fn select_non_da_transactions(
-        &self,
-        max_count: usize,
-        max_bytes: usize,
-    ) -> Vec<Vec<u8>> {
-        self.select_transactions_with(max_count, max_bytes, false)
+    pub(crate) fn select_non_da(&self, max_count: usize, max_bytes: usize) -> Vec<Vec<u8>> {
+        self.select_with(max_count, max_bytes, false)
     }
-
-    fn select_transactions_with(
-        &self,
-        max_count: usize,
-        max_bytes: usize,
-        include_da: bool,
-    ) -> Vec<Vec<u8>> {
+    fn select_with(&self, max_count: usize, max_bytes: usize, include_da: bool) -> Vec<Vec<u8>> {
         if max_count == 0 || max_bytes == 0 {
             return Vec::new();
         }
@@ -514,11 +503,11 @@ impl TxPool {
         let mut selected = Vec::with_capacity(entries.len().min(max_count));
         let mut used_bytes = 0usize;
         for entry in entries {
-            if !include_da && is_mining_da_raw_for_selection(&entry.1.raw) {
-                continue;
-            }
             if selected.len() >= max_count {
                 break;
+            }
+            if !include_da && is_mining_da_raw_for_selection(&entry.1.raw) {
+                continue;
             }
             if entry.1.size > max_bytes.saturating_sub(used_bytes) {
                 continue;

--- a/clients/rust/crates/rubin-node/src/txpool.rs
+++ b/clients/rust/crates/rubin-node/src/txpool.rs
@@ -487,6 +487,23 @@ impl TxPool {
     }
 
     pub fn select_transactions(&self, max_count: usize, max_bytes: usize) -> Vec<Vec<u8>> {
+        self.select_transactions_with(max_count, max_bytes, true)
+    }
+
+    pub(crate) fn select_non_da_transactions(
+        &self,
+        max_count: usize,
+        max_bytes: usize,
+    ) -> Vec<Vec<u8>> {
+        self.select_transactions_with(max_count, max_bytes, false)
+    }
+
+    fn select_transactions_with(
+        &self,
+        max_count: usize,
+        max_bytes: usize,
+        include_da: bool,
+    ) -> Vec<Vec<u8>> {
         if max_count == 0 || max_bytes == 0 {
             return Vec::new();
         }
@@ -497,6 +514,9 @@ impl TxPool {
         let mut selected = Vec::with_capacity(entries.len().min(max_count));
         let mut used_bytes = 0usize;
         for entry in entries {
+            if !include_da && is_mining_da_raw_for_selection(&entry.1.raw) {
+                continue;
+            }
             if selected.len() >= max_count {
                 break;
             }
@@ -1925,6 +1945,10 @@ fn compare_entries_for_mining(
             other => other,
         },
     }
+}
+
+fn is_mining_da_raw_for_selection(raw: &[u8]) -> bool {
+    matches!(parse_tx(raw), Ok((tx, _, _, consumed)) if consumed == raw.len() && (tx.tx_kind == 0x01 || tx.tx_kind == 0x02))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Scope:
- Add Rust miner provider COMPLETE_SET selection after flat candidates.
- Enforce transaction slot, block weight, provider DA-byte, policy DA-byte, duplicate DAID, and provider batch budgets before appending provider groups.
- Preserve provider-absent flat candidate compatibility until RUB-389 wires live provider input.

Not in scope:
- Live runtime wiring through RPC/main; owned by RUB-389.
- Rust flat/txpool DA filtering beyond the RUB-407 provider-present miner path; owned by RUB-387.
- DA relay state/provider implementation changes.
- Go reference, spec, or conformance fixture changes.

## required_parity_cases_matrix
| case | go_callsite | rust_callsite | rust_mirror_test |
| -- | -- | -- | -- |
| flat_then_provider_complete_sets | clients/go/node/miner.go selectCandidateTransactions provider loop; clients/go/node/miner_flat_filter.go isMiningDATx | clients/rust/crates/rubin-node/src/miner.rs select_candidate_transactions provider-present DA filter | miner::tests::select_candidate_transactions_covers_reject_skip_and_accept_paths; miner::tests::miner_da_provider_selection_bounds_matrix |
| provider_slot_weight_atomicity | clients/go/node/miner.go selectCandidateTransactions remainingSlots and projectCompleteDASetGroup | clients/rust/crates/rubin-node/src/miner.rs select_candidate_transactions and project_complete_da_set_group | miner::tests::miner_da_provider_selection_bounds_matrix |
| provider_da_byte_budgets | clients/go/node/miner.go providerBudget/providerDaIncluded and updatedPolicyDaBytes | clients/rust/crates/rubin-node/src/miner.rs provider_budget/provider_da_included and updated_policy_da_bytes | miner::tests::miner_da_provider_selection_bounds_matrix; miner::tests::miner_da_provider_group_projection_matrix |
| duplicate_daid_guard | clients/go/node/miner.go selectedDAIDs and MAX_DA_BATCHES_PER_BLOCK | clients/rust/crates/rubin-node/src/miner.rs selected_da_ids and MAX_DA_BATCHES_PER_BLOCK | miner::tests::miner_da_provider_selection_bounds_matrix |
| provider_project_before_append | clients/go/node/miner.go parseCompleteDASetCandidate, projectCompleteDASetGroup, collectCompleteDASetGroupInputs | clients/rust/crates/rubin-node/src/miner.rs parse_complete_da_set_candidate, project_complete_da_set_group, collect_complete_da_set_group_inputs | miner::tests::miner_da_provider_group_projection_matrix; miner::tests::miner_da_provider_selection_bounds_matrix |

Closes #1869
