### PR TITLE
RUB-549 rust: mirror Simplicity bounds and cost hash

### DIFF
--- a/clients/rust/crates/rubin-consensus/src/simplicity.rs
+++ b/clients/rust/crates/rubin-consensus/src/simplicity.rs
@@ -208,7 +208,7 @@ fn check_memory_bounds(frame_bit_widths: &[u64]) -> Result<(), EvalError> {
 }
 
 #[rustfmt::skip]
-fn frame_bytes(bits: u64) -> u64 { bits / 8 + u64::from(bits % 8 != 0) }
+fn frame_bytes(bits: u64) -> u64 { bits / 8 + u64::from(!bits.is_multiple_of(8)) }
 
 #[rustfmt::skip]
 fn cost_model_bytes() -> Vec<u8> {

--- a/clients/rust/crates/rubin-consensus/src/simplicity.rs
+++ b/clients/rust/crates/rubin-consensus/src/simplicity.rs
@@ -2,11 +2,19 @@ use core::fmt;
 use std::sync::OnceLock;
 
 use sha2::{compress256, digest::generic_array::GenericArray};
+use sha3::{Digest, Sha3_256};
 
 pub const SEMANTICS_VERSION: u32 = 1;
 pub const MAX_PROGRAM_BYTES: usize = 16_384;
 pub const MAX_EXEC_COST: u64 = 400_000;
 pub const STEP_COST: u64 = 1;
+pub const COST_MODEL_SEMANTICS_VERSION: u32 = 2;
+pub const INTRINSIC_READ_COST: u64 = 1;
+pub const INTRINSIC_MISS_COST: u64 = 1;
+pub const DESCRIPTOR_HASH_BASE_COST: u64 = 64;
+pub const DESCRIPTOR_HASH_BYTE_COST: u64 = 1;
+pub const MAX_FRAME_BYTES: u64 = 65_536;
+pub const MAX_LIVE_MEMORY_BYTES: u64 = 1_048_576;
 #[rustfmt::skip]
 pub const PROGRAM_ENCODING_HASH: [u8; 32] = [
     0x27, 0xe5, 0xad, 0x52, 0x1e, 0xfd, 0xf9, 0xd1, 0x85, 0xc1, 0xc9, 0x2a, 0x3a, 0x1a, 0x4a, 0xac, 0xc9, 0x27, 0x6c, 0x2a, 0x5b, 0x1b, 0x85, 0x18, 0xce, 0x25, 0xc8, 0xc9, 0x73, 0xa3, 0x8a, 0xdc,
@@ -37,7 +45,7 @@ pub struct DecodeOptions { pub semantics_version: u32, pub covenant_program_cmr:
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[rustfmt::skip]
-pub struct Program { pub cmr: [u8; 32], pub jet: Option<Jet>, pub needs_witness: bool, max_witness_len: usize, witness_kind: WitnessKind, eval_steps: u64, has_jet: bool, jet_key: Option<JetKey> }
+pub struct Program { pub cmr: [u8; 32], pub jet: Option<Jet>, pub needs_witness: bool, max_witness_len: usize, witness_kind: WitnessKind, eval_steps: u64, decoded: bool, has_jet: bool, jet_key: Option<JetKey>, frame_bit_widths: Vec<u64> }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[rustfmt::skip]
@@ -72,6 +80,15 @@ pub struct EvalOptions<'a> { pub jet_evaluator: Option<&'a dyn Fn(Jet) -> Result
 #[rustfmt::skip]
 struct JetRow { id: u16, sub_op: u8, name: &'static str, selector_bit_len: usize, selector_padded: &'static [u8], cmr: &'static str }
 
+#[derive(Clone, Copy)]
+#[rustfmt::skip]
+struct CostModelRow { jet: JetKey, formula: CostFormula, param: u64 }
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(u8)]
+#[rustfmt::skip]
+enum CostFormula { Constant, BasePlusLen, OnePlusCeilLen32 }
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[rustfmt::skip]
 enum WitnessKind { None, Bool }
@@ -81,9 +98,10 @@ type JetKey = (u16, u8);
 #[rustfmt::skip]
 pub fn decode(program: &[u8], witness: &[u8], opts: DecodeOptions) -> Result<Program, Error> {
     if program.len() > MAX_PROGRAM_BYTES { return Err(Error { code: ErrorCode::ProgramTooLarge }); }
-    let decoded = decode_program(program)?;
+    let mut decoded = decode_program(program)?;
     if opts.covenant_program_cmr.is_some_and(|want| decoded.cmr != want) { return Err(Error { code: ErrorCode::CmrMismatch }); }
     if witness.len() > decoded.max_witness_len || !witness_allowed(decoded.witness_kind, opts.semantics_version, witness) { return Err(Error { code: ErrorCode::Decode }); }
+    decoded.decoded = true;
     Ok(decoded)
 }
 
@@ -96,14 +114,17 @@ pub fn lookup_jet(id: u16, sub_op: u8) -> Option<Jet> {
 #[rustfmt::skip]
 impl Program {
     pub fn evaluate(&self, opts: EvalOptions<'_>) -> Result<EvalResult, EvalError> {
+        if !self.decoded { return Err(EvalError::new(ErrorCode::Decode)); }
         if self.has_jet { return self.evaluate_jet(opts); }
         if self.eval_steps == 0 { return Err(EvalError::new(ErrorCode::Decode)); }
+        check_memory_bounds(&self.frame_bit_widths)?;
         evaluate_steps(self.eval_steps)
     }
 
     fn evaluate_jet(&self, opts: EvalOptions<'_>) -> Result<EvalResult, EvalError> {
-        let evaluator = opts.jet_evaluator.ok_or_else(|| EvalError::new(ErrorCode::JetDisallowed))?;
         let jet = decoded_jet(self.jet_key)?;
+        check_memory_bounds(&self.frame_bit_widths)?;
+        let evaluator = opts.jet_evaluator.ok_or_else(|| EvalError::new(ErrorCode::JetDisallowed))?;
         metered_jet_result(evaluator(jet).map_err(|err| EvalError::new(err.code))?)
     }
 }
@@ -128,6 +149,11 @@ fn metered_jet_result(mut result: EvalResult) -> Result<EvalResult, EvalError> {
         return Err(EvalError::with_result(ErrorCode::BudgetExceeded, result));
     }
     if result.accepted { Ok(result) } else { Err(EvalError::with_result(ErrorCode::Rejected, result)) }
+}
+
+#[rustfmt::skip]
+pub fn cost_model_hash() -> [u8; 32] {
+    Sha3_256::digest(cost_model_bytes()).into()
 }
 
 #[rustfmt::skip]
@@ -158,14 +184,50 @@ fn decode_program(program: &[u8]) -> Result<Program, Error> {
 
 #[rustfmt::skip]
 fn program_entry(cmr: &str, jet: Option<Jet>, witness_kind: WitnessKind, eval_steps: u64) -> Result<Program, Error> {
+    let frames = if witness_kind == WitnessKind::Bool { BOOL_FRAMES } else { UNIT_FRAMES };
     let needs_witness = witness_kind == WitnessKind::Bool;
     let jet_key = jet.map(|j| (j.id, j.sub_op));
-    Ok(Program { cmr: hex32(cmr)?, jet, needs_witness, max_witness_len: usize::from(needs_witness), witness_kind, eval_steps, has_jet: jet_key.is_some(), jet_key })
+    Ok(Program { cmr: hex32(cmr)?, jet, needs_witness, max_witness_len: usize::from(needs_witness), witness_kind, eval_steps, decoded: false, has_jet: jet_key.is_some(), jet_key, frame_bit_widths: frames.to_vec() })
 }
 
 #[rustfmt::skip]
 fn jet_entry(jet: Jet) -> Program {
-    Program { cmr: jet.cmr, jet: Some(jet), needs_witness: false, max_witness_len: 0, witness_kind: WitnessKind::None, eval_steps: 0, has_jet: true, jet_key: Some((jet.id, jet.sub_op)) }
+    let frames = match (jet.id, jet.sub_op) { (0x0001, 0x00) => SHA3_FRAMES, (0x0002, 0x00) => MLDSA87_FRAMES, _ => &[] };
+    Program { cmr: jet.cmr, jet: Some(jet), needs_witness: false, max_witness_len: 0, witness_kind: WitnessKind::None, eval_steps: 0, decoded: false, has_jet: true, jet_key: Some((jet.id, jet.sub_op)), frame_bit_widths: frames.to_vec() }
+}
+
+#[rustfmt::skip]
+fn check_memory_bounds(frame_bit_widths: &[u64]) -> Result<(), EvalError> {
+    let mut live = 0u64;
+    for bits in frame_bit_widths {
+        let frame = frame_bytes(*bits);
+        if frame > MAX_FRAME_BYTES || live > MAX_LIVE_MEMORY_BYTES - frame { return Err(EvalError::new(ErrorCode::BudgetExceeded)); }
+        live += frame;
+    }
+    Ok(())
+}
+
+#[rustfmt::skip]
+fn frame_bytes(bits: u64) -> u64 { bits / 8 + u64::from(bits % 8 != 0) }
+
+#[rustfmt::skip]
+fn cost_model_bytes() -> Vec<u8> {
+    let mut out = b"RUBIN-SIMPLICITY-COST-v1".to_vec();
+    out.extend_from_slice(&COST_MODEL_SEMANTICS_VERSION.to_le_bytes());
+    for value in [STEP_COST, INTRINSIC_READ_COST, INTRINSIC_MISS_COST, DESCRIPTOR_HASH_BASE_COST, DESCRIPTOR_HASH_BYTE_COST, MAX_FRAME_BYTES, MAX_LIVE_MEMORY_BYTES] { out.extend_from_slice(&value.to_le_bytes()); }
+    out.push(cost_model_row_count_byte(COST_MODEL_ROWS.len()));
+    for row in COST_MODEL_ROWS {
+        out.extend_from_slice(&row.jet.0.to_le_bytes());
+        out.extend_from_slice(&[row.jet.1, row.formula as u8]);
+        out.extend_from_slice(&row.param.to_le_bytes());
+    }
+    out
+}
+
+#[rustfmt::skip]
+fn cost_model_row_count_byte(rows: usize) -> u8 {
+    assert!(rows < 253, "cost model row count exceeds one-byte CompactSize encoding");
+    rows as u8
 }
 
 #[rustfmt::skip]
@@ -187,6 +249,27 @@ const JET_ROWS: &[JetRow] = &[
     JetRow { id: 0x0020, sub_op: 0x00, name: "bytes_eq",         selector_bit_len: 13, selector_padded: &[0xe2, 0x00],       cmr: "33f82e38417283760f1d9deba367aeaa0feb4c703b69aa37dc8c2aefe7c32d4a" },
     JetRow { id: 0x0020, sub_op: 0x01, name: "bytes_cmp",        selector_bit_len: 15, selector_padded: &[0xe2, 0x08],       cmr: "bd237f53ad86be9b3c8bd3dcb2a36642782c07885d5afc44903b5dc6d017960a" },
     JetRow { id: 0x0021, sub_op: 0x00, name: "bytes_slice",      selector_bit_len: 13, selector_padded: &[0xe2, 0x10],       cmr: "9c28e72f9da964de2c90d92c5c772211537ed2e07d20f6790c988284a87c0ce2" },
+];
+
+const UNIT_FRAMES: &[u64] = &[0, 0];
+const BOOL_FRAMES: &[u64] = &[1, 1];
+const SHA3_FRAMES: &[u64] = &[512, 256];
+const MLDSA87_FRAMES: &[u64] = &[(2_592 + 4_627 + 32) * 8, 1];
+
+#[rustfmt::skip]
+const COST_MODEL_ROWS: &[CostModelRow] = &[
+    CostModelRow { jet: (0x0001, 0x00), formula: CostFormula::BasePlusLen, param: 64 },
+    CostModelRow { jet: (0x0002, 0x00), formula: CostFormula::Constant, param: 50_000 },
+    CostModelRow { jet: (0x0010, 0x00), formula: CostFormula::Constant, param: 1 },
+    CostModelRow { jet: (0x0010, 0x01), formula: CostFormula::Constant, param: 1 },
+    CostModelRow { jet: (0x0010, 0x02), formula: CostFormula::Constant, param: 1 },
+    CostModelRow { jet: (0x0010, 0x03), formula: CostFormula::Constant, param: 1 },
+    CostModelRow { jet: (0x0011, 0x00), formula: CostFormula::Constant, param: 1 },
+    CostModelRow { jet: (0x0011, 0x01), formula: CostFormula::Constant, param: 1 },
+    CostModelRow { jet: (0x0011, 0x03), formula: CostFormula::Constant, param: 1 },
+    CostModelRow { jet: (0x0020, 0x00), formula: CostFormula::OnePlusCeilLen32, param: 0 },
+    CostModelRow { jet: (0x0020, 0x01), formula: CostFormula::OnePlusCeilLen32, param: 0 },
+    CostModelRow { jet: (0x0021, 0x00), formula: CostFormula::OnePlusCeilLen32, param: 0 },
 ];
 
 #[rustfmt::skip]

--- a/clients/rust/crates/rubin-consensus/src/simplicity/tests/mod.rs
+++ b/clients/rust/crates/rubin-consensus/src/simplicity/tests/mod.rs
@@ -167,11 +167,136 @@ fn rubin_jet_cmr_examples_match_go_reference() {
 }
 
 #[test]
+fn cost_model_hash_matches_go_reference() {
+    let want_preimage = concat!(
+        "525542494e2d53494d504c49434954592d434f53542d76310200000001000000000000000100000000000000010000000000000040000000000000000100000000000000000001000000000000001000000000000c",
+        "0100000140000000000000000200000050c3000000000000100000000100000000000000100001000100000000000000100002000100000000000000100003000100000000000000110000000100000000000000110001000100000000000000110003000100000000000000200000020000000000000000200001020000000000000000210000020000000000000000",
+    );
+    assert_eq!(hex::encode(cost_model_bytes()), want_preimage);
+    assert_eq!(
+        cost_model_hash(),
+        hex32("accb55570168bd7b1fedadff2135c99e32508680ff7a315cf4f33f97744aabc9").unwrap()
+    );
+}
+
+#[test]
+fn cost_model_rows_match_jet_table() {
+    assert_eq!(COST_MODEL_ROWS.len(), JET_ROWS.len());
+    assert!(COST_MODEL_ROWS.len() < 253);
+    let mut prev = (0, 0);
+    for (i, row) in COST_MODEL_ROWS.iter().enumerate() {
+        assert!(
+            lookup_jet(row.jet.0, row.jet.1).is_some(),
+            "missing jet row {i}"
+        );
+        assert!(i == 0 || prev < row.jet, "cost rows not sorted at {i}");
+        assert!(row.formula <= CostFormula::OnePlusCeilLen32);
+        assert!(row.formula != CostFormula::OnePlusCeilLen32 || row.param == 0);
+        prev = row.jet;
+    }
+}
+
+#[test]
+#[should_panic(expected = "cost model row count exceeds one-byte CompactSize encoding")]
+fn cost_model_row_count_rejects_multi_byte_compact_size() {
+    let _ = cost_model_row_count_byte(253);
+}
+
+#[test]
 #[rustfmt::skip]
 fn evaluate_charges_decoded_program_steps() {
     for (program, witness, cost) in [("24", "", 1), ("8900", "", 2), ("c1220f0100", "", 4), ("c1d21014", "00", 4)] {
         assert_eq!(decoded(program, witness).evaluate(EvalOptions::default()).unwrap(), EvalResult { accepted: true, cost: cost * STEP_COST });
     }
+}
+
+#[test]
+fn evaluate_memory_bounds_match_go_reference() {
+    for frames in [
+        vec![MAX_FRAME_BYTES * 8],
+        repeated(
+            MAX_FRAME_BYTES * 8,
+            (MAX_LIVE_MEMORY_BYTES / MAX_FRAME_BYTES) as usize,
+        ),
+    ] {
+        let got = internal_program(1, false, None, frames)
+            .evaluate(EvalOptions::default())
+            .unwrap();
+        assert_eq!(got, ok(STEP_COST));
+    }
+    for frames in [
+        vec![MAX_FRAME_BYTES * 8 + 1],
+        [
+            repeated(
+                MAX_FRAME_BYTES * 8,
+                (MAX_LIVE_MEMORY_BYTES / MAX_FRAME_BYTES) as usize,
+            ),
+            vec![8],
+        ]
+        .concat(),
+    ] {
+        assert_eq!(
+            internal_program(1, false, None, frames)
+                .evaluate(EvalOptions::default())
+                .unwrap_err()
+                .code,
+            ErrorCode::BudgetExceeded
+        );
+    }
+
+    let calls = std::cell::Cell::new(0);
+    let mut program = decoded("60", "");
+    program.frame_bit_widths = vec![MAX_FRAME_BYTES * 8 + 1];
+    let hook = |_: Jet| {
+        calls.set(calls.get() + 1);
+        Ok(ok(1))
+    };
+    assert_eq!(
+        program.evaluate(with_jet_hook(&hook)).unwrap_err().code,
+        ErrorCode::BudgetExceeded
+    );
+    assert_eq!(calls.get(), 0);
+}
+
+#[test]
+fn decode_populates_memory_schedule() {
+    for (program, witness) in [("24", ""), ("c1d21014", "00"), ("60", ""), ("70", "")] {
+        let program = decoded(program, witness);
+        assert!(!program.frame_bit_widths.is_empty());
+        check_memory_bounds(&program.frame_bit_widths).unwrap();
+    }
+}
+
+#[test]
+fn evaluate_memory_error_class_priority() {
+    let over_frame = vec![MAX_FRAME_BYTES * 8 + 1];
+    let mut undecoded = internal_program(1, false, None, over_frame.clone());
+    undecoded.decoded = false;
+    assert_eq!(
+        undecoded.evaluate(EvalOptions::default()).unwrap_err().code,
+        ErrorCode::Decode
+    );
+    assert_eq!(
+        internal_program(0, false, None, over_frame.clone())
+            .evaluate(EvalOptions::default())
+            .unwrap_err()
+            .code,
+        ErrorCode::Decode
+    );
+    assert_eq!(
+        internal_program(0, true, Some((0xffff, 0x00)), over_frame.clone())
+            .evaluate(EvalOptions::default())
+            .unwrap_err()
+            .code,
+        ErrorCode::Decode
+    );
+    assert_eq!(
+        internal_program(1, false, None, over_frame)
+            .evaluate(EvalOptions::default())
+            .unwrap_err()
+            .code,
+        ErrorCode::BudgetExceeded
+    );
 }
 
 #[test]
@@ -187,7 +312,7 @@ fn evaluate_jet_requires_cost_hook() {
 #[rustfmt::skip]
 fn evaluate_ignores_public_jet_without_decoded_key() {
     let hook = |_: Jet| Ok(ok(1));
-    let program = Program { jet: Some(lookup_jet(0x0001, 0x00).unwrap()), ..internal_program(0, false, None) };
+    let program = Program { jet: Some(lookup_jet(0x0001, 0x00).unwrap()), ..internal_program(0, false, None, vec![]) };
     assert_eq!(program.evaluate(with_jet_hook(&hook)).unwrap_err().code, ErrorCode::Decode);
 }
 
@@ -231,14 +356,14 @@ fn evaluate_jet_rejects_failed_hook_result() {
 #[test]
 #[rustfmt::skip]
 fn evaluate_internal_fail_closed_paths() {
-    assert_eq!(internal_program(0, false, None).evaluate(EvalOptions::default()).unwrap_err().code, ErrorCode::Decode);
+    assert_eq!(internal_program(0, false, None, vec![]).evaluate(EvalOptions::default()).unwrap_err().code, ErrorCode::Decode);
     let hook = |_: Jet| Ok(ok(0));
-    assert_eq!(internal_program(0, true, Some((0xffff, 0x00))).evaluate(with_jet_hook(&hook)).unwrap_err().code, ErrorCode::Decode);
+    assert_eq!(internal_program(0, true, Some((0xffff, 0x00)), vec![]).evaluate(with_jet_hook(&hook)).unwrap_err().code, ErrorCode::Decode);
     let hook_error = |_: Jet| Err(EvalError { code: ErrorCode::Decode, result: ok(9) });
     let err = decoded("60", "").evaluate(with_jet_hook(&hook_error)).unwrap_err();
     assert_eq!(err.code, ErrorCode::Decode);
     assert_eq!(err.result, EvalResult::default());
-    let err = internal_program(MAX_EXEC_COST / STEP_COST + 1, false, None)
+    let err = internal_program(MAX_EXEC_COST / STEP_COST + 1, false, None, vec![])
         .evaluate(EvalOptions::default())
         .unwrap_err();
     assert_eq!(err.code, ErrorCode::BudgetExceeded);
@@ -263,8 +388,12 @@ fn rejected(cost: u64) -> EvalResult { EvalResult { accepted: false, cost } }
 fn with_jet_hook<'a>(hook: &'a dyn Fn(Jet) -> Result<EvalResult, EvalError>) -> EvalOptions<'a> { EvalOptions { jet_evaluator: Some(hook) } }
 
 #[rustfmt::skip]
-fn internal_program(eval_steps: u64, has_jet: bool, jet_key: Option<JetKey>) -> Program {
-    Program { cmr: [0; 32], jet: None, needs_witness: false, max_witness_len: 0, witness_kind: WitnessKind::None, eval_steps, has_jet, jet_key }
+fn internal_program(eval_steps: u64, has_jet: bool, jet_key: Option<JetKey>, frame_bit_widths: Vec<u64>) -> Program {
+    Program { cmr: [0; 32], jet: None, needs_witness: false, max_witness_len: 0, witness_kind: WitnessKind::None, eval_steps, decoded: true, has_jet, jet_key, frame_bit_widths }
+}
+
+fn repeated(value: u64, count: usize) -> Vec<u64> {
+    vec![value; count]
 }
 
 fn decode_err(program: &[u8], witness: &[u8]) -> ErrorCode {


### PR DESCRIPTION
Refs #2080

Invariant:
Rust Simplicity evaluation mirrors the merged Go memory bounds, cost_model_hash preimage/hash, and first error-class ordering from RUB-548.

Layer:
implementation/tests

Files changed:
- clients/rust/crates/rubin-consensus/src/simplicity.rs
- clients/rust/crates/rubin-consensus/src/simplicity/tests/mod.rs

### Parity exemption justification
This PR intentionally changes only Rust consensus implementation paths because the Go memory bounds and cost_model_hash behavior already landed in RUB-548 before this Rust mirror slice. The invariant here is Rust parity with that existing Go reference behavior; there is no new Go-side behavior in this PR.

Tests:
- scripts/dev-env.sh -- bash -lc "cd clients/rust && cargo fmt --check" - PASS
- git diff --check - PASS
- scripts/dev-env.sh -- bash -lc "cd clients/rust && cargo test -p rubin-consensus simplicity" - PASS
- scripts/dev-env.sh -- bash -lc "cd clients/rust && cargo test --workspace" - PASS
- scripts/dev-env.sh -- ./scripts/preflight-codacy-coverage.sh - PASS
- rubin-precommit-one-review --repo . --base-ref origin/main - PASS
- rubin-one-review-gate --check --repo . --base-ref origin/main - PASS

Behavior impact:
- Adds Rust cost_model_hash and memory frame bounds for the standalone Simplicity evaluation subset.
- Keeps the standalone library unwired from consensus dispatch.

Compatibility impact:
- Adds public constants and cost_model_hash; no Cargo dependency or fixture/schema changes.

Known non-goals:
- No Go changes.
- No shared conformance corpus changes.
- No consensus dispatch wiring.
- No workflow changes.

Risk:
Consensus dispatch is unchanged; risk is limited to the standalone Rust Simplicity library.

Rollback:
Revert this commit.

Not checked:
External GitHub/Codacy CI before PR creation.
