### PR TITLE
formal: refresh section hash disposition

### DIFF
--- a/rubin-formal/proof_coverage.json
+++ b/rubin-formal/proof_coverage.json
@@ -4,7 +4,7 @@
   "claim_level": "refined",
   "spec_source_file": "spec/RUBIN_L1_CANONICAL.md",
   "spec_section_hashes_file": "spec/SECTION_HASHES.json",
-  "spec_section_hashes_sha3_256": "e5de49458d2bbb78b58a5a90c5c90618eb7533a24702755c8daee13992c6d31f",
+  "spec_section_hashes_sha3_256": "556f717801a99e90937c7036911421f92bb5fbe0e8860c71ecf4117f4db1e5df",
   "coverage_summary": {
     "section_rows": 18,
     "proved_rows": 11,


### PR DESCRIPTION
Invariant:
Formal disposition metadata must point at the current spec SECTION_HASHES.json digest after the RUB-517 spec citation/hash refresh.

Layer:
Formal metadata.

Files changed:
- rubin-formal/proof_coverage.json

Tests:
- python3 -m json.tool rubin-formal/proof_coverage.json >/dev/null — PASS
- python3 tools/check_formal_coverage.py — PASS
- python3 tools/check_formal_claims_lint.py — PASS
- python3 tools/check_formal_disposition_for_section_hashes.py --spec-root /Users/gpt/Documents/rubin-spec-rub517 --formal-root rubin-formal — PASS
- python3 tools/check_formal_risk_gate.py --profile phase0 — PASS (pre-push reviewer)
- git diff --check — PASS
- git verify-commit HEAD — PASS

Behavior impact:
No runtime behavior changes.

Compatibility impact:
No Go, Rust, conformance fixture, or spec text changes.

Known non-goals:
- No Rust work.
- No client implementation work.
- No formal claim expansion.

Follow-ups:
- Merge after the companion spec PR updates SECTION_HASHES.json.

Risk:
Low: one metadata digest update.

Rollback:
Revert this commit.

Not checked:
Go/Rust test suites were not run because this PR only changes formal metadata.
