### PR TITLE
[RUB-517] Refresh formal section-hash disposition

### DIFF
--- a/rubin-formal/proof_coverage.json
+++ b/rubin-formal/proof_coverage.json
@@ -4,7 +4,7 @@
   "claim_level": "refined",
   "spec_source_file": "spec/RUBIN_L1_CANONICAL.md",
   "spec_section_hashes_file": "spec/SECTION_HASHES.json",
-  "spec_section_hashes_sha3_256": "b87095c482a8c404c77069325191efec80966f22a1f829a0eed4c10f133dc8ab",
+  "spec_section_hashes_sha3_256": "e5de49458d2bbb78b58a5a90c5c90618eb7533a24702755c8daee13992c6d31f",
   "coverage_summary": {
     "section_rows": 18,
     "proved_rows": 11,


### PR DESCRIPTION
Invariant:
Formal disposition points at the current RUB-517 `spec/SECTION_HASHES.json` content used by the companion rubin-spec PR.

Layer:
formal metadata

Files changed:
- `rubin-formal/proof_coverage.json`

Tests:
- `python3 -m json.tool rubin-formal/proof_coverage.json >/dev/null` — PASS
- exact SHA3 comparison against `/Users/gpt/Documents/rubin-spec-rub517/spec/SECTION_HASHES.json` — PASS
- `python3 tools/check_formal_coverage.py` — PASS
- `python3 tools/check_formal_claims_lint.py` — PASS
- `python3 tools/check_formal_disposition_for_section_hashes.py --spec-root /Users/gpt/Documents/rubin-spec-rub517 --formal-root rubin-formal` — PASS
- `git diff --check` — PASS
- `git verify-commit HEAD` — PASS

Behavior impact:
No executable behavior change. This updates only the formal metadata hash pointer.

Compatibility impact:
No client, fixture, or wire-format changes.

Known non-goals:
- No proof coverage claim changes.
- No spec text changes in this PR.
- No Rust or Go changes.

Risk:
Low; single JSON field update.

Rollback:
Revert this commit.

Not checked:
Full Go/Rust workspaces were not run because this PR changes only formal metadata.

Related:
- Companion for rubin-spec PR #274.
- Linear: RUB-517
