### PR TITLE
RUB-550 go: add Simplicity crypto jet primitives

### DIFF
--- a/clients/go/consensus/simplicity/crypto_jets.go
+++ b/clients/go/consensus/simplicity/crypto_jets.go
@@ -1,0 +1,50 @@
+package simplicity
+
+import "crypto/sha3"
+
+const (
+	sha3256JetBaseCost   uint64 = 64
+	mldsa87VerifyJetCost uint64 = 50_000
+	mldsa87PubkeyBytes          = 2_592
+	mldsa87SigBytes             = 4_627
+)
+
+// These helpers are staged Go-native primitives. They do not wire Program.Evaluate
+// or consensus validation; Rust/shared parity slices must land before dispatch.
+type SHA3256JetResult struct {
+	Digest [32]byte
+	Cost   uint64
+}
+
+func EvaluateSHA3256Jet(message []byte) SHA3256JetResult {
+	return SHA3256JetResult{
+		Digest: sha3.Sum256(message),
+		Cost:   sha3256JetBaseCost + uint64(len(message)),
+	}
+}
+
+// A false verification result is program-visible and is not an error here.
+type MLDSA87VerifyJetResult struct {
+	Verified bool
+	Cost     uint64
+}
+
+type MLDSA87Digest32Verifier func(pubkey []byte, signature []byte, digest32 [32]byte) (bool, error)
+
+// EvaluateMLDSA87VerifyJet accepts raw ML-DSA-87 signatures only; no trailing
+// sighash byte is stripped or interpreted.
+func EvaluateMLDSA87VerifyJet(pubkey []byte, signature []byte, digest32 [32]byte, verifier MLDSA87Digest32Verifier) (MLDSA87VerifyJetResult, error) {
+	result := MLDSA87VerifyJetResult{Cost: mldsa87VerifyJetCost}
+	if len(pubkey) != mldsa87PubkeyBytes || len(signature) != mldsa87SigBytes {
+		return result, nil
+	}
+	if verifier == nil {
+		return result, &Error{Code: ErrJetDisallowed}
+	}
+	ok, err := verifier(pubkey, signature, digest32)
+	if err != nil {
+		return result, err
+	}
+	result.Verified = ok
+	return result, nil
+}

--- a/clients/go/consensus/simplicity/crypto_jets_backend_test.go
+++ b/clients/go/consensus/simplicity/crypto_jets_backend_test.go
@@ -1,0 +1,46 @@
+//go:build cgo
+
+package simplicity_test
+
+import (
+	"crypto/sha3"
+	"strings"
+	"testing"
+
+	consensus "github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus/simplicity"
+)
+
+func TestMLDSA87VerifyJetUsesNativeDigest32BackendAndFlatCost(t *testing.T) {
+	kp, err := consensus.NewMLDSA87Keypair()
+	if err != nil {
+		if strings.Contains(err.Error(), "unsupported") {
+			t.Skipf("ML-DSA backend unavailable in this OpenSSL build: %v", err)
+		}
+		t.Fatalf("NewMLDSA87Keypair: %v", err)
+	}
+	t.Cleanup(func() { kp.Close() })
+
+	digest := sha3.Sum256([]byte("simplicity mldsa87_verify"))
+	signature, err := kp.SignDigest32(digest)
+	if err != nil {
+		t.Fatalf("SignDigest32: %v", err)
+	}
+
+	got, err := simplicity.EvaluateMLDSA87VerifyJet(kp.PubkeyBytes(), signature, digest, consensus.VerifyMLDSA87Digest32)
+	if err != nil {
+		t.Fatalf("mldsa87_verify valid: %v", err)
+	}
+	if !got.Verified || got.Cost != 50_000 {
+		t.Fatalf("valid mldsa87_verify=%+v want verified flat cost 50000", got)
+	}
+
+	digest[0] ^= 0xff
+	got, err = simplicity.EvaluateMLDSA87VerifyJet(kp.PubkeyBytes(), signature, digest, consensus.VerifyMLDSA87Digest32)
+	if err != nil {
+		t.Fatalf("mldsa87_verify wrong digest: %v", err)
+	}
+	if got.Verified || got.Cost != 50_000 {
+		t.Fatalf("wrong-digest mldsa87_verify=%+v want false flat cost 50000", got)
+	}
+}

