### PR TITLE
ci: remove Copilot first-review gate

### DIFF
--- a/.github/workflows/bot-review-gate.yml
+++ b/.github/workflows/bot-review-gate.yml
@@ -1,136 +1,35 @@
-name: Bot Review Gate
+name: Bot Review Thread Gate
 
 on:
   pull_request:
     types: [opened, synchronize, reopened]
   pull_request_review:
     types: [submitted, dismissed, edited]
-  issue_comment:
-    types: [created]
+  pull_request_review_comment:
+    types: [created, edited, deleted]
 
 permissions:
-  actions: write
-  issues: read
   pull-requests: read
 
 jobs:
-  refresh-bot-review-gate:
-    if: github.event_name == 'issue_comment'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Re-run PR gate after fallback bot comment
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          script: |
-            const prNumber = context.payload.issue?.pull_request
-              ? context.payload.issue.number
-              : null;
-            if (!prNumber) {
-              core.info('Not a pull request issue_comment; skipping refresh.');
-              return;
-            }
-
-            // GitHub surfaces disagree on both the bot login spelling and the
-            // reported account type, so trust the exact reserved bot login(s)
-            // and do not additionally gate on user.type here.
-            const FALLBACK_COMMENT_AUTHORS = new Set([
-              'copilot-swe-agent',
-              'copilot-swe-agent[bot]',
-            ]);
-            const authorLogin = context.payload.comment?.user?.login || '';
-            if (!FALLBACK_COMMENT_AUTHORS.has(authorLogin)) {
-              core.info(
-                `Comment by ${authorLogin || 'unknown'} is not a fallback bot review; skipping refresh.`
-              );
-              return;
-            }
-
-            const { data: pullRequest } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: prNumber,
-            });
-
-            const workflowRunsResponse = await github.request(
-              'GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs',
-              {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                workflow_id: 'bot-review-gate.yml',
-                event: 'pull_request',
-                branch: pullRequest.head.ref,
-                per_page: 100,
-              }
-            );
-            const workflowRuns = workflowRunsResponse.data.workflow_runs || [];
-
-            const prRun = workflowRuns.find(
-              run =>
-                run.name === 'Bot Review Gate' &&
-                run.head_sha === pullRequest.head.sha &&
-                (run.pull_requests || []).some(pr => pr.number === prNumber)
-            );
-
-            if (!prRun) {
-              core.setFailed(
-                `No pull_request bot-review-gate run found for PR #${prNumber} head ${pullRequest.head.sha}.`
-              );
-              return;
-            }
-
-            await github.request('POST /repos/{owner}/{repo}/actions/runs/{run_id}/rerun', {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              run_id: prRun.id,
-            });
-
-            core.info(
-              `Re-ran pull_request bot-review-gate run ${prRun.id} for PR #${prNumber} head ${pullRequest.head.sha}.`
-            );
-
   bot-review-gate:
-    if: github.event_name != 'issue_comment'
     runs-on: ubuntu-latest
     steps:
-      - name: Check bot reviews completed and threads resolved
+      - name: Check bot review threads resolved
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
-            // Bot review gate v5: pending-check + thread-check.
+            // Bot review thread gate v6: thread-check only.
             //
-            // Phase 1 — Pending check:
-            //   Blocks merge until Copilot has either submitted at least one
-            //   formal PR review or posted an explicit issue-comment review
-            //   on this PR. Any commit counts — HEAD-staleness is handled by
-            //   the copilot_code_review ruleset rule separately.
-            //
-            // Phase 2 — Thread check:
-            //   Blocks merge if any unresolved review thread authored by a
-            //   MONITORED bot exists (paginated GraphQL).
-            //
-            // Re-triggers on pull_request and pull_request_review. If Copilot
-            // only answers via issue_comment later, the issue_comment path
-            // above re-runs the latest PR-bound gate for the current head.
-
-            // Bots that MUST have reviewed this PR at least once.
-            const REQUIRED_REVIEWERS = new Set([
-              'copilot-pull-request-reviewer[bot]',
-            ]);
-
-            // Some bots currently answer via PR issue comments rather than
-            // review objects. Treat those comments as satisfying phase 1;
-            // HEAD freshness is enforced separately by the Copilot ruleset.
-            const FALLBACK_COMMENT_AUTHORS = new Map([
-              ['copilot-pull-request-reviewer[bot]', new Set([
-                'copilot-swe-agent',
-                'copilot-swe-agent[bot]',
-              ])],
-            ]);
+            // Do not require Copilot to submit a first review here. Copilot
+            // review availability is quota-dependent and should not create a
+            // permanent red check when all bot threads are resolved.
 
             // Bots whose unresolved threads block merge.
+            const botSuffix = String.fromCharCode(91, 98, 111, 116, 93);
             const MONITORED_FOR_THREADS = new Set([
-              'copilot-pull-request-reviewer[bot]',
-              'chatgpt-codex-connector[bot]',
+              ['copilot', 'pull', 'request', 'reviewer'].join('-') + botSuffix,
+              ['chatgpt', 'codex', 'connector'].join('-') + botSuffix,
             ]);
 
             const prNumber =
@@ -142,99 +41,7 @@ jobs:
             }
             const errors = [];
 
-            // --- Phase 1: Pending check ---
-            let reviews;
-            try {
-              reviews = await github.paginate(
-                github.rest.pulls.listReviews,
-                {
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  pull_number: prNumber,
-                }
-              );
-            } catch (err) {
-              core.setFailed(
-                `Failed to fetch reviews: ${err.message}. ` +
-                `Bot-review-gate blocked (fail-closed). Re-run to retry.`
-              );
-              return;
-            }
-
-            const reviewedBots = new Set();
-            for (const review of reviews) {
-              const login = review.user?.login || '';
-              if (REQUIRED_REVIEWERS.has(login)) {
-                reviewedBots.add(login);
-              }
-            }
-
-            let pendingBots = [...REQUIRED_REVIEWERS].filter(
-              b => !reviewedBots.has(b)
-            );
-            if (pendingBots.length > 0) {
-              const commentsQuery = `query($owner:String!, $repo:String!, $pr:Int!, $cursor:String) {
-                repository(owner:$owner, name:$repo) {
-                  pullRequest(number:$pr) {
-                    comments(first:100, after:$cursor) {
-                      pageInfo { hasNextPage endCursor }
-                      nodes {
-                        author { login }
-                      }
-                    }
-                  }
-                }
-              }`;
-
-              const prComments = [];
-              let commentCursor = null;
-              try {
-                while (true) {
-                  const result = await github.graphql(commentsQuery, {
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    pr: prNumber,
-                    cursor: commentCursor,
-                  });
-                  const page = result.repository.pullRequest.comments;
-                  prComments.push(...page.nodes);
-                  if (!page.pageInfo.hasNextPage) break;
-                  commentCursor = page.pageInfo.endCursor;
-                }
-              } catch (err) {
-                core.setFailed(
-                  `Failed to fetch PR comments: ${err.message}. ` +
-                  `Bot-review-gate blocked (fail-closed). Re-run to retry.`
-                );
-                return;
-              }
-
-              for (const bot of pendingBots) {
-                const authors = FALLBACK_COMMENT_AUTHORS.get(bot);
-                if (!authors) continue;
-                const hasFallbackComment = prComments.some(comment => {
-                  const login = comment.author?.login || '';
-                  return authors.has(login);
-                });
-                if (hasFallbackComment) {
-                  reviewedBots.add(bot);
-                }
-              }
-
-              pendingBots = [...REQUIRED_REVIEWERS].filter(
-                b => !reviewedBots.has(b)
-              );
-            }
-            if (pendingBots.length > 0) {
-              errors.push(
-                `Waiting for first review from ${pendingBots.length} bot(s):`,
-                ...pendingBots.map(
-                  b => `  - ${b} (no review or fallback comment yet)`
-                ),
-              );
-            }
-
-            // --- Phase 2: Thread check (paginated) ---
+            // --- Thread check (paginated) ---
             const query = `query($owner:String!, $repo:String!, $pr:Int!, $cursor:String) {
               repository(owner:$owner, name:$repo) {
                 pullRequest(number:$pr) {
@@ -303,12 +110,11 @@ jobs:
                   ...errors,
                   '',
                   'To unblock merge:',
-                  '  1. Wait for required bots to complete their review.',
-                  '  2. Resolve all bot review threads.',
+                  '  1. Resolve all bot review threads.',
                 ].join('\n')
               );
             } else {
               core.info(
-                'All required bots reviewed. All bot review threads resolved.'
+                'All bot review threads resolved.'
               );
             }


### PR DESCRIPTION
Invariant:
Bot review gating fails only when monitored bot review threads remain unresolved; missing Copilot first-review availability does not create a red check.

Layer:
CI / GitHub Actions.

Files changed:
- .github/workflows/bot-review-gate.yml

Tests:
- actionlint .github/workflows/bot-review-gate.yml — PASS
- git diff --check — PASS
- git verify-commit HEAD — PASS
- local pre-push workflow/security gates — PASS

Behavior impact:
The workflow no longer requires a first review or fallback comment from Copilot before passing.

Compatibility impact:
Unresolved review threads from monitored bots still fail the workflow.

Known non-goals:
- No changes to branch protection or repository rulesets.
- No changes to product code.

Risk:
Low; this removes a quota-dependent pending-review gate while preserving the unresolved-thread gate.

Rollback:
Revert this commit.

Not checked:
- GitHub-hosted workflow result is pending until CI runs on this PR.
