### PR TITLE
RUB-590: Rust CORE_SIMPLICITY (0x0106) deployment-active gate + rotation threading

### DIFF
--- a/clients/rust/crates/rubin-consensus/src/block_basic.rs
+++ b/clients/rust/crates/rubin-consensus/src/block_basic.rs
@@ -1,6 +1,7 @@
 use crate::block::{BlockHeader, BLOCK_HEADER_BYTES};
 use crate::constants::{MAX_ANCHOR_BYTES_PER_BLOCK, MAX_BLOCK_WEIGHT, MAX_DA_BYTES_PER_BLOCK};
 use crate::error::{ErrorCode, TxError};
+use crate::suite_registry::RotationProvider;
 use crate::tx::Tx;
 
 mod coinbase;
@@ -86,6 +87,28 @@ pub fn validate_block_basic_with_context_at_height(
     block_height: u64,
     prev_timestamps: Option<&[u64]>,
 ) -> Result<BlockBasicSummary, TxError> {
+    validate_block_basic_with_context_at_height_and_rotation(
+        block_bytes,
+        expected_prev_hash,
+        expected_target,
+        block_height,
+        prev_timestamps,
+        None,
+    )
+}
+
+/// Rotation-aware variant of `validate_block_basic_with_context_at_height`.
+/// Threads the rotation/deployment provider to genesis covenant validation so
+/// an active CORE_SIMPLICITY (0x0106) deployment is accepted. Mirrors Go
+/// `ValidateBlockBasicWithContextAtHeightAndRotation`.
+pub fn validate_block_basic_with_context_at_height_and_rotation(
+    block_bytes: &[u8],
+    expected_prev_hash: Option<[u8; 32]>,
+    expected_target: Option<[u8; 32]>,
+    block_height: u64,
+    prev_timestamps: Option<&[u64]>,
+    rotation: Option<&dyn RotationProvider>,
+) -> Result<BlockBasicSummary, TxError> {
     let pb = parse_block_bytes(block_bytes)?;
     validate_parsed_block_basic_with_context_at_height(
         &pb,
@@ -93,6 +116,7 @@ pub fn validate_block_basic_with_context_at_height(
         expected_target,
         block_height,
         prev_timestamps,
+        rotation,
     )
 }
 
@@ -105,6 +129,31 @@ pub fn validate_block_basic_with_context_and_fees_at_height(
     already_generated: u128,
     sum_fees: u64,
 ) -> Result<BlockBasicSummary, TxError> {
+    validate_block_basic_with_context_and_fees_at_height_and_rotation(
+        block_bytes,
+        expected_prev_hash,
+        expected_target,
+        block_height,
+        prev_timestamps,
+        already_generated,
+        sum_fees,
+        None,
+    )
+}
+
+/// Rotation-aware variant of `validate_block_basic_with_context_and_fees_at_height`.
+/// Mirrors Go `ValidateBlockBasicWithContextAndFeesAtHeightAndRotation`.
+#[allow(clippy::too_many_arguments)]
+pub fn validate_block_basic_with_context_and_fees_at_height_and_rotation(
+    block_bytes: &[u8],
+    expected_prev_hash: Option<[u8; 32]>,
+    expected_target: Option<[u8; 32]>,
+    block_height: u64,
+    prev_timestamps: Option<&[u64]>,
+    already_generated: u128,
+    sum_fees: u64,
+    rotation: Option<&dyn RotationProvider>,
+) -> Result<BlockBasicSummary, TxError> {
     // G.9: parse once, share `pb` between basic validation and the
     // coinbase-value-bound check, instead of parsing twice.
     let pb = parse_block_bytes(block_bytes)?;
@@ -114,6 +163,7 @@ pub fn validate_block_basic_with_context_and_fees_at_height(
         expected_target,
         block_height,
         prev_timestamps,
+        rotation,
     )?;
     validate_coinbase_value_bound(&pb, block_height, already_generated, sum_fees)?;
     Ok(s)

--- a/clients/rust/crates/rubin-consensus/src/block_basic/orchestration.rs
+++ b/clients/rust/crates/rubin-consensus/src/block_basic/orchestration.rs
@@ -6,6 +6,7 @@ use super::{
 };
 use crate::block::block_hash;
 use crate::error::{ErrorCode, TxError};
+use crate::suite_registry::RotationProvider;
 
 /// G.9 / Go parity (`clients/go/consensus/block_basic.go`,
 /// `validateParsedBlockBasicWithContextAtHeight`): validation logic against an
@@ -18,6 +19,7 @@ pub(crate) fn validate_parsed_block_basic_with_context_at_height(
     expected_target: Option<[u8; 32]>,
     block_height: u64,
     prev_timestamps: Option<&[u64]>,
+    rotation: Option<&dyn RotationProvider>,
 ) -> Result<BlockBasicSummary, TxError> {
     let stats = validate_parsed_block_basic_checks(
         pb,
@@ -25,6 +27,7 @@ pub(crate) fn validate_parsed_block_basic_with_context_at_height(
         expected_target,
         block_height,
         prev_timestamps,
+        rotation,
     )?;
     let h = block_hash(&pb.header_bytes)
         .map_err(|_| TxError::new(ErrorCode::BlockErrParse, "failed to hash block header"))?;
@@ -43,6 +46,7 @@ fn validate_parsed_block_basic_checks(
     expected_target: Option<[u8; 32]>,
     block_height: u64,
     prev_timestamps: Option<&[u64]>,
+    rotation: Option<&dyn RotationProvider>,
 ) -> Result<BlockTxStats, TxError> {
     validate_header_commitments(pb, expected_prev_hash, expected_target)
         .and_then(|_| validate_coinbase_witness_commitment(pb))
@@ -54,7 +58,7 @@ fn validate_parsed_block_basic_checks(
     validate_block_resource_limits(stats)?;
 
     validate_da_set_integrity(&pb.txs)
-        .and_then(|_| validate_block_tx_semantics(pb, block_height))?;
+        .and_then(|_| validate_block_tx_semantics(pb, block_height, rotation))?;
 
     Ok(stats)
 }

--- a/clients/rust/crates/rubin-consensus/src/block_basic/txs.rs
+++ b/clients/rust/crates/rubin-consensus/src/block_basic/txs.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::covenant_genesis::validate_tx_covenants_genesis;
+use crate::suite_registry::RotationProvider;
 use std::collections::HashMap;
 
 #[derive(Clone, Copy, Debug)]
@@ -34,6 +35,7 @@ fn add_block_resource_stat(current: u64, delta: u64, msg: &'static str) -> Resul
 pub(super) fn validate_block_tx_semantics(
     pb: &ParsedBlock,
     block_height: u64,
+    rotation: Option<&dyn RotationProvider>,
 ) -> Result<(), TxError> {
     coinbase::validate_coinbase_structure(pb, block_height)?;
     let mut seen_nonces: HashMap<u64, ()> = HashMap::with_capacity(pb.txs.len());
@@ -58,7 +60,7 @@ pub(super) fn validate_block_tx_semantics(
                 ));
             }
         }
-        validate_tx_covenants_genesis(tx, block_height, None)?;
+        validate_tx_covenants_genesis(tx, block_height, rotation)?;
     }
     Ok(())
 }
@@ -199,7 +201,7 @@ mod tests {
     #[test]
     fn validate_block_tx_semantics_rejects_nonce_replay() {
         let pb = parsed_block(vec![coinbase(1), spend(42, 1), spend(42, 1)]);
-        let err = validate_block_tx_semantics(&pb, 1).unwrap_err();
+        let err = validate_block_tx_semantics(&pb, 1, None).unwrap_err();
         assert_eq!(err.code, ErrorCode::TxErrNonceReplay);
     }
 
@@ -208,7 +210,7 @@ mod tests {
         let mut bad = spend(99, 0);
         bad.outputs[0].value = 0;
         let pb = parsed_block(vec![coinbase(1), bad]);
-        let err = validate_block_tx_semantics(&pb, 1).unwrap_err();
+        let err = validate_block_tx_semantics(&pb, 1, None).unwrap_err();
         assert_eq!(err.code, ErrorCode::TxErrCovenantTypeInvalid);
     }
 }

--- a/clients/rust/crates/rubin-consensus/src/connect_block_inmem.rs
+++ b/clients/rust/crates/rubin-consensus/src/connect_block_inmem.rs
@@ -174,6 +174,7 @@ fn prepare_connect_block(
         ctx.expected_target,
         ctx.block_height,
         ctx.prev_timestamps,
+        ctx.rotation,
     )?;
     if pb.txs.is_empty() || pb.txids.len() != pb.txs.len() {
         return Err(TxError::new(

--- a/clients/rust/crates/rubin-consensus/src/covenant_genesis.rs
+++ b/clients/rust/crates/rubin-consensus/src/covenant_genesis.rs
@@ -5,7 +5,9 @@ use crate::constants::{
 };
 use crate::error::{ErrorCode, TxError};
 use crate::htlc::parse_htlc_covenant_data;
-use crate::simplicity_covenant::validate_core_simplicity_covenant_data;
+use crate::simplicity_covenant::{
+    validate_core_simplicity_covenant_data, validate_core_simplicity_deployment_active,
+};
 use crate::stealth::parse_stealth_covenant_data;
 use crate::suite_registry::{DefaultRotationProvider, RotationProvider};
 use crate::tx::Tx;
@@ -124,14 +126,12 @@ pub fn validate_tx_covenants_genesis(
                 }
             }
             COV_TYPE_CORE_SIMPLICITY => {
-                // Creation is fail-closed in this slice: the deployment-active gate and
-                // its rotation threading are inseparable and land together in RUB-590.
-                // Validate covenant_data structure, then reject (creation not enabled).
+                // Mirrors Go: gate on the deployment being active first, then
+                // validate covenant_data structure. The default provider reports
+                // inactive, so creation stays fail-closed ("deployment not
+                // active") until a deployment is wired and threaded.
+                validate_core_simplicity_deployment_active(block_height, rp)?;
                 validate_core_simplicity_covenant_data(out.value, &out.covenant_data)?;
-                return Err(TxError::new(
-                    ErrorCode::TxErrCovenantTypeInvalid,
-                    "CORE_SIMPLICITY creation not enabled",
-                ));
             }
             COV_TYPE_RESERVED_FUTURE => {
                 return Err(TxError::new(

--- a/clients/rust/crates/rubin-consensus/src/lib.rs
+++ b/clients/rust/crates/rubin-consensus/src/lib.rs
@@ -43,7 +43,9 @@ pub use block_basic::{
     parse_block_bytes, tx_weight_and_stats_at_height, tx_weight_and_stats_public,
     validate_block_basic, validate_block_basic_at_height,
     validate_block_basic_with_context_and_fees_at_height,
-    validate_block_basic_with_context_at_height, BlockBasicSummary, ParsedBlock,
+    validate_block_basic_with_context_and_fees_at_height_and_rotation,
+    validate_block_basic_with_context_at_height,
+    validate_block_basic_with_context_at_height_and_rotation, BlockBasicSummary, ParsedBlock,
 };
 pub use compact_relay::compact_shortid;
 pub use compactsize::encode_compact_size;

--- a/clients/rust/crates/rubin-consensus/src/simplicity_covenant.rs
+++ b/clients/rust/crates/rubin-consensus/src/simplicity_covenant.rs
@@ -1,16 +1,36 @@
 //! CORE_SIMPLICITY (0x0106) creation-side covenant rules.
 //!
 //! Rust mirror of the merged Go reference (`clients/go/consensus/simplicity_covenant.go`,
-//! RUB-494), scoped to the creation-side `covenant_data` structure validation.
-//! Creation is fail-closed in this slice (see `covenant_genesis`). The
-//! deployment-active gate + rotation threading land together in RUB-590;
-//! spend-side handling (witness_slots, spend reject, apply/precompute
-//! error-priority) lands in RUB-591.
+//! RUB-494): the creation-side `covenant_data` structure validation plus the
+//! deployment-active gate. Creation is accepted only when the rotation provider
+//! reports the Simplicity deployment active at the block height; otherwise it is
+//! rejected ("deployment not active"), which is the default (fail-closed) for any
+//! provider that does not wire a deployment. Spend-side handling (witness_slots,
+//! spend reject, apply/precompute error-priority) lands in RUB-591.
 
 use crate::compactsize::read_compact_size;
 use crate::constants::MAX_SIMPLICITY_STATE_BYTES;
 use crate::error::{ErrorCode, TxError};
+use crate::suite_registry::RotationProvider;
 use crate::wire_read::Reader;
+
+/// Rejects CORE_SIMPLICITY creation unless the rotation provider reports the
+/// Simplicity deployment active at `height`. Mirrors Go
+/// `validateCoreSimplicityDeploymentActive`: a provider that does not wire a
+/// deployment (the default) yields "deployment not active".
+pub(crate) fn validate_core_simplicity_deployment_active(
+    height: u64,
+    rotation: &dyn RotationProvider,
+) -> Result<(), TxError> {
+    if rotation.simplicity_active_at_height(height) {
+        Ok(())
+    } else {
+        Err(TxError::new(
+            ErrorCode::TxErrCovenantTypeInvalid,
+            "CORE_SIMPLICITY deployment not active",
+        ))
+    }
+}
 
 /// Validates a CORE_SIMPLICITY creation output's `covenant_data`:
 /// `program_cmr:bytes32 || state_len:CompactSize || state`, with

--- a/clients/rust/crates/rubin-consensus/src/suite_registry.rs
+++ b/clients/rust/crates/rubin-consensus/src/suite_registry.rs
@@ -152,6 +152,25 @@ pub trait RotationProvider {
 
     /// Returns suites valid for spending native covenant outputs at height.
     fn native_spend_suites(&self, height: u64) -> NativeSuiteSet;
+
+    /// Whether the CORE_SIMPLICITY (0x0106) deployment is active at `height`.
+    ///
+    /// Default is inactive (fail-closed): a rotation provider that does not
+    /// wire a Simplicity deployment keeps 0x0106 creation rejected. This
+    /// mirrors Go's optional `SimplicityDeploymentProvider` seam, where a
+    /// `RotationProvider` that does not also implement it is treated as
+    /// "deployment not active".
+    ///
+    /// The seam is intentionally infallible (`bool`). Go's interface returns
+    /// `(bool, error)` and maps the error case to a distinct
+    /// "CORE_SIMPLICITY deployment lookup failure" reject. No current provider
+    /// performs a fallible lookup, so that third state is unrepresentable and
+    /// unreachable here. When a real (fallible) deployment provider is wired
+    /// (activation slice), this must widen to a `Result` to re-establish the
+    /// lookup-failure error-string parity with Go.
+    fn simplicity_active_at_height(&self, _height: u64) -> bool {
+        false
+    }
 }
 
 /// Pre-rotation provider: always returns {ML_DSA_87} for both create and spend.

--- a/clients/rust/crates/rubin-consensus/src/tests/block_basic.rs
+++ b/clients/rust/crates/rubin-consensus/src/tests/block_basic.rs
@@ -139,6 +139,86 @@ fn validate_block_basic_subsidy_with_fees_ok() {
     assert_eq!(s.tx_count, 1);
 }
 
+// Mirrors Go TestValidateBlockBasicWithFees_CoreSimplicityUsesRotation: a block
+// creating an active CORE_SIMPLICITY (0x0106) output is rejected by the
+// rotation-unaware block-basic path ("deployment not active") and accepted once
+// the active rotation provider is threaded through to genesis validation.
+#[test]
+fn validate_block_basic_with_fees_core_simplicity_uses_rotation() {
+    use crate::suite_registry::{DefaultRotationProvider, NativeSuiteSet, RotationProvider};
+
+    struct SimplicityActive;
+    impl RotationProvider for SimplicityActive {
+        fn native_create_suites(&self, h: u64) -> NativeSuiteSet {
+            DefaultRotationProvider.native_create_suites(h)
+        }
+        fn native_spend_suites(&self, h: u64) -> NativeSuiteSet {
+            DefaultRotationProvider.native_spend_suites(h)
+        }
+        fn simplicity_active_at_height(&self, _h: u64) -> bool {
+            true
+        }
+    }
+
+    let height = 10u64;
+    let mut cmr = [0u8; 32];
+    cmr[0] = 0x44;
+    let mut cov = cmr.to_vec(); // program_cmr || state_len=0 (empty state)
+    crate::compactsize::encode_compact_size(0, &mut cov);
+    let mut prev_txid = [0u8; 32];
+    prev_txid[0] = 0x66;
+    let simp = tx_with_one_input_one_output(prev_txid, 0, 1, COV_TYPE_CORE_SIMPLICITY, &cov);
+
+    let subsidy = crate::subsidy::block_subsidy(height, 0);
+    let coinbase = coinbase_with_witness_commitment_and_p2pk_value(
+        height as u32,
+        subsidy,
+        std::slice::from_ref(&simp),
+    );
+    let (_c, coinbase_txid, _wc, _nc) = parse_tx(&coinbase).expect("coinbase");
+    let (_s, simp_txid, _ws, _ns) = parse_tx(&simp).expect("simp");
+    let root = merkle_root_txids(&[coinbase_txid, simp_txid]).expect("root");
+    let mut prev = [0u8; 32];
+    prev[0] = 0x9c;
+    let target = [0xffu8; 32];
+    let block = build_block_bytes(prev, root, target, 58, &[coinbase, simp]);
+
+    // Rotation-unaware path: the inactive deployment rejects the 0x0106 create.
+    let e = validate_block_basic_with_context_and_fees_at_height(
+        &block,
+        Some(prev),
+        Some(target),
+        height,
+        None,
+        0,
+        0,
+    )
+    .unwrap_err();
+    assert_eq!(e.code, ErrorCode::TxErrCovenantTypeInvalid);
+
+    // Active provider threaded through: the same block validates.
+    crate::validate_block_basic_with_context_and_fees_at_height_and_rotation(
+        &block,
+        Some(prev),
+        Some(target),
+        height,
+        None,
+        0,
+        0,
+        Some(&SimplicityActive),
+    )
+    .expect("active CORE_SIMPLICITY block must validate");
+
+    // The active provider keeps native create/spend suites at the default; only
+    // the Simplicity deployment flag flips.
+    assert!(SimplicityActive
+        .native_create_suites(height)
+        .contains(SUITE_ID_ML_DSA_87));
+    assert!(SimplicityActive
+        .native_spend_suites(height)
+        .contains(SUITE_ID_ML_DSA_87));
+}
+
 #[test]
 fn validate_block_basic_linkage_mismatch() {
     let tx = minimal_tx_bytes();

--- a/clients/rust/crates/rubin-consensus/src/tests/simplicity_covenant.rs
+++ b/clients/rust/crates/rubin-consensus/src/tests/simplicity_covenant.rs
@@ -1,8 +1,28 @@
 use super::*;
 use crate::compactsize::encode_compact_size;
-use crate::constants::{COV_TYPE_CORE_SIMPLICITY, MAX_SIMPLICITY_STATE_BYTES};
+use crate::constants::{COV_TYPE_CORE_SIMPLICITY, MAX_SIMPLICITY_STATE_BYTES, SUITE_ID_ML_DSA_87};
 use crate::error::ErrorCode;
+use crate::suite_registry::{DefaultRotationProvider, NativeSuiteSet, RotationProvider};
 use crate::tx::{Tx, TxOutput};
+
+// Rotation provider that reports the Simplicity deployment active at/above a
+// threshold height, mirroring Go's testRotationProvider{simplicityActiveHeight}.
+// Suite sets fall back to the default ({ML-DSA-87}) so unrelated P2PK creation
+// rules are intact.
+struct ActiveSimplicity {
+    active_from: u64,
+}
+impl RotationProvider for ActiveSimplicity {
+    fn native_create_suites(&self, h: u64) -> NativeSuiteSet {
+        DefaultRotationProvider.native_create_suites(h)
+    }
+    fn native_spend_suites(&self, h: u64) -> NativeSuiteSet {
+        DefaultRotationProvider.native_spend_suites(h)
+    }
+    fn simplicity_active_at_height(&self, h: u64) -> bool {
+        h >= self.active_from
+    }
+}
 
 fn encode_simplicity_covenant_data(program_cmr: [u8; 32], state: &[u8]) -> Vec<u8> {
     let mut out = Vec::with_capacity(32 + 1 + state.len());
@@ -80,20 +100,60 @@ fn covenant_data_validation_cases() {
     }
 }
 
-// End-to-end through the genesis dispatch: creation is fail-closed in this slice
-// ("creation not enabled"); malformed covenant_data surfaces the structural
-// error first. The deployment-active gate that turns this into conditional
-// acceptance lands in RUB-590.
+// End-to-end through the genesis dispatch. Mirrors Go
+// TestValidateTxCovenantsGenesis_CoreSimplicityActive: the deployment-active
+// gate runs before any structural parse (so an inactive provider rejects even
+// malformed data with "deployment not active"), and an active provider accepts
+// well-formed data while still surfacing structural errors.
 #[test]
-fn genesis_arm_fail_closed() {
-    let data = encode_simplicity_covenant_data([0x44; 32], &[0x01, 0x02]);
-    let tx = tx_with_outputs(vec![simplicity_output(1, data)]);
+fn genesis_deployment_gate() {
+    let active = ActiveSimplicity { active_from: 10 };
+    let valid = encode_simplicity_covenant_data([0x44; 32], &[0x01, 0x02]);
+
+    // The active provider only flips the Simplicity deployment flag; its native
+    // create/spend suites stay the default ({ML-DSA-87}), so P2PK rotation is
+    // unaffected by the gate.
+    assert!(active.native_create_suites(10).contains(SUITE_ID_ML_DSA_87));
+    assert!(active.native_spend_suites(10).contains(SUITE_ID_ML_DSA_87));
+
+    // Inactive (default): rejected at the gate, before any covenant_data parse.
+    let tx = tx_with_outputs(vec![simplicity_output(1, valid.clone())]);
     let e = crate::validate_tx_covenants_genesis(&tx, 10, None).unwrap_err();
     assert_eq!(e.code, ErrorCode::TxErrCovenantTypeInvalid);
-    assert!(err_msg(&e).contains("creation not enabled"));
+    assert!(err_msg(&e).contains("deployment not active"));
 
+    // Inactive + malformed: still the gate message, not the structural one.
+    let bad_inactive = tx_with_outputs(vec![simplicity_output(1, vec![0u8; 10])]);
+    let e = crate::validate_tx_covenants_genesis(&bad_inactive, 10, None).unwrap_err();
+    assert!(err_msg(&e).contains("deployment not active"));
+
+    // Active provider, but BELOW its activation height: still "not active".
+    let e = crate::validate_tx_covenants_genesis(&tx, 9, Some(&active)).unwrap_err();
+    assert!(err_msg(&e).contains("deployment not active"));
+
+    // Production DescriptorRotationProvider does not wire a deployment, so it
+    // inherits the default-false seam: fail-closed even at a high height.
+    let descriptor = crate::suite_registry::DescriptorRotationProvider {
+        descriptor: crate::suite_registry::CryptoRotationDescriptor {
+            name: "t".into(),
+            old_suite_id: crate::constants::SUITE_ID_ML_DSA_87,
+            new_suite_id: 0x02,
+            create_height: 1,
+            spend_height: 2,
+            sunset_height: 0,
+        },
+    };
+    let e = crate::validate_tx_covenants_genesis(&tx, 100, Some(&descriptor)).unwrap_err();
+    assert!(err_msg(&e).contains("deployment not active"));
+
+    // Active at/above the activation height: a well-formed output is accepted.
+    assert!(crate::validate_tx_covenants_genesis(&tx, 10, Some(&active)).is_ok());
+
+    // Active + value 0 / malformed: structural errors surface after the gate.
+    let zero = tx_with_outputs(vec![simplicity_output(0, valid)]);
+    let e = crate::validate_tx_covenants_genesis(&zero, 10, Some(&active)).unwrap_err();
+    assert!(err_msg(&e).contains("value must be > 0"));
     let bad = tx_with_outputs(vec![simplicity_output(1, vec![0u8; 10])]);
-    let e = crate::validate_tx_covenants_genesis(&bad, 10, None).unwrap_err();
-    assert_eq!(e.code, ErrorCode::TxErrCovenantTypeInvalid);
+    let e = crate::validate_tx_covenants_genesis(&bad, 10, Some(&active)).unwrap_err();
     assert!(err_msg(&e).contains("program_cmr parse failure"));
 }

--- a/clients/rust/crates/rubin-node/src/sync_reorg.rs
+++ b/clients/rust/crates/rubin-node/src/sync_reorg.rs
@@ -1,6 +1,7 @@
 use rubin_consensus::{
     block_hash, parse_block_bytes, parse_tx, read_compact_size_bytes,
-    validate_block_basic_with_context_at_height, Outpoint, ParsedBlock, BLOCK_HEADER_BYTES,
+    validate_block_basic_with_context_at_height_and_rotation, Outpoint, ParsedBlock,
+    BLOCK_HEADER_BYTES,
 };
 use std::ops::Deref;
 
@@ -320,12 +321,16 @@ impl SyncEngine {
             // issue #1168).
             let candidate = branch.last().ok_or("empty side branch")?;
             let ts = self.side_branch_prev_timestamps(&branch, common_ancestor_height)?;
-            validate_block_basic_with_context_at_height(
+            // Thread the engine's rotation provider so an active CORE_SIMPLICITY
+            // (0x0106) side-branch block is accepted, mirroring Go sync_reorg.go.
+            let (rotation, _registry) = self.suite_context();
+            validate_block_basic_with_context_at_height_and_rotation(
                 &candidate.block_bytes,
                 Some(candidate.prev_hash),
                 self.cfg.expected_target,
                 candidate_height,
                 ts.as_deref(),
+                rotation,
             )
             .map_err(|e| e.to_string())?;
 


### PR DESCRIPTION
## Summary

Rust mirror of the merged Go CORE_SIMPLICITY (0x0106) **creation-side** reference (RUB-494) — **child 2 of the RUB-495 split**: the **deployment-active gate** and its **rotation threading**, together (they are inseparable — a gate without threading rejects valid active blocks on side paths, which is exactly why RUB-495 was split out of this).

After this slice, an `0x0106` creation is accepted iff the rotation provider reports the Simplicity deployment **active** at the block height, on **every** block-validation entry point. Pre-activation behavior is **unchanged**: no production provider reports the deployment active (the `simplicity_active_at_height` seam defaults to `false`), so `0x0106` is still rejected on every production path — now with `"deployment not active"` instead of child 1's `"creation not enabled"`. Cross-client bundle unchanged (**519, Go == Rust**).

## Scope

- [x] Implementation-only change (Rust catches up to merged Go canonical rules; net observable production behavior preserved — `0x0106` rejected pre-activation, bundle 519). The deployment-active acceptance path is a dormant provider seam exercised only by unit tests.

**Consensus boundary:** Consensus rules unchanged: YES · `SECTION_HASHES.json` unchanged: YES · Wire format unchanged: YES

(Canonical rules are defined by the merged Go reference + spec; this PR mirrors them into the Rust client. The added active-accept path is dormant — no production `RotationProvider` returns `simplicity_active_at_height == true` yet — so production behavior is preserved.)

### Parity exemption justification

Staged single-client (Rust) child slice of the Go-first Simplicity track. Its Go sibling RUB-494 is merged; this PR mirrors only the deployment-gate + rotation threading into the Rust client. Per the staged Go→Rust split, the sibling client and shared evidence are separate Linear issues — do not add Go-side changes to satisfy per-PR source lockstep. Behavior parity is verified by `run_cv_bundle.py` = 519 (Go == Rust).

## What changed (Rust only)

- **suite_registry.rs**: `RotationProvider::simplicity_active_at_height(height) -> bool`, default `false`. Mirrors Go's optional `SimplicityDeploymentProvider` seam (a `RotationProvider` that does not also implement it is treated as "deployment not active"). Default method ⇒ existing impls unaffected.
- **simplicity_covenant.rs**: `validate_core_simplicity_deployment_active(height, &dyn RotationProvider)` → `Ok` iff active, else `TX_ERR_COVENANT_TYPE_INVALID "CORE_SIMPLICITY deployment not active"`. Mirrors Go `validateCoreSimplicityDeploymentActive`.
- **covenant_genesis.rs**: the `0x0106` arm now gates on deployment-active **first** (Go order), then validates `covenant_data`; the unconditional `"creation not enabled"` reject is removed.
- **block_basic.rs**: new public `validate_block_basic_with_context_at_height_and_rotation` + `..._and_fees_..._and_rotation`; the existing non-rotation fns delegate with `None`. Mirrors Go's `...AtHeight` → `...AtHeightAndRotation(nil)` pattern.
- **block_basic/orchestration.rs, block_basic/txs.rs**: thread `rotation` through `validate_parsed_block_basic_with_context_at_height` and `validate_block_tx_semantics` into genesis.
- **connect_block_inmem.rs**: the structural pre-check threads `ctx.rotation` (was `None` — a **latent divergence** from Go `connect_block_inmem.go`, which passes `input.Rotation`).
- **rubin-node/src/sync_reorg.rs**: side-branch validation threads the engine's rotation provider (`self.suite_context().0`). Mirrors Go `node/sync_reorg.go:82` (`s.cfg.RotationProvider`).

### Caller-completeness (mandatory gate)

Every `validate_tx_covenants_genesis` block-validation caller across all crates, with its Go analog:

| Rust caller | Provider | Go analog | Verdict |
|---|---|---|---|
| `utxo_basic.rs` (apply) | `rotation` | `connect_block_parallel.go` apply | already threaded ✓ |
| `connect_block_inmem.rs` (structural) | `ctx.rotation` (changed) | `connect_block_inmem.go` `input.Rotation` | now matches Go ✓ |
| `block_basic/txs.rs` (tx-semantics) | threaded param | `block_basic_txs.go` | threaded ✓ |
| `rubin-node/sync_reorg.rs` (side-branch) | engine rotation | `node/sync_reorg.go:82` | threaded ✓ |
| `precompute.rs` | `None` | `connect_block_parallel_precompute.go:136` passes `nil` ("worker-env mirror") | **match — no change** ✓ |
| `rubin-consensus-cli/main.rs` | `None` (non-rotation variant) | Go CLI `runtime.go` uses non-rotation variant | **match — no change** ✓ |
| benches / fuzz | `None` | test-only | unchanged ✓ |

The active-deployment acceptance for the parallel-connect path is carried by the apply path (`utxo_basic`, already rotation-aware); `precompute` deliberately stays `None` to mirror Go's worker-env (`nil`).

## Verification

- `cargo test -p rubin-consensus` (722 lib + bins), `-p rubin-node` (761), `-p rubin-consensus-cli` — all green.
- `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt --all --check` clean (exit 0).
- `conformance/runner/run_cv_bundle.py` → **519/519 (Go == Rust)**. fixtures policy/drift, conformance ids, formal refinement/coverage/staleness, `check_pv_doc_compliance.py`, map-determinism, openssl isolation self-test — OK. No fixtures/spec changed (runtime logic unchanged since the bundle run; only tests + a doc comment were added during review hardening).
- Codacy: complexity increase well under +20 (`suite_registry.rs` + CLI are metric-excluded per `.codacy.yml`; counting files add the gate helper `if/else` + 2 zero-branch wrappers ≈ +3-4; tests under `src/tests/**` excluded).
- LOC: **258 insertions / 288 total changed lines** (≤350 hard cap; over the ≤150 target — pure mechanical multi-crate threading, kept as one unit per controller directive not to over-fragment).

### Tests (under `src/tests/**`, Codacy-excluded)

- `genesis_deployment_gate`: inactive→"deployment not active" (before any covenant_data parse), inactive+malformed→still the gate message, active-provider **below** its activation height→rejected, production `DescriptorRotationProvider`→fail-closed (inherits default seam), active→accepted, active+value0/malformed→structural errors after the gate. Mirrors Go `TestValidateTxCovenantsGenesis_CoreSimplicityActive`.
- `validate_block_basic_with_fees_core_simplicity_uses_rotation`: block creating an active 0x0106 is rejected by the rotation-unaware path and accepted via the `_and_rotation` variant. Mirrors Go `TestValidateBlockBasicWithFees_CoreSimplicityUsesRotation`.

### Adversarial review (3 lenses)

Caller-completeness, consensus-correctness, and Go-parity — **all returned no P0/P1**. Review also confirmed this PR *closes* two pre-existing latent divergences (connect-structural and reorg standalone-validate, where the structural check rejected what apply accepted). The connect/reorg `ctx.rotation` threading is covered by Go-parity (`connect_block_inmem.go:166`, `node/sync_reorg.go:82`), the block-basic rotation test (same `validate_parsed`→genesis path), and existing connect/reorg tests staying green; a dedicated active-connect regression test was prototyped and verified passing but **deferred** to keep this slice within the LOC cap. The infallible-`bool` seam vs Go's `(bool, error)` "deployment lookup failure" path is documented in-code as a follow-up for when a fallible deployment provider is wired.

## Push note

Pushed via direct git (controller-authorized override): the `cl push` gate wrapper is absent in the authoring environment; the pre-push checks above were run manually.

Refs: Q-SIMPLICITY-COVENANT-CREATE-RUST-ROTATION-01

🤖 Generated with [Claude Code](https://claude.com/claude-code)
