### PR TITLE
RUB-587 S1: remove inert CORE_EXT connect-block threading (Rust, behavior-neutral)

### DIFF
--- a/clients/rust/crates/rubin-consensus-cli/src/main.rs
+++ b/clients/rust/crates/rubin-consensus-cli/src/main.rs
@@ -15,10 +15,10 @@ use rubin_consensus::{
     validate_block_basic_with_context_and_fees_at_height,
     validate_block_basic_with_context_at_height, validate_htlc_spend,
     validate_rotation_descriptor_for_network, validate_rotation_set_for_network,
-    validate_tx_covenants_genesis, work_from_target, CoreExtDeploymentProfiles, CoreExtProfiles,
-    CryptoRotationDescriptor, DescriptorRotationProvider, ErrorCode, FeatureBitDeployment,
-    FeatureBitState, FlagDayDeployment, HtlcSpendContext, InMemoryChainState, Outpoint,
-    RotationProvider, SuiteParams, SuiteRegistry, Tx, TxInput, TxOutput, UtxoEntry, WitnessItem,
+    validate_tx_covenants_genesis, work_from_target, CryptoRotationDescriptor,
+    DescriptorRotationProvider, ErrorCode, FeatureBitDeployment, FeatureBitState,
+    FlagDayDeployment, HtlcSpendContext, InMemoryChainState, Outpoint, RotationProvider,
+    SuiteParams, SuiteRegistry, Tx, TxInput, TxOutput, UtxoEntry, WitnessItem,
     ROTATION_V1_PRODUCTION_AT_MOST_ONE_DESCRIPTOR_ERR_STEM,
     ROTATION_V1_PRODUCTION_FINITE_H4_REQUIRED_ERR_STEM,
 };
@@ -3467,8 +3467,6 @@ fn main() {
                 let _ = serde_json::to_writer(std::io::stdout(), &resp);
                 return;
             }
