### PR TITLE
formal: sync embedded section hash disposition for RUB-597

### DIFF
--- a/rubin-formal/proof_coverage.json
+++ b/rubin-formal/proof_coverage.json
@@ -4,7 +4,7 @@
   "claim_level": "refined",
   "spec_source_file": "spec/RUBIN_L1_CANONICAL.md",
   "spec_section_hashes_file": "spec/SECTION_HASHES.json",
-  "spec_section_hashes_sha3_256": "12dc7529b89b679d1cd9def00c98072ac4ae3eee9811f28a02356f908f7b624d",
+  "spec_section_hashes_sha3_256": "17da57c842c342ffaaa516310c9f41bf8ce61929eebc341294f60f4f4ec09166",
   "coverage_summary": {
     "section_rows": 18,
     "proved_rows": 11,


### PR DESCRIPTION
## Paired formal-disposition sync (AM-02 governance gate)

One-line update to `rubin-formal/proof_coverage.json` `spec_section_hashes_sha3_256`:

```
-> 17da57c842c342ffaaa516310c9f41bf8ce61929eebc341294f60f4f4ec09166
```

**Why:** rubin-spec PR #278 (RUB-597) publishes the context-ABI committed artifact and integrates
`context_schema_hash` into CANONICAL §23.2.4 (binding + invalid-descriptor disposition + the
pair-decode rule), regenerating `spec/SECTION_HASHES.json` for the
`simplicity_deployment_descriptors` section. The AM-02 merge gate
(`tools/check_section_hashes.py`) requires the embedded formal disposition pointer to match the new
`spec/SECTION_HASHES.json`, so this pointer moves in lockstep.

**Pairs with:** rubin-spec [#278](https://github.com/2tbmz9y2xt-lang/rubin-spec/pull/278) — merge together (this side first, then spec CI `validate` goes green reading rubin-protocol@main).

**Precedent:** identical to RUB-575 (#2108) / RUB-576 (#2116) "formal: sync embedded section hash disposition".

Scope: 1 file, 1 line; no Go/Rust/consensus code; formal disposition pointer only.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Verification evidence (added after review)

- `simplicity_deployment_descriptors` per-section hash: `f661b3bfabf93d11...` -> `db6c4d909eadcf4d...`
- Whole-file digest (what `spec_section_hashes_sha3_256` actually hashes): `12dc7529b89b679d...` -> `17da57c842c342ff...`
- Locally reconfirmed against the real private spec checkout: `spec_got == formal_exp == 17da57c842c342ffaaa516310c9f41bf8ce61929eebc341294f60f4f4ec09166` — MATCH.
- Enforcement point: rubin-spec's `spec-ci.yml` `Section hashes check (CANONICAL)` step (checks out this repo's `tools/check_section_hashes.py`, runs it against the real private spec). This repo's own CI does not run this check (by design — spec is private).
