### PR TITLE
RUB-583: Enforce DA commit declared budget in Go mempool policy

### DIFF
--- a/clients/go/node/mempolicy_helpers.go
+++ b/clients/go/node/mempolicy_helpers.go
@@ -59,6 +59,9 @@ func extractTxInputs(checked *consensus.CheckedTransaction) []consensus.Outpoint
 
 // applyPolicyAgainstStateDA handles DA fee policy application
 func applyPolicyAgainstStateDA(checked *consensus.CheckedTransaction, policy MempoolConfig, utxos map[consensus.Outpoint]consensus.UtxoEntry) error {
+	if err := rejectDaCommitDeclaredBudget(checked.Tx, policy.PolicyMaxDaBytesPerBlock); err != nil {
+		return err
+	}
 	// Stage C DA fee policy: only enter the helper for DA-bearing tx when
 	// the DA-side floor is configured (MinDaFeeRate > 0) or a per-byte
 	// surcharge applies. Non-DA tx skip the helper entirely on the hot
@@ -94,6 +97,20 @@ func applyPolicyAgainstStateDA(checked *consensus.CheckedTransaction, policy Mem
 		if reject {
 			return txAdmitRejected(reason)
 		}
+	}
+	return nil
+}
+
+func rejectDaCommitDeclaredBudget(tx *consensus.Tx, maxDaBytesPerBlock uint64) error {
+	if tx == nil || tx.TxKind != 0x01 || tx.DaCommitCore == nil {
+		return nil
+	}
+	declaredDaBytes, err := mulU64NoOverflow(uint64(tx.DaCommitCore.ChunkCount), consensus.CHUNK_BYTES)
+	if err != nil {
+		return fmt.Errorf("DA declared chunk budget overflow (chunk_count=%d chunk_bytes=%d): %w", tx.DaCommitCore.ChunkCount, consensus.CHUNK_BYTES, err)
+	}
+	if maxDaBytesPerBlock > 0 && declaredDaBytes > maxDaBytesPerBlock {
+		return fmt.Errorf("DA declared chunk budget exceeded (declared_da_bytes=%d max_da_bytes=%d chunk_count=%d chunk_bytes=%d)", declaredDaBytes, maxDaBytesPerBlock, tx.DaCommitCore.ChunkCount, consensus.CHUNK_BYTES)
 	}
 	return nil
 }

