### PR TITLE
RUB-551 rust: mirror Simplicity crypto jets

### DIFF
--- a/clients/rust/crates/rubin-consensus/src/simplicity.rs
+++ b/clients/rust/crates/rubin-consensus/src/simplicity.rs
@@ -84,7 +84,7 @@ pub struct EvalOptions<'a> { pub jet_evaluator: Option<&'a dyn Fn(Jet) -> Result
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[rustfmt::skip]
-pub struct Sha3256JetResult { pub digest: [u8; 32], pub cost: u64 }
+pub struct Sha3DigestJetResult { pub digest: [u8; 32], pub cost: u64 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[rustfmt::skip]
@@ -128,8 +128,10 @@ pub fn lookup_jet(id: u16, sub_op: u8) -> Option<Jet> {
 }
 
 #[rustfmt::skip]
-pub fn evaluate_sha3_256_jet(message: &[u8]) -> Sha3256JetResult {
-    Sha3256JetResult { digest: crate::hash::sha3_256(message), cost: SHA3_256_JET_BASE_COST + message.len() as u64 }
+pub fn evaluate_sha3_256_jet(message: &[u8]) -> Sha3DigestJetResult {
+    let message_len = u64::try_from(message.len()).unwrap_or(u64::MAX);
+    let cost = SHA3_256_JET_BASE_COST.saturating_add(message_len);
+    Sha3DigestJetResult { digest: crate::hash::sha3_256(message), cost }
 }
 
 #[rustfmt::skip]

--- a/clients/rust/crates/rubin-consensus/src/simplicity.rs
+++ b/clients/rust/crates/rubin-consensus/src/simplicity.rs
@@ -1,6 +1,7 @@
 use core::fmt;
 use std::sync::OnceLock;
 
+use crate::constants::{ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES};
 use sha2::{compress256, digest::generic_array::GenericArray};
 use sha3::{Digest, Sha3_256};
 
@@ -15,6 +16,10 @@ pub const DESCRIPTOR_HASH_BASE_COST: u64 = 64;
 pub const DESCRIPTOR_HASH_BYTE_COST: u64 = 1;
 pub const MAX_FRAME_BYTES: u64 = 65_536;
 pub const MAX_LIVE_MEMORY_BYTES: u64 = 1_048_576;
+pub const SHA3_256_JET_BASE_COST: u64 = 64;
+pub const MLDSA87_VERIFY_JET_COST: u64 = 50_000;
+pub const MLDSA87_JET_PUBKEY_BYTES: usize = ML_DSA_87_PUBKEY_BYTES as usize;
+pub const MLDSA87_JET_SIG_BYTES: usize = ML_DSA_87_SIG_BYTES as usize;
 #[rustfmt::skip]
 pub const PROGRAM_ENCODING_HASH: [u8; 32] = [
     0x27, 0xe5, 0xad, 0x52, 0x1e, 0xfd, 0xf9, 0xd1, 0x85, 0xc1, 0xc9, 0x2a, 0x3a, 0x1a, 0x4a, 0xac, 0xc9, 0x27, 0x6c, 0x2a, 0x5b, 0x1b, 0x85, 0x18, 0xce, 0x25, 0xc8, 0xc9, 0x73, 0xa3, 0x8a, 0xdc,
@@ -77,6 +82,17 @@ impl std::error::Error for EvalError {}
 #[rustfmt::skip]
 pub struct EvalOptions<'a> { pub jet_evaluator: Option<&'a dyn Fn(Jet) -> Result<EvalResult, EvalError>> }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[rustfmt::skip]
+pub struct Sha3256JetResult { pub digest: [u8; 32], pub cost: u64 }
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[rustfmt::skip]
+pub struct Mldsa87VerifyJetResult { pub verified: bool, pub cost: u64 }
+
+#[rustfmt::skip]
+pub type Mldsa87Digest32Verifier<'a> = dyn Fn(&[u8], &[u8], [u8; 32]) -> Result<bool, EvalError> + 'a;
+
 #[rustfmt::skip]
 struct JetRow { id: u16, sub_op: u8, name: &'static str, selector_bit_len: usize, selector_padded: &'static [u8], cmr: &'static str }
 
@@ -109,6 +125,25 @@ pub fn decode(program: &[u8], witness: &[u8], opts: DecodeOptions) -> Result<Pro
 pub fn lookup_jet(id: u16, sub_op: u8) -> Option<Jet> {
     static JETS: OnceLock<Vec<Jet>> = OnceLock::new();
     JETS.get_or_init(|| JET_ROWS.iter().map(|row| { let cmr = hex32(row.cmr).expect("valid checked-in Rubin jet CMR hex"); Jet { id: row.id, sub_op: row.sub_op, name: row.name, selector_bit_len: row.selector_bit_len, selector_padded: row.selector_padded, cmr } }).collect()).iter().copied().find(|jet| (jet.id, jet.sub_op) == (id, sub_op))
+}
+
+#[rustfmt::skip]
+pub fn evaluate_sha3_256_jet(message: &[u8]) -> Sha3256JetResult {
+    Sha3256JetResult { digest: crate::hash::sha3_256(message), cost: SHA3_256_JET_BASE_COST + message.len() as u64 }
+}
+
+#[rustfmt::skip]
+pub fn evaluate_mldsa87_verify_jet(pubkey: &[u8], signature: &[u8], digest32: [u8; 32], verifier: Option<&Mldsa87Digest32Verifier<'_>>) -> Result<Mldsa87VerifyJetResult, EvalError> {
+    let result = Mldsa87VerifyJetResult { verified: false, cost: MLDSA87_VERIFY_JET_COST };
+    if pubkey.len() != MLDSA87_JET_PUBKEY_BYTES || signature.len() != MLDSA87_JET_SIG_BYTES { return Ok(result); }
+    let verifier = verifier.ok_or_else(|| EvalError::with_result(ErrorCode::JetDisallowed, result.into_eval_result()))?;
+    let verified = verifier(pubkey, signature, digest32).map_err(|err| EvalError::with_result(err.code, result.into_eval_result()))?;
+    Ok(Mldsa87VerifyJetResult { verified, ..result })
+}
+
+#[rustfmt::skip]
+impl Mldsa87VerifyJetResult {
+    fn into_eval_result(self) -> EvalResult { EvalResult { accepted: self.verified, cost: self.cost } }
 }
 
 #[rustfmt::skip]
@@ -258,8 +293,8 @@ const MLDSA87_FRAMES: &[u64] = &[(2_592 + 4_627 + 32) * 8, 1];
 
 #[rustfmt::skip]
 const COST_MODEL_ROWS: &[CostModelRow] = &[
-    CostModelRow { jet: (0x0001, 0x00), formula: CostFormula::BasePlusLen, param: 64 },
-    CostModelRow { jet: (0x0002, 0x00), formula: CostFormula::Constant, param: 50_000 },
+    CostModelRow { jet: (0x0001, 0x00), formula: CostFormula::BasePlusLen, param: SHA3_256_JET_BASE_COST },
+    CostModelRow { jet: (0x0002, 0x00), formula: CostFormula::Constant, param: MLDSA87_VERIFY_JET_COST },
     CostModelRow { jet: (0x0010, 0x00), formula: CostFormula::Constant, param: 1 },
     CostModelRow { jet: (0x0010, 0x01), formula: CostFormula::Constant, param: 1 },
     CostModelRow { jet: (0x0010, 0x02), formula: CostFormula::Constant, param: 1 },

--- a/clients/rust/crates/rubin-consensus/src/simplicity/tests/mod.rs
+++ b/clients/rust/crates/rubin-consensus/src/simplicity/tests/mod.rs
@@ -290,6 +290,84 @@ fn cost_model_row_count_rejects_multi_byte_compact_size() {
 
 #[test]
 #[rustfmt::skip]
+fn sha3_256_jet_uses_native_sha3_and_charges_by_message_len() {
+    for msg in [&[][..], b"abc", &[0xa5; 65][..]] {
+        let got = evaluate_sha3_256_jet(msg);
+        assert_eq!(got.digest, crate::hash::sha3_256(msg));
+        assert_eq!(got.cost, SHA3_256_JET_BASE_COST + u64::try_from(msg.len()).unwrap());
+    }
+}
+
+#[test]
+#[rustfmt::skip]
+fn mldsa87_verify_jet_length_mismatch_is_program_false() {
+    let digest = crate::hash::sha3_256(b"");
+    let called = std::cell::Cell::new(false);
+    let verifier = |_: &[u8], _: &[u8], _: [u8; 32]| { called.set(true); Ok(true) };
+    for (pubkey_len, sig_len) in [
+        (MLDSA87_JET_PUBKEY_BYTES - 1, MLDSA87_JET_SIG_BYTES),
+        (MLDSA87_JET_PUBKEY_BYTES, MLDSA87_JET_SIG_BYTES - 1),
+        (MLDSA87_JET_PUBKEY_BYTES, MLDSA87_JET_SIG_BYTES + 1),
+    ] {
+        called.set(false);
+        let got = evaluate_mldsa87_verify_jet(&vec![0; pubkey_len], &vec![0; sig_len], digest, Some(&verifier)).unwrap();
+        assert!(!called.get());
+        assert_eq!(got, mldsa_result(false));
+    }
+}
+
+#[test]
+#[rustfmt::skip]
+fn mldsa87_verify_jet_calls_verifier_for_valid_lengths() {
+    let pubkey = vec![0x11; MLDSA87_JET_PUBKEY_BYTES];
+    let signature = vec![0x22; MLDSA87_JET_SIG_BYTES];
+    let digest = [0x33; 32];
+    let verifier = |got_pubkey: &[u8], got_signature: &[u8], got_digest: [u8; 32]| {
+        assert_eq!(got_pubkey, pubkey);
+        assert_eq!(got_signature, signature);
+        assert_eq!(got_digest, digest);
+        Ok(true)
+    };
+    let got = evaluate_mldsa87_verify_jet(&pubkey, &signature, digest, Some(&verifier)).unwrap();
+    assert_eq!(got, mldsa_result(true));
+}
+
+#[test]
+#[rustfmt::skip]
+fn mldsa87_verify_jet_uses_native_backend_and_flat_cost() {
+    let keypair = match crate::Mldsa87Keypair::generate() {
+        Ok(value) => value,
+        Err(err) if err.code == crate::error::ErrorCode::TxErrParse && err.msg.contains("EVP_PKEY_CTX_new_from_name") => return,
+        Err(err) => panic!("unexpected ML-DSA-87 keypair failure: {err}"),
+    };
+    let mut digest = crate::hash::sha3_256(b"simplicity mldsa87_verify");
+    let signature = keypair.sign_digest32(digest).expect("sign digest");
+    let pubkey = keypair.pubkey_bytes();
+    let verifier = |pk: &[u8], sig: &[u8], d: [u8; 32]| crate::verify_sig(crate::constants::SUITE_ID_ML_DSA_87, pk, sig, &d).map_err(|_| EvalError::new(ErrorCode::JetDisallowed));
+    assert_eq!(evaluate_mldsa87_verify_jet(&pubkey, &signature, digest, Some(&verifier)).unwrap(), mldsa_result(true));
+    digest[0] ^= 0xff;
+    assert_eq!(evaluate_mldsa87_verify_jet(&pubkey, &signature, digest, Some(&verifier)).unwrap(), mldsa_result(false));
+}
+
+#[test]
+#[rustfmt::skip]
+fn mldsa87_verify_jet_requires_verifier_for_valid_lengths() {
+    let err = evaluate_mldsa87_verify_jet(&vec![0; MLDSA87_JET_PUBKEY_BYTES], &vec![0; MLDSA87_JET_SIG_BYTES], [0; 32], None).unwrap_err();
+    assert_eq!(err.code, ErrorCode::JetDisallowed);
+    assert_eq!(err.result, rejected(MLDSA87_VERIFY_JET_COST));
+}
+
+#[test]
+#[rustfmt::skip]
+fn mldsa87_verify_jet_propagates_verifier_error_code_with_flat_cost() {
+    let verifier = |_: &[u8], _: &[u8], _: [u8; 32]| Err(EvalError { code: ErrorCode::Decode, result: ok(9) });
+    let err = evaluate_mldsa87_verify_jet(&vec![0; MLDSA87_JET_PUBKEY_BYTES], &vec![0; MLDSA87_JET_SIG_BYTES], [0; 32], Some(&verifier)).unwrap_err();
+    assert_eq!(err.code, ErrorCode::Decode);
+    assert_eq!(err.result, rejected(MLDSA87_VERIFY_JET_COST));
+}
+
+#[test]
+#[rustfmt::skip]
 fn evaluate_charges_decoded_program_steps() {
     for (program, witness, cost) in [("24", "", 1), ("8900", "", 2), ("c1220f0100", "", 4), ("c1d21014", "00", 4)] {
         assert_eq!(decoded(program, witness).evaluate(EvalOptions::default()).unwrap(), EvalResult { accepted: true, cost: cost * STEP_COST });
@@ -469,6 +547,9 @@ fn ok(cost: u64) -> EvalResult { EvalResult { accepted: true, cost } }
 
 #[rustfmt::skip]
 fn rejected(cost: u64) -> EvalResult { EvalResult { accepted: false, cost } }
+
+#[rustfmt::skip]
+fn mldsa_result(verified: bool) -> Mldsa87VerifyJetResult { Mldsa87VerifyJetResult { verified, cost: MLDSA87_VERIFY_JET_COST } }
 
 #[rustfmt::skip]
 fn with_jet_hook<'a>(hook: &'a dyn Fn(Jet) -> Result<EvalResult, EvalError>) -> EvalOptions<'a> { EvalOptions { jet_evaluator: Some(hook) } }


### PR DESCRIPTION
Refs RUB-551
Closes #2081

Invariant:
Rust SHA3-256 and ML-DSA-87 verify Simplicity helper behavior mirrors merged Go RUB-550 outputs, errors, and charging for the staged crypto-jet slice.

Layer:
implementation / tests

Files changed:
- clients/rust/crates/rubin-consensus/src/simplicity.rs
- clients/rust/crates/rubin-consensus/src/simplicity/tests/mod.rs

Tests:
- scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo fmt --all' — PASS
- git diff --check — PASS
- scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test -p rubin-consensus simplicity::tests::mldsa87_verify_jet_uses_native_backend_and_flat_cost -- --exact' — PASS
- scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test -p rubin-consensus simplicity::tests::mldsa87_verify_jet' — PASS
- scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test --workspace' — PASS
- rubin-precommit-one-review --repo . --base-ref origin/main --include-base-diff — PASS
- rubin-push --repo . --base-ref origin/main --coverage-cmd 'scripts/dev-env.sh -- ./scripts/preflight-codacy-coverage.sh' -- origin HEAD — PASS

### Parity exemption justification
This is a staged single-client child slice. The sibling client and shared evidence are tracked in separate Linear issues, so this PR intentionally does not add sibling-client changes only to satisfy per-PR source lockstep.

Behavior impact:
Adds Rust staged helper primitives and Rust tests only. No consensus dispatch is wired in this PR.

Compatibility impact:
No wire, fixture, shared corpus, or Go changes.

Known non-goals:
- No Go changes.
- No shared parity corpus.
- No data jets.
- No consensus dispatch wiring.

Follow-ups:
- Continue with the next staged child issue after controller merge.