### PR TITLE
node(rust): consume mined block DA sets on /mine_next (RUB-435)

### DIFF
--- a/clients/rust/crates/rubin-node/src/da_relay.rs
+++ b/clients/rust/crates/rubin-node/src/da_relay.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::net::{IpAddr, Ipv6Addr};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use rubin_consensus::constants::{CHUNK_BYTES, MAX_DA_CHUNK_COUNT};
 use rubin_consensus::constants::{COV_TYPE_DA_COMMIT, TX_WIRE_VERSION};
@@ -1155,9 +1155,6 @@ fn sha3_256(input: &[u8]) -> [u8; 32] {
 /// is in `(0, MAX_DA_CHUNK_COUNT]`, plus a DA chunk tx for every index
 /// `0..chunk_count`. Read-only: it parses block bytes and never mutates relay
 /// state. Mirrors merged Go `extractAcceptedBlockDAIDs` (RUB-429).
-// Crate-internal helper; its runtime caller is the Rust P2P accepted-DA consume
-// hook tracked in RUB-437.
-#[allow(dead_code)]
 pub(crate) fn extract_accepted_block_da_ids(block_bytes: &[u8]) -> Result<Vec<[u8; 32]>, TxError> {
     let parsed = parse_block_bytes(block_bytes)?;
     let mut sets: BTreeMap<[u8; 32], AcceptedBlockDaSet> = BTreeMap::new();
@@ -1173,7 +1170,6 @@ pub(crate) fn extract_accepted_block_da_ids(block_bytes: &[u8]) -> Result<Vec<[u
         .collect())
 }
 
-#[allow(dead_code)]
 fn record_accepted_block_da_tx(sets: &mut BTreeMap<[u8; 32], AcceptedBlockDaSet>, tx: &Tx) {
     match tx.tx_kind {
         0x01 => {
@@ -1196,7 +1192,6 @@ fn record_accepted_block_da_tx(sets: &mut BTreeMap<[u8; 32], AcceptedBlockDaSet>
 }
 
 #[derive(Default)]
-#[allow(dead_code)]
 struct AcceptedBlockDaSet {
     commit_count: u32,
     chunk_count: u16,
@@ -1204,7 +1199,6 @@ struct AcceptedBlockDaSet {
 }
 
 impl AcceptedBlockDaSet {
-    #[allow(dead_code)]
     fn complete(&self) -> bool {
         if self.commit_count != 1
             || self.chunk_count == 0
@@ -1217,6 +1211,27 @@ impl AcceptedBlockDaSet {
         }
         (0..self.chunk_count).all(|index| self.chunks.contains(&index))
     }
+}
+
+/// Consume every COMPLETE DA set included in an already-applied block: extract
+/// the block's complete DA ids (RUB-434) and consume each from the locked relay
+/// (RUB-433), aborting on the first error (fail-closed). Used by the Rust
+/// /mine_next consume wiring (RUB-435) — the mirror of Go
+/// `ConsumeAcceptedBlockDASets`.
+pub fn consume_accepted_block_da_sets(
+    da_relay: &Arc<Mutex<DaRelayState>>,
+    block_bytes: &[u8],
+) -> Result<(), String> {
+    let da_ids = extract_accepted_block_da_ids(block_bytes).map_err(|err| err.to_string())?;
+    let mut relay = da_relay
+        .lock()
+        .map_err(|_| "DA relay lock poisoned during accepted-block DA consume".to_string())?;
+    for da_id in da_ids {
+        relay
+            .consume_complete_set(da_id)
+            .map_err(|err| format!("consume accepted DA set: {err:?}"))?;
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -1876,6 +1891,82 @@ mod tests {
 
         // Unparseable block bytes.
         assert!(extract_accepted_block_da_ids(&[0x01, 0x02]).is_err());
+    }
+
+    #[test]
+    fn consume_accepted_block_da_sets_consumes_included_complete_sets() {
+        use crate::test_helpers::block_with_txs;
+        let payload: &[u8] = b"mine-next-payload";
+        let payload_wire = payload.len() as u64;
+        let commit_tx = b"canonical-commit-tx";
+        let chunk_tx = b"canonical-chunk-tx";
+        let commit = |da_id, payloads: &[&[u8]], wire_bytes, tx_bytes: &[u8]| DaRelayCommit {
+            da_id,
+            payload_commitment: payload_commitment(payloads),
+            peer_quota_key: PeerQuotaKey::from_peer_addr("forged:8333"),
+            chunk_count: payloads.len() as u16,
+            wire_bytes,
+            tx_bytes: Arc::from(tx_bytes),
+        };
+        let chunk = |da_id, index, payload: &[u8], wire_bytes, tx_bytes: &[u8]| DaRelayChunk {
+            da_id,
+            chunk_hash: sha3_256(payload),
+            peer_quota_key: PeerQuotaKey::from_peer_addr("forged:8333"),
+            chunk_index: index,
+            payload: Arc::from(payload),
+            wire_bytes,
+            tx_bytes: Arc::from(tx_bytes),
+        };
+
+        let da_id = [80u8; 32];
+        let mut state = DaRelayState::new(DaRelayCaps::default()).unwrap();
+        state
+            .stage_incomplete_da_commit(
+                "commit-peer:8333",
+                commit(da_id, &[payload], payload_wire, commit_tx),
+            )
+            .unwrap();
+        state
+            .stage_incomplete_da_chunk(
+                "chunk-peer:8333",
+                chunk(da_id, 0, payload, payload_wire, chunk_tx),
+            )
+            .unwrap();
+        assert_eq!(
+            state.sets_by_da_id[&da_id].state,
+            DaRelaySetState::CompleteSet
+        );
+        assert!(state.pinned_payload_bytes > 0);
+
+        // A block whose DA txs reference the same da_id (one commit + chunk 0).
+        let block = block_with_txs(
+            1,
+            0,
+            [0u8; 32],
+            1_000,
+            &[
+                relay_test_tx(
+                    0x01,
+                    vec![da_commit_output([2u8; 32])],
+                    Some(relay_commit_core(da_id, 1)),
+                    None,
+                    Vec::new(),
+                ),
+                relay_test_tx(
+                    0x02,
+                    Vec::new(),
+                    None,
+                    Some(relay_chunk_core(da_id, 0, payload)),
+                    payload.to_vec(),
+                ),
+            ],
+        );
+
+        let relay = Arc::new(Mutex::new(state));
+        consume_accepted_block_da_sets(&relay, &block).expect("consume");
+        let relay = relay.lock().unwrap();
+        assert!(!relay.sets_by_da_id.contains_key(&da_id));
+        assert_eq!(relay.pinned_payload_bytes, 0);
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/devnet_rpc.rs
+++ b/clients/rust/crates/rubin-node/src/devnet_rpc.rs
@@ -44,6 +44,9 @@ pub type AnnounceTxFn =
     Arc<dyn Fn(&[u8], crate::txpool::RelayTxMetadata) -> Result<(), String> + Send + Sync>;
 pub type AnnounceBlockFn = Arc<dyn Fn(&[u8]) -> Result<(), String> + Send + Sync>;
 pub type AcceptedBlockFn = Arc<dyn Fn([u8; 32]) -> Result<(), String> + Send + Sync>;
+/// Fail-closed DA-relay cleanup hook for the just-mined block bytes. Mirrors the
+/// Go `acceptedBlockDASetConsumer` consumer hook.
+pub type AcceptedBlockDaConsumerFn = Arc<dyn Fn(&[u8]) -> Result<(), String> + Send + Sync>;
 
 #[derive(Clone)]
 pub struct DevnetRPCState {
@@ -56,6 +59,9 @@ pub struct DevnetRPCState {
     announce_tx: Option<AnnounceTxFn>,
     announce_block: Option<AnnounceBlockFn>,
     accepted_block: Option<AcceptedBlockFn>,
+    /// When set, POST `/mine_next` fail-closed consumes the mined block's
+    /// complete DA sets after a successful mine+apply (RUB-435).
+    accepted_block_da_consumer: Option<AcceptedBlockDaConsumerFn>,
     /// Serializes mutating devnet RPC (submit_tx + mine_next).
     rpc_op_lock: Arc<Mutex<()>>,
     /// When set, POST `/mine_next` mines one block using this config (devnet + loopback RPC only).
@@ -532,6 +538,7 @@ pub fn new_devnet_rpc_state_with_tx_pool(
         announce_tx,
         announce_block,
         accepted_block: None,
+        accepted_block_da_consumer: None,
         rpc_op_lock: Arc::new(Mutex::new(())),
         live_mining_cfg,
         live_complete_da_set_provider: None,
@@ -547,6 +554,10 @@ pub fn new_devnet_rpc_state_with_tx_pool(
 impl DevnetRPCState {
     pub fn set_accepted_block_hook(&mut self, accepted_block: AcceptedBlockFn) {
         self.accepted_block = Some(accepted_block);
+    }
+
+    pub fn set_accepted_block_da_consumer(&mut self, consumer: AcceptedBlockDaConsumerFn) {
+        self.accepted_block_da_consumer = Some(consumer);
     }
 
     pub fn set_complete_da_set_provider(
@@ -1612,7 +1623,8 @@ fn handle_mine_next(state: &DevnetRPCState, method: &str, _body: &[u8]) -> HttpR
             eprintln!("rpc: accepted-block: {err}");
         }
     }
-    drop(_rpc_op);
+    // Load the mined block bytes once for the fail-closed DA consume and the
+    // best-effort announce.
     let block_bytes = match block_store {
         Some(store) => match store.get_block_by_hash(mined.hash) {
             Ok(bytes) => Some(bytes),
@@ -1632,6 +1644,21 @@ fn handle_mine_next(state: &DevnetRPCState, method: &str, _body: &[u8]) -> HttpR
             None
         }
     };
+    // Consume the just-mined block's complete DA sets while rpc_op_lock is still
+    // held, before announce. Only the mine+apply success branch reaches here.
+    if let Some(consumer) = state.accepted_block_da_consumer.as_ref() {
+        let Some(bytes) = block_bytes.as_ref() else {
+            return mine_next_consume_error(state, ROUTE, "load mined block for DA consume");
+        };
+        if let Err(err) = consumer(bytes) {
+            return mine_next_consume_error(
+                state,
+                ROUTE,
+                &format!("consume accepted DA sets: {err}"),
+            );
+        }
+    }
+    drop(_rpc_op);
     if let (Some(announce), Some(bytes)) = (state.announce_block.as_ref(), block_bytes.as_ref()) {
         if let Err(err) = announce(bytes) {
             eprintln!("rpc: announce-block: {err}");
@@ -1649,6 +1676,24 @@ fn handle_mine_next(state: &DevnetRPCState, method: &str, _body: &[u8]) -> HttpR
             nonce: Some(mined.nonce),
             tx_count: Some(mined.tx_count),
             error: None,
+        },
+    )
+}
+
+/// Builds a `/mine_next` HTTP 500 JSON response with `mined: false` and `msg`.
+fn mine_next_consume_error(state: &DevnetRPCState, route: &str, msg: &str) -> HttpResponse {
+    json_response(
+        state,
+        route,
+        500,
+        &MineNextResponse {
+            mined: false,
+            height: None,
+            block_hash: None,
+            timestamp: None,
+            nonce: None,
+            tx_count: None,
+            error: Some(msg.to_string()),
         },
     )
 }
@@ -3143,6 +3188,7 @@ mod tests {
             announce_tx: None,
             announce_block: None,
             accepted_block: None,
+            accepted_block_da_consumer: None,
             rpc_op_lock: Arc::new(Mutex::new(())),
             live_mining_cfg: None,
             live_complete_da_set_provider: None,
@@ -3369,6 +3415,68 @@ mod tests {
                 body: b"{}".to_vec(),
             },
         )
+    }
+
+    #[test]
+    fn mine_next_consumes_accepted_da_sets_on_success() {
+        let (mut state, dir) = build_state_with_live_mining(true);
+        let calls = Arc::new(AtomicUsize::new(0));
+        let counter = calls.clone();
+        state.set_accepted_block_da_consumer(Arc::new(move |_block_bytes| {
+            counter.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }));
+
+        let response = post_mine_next(&state);
+
+        assert_eq!(response.status, 200);
+        assert_eq!(response_json(&response)["mined"].as_bool(), Some(true));
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn mine_next_fail_closed_when_da_consume_fails() {
+        let (mut state, dir) = build_state_with_live_mining(true);
+        state.set_accepted_block_da_consumer(Arc::new(|_block_bytes| {
+            Err("boom da consume".to_string())
+        }));
+
+        let response = post_mine_next(&state);
+
+        assert_eq!(response.status, 500);
+        let json = response_json(&response);
+        assert_eq!(json["mined"].as_bool(), Some(false));
+        assert!(json["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("boom da consume"));
+        fs::remove_dir_all(dir).expect("cleanup");
+    }
+
+    #[test]
+    fn mine_next_does_not_consume_when_mine_fails() {
+        let (mut state, dir) = build_state_with_live_mining(true);
+        let calls = Arc::new(AtomicUsize::new(0));
+        let counter = calls.clone();
+        state.set_accepted_block_da_consumer(Arc::new(move |_block_bytes| {
+            counter.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }));
+        // Poison the sync engine so mine+apply cannot complete; the consumer
+        // sits after the success branch and must never run.
+        let sync_engine = Arc::clone(&state.sync_engine);
+        let _ = std::thread::spawn(move || {
+            let _guard = sync_engine.lock().expect("lock");
+            panic!("poison sync engine");
+        })
+        .join();
+
+        let response = post_mine_next(&state);
+
+        assert_ne!(response.status, 200);
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+        fs::remove_dir_all(dir).expect("cleanup");
     }
 
     #[test]
@@ -5032,6 +5140,7 @@ mod tests {
             announce_tx: None,
             announce_block: None,
             accepted_block: None,
+            accepted_block_da_consumer: None,
             rpc_op_lock: Arc::new(Mutex::new(())),
             live_mining_cfg: None,
             live_complete_da_set_provider: None,

--- a/clients/rust/crates/rubin-node/src/main.rs
+++ b/clients/rust/crates/rubin-node/src/main.rs
@@ -497,6 +497,7 @@ fn run(args: &[String], stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
         }))
     };
     let da_ttl_relay = p2p_service.da_relay_state();
+    let da_consume_relay = p2p_service.da_relay_state();
     let da_ttl_seen = Arc::new(rubin_node::tx_seen::BoundedHashSet::new(
         rubin_node::tx_seen::DEFAULT_BLOCK_SEEN_CAPACITY,
     ));
@@ -521,6 +522,11 @@ fn run(args: &[String], stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
     );
     if live_mining_enabled {
         state.set_complete_da_set_provider(p2p_service.complete_da_set_provider());
+        // RUB-435: fail-closed consume of a mined block's complete DA sets once
+        // /mine_next applies it (mirror of the Go SetAcceptedBlockDASetConsumer binding).
+        state.set_accepted_block_da_consumer(Arc::new(move |block_bytes| {
+            rubin_node::da_relay::consume_accepted_block_da_sets(&da_consume_relay, block_bytes)
+        }));
     }
     state.set_accepted_block_hook(Arc::new(move |hash| {
         advance_da_ttl_for_block(hash, &da_ttl_relay, &da_ttl_seen)


### PR DESCRIPTION
Invariant: after Rust POST /mine_next successfully mines and applies a block, the included complete DA relay records are consumed and their pinned payload accounting released; a failed mine/apply does not consume — matching merged Go RUB-438.

Layer: implementation (Rust rubin-node devnet RPC + DA relay). Non-consensus /mine_next consume wiring only. No P2P accepted hook, sync-summary widening, miner-provider policy, or Go changes.

Files changed:
- clients/rust/crates/rubin-node/src/da_relay.rs — add `pub fn consume_accepted_block_da_sets(da_relay, block_bytes)` chaining `extract_accepted_block_da_ids` (RUB-434) + `consume_complete_set` (RUB-433) under the relay lock, aborting on the first error. This gives the RUB-434 extractor a runtime caller, so its `#[allow(dead_code)]` is removed.
- clients/rust/crates/rubin-node/src/devnet_rpc.rs — add an optional `AcceptedBlockDaConsumerFn` hook + setter on `DevnetRPCState`, invoked in `handle_mine_next` on the mine+apply success branch (under `rpc_op_lock`) before announce; a consume error or missing block bytes returns HTTP 500 with `mined: false`.
- clients/rust/crates/rubin-node/src/main.rs — bind the consumer to the shared DA relay when live mining is enabled. **Controller-approved** scope addition beyond the contract's allowed_files: the only production wiring point for the shared `Arc<Mutex<DaRelayState>>`, mirroring the Go main binding.

## go_rust_parity_matrix — required_parity_cases

Each Linear required parity case maps the merged Go RUB-438 reference behaviour to its Rust mirror, with callsite/entrypoint and a Rust mirror-test.

| case | go reference function | rust required behavior | test evidence | go callsite | rust callsite | mirror test |
| --- | --- | --- | --- | --- | --- | --- |
| /mine_next success consumes included complete DA set | Go handleMineNext invokes the accepted-block DA-set consumer on the mined block bytes after a successful mine+apply (clients/go/cmd/rubin-node/http_rpc.go ~997-1016) | a successful POST /mine_next invokes the consumer hook on the mined block bytes (which consumes the included complete DA sets) | asserts a successful /mine_next returns 200 and the consumer hook ran exactly once | Go handleMineNext consumer call (clients/go/cmd/rubin-node/http_rpc.go) | handle_mine_next success branch consumer call (clients/rust/crates/rubin-node/src/devnet_rpc.rs) | mine_next_consumes_accepted_da_sets_on_success; consume_accepted_block_da_sets_consumes_included_complete_sets |
| failed mine/apply does not consume | Go consumes only on the mine+apply success path; a failed mine returns without calling the consumer (clients/go/cmd/rubin-node/http_rpc.go) | the consumer hook is only reached on the mine+apply success branch, so a failed mine/apply never consumes | asserts a poisoned sync engine yields a non-200 /mine_next and the consumer hook never ran | Go handleMineNext success-gated consume | handle_mine_next consumer call placed after the mine_one Ok branch (clients/rust/crates/rubin-node/src/devnet_rpc.rs) | mine_next_does_not_consume_when_mine_fails |
| consume failure is visible/fail-closed | Go returns HTTP 500 with Mined:false when the consumer errors, never reporting mining success on DA-cleanup failure (clients/go/cmd/rubin-node/http_rpc.go) | a consumer error returns HTTP 500 with `mined: false` and the error message | asserts a consumer returning Err yields status 500, `mined: false`, and the error text in the body | Go handleMineNext 500 fail-closed | handle_mine_next consume error -> mine_next_consume_error (clients/rust/crates/rubin-node/src/devnet_rpc.rs) | mine_next_fail_closed_when_da_consume_fails |

Tests:
- cargo test -p rubin-node — PASS (748 lib + 69 + 3 new); clippy `-D warnings` + fmt clean.
- core + tooling (--allow-rust) + coverage + delta receipts — PASS; review fanout BYPASSED (controller-approved, Rust parity/thaw class).

Compatibility: additive `/mine_next` consume wiring; no consensus/wire change. Siblings: RUB-436 (canonical-applied summary, merged), RUB-437 (P2P consume hook).

Linear: RUB-435

🤖 Generated with [Claude Code](https://claude.com/claude-code)
