### PR TITLE
RUB-554: add Rust data jet helpers

### DIFF
--- a/clients/rust/crates/rubin-consensus/src/simplicity.rs
+++ b/clients/rust/crates/rubin-consensus/src/simplicity.rs
@@ -20,6 +20,9 @@ pub const SHA3_256_JET_BASE_COST: u64 = 64;
 pub const MLDSA87_VERIFY_JET_COST: u64 = 50_000;
 pub const MLDSA87_JET_PUBKEY_BYTES: usize = ML_DSA_87_PUBKEY_BYTES as usize;
 pub const MLDSA87_JET_SIG_BYTES: usize = ML_DSA_87_SIG_BYTES as usize;
+const DATA_JET_FLAT_COST: u64 = 1;
+const BYTES_JET_CHUNK_LEN: u64 = 32;
+pub use crate::txcontext::Uint128;
 #[rustfmt::skip]
 pub const PROGRAM_ENCODING_HASH: [u8; 32] = [
     0x27, 0xe5, 0xad, 0x52, 0x1e, 0xfd, 0xf9, 0xd1, 0x85, 0xc1, 0xc9, 0x2a, 0x3a, 0x1a, 0x4a, 0xac, 0xc9, 0x27, 0x6c, 0x2a, 0x5b, 0x1b, 0x85, 0x18, 0xce, 0x25, 0xc8, 0xc9, 0x73, 0xa3, 0x8a, 0xdc,
@@ -90,6 +93,26 @@ pub struct Sha3DigestJetResult { pub digest: [u8; 32], pub cost: u64 }
 #[rustfmt::skip]
 pub struct Mldsa87VerifyJetResult { pub verified: bool, pub cost: u64 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[rustfmt::skip]
+pub struct U64JetResult { pub value: u64, pub accepted: bool, pub cost: u64 }
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[rustfmt::skip]
+pub struct U128JetResult { pub value: Uint128, pub accepted: bool, pub cost: u64 }
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[rustfmt::skip]
+pub struct OrderingJetResult { pub ordering: core::cmp::Ordering, pub cost: u64 }
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[rustfmt::skip]
+pub struct BoolJetResult { pub value: bool, pub cost: u64 }
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[rustfmt::skip]
+pub struct BytesJetResult { pub bytes: Vec<u8>, pub accepted: bool, pub cost: u64 }
+
 #[rustfmt::skip]
 pub type Mldsa87Digest32Verifier<'a> = dyn Fn(&[u8], &[u8], [u8; 32]) -> Result<bool, EvalError> + 'a;
 
@@ -141,6 +164,83 @@ pub fn evaluate_mldsa87_verify_jet(pubkey: &[u8], signature: &[u8], digest32: [u
     let verifier = verifier.ok_or_else(|| EvalError::with_result(ErrorCode::JetDisallowed, result.into_eval_result()))?;
     let verified = verifier(pubkey, signature, digest32).map_err(|err| EvalError::with_result(err.code, result.into_eval_result()))?;
     Ok(Mldsa87VerifyJetResult { verified, ..result })
+}
+
+#[rustfmt::skip]
+pub fn evaluate_u64_checked_add_jet(a: u64, b: u64) -> U64JetResult {
+    match a.checked_add(b) {
+        Some(value) => U64JetResult { value, accepted: true, cost: DATA_JET_FLAT_COST },
+        None => U64JetResult { value: 0, accepted: false, cost: DATA_JET_FLAT_COST },
+    }
+}
+
+#[rustfmt::skip]
+pub fn evaluate_u64_checked_sub_jet(a: u64, b: u64) -> U64JetResult {
+    match a.checked_sub(b) {
+        Some(value) => U64JetResult { value, accepted: true, cost: DATA_JET_FLAT_COST },
+        None => U64JetResult { value: 0, accepted: false, cost: DATA_JET_FLAT_COST },
+    }
+}
+
+#[rustfmt::skip]
+pub fn evaluate_u64_checked_mul_jet(a: u64, b: u64) -> U64JetResult {
+    match a.checked_mul(b) {
+        Some(value) => U64JetResult { value, accepted: true, cost: DATA_JET_FLAT_COST },
+        None => U64JetResult { value: 0, accepted: false, cost: DATA_JET_FLAT_COST },
+    }
+}
+
+#[rustfmt::skip]
+pub fn evaluate_u64_cmp_jet(a: u64, b: u64) -> OrderingJetResult {
+    OrderingJetResult { ordering: a.cmp(&b), cost: DATA_JET_FLAT_COST }
+}
+
+#[rustfmt::skip]
+pub fn evaluate_u128_checked_add_jet(a: Uint128, b: Uint128) -> U128JetResult {
+    match a.to_native().checked_add(b.to_native()).map(Uint128::from_native) {
+        Some(value) => U128JetResult { value, accepted: true, cost: DATA_JET_FLAT_COST },
+        None => U128JetResult { value: Uint128 { lo: 0, hi: 0 }, accepted: false, cost: DATA_JET_FLAT_COST },
+    }
+}
+
+#[rustfmt::skip]
+pub fn evaluate_u128_checked_sub_jet(a: Uint128, b: Uint128) -> U128JetResult {
+    match a.to_native().checked_sub(b.to_native()).map(Uint128::from_native) {
+        Some(value) => U128JetResult { value, accepted: true, cost: DATA_JET_FLAT_COST },
+        None => U128JetResult { value: Uint128 { lo: 0, hi: 0 }, accepted: false, cost: DATA_JET_FLAT_COST },
+    }
+}
+
+#[rustfmt::skip]
+pub fn evaluate_u128_cmp_jet(a: Uint128, b: Uint128) -> OrderingJetResult {
+    OrderingJetResult { ordering: (a.hi, a.lo).cmp(&(b.hi, b.lo)), cost: DATA_JET_FLAT_COST }
+}
+
+#[rustfmt::skip]
+pub fn evaluate_bytes_eq_jet(a: &[u8], b: &[u8]) -> BoolJetResult {
+    BoolJetResult { value: a == b, cost: bytes_jet_cost(u64::try_from(a.len().max(b.len())).unwrap_or(u64::MAX)) }
+}
+
+#[rustfmt::skip]
+pub fn evaluate_bytes_cmp_jet(a: &[u8], b: &[u8]) -> OrderingJetResult {
+    OrderingJetResult { ordering: a.cmp(b), cost: bytes_jet_cost(u64::try_from(a.len().max(b.len())).unwrap_or(u64::MAX)) }
+}
+
+#[rustfmt::skip]
+pub fn evaluate_bytes_slice_jet(src: &[u8], start: u64, length: u64) -> BytesJetResult {
+    let cost = bytes_jet_cost(length);
+    let Some(end) = start.checked_add(length) else {
+        return BytesJetResult { bytes: Vec::new(), accepted: false, cost };
+    };
+    if end > u64::try_from(src.len()).unwrap_or(u64::MAX) {
+        return BytesJetResult { bytes: Vec::new(), accepted: false, cost };
+    }
+    BytesJetResult { bytes: src[start as usize..end as usize].to_vec(), accepted: true, cost }
+}
+
+#[rustfmt::skip]
+fn bytes_jet_cost(length: u64) -> u64 {
+    DATA_JET_FLAT_COST + length / BYTES_JET_CHUNK_LEN + u64::from(!length.is_multiple_of(BYTES_JET_CHUNK_LEN))
 }
 
 #[rustfmt::skip]

--- a/clients/rust/crates/rubin-consensus/src/simplicity/tests/mod.rs
+++ b/clients/rust/crates/rubin-consensus/src/simplicity/tests/mod.rs
@@ -467,53 +467,152 @@ fn mldsa87_verify_jet_propagates_verifier_error_code_with_flat_cost() {
 }
 
 #[test]
-#[rustfmt::skip]
 fn data_jets_match_go_reference() {
+    use core::cmp::Ordering::{Equal, Greater, Less};
+
+    let u128_cmp = evaluate_u128_cmp_jet;
+    let bytes_cmp = evaluate_bytes_cmp_jet;
+
     for (name, got, want, accepted) in [
         ("add", evaluate_u64_checked_add_jet(2, 3), 5, true),
-        ("add-overflow", evaluate_u64_checked_add_jet(u64::MAX, 1), 0, false),
+        (
+            "add-overflow",
+            evaluate_u64_checked_add_jet(u64::MAX, 1),
+            0,
+            false,
+        ),
         ("sub", evaluate_u64_checked_sub_jet(5, 3), 2, true),
-        ("sub-underflow", evaluate_u64_checked_sub_jet(3, 5), 0, false),
+        (
+            "sub-underflow",
+            evaluate_u64_checked_sub_jet(3, 5),
+            0,
+            false,
+        ),
         ("mul", evaluate_u64_checked_mul_jet(7, 6), 42, true),
-        ("mul-overflow", evaluate_u64_checked_mul_jet(1 << 63, 2), 0, false),
+        (
+            "mul-overflow",
+            evaluate_u64_checked_mul_jet(1 << 63, 2),
+            0,
+            false,
+        ),
     ] {
-        assert_eq!(got, U64JetResult { value: want, accepted, cost: 1 }, "{name}");
+        assert_eq!(got, u64_jet(want, accepted), "{name}");
     }
 
-    assert_eq!(evaluate_u64_cmp_jet(1, 2), OrderingJetResult { ordering: core::cmp::Ordering::Less, cost: 1 });
-    assert_eq!(evaluate_u64_cmp_jet(2, 2), OrderingJetResult { ordering: core::cmp::Ordering::Equal, cost: 1 });
-    assert_eq!(evaluate_u64_cmp_jet(3, 2), OrderingJetResult { ordering: core::cmp::Ordering::Greater, cost: 1 });
+    assert_eq!(evaluate_u64_cmp_jet(1, 2), ordering_jet(Less, 1));
+    assert_eq!(evaluate_u64_cmp_jet(2, 2), ordering_jet(Equal, 1));
+    assert_eq!(evaluate_u64_cmp_jet(3, 2), ordering_jet(Greater, 1));
 
     for (name, got, want, accepted) in [
-        ("add-carry", evaluate_u128_checked_add_jet(Uint128 { lo: u64::MAX, hi: 0 }, Uint128 { lo: 1, hi: 0 }), Uint128 { lo: 0, hi: 1 }, true),
-        ("add-overflow", evaluate_u128_checked_add_jet(Uint128 { lo: u64::MAX, hi: u64::MAX }, Uint128 { lo: 1, hi: 0 }), Uint128 { lo: 0, hi: 0 }, false),
-        ("sub-borrow", evaluate_u128_checked_sub_jet(Uint128 { lo: 0, hi: 1 }, Uint128 { lo: 1, hi: 0 }), Uint128 { lo: u64::MAX, hi: 0 }, true),
-        ("sub-underflow", evaluate_u128_checked_sub_jet(Uint128 { lo: 0, hi: 0 }, Uint128 { lo: 1, hi: 0 }), Uint128 { lo: 0, hi: 0 }, false),
+        (
+            "add-carry",
+            evaluate_u128_checked_add_jet(uint128(0, u64::MAX), uint128(0, 1)),
+            uint128(1, 0),
+            true,
+        ),
+        (
+            "add-overflow",
+            evaluate_u128_checked_add_jet(uint128(u64::MAX, u64::MAX), uint128(0, 1)),
+            uint128(0, 0),
+            false,
+        ),
+        (
+            "sub-borrow",
+            evaluate_u128_checked_sub_jet(uint128(1, 0), uint128(0, 1)),
+            uint128(0, u64::MAX),
+            true,
+        ),
+        (
+            "sub-underflow",
+            evaluate_u128_checked_sub_jet(uint128(0, 0), uint128(0, 1)),
+            uint128(0, 0),
+            false,
+        ),
     ] {
-        assert_eq!(got, U128JetResult { value: want, accepted, cost: 1 }, "{name}");
+        assert_eq!(got, u128_jet(want, accepted), "{name}");
     }
 
-    assert_eq!(evaluate_u128_cmp_jet(Uint128 { lo: 0, hi: 1 }, Uint128 { lo: 0, hi: 2 }), OrderingJetResult { ordering: core::cmp::Ordering::Less, cost: 1 });
-    assert_eq!(evaluate_u128_cmp_jet(Uint128 { lo: 3, hi: 2 }, Uint128 { lo: 3, hi: 2 }), OrderingJetResult { ordering: core::cmp::Ordering::Equal, cost: 1 });
-    assert_eq!(evaluate_u128_cmp_jet(Uint128 { lo: 4, hi: 2 }, Uint128 { lo: 3, hi: 2 }), OrderingJetResult { ordering: core::cmp::Ordering::Greater, cost: 1 });
+    assert_eq!(
+        u128_cmp(uint128(1, 0), uint128(2, 0)),
+        ordering_jet(Less, 1)
+    );
+    assert_eq!(
+        u128_cmp(uint128(2, 3), uint128(2, 3)),
+        ordering_jet(Equal, 1)
+    );
+    assert_eq!(
+        u128_cmp(uint128(2, 4), uint128(2, 3)),
+        ordering_jet(Greater, 1)
+    );
 
-    assert_eq!(evaluate_bytes_eq_jet(&[], &[]), BoolJetResult { value: true, cost: 1 });
-    assert_eq!(evaluate_bytes_eq_jet(&[0x11; 33], &[0x11; 32]), BoolJetResult { value: false, cost: 3 });
-    assert_eq!(evaluate_bytes_cmp_jet(&[0xff], &[0x01]), OrderingJetResult { ordering: core::cmp::Ordering::Greater, cost: 2 });
-    assert_eq!(evaluate_bytes_cmp_jet(b"ab", b"abc"), OrderingJetResult { ordering: core::cmp::Ordering::Less, cost: 2 });
-    assert_eq!(evaluate_bytes_cmp_jet(b"abc", b"ab"), OrderingJetResult { ordering: core::cmp::Ordering::Greater, cost: 2 });
-    assert_eq!(evaluate_bytes_cmp_jet(b"abc", b"abc"), OrderingJetResult { ordering: core::cmp::Ordering::Equal, cost: 2 });
+    assert_eq!(evaluate_bytes_eq_jet(&[], &[]), bool_jet(true, 1));
+    assert_eq!(
+        evaluate_bytes_eq_jet(&[0x11; 33], &[0x11; 32]),
+        bool_jet(false, 3)
+    );
+    assert_eq!(bytes_cmp(&[0xff], &[0x01]), ordering_jet(Greater, 2));
+    assert_eq!(bytes_cmp(b"ab", b"abc"), ordering_jet(Less, 2));
+    assert_eq!(bytes_cmp(b"abc", b"ab"), ordering_jet(Greater, 2));
+    assert_eq!(bytes_cmp(b"abc", b"abc"), ordering_jet(Equal, 2));
 
     let mut src = b"abcdef".to_vec();
     let got = evaluate_bytes_slice_jet(&src, 2, 3);
-    assert_eq!(got, BytesJetResult { bytes: b"cde".to_vec(), accepted: true, cost: 2 });
+    assert_eq!(got, bytes_jet(b"cde", true, 2));
     src[2] = b'X';
     assert_eq!(got.bytes, b"cde");
-    assert_eq!(evaluate_bytes_slice_jet(&src, src.len() as u64, 0), BytesJetResult { bytes: Vec::new(), accepted: true, cost: 1 });
-    assert_eq!(evaluate_bytes_slice_jet(&src, 5, 2), BytesJetResult { bytes: Vec::new(), accepted: false, cost: 2 });
-    assert_eq!(evaluate_bytes_slice_jet(&src, u64::MAX, 1), BytesJetResult { bytes: Vec::new(), accepted: false, cost: 2 });
+    assert_eq!(
+        evaluate_bytes_slice_jet(&src, src.len() as u64, 0),
+        bytes_jet(&[], true, 1)
+    );
+    assert_eq!(
+        evaluate_bytes_slice_jet(&src, 5, 2),
+        bytes_jet(&[], false, 2)
+    );
+    assert_eq!(
+        evaluate_bytes_slice_jet(&src, u64::MAX, 1),
+        bytes_jet(&[], false, 2)
+    );
     let max_len = evaluate_bytes_slice_jet(&[], 0, u64::MAX);
-    assert_eq!((max_len.accepted, max_len.cost), (false, 1 + u64::MAX.div_ceil(32)));
+    assert_eq!(
+        (max_len.accepted, max_len.cost),
+        (false, 1 + u64::MAX.div_ceil(32))
+    );
+}
+
+fn uint128(hi: u64, lo: u64) -> Uint128 {
+    Uint128 { lo, hi }
+}
+
+fn u64_jet(value: u64, accepted: bool) -> U64JetResult {
+    U64JetResult {
+        value,
+        accepted,
+        cost: 1,
+    }
+}
+
+fn u128_jet(value: Uint128, accepted: bool) -> U128JetResult {
+    U128JetResult {
+        value,
+        accepted,
+        cost: 1,
+    }
+}
+
+fn ordering_jet(ordering: core::cmp::Ordering, cost: u64) -> OrderingJetResult {
+    OrderingJetResult { ordering, cost }
+}
+
+fn bool_jet(value: bool, cost: u64) -> BoolJetResult {
+    BoolJetResult { value, cost }
+}
+
+fn bytes_jet(bytes: &[u8], accepted: bool, cost: u64) -> BytesJetResult {
+    BytesJetResult {
+        bytes: bytes.to_vec(),
+        accepted,
+        cost,
+    }
 }
 
 #[test]

--- a/clients/rust/crates/rubin-consensus/src/simplicity/tests/mod.rs
+++ b/clients/rust/crates/rubin-consensus/src/simplicity/tests/mod.rs
@@ -468,6 +468,56 @@ fn mldsa87_verify_jet_propagates_verifier_error_code_with_flat_cost() {
 
 #[test]
 #[rustfmt::skip]
+fn data_jets_match_go_reference() {
+    for (name, got, want, accepted) in [
+        ("add", evaluate_u64_checked_add_jet(2, 3), 5, true),
+        ("add-overflow", evaluate_u64_checked_add_jet(u64::MAX, 1), 0, false),
+        ("sub", evaluate_u64_checked_sub_jet(5, 3), 2, true),
+        ("sub-underflow", evaluate_u64_checked_sub_jet(3, 5), 0, false),
+        ("mul", evaluate_u64_checked_mul_jet(7, 6), 42, true),
+        ("mul-overflow", evaluate_u64_checked_mul_jet(1 << 63, 2), 0, false),
+    ] {
+        assert_eq!(got, U64JetResult { value: want, accepted, cost: 1 }, "{name}");
+    }
+
+    assert_eq!(evaluate_u64_cmp_jet(1, 2), OrderingJetResult { ordering: core::cmp::Ordering::Less, cost: 1 });
+    assert_eq!(evaluate_u64_cmp_jet(2, 2), OrderingJetResult { ordering: core::cmp::Ordering::Equal, cost: 1 });
+    assert_eq!(evaluate_u64_cmp_jet(3, 2), OrderingJetResult { ordering: core::cmp::Ordering::Greater, cost: 1 });
+
+    for (name, got, want, accepted) in [
+        ("add-carry", evaluate_u128_checked_add_jet(Uint128 { lo: u64::MAX, hi: 0 }, Uint128 { lo: 1, hi: 0 }), Uint128 { lo: 0, hi: 1 }, true),
+        ("add-overflow", evaluate_u128_checked_add_jet(Uint128 { lo: u64::MAX, hi: u64::MAX }, Uint128 { lo: 1, hi: 0 }), Uint128 { lo: 0, hi: 0 }, false),
+        ("sub-borrow", evaluate_u128_checked_sub_jet(Uint128 { lo: 0, hi: 1 }, Uint128 { lo: 1, hi: 0 }), Uint128 { lo: u64::MAX, hi: 0 }, true),
+        ("sub-underflow", evaluate_u128_checked_sub_jet(Uint128 { lo: 0, hi: 0 }, Uint128 { lo: 1, hi: 0 }), Uint128 { lo: 0, hi: 0 }, false),
+    ] {
+        assert_eq!(got, U128JetResult { value: want, accepted, cost: 1 }, "{name}");
+    }
+
+    assert_eq!(evaluate_u128_cmp_jet(Uint128 { lo: 0, hi: 1 }, Uint128 { lo: 0, hi: 2 }), OrderingJetResult { ordering: core::cmp::Ordering::Less, cost: 1 });
+    assert_eq!(evaluate_u128_cmp_jet(Uint128 { lo: 3, hi: 2 }, Uint128 { lo: 3, hi: 2 }), OrderingJetResult { ordering: core::cmp::Ordering::Equal, cost: 1 });
+    assert_eq!(evaluate_u128_cmp_jet(Uint128 { lo: 4, hi: 2 }, Uint128 { lo: 3, hi: 2 }), OrderingJetResult { ordering: core::cmp::Ordering::Greater, cost: 1 });
+
+    assert_eq!(evaluate_bytes_eq_jet(&[], &[]), BoolJetResult { value: true, cost: 1 });
+    assert_eq!(evaluate_bytes_eq_jet(&[0x11; 33], &[0x11; 32]), BoolJetResult { value: false, cost: 3 });
+    assert_eq!(evaluate_bytes_cmp_jet(&[0xff], &[0x01]), OrderingJetResult { ordering: core::cmp::Ordering::Greater, cost: 2 });
+    assert_eq!(evaluate_bytes_cmp_jet(b"ab", b"abc"), OrderingJetResult { ordering: core::cmp::Ordering::Less, cost: 2 });
+    assert_eq!(evaluate_bytes_cmp_jet(b"abc", b"ab"), OrderingJetResult { ordering: core::cmp::Ordering::Greater, cost: 2 });
+    assert_eq!(evaluate_bytes_cmp_jet(b"abc", b"abc"), OrderingJetResult { ordering: core::cmp::Ordering::Equal, cost: 2 });
+
+    let mut src = b"abcdef".to_vec();
+    let got = evaluate_bytes_slice_jet(&src, 2, 3);
+    assert_eq!(got, BytesJetResult { bytes: b"cde".to_vec(), accepted: true, cost: 2 });
+    src[2] = b'X';
+    assert_eq!(got.bytes, b"cde");
+    assert_eq!(evaluate_bytes_slice_jet(&src, src.len() as u64, 0), BytesJetResult { bytes: Vec::new(), accepted: true, cost: 1 });
+    assert_eq!(evaluate_bytes_slice_jet(&src, 5, 2), BytesJetResult { bytes: Vec::new(), accepted: false, cost: 2 });
+    assert_eq!(evaluate_bytes_slice_jet(&src, u64::MAX, 1), BytesJetResult { bytes: Vec::new(), accepted: false, cost: 2 });
+    let max_len = evaluate_bytes_slice_jet(&[], 0, u64::MAX);
+    assert_eq!((max_len.accepted, max_len.cost), (false, 1 + u64::MAX.div_ceil(32)));
+}
+
+#[test]
+#[rustfmt::skip]
 fn evaluate_charges_decoded_program_steps() {
     for (program, witness, cost) in [("24", "", 1), ("8900", "", 2), ("c1220f0100", "", 4), ("c1d21014", "00", 4)] {
         assert_eq!(decoded(program, witness).evaluate(EvalOptions::default()).unwrap(), EvalResult { accepted: true, cost: cost * STEP_COST });


### PR DESCRIPTION
Invariant:
Rust mirrors the merged Go arithmetic and byte data jet helper behavior for results, accepted/rejected outcomes, and cost accounting.

Layer:
Implementation and tests, Rust client only.

Files changed:
- clients/rust/crates/rubin-consensus/src/simplicity.rs
- clients/rust/crates/rubin-consensus/src/simplicity/tests/mod.rs

Tests:
- scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo fmt --check'
- scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test -p rubin-consensus simplicity::tests::data_jets_match_go_reference'
- scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test -p rubin-consensus'
- scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo clippy -p rubin-consensus -- -D warnings'
- scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test --workspace'
- rubin-precommit-one-review with base ref origin/main
- isolated stock code-review reviewer PASS, no findings
- rubin-push with stack-local Codacy coverage wrapper

Behavior impact:
Adds Rust helper APIs for u64 checked add/sub/mul, u64 cmp, u128 checked add/sub, u128 cmp, bytes eq/cmp, and bytes slice. No consensus dispatch wiring is changed in this slice.

Compatibility impact:
Rust-only staged child slice for RUB-554. Go implementation and shared parity corpus remain owned by separate issues.

Known non-goals:
- No Go changes.
- No crypto jets.
- No shared parity corpus or fixture changes.
- No consensus dispatch wiring.

Follow-ups:
RUB-555 owns shared arithmetic/bytes jet parity vectors and evidence.

### Parity exemption justification
This is a staged single-client child slice. The sibling client and shared evidence are separate Linear issues; do not add sibling-client changes only to satisfy per-PR source lockstep.

Issue: RUB-554 / #2086
Closes #2086
