### PR TITLE
node(rust): add in-process signed DA commit/chunk tx source (RUB-442)

### DIFF
--- a/clients/rust/crates/rubin-node/src/bin/rust-da-txgen.rs
+++ b/clients/rust/crates/rubin-node/src/bin/rust-da-txgen.rs
@@ -1,0 +1,139 @@
+//! Devnet-only signed DA tx source for `scripts/devnet-rust-da-relay.sh`
+//! (RUB-442, `Q-RUST-DA-SIGNED-TX-SOURCE-01`).
+//!
+//! Usage: `rust-da-txgen [--] <datadir> [mine_blocks]`
+//!
+//! `--` terminates flag parsing so a datadir path beginning with `-` is
+//! accepted; unknown `-`-prefixed flags are rejected.
+//!
+//! Mines a fresh base chain into `<datadir>` paying an ephemeral in-process
+//! devnet keypair, then emits a JSON object of signed DA txs
+//! (`{da_id, chunk0, commit, duplicate_commit, chunk1: {hex, txid}}`) to stdout.
+//! The keypair is generated, used for mining and signing, and discarded within
+//! this one process, so no key material crosses a process boundary or touches
+//! disk. `mine_blocks` defaults to the matured base height used by the relay
+//! smoke.
+
+use std::env;
+use std::io::{self, Write};
+use std::path::PathBuf;
+use std::process;
+
+use rubin_node::da_txgen::{mine_and_generate, DA_RELAY_BASE_HEIGHT};
+
+const PROGRAM: &str = "rust-da-txgen";
+
+fn usage() -> String {
+    format!("usage: {PROGRAM} [--] <datadir> [mine_blocks]")
+}
+
+/// Strict positional parse: `-h`/`--help` print usage; any other `-`-prefixed
+/// token before `--` is an error rather than being silently dropped; `--`
+/// terminates flag parsing so a datadir path beginning with `-` is accepted.
+/// Returns the (datadir, mine_blocks) pair, or `Ok(None)` when help was shown.
+fn parse_args(args: &[String]) -> Result<Option<(PathBuf, u64)>, String> {
+    let mut positional: Vec<&str> = Vec::with_capacity(2);
+    let mut flags_done = false;
+    for arg in args {
+        if flags_done {
+            positional.push(arg);
+            continue;
+        }
+        match arg.as_str() {
+            "--" => flags_done = true,
+            "-h" | "--help" => {
+                println!("{}", usage());
+                return Ok(None);
+            }
+            _ if arg.starts_with('-') => return Err(format!("unknown flag {arg}\n{}", usage())),
+            _ => positional.push(arg),
+        }
+    }
+    if positional.is_empty() || positional.len() > 2 {
+        return Err(usage());
+    }
+    let datadir = PathBuf::from(positional[0]);
+    let mine_blocks = match positional.get(1) {
+        Some(value) => value
+            .parse::<u64>()
+            .map_err(|_| format!("invalid mine_blocks: {value}"))?,
+        None => DA_RELAY_BASE_HEIGHT,
+    };
+    Ok(Some((datadir, mine_blocks)))
+}
+
+fn run(args: &[String]) -> Result<(), String> {
+    let Some((datadir, mine_blocks)) = parse_args(args)? else {
+        return Ok(());
+    };
+    let set = mine_and_generate(&datadir, mine_blocks)?;
+    let mut stdout = io::stdout();
+    serde_json::to_writer(&mut stdout, &set.to_json())
+        .map_err(|err| format!("encode DA txs json: {err}"))?;
+    writeln!(stdout).map_err(|err| err.to_string())?;
+    Ok(())
+}
+
+fn main() {
+    let args: Vec<String> = env::args().skip(1).collect();
+    if let Err(err) = run(&args) {
+        let _ = writeln!(io::stderr(), "{err}");
+        process::exit(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_args, DA_RELAY_BASE_HEIGHT};
+    use std::path::PathBuf;
+
+    fn args(items: &[&str]) -> Vec<String> {
+        items.iter().map(|s| (*s).to_string()).collect()
+    }
+
+    #[test]
+    fn datadir_only_defaults_mine_blocks() {
+        let parsed = parse_args(&args(&["/tmp/dd"])).expect("ok").expect("some");
+        assert_eq!(parsed, (PathBuf::from("/tmp/dd"), DA_RELAY_BASE_HEIGHT));
+    }
+
+    #[test]
+    fn datadir_and_mine_blocks() {
+        let parsed = parse_args(&args(&["/tmp/dd", "12"]))
+            .expect("ok")
+            .expect("some");
+        assert_eq!(parsed, (PathBuf::from("/tmp/dd"), 12));
+    }
+
+    #[test]
+    fn unknown_flag_is_rejected_not_dropped() {
+        let err = parse_args(&args(&["--foo", "/tmp/dd"])).expect_err("must reject");
+        assert!(err.contains("unknown flag --foo"), "got: {err}");
+    }
+
+    #[test]
+    fn double_dash_allows_dash_prefixed_datadir() {
+        let parsed = parse_args(&args(&["--", "-weird-path"]))
+            .expect("ok")
+            .expect("some");
+        assert_eq!(parsed, (PathBuf::from("-weird-path"), DA_RELAY_BASE_HEIGHT));
+    }
+
+    #[test]
+    fn help_returns_none() {
+        assert!(parse_args(&args(&["--help"])).expect("ok").is_none());
+        assert!(parse_args(&args(&["-h"])).expect("ok").is_none());
+    }
+
+    #[test]
+    fn missing_and_excess_positionals_are_errors() {
+        assert!(parse_args(&args(&[])).is_err());
+        assert!(parse_args(&args(&["a", "b", "c"])).is_err());
+    }
+
+    #[test]
+    fn invalid_mine_blocks_is_an_error() {
+        let err = parse_args(&args(&["/tmp/dd", "nope"])).expect_err("must reject");
+        assert!(err.contains("invalid mine_blocks"), "got: {err}");
+    }
+}

--- a/clients/rust/crates/rubin-node/src/da_txgen.rs
+++ b/clients/rust/crates/rubin-node/src/da_txgen.rs
@@ -1,0 +1,510 @@
+//! Deterministic in-process signed DA tx source for the devnet DA relay
+//! process smoke (`scripts/devnet-rust-da-relay.sh`).
+//!
+//! RUB-442 (`Q-RUST-DA-SIGNED-TX-SOURCE-01`). The Go devnet DA relay smoke
+//! (`scripts/devnet-go-da-relay.sh`) generates its signed DA commit/chunk txs
+//! with a throwaway `go run` helper that exports the mining keypair as DER and
+//! re-imports it to sign coinbase spends across a keygen -> mine -> sign process
+//! boundary. The Rust `Mldsa87Keypair` exposes neither a DER export nor a
+//! seed/from-bytes constructor (only OpenSSL random `generate()`), so the same
+//! key cannot be reconstructed in a second process. This module closes that gap
+//! in the only way available without introducing a new crypto path: it does
+//! keygen + mine + sign **in one process**, so the single keypair never leaves
+//! memory.
+//!
+//! Scope is the DA tx *source* only: it produces one `DA_COMMIT` tx and two
+//! `DA_CHUNK` txs (plus the Go-parity duplicate commit) that pass Rust canonical
+//! tx admission. Driving the two-node relay -> complete-set -> mine scenario to
+//! a PASS verdict is the follow-up RUB-443.
+//!
+//! Non-scope (mirrors the Linear issue): no consensus changes, no Go changes,
+//! no P2P protocol changes, no DA economics, no DA ticket gate, no production
+//! wallet/key generation. The key material is devnet-only and ephemeral.
+
+use std::fs;
+use std::path::Path;
+
+use rubin_consensus::constants::{
+    COINBASE_MATURITY, COV_TYPE_DA_COMMIT, COV_TYPE_P2PK, TX_WIRE_VERSION,
+};
+use rubin_consensus::{
+    marshal_tx, p2pk_covenant_data_for_pubkey, parse_tx, sign_transaction, DaChunkCore,
+    DaCommitCore, Mldsa87Keypair, Outpoint, Tx, TxInput, TxOutput,
+};
+use sha3::{Digest, Sha3_256};
+
+use crate::blockstore::{block_store_path, BlockStore};
+use crate::chainstate::{chain_state_path, load_chain_state, ChainState};
+use crate::genesis::load_genesis_config;
+use crate::miner::{Miner, MinerConfig};
+use crate::sync::{default_sync_config, SyncEngine};
+use crate::txpool::{TxPool, TxPoolConfig};
+
+/// Base chain height mined before generating the DA set. Mirrors the Go relay
+/// smoke (`BASE_HEIGHT=105`): enough confirmations that the early coinbase
+/// outputs spent by the DA txs are mature (`COINBASE_MATURITY = 100`).
+pub const DA_RELAY_BASE_HEIGHT: u64 = 105;
+
+/// Number of mature coinbase outputs the DA set spends: chunk0, commit,
+/// duplicate commit, chunk1 — each from a distinct coinbase, mirroring the Go
+/// helper's four-coin selection.
+const DA_SET_COIN_COUNT: usize = 4;
+
+// Deterministic fixture material. The byte labels are identical to the Go relay
+// smoke so both clients exercise the same DA identity/payloads; the txids still
+// differ per run because the signing key is freshly generated.
+const DA_ID_LABEL: &[u8] = b"rubin-da-relay-process-smoke-da-id";
+const PAYLOAD_0: &[u8] = b"rubin-da-relay-process-smoke-0";
+const PAYLOAD_1: &[u8] = b"rubin-da-relay-process-smoke-1";
+const REPLACEMENT_PAYLOAD: &[u8] = b"rubin-da-relay-replacement";
+const BATCH_SIG_LABEL: &[u8] = b"rubin-da-relay-process-smoke-batch-sig";
+
+// DA commit manifest body (`da_payload` for tx_kind=0x01). Matches the Go
+// helper's single opaque byte; the consensus rules only bound its length.
+const DA_COMMIT_MANIFEST: &[u8] = &[0xa1];
+
+// RETL batch header fields carried in `DaCommitCore`. These reuse the canonical
+// in-repo Rust DA-commit fixture values (`main.rs` local DA commit builder and
+// `da_relay.rs` relay_commit_core): retl_domain_id=0x10.., roots=0x11../0x12../
+// 0x13.., batch_number=1. They are opaque to tx admission (DA economics /
+// settlement semantics are out of scope) but are populated deterministically as
+// the issue's fixture shape requires rather than left zero.
+const RETL_DOMAIN_ID: [u8; 32] = [0x10; 32];
+const TX_DATA_ROOT: [u8; 32] = [0x11; 32];
+const STATE_ROOT: [u8; 32] = [0x12; 32];
+const WITHDRAWALS_ROOT: [u8; 32] = [0x13; 32];
+const BATCH_NUMBER: u64 = 1;
+/// `batch_sig_suite` for the fixture. Suite 0 with an opaque (here, non-empty)
+/// `batch_sig` blob matches existing in-repo usage; admission treats the blob as
+/// opaque and only bounds its length.
+const BATCH_SIG_SUITE: u8 = 0;
+
+// tx_nonce values, identical to the Go helper (chunk0/commit/duplicate/chunk1).
+const NONCE_CHUNK_0: u64 = 3201;
+const NONCE_COMMIT: u64 = 3202;
+const NONCE_DUPLICATE: u64 = 3203;
+const NONCE_CHUNK_1: u64 = 3204;
+
+const DA_CHUNK_COUNT: u16 = 2;
+
+fn sha3_256(bytes: &[u8]) -> [u8; 32] {
+    let mut hasher = Sha3_256::new();
+    hasher.update(bytes);
+    hasher.finalize().into()
+}
+
+/// Deterministic da_id shared by the whole set.
+pub fn fixture_da_id() -> [u8; 32] {
+    sha3_256(DA_ID_LABEL)
+}
+
+/// Deterministic opaque batch signature blob (devnet fixture only).
+fn fixture_batch_sig() -> Vec<u8> {
+    sha3_256(BATCH_SIG_LABEL).to_vec()
+}
+
+/// One signed DA transaction: canonical wire bytes plus its txid.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SignedDaTx {
+    pub raw: Vec<u8>,
+    pub txid: [u8; 32],
+}
+
+impl SignedDaTx {
+    pub fn hex(&self) -> String {
+        hex::encode(&self.raw)
+    }
+
+    pub fn txid_hex(&self) -> String {
+        hex::encode(self.txid)
+    }
+}
+
+/// A complete signed DA set for the relay smoke: the commit, both chunks, and
+/// the duplicate commit (used by the relay first-seen-no-replacement evidence
+/// path). The complete, internally consistent set is `commit` + `chunk0` +
+/// `chunk1`; `duplicate_commit` is an alternate commit over the same da_id.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SignedDaSet {
+    pub da_id: [u8; 32],
+    pub commit: SignedDaTx,
+    pub chunk0: SignedDaTx,
+    pub chunk1: SignedDaTx,
+    pub duplicate_commit: SignedDaTx,
+}
+
+impl SignedDaSet {
+    /// JSON carrying the Go helper's `da-txs.json` keys
+    /// (`{chunk0,commit,duplicate_commit,chunk1: {hex, txid}}`) so the shell
+    /// harness can consume either client's output with one keyed parser,
+    /// plus an additive top-level `da_id` field (not present in the Go
+    /// output) for downstream relay wiring.
+    pub fn to_json(&self) -> serde_json::Value {
+        let entry = |tx: &SignedDaTx| serde_json::json!({"hex": tx.hex(), "txid": tx.txid_hex()});
+        serde_json::json!({
+            "da_id": hex::encode(self.da_id),
+            "chunk0": entry(&self.chunk0),
+            "commit": entry(&self.commit),
+            "duplicate_commit": entry(&self.duplicate_commit),
+            "chunk1": entry(&self.chunk1),
+        })
+    }
+}
+
+/// Select `count` mature coinbase P2PK outputs paying to `mine_covenant_data`,
+/// in a deterministic order (by outpoint). Mirrors the Go helper's `selectCoins`
+/// maturity + ownership filter. Errors if too few mature coins exist.
+pub fn select_mature_p2pk_coinbases(
+    state: &ChainState,
+    mine_covenant_data: &[u8],
+    next_height: u64,
+    count: usize,
+) -> Result<Vec<Outpoint>, String> {
+    let mut coins: Vec<Outpoint> = state
+        .utxos
+        .iter()
+        .filter(|(_, entry)| {
+            entry.created_by_coinbase
+                && entry.covenant_type == COV_TYPE_P2PK
+                && entry.covenant_data.as_slice() == mine_covenant_data
+                && entry
+                    .creation_height
+                    .checked_add(COINBASE_MATURITY)
+                    .is_some_and(|mature_at| next_height >= mature_at)
+        })
+        .map(|(outpoint, _)| outpoint.clone())
+        .collect();
+    // Deterministic selection given a fixed chain state.
+    coins.sort_by(|a, b| a.txid.cmp(&b.txid).then(a.vout.cmp(&b.vout)));
+    if coins.len() < count {
+        return Err(format!(
+            "need {count} mature P2PK coinbase outputs, have {}",
+            coins.len()
+        ));
+    }
+    coins.truncate(count);
+    Ok(coins)
+}
+
+fn da_input(coin: &Outpoint) -> TxInput {
+    TxInput {
+        prev_txid: coin.txid,
+        prev_vout: coin.vout,
+        script_sig: Vec::new(),
+        sequence: 0,
+    }
+}
+
+fn da_commit_core(da_id: [u8; 32]) -> DaCommitCore {
+    DaCommitCore {
+        da_id,
+        chunk_count: DA_CHUNK_COUNT,
+        retl_domain_id: RETL_DOMAIN_ID,
+        batch_number: BATCH_NUMBER,
+        tx_data_root: TX_DATA_ROOT,
+        state_root: STATE_ROOT,
+        withdrawals_root: WITHDRAWALS_ROOT,
+        batch_sig_suite: BATCH_SIG_SUITE,
+        batch_sig: fixture_batch_sig(),
+    }
+}
+
+/// Build an unsigned `DA_COMMIT` tx (tx_kind=0x01). The single
+/// `COV_TYPE_DA_COMMIT` output carries the 32-byte payload commitment
+/// `sha3_256(payload)`; the commit spends `coin` entirely as fee.
+fn build_da_commit(coin: &Outpoint, da_id: [u8; 32], nonce: u64, payload: &[u8]) -> Tx {
+    let commitment = sha3_256(payload);
+    Tx {
+        version: TX_WIRE_VERSION,
+        tx_kind: 0x01,
+        tx_nonce: nonce,
+        inputs: vec![da_input(coin)],
+        outputs: vec![TxOutput {
+            value: 0,
+            covenant_type: COV_TYPE_DA_COMMIT,
+            covenant_data: commitment.to_vec(),
+        }],
+        locktime: 0,
+        da_commit_core: Some(da_commit_core(da_id)),
+        da_chunk_core: None,
+        witness: Vec::new(),
+        da_payload: DA_COMMIT_MANIFEST.to_vec(),
+    }
+}
+
+/// Build an unsigned `DA_CHUNK` tx (tx_kind=0x02). It carries the chunk payload
+/// in `da_payload` with `chunk_hash = sha3_256(payload)`, has no outputs, and
+/// spends `coin` entirely as fee (mirrors the Go helper's chunk shape).
+fn build_da_chunk(coin: &Outpoint, da_id: [u8; 32], nonce: u64, index: u16, payload: &[u8]) -> Tx {
+    Tx {
+        version: TX_WIRE_VERSION,
+        tx_kind: 0x02,
+        tx_nonce: nonce,
+        inputs: vec![da_input(coin)],
+        outputs: Vec::new(),
+        locktime: 0,
+        da_commit_core: None,
+        da_chunk_core: Some(DaChunkCore {
+            da_id,
+            chunk_index: index,
+            chunk_hash: sha3_256(payload),
+        }),
+        witness: Vec::new(),
+        da_payload: payload.to_vec(),
+    }
+}
+
+/// Sign `tx`, marshal it, and confirm the result passes Rust canonical tx
+/// admission (`TxPool::admit`) — the same gate the relay `/submit_tx` path uses.
+/// Returns the canonical bytes + txid only if admission accepts.
+fn sign_marshal_admit(
+    mut tx: Tx,
+    state: &ChainState,
+    block_store: Option<&BlockStore>,
+    keypair: &Mldsa87Keypair,
+    chain_id: [u8; 32],
+) -> Result<SignedDaTx, String> {
+    sign_transaction(&mut tx, &state.utxos, chain_id, keypair).map_err(|err| err.to_string())?;
+    let raw = marshal_tx(&tx).map_err(|err| err.to_string())?;
+    let (_, txid, _, consumed) = parse_tx(&raw).map_err(|err| err.to_string())?;
+    if consumed != raw.len() {
+        return Err("generated non-canonical DA tx bytes".to_string());
+    }
+    let mut pool = TxPool::new_with_config(TxPoolConfig::default());
+    pool.admit(&raw, state, block_store, chain_id)
+        .map_err(|err| format!("DA tx failed canonical admission: {}", err.message))?;
+    Ok(SignedDaTx { raw, txid })
+}
+
+/// Build the complete signed DA set against a chain state that already holds
+/// mature coinbase outputs owned by `keypair`. `block_store` (when present) is
+/// used by admission for median-time-past; `chain_id` is the signing/admission
+/// chain id (devnet).
+pub fn build_signed_da_set(
+    state: &ChainState,
+    block_store: Option<&BlockStore>,
+    keypair: &Mldsa87Keypair,
+    chain_id: [u8; 32],
+) -> Result<SignedDaSet, String> {
+    let next_height = state
+        .height
+        .checked_add(1)
+        .ok_or_else(|| "chain height overflow".to_string())?;
+    let mine_covenant_data = p2pk_covenant_data_for_pubkey(&keypair.pubkey_bytes());
+    let coins =
+        select_mature_p2pk_coinbases(state, &mine_covenant_data, next_height, DA_SET_COIN_COUNT)?;
+
+    let da_id = fixture_da_id();
+    let mut full_payload = PAYLOAD_0.to_vec();
+    full_payload.extend_from_slice(PAYLOAD_1);
+
+    let sign = |tx| sign_marshal_admit(tx, state, block_store, keypair, chain_id);
+    let chunk0 = sign(build_da_chunk(
+        &coins[0],
+        da_id,
+        NONCE_CHUNK_0,
+        0,
+        PAYLOAD_0,
+    ))?;
+    let commit = sign(build_da_commit(
+        &coins[1],
+        da_id,
+        NONCE_COMMIT,
+        &full_payload,
+    ))?;
+    let duplicate_commit = sign(build_da_commit(
+        &coins[2],
+        da_id,
+        NONCE_DUPLICATE,
+        REPLACEMENT_PAYLOAD,
+    ))?;
+    let chunk1 = sign(build_da_chunk(
+        &coins[3],
+        da_id,
+        NONCE_CHUNK_1,
+        1,
+        PAYLOAD_1,
+    ))?;
+
+    Ok(SignedDaSet {
+        da_id,
+        commit,
+        chunk0,
+        chunk1,
+        duplicate_commit,
+    })
+}
+
+/// In-process keygen + mine + sign: mine `mine_blocks` base blocks into
+/// `data_dir` paying a fresh ephemeral devnet keypair, then build and return the
+/// signed DA set spending the matured coinbases. The keypair never leaves this
+/// process. Leaves a persisted devnet datadir (chainstate + blockstore) for
+/// downstream relay wiring (RUB-443).
+pub fn mine_and_generate(data_dir: &Path, mine_blocks: u64) -> Result<SignedDaSet, String> {
+    let genesis = load_genesis_config(None, "devnet")?;
+    let chain_id = genesis.chain_id;
+    let keypair = Mldsa87Keypair::generate().map_err(|err| err.to_string())?;
+    let mine_covenant_data = p2pk_covenant_data_for_pubkey(&keypair.pubkey_bytes());
+
+    fs::create_dir_all(data_dir)
+        .map_err(|err| format!("datadir create failed ({}): {err}", data_dir.display()))?;
+    let chain_state_file = chain_state_path(data_dir);
+    let chain_state = load_chain_state(&chain_state_file)?;
+    let block_store = BlockStore::open(block_store_path(data_dir))?;
+
+    let mut sync_cfg = default_sync_config(None, chain_id, Some(chain_state_file.clone()));
+    sync_cfg.core_ext_deployments = genesis.core_ext_deployments.clone();
+    sync_cfg.suite_context = genesis.suite_context.clone();
+    let mut sync_engine = SyncEngine::new(chain_state, Some(block_store), sync_cfg)?;
+
+    let miner_cfg = MinerConfig {
+        core_ext_deployments: genesis.core_ext_deployments.clone(),
+        mine_address: mine_covenant_data,
+        ..MinerConfig::default()
+    };
+    {
+        let mut miner = Miner::new(&mut sync_engine, None, miner_cfg)?;
+        let blocks = usize::try_from(mine_blocks)
+            .map_err(|_| "mine_blocks exceeds usize range".to_string())?;
+        miner.mine_n(blocks, &[])?;
+    }
+
+    // Persist the mined state and reopen independent handles so admission reads
+    // the same on-disk datadir a node would load.
+    sync_engine.chain_state.save(&chain_state_file)?;
+    let state = load_chain_state(&chain_state_file)?;
+    let block_store = BlockStore::open(block_store_path(data_dir))?;
+    build_signed_da_set(&state, Some(&block_store), &keypair, chain_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::da_relay::{DaRelayError, DaRelayState};
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    struct TempDir {
+        path: std::path::PathBuf,
+    }
+
+    impl TempDir {
+        fn new() -> Self {
+            let n = TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+            let path = std::env::temp_dir()
+                .join(format!("rubin-da-txgen-test-{}-{n}", std::process::id()));
+            fs::create_dir_all(&path).expect("create temp dir");
+            Self { path }
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+
+    fn parse(raw: &[u8]) -> Tx {
+        let (tx, _txid, _wtxid, consumed) = parse_tx(raw).expect("parse generated DA tx");
+        assert_eq!(consumed, raw.len(), "generated DA tx has trailing bytes");
+        tx
+    }
+
+    #[test]
+    fn signed_da_set_is_complete_consistent_and_admissible() {
+        let dir = TempDir::new();
+        let set = mine_and_generate(&dir.path, DA_RELAY_BASE_HEIGHT)
+            .expect("mine + generate signed DA set");
+
+        // Four distinct transactions.
+        let txids = [
+            set.commit.txid,
+            set.chunk0.txid,
+            set.chunk1.txid,
+            set.duplicate_commit.txid,
+        ];
+        for i in 0..txids.len() {
+            for j in (i + 1)..txids.len() {
+                assert_ne!(txids[i], txids[j], "DA set txids must be distinct");
+            }
+        }
+
+        let da_id = fixture_da_id();
+        assert_eq!(set.da_id, da_id);
+
+        // Commit: covenant commitment == sha3(payload0 || payload1), 2 chunks,
+        // shared da_id, deterministic RETL header fields.
+        let commit = parse(&set.commit.raw);
+        assert_eq!(commit.tx_kind, 0x01);
+        let mut full_payload = PAYLOAD_0.to_vec();
+        full_payload.extend_from_slice(PAYLOAD_1);
+        let expected_commitment = sha3_256(&full_payload);
+        let commit_output = commit
+            .outputs
+            .iter()
+            .find(|o| o.covenant_type == COV_TYPE_DA_COMMIT)
+            .expect("commit output");
+        assert_eq!(commit_output.covenant_data.as_slice(), &expected_commitment);
+        let core = commit.da_commit_core.as_ref().expect("commit core");
+        assert_eq!(core.da_id, da_id);
+        assert_eq!(core.chunk_count, DA_CHUNK_COUNT);
+        assert_eq!(core.retl_domain_id, RETL_DOMAIN_ID);
+        assert_eq!(core.tx_data_root, TX_DATA_ROOT);
+        assert_eq!(core.state_root, STATE_ROOT);
+        assert_eq!(core.withdrawals_root, WITHDRAWALS_ROOT);
+        assert_eq!(core.batch_number, BATCH_NUMBER);
+        assert_eq!(core.batch_sig, fixture_batch_sig());
+
+        // Chunks: chunk_hash == sha3(payload), indexes 0 and 1, shared da_id.
+        for (raw, index, payload) in [
+            (&set.chunk0.raw, 0u16, PAYLOAD_0),
+            (&set.chunk1.raw, 1u16, PAYLOAD_1),
+        ] {
+            let chunk = parse(raw);
+            assert_eq!(chunk.tx_kind, 0x02);
+            let chunk_core = chunk.da_chunk_core.as_ref().expect("chunk core");
+            assert_eq!(chunk_core.da_id, da_id);
+            assert_eq!(chunk_core.chunk_index, index);
+            assert_eq!(chunk_core.chunk_hash, sha3_256(payload));
+            assert_eq!(chunk.da_payload.as_slice(), payload);
+        }
+
+        // Independent canonical re-admission against the persisted datadir.
+        let state = load_chain_state(chain_state_path(&dir.path)).expect("reload state");
+        let block_store = BlockStore::open(block_store_path(&dir.path)).expect("reopen blockstore");
+        for tx in [&set.commit, &set.chunk0, &set.chunk1, &set.duplicate_commit] {
+            let mut pool = TxPool::new_with_config(TxPoolConfig::default());
+            pool.admit(&tx.raw, &state, Some(&block_store), genesis_chain_id())
+                .expect("DA tx must pass canonical admission");
+        }
+
+        // Relay DA admission accepts the well-formed chunks.
+        DaRelayState::validate_relay_da_tx_for_admission(&set.chunk0.raw)
+            .expect("well-formed chunk passes relay admission");
+        DaRelayState::validate_relay_da_tx_for_admission(&set.chunk1.raw)
+            .expect("well-formed chunk passes relay admission");
+    }
+
+    #[test]
+    fn corrupted_chunk_hash_is_rejected_by_relay_admission() {
+        let dir = TempDir::new();
+        let set = mine_and_generate(&dir.path, DA_RELAY_BASE_HEIGHT)
+            .expect("mine + generate signed DA set");
+
+        // Flip the chunk_hash so it no longer matches sha3(payload), re-marshal,
+        // and confirm relay DA admission rejects it.
+        let mut chunk = parse(&set.chunk0.raw);
+        let core = chunk.da_chunk_core.as_mut().expect("chunk core");
+        core.chunk_hash[0] ^= 0xff;
+        let corrupted = marshal_tx(&chunk).expect("marshal corrupted chunk");
+
+        let err = DaRelayState::validate_relay_da_tx_for_admission(&corrupted)
+            .expect_err("corrupted chunk_hash must be rejected");
+        assert_eq!(err, DaRelayError::ChunkHashMismatch);
+    }
+
+    fn genesis_chain_id() -> [u8; 32] {
+        crate::genesis::devnet_genesis_chain_id()
+    }
+}

--- a/clients/rust/crates/rubin-node/src/lib.rs
+++ b/clients/rust/crates/rubin-node/src/lib.rs
@@ -4,6 +4,7 @@ mod chainstate_recovery;
 pub mod coinbase;
 pub mod da_prefetch;
 pub mod da_relay;
+pub mod da_txgen;
 pub mod devnet_rpc;
 pub mod genesis;
 pub mod interop;
@@ -33,6 +34,10 @@ pub use chainstate_recovery::reconcile_chain_state_with_block_store;
 pub use coinbase::{
     build_coinbase_tx, default_mine_address, normalize_mine_address, parse_mine_address,
     validate_mine_address,
+};
+pub use da_txgen::{
+    build_signed_da_set, mine_and_generate, select_mature_p2pk_coinbases, SignedDaSet, SignedDaTx,
+    DA_RELAY_BASE_HEIGHT,
 };
 pub use devnet_rpc::{
     new_devnet_rpc_state, new_devnet_rpc_state_with_tx_pool, new_shared_runtime_tx_pool,

--- a/scripts/devnet-rust-da-relay.sh
+++ b/scripts/devnet-rust-da-relay.sh
@@ -19,12 +19,14 @@ done
 # default-on for devnet), prove a real two-node handshake, then emit a source-bound
 # PASS/FAIL/NO_DATA report. The runtime relay->complete-set-provider->miner path is
 # wired (RUB-440 inbound staging, RUB-389 provider, RUB-435 consume, RUB-387 flat
-# exclusion), but this harness has no signed DA commit/chunk tx source: the Rust node
-# mines to a public key and exposes no key persistence across the keygen->mine->sign
-# process boundary, so a follow-up in-process DA-tx generator is required before the
-# relay->complete-set->mine scenario can be driven to PASS. PASS would assert the
-# complete set mined (tx_count==4: commit+chunk0+chunk1, duplicate omitted) and tip
-# convergence; FAIL would be that invariant disproven once a tx source exists.
+# exclusion). RUB-442 adds the in-process signed DA tx source (rust-da-txgen):
+# because the Rust node mines to a public key and exposes no key persistence
+# across the keygen->mine->sign process boundary, the generator does keygen + mine
+# + sign in one process and emits a complete signed DA set (commit + chunk0 +
+# chunk1, plus the duplicate commit) that passes Rust canonical tx admission. This
+# harness now generates that set to prove the source exists, then emits NO_DATA:
+# driving the relay->complete-set->mine scenario to PASS (assert the complete set
+# mined with tx_count==4 and tip convergence) is the follow-up RUB-443.
 emit_report() {
   local verdict="$1" reason="${2:-}"
   if [[ -n "${REPORT_JSON:-}" ]]; then
@@ -61,19 +63,62 @@ DA_RELAY_IO_TIMEOUT_SECONDS="$(_rubin_process_uint_decimal DA_RELAY_IO_TIMEOUT_S
 export KEEP_TMP
 rubin_process_init rust-da-relay
 NODE_BIN="${RUBIN_PROCESS_ARTIFACT_ROOT}/rubin-node-rust"
+DATXGEN_BIN="${RUBIN_PROCESS_ARTIFACT_ROOT}/rust-da-txgen"
+DA_DATADIR="${RUBIN_PROCESS_ARTIFACT_ROOT}/da-txgen-datadir"
+DA_TX_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/rust-da-txs.json"
+DA_TX_ERR="${RUBIN_PROCESS_ARTIFACT_ROOT}/rust-da-txgen.err"
 REPORT_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/rust-da-relay-report.json"
 A_DIR="${RUBIN_PROCESS_ARTIFACT_ROOT}/node-a"
 B_DIR="${RUBIN_PROCESS_ARTIFACT_ROOT}/node-b"
 build_node() {
-  local host bin
+  local host bin datxgen
   host="$("${DEV_ENV}" -- rustc -vV | awk '/^host:/ {print $2}')"
   [[ -n "${host}" ]] || { echo "could not derive host target triple" >&2; return 1; }
+  # `-p rubin-node` builds every target of the package, including the
+  # rust-da-txgen binary used by generate_da_set below.
   "${DEV_ENV}" -- cargo build --manifest-path "${RUST_ROOT}/Cargo.toml" \
     --release --locked -p rubin-node --target "${host}" --target-dir "${RUBIN_PROCESS_ARTIFACT_ROOT}/cargo-target" \
     >/dev/null
   bin="${RUBIN_PROCESS_ARTIFACT_ROOT}/cargo-target/${host}/release/rubin-node"
   cp -- "${bin}" "${NODE_BIN}"
   [[ -x "${NODE_BIN}" ]] || { echo "built Rust node is not executable: ${NODE_BIN}" >&2; return 1; }
+  datxgen="${RUBIN_PROCESS_ARTIFACT_ROOT}/cargo-target/${host}/release/rust-da-txgen"
+  cp -- "${datxgen}" "${DATXGEN_BIN}"
+  [[ -x "${DATXGEN_BIN}" ]] || { echo "built Rust DA tx generator is not executable: ${DATXGEN_BIN}" >&2; return 1; }
+}
+# RUB-442: produce a complete signed DA set (commit + two chunks + duplicate
+# commit) with the in-process keygen+mine+sign generator and assert it is
+# well-formed (valid hex, distinct 64-hex txids). The generator self-checks each
+# tx against Rust canonical tx admission and exits non-zero on failure.
+generate_da_set() {
+  mkdir -p "${DA_DATADIR}" || { echo "da-txgen datadir setup failed" >&2; return 1; }
+  if ! "${DATXGEN_BIN}" "${DA_DATADIR}" >"${DA_TX_JSON}" 2>"${DA_TX_ERR}"; then
+    echo "rust-da-txgen failed: $(tail -n 1 "${DA_TX_ERR}" 2>/dev/null)" >&2
+    return 1
+  fi
+  python3 - "${DA_TX_JSON}" <<'PY'
+import json, re, sys
+with open(sys.argv[1], encoding="utf-8") as fh:
+    data = json.load(fh)
+if not isinstance(data, dict):
+    raise SystemExit("DA tx JSON is not an object")
+required = ("chunk0", "commit", "duplicate_commit", "chunk1")
+txids = set()
+for key in required:
+    entry = data.get(key)
+    if not isinstance(entry, dict):
+        raise SystemExit(f"missing or malformed entry for {key}")
+    tx_hex = entry.get("hex")
+    txid = entry.get("txid")
+    if not (isinstance(tx_hex, str) and re.fullmatch(r"[0-9a-f]+", tx_hex) and len(tx_hex) % 2 == 0):
+        raise SystemExit(f"malformed hex for {key}")
+    if not (isinstance(txid, str) and re.fullmatch(r"[0-9a-f]{64}", txid)):
+        raise SystemExit(f"malformed txid for {key}")
+    txids.add(txid)
+if len(txids) != len(required):
+    raise SystemExit("DA set txids are not distinct")
+print("rust-da-txgen DA set: " + ", ".join(f"{k}={data[k]['txid'][:12]}" for k in required), file=sys.stderr)
+PY
 }
 start_node() {
   local label="$1" log="$2" datadir="$3" peers="${4:-}"
@@ -123,4 +168,8 @@ fi
 A_PID="${STARTED_PID}"; A_RPC="${STARTED_RPC}"; A_P2P="${STARTED_P2P}"
 A_PEERS="$(wait_peers_ready node-a "${A_RPC}")" || emit_no_data node_a_handshake_missing
 B_PEERS="$(wait_peers_ready node-b "${B_RPC}")" || emit_no_data node_b_handshake_missing
-emit_no_data rust_da_signed_tx_source_unavailable
+echo "Generating signed Rust DA set (in-process keygen+mine+sign)"
+generate_da_set || emit_no_data rust_da_signed_tx_source_generation_failed
+# Source proven: a complete admissible signed DA set now exists. Driving the
+# relay->complete-set->mine scenario to PASS is the follow-up RUB-443.
+emit_no_data rust_da_relay_complete_set_mine_pending


### PR DESCRIPTION
Invariant: the Rust devnet DA relay smoke has an in-process signed DA commit/chunk tx source, closing the `rust_da_signed_tx_source_unavailable` gap documented by RUB-409 — the txgen prerequisite for converting the smoke from NO_DATA to PASS (RUB-443).

Scope: one new library module (`clients/rust/crates/rubin-node/src/da_txgen.rs`), one thin devnet-only binary (`clients/rust/crates/rubin-node/src/bin/rust-da-txgen.rs`), re-exports in `lib.rs`, and the `scripts/devnet-rust-da-relay.sh` wiring that builds/runs the generator. No consensus changes, no Go changes, no P2P protocol changes, no DA economics, no production wallet/key generation.

Why in-process: the Go DA relay smoke generates signed DA txs with a throwaway `go run` helper that DER-exports the mining keypair and re-imports it to sign across a keygen → mine → sign process boundary. Rust `Mldsa87Keypair` has no DER export and no seed/from-bytes constructor (only OpenSSL random `generate()`), so the same key cannot be reconstructed in a second process. `mine_and_generate` therefore does keygen + mine + sign in one process — the ephemeral devnet keypair never leaves memory and no new crypto path is introduced.

What it produces: a deterministic fixture mirroring the Go helper — shared `da_id = SHA3-256("rubin-da-relay-process-smoke-da-id")`, `chunk_count=2`, payloads `…-smoke-0`/`…-smoke-1`, `chunk_hash = SHA3-256(payload)`, commit covenant commitment `SHA3-256(payload0||payload1)` in a single zero-value `COV_TYPE_DA_COMMIT` output, tx_nonce 3201–3204, plus the Go-parity duplicate commit. `DaCommitCore` RETL header fields are populated deterministically with the canonical in-repo fixture values (`retl_domain_id=0x10…`, roots `0x11…`/`0x12…`/`0x13…`, `batch_number=1`) and an opaque deterministic non-empty `batch_sig` (`SHA3-256` of a fixed label, suite 0), satisfying the issue's fixture shape. Each tx is signed with `sign_transaction` over mature coinbase P2PK spends and self-checked through `TxPool::admit` (the same canonical admission gate `/submit_tx` uses) before being emitted; the binary emits the Go-shaped `{chunk0,commit,duplicate_commit,chunk1: {hex,txid}}` JSON so the shell harness can consume either client's output with one parser.

Script behavior: `scripts/devnet-rust-da-relay.sh` now builds `rust-da-txgen` alongside the node, generates the signed DA set after the two-node handshake, validates the JSON shape (distinct 64-hex txids), and fail-closes with the new terminal reason `rust_da_relay_complete_set_mine_pending`. The `rust_da_signed_tx_source_unavailable` failure no longer exists. Driving relay → complete-set → mine to PASS (`tx_count==4`, tip convergence) stays with RUB-443.

Parity Matrix:
| Required parity case | Go reference | Rust target | Evidence |
| -- | -- | -- | -- |
| signed DA set generation (commit + chunk0 + chunk1 + duplicate commit) spending mature coinbases | `write_da_txgen` helper in `scripts/devnet-go-da-relay.sh` (signDACommit/signDAChunk/selectCoins/signMarshalCheck) | `da_txgen::build_signed_da_set` + `select_mature_p2pk_coinbases` | identical fixture labels, nonces 3201–3204, commitment/chunk_hash derivation; `signed_da_set_is_complete_consistent_and_admissible` |
| generated txs pass canonical tx admission | Go `consensus.CheckTransaction` round-trip in `signMarshalCheck` | `TxPool::admit` self-check in `sign_marshal_admit` + independent re-admission against the persisted datadir in the test | both tests green; admission failure aborts generation |
| key material crosses keygen → mine → sign | Go DER export/import via `NewMLDSA87KeypairFromDER` | in-process `mine_and_generate` (no DER export exists in Rust) | doc-comment contract in `da_txgen.rs`; key never leaves the process |
| malformed chunk_hash rejection | Go relay rejects `ChunkHashMismatch` | `DaRelayState::validate_relay_da_tx_for_admission` | `corrupted_chunk_hash_is_rejected_by_relay_admission` (flip hash byte → `DaRelayError::ChunkHashMismatch`) |
| smoke harness no longer fails `rust_da_signed_tx_source_unavailable` | n/a (Go smoke is PASS) | `scripts/devnet-rust-da-relay.sh` `generate_da_set` | reason string fully removed; terminal reason now `rust_da_relay_complete_set_mine_pending` (RUB-443 owns NO_DATA→PASS) |

Evidence (mandatory local gates):
- `cargo test -p rubin-node da_txgen::` — 2/2 green (in-process mine of 105 blocks ×2, set built, admitted, corrupted chunk rejected)
- full rubin-node suite — 778 + 69 + 3 tests, 0 failures; `cargo clippy --all-targets -- -D warnings` — clean; `cargo fmt --all --check` — clean
- `rust-da-txgen <datadir>` run — emits the DA set JSON (`da_id 46220dc9925f375f190473ec9adbee5ede6c44af698a19fd546e8ae9c9a8f734`, stable across runs; 4 distinct txids), persists the devnet datadir (chainstate + blockstore) for RUB-443 wiring
- `shellcheck -x scripts/devnet-rust-da-relay.sh` — clean; `bash -n` — clean (tooling lane)
- narrow script run — locally fail-closes at `node_a_handshake_missing` (same documented local-networking behavior as the merged RUB-409/compact-relay siblings; handshake completes in CI networking); `generate_da_set` validated standalone
- core + tooling + coverage + delta receipts — PASS; review fanout BYPASSED (controller-approved, Rust parity/thaw class); adversarial multi-lens review (go-parity, consensus-admission, safety) — 0 confirmed findings

Linear: RUB-442

🤖 Generated with [Claude Code](https://claude.com/claude-code)
