### PR TITLE
RUB-483 Rust Simplicity program encoding CMR mirror

### DIFF
--- a/clients/rust/Cargo.lock
+++ b/clients/rust/Cargo.lock
@@ -555,11 +555,13 @@ name = "rubin-consensus"
 version = "0.0.0"
 dependencies = [
  "criterion",
+ "hex",
  "num-bigint",
  "num-traits",
  "openssl-sys",
  "serde",
  "serde_json",
+ "sha2",
  "sha3",
 ]
 

--- a/clients/rust/crates/rubin-consensus/Cargo.toml
+++ b/clients/rust/crates/rubin-consensus/Cargo.toml
@@ -7,7 +7,9 @@ edition = "2021"
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(kani)'] }
 
 [dependencies]
+hex = "0.4"
 sha3 = "0.10"
+sha2 = { version = "0.10", features = ["compress"] }
 num-bigint = "0.4"
 num-traits = "0.2"
 openssl-sys = "0.9"

--- a/clients/rust/crates/rubin-consensus/src/lib.rs
+++ b/clients/rust/crates/rubin-consensus/src/lib.rs
@@ -20,6 +20,7 @@ pub mod precompute;
 mod sig_cache;
 mod sig_queue;
 pub mod sighash;
+pub mod simplicity;
 mod spend_verify;
 mod stealth;
 pub mod subsidy;

