### PR TITLE
RUB-360: Bound formal proof coverage claims

### DIFF
--- a/rubin-formal/PROOF_COVERAGE.md
+++ b/rubin-formal/PROOF_COVERAGE.md
@@ -4,10 +4,12 @@
 Authoritative machine-readable source: standalone `rubin-formal/proof_coverage.json`  
 In-repo summary: `rubin-protocol/rubin-formal/proof_coverage.json`
 
-Текущее состояние: authoritative standalone source-of-truth фиксирует `proof_level=refinement`,
-`claim_level=refined`, полный registry по 17 pinned section keys и явные `notes` / `limitations`
-для thin или partial entries. Файл в `rubin-protocol` — это summary subset для local CI/tooling;
-он не должен расходиться по top-level claim boundary и hash baseline, но может не содержать полный registry.
+Текущее состояние: in-repo summary фиксирует `proof_level=refinement`,
+`claim_level=refined`, registry по 18 section rows и явные `notes` / `limitations`
+для thin или partial entries. В `coverage_summary` зафиксированы текущие счетчики:
+11 `proved`, 7 `stated`, 0 `deferred`, 29 theorem references, 23 unique theorem names.
+Повтор theorem name в нескольких section rows является coverage reference reuse, а не
+дополнительным уникальным доказательством.
 
 ## Термины (важно)
 
@@ -18,13 +20,38 @@ In-repo summary: `rubin-protocol/rubin-formal/proof_coverage.json`
   - `byte` (byte-accurate слой),
   - `refined` (refinement to executable path).
 - `status=proved/stated/deferred` относится к конкретной pinned-секции **в рамках указанного `proof_level`**.
+- `coverage_summary.theorem_references` считает ссылки из section rows; для уникального
+  числа theorem names использовать `coverage_summary.unique_theorem_names`.
 
 Внешний аудит / freeze-ready коммуникации **НЕ ДОЛЖНЫ** трактовать `proof_level=refinement`
 как “formal verification of CANONICAL for all inputs/sections”.
 
+## Critical op bridge
+
+`rubin-formal/refinement_bridge.json` describes executable trace-op evidence. Its
+`evidence_level=fixture_trace_refinement` means Go trace replay over the committed
+replay-covered fixture traces for that gate plus the named bounded Lean theorem.
+It does **not** mean a universal proof for every possible input.
+
+Current bridge rows:
+
+| op | gate | model theorem | scope |
+| --- | --- | --- | --- |
+| `parse_tx` | `CV-PARSE` | `RubinFormal.transaction_wire_proved` | listed trace IDs `PARSE-01`, `PARSE-16` plus bounded transaction wire theorem |
+| `sighash_v1` | `CV-SIGHASH` | `RubinFormal.sighash_v1_proved` | listed trace IDs `SIGHASH-01`..`SIGHASH-05` plus bounded sighash theorem; no cryptographic security proof |
+| `retarget_v1` | `CV-POW` | `RubinFormal.difficulty_update_proved` | listed retarget trace IDs plus bounded arithmetic/clamp invariants |
+| `utxo_apply_basic` | `CV-UTXO-BASIC` | `RubinFormal.value_conservation_proved` | listed UTXO trace IDs plus bounded value-conservation statements; known trace drift allowances remain explicit |
+
+Known deferred proof-expansion follow-ups:
+
+- RUB-580: scope a universal `parse_tx` proof beyond fixture trace replay.
+- RUB-581: verify and scope the byte-wire trace bridge residual.
+
 Связка с hash-pinning:
 
-- `spec/SECTION_HASHES.json` сейчас содержит 17 pinned section keys.
+- `spec/SECTION_HASHES.json` baseline представлен `spec_section_hashes_sha3_256` в
+  `rubin-formal/proof_coverage.json`; current coverage registry contains 18 rows,
+  including `parallel_validation_equivalence`.
 - summary `proof_coverage.json` обязан совпадать с authoritative standalone файлом по
   `proof_level`, `claim_level`, `spec_section_hashes_sha3_256` и по смысловой границе claims
   для тех секций, которые он перечисляет.

