### PR TITLE
node(rust): wire DA prefetch scheduler into peer enumeration + ingest (RUB-440)

### DIFF
--- a/clients/rust/crates/rubin-node/src/da_relay.rs
+++ b/clients/rust/crates/rubin-node/src/da_relay.rs
@@ -542,43 +542,46 @@ impl DaRelayState {
     }
 
     #[rustfmt::skip]
-    pub(crate) fn stage_relay_da_tx_bytes(&mut self, peer_addr: &str, tx_bytes: Vec<u8>) -> DaRelayResult { self.stage_relay_da_tx_bytes_checked(peer_addr, tx_bytes, false) }
+    pub(crate) fn stage_relay_da_tx_bytes(&mut self, peer_addr: &str, tx_bytes: Vec<u8>) -> DaRelayResult { self.stage_relay_da_tx_bytes_checked(peer_addr, tx_bytes, false).1 }
 
+    /// Stage a relay DA tx, returning the schedulable da_id with the staging result
+    /// from this single parse (so the caller drives `finish_da_prefetch` without a
+    /// second `parse_tx`). The da_id is `Some` only for a DA chunk or a commit with a
+    /// well-formed DA_COMMIT covenant (mirror of Go `stageRelayDACommitTx` gating
+    /// `finishDAPrefetch`); it is returned even on a staging error (e.g. a payload-
+    /// commitment mismatch driving a snapshot reschedule).
     #[rustfmt::skip]
-    pub(crate) fn stage_relay_da_tx_bytes_checked(&mut self, peer_addr: &str, tx_bytes: Vec<u8>, chunk_hash_prevalidated: bool) -> DaRelayResult {
-        let wire_bytes = u64::try_from(tx_bytes.len()).map_err(|_| DaRelayError::AccountingOverflow)?;
-        let (tx, _txid, _wtxid, consumed) = parse_tx(&tx_bytes).map_err(|_| DaRelayError::InvalidWireBytes)?;
+    pub(crate) fn stage_relay_da_tx_bytes_checked(&mut self, peer_addr: &str, tx_bytes: Vec<u8>, chunk_hash_prevalidated: bool) -> (Option<[u8; 32]>, DaRelayResult) {
+        let Ok(wire_bytes) = u64::try_from(tx_bytes.len()) else { return (None, Err(DaRelayError::AccountingOverflow)); };
+        let Ok((tx, _txid, _wtxid, consumed)) = parse_tx(&tx_bytes) else { return (None, Err(DaRelayError::InvalidWireBytes)); };
         if consumed != tx_bytes.len() {
-            return Err(DaRelayError::InvalidWireBytes);
+            return (None, Err(DaRelayError::InvalidWireBytes));
         }
         match tx.tx_kind {
             0x01 => {
-                let Some(core) = tx.da_commit_core.as_ref() else {
-                    return Ok(());
-                };
-                let Some(payload_commitment) = relay_da_commit_payload_commitment(&tx) else {
-                    return Ok(());
-                };
-                self.stage_incomplete_da_commit(
+                let Some(core) = tx.da_commit_core.as_ref() else { return (None, Ok(())); };
+                let Some(payload_commitment) = relay_da_commit_payload_commitment(&tx) else { return (None, Ok(())); };
+                let da_id = core.da_id;
+                let result = self.stage_incomplete_da_commit(
                     peer_addr,
                     DaRelayCommit {
-                        da_id: core.da_id,
+                        da_id,
                         payload_commitment,
                         peer_quota_key: PeerQuotaKey::from_peer_addr(peer_addr),
                         chunk_count: core.chunk_count,
                         wire_bytes,
                         tx_bytes: Arc::from(tx_bytes.into_boxed_slice()),
                     },
-                )
+                );
+                (Some(da_id), result)
             }
             0x02 => {
-                let Some(core) = tx.da_chunk_core.as_ref() else {
-                    return Ok(());
-                };
-                self.stage_incomplete_da_chunk_inner(
+                let Some(core) = tx.da_chunk_core.as_ref() else { return (None, Ok(())); };
+                let da_id = core.da_id;
+                let result = self.stage_incomplete_da_chunk_inner(
                     peer_addr,
                     DaRelayChunk {
-                        da_id: core.da_id,
+                        da_id,
                         chunk_hash: core.chunk_hash,
                         peer_quota_key: PeerQuotaKey::from_peer_addr(peer_addr),
                         chunk_index: core.chunk_index,
@@ -587,9 +590,10 @@ impl DaRelayState {
                         tx_bytes: Arc::from(tx_bytes.into_boxed_slice()),
                     },
                     chunk_hash_prevalidated,
-                )
+                );
+                (Some(da_id), result)
             }
-            _ => Ok(()),
+            _ => (None, Ok(())),
         }
     }
 
@@ -1164,7 +1168,7 @@ fn validate_relay_da_chunk_for_admission(tx: &Tx, wire_bytes: u64) -> DaRelayRes
     Ok(())
 }
 
-pub(crate) fn relay_da_commit_payload_commitment(tx: &Tx) -> Option<[u8; 32]> {
+fn relay_da_commit_payload_commitment(tx: &Tx) -> Option<[u8; 32]> {
     let mut outputs = tx
         .outputs
         .iter()
@@ -1379,6 +1383,20 @@ mod tests {
         let good_tx = relay_test_tx(0x02, Vec::new(), None, Some(relay_chunk_core([7u8; 32], 0, &payload)), payload.clone()); reject_state.stage_relay_da_tx_bytes(peer, good_tx.clone()).unwrap(); assert_eq!(reject_state.test_record_summary([7u8; 32]), Some((false, 1, good_tx.len() as u64))); assert_eq!(reject_state.sets_by_da_id[&[7u8; 32]].chunks[&0].tx_bytes.as_ref(), good_tx.as_slice());
         let (good_chunk_tx, _, _, _) = parse_tx(&good_tx).unwrap(); let mut edge_tx = good_chunk_tx.clone(); edge_tx.da_chunk_core.as_mut().unwrap().chunk_index = MAX_DA_CHUNK_COUNT as u16; assert_eq!(validate_relay_da_chunk_for_admission(&edge_tx, good_tx.len() as u64), Err(ChunkIndexOutOfRange)); edge_tx.da_chunk_core.as_mut().unwrap().chunk_index = 0; edge_tx.da_payload.clear(); assert_eq!(validate_relay_da_chunk_for_admission(&edge_tx, good_tx.len() as u64), Err(ChunkPayloadSizeInvalid)); edge_tx.da_payload = payload.clone(); assert_eq!(validate_relay_da_chunk_for_admission(&edge_tx, 0), Err(InvalidWireBytes));
         let caps = DaRelayCaps { orphan_pool_per_peer_bytes: good_tx.len() as u64 + payload.len() as u64 - 1, ..DaRelayCaps::default() }; let mut cap_state = DaRelayState::new(caps).unwrap(); assert_eq!(cap_state.stage_relay_da_tx_bytes(peer, good_tx), Err(AccountingCapExceeded)); assert!(cap_state.is_empty());
+    }
+
+    #[test]
+    #[rustfmt::skip]
+    fn stage_returns_schedulable_da_id() {
+        let peer = "peer-a:8333"; let mut state = DaRelayState::new(DaRelayCaps::default()).unwrap();
+        // non-DA tx -> no schedulable da_id
+        let non_da = relay_test_tx(0x00, Vec::new(), None, None, Vec::new()); assert_eq!(state.stage_relay_da_tx_bytes_checked(peer, non_da, false).0, None);
+        // commit with a malformed (31-byte) DA_COMMIT covenant -> gated out, no da_id (mirror Go stageRelayDACommitTx)
+        let bad_out = rubin_consensus::TxOutput { value: 0, covenant_type: rubin_consensus::constants::COV_TYPE_DA_COMMIT, covenant_data: vec![4u8; 31] }; let bad_commit = relay_test_tx(0x01, vec![bad_out], Some(relay_commit_core([4u8; 32], 1)), None, Vec::new()); assert_eq!(state.stage_relay_da_tx_bytes_checked(peer, bad_commit, false).0, None);
+        // well-formed commit -> its da_id with an Ok stage
+        let commit_tx = relay_test_tx(0x01, vec![da_commit_output([2u8; 32])], Some(relay_commit_core([1u8; 32], 1)), None, Vec::new()); assert_eq!(state.stage_relay_da_tx_bytes_checked(peer, commit_tx, false), (Some([1u8; 32]), Ok(())));
+        // DA chunk -> its da_id
+        let payload = b"relay chunk".to_vec(); let chunk_tx = relay_test_tx(0x02, Vec::new(), None, Some(relay_chunk_core([7u8; 32], 0, &payload)), payload.clone()); assert_eq!(state.stage_relay_da_tx_bytes_checked(peer, chunk_tx, false).0, Some([7u8; 32]));
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/da_relay.rs
+++ b/clients/rust/crates/rubin-node/src/da_relay.rs
@@ -175,6 +175,12 @@ impl PeerQuotaKey {
         }
         Self(normalize_peer_host(split_peer_host(addr)))
     }
+
+    /// The host-only quota key string (used by DA prefetch peer enumeration to
+    /// build the quota-key -> addr map).
+    pub(crate) fn as_str(&self) -> &str {
+        &self.0
+    }
 }
 
 fn split_peer_host(addr: &str) -> &str {
@@ -285,6 +291,23 @@ impl DaRelaySetRecord {
             payload_commitment_expected: commit.payload_commitment,
             chunks,
         })
+    }
+    /// The still-missing chunk indexes of this set (mirror of Go
+    /// `daRelaySetRecord.missingChunkIndexes`): empty if there is no commit, the
+    /// commit declares no chunks, or the set is already complete; otherwise every
+    /// index not yet retained, plus any marked replaceable.
+    fn missing_chunk_indexes(&self) -> Vec<u16> {
+        let Some(commit) = self.commit.as_ref() else {
+            return Vec::new();
+        };
+        if commit.chunk_count == 0 || self.state == DaRelaySetState::CompleteSet {
+            return Vec::new();
+        }
+        (0..commit.chunk_count)
+            .filter(|index| {
+                !self.chunks.contains_key(index) || self.replaceable_chunks.contains(index)
+            })
+            .collect()
     }
     fn mark_complete(&mut self, payload_bytes: u64) {
         self.payload_bytes = payload_bytes;
@@ -508,6 +531,16 @@ impl DaRelayState {
         validate_relay_da_chunk_for_admission(&tx, wire_bytes)
     }
 
+    /// Still-missing chunk indexes for a DA set, read live by da_id (empty if the
+    /// set is absent or complete) — the DA prefetch planner input. Mirror of Go
+    /// reading sets[daID].missingChunkIndexes().
+    pub(crate) fn missing_chunk_indexes(&self, da_id: [u8; 32]) -> Vec<u16> {
+        self.sets_by_da_id
+            .get(&da_id)
+            .map(DaRelaySetRecord::missing_chunk_indexes)
+            .unwrap_or_default()
+    }
+
     #[rustfmt::skip]
     pub(crate) fn stage_relay_da_tx_bytes(&mut self, peer_addr: &str, tx_bytes: Vec<u8>) -> DaRelayResult { self.stage_relay_da_tx_bytes_checked(peer_addr, tx_bytes, false) }
 
@@ -563,6 +596,27 @@ impl DaRelayState {
     #[cfg(test)]
     #[rustfmt::skip]
     pub(crate) fn test_record_summary(&self, da_id: [u8; 32]) -> Option<(bool, usize, u64)> { let record = self.sets_by_da_id.get(&da_id)?; Some((record.commit.is_some(), record.chunks.len(), record.wire_bytes)) }
+
+    #[cfg(test)]
+    pub(crate) fn test_stage_incomplete_da_commit(
+        &mut self,
+        peer_addr: &str,
+        da_id: [u8; 32],
+        chunk_count: u16,
+        wire_bytes: u64,
+    ) -> DaRelayResult {
+        self.stage_incomplete_da_commit(
+            peer_addr,
+            DaRelayCommit {
+                da_id,
+                payload_commitment: [0u8; 32],
+                peer_quota_key: PeerQuotaKey::from_peer_addr(peer_addr),
+                chunk_count,
+                wire_bytes,
+                tx_bytes: Arc::from([]),
+            },
+        )
+    }
 
     #[cfg(test)]
     pub(crate) fn test_stage_incomplete_da_chunk(
@@ -1110,7 +1164,7 @@ fn validate_relay_da_chunk_for_admission(tx: &Tx, wire_bytes: u64) -> DaRelayRes
     Ok(())
 }
 
-fn relay_da_commit_payload_commitment(tx: &Tx) -> Option<[u8; 32]> {
+pub(crate) fn relay_da_commit_payload_commitment(tx: &Tx) -> Option<[u8; 32]> {
     let mut outputs = tx
         .outputs
         .iter()

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -246,6 +246,8 @@ pub struct PeerRelayContext<'a> {
     /// statement (line 53) is `p.mempool.AddRemoteTx(raw)`.
     pub tx_pool: &'a std::sync::Mutex<crate::txpool::TxPool>,
     pub da_relay: &'a std::sync::Mutex<crate::da_relay::DaRelayState>,
+    /// DA prefetch reservation state, scheduled after a DA tx stages (RUB-440).
+    pub prefetch: &'a std::sync::Mutex<crate::da_prefetch::DaRelayPrefetchState>,
 }
 
 pub(crate) type PendingDaRelayStaging = (String, Vec<u8>, bool);
@@ -515,16 +517,77 @@ impl PeerSession {
         &mut self,
         da_relay: &std::sync::Mutex<crate::da_relay::DaRelayState>,
         pending: Option<PendingDaRelayStaging>,
-    ) {
+    ) -> DaPrefetchFollowup {
         let Some((peer_addr, tx_bytes, chunk_hash_prevalidated)) = pending else {
-            return;
+            return DaPrefetchFollowup::None;
         };
+        let da_id = pending_da_tx_da_id(&tx_bytes);
         let Ok(mut da_relay) = da_relay.lock() else {
             self.peer.last_error = "da relay state poisoned; peer-tx staging skipped".to_string();
+            return DaPrefetchFollowup::None;
+        };
+        let staging =
+            da_relay.stage_relay_da_tx_bytes_checked(&peer_addr, tx_bytes, chunk_hash_prevalidated);
+        drop(da_relay);
+        if let Err(ref err) = staging {
+            self.peer.last_error = format!("DA relay tx staging failed: {err:?}");
+        }
+        match da_id {
+            Some(id) => finish_da_prefetch(id, staging),
+            None => DaPrefetchFollowup::None,
+        }
+    }
+
+    /// Schedule DA prefetch after a DA tx stages (mirror of Go scheduleDAPrefetch
+    /// from finishDAPrefetch): re-read still-missing chunks, enumerate
+    /// compact-receiving peers (trigger-preferred), reserve a bounded plan, and
+    /// send each as getdachunk. Lock order da_relay -> drop -> peer_manager ->
+    /// prefetch -> peer_writers; only entered after the staging da_relay lock drops.
+    pub(crate) fn schedule_da_prefetch(
+        &mut self,
+        followup: DaPrefetchFollowup,
+        da_relay: &Mutex<crate::da_relay::DaRelayState>,
+        prefetch: &Mutex<crate::da_prefetch::DaRelayPrefetchState>,
+        peer_manager: &PeerManager,
+        peer_writers: &Mutex<HashMap<String, crate::tx_relay::PeerOutbox>>,
+        trigger_peer_addr: &str,
+    ) {
+        let da_id = match followup {
+            DaPrefetchFollowup::Schedule(id) | DaPrefetchFollowup::ScheduleSnapshot(id) => id,
+            DaPrefetchFollowup::None => return,
+        };
+        let missing = {
+            let Ok(relay) = da_relay.lock() else {
+                return;
+            };
+            relay.missing_chunk_indexes(da_id)
+        };
+        let (quota_key_to_addr, keys) = da_prefetch_peers(
+            &peer_manager.snapshot(),
+            self.cfg.enable_compact_receive,
+            trigger_peer_addr,
+        );
+        let Ok(mut prefetch) = prefetch.lock() else {
             return;
         };
-        if let Err(err) = da_relay.stage_relay_da_tx_bytes_checked(&peer_addr, tx_bytes, chunk_hash_prevalidated) {
-            self.peer.last_error = format!("DA relay tx staging failed: {err:?}");
+        // Always plan (even for empty missing / no peers): plan_da_prefetch expires
+        // stale sets and releases the reservation, as Go planDAPrefetch does.
+        let (plans, diagnostic) = prefetch.plan_da_prefetch(da_id, &missing, &keys, now_nanos());
+        // Surface the planner diagnostic to the trigger peer (mirror Go
+        // reportDAPrefetchDiagnostic; its keys[0] is the trigger after prefer).
+        if !diagnostic.is_empty() {
+            self.peer.last_error = diagnostic;
+        }
+        for plan in plans {
+            if let Err(err) = send_da_prefetch_plan(
+                &mut prefetch,
+                plan,
+                &self.cfg.network,
+                &quota_key_to_addr,
+                peer_writers,
+            ) {
+                self.peer.last_error = err;
+            }
         }
     }
 
@@ -955,7 +1018,9 @@ impl PeerSession {
         let outcome = self.collect_live_responses(msg, sync_engine, relay_ctx)?;
         let pending_da_relay_staging = self.take_pending_da_relay_staging();
         if let Some(ctx) = relay_ctx {
-            self.apply_pending_da_relay_staging(ctx.da_relay, pending_da_relay_staging);
+            // Live inbound prefetch is driven from p2p_service::handle_peer; the only
+            // caller here (block-sync) passes relay_ctx=None, so this stages only.
+            let _ = self.apply_pending_da_relay_staging(ctx.da_relay, pending_da_relay_staging);
         }
         for response in outcome.responses {
             self.write_message(&response)?;
@@ -2335,20 +2400,79 @@ pub fn decode_getdachunk_payload(payload: &[u8]) -> io::Result<GetDAChunkPayload
     })
 }
 
-// The reservation-release/retry decision and the plan sender below have no
-// production caller until the prefetch runtime-wiring follow-up slice threads
-// the scheduler through the staging path; they are exercised by tests here.
+/// Wall-clock nanoseconds for prefetch reservation TTLs.
+fn now_nanos() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0)
+}
+
+/// The DA id of a staged DA relay tx that should drive prefetch, or None for a
+/// non-DA tx. A commit only counts with a well-formed DA_COMMIT covenant (mirror
+/// of Go stageRelayDACommitTx returning before finishDAPrefetch when not ok).
+fn pending_da_tx_da_id(tx_bytes: &[u8]) -> Option<[u8; 32]> {
+    let (tx, ..) = parse_tx(tx_bytes).ok()?;
+    if let Some(da_id) = tx.da_commit_core.as_ref().map(|core| core.da_id) {
+        return crate::da_relay::relay_da_commit_payload_commitment(&tx).map(|_| da_id);
+    }
+    tx.da_chunk_core.map(|core| core.da_id)
+}
+
+/// Enumerate DA prefetch peers from a PeerManager snapshot (mirror of Go
+/// allDAPrefetchPeersLocked + preferDAPrefetchPeer): keep peers usable under the
+/// local gate, key by host-only quota key (last-writer-wins on a shared host),
+/// sort, then move the trigger peer's key first. Returns (quota_key -> addr, keys).
+pub(crate) fn da_prefetch_peers(
+    peers: &[PeerState],
+    enable_compact_receive: bool,
+    trigger_peer_addr: &str,
+) -> (std::collections::BTreeMap<String, String>, Vec<String>) {
+    let accepts = |peer: &PeerState| enable_compact_receive && peer.accepts_compact_blocks();
+    let mut quota_key_to_addr = std::collections::BTreeMap::new();
+    for peer in peers {
+        if !accepts(peer) {
+            continue;
+        }
+        let key = crate::da_relay::PeerQuotaKey::from_peer_addr(&peer.addr);
+        if !key.as_str().is_empty() {
+            quota_key_to_addr.insert(key.as_str().to_string(), peer.addr.clone());
+        }
+    }
+    let preferred = peers
+        .iter()
+        .find(|peer| peer.addr == trigger_peer_addr && accepts(peer))
+        .map(|peer| {
+            crate::da_relay::PeerQuotaKey::from_peer_addr(&peer.addr)
+                .as_str()
+                .to_string()
+        })
+        .unwrap_or_default();
+    let keys: Vec<String> = quota_key_to_addr.keys().cloned().collect();
+    (quota_key_to_addr, prefer_da_prefetch_peer(keys, &preferred))
+}
+
+/// Move `preferred` to the front of `keys` if present (mirror of Go
+/// preferDAPrefetchPeer); otherwise return the sorted keys unchanged.
+fn prefer_da_prefetch_peer(keys: Vec<String>, preferred: &str) -> Vec<String> {
+    if preferred.is_empty() || keys.len() < 2 || !keys.iter().any(|key| key == preferred) {
+        return keys;
+    }
+    let mut ordered = Vec::with_capacity(keys.len());
+    ordered.push(preferred.to_string());
+    ordered.extend(keys.into_iter().filter(|key| key != preferred));
+    ordered
+}
+
 /// Followup after a DA tx stage completes (mirror of Go `finishDAPrefetch`): a
 /// successful stage re-schedules prefetch for the record, a payload-commitment
 /// mismatch re-schedules from a fresh snapshot, and any other error does nothing.
-#[allow(dead_code)]
 pub(crate) enum DaPrefetchFollowup {
     Schedule([u8; 32]),
     ScheduleSnapshot([u8; 32]),
     None,
 }
 
-#[allow(dead_code)]
 pub(crate) fn finish_da_prefetch(
     da_id: [u8; 32],
     staging: Result<(), crate::da_relay::DaRelayError>,
@@ -2367,7 +2491,6 @@ pub(crate) fn finish_da_prefetch(
 /// addr and enqueue the encoded request. If the peer is gone or the send fails,
 /// the reservation is released so it can be re-planned later. Returns the send
 /// error so the caller can record it as the peer's last error.
-#[allow(dead_code)]
 pub(crate) fn send_da_prefetch_plan(
     prefetch: &mut crate::da_prefetch::DaRelayPrefetchState,
     plan: crate::da_prefetch::DaRelayPrefetchPlan,
@@ -4153,6 +4276,177 @@ mod tests {
         ));
     }
 
+    fn compact_peer(addr: &str) -> PeerState {
+        PeerState {
+            addr: addr.to_string(),
+            remote_compact_mode: CompactModeSnapshot {
+                mode: 1,
+                version: COMPACT_RELAY_VERSION,
+            },
+            ..PeerState::default()
+        }
+    }
+
+    fn da_relay_with_commit(
+        da_id: [u8; 32],
+        chunk_count: u16,
+    ) -> std::sync::Mutex<crate::da_relay::DaRelayState> {
+        let relay = std::sync::Mutex::new(
+            crate::da_relay::DaRelayState::new(crate::da_relay::DaRelayCaps::default())
+                .expect("caps"),
+        );
+        relay
+            .lock()
+            .unwrap()
+            .test_stage_incomplete_da_commit("host-a:1111", da_id, chunk_count, 100)
+            .expect("stage commit");
+        relay
+    }
+
+    /// Run `schedule_da_prefetch` against one compact-receiving peer (host-a:1111),
+    /// returning the sorted union of requested chunk indexes and the last_error.
+    fn run_schedule(
+        da_relay: &std::sync::Mutex<crate::da_relay::DaRelayState>,
+        followup: DaPrefetchFollowup,
+    ) -> (Vec<u16>, String) {
+        use crate::da_prefetch::DaRelayPrefetchState;
+        use crate::tx_relay::PeerOutbox;
+        use std::sync::Mutex;
+        let (mut session, _client) = test_peer_session();
+        let prefetch = Mutex::new(DaRelayPrefetchState::default());
+        let peer_manager = PeerManager::new(default_peer_runtime_config("devnet", 64));
+        peer_manager
+            .add_peer(compact_peer("host-a:1111"))
+            .expect("add peer");
+        let writers = Mutex::new(HashMap::from([(
+            "host-a:1111".to_string(),
+            PeerOutbox::default(),
+        )]));
+        session.schedule_da_prefetch(
+            followup,
+            da_relay,
+            &prefetch,
+            &peer_manager,
+            &writers,
+            "host-a:1111",
+        );
+        let frames = writers
+            .lock()
+            .unwrap()
+            .get_mut("host-a:1111")
+            .unwrap()
+            .take_frames();
+        let mut requested: Vec<u16> = frames
+            .iter()
+            .flat_map(|frame| {
+                decode_getdachunk_payload(&frame[WIRE_HEADER_SIZE..])
+                    .expect("scheduled frame is a getdachunk request")
+                    .indexes
+            })
+            .collect();
+        requested.sort_unstable();
+        (requested, session.state().last_error)
+    }
+
+    #[test]
+    fn schedule_da_prefetch_requests_live_missing_chunks() {
+        // Schedule: commit declares 3 chunks, only chunk 0 retained -> request {1, 2}.
+        let da_id = [0x77u8; 32];
+        let da_relay = da_relay_with_commit(da_id, 3);
+        da_relay
+            .lock()
+            .unwrap()
+            .test_stage_incomplete_da_chunk("host-a:1111", da_id, 0, b"chunk0", 50)
+            .expect("stage chunk 0");
+        let (requested, last_error) = run_schedule(&da_relay, DaPrefetchFollowup::Schedule(da_id));
+        assert_eq!(
+            requested,
+            vec![1, 2],
+            "schedule requests the still-missing chunks"
+        );
+        assert!(
+            last_error.is_empty(),
+            "a successful schedule records no error"
+        );
+        // ScheduleSnapshot (payload-commitment mismatch) must also re-plan from the
+        // live missing set (mirror of Go finishDAPrefetch's re-schedule on mismatch).
+        let snap_id = [0x88u8; 32];
+        let snap_relay = da_relay_with_commit(snap_id, 2);
+        let (snap_requested, _) =
+            run_schedule(&snap_relay, DaPrefetchFollowup::ScheduleSnapshot(snap_id));
+        assert_eq!(
+            snap_requested,
+            vec![0, 1],
+            "snapshot followup schedules all missing"
+        );
+    }
+
+    #[test]
+    fn da_prefetch_peers_collapses_host_and_prefers_trigger() {
+        // Two ports on one host collapse to a single host-only key (last-writer-
+        // wins), non-compact peers drop, trigger key first (mirror of Go
+        // allDAPrefetchPeersLocked + preferDAPrefetchPeer).
+        let mut host_c = compact_peer("host-c:4444");
+        host_c.remote_compact_mode.mode = 0; // not compact-receiving -> dropped
+        let peers = vec![
+            compact_peer("host-a:1111"),
+            compact_peer("host-a:2222"),
+            compact_peer("host-b:3333"),
+            host_c,
+        ];
+        let (map, keys) = da_prefetch_peers(&peers, true, "host-b:3333");
+        assert_eq!(
+            keys,
+            vec!["host-b".to_string(), "host-a".to_string()],
+            "trigger host first, non-compact peer dropped"
+        );
+        assert_eq!(map.len(), 2, "host-a's two ports collapse to one key");
+        assert_eq!(
+            map.get("host-a"),
+            Some(&"host-a:2222".to_string()),
+            "host-only key keeps the last writer on the shared host"
+        );
+    }
+
+    #[test]
+    fn schedule_da_prefetch_is_noop_without_da_or_gate() {
+        // (a) A None followup short-circuits before any enumeration or send.
+        let da_relay = da_relay_with_commit([0x99u8; 32], 2);
+        let (requested, last_error) = run_schedule(&da_relay, DaPrefetchFollowup::None);
+        assert!(requested.is_empty(), "a None followup schedules nothing");
+        assert!(last_error.is_empty());
+        // (b) The disabled local compact-receive gate enumerates no peers even when
+        // compact-accepting peers are present.
+        let (map_off, keys_off) =
+            da_prefetch_peers(&[compact_peer("host-a:1111")], false, "host-a:1111");
+        assert!(
+            map_off.is_empty() && keys_off.is_empty(),
+            "the disabled local gate yields no prefetch peers"
+        );
+        // (c) A non-DA tx carries no DA id, so the apply_pending hook yields None
+        // and never schedules (the DA-tx -> Some path is covered by every schedule
+        // test above, which routes a staged chunk through to a getdachunk request).
+        let (mut plain, ..) =
+            parse_tx(&relay_da_chunk_tx([9u8; 32], b"x")).expect("parse DA chunk tx");
+        plain.tx_kind = 0x00;
+        plain.da_chunk_core = None;
+        plain.da_payload = Vec::new();
+        let plain_bytes = rubin_consensus::marshal_tx(&plain).expect("marshal non-DA tx");
+        assert_eq!(pending_da_tx_da_id(&plain_bytes), None);
+    }
+
+    #[test]
+    fn schedule_da_prefetch_surfaces_planner_diagnostic() {
+        // 9 missing chunks but the single peer's per-peer byte cap is 7: the planner
+        // diagnostic surfaces on the trigger peer's last_error and the request is
+        // bounded (mirror Go reportDAPrefetchDiagnostic + per-peer cap).
+        let da_id = [0xAAu8; 32];
+        let da_relay = da_relay_with_commit(da_id, 9);
+        let (requested, last_error) = run_schedule(&da_relay, DaPrefetchFollowup::Schedule(da_id));
+        assert_eq!(requested.len(), 7, "per-peer cap bounds the request");
+        assert_eq!(last_error, "da prefetch per-peer byte cap exceeded");
+    }
+
     #[test]
     fn getblocktxn_serves_announced_block_in_request_order() {
         let (mut session, _client) = test_peer_session();
@@ -5841,6 +6135,7 @@ mod tests {
                 crate::da_relay::DaRelayState::new(crate::da_relay::DaRelayCaps::default())
                     .expect("valid DA relay caps"),
             );
+            let prefetch = Mutex::new(crate::da_prefetch::DaRelayPrefetchState::default());
             let relay_ctx = PeerRelayContext {
                 relay_state: &relay_state,
                 peer_manager: &peer_manager,
@@ -5849,6 +6144,7 @@ mod tests {
                 peer_writers: &peer_outboxes,
                 tx_pool: &canonical_tx_pool,
                 da_relay: &da_relay,
+                prefetch: &prefetch,
             };
 
             // block2 arrives before its parent: retained as an orphan.
@@ -5912,6 +6208,7 @@ mod tests {
                 crate::da_relay::DaRelayState::new(crate::da_relay::DaRelayCaps::default())
                     .expect("valid DA relay caps"),
             );
+            let prefetch = Mutex::new(crate::da_prefetch::DaRelayPrefetchState::default());
             let da_id = [0x62; 32];
             let da_tx = relay_da_chunk_tx(da_id, b"peer-partial-error-ttl");
             da_relay
@@ -5927,6 +6224,7 @@ mod tests {
                 peer_writers: &peer_outboxes,
                 tx_pool: &canonical_tx_pool,
                 da_relay: &da_relay,
+                prefetch: &prefetch,
             };
 
             session
@@ -6660,6 +6958,7 @@ mod tests {
                 crate::da_relay::DaRelayState::new(crate::da_relay::DaRelayCaps::default())
                     .expect("valid DA relay caps"),
             );
+            let prefetch = Mutex::new(crate::da_prefetch::DaRelayPrefetchState::default());
 
             let relay_ctx = PeerRelayContext {
                 relay_state: &relay_state,
@@ -6669,6 +6968,7 @@ mod tests {
                 peer_writers: &peer_outboxes,
                 tx_pool: &canonical_tx_pool,
                 da_relay: &da_relay_state,
+                prefetch: &prefetch,
             };
 
             let msg = WireMessage {
@@ -6747,7 +7047,8 @@ mod tests {
             let mut sync_cfg = crate::sync::default_sync_config(None, crate::genesis::devnet_genesis_chain_id(), None);
             sync_cfg.core_ext_deployments = rubin_consensus::CoreExtDeploymentProfiles::empty();
             let mut engine = crate::sync::SyncEngine::new(chain_state, None, sync_cfg).expect("sync engine"); let relay_state = crate::tx_relay::TxRelayState::new(); let peer_manager = PeerManager::new(default_peer_runtime_config("devnet", 64)); let peer_outboxes: Mutex<HashMap<String, crate::tx_relay::PeerOutbox>> = Mutex::new(HashMap::new()); let canonical_tx_pool = Mutex::new(TxPool::new()); let da_relay = Mutex::new(crate::da_relay::DaRelayState::new(crate::da_relay::DaRelayCaps::default()).expect("valid DA relay caps"));
-            let relay_ctx = PeerRelayContext { relay_state: &relay_state, peer_manager: &peer_manager, local_addr: "local:8333", peer_registered_addr: "sender:8333", peer_writers: &peer_outboxes, tx_pool: &canonical_tx_pool, da_relay: &da_relay };
+            let prefetch = Mutex::new(crate::da_prefetch::DaRelayPrefetchState::default());
+            let relay_ctx = PeerRelayContext { relay_state: &relay_state, peer_manager: &peer_manager, local_addr: "local:8333", peer_registered_addr: "sender:8333", peer_writers: &peer_outboxes, tx_pool: &canonical_tx_pool, da_relay: &da_relay, prefetch: &prefetch };
             let (_, bad_txid, _, _) = parse_tx(&bad_tx).expect("parse bad DA tx");
             session.collect_live_responses(WireMessage { command: MESSAGE_TX.to_string(), payload: bad_tx }, &mut engine, Some(&relay_ctx)).expect("sub-threshold malformed DA tx is peer-neutral"); assert_eq!(session.state().ban_score, 10); assert!(!relay_state.tx_seen.has(&bad_txid)); assert!(session.take_pending_da_relay_staging().is_none()); assert_eq!(da_relay.lock().unwrap().test_record_summary(bad_da_id), None);
             let (_, txid, _, _) = parse_tx(&admitted_tx).expect("parse admitted DA tx");
@@ -6895,6 +7196,7 @@ mod tests {
                 crate::da_relay::DaRelayState::new(crate::da_relay::DaRelayCaps::default())
                     .expect("valid DA relay caps"),
             );
+            let prefetch = Mutex::new(crate::da_prefetch::DaRelayPrefetchState::default());
 
             let relay_ctx = PeerRelayContext {
                 relay_state: &relay_state,
@@ -6904,6 +7206,7 @@ mod tests {
                 peer_writers: &peer_outboxes,
                 tx_pool: &canonical_tx_pool,
                 da_relay: &da_relay_state,
+                prefetch: &prefetch,
             };
 
             let msg = WireMessage {

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -521,12 +521,13 @@ impl PeerSession {
         let Some((peer_addr, tx_bytes, chunk_hash_prevalidated)) = pending else {
             return DaPrefetchFollowup::None;
         };
-        let da_id = pending_da_tx_da_id(&tx_bytes);
         let Ok(mut da_relay) = da_relay.lock() else {
             self.peer.last_error = "da relay state poisoned; peer-tx staging skipped".to_string();
             return DaPrefetchFollowup::None;
         };
-        let staging =
+        // Single parse: the staging call returns the schedulable da_id (commit-
+        // commitment gated) so we feed finish_da_prefetch without re-parsing.
+        let (da_id, staging) =
             da_relay.stage_relay_da_tx_bytes_checked(&peer_addr, tx_bytes, chunk_hash_prevalidated);
         drop(da_relay);
         if let Err(ref err) = staging {
@@ -2412,17 +2413,6 @@ fn now_nanos() -> u64 {
         .get_or_init(std::time::Instant::now)
         .elapsed()
         .as_nanos() as u64
-}
-
-/// The DA id of a staged DA relay tx that should drive prefetch, or None for a
-/// non-DA tx. A commit only counts with a well-formed DA_COMMIT covenant (mirror
-/// of Go stageRelayDACommitTx returning before finishDAPrefetch when not ok).
-fn pending_da_tx_da_id(tx_bytes: &[u8]) -> Option<[u8; 32]> {
-    let (tx, ..) = parse_tx(tx_bytes).ok()?;
-    if let Some(da_id) = tx.da_commit_core.as_ref().map(|core| core.da_id) {
-        return crate::da_relay::relay_da_commit_payload_commitment(&tx).map(|_| da_id);
-    }
-    tx.da_chunk_core.map(|core| core.da_id)
 }
 
 /// Enumerate DA prefetch peers from a PeerManager snapshot (mirror of Go
@@ -4429,16 +4419,8 @@ mod tests {
             map_off.is_empty() && keys_off.is_empty(),
             "the disabled local gate yields no prefetch peers"
         );
-        // (c) A non-DA tx carries no DA id, so the apply_pending hook yields None
-        // and never schedules (the DA-tx -> Some path is covered by every schedule
-        // test above, which routes a staged chunk through to a getdachunk request).
-        let (mut plain, ..) =
-            parse_tx(&relay_da_chunk_tx([9u8; 32], b"x")).expect("parse DA chunk tx");
-        plain.tx_kind = 0x00;
-        plain.da_chunk_core = None;
-        plain.da_payload = Vec::new();
-        let plain_bytes = rubin_consensus::marshal_tx(&plain).expect("marshal non-DA tx");
-        assert_eq!(pending_da_tx_da_id(&plain_bytes), None);
+        // The non-DA / malformed-commit -> no-schedulable-da_id path (so apply_pending
+        // never schedules) is covered by da_relay::stage_returns_schedulable_da_id.
     }
 
     #[test]

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -570,8 +570,9 @@ impl PeerSession {
         let Ok(mut prefetch) = prefetch.lock() else {
             return;
         };
-        // Always plan (even for empty missing / no peers): plan_da_prefetch expires
-        // stale sets and releases the reservation, as Go planDAPrefetch does.
+        // Always plan (even for empty missing / no peers): plan_da_prefetch runs the
+        // release_expired + release-on-empty-missing + release-fulfilled cleanup that
+        // Go planDAPrefetch does before reserving; an empty peer set reserves nothing.
         let (plans, diagnostic) = prefetch.plan_da_prefetch(da_id, &missing, &keys, now_nanos());
         // Surface the planner diagnostic to the trigger peer (mirror Go
         // reportDAPrefetchDiagnostic; its keys[0] is the trigger after prefer).
@@ -1018,8 +1019,8 @@ impl PeerSession {
         let outcome = self.collect_live_responses(msg, sync_engine, relay_ctx)?;
         let pending_da_relay_staging = self.take_pending_da_relay_staging();
         if let Some(ctx) = relay_ctx {
-            // Live inbound prefetch is driven from p2p_service::handle_peer; the only
-            // caller here (block-sync) passes relay_ctx=None, so this stages only.
+            // Block-sync, the only caller, passes relay_ctx=None, so this block is
+            // skipped; live inbound prefetch is driven from p2p_service::handle_peer.
             let _ = self.apply_pending_da_relay_staging(ctx.da_relay, pending_da_relay_staging);
         }
         for response in outcome.responses {

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -558,6 +558,7 @@ impl PeerSession {
         };
         let missing = {
             let Ok(relay) = da_relay.lock() else {
+                self.peer.last_error = "da relay state poisoned; prefetch skipped".to_string();
                 return;
             };
             relay.missing_chunk_indexes(da_id)
@@ -568,11 +569,12 @@ impl PeerSession {
             trigger_peer_addr,
         );
         let Ok(mut prefetch) = prefetch.lock() else {
+            self.peer.last_error = "da prefetch state poisoned; prefetch skipped".to_string();
             return;
         };
-        // Always plan (even for empty missing / no peers): plan_da_prefetch runs the
-        // release_expired + release-on-empty-missing + release-fulfilled cleanup that
-        // Go planDAPrefetch does before reserving; an empty peer set reserves nothing.
+        // Always call plan_da_prefetch (Go scheduleDAPrefetch does too): it expires +
+        // releases fulfilled reservations, releases the set only when missing is empty,
+        // and reserves nothing when there are no peers.
         let (plans, diagnostic) = prefetch.plan_da_prefetch(da_id, &missing, &keys, now_nanos());
         // Surface the planner diagnostic to the trigger peer (mirror Go
         // reportDAPrefetchDiagnostic; its keys[0] is the trigger after prefer).
@@ -2401,12 +2403,15 @@ pub fn decode_getdachunk_payload(payload: &[u8]) -> io::Result<GetDAChunkPayload
     })
 }
 
-/// Wall-clock nanoseconds for prefetch reservation TTLs.
+/// Monotonic nanoseconds for prefetch reservation TTLs (the planner does only
+/// relative `now >= expires` comparisons), immune to wall-clock jumps.
 fn now_nanos() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_nanos() as u64)
-        .unwrap_or(0)
+    use std::sync::OnceLock;
+    static START: OnceLock<std::time::Instant> = OnceLock::new();
+    START
+        .get_or_init(std::time::Instant::now)
+        .elapsed()
+        .as_nanos() as u64
 }
 
 /// The DA id of a staged DA relay tx that should drive prefetch, or None for a

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -530,8 +530,12 @@ impl PeerSession {
         let (da_id, staging) =
             da_relay.stage_relay_da_tx_bytes_checked(&peer_addr, tx_bytes, chunk_hash_prevalidated);
         drop(da_relay);
+        // A payload-commitment mismatch is the recoverable snapshot-reschedule case
+        // (Go does not surface it as a peer error); only genuine failures record it.
         if let Err(ref err) = staging {
-            self.peer.last_error = format!("DA relay tx staging failed: {err:?}");
+            if !matches!(err, crate::da_relay::DaRelayError::PayloadCommitmentMismatch) {
+                self.peer.last_error = format!("DA relay tx staging failed: {err:?}");
+            }
         }
         match da_id {
             Some(id) => finish_da_prefetch(id, staging),

--- a/clients/rust/crates/rubin-node/src/p2p_service.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_service.rs
@@ -6,6 +6,7 @@ use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
+use crate::da_prefetch::DaRelayPrefetchState;
 use crate::da_relay::{
     CompleteDaSetCandidate, CompleteDaSetProvider, DaRelayCaps, DaRelayState, PeerQuotaKey,
 };
@@ -86,6 +87,7 @@ struct SharedServiceState {
     sync_engine: Arc<Mutex<SyncEngine>>,
     tx_pool: Arc<Mutex<TxPool>>,
     da_relay: Arc<Mutex<DaRelayState>>,
+    prefetch_state: Arc<Mutex<DaRelayPrefetchState>>,
     bootstrap_peers: Arc<Vec<String>>,
     bootstrap_rotate_idx: Arc<AtomicUsize>,
     in_flight_dials: Arc<Mutex<HashSet<String>>>,
@@ -191,6 +193,7 @@ pub fn start_node_p2p_service(cfg: NodeP2PServiceConfig) -> Result<RunningNodeP2
         sync_engine: cfg.sync_engine,
         tx_pool: cfg.tx_pool,
         da_relay,
+        prefetch_state: Arc::new(Mutex::new(DaRelayPrefetchState::default())),
         bootstrap_peers: Arc::new(cfg.bootstrap_peers),
         bootstrap_rotate_idx: Arc::new(AtomicUsize::new(0)),
         in_flight_dials: Arc::new(Mutex::new(HashSet::new())),
@@ -903,6 +906,7 @@ fn handle_peer(
         peer_writers: &shared.peer_outboxes,
         tx_pool: &shared.tx_pool,
         da_relay: &shared.da_relay,
+        prefetch: &shared.prefetch_state,
     };
 
     {
@@ -973,7 +977,20 @@ fn handle_peer(
                 &shared,
                 tx_pool_cleanup,
             )?);
-            session.apply_pending_da_relay_staging(&shared.da_relay, pending_da_relay_staging);
+            // Stage the peer DA tx, then drive prefetch from the followup (mirror of
+            // Go handleTx -> stageRelayDATx -> finishDAPrefetch -> scheduleDAPrefetch).
+            // Engine lock is already dropped; schedule's lock order holds since
+            // apply_pending releases the da_relay lock before returning.
+            let followup = session
+                .apply_pending_da_relay_staging(relay_ctx.da_relay, pending_da_relay_staging);
+            session.schedule_da_prefetch(
+                followup,
+                relay_ctx.da_relay,
+                relay_ctx.prefetch,
+                relay_ctx.peer_manager,
+                relay_ctx.peer_writers,
+                relay_ctx.peer_registered_addr,
+            );
             responses
         };
         for outbound in outbound_messages {
@@ -1528,6 +1545,9 @@ mod tests {
             da_relay: Arc::new(Mutex::new(
                 crate::da_relay::DaRelayState::new(crate::da_relay::DaRelayCaps::default())
                     .expect("valid DA relay caps"),
+            )),
+            prefetch_state: Arc::new(Mutex::new(
+                crate::da_prefetch::DaRelayPrefetchState::default(),
             )),
             bootstrap_peers: Arc::new(bootstrap_peers),
             bootstrap_rotate_idx: Arc::new(AtomicUsize::new(0)),


### PR DESCRIPTION
Invariant: after a DA commit/chunk tx is staged on the live inbound handler, the Rust node re-plans and sends `getdachunk` prefetch requests to connected compact-receiving peers (host-only quota keys, trigger-preferred order), surfacing the planner diagnostic to the trigger peer. Mirror of Go `handleTx -> stageRelayDATx -> finishDAPrefetch -> scheduleDAPrefetch` (`clients/go/node/p2p/{handlers_tx,da_relay_ingest,da_relay_state}.go`).

Chain finale: this wires the merged RUB-415 send/finish primitives and the RUB-404 bounded planner into the production runtime and removes the last `#[allow(dead_code)]` on the prefetch chain.

Scope:
- `clients/rust/crates/rubin-node/src/p2p_service.rs`: `handle_peer` (the production inbound loop) drives `schedule_da_prefetch` from the `apply_pending_da_relay_staging` followup; owns `DaRelayPrefetchState` in `SharedServiceState`, threaded through `PeerRelayContext`.
- `clients/rust/crates/rubin-node/src/p2p_runtime.rs`: `schedule_da_prefetch` (enumerate → plan → send, diagnostic → trigger `last_error`), `da_prefetch_peers` / `prefer_da_prefetch_peer`, `now_nanos` (monotonic TTL); `apply_pending_da_relay_staging` drives `finish_da_prefetch` from the staging-returned da_id (single parse); removes the RUB-415 dead-code allows.
- `clients/rust/crates/rubin-node/src/da_relay.rs`: `missing_chunk_indexes` (state + record), `PeerQuotaKey::as_str`; `stage_relay_da_tx_bytes_checked` returns the schedulable da_id from one parse (commit gated on a well-formed DA_COMMIT covenant); a `#[cfg(test)]` commit-staging helper.
- No provider/miner, no txpool admission, no compact-block runtime change, no consensus/wire/spec/Go change.

Lock order (documented, deadlock-free vs the broadcast path): `da_relay -> drop -> peer_manager.snapshot() -> prefetch -> peer_writers`; entered only after the staging `da_relay` lock and the engine lock are dropped.

Parity Matrix:
| Required parity case | Go callsite | Rust entrypoint | Rust mirror test evidence |
| -- | -- | -- | -- |
| case: staging a DA tx schedules getdachunk to enumerated compact peers | `clients/go/node/p2p/da_relay_state.go::scheduleDAPrefetch` (via `da_relay_ingest.go::finishDAPrefetch`, `handlers_tx.go::handleTx`) | `p2p_service.rs::handle_peer` + `p2p_runtime.rs::schedule_da_prefetch` | `schedule_da_prefetch_requests_live_missing_chunks` (request union == still-missing indexes) |
| case: payload-commitment mismatch re-schedules from a fresh snapshot | `clients/go/node/p2p/da_relay_ingest.go::finishDAPrefetch` (mismatch → `scheduleDAPrefetchSnapshot`) | `p2p_runtime.rs::finish_da_prefetch` → `ScheduleSnapshot` | `schedule_da_prefetch_requests_live_missing_chunks` (snapshot arm re-plans live missing) |
| case: prefetch peers are host-only quota keys, sorted, trigger-preferred | `clients/go/node/p2p/da_relay_state.go::allDAPrefetchPeersLocked` / `daPrefetchPeers` / `preferDAPrefetchPeer` | `p2p_runtime.rs::da_prefetch_peers` / `prefer_da_prefetch_peer` | `da_prefetch_peers_collapses_host_and_prefers_trigger` (two ports collapse, non-compact dropped, trigger first) |
| case: planner diagnostic surfaces to the trigger peer | `clients/go/node/p2p/da_relay_state.go::reportDAPrefetchDiagnostic` (`keys[0]` is the trigger after prefer) | `p2p_runtime.rs::schedule_da_prefetch` (diagnostic → `self.peer.last_error`) | `schedule_da_prefetch_surfaces_planner_diagnostic` (per-peer cap → diagnostic on trigger) |
| case: malformed-commitment commit and non-DA / disabled-gate do not schedule | `clients/go/node/p2p/da_relay_ingest.go::stageRelayDACommitTx` (returns before `finishDAPrefetch` when `daRelayCommitPayloadCommitment` is not ok) | `da_relay.rs::stage_relay_da_tx_bytes_checked` (returns a `None` da_id for a malformed-commit / non-DA tx) | `stage_returns_schedulable_da_id` (chunk/valid-commit → Some, malformed-commit/non-DA → None) + `schedule_da_prefetch_is_noop_without_da_or_gate` (None followup / disabled gate) |
| case: no provider/miner/txpool/compact-runtime/Go changes | n/a (scope guard) | three-file prefetch wiring only | `schedule_da_prefetch_is_noop_without_da_or_gate` + three-file diff |

Evidence:
- `cd clients/rust && cargo test -p rubin-node da_prefetch --lib` — PASS (17); `cargo test -p rubin-node p2p_runtime --lib` — PASS (73)
- full suite `cargo test -p rubin-node` — PASS (772 lib + 69 + 3)
- `cargo clippy --workspace --all-targets -- -D warnings` — PASS; `cargo fmt --check` clean
- core + tooling (`--allow-rust --serial-rust-tests`) + coverage + delta receipts — PASS; review fanout BYPASSED (controller-approved, Rust parity/thaw class)
- adversarial multi-agent verification (parity / scope / concurrency-deadlock / edge lenses) found the production-wiring gap (`handle_peer` discarded the followup) and the commit-commitment gate; both fixed and re-verified (deadlock / regression / gate-correctness → all `fix_correct`).
- single-parse DA-staging refactor (folded in per PR review) adversarially verified behavior-equivalent (equivalence / caller-safety / parity lenses → all `equivalent_correct`).

LOC: net +387 incl tests (target 260, max 380; the +7 over the soft max is folded-in review work the controller chose to land in this PR — monotonic TTL clock, lock-poison and payload-mismatch `last_error` semantics, and a single-parse staging refactor). The size is the cross-file invariant wiring (production handler + enumeration + ingest hook) plus its parity tests, the Copilot-requested robustness fixes, and a net-LOC-neutral single-parse staging refactor (removes a second `parse_tx` on the hot path and narrows the surface by deleting `pending_da_tx_da_id` and reverting `relay_da_commit_payload_commitment` to private); no forbidden surface (provider/miner/compact-runtime) is touched, so the contract's stop-and-split condition does not apply.

Compatibility: additive; mirrors Go's staging→prefetch path exactly. Completes the Rust DA-relay prefetch chain (RUB-403 wire → RUB-404 planner → RUB-415 send/finish → RUB-439 PeerState compact mode → RUB-440 enumeration + schedule + ingest hook).

Linear: RUB-440

🤖 Generated with [Claude Code](https://claude.com/claude-code)
