### PR TITLE
RUB-503: Rust SimplicityTxContext descriptor_hash accessors (mirror of Go)

### DIFF
--- a/clients/rust/crates/rubin-consensus/src/simplicity.rs
+++ b/clients/rust/crates/rubin-consensus/src/simplicity.rs
@@ -48,6 +48,33 @@ impl fmt::Display for Error {
 
 impl std::error::Error for Error {}
 
+/// Applies the shared Simplicity execution budget cap. Mirrors Go
+/// `simplicity.ChargeCost` (budget failure caps the meter at `MAX_EXEC_COST`).
+pub fn charge_cost(current: u64, cost: u64) -> Result<u64, Error> {
+    if current > MAX_EXEC_COST || cost > MAX_EXEC_COST - current {
+        return Err(Error {
+            code: ErrorCode::BudgetExceeded,
+        });
+    }
+    Ok(current + cost)
+}
+
+/// Returns the in-range descriptor_hash access cost. Mirrors Go
+/// `simplicity.DescriptorHashAccessCost`.
+pub fn descriptor_hash_access_cost(descriptor_len: u64) -> Result<u64, Error> {
+    if DESCRIPTOR_HASH_BYTE_COST != 0
+        && descriptor_len > (u64::MAX - DESCRIPTOR_HASH_BASE_COST) / DESCRIPTOR_HASH_BYTE_COST
+    {
+        return Err(Error {
+            code: ErrorCode::BudgetExceeded,
+        });
+    }
+    charge_cost(
+        0,
+        DESCRIPTOR_HASH_BASE_COST + DESCRIPTOR_HASH_BYTE_COST * descriptor_len,
+    )
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[rustfmt::skip]
 pub struct DecodeOptions { pub semantics_version: u32, pub covenant_program_cmr: Option<[u8; 32]> }

--- a/clients/rust/crates/rubin-consensus/src/simplicity/tests/mod.rs
+++ b/clients/rust/crates/rubin-consensus/src/simplicity/tests/mod.rs
@@ -1369,3 +1369,31 @@ fn error_code(s: &str) -> Option<ErrorCode> {
     .into_iter()
     .find(|code| code.as_str() == s)
 }
+
+#[test]
+fn descriptor_hash_access_cost_boundaries() {
+    // Mirrors Go TestDescriptorHashAccessCostBoundaries: pin the in-range cost, the
+    // exact MAX_EXEC_COST boundary (no error), the one-past budget reject, and the
+    // pre-charge overflow guard that the txcontext oversize test never reaches.
+    assert_eq!(
+        descriptor_hash_access_cost(3).expect("in range"),
+        DESCRIPTOR_HASH_BASE_COST + 3 * DESCRIPTOR_HASH_BYTE_COST
+    );
+    let max_len = (MAX_EXEC_COST - DESCRIPTOR_HASH_BASE_COST) / DESCRIPTOR_HASH_BYTE_COST;
+    assert_eq!(
+        descriptor_hash_access_cost(max_len).expect("max boundary"),
+        MAX_EXEC_COST
+    );
+    assert_eq!(
+        descriptor_hash_access_cost(max_len + 1)
+            .expect_err("over budget")
+            .code,
+        ErrorCode::BudgetExceeded
+    );
+    assert_eq!(
+        descriptor_hash_access_cost(u64::MAX)
+            .expect_err("overflow guard")
+            .code,
+        ErrorCode::BudgetExceeded
+    );
+}

--- a/clients/rust/crates/rubin-consensus/src/simplicity_txcontext.rs
+++ b/clients/rust/crates/rubin-consensus/src/simplicity_txcontext.rs
@@ -11,10 +11,13 @@ use crate::constants::{
     MAX_TX_OUTPUTS, SIMPLICITY_MAX_GROUP_INPUTS,
 };
 use crate::error::{ErrorCode, TxError};
+use crate::hash::sha3_256;
+use crate::simplicity;
 use crate::simplicity_covenant::parse_core_simplicity_covenant_data;
 use crate::tx::{DaCommitCore, Tx, TxOutput};
 use crate::txcontext::Uint128;
 use crate::utxo_basic::UtxoEntry;
+use crate::vault::output_descriptor_bytes;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SimplicityTxContextBase {
@@ -101,6 +104,46 @@ struct SimplicityTxContextSelfSource {
     is_core_simplicity: bool,
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct SimplicityTxContextDescriptorHashResult {
+    pub hash: [u8; 32],
+    pub present: bool,
+}
+
+/// Shared per-access execution meter for the descriptor_hash intrinsics. Mirrors
+/// Go `SimplicityTxContextMeter`; a budget failure caps `cost` at `MAX_EXEC_COST`.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct SimplicityTxContextMeter {
+    cost: u64,
+}
+
+impl SimplicityTxContextMeter {
+    pub fn cost(&self) -> u64 {
+        self.cost
+    }
+
+    fn charge(&mut self, cost: u64) -> Result<(), simplicity::Error> {
+        match simplicity::charge_cost(self.cost, cost) {
+            Ok(next) => {
+                self.cost = next;
+                Ok(())
+            }
+            Err(err) => {
+                self.cost = simplicity::MAX_EXEC_COST;
+                Err(err)
+            }
+        }
+    }
+}
+
+// Index-aligned with the resolved inputs / tx outputs; the descriptor bytes are
+// copied at build time so accessor hashes never alias the source covenant_data.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct SimplicityTxContextDescriptorSource {
+    covenant_type: u16,
+    covenant_data: Vec<u8>,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SimplicityTxContext {
     pub base: SimplicityTxContextBase,
@@ -112,6 +155,9 @@ pub struct SimplicityTxContext {
     group_inputs: BTreeMap<[u8; 32], Vec<SimplicityTxContextGroupEntry>>,
     group_outputs: BTreeMap<[u8; 32], Vec<SimplicityTxContextGroupEntry>>,
     da_view: SimplicityTxContextDaView,
+    // Index-aligned descriptor sources feeding the descriptor_hash intrinsics.
+    input_descriptors: Vec<SimplicityTxContextDescriptorSource>,
+    output_descriptors: Vec<SimplicityTxContextDescriptorSource>,
 }
 
 fn parse_err(msg: &'static str) -> TxError {
@@ -166,6 +212,8 @@ pub fn build_simplicity_tx_context(
         group_inputs: BTreeMap::new(),
         group_outputs: BTreeMap::new(),
         da_view: SimplicityTxContextDaView::default(),
+        input_descriptors: Vec::with_capacity(resolved_inputs.len()),
+        output_descriptors: Vec::with_capacity(tx.outputs.len()),
     };
     populate_simplicity_tx_context_views(&mut ctx, tx, resolved_inputs)?;
     Ok(Some(ctx))
@@ -197,6 +245,11 @@ fn populate_simplicity_tx_context_input_views(
             value: entry.value,
             covenant_type: entry.covenant_type,
         });
+        ctx.input_descriptors
+            .push(SimplicityTxContextDescriptorSource {
+                covenant_type: entry.covenant_type,
+                covenant_data: entry.covenant_data.clone(),
+            });
         if entry.covenant_type != COV_TYPE_CORE_SIMPLICITY {
             ctx.self_sources.push(SimplicityTxContextSelfSource {
                 program_cmr: [0u8; 32],
@@ -241,6 +294,11 @@ fn populate_simplicity_tx_context_output_views(
             value: out.value,
             covenant_type: out.covenant_type,
         });
+        ctx.output_descriptors
+            .push(SimplicityTxContextDescriptorSource {
+                covenant_type: out.covenant_type,
+                covenant_data: out.covenant_data.clone(),
+            });
         if out.covenant_type != COV_TYPE_CORE_SIMPLICITY {
             continue;
         }
@@ -393,6 +451,57 @@ impl SimplicityTxContext {
                 .unwrap_or_default(),
         })
     }
+
+    /// The descriptor_hash intrinsic for input `input_index`: charges the shared
+    /// meter and returns sha3-256 of the input's output-descriptor bytes (== its
+    /// lock_id), or a not-present miss for an out-of-range index. Mirrors Go
+    /// `InputDescriptorHash`.
+    pub fn input_descriptor_hash(
+        &self,
+        input_index: u16,
+        meter: &mut SimplicityTxContextMeter,
+    ) -> Result<SimplicityTxContextDescriptorHashResult, simplicity::Error> {
+        descriptor_hash(&self.input_descriptors, input_index, meter)
+    }
+
+    /// The descriptor_hash intrinsic for output `output_index`. Mirrors Go
+    /// `OutputDescriptorHash`.
+    pub fn output_descriptor_hash(
+        &self,
+        output_index: u16,
+        meter: &mut SimplicityTxContextMeter,
+    ) -> Result<SimplicityTxContextDescriptorHashResult, simplicity::Error> {
+        descriptor_hash(&self.output_descriptors, output_index, meter)
+    }
+}
+
+/// Shared descriptor_hash logic: an out-of-range index charges `INTRINSIC_MISS_COST`
+/// and returns a not-present result; otherwise it charges the per-access descriptor
+/// cost and returns sha3-256 of the descriptor bytes. A budget failure saturates the
+/// meter at `MAX_EXEC_COST`. Mirrors Go `SimplicityTxContext.descriptorHash` — the
+/// Rust `&mut` meter makes Go's nil-meter branch statically unreachable.
+fn descriptor_hash(
+    sources: &[SimplicityTxContextDescriptorSource],
+    index: u16,
+    meter: &mut SimplicityTxContextMeter,
+) -> Result<SimplicityTxContextDescriptorHashResult, simplicity::Error> {
+    let Some(source) = sources.get(index as usize) else {
+        meter.charge(simplicity::INTRINSIC_MISS_COST)?;
+        return Ok(SimplicityTxContextDescriptorHashResult::default());
+    };
+    let desc = output_descriptor_bytes(source.covenant_type, &source.covenant_data);
+    let cost = match simplicity::descriptor_hash_access_cost(desc.len() as u64) {
+        Ok(cost) => cost,
+        Err(err) => {
+            meter.cost = simplicity::MAX_EXEC_COST;
+            return Err(err);
+        }
+    };
+    meter.charge(cost)?;
+    Ok(SimplicityTxContextDescriptorHashResult {
+        hash: sha3_256(&desc),
+        present: true,
+    })
 }
 
 #[cfg(test)]

--- a/clients/rust/crates/rubin-consensus/src/tests/simplicity_txcontext.rs
+++ b/clients/rust/crates/rubin-consensus/src/tests/simplicity_txcontext.rs
@@ -429,3 +429,147 @@ fn da_view_kinds_and_rejects() {
         assert_eq!(code, ErrorCode::TxErrParse, "{name}");
     }
 }
+
+fn p2pk_out(value: u64, covenant_data: Vec<u8>) -> TxOutput {
+    TxOutput {
+        value,
+        covenant_type: COV_TYPE_P2PK,
+        covenant_data,
+    }
+}
+
+fn access_cost(descriptor: &[u8]) -> u64 {
+    simplicity::DESCRIPTOR_HASH_BASE_COST
+        + descriptor.len() as u64 * simplicity::DESCRIPTOR_HASH_BYTE_COST
+}
+
+fn descriptor_source(
+    covenant_type: u16,
+    covenant_data: Vec<u8>,
+) -> SimplicityTxContextDescriptorSource {
+    SimplicityTxContextDescriptorSource {
+        covenant_type,
+        covenant_data,
+    }
+}
+
+#[test]
+fn descriptor_hash_accessors_accumulate_cost() {
+    let cmr = [0xdau8; 32];
+    let mut input_data = vec![0x01, 0xaa, 0xbb];
+    let mut output_data = vec![0x01, 0xcc, 0xdd];
+    let tx = tx_with(
+        vec![input(), input()],
+        vec![p2pk_out(3, output_data.clone())],
+    );
+    let resolved = vec![
+        utxo(1, COV_TYPE_CORE_SIMPLICITY, covenant(cmr, &[])),
+        utxo(2, COV_TYPE_P2PK, input_data.clone()),
+    ];
+    let ctx = build_simplicity_tx_context(&tx, &resolved, 1, [0u8; 32])
+        .expect("build")
+        .expect("context");
+    // Mutating the sources after build must not affect the copied descriptors.
+    input_data[0] = 0xff;
+    output_data[0] = 0xff;
+
+    let input_desc = output_descriptor_bytes(COV_TYPE_P2PK, &[0x01, 0xaa, 0xbb]);
+    let input_cost = access_cost(&input_desc);
+    let mut meter = SimplicityTxContextMeter::default();
+    for i in 1..=2u64 {
+        let got = ctx
+            .input_descriptor_hash(1, &mut meter)
+            .expect("input hash");
+        assert!(got.present);
+        assert_eq!(got.hash, sha3_256(&input_desc));
+        assert_eq!(meter.cost(), i * input_cost);
+    }
+
+    let output_desc = output_descriptor_bytes(COV_TYPE_P2PK, &[0x01, 0xcc, 0xdd]);
+    let got = ctx
+        .output_descriptor_hash(0, &mut meter)
+        .expect("output hash");
+    assert!(got.present);
+    assert_eq!(got.hash, sha3_256(&output_desc));
+    assert_eq!(meter.cost(), 2 * input_cost + access_cost(&output_desc));
+}
+
+#[test]
+fn descriptor_hash_miss_and_budget_cross() {
+    let cmr = [0xdbu8; 32];
+    let tx = tx_with(vec![input()], vec![]);
+    let resolved = vec![utxo(1, COV_TYPE_CORE_SIMPLICITY, covenant(cmr, &[]))];
+    let ctx = build_simplicity_tx_context(&tx, &resolved, 1, [0u8; 32])
+        .expect("build")
+        .expect("context");
+
+    // Out-of-range index charges only the miss cost and reports not-present.
+    let mut miss = SimplicityTxContextMeter::default();
+    let got = ctx.input_descriptor_hash(1, &mut miss).expect("miss");
+    assert!(!got.present);
+    assert_eq!(got.hash, [0u8; 32]);
+    assert_eq!(miss.cost(), simplicity::INTRINSIC_MISS_COST);
+
+    // A meter primed one unit below the access cost saturates to MAX on charge.
+    let cost = access_cost(&output_descriptor_bytes(
+        COV_TYPE_CORE_SIMPLICITY,
+        &covenant(cmr, &[]),
+    ));
+    let mut over = SimplicityTxContextMeter {
+        cost: simplicity::MAX_EXEC_COST - cost + 1,
+    };
+    let err = ctx.input_descriptor_hash(0, &mut over).expect_err("budget");
+    assert_eq!(err.code, simplicity::ErrorCode::BudgetExceeded);
+    assert_eq!(over.cost(), simplicity::MAX_EXEC_COST);
+}
+
+#[test]
+fn descriptor_hash_error_branches() {
+    let cmr = [0xdcu8; 32];
+    let tx = tx_with(vec![input()], vec![]);
+    let resolved = vec![utxo(1, COV_TYPE_CORE_SIMPLICITY, covenant(cmr, &[]))];
+    let ctx = build_simplicity_tx_context(&tx, &resolved, 1, [0u8; 32])
+        .expect("build")
+        .expect("context");
+
+    // A miss on an already-saturated meter still fails closed.
+    let mut miss_over = SimplicityTxContextMeter {
+        cost: simplicity::MAX_EXEC_COST,
+    };
+    let err = ctx
+        .input_descriptor_hash(1, &mut miss_over)
+        .expect_err("miss over budget");
+    assert_eq!(err.code, simplicity::ErrorCode::BudgetExceeded);
+    assert_eq!(miss_over.cost(), simplicity::MAX_EXEC_COST);
+
+    // A single descriptor whose access cost alone exceeds the budget fails closed.
+    let oversize = [descriptor_source(
+        COV_TYPE_P2PK,
+        vec![0u8; usize::try_from(simplicity::MAX_EXEC_COST).expect("fits usize")],
+    )];
+    let mut meter = SimplicityTxContextMeter::default();
+    let err = descriptor_hash(&oversize, 0, &mut meter).expect_err("oversize");
+    assert_eq!(err.code, simplicity::ErrorCode::BudgetExceeded);
+    assert_eq!(meter.cost(), simplicity::MAX_EXEC_COST);
+}
+
+#[test]
+fn descriptor_hash_equals_lock_id() {
+    // The descriptor_hash intrinsic returns the covenant lock_id: sha3-256 of the
+    // output-descriptor bytes — the same value utxo_basic derives for owner auth.
+    let cmr = [0xd0u8; 32];
+    let owner = vec![0x01u8; 33];
+    let tx = tx_with(vec![input()], vec![p2pk_out(5, owner.clone())]);
+    let resolved = vec![utxo(1, COV_TYPE_CORE_SIMPLICITY, covenant(cmr, &[]))];
+    let ctx = build_simplicity_tx_context(&tx, &resolved, 1, [0u8; 32])
+        .expect("build")
+        .expect("context");
+
+    let mut meter = SimplicityTxContextMeter::default();
+    let got = ctx.output_descriptor_hash(0, &mut meter).expect("hash");
+    assert!(got.present);
+    assert_eq!(
+        got.hash,
+        sha3_256(&output_descriptor_bytes(COV_TYPE_P2PK, &owner))
+    );
+}


### PR DESCRIPTION
## What

Rust mirror of the merged Go reference (RUB-502) descriptor_hash intrinsics on `SimplicityTxContext`:

- **`simplicity::charge_cost` + `simplicity::descriptor_hash_access_cost`** — mirror the Go budget-charging primitives (`ChargeCost` / `DescriptorHashAccessCost`), returning `simplicity::Error`.
- **`SimplicityTxContextMeter`** — the shared per-access execution meter; a budget failure saturates `cost` at `MAX_EXEC_COST`. Plus `SimplicityTxContextDescriptorHashResult` and index-aligned input/output descriptor sources **copied at build time** (accessor hashes never alias the source `covenant_data`).
- **`input_descriptor_hash` / `output_descriptor_hash`** over a shared `descriptor_hash`: an out-of-range index charges `INTRINSIC_MISS_COST` and returns a not-present result; otherwise it charges the per-access cost and returns `sha3-256(output_descriptor_bytes(..))` — which **equals the covenant lock_id** `utxo_basic` derives for owner auth.

## Parity

Byte-faithful to merged Go: same per-access cost formula (`BASE + len·BYTE`), same budget saturation to `MAX_EXEC_COST`, same miss semantics, same `sha3-256` of the output-descriptor bytes. Go's descriptor_hash returns the raw `simplicity.Error{BudgetExceeded}` for budget failures — the Rust accessor mirrors this (`Result<_, simplicity::Error>`); the Rust `&mut` meter makes Go's nil-meter branch **statically unreachable** (a stronger guarantee, not a divergence).

No panics on the validity path (typed errors, no `unwrap`/index); the only cast is a widening `desc.len() as u64`.

Mirrored unit tests pin: cost accumulation across repeated access, the miss + budget-cross corners, the oversize-descriptor budget failure, and the `hash == lock_id` equivalence.

## Scope (RUB-503)

`target_repo: clients/rust only`. The **shared parity vectors (generator + both consumers)** were folded into **RUB-593** (the SimplicityTxContext parity corpus, controller-sanctioned) — the corpus does not exist in the reference and "both consumers" needs a Go consumer that this slice's Non-scope ("no Go changes") + scope gate forbid. Same split as RUB-501→RUB-593.

Non-scope: no Go changes; no UTXO-entry caching; no spend dispatch (RUB-505); no schema changes.

## Verification

- Local `cl push` matrix GREEN (clean-tree · contract 280/350 · deterministic deep tests · policy · coverage · semantic review 0-confirmed across hostile/security/rust-parity/consensus).
- 13/13 `simplicity_txcontext` unit tests green (4 new); full consensus suite 743 green; clippy `-D warnings` + fmt clean; lizard per-method new-only clean (CCN ≤ 8, NLOC ≤ 50).

## Codacy note (advisory)

Aggregate per-file complexity rises (`simplicity.rs` 88→94, `simplicity_txcontext.rs` 47→56) purely from mirroring Go's decomposition into small helpers — a decomposition penalty, not real complexity. Every method is CCN ≤ 8. Flagging for reviewer awareness.

### Parity exemption justification

This is a **Rust parity mirror of the already-merged Go reference** (RUB-502 descriptor_hash accessors). The Go side landed in a prior PR; this slice only ports those intrinsics to Rust, so there is intentionally **no paired Go consensus change** in this PR — a matching Go change would duplicate already-merged work. Behavior is byte-identical to merged Go (mirrored unit tests pin every cost/error corner; the local semantic parity review — rust-parity/consensus/security/hostile — passed with 0 confirmed findings). Single-client (Rust-only) mirror ⇒ `parity-exempt`.

Refs: RUB-503, RUB-593 (deferred corpus), RUB-502 (Go reference), RUB-501 (Rust context views).

🤖 Generated with [Claude Code](https://claude.com/claude-code)