### PR TITLE
[Q-SIMPLICITY-JETS-DATA-GO-01] Add Go arithmetic and bytes data jets

### DIFF
--- a/clients/go/consensus/simplicity/data_jets.go
+++ b/clients/go/consensus/simplicity/data_jets.go
@@ -1,0 +1,134 @@
+package simplicity
+
+import (
+	"bytes"
+	"cmp"
+	"math/bits"
+)
+
+const dataJetFlatCost, bytesJetChunkLen uint64 = 1, 32
+
+type Ordering int8
+
+const (
+	OrderingLT Ordering = -1
+	OrderingEQ Ordering = 0
+	OrderingGT Ordering = 1
+)
+
+type Uint128 struct{ Hi, Lo uint64 }
+
+type U64JetResult struct {
+	Value    uint64
+	Accepted bool
+	Cost     uint64
+}
+
+type U128JetResult struct {
+	Value    Uint128
+	Accepted bool
+	Cost     uint64
+}
+
+type OrderingJetResult struct {
+	Ordering Ordering
+	Cost     uint64
+}
+
+type BoolJetResult struct {
+	Value bool
+	Cost  uint64
+}
+
+type BytesJetResult struct {
+	Bytes    []byte
+	Accepted bool
+	Cost     uint64
+}
+
+func EvaluateU64CheckedAddJet(a, b uint64) U64JetResult {
+	value, carry := bits.Add64(a, b, 0)
+	if carry != 0 {
+		return U64JetResult{Cost: dataJetFlatCost}
+	}
+	return U64JetResult{Value: value, Accepted: true, Cost: dataJetFlatCost}
+}
+
+func EvaluateU64CheckedSubJet(a, b uint64) U64JetResult {
+	value, borrow := bits.Sub64(a, b, 0)
+	if borrow != 0 {
+		return U64JetResult{Cost: dataJetFlatCost}
+	}
+	return U64JetResult{Value: value, Accepted: true, Cost: dataJetFlatCost}
+}
+
+func EvaluateU64CheckedMulJet(a, b uint64) U64JetResult {
+	hi, lo := bits.Mul64(a, b)
+	if hi != 0 {
+		return U64JetResult{Cost: dataJetFlatCost}
+	}
+	return U64JetResult{Value: lo, Accepted: true, Cost: dataJetFlatCost}
+}
+
+func EvaluateU64CmpJet(a, b uint64) OrderingJetResult {
+	return OrderingJetResult{Ordering: Ordering(cmp.Compare(a, b)), Cost: dataJetFlatCost}
+}
+
+func EvaluateU128CheckedAddJet(a, b Uint128) U128JetResult {
+	lo, carry := bits.Add64(a.Lo, b.Lo, 0)
+	hi, overflow := bits.Add64(a.Hi, b.Hi, carry)
+	if overflow != 0 {
+		return U128JetResult{Cost: dataJetFlatCost}
+	}
+	return U128JetResult{Value: Uint128{Hi: hi, Lo: lo}, Accepted: true, Cost: dataJetFlatCost}
+}
+
+func EvaluateU128CheckedSubJet(a, b Uint128) U128JetResult {
+	lo, borrow := bits.Sub64(a.Lo, b.Lo, 0)
+	hi, underflow := bits.Sub64(a.Hi, b.Hi, borrow)
+	if underflow != 0 {
+		return U128JetResult{Cost: dataJetFlatCost}
+	}
+	return U128JetResult{Value: Uint128{Hi: hi, Lo: lo}, Accepted: true, Cost: dataJetFlatCost}
+}
+
+func EvaluateU128CmpJet(a, b Uint128) OrderingJetResult {
+	ordering := Ordering(cmp.Compare(a.Hi, b.Hi))
+	if ordering == OrderingEQ {
+		ordering = Ordering(cmp.Compare(a.Lo, b.Lo))
+	}
+	return OrderingJetResult{Ordering: ordering, Cost: dataJetFlatCost}
+}
+
+func EvaluateBytesEqJet(a, b []byte) BoolJetResult {
+	return BoolJetResult{
+		Value: bytes.Equal(a, b),
+		Cost:  bytesJetCost(max(uint64(len(a)), uint64(len(b)))),
+	}
+}
+
+func EvaluateBytesCmpJet(a, b []byte) OrderingJetResult {
+	return OrderingJetResult{
+		Ordering: Ordering(bytes.Compare(a, b)),
+		Cost:     bytesJetCost(max(uint64(len(a)), uint64(len(b)))),
+	}
+}
+
+func EvaluateBytesSliceJet(src []byte, start, length uint64) BytesJetResult {
+	cost := bytesJetCost(length)
+	end, carry := bits.Add64(start, length, 0)
+	if carry != 0 || end > uint64(len(src)) {
+		return BytesJetResult{Cost: cost}
+	}
+
+	out := append([]byte(nil), src[int(start):int(end)]...)
+	return BytesJetResult{Bytes: out, Accepted: true, Cost: cost}
+}
+
+func bytesJetCost(length uint64) uint64 {
+	chunks := length / bytesJetChunkLen
+	if length%bytesJetChunkLen != 0 {
+		chunks++
+	}
+	return dataJetFlatCost + chunks
+}

