### PR TITLE
node/p2p: consume canonical-applied DA sets on block accept (RUB-432)

### DIFF
--- a/clients/go/node/p2p/da_relay_consume.go
+++ b/clients/go/node/p2p/da_relay_consume.go
@@ -3,10 +3,36 @@ package p2p
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"sort"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/node"
 )
+
+// consumeCanonicalAppliedDASets consumes the complete DA sets carried by every
+// block the SyncEngine reported as canonical-applied through
+// ChainStateConnectSummary.CanonicalAppliedBlocks: a direct apply reports the
+// single connected block, a reorg reports every newly-canonical branch block in
+// canonical order, and a stored-but-not-switched side branch reports none (nil
+// slice) so nothing is consumed. DA consume is therefore driven strictly by
+// canonical application, never by mere block storage. It no-ops when DA relay is
+// disabled (nil relay), mirroring advanceDAOrphanTTL. It is best-effort across
+// blocks — each block is attempted and the first error is returned — so one
+// block's accounting failure cannot silently skip DA cleanup for the remaining
+// canonical blocks of a reorg.
+func (s *Service) consumeCanonicalAppliedDASets(blocks []node.CanonicalAppliedBlock) error {
+	if s == nil || s.daRelay == nil {
+		return nil
+	}
+	var firstErr error
+	for i := range blocks {
+		if err := s.ConsumeAcceptedBlockDASets(blocks[i].BlockBytes); err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("consume canonical-applied DA sets for block %x: %w", blocks[i].Hash, err)
+		}
+	}
+	return firstErr
+}
 
 func (s *Service) ConsumeAcceptedBlockDASets(blockBytes []byte) error {
 	if s == nil {

--- a/clients/go/node/p2p/da_relay_consume_test.go
+++ b/clients/go/node/p2p/da_relay_consume_test.go
@@ -1,8 +1,12 @@
 package p2p
 
 import (
+	"fmt"
 	"reflect"
+	"strings"
 	"testing"
+
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/node"
 )
 
 func TestExtractAcceptedBlockDAIDsNoDA(t *testing.T) {
@@ -157,5 +161,105 @@ func TestConsumeAcceptedBlockDASetsMalformedBlock(t *testing.T) {
 	svc := &Service{daRelay: newDARelayStateForTest(t, defaultDARelayCaps())}
 	if err := svc.ConsumeAcceptedBlockDASets([]byte{0x01, 0x02}); err == nil {
 		t.Fatal("malformed block via Service returned nil error")
+	}
+}
+
+// stageCompleteDASet stages a relay-complete (single commit + full chunk set)
+// DA record and returns block bytes carrying the same complete DA group.
+func stageCompleteDASet(t *testing.T, state *daRelayState, daID [32]byte, peer string, payload []byte) []byte {
+	t.Helper()
+	mustAddDACommit(t, state, peer+"-commit", daRelayTestCommitForPayloads(daID, 1, payload))
+	mustAddDAChunk(t, state, peer+"-chunk", daRelayTestChunkPayload(daID, 0, uint64(len(payload)), payload))
+	return compactTestBlockBytesWithTxs(t, [][]byte{
+		minimalValidTxBytes(t),
+		daCommitRelayTxBytes(t, daID, 1, payload),
+		daChunkRelayTxBytes(t, daID, 0, 2, payload),
+	})
+}
+
+func TestConsumeCanonicalAppliedDASetsDirectApplyConsumes(t *testing.T) {
+	state := newDARelayStateForTest(t, defaultDARelayCaps())
+	daID := daRelayTestID(0x61)
+	block := stageCompleteDASet(t, state, daID, "direct", []byte("direct-payload"))
+
+	svc := &Service{daRelay: state}
+	blocks := []node.CanonicalAppliedBlock{{Hash: daRelayTestID(0xa0), BlockBytes: block}}
+	if err := svc.consumeCanonicalAppliedDASets(blocks); err != nil {
+		t.Fatalf("consumeCanonicalAppliedDASets: %v", err)
+	}
+	if _, ok := state.sets[daID]; ok {
+		t.Fatal("direct canonical apply did not consume the complete DA set")
+	}
+}
+
+func TestConsumeCanonicalAppliedDASetsSideBranchDoesNotConsume(t *testing.T) {
+	state := newDARelayStateForTest(t, defaultDARelayCaps())
+	daID := daRelayTestID(0x62)
+	_ = stageCompleteDASet(t, state, daID, "side", []byte("side-payload"))
+
+	svc := &Service{daRelay: state}
+	// Non-switching side branch: SyncEngine reports nil CanonicalAppliedBlocks.
+	if err := svc.consumeCanonicalAppliedDASets(nil); err != nil {
+		t.Fatalf("consumeCanonicalAppliedDASets(nil): %v", err)
+	}
+	if got := state.sets[daID]; got.state != daRelayStateCompleteSet {
+		t.Fatalf("side branch consumed DA set state=%v, want complete (untouched)", got.state)
+	}
+}
+
+func TestConsumeCanonicalAppliedDASetsReorgConsumesAllBlocks(t *testing.T) {
+	state := newDARelayStateForTest(t, defaultDARelayCaps())
+	idA := daRelayTestID(0x63)
+	idB := daRelayTestID(0x64)
+	blockA := stageCompleteDASet(t, state, idA, "reorg-a", []byte("reorg-a-payload"))
+	blockB := stageCompleteDASet(t, state, idB, "reorg-b", []byte("reorg-b-payload"))
+
+	svc := &Service{daRelay: state}
+	blocks := []node.CanonicalAppliedBlock{
+		{Hash: daRelayTestID(0xa1), BlockBytes: blockA},
+		{Hash: daRelayTestID(0xb1), BlockBytes: blockB},
+	}
+	if err := svc.consumeCanonicalAppliedDASets(blocks); err != nil {
+		t.Fatalf("consumeCanonicalAppliedDASets: %v", err)
+	}
+	if _, ok := state.sets[idA]; ok {
+		t.Fatal("reorg did not consume first canonical block's DA set")
+	}
+	if _, ok := state.sets[idB]; ok {
+		t.Fatal("reorg did not consume second canonical block's DA set")
+	}
+}
+
+func TestConsumeCanonicalAppliedDASetsSurfacesErrorAndContinues(t *testing.T) {
+	state := newDARelayStateForTest(t, defaultDARelayCaps())
+	daID := daRelayTestID(0x65)
+	goodBlock := stageCompleteDASet(t, state, daID, "after-bad", []byte("after-bad-payload"))
+
+	badHash := daRelayTestID(0xee)
+	svc := &Service{daRelay: state}
+	blocks := []node.CanonicalAppliedBlock{
+		{Hash: badHash, BlockBytes: []byte{0x01, 0x02}}, // unparseable -> visible error
+		{Hash: daRelayTestID(0xcc), BlockBytes: goodBlock},
+	}
+	err := svc.consumeCanonicalAppliedDASets(blocks)
+	if err == nil {
+		t.Fatal("malformed canonical block was consumed silently (want visible error)")
+	}
+	if !strings.Contains(err.Error(), fmt.Sprintf("%x", badHash)) {
+		t.Fatalf("error %q does not identify failing block %x", err, badHash)
+	}
+	// Best-effort: the later valid canonical block is still consumed despite the
+	// earlier error.
+	if _, ok := state.sets[daID]; ok {
+		t.Fatal("best-effort consume skipped a valid canonical block after an earlier error")
+	}
+}
+
+func TestConsumeCanonicalAppliedDASetsNilRelayNoOp(t *testing.T) {
+	// DA relay disabled: the hook must no-op (not error on every accepted block).
+	svc := &Service{daRelay: nil}
+	blocks := []node.CanonicalAppliedBlock{{Hash: daRelayTestID(0x66), BlockBytes: []byte{0x01, 0x02}}}
+	if err := svc.consumeCanonicalAppliedDASets(blocks); err != nil {
+		t.Fatalf("nil daRelay should no-op, got: %v", err)
 	}
 }

--- a/clients/go/node/p2p/handlers_block.go
+++ b/clients/go/node/p2p/handlers_block.go
@@ -145,12 +145,17 @@ func (p *peer) acceptedRelayedBlock(blockHash [32]byte, summary *node.ChainState
 }
 
 func (s *Service) noteAcceptedBlock(skip *peer, blockHash [32]byte, summary *node.ChainStateConnectSummary) error {
+	var consumeErr error
 	if summary != nil {
 		s.cfg.SyncEngine.RecordBestKnownHeight(summary.BlockHeight)
+		// Consume complete DA sets only for blocks the SyncEngine reported as
+		// canonical-applied. Side branches report none, so storing a side block
+		// never consumes; reorgs report every newly-canonical block.
+		consumeErr = s.consumeCanonicalAppliedDASets(summary.CanonicalAppliedBlocks)
 	}
 	s.blockSeen.Add(blockHash)
 	_ = s.broadcastAcceptedBlock(skip, blockHash)
-	return s.advanceDAOrphanTTL()
+	return errors.Join(consumeErr, s.advanceDAOrphanTTL())
 }
 
 func (s *Service) broadcastAcceptedBlock(skip *peer, blockHash [32]byte) error {


### PR DESCRIPTION
Invariant: Go P2P accepted-block handling consumes complete DA sets only for blocks reported canonical-applied by SyncEngine (RUB-431's `ChainStateConnectSummary.CanonicalAppliedBlocks`); non-canonical side branches do not consume.

Layer: implementation (Go node P2P). Non-consensus relay bookkeeping — no consensus, wire-format, summary-shape, RPC, miner, or Rust changes.

Files changed:
- clients/go/node/p2p/da_relay_consume.go — add `consumeCanonicalAppliedDASets`: drives the existing complete-set consume primitive off `CanonicalAppliedBlocks`; no-ops when DA relay is disabled (nil relay); best-effort across blocks, first error surfaced.
- clients/go/node/p2p/handlers_block.go — `noteAcceptedBlock` (single convergence of direct relay, compact relay, and orphan-resolution accept paths) invokes the hook before `advanceDAOrphanTTL` and joins the error.
- clients/go/node/p2p/da_relay_consume_test.go — 5 targeted tests.

Behavior:
- direct canonical apply: consumes the one connected block's complete DA sets.
- side branch (stored, not switched): `CanonicalAppliedBlocks` nil → consumes nothing.
- reorg: consumes every newly-canonical branch block's complete DA sets, in canonical order.
- consume failure: visible (joined into the returned error, surfaced via `setLastError`), not silent.
- `consumeCompleteSet` stays idempotent and keyed by da_id; consume runs without `chainMu` held (released before the accept hook).

Tests:
- TestConsumeCanonicalAppliedDASetsDirectApplyConsumes — PASS
- TestConsumeCanonicalAppliedDASetsSideBranchDoesNotConsume — PASS
- TestConsumeCanonicalAppliedDASetsReorgConsumesAllBlocks — PASS
- TestConsumeCanonicalAppliedDASetsSurfacesErrorAndContinues — PASS
- TestConsumeCanonicalAppliedDASetsNilRelayNoOp — PASS
- go test ./node/p2p — PASS; new code 100% covered.
- core + tooling (govulncheck go1.26.4, -race -count=2 -shuffle) + coverage + delta receipts — PASS; review fanout BYPASSED (controller-approved, go-only non-consensus class).

Compatibility: additive relay bookkeeping; no consensus/wire change. Rust P2P parity tracked in RUB-437.

Linear: RUB-432

🤖 Generated with [Claude Code](https://claude.com/claude-code)
