### PR TITLE
RUB-498: add Go SimplicityTxContext core construction

### DIFF
--- a/clients/go/consensus/simplicity_covenant.go
+++ b/clients/go/consensus/simplicity_covenant.go
@@ -21,27 +21,36 @@ func validateCoreSimplicityCovenantData(value uint64, covenantData []byte) error
 		return txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_SIMPLICITY value must be > 0")
 	}
 
+	_, _, err := parseCoreSimplicityCovenantData(covenantData)
+	return err
+}
+
+func parseCoreSimplicityCovenantData(covenantData []byte) ([32]byte, []byte, error) {
+	var programCMR [32]byte
 	off := 0
-	if _, err := readBytes(covenantData, &off, 32); err != nil {
-		return txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_SIMPLICITY program_cmr parse failure")
+	cmrBytes, err := readBytes(covenantData, &off, 32)
+	if err != nil {
+		return programCMR, nil, txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_SIMPLICITY program_cmr parse failure")
 	}
+	copy(programCMR[:], cmrBytes)
 
 	stateLenU64, stateLenVarintBytes, err := readCompactSize(covenantData, &off)
 	if err != nil {
-		return txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_SIMPLICITY state_len parse failure")
+		return programCMR, nil, txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_SIMPLICITY state_len parse failure")
 	}
 	if stateLenU64 > MAX_SIMPLICITY_STATE_BYTES {
-		return txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_SIMPLICITY state_len too large")
+		return programCMR, nil, txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_SIMPLICITY state_len too large")
 	}
 	stateLen := int(stateLenU64)
 
-	if _, err := readBytes(covenantData, &off, stateLen); err != nil {
-		return txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_SIMPLICITY state parse failure")
+	state, err := readBytes(covenantData, &off, stateLen)
+	if err != nil {
+		return programCMR, nil, txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_SIMPLICITY state parse failure")
 	}
 	if len(covenantData) != 32+stateLenVarintBytes+stateLen {
-		return txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_SIMPLICITY covenant_data length mismatch")
+		return programCMR, nil, txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_SIMPLICITY covenant_data length mismatch")
 	}
-	return nil
+	return programCMR, append([]byte{}, state...), nil
 }
 
 func validateCoreSimplicityDeploymentActive(height uint64, provider SimplicityDeploymentProvider) error {

--- a/clients/go/consensus/simplicity_covenant.go
+++ b/clients/go/consensus/simplicity_covenant.go
@@ -50,7 +50,7 @@ func parseCoreSimplicityCovenantData(covenantData []byte) ([32]byte, []byte, err
 	if len(covenantData) != 32+stateLenVarintBytes+stateLen {
 		return programCMR, nil, txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_SIMPLICITY covenant_data length mismatch")
 	}
-	return programCMR, append([]byte{}, state...), nil
+	return programCMR, state, nil
 }
 
 func validateCoreSimplicityDeploymentActive(height uint64, provider SimplicityDeploymentProvider) error {

--- a/clients/go/consensus/simplicity_txcontext.go
+++ b/clients/go/consensus/simplicity_txcontext.go
@@ -1,5 +1,7 @@
 package consensus
 
+import "slices"
+
 type SimplicityTxContextBase struct {
 	ChainID     [32]byte
 	TotalIn     Uint128
@@ -56,6 +58,11 @@ func BuildSimplicityTxContext(tx *Tx, resolvedInputs []UtxoEntry, blockHeight ui
 			return nil, txerr(TX_ERR_PARSE, check.message)
 		}
 	}
+	if !slices.ContainsFunc(resolvedInputs, func(entry UtxoEntry) bool {
+		return entry.CovenantType == COV_TYPE_CORE_SIMPLICITY
+	}) {
+		return nil, nil
+	}
 
 	totalIn, err := sumTxContextInputValues(resolvedInputs, u128{})
 	if err != nil {
@@ -83,18 +90,13 @@ func BuildSimplicityTxContext(tx *Tx, resolvedInputs []UtxoEntry, blockHeight ui
 		selfSources: make([]simplicityTxContextSelfSource, len(resolvedInputs)),
 	}
 
-	hasSimplicityInput, err := populateSimplicityTxContextViews(ctx, tx, resolvedInputs)
-	if err != nil {
+	if err := populateSimplicityTxContextViews(ctx, tx, resolvedInputs); err != nil {
 		return nil, err
-	}
-	if !hasSimplicityInput {
-		return nil, nil
 	}
 	return ctx, nil
 }
 
-func populateSimplicityTxContextViews(ctx *SimplicityTxContext, tx *Tx, resolvedInputs []UtxoEntry) (bool, error) {
-	hasSimplicityInput := false
+func populateSimplicityTxContextViews(ctx *SimplicityTxContext, tx *Tx, resolvedInputs []UtxoEntry) error {
 	for i, entry := range resolvedInputs {
 		ctx.inputViews[i] = SimplicityTxContextIOView{
 			Value:        entry.Value,
@@ -105,15 +107,14 @@ func populateSimplicityTxContextViews(ctx *SimplicityTxContext, tx *Tx, resolved
 		}
 		programCMR, state, err := parseCoreSimplicityCovenantData(entry.CovenantData)
 		if err != nil {
-			return false, err
+			return err
 		}
 		ctx.selfSources[i] = simplicityTxContextSelfSource{
 			programCMR:       programCMR,
-			state:            state,
+			state:            append([]byte{}, state...),
 			value:            entry.Value,
 			isCoreSimplicity: true,
 		}
-		hasSimplicityInput = true
 	}
 
 	for i, out := range tx.Outputs {
@@ -122,7 +123,7 @@ func populateSimplicityTxContextViews(ctx *SimplicityTxContext, tx *Tx, resolved
 			CovenantType: out.CovenantType,
 		}
 	}
-	return hasSimplicityInput, nil
+	return nil
 }
 
 func (c *SimplicityTxContext) InputViews() []SimplicityTxContextIOView {

--- a/clients/go/consensus/simplicity_txcontext.go
+++ b/clients/go/consensus/simplicity_txcontext.go
@@ -1,0 +1,152 @@
+package consensus
+
+type SimplicityTxContextBase struct {
+	ChainID     [32]byte
+	TotalIn     Uint128
+	TotalOut    Uint128
+	Height      uint64
+	TxNonce     uint64
+	Locktime    uint32
+	InputCount  uint16
+	OutputCount uint16
+	TxKind      uint8
+}
+
+type SimplicityTxContextIOView struct {
+	Value        uint64
+	CovenantType uint16
+}
+
+type SimplicityTxContextSelfView struct {
+	SelfProgramCMR [32]byte
+	Digest32       [32]byte
+	SelfState      []byte
+	SelfValue      uint64
+	InputIndex     uint16
+	SighashType    uint8
+}
+
+type simplicityTxContextSelfSource struct {
+	programCMR       [32]byte
+	state            []byte
+	value            uint64
+	isCoreSimplicity bool
+}
+
+type SimplicityTxContext struct {
+	Base        SimplicityTxContextBase
+	inputViews  []SimplicityTxContextIOView
+	outputViews []SimplicityTxContextIOView
+	selfSources []simplicityTxContextSelfSource
+}
+
+func BuildSimplicityTxContext(tx *Tx, resolvedInputs []UtxoEntry, blockHeight uint64, chainID [32]byte) (*SimplicityTxContext, error) {
+	if tx == nil {
+		return nil, txerr(TX_ERR_PARSE, "nil tx")
+	}
+	for _, check := range []struct {
+		invalid bool
+		message string
+	}{
+		{len(tx.Inputs) != len(resolvedInputs), "simplicity txcontext resolved input count mismatch"},
+		{len(tx.Inputs) > MAX_TX_INPUTS, "simplicity txcontext input_count overflow"},
+		{len(tx.Outputs) > MAX_TX_OUTPUTS, "simplicity txcontext output_count overflow"},
+	} {
+		if check.invalid {
+			return nil, txerr(TX_ERR_PARSE, check.message)
+		}
+	}
+
+	totalIn, err := sumTxContextInputValues(resolvedInputs, u128{})
+	if err != nil {
+		return nil, err
+	}
+	totalOut, err := sumTxContextOutputValues(tx.Outputs, u128{})
+	if err != nil {
+		return nil, err
+	}
+
+	ctx := &SimplicityTxContext{
+		Base: SimplicityTxContextBase{
+			ChainID:     chainID,
+			Height:      blockHeight,
+			TxKind:      tx.TxKind,
+			TxNonce:     tx.TxNonce,
+			Locktime:    tx.Locktime,
+			InputCount:  uint16(len(tx.Inputs)),
+			OutputCount: uint16(len(tx.Outputs)),
+			TotalIn:     uint128FromInternal(totalIn),
+			TotalOut:    uint128FromInternal(totalOut),
+		},
+		inputViews:  make([]SimplicityTxContextIOView, len(resolvedInputs)),
+		outputViews: make([]SimplicityTxContextIOView, len(tx.Outputs)),
+		selfSources: make([]simplicityTxContextSelfSource, len(resolvedInputs)),
+	}
+
+	hasSimplicityInput, err := populateSimplicityTxContextViews(ctx, tx, resolvedInputs)
+	if err != nil {
+		return nil, err
+	}
+	if !hasSimplicityInput {
+		return nil, nil
+	}
+	return ctx, nil
+}
+
+func populateSimplicityTxContextViews(ctx *SimplicityTxContext, tx *Tx, resolvedInputs []UtxoEntry) (bool, error) {
+	hasSimplicityInput := false
+	for i, entry := range resolvedInputs {
+		ctx.inputViews[i] = SimplicityTxContextIOView{
+			Value:        entry.Value,
+			CovenantType: entry.CovenantType,
+		}
+		if entry.CovenantType != COV_TYPE_CORE_SIMPLICITY {
+			continue
+		}
+		programCMR, state, err := parseCoreSimplicityCovenantData(entry.CovenantData)
+		if err != nil {
+			return false, err
+		}
+		ctx.selfSources[i] = simplicityTxContextSelfSource{
+			programCMR:       programCMR,
+			state:            state,
+			value:            entry.Value,
+			isCoreSimplicity: true,
+		}
+		hasSimplicityInput = true
+	}
+
+	for i, out := range tx.Outputs {
+		ctx.outputViews[i] = SimplicityTxContextIOView{
+			Value:        out.Value,
+			CovenantType: out.CovenantType,
+		}
+	}
+	return hasSimplicityInput, nil
+}
+
+func (c *SimplicityTxContext) InputViews() []SimplicityTxContextIOView {
+	return append([]SimplicityTxContextIOView{}, c.inputViews...)
+}
+
+func (c *SimplicityTxContext) OutputViews() []SimplicityTxContextIOView {
+	return append([]SimplicityTxContextIOView{}, c.outputViews...)
+}
+
+func (c *SimplicityTxContext) SelfView(inputIndex uint16, sighashType uint8, digest32 [32]byte) (SimplicityTxContextSelfView, error) {
+	if int(inputIndex) >= len(c.selfSources) {
+		return SimplicityTxContextSelfView{}, txerr(TX_ERR_PARSE, "simplicity txcontext self input index out of range")
+	}
+	source := c.selfSources[inputIndex]
+	if !source.isCoreSimplicity {
+		return SimplicityTxContextSelfView{}, txerr(TX_ERR_COVENANT_TYPE_INVALID, "simplicity txcontext self input is not CORE_SIMPLICITY")
+	}
+	return SimplicityTxContextSelfView{
+		InputIndex:     inputIndex,
+		SelfValue:      source.value,
+		SelfState:      append([]byte{}, source.state...),
+		SelfProgramCMR: source.programCMR,
+		SighashType:    sighashType,
+		Digest32:       digest32,
+	}, nil
+}

--- a/clients/go/consensus/simplicity_txcontext_test.go
+++ b/clients/go/consensus/simplicity_txcontext_test.go
@@ -1,0 +1,170 @@
+package consensus
+
+import "testing"
+
+func makeCoreSimplicityCovenantData(programCMR [32]byte, state []byte) []byte {
+	out := make([]byte, 0, 32+1+len(state))
+	out = append(out, programCMR[:]...)
+	out = AppendCompactSize(out, uint64(len(state)))
+	out = append(out, state...)
+	return out
+}
+
+func TestBuildSimplicityTxContext_NoCoreSimplicityInputReturnsNil(t *testing.T) {
+	tx := &Tx{
+		Version:  TX_WIRE_VERSION,
+		TxNonce:  1,
+		Locktime: 9,
+		Inputs:   []TxInput{{PrevVout: 0}},
+		Outputs:  []TxOutput{{Value: 5, CovenantType: COV_TYPE_P2PK}},
+	}
+	resolved := []UtxoEntry{{Value: 10, CovenantType: COV_TYPE_P2PK}}
+
+	ctx, err := BuildSimplicityTxContext(tx, resolved, 77, [32]byte{0x01})
+	if err != nil {
+		t.Fatalf("BuildSimplicityTxContext: %v", err)
+	}
+	if ctx != nil {
+		t.Fatalf("expected nil context, got %#v", ctx)
+	}
+
+	if _, err := BuildSimplicityTxContext(nil, nil, 1, [32]byte{}); err == nil || mustTxErrCode(t, err) != TX_ERR_PARSE {
+		t.Fatalf("expected nil tx parse error, got %v", err)
+	}
+	tx.Inputs = append(tx.Inputs, TxInput{PrevVout: 1})
+	if _, err := BuildSimplicityTxContext(tx, resolved, 1, [32]byte{}); err == nil || mustTxErrCode(t, err) != TX_ERR_PARSE {
+		t.Fatalf("expected resolved input mismatch, got %v", err)
+	}
+}
+
+func TestBuildSimplicityTxContext_BaseInputsOutputsAndSelf(t *testing.T) {
+	chainID := [32]byte{0: 0x11, 31: 0xee}
+	cmr := [32]byte{0: 0xaa, 31: 0xbb}
+	digest := [32]byte{0: 0x42}
+	state := []byte{0x01, 0x02, 0x03}
+	simplicityCovenant := makeCoreSimplicityCovenantData(cmr, state)
+
+	tx := &Tx{
+		Version:  TX_WIRE_VERSION,
+		TxKind:   0x02,
+		TxNonce:  99,
+		Locktime: 12345,
+		Inputs:   []TxInput{{PrevVout: 0}, {PrevVout: 1}},
+		Outputs: []TxOutput{
+			{Value: ^uint64(0), CovenantType: COV_TYPE_CORE_SIMPLICITY, CovenantData: makeCoreSimplicityCovenantData(cmr, nil)},
+			{Value: 1, CovenantType: COV_TYPE_P2PK},
+		},
+	}
+	resolved := []UtxoEntry{
+		{Value: ^uint64(0), CovenantType: COV_TYPE_CORE_SIMPLICITY, CovenantData: simplicityCovenant},
+		{Value: 1, CovenantType: COV_TYPE_P2PK},
+	}
+
+	ctx, err := BuildSimplicityTxContext(tx, resolved, 700, chainID)
+	if err != nil {
+		t.Fatalf("BuildSimplicityTxContext: %v", err)
+	}
+	if ctx == nil {
+		t.Fatalf("expected context")
+	}
+	if got := ctx.Base.ChainID; got != chainID {
+		t.Fatalf("chain_id=%x want %x", got, chainID)
+	}
+	if ctx.Base.Height != 700 || ctx.Base.TxKind != 0x02 || ctx.Base.TxNonce != 99 || ctx.Base.Locktime != 12345 {
+		t.Fatalf("base scalar fields mismatch: %+v", ctx.Base)
+	}
+	if ctx.Base.InputCount != 2 || ctx.Base.OutputCount != 2 {
+		t.Fatalf("counts=%d/%d want 2/2", ctx.Base.InputCount, ctx.Base.OutputCount)
+	}
+	if got := ctx.Base.TotalIn; got != (Uint128{Lo: 0, Hi: 1}) {
+		t.Fatalf("total_in=%+v want hi carry", got)
+	}
+	if got := ctx.Base.TotalOut; got != (Uint128{Lo: 0, Hi: 1}) {
+		t.Fatalf("total_out=%+v want hi carry", got)
+	}
+
+	inputs := ctx.InputViews()
+	if len(inputs) != 2 || inputs[0] != (SimplicityTxContextIOView{Value: ^uint64(0), CovenantType: COV_TYPE_CORE_SIMPLICITY}) {
+		t.Fatalf("input views=%+v", inputs)
+	}
+	outputs := ctx.OutputViews()
+	if len(outputs) != 2 || outputs[1] != (SimplicityTxContextIOView{Value: 1, CovenantType: COV_TYPE_P2PK}) {
+		t.Fatalf("output views=%+v", outputs)
+	}
+
+	self, err := ctx.SelfView(0, SIGHASH_ALL, digest)
+	if err != nil {
+		t.Fatalf("SelfView: %v", err)
+	}
+	if self.InputIndex != 0 || self.SelfValue != ^uint64(0) || self.SighashType != SIGHASH_ALL {
+		t.Fatalf("self scalar fields mismatch: %+v", self)
+	}
+	if self.SelfProgramCMR != cmr || self.Digest32 != digest {
+		t.Fatalf("self cmr/digest mismatch")
+	}
+	if string(self.SelfState) != string(state) {
+		t.Fatalf("self state=%x want %x", self.SelfState, state)
+	}
+
+	if _, err := ctx.SelfView(1, SIGHASH_ALL, [32]byte{}); err == nil || mustTxErrCode(t, err) != TX_ERR_COVENANT_TYPE_INVALID {
+		t.Fatalf("expected non-CORE_SIMPLICITY self error, got %v", err)
+	}
+	if _, err := ctx.SelfView(2, SIGHASH_ALL, [32]byte{}); err == nil || mustTxErrCode(t, err) != TX_ERR_PARSE {
+		t.Fatalf("expected out-of-range self error, got %v", err)
+	}
+}
+
+func TestBuildSimplicityTxContext_EmptyStateIsNonNilAndAliasingSafe(t *testing.T) {
+	cmr := [32]byte{0: 0x51}
+	covenantData := makeCoreSimplicityCovenantData(cmr, nil)
+	tx := &Tx{Version: TX_WIRE_VERSION, Inputs: []TxInput{{PrevVout: 0}}}
+	resolved := []UtxoEntry{{Value: 1, CovenantType: COV_TYPE_CORE_SIMPLICITY, CovenantData: covenantData}}
+
+	ctx, err := BuildSimplicityTxContext(tx, resolved, 1, [32]byte{})
+	if err != nil {
+		t.Fatalf("BuildSimplicityTxContext: %v", err)
+	}
+	if ctx == nil {
+		t.Fatalf("expected context")
+	}
+
+	covenantData[0] = 0xff
+	self, err := ctx.SelfView(0, SIGHASH_ALL, [32]byte{})
+	if err != nil {
+		t.Fatalf("SelfView: %v", err)
+	}
+	if self.SelfProgramCMR != cmr {
+		t.Fatalf("self program CMR aliases source covenant data")
+	}
+	if self.SelfState == nil {
+		t.Fatalf("empty self_state must be non-nil")
+	}
+	if len(self.SelfState) != 0 {
+		t.Fatalf("empty self_state len=%d want 0", len(self.SelfState))
+	}
+
+	self.SelfState = append(self.SelfState, 0xaa)
+	selfAgain, err := ctx.SelfView(0, SIGHASH_ALL, [32]byte{})
+	if err != nil {
+		t.Fatalf("SelfView again: %v", err)
+	}
+	if len(selfAgain.SelfState) != 0 {
+		t.Fatalf("self_state accessor must return a fresh copy, got %x", selfAgain.SelfState)
+	}
+
+	inputs := ctx.InputViews()
+	inputs[0].Value = 99
+	if got := ctx.InputViews()[0].Value; got != 1 {
+		t.Fatalf("input views must return a fresh copy, got value %d", got)
+	}
+}
+
+func TestBuildSimplicityTxContext_MalformedSelfCovenantFailsClosed(t *testing.T) {
+	tx := &Tx{Version: TX_WIRE_VERSION, Inputs: []TxInput{{PrevVout: 0}}}
+	resolved := []UtxoEntry{{Value: 1, CovenantType: COV_TYPE_CORE_SIMPLICITY, CovenantData: []byte{0x01}}}
+
+	_, err := BuildSimplicityTxContext(tx, resolved, 1, [32]byte{})
+	if err == nil || mustTxErrCode(t, err) != TX_ERR_COVENANT_TYPE_INVALID {
+		t.Fatalf("expected malformed CORE_SIMPLICITY covenant error, got %v", err)
+	}
+}

--- a/clients/go/consensus/simplicity_txcontext_test.go
+++ b/clients/go/consensus/simplicity_txcontext_test.go
@@ -67,6 +67,7 @@ func TestBuildSimplicityTxContext_BaseInputsOutputsAndSelf(t *testing.T) {
 	if ctx == nil {
 		t.Fatalf("expected context")
 	}
+	simplicityCovenant[len(simplicityCovenant)-1] = 0xff
 	if got := ctx.Base.ChainID; got != chainID {
 		t.Fatalf("chain_id=%x want %x", got, chainID)
 	}


### PR DESCRIPTION
Invariant:
Go SimplicityTxContext core construction is a pure function of the transaction, resolved-input snapshot, block height, and chain ID for the base, IO, and self views.

Layer:
implementation, tests

Files changed:
- clients/go/consensus/simplicity_covenant.go
- clients/go/consensus/simplicity_txcontext.go
- clients/go/consensus/simplicity_txcontext_test.go

Tests:
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./consensus -run SimplicityTxContext' - PASS
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./consensus' - PASS
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go vet ./consensus' - PASS
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./...' - PASS
- git diff --check - PASS
- rubin-common-preflight --lane core with explicit local scope manifest - PASS
- rubin-pattern-self-review-gate --check - PASS
- rubin-one-review-gate --check - PASS
- rubin-push --no-coverage-reason for Go-only RUB-498/Rust deferred scope - PASS
- one isolated stock reviewer - PASS, no findings

Behavior impact:
Adds Go-only context construction data for CORE_SIMPLICITY inputs. Returns nil when no resolved CORE_SIMPLICITY input is present. No Rust implementation or dispatch wiring is included.

Compatibility impact:
New Go implementation surface only; no wire format, Rust, conformance fixture, or consensus activation change.

Known non-goals:
Rust parity, descriptor-hash accessors, group/DA views, spend dispatch, CORE_EXT removal, and cross-transaction visibility.

Follow-ups:
Rust parity remains deferred behind the Linear Rust gate after the Go/docs track completes.

Risk:
Low-to-medium implementation risk in a consensus-adjacent Go helper. Tests cover malformed covenant data, u128 carry, nil-vs-empty state copy, self-view errors, and copy-out IO views.

Rollback:
Revert this commit.

Not checked:
Rust implementation/parity was intentionally not changed because Rust is deferred for this track.

### Parity exemption justification
This issue is a staged single-client child slice. The sibling client and shared evidence are separate Linear issues; do not add sibling-client changes only to satisfy per-PR source lockstep.