--- a/clients/go/consensus/simplicity/data_jets_test.go
+++ b/clients/go/consensus/simplicity/data_jets_test.go
@@ -82,8 +82,13 @@ func TestBytesDataJets(t *testing.T) {
 	if got := EvaluateBytesSliceJet(src, ^uint64(0), 1); got.Accepted || got.Cost != 2 {
 		t.Fatalf("bytes_slice overflow = %+v, want rejected cost=2", got)
 	}
-	if got := EvaluateBytesSliceJet(nil, 0, ^uint64(0)); got.Accepted || got.Cost != 576460752303423489 {
-		t.Fatalf("bytes_slice max len = %+v, want rejected cost=576460752303423489", got)
+	maxLength := ^uint64(0)
+	expectedMaxCost := dataJetFlatCost + maxLength/bytesJetChunkLen
+	if maxLength%bytesJetChunkLen != 0 {
+		expectedMaxCost++
+	}
+	if got := EvaluateBytesSliceJet(nil, 0, maxLength); got.Accepted || got.Cost != expectedMaxCost {
+		t.Fatalf("bytes_slice max len = %+v, want rejected cost=%d", got, expectedMaxCost)
 	}
 }
 

--- a/clients/go/consensus/simplicity/data_jets_test.go
+++ b/clients/go/consensus/simplicity/data_jets_test.go
@@ -1,0 +1,95 @@
+package simplicity
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestU64DataJets(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		got      U64JetResult
+		want     uint64
+		accepted bool
+	}{
+		{"add", EvaluateU64CheckedAddJet(2, 3), 5, true},
+		{"add-overflow", EvaluateU64CheckedAddJet(^uint64(0), 1), 0, false},
+		{"sub", EvaluateU64CheckedSubJet(5, 3), 2, true},
+		{"sub-underflow", EvaluateU64CheckedSubJet(3, 5), 0, false},
+		{"mul", EvaluateU64CheckedMulJet(7, 6), 42, true},
+		{"mul-overflow", EvaluateU64CheckedMulJet(1<<63, 2), 0, false},
+	} {
+		if tc.got.Accepted != tc.accepted || tc.got.Value != tc.want || tc.got.Cost != 1 {
+			t.Fatalf("%s = %+v, want accepted=%v value=%d cost=1", tc.name, tc.got, tc.accepted, tc.want)
+		}
+	}
+
+	assertOrdering(t, "u64-lt", EvaluateU64CmpJet(1, 2), OrderingLT, 1)
+	assertOrdering(t, "u64-eq", EvaluateU64CmpJet(2, 2), OrderingEQ, 1)
+	assertOrdering(t, "u64-gt", EvaluateU64CmpJet(3, 2), OrderingGT, 1)
+}
+
+func TestU128DataJets(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		got      U128JetResult
+		want     Uint128
+		accepted bool
+	}{
+		{"add-carry", EvaluateU128CheckedAddJet(Uint128{Lo: ^uint64(0)}, Uint128{Lo: 1}), Uint128{Hi: 1}, true},
+		{"add-overflow", EvaluateU128CheckedAddJet(Uint128{Hi: ^uint64(0), Lo: ^uint64(0)}, Uint128{Lo: 1}), Uint128{}, false},
+		{"sub-borrow", EvaluateU128CheckedSubJet(Uint128{Hi: 1}, Uint128{Lo: 1}), Uint128{Lo: ^uint64(0)}, true},
+		{"sub-underflow", EvaluateU128CheckedSubJet(Uint128{}, Uint128{Lo: 1}), Uint128{}, false},
+	} {
+		if tc.got.Accepted != tc.accepted || tc.got.Value != tc.want || tc.got.Cost != 1 {
+			t.Fatalf("%s = %+v, want accepted=%v value=%+v cost=1", tc.name, tc.got, tc.accepted, tc.want)
+		}
+	}
+
+	assertOrdering(t, "u128-hi-lt", EvaluateU128CmpJet(Uint128{Hi: 1}, Uint128{Hi: 2}), OrderingLT, 1)
+	assertOrdering(t, "u128-eq", EvaluateU128CmpJet(Uint128{Hi: 2, Lo: 3}, Uint128{Hi: 2, Lo: 3}), OrderingEQ, 1)
+	assertOrdering(t, "u128-lo-gt", EvaluateU128CmpJet(Uint128{Hi: 2, Lo: 4}, Uint128{Hi: 2, Lo: 3}), OrderingGT, 1)
+}
+
+func TestBytesDataJets(t *testing.T) {
+	if got := EvaluateBytesEqJet(nil, []byte{}); !got.Value || got.Cost != 1 {
+		t.Fatalf("bytes_eq empty = %+v, want true cost=1", got)
+	}
+	if got := EvaluateBytesEqJet(bytes.Repeat([]byte{0x11}, 33), bytes.Repeat([]byte{0x11}, 32)); got.Value || got.Cost != 3 {
+		t.Fatalf("bytes_eq 33/32 = %+v, want false cost=3", got)
+	}
+
+	assertOrdering(t, "bytes-unsigned", EvaluateBytesCmpJet([]byte{0xff}, []byte{0x01}), OrderingGT, 2)
+	assertOrdering(t, "bytes-prefix-shorter", EvaluateBytesCmpJet([]byte("ab"), []byte("abc")), OrderingLT, 2)
+	assertOrdering(t, "bytes-prefix-longer", EvaluateBytesCmpJet([]byte("abc"), []byte("ab")), OrderingGT, 2)
+	assertOrdering(t, "bytes-eq", EvaluateBytesCmpJet([]byte("abc"), []byte("abc")), OrderingEQ, 2)
+
+	src := []byte("abcdef")
+	if got := EvaluateBytesSliceJet(src, 2, 3); !got.Accepted || string(got.Bytes) != "cde" || got.Cost != 2 {
+		t.Fatalf("bytes_slice = %+v, want accepted cde cost=2", got)
+	} else {
+		src[2] = 'X'
+		if string(got.Bytes) != "cde" {
+			t.Fatalf("bytes_slice returned aliased bytes %q", got.Bytes)
+		}
+	}
+	if got := EvaluateBytesSliceJet(src, uint64(len(src)), 0); !got.Accepted || len(got.Bytes) != 0 || got.Cost != 1 {
+		t.Fatalf("bytes_slice empty = %+v, want accepted empty cost=1", got)
+	}
+	if got := EvaluateBytesSliceJet(src, 5, 2); got.Accepted || got.Cost != 2 {
+		t.Fatalf("bytes_slice out of range = %+v, want rejected cost=2", got)
+	}
+	if got := EvaluateBytesSliceJet(src, ^uint64(0), 1); got.Accepted || got.Cost != 2 {
+		t.Fatalf("bytes_slice overflow = %+v, want rejected cost=2", got)
+	}
+	if got := EvaluateBytesSliceJet(nil, 0, ^uint64(0)); got.Accepted || got.Cost != 576460752303423489 {
+		t.Fatalf("bytes_slice max len = %+v, want rejected cost=576460752303423489", got)
+	}
+}
+
+func assertOrdering(t *testing.T, name string, got OrderingJetResult, want Ordering, cost uint64) {
+	t.Helper()
+	if got.Ordering != want || got.Cost != cost {
+		t.Fatalf("%s = %+v, want ordering=%d cost=%d", name, got, want, cost)
+	}
+}


