### PR TITLE
RUB-591: Rust CORE_SIMPLICITY (0x0106) spend fail-closed error-priority parity

### DIFF
--- a/clients/rust/crates/rubin-consensus/src/constants.rs
+++ b/clients/rust/crates/rubin-consensus/src/constants.rs
@@ -44,6 +44,7 @@ pub const COV_TYPE_CORE_EXT: u16 = 0x0102;
 pub const COV_TYPE_CORE_STEALTH: u16 = 0x0105;
 pub const CORE_STEALTH_WITNESS_SLOTS: u64 = 1;
 pub const COV_TYPE_CORE_SIMPLICITY: u16 = 0x0106;
+pub const SIMPLICITY_WITNESS_SLOTS: u64 = 1;
 
 #[deprecated(note = "use COV_TYPE_CORE_EXT")]
 pub const COV_TYPE_EXT: u16 = COV_TYPE_CORE_EXT;
@@ -116,6 +117,7 @@ mod tests {
             COV_TYPE_CORE_SIMPLICITY.to_le_bytes(),
             0x0106u16.to_le_bytes()
         );
+        assert_eq!(SIMPLICITY_WITNESS_SLOTS, 1);
     }
 
     #[allow(deprecated)]

--- a/clients/rust/crates/rubin-consensus/src/precompute.rs
+++ b/clients/rust/crates/rubin-consensus/src/precompute.rs
@@ -1,9 +1,12 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::block_basic::ParsedBlock;
-use crate::constants::{COINBASE_MATURITY, COV_TYPE_ANCHOR, COV_TYPE_DA_COMMIT};
+use crate::constants::{
+    COINBASE_MATURITY, COV_TYPE_ANCHOR, COV_TYPE_CORE_SIMPLICITY, COV_TYPE_DA_COMMIT,
+};
 use crate::covenant_genesis::validate_tx_covenants_genesis;
 use crate::error::{ErrorCode, TxError};
+use crate::simplicity_covenant::reject_core_simplicity_spend;
 use crate::utxo_basic::{Outpoint, UtxoEntry};
 use crate::vault::witness_slots;
 
@@ -114,6 +117,10 @@ pub fn precompute_tx_contexts(
         let mut seen_inputs: HashSet<Outpoint> = HashSet::with_capacity(tx.inputs.len());
         let mut total_witness_slots: usize = 0;
         let mut sum_in: u128 = 0;
+        // Mirror Go's StoppedAtCoreSimplicity: a 0x0106 input contributes 0
+        // witness slots, relaxes the witness-count mismatch check, and triggers
+        // the dedicated spend reject after bound validation.
+        let mut stopped_at_core_simplicity = false;
 
         for input in &tx.inputs {
             // Coinbase prevout encoding forbidden in non-coinbase.
@@ -160,6 +167,20 @@ pub fn precompute_tx_contexts(
                 ));
             }
 
