### PR TITLE
RUB-516: keep CORE_EXT removal checks transition-safe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Sensitive files/content gate
         run: python3 tools/check_sensitive_files.py
 
-      - name: PV/CORE_EXT PR template compliance (policy)
+      - name: PV/sensitive PR template compliance (policy)
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: python3 tools/check_pv_doc_compliance.py

--- a/evidence/native-rotation/RUB-507-rotation-coverage-audit.md
+++ b/evidence/native-rotation/RUB-507-rotation-coverage-audit.md
@@ -73,7 +73,7 @@ Local command evidence:
   — PASS.
 - `python3 -m py_compile conformance/runner/run_cv_bundle.py conformance/runner/test_run_cv_bundle.py`
   — PASS.
-- `/Users/gpt/.local/bin/ruff check conformance/runner/run_cv_bundle.py conformance/runner/test_run_cv_bundle.py`
+- `$HOME/.local/bin/ruff check conformance/runner/run_cv_bundle.py conformance/runner/test_run_cv_bundle.py`
   — PASS.
 - `scripts/dev-env.sh -- bash -lc 'cd clients/go && go run ./cmd/formal-trace --fixtures-dir ../../conformance/fixtures --out ../../rubin-formal/traces/go_trace_v1.jsonl'`
   — PASS.

--- a/scripts/check-spec-invariants.mjs
+++ b/scripts/check-spec-invariants.mjs
@@ -72,7 +72,14 @@ const invariants = [
   { id: "REG_VAULT", re: /0x0101` `CORE_VAULT/, desc: "registry: CORE_VAULT = 0x0101" },
   { id: "REG_DA_COMMIT", re: /0x0103` `CORE_DA_COMMIT/, desc: "registry: CORE_DA_COMMIT = 0x0103" },
   { id: "REG_MULTISIG", re: /0x0104` `CORE_MULTISIG/, desc: "registry: CORE_MULTISIG = 0x0104" },
-  { id: "REG_0102_CORE_EXT", re: /0x0102` `CORE_EXT/, desc: "registry: CORE_EXT = 0x0102" },
+  {
+    id: "REG_0102_DISPOSITION",
+    any: [
+      /0x0102`\s+`CORE_EXT/,
+      /0x0102`\s+\*\(unassigned[^)]*TX_ERR_COVENANT_TYPE_INVALID[^)]*\)\*/i,
+    ],
+    desc: "registry: 0x0102 is recognized during the CORE_EXT removal window",
+  },
   { id: "RULE_CLAMP_POW_LIMIT", re: /min\(target_old \* 4,\s*POW_LIMIT\)/, desc: "retarget clamp uses POW_LIMIT" },
   { id: "RULE_TARGET_RANGE", re: /1 <= target <= POW_LIMIT/, desc: "target range bound present" },
   { id: "RULE_320_BIT", re: /320-bit/, desc: "320-bit arithmetic requirement present" },
@@ -86,7 +93,8 @@ const invariants = [
 
 let failed = 0;
 for (const inv of invariants) {
-  if (!inv.re.test(spec)) {
+  const patterns = inv.any || [inv.re];
+  if (!patterns.some((pattern) => pattern.test(spec))) {
     console.error(`FAIL [${inv.id}] ${inv.desc}`);
     failed += 1;
   }

--- a/tools/check_cv_txctx_schema.py
+++ b/tools/check_cv_txctx_schema.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
-"""Validate CV-TXCTX.json against its JSON Schema.
+"""Validate CV-TXCTX.json against its JSON Schema when the fixture exists.
 
 Usage:
     python3 tools/check_cv_txctx_schema.py [--fixtures PATH] [--schema PATH]
 
-Exits 0 on success, 1 on validation failure.
+Exits 0 on success or retired default fixture, 1 on validation failure.
 """
+from __future__ import annotations
+
 import argparse
 import json
 import sys
@@ -14,17 +16,16 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_FIXTURES = REPO_ROOT / "conformance" / "fixtures" / "CV-TXCTX.json"
 DEFAULT_SCHEMA = REPO_ROOT / "conformance" / "schemas" / "cv-txctx-v1.json"
+ROOT_OBJECT_ERROR = "<root>: expected object"
 
 
 def validate(fixture_path: Path, schema_path: Path) -> list[str]:
     """Return list of error messages. Empty = valid."""
-    # Always run structural invariants (duplicate IDs, vector_count consistency)
-    structural_errors = validate_structural_invariants(fixture_path)
-
     try:
         import jsonschema  # type: ignore[import-untyped]
     except ImportError:
         # Fallback: structural checks without jsonschema library
+        structural_errors = validate_structural_invariants(fixture_path)
         return structural_errors + validate_structural(fixture_path, schema_path)
 
     with open(schema_path) as f:
@@ -32,9 +33,25 @@ def validate(fixture_path: Path, schema_path: Path) -> list[str]:
     with open(fixture_path) as f:
         data = json.load(f)
 
-    validator = jsonschema.Draft202012Validator(schema)
-    schema_errors = sorted(validator.iter_errors(data), key=lambda e: list(e.path))
-    return [f"{'.'.join(str(p) for p in e.absolute_path)}: {e.message}" for e in schema_errors] + structural_errors
+    try:
+        jsonschema.Draft202012Validator.check_schema(schema)
+        validator = jsonschema.Draft202012Validator(schema)
+        schema_errors = sorted(validator.iter_errors(data), key=lambda e: list(e.path))
+    except jsonschema.exceptions.SchemaError as e:
+        return [f"schema: {e.message}"]
+    except jsonschema.exceptions.ValidationError as e:
+        return [f"schema: {e.message}"]
+
+    schema_messages = [
+        f"{'.'.join(str(p) for p in e.absolute_path)}: {e.message}"
+        for e in schema_errors
+    ]
+    structural_errors = validate_structural_invariants(fixture_path)
+    if schema_messages:
+        structural_errors = [
+            error for error in structural_errors if error != ROOT_OBJECT_ERROR
+        ]
+    return schema_messages + structural_errors
 
 
 def validate_structural_invariants(fixture_path: Path) -> list[str]:
@@ -44,7 +61,7 @@ def validate_structural_invariants(fixture_path: Path) -> list[str]:
         data = json.load(f)
 
     if not isinstance(data, dict):
-        return ["top-level JSON must be an object"]
+        return [ROOT_OBJECT_ERROR]
 
     vectors = data.get("vectors")
     if not isinstance(vectors, list):
@@ -77,6 +94,9 @@ def validate_structural(fixture_path: Path, schema_path: Path) -> list[str]:
 
     with open(fixture_path) as f:
         data = json.load(f)
+
+    if not isinstance(data, dict):
+        return errors
 
     # Top-level required fields
     for key in ("gate", "spec", "version", "profiles", "vectors", "vector_count"):
@@ -124,13 +144,20 @@ def validate_structural(fixture_path: Path, schema_path: Path) -> list[str]:
     return errors
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
+    raw_argv = sys.argv[1:] if argv is None else argv
+    fixture_arg_provided = any(
+        arg == "--fixtures" or arg.startswith("--fixtures=") for arg in raw_argv
+    )
     parser = argparse.ArgumentParser(description="Validate CV-TXCTX.json schema")
     parser.add_argument("--fixtures", type=Path, default=DEFAULT_FIXTURES)
     parser.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA)
-    args = parser.parse_args()
+    args = parser.parse_args(raw_argv)
 
     if not args.fixtures.exists():
+        if args.fixtures == DEFAULT_FIXTURES and not fixture_arg_provided:
+            print(f"SKIP: default CV-TXCTX fixture retired: {args.fixtures}")
+            return 0
         print(f"FAIL: fixture file not found: {args.fixtures}", file=sys.stderr)
         return 1
     if not args.schema.exists():

--- a/tools/check_no_absolute_paths.py
+++ b/tools/check_no_absolute_paths.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
+from __future__ import annotations
 
-import subprocess
-import sys
+import argparse
+import shutil
+import subprocess  # nosec B404
 from pathlib import Path
 
-
-REPO_ROOT = Path(__file__).resolve().parents[1]
 
 DISALLOWED_SUBSTRINGS = [
     "/" + "Users" + "/",
@@ -13,14 +13,34 @@ DISALLOWED_SUBSTRINGS = [
 ]
 
 
-def iter_tracked_files() -> list[Path]:
-    out = subprocess.check_output(["git", "ls-files"], cwd=str(REPO_ROOT), text=True)
+def git_executable() -> str:
+    git = shutil.which("git")
+    if git is None:
+        raise RuntimeError("git executable not found")
+    return git
+
+
+def resolve_repo_root(start: Path) -> Path:
+    out = subprocess.check_output(  # nosec B603
+        [git_executable(), "rev-parse", "--show-toplevel"],
+        cwd=str(start),
+        text=True,
+    )
+    return Path(out.strip()).resolve()
+
+
+def iter_tracked_files(repo_root: Path) -> list[Path]:
+    out = subprocess.check_output(  # nosec B603
+        [git_executable(), "ls-files"],
+        cwd=str(repo_root),
+        text=True,
+    )
     paths: list[Path] = []
     for line in out.splitlines():
         line = line.strip()
         if not line:
             continue
-        paths.append(REPO_ROOT / line)
+        paths.append(repo_root / line)
     return paths
 
 
@@ -37,10 +57,22 @@ def should_scan(p: Path) -> bool:
     return True
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Reject tracked files containing local absolute home paths."
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path.cwd(),
+        help="Repository root to scan. Defaults to the current working directory.",
+    )
+    args = parser.parse_args(argv)
+    repo_root = resolve_repo_root(args.repo_root.resolve())
+
     bad: list[str] = []
-    for p in iter_tracked_files():
-        rel = str(p.relative_to(REPO_ROOT))
+    for p in iter_tracked_files(repo_root):
+        rel = str(p.relative_to(repo_root))
         if not should_scan(p):
             continue
         try:

--- a/tools/tests/test_check_cv_txctx_schema.py
+++ b/tools/tests/test_check_cv_txctx_schema.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import io
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+TOOLS_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(TOOLS_DIR))
+
+import check_cv_txctx_schema as m  # noqa: E402
+
+
+class CvTxctxSchemaMainTests(unittest.TestCase):
+    def test_missing_default_fixture_is_retired_skip(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            retired = Path(td) / "CV-TXCTX.json"
+            captured = io.StringIO()
+            with mock.patch.object(m, "DEFAULT_FIXTURES", retired):
+                with mock.patch("sys.stdout", captured):
+                    rc = m.main([])
+        self.assertEqual(rc, 0)
+        self.assertIn("SKIP: default CV-TXCTX fixture retired", captured.getvalue())
+
+    def test_missing_explicit_fixture_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            missing = Path(td) / "missing.json"
+            captured = io.StringIO()
+            with mock.patch("sys.stderr", captured):
+                rc = m.main(["--fixtures", str(missing)])
+        self.assertEqual(rc, 1)
+        self.assertIn("FAIL: fixture file not found", captured.getvalue())
+
+    def test_missing_explicit_fixture_equals_form_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            missing = Path(td) / "missing.json"
+            captured = io.StringIO()
+            with mock.patch("sys.stderr", captured):
+                rc = m.main([f"--fixtures={missing}"])
+        self.assertEqual(rc, 1)
+        self.assertIn("FAIL: fixture file not found", captured.getvalue())
+
+    def test_invalid_schema_returns_deterministic_error(self) -> None:
+        try:
+            import jsonschema  # noqa: F401
+        except ImportError:
+            self.skipTest("jsonschema is not installed")
+
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            fixture = root / "fixture.json"
+            schema = root / "schema.json"
+            fixture.write_text(json.dumps({}), encoding="utf-8")
+            schema.write_text(json.dumps({"type": 1}), encoding="utf-8")
+
+            errors = m.validate(fixture, schema)
+
+        self.assertTrue(errors)
+        self.assertTrue(errors[0].startswith("schema: "))
+
+    def test_jsonschema_path_owns_top_level_type_error(self) -> None:
+        try:
+            import jsonschema  # noqa: F401
+        except ImportError:
+            self.skipTest("jsonschema is not installed")
+
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            fixture = root / "fixture.json"
+            schema = root / "schema.json"
+            fixture.write_text(json.dumps([]), encoding="utf-8")
+            schema.write_text(json.dumps({"type": "object"}), encoding="utf-8")
+
+            errors = m.validate(fixture, schema)
+
+        self.assertTrue(errors)
+        self.assertNotIn(m.ROOT_OBJECT_ERROR, errors)
+
+    def test_permissive_schema_does_not_accept_non_object_root(self) -> None:
+        try:
+            import jsonschema  # noqa: F401
+        except ImportError:
+            self.skipTest("jsonschema is not installed")
+
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            fixture = root / "fixture.json"
+            schema = root / "schema.json"
+            fixture.write_text(json.dumps([]), encoding="utf-8")
+            schema.write_text(json.dumps({}), encoding="utf-8")
+
+            errors = m.validate(fixture, schema)
+
+        self.assertEqual(errors, [m.ROOT_OBJECT_ERROR])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_check_no_absolute_paths.py
+++ b/tools/tests/test_check_no_absolute_paths.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess  # nosec B404
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+TOOLS_DIR = Path(__file__).resolve().parents[1]
+if str(TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(TOOLS_DIR))
+
+import check_no_absolute_paths as m  # noqa: E402
+
+
+def _init_repo(root: Path) -> None:
+    subprocess.run([_git(), "init", "-q"], cwd=root, check=True)  # nosec B603
+
+
+def _track(root: Path, rel: str, text: str) -> None:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    subprocess.run([_git(), "add", rel], cwd=root, check=True)  # nosec B603
+
+
+def _git() -> str:
+    git = shutil.which("git")
+    if git is None:
+        raise unittest.SkipTest("git executable not found")
+    return git
+
+
+class CheckNoAbsolutePathsTests(unittest.TestCase):
+    def test_repo_root_argument_scans_selected_repo(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            _init_repo(root)
+            _track(root, "README.md", "repo-relative path only\n")
+
+            self.assertEqual(m.main(["--repo-root", str(root)]), 0)
+
+    def test_disallowed_home_path_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            _init_repo(root)
+            path = "/" + "Users" + "/example/project\n"
+            _track(root, "README.md", f"local path: {path}")
+
+            self.assertEqual(m.main(["--repo-root", str(root)]), 1)
+
+    def test_default_from_subdir_scans_repo_toplevel(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            _init_repo(root)
+            path = "/" + "Users" + "/example/project\n"
+            _track(root, "README.md", f"local path: {path}")
+            subdir = root / ".github"
+            subdir.mkdir()
+
+            old_cwd = Path.cwd()
+            try:
+                os.chdir(subdir)
+                rc = m.main([])
+            finally:
+                os.chdir(old_cwd)
+
+        self.assertEqual(rc, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Linear: RUB-516
Refs: Q-CORE-EXT-REMOVAL-CI-SCRIPTS-01

Invariant:
Rubin protocol check scripts and CI policy gates stay green through the CORE_EXT removal transition without expecting retired CORE_EXT fixture surfaces.

Layer:
Tooling / CI / evidence hygiene. No consensus, client runtime, fixture content, spec prose, or SECTION_HASHES change.

Files changed:
- `.github/workflows/ci.yml`
- `scripts/check-spec-invariants.mjs`
- `tools/check_cv_txctx_schema.py`
- `tools/check_no_absolute_paths.py`
- `tools/tests/test_check_cv_txctx_schema.py`
- `tools/tests/test_check_no_absolute_paths.py`
- `evidence/native-rotation/RUB-507-rotation-coverage-audit.md`

Behavior impact:
- The default missing `CV-TXCTX.json` check is treated as a retired fixture skip, while explicit missing `--fixtures` paths still fail.
- The 0x0102 registry invariant accepts the current CORE_EXT form and the upcoming unassigned/invalid form during this transition window.
- `check_no_absolute_paths.py` resolves the selected git toplevel before scanning, so protocol-root and spec-ci cross-repo invocations scan the intended repository.
- The CI policy step label no longer names CORE_EXT as the active policy surface.

Compatibility impact:
- Python 3.9-compatible annotations are preserved for cross-repo spec-ci callers.
- No Go or Rust code changes.

Known non-goals:
- No fixture content changes.
- No client behavior changes.
- No spec prose or SECTION_HASHES changes.
- No Rust thaw/parity claim.

Tests:
- `python3 -m unittest discover -s tools/tests -p 'test_*.py'` — PASS
- `python3 tools/check_cv_txctx_schema.py` — PASS/SKIP retired default fixture
- `python3 tools/check_no_absolute_paths.py` — PASS
- `python3 tools/check_workflow_yaml_syntax.py .github/workflows/ci.yml` — PASS
- `RUBIN_SPEC_ROOT=/Users/gpt/Documents/rubin-spec-private/spec node scripts/check-spec-invariants.mjs` — PASS
- Synthetic future 0x0102 unassigned spec check — PASS
- `/Users/gpt/.local/bin/ruff check ...` — PASS
- `/Users/gpt/.local/bin/bandit -q ...` — PASS
- `/Users/gpt/.local/bin/vulture --min-confidence 100 ...` — PASS
- `semgrep --quiet --config auto ...` — PASS
- `python3 /Users/gpt/Documents/local-agent-protocols/common-preflight/rubin_common_preflight.py --repo /Users/gpt/Documents/rubin-protocol --base-ref origin/main --lane core` — PASS
- `git verify-commit HEAD` — PASS
- One isolated stock raw-diff reviewer — No findings

Not checked:
Full Go/Rust workspace coverage was not run because this is tooling/CI/docs-only and changes no Go/Rust implementation surface.
