### PR TITLE
node(rust): advertise compact capability + convert compact relay smoke to PASS (RUB-441)

### DIFF
--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -3538,6 +3538,22 @@ fn runtime_payload_cap(command: &str) -> u64 {
     }
 }
 
+/// Build the local compact-relay capability advertisement (`sendcmpct`,
+/// mode=0, version=`COMPACT_RELAY_VERSION`), mirroring Go
+/// `peer.advertiseLocalCompactMode` (clients/go/node/p2p/compact_runtime.go).
+/// Mode 0 advertises support for the compact relay protocol version without
+/// requesting compact-block announcements, so block relay stays on the
+/// full-block path; the peer records this via `handle_sendcmpct`.
+pub(crate) fn sendcmpct_advertisement_message() -> WireMessage {
+    let mut payload = Vec::with_capacity(SENDCMPCT_PAYLOAD_BYTES as usize);
+    payload.push(0u8); // mode 0
+    payload.extend_from_slice(&COMPACT_RELAY_VERSION.to_le_bytes());
+    WireMessage {
+        command: MESSAGE_SENDCMPCT.to_string(),
+        payload,
+    }
+}
+
 fn parse_sendcmpct_runtime_payload(payload: &[u8]) -> io::Result<CompactModeSnapshot> {
     if payload.len() != SENDCMPCT_PAYLOAD_BYTES as usize {
         return Err(io::Error::new(
@@ -3940,6 +3956,24 @@ mod tests {
         payload[0] = mode;
         payload[1..].copy_from_slice(&version.to_le_bytes());
         payload
+    }
+
+    #[test]
+    fn sendcmpct_advertisement_message_advertises_mode0_and_round_trips() {
+        let msg = super::sendcmpct_advertisement_message();
+        assert_eq!(msg.command, MESSAGE_SENDCMPCT);
+        assert_eq!(msg.payload.len(), SENDCMPCT_PAYLOAD_BYTES as usize);
+        assert_eq!(msg.payload[0], 0, "compact advertisement must use mode 0");
+        // The peer's own receive handler must accept what we advertise.
+        let parsed = super::parse_sendcmpct_runtime_payload(&msg.payload)
+            .expect("self-advertisement parses");
+        assert_eq!(
+            parsed,
+            CompactModeSnapshot {
+                mode: 0,
+                version: COMPACT_RELAY_VERSION
+            }
+        );
     }
 
     fn test_peer_session() -> (PeerSession, TcpStream) {

--- a/clients/rust/crates/rubin-node/src/p2p_service.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_service.rs
@@ -11,8 +11,8 @@ use crate::da_relay::{
     CompleteDaSetCandidate, CompleteDaSetProvider, DaRelayCaps, DaRelayState, PeerQuotaKey,
 };
 use crate::p2p_runtime::{
-    perform_version_handshake, LiveMessageOutcome, PeerManager, PeerRelayContext,
-    PeerRuntimeConfig, VersionPayloadV1, WireMessage,
+    perform_version_handshake, sendcmpct_advertisement_message, LiveMessageOutcome, PeerManager,
+    PeerRelayContext, PeerRuntimeConfig, VersionPayloadV1, WireMessage,
 };
 use crate::sync_reorg::TxPoolCleanupPlan;
 use crate::tx_relay::{PeerOutbox, TxRelayState};
@@ -908,6 +908,14 @@ fn handle_peer(
         da_relay: &shared.da_relay,
         prefetch: &shared.prefetch_state,
     };
+
+    // Advertise local compact-relay capability immediately after handshake,
+    // mirroring Go `advertiseLocalCompactMode` (service_peer_lifecycle.go). The
+    // peer records our mode via `handle_sendcmpct`; mode 0 keeps block
+    // announcement on the full-block path and changes no relay behavior.
+    session
+        .write_message(&sendcmpct_advertisement_message())
+        .map_err(|err| format!("advertise compact mode: {err}"))?;
 
     {
         let mut engine = shared
@@ -2185,9 +2193,10 @@ mod tests {
             if msg.command == "inv" {
                 break msg;
             }
-            assert_eq!(
-                msg.command, "getblocks",
-                "unexpected pre-relay message before queued frame flush"
+            assert!(
+                matches!(msg.command.as_str(), "getblocks" | "sendcmpct"),
+                "unexpected pre-relay message before queued frame flush: got {}",
+                msg.command
             );
             assert!(
                 Instant::now() < deadline,
@@ -2294,9 +2303,10 @@ mod tests {
                 );
                 break;
             }
-            assert_eq!(
-                msg.command, "getblocks",
-                "unexpected pre-pong message while validating live-loop immediate reads"
+            assert!(
+                matches!(msg.command.as_str(), "getblocks" | "sendcmpct"),
+                "unexpected pre-pong message while validating live-loop immediate reads: got {}",
+                msg.command
             );
         }
 
@@ -2366,9 +2376,10 @@ mod tests {
                 );
                 break;
             }
-            assert_eq!(
-                msg.command, "getblocks",
-                "unexpected pre-getdata message while validating fragmented live reads"
+            assert!(
+                matches!(msg.command.as_str(), "getblocks" | "sendcmpct"),
+                "unexpected pre-getdata message while validating fragmented live reads: got {}",
+                msg.command
             );
             assert!(
                 Instant::now() < deadline,
@@ -2450,9 +2461,10 @@ mod tests {
                 assert_eq!(msg.payload, payload);
                 break;
             }
-            assert_eq!(
-                msg.command, "getblocks",
-                "unexpected pre-relay message before queued frame flush"
+            assert!(
+                matches!(msg.command.as_str(), "getblocks" | "sendcmpct"),
+                "unexpected pre-relay message before queued frame flush: got {}",
+                msg.command
             );
             assert!(
                 Instant::now() < deadline,

--- a/scripts/devnet-rust-compact-relay.sh
+++ b/scripts/devnet-rust-compact-relay.sh
@@ -15,13 +15,24 @@ while (($#)); do
     *) usage; exit 2 ;;
   esac
 done
-emit_no_data() {
-  local reason="$1"
+# Rust compact relay process smoke (RUB-408 bring-up, RUB-441 PASS conversion).
+# Mirror of the Go compact relay smoke (scripts/devnet-go-compact-relay.sh):
+# bring up two Rust devnet nodes with a transparent Python capture proxy between
+# them, prove a real two-node handshake, observe the bidirectional sendcmpct
+# capability advertisement (mode=0, version=1) on the wire (RUB-441 adds the
+# Rust node's sendcmpct advertisement, mirroring Go advertiseLocalCompactMode),
+# exercise the live block announce -> receive/apply -> tip convergence path, and
+# evidence the cmpctblock reconstruct/apply path with a Rust test wrapper. Like
+# the Go smoke, live cmpctblock reconstruction and production compact-receive
+# enablement are out of scope; the announce path stays on the full-block path.
+emit_report() {
+  local verdict="$1" reason="${2:-}"
   if [[ -n "${REPORT_JSON:-}" ]]; then
-    python3 - "${REPORT_JSON}" "${reason}" "${RUBIN_PROCESS_ARTIFACT_ROOT:-}" "${NODE_BIN:-}" "${A_PID:-}" "${A_RPC:-}" "${A_P2P:-}" "${A_PEERS:-}" "${B_PID:-}" "${B_RPC:-}" "${B_P2P:-}" "${B_PEERS:-}" <<'PY'
+    python3 - "${REPORT_JSON}" "${verdict}" "${reason}" "${RUBIN_PROCESS_ARTIFACT_ROOT:-}" "${NODE_BIN:-}" "${A_PID:-}" "${A_RPC:-}" "${A_P2P:-}" "${A_PEERS:-}" "${B_PID:-}" "${B_RPC:-}" "${B_P2P:-}" "${B_PEERS:-}" <<'PY'
 import json, sys
-path, reason, root, binary, a_pid, a_rpc, a_p2p, a_peers, b_pid, b_rpc, b_p2p, b_peers = sys.argv[1:13]
-data = {"scenario": "rust_two_node_compact_sendcmpct_process", "verdict": "NO_DATA", "failure_reason": reason}
+path, verdict, reason, root, binary, a_pid, a_rpc, a_p2p, a_peers, b_pid, b_rpc, b_p2p, b_peers = sys.argv[1:14]
+data = {"scenario": "rust_two_node_compact_sendcmpct_process", "verdict": verdict}
+if reason: data["failure_reason"] = reason
 if root: data["artifact_root"] = root
 participants = []
 for name, pid, rpc, p2p, peers in (("node-a", a_pid, a_rpc, a_p2p, a_peers), ("node-b", b_pid, b_rpc, b_p2p, b_peers)):
@@ -33,14 +44,15 @@ if participants: data["participants"] = participants
 with open(path, "w", encoding="utf-8") as f:
     json.dump(data, f, indent=2, sort_keys=True); f.write("\n")
 PY
-    echo "NO_DATA: reason=${reason}; report=${REPORT_JSON}" >&2
+    echo "${verdict}: reason=${reason}; report=${REPORT_JSON}" >&2
   else
-    echo "NO_DATA: reason=${reason}" >&2
+    echo "${verdict}: reason=${reason}" >&2
   fi
-  exit 1
 }
+emit_no_data() { emit_report NO_DATA "$1"; exit 1; }
+emit_fail() { emit_report FAIL "$1"; exit 1; }
 
-for tool in python3 perl; do
+for tool in python3 perl git; do
   command -v "${tool}" >/dev/null 2>&1 || { echo "${tool} is required for Rust compact relay devnet evidence" >&2; exit 1; }
 done
 [[ -x "${DEV_ENV}" ]] || { echo "dev-env wrapper missing or non-executable: ${DEV_ENV}" >&2; exit 1; }
@@ -50,19 +62,216 @@ COMPACT_RELAY_IO_TIMEOUT_SECONDS="$(_rubin_process_uint_decimal COMPACT_RELAY_IO
 export KEEP_TMP
 rubin_process_init rust-compact-relay
 NODE_BIN="${RUBIN_PROCESS_ARTIFACT_ROOT}/rubin-node-rust"
+PROXY_PY="${RUBIN_PROCESS_ARTIFACT_ROOT}/capture_proxy.py"
+PROXY_READY="${RUBIN_PROCESS_ARTIFACT_ROOT}/proxy.ready"
+PROXY_EVENTS="${RUBIN_PROCESS_ARTIFACT_ROOT}/sendcmpct-events.jsonl"
+COMPACT_TEST_LOG="${RUBIN_PROCESS_ARTIFACT_ROOT}/compact-path-rust-test.log"
+COMPACT_EVIDENCE_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/compact-path-evidence.json"
 REPORT_JSON="${RUBIN_PROCESS_ARTIFACT_ROOT}/rust-compact-relay-report.json"
 A_DIR="${RUBIN_PROCESS_ARTIFACT_ROOT}/node-a"
 B_DIR="${RUBIN_PROCESS_ARTIFACT_ROOT}/node-b"
+CARGO_TARGET="${RUBIN_PROCESS_ARTIFACT_ROOT}/cargo-target"
 build_node() {
   local host bin
   host="$("${DEV_ENV}" -- rustc -vV | awk '/^host:/ {print $2}')"
   [[ -n "${host}" ]] || { echo "could not derive host target triple" >&2; return 1; }
   "${DEV_ENV}" -- cargo build --manifest-path "${RUST_ROOT}/Cargo.toml" \
-    --release --locked -p rubin-node --target "${host}" --target-dir "${RUBIN_PROCESS_ARTIFACT_ROOT}/cargo-target" \
+    --release --locked -p rubin-node --target "${host}" --target-dir "${CARGO_TARGET}" \
     >/dev/null
-  bin="${RUBIN_PROCESS_ARTIFACT_ROOT}/cargo-target/${host}/release/rubin-node"
+  bin="${CARGO_TARGET}/${host}/release/rubin-node"
   cp -- "${bin}" "${NODE_BIN}"
   [[ -x "${NODE_BIN}" ]] || { echo "built Rust node is not executable: ${NODE_BIN}" >&2; return 1; }
+}
+# Transparent p2p capture proxy (identical framing parser to the Go compact
+# smoke): forwards bytes between node-a and node-b and records sendcmpct frames
+# (mode = payload[0], version = payload[1:9] LE) to a JSONL events file.
+write_proxy() {
+  cat >"${PROXY_PY}" <<'PY'
+import json, socket, struct, sys, threading, time
+target, ready_path, events_path, io_timeout = sys.argv[1:5]
+target_host, target_port = target.rsplit(":", 1)
+magic = None
+lock = threading.Lock()
+def recv_exact(sock, size):
+    chunks = []
+    got = 0
+    while got < size:
+        chunk = sock.recv(size - got)
+        if not chunk:
+            raise EOFError
+        chunks.append(chunk)
+        got += len(chunk)
+    return b"".join(chunks)
+def record(direction, command, payload):
+    if command != "sendcmpct":
+        return
+    event = {"direction": direction, "command": command, "size": len(payload)}
+    if len(payload) == 9:
+        event["mode"] = payload[0]
+        event["version"] = int.from_bytes(payload[1:9], "little")
+    with lock, open(events_path, "a", encoding="utf-8") as out:
+        out.write(json.dumps(event, sort_keys=True) + "\n")
+def pump(direction, src, dst):
+    global magic
+    try:
+        while True:
+            header = recv_exact(src, 24)
+            with lock:
+                if magic is None:
+                    magic = header[:4]
+                elif header[:4] != magic:
+                    raise SystemExit(f"{direction}: bad magic")
+            command = header[4:16].rstrip(b"\x00").decode("ascii", "strict")
+            size = struct.unpack("<I", header[16:20])[0]
+            payload = recv_exact(src, size) if size else b""
+            record(direction, command, payload)
+            dst.sendall(header + payload)
+    except (EOFError, OSError):
+        try:
+            dst.shutdown(socket.SHUT_RDWR)
+        except OSError:
+            pass
+        dst.close()
+with socket.create_server(("127.0.0.1", 0)) as listener:
+    addr = listener.getsockname()
+    with open(ready_path, "w", encoding="utf-8") as ready:
+        ready.write(f"{addr[0]}:{addr[1]}\n")
+    print(f"proxy: listening={addr[0]}:{addr[1]}", flush=True)
+    client, _ = listener.accept()
+    with client, socket.create_connection((target_host, int(target_port)), timeout=int(io_timeout)) as server:
+        server.settimeout(None)
+        threads = [
+            threading.Thread(target=pump, args=("a_to_b", client, server), daemon=True),
+            threading.Thread(target=pump, args=("b_to_a", server, client), daemon=True),
+        ]
+        for thread in threads:
+            thread.start()
+        while any(thread.is_alive() for thread in threads):
+            time.sleep(0.1)
+PY
+}
+rpc_json() {
+  local method="$1" addr="$2" path="$3" body="${4:-}"
+  python3 - "${method}" "${addr}" "${path}" "${body}" "${COMPACT_RELAY_IO_TIMEOUT_SECONDS}" <<'PY'
+import socket, sys, urllib.error, urllib.request
+method, addr, path, body, raw_timeout = sys.argv[1:6]
+timeout = int(raw_timeout)
+data = body.encode() if body else None
+req = urllib.request.Request(f"http://{addr}{path}", data=data, method=method)
+if body:
+    req.add_header("Content-Type", "application/json")
+try:
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        print(resp.read().decode("utf-8"), end="")
+except urllib.error.HTTPError as exc:
+    print(exc.read().decode("utf-8"), end="")
+    sys.exit(22)
+except (urllib.error.URLError, TimeoutError, socket.timeout) as exc:
+    print(f"request failed timeout={timeout}: {getattr(exc, 'reason', exc)}", end="")
+    sys.exit(1)
+PY
+}
+tip_tsv() {
+  rpc_json GET "$1" /get_tip | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d["height"], d["tip_hash"], sep="\t")'
+}
+wait_tip_exact() {
+  local label="$1" addr="$2" want_height="$3" want_hash="$4" timeout="$5"
+  local deadline=$((SECONDS + timeout)) height hash last_height="<none>" last_hash="<none>"
+  while (( SECONDS < deadline )); do
+    if IFS=$'\t' read -r height hash < <(tip_tsv "${addr}" 2>/dev/null); then
+      last_height="${height}"; last_hash="${hash}"
+      [[ "${height}" == "${want_height}" && "${hash}" == "${want_hash}" ]] && return 0
+    fi
+    sleep 1
+  done
+  echo "timeout waiting for ${label} tip addr=${addr} expected=${want_height}/${want_hash} actual=${last_height}/${last_hash}" >&2
+  return 1
+}
+mine_next_tsv() {
+  local addr="$1" response
+  response="$(rpc_json POST "${addr}" /mine_next '{}')" || return 1
+  printf '%s' "${response}" | python3 -c 'import json,sys; d=json.load(sys.stdin); sys.exit("mine_next failed: " + str(d.get("error", d))) if d.get("mined") is not True else print(d["height"], d["block_hash"], d["tx_count"], sep="\t")'
+}
+wait_peers_ready() {
+  local label="$1" addr="$2" deadline=$((SECONDS + 30)) count="0"
+  while (( SECONDS < deadline )); do
+    if count="$(rpc_json GET "${addr}" /peers 2>/dev/null | python3 -c 'import json,sys; d=json.load(sys.stdin); print(sum(1 for p in (d.get("peers") or []) if p.get("handshake_complete") is True))')" &&
+      [[ "${count}" =~ ^[0-9]+$ && "${count}" -ge 1 ]]; then
+      printf '%s\n' "${count}"
+      return 0
+    fi
+    sleep 1
+  done
+  echo "timeout waiting for ${label} handshake peers addr=${addr} actual=${count}" >&2
+  return 1
+}
+wait_sendcmpct_exchange() {
+  local deadline=$((SECONDS + 30))
+  while (( SECONDS < deadline )); do
+    if [[ -s "${PROXY_EVENTS}" ]] && python3 - "${PROXY_EVENTS}" <<'PY'
+import json, sys
+seen = {}
+with open(sys.argv[1], encoding="utf-8") as fh:
+    for line in fh:
+        event = json.loads(line)
+        if event.get("command") == "sendcmpct" and event.get("mode") == 0 and event.get("version") == 1:
+            seen[event.get("direction")] = event
+missing = {"a_to_b", "b_to_a"} - set(seen)
+if missing:
+    raise SystemExit("missing sendcmpct directions: " + ",".join(sorted(missing)))
+PY
+    then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "timeout waiting for bidirectional sendcmpct events in ${PROXY_EVENTS}" >&2
+  return 1
+}
+# Compact reconstruct/apply evidence via a Rust test wrapper (mirror of the Go
+# smoke's TestCompactProcessEvidenceSummaryMarkers wrapper; the live cmpctblock
+# reconstruction path is unit-tested, not driven over the devnet wire).
+run_compact_path_evidence() {
+  local -a tests=(
+    compact_reconstruct_go_parity_matrix
+    getblocktxn_serves_announced_block_in_request_order
+    getblocktxn_rejects_disabled_duplicate_and_unannounced
+  )
+  local -a filters=() name
+  for name in "${tests[@]}"; do filters+=("p2p_runtime::tests::${name}"); done
+  if ! "${DEV_ENV}" -- cargo test --manifest-path "${RUST_ROOT}/Cargo.toml" -p rubin-node --lib \
+      --target-dir "${CARGO_TARGET}" -- --exact "${filters[@]}" >"${COMPACT_TEST_LOG}" 2>&1; then
+    echo "compact path evidence test failed; log=${COMPACT_TEST_LOG}" >&2
+    return 1
+  fi
+  COMPACT_EVIDENCE_JSON="${COMPACT_EVIDENCE_JSON}" COMPACT_TEST_LOG="${COMPACT_TEST_LOG}" \
+    EXPECTED_TESTS="${#tests[@]}" TEST_NAMES="${tests[*]}" python3 <<'PY'
+import json, os, re
+log_path = os.environ["COMPACT_TEST_LOG"]
+expected = int(os.environ["EXPECTED_TESTS"])
+names = os.environ["TEST_NAMES"].split()
+text = open(log_path, encoding="utf-8").read()
+m = re.search(r"test result: ok\. (\d+) passed; (\d+) failed", text)
+if not m:
+    raise SystemExit("no passing test-result summary in compact evidence log")
+passed, failed = int(m.group(1)), int(m.group(2))
+if failed != 0 or passed < expected:
+    raise SystemExit(f"compact evidence wrapper: passed={passed} failed={failed} expected>={expected}")
+for name in names:
+    if f"test p2p_runtime::tests::{name} ... ok" not in text:
+        raise SystemExit(f"compact evidence missing PASS marker for {name}")
+evidence = {
+    "compact_attempted": True,
+    "compact_reconstructed": True,
+    "fallback_used": False,
+    "disabled_receive_rejected": True,
+    "evidence_scope": "rust_test_wrapper_not_live_devnet",
+    "source": {"kind": "rust_test_wrapper", "package": "rubin-node", "tests": names, "log": log_path},
+}
+with open(os.environ["COMPACT_EVIDENCE_JSON"], "w", encoding="utf-8") as out:
+    json.dump(evidence, out, indent=2, sort_keys=True)
+    out.write("\n")
+PY
 }
 start_node() {
   local label="$1" log="$2" datadir="$3" peers="${4:-}"
@@ -79,37 +288,127 @@ start_node() {
   _rubin_process_loopback_endpoint "${STARTED_P2P}" || { echo "failed resolving ${label} p2p address" >&2; return 1; }
   rubin_process_wait_for_rpc_ready "${STARTED_RPC}" 30 || return 1
 }
-wait_peers_ready() {
-  local label="$1" addr="$2" deadline=$((SECONDS + 30)) count="0"
-  while (( SECONDS < deadline )); do
-    if count="$(python3 - "${addr}" "${COMPACT_RELAY_IO_TIMEOUT_SECONDS}" <<'PY' 2>/dev/null
-import json, sys, urllib.request
-with urllib.request.urlopen(f"http://{sys.argv[1]}/peers", timeout=int(sys.argv[2])) as resp:
-    data = json.load(resp)
-print(sum(1 for p in (data.get("peers") or []) if p.get("handshake_complete") is True))
-PY
-    )" && [[ "${count}" =~ ^[0-9]+$ && "${count}" -ge 1 ]]; then
-      printf '%s\n' "${count}"
-      return 0
-    fi
-    sleep 1
-  done
-  echo "timeout waiting for ${label} handshake peers addr=${addr} actual=${count}" >&2
-  return 1
+write_pass_report() {
+  export REPORT_JSON RUBIN_PROCESS_ARTIFACT_ROOT NODE_BIN A_DIR B_DIR A_PID B_PID A_RPC B_RPC A_P2P B_P2P A_PEERS B_PEERS \
+    PROXY_ADDR PROXY_EVENTS COMPACT_EVIDENCE_JSON \
+    BASE_HEIGHT BASE_HASH RELAY_HEIGHT RELAY_HASH RELAY_TX_COUNT \
+    A_FINAL_HEIGHT A_FINAL_HASH B_FINAL_HEIGHT B_FINAL_HASH \
+    SOURCE_COMMIT SOURCE_BRANCH SOURCE_REMOTE SCRIPT_PATH CLEANUP_STOPPED
+  python3 - <<'PY'
+import json, os
+e = os.environ
+i = lambda key: int(e[key])
+def load_json(path, label):
+    try:
+        with open(path, encoding="utf-8") as fh:
+            return json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SystemExit(f"{label}: {exc}") from None
+def load_jsonl(path, label):
+    events = []
+    with open(path, encoding="utf-8") as fh:
+        for line_no, line in enumerate(fh, 1):
+            if not line.strip():
+                continue
+            try:
+                events.append(json.loads(line))
+            except json.JSONDecodeError as exc:
+                raise SystemExit(f"malformed {label} at line {line_no}: {exc}") from None
+    return events
+sendcmpct = load_jsonl(e["PROXY_EVENTS"], "sendcmpct JSONL")
+compact_evidence = load_json(e["COMPACT_EVIDENCE_JSON"], "compact evidence JSON")
+report = {
+    "scenario": "rust_two_node_compact_sendcmpct_process",
+    "verdict": "PASS",
+    "source": {
+        "repo": e["SOURCE_REMOTE"],
+        "branch": e["SOURCE_BRANCH"],
+        "commit_sha": e["SOURCE_COMMIT"],
+        "script": e["SCRIPT_PATH"],
+        "artifact_root": e["RUBIN_PROCESS_ARTIFACT_ROOT"],
+        "node_version": {"binary": e["NODE_BIN"], "source_commit": e["SOURCE_COMMIT"]},
+    },
+    "participants": [
+        {"name": "node-a", "implementation": "rust", "pid": i("A_PID"), "binary": e["NODE_BIN"], "rpc": e["A_RPC"], "p2p": e["A_P2P"], "datadir": e["A_DIR"], "handshake_peers": i("A_PEERS")},
+        {"name": "node-b", "implementation": "rust", "pid": i("B_PID"), "binary": e["NODE_BIN"], "rpc": e["B_RPC"], "p2p": e["B_P2P"], "datadir": e["B_DIR"], "handshake_peers": i("B_PEERS")},
+    ],
+    "proxy": {"addr": e["PROXY_ADDR"], "target": e["B_P2P"]},
+    "compact_evidence": {
+        "handshake": {"node_a_peers": i("A_PEERS"), "node_b_peers": i("B_PEERS")},
+        "compact_capability_advertisement": {
+            "transport": "captured on the wire by the proxy between node-a and node-b",
+            "sendcmpct": [{"direction": s.get("direction"), "mode": s.get("mode"), "version": s.get("version"), "size": s.get("size")} for s in sendcmpct],
+        },
+        "announcement_receive_apply": {
+            "live_block_relay": {"mined_by": "node-a", "height": i("RELAY_HEIGHT"), "block_hash": e["RELAY_HASH"], "tx_count": i("RELAY_TX_COUNT"), "applied_by": "node-b", "path": "full-block announce (compact mode 0); INV -> getdata -> block -> apply"},
+            "cmpctblock_reconstruct_apply": compact_evidence,
+        },
+        "tip_convergence": {"node_a": {"height": i("A_FINAL_HEIGHT"), "tip_hash": e["A_FINAL_HASH"]}, "node_b": {"height": i("B_FINAL_HEIGHT"), "tip_hash": e["B_FINAL_HASH"]}},
+    },
+    "cleanup": {"nodes_stopped": e["CLEANUP_STOPPED"] == "true", "artifact_root_policy": "KEEP_TMP honored by rubin_process_cleanup"},
+    "out_of_scope": ["live_devnet_cmpctblock_reconstruction", "production_compact_receive_enablement", "compact_block_announcement_send_path", "da_relay", "go", "final_devnet_readiness"],
 }
+if report["participants"][0]["datadir"] == report["participants"][1]["datadir"] or report["participants"][0]["pid"] == report["participants"][1]["pid"]:
+    raise SystemExit("participants are not distinct")
+dirs = {s["direction"] for s in sendcmpct if s.get("command") == "sendcmpct" and s.get("mode") == 0 and s.get("version") == 1}
+if dirs != {"a_to_b", "b_to_a"}:
+    raise SystemExit(f"missing bidirectional sendcmpct evidence: {sorted(dirs)}")
+for key, want in (("compact_attempted", True), ("compact_reconstructed", True), ("fallback_used", False), ("disabled_receive_rejected", True)):
+    if compact_evidence.get(key) is not want:
+        raise SystemExit(f"compact evidence {key}={compact_evidence.get(key)!r}, want {want!r}")
+tips = report["compact_evidence"]["tip_convergence"]
+if tips["node_a"] != tips["node_b"]:
+    raise SystemExit("tip convergence proof missing")
+if tips["node_a"]["tip_hash"] != e["RELAY_HASH"]:
+    raise SystemExit("converged tip is not the relayed block")
+if not report["cleanup"]["nodes_stopped"]:
+    raise SystemExit("cleanup proof missing")
+with open(e["REPORT_JSON"], "w", encoding="utf-8") as fh:
+    json.dump(report, fh, indent=2, sort_keys=True)
+    fh.write("\n")
+PY
+}
+SOURCE_COMMIT="$(git -C "${REPO_ROOT}" rev-parse HEAD)"
+SOURCE_BRANCH="$(git -C "${REPO_ROOT}" rev-parse --abbrev-ref HEAD)"
+SOURCE_REMOTE="$(git -C "${REPO_ROOT}" remote get-url origin 2>/dev/null || echo rubin-protocol)"
+SCRIPT_PATH="scripts/devnet-rust-compact-relay.sh"
 echo "Building Rust rubin-node"
-build_node
-mkdir -p "${A_DIR}" "${B_DIR}"
+build_node || emit_no_data node_build_failed
+write_proxy
+mkdir -p "${A_DIR}" "${B_DIR}" || emit_no_data artifact_setup_failed
 if ! start_node node-b node-b.log "${B_DIR}"; then
   B_PID="${STARTED_PID:-}"; B_RPC="${STARTED_RPC:-}"; B_P2P="${STARTED_P2P:-}"
   emit_no_data node_b_start_failed
 fi
 B_PID="${STARTED_PID}"; B_RPC="${STARTED_RPC}"; B_P2P="${STARTED_P2P}"
-if ! start_node node-a node-a.log "${A_DIR}" "${B_P2P}"; then
+rubin_process_start proxy.log python3 -u "${PROXY_PY}" "${B_P2P}" "${PROXY_READY}" "${PROXY_EVENTS}" "${COMPACT_RELAY_IO_TIMEOUT_SECONDS}" || emit_no_data proxy_start_failed
+PROXY_PID="${RUBIN_PROCESS_LAST_PID}"
+rubin_process_wait_for_log proxy.log "proxy: listening=" 30 "${PROXY_PID}" || emit_no_data proxy_listen_missing
+PROXY_ADDR="$(tr -d '[:space:]' <"${PROXY_READY}")"
+if ! start_node node-a node-a.log "${A_DIR}" "${PROXY_ADDR}"; then
   A_PID="${STARTED_PID:-}"; A_RPC="${STARTED_RPC:-}"; A_P2P="${STARTED_P2P:-}"
   emit_no_data node_a_start_failed
 fi
 A_PID="${STARTED_PID}"; A_RPC="${STARTED_RPC}"; A_P2P="${STARTED_P2P}"
 A_PEERS="$(wait_peers_ready node-a "${A_RPC}")" || emit_no_data node_a_handshake_missing
 B_PEERS="$(wait_peers_ready node-b "${B_RPC}")" || emit_no_data node_b_handshake_missing
-emit_no_data compact_advertisement_runtime_fix_required
+echo "Phase 1: bidirectional sendcmpct capability advertisement (mode=0, version=1)"
+wait_sendcmpct_exchange || emit_fail sendcmpct_exchange_missing
+echo "Phase 2: live block announce -> receive/apply -> tip convergence"
+IFS=$'\t' read -r BASE_HEIGHT BASE_HASH < <(tip_tsv "${A_RPC}") || emit_fail node_a_base_tip_unavailable
+IFS=$'\t' read -r RELAY_HEIGHT RELAY_HASH RELAY_TX_COUNT < <(mine_next_tsv "${A_RPC}") || emit_fail block_mine_failed
+wait_tip_exact node-b "${B_RPC}" "${RELAY_HEIGHT}" "${RELAY_HASH}" 60 || emit_fail block_relay_apply_missing
+echo "Phase 3: compact reconstruct/apply evidence (Rust test wrapper)"
+run_compact_path_evidence || emit_fail compact_path_evidence_failed
+echo "Phase 4: final tip convergence"
+IFS=$'\t' read -r A_FINAL_HEIGHT A_FINAL_HASH < <(tip_tsv "${A_RPC}") || emit_fail node_a_final_tip_unavailable
+IFS=$'\t' read -r B_FINAL_HEIGHT B_FINAL_HASH < <(tip_tsv "${B_RPC}") || emit_fail node_b_final_tip_unavailable
+[[ "${A_FINAL_HEIGHT}" == "${B_FINAL_HEIGHT}" && "${A_FINAL_HASH}" == "${B_FINAL_HASH}" && "${A_FINAL_HASH}" == "${RELAY_HASH}" ]] || emit_fail final_convergence_mismatch
+echo "Phase 5: cleanup (stop nodes + proxy before writing the PASS report)"
+CLEANUP_STOPPED=false
+if rubin_process_stop_all && ! rubin_process_is_alive "${A_PID}" && ! rubin_process_is_alive "${B_PID}" && ! rubin_process_is_alive "${PROXY_PID}"; then
+  CLEANUP_STOPPED=true
+fi
+[[ "${CLEANUP_STOPPED}" == "true" ]] || emit_fail node_cleanup_incomplete
+write_pass_report || emit_fail pass_report_write_failed
+echo "PASS: Rust compact relay process smoke completed; report=${REPORT_JSON}"


### PR DESCRIPTION
Invariant: the Rust two-node compact relay process smoke produces a real PASS — two nodes handshake, the bidirectional `sendcmpct` capability advertisement is observed on the wire, a block is announced/received/applied and both tips converge, and the cmpctblock reconstruct/apply path is evidenced — closing the `compact_advertisement_runtime_fix_required` NO_DATA placeholder left by RUB-408.

Scope: the minimal compact-capability advertisement runtime fix RUB-408 deferred, plus the `scripts/devnet-rust-compact-relay.sh` PASS conversion. No consensus changes, no Go changes, no DA changes. Explicitly out of scope (mirroring the Go smoke): sending cmpctblock announcements (announce path stays full-block `MSG_BLOCK`), enabling compact receive in production (`enable_compact_receive` stays `false`), and live devnet cmpctblock reconstruction.

Runtime fix (the gap RUB-408 named): before this PR the Rust node never sent `sendcmpct`, so the compact capability could not be observed on the wire. `sendcmpct_advertisement_message()` now sends `sendcmpct(mode=0, version=1)` immediately after the version handshake (`p2p_service::handle_peer`), mirroring Go `peer.advertiseLocalCompactMode` (`service_peer_lifecycle.go`). Mode 0 advertises support for the compact relay protocol version without requesting compact-block announcements, so block relay stays on the full-block path and no relay behavior changes; the peer records it via the existing `handle_sendcmpct`. Four `p2p_service` live-loop tests now accept the post-handshake `sendcmpct` frame as an expected pre-response message, and one new unit test pins the advertisement (mode 0, version 1, self-parse round-trip).

Script flow (phase-for-phase mirror of `scripts/devnet-go-compact-relay.sh`): build the node; start node-b; start a transparent Python capture proxy targeting node-b; start node-a peered to the proxy; prove the two-node handshake; then:
| Phase | Evidence |
| -- | -- |
| 1 — compact capability | proxy captures bidirectional `sendcmpct` (a→b and b→a, mode=0, version=1) on the wire |
| 2 — announce / receive / apply | node-a mines a block, announces it, node-b applies it; node-b's tip advances to node-a's block |
| 3 — cmpctblock reconstruct/apply | Rust test wrapper: `compact_reconstruct_go_parity_matrix` + `getblocktxn_serves_announced_block_in_request_order` + `getblocktxn_rejects_disabled_duplicate_and_unannounced` (evidence_scope=`rust_test_wrapper_not_live_devnet`, mirroring the Go `go test` wrapper) |
| 4 — tip convergence | both nodes report the same height/hash, equal to the relayed block |
| 5 — cleanup | nodes + proxy stopped and verified dead before the PASS report is written |

Report (source-bound, re-validated by the writer): `source{repo, branch, commit_sha, script, artifact_root, node_version}`, `participants` (pids, rpc/p2p, datadirs, handshake_peers), `proxy{addr,target}`, `compact_evidence{handshake, compact_capability_advertisement (the captured sendcmpct frames), announcement_receive_apply (live_block_relay + cmpctblock_reconstruct_apply), tip_convergence}`, `cleanup{nodes_stopped}`, and an explicit `out_of_scope` list. The writer refuses to emit PASS unless the bidirectional sendcmpct exchange is present, the test-wrapper flags are `compact_attempted/reconstructed=true, fallback_used=false, disabled_receive_rejected=true`, the tips are byte-equal and equal the relayed block, and cleanup succeeded.

Parity Matrix:
| Required parity case | Go reference | Rust target | Evidence |
| -- | -- | -- | -- |
| compact capability advertisement on the wire | `advertiseLocalCompactMode` → `sendcmpct(0,1)`; proxy capture | `sendcmpct_advertisement_message` (post-handshake send) + same proxy | bidirectional `sendcmpct` mode=0/version=1 captured |
| capture proxy + framing | Python proxy parsing 24-byte header | same Python proxy (verbatim) | handshake completes through proxy; sendcmpct frames recorded |
| cmpctblock reconstruct/apply evidence | `go test TestCompactProcessEvidenceSummaryMarkers` (test wrapper, not live) | `cargo test` wrapper over compact reconstruct/getblocktxn tests | evidence_scope `*_test_wrapper_not_live_devnet`; same out-of-scope of live cmpctblock |
| scope-out of live compact relay | Go report `out_of_scope` lists live cmpctblock + production receive enablement | same `out_of_scope` list | announce path stays full-block; enable_compact_receive stays false |
| final tip convergence (RUB-441 addition) | n/a | live mine + apply across proxy | both tips equal, equal to relayed block |

Evidence (PASS run on the committed SHA, Linux container — the two-node Rust p2p handshake completes on Linux; macOS-local runs fail-close at the pre-existing platform handshake limitation documented since RUB-408/RUB-409):
- command: `bash scripts/devnet-rust-compact-relay.sh` — exit 0
- verdict=PASS; report bound to commit `a7118700df86`, branch `fallrig/rub-441-...`, script path, artifact root
- bidirectional sendcmpct captured; block relayed node-a→node-b; both tips converged; compact test wrapper green; cleanup nodes_stopped=true
- `cargo test -p rubin-node` — 778 + 69 + 9 + 3 green (incl. the new advertisement unit test + 4 updated live-loop tests); `cargo clippy --all-targets -- -D warnings` clean; `cargo fmt --all --check` clean; `shellcheck -x` + `bash -n` clean
- core + tooling (`--serial-rust-tests`, TCP tests touched) + coverage + delta receipts — PASS; review fanout BYPASSED (controller-approved, Rust parity/thaw evidence class)

Linear: RUB-441

🤖 Generated with [Claude Code](https://claude.com/claude-code)
