### PR TITLE
node(rust): report canonical-applied blocks from apply_block_with_reorg (RUB-436)

### DIFF
--- a/clients/rust/crates/rubin-node/src/chainstate.rs
+++ b/clients/rust/crates/rubin-node/src/chainstate.rs
@@ -29,6 +29,12 @@ pub struct ChainState {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CanonicalAppliedBlock {
+    pub hash: [u8; 32],
+    pub block_bytes: Vec<u8>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ChainStateConnectSummary {
     pub block_height: u64,
     pub block_hash: [u8; 32],
@@ -36,6 +42,7 @@ pub struct ChainStateConnectSummary {
     pub already_generated: u64,
     pub already_generated_n1: u64,
     pub utxo_count: u64,
+    pub canonical_applied_blocks: Vec<CanonicalAppliedBlock>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -189,6 +196,10 @@ impl ChainState {
             already_generated_n1: u64::try_from(connect_summary.already_generated_n1)
                 .map_err(|_| "already_generated_n1 overflow".to_string())?,
             utxo_count: connect_summary.utxo_count,
+            canonical_applied_blocks: vec![CanonicalAppliedBlock {
+                hash: tip_hash,
+                block_bytes: block_bytes.to_vec(),
+            }],
         })
     }
 

--- a/clients/rust/crates/rubin-node/src/chainstate_recovery.rs
+++ b/clients/rust/crates/rubin-node/src/chainstate_recovery.rs
@@ -942,6 +942,7 @@ mod tests {
                     already_generated: 0,
                     already_generated_n1: 0,
                     utxo_count: 0,
+                    canonical_applied_blocks: Vec::new(),
                 }),
             ),
             "tipless state must persist to seed first snapshot"
@@ -977,6 +978,7 @@ mod tests {
                     already_generated: 0,
                     already_generated_n1: 0,
                     utxo_count: small.utxos.len() as u64,
+                    canonical_applied_blocks: Vec::new(),
                 }),
             ),
             "small utxo set must persist every block"
@@ -1014,6 +1016,7 @@ mod tests {
                     already_generated: 0,
                     already_generated_n1: 0,
                     utxo_count: large.utxos.len() as u64,
+                    canonical_applied_blocks: Vec::new(),
                 }),
             ),
             "large utxo set must skip non-interval snapshots"
@@ -1029,6 +1032,7 @@ mod tests {
                     already_generated: 0,
                     already_generated_n1: 0,
                     utxo_count: large.utxos.len() as u64,
+                    canonical_applied_blocks: Vec::new(),
                 }),
             ),
             "large utxo set must persist on interval boundary"
@@ -1044,6 +1048,7 @@ mod tests {
                     already_generated: 0,
                     already_generated_n1: 0,
                     utxo_count: large.utxos.len() as u64,
+                    canonical_applied_blocks: Vec::new(),
                 }),
             ),
             "height zero summary must persist"