-            let core_ext_deployments = CoreExtDeploymentProfiles::empty();
-
             let (rotation, registry) = match build_core_ext_suite_context(&req) {
                 Ok(v) => v,
                 Err(e) => {
@@ -3490,7 +3488,6 @@ fn main() {
                 prev_timestamps,
                 &mut state,
                 chain_id,
-                &core_ext_deployments,
                 rotation.as_ref().map(|rp| rp as &dyn RotationProvider),
                 registry.as_ref(),
             ) {
@@ -3799,8 +3796,6 @@ fn main() {
                     return;
                 }
             };
-            let core_ext_profiles = CoreExtProfiles::empty();
-
             let apply_result =
                 apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles_and_suite_context(
                     &tx,
@@ -3810,7 +3805,6 @@ fn main() {
                     req.block_timestamp,
                     block_mtp,
                     chain_id,
-                    &core_ext_profiles,
                     rotation.as_ref().map(|rp| rp as &dyn RotationProvider),
                     registry.as_ref(),
                 );

--- a/clients/rust/crates/rubin-consensus/src/connect_block_inmem.rs
+++ b/clients/rust/crates/rubin-consensus/src/connect_block_inmem.rs
@@ -8,7 +8,6 @@ use crate::block_basic::{
 };
 use crate::compactsize::encode_compact_size;
 use crate::constants::{COV_TYPE_ANCHOR, COV_TYPE_DA_COMMIT};
-use crate::core_ext::{CoreExtDeploymentProfiles, CoreExtProfiles};
 use crate::error::{ErrorCode, TxError};
 use crate::sig_queue::SigCheckQueue;
 use crate::subsidy::block_subsidy;
@@ -48,7 +47,6 @@ struct ConnectBlockContext<'a> {
     block_height: u64,
     prev_timestamps: Option<&'a [u64]>,
     chain_id: [u8; 32],
-    core_ext_deployments: &'a CoreExtDeploymentProfiles,
     rotation: Option<&'a dyn RotationProvider>,
     registry: Option<&'a SuiteRegistry>,
 }
@@ -58,7 +56,6 @@ struct PreparedConnectBlock {
     block_height: u64,
     already_generated: u128,
     block_mtp: u64,
-    core_ext_profiles: CoreExtProfiles,
 }
 
 /// ConnectBlockBasicInMemoryAtHeight connects a block against an in-memory chainstate and enforces
@@ -74,29 +71,6 @@ pub fn connect_block_basic_in_memory_at_height(
     state: &mut InMemoryChainState,
     chain_id: [u8; 32],
 ) -> Result<ConnectBlockBasicSummary, TxError> {
-    connect_block_basic_in_memory_at_height_and_core_ext_deployments(
-        block_bytes,
-        expected_prev_hash,
-        expected_target,
-        block_height,
-        prev_timestamps,
-        state,
-        chain_id,
-        &CoreExtDeploymentProfiles::empty(),
-    )
-}
-
-#[allow(clippy::too_many_arguments)]
-pub fn connect_block_basic_in_memory_at_height_and_core_ext_deployments(
-    block_bytes: &[u8],
-    expected_prev_hash: Option<[u8; 32]>,
-    expected_target: Option<[u8; 32]>,
-    block_height: u64,
-    prev_timestamps: Option<&[u64]>,
-    state: &mut InMemoryChainState,
-    chain_id: [u8; 32],
-    core_ext_deployments: &CoreExtDeploymentProfiles,
-) -> Result<ConnectBlockBasicSummary, TxError> {
     connect_block_basic_in_memory_at_height_and_core_ext_deployments_with_suite_context(
         block_bytes,
         expected_prev_hash,
@@ -105,7 +79,6 @@ pub fn connect_block_basic_in_memory_at_height_and_core_ext_deployments(
         prev_timestamps,
         state,
         chain_id,
-        core_ext_deployments,
         None,
         None,
     )
@@ -120,7 +93,6 @@ pub fn connect_block_basic_in_memory_at_height_and_core_ext_deployments_with_sui
     prev_timestamps: Option<&[u64]>,
     state: &mut InMemoryChainState,
     chain_id: [u8; 32],
-    core_ext_deployments: &CoreExtDeploymentProfiles,
     rotation: Option<&dyn RotationProvider>,
     registry: Option<&SuiteRegistry>,
 ) -> Result<ConnectBlockBasicSummary, TxError> {
@@ -130,7 +102,6 @@ pub fn connect_block_basic_in_memory_at_height_and_core_ext_deployments_with_sui
         block_height,
         prev_timestamps,
         chain_id,
-        core_ext_deployments,
         rotation,
         registry,
     };
@@ -151,31 +122,6 @@ pub fn connect_block_parallel_sig_verify(
     chain_id: [u8; 32],
     workers: usize,
 ) -> Result<ConnectBlockBasicSummary, TxError> {
-    connect_block_parallel_sig_verify_and_core_ext_deployments(
-        block_bytes,
-        expected_prev_hash,
-        expected_target,
-        block_height,
-        prev_timestamps,
-        state,
-        chain_id,
-        &CoreExtDeploymentProfiles::empty(),
-        workers,
-    )
-}
-
-#[allow(clippy::too_many_arguments)]
-pub fn connect_block_parallel_sig_verify_and_core_ext_deployments(
-    block_bytes: &[u8],
-    expected_prev_hash: Option<[u8; 32]>,
-    expected_target: Option<[u8; 32]>,
-    block_height: u64,
-    prev_timestamps: Option<&[u64]>,
-    state: &mut InMemoryChainState,
-    chain_id: [u8; 32],
-    core_ext_deployments: &CoreExtDeploymentProfiles,
-    workers: usize,
-) -> Result<ConnectBlockBasicSummary, TxError> {
     connect_block_parallel_sig_verify_and_core_ext_deployments_with_suite_context(
         block_bytes,
         expected_prev_hash,
@@ -184,7 +130,6 @@ pub fn connect_block_parallel_sig_verify_and_core_ext_deployments(
         prev_timestamps,
         state,
         chain_id,
-        core_ext_deployments,
         None,
         None,
         workers,
@@ -200,7 +145,6 @@ pub fn connect_block_parallel_sig_verify_and_core_ext_deployments_with_suite_con
     prev_timestamps: Option<&[u64]>,
     state: &mut InMemoryChainState,
     chain_id: [u8; 32],
-    core_ext_deployments: &CoreExtDeploymentProfiles,
     rotation: Option<&dyn RotationProvider>,
     registry: Option<&SuiteRegistry>,
     workers: usize,
@@ -211,7 +155,6 @@ pub fn connect_block_parallel_sig_verify_and_core_ext_deployments_with_suite_con
         block_height,
         prev_timestamps,
         chain_id,
-        core_ext_deployments,
         rotation,
         registry,
     };
@@ -239,19 +182,14 @@ fn prepare_connect_block(
         ));
     }
 
-    // 0x0102 (CORE_EXT) is unassigned with no activation path, so the retired
-    // deployment set must not influence consensus/admission for ordinary
-    // (e.g. P2PK) traffic. Do NOT call `active_profiles_at_height` here: it
-    // validates the deployment set and would reject otherwise-valid blocks if a
-    // node were started with a stale/invalid `core_ext_deployments` entry. Pass
-    // empty active profiles instead, mirroring Go, which ignores the parameter.
-    // The parameter is retained on the public signatures for node/CLI API
-    // compatibility; full removal is tracked under CORE_EXT retirement.
-    let _ = ctx.core_ext_deployments;
+    // 0x0102 (CORE_EXT) is unassigned with no activation path, so there is no
+    // CORE_EXT profile machinery on the connect-block path: 0x0102 is rejected
+    // by `check_spend_covenant`/`witness_slots` during input resolution for
+    // ordinary (e.g. P2PK) traffic. Matches Go, which carries no profile set on
+    // the connect-block path.
     Ok(PreparedConnectBlock {
         block_mtp: median_time_past(ctx.block_height, ctx.prev_timestamps)?
             .unwrap_or(pb.header.timestamp),
-        core_ext_profiles: CoreExtProfiles::default(),
         pb,
         block_height: ctx.block_height,
         already_generated,
@@ -286,7 +224,6 @@ fn apply_non_coinbase_txs_sequential(
                 prepared.pb.header.timestamp,
                 prepared.block_mtp,
                 ctx.chain_id,
-                &prepared.core_ext_profiles,
                 ctx.rotation,
                 ctx.registry,
             )?;
@@ -332,7 +269,6 @@ fn apply_non_coinbase_txs_parallel(
                 prepared.pb.header.timestamp,
                 prepared.block_mtp,
                 ctx.chain_id,
-                &prepared.core_ext_profiles,
                 ctx.rotation,
                 ctx.registry,
                 &mut sig_queue,

--- a/clients/rust/crates/rubin-consensus/src/core_ext.rs
+++ b/clients/rust/crates/rubin-consensus/src/core_ext.rs
@@ -56,23 +56,6 @@ pub struct CoreExtOpenSslDigest32BindingDescriptor {
 
 #[allow(unpredictable_function_pointer_comparisons)]
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct CoreExtActiveProfile {
-    pub ext_id: u16,
-    pub tx_context_enabled: bool,
-    pub allowed_suite_ids: Vec<u8>,
-    pub verification_binding: CoreExtVerificationBinding,
-    pub verify_sig_ext_tx_context_fn: Option<CoreExtVerifySigExtTxContextFn>,
-    pub binding_descriptor: Vec<u8>,
-    pub ext_payload_schema: Vec<u8>,
-}
-
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct CoreExtProfiles {
-    pub active: Vec<CoreExtActiveProfile>,
-}
-
-#[allow(unpredictable_function_pointer_comparisons)]
-#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CoreExtDeploymentProfile {
     pub ext_id: u16,
     pub activation_height: u64,
@@ -227,71 +210,6 @@ fn read_replay_token_u64(data: &[u8], offset: usize) -> Result<u64, String> {
     let mut raw = [0u8; 8];
     raw.copy_from_slice(bytes);
     Ok(u64::from_le_bytes(raw))
-}
-
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct CoreExtDeploymentProfiles {
-    pub deployments: Vec<CoreExtDeploymentProfile>,
-}
-
-impl CoreExtProfiles {
-    pub fn empty() -> Self {
-        Self { active: Vec::new() }
-    }
-}
-
-impl CoreExtDeploymentProfiles {
-    pub fn empty() -> Self {
-        Self {
-            deployments: Vec::new(),
-        }
-    }
-
-    pub fn validate(&self) -> Result<(), String> {
-        for deployment in &self.deployments {
-            if deployment.allowed_suite_ids.is_empty() {
-                return Err(format!(
-                    "core_ext deployment for ext_id={} must have non-empty allowed_suite_ids",
-                    deployment.ext_id
-                ));
-            }
-        }
-        Ok(())
-    }
-
-    pub fn active_profiles_at_height(&self, height: u64) -> Result<CoreExtProfiles, TxError> {
-        self.validate().map_err(|_| {
-            TxError::new(
-                ErrorCode::TxErrCovenantTypeInvalid,
-                "CORE_EXT active profile must have non-empty allowed_suite_ids",
-            )
-        })?;
-        let mut active = Vec::new();
-        for deployment in &self.deployments {
-            if height < deployment.activation_height {
-                continue;
-            }
-            if active
-                .iter()
-                .any(|profile: &CoreExtActiveProfile| profile.ext_id == deployment.ext_id)
-            {
-                return Err(TxError::new(
-                    ErrorCode::TxErrCovenantTypeInvalid,
-                    "CORE_EXT multiple ACTIVE profiles for ext_id",
-                ));
-            }
-            active.push(CoreExtActiveProfile {
-                ext_id: deployment.ext_id,
-                tx_context_enabled: deployment.tx_context_enabled,
-                allowed_suite_ids: deployment.allowed_suite_ids.clone(),
-                verification_binding: deployment.verification_binding.clone(),
-                verify_sig_ext_tx_context_fn: deployment.verify_sig_ext_tx_context_fn,
-                binding_descriptor: deployment.binding_descriptor.clone(),
-                ext_payload_schema: deployment.ext_payload_schema.clone(),
-            });
-        }
-        Ok(CoreExtProfiles { active })
-    }
 }
 
 fn normalized_allowed_suite_ids(ids: &[u8]) -> Vec<u8> {
@@ -732,84 +650,6 @@ mod tests {
         assert_eq!(desc.openssl_alg, "ML-DSA-87");
         assert_eq!(desc.pubkey_len, ML_DSA_87_PUBKEY_BYTES);
         assert_eq!(desc.sig_len, ML_DSA_87_SIG_BYTES);
-    }
-
-    #[test]
-    fn core_ext_deployments_activate_at_height() {
-        let deployments = CoreExtDeploymentProfiles {
-            deployments: vec![CoreExtDeploymentProfile {
-                ext_id: 7,
-                activation_height: 10,
-                tx_context_enabled: true,
-                allowed_suite_ids: vec![0x03],
-                verification_binding: CoreExtVerificationBinding::VerifySigExtAccept,
-                verify_sig_ext_tx_context_fn: None,
-                binding_descriptor: b"accept".to_vec(),
-                ext_payload_schema: b"schema".to_vec(),
-                governance_nonce: 0,
-            }],
-        };
-
-        let before = deployments.active_profiles_at_height(9).unwrap();
-        assert!(before.active.is_empty());
-
-        let active = deployments.active_profiles_at_height(10).unwrap();
-        assert_eq!(active.active.len(), 1);
-        assert_eq!(active.active[0].ext_id, 7);
-        assert!(active.active[0].tx_context_enabled);
-    }
-
-    #[test]
-    fn core_ext_deployments_empty_allowed_suite_ids_rejected_at_activation_lookup() {
-        let deployments = CoreExtDeploymentProfiles {
-            deployments: vec![CoreExtDeploymentProfile {
-                ext_id: 7,
-                activation_height: 10,
-                tx_context_enabled: false,
-                allowed_suite_ids: Vec::new(),
-                verification_binding: CoreExtVerificationBinding::NativeVerifySig,
-                verify_sig_ext_tx_context_fn: None,
-                binding_descriptor: Vec::new(),
-                ext_payload_schema: b"schema".to_vec(),
-                governance_nonce: 0,
-            }],
-        };
-
-        let err = deployments.active_profiles_at_height(10).unwrap_err();
-        assert_eq!(err.code, ErrorCode::TxErrCovenantTypeInvalid);
-    }
-
-    #[test]
-    fn core_ext_deployments_duplicate_active_rejected() {
-        let deployments = CoreExtDeploymentProfiles {
-            deployments: vec![
-                CoreExtDeploymentProfile {
-                    ext_id: 7,
-                    activation_height: 0,
-                    tx_context_enabled: false,
-                    allowed_suite_ids: vec![0x03],
-                    verification_binding: CoreExtVerificationBinding::VerifySigExtAccept,
-                    verify_sig_ext_tx_context_fn: None,
-                    binding_descriptor: b"accept".to_vec(),
-                    ext_payload_schema: b"schema-a".to_vec(),
-                    governance_nonce: 0,
-                },
-                CoreExtDeploymentProfile {
-                    ext_id: 7,
-                    activation_height: 0,
-                    tx_context_enabled: false,
-                    allowed_suite_ids: vec![0x04],
-                    verification_binding: CoreExtVerificationBinding::VerifySigExtReject,
-                    verify_sig_ext_tx_context_fn: None,
-                    binding_descriptor: b"reject".to_vec(),
-                    ext_payload_schema: b"schema-b".to_vec(),
-                    governance_nonce: 0,
-                },
-            ],
-        };
-
-        let err = deployments.active_profiles_at_height(0).unwrap_err();
-        assert_eq!(err.code, ErrorCode::TxErrCovenantTypeInvalid);
     }
 
     #[test]

--- a/clients/rust/crates/rubin-consensus/src/lib.rs
+++ b/clients/rust/crates/rubin-consensus/src/lib.rs
@@ -49,9 +49,8 @@ pub use compactsize::encode_compact_size;
 pub use compactsize::read_compact_size_bytes;
 pub use connect_block_inmem::{
     connect_block_basic_in_memory_at_height,
-    connect_block_basic_in_memory_at_height_and_core_ext_deployments,
     connect_block_basic_in_memory_at_height_and_core_ext_deployments_with_suite_context,
-    connect_block_parallel_sig_verify, connect_block_parallel_sig_verify_and_core_ext_deployments,
+    connect_block_parallel_sig_verify,
     connect_block_parallel_sig_verify_and_core_ext_deployments_with_suite_context,
     ConnectBlockBasicSummary, InMemoryChainState,
 };
@@ -64,8 +63,7 @@ pub use core_ext::{
     live_core_ext_verification_binding_from_normalized_name_and_descriptor,
     normalize_core_ext_binding_name, normalize_live_core_ext_binding_name,
     parse_core_ext_covenant_data, parse_core_ext_openssl_digest32_binding_descriptor,
-    CoreExtActiveProfile, CoreExtDeploymentProfile, CoreExtDeploymentProfiles,
-    CoreExtOpenSslDigest32BindingDescriptor, CoreExtProfiles, CoreExtVerificationBinding,
+    CoreExtDeploymentProfile, CoreExtOpenSslDigest32BindingDescriptor, CoreExtVerificationBinding,
     GovernanceReplayToken, CORE_EXT_BINDING_NAME_VERIFY_SIG_EXT_OPENSSL_DIGEST32_V1,
 };
 pub use covenant_genesis::validate_tx_covenants_genesis;
@@ -119,7 +117,6 @@ pub use txcontext::{
 pub use utxo_basic::{
     apply_non_coinbase_tx_basic, apply_non_coinbase_tx_basic_update,
     apply_non_coinbase_tx_basic_update_with_mtp,
-    apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles,
     apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles_and_suite_context,
     apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles_and_suite_context_deferred_sigchecks,
     apply_non_coinbase_tx_basic_with_mtp, Outpoint, UtxoApplySummary, UtxoEntry,

--- a/clients/rust/crates/rubin-consensus/src/tests/connect_block_parallel.rs
+++ b/clients/rust/crates/rubin-consensus/src/tests/connect_block_parallel.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::CoreExtProfiles;
 
 fn clone_state(
     utxos: &HashMap<Outpoint, UtxoEntry>,
@@ -603,7 +602,6 @@ fn apply_non_coinbase_tx_basic_update_deferred_sigchecks_matches_sequential() {
             0,
             0,
             ZERO_CHAIN_ID,
-            &CoreExtProfiles::empty(),
             None,
             None,
         )
@@ -618,7 +616,6 @@ fn apply_non_coinbase_tx_basic_update_deferred_sigchecks_matches_sequential() {
             0,
             0,
             ZERO_CHAIN_ID,
-            &CoreExtProfiles::empty(),
             None,
             None,
         )
@@ -663,7 +660,6 @@ fn apply_non_coinbase_tx_basic_update_deferred_sigchecks_missing_utxo_fails_befo
             0,
             0,
             ZERO_CHAIN_ID,
-            &CoreExtProfiles::empty(),
             None,
             None,
         )

--- a/clients/rust/crates/rubin-consensus/src/tests/connect_block_parallel_branches.rs
+++ b/clients/rust/crates/rubin-consensus/src/tests/connect_block_parallel_branches.rs
@@ -1,13 +1,11 @@
 use super::*;
 use crate::output_descriptor_bytes;
-use crate::CoreExtProfiles;
 
 fn deferred_apply(
     tx: &crate::tx::Tx,
     txid: [u8; 32],
     utxos: &HashMap<Outpoint, UtxoEntry>,
     height: u64,
-    profiles: &CoreExtProfiles,
 ) -> Result<(HashMap<Outpoint, UtxoEntry>, crate::UtxoApplySummary), crate::error::TxError> {
     crate::apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles_and_suite_context_deferred_sigchecks(
         tx,
@@ -17,7 +15,6 @@ fn deferred_apply(
         0,
         0,
         ZERO_CHAIN_ID,
-        profiles,
         None,
         None,
     )
@@ -116,9 +113,7 @@ fn apply_non_coinbase_tx_basic_workq_multisig_branch() {
         },
     )]);
 
-    let profiles = CoreExtProfiles::empty();
-    let (next_utxos, summary) =
-        deferred_apply(&tx, txid, &utxos, 1, &profiles).expect("multisig branch");
+    let (next_utxos, summary) = deferred_apply(&tx, txid, &utxos, 1).expect("multisig branch");
     assert_eq!(summary.fee, 100);
     assert_eq!(next_utxos.len(), 1);
 }
@@ -213,9 +208,7 @@ fn apply_non_coinbase_tx_basic_workq_htlc_claim_branch() {
         entry.clone(),
     )]);
 
-    let profiles = CoreExtProfiles::empty();
-    let (_next_utxos, summary) =
-        deferred_apply(&tx, txid, &utxos, 1, &profiles).expect("htlc claim branch");
+    let (_next_utxos, summary) = deferred_apply(&tx, txid, &utxos, 1).expect("htlc claim branch");
     assert_eq!(summary.fee, entry.value - 90);
 }
 
@@ -286,17 +279,13 @@ fn apply_non_coinbase_tx_basic_workq_stealth_branch() {
         },
     )]);
 
-    let profiles = CoreExtProfiles::empty();
-    let (next_utxos, summary) =
-        deferred_apply(&tx, txid, &utxos, 1, &profiles).expect("stealth branch");
+    let (next_utxos, summary) = deferred_apply(&tx, txid, &utxos, 1).expect("stealth branch");
     assert_eq!(summary.fee, 100);
     assert_eq!(next_utxos.len(), 1);
 }
 
 #[test]
 fn apply_non_coinbase_tx_basic_workq_error_paths() {
-    let profiles = CoreExtProfiles::empty();
-
     let err = deferred_apply(
         &crate::tx::Tx {
             version: 1,
@@ -313,7 +302,6 @@ fn apply_non_coinbase_tx_basic_workq_error_paths() {
         [0u8; 32],
         &HashMap::new(),
         0,
-        &profiles,
     )
     .unwrap_err();
     assert_eq!(err.code, ErrorCode::TxErrParse);
@@ -339,7 +327,6 @@ fn apply_non_coinbase_tx_basic_workq_error_paths() {
         [0u8; 32],
         &HashMap::new(),
         0,
-        &profiles,
     )
     .unwrap_err();
     assert_eq!(err.code, ErrorCode::TxErrTxNonceInvalid);
@@ -374,8 +361,7 @@ fn apply_non_coinbase_tx_basic_workq_error_paths() {
         ZERO_CHAIN_ID,
         &kp,
     )];
-    let err =
-        deferred_apply(&missing_utxo_tx, [0u8; 32], &HashMap::new(), 1, &profiles).unwrap_err();
+    let err = deferred_apply(&missing_utxo_tx, [0u8; 32], &HashMap::new(), 1).unwrap_err();
     assert_eq!(err.code, ErrorCode::TxErrMissingUtxo);
 
     let prev_txid = [0x24; 32];
@@ -425,7 +411,7 @@ fn apply_non_coinbase_tx_basic_workq_error_paths() {
             created_by_coinbase: false,
         },
     )]);
