### PR TITLE
test(rust): isolate miner test_sync temp dirs to fix flaky chainstate-save race (RUB-447)

### DIFF
--- a/clients/rust/crates/rubin-node/src/miner.rs
+++ b/clients/rust/crates/rubin-node/src/miner.rs
@@ -835,8 +835,44 @@ mod tests {
         Miner, MinerConfig,
     };
 
-    fn test_sync(prefix: &str) -> (PathBuf, BlockStore, SyncEngine) {
-        let dir = std::env::temp_dir().join(format!("{prefix}-{}", std::process::id()));
+    use std::path::Path;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    // Per-call sequence so two test_sync() dirs never collide. Keying only on
+    // pid let tests sharing a `prefix` (the `s` helper is called many times by
+    // miner_da_provider_selection_bounds_matrix, plus any parallel test on the
+    // same prefix) reuse one `{prefix}-{pid}` directory under `cargo test`; one
+    // call's start-of-setup `remove_dir_all` then raced another call's
+    // chainstate save, flaking with
+    // `rename ... chainstate.json: No such file or directory`.
+    static TEST_SYNC_SEQ: AtomicU64 = AtomicU64::new(0);
+
+    /// RAII scratch directory: removes its tree on drop so the per-call unique
+    /// `test_sync` directories cannot accumulate in TMPDIR, even for callers
+    /// that bind it as `_dir`. Derefs/`AsRef`s to `Path` so existing `&dir`
+    /// uses (and the explicit end-of-test `remove_dir_all(&dir)` calls) keep
+    /// working; drop is best-effort and ignores errors.
+    struct TempDirGuard(PathBuf);
+    impl std::ops::Deref for TempDirGuard {
+        type Target = Path;
+        fn deref(&self) -> &Path {
+            &self.0
+        }
+    }
+    impl AsRef<Path> for TempDirGuard {
+        fn as_ref(&self) -> &Path {
+            &self.0
+        }
+    }
+    impl Drop for TempDirGuard {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn test_sync(prefix: &str) -> (TempDirGuard, BlockStore, SyncEngine) {
+        let seq = TEST_SYNC_SEQ.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!("{prefix}-{}-{seq}", std::process::id()));
         let _ = fs::remove_dir_all(&dir);
         fs::create_dir_all(&dir).expect("mkdir");
         let chain_state_file = chain_state_path(&dir);
@@ -849,7 +885,7 @@ mod tests {
             default_sync_config(None, devnet_genesis_chain_id(), Some(chain_state_file)),
         )
         .expect("sync");
-        (dir, block_store, sync)
+        (TempDirGuard(dir), block_store, sync)
     }
 
     fn coinbase_bytes(height: u64) -> Vec<u8> {


### PR DESCRIPTION
Invariant: the Rust test `miner::tests::miner_da_provider_selection_bounds_matrix` is deterministic — its scratch directories can no longer be clobbered by a sibling `test_sync` call running on another thread of the same `cargo test` process, and the per-call directories do not accumulate in TMPDIR.

Scope: one test-only change confined to the `#[cfg(test)]` module of `clients/rust/crates/rubin-node/src/miner.rs` (the `test_sync` scaffolding helper). No consensus changes, no Go changes, no P2P changes, no production runtime/miner behavior change.

Root cause: the `test_sync(prefix)` test helper keyed its scratch directory only on `{prefix}-{pid}`:
```rust
let dir = std::env::temp_dir().join(format!("{prefix}-{}", std::process::id()));
let _ = fs::remove_dir_all(&dir);
```
The `s` helper — called repeatedly by `miner_da_provider_selection_bounds_matrix` — uses the prefix `rubin-rust-miner-da-provider-selection`, so under `cargo test` (single process, parallel test threads, shared pid) two callers map to the *same* `{prefix}-{pid}` directory. One call's start-of-setup `remove_dir_all(&dir)` then races another call's chainstate save, intermittently failing with:
```
save: "rename ... /chainstate.json.tmp.<pid>.<n> -> .../chainstate.json: No such file or directory (os error 2)"
```
This surfaced on PR #1974 CI (the `test` job runs `cargo test`); a re-run passed. `cargo nextest` (used by the tooling lane) isolates each test in its own process, so its per-test pid is unique and the flake never reproduces there — which is why only the `cargo test` stage flaked.

Fix (test-only):
- Give each `test_sync` call a unique directory via a process-local atomic sequence (`{prefix}-{pid}-{seq}`), so no two calls — sequential or parallel — ever share a path.
- Return that directory as a small RAII guard that `remove_dir_all`s on drop (Deref/AsRef to `Path` so existing `&dir` uses and the explicit end-of-test `remove_dir_all(&dir)` calls keep working; drop is best-effort). This keeps the per-call uniqueness from accumulating scratch directories in TMPDIR, including for callers that bind `_dir`.

Parity Matrix:
| Required parity case | Go reference | Rust target | Evidence |
| -- | -- | -- | -- |
| per-test scratch dirs are unique and never shared across parallel tests | Go tests use `t.TempDir()` (per-test unique dir managed by the framework) | `test_sync` `{prefix}-{pid}-{seq}` via a process-local atomic sequence | 20× parallel `cargo test` runs of the previously-flaky tests — 20/20 green |
| scratch dirs are cleaned up after the test | `t.TempDir()` auto-removes on test end | `TempDirGuard` RAII drop (`remove_dir_all`, best-effort) | 0 new TMPDIR scratch directories remain after a miner test run |
| no production behavior change | n/a (test scaffolding only) | change confined to `#[cfg(test)]` | full `-p rubin-node` suite green; clippy `-D warnings` clean |

Evidence:
- ran the previously-flaky `miner_da_provider*` tests 20× under `cargo test` (parallel threads) — 20/20 green
- full `cargo test -p rubin-node` (serial) — 779 + 69 + 9 + 3 green; `cargo clippy --all-targets -- -D warnings` clean; `cargo fmt --all --check` clean
- confirmed 0 new TMPDIR scratch directories remain after a miner test run (RAII guard cleans up)
- core + tooling + coverage + delta receipts — PASS; review fanout BYPASSED (controller-approved, test-stability class)

Found while triaging the `test`/`validator` CI failures on PR #1974 (RUB-444); split out as its own change so the soak PR stayed scoped.

Linear: RUB-447

🤖 Generated with [Claude Code](https://claude.com/claude-code)