+            if entry.covenant_type == COV_TYPE_CORE_SIMPLICITY {
+                // Mirror Go's early return (collectPrecomputeTxInputs): STOP
+                // resolving inputs at the first 0x0106 so no trailing input can
+                // surface a competing error ahead of the dedicated reject. The
+                // 0x0106 input contributes 0 witness slots; the reject is
+                // deferred until after the (mismatch-relaxed) bound check.
+                // `sum_in` is left unaccumulated — the reject precedes the fee /
+                // value-conservation checks, so its value is never read.
+                stopped_at_core_simplicity = true;
+                resolved_inputs.push(entry);
+                input_outpoints.push(op);
+                break;
+            }
+
             let slots = witness_slots(entry.covenant_type, &entry.covenant_data)?;
             if slots == 0 {
                 return Err(TxError::new(ErrorCode::TxErrParse, "invalid witness slots"));
@@ -181,11 +202,16 @@ pub fn precompute_tx_contexts(
         if witness_end > tx.witness.len() {
             return Err(TxError::new(ErrorCode::TxErrParse, "witness underflow"));
         }
-        if witness_end != tx.witness.len() {
+        if !stopped_at_core_simplicity && witness_end != tx.witness.len() {
             return Err(TxError::new(
                 ErrorCode::TxErrParse,
                 "witness_count mismatch",
             ));
+        }
+        // Fail-closed: surface the dedicated 0x0106 spend reject ahead of the
+        // fee/value-conservation checks, with Go-identical code+message.
+        if stopped_at_core_simplicity {
+            return Err(reject_core_simplicity_spend());
         }
 
         // Fee = sum_in − sum_out, matching sequential value conservation.

--- a/clients/rust/crates/rubin-consensus/src/simplicity_covenant.rs
+++ b/clients/rust/crates/rubin-consensus/src/simplicity_covenant.rs
@@ -1,17 +1,20 @@
-//! CORE_SIMPLICITY (0x0106) creation-side covenant rules.
+//! CORE_SIMPLICITY (0x0106) covenant rules.
 //!
-//! Rust mirror of the merged Go reference (`clients/go/consensus/simplicity_covenant.go`,
-//! RUB-494): the creation-side `covenant_data` structure validation plus the
-//! deployment-active gate. Creation is accepted only when the rotation provider
-//! reports the Simplicity deployment active at the block height; otherwise it is
-//! rejected ("deployment not active"), which is the default (fail-closed) for any
-//! provider that does not wire a deployment. Spend-side handling (witness_slots,
-//! spend reject, apply/precompute error-priority) lands in RUB-591.
+//! Rust mirror of the merged Go reference (`clients/go/consensus/simplicity_covenant.go`):
+//! the creation-side `covenant_data` structure validation plus the
+//! deployment-active gate (RUB-494/590), and the spend-side fail-closed reject
+//! (RUB-591). Creation is accepted only when the rotation provider reports the
+//! Simplicity deployment active at the block height; otherwise it is rejected
+//! ("deployment not active"), the default (fail-closed) for any provider that
+//! does not wire a deployment. Spending a 0x0106 output is rejected with the
+//! dedicated "spend evaluation not enabled" message ahead of generic
+//! covenant/witness errors; actual spend evaluation is a later slice (RUB-505).
 
 use crate::compactsize::read_compact_size;
-use crate::constants::MAX_SIMPLICITY_STATE_BYTES;
+use crate::constants::{COV_TYPE_CORE_SIMPLICITY, MAX_SIMPLICITY_STATE_BYTES};
 use crate::error::{ErrorCode, TxError};
 use crate::suite_registry::RotationProvider;
+use crate::utxo_basic::UtxoEntry;
 use crate::wire_read::Reader;
 
 /// Rejects CORE_SIMPLICITY creation unless the rotation provider reports the
@@ -30,6 +33,29 @@ pub(crate) fn validate_core_simplicity_deployment_active(
             "CORE_SIMPLICITY deployment not active",
         ))
     }
+}
+
+/// The dedicated fail-closed reject for spending a CORE_SIMPLICITY (0x0106)
+/// output. Mirrors Go `rejectCoreSimplicitySpend`: spend evaluation is not yet
+/// enabled, so any 0x0106 spend is rejected with this exact code+message, ahead
+/// of generic covenant/witness errors.
+pub(crate) fn reject_core_simplicity_spend() -> TxError {
+    TxError::new(
+        ErrorCode::TxErrCovenantTypeInvalid,
+        "CORE_SIMPLICITY spend evaluation not enabled",
+    )
+}
+
+/// Rejects if any resolved input spends a CORE_SIMPLICITY (0x0106) output.
+/// Mirrors Go `rejectCoreSimplicitySpendIfPresent`.
+pub(crate) fn reject_core_simplicity_spend_if_present(inputs: &[UtxoEntry]) -> Result<(), TxError> {
+    if inputs
+        .iter()
+        .any(|input| input.covenant_type == COV_TYPE_CORE_SIMPLICITY)
+    {
+        return Err(reject_core_simplicity_spend());
+    }
+    Ok(())
 }
 
 /// Validates a CORE_SIMPLICITY creation output's `covenant_data`:

--- a/clients/rust/crates/rubin-consensus/src/tests/precompute.rs
+++ b/clients/rust/crates/rubin-consensus/src/tests/precompute.rs
@@ -1017,3 +1017,119 @@ fn add_witness_slots_overflow() {
         err.msg
     );
 }
