### PR TITLE
RUB-559: add Go simplicity exec vector CLI op

### DIFF
--- a/clients/go/cmd/rubin-consensus-cli/runtime.go
+++ b/clients/go/cmd/rubin-consensus-cli/runtime.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus/simplicity"
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/node"
 )
 
@@ -60,6 +61,9 @@ type Request struct {
 	TargetHex             string                         `json:"target_hex,omitempty"`
 	ExpectedPrev          string                         `json:"expected_prev_hash,omitempty"`
 	HeaderHex             string                         `json:"header_hex,omitempty"`
+	ProgramHex            string                         `json:"program_hex,omitempty"`
+	WitnessHex            string                         `json:"witness_hex,omitempty"`
+	CovenantCMRHex        string                         `json:"covenant_cmr_hex,omitempty"`
 	CovenantDataHex       string                         `json:"covenant_data_hex,omitempty"`
 	WtxidHex              string                         `json:"wtxid,omitempty"`
 	Path                  string                         `json:"path,omitempty"`
@@ -160,6 +164,9 @@ type Request struct {
 	ExpectedArtifactHash  string                         `json:"expected_artifact_hash_hex,omitempty"`
 	DependencyChecklists  []TxctxDependencyChecklistJSON `json:"dependency_checklists,omitempty"`
 	MempoolTxctxConfirmed *bool                          `json:"mempool_txctx_confirmed,omitempty"`
+	SemanticsVersion      *uint32                        `json:"semantics_version,omitempty"`
+	JetAccepted           *bool                          `json:"jet_accepted,omitempty"`
+	JetCost               *uint64                        `json:"jet_cost,omitempty"`
 }
 
 type requestEnvelope struct {
@@ -365,9 +372,11 @@ func (item SuiteParamsJSON) MarshalJSON() ([]byte, error) {
 	})
 }
 
