### PR TITLE
RUB-548 Go Simplicity cost bounds and hash

### DIFF
--- a/clients/go/consensus/simplicity/program.go
+++ b/clients/go/consensus/simplicity/program.go
@@ -315,13 +315,20 @@ func costModelBytes() []byte {
 	for _, v := range []uint64{StepCost, IntrinsicReadCost, IntrinsicMissCost, DescriptorHashBaseCost, DescriptorHashByteCost, MaxFrameBytes, MaxLiveMemoryBytes} {
 		out = binary.LittleEndian.AppendUint64(out, v)
 	}
-	out = append(out, byte(len(costModelRows)))
+	out = append(out, costModelRowCountByte(costModelRows))
 	for _, row := range costModelRows {
 		out = binary.LittleEndian.AppendUint16(out, row.jet.id)
 		out = append(out, row.jet.subOp, byte(row.formula))
 		out = binary.LittleEndian.AppendUint64(out, row.param)
 	}
 	return out
+}
+
+func costModelRowCountByte(rows []costModelRow) byte {
+	if len(rows) >= 253 {
+		panic("cost model row count exceeds one-byte CompactSize encoding")
+	}
+	return byte(len(rows))
 }
 
 var (

--- a/clients/go/consensus/simplicity/program.go
+++ b/clients/go/consensus/simplicity/program.go
@@ -99,6 +99,14 @@ func Decode(program, witness []byte, opts DecodeOptions) (Program, error) {
 	if _, ok := decoded.witnesses[witnessKey{version: opts.SemanticsVersion, bytes: string(witness)}]; !ok {
 		return Program{}, &Error{Code: ErrDecode}
 	}
+	decoded.decoded = true
+	decoded.frameBitWidths = append([]uint64(nil), decoded.frameBitWidths...)
+	if decoded.Jet != nil {
+		jet := copyJet(*decoded.Jet)
+		decoded.Jet = &jet
+		decoded.hasJet = true
+		decoded.jetKey = jetKey{id: jet.ID, subOp: jet.SubOp}
+	}
 	return decoded, nil
 }
 
@@ -201,15 +209,7 @@ func decodeProgram(program []byte) (Program, error) {
 	if entry.err != "" {
 		return Program{}, &Error{Code: entry.err}
 	}
-	decoded := entry.program
-	decoded.decoded = true
-	if decoded.Jet != nil {
-		jet := copyJet(*decoded.Jet)
-		decoded.Jet = &jet
-		decoded.hasJet = true
-		decoded.jetKey = jetKey{id: jet.ID, subOp: jet.SubOp}
-	}
-	return decoded, nil
+	return entry.program, nil
 }
 
 func copyJet(row Jet) Jet {
@@ -329,6 +329,10 @@ var (
 	boolWitness   = map[witnessKey]struct{}{{version: SemanticsVersion, bytes: string([]byte{0x00})}: {}, {version: SemanticsVersion, bytes: string([]byte{0x80})}: {}}
 	sha3JetRow    = jetRows[jetKey{id: 0x0001, subOp: 0x00}]
 	mldsa87JetRow = jetRows[jetKey{id: 0x0002, subOp: 0x00}]
+	unitFrames    = []uint64{0, 0}
+	boolFrames    = []uint64{1, 1}
+	sha3Frames    = []uint64{512, 256}
+	mldsa87Frames = []uint64{(2_592 + 4_627 + 32) * 8, 1}
 	costModelRows = []costModelRow{
 		{jet: jetKey{id: 0x0001, subOp: 0x00}, formula: costBasePlusLen, param: 64},
 		{jet: jetKey{id: 0x0002, subOp: 0x00}, formula: costConstant, param: 50_000},
@@ -344,12 +348,12 @@ var (
 		{jet: jetKey{id: 0x0021, subOp: 0x00}, formula: costOnePlusCeilLen32},
 	}
 	programs = map[string]programEntry{
-		string([]byte{0x24}):                         {program: Program{CMR: hex32("c40a10263f7436b4160acbef1c36fba4be4d95df181a968afeab5eac247adff7"), witnesses: noWitness, evalSteps: 1}},
-		string([]byte{0xc1, 0x22, 0x0f, 0x01, 0x00}): {program: Program{CMR: hex32("afeae8c18903b9e0aae2c125f31f7b8e09de916e461f221936b633d587c1b434"), witnesses: noWitness, evalSteps: 4}},
-		string([]byte{0x89, 0x00}):                   {program: Program{CMR: hex32("d296a48e538af38908242ab30244036fdb66e9056d5f812a5b328fae2b6a2726"), witnesses: noWitness, evalSteps: 2}},
-		string([]byte{0xc1, 0xd2, 0x10, 0x14}):       {program: Program{CMR: hex32("d3ae07ae97378595ef49c6677fd92a1761f8fe7fd8dde86197efb49a49448b83"), NeedsWitness: true, maxWitnessLen: 1, witnesses: boolWitness, evalSteps: 4}},
-		string([]byte{0x60}):                         {program: Program{CMR: sha3JetRow.CMR, Jet: &sha3JetRow, witnesses: noWitness}},
-		string([]byte{0x70}):                         {program: Program{CMR: mldsa87JetRow.CMR, Jet: &mldsa87JetRow, witnesses: noWitness}},
+		string([]byte{0x24}):                         {program: Program{CMR: hex32("c40a10263f7436b4160acbef1c36fba4be4d95df181a968afeab5eac247adff7"), witnesses: noWitness, evalSteps: 1, frameBitWidths: unitFrames}},
+		string([]byte{0xc1, 0x22, 0x0f, 0x01, 0x00}): {program: Program{CMR: hex32("afeae8c18903b9e0aae2c125f31f7b8e09de916e461f221936b633d587c1b434"), witnesses: noWitness, evalSteps: 4, frameBitWidths: unitFrames}},
+		string([]byte{0x89, 0x00}):                   {program: Program{CMR: hex32("d296a48e538af38908242ab30244036fdb66e9056d5f812a5b328fae2b6a2726"), witnesses: noWitness, evalSteps: 2, frameBitWidths: unitFrames}},
+		string([]byte{0xc1, 0xd2, 0x10, 0x14}):       {program: Program{CMR: hex32("d3ae07ae97378595ef49c6677fd92a1761f8fe7fd8dde86197efb49a49448b83"), NeedsWitness: true, maxWitnessLen: 1, witnesses: boolWitness, evalSteps: 4, frameBitWidths: boolFrames}},
+		string([]byte{0x60}):                         {program: Program{CMR: sha3JetRow.CMR, Jet: &sha3JetRow, witnesses: noWitness, frameBitWidths: sha3Frames}},
+		string([]byte{0x70}):                         {program: Program{CMR: mldsa87JetRow.CMR, Jet: &mldsa87JetRow, witnesses: noWitness, frameBitWidths: mldsa87Frames}},
 		string([]byte{0x7c, 0x06, 0x80}):             {err: ErrJetDisallowed},
 	}
 )

--- a/clients/go/consensus/simplicity/program.go
+++ b/clients/go/consensus/simplicity/program.go
@@ -8,6 +8,7 @@
 package simplicity
 
 import (
+	"crypto/sha3"
 	"encoding/binary"
 	"encoding/hex"
 	"math/bits"
@@ -18,6 +19,14 @@ const (
 	MaxProgramBytes         = 16_384
 	MaxExecCost      uint64 = 400_000
 	StepCost         uint64 = 1
+
+	CostModelSemanticsVersion uint32 = 2
+	IntrinsicReadCost         uint64 = 1
+	IntrinsicMissCost         uint64 = 1
+	DescriptorHashBaseCost    uint64 = 64
+	DescriptorHashByteCost    uint64 = 1
+	MaxFrameBytes             uint64 = 65_536
+	MaxLiveMemoryBytes        uint64 = 1_048_576
 )
 
 type ErrorCode string
@@ -43,15 +52,16 @@ type DecodeOptions struct {
 }
 
 type Program struct {
-	CMR           [32]byte
-	Jet           *Jet
-	NeedsWitness  bool
-	maxWitnessLen int
-	witnesses     map[witnessKey]struct{}
-	evalSteps     uint64
-	decoded       bool
-	hasJet        bool
-	jetKey        jetKey
+	CMR            [32]byte
+	Jet            *Jet
+	NeedsWitness   bool
+	maxWitnessLen  int
+	witnesses      map[witnessKey]struct{}
+	evalSteps      uint64
+	decoded        bool
+	hasJet         bool
+	jetKey         jetKey
+	frameBitWidths []uint64
 }
 
 type Jet struct {
@@ -102,10 +112,19 @@ func (p Program) Evaluate(opts EvalOptions) (EvalResult, error) {
 		return EvalResult{}, &Error{Code: ErrDecode}
 	}
 	if p.hasJet {
+		if _, ok := jetRows[p.jetKey]; !ok {
+			return EvalResult{}, &Error{Code: ErrDecode}
+		}
+		if err := checkMemoryBounds(p.frameBitWidths); err != nil {
+			return EvalResult{}, err
+		}
 		return p.evaluateJet(opts)
 	}
 	if p.evalSteps == 0 {
 		return EvalResult{}, &Error{Code: ErrDecode}
+	}
+	if err := checkMemoryBounds(p.frameBitWidths); err != nil {
+		return EvalResult{}, err
 	}
 	return evaluateSteps(p.evalSteps)
 }
@@ -170,6 +189,10 @@ func RubinJetCMR(identityHash [32]byte, jetWeight uint64) [32]byte {
 	return out
 }
 
+func CostModelHash() [32]byte {
+	return sha3.Sum256(costModelBytes())
+}
+
 func decodeProgram(program []byte) (Program, error) {
 	entry, ok := programs[string(program)]
 	if !ok {
@@ -214,6 +237,20 @@ type jetKey struct {
 	subOp uint8
 }
 
+type costFormulaID uint8
+
+const (
+	costConstant costFormulaID = iota
+	costBasePlusLen
+	costOnePlusCeilLen32
+)
+
+type costModelRow struct {
+	jet     jetKey
+	formula costFormulaID
+	param   uint64
+}
+
 type witnessKey struct {
 	version uint32
 	bytes   string
@@ -252,12 +289,61 @@ func (m *meter) charge(cost uint64) error {
 	return nil
 }
 
+func checkMemoryBounds(frameBitWidths []uint64) error {
+	var live uint64
+	for _, bits := range frameBitWidths {
+		frame := frameBytes(bits)
+		if frame > MaxFrameBytes || live > MaxLiveMemoryBytes-frame {
+			return &Error{Code: ErrBudgetExceeded}
+		}
+		live += frame
+	}
+	return nil
+}
+
+func frameBytes(bitWidth uint64) uint64 {
+	bytes := bitWidth / 8
+	if bitWidth%8 != 0 {
+		bytes++
+	}
+	return bytes
+}
+
+func costModelBytes() []byte {
+	out := []byte("RUBIN-SIMPLICITY-COST-v1")
+	out = binary.LittleEndian.AppendUint32(out, CostModelSemanticsVersion)
+	for _, v := range []uint64{StepCost, IntrinsicReadCost, IntrinsicMissCost, DescriptorHashBaseCost, DescriptorHashByteCost, MaxFrameBytes, MaxLiveMemoryBytes} {
+		out = binary.LittleEndian.AppendUint64(out, v)
+	}
+	out = append(out, byte(len(costModelRows)))
+	for _, row := range costModelRows {
+		out = binary.LittleEndian.AppendUint16(out, row.jet.id)
+		out = append(out, row.jet.subOp, byte(row.formula))
+		out = binary.LittleEndian.AppendUint64(out, row.param)
+	}
+	return out
+}
+
 var (
 	noWitness     = map[witnessKey]struct{}{{version: SemanticsVersion, bytes: ""}: {}}
 	boolWitness   = map[witnessKey]struct{}{{version: SemanticsVersion, bytes: string([]byte{0x00})}: {}, {version: SemanticsVersion, bytes: string([]byte{0x80})}: {}}
 	sha3JetRow    = jetRows[jetKey{id: 0x0001, subOp: 0x00}]
 	mldsa87JetRow = jetRows[jetKey{id: 0x0002, subOp: 0x00}]
-	programs      = map[string]programEntry{
+	costModelRows = []costModelRow{
+		{jet: jetKey{id: 0x0001, subOp: 0x00}, formula: costBasePlusLen, param: 64},
+		{jet: jetKey{id: 0x0002, subOp: 0x00}, formula: costConstant, param: 50_000},
+		{jet: jetKey{id: 0x0010, subOp: 0x00}, formula: costConstant, param: 1},
+		{jet: jetKey{id: 0x0010, subOp: 0x01}, formula: costConstant, param: 1},
+		{jet: jetKey{id: 0x0010, subOp: 0x02}, formula: costConstant, param: 1},
+		{jet: jetKey{id: 0x0010, subOp: 0x03}, formula: costConstant, param: 1},
+		{jet: jetKey{id: 0x0011, subOp: 0x00}, formula: costConstant, param: 1},
+		{jet: jetKey{id: 0x0011, subOp: 0x01}, formula: costConstant, param: 1},
+		{jet: jetKey{id: 0x0011, subOp: 0x03}, formula: costConstant, param: 1},
+		{jet: jetKey{id: 0x0020, subOp: 0x00}, formula: costOnePlusCeilLen32},
+		{jet: jetKey{id: 0x0020, subOp: 0x01}, formula: costOnePlusCeilLen32},
+		{jet: jetKey{id: 0x0021, subOp: 0x00}, formula: costOnePlusCeilLen32},
+	}
+	programs = map[string]programEntry{
 		string([]byte{0x24}):                         {program: Program{CMR: hex32("c40a10263f7436b4160acbef1c36fba4be4d95df181a968afeab5eac247adff7"), witnesses: noWitness, evalSteps: 1}},
 		string([]byte{0xc1, 0x22, 0x0f, 0x01, 0x00}): {program: Program{CMR: hex32("afeae8c18903b9e0aae2c125f31f7b8e09de916e461f221936b633d587c1b434"), witnesses: noWitness, evalSteps: 4}},
 		string([]byte{0x89, 0x00}):                   {program: Program{CMR: hex32("d296a48e538af38908242ab30244036fdb66e9056d5f812a5b328fae2b6a2726"), witnesses: noWitness, evalSteps: 2}},

--- a/clients/go/consensus/simplicity/program_test.go
+++ b/clients/go/consensus/simplicity/program_test.go
@@ -260,6 +260,16 @@ func TestCostModelRowsMatchJetTable(t *testing.T) {
 	}
 }
 
+func TestCostModelRowCountRejectsMultiByteCompactSize(t *testing.T) {
+	defer func() {
+		if got := recover(); got == nil {
+			t.Fatal("cost model row count requiring multi-byte CompactSize did not panic")
+		}
+	}()
+
+	_ = costModelRowCountByte(make([]costModelRow, 253))
+}
+
 func TestEvaluateJetRequiresCostHook(t *testing.T) {
 	program := decodeSHA3Jet(t)
 	_, err := program.Evaluate(EvalOptions{})

--- a/clients/go/consensus/simplicity/program_test.go
+++ b/clients/go/consensus/simplicity/program_test.go
@@ -228,6 +228,38 @@ func TestEvaluateChargesDecodedProgramSteps(t *testing.T) {
 	}
 }
 
+func TestCostModelHashMatchesSpecArtifact(t *testing.T) {
+	preimage := costModelBytes()
+	wantPreimage := "" +
+		"525542494e2d53494d504c49434954592d434f53542d76310200000001000000000000000100000000000000010000000000000040000000000000000100000000000000000001000000000000001000000000000c" +
+		"0100000140000000000000000200000050c3000000000000100000000100000000000000100001000100000000000000100002000100000000000000100003000100000000000000110000000100000000000000110001000100000000000000110003000100000000000000200000020000000000000000200001020000000000000000210000020000000000000000"
+	if got := hex.EncodeToString(preimage); got != wantPreimage {
+		t.Fatalf("cost preimage=%s want %s", got, wantPreimage)
+	}
+	if got := CostModelHash(); got != hex32("accb55570168bd7b1fedadff2135c99e32508680ff7a315cf4f33f97744aabc9") {
+		t.Fatalf("cost_model_hash=%x", got)
+	}
+}
+
+func TestCostModelRowsMatchJetTable(t *testing.T) {
+	if len(costModelRows) != len(jetRows) || len(costModelRows) >= 253 {
+		t.Fatalf("cost rows=%d jet rows=%d", len(costModelRows), len(jetRows))
+	}
+	var prev jetKey
+	for i, row := range costModelRows {
+		if _, ok := jetRows[row.jet]; !ok {
+			t.Fatalf("cost row %d missing jet %#04x/%#02x", i, row.jet.id, row.jet.subOp)
+		}
+		if i > 0 && (prev.id > row.jet.id || (prev.id == row.jet.id && prev.subOp >= row.jet.subOp)) {
+			t.Fatalf("cost rows not sorted at %d", i)
+		}
+		if row.formula > costOnePlusCeilLen32 || (row.formula == costOnePlusCeilLen32 && row.param != 0) {
+			t.Fatalf("bad cost formula at %d", i)
+		}
+		prev = row.jet
+	}
+}
+
 func TestEvaluateJetRequiresCostHook(t *testing.T) {
 	program := decodeSHA3Jet(t)
 	_, err := program.Evaluate(EvalOptions{})
@@ -279,6 +311,60 @@ func TestEvaluateJetCostHookCapBoundary(t *testing.T) {
 	if !got.Accepted || got.Cost != MaxExecCost {
 		t.Fatalf("evaluation=%+v want accepted saturated cost=%d", got, MaxExecCost)
 	}
+}
+
+func TestEvaluateMemoryBounds(t *testing.T) {
+	tests := []struct {
+		name   string
+		frames []uint64
+		want   ErrorCode
+	}{
+		{name: "frame at cap", frames: []uint64{MaxFrameBytes * 8}},
+		{name: "total live at cap", frames: repeated(MaxFrameBytes*8, int(MaxLiveMemoryBytes/MaxFrameBytes))},
+		{name: "frame over cap", frames: []uint64{MaxFrameBytes*8 + 1}, want: ErrBudgetExceeded},
+		{name: "total live over cap", frames: append(repeated(MaxFrameBytes*8, int(MaxLiveMemoryBytes/MaxFrameBytes)), 8), want: ErrBudgetExceeded},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Program{decoded: true, evalSteps: 1, frameBitWidths: tt.frames}.Evaluate(EvalOptions{})
+			if tt.want != "" {
+				assertErrorCode(t, err, tt.want)
+				return
+			}
+			if err != nil || !got.Accepted || got.Cost != StepCost {
+				t.Fatalf("evaluation=%+v err=%v want accepted cost=%d", got, err, StepCost)
+			}
+		})
+	}
+
+	calls := 0
+	program := decodeSHA3Jet(t)
+	program.frameBitWidths = []uint64{MaxFrameBytes*8 + 1}
+	_, err := program.Evaluate(EvalOptions{
+		JetEvaluator: func(Jet) (EvalResult, error) {
+			calls++
+			return EvalResult{Accepted: true, Cost: 1}, nil
+		},
+	})
+	assertErrorCode(t, err, ErrBudgetExceeded)
+	if calls != 0 {
+		t.Fatalf("JetEvaluator calls=%d want 0 before memory reject", calls)
+	}
+}
+
+func TestEvaluateMemoryErrorClassPriority(t *testing.T) {
+	overFrame := []uint64{MaxFrameBytes*8 + 1}
+	_, err := Program{frameBitWidths: overFrame}.Evaluate(EvalOptions{})
+	assertErrorCode(t, err, ErrDecode)
+
+	_, err = Program{decoded: true, frameBitWidths: overFrame}.Evaluate(EvalOptions{})
+	assertErrorCode(t, err, ErrDecode)
+
+	_, err = Program{decoded: true, hasJet: true, jetKey: jetKey{id: 0xffff}, frameBitWidths: overFrame}.Evaluate(EvalOptions{})
+	assertErrorCode(t, err, ErrDecode)
+
+	_, err = Program{decoded: true, evalSteps: 1, frameBitWidths: overFrame}.Evaluate(EvalOptions{})
+	assertErrorCode(t, err, ErrBudgetExceeded)
 }
 
 func TestEvaluateJetRejectsFailedHookResult(t *testing.T) {
@@ -378,6 +464,14 @@ func evaluateSHA3JetWithResult(t *testing.T, program Program, result EvalResult)
 		t.Fatalf("JetEvaluator calls=%d want 1", calls)
 	}
 	return got, err
+}
+
+func repeated(value uint64, count int) []uint64 {
+	out := make([]uint64, count)
+	for i := range out {
+		out[i] = value
+	}
+	return out
 }
 
 func assertErrorCode(t *testing.T, err error, want ErrorCode) {

--- a/clients/go/consensus/simplicity/program_test.go
+++ b/clients/go/consensus/simplicity/program_test.go
@@ -314,27 +314,15 @@ func TestEvaluateJetCostHookCapBoundary(t *testing.T) {
 }
 
 func TestEvaluateMemoryBounds(t *testing.T) {
-	tests := []struct {
-		name   string
-		frames []uint64
-		want   ErrorCode
-	}{
-		{name: "frame at cap", frames: []uint64{MaxFrameBytes * 8}},
-		{name: "total live at cap", frames: repeated(MaxFrameBytes*8, int(MaxLiveMemoryBytes/MaxFrameBytes))},
-		{name: "frame over cap", frames: []uint64{MaxFrameBytes*8 + 1}, want: ErrBudgetExceeded},
-		{name: "total live over cap", frames: append(repeated(MaxFrameBytes*8, int(MaxLiveMemoryBytes/MaxFrameBytes)), 8), want: ErrBudgetExceeded},
+	for _, frames := range [][]uint64{{MaxFrameBytes * 8}, repeated(MaxFrameBytes*8, int(MaxLiveMemoryBytes/MaxFrameBytes))} {
+		got, err := Program{decoded: true, evalSteps: 1, frameBitWidths: frames}.Evaluate(EvalOptions{})
+		if err != nil || !got.Accepted || got.Cost != StepCost {
+			t.Fatalf("evaluation=%+v err=%v want accepted cost=%d", got, err, StepCost)
+		}
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := Program{decoded: true, evalSteps: 1, frameBitWidths: tt.frames}.Evaluate(EvalOptions{})
-			if tt.want != "" {
-				assertErrorCode(t, err, tt.want)
-				return
-			}
-			if err != nil || !got.Accepted || got.Cost != StepCost {
-				t.Fatalf("evaluation=%+v err=%v want accepted cost=%d", got, err, StepCost)
-			}
-		})
+	for _, frames := range [][]uint64{{MaxFrameBytes*8 + 1}, append(repeated(MaxFrameBytes*8, int(MaxLiveMemoryBytes/MaxFrameBytes)), 8)} {
+		_, err := Program{decoded: true, evalSteps: 1, frameBitWidths: frames}.Evaluate(EvalOptions{})
+		assertErrorCode(t, err, ErrBudgetExceeded)
 	}
 
 	calls := 0
@@ -349,6 +337,33 @@ func TestEvaluateMemoryBounds(t *testing.T) {
 	assertErrorCode(t, err, ErrBudgetExceeded)
 	if calls != 0 {
 		t.Fatalf("JetEvaluator calls=%d want 0 before memory reject", calls)
+	}
+}
+
+func TestDecodePopulatesMemorySchedule(t *testing.T) {
+	for _, tt := range []struct{ program, witness string }{
+		{"24", ""},
+		{"c1d21014", "00"},
+		{"60", ""},
+		{"70", ""},
+	} {
+		program, err := Decode(hx(tt.program), hx(tt.witness), DecodeOptions{SemanticsVersion: SemanticsVersion})
+		if err != nil {
+			t.Fatalf("Decode(%s): %v", tt.program, err)
+		}
+		if len(program.frameBitWidths) == 0 {
+			t.Fatalf("Decode(%s) returned no frame schedule", tt.program)
+		}
+		if err := checkMemoryBounds(program.frameBitWidths); err != nil {
+			t.Fatalf("Decode(%s) frame schedule exceeds bounds: %v", tt.program, err)
+		}
+	}
+
+	first := decodeSHA3Jet(t)
+	first.frameBitWidths[0] = MaxFrameBytes*8 + 1
+
+	if err := checkMemoryBounds(decodeSHA3Jet(t).frameBitWidths); err != nil {
+		t.Fatalf("Decode returned mutable frame schedule: %v", err)
 	}
 }
 


### PR DESCRIPTION
Invariant:
Go Simplicity evaluation enforces RUB-548 frame/live memory bounds and exposes the deterministic SPEC-SIMPLICITY-01 cost_model_hash.

Layer:
implementation, tests

Files changed:
- clients/go/consensus/simplicity/program.go
- clients/go/consensus/simplicity/program_test.go

Tests:
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./consensus/simplicity -count=1': PASS
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./...': PASS
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go vet ./...': PASS
- git diff --check: PASS
- rubin-precommit-one-review with include-base-diff: PASS
- one isolated stock code-review receipt: PASS; reviewer raised a Go/Rust parity concern, disposition non-applicable under the RUB-548 staged Go-only contract because RUB-549 owns the Rust mirror.
- rubin-push with scripts/dev-env.sh -- ./scripts/preflight-codacy-coverage.sh: PASS

Pre-push review index:
- S1 Decode/memory path: PASS
- S2 error/resource bounds and priority: PASS
- S3 cost artifact and hash: PASS
- S4 test-proof and bot-gap scan: PASS
- S5 staged parity scope: PASS

Behavior impact:
- Programs whose abstract frame bytes exceed 65,536 now fail with TX_ERR_SIMPLICITY_BUDGET_EXCEEDED after decode/internal-shape checks.
- Programs whose total live abstract frame bytes exceed 1,048,576 now fail with TX_ERR_SIMPLICITY_BUDGET_EXCEEDED.
- CostModelHash returns SHA3-256 over the committed CostModelBytes_v1 rows for the current Go Simplicity jet table.

Compatibility impact:
- Go-only staged implementation slice.
- No Rust files, shared corpus files, consensus dispatch, jets, or metering semantics outside the RUB-548 bounds/hash/error-class scope are changed.

### Parity exemption justification

This PR is intentionally Go-only under RUB-548. The Linear graph stages Rust parity separately in RUB-549 and shared parity corpus work in RUB-488 after both client slices exist. The PR therefore must not modify Rust or shared conformance fixtures in this slice.

Known non-goals:
- No Rust mirror implementation.
- No shared execution corpus update.
- No Program Encoding grammar changes.
- No changes to jets beyond the cost model rows already keyed to the existing Go jet table.

Follow-ups:
- RUB-549: Rust mirror for the same memory bounds, cost_model_hash, and deterministic first-error classes.
- RUB-488: shared Go/Rust parity corpus after staged client slices.

Closes #2079
