### PR TITLE
RUB-586: remove inert CORE_EXT connect-block threading (Go consensus, behavior-neutral)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,7 @@ spec/RUBIN_IMPLEMENTATION_ROADMAP.md
 # Local orchestration files (must stay local-only)
 scripts/orchestration/
 operational/orchestration/
+
+# Compiled CLI binaries (go build/run output)
+/clients/go/rubin-consensus-cli
+/clients/go/rubin-node

--- a/clients/go/cmd/formal-trace/main.go
+++ b/clients/go/cmd/formal-trace/main.go
@@ -98,15 +98,16 @@ type utxoBasicFixture struct {
 	Vectors []utxoBasicVector `json:"vectors"`
 }
 type utxoBasicVector struct {
-	BlockMTP       *uint64    `json:"block_mtp"`
-	ID             string     `json:"id"`
-	Op             string     `json:"op"`
-	TxHex          string     `json:"tx_hex"`
-	ExpectErr      string     `json:"expect_err"`
-	Utxos          []utxoJSON `json:"utxos"`
-	Height         uint64     `json:"height"`
-	BlockTimestamp uint64     `json:"block_timestamp"`
-	ExpectOk       bool       `json:"expect_ok"`
+	BlockMTP        *uint64           `json:"block_mtp"`
+	CoreExtProfiles []json.RawMessage `json:"core_ext_profiles,omitempty"`
+	ID              string            `json:"id"`
+	Op              string            `json:"op"`
+	TxHex           string            `json:"tx_hex"`
+	ExpectErr       string            `json:"expect_err"`
+	Utxos           []utxoJSON        `json:"utxos"`
+	Height          uint64            `json:"height"`
+	BlockTimestamp  uint64            `json:"block_timestamp"`
+	ExpectOk        bool              `json:"expect_ok"`
 }
 
 type utxoJSON struct {
@@ -740,6 +741,12 @@ func run(fixturesDir, outPath string) error {
 					utxos, e := buildUtxoMapFromJSON(v.Utxos)
 					if e != nil {
 						runErr = e
+					} else if len(v.CoreExtProfiles) != 0 {
+						// 0x0102 (CORE_EXT) is unassigned: a fixture still carrying
+						// core_ext_profiles is rejected (fail-closed), matching the
+						// consensus CLI / runner, so the Go->Lean trace does not cover a
+						// request shape the active paths reject.
+						runErr = fmt.Errorf("core_ext_profiles unsupported by Go runtime")
 					} else {
 						mtp := v.BlockTimestamp
 						if v.BlockMTP != nil {

--- a/clients/go/cmd/formal-trace/main.go
+++ b/clients/go/cmd/formal-trace/main.go
@@ -98,16 +98,15 @@ type utxoBasicFixture struct {
 	Vectors []utxoBasicVector `json:"vectors"`
 }
 type utxoBasicVector struct {
-	BlockMTP        *uint64              `json:"block_mtp"`
-	CoreExtProfiles []coreExtProfileJSON `json:"core_ext_profiles,omitempty"`
-	ID              string               `json:"id"`
-	Op              string               `json:"op"`
-	TxHex           string               `json:"tx_hex"`
-	ExpectErr       string               `json:"expect_err"`
-	Utxos           []utxoJSON           `json:"utxos"`
-	Height          uint64               `json:"height"`
-	BlockTimestamp  uint64               `json:"block_timestamp"`
-	ExpectOk        bool                 `json:"expect_ok"`
+	BlockMTP       *uint64    `json:"block_mtp"`
+	ID             string     `json:"id"`
+	Op             string     `json:"op"`
+	TxHex          string     `json:"tx_hex"`
+	ExpectErr      string     `json:"expect_err"`
+	Utxos          []utxoJSON `json:"utxos"`
+	Height         uint64     `json:"height"`
+	BlockTimestamp uint64     `json:"block_timestamp"`
+	ExpectOk       bool       `json:"expect_ok"`
 }
 
 type utxoJSON struct {
@@ -118,22 +117,6 @@ type utxoJSON struct {
 	Vout              uint32 `json:"vout"`
 	CovenantType      uint16 `json:"covenant_type"`
 	CreatedByCoinbase bool   `json:"created_by_coinbase"`
-}
-
-type coreExtProfileJSON struct {
-	ExtID                uint16  `json:"ext_id"`
-	ActivationHeight     uint64  `json:"activation_height"`
-	AllowedSuiteIDs      []uint8 `json:"allowed_suite_ids,omitempty"`
-	Binding              string  `json:"binding,omitempty"`
-	BindingDescriptorHex string  `json:"binding_descriptor_hex,omitempty"`
-	ExtPayloadSchemaHex  string  `json:"ext_payload_schema_hex,omitempty"`
-}
-
-func buildCoreExtProfiles(items []coreExtProfileJSON) (any, error) {
-	if len(items) == 0 {
-		return nil, nil
-	}
-	return nil, fmt.Errorf("core_ext_profiles unsupported by Go runtime")
 }
 
 type blockBasicFixture struct {
@@ -763,21 +746,15 @@ func run(fixturesDir, outPath string) error {
 							mtp = *v.BlockMTP
 						}
 						var chainID [32]byte
-						coreExtProfiles, e := buildCoreExtProfiles(v.CoreExtProfiles)
-						if e != nil {
-							runErr = e
-						} else {
-							_, sum, runErr = consensus.ApplyNonCoinbaseTxBasicUpdateWithMTPAndCoreExtProfiles(
-								tx,
-								txid,
-								utxos,
-								v.Height,
-								v.BlockTimestamp,
-								mtp,
-								chainID,
-								coreExtProfiles,
-							)
-						}
+						_, sum, runErr = consensus.ApplyNonCoinbaseTxBasicUpdateWithMTP(
+							tx,
+							txid,
+							utxos,
+							v.Height,
+							v.BlockTimestamp,
+							mtp,
+							chainID,
+						)
 					}
 				}
 				outputs := map[string]any{}

--- a/clients/go/cmd/rubin-consensus-cli/runtime.go
+++ b/clients/go/cmd/rubin-consensus-cli/runtime.go
@@ -170,6 +170,25 @@ type Request struct {
 
 type requestEnvelope struct {
 	Request
+	CoreExtProfiles            json.RawMessage `json:"core_ext_profiles,omitempty"`
+	CoreExtProfileSetAnchorHex string          `json:"core_ext_profile_set_anchor_hex,omitempty"`
+}
+
+// rejectRetiredCoreExtProfiles preserves the Go runtime's explicit rejection of
+// the retired CORE_EXT request fields, matching the Rust consensus CLI. 0x0102
+// (CORE_EXT) is unassigned, so a request still carrying core_ext_profiles /
+// core_ext_profile_set_anchor_hex is rejected — not silently ignored.
+func rejectRetiredCoreExtProfiles(profiles json.RawMessage, anchorHex string) error {
+	if strings.TrimSpace(anchorHex) != "" {
+		return fmt.Errorf("core_ext_profile_set_anchor_hex unsupported by Go runtime")
+	}
+	if len(profiles) > 0 {
+		var items []json.RawMessage
+		if err := json.Unmarshal(profiles, &items); err != nil || len(items) != 0 {
+			return fmt.Errorf("core_ext_profiles unsupported by Go runtime")
+		}
+	}
+	return nil
 }
 
 const rotationDescriptorNotActivatedErr = "descriptor-not-activated"
@@ -1920,6 +1939,10 @@ func runFromStdin() {
 			return
 		}
 
+		if err := rejectRetiredCoreExtProfiles(envelope.CoreExtProfiles, envelope.CoreExtProfileSetAnchorHex); err != nil {
+			writeResp(os.Stdout, Response{Ok: false, Err: err.Error()})
+			return
+		}
 		rotation, registry, err := buildCoreExtSuiteContext(req)
 		if err != nil {
 			writeResp(os.Stdout, Response{Ok: false, Err: err.Error()})
@@ -1998,6 +2021,10 @@ func runFromStdin() {
 			return
 		}
 
+		if err := rejectRetiredCoreExtProfiles(envelope.CoreExtProfiles, envelope.CoreExtProfileSetAnchorHex); err != nil {
+			writeResp(os.Stdout, Response{Ok: false, Err: err.Error()})
+			return
+		}
 		rotation, registry, err := buildCoreExtSuiteContext(req)
 		if err != nil {
 			writeResp(os.Stdout, Response{Ok: false, Err: err.Error()})

--- a/clients/go/cmd/rubin-consensus-cli/runtime.go
+++ b/clients/go/cmd/rubin-consensus-cli/runtime.go
@@ -170,23 +170,25 @@ type Request struct {
 
 type requestEnvelope struct {
 	Request
-	CoreExtProfiles            json.RawMessage `json:"core_ext_profiles,omitempty"`
-	CoreExtProfileSetAnchorHex string          `json:"core_ext_profile_set_anchor_hex,omitempty"`
+	// core_ext_profiles is typed as a sequence so a non-array (string/object)
+	// payload fails envelope decoding as a schema/bad-request error — matching
+	// the pre-removal []CoreExtProfileJSON behavior and the Rust CLI, which
+	// deserializes the same retired field as a sequence.
+	CoreExtProfiles            []json.RawMessage `json:"core_ext_profiles,omitempty"`
+	CoreExtProfileSetAnchorHex string            `json:"core_ext_profile_set_anchor_hex,omitempty"`
 }
 
 // rejectRetiredCoreExtProfiles preserves the Go runtime's explicit rejection of
 // the retired CORE_EXT request fields, matching the Rust consensus CLI. 0x0102
-// (CORE_EXT) is unassigned, so a request still carrying core_ext_profiles /
-// core_ext_profile_set_anchor_hex is rejected — not silently ignored.
-func rejectRetiredCoreExtProfiles(profiles json.RawMessage, anchorHex string) error {
+// (CORE_EXT) is unassigned, so a request still carrying a non-empty
+// core_ext_profiles array / core_ext_profile_set_anchor_hex is rejected — not
+// silently ignored. (A non-array core_ext_profiles already fails at decode.)
+func rejectRetiredCoreExtProfiles(profiles []json.RawMessage, anchorHex string) error {
 	if strings.TrimSpace(anchorHex) != "" {
 		return fmt.Errorf("core_ext_profile_set_anchor_hex unsupported by Go runtime")
 	}
-	if len(profiles) > 0 {
-		var items []json.RawMessage
-		if err := json.Unmarshal(profiles, &items); err != nil || len(items) != 0 {
-			return fmt.Errorf("core_ext_profiles unsupported by Go runtime")
-		}
+	if len(profiles) != 0 {
+		return fmt.Errorf("core_ext_profiles unsupported by Go runtime")
 	}
 	return nil
 }

--- a/clients/go/cmd/rubin-consensus-cli/runtime.go
+++ b/clients/go/cmd/rubin-consensus-cli/runtime.go
@@ -170,8 +170,6 @@ type Request struct {
 
 type requestEnvelope struct {
 	Request
-	CoreExtProfiles            []CoreExtProfileJSON `json:"core_ext_profiles,omitempty"`
-	CoreExtProfileSetAnchorHex string               `json:"core_ext_profile_set_anchor_hex,omitempty"`
 }
 
 const rotationDescriptorNotActivatedErr = "descriptor-not-activated"
@@ -240,52 +238,6 @@ type UtxoJSON struct {
 	Vout              uint32 `json:"vout"`
 	CovenantType      uint16 `json:"covenant_type"`
 	CreatedByCoinbase bool   `json:"created_by_coinbase"`
-}
-
-type CoreExtProfileJSON struct {
-	ExtID                uint16      `json:"ext_id"`
-	ActivationHeight     uint64      `json:"activation_height"`
-	TxContextEnabled     BoolishFlag `json:"tx_context_enabled"`
-	AllowedSuiteIDs      []uint8     `json:"allowed_suite_ids,omitempty"`
-	AllowedSighashSet    uint8       `json:"allowed_sighash_set,omitempty"`
-	MaxExtPayloadBytes   int         `json:"max_ext_payload_bytes,omitempty"`
-	Binding              string      `json:"binding,omitempty"`
-	BindingDescriptorHex string      `json:"binding_descriptor_hex,omitempty"`
-	ExtPayloadSchemaHex  string      `json:"ext_payload_schema_hex,omitempty"`
-}
-
-type BoolishFlag int
-
-func (flag *BoolishFlag) UnmarshalJSON(data []byte) error {
-	trimmed := bytes.TrimSpace(data)
-	switch string(trimmed) {
-	case "true":
-		*flag = 1
-		return nil
-	case "false":
-		*flag = 0
-		return nil
-	}
-	var value int
-	if err := json.Unmarshal(trimmed, &value); err != nil {
-		return fmt.Errorf("bad tx_context_enabled")
-	}
-	if value != 0 && value != 1 {
-		return fmt.Errorf("bad tx_context_enabled")
-	}
-	*flag = BoolishFlag(value)
-	return nil
-}
-
-func (flag BoolishFlag) MarshalJSON() ([]byte, error) {
-	switch flag {
-	case 0:
-		return []byte("false"), nil
-	case 1:
-		return []byte("true"), nil
-	default:
-		return nil, fmt.Errorf("bad tx_context_enabled")
-	}
 }
 
 type RotationDescriptorJSON struct {
@@ -405,16 +357,6 @@ func validateSuiteRegistryItem(item SuiteParamsJSON) (consensus.SuiteParams, err
 		VerifyCost: item.VerifyCost,
 		AlgName:    algName,
 	}, nil
-}
-
-func buildCoreExtProfiles(items []CoreExtProfileJSON, _ string, expectedSetAnchorHex string) (any, error) {
-	if strings.TrimSpace(expectedSetAnchorHex) != "" {
-		return nil, fmt.Errorf("core_ext_profile_set_anchor_hex unsupported by Go runtime")
-	}
-	if len(items) != 0 {
-		return nil, fmt.Errorf("core_ext_profiles unsupported by Go runtime")
-	}
-	return nil, nil
 }
 
 type ForkChoiceChain struct {
@@ -1477,7 +1419,6 @@ func runFromStdin() {
 		return
 	}
 	req := envelope.Request
-	coreExtProfilesReq := envelope.CoreExtProfiles
 
 	switch req.Op {
 	case "simplicity_exec_vector":
@@ -1979,18 +1920,13 @@ func runFromStdin() {
 			return
 		}
 
-		coreExtProfiles, err := buildCoreExtProfiles(coreExtProfilesReq, req.ChainIDHex, envelope.CoreExtProfileSetAnchorHex)
-		if err != nil {
-			writeResp(os.Stdout, Response{Ok: false, Err: err.Error()})
-			return
-		}
 		rotation, registry, err := buildCoreExtSuiteContext(req)
 		if err != nil {
 			writeResp(os.Stdout, Response{Ok: false, Err: err.Error()})
 			return
 		}
 
-		s, err := consensus.ConnectBlockBasicInMemoryAtHeightAndCoreExtProfilesAndSuiteContext(
+		s, err := consensus.ConnectBlockBasicInMemoryAtHeightAndSuiteContext(
 			blockBytes,
 			expectedPrev,
 			expectedTarget,
@@ -1998,7 +1934,6 @@ func runFromStdin() {
 			req.PrevTimestamps,
 			&st,
 			chainID,
-			coreExtProfiles,
 			rotation,
 			registry,
 		)
@@ -2063,17 +1998,13 @@ func runFromStdin() {
 			return
 		}
 
-		if _, err := buildCoreExtProfiles(coreExtProfilesReq, req.ChainIDHex, envelope.CoreExtProfileSetAnchorHex); err != nil {
-			writeResp(os.Stdout, Response{Ok: false, Err: err.Error()})
-			return
-		}
 		rotation, registry, err := buildCoreExtSuiteContext(req)
 		if err != nil {
 			writeResp(os.Stdout, Response{Ok: false, Err: err.Error()})
 			return
 		}
 
-		_, s, err := consensus.ApplyNonCoinbaseTxBasicUpdateWithMTPAndCoreExtProfilesAndSuiteContext(
+		_, s, err := consensus.ApplyNonCoinbaseTxBasicUpdateWithMTPAndSuiteContext(
 			tx,
 			txid,
 			utxos,

--- a/clients/go/cmd/rubin-consensus-cli/runtime_test.go
+++ b/clients/go/cmd/rubin-consensus-cli/runtime_test.go
@@ -312,27 +312,28 @@ func newRuntimeKeyOpsFixture(t *testing.T) runtimeKeyOpsFixture {
 // reject_core_ext_profiles_from_json tests: the retired 0x0102 CORE_EXT request
 // fields are rejected (not silently ignored), keeping Go/Rust CLI parity.
 func TestRejectRetiredCoreExtProfiles(t *testing.T) {
+	mk := func(items ...string) []json.RawMessage {
+		out := make([]json.RawMessage, 0, len(items))
+		for _, it := range items {
+			out = append(out, json.RawMessage(it))
+		}
+		return out
+	}
 	cases := []struct {
 		name     string
-		profiles string
+		profiles []json.RawMessage
 		anchor   string
 		wantErr  string
 	}{
-		{"absent", "", "", ""},
-		{"null", "null", "", ""},
-		{"empty array", "[]", "", ""},
-		{"non-empty profiles", `[{"ext_id":1}]`, "", "core_ext_profiles unsupported by Go runtime"},
-		{"malformed profiles", `"oops"`, "", "core_ext_profiles unsupported by Go runtime"},
-		{"anchor set", "", "deadbeef", "core_ext_profile_set_anchor_hex unsupported by Go runtime"},
-		{"anchor takes precedence", `[{"ext_id":1}]`, "deadbeef", "core_ext_profile_set_anchor_hex unsupported by Go runtime"},
+		{"absent", nil, "", ""},
+		{"empty array", []json.RawMessage{}, "", ""},
+		{"non-empty profiles", mk(`{"ext_id":1}`), "", "core_ext_profiles unsupported by Go runtime"},
+		{"anchor set", nil, "deadbeef", "core_ext_profile_set_anchor_hex unsupported by Go runtime"},
+		{"anchor takes precedence", mk(`{"ext_id":1}`), "deadbeef", "core_ext_profile_set_anchor_hex unsupported by Go runtime"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			var profiles json.RawMessage
-			if tc.profiles != "" {
-				profiles = json.RawMessage(tc.profiles)
-			}
-			err := rejectRetiredCoreExtProfiles(profiles, tc.anchor)
+			err := rejectRetiredCoreExtProfiles(tc.profiles, tc.anchor)
 			if tc.wantErr == "" {
 				if err != nil {
 					t.Fatalf("expected no error, got: %v", err)
@@ -344,6 +345,14 @@ func TestRejectRetiredCoreExtProfiles(t *testing.T) {
 			}
 		})
 	}
+	// A non-array core_ext_profiles is a schema/decode error (Rust parity:
+	// "bad request"), not the op-level "unsupported" error.
+	t.Run("malformed non-array is a decode error", func(t *testing.T) {
+		var env requestEnvelope
+		if err := json.Unmarshal([]byte(`{"core_ext_profiles":"oops"}`), &env); err == nil {
+			t.Fatal("expected decode error for non-array core_ext_profiles")
+		}
+	})
 }
 
 func TestRubinConsensusCLI_RunFromStdin_CoversKeyOps(t *testing.T) {

--- a/clients/go/cmd/rubin-consensus-cli/runtime_test.go
+++ b/clients/go/cmd/rubin-consensus-cli/runtime_test.go
@@ -308,6 +308,44 @@ func newRuntimeKeyOpsFixture(t *testing.T) runtimeKeyOpsFixture {
 	}
 }
 
+// TestRejectRetiredCoreExtProfiles mirrors the Rust consensus CLI's
+// reject_core_ext_profiles_from_json tests: the retired 0x0102 CORE_EXT request
+// fields are rejected (not silently ignored), keeping Go/Rust CLI parity.
+func TestRejectRetiredCoreExtProfiles(t *testing.T) {
+	cases := []struct {
+		name     string
+		profiles string
+		anchor   string
+		wantErr  string
+	}{
+		{"absent", "", "", ""},
+		{"null", "null", "", ""},
+		{"empty array", "[]", "", ""},
+		{"non-empty profiles", `[{"ext_id":1}]`, "", "core_ext_profiles unsupported by Go runtime"},
+		{"malformed profiles", `"oops"`, "", "core_ext_profiles unsupported by Go runtime"},
+		{"anchor set", "", "deadbeef", "core_ext_profile_set_anchor_hex unsupported by Go runtime"},
+		{"anchor takes precedence", `[{"ext_id":1}]`, "deadbeef", "core_ext_profile_set_anchor_hex unsupported by Go runtime"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var profiles json.RawMessage
+			if tc.profiles != "" {
+				profiles = json.RawMessage(tc.profiles)
+			}
+			err := rejectRetiredCoreExtProfiles(profiles, tc.anchor)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected no error, got: %v", err)
+				}
+				return
+			}
+			if err == nil || err.Error() != tc.wantErr {
+				t.Fatalf("expected error %q, got: %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
 func TestRubinConsensusCLI_RunFromStdin_CoversKeyOps(t *testing.T) {
 	fixture := newRuntimeKeyOpsFixture(t)
 

--- a/clients/go/consensus/connect_block_inmem.go
+++ b/clients/go/consensus/connect_block_inmem.go
@@ -62,7 +62,7 @@ func ConnectBlockBasicInMemoryAtHeight(
 	state *InMemoryChainState,
 	chainID [32]byte,
 ) (*ConnectBlockBasicSummary, error) {
-	return ConnectBlockBasicInMemoryAtHeightAndCoreExtProfiles(
+	return ConnectBlockBasicInMemoryAtHeightAndSuiteContext(
 		blockBytes,
 		expectedPrevHash,
 		expectedTarget,
@@ -70,36 +70,13 @@ func ConnectBlockBasicInMemoryAtHeight(
 		prevTimestamps,
 		state,
 		chainID,
-		nil,
-	)
-}
-
-func ConnectBlockBasicInMemoryAtHeightAndCoreExtProfiles(
-	blockBytes []byte,
-	expectedPrevHash *[32]byte,
-	expectedTarget *[32]byte,
-	blockHeight uint64,
-	prevTimestamps []uint64,
-	state *InMemoryChainState,
-	chainID [32]byte,
-	_ any,
-) (*ConnectBlockBasicSummary, error) {
-	return ConnectBlockBasicInMemoryAtHeightAndCoreExtProfilesAndSuiteContext(
-		blockBytes,
-		expectedPrevHash,
-		expectedTarget,
-		blockHeight,
-		prevTimestamps,
-		state,
-		chainID,
-		nil,
-		nil,
-		nil,
+		nil, /*rotation*/
+		nil, /*registry*/
 	)
 }
 
 // #lizard forgive
-func ConnectBlockBasicInMemoryAtHeightAndCoreExtProfilesAndSuiteContext(
+func ConnectBlockBasicInMemoryAtHeightAndSuiteContext(
 	blockBytes []byte,
 	expectedPrevHash *[32]byte,
 	expectedTarget *[32]byte,
@@ -107,11 +84,10 @@ func ConnectBlockBasicInMemoryAtHeightAndCoreExtProfilesAndSuiteContext(
 	prevTimestamps []uint64,
 	state *InMemoryChainState,
 	chainID [32]byte,
-	_ any,
 	rotation RotationProvider,
 	registry *SuiteRegistry,
 ) (*ConnectBlockBasicSummary, error) {
-	return connectBlockBasicInMemoryAtHeightAndCoreExtProfilesAndSuiteContext(connectBlockBasicInMemorySuiteContext{
+	return connectBlockBasicInMemoryAtHeightAndSuiteContext(connectBlockBasicInMemorySuiteContext{
 		BlockBytes:       blockBytes,
 		ExpectedPrevHash: expectedPrevHash,
 		ExpectedTarget:   expectedTarget,
@@ -124,7 +100,7 @@ func ConnectBlockBasicInMemoryAtHeightAndCoreExtProfilesAndSuiteContext(
 	})
 }
 
-func connectBlockBasicInMemoryAtHeightAndCoreExtProfilesAndSuiteContext(
+func connectBlockBasicInMemoryAtHeightAndSuiteContext(
 	input connectBlockBasicInMemorySuiteContext,
 ) (*ConnectBlockBasicSummary, error) {
 	if err := prepareInMemoryChainState(input.State); err != nil {

--- a/clients/go/consensus/connect_block_parallel.go
+++ b/clients/go/consensus/connect_block_parallel.go
@@ -31,7 +31,7 @@ func ConnectBlockParallelSigVerify(
 	chainID [32]byte,
 	workers int,
 ) (*ConnectBlockBasicSummary, error) {
-	return ConnectBlockParallelSigVerifyWithCoreExtProfiles(
+	return ConnectBlockParallelSigVerifyWithSuiteContext(
 		blockBytes,
 		expectedPrevHash,
 		expectedTarget,
@@ -39,15 +39,13 @@ func ConnectBlockParallelSigVerify(
 		prevTimestamps,
 		state,
 		chainID,
-		nil,
+		nil, /*rotation*/
+		nil, /*registry*/
 		workers,
 	)
 }
 
-// ConnectBlockParallelSigVerifyWithCoreExtProfiles preserves the legacy helper
-// name for callers. The profile argument is ignored because Go CORE_EXT runtime
-// wiring has been removed; see ConnectBlockParallelSigVerify for behavior.
-func ConnectBlockParallelSigVerifyWithCoreExtProfiles(
+func ConnectBlockParallelSigVerifyWithSuiteContext(
 	blockBytes []byte,
 	expectedPrevHash *[32]byte,
 	expectedTarget *[32]byte,
@@ -55,33 +53,6 @@ func ConnectBlockParallelSigVerifyWithCoreExtProfiles(
 	prevTimestamps []uint64,
 	state *InMemoryChainState,
 	chainID [32]byte,
-	_ any,
-	workers int,
-) (*ConnectBlockBasicSummary, error) {
-	return ConnectBlockParallelSigVerifyWithCoreExtProfilesAndSuiteContext(
-		blockBytes,
-		expectedPrevHash,
-		expectedTarget,
-		blockHeight,
-		prevTimestamps,
-		state,
-		chainID,
-		nil,
-		nil,
-		nil,
-		workers,
-	)
-}
-
-func ConnectBlockParallelSigVerifyWithCoreExtProfilesAndSuiteContext(
-	blockBytes []byte,
-	expectedPrevHash *[32]byte,
-	expectedTarget *[32]byte,
-	blockHeight uint64,
-	prevTimestamps []uint64,
-	state *InMemoryChainState,
-	chainID [32]byte,
-	_ any,
 	rotation RotationProvider,
 	registry *SuiteRegistry,
 	workers int,
@@ -148,7 +119,7 @@ func ConnectBlockParallelSigVerifyWithCoreExtProfilesAndSuiteContext(
 		tx := pb.Txs[i]
 		txid := pb.Txids[i]
 
-		nextUtxos, s, err := applyNonCoinbaseTxBasicUpdateWithMTPAndCoreExtProfilesQ(
+		nextUtxos, s, err := applyNonCoinbaseTxBasicUpdateWithMTPQ(
 			tx,
 			txid,
 			workUtxos,
@@ -156,7 +127,6 @@ func ConnectBlockParallelSigVerifyWithCoreExtProfilesAndSuiteContext(
 			pb.Header.Timestamp,
 			blockMTP,
 			chainID,
-			nil,
 			sigQueue,
 			rot,
 			reg,
@@ -238,24 +208,22 @@ func ConnectBlockParallelSigVerifyWithCoreExtProfilesAndSuiteContext(
 	}, nil
 }
 
-// applyNonCoinbaseTxBasicUpdateWithMTPAndCoreExtProfilesQ is the queue-aware
-// wrapper around applyNonCoinbaseTxBasicWorkQ. The legacy profile argument is
-// ignored; the SigCheckQueue is used for deferred signature verification.
-func applyNonCoinbaseTxBasicUpdateWithMTPAndCoreExtProfilesQ(
+// applyNonCoinbaseTxBasicUpdateWithMTPQ is the queue-aware
+// wrapper around applyNonCoinbaseTxBasicWorkQ. The SigCheckQueue is used for
+// deferred signature verification.
+func applyNonCoinbaseTxBasicUpdateWithMTPQ(
 	tx *Tx,
 	txid [32]byte,
 	utxoSet map[Outpoint]UtxoEntry,
 	height uint64,
-	blockTimestamp uint64,
+	_ uint64,
 	blockMTP uint64,
 	chainID [32]byte,
-	_ any,
 	sigQueue *SigCheckQueue,
 	rotation RotationProvider,
 	registry *SuiteRegistry,
 ) (map[Outpoint]UtxoEntry, *UtxoApplySummary, error) {
-	_ = blockTimestamp
-	work, fee, err := applyNonCoinbaseTxBasicWorkQ(tx, txid, utxoSet, height, blockMTP, chainID, nil, sigQueue, rotation, registry)
+	work, fee, err := applyNonCoinbaseTxBasicWorkQ(tx, txid, utxoSet, height, blockMTP, chainID, sigQueue, rotation, registry)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -279,7 +247,6 @@ func applyNonCoinbaseTxBasicWorkQ(
 	height uint64,
 	blockMTP uint64,
 	chainID [32]byte,
-	_ any,
 	sigQueue *SigCheckQueue,
 	rotation RotationProvider,
 	registry *SuiteRegistry,

--- a/clients/go/consensus/connect_block_parallel_branches_test.go
+++ b/clients/go/consensus/connect_block_parallel_branches_test.go
@@ -48,7 +48,7 @@ func TestApplyNonCoinbaseTxBasicWorkQ_MultisigBranch(t *testing.T) {
 	}
 
 	q := NewSigCheckQueue(1)
-	nextUtxos, fee, err := applyNonCoinbaseTxBasicWorkQ(tx, hashWithPrefix(0xBB), utxoSet, 1, 0, [32]byte{}, nil, q, nil, nil)
+	nextUtxos, fee, err := applyNonCoinbaseTxBasicWorkQ(tx, hashWithPrefix(0xBB), utxoSet, 1, 0, [32]byte{}, q, nil, nil)
 	if err != nil {
 		t.Fatalf("multisig branch: %v", err)
 	}
@@ -97,7 +97,7 @@ func TestApplyNonCoinbaseTxBasicWorkQ_HTLCClaimBranch(t *testing.T) {
 	tx.Witness = []WitnessItem{pathItem, sigItem}
 
 	q := NewSigCheckQueue(1)
-	nextUtxos, fee, err := applyNonCoinbaseTxBasicWorkQ(tx, hashWithPrefix(0xDD), utxoSet, 1, 0, [32]byte{}, nil, q, nil, nil)
+	nextUtxos, fee, err := applyNonCoinbaseTxBasicWorkQ(tx, hashWithPrefix(0xDD), utxoSet, 1, 0, [32]byte{}, q, nil, nil)
 	if err != nil {
 		t.Fatalf("HTLC claim branch: %v", err)
 	}
@@ -137,7 +137,7 @@ func TestApplyNonCoinbaseTxBasicWorkQ_StealthBranch(t *testing.T) {
 	tx.Witness = []WitnessItem{signP2PKInputWitness(t, tx, 0, 500, [32]byte{}, kp)}
 
 	q := NewSigCheckQueue(1)
-	nextUtxos, fee, err := applyNonCoinbaseTxBasicWorkQ(tx, hashWithPrefix(0xFF), utxoSet, 1, 0, [32]byte{}, nil, q, nil, nil)
+	nextUtxos, fee, err := applyNonCoinbaseTxBasicWorkQ(tx, hashWithPrefix(0xFF), utxoSet, 1, 0, [32]byte{}, q, nil, nil)
 	if err != nil {
 		t.Fatalf("stealth branch: %v", err)
 	}
@@ -155,7 +155,7 @@ func TestApplyNonCoinbaseTxBasicWorkQ_StealthBranch(t *testing.T) {
 func TestApplyNonCoinbaseTxBasicWorkQ_ErrorPaths(t *testing.T) {
 	t.Run("nil_tx", func(t *testing.T) {
 		q := NewSigCheckQueue(1)
-		_, _, err := applyNonCoinbaseTxBasicWorkQ(nil, [32]byte{}, nil, 0, 0, [32]byte{}, nil, q, nil, nil)
+		_, _, err := applyNonCoinbaseTxBasicWorkQ(nil, [32]byte{}, nil, 0, 0, [32]byte{}, q, nil, nil)
 		if err == nil {
 			t.Fatal("expected error for nil tx")
 		}
@@ -164,7 +164,7 @@ func TestApplyNonCoinbaseTxBasicWorkQ_ErrorPaths(t *testing.T) {
 	t.Run("no_inputs", func(t *testing.T) {
 		tx := &Tx{Version: 1, TxNonce: 1}
 		q := NewSigCheckQueue(1)
-		_, _, err := applyNonCoinbaseTxBasicWorkQ(tx, [32]byte{}, nil, 0, 0, [32]byte{}, nil, q, nil, nil)
+		_, _, err := applyNonCoinbaseTxBasicWorkQ(tx, [32]byte{}, nil, 0, 0, [32]byte{}, q, nil, nil)
 		if err == nil {
 			t.Fatal("expected error for no inputs")
 		}
@@ -177,7 +177,7 @@ func TestApplyNonCoinbaseTxBasicWorkQ_ErrorPaths(t *testing.T) {
 			Inputs:  []TxInput{{PrevTxid: hashWithPrefix(1), PrevVout: 0}},
 		}
 		q := NewSigCheckQueue(1)
-		_, _, err := applyNonCoinbaseTxBasicWorkQ(tx, [32]byte{}, nil, 0, 0, [32]byte{}, nil, q, nil, nil)
+		_, _, err := applyNonCoinbaseTxBasicWorkQ(tx, [32]byte{}, nil, 0, 0, [32]byte{}, q, nil, nil)
 		if err == nil {
 			t.Fatal("expected error for zero nonce")
 		}
@@ -200,7 +200,7 @@ func TestApplyNonCoinbaseTxBasicWorkQ_ErrorPaths(t *testing.T) {
 
 		q := NewSigCheckQueue(1)
 		utxos := make(map[Outpoint]UtxoEntry) // empty
-		_, _, err := applyNonCoinbaseTxBasicWorkQ(tx, [32]byte{}, utxos, 1, 0, [32]byte{}, nil, q, nil, nil)
+		_, _, err := applyNonCoinbaseTxBasicWorkQ(tx, [32]byte{}, utxos, 1, 0, [32]byte{}, q, nil, nil)
 		if err == nil {
 			t.Fatal("expected missing UTXO error")
 		}
@@ -226,7 +226,7 @@ func TestApplyNonCoinbaseTxBasicWorkQ_ErrorPaths(t *testing.T) {
 			{Txid: prevTxid, Vout: 0}: {Value: 100, CovenantType: COV_TYPE_CORE_EXT, CovenantData: []byte{0x07, 0x00, 0x00}},
 		}
 		q := NewSigCheckQueue(1)
-		_, _, err := applyNonCoinbaseTxBasicWorkQ(tx, [32]byte{}, utxos, 1, 0, [32]byte{}, nil, q, nil, nil)
+		_, _, err := applyNonCoinbaseTxBasicWorkQ(tx, [32]byte{}, utxos, 1, 0, [32]byte{}, q, nil, nil)
 		if err == nil {
 			t.Fatal("expected CORE_EXT 0x0102 to be rejected")
 		}
@@ -258,7 +258,7 @@ func TestApplyNonCoinbaseTxBasicWorkQ_ErrorPaths(t *testing.T) {
 			{Txid: prevTxid, Vout: 0}: {Value: 100, CovenantType: COV_TYPE_P2PK, CovenantData: covData},
 		}
 		q := NewSigCheckQueue(1)
-		_, _, err := applyNonCoinbaseTxBasicWorkQ(tx, [32]byte{}, utxos, 1, 0, [32]byte{}, nil, q, nil, nil)
+		_, _, err := applyNonCoinbaseTxBasicWorkQ(tx, [32]byte{}, utxos, 1, 0, [32]byte{}, q, nil, nil)
 		if err == nil {
 			t.Fatal("expected duplicate input error")
 		}
@@ -288,7 +288,7 @@ func TestApplyNonCoinbaseTxBasicWorkQ_ErrorPaths(t *testing.T) {
 		}
 		q := NewSigCheckQueue(1)
 		// height=50, but coinbase at height=0 needs COINBASE_MATURITY blocks
-		_, _, err := applyNonCoinbaseTxBasicWorkQ(tx, [32]byte{}, utxos, 50, 0, [32]byte{}, nil, q, nil, nil)
+		_, _, err := applyNonCoinbaseTxBasicWorkQ(tx, [32]byte{}, utxos, 50, 0, [32]byte{}, q, nil, nil)
 		if err == nil {
 			t.Fatal("expected coinbase immature error")
 		}
@@ -318,7 +318,7 @@ func TestApplyNonCoinbaseTxBasicWorkQ_ErrorPaths(t *testing.T) {
 			},
 		}
 		q := NewSigCheckQueue(1)
-		_, _, err := applyNonCoinbaseTxBasicWorkQ(tx, [32]byte{}, utxos, 1, 0, [32]byte{}, nil, q, nil, nil)
+		_, _, err := applyNonCoinbaseTxBasicWorkQ(tx, [32]byte{}, utxos, 1, 0, [32]byte{}, q, nil, nil)
 		if err == nil {
 			t.Fatal("expected unspendable anchor error")
 		}
@@ -344,7 +344,7 @@ func TestApplyNonCoinbaseTxBasicWorkQ_ErrorPaths(t *testing.T) {
 			{Txid: prevTxid, Vout: 0}: {Value: 100, CovenantType: COV_TYPE_P2PK, CovenantData: covData},
 		}
 		q := NewSigCheckQueue(1)
-		_, _, err := applyNonCoinbaseTxBasicWorkQ(tx, [32]byte{}, utxos, 1, 0, [32]byte{}, nil, q, nil, nil)
+		_, _, err := applyNonCoinbaseTxBasicWorkQ(tx, [32]byte{}, utxos, 1, 0, [32]byte{}, q, nil, nil)
 		if err == nil {
 			t.Fatal("expected sequence invalid error")
 		}
@@ -373,7 +373,7 @@ func TestApplyNonCoinbaseTxBasicWorkQ_ErrorPaths(t *testing.T) {
 			{Txid: prevTxid, Vout: 0}: {Value: 100, CovenantType: COV_TYPE_P2PK, CovenantData: covData},
 		}
 		q := NewSigCheckQueue(1)
-		_, _, err := applyNonCoinbaseTxBasicWorkQ(tx, [32]byte{}, utxos, 1, 0, [32]byte{}, nil, q, nil, nil)
+		_, _, err := applyNonCoinbaseTxBasicWorkQ(tx, [32]byte{}, utxos, 1, 0, [32]byte{}, q, nil, nil)
 		if err == nil {
 			t.Fatal("expected witness count mismatch error")
 		}
@@ -396,7 +396,7 @@ func TestApplyNonCoinbaseTxBasicWorkQ_ErrorPaths(t *testing.T) {
 			{Txid: prevTxid, Vout: 0}: {Value: 100, CovenantType: COV_TYPE_P2PK, CovenantData: covData},
 		}
 		q := NewSigCheckQueue(1)
-		_, _, err := applyNonCoinbaseTxBasicWorkQ(tx, [32]byte{}, utxos, 1, 0, [32]byte{}, nil, q, nil, nil)
+		_, _, err := applyNonCoinbaseTxBasicWorkQ(tx, [32]byte{}, utxos, 1, 0, [32]byte{}, q, nil, nil)
 		if err == nil {
 			t.Fatal("expected value conservation error")
 		}
@@ -419,7 +419,7 @@ func TestApplyNonCoinbaseTxBasicWorkQ_ErrorPaths(t *testing.T) {
 
 		utxos := make(map[Outpoint]UtxoEntry)
 		q := NewSigCheckQueue(1)
-		_, _, err := applyNonCoinbaseTxBasicWorkQ(tx, [32]byte{}, utxos, 1, 0, [32]byte{}, nil, q, nil, nil)
+		_, _, err := applyNonCoinbaseTxBasicWorkQ(tx, [32]byte{}, utxos, 1, 0, [32]byte{}, q, nil, nil)
 		if err == nil {
 			t.Fatal("expected coinbase prevout encoding error")
 		}
@@ -446,7 +446,7 @@ func TestApplyNonCoinbaseTxBasicWorkQ_ErrorPaths(t *testing.T) {
 			},
 		}
 		q := NewSigCheckQueue(1)
-		_, _, err := applyNonCoinbaseTxBasicWorkQ(tx, [32]byte{}, utxos, 1, 0, [32]byte{}, nil, q, nil, nil)
+		_, _, err := applyNonCoinbaseTxBasicWorkQ(tx, [32]byte{}, utxos, 1, 0, [32]byte{}, q, nil, nil)
 		if err == nil {
 			t.Fatal("expected DA_COMMIT unspendable error")
 		}
@@ -472,7 +472,7 @@ func TestApplyNonCoinbaseTxBasicWorkQ_ErrorPaths(t *testing.T) {
 			{Txid: prevTxid, Vout: 0}: {Value: 100, CovenantType: COV_TYPE_P2PK, CovenantData: covData},
 		}
 		q := NewSigCheckQueue(1)
-		_, _, err := applyNonCoinbaseTxBasicWorkQ(tx, [32]byte{}, utxos, 1, 0, [32]byte{}, nil, q, nil, nil)
+		_, _, err := applyNonCoinbaseTxBasicWorkQ(tx, [32]byte{}, utxos, 1, 0, [32]byte{}, q, nil, nil)
 		if err == nil {
 			t.Fatal("expected script_sig error")
 		}
@@ -495,7 +495,7 @@ func TestApplyNonCoinbaseTxBasicWorkQ_ErrorPaths(t *testing.T) {
 			{Txid: prevTxid, Vout: 0}: {Value: 100, CovenantType: COV_TYPE_P2PK, CovenantData: covData},
 		}
 		q := NewSigCheckQueue(1)
-		_, _, err := applyNonCoinbaseTxBasicWorkQ(tx, [32]byte{}, utxos, 1, 0, [32]byte{}, nil, q, nil, nil)
+		_, _, err := applyNonCoinbaseTxBasicWorkQ(tx, [32]byte{}, utxos, 1, 0, [32]byte{}, q, nil, nil)
 		if err == nil {
 			t.Fatal("expected witness underflow error")
 		}
@@ -535,7 +535,7 @@ func TestApplyNonCoinbaseTxBasicWorkQ_ErrorPaths(t *testing.T) {
 			{Txid: prevVault2, Vout: 0}: {Value: 100, CovenantType: COV_TYPE_VAULT, CovenantData: vaultCovData},
 		}
 		q := NewSigCheckQueue(1)
-		_, _, err := applyNonCoinbaseTxBasicWorkQ(tx, [32]byte{}, utxos, 1, 0, [32]byte{}, nil, q, nil, nil)
+		_, _, err := applyNonCoinbaseTxBasicWorkQ(tx, [32]byte{}, utxos, 1, 0, [32]byte{}, q, nil, nil)
 		if err == nil {
 			t.Fatal("expected multiple vault inputs error")
 		}
@@ -590,7 +590,7 @@ func TestApplyNonCoinbaseTxBasicWorkQ_VaultSpendOK(t *testing.T) {
 	}
 
 	q := NewSigCheckQueue(1)
-	nextUtxos, fee, err := applyNonCoinbaseTxBasicWorkQ(tx, txid, utxos, 200, 0, [32]byte{}, nil, q, nil, nil)
+	nextUtxos, fee, err := applyNonCoinbaseTxBasicWorkQ(tx, txid, utxos, 200, 0, [32]byte{}, q, nil, nil)
 	if err != nil {
 		t.Fatalf("vault spend: %v", err)
 	}
@@ -640,7 +640,7 @@ func TestApplyNonCoinbaseTxBasicWorkQ_VaultCreationOK(t *testing.T) {
 	}
 
 	q := NewSigCheckQueue(1)
-	nextUtxos, fee, err := applyNonCoinbaseTxBasicWorkQ(tx, txid, utxos, 200, 0, [32]byte{}, nil, q, nil, nil)
+	nextUtxos, fee, err := applyNonCoinbaseTxBasicWorkQ(tx, txid, utxos, 200, 0, [32]byte{}, q, nil, nil)
 	if err != nil {
 		t.Fatalf("vault creation: %v", err)
 	}
@@ -705,7 +705,7 @@ func TestApplyNonCoinbaseTxBasicWorkQ_VaultErrorPaths(t *testing.T) {
 			{Txid: prevOwner, Vout: 0}: {Value: 10, CovenantType: COV_TYPE_P2PK, CovenantData: ownerCovData},
 		}
 		q := NewSigCheckQueue(1)
-		_, _, err := applyNonCoinbaseTxBasicWorkQ(tx, [32]byte{}, utxos, 200, 0, [32]byte{}, nil, q, nil, nil)
+		_, _, err := applyNonCoinbaseTxBasicWorkQ(tx, [32]byte{}, utxos, 200, 0, [32]byte{}, q, nil, nil)
 		if err == nil {
 			t.Fatal("expected vault output in spend error")
 		}
@@ -749,7 +749,7 @@ func TestApplyNonCoinbaseTxBasicWorkQ_VaultErrorPaths(t *testing.T) {
 			{Txid: prevSponsor, Vout: 0}: {Value: 5, CovenantType: COV_TYPE_P2PK, CovenantData: sponsorCovData},
 		}
 		q := NewSigCheckQueue(1)
-		_, _, err := applyNonCoinbaseTxBasicWorkQ(tx, [32]byte{}, utxos, 200, 0, [32]byte{}, nil, q, nil, nil)
+		_, _, err := applyNonCoinbaseTxBasicWorkQ(tx, [32]byte{}, utxos, 200, 0, [32]byte{}, q, nil, nil)
 		if err == nil {
 			t.Fatal("expected fee sponsor forbidden error")
 		}
@@ -789,7 +789,7 @@ func TestApplyNonCoinbaseTxBasicWorkQ_VaultErrorPaths(t *testing.T) {
 			{Txid: prevOwner, Vout: 0}: {Value: 10, CovenantType: COV_TYPE_P2PK, CovenantData: ownerCovData},
 		}
 		q := NewSigCheckQueue(1)
-		_, _, err := applyNonCoinbaseTxBasicWorkQ(tx, [32]byte{}, utxos, 200, 0, [32]byte{}, nil, q, nil, nil)
+		_, _, err := applyNonCoinbaseTxBasicWorkQ(tx, [32]byte{}, utxos, 200, 0, [32]byte{}, q, nil, nil)
 		if err == nil {
 			t.Fatal("expected whitelist error")
 		}
@@ -831,7 +831,7 @@ func TestApplyNonCoinbaseTxBasicWorkQ_VaultErrorPaths(t *testing.T) {
 			{Txid: prevInput, Vout: 0}: {Value: 100, CovenantType: COV_TYPE_P2PK, CovenantData: inputCovData},
 		}
 		q := NewSigCheckQueue(1)
-		_, _, err := applyNonCoinbaseTxBasicWorkQ(tx, [32]byte{}, utxos, 200, 0, [32]byte{}, nil, q, nil, nil)
+		_, _, err := applyNonCoinbaseTxBasicWorkQ(tx, [32]byte{}, utxos, 200, 0, [32]byte{}, q, nil, nil)
 		if err == nil {
 			t.Fatal("expected vault owner auth error")
 		}
@@ -869,7 +869,7 @@ func TestApplyNonCoinbaseTxBasicWorkQ_VaultErrorPaths(t *testing.T) {
 			{Txid: prevOwner, Vout: 0}: {Value: 10, CovenantType: COV_TYPE_P2PK, CovenantData: ownerCovData},
 		}
 		q := NewSigCheckQueue(1)
-		_, _, err := applyNonCoinbaseTxBasicWorkQ(tx, [32]byte{}, utxos, 200, 0, [32]byte{}, nil, q, nil, nil)
+		_, _, err := applyNonCoinbaseTxBasicWorkQ(tx, [32]byte{}, utxos, 200, 0, [32]byte{}, q, nil, nil)
 		if err == nil {
 			t.Fatal("expected disallowed destination type error")
 		}
@@ -904,7 +904,7 @@ func TestApplyNonCoinbaseTxBasicWorkQ_AnchorOutputSkip(t *testing.T) {
 	}
 
 	q := NewSigCheckQueue(1)
-	nextUtxos, fee, err := applyNonCoinbaseTxBasicWorkQ(tx, txid, utxos, 1, 0, [32]byte{}, nil, q, nil, nil)
+	nextUtxos, fee, err := applyNonCoinbaseTxBasicWorkQ(tx, txid, utxos, 1, 0, [32]byte{}, q, nil, nil)
 	if err != nil {
 		t.Fatalf("anchor output skip: %v", err)
 	}
@@ -922,7 +922,7 @@ func TestApplyNonCoinbaseTxBasicWorkQ_AnchorOutputSkip(t *testing.T) {
 }
 
 // TestApplyWrapper exercises the wrapper function
-// applyNonCoinbaseTxBasicUpdateWithMTPAndCoreExtProfilesQ through both success
+// applyNonCoinbaseTxBasicUpdateWithMTPQ through both success
 // and error paths.
 func TestApplyWrapper(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
@@ -945,8 +945,8 @@ func TestApplyWrapper(t *testing.T) {
 		}
 
 		q := NewSigCheckQueue(1)
-		nextUtxos, summary, err := applyNonCoinbaseTxBasicUpdateWithMTPAndCoreExtProfilesQ(
-			tx, txid, utxos, 1, 12345, 0, [32]byte{}, nil, q, nil, nil,
+		nextUtxos, summary, err := applyNonCoinbaseTxBasicUpdateWithMTPQ(
+			tx, txid, utxos, 1, 12345, 0, [32]byte{}, q, nil, nil,
 		)
 		if err != nil {
 			t.Fatalf("wrapper success: %v", err)
@@ -964,8 +964,8 @@ func TestApplyWrapper(t *testing.T) {
 
 	t.Run("error_propagated", func(t *testing.T) {
 		q := NewSigCheckQueue(1)
-		_, _, err := applyNonCoinbaseTxBasicUpdateWithMTPAndCoreExtProfilesQ(
-			nil, [32]byte{}, nil, 0, 0, 0, [32]byte{}, nil, q, nil, nil,
+		_, _, err := applyNonCoinbaseTxBasicUpdateWithMTPQ(
+			nil, [32]byte{}, nil, 0, 0, 0, [32]byte{}, q, nil, nil,
 		)
 		if err == nil {
 			t.Fatal("expected error from nil tx")
@@ -998,7 +998,7 @@ func TestApplyNonCoinbaseTxBasicWorkQ_CovenantGenesisError(t *testing.T) {
 	tx.Witness = []WitnessItem{signP2PKInputWitness(t, tx, 0, 100, [32]byte{}, kp)}
 
 	q := NewSigCheckQueue(1)
-	_, _, err := applyNonCoinbaseTxBasicWorkQ(tx, [32]byte{}, utxoSet, 1, 0, [32]byte{}, nil, q, nil, nil)
+	_, _, err := applyNonCoinbaseTxBasicWorkQ(tx, [32]byte{}, utxoSet, 1, 0, [32]byte{}, q, nil, nil)
 	if err == nil {
 		t.Fatal("expected covenant genesis error for P2PK value=0")
 	}
@@ -1033,7 +1033,7 @@ func TestApplyNonCoinbaseTxBasicWorkQ_SighashPrehashError(t *testing.T) {
 	tx.Witness = []WitnessItem{{SuiteID: SUITE_ID_ML_DSA_87, Pubkey: kp.PubkeyBytes(), Signature: make([]byte, ML_DSA_87_SIG_BYTES)}}
 
 	q := NewSigCheckQueue(1)
-	_, _, err := applyNonCoinbaseTxBasicWorkQ(tx, [32]byte{}, utxoSet, 1, 0, [32]byte{}, nil, q, nil, nil)
+	_, _, err := applyNonCoinbaseTxBasicWorkQ(tx, [32]byte{}, utxoSet, 1, 0, [32]byte{}, q, nil, nil)
 	if err == nil {
 		t.Fatal("expected sighash prehash error for tx_kind=0x01 without da_commit_core")
 	}
@@ -1068,7 +1068,7 @@ func TestApplyNonCoinbaseTxBasicWorkQ_CheckSpendCovenantError(t *testing.T) {
 	tx.Witness = []WitnessItem{signP2PKInputWitness(t, tx, 0, 100, [32]byte{}, kp)}
 
 	q := NewSigCheckQueue(1)
-	_, _, err := applyNonCoinbaseTxBasicWorkQ(tx, [32]byte{}, utxoSet, 1, 0, [32]byte{}, nil, q, nil, nil)
+	_, _, err := applyNonCoinbaseTxBasicWorkQ(tx, [32]byte{}, utxoSet, 1, 0, [32]byte{}, q, nil, nil)
 	if err == nil {
 		t.Fatal("expected checkSpendCovenant error for corrupt vault data")
 	}
@@ -1087,7 +1087,7 @@ func TestApplyNonCoinbaseTxBasicWorkQ_CoreSimplicitySpendRejected(t *testing.T) 
 	tx, txid := mustParseTxForUtxo(t, txBytes)
 	q := NewSigCheckQueue(1)
 
-	_, _, err := applyNonCoinbaseTxBasicWorkQ(tx, txid, utxoSet, 1, 0, [32]byte{}, nil, q, nil, nil)
+	_, _, err := applyNonCoinbaseTxBasicWorkQ(tx, txid, utxoSet, 1, 0, [32]byte{}, q, nil, nil)
 	assertTxErrCodeMsg(t, err, TX_ERR_COVENANT_TYPE_INVALID, "CORE_SIMPLICITY spend evaluation not enabled")
 }
 
@@ -1109,7 +1109,7 @@ func TestApplyNonCoinbaseTxBasicWorkQ_CoreSimplicityRejectsBeforeWitnessChecks(t
 	}
 	q := NewSigCheckQueue(1)
 
-	work, fee, err := applyNonCoinbaseTxBasicWorkQ(tx, hashWithPrefix(0xed), utxoSet, 1, 0, [32]byte{}, nil, q, nil, nil)
+	work, fee, err := applyNonCoinbaseTxBasicWorkQ(tx, hashWithPrefix(0xed), utxoSet, 1, 0, [32]byte{}, q, nil, nil)
 	if work != nil || fee != 0 || q.Len() != 0 {
 		t.Fatalf("expected no queued mutation/sigs on reject, got work=%v fee=%d sigs=%d", work, fee, q.Len())
 	}
@@ -1135,7 +1135,7 @@ func TestApplyNonCoinbaseTxBasicUpdate_CoreSimplicityOutputGroupingShadowOnly(t 
 	rotation := testRotationProvider{createSuiteID: SUITE_ID_ML_DSA_87, simplicityActiveHeight: 1}
 	outputCount := 9
 
-	work, summary, err := ApplyNonCoinbaseTxBasicUpdateWithMTPAndCoreExtProfilesAndSuiteContext(makeTx(outputCount), hashWithPrefix(0xF1), utxoSet, 1, 0, [32]byte{}, rotation, nil)
+	work, summary, err := ApplyNonCoinbaseTxBasicUpdateWithMTPAndSuiteContext(makeTx(outputCount), hashWithPrefix(0xF1), utxoSet, 1, 0, [32]byte{}, rotation, nil)
 	if err != nil {
 		t.Fatalf("sequential same-CMR output grouping is shadow-only in this slice: %v", err)
 	}
@@ -1143,7 +1143,7 @@ func TestApplyNonCoinbaseTxBasicUpdate_CoreSimplicityOutputGroupingShadowOnly(t 
 		t.Fatalf("expected work and summary, got work=%v summary=%v", work, summary)
 	}
 
-	work, fee, err := applyNonCoinbaseTxBasicWorkQ(makeTx(outputCount), hashWithPrefix(0xF2), utxoSet, 1, 0, [32]byte{}, nil, NewSigCheckQueue(1), rotation, nil)
+	work, fee, err := applyNonCoinbaseTxBasicWorkQ(makeTx(outputCount), hashWithPrefix(0xF2), utxoSet, 1, 0, [32]byte{}, NewSigCheckQueue(1), rotation, nil)
 	if err != nil {
 		t.Fatalf("queued same-CMR output grouping is shadow-only in this slice: %v", err)
 	}
@@ -1169,7 +1169,7 @@ func TestApplyNonCoinbaseTxBasicUpdate_CoreSimplicityInputGroupCapDeferredBehind
 	}
 	runSeq := func(inputCount int, splitLast bool) error {
 		tx, txid, utxos := makeCase(inputCount, splitLast)
-		work, summary, err := ApplyNonCoinbaseTxBasicUpdateWithMTPAndCoreExtProfilesAndSuiteContext(tx, txid, utxos, 1, 0, [32]byte{}, nil, nil)
+		work, summary, err := ApplyNonCoinbaseTxBasicUpdateWithMTPAndSuiteContext(tx, txid, utxos, 1, 0, [32]byte{}, nil, nil)
 		if work != nil || summary != nil {
 			t.Fatalf("expected no sequential mutation on reject, got work=%v summary=%v", work, summary)
 		}
@@ -1178,7 +1178,7 @@ func TestApplyNonCoinbaseTxBasicUpdate_CoreSimplicityInputGroupCapDeferredBehind
 	runQ := func(inputCount int, splitLast bool) error {
 		tx, txid, utxos := makeCase(inputCount, splitLast)
 		q := NewSigCheckQueue(1)
-		work, fee, err := applyNonCoinbaseTxBasicWorkQ(tx, txid, utxos, 1, 0, [32]byte{}, nil, q, nil, nil)
+		work, fee, err := applyNonCoinbaseTxBasicWorkQ(tx, txid, utxos, 1, 0, [32]byte{}, q, nil, nil)
 		if work != nil || fee != 0 || q.Len() != 0 {
 			t.Fatalf("expected no queued mutation/sigs on reject, got work=%v fee=%d sigs=%d", work, fee, q.Len())
 		}
@@ -1218,7 +1218,7 @@ func TestApplyNonCoinbaseTxBasicWorkQ_P2PKSpendQError(t *testing.T) {
 	tx.Witness = []WitnessItem{{SuiteID: 0xFF, Pubkey: kp.PubkeyBytes(), Signature: make([]byte, ML_DSA_87_SIG_BYTES)}}
 
 	q := NewSigCheckQueue(1)
-	_, _, err := applyNonCoinbaseTxBasicWorkQ(tx, [32]byte{}, utxoSet, 1, 0, [32]byte{}, nil, q, nil, nil)
+	_, _, err := applyNonCoinbaseTxBasicWorkQ(tx, [32]byte{}, utxoSet, 1, 0, [32]byte{}, q, nil, nil)
 	if err == nil {
 		t.Fatal("expected P2PK spend error for invalid suite ID")
 	}

--- a/clients/go/consensus/connect_block_parallel_conformance_test.go
+++ b/clients/go/consensus/connect_block_parallel_conformance_test.go
@@ -241,11 +241,11 @@ func copyUtxoMap(src map[Outpoint]UtxoEntry) map[Outpoint]UtxoEntry {
 }
 
 // TestConnectBlockParallelSigVerify_GuardPaths exercises early-return guard
-// paths in ConnectBlockParallelSigVerifyWithCoreExtProfiles.
+// paths in ConnectBlockParallelSigVerify.
 func TestConnectBlockParallelSigVerify_GuardPaths(t *testing.T) {
 	t.Run("nil_state", func(t *testing.T) {
-		_, err := ConnectBlockParallelSigVerifyWithCoreExtProfiles(
-			[]byte{}, nil, nil, 0, nil, nil, [32]byte{}, nil, 0,
+		_, err := ConnectBlockParallelSigVerify(
+			[]byte{}, nil, nil, 0, nil, nil, [32]byte{}, 0,
 		)
 		if err == nil {
 			t.Fatal("expected error for nil state")
@@ -258,8 +258,8 @@ func TestConnectBlockParallelSigVerify_GuardPaths(t *testing.T) {
 			AlreadyGenerated: nil,
 		}
 		// Should normalize nil to zero, then fail at block validation.
-		_, err := ConnectBlockParallelSigVerifyWithCoreExtProfiles(
-			[]byte{0x00}, nil, nil, 0, nil, state, [32]byte{}, nil, 0,
+		_, err := ConnectBlockParallelSigVerify(
+			[]byte{0x00}, nil, nil, 0, nil, state, [32]byte{}, 0,
 		)
 		if err == nil {
 			t.Fatal("expected error for invalid block bytes")
@@ -271,8 +271,8 @@ func TestConnectBlockParallelSigVerify_GuardPaths(t *testing.T) {
 			Utxos:            make(map[Outpoint]UtxoEntry),
 			AlreadyGenerated: big.NewInt(-1),
 		}
-		_, err := ConnectBlockParallelSigVerifyWithCoreExtProfiles(
-			[]byte{0x00}, nil, nil, 0, nil, state, [32]byte{}, nil, 0,
+		_, err := ConnectBlockParallelSigVerify(
+			[]byte{0x00}, nil, nil, 0, nil, state, [32]byte{}, 0,
 		)
 		if err == nil {
 			t.Fatal("expected error for negative AlreadyGenerated")
@@ -284,8 +284,8 @@ func TestConnectBlockParallelSigVerify_GuardPaths(t *testing.T) {
 			Utxos:            nil, // should be normalized to empty map
 			AlreadyGenerated: new(big.Int),
 		}
-		_, err := ConnectBlockParallelSigVerifyWithCoreExtProfiles(
-			[]byte{0x00}, nil, nil, 0, nil, state, [32]byte{}, nil, 0,
+		_, err := ConnectBlockParallelSigVerify(
+			[]byte{0x00}, nil, nil, 0, nil, state, [32]byte{}, 0,
 		)
 		// Will fail at block validation but nil Utxos normalization is covered.
 		if err == nil {
@@ -301,8 +301,8 @@ func TestConnectBlockParallelSigVerify_GuardPaths(t *testing.T) {
 			Utxos:            nil,
 			AlreadyGenerated: nil,
 		}
-		_, err := ConnectBlockParallelSigVerifyWithCoreExtProfiles(
-			[]byte{0x00}, nil, nil, 0, nil, state, [32]byte{}, nil, 0,
+		_, err := ConnectBlockParallelSigVerify(
+			[]byte{0x00}, nil, nil, 0, nil, state, [32]byte{}, 0,
 		)
 		if err == nil {
 			t.Fatal("expected error for invalid block bytes")
@@ -380,8 +380,8 @@ func TestConnectBlockParallelSigVerify_TxValidationError_MissingUTXO(t *testing.
 		Utxos:            make(map[Outpoint]UtxoEntry),
 		AlreadyGenerated: new(big.Int),
 	}
-	_, err := ConnectBlockParallelSigVerifyWithCoreExtProfiles(
-		block, &prev, &target, height, []uint64{0}, state, [32]byte{}, nil, 4,
+	_, err := ConnectBlockParallelSigVerify(
+		block, &prev, &target, height, []uint64{0}, state, [32]byte{}, 4,
 	)
 	if err == nil {
 		t.Fatal("expected error for missing UTXO")
@@ -403,8 +403,8 @@ func TestConnectBlockParallelSigVerify_CoinbaseValueBound(t *testing.T) {
 		Utxos:            utxos,
 		AlreadyGenerated: new(big.Int).SetUint64(MINEABLE_CAP),
 	}
-	_, err := ConnectBlockParallelSigVerifyWithCoreExtProfiles(
-		block, &prev, &target, height, []uint64{0}, state, [32]byte{}, nil, 4,
+	_, err := ConnectBlockParallelSigVerify(
+		block, &prev, &target, height, []uint64{0}, state, [32]byte{}, 4,
 	)
 	if err == nil {
 		t.Fatal("expected coinbase value bound error")
@@ -428,8 +428,8 @@ func TestConnectBlockParallelSigVerify_AlreadyGeneratedOverflow(t *testing.T) {
 		Utxos:            utxos,
 		AlreadyGenerated: hugeAG,
 	}
-	_, err := ConnectBlockParallelSigVerifyWithCoreExtProfiles(
-		block, &prev, &target, height, []uint64{0}, state, [32]byte{}, nil, 4,
+	_, err := ConnectBlockParallelSigVerify(
+		block, &prev, &target, height, []uint64{0}, state, [32]byte{}, 4,
 	)
 	if err == nil {
 		t.Fatal("expected already_generated overflow error")
@@ -454,8 +454,8 @@ func TestConnectBlockParallelSigVerify_AlreadyGeneratedN1Overflow(t *testing.T) 
 		Utxos:            utxos,
 		AlreadyGenerated: ag,
 	}
-	_, err := ConnectBlockParallelSigVerifyWithCoreExtProfiles(
-		block, &prev, &target, height, []uint64{0}, state, [32]byte{}, nil, 4,
+	_, err := ConnectBlockParallelSigVerify(
+		block, &prev, &target, height, []uint64{0}, state, [32]byte{}, 4,
 	)
 	if err == nil {
 		t.Fatal("expected already_generated_n1 overflow error")
@@ -507,8 +507,8 @@ func TestConnectBlockParallelSigVerify_CoinbaseVaultForbidden(t *testing.T) {
 		Utxos:            make(map[Outpoint]UtxoEntry),
 		AlreadyGenerated: new(big.Int),
 	}
-	_, err = ConnectBlockParallelSigVerifyWithCoreExtProfiles(
-		block, &prev, &target, height, []uint64{0}, state, [32]byte{}, nil, 4,
+	_, err = ConnectBlockParallelSigVerify(
+		block, &prev, &target, height, []uint64{0}, state, [32]byte{}, 4,
 	)
 	if err == nil {
 		t.Fatal("expected coinbase vault forbidden error")

--- a/clients/go/consensus/connect_block_parallel_simplicity_queue_test.go
+++ b/clients/go/consensus/connect_block_parallel_simplicity_queue_test.go
@@ -26,7 +26,7 @@ func TestApplyNonCoinbaseTxBasicWorkQ_CoreSimplicityPrevalidationRejectLeavesSig
 	}
 	q := NewSigCheckQueue(1)
 
-	work, fee, err := applyNonCoinbaseTxBasicWorkQ(tx, hashWithPrefix(0xD2), utxoSet, 1, 0, [32]byte{}, nil, q, nil, nil)
+	work, fee, err := applyNonCoinbaseTxBasicWorkQ(tx, hashWithPrefix(0xD2), utxoSet, 1, 0, [32]byte{}, q, nil, nil)
 	if work != nil || fee != 0 || q.Len() != 0 {
 		t.Fatalf("expected no queued mutation/sigs on reject, got work=%v fee=%d sigs=%d", work, fee, q.Len())
 	}
@@ -85,7 +85,7 @@ func TestApplyNonCoinbaseTxBasicWorkQ_CoreSimplicityPreservesEarlierPrevalidatio
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			q := NewSigCheckQueue(1)
-			work, fee, err := applyNonCoinbaseTxBasicWorkQ(tc.tx, hashWithPrefix(0xD7), tc.utxos, 1, 0, [32]byte{}, nil, q, nil, nil)
+			work, fee, err := applyNonCoinbaseTxBasicWorkQ(tc.tx, hashWithPrefix(0xD7), tc.utxos, 1, 0, [32]byte{}, q, nil, nil)
 			if work != nil || fee != 0 || q.Len() != 0 {
 				t.Fatalf("expected no queued mutation/sigs on reject, got work=%v fee=%d sigs=%d", work, fee, q.Len())
 			}

--- a/clients/go/consensus/connect_block_parallel_test.go
+++ b/clients/go/consensus/connect_block_parallel_test.go
@@ -425,7 +425,7 @@ func TestApplyNonCoinbaseTxBasicWorkQ_MatchesSequential(t *testing.T) {
 	// Queued (parallel).
 	parUtxos := map[Outpoint]UtxoEntry{op: utxo}
 	q := NewSigCheckQueue(2)
-	parWork, parFee, err := applyNonCoinbaseTxBasicWorkQ(tx, txid, parUtxos, 1, 0, [32]byte{}, nil, q, nil, nil)
+	parWork, parFee, err := applyNonCoinbaseTxBasicWorkQ(tx, txid, parUtxos, 1, 0, [32]byte{}, q, nil, nil)
 	if err != nil {
 		t.Fatalf("Queued pre-flush: %v", err)
 	}
@@ -459,7 +459,7 @@ func TestApplyNonCoinbaseTxBasicWorkQ_MissingUTXO(t *testing.T) {
 		Witness: []WitnessItem{{SuiteID: SUITE_ID_ML_DSA_87, Pubkey: kp.PubkeyBytes(), Signature: make([]byte, ML_DSA_87_SIG_BYTES+1)}},
 	}
 	q := NewSigCheckQueue(1)
-	_, _, err := applyNonCoinbaseTxBasicWorkQ(tx, [32]byte{}, make(map[Outpoint]UtxoEntry), 1, 0, [32]byte{}, nil, q, nil, nil)
+	_, _, err := applyNonCoinbaseTxBasicWorkQ(tx, [32]byte{}, make(map[Outpoint]UtxoEntry), 1, 0, [32]byte{}, q, nil, nil)
 	if err == nil {
 		t.Fatalf("expected UTXO error")
 	}

--- a/clients/go/consensus/fuzz_dispatch_test.go
+++ b/clients/go/consensus/fuzz_dispatch_test.go
@@ -141,7 +141,7 @@ func FuzzValidateTxLocalDispatch(f *testing.F) {
 			Fee:            42,
 		}
 
-		r1 := ValidateTxLocal(tvc, chainID, blockHeight, blockMTP, nil, nil)
+		r1 := ValidateTxLocal(tvc, chainID, blockHeight, blockMTP, nil)
 
 		// Invariant: Valid ↔ Err consistency.
 		if r1.Valid && r1.Err != nil {
@@ -167,7 +167,7 @@ func FuzzValidateTxLocalDispatch(f *testing.F) {
 		}
 
 		// Invariant: Determinism.
-		r2 := ValidateTxLocal(tvc, chainID, blockHeight, blockMTP, nil, nil)
+		r2 := ValidateTxLocal(tvc, chainID, blockHeight, blockMTP, nil)
 		if r1.Valid != r2.Valid {
 			t.Fatalf("non-deterministic Valid: %v vs %v", r1.Valid, r2.Valid)
 		}

--- a/clients/go/consensus/pv_coverage_test.go
+++ b/clients/go/consensus/pv_coverage_test.go
@@ -93,7 +93,7 @@ func TestPV14_RunTxValidationWorkers_ValidP2PK(t *testing.T) {
 	results, err := RunTxValidationWorkers(
 		context.Background(), 2,
 		[]TxValidationContext{tvc},
-		[32]byte{}, 1, 0, nil, nil,
+		[32]byte{}, 1, 0, nil,
 	)
 	if err != nil {
 		t.Fatalf("RunTxValidationWorkers: %v", err)
@@ -146,7 +146,7 @@ func TestPV14_RunTxValidationWorkers_WithSigCache(t *testing.T) {
 	cache := NewSigCache(100)
 
 	// First run: no cache hits.
-	results1, err := RunTxValidationWorkers(context.Background(), 1, []TxValidationContext{tvc}, [32]byte{}, 1, 0, nil, cache)
+	results1, err := RunTxValidationWorkers(context.Background(), 1, []TxValidationContext{tvc}, [32]byte{}, 1, 0, cache)
 	if err != nil {
 		t.Fatalf("first run: %v", err)
 	}
@@ -158,7 +158,7 @@ func TestPV14_RunTxValidationWorkers_WithSigCache(t *testing.T) {
 	}
 
 	// Second run: should get cache hit.
-	results2, err := RunTxValidationWorkers(context.Background(), 1, []TxValidationContext{tvc}, [32]byte{}, 1, 0, nil, cache)
+	results2, err := RunTxValidationWorkers(context.Background(), 1, []TxValidationContext{tvc}, [32]byte{}, 1, 0, cache)
 	if err != nil {
 		t.Fatalf("second run: %v", err)
 	}
@@ -190,7 +190,7 @@ func TestPV14_RunTxValidationWorkers_CancelledContext(t *testing.T) {
 		WitnessStart:   0, WitnessEnd: 1, SighashCache: sighashCache, Fee: 10,
 	}
 
-	results, err := RunTxValidationWorkers(ctx, 1, []TxValidationContext{tvc}, [32]byte{}, 1, 0, nil, nil)
+	results, err := RunTxValidationWorkers(ctx, 1, []TxValidationContext{tvc}, [32]byte{}, 1, 0, nil)
 	if err != nil {
 		t.Fatalf("RunTxValidationWorkers: %v", err)
 	}
@@ -219,7 +219,7 @@ func TestPV14_ValidateTxLocal_WitnessUnderflow(t *testing.T) {
 		ResolvedInputs: []UtxoEntry{{Value: 100, CovenantType: COV_TYPE_P2PK, CovenantData: covData}},
 		WitnessStart:   0, WitnessEnd: 0, SighashCache: sighashCache, Fee: 10,
 	}
-	result := ValidateTxLocal(tvc, [32]byte{}, 1, 0, nil, nil)
+	result := ValidateTxLocal(tvc, [32]byte{}, 1, 0, nil)
 	if result.Err == nil {
 		t.Fatal("expected witness underflow error")
 	}

--- a/clients/go/consensus/tx_helpers.go
+++ b/clients/go/consensus/tx_helpers.go
@@ -47,53 +47,49 @@ func CheckTransaction(
 	blockMTP uint64,
 	chainID [32]byte,
 ) (*CheckedTransaction, error) {
-	return CheckTransactionWithCoreExtProfilesAndSuiteContext(
+	return CheckTransactionWithSuiteContext(
 		txBytes,
 		utxoSet,
 		height,
 		blockMTP,
 		chainID,
-		nil,
-		nil,
-		nil,
+		nil, /*rotation*/
+		nil, /*registry*/
 	)
 }
 
-func CheckTransactionWithCoreExtProfilesAndSuiteContext(
+func CheckTransactionWithSuiteContext(
 	txBytes []byte,
 	utxoSet map[Outpoint]UtxoEntry,
 	height uint64,
 	blockMTP uint64,
 	chainID [32]byte,
-	_ any,
 	rotation RotationProvider,
 	registry *SuiteRegistry,
 ) (*CheckedTransaction, error) {
 	workUtxos := cloneUtxoSet(utxoSet)
-	return CheckTransactionWithOwnedUtxoSetAndCoreExtProfilesAndSuiteContext(
+	return CheckTransactionWithOwnedUtxoSetAndSuiteContext(
 		txBytes,
 		workUtxos,
 		height,
 		blockMTP,
 		chainID,
-		nil,
 		rotation,
 		registry,
 	)
 }
 
-// CheckTransactionWithOwnedUtxoSetAndCoreExtProfilesAndSuiteContext validates
+// CheckTransactionWithOwnedUtxoSetAndSuiteContext validates
 // a transaction against a caller-owned mutable UTXO work set. The caller must
 // not pass a live shared chainstate map; this helper may mutate the supplied
 // work set while preserving the same CheckedTransaction result contract as the
 // cloned wrapper above.
-func CheckTransactionWithOwnedUtxoSetAndCoreExtProfilesAndSuiteContext(
+func CheckTransactionWithOwnedUtxoSetAndSuiteContext(
 	txBytes []byte,
 	workUtxos map[Outpoint]UtxoEntry,
 	height uint64,
 	blockMTP uint64,
 	chainID [32]byte,
-	_ any,
 	rotation RotationProvider,
 	registry *SuiteRegistry,
 ) (*CheckedTransaction, error) {
@@ -105,7 +101,7 @@ func CheckTransactionWithOwnedUtxoSetAndCoreExtProfilesAndSuiteContext(
 		return nil, txerr(TX_ERR_PARSE, "trailing bytes after canonical tx")
 	}
 
-	return CheckParsedTransactionWithOwnedUtxoSetAndCoreExtProfilesAndSuiteContext(
+	return CheckParsedTransactionWithOwnedUtxoSetAndSuiteContext(
 		txBytes,
 		tx,
 		ParsedTxIDs{TxID: txid, WTxID: wtxid},
@@ -117,9 +113,9 @@ func CheckTransactionWithOwnedUtxoSetAndCoreExtProfilesAndSuiteContext(
 	)
 }
 
-// CheckParsedTransactionWithOwnedUtxoSetAndCoreExtProfilesAndSuiteContext validates an already
+// CheckParsedTransactionWithOwnedUtxoSetAndSuiteContext validates an already
 // parsed canonical transaction against a caller-owned mutable UTXO work set.
-func CheckParsedTransactionWithOwnedUtxoSetAndCoreExtProfilesAndSuiteContext(
+func CheckParsedTransactionWithOwnedUtxoSetAndSuiteContext(
 	txBytes []byte,
 	tx *Tx,
 	ids ParsedTxIDs,

--- a/clients/go/consensus/tx_helpers_test.go
+++ b/clients/go/consensus/tx_helpers_test.go
@@ -205,25 +205,24 @@ func TestCheckTransaction_CoreSimplicityCreationUsesDeploymentProvider(t *testin
 	_, err = CheckTransaction(txBytes, utxoSet, 10, 0, chainID)
 	assertTxErrCode(t, err, TX_ERR_COVENANT_TYPE_INVALID)
 
-	checked, err := CheckTransactionWithCoreExtProfilesAndSuiteContext(
+	checked, err := CheckTransactionWithSuiteContext(
 		txBytes,
 		utxoSet,
 		10,
 		0,
 		chainID,
-		nil,
 		testRotationProvider{createSuiteID: SUITE_ID_ML_DSA_87},
 		nil,
 	)
 	if err != nil {
-		t.Fatalf("CheckTransactionWithCoreExtProfilesAndSuiteContext: %v", err)
+		t.Fatalf("CheckTransactionWithSuiteContext: %v", err)
 	}
 	if checked.Fee != 10 {
 		t.Fatalf("fee=%d, want 10", checked.Fee)
 	}
 }
 
-func TestCheckTransactionWithCoreExtProfilesAndSuiteContext_DoesNotMutateCallerUtxoSet(t *testing.T) {
+func TestCheckTransactionWithSuiteContext_DoesNotMutateCallerUtxoSet(t *testing.T) {
 	kp := mustMLDSA87Keypair(t)
 	covData := P2PKCovenantDataForPubkey(kp.PubkeyBytes())
 
@@ -268,7 +267,7 @@ func TestCheckTransactionWithCoreExtProfilesAndSuiteContext_DoesNotMutateCallerU
 	}
 
 	original := copyTestUtxoSet(utxoSet)
-	checked, err := CheckTransactionWithCoreExtProfilesAndSuiteContext(
+	checked, err := CheckTransactionWithSuiteContext(
 		txBytes,
 		utxoSet,
 		200,
@@ -276,21 +275,20 @@ func TestCheckTransactionWithCoreExtProfilesAndSuiteContext_DoesNotMutateCallerU
 		chainID,
 		nil,
 		nil,
-		nil,
 	)
 	if err != nil {
-		t.Fatalf("CheckTransactionWithCoreExtProfilesAndSuiteContext: %v", err)
+		t.Fatalf("CheckTransactionWithSuiteContext: %v", err)
 	}
 	if checked.Fee != 10_000_000 {
 		t.Fatalf("expected fee 10_000_000, got %d", checked.Fee)
 	}
 	if !reflect.DeepEqual(utxoSet, original) {
-		t.Fatalf("CheckTransactionWithCoreExtProfilesAndSuiteContext mutated caller utxo set")
+		t.Fatalf("CheckTransactionWithSuiteContext mutated caller utxo set")
 	}
 }
 
-func TestCheckParsedTransactionWithOwnedUtxoSetAndCoreExtProfilesAndSuiteContext_NilTx(t *testing.T) {
-	_, err := CheckParsedTransactionWithOwnedUtxoSetAndCoreExtProfilesAndSuiteContext(
+func TestCheckParsedTransactionWithOwnedUtxoSetAndSuiteContext_NilTx(t *testing.T) {
+	_, err := CheckParsedTransactionWithOwnedUtxoSetAndSuiteContext(
 		nil,
 		nil,
 		ParsedTxIDs{},
@@ -305,7 +303,7 @@ func TestCheckParsedTransactionWithOwnedUtxoSetAndCoreExtProfilesAndSuiteContext
 	}
 }
 
-func TestCheckParsedTransactionWithOwnedUtxoSetAndCoreExtProfilesAndSuiteContext_ValidTx(t *testing.T) {
+func TestCheckParsedTransactionWithOwnedUtxoSetAndSuiteContext_ValidTx(t *testing.T) {
 	kp := mustMLDSA87Keypair(t)
 	covData := P2PKCovenantDataForPubkey(kp.PubkeyBytes())
 
@@ -355,7 +353,7 @@ func TestCheckParsedTransactionWithOwnedUtxoSetAndCoreExtProfilesAndSuiteContext
 		t.Fatalf("consumed=%d len=%d", consumed, len(txBytes))
 	}
 
-	checked, err := CheckParsedTransactionWithOwnedUtxoSetAndCoreExtProfilesAndSuiteContext(
+	checked, err := CheckParsedTransactionWithOwnedUtxoSetAndSuiteContext(
 		txBytes,
 		parsed,
 		ParsedTxIDs{TxID: txid, WTxID: wtxid},
@@ -366,7 +364,7 @@ func TestCheckParsedTransactionWithOwnedUtxoSetAndCoreExtProfilesAndSuiteContext
 		SuiteValidationContext{},
 	)
 	if err != nil {
-		t.Fatalf("CheckParsedTransactionWithOwnedUtxoSetAndCoreExtProfilesAndSuiteContext: %v", err)
+		t.Fatalf("CheckParsedTransactionWithOwnedUtxoSetAndSuiteContext: %v", err)
 	}
 	if checked.Fee != 10_000_000 {
 		t.Fatalf("expected fee 10_000_000, got %d", checked.Fee)

--- a/clients/go/consensus/tx_validate_worker.go
+++ b/clients/go/consensus/tx_validate_worker.go
@@ -59,7 +59,6 @@ func ValidateTxLocal(
 	chainID [32]byte,
 	blockHeight uint64,
 	blockMTP uint64,
-	_ any,
 	sigCache *SigCache,
 ) TxValidationResult {
 	result := TxValidationResult{TxIndex: tvc.TxIndex, Fee: tvc.Fee}
@@ -246,11 +245,10 @@ func RunTxValidationWorkers(
 	chainID [32]byte,
 	blockHeight uint64,
 	blockMTP uint64,
-	_ any,
 	sigCache *SigCache,
 ) ([]WorkerResult[TxValidationResult], error) {
 	return RunFunc(ctx, maxWorkers, len(txcs), txcs, func(ctx context.Context, tvc TxValidationContext) (TxValidationResult, error) {
-		r := ValidateTxLocal(tvc, chainID, blockHeight, blockMTP, nil, sigCache)
+		r := ValidateTxLocal(tvc, chainID, blockHeight, blockMTP, sigCache)
 		if r.Err != nil {
 			return r, r.Err
 		}

--- a/clients/go/consensus/tx_validate_worker_test.go
+++ b/clients/go/consensus/tx_validate_worker_test.go
@@ -44,7 +44,7 @@ func TestValidateTxLocal_P2PK_Valid(t *testing.T) {
 		Fee:          10,
 	}
 
-	result := ValidateTxLocal(tvc, [32]byte{}, 1, 0, nil, nil)
+	result := ValidateTxLocal(tvc, [32]byte{}, 1, 0, nil)
 	if !result.Valid {
 		t.Fatalf("expected valid, got err: %v", result.Err)
 	}
@@ -95,7 +95,7 @@ func TestValidateTxLocal_P2PK_InvalidSig(t *testing.T) {
 		Fee:          10,
 	}
 
-	result := ValidateTxLocal(tvc, [32]byte{}, 1, 0, nil, nil)
+	result := ValidateTxLocal(tvc, [32]byte{}, 1, 0, nil)
 	if result.Valid {
 		t.Fatalf("expected invalid, got valid")
 	}
@@ -106,7 +106,7 @@ func TestValidateTxLocal_P2PK_InvalidSig(t *testing.T) {
 
 func TestValidateTxLocal_NilTx(t *testing.T) {
 	tvc := TxValidationContext{TxIndex: 1, Tx: nil}
-	result := ValidateTxLocal(tvc, [32]byte{}, 1, 0, nil, nil)
+	result := ValidateTxLocal(tvc, [32]byte{}, 1, 0, nil)
 	if result.Valid {
 		t.Fatalf("expected invalid for nil tx")
 	}
@@ -123,7 +123,7 @@ func TestValidateTxLocal_ResolvedInputCountMismatchUsesTxContextError(t *testing
 		Inputs:  []TxInput{{PrevVout: 0}},
 	}
 
-	result := ValidateTxLocal(TxValidationContext{TxIndex: 1, Tx: tx}, [32]byte{}, 1, 0, nil, nil)
+	result := ValidateTxLocal(TxValidationContext{TxIndex: 1, Tx: tx}, [32]byte{}, 1, 0, nil)
 	assertTxErrCodeMsg(t, result.Err, TX_ERR_PARSE, "txcontext resolved input count mismatch")
 }
 
@@ -159,7 +159,7 @@ func TestValidateTxLocal_WitnessUnderflow(t *testing.T) {
 		Fee:          10,
 	}
 
-	result := ValidateTxLocal(tvc, [32]byte{}, 1, 0, nil, nil)
+	result := ValidateTxLocal(tvc, [32]byte{}, 1, 0, nil)
 	if result.Valid {
 		t.Fatalf("expected invalid for witness underflow")
 	}
@@ -200,7 +200,7 @@ func TestValidateTxLocal_WitnessCountMismatch(t *testing.T) {
 		SighashCache: sighashCache,
 	}
 
-	result := ValidateTxLocal(tvc, [32]byte{}, 1, 0, nil, nil)
+	result := ValidateTxLocal(tvc, [32]byte{}, 1, 0, nil)
 	if result.Valid {
 		t.Fatalf("expected invalid for witness count mismatch")
 	}
@@ -236,7 +236,7 @@ func TestValidateTxLocal_CoreSimplicitySpendRejected(t *testing.T) {
 		Fee:          10,
 	}
 
-	result := ValidateTxLocal(tvc, [32]byte{}, 1, 0, nil, nil)
+	result := ValidateTxLocal(tvc, [32]byte{}, 1, 0, nil)
 	assertTxErrCodeMsg(t, result.Err, TX_ERR_COVENANT_TYPE_INVALID, "CORE_SIMPLICITY spend evaluation not enabled")
 }
 
@@ -268,7 +268,7 @@ func TestValidateTxLocal_CoreExt0x0102Rejected(t *testing.T) {
 		Fee:          10,
 	}
 
-	result := ValidateTxLocal(tvc, [32]byte{}, 1, 0, nil, nil)
+	result := ValidateTxLocal(tvc, [32]byte{}, 1, 0, nil)
 	if got := mustTxErrCode(t, result.Err); got != TX_ERR_COVENANT_TYPE_INVALID {
 		t.Fatalf("worker path: code=%s, want %s", got, TX_ERR_COVENANT_TYPE_INVALID)
 	}
@@ -313,7 +313,7 @@ func TestValidateTxLocal_CoreSimplicityInputGroupCapDeferredBehindDisabledSpend(
 			WitnessEnd:     len(tx.Witness),
 			SighashCache:   sighashCache,
 			Fee:            uint64(inputCount - 1),
-		}, [32]byte{}, 1, 0, nil, nil)
+		}, [32]byte{}, 1, 0, nil)
 	}
 
 	assertTxErrCodeMsg(t, run(SIMPLICITY_MAX_GROUP_INPUTS, false).Err, TX_ERR_COVENANT_TYPE_INVALID, "CORE_SIMPLICITY spend evaluation not enabled")
@@ -359,7 +359,7 @@ func TestValidateTxLocal_WithSigCache(t *testing.T) {
 	}
 
 	// First call populates sig cache.
-	result := ValidateTxLocal(tvc, [32]byte{}, 1, 0, nil, sigCache)
+	result := ValidateTxLocal(tvc, [32]byte{}, 1, 0, sigCache)
 	if !result.Valid {
 		t.Fatalf("first call: %v", result.Err)
 	}
@@ -368,7 +368,7 @@ func TestValidateTxLocal_WithSigCache(t *testing.T) {
 	}
 
 	// Second call should hit cache.
-	result2 := ValidateTxLocal(tvc, [32]byte{}, 1, 0, nil, sigCache)
+	result2 := ValidateTxLocal(tvc, [32]byte{}, 1, 0, sigCache)
 	if !result2.Valid {
 		t.Fatalf("second call (cached): %v", result2.Err)
 	}
@@ -383,7 +383,7 @@ func TestValidateTxLocal_WithSigCache(t *testing.T) {
 
 func TestRunTxValidationWorkers_Empty(t *testing.T) {
 	results, err := RunTxValidationWorkers(
-		context.Background(), 4, nil, [32]byte{}, 1, 0, nil, nil,
+		context.Background(), 4, nil, [32]byte{}, 1, 0, nil,
 	)
 	if err != nil {
 		t.Fatalf("RunTxValidationWorkers: %v", err)
@@ -428,7 +428,7 @@ func TestRunTxValidationWorkers_SingleValid(t *testing.T) {
 	}}
 
 	results, err := RunTxValidationWorkers(
-		context.Background(), 2, txcs, [32]byte{}, 1, 0, nil, nil,
+		context.Background(), 2, txcs, [32]byte{}, 1, 0, nil,
 	)
 	if err != nil {
 		t.Fatalf("RunTxValidationWorkers: %v", err)
@@ -492,7 +492,7 @@ func TestRunTxValidationWorkers_MultipleWithOneInvalid(t *testing.T) {
 	}
 
 	results, err := RunTxValidationWorkers(
-		context.Background(), 2, txcs, [32]byte{}, 1, 0, nil, nil,
+		context.Background(), 2, txcs, [32]byte{}, 1, 0, nil,
 	)
 	if err != nil {
 		t.Fatalf("RunTxValidationWorkers: %v", err)
@@ -560,7 +560,7 @@ func TestRunTxValidationWorkers_CancelledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // already canceled
 
-	results, err := RunTxValidationWorkers(ctx, 2, txcs, [32]byte{}, 1, 0, nil, nil)
+	results, err := RunTxValidationWorkers(ctx, 2, txcs, [32]byte{}, 1, 0, nil)
 	if err != nil {
 		t.Fatalf("RunTxValidationWorkers: %v", err)
 	}
@@ -697,7 +697,7 @@ func TestValidateTxLocal_Multisig_Valid(t *testing.T) {
 		Fee:          10,
 	}
 
-	result := ValidateTxLocal(tvc, [32]byte{}, 1, 0, nil, nil)
+	result := ValidateTxLocal(tvc, [32]byte{}, 1, 0, nil)
 	if !result.Valid {
 		t.Fatalf("multisig valid: %v", result.Err)
 	}
@@ -754,7 +754,7 @@ func TestValidateTxLocal_HTLC_ClaimValid(t *testing.T) {
 		Fee:          10,
 	}
 
-	result := ValidateTxLocal(tvc, [32]byte{}, 1, 0, nil, nil)
+	result := ValidateTxLocal(tvc, [32]byte{}, 1, 0, nil)
 	if !result.Valid {
 		t.Fatalf("HTLC claim valid: %v", result.Err)
 	}
@@ -800,7 +800,7 @@ func TestValidateTxLocal_Vault_SigValid(t *testing.T) {
 		Fee:          10,
 	}
 
-	result := ValidateTxLocal(tvc, [32]byte{}, 1, 0, nil, nil)
+	result := ValidateTxLocal(tvc, [32]byte{}, 1, 0, nil)
 	if !result.Valid {
 		t.Fatalf("vault sig valid: %v", result.Err)
 	}
@@ -841,7 +841,7 @@ func TestValidateTxLocal_Stealth_Valid(t *testing.T) {
 		Fee:          10,
 	}
 
-	result := ValidateTxLocal(tvc, [32]byte{}, 1, 0, nil, nil)
+	result := ValidateTxLocal(tvc, [32]byte{}, 1, 0, nil)
 	if !result.Valid {
 		t.Fatalf("stealth valid: %v", result.Err)
 	}

--- a/clients/go/consensus/utxo_basic_common.go
+++ b/clients/go/consensus/utxo_basic_common.go
@@ -58,51 +58,26 @@ func ApplyNonCoinbaseTxBasicUpdateWithMTP(
 	txid [32]byte,
 	utxoSet map[Outpoint]UtxoEntry,
 	height uint64,
-	blockTimestamp uint64,
-	blockMTP uint64,
-	chainID [32]byte,
-) (map[Outpoint]UtxoEntry, *UtxoApplySummary, error) {
-	return ApplyNonCoinbaseTxBasicUpdateWithMTPAndCoreExtProfiles(
-		tx,
-		txid,
-		utxoSet,
-		height,
-		blockTimestamp,
-		blockMTP,
-		chainID,
-		nil,
-	)
-}
-
-// ApplyNonCoinbaseTxBasicUpdateWithMTPAndCoreExtProfiles preserves the legacy
-// helper name for deterministic tooling. The profile argument is ignored
-// because Go CORE_EXT runtime wiring has been removed.
-func ApplyNonCoinbaseTxBasicUpdateWithMTPAndCoreExtProfiles(
-	tx *Tx,
-	txid [32]byte,
-	utxoSet map[Outpoint]UtxoEntry,
-	height uint64,
 	_ uint64,
 	blockMTP uint64,
 	chainID [32]byte,
-	_ any,
 ) (map[Outpoint]UtxoEntry, *UtxoApplySummary, error) {
-	return ApplyNonCoinbaseTxBasicUpdateWithMTPAndCoreExtProfilesAndSuiteContext(
+	return ApplyNonCoinbaseTxBasicUpdateWithMTPAndSuiteContext(
 		tx,
 		txid,
 		utxoSet,
 		height,
 		blockMTP,
 		chainID,
-		nil,
-		nil,
+		nil, /*rotation*/
+		nil, /*registry*/
 	)
 }
 
-// ApplyNonCoinbaseTxBasicUpdateWithMTPAndCoreExtProfilesAndSuiteContext is the
+// ApplyNonCoinbaseTxBasicUpdateWithMTPAndSuiteContext is the
 // suite-aware variant for deterministic tooling that needs explicit native-suite
 // rotation/registry context.
-func ApplyNonCoinbaseTxBasicUpdateWithMTPAndCoreExtProfilesAndSuiteContext(
+func ApplyNonCoinbaseTxBasicUpdateWithMTPAndSuiteContext(
 	tx *Tx,
 	txid [32]byte,
 	utxoSet map[Outpoint]UtxoEntry,

--- a/clients/go/consensus/utxo_basic_test.go
+++ b/clients/go/consensus/utxo_basic_test.go
@@ -249,7 +249,7 @@ func TestApplyNonCoinbaseTxBasicUpdate_CoreSimplicityPreservesInputOrderPriority
 			makeOutpoint(simpPrev): coreSimplicityAcceptEntry(100),
 		}
 
-		work, summary, err := ApplyNonCoinbaseTxBasicUpdateWithMTPAndCoreExtProfilesAndSuiteContext(
+		work, summary, err := ApplyNonCoinbaseTxBasicUpdateWithMTPAndSuiteContext(
 			tx,
 			hashWithPrefix(0xE3),
 			utxos,
@@ -281,7 +281,7 @@ func TestApplyNonCoinbaseTxBasicUpdate_CoreSimplicityPreservesInputOrderPriority
 			makeOutpoint(simpPrev): coreSimplicityAcceptEntry(100),
 		}
 
-		work, summary, err := ApplyNonCoinbaseTxBasicUpdateWithMTPAndCoreExtProfilesAndSuiteContext(
+		work, summary, err := ApplyNonCoinbaseTxBasicUpdateWithMTPAndSuiteContext(
 			tx,
 			hashWithPrefix(0xE4),
 			utxos,
@@ -316,7 +316,7 @@ func TestApplyNonCoinbaseTxBasicUpdate_NonSimplicityWitnessUnderflowPrecedesLate
 		{Txid: laterPrev, Vout: 0}: {Value: 100, CovenantType: COV_TYPE_HTLC, CovenantData: []byte{0x01}},
 	}
 
-	work, summary, err := ApplyNonCoinbaseTxBasicUpdateWithMTPAndCoreExtProfilesAndSuiteContext(
+	work, summary, err := ApplyNonCoinbaseTxBasicUpdateWithMTPAndSuiteContext(
 		tx,
 		hashWithPrefix(0xE9),
 		utxos,

--- a/clients/go/node/chainstate_connect.go
+++ b/clients/go/node/chainstate_connect.go
@@ -13,33 +13,21 @@ func (s *ChainState) ConnectBlock(
 	prevTimestamps []uint64,
 	chainID [32]byte,
 ) (*ChainStateConnectSummary, error) {
-	return s.ConnectBlockWithCoreExtProfiles(blockBytes, expectedTarget, prevTimestamps, chainID, nil)
-}
-
-func (s *ChainState) ConnectBlockWithCoreExtProfiles(
-	blockBytes []byte,
-	expectedTarget *[32]byte,
-	prevTimestamps []uint64,
-	chainID [32]byte,
-	coreExtProfiles any,
-) (*ChainStateConnectSummary, error) {
-	return s.ConnectBlockWithCoreExtProfilesAndSuiteContext(
+	return s.ConnectBlockWithSuiteContext(
 		blockBytes,
 		expectedTarget,
 		prevTimestamps,
 		chainID,
-		coreExtProfiles,
 		s.rotationOrNil(),
 		s.registryOrNil(),
 	)
 }
 
-func (s *ChainState) ConnectBlockWithCoreExtProfilesAndSuiteContext(
+func (s *ChainState) ConnectBlockWithSuiteContext(
 	blockBytes []byte,
 	expectedTarget *[32]byte,
 	prevTimestamps []uint64,
 	chainID [32]byte,
-	coreExtProfiles any,
 	rotation consensus.RotationProvider,
 	registry *consensus.SuiteRegistry,
 ) (*ChainStateConnectSummary, error) {
@@ -55,7 +43,7 @@ func (s *ChainState) ConnectBlockWithCoreExtProfilesAndSuiteContext(
 	if err != nil {
 		return nil, err
 	}
-	summary, err := consensus.ConnectBlockBasicInMemoryAtHeightAndCoreExtProfilesAndSuiteContext(
+	summary, err := consensus.ConnectBlockBasicInMemoryAtHeightAndSuiteContext(
 		blockBytes,
 		expectedPrevHash,
 		expectedTarget,
@@ -63,7 +51,6 @@ func (s *ChainState) ConnectBlockWithCoreExtProfilesAndSuiteContext(
 		prevTimestamps,
 		&workState,
 		chainID,
-		coreExtProfiles,
 		rotation,
 		registry,
 	)
@@ -92,7 +79,6 @@ func (s *ChainState) ConnectBlockParallelSigs(
 	expectedTarget *[32]byte,
 	prevTimestamps []uint64,
 	chainID [32]byte,
-	coreExtProfiles any,
 	workers int,
 ) (*ChainStateConnectSummary, error) {
 	return s.ConnectBlockParallelSigsWithSuiteContext(
@@ -100,7 +86,6 @@ func (s *ChainState) ConnectBlockParallelSigs(
 		expectedTarget,
 		prevTimestamps,
 		chainID,
-		coreExtProfiles,
 		s.rotationOrNil(),
 		s.registryOrNil(),
 		workers,
@@ -112,7 +97,6 @@ func (s *ChainState) ConnectBlockParallelSigsWithSuiteContext(
 	expectedTarget *[32]byte,
 	prevTimestamps []uint64,
 	chainID [32]byte,
-	coreExtProfiles any,
 	rotation consensus.RotationProvider,
 	registry *consensus.SuiteRegistry,
 	workers int,
@@ -129,7 +113,7 @@ func (s *ChainState) ConnectBlockParallelSigsWithSuiteContext(
 	if err != nil {
 		return nil, err
 	}
-	summary, err := consensus.ConnectBlockParallelSigVerifyWithCoreExtProfilesAndSuiteContext(
+	summary, err := consensus.ConnectBlockParallelSigVerifyWithSuiteContext(
 		blockBytes,
 		expectedPrevHash,
 		expectedTarget,
@@ -137,7 +121,6 @@ func (s *ChainState) ConnectBlockParallelSigsWithSuiteContext(
 		prevTimestamps,
 		&workState,
 		chainID,
-		coreExtProfiles,
 		rotation,
 		registry,
 		workers,

--- a/clients/go/node/chainstate_recovery.go
+++ b/clients/go/node/chainstate_recovery.go
@@ -205,12 +205,11 @@ func replayCanonicalBlocks(state *ChainState, store *BlockStore, cfg SyncConfig,
 		if err != nil {
 			return false, err
 		}
-		if _, err := state.ConnectBlockWithCoreExtProfilesAndSuiteContext(
+		if _, err := state.ConnectBlockWithSuiteContext(
 			blockBytes,
 			cfg.ExpectedTarget,
 			prevTimestamps,
 			cfg.ChainID,
-			nil,
 			cfg.RotationProvider,
 			cfg.SuiteRegistry,
 		); err != nil {

--- a/clients/go/node/chainstate_recovery_test.go
+++ b/clients/go/node/chainstate_recovery_test.go
@@ -516,9 +516,9 @@ func TestReconcileChainStateWithBlockStore_PropagatesCorruptBlockBytesSwap(t *te
 	}
 
 	state := NewChainState()
-	if _, err := state.ConnectBlockWithCoreExtProfilesAndSuiteContext(
+	if _, err := state.ConnectBlockWithSuiteContext(
 		devnetGenesisBlockBytes, &target, nil, devnetGenesisChainID,
-		nil, cfg.RotationProvider, cfg.SuiteRegistry,
+		cfg.RotationProvider, cfg.SuiteRegistry,
 	); err != nil {
 		t.Fatalf("seed genesis state: %v", err)
 	}

--- a/clients/go/node/chainstate_test.go
+++ b/clients/go/node/chainstate_test.go
@@ -573,7 +573,7 @@ func TestChainStateConnectBlockParallelSigs(t *testing.T) {
 
 	// Parallel path: connect genesis + same block.
 	parSt := NewChainState()
-	parGenesis, err := parSt.ConnectBlockParallelSigs(devnetGenesisBlockBytes, &target, nil, devnetGenesisChainID, nil, 4)
+	parGenesis, err := parSt.ConnectBlockParallelSigs(devnetGenesisBlockBytes, &target, nil, devnetGenesisChainID, 4)
 	if err != nil {
 		t.Fatalf("par connect genesis: %v", err)
 	}
@@ -581,7 +581,7 @@ func TestChainStateConnectBlockParallelSigs(t *testing.T) {
 		t.Fatalf("genesis height mismatch: seq=%d par=%d", seqGenesis.BlockHeight, parGenesis.BlockHeight)
 	}
 
-	parBlock1, err := parSt.ConnectBlockParallelSigs(block1, &target, nil, devnetGenesisChainID, nil, 4)
+	parBlock1, err := parSt.ConnectBlockParallelSigs(block1, &target, nil, devnetGenesisChainID, 4)
 	if err != nil {
 		t.Fatalf("par connect block 1: %v", err)
 	}
@@ -615,7 +615,7 @@ func TestChainStateConnectBlockParallelSigs(t *testing.T) {
 // TestChainStateConnectBlockParallelSigs_NilState checks that nil receiver is rejected.
 func TestChainStateConnectBlockParallelSigs_NilState(t *testing.T) {
 	var st *ChainState
-	_, err := st.ConnectBlockParallelSigs(nil, nil, nil, [32]byte{}, nil, 0)
+	_, err := st.ConnectBlockParallelSigs(nil, nil, nil, [32]byte{}, 0)
 	if err == nil {
 		t.Fatal("expected error for nil chainstate")
 	}
@@ -625,7 +625,7 @@ func TestChainStateConnectBlockParallelSigs_NilState(t *testing.T) {
 func TestChainStateConnectBlockParallelSigs_InvalidBlock(t *testing.T) {
 	target := consensus.POW_LIMIT
 	st := NewChainState()
-	_, err := st.ConnectBlockParallelSigs([]byte{0x00}, &target, nil, [32]byte{}, nil, 1)
+	_, err := st.ConnectBlockParallelSigs([]byte{0x00}, &target, nil, [32]byte{}, 1)
 	if err == nil {
 		t.Fatal("expected error for invalid block")
 	}

--- a/clients/go/node/fuzz_test.go
+++ b/clients/go/node/fuzz_test.go
@@ -285,7 +285,7 @@ func fuzzCheckedDaPolicyTx(
 	if consumed != len(txBytes) {
 		t.Fatalf("ParseTx consumed=%d, want %d", consumed, len(txBytes))
 	}
-	checked, err := consensus.CheckParsedTransactionWithOwnedUtxoSetAndCoreExtProfilesAndSuiteContext(
+	checked, err := consensus.CheckParsedTransactionWithOwnedUtxoSetAndSuiteContext(
 		txBytes,
 		tx,
 		consensus.ParsedTxIDs{TxID: txid, WTxID: wtxid},
@@ -296,7 +296,7 @@ func fuzzCheckedDaPolicyTx(
 		consensus.SuiteValidationContext{},
 	)
 	if err != nil {
-		t.Fatalf("CheckParsedTransactionWithOwnedUtxoSetAndCoreExtProfilesAndSuiteContext(signed fuzz tx): %v", err)
+		t.Fatalf("CheckParsedTransactionWithOwnedUtxoSetAndSuiteContext(signed fuzz tx): %v", err)
 	}
 	if checked.Fee != policyFee {
 		t.Fatalf("checked fee=%d, want %d", checked.Fee, policyFee)

--- a/clients/go/node/mempolicy_helpers.go
+++ b/clients/go/node/mempolicy_helpers.go
@@ -32,7 +32,7 @@ func (m *Mempool) validateTransactionWithConsensus(
 	blockMTP uint64,
 	policy MempoolConfig,
 ) (*consensus.CheckedTransaction, error) {
-	checked, err := consensus.CheckParsedTransactionWithOwnedUtxoSetAndCoreExtProfilesAndSuiteContext(
+	checked, err := consensus.CheckParsedTransactionWithOwnedUtxoSetAndSuiteContext(
 		txBytes,
 		tx,
 		consensus.ParsedTxIDs{TxID: txid, WTxID: wtxid},

--- a/clients/go/node/mempool_precheck.go
+++ b/clients/go/node/mempool_precheck.go
@@ -99,13 +99,12 @@ func (m *Mempool) checkTransactionWithSnapshot(txBytes []byte, snapshot *chainSt
 			return nil, nil, txAdmitRejected(reason)
 		}
 	}
-	checked, err := consensus.CheckTransactionWithOwnedUtxoSetAndCoreExtProfilesAndSuiteContext(
+	checked, err := consensus.CheckTransactionWithOwnedUtxoSetAndSuiteContext(
 		txBytes,
 		snapshot.utxos,
 		nextHeight,
 		blockMTP,
 		m.chainID,
-		nil,
 		policy.RotationProvider,
 		policy.SuiteRegistry,
 	)

--- a/clients/go/node/mempool_test.go
+++ b/clients/go/node/mempool_test.go
@@ -2488,18 +2488,17 @@ func TestMempoolPolicySnapshot_DoesNotMutateForDaPolicy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("nextBlockMTP: %v", err)
 	}
-	checked, err := consensus.CheckTransactionWithOwnedUtxoSetAndCoreExtProfilesAndSuiteContext(
+	checked, err := consensus.CheckTransactionWithOwnedUtxoSetAndSuiteContext(
 		txBytes,
 		copyUtxoSet(st.Utxos),
 		nextHeight,
 		blockMTP,
 		devnetGenesisChainID,
-		nil,
 		mp.policy.RotationProvider,
 		mp.policy.SuiteRegistry,
 	)
 	if err != nil {
-		t.Fatalf("CheckTransactionWithOwnedUtxoSetAndCoreExtProfilesAndSuiteContext: %v", err)
+		t.Fatalf("CheckTransactionWithOwnedUtxoSetAndSuiteContext: %v", err)
 	}
 	policyUtxos, err := policyInputSnapshot(checked.Tx, st.Utxos)
 	if err != nil {

--- a/clients/go/node/miner.go
+++ b/clients/go/node/miner.go
@@ -635,7 +635,7 @@ func collectCompleteDASetGroupInputs(group []miningCandidate, selectedNonces map
 func validateCompleteDASetGroupConsensus(group []miningCandidate, utxos map[consensus.Outpoint]consensus.UtxoEntry, groupInputOutpoints []consensus.Outpoint, nextHeight uint64, validationCtx miningConsensusContext) bool {
 	workUtxos := copySelectedUtxoSet(utxos, groupInputOutpoints)
 	for _, candidate := range group {
-		if _, err := consensus.CheckParsedTransactionWithOwnedUtxoSetAndCoreExtProfilesAndSuiteContext(
+		if _, err := consensus.CheckParsedTransactionWithOwnedUtxoSetAndSuiteContext(
 			candidate.minedCandidate.raw,
 			candidate.tx,
 			consensus.ParsedTxIDs{TxID: candidate.minedCandidate.txid, WTxID: candidate.minedCandidate.wtxid},
@@ -674,7 +674,7 @@ func (m *Miner) trySelectFlatCandidate(raw []byte, utxos map[consensus.Outpoint]
 	if err != nil {
 		return miningCandidate{}, policyDaIncluded, false, nil
 	}
-	if _, err := consensus.CheckParsedTransactionWithOwnedUtxoSetAndCoreExtProfilesAndSuiteContext(candidate.minedCandidate.raw, candidate.tx, consensus.ParsedTxIDs{TxID: candidate.minedCandidate.txid, WTxID: candidate.minedCandidate.wtxid}, workUtxos, nextHeight, validationCtx.blockMTP, validationCtx.chainID, consensus.SuiteValidationContext{Rotation: validationCtx.rotation, Registry: validationCtx.registry}); err != nil {
+	if _, err := consensus.CheckParsedTransactionWithOwnedUtxoSetAndSuiteContext(candidate.minedCandidate.raw, candidate.tx, consensus.ParsedTxIDs{TxID: candidate.minedCandidate.txid, WTxID: candidate.minedCandidate.wtxid}, workUtxos, nextHeight, validationCtx.blockMTP, validationCtx.chainID, consensus.SuiteValidationContext{Rotation: validationCtx.rotation, Registry: validationCtx.registry}); err != nil {
 		return miningCandidate{}, policyDaIncluded, false, nil
 	}
 	return candidate, nextDaIncluded, true, nil

--- a/clients/go/node/runtime_perf_baseline_test.go
+++ b/clients/go/node/runtime_perf_baseline_test.go
@@ -415,7 +415,7 @@ func BenchmarkCopyUtxoSet(b *testing.B) {
 	}
 }
 
-func BenchmarkConnectBlockWithCoreExtProfilesAndSuiteContext(b *testing.B) {
+func BenchmarkConnectBlockWithSuiteContext(b *testing.B) {
 	benchmarkConnectBlockWithSuiteContext(b)
 }
 
@@ -428,16 +428,15 @@ func benchmarkConnectBlockWithSuiteContext(b *testing.B) {
 		b.StopTimer()
 		state := cloneChainState(baseState)
 		b.StartTimer()
-		if _, err := state.ConnectBlockWithCoreExtProfilesAndSuiteContext(
+		if _, err := state.ConnectBlockWithSuiteContext(
 			blockBytes,
 			nil,
 			prevTimestamps,
 			devnetGenesisChainID,
 			nil,
 			nil,
-			nil,
 		); err != nil {
-			b.Fatalf("ConnectBlockWithCoreExtProfilesAndSuiteContext: %v", err)
+			b.Fatalf("ConnectBlockWithSuiteContext: %v", err)
 		}
 	}
 }
@@ -456,7 +455,6 @@ func BenchmarkConnectBlockParallelSigsWithSuiteContext(b *testing.B) {
 			nil,
 			prevTimestamps,
 			devnetGenesisChainID,
-			nil,
 			nil,
 			nil,
 			2,

--- a/clients/go/node/sync.go
+++ b/clients/go/node/sync.go
@@ -567,12 +567,11 @@ func (s *SyncEngine) connectCanonicalBlock(
 	blockBytes []byte,
 	prevTimestamps []uint64,
 ) (*ChainStateConnectSummary, error) {
-	return s.chainState.ConnectBlockWithCoreExtProfilesAndSuiteContext(
+	return s.chainState.ConnectBlockWithSuiteContext(
 		blockBytes,
 		s.cfg.ExpectedTarget,
 		prevTimestamps,
 		s.cfg.ChainID,
-		nil,
 		s.cfg.RotationProvider,
 		s.cfg.SuiteRegistry,
 	)

--- a/clients/go/node/sync_pv.go
+++ b/clients/go/node/sync_pv.go
@@ -33,7 +33,7 @@ func (s *SyncEngine) runPVShadowOnError(blockBytes []byte, prevTimestamps []uint
 	_, parErr := shadowState.ConnectBlockParallelSigsWithSuiteContext(
 		blockBytes,
 		s.cfg.ExpectedTarget, prevTimestamps, s.cfg.ChainID,
-		nil, s.cfg.RotationProvider, s.cfg.SuiteRegistry, 0,
+		s.cfg.RotationProvider, s.cfg.SuiteRegistry, 0,
 	)
 	s.pvTelemetry.RecordValidateLatency(time.Since(validateStart))
 	seqCode, parCode := txErrCode(seqErr), txErrCode(parErr)
@@ -56,7 +56,7 @@ func (s *SyncEngine) runPVShadowOnSuccess(blockBytes []byte, prevTimestamps []ui
 	parSummary, parErr := shadowState.ConnectBlockParallelSigsWithSuiteContext(
 		blockBytes,
 		s.cfg.ExpectedTarget, prevTimestamps, s.cfg.ChainID,
-		nil, s.cfg.RotationProvider, s.cfg.SuiteRegistry, 0,
+		s.cfg.RotationProvider, s.cfg.SuiteRegistry, 0,
 	)
 	s.pvTelemetry.RecordValidateLatency(time.Since(validateStart))
 	if parSummary != nil {

--- a/clients/go/node/sync_reorg.go
+++ b/clients/go/node/sync_reorg.go
@@ -256,12 +256,11 @@ func (s *SyncEngine) preparePreferredBranch(
 		return nil, 0, err
 	}
 	for _, item := range branch {
-		if _, err := previewState.ConnectBlockWithCoreExtProfilesAndSuiteContext(
+		if _, err := previewState.ConnectBlockWithSuiteContext(
 			item.blockBytes,
 			s.cfg.ExpectedTarget,
 			slidingTs,
 			s.cfg.ChainID,
-			nil,
 			s.cfg.RotationProvider,
 			s.cfg.SuiteRegistry,
 		); err != nil {

--- a/evidence/runtime-perf/CI_RUNTIME_PERF_GUARDRAILS.md
+++ b/evidence/runtime-perf/CI_RUNTIME_PERF_GUARDRAILS.md
@@ -28,7 +28,7 @@ Go:
 - `BenchmarkMinerBuildContext`
 - `BenchmarkCloneChainState`
 - `BenchmarkCopyUtxoSet`
-- `BenchmarkConnectBlockWithCoreExtProfilesAndSuiteContext`
+- `BenchmarkConnectBlockWithSuiteContext`
 - `BenchmarkConnectBlockParallelSigsWithSuiteContext`
 
 Rust:

--- a/scripts/runtime_perf/run_runtime_perf_suite.sh
+++ b/scripts/runtime_perf/run_runtime_perf_suite.sh
@@ -35,7 +35,7 @@ RUST_JSON="$OUT_DIR/rust_metrics.json"
 
 pushd "$REPO_ROOT" >/dev/null
 
-go_bench_regex='^(BenchmarkMempoolAddTx|BenchmarkMempoolRelayMetadata|BenchmarkMinerBuildContext|BenchmarkCloneChainState|BenchmarkCopyUtxoSet|BenchmarkConnectBlockWithSuiteContext|BenchmarkConnectBlockParallelSigsWithSuiteContext)$'
+go_bench_regex='^(BenchmarkMempoolAddTx|BenchmarkMempoolRelayMetadata|BenchmarkMinerBuildContext|BenchmarkCloneChainState|BenchmarkCopyUtxoSet|BenchmarkConnectBlockWithCoreExtProfilesAndSuiteContext|BenchmarkConnectBlockWithSuiteContext|BenchmarkConnectBlockParallelSigsWithSuiteContext)$'
 
 set +e
 (cd clients/go && go test ./node -run '^$' -bench "$go_bench_regex" -benchmem -count=1) | tee "$GO_OUT"

--- a/scripts/runtime_perf/run_runtime_perf_suite.sh
+++ b/scripts/runtime_perf/run_runtime_perf_suite.sh
@@ -35,7 +35,7 @@ RUST_JSON="$OUT_DIR/rust_metrics.json"
 
 pushd "$REPO_ROOT" >/dev/null
 
-go_bench_regex='^(BenchmarkMempoolAddTx|BenchmarkMempoolRelayMetadata|BenchmarkMinerBuildContext|BenchmarkCloneChainState|BenchmarkCopyUtxoSet|BenchmarkConnectBlockWithCoreExtProfilesAndSuiteContext|BenchmarkConnectBlockParallelSigsWithSuiteContext)$'
+go_bench_regex='^(BenchmarkMempoolAddTx|BenchmarkMempoolRelayMetadata|BenchmarkMinerBuildContext|BenchmarkCloneChainState|BenchmarkCopyUtxoSet|BenchmarkConnectBlockWithSuiteContext|BenchmarkConnectBlockParallelSigsWithSuiteContext)$'
 
 set +e
 (cd clients/go && go test ./node -run '^$' -bench "$go_bench_regex" -benchmem -count=1) | tee "$GO_OUT"


### PR DESCRIPTION
## Summary

Removes the inert `CORE_EXT` "profiles" connect-block threading left in the Go client after #2173 made `0x0102` unassigned-rejected. This is **behavior-neutral dead-code removal** — the profile params were already ignored (`_ any`) and the CLI/formal-trace builders already errored on the retired input; no consensus behavior changes. Go-only; the Rust mirror + the shadow-test re-pin + the `core_ext_live_binding_name` rename are deferred behind `RUB-577` in the sibling issue **RUB-587**.

Closes **RUB-586**.

## Scope

- [ ] Documentation-only
- [x] Implementation-only change (no consensus change)
- [ ] Consensus-affecting change (requires explicit process)

Pure removal of ignored plumbing + a public-helper rename. No validation, error code, or state-transition is altered.

**Consensus boundary (required):**

- Consensus rules unchanged: YES
- `SECTION_HASHES.json` unchanged: YES
- Wire format unchanged: YES

*Boundary note: the 0x0102 reject behavior shipped in #2173 is untouched — the reject arms at `clients/go/consensus/covenant_genesis.go:43`, `utxo_basic_common.go` `checkSpendCovenant` default, and `vault.go` `witnessSlots` default are unchanged. This PR only deletes the surrounding ignored profile-threading.*

## What changed (clients/go only)

- **Delete 4 redundant middle wrappers** whose only role was carrying the ignored `_ any` profile arg: `ConnectBlockParallelSigVerifyWithCoreExtProfiles`, `ConnectBlockBasicInMemoryAtHeightAndCoreExtProfiles`, `ApplyNonCoinbaseTxBasicUpdateWithMTPAndCoreExtProfiles`, and `*ChainState.ConnectBlockWithCoreExtProfiles`. Base functions now call their `*WithSuiteContext` variant directly with `nil` rotation/registry.
- **Remove the ignored `_ any` profile param** from the suite-context impls + internal workers (`applyNonCoinbaseTxBasicUpdateWithMTPQ`, `applyNonCoinbaseTxBasicWorkQ`, `ValidateTxLocal`, `RunTxValidationWorkers`, `CheckTransaction*WithSuiteContext`) and **rename** `*AndCoreExtProfilesAndSuiteContext` → `*AndSuiteContext` (and the parallel/inmem/check variants). All ~90 call sites + tests updated.
- **Remove the dead `core_ext_profiles` threading** from `rubin-consensus-cli` (the `CoreExtProfileJSON`/`BoolishFlag` types + `buildCoreExtProfiles` builder) and `formal-trace` (field, builder; now uses the base `ApplyNonCoinbaseTxBasicUpdateWithMTP`). The CLI **still rejects** the retired request keys — see below.
- Pre-PR review fixes: repoint the runtime-perf `-bench` regex + `CI_RUNTIME_PERF_GUARDRAILS.md` to the renamed `BenchmarkConnectBlockWithSuiteContext` (else the benchmark silently drops from perf metrics); drop a redundant `_ = blockTimestamp` no-op; gitignore the stray `cmd` build binaries.

## Deliberate / documented

- **Retired-input handling (reject preserved, Rust parity):** an exhaustive multi-vector review flagged that removing the CLI builder turned the Go consensus-CLI's explicit *"unsupported by Go runtime"* rejection of `core_ext_profiles` / `core_ext_profile_set_anchor_hex` into silent-ignore, diverging from the Rust CLI's `reject_core_ext_profiles_from_json`. **Restored** (`rejectRetiredCoreExtProfiles` guard at both ops, with the original error strings + a mirroring unit test) so behavior is unchanged and Go/Rust CLI parity is exact. Gate-safe regardless (no `CV-*.json` carries these keys; the runner pre-rejects them).
- **Cross-client naming asymmetry:** the Rust crate still carries the `*_and_core_ext_profiles_and_suite_context` names + inert `let _ = core_ext_profiles` params. That is **RUB-587** (deferred behind RUB-577); this PR is the Go-only, ungated half (parity-exempt: Go-only, behavior-neutral — the conformance bundle compares observable behavior, not function signatures).

### Parity exemption justification

Go-only, behavior-neutral CORE_EXT inert-threading removal. The cross-client conformance bundle stays **519/519 (Go == Rust)** — observable consensus behavior is unchanged; this PR only deletes ignored internal/CLI plumbing and renames public helpers (no validation/error-code/state change). The Rust mirror (same threading removal + shadow-test re-pin + identifier rename) is **RUB-587**, deliberately deferred behind the `RUB-577` Rust-parity gate (the staged thaw covered only legs 512/513/514). Per the RUB-586 contract this is the ungated Go half; a temporary Go/Rust internal-API asymmetry is acceptable because the params are inert and the bundle compares behavior, not signatures. `parity-exempt` requested on this basis.

## Verification (all green)

- Go: `go build ./...`, `go vet ./...`, `gofmt -l` empty, `go test ./consensus/... ./node/...` (0 fails; node 217s, p2p 17s).
- Cross-client: `run_cv_bundle.py` **519/519 (Go == Rust)** — behavior unchanged.
- Formal: GoTraceV1 regeneration **NO DRIFT**; `check_formal_refinement_bridge.py` + `check_lean_conformance_staleness.py` green.
- Reject arms confirmed untouched; tree scoped to `clients/go/` + the perf script/doc/`.gitignore`.
- Pre-PR adversarial multi-agent review (behavior-neutrality / residue / bot-hooks); all findings addressed (P2 benchmark-name drift fixed; P3s fixed or documented above).

## Push note

Pushed via direct git (controller-authorized override): the `cl push` gate wrapper is absent in the authoring environment. Sanctioned pre-push checks above were run manually.

Refs: Q-CORE-EXT-RESIDUE-CLEANUP-GO-01

🤖 Generated with [Claude Code](https://claude.com/claude-code)
