### PR TITLE
node(rust): expose per-peer remote compact mode in PeerState/PeerManager (RUB-439)

### DIFF
--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -480,6 +480,13 @@ impl PeerSession {
         state
     }
 
+    /// The peer's negotiated remote compact mode — a cheap `Copy` read that
+    /// avoids cloning the full `PeerState` (used by the message loop to refresh
+    /// `PeerManager` after a sendcmpct).
+    pub fn negotiated_compact_mode(&self) -> CompactModeSnapshot {
+        self.remote_compact_mode
+    }
+
     pub fn take_pending_tx_pool_cleanup(&mut self) -> TxPoolCleanupPlan {
         std::mem::take(&mut self.pending_tx_pool_cleanup)
     }

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -194,6 +194,21 @@ pub struct PeerState {
     pub handshake_complete: bool,
     pub version_received: bool,
     pub verack_received: bool,
+    /// The peer's negotiated remote compact-receive mode, surfaced so non-session
+    /// code (e.g. DA prefetch peer enumeration) can filter compact-receiving
+    /// peers without holding the live session. Mirror of Go remoteCompactMode().
+    pub remote_compact_mode: CompactModeSnapshot,
+}
+
+impl PeerState {
+    /// Whether the peer advertised a usable compact-receive mode (the peer side
+    /// of Go acceptsCompactBlocks: version == compact-relay version and a
+    /// non-zero mode). The local `enable_compact_receive` gate is applied by the
+    /// caller.
+    pub fn accepts_compact_blocks(&self) -> bool {
+        self.remote_compact_mode.version == COMPACT_RELAY_VERSION
+            && self.remote_compact_mode.mode != 0
+    }
 }
 
 /// Context for TX relay operations, passed through the message loop.