--- a/clients/rust/crates/rubin-node/src/lib.rs
+++ b/clients/rust/crates/rubin-node/src/lib.rs
@@ -25,8 +25,8 @@ mod test_helpers;
 
 pub use blockstore::{block_store_path, BlockStore, BLOCK_STORE_DIR_NAME};
 pub use chainstate::{
-    chain_state_path, load_chain_state, ChainState, ChainStateConnectSummary,
-    CHAIN_STATE_FILE_NAME, UTXO_SET_HASH_DST,
+    chain_state_path, load_chain_state, CanonicalAppliedBlock, ChainState,
+    ChainStateConnectSummary, CHAIN_STATE_FILE_NAME, UTXO_SET_HASH_DST,
 };
 pub use chainstate_recovery::reconcile_chain_state_with_block_store;
 pub use coinbase::{

--- a/clients/rust/crates/rubin-node/src/sync_reorg.rs
+++ b/clients/rust/crates/rubin-node/src/sync_reorg.rs
@@ -5,7 +5,7 @@ use rubin_consensus::{
 use std::ops::Deref;
 
 use crate::blockstore::BlockStore;
-use crate::chainstate::ChainStateConnectSummary;
+use crate::chainstate::{CanonicalAppliedBlock, ChainStateConnectSummary};
 use crate::sync::SyncEngine;
 use crate::txpool::{TxPool, TxPoolAdmitError, TxPoolAdmitErrorKind, TxSource};
 
@@ -458,9 +458,18 @@ impl SyncEngine {
         // fresh timestamps from the (updated) canonical index for each block,
         // instead of reusing the stale caller value (B.9 fix, issue #1166).
         let mut last_summary = None;
+        let mut canonical_applied_blocks: Vec<CanonicalAppliedBlock> = Vec::new();
         for item in &branch {
             match self.apply_block(&item.block_bytes, None) {
-                Ok(summary) => last_summary = Some(summary),
+                Ok(mut summary) => {
+                    // branch is in ascending canonical (height) order, so this
+                    // accumulates every newly-canonical block in canonical order.
+                    // Move (not clone) the per-block entries: this throwaway
+                    // summary's vec is never read again — the returned summary's
+                    // vec is overwritten below.
+                    canonical_applied_blocks.append(&mut summary.canonical_applied_blocks);
+                    last_summary = Some(summary);
+                }
                 Err(err) => {
                     return Err(Self::err_with_rollback(
                         err,
@@ -485,7 +494,10 @@ impl SyncEngine {
             requeue_block_hashes: collect_disconnected_block_hashes(&disconnected_blocks),
         };
 
-        let summary = last_summary.ok_or_else(|| "reorg branch was empty".to_string())?;
+        let mut summary = last_summary.ok_or_else(|| "reorg branch was empty".to_string())?;
+        // Report every block that became canonical in this reorg (the returned
+        // summary's scalar fields otherwise reflect only the new tip).
+        summary.canonical_applied_blocks = canonical_applied_blocks;
         self.note_reorg(reorg_depth);
         Ok(ApplyBlockWithReorgOutcome {
             summary,
@@ -597,6 +609,8 @@ impl SyncEngine {
             already_generated: self.chain_state.already_generated,
             already_generated_n1: self.chain_state.already_generated,
             utxo_count: self.chain_state.utxos.len() as u64,
+            // Side branch stored but not switched: no block became canonical.
+            canonical_applied_blocks: Vec::new(),
         }
     }
 }
@@ -1107,6 +1121,111 @@ mod tests {
         assert_eq!(engine.chain_state.tip_hash, block2_hash);
         assert_eq!(engine.reorg_count(), 0);
         assert_eq!(engine.last_reorg_depth(), 0);
+
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    #[test]
+    fn apply_block_with_reorg_reports_single_canonical_applied_block_on_direct_apply() {
+        let (mut engine, dir) = engine_with_store("rubin-reorg-canon-direct");
+        let (genesis, genesis_hash, gen_ts) = genesis_info();
+        engine
+            .apply_block_with_reorg(&genesis, None)
+            .expect("genesis");
+
+        let block1 = height_one_coinbase_only_block(genesis_hash, gen_ts + 1);
+        let block1_hash = block_header_hash(&block1);
+        let summary = engine
+            .apply_block_with_reorg(&block1, None)
+            .expect("block1 direct apply");
+
+        assert_eq!(summary.canonical_applied_blocks.len(), 1);
+        assert_eq!(summary.canonical_applied_blocks[0].hash, block1_hash);
+        assert_eq!(summary.canonical_applied_blocks[0].hash, summary.block_hash);
+        assert_eq!(summary.canonical_applied_blocks[0].block_bytes, block1);
+
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    #[test]
+    fn apply_block_with_reorg_reports_no_canonical_applied_blocks_on_side_branch() {
+        let (mut engine, dir) = engine_with_store("rubin-reorg-canon-side");
+        let (genesis, genesis_hash, gen_ts) = genesis_info();
+        engine
+            .apply_block_with_reorg(&genesis, None)
+            .expect("genesis");
+
+        let block1 = height_one_coinbase_only_block(genesis_hash, gen_ts + 1);
+        let block1_hash = block_header_hash(&block1);
+        engine
+            .apply_block_with_reorg(&block1, None)
+            .expect("block1 canonical");
+        let subsidy1 = rubin_consensus::subsidy::block_subsidy(1, 0);
+        let block2 = coinbase_only_block_with_gen(2, subsidy1, block1_hash, gen_ts + 2);
+        let block2_hash = block_header_hash(&block2);
+        engine
+            .apply_block_with_reorg(&block2, None)
+            .expect("block2 canonical");
+
+        // Lower-work side block at height 1: stored, does not switch the tip.
+        let side = height_one_coinbase_only_block(genesis_hash, gen_ts + 3);
+        let summary = engine
+            .apply_block_with_reorg(&side, None)
+            .expect("side branch stored");
+
+        assert!(
+            summary.canonical_applied_blocks.is_empty(),
+            "stored-but-not-switched side branch must report zero canonical-applied blocks"
+        );
+        assert_eq!(engine.chain_state.tip_hash, block2_hash);
+
+        std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    #[test]
+    fn apply_block_with_reorg_reports_all_canonical_applied_blocks_in_order_on_reorg() {
+        let (mut engine, dir) = engine_with_store("rubin-reorg-canon-reorg");
+        let (genesis, genesis_hash, gen_ts) = genesis_info();
+        engine
+            .apply_block_with_reorg(&genesis, None)
+            .expect("genesis");
+
+        // Canonical: genesis -> block1 (1-block chain, work = 1).
+        let block1 = coinbase_only_block(1, genesis_hash, gen_ts + 1);
+        engine
+            .apply_block_with_reorg(&block1, None)
+            .expect("block1 canonical");
+
+        // Heavier branch: genesis -> block1_alt -> block2_alt (work = 2).
+        let block1_alt = coinbase_only_block(1, genesis_hash, gen_ts + 2);
+        let block1_alt_hash = block_header_hash(&block1_alt);
+        engine
+            .block_store
+            .as_ref()
+            .unwrap()
+            .store_block(
+                block1_alt_hash,
+                &block1_alt[..rubin_consensus::BLOCK_HEADER_BYTES],
+                &block1_alt,
+            )
+            .expect("store block1_alt as side");
+
+        let subsidy1 = rubin_consensus::subsidy::block_subsidy(1, 0);
+        let block2_alt = coinbase_only_block_with_gen(2, subsidy1, block1_alt_hash, gen_ts + 3);
+        let block2_alt_hash = block_header_hash(&block2_alt);
+
+        let summary = engine
+            .apply_block_with_reorg(&block2_alt, None)
+            .expect("reorg to heavier branch");
+
+        assert_eq!(engine.chain_state.tip_hash, block2_alt_hash);
+        assert_eq!(engine.reorg_count(), 1);
+        // Every block that became canonical, in ascending canonical order.
+        assert_eq!(summary.canonical_applied_blocks.len(), 2);
+        assert_eq!(summary.canonical_applied_blocks[0].hash, block1_alt_hash);
+        assert_eq!(summary.canonical_applied_blocks[0].block_bytes, block1_alt);
+        assert_eq!(summary.canonical_applied_blocks[1].hash, block2_alt_hash);
+        assert_eq!(summary.canonical_applied_blocks[1].block_bytes, block2_alt);
 
         std::fs::remove_dir_all(&dir).expect("cleanup");
     }


### PR DESCRIPTION
Invariant: Rust sync summaries identify exactly which block hashes/bytes became canonical during direct apply, side-branch storage, and reorg — matching merged Go RUB-431.

Layer: implementation (Rust rubin-node sync). Non-consensus sync summary/reporting only. No consensus, wire-format, DA-relay, RPC, P2P-consume, or Go changes.

Files changed:
- clients/rust/crates/rubin-node/src/chainstate.rs — add `CanonicalAppliedBlock { hash, block_bytes }` and `ChainStateConnectSummary.canonical_applied_blocks`; populate the single connected block inline where the summary is built.
- clients/rust/crates/rubin-node/src/sync_reorg.rs — accumulate every newly-canonical branch block in canonical order in `apply_preferred_branch`; `synthetic_side_chain_summary` reports empty; + 3 tests.
- clients/rust/crates/rubin-node/src/lib.rs — re-export `CanonicalAppliedBlock` alongside `ChainStateConnectSummary`.
- clients/rust/crates/rubin-node/src/chainstate_recovery.rs — update 5 snapshot-cadence test literals for the new field (test-only).

## go_rust_parity_matrix — required_parity_cases

Each Linear required parity case maps the merged Go RUB-431 reference behaviour to its Rust mirror, with callsite/entrypoint and a Rust mirror-test.

| case | go reference function | rust required behavior | test evidence | go callsite | rust callsite | mirror test |
| --- | --- | --- | --- | --- | --- | --- |
| direct apply summary includes one canonical block | Go `chainStateConnectSummary` sets a 1-element `CanonicalAppliedBlocks` = {blockHash, copy(blockBytes)} (clients/go/node/chainstate_connect.go) | Rust connect summary reports exactly one `canonical_applied_block` (the connected block: hash + owned block bytes) | asserts `canonical_applied_blocks.len()==1`, `[0].hash==block_hash`, `[0].block_bytes==block` | Go `SyncEngine.applyCanonicalParsedBlock` → `ChainState.ConnectBlock*` (clients/go/node/chainstate_connect.go) | `ChainState::connect_block_with_core_ext_deployments_and_suite_context` → `SyncEngine::apply_block_with_reorg` (clients/rust/crates/rubin-node/src/chainstate.rs) | apply_block_with_reorg_reports_single_canonical_applied_block_on_direct_apply |
| non-switch side branch summary includes zero | Go `syntheticSideChainSummary` leaves `CanonicalAppliedBlocks` nil (clients/go/node/sync_reorg.go) | Rust `synthetic_side_chain_summary` reports an empty `canonical_applied_blocks`; canonical tip unchanged | asserts `canonical_applied_blocks.is_empty()` and tip still equals the canonical block | Go `SyncEngine.storeSideBlockAndSummary` (clients/go/node/sync_reorg.go) | `SyncEngine::synthetic_side_chain_summary` (clients/rust/crates/rubin-node/src/sync_reorg.rs) | apply_block_with_reorg_reports_no_canonical_applied_blocks_on_side_branch |
| reorg summary includes every canonicalized branch block in order | Go `applyPreferredBranch` accumulates one entry per branch block in ascending canonical order (clients/go/node/sync_reorg.go) | Rust `apply_preferred_branch` accumulates every newly-canonical block in ascending canonical order, overwriting the tip summary's vec | asserts `len==2`, `[0]`=block1_alt, `[1]`=block2_alt (hash+bytes), tip==block2_alt | Go `SyncEngine.applyPreferredBranch` (clients/go/node/sync_reorg.go) | `SyncEngine::apply_preferred_branch` (clients/rust/crates/rubin-node/src/sync_reorg.rs) | apply_block_with_reorg_reports_all_canonical_applied_blocks_in_order_on_reorg |

Tests:
- cargo test -p rubin-node — PASS (742 lib + 69 + 3 new); clippy + fmt clean.
- core + tooling (--allow-rust: clippy, nextest, cargo-deny) + coverage + delta receipts — PASS; review fanout BYPASSED (controller-approved, Rust parity/thaw class).

Compatibility: additive summary field; no consensus/wire change. Rust P2P consume parity tracked in RUB-437.

Linear: RUB-436

🤖 Generated with [Claude Code](https://claude.com/claude-code)