--- a/clients/go/node/mempool_stats.go
+++ b/clients/go/node/mempool_stats.go
@@ -40,8 +40,14 @@ type MempoolAdmissionCounts struct {
 }
 
 type MempoolConfig struct {
-	MaxTransactions          int
-	MaxBytes                 int
+	MaxTransactions int
+	MaxBytes        int
+	// PolicyMaxDaBytesPerBlock caps the declared DA bytes of a DA_COMMIT
+	// transaction admitted to mempool/relay policy. The value is derived from
+	// DaCommitCore.ChunkCount * CHUNK_BYTES, not caller-supplied payload bytes.
+	// A zero value is treated as omitted and normalized to the miner policy
+	// default so partial configs do not accidentally disable the budget.
+	PolicyMaxDaBytesPerBlock uint64
 	PolicyDaSurchargePerByte uint64
 	// MinDaFeeRate is the spec-side per-byte DA fee floor
 	// (POLICY_MEMPOOL_ADMISSION_GENESIS.md Stage C `min_da_fee_rate`,
@@ -101,6 +107,7 @@ func DefaultMempoolConfig() MempoolConfig {
 	return MempoolConfig{
 		MaxTransactions:                      DefaultMempoolMaxTransactions,
 		MaxBytes:                             DefaultMempoolMaxBytes,
+		PolicyMaxDaBytesPerBlock:             minerDefaults.PolicyMaxDaBytesPerBlock,
 		PolicyDaSurchargePerByte:             minerDefaults.PolicyDaSurchargePerByte,
 		MinDaFeeRate:                         DefaultMinDaFeeRate,
 		PolicyRejectNonCoinbaseAnchorOutputs: minerDefaults.PolicyRejectNonCoinbaseAnchorOutputs,
@@ -134,6 +141,9 @@ func normalizeMempoolConfig(cfg MempoolConfig) MempoolConfig {
 	}
 	if cfg.MaxBytes <= 0 {
 		cfg.MaxBytes = DefaultMempoolMaxBytes
+	}
+	if cfg.PolicyMaxDaBytesPerBlock == 0 {
+		cfg.PolicyMaxDaBytesPerBlock = DefaultMinerConfig().PolicyMaxDaBytesPerBlock
 	}
 	if cfg.MinDaFeeRate == 0 {
 		cfg.MinDaFeeRate = DefaultMinDaFeeRate

--- a/clients/go/node/mempool_test.go
+++ b/clients/go/node/mempool_test.go
@@ -1207,6 +1207,125 @@ func TestMempoolPolicyAllowsSufficientFeeDaCommit(t *testing.T) {
 	}
 }
 
+func TestMempoolPolicyRejectsDaCommitDeclaredChunkBudget(t *testing.T) {
+	fromKey := mustNodeMLDSA87Keypair(t)
+	toKey := mustNodeMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000})
+
+	mp, err := NewMempoolWithConfig(st, nil, devnetGenesisChainID, MempoolConfig{
+		PolicyMaxDaBytesPerBlock: consensus.CHUNK_BYTES - 1,
+	})
+	if err != nil {
+		t.Fatalf("new mempool: %v", err)
+	}
+
+	txBytes := mustBuildSignedDaCommitTxWithChunkCount(t, st.Utxos, outpoints[0], 50_000, 950_000, 1, fromKey, toAddress, 1, []byte("0123456789"))
+	err = mp.AddTx(txBytes)
+	if err == nil || !strings.Contains(err.Error(), "DA declared chunk budget exceeded") {
+		t.Fatalf("expected DA declared chunk budget rejection, got %v", err)
+	}
+	var txErr *TxAdmitError
+	if !errors.As(err, &txErr) || txErr.Kind != TxAdmitRejected {
+		t.Fatalf("over-budget DA err=%v, want TxAdmitRejected", err)
+	}
+	if got := mp.Len(); got != 0 {
+		t.Fatalf("mempool len=%d after rejected AddTx, want 0", got)
+	}
+	if got := mp.BytesUsed(); got != 0 {
+		t.Fatalf("mempool bytes=%d after rejected AddTx, want 0", got)
+	}
+	if mp.lastAdmissionSeq != 0 {
+		t.Fatalf("rejected AddTx consumed admission_seq=%d, want 0", mp.lastAdmissionSeq)
+	}
+	counts := mp.AdmissionCounts()
+	if counts.Rejected != 1 || counts.Accepted != 0 || counts.Conflict != 0 || counts.Unavailable != 0 {
+		t.Fatalf("admission counts=%+v, want one rejected AddTx", counts)
+	}
+
+	_, err = mp.RelayMetadata(txBytes)
+	if !errors.As(err, &txErr) || txErr.Kind != TxAdmitRejected {
+		t.Fatalf("RelayMetadata over-budget err=%T %v, want TxAdmitRejected", err, err)
+	}
+	if !strings.Contains(txErr.Message, "DA declared chunk budget exceeded") {
+		t.Fatalf("RelayMetadata reason=%q, want declared chunk budget rejection", txErr.Message)
+	}
+	if got := mp.Len(); got != 0 {
+		t.Fatalf("RelayMetadata mutated mempool len=%d, want 0", got)
+	}
+	if got := mp.BytesUsed(); got != 0 {
+		t.Fatalf("RelayMetadata mutated mempool bytes=%d, want 0", got)
+	}
+	if mp.lastAdmissionSeq != 0 {
+		t.Fatalf("RelayMetadata consumed admission_seq=%d, want 0", mp.lastAdmissionSeq)
+	}
+}
+
+func TestMempoolPolicyAllowsDaCommitAtDeclaredChunkBudget(t *testing.T) {
+	fromKey := mustNodeMLDSA87Keypair(t)
+	toKey := mustNodeMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+	st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000})
+
+	mp, err := NewMempoolWithConfig(st, nil, devnetGenesisChainID, MempoolConfig{
+		PolicyMaxDaBytesPerBlock: consensus.CHUNK_BYTES,
+	})
+	if err != nil {
+		t.Fatalf("new mempool: %v", err)
+	}
+
+	txBytes := mustBuildSignedDaCommitTxWithChunkCount(t, st.Utxos, outpoints[0], 50_000, 950_000, 1, fromKey, toAddress, 1, []byte("0123456789"))
+	if _, err := mp.RelayMetadata(txBytes); err != nil {
+		t.Fatalf("RelayMetadata at budget: %v", err)
+	}
+	if got := mp.Len(); got != 0 {
+		t.Fatalf("RelayMetadata inserted tx; mempool len=%d, want 0", got)
+	}
+	if err := mp.AddTx(txBytes); err != nil {
+		t.Fatalf("AddTx at budget: %v", err)
+	}
+	if got := mp.Len(); got != 1 {
+		t.Fatalf("mempool len=%d, want 1", got)
+	}
+}
+
+func TestMempoolAdmissionSourceWrappersRejectDaCommitDeclaredBudget(t *testing.T) {
+	fromKey := mustNodeMLDSA87Keypair(t)
+	toKey := mustNodeMLDSA87Keypair(t)
+	fromAddress := consensus.P2PKCovenantDataForPubkey(fromKey.PubkeyBytes())
+	toAddress := consensus.P2PKCovenantDataForPubkey(toKey.PubkeyBytes())
+
+	cases := []struct {
+		name  string
+		admit func(*Mempool, []byte) error
+	}{
+		{name: "local", admit: func(mp *Mempool, tx []byte) error { return mp.AddTx(tx) }},
+		{name: "remote", admit: func(mp *Mempool, tx []byte) error { return mp.AddRemoteTx(tx) }},
+		{name: "reorg", admit: func(mp *Mempool, tx []byte) error { return mp.AddReorgTx(tx) }},
+	}
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			st, outpoints := testSpendableChainState(fromAddress, []uint64{1_000_000})
+			mp, err := NewMempoolWithConfig(st, nil, devnetGenesisChainID, MempoolConfig{
+				PolicyMaxDaBytesPerBlock: consensus.CHUNK_BYTES - 1,
+			})
+			if err != nil {
+				t.Fatalf("new mempool: %v", err)
+			}
+			txBytes := mustBuildSignedDaCommitTxWithChunkCount(t, st.Utxos, outpoints[0], 50_000, 950_000, uint64(i+1), fromKey, toAddress, 1, []byte("0123456789"))
+			err = tc.admit(mp, txBytes)
+			if err == nil || !strings.Contains(err.Error(), "DA declared chunk budget exceeded") {
+				t.Fatalf("expected DA declared chunk budget rejection, got %v", err)
+			}
+			if got := mp.Len(); got != 0 {
+				t.Fatalf("mempool len=%d, want 0", got)
+			}
+		})
+	}
+}
+
 // TestMempoolPartialConfigBackfillsMinDaFeeRateAndAdmitsSufficientDaTx
 // pins the default-config path for PR #1368: a partial MempoolConfig
 // literal is interpreted as defaults plus overrides, so an omitted