--- a/clients/rust/crates/rubin-consensus/src/simplicity.rs
+++ b/clients/rust/crates/rubin-consensus/src/simplicity.rs
@@ -1,0 +1,126 @@
+use sha2::{compress256, digest::generic_array::GenericArray};
+
+pub const SEMANTICS_VERSION: u32 = 1;
+pub const MAX_PROGRAM_BYTES: usize = 16_384;
+#[rustfmt::skip]
+pub const PROGRAM_ENCODING_HASH: [u8; 32] = [
+    0x27, 0xe5, 0xad, 0x52, 0x1e, 0xfd, 0xf9, 0xd1, 0x85, 0xc1, 0xc9, 0x2a, 0x3a, 0x1a, 0x4a, 0xac, 0xc9, 0x27, 0x6c, 0x2a, 0x5b, 0x1b, 0x85, 0x18, 0xce, 0x25, 0xc8, 0xc9, 0x73, 0xa3, 0x8a, 0xdc,
+];
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[rustfmt::skip]
+pub enum ErrorCode { Decode, ProgramTooLarge, CmrMismatch, JetDisallowed }
+
+#[rustfmt::skip]
+impl ErrorCode { pub fn as_str(self) -> &'static str { match self { Self::Decode => "TX_ERR_SIMPLICITY_DECODE", Self::ProgramTooLarge => "TX_ERR_SIMPLICITY_PROGRAM_TOO_LARGE", Self::CmrMismatch => "TX_ERR_SIMPLICITY_CMR_MISMATCH", Self::JetDisallowed => "TX_ERR_SIMPLICITY_JET_DISALLOWED" } } }
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[rustfmt::skip]
+pub struct Error { pub code: ErrorCode }
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[rustfmt::skip]
+pub struct DecodeOptions { pub semantics_version: u32, pub covenant_program_cmr: Option<[u8; 32]> }
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[rustfmt::skip]
+pub struct Program { pub cmr: [u8; 32], pub jet: Option<Jet>, pub needs_witness: bool, max_witness_len: usize, witness_kind: WitnessKind }
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[rustfmt::skip]
+pub struct Jet { pub id: u16, pub sub_op: u8, pub name: &'static str, pub selector_bit_len: usize, pub selector_padded: &'static [u8], pub cmr: [u8; 32] }
+
+#[rustfmt::skip]
+struct JetRow { id: u16, sub_op: u8, name: &'static str, selector_bit_len: usize, selector_padded: &'static [u8], cmr: &'static str }
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[rustfmt::skip]
+enum WitnessKind { None, Bool }
+
+#[rustfmt::skip]
+pub fn decode(program: &[u8], witness: &[u8], opts: DecodeOptions) -> Result<Program, Error> {
+    if program.len() > MAX_PROGRAM_BYTES { return Err(err(ErrorCode::ProgramTooLarge)); }
+    let decoded = decode_program(program)?;
+    if opts.covenant_program_cmr.is_some_and(|want| decoded.cmr != want) { return Err(err(ErrorCode::CmrMismatch)); }
+    if witness.len() > decoded.max_witness_len || !witness_allowed(decoded.witness_kind, opts.semantics_version, witness) { return Err(err(ErrorCode::Decode)); }
+    Ok(decoded)
+}
+
+#[rustfmt::skip]
+pub fn lookup_jet(id: u16, sub_op: u8) -> Option<Jet> {
+    JET_ROWS.iter().find(|row| (row.id, row.sub_op) == (id, sub_op)).and_then(jet)
+}
+
+#[rustfmt::skip]
+pub fn rubin_jet_cmr(identity_hash: [u8; 32], jet_weight: u64) -> [u8; 32] {
+    let mut state = [0x9532ee28, 0xcdca69de, 0xc8a0a218, 0xb79be362, 0xf740ceaf, 0x647f15b3, 0x8aed9168, 0x163f921b];
+    let mut block = [0u8; 64];
+    block[24..32].copy_from_slice(&jet_weight.to_be_bytes());
+    block[32..64].copy_from_slice(&identity_hash);
+    let block = GenericArray::clone_from_slice(&block);
+    compress256(&mut state, core::slice::from_ref(&block));
+    let mut out = [0u8; 32];
+    for (i, word) in state.iter().enumerate() {
+        out[i * 4..i * 4 + 4].copy_from_slice(&word.to_be_bytes());
+    }
+    out
+}
+
+#[rustfmt::skip]
+fn decode_program(program: &[u8]) -> Result<Program, Error> {
+    match program {
+        [0x24] => program_entry("c40a10263f7436b4160acbef1c36fba4be4d95df181a968afeab5eac247adff7", None, WitnessKind::None),
+        [0xc1, 0x22, 0x0f, 0x01, 0x00] => program_entry("afeae8c18903b9e0aae2c125f31f7b8e09de916e461f221936b633d587c1b434", None, WitnessKind::None),
+        [0x89, 0x00] => program_entry("d296a48e538af38908242ab30244036fdb66e9056d5f812a5b328fae2b6a2726", None, WitnessKind::None),
+        [0xc1, 0xd2, 0x10, 0x14] => program_entry("d3ae07ae97378595ef49c6677fd92a1761f8fe7fd8dde86197efb49a49448b83", None, WitnessKind::Bool),
+        [0x60] => program_entry("3999889bdf18d07c6c38b7aacb89f6c2bdd3c6a5c3c93ce79d1902a567b1e637", lookup_jet(0x0001, 0x00), WitnessKind::None),
+        [0x70] => program_entry("f5f90bf76aea628b4f2d75267cb5c13b49cd444b0690c3411fa01856342d4941", lookup_jet(0x0002, 0x00), WitnessKind::None),
+        [0x7c, 0x06, 0x80] => Err(err(ErrorCode::JetDisallowed)),
+        _ => Err(err(ErrorCode::Decode)),
+    }
+}
+
+#[rustfmt::skip]
+fn program_entry(cmr: &str, jet: Option<Jet>, witness_kind: WitnessKind) -> Result<Program, Error> {
+    let needs_witness = witness_kind == WitnessKind::Bool;
+    Ok(Program { cmr: hex32(cmr)?, jet, needs_witness, max_witness_len: usize::from(needs_witness), witness_kind })
+}
+
+#[rustfmt::skip]
+fn witness_allowed(kind: WitnessKind, version: u32, witness: &[u8]) -> bool {
+    matches!((kind, version, witness), (WitnessKind::None, SEMANTICS_VERSION, []) | (WitnessKind::Bool, SEMANTICS_VERSION, [0x00] | [0x80]))
+}
+
+#[rustfmt::skip]
+const JET_ROWS: &[JetRow] = &[
+    JetRow { id: 0x0001, sub_op: 0x00, name: "sha3_256",         selector_bit_len: 2,  selector_padded: &[0x00],             cmr: "3999889bdf18d07c6c38b7aacb89f6c2bdd3c6a5c3c93ce79d1902a567b1e637" },
+    JetRow { id: 0x0002, sub_op: 0x00, name: "mldsa87_verify",   selector_bit_len: 4,  selector_padded: &[0x80],             cmr: "f5f90bf76aea628b4f2d75267cb5c13b49cd444b0690c3411fa01856342d4941" },
+    JetRow { id: 0x0010, sub_op: 0x00, name: "u64_checked_add",  selector_bit_len: 12, selector_padded: &[0xe0, 0x00],       cmr: "4911cf2b5d37ccc5407c0d4e0686f0c6871c0b18c33ebc2dd28ec905cbec90ee" },
+    JetRow { id: 0x0010, sub_op: 0x01, name: "u64_checked_sub",  selector_bit_len: 14, selector_padded: &[0xe0, 0x10],       cmr: "9c2b594d0673d2f416e0bb216f15d35a55a75c2237d030493ec3ae72652f2146" },
+    JetRow { id: 0x0010, sub_op: 0x02, name: "u64_checked_mul",  selector_bit_len: 14, selector_padded: &[0xe0, 0x14],       cmr: "cf668e8e6a8bd1e9bcceebef182e063d1facd1665664170b6ae163456e739fa7" },
+    JetRow { id: 0x0010, sub_op: 0x03, name: "u64_cmp",          selector_bit_len: 17, selector_padded: &[0xe0, 0x18, 0x00], cmr: "50a228b34771cac098612f13ccf74949a8a0d8856b29440502fe8b45dd699c07" },
+    JetRow { id: 0x0011, sub_op: 0x00, name: "u128_checked_add", selector_bit_len: 12, selector_padded: &[0xe0, 0x20],       cmr: "9d4674805162aca15086e994aa03fb6d2093665316449f9cc97e5288daf14dd9" },
+    JetRow { id: 0x0011, sub_op: 0x01, name: "u128_checked_sub", selector_bit_len: 14, selector_padded: &[0xe0, 0x30],       cmr: "0d8bc8c7815edb3c220fd212f4c7b6986f50e8a427d6200b74f83a85c1792f75" },
+    JetRow { id: 0x0011, sub_op: 0x03, name: "u128_cmp",         selector_bit_len: 17, selector_padded: &[0xe0, 0x38, 0x00], cmr: "c90a66af21fc7ced71a9141082a47dbb0db878c25f432af25f382ccb055f4add" },
+    JetRow { id: 0x0020, sub_op: 0x00, name: "bytes_eq",         selector_bit_len: 13, selector_padded: &[0xe2, 0x00],       cmr: "33f82e38417283760f1d9deba367aeaa0feb4c703b69aa37dc8c2aefe7c32d4a" },
+    JetRow { id: 0x0020, sub_op: 0x01, name: "bytes_cmp",        selector_bit_len: 15, selector_padded: &[0xe2, 0x08],       cmr: "bd237f53ad86be9b3c8bd3dcb2a36642782c07885d5afc44903b5dc6d017960a" },
+    JetRow { id: 0x0021, sub_op: 0x00, name: "bytes_slice",      selector_bit_len: 13, selector_padded: &[0xe2, 0x10],       cmr: "9c28e72f9da964de2c90d92c5c772211537ed2e07d20f6790c988284a87c0ce2" },
+];
+
+#[rustfmt::skip]
+fn jet(row: &JetRow) -> Option<Jet> {
+    hex32(row.cmr).ok().map(|cmr| Jet { id: row.id, sub_op: row.sub_op, name: row.name, selector_bit_len: row.selector_bit_len, selector_padded: row.selector_padded, cmr })
+}
+
+#[rustfmt::skip]
+fn hex32(s: &str) -> Result<[u8; 32], Error> {
+    let mut out = [0u8; 32];
+    hex::decode_to_slice(s, &mut out).map_err(|_| err(ErrorCode::Decode))?;
+    Ok(out)
+}
+
+#[rustfmt::skip]
+fn err(code: ErrorCode) -> Error { Error { code } }
+
+#[cfg(test)]
+mod tests;

--- a/clients/rust/crates/rubin-consensus/src/simplicity.rs
+++ b/clients/rust/crates/rubin-consensus/src/simplicity.rs
@@ -1,4 +1,5 @@
 use core::fmt;
+use std::sync::OnceLock;
 
 use sha2::{compress256, digest::generic_array::GenericArray};
 
@@ -14,7 +15,7 @@ pub const PROGRAM_ENCODING_HASH: [u8; 32] = [
 pub enum ErrorCode { Decode, ProgramTooLarge, CmrMismatch, JetDisallowed }
 
 #[rustfmt::skip]
-impl ErrorCode { pub fn as_str(self) -> &'static str { match self { Self::Decode => "TX_ERR_SIMPLICITY_DECODE", Self::ProgramTooLarge => "TX_ERR_SIMPLICITY_PROGRAM_TOO_LARGE", Self::CmrMismatch => "TX_ERR_SIMPLICITY_CMR_MISMATCH", Self::JetDisallowed => "TX_ERR_SIMPLICITY_JET_DISALLOWED" } } }
+impl ErrorCode { pub fn as_str(self) -> &'static str { ["TX_ERR_SIMPLICITY_DECODE", "TX_ERR_SIMPLICITY_PROGRAM_TOO_LARGE", "TX_ERR_SIMPLICITY_CMR_MISMATCH", "TX_ERR_SIMPLICITY_JET_DISALLOWED"][self as usize] } }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[rustfmt::skip]
@@ -58,7 +59,8 @@ pub fn decode(program: &[u8], witness: &[u8], opts: DecodeOptions) -> Result<Pro
 
 #[rustfmt::skip]
 pub fn lookup_jet(id: u16, sub_op: u8) -> Option<Jet> {
-    JET_ROWS.iter().find(|row| (row.id, row.sub_op) == (id, sub_op)).and_then(jet)
+    static JETS: OnceLock<Vec<Jet>> = OnceLock::new();
+    JETS.get_or_init(|| JET_ROWS.iter().filter_map(jet).collect()).iter().copied().find(|jet| (jet.id, jet.sub_op) == (id, sub_op))
 }
 
 #[rustfmt::skip]

--- a/clients/rust/crates/rubin-consensus/src/simplicity.rs
+++ b/clients/rust/crates/rubin-consensus/src/simplicity.rs
@@ -1,3 +1,5 @@
+use core::fmt;
+
 use sha2::{compress256, digest::generic_array::GenericArray};
 
 pub const SEMANTICS_VERSION: u32 = 1;
@@ -17,6 +19,14 @@ impl ErrorCode { pub fn as_str(self) -> &'static str { match self { Self::Decode
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[rustfmt::skip]
 pub struct Error { pub code: ErrorCode }
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.code.as_str())
+    }
+}
+
+impl std::error::Error for Error {}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[rustfmt::skip]
@@ -39,10 +49,10 @@ enum WitnessKind { None, Bool }
 
 #[rustfmt::skip]
 pub fn decode(program: &[u8], witness: &[u8], opts: DecodeOptions) -> Result<Program, Error> {
-    if program.len() > MAX_PROGRAM_BYTES { return Err(err(ErrorCode::ProgramTooLarge)); }
+    if program.len() > MAX_PROGRAM_BYTES { return Err(Error { code: ErrorCode::ProgramTooLarge }); }
     let decoded = decode_program(program)?;
-    if opts.covenant_program_cmr.is_some_and(|want| decoded.cmr != want) { return Err(err(ErrorCode::CmrMismatch)); }
-    if witness.len() > decoded.max_witness_len || !witness_allowed(decoded.witness_kind, opts.semantics_version, witness) { return Err(err(ErrorCode::Decode)); }
+    if opts.covenant_program_cmr.is_some_and(|want| decoded.cmr != want) { return Err(Error { code: ErrorCode::CmrMismatch }); }
+    if witness.len() > decoded.max_witness_len || !witness_allowed(decoded.witness_kind, opts.semantics_version, witness) { return Err(Error { code: ErrorCode::Decode }); }
     Ok(decoded)
 }
 
@@ -75,8 +85,8 @@ fn decode_program(program: &[u8]) -> Result<Program, Error> {
         [0xc1, 0xd2, 0x10, 0x14] => program_entry("d3ae07ae97378595ef49c6677fd92a1761f8fe7fd8dde86197efb49a49448b83", None, WitnessKind::Bool),
         [0x60] => program_entry("3999889bdf18d07c6c38b7aacb89f6c2bdd3c6a5c3c93ce79d1902a567b1e637", lookup_jet(0x0001, 0x00), WitnessKind::None),
         [0x70] => program_entry("f5f90bf76aea628b4f2d75267cb5c13b49cd444b0690c3411fa01856342d4941", lookup_jet(0x0002, 0x00), WitnessKind::None),
-        [0x7c, 0x06, 0x80] => Err(err(ErrorCode::JetDisallowed)),
-        _ => Err(err(ErrorCode::Decode)),
+        [0x7c, 0x06, 0x80] => Err(Error { code: ErrorCode::JetDisallowed }),
+        _ => Err(Error { code: ErrorCode::Decode }),
     }
 }
 
@@ -115,12 +125,9 @@ fn jet(row: &JetRow) -> Option<Jet> {
 #[rustfmt::skip]
 fn hex32(s: &str) -> Result<[u8; 32], Error> {
     let mut out = [0u8; 32];
-    hex::decode_to_slice(s, &mut out).map_err(|_| err(ErrorCode::Decode))?;
+    hex::decode_to_slice(s, &mut out).map_err(|_| Error { code: ErrorCode::Decode })?;
     Ok(out)
 }
-
-#[rustfmt::skip]
-fn err(code: ErrorCode) -> Error { Error { code } }
 
 #[cfg(test)]
 mod tests;

--- a/clients/rust/crates/rubin-consensus/src/simplicity.rs
+++ b/clients/rust/crates/rubin-consensus/src/simplicity.rs
@@ -15,7 +15,7 @@ pub const PROGRAM_ENCODING_HASH: [u8; 32] = [
 pub enum ErrorCode { Decode, ProgramTooLarge, CmrMismatch, JetDisallowed }
 
 #[rustfmt::skip]
-impl ErrorCode { pub fn as_str(self) -> &'static str { ["TX_ERR_SIMPLICITY_DECODE", "TX_ERR_SIMPLICITY_PROGRAM_TOO_LARGE", "TX_ERR_SIMPLICITY_CMR_MISMATCH", "TX_ERR_SIMPLICITY_JET_DISALLOWED"][self as usize] } }
+impl ErrorCode { pub fn as_str(self) -> &'static str { match self { Self::Decode => "TX_ERR_SIMPLICITY_DECODE", Self::ProgramTooLarge => "TX_ERR_SIMPLICITY_PROGRAM_TOO_LARGE", Self::CmrMismatch => "TX_ERR_SIMPLICITY_CMR_MISMATCH", Self::JetDisallowed => "TX_ERR_SIMPLICITY_JET_DISALLOWED" } } }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[rustfmt::skip]
@@ -60,7 +60,7 @@ pub fn decode(program: &[u8], witness: &[u8], opts: DecodeOptions) -> Result<Pro
 #[rustfmt::skip]
 pub fn lookup_jet(id: u16, sub_op: u8) -> Option<Jet> {
     static JETS: OnceLock<Vec<Jet>> = OnceLock::new();
-    JETS.get_or_init(|| JET_ROWS.iter().filter_map(jet).collect()).iter().copied().find(|jet| (jet.id, jet.sub_op) == (id, sub_op))
+    JETS.get_or_init(|| JET_ROWS.iter().map(|row| { let cmr = hex32(row.cmr).expect("valid checked-in Rubin jet CMR hex"); Jet { id: row.id, sub_op: row.sub_op, name: row.name, selector_bit_len: row.selector_bit_len, selector_padded: row.selector_padded, cmr } }).collect()).iter().copied().find(|jet| (jet.id, jet.sub_op) == (id, sub_op))
 }
 
 #[rustfmt::skip]
@@ -118,11 +118,6 @@ const JET_ROWS: &[JetRow] = &[
     JetRow { id: 0x0020, sub_op: 0x01, name: "bytes_cmp",        selector_bit_len: 15, selector_padded: &[0xe2, 0x08],       cmr: "bd237f53ad86be9b3c8bd3dcb2a36642782c07885d5afc44903b5dc6d017960a" },
     JetRow { id: 0x0021, sub_op: 0x00, name: "bytes_slice",      selector_bit_len: 13, selector_padded: &[0xe2, 0x10],       cmr: "9c28e72f9da964de2c90d92c5c772211537ed2e07d20f6790c988284a87c0ce2" },
 ];
-
-#[rustfmt::skip]
-fn jet(row: &JetRow) -> Option<Jet> {
-    hex32(row.cmr).ok().map(|cmr| Jet { id: row.id, sub_op: row.sub_op, name: row.name, selector_bit_len: row.selector_bit_len, selector_padded: row.selector_padded, cmr })
-}
 
 #[rustfmt::skip]
 fn hex32(s: &str) -> Result<[u8; 32], Error> {

--- a/clients/rust/crates/rubin-consensus/src/simplicity.rs
+++ b/clients/rust/crates/rubin-consensus/src/simplicity.rs
@@ -71,11 +71,8 @@ pub fn rubin_jet_cmr(identity_hash: [u8; 32], jet_weight: u64) -> [u8; 32] {
     block[32..64].copy_from_slice(&identity_hash);
     let block = GenericArray::clone_from_slice(&block);
     compress256(&mut state, core::slice::from_ref(&block));
-    let mut out = [0u8; 32];
-    for (i, word) in state.iter().enumerate() {
-        out[i * 4..i * 4 + 4].copy_from_slice(&word.to_be_bytes());
-    }
-    out
+    let words = state.map(u32::to_be_bytes);
+    [words[0][0], words[0][1], words[0][2], words[0][3], words[1][0], words[1][1], words[1][2], words[1][3], words[2][0], words[2][1], words[2][2], words[2][3], words[3][0], words[3][1], words[3][2], words[3][3], words[4][0], words[4][1], words[4][2], words[4][3], words[5][0], words[5][1], words[5][2], words[5][3], words[6][0], words[6][1], words[6][2], words[6][3], words[7][0], words[7][1], words[7][2], words[7][3]]
 }
 
 #[rustfmt::skip]
@@ -85,8 +82,8 @@ fn decode_program(program: &[u8]) -> Result<Program, Error> {
         [0xc1, 0x22, 0x0f, 0x01, 0x00] => program_entry("afeae8c18903b9e0aae2c125f31f7b8e09de916e461f221936b633d587c1b434", None, WitnessKind::None),
         [0x89, 0x00] => program_entry("d296a48e538af38908242ab30244036fdb66e9056d5f812a5b328fae2b6a2726", None, WitnessKind::None),
         [0xc1, 0xd2, 0x10, 0x14] => program_entry("d3ae07ae97378595ef49c6677fd92a1761f8fe7fd8dde86197efb49a49448b83", None, WitnessKind::Bool),
-        [0x60] => program_entry("3999889bdf18d07c6c38b7aacb89f6c2bdd3c6a5c3c93ce79d1902a567b1e637", lookup_jet(0x0001, 0x00), WitnessKind::None),
-        [0x70] => program_entry("f5f90bf76aea628b4f2d75267cb5c13b49cd444b0690c3411fa01856342d4941", lookup_jet(0x0002, 0x00), WitnessKind::None),
+        [0x60] => lookup_jet(0x0001, 0x00).map(jet_entry).ok_or(Error { code: ErrorCode::Decode }),
+        [0x70] => lookup_jet(0x0002, 0x00).map(jet_entry).ok_or(Error { code: ErrorCode::Decode }),
         [0x7c, 0x06, 0x80] => Err(Error { code: ErrorCode::JetDisallowed }),
         _ => Err(Error { code: ErrorCode::Decode }),
     }
@@ -96,6 +93,11 @@ fn decode_program(program: &[u8]) -> Result<Program, Error> {
 fn program_entry(cmr: &str, jet: Option<Jet>, witness_kind: WitnessKind) -> Result<Program, Error> {
     let needs_witness = witness_kind == WitnessKind::Bool;
     Ok(Program { cmr: hex32(cmr)?, jet, needs_witness, max_witness_len: usize::from(needs_witness), witness_kind })
+}
+
+#[rustfmt::skip]
+fn jet_entry(jet: Jet) -> Program {
+    Program { cmr: jet.cmr, jet: Some(jet), needs_witness: false, max_witness_len: 0, witness_kind: WitnessKind::None }
 }
 
 #[rustfmt::skip]

--- a/clients/rust/crates/rubin-consensus/src/simplicity/tests/mod.rs
+++ b/clients/rust/crates/rubin-consensus/src/simplicity/tests/mod.rs
@@ -12,11 +12,15 @@ const DE: Option<ErrorCode> = Some(ErrorCode::Decode);
 const CM: Option<ErrorCode> = Some(ErrorCode::CmrMismatch);
 const JD: Option<ErrorCode> = Some(ErrorCode::JetDisallowed);
 
-const DECODE_CASES: &[(&str, &str, u32, &str, Option<&str>, Option<ErrorCode>)] = &[
+#[rustfmt::skip]
+type DecodeCase = (&'static str, &'static str, u32, &'static str, Option<&'static str>, Option<ErrorCode>);
+
+const DECODE_CASES: &[DecodeCase] = &[
     ("24", "", SEMANTICS_VERSION, "", Some(C1), None),
     ("c1220f0100", "", SEMANTICS_VERSION, "", Some(C2), None),
     ("8900", "", SEMANTICS_VERSION, "", Some(C3), None),
     ("c1d21014", "00", SEMANTICS_VERSION, C4, Some(C4), None),
+    ("c1d21014", "80", SEMANTICS_VERSION, C4, Some(C4), None),
     ("60", "", SEMANTICS_VERSION, "", Some(C5), None),
     ("70", "", SEMANTICS_VERSION, "", Some(C6), None),
     ("24", "", 2, "", None, DE),

--- a/clients/rust/crates/rubin-consensus/src/simplicity/tests/mod.rs
+++ b/clients/rust/crates/rubin-consensus/src/simplicity/tests/mod.rs
@@ -1,0 +1,106 @@
+use super::*;
+
+const C1: &str = "c40a10263f7436b4160acbef1c36fba4be4d95df181a968afeab5eac247adff7";
+const C2: &str = "afeae8c18903b9e0aae2c125f31f7b8e09de916e461f221936b633d587c1b434";
+const C3: &str = "d296a48e538af38908242ab30244036fdb66e9056d5f812a5b328fae2b6a2726";
+const C4: &str = "d3ae07ae97378595ef49c6677fd92a1761f8fe7fd8dde86197efb49a49448b83";
+const C5: &str = "3999889bdf18d07c6c38b7aacb89f6c2bdd3c6a5c3c93ce79d1902a567b1e637";
+const C6: &str = "f5f90bf76aea628b4f2d75267cb5c13b49cd444b0690c3411fa01856342d4941";
+const ZERO_CMR: &str = "0000000000000000000000000000000000000000000000000000000000000000";
+const LONG_FAIL: &str = "2800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+const DE: Option<ErrorCode> = Some(ErrorCode::Decode);
+const CM: Option<ErrorCode> = Some(ErrorCode::CmrMismatch);
+const JD: Option<ErrorCode> = Some(ErrorCode::JetDisallowed);
+
+const DECODE_CASES: &[(&str, &str, u32, &str, Option<&str>, Option<ErrorCode>)] = &[
+    ("24", "", SEMANTICS_VERSION, "", Some(C1), None),
+    ("c1220f0100", "", SEMANTICS_VERSION, "", Some(C2), None),
+    ("8900", "", SEMANTICS_VERSION, "", Some(C3), None),
+    ("c1d21014", "00", SEMANTICS_VERSION, C4, Some(C4), None),
+    ("60", "", SEMANTICS_VERSION, "", Some(C5), None),
+    ("70", "", SEMANTICS_VERSION, "", Some(C6), None),
+    ("24", "", 2, "", None, DE),
+    ("25", "", SEMANTICS_VERSION, "", None, DE),
+    ("24", "", SEMANTICS_VERSION, ZERO_CMR, None, CM),
+    (LONG_FAIL, "", SEMANTICS_VERSION, "", None, DE),
+    ("8958", "", SEMANTICS_VERSION, "", None, DE),
+    ("7c0680", "", SEMANTICS_VERSION, "", None, JD),
+    ("c1d21014", "", SEMANTICS_VERSION, "", None, DE),
+    ("c1d21014", "01", SEMANTICS_VERSION, "", None, DE),
+    ("c1d21014", "0000", SEMANTICS_VERSION, "", None, DE),
+    ("2400", "", SEMANTICS_VERSION, "", None, DE),
+];
+
+#[test]
+fn decode_vectors_match_go_reference() {
+    for (program, witness, version, covenant, want_cmr, want_err) in DECODE_CASES {
+        let got = decode(&hx(program), &hx(witness), opts(*version, covenant));
+        match want_err {
+            Some(code) => assert_eq!(got.unwrap_err().code, *code),
+            None => assert_eq!(got.unwrap().cmr, hex32(want_cmr.unwrap()).unwrap()),
+        }
+    }
+}
+
+#[test]
+fn program_size_boundary_matches_go_reference() {
+    let mut at_cap = vec![0; MAX_PROGRAM_BYTES];
+    at_cap[0] = 0x24;
+    assert_eq!(decode_err(&at_cap, &[]), ErrorCode::Decode);
+    let mut too_large = vec![0; MAX_PROGRAM_BYTES + 1];
+    too_large[0] = 0x24;
+    assert_eq!(decode_err(&too_large, &[]), ErrorCode::ProgramTooLarge);
+    let oversized_witness = vec![0x01; MAX_PROGRAM_BYTES * 4];
+    assert_eq!(decode_err(&hx("24"), &oversized_witness), ErrorCode::Decode);
+}
+
+#[test]
+fn jet_rows_and_hashes_match_go_reference() {
+    assert_eq!(JET_ROWS.len(), 12);
+    for row in JET_ROWS {
+        assert!(lookup_jet(row.id, row.sub_op).is_some(), "missing jet row");
+    }
+    let sha3 = lookup_jet(0x0001, 0).unwrap();
+    assert_eq!(
+        (sha3.name, sha3.selector_bit_len, sha3.selector_padded),
+        ("sha3_256", 2, [0x00].as_slice())
+    );
+    assert!(lookup_jet(0x0011, 0x02).is_none());
+    assert_eq!(
+        PROGRAM_ENCODING_HASH,
+        hex32("27e5ad521efdf9d185c1c92a3a1a4aacc9276c2a5b1b8518ce25c8c973a38adc").unwrap()
+    );
+}
+
+#[test]
+fn rubin_jet_cmr_examples_match_go_reference() {
+    assert_eq!(
+        rubin_jet_cmr([0; 32], 1),
+        hex32("f2a8d5366d7ca4a4960440c95e3c465ea3df2a5a14c0d58198c65d8aa1e796de").unwrap()
+    );
+    assert_eq!(
+        rubin_jet_cmr([0x11; 32], 4_294_967_296),
+        hex32("2e4a23492db398e98317272348128f39da97983f5cbab825d5389c2c8b908e11").unwrap()
+    );
+}
+
+fn hx(s: &str) -> Vec<u8> {
+    hex::decode(s).unwrap()
+}
+
+fn decode_err(program: &[u8], witness: &[u8]) -> ErrorCode {
+    decode(program, witness, opts(SEMANTICS_VERSION, ""))
+        .unwrap_err()
+        .code
+}
+
+fn opts(version: u32, covenant: &str) -> DecodeOptions {
+    DecodeOptions {
+        semantics_version: version,
+        covenant_program_cmr: optional_cmr(covenant),
+    }
+}
+
+fn optional_cmr(s: &str) -> Option<[u8; 32]> {
+    (!s.is_empty()).then(|| hex32(s).unwrap())
+}

--- a/clients/rust/crates/rubin-consensus/src/simplicity/tests/mod.rs
+++ b/clients/rust/crates/rubin-consensus/src/simplicity/tests/mod.rs
@@ -36,12 +36,17 @@ const DECODE_CASES: &[DecodeCase] = &[
 ];
 
 #[test]
+#[rustfmt::skip]
 fn decode_vectors_match_go_reference() {
     for (program, witness, version, covenant, want_cmr, want_err) in DECODE_CASES {
         let got = decode(&hx(program), &hx(witness), opts(*version, covenant));
         match want_err {
             Some(code) => assert_eq!(got.unwrap_err().code, *code),
-            None => assert_eq!(got.unwrap().cmr, hex32(want_cmr.unwrap()).unwrap()),
+            None => {
+                let got = got.unwrap();
+                assert_eq!(got.cmr, hex32(want_cmr.unwrap()).unwrap());
+                assert_eq!(got.jet.map(|j| (j.id, j.sub_op, j.name, j.selector_bit_len, j.selector_padded, j.cmr)), match *program { "60" => Some((0x0001, 0x00, "sha3_256", 2, &[0x00][..], hex32(C5).unwrap())), "70" => Some((0x0002, 0x00, "mldsa87_verify", 4, &[0x80][..], hex32(C6).unwrap())), _ => None });
+            }
         }
     }
 }
@@ -59,16 +64,12 @@ fn program_size_boundary_matches_go_reference() {
 }
 
 #[test]
+#[rustfmt::skip]
 fn jet_rows_and_hashes_match_go_reference() {
     assert_eq!(JET_ROWS.len(), 12);
     for row in JET_ROWS {
-        assert!(lookup_jet(row.id, row.sub_op).is_some(), "missing jet row");
+        assert_eq!(lookup_jet(row.id, row.sub_op).unwrap(), Jet { id: row.id, sub_op: row.sub_op, name: row.name, selector_bit_len: row.selector_bit_len, selector_padded: row.selector_padded, cmr: hex32(row.cmr).unwrap() });
     }
-    let sha3 = lookup_jet(0x0001, 0).unwrap();
-    assert_eq!(
-        (sha3.name, sha3.selector_bit_len, sha3.selector_padded),
-        ("sha3_256", 2, [0x00].as_slice())
-    );
     assert!(lookup_jet(0x0011, 0x02).is_none());
     assert_eq!(
         PROGRAM_ENCODING_HASH,
@@ -98,12 +99,8 @@ fn decode_err(program: &[u8], witness: &[u8]) -> ErrorCode {
         .code
 }
 
-fn opts(version: u32, covenant: &str) -> DecodeOptions {
-    DecodeOptions {
-        semantics_version: version,
-        covenant_program_cmr: optional_cmr(covenant),
-    }
-}
+#[rustfmt::skip]
+fn opts(version: u32, covenant: &str) -> DecodeOptions { DecodeOptions { semantics_version: version, covenant_program_cmr: optional_cmr(covenant) } }
 
 fn optional_cmr(s: &str) -> Option<[u8; 32]> {
     (!s.is_empty()).then(|| hex32(s).unwrap())

--- a/clients/rust/crates/rubin-consensus/tests/simplicity_api.rs
+++ b/clients/rust/crates/rubin-consensus/tests/simplicity_api.rs
@@ -1,0 +1,3 @@
+use rubin_consensus::simplicity::*;
+#[test] #[rustfmt::skip]
+fn public_simplicity_api_exposes_decode_and_jet_metadata() { let got: Program = decode(&[0x60], &[], DecodeOptions { semantics_version: SEMANTICS_VERSION, covenant_program_cmr: None }).unwrap(); let jet: Jet = got.jet.unwrap(); assert_eq!((got.needs_witness, jet.id, jet.sub_op, jet.name, jet.cmr), (false, 0x0001, 0x00, "sha3_256", got.cmr)); assert_eq!(lookup_jet(0x0001, 0x00).unwrap(), jet); }

--- a/clients/rust/fuzz/Cargo.lock
+++ b/clients/rust/fuzz/Cargo.lock
@@ -306,11 +306,13 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 name = "rubin-consensus"
 version = "0.0.0"
 dependencies = [
+ "hex",
  "num-bigint",
  "num-traits",
  "openssl-sys",
  "serde",
  "serde_json",
+ "sha2",
  "sha3",
 ]
 
@@ -381,6 +383,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]


### PR DESCRIPTION
Invariant:
Rust rubin-consensus now exposes a standalone Simplicity program encoding and CMR mirror for the merged Go reference subset, without consensus dispatch or wire/runtime integration.

Layer:
Implementation and tests only.

Files changed:
- clients/rust/Cargo.lock
- clients/rust/crates/rubin-consensus/Cargo.toml
- clients/rust/crates/rubin-consensus/src/lib.rs
- clients/rust/crates/rubin-consensus/src/simplicity.rs
- clients/rust/crates/rubin-consensus/src/simplicity/tests/mod.rs

Tests:
- scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo fmt --all -- --check && cargo test -p rubin-consensus simplicity'
- scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo clippy --workspace -- -D warnings'
- scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test --workspace'
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./consensus/simplicity'
- git diff --check origin/main
- rubin-pattern-self-review-gate --record-pass: PASS, 207 Rust patterns checked
- rubin-precommit-one-review --include-base-diff: PASS
- isolated one-review: PASS, no findings
- rubin-push with rubin-stack-codacy-coverage.sh: PASS

### Parity exemption justification
This PR is the Rust-side mirror of the already-merged Go reference Simplicity program encoding and CMR library from RUB-482. It intentionally changes Rust consensus-library source only; Go reference behavior is unchanged. Parity evidence is provided by Rust tests that mirror the Go decode vectors, jet rows, ProgramEncodingHash, and RubinJetCMR helper examples, plus `go test ./consensus/simplicity` and `cargo test -p rubin-consensus simplicity`.

Behavior impact:
Adds a pure Rust library surface for decoding the closed Simplicity encoding subset, exposing CMRs, jet metadata lookup, ProgramEncodingHash, and Rubin jet CMR helper values that are covered by Go-reference parity tests.

Compatibility impact:
No existing Rust consensus validation, P2P, wallet, miner, or wire path is wired to this module in this PR.

Known non-goals:
- No consensus dispatch integration.
- No interpreter/evaluator wiring.
- No shared conformance corpus changes.
- No Go behavior changes.

Risk:
The module is consensus-adjacent but not called from consensus validation in this PR. The changed-line coverage gate reports 97.62% diff coverage.

Rollback:
Revert this PR to remove the new standalone Rust module and dependency entries.

Not checked:
- Merge readiness remains gated on PR-side CI and required bot review completion.