+
+// RUB-591: a 0x0106 spend input is rejected by precompute with the dedicated
+// "spend evaluation not enabled" message and TX_ERR_COVENANT_TYPE_INVALID — even
+// with a mismatched witness count that would otherwise surface TX_ERR_PARSE
+// ("witness_count mismatch"). Mirrors Go StoppedAtCoreSimplicity priority.
+#[test]
+fn precompute_core_simplicity_0x0106_spend_rejects_ahead_of_witness_errors() {
+    let prev_txid = sha3_256(b"simplicity-spend");
+    let utxos = HashMap::from([(
+        Outpoint {
+            txid: prev_txid,
+            vout: 0,
+        },
+        UtxoEntry {
+            value: 500,
+            covenant_type: COV_TYPE_CORE_SIMPLICITY,
+            covenant_data: vec![0xab; 33],
+            creation_height: 0,
+            created_by_coinbase: false,
+        },
+    )]);
+    let tx = Tx {
+        version: 1,
+        tx_kind: 0x00,
+        tx_nonce: 1,
+        inputs: vec![TxInput {
+            prev_txid,
+            prev_vout: 0,
+            script_sig: Vec::new(),
+            sequence: 0,
+        }],
+        outputs: vec![TxOutput {
+            value: 400,
+            covenant_type: COV_TYPE_P2PK,
+            covenant_data: valid_p2pk_covenant_data(),
+        }],
+        locktime: 0,
+        da_commit_core: None,
+        da_chunk_core: None,
+        // Extra witnesses: would be "witness_count mismatch" (TX_ERR_PARSE) for a
+        // normal covenant, but must NOT mask the dedicated 0x0106 spend reject.
+        witness: vec![dummy_witness(), dummy_witness()],
+        da_payload: Vec::new(),
+    };
+    let pb = make_parsed_block(simple_coinbase(), vec![tx]);
+    let err = precompute_tx_contexts(&pb, &utxos, 100).unwrap_err();
+    assert_eq!(err.code, ErrorCode::TxErrCovenantTypeInvalid);
+    assert!(
+        err.msg
+            .contains("CORE_SIMPLICITY spend evaluation not enabled"),
+        "unexpected: {}",
+        err.msg
+    );
+}
+
+// RUB-591: precompute must STOP at the first 0x0106 input (mirror Go's early
+// return), so a trailing input that is independently invalid (here: a missing
+// UTXO) cannot surface its own error ahead of the dedicated 0x0106 reject. With
+// a `continue` (instead of `break`) this would return TX_ERR_MISSING_UTXO.
+#[test]
+fn precompute_core_simplicity_0x0106_spend_wins_over_trailing_input_error() {
+    let simp_prev = sha3_256(b"simplicity-first-input");
+    let missing_prev = sha3_256(b"missing-second-input");
+    let utxos = HashMap::from([(
+        Outpoint {
+            txid: simp_prev,
+            vout: 0,
+        },
+        UtxoEntry {
+            value: 500,
+            covenant_type: COV_TYPE_CORE_SIMPLICITY,
+            covenant_data: vec![0xab; 33],
+            creation_height: 0,
+            created_by_coinbase: false,
+        },
+    )]);
+    // missing_prev is intentionally absent from `utxos`.
+    let tx = Tx {
+        version: 1,
+        tx_kind: 0x00,
+        tx_nonce: 1,
+        inputs: vec![
+            TxInput {
+                prev_txid: simp_prev,
+                prev_vout: 0,
+                script_sig: Vec::new(),
+                sequence: 0,
+            },
+            TxInput {
+                prev_txid: missing_prev,
+                prev_vout: 0,
+                script_sig: Vec::new(),
+                sequence: 0,
+            },
+        ],
+        outputs: vec![TxOutput {
+            value: 400,
+            covenant_type: COV_TYPE_P2PK,
+            covenant_data: valid_p2pk_covenant_data(),
+        }],
+        locktime: 0,
+        da_commit_core: None,
+        da_chunk_core: None,
+        witness: vec![dummy_witness()],
+        da_payload: Vec::new(),
+    };
+    let pb = make_parsed_block(simple_coinbase(), vec![tx]);
+    let err = precompute_tx_contexts(&pb, &utxos, 100).unwrap_err();
+    assert_eq!(err.code, ErrorCode::TxErrCovenantTypeInvalid);
+    assert!(
+        err.msg
+            .contains("CORE_SIMPLICITY spend evaluation not enabled"),
+        "trailing missing-utxo must not mask the 0x0106 reject; got: {}",
+        err.msg
+    );
+}