-    let err = deferred_apply(&duplicate_input_tx, [0u8; 32], &utxos, 1, &profiles).unwrap_err();
+    let err = deferred_apply(&duplicate_input_tx, [0u8; 32], &utxos, 1).unwrap_err();
     assert_eq!(err.code, ErrorCode::TxErrParse);
 
     let immature_utxos = HashMap::from([(
@@ -469,8 +455,7 @@ fn apply_non_coinbase_tx_basic_workq_error_paths() {
         ZERO_CHAIN_ID,
         &kp,
     )];
-    let err =
-        deferred_apply(&mature_check_tx, [0u8; 32], &immature_utxos, 50, &profiles).unwrap_err();
+    let err = deferred_apply(&mature_check_tx, [0u8; 32], &immature_utxos, 50).unwrap_err();
     assert_eq!(err.code, ErrorCode::TxErrCoinbaseImmature);
 }
 
@@ -617,9 +602,7 @@ fn apply_non_coinbase_tx_basic_workq_vault_spend_ok() {
         ),
     ]);
 
-    let profiles = CoreExtProfiles::empty();
-    let (next_utxos, summary) =
-        deferred_apply(&tx, txid, &utxos, 200, &profiles).expect("vault spend");
+    let (next_utxos, summary) = deferred_apply(&tx, txid, &utxos, 200).expect("vault spend");
     assert_eq!(summary.fee, 10);
     assert_eq!(next_utxos.len(), 1);
 }
@@ -671,9 +654,7 @@ fn apply_non_coinbase_tx_basic_workq_vault_creation_ok() {
         },
     )]);
 
-    let profiles = CoreExtProfiles::empty();
-    let (next_utxos, summary) =
-        deferred_apply(&tx, txid, &utxos, 200, &profiles).expect("vault creation");
+    let (next_utxos, summary) = deferred_apply(&tx, txid, &utxos, 200).expect("vault creation");
     assert_eq!(summary.fee, 10);
     assert_eq!(next_utxos.len(), 1);
 }
@@ -753,9 +734,7 @@ fn apply_non_coinbase_tx_basic_workq_vault_error_paths() {
             },
         ),
     ]);
-    let profiles = CoreExtProfiles::empty();
-    let err =
-        deferred_apply(&forbidden_output_tx, [0u8; 32], &base_utxos, 200, &profiles).unwrap_err();
+    let err = deferred_apply(&forbidden_output_tx, [0u8; 32], &base_utxos, 200).unwrap_err();
     assert_eq!(err.code, ErrorCode::TxErrVaultOutputNotWhitelisted);
 
     let sponsor_kp = kp_or_skip!();
