### PR TITLE
RUB-502: add Go descriptor hash accessors

### DIFF
--- a/clients/go/consensus/simplicity/program.go
+++ b/clients/go/consensus/simplicity/program.go
@@ -304,13 +304,26 @@ type meter struct {
 	cost uint64
 }
 
-func (m *meter) charge(cost uint64) error {
-	if m.cost > MaxExecCost || cost > MaxExecCost-m.cost {
-		m.cost = MaxExecCost
-		return &Error{Code: ErrBudgetExceeded}
+// ChargeCost applies the shared Simplicity execution budget cap.
+func ChargeCost(current, cost uint64) (uint64, error) {
+	if current > MaxExecCost || cost > MaxExecCost-current {
+		return MaxExecCost, &Error{Code: ErrBudgetExceeded}
 	}
-	m.cost += cost
-	return nil
+	return current + cost, nil
+}
+
+// DescriptorHashAccessCost returns the in-range descriptor_hash access cost.
+func DescriptorHashAccessCost(descriptorLen uint64) (uint64, error) {
+	if DescriptorHashByteCost != 0 && descriptorLen > (^uint64(0)-DescriptorHashBaseCost)/DescriptorHashByteCost {
+		return MaxExecCost, &Error{Code: ErrBudgetExceeded}
+	}
+	return ChargeCost(0, DescriptorHashBaseCost+DescriptorHashByteCost*descriptorLen)
+}
+
+func (m *meter) charge(cost uint64) error {
+	next, err := ChargeCost(m.cost, cost)
+	m.cost = next
+	return err
 }
 
 func checkMemoryBounds(frameBitWidths []uint64) error {

--- a/clients/go/consensus/simplicity/program_test.go
+++ b/clients/go/consensus/simplicity/program_test.go
@@ -15,6 +15,31 @@ import (
 
 var errSink error
 
+func TestDescriptorHashAccessCostBoundaries(t *testing.T) {
+	got, err := DescriptorHashAccessCost(3)
+	if err != nil || got != DescriptorHashBaseCost+3*DescriptorHashByteCost {
+		t.Fatalf("DescriptorHashAccessCost(3)=%d err=%v", got, err)
+	}
+
+	maxLen := (MaxExecCost - DescriptorHashBaseCost) / DescriptorHashByteCost
+	got, err = DescriptorHashAccessCost(maxLen)
+	if err != nil || got != MaxExecCost {
+		t.Fatalf("DescriptorHashAccessCost(maxLen)=%d err=%v want %d", got, err, MaxExecCost)
+	}
+
+	got, err = DescriptorHashAccessCost(maxLen + 1)
+	assertErrorCode(t, err, ErrBudgetExceeded)
+	if got != MaxExecCost {
+		t.Fatalf("over-budget cost=%d want %d", got, MaxExecCost)
+	}
+
+	got, err = DescriptorHashAccessCost(^uint64(0))
+	assertErrorCode(t, err, ErrBudgetExceeded)
+	if got != MaxExecCost {
+		t.Fatalf("overflow cost=%d want %d", got, MaxExecCost)
+	}
+}
+
 func TestDecodeVectors(t *testing.T) {
 	tests := []struct {
 		id        string

--- a/clients/go/consensus/simplicity_txcontext.go
+++ b/clients/go/consensus/simplicity_txcontext.go
@@ -314,8 +314,8 @@ func (c *SimplicityTxContext) descriptorHash(sources []simplicityTxContextDescri
 		}
 		return SimplicityTxContextDescriptorHashResult{}, nil
 	}
-	desc := OutputDescriptorBytes(sources[index].covenantType, sources[index].covenantData)
-	cost, err := simplicity.DescriptorHashAccessCost(uint64(len(desc)))
+	source := sources[index]
+	cost, err := simplicity.DescriptorHashAccessCost(descriptorSourceLen(source))
 	if err != nil {
 		meter.cost = simplicity.MaxExecCost
 		return SimplicityTxContextDescriptorHashResult{}, err
@@ -323,7 +323,13 @@ func (c *SimplicityTxContext) descriptorHash(sources []simplicityTxContextDescri
 	if err := meter.charge(cost); err != nil {
 		return SimplicityTxContextDescriptorHashResult{}, err
 	}
+	desc := OutputDescriptorBytes(source.covenantType, source.covenantData)
 	return SimplicityTxContextDescriptorHashResult{Hash: sha3_256(desc), Present: true}, nil
+}
+
+func descriptorSourceLen(source simplicityTxContextDescriptorSource) uint64 {
+	dataLen := uint64(len(source.covenantData))
+	return 2 + compactSizeLen(dataLen) + dataLen
 }
 
 func (m *SimplicityTxContextMeter) charge(cost uint64) error {

--- a/clients/go/consensus/simplicity_txcontext.go
+++ b/clients/go/consensus/simplicity_txcontext.go
@@ -1,6 +1,10 @@
 package consensus
 
-import "slices"
+import (
+	"slices"
+
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus/simplicity"
+)
 
 type SimplicityTxContextBase struct {
 	ChainID     [32]byte
@@ -17,6 +21,19 @@ type SimplicityTxContextBase struct {
 type SimplicityTxContextIOView struct {
 	Value        uint64
 	CovenantType uint16
+}
+
+type SimplicityTxContextDescriptorHashResult struct {
+	Hash    [32]byte
+	Present bool
+}
+
+type SimplicityTxContextMeter struct {
+	cost uint64
+}
+
+func (m *SimplicityTxContextMeter) Cost() uint64 {
+	return m.cost
 }
 
 type SimplicityTxContextSelfView struct {
@@ -76,14 +93,21 @@ type simplicityTxContextSelfSource struct {
 	isCoreSimplicity bool
 }
 
+type simplicityTxContextDescriptorSource struct {
+	covenantData []byte
+	covenantType uint16
+}
+
 type SimplicityTxContext struct {
-	Base         SimplicityTxContextBase
-	inputViews   []SimplicityTxContextIOView
-	outputViews  []SimplicityTxContextIOView
-	selfSources  []simplicityTxContextSelfSource
-	groupInputs  map[[32]byte][]SimplicityTxContextGroupEntry
-	groupOutputs map[[32]byte][]SimplicityTxContextGroupEntry
-	daView       SimplicityTxContextDAView
+	Base              SimplicityTxContextBase
+	inputViews        []SimplicityTxContextIOView
+	outputViews       []SimplicityTxContextIOView
+	inputDescriptors  []simplicityTxContextDescriptorSource
+	outputDescriptors []simplicityTxContextDescriptorSource
+	selfSources       []simplicityTxContextSelfSource
+	groupInputs       map[[32]byte][]SimplicityTxContextGroupEntry
+	groupOutputs      map[[32]byte][]SimplicityTxContextGroupEntry
+	daView            SimplicityTxContextDAView
 }
 
 func BuildSimplicityTxContext(tx *Tx, resolvedInputs []UtxoEntry, blockHeight uint64, chainID [32]byte) (*SimplicityTxContext, error) {
@@ -129,9 +153,11 @@ func BuildSimplicityTxContext(tx *Tx, resolvedInputs []UtxoEntry, blockHeight ui
 			TotalIn:     uint128FromInternal(totalIn),
 			TotalOut:    uint128FromInternal(totalOut),
 		},
-		inputViews:  make([]SimplicityTxContextIOView, len(resolvedInputs)),
-		outputViews: make([]SimplicityTxContextIOView, len(tx.Outputs)),
-		selfSources: make([]simplicityTxContextSelfSource, len(resolvedInputs)),
+		inputViews:        make([]SimplicityTxContextIOView, len(resolvedInputs)),
+		outputViews:       make([]SimplicityTxContextIOView, len(tx.Outputs)),
+		inputDescriptors:  make([]simplicityTxContextDescriptorSource, len(resolvedInputs)),
+		outputDescriptors: make([]simplicityTxContextDescriptorSource, len(tx.Outputs)),
+		selfSources:       make([]simplicityTxContextSelfSource, len(resolvedInputs)),
 	}
 
 	if err := populateSimplicityTxContextViews(ctx, tx, resolvedInputs); err != nil {
@@ -143,10 +169,26 @@ func BuildSimplicityTxContext(tx *Tx, resolvedInputs []UtxoEntry, blockHeight ui
 func populateSimplicityTxContextViews(ctx *SimplicityTxContext, tx *Tx, resolvedInputs []UtxoEntry) error {
 	ctx.groupInputs, ctx.groupOutputs = make(map[[32]byte][]SimplicityTxContextGroupEntry), make(map[[32]byte][]SimplicityTxContextGroupEntry)
 
+	if err := populateSimplicityTxContextInputViews(ctx, resolvedInputs); err != nil {
+		return err
+	}
+	if err := populateSimplicityTxContextOutputViews(ctx, tx.Outputs); err != nil {
+		return err
+	}
+	var err error
+	ctx.daView, err = buildSimplicityTxContextDAView(tx)
+	return err
+}
+
+func populateSimplicityTxContextInputViews(ctx *SimplicityTxContext, resolvedInputs []UtxoEntry) error {
 	for i, entry := range resolvedInputs {
 		ctx.inputViews[i] = SimplicityTxContextIOView{
 			Value:        entry.Value,
 			CovenantType: entry.CovenantType,
+		}
+		ctx.inputDescriptors[i] = simplicityTxContextDescriptorSource{
+			covenantType: entry.CovenantType,
+			covenantData: append([]byte{}, entry.CovenantData...),
 		}
 		if entry.CovenantType != COV_TYPE_CORE_SIMPLICITY {
 			continue
@@ -170,11 +212,18 @@ func populateSimplicityTxContextViews(ctx *SimplicityTxContext, tx *Tx, resolved
 			return txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_SIMPLICITY same-cmr input group exceeds limit")
 		}
 	}
+	return nil
+}
 
-	for i, out := range tx.Outputs {
+func populateSimplicityTxContextOutputViews(ctx *SimplicityTxContext, outputs []TxOutput) error {
+	for i, out := range outputs {
 		ctx.outputViews[i] = SimplicityTxContextIOView{
 			Value:        out.Value,
 			CovenantType: out.CovenantType,
+		}
+		ctx.outputDescriptors[i] = simplicityTxContextDescriptorSource{
+			covenantType: out.CovenantType,
+			covenantData: append([]byte{}, out.CovenantData...),
 		}
 		if out.CovenantType != COV_TYPE_CORE_SIMPLICITY {
 			continue
@@ -188,9 +237,7 @@ func populateSimplicityTxContextViews(ctx *SimplicityTxContext, tx *Tx, resolved
 			State: append([]byte{}, state...),
 		})
 	}
-	var err error
-	ctx.daView, err = buildSimplicityTxContextDAView(tx)
-	return err
+	return nil
 }
 
 func buildSimplicityTxContextDAView(tx *Tx) (SimplicityTxContextDAView, error) {
@@ -247,6 +294,45 @@ func (c *SimplicityTxContext) InputViews() []SimplicityTxContextIOView {
 
 func (c *SimplicityTxContext) OutputViews() []SimplicityTxContextIOView {
 	return append([]SimplicityTxContextIOView{}, c.outputViews...)
+}
+
+func (c *SimplicityTxContext) InputDescriptorHash(inputIndex uint16, meter *SimplicityTxContextMeter) (SimplicityTxContextDescriptorHashResult, error) {
+	return c.descriptorHash(c.inputDescriptors, inputIndex, meter)
+}
+
+func (c *SimplicityTxContext) OutputDescriptorHash(outputIndex uint16, meter *SimplicityTxContextMeter) (SimplicityTxContextDescriptorHashResult, error) {
+	return c.descriptorHash(c.outputDescriptors, outputIndex, meter)
+}
+
+func (c *SimplicityTxContext) descriptorHash(sources []simplicityTxContextDescriptorSource, index uint16, meter *SimplicityTxContextMeter) (SimplicityTxContextDescriptorHashResult, error) {
+	if meter == nil {
+		return SimplicityTxContextDescriptorHashResult{}, txerr(TX_ERR_PARSE, "nil simplicity txcontext meter")
+	}
+	if int(index) >= len(sources) {
+		if err := meter.charge(simplicity.IntrinsicMissCost); err != nil {
+			return SimplicityTxContextDescriptorHashResult{}, err
+		}
+		return SimplicityTxContextDescriptorHashResult{}, nil
+	}
+	desc := OutputDescriptorBytes(sources[index].covenantType, sources[index].covenantData)
+	cost, err := simplicity.DescriptorHashAccessCost(uint64(len(desc)))
+	if err != nil {
+		meter.cost = simplicity.MaxExecCost
+		return SimplicityTxContextDescriptorHashResult{}, err
+	}
+	if err := meter.charge(cost); err != nil {
+		return SimplicityTxContextDescriptorHashResult{}, err
+	}
+	return SimplicityTxContextDescriptorHashResult{Hash: sha3_256(desc), Present: true}, nil
+}
+
+func (m *SimplicityTxContextMeter) charge(cost uint64) error {
+	if m == nil {
+		return txerr(TX_ERR_PARSE, "nil simplicity txcontext meter")
+	}
+	next, err := simplicity.ChargeCost(m.cost, cost)
+	m.cost = next
+	return err
 }
 
 func (c *SimplicityTxContext) SameCMRView(inputIndex uint16) (SimplicityTxContextSameCMRView, error) {

--- a/clients/go/consensus/simplicity_txcontext_test.go
+++ b/clients/go/consensus/simplicity_txcontext_test.go
@@ -3,6 +3,8 @@ package consensus
 import (
 	"reflect"
 	"testing"
+
+	"github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus/simplicity"
 )
 
 func makeCoreSimplicityCovenantData(programCMR [32]byte, state []byte) []byte {
@@ -204,12 +206,133 @@ func TestBuildSimplicityTxContext_InvalidCoreSimplicityOutputFailsClosed(t *test
 	assertTxErrCodeMsg(t, err, TX_ERR_COVENANT_TYPE_INVALID, "CORE_SIMPLICITY value must be > 0")
 }
 
+func TestSimplicityTxContextDescriptorHashAccessors(t *testing.T) {
+	cmr := [32]byte{0: 0xda}
+	inputData := []byte{0x01, 0xaa, 0xbb}
+	outputData := []byte{0x01, 0xcc, 0xdd}
+	tx := &Tx{
+		Version: TX_WIRE_VERSION,
+		Inputs:  []TxInput{{PrevVout: 0}, {PrevVout: 1}},
+		Outputs: []TxOutput{
+			{Value: 3, CovenantType: COV_TYPE_P2PK, CovenantData: outputData},
+		},
+	}
+	resolved := []UtxoEntry{
+		{Value: 1, CovenantType: COV_TYPE_CORE_SIMPLICITY, CovenantData: makeCoreSimplicityCovenantData(cmr, nil)},
+		{Value: 2, CovenantType: COV_TYPE_P2PK, CovenantData: inputData},
+	}
+	ctx, err := BuildSimplicityTxContext(tx, resolved, 1, [32]byte{})
+	if err != nil {
+		t.Fatalf("BuildSimplicityTxContext: %v", err)
+	}
+	inputData[0], outputData[0] = 0xff, 0xff
+
+	inputDesc := OutputDescriptorBytes(COV_TYPE_P2PK, []byte{0x01, 0xaa, 0xbb})
+	inputCost := simplicity.DescriptorHashBaseCost + uint64(len(inputDesc))*simplicity.DescriptorHashByteCost
+	wantInputHash := sha3_256(inputDesc)
+	var meter SimplicityTxContextMeter
+	for i := 1; i <= 2; i++ {
+		got, err := ctx.InputDescriptorHash(1, &meter)
+		if err != nil {
+			t.Fatalf("InputDescriptorHash access %d: %v", i, err)
+		}
+		if !got.Present || got.Hash != wantInputHash {
+			t.Fatalf("input descriptor hash access %d = %+v want %x", i, got, wantInputHash)
+		}
+		if want := uint64(i) * inputCost; meter.Cost() != want {
+			t.Fatalf("cost after input access %d = %d want %d", i, meter.Cost(), want)
+		}
+	}
+
+	outputDesc := OutputDescriptorBytes(COV_TYPE_P2PK, []byte{0x01, 0xcc, 0xdd})
+	outputCost := simplicity.DescriptorHashBaseCost + uint64(len(outputDesc))*simplicity.DescriptorHashByteCost
+	got, err := ctx.OutputDescriptorHash(0, &meter)
+	if err != nil {
+		t.Fatalf("OutputDescriptorHash: %v", err)
+	}
+	if !got.Present || got.Hash != sha3_256(outputDesc) {
+		t.Fatalf("output descriptor hash = %+v", got)
+	}
+	if want := 2*inputCost + outputCost; meter.Cost() != want {
+		t.Fatalf("cost after output access = %d want %d", meter.Cost(), want)
+	}
+}
+
+func TestSimplicityTxContextDescriptorHashMissAndBudgetCross(t *testing.T) {
+	cmr := [32]byte{0: 0xdb}
+	tx := &Tx{Version: TX_WIRE_VERSION, Inputs: []TxInput{{PrevVout: 0}}}
+	resolved := []UtxoEntry{{Value: 1, CovenantType: COV_TYPE_CORE_SIMPLICITY, CovenantData: makeCoreSimplicityCovenantData(cmr, nil)}}
+	ctx, err := BuildSimplicityTxContext(tx, resolved, 1, [32]byte{})
+	if err != nil {
+		t.Fatalf("BuildSimplicityTxContext: %v", err)
+	}
+
+	var missMeter SimplicityTxContextMeter
+	miss, err := ctx.InputDescriptorHash(1, &missMeter)
+	if err != nil {
+		t.Fatalf("InputDescriptorHash miss: %v", err)
+	}
+	if miss.Present || miss.Hash != ([32]byte{}) || missMeter.Cost() != simplicity.IntrinsicMissCost {
+		t.Fatalf("miss result=%+v cost=%d", miss, missMeter.Cost())
+	}
+
+	desc := OutputDescriptorBytes(COV_TYPE_CORE_SIMPLICITY, makeCoreSimplicityCovenantData(cmr, nil))
+	cost := simplicity.DescriptorHashBaseCost + uint64(len(desc))*simplicity.DescriptorHashByteCost
+	over := SimplicityTxContextMeter{cost: simplicity.MaxExecCost - cost + 1}
+	got, err := ctx.InputDescriptorHash(0, &over)
+	assertSimplicityErrCode(t, err, simplicity.ErrBudgetExceeded)
+	if got.Present || got.Hash != ([32]byte{}) || over.Cost() != simplicity.MaxExecCost {
+		t.Fatalf("budget-cross result=%+v cost=%d", got, over.Cost())
+	}
+}
+
+func TestSimplicityTxContextDescriptorHashErrorBranches(t *testing.T) {
+	cmr := [32]byte{0: 0xdc}
+	tx := &Tx{Version: TX_WIRE_VERSION, Inputs: []TxInput{{PrevVout: 0}}}
+	resolved := []UtxoEntry{{Value: 1, CovenantType: COV_TYPE_CORE_SIMPLICITY, CovenantData: makeCoreSimplicityCovenantData(cmr, nil)}}
+	ctx, err := BuildSimplicityTxContext(tx, resolved, 1, [32]byte{})
+	if err != nil {
+		t.Fatalf("BuildSimplicityTxContext: %v", err)
+	}
+
+	got, err := ctx.InputDescriptorHash(0, nil)
+	if err == nil || mustTxErrCode(t, err) != TX_ERR_PARSE || got != (SimplicityTxContextDescriptorHashResult{}) {
+		t.Fatalf("nil meter result=%+v err=%v", got, err)
+	}
+
+	missOver := SimplicityTxContextMeter{cost: simplicity.MaxExecCost}
+	got, err = ctx.InputDescriptorHash(1, &missOver)
+	assertSimplicityErrCode(t, err, simplicity.ErrBudgetExceeded)
+	if got != (SimplicityTxContextDescriptorHashResult{}) || missOver.Cost() != simplicity.MaxExecCost {
+		t.Fatalf("miss over-budget result=%+v cost=%d", got, missOver.Cost())
+	}
+
+	oversize := &SimplicityTxContext{inputDescriptors: []simplicityTxContextDescriptorSource{{
+		covenantType: COV_TYPE_P2PK,
+		covenantData: make([]byte, int(simplicity.MaxExecCost)),
+	}}}
+	var meter SimplicityTxContextMeter
+	got, err = oversize.InputDescriptorHash(0, &meter)
+	assertSimplicityErrCode(t, err, simplicity.ErrBudgetExceeded)
+	if got != (SimplicityTxContextDescriptorHashResult{}) || meter.Cost() != simplicity.MaxExecCost {
+		t.Fatalf("oversize descriptor result=%+v cost=%d", got, meter.Cost())
+	}
+}
+
 func isZeroSimplicitySelfView(view SimplicityTxContextSelfView) bool {
 	return reflect.DeepEqual(view, SimplicityTxContextSelfView{})
 }
 
 func isZeroSimplicitySameCMRView(view SimplicityTxContextSameCMRView) bool {
 	return reflect.DeepEqual(view, SimplicityTxContextSameCMRView{})
+}
+
+func assertSimplicityErrCode(t *testing.T, err error, want simplicity.ErrorCode) {
+	t.Helper()
+	got, ok := err.(*simplicity.Error)
+	if !ok || got.Code != want {
+		t.Fatalf("simplicity err=%v want %s", err, want)
+	}
 }
 
 func TestBuildSimplicityTxContext_SameCMRInputCap(t *testing.T) {


### PR DESCRIPTION
Closes #2033.

Invariant:
Every Go Simplicity tx-context input/output descriptor_hash access charges DescriptorHashBaseCost + DescriptorHashByteCost * len(OutputDescriptorBytes(i)) for every in-range access and returns SHA3-256 of the canonical output descriptor bytes.

Layer:
Go consensus implementation and tests.

Files changed:
- clients/go/consensus/simplicity/program.go
- clients/go/consensus/simplicity/program_test.go
- clients/go/consensus/simplicity_txcontext.go
- clients/go/consensus/simplicity_txcontext_test.go

Tests:
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -count=1 ./consensus ./consensus/simplicity -run "TestSimplicityTxContextDescriptorHash|TestDescriptorHashAccessCostBoundaries"'
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -count=1 ./consensus ./consensus/simplicity'
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go vet ./consensus ./consensus/simplicity'
- git diff --check
- rubin-pattern-self-review-gate --prepare --repo . --base-ref origin/main
- rubin-push --repo . --base-ref origin/main --coverage-cmd 'scripts/dev-env.sh -- ./scripts/preflight-codacy-coverage.sh' -- origin HEAD

Coverage:
- local coverage preflight: PASS
- base: 93.08% (30558/32829)
- head: 93.09% (30620/32892)
- variation: +0.01%
- diff coverage: 97.33% (73/75)

Behavior impact:
Go tx-context descriptor_hash callers can access canonical input/output descriptor hashes with per-access metering, repeated access charging, miss cost, nil-meter parse errors, overflow checks, and budget saturation.

Compatibility impact:
No wire format, fixture, schema, Rust, or dispatch change.

Known non-goals:
- Rust parity implementation.
- Simplicity dispatch/evaluator wiring.
- Conformance fixture updates.
- UTXO-entry descriptor hash caching.
- CORE_EXT behavior changes.

Follow-ups:
- Rust parity remains deferred to the separate Rust parity track after the Go track is complete.

Risk:
Consensus-adjacent metering helper surface; mitigated by targeted Go tests, local preflight, pattern self-review, one isolated stock review, and rubin-push.

Rollback:
Revert the descriptor_hash accessor commit.

Not checked:
- PR CI status before opening the PR.

### Parity exemption justification
This issue is a staged single-client Go child slice. The sibling Rust client and shared evidence are separate deferred Rust parity track work; do not add sibling-client changes only to satisfy per-PR source lockstep.