--- a/rubin-formal/README.md
+++ b/rubin-formal/README.md
@@ -28,15 +28,16 @@ Machine-readable summary contract:
 
 ## Граница claims (критично)
 
-Этот proof-pack — executable replay/refinement coverage для conformance-фикстур (CV-*.json) и baseline-слой
-для дальнейшей формализации. Он нужен для воспроизводимого "якоря", но **не** является универсальной
-формальной верификацией CANONICAL.
+Этот proof-pack — executable replay/refinement coverage для replay-covered conformance-фикстур
+и baseline-слой для дальнейшей формализации. Runtime/parallel-only `CV-PV-*` gates не входят
+в текущий Lean replay scope. Он нужен для воспроизводимого "якоря", но **не** является
+универсальной формальной верификацией CANONICAL.
 Текущий machine-readable статус: `proof_level=refinement`, `claim_level=refined`.
 
 Разрешённые формулировки (OK):
 
-- "Lean executable semantics replay all conformance fixtures (CV-*.json)"
-- "Go(reference) → Lean refinement is checked for critical ops over conformance fixture set"
+- "Lean executable semantics replay the non-CV-PV conformance fixtures imported by RubinFormal.Conformance.Index"
+- "Go(reference) → Lean refinement is checked for listed critical ops over replay-covered fixture traces"
 
 Запрещённые формулировки (NOT OK):
 

--- a/rubin-formal/proof_coverage.json
+++ b/rubin-formal/proof_coverage.json
@@ -5,6 +5,22 @@
   "spec_source_file": "spec/RUBIN_L1_CANONICAL.md",
   "spec_section_hashes_file": "spec/SECTION_HASHES.json",
   "spec_section_hashes_sha3_256": "f7862a144ae9a62bbe0cf6ca721a3768c65c4a3ee34f6530e4919d063b14a70f",
+  "coverage_summary": {
+    "section_rows": 18,
+    "proved_rows": 11,
+    "stated_rows": 7,
+    "deferred_rows": 0,
+    "theorem_references": 29,
+    "unique_theorem_names": 23,
+    "reused_theorem_names": [
+      "RubinFormal.Conformance.cv_parse_vectors_pass",
+      "RubinFormal.Conformance.cv_subsidy_vectors_pass",
+      "RubinFormal.Conformance.cv_utxo_basic_vectors_pass",
+      "RubinFormal.Conformance.cv_validation_order_vectors_pass",
+      "RubinFormal.Conformance.cv_weight_vectors_pass"
+    ],
+    "counting_rule": "section_rows and theorem_references are registry coverage references; unique_theorem_names is the deduplicated theorem-name count and must not be inflated by cross-section reuse."
+  },
   "lean_toolchain_file": "rubin-formal/lean-toolchain",
   "refinement_bridge_file": "rubin-formal/refinement_bridge.json",
   "coverage": [
@@ -191,7 +207,6 @@
         "RubinFormal.Refinement.ParallelEquivalence.commit_equivalence_accept",
         "RubinFormal.Refinement.ParallelEquivalence.commit_equivalence_reject",
         "RubinFormal.Refinement.ParallelEquivalence.worker_purity",
-        "RubinFormal.Refinement.ParallelEquivalence.worker_deterministic",
         "RubinFormal.Refinement.ParallelEquivalence.reducer_permutation_invariant",
         "RubinFormal.Refinement.ParallelEquivalence.precompute_enables_reorder"
       ],
