### PR TITLE
RUB-389: wire live DA provider into devnet mining

### DIFF
--- a/clients/rust/crates/rubin-node/src/devnet_rpc.rs
+++ b/clients/rust/crates/rubin-node/src/devnet_rpc.rs
@@ -8,6 +8,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 
+use crate::da_relay::CompleteDaSetProvider;
 use crate::miner::{Miner, MinerConfig};
 use crate::p2p_runtime::{orphan_pool_metrics_snapshot, PeerManager};
 use crate::txpool::TxSource;
@@ -59,6 +60,7 @@ pub struct DevnetRPCState {
     rpc_op_lock: Arc<Mutex<()>>,
     /// When set, POST `/mine_next` mines one block using this config (devnet + loopback RPC only).
     live_mining_cfg: Option<MinerConfig>,
+    live_complete_da_set_provider: Option<Arc<dyn CompleteDaSetProvider + Send + Sync>>,
     /// RUB-10 / GitHub #1151: readiness gate driving `/ready` semantics.
     /// Mirrors Go's `clients/go/cmd/rubin-node/http_rpc.go::readinessGate`
     /// (type at line 125; methods 143-219). Three-state machine:
@@ -532,6 +534,7 @@ pub fn new_devnet_rpc_state_with_tx_pool(
         accepted_block: None,
         rpc_op_lock: Arc::new(Mutex::new(())),
         live_mining_cfg,
+        live_complete_da_set_provider: None,
         // RUB-10 / GitHub #1151: gate starts in `NotReady`. The
         // `try_mark_ready_on_startup` transition runs inside
         // `start_devnet_rpc_server` after the listener is bound, so
@@ -544,6 +547,13 @@ pub fn new_devnet_rpc_state_with_tx_pool(
 impl DevnetRPCState {
     pub fn set_accepted_block_hook(&mut self, accepted_block: AcceptedBlockFn) {
         self.accepted_block = Some(accepted_block);
+    }
+
+    pub fn set_complete_da_set_provider(
+        &mut self,
+        provider: Arc<dyn CompleteDaSetProvider + Send + Sync>,
+    ) {
+        self.live_complete_da_set_provider = Some(provider);
     }
 }
 
@@ -1571,6 +1581,9 @@ fn handle_mine_next(state: &DevnetRPCState, method: &str, _body: &[u8]) -> HttpR
             );
         }
     };
