### PR TITLE
RUB-556: add Go jets registry hash

### DIFF
--- a/clients/go/consensus/simplicity/program.go
+++ b/clients/go/consensus/simplicity/program.go
@@ -11,6 +11,7 @@ import (
 	"crypto/sha3"
 	"encoding/binary"
 	"encoding/hex"
+	"fmt"
 	"math/bits"
 )
 
@@ -20,13 +21,14 @@ const (
 	MaxExecCost      uint64 = 400_000
 	StepCost         uint64 = 1
 
-	CostModelSemanticsVersion uint32 = 2
-	IntrinsicReadCost         uint64 = 1
-	IntrinsicMissCost         uint64 = 1
-	DescriptorHashBaseCost    uint64 = 64
-	DescriptorHashByteCost    uint64 = 1
-	MaxFrameBytes             uint64 = 65_536
-	MaxLiveMemoryBytes        uint64 = 1_048_576
+	CostModelSemanticsVersion    uint32 = 2
+	JetsRegistrySemanticsVersion uint32 = 2
+	IntrinsicReadCost            uint64 = 1
+	IntrinsicMissCost            uint64 = 1
+	DescriptorHashBaseCost       uint64 = 64
+	DescriptorHashByteCost       uint64 = 1
+	MaxFrameBytes                uint64 = 65_536
+	MaxLiveMemoryBytes           uint64 = 1_048_576
 )
 
 type ErrorCode string
@@ -115,12 +117,20 @@ func LookupJet(id uint16, subOp uint8) (Jet, bool) {
 	return copyJet(row), ok
 }
 