--- a/clients/rust/crates/rubin-consensus/src/tests/simplicity_covenant.rs
+++ b/clients/rust/crates/rubin-consensus/src/tests/simplicity_covenant.rs
@@ -1,9 +1,14 @@
 use super::*;
 use crate::compactsize::encode_compact_size;
-use crate::constants::{COV_TYPE_CORE_SIMPLICITY, MAX_SIMPLICITY_STATE_BYTES, SUITE_ID_ML_DSA_87};
+use crate::constants::{
+    COV_TYPE_CORE_SIMPLICITY, COV_TYPE_P2PK, MAX_SIMPLICITY_STATE_BYTES, SIMPLICITY_WITNESS_SLOTS,
+    SUITE_ID_ML_DSA_87,
+};
 use crate::error::ErrorCode;
 use crate::suite_registry::{DefaultRotationProvider, NativeSuiteSet, RotationProvider};
 use crate::tx::{Tx, TxOutput};
+use crate::utxo_basic::UtxoEntry;
+use crate::vault::witness_slots;
 
 // Rotation provider that reports the Simplicity deployment active at/above a
 // threshold height, mirroring Go's testRotationProvider{simplicityActiveHeight}.
@@ -156,4 +161,40 @@ fn genesis_deployment_gate() {
     let bad = tx_with_outputs(vec![simplicity_output(1, vec![0u8; 10])]);
     let e = crate::validate_tx_covenants_genesis(&bad, 10, Some(&active)).unwrap_err();
     assert!(err_msg(&e).contains("program_cmr parse failure"));
+}
+
+fn utxo_entry(covenant_type: u16) -> UtxoEntry {
+    UtxoEntry {
+        value: 1,
+        covenant_type,
+        covenant_data: vec![],
+        creation_height: 0,
+        created_by_coinbase: false,
+    }
+}
+
+// Spend-side fail-closed building blocks (RUB-591). Mirrors Go
+// rejectCoreSimplicitySpend / rejectCoreSimplicitySpendIfPresent / WitnessSlots.
+#[test]
+fn spend_fail_closed_helpers() {
+    // witness_slots routes 0x0106 to SIMPLICITY_WITNESS_SLOTS (= 1).
+    assert_eq!(
+        witness_slots(COV_TYPE_CORE_SIMPLICITY, &[]).unwrap(),
+        SIMPLICITY_WITNESS_SLOTS as usize
+    );
+
+    // The dedicated reject carries the exact code + message.
+    let e = reject_core_simplicity_spend();
+    assert_eq!(e.code, ErrorCode::TxErrCovenantTypeInvalid);
+    assert!(err_msg(&e).contains("CORE_SIMPLICITY spend evaluation not enabled"));
+
+    // _if_present fires iff an input spends a 0x0106 output.
+    assert!(reject_core_simplicity_spend_if_present(&[]).is_ok());
+    assert!(reject_core_simplicity_spend_if_present(&[utxo_entry(COV_TYPE_P2PK)]).is_ok());
+    let e = reject_core_simplicity_spend_if_present(&[
+        utxo_entry(COV_TYPE_P2PK),
+        utxo_entry(COV_TYPE_CORE_SIMPLICITY),
+    ])
+    .unwrap_err();
+    assert!(err_msg(&e).contains("CORE_SIMPLICITY spend evaluation not enabled"));
 }

--- a/clients/rust/crates/rubin-consensus/src/tests/tx_validate_worker.rs
+++ b/clients/rust/crates/rubin-consensus/src/tests/tx_validate_worker.rs
@@ -290,6 +290,41 @@ fn validate_tx_local_multisig_dispatch_enters_branch() {
     assert_eq!(r.fee, 10);
 }
 