--- a/clients/go/consensus/simplicity/crypto_jets_test.go
+++ b/clients/go/consensus/simplicity/crypto_jets_test.go
@@ -1,0 +1,95 @@
+package simplicity
+
+import (
+	"bytes"
+	"crypto/sha3"
+	"errors"
+	"testing"
+)
+
+func TestSHA3256JetUsesNativeSHA3AndChargesByMessageLen(t *testing.T) {
+	for _, msg := range [][]byte{
+		nil,
+		[]byte("abc"),
+		bytes.Repeat([]byte{0xa5}, 65),
+	} {
+		got := EvaluateSHA3256Jet(msg)
+		if got.Digest != sha3.Sum256(msg) {
+			t.Fatalf("sha3_256(%x)=%x", msg, got.Digest)
+		}
+		if got.Cost != sha3256JetBaseCost+uint64(len(msg)) {
+			t.Fatalf("sha3_256 cost=%d want %d", got.Cost, sha3256JetBaseCost+uint64(len(msg)))
+		}
+	}
+}
+
+func TestMLDSA87VerifyJetLengthMismatchIsProgramFalse(t *testing.T) {
+	digest := sha3.Sum256(nil)
+	called := false
+	verifier := func([]byte, []byte, [32]byte) (bool, error) {
+		called = true
+		return true, nil
+	}
+	tests := []struct {
+		name      string
+		pubkey    []byte
+		signature []byte
+	}{
+		{
+			name:      "short pubkey",
+			pubkey:    make([]byte, mldsa87PubkeyBytes-1),
+			signature: make([]byte, mldsa87SigBytes),
+		},
+		{
+			name:      "short signature",
+			pubkey:    make([]byte, mldsa87PubkeyBytes),
+			signature: make([]byte, mldsa87SigBytes-1),
+		},
+		{
+			name:      "sighash byte is not stripped",
+			pubkey:    make([]byte, mldsa87PubkeyBytes),
+			signature: make([]byte, mldsa87SigBytes+1),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			called = false
+			got, err := EvaluateMLDSA87VerifyJet(tt.pubkey, tt.signature, digest, verifier)
+			if err != nil {
+				t.Fatalf("mldsa87_verify: %v", err)
+			}
+			if called {
+				t.Fatal("mldsa87_verify called verifier for length mismatch")
+			}
+			if got.Verified || got.Cost != mldsa87VerifyJetCost {
+				t.Fatalf("mldsa87_verify=%+v want false flat cost %d", got, mldsa87VerifyJetCost)
+			}
+		})
+	}
+}
+
+func TestMLDSA87VerifyJetRequiresVerifierForValidLengths(t *testing.T) {
+	got, err := EvaluateMLDSA87VerifyJet(make([]byte, mldsa87PubkeyBytes), make([]byte, mldsa87SigBytes), [32]byte{}, nil)
+	assertErrorCode(t, err, ErrJetDisallowed)
+	if got.Verified || got.Cost != mldsa87VerifyJetCost {
+		t.Fatalf("mldsa87_verify=%+v want false flat cost %d", got, mldsa87VerifyJetCost)
+	}
+}
+
+func TestMLDSA87VerifyJetPropagatesVerifierError(t *testing.T) {
+	sentinel := errors.New("verifier failed")
+	got, err := EvaluateMLDSA87VerifyJet(
+		make([]byte, mldsa87PubkeyBytes),
+		make([]byte, mldsa87SigBytes),
+		[32]byte{},
+		func([]byte, []byte, [32]byte) (bool, error) {
+			return false, sentinel
+		},
+	)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("mldsa87_verify error=%v want %v", err, sentinel)
+	}
+	if got.Verified || got.Cost != mldsa87VerifyJetCost {
+		t.Fatalf("mldsa87_verify=%+v want false flat cost %d", got, mldsa87VerifyJetCost)
+	}
+}

