### PR TITLE
node(rust): add DA relay complete-set consume primitive (RUB-433)

### DIFF
--- a/clients/rust/crates/rubin-node/src/da_relay.rs
+++ b/clients/rust/crates/rubin-node/src/da_relay.rs
@@ -725,6 +725,36 @@ impl DaRelayState {
         Ok(())
     }
 
+    /// Consume (remove) the COMPLETE_SET record matching `da_id` exactly once,
+    /// releasing its pinned payload accounting. Returns `Ok(true)` when a
+    /// complete set was removed, `Ok(false)` when no record exists or it is not
+    /// in `CompleteSet` state. Idempotent: a second consume of the same `da_id`
+    /// is an `Ok(false)` no-op and cannot underflow accounting. Mirrors merged
+    /// Go `daRelayState.consumeCompleteSet` (RUB-428): a complete set contributes
+    /// only pinned payload bytes (its orphan/peer/commit accounting was released
+    /// on completion), and the release is projected before any mutation so a
+    /// projection error leaves the state unchanged.
+    pub(crate) fn consume_complete_set(&mut self, da_id: [u8; 32]) -> DaRelayResult<bool> {
+        let Some(record) = self.sets_by_da_id.get(&da_id) else {
+            return Ok(false);
+        };
+        if record.state != DaRelaySetState::CompleteSet {
+            return Ok(false);
+        }
+        let pinned = record.pinned_payload_accounting_bytes()?;
+        // project_counter returns Err on underflow/overflow/cap; the counter and
+        // the record below are written only after it succeeds.
+        let pinned_payload_bytes = Self::project_counter(
+            self.pinned_payload_bytes,
+            pinned,
+            0,
+            self.caps.pinned_payload_bytes,
+        )?;
+        self.pinned_payload_bytes = pinned_payload_bytes;
+        self.sets_by_da_id.remove(&da_id);
+        Ok(true)
+    }
+
     pub(crate) fn stage_incomplete_da_commit(
         &mut self,
         peer_addr: &str,
@@ -1701,6 +1731,99 @@ mod tests {
         );
         assert_eq!(ids_for(late_payload.len() as u64), vec![late_id]);
         assert!(state.complete_da_set_candidates(0).is_empty());
+    }
+
+    #[test]
+    fn da_relay_consume_complete_set_matrix() {
+        let peer_commit = "commit-peer:8333";
+        let peer_chunk = "chunk-peer:8333";
+        let payload: &[u8] = b"consume-payload";
+        let payload_wire = payload.len() as u64;
+        let commit_tx = b"canonical-commit-tx";
+        let chunk_tx = b"canonical-chunk-tx";
+        let commit = |da_id, payloads: &[&[u8]], wire_bytes, tx_bytes: &[u8]| DaRelayCommit {
+            da_id,
+            payload_commitment: payload_commitment(payloads),
+            peer_quota_key: PeerQuotaKey::from_peer_addr("forged:8333"),
+            chunk_count: payloads.len() as u16,
+            wire_bytes,
+            tx_bytes: Arc::from(tx_bytes),
+        };
+        let chunk = |da_id, index, payload: &[u8], wire_bytes, tx_bytes: &[u8]| DaRelayChunk {
+            da_id,
+            chunk_hash: sha3_256(payload),
+            peer_quota_key: PeerQuotaKey::from_peer_addr("forged:8333"),
+            chunk_index: index,
+            payload: Arc::from(payload),
+            wire_bytes,
+            tx_bytes: Arc::from(tx_bytes),
+        };
+
+        let mut state = DaRelayState::new(DaRelayCaps::default()).unwrap();
+        state
+            .stage_incomplete_da_commit(
+                peer_commit,
+                commit([71; 32], &[payload], payload_wire, commit_tx),
+            )
+            .unwrap();
+        state
+            .stage_incomplete_da_chunk(
+                peer_chunk,
+                chunk([71; 32], 0, payload, payload_wire, chunk_tx),
+            )
+            .unwrap();
+        assert_eq!(
+            state.sets_by_da_id[&[71; 32]].state,
+            DaRelaySetState::CompleteSet
+        );
+        let pinned_one = state.pinned_payload_bytes;
+        assert!(pinned_one > 0);
+
+        // Second, unrelated complete set with identical pinned footprint.
+        state
+            .stage_incomplete_da_commit(
+                peer_commit,
+                commit([73; 32], &[payload], payload_wire, commit_tx),
+            )
+            .unwrap();
+        state
+            .stage_incomplete_da_chunk(
+                peer_chunk,
+                chunk([73; 32], 0, payload, payload_wire, chunk_tx),
+            )
+            .unwrap();
+        assert_eq!(state.pinned_payload_bytes, pinned_one * 2);
+
+        // Mirror of Go RUB-428: consume removes the matching COMPLETE_SET and
+        // releases its pinned payload bytes; the unrelated set is untouched.
+        assert_eq!(state.consume_complete_set([71; 32]), Ok(true));
+        assert!(!state.sets_by_da_id.contains_key(&[71; 32]));
+        assert_eq!(
+            state.sets_by_da_id[&[73; 32]].state,
+            DaRelaySetState::CompleteSet
+        );
+        assert_eq!(state.pinned_payload_bytes, pinned_one);
+
+        // Second consume cannot underflow: no-op false, accounting unchanged.
+        assert_eq!(state.consume_complete_set([71; 32]), Ok(false));
+        assert_eq!(state.pinned_payload_bytes, pinned_one);
+
+        // Incomplete set (chunk only, no commit) is not consumed.
+        state
+            .stage_incomplete_da_chunk(
+                peer_chunk,
+                chunk([72; 32], 0, payload, payload_wire, chunk_tx),
+            )
+            .unwrap();
+        assert_ne!(
+            state.sets_by_da_id[&[72; 32]].state,
+            DaRelaySetState::CompleteSet
+        );
+        assert_eq!(state.consume_complete_set([72; 32]), Ok(false));
+        assert!(state.sets_by_da_id.contains_key(&[72; 32]));
+
+        // Absent da_id is a no-op.
+        assert_eq!(state.consume_complete_set([99; 32]), Ok(false));
     }
 
     #[test]