@@ -263,9 +278,9 @@ struct RelayedBlockOutcome {
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-struct CompactModeSnapshot {
-    mode: u8,
-    version: u64,
+pub struct CompactModeSnapshot {
+    pub mode: u8,
+    pub version: u64,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -409,6 +424,18 @@ impl PeerManager {
         peers.remove(addr).is_some()
     }
 
+    /// Update the stored per-peer negotiated compact-receive mode (idempotent;
+    /// no-op when the peer is unknown). Keeps snapshot() current after a
+    /// sendcmpct so non-session code observes the live compact mode.
+    pub fn set_compact_mode(&self, addr: &str, mode: CompactModeSnapshot) {
+        let Ok(mut peers) = self.peers.write() else {
+            return;
+        };
+        if let Some(state) = peers.get_mut(addr) {
+            state.remote_compact_mode = mode;
+        }
+    }
+
     pub fn snapshot(&self) -> Vec<PeerState> {
         let Ok(peers) = self.peers.read() else {
             return Vec::new();
@@ -448,7 +475,9 @@ impl PeerSession {
     }
 
     pub fn state(&self) -> PeerState {
-        self.peer.clone()
+        let mut state = self.peer.clone();
+        state.remote_compact_mode = self.remote_compact_mode;
+        state
     }
 
     pub fn take_pending_tx_pool_cleanup(&mut self) -> TxPoolCleanupPlan {
@@ -6273,6 +6302,73 @@ mod tests {
         );
         drop(second_client);
         drop(client);
+    }
+
+    #[test]
+    fn peer_state_accepts_compact_blocks_and_manager_set_mode() {
+        let active = CompactModeSnapshot {
+            mode: 1,
+            version: COMPACT_RELAY_VERSION,
+        };
+        let with_mode = |mode| PeerState {
+            addr: "p:8333".to_string(),
+            remote_compact_mode: mode,
+            ..PeerState::default()
+        };
+        assert!(with_mode(active).accepts_compact_blocks());
+        assert!(
+            !with_mode(CompactModeSnapshot {
+                mode: 0,
+                version: COMPACT_RELAY_VERSION
+            })
+            .accepts_compact_blocks(),
+            "mode 0 is not accepted"
+        );
+        assert!(
+            !with_mode(CompactModeSnapshot {
+                mode: 1,
+                version: COMPACT_RELAY_VERSION + 1
+            })
+            .accepts_compact_blocks(),
+            "wrong compact-relay version is not accepted"
+        );
+        // PeerManager.set_compact_mode surfaces the mode in snapshot(); an unknown
+        // peer is a no-op.
+        let pm = PeerManager::new(default_peer_runtime_config("devnet", 8));
+        pm.add_peer(PeerState {
+            addr: "p:8333".to_string(),
+            ..PeerState::default()
+        })
+        .expect("add peer");
+        assert!(
+            !pm.snapshot()[0].accepts_compact_blocks(),
+            "default (un-negotiated) mode is not accepted"
+        );
+        pm.set_compact_mode("p:8333", active);
+        assert_eq!(pm.snapshot()[0].remote_compact_mode, active);
+        assert!(pm.snapshot()[0].accepts_compact_blocks());
+        pm.set_compact_mode("unknown:8333", active);
+        assert_eq!(pm.snapshot().len(), 1, "unknown peer set is a no-op");
+    }
+
+    #[test]
+    fn session_state_surfaces_negotiated_compact_mode() {
+        let (mut session, _client) = test_peer_session();
+        // test_peer_session negotiates mode 1 at the current compact-relay version.
+        assert_eq!(
+            session.state().remote_compact_mode,
+            CompactModeSnapshot {
+                mode: 1,
+                version: COMPACT_RELAY_VERSION
+            }
+        );
+        assert!(session.state().accepts_compact_blocks());
+        // A cleared/renegotiated mode is surfaced through state() too.
+        session.remote_compact_mode = CompactModeSnapshot {
+            mode: 0,
+            version: COMPACT_RELAY_VERSION,
+        };
+        assert!(!session.state().accepts_compact_blocks());
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -432,7 +432,9 @@ impl PeerManager {
             return;
         };
         if let Some(state) = peers.get_mut(addr) {
-            state.remote_compact_mode = mode;
+            if state.remote_compact_mode != mode {
+                state.remote_compact_mode = mode;
+            }
         }
     }
 

--- a/clients/rust/crates/rubin-node/src/p2p_service.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_service.rs
@@ -985,7 +985,7 @@ fn handle_peer(
         // PeerManager so non-session code observes the live mode (RUB-439).
         shared
             .peer_manager
-            .set_compact_mode(&peer_addr, session.state().remote_compact_mode);
+            .set_compact_mode(&peer_addr, session.negotiated_compact_mode());
         flush_peer_outbox(&shared, &peer_addr, |frame| session.write_raw(frame))?;
     }
     Ok(())

--- a/clients/rust/crates/rubin-node/src/p2p_service.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_service.rs
@@ -981,6 +981,11 @@ fn handle_peer(
                 .write_message(&outbound)
                 .map_err(|err| format!("handle live message: {err}"))?;
         }
+        // Surface the peer's negotiated compact mode (e.g. after a sendcmpct) into
+        // PeerManager so non-session code observes the live mode (RUB-439).
+        shared
+            .peer_manager
+            .set_compact_mode(&peer_addr, session.state().remote_compact_mode);
         flush_peer_outbox(&shared, &peer_addr, |frame| session.write_raw(frame))?;
     }
     Ok(())


### PR DESCRIPTION
Invariant: the negotiated remote compact-receive mode (version + mode) is exposed per-peer through `PeerState` / `PeerManager.snapshot()`, so non-session code (the DA prefetch peer enumeration in RUB-440) can determine whether a peer accepts compact-gated messages without holding the live session. Mirror of Go's per-peer `remoteCompactMode()` / `acceptsCompactBlocks()` (`clients/go/node/p2p/peer_runtime.go`).

Prerequisite split out of RUB-415 (getdachunk runtime, Variant A), per precedent RUB-401→RUB-420 / RUB-402→RUB-421. Unblocks RUB-440 (prefetch runtime wiring), which needs the per-peer accepts-compact filter.

Scope:
- `clients/rust/crates/rubin-node/src/p2p_runtime.rs`: `CompactModeSnapshot` made pub; `PeerState` gains a `remote_compact_mode` field (surfaced by `session.state()` and `PeerManager.snapshot()`); `PeerState::accepts_compact_blocks()` accessor; `PeerManager::set_compact_mode`.
- `clients/rust/crates/rubin-node/src/p2p_service.rs`: the message loop calls `set_compact_mode` after each message so a sendcmpct is reflected in the snapshot.
- No DA prefetch send/serve, no provider/miner, no compact-block runtime change, no Go/spec/fixture changes. PeerState literals unchanged (Default-covered).

Parity Matrix:
| Required parity case | Go callsite | Rust entrypoint | Rust mirror test evidence |
| -- | -- | -- | -- |
| case: PeerState exposes negotiated remote compact mode in snapshot | `clients/go/node/p2p/peer_runtime.go::remoteCompactMode` (per-peer) | `PeerState.remote_compact_mode` via `session.state()` / `PeerManager.snapshot()` | `session_state_surfaces_negotiated_compact_mode` |
| case: per-peer accepts-compact accessor reflects version and mode | `clients/go/node/p2p/peer_runtime.go::acceptsCompactBlocks` (peer-side predicate) | `PeerState::accepts_compact_blocks` | `peer_state_accepts_compact_blocks_and_manager_set_mode` (mode 0 / wrong version / valid) |
| case: PeerManager keeps snapshot compact mode current; unknown peer no-op | `clients/go/node/p2p/service_peer_lifecycle.go` per-peer state update | `PeerManager::set_compact_mode` | `peer_state_accepts_compact_blocks_and_manager_set_mode` (update + unknown-peer no-op) |
| case: no DA prefetch/provider/miner/Go changes | n/a (scope guard) | `p2p_runtime.rs` + `p2p_service.rs` loop sync only | `peer_state_accepts_compact_blocks_and_manager_set_mode` + two-file diff |

Evidence:
- `cd clients/rust && cargo test -p rubin-node p2p_runtime --lib` — PASS
- full suite `cargo test -p rubin-node` — PASS (767 lib + 69 + 3)
- `cargo clippy --workspace --all-targets -- -D warnings` — PASS; `cargo fmt` clean
- core + tooling (--allow-rust --serial-rust-tests) + coverage + delta receipts — PASS; review fanout BYPASSED (controller-approved, Rust parity/thaw class)

Compatibility: additive; the local `enable_compact_receive` gate stays the caller's (the accessor is the peer-side predicate only, matching Go's split). Follow-up: RUB-440 combines `cfg.enable_compact_receive` with `PeerState::accepts_compact_blocks()` to enumerate prefetch peers.

Linear: RUB-439

🤖 Generated with [Claude Code](https://claude.com/claude-code)
