### PR TITLE
RUB-513 Remove Rust node CORE_EXT runtime wiring

### DIFF
--- a/clients/rust/crates/rubin-node/src/chainstate.rs
+++ b/clients/rust/crates/rubin-node/src/chainstate.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 
 use rubin_consensus::{
     block_hash,
-    connect_block_basic_in_memory_at_height_and_core_ext_deployments_with_suite_context,
+    connect_block_basic_in_memory_at_height_and_core_ext_deployments_with_suite_context as connect_block_basic_in_memory_at_height_with_suite_context,
     encode_compact_size, parse_block_bytes, ConnectBlockBasicSummary, CoreExtDeploymentProfiles,
     InMemoryChainState, Outpoint, RotationProvider, SuiteRegistry, UtxoEntry,
 };
@@ -116,42 +116,23 @@ impl ChainState {
         prev_timestamps: Option<&[u64]>,
         chain_id: [u8; 32],
     ) -> Result<ChainStateConnectSummary, String> {
-        self.connect_block_with_core_ext_deployments(
+        self.connect_block_with_suite_context(
             block_bytes,
             expected_target,
             prev_timestamps,
             chain_id,
-            &CoreExtDeploymentProfiles::empty(),
-        )
-    }
-
-    pub fn connect_block_with_core_ext_deployments(
-        &mut self,
-        block_bytes: &[u8],
-        expected_target: Option<[u8; 32]>,
-        prev_timestamps: Option<&[u64]>,
-        chain_id: [u8; 32],
-        core_ext_deployments: &CoreExtDeploymentProfiles,
-    ) -> Result<ChainStateConnectSummary, String> {
-        self.connect_block_with_core_ext_deployments_and_suite_context(
-            block_bytes,
-            expected_target,
-            prev_timestamps,
-            chain_id,
-            core_ext_deployments,
             None,
             None,
         )
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn connect_block_with_core_ext_deployments_and_suite_context(
+    pub fn connect_block_with_suite_context(
         &mut self,
         block_bytes: &[u8],
         expected_target: Option<[u8; 32]>,
         prev_timestamps: Option<&[u64]>,
         chain_id: [u8; 32],
-        core_ext_deployments: &CoreExtDeploymentProfiles,
         rotation: Option<&dyn RotationProvider>,
         registry: Option<&SuiteRegistry>,
     ) -> Result<ChainStateConnectSummary, String> {
@@ -163,7 +144,7 @@ impl ChainState {
         };
 
         let connect_summary: ConnectBlockBasicSummary =
-            connect_block_basic_in_memory_at_height_and_core_ext_deployments_with_suite_context(
+            connect_block_basic_in_memory_at_height_with_suite_context(
                 block_bytes,
                 expected_prev_hash,
                 expected_target,
@@ -171,7 +152,7 @@ impl ChainState {
                 prev_timestamps,
                 &mut work_state,
                 chain_id,
-                core_ext_deployments,
+                &CoreExtDeploymentProfiles::empty(),
                 rotation,
                 registry,
             )
@@ -292,7 +273,7 @@ pub(crate) fn copy_utxo_entry(entry: &UtxoEntry) -> UtxoEntry {
 }
 
 /// Defensive deep-copy of a full UTXO set. Mirrors the Go twin `copyUtxoSet`.
-/// Used by `connect_block_with_core_ext_deployments_and_suite_context` to
+/// Used by `connect_block_with_suite_context` to
 /// build the `work_state` replay map without sharing entries with the
 /// canonical `ChainState.utxos` map. Implemented as `src.clone()` to avoid
 /// a manual per-entry `insert` loop and preserve the source `HashMap`'s

--- a/clients/rust/crates/rubin-node/src/chainstate_recovery.rs
+++ b/clients/rust/crates/rubin-node/src/chainstate_recovery.rs
@@ -38,10 +38,9 @@
 //!      * canonical(H) ≠ snapshot.tip OR snapshot.height > tip → reset
 //!        snapshot and replay from genesis.
 //!
-//! Replay reuses `ChainState::connect_block_with_core_ext_deployments_
-//! and_suite_context`, the same entry point the live sync engine uses,
-//! so consensus rules during reconcile match consensus rules during
-//! steady-state sync.
+//! Replay reuses `ChainState::connect_block_with_suite_context`, the same
+//! entry point the live sync engine uses, so consensus rules during reconcile
+//! match consensus rules during steady-state sync.
 //!
 //! # Out of scope
 //!
@@ -203,7 +202,7 @@ pub(crate) fn truncate_incomplete_canonical_suffix(store: &mut BlockStore) -> Re
 ///    from height 0.
 ///
 /// Replay reuses
-/// `ChainState::connect_block_with_core_ext_deployments_and_suite_context`
+/// `ChainState::connect_block_with_suite_context`
 /// so consensus checks during recovery match steady-state sync.
 ///
 /// # Threat model
@@ -303,7 +302,7 @@ pub fn reconcile_chain_state_with_block_store(
     // The trait-erasure re-borrow has to stay even at the hoist
     // point: `SuiteContext.rotation` is stored as
     // `Arc<dyn RotationProvider + Send + Sync>` while
-    // `connect_block_with_core_ext_deployments_and_suite_context`
+    // `connect_block_with_suite_context`
     // takes the bare `Option<&dyn RotationProvider>` (no `+ Send +
     // Sync` bound). Without the explicit `let r: &(dyn ... + Send +
     // Sync) = ctx.rotation.as_ref();` step the compiler refuses to
@@ -358,12 +357,11 @@ pub fn reconcile_chain_state_with_block_store(
             ));
         }
         let prev_timestamps = prev_timestamps_from_store(store, height)?;
-        state.connect_block_with_core_ext_deployments_and_suite_context(
+        state.connect_block_with_suite_context(
             &block_bytes,
             cfg.expected_target,
             prev_timestamps.as_deref(),
             cfg.chain_id,
-            &cfg.core_ext_deployments,
             rotation,
             registry,
         )?;
@@ -613,23 +611,21 @@ mod tests {
         // only block 2.
         let mut state = ChainState::new();
         state
-            .connect_block_with_core_ext_deployments_and_suite_context(
+            .connect_block_with_suite_context(
                 &devnet_genesis_block_bytes(),
                 cfg.expected_target,
                 None,
                 cfg.chain_id,
-                &cfg.core_ext_deployments,
                 None,
                 None,
             )
             .expect("seed genesis");
         state
-            .connect_block_with_core_ext_deployments_and_suite_context(
+            .connect_block_with_suite_context(
                 &block1,
                 cfg.expected_target,
                 Some(&[g_ts]),
                 cfg.chain_id,
-                &cfg.core_ext_deployments,
                 None,
                 None,
             )
@@ -692,12 +688,11 @@ mod tests {
         let mut store = engine.block_store_snapshot().expect("blockstore");
         let mut state = ChainState::new();
         state
-            .connect_block_with_core_ext_deployments_and_suite_context(
+            .connect_block_with_suite_context(
                 &devnet_genesis_block_bytes(),
                 cfg.expected_target,
                 None,
                 cfg.chain_id,
-                &cfg.core_ext_deployments,
                 None,
                 None,
             )

--- a/clients/rust/crates/rubin-node/src/da_txgen.rs
+++ b/clients/rust/crates/rubin-node/src/da_txgen.rs
@@ -353,12 +353,10 @@ pub fn mine_and_generate(data_dir: &Path, mine_blocks: u64) -> Result<SignedDaSe
     let block_store = BlockStore::open(block_store_path(data_dir))?;
 
     let mut sync_cfg = default_sync_config(None, chain_id, Some(chain_state_file.clone()));
-    sync_cfg.core_ext_deployments = genesis.core_ext_deployments.clone();
     sync_cfg.suite_context = genesis.suite_context.clone();
     let mut sync_engine = SyncEngine::new(chain_state, Some(block_store), sync_cfg)?;
 
     let miner_cfg = MinerConfig {
-        core_ext_deployments: genesis.core_ext_deployments.clone(),
         mine_address: mine_covenant_data,
         ..MinerConfig::default()
     };

--- a/clients/rust/crates/rubin-node/src/devnet_rpc.rs
+++ b/clients/rust/crates/rubin-node/src/devnet_rpc.rs
@@ -577,17 +577,11 @@ pub fn attach_shutdown_signal_to_devnet_rpc_state(
 }
 
 pub fn new_shared_runtime_tx_pool(sync_engine: &Arc<Mutex<SyncEngine>>) -> Arc<Mutex<TxPool>> {
-    let (core_ext_deployments, suite_context) = sync_engine
+    let suite_context = sync_engine
         .lock()
-        .map(|engine| {
-            (
-                engine.core_ext_deployments(),
-                engine.cfg.suite_context.clone(),
-            )
-        })
-        .unwrap_or_else(|_| (Default::default(), None));
+        .map(|engine| engine.cfg.suite_context.clone())
+        .unwrap_or(None);
     Arc::new(Mutex::new(TxPool::new_with_config(TxPoolConfig {
-        core_ext_deployments,
         suite_context,
         ..TxPoolConfig::default()
     })))
@@ -2932,7 +2926,6 @@ mod tests {
         let sync_engine = Arc::new(Mutex::new(engine));
         let tx_pool = new_shared_runtime_tx_pool(&sync_engine);
         let live_cfg = MinerConfig {
-            core_ext_deployments: sync_engine.lock().expect("lock").core_ext_deployments(),
             ..MinerConfig::default()
         };
         let state = new_devnet_rpc_state_with_tx_pool(

--- a/clients/rust/crates/rubin-node/src/genesis.rs
+++ b/clients/rust/crates/rubin-node/src/genesis.rs
@@ -8,12 +8,11 @@ use rubin_consensus::constants::{
 };
 use rubin_consensus::encode_compact_size;
 use rubin_consensus::{
-    block_hash, canonical_rotation_network_name_normalized, core_ext_profile_set_anchor_v1,
+    block_hash, canonical_rotation_network_name_normalized,
     is_v1_production_rotation_network_normalized,
-    validate_rotation_descriptor_for_normalized_network, CoreExtDeploymentProfile,
-    CoreExtDeploymentProfiles, CryptoRotationDescriptor, DefaultRotationProvider,
-    DescriptorRotationProvider, SuiteParams, SuiteRegistry, BLOCK_HEADER_BYTES,
-    SUPPORTED_ROTATION_NETWORK_NAMES_CSV,
+    validate_rotation_descriptor_for_normalized_network, CryptoRotationDescriptor,
+    DefaultRotationProvider, DescriptorRotationProvider, SuiteParams, SuiteRegistry,
+    BLOCK_HEADER_BYTES, SUPPORTED_ROTATION_NETWORK_NAMES_CSV,
 };
 use serde::Deserialize;
 use std::collections::{BTreeMap, BTreeSet};
@@ -33,10 +32,6 @@ struct GenesisPack {
     chain_id_hex: String,
     #[serde(default)]
     genesis_hash_hex: String,
-    #[serde(default)]
-    core_ext_profile_set_anchor_hex: String,
-    #[serde(default)]
-    core_ext_profiles: Vec<GenesisCoreExtProfile>,
     #[serde(default)]
     rotation_descriptor: Option<GenesisRotationDescriptor>,
     #[serde(default)]
@@ -100,29 +95,10 @@ impl<'de> Deserialize<'de> for GenesisSuiteParams {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
-struct GenesisCoreExtProfile {
-    ext_id: u16,
-    activation_height: u64,
-    #[serde(default)]
-    tx_context_enabled: bool,
-    #[serde(default)]
-    allowed_suite_ids: Vec<u8>,
-    #[serde(default)]
-    binding: String,
-    #[serde(default)]
-    binding_descriptor_hex: String,
-    #[serde(default)]
-    ext_payload_schema_hex: String,
-    #[serde(default)]
-    governance_nonce: u64,
-}
-
 #[derive(Clone, Debug)]
 pub struct LoadedGenesisConfig {
     pub chain_id: [u8; 32],
     pub genesis_hash: Option<[u8; 32]>,
-    pub core_ext_deployments: CoreExtDeploymentProfiles,
     /// Optional SuiteContext built from non-production config or the compiled
     /// production activation schedule. Non-production callers without an
     /// explicit overlay keep this as None; production empty slots use an
@@ -157,13 +133,15 @@ pub fn load_genesis_config(
         return Ok(LoadedGenesisConfig {
             chain_id: devnet_genesis_chain_id(),
             genesis_hash: Some(devnet_genesis_hash()),
-            core_ext_deployments: CoreExtDeploymentProfiles::empty(),
             suite_context: None,
         });
     };
     let raw = fs::read_to_string(path)
         .map_err(|e| format!("read genesis file {}: {e}", path.display()))?;
-    let payload: GenesisPack = serde_json::from_str(&raw)
+    let raw_json: serde_json::Value = serde_json::from_str(&raw)
+        .map_err(|e| format!("parse genesis file {}: {e}", path.display()))?;
+    reject_removed_genesis_core_ext_keys(&raw_json)?;
+    let payload: GenesisPack = serde_json::from_value(raw_json)
         .map_err(|e| format!("parse genesis file {}: {e}", path.display()))?;
     let mut trimmed = payload.chain_id_hex.trim();
     if trimmed.is_empty() {
@@ -190,17 +168,26 @@ pub fn load_genesis_config(
     Ok(LoadedGenesisConfig {
         chain_id,
         genesis_hash,
-        core_ext_deployments: core_ext_deployments_from_json(
-            chain_id,
-            &payload.core_ext_profile_set_anchor_hex,
-            &payload.core_ext_profiles,
-        )?,
         suite_context: build_suite_context_from_descriptor(
             &payload.rotation_descriptor,
             &payload.suite_registry,
             network,
         )?,
     })
+}
+
+fn reject_removed_genesis_core_ext_keys(raw_json: &serde_json::Value) -> Result<(), String> {
+    let Some(fields) = raw_json.as_object() else {
+        return Ok(());
+    };
+    for key in ["core_ext_profiles", "core_ext_profile_set_anchor_hex"] {
+        if fields.contains_key(key) {
+            return Err(format!(
+                "unsupported genesis field {key:?}: Rust node CORE_EXT profile wiring was removed"
+            ));
+        }
+    }
+    Ok(())
 }
 
 fn normalize_suite_alg_name(value: &str) -> Result<&'static str, String> {
@@ -434,94 +421,18 @@ fn parse_hex32(name: &str, value: &str) -> Result<[u8; 32], String> {
     Ok(out)
 }
 
-fn decode_optional_hex_bytes(name: &str, value: &str) -> Result<Vec<u8>, String> {
-    const MAX_CORE_EXT_HEX_FIELD_BYTES: usize = 4096;
-    let trimmed = value.trim();
-    if trimmed.is_empty() {
-        return Ok(Vec::new());
-    }
-    let trimmed = trimmed
-        .strip_prefix("0x")
-        .or_else(|| trimmed.strip_prefix("0X"))
-        .unwrap_or(trimmed);
-    if trimmed.len() > MAX_CORE_EXT_HEX_FIELD_BYTES * 2 {
-        return Err(format!("bad {name}"));
-    }
-    hex::decode(trimmed).map_err(|e| format!("{name}: {e}"))
-}
-
-fn core_ext_deployments_from_json(
-    chain_id: [u8; 32],
-    expected_set_anchor_hex: &str,
-    items: &[GenesisCoreExtProfile],
-) -> Result<CoreExtDeploymentProfiles, String> {
-    let mut seen = std::collections::HashSet::new();
-    let mut deployments = Vec::with_capacity(items.len());
-    for item in items {
-        let binding_name =
-            rubin_consensus::normalize_live_core_ext_binding_name(item.binding.trim())?;
-        if !seen.insert(item.ext_id) {
-            return Err(format!(
-                "duplicate core_ext deployment for ext_id={}",
-                item.ext_id
-            ));
-        }
-        if item.tx_context_enabled {
-            return Err(format!(
-                "tx_context_enabled core_ext profile for ext_id={} requires runtime txcontext verifier wiring",
-                item.ext_id
-            ));
-        }
-        let binding_descriptor =
-            decode_optional_hex_bytes("binding_descriptor_hex", &item.binding_descriptor_hex)?;
-        let ext_payload_schema =
-            decode_optional_hex_bytes("ext_payload_schema_hex", &item.ext_payload_schema_hex)?;
-        let verification_binding =
-            rubin_consensus::live_core_ext_verification_binding_from_normalized_name_and_descriptor(
-                binding_name,
-                &binding_descriptor,
-                &ext_payload_schema,
-            )?;
-        deployments.push(CoreExtDeploymentProfile {
-            ext_id: item.ext_id,
-            activation_height: item.activation_height,
-            tx_context_enabled: item.tx_context_enabled,
-            allowed_suite_ids: item.allowed_suite_ids.clone(),
-            verification_binding,
-            verify_sig_ext_tx_context_fn: None,
-            binding_descriptor,
-            ext_payload_schema,
-            governance_nonce: item.governance_nonce,
-        });
-    }
-    let profiles = CoreExtDeploymentProfiles { deployments };
-    profiles.validate()?;
-    if !expected_set_anchor_hex.trim().is_empty() {
-        let expected = parse_hex32("core_ext_profile_set_anchor_hex", expected_set_anchor_hex)?;
-        let actual = core_ext_profile_set_anchor_v1(chain_id, &profiles.deployments)?;
-        if actual != expected {
-            return Err("core_ext profile set anchor mismatch".to_string());
-        }
-    }
-    Ok(profiles)
-}
-
 #[cfg(test)]
 mod tests {
     use rubin_consensus::constants::{
         ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES, SUITE_ID_ML_DSA_87, VERIFY_COST_ML_DSA_87,
     };
-    use rubin_consensus::{
-        core_ext_profile_set_anchor_v1, CoreExtDeploymentProfile, CoreExtVerificationBinding,
-        SuiteRegistry,
-    };
+    use rubin_consensus::SuiteRegistry;
 
     use super::{
         build_suite_context_from_descriptor_with_production_lookup, derive_devnet_genesis_chain_id,
-        devnet_genesis_block_bytes, devnet_genesis_chain_id, devnet_genesis_hash,
-        load_chain_id_from_genesis_file, load_genesis_config, validate_incoming_chain_id,
-        CryptoRotationDescriptor, GenesisRotationDescriptor, GenesisSuiteParams,
-        PRODUCTION_LOCAL_ROTATION_DESCRIPTOR_ERR,
+        devnet_genesis_block_bytes, devnet_genesis_chain_id, load_chain_id_from_genesis_file,
+        load_genesis_config, validate_incoming_chain_id, CryptoRotationDescriptor,
+        GenesisRotationDescriptor, GenesisSuiteParams, PRODUCTION_LOCAL_ROTATION_DESCRIPTOR_ERR,
     };
     use std::collections::BTreeMap;
 
@@ -618,43 +529,37 @@ mod tests {
     }
 
     #[test]
-    fn load_genesis_config_reads_core_ext_profiles() {
+    fn load_genesis_config_rejects_removed_core_ext_fields() {
         let dir = std::env::temp_dir().join(format!(
-            "rubin-node-genesis-core-ext-{}",
+            "rubin-node-genesis-removed-core-ext-{}",
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .expect("time")
                 .as_nanos()
         ));
         std::fs::create_dir_all(&dir).expect("mkdir");
-        let path = dir.join("genesis.json");
-        let binding_descriptor =
-            rubin_consensus::core_ext_openssl_digest32_binding_descriptor_bytes(
-                "ML-DSA-87",
-                rubin_consensus::constants::ML_DSA_87_PUBKEY_BYTES,
-                rubin_consensus::constants::ML_DSA_87_SIG_BYTES,
-            )
-            .expect("descriptor");
-        std::fs::write(
-            &path,
-            format!(
-                "{{\"chain_id_hex\":\"0x88f8a9acdeeb902e27aa2fdcb8c46ecf818bf68dec5273ec1bcc5084e2333103\",\"core_ext_profiles\":[{{\"ext_id\":7,\"activation_height\":12,\"allowed_suite_ids\":[3],\"binding\":\"{}\",\"binding_descriptor_hex\":\"{}\",\"ext_payload_schema_hex\":\"b2\"}}]}}",
-                rubin_consensus::CORE_EXT_BINDING_NAME_VERIFY_SIG_EXT_OPENSSL_DIGEST32_V1,
-                hex::encode(binding_descriptor),
+        for (name, field, value) in [
+            ("profiles", "core_ext_profiles", "[]"),
+            (
+                "profile_set_anchor",
+                "core_ext_profile_set_anchor_hex",
+                "\"00\"",
             ),
-        )
-        .expect("write");
-
-        let cfg = load_genesis_config(Some(&path), "devnet").expect("load");
-        assert_eq!(cfg.chain_id, devnet_genesis_chain_id());
-        assert_eq!(cfg.genesis_hash, Some(devnet_genesis_hash()));
-        assert_eq!(cfg.core_ext_deployments.deployments.len(), 1);
-        assert_eq!(cfg.core_ext_deployments.deployments[0].ext_id, 7);
-        assert_eq!(
-            cfg.core_ext_deployments.deployments[0].activation_height,
-            12
-        );
-        assert!(!cfg.core_ext_deployments.deployments[0].tx_context_enabled);
+        ] {
+            let path = dir.join(format!("{name}.json"));
+            std::fs::write(
+                &path,
+                format!(
+                    "{{\"chain_id_hex\":\"0x88f8a9acdeeb902e27aa2fdcb8c46ecf818bf68dec5273ec1bcc5084e2333103\",\"{field}\":{value}}}"
+                ),
+            )
+            .expect("write");
+            let err = load_genesis_config(Some(&path), "devnet").expect_err("removed field");
+            assert!(
+                err.contains(&format!("unsupported genesis field \"{field}\"")),
+                "unexpected error for {field}: {err}"
+            );
+        }
 
         std::fs::remove_dir_all(&dir).expect("cleanup");
     }
@@ -1579,348 +1484,6 @@ mod tests {
 
         let err = load_genesis_config(Some(&path), "devnet").unwrap_err();
         assert!(err.contains("bad suite_registry"));
-
-        std::fs::remove_dir_all(&dir).expect("cleanup");
-    }
-
-    #[test]
-    fn load_genesis_config_rejects_empty_core_ext_allowed_suite_ids() {
-        let dir = std::env::temp_dir().join(format!(
-            "rubin-node-genesis-core-ext-empty-{}",
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .expect("time")
-                .as_nanos()
-        ));
-        std::fs::create_dir_all(&dir).expect("mkdir");
-        let path = dir.join("genesis.json");
-        let binding_descriptor =
-            rubin_consensus::core_ext_openssl_digest32_binding_descriptor_bytes(
-                "ML-DSA-87",
-                rubin_consensus::constants::ML_DSA_87_PUBKEY_BYTES,
-                rubin_consensus::constants::ML_DSA_87_SIG_BYTES,
-            )
-            .expect("descriptor");
-        std::fs::write(
-            &path,
-            format!(
-                "{{\"chain_id_hex\":\"0x88f8a9acdeeb902e27aa2fdcb8c46ecf818bf68dec5273ec1bcc5084e2333103\",\"core_ext_profiles\":[{{\"ext_id\":7,\"activation_height\":12,\"allowed_suite_ids\":[],\"binding\":\"{}\",\"binding_descriptor_hex\":\"{}\",\"ext_payload_schema_hex\":\"b2\"}}]}}",
-                rubin_consensus::CORE_EXT_BINDING_NAME_VERIFY_SIG_EXT_OPENSSL_DIGEST32_V1,
-                hex::encode(binding_descriptor),
-            ),
-        )
-        .expect("write");
-
-        let err = load_genesis_config(Some(&path), "devnet").unwrap_err();
-        assert!(err.contains("non-empty allowed_suite_ids"));
-
-        std::fs::remove_dir_all(&dir).expect("cleanup");
-    }
-
-    #[test]
-    fn load_genesis_config_reads_openssl_digest32_core_ext_profile() {
-        let dir = std::env::temp_dir().join(format!(
-            "rubin-node-genesis-core-ext-openssl-{}",
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .expect("time")
-                .as_nanos()
-        ));
-        std::fs::create_dir_all(&dir).expect("mkdir");
-        let path = dir.join("genesis.json");
-        let binding_descriptor =
-            rubin_consensus::core_ext_openssl_digest32_binding_descriptor_bytes(
-                "ML-DSA-87",
-                rubin_consensus::constants::ML_DSA_87_PUBKEY_BYTES,
-                rubin_consensus::constants::ML_DSA_87_SIG_BYTES,
-            )
-            .expect("descriptor");
-        std::fs::write(
-            &path,
-            format!(
-                "{{\"chain_id_hex\":\"0x88f8a9acdeeb902e27aa2fdcb8c46ecf818bf68dec5273ec1bcc5084e2333103\",\"core_ext_profiles\":[{{\"ext_id\":7,\"activation_height\":12,\"allowed_suite_ids\":[3],\"binding\":\"{}\",\"binding_descriptor_hex\":\"{}\",\"ext_payload_schema_hex\":\"b2\"}}]}}",
-                rubin_consensus::CORE_EXT_BINDING_NAME_VERIFY_SIG_EXT_OPENSSL_DIGEST32_V1,
-                hex::encode(binding_descriptor)
-            ),
-        )
-        .expect("write");
-
-        let cfg = load_genesis_config(Some(&path), "devnet").expect("load");
-        assert_eq!(cfg.genesis_hash, Some(devnet_genesis_hash()));
-        assert_eq!(cfg.core_ext_deployments.deployments.len(), 1);
-
-        std::fs::remove_dir_all(&dir).expect("cleanup");
-    }
-
-    #[test]
-    fn load_genesis_config_rejects_tx_context_enabled_profile_without_runtime_verifier() {
-        let dir = std::env::temp_dir().join(format!(
-            "rubin-node-genesis-core-ext-txcontext-{}",
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .expect("time")
-                .as_nanos()
-        ));
-        std::fs::create_dir_all(&dir).expect("mkdir");
-        let path = dir.join("genesis.json");
-        let binding_descriptor =
-            rubin_consensus::core_ext_openssl_digest32_binding_descriptor_bytes(
-                "ML-DSA-87",
-                rubin_consensus::constants::ML_DSA_87_PUBKEY_BYTES,
-                rubin_consensus::constants::ML_DSA_87_SIG_BYTES,
-            )
-            .expect("descriptor");
-        std::fs::write(
-            &path,
-            format!(
-                "{{\"chain_id_hex\":\"0x88f8a9acdeeb902e27aa2fdcb8c46ecf818bf68dec5273ec1bcc5084e2333103\",\"core_ext_profiles\":[{{\"ext_id\":7,\"activation_height\":12,\"tx_context_enabled\":true,\"allowed_suite_ids\":[3],\"binding\":\"{}\",\"binding_descriptor_hex\":\"{}\",\"ext_payload_schema_hex\":\"b2\"}}]}}",
-                rubin_consensus::CORE_EXT_BINDING_NAME_VERIFY_SIG_EXT_OPENSSL_DIGEST32_V1,
-                hex::encode(binding_descriptor),
-            ),
-        )
-        .expect("write");
-
-        let err = load_genesis_config(Some(&path), "devnet").unwrap_err();
-        assert!(err.contains(
-            "tx_context_enabled core_ext profile for ext_id=7 requires runtime txcontext verifier wiring"
-        ));
-
-        std::fs::remove_dir_all(&dir).expect("cleanup");
-    }
-
-    #[test]
-    fn load_genesis_config_rejects_non_boolean_tx_context_enabled() {
-        let dir = std::env::temp_dir().join(format!(
-            "rubin-node-genesis-core-ext-invalid-txcontext-{}",
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .expect("time")
-                .as_nanos()
-        ));
-        std::fs::create_dir_all(&dir).expect("mkdir");
-        let path = dir.join("genesis.json");
-        let binding_descriptor =
-            rubin_consensus::core_ext_openssl_digest32_binding_descriptor_bytes(
-                "ML-DSA-87",
-                rubin_consensus::constants::ML_DSA_87_PUBKEY_BYTES,
-                rubin_consensus::constants::ML_DSA_87_SIG_BYTES,
-            )
-            .expect("descriptor");
-        std::fs::write(
-            &path,
-            format!(
-                "{{\"chain_id_hex\":\"0x88f8a9acdeeb902e27aa2fdcb8c46ecf818bf68dec5273ec1bcc5084e2333103\",\"core_ext_profiles\":[{{\"ext_id\":7,\"activation_height\":12,\"tx_context_enabled\":1,\"allowed_suite_ids\":[3],\"binding\":\"{}\",\"binding_descriptor_hex\":\"{}\",\"ext_payload_schema_hex\":\"b2\"}}]}}",
-                rubin_consensus::CORE_EXT_BINDING_NAME_VERIFY_SIG_EXT_OPENSSL_DIGEST32_V1,
-                hex::encode(binding_descriptor),
-            ),
-        )
-        .expect("write");
-
-        let err = load_genesis_config(Some(&path), "devnet").unwrap_err();
-        assert!(err.contains("expected a boolean"));
-
-        std::fs::remove_dir_all(&dir).expect("cleanup");
-    }
-
-    #[test]
-    fn load_genesis_config_rejects_openssl_digest32_binding_without_payload_schema() {
-        let dir = std::env::temp_dir().join(format!(
-            "rubin-node-genesis-core-ext-openssl-missing-schema-{}",
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .expect("time")
-                .as_nanos()
-        ));
-        std::fs::create_dir_all(&dir).expect("mkdir");
-        let path = dir.join("genesis.json");
-        let binding_descriptor =
-            rubin_consensus::core_ext_openssl_digest32_binding_descriptor_bytes(
-                "ML-DSA-87",
-                rubin_consensus::constants::ML_DSA_87_PUBKEY_BYTES,
-                rubin_consensus::constants::ML_DSA_87_SIG_BYTES,
-            )
-            .expect("descriptor");
-        std::fs::write(
-            &path,
-            format!(
-                "{{\"chain_id_hex\":\"0x88f8a9acdeeb902e27aa2fdcb8c46ecf818bf68dec5273ec1bcc5084e2333103\",\"core_ext_profiles\":[{{\"ext_id\":7,\"activation_height\":12,\"allowed_suite_ids\":[3],\"binding\":\"{}\",\"binding_descriptor_hex\":\"{}\"}}]}}",
-                rubin_consensus::CORE_EXT_BINDING_NAME_VERIFY_SIG_EXT_OPENSSL_DIGEST32_V1,
-                hex::encode(binding_descriptor)
-            ),
-        )
-        .expect("write");
-
-        let err = load_genesis_config(Some(&path), "devnet").unwrap_err();
-        assert!(err.contains("requires ext_payload_schema_hex"));
-
-        std::fs::remove_dir_all(&dir).expect("cleanup");
-    }
-
-    #[test]
-    fn load_genesis_config_rejects_core_ext_profile_set_anchor_mismatch() {
-        let dir = std::env::temp_dir().join(format!(
-            "rubin-node-genesis-core-ext-anchor-{}",
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .expect("time")
-                .as_nanos()
-        ));
-        std::fs::create_dir_all(&dir).expect("mkdir");
-        let path = dir.join("genesis.json");
-        let binding_descriptor =
-            rubin_consensus::core_ext_openssl_digest32_binding_descriptor_bytes(
-                "ML-DSA-87",
-                rubin_consensus::constants::ML_DSA_87_PUBKEY_BYTES,
-                rubin_consensus::constants::ML_DSA_87_SIG_BYTES,
-            )
-            .expect("descriptor");
-        let descriptor = rubin_consensus::parse_core_ext_openssl_digest32_binding_descriptor(
-            &binding_descriptor,
-        )
-        .expect("parse");
-        let mut anchor = core_ext_profile_set_anchor_v1(
-            devnet_genesis_chain_id(),
-            &[CoreExtDeploymentProfile {
-                ext_id: 7,
-                activation_height: 12,
-                tx_context_enabled: false,
-                allowed_suite_ids: vec![3],
-                verification_binding: CoreExtVerificationBinding::VerifySigExtOpenSslDigest32V1(
-                    descriptor,
-                ),
-                verify_sig_ext_tx_context_fn: None,
-                binding_descriptor: binding_descriptor.clone(),
-                ext_payload_schema: vec![0xb2],
-                governance_nonce: 0,
-            }],
-        )
-        .expect("anchor");
-        anchor[0] ^= 0xff;
-        std::fs::write(
-            &path,
-            format!(
-                "{{\"chain_id_hex\":\"0x88f8a9acdeeb902e27aa2fdcb8c46ecf818bf68dec5273ec1bcc5084e2333103\",\"core_ext_profile_set_anchor_hex\":\"0x{}\",\"core_ext_profiles\":[{{\"ext_id\":7,\"activation_height\":12,\"allowed_suite_ids\":[3],\"binding\":\"{}\",\"binding_descriptor_hex\":\"{}\",\"ext_payload_schema_hex\":\"b2\"}}]}}",
-                hex::encode(anchor),
-                rubin_consensus::CORE_EXT_BINDING_NAME_VERIFY_SIG_EXT_OPENSSL_DIGEST32_V1,
-                hex::encode(binding_descriptor),
-            ),
-        )
-        .expect("write");
-
-        let err = load_genesis_config(Some(&path), "devnet").unwrap_err();
-        assert!(err.contains("anchor mismatch"));
-
-        std::fs::remove_dir_all(&dir).expect("cleanup");
-    }
-
-    #[test]
-    fn load_genesis_config_rejects_oversized_core_ext_hex_fields() {
-        let dir = std::env::temp_dir().join(format!(
-            "rubin-node-genesis-core-ext-oversized-{}",
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .expect("time")
-                .as_nanos()
-        ));
-        std::fs::create_dir_all(&dir).expect("mkdir");
-        let path = dir.join("genesis.json");
-        std::fs::write(
-            &path,
-            format!(
-                "{{\"chain_id_hex\":\"0x88f8a9acdeeb902e27aa2fdcb8c46ecf818bf68dec5273ec1bcc5084e2333103\",\"core_ext_profiles\":[{{\"ext_id\":7,\"activation_height\":12,\"allowed_suite_ids\":[3],\"binding\":\"{}\",\"binding_descriptor_hex\":\"{}\",\"ext_payload_schema_hex\":\"b2\"}}]}}",
-                rubin_consensus::CORE_EXT_BINDING_NAME_VERIFY_SIG_EXT_OPENSSL_DIGEST32_V1,
-                "aa".repeat(4097)
-            ),
-        )
-        .expect("write");
-
-        let err = load_genesis_config(Some(&path), "devnet").unwrap_err();
-        assert!(err.contains("bad binding_descriptor_hex"));
-
-        std::fs::remove_dir_all(&dir).expect("cleanup");
-    }
-
-    #[test]
-    fn load_genesis_config_rejects_unsupported_binding_before_hex_decode() {
-        let dir = std::env::temp_dir().join(format!(
-            "rubin-node-genesis-core-ext-unsupported-{}",
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .expect("time")
-                .as_nanos()
-        ));
-        std::fs::create_dir_all(&dir).expect("mkdir");
-        let path = dir.join("genesis.json");
-        std::fs::write(
-            &path,
-            "{\"chain_id_hex\":\"0x88f8a9acdeeb902e27aa2fdcb8c46ecf818bf68dec5273ec1bcc5084e2333103\",\"core_ext_profiles\":[{\"ext_id\":7,\"activation_height\":12,\"allowed_suite_ids\":[3],\"binding\":\"unknown-binding\",\"binding_descriptor_hex\":\"zz\",\"ext_payload_schema_hex\":\"zz\"}]}",
-        )
-        .expect("write");
-
-        let err = load_genesis_config(Some(&path), "devnet").unwrap_err();
-        assert!(err.contains("unsupported core_ext binding"));
-
-        std::fs::remove_dir_all(&dir).expect("cleanup");
-    }
-
-    #[test]
-    fn load_genesis_config_accepts_whitespace_wrapped_binding() {
-        let dir = std::env::temp_dir().join(format!(
-            "rubin-node-genesis-core-ext-whitespace-{}",
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .expect("time")
-                .as_nanos()
-        ));
-        std::fs::create_dir_all(&dir).expect("mkdir");
-        let path = dir.join("genesis.json");
-        let binding_descriptor =
-            rubin_consensus::core_ext_openssl_digest32_binding_descriptor_bytes(
-                "ML-DSA-87",
-                rubin_consensus::constants::ML_DSA_87_PUBKEY_BYTES,
-                rubin_consensus::constants::ML_DSA_87_SIG_BYTES,
-            )
-            .expect("descriptor");
-        std::fs::write(
-            &path,
-            format!(
-                "{{\"chain_id_hex\":\"0x88f8a9acdeeb902e27aa2fdcb8c46ecf818bf68dec5273ec1bcc5084e2333103\",\"core_ext_profiles\":[{{\"ext_id\":7,\"activation_height\":12,\"allowed_suite_ids\":[3],\"binding\":\"  {}\\n\",\"binding_descriptor_hex\":\"{}\",\"ext_payload_schema_hex\":\"b2\"}}]}}",
-                rubin_consensus::CORE_EXT_BINDING_NAME_VERIFY_SIG_EXT_OPENSSL_DIGEST32_V1,
-                hex::encode(binding_descriptor),
-            ),
-        )
-        .expect("write");
-
-        let cfg = load_genesis_config(Some(&path), "devnet").expect("load genesis");
-        assert_eq!(cfg.genesis_hash, Some(devnet_genesis_hash()));
-        let profiles = cfg
-            .core_ext_deployments
-            .active_profiles_at_height(12)
-            .expect("active profiles");
-        assert_eq!(profiles.active.len(), 1);
-
-        std::fs::remove_dir_all(&dir).expect("cleanup");
-    }
-
-    #[test]
-    fn load_genesis_config_rejects_native_binding_on_live_path() {
-        let dir = std::env::temp_dir().join(format!(
-            "rubin-node-genesis-core-ext-native-live-{}",
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .expect("time")
-                .as_nanos()
-        ));
-        std::fs::create_dir_all(&dir).expect("mkdir");
-        let path = dir.join("genesis.json");
-        std::fs::write(
-            &path,
-            "{\"chain_id_hex\":\"0x88f8a9acdeeb902e27aa2fdcb8c46ecf818bf68dec5273ec1bcc5084e2333103\",\"core_ext_profiles\":[{\"ext_id\":7,\"activation_height\":12,\"allowed_suite_ids\":[3],\"binding\":\"native_verify_sig\",\"ext_payload_schema_hex\":\"b2\"}]}",
-        )
-        .expect("write");
-
-        let err = load_genesis_config(Some(&path), "devnet").unwrap_err();
-        assert!(err.contains("unsupported core_ext binding"));
 
         std::fs::remove_dir_all(&dir).expect("cleanup");
     }

--- a/clients/rust/crates/rubin-node/src/main.rs
+++ b/clients/rust/crates/rubin-node/src/main.rs
@@ -217,7 +217,6 @@ fn run(args: &[String], stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
 
     let mut sync_cfg = default_sync_config(None, chain_id, Some(chain_state_file.clone()));
     sync_cfg.network = cfg.network.clone();
-    sync_cfg.core_ext_deployments = genesis_cfg.core_ext_deployments.clone();
     sync_cfg.suite_context = genesis_cfg.suite_context.clone();
     sync_cfg.parallel_validation_mode = cfg.pv_mode.clone();
     sync_cfg.pv_shadow_max_samples = cfg.pv_shadow_max;
@@ -351,10 +350,7 @@ fn run(args: &[String], stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
         return 0;
     }
     if cfg.mine_blocks > 0 {
-        let mut miner_cfg = MinerConfig {
-            core_ext_deployments: genesis_cfg.core_ext_deployments.clone(),
-            ..MinerConfig::default()
-        };
+        let mut miner_cfg = MinerConfig::default();
         if let Some(ref value) = cfg.mine_address {
             let parsed = match parse_mine_address_arg(value) {
                 Ok(Some(addr)) => addr,
@@ -397,10 +393,7 @@ fn run(args: &[String], stdout: &mut dyn Write, stderr: &mut dyn Write) -> i32 {
     }
 
     let live_mining_cfg = if live_devnet_loopback_mining_allowed(&cfg) {
-        let mut miner_cfg = MinerConfig {
-            core_ext_deployments: genesis_cfg.core_ext_deployments.clone(),
-            ..MinerConfig::default()
-        };
+        let mut miner_cfg = MinerConfig::default();
         let mut addr_invalid = false;
         if let Some(ref value) = cfg.mine_address {
             match parse_mine_address_arg(value) {

--- a/clients/rust/crates/rubin-node/src/miner.rs
+++ b/clients/rust/crates/rubin-node/src/miner.rs
@@ -9,7 +9,7 @@ use rubin_consensus::merkle::{witness_commitment_hash, witness_merkle_root_wtxid
 use rubin_consensus::{
     apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles_and_suite_context as apply_basic_non_coinbase_update,
     encode_compact_size, merkle_root_txids, parse_tx, pow_check, tx_weight_and_stats_public,
-    CoreExtDeploymentProfiles, Outpoint, Tx, UtxoEntry,
+    CoreExtProfiles, Outpoint, Tx, UtxoEntry,
 };
 use sha3::{Digest, Sha3_256};
 
@@ -56,8 +56,6 @@ pub struct MinerConfig {
     /// `DEFAULT_MEMPOOL_MIN_FEE_RATE` so a future change to the relay
     /// floor cannot silently change the DA floor.
     pub policy_min_da_fee_rate: u64,
-    pub policy_reject_core_ext_pre_activation: bool,
-    pub core_ext_deployments: CoreExtDeploymentProfiles,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -115,8 +113,6 @@ impl Default for MinerConfig {
             policy_da_surcharge_per_byte: 0,
             policy_current_mempool_min_fee_rate: DEFAULT_MEMPOOL_MIN_FEE_RATE,
             policy_min_da_fee_rate: DEFAULT_MIN_DA_FEE_RATE,
-            policy_reject_core_ext_pre_activation: true,
-            core_ext_deployments: CoreExtDeploymentProfiles::empty(),
         }
     }
 }
@@ -379,7 +375,7 @@ impl<'a> Miner<'a> {
         &self,
         tx: &Tx,
         utxos: &HashMap<Outpoint, UtxoEntry>,
-        next_height: u64,
+        _next_height: u64,
         policy_da_included: u64,
     ) -> Result<(bool, u64), String> {
         let policy_cfg = TxPoolConfig {
@@ -392,9 +388,6 @@ impl<'a> Miner<'a> {
             // by policy contract; this does not change consensus validity.
             policy_reject_non_coinbase_anchor_outputs: self.cfg.policy_da_anchor_anti_abuse
                 && self.cfg.policy_reject_non_coinbase_anchor_outputs,
-            policy_reject_core_ext_pre_activation: self.cfg.policy_reject_core_ext_pre_activation,
-            policy_max_ext_payload_bytes: 0,
-            core_ext_deployments: self.cfg.core_ext_deployments.clone(),
             suite_context: self.sync.cfg.suite_context.clone(),
             policy_current_mempool_min_fee_rate: if self.cfg.policy_da_anchor_anti_abuse {
                 self.cfg.policy_current_mempool_min_fee_rate
@@ -414,7 +407,7 @@ impl<'a> Miner<'a> {
         // `apply_policy` recomputed weight/da_bytes internally and the
         // miner then walked again to read `da_bytes`.
         let (weight, da_bytes, _) = tx_weight_and_stats_public(tx).map_err(|e| e.to_string())?;
-        let policy_result = apply_policy(tx, weight, da_bytes, utxos, next_height, &policy_cfg);
+        let policy_result = apply_policy(tx, weight, da_bytes, utxos, &policy_cfg);
         if policy_result.is_err() {
             return Ok((true, policy_da_included));
         }
@@ -493,10 +486,6 @@ impl<'a> Miner<'a> {
             &HashMap<Outpoint, UtxoEntry>,
         ) -> Result<bool, String>,
     ) -> Result<bool, String> {
-        let deployments = &self.sync.cfg.core_ext_deployments;
-        let active_profiles = deployments
-            .active_profiles_at_height(next_height)
-            .map_err(|err| err.to_string())?;
         let (rotation, registry) = self.sync.suite_context();
         let mut work_utxos = copy_selected_utxo_set(&self.sync.chain_state.utxos, group_inputs);
         for candidate in group {
@@ -511,7 +500,7 @@ impl<'a> Miner<'a> {
                 block_mtp,
                 block_mtp,
                 self.sync.cfg.chain_id,
-                &active_profiles,
+                &CoreExtProfiles::empty(),
                 rotation,
                 registry,
             );
@@ -813,8 +802,8 @@ mod tests {
     use rubin_consensus::merkle::{witness_commitment_hash, witness_merkle_root_wtxids};
     use rubin_consensus::{
         encode_compact_size, marshal_tx, p2pk_covenant_data_for_pubkey, parse_tx, sign_transaction,
-        tx_weight_and_stats_public, CoreExtDeploymentProfiles, DaChunkCore, DaCommitCore,
-        Mldsa87Keypair, Outpoint, Tx, TxInput, TxOutput, UtxoEntry,
+        tx_weight_and_stats_public, DaChunkCore, DaCommitCore, Mldsa87Keypair, Outpoint, Tx,
+        TxInput, TxOutput, UtxoEntry,
     };
     use sha3::{Digest, Sha3_256};
 
@@ -1366,14 +1355,12 @@ mod tests {
     }
 
     #[test]
-    fn miner_core_ext_policy_still_runs_when_da_anchor_master_off() {
+    fn miner_rejects_core_ext_when_da_anchor_master_off() {
         let (dir, _block_store, mut sync) = test_sync("rubin-rust-miner-core-ext-master-off");
         let (tx, utxos) = core_ext_policy_tx(0x75);
         sync.chain_state.utxos = utxos;
         let cfg = MinerConfig {
             policy_da_anchor_anti_abuse: false,
-            policy_reject_core_ext_pre_activation: true,
-            core_ext_deployments: CoreExtDeploymentProfiles::empty(),
             ..MinerConfig::default()
         };
         let miner = Miner::new(&mut sync, None, cfg).expect("miner");
@@ -1383,7 +1370,7 @@ mod tests {
             .expect("CORE_EXT candidate");
         assert!(
             reject,
-            "CORE_EXT pre-activation policy must still run when DA/anchor master is off"
+            "CORE_EXT unsupported-runtime policy must still run when DA/anchor master is off"
         );
         assert_eq!(next_da, 0);
         let _ = fs::remove_dir_all(&dir);

--- a/clients/rust/crates/rubin-node/src/p2p_runtime.rs
+++ b/clients/rust/crates/rubin-node/src/p2p_runtime.rs
@@ -6949,12 +6949,11 @@ mod tests {
             // `Relayed` and the canonical seam fires).
             let (chain_state, tx_bytes, _unused) =
                 signed_conflicting_p2pk_state_and_txs(20_000, 10, 9);
-            let mut sync_cfg = crate::sync::default_sync_config(
+            let sync_cfg = crate::sync::default_sync_config(
                 None,
                 crate::genesis::devnet_genesis_chain_id(),
                 None,
             );
-            sync_cfg.core_ext_deployments = rubin_consensus::CoreExtDeploymentProfiles::empty();
             let mut engine =
                 crate::sync::SyncEngine::new(chain_state, None, sync_cfg).expect("sync engine");
 
@@ -7070,8 +7069,7 @@ mod tests {
         let server = thread::spawn(move || {
             let (stream, _) = listener.accept().expect("accept"); let mut session = PeerSession::new(stream, default_peer_runtime_config("devnet", 8)).expect("session");
             let (chain_state, admitted_tx, conflicting_tx, bad_tx, da_id, conflict_da_id, bad_da_id) = signed_conflicting_da_chunk_state_and_txs();
-            let mut sync_cfg = crate::sync::default_sync_config(None, crate::genesis::devnet_genesis_chain_id(), None);
-            sync_cfg.core_ext_deployments = rubin_consensus::CoreExtDeploymentProfiles::empty();
+            let sync_cfg = crate::sync::default_sync_config(None, crate::genesis::devnet_genesis_chain_id(), None);
             let mut engine = crate::sync::SyncEngine::new(chain_state, None, sync_cfg).expect("sync engine"); let relay_state = crate::tx_relay::TxRelayState::new(); let peer_manager = PeerManager::new(default_peer_runtime_config("devnet", 64)); let peer_outboxes: Mutex<HashMap<String, crate::tx_relay::PeerOutbox>> = Mutex::new(HashMap::new()); let canonical_tx_pool = Mutex::new(TxPool::new()); let da_relay = Mutex::new(crate::da_relay::DaRelayState::new(crate::da_relay::DaRelayCaps::default()).expect("valid DA relay caps"));
             let prefetch = Mutex::new(crate::da_prefetch::DaRelayPrefetchState::default());
             let relay_ctx = PeerRelayContext { relay_state: &relay_state, peer_manager: &peer_manager, local_addr: "local:8333", peer_registered_addr: "sender:8333", peer_writers: &peer_outboxes, tx_pool: &canonical_tx_pool, da_relay: &da_relay, prefetch: &prefetch };
@@ -7122,12 +7120,11 @@ mod tests {
 
             let (chain_state, tx_bytes, _unused) =
                 signed_conflicting_p2pk_state_and_txs(20_000, 10, 9);
-            let mut sync_cfg = crate::sync::default_sync_config(
+            let sync_cfg = crate::sync::default_sync_config(
                 None,
                 crate::genesis::devnet_genesis_chain_id(),
                 None,
             );
-            sync_cfg.core_ext_deployments = rubin_consensus::CoreExtDeploymentProfiles::empty();
             let mut engine =
                 crate::sync::SyncEngine::new(chain_state, None, sync_cfg).expect("sync engine");
 
@@ -7176,12 +7173,11 @@ mod tests {
 
             let (chain_state, tx_bytes, _unused) =
                 signed_conflicting_p2pk_state_and_txs(20_000, 10, 9);
-            let mut sync_cfg = crate::sync::default_sync_config(
+            let sync_cfg = crate::sync::default_sync_config(
                 None,
                 crate::genesis::devnet_genesis_chain_id(),
                 None,
             );
-            sync_cfg.core_ext_deployments = rubin_consensus::CoreExtDeploymentProfiles::empty();
             let mut engine =
                 crate::sync::SyncEngine::new(chain_state, None, sync_cfg).expect("sync engine");
 

--- a/clients/rust/crates/rubin-node/src/sync.rs
+++ b/clients/rust/crates/rubin-node/src/sync.rs
@@ -5,9 +5,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use rubin_consensus::constants::POW_LIMIT;
-use rubin_consensus::{
-    block_hash, parse_block_bytes, parse_block_header_bytes, CoreExtDeploymentProfiles,
-};
+use rubin_consensus::{block_hash, parse_block_bytes, parse_block_header_bytes};
 use rubin_consensus::{RotationProvider, SuiteRegistry};
 
 use crate::blockstore::BlockStore;
@@ -28,7 +26,6 @@ pub struct SyncConfig {
     pub chain_id: [u8; 32],
     pub chain_state_path: Option<PathBuf>,
     pub network: String,
-    pub core_ext_deployments: CoreExtDeploymentProfiles,
     pub suite_context: Option<SuiteContext>,
     pub parallel_validation_mode: String,
     pub pv_shadow_max_samples: u64,
@@ -521,7 +518,6 @@ pub fn default_sync_config(
         chain_id,
         chain_state_path,
         network: "devnet".to_string(),
-        core_ext_deployments: CoreExtDeploymentProfiles::empty(),
         suite_context: None,
         parallel_validation_mode: "off".to_string(),
         pv_shadow_max_samples: DEFAULT_PV_SHADOW_MAX_SAMPLES,
@@ -636,10 +632,6 @@ impl SyncEngine {
 
     pub fn block_store_snapshot(&self) -> Option<BlockStore> {
         self.block_store.clone()
-    }
-
-    pub fn core_ext_deployments(&self) -> CoreExtDeploymentProfiles {
-        self.cfg.core_ext_deployments.clone()
     }
 
     pub fn tip(&self) -> Result<Option<(u64, [u8; 32])>, String> {
@@ -759,17 +751,14 @@ impl SyncEngine {
                 Some(ctx) => (Some(ctx.rotation.as_ref()), Some(ctx.registry.as_ref())),
                 None => (None, None),
             };
-        let summary = match self
-            .chain_state
-            .connect_block_with_core_ext_deployments_and_suite_context(
-                block_bytes,
-                self.cfg.expected_target,
-                prev_timestamps,
-                self.cfg.chain_id,
-                &self.cfg.core_ext_deployments,
-                rotation,
-                registry,
-            ) {
+        let summary = match self.chain_state.connect_block_with_suite_context(
+            block_bytes,
+            self.cfg.expected_target,
+            prev_timestamps,
+            self.cfg.chain_id,
+            rotation,
+            registry,
+        ) {
             Ok(summary) => summary,
             Err(err) => {
                 if pv_active {
@@ -1174,12 +1163,11 @@ fn run_pv_shadow_validation(
             Some(ctx) => (Some(ctx.rotation.as_ref()), Some(ctx.registry.as_ref())),
             None => (None, None),
         };
-    shadow_state.connect_block_with_core_ext_deployments_and_suite_context(
+    shadow_state.connect_block_with_suite_context(
         block_bytes,
         cfg.expected_target,
         prev_timestamps,
         cfg.chain_id,
-        &cfg.core_ext_deployments,
         rotation,
         registry,
     )?;
@@ -1195,24 +1183,16 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::sync::Arc;
     use std::time::{SystemTime, UNIX_EPOCH};
 
-    use rubin_consensus::constants::{
-        COV_TYPE_CORE_EXT, COV_TYPE_P2PK, POW_LIMIT, SUITE_ID_ML_DSA_87,
-    };
-    use rubin_consensus::merkle::{witness_commitment_hash, witness_merkle_root_wtxids};
+    use rubin_consensus::constants::{COV_TYPE_P2PK, POW_LIMIT, SUITE_ID_ML_DSA_87};
     use rubin_consensus::{
-        block_hash, encode_compact_size, merkle_root_txids, parse_block_bytes, parse_tx,
-        CoreExtDeploymentProfile, CoreExtDeploymentProfiles, CoreExtVerificationBinding,
-        NativeSuiteSet, Outpoint, RotationProvider, UtxoEntry, BLOCK_HEADER_BYTES,
+        block_hash, encode_compact_size, Outpoint, UtxoEntry, BLOCK_HEADER_BYTES,
     };
     use rubin_consensus::{DefaultRotationProvider, SuiteRegistry};
 
     use crate::blockstore::{block_store_path, BlockStore};
     use crate::chainstate::{chain_state_path, load_chain_state, ChainState};
-    use crate::coinbase::{build_coinbase_tx, default_mine_address};
     use crate::genesis::{devnet_genesis_block_bytes, devnet_genesis_chain_id};
     use crate::io_utils::unique_temp_path;
     use crate::sync::{
@@ -1221,24 +1201,6 @@ mod tests {
     };
 
     const VALID_BLOCK_HEX: &str = "01000000111111111111111111111111111111111111111111111111111111111111111102e66000bf8ce870908df4a8689554852ccef681ee0b5df32246162a53e36e290100000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff07000000000000000101000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000ffffffff00ffffffff010000000000000000020020b716a4b7f4c0fab665298ab9b8199b601ab9fa7e0a27f0713383f34cf37071a8000000000000";
-    const CORE_EXT_NATIVE_BINDING_SPEND_TX_HEX: &str = "0100000000010000000000000001eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee000000000000000000015a0000000000000000002101111111111111111111111111111111111111111111111111111111111111111100000000010300010100";
-
-    struct CountingRotationProvider {
-        spend_calls: AtomicUsize,
-    }
-
-    impl RotationProvider for CountingRotationProvider {
-        fn native_create_suites(&self, _height: u64) -> NativeSuiteSet {
-            NativeSuiteSet::try_new(&[SUITE_ID_ML_DSA_87])
-                .expect("counting rotation provider suite set must stay <= 2")
-        }
-
-        fn native_spend_suites(&self, _height: u64) -> NativeSuiteSet {
-            self.spend_calls.fetch_add(1, Ordering::SeqCst);
-            NativeSuiteSet::try_new(&[SUITE_ID_ML_DSA_87])
-                .expect("counting rotation provider suite set must stay <= 2")
-        }
-    }
 
     fn hex_to_bytes(hex: &str) -> Vec<u8> {
         let mut out = Vec::with_capacity(hex.len() / 2);
@@ -1580,168 +1542,6 @@ mod tests {
             .expect("default rotation must accept genesis");
         assert!(engine.chain_state.has_tip);
         assert_eq!(engine.chain_state.height, 0);
-    }
-
-    #[test]
-    fn sync_engine_rejects_post_activation_core_ext_spend_without_pre_active_bypass() {
-        let dir = unique_temp_path("rubin-node-sync-core-ext");
-        let chain_state_file = chain_state_path(&dir);
-        let block_store_root = block_store_path(&dir);
-        let store = BlockStore::open(block_store_root).expect("open blockstore");
-
-        let mut cfg = default_sync_config(
-            Some(POW_LIMIT),
-            devnet_genesis_chain_id(),
-            Some(chain_state_file),
-        );
-        cfg.core_ext_deployments = CoreExtDeploymentProfiles {
-            deployments: vec![CoreExtDeploymentProfile {
-                ext_id: 1,
-                activation_height: 1,
-                tx_context_enabled: false,
-                allowed_suite_ids: vec![3],
-                verification_binding: CoreExtVerificationBinding::NativeVerifySig,
-                verify_sig_ext_tx_context_fn: None,
-                binding_descriptor: Vec::new(),
-                ext_payload_schema: Vec::new(),
-                governance_nonce: 0,
-            }],
-        };
-        let mut engine = SyncEngine::new(ChainState::new(), Some(store), cfg).expect("new sync");
-        engine
-            .apply_block(&devnet_genesis_block_bytes(), None)
-            .expect("apply genesis");
-
-        engine.chain_state.utxos.insert(
-            Outpoint {
-                txid: [0xee; 32],
-                vout: 0,
-            },
-            UtxoEntry {
-                value: 100,
-                covenant_type: COV_TYPE_CORE_EXT,
-                covenant_data: vec![0x01, 0x00, 0x00],
-                creation_height: 0,
-                created_by_coinbase: false,
-            },
-        );
-
-        let spend_tx = hex_to_bytes(CORE_EXT_NATIVE_BINDING_SPEND_TX_HEX);
-        let (_, spend_txid, spend_wtxid, consumed) = parse_tx(&spend_tx).expect("parse spend");
-        assert_eq!(consumed, spend_tx.len());
-        let witness_root =
-            witness_merkle_root_wtxids(&[[0u8; 32], spend_wtxid]).expect("witness root");
-        let witness_commitment = witness_commitment_hash(witness_root);
-        let coinbase =
-            build_coinbase_tx(1, 0, &default_mine_address(), witness_commitment).expect("coinbase");
-        let (_, coinbase_txid, _, coinbase_consumed) = parse_tx(&coinbase).expect("parse coinbase");
-        assert_eq!(coinbase_consumed, coinbase.len());
-        let merkle_root = merkle_root_txids(&[coinbase_txid, spend_txid]).expect("merkle root");
-        let genesis = devnet_genesis_block_bytes();
-        let genesis_hash = block_hash(&genesis[..BLOCK_HEADER_BYTES]).expect("genesis hash");
-        let parsed_genesis = parse_block_bytes(&genesis).expect("parse genesis");
-        let block = build_block_bytes(
-            genesis_hash,
-            merkle_root,
-            POW_LIMIT,
-            parsed_genesis.header.timestamp.saturating_add(1),
-            &[coinbase, spend_tx],
-        );
-
-        let err = engine.apply_block(&block, None).unwrap_err();
-        assert!(
-            err.contains("TX_ERR_SIG_ALG_INVALID"),
-            "unexpected error: {err}"
-        );
-    }
-
-    #[test]
-    fn sync_engine_shadow_mode_reuses_shared_suite_context_sequentially() {
-        let dir = unique_temp_path("rubin-node-sync-pv-shared-suite-context");
-        let chain_state_file = chain_state_path(&dir);
-        let block_store_root = block_store_path(&dir);
-        let store = BlockStore::open(block_store_root).expect("open blockstore");
-
-        let rotation = Arc::new(CountingRotationProvider {
-            spend_calls: AtomicUsize::new(0),
-        });
-
-        let mut cfg = default_sync_config(
-            Some(POW_LIMIT),
-            devnet_genesis_chain_id(),
-            Some(chain_state_file),
-        );
-        cfg.parallel_validation_mode = "shadow".to_string();
-        cfg.suite_context = Some(SuiteContext {
-            rotation: rotation.clone(),
-            registry: Arc::new(SuiteRegistry::default_registry().clone()),
-        });
-        cfg.core_ext_deployments = CoreExtDeploymentProfiles {
-            deployments: vec![CoreExtDeploymentProfile {
-                ext_id: 1,
-                activation_height: 1,
-                tx_context_enabled: false,
-                allowed_suite_ids: vec![3],
-                verification_binding: CoreExtVerificationBinding::NativeVerifySig,
-                verify_sig_ext_tx_context_fn: None,
-                binding_descriptor: Vec::new(),
-                ext_payload_schema: Vec::new(),
-                governance_nonce: 0,
-            }],
-        };
-
-        let mut engine = SyncEngine::new(ChainState::new(), Some(store), cfg).expect("new sync");
-        engine
-            .apply_block(&devnet_genesis_block_bytes(), None)
-            .expect("apply genesis");
-
-        engine.chain_state.utxos.insert(
-            Outpoint {
-                txid: [0xee; 32],
-                vout: 0,
-            },
-            UtxoEntry {
-                value: 100,
-                covenant_type: COV_TYPE_CORE_EXT,
-                covenant_data: vec![0x01, 0x00, 0x00],
-                creation_height: 0,
-                created_by_coinbase: false,
-            },
-        );
-
-        let spend_tx = hex_to_bytes(CORE_EXT_NATIVE_BINDING_SPEND_TX_HEX);
-        let (_, spend_txid, spend_wtxid, consumed) = parse_tx(&spend_tx).expect("parse spend");
-        assert_eq!(consumed, spend_tx.len());
-        let witness_root =
-            witness_merkle_root_wtxids(&[[0u8; 32], spend_wtxid]).expect("witness root");
-        let witness_commitment = witness_commitment_hash(witness_root);
-        let coinbase =
-            build_coinbase_tx(1, 0, &default_mine_address(), witness_commitment).expect("coinbase");
-        let (_, coinbase_txid, _, coinbase_consumed) = parse_tx(&coinbase).expect("parse coinbase");
-        assert_eq!(coinbase_consumed, coinbase.len());
-        let merkle_root = merkle_root_txids(&[coinbase_txid, spend_txid]).expect("merkle root");
-        let genesis = devnet_genesis_block_bytes();
-        let genesis_hash = block_hash(&genesis[..BLOCK_HEADER_BYTES]).expect("genesis hash");
-        let parsed_genesis = parse_block_bytes(&genesis).expect("parse genesis");
-        let block = build_block_bytes(
-            genesis_hash,
-            merkle_root,
-            POW_LIMIT,
-            parsed_genesis.header.timestamp.saturating_add(1),
-            &[coinbase, spend_tx],
-        );
-
-        let err = engine.apply_block(&block, None).unwrap_err();
-        assert!(
-            err.contains("TX_ERR_SIG_ALG_INVALID"),
-            "unexpected error: {err}"
-        );
-        assert!(
-            rotation.spend_calls.load(Ordering::SeqCst) >= 2,
-            "shared suite context should be exercised by both primary and shadow validation paths"
-        );
-
-        std::fs::remove_dir_all(&dir).expect("cleanup");
     }
 
     /// RUB-12 / GitHub #1156: pin the exact 33-line Prometheus

--- a/clients/rust/crates/rubin-node/src/sync_reorg.rs
+++ b/clients/rust/crates/rubin-node/src/sync_reorg.rs
@@ -524,12 +524,11 @@ impl SyncEngine {
         let mut sliding_ts = self.prev_timestamps_for_height(common_ancestor_height + 1)?;
         let (rotation, registry) = self.suite_context();
         for item in branch {
-            preview_state.connect_block_with_core_ext_deployments_and_suite_context(
+            preview_state.connect_block_with_suite_context(
                 &item.block_bytes,
                 self.cfg.expected_target,
                 sliding_ts.as_deref(),
                 self.cfg.chain_id,
-                &self.cfg.core_ext_deployments,
                 rotation,
                 registry,
             )?;

--- a/clients/rust/crates/rubin-node/src/tx_relay.rs
+++ b/clients/rust/crates/rubin-node/src/tx_relay.rs
@@ -646,7 +646,6 @@ pub fn handle_received_tx(
     }
 
     let relay_cfg = crate::txpool::TxPoolConfig {
-        core_ext_deployments: sync_engine.cfg.core_ext_deployments.clone(),
         suite_context: sync_engine.cfg.suite_context.clone(),
         ..crate::txpool::TxPoolConfig::default()
     };
@@ -1406,8 +1405,7 @@ mod tests {
         // other) is preserved.
         let (chain_state, tx_bytes, _second_tx_unused) =
             crate::test_helpers::signed_conflicting_p2pk_state_and_txs(20_000, 10, 9);
-        let mut cfg = default_sync_config(None, crate::genesis::devnet_genesis_chain_id(), None);
-        cfg.core_ext_deployments = rubin_consensus::CoreExtDeploymentProfiles::empty();
+        let cfg = default_sync_config(None, crate::genesis::devnet_genesis_chain_id(), None);
         let sync_engine = SyncEngine::new(chain_state, None, cfg).expect("sync engine");
         let relay = TxRelayState::new();
         let pm = PeerManager::new(crate::p2p_runtime::default_peer_runtime_config(

--- a/clients/rust/crates/rubin-node/src/txpool.rs
+++ b/clients/rust/crates/rubin-node/src/txpool.rs
@@ -4,9 +4,9 @@ use std::sync::OnceLock;
 
 use rubin_consensus::{
     apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles_and_suite_context,
-    constants::MAX_RELAY_MSG_BYTES, parse_block_header_bytes, parse_core_ext_covenant_data,
-    parse_tx, tx_weight_and_stats_public, CoreExtDeploymentProfiles, DefaultRotationProvider,
-    NativeSuiteSet, Outpoint, RotationProvider, SuiteRegistry,
+    constants::{COV_TYPE_CORE_EXT, MAX_RELAY_MSG_BYTES},
+    parse_block_header_bytes, parse_tx, tx_weight_and_stats_public, CoreExtProfiles,
+    DefaultRotationProvider, NativeSuiteSet, Outpoint, RotationProvider, SuiteRegistry,
 };
 
 use crate::sync::SuiteContext;
@@ -94,9 +94,6 @@ pub const DEFAULT_MIN_DA_FEE_RATE: u64 = 1;
 pub struct TxPoolConfig {
     pub policy_da_surcharge_per_byte: u64,
     pub policy_reject_non_coinbase_anchor_outputs: bool,
-    pub policy_reject_core_ext_pre_activation: bool,
-    pub policy_max_ext_payload_bytes: usize,
-    pub core_ext_deployments: CoreExtDeploymentProfiles,
     pub suite_context: Option<SuiteContext>,
     /// Rolling local mempool floor used by the Stage C relay-fee term.
     /// Defaults to `DEFAULT_MEMPOOL_MIN_FEE_RATE`; a live rolling floor
@@ -607,11 +604,6 @@ impl TxPool {
 
         let next_height = next_block_height(chain_state)?;
         let block_mtp = next_block_mtp(block_store, next_height)?;
-        let active_profiles = self
-            .cfg
-            .core_ext_deployments
-            .active_profiles_at_height(next_height)
-            .map_err(|err| rejected(format!("transaction rejected: {err}")))?;
         let (rotation, registry): (Option<&dyn RotationProvider>, Option<&SuiteRegistry>) =
             match self.cfg.suite_context.as_ref() {
                 Some(ctx) => (Some(ctx.rotation.as_ref()), Some(ctx.registry.as_ref())),
@@ -666,7 +658,7 @@ impl TxPool {
                 block_mtp,
                 block_mtp,
                 chain_id,
-                &active_profiles,
+                &CoreExtProfiles::empty(),
                 rotation,
                 registry,
             )
@@ -688,7 +680,7 @@ impl TxPool {
         let utxos = &chain_state.utxos;
         let cfg = &self.cfg;
         #[rustfmt::skip]
-        let policy_result = apply_post_consensus_policy_without_floor(&tx, utxos, next_height, weight, da_bytes, cfg);
+        let policy_result = apply_post_consensus_policy_without_floor(&tx, utxos, weight, da_bytes, cfg);
         policy_result?;
 
         if self.txs.contains_key(&txid) {
@@ -1106,10 +1098,6 @@ pub(crate) fn relay_metadata(
 
     let next_height = next_block_height(chain_state)?;
     let block_mtp = next_block_mtp(block_store, next_height)?;
-    let active_profiles = cfg
-        .core_ext_deployments
-        .active_profiles_at_height(next_height)
-        .map_err(|err| rejected(format!("transaction rejected: {err}")))?;
     let (rotation, registry): (Option<&dyn RotationProvider>, Option<&SuiteRegistry>) =
         match cfg.suite_context.as_ref() {
             Some(ctx) => (Some(ctx.rotation.as_ref()), Some(ctx.registry.as_ref())),
@@ -1124,7 +1112,7 @@ pub(crate) fn relay_metadata(
             block_mtp,
             block_mtp,
             chain_id,
-            &active_profiles,
+            &CoreExtProfiles::empty(),
             rotation,
             registry,
         )
@@ -1144,7 +1132,7 @@ pub(crate) fn relay_metadata(
     // Codacy diff-coverage attribution (mirror of admit_with_metadata).
     let utxos = &chain_state.utxos;
     #[rustfmt::skip]
-    let policy_result = apply_post_consensus_policy_with_floor(&tx, utxos, next_height, summary.fee, weight, da_bytes, cfg);
+    let policy_result = apply_post_consensus_policy_with_floor(&tx, utxos, summary.fee, weight, da_bytes, cfg);
     policy_result?;
 
     Ok(RelayTxMetadata {
@@ -1199,27 +1187,25 @@ pub(crate) fn relay_metadata(
 fn apply_post_consensus_policy_with_floor(
     tx: &rubin_consensus::Tx,
     utxos: &HashMap<Outpoint, rubin_consensus::UtxoEntry>,
-    next_height: u64,
     fee: u64,
     weight: u64,
     da_bytes: u64,
     cfg: &TxPoolConfig,
 ) -> Result<(), TxPoolAdmitError> {
-    apply_post_consensus_policy_without_floor(tx, utxos, next_height, weight, da_bytes, cfg)?;
+    apply_post_consensus_policy_without_floor(tx, utxos, weight, da_bytes, cfg)?;
     validate_fee_floor(fee, weight, cfg.policy_current_mempool_min_fee_rate)
 }
 
 fn apply_post_consensus_policy_without_floor(
     tx: &rubin_consensus::Tx,
     utxos: &HashMap<Outpoint, rubin_consensus::UtxoEntry>,
-    next_height: u64,
     weight: u64,
     da_bytes: u64,
     cfg: &TxPoolConfig,
 ) -> Result<(), TxPoolAdmitError> {
     let mut policy_cfg = cfg.clone();
     policy_cfg.policy_current_mempool_min_fee_rate = 0;
-    apply_policy(tx, weight, da_bytes, utxos, next_height, &policy_cfg).map_err(rejected)
+    apply_policy(tx, weight, da_bytes, utxos, &policy_cfg).map_err(rejected)
 }
 
 impl Default for TxPool {
@@ -1233,9 +1219,6 @@ impl Default for TxPoolConfig {
         Self {
             policy_da_surcharge_per_byte: 0,
             policy_reject_non_coinbase_anchor_outputs: true,
-            policy_reject_core_ext_pre_activation: true,
-            policy_max_ext_payload_bytes: 0,
-            core_ext_deployments: CoreExtDeploymentProfiles::empty(),
             suite_context: None,
             policy_current_mempool_min_fee_rate: DEFAULT_MEMPOOL_MIN_FEE_RATE,
             policy_min_da_fee_rate: DEFAULT_MIN_DA_FEE_RATE,
@@ -1660,7 +1643,6 @@ pub(crate) fn apply_policy(
     weight: u64,
     da_bytes: u64,
     utxos: &HashMap<Outpoint, rubin_consensus::UtxoEntry>,
-    next_height: u64,
     cfg: &TxPoolConfig,
 ) -> Result<(), String> {
     if cfg.policy_reject_non_coinbase_anchor_outputs {
@@ -1675,42 +1657,45 @@ pub(crate) fn apply_policy(
         cfg.policy_min_da_fee_rate,
         cfg.policy_da_surcharge_per_byte,
     )?;
-    if cfg.policy_reject_core_ext_pre_activation {
-        reject_core_ext_tx_pre_activation(tx, utxos, next_height, &cfg.core_ext_deployments)?;
-    }
-    if cfg.policy_max_ext_payload_bytes > 0 {
-        reject_core_ext_tx_oversized_payload(tx, cfg.policy_max_ext_payload_bytes)?;
+    if let Some(reason) = reject_unsupported_core_ext_node_runtime(tx, utxos) {
+        return Err(reason);
     }
     Ok(())
 }
 
-/// SHOULD-level mempool policy: reject transactions with CORE_EXT outputs whose
-/// ext_payload exceeds the configured maximum. This is relay policy, not consensus.
-pub(crate) fn reject_core_ext_tx_oversized_payload(
+fn reject_unsupported_core_ext_node_runtime(
     tx: &rubin_consensus::Tx,
-    max_bytes: usize,
-) -> Result<(), String> {
-    if max_bytes == 0 {
-        return Ok(());
+    utxos: &HashMap<Outpoint, rubin_consensus::UtxoEntry>,
+) -> Option<String> {
+    covenant_policy_kind(tx, utxos, COV_TYPE_CORE_EXT)
+        .map(|kind| format!("CORE_EXT {kind} unsupported by Rust node runtime"))
+}
+
+fn covenant_policy_kind(
+    tx: &rubin_consensus::Tx,
+    utxos: &HashMap<Outpoint, rubin_consensus::UtxoEntry>,
+    covenant_type: u16,
+) -> Option<&'static str> {
+    if tx
+        .outputs
+        .iter()
+        .any(|output| output.covenant_type == covenant_type)
+    {
+        return Some("output");
     }
-    for (i, output) in tx.outputs.iter().enumerate() {
-        if output.covenant_type != rubin_consensus::constants::COV_TYPE_CORE_EXT {
-            continue;
-        }
-        let cov = match parse_core_ext_covenant_data(&output.covenant_data) {
-            Ok(c) => c,
-            Err(_) => continue, // Parse failure handled by consensus validation
+    for input in &tx.inputs {
+        let outpoint = Outpoint {
+            txid: input.prev_txid,
+            vout: input.prev_vout,
         };
-        if cov.ext_payload.len() > max_bytes {
-            return Err(format!(
-                "CORE_EXT output {} ext_payload {} bytes exceeds policy limit {}",
-                i,
-                cov.ext_payload.len(),
-                max_bytes,
-            ));
+        if utxos
+            .get(&outpoint)
+            .is_some_and(|entry| entry.covenant_type == covenant_type)
+        {
+            return Some("spend");
         }
     }
-    Ok(())
+    None
 }
 
 pub(crate) fn reject_non_coinbase_anchor_outputs(tx: &rubin_consensus::Tx) -> Result<(), String> {
@@ -1866,53 +1851,6 @@ pub(crate) fn compute_fee_no_verify(
         return Err("overspend".to_string());
     }
     Ok(sum_in - sum_out)
-}
-
-pub(crate) fn reject_core_ext_tx_pre_activation(
-    tx: &rubin_consensus::Tx,
-    utxos: &HashMap<Outpoint, rubin_consensus::UtxoEntry>,
-    height: u64,
-    deployments: &CoreExtDeploymentProfiles,
-) -> Result<(), String> {
-    let active = deployments
-        .active_profiles_at_height(height)
-        .map_err(|err| err.to_string())?;
-    for output in &tx.outputs {
-        if output.covenant_type != rubin_consensus::constants::COV_TYPE_CORE_EXT {
-            continue;
-        }
-        let cov =
-            parse_core_ext_covenant_data(&output.covenant_data).map_err(|err| err.to_string())?;
-        if !active
-            .active
-            .iter()
-            .any(|profile| profile.ext_id == cov.ext_id)
-        {
-            return Err(format!("CORE_EXT output pre-ACTIVE ext_id={}", cov.ext_id));
-        }
-    }
-    for input in &tx.inputs {
-        let outpoint = Outpoint {
-            txid: input.prev_txid,
-            vout: input.prev_vout,
-        };
-        let Some(entry) = utxos.get(&outpoint) else {
-            continue;
-        };
-        if entry.covenant_type != rubin_consensus::constants::COV_TYPE_CORE_EXT {
-            continue;
-        }
-        let cov =
-            parse_core_ext_covenant_data(&entry.covenant_data).map_err(|err| err.to_string())?;
-        if !active
-            .active
-            .iter()
-            .any(|profile| profile.ext_id == cov.ext_id)
-        {
-            return Err(format!("CORE_EXT spend pre-ACTIVE ext_id={}", cov.ext_id));
-        }
-    }
-    Ok(())
 }
 
 fn compare_entries_for_mining(
@@ -2079,8 +2017,7 @@ mod tests {
     };
     use rubin_consensus::{
         marshal_tx, p2pk_covenant_data_for_pubkey, parse_tx, sign_transaction,
-        tx_weight_and_stats_public, CoreExtDeploymentProfile, CoreExtDeploymentProfiles,
-        CoreExtVerificationBinding, DaChunkCore, Mldsa87Keypair, Outpoint, Tx, TxInput, TxOutput,
+        tx_weight_and_stats_public, DaChunkCore, Mldsa87Keypair, Outpoint, Tx, TxInput, TxOutput,
         UtxoEntry, WitnessItem,
     };
 
@@ -2088,10 +2025,9 @@ mod tests {
         cheap_fee_floor_precheck, compare_admit_priority, compare_entries_for_mining,
         compare_fee_rate, conflict, default_tx_pool_low_water_bytes, fee_precheck_p2pk_input_value,
         fee_precheck_p2pk_output_value, mtp_median, next_block_height, next_block_mtp,
-        reject_core_ext_tx_oversized_payload, reject_da_anchor_tx_policy, rejected, relay_metadata,
-        tx_pool_byte_pressure_target, unavailable, TxPool, TxPoolAdmitErrorKind, TxPoolConfig,
-        TxPoolEntry, TxPoolSnapshot, TxPoolSnapshotEntry, TxSource, DEFAULT_MEMPOOL_MIN_FEE_RATE,
-        MAX_TX_POOL_TRANSACTIONS,
+        reject_da_anchor_tx_policy, rejected, relay_metadata, tx_pool_byte_pressure_target,
+        unavailable, TxPool, TxPoolAdmitErrorKind, TxPoolConfig, TxPoolEntry, TxPoolSnapshot,
+        TxPoolSnapshotEntry, TxSource, DEFAULT_MEMPOOL_MIN_FEE_RATE, MAX_TX_POOL_TRANSACTIONS,
     };
     use crate::{
         block_store_path, default_sync_config, devnet_genesis_block_bytes, devnet_genesis_chain_id,
@@ -2533,14 +2469,12 @@ mod tests {
 
         let lenient_snapshot = TxPool::new_with_config(TxPoolConfig {
             policy_current_mempool_min_fee_rate: 0,
-            policy_reject_core_ext_pre_activation: false,
             ..TxPoolConfig::default()
         })
         .snapshot()
         .expect("lenient snapshot");
         pool.restore_snapshot(&lenient_snapshot)
             .expect("empty snapshot restores");
-        assert!(pool.cfg.policy_reject_core_ext_pre_activation);
         assert!(pool.cfg.policy_current_mempool_min_fee_rate == DEFAULT_MEMPOOL_MIN_FEE_RATE);
     }
 
@@ -2713,7 +2647,7 @@ mod tests {
     }
 
     #[test]
-    fn relay_metadata_rejects_pre_activation_core_ext_outputs() {
+    fn relay_metadata_rejects_core_ext_outputs_as_unsupported_runtime() {
         let (state, raw) = signed_p2pk_state_and_tx(
             10,
             vec![TxOutput {
@@ -2730,7 +2664,7 @@ mod tests {
             relay_metadata(&raw, &state, None, [0u8; 32], &TxPoolConfig::default()).unwrap_err();
 
         assert_eq!(err.kind, TxPoolAdmitErrorKind::Rejected);
-        assert!(err.message.contains("CORE_EXT output pre-ACTIVE"));
+        assert!(err.message.contains("CORE_EXT output unsupported"));
     }
 
     #[test]
@@ -3834,26 +3768,9 @@ mod tests {
     }
 
     #[test]
-    fn admit_rejects_core_ext_output_pre_activation_by_policy() {
-        // RUB-162 Phase A migration rationale (per controller Path A
-        // approval 2026-05-03 + RESP P1 #2 reorder fix 2026-05-03):
-        //   - old assumption: input=10/output=9 fee=1 reached the
-        //     CORE_EXT pre-activation policy guard returning Rejected.
-        //   - new invariant: apply_policy (which evaluates the
-        //     CORE_EXT pre-activation policy) precedes the rolling-floor
-        //     check in admit_with_metadata.
-        //   - Proof assertion: `assert_eq!(err.kind, Rejected)` plus
-        //     `err.message.contains("CORE_EXT output pre-ACTIVE")`
-        //     below pin the class winner against the alternative
-        //     `Unavailable("mempool fee below rolling minimum")`
-        //     outcome.
-        //   - replacement coverage: input bumped to 7700 so fee=7691
-        //     ≥ weight ⇒ candidate also passes the floor (defensive,
-        //     since apply_policy rejects regardless) and reaches the
-        //     CORE_EXT pre-activation policy guard. The fixture is
-        //     mirrored in
-        //     rub162_admit_sub_floor_core_ext_classifies_as_core_ext_rejected
-        //     to PIN the cross-pollination class winner.
+    fn admit_rejects_core_ext_output_as_unsupported_runtime_before_floor() {
+        // The candidate is floor-compliant; the test pins CORE_EXT
+        // unsupported-runtime classification independent of fee floor.
         let (state, raw) = signed_p2pk_state_and_tx(
             7700,
             vec![TxOutput {
@@ -3869,75 +3786,13 @@ mod tests {
             .admit(&raw, &state, None, [0u8; 32])
             .unwrap_err();
         assert_eq!(err.kind, TxPoolAdmitErrorKind::Rejected);
-        assert!(err.message.contains("CORE_EXT output pre-ACTIVE"));
+        assert!(err.message.contains("CORE_EXT output unsupported"));
     }
 
     #[test]
-    fn admit_allows_core_ext_output_when_profile_is_active() {
-        // RUB-162 Phase A migration rationale (per controller Q2 record):
-        //   - old assumption: input=10/output=9 → fee=1 with weight≈7533
-        //     admits once core_ext profile is registered (pre-RUB-162 had no
-        //     fee-floor check).
-        //   - new invariant: admit_with_metadata enforces the rolling fee
-        //     floor (DEFAULT_MEMPOOL_MIN_FEE_RATE=1).
-        //   - why it reaches policy path: tx is well-formed; floor check is
-        //     after apply_policy and after the CORE_EXT pre-activation check
-        //     succeeds for the registered profile.
-        //   - replacement coverage: input bumped to 7542 so fee = 7542 - 9
-        //     = 7533 ≥ weight (≈7533) ⇒ fee/weight ≥ 1 ⇒ passes the
-        //     default floor; the test's CORE_EXT-profile-activation
-        //     invariant remains under test.
-        let (state, raw) = signed_p2pk_state_and_tx(
-            7_542,
-            vec![TxOutput {
-                value: 9,
-                covenant_type: COV_TYPE_CORE_EXT,
-                covenant_data: empty_core_ext_covenant_data(7),
-            }],
-            0x00,
-            None,
-            Vec::new(),
-        );
-        let mut pool = TxPool::new_with_config(TxPoolConfig::default());
-        pool.cfg.core_ext_deployments = CoreExtDeploymentProfiles {
-            deployments: vec![CoreExtDeploymentProfile {
-                ext_id: 7,
-                activation_height: 0,
-                tx_context_enabled: false,
-                allowed_suite_ids: vec![3],
-                verification_binding: CoreExtVerificationBinding::VerifySigExtAccept,
-                verify_sig_ext_tx_context_fn: None,
-                binding_descriptor: b"accept".to_vec(),
-                ext_payload_schema: b"schema".to_vec(),
-                governance_nonce: 0,
-            }],
-        };
-        let txid = pool.admit(&raw, &state, None, [0u8; 32]).expect("admit");
-        assert!(pool.txs.contains_key(&txid));
-    }
-
-    #[test]
-    fn admit_rejects_core_ext_spend_pre_activation_by_policy() {
-        // RUB-162 Phase A migration rationale (per controller Path A
-        // approval 2026-05-03 + RESP P1 #2 reorder fix 2026-05-03):
-        //   - old assumption: core_ext_spend_state_and_tx helper sets
-        //     UTXO value=10/output value=9 → fee=1 reaches the
-        //     CORE_EXT-spend pre-activation policy guard.
-        //   - new invariant: apply_policy (which evaluates the
-        //     CORE_EXT spend pre-activation policy) precedes the
-        //     rolling-floor check in admit_with_metadata. Headroom is
-        //     defensive.
-        //   - Proof assertion: `assert_eq!(err.kind, Rejected)` plus
-        //     `err.message.contains("CORE_EXT spend pre-ACTIVE")`
-        //     below pin the class winner against the alternative
-        //     `Unavailable("mempool fee below rolling minimum")`
-        //     outcome.
-        //   - replacement coverage: bump UTXO value in-place to 7700
-        //     (helper's UTXO value patched after construction; helper
-        //     signature preserved for any future caller). fee = 7700 -
-        //     9 = 7691 ≥ weight ⇒ candidate also passes the floor; the
-        //     CORE_EXT-spend pre-activation guard remains the test
-        //     goal.
+    fn admit_rejects_core_ext_spend_as_unsupported_runtime_before_floor() {
+        // Spend-side twin of the output test. The candidate is made
+        // floor-compliant so the unsupported-runtime policy is the winner.
         let (mut state, raw) = core_ext_spend_state_and_tx(9);
         for entry in state.utxos.values_mut() {
             entry.value = 7700;
@@ -3946,7 +3801,7 @@ mod tests {
             .admit(&raw, &state, None, [0u8; 32])
             .unwrap_err();
         assert_eq!(err.kind, TxPoolAdmitErrorKind::Rejected);
-        assert!(err.message.contains("CORE_EXT spend pre-ACTIVE"));
+        assert!(err.message.contains("CORE_EXT spend unsupported"));
     }
 
     #[test]
@@ -3962,134 +3817,6 @@ mod tests {
         let unavailable_err = unavailable("unavailable");
         assert_eq!(unavailable_err.kind, TxPoolAdmitErrorKind::Unavailable);
         assert_eq!(unavailable_err.to_string(), "unavailable");
-    }
-
-    #[test]
-    fn reject_oversized_payload_allows_under_limit() {
-        let tx = Tx {
-            version: TX_WIRE_VERSION,
-            tx_kind: 0,
-            tx_nonce: 1,
-            inputs: vec![],
-            outputs: vec![TxOutput {
-                value: 1,
-                covenant_type: COV_TYPE_CORE_EXT,
-                covenant_data: core_ext_covenant_data_with_payload(5, &[0u8; 32]),
-            }],
-            locktime: 0,
-            da_commit_core: None,
-            da_chunk_core: None,
-            witness: vec![],
-            da_payload: vec![],
-        };
-        assert!(reject_core_ext_tx_oversized_payload(&tx, 48).is_ok());
-    }
-
-    #[test]
-    fn reject_oversized_payload_allows_at_limit() {
-        let tx = Tx {
-            version: TX_WIRE_VERSION,
-            tx_kind: 0,
-            tx_nonce: 1,
-            inputs: vec![],
-            outputs: vec![TxOutput {
-                value: 1,
-                covenant_type: COV_TYPE_CORE_EXT,
-                covenant_data: core_ext_covenant_data_with_payload(5, &[0u8; 48]),
-            }],
-            locktime: 0,
-            da_commit_core: None,
-            da_chunk_core: None,
-            witness: vec![],
-            da_payload: vec![],
-        };
-        assert!(reject_core_ext_tx_oversized_payload(&tx, 48).is_ok());
-    }
-
-    #[test]
-    fn reject_oversized_payload_rejects_over_limit() {
-        let tx = Tx {
-            version: TX_WIRE_VERSION,
-            tx_kind: 0,
-            tx_nonce: 1,
-            inputs: vec![],
-            outputs: vec![TxOutput {
-                value: 1,
-                covenant_type: COV_TYPE_CORE_EXT,
-                covenant_data: core_ext_covenant_data_with_payload(5, &[0u8; 49]),
-            }],
-            locktime: 0,
-            da_commit_core: None,
-            da_chunk_core: None,
-            witness: vec![],
-            da_payload: vec![],
-        };
-        let err = reject_core_ext_tx_oversized_payload(&tx, 48);
-        assert!(err.is_err());
-        assert!(err.unwrap_err().contains("exceeds policy limit"));
-    }
-
-    #[test]
-    fn reject_oversized_payload_ignores_non_core_ext() {
-        let tx = Tx {
-            version: TX_WIRE_VERSION,
-            tx_kind: 0,
-            tx_nonce: 1,
-            inputs: vec![],
-            outputs: vec![TxOutput {
-                value: 1,
-                covenant_type: COV_TYPE_P2PK,
-                covenant_data: vec![0u8; 100],
-            }],
-            locktime: 0,
-            da_commit_core: None,
-            da_chunk_core: None,
-            witness: vec![],
-            da_payload: vec![],
-        };
-        assert!(reject_core_ext_tx_oversized_payload(&tx, 1).is_ok());
-    }
-
-    #[test]
-    fn reject_oversized_payload_zero_limit_disables() {
-        let tx = Tx {
-            version: TX_WIRE_VERSION,
-            tx_kind: 0,
-            tx_nonce: 1,
-            inputs: vec![],
-            outputs: vec![TxOutput {
-                value: 1,
-                covenant_type: COV_TYPE_CORE_EXT,
-                covenant_data: core_ext_covenant_data_with_payload(5, &[0u8; 100]),
-            }],
-            locktime: 0,
-            da_commit_core: None,
-            da_chunk_core: None,
-            witness: vec![],
-            da_payload: vec![],
-        };
-        assert!(reject_core_ext_tx_oversized_payload(&tx, 0).is_ok());
-    }
-
-    #[test]
-    fn reject_oversized_payload_empty_payload_allowed() {
-        let tx = Tx {
-            version: TX_WIRE_VERSION,
-            tx_kind: 0,
-            tx_nonce: 1,
-            inputs: vec![],
-            outputs: vec![TxOutput {
-                value: 1,
-                covenant_type: COV_TYPE_CORE_EXT,
-                covenant_data: core_ext_covenant_data_with_payload(5, &[]),
-            }],
-            locktime: 0,
-            da_commit_core: None,
-            da_chunk_core: None,
-            witness: vec![],
-            da_payload: vec![],
-        };
-        assert!(reject_core_ext_tx_oversized_payload(&tx, 1).is_ok());
     }
 
     // ----- Stage C DA fee policy parity tests (Linear RUB-122) -----
@@ -5198,21 +4925,18 @@ mod tests {
     }
 
     /// RUB-162 cross-pollination ordering PIN — sub-floor tx with a
-    /// CORE_EXT output before its profile is active. Same ordering
-    /// invariant as the DA-anchor cross-pollination test above; ext-id
-    /// 7 is unregistered so the pre-activation guard inside
-    /// apply_policy is the relevant gate.
+    /// CORE_EXT output while the node runtime does not support CORE_EXT.
+    /// Same ordering invariant as the DA-anchor cross-pollination test above.
     ///
-    /// Proof assertion: build a sub-floor P2PK→CORE_EXT tx with no
-    /// matching active profile; `assert_eq!(err.kind, Rejected)` plus
-    /// `err.message.contains("CORE_EXT output pre-ACTIVE")` below pin
+    /// Proof assertion: build a sub-floor P2PK->CORE_EXT tx;
+    /// `assert_eq!(err.kind, Rejected)` plus
+    /// `err.message.contains("CORE_EXT output unsupported")` below pin
     /// the class winner against the alternative
     /// `Unavailable("mempool fee below rolling minimum")` outcome.
     #[test]
     fn rub162_admit_sub_floor_core_ext_classifies_as_core_ext_rejected_not_floor_unavailable() {
         // input=10 / output=9 → fee=1 with weight≈7533 ⇒ sub-floor.
-        // CORE_EXT output with ext_id=7 and no profile registered ⇒
-        // pre-activation guard rejects.
+        // CORE_EXT output with ext_id=7 => unsupported-runtime guard rejects.
         let (state, raw) = signed_p2pk_state_and_tx(
             10,
             vec![TxOutput {
@@ -5227,17 +4951,17 @@ mod tests {
         let mut pool = TxPool::new();
         let err = pool
             .admit(&raw, &state, None, [0u8; 32])
-            .expect_err("admit must reject when both sub-floor and pre-activation CORE_EXT");
+            .expect_err("admit must reject when both sub-floor and unsupported CORE_EXT");
         assert_eq!(
             err.kind,
             TxPoolAdmitErrorKind::Rejected,
-            "CORE_EXT pre-activation class must win when apply_policy runs before validate_fee_floor; got kind={:?} message={}",
+            "CORE_EXT unsupported class must win when apply_policy runs before validate_fee_floor; got kind={:?} message={}",
             err.kind,
             err.message
         );
         assert!(
-            err.message.contains("CORE_EXT output pre-ACTIVE"),
-            "error must come from CORE_EXT pre-activation guard, not the rolling floor check; got: {}",
+            err.message.contains("CORE_EXT output unsupported"),
+            "error must come from CORE_EXT unsupported guard, not the rolling floor check; got: {}",
             err.message
         );
         // Atomicity: no partial insert on cross-pollination reject.


### PR DESCRIPTION
Invariant:
Rust node no longer has active CORE_EXT runtime deployment/profile wiring. CORE_EXT consensus internals remain untouched for RUB-514.

Layer:
Rust node policy/runtime wiring.

Files changed:
- clients/rust/crates/rubin-node/src

Tests:
- scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo fmt --all --check' — PASS
- git diff --check — PASS
- scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo check -p rubin-node' — PASS
- scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo clippy -p rubin-node -- -D warnings' — PASS
- scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test -p rubin-node' — PASS
- scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test --workspace' — PASS
- python3 /Users/gpt/Documents/local-agent-protocols/common-preflight/rubin_common_preflight.py --repo /Users/gpt/Documents/rubin-protocol --base-ref origin/main --lane core — PASS
- scripts/dev-env.sh -- ./scripts/preflight-codacy-coverage.sh — PASS
- git verify-commit HEAD — PASS

Behavior impact:
Rust node genesis/config/sync/relay/miner surfaces no longer accept or carry CORE_EXT runtime deployments. Mempool/miner policy rejects CORE_EXT outputs/spends as unsupported runtime behavior.

Compatibility impact:
No Go changes, no spec/conformance/fixture changes, no rubin-consensus changes.

Known non-goals:
- No RUB-514 consensus CORE_EXT removal.
- No Go/spec/conformance/fixture updates.
- No blanket Rust gate thaw beyond RUB-513.

Follow-ups:
- RUB-514 owns Rust consensus CORE_EXT removal.

Risk:
Low within RUB-513 scope; change removes node runtime wiring and keeps the consensus bridge empty until RUB-514.

Rollback:
Revert this commit.

Not checked:
None beyond listed local gates.

Linear: RUB-513