--- a/clients/go/consensus/simplicity/program.go
+++ b/clients/go/consensus/simplicity/program.go
@@ -341,8 +341,8 @@ var (
 	sha3Frames    = []uint64{512, 256}
 	mldsa87Frames = []uint64{(2_592 + 4_627 + 32) * 8, 1}
 	costModelRows = []costModelRow{
-		{jet: jetKey{id: 0x0001, subOp: 0x00}, formula: costBasePlusLen, param: 64},
-		{jet: jetKey{id: 0x0002, subOp: 0x00}, formula: costConstant, param: 50_000},
+		{jet: jetKey{id: 0x0001, subOp: 0x00}, formula: costBasePlusLen, param: sha3256JetBaseCost},
+		{jet: jetKey{id: 0x0002, subOp: 0x00}, formula: costConstant, param: mldsa87VerifyJetCost},
 		{jet: jetKey{id: 0x0010, subOp: 0x00}, formula: costConstant, param: 1},
 		{jet: jetKey{id: 0x0010, subOp: 0x01}, formula: costConstant, param: 1},
 		{jet: jetKey{id: 0x0010, subOp: 0x02}, formula: costConstant, param: 1},

--- a/clients/go/consensus/verify_sig_openssl.go
+++ b/clients/go/consensus/verify_sig_openssl.go
@@ -407,6 +407,23 @@ func verifySig(suiteID uint8, pubkey []byte, signature []byte, digest32 [32]byte
 	}
 }
 
+// VerifyMLDSA87Digest32 verifies a raw ML-DSA-87 signature over an already-built
+// 32-byte digest using the live ML-DSA-87 backend. It does not append, strip,
+// interpret sighash bytes, or dispatch on a suite_id operand.
+func VerifyMLDSA87Digest32(pubkey []byte, signature []byte, digest32 [32]byte) (bool, error) {
+	if len(pubkey) != ML_DSA_87_PUBKEY_BYTES || len(signature) != ML_DSA_87_SIG_BYTES {
+		return false, nil
+	}
+	if err := ensureOpenSSLConsensusInit(); err != nil {
+		return false, err
+	}
+	binding, err := resolveSuiteVerifierBinding("ML-DSA-87", ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES)
+	if err != nil {
+		return false, err
+	}
+	return verifySigWithBinding(binding, pubkey, signature, digest32)
+}
+
 type suiteVerifierBindingKind uint8
 
 const (

--- a/clients/go/consensus/verify_sig_openssl_additional_test.go
+++ b/clients/go/consensus/verify_sig_openssl_additional_test.go
@@ -60,6 +60,42 @@ func TestOpenSSL_MLDSA87_VerifyWrongMessageReturnsFalse(t *testing.T) {
 	}
 }
 
+func TestVerifyMLDSA87Digest32UsesNativeBackend(t *testing.T) {
+	kp := mustMLDSA87Keypair(t)
+
+	var digest [32]byte
+	digest[0] = 0x5a
+	sig, err := kp.SignDigest32(digest)
+	if err != nil {
+		t.Fatalf("SignDigest32: %v", err)
+	}
+
+	ok, err := VerifyMLDSA87Digest32(kp.PubkeyBytes(), sig, digest)
+	if err != nil {
+		t.Fatalf("VerifyMLDSA87Digest32 valid: %v", err)
+	}
+	if !ok {
+		t.Fatal("VerifyMLDSA87Digest32=false for valid signature")
+	}
+
+	digest[0] ^= 0xff
+	ok, err = VerifyMLDSA87Digest32(kp.PubkeyBytes(), sig, digest)
+	if err != nil {
+		t.Fatalf("VerifyMLDSA87Digest32 wrong digest: %v", err)
+	}
+	if ok {
+		t.Fatal("VerifyMLDSA87Digest32=true for wrong digest")
+	}
+
+	ok, err = VerifyMLDSA87Digest32(make([]byte, ML_DSA_87_PUBKEY_BYTES-1), make([]byte, ML_DSA_87_SIG_BYTES), digest)
+	if err != nil {
+		t.Fatalf("VerifyMLDSA87Digest32 length mismatch: %v", err)
+	}
+	if ok {
+		t.Fatal("VerifyMLDSA87Digest32=true for length mismatch")
+	}
+}
+
 func TestOpenSSLVerifySig_UnknownAlgErrors(t *testing.T) {
 	var d [32]byte
 	ok, err := opensslVerifySigOneShot("NO_SUCH_ALG", []byte{0x01}, []byte{0x02}, d[:])


### PR DESCRIPTION
Refs RUB-550

Invariant:
Go exposes staged Simplicity sha3_256 and mldsa87_verify primitive helpers with spec-pinned digest, verifier, and cost behavior, without wiring consensus dispatch.

Layer:
Go implementation/tests only.

Files changed:
- clients/go/consensus/simplicity/crypto_jets.go
- clients/go/consensus/simplicity/crypto_jets_test.go
- clients/go/consensus/simplicity/crypto_jets_backend_test.go
- clients/go/consensus/simplicity/program.go
- clients/go/consensus/verify_sig_openssl.go
- clients/go/consensus/verify_sig_openssl_additional_test.go

Tests:
- go test ./consensus/simplicity -count=1
- CGO_ENABLED=0 go test ./consensus/simplicity -count=1
- go test ./consensus -run 'TestVerifyMLDSA87Digest32UsesNativeBackend' -count=1
- go test ./consensus -count=1
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./...'
- git diff --check
- rubin-pattern-self-review-gate --check
- rubin-precommit-one-review --repo <repo> --base-ref origin/main --include-base-diff
- rubin-one-review-gate --check --repo <repo> --base-ref origin/main
- scripts/dev-env.sh -- ./scripts/preflight-codacy-coverage.sh
- rubin-push --repo <repo> --base-ref origin/main --coverage-cmd 'scripts/dev-env.sh -- ./scripts/preflight-codacy-coverage.sh' -- origin HEAD

Behavior impact:
Adds Go staged helper surface for Simplicity crypto primitives. It does not wire Program.Evaluate or consensus validation.

Compatibility impact:
No wire, fixture, or consensus dispatch change.

Known non-goals:
Rust mirror, shared parity corpus, and consensus dispatch wiring are out of scope for RUB-550.

### Parity exemption justification
RUB-550 is the Go-only staged slice under RUB-489. It adds Go helper primitives only and does not wire Program.Evaluate or consensus dispatch. Rust mirror and shared parity vectors are follow-up slices before dispatch can call these helpers.

Risk:
The helper is consensus-adjacent. Scope is bounded by no dispatch wiring and focused Go tests.

Rollback:
Revert this PR; no persisted state or wire behavior depends on it.

Not checked:
Rust implementation parity and shared corpus execution, by issue scope.
