### PR TITLE
RUB-545: price Go Simplicity envelope weight

### DIFF
--- a/clients/go/consensus/block_basic_weight.go
+++ b/clients/go/consensus/block_basic_weight.go
@@ -209,6 +209,8 @@ func computeTxDASize(tx *Tx) (uint64, uint64) {
 func txWeightAndStats(tx *Tx) (uint64, uint64, uint64, error) {
 	return txWeightComponents(tx, func(w WitnessItem) (uint64, error) {
 		switch w.SuiteID {
+		case SUITE_ID_SIMPLICITY_ENVELOPE:
+			return SIMPLICITY_BASE_VERIFY_COST, nil
 		case SUITE_ID_ML_DSA_87:
 			if len(w.Pubkey) == ML_DSA_87_PUBKEY_BYTES && len(w.Signature) == ML_DSA_87_SIG_BYTES+1 {
 				return VERIFY_COST_ML_DSA_87, nil
@@ -280,6 +282,9 @@ func txWeightAndStatsWithRegistry(tx *Tx, height uint64, rotation RotationProvid
 	nativeSpend := rotation.NativeSpendSuites(height)
 
 	return txWeightComponents(tx, func(w WitnessItem) (uint64, error) {
+		if w.SuiteID == SUITE_ID_SIMPLICITY_ENVELOPE {
+			return SIMPLICITY_BASE_VERIFY_COST, nil
+		}
 		if nativeSpend.Contains(w.SuiteID) {
 			if params, ok := registry.Lookup(w.SuiteID); ok {
 				// Native registered suite: use registry cost if lengths match,

--- a/clients/go/consensus/constants.go
+++ b/clients/go/consensus/constants.go
@@ -75,8 +75,9 @@ const (
 	ML_KEM_1024_CT_BYTES      = 1568
 	MAX_STEALTH_COVENANT_DATA = 1600
 
-	VERIFY_COST_ML_DSA_87     = 8
-	VERIFY_COST_UNKNOWN_SUITE = 64 // conservative floor for non-native suites (CANONICAL §9)
+	VERIFY_COST_ML_DSA_87       = 8
+	VERIFY_COST_UNKNOWN_SUITE   = 64 // conservative floor for non-native suites (CANONICAL §9)
+	SIMPLICITY_BASE_VERIFY_COST = 64
 
 	// EXT_BASE_COST is a policy/activation prerequisite constant for CORE_EXT tracks.
 	// It is defined as a stable numeric baseline derived from devnet-style measurement

--- a/clients/go/consensus/weight_registry_test.go
+++ b/clients/go/consensus/weight_registry_test.go
@@ -66,6 +66,47 @@ func TestTxWeightAtHeight_UnknownSuite_UsesFloor(t *testing.T) {
 	}
 }
 
+func TestTxWeight_SigCostSpecialCases(t *testing.T) {
+	cases := []struct {
+		name    string
+		suiteID uint8
+		want    uint64
+	}{
+		{"simplicity_envelope", SUITE_ID_SIMPLICITY_ENVELOPE, SIMPLICITY_BASE_VERIFY_COST},
+		{"unknown_suite", 0xff, VERIFY_COST_UNKNOWN_SUITE},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sentinel := txWithWitness([]WitnessItem{{SuiteID: SUITE_ID_SENTINEL}})
+			item := txWithWitness([]WitnessItem{{SuiteID: tc.suiteID}})
+
+			legacySentinel, _, _, err := TxWeightAndStats(sentinel)
+			if err != nil {
+				t.Fatalf("legacy sentinel weight: %v", err)
+			}
+			legacyItem, _, _, err := TxWeightAndStats(item)
+			if err != nil {
+				t.Fatalf("legacy item weight: %v", err)
+			}
+			if got := legacyItem - legacySentinel; got != tc.want {
+				t.Fatalf("legacy sig_cost delta=%d, want %d", got, tc.want)
+			}
+
+			registrySentinel, _, _, err := TxWeightAndStatsAtHeight(sentinel, 100, DefaultRotationProvider{}, DefaultSuiteRegistry())
+			if err != nil {
+				t.Fatalf("registry sentinel weight: %v", err)
+			}
+			registryItem, _, _, err := TxWeightAndStatsAtHeight(item, 100, DefaultRotationProvider{}, DefaultSuiteRegistry())
+			if err != nil {
+				t.Fatalf("registry item weight: %v", err)
+			}
+			if got := registryItem - registrySentinel; got != tc.want {
+				t.Fatalf("registry sig_cost delta=%d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestTxWeightAtHeight_NativeNotInSpendSet_UsesFloor(t *testing.T) {
 	// Simulate suite 0x02 that IS registered but NOT in spend suites at this height.
 	reg := &SuiteRegistry{


### PR DESCRIPTION
Invariant:
Go consensus weight accounting charges suite_id 0xF0 with SIMPLICITY_BASE_VERIFY_COST=64 in both direct and height-aware weight paths.

Layer:
consensus implementation and focused tests

Files changed:
- clients/go/consensus/constants.go
- clients/go/consensus/block_basic_weight.go
- clients/go/consensus/weight_registry_test.go

Tests:
- Focused Go consensus weight tests — PASS
- clients/go consensus package — PASS
- clients/go full test target — PASS
- core preflight receipt — PASS
- coverage preflight receipt — PASS
- git verify-commit HEAD — PASS

Behavior impact:
Go now handles SUITE_ID_SIMPLICITY_ENVELOPE explicitly instead of relying on unknown-suite fallback. Other suite costs are unchanged.

### Parity exemption justification
RUB-545 is explicitly Go-only. Rust Simplicity parity remains deferred behind the Rust gate until the Go Simplicity track and docs are complete. This PR does not change Rust, shared conformance fixtures, wire format, or Simplicity execution semantics.

Known non-goals:
- No Rust implementation.
- No shared fixture or conformance corpus update.
- No Simplicity VM execution or spend enablement.

Linear: RUB-545