### PR TITLE
formal: mirror RUB-576 section hash disposition

### DIFF
--- a/rubin-formal/proof_coverage.json
+++ b/rubin-formal/proof_coverage.json
@@ -4,7 +4,7 @@
   "claim_level": "refined",
   "spec_source_file": "spec/RUBIN_L1_CANONICAL.md",
   "spec_section_hashes_file": "spec/SECTION_HASHES.json",
-  "spec_section_hashes_sha3_256": "ffef2c8fcecc12a0cc4e95bb7063bca9217af204b1c33e2c41e3213d1ec4fb48",
+  "spec_section_hashes_sha3_256": "f7862a144ae9a62bbe0cf6ca721a3768c65c4a3ee34f6530e4919d063b14a70f",
   "lean_toolchain_file": "rubin-formal/lean-toolchain",
   "refinement_bridge_file": "rubin-formal/refinement_bridge.json",
   "coverage": [


### PR DESCRIPTION
Invariant:
Sync the embedded formal mirror pointer used by spec CI for the RUB-576 candidate spec/SECTION_HASHES.json bytes.

Layer:
Repository-local formal mirror / spec-ci gate support.

Files changed:
- rubin-formal/proof_coverage.json

Tests:
- python3 -m json.tool rubin-formal/proof_coverage.json - PASS
- git diff --check - PASS
- python3 tools/check_formal_disposition_for_section_hashes.py --spec-root <RUB-576 spec candidate> --formal-root rubin-formal - PASS
- spec-ci layout simulation with this protocol mirror and the RUB-576 spec candidate - PASS
- scripts/dev-env.sh -- python3 tools/check_formal_coverage.py - PASS
- scripts/dev-env.sh -- python3 tools/check_formal_claims_lint.py - PASS
- scripts/dev-env.sh -- python3 tools/check_formal_risk_gate.py --profile phase0 - PASS
- scripts/dev-env.sh -- python3 tools/check_formal_refinement_bridge.py - PASS
- rubin-precommit-one-review --base-ref origin/main --include-base-diff - PASS
- isolated stock code-review - PASS, no findings
- rubin-push --base-ref origin/main --no-coverage-reason ... - PASS

Behavior impact:
No Go/Rust client behavior, tooling logic, generated artifact, deployment descriptor, or activation change.

Compatibility impact:
This PR is a RUB-576 companion for spec/SECTION_HASHES.json sha3-256 f7862a144ae9a62bbe0cf6ca721a3768c65c4a3ee34f6530e4919d063b14a70f.

Known non-goals:
- No client implementation changes.
- No generated artifact changes.
- No activation.
- No formal claim expansion.

Risk:
This PR is not standalone against current spec main by design. Merge only as part of the RUB-576 release train, after rubin-formal#529 and before the spec PR.

Rollback:
Revert the one-line embedded mirror hash update.

Not checked:
Full protocol coverage was not run locally because this is a JSON-only mirror pointer update with no executable coverage surface.

Linear: RUB-576