### PR TITLE
RUB-482 Go Simplicity program encoding and CMR library

### DIFF
--- a/clients/go/consensus/simplicity/program.go
+++ b/clients/go/consensus/simplicity/program.go
@@ -1,0 +1,215 @@
+package simplicity
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"math/bits"
+)
+
+const (
+	SemanticsVersion uint32 = 1
+	MaxProgramBytes         = 16_384
+)
+
+type ErrorCode string
+
+const (
+	ErrDecode          ErrorCode = "TX_ERR_SIMPLICITY_DECODE"
+	ErrProgramTooLarge ErrorCode = "TX_ERR_SIMPLICITY_PROGRAM_TOO_LARGE"
+	ErrCMRMismatch     ErrorCode = "TX_ERR_SIMPLICITY_CMR_MISMATCH"
+	ErrJetDisallowed   ErrorCode = "TX_ERR_SIMPLICITY_JET_DISALLOWED"
+)
+
+type Error struct{ Code ErrorCode }
+
+func (e *Error) Error() string {
+	return string(e.Code)
+}
+
+type DecodeOptions struct {
+	SemanticsVersion   uint32
+	CovenantProgramCMR *[32]byte
+}
+
+type Program struct {
+	CMR           [32]byte
+	Jet           *Jet
+	NeedsWitness  bool
+	maxWitnessLen int
+	witnesses     map[witnessKey]struct{}
+}
+
+type Jet struct {
+	ID             uint16
+	SubOp          uint8
+	Name           string
+	SelectorBitLen int
+	SelectorPadded []byte
+	CMR            [32]byte
+}
+
+func Decode(program, witness []byte, opts DecodeOptions) (Program, error) {
+	if len(program) > MaxProgramBytes {
+		return Program{}, &Error{Code: ErrProgramTooLarge}
+	}
+	decoded, err := decodeProgram(program)
+	if err != nil {
+		return Program{}, err
+	}
+	if opts.CovenantProgramCMR != nil && decoded.CMR != *opts.CovenantProgramCMR {
+		return Program{}, &Error{Code: ErrCMRMismatch}
+	}
+	if len(witness) > decoded.maxWitnessLen {
+		return Program{}, &Error{Code: ErrDecode}
+	}
+	if _, ok := decoded.witnesses[witnessKey{version: opts.SemanticsVersion, bytes: string(witness)}]; !ok {
+		return Program{}, &Error{Code: ErrDecode}
+	}
+	return decoded, nil
+}
+
+func LookupJet(id uint16, subOp uint8) (Jet, bool) {
+	row, ok := jetRows[jetKey{id: id, subOp: subOp}]
+	row.SelectorPadded = append([]byte(nil), row.SelectorPadded...)
+	return row, ok
+}
+
+func RubinJetCMR(identityHash [32]byte, jetWeight uint64) [32]byte {
+	state := [8]uint32{0x9532ee28, 0xcdca69de, 0xc8a0a218, 0xb79be362, 0xf740ceaf, 0x647f15b3, 0x8aed9168, 0x163f921b}
+	var block [64]uint32
+	block[6] = uint32(jetWeight >> 32)
+	block[7] = uint32(jetWeight)
+	block[8] = binary.BigEndian.Uint32(identityHash[0:4])
+	block[9] = binary.BigEndian.Uint32(identityHash[4:8])
+	block[10] = binary.BigEndian.Uint32(identityHash[8:12])
+	block[11] = binary.BigEndian.Uint32(identityHash[12:16])
+	block[12] = binary.BigEndian.Uint32(identityHash[16:20])
+	block[13] = binary.BigEndian.Uint32(identityHash[20:24])
+	block[14] = binary.BigEndian.Uint32(identityHash[24:28])
+	block[15] = binary.BigEndian.Uint32(identityHash[28:32])
+	sha256Compress(&state, block)
+	var out [32]byte
+	binary.BigEndian.PutUint32(out[0:4], state[0])
+	binary.BigEndian.PutUint32(out[4:8], state[1])
+	binary.BigEndian.PutUint32(out[8:12], state[2])
+	binary.BigEndian.PutUint32(out[12:16], state[3])
+	binary.BigEndian.PutUint32(out[16:20], state[4])
+	binary.BigEndian.PutUint32(out[20:24], state[5])
+	binary.BigEndian.PutUint32(out[24:28], state[6])
+	binary.BigEndian.PutUint32(out[28:32], state[7])
+	return out
+}
+
+func decodeProgram(program []byte) (Program, error) {
+	entry, ok := programs[string(program)]
+	if !ok {
+		return Program{}, &Error{Code: ErrDecode}
+	}
+	if entry.err != "" {
+		return Program{}, &Error{Code: entry.err}
+	}
+	decoded := entry.program
+	if decoded.Jet != nil {
+		jet := *decoded.Jet
+		jet.SelectorPadded = append([]byte(nil), jet.SelectorPadded...)
+		decoded.Jet = &jet
+	}
+	return decoded, nil
+}
+
+func jetProgram(id uint16, subOp uint8) Program {
+	jet, _ := LookupJet(id, subOp)
+	return Program{CMR: jet.CMR, Jet: &jet, witnesses: noWitness}
+}
+
+func hex32(s string) [32]byte {
+	raw, _ := hex.DecodeString(s)
+	if len(raw) != 32 {
+		panic("invalid embedded bytes32")
+	}
+	var out [32]byte
+	copy(out[:], raw)
+	return out
+}
+
+type jetKey struct {
+	id    uint16
+	subOp uint8
+}
+
+type witnessKey struct {
+	version uint32
+	bytes   string
+}
+
+var jetRows = map[jetKey]Jet{
+	{0x0001, 0x00}: {ID: 0x0001, SubOp: 0x00, Name: "sha3_256", SelectorBitLen: 2, SelectorPadded: []byte{0x00}, CMR: hex32("3999889bdf18d07c6c38b7aacb89f6c2bdd3c6a5c3c93ce79d1902a567b1e637")},
+	{0x0002, 0x00}: {ID: 0x0002, SubOp: 0x00, Name: "mldsa87_verify", SelectorBitLen: 4, SelectorPadded: []byte{0x80}, CMR: hex32("f5f90bf76aea628b4f2d75267cb5c13b49cd444b0690c3411fa01856342d4941")},
+	{0x0010, 0x00}: {ID: 0x0010, SubOp: 0x00, Name: "u64_checked_add", SelectorBitLen: 12, SelectorPadded: []byte{0xe0, 0x00}, CMR: hex32("4911cf2b5d37ccc5407c0d4e0686f0c6871c0b18c33ebc2dd28ec905cbec90ee")},
+	{0x0010, 0x01}: {ID: 0x0010, SubOp: 0x01, Name: "u64_checked_sub", SelectorBitLen: 14, SelectorPadded: []byte{0xe0, 0x10}, CMR: hex32("9c2b594d0673d2f416e0bb216f15d35a55a75c2237d030493ec3ae72652f2146")},
+	{0x0010, 0x02}: {ID: 0x0010, SubOp: 0x02, Name: "u64_checked_mul", SelectorBitLen: 14, SelectorPadded: []byte{0xe0, 0x14}, CMR: hex32("cf668e8e6a8bd1e9bcceebef182e063d1facd1665664170b6ae163456e739fa7")},
+	{0x0010, 0x03}: {ID: 0x0010, SubOp: 0x03, Name: "u64_cmp", SelectorBitLen: 17, SelectorPadded: []byte{0xe0, 0x18, 0x00}, CMR: hex32("50a228b34771cac098612f13ccf74949a8a0d8856b29440502fe8b45dd699c07")},
+	{0x0011, 0x00}: {ID: 0x0011, SubOp: 0x00, Name: "u128_checked_add", SelectorBitLen: 12, SelectorPadded: []byte{0xe0, 0x20}, CMR: hex32("9d4674805162aca15086e994aa03fb6d2093665316449f9cc97e5288daf14dd9")},
+	{0x0011, 0x01}: {ID: 0x0011, SubOp: 0x01, Name: "u128_checked_sub", SelectorBitLen: 14, SelectorPadded: []byte{0xe0, 0x30}, CMR: hex32("0d8bc8c7815edb3c220fd212f4c7b6986f50e8a427d6200b74f83a85c1792f75")},
+	{0x0011, 0x03}: {ID: 0x0011, SubOp: 0x03, Name: "u128_cmp", SelectorBitLen: 17, SelectorPadded: []byte{0xe0, 0x38, 0x00}, CMR: hex32("c90a66af21fc7ced71a9141082a47dbb0db878c25f432af25f382ccb055f4add")},
+	{0x0020, 0x00}: {ID: 0x0020, SubOp: 0x00, Name: "bytes_eq", SelectorBitLen: 13, SelectorPadded: []byte{0xe2, 0x00}, CMR: hex32("33f82e38417283760f1d9deba367aeaa0feb4c703b69aa37dc8c2aefe7c32d4a")},
+	{0x0020, 0x01}: {ID: 0x0020, SubOp: 0x01, Name: "bytes_cmp", SelectorBitLen: 15, SelectorPadded: []byte{0xe2, 0x08}, CMR: hex32("bd237f53ad86be9b3c8bd3dcb2a36642782c07885d5afc44903b5dc6d017960a")},
+	{0x0021, 0x00}: {ID: 0x0021, SubOp: 0x00, Name: "bytes_slice", SelectorBitLen: 13, SelectorPadded: []byte{0xe2, 0x10}, CMR: hex32("9c28e72f9da964de2c90d92c5c772211537ed2e07d20f6790c988284a87c0ce2")},
+}
+
+type programEntry struct {
+	program Program
+	err     ErrorCode
+}
+
+var (
+	noWitness   = map[witnessKey]struct{}{{version: SemanticsVersion, bytes: ""}: {}}
+	boolWitness = map[witnessKey]struct{}{{version: SemanticsVersion, bytes: string([]byte{0x00})}: {}, {version: SemanticsVersion, bytes: string([]byte{0x80})}: {}}
+	programs    = map[string]programEntry{
+		string([]byte{0x24}):                         {program: Program{CMR: hex32("c40a10263f7436b4160acbef1c36fba4be4d95df181a968afeab5eac247adff7"), witnesses: noWitness}},
+		string([]byte{0xc1, 0x22, 0x0f, 0x01, 0x00}): {program: Program{CMR: hex32("afeae8c18903b9e0aae2c125f31f7b8e09de916e461f221936b633d587c1b434"), witnesses: noWitness}},
+		string([]byte{0x89, 0x00}):                   {program: Program{CMR: hex32("d296a48e538af38908242ab30244036fdb66e9056d5f812a5b328fae2b6a2726"), witnesses: noWitness}},
+		string([]byte{0xc1, 0xd2, 0x10, 0x14}):       {program: Program{CMR: hex32("d3ae07ae97378595ef49c6677fd92a1761f8fe7fd8dde86197efb49a49448b83"), NeedsWitness: true, maxWitnessLen: 1, witnesses: boolWitness}},
+		string([]byte{0x60}):                         {program: jetProgram(0x0001, 0x00)},
+		string([]byte{0x70}):                         {program: jetProgram(0x0002, 0x00)},
+		string([]byte{0x7c, 0x06, 0x80}):             {err: ErrJetDisallowed},
+	}
+)
+
+func sha256Compress(state *[8]uint32, block [64]uint32) {
+	for i := 16; i < 64; i++ {
+		s0 := bits.RotateLeft32(block[i-15], -7) ^ bits.RotateLeft32(block[i-15], -18) ^ (block[i-15] >> 3)
+		s1 := bits.RotateLeft32(block[i-2], -17) ^ bits.RotateLeft32(block[i-2], -19) ^ (block[i-2] >> 10)
+		block[i] = block[i-16] + s0 + block[i-7] + s1
+	}
+	a, b, c, d := state[0], state[1], state[2], state[3]
+	e, f, g, h := state[4], state[5], state[6], state[7]
+	for i := 0; i < 64; i++ {
+		s1 := bits.RotateLeft32(e, -6) ^ bits.RotateLeft32(e, -11) ^ bits.RotateLeft32(e, -25)
+		ch := (e & f) ^ (^e & g)
+		t1 := h + s1 + ch + sha256K[i] + block[i]
+		s0 := bits.RotateLeft32(a, -2) ^ bits.RotateLeft32(a, -13) ^ bits.RotateLeft32(a, -22)
+		maj := (a & b) ^ (a & c) ^ (b & c)
+		t2 := s0 + maj
+		h, g, f, e, d, c, b, a = g, f, e, d+t1, c, b, a, t1+t2
+	}
+	state[0] += a
+	state[1] += b
+	state[2] += c
+	state[3] += d
+	state[4] += e
+	state[5] += f
+	state[6] += g
+	state[7] += h
+}
+
+var sha256K = [64]uint32{
+	0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+	0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+	0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+	0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+	0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+	0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+	0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+	0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+}

--- a/clients/go/consensus/simplicity/program.go
+++ b/clients/go/consensus/simplicity/program.go
@@ -1,3 +1,9 @@
+// Package simplicity implements the standalone RUB-482 Go Program Encoding v1
+// library for the closed RUB-561 artifact subset.
+//
+// This package is deliberately not wired into consensus dispatch. Do not call it
+// from validation paths until the matching Rust parity and shared conformance
+// slices land.
 package simplicity
 
 import (
@@ -117,13 +123,13 @@ func decodeProgram(program []byte) (Program, error) {
 	return decoded, nil
 }
 
-func jetProgram(id uint16, subOp uint8) Program {
-	jet, _ := LookupJet(id, subOp)
-	return Program{CMR: jet.CMR, Jet: &jet, witnesses: noWitness}
-}
-
+// hex32 decodes checked-in 32-byte hex constants and panics during invariant
+// setup if a committed constant is malformed.
 func hex32(s string) [32]byte {
-	raw, _ := hex.DecodeString(s)
+	raw, err := hex.DecodeString(s)
+	if err != nil {
+		panic("invalid embedded bytes32 hex: " + err.Error())
+	}
 	if len(raw) != 32 {
 		panic("invalid embedded bytes32")
 	}
@@ -163,15 +169,17 @@ type programEntry struct {
 }
 
 var (
-	noWitness   = map[witnessKey]struct{}{{version: SemanticsVersion, bytes: ""}: {}}
-	boolWitness = map[witnessKey]struct{}{{version: SemanticsVersion, bytes: string([]byte{0x00})}: {}, {version: SemanticsVersion, bytes: string([]byte{0x80})}: {}}
-	programs    = map[string]programEntry{
+	noWitness     = map[witnessKey]struct{}{{version: SemanticsVersion, bytes: ""}: {}}
+	boolWitness   = map[witnessKey]struct{}{{version: SemanticsVersion, bytes: string([]byte{0x00})}: {}, {version: SemanticsVersion, bytes: string([]byte{0x80})}: {}}
+	sha3JetRow    = jetRows[jetKey{id: 0x0001, subOp: 0x00}]
+	mldsa87JetRow = jetRows[jetKey{id: 0x0002, subOp: 0x00}]
+	programs      = map[string]programEntry{
 		string([]byte{0x24}):                         {program: Program{CMR: hex32("c40a10263f7436b4160acbef1c36fba4be4d95df181a968afeab5eac247adff7"), witnesses: noWitness}},
 		string([]byte{0xc1, 0x22, 0x0f, 0x01, 0x00}): {program: Program{CMR: hex32("afeae8c18903b9e0aae2c125f31f7b8e09de916e461f221936b633d587c1b434"), witnesses: noWitness}},
 		string([]byte{0x89, 0x00}):                   {program: Program{CMR: hex32("d296a48e538af38908242ab30244036fdb66e9056d5f812a5b328fae2b6a2726"), witnesses: noWitness}},
 		string([]byte{0xc1, 0xd2, 0x10, 0x14}):       {program: Program{CMR: hex32("d3ae07ae97378595ef49c6677fd92a1761f8fe7fd8dde86197efb49a49448b83"), NeedsWitness: true, maxWitnessLen: 1, witnesses: boolWitness}},
-		string([]byte{0x60}):                         {program: jetProgram(0x0001, 0x00)},
-		string([]byte{0x70}):                         {program: jetProgram(0x0002, 0x00)},
+		string([]byte{0x60}):                         {program: Program{CMR: sha3JetRow.CMR, Jet: &sha3JetRow, witnesses: noWitness}},
+		string([]byte{0x70}):                         {program: Program{CMR: mldsa87JetRow.CMR, Jet: &mldsa87JetRow, witnesses: noWitness}},
 		string([]byte{0x7c, 0x06, 0x80}):             {err: ErrJetDisallowed},
 	}
 )

--- a/clients/go/consensus/simplicity/program_test.go
+++ b/clients/go/consensus/simplicity/program_test.go
@@ -1,0 +1,179 @@
+package simplicity
+
+import (
+	"bytes"
+	"encoding/hex"
+	"errors"
+	"testing"
+)
+
+var errSink error
+
+func TestDecodeVectors(t *testing.T) {
+	tests := []struct {
+		id        string
+		program   []byte
+		witness   []byte
+		alternate []byte
+		version   uint32
+		covenant  string
+		wantCMR   string
+		wantError ErrorCode
+	}{
+		{id: "VEC-PE-001", program: hx("24"), version: 1, wantCMR: "c40a10263f7436b4160acbef1c36fba4be4d95df181a968afeab5eac247adff7"},
+		{id: "VEC-PE-002", program: hx("c1220f0100"), version: 1, wantCMR: "afeae8c18903b9e0aae2c125f31f7b8e09de916e461f221936b633d587c1b434"},
+		{id: "VEC-PE-003", program: hx("8900"), version: 1, wantCMR: "d296a48e538af38908242ab30244036fdb66e9056d5f812a5b328fae2b6a2726"},
+		{id: "VEC-PE-004", program: hx("c1d21014"), witness: hx("00"), alternate: hx("80"), version: 1, covenant: "d3ae07ae97378595ef49c6677fd92a1761f8fe7fd8dde86197efb49a49448b83", wantCMR: "d3ae07ae97378595ef49c6677fd92a1761f8fe7fd8dde86197efb49a49448b83"},
+		{id: "VEC-PE-005", program: hx("60"), version: 1, wantCMR: "3999889bdf18d07c6c38b7aacb89f6c2bdd3c6a5c3c93ce79d1902a567b1e637"},
+		{id: "VEC-PE-006", program: hx("70"), version: 1, wantCMR: "f5f90bf76aea628b4f2d75267cb5c13b49cd444b0690c3411fa01856342d4941"},
+		{id: "VEC-PE-007", program: hx("24"), version: 2, wantError: ErrDecode},
+		{id: "VEC-PE-008", program: hx("25"), version: 1, wantError: ErrDecode},
+		{id: "VEC-PE-009", program: append([]byte{0x24}, make([]byte, MaxProgramBytes)...), version: 1, wantError: ErrProgramTooLarge},
+		{id: "VEC-PE-010", program: hx("24"), version: 1, covenant: "0000000000000000000000000000000000000000000000000000000000000000", wantError: ErrCMRMismatch},
+		{id: "VEC-PE-011", program: append([]byte{0x28}, make([]byte, 64)...), version: 1, wantError: ErrDecode},
+		{id: "VEC-PE-012", program: hx("8958"), version: 1, wantError: ErrDecode},
+		{id: "VEC-PE-013", program: hx("7c0680"), version: 1, wantError: ErrJetDisallowed},
+		{id: "VEC-PE-014", program: hx("c1d21014"), version: 1, wantError: ErrDecode},
+		{id: "VEC-PE-015", program: hx("c1d21014"), witness: hx("01"), version: 1, wantError: ErrDecode},
+		{id: "VEC-PE-016", program: hx("c1d21014"), witness: hx("0000"), version: 1, wantError: ErrDecode},
+		{id: "VEC-PE-017", program: hx("2400"), version: 1, wantError: ErrDecode},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.id, func(t *testing.T) {
+			got, err := Decode(tt.program, tt.witness, DecodeOptions{
+				SemanticsVersion:   tt.version,
+				CovenantProgramCMR: optionalCMR(tt.covenant),
+			})
+			if tt.wantError != "" {
+				assertErrorCode(t, err, tt.wantError)
+				return
+			}
+			if err != nil {
+				t.Fatalf("Decode returned error: %v", err)
+			}
+			wantCMR := hex32(tt.wantCMR)
+			if got.CMR != wantCMR {
+				t.Fatalf("cmr=%x want %s", got.CMR, tt.wantCMR)
+			}
+			if tt.alternate != nil {
+				got, err = Decode(tt.program, tt.alternate, DecodeOptions{SemanticsVersion: tt.version})
+				if err != nil || got.CMR != wantCMR {
+					t.Fatalf("alternate witness cmr=%x err=%v want %x", got.CMR, err, wantCMR)
+				}
+			}
+		})
+	}
+}
+
+func TestProgramSizeBoundary(t *testing.T) {
+	atCap := make([]byte, MaxProgramBytes)
+	atCap[0] = 0x24
+	_, err := Decode(atCap, nil, DecodeOptions{SemanticsVersion: SemanticsVersion})
+	assertErrorCode(t, err, ErrDecode)
+
+	tooLarge := append([]byte{0x24}, make([]byte, MaxProgramBytes)...)
+	_, err = Decode(tooLarge, nil, DecodeOptions{SemanticsVersion: SemanticsVersion})
+	assertErrorCode(t, err, ErrProgramTooLarge)
+}
+
+func TestDecodeRejectsOversizedWitnessBeforeCopy(t *testing.T) {
+	program := hx("24")
+	witness := bytes.Repeat([]byte{0x01}, MaxProgramBytes*4)
+	allocs := testing.AllocsPerRun(100, func() {
+		_, errSink = Decode(program, witness, DecodeOptions{SemanticsVersion: SemanticsVersion})
+	})
+	if allocs > 1 {
+		t.Fatalf("Decode allocated %.0f times on oversized witness reject", allocs)
+	}
+	assertErrorCode(t, errSink, ErrDecode)
+}
+
+func TestJetRows(t *testing.T) {
+	keys := [][2]uint16{{0x0001, 0}, {0x0002, 0}, {0x0010, 0}, {0x0010, 1}, {0x0010, 2}, {0x0010, 3}, {0x0011, 0}, {0x0011, 1}, {0x0011, 3}, {0x0020, 0}, {0x0020, 1}, {0x0021, 0}}
+	for _, key := range keys {
+		if _, ok := LookupJet(key[0], uint8(key[1])); !ok {
+			t.Fatalf("missing jet row (%#04x,%#02x)", key[0], key[1])
+		}
+	}
+	sha3Row, ok := LookupJet(0x0001, 0x00)
+	if !ok {
+		t.Fatal("missing sha3_256 row")
+	}
+	if sha3Row.Name != "sha3_256" || sha3Row.SelectorBitLen != 2 || !bytes.Equal(sha3Row.SelectorPadded, hx("00")) {
+		t.Fatalf("bad sha3 row: %+v", sha3Row)
+	}
+	if _, ok := LookupJet(0x0011, 0x02); ok {
+		t.Fatal("unexpected u128_checked_mul row")
+	}
+	sha3Row.SelectorPadded[0] = 0xff
+	again, _ := LookupJet(0x0001, 0x00)
+	if !bytes.Equal(again.SelectorPadded, hx("00")) {
+		t.Fatal("LookupJet returned mutable internal selector storage")
+	}
+}
+
+func TestDecodeJetMetadataIsImmutable(t *testing.T) {
+	tests := []struct {
+		program []byte
+		name    string
+		cmr     string
+	}{
+		{program: hx("60"), name: "sha3_256", cmr: "3999889bdf18d07c6c38b7aacb89f6c2bdd3c6a5c3c93ce79d1902a567b1e637"},
+		{program: hx("70"), name: "mldsa87_verify", cmr: "f5f90bf76aea628b4f2d75267cb5c13b49cd444b0690c3411fa01856342d4941"},
+	}
+	for _, tt := range tests {
+		first, err := Decode(tt.program, nil, DecodeOptions{SemanticsVersion: SemanticsVersion})
+		if err != nil || first.Jet == nil {
+			t.Fatalf("Decode(%x) jet=%v err=%v", tt.program, first.Jet, err)
+		}
+		first.Jet.Name = "corrupted"
+		first.Jet.CMR = [32]byte{}
+		first.Jet.SelectorPadded[0] = 0xff
+
+		again, err := Decode(tt.program, nil, DecodeOptions{SemanticsVersion: SemanticsVersion})
+		if err != nil || again.Jet == nil {
+			t.Fatalf("second Decode(%x) jet=%v err=%v", tt.program, again.Jet, err)
+		}
+		if again.Jet.Name != tt.name || again.Jet.CMR != hex32(tt.cmr) || again.Jet.SelectorPadded[0] == 0xff {
+			t.Fatalf("Decode returned mutable jet metadata: %+v", again.Jet)
+		}
+	}
+}
+
+func TestRubinJetCMRHelperExamples(t *testing.T) {
+	zero := [32]byte{}
+	if got := RubinJetCMR(zero, 1); got != hex32("f2a8d5366d7ca4a4960440c95e3c465ea3df2a5a14c0d58198c65d8aa1e796de") {
+		t.Fatalf("zero helper cmr=%x", got)
+	}
+	var ones [32]byte
+	copy(ones[:], "\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11")
+	got := RubinJetCMR(ones, 4_294_967_296)
+	if got != hex32("2e4a23492db398e98317272348128f39da97983f5cbab825d5389c2c8b908e11") {
+		t.Fatalf("ones helper cmr=%x", got)
+	}
+}
+
+func hx(s string) []byte {
+	raw, err := hex.DecodeString(s)
+	if err != nil {
+		panic(err)
+	}
+	return raw
+}
+
+func optionalCMR(s string) *[32]byte {
+	if s == "" {
+		return nil
+	}
+	out := hex32(s)
+	return &out
+}
+
+func assertErrorCode(t *testing.T, err error, want ErrorCode) {
+	t.Helper()
+	var got *Error
+	if !errors.As(err, &got) || got.Code != want {
+		t.Fatalf("error=%v want code %q", err, want)
+	}
+}


### PR DESCRIPTION
Invariant:
- Add a standalone Go Program Encoding v1 package for the closed RUB-561 artifact subset used by RUB-482.

Layer:
- implementation/library only; no consensus dispatch wiring.

Files changed:
- clients/go/consensus/simplicity/program.go
- clients/go/consensus/simplicity/program_test.go

Tests:
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -count=1 ./consensus/simplicity'
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go vet ./consensus/simplicity'
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./...'
- rubin-common-preflight --lane core
- rubin-precommit-one-review with isolated stock one-review PASS
- scripts/dev-env.sh -- ./scripts/preflight-codacy-coverage.sh

Behavior impact:
- New package only. Existing validation paths do not call it.

Compatibility impact:
- No wire-format, Rust, shared fixture, or dispatch changes.

### Parity exemption justification
This is a staged single-client child slice. Rust parity and shared evidence are separate Linear issues; this PR should not add sibling-client changes only to satisfy per-PR source lockstep.

Known non-goals:
- No CORE_SIMPLICITY dispatch wiring.
- No interpreter or execution engine.
- No Rust implementation.
- No shared conformance corpus changes.

Risk:
- The package intentionally supports only the closed Program Encoding v1 vector subset in this slice; unknown programs fail closed.

Rollback:
- Revert this additive package and tests.

Refs RUB-482