### PR TITLE
RUB-438: wire Go /mine_next complete DA set consume callback

### DIFF
--- a/clients/go/cmd/rubin-node/http_rpc.go
+++ b/clients/go/cmd/rubin-node/http_rpc.go
@@ -31,9 +31,14 @@ type devnetRPCState struct {
 	// devnet evidence must still prove peer adoption instead of treating
 	// /mine_next success as network success.
 	announceBlock func([]byte) error
-	stderr        io.Writer
-	nowUnix       func() uint64
-	metrics       *rpcMetrics
+	// acceptedBlockDASetConsumer is the fail-closed DA relay cleanup hook
+	// for locally mined blocks. Unlike announceBlock, this is part of the
+	// local /mine_next state transition and must succeed before the RPC
+	// reports success.
+	acceptedBlockDASetConsumer func([]byte) error
+	stderr                     io.Writer
+	nowUnix                    func() uint64
+	metrics                    *rpcMetrics
 	// rpcMut serializes mutating devnet RPC work (mempool admits + live mining)
 	// so concurrent HTTP handlers cannot interleave chain/mempool updates.
 	rpcMut sync.Mutex
@@ -509,6 +514,13 @@ func newDevnetRPCStateWithLifecycle(
 	return state
 }
 
+func (s *devnetRPCState) SetAcceptedBlockDASetConsumer(fn func([]byte) error) {
+	if s == nil {
+		return
+	}
+	s.acceptedBlockDASetConsumer = fn
+}
+
 // rpcBindHostIsLoopback reports whether the host part of host:port is suitable
 // for devnet-only live mining RPC (loopback only). Non-loopback binds disable
 // live mining even when network=devnet.
@@ -980,11 +992,34 @@ func handleMineNext(state *devnetRPCState, w http.ResponseWriter, r *http.Reques
 		})
 		return
 	}
+	var blockBytes []byte
+	blockBytesLoaded := false
+	if state.acceptedBlockDASetConsumer != nil {
+		blockBytes, err = minedBlockBytes(state, mb.Hash)
+		if err != nil {
+			state.rpcMut.Unlock()
+			writeJSONResponse(state, route, w, http.StatusInternalServerError, mineNextResponse{
+				Mined: false,
+				Error: fmt.Sprintf("load mined block for DA consume: %v", err),
+			})
+			return
+		}
+		blockBytesLoaded = true
+		if err := state.acceptedBlockDASetConsumer(blockBytes); err != nil {
+			state.rpcMut.Unlock()
+			writeJSONResponse(state, route, w, http.StatusInternalServerError, mineNextResponse{
+				Mined: false,
+				Error: fmt.Sprintf("consume accepted DA sets: %v", err),
+			})
+			return
+		}
+	}
 	state.rpcMut.Unlock()
 	if state.announceBlock != nil {
-		if state.blockStore == nil {
-			_, _ = fmt.Fprintf(state.stderr, "rpc: announce-block: block store unavailable for %x\n", mb.Hash)
-		} else if blockBytes, err := state.blockStore.GetBlockByHash(mb.Hash); err != nil {
+		if !blockBytesLoaded {
+			blockBytes, err = minedBlockBytes(state, mb.Hash)
+		}
+		if err != nil {
 			_, _ = fmt.Fprintf(state.stderr, "rpc: announce-block: get mined block %x: %v\n", mb.Hash, err)
 		} else if err := state.announceBlock(blockBytes); err != nil {
 			_, _ = fmt.Fprintf(state.stderr, "rpc: announce-block: %v\n", err)
@@ -1003,6 +1038,13 @@ func handleMineNext(state *devnetRPCState, w http.ResponseWriter, r *http.Reques
 		Nonce:     &nonce,
 		TxCount:   &txCount,
 	})
+}
+
+func minedBlockBytes(state *devnetRPCState, hash [32]byte) ([]byte, error) {
+	if state == nil || state.blockStore == nil {
+		return nil, errors.New("block store unavailable")
+	}
+	return state.blockStore.GetBlockByHash(hash)
 }
 
 // parseTxIDQuery decodes a 64-hex-char "txid" query parameter into a [32]byte.

--- a/clients/go/cmd/rubin-node/http_rpc_test.go
+++ b/clients/go/cmd/rubin-node/http_rpc_test.go
@@ -2109,6 +2109,11 @@ func TestDevnetRPCMineNextMineOneError(t *testing.T) {
 	}
 	state := newDevnetRPCState(syncEngine, blockStore, mempool, peerManager, nil, nil, io.Discard, miner)
 	state.nowUnix = func() uint64 { return 0 }
+	var consumeCalls int
+	state.SetAcceptedBlockDASetConsumer(func([]byte) error {
+		consumeCalls++
+		return nil
+	})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -2127,6 +2132,9 @@ func TestDevnetRPCMineNextMineOneError(t *testing.T) {
 	}
 	if !strings.Contains(got.Error, context.Canceled.Error()) {
 		t.Fatalf("error=%q want context canceled", got.Error)
+	}
+	if consumeCalls != 0 {
+		t.Fatalf("consume calls after MineOne error=%d, want 0", consumeCalls)
 	}
 }
 
