### PR TITLE
RUB-501: Rust SimplicityTxContext group/DA views + output reject (mirror of Go)

### DIFF
--- a/clients/rust/crates/rubin-consensus/src/constants.rs
+++ b/clients/rust/crates/rubin-consensus/src/constants.rs
@@ -33,6 +33,7 @@ pub const MAX_HTLC_COVENANT_DATA: u64 = 105;
 pub const MIN_HTLC_PREIMAGE_BYTES: u64 = 16; // consensus security floor (Q-A287-03)
 pub const MAX_HTLC_PREIMAGE_BYTES: u64 = 256;
 pub const MAX_SIMPLICITY_STATE_BYTES: u64 = 512;
+pub const SIMPLICITY_MAX_GROUP_INPUTS: usize = 8;
 pub const MAX_VAULT_KEYS: u8 = 12;
 pub const MAX_VAULT_WHITELIST_ENTRIES: u16 = 1024;
 pub const MAX_MULTISIG_KEYS: u8 = 12;

--- a/clients/rust/crates/rubin-consensus/src/simplicity_txcontext.rs
+++ b/clients/rust/crates/rubin-consensus/src/simplicity_txcontext.rs
@@ -1,12 +1,18 @@
-//! CORE_SIMPLICITY (0x0106) transaction-context core construction — Rust mirror
-//! of the merged Go reference `simplicity_txcontext.go` (RUB-498). Crypto-free
-//! base + input/output views + per-input self view; group/DA views and spend
-//! dispatch are later slices (RUB-501 / RUB-459D / RUB-505).
+//! CORE_SIMPLICITY (0x0106) transaction-context construction — Rust mirror of the
+//! merged Go reference `simplicity_txcontext.go`. Base + IO views + self view
+//! (RUB-500); same-CMR group views (8/8 + symmetric B-1 + atomic overflow
+//! discard), the DA view, and the output covenant reject (RUB-501). Descriptor-hash
+//! accessors and spend dispatch are later slices (RUB-503 / RUB-505).
 
-use crate::constants::{COV_TYPE_CORE_SIMPLICITY, MAX_TX_INPUTS, MAX_TX_OUTPUTS};
+use std::collections::BTreeMap;
+
+use crate::constants::{
+    COV_TYPE_CORE_SIMPLICITY, MAX_DA_CHUNK_COUNT, MAX_DA_MANIFEST_BYTES_PER_TX, MAX_TX_INPUTS,
+    MAX_TX_OUTPUTS, SIMPLICITY_MAX_GROUP_INPUTS,
+};
 use crate::error::{ErrorCode, TxError};
 use crate::simplicity_covenant::parse_core_simplicity_covenant_data;
-use crate::tx::Tx;
+use crate::tx::{DaCommitCore, Tx, TxOutput};
 use crate::txcontext::Uint128;
 use crate::utxo_basic::UtxoEntry;
 
