### PR TITLE
node(rust): consume canonical-applied DA sets on P2P block accept (RUB-437)

### DIFF
--- a/clients/rust/crates/rubin-node/src/da_relay.rs
+++ b/clients/rust/crates/rubin-node/src/da_relay.rs
@@ -1238,17 +1238,27 @@ pub fn consume_accepted_block_da_sets(
 /// canonical-applied by the sync engine (RUB-436): a direct apply reports the
 /// single connected block, a reorg reports every newly-canonical branch block,
 /// and a stored-but-not-switched side branch reports none (so nothing is
-/// consumed). Aborts on the first error (fail-closed). Used by the Rust P2P
+/// consumed). Best-effort across blocks — every block is attempted and the
+/// first error is returned — so one block's accounting failure cannot skip DA
+/// cleanup for the remaining canonical blocks. Used by the Rust P2P
 /// accepted-block consume hook (RUB-437) — the mirror of Go
 /// `consumeCanonicalAppliedDASets`.
 pub fn consume_canonical_applied_da_sets(
     da_relay: &Mutex<DaRelayState>,
     canonical_applied_blocks: &[crate::chainstate::CanonicalAppliedBlock],
 ) -> Result<(), String> {
+    let mut first_err: Option<String> = None;
     for block in canonical_applied_blocks {
-        consume_accepted_block_da_sets(da_relay, &block.block_bytes)?;
+        if let Err(err) = consume_accepted_block_da_sets(da_relay, &block.block_bytes) {
+            first_err.get_or_insert_with(|| {
+                format!(
+                    "consume canonical-applied DA sets for block {}: {err}",
+                    hex::encode(block.hash)
+                )
+            });
+        }
     }
-    Ok(())
+    first_err.map_or(Ok(()), Err)
 }
 
 #[cfg(test)]
@@ -2081,6 +2091,54 @@ mod tests {
             block_bytes: vec![0x01, 0x02],
         }];
         assert!(consume_canonical_applied_da_sets(&relay2, &bad).is_err());
