### PR TITLE
[RUB-517] Sync formal section-hash disposition

### DIFF
--- a/rubin-formal/proof_coverage.json
+++ b/rubin-formal/proof_coverage.json
@@ -4,7 +4,7 @@
   "claim_level": "refined",
   "spec_source_file": "spec/RUBIN_L1_CANONICAL.md",
   "spec_section_hashes_file": "spec/SECTION_HASHES.json",
-  "spec_section_hashes_sha3_256": "f7862a144ae9a62bbe0cf6ca721a3768c65c4a3ee34f6530e4919d063b14a70f",
+  "spec_section_hashes_sha3_256": "b87095c482a8c404c77069325191efec80966f22a1f829a0eed4c10f133dc8ab",
   "coverage_summary": {
     "section_rows": 18,
     "proved_rows": 11,


### PR DESCRIPTION
Invariant:
`rubin-formal/proof_coverage.json` records the SHA3-256 disposition for the `SECTION_HASHES.json` bytes produced by RUB-517.

Layer:
Formal disposition metadata only.

Files changed:
- `rubin-formal/proof_coverage.json`: update `spec_section_hashes_sha3_256` only.

Tests:
- `python3 -m json.tool rubin-formal/proof_coverage.json >/dev/null` — PASS
- Python check: LF-normalized SHA3-256 of `rubin-spec` PR #274 `spec/SECTION_HASHES.json` equals `b87095c482a8c404c77069325191efec80966f22a1f829a0eed4c10f133dc8ab` — PASS
- `python3 tools/check_formal_coverage.py` — PASS
- `python3 tools/check_formal_claims_lint.py` — PASS
- `python3 tools/check_formal_disposition_for_section_hashes.py --spec-root /Users/gpt/Documents/rubin-spec-rub517 --formal-root rubin-formal` — PASS
- `git diff --check` — PASS
- `git verify-commit HEAD` — PASS

Behavior impact:
No implementation behavior change.

Compatibility impact:
No formal claim level, proof level, theorem list, or coverage rows changed.

Known non-goals:
- No Lean theorem or formal proof update.
- No Go/Rust/client changes.
- No spec text changes in this PR.

Follow-ups:
This companion is intended to unblock rubin-spec PR #274's spec-ci formal disposition gate.

Risk:
Low; single metadata hash update tied to the referenced spec PR.

Rollback:
Revert this commit.

Not checked:
Full Lean build was not run; this PR does not change Lean sources.

Related: 2tbmz9y2xt-lang/rubin-spec#274
Linear: RUB-517