### PR TITLE
[RUB-597] formal: sync embedded section hash pointer

### DIFF
--- a/rubin-formal/proof_coverage.json
+++ b/rubin-formal/proof_coverage.json
@@ -4,7 +4,7 @@
   "claim_level": "refined",
   "spec_source_file": "spec/RUBIN_L1_CANONICAL.md",
   "spec_section_hashes_file": "spec/SECTION_HASHES.json",
-  "spec_section_hashes_sha3_256": "17da57c842c342ffaaa516310c9f41bf8ce61929eebc341294f60f4f4ec09166",
+  "spec_section_hashes_sha3_256": "930107d62f2f2a23db3f783bb359e8b8c579abdaa07cea4ecd4e110b5ba4c31c",
   "coverage_summary": {
     "section_rows": 18,
     "proved_rows": 11,


### PR DESCRIPTION
Invariant:
Keep the embedded `rubin-protocol/rubin-formal/proof_coverage.json` mirror aligned with the RUB-597 `rubin-spec` `SECTION_HASHES.json` digest.

Layer:
Formal disposition mirror / CI gate metadata only.

Files changed:
- `rubin-formal/proof_coverage.json`

Why:
`rubin-spec` PR #278 now computes `spec/SECTION_HASHES.json` SHA3-256 as `930107d62f2f2a23db3f783bb359e8b8c579abdaa07cea4ecd4e110b5ba4c31c`.

`rubin-formal` PR #547 has already merged the same standalone pointer, but `rubin-spec` CI validates against this embedded mirror from `rubin-protocol@main`, so this mirror must carry the same digest for #278 to pass `spec-ci / validate`.

Tests:
- `python3 -m json.tool rubin-formal/proof_coverage.json >/dev/null`
- `git diff --check origin/main...HEAD`
- `python3 tools/check_formal_disposition_for_section_hashes.py --spec-root /Users/gpt/Documents/rubin-spec-private --formal-root rubin-formal`

Behavior impact:
No protocol, client, consensus, Rust, Go, or Lean source behavior changes. This is a one-line metadata mirror update.

Compatibility impact:
Depends on 2tbmz9y2xt-lang/rubin-spec#278 using the matching `spec/SECTION_HASHES.json` digest.

Known non-goals:
- No theorem coverage change.
- No implementation change.
- No conformance fixture change.

Not checked:
- Full local `cl push` matrix was not used for this mirror-only PR. The full matrix is scoped to a Linear contract that allows only `spec/` surfaces for RUB-597 and starts unrelated full-repo coverage/lint gates; the targeted checks above cover this one-line mirror update.