+// RUB-591: the worker upfront guard rejects a 0x0106 spend with the dedicated
+// message before any input dispatch (defensive — precompute already rejects it).
+#[test]
+fn validate_tx_local_rejects_core_simplicity_spend() {
+    let mut tx = simple_p2pk_tx(0x55);
+    tx.witness = vec![dummy_witness()];
+    let pb = make_parsed_block(simple_coinbase(), vec![tx]);
+    let ptc = PrecomputedTxContext {
+        tx_index: 1,
+        tx_block_idx: 1,
+        txid: [0u8; 32],
+        resolved_inputs: vec![UtxoEntry {
+            value: 100,
+            covenant_type: COV_TYPE_CORE_SIMPLICITY,
+            covenant_data: vec![],
+            creation_height: 1,
+            created_by_coinbase: false,
+        }],
+        witness_start: 0,
+        witness_end: 1,
+        input_outpoints: vec![Outpoint {
+            txid: [0u8; 32],
+            vout: 0,
+        }],
+        fee: 10,
+    };
+    let r = validate_tx_local(&ptc, &pb, [0u8; 32], 100, 0, None);
+    assert!(!r.valid);
+    let err = r.err.expect("0x0106 worker input must reject");
+    assert_eq!(err.code, ErrorCode::TxErrCovenantTypeInvalid);
+    assert!(err
+        .msg
+        .contains("CORE_SIMPLICITY spend evaluation not enabled"));
+}
+
 /// Covers validate_input_spend → COV_TYPE_VAULT branch. Uses synthetic PTC
 /// with a vault resolved input.
 #[test]

--- a/clients/rust/crates/rubin-consensus/src/tx_validate_worker.rs
+++ b/clients/rust/crates/rubin-consensus/src/tx_validate_worker.rs
@@ -9,6 +9,7 @@ use crate::precompute::PrecomputedTxContext;
 use crate::sig_cache::SigCache;
 use crate::sig_queue::SigCheckQueue;
 use crate::sighash::SighashV1PrehashCache;
+use crate::simplicity_covenant::reject_core_simplicity_spend_if_present;
 use crate::spend_verify::{validate_p2pk_spend_q, validate_threshold_sig_spend_q};
 use crate::stealth::validate_stealth_spend_q;
 use crate::suite_registry::{DefaultRotationProvider, RotationProvider, SuiteRegistry};
@@ -148,6 +149,13 @@ pub fn validate_tx_local(
     // (TxErrCovenantTypeInvalid) before any spend dispatch, so no CORE_EXT
     // profile gating runs here.
     let tx = &pb.txs[ptc.tx_block_idx];
+
+    // Fail-closed upfront guard (mirror Go ValidateTxLocal): a 0x0106 spend is
+    // rejected with the dedicated message before any input dispatch. Defensive —
+    // precompute already rejects 0x0106 inputs before a worker context exists.
+    if let Err(e) = reject_core_simplicity_spend_if_present(&ptc.resolved_inputs) {
+        return tx_validation_error_result(ptc, e);
+    }
 
     let mut sighash_cache = match build_tx_local_preflight(tx) {
         Ok(preflight) => preflight,
@@ -316,6 +324,9 @@ fn validate_input_spend(
 
         _ => {
             // Other covenant types have no spend-time checks in the genesis set.
+            // A 0x0106 input never reaches here — `validate_tx_local`'s upfront
+            // reject_core_simplicity_spend_if_present guard rejects it first
+            // (mirror Go ValidateTxLocal).
             Ok(())
         }
     }

--- a/clients/rust/crates/rubin-consensus/src/utxo_basic.rs
+++ b/clients/rust/crates/rubin-consensus/src/utxo_basic.rs
@@ -2,8 +2,8 @@ use std::collections::HashMap;
 use std::ops::Range;
 
 use crate::constants::{
-    COINBASE_MATURITY, COV_TYPE_ANCHOR, COV_TYPE_CORE_STEALTH, COV_TYPE_DA_COMMIT, COV_TYPE_HTLC,
-    COV_TYPE_MULTISIG, COV_TYPE_P2PK, COV_TYPE_VAULT,
+    COINBASE_MATURITY, COV_TYPE_ANCHOR, COV_TYPE_CORE_SIMPLICITY, COV_TYPE_CORE_STEALTH,
+    COV_TYPE_DA_COMMIT, COV_TYPE_HTLC, COV_TYPE_MULTISIG, COV_TYPE_P2PK, COV_TYPE_VAULT,
 };
 use crate::covenant_genesis::validate_tx_covenants_genesis;
 use crate::error::{ErrorCode, TxError};
@@ -11,6 +11,7 @@ use crate::hash::sha3_256;
 use crate::htlc::{parse_htlc_covenant_data, validate_htlc_spend_q, HtlcSpendContext};
 use crate::sig_queue::SigCheckQueue;
 use crate::sighash::SighashV1PrehashCache;
+use crate::simplicity_covenant::reject_core_simplicity_spend;
 use crate::spend_verify::{validate_p2pk_spend_q, validate_threshold_sig_spend_q};
 use crate::stealth::{parse_stealth_covenant_data, validate_stealth_spend_q};
 use crate::suite_registry::{RotationProvider, SuiteRegistry};
@@ -302,6 +303,12 @@ fn apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles_and_suite_c
                     "multiple CORE_VAULT inputs forbidden",
                 ));
             }