@@ -201,8 +216,9 @@
   "proof_level": "refinement",
   "claims": {
     "allowed": [
-      "Lean executable semantics replay all conformance fixtures (CV-*.json) with byte-level input coverage; this is not a universal proof of CANONICAL semantics",
-      "Go(reference) \u2192 Lean refinement is checked for critical ops over the full conformance fixture set (trace schema v1)",
+      "Lean executable semantics replay the non-CV-PV conformance fixtures imported by RubinFormal.Conformance.Index; this is not a universal proof of CANONICAL semantics",
+      "Go(reference) \u2192 Lean refinement is checked for listed critical ops over replay-covered fixture traces (trace schema v1), excluding runtime/parallel-only CV-PV gates",
+      "proved/stated coverage rows are interpreted at proof_level=refinement; repeated theorem names across multiple sections are coverage references, not additional unique proofs",
       "formal claims are bounded by explicit forbidden claims below"
     ],
     "forbidden": [

--- a/rubin-formal/refinement_bridge.json
+++ b/rubin-formal/refinement_bridge.json
@@ -8,28 +8,77 @@
       "gate": "CV-PARSE",
       "model_theorem": "RubinFormal.transaction_wire_proved",
       "lean_file": "rubin-formal/RubinFormal/PinnedSections.lean",
-      "evidence_level": "baseline"
+      "evidence_level": "fixture_trace_refinement",
+      "traced_vector_ids": [
+        "PARSE-01",
+        "PARSE-16"
+      ],
+      "scope": "Go trace replay for the listed CV-PARSE trace IDs plus the bounded transactionWireStatement theorem.",
+      "limitations": [
+        "PARSE-16 is replayed as a concrete generated trace vector.",
+        "This row does not claim all byte strings are universally refined against Go."
+      ]
     },
     {
       "op": "sighash_v1",
       "gate": "CV-SIGHASH",
       "model_theorem": "RubinFormal.sighash_v1_proved",
       "lean_file": "rubin-formal/RubinFormal/PinnedSections.lean",
-      "evidence_level": "baseline"
+      "evidence_level": "fixture_trace_refinement",
+      "traced_vector_ids": [
+        "SIGHASH-01",
+        "SIGHASH-02",
+        "SIGHASH-03",
+        "SIGHASH-04",
+        "SIGHASH-05"
+      ],
+      "scope": "Go trace replay for the listed CV-SIGHASH trace IDs plus the bounded sighashV1Statement theorem.",
+      "limitations": [
+        "This row does not claim a cryptographic security proof or universal equivalence for all transaction inputs."
+      ]
     },
     {
       "op": "retarget_v1",
       "gate": "CV-POW",
       "model_theorem": "RubinFormal.difficulty_update_proved",
       "lean_file": "rubin-formal/RubinFormal/PinnedSections.lean",
-      "evidence_level": "baseline"
+      "evidence_level": "fixture_trace_refinement",
+      "traced_vector_ids": [
+        "POW-01",
+        "POW-02",
+        "POW-03",
+        "POW-03A",
+        "POW-03C",
+        "POW-03D",
+        "POW-08",
+        "POW-09",
+        "POW-10"
+      ],
+      "scope": "Go trace replay for the listed CV-POW retarget trace IDs plus bounded arithmetic/clamp invariants in difficultyUpdateStatement.",
+      "limitations": [
+        "This row does not claim universal refinement for every retargetV1 input tuple."
+      ]
     },
     {
       "op": "utxo_apply_basic",
       "gate": "CV-UTXO-BASIC",
       "model_theorem": "RubinFormal.value_conservation_proved",
       "lean_file": "rubin-formal/RubinFormal/PinnedSections.lean",
-      "evidence_level": "baseline"
+      "evidence_level": "fixture_trace_refinement",
+      "traced_vector_ids": [
+        "CV-U-06",
+        "CV-U-09",
+        "CV-U-11",
+        "CV-U-13",
+        "CV-U-19",
+        "CV-U-EXT-01",
+        "CV-U-EXT-02",
+        "CV-U-EXT-03"
+      ],
+      "scope": "Go trace replay for the listed CV-UTXO-BASIC trace IDs plus bounded value-conservation statements.",
+      "limitations": [
+        "Known drift allowances in GoTraceV1Check remain explicit and this row does not claim universal SpendTx refinement."
+      ]
     }
   ]
 }

--- a/tools/check_formal_coverage.py
+++ b/tools/check_formal_coverage.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -35,11 +36,72 @@ REQUIRED_SECTION_KEYS = {
     "block_validation_order",
     "parallel_validation_equivalence",
 }
