### PR TITLE
RUB-584: Harden retired Rust CLI CORE_EXT inputs

### DIFF
--- a/clients/rust/Cargo.lock
+++ b/clients/rust/Cargo.lock
@@ -576,7 +576,6 @@ dependencies = [
  "rubin-node",
  "serde",
  "serde_json",
- "sha2",
  "sha3",
 ]
 

--- a/clients/rust/crates/rubin-consensus-cli/Cargo.toml
+++ b/clients/rust/crates/rubin-consensus-cli/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 hex = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-sha2 = "0.10"
 sha3 = "0.10"
 num-bigint = "0.4"
 num-traits = "0.2"

--- a/clients/rust/crates/rubin-consensus-cli/src/main.rs
+++ b/clients/rust/crates/rubin-consensus-cli/src/main.rs
@@ -23,6 +23,7 @@ use rubin_consensus::{
     ROTATION_V1_PRODUCTION_FINITE_H4_REQUIRED_ERR_STEM,
 };
 use rubin_node::{devnet_genesis_chain_id, ChainState, TxPool, TxPoolAdmitErrorKind, TxPoolConfig};
+use serde::de::{IgnoredAny, SeqAccess, Visitor};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 use sha3::{Digest, Sha3_256};
@@ -44,6 +45,41 @@ const ROTATION_NEW_SUITE_NOT_REGISTERED_MSG: &str = "rotation: new suite ";
 const ROTATION_EQUAL_SUITE_IDS_MSG: &str = "must differ from new suite";
 const ROTATION_CREATE_HEIGHT_ORDER_MSG: &str = "rotation: create_height (";
 const ROTATION_SUNSET_HEIGHT_ORDER_MSG: &str = "rotation: sunset_height (";
+
+#[derive(Default)]
+struct RetiredCoreExtProfiles {
+    has_items: bool,
+}
+
+fn deserialize_retired_core_ext_profiles<'de, D>(
+    deserializer: D,
+) -> Result<RetiredCoreExtProfiles, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct RetiredCoreExtProfilesVisitor;
+
+    impl<'de> Visitor<'de> for RetiredCoreExtProfilesVisitor {
+        type Value = RetiredCoreExtProfiles;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            formatter.write_str("an array")
+        }
+
+        fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+        where
+            A: SeqAccess<'de>,
+        {
+            let mut has_items = false;
+            while seq.next_element::<IgnoredAny>()?.is_some() {
+                has_items = true;
+            }
+            Ok(RetiredCoreExtProfiles { has_items })
+        }
+    }
+
+    deserializer.deserialize_seq(RetiredCoreExtProfilesVisitor)
+}
 
 fn matches_wrapped_prefix_validation_err(err: &str, expected: &str) -> bool {
     err.starts_with(expected) || err.contains(&format!(": {expected}"))
@@ -169,8 +205,8 @@ struct Request {
     #[serde(default)]
     utxos: Vec<UtxoJson>,
 
-    #[serde(default)]
-    core_ext_profiles: Vec<Value>,
+    #[serde(default, deserialize_with = "deserialize_retired_core_ext_profiles")]
+    core_ext_profiles: RetiredCoreExtProfiles,
 
     #[serde(default)]
     core_ext_profile_set_anchor_hex: String,
@@ -1779,13 +1815,13 @@ fn relay_metadata_parse_reject(message: &str) -> bool {
 }
 
 fn reject_core_ext_profiles_from_json(
-    items: &[Value],
+    profiles: &RetiredCoreExtProfiles,
     expected_set_anchor_hex: &str,
 ) -> Result<(), String> {
     if !expected_set_anchor_hex.trim().is_empty() {
         return Err("core_ext_profile_set_anchor_hex unsupported by Rust runtime".to_string());
     }
-    if !items.is_empty() {
+    if profiles.has_items {
         return Err("core_ext_profiles unsupported by Rust runtime".to_string());
     }
     Ok(())
@@ -5513,13 +5549,15 @@ mod tests {
 
     #[test]
     fn core_ext_profiles_empty_input_is_retired_noop() {
-        reject_core_ext_profiles_from_json(&[], "").expect("empty retired profile input");
+        reject_core_ext_profiles_from_json(&RetiredCoreExtProfiles::default(), "")
+            .expect("empty retired profile input");
     }
 
     #[test]
     fn core_ext_profiles_non_empty_input_is_unsupported() {
-        let err = reject_core_ext_profiles_from_json(&[serde_json::json!({"ext_id": 9})], "")
-            .unwrap_err();
+        let err =
+            reject_core_ext_profiles_from_json(&RetiredCoreExtProfiles { has_items: true }, "")
+                .unwrap_err();
         assert_eq!(err, "core_ext_profiles unsupported by Rust runtime");
     }
 
@@ -5535,7 +5573,8 @@ mod tests {
 
     #[test]
     fn core_ext_profile_set_anchor_input_is_unsupported() {
-        let err = reject_core_ext_profiles_from_json(&[], "00").unwrap_err();
+        let err = reject_core_ext_profiles_from_json(&RetiredCoreExtProfiles::default(), "00")
+            .unwrap_err();
         assert_eq!(
             err,
             "core_ext_profile_set_anchor_hex unsupported by Rust runtime"

--- a/clients/rust/crates/rubin-consensus-cli/tests/retired_ops.rs
+++ b/clients/rust/crates/rubin-consensus-cli/tests/retired_ops.rs
@@ -1,0 +1,51 @@
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn run_cli(payload: &str) -> serde_json::Value {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_rubin-consensus-cli"))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("spawn rubin-consensus-cli");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(payload.as_bytes())
+        .expect("write request");
+
+    let output = child.wait_with_output().expect("wait for cli");
+    assert!(
+        output.status.success(),
+        "cli exited with {:?}: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).expect("json response")
+}
+
+#[test]
+fn retired_core_ext_tooling_ops_return_unknown_op() {
+    for op in [
+        "txctx_spend_vector",
+        "txctx_governance_vector",
+        "ext_envelope_parse",
+        "ext_activation_check",
+        "ext_pre_activation_spend",
+        "ext_enforcement_check",
+        "ext_error_priority",
+        "ext_duplicate_profile",
+    ] {
+        let response = run_cli(&format!(r#"{{"op":"{op}"}}"#));
+
+        assert_eq!(
+            response.get("ok").and_then(serde_json::Value::as_bool),
+            Some(false)
+        );
+        assert_eq!(
+            response.get("err").and_then(serde_json::Value::as_str),
+            Some("unknown op")
+        );
+    }
+}


### PR DESCRIPTION
Invariant:
Retired Rust CLI CORE_EXT inputs fail closed without retaining unsupported `core_ext_profiles` payloads, and retired CORE_EXT tooling op names return the existing `unknown op` response at the stdin CLI boundary.

Layer:
Rust CLI implementation hardening.

Files changed:
- `clients/rust/crates/rubin-consensus-cli/src/main.rs`
- `clients/rust/crates/rubin-consensus-cli/tests/retired_ops.rs`
- `clients/rust/crates/rubin-consensus-cli/Cargo.toml`
- `clients/rust/Cargo.lock`

Tests:
- `scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo fmt --check'` — PASS
- `scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test -p rubin-consensus-cli'` — PASS
- `git diff --check origin/main...HEAD` — PASS
- `python3 /Users/gpt/Documents/local-agent-protocols/common-preflight/rubin_common_preflight.py --repo /Users/gpt/Documents/rubin-protocol --base-ref origin/main --lane core` — PASS
- `scripts/dev-env.sh -- ./scripts/preflight-codacy-coverage.sh` — PASS
- `git verify-commit HEAD` — PASS
- isolated pre-push reviewer on `origin/main...HEAD` — PASS

Behavior impact:
Non-empty retired `core_ext_profiles` still rejects as unsupported, but the request struct now records only whether items were present instead of retaining the unsupported JSON payloads. Removed RUB-512 op names are covered through the CLI binary/stdin path.

Compatibility impact:
No Go changes, no spec changes, no fixture changes, no conformance runner changes, no Rust consensus/node behavior changes.

Known non-goals:
- No RUB-513 rubin-node work.
- No RUB-514 rust-consensus work.
- No conformance runner retired-field hardening in this PR.

Risk:
Low; this is a Rust CLI-only hardening follow-up after PR #2165.

Rollback:
Revert this commit.

Not checked:
External Codacy parity was not available before PR creation; local coverage preflight passed and GitHub CI will run on this PR.

Linear: RUB-584

### Parity exemption justification
This is a staged single-client Rust CLI follow-up. It does not change Go, shared fixtures, conformance runner behavior, or Rust consensus/node behavior.
The PR carries the `parity-exempt` label.

