### PR TITLE
RUB-495: Rust CORE_SIMPLICITY (0x0106) creation-side mirror

### DIFF
--- a/clients/rust/crates/rubin-consensus/src/constants.rs
+++ b/clients/rust/crates/rubin-consensus/src/constants.rs
@@ -32,6 +32,7 @@ pub const MAX_P2PK_COVENANT_DATA: u64 = 33;
 pub const MAX_HTLC_COVENANT_DATA: u64 = 105;
 pub const MIN_HTLC_PREIMAGE_BYTES: u64 = 16; // consensus security floor (Q-A287-03)
 pub const MAX_HTLC_PREIMAGE_BYTES: u64 = 256;
+pub const MAX_SIMPLICITY_STATE_BYTES: u64 = 512;
 pub const MAX_VAULT_KEYS: u8 = 12;
 pub const MAX_VAULT_WHITELIST_ENTRIES: u16 = 1024;
 pub const MAX_MULTISIG_KEYS: u8 = 12;
@@ -42,6 +43,7 @@ pub const COV_TYPE_MULTISIG: u16 = 0x0104;
 pub const COV_TYPE_CORE_EXT: u16 = 0x0102;
 pub const COV_TYPE_CORE_STEALTH: u16 = 0x0105;
 pub const CORE_STEALTH_WITNESS_SLOTS: u64 = 1;
+pub const COV_TYPE_CORE_SIMPLICITY: u16 = 0x0106;
 
 #[deprecated(note = "use COV_TYPE_CORE_EXT")]
 pub const COV_TYPE_EXT: u16 = COV_TYPE_CORE_EXT;
@@ -107,8 +109,13 @@ mod tests {
         assert_eq!(COV_TYPE_CORE_EXT, 0x0102);
         assert_eq!(COV_TYPE_DA_COMMIT, 0x0103);
         assert_eq!(COV_TYPE_CORE_STEALTH, 0x0105);
+        assert_eq!(COV_TYPE_CORE_SIMPLICITY, 0x0106);
         assert_eq!(COV_TYPE_CORE_EXT.to_le_bytes(), 0x0102u16.to_le_bytes());
         assert_eq!(COV_TYPE_CORE_STEALTH.to_le_bytes(), 0x0105u16.to_le_bytes());
+        assert_eq!(
+            COV_TYPE_CORE_SIMPLICITY.to_le_bytes(),
+            0x0106u16.to_le_bytes()
+        );
     }
 
     #[allow(deprecated)]

--- a/clients/rust/crates/rubin-consensus/src/covenant_genesis.rs
+++ b/clients/rust/crates/rubin-consensus/src/covenant_genesis.rs
@@ -1,10 +1,11 @@
 use crate::constants::{
-    COV_TYPE_ANCHOR, COV_TYPE_CORE_STEALTH, COV_TYPE_DA_COMMIT, COV_TYPE_HTLC, COV_TYPE_MULTISIG,
-    COV_TYPE_P2PK, COV_TYPE_RESERVED_FUTURE, COV_TYPE_VAULT, MAX_ANCHOR_PAYLOAD_SIZE,
-    MAX_COVENANT_DATA_PER_OUTPUT, MAX_P2PK_COVENANT_DATA,
+    COV_TYPE_ANCHOR, COV_TYPE_CORE_SIMPLICITY, COV_TYPE_CORE_STEALTH, COV_TYPE_DA_COMMIT,
+    COV_TYPE_HTLC, COV_TYPE_MULTISIG, COV_TYPE_P2PK, COV_TYPE_RESERVED_FUTURE, COV_TYPE_VAULT,
+    MAX_ANCHOR_PAYLOAD_SIZE, MAX_COVENANT_DATA_PER_OUTPUT, MAX_P2PK_COVENANT_DATA,
 };
 use crate::error::{ErrorCode, TxError};
 use crate::htlc::parse_htlc_covenant_data;
+use crate::simplicity_covenant::validate_core_simplicity_covenant_data;
 use crate::stealth::parse_stealth_covenant_data;
 use crate::suite_registry::{DefaultRotationProvider, RotationProvider};
 use crate::tx::Tx;
@@ -121,6 +122,16 @@ pub fn validate_tx_covenants_genesis(
                         "invalid CORE_DA_COMMIT covenant_data length",
                     ));
                 }
