### PR TITLE
RUB-429: extract Go accepted-block DA ids

### DIFF
--- a/clients/go/node/p2p/da_relay_consume.go
+++ b/clients/go/node/p2p/da_relay_consume.go
@@ -1,0 +1,35 @@
+package p2p
+
+import (
+	"bytes"
+	"sort"
+
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+)
+
+func extractAcceptedBlockDAIDs(blockBytes []byte) ([][32]byte, error) {
+	parsed, err := consensus.ParseBlockBytes(blockBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	seen := make(map[[32]byte]struct{})
+	for _, tx := range parsed.Txs {
+		if tx == nil || tx.TxKind != 0x01 || tx.DaCommitCore == nil {
+			continue
+		}
+		seen[tx.DaCommitCore.DaID] = struct{}{}
+	}
+	if len(seen) == 0 {
+		return nil, nil
+	}
+
+	ids := make([][32]byte, 0, len(seen))
+	for daID := range seen {
+		ids = append(ids, daID)
+	}
+	sort.Slice(ids, func(i, j int) bool {
+		return bytes.Compare(ids[i][:], ids[j][:]) < 0
+	})
+	return ids, nil
+}

--- a/clients/go/node/p2p/da_relay_consume_test.go
+++ b/clients/go/node/p2p/da_relay_consume_test.go
@@ -1,0 +1,73 @@
+package p2p
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestExtractAcceptedBlockDAIDsNoDA(t *testing.T) {
+	block := compactTestBlockBytesWithTxs(t, [][]byte{minimalValidTxBytes(t)})
+
+	got, err := extractAcceptedBlockDAIDs(block)
+	if err != nil {
+		t.Fatalf("extractAcceptedBlockDAIDs: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("got %d DA ids, want none", len(got))
+	}
+}
+
+func TestExtractAcceptedBlockDAIDsSingle(t *testing.T) {
+	daID := daRelayTestID(0x41)
+	payload := []byte("payload")
+	block := compactTestBlockBytesWithTxs(t, [][]byte{
+		minimalValidTxBytes(t),
+		daCommitRelayTxBytes(t, daID, 1, payload),
+		daChunkRelayTxBytes(t, daID, 0, 2, payload),
+	})
+
+	got, err := extractAcceptedBlockDAIDs(block)
+	if err != nil {
+		t.Fatalf("extractAcceptedBlockDAIDs: %v", err)
+	}
+	if !reflect.DeepEqual(got, [][32]byte{daID}) {
+		t.Fatalf("got %x, want %x", got, [][32]byte{daID})
+	}
+}
+
+func TestExtractAcceptedBlockDAIDsSortedUnique(t *testing.T) {
+	low := daRelayTestID(0x01)
+	mid := daRelayTestID(0x7f)
+	high := daRelayTestID(0xf0)
+	lowPayload := []byte("low")
+	midPayload := []byte("mid")
+	highPayloadA := []byte("high-a")
+	highPayloadB := []byte("high-b")
+	block := compactTestBlockBytesWithTxs(t, [][]byte{
+		minimalValidTxBytes(t),
+		daCommitRelayTxBytes(t, high, 1, highPayloadA),
+		daChunkRelayTxBytes(t, high, 0, 2, highPayloadA),
+		daCommitRelayTxBytes(t, low, 3, lowPayload),
+		daChunkRelayTxBytes(t, low, 0, 4, lowPayload),
+		daCommitRelayTxBytes(t, high, 5, highPayloadB),
+		daChunkRelayTxBytes(t, high, 0, 6, highPayloadB),
+		daCommitRelayTxBytes(t, mid, 7, midPayload),
+		daChunkRelayTxBytes(t, mid, 0, 8, midPayload),
+	})
+
+	got, err := extractAcceptedBlockDAIDs(block)
+	if err != nil {
+		t.Fatalf("extractAcceptedBlockDAIDs: %v", err)
+	}
+	want := [][32]byte{low, mid, high}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %x, want %x", got, want)
+	}
+}
+
+func TestExtractAcceptedBlockDAIDsMalformedBlock(t *testing.T) {
+	_, err := extractAcceptedBlockDAIDs([]byte{0x01, 0x02})
+	if err == nil {
+		t.Fatal("malformed block returned nil error")
+	}
+}


### PR DESCRIPTION
Scope:
- Add a Go P2P helper that parses already accepted block bytes with the canonical Go block parser and returns sorted unique DA commit `da_id` values.
- Keep this slice extraction-only: no relay state mutation, no consume hook, no sync/reorg wiring, no Rust.

Matrix:
| Contract case | Covered by |
| --- | --- |
| Block with no DA returns empty | `TestExtractAcceptedBlockDAIDsNoDA` |
| Block with one complete DA set returns one `da_id` | `TestExtractAcceptedBlockDAIDsSingle` |
| Block with multiple/duplicate DA sets returns sorted unique `da_id`s | `TestExtractAcceptedBlockDAIDsSortedUnique` |
| Malformed block returns an error | `TestExtractAcceptedBlockDAIDsMalformedBlock` |

Evidence:
- `go test ./node/p2p -run 'TestExtractAcceptedBlockDAIDs' -count=1`
- `go test ./node/p2p -count=1`
- `go test ./...`
- Coverage: diff 100.00% (21/21), variation +0.01%.

Non-goals:
- No COMPLETE_SET deletion.
- No canonical/reorg accepted-block hook.
- No RPC, miner, conformance, spec, CI, or Rust changes.
