### PR TITLE
RUB-527: Go Simplicity preactivation policy

### DIFF
--- a/clients/go/node/mempolicy_helpers.go
+++ b/clients/go/node/mempolicy_helpers.go
@@ -104,7 +104,7 @@ func applyPolicyAgainstStateDA(checked *consensus.CheckedTransaction, policy Mem
 // applyPolicyAgainstStateCoreExt handles CoreExt policy application
 func applyPolicyAgainstStateCoreExt(checked *consensus.CheckedTransaction, utxos map[consensus.Outpoint]consensus.UtxoEntry, nextHeight uint64, policy MempoolConfig) error {
 	if policy.PolicyRejectCoreExtPreActivation {
-		reject, reason, err := RejectCoreExtTxPreActivation(checked.Tx, utxos, nextHeight, policy.CoreExtProfiles)
+		reject, reason, err := RejectCoreExtTxPreActivationWithRotation(checked.Tx, utxos, nextHeight, policy.CoreExtProfiles, policy.RotationProvider)
 		if err != nil {
 			return err
 		}

--- a/clients/go/node/mempool.go
+++ b/clients/go/node/mempool.go
@@ -290,6 +290,15 @@ func (m *Mempool) checkParsedTransactionWithSnapshot(
 	if err != nil {
 		return nil, nil, err
 	}
+	if policy.PolicyRejectCoreExtPreActivation {
+		reject, reason, err := rejectCoreSimplicityPreActivation(tx, policyUtxos, nextHeight, policy.RotationProvider)
+		if err != nil {
+			return nil, nil, txAdmitRejected(err.Error())
+		}
+		if reject {
+			return nil, nil, txAdmitRejected(reason)
+		}
+	}
 
 	// Perform consensus validation
 	checked, err := m.validateTransactionWithConsensus(txBytes, tx, txid, wtxid, snapshot, nextHeight, blockMTP, policy)

--- a/clients/go/node/mempool_policy.go
+++ b/clients/go/node/mempool_policy.go
@@ -127,8 +127,8 @@ func (m *Mempool) policySnapshot() MempoolConfig {
 //
 // Trigger conditions:
 //
-//  1. `PolicyRejectCoreExtPreActivation` is on — the CORE_EXT classifier
-//     reads input state for any candidate, so the snapshot is required
+//  1. `PolicyRejectCoreExtPreActivation` is on — the pre-activation classifier
+//     reads input state for CORE_EXT and CORE_SIMPLICITY candidates, so the snapshot is required
 //     regardless of tx shape.
 //  2. The DA path is exercisable AND the tx is DA-bearing
 //     (`daBytes > 0`). `applyPolicyAgainstState` repeats the DA-bearing

--- a/clients/go/node/mempool_precheck.go
+++ b/clients/go/node/mempool_precheck.go
@@ -93,6 +93,15 @@ func (m *Mempool) checkTransactionWithSnapshot(txBytes []byte, snapshot *chainSt
 	if err != nil {
 		return nil, nil, err
 	}
+	if policy.PolicyRejectCoreExtPreActivation {
+		reject, reason, err := rejectCoreSimplicityPreActivation(parsedTx, policyUtxos, nextHeight, policy.RotationProvider)
+		if err != nil {
+			return nil, nil, txAdmitRejected(err.Error())
+		}
+		if reject {
+			return nil, nil, txAdmitRejected(reason)
+		}
+	}
 	checked, err := consensus.CheckTransactionWithOwnedUtxoSetAndCoreExtProfilesAndSuiteContext(
 		txBytes,
 		snapshot.utxos,

--- a/clients/go/node/mempool_test.go
+++ b/clients/go/node/mempool_test.go
@@ -2449,6 +2449,113 @@ func TestMempoolPolicyRejectsCoreExtSpendPreActivation(t *testing.T) {
 	}
 }
 
+func TestMempoolPolicyRejectsCoreSimplicityPreActivationBeforeConsensus(t *testing.T) {
+	fromKey := mustNodeMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{100})
+
+	mp, err := NewMempoolWithConfig(st, nil, devnetGenesisChainID, MempoolConfig{
+		PolicyRejectCoreExtPreActivation: true,
+	})
+	if err != nil {
+		t.Fatalf("new mempool: %v", err)
+	}
+
+	createTx := txWithOneInputOneOutput(outpoints[0].Txid, outpoints[0].Vout, 1, consensus.COV_TYPE_CORE_SIMPLICITY, simplicityCovenantDataForNodeTest([32]byte{0x53}, nil), nil)
+	if err := mp.AddTx(createTx); err == nil || !strings.Contains(err.Error(), "CORE_SIMPLICITY output pre-ACTIVE") {
+		t.Fatalf("expected CORE_SIMPLICITY output policy rejection, got %v", err)
+	}
+	if _, err := mp.RelayMetadata(createTx); err == nil || !strings.Contains(err.Error(), "CORE_SIMPLICITY output pre-ACTIVE") {
+		t.Fatalf("expected relay CORE_SIMPLICITY output policy rejection, got %v", err)
+	}
+
+	var prev [32]byte
+	prev[0] = 0x54
+	st.Utxos[consensus.Outpoint{Txid: prev, Vout: 0}] = consensus.UtxoEntry{
+		Value:        100,
+		CovenantType: consensus.COV_TYPE_CORE_SIMPLICITY,
+		CovenantData: simplicityCovenantDataForNodeTest([32]byte{0x55}, nil),
+	}
+	spendTx := txWithOneInputOneOutput(prev, 0, 99, consensus.COV_TYPE_P2PK, append([]byte(nil), fromAddress...), nil)
+	if err := mp.AddTx(spendTx); err == nil || !strings.Contains(err.Error(), "CORE_SIMPLICITY spend pre-ACTIVE") {
+		t.Fatalf("expected CORE_SIMPLICITY spend policy rejection, got %v", err)
+	}
+	if _, err := mp.RelayMetadata(spendTx); err == nil || !strings.Contains(err.Error(), "CORE_SIMPLICITY spend pre-ACTIVE") {
+		t.Fatalf("expected relay CORE_SIMPLICITY spend policy rejection, got %v", err)
+	}
+}
+
+func TestMempoolPolicyAllowsCoreSimplicityCreateWhenActive(t *testing.T) {
+	fromKey := mustNodeMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000})
+	entry := st.Utxos[outpoints[0]]
+
+	tx := &consensus.Tx{
+		Version: 1,
+		TxKind:  0x00,
+		TxNonce: 1,
+		Inputs:  []consensus.TxInput{{PrevTxid: outpoints[0].Txid, PrevVout: outpoints[0].Vout}},
+		Outputs: []consensus.TxOutput{
+			{Value: 100_000, CovenantType: consensus.COV_TYPE_CORE_SIMPLICITY, CovenantData: simplicityCovenantDataForNodeTest([32]byte{0x58}, nil)},
+			{Value: entry.Value - 200_000, CovenantType: consensus.COV_TYPE_P2PK, CovenantData: append([]byte(nil), fromAddress...)},
+		},
+	}
+	if err := consensus.SignTransaction(tx, st.Utxos, devnetGenesisChainID, fromKey); err != nil {
+		t.Fatalf("SignTransaction: %v", err)
+	}
+	txBytes, err := consensus.MarshalTx(tx)
+	if err != nil {
+		t.Fatalf("MarshalTx: %v", err)
+	}
+
+	mp, err := NewMempoolWithConfig(st, nil, devnetGenesisChainID, MempoolConfig{
+		PolicyRejectCoreExtPreActivation: true,
+		RotationProvider:                 testSimplicityRotation{activeAt: 0},
+	})
+	if err != nil {
+		t.Fatalf("new mempool: %v", err)
+	}
+	if err := mp.AddTx(txBytes); err != nil {
+		t.Fatalf("expected active CORE_SIMPLICITY policy allow, got %v", err)
+	}
+}
+
+func TestMempoolPolicyDoesNotMaskMalformedNonSimplicityOutput(t *testing.T) {
+	fromKey := mustNodeMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{100})
+	txBytes := mustMarshalTxForNodeTest(t, &consensus.Tx{
+		Version: 1,
+		TxKind:  0x00,
+		TxNonce: 1,
+		Inputs:  []consensus.TxInput{{PrevTxid: outpoints[0].Txid, PrevVout: outpoints[0].Vout}},
+		Outputs: []consensus.TxOutput{
+			{Value: 1, CovenantType: consensus.COV_TYPE_CORE_SIMPLICITY, CovenantData: simplicityCovenantDataForNodeTest([32]byte{0x59}, nil)},
+			{Value: 1, CovenantType: consensus.COV_TYPE_P2PK, CovenantData: nil},
+		},
+	})
+
+	mp, err := NewMempoolWithConfig(st, nil, devnetGenesisChainID, MempoolConfig{
+		PolicyRejectCoreExtPreActivation: true,
+	})
+	if err != nil {
+		t.Fatalf("new mempool: %v", err)
+	}
+	for _, admit := range []struct {
+		name string
+		run  func() error
+	}{
+		{"AddTx", func() error { return mp.AddTx(txBytes) }},
+		{"RelayMetadata", func() error { _, err := mp.RelayMetadata(txBytes); return err }},
+	} {
+		err := admit.run()
+		if err == nil || !strings.Contains(err.Error(), "invalid CORE_P2PK covenant_data length") || strings.Contains(err.Error(), "CORE_SIMPLICITY output pre-ACTIVE") {
+			t.Fatalf("%s err=%v, want malformed P2PK without CORE_SIMPLICITY policy masking", admit.name, err)
+		}
+	}
+}
+
 func TestMempoolPolicyAllowsCoreExtWhenProfileActive(t *testing.T) {
 	fromKey := mustNodeMLDSA87Keypair(t)
 	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())

--- a/clients/go/node/miner.go
+++ b/clients/go/node/miner.go
@@ -70,10 +70,11 @@ type MinerConfig struct {
 	// CurrentMempoolMinFeeRate above.
 	CurrentMempoolMinFeeRateFn func() uint64
 
-	// PolicyRejectCoreExtPreActivation controls non-consensus guardrails for CORE_EXT (COV_TYPE_CORE_EXT).
-	// When enabled, the miner will exclude transactions that create or spend CORE_EXT outputs
-	// whose profile(ext_id, height) is not ACTIVE. This is a safety policy to avoid pre-activation
-	// anyone-can-spend risk; consensus validity is unaffected.
+	// PolicyRejectCoreExtPreActivation controls non-consensus pre-activation guardrails
+	// for CORE_EXT and CORE_SIMPLICITY. When enabled, the miner will exclude
+	// transactions that create or spend CORE_EXT outputs whose profile(ext_id, height)
+	// is not ACTIVE, and CORE_SIMPLICITY transactions until the miner rotation provider
+	// reports Simplicity active at the candidate height.
 	//
 	// If CoreExtProfiles is nil, all CORE_EXT profiles are treated as not ACTIVE.
 	PolicyRejectCoreExtPreActivation bool

--- a/clients/go/node/miner_core_ext_policy_test.go
+++ b/clients/go/node/miner_core_ext_policy_test.go
@@ -154,6 +154,20 @@ func TestMinerPolicyFiltersCoreExtSpend(t *testing.T) {
 	}
 }
 
+func TestMinerPolicyFiltersCoreSimplicityPreActivation(t *testing.T) {
+	var prev [32]byte
+	prev[0] = 0x24
+	raw := txWithOneInputOneOutput(prev, 0, 1, consensus.COV_TYPE_CORE_SIMPLICITY, simplicityCovenantDataForNodeTest([32]byte{0x56}, nil), nil)
+	miner := &Miner{cfg: MinerConfig{PolicyRejectCoreExtPreActivation: true}}
+	_, _, ok, err := miner.trySelectFlatCandidate(raw, nil, 1, 0, ^uint64(0), 0)
+	if err != nil {
+		t.Fatalf("trySelectFlatCandidate: %v", err)
+	}
+	if ok {
+		t.Fatalf("CORE_SIMPLICITY output tx must be filtered")
+	}
+}
+
 func TestMinerPolicySkipsMalformedCoreExtOutput(t *testing.T) {
 	dir := t.TempDir()
 	chainStatePath := ChainStatePath(dir)

--- a/clients/go/node/miner_helpers.go
+++ b/clients/go/node/miner_helpers.go
@@ -62,7 +62,11 @@ func (m *Miner) rejectCandidateCoreExtPolicy(tx *consensus.Tx, utxos map[consens
 		return false, nil
 	}
 
-	reject, _, err := RejectCoreExtTxPreActivation(tx, utxos, nextHeight, m.cfg.CoreExtProfiles)
+	var rotation consensus.RotationProvider
+	if m.sync != nil {
+		rotation = m.sync.cfg.RotationProvider
+	}
+	reject, _, err := RejectCoreExtTxPreActivationWithRotation(tx, utxos, nextHeight, m.cfg.CoreExtProfiles, rotation)
 	if err != nil {
 		return false, err
 	}

--- a/clients/go/node/policy_core_ext.go
+++ b/clients/go/node/policy_core_ext.go
@@ -73,10 +73,16 @@ func RejectCoreExtTxOversizedPayload(
 	return false, "", nil
 }
 
-// RejectCoreExtTxPreActivation implements non-consensus policy guardrails for CORE_EXT.
+// RejectCoreExtTxPreActivation enforces non-consensus pre-activation policy
+// for CORE_EXT profiles and CORE_SIMPLICITY covenant exposure.
 //
 // It returns reject=true if tx creates or spends a CORE_EXT output whose profile(ext_id, height)
-// is not ACTIVE. If profiles is nil or lookup fails/misses, the profile is treated as not ACTIVE.
+// is not ACTIVE, or creates/spends a CORE_SIMPLICITY output before Simplicity activation.
+// If profiles is nil or lookup misses, the CORE_EXT profile is treated as not ACTIVE;
+// lookup errors are returned to the caller.
+// This compatibility entrypoint has no Simplicity rotation provider, so CORE_SIMPLICITY
+// is treated as pre-ACTIVE. Callers that can provide Simplicity activation state must use
+// RejectCoreExtTxPreActivationWithRotation.
 //
 // This is intended for wallet/mempool/miner admission policy to mitigate pre-activation
 // anyone-can-spend exposure. Consensus rules are implemented elsewhere.
@@ -85,6 +91,18 @@ func RejectCoreExtTxPreActivation(
 	utxos map[consensus.Outpoint]consensus.UtxoEntry,
 	height uint64,
 	profiles consensus.CoreExtProfileProvider,
+) (reject bool, reason string, err error) {
+	return RejectCoreExtTxPreActivationWithRotation(tx, utxos, height, profiles, nil)
+}
+
+// RejectCoreExtTxPreActivationWithRotation is the rotation-aware policy entrypoint.
+// It allows CORE_SIMPLICITY only when rotation reports Simplicity active at height.
+func RejectCoreExtTxPreActivationWithRotation(
+	tx *consensus.Tx,
+	utxos map[consensus.Outpoint]consensus.UtxoEntry,
+	height uint64,
+	profiles consensus.CoreExtProfileProvider,
+	rotation consensus.RotationProvider,
 ) (reject bool, reason string, err error) {
 	if tx == nil {
 		return true, "nil tx", fmt.Errorf("nil tx")
@@ -99,7 +117,11 @@ func RejectCoreExtTxPreActivation(
 			return reject, reason, err
 		}
 	}
-	return rejectCoreExtSpendsPreActivation(tx, utxos, height, profiles)
+	reject, reason, err = rejectCoreExtSpendsPreActivation(tx, utxos, height, profiles)
+	if err != nil || reject {
+		return reject, reason, err
+	}
+	return rejectCoreSimplicityPreActivation(tx, utxos, height, rotation)
 }
 
 func rejectCoreExtSpendsPreActivation(
@@ -124,4 +146,67 @@ func rejectCoreExtSpendsPreActivation(
 	}
 
 	return false, "", nil
+}
+
+func rejectCoreSimplicityPreActivation(
+	tx *consensus.Tx,
+	utxos map[consensus.Outpoint]consensus.UtxoEntry,
+	height uint64,
+	rotation consensus.RotationProvider,
+) (reject bool, reason string, err error) {
+	kind := coreSimplicityPolicyKind(tx, utxos)
+	if kind == "" {
+		return false, "", nil
+	}
+	active, err := coreSimplicityActive(height, rotation)
+	if err != nil {
+		return true, "CORE_SIMPLICITY deployment lookup failure",
+			fmt.Errorf("CORE_SIMPLICITY deployment lookup failure: %w", err)
+	}
+	if active {
+		return false, "", nil
+	}
+	if err := validateTxCovenantsGenesisWithActiveSimplicity(tx, height, rotation); err != nil {
+		return false, "", err
+	}
+	return true, fmt.Sprintf("CORE_SIMPLICITY %s pre-ACTIVE", kind), nil
+}
+
+func coreSimplicityPolicyKind(tx *consensus.Tx, utxos map[consensus.Outpoint]consensus.UtxoEntry) string {
+	for _, out := range tx.Outputs {
+		if out.CovenantType == consensus.COV_TYPE_CORE_SIMPLICITY {
+			return "output"
+		}
+	}
+	for _, in := range tx.Inputs {
+		op := consensus.Outpoint{Txid: in.PrevTxid, Vout: in.PrevVout}
+		entry, ok := utxos[op]
+		if ok && entry.CovenantType == consensus.COV_TYPE_CORE_SIMPLICITY {
+			return "spend"
+		}
+	}
+	return ""
+}
+
+func coreSimplicityActive(height uint64, rotation consensus.RotationProvider) (bool, error) {
+	provider, ok := rotation.(consensus.SimplicityDeploymentProvider)
+	if !ok {
+		return false, nil
+	}
+	return provider.SimplicityActiveAtHeight(height)
+}
+
+func validateTxCovenantsGenesisWithActiveSimplicity(tx *consensus.Tx, height uint64, rotation consensus.RotationProvider) error {
+	if rotation == nil {
+		rotation = consensus.DefaultRotationProvider{}
+	}
+	return consensus.ValidateTxCovenantsGenesis(tx, height, activeSimplicityGenesisRotation{RotationProvider: rotation})
+}
+
+type activeSimplicityGenesisRotation struct {
+	consensus.RotationProvider
+}
+
+func (activeSimplicityGenesisRotation) SimplicityActiveAtHeight(uint64) (bool, error) {
+	return true, nil
 }

--- a/clients/go/node/policy_core_ext_test.go
+++ b/clients/go/node/policy_core_ext_test.go
@@ -21,10 +21,39 @@ func (p testCoreExtProfiles) LookupCoreExtProfile(extID uint16, _ uint64) (conse
 	return consensus.CoreExtProfile{Active: active}, true, nil
 }
 
+type testSimplicityRotation struct {
+	activeAt uint64
+}
+
+func (r testSimplicityRotation) NativeCreateSuites(uint64) *consensus.NativeSuiteSet {
+	return consensus.NewNativeSuiteSet(consensus.SUITE_ID_ML_DSA_87)
+}
+
+func (r testSimplicityRotation) NativeSpendSuites(uint64) *consensus.NativeSuiteSet {
+	return consensus.NewNativeSuiteSet(consensus.SUITE_ID_ML_DSA_87)
+}
+
+func (r testSimplicityRotation) SimplicityActiveAtHeight(height uint64) (bool, error) {
+	return height >= r.activeAt, nil
+}
+
 func coreExtCovenantData(extID uint16, payload []byte) []byte {
 	out := consensus.AppendU16le(nil, extID)
 	out = consensus.AppendCompactSize(out, uint64(len(payload)))
 	out = append(out, payload...)
+	return out
+}
+
+func simplicityCovenantDataForNodeTest(programCMR [32]byte, state []byte) []byte {
+	out := append([]byte(nil), programCMR[:]...)
+	out = consensus.AppendCompactSize(out, uint64(len(state)))
+	out = append(out, state...)
+	return out
+}
+
+func p2pkCovenantDataForNodePolicyTest() []byte {
+	out := make([]byte, consensus.MAX_P2PK_COVENANT_DATA)
+	out[0] = consensus.SUITE_ID_ML_DSA_87
 	return out
 }
 
@@ -120,6 +149,67 @@ func TestRejectCoreExtTxPreActivation_RejectsSpendWhenProfileMissing(t *testing.
 	}
 	if !reject {
 		t.Fatalf("expected reject")
+	}
+}
+
+func TestRejectCoreExtTxPreActivation_RejectsSimplicityPreActivation(t *testing.T) {
+	var prev [32]byte
+	prev[0] = 0x14
+	spendUtxos := map[consensus.Outpoint]consensus.UtxoEntry{{Txid: prev, Vout: 0}: {
+		Value:        10,
+		CovenantType: consensus.COV_TYPE_CORE_SIMPLICITY,
+		CovenantData: simplicityCovenantDataForNodeTest([32]byte{0x52}, nil),
+	}}
+	tests := []struct {
+		name    string
+		raw     []byte
+		utxos   map[consensus.Outpoint]consensus.UtxoEntry
+		wantMsg string
+	}{
+		{"output", txWithOneInputOneOutput(prev, 0, 1, consensus.COV_TYPE_CORE_SIMPLICITY, simplicityCovenantDataForNodeTest([32]byte{0x51}, nil), nil), nil, "CORE_SIMPLICITY output pre-ACTIVE"},
+		{"spend", txWithOneInputOneOutput(prev, 0, 1, consensus.COV_TYPE_P2PK, p2pkCovenantDataForNodePolicyTest(), nil), spendUtxos, "CORE_SIMPLICITY spend pre-ACTIVE"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			reject, reason, err := RejectCoreExtTxPreActivation(mustParseTx(t, tc.raw), tc.utxos, 0, nil)
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if !reject || reason != tc.wantMsg {
+				t.Fatalf("reject=%v reason=%q, want %q", reject, reason, tc.wantMsg)
+			}
+		})
+	}
+}
+
+func TestRejectCoreExtTxPreActivation_AllowsSimplicityWhenActive(t *testing.T) {
+	var prev [32]byte
+	prev[0] = 0x16
+	raw := txWithOneInputOneOutput(prev, 0, 1, consensus.COV_TYPE_CORE_SIMPLICITY, simplicityCovenantDataForNodeTest([32]byte{0x53}, nil), nil)
+	tx := mustParseTx(t, raw)
+
+	reject, reason, err := RejectCoreExtTxPreActivationWithRotation(tx, nil, 10, nil, testSimplicityRotation{activeAt: 10})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if reject || reason != "" {
+		t.Fatalf("reject=%v reason=%q, want allow", reject, reason)
+	}
+}
+
+func TestRejectCoreExtTxPreActivation_IgnoresSimplicityWitnessWithoutSimplicityCovenant(t *testing.T) {
+	var prev [32]byte
+	prev[0] = 0x17
+	witness := []consensus.WitnessItem{{SuiteID: consensus.SUITE_ID_SIMPLICITY_ENVELOPE, Signature: []byte{0x01, 0x00, 0x00, consensus.SIGHASH_ALL}}}
+	raw := txWithOneInputOneOutput(prev, 0, 1, consensus.COV_TYPE_P2PK, make([]byte, consensus.MAX_P2PK_COVENANT_DATA), witness)
+	tx := mustParseTx(t, raw)
+
+	reject, reason, err := RejectCoreExtTxPreActivation(tx, nil, 0, nil)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if reject || reason != "" {
+		t.Fatalf("reject=%v reason=%q, want allow", reject, reason)
 	}
 }
 


### PR DESCRIPTION
Refs: Q-SIMPLICITY-POLICY-GO-01

## Summary
- Add Go node policy gating for CORE_SIMPLICITY create/spend before Simplicity activation.
- Apply the gate in AddTx, RelayMetadata, and miner candidate selection.
- Preserve active-height allowance and malformed non-Simplicity consensus errors.

## Scope
Go node policy only.

Consensus rules unchanged: YES
Consensus implementation files changed: NO
SECTION_HASHES.json unchanged: YES
Rust unchanged: YES
Spec unchanged: YES
Conformance fixtures unchanged: YES

## Rule -> Ceiling Table
- CORE_SIMPLICITY output create -> rejected before activation; allowed when RotationProvider reports Simplicity active.
- CORE_SIMPLICITY resolved-input spend -> rejected before activation; allowed when RotationProvider reports Simplicity active.
- Witness suite 0xF0 without CORE_SIMPLICITY output/resolved input -> not classified as CORE_SIMPLICITY policy.
- Malformed non-Simplicity outputs -> consensus structural error is preserved, not masked by policy.

## Tests
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -count=1 ./node -run "TestRejectCoreExtTxPreActivation_(RejectsSimplicity|AllowsSimplicity|IgnoresSimplicity)|TestMempoolPolicy(RejectsCoreSimplicity|AllowsCoreSimplicity|DoesNotMaskMalformed)|TestMinerPolicyFiltersCoreSimplicityPreActivation"' — PASS
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go vet ./node' — PASS
- python3 /Users/gpt/Documents/local-agent-protocols/common-preflight/check_complexity.py --repo /Users/gpt/Documents/rubin-protocol $(git diff --name-only --diff-filter=ACMR origin/main -- '*.go') — PASS
- python3 /Users/gpt/Documents/local-agent-protocols/common-preflight/rubin_common_preflight.py --repo /Users/gpt/Documents/rubin-protocol --base-ref origin/main --lane core — PASS
- git diff --check — PASS
- git verify-commit HEAD — PASS

## Behavior Impact
Pre-activation CORE_SIMPLICITY create/spend is rejected by Go node admission/template policy before it can be admitted or mined.

## Compatibility Impact
No consensus implementation files, Rust, spec, conformance fixture, wire-format, or shared corpus changes.

## Known Non-goals
- No Rust parity implementation; Rust remains deferred behind the gate.
- No Simplicity VM execution or spend enablement.
- No consensus constant or activation schedule change.

## Risk
Low within RUB-527: Go node policy admission/template gating.

## Rollback
Revert this commit.

## Not Checked
- Full clients/go ./... was not rerun after the final amendment; this PR used targeted node, vet, complexity, and common-preflight gates.
- Local coverage preflight was not rerun after the final node-only amendment; GitHub coverage is the current receipt.
- Rust workspace was not run because RUB-527 is Go node policy only and Rust is deferred.

Linear: RUB-527