+THEOREM_DECL_RE = re.compile(r"^\s*theorem\s+([A-Za-z_][A-Za-z0-9_']*)\b", re.MULTILINE)
+NAMESPACE_RE = re.compile(r"^\s*namespace\s+([A-Za-z_][A-Za-z0-9_']*(?:\.[A-Za-z_][A-Za-z0-9_']*)*)\b")
+END_RE = re.compile(r"^\s*end(?:\s+([A-Za-z_][A-Za-z0-9_']*(?:\.[A-Za-z_][A-Za-z0-9_']*)*))?\s*$")
 
 
 def fail(msg: str) -> int:
     print(f"ERROR: {msg}", file=sys.stderr)
     return 1
+
+
+def declared_lean_theorems(lean_root: Path) -> set[str]:
+    names: set[str] = set()
+    for path in lean_root.rglob("*.lean"):
+        namespace_stack: list[str] = []
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if match := NAMESPACE_RE.match(line):
+                namespace_stack.append(match.group(1))
+                continue
+            if END_RE.match(line):
+                if namespace_stack:
+                    namespace_stack.pop()
+                continue
+            if match := THEOREM_DECL_RE.match(line):
+                theorem_name = match.group(1)
+                namespace = ".".join(namespace_stack)
+                names.add(f"{namespace}.{theorem_name}" if namespace else theorem_name)
+    return names
+
+
+def validate_coverage_summary(coverage: dict, rows: list[dict]) -> list[str]:
+    summary = coverage.get("coverage_summary")
+    if not isinstance(summary, dict):
+        return ["missing coverage_summary{} in rubin-formal/proof_coverage.json"]
+
+    status_counts = {status: 0 for status in ALLOWED_STATUS}
+    theorem_refs: list[str] = []
+    for index, row in enumerate(rows):
+        if not isinstance(row, dict):
+            return [f"coverage_summary cannot inspect non-object coverage[{index}]"]
+        status = row.get("status")
+        if status in status_counts:
+            status_counts[status] += 1
+        theorems = row.get("theorems", [])
+        if isinstance(theorems, list):
+            theorem_refs.extend(t for t in theorems if isinstance(t, str))
+
+    unique_theorems = sorted(set(theorem_refs))
+    reused_theorems = sorted(t for t in unique_theorems if theorem_refs.count(t) > 1)
+    expected = {
+        "section_rows": len(rows),
+        "proved_rows": status_counts["proved"],
+        "stated_rows": status_counts["stated"],
+        "deferred_rows": status_counts["deferred"],
+        "theorem_references": len(theorem_refs),
+        "unique_theorem_names": len(unique_theorems),
+        "reused_theorem_names": reused_theorems,
+    }
+
+    errors: list[str] = []
+    for key, value in expected.items():
+        if summary.get(key) != value:
+            errors.append(f"coverage_summary.{key} drift: expected {value!r}, got {summary.get(key)!r}")
+    rule = summary.get("counting_rule")
+    if not isinstance(rule, str) or "unique_theorem_names" not in rule:
+        errors.append("coverage_summary.counting_rule must explain theorem reference vs unique theorem-name counting")
+    return errors
 
 
 def main() -> int:
@@ -98,6 +160,13 @@ def main() -> int:
     rows = coverage.get("coverage")
     if not isinstance(rows, list):
         return fail("coverage[]. list is missing in proof_coverage.json")
+    declared_theorems = declared_lean_theorems(repo_root / "rubin-formal" / "RubinFormal")
+
+    summary_errors = validate_coverage_summary(coverage, rows)
+    if summary_errors:
+        for err in summary_errors:
+            print(f"ERROR: {err}", file=sys.stderr)
+        return 1
 
     seen_keys: set[str] = set()
     bad = False
@@ -132,6 +201,15 @@ def main() -> int:
             if not isinstance(theorems, list) or len(theorems) == 0:
                 print(f"ERROR: {key} has status={status} but empty theorems[]", file=sys.stderr)
                 bad = True
+        if isinstance(theorems, list):
+            for theorem_ref in theorems:
+                if not isinstance(theorem_ref, str) or not theorem_ref:
+                    print(f"ERROR: {key} has invalid theorem reference: {theorem_ref}", file=sys.stderr)
+                    bad = True
+                    continue
+                if theorem_ref not in declared_theorems:
+                    print(f"ERROR: {key} references missing Lean theorem declaration: {theorem_ref}", file=sys.stderr)
+                    bad = True
 
         if not isinstance(file_path, str) or not file_path:
             print(f"ERROR: {key} has missing file path", file=sys.stderr)