+
+        // Best-effort: a malformed block between two valid canonical blocks does
+        // not skip the others; the first error (naming that block) is surfaced.
+        let id_c = [83u8; 32];
+        let id_d = [84u8; 32];
+        let mut state3 = DaRelayState::new(DaRelayCaps::default()).unwrap();
+        for (id, c, k) in [
+            (id_c, "commit-c:8333", "chunk-c:8333"),
+            (id_d, "commit-d:8333", "chunk-d:8333"),
+        ] {
+            state3
+                .stage_incomplete_da_commit(c, commit(id, &[payload], payload_wire, commit_tx))
+                .unwrap();
+            state3
+                .stage_incomplete_da_chunk(k, chunk(id, 0, payload, payload_wire, chunk_tx))
+                .unwrap();
+        }
+        let relay3 = Mutex::new(state3);
+        let mixed = vec![
+            CanonicalAppliedBlock {
+                hash: [0xc0; 32],
+                block_bytes: block_for(id_c, 1_002),
+            },
+            CanonicalAppliedBlock {
+                hash: [0xee; 32],
+                block_bytes: vec![0x01, 0x02],
+            },
+            CanonicalAppliedBlock {
+                hash: [0xd0; 32],
+                block_bytes: block_for(id_d, 1_003),
+            },
+        ];
+        let err = consume_canonical_applied_da_sets(&relay3, &mixed)
+            .expect_err("malformed middle block surfaces an error");
+        assert!(
+            err.contains(&hex::encode([0xee; 32])),
+            "first error names the malformed block: {err}"
+        );
+        let guard3 = relay3.lock().unwrap();
+        assert!(
+            !guard3.sets_by_da_id.contains_key(&id_c),
+            "block before the malformed one is consumed"
+        );
+        assert!(
+            !guard3.sets_by_da_id.contains_key(&id_d),
+            "block after the malformed one is still consumed (best-effort)"
+        );
+        assert_eq!(guard3.pinned_payload_bytes, 0);
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/da_relay.rs
+++ b/clients/rust/crates/rubin-node/src/da_relay.rs
@@ -1219,7 +1219,7 @@ impl AcceptedBlockDaSet {
 /// /mine_next consume wiring (RUB-435) — the mirror of Go
 /// `ConsumeAcceptedBlockDASets`.
 pub fn consume_accepted_block_da_sets(
-    da_relay: &Arc<Mutex<DaRelayState>>,
+    da_relay: &Mutex<DaRelayState>,
     block_bytes: &[u8],
 ) -> Result<(), String> {
     let da_ids = extract_accepted_block_da_ids(block_bytes).map_err(|err| err.to_string())?;
@@ -1230,6 +1230,23 @@ pub fn consume_accepted_block_da_sets(
         relay
             .consume_complete_set(da_id)
             .map_err(|err| format!("consume accepted DA set: {err:?}"))?;
+    }
+    Ok(())
+}
+
+/// Consume the complete DA sets included in every block reported
+/// canonical-applied by the sync engine (RUB-436): a direct apply reports the
+/// single connected block, a reorg reports every newly-canonical branch block,
+/// and a stored-but-not-switched side branch reports none (so nothing is
+/// consumed). Aborts on the first error (fail-closed). Used by the Rust P2P
+/// accepted-block consume hook (RUB-437) — the mirror of Go
+/// `consumeCanonicalAppliedDASets`.
+pub fn consume_canonical_applied_da_sets(
+    da_relay: &Mutex<DaRelayState>,
+    canonical_applied_blocks: &[crate::chainstate::CanonicalAppliedBlock],
+) -> Result<(), String> {
+    for block in canonical_applied_blocks {
+        consume_accepted_block_da_sets(da_relay, &block.block_bytes)?;
     }
     Ok(())
 }
@@ -1967,6 +1984,103 @@ mod tests {
         let relay = relay.lock().unwrap();
         assert!(!relay.sets_by_da_id.contains_key(&da_id));
         assert_eq!(relay.pinned_payload_bytes, 0);
+    }
+
+    #[test]
+    fn consume_canonical_applied_da_sets_consumes_all_canonical_blocks() {
+        use crate::chainstate::CanonicalAppliedBlock;
+        use crate::test_helpers::block_with_txs;
+        let payload: &[u8] = b"p2p-accept-payload";
+        let payload_wire = payload.len() as u64;
+        let commit_tx = b"canonical-commit-tx";
+        let chunk_tx = b"canonical-chunk-tx";
+        let commit = |da_id, payloads: &[&[u8]], wire_bytes, tx_bytes: &[u8]| DaRelayCommit {
+            da_id,
+            payload_commitment: payload_commitment(payloads),
+            peer_quota_key: PeerQuotaKey::from_peer_addr("forged:8333"),
+            chunk_count: payloads.len() as u16,
+            wire_bytes,
+            tx_bytes: Arc::from(tx_bytes),
+        };
+        let chunk = |da_id, index, payload: &[u8], wire_bytes, tx_bytes: &[u8]| DaRelayChunk {
+            da_id,
+            chunk_hash: sha3_256(payload),
+            peer_quota_key: PeerQuotaKey::from_peer_addr("forged:8333"),
+            chunk_index: index,
+            payload: Arc::from(payload),
+            wire_bytes,
+            tx_bytes: Arc::from(tx_bytes),
+        };
+        let block_for = |da_id, ts| {
+            block_with_txs(
+                1,
+                0,
+                [0u8; 32],
+                ts,
+                &[
+                    relay_test_tx(
+                        0x01,
+                        vec![da_commit_output([2u8; 32])],
+                        Some(relay_commit_core(da_id, 1)),
+                        None,
+                        Vec::new(),
+                    ),
+                    relay_test_tx(
+                        0x02,
+                        Vec::new(),
+                        None,
+                        Some(relay_chunk_core(da_id, 0, payload)),
+                        payload.to_vec(),
+                    ),
+                ],
+            )
+        };
+
+        let id_a = [81u8; 32];
+        let id_b = [82u8; 32];
+        let mut state = DaRelayState::new(DaRelayCaps::default()).unwrap();
+        for (id, c, k) in [
+            (id_a, "commit-a:8333", "chunk-a:8333"),
+            (id_b, "commit-b:8333", "chunk-b:8333"),
+        ] {
+            state
+                .stage_incomplete_da_commit(c, commit(id, &[payload], payload_wire, commit_tx))
+                .unwrap();
+            state
+                .stage_incomplete_da_chunk(k, chunk(id, 0, payload, payload_wire, chunk_tx))
+                .unwrap();
+        }
+        let relay = Mutex::new(state);
+
+        // Side branch: empty canonical-applied list consumes nothing.
+        consume_canonical_applied_da_sets(&relay, &[]).expect("side branch no-op");
+        assert_eq!(relay.lock().unwrap().sets_by_da_id.len(), 2);
+
+        // Both canonical-applied blocks consume their complete sets, in order.
+        let blocks = vec![
+            CanonicalAppliedBlock {
+                hash: [0xa0; 32],
+                block_bytes: block_for(id_a, 1_000),
+            },
+            CanonicalAppliedBlock {
+                hash: [0xb0; 32],
+                block_bytes: block_for(id_b, 1_001),
+            },
+        ];
+        consume_canonical_applied_da_sets(&relay, &blocks).expect("consume canonical");
+        let guard = relay.lock().unwrap();
+        assert!(!guard.sets_by_da_id.contains_key(&id_a));
+        assert!(!guard.sets_by_da_id.contains_key(&id_b));
+        assert_eq!(guard.pinned_payload_bytes, 0);
+        drop(guard);
+
+        // Fail-closed: a malformed canonical block surfaces an error.
+        let relay2 = Mutex::new(DaRelayState::new(DaRelayCaps::default()).unwrap());
+        let bad = vec![CanonicalAppliedBlock {
+            hash: [0xee; 32],
+            block_bytes: vec![0x01, 0x02],
+        }];
+        assert!(consume_canonical_applied_da_sets(&relay2, &bad).is_err());
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -1397,6 +1397,7 @@ impl PeerSession {
                     sync_engine,
                     &mut tx_pool_cleanup,
                     &mut accepted_blocks,
+                    relay_ctx,
                 ) {
                     self.stash_pending_tx_pool_cleanup(tx_pool_cleanup);
                     self.advance_da_orphan_ttl_for_accepted_blocks(relay_ctx, accepted_blocks);
@@ -1439,6 +1440,7 @@ impl PeerSession {
                 sync_engine,
                 &mut tx_pool_cleanup,
                 &mut accepted_blocks,
+                relay_ctx,
             ) {
                 self.stash_pending_tx_pool_cleanup(tx_pool_cleanup);
                 self.advance_da_orphan_ttl_for_accepted_blocks(relay_ctx, accepted_blocks);
@@ -1458,12 +1460,20 @@ impl PeerSession {
         sync_engine: &mut SyncEngine,
         tx_pool_cleanup: &mut TxPoolCleanupPlan,
         accepted_blocks: &mut usize,
+        relay_ctx: Option<&PeerRelayContext<'_>>,
     ) -> io::Result<()> {
         let mut ready = self.orphans.take_children(parent_hash);
         while let Some(child) = ready.pop() {
             match sync_engine.apply_block_with_reorg(&child.block_bytes, None) {
                 Ok(outcome) => {
                     sync_engine.record_best_known_height(outcome.summary.block_height);
+                    // Consume the complete DA sets reported canonical-applied by
+                    // this orphan-resolved apply (RUB-437); a non-canonical apply
+                    // reports none.
+                    self.consume_canonical_applied_da_sets(
+                        relay_ctx,
+                        &outcome.summary.canonical_applied_blocks,
+                    );
                     *tx_pool_cleanup =
                         std::mem::take(tx_pool_cleanup).merge(outcome.tx_pool_cleanup);
                     *accepted_blocks = accepted_blocks.saturating_add(1);
@@ -5511,6 +5521,81 @@ mod tests {
             assert!(engine.has_block(block1_hash).expect("block1 applied"));
             assert!(engine.has_block(block2_hash).expect("block2 resolved"));
             assert_eq!(engine.chain_state.height, 2);
+        });
+
+        let _client = TcpStream::connect(addr).expect("connect");
+        server.join().expect("server join");
+        reset_orphan_pool_metrics_for_test();
+    }
+
+    #[test]
+    fn resolve_orphans_runs_da_consume_hook_under_relay_context() {
+        // Orphan resolution must run the accepted-block DA consume hook with the
+        // live peer relay context (RUB-437); a coinbase-only child carries no DA
+        // set, so the hook is a no-op, but this drives resolve_orphans' apply
+        // success arm under Some(relay_ctx) end-to-end without error.
+        let _guard = orphan_pool_metrics_test_guard();
+        reset_orphan_pool_metrics_for_test();
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let addr = listener.local_addr().expect("addr");
+
+        let server = thread::spawn(move || {
+            let (stream, _) = listener.accept().expect("accept");
+            let mut session = PeerSession::new(stream, default_peer_runtime_config("devnet", 8))
+                .expect("session");
+            let mut engine = test_sync_engine_with_genesis();
+            let genesis = parse_block_bytes(&devnet_genesis_block_bytes()).expect("parse genesis");
+            let genesis_hash = block_hash(&genesis.header_bytes).expect("genesis hash");
+            let block1 = height_one_coinbase_only_block(genesis_hash, genesis.header.timestamp + 1);
+            let block1_hash = block_hash(&block1[..BLOCK_HEADER_BYTES]).expect("block1 hash");
+            let subsidy1 = rubin_consensus::subsidy::block_subsidy(1, 0);
+            let block2 = coinbase_only_block_with_gen(
+                2,
+                subsidy1,
+                block1_hash,
+                genesis.header.timestamp + 2,
+            );
+            let block2_hash = block_hash(&block2[..BLOCK_HEADER_BYTES]).expect("block2 hash");
+
+            let relay_state = crate::tx_relay::TxRelayState::new();
+            let peer_manager = PeerManager::new(default_peer_runtime_config("devnet", 8));
+            let peer_outboxes: Mutex<HashMap<String, crate::tx_relay::PeerOutbox>> =
+                Mutex::new(HashMap::new());
+            let canonical_tx_pool = Mutex::new(TxPool::new());
+            let da_relay = Mutex::new(
+                crate::da_relay::DaRelayState::new(crate::da_relay::DaRelayCaps::default())
+                    .expect("valid DA relay caps"),
+            );
+            let relay_ctx = PeerRelayContext {
+                relay_state: &relay_state,
+                peer_manager: &peer_manager,
+                local_addr: "local:8333",
+                peer_registered_addr: "peer:8333",
+                peer_writers: &peer_outboxes,
+                tx_pool: &canonical_tx_pool,
+                da_relay: &da_relay,
+            };
+
+            // block2 arrives before its parent: retained as an orphan.
+            collect_block_message(&mut session, &mut engine, &relay_ctx, block2.clone())
+                .expect("orphan retained until parent arrives");
+            assert_eq!(engine.chain_state.height, 0, "orphan must not advance tip");
+
+            // Parent arrives under the live relay context: resolve_orphans applies
+            // block2 and runs the consume hook on its canonical-applied summary.
+            collect_block_message(&mut session, &mut engine, &relay_ctx, block1)
+                .expect("parent connects and resolves orphan");
+
+            assert_eq!(session.orphans.len(), 0, "orphan pool drains");
+            assert!(engine.has_block(block1_hash).expect("block1 applied"));
+            assert!(engine.has_block(block2_hash).expect("block2 resolved"));
+            assert_eq!(engine.chain_state.height, 2, "resolved orphan advances tip");
+            assert!(
+                session.state().last_error.is_empty(),
+                "orphan-resolution consume must not surface an error: {}",
+                session.state().last_error
+            );
         });
 
         let _client = TcpStream::connect(addr).expect("connect");

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -1384,6 +1384,12 @@ impl PeerSession {
         match sync_engine.apply_block_with_reorg(block_bytes, None) {
             Ok(outcome) => {
                 sync_engine.record_best_known_height(outcome.summary.block_height);
+                // Consume the complete DA sets reported canonical-applied by this
+                // apply (RUB-437); a side branch reports none.
+                self.consume_canonical_applied_da_sets(
+                    relay_ctx,
+                    &outcome.summary.canonical_applied_blocks,
+                );
                 let mut tx_pool_cleanup = outcome.tx_pool_cleanup;
                 let mut accepted_blocks = 1;
                 if let Err(err) = self.resolve_orphans(
@@ -1495,6 +1501,22 @@ impl PeerSession {
         };
         if let Err(err) = da_relay.advance_orphan_ttl_by(accepted_blocks) {
             self.peer.last_error = format!("DA relay TTL advance failed: {err:?}");
+        }
+    }
+
+    fn consume_canonical_applied_da_sets(
+        &mut self,
+        relay_ctx: Option<&PeerRelayContext<'_>>,
+        canonical_applied_blocks: &[crate::chainstate::CanonicalAppliedBlock],
+    ) {
+        let (Some(ctx), false) = (relay_ctx, canonical_applied_blocks.is_empty()) else {
+            return;
+        };
+        if let Err(err) = crate::da_relay::consume_canonical_applied_da_sets(
+            ctx.da_relay,
+            canonical_applied_blocks,
+        ) {
+            self.peer.last_error = format!("DA relay accepted-block consume failed: {err}");
         }
     }
 


### PR DESCRIPTION
Invariant: Rust P2P accepted-block handling consumes the complete DA relay sets of every block the SyncEngine reports as canonical-applied (RUB-436 `summary.canonical_applied_blocks`), and only those — a stored-but-not-switched side branch reports none and consumes nothing, a reorg reports every newly-canonical branch block. Mirrors merged Go RUB-432.

Layer: implementation (Rust rubin-node P2P accepted-block path + DA relay). Non-consensus consume hook only. No sync-summary shape change, RPC `/mine_next`, miner-provider policy, compact-relay semantics, or Go changes.

Files changed:
- clients/rust/crates/rubin-node/src/da_relay.rs — add `pub fn consume_canonical_applied_da_sets(da_relay, blocks)` iterating the canonical-applied blocks and consuming each block's complete sets via the RUB-435 `consume_accepted_block_da_sets` primitive, returning the first error (fail-closed, best-effort across blocks). Relax `consume_accepted_block_da_sets` to take `&Mutex<DaRelayState>` (the existing main.rs caller reaches it unchanged through `Arc` deref coercion).
- clients/rust/crates/rubin-node/src/p2p_runtime.rs — `handle_block_with_acceptance` consumes `outcome.summary.canonical_applied_blocks` on the apply-success path (after `record_best_known_height`, under the existing relay context); a new private `consume_canonical_applied_da_sets` method surfaces any consume error via `peer.last_error`, matching the sibling `advance_da_orphan_ttl_for_accepted_blocks` hook convention and Go's `setLastError`.

No scope expansion beyond the contract's allowed_files: da_relay.rs is the contract's allowed tiny-helper surface; p2p_runtime.rs is an allowed surface. main.rs is untouched.

## go_rust_parity_matrix — required_parity_cases

Each Linear required parity case maps the merged Go RUB-432 reference behaviour to its Rust mirror, with callsite/entrypoint and a Rust mirror-test.

| case | go reference function | rust required behavior | test evidence | go callsite | rust callsite | mirror test |
| --- | --- | --- | --- | --- | --- | --- |
| relayed direct canonical block consumes | Go noteAcceptedBlock calls consumeCanonicalAppliedDASets(summary.CanonicalAppliedBlocks); a direct apply reports the single connected block whose complete DA sets are consumed (clients/go/node/p2p/handlers_block.go ~148-160, clients/go/node/p2p/da_relay_consume.go ~24-35) | handle_block_with_acceptance consumes outcome.summary.canonical_applied_blocks' complete sets on the apply-success path; a direct apply reports the single connected block | asserts a single staged complete-set block reported canonical-applied is consumed (its pinned record removed) | Go noteAcceptedBlock consume call (clients/go/node/p2p/handlers_block.go) | handle_block_with_acceptance consume call -> consume_canonical_applied_da_sets (clients/rust/crates/rubin-node/src/p2p_runtime.rs, clients/rust/crates/rubin-node/src/da_relay.rs) | consume_canonical_applied_da_sets_consumes_all_canonical_blocks |
| non-switch side branch does not consume | Go side branches report no CanonicalAppliedBlocks (nil slice) so nothing is consumed; DA consume is driven by canonical application, never mere storage (clients/go/node/p2p/da_relay_consume.go ~12-23) | a stored-but-not-switched side branch yields an empty canonical_applied_blocks, so the consume hook is a no-op | asserts an empty canonical_applied_blocks slice leaves a staged complete set intact (nothing consumed) | Go consumeCanonicalAppliedDASets nil-slice no-op (clients/go/node/p2p/da_relay_consume.go) | consume_canonical_applied_da_sets empty-slice skip + p2p method empty guard (clients/rust/crates/rubin-node/src/da_relay.rs, clients/rust/crates/rubin-node/src/p2p_runtime.rs) | consume_canonical_applied_da_sets_consumes_all_canonical_blocks |
| reorg canonicalized branch blocks consume all included complete sets | Go reports every newly-canonical branch block in canonical order; consume loops best-effort across all blocks so one failure cannot skip the rest (clients/go/node/p2p/da_relay_consume.go ~24-35) | consume_canonical_applied_da_sets iterates every canonical-applied block, consuming each block's complete sets | asserts two distinct canonical-applied blocks each with a staged complete set are both consumed | Go consumeCanonicalAppliedDASets loop over blocks (clients/go/node/p2p/da_relay_consume.go) | consume_canonical_applied_da_sets per-block consume_accepted_block_da_sets loop (clients/rust/crates/rubin-node/src/da_relay.rs) | consume_canonical_applied_da_sets_consumes_all_canonical_blocks |
| consume failure is visible/fail-closed | Go returns the first consume error, joins it into noteAcceptedBlock's result, and surfaces it via setLastError; never silently dropped (clients/go/node/p2p/handlers_block.go ~141-160, clients/go/node/p2p/da_relay_consume.go ~28-33) | consume_canonical_applied_da_sets returns Err on the first failing block; the p2p hook surfaces it via peer.last_error (visible) | asserts a malformed block in the canonical-applied set yields Err from the helper (fail-closed) | Go noteAcceptedBlock errors.Join(consumeErr, ...) + acceptedRelayedBlock setLastError (clients/go/node/p2p/handlers_block.go) | consume_canonical_applied_da_sets fail-closed return + p2p_runtime.rs peer.last_error assignment (clients/rust/crates/rubin-node/src/da_relay.rs, clients/rust/crates/rubin-node/src/p2p_runtime.rs) | consume_canonical_applied_da_sets_consumes_all_canonical_blocks |

Tests:
- cargo test -p rubin-node — PASS (749 lib + 69 + 3 new); clippy `-D warnings` + fmt clean.
- core + tooling (--allow-rust --serial-rust-tests) + coverage + delta receipts — PASS; review fanout BYPASSED (controller-approved, Rust parity/thaw class).

Compatibility: additive P2P accepted-block consume wiring; no consensus/wire change. Siblings: RUB-433 (Rust consume primitive, merged), RUB-434 (Rust DA id extraction, merged), RUB-435 (Rust /mine_next consume, merged), RUB-436 (Rust canonical-applied summary, merged), RUB-432 (Go P2P consume reference, merged). Final slice of the Rust DA consume/eviction parity chain under RUB-427.

Linear: RUB-437

🤖 Generated with [Claude Code](https://claude.com/claude-code)
