### PR TITLE
[RUB-504] Gate Go Simplicity sequential spends

### DIFF
--- a/clients/go/consensus/connect_block_parallel_precompute.go
+++ b/clients/go/consensus/connect_block_parallel_precompute.go
@@ -204,8 +204,8 @@ func resolvePrecomputeInput(
 	blockHeight uint64,
 ) (UtxoEntry, Outpoint, int, bool, error) {
 	var zeroTxid [32]byte
-	if in.PrevVout == 0xffff_ffff && in.PrevTxid == zeroTxid {
-		return UtxoEntry{}, Outpoint{}, 0, false, txerr(TX_ERR_PARSE, "coinbase prevout encoding forbidden in non-coinbase")
+	if err := validateNonCoinbaseInputEncoding(in, zeroTxid); err != nil {
+		return UtxoEntry{}, Outpoint{}, 0, false, err
 	}
 
 	op := Outpoint{Txid: in.PrevTxid, Vout: in.PrevVout}

--- a/clients/go/consensus/connect_block_parallel_precompute.go
+++ b/clients/go/consensus/connect_block_parallel_precompute.go
@@ -58,10 +58,11 @@ type TxValidationContext struct {
 }
 
 type precomputeTxInputs struct {
-	ResolvedInputs    []UtxoEntry
-	InputOutpoints    []Outpoint
-	TotalWitnessSlots int
-	SumIn             u128
+	ResolvedInputs          []UtxoEntry
+	InputOutpoints          []Outpoint
+	TotalWitnessSlots       int
+	SumIn                   u128
+	StoppedAtCoreSimplicity bool
 }
 
 // PrecomputeTxContexts builds an immutable TxValidationContext slice for all
@@ -131,14 +132,17 @@ func precomputeTxContext(
 		return TxValidationContext{}, err
 	}
 
-	witnessStart, witnessEnd, err := precomputeWitnessBounds(tx, inputs.TotalWitnessSlots)
+	witnessStart, witnessEnd, err := precomputeWitnessBounds(tx, inputs.TotalWitnessSlots, inputs.StoppedAtCoreSimplicity)
 	if err != nil {
 		return TxValidationContext{}, err
 	}
 
-	fee, err := computePrecomputeFee(inputs.SumIn, tx.Outputs)
-	if err != nil {
-		return TxValidationContext{}, err
+	var fee uint64
+	if !inputs.StoppedAtCoreSimplicity {
+		fee, err = computePrecomputeFee(inputs.SumIn, tx.Outputs)
+		if err != nil {
+			return TxValidationContext{}, err
+		}
 	}
 
 	sighashCache, err := NewSighashV1PrehashCache(tx)
@@ -165,22 +169,26 @@ func collectPrecomputeTxInputs(
 	blockHeight uint64,
 ) (precomputeTxInputs, error) {
 	out := precomputeTxInputs{
-		ResolvedInputs: make([]UtxoEntry, len(tx.Inputs)),
-		InputOutpoints: make([]Outpoint, len(tx.Inputs)),
+		ResolvedInputs: make([]UtxoEntry, 0, len(tx.Inputs)),
+		InputOutpoints: make([]Outpoint, 0, len(tx.Inputs)),
 	}
 	seenInputs := make(map[Outpoint]struct{}, len(tx.Inputs))
 
-	for j, in := range tx.Inputs {
-		entry, op, slots, err := resolvePrecomputeInput(in, seenInputs, overlay, blockHeight)
+	for _, in := range tx.Inputs {
+		entry, op, slots, stoppedAtCoreSimplicity, err := resolvePrecomputeInput(in, seenInputs, overlay, blockHeight)
 		if err != nil {
 			return precomputeTxInputs{}, err
 		}
-		if out.TotalWitnessSlots, err = addWitnessSlots(out.TotalWitnessSlots, slots); err != nil {
+		out.ResolvedInputs = append(out.ResolvedInputs, entry)
+		out.InputOutpoints = append(out.InputOutpoints, op)
+		if out.SumIn, err = addU64ToU128(out.SumIn, entry.Value); err != nil {
 			return precomputeTxInputs{}, err
 		}
-		out.ResolvedInputs[j] = entry
-		out.InputOutpoints[j] = op
-		if out.SumIn, err = addU64ToU128(out.SumIn, entry.Value); err != nil {
+		if stoppedAtCoreSimplicity {
+			out.StoppedAtCoreSimplicity = true
+			return out, nil
+		}
+		if out.TotalWitnessSlots, err = addWitnessSlots(out.TotalWitnessSlots, slots); err != nil {
 			return precomputeTxInputs{}, err
 		}
 	}
@@ -193,30 +201,33 @@ func resolvePrecomputeInput(
 	seenInputs map[Outpoint]struct{},
 	overlay map[Outpoint]UtxoEntry,
 	blockHeight uint64,
-) (UtxoEntry, Outpoint, int, error) {
+) (UtxoEntry, Outpoint, int, bool, error) {
 	var zeroTxid [32]byte
 	if in.PrevVout == 0xffff_ffff && in.PrevTxid == zeroTxid {
-		return UtxoEntry{}, Outpoint{}, 0, txerr(TX_ERR_PARSE, "coinbase prevout encoding forbidden in non-coinbase")
+		return UtxoEntry{}, Outpoint{}, 0, false, txerr(TX_ERR_PARSE, "coinbase prevout encoding forbidden in non-coinbase")
 	}
 
 	op := Outpoint{Txid: in.PrevTxid, Vout: in.PrevVout}
 	if err := rememberPrecomputeInput(op, seenInputs); err != nil {
-		return UtxoEntry{}, Outpoint{}, 0, err
+		return UtxoEntry{}, Outpoint{}, 0, false, err
 	}
 
 	entry, ok := overlay[op]
 	if !ok {
-		return UtxoEntry{}, Outpoint{}, 0, txerr(TX_ERR_MISSING_UTXO, "utxo not found")
+		return UtxoEntry{}, Outpoint{}, 0, false, txerr(TX_ERR_MISSING_UTXO, "utxo not found")
 	}
 	if err := validatePrecomputeEntry(entry, blockHeight); err != nil {
-		return UtxoEntry{}, Outpoint{}, 0, err
+		return UtxoEntry{}, Outpoint{}, 0, false, err
+	}
+	if entry.CovenantType == COV_TYPE_CORE_SIMPLICITY {
+		return entry, op, 0, true, nil
 	}
 
 	slots, err := precomputeWitnessSlots(entry)
 	if err != nil {
-		return UtxoEntry{}, Outpoint{}, 0, err
+		return UtxoEntry{}, Outpoint{}, 0, false, err
 	}
-	return entry, op, slots, nil
+	return entry, op, slots, false, nil
 }
 
 func rememberPrecomputeInput(op Outpoint, seenInputs map[Outpoint]struct{}) error {
@@ -248,7 +259,7 @@ func precomputeWitnessSlots(entry UtxoEntry) (int, error) {
 	return slots, nil
 }
 
-func precomputeWitnessBounds(tx *Tx, totalWitnessSlots int) (int, int, error) {
+func precomputeWitnessBounds(tx *Tx, totalWitnessSlots int, stoppedAtCoreSimplicity bool) (int, int, error) {
 	// Witness cursor is per-transaction (reset to 0 for each tx), matching
 	// the sequential path in applyNonCoinbaseTxBasicWorkQ.
 	witnessCursor := 0
@@ -258,7 +269,7 @@ func precomputeWitnessBounds(tx *Tx, totalWitnessSlots int) (int, int, error) {
 		return 0, 0, txerr(TX_ERR_PARSE, "witness underflow")
 	}
 	witnessCursor = witnessEnd
-	if witnessCursor != len(tx.Witness) {
+	if !stoppedAtCoreSimplicity && witnessCursor != len(tx.Witness) {
 		return 0, 0, txerr(TX_ERR_PARSE, "witness_count mismatch")
 	}
 	return witnessStart, witnessEnd, nil

--- a/clients/go/consensus/connect_block_parallel_precompute.go
+++ b/clients/go/consensus/connect_block_parallel_precompute.go
@@ -136,13 +136,14 @@ func precomputeTxContext(
 	if err != nil {
 		return TxValidationContext{}, err
 	}
+	if inputs.StoppedAtCoreSimplicity {
+		return TxValidationContext{}, rejectCoreSimplicitySpend()
+	}
 
 	var fee uint64
-	if !inputs.StoppedAtCoreSimplicity {
-		fee, err = computePrecomputeFee(inputs.SumIn, tx.Outputs)
-		if err != nil {
-			return TxValidationContext{}, err
-		}
+	fee, err = computePrecomputeFee(inputs.SumIn, tx.Outputs)
+	if err != nil {
+		return TxValidationContext{}, err
 	}
 
 	sighashCache, err := NewSighashV1PrehashCache(tx)

--- a/clients/go/consensus/connect_block_parallel_precompute_test.go
+++ b/clients/go/consensus/connect_block_parallel_precompute_test.go
@@ -399,23 +399,31 @@ func TestPrecomputeTxContexts_CoreSimplicityStopsWitnessPrecompute(t *testing.T)
 			}
 			pb := makeParsedBlockForPrecompute(makeSimpleCoinbase(), []*Tx{tx})
 
-			results, err := PrecomputeTxContexts(pb, utxos, 100)
-			if err != nil {
-				t.Fatalf("unexpected precompute error: %v", err)
-			}
-			if len(results) != 1 {
-				t.Fatalf("expected 1 context, got %d", len(results))
-			}
-			ctx := results[0]
-			if ctx.WitnessStart != 0 || ctx.WitnessEnd != 1 {
-				t.Fatalf("witness bounds: got [%d,%d), want [0,1)", ctx.WitnessStart, ctx.WitnessEnd)
-			}
-			if len(ctx.ResolvedInputs) != 2 {
-				t.Fatalf("resolved inputs: got %d, want 2", len(ctx.ResolvedInputs))
-			}
-			assertTxErrCodeMsg(t, ValidateTxLocal(ctx, [32]byte{}, 100, 0, nil, nil).Err, TX_ERR_COVENANT_TYPE_INVALID, "CORE_SIMPLICITY spend evaluation not enabled")
+			_, err := PrecomputeTxContexts(pb, utxos, 100)
+			assertTxErrCodeMsg(t, err, TX_ERR_COVENANT_TYPE_INVALID, "CORE_SIMPLICITY spend evaluation not enabled")
 		})
 	}
+
+	t.Run("does_not_overlay_invalid_simplicity_outputs", func(t *testing.T) {
+		utxos := map[Outpoint]UtxoEntry{
+			{Txid: simpPrev, Vout: 0}: coreSimplicityAcceptEntry(100),
+		}
+		tx1 := &Tx{
+			Version: 1, TxKind: 0x00, TxNonce: 1,
+			Inputs:  []TxInput{{PrevTxid: simpPrev, PrevVout: 0, Sequence: 0}},
+			Outputs: []TxOutput{{Value: 50, CovenantType: COV_TYPE_P2PK, CovenantData: validP2PKCovenantData()}},
+		}
+		tx1Txid := sha3_256([]byte{byte(1)})
+		tx2 := &Tx{
+			Version: 1, TxKind: 0x00, TxNonce: 2,
+			Inputs:  []TxInput{{PrevTxid: tx1Txid, PrevVout: 0, Sequence: 0}},
+			Outputs: []TxOutput{{Value: 40, CovenantType: COV_TYPE_P2PK, CovenantData: validP2PKCovenantData()}},
+		}
+		pb := makeParsedBlockForPrecompute(makeSimpleCoinbase(), []*Tx{tx1, tx2})
+
+		_, err := PrecomputeTxContexts(pb, utxos, 100)
+		assertTxErrCodeMsg(t, err, TX_ERR_COVENANT_TYPE_INVALID, "CORE_SIMPLICITY spend evaluation not enabled")
+	})
 }
 
 func TestPrecomputeTxContexts_WitnessCountMismatch(t *testing.T) {

--- a/clients/go/consensus/connect_block_parallel_precompute_test.go
+++ b/clients/go/consensus/connect_block_parallel_precompute_test.go
@@ -352,6 +352,72 @@ func TestPrecomputeTxContexts_WitnessUnderflow(t *testing.T) {
 	}
 }
 
+func TestPrecomputeTxContexts_CoreSimplicityStopsWitnessPrecompute(t *testing.T) {
+	p2pkPrev := sha3_256([]byte("precompute-p2pk-before-simplicity"))
+	simpPrev := sha3_256([]byte("precompute-simplicity"))
+	missingPrev := sha3_256([]byte("precompute-after-simplicity-missing"))
+	dummyWitness := WitnessItem{
+		SuiteID:   SUITE_ID_ML_DSA_87,
+		Pubkey:    make([]byte, ML_DSA_87_PUBKEY_BYTES),
+		Signature: make([]byte, ML_DSA_87_SIG_BYTES+1),
+	}
+	baseUTXOs := map[Outpoint]UtxoEntry{
+		{Txid: p2pkPrev, Vout: 0}: {Value: 100, CovenantType: COV_TYPE_P2PK, CovenantData: validP2PKCovenantData()},
+		{Txid: simpPrev, Vout: 0}: coreSimplicityAcceptEntry(100),
+	}
+
+	for _, tc := range []struct {
+		name   string
+		inputs []TxInput
+	}{
+		{
+			name: "missing_simplicity_witness",
+			inputs: []TxInput{
+				{PrevTxid: p2pkPrev, PrevVout: 0, Sequence: 0},
+				{PrevTxid: simpPrev, PrevVout: 0, Sequence: 0},
+			},
+		},
+		{
+			name: "later_missing_utxo",
+			inputs: []TxInput{
+				{PrevTxid: p2pkPrev, PrevVout: 0, Sequence: 0},
+				{PrevTxid: simpPrev, PrevVout: 0, Sequence: 0},
+				{PrevTxid: missingPrev, PrevVout: 0, Sequence: 0},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			utxos := map[Outpoint]UtxoEntry{}
+			for op, entry := range baseUTXOs {
+				utxos[op] = entry
+			}
+			tx := &Tx{
+				Version: 1, TxKind: 0x00, TxNonce: 1,
+				Inputs:  tc.inputs,
+				Outputs: []TxOutput{{Value: 150, CovenantType: COV_TYPE_P2PK, CovenantData: validP2PKCovenantData()}},
+				Witness: []WitnessItem{dummyWitness},
+			}
+			pb := makeParsedBlockForPrecompute(makeSimpleCoinbase(), []*Tx{tx})
+
+			results, err := PrecomputeTxContexts(pb, utxos, 100)
+			if err != nil {
+				t.Fatalf("unexpected precompute error: %v", err)
+			}
+			if len(results) != 1 {
+				t.Fatalf("expected 1 context, got %d", len(results))
+			}
+			ctx := results[0]
+			if ctx.WitnessStart != 0 || ctx.WitnessEnd != 1 {
+				t.Fatalf("witness bounds: got [%d,%d), want [0,1)", ctx.WitnessStart, ctx.WitnessEnd)
+			}
+			if len(ctx.ResolvedInputs) != 2 {
+				t.Fatalf("resolved inputs: got %d, want 2", len(ctx.ResolvedInputs))
+			}
+			assertTxErrCodeMsg(t, ValidateTxLocal(ctx, [32]byte{}, 100, 0, nil, nil).Err, TX_ERR_COVENANT_TYPE_INVALID, "CORE_SIMPLICITY spend evaluation not enabled")
+		})
+	}
+}
+
 func TestPrecomputeTxContexts_WitnessCountMismatch(t *testing.T) {
 	covData := validP2PKCovenantData()
 	prevTxid := sha3_256([]byte("witness-overflow"))

--- a/clients/go/consensus/connect_block_parallel_precompute_test.go
+++ b/clients/go/consensus/connect_block_parallel_precompute_test.go
@@ -522,6 +522,51 @@ func TestPrecomputeTxContexts_CoinbasePrevoutForbidden(t *testing.T) {
 	}
 }
 
+func TestPrecomputeTxContexts_NonCoinbaseInputEncoding(t *testing.T) {
+	prevTxid := sha3_256([]byte("precompute-input-encoding"))
+	utxos := map[Outpoint]UtxoEntry{
+		{Txid: prevTxid, Vout: 0}: {Value: 100, CovenantType: COV_TYPE_P2PK, CovenantData: validP2PKCovenantData()},
+	}
+	dummyWitness := WitnessItem{
+		SuiteID:   SUITE_ID_ML_DSA_87,
+		Pubkey:    make([]byte, ML_DSA_87_PUBKEY_BYTES),
+		Signature: make([]byte, ML_DSA_87_SIG_BYTES+1),
+	}
+
+	for _, tc := range []struct {
+		name    string
+		input   TxInput
+		code    ErrorCode
+		message string
+	}{
+		{
+			name:    "script_sig",
+			input:   TxInput{PrevTxid: prevTxid, PrevVout: 0, Sequence: 0, ScriptSig: []byte{0x01}},
+			code:    TX_ERR_PARSE,
+			message: "script_sig must be empty under genesis covenant set",
+		},
+		{
+			name:    "sequence_high_bit",
+			input:   TxInput{PrevTxid: prevTxid, PrevVout: 0, Sequence: 0x8000_0000},
+			code:    TX_ERR_SEQUENCE_INVALID,
+			message: "sequence exceeds 0x7fffffff",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tx := &Tx{
+				Version: 1, TxKind: 0x00, TxNonce: 1,
+				Inputs:  []TxInput{tc.input},
+				Outputs: []TxOutput{{Value: 50, CovenantType: COV_TYPE_P2PK, CovenantData: validP2PKCovenantData()}},
+				Witness: []WitnessItem{dummyWitness},
+			}
+			pb := makeParsedBlockForPrecompute(makeSimpleCoinbase(), []*Tx{tx})
+
+			_, err := PrecomputeTxContexts(pb, utxos, 100)
+			assertTxErrCodeMsg(t, err, tc.code, tc.message)
+		})
+	}
+}
+
 func TestPrecomputeTxContexts_NilTx(t *testing.T) {
 	pb := makeParsedBlockForPrecompute(makeSimpleCoinbase(), []*Tx{nil})
 	_, err := PrecomputeTxContexts(pb, map[Outpoint]UtxoEntry{}, 100)

--- a/clients/go/consensus/tx_validate_worker.go
+++ b/clients/go/consensus/tx_validate_worker.go
@@ -70,7 +70,7 @@ func ValidateTxLocal(
 		result.Err = txerr(TX_ERR_PARSE, "nil tx in TxValidationContext")
 		return result
 	}
-	if !txValidationInputCountMatches(tx, tvc.ResolvedInputs) {
+	if len(tx.Inputs) != len(tvc.ResolvedInputs) {
 		result.Err = txerr(TX_ERR_PARSE, "txcontext resolved input count mismatch")
 		return result
 	}
@@ -93,16 +93,6 @@ func ValidateTxLocal(
 	}
 	finishTxValidationResult(&result, env.sigQueue)
 	return result
-}
-
-func txValidationInputCountMatches(tx *Tx, resolvedInputs []UtxoEntry) bool {
-	if len(tx.Inputs) == len(resolvedInputs) {
-		return true
-	}
-	if len(resolvedInputs) == 0 || len(resolvedInputs) >= len(tx.Inputs) {
-		return false
-	}
-	return resolvedInputs[len(resolvedInputs)-1].CovenantType == COV_TYPE_CORE_SIMPLICITY
 }
 
 func newTxValidationWorkerEnv(

--- a/clients/go/consensus/tx_validate_worker.go
+++ b/clients/go/consensus/tx_validate_worker.go
@@ -70,7 +70,7 @@ func ValidateTxLocal(
 		result.Err = txerr(TX_ERR_PARSE, "nil tx in TxValidationContext")
 		return result
 	}
-	if len(tx.Inputs) != len(tvc.ResolvedInputs) {
+	if !txValidationInputCountMatches(tx, tvc.ResolvedInputs) {
 		result.Err = txerr(TX_ERR_PARSE, "txcontext resolved input count mismatch")
 		return result
 	}
@@ -93,6 +93,16 @@ func ValidateTxLocal(
 	}
 	finishTxValidationResult(&result, env.sigQueue)
 	return result
+}
+
+func txValidationInputCountMatches(tx *Tx, resolvedInputs []UtxoEntry) bool {
+	if len(tx.Inputs) == len(resolvedInputs) {
+		return true
+	}
+	if len(resolvedInputs) == 0 || len(resolvedInputs) >= len(tx.Inputs) {
+		return false
+	}
+	return resolvedInputs[len(resolvedInputs)-1].CovenantType == COV_TYPE_CORE_SIMPLICITY
 }
 
 func newTxValidationWorkerEnv(

--- a/clients/go/consensus/utxo_basic.go
+++ b/clients/go/consensus/utxo_basic.go
@@ -50,6 +50,9 @@ func (ctx *nonCoinbaseApplyContext) applyPreOutputPhases() error {
 	if err := ctx.resolveInputs(); err != nil {
 		return err
 	}
+	if ctx.hasCoreSimplicityResolvedInput() {
+		return ctx.validateInputSpends()
+	}
 	if err := ctx.buildTxContext(); err != nil {
 		return err
 	}
@@ -107,13 +110,26 @@ func (ctx *nonCoinbaseApplyContext) prepare() error {
 }
 
 func (ctx *nonCoinbaseApplyContext) resolveInputs() error {
-	witnessCursor := 0
 	seenInputs := make(map[Outpoint]struct{}, len(ctx.tx.Inputs))
 	var zeroTxid [32]byte
+	witnessCursor := 0
 	ctx.resolved = make([]nonCoinbaseResolvedInput, 0, len(ctx.tx.Inputs))
 	for _, in := range ctx.tx.Inputs {
 		entry, op, err := ctx.resolveInput(in, seenInputs, zeroTxid)
 		if err != nil {
+			return err
+		}
+		if entry.CovenantType == COV_TYPE_CORE_SIMPLICITY {
+			if err := ctx.validateCoinbaseInputMaturity(entry); err != nil {
+				return err
+			}
+			ctx.resolved = append(ctx.resolved, nonCoinbaseResolvedInput{
+				entry:    entry,
+				outpoint: op,
+			})
+			return nil
+		}
+		if err := ctx.validateResolvedInputEntry(entry); err != nil {
 			return err
 		}
 		slots, err := WitnessSlots(entry.CovenantType, entry.CovenantData)
@@ -146,9 +162,6 @@ func (ctx *nonCoinbaseApplyContext) resolveInput(in TxInput, seenInputs map[Outp
 	}
 	entry, op, err := ctx.lookupInputEntry(in, seenInputs)
 	if err != nil {
-		return UtxoEntry{}, Outpoint{}, err
-	}
-	if err := ctx.validateResolvedInputEntry(entry); err != nil {
 		return UtxoEntry{}, Outpoint{}, err
 	}
 	return entry, op, nil
@@ -253,7 +266,21 @@ func (ctx *nonCoinbaseApplyContext) resolvedEntries() []UtxoEntry {
 	return entries
 }
 
+func (ctx *nonCoinbaseApplyContext) hasCoreSimplicityResolvedInput() bool {
+	for _, input := range ctx.resolved {
+		if input.entry.CovenantType == COV_TYPE_CORE_SIMPLICITY {
+			return true
+		}
+	}
+	return false
+}
+
 func (ctx *nonCoinbaseApplyContext) validateInputSpends() error {
+	for inputIndex, input := range ctx.resolved {
+		if input.entry.CovenantType == COV_TYPE_CORE_SIMPLICITY {
+			return ctx.validateInputSpend(inputIndex, input)
+		}
+	}
 	for inputIndex, input := range ctx.resolved {
 		if err := ctx.validateInputSpend(inputIndex, input); err != nil {
 			return err
@@ -293,6 +320,8 @@ func (ctx *nonCoinbaseApplyContext) validateInputSpend(inputIndex int, input non
 		return ctx.validateCoreExtInput(inputIndex, entry, assigned)
 	case COV_TYPE_CORE_STEALTH:
 		return ctx.validateCoreStealthInput(inputIndex, entry, assigned)
+	case COV_TYPE_CORE_SIMPLICITY:
+		return ctx.validateCoreSimplicityInput(entry, assigned)
 	default:
 		return nil
 	}
@@ -400,6 +429,10 @@ func (ctx *nonCoinbaseApplyContext) validateCoreStealthInput(inputIndex int, ent
 		rotation:    ctx.rotation,
 		registry:    ctx.registry,
 	})
+}
+
+func (ctx *nonCoinbaseApplyContext) validateCoreSimplicityInput(_ UtxoEntry, _ []WitnessItem) error {
+	return rejectCoreSimplicitySpend()
 }
 
 func (ctx *nonCoinbaseApplyContext) addSpendableOutputs() error {

--- a/clients/go/consensus/utxo_basic_test.go
+++ b/clients/go/consensus/utxo_basic_test.go
@@ -174,6 +174,34 @@ func TestApplyNonCoinbaseTxBasicUpdate_CoreSimplicitySpendRejected(t *testing.T)
 	assertTxErrCodeMsg(t, err, TX_ERR_COVENANT_TYPE_INVALID, "CORE_SIMPLICITY spend evaluation not enabled")
 }
 
+func TestApplyNonCoinbaseTxBasicUpdate_CoreSimplicityImmatureCoinbasePrecedesDisabledSpend(t *testing.T) {
+	prev := hashWithPrefix(0x67)
+	tx := &Tx{
+		Version: TX_WIRE_VERSION,
+		TxKind:  0x00,
+		TxNonce: 1,
+		Inputs:  []TxInput{{PrevTxid: prev, PrevVout: 0}},
+		Outputs: []TxOutput{{Value: 90, CovenantType: COV_TYPE_P2PK, CovenantData: validP2PKCovenantData()}},
+	}
+	utxos := map[Outpoint]UtxoEntry{
+		{Txid: prev, Vout: 0}: {
+			Value:             100,
+			CovenantType:      COV_TYPE_CORE_SIMPLICITY,
+			CovenantData:      encodeSimplicityCovenantData([32]byte{0x67}, nil),
+			CreationHeight:    0,
+			CreatedByCoinbase: true,
+		},
+	}
+
+	work, summary, err := ApplyNonCoinbaseTxBasicUpdate(tx, hashWithPrefix(0x68), utxos, COINBASE_MATURITY-1, 0, [32]byte{})
+	if work != nil || summary != nil {
+		t.Fatalf("expected no mutation on reject, got work=%v summary=%v", work, summary)
+	}
+	if got := mustTxErrCode(t, err); got != TX_ERR_COINBASE_IMMATURE {
+		t.Fatalf("code=%s, want %s", got, TX_ERR_COINBASE_IMMATURE)
+	}
+}
+
 func TestApplyNonCoinbaseTxBasicUpdate_CoreSimplicityRejectsBeforeWitnessChecks(t *testing.T) {
 	prev := hashWithPrefix(0x65)
 	tx := &Tx{
@@ -241,6 +269,118 @@ func TestApplyNonCoinbaseTxBasicUpdate_CoreSimplicityRejectsBeforeTxContextLooku
 		t.Fatalf("expected no mutation on reject, got work=%v summary=%v", work, summary)
 	}
 	assertTxErrCodeMsg(t, err, TX_ERR_COVENANT_TYPE_INVALID, "CORE_SIMPLICITY spend evaluation not enabled")
+}
+
+func TestApplyNonCoinbaseTxBasicUpdate_CoreSimplicityPreservesInputOrderPriority(t *testing.T) {
+	makeOutpoint := func(prev [32]byte) Outpoint {
+		return Outpoint{Txid: prev, Vout: 0}
+	}
+	p2pkPrev := hashWithPrefix(0xE0)
+	simpPrev := hashWithPrefix(0xE1)
+	laterMissingPrev := hashWithPrefix(0xE2)
+
+	t.Run("current_simplicity_precedes_later_missing_utxo", func(t *testing.T) {
+		tx := &Tx{
+			Version: TX_WIRE_VERSION,
+			TxKind:  0x00,
+			TxNonce: 1,
+			Inputs: []TxInput{
+				{PrevTxid: simpPrev, PrevVout: 0},
+				{PrevTxid: laterMissingPrev, PrevVout: 0},
+			},
+			Outputs: []TxOutput{{Value: 90, CovenantType: COV_TYPE_P2PK, CovenantData: validP2PKCovenantData()}},
+		}
+		utxos := map[Outpoint]UtxoEntry{
+			makeOutpoint(simpPrev): coreSimplicityAcceptEntry(100),
+		}
+
+		work, summary, err := ApplyNonCoinbaseTxBasicUpdateWithMTPAndCoreExtProfilesAndSuiteContext(
+			tx,
+			hashWithPrefix(0xE3),
+			utxos,
+			1,
+			0,
+			0,
+			[32]byte{},
+			nil,
+			nil,
+			nil,
+		)
+		if work != nil || summary != nil {
+			t.Fatalf("expected no mutation on reject, got work=%v summary=%v", work, summary)
+		}
+		assertTxErrCodeMsg(t, err, TX_ERR_COVENANT_TYPE_INVALID, "CORE_SIMPLICITY spend evaluation not enabled")
+	})
+
+	t.Run("earlier_p2pk_witness_underflow_precedes_later_simplicity", func(t *testing.T) {
+		tx := &Tx{
+			Version: TX_WIRE_VERSION,
+			TxKind:  0x00,
+			TxNonce: 1,
+			Inputs: []TxInput{
+				{PrevTxid: p2pkPrev, PrevVout: 0},
+				{PrevTxid: simpPrev, PrevVout: 0},
+			},
+			Outputs: []TxOutput{{Value: 190, CovenantType: COV_TYPE_P2PK, CovenantData: validP2PKCovenantData()}},
+		}
+		utxos := map[Outpoint]UtxoEntry{
+			makeOutpoint(p2pkPrev): {Value: 100, CovenantType: COV_TYPE_P2PK, CovenantData: validP2PKCovenantData()},
+			makeOutpoint(simpPrev): coreSimplicityAcceptEntry(100),
+		}
+
+		work, summary, err := ApplyNonCoinbaseTxBasicUpdateWithMTPAndCoreExtProfilesAndSuiteContext(
+			tx,
+			hashWithPrefix(0xE4),
+			utxos,
+			1,
+			0,
+			0,
+			[32]byte{},
+			nil,
+			nil,
+			nil,
+		)
+		if work != nil || summary != nil {
+			t.Fatalf("expected no mutation on reject, got work=%v summary=%v", work, summary)
+		}
+		assertTxErrCodeMsg(t, err, TX_ERR_PARSE, "witness underflow")
+	})
+}
+
+func TestApplyNonCoinbaseTxBasicUpdate_NonSimplicityWitnessUnderflowPrecedesLaterValidation(t *testing.T) {
+	firstPrev := hashWithPrefix(0xE7)
+	laterPrev := hashWithPrefix(0xE8)
+	tx := &Tx{
+		Version: TX_WIRE_VERSION,
+		TxKind:  0x00,
+		TxNonce: 1,
+		Inputs: []TxInput{
+			{PrevTxid: firstPrev, PrevVout: 0},
+			{PrevTxid: laterPrev, PrevVout: 0},
+		},
+		Outputs: []TxOutput{{Value: 190, CovenantType: COV_TYPE_P2PK, CovenantData: validP2PKCovenantData()}},
+	}
+	utxos := map[Outpoint]UtxoEntry{
+		{Txid: firstPrev, Vout: 0}: {Value: 100, CovenantType: COV_TYPE_P2PK, CovenantData: validP2PKCovenantData()},
+		{Txid: laterPrev, Vout: 0}: {Value: 100, CovenantType: COV_TYPE_HTLC, CovenantData: []byte{0x01}},
+	}
+
+	work, summary, err := ApplyNonCoinbaseTxBasicUpdateWithMTPAndCoreExtProfilesAndSuiteContext(
+		tx,
+		hashWithPrefix(0xE9),
+		utxos,
+		1,
+		0,
+		0,
+		[32]byte{},
+		nil,
+		nil,
+		nil,
+	)
+	if work != nil || summary != nil {
+		t.Fatalf("expected no mutation on reject, got work=%v summary=%v", work, summary)
+	}
+	assertTxErrCodeMsg(t, err, TX_ERR_PARSE, "witness underflow")
 }
 
 func TestApplyNonCoinbaseTxBasicUpdate_RejectsImmatureCoinbaseSpend_OverflowSafe(t *testing.T) {


### PR DESCRIPTION
Refs: Q-RUB-504

## Summary
Invariant:
Go consensus rejects resolved CORE_SIMPLICITY spends at the first sequential Simplicity boundary without letting later input resolution, later witness checks, or precompute witness-slot accounting mask the disabled-Simplicity rejection.

Layer:
consensus / tests

Consensus rules unchanged: YES
SECTION_HASHES.json unchanged: YES

## Scope
Files changed:
- clients/go/consensus/utxo_basic.go
- clients/go/consensus/utxo_basic_test.go
- clients/go/consensus/connect_block_parallel_precompute.go
- clients/go/consensus/connect_block_parallel_precompute_test.go
- clients/go/consensus/tx_validate_worker.go

Behavior impact:
- Sequential non-coinbase input resolution preserves earlier non-Simplicity witness and maturity priority.
- CORE_SIMPLICITY still runs the standard coinbase maturity check before disabled-spend rejection.
- Precompute/worker validation now stops at the same first CORE_SIMPLICITY boundary for witness-slot accounting and later input resolution.

Compatibility impact:
No wire format, fixture, Rust, or documentation changes in this slice.

Known non-goals:
- No CORE_SIMPLICITY enablement.
- No Rust parity change.
- No conformance fixture change.

### Parity exemption justification
This is a Go-track-only Simplicity slice. Rust Simplicity parity is intentionally deferred until the Go Simplicity track, including docs, is complete.

Tests:
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -count=1 ./consensus -run "TestPrecomputeTxContexts_(CoreSimplicityStopsWitnessPrecompute|WitnessUnderflow|WitnessCountMismatch)|TestApplyNonCoinbaseTxBasicUpdate_(CoreSimplicity|NonSimplicityWitnessUnderflow)"' - PASS
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -count=1 ./consensus' - PASS

Risk:
This is a narrow ordering change in Go non-coinbase input validation and Go precompute/worker validation.

Rollback:
Revert this PR.

Not checked:
- Local Rubin cl/rubin-push receipt gate was not run in this environment because the local /Users/gpt/bin bootstrap tools are unavailable.