@@ -2186,11 +2194,20 @@ func TestDevnetRPCMineNextMinesAfterGenesis(t *testing.T) {
 		t.Fatalf("NewMiner: %v", err)
 	}
 	var announcedBlock []byte
+	var events []string
 	state := newDevnetRPCState(syncEngine, blockStore, mempool, peerManager, nil, func(block []byte) error {
+		events = append(events, "announce")
 		announcedBlock = append([]byte(nil), block...)
 		return nil
 	}, io.Discard, miner)
 	state.nowUnix = func() uint64 { return 0 }
+	state.SetAcceptedBlockDASetConsumer(func(block []byte) error {
+		if _, err := consensus.ParseBlockBytes(block); err != nil {
+			t.Fatalf("ParseBlockBytes(consumer): %v", err)
+		}
+		events = append(events, "consume")
+		return nil
+	})
 	server := httptest.NewServer(newDevnetRPCHandler(state))
 	t.Cleanup(server.Close)
 	resp, err := http.Post(server.URL+"/mine_next", "application/json", bytes.NewReader([]byte("{}")))
@@ -2213,6 +2230,9 @@ func TestDevnetRPCMineNextMinesAfterGenesis(t *testing.T) {
 	}
 	if len(announcedBlock) == 0 {
 		t.Fatal("expected /mine_next to announce the mined full block")
+	}
+	if got := strings.Join(events, ","); got != "consume,announce" {
+		t.Fatalf("events=%s, want consume before announce", got)
 	}
 	parsedBlock, err := consensus.ParseBlockBytes(announcedBlock)
 	if err != nil {
@@ -2251,6 +2271,70 @@ func TestDevnetRPCMineNextMinesAfterGenesis(t *testing.T) {
 	}
 	if anchorOutputs != 1 {
 		t.Fatalf("coinbase CORE_ANCHOR outputs=%d, want 1", anchorOutputs)
+	}
+}
+
+func mustRPCMineNextState(t *testing.T) *devnetRPCState {
+	t.Helper()
+	dir := t.TempDir()
+	chainStatePath := node.ChainStatePath(dir)
+	chainState := node.NewChainState()
+	if err := chainState.Save(chainStatePath); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	blockStore, err := node.OpenBlockStore(node.BlockStorePath(dir))
+	if err != nil {
+		t.Fatalf("OpenBlockStore: %v", err)
+	}
+	syncCfg := node.DefaultSyncConfig(nil, node.DevnetGenesisChainID(), chainStatePath)
+	syncEngine, err := node.NewSyncEngine(chainState, blockStore, syncCfg)
+	if err != nil {
+		t.Fatalf("NewSyncEngine: %v", err)
+	}
+	if _, err := syncEngine.ApplyBlock(node.DevnetGenesisBlockBytes(), nil); err != nil {
+		t.Fatalf("ApplyBlock(genesis): %v", err)
+	}
+	mempool, err := node.NewMempool(chainState, blockStore, node.DevnetGenesisChainID())
+	if err != nil {
+		t.Fatalf("NewMempool: %v", err)
+	}
+	syncEngine.SetMempool(mempool)
+	peerManager := node.NewPeerManager(node.DefaultPeerRuntimeConfig("devnet", 8))
+	miner, err := node.NewMiner(chainState, blockStore, syncEngine, node.DefaultMinerConfig())
+	if err != nil {
+		t.Fatalf("NewMiner: %v", err)
+	}
+	state := newDevnetRPCState(syncEngine, blockStore, mempool, peerManager, nil, nil, io.Discard, miner)
+	state.nowUnix = func() uint64 { return 0 }
+	return state
+}
+
+func TestDevnetRPCMineNextFailsClosedOnDAConsumeError(t *testing.T) {
+	state := mustRPCMineNextState(t)
+	var announced bool
+	state.announceBlock = func([]byte) error {
+		announced = true
+		return nil
+	}
+	state.SetAcceptedBlockDASetConsumer(func([]byte) error {
+		return errors.New("consume failed")
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/mine_next", nil)
+	handleMineNext(state, rec, req)
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status=%d want 500 body=%s", rec.Code, rec.Body.String())
+	}
+	var got mineNextResponse
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if got.Mined || !strings.Contains(got.Error, "consume accepted DA sets: consume failed") {
+		t.Fatalf("unexpected response: %+v", got)
+	}
+	if announced {
+		t.Fatal("announceBlock called after consume failure")
 	}
 }
 
@@ -3491,5 +3575,34 @@ func TestDevnetRPCPeersExposesAllBoundedFields(t *testing.T) {
 	}
 	if got != want {
 		t.Fatalf("peer entry mismatch:\n got=%+v\nwant=%+v", got, want)
+	}
+}
+
+func TestSetAcceptedBlockDASetConsumerNilReceiver(t *testing.T) {
+	var state *devnetRPCState
+	called := false
+	state.SetAcceptedBlockDASetConsumer(func([]byte) error {
+		called = true
+		return nil
+	})
+	if called {
+		t.Fatal("nil receiver invoked consumer")
+	}
+}
+
+func TestMinedBlockBytesNilState(t *testing.T) {
+	var hash [32]byte
+	_, err := minedBlockBytes(nil, hash)
+	if err == nil {
+		t.Fatal("nil state returned nil error")
+	}
+}
+
+func TestMinedBlockBytesNilBlockStore(t *testing.T) {
+	state := &devnetRPCState{blockStore: nil}
+	var hash [32]byte
+	_, err := minedBlockBytes(state, hash)
+	if err == nil {
+		t.Fatal("nil blockStore returned nil error")
 	}
 }

