### PR TITLE
formal: sync embedded section hash disposition for RUB-542

### DIFF
--- a/rubin-formal/proof_coverage.json
+++ b/rubin-formal/proof_coverage.json
@@ -4,7 +4,7 @@
   "claim_level": "refined",
   "spec_source_file": "spec/RUBIN_L1_CANONICAL.md",
   "spec_section_hashes_file": "spec/SECTION_HASHES.json",
-  "spec_section_hashes_sha3_256": "f8ab1b9b6d65e58d1275b6094106586c8504107552720f7610c5c8c3774eb43f",
+  "spec_section_hashes_sha3_256": "9010971320e9a16c19e99a5c5046496ff7484c859ca71969c201d9c49f7bfdaf",
   "lean_toolchain_file": "rubin-formal/lean-toolchain",
   "refinement_bridge_file": "rubin-formal/refinement_bridge.json",
   "coverage": [


### PR DESCRIPTION
Invariant:
- Align the embedded protocol formal disposition summary with the RUB-542 spec SECTION_HASHES aggregate, after updating the authoritative formal registry.

Layer:
- formal metadata / cross-repo gate

Files changed:
- rubin-formal/proof_coverage.json

Tests:
- python3 -m json.tool rubin-formal/proof_coverage.json >/dev/null — PASS
- python3 tools/check_formal_coverage.py — PASS
- python3 tools/check_formal_risk_gate.py --profile phase0 — PASS
- python3 tools/check_formal_claims_lint.py — PASS
- python3 tools/check_formal_disposition_for_section_hashes.py --spec-root <rubin-spec checkout> --formal-root rubin-formal — PASS
- python3 rubin-protocol/tools/check_section_hashes.py (from spec checkout) — PASS

Behavior impact:
- No executable protocol behavior change; metadata hash only.

Compatibility impact:
- Requires the matching authoritative formal update: rubin-formal#526.

Known non-goals:
- No proof-level, claim-level, theorem, or coverage-status changes.

Not checked:
- GitHub CI still needs to run on this PR.