+            }
+            COV_TYPE_CORE_SIMPLICITY => {
+                // Creation is fail-closed in this slice: the deployment-active gate and
+                // its rotation threading are inseparable and land together in RUB-590.
+                // Validate covenant_data structure, then reject (creation not enabled).
+                validate_core_simplicity_covenant_data(out.value, &out.covenant_data)?;
+                return Err(TxError::new(
+                    ErrorCode::TxErrCovenantTypeInvalid,
+                    "CORE_SIMPLICITY creation not enabled",
+                ));
             }
             COV_TYPE_RESERVED_FUTURE => {
                 return Err(TxError::new(

--- a/clients/rust/crates/rubin-consensus/src/lib.rs
+++ b/clients/rust/crates/rubin-consensus/src/lib.rs
@@ -21,6 +21,7 @@ mod sig_cache;
 mod sig_queue;
 pub mod sighash;
 pub mod simplicity;
+mod simplicity_covenant;
 mod spend_verify;
 mod stealth;
 pub mod subsidy;

--- a/clients/rust/crates/rubin-consensus/src/simplicity_covenant.rs
+++ b/clients/rust/crates/rubin-consensus/src/simplicity_covenant.rs
@@ -1,0 +1,70 @@
+//! CORE_SIMPLICITY (0x0106) creation-side covenant rules.
+//!
+//! Rust mirror of the merged Go reference (`clients/go/consensus/simplicity_covenant.go`,
+//! RUB-494), scoped to the creation-side `covenant_data` structure validation.
+//! Creation is fail-closed in this slice (see `covenant_genesis`). The
+//! deployment-active gate + rotation threading land together in RUB-590;
+//! spend-side handling (witness_slots, spend reject, apply/precompute
+//! error-priority) lands in RUB-591.
+
+use crate::compactsize::read_compact_size;
+use crate::constants::MAX_SIMPLICITY_STATE_BYTES;
+use crate::error::{ErrorCode, TxError};
+use crate::wire_read::Reader;
+
+/// Validates a CORE_SIMPLICITY creation output's `covenant_data`:
+/// `program_cmr:bytes32 || state_len:CompactSize || state`, with
+/// `value > 0`, `state_len <= MAX_SIMPLICITY_STATE_BYTES`, and the total
+/// length matching exactly (no trailing bytes). Mirrors Go
+/// `validateCoreSimplicityCovenantData`.
+pub(crate) fn validate_core_simplicity_covenant_data(
+    value: u64,
+    covenant_data: &[u8],
+) -> Result<(), TxError> {
+    if value == 0 {
+        return Err(TxError::new(
+            ErrorCode::TxErrCovenantTypeInvalid,
+            "CORE_SIMPLICITY value must be > 0",
+        ));
+    }
+
+    let mut r = Reader::new(covenant_data);
+    if r.read_bytes(32).is_err() {
+        return Err(TxError::new(
+            ErrorCode::TxErrCovenantTypeInvalid,
+            "CORE_SIMPLICITY program_cmr parse failure",
+        ));
+    }
+
+    let (state_len_u64, state_len_varint_bytes) = read_compact_size(&mut r).map_err(|_| {
+        TxError::new(
+            ErrorCode::TxErrCovenantTypeInvalid,
+            "CORE_SIMPLICITY state_len parse failure",
+        )
+    })?;
+    if state_len_u64 > MAX_SIMPLICITY_STATE_BYTES {
+        return Err(TxError::new(
+            ErrorCode::TxErrCovenantTypeInvalid,
+            "CORE_SIMPLICITY state_len too large",
+        ));
+    }
+    let state_len = state_len_u64 as usize;
+
+    if r.read_bytes(state_len).is_err() {
+        return Err(TxError::new(
+            ErrorCode::TxErrCovenantTypeInvalid,
+            "CORE_SIMPLICITY state parse failure",
+        ));
+    }
+    if covenant_data.len() != 32 + state_len_varint_bytes + state_len {
+        return Err(TxError::new(
+            ErrorCode::TxErrCovenantTypeInvalid,
+            "CORE_SIMPLICITY covenant_data length mismatch",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "tests/simplicity_covenant.rs"]
+mod tests;

--- a/clients/rust/crates/rubin-consensus/src/tests/simplicity_covenant.rs
+++ b/clients/rust/crates/rubin-consensus/src/tests/simplicity_covenant.rs
@@ -1,0 +1,99 @@
+use super::*;
+use crate::compactsize::encode_compact_size;
+use crate::constants::{COV_TYPE_CORE_SIMPLICITY, MAX_SIMPLICITY_STATE_BYTES};
+use crate::error::ErrorCode;
+use crate::tx::{Tx, TxOutput};
+
+fn encode_simplicity_covenant_data(program_cmr: [u8; 32], state: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(32 + 1 + state.len());
+    out.extend_from_slice(&program_cmr);
+    encode_compact_size(state.len() as u64, &mut out);
+    out.extend_from_slice(state);
+    out
+}
+
+fn err_msg(e: &crate::error::TxError) -> String {
+    format!("{e}")
+}
+
+fn tx_with_outputs(outputs: Vec<TxOutput>) -> Tx {
+    Tx {
+        version: 1,
+        tx_kind: 0x00,
+        tx_nonce: 1,
+        inputs: vec![],
+        outputs,
+        locktime: 0,
+        witness: vec![],
+        da_payload: vec![],
+        da_commit_core: None,
+        da_chunk_core: None,
+    }
+}
+
+fn simplicity_output(value: u64, covenant_data: Vec<u8>) -> TxOutput {
+    TxOutput {
+        value,
+        covenant_type: COV_TYPE_CORE_SIMPLICITY,
+        covenant_data,
+    }
+}
+
+// covenant_data = program_cmr:32 || state_len:CompactSize || state; value>0;
+// state_len<=512; exact total length. Mirrors Go validateCoreSimplicityCovenantData.
+#[test]
+fn covenant_data_validation_cases() {
+    let cmr = [0xab; 32];
+    let max = MAX_SIMPLICITY_STATE_BYTES as usize;
+    let ok_empty = encode_simplicity_covenant_data(cmr, &[]);
+    let ok_max = encode_simplicity_covenant_data(cmr, &vec![0u8; max]);
+    let over = encode_simplicity_covenant_data(cmr, &vec![0u8; max + 1]);
+    let mut trailing = encode_simplicity_covenant_data(cmr, &[0x09]);
+    trailing.push(0xff); // extra byte past the declared state
+    let mut truncated = vec![0x22; 32]; // CMR + state_len=3 but only 2 state bytes
+    encode_compact_size(3, &mut truncated);
+    truncated.extend_from_slice(&[0x01, 0x02]);
+    let mut nonminimal = vec![0xa5; 32]; // state_len 252 in non-minimal 3-byte form
+    nonminimal.extend_from_slice(&[0xfd, 0xfc, 0x00]);
+    nonminimal.extend_from_slice(&vec![0u8; 0xfc]);
+
+    let cases: &[(u64, &[u8], Option<&str>)] = &[
+        (1, &ok_empty, None),
+        (1, &ok_max, None),
+        (0, &ok_empty, Some("value must be > 0")),
+        (1, &[0u8; 31], Some("program_cmr parse failure")),
+        (1, &nonminimal, Some("state_len parse failure")),
+        (1, &over, Some("state_len too large")),
+        (1, &truncated, Some("state parse failure")),
+        (1, &trailing, Some("covenant_data length mismatch")),
+    ];
+    for (i, (value, data, want)) in cases.iter().enumerate() {
+        let res = validate_core_simplicity_covenant_data(*value, data);
+        match want {
+            None => assert!(res.is_ok(), "case {i}: expected ok, got {res:?}"),
+            Some(sub) => {
+                let e = res.unwrap_err();
+                assert_eq!(e.code, ErrorCode::TxErrCovenantTypeInvalid, "case {i}");
+                assert!(err_msg(&e).contains(sub), "case {i}: got {}", err_msg(&e));
+            }
+        }
+    }
+}
+
+// End-to-end through the genesis dispatch: creation is fail-closed in this slice
+// ("creation not enabled"); malformed covenant_data surfaces the structural
+// error first. The deployment-active gate that turns this into conditional
+// acceptance lands in RUB-590.
+#[test]
+fn genesis_arm_fail_closed() {
+    let data = encode_simplicity_covenant_data([0x44; 32], &[0x01, 0x02]);
+    let tx = tx_with_outputs(vec![simplicity_output(1, data)]);
+    let e = crate::validate_tx_covenants_genesis(&tx, 10, None).unwrap_err();
+    assert_eq!(e.code, ErrorCode::TxErrCovenantTypeInvalid);
+    assert!(err_msg(&e).contains("creation not enabled"));
+
+    let bad = tx_with_outputs(vec![simplicity_output(1, vec![0u8; 10])]);
+    let e = crate::validate_tx_covenants_genesis(&bad, 10, None).unwrap_err();
+    assert_eq!(e.code, ErrorCode::TxErrCovenantTypeInvalid);
+    assert!(err_msg(&e).contains("program_cmr parse failure"));
+}


### PR DESCRIPTION
## Summary

Rust mirror of the merged Go CORE_SIMPLICITY (0x0106) **creation-side** reference (RUB-494), scoped to **child 1 of the RUB-495 split**: constants + `covenant_data` structure validation + the genesis 0x0106 arm. Creation is **uniformly fail-closed** in this slice — the arm validates structure and then unconditionally rejects (`CORE_SIMPLICITY creation not enabled`). No deployment gate, hence **no rotation-sensitivity**: 0x0106 is rejected on every path pre-activation. Cross-client bundle unchanged (519, Go == Rust).

**RUB-495 split into 3 children (controller directive) so each fits the LOC budget and ships a complete, non-half-wired unit:**
- **RUB-495 (this PR)** — creation core (constants + covenant_data validation + fail-closed genesis arm). ~89 feature lines (≤150 target); tests in `src/tests/`.
- **RUB-590** — the deployment-active gate **and** its rotation threading, together (they are inseparable): the `RotationProvider::simplicity_active_at_height` hook, `validate_core_simplicity_deployment_active`, and threading the active provider through every block-basic/connect/node-`sync_reorg`/CLI genesis site so an active deployment accepts valid 0x0106 creation. Mirrors Go RUB-494.
- **RUB-591** — spend-side fail-closed: `witness_slots(0x0106)` routing, worker/apply dedicated reject, precompute `StoppedAtCoreSimplicity` early-stop, error-priority. Mirrors Go RUB-504-era.

## Scope

- [x] Implementation-only change (Rust catches up to merged Go canonical rules; net observable behavior preserved — 0x0106 rejected pre-activation, bundle 519).

**Consensus boundary:** Consensus rules unchanged: YES · `SECTION_HASHES.json` unchanged: YES · Wire format unchanged: YES

### Parity exemption justification

Staged single-client (Rust) child slice of the Go-first Simplicity track. Its Go sibling RUB-494 is merged; this PR mirrors only the creation core into the Rust client. Per the staged Go→Rust split, the sibling client and shared evidence are separate Linear issues — do not add Go-side changes to satisfy per-PR source lockstep. Behavior parity is verified by `run_cv_bundle.py` = 519 (Go == Rust).

## What changed (Rust only)

- **constants.rs**: `COV_TYPE_CORE_SIMPLICITY = 0x0106`, `MAX_SIMPLICITY_STATE_BYTES = 512` (+ constants test).
- **simplicity_covenant.rs (new)**: `validate_core_simplicity_covenant_data` (value>0; `program_cmr:bytes32 || state_len:CompactSize || state`; `state_len <= 512`; exact total length). Tests in `src/tests/simplicity_covenant.rs`.
- **covenant_genesis.rs**: a `COV_TYPE_CORE_SIMPLICITY` arm added to the existing inline dispatch — validate covenant_data structure, then fail closed (`CORE_SIMPLICITY creation not enabled`). No deployment gate, no rotation provider use (those land in RUB-590).

The deployment gate, rotation threading, `witness_slots`, and the spend reject are intentionally NOT here — they belong to RUB-590 / RUB-591. 0x0106 spend is fail-closed via `witness_slots`'s default reject, exactly like the unassigned 0x0102.

## Verification

- `cargo test -p rubin-consensus` green (1099 lib tests), `cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo fmt --all --check` clean.
- `run_cv_bundle.py` **519/519 (Go == Rust)**; matrix, fixtures policy/drift, `check_pv_doc_compliance.py`, formal checkers OK. No fixtures/spec changed.
- Codacy: diff coverage green; complexity increase well under the +20 gate (inline genesis arm, no helper extraction; tests under `src/tests/**`, excluded per `.codacy.yml`).
- LOC: ~191 changed lines (≤350 hard cap); ~89 feature (≤150 target).
- Reviewed adversarially (multi-round, Codex + internal). The rotation/activation completeness and spend error-priority surfaced by Codex are split to RUB-590 / RUB-591; this slice carries no half-wired gate and no latent activation bug (uniformly fail-closed).

## Push note

Pushed via direct git (controller-authorized override): the `cl push` gate wrapper is absent in the authoring environment; the pre-push checks above were run manually.

Refs: Q-SIMPLICITY-COVENANT-CREATE-RUST-01

🤖 Generated with [Claude Code](https://claude.com/claude-code)
