### PR TITLE
feat(rust-consensus): §5.4 Simplicity envelope (0xF0) parse case + structural-range guard [RUB-497]

### DIFF
--- a/clients/rust/crates/rubin-consensus-cli/src/main.rs
+++ b/clients/rust/crates/rubin-consensus-cli/src/main.rs
@@ -1138,7 +1138,11 @@ fn build_suite_registry_from_json(
 
     let mut suites = std::collections::BTreeMap::new();
     for s in items {
-        if s.suite_id == rubin_consensus::constants::SUITE_ID_SENTINEL || s.verify_cost == 0 {
+        // Reject structural ids (0xF0..=0xFE) (mirror of Go) so untrusted config can't panic `with_suites`.
+        if s.suite_id == rubin_consensus::constants::SUITE_ID_SENTINEL
+            || rubin_consensus::suite_registry::is_structural_witness_carrier_suite_id(s.suite_id)
+            || s.verify_cost == 0
+        {
             return Err("bad suite_registry".to_string());
         }
         let pubkey_len = validate_suite_registry_param_len(s.pubkey_len)?;
@@ -5583,6 +5587,19 @@ mod tests {
             sig_len: rubin_consensus::constants::ML_DSA_87_SIG_BYTES,
             verify_cost: rubin_consensus::constants::VERIFY_COST_ML_DSA_87,
             alg_name: "SLH-DSA".to_string(),
+        }])
+        .unwrap_err();
+        assert_eq!(err, "bad suite_registry");
+    }
+
+    #[test]
+    fn suite_registry_rejects_structural_carrier_suite_id() {
+        let err = build_suite_registry_from_json(&[SuiteParamsJson {
+            suite_id: rubin_consensus::constants::SUITE_ID_SIMPLICITY_ENVELOPE,
+            pubkey_len: rubin_consensus::constants::ML_DSA_87_PUBKEY_BYTES,
+            sig_len: rubin_consensus::constants::ML_DSA_87_SIG_BYTES,
+            verify_cost: rubin_consensus::constants::VERIFY_COST_ML_DSA_87,
+            alg_name: "ML-DSA-87".to_string(),
         }])
         .unwrap_err();
         assert_eq!(err, "bad suite_registry");

--- a/clients/rust/crates/rubin-consensus/src/constants.rs
+++ b/clients/rust/crates/rubin-consensus/src/constants.rs
@@ -60,6 +60,12 @@ pub const TX_WIRE_VERSION: u32 = 1;
 
 pub const SUITE_ID_SENTINEL: u8 = 0x00;
 pub const SUITE_ID_ML_DSA_87: u8 = 0x01;
+/// Structural witness carrier for CORE_SIMPLICITY (§5.4). Not a native crypto suite.
+pub const SUITE_ID_SIMPLICITY_ENVELOPE: u8 = 0xf0;
+
+/// Canonical bounds for the §5.4 Simplicity envelope witness item (mirror of Go).
+pub const MAX_SIMPLICITY_PROGRAM_BYTES: u64 = 16_384;
+pub const MAX_SIMPLICITY_ENVELOPE_BYTES: usize = 32_768;
 
 pub const COV_TYPE_P2PK: u16 = 0x0000;
 pub const COV_TYPE_ANCHOR: u16 = 0x0002;

--- a/clients/rust/crates/rubin-consensus/src/suite_registry.rs
+++ b/clients/rust/crates/rubin-consensus/src/suite_registry.rs
@@ -1,5 +1,6 @@
 use crate::constants::{
-    ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES, SUITE_ID_ML_DSA_87, VERIFY_COST_ML_DSA_87,
+    ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES, SUITE_ID_ML_DSA_87, SUITE_ID_SIMPLICITY_ENVELOPE,
+    VERIFY_COST_ML_DSA_87,
 };
 use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet};