@@ -27,6 +33,52 @@ pub struct SimplicityTxContextBase {
 pub struct SimplicityTxContextIoView {
     pub value: u64,
     pub covenant_type: u16,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SimplicityTxContextGroupEntry {
+    pub state: Vec<u8>,
+    pub value: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SimplicityTxContextSameCmrView {
+    pub program_cmr: [u8; 32],
+    pub inputs: Vec<SimplicityTxContextGroupEntry>,
+    pub outputs: Vec<SimplicityTxContextGroupEntry>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum SimplicityTxContextDaViewKind {
+    #[default]
+    Absent,
+    Commit,
+    Chunk,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub struct SimplicityTxContextDaCommitView {
+    pub da_id: [u8; 32],
+    pub retl_domain_id: [u8; 32],
+    pub tx_data_root: [u8; 32],
+    pub state_root: [u8; 32],
+    pub withdrawals_root: [u8; 32],
+    pub batch_number: u64,
+    pub chunk_count: u16,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub struct SimplicityTxContextDaChunkView {
+    pub da_id: [u8; 32],
+    pub chunk_hash: [u8; 32],
+    pub chunk_index: u16,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub struct SimplicityTxContextDaView {
+    pub commit: SimplicityTxContextDaCommitView,
+    pub chunk: SimplicityTxContextDaChunkView,
+    pub kind: SimplicityTxContextDaViewKind,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -55,6 +107,11 @@ pub struct SimplicityTxContext {
     input_views: Vec<SimplicityTxContextIoView>,
     output_views: Vec<SimplicityTxContextIoView>,
     self_sources: Vec<SimplicityTxContextSelfSource>,
+    // Keyed by program_cmr; the per-key Vec preserves ascending input/output
+    // order. BTreeMap keeps the structure iteration-order-free (determinism).
+    group_inputs: BTreeMap<[u8; 32], Vec<SimplicityTxContextGroupEntry>>,
+    group_outputs: BTreeMap<[u8; 32], Vec<SimplicityTxContextGroupEntry>>,
+    da_view: SimplicityTxContextDaView,
 }
 
 fn parse_err(msg: &'static str) -> TxError {
@@ -88,21 +145,16 @@ pub fn build_simplicity_tx_context(
         return Ok(None);
     }
 
-    let total_in = sum_values(resolved_inputs.iter().map(|entry| entry.value))?;
-    let total_out = sum_values(tx.outputs.iter().map(|out| out.value))?;
-    #[allow(clippy::cast_possible_truncation)] // guarded len <= 1024 < u16::MAX
-    let input_count = tx.inputs.len() as u16;
-    #[allow(clippy::cast_possible_truncation)] // guarded len <= 1024 < u16::MAX
-    let output_count = tx.outputs.len() as u16;
+    #[allow(clippy::cast_possible_truncation)] // counts guarded len <= 1024 < u16::MAX
     let base = SimplicityTxContextBase {
         chain_id,
-        total_in,
-        total_out,
+        total_in: sum_values(resolved_inputs.iter().map(|entry| entry.value))?,
+        total_out: sum_values(tx.outputs.iter().map(|out| out.value))?,
         height: block_height,
         tx_nonce: tx.tx_nonce,
         locktime: tx.locktime,
-        input_count,
-        output_count,
+        input_count: tx.inputs.len() as u16,
+        output_count: tx.outputs.len() as u16,
         tx_kind: tx.tx_kind,
     };
 
@@ -111,16 +163,33 @@ pub fn build_simplicity_tx_context(
         input_views: Vec::with_capacity(resolved_inputs.len()),
         output_views: Vec::with_capacity(tx.outputs.len()),
         self_sources: Vec::with_capacity(resolved_inputs.len()),
+        group_inputs: BTreeMap::new(),
+        group_outputs: BTreeMap::new(),
+        da_view: SimplicityTxContextDaView::default(),
     };
     populate_simplicity_tx_context_views(&mut ctx, tx, resolved_inputs)?;
     Ok(Some(ctx))
 }
 
-/// Fills the input/output views and per-input self sources. Mirrors Go
-/// `populateSimplicityTxContextViews`, the decomposition `Build` delegates to.
+/// Fills input/output views, per-input self sources, same-CMR group views, and
+/// the DA view. Mirrors Go `populateSimplicityTxContextViews`, the decomposition
+/// `Build` delegates to.
 fn populate_simplicity_tx_context_views(
     ctx: &mut SimplicityTxContext,
     tx: &Tx,
+    resolved_inputs: &[UtxoEntry],
+) -> Result<(), TxError> {
+    populate_simplicity_tx_context_input_views(ctx, resolved_inputs)?;
+    populate_simplicity_tx_context_output_views(ctx, &tx.outputs)?;
+    ctx.da_view = build_simplicity_tx_context_da_view(tx)?;
+    Ok(())
+}
+
+/// Input views + per-input self sources + same-CMR input groups. A same-CMR input
+/// group exceeding `SIMPLICITY_MAX_GROUP_INPUTS` fails closed (atomic discard: the
+/// error unwinds the whole build). Mirrors Go `populateSimplicityTxContextInputViews`.
+fn populate_simplicity_tx_context_input_views(
+    ctx: &mut SimplicityTxContext,
     resolved_inputs: &[UtxoEntry],
 ) -> Result<(), TxError> {
     for entry in resolved_inputs {
@@ -145,14 +214,105 @@ fn populate_simplicity_tx_context_views(
             value: entry.value,
             is_core_simplicity: true,
         });
+        let group = ctx.group_inputs.entry(program_cmr).or_default();
+        group.push(SimplicityTxContextGroupEntry {
+            value: entry.value,
+            state: state.to_vec(),
+        });
+        if group.len() > SIMPLICITY_MAX_GROUP_INPUTS {
+            return Err(TxError::new(
+                ErrorCode::TxErrCovenantTypeInvalid,
+                "CORE_SIMPLICITY same-cmr input group exceeds limit",
+            ));
+        }
     }
-    for out in &tx.outputs {
+    Ok(())
+}
+
+/// Output views + same-CMR output groups. A CORE_SIMPLICITY output whose value is 0
+/// or whose covenant_data is malformed fails closed via the shared parse (the reject
+/// RUB-500 core deferred here). Mirrors Go `populateSimplicityTxContextOutputViews`.
+fn populate_simplicity_tx_context_output_views(
+    ctx: &mut SimplicityTxContext,
+    outputs: &[TxOutput],
+) -> Result<(), TxError> {
+    for out in outputs {
         ctx.output_views.push(SimplicityTxContextIoView {
             value: out.value,
             covenant_type: out.covenant_type,
         });
+        if out.covenant_type != COV_TYPE_CORE_SIMPLICITY {
+            continue;
+        }
+        let (program_cmr, state) =
+            parse_core_simplicity_covenant_data(out.value, &out.covenant_data)?;
+        ctx.group_outputs
+            .entry(program_cmr)
+            .or_default()
+            .push(SimplicityTxContextGroupEntry {
+                value: out.value,
+                state: state.to_vec(),
+            });
     }
     Ok(())
+}
+
+/// Builds the DA view from `tx_kind`: 0x00 absent, 0x01 commit (validated), 0x02
+/// chunk (validated), any other rejected. Mirrors Go `buildSimplicityTxContextDAView`;
+/// re-validates the DA cores since the builder may take a directly-constructed tx.
+fn build_simplicity_tx_context_da_view(tx: &Tx) -> Result<SimplicityTxContextDaView, TxError> {
+    let mut view = SimplicityTxContextDaView::default();
+    match tx.tx_kind {
+        0x00 => view.kind = SimplicityTxContextDaViewKind::Absent,
+        0x01 => {
+            let core = validate_simplicity_tx_context_da_commit_core(tx.da_commit_core.as_ref())?;
+            view.kind = SimplicityTxContextDaViewKind::Commit;
+            view.commit = SimplicityTxContextDaCommitView {
+                da_id: core.da_id,
+                chunk_count: core.chunk_count,
+                retl_domain_id: core.retl_domain_id,
+                batch_number: core.batch_number,
+                tx_data_root: core.tx_data_root,
+                state_root: core.state_root,
+                withdrawals_root: core.withdrawals_root,
+            };
+        }
+        0x02 => {
+            let core = tx
+                .da_chunk_core
+                .as_ref()
+                .ok_or_else(|| parse_err("missing da_chunk_core for tx_kind=0x02"))?;
+            if u64::from(core.chunk_index) >= MAX_DA_CHUNK_COUNT {
+                return Err(parse_err("chunk_index out of range for tx_kind=0x02"));
+            }
+            view.kind = SimplicityTxContextDaViewKind::Chunk;
+            view.chunk = SimplicityTxContextDaChunkView {
+                da_id: core.da_id,
+                chunk_index: core.chunk_index,
+                chunk_hash: core.chunk_hash,
+            };
+        }
+        _ => return Err(parse_err("unsupported tx_kind")),
+    }
+    Ok(view)
+}
+
+/// Fail-closed DA commit-core validation for tx_kind=0x01: rejects a missing core, a
+/// zero/over-limit chunk_count, or an oversized batch_sig — all with the single Go
+/// message. Mirrors Go `validateSimplicityTxContextDACommitCore`.
+fn validate_simplicity_tx_context_da_commit_core(
+    core: Option<&DaCommitCore>,
+) -> Result<&DaCommitCore, TxError> {
+    match core {
+        Some(core)
+            if core.chunk_count != 0
+                && u64::from(core.chunk_count) <= MAX_DA_CHUNK_COUNT
+                && core.batch_sig.len() as u64 <= MAX_DA_MANIFEST_BYTES_PER_TX =>
+        {
+            Ok(core)
+        }
+        _ => Err(parse_err("invalid da_commit_core for tx_kind=0x01")),
+    }
 }
 
 // u128-widened checked add: no truncation, and keeps Go's fail-closed overflow corner.
@@ -198,6 +358,39 @@ impl SimplicityTxContext {
             self_value: source.value,
             input_index,
             sighash_type,
+        })
+    }
+
+    /// The same-CMR group projection for `input_index`: every input AND output
+    /// carrying this input's program_cmr, in ascending index order, as fresh clones
+    /// (projection isolation). Fails closed on a non-CORE_SIMPLICITY or out-of-range
+    /// index. Mirrors Go `SameCMRView`.
+    pub fn same_cmr_view(
+        &self,
+        input_index: u16,
+    ) -> Result<SimplicityTxContextSameCmrView, TxError> {
+        let source = self
+            .self_sources
+            .get(input_index as usize)
+            .ok_or_else(|| parse_err("simplicity txcontext self input index out of range"))?;
+        if !source.is_core_simplicity {
+            return Err(TxError::new(
+                ErrorCode::TxErrCovenantTypeInvalid,
+                "simplicity txcontext self input is not CORE_SIMPLICITY",
+            ));
+        }
+        Ok(SimplicityTxContextSameCmrView {
+            program_cmr: source.program_cmr,
+            inputs: self
+                .group_inputs
+                .get(&source.program_cmr)
+                .cloned()
+                .unwrap_or_default(),
+            outputs: self
+                .group_outputs
+                .get(&source.program_cmr)
+                .cloned()
+                .unwrap_or_default(),
         })
     }
 }

--- a/clients/rust/crates/rubin-consensus/src/tests/simplicity_txcontext.rs
+++ b/clients/rust/crates/rubin-consensus/src/tests/simplicity_txcontext.rs
@@ -1,10 +1,11 @@
 use super::*;
 use crate::compactsize::encode_compact_size;
 use crate::constants::{
-    COV_TYPE_CORE_SIMPLICITY, COV_TYPE_P2PK, MAX_TX_INPUTS, MAX_TX_OUTPUTS, SIGHASH_ALL,
+    COV_TYPE_CORE_SIMPLICITY, COV_TYPE_P2PK, MAX_DA_CHUNK_COUNT, MAX_DA_MANIFEST_BYTES_PER_TX,
+    MAX_TX_INPUTS, MAX_TX_OUTPUTS, SIGHASH_ALL, SIMPLICITY_MAX_GROUP_INPUTS,
 };
 use crate::error::ErrorCode;
-use crate::tx::{DaChunkCore, Tx, TxInput, TxOutput};
+use crate::tx::{DaChunkCore, DaCommitCore, Tx, TxInput, TxOutput};
 use crate::txcontext::Uint128;
 use crate::utxo_basic::UtxoEntry;
 
@@ -55,6 +56,43 @@ fn p2pk(value: u64) -> TxOutput {
         value,
         covenant_type: COV_TYPE_P2PK,
         covenant_data: vec![],
+    }
+}
+
+fn core_out(value: u64, program_cmr: [u8; 32], state: &[u8]) -> TxOutput {
+    TxOutput {
+        value,
+        covenant_type: COV_TYPE_CORE_SIMPLICITY,
+        covenant_data: covenant(program_cmr, state),
+    }
+}
+
+fn da_commit(chunk_count: u16, batch_sig: Vec<u8>) -> DaCommitCore {
+    DaCommitCore {
+        da_id: [0u8; 32],
+        chunk_count,
+        retl_domain_id: [0u8; 32],
+        batch_number: 0,
+        tx_data_root: [0u8; 32],
+        state_root: [0u8; 32],
+        withdrawals_root: [0u8; 32],
+        batch_sig_suite: 0,
+        batch_sig,
+    }
+}
+
+fn chunk_core(da_id: [u8; 32], chunk_index: u16, chunk_hash: [u8; 32]) -> DaChunkCore {
+    DaChunkCore {
+        da_id,
+        chunk_index,
+        chunk_hash,
+    }
+}
+
+fn ge(state: &[u8], value: u64) -> SimplicityTxContextGroupEntry {
+    SimplicityTxContextGroupEntry {
+        state: state.to_vec(),
+        value,
     }
 }
 
@@ -167,6 +205,10 @@ fn build_populates_base_views_self_and_fresh_copies() {
         .self_view(2, SIGHASH_ALL, digest)
         .expect_err("out of range");
     assert_eq!(e2.code, ErrorCode::TxErrParse);
+
+    // Same-CMR view fail-closed on a non-CORE_SIMPLICITY input (input 1 is P2PK).
+    let e3 = ctx.same_cmr_view(1).expect_err("non-core same-cmr");
+    assert_eq!(e3.code, ErrorCode::TxErrCovenantTypeInvalid);
 }
 
 #[test]
@@ -208,4 +250,182 @@ fn build_rejects_zero_value_core_simplicity_input() {
     let err = build_simplicity_tx_context(&tx, &resolved, 1, [0u8; 32]).expect_err("zero value");
     assert_eq!(err.code, ErrorCode::TxErrCovenantTypeInvalid);
     assert_eq!(err.msg, "CORE_SIMPLICITY value must be > 0");
+}
+
+#[test]
+fn rejects_zero_value_core_simplicity_output() {
+    // Mirrors Go: the output covenant is parsed too — a zero-value output fails closed.
+    let cmr = [0xbau8; 32];
+    let tx = tx_with(vec![input()], vec![core_out(0, cmr, &[])]);
+    let resolved = vec![utxo(1, COV_TYPE_CORE_SIMPLICITY, covenant(cmr, &[]))];
+    let err = build_simplicity_tx_context(&tx, &resolved, 1, [0u8; 32]).expect_err("zero output");
+    assert_eq!(err.code, ErrorCode::TxErrCovenantTypeInvalid);
+    assert_eq!(err.msg, "CORE_SIMPLICITY value must be > 0");
+}
+
+#[test]
+fn same_cmr_view_projection() {
+    // Group both inputs AND outputs by program_cmr (symmetric B-1), ascending
+    // order, foreign CMRs excluded, returned entries are fresh copies.
+    let cmr_a = [0xa0u8; 32];
+    let cmr_b = [0xb0u8; 32];
+    let tx = tx_with(
+        vec![input(), input(), input()],
+        vec![core_out(44, cmr_a, &[0x04]), core_out(55, cmr_b, &[0x05])],
+    );
+    let resolved = vec![
+        utxo(11, COV_TYPE_CORE_SIMPLICITY, covenant(cmr_a, &[0x01])),
+        utxo(22, COV_TYPE_CORE_SIMPLICITY, covenant(cmr_b, &[0x02])),
+        utxo(33, COV_TYPE_CORE_SIMPLICITY, covenant(cmr_a, &[0x03])),
+    ];
+    let ctx = build_simplicity_tx_context(&tx, &resolved, 7, [0u8; 32])
+        .expect("build")
+        .expect("context");
+
+    let mut view_a = ctx.same_cmr_view(0).expect("view a");
+    assert_eq!(view_a.program_cmr, cmr_a);
+    assert_eq!(view_a.inputs, vec![ge(&[0x01], 11), ge(&[0x03], 33)]);
+    assert_eq!(view_a.outputs, vec![ge(&[0x04], 44)]);
+
+    // Projection isolation: mutating the returned view cannot alias the ctx.
+    view_a.inputs[0].state[0] = 0xff;
+    assert_eq!(
+        ctx.same_cmr_view(0).expect("view a again").inputs[0].state,
+        vec![0x01]
+    );
+
+    let view_b = ctx.same_cmr_view(1).expect("view b");
+    assert_eq!(view_b.program_cmr, cmr_b);
+    assert_eq!(view_b.inputs, vec![ge(&[0x02], 22)]);
+    assert_eq!(view_b.outputs, vec![ge(&[0x05], 55)]);
+
+    let err = ctx.same_cmr_view(3).expect_err("out of range");
+    assert_eq!(err.code, ErrorCode::TxErrParse);
+}
+
+#[test]
+fn same_cmr_input_cap() {
+    let cmr = [0xc0u8; 32];
+    let n = SIMPLICITY_MAX_GROUP_INPUTS + 1; // 9
+    let mut resolved: Vec<UtxoEntry> = (0..n)
+        .map(|_| utxo(1, COV_TYPE_CORE_SIMPLICITY, covenant(cmr, &[])))
+        .collect();
+    let tx = tx_with(vec![input(); n], vec![]);
+
+    // Exactly SIMPLICITY_MAX_GROUP_INPUTS (8) same-CMR inputs sit at the cap -> pass.
+    let tx_exact = tx_with(vec![input(); SIMPLICITY_MAX_GROUP_INPUTS], vec![]);
+    build_simplicity_tx_context(
+        &tx_exact,
+        &resolved[..SIMPLICITY_MAX_GROUP_INPUTS],
+        1,
+        [0u8; 32],
+    )
+    .expect("8 same-cmr inputs pass the cap");
+
+    // 9 inputs but the 9th splits into its own CMR group -> pass.
+    resolved[SIMPLICITY_MAX_GROUP_INPUTS].covenant_data = covenant([0xc1u8; 32], &[]);
+    build_simplicity_tx_context(&tx, &resolved, 1, [0u8; 32]).expect("9 split-cmr inputs pass");
+
+    // 9 inputs all in one CMR group -> fail closed.
+    resolved[SIMPLICITY_MAX_GROUP_INPUTS].covenant_data = covenant(cmr, &[]);
+    let err = build_simplicity_tx_context(&tx, &resolved, 1, [0u8; 32]).expect_err("9 same-cmr");
+    assert_eq!(err.code, ErrorCode::TxErrCovenantTypeInvalid);
+    assert_eq!(
+        err.msg,
+        "CORE_SIMPLICITY same-cmr input group exceeds limit"
+    );
+}
+
+#[test]
+fn da_view_kinds_and_rejects() {
+    let da_id = [0x01u8; 32];
+    let resolved = vec![utxo(
+        1,
+        COV_TYPE_CORE_SIMPLICITY,
+        covenant([0xd0u8; 32], &[]),
+    )];
+    let da_view_of = |tx_kind: u8,
+                      commit: Option<DaCommitCore>,
+                      chunk: Option<DaChunkCore>|
+     -> Result<SimplicityTxContextDaView, TxError> {
+        let mut tx = tx_with(vec![input()], vec![]);
+        tx.tx_kind = tx_kind;
+        tx.da_commit_core = commit;
+        tx.da_chunk_core = chunk;
+        Ok(build_simplicity_tx_context(&tx, &resolved, 1, [0u8; 32])?
+            .expect("context")
+            .da_view)
+    };
+
+    // commit (0x01): copies commit fields, excludes batch_sig, ignores stale chunk.
+    let mut commit_core = da_commit(2, vec![0xaa, 0xbb]);
+    commit_core.da_id = da_id;
+    commit_core.batch_number = 9;
+    let commit = da_view_of(
+        0x01,
+        Some(commit_core),
+        Some(chunk_core(da_id, 7, [0u8; 32])),
+    )
+    .expect("commit");
+    assert_eq!(
+        commit,
+        SimplicityTxContextDaView {
+            kind: SimplicityTxContextDaViewKind::Commit,
+            commit: SimplicityTxContextDaCommitView {
+                da_id,
+                chunk_count: 2,
+                batch_number: 9,
+                ..Default::default()
+            },
+            chunk: SimplicityTxContextDaChunkView::default(),
+        }
+    );
+
+    // absent (0x00) ignores stale cores; chunk (0x02) ignores stale commit.
+    let absent = da_view_of(
+        0x00,
+        Some(da_commit(0, vec![])),
+        Some(chunk_core(da_id, 1, [0u8; 32])),
+    )
+    .expect("absent");
+    assert_eq!(absent, SimplicityTxContextDaView::default());
+
+    let chunk_hash = [0x03u8; 32];
+    let chunk = da_view_of(
+        0x02,
+        Some(da_commit(0, vec![])),
+        Some(chunk_core(da_id, 4, chunk_hash)),
+    )
+    .expect("chunk");
+    assert_eq!(
+        chunk,
+        SimplicityTxContextDaView {
+            kind: SimplicityTxContextDaViewKind::Chunk,
+            commit: SimplicityTxContextDaCommitView::default(),
+            chunk: SimplicityTxContextDaChunkView {
+                da_id,
+                chunk_index: 4,
+                chunk_hash
+            },
+        }
+    );
+
+    // Every malformed / unsupported DA shape fails closed with TX_ERR_PARSE.
+    let big_sig = vec![0u8; usize::try_from(MAX_DA_MANIFEST_BYTES_PER_TX + 1).expect("fits usize")];
+    let over_chunks = u16::try_from(MAX_DA_CHUNK_COUNT + 1).expect("fits u16");
+    let over_index = u16::try_from(MAX_DA_CHUNK_COUNT).expect("fits u16");
+    #[rustfmt::skip]
+    let rejects: [(&str, u8, Option<DaCommitCore>, Option<DaChunkCore>); 7] = [
+        ("missing commit core", 0x01, None, None),
+        ("missing chunk core", 0x02, None, None),
+        ("unsupported tx kind", 0x03, None, None),
+        ("zero commit chunk count", 0x01, Some(da_commit(0, vec![])), None),
+        ("too many commit chunks", 0x01, Some(da_commit(over_chunks, vec![])), None),
+        ("oversized batch sig", 0x01, Some(da_commit(1, big_sig)), None),
+        ("chunk index out of range", 0x02, None, Some(chunk_core(da_id, over_index, [0u8; 32]))),
+    ];
+    for (name, kind, commit, chunk) in rejects {
+        let code = da_view_of(kind, commit, chunk).expect_err(name).code;
+        assert_eq!(code, ErrorCode::TxErrParse, "{name}");
+    }
 }


### PR DESCRIPTION
## What

Rust mirror of the merged Go reference `clients/go/consensus/simplicity_txcontext.go` (RUB-499) — the parts the RUB-500 core (`build_simplicity_tx_context`) deferred here:

- **Same-CMR group views (8/8 + symmetric B-1):** inputs AND outputs grouped by `program_cmr`; `SIMPLICITY_MAX_GROUP_INPUTS = 8` cap (8 accepted / 9-same rejected, atomic discard — the error unwinds the whole build); projection-isolated `same_cmr_view` accessor returning fresh clones.
- **DA view:** `tx_kind` 0x00 absent / 0x01 commit (validated) / 0x02 chunk (validated) / any other rejected. The builder re-validates the DA cores inline because it may take a directly-constructed (unparsed) tx.
- **CORE_SIMPLICITY output covenant reject:** an output with `value == 0` or malformed `covenant_data` now fails closed via the shared parse (the reject RUB-500 core deferred).

## Parity

Byte-faithful to merged Go: identical error codes + messages, ascending group order, `BTreeMap` keying keeps the group structure iteration-order-free (determinism invariant), and accessors return deep clones (projection isolation). Mirrored unit tests pin every accept/reject corner (group cap 8/9, DA `tx_kind` kinds + all reject shapes, output `value > 0`, malformed covenant, same-CMR non-core / out-of-range).

No panics on the validity path (typed errors, `ok_or_else`, no `unwrap`/index); the single guarded `len() as u16` cast is `#[allow]`-annotated (guarded `len <= 1024 < u16::MAX`); the `batch_sig.len() as u64` is a widening cast.

## Scope (RUB-501)

`target_repo: clients/rust only`. Two former scope items were carved out to **RUB-593** (new cross-client issue, controller-sanctioned), because RUB-501 cannot own them without violating its own contract:

- **Shared construction parity corpus** (generator + both consumers): the merged Go reference has none, and "both consumers" needs a Go consumer that this slice's Non-scope ("no Go changes") + scope gate (`clients/rust` only) forbid.
- **Shadow wiring:** `BuildSimplicityTxContext` has ZERO production call sites in the merged Go reference (CORE_SIMPLICITY is rejected at precompute before any context build), so a Rust production call would be a Go↔Rust divergence — satisfied-as-absent.

Non-scope: no Go changes; no descriptor-hash accessors (RUB-503); no spend dispatch (RUB-505); no schema changes.

## Verification

- Local `cl push` matrix GREEN (clean-tree · contract · deterministic deep tests · policy · coverage · semantic review 0-confirmed across hostile/security/rust-parity/consensus).
- 9/9 `simplicity_txcontext` unit tests green; clippy `-D warnings` + fmt clean; lizard per-method new-only clean (CCN ≤ 8, NLOC ≤ 50).
- Diff coverage 100% (98/98 changed lines).

## Codacy note (advisory)

The aggregate per-file complexity metric rises (sum-CCN 24 → 47) purely from mirroring Go's decomposition into small helpers (`populate_*`, `build_*_da_view`, `validate_*`) — a decomposition penalty, not real complexity. Every method is CCN ≤ 8; the Go sibling file is CCN 52 and accepted. Flagging for reviewer awareness; not a correctness concern.

Refs: RUB-501, RUB-593 (deferred corpus/shadow), RUB-499 (Go reference), RUB-500 (Rust core).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Parity exemption justification

This is a **Rust parity mirror of the already-merged Go reference** (`clients/go/consensus/simplicity_txcontext.go`, RUB-499). The Go side landed in a prior PR; this slice only ports those views to Rust, so there is intentionally **no paired Go consensus change** in this PR — a matching Go change would duplicate already-merged work. Behavior is byte-identical to merged Go (mirrored unit tests pin every error code/message and accept/reject corner; the local semantic parity review — rust-parity/consensus/security/hostile — passed with 0 confirmed findings). Single-client (Rust-only) mirror ⇒ `parity-exempt`.
