### PR TITLE
RUB-578 cover queued simplicity reject priority

### DIFF
--- a/clients/go/consensus/connect_block_parallel_simplicity_queue_test.go
+++ b/clients/go/consensus/connect_block_parallel_simplicity_queue_test.go
@@ -1,0 +1,95 @@
+package consensus
+
+import "testing"
+
+func TestApplyNonCoinbaseTxBasicWorkQ_CoreSimplicityPrevalidationRejectLeavesSigQueueEmpty(t *testing.T) {
+	pubkey := make([]byte, ML_DSA_87_PUBKEY_BYTES)
+	pubkey[0] = 0xA5
+	signature := make([]byte, ML_DSA_87_SIG_BYTES+1)
+	signature[len(signature)-1] = SIGHASH_ALL
+	p2pkPrev := hashWithPrefix(0xD0)
+	simpPrev := hashWithPrefix(0xD1)
+	tx := &Tx{
+		Version: TX_WIRE_VERSION,
+		TxKind:  0x00,
+		TxNonce: 1,
+		Inputs: []TxInput{
+			{PrevTxid: p2pkPrev, PrevVout: 0},
+			{PrevTxid: simpPrev, PrevVout: 0},
+		},
+		Outputs: []TxOutput{{Value: 190, CovenantType: COV_TYPE_P2PK, CovenantData: validP2PKCovenantData()}},
+	}
+	tx.Witness = []WitnessItem{{SuiteID: SUITE_ID_ML_DSA_87, Pubkey: pubkey, Signature: signature}}
+	utxoSet := map[Outpoint]UtxoEntry{
+		{Txid: p2pkPrev, Vout: 0}: {Value: 100, CovenantType: COV_TYPE_P2PK, CovenantData: p2pkCovenantDataForPubkey(pubkey)},
+		{Txid: simpPrev, Vout: 0}: coreSimplicityAcceptEntry(100),
+	}
+	q := NewSigCheckQueue(1)
+
+	work, fee, err := applyNonCoinbaseTxBasicWorkQ(tx, hashWithPrefix(0xD2), utxoSet, 1, 0, [32]byte{}, nil, q, nil, nil)
+	if work != nil || fee != 0 || q.Len() != 0 {
+		t.Fatalf("expected no queued mutation/sigs on reject, got work=%v fee=%d sigs=%d", work, fee, q.Len())
+	}
+	assertTxErrCodeMsg(t, err, TX_ERR_COVENANT_TYPE_INVALID, "CORE_SIMPLICITY spend evaluation not enabled")
+}
+
+func TestApplyNonCoinbaseTxBasicWorkQ_CoreSimplicityPreservesEarlierPrevalidationPriority(t *testing.T) {
+	makeTx := func(firstPrev, simpPrev [32]byte, witness []WitnessItem) *Tx {
+		return &Tx{
+			Version: TX_WIRE_VERSION,
+			TxKind:  0x00,
+			TxNonce: 1,
+			Inputs: []TxInput{
+				{PrevTxid: firstPrev, PrevVout: 0},
+				{PrevTxid: simpPrev, PrevVout: 0},
+			},
+			Outputs: []TxOutput{{Value: 190, CovenantType: COV_TYPE_P2PK, CovenantData: validP2PKCovenantData()}},
+			Witness: witness,
+		}
+	}
+	makeOutpoint := func(prev [32]byte) Outpoint {
+		return Outpoint{Txid: prev, Vout: 0}
+	}
+
+	p2pkPrev := hashWithPrefix(0xD3)
+	p2pkSimpPrev := hashWithPrefix(0xD4)
+	htlcPrev := hashWithPrefix(0xD5)
+	htlcSimpPrev := hashWithPrefix(0xD6)
+	for _, tc := range []struct {
+		name    string
+		tx      *Tx
+		utxos   map[Outpoint]UtxoEntry
+		code    ErrorCode
+		message string
+	}{
+		{
+			name: "p2pk_missing_witness",
+			tx:   makeTx(p2pkPrev, p2pkSimpPrev, nil),
+			utxos: map[Outpoint]UtxoEntry{
+				makeOutpoint(p2pkPrev):     {Value: 100, CovenantType: COV_TYPE_P2PK, CovenantData: validP2PKCovenantData()},
+				makeOutpoint(p2pkSimpPrev): coreSimplicityAcceptEntry(100),
+			},
+			code:    TX_ERR_PARSE,
+			message: "witness underflow",
+		},
+		{
+			name: "htlc_malformed_data",
+			tx:   makeTx(htlcPrev, htlcSimpPrev, dummyWitnesses(2)),
+			utxos: map[Outpoint]UtxoEntry{
+				makeOutpoint(htlcPrev):     {Value: 100, CovenantType: COV_TYPE_HTLC, CovenantData: []byte{0x01}},
+				makeOutpoint(htlcSimpPrev): coreSimplicityAcceptEntry(100),
+			},
+			code:    TX_ERR_COVENANT_TYPE_INVALID,
+			message: "CORE_HTLC covenant_data length mismatch",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			q := NewSigCheckQueue(1)
+			work, fee, err := applyNonCoinbaseTxBasicWorkQ(tc.tx, hashWithPrefix(0xD7), tc.utxos, 1, 0, [32]byte{}, nil, q, nil, nil)
+			if work != nil || fee != 0 || q.Len() != 0 {
+				t.Fatalf("expected no queued mutation/sigs on reject, got work=%v fee=%d sigs=%d", work, fee, q.Len())
+			}
+			assertTxErrCodeMsg(t, err, tc.code, tc.message)
+		})
+	}
+}


### PR DESCRIPTION
Refs: Q-RUB-578

## Summary
Invariant:
The Go queued non-coinbase path has regression coverage for disabled CORE_SIMPLICITY rejection before queued signature side effects at the prevalidation boundary, while preserving earlier prevalidation error priority for earlier non-Simplicity inputs.

Layer:
tests / consensus validation coverage

Files changed:
- clients/go/consensus/connect_block_parallel_simplicity_queue_test.go

Tests:
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -count=1 ./consensus -run "TestApplyNonCoinbaseTxBasicWorkQ_CoreSimplicity(PrevalidationRejectLeavesSigQueueEmpty|PreservesEarlierPrevalidationPriority|RejectsBeforeWitnessChecks|SpendRejected)$"' — PASS
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -count=1 ./consensus' — PASS
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go vet ./consensus' — PASS
- git diff --check origin/main...HEAD — PASS
- python3 /Users/gpt/Documents/local-agent-protocols/common-preflight/rubin_common_preflight.py --repo /Users/gpt/Documents/rubin-protocol --base-ref origin/main --lane core — PASS

Behavior impact:
No production code changed.

Compatibility impact:
Go test-only change.

## Scope
Consensus rules unchanged: YES
SECTION_HASHES.json unchanged: YES

Known non-goals:
- No Rust changes.
- No shared corpus or conformance fixture changes.
- No docs changes.
- No weight formula changes.

Risk:
Test-only; main risk is overfitting error-order assertions to the current queued prevalidation boundary.

Rollback:
Revert the test-only commit.

Not checked:
- Full go-deep, race/shuffle, coverage, and Rust workspace tests were not run.