### PR DESCRIPTION
Invariant: the Rust DA relay state removes a matching COMPLETE_SET by da_id exactly once and releases its pinned payload accounting — matching merged Go RUB-428.

Layer: implementation (Rust rubin-node DA relay). Non-consensus relay bookkeeping only. No consensus, wire-format, RPC, P2P-hook, sync-summary, DA-id-extraction, or Go changes.

Files changed:
- clients/rust/crates/rubin-node/src/da_relay.rs — add `DaRelayState::consume_complete_set(da_id)` and a targeted test.

Behavior (mirrors Go `daRelayState.consumeCompleteSet`):
- looks up `sets_by_da_id` by `da_id`; returns `Ok(false)` when absent or not in `CompleteSet` state (no-op).
- otherwise releases the record's pinned payload bytes via `project_counter` (which returns `Err` on underflow/overflow/cap before any write), removes the record, returns `Ok(true)`.
- idempotent: a second consume of the same `da_id` is `Ok(false)` and cannot underflow.
- a complete set contributes only pinned payload bytes (orphan/peer/commit accounting was released on completion); the Rust relay has no prefetch subsystem, so Go's `prefetch.releaseSet` has no analog.

## go_rust_parity_matrix — required_parity_cases

Each Linear required parity case maps the merged Go RUB-428 reference behaviour to its Rust mirror, with callsite/entrypoint and a Rust mirror-test.

| case | go reference function | rust required behavior | test evidence | go callsite | rust callsite | mirror test |
| --- | --- | --- | --- | --- | --- | --- |
| Rust mirror of Go RUB-428 behavior passes | Go `consumeCompleteSet` removes a CompleteSet by da_id and releases pinned accounting (clients/go/node/p2p/da_relay_state.go:287) | `consume_complete_set` removes the CompleteSet record and releases `pinned_payload_bytes`, returning `Ok(true)` | asserts `Ok(true)`, the record is gone from `sets_by_da_id`, and `pinned_payload_bytes` drops by the set footprint | Go `consumeCompleteSet` (clients/go/node/p2p/da_relay_state.go:287) | `DaRelayState::consume_complete_set` (clients/rust/crates/rubin-node/src/da_relay.rs) | da_relay_consume_complete_set_matrix |
| second consume cannot underflow | Go second `consumeCompleteSet` returns `(false,nil)` with no underflow (clients/go/node/p2p/da_relay_state.go:287) | second consume returns `Ok(false)` and leaves `pinned_payload_bytes` unchanged | asserts the second `consume_complete_set` is `Ok(false)` and `pinned_payload_bytes` is unchanged | Go `consumeCompleteSet` idempotent lookup path | `DaRelayState::consume_complete_set` absent-record early `Ok(false)` | da_relay_consume_complete_set_matrix |
| incomplete set is not consumed | Go `consumeCompleteSet` returns `(false,nil)` when the record is not CompleteSet (clients/go/node/p2p/da_relay_state.go:287) | `consume_complete_set` returns `Ok(false)` for a non-CompleteSet record and leaves it in place | asserts a chunk-only (non-CompleteSet) record yields `Ok(false)` and remains in `sets_by_da_id` | Go `consumeCompleteSet` state guard | `DaRelayState::consume_complete_set` `state != CompleteSet` guard | da_relay_consume_complete_set_matrix |
| unrelated complete set remains | Go `removeDASetRecordLocked` removes only the matched record (clients/go/node/p2p/da_relay_state.go:680) | consuming one da_id leaves other CompleteSet records and their pinned accounting intact | asserts the unrelated set is still CompleteSet and its pinned bytes are retained | Go `removeDASetRecordLocked` single-record removal | `DaRelayState::consume_complete_set` `sets_by_da_id.remove(&da_id)` | da_relay_consume_complete_set_matrix |

Tests:
- cargo test -p rubin-node — PASS (743 lib + 69 + 3 new); clippy + fmt clean.
- core + tooling (--allow-rust) + coverage + delta receipts — PASS; review fanout BYPASSED (controller-approved, Rust parity/thaw class).

Compatibility: additive crate-internal primitive (no public API removed); no consensus/wire change. Siblings: RUB-434 (DA id extraction), RUB-435 (/mine_next consume), RUB-437 (P2P consume hook).

Linear: RUB-433

🤖 Generated with [Claude Code](https://claude.com/claude-code)