+func requireJet(id uint16, subOp uint8) (Jet, error) {
+	jet, ok := LookupJet(id, subOp)
+	if !ok {
+		return Jet{}, &Error{Code: ErrJetDisallowed}
+	}
+	return jet, nil
+}
+
 func (p Program) Evaluate(opts EvalOptions) (EvalResult, error) {
 	if !p.decoded {
 		return EvalResult{}, &Error{Code: ErrDecode}
 	}
 	if p.hasJet {
-		if _, ok := jetRows[p.jetKey]; !ok {
+		if _, ok := LookupJet(p.jetKey.id, p.jetKey.subOp); !ok {
 			return EvalResult{}, &Error{Code: ErrDecode}
 		}
 		if err := checkMemoryBounds(p.frameBitWidths); err != nil {
@@ -201,6 +211,10 @@ func CostModelHash() [32]byte {
 	return sha3.Sum256(costModelBytes())
 }
 
+func jetsRegistryHash() [32]byte {
+	return sha3.Sum256(jetsRegistryBytes(jetRegistryRows))
+}
+
 func decodeProgram(program []byte) (Program, error) {
 	entry, ok := programs[string(program)]
 	if !ok {
@@ -237,6 +251,11 @@ type jetKey struct {
 	subOp uint8
 }
 
+type jetRegistryRow struct {
+	jet       Jet
+	signature string
+}
+
 type costFormulaID uint8
 
 const (
@@ -256,20 +275,22 @@ type witnessKey struct {
 	bytes   string
 }
 
-var jetRows = map[jetKey]Jet{
-	{0x0001, 0x00}: {ID: 0x0001, SubOp: 0x00, Name: "sha3_256", SelectorBitLen: 2, SelectorPadded: []byte{0x00}, CMR: hex32("3999889bdf18d07c6c38b7aacb89f6c2bdd3c6a5c3c93ce79d1902a567b1e637")},
-	{0x0002, 0x00}: {ID: 0x0002, SubOp: 0x00, Name: "mldsa87_verify", SelectorBitLen: 4, SelectorPadded: []byte{0x80}, CMR: hex32("f5f90bf76aea628b4f2d75267cb5c13b49cd444b0690c3411fa01856342d4941")},
-	{0x0010, 0x00}: {ID: 0x0010, SubOp: 0x00, Name: "u64_checked_add", SelectorBitLen: 12, SelectorPadded: []byte{0xe0, 0x00}, CMR: hex32("4911cf2b5d37ccc5407c0d4e0686f0c6871c0b18c33ebc2dd28ec905cbec90ee")},
-	{0x0010, 0x01}: {ID: 0x0010, SubOp: 0x01, Name: "u64_checked_sub", SelectorBitLen: 14, SelectorPadded: []byte{0xe0, 0x10}, CMR: hex32("9c2b594d0673d2f416e0bb216f15d35a55a75c2237d030493ec3ae72652f2146")},
-	{0x0010, 0x02}: {ID: 0x0010, SubOp: 0x02, Name: "u64_checked_mul", SelectorBitLen: 14, SelectorPadded: []byte{0xe0, 0x14}, CMR: hex32("cf668e8e6a8bd1e9bcceebef182e063d1facd1665664170b6ae163456e739fa7")},
-	{0x0010, 0x03}: {ID: 0x0010, SubOp: 0x03, Name: "u64_cmp", SelectorBitLen: 17, SelectorPadded: []byte{0xe0, 0x18, 0x00}, CMR: hex32("50a228b34771cac098612f13ccf74949a8a0d8856b29440502fe8b45dd699c07")},
-	{0x0011, 0x00}: {ID: 0x0011, SubOp: 0x00, Name: "u128_checked_add", SelectorBitLen: 12, SelectorPadded: []byte{0xe0, 0x20}, CMR: hex32("9d4674805162aca15086e994aa03fb6d2093665316449f9cc97e5288daf14dd9")},
-	{0x0011, 0x01}: {ID: 0x0011, SubOp: 0x01, Name: "u128_checked_sub", SelectorBitLen: 14, SelectorPadded: []byte{0xe0, 0x30}, CMR: hex32("0d8bc8c7815edb3c220fd212f4c7b6986f50e8a427d6200b74f83a85c1792f75")},
-	{0x0011, 0x03}: {ID: 0x0011, SubOp: 0x03, Name: "u128_cmp", SelectorBitLen: 17, SelectorPadded: []byte{0xe0, 0x38, 0x00}, CMR: hex32("c90a66af21fc7ced71a9141082a47dbb0db878c25f432af25f382ccb055f4add")},
-	{0x0020, 0x00}: {ID: 0x0020, SubOp: 0x00, Name: "bytes_eq", SelectorBitLen: 13, SelectorPadded: []byte{0xe2, 0x00}, CMR: hex32("33f82e38417283760f1d9deba367aeaa0feb4c703b69aa37dc8c2aefe7c32d4a")},
-	{0x0020, 0x01}: {ID: 0x0020, SubOp: 0x01, Name: "bytes_cmp", SelectorBitLen: 15, SelectorPadded: []byte{0xe2, 0x08}, CMR: hex32("bd237f53ad86be9b3c8bd3dcb2a36642782c07885d5afc44903b5dc6d017960a")},
-	{0x0021, 0x00}: {ID: 0x0021, SubOp: 0x00, Name: "bytes_slice", SelectorBitLen: 13, SelectorPadded: []byte{0xe2, 0x10}, CMR: hex32("9c28e72f9da964de2c90d92c5c772211537ed2e07d20f6790c988284a87c0ce2")},
+var jetRegistryRows = []jetRegistryRow{
+	{jet: Jet{ID: 0x0001, SubOp: 0x00, Name: "sha3_256", SelectorBitLen: 2, SelectorPadded: []byte{0x00}, CMR: hex32("3999889bdf18d07c6c38b7aacb89f6c2bdd3c6a5c3c93ce79d1902a567b1e637")}, signature: "bytes -> bytes32"},
+	{jet: Jet{ID: 0x0002, SubOp: 0x00, Name: "mldsa87_verify", SelectorBitLen: 4, SelectorPadded: []byte{0x80}, CMR: hex32("f5f90bf76aea628b4f2d75267cb5c13b49cd444b0690c3411fa01856342d4941")}, signature: "(pubkey:bytes, sig:bytes, digest32:bytes32) -> bool"},
+	{jet: Jet{ID: 0x0010, SubOp: 0x00, Name: "u64_checked_add", SelectorBitLen: 12, SelectorPadded: []byte{0xe0, 0x00}, CMR: hex32("4911cf2b5d37ccc5407c0d4e0686f0c6871c0b18c33ebc2dd28ec905cbec90ee")}, signature: "(u64, u64) -> Either<unit, u64>"},
+	{jet: Jet{ID: 0x0010, SubOp: 0x01, Name: "u64_checked_sub", SelectorBitLen: 14, SelectorPadded: []byte{0xe0, 0x10}, CMR: hex32("9c2b594d0673d2f416e0bb216f15d35a55a75c2237d030493ec3ae72652f2146")}, signature: "(u64, u64) -> Either<unit, u64>"},
+	{jet: Jet{ID: 0x0010, SubOp: 0x02, Name: "u64_checked_mul", SelectorBitLen: 14, SelectorPadded: []byte{0xe0, 0x14}, CMR: hex32("cf668e8e6a8bd1e9bcceebef182e063d1facd1665664170b6ae163456e739fa7")}, signature: "(u64, u64) -> Either<unit, u64>"},
+	{jet: Jet{ID: 0x0010, SubOp: 0x03, Name: "u64_cmp", SelectorBitLen: 17, SelectorPadded: []byte{0xe0, 0x18, 0x00}, CMR: hex32("50a228b34771cac098612f13ccf74949a8a0d8856b29440502fe8b45dd699c07")}, signature: "(u64, u64) -> ordering"},
+	{jet: Jet{ID: 0x0011, SubOp: 0x00, Name: "u128_checked_add", SelectorBitLen: 12, SelectorPadded: []byte{0xe0, 0x20}, CMR: hex32("9d4674805162aca15086e994aa03fb6d2093665316449f9cc97e5288daf14dd9")}, signature: "(u128, u128) -> Either<unit, u128>"},
+	{jet: Jet{ID: 0x0011, SubOp: 0x01, Name: "u128_checked_sub", SelectorBitLen: 14, SelectorPadded: []byte{0xe0, 0x30}, CMR: hex32("0d8bc8c7815edb3c220fd212f4c7b6986f50e8a427d6200b74f83a85c1792f75")}, signature: "(u128, u128) -> Either<unit, u128>"},
+	{jet: Jet{ID: 0x0011, SubOp: 0x03, Name: "u128_cmp", SelectorBitLen: 17, SelectorPadded: []byte{0xe0, 0x38, 0x00}, CMR: hex32("c90a66af21fc7ced71a9141082a47dbb0db878c25f432af25f382ccb055f4add")}, signature: "(u128, u128) -> ordering"},
+	{jet: Jet{ID: 0x0020, SubOp: 0x00, Name: "bytes_eq", SelectorBitLen: 13, SelectorPadded: []byte{0xe2, 0x00}, CMR: hex32("33f82e38417283760f1d9deba367aeaa0feb4c703b69aa37dc8c2aefe7c32d4a")}, signature: "(bytes, bytes) -> bool"},
+	{jet: Jet{ID: 0x0020, SubOp: 0x01, Name: "bytes_cmp", SelectorBitLen: 15, SelectorPadded: []byte{0xe2, 0x08}, CMR: hex32("bd237f53ad86be9b3c8bd3dcb2a36642782c07885d5afc44903b5dc6d017960a")}, signature: "(bytes, bytes) -> ordering"},
+	{jet: Jet{ID: 0x0021, SubOp: 0x00, Name: "bytes_slice", SelectorBitLen: 13, SelectorPadded: []byte{0xe2, 0x10}, CMR: hex32("9c28e72f9da964de2c90d92c5c772211537ed2e07d20f6790c988284a87c0ce2")}, signature: "(src:bytes, start:u64, len:u64) -> Either<unit, bytes>"},
 }
+
+var jetRows = jetRowsFromRegistryRows(jetRegistryRows)
 
 type programEntry struct {
 	program Program
@@ -320,6 +341,54 @@ func costModelBytes() []byte {
 		out = binary.LittleEndian.AppendUint16(out, row.jet.id)
 		out = append(out, row.jet.subOp, byte(row.formula))
 		out = binary.LittleEndian.AppendUint64(out, row.param)
+	}
+	return out
+}
+
+func jetsRegistryBytes(rows []jetRegistryRow) []byte {
+	if err := validateJetRegistryRows(rows); err != nil {
+		panic(err)
+	}
+	out := []byte("RUBIN-SIMPLICITY-JETS-v1")
+	out = binary.LittleEndian.AppendUint32(out, JetsRegistrySemanticsVersion)
+	out = appendOneByteCompactSize(out, len(rows))
+	for _, row := range rows {
+		out = binary.LittleEndian.AppendUint16(out, row.jet.ID)
+		out = append(out, row.jet.SubOp)
+		out = appendOneByteCompactSize(out, len(row.jet.Name))
+		out = append(out, row.jet.Name...)
+		out = appendOneByteCompactSize(out, len(row.signature))
+		out = append(out, row.signature...)
+	}
+	return out
+}
+
+func validateJetRegistryRows(rows []jetRegistryRow) error {
+	var prev jetKey
+	for i, row := range rows {
+		key := jetKey{id: row.jet.ID, subOp: row.jet.SubOp}
+		if i > 0 && (prev.id > key.id || (prev.id == key.id && prev.subOp >= key.subOp)) {
+			return fmt.Errorf("jet registry rows not strictly sorted at %d", i)
+		}
+		prev = key
+	}
+	return nil
+}
+
+func appendOneByteCompactSize(out []byte, n int) []byte {
+	if n >= 253 {
+		panic("jet registry CompactSize value exceeds one-byte encoding")
+	}
+	return append(out, byte(n))
+}
+
+func jetRowsFromRegistryRows(rows []jetRegistryRow) map[jetKey]Jet {
+	if err := validateJetRegistryRows(rows); err != nil {
+		panic(err)
+	}
+	out := make(map[jetKey]Jet, len(rows))
+	for _, row := range rows {
+		out[jetKey{id: row.jet.ID, subOp: row.jet.SubOp}] = copyJet(row.jet)
 	}
 	return out
 }

--- a/clients/go/consensus/simplicity/program.go
+++ b/clients/go/consensus/simplicity/program.go
@@ -213,7 +213,7 @@ func CostModelHash() [32]byte {
 
 // JetsRegistryHash returns the hash of the ordered Go jet registry table.
 func JetsRegistryHash() [32]byte {
-	return sha3.Sum256(jetsRegistryBytes(jetRegistryRows))
+	return jetsRegistryHashValue
 }
 
 func decodeProgram(program []byte) (Program, error) {
@@ -292,6 +292,8 @@ var jetRegistryRows = []jetRegistryRow{
 }
 
 var jetRows = jetRowsFromRegistryRows(jetRegistryRows)
+
+var jetsRegistryHashValue = sha3.Sum256(jetsRegistryBytes(jetRegistryRows))
 
 type programEntry struct {
 	program Program

--- a/clients/go/consensus/simplicity/program.go
+++ b/clients/go/consensus/simplicity/program.go
@@ -130,7 +130,7 @@ func (p Program) Evaluate(opts EvalOptions) (EvalResult, error) {
 		return EvalResult{}, &Error{Code: ErrDecode}
 	}
 	if p.hasJet {
-		if _, ok := LookupJet(p.jetKey.id, p.jetKey.subOp); !ok {
+		if _, ok := jetRows[p.jetKey]; !ok {
 			return EvalResult{}, &Error{Code: ErrDecode}
 		}
 		if err := checkMemoryBounds(p.frameBitWidths); err != nil {

--- a/clients/go/consensus/simplicity/program.go
+++ b/clients/go/consensus/simplicity/program.go
@@ -211,6 +211,11 @@ func CostModelHash() [32]byte {
 	return sha3.Sum256(costModelBytes())
 }
 
+// JetsRegistryHash returns the hash of the ordered Go jet registry table.
+func JetsRegistryHash() [32]byte {
+	return sha3.Sum256(jetsRegistryBytes(jetRegistryRows))
+}
+
 func decodeProgram(program []byte) (Program, error) {
 	entry, ok := programs[string(program)]
 	if !ok {
@@ -339,6 +344,31 @@ func costModelBytes() []byte {
 		out = binary.LittleEndian.AppendUint64(out, row.param)
 	}
 	return out
+}
+
+func jetsRegistryBytes(rows []jetRegistryRow) []byte {
+	if err := validateJetLookupRows(rows); err != nil {
+		panic(err)
+	}
+	out := []byte("RUBIN-SIMPLICITY-JETS-v1")
+	out = binary.LittleEndian.AppendUint32(out, JetsRegistrySemanticsVersion)
+	out = appendOneByteCompactSize(out, len(rows))
+	for _, row := range rows {
+		out = binary.LittleEndian.AppendUint16(out, row.jet.ID)
+		out = append(out, row.jet.SubOp)
+		out = appendOneByteCompactSize(out, len(row.jet.Name))
+		out = append(out, row.jet.Name...)
+		out = appendOneByteCompactSize(out, len(row.signature))
+		out = append(out, row.signature...)
+	}
+	return out
+}
+
+func appendOneByteCompactSize(out []byte, n int) []byte {
+	if n >= 253 {
+		panic("jet registry CompactSize value exceeds one-byte encoding")
+	}
+	return append(out, byte(n))
 }
 
 func validateJetLookupRows(rows []jetRegistryRow) error {

--- a/clients/go/consensus/simplicity/program.go
+++ b/clients/go/consensus/simplicity/program.go
@@ -211,10 +211,6 @@ func CostModelHash() [32]byte {
 	return sha3.Sum256(costModelBytes())
 }
 
-func jetsRegistryHash() [32]byte {
-	return sha3.Sum256(jetsRegistryBytes(jetRegistryRows))
-}
-
 func decodeProgram(program []byte) (Program, error) {
 	entry, ok := programs[string(program)]
 	if !ok {
@@ -345,25 +341,7 @@ func costModelBytes() []byte {
 	return out
 }
 
-func jetsRegistryBytes(rows []jetRegistryRow) []byte {
-	if err := validateJetRegistryRows(rows); err != nil {
-		panic(err)
-	}
-	out := []byte("RUBIN-SIMPLICITY-JETS-v1")
-	out = binary.LittleEndian.AppendUint32(out, JetsRegistrySemanticsVersion)
-	out = appendOneByteCompactSize(out, len(rows))
-	for _, row := range rows {
-		out = binary.LittleEndian.AppendUint16(out, row.jet.ID)
-		out = append(out, row.jet.SubOp)
-		out = appendOneByteCompactSize(out, len(row.jet.Name))
-		out = append(out, row.jet.Name...)
-		out = appendOneByteCompactSize(out, len(row.signature))
-		out = append(out, row.signature...)
-	}
-	return out
-}
-
-func validateJetRegistryRows(rows []jetRegistryRow) error {
+func validateJetLookupRows(rows []jetRegistryRow) error {
 	var prev jetKey
 	for i, row := range rows {
 		key := jetKey{id: row.jet.ID, subOp: row.jet.SubOp}
@@ -375,15 +353,8 @@ func validateJetRegistryRows(rows []jetRegistryRow) error {
 	return nil
 }
 
-func appendOneByteCompactSize(out []byte, n int) []byte {
-	if n >= 253 {
-		panic("jet registry CompactSize value exceeds one-byte encoding")
-	}
-	return append(out, byte(n))
-}
-
 func jetRowsFromRegistryRows(rows []jetRegistryRow) map[jetKey]Jet {
-	if err := validateJetRegistryRows(rows); err != nil {
+	if err := validateJetLookupRows(rows); err != nil {
 		panic(err)
 	}
 	out := make(map[jetKey]Jet, len(rows))

--- a/clients/go/consensus/simplicity/program_test.go
+++ b/clients/go/consensus/simplicity/program_test.go
@@ -2,6 +2,8 @@ package simplicity
 
 import (
 	"bytes"
+	"crypto/sha3"
+	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -360,8 +362,37 @@ func TestCostModelHashMatchesSpecArtifact(t *testing.T) {
 	}
 }
 
+func testJetsRegistryHash() [32]byte {
+	return sha3.Sum256(testJetsRegistryBytes(jetRegistryRows))
+}
+
+func testJetsRegistryBytes(rows []jetRegistryRow) []byte {
+	if err := validateJetLookupRows(rows); err != nil {
+		panic(err)
+	}
+	out := []byte("RUBIN-SIMPLICITY-JETS-v1")
+	out = binary.LittleEndian.AppendUint32(out, JetsRegistrySemanticsVersion)
+	out = appendTestOneByteCompactSize(out, len(rows))
+	for _, row := range rows {
+		out = binary.LittleEndian.AppendUint16(out, row.jet.ID)
+		out = append(out, row.jet.SubOp)
+		out = appendTestOneByteCompactSize(out, len(row.jet.Name))
+		out = append(out, row.jet.Name...)
+		out = appendTestOneByteCompactSize(out, len(row.signature))
+		out = append(out, row.signature...)
+	}
+	return out
+}
+
+func appendTestOneByteCompactSize(out []byte, n int) []byte {
+	if n >= 253 {
+		panic("jet registry CompactSize value exceeds one-byte encoding")
+	}
+	return append(out, byte(n))
+}
+
 func TestJetsRegistryHashMatchesSpecArtifact(t *testing.T) {
-	preimage := jetsRegistryBytes(jetRegistryRows)
+	preimage := testJetsRegistryBytes(jetRegistryRows)
 	wantPreimage := "" +
 		"525542494e2d53494d504c49434954592d4a4554532d7631020000000c010000" +
 		"08736861335f323536106279746573202d3e20627974657333320200000e6d6c" +
@@ -385,7 +416,7 @@ func TestJetsRegistryHashMatchesSpecArtifact(t *testing.T) {
 	if got := hex.EncodeToString(preimage); got != wantPreimage {
 		t.Fatalf("jets registry preimage=%s want %s", got, wantPreimage)
 	}
-	if got := jetsRegistryHash(); got != hex32("5aee78aae6b610a3eb3c05bd1487523e318418e0419de48e4fe9555b37f1c059") {
+	if got := testJetsRegistryHash(); got != hex32("5aee78aae6b610a3eb3c05bd1487523e318418e0419de48e4fe9555b37f1c059") {
 		t.Fatalf("jets_registry_hash=%x", got)
 	}
 }
@@ -427,13 +458,13 @@ func TestJetRegistryRuntimeMetadataMatchesSpecArtifact(t *testing.T) {
 func TestJetsRegistryRowsRejectDuplicatesAndOrderDrift(t *testing.T) {
 	duplicate := append([]jetRegistryRow(nil), jetRegistryRows...)
 	duplicate[1] = duplicate[0]
-	if err := validateJetRegistryRows(duplicate); err == nil {
+	if err := validateJetLookupRows(duplicate); err == nil {
 		t.Fatal("duplicate jet registry key was accepted")
 	}
 
 	orderDrift := append([]jetRegistryRow(nil), jetRegistryRows...)
 	orderDrift[0], orderDrift[1] = orderDrift[1], orderDrift[0]
-	if err := validateJetRegistryRows(orderDrift); err == nil {
+	if err := validateJetLookupRows(orderDrift); err == nil {
 		t.Fatal("out-of-order jet registry rows were accepted")
 	}
 }

--- a/clients/go/consensus/simplicity/program_test.go
+++ b/clients/go/consensus/simplicity/program_test.go
@@ -2,8 +2,6 @@ package simplicity
 
 import (
 	"bytes"
-	"crypto/sha3"
-	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -362,37 +360,8 @@ func TestCostModelHashMatchesSpecArtifact(t *testing.T) {
 	}
 }
 
-func testJetsRegistryHash() [32]byte {
-	return sha3.Sum256(testJetsRegistryBytes(jetRegistryRows))
-}
-
-func testJetsRegistryBytes(rows []jetRegistryRow) []byte {
-	if err := validateJetLookupRows(rows); err != nil {
-		panic(err)
-	}
-	out := []byte("RUBIN-SIMPLICITY-JETS-v1")
-	out = binary.LittleEndian.AppendUint32(out, JetsRegistrySemanticsVersion)
-	out = appendTestOneByteCompactSize(out, len(rows))
-	for _, row := range rows {
-		out = binary.LittleEndian.AppendUint16(out, row.jet.ID)
-		out = append(out, row.jet.SubOp)
-		out = appendTestOneByteCompactSize(out, len(row.jet.Name))
-		out = append(out, row.jet.Name...)
-		out = appendTestOneByteCompactSize(out, len(row.signature))
-		out = append(out, row.signature...)
-	}
-	return out
-}
-
-func appendTestOneByteCompactSize(out []byte, n int) []byte {
-	if n >= 253 {
-		panic("jet registry CompactSize value exceeds one-byte encoding")
-	}
-	return append(out, byte(n))
-}
-
 func TestJetsRegistryHashMatchesSpecArtifact(t *testing.T) {
-	preimage := testJetsRegistryBytes(jetRegistryRows)
+	preimage := jetsRegistryBytes(jetRegistryRows)
 	wantPreimage := "" +
 		"525542494e2d53494d504c49434954592d4a4554532d7631020000000c010000" +
 		"08736861335f323536106279746573202d3e20627974657333320200000e6d6c" +
@@ -416,7 +385,7 @@ func TestJetsRegistryHashMatchesSpecArtifact(t *testing.T) {
 	if got := hex.EncodeToString(preimage); got != wantPreimage {
 		t.Fatalf("jets registry preimage=%s want %s", got, wantPreimage)
 	}
-	if got := testJetsRegistryHash(); got != hex32("5aee78aae6b610a3eb3c05bd1487523e318418e0419de48e4fe9555b37f1c059") {
+	if got := JetsRegistryHash(); got != hex32("5aee78aae6b610a3eb3c05bd1487523e318418e0419de48e4fe9555b37f1c059") {
 		t.Fatalf("jets_registry_hash=%x", got)
 	}
 }

--- a/clients/go/consensus/simplicity/program_test.go
+++ b/clients/go/consensus/simplicity/program_test.go
@@ -283,6 +283,11 @@ func TestJetRows(t *testing.T) {
 	if !bytes.Equal(again.SelectorPadded, hx("00")) {
 		t.Fatal("LookupJet returned mutable internal selector storage")
 	}
+	if _, err := requireJet(0x0011, 0x02); err == nil {
+		t.Fatal("requireJet accepted unassigned u128_checked_mul")
+	} else {
+		assertErrorCode(t, err, ErrJetDisallowed)
+	}
 }
 
 func TestDecodeJetMetadataIsImmutable(t *testing.T) {
@@ -352,6 +357,84 @@ func TestCostModelHashMatchesSpecArtifact(t *testing.T) {
 	}
 	if got := CostModelHash(); got != hex32("accb55570168bd7b1fedadff2135c99e32508680ff7a315cf4f33f97744aabc9") {
 		t.Fatalf("cost_model_hash=%x", got)
+	}
+}
+
+func TestJetsRegistryHashMatchesSpecArtifact(t *testing.T) {
+	preimage := jetsRegistryBytes(jetRegistryRows)
+	wantPreimage := "" +
+		"525542494e2d53494d504c49434954592d4a4554532d7631020000000c010000" +
+		"08736861335f323536106279746573202d3e20627974657333320200000e6d6c" +
+		"64736138375f76657269667933287075626b65793a62797465732c207369673a" +
+		"62797465732c2064696765737433323a6279746573333229202d3e20626f6f6c" +
+		"1000000f7536345f636865636b65645f6164641f287536342c2075363429202d" +
+		"3e204569746865723c756e69742c207536343e1000010f7536345f636865636b" +
+		"65645f7375621f287536342c2075363429202d3e204569746865723c756e6974" +
+		"2c207536343e1000020f7536345f636865636b65645f6d756c1f287536342c20" +
+		"75363429202d3e204569746865723c756e69742c207536343e10000307753634" +
+		"5f636d7016287536342c2075363429202d3e206f72646572696e671100001075" +
+		"3132385f636865636b65645f6164642228753132382c207531323829202d3e20" +
+		"4569746865723c756e69742c20753132383e11000110753132385f636865636b" +
+		"65645f7375622228753132382c207531323829202d3e204569746865723c756e" +
+		"69742c20753132383e11000308753132385f636d701828753132382c20753132" +
+		"3829202d3e206f72646572696e672000000862797465735f6571162862797465" +
+		"732c20627974657329202d3e20626f6f6c2000010962797465735f636d701a28" +
+		"62797465732c20627974657329202d3e206f72646572696e672100000b627974" +
+		"65735f736c69636536287372633a62797465732c2073746172743a7536342c20" +
+		"6c656e3a75363429202d3e204569746865723c756e69742c2062797465733e"
+	if got := hex.EncodeToString(preimage); got != wantPreimage {
+		t.Fatalf("jets registry preimage=%s want %s", got, wantPreimage)
+	}
+	if got := jetsRegistryHash(); got != hex32("5aee78aae6b610a3eb3c05bd1487523e318418e0419de48e4fe9555b37f1c059") {
+		t.Fatalf("jets_registry_hash=%x", got)
+	}
+}
+
+func TestJetRegistryRuntimeMetadataMatchesSpecArtifact(t *testing.T) {
+	want := map[jetKey]struct {
+		selectorBitLen int
+		selectorPadded string
+		cmr            string
+	}{
+		{id: 0x0001, subOp: 0x00}: {selectorBitLen: 2, selectorPadded: "00", cmr: "3999889bdf18d07c6c38b7aacb89f6c2bdd3c6a5c3c93ce79d1902a567b1e637"},
+		{id: 0x0002, subOp: 0x00}: {selectorBitLen: 4, selectorPadded: "80", cmr: "f5f90bf76aea628b4f2d75267cb5c13b49cd444b0690c3411fa01856342d4941"},
+		{id: 0x0010, subOp: 0x00}: {selectorBitLen: 12, selectorPadded: "e000", cmr: "4911cf2b5d37ccc5407c0d4e0686f0c6871c0b18c33ebc2dd28ec905cbec90ee"},
+		{id: 0x0010, subOp: 0x01}: {selectorBitLen: 14, selectorPadded: "e010", cmr: "9c2b594d0673d2f416e0bb216f15d35a55a75c2237d030493ec3ae72652f2146"},
+		{id: 0x0010, subOp: 0x02}: {selectorBitLen: 14, selectorPadded: "e014", cmr: "cf668e8e6a8bd1e9bcceebef182e063d1facd1665664170b6ae163456e739fa7"},
+		{id: 0x0010, subOp: 0x03}: {selectorBitLen: 17, selectorPadded: "e01800", cmr: "50a228b34771cac098612f13ccf74949a8a0d8856b29440502fe8b45dd699c07"},
+		{id: 0x0011, subOp: 0x00}: {selectorBitLen: 12, selectorPadded: "e020", cmr: "9d4674805162aca15086e994aa03fb6d2093665316449f9cc97e5288daf14dd9"},
+		{id: 0x0011, subOp: 0x01}: {selectorBitLen: 14, selectorPadded: "e030", cmr: "0d8bc8c7815edb3c220fd212f4c7b6986f50e8a427d6200b74f83a85c1792f75"},
+		{id: 0x0011, subOp: 0x03}: {selectorBitLen: 17, selectorPadded: "e03800", cmr: "c90a66af21fc7ced71a9141082a47dbb0db878c25f432af25f382ccb055f4add"},
+		{id: 0x0020, subOp: 0x00}: {selectorBitLen: 13, selectorPadded: "e200", cmr: "33f82e38417283760f1d9deba367aeaa0feb4c703b69aa37dc8c2aefe7c32d4a"},
+		{id: 0x0020, subOp: 0x01}: {selectorBitLen: 15, selectorPadded: "e208", cmr: "bd237f53ad86be9b3c8bd3dcb2a36642782c07885d5afc44903b5dc6d017960a"},
+		{id: 0x0021, subOp: 0x00}: {selectorBitLen: 13, selectorPadded: "e210", cmr: "9c28e72f9da964de2c90d92c5c772211537ed2e07d20f6790c988284a87c0ce2"},
+	}
+	if len(want) != len(jetRegistryRows) {
+		t.Fatalf("metadata rows=%d want registry rows=%d", len(want), len(jetRegistryRows))
+	}
+	for _, row := range jetRegistryRows {
+		key := jetKey{id: row.jet.ID, subOp: row.jet.SubOp}
+		w, ok := want[key]
+		if !ok {
+			t.Fatalf("unexpected jet row %#04x/%#02x", key.id, key.subOp)
+		}
+		if row.jet.SelectorBitLen != w.selectorBitLen || !bytes.Equal(row.jet.SelectorPadded, hx(w.selectorPadded)) || row.jet.CMR != hex32(w.cmr) {
+			t.Fatalf("metadata %#04x/%#02x got selector=%d/%x cmr=%x", key.id, key.subOp, row.jet.SelectorBitLen, row.jet.SelectorPadded, row.jet.CMR)
+		}
+	}
+}
+
+func TestJetsRegistryRowsRejectDuplicatesAndOrderDrift(t *testing.T) {
+	duplicate := append([]jetRegistryRow(nil), jetRegistryRows...)
+	duplicate[1] = duplicate[0]
+	if err := validateJetRegistryRows(duplicate); err == nil {
+		t.Fatal("duplicate jet registry key was accepted")
+	}
+
+	orderDrift := append([]jetRegistryRow(nil), jetRegistryRows...)
+	orderDrift[0], orderDrift[1] = orderDrift[1], orderDrift[0]
+	if err := validateJetRegistryRows(orderDrift); err == nil {
+		t.Fatal("out-of-order jet registry rows were accepted")
 	}
 }
 


### PR DESCRIPTION
Invariant:
Go derives the Simplicity jets_registry_hash from the ordered v1 Go registry table and rejects out-of-registry jet ids as TX_ERR_SIMPLICITY_JET_DISALLOWED at decode for the disallowed program encoding.

Layer:
implementation, tests

Files changed:
- clients/go/consensus/simplicity/program.go
- clients/go/consensus/simplicity/program_test.go

Tests:
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./consensus/simplicity -run "Test(JetsRegistryHashMatchesSpecArtifact|JetRegistryRuntimeMetadataMatchesSpecArtifact|JetsRegistryRowsRejectDuplicatesAndOrderDrift|JetRows|DecodeVectors|EvaluateInternalFailClosedPaths|EvaluateMemoryErrorClassPriority)$"' - PASS
- git diff --check - PASS
- check_complexity.py --base-ref origin/main clients/go/consensus/simplicity/program.go clients/go/consensus/simplicity/program_test.go - PASS
- rubin-stack-codacy-coverage.sh origin/main - PASS
- rubin-push --base-ref origin/main --coverage-cmd rubin-stack-codacy-coverage.sh -- origin HEAD:codex/rub-556-jets-registry-go - PASS, with a receipt-only fast-path rerun after refreshing local pattern and one-review receipts
- Fresh isolated stock reviewer 019ed176-4a41-77a2-ae23-15268099d3e9 - PASS, no findings

Behavior impact:
The Go Simplicity package now derives the private jets registry hash from the ordered registry table and pins selector/CMR metadata against the generated artifact. The disallowed external program encoding remains TX_ERR_SIMPLICITY_JET_DISALLOWED; internal forged decoded jet keys keep the existing decode-error priority.

Compatibility impact:
Go-only child slice. No Rust/shared corpus changes in this PR.

Known non-goals:
- No Rust implementation changes.
- No shared parity corpus changes.
- No consensus dispatch wiring.
- No jet semantic changes.

Follow-ups:
- RUB-557 owns the Rust mirror.
- RUB-558 owns shared final parity evidence.

Risk:
Low; code is private to the Go Simplicity package and package comments still forbid consensus dispatch until Rust/shared parity land.

Rollback:
Revert the commit.

Not checked:
- Rust workspace tests; out of scope for this Go-only child.

### Parity exemption justification
This is a staged single-client child slice. The sibling Rust client and shared evidence are separate Linear issues (RUB-557 and RUB-558); this PR intentionally does not add sibling-client changes only to satisfy per-PR source lockstep.