--- a/clients/go/cmd/rubin-node/main.go
+++ b/clients/go/cmd/rubin-node/main.go
@@ -533,6 +533,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 	// helper to keep production-wiring and regression-wiring paths
 	// identical.
 	rpcState := newDevnetRPCStateWithLifecycle(syncEngine, blockStore, mempool, peerManager, p2pService.AnnounceTx, p2pService.AnnounceBlock, stderr, liveMiner, ctx)
+	rpcState.SetAcceptedBlockDASetConsumer(p2pService.ConsumeAcceptedBlockDASets)
 	// Late-bind the startup-wired chain identity so the read-only
 	// /chain_identity handler echoes the values that already flowed
 	// through genesis parsing + network canonicalization, rather than

--- a/clients/go/node/p2p/da_relay_consume.go
+++ b/clients/go/node/p2p/da_relay_consume.go
@@ -2,10 +2,30 @@ package p2p
 
 import (
 	"bytes"
+	"errors"
 	"sort"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
 )
+
+func (s *Service) ConsumeAcceptedBlockDASets(blockBytes []byte) error {
+	if s == nil {
+		return errors.New("nil service")
+	}
+	if s.daRelay == nil {
+		return errors.New("nil DA relay")
+	}
+	daIDs, err := extractAcceptedBlockDAIDs(blockBytes)
+	if err != nil {
+		return err
+	}
+	for _, daID := range daIDs {
+		if _, err := s.daRelay.consumeCompleteSet(daID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
 
 func extractAcceptedBlockDAIDs(blockBytes []byte) ([][32]byte, error) {
 	parsed, err := consensus.ParseBlockBytes(blockBytes)
@@ -13,23 +33,59 @@ func extractAcceptedBlockDAIDs(blockBytes []byte) ([][32]byte, error) {
 		return nil, err
 	}
 
-	seen := make(map[[32]byte]struct{})
+	sets := make(map[[32]byte]acceptedBlockDASet)
 	for _, tx := range parsed.Txs {
-		if tx == nil || tx.TxKind != 0x01 || tx.DaCommitCore == nil {
+		recordAcceptedBlockDATx(sets, tx)
+	}
+	ids := make([][32]byte, 0, len(sets))
+	for daID, set := range sets {
+		if !set.complete() {
 			continue
 		}
-		seen[tx.DaCommitCore.DaID] = struct{}{}
-	}
-	if len(seen) == 0 {
-		return nil, nil
-	}
-
-	ids := make([][32]byte, 0, len(seen))
-	for daID := range seen {
 		ids = append(ids, daID)
 	}
 	sort.Slice(ids, func(i, j int) bool {
 		return bytes.Compare(ids[i][:], ids[j][:]) < 0
 	})
 	return ids, nil
+}
+
+func recordAcceptedBlockDATx(sets map[[32]byte]acceptedBlockDASet, tx *consensus.Tx) {
+	switch tx.TxKind {
+	case 0x01:
+		daID := tx.DaCommitCore.DaID
+		set := sets[daID]
+		set.commitCount++
+		set.chunkCount = tx.DaCommitCore.ChunkCount
+		sets[daID] = set
+	case 0x02:
+		daID := tx.DaChunkCore.DaID
+		set := sets[daID]
+		if set.chunks == nil {
+			set.chunks = make(map[uint16]struct{})
+		}
+		set.chunks[tx.DaChunkCore.ChunkIndex] = struct{}{}
+		sets[daID] = set
+	}
+}
+
+type acceptedBlockDASet struct {
+	commitCount int
+	chunkCount  uint16
+	chunks      map[uint16]struct{}
+}
+
+func (s acceptedBlockDASet) complete() bool {
+	if s.commitCount != 1 || s.chunkCount == 0 || uint64(s.chunkCount) > consensus.MAX_DA_CHUNK_COUNT {
+		return false
+	}
+	if len(s.chunks) != int(s.chunkCount) {
+		return false
+	}
+	for i := uint16(0); i < s.chunkCount; i++ {
+		if _, ok := s.chunks[i]; !ok {
+			return false
+		}
+	}
+	return true
 }

--- a/clients/go/node/p2p/da_relay_consume_test.go
+++ b/clients/go/node/p2p/da_relay_consume_test.go
@@ -35,22 +35,17 @@ func TestExtractAcceptedBlockDAIDsSingle(t *testing.T) {
 	}
 }
 
-func TestExtractAcceptedBlockDAIDsSortedUnique(t *testing.T) {
+func TestExtractAcceptedBlockDAIDsSorted(t *testing.T) {
 	low := daRelayTestID(0x01)
 	mid := daRelayTestID(0x7f)
 	high := daRelayTestID(0xf0)
-	lowPayload := []byte("low")
-	midPayload := []byte("mid")
-	highPayloadA := []byte("high-a")
-	highPayloadB := []byte("high-b")
+	lowPayload, midPayload, highPayload := []byte("low"), []byte("mid"), []byte("high")
 	block := compactTestBlockBytesWithTxs(t, [][]byte{
 		minimalValidTxBytes(t),
-		daCommitRelayTxBytes(t, high, 1, highPayloadA),
-		daChunkRelayTxBytes(t, high, 0, 2, highPayloadA),
+		daCommitRelayTxBytes(t, high, 1, highPayload),
+		daChunkRelayTxBytes(t, high, 0, 2, highPayload),
 		daCommitRelayTxBytes(t, low, 3, lowPayload),
 		daChunkRelayTxBytes(t, low, 0, 4, lowPayload),
-		daCommitRelayTxBytes(t, high, 5, highPayloadB),
-		daChunkRelayTxBytes(t, high, 0, 6, highPayloadB),
 		daCommitRelayTxBytes(t, mid, 7, midPayload),
 		daChunkRelayTxBytes(t, mid, 0, 8, midPayload),
 	})
@@ -69,5 +64,98 @@ func TestExtractAcceptedBlockDAIDsMalformedBlock(t *testing.T) {
 	_, err := extractAcceptedBlockDAIDs([]byte{0x01, 0x02})
 	if err == nil {
 		t.Fatal("malformed block returned nil error")
+	}
+}
+
+func TestServiceConsumeAcceptedBlockDASetsRemovesCompleteSetAccounting(t *testing.T) {
+	state := newDARelayStateForTest(t, defaultDARelayCaps())
+	consumeID := daRelayTestID(0x51)
+	keepID := daRelayTestID(0x52)
+	consumePayload := []byte("consume-payload")
+	keepPayload := []byte("keep-payload")
+
+	mustAddDACommit(t, state, "peer-a", daRelayTestCommitForPayloads(consumeID, 1, consumePayload))
+	mustAddDAChunk(t, state, "peer-b", daRelayTestChunkPayload(consumeID, 0, uint64(len(consumePayload)), consumePayload))
+	mustAddDACommit(t, state, "peer-c", daRelayTestCommitForPayloads(keepID, 1, keepPayload))
+	keepRecord := mustAddDAChunk(t, state, "peer-d", daRelayTestChunkPayload(keepID, 0, uint64(len(keepPayload)), keepPayload))
+	keepPinned := mustPinnedPayloadAccounting(t, keepRecord)
+
+	block := compactTestBlockBytesWithTxs(t, [][]byte{
+		minimalValidTxBytes(t),
+		daCommitRelayTxBytes(t, consumeID, 1, consumePayload),
+		daChunkRelayTxBytes(t, consumeID, 0, 2, consumePayload),
+	})
+	if err := (&Service{daRelay: state}).ConsumeAcceptedBlockDASets(block); err != nil {
+		t.Fatalf("ConsumeAcceptedBlockDASets: %v", err)
+	}
+	if _, ok := state.sets[consumeID]; ok {
+		t.Fatal("consumed complete set retained record")
+	}
+	if got := state.sets[keepID]; got.state != daRelayStateCompleteSet {
+		t.Fatalf("unrelated set state=%v, want complete", got.state)
+	}
+	if state.pinnedPayloadBytes != keepPinned {
+		t.Fatalf("pinned after consume=%d, want %d", state.pinnedPayloadBytes, keepPinned)
+	}
+}
+
+func TestServiceConsumeAcceptedBlockDASetsRequiresCompleteAcceptedGroup(t *testing.T) {
+	state := newDARelayStateForTest(t, defaultDARelayCaps())
+	daID := daRelayTestID(0x53)
+	payload := []byte("partial-accepted-payload")
+	mustAddDACommit(t, state, "peer-a", daRelayTestCommitForPayloads(daID, 1, payload))
+	mustAddDAChunk(t, state, "peer-b", daRelayTestChunkPayload(daID, 0, uint64(len(payload)), payload))
+
+	block := compactTestBlockBytesWithTxs(t, [][]byte{
+		minimalValidTxBytes(t),
+		daCommitRelayTxBytes(t, daID, 1, payload),
+	})
+	if err := (&Service{daRelay: state}).ConsumeAcceptedBlockDASets(block); err != nil {
+		t.Fatalf("ConsumeAcceptedBlockDASets: %v", err)
+	}
+	if got := state.sets[daID]; got.state != daRelayStateCompleteSet {
+		t.Fatalf("partial accepted group consumed state=%v, want complete", got.state)
+	}
+}
+
+func TestConsumeAcceptedBlockDASetsNilService(t *testing.T) {
+	var svc *Service
+	if err := svc.ConsumeAcceptedBlockDASets([]byte{0x00}); err == nil {
+		t.Fatal("nil service returned nil error")
+	}
+}
+
+func TestConsumeAcceptedBlockDASetsNilDARelay(t *testing.T) {
+	svc := &Service{daRelay: nil}
+	if err := svc.ConsumeAcceptedBlockDASets([]byte{0x00}); err == nil {
+		t.Fatal("nil daRelay returned nil error")
+	}
+}
+
+func TestAcceptedBlockDASetCompleteRejectsNonSingleCommit(t *testing.T) {
+	s := acceptedBlockDASet{commitCount: 2, chunkCount: 1, chunks: map[uint16]struct{}{0: {}}}
+	if s.complete() {
+		t.Fatal("commitCount=2 accepted as complete")
+	}
+}
+
+func TestAcceptedBlockDASetCompleteRejectsZeroChunks(t *testing.T) {
+	s := acceptedBlockDASet{commitCount: 1, chunkCount: 0}
+	if s.complete() {
+		t.Fatal("chunkCount=0 accepted as complete")
+	}
+}
+
+func TestAcceptedBlockDASetCompleteRejectsChunkCountMismatch(t *testing.T) {
+	s := acceptedBlockDASet{commitCount: 1, chunkCount: 2, chunks: map[uint16]struct{}{0: {}}}
+	if s.complete() {
+		t.Fatal("chunk count mismatch accepted as complete")
+	}
+}
+
+func TestConsumeAcceptedBlockDASetsMalformedBlock(t *testing.T) {
+	svc := &Service{daRelay: newDARelayStateForTest(t, defaultDARelayCaps())}
+	if err := svc.ConsumeAcceptedBlockDASets([]byte{0x01, 0x02}); err == nil {
+		t.Fatal("malformed block via Service returned nil error")
 	}
 }


### PR DESCRIPTION
Invariant: after /mine_next accepts a block, consume complete DA relay sets before reporting success.

Layer: implementation (non-consensus).

Files: clients/go/cmd/rubin-node/{http_rpc.go,http_rpc_test.go,main.go}, clients/go/node/p2p/{da_relay_consume.go,da_relay_consume_test.go}
5 files, +325/-25.

- Adds fail-closed acceptedBlockDASetConsumer hook to devnetRPCState
- Consumer runs under rpcMut before /mine_next success response
- Consumer failure returns 500 Mined:false
- Extracts complete DA IDs from accepted block txs
- Consumes complete sets via daRelay.consumeCompleteSet (with accounting)
- Tests: positive consume+accounting removal, negative MineOne error no-consume, partial group no-consume, unrelated set isolation, nil-guard coverage, complete() edge cases

Gates: parity-matrix PASS, precommit-tooling PASS, common-preflight 7/7 PASS, pattern-self-review PASS, one-review PASS.
Coverage: diff 87.21%, variation -0.03% (both within gates).

Risk: none — Go-only, RPC hook, no consensus or wire format changes.
Rollback: revert PR.