@@ -23,6 +24,13 @@ pub struct SuiteParams {
 
 /// Maps suite IDs to their consensus parameters. Single source of truth for
 /// per-suite constants, replacing scattered hardcoded ML_DSA_87_* constants.
+/// Reports whether `suite_id` is reserved for a structural witness carrier (e.g.
+/// the §5.4 Simplicity envelope, 0xF0) rather than native cryptographic
+/// verification. Mirror of Go `IsStructuralWitnessCarrierSuiteID`.
+pub fn is_structural_witness_carrier_suite_id(suite_id: u8) -> bool {
+    (SUITE_ID_SIMPLICITY_ENVELOPE..=0xfe).contains(&suite_id)
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SuiteRegistry {
     suites: BTreeMap<u8, SuiteParams>,
@@ -66,6 +74,15 @@ impl SuiteRegistry {
     /// custom rotation deployments or tests that need additional suites beyond
     /// the default (e.g. `CryptoRotationDescriptor::validate` with old→new transition).
     pub fn with_suites(suites: BTreeMap<u8, SuiteParams>) -> Self {
+        // Structural-range guard (§5.4): suite IDs 0xF0..=0xFE are structural
+        // witness carriers, not native cryptographic suites, and must never be
+        // registered as one. Mirror of the Go suite-registry panic.
+        for &suite_id in suites.keys() {
+            assert!(
+                !is_structural_witness_carrier_suite_id(suite_id),
+                "structural witness carrier suite 0x{suite_id:02x} cannot be registered as native crypto suite",
+            );
+        }
         Self { suites }
     }
 

--- a/clients/rust/crates/rubin-consensus/src/suite_registry.rs
+++ b/clients/rust/crates/rubin-consensus/src/suite_registry.rs
@@ -22,8 +22,6 @@ pub struct SuiteParams {
     pub alg_name: &'static str,
 }
 
-/// Maps suite IDs to their consensus parameters. Single source of truth for
-/// per-suite constants, replacing scattered hardcoded ML_DSA_87_* constants.
 /// Reports whether `suite_id` is reserved for a structural witness carrier (e.g.
 /// the §5.4 Simplicity envelope, 0xF0) rather than native cryptographic
 /// verification. Mirror of Go `IsStructuralWitnessCarrierSuiteID`.
@@ -31,6 +29,8 @@ pub fn is_structural_witness_carrier_suite_id(suite_id: u8) -> bool {
     (SUITE_ID_SIMPLICITY_ENVELOPE..=0xfe).contains(&suite_id)
 }
 
+/// Maps suite IDs to their consensus parameters. Single source of truth for
+/// per-suite constants, replacing scattered hardcoded ML_DSA_87_* constants.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SuiteRegistry {
     suites: BTreeMap<u8, SuiteParams>,

--- a/clients/rust/crates/rubin-consensus/src/tests/tx_parse.rs
+++ b/clients/rust/crates/rubin-consensus/src/tests/tx_parse.rs
@@ -584,17 +584,11 @@ fn pow_check_rejects_invalid_header_length_before_target() {
 fn compact_size(n: usize) -> Vec<u8> {
     if n < 0xfd {
         vec![n as u8]
-    } else if n <= 0xffff {
+    } else {
+        // Test envelopes never exceed u16 lengths (the envelope cap is 32_768 bytes),
+        // so only the single-byte and 3-byte (0xfd) compactSize forms are needed.
         let mut v = vec![0xfd];
         v.extend_from_slice(&(n as u16).to_le_bytes());
-        v
-    } else if n <= 0xffff_ffff {
-        let mut v = vec![0xfe];
-        v.extend_from_slice(&(n as u32).to_le_bytes());
-        v
-    } else {
-        let mut v = vec![0xff];
-        v.extend_from_slice(&(n as u64).to_le_bytes());
         v
     }
 }
@@ -624,6 +618,24 @@ fn envelope_witness_tx(suite: u8, pubkey: &[u8], sig: &[u8]) -> Vec<u8> {
     tx.extend_from_slice(sig);
     tx.push(0x00); // da_payload_len
     tx
+}
+
+#[test]
+fn parse_tx_simplicity_envelope_witness_len_overflow_rejected() {
+    // witness_len = u64::MAX (0xFF compactSize) exceeds isize::MAX → TX_ERR_PARSE (mirror of Go).
+    let mut sig = vec![0x01u8]; // version
+    sig.push(0x00); // program_len = 0 (minimal)
+    sig.push(0xff); // witness_len: 64-bit compactSize form
+    sig.extend_from_slice(&u64::MAX.to_le_bytes());
+    sig.push(SIGHASH_ALL); // trailing sighash byte (stripped before parse)
+    let err = parse_tx(&envelope_witness_tx(
+        SUITE_ID_SIMPLICITY_ENVELOPE,
+        &[],
+        &sig,
+    ))
+    .unwrap_err();
+    assert_eq!(err.code, ErrorCode::TxErrParse);
+    assert_eq!(err.msg, "Simplicity witness_len overflows int");
 }
 
 #[test]

--- a/clients/rust/crates/rubin-consensus/src/tests/tx_parse.rs
+++ b/clients/rust/crates/rubin-consensus/src/tests/tx_parse.rs
@@ -578,3 +578,217 @@ fn pow_check_rejects_invalid_header_length_before_target() {
         assert_eq!(err.msg, "pow: invalid header length", "{name}");
     }
 }
+
+// --- RUB-497 §5.4 Simplicity envelope (0xF0) parse case (mirror of Go) ---
+
+fn compact_size(n: usize) -> Vec<u8> {
+    if n < 0xfd {
+        vec![n as u8]
+    } else if n <= 0xffff {
+        let mut v = vec![0xfd];
+        v.extend_from_slice(&(n as u16).to_le_bytes());
+        v
+    } else if n <= 0xffff_ffff {
+        let mut v = vec![0xfe];
+        v.extend_from_slice(&(n as u32).to_le_bytes());
+        v
+    } else {
+        let mut v = vec![0xff];
+        v.extend_from_slice(&(n as u64).to_le_bytes());
+        v
+    }
+}
+
+fn simplicity_env_sig_ver(version: u8, program: &[u8], witness: &[u8], sighash: u8) -> Vec<u8> {
+    let mut sig = vec![version];
+    sig.extend(compact_size(program.len()));
+    sig.extend_from_slice(program);
+    sig.extend(compact_size(witness.len()));
+    sig.extend_from_slice(witness);
+    sig.push(sighash);
+    sig
+}
+
+fn simplicity_env_sig(program: &[u8], witness: &[u8], sighash: u8) -> Vec<u8> {
+    simplicity_env_sig_ver(0x01, program, witness, sighash)
+}
+
+fn envelope_witness_tx(suite: u8, pubkey: &[u8], sig: &[u8]) -> Vec<u8> {
+    let mut tx = minimal_tx_bytes();
+    tx.truncate(core_end());
+    tx.push(0x01); // witness_count = 1
+    tx.push(suite);
+    tx.extend(compact_size(pubkey.len()));
+    tx.extend_from_slice(pubkey);
+    tx.extend(compact_size(sig.len()));
+    tx.extend_from_slice(sig);
+    tx.push(0x00); // da_payload_len
+    tx
+}
+
+#[test]
+fn parse_tx_simplicity_envelope_witness_canonicalization() {
+    let program = [0xa0u8, 0xa1, 0xa2];
+    let witness = [0xb0u8, 0xb1];
+    let valid_sig = simplicity_env_sig(&program, &witness, SIGHASH_ALL);
+
+    // valid_envelope: parses; suite=0xf0, pubkey empty, signature preserved.
+    let (parsed, _, _, _) = parse_tx(&envelope_witness_tx(
+        SUITE_ID_SIMPLICITY_ENVELOPE,
+        &[],
+        &valid_sig,
+    ))
+    .expect("valid envelope parses");
+    assert_eq!(parsed.witness.len(), 1);
+    assert_eq!(parsed.witness[0].suite_id, SUITE_ID_SIMPLICITY_ENVELOPE);
+    assert!(parsed.witness[0].pubkey.is_empty());
+    assert_eq!(parsed.witness[0].signature, valid_sig);
+
+    // invalid sighash type is a SEMANTIC concern, not a parse error.
+    let mut bad_sighash = valid_sig.clone();
+    *bad_sighash.last_mut().unwrap() = 0x7f;
+    let (parsed, _, _, _) = parse_tx(&envelope_witness_tx(
+        SUITE_ID_SIMPLICITY_ENVELOPE,
+        &[],
+        &bad_sighash,
+    ))
+    .expect("non-canonical sighash still parses");
+    assert_eq!(parsed.witness[0].signature, bad_sighash);
+
+    // TX_ERR_PARSE corners (byte-for-byte with the Go reference table).
+    let nonminimal: Vec<u8> = vec![
+        0x01,
+        0xfd,
+        program.len() as u8,
+        0x00,
+        program[0],
+        program[1],
+        program[2],
+        witness.len() as u8,
+        witness[0],
+        witness[1],
+        SIGHASH_ALL,
+    ];
+    let trailing: Vec<u8> = {
+        let mut s = valid_sig[..valid_sig.len() - 1].to_vec();
+        s.extend_from_slice(&[0xcc, SIGHASH_ALL]);
+        s
+    };
+    let truncated: Vec<u8> = vec![
+        0x01,
+        program.len() as u8,
+        program[0],
+        program[1],
+        program[2],
+        0x03,
+        witness[0],
+        witness[1],
+        SIGHASH_ALL,
+    ];
+    let cases: Vec<(&str, u8, Vec<u8>, Vec<u8>)> = vec![
+        (
+            "nonzero_pubkey",
+            SUITE_ID_SIMPLICITY_ENVELOPE,
+            vec![0x01],
+            valid_sig.clone(),
+        ),
+        (
+            "missing_envelope",
+            SUITE_ID_SIMPLICITY_ENVELOPE,
+            vec![],
+            vec![SIGHASH_ALL],
+        ),
+        (
+            "wrong_version",
+            SUITE_ID_SIMPLICITY_ENVELOPE,
+            vec![],
+            simplicity_env_sig_ver(0x02, &program, &witness, SIGHASH_ALL),
+        ),
+        (
+            "nonminimal_program_len",
+            SUITE_ID_SIMPLICITY_ENVELOPE,
+            vec![],
+            nonminimal,
+        ),
+        (
+            "trailing_envelope_byte",
+            SUITE_ID_SIMPLICITY_ENVELOPE,
+            vec![],
+            trailing,
+        ),
+        (
+            "truncated_witness",
+            SUITE_ID_SIMPLICITY_ENVELOPE,
+            vec![],
+            truncated,
+        ),
+        (
+            "program_too_large",
+            SUITE_ID_SIMPLICITY_ENVELOPE,
+            vec![],
+            simplicity_env_sig(
+                &vec![0u8; MAX_SIMPLICITY_PROGRAM_BYTES as usize + 1],
+                &[],
+                SIGHASH_ALL,
+            ),
+        ),
+        (
+            "envelope_too_large",
+            SUITE_ID_SIMPLICITY_ENVELOPE,
+            vec![],
+            simplicity_env_sig(
+                &vec![0u8; MAX_SIMPLICITY_PROGRAM_BYTES as usize],
+                &vec![0u8; MAX_SIMPLICITY_ENVELOPE_BYTES],
+                SIGHASH_ALL,
+            ),
+        ),
+    ];
+    for (name, suite, pubkey, sig) in cases {
+        let err = parse_tx(&envelope_witness_tx(suite, &pubkey, &sig)).unwrap_err();
+        assert_eq!(
+            err.code,
+            ErrorCode::TxErrParse,
+            "case {name}: expected TX_ERR_PARSE"
+        );
+    }
+
+    // Unknown suites in the structural range (0xF1..=0xFE) keep unknown-suite
+    // tolerance — only 0xF0 has the §5.4 structural parse rule.
+    for suite in [0xf1u8, 0xfe] {
+        let (parsed, _, _, _) =
+            parse_tx(&envelope_witness_tx(suite, &[0x01], &[0x02, SIGHASH_ALL]))
+                .unwrap_or_else(|e| panic!("unknown suite 0x{suite:02x} should parse: {e:?}"));
+        assert_eq!(parsed.witness.len(), 1);
+        assert_eq!(parsed.witness[0].suite_id, suite);
+    }
+}
+
+#[test]
+fn suite_registry_rejects_structural_carrier_registration() {
+    use crate::suite_registry::{
+        is_structural_witness_carrier_suite_id, SuiteParams, SuiteRegistry,
+    };
+    use std::collections::BTreeMap;
+    assert!(is_structural_witness_carrier_suite_id(
+        SUITE_ID_SIMPLICITY_ENVELOPE
+    ));
+    assert!(is_structural_witness_carrier_suite_id(0xfe));
+    assert!(!is_structural_witness_carrier_suite_id(0xff));
+    assert!(!is_structural_witness_carrier_suite_id(SUITE_ID_ML_DSA_87));
+    let mut m: BTreeMap<u8, SuiteParams> = BTreeMap::new();
+    m.insert(
+        SUITE_ID_SIMPLICITY_ENVELOPE,
+        SuiteParams {
+            suite_id: SUITE_ID_SIMPLICITY_ENVELOPE,
+            pubkey_len: 0,
+            sig_len: 0,
+            verify_cost: 0,
+            alg_name: "bogus",
+        },
+    );
+    let res = std::panic::catch_unwind(|| SuiteRegistry::with_suites(m));
+    assert!(
+        res.is_err(),
+        "registering a structural carrier as a crypto suite must panic"
+    );
+}

--- a/clients/rust/crates/rubin-consensus/src/tx.rs
+++ b/clients/rust/crates/rubin-consensus/src/tx.rs
@@ -405,8 +405,8 @@ fn validate_simplicity_envelope_signature(signature: &[u8]) -> Result<(), TxErro
     }
     r.read_bytes(program_len_u64 as usize)?;
     let (witness_len_u64, _) = read_compact_size(&mut r)?;
-    // Go rejects witness_len > math.MaxInt (== i64::MAX on the 64-bit consensus target).
-    if witness_len_u64 > i64::MAX as u64 {
+    // `isize::MAX` == Go's `math.MaxInt` on every target: byte-identical, and blocks a 32-bit `as usize` truncation.
+    if witness_len_u64 > isize::MAX as u64 {
         return Err(TxError::new(
             ErrorCode::TxErrParse,
             "Simplicity witness_len overflows int",

--- a/clients/rust/crates/rubin-consensus/src/tx.rs
+++ b/clients/rust/crates/rubin-consensus/src/tx.rs
@@ -362,8 +362,64 @@ fn validate_witness_item_shape(
                 "non-canonical ML-DSA witness item lengths",
             ))
         }
+        SUITE_ID_SIMPLICITY_ENVELOPE if pub_len_u64 != 0 => Err(TxError::new(
+            ErrorCode::TxErrParse,
+            "non-canonical Simplicity envelope witness item",
+        )),
+        SUITE_ID_SIMPLICITY_ENVELOPE => validate_simplicity_envelope_signature(signature),
         _ => Ok(()),
     }
+}
+
+/// Structurally validates a §5.4 Simplicity envelope witness signature, byte-for-byte
+/// with the merged Go `parseSimplicityEnvelopeSignature`: the trailing sighash byte is
+/// dropped, then version(0x01) + compactSize program + compactSize witness must consume
+/// the envelope exactly, within the canonical size bounds.
+fn validate_simplicity_envelope_signature(signature: &[u8]) -> Result<(), TxError> {
+    if signature.len() < 2 {
+        return Err(TxError::new(
+            ErrorCode::TxErrParse,
+            "non-canonical Simplicity envelope witness item",
+        ));
+    }
+    let envelope = &signature[..signature.len() - 1];
+    if envelope.len() > MAX_SIMPLICITY_ENVELOPE_BYTES {
+        return Err(TxError::new(
+            ErrorCode::TxErrParse,
+            "Simplicity envelope too large",
+        ));
+    }
+    let mut r = Reader::new(envelope);
+    if r.read_u8()? != 0x01 {
+        return Err(TxError::new(
+            ErrorCode::TxErrParse,
+            "non-canonical Simplicity envelope witness item",
+        ));
+    }
+    let (program_len_u64, _) = read_compact_size(&mut r)?;
+    if program_len_u64 > MAX_SIMPLICITY_PROGRAM_BYTES {
+        return Err(TxError::new(
+            ErrorCode::TxErrParse,
+            "Simplicity program too large",
+        ));
+    }
+    r.read_bytes(program_len_u64 as usize)?;
+    let (witness_len_u64, _) = read_compact_size(&mut r)?;
+    // Go rejects witness_len > math.MaxInt (== i64::MAX on the 64-bit consensus target).
+    if witness_len_u64 > i64::MAX as u64 {
+        return Err(TxError::new(
+            ErrorCode::TxErrParse,
+            "Simplicity witness_len overflows int",
+        ));
+    }
+    r.read_bytes(witness_len_u64 as usize)?;
+    if r.offset() != envelope.len() {
+        return Err(TxError::new(
+            ErrorCode::TxErrParse,
+            "non-canonical Simplicity envelope witness item",
+        ));
+    }
+    Ok(())
 }
 
 fn validate_sentinel_witness(pub_len: usize, signature: &[u8]) -> Result<(), TxError> {

--- a/clients/rust/crates/rubin-node/src/genesis.rs
+++ b/clients/rust/crates/rubin-node/src/genesis.rs
@@ -219,7 +219,11 @@ fn validate_suite_registry_param_len(value: u64) -> Result<u64, String> {
 }
 
 fn validate_suite_registry_item(item: &GenesisSuiteParams) -> Result<SuiteParams, String> {
-    if item.suite_id == SUITE_ID_SENTINEL || item.verify_cost == 0 {
+    // Reject structural ids (0xF0..=0xFE) here (mirror of Go) so untrusted genesis can't panic `with_suites`.
+    if item.suite_id == SUITE_ID_SENTINEL
+        || rubin_consensus::suite_registry::is_structural_witness_carrier_suite_id(item.suite_id)
+        || item.verify_cost == 0
+    {
         return Err("bad suite_registry".to_string());
     }
     let pubkey_len = validate_suite_registry_param_len(item.pubkey_len)?;
@@ -1121,6 +1125,21 @@ mod tests {
         assert_eq!(err, "bad suite_registry");
 
         std::fs::remove_dir_all(&dir).expect("cleanup");
+    }
+
+    #[test]
+    fn validate_suite_registry_item_rejects_structural_carrier() {
+        let item = GenesisSuiteParams {
+            suite_id: rubin_consensus::constants::SUITE_ID_SIMPLICITY_ENVELOPE,
+            pubkey_len: ML_DSA_87_PUBKEY_BYTES,
+            sig_len: ML_DSA_87_SIG_BYTES,
+            verify_cost: VERIFY_COST_ML_DSA_87,
+            alg_name: "ML-DSA-87".to_string(),
+        };
+        assert_eq!(
+            super::validate_suite_registry_item(&item).unwrap_err(),
+            "bad suite_registry"
+        );
     }
 
     #[test]

--- a/clients/rust/fuzz/fuzz_targets/suite_registry_surface.rs
+++ b/clients/rust/fuzz/fuzz_targets/suite_registry_surface.rs
@@ -14,7 +14,11 @@ fn build_registry(data: &[u8]) -> SuiteRegistry {
     }
 
     let mut suites = BTreeMap::new();
-    let custom_id = data.get(1).copied().unwrap_or(0x09);
+    // Fold structural ids (0xF0..=0xFE) into the native range so `with_suites` isn't a false crash.
+    let mut custom_id = data.get(1).copied().unwrap_or(0x09);
+    if rubin_consensus::suite_registry::is_structural_witness_carrier_suite_id(custom_id) {
+        custom_id &= 0x0f;
+    }
     let pubkey_len = u64::from(data.get(2).copied().unwrap_or(0)) + 1;
     let sig_len = u64::from(data.get(3).copied().unwrap_or(0)) + 1;
     let verify_cost = u64::from(data.get(4).copied().unwrap_or(0)) + 1;


### PR DESCRIPTION
Mirrors the merged Go reference (RUB-496 / #2027) for suite `0xF0` §5.4 parse behavior. **clients/rust only; no Go changes.**

## What
- `constants`: `SUITE_ID_SIMPLICITY_ENVELOPE=0xf0`, `MAX_SIMPLICITY_PROGRAM_BYTES=16384`, `MAX_SIMPLICITY_ENVELOPE_BYTES=32768`.
- `tx.rs validate_witness_item_shape`: `0xF0` parse case — pubkey must be empty; envelope = version `0x01` + compactSize program + compactSize witness, consumed exactly, within canonical bounds. `TX_ERR_PARSE` corners byte-identical to Go.
- `suite_registry`: structural-range guard `is_structural_witness_carrier_suite_id` (`0xF0..=0xFE`); `with_suites` panics if such a suite is registered as a native crypto suite (mirror of Go).

## Tests / gates
- Mirrored parse test: valid envelope, semantic-sighash tolerance, 8 `TX_ERR_PARSE` corners, unknown-suite tolerance (`0xF1`/`0xFE`); registry-guard test.
- `rubin-consensus`: 729 passed; clippy `-D warnings` clean; fmt clean; coverage diff 86.84% (gate 85%), variation -0.02%.

## Invariant
Rust `0xF0` parse is byte-identical to merged Go; every other suite parse byte-unchanged.

### Parity exemption justification
Single-client (Rust) leaf mirroring an ALREADY-MERGED Go reference (RUB-496 / #2027). No sibling-client (Go) changes and no shared corpus/vector/fixture changes; parity target is the merged Go behavior, verified by mirrored tests. Qualifies for `parity-exempt` per the RUB-497 ci_runtime_gate_contract (staged_split, client_slice: rust).

🤖 Generated with [Claude Code](https://claude.com/claude-code)