+        }
+        // Fail-closed: a CORE_SIMPLICITY (0x0106) spend is rejected with the
+        // dedicated message ahead of the generic check_spend_covenant/witness
+        // errors, matching Go's input-resolution order.
+        if entry.covenant_type == COV_TYPE_CORE_SIMPLICITY {
+            return Err(reject_core_simplicity_spend());
         }
         check_spend_covenant(entry.covenant_type, &entry.covenant_data)?;
         let slots = witness_slots(entry.covenant_type, &entry.covenant_data)?;
@@ -776,6 +783,54 @@ mod tests {
             )
             .expect_err("0x0102 spend must reject");
             assert_eq!(spend_err.code, ErrorCode::TxErrCovenantTypeInvalid);
+        }
+    }
+
+    // RUB-591: a tx consuming a 0x0106 UTXO is rejected during input resolution
+    // with the DEDICATED "spend evaluation not enabled" message — ahead of the
+    // generic check_spend_covenant/witness errors — for any covenant_data.
+    #[test]
+    fn core_simplicity_0x0106_spend_rejects_with_dedicated_message() {
+        let keypair = Mldsa87Keypair::generate().expect("keypair");
+        let pubkey = keypair.pubkey_bytes();
+        let spend_prev = [0x91; 32];
+        let spend_txid = [0x92; 32];
+        let spend_chain = [0x93; 32];
+        for cov_data in [vec![], vec![0xffu8; 8]] {
+            let spend_set =
+                HashMap::from([utxo(spend_prev, 100, COV_TYPE_CORE_SIMPLICITY, cov_data)]);
+            let mut spend_tx = unsigned_tx(
+                0x00,
+                2,
+                vec![tx_input(spend_prev)],
+                vec![tx_output(
+                    90,
+                    COV_TYPE_P2PK,
+                    p2pk_covenant_data_for_pubkey(&pubkey),
+                )],
+            );
+            spend_tx.witness = vec![WitnessItem {
+                suite_id: SUITE_ID_ML_DSA_87,
+                pubkey: pubkey.to_vec(),
+                signature: vec![0u8; 1],
+            }];
+            let err = apply_non_coinbase_tx_basic_update_with_mtp_and_core_ext_profiles_and_suite_context(
+                &spend_tx,
+                spend_txid,
+                &spend_set,
+                1,
+                0,
+                0,
+                spend_chain,
+                None,
+                None,
+            )
+            .expect_err("0x0106 spend must reject");
+            assert_eq!(err.code, ErrorCode::TxErrCovenantTypeInvalid);
+            assert!(
+                format!("{err}").contains("CORE_SIMPLICITY spend evaluation not enabled"),
+                "got: {err}"
+            );
         }
     }
 