@@ -1288,6 +1407,9 @@ func TestMempoolConfigZeroMinDaFeeRateMeansDefault(t *testing.T) {
 	}
 	if got := mp.policy.MinDaFeeRate; got != DefaultMinDaFeeRate {
 		t.Fatalf("MinDaFeeRate=%d, want DefaultMinDaFeeRate=%d", got, DefaultMinDaFeeRate)
+	}
+	if got, want := mp.policy.PolicyMaxDaBytesPerBlock, DefaultMinerConfig().PolicyMaxDaBytesPerBlock; got != want {
+		t.Fatalf("PolicyMaxDaBytesPerBlock=%d, want default %d", got, want)
 	}
 	if got := mp.policy.PolicyDaSurchargePerByte; got != 2 {
 		t.Fatalf("PolicyDaSurchargePerByte=%d, want 2", got)
@@ -4222,6 +4344,22 @@ func mustBuildSignedDaCommitTx(
 	manifest []byte,
 ) []byte {
 	t.Helper()
+	return mustBuildSignedDaCommitTxWithChunkCount(t, utxos, input, amount, fee, nonce, signer, toAddress, 1, manifest)
+}
+
+func mustBuildSignedDaCommitTxWithChunkCount(
+	t *testing.T,
+	utxos map[consensus.Outpoint]consensus.UtxoEntry,
+	input consensus.Outpoint,
+	amount uint64,
+	fee uint64,
+	nonce uint64,
+	signer *consensus.MLDSA87Keypair,
+	toAddress []byte,
+	chunkCount uint16,
+	manifest []byte,
+) []byte {
+	t.Helper()
 	tx := &consensus.Tx{
 		Version: 1,
 		TxKind:  0x01,
@@ -4239,7 +4377,7 @@ func mustBuildSignedDaCommitTx(
 		Locktime:  0,
 		DaPayload: append([]byte(nil), manifest...),
 		DaCommitCore: &consensus.DaCommitCore{
-			ChunkCount:  1,
+			ChunkCount:  chunkCount,
 			BatchNumber: 1,
 		},
 	}


### PR DESCRIPTION
Invariant:
Go mempool/relay policy rejects DA_COMMIT transactions whose declared chunk count exceeds the configured per-block DA byte budget before admission or relay metadata side effects.

Layer:
Policy and tests. No consensus behavior is changed.

Files changed:
- clients/go/node/mempool_stats.go
- clients/go/node/mempolicy_helpers.go
- clients/go/node/mempool_test.go

Tests:
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -count=1 ./node -run "TestMempoolPolicy.*Da|TestMempoolRelayMetadata|TestMempoolAdmissionSourceWrappersRecordOrigin|TestMempoolAdmissionSourceWrappersRejectDaCommitDeclaredBudget"' — PASS
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go vet ./node' — PASS
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -count=1 ./node' — PASS
- scripts/dev-env.sh -- bash -lc 'cd clients/go && go test -count=1 ./...' — PASS
- python3 /Users/gpt/Documents/local-agent-protocols/common-preflight/rubin_common_preflight.py --repo /Users/gpt/Documents/rubin-protocol --base-ref origin/main --lane core — PASS
- scripts/dev-env.sh -- ./scripts/preflight-codacy-coverage.sh — PASS
- git verify-commit HEAD — PASS

Behavior impact:
Go mempool AddTx/AddRemoteTx/AddReorgTx and RelayMetadata now fail closed for over-budget DA_COMMIT declared chunk counts. At-budget DA_COMMIT remains accepted.

Compatibility impact:
No Rust, spec, conformance, fixture, P2P DA relay, or wire-format changes.

Known non-goals:
- No Rust parity implementation in this PR; Rust remains deferred behind the post-Go-devnet-ready gate.
- No DA ticket recognition, da_admission_cmr_set validation, compact/DA relay protocol change, or consensus DA admission change.

Follow-ups:
- Rust parity for this policy belongs to the deferred Rust parity stage after Go devnet-ready acceptance.

Risk:
Low within the Go policy slice: the check is admission/relay policy only and rejects before insertion or relay metadata side effects.

Rollback:
Revert this commit.

Not checked:
- Rust parity was not implemented because RUB-583 is Go-only and Rust parity is deferred.

Linear: RUB-583