+    if let Some(provider) = state.live_complete_da_set_provider.as_ref() {
+        miner.set_complete_da_set_provider(provider.as_ref());
+    }
     let mined = match miner.mine_one(&[]) {
         Ok(b) => b,
         Err(err) => {
@@ -2819,6 +2832,16 @@ mod tests {
         route_request, split_target, start_devnet_rpc_server, status_text, HttpRequest, ReadyState,
     };
 
+    impl crate::da_relay::CompleteDaSetProvider for AtomicUsize {
+        fn complete_da_set_candidates(
+            &self,
+            _max_payload_bytes: u64,
+        ) -> Vec<crate::da_relay::CompleteDaSetCandidate> {
+            self.fetch_add(1, Ordering::SeqCst);
+            Vec::new()
+        }
+    }
+
     fn build_state(with_genesis: bool) -> (super::DevnetRPCState, PathBuf) {
         let dir = unique_temp_path("rubin-devnet-rpc");
         fs::create_dir_all(&dir).expect("mkdir");
@@ -3122,6 +3145,7 @@ mod tests {
             accepted_block: None,
             rpc_op_lock: Arc::new(Mutex::new(())),
             live_mining_cfg: None,
+            live_complete_da_set_provider: None,
             // RUB-10 / GitHub #1151: this helper bypasses the public
             // constructor (`new_devnet_rpc_state*`) so it does not
             // benefit from the default-NotReady wiring there. Keep
@@ -3320,6 +3344,19 @@ mod tests {
             response_json(&response)["error"].as_str(),
             Some("live mining unavailable")
         );
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn mine_next_passes_live_complete_da_provider_to_miner() {
+        let (mut state, dir) = build_state_with_live_mining(true);
+        let calls = Arc::new(AtomicUsize::new(0));
+        state.set_complete_da_set_provider(calls.clone());
+
+        let response = post_mine_next(&state);
+
+        assert_eq!(response.status, 200);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
         fs::remove_dir_all(dir).expect("cleanup");
     }
 
@@ -4997,6 +5034,7 @@ mod tests {
             accepted_block: None,
             rpc_op_lock: Arc::new(Mutex::new(())),
             live_mining_cfg: None,
+            live_complete_da_set_provider: None,
             // RUB-10 / GitHub #1151: render_prometheus_metrics test does
             // not exercise `/ready`; default `NotReady` is fine.
             readiness: Arc::new(super::ReadinessGate::default()),

--- a/clients/rust/crates/rubin-node/src/main.rs
+++ b/clients/rust/crates/rubin-node/src/main.rs
@@ -396,10 +396,7 @@ fn run(args: &[String], stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
         }
     }
 
-    let live_mining_cfg = if cfg.network == "devnet"
-        && !cfg.rpc_bind_addr.trim().is_empty()
-        && rpc_bind_host_is_loopback(&cfg.rpc_bind_addr)
-    {
+    let live_mining_cfg = if live_devnet_loopback_mining_allowed(&cfg) {
         let mut miner_cfg = MinerConfig {
             core_ext_deployments: genesis_cfg.core_ext_deployments.clone(),
             ..MinerConfig::default()
@@ -512,6 +509,7 @@ fn run(args: &[String], stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
             rubin_node::tx_relay::announce_block(block_bytes, &relay_state, &pm, &local, &pw)
         }))
     };
+    let live_mining_enabled = live_mining_cfg.is_some();
     let mut state = new_devnet_rpc_state_with_tx_pool(
         Arc::clone(&sync_engine),
         Some(block_store),
@@ -521,6 +519,9 @@ fn run(args: &[String], stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
         announce_block,
         live_mining_cfg,
     );
+    if live_mining_enabled {
+        state.set_complete_da_set_provider(p2p_service.complete_da_set_provider());
+    }
     state.set_accepted_block_hook(Arc::new(move |hash| {
         advance_da_ttl_for_block(hash, &da_ttl_relay, &da_ttl_seen)
     }));
@@ -1149,6 +1150,10 @@ fn validate_config(cfg: &mut CliConfig) -> Result<(), String> {
     Ok(())
 }
 
+fn live_devnet_loopback_mining_allowed(cfg: &CliConfig) -> bool {
+    cfg.network == "devnet" && rpc_bind_host_is_loopback(&cfg.rpc_bind_addr)
+}
+
 fn validate_addr(label: &str, addr: &str) -> Result<(), String> {
     validate_addr_inner(label, addr, false)
 }
@@ -1306,9 +1311,9 @@ mod tests {
     use super::{
         advance_da_ttl_for_block, announce_tx_after_local_admission, format_peer_slots_banner,
         handle_rpc_start_error_after_maybe_stop, legacy_exposure_hooks,
-        maybe_shutdown_if_requested, parse_args, run, runtime_genesis_hash, stop_signal_pair,
-        validate_config, wait_for_stop_and_shutdown, LegacyExposureReport,
-        PRODUCTION_STOP_SIGNAL_SET, RPC_READINESS_TRANSITION_FAILED,
+        live_devnet_loopback_mining_allowed, maybe_shutdown_if_requested, parse_args, run,
+        runtime_genesis_hash, stop_signal_pair, validate_config, wait_for_stop_and_shutdown,
+        LegacyExposureReport, PRODUCTION_STOP_SIGNAL_SET, RPC_READINESS_TRANSITION_FAILED,
     };
     use rubin_consensus::constants::{
         COV_TYPE_DA_COMMIT, ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES, SUITE_ID_ML_DSA_87,
@@ -2168,6 +2173,34 @@ mod tests {
             parse_args(&["--network".to_string(), "  devnet  ".to_string()]).expect("parse args");
         validate_config(&mut cfg).expect("trimmed devnet should pass");
         assert_eq!(cfg.network, "devnet");
+    }
+
+    #[test]
+    fn live_devnet_loopback_mining_provider_gate_matches_runtime_scope() {
+        let mut loopback = parse_args(&["--rpc-bind".to_string(), "127.0.0.1:19112".to_string()])
+            .expect("parse args");
+        validate_config(&mut loopback).expect("loopback devnet config");
+        assert!(live_devnet_loopback_mining_allowed(&loopback));
+
+        let mut no_rpc = parse_args(&[]).expect("parse args");
+        validate_config(&mut no_rpc).expect("default devnet config");
+        assert!(!live_devnet_loopback_mining_allowed(&no_rpc));
+
+        let mut non_loopback = parse_args(&["--rpc-bind".to_string(), "0.0.0.0:19112".to_string()])
+            .expect("parse args");
+        validate_config(&mut non_loopback).expect("non-loopback devnet config");
+        assert!(!live_devnet_loopback_mining_allowed(&non_loopback));
+
+        let mut non_devnet = parse_args(&[
+            "--network".to_string(),
+            "mainnet".to_string(),
+            "--rpc-bind".to_string(),
+            "127.0.0.1:19112".to_string(),
+        ])
+        .expect("parse args");
+        non_devnet.genesis_file = Some(PathBuf::from("genesis.json"));
+        validate_config(&mut non_devnet).expect("non-devnet config with genesis path");
+        assert!(!live_devnet_loopback_mining_allowed(&non_devnet));
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/p2p_service.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_service.rs
@@ -6,7 +6,9 @@ use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
-use crate::da_relay::{DaRelayCaps, DaRelayState, PeerQuotaKey};
+use crate::da_relay::{
+    CompleteDaSetCandidate, CompleteDaSetProvider, DaRelayCaps, DaRelayState, PeerQuotaKey,
+};
 use crate::p2p_runtime::{
     perform_version_handshake, LiveMessageOutcome, PeerManager, PeerRelayContext,
     PeerRuntimeConfig, VersionPayloadV1, WireMessage,
@@ -53,6 +55,20 @@ pub struct RunningNodeP2PService {
     shared: SharedServiceState,
     accept_join: Option<JoinHandle<()>>,
     reconnect_join: Option<JoinHandle<()>>,
+}
+
+struct ServiceCompleteDaSetProvider {
+    da_relay: Arc<Mutex<DaRelayState>>,
+}
+
+impl CompleteDaSetProvider for ServiceCompleteDaSetProvider {
+    fn complete_da_set_candidates(&self, max_payload_bytes: u64) -> Vec<CompleteDaSetCandidate> {
+        let relay = match self.da_relay.lock() {
+            Ok(relay) => relay,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        relay.complete_da_set_candidates(max_payload_bytes)
+    }
 }
 
 #[derive(Clone)]
@@ -215,6 +231,12 @@ impl RunningNodeP2PService {
 
     pub fn da_relay_state(&self) -> Arc<Mutex<DaRelayState>> {
         Arc::clone(&self.shared.da_relay)
+    }
+
+    pub fn complete_da_set_provider(&self) -> Arc<dyn CompleteDaSetProvider + Send + Sync> {
+        Arc::new(ServiceCompleteDaSetProvider {
+            da_relay: Arc::clone(&self.shared.da_relay),
+        })
     }
 
     pub fn close(&mut self) {
@@ -1354,7 +1376,12 @@ mod tests {
     use std::thread;
     use std::time::{Duration, Instant};
 
-    use rubin_consensus::{block_hash, constants::POW_LIMIT, parse_tx, BLOCK_HEADER_BYTES};
+    use rubin_consensus::{
+        block_hash,
+        constants::{COV_TYPE_DA_COMMIT, POW_LIMIT, TX_WIRE_VERSION},
+        marshal_tx, parse_tx, DaChunkCore, DaCommitCore, Tx, TxOutput, BLOCK_HEADER_BYTES,
+    };
+    use sha3::Digest;
 
     use super::{
         apply_tx_pool_cleanup, connect_with_timeout, finalize_live_message_outcome,
@@ -1418,6 +1445,61 @@ mod tests {
     fn test_genesis_hash() -> [u8; 32] {
         let genesis = devnet_genesis_block_bytes();
         block_hash(&genesis[..BLOCK_HEADER_BYTES]).expect("genesis hash")
+    }
+
+    fn relay_test_id(seed: &[u8]) -> [u8; 32] {
+        sha3::Sha3_256::digest(seed).into()
+    }
+
+    fn relay_test_nonce(seed: &[u8]) -> u64 {
+        u64::from_le_bytes(relay_test_id(seed)[..8].try_into().expect("hash prefix"))
+    }
+
+    fn relay_da_base_tx(tx_kind: u8, tx_nonce: u64) -> Tx {
+        Tx {
+            version: TX_WIRE_VERSION,
+            tx_kind,
+            tx_nonce,
+            inputs: Vec::new(),
+            outputs: Vec::new(),
+            locktime: 0,
+            da_commit_core: None,
+            da_chunk_core: None,
+            witness: Vec::new(),
+            da_payload: Vec::new(),
+        }
+    }
+
+    fn relay_da_commit_tx(da_id: [u8; 32], commitment: [u8; 32]) -> Vec<u8> {
+        let mut tx = relay_da_base_tx(0x01, relay_test_nonce(b"rub389-commit-nonce"));
+        tx.outputs.push(TxOutput {
+            value: 0,
+            covenant_type: COV_TYPE_DA_COMMIT,
+            covenant_data: commitment.to_vec(),
+        });
+        tx.da_commit_core = Some(DaCommitCore {
+            da_id,
+            chunk_count: 1,
+            retl_domain_id: relay_test_id(b"rub389-retl-domain"),
+            batch_number: 1,
+            tx_data_root: relay_test_id(b"rub389-tx-data-root"),
+            state_root: relay_test_id(b"rub389-state-root"),
+            withdrawals_root: relay_test_id(b"rub389-withdrawals-root"),
+            batch_sig_suite: 0,
+            batch_sig: Vec::new(),
+        });
+        marshal_tx(&tx).expect("marshal DA commit tx")
+    }
+
+    fn relay_da_chunk_tx(da_id: [u8; 32], payload: &[u8]) -> Vec<u8> {
+        let mut tx = relay_da_base_tx(0x02, relay_test_nonce(b"rub389-chunk-nonce"));
+        tx.da_chunk_core = Some(DaChunkCore {
+            da_id,
+            chunk_index: 0,
+            chunk_hash: sha3::Sha3_256::digest(payload).into(),
+        });
+        tx.da_payload = payload.to_vec();
+        marshal_tx(&tx).expect("marshal DA chunk tx")
     }
 
     fn test_shared_state(
@@ -1518,6 +1600,55 @@ mod tests {
         tx_bytes.push(0x01);
         super::stage_local_da_relay_tx_bytes(&da_relay, &tx_bytes);
         service.close();
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn service_complete_da_set_provider_enforces_snapshot_payload_budget() {
+        let (sync_engine, dir) = test_engine("rubin-node-p2p-da-provider");
+        let shared = test_shared_state(
+            default_peer_runtime_config("devnet", 8),
+            Vec::new(),
+            sync_engine,
+        );
+        let service = super::RunningNodeP2PService {
+            addr: "127.0.0.1:0".to_string(),
+            stop: Arc::clone(&shared.stop),
+            shared: shared.clone(),
+            accept_join: None,
+            reconnect_join: None,
+        };
+        let provider = service.complete_da_set_provider();
+
+        let da_id = relay_test_id(b"rub389-service-provider-da-id");
+        let payload: &[u8] = b"service-owned-complete-set";
+        let payload_commitment: [u8; 32] = sha3::Sha3_256::digest(payload).into();
+        let commit_tx = relay_da_commit_tx(da_id, payload_commitment);
+        let chunk_tx = relay_da_chunk_tx(da_id, payload);
+        {
+            let da_relay = service.da_relay_state();
+            let mut da_relay = da_relay.lock().expect("lock DA relay");
+            da_relay
+                .stage_relay_da_tx_bytes("peer-a:8333", commit_tx)
+                .expect("stage complete-set commit tx");
+            da_relay
+                .stage_relay_da_tx_bytes("peer-a:8333", chunk_tx)
+                .expect("stage complete-set chunk tx");
+        }
+        let under_budget = provider.complete_da_set_candidates((payload.len() - 1) as u64);
+        assert!(under_budget.is_empty());
+        let candidates = provider.complete_da_set_candidates(payload.len() as u64);
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].da_id, da_id);
+        assert_eq!(candidates[0].payload_bytes, payload.len() as u64);
+
+        let poison_target = service.da_relay_state();
+        let _ = std::panic::catch_unwind(move || {
+            let _guard = poison_target.lock().expect("lock DA relay");
+            panic!("poison DA provider lock");
+        });
+        assert_eq!(provider.complete_da_set_candidates(u64::MAX).len(), 1);
+
         fs::remove_dir_all(dir).expect("cleanup");
     }
 


### PR DESCRIPTION
Invariant:
Rust live devnet loopback mining wires the service-owned P2P DA complete-set provider into `/mine_next` only when live mining is enabled.

Scope:
- Adds a service-owned `CompleteDaSetProvider` adapter over P2P DA relay state.
- Passes the provider into the RPC miner only for the existing devnet loopback live-mining gate.
- Keeps dry-run, offline `--mine-blocks`, non-loopback RPC, and non-devnet paths without a live DA provider.

Matrix:
- devnet + loopback RPC: provider is installed and passed to the miner.
- no RPC / non-loopback RPC / non-devnet: provider is not installed.
- provider snapshot: payload budget is enforced; poisoned relay lock recovers and returns the owned snapshot.
- miner path: provider candidates still go through miner parsing, commitment, policy, and budget checks.

Evidence:
- `cargo fmt --check`
- `cargo test -p rubin-node main --lib`
- `cargo test -p rubin-node miner --lib`
- `cargo test -p rubin-node p2p_service --lib`
- `cargo test -p rubin-node --bin rubin-node`
- `cargo test -p rubin-node --lib`
- `cargo clippy -p rubin-node --lib --tests -- -D warnings`
- Coverage: diff coverage 100.00%, variation +0.01%.

Not included:
- DA relay consume/eviction lifecycle for mined complete sets; tracked separately in RUB-425.
- Miner provider selection policy changes.
- Compact runtime or process soak behavior.
- Non-devnet or non-loopback live mining behavior.

Closes #1851