--- a/clients/rust/crates/rubin-consensus/src/vault.rs
+++ b/clients/rust/crates/rubin-consensus/src/vault.rs
@@ -1,7 +1,8 @@
 use crate::compactsize::encode_compact_size;
 use crate::constants::{
-    CORE_STEALTH_WITNESS_SLOTS, COV_TYPE_CORE_STEALTH, COV_TYPE_HTLC, COV_TYPE_MULTISIG,
-    COV_TYPE_P2PK, COV_TYPE_VAULT, MAX_MULTISIG_KEYS, MAX_VAULT_KEYS, MAX_VAULT_WHITELIST_ENTRIES,
+    CORE_STEALTH_WITNESS_SLOTS, COV_TYPE_CORE_SIMPLICITY, COV_TYPE_CORE_STEALTH, COV_TYPE_HTLC,
+    COV_TYPE_MULTISIG, COV_TYPE_P2PK, COV_TYPE_VAULT, MAX_MULTISIG_KEYS, MAX_VAULT_KEYS,
+    MAX_VAULT_WHITELIST_ENTRIES, SIMPLICITY_WITNESS_SLOTS,
 };
 use crate::error::{ErrorCode, TxError};
 
@@ -217,6 +218,7 @@ pub fn witness_slots(covenant_type: u16, covenant_data: &[u8]) -> Result<usize, 
         // CORE_VAULT: owner_lock_id[32] || threshold[1] || key_count[1] || ...
         COV_TYPE_VAULT => Ok(covenant_data.get(33).copied().unwrap_or(1) as usize),
         COV_TYPE_HTLC => Ok(2),