@@ -841,8 +820,7 @@ fn apply_non_coinbase_tx_basic_workq_vault_error_paths() {
             },
         ),
     ]);
-    let err =
-        deferred_apply(&fee_sponsor_tx, [0u8; 32], &sponsor_utxos, 200, &profiles).unwrap_err();
+    let err = deferred_apply(&fee_sponsor_tx, [0u8; 32], &sponsor_utxos, 200).unwrap_err();
     assert_eq!(err.code, ErrorCode::TxErrVaultFeeSponsorForbidden);
 
     let outsider_kp = kp_or_skip!();
@@ -856,8 +834,7 @@ fn apply_non_coinbase_tx_basic_workq_vault_error_paths() {
         sign_input_witness(&not_whitelisted_tx, 0, 100, ZERO_CHAIN_ID, &vault_kp),
         sign_input_witness(&not_whitelisted_tx, 1, 10, ZERO_CHAIN_ID, &owner_kp),
     ];
-    let err =
-        deferred_apply(&not_whitelisted_tx, [0u8; 32], &base_utxos, 200, &profiles).unwrap_err();
+    let err = deferred_apply(&not_whitelisted_tx, [0u8; 32], &base_utxos, 200).unwrap_err();
     assert_eq!(err.code, ErrorCode::TxErrVaultOutputNotWhitelisted);
 
     let input_kp = kp_or_skip!();
@@ -906,14 +883,8 @@ fn apply_non_coinbase_tx_basic_workq_vault_error_paths() {
             created_by_coinbase: false,
         },
     )]);
-    let err = deferred_apply(
-        &creation_missing_owner_tx,
-        [0u8; 32],
-        &creation_utxos,
-        200,
-        &profiles,
-    )
-    .unwrap_err();
+    let err =
+        deferred_apply(&creation_missing_owner_tx, [0u8; 32], &creation_utxos, 200).unwrap_err();
     assert_eq!(err.code, ErrorCode::TxErrVaultOwnerAuthRequired);
 
     // A CORE_EXT (0x0102) destination output is UNASSIGNED and rejected by the
@@ -928,14 +899,7 @@ fn apply_non_coinbase_tx_basic_workq_vault_error_paths() {
         sign_input_witness(&disallowed_destination_tx, 0, 100, ZERO_CHAIN_ID, &vault_kp),
         sign_input_witness(&disallowed_destination_tx, 1, 10, ZERO_CHAIN_ID, &owner_kp),
     ];
-    let err = deferred_apply(
-        &disallowed_destination_tx,
-        [0u8; 32],
-        &base_utxos,
-        200,
-        &profiles,
-    )
-    .unwrap_err();
+    let err = deferred_apply(&disallowed_destination_tx, [0u8; 32], &base_utxos, 200).unwrap_err();
     assert_eq!(err.code, ErrorCode::TxErrCovenantTypeInvalid);
 }
 
@@ -989,7 +953,7 @@ fn apply_non_coinbase_tx_basic_workq_core_ext_0x0102_rejects() {
         },
     )]);
 
-    let err = deferred_apply(&tx, txid, &ext_utxos, 1, &CoreExtProfiles::empty()).unwrap_err();
+    let err = deferred_apply(&tx, txid, &ext_utxos, 1).unwrap_err();
     assert_eq!(err.code, ErrorCode::TxErrCovenantTypeInvalid);
 }
 
@@ -1042,9 +1006,7 @@ fn apply_non_coinbase_tx_basic_workq_anchor_output_skip() {
         },
     )]);
 
-    let profiles = CoreExtProfiles::empty();
-    let (next_utxos, summary) =
-        deferred_apply(&tx, txid, &utxos, 1, &profiles).expect("anchor output skip");
+    let (next_utxos, summary) = deferred_apply(&tx, txid, &utxos, 1).expect("anchor output skip");
     assert_eq!(summary.fee, 10);
     assert_eq!(next_utxos.len(), 1);
     assert!(!next_utxos.contains_key(&Outpoint { txid, vout: 1 }));
@@ -1093,9 +1055,7 @@ fn apply_wrapper() {
         )]);
         (tx, utxos, [0x71; 32])
     };
-    let profiles = CoreExtProfiles::empty();
-    let (next_utxos, summary) =
-        deferred_apply(&tx, txid, &utxo_set, 1, &profiles).expect("wrapper success");
+    let (next_utxos, summary) = deferred_apply(&tx, txid, &utxo_set, 1).expect("wrapper success");
     assert_eq!(summary.fee, 10);
     assert_eq!(next_utxos.len(), 1);
 
@@ -1115,7 +1075,6 @@ fn apply_wrapper() {
         [0u8; 32],
         &HashMap::new(),
         0,
-        &profiles,
     )
     .unwrap_err();
     assert_eq!(err.code, ErrorCode::TxErrParse);
@@ -1162,8 +1121,7 @@ fn apply_non_coinbase_tx_basic_workq_covenant_genesis_error() {
         },
     )]);
 
-    let profiles = CoreExtProfiles::empty();
-    let err = deferred_apply(&tx, [0u8; 32], &utxos, 1, &profiles).unwrap_err();
+    let err = deferred_apply(&tx, [0u8; 32], &utxos, 1).unwrap_err();
     assert_eq!(err.code, ErrorCode::TxErrCovenantTypeInvalid);
 }
 
@@ -1209,8 +1167,7 @@ fn apply_non_coinbase_tx_basic_workq_sighash_prehash_error() {
         },
     )]);
 
-    let profiles = CoreExtProfiles::empty();
-    let err = deferred_apply(&tx, [0u8; 32], &utxos, 1, &profiles).unwrap_err();
+    let err = deferred_apply(&tx, [0u8; 32], &utxos, 1).unwrap_err();
     assert_eq!(err.code, ErrorCode::TxErrParse);
 }
 
@@ -1255,8 +1212,7 @@ fn apply_non_coinbase_tx_basic_workq_check_spend_covenant_error() {
         },
     )]);
 
-    let profiles = CoreExtProfiles::empty();
-    let err = deferred_apply(&tx, [0u8; 32], &utxos, 1, &profiles).unwrap_err();
+    let err = deferred_apply(&tx, [0u8; 32], &utxos, 1).unwrap_err();
     assert_eq!(err.code, ErrorCode::TxErrVaultMalformed);
 }
 
@@ -1304,7 +1260,6 @@ fn apply_non_coinbase_tx_basic_workq_p2pk_spend_q_error() {
         },
     )]);
 
-    let profiles = CoreExtProfiles::empty();
-    let err = deferred_apply(&tx, [0u8; 32], &utxos, 1, &profiles).unwrap_err();
+    let err = deferred_apply(&tx, [0u8; 32], &utxos, 1).unwrap_err();
     assert_eq!(err.code, ErrorCode::TxErrSigAlgInvalid);
 }

--- a/clients/rust/crates/rubin-consensus/src/tests/tx_validate_worker.rs
+++ b/clients/rust/crates/rubin-consensus/src/tests/tx_validate_worker.rs
@@ -3,7 +3,6 @@ use std::collections::HashMap;
 use crate::block::{BlockHeader, BLOCK_HEADER_BYTES};
 use crate::block_basic::ParsedBlock;
 use crate::constants::*;
-use crate::core_ext::CoreExtProfiles;
 use crate::error::ErrorCode;
 use crate::hash::sha3_256;
 use crate::precompute::{precompute_tx_contexts, PrecomputedTxContext};
@@ -161,8 +160,7 @@ fn validate_tx_local_witness_underflow() {
     // Corrupt witness_end so the worker sees fewer witness items than needed.
     ptcs[0].witness_end = ptcs[0].witness_start;
 
-    let profiles = CoreExtProfiles::empty();
-    let r = validate_tx_local(&ptcs[0], &pb, [0u8; 32], 100, 0, &profiles, None);
+    let r = validate_tx_local(&ptcs[0], &pb, [0u8; 32], 100, 0, None);
     assert!(!r.valid);
     assert!(r.err.is_some());
     let err = r.err.unwrap();
@@ -186,8 +184,7 @@ fn validate_tx_local_witness_count_mismatch() {
         input_outpoints: vec![],
         fee: 0,
     };
-    let profiles = CoreExtProfiles::empty();
-    let r = validate_tx_local(&ptc, &pb, [0u8; 32], 100, 0, &profiles, None);
+    let r = validate_tx_local(&ptc, &pb, [0u8; 32], 100, 0, None);
     assert!(!r.valid);
     assert!(r.err.is_some());
     let err = r.err.unwrap();
@@ -200,8 +197,7 @@ fn validate_tx_local_fee_and_index_preserved() {
     let tx = simple_p2pk_tx(0x42);
     let (pb, ptcs, _snap) = precompute_single_tx(tx, 100, 100);
 
-    let profiles = CoreExtProfiles::empty();
-    let r = validate_tx_local(&ptcs[0], &pb, [0u8; 32], 100, 0, &profiles, None);
+    let r = validate_tx_local(&ptcs[0], &pb, [0u8; 32], 100, 0, None);
     // Note: this test will likely fail at signature verification (dummy witness
     // won't pass ML-DSA verify) — we're testing that fee/index are set correctly
     // before any validation error is returned.
@@ -226,8 +222,7 @@ fn validate_tx_local_default_covenant_passthrough() {
         input_outpoints: vec![],
         fee: 0,
     };
-    let profiles = CoreExtProfiles::empty();
-    let r = validate_tx_local(&ptc, &pb, [0u8; 32], 100, 0, &profiles, None);
+    let r = validate_tx_local(&ptc, &pb, [0u8; 32], 100, 0, None);
     assert!(r.valid);
     assert!(r.err.is_none());
 }
@@ -240,8 +235,7 @@ fn validate_tx_local_p2pk_dispatch_enters_branch() {
     let tx = simple_p2pk_tx(0x42);
     let (pb, ptcs, _snap) = precompute_single_tx(tx, 100, 100);
 
-    let profiles = CoreExtProfiles::empty();
-    let r = validate_tx_local(&ptcs[0], &pb, [0u8; 32], 100, 0, &profiles, None);
+    let r = validate_tx_local(&ptcs[0], &pb, [0u8; 32], 100, 0, None);
     // Dummy sig will fail at ML-DSA verify but the P2PK branch was entered.
     // Dummy sig will fail ML-DSA verify but the P2PK branch was entered.
     // We only care that the path was exercised, not that it passed.
@@ -290,8 +284,7 @@ fn validate_tx_local_multisig_dispatch_enters_branch() {
         }],
         fee: 10,
     };