@@ -153,8 +231,8 @@ def main() -> int:
         return 1
 
     # Conformance fixture → Lean replay coverage check.
-    # Policy: every CV-*.json fixture MUST have a matching Lean vectors+replay module
-    # imported by Conformance/Index.lean, and a gate theorem named:
+    # Policy: every replay-covered CV-*.json fixture MUST have a matching Lean
+    # vectors+replay module imported by Conformance/Index.lean, and a gate theorem named:
     #   cv_<gate_snake>_vectors_pass
     #
     # This prevents silently adding fixtures without formal replay coverage.
@@ -180,6 +258,8 @@ def main() -> int:
         return fail("no CV-*.json fixtures found in conformance/fixtures")
 
     conf_bad = False
+    replay_fixture_files: list[Path] = []
+    skipped_fixture_files: list[Path] = []
     for p in fixture_files:
         fixture = json.loads(p.read_text(encoding="utf-8"))
         gate = fixture.get("gate")
@@ -188,7 +268,9 @@ def main() -> int:
             conf_bad = True
             continue
         if any(gate.startswith(prefix) for prefix in FORMAL_SKIP_GATE_PREFIXES):
+            skipped_fixture_files.append(p)
             continue
+        replay_fixture_files.append(p)
 
         camel = gate_to_camel(gate)
         snake = gate_to_snake(gate)
@@ -231,8 +313,9 @@ def main() -> int:
 
     print(
         f"OK: formal coverage baseline is consistent "
-        f"({len(seen_keys)} pinned section keys), "
-        f"{len(fixture_files)} conformance fixtures covered by Lean replay, "
+        f"({len(seen_keys)} section rows), "
+        f"{len(replay_fixture_files)} replay-covered conformance fixtures "
+        f"({len(skipped_fixture_files)} runtime/parallel-only fixtures skipped), "
         f"proof_level={proof_level}, claim_level={claim_level}."
     )
     return 0

--- a/tools/check_formal_refinement_bridge.py
+++ b/tools/check_formal_refinement_bridge.py
@@ -5,6 +5,86 @@ import json
 import sys
 from pathlib import Path
 
+from check_formal_coverage import declared_lean_theorems
+
+
+ALLOWED_EVIDENCE_LEVEL = {"fixture_trace_refinement"}
+FORMAL_SKIP_GATE_PREFIXES = ("CV-PV-",)
+FORBIDDEN_SCOPE_MARKERS = ("universal", "for all", "all inputs", "all byte strings", "not bounded", "not-bounded")
+
+
+def valid_non_empty_string_list(value: object) -> bool:
+    return isinstance(value, list) and bool(value) and all(isinstance(item, str) and item for item in value)
+
+
+def states_bounded_scope(value: object) -> bool:
+    if not isinstance(value, str):
+        return False
+    lowered = value.lower()
+    if any(marker in lowered for marker in FORBIDDEN_SCOPE_MARKERS):
+        return False
+    words = set(lowered.replace("-", " ").split())
+    return "bounded" in words and "unbounded" not in words
+
+
+def trace_ids_for_op(trace_text: str, op: str) -> set[str]:
+    list_name_by_op = {
+        "parse_tx": "parseOuts",
+        "sighash_v1": "sighashOuts",
+        "retarget_v1": "powOuts",
+        "utxo_apply_basic": "utxoBasicOuts",
+    }
+    list_name = list_name_by_op.get(op)
+    if list_name is None:
+        return set()
+    marker = f"def {list_name} : List "
+    start = trace_text.find(marker)
+    if start == -1:
+        return set()
+    block_start = trace_text.find("[", start)
+    block_end = trace_text.find("\n]", block_start)
+    if block_start == -1 or block_end == -1:
+        return set()
+    block = trace_text[block_start:block_end]
+    ids: set[str] = set()
+    for item in block.split("},"):
+        if op == "retarget_v1" and 'op := "retarget_v1"' not in item:
+            continue
+        marker = 'id := "'
+        id_start = item.find(marker)
+        if id_start == -1:
+            continue
+        id_start += len(marker)
+        id_end = item.find('"', id_start)
+        if id_end != -1:
+            ids.add(item[id_start:id_end])
+    return ids
+
+
+def gate_to_camel(gate: str) -> str:
+    if not gate.startswith("CV-"):
+        raise ValueError(f"invalid gate name: {gate}")
+    return "".join(part.lower().capitalize() for part in gate[3:].split("-") if part)
+
+
+def has_lean_replay_evidence(repo_root: Path, gate: str) -> bool:
+    if any(gate.startswith(prefix) for prefix in FORMAL_SKIP_GATE_PREFIXES):
+        return False
+    conformance_dir = repo_root / "rubin-formal" / "RubinFormal" / "Conformance"
+    index_path = conformance_dir / "Index.lean"
+    if not index_path.exists():
+        return False
+    camel = gate_to_camel(gate)
+    vectors_file = conformance_dir / f"CV{camel}Vectors.lean"
+    replay_file = conformance_dir / f"CV{camel}Replay.lean"
+    index_text = index_path.read_text(encoding="utf-8")
+    return (
+        vectors_file.exists()
+        and replay_file.exists()
+        and f"import RubinFormal.Conformance.CV{camel}Vectors" in index_text
+        and f"import RubinFormal.Conformance.CV{camel}Replay" in index_text
+    )
+
 
 def fail(msg: str) -> int:
     print(f"ERROR: {msg}", file=sys.stderr)