### PR DESCRIPTION
Invariant:
Go data jet helpers implement checked u64/u128 arithmetic, ordering, and bytes equality/comparison/slicing with deterministic overflow and bounds behavior.

Layer:
implementation / tests

Files changed:
- `clients/go/consensus/simplicity/data_jets.go`
- `clients/go/consensus/simplicity/data_jets_test.go`

Tests:
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./consensus/simplicity'` - PASS
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./...'` - PASS
- `scripts/dev-env.sh -- bash -lc 'cd clients/go && go vet ./...'` - PASS
- `git diff --check` - PASS
- `check_complexity.py --repo . --base-ref origin/main clients/go/consensus/simplicity/data_jets.go clients/go/consensus/simplicity/data_jets_test.go` - PASS, added CCN 20
- `rubin-stack-codacy-coverage.sh . origin/main` - PASS, diff coverage 100.00%, variation +0.02%
- `rubin-precommit-one-review --repo . --base-ref origin/main --include-base-diff` - PASS
- isolated stock code-review - No findings
- `rubin-push --coverage-cmd 'rubin-stack-codacy-coverage.sh . origin/main'` - PASS

Behavior impact:
Adds pure Go helper functions and focused tests for data jets. This PR does not wire the helpers into Simplicity dispatch.

Compatibility impact:
No wire format, fixture, Rust, or shared corpus change.

Known non-goals:
- No Rust mirror.
- No shared parity corpus.
- No crypto jets.
- No consensus dispatch wiring.
- No generated artifact changes.

### Parity exemption justification

RUB-553 is a Go-only child slice. The sibling Rust mirror and cross-client parity work are explicitly outside this PR. The diff adds Go helper implementations and Go package tests only; it does not change shared conformance fixtures, generated corpora, dispatch wiring, or Rust code. This block is the parity-exempt justification required by the parity-smoke gate.

Closes #2085