-const maxExplicitSuiteRegistryItems = 16
-const maxCoreExtHexFieldBytes = 4096
-const canonicalSuiteRegistryAlgName = "ML-DSA-87"
+const (
+	maxExplicitSuiteRegistryItems = 16
+	maxCoreExtHexFieldBytes       = 4096
+	canonicalSuiteRegistryAlgName = "ML-DSA-87"
+)
 
 func validateSuiteRegistryParamLen(value int) (int, error) {
 	// Negative lengths fail closed during JSON decode because the wire surface
@@ -664,6 +673,8 @@ type Response struct {
 	Prioritize         bool           `json:"prioritize,omitempty"`
 	ExtID              uint16         `json:"ext_id,omitempty"`
 	SuiteIDs           []uint8        `json:"suite_ids,omitempty"`
+	Accepted           *bool          `json:"accepted,omitempty"`
+	FinalCounter       *uint64        `json:"final_counter,omitempty"`
 }
 
 func writeResp(w io.Writer, resp Response) {
@@ -740,6 +751,82 @@ func parseOptionalChainIDHex(chainIDHex string) ([32]byte, error) {
 	return parsed, nil
 }
 
+func parseSimplicityHex(name, value string, required bool, maxBytes int) ([]byte, error) {
+	value = strings.TrimSpace(value)
+	value = strings.TrimPrefix(strings.TrimPrefix(value, "0x"), "0X")
+	if value == "" {
+		if required {
+			return nil, fmt.Errorf("bad %s", name)
+		}
+		return nil, nil
+	}
+	if maxBytes >= 0 && len(value) > maxBytes*2 {
+		return nil, fmt.Errorf("bad %s", name)
+	}
+	raw, err := hex.DecodeString(value)
+	if err != nil {
+		return nil, fmt.Errorf("bad %s", name)
+	}
+	return raw, nil
+}
+
+func simplicityErrString(err error) string {
+	var se *simplicity.Error
+	if errors.As(err, &se) {
+		return string(se.Code)
+	}
+	return err.Error()
+}
+
+func runSimplicityExecVector(req Request) Response {
+	programBytes, err := parseSimplicityHex("program_hex", req.ProgramHex, true, simplicity.MaxProgramBytes)
+	if err != nil {
+		return Response{Ok: false, Err: err.Error()}
+	}
+	witnessBytes, err := parseSimplicityHex("witness_hex", req.WitnessHex, false, simplicity.MaxProgramBytes)
+	if err != nil {
+		return Response{Ok: false, Err: err.Error()}
+	}
+	covenantCMR, err := parseOptionalHex32(req.CovenantCMRHex, "bad covenant_cmr_hex")
+	if err != nil {
+		return Response{Ok: false, Err: err.Error()}
+	}
+
+	semanticsVersion := simplicity.SemanticsVersion
+	if req.SemanticsVersion != nil {
+		semanticsVersion = *req.SemanticsVersion
+	}
+	program, err := simplicity.Decode(programBytes, witnessBytes, simplicity.DecodeOptions{
+		SemanticsVersion:   semanticsVersion,
+		CovenantProgramCMR: covenantCMR,
+	})
+	if err != nil {
+		return Response{Ok: false, Err: simplicityErrString(err)}
+	}
+
+	opts := simplicity.EvalOptions{}
+	if program.Jet != nil {
+		if req.JetCost == nil {
+			return Response{Ok: false, Err: "bad jet_result"}
+		}
+		jetAccepted := false
+		if req.JetAccepted != nil {
+			jetAccepted = *req.JetAccepted
+		}
+		opts.JetEvaluator = func(simplicity.Jet) (simplicity.EvalResult, error) {
+			return simplicity.EvalResult{Accepted: jetAccepted, Cost: *req.JetCost}, nil
+		}
+	}
+
+	result, err := program.Evaluate(opts)
+	accepted := result.Accepted
+	finalCounter := result.Cost
+	if err != nil {
+		return Response{Ok: false, Err: simplicityErrString(err), Accepted: &accepted, FinalCounter: &finalCounter}
+	}
+	return Response{Ok: true, Accepted: &accepted, FinalCounter: &finalCounter}
+}
+
 func parseHex32List(items []string, badErr string) ([][32]byte, error) {
 	parsed := make([][32]byte, 0, len(items))
 	for _, item := range items {
@@ -793,8 +880,10 @@ func buildUtxoMap(items []UtxoJSON) (map[consensus.Outpoint]consensus.UtxoEntry,
 }
 
 // Conformance replay mirrors the current standard mempool default without importing node runtime.
-const conformanceDefaultMempoolMinFeeRate uint64 = 1
-const conformanceDefaultMinDAFeeRate uint64 = 1
+const (
+	conformanceDefaultMempoolMinFeeRate uint64 = 1
+	conformanceDefaultMinDAFeeRate      uint64 = 1
+)
 
 func addU64Policy(a, b uint64) (uint64, bool) {
 	if a > ^uint64(0)-b {
@@ -1432,6 +1521,10 @@ func runFromStdin() {
 	case "txctx_governance_vector":
 		resp := runTxctxGovernanceVector(req, coreExtProfilesReq)
 		writeResp(os.Stdout, resp)
+		return
+
+	case "simplicity_exec_vector":
+		writeResp(os.Stdout, runSimplicityExecVector(req))
 		return
 
 	case "parse_tx":

--- a/clients/go/cmd/rubin-consensus-cli/runtime.go
+++ b/clients/go/cmd/rubin-consensus-cli/runtime.go
@@ -798,6 +798,9 @@ func simplicityErrString(err error) string {
 
 func runSimplicitySyntheticExecVector(req Request) Response {
 	if req.EvalSteps == nil {
+		if len(req.FrameBitWidths) > 0 {
+			return Response{Ok: false, Err: "bad eval_steps"}
+		}
 		return Response{Ok: false, Err: "bad program_hex"}
 	}
 	result, err := evaluateSimplicitySynthetic(*req.EvalSteps, req.FrameBitWidths)

--- a/clients/go/cmd/rubin-consensus-cli/runtime.go
+++ b/clients/go/cmd/rubin-consensus-cli/runtime.go
@@ -816,9 +816,6 @@ func evaluateSimplicitySynthetic(evalSteps uint64, frameBitWidths []uint64) (sim
 	if err := checkSimplicitySyntheticMemory(frameBitWidths); err != nil {
 		return simplicity.EvalResult{}, err
 	}
-	if simplicity.StepCost == 0 {
-		return simplicity.EvalResult{}, &simplicity.Error{Code: simplicity.ErrBudgetExceeded}
-	}
 	maxSteps := simplicity.MaxExecCost / simplicity.StepCost
 	if evalSteps > maxSteps {
 		return simplicity.EvalResult{Accepted: true, Cost: simplicity.MaxExecCost}, &simplicity.Error{Code: simplicity.ErrBudgetExceeded}

--- a/clients/go/cmd/rubin-consensus-cli/runtime.go
+++ b/clients/go/cmd/rubin-consensus-cli/runtime.go
@@ -165,6 +165,8 @@ type Request struct {
 	DependencyChecklists  []TxctxDependencyChecklistJSON `json:"dependency_checklists,omitempty"`
 	MempoolTxctxConfirmed *bool                          `json:"mempool_txctx_confirmed,omitempty"`
 	SemanticsVersion      *uint32                        `json:"semantics_version,omitempty"`
+	EvalSteps             *uint64                        `json:"eval_steps,omitempty"`
+	FrameBitWidths        []uint64                       `json:"frame_bit_widths,omitempty"`
 	JetAccepted           *bool                          `json:"jet_accepted,omitempty"`
 	JetCost               *uint64                        `json:"jet_cost,omitempty"`
 }
@@ -770,6 +772,22 @@ func parseSimplicityHex(name, value string, required bool, maxBytes int) ([]byte
 	return raw, nil
 }
 
+func parseSimplicityProgramHex(value string) ([]byte, error) {
+	value = strings.TrimSpace(value)
+	value = strings.TrimPrefix(strings.TrimPrefix(value, "0x"), "0X")
+	if value == "" {
+		return nil, fmt.Errorf("bad program_hex")
+	}
+	if len(value) > simplicity.MaxProgramBytes*2 {
+		return nil, &simplicity.Error{Code: simplicity.ErrProgramTooLarge}
+	}
+	raw, err := hex.DecodeString(value)
+	if err != nil {
+		return nil, fmt.Errorf("bad program_hex")
+	}
+	return raw, nil
+}
+
 func simplicityErrString(err error) string {
 	var se *simplicity.Error
 	if errors.As(err, &se) {
@@ -778,10 +796,58 @@ func simplicityErrString(err error) string {
 	return err.Error()
 }
 
-func runSimplicityExecVector(req Request) Response {
-	programBytes, err := parseSimplicityHex("program_hex", req.ProgramHex, true, simplicity.MaxProgramBytes)
+func runSimplicitySyntheticExecVector(req Request) Response {
+	if req.EvalSteps == nil {
+		return Response{Ok: false, Err: "bad program_hex"}
+	}
+	result, err := evaluateSimplicitySynthetic(*req.EvalSteps, req.FrameBitWidths)
+	accepted := result.Accepted
+	finalCounter := result.Cost
 	if err != nil {
-		return Response{Ok: false, Err: err.Error()}
+		return Response{Ok: false, Err: simplicityErrString(err), Accepted: &accepted, FinalCounter: &finalCounter}
+	}
+	return Response{Ok: true, Accepted: &accepted, FinalCounter: &finalCounter}
+}
+
+func evaluateSimplicitySynthetic(evalSteps uint64, frameBitWidths []uint64) (simplicity.EvalResult, error) {
+	if evalSteps == 0 {
+		return simplicity.EvalResult{}, &simplicity.Error{Code: simplicity.ErrDecode}
+	}
+	if err := checkSimplicitySyntheticMemory(frameBitWidths); err != nil {
+		return simplicity.EvalResult{}, err
+	}
+	if simplicity.StepCost == 0 {
+		return simplicity.EvalResult{}, &simplicity.Error{Code: simplicity.ErrBudgetExceeded}
+	}
+	maxSteps := simplicity.MaxExecCost / simplicity.StepCost
+	if evalSteps > maxSteps {
+		return simplicity.EvalResult{Accepted: true, Cost: simplicity.MaxExecCost}, &simplicity.Error{Code: simplicity.ErrBudgetExceeded}
+	}
+	return simplicity.EvalResult{Accepted: true, Cost: evalSteps * simplicity.StepCost}, nil
+}
+
+func checkSimplicitySyntheticMemory(frameBitWidths []uint64) error {
+	var live uint64
+	for _, frameBits := range frameBitWidths {
+		if frameBits > ^uint64(0)-7 {
+			return &simplicity.Error{Code: simplicity.ErrBudgetExceeded}
+		}
+		frameBytes := (frameBits + 7) / 8
+		if frameBytes > simplicity.MaxFrameBytes || live > simplicity.MaxLiveMemoryBytes-frameBytes {
+			return &simplicity.Error{Code: simplicity.ErrBudgetExceeded}
+		}
+		live += frameBytes
+	}
+	return nil
+}
+
+func runSimplicityExecVector(req Request) Response {
+	if strings.TrimSpace(req.ProgramHex) == "" {
+		return runSimplicitySyntheticExecVector(req)
+	}
+	programBytes, err := parseSimplicityProgramHex(req.ProgramHex)
+	if err != nil {
+		return Response{Ok: false, Err: simplicityErrString(err)}
 	}
 	witnessBytes, err := parseSimplicityHex("witness_hex", req.WitnessHex, false, simplicity.MaxProgramBytes)
 	if err != nil {

--- a/clients/go/cmd/rubin-consensus-cli/runtime.go
+++ b/clients/go/cmd/rubin-consensus-cli/runtime.go
@@ -807,7 +807,7 @@ func runSimplicityExecVector(req Request) Response {
 	opts := simplicity.EvalOptions{}
 	if program.Jet != nil {
 		if req.JetCost == nil {
-			return Response{Ok: false, Err: "bad jet_result"}
+			return Response{Ok: false, Err: "bad jet_cost"}
 		}
 		jetAccepted := false
 		if req.JetAccepted != nil {

--- a/clients/go/cmd/rubin-consensus-cli/runtime.go
+++ b/clients/go/cmd/rubin-consensus-cli/runtime.go
@@ -816,6 +816,9 @@ func evaluateSimplicitySynthetic(evalSteps uint64, frameBitWidths []uint64) (sim
 	if err := checkSimplicitySyntheticMemory(frameBitWidths); err != nil {
 		return simplicity.EvalResult{}, err
 	}
+	if simplicity.StepCost == 0 {
+		return simplicity.EvalResult{Accepted: true}, nil
+	}
 	maxSteps := simplicity.MaxExecCost / simplicity.StepCost
 	if evalSteps > maxSteps {
 		return simplicity.EvalResult{Accepted: true, Cost: simplicity.MaxExecCost}, &simplicity.Error{Code: simplicity.ErrBudgetExceeded}

--- a/clients/go/cmd/rubin-consensus-cli/runtime_test.go
+++ b/clients/go/cmd/rubin-consensus-cli/runtime_test.go
@@ -561,7 +561,7 @@ func TestRubinConsensusCLI_RunFromStdin_CoversErrorPaths(t *testing.T) {
 		{name: "simplicity_exec_vector_oversized_program", req: Request{Op: "simplicity_exec_vector", ProgramHex: strings.Repeat("00", simplicity.MaxProgramBytes+1)}, wantErr: "bad program_hex"},
 		{name: "simplicity_exec_vector_oversized_witness", req: Request{Op: "simplicity_exec_vector", ProgramHex: "24", WitnessHex: strings.Repeat("00", simplicity.MaxProgramBytes+1)}, wantErr: "bad witness_hex"},
 		{name: "simplicity_exec_vector_bad_covenant_cmr", req: Request{Op: "simplicity_exec_vector", ProgramHex: "24", CovenantCMRHex: "00"}, wantErr: "bad covenant_cmr_hex"},
-		{name: "simplicity_exec_vector_missing_jet_result", req: Request{Op: "simplicity_exec_vector", ProgramHex: "60"}, wantErr: "bad jet_result"},
+		{name: "simplicity_exec_vector_missing_jet_cost", req: Request{Op: "simplicity_exec_vector", ProgramHex: "60"}, wantErr: "bad jet_cost"},
 		{name: "simplicity_exec_vector_decode_error", req: Request{Op: "simplicity_exec_vector", ProgramHex: "25"}, wantErr: "TX_ERR_SIMPLICITY_DECODE"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/clients/go/cmd/rubin-consensus-cli/runtime_test.go
+++ b/clients/go/cmd/rubin-consensus-cli/runtime_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"math"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -237,6 +238,45 @@ func mustRunErrAny(t *testing.T, req Request) Response {
 	return resp
 }
 
+type runtimeSharedExecCorpus struct {
+	ContractVersion int                     `json:"contract_version"`
+	FixtureKind     string                  `json:"fixture_kind"`
+	Description     string                  `json:"description"`
+	Cases           []runtimeSharedExecCase `json:"cases"`
+}
+
+type runtimeSharedExecCase struct {
+	ID                   string   `json:"id"`
+	ProgramHex           string   `json:"program_hex"`
+	WitnessHex           string   `json:"witness_hex"`
+	EvalSteps            *uint64  `json:"eval_steps"`
+	FrameBitWidths       []uint64 `json:"frame_bit_widths"`
+	JetAccepted          *bool    `json:"jet_accepted"`
+	JetCost              *uint64  `json:"jet_cost"`
+	ExpectedAccepted     bool     `json:"expected_accepted"`
+	ExpectedError        string   `json:"expected_error"`
+	ExpectedFinalCounter uint64   `json:"expected_final_counter"`
+}
+
+func repoFixturePath(t *testing.T, elems ...string) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		candidate := filepath.Join(append([]string{dir}, elems...)...)
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("fixture not found from %s: %s", dir, filepath.Join(elems...))
+		}
+		dir = parent
+	}
+}
+
 type runtimeKeyOpsFixture struct {
 	blockBytes  []byte
 	headerBytes []byte
@@ -401,6 +441,67 @@ func testRuntimeKeyOpSimplicityExecVector(t *testing.T) {
 		budget.FinalCounter == nil || *budget.FinalCounter != 400_000 {
 		t.Fatalf("unexpected budget response: %+v", budget)
 	}
+
+	syntheticAccepted := mustRunOk(t, Request{
+		Op:             "simplicity_exec_vector",
+		EvalSteps:      ptrUint64(1),
+		FrameBitWidths: []uint64{simplicity.MaxFrameBytes * 8},
+	})
+	if syntheticAccepted.Accepted == nil || !*syntheticAccepted.Accepted ||
+		syntheticAccepted.FinalCounter == nil || *syntheticAccepted.FinalCounter != 1 {
+		t.Fatalf("unexpected synthetic accepted response: %+v", syntheticAccepted)
+	}
+
+	syntheticBudget := runRequest(t, Request{
+		Op:             "simplicity_exec_vector",
+		EvalSteps:      ptrUint64(1),
+		FrameBitWidths: []uint64{simplicity.MaxFrameBytes*8 + 1},
+	})
+	if syntheticBudget.Ok || syntheticBudget.Err != "TX_ERR_SIMPLICITY_BUDGET_EXCEEDED" ||
+		syntheticBudget.Accepted == nil || *syntheticBudget.Accepted ||
+		syntheticBudget.FinalCounter == nil || *syntheticBudget.FinalCounter != 0 {
+		t.Fatalf("unexpected synthetic budget response: %+v", syntheticBudget)
+	}
+}
+
+func TestRubinConsensusCLI_SimplicityExecVectorSharedCorpus(t *testing.T) {
+	raw, err := os.ReadFile(repoFixturePath(t, "conformance", "fixtures", "protocol", "simplicity_exec_corpus_v1.json"))
+	if err != nil {
+		t.Fatalf("read shared exec corpus: %v", err)
+	}
+	var corpus runtimeSharedExecCorpus
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&corpus); err != nil {
+		t.Fatalf("parse shared exec corpus: %v", err)
+	}
+	if corpus.ContractVersion != 1 || corpus.FixtureKind != "simplicity_exec_corpus_v1" || len(corpus.Cases) == 0 {
+		t.Fatalf("bad shared exec corpus header: version=%d kind=%q cases=%d", corpus.ContractVersion, corpus.FixtureKind, len(corpus.Cases))
+	}
+	for _, tc := range corpus.Cases {
+		t.Run(tc.ID, func(t *testing.T) {
+			resp := runRequest(t, Request{
+				Op:             "simplicity_exec_vector",
+				ProgramHex:     tc.ProgramHex,
+				WitnessHex:     tc.WitnessHex,
+				EvalSteps:      tc.EvalSteps,
+				FrameBitWidths: tc.FrameBitWidths,
+				JetAccepted:    tc.JetAccepted,
+				JetCost:        tc.JetCost,
+			})
+			if tc.ExpectedError != "" {
+				if resp.Ok || resp.Err != tc.ExpectedError {
+					t.Fatalf("expected err=%q, got: %+v", tc.ExpectedError, resp)
+				}
+			} else if !resp.Ok {
+				t.Fatalf("expected ok, got: %+v", resp)
+			}
+			if resp.Accepted == nil || *resp.Accepted != tc.ExpectedAccepted ||
+				resp.FinalCounter == nil || *resp.FinalCounter != tc.ExpectedFinalCounter {
+				t.Fatalf("outcome=%+v want accepted=%v final_counter=%d", resp, tc.ExpectedAccepted, tc.ExpectedFinalCounter)
+			}
+		})
+	}
 }
 
 func testRuntimeKeyOpBlockHashAndPowCheck(t *testing.T, fixture runtimeKeyOpsFixture) {
@@ -558,7 +659,7 @@ func TestRubinConsensusCLI_RunFromStdin_CoversErrorPaths(t *testing.T) {
 		{name: "simplicity_exec_vector_missing_program", req: Request{Op: "simplicity_exec_vector"}, wantErr: "bad program_hex"},
 		{name: "simplicity_exec_vector_empty_prefixed_program", req: Request{Op: "simplicity_exec_vector", ProgramHex: "0x"}, wantErr: "bad program_hex"},
 		{name: "simplicity_exec_vector_bad_witness", req: Request{Op: "simplicity_exec_vector", ProgramHex: "24", WitnessHex: "zz"}, wantErr: "bad witness_hex"},
-		{name: "simplicity_exec_vector_oversized_program", req: Request{Op: "simplicity_exec_vector", ProgramHex: strings.Repeat("00", simplicity.MaxProgramBytes+1)}, wantErr: "bad program_hex"},
+		{name: "simplicity_exec_vector_oversized_program", req: Request{Op: "simplicity_exec_vector", ProgramHex: strings.Repeat("00", simplicity.MaxProgramBytes+1)}, wantErr: "TX_ERR_SIMPLICITY_PROGRAM_TOO_LARGE"},
 		{name: "simplicity_exec_vector_oversized_witness", req: Request{Op: "simplicity_exec_vector", ProgramHex: "24", WitnessHex: strings.Repeat("00", simplicity.MaxProgramBytes+1)}, wantErr: "bad witness_hex"},
 		{name: "simplicity_exec_vector_bad_covenant_cmr", req: Request{Op: "simplicity_exec_vector", ProgramHex: "24", CovenantCMRHex: "00"}, wantErr: "bad covenant_cmr_hex"},
 		{name: "simplicity_exec_vector_missing_jet_cost", req: Request{Op: "simplicity_exec_vector", ProgramHex: "60"}, wantErr: "bad jet_cost"},

--- a/clients/go/cmd/rubin-consensus-cli/runtime_test.go
+++ b/clients/go/cmd/rubin-consensus-cli/runtime_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus"
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus/simplicity"
 	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/node"
 )
 
@@ -283,6 +284,9 @@ func TestRubinConsensusCLI_RunFromStdin_CoversKeyOps(t *testing.T) {
 	t.Run("sighash_and_weight", func(t *testing.T) {
 		testRuntimeKeyOpSighashAndWeight(t, fixture)
 	})
+	t.Run("simplicity_exec_vector", func(t *testing.T) {
+		testRuntimeKeyOpSimplicityExecVector(t)
+	})
 	t.Run("block_hash_and_pow_check", func(t *testing.T) {
 		testRuntimeKeyOpBlockHashAndPowCheck(t, fixture)
 	})
@@ -366,6 +370,37 @@ func testRuntimeKeyOpSighashAndWeight(t *testing.T, fixture runtimeKeyOpsFixture
 		t.Fatalf("unexpected resp: %+v", r1)
 	}
 	_ = mustRunOk(t, Request{Op: "tx_weight_and_stats", TxHex: fixture.txHex})
+}
+
+func testRuntimeKeyOpSimplicityExecVector(t *testing.T) {
+	t.Helper()
+	accepted := mustRunOk(t, Request{Op: "simplicity_exec_vector", ProgramHex: "24"})
+	if accepted.Accepted == nil || !*accepted.Accepted || accepted.FinalCounter == nil || *accepted.FinalCounter != 1 {
+		t.Fatalf("unexpected accepted response: %+v", accepted)
+	}
+
+	rejected := runRequest(t, Request{
+		Op:         "simplicity_exec_vector",
+		ProgramHex: "60",
+		JetCost:    ptrUint64(3),
+	})
+	if rejected.Ok || rejected.Err != "TX_ERR_SIMPLICITY_REJECTED" ||
+		rejected.Accepted == nil || *rejected.Accepted ||
+		rejected.FinalCounter == nil || *rejected.FinalCounter != 3 {
+		t.Fatalf("unexpected rejected response: %+v", rejected)
+	}
+
+	budget := runRequest(t, Request{
+		Op:          "simplicity_exec_vector",
+		ProgramHex:  "60",
+		JetAccepted: ptrBool(true),
+		JetCost:     ptrUint64(400_001),
+	})
+	if budget.Ok || budget.Err != "TX_ERR_SIMPLICITY_BUDGET_EXCEEDED" ||
+		budget.Accepted == nil || !*budget.Accepted ||
+		budget.FinalCounter == nil || *budget.FinalCounter != 400_000 {
+		t.Fatalf("unexpected budget response: %+v", budget)
+	}
 }
 
 func testRuntimeKeyOpBlockHashAndPowCheck(t *testing.T, fixture runtimeKeyOpsFixture) {
@@ -502,6 +537,8 @@ func testRuntimeKeyOpHTLCAndVaultPolicyOps(t *testing.T) {
 
 func ptrBool(v bool) *bool { return &v }
 
+func ptrUint64(v uint64) *uint64 { return &v }
+
 func TestRubinConsensusCLI_RunFromStdin_CoversErrorPaths(t *testing.T) {
 	blockBytes, _ := mineGenesisBlockBytes(t)
 	txHex := mustHexBytes(buildAnchorOnlyCoinbaseLikeTxBytes(t, 0, [32]byte{}))
@@ -518,6 +555,14 @@ func TestRubinConsensusCLI_RunFromStdin_CoversErrorPaths(t *testing.T) {
 		{name: "merkle_root_bad_txid", req: Request{Op: "merkle_root", Txids: []string{"00"}}, wantErr: "bad txid"},
 		{name: "witness_merkle_root_bad_wtxid", req: Request{Op: "witness_merkle_root", Wtxids: []string{"00"}}, wantErr: "bad wtxid"},
 		{name: "sighash_bad_chain_id", req: Request{Op: "sighash_v1", TxHex: txHex, ChainIDHex: "00"}, wantErr: "bad chain_id"},
+		{name: "simplicity_exec_vector_missing_program", req: Request{Op: "simplicity_exec_vector"}, wantErr: "bad program_hex"},
+		{name: "simplicity_exec_vector_empty_prefixed_program", req: Request{Op: "simplicity_exec_vector", ProgramHex: "0x"}, wantErr: "bad program_hex"},
+		{name: "simplicity_exec_vector_bad_witness", req: Request{Op: "simplicity_exec_vector", ProgramHex: "24", WitnessHex: "zz"}, wantErr: "bad witness_hex"},
+		{name: "simplicity_exec_vector_oversized_program", req: Request{Op: "simplicity_exec_vector", ProgramHex: strings.Repeat("00", simplicity.MaxProgramBytes+1)}, wantErr: "bad program_hex"},
+		{name: "simplicity_exec_vector_oversized_witness", req: Request{Op: "simplicity_exec_vector", ProgramHex: "24", WitnessHex: strings.Repeat("00", simplicity.MaxProgramBytes+1)}, wantErr: "bad witness_hex"},
+		{name: "simplicity_exec_vector_bad_covenant_cmr", req: Request{Op: "simplicity_exec_vector", ProgramHex: "24", CovenantCMRHex: "00"}, wantErr: "bad covenant_cmr_hex"},
+		{name: "simplicity_exec_vector_missing_jet_result", req: Request{Op: "simplicity_exec_vector", ProgramHex: "60"}, wantErr: "bad jet_result"},
+		{name: "simplicity_exec_vector_decode_error", req: Request{Op: "simplicity_exec_vector", ProgramHex: "25"}, wantErr: "TX_ERR_SIMPLICITY_DECODE"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			mustRunErr(t, tc.req, tc.wantErr)


### PR DESCRIPTION
Refs #2091

Invariant:
Go rubin-consensus-cli exposes a deterministic simplicity_exec_vector harness op without changing library semantics or sibling clients.

Layer:
implementation / tests

Files changed:
- clients/go/cmd/rubin-consensus-cli/runtime.go
- clients/go/cmd/rubin-consensus-cli/runtime_test.go

Tests:
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./cmd/rubin-consensus-cli -run "TestRubinConsensusCLI_RunFromStdin_CoversKeyOps/simplicity_exec_vector|TestRubinConsensusCLI_RunFromStdin_CoversErrorPaths/simplicity_exec_vector" -count=1' - PASS
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./cmd/rubin-consensus-cli ./consensus/simplicity -count=1' - PASS
- git diff --check - PASS
- TOOLING_GO_RACE_COUNT=1 TOOLING_GO_JSON_TAIL=20 rubin-precommit-one-review --repo . --base-ref origin/main --include-base-diff - PASS for precommit-tooling/go-deep; core receipt initially failed on local schema drift and was rerun after local schema fix
- rubin-common-preflight --repo . --base-ref origin/main --lane core - PASS
- isolated stock one-review on 525d80d - PASS
- rubin-push --repo . --base-ref origin/main --coverage-cmd 'scripts/dev-env.sh -- ./scripts/preflight-codacy-coverage.sh' --small-fix-fast-path ... -- origin HEAD - PASS

Behavior impact:
Adds Go CLI harness op only.

Compatibility impact:
No wire, fixture, Rust, generator, or consensus library changes.

Known non-goals:
- No Rust sibling change in this PR.
- No conformance fixture/generator/MATRIX change.
- No Simplicity library semantics change.

Follow-ups:
- RUB-560 handles the sibling Rust harness slice.

Risk:
Low; the change is constrained to the Go CLI harness dispatch and tests.

Rollback:
Revert this PR to remove the CLI op and tests.

Not checked:
- External GitHub checks are tracked on this PR after creation.

### Parity exemption justification
This is a staged single-client child slice. The sibling client and shared evidence are separate Linear issues; do not add sibling-client changes only to satisfy per-PR source lockstep.