@@ -44,15 +124,6 @@ def parse_fixture_gates(fixtures_dir: Path) -> dict[str, set[str]]:
     return gate_ops
 
 
-def theorem_exists(repo_root: Path, theorem_name: str) -> bool:
-    short_name = theorem_name.split(".")[-1]
-    for p in (repo_root / "rubin-formal" / "RubinFormal").rglob("*.lean"):
-        txt = p.read_text(encoding="utf-8")
-        if f"theorem {short_name}" in txt:
-            return True
-    return False
-
-
 def main() -> int:
     repo_root = Path(__file__).resolve().parents[1]
     bridge_path = repo_root / "rubin-formal" / "refinement_bridge.json"
@@ -74,6 +145,11 @@ def main() -> int:
     matrix_text = matrix_path.read_text(encoding="utf-8")
     executable_ops = parse_executable_ops(matrix_text)
     gate_ops = parse_fixture_gates(fixtures_dir)
+    declared_theorems = declared_lean_theorems(repo_root / "rubin-formal" / "RubinFormal")
+    trace_path = repo_root / "rubin-formal" / "RubinFormal" / "Refinement" / "GoTraceV1.lean"
+    if not trace_path.exists():
+        return fail("rubin-formal/RubinFormal/Refinement/GoTraceV1.lean not found")
+    trace_text = trace_path.read_text(encoding="utf-8")
 
     bad = False
     for idx, row in enumerate(rows):
@@ -85,6 +161,10 @@ def main() -> int:
         gate = row.get("gate")
         theorem = row.get("model_theorem")
         lean_file = row.get("lean_file")
+        evidence_level = row.get("evidence_level")
+        traced_vector_ids = row.get("traced_vector_ids")
+        scope = row.get("scope")
+        limitations = row.get("limitations")
 
         if not isinstance(op, str) or not op:
             print(f"ERROR: critical_ops[{idx}] missing op", file=sys.stderr)
@@ -100,16 +180,46 @@ def main() -> int:
         elif op not in gate_ops[gate]:
             print(f"ERROR: op `{op}` is not present in fixture gate `{gate}`", file=sys.stderr)
             bad = True
+        elif not has_lean_replay_evidence(repo_root, gate):
+            print(f"ERROR: gate `{gate}` lacks imported Lean replay evidence for fixture_trace_refinement", file=sys.stderr)
+            bad = True
 
         if not isinstance(theorem, str) or not theorem:
             print(f"ERROR: missing model_theorem for op `{op}`", file=sys.stderr)
             bad = True
