### PR TITLE
RUB-500: Rust SimplicityTxContext core construction (mirror of Go)

### DIFF
--- a/clients/rust/crates/rubin-consensus/src/lib.rs
+++ b/clients/rust/crates/rubin-consensus/src/lib.rs
@@ -22,6 +22,7 @@ mod sig_queue;
 pub mod sighash;
 pub mod simplicity;
 mod simplicity_covenant;
+pub mod simplicity_txcontext;
 mod spend_verify;
 mod stealth;
 pub mod subsidy;

--- a/clients/rust/crates/rubin-consensus/src/simplicity_covenant.rs
+++ b/clients/rust/crates/rubin-consensus/src/simplicity_covenant.rs
@@ -58,12 +58,20 @@ pub(crate) fn reject_core_simplicity_spend_if_present(inputs: &[UtxoEntry]) -> R
     Ok(())
 }
 
-/// Parses `program_cmr:bytes32 || state_len:CompactSize || state` (no trailing
-/// bytes, `state_len <= MAX_SIMPLICITY_STATE_BYTES`) into the CMR and a fresh
+/// Parses a CORE_SIMPLICITY covenant blob: rejects `value == 0`, then
+/// `program_cmr:bytes32 || state_len:CompactSize || state` (no trailing bytes,
+/// `state_len <= MAX_SIMPLICITY_STATE_BYTES`), returning the CMR and a fresh
 /// copy of the state. Mirrors Go `parseCoreSimplicityCovenantData`.
 pub(crate) fn parse_core_simplicity_covenant_data(
+    value: u64,
     covenant_data: &[u8],
 ) -> Result<([u8; 32], Vec<u8>), TxError> {
+    if value == 0 {
+        return Err(TxError::new(
+            ErrorCode::TxErrCovenantTypeInvalid,
+            "CORE_SIMPLICITY value must be > 0",
+        ));
+    }
     let mut r = Reader::new(covenant_data);
     let cmr_bytes = r.read_bytes(32).map_err(|_| {
         TxError::new(
@@ -110,13 +118,7 @@ pub(crate) fn validate_core_simplicity_covenant_data(
     value: u64,
     covenant_data: &[u8],
 ) -> Result<(), TxError> {
-    if value == 0 {
-        return Err(TxError::new(
-            ErrorCode::TxErrCovenantTypeInvalid,
-            "CORE_SIMPLICITY value must be > 0",
-        ));
-    }
-    parse_core_simplicity_covenant_data(covenant_data)?;
+    parse_core_simplicity_covenant_data(value, covenant_data)?;
     Ok(())
 }
 

--- a/clients/rust/crates/rubin-consensus/src/simplicity_covenant.rs
+++ b/clients/rust/crates/rubin-consensus/src/simplicity_covenant.rs
@@ -58,29 +58,21 @@ pub(crate) fn reject_core_simplicity_spend_if_present(inputs: &[UtxoEntry]) -> R
     Ok(())
 }
 
-/// Validates a CORE_SIMPLICITY creation output's `covenant_data`:
-/// `program_cmr:bytes32 || state_len:CompactSize || state`, with
-/// `value > 0`, `state_len <= MAX_SIMPLICITY_STATE_BYTES`, and the total
-/// length matching exactly (no trailing bytes). Mirrors Go
-/// `validateCoreSimplicityCovenantData`.
-pub(crate) fn validate_core_simplicity_covenant_data(
-    value: u64,
+/// Parses `program_cmr:bytes32 || state_len:CompactSize || state` (no trailing
+/// bytes, `state_len <= MAX_SIMPLICITY_STATE_BYTES`) into the CMR and a fresh
+/// copy of the state. Mirrors Go `parseCoreSimplicityCovenantData`.
+pub(crate) fn parse_core_simplicity_covenant_data(
     covenant_data: &[u8],
-) -> Result<(), TxError> {
-    if value == 0 {
-        return Err(TxError::new(
-            ErrorCode::TxErrCovenantTypeInvalid,
-            "CORE_SIMPLICITY value must be > 0",
-        ));
-    }
-
+) -> Result<([u8; 32], Vec<u8>), TxError> {
     let mut r = Reader::new(covenant_data);
-    if r.read_bytes(32).is_err() {
-        return Err(TxError::new(
+    let cmr_bytes = r.read_bytes(32).map_err(|_| {
+        TxError::new(
             ErrorCode::TxErrCovenantTypeInvalid,
             "CORE_SIMPLICITY program_cmr parse failure",
-        ));
-    }
+        )
+    })?;
+    let mut program_cmr = [0u8; 32];
+    program_cmr.copy_from_slice(cmr_bytes);
 
     let (state_len_u64, state_len_varint_bytes) = read_compact_size(&mut r).map_err(|_| {
         TxError::new(
@@ -96,18 +88,35 @@ pub(crate) fn validate_core_simplicity_covenant_data(
     }
     let state_len = state_len_u64 as usize;
 
-    if r.read_bytes(state_len).is_err() {
-        return Err(TxError::new(
+    let state = r.read_bytes(state_len).map_err(|_| {
+        TxError::new(
             ErrorCode::TxErrCovenantTypeInvalid,
             "CORE_SIMPLICITY state parse failure",
-        ));
-    }
+        )
+    })?;
     if covenant_data.len() != 32 + state_len_varint_bytes + state_len {
         return Err(TxError::new(
             ErrorCode::TxErrCovenantTypeInvalid,
             "CORE_SIMPLICITY covenant_data length mismatch",
         ));
     }
+    Ok((program_cmr, state.to_vec()))
+}
+
+/// Validates a CORE_SIMPLICITY creation output's `covenant_data`: `value > 0`
+/// and the structure parses exactly. Mirrors Go
+/// `validateCoreSimplicityCovenantData`.
+pub(crate) fn validate_core_simplicity_covenant_data(
+    value: u64,
+    covenant_data: &[u8],
+) -> Result<(), TxError> {
+    if value == 0 {
+        return Err(TxError::new(
+            ErrorCode::TxErrCovenantTypeInvalid,
+            "CORE_SIMPLICITY value must be > 0",
+        ));
+    }
+    parse_core_simplicity_covenant_data(covenant_data)?;
     Ok(())
 }
 

--- a/clients/rust/crates/rubin-consensus/src/simplicity_covenant.rs
+++ b/clients/rust/crates/rubin-consensus/src/simplicity_covenant.rs
@@ -60,12 +60,13 @@ pub(crate) fn reject_core_simplicity_spend_if_present(inputs: &[UtxoEntry]) -> R
 
 /// Parses a CORE_SIMPLICITY covenant blob: rejects `value == 0`, then
 /// `program_cmr:bytes32 || state_len:CompactSize || state` (no trailing bytes,
-/// `state_len <= MAX_SIMPLICITY_STATE_BYTES`), returning the CMR and a fresh
-/// copy of the state. Mirrors Go `parseCoreSimplicityCovenantData`.
+/// `state_len <= MAX_SIMPLICITY_STATE_BYTES`), returning the CMR and a borrowed
+/// `state` slice (callers copy only when they need ownership). Mirrors Go
+/// `parseCoreSimplicityCovenantData` (returns a slice; `Build` copies).
 pub(crate) fn parse_core_simplicity_covenant_data(
     value: u64,
     covenant_data: &[u8],
-) -> Result<([u8; 32], Vec<u8>), TxError> {
+) -> Result<([u8; 32], &[u8]), TxError> {
     if value == 0 {
         return Err(TxError::new(
             ErrorCode::TxErrCovenantTypeInvalid,
@@ -108,7 +109,7 @@ pub(crate) fn parse_core_simplicity_covenant_data(
             "CORE_SIMPLICITY covenant_data length mismatch",
         ));
     }
-    Ok((program_cmr, state.to_vec()))
+    Ok((program_cmr, state))
 }
 
 /// Validates a CORE_SIMPLICITY creation output's `covenant_data`: `value > 0`

--- a/clients/rust/crates/rubin-consensus/src/simplicity_txcontext.rs
+++ b/clients/rust/crates/rubin-consensus/src/simplicity_txcontext.rs
@@ -1,0 +1,201 @@
+//! CORE_SIMPLICITY (0x0106) transaction-context core construction — Rust mirror
+//! of the merged Go reference `simplicity_txcontext.go` (RUB-498). Crypto-free
+//! base + input/output views + per-input self view; group/DA views and spend
+//! dispatch are later slices (RUB-501 / RUB-459D / RUB-505).
+
+use crate::constants::{COV_TYPE_CORE_SIMPLICITY, MAX_TX_INPUTS, MAX_TX_OUTPUTS};
+use crate::error::{ErrorCode, TxError};
+use crate::simplicity_covenant::parse_core_simplicity_covenant_data;
+use crate::tx::Tx;
+use crate::txcontext::Uint128;
+use crate::utxo_basic::UtxoEntry;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SimplicityTxContextBase {
+    pub chain_id: [u8; 32],
+    pub total_in: Uint128,
+    pub total_out: Uint128,
+    pub height: u64,
+    pub tx_nonce: u64,
+    pub locktime: u32,
+    pub input_count: u16,
+    pub output_count: u16,
+    pub tx_kind: u8,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SimplicityTxContextIoView {
+    pub value: u64,
+    pub covenant_type: u16,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SimplicityTxContextSelfView {
+    pub self_program_cmr: [u8; 32],
+    pub digest32: [u8; 32],
+    pub self_state: Vec<u8>,
+    pub self_value: u64,
+    pub input_index: u16,
+    pub sighash_type: u8,
+}
+
+// Index-aligned with the resolved inputs; only CORE_SIMPLICITY inputs carry a
+// meaningful source, others keep a fail-closed placeholder.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct SimplicityTxContextSelfSource {
+    program_cmr: [u8; 32],
+    state: Vec<u8>,
+    value: u64,
+    is_core_simplicity: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SimplicityTxContext {
+    pub base: SimplicityTxContextBase,
+    input_views: Vec<SimplicityTxContextIoView>,
+    output_views: Vec<SimplicityTxContextIoView>,
+    self_sources: Vec<SimplicityTxContextSelfSource>,
+}
+
+fn parse_err(msg: &'static str) -> TxError {
+    TxError::new(ErrorCode::TxErrParse, msg)
+}
+
+/// Returns `Ok(None)` when no resolved input spends a CORE_SIMPLICITY output
+/// (mirrors the Go reference's `(nil, nil)`); otherwise builds the context
+/// fail-closed. Crypto-free.
+pub fn build_simplicity_tx_context(
+    tx: &Tx,
+    resolved_inputs: &[UtxoEntry],
+    block_height: u64,
+    chain_id: [u8; 32],
+) -> Result<Option<SimplicityTxContext>, TxError> {
+    if tx.inputs.len() != resolved_inputs.len() {
+        return Err(parse_err(
+            "simplicity txcontext resolved input count mismatch",
+        ));
+    }
+    if tx.inputs.len() as u64 > MAX_TX_INPUTS {
+        return Err(parse_err("simplicity txcontext input_count overflow"));
+    }
+    if tx.outputs.len() as u64 > MAX_TX_OUTPUTS {
+        return Err(parse_err("simplicity txcontext output_count overflow"));
+    }
+    if !resolved_inputs
+        .iter()
+        .any(|entry| entry.covenant_type == COV_TYPE_CORE_SIMPLICITY)
+    {
+        return Ok(None);
+    }
+
+    let total_in = sum_values(resolved_inputs.iter().map(|entry| entry.value))?;
+    let total_out = sum_values(tx.outputs.iter().map(|out| out.value))?;
+
+    // Counts are bounded by MAX_TX_INPUTS/MAX_TX_OUTPUTS above, so the u16
+    // narrowing below cannot truncate.
+    let base = SimplicityTxContextBase {
+        chain_id,
+        total_in,
+        total_out,
+        height: block_height,
+        tx_nonce: tx.tx_nonce,
+        locktime: tx.locktime,
+        input_count: tx.inputs.len() as u16,
+        output_count: tx.outputs.len() as u16,
+        tx_kind: tx.tx_kind,
+    };
+
+    let mut input_views = Vec::with_capacity(resolved_inputs.len());
+    let mut self_sources = Vec::with_capacity(resolved_inputs.len());
+    for entry in resolved_inputs {
+        input_views.push(SimplicityTxContextIoView {
+            value: entry.value,
+            covenant_type: entry.covenant_type,
+        });
+        if entry.covenant_type != COV_TYPE_CORE_SIMPLICITY {
+            self_sources.push(SimplicityTxContextSelfSource {
+                program_cmr: [0u8; 32],
+                state: Vec::new(),
+                value: 0,
+                is_core_simplicity: false,
+            });
+            continue;
+        }
+        let (program_cmr, state) = parse_core_simplicity_covenant_data(&entry.covenant_data)?;
+        self_sources.push(SimplicityTxContextSelfSource {
+            program_cmr,
+            state,
+            value: entry.value,
+            is_core_simplicity: true,
+        });
+    }
+
+    let output_views = tx
+        .outputs
+        .iter()
+        .map(|out| SimplicityTxContextIoView {
+            value: out.value,
+            covenant_type: out.covenant_type,
+        })
+        .collect();
+
+    Ok(Some(SimplicityTxContext {
+        base,
+        input_views,
+        output_views,
+        self_sources,
+    }))
+}
+
+// Widening each u64 to u128 before the add avoids truncation; the checked add
+// keeps the Go reference's fail-closed overflow corner (unreachable for the
+// wire-bounded counts).
+fn sum_values(values: impl Iterator<Item = u64>) -> Result<Uint128, TxError> {
+    let mut total: u128 = 0;
+    for value in values {
+        total = total
+            .checked_add(u128::from(value))
+            .ok_or_else(|| parse_err("u128 overflow"))?;
+    }
+    Ok(Uint128::from_native(total))
+}
+
+impl SimplicityTxContext {
+    pub fn input_views(&self) -> Vec<SimplicityTxContextIoView> {
+        self.input_views.clone()
+    }
+
+    pub fn output_views(&self) -> Vec<SimplicityTxContextIoView> {
+        self.output_views.clone()
+    }
+
+    pub fn self_view(
+        &self,
+        input_index: u16,
+        sighash_type: u8,
+        digest32: [u8; 32],
+    ) -> Result<SimplicityTxContextSelfView, TxError> {
+        let source = self
+            .self_sources
+            .get(input_index as usize)
+            .ok_or_else(|| parse_err("simplicity txcontext self input index out of range"))?;
+        if !source.is_core_simplicity {
+            return Err(TxError::new(
+                ErrorCode::TxErrCovenantTypeInvalid,
+                "simplicity txcontext self input is not CORE_SIMPLICITY",
+            ));
+        }
+        Ok(SimplicityTxContextSelfView {
+            self_program_cmr: source.program_cmr,
+            digest32,
+            self_state: source.state.clone(),
+            self_value: source.value,
+            input_index,
+            sighash_type,
+        })
+    }
+}
+
+#[cfg(test)]
+#[path = "tests/simplicity_txcontext.rs"]
+mod tests;

--- a/clients/rust/crates/rubin-consensus/src/simplicity_txcontext.rs
+++ b/clients/rust/crates/rubin-consensus/src/simplicity_txcontext.rs
@@ -90,9 +90,6 @@ pub fn build_simplicity_tx_context(
 
     let total_in = sum_values(resolved_inputs.iter().map(|entry| entry.value))?;
     let total_out = sum_values(tx.outputs.iter().map(|out| out.value))?;
-
-    // Counts are bounded by MAX_TX_INPUTS/MAX_TX_OUTPUTS (1024) above, so these
-    // u16 casts cannot truncate.
     #[allow(clippy::cast_possible_truncation)] // guarded len <= 1024 < u16::MAX
     let input_count = tx.inputs.len() as u16;
     #[allow(clippy::cast_possible_truncation)] // guarded len <= 1024 < u16::MAX
@@ -108,16 +105,30 @@ pub fn build_simplicity_tx_context(
         output_count,
         tx_kind: tx.tx_kind,
     };
+    let mut ctx = SimplicityTxContext {
+        base,
+        input_views: Vec::with_capacity(resolved_inputs.len()),
+        output_views: Vec::with_capacity(tx.outputs.len()),
+        self_sources: Vec::with_capacity(resolved_inputs.len()),
+    };
+    populate_simplicity_tx_context_views(&mut ctx, tx, resolved_inputs)?;
+    Ok(Some(ctx))
+}
 
-    let mut input_views = Vec::with_capacity(resolved_inputs.len());
-    let mut self_sources = Vec::with_capacity(resolved_inputs.len());
+/// Fills the input/output views and per-input self sources. Mirrors Go
+/// `populateSimplicityTxContextViews`, the decomposition `Build` delegates to.
+fn populate_simplicity_tx_context_views(
+    ctx: &mut SimplicityTxContext,
+    tx: &Tx,
+    resolved_inputs: &[UtxoEntry],
+) -> Result<(), TxError> {
     for entry in resolved_inputs {
-        input_views.push(SimplicityTxContextIoView {
+        ctx.input_views.push(SimplicityTxContextIoView {
             value: entry.value,
             covenant_type: entry.covenant_type,
         });
         if entry.covenant_type != COV_TYPE_CORE_SIMPLICITY {
-            self_sources.push(SimplicityTxContextSelfSource {
+            ctx.self_sources.push(SimplicityTxContextSelfSource {
                 program_cmr: [0u8; 32],
                 state: Vec::new(),
                 value: 0,
@@ -127,34 +138,23 @@ pub fn build_simplicity_tx_context(
         }
         let (program_cmr, state) =
             parse_core_simplicity_covenant_data(entry.value, &entry.covenant_data)?;
-        self_sources.push(SimplicityTxContextSelfSource {
+        ctx.self_sources.push(SimplicityTxContextSelfSource {
             program_cmr,
             state,
             value: entry.value,
             is_core_simplicity: true,
         });
     }
-
-    let output_views = tx
-        .outputs
-        .iter()
-        .map(|out| SimplicityTxContextIoView {
+    for out in &tx.outputs {
+        ctx.output_views.push(SimplicityTxContextIoView {
             value: out.value,
             covenant_type: out.covenant_type,
-        })
-        .collect();
-
-    Ok(Some(SimplicityTxContext {
-        base,
-        input_views,
-        output_views,
-        self_sources,
-    }))
+        });
+    }
+    Ok(())
 }
 
-// Widening each u64 to u128 before the add avoids truncation; the checked add
-// keeps the Go reference's fail-closed overflow corner (unreachable for the
-// wire-bounded counts).
+// u128-widened checked add: no truncation, and keeps Go's fail-closed overflow corner.
 fn sum_values(values: impl Iterator<Item = u64>) -> Result<Uint128, TxError> {
     let mut total: u128 = 0;
     for value in values {

--- a/clients/rust/crates/rubin-consensus/src/simplicity_txcontext.rs
+++ b/clients/rust/crates/rubin-consensus/src/simplicity_txcontext.rs
@@ -105,6 +105,7 @@ pub fn build_simplicity_tx_context(
         output_count,
         tx_kind: tx.tx_kind,
     };
+
     let mut ctx = SimplicityTxContext {
         base,
         input_views: Vec::with_capacity(resolved_inputs.len()),
@@ -140,7 +141,7 @@ fn populate_simplicity_tx_context_views(
             parse_core_simplicity_covenant_data(entry.value, &entry.covenant_data)?;
         ctx.self_sources.push(SimplicityTxContextSelfSource {
             program_cmr,
-            state,
+            state: state.to_vec(),
             value: entry.value,
             is_core_simplicity: true,
         });

--- a/clients/rust/crates/rubin-consensus/src/simplicity_txcontext.rs
+++ b/clients/rust/crates/rubin-consensus/src/simplicity_txcontext.rs
@@ -91,8 +91,12 @@ pub fn build_simplicity_tx_context(
     let total_in = sum_values(resolved_inputs.iter().map(|entry| entry.value))?;
     let total_out = sum_values(tx.outputs.iter().map(|out| out.value))?;
 
-    // Counts are bounded by MAX_TX_INPUTS/MAX_TX_OUTPUTS above, so the u16
-    // narrowing below cannot truncate.
+    // Counts are bounded by MAX_TX_INPUTS/MAX_TX_OUTPUTS (1024) above, so these
+    // u16 casts cannot truncate.
+    #[allow(clippy::cast_possible_truncation)] // guarded len <= 1024 < u16::MAX
+    let input_count = tx.inputs.len() as u16;
+    #[allow(clippy::cast_possible_truncation)] // guarded len <= 1024 < u16::MAX
+    let output_count = tx.outputs.len() as u16;
     let base = SimplicityTxContextBase {
         chain_id,
         total_in,
@@ -100,8 +104,8 @@ pub fn build_simplicity_tx_context(
         height: block_height,
         tx_nonce: tx.tx_nonce,
         locktime: tx.locktime,
-        input_count: tx.inputs.len() as u16,
-        output_count: tx.outputs.len() as u16,
+        input_count,
+        output_count,
         tx_kind: tx.tx_kind,
     };
 

--- a/clients/rust/crates/rubin-consensus/src/simplicity_txcontext.rs
+++ b/clients/rust/crates/rubin-consensus/src/simplicity_txcontext.rs
@@ -121,7 +121,8 @@ pub fn build_simplicity_tx_context(
             });
             continue;
         }
-        let (program_cmr, state) = parse_core_simplicity_covenant_data(&entry.covenant_data)?;
+        let (program_cmr, state) =
+            parse_core_simplicity_covenant_data(entry.value, &entry.covenant_data)?;
         self_sources.push(SimplicityTxContextSelfSource {
             program_cmr,
             state,

--- a/clients/rust/crates/rubin-consensus/src/tests/simplicity_txcontext.rs
+++ b/clients/rust/crates/rubin-consensus/src/tests/simplicity_txcontext.rs
@@ -4,7 +4,7 @@ use crate::constants::{
     COV_TYPE_CORE_SIMPLICITY, COV_TYPE_P2PK, MAX_TX_INPUTS, MAX_TX_OUTPUTS, SIGHASH_ALL,
 };
 use crate::error::ErrorCode;
-use crate::tx::{Tx, TxInput, TxOutput};
+use crate::tx::{DaChunkCore, Tx, TxInput, TxOutput};
 use crate::txcontext::Uint128;
 use crate::utxo_basic::UtxoEntry;
 
@@ -99,7 +99,14 @@ fn build_populates_base_views_self_and_fresh_copies() {
     let mut src = covenant(cmr, &state);
 
     let mut tx = tx_with(vec![input(), input()], vec![p2pk(u64::MAX), p2pk(1)]);
+    // tx_kind=0x02 with a valid da_chunk_core so the tx is well-formed in both
+    // clients (RUB-500 core ignores DA; the DA view + validation is RUB-501).
     tx.tx_kind = 2;
+    tx.da_chunk_core = Some(DaChunkCore {
+        da_id: [0u8; 32],
+        chunk_index: 0,
+        chunk_hash: [0u8; 32],
+    });
     tx.tx_nonce = 99;
     tx.locktime = 12345;
     let resolved = vec![

--- a/clients/rust/crates/rubin-consensus/src/tests/simplicity_txcontext.rs
+++ b/clients/rust/crates/rubin-consensus/src/tests/simplicity_txcontext.rs
@@ -1,0 +1,189 @@
+use super::*;
+use crate::compactsize::encode_compact_size;
+use crate::constants::{
+    COV_TYPE_CORE_SIMPLICITY, COV_TYPE_P2PK, MAX_TX_INPUTS, MAX_TX_OUTPUTS, SIGHASH_ALL,
+};
+use crate::error::ErrorCode;
+use crate::tx::{Tx, TxInput, TxOutput};
+use crate::txcontext::Uint128;
+use crate::utxo_basic::UtxoEntry;
+
+fn covenant(program_cmr: [u8; 32], state: &[u8]) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(&program_cmr);
+    encode_compact_size(state.len() as u64, &mut out);
+    out.extend_from_slice(state);
+    out
+}
+
+fn tx_with(inputs: Vec<TxInput>, outputs: Vec<TxOutput>) -> Tx {
+    Tx {
+        version: 1,
+        tx_kind: 0,
+        tx_nonce: 1,
+        inputs,
+        outputs,
+        locktime: 0,
+        witness: vec![],
+        da_payload: vec![],
+        da_commit_core: None,
+        da_chunk_core: None,
+    }
+}
+
+fn input() -> TxInput {
+    TxInput {
+        prev_txid: [0u8; 32],
+        prev_vout: 0,
+        script_sig: vec![],
+        sequence: 0,
+    }
+}
+
+fn utxo(value: u64, covenant_type: u16, covenant_data: Vec<u8>) -> UtxoEntry {
+    UtxoEntry {
+        value,
+        covenant_type,
+        covenant_data,
+        creation_height: 0,
+        created_by_coinbase: false,
+    }
+}
+
+fn p2pk(value: u64) -> TxOutput {
+    TxOutput {
+        value,
+        covenant_type: COV_TYPE_P2PK,
+        covenant_data: vec![],
+    }
+}
+
+#[test]
+fn build_returns_none_and_rejects_bad_counts() {
+    // No CORE_SIMPLICITY input -> no context.
+    let tx = tx_with(vec![input()], vec![p2pk(5)]);
+    let resolved = vec![utxo(10, COV_TYPE_P2PK, vec![])];
+    assert!(build_simplicity_tx_context(&tx, &resolved, 77, [0u8; 32])
+        .expect("build")
+        .is_none());
+
+    // Resolved-input count mismatch.
+    let tx2 = tx_with(vec![input(), input()], vec![]);
+    let err = build_simplicity_tx_context(&tx2, &resolved, 1, [0u8; 32]).expect_err("mismatch");
+    assert_eq!(err.code, ErrorCode::TxErrParse);
+    assert_eq!(
+        err.msg,
+        "simplicity txcontext resolved input count mismatch"
+    );
+
+    // Input-count overflow.
+    let n = MAX_TX_INPUTS as usize + 1;
+    let in_over = tx_with(vec![input(); n], vec![]);
+    let in_res = vec![utxo(0, COV_TYPE_P2PK, vec![]); n];
+    let err = build_simplicity_tx_context(&in_over, &in_res, 1, [0u8; 32]).expect_err("in over");
+    assert_eq!(err.msg, "simplicity txcontext input_count overflow");
+
+    // Output-count overflow.
+    let out_over = tx_with(vec![input()], vec![p2pk(0); MAX_TX_OUTPUTS as usize + 1]);
+    let out_res = vec![utxo(0, COV_TYPE_P2PK, vec![])];
+    let err = build_simplicity_tx_context(&out_over, &out_res, 1, [0u8; 32]).expect_err("out over");
+    assert_eq!(err.msg, "simplicity txcontext output_count overflow");
+}
+
+#[test]
+fn build_populates_base_views_self_and_fresh_copies() {
+    let chain_id = [0x11u8; 32];
+    let cmr = [0xaau8; 32];
+    let digest = [0x42u8; 32];
+    let state = [1u8, 2, 3];
+    let mut src = covenant(cmr, &state);
+
+    let mut tx = tx_with(vec![input(), input()], vec![p2pk(u64::MAX), p2pk(1)]);
+    tx.tx_kind = 2;
+    tx.tx_nonce = 99;
+    tx.locktime = 12345;
+    let resolved = vec![
+        utxo(u64::MAX, COV_TYPE_CORE_SIMPLICITY, src.clone()),
+        utxo(1, COV_TYPE_P2PK, vec![]),
+    ];
+
+    let ctx = build_simplicity_tx_context(&tx, &resolved, 700, chain_id)
+        .expect("build")
+        .expect("context");
+    src[0] = 0xff; // mutating the source after build must not alias into ctx
+
+    assert_eq!(ctx.base.chain_id, chain_id);
+    assert_eq!(ctx.base.height, 700);
+    assert_eq!(ctx.base.tx_kind, 2);
+    assert_eq!(ctx.base.tx_nonce, 99);
+    assert_eq!(ctx.base.locktime, 12345);
+    assert_eq!(ctx.base.input_count, 2);
+    assert_eq!(ctx.base.output_count, 2);
+    // u64::MAX + 1 == 2^64 -> hi carry.
+    assert_eq!(ctx.base.total_in, Uint128 { lo: 0, hi: 1 });
+    assert_eq!(ctx.base.total_out, Uint128 { lo: 0, hi: 1 });
+
+    let inputs = ctx.input_views();
+    assert_eq!(inputs.len(), 2);
+    assert_eq!(inputs[0].value, u64::MAX);
+    assert_eq!(inputs[0].covenant_type, COV_TYPE_CORE_SIMPLICITY);
+    assert_eq!(
+        ctx.output_views()[1],
+        SimplicityTxContextIoView {
+            value: 1,
+            covenant_type: COV_TYPE_P2PK,
+        }
+    );
+
+    let mut self_view = ctx.self_view(0, SIGHASH_ALL, digest).expect("self");
+    assert_eq!(self_view.input_index, 0);
+    assert_eq!(self_view.self_value, u64::MAX);
+    assert_eq!(self_view.sighash_type, SIGHASH_ALL);
+    assert_eq!(self_view.self_program_cmr, cmr);
+    assert_eq!(self_view.digest32, digest);
+    assert_eq!(self_view.self_state, state.to_vec());
+
+    // Accessors return fresh copies: local mutation must not leak back.
+    self_view.self_state.push(0xaa);
+    let mut views = ctx.input_views();
+    views[0].value = 0;
+    assert_eq!(
+        ctx.self_view(0, SIGHASH_ALL, digest).unwrap().self_state,
+        state.to_vec()
+    );
+    assert_eq!(ctx.input_views()[0].value, u64::MAX);
+
+    // Self view fail-closed: input 1 is P2PK, input 2 is out of range.
+    let e1 = ctx.self_view(1, SIGHASH_ALL, digest).expect_err("non-core");
+    assert_eq!(e1.code, ErrorCode::TxErrCovenantTypeInvalid);
+    let e2 = ctx
+        .self_view(2, SIGHASH_ALL, digest)
+        .expect_err("out of range");
+    assert_eq!(e2.code, ErrorCode::TxErrParse);
+}
+
+#[test]
+fn build_accepts_empty_state_without_aliasing() {
+    let cmr = [0x51u8; 32];
+    let mut src = covenant(cmr, &[]);
+    let tx = tx_with(vec![input()], vec![]);
+    let resolved = vec![utxo(1, COV_TYPE_CORE_SIMPLICITY, src.clone())];
+
+    let ctx = build_simplicity_tx_context(&tx, &resolved, 1, [0u8; 32])
+        .expect("build")
+        .expect("context");
+    src[0] = 0xff;
+
+    let self_view = ctx.self_view(0, SIGHASH_ALL, [0u8; 32]).expect("self");
+    assert_eq!(self_view.self_program_cmr, cmr);
+    assert!(self_view.self_state.is_empty());
+}
+
+#[test]
+fn build_fails_closed_on_malformed_self_covenant() {
+    let tx = tx_with(vec![input()], vec![]);
+    let resolved = vec![utxo(1, COV_TYPE_CORE_SIMPLICITY, vec![0x01])];
+    let err = build_simplicity_tx_context(&tx, &resolved, 1, [0u8; 32]).expect_err("malformed");
+    assert_eq!(err.code, ErrorCode::TxErrCovenantTypeInvalid);
+    assert_eq!(err.msg, "CORE_SIMPLICITY program_cmr parse failure");
+}

--- a/clients/rust/crates/rubin-consensus/src/tests/simplicity_txcontext.rs
+++ b/clients/rust/crates/rubin-consensus/src/tests/simplicity_txcontext.rs
@@ -187,3 +187,18 @@ fn build_fails_closed_on_malformed_self_covenant() {
     assert_eq!(err.code, ErrorCode::TxErrCovenantTypeInvalid);
     assert_eq!(err.msg, "CORE_SIMPLICITY program_cmr parse failure");
 }
+
+#[test]
+fn build_rejects_zero_value_core_simplicity_input() {
+    // Mirrors Go: parse checks value > 0 before structure, so a structurally
+    // valid but zero-value CORE_SIMPLICITY input is rejected at build time.
+    let tx = tx_with(vec![input()], vec![]);
+    let resolved = vec![utxo(
+        0,
+        COV_TYPE_CORE_SIMPLICITY,
+        covenant([0x77u8; 32], &[]),
+    )];
+    let err = build_simplicity_tx_context(&tx, &resolved, 1, [0u8; 32]).expect_err("zero value");
+    assert_eq!(err.code, ErrorCode::TxErrCovenantTypeInvalid);
+    assert_eq!(err.msg, "CORE_SIMPLICITY value must be > 0");
+}


### PR DESCRIPTION
Mirrors the merged Go reference `clients/go/consensus/simplicity_txcontext.go` (RUB-498, since extended on `main`): the crypto-free `SimplicityTxContext` **base + input/output views + per-input self view**. Rust-side catch-up of an already-merged Go primitive.

**Invariant:** Rust core construction matches the current Go reference's accept/reject on base/IO/self — same u128 totals, `value > 0` gate on CORE_SIMPLICITY inputs, and defensive state/CMR copies (a later mutation of the source covenant blob cannot alias into the context). Returns `Ok(None)` when no resolved input spends a CORE_SIMPLICITY output (mirrors Go `(nil, nil)`).

**Changed (clients/rust only):**
- `simplicity_txcontext.rs` — new module: base / IO-view / self-view types + `build_simplicity_tx_context` (fail-closed on count mismatch, wire-bound overflow, covenant parse).
- `simplicity_covenant.rs` — `parse_core_simplicity_covenant_data` gains the `value` arg and enforces `value > 0` first (mirrors current Go); `validate_core_simplicity_covenant_data` delegates.
- `lib.rs` — module decl. Plus mirrored unit tests.

**Non-scope (per contract):** no group/DA views (RUB-501), no descriptor-hash accessors, no dispatch (RUB-505), no Go changes.

**Validation:** local `cl push` matrix GREEN — clean-tree · contract (445/450 LOC) · deterministic (full Go+Rust deep tests, clippy, scaffold-lints, semgrep, cargo-deny) · policy · coverage (100% diff). Semantic: dynamic reviewer fan-out was run — see the deferral below.

**Deferred to RUB-501 (controller-approved, ownership verified) — one bundle, three rejects.** RUB-500 mirrors only the CORE of Go's `BuildSimplicityTxContext` (base + `{value, covenant_type}` IO views + self view). The current Go entry point additionally bundles output-descriptor / group-view / DA-view construction that is owned by **RUB-501** — the Rust mirror of Go **RUB-499** (which added all of them; commit `81d7297`). So the Rust core build does not yet perform three rejects that Go does; all three land in RUB-501 and appear here only as non-blocking **P2** parity-accuracy notes (Copilot/Codex compare whole-function and are blind to the staged split):

1. **CORE_SIMPLICITY output** value==0 / malformed-covenant reject — Go `populateSimplicityTxContextOutputViews` → `parseCoreSimplicityCovenantData(out.Value, …)` (rides with the output descriptor = RUB-501).
2. **Same-CMR input group cap** `SIMPLICITY_MAX_GROUP_INPUTS` — Go's `groupInputs` bound = group-view machinery = RUB-501.
3. **DA-view** `tx_kind` / `da_core` reject — Go `buildSimplicityTxContextDAView` (`SimplicityTxContextDAView` / "DaSameTxView"; no separate symbol) = RUB-501.

None is production-reachable: `build_simplicity_tx_context` has no caller yet, and the strict sequential chain lands RUB-501 (which re-mirrors all three, byte-identical, with shadow wiring into the build path) before RUB-505 (spend dispatch) wires it in. The only core-required reject — CORE_SIMPLICITY **input** `value > 0`, whose parse feeds the self view — IS enforced here. The semantic matrix cell was therefore taken as a recorded `CL_SKIP_SEMANTIC=1` bypass for this reason.

### Parity exemption justification
Single-client (Rust-only) PR. The Go counterpart is already merged on `main` (RUB-498, `clients/go/consensus/simplicity_txcontext.go`); this PR is the Rust mirror, so no paired Go change exists or is expected. The cross-client construction parity corpus is owned by RUB-501.

Refs: RUB-500

🤖 Generated with [Claude Code](https://claude.com/claude-code)