+        COV_TYPE_CORE_SIMPLICITY => Ok(SIMPLICITY_WITNESS_SLOTS as usize),
         _ => Err(TxError::new(
             ErrorCode::TxErrCovenantTypeInvalid,
             "unsupported covenant in witness_slots",


### PR DESCRIPTION
## Summary

Rust mirror of the merged Go CORE_SIMPLICITY (0x0106) spend-side reference — **child 3 (final) of the RUB-495 split**: the **spend fail-closed error-priority** parity. Spending a 0x0106 output is rejected with the dedicated `TX_ERR_COVENANT_TYPE_INVALID` / `"CORE_SIMPLICITY spend evaluation not enabled"` on **every** path (sequential apply, precompute, worker), **ahead of** the generic covenant/witness/parse errors — matching Go's error priority. This is the fail-closed *reject precursor* only; actual Simplicity spend **evaluation/dispatch** is a later slice (RUB-505). Cross-client bundle unchanged (**519, Go == Rust**).

## Scope

- [x] Implementation-only change (Rust catches up to merged Go canonical rules; net accept/reject behavior preserved — a 0x0106 spend was rejected before and after, this aligns the error code/message/priority to Go).

**Consensus boundary:** Consensus rules unchanged: YES · `SECTION_HASHES.json` unchanged: YES · Wire format unchanged: YES

(The accept/reject decision is unchanged — 0x0106 spends are fail-closed before and after. This PR only aligns the Rust reject *code/message/priority* to the merged Go reference: previously a 0x0106 spend surfaced the generic `"unsupported covenant in basic apply"` (apply) / `"unsupported covenant in witness_slots"` (precompute) — fail-closed but divergent from Go, and precompute could surface `TX_ERR_PARSE` on a malformed witness count before the covenant reject. bundle 519 holds.)

### Parity exemption justification

Staged single-client (Rust) child slice of the Go-first Simplicity track. Its Go sibling is merged; this PR mirrors only the spend fail-closed reject into the Rust client. Per the staged Go→Rust split, the sibling client and shared evidence are separate Linear issues — do not add Go-side changes to satisfy per-PR source lockstep. Behavior parity is verified by `run_cv_bundle.py` = 519 (Go == Rust).

## What changed (Rust only)

- **constants.rs**: `SIMPLICITY_WITNESS_SLOTS = 1` (+ constants test).
- **vault.rs `witness_slots`**: route `COV_TYPE_CORE_SIMPLICITY → SIMPLICITY_WITNESS_SLOTS`, mirroring Go `WitnessSlots` (previously fell to the default error).
- **simplicity_covenant.rs**: `reject_core_simplicity_spend()` + `reject_core_simplicity_spend_if_present(inputs)`, mirroring Go `rejectCoreSimplicitySpend` / `...IfPresent`.
- **utxo_basic.rs (sequential apply)**: a 0x0106 input is early-stop rejected **before** `check_spend_covenant`/`witness_slots`, mirroring Go `connect_block_parallel.go` input resolution.
- **precompute.rs**: mirror Go `StoppedAtCoreSimplicity` — a 0x0106 input contributes 0 witness slots, relaxes the `witness_count` mismatch check, and surfaces the dedicated reject ahead of the fee/value-conservation checks.
- **tx_validate_worker.rs (`validate_tx_local`)**: upfront `reject_core_simplicity_spend_if_present` guard, mirroring Go `ValidateTxLocal` (defensive — precompute rejects a 0x0106 input before a worker context exists).

### Caller-completeness (mandatory gate)

Every spend-validation path that can encounter a 0x0106 input, with its Go analog:

| Rust path | change | Go analog | Verdict |
|---|---|---|---|
| sequential apply (`utxo_basic`) | 0x0106 early-stop reject before `check_spend_covenant` | `connect_block_parallel.go:327` | dedicated reject ✓ |
| precompute (`precompute_tx_contexts`) | `StoppedAtCoreSimplicity`: 0 slots, relaxed mismatch, reject before fee | `connect_block_parallel_precompute.go:149/233` | dedicated reject ✓ |
| worker (`validate_tx_local`) | upfront `reject_..._if_present` guard | `node` `tx_validate_worker.go:74` | dedicated reject ✓ |
| `witness_slots` routing | `0x0106 → SIMPLICITY_WITNESS_SLOTS` | `vault.go:188` | routed ✓ |

Note: there is no separate `connect_block_parallel.rs` in Rust — the **parallel** apply path *is* precompute + worker (both covered above); the apply path's authoritative reject is `utxo_basic`. Creation-side genesis (RUB-590) is unchanged.

## Verification

- `cargo test -p rubin-consensus` (727 lib + bins), `-p rubin-node` (761), `-p rubin-consensus-cli` — all green. Spend tests pin code+message on each path: apply, precompute (single-input witness-mismatch priority **and** multi-input `[0x0106, X]` trailing-error priority), worker guard, helpers, witness_slots routing.
- `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt --all --check` clean.
- `conformance/runner/run_cv_bundle.py` → **519/519 (Go == Rust)**. fixtures policy/drift, conformance ids, formal refinement/staleness, `check_pv_doc_compliance.py`, map-determinism — OK. No fixtures/spec changed.
- **Codacy diff coverage predicted locally** (tarpaulin lcov + `check_codacy_coverage.py`): **100% (23/23)**, ≥ 85% gate — verified before push.
- LOC: **330 insertions / 346 total changed lines** (≤350 hard cap).

### Adversarial review (2 rounds)

Reviewed adversarially across caller-completeness, consensus-correctness, Go-parity, and test-quality lenses (each finding adversarially verified). **Round 1 found a real P1**: precompute used `continue` on a 0x0106 input (a trailing invalid input could surface its error ahead of the dedicated reject, and precompute disagreed with the apply path). **Fixed**: `continue` → `break`, mirroring Go's early return in `collectPrecomputeTxInputs`, with a `[0x0106, missing-utxo]` regression test (fails under `continue`, passes under `break`). **Round 2 (re-review) confirmed the fix correct and complete on all orderings** (incl. non-first 0x0106) — 0 blocking findings; one non-blocking nit (a `[P2PK-valid, 0x0106]` precompute test would lock the non-first-ordering path, deferred to fit the LOC cap; the path is review-verified Go-equivalent and the non-first ordering is already covered for the `reject_..._if_present` helper).

Note on the worker path: the upfront `validate_tx_local` guard (mirror Go `ValidateTxLocal`) is the primary mechanism; Go's additional belt-and-suspenders per-input dispatch arm is intentionally omitted in Rust (unreachable behind the guard — zero observable difference) to fit the ≤350 LOC cap.

## Push note

Pushed via direct git (controller-authorized override): the `cl push` gate wrapper is absent in the authoring environment; the pre-push checks above were run manually.

Refs: Q-SIMPLICITY-COVENANT-CREATE-RUST-SPENDFAILCLOSED-01

🤖 Generated with [Claude Code](https://claude.com/claude-code)