-        elif not theorem_exists(repo_root, theorem):
+        elif theorem not in declared_theorems:
             print(f"ERROR: theorem `{theorem}` not found in rubin-formal Lean files", file=sys.stderr)
             bad = True
 
         if not isinstance(lean_file, str) or not (repo_root / lean_file).exists():
             print(f"ERROR: lean_file missing for op `{op}`: {lean_file}", file=sys.stderr)
+            bad = True
+
+        if evidence_level not in ALLOWED_EVIDENCE_LEVEL:
+            print(
+                f"ERROR: invalid evidence_level for op `{op}`: {evidence_level}; "
+                f"expected one of {sorted(ALLOWED_EVIDENCE_LEVEL)}",
+                file=sys.stderr,
+            )
+            bad = True
+        if not valid_non_empty_string_list(traced_vector_ids):
+            print(f"ERROR: traced_vector_ids[] for op `{op}` must be a non-empty string list", file=sys.stderr)
+            bad = True
+        else:
+            expected_trace_ids = trace_ids_for_op(trace_text, op)
+            actual_trace_ids = set(traced_vector_ids)
+            if actual_trace_ids != expected_trace_ids:
+                print(
+                    f"ERROR: traced_vector_ids[] for op `{op}` drift: expected {sorted(expected_trace_ids)}, "
+                    f"got {sorted(actual_trace_ids)}",
+                    file=sys.stderr,
+                )
+                bad = True
+        if not states_bounded_scope(scope):
+            print(f"ERROR: scope for op `{op}` must state the bounded claim", file=sys.stderr)
+            bad = True
+        if not valid_non_empty_string_list(limitations):
+            print(f"ERROR: limitations[] for op `{op}` must be a non-empty string list", file=sys.stderr)
             bad = True
 
     if bad:

--- a/tools/tests/test_check_formal_coverage.py
+++ b/tools/tests/test_check_formal_coverage.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+TOOLS_DIR = Path(__file__).resolve().parents[1]
+if str(TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(TOOLS_DIR))
+
+import check_formal_coverage as m  # noqa: E402
+
+
+class FormalCoverageSummaryTests(unittest.TestCase):
+    def test_summary_accepts_exact_counts(self) -> None:
+        rows = [
+            {"status": "proved", "theorems": ["A", "B"]},
+            {"status": "stated", "theorems": ["A"]},
+            {"status": "deferred", "theorems": []},
+        ]
+        coverage = {
+            "coverage_summary": {
+                "section_rows": 3,
+                "proved_rows": 1,
+                "stated_rows": 1,
+                "deferred_rows": 1,
+                "theorem_references": 3,
+                "unique_theorem_names": 2,
+                "reused_theorem_names": ["A"],
+                "counting_rule": "unique_theorem_names is deduplicated",
+            }
+        }
+
+        self.assertEqual(m.validate_coverage_summary(coverage, rows), [])
+
+    def test_summary_rejects_drift(self) -> None:
+        rows = [{"status": "proved", "theorems": ["A", "A"]}]
+        coverage = {
+            "coverage_summary": {
+                "section_rows": 1,
+                "proved_rows": 1,
+                "stated_rows": 0,
+                "deferred_rows": 0,
+                "theorem_references": 1,
+                "unique_theorem_names": 1,
+                "reused_theorem_names": [],
+                "counting_rule": "unique_theorem_names is deduplicated",
+            }
+        }
+
+        errors = m.validate_coverage_summary(coverage, rows)
+
+        self.assertIn("coverage_summary.theorem_references drift: expected 2, got 1", errors)
+        self.assertIn("coverage_summary.reused_theorem_names drift: expected ['A'], got []", errors)
+
+    def test_summary_rejects_non_object_rows_without_traceback(self) -> None:
+        coverage = {"coverage_summary": {}}
+
+        self.assertEqual(m.validate_coverage_summary(coverage, ["bad"]), ["coverage_summary cannot inspect non-object coverage[0]"])
+
+    def test_declared_lean_theorems_collects_theorem_declarations_only(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            source = root / "Example.lean"
+            source.write_text(
+                (
+                    "namespace RubinFormal.Example\n"
+                    "theorem present_theorem : True := by trivial\n"
+                    "def helper_definition : Nat := 1\n"
+                    "end RubinFormal.Example\n"
+                ),
+                encoding="utf-8",
+            )
+
+            names = m.declared_lean_theorems(root)
+
+        self.assertIn("RubinFormal.Example.present_theorem", names)
+        self.assertNotIn("present_theorem", names)
+        self.assertNotIn("helper_definition", names)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_check_formal_refinement_bridge.py
+++ b/tools/tests/test_check_formal_refinement_bridge.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+TOOLS_DIR = Path(__file__).resolve().parents[1]
+if str(TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(TOOLS_DIR))
+
+import check_formal_refinement_bridge as m  # noqa: E402
+
+
+class FormalRefinementBridgeTests(unittest.TestCase):
+    def test_limitations_must_be_non_empty_string_list(self) -> None:
+        self.assertTrue(m.valid_non_empty_string_list(["bounded trace scope"]))
+        self.assertFalse(m.valid_non_empty_string_list([]))
+        self.assertFalse(m.valid_non_empty_string_list([""]))
+        self.assertFalse(m.valid_non_empty_string_list(["ok", 7]))
+        self.assertFalse(m.valid_non_empty_string_list("bounded trace scope"))
+
+    def test_scope_marker_rejects_unbounded(self) -> None:
+        self.assertTrue(m.states_bounded_scope("bounded fixture trace scope"))
+        self.assertFalse(m.states_bounded_scope("unbounded universal proof"))
+        self.assertFalse(m.states_bounded_scope("bounded universal proof for all inputs"))
+        self.assertFalse(m.states_bounded_scope("not bounded universal proof"))
+        self.assertFalse(m.states_bounded_scope("fixture trace scope"))
+
+    def test_trace_ids_for_op_uses_exact_trace_subset(self) -> None:
+        trace_text = '''
+def parseOuts : List ParseOut := [
+  { id := "PARSE-01", ok := true },
+  { id := "PARSE-16", ok := true }
+]
+
+def powOuts : List PowOut := [
+  { id := "POW-01", op := "retarget_v1", ok := true },
+  { id := "POW-04", op := "block_hash", ok := true }
+]
+'''
+
+        self.assertEqual(m.trace_ids_for_op(trace_text, "parse_tx"), {"PARSE-01", "PARSE-16"})
+        self.assertEqual(m.trace_ids_for_op(trace_text, "retarget_v1"), {"POW-01"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Invariant:
Formal proof coverage claims must match repository evidence: replay/refinement is bounded to replay-covered fixture traces, not a universal CANONICAL proof or a full conformance-fixture claim.

Layer:
Formal documentation, formal metadata, and local formal check tooling.

Files changed:
- rubin-formal/PROOF_COVERAGE.md
- rubin-formal/README.md
- rubin-formal/proof_coverage.json
- rubin-formal/refinement_bridge.json
- tools/check_formal_coverage.py
- tools/check_formal_refinement_bridge.py
- tools/tests/test_check_formal_coverage.py

Tests:
- Formal gates: check_formal_coverage, check_formal_refinement_bridge, check_formal_claims_lint, check_formal_risk_gate --profile phase0, and rubin-formal lake build — PASS.
- Python/tooling hygiene: unittest, json.tool, py_compile, ruff, semgrep, bandit, vulture, and git diff --check — PASS.
- Rubin common preflight core and local pre-push hook — PASS.
- git verify-commit HEAD — PASS.

Behavior impact:
No consensus, client runtime, spec, conformance fixture, or Rust behavior changes.

Compatibility impact:
Existing formal metadata remains proof_level=refinement / claim_level=refined, with mechanical count checks added for coverage_summary drift.

Known non-goals:
- No Rust changes or Rust parity thaw.
- No universal parse_tx proof in this PR.
- No byte-wire trace bridge expansion in this PR.

Follow-ups:
- RUB-580: scope universal parse_tx proof beyond fixture trace replay.
- RUB-581: verify and scope byte-wire trace bridge residual.

Risk:
Low. This narrows claims and adds drift checks; it does not change validation behavior.

Rollback:
Revert this commit.

Not checked:
Rust workspace was not run because RUB-360 is formal docs/metadata/tooling only and Rust is deferred/out of scope.

Linear: RUB-360