### PR TITLE
node(rust): ratify provider parse-error abort policy + parity test (RUB-423)

### DIFF
--- a/clients/rust/crates/rubin-node/src/miner.rs
+++ b/clients/rust/crates/rubin-node/src/miner.rs
@@ -328,6 +328,12 @@ impl<'a> Miner<'a> {
             if group_len > max_selected - parsed.len() {
                 continue;
             }
+            // RUB-423 decision: a parse error here ABORTS template construction
+            // (mirror of Go miner.go selectCandidateTransactions returning the error),
+            // it is not skipped — the complete-DA-set provider is the node's own
+            // trusted source, so a non-canonical candidate is an internal invariant
+            // violation handled fail-closed, not a provider-induced template DoS. An
+            // invalid *shape* with no parse error (Ok(None)) is still skipped below.
             let group = parse_complete_da_set_candidate(&set)?;
             #[rustfmt::skip]
             let Some(group) = group else { continue; };
@@ -1142,6 +1148,20 @@ mod tests {
         assert_eq!(
             parse_complete_da_set_candidate(&malformed_commit).unwrap_err(),
             "non-canonical tx bytes in miner input"
+        );
+    }
+
+    #[test]
+    fn miner_provider_parse_error_aborts_selection() {
+        // RUB-423 decision: a provider COMPLETE_SET parse error ABORTS the whole
+        // mining selection (mirror of Go selectCandidateTransactions returning the
+        // error), it is not skipped — provider raw is trusted internal input, so a
+        // non-canonical candidate is fail-closed, not a provider-induced template DoS.
+        let mut malformed = miner_da_provider_shape_set([0x82; 32], &[b"chunk-0"]);
+        malformed.commit_tx.push(0); // trailing byte -> non-canonical parse error
+        assert_eq!(
+            s(vec![malformed], HashMap::new(), MinerConfig::default()).unwrap_err(),
+            "non-canonical tx bytes in miner input",
         );
     }
 


### PR DESCRIPTION
Decision (controller-ratified): a complete-DA-set provider COMPLETE_SET candidate **parse error ABORTS** mining template construction (Go/Rust parity); an invalid *shape* with no parse error is still skipped. This ratifies the existing Go + Rust behavior — **no behavior change, no Go change**.

Rationale: the complete-DA-set provider is the node's own trusted component (`p2p_service::ServiceCompleteDaSetProvider`, assembled from already-admitted, structurally-validated relayed DA txs). A non-canonical/unparseable candidate is therefore an internal invariant violation handled fail-closed — not untrusted external input — so the "provider-induced template DoS" argument for *skip* does not apply. Skip was rejected.

Scope: `clients/rust/crates/rubin-node/src/miner.rs` only — a decision comment at the abort site and one end-to-end parity test. No provider/group selection, DA relay state, live-wiring, txpool, compact-runtime, consensus, fixture, or Go reference change.

Parity Matrix:
| Required parity case | Go reference | Rust entrypoint | Rust mirror test |
| -- | -- | -- | -- |
| provider parse-error aborts mining selection | `clients/go/node/miner.go::selectCandidateTransactions` (`parseCompleteDASetCandidate` err → `return nil, err`) | `miner.rs::select_candidate_transactions` (`parse_complete_da_set_candidate(&set)?`) | `miner_provider_parse_error_aborts_selection` (malformed provider raw → `Err("non-canonical tx bytes in miner input")` end-to-end) |
| invalid-shape (no parse error) is skipped, not aborted | `selectCandidateTransactions` (`ok == false` → `continue`) | `miner.rs::select_candidate_transactions` (`Ok(None)` → `continue`) | `validate_complete_da_set_candidate_shape` + `miner_da_provider_selection_bounds_matrix` (existing) |

Evidence:
- `cd clients/rust && cargo test -p rubin-node miner --lib` — PASS (29, incl. the new `miner_provider_parse_error_aborts_selection`)
- full suite `cargo test -p rubin-node` — PASS (776 lib + 69 + 3)
- `cargo clippy --workspace --all-targets -- -D warnings` — PASS; `cargo fmt --check` clean
- core (scope-contract-invariants normalized) + tooling + coverage + delta receipts — PASS; review fanout BYPASSED (controller-approved, Rust parity/thaw class)

Go side: unchanged — `clients/go/node/miner.go` already aborts on the provider parse error and already has an end-to-end abort test (`miner_da_flat_filter_test.go` — "expected malformed provider raw error"), so Go already matches the decision. The pre-existing Rust `miner_da_provider_shape_malformed_raw_errors` covers the parse-function level; this slice adds the missing end-to-end selection-abort coverage for Rust.

LOC: +14 net incl test. RUB-407 / PR #1923 unaffected.

Linear: RUB-423

🤖 Generated with [Claude Code](https://claude.com/claude-code)