-    let profiles = CoreExtProfiles::empty();
-    let r = validate_tx_local(&ptc, &pb, [0u8; 32], 100, 0, &profiles, None);
+    let r = validate_tx_local(&ptc, &pb, [0u8; 32], 100, 0, None);
     // Will fail at sig verify but MULTISIG branch was entered.
     assert_eq!(r.tx_index, 1);
     assert_eq!(r.fee, 10);
@@ -338,8 +331,7 @@ fn validate_tx_local_vault_dispatch_enters_branch() {
         }],
         fee: 10,
     };
-    let profiles = CoreExtProfiles::empty();
-    let r = validate_tx_local(&ptc, &pb, [0u8; 32], 100, 0, &profiles, None);
+    let r = validate_tx_local(&ptc, &pb, [0u8; 32], 100, 0, None);
     assert_eq!(r.tx_index, 1);
 }
 
@@ -374,8 +366,7 @@ fn validate_tx_local_htlc_dispatch_enters_branch() {
         }],
         fee: 10,
     };
-    let profiles = CoreExtProfiles::empty();
-    let r = validate_tx_local(&ptc, &pb, [0u8; 32], 100, 0, &profiles, None);
+    let r = validate_tx_local(&ptc, &pb, [0u8; 32], 100, 0, None);
     assert_eq!(r.tx_index, 1);
 }
 
@@ -407,15 +398,15 @@ fn validate_tx_local_unknown_covenant_witness_slots_error() {
         }],
         fee: 10,
     };
-    let profiles = CoreExtProfiles::empty();
-    let r = validate_tx_local(&ptc, &pb, [0u8; 32], 100, 0, &profiles, None);
+    let r = validate_tx_local(&ptc, &pb, [0u8; 32], 100, 0, None);
     assert!(!r.valid);
     assert!(r.err.is_some());
     assert_eq!(r.err.unwrap().code, ErrorCode::TxErrCovenantTypeInvalid);
 }
 
-/// Covers build_tx_context_if_needed error path (lines 89-91) when CORE_EXT
-/// input has malformed data that causes collect_txcontext_ext_ids to fail.
+/// A CORE_EXT (0x0102) input with malformed covenant data is rejected during
+/// worker spend dispatch (`witness_slots` -> TxErrCovenantTypeInvalid), since
+/// 0x0102 is UNASSIGNED. No CORE_EXT profile machinery is involved.
 #[test]
 fn validate_tx_local_ext_context_build_error() {
     let mut tx = simple_p2pk_tx(0x42);
@@ -425,23 +416,6 @@ fn validate_tx_local_ext_context_build_error() {
     prev_txid[0] = 0x42;
 
     let pb = make_parsed_block(simple_coinbase(), vec![tx]);
-
-    // Build a CORE_EXT profile that will cause collect_txcontext_ext_ids to
-    // try to parse the covenant data. With truncated/empty data this should
-    // return an error during context building.
-    use crate::core_ext::{CoreExtActiveProfile, CoreExtProfiles, CoreExtVerificationBinding};
-    let active_profile = CoreExtActiveProfile {
-        ext_id: 1,
-        tx_context_enabled: true,
-        allowed_suite_ids: vec![SUITE_ID_ML_DSA_87],
-        verification_binding: CoreExtVerificationBinding::VerifySigExtAccept,
-        verify_sig_ext_tx_context_fn: None,
-        binding_descriptor: vec![],
-        ext_payload_schema: vec![],
-    };
-    let profiles = CoreExtProfiles {
-        active: vec![active_profile],
-    };
 
     let ptc = PrecomputedTxContext {
         tx_index: 1,
@@ -462,7 +436,7 @@ fn validate_tx_local_ext_context_build_error() {
         }],
         fee: 10,
     };
-    let r = validate_tx_local(&ptc, &pb, [0u8; 32], 100, 0, &profiles, None);
+    let r = validate_tx_local(&ptc, &pb, [0u8; 32], 100, 0, None);
     assert!(!r.valid);
     assert!(r.err.is_some());
 }
