### PR TITLE
formal: refresh section hash disposition

### DIFF
--- a/rubin-formal/proof_coverage.json
+++ b/rubin-formal/proof_coverage.json
@@ -4,7 +4,7 @@
   "claim_level": "refined",
   "spec_source_file": "spec/RUBIN_L1_CANONICAL.md",
   "spec_section_hashes_file": "spec/SECTION_HASHES.json",
-  "spec_section_hashes_sha3_256": "3d6f67b26c40825f9b05efc8d28453c769cf5603674220781c1579ca640d1c8a",
+  "spec_section_hashes_sha3_256": "effe62648fd737ec5eb9816ac26449af317eeba620807e95c388732d28680072",
   "coverage_summary": {
     "section_rows": 18,
     "proved_rows": 11,

--- a/rubin-formal/proof_coverage.json
+++ b/rubin-formal/proof_coverage.json
@@ -4,7 +4,7 @@
   "claim_level": "refined",
   "spec_source_file": "spec/RUBIN_L1_CANONICAL.md",
   "spec_section_hashes_file": "spec/SECTION_HASHES.json",
-  "spec_section_hashes_sha3_256": "556f717801a99e90937c7036911421f92bb5fbe0e8860c71ecf4117f4db1e5df",
+  "spec_section_hashes_sha3_256": "3d6f67b26c40825f9b05efc8d28453c769cf5603674220781c1579ca640d1c8a",
   "coverage_summary": {
     "section_rows": 18,
     "proved_rows": 11,

--- a/rubin-formal/proof_coverage.json
+++ b/rubin-formal/proof_coverage.json
@@ -4,7 +4,7 @@
   "claim_level": "refined",
   "spec_source_file": "spec/RUBIN_L1_CANONICAL.md",
   "spec_section_hashes_file": "spec/SECTION_HASHES.json",
-  "spec_section_hashes_sha3_256": "effe62648fd737ec5eb9816ac26449af317eeba620807e95c388732d28680072",
+  "spec_section_hashes_sha3_256": "12dc7529b89b679d1cd9def00c98072ac4ae3eee9811f28a02356f908f7b624d",
   "coverage_summary": {
     "section_rows": 18,
     "proved_rows": 11,


### PR DESCRIPTION
Invariant:
Formal disposition metadata must point at the current rubin-spec PR #274 SECTION_HASHES.json digest.

Layer:
Formal metadata.

Files changed:
- rubin-formal/proof_coverage.json

Companion spec evidence:
- Spec PR: https://github.com/2tbmz9y2xt-lang/rubin-spec/pull/274
- Spec head: c84279756c049752460327f9df0e5edb273268bc
- Spec file: spec/SECTION_HASHES.json
- Spec SECTION_HASHES.json sha3-256: 12dc7529b89b679d1cd9def00c98072ac4ae3eee9811f28a02356f908f7b624d
- Merge order: merge this protocol PR first, then rerun/merge the companion spec PR. Spec PR validate is expected to fail until rubin-protocol main contains this digest.

Tests:
- python3 -m json.tool rubin-formal/proof_coverage.json >/dev/null — PASS
- python3 tools/check_formal_coverage.py — PASS
- python3 tools/check_formal_claims_lint.py — PASS
- python3 tools/check_formal_risk_gate.py --profile phase0 — PASS
- python3 tools/check_formal_disposition_for_section_hashes.py --spec-root /Users/gpt/Documents/rubin-spec-rub517 --formal-root rubin-formal — PASS
- git diff --check — PASS
- git verify-commit HEAD — PASS

Behavior impact:
No runtime behavior changes.

Compatibility impact:
No Go, Rust, conformance fixture, or spec text changes.

Known non-goals:
- No Rust work.
- No client implementation work.
- No formal claim expansion.

Follow-ups:
- After this PR is merged, rerun the companion spec PR validate check so it reads the updated formal disposition from rubin-protocol main.

Risk:
Low: one metadata digest update.

Rollback:
Revert this commit.

Not checked:
Go/Rust test suites were not run because this PR only changes formal metadata.