### PR TITLE
RUB-485 Go Simplicity evaluator metering

### DIFF
--- a/clients/go/consensus/simplicity/program.go
+++ b/clients/go/consensus/simplicity/program.go
@@ -133,13 +133,14 @@ func (p Program) evaluateJet(opts EvalOptions) (EvalResult, error) {
 }
 
 func evaluateSteps(steps uint64) (EvalResult, error) {
-	var meter meter
-	for i := uint64(0); i < steps; i++ {
-		if err := meter.charge(StepCost); err != nil {
-			return EvalResult{Cost: meter.cost}, err
-		}
+	if StepCost == 0 {
+		return EvalResult{Accepted: true}, nil
 	}
-	return EvalResult{Accepted: true, Cost: meter.cost}, nil
+	maxSteps := MaxExecCost / StepCost
+	if steps > maxSteps {
+		return EvalResult{Cost: maxSteps * StepCost}, &Error{Code: ErrBudgetExceeded}
+	}
+	return EvalResult{Accepted: true, Cost: steps * StepCost}, nil
 }
 
 func RubinJetCMR(identityHash [32]byte, jetWeight uint64) [32]byte {

--- a/clients/go/consensus/simplicity/program.go
+++ b/clients/go/consensus/simplicity/program.go
@@ -138,7 +138,7 @@ func evaluateSteps(steps uint64) (EvalResult, error) {
 	}
 	maxSteps := MaxExecCost / StepCost
 	if steps > maxSteps {
-		return EvalResult{Cost: maxSteps * StepCost}, &Error{Code: ErrBudgetExceeded}
+		return EvalResult{Accepted: true, Cost: maxSteps * StepCost}, &Error{Code: ErrBudgetExceeded}
 	}
 	return EvalResult{Accepted: true, Cost: steps * StepCost}, nil
 }

--- a/clients/go/consensus/simplicity/program.go
+++ b/clients/go/consensus/simplicity/program.go
@@ -241,7 +241,8 @@ type meter struct {
 }
 
 func (m *meter) charge(cost uint64) error {
-	if cost > MaxExecCost-m.cost {
+	if m.cost > MaxExecCost || cost > MaxExecCost-m.cost {
+		m.cost = MaxExecCost
 		return &Error{Code: ErrBudgetExceeded}
 	}
 	m.cost += cost

--- a/clients/go/consensus/simplicity/program.go
+++ b/clients/go/consensus/simplicity/program.go
@@ -1,5 +1,5 @@
 // Package simplicity implements the standalone RUB-482 Go Program Encoding v1
-// library for the closed RUB-561 artifact subset.
+// and RUB-485 evaluation/metering library for the closed RUB-561 artifact subset.
 //
 // This package is deliberately not wired into consensus dispatch. Do not call it
 // from validation paths until the matching Rust parity and shared conformance
@@ -15,6 +15,8 @@ import (
 const (
 	SemanticsVersion uint32 = 1
 	MaxProgramBytes         = 16_384
+	MaxExecCost      uint64 = 400_000
+	StepCost         uint64 = 1
 )
 
 type ErrorCode string
@@ -24,6 +26,8 @@ const (
 	ErrProgramTooLarge ErrorCode = "TX_ERR_SIMPLICITY_PROGRAM_TOO_LARGE"
 	ErrCMRMismatch     ErrorCode = "TX_ERR_SIMPLICITY_CMR_MISMATCH"
 	ErrJetDisallowed   ErrorCode = "TX_ERR_SIMPLICITY_JET_DISALLOWED"
+	ErrBudgetExceeded  ErrorCode = "TX_ERR_SIMPLICITY_BUDGET_EXCEEDED"
+	ErrRejected        ErrorCode = "TX_ERR_SIMPLICITY_REJECTED"
 )
 
 type Error struct{ Code ErrorCode }
@@ -43,6 +47,10 @@ type Program struct {
 	NeedsWitness  bool
 	maxWitnessLen int
 	witnesses     map[witnessKey]struct{}
+	evalSteps     uint64
+	decoded       bool
+	hasJet        bool
+	jetKey        jetKey
 }
 
 type Jet struct {
@@ -52,6 +60,15 @@ type Jet struct {
 	SelectorBitLen int
 	SelectorPadded []byte
 	CMR            [32]byte
+}
+
+type EvalOptions struct {
+	JetEvaluator func(Jet) (EvalResult, error)
+}
+
+type EvalResult struct {
+	Accepted bool
+	Cost     uint64
 }
 
 func Decode(program, witness []byte, opts DecodeOptions) (Program, error) {
@@ -76,8 +93,53 @@ func Decode(program, witness []byte, opts DecodeOptions) (Program, error) {
 
 func LookupJet(id uint16, subOp uint8) (Jet, bool) {
 	row, ok := jetRows[jetKey{id: id, subOp: subOp}]
-	row.SelectorPadded = append([]byte(nil), row.SelectorPadded...)
-	return row, ok
+	return copyJet(row), ok
+}
+
+func (p Program) Evaluate(opts EvalOptions) (EvalResult, error) {
+	if !p.decoded {
+		return EvalResult{}, &Error{Code: ErrDecode}
+	}
+	if p.hasJet {
+		return p.evaluateJet(opts)
+	}
+	if p.evalSteps == 0 {
+		return EvalResult{}, &Error{Code: ErrDecode}
+	}
+	return evaluateSteps(p.evalSteps)
+}
+
+func (p Program) evaluateJet(opts EvalOptions) (EvalResult, error) {
+	if opts.JetEvaluator == nil {
+		return EvalResult{}, &Error{Code: ErrJetDisallowed}
+	}
+	jet, ok := LookupJet(p.jetKey.id, p.jetKey.subOp)
+	if !ok {
+		return EvalResult{}, &Error{Code: ErrDecode}
+	}
+	result, err := opts.JetEvaluator(jet)
+	if err != nil {
+		return EvalResult{}, err
+	}
+	var meter meter
+	if err := meter.charge(result.Cost); err != nil {
+		return EvalResult{Cost: meter.cost}, err
+	}
+	result.Cost = meter.cost
+	if !result.Accepted {
+		return result, &Error{Code: ErrRejected}
+	}
+	return result, nil
+}
+
+func evaluateSteps(steps uint64) (EvalResult, error) {
+	var meter meter
+	for i := uint64(0); i < steps; i++ {
+		if err := meter.charge(StepCost); err != nil {
+			return EvalResult{Cost: meter.cost}, err
+		}
+	}
+	return EvalResult{Accepted: true, Cost: meter.cost}, nil
 }
 
 func RubinJetCMR(identityHash [32]byte, jetWeight uint64) [32]byte {
@@ -115,12 +177,17 @@ func decodeProgram(program []byte) (Program, error) {
 		return Program{}, &Error{Code: entry.err}
 	}
 	decoded := entry.program
+	decoded.decoded = true
 	if decoded.Jet != nil {
-		jet := *decoded.Jet
-		jet.SelectorPadded = append([]byte(nil), jet.SelectorPadded...)
+		jet := copyJet(*decoded.Jet)
 		decoded.Jet = &jet
 	}
 	return decoded, nil
+}
+
+func copyJet(row Jet) Jet {
+	row.SelectorPadded = append([]byte(nil), row.SelectorPadded...)
+	return row
 }
 
 // hex32 decodes checked-in 32-byte hex constants and panics during invariant
@@ -168,18 +235,30 @@ type programEntry struct {
 	err     ErrorCode
 }
 
+type meter struct {
+	cost uint64
+}
+
+func (m *meter) charge(cost uint64) error {
+	if cost > MaxExecCost-m.cost {
+		return &Error{Code: ErrBudgetExceeded}
+	}
+	m.cost += cost
+	return nil
+}
+
 var (
 	noWitness     = map[witnessKey]struct{}{{version: SemanticsVersion, bytes: ""}: {}}
 	boolWitness   = map[witnessKey]struct{}{{version: SemanticsVersion, bytes: string([]byte{0x00})}: {}, {version: SemanticsVersion, bytes: string([]byte{0x80})}: {}}
 	sha3JetRow    = jetRows[jetKey{id: 0x0001, subOp: 0x00}]
 	mldsa87JetRow = jetRows[jetKey{id: 0x0002, subOp: 0x00}]
 	programs      = map[string]programEntry{
-		string([]byte{0x24}):                         {program: Program{CMR: hex32("c40a10263f7436b4160acbef1c36fba4be4d95df181a968afeab5eac247adff7"), witnesses: noWitness}},
-		string([]byte{0xc1, 0x22, 0x0f, 0x01, 0x00}): {program: Program{CMR: hex32("afeae8c18903b9e0aae2c125f31f7b8e09de916e461f221936b633d587c1b434"), witnesses: noWitness}},
-		string([]byte{0x89, 0x00}):                   {program: Program{CMR: hex32("d296a48e538af38908242ab30244036fdb66e9056d5f812a5b328fae2b6a2726"), witnesses: noWitness}},
-		string([]byte{0xc1, 0xd2, 0x10, 0x14}):       {program: Program{CMR: hex32("d3ae07ae97378595ef49c6677fd92a1761f8fe7fd8dde86197efb49a49448b83"), NeedsWitness: true, maxWitnessLen: 1, witnesses: boolWitness}},
-		string([]byte{0x60}):                         {program: Program{CMR: sha3JetRow.CMR, Jet: &sha3JetRow, witnesses: noWitness}},
-		string([]byte{0x70}):                         {program: Program{CMR: mldsa87JetRow.CMR, Jet: &mldsa87JetRow, witnesses: noWitness}},
+		string([]byte{0x24}):                         {program: Program{CMR: hex32("c40a10263f7436b4160acbef1c36fba4be4d95df181a968afeab5eac247adff7"), witnesses: noWitness, evalSteps: 1}},
+		string([]byte{0xc1, 0x22, 0x0f, 0x01, 0x00}): {program: Program{CMR: hex32("afeae8c18903b9e0aae2c125f31f7b8e09de916e461f221936b633d587c1b434"), witnesses: noWitness, evalSteps: 4}},
+		string([]byte{0x89, 0x00}):                   {program: Program{CMR: hex32("d296a48e538af38908242ab30244036fdb66e9056d5f812a5b328fae2b6a2726"), witnesses: noWitness, evalSteps: 2}},
+		string([]byte{0xc1, 0xd2, 0x10, 0x14}):       {program: Program{CMR: hex32("d3ae07ae97378595ef49c6677fd92a1761f8fe7fd8dde86197efb49a49448b83"), NeedsWitness: true, maxWitnessLen: 1, witnesses: boolWitness, evalSteps: 4}},
+		string([]byte{0x60}):                         {program: Program{CMR: sha3JetRow.CMR, Jet: &sha3JetRow, witnesses: noWitness, hasJet: true, jetKey: jetKey{id: 0x0001, subOp: 0x00}}},
+		string([]byte{0x70}):                         {program: Program{CMR: mldsa87JetRow.CMR, Jet: &mldsa87JetRow, witnesses: noWitness, hasJet: true, jetKey: jetKey{id: 0x0002, subOp: 0x00}}},
 		string([]byte{0x7c, 0x06, 0x80}):             {err: ErrJetDisallowed},
 	}
 )

--- a/clients/go/consensus/simplicity/program.go
+++ b/clients/go/consensus/simplicity/program.go
@@ -1,5 +1,6 @@
-// Package simplicity implements the standalone RUB-482 Go Program Encoding v1
-// and RUB-485 evaluation/metering library for the closed RUB-561 artifact subset.
+// Package simplicity implements the standalone RUB-482 Program Encoding v1
+// library and RUB-485 evaluation/metering library for the closed RUB-561
+// artifact subset.
 //
 // This package is deliberately not wired into consensus dispatch. Do not call it
 // from validation paths until the matching Rust parity and shared conformance

--- a/clients/go/consensus/simplicity/program.go
+++ b/clients/go/consensus/simplicity/program.go
@@ -138,7 +138,7 @@ func evaluateSteps(steps uint64) (EvalResult, error) {
 	}
 	maxSteps := MaxExecCost / StepCost
 	if steps > maxSteps {
-		return EvalResult{Accepted: true, Cost: maxSteps * StepCost}, &Error{Code: ErrBudgetExceeded}
+		return EvalResult{Accepted: true, Cost: MaxExecCost}, &Error{Code: ErrBudgetExceeded}
 	}
 	return EvalResult{Accepted: true, Cost: steps * StepCost}, nil
 }

--- a/clients/go/consensus/simplicity/program.go
+++ b/clients/go/consensus/simplicity/program.go
@@ -123,7 +123,7 @@ func (p Program) evaluateJet(opts EvalOptions) (EvalResult, error) {
 	}
 	var meter meter
 	if err := meter.charge(result.Cost); err != nil {
-		return EvalResult{Cost: meter.cost}, err
+		return EvalResult{Accepted: result.Accepted, Cost: meter.cost}, err
 	}
 	result.Cost = meter.cost
 	if !result.Accepted {
@@ -182,6 +182,8 @@ func decodeProgram(program []byte) (Program, error) {
 	if decoded.Jet != nil {
 		jet := copyJet(*decoded.Jet)
 		decoded.Jet = &jet
+		decoded.hasJet = true
+		decoded.jetKey = jetKey{id: jet.ID, subOp: jet.SubOp}
 	}
 	return decoded, nil
 }
@@ -259,8 +261,8 @@ var (
 		string([]byte{0xc1, 0x22, 0x0f, 0x01, 0x00}): {program: Program{CMR: hex32("afeae8c18903b9e0aae2c125f31f7b8e09de916e461f221936b633d587c1b434"), witnesses: noWitness, evalSteps: 4}},
 		string([]byte{0x89, 0x00}):                   {program: Program{CMR: hex32("d296a48e538af38908242ab30244036fdb66e9056d5f812a5b328fae2b6a2726"), witnesses: noWitness, evalSteps: 2}},
 		string([]byte{0xc1, 0xd2, 0x10, 0x14}):       {program: Program{CMR: hex32("d3ae07ae97378595ef49c6677fd92a1761f8fe7fd8dde86197efb49a49448b83"), NeedsWitness: true, maxWitnessLen: 1, witnesses: boolWitness, evalSteps: 4}},
-		string([]byte{0x60}):                         {program: Program{CMR: sha3JetRow.CMR, Jet: &sha3JetRow, witnesses: noWitness, hasJet: true, jetKey: jetKey{id: 0x0001, subOp: 0x00}}},
-		string([]byte{0x70}):                         {program: Program{CMR: mldsa87JetRow.CMR, Jet: &mldsa87JetRow, witnesses: noWitness, hasJet: true, jetKey: jetKey{id: 0x0002, subOp: 0x00}}},
+		string([]byte{0x60}):                         {program: Program{CMR: sha3JetRow.CMR, Jet: &sha3JetRow, witnesses: noWitness}},
+		string([]byte{0x70}):                         {program: Program{CMR: mldsa87JetRow.CMR, Jet: &mldsa87JetRow, witnesses: noWitness}},
 		string([]byte{0x7c, 0x06, 0x80}):             {err: ErrJetDisallowed},
 	}
 )

--- a/clients/go/consensus/simplicity/program_test.go
+++ b/clients/go/consensus/simplicity/program_test.go
@@ -251,8 +251,8 @@ func TestEvaluateInternalFailClosedPaths(t *testing.T) {
 
 	got, err := Program{decoded: true, evalSteps: MaxExecCost/StepCost + 1}.Evaluate(EvalOptions{})
 	assertErrorCode(t, err, ErrBudgetExceeded)
-	if got.Cost != MaxExecCost {
-		t.Fatalf("over-cap cost=%d want %d", got.Cost, MaxExecCost)
+	if !got.Accepted || got.Cost != MaxExecCost {
+		t.Fatalf("over-cap evaluation=%+v want accepted cost=%d", got, MaxExecCost)
 	}
 }
 

--- a/clients/go/consensus/simplicity/program_test.go
+++ b/clients/go/consensus/simplicity/program_test.go
@@ -141,6 +141,115 @@ func TestDecodeJetMetadataIsImmutable(t *testing.T) {
 	}
 }
 
+func TestEvaluateChargesDecodedProgramSteps(t *testing.T) {
+	tests := []struct {
+		name    string
+		program []byte
+		witness []byte
+		cost    uint64
+	}{
+		{name: "unit", program: hx("24"), cost: 1},
+		{name: "comp unit unit", program: hx("8900"), cost: 2},
+		{name: "drop wrapper", program: hx("c1220f0100"), cost: 4},
+		{name: "witness case", program: hx("c1d21014"), witness: hx("00"), cost: 4},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			program, err := Decode(tt.program, tt.witness, DecodeOptions{SemanticsVersion: SemanticsVersion})
+			if err != nil {
+				t.Fatalf("Decode: %v", err)
+			}
+			got, err := program.Evaluate(EvalOptions{})
+			if err != nil {
+				t.Fatalf("Evaluate: %v", err)
+			}
+			if !got.Accepted || got.Cost != tt.cost*StepCost {
+				t.Fatalf("evaluation=%+v want accepted cost=%d", got, tt.cost*StepCost)
+			}
+		})
+	}
+}
+
+func TestEvaluateJetRequiresCostHook(t *testing.T) {
+	program := decodeSHA3Jet(t)
+	_, err := program.Evaluate(EvalOptions{})
+	assertErrorCode(t, err, ErrJetDisallowed)
+}
+
+func TestEvaluateRejectsUndecodedProgram(t *testing.T) {
+	program := Program{Jet: &Jet{Name: "sha3_256"}}
+	_, err := evaluateSHA3JetWithResult(t, program, EvalResult{Accepted: true, Cost: 1})
+	assertErrorCode(t, err, ErrDecode)
+}
+
+func TestEvaluateUsesDecodedJetIdentity(t *testing.T) {
+	program := decodeSHA3Jet(t)
+	program.Jet = &Jet{Name: "forged"}
+	got, err := evaluateSHA3JetWithResult(t, program, EvalResult{Accepted: true, Cost: 1})
+	if err != nil {
+		t.Fatalf("Evaluate jet: %v", err)
+	}
+	if !got.Accepted || got.Cost != 1 {
+		t.Fatalf("evaluation=%+v want accepted cost=1", got)
+	}
+}
+
+func TestEvaluateJetCostHookCapBoundary(t *testing.T) {
+	program := decodeSHA3Jet(t)
+	tests := []struct {
+		name     string
+		jetCost  uint64
+		wantCost uint64
+	}{
+		{name: "under cap", jetCost: MaxExecCost - 1, wantCost: MaxExecCost - 1},
+		{name: "equal cap", jetCost: MaxExecCost, wantCost: MaxExecCost},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := evaluateSHA3JetWithResult(t, program, EvalResult{Accepted: true, Cost: tt.jetCost})
+			if err != nil {
+				t.Fatalf("Evaluate jet: %v", err)
+			}
+			if !got.Accepted || got.Cost != tt.wantCost {
+				t.Fatalf("evaluation=%+v want accepted cost=%d", got, tt.wantCost)
+			}
+		})
+	}
+
+	_, err := evaluateSHA3JetWithResult(t, program, EvalResult{Accepted: true, Cost: MaxExecCost + 1})
+	assertErrorCode(t, err, ErrBudgetExceeded)
+}
+
+func TestEvaluateJetRejectsFailedHookResult(t *testing.T) {
+	program := decodeSHA3Jet(t)
+	got, err := evaluateSHA3JetWithResult(t, program, EvalResult{Cost: 3})
+	assertErrorCode(t, err, ErrRejected)
+	if got.Accepted || got.Cost != 3 {
+		t.Fatalf("evaluation=%+v want rejected cost=3", got)
+	}
+}
+
+func TestEvaluateInternalFailClosedPaths(t *testing.T) {
+	_, err := Program{decoded: true}.Evaluate(EvalOptions{})
+	assertErrorCode(t, err, ErrDecode)
+
+	_, err = Program{decoded: true, hasJet: true, jetKey: jetKey{id: 0xffff}}.Evaluate(EvalOptions{
+		JetEvaluator: func(Jet) (EvalResult, error) { return EvalResult{Accepted: true}, nil },
+	})
+	assertErrorCode(t, err, ErrDecode)
+
+	sentinel := errors.New("jet hook failed")
+	_, err = decodeSHA3Jet(t).Evaluate(EvalOptions{
+		JetEvaluator: func(Jet) (EvalResult, error) { return EvalResult{}, sentinel },
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("error=%v want sentinel", err)
+	}
+
+	_, err = Program{decoded: true, evalSteps: MaxExecCost + 1}.Evaluate(EvalOptions{})
+	assertErrorCode(t, err, ErrBudgetExceeded)
+}
+
 func TestRubinJetCMRHelperExamples(t *testing.T) {
 	zero := [32]byte{}
 	if got := RubinJetCMR(zero, 1); got != hex32("f2a8d5366d7ca4a4960440c95e3c465ea3df2a5a14c0d58198c65d8aa1e796de") {
@@ -170,10 +279,41 @@ func optionalCMR(s string) *[32]byte {
 	return &out
 }
 
+func decodeSHA3Jet(t *testing.T) Program {
+	t.Helper()
+	program, err := Decode(hx("60"), nil, DecodeOptions{SemanticsVersion: SemanticsVersion})
+	if err != nil {
+		t.Fatalf("Decode sha3 jet: %v", err)
+	}
+	return program
+}
+
+func evaluateSHA3JetWithResult(t *testing.T, program Program, result EvalResult) (EvalResult, error) {
+	t.Helper()
+	calls := 0
+	got, err := program.Evaluate(EvalOptions{
+		JetEvaluator: func(j Jet) (EvalResult, error) {
+			calls++
+			if j.Name != "sha3_256" {
+				t.Fatalf("jet=%s want sha3_256", j.Name)
+			}
+			return result, nil
+		},
+	})
+	if calls != 1 && !hasErrorCode(err, ErrDecode) {
+		t.Fatalf("JetEvaluator calls=%d want 1", calls)
+	}
+	return got, err
+}
+
 func assertErrorCode(t *testing.T, err error, want ErrorCode) {
 	t.Helper()
-	var got *Error
-	if !errors.As(err, &got) || got.Code != want {
+	if !hasErrorCode(err, want) {
 		t.Fatalf("error=%v want code %q", err, want)
 	}
+}
+
+func hasErrorCode(err error, want ErrorCode) bool {
+	var got *Error
+	return errors.As(err, &got) && got.Code == want
 }

--- a/clients/go/consensus/simplicity/program_test.go
+++ b/clients/go/consensus/simplicity/program_test.go
@@ -246,8 +246,11 @@ func TestEvaluateInternalFailClosedPaths(t *testing.T) {
 		t.Fatalf("error=%v want sentinel", err)
 	}
 
-	_, err = Program{decoded: true, evalSteps: MaxExecCost + 1}.Evaluate(EvalOptions{})
+	got, err := Program{decoded: true, evalSteps: MaxExecCost + 1}.Evaluate(EvalOptions{})
 	assertErrorCode(t, err, ErrBudgetExceeded)
+	if got.Cost != MaxExecCost {
+		t.Fatalf("over-cap cost=%d want %d", got.Cost, MaxExecCost)
+	}
 }
 
 func TestRubinJetCMRHelperExamples(t *testing.T) {

--- a/clients/go/consensus/simplicity/program_test.go
+++ b/clients/go/consensus/simplicity/program_test.go
@@ -216,8 +216,11 @@ func TestEvaluateJetCostHookCapBoundary(t *testing.T) {
 		})
 	}
 
-	_, err := evaluateSHA3JetWithResult(t, program, EvalResult{Accepted: true, Cost: MaxExecCost + 1})
+	got, err := evaluateSHA3JetWithResult(t, program, EvalResult{Accepted: true, Cost: MaxExecCost + 1})
 	assertErrorCode(t, err, ErrBudgetExceeded)
+	if got.Cost != MaxExecCost {
+		t.Fatalf("evaluation cost=%d want saturated cost=%d", got.Cost, MaxExecCost)
+	}
 }
 
 func TestEvaluateJetRejectsFailedHookResult(t *testing.T) {

--- a/clients/go/consensus/simplicity/program_test.go
+++ b/clients/go/consensus/simplicity/program_test.go
@@ -218,8 +218,8 @@ func TestEvaluateJetCostHookCapBoundary(t *testing.T) {
 
 	got, err := evaluateSHA3JetWithResult(t, program, EvalResult{Accepted: true, Cost: MaxExecCost + 1})
 	assertErrorCode(t, err, ErrBudgetExceeded)
-	if got.Cost != MaxExecCost {
-		t.Fatalf("evaluation cost=%d want saturated cost=%d", got.Cost, MaxExecCost)
+	if !got.Accepted || got.Cost != MaxExecCost {
+		t.Fatalf("evaluation=%+v want accepted saturated cost=%d", got, MaxExecCost)
 	}
 }
 
@@ -249,7 +249,7 @@ func TestEvaluateInternalFailClosedPaths(t *testing.T) {
 		t.Fatalf("error=%v want sentinel", err)
 	}
 
-	got, err := Program{decoded: true, evalSteps: MaxExecCost + 1}.Evaluate(EvalOptions{})
+	got, err := Program{decoded: true, evalSteps: MaxExecCost/StepCost + 1}.Evaluate(EvalOptions{})
 	assertErrorCode(t, err, ErrBudgetExceeded)
 	if got.Cost != MaxExecCost {
 		t.Fatalf("over-cap cost=%d want %d", got.Cost, MaxExecCost)


### PR DESCRIPTION
Invariant:
Decoded RUB-482 Simplicity programs can be evaluated through the Go library with deterministic metering and jet hook semantic results, capped by MAX_SIMPLICITY_EXEC_COST.

Layer:
implementation/tests

Linear:
RUB-485

Files changed:
- clients/go/consensus/simplicity/program.go
- clients/go/consensus/simplicity/program_test.go

Behavior impact:
- Adds a library-only Evaluate surface for the closed RUB-561 artifact subset.
- Non-jet decoded examples charge StepCost per decoded node count.
- Step metering is computed in O(1) while preserving equal-cap and over-cap partial-cost semantics.
- Jet programs require a JetEvaluator hook, and the hook returns both semantic acceptance and charged cost.
- Budget exceed maps to TX_ERR_SIMPLICITY_BUDGET_EXCEEDED.
- Semantic non-accept maps to TX_ERR_SIMPLICITY_REJECTED after cost charging.
- Evaluate rejects manually constructed or undecoded Program values and uses internal decoded jet identity instead of the mutable exported Program.Jet field.

Compatibility impact:
- Go-only staged implementation slice.
- No consensus dispatch wiring.
- No Rust parity changes in this PR.

### Parity exemption justification
This issue is a staged single-client child slice. RUB-485 explicitly owns the Go interpreter and deterministic metering library surface only. Rust parity is tracked separately by RUB-483/RUB-484, and shared parity corpus work is tracked separately; this PR must not add sibling-client changes only to satisfy per-PR source lockstep.

Known non-goals:
- No consensus validation path calls this library.
- No shared conformance corpus changes.
- No Rust implementation.
- No jet semantics implementation beyond caller-supplied hook result.
- No context intrinsics or cost-model hash changes.

Tests:
- git diff --check
- scripts/dev-env.sh -- bash -lc "cd clients/go && go test -count=1 ./consensus/simplicity"
- scripts/dev-env.sh -- bash -lc "cd clients/go && go test ./..."
- scripts/dev-env.sh -- bash -lc "cd clients/go && go vet ./..."
- scripts/dev-env.sh -- bash -lc "cd clients/go && gocyclo -over 8 consensus/simplicity/program.go consensus/simplicity/program_test.go"
  - Reports only pre-existing TestJetRows/TestDecodeJetMetadataIsImmutable rows; no new changed function rows.
- rubin-pattern-self-review-gate prepare/record-pass, 394 recalled Go patterns
- one isolated raw-diff reviewer; no findings after the thread fix
- rubin-precommit-tooling
- rubin-common-preflight --lane core
- rubin-push with coverage command
  - coverage variation +0.00%
  - diff coverage 96.36% (53/55)