@@ -528,15 +502,14 @@ fn validate_tx_local_real_signature_full_path() {
     let pb = make_parsed_block(simple_coinbase(), vec![tx]);
     let ptcs = precompute_tx_contexts(&pb, &utxo_map, 100).unwrap();
 
-    let profiles = CoreExtProfiles::empty();
-    let r = validate_tx_local(&ptcs[0], &pb, [0u8; 32], 100, 0, &profiles, None);
+    let r = validate_tx_local(&ptcs[0], &pb, [0u8; 32], 100, 0, None);
     assert!(r.valid, "expected valid tx, got err: {:?}", r.err);
     assert!(r.err.is_none());
     assert_eq!(r.sig_count, 1);
     assert_eq!(r.fee, 10); // 100 - 90
 
     let cache = SigCache::new(100);
-    let cached_first = validate_tx_local(&ptcs[0], &pb, [0u8; 32], 100, 0, &profiles, Some(&cache));
+    let cached_first = validate_tx_local(&ptcs[0], &pb, [0u8; 32], 100, 0, Some(&cache));
     assert!(
         cached_first.valid,
         "expected cached first run to pass: {:?}",
@@ -544,8 +517,7 @@ fn validate_tx_local_real_signature_full_path() {
     );
     assert_eq!(cache.hits(), 0);
 
-    let cached_second =
-        validate_tx_local(&ptcs[0], &pb, [0u8; 32], 100, 0, &profiles, Some(&cache));
+    let cached_second = validate_tx_local(&ptcs[0], &pb, [0u8; 32], 100, 0, Some(&cache));
     assert!(
         cached_second.valid,
         "expected cached second run to pass: {:?}",
@@ -606,8 +578,7 @@ fn validate_tx_local_stealth_valid() {
         fee: 10,
     };
 
-    let profiles = CoreExtProfiles::empty();
-    let result = validate_tx_local(&ptc, &pb, [0u8; 32], 100, 0, &profiles, None);
+    let result = validate_tx_local(&ptc, &pb, [0u8; 32], 100, 0, None);
     assert!(result.valid, "expected valid, got {:?}", result.err);
     assert!(result.err.is_none());
     assert_eq!(result.sig_count, 1);
@@ -642,7 +613,7 @@ fn validate_tx_local_core_ext_0x0102_rejects_unassigned() {
         fee: 10,
     };
 
-    let result = validate_tx_local(&ptc, &pb, [0u8; 32], 1, 0, &CoreExtProfiles::empty(), None);
+    let result = validate_tx_local(&ptc, &pb, [0u8; 32], 1, 0, None);
     assert!(!result.valid);
     assert_eq!(
         result.err.unwrap().code,
@@ -707,7 +678,6 @@ fn run_tx_validation_workers_with_sig_cache_reuses_positive_result() {
     let pb = make_parsed_block(simple_coinbase(), vec![tx]);
     let ptcs = precompute_tx_contexts(&pb, &utxo_map, 100).unwrap();
     let token = WorkerCancellationToken::new();
-    let profiles = CoreExtProfiles::empty();
     let cache = SigCache::new(100);
 
     let first = run_tx_validation_workers(
@@ -718,7 +688,6 @@ fn run_tx_validation_workers_with_sig_cache_reuses_positive_result() {
         [0u8; 32],
         100,
         0,
-        &profiles,
         Some(cache.clone()),
     )
     .unwrap();
@@ -730,18 +699,9 @@ fn run_tx_validation_workers_with_sig_cache_reuses_positive_result() {
     );
     assert_eq!(cache.hits(), 0);
 
-    let second = run_tx_validation_workers(
-        &token,
-        1,
-        ptcs,
-        &pb,
-        [0u8; 32],
-        100,
-        0,
-        &profiles,
-        Some(cache.clone()),
-    )
-    .unwrap();
+    let second =
+        run_tx_validation_workers(&token, 1, ptcs, &pb, [0u8; 32], 100, 0, Some(cache.clone()))
+            .unwrap();
     assert_eq!(second.len(), 1);
     assert!(
         second[0].error.is_none(),
@@ -758,10 +718,7 @@ fn validate_tx_local_worker_pool_closure() {
     let (pb, ptcs, _snap) = precompute_single_tx(tx, 100, 100);
 
     let token = WorkerCancellationToken::new();
-    let profiles = CoreExtProfiles::empty();
-    let results =
-        run_tx_validation_workers(&token, 2, ptcs, &pb, [0u8; 32], 100, 0, &profiles, None)
-            .unwrap();
+    let results = run_tx_validation_workers(&token, 2, ptcs, &pb, [0u8; 32], 100, 0, None).unwrap();
     assert_eq!(results.len(), 1);
     // The result will have an error (dummy sig) but the worker was exercised.
     assert!(results[0].error.is_some() || results[0].value.is_some());
@@ -774,11 +731,8 @@ fn validate_tx_local_worker_pool_closure() {
 #[test]
 fn run_tx_validation_workers_empty() {
     let token = WorkerCancellationToken::new();
-    let profiles = CoreExtProfiles::empty();
     let pb = make_parsed_block(simple_coinbase(), vec![]);
-    let results =
-        run_tx_validation_workers(&token, 4, vec![], &pb, [0u8; 32], 1, 0, &profiles, None)
-            .unwrap();
+    let results = run_tx_validation_workers(&token, 4, vec![], &pb, [0u8; 32], 1, 0, None).unwrap();
     assert!(results.is_empty());
 }
 
@@ -790,10 +744,7 @@ fn run_tx_validation_workers_cancelled_token() {
     let token = WorkerCancellationToken::new();
     token.cancel(); // pre-cancel
 
-    let profiles = CoreExtProfiles::empty();
-    let results =
-        run_tx_validation_workers(&token, 2, ptcs, &pb, [0u8; 32], 100, 0, &profiles, None)
-            .unwrap();
+    let results = run_tx_validation_workers(&token, 2, ptcs, &pb, [0u8; 32], 100, 0, None).unwrap();
     assert_eq!(results.len(), 1);
     assert!(results[0].error.is_some());
     match &results[0].error {
@@ -859,11 +810,9 @@ fn run_tx_validation_workers_valid_p2pk_real_signature() {
     let pb = make_parsed_block(simple_coinbase(), vec![tx]);
     let ptcs = precompute_tx_contexts(&pb, &utxo_map, 100).expect("precompute");
     let token = WorkerCancellationToken::new();
-    let profiles = CoreExtProfiles::empty();
 
-    let results =
-        run_tx_validation_workers(&token, 2, ptcs, &pb, [0u8; 32], 100, 0, &profiles, None)
-            .expect("run workers");
+    let results = run_tx_validation_workers(&token, 2, ptcs, &pb, [0u8; 32], 100, 0, None)
+        .expect("run workers");
     assert_eq!(results.len(), 1);
     assert!(
         results[0].error.is_none(),

--- a/clients/rust/crates/rubin-consensus/src/tx_validate_worker.rs
+++ b/clients/rust/crates/rubin-consensus/src/tx_validate_worker.rs
@@ -3,7 +3,6 @@ use crate::constants::{
     CORE_STEALTH_WITNESS_SLOTS, COV_TYPE_CORE_STEALTH, COV_TYPE_HTLC, COV_TYPE_MULTISIG,
     COV_TYPE_P2PK, COV_TYPE_VAULT,
 };
-use crate::core_ext::CoreExtProfiles;
 use crate::error::{ErrorCode, TxError};
 use crate::htlc::{validate_htlc_spend_q, HtlcSpendContext};
 use crate::precompute::PrecomputedTxContext;
@@ -137,21 +136,17 @@ fn build_tx_local_preflight(tx: &Tx) -> Result<SighashV1PrehashCache<'_>, TxErro
 /// Vault inputs: only the threshold signature is verified here. Full vault
 /// policy (whitelist, owner lock, output rules) is enforced in the sequential
 /// commit stage, which has access to block-level context.
-#[allow(clippy::too_many_arguments)]
 pub fn validate_tx_local(
     ptc: &PrecomputedTxContext,
     pb: &ParsedBlock,
     chain_id: [u8; 32],
     block_height: u64,
     block_mtp: u64,
-    core_ext_profiles: &CoreExtProfiles,
     sig_cache: Option<&SigCache>,
 ) -> TxValidationResult {
     // COV_TYPE_CORE_EXT (0x0102) is UNASSIGNED and rejected by `witness_slots`
     // (TxErrCovenantTypeInvalid) before any spend dispatch, so no CORE_EXT
-    // profile gating runs here. `core_ext_profiles` is retained in the public
-    // signature for node/connect_block callers but carries no behavior.
-    let _ = core_ext_profiles;
+    // profile gating runs here.
     let tx = &pb.txs[ptc.tx_block_idx];
 
     let mut sighash_cache = match build_tx_local_preflight(tx) {
@@ -340,7 +335,6 @@ pub fn run_tx_validation_workers(
     chain_id: [u8; 32],
     block_height: u64,
     block_mtp: u64,
-    core_ext_profiles: &CoreExtProfiles,
     sig_cache: Option<SigCache>,
 ) -> Result<Vec<WorkerResult<TxValidationResult, TxError>>, WorkerPoolRunError> {
     let max_tasks = ptcs.len();
@@ -354,7 +348,6 @@ pub fn run_tx_validation_workers(
             chain_id,
             block_height,
             block_mtp,
-            core_ext_profiles,
             sig_cache.as_ref(),
         );
         if let Some(ref e) = r.err {

--- a/clients/rust/crates/rubin-consensus/src/utxo_basic.rs
+++ b/clients/rust/crates/rubin-consensus/src/utxo_basic.rs
@@ -5,7 +5,6 @@ use crate::constants::{
     COINBASE_MATURITY, COV_TYPE_ANCHOR, COV_TYPE_CORE_STEALTH, COV_TYPE_DA_COMMIT, COV_TYPE_HTLC,
     COV_TYPE_MULTISIG, COV_TYPE_P2PK, COV_TYPE_VAULT,
 };
-use crate::core_ext::CoreExtProfiles;
 use crate::covenant_genesis::validate_tx_covenants_genesis;
 use crate::error::{ErrorCode, TxError};
 use crate::hash::sha3_256;
@@ -50,7 +49,6 @@ struct UtxoApplyImplContext<'a> {
     block_timestamp: u64,
     block_mtp: u64,
     chain_id: [u8; 32],
-    core_ext_profiles_at_height: &'a CoreExtProfiles,
     rotation: Option<&'a dyn RotationProvider>,
     registry: Option<&'a SuiteRegistry>,
 }
@@ -83,29 +81,6 @@ pub fn apply_non_coinbase_tx_basic_update_with_mtp(
     block_mtp: u64,
     chain_id: [u8; 32],
 ) -> Result<(HashMap<Outpoint, UtxoEntry>, UtxoApplySummary), TxError> {
-    apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles(
-        tx,
-        txid,
-        utxo_set,
-        height,
-        block_timestamp,
-        block_mtp,
-        chain_id,
-        &CoreExtProfiles::empty(),
-    )
-}
-
-#[allow(clippy::too_many_arguments)]
-pub fn apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles(
-    tx: &Tx,
-    txid: [u8; 32],
-    utxo_set: &HashMap<Outpoint, UtxoEntry>,
-    height: u64,
-    block_timestamp: u64,
-    block_mtp: u64,
-    chain_id: [u8; 32],
-    core_ext_profiles_at_height: &CoreExtProfiles,
-) -> Result<(HashMap<Outpoint, UtxoEntry>, UtxoApplySummary), TxError> {
     apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles_and_suite_context(
         tx,
         txid,
@@ -114,7 +89,6 @@ pub fn apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles(
         block_timestamp,
         block_mtp,
         chain_id,
-        core_ext_profiles_at_height,
         None,
         None,
     )
@@ -129,7 +103,6 @@ pub fn apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles_and_sui
     block_timestamp: u64,
     block_mtp: u64,
     chain_id: [u8; 32],
-    core_ext_profiles_at_height: &CoreExtProfiles,
     rotation: Option<&dyn RotationProvider>,
     registry: Option<&SuiteRegistry>,
 ) -> Result<(HashMap<Outpoint, UtxoEntry>, UtxoApplySummary), TxError> {
@@ -142,7 +115,6 @@ pub fn apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles_and_sui
             block_timestamp,
             block_mtp,
             chain_id,
-            core_ext_profiles_at_height,
             rotation,
             registry,
         },
@@ -159,7 +131,6 @@ pub(crate) fn apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles_
     block_timestamp: u64,
     block_mtp: u64,
     chain_id: [u8; 32],
-    core_ext_profiles_at_height: &CoreExtProfiles,
     rotation: Option<&dyn RotationProvider>,
     registry: Option<&SuiteRegistry>,
     sig_queue: &mut SigCheckQueue,
@@ -173,7 +144,6 @@ pub(crate) fn apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles_
             block_timestamp,
             block_mtp,
             chain_id,
-            core_ext_profiles_at_height,
             rotation,
             registry,
         },
@@ -190,26 +160,23 @@ pub fn apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles_and_sui
     block_timestamp: u64,
     block_mtp: u64,
     chain_id: [u8; 32],
-    core_ext_profiles_at_height: &CoreExtProfiles,
     rotation: Option<&dyn RotationProvider>,
     registry: Option<&SuiteRegistry>,
 ) -> Result<(HashMap<Outpoint, UtxoEntry>, UtxoApplySummary), TxError> {
     let mut sig_queue = SigCheckQueue::new(1);
     let queue_mark = sig_queue.mark();
-    let result =
-        apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles_and_suite_context_queued_sigchecks(
-            tx,
-            txid,
-            utxo_set,
-            height,
-            block_timestamp,
-            block_mtp,
-            chain_id,
-            core_ext_profiles_at_height,
-            rotation,
-            registry,
-            &mut sig_queue,
-        );
+    let result = apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles_and_suite_context_queued_sigchecks(
+        tx,
+        txid,
+        utxo_set,
+        height,
+        block_timestamp,
+        block_mtp,
+        chain_id,
+        rotation,
+        registry,
+        &mut sig_queue,
+    );
     let (work, summary) = match result {
         Ok(ok) => ok,
         Err(err) => {
@@ -233,7 +200,6 @@ fn apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles_and_suite_c
         block_timestamp,
         block_mtp,
         chain_id,
-        core_ext_profiles_at_height,
         rotation,
         registry,
     } = ctx;
@@ -361,9 +327,6 @@ fn apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles_and_suite_c
     // COV_TYPE_CORE_EXT (0x0102) is UNASSIGNED and already rejected by
     // `check_spend_covenant`/`witness_slots` (TxErrCovenantTypeInvalid) during
     // input resolution above, so no CORE_EXT profile gating runs here.
-    // `core_ext_profiles_at_height` is retained in the public signatures for
-    // node/connect_block callers but carries no behavior.
-    let _ = core_ext_profiles_at_height;
 
     for (input_index, ((entry, assigned_range), op)) in resolved_inputs
         .iter()
@@ -771,16 +734,7 @@ mod tests {
         );
         let create_err =
             apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles_and_suite_context(
-                &create_tx,
-                txid,
-                &funding,
-                1,
-                0,
-                0,
-                chain_id,
-                &CoreExtProfiles::empty(),
-                None,
-                None,
+                &create_tx, txid, &funding, 1, 0, 0, chain_id, None, None,
             )
             .expect_err("0x0102 creation must reject");
         assert_eq!(create_err.code, ErrorCode::TxErrCovenantTypeInvalid);
@@ -817,7 +771,6 @@ mod tests {
                 0,
                 0,
                 spend_chain,
-                &CoreExtProfiles::empty(),
                 None,
                 None,
             )
@@ -1280,16 +1233,7 @@ mod tests {
         let original = utxo_set.clone();
         let (_work, summary) =
             apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles_and_suite_context(
-                tx,
-                txid,
-                utxo_set,
-                200,
-                1_000,
-                1_000,
-                chain_id,
-                &CoreExtProfiles::empty(),
-                None,
-                None,
+                tx, txid, utxo_set, 200, 1_000, 1_000, chain_id, None, None,
             )
             .expect("apply");
         assert!(summary.fee > 0);
@@ -1302,32 +1246,15 @@ mod tests {
 
         let sequential =
             apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles_and_suite_context(
-                &tx,
-                txid,
-                &utxo_set,
-                1,
-                0,
-                0,
-                chain_id,
-                &CoreExtProfiles::empty(),
-                None,
-                None,
+                &tx, txid, &utxo_set, 1, 0, 0, chain_id, None, None,
             )
             .expect("sequential apply");
 
-        let deferred = apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles_and_suite_context_deferred_sigchecks(
-            &tx,
-            txid,
-            &utxo_set,
-            1,
-            0,
-            0,
-            chain_id,
-            &CoreExtProfiles::empty(),
-            None,
-            None,
-        )
-        .expect("deferred apply");
+        let deferred =
+            apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles_and_suite_context_deferred_sigchecks(
+                &tx, txid, &utxo_set, 1, 0, 0, chain_id, None, None,
+            )
+            .expect("deferred apply");
 
         assert_eq!(deferred, sequential);
     }
@@ -1380,16 +1307,7 @@ mod tests {
         tx.witness[0].signature[0] ^= 0x01;
 
         let err = apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles_and_suite_context_deferred_sigchecks(
-            &tx,
-            txid,
-            &utxo_set,
-            1,
-            0,
-            0,
-            chain_id,
-            &CoreExtProfiles::empty(),
-            None,
-            None,
+            &tx, txid, &utxo_set, 1, 0, 0, chain_id, None, None,
         )
         .expect_err("bad signature must fail");
 
@@ -1402,16 +1320,7 @@ mod tests {
         tx.outputs[0].value = 101;
 
         let err = apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles_and_suite_context_deferred_sigchecks(
-            &tx,
-            txid,
-            &utxo_set,
-            1,
-            0,
-            0,
-            chain_id,
-            &CoreExtProfiles::empty(),
-            None,
-            None,
+            &tx, txid, &utxo_set, 1, 0, 0, chain_id, None, None,
         )
         .expect_err("late value-conservation failure must return error, not leave queued tasks");
 

--- a/clients/rust/crates/rubin-node/src/chainstate.rs
+++ b/clients/rust/crates/rubin-node/src/chainstate.rs
@@ -5,9 +5,9 @@ use std::path::{Path, PathBuf};
 
 use rubin_consensus::{
     block_hash,
-    connect_block_basic_in_memory_at_height_and_core_ext_deployments_with_suite_context as connect_block_basic_in_memory_at_height_with_suite_context,
-    encode_compact_size, parse_block_bytes, ConnectBlockBasicSummary, CoreExtDeploymentProfiles,
-    InMemoryChainState, Outpoint, RotationProvider, SuiteRegistry, UtxoEntry,
+    connect_block_basic_in_memory_at_height_and_core_ext_deployments_with_suite_context,
+    encode_compact_size, parse_block_bytes, ConnectBlockBasicSummary, InMemoryChainState, Outpoint,
+    RotationProvider, SuiteRegistry, UtxoEntry,
 };
 use serde::{Deserialize, Serialize};
 use sha3::{Digest, Sha3_256};
@@ -144,7 +144,7 @@ impl ChainState {
         };
 
         let connect_summary: ConnectBlockBasicSummary =
-            connect_block_basic_in_memory_at_height_with_suite_context(
+            connect_block_basic_in_memory_at_height_and_core_ext_deployments_with_suite_context(
                 block_bytes,
                 expected_prev_hash,
                 expected_target,
@@ -152,7 +152,6 @@ impl ChainState {
                 prev_timestamps,
                 &mut work_state,
                 chain_id,
-                &CoreExtDeploymentProfiles::empty(),
                 rotation,
                 registry,
             )

--- a/clients/rust/crates/rubin-node/src/miner.rs
+++ b/clients/rust/crates/rubin-node/src/miner.rs
@@ -9,7 +9,7 @@ use rubin_consensus::merkle::{witness_commitment_hash, witness_merkle_root_wtxid
 use rubin_consensus::{
     apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles_and_suite_context as apply_basic_non_coinbase_update,
     encode_compact_size, merkle_root_txids, parse_tx, pow_check, tx_weight_and_stats_public,
-    CoreExtProfiles, Outpoint, Tx, UtxoEntry,
+    Outpoint, Tx, UtxoEntry,
 };
 use sha3::{Digest, Sha3_256};
 
@@ -500,7 +500,6 @@ impl<'a> Miner<'a> {
                 block_mtp,
                 block_mtp,
                 self.sync.cfg.chain_id,
-                &CoreExtProfiles::empty(),
                 rotation,
                 registry,
             );

--- a/clients/rust/crates/rubin-node/src/txpool.rs
+++ b/clients/rust/crates/rubin-node/src/txpool.rs
@@ -5,8 +5,8 @@ use std::sync::OnceLock;
 use rubin_consensus::{
     apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles_and_suite_context,
     constants::{COV_TYPE_CORE_EXT, MAX_RELAY_MSG_BYTES},
-    parse_block_header_bytes, parse_tx, tx_weight_and_stats_public, CoreExtProfiles,
-    DefaultRotationProvider, NativeSuiteSet, Outpoint, RotationProvider, SuiteRegistry,
+    parse_block_header_bytes, parse_tx, tx_weight_and_stats_public, DefaultRotationProvider,
+    NativeSuiteSet, Outpoint, RotationProvider, SuiteRegistry,
 };
 
 use crate::sync::SuiteContext;
@@ -614,32 +614,24 @@ impl TxPool {
         // spam BEFORE expensive ML-DSA signature verification in
         // `apply_non_coinbase_tx_basic_update_*` below, but AFTER all
         // chain-context resolution (`next_block_height`,
-        // `next_block_mtp`, `active_profiles_at_height`,
-        // `suite_context` lookup). Chain-context failures (height
-        // overflow, missing tip MTP, invalid CORE_EXT deployment
-        // config) keep their existing error precedence so
-        // `admit_with_metadata` does NOT diverge from `relay_metadata`
-        // on the (chain-context-error vs fee-floor-fail) precedence.
+        // `next_block_mtp`, `suite_context` lookup). Chain-context
+        // failures (height overflow, missing tip MTP) keep their
+        // existing error precedence so `admit_with_metadata` does NOT
+        // diverge from `relay_metadata` on the (chain-context-error vs
+        // fee-floor-fail) precedence.
         // Mirrors Go's `cheapFeeFloorPrecheck` call site inside
         // `checkTransactionWithSnapshot` at
         // `clients/go/node/mempool_precheck.go` `checkTransactionWithSnapshot` (RUB-165 PR #1415):
         // Go runs the precheck after `nextBlockContext`/`nextBlockMTP`
-        // and immediately before the expensive
-        // `CheckTransactionWithOwnedUtxoSetAndCoreExtProfilesAndSuiteContext`
-        // call. Note: Go's `policy.CoreExtProfiles` /
-        // `policy.SuiteRegistry` are resolved at policy-snapshot time
-        // outside admission, so they cannot error mid-admission in Go.
-        // Rust's per-admission `active_profiles_at_height` lookup adds
-        // a chain-context error path Go does not have; running precheck
-        // after it preserves the admit/relay endpoint precedence
-        // consistency. The helper bails (`Ok(())`) for any tx shape it
-        // cannot soundly classify (DA / multi-input / non-P2PK
-        // covenant / overspend) and the existing expensive path keeps
-        // its error precedence. Reuses the RUB-167 pre-computed
-        // `weight`. Same `Unavailable` error class + same message
-        // format as `validate_fee_floor`, so the rolling-floor
-        // classification stays uniform across the fast-reject path and
-        // the post-consensus path.
+        // and immediately before the expensive consensus apply call.
+        // The helper bails (`Ok(())`) for any tx shape it cannot
+        // soundly classify (DA / multi-input / non-P2PK covenant /
+        // overspend) and the existing expensive path keeps its error
+        // precedence. Reuses the RUB-167 pre-computed `weight`. Same
+        // `Unavailable` error class + same message format as
+        // `validate_fee_floor`, so the rolling-floor classification
+        // stays uniform across the fast-reject path and the
+        // post-consensus path.
         cheap_fee_floor_precheck(
             &tx,
             &chain_state.utxos,
@@ -658,7 +650,6 @@ impl TxPool {
                 block_mtp,
                 block_mtp,
                 chain_id,
-                &CoreExtProfiles::empty(),
                 rotation,
                 registry,
             )
@@ -1112,7 +1103,6 @@ pub(crate) fn relay_metadata(
             block_mtp,
             block_mtp,
             chain_id,
-            &CoreExtProfiles::empty(),
             rotation,
             registry,
         )

--- a/clients/rust/fuzz/fuzz_targets/spend_dispatch_structural.rs
+++ b/clients/rust/fuzz/fuzz_targets/spend_dispatch_structural.rs
@@ -193,12 +193,8 @@ fuzz_target!(|data: &[u8]| {
         wtxids: vec![[0u8; 32]],
     };
 
-    let profiles = rubin_consensus::CoreExtProfiles { active: vec![] };
-
     // --- First call ---
-    let r1 = rubin_consensus::validate_tx_local(
-        &ptc, &pb, chain_id, block_height, 0, &profiles, None,
-    );
+    let r1 = rubin_consensus::validate_tx_local(&ptc, &pb, chain_id, block_height, 0, None);
 
     // --- Invariant: Valid ↔ Err consistency ---
     if r1.valid && r1.err.is_some() {
@@ -217,9 +213,7 @@ fuzz_target!(|data: &[u8]| {
     }
 
     // --- Invariant: Determinism ---
-    let r2 = rubin_consensus::validate_tx_local(
-        &ptc, &pb, chain_id, block_height, 0, &profiles, None,
-    );
+    let r2 = rubin_consensus::validate_tx_local(&ptc, &pb, chain_id, block_height, 0, None);
     if r1 != r2 {
         panic!("validate_tx_local non-deterministic");
     }

--- a/clients/rust/fuzz/fuzz_targets/validate_tx_local.rs
+++ b/clients/rust/fuzz/fuzz_targets/validate_tx_local.rs
@@ -237,8 +237,6 @@ fuzz_target!(|data: &[u8]| {
         wtxids: vec![[0u8; 32]],
     };
 
-    let profiles = rubin_consensus::CoreExtProfiles { active: vec![] };
-
     // --- First call ---
     let r1 = rubin_consensus::validate_tx_local(
         &ptc,
@@ -246,7 +244,6 @@ fuzz_target!(|data: &[u8]| {
         chain_id,
         block_height,
         block_mtp,
-        &profiles,
         None,
     );
 
@@ -273,7 +270,6 @@ fuzz_target!(|data: &[u8]| {
         chain_id,
         block_height,
         block_mtp,
-        &profiles,
         None,
     );
     if r1 != r2 {


### PR DESCRIPTION
## Summary

Removes the inert `CORE_EXT` "profiles/deployments" connect-block threading from the **Rust** client — the mirror of the already-merged Go cleanup **RUB-586** ([#2176](https://github.com/2tbmz9y2xt-lang/rubin-protocol/pull/2176), commit `d75e5f7`). **Behavior-neutral dead-code removal**: `0x0102` (CORE_EXT) is already unassigned-rejected (#2173), the deployment/profile params were inert (the node/CLI always pass empty), and `prepare_connect_block` already ignored them.

This is **S1** of RUB-587 (per its loc_policy "split per S#"). S2 (shadow-test re-pin) and S3 (`core_ext_live_binding_name` rename) follow as separate slices.

Part of **RUB-587** (controller-authorized staged thaw of RUB-577 for this CORE_EXT-removal leg, continuing 512→513→514).

## Scope

- [ ] Documentation-only
- [x] Implementation-only change (no consensus change)
- [ ] Consensus-affecting change (requires explicit process)

Pure removal of inert plumbing (params, fields, unused types). No validation, error code, state transition, or the `0x0102` reject is altered.

**Consensus boundary (required):**

- Consensus rules unchanged: YES
- `SECTION_HASHES.json` unchanged: YES
- Wire format unchanged: YES

*Boundary note: the 0x0102 reject arms (`covenant_genesis.rs:131-134`, `utxo_basic.rs` `check_spend_covenant` default, `vault.rs` `witness_slots` default) are verified 0-diff. This PR only deletes the surrounding inert profile-threading.*

### Parity exemption justification

Rust-only consensus-crate change with no Go change in this diff, so the source-level parity gate flags it. This is the **Rust mirror of the already-merged Go RUB-586** (`d75e5f7`) — the Go threading was removed there; this brings Rust to parity. Behavior-neutral; the cross-client conformance bundle stays **519/519 (Go == Rust)** — observable behavior is unchanged, only inert plumbing removed. `parity-exempt` requested on this basis.

## What changed (clients/rust only)

- `connect_block_inmem.rs`: drop the 4 `*_and_core_ext_deployments*` connect-block fns; base fns now call their `*_with_suite_context` variant directly; remove the `core_ext_deployments`/`core_ext_profiles` `ConnectBlockContext`/`PreparedConnectBlock` fields + the inert pass-through.
- `utxo_basic.rs` / `tx_validate_worker.rs`: drop the ignored `core_ext_profiles` params; collapse the redundant no-suite apply wrapper into the base. **Function names are kept as-is** (e.g. `*_and_core_ext_profiles_and_suite_context`): dropping the now-vestigial token would re-flag these pre-existing high-complexity fns (params>8, the 371-line / CCN-68 apply impl) as *new* Codacy issues even though this change reduces them. The Go-parity name cleanup is deferred to a dedicated slice that also addresses the complexity.
- `core_ext.rs`: remove the now-unused `CoreExtProfiles` / `CoreExtDeploymentProfiles` / `CoreExtActiveProfile` / `active_profiles_at_height` profile-collection.
- `lib.rs` exports, `rubin-node` (`chainstate.rs`/`miner.rs`/`txpool.rs`, incl. stale `active_profiles_at_height` comments), `rubin-consensus-cli`, tests, fuzz targets updated.

**Kept (with reason):** `COV_TYPE_CORE_EXT`, `CORE_EXT_BINDING_NAME_VERIFY_SIG_EXT_OPENSSL_DIGEST32_V1` + binding helpers, `CoreExtDeploymentProfile` (singular — used by the kept `core_ext_profile_bytes/anchor` helpers), the CLI's `reject_core_ext_profiles_from_json` retired-input hardening, and all `0x0102` reject machinery.

## Verification (all green)

- `cargo build -p rubin-consensus -p rubin-node -p rubin-consensus-cli` — clean
- `cargo test` — **0 failures**; `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt --all --check` clean
- `run_cv_bundle.py` — **519/519 (Go == Rust)**, behavior unchanged
- reject arms confirmed 0-diff; `clients/rust/` only
- Pre-PR adversarial multi-vector review (rename-correctness / reject-integrity / Go-parity / dead-code / coverage) with independent finding-verification — **merge-safe, 0 confirmed findings**.

## Push note

Pushed via direct git (controller-authorized override): the `cl push` gate wrapper is absent in the authoring environment; sanctioned pre-push checks above were run manually.

Refs: Q-CORE-EXT-RESIDUE-CLEANUP-RUST-01

🤖 Generated with [Claude Code](https://claude.com/claude-code)
