### PR TITLE
RUB-546: Rust §9 0xF0 Simplicity-envelope sig_cost arm (mirror of Go RUB-545)

### DIFF
--- a/clients/rust/crates/rubin-consensus/src/block_basic/weight.rs
+++ b/clients/rust/crates/rubin-consensus/src/block_basic/weight.rs
@@ -1,6 +1,7 @@
 use crate::constants::{
     COV_TYPE_ANCHOR, COV_TYPE_DA_COMMIT, ML_DSA_87_PUBKEY_BYTES, ML_DSA_87_SIG_BYTES,
-    SUITE_ID_ML_DSA_87, SUITE_ID_SENTINEL, VERIFY_COST_ML_DSA_87, VERIFY_COST_UNKNOWN_SUITE,
+    SIMPLICITY_BASE_VERIFY_COST, SUITE_ID_ML_DSA_87, SUITE_ID_SENTINEL,
+    SUITE_ID_SIMPLICITY_ENVELOPE, VERIFY_COST_ML_DSA_87, VERIFY_COST_UNKNOWN_SUITE,
     WITNESS_DISCOUNT_DIVISOR,
 };
 use crate::error::{ErrorCode, TxError};
@@ -111,6 +112,10 @@ pub(super) fn tx_weight_and_stats(tx: &Tx) -> Result<(u64, u64, u64), TxError> {
 fn legacy_sig_cost(witness: &WitnessItem) -> Result<u64, TxError> {
     Ok(match witness.suite_id {
         SUITE_ID_SENTINEL => 0,
+        // CANONICAL §9 / mirror of Go `txWeightAndStats`: a 0xF0 Simplicity
+        // envelope witness is priced at its own base cost, not the
+        // unknown-suite floor (numerically equal today; see the constant).
+        SUITE_ID_SIMPLICITY_ENVELOPE => SIMPLICITY_BASE_VERIFY_COST,
         SUITE_ID_ML_DSA_87 if has_expected_mldsa87_shape(witness) => VERIFY_COST_ML_DSA_87,
         SUITE_ID_ML_DSA_87 => 0,
         _ => VERIFY_COST_UNKNOWN_SUITE,
@@ -148,6 +153,12 @@ fn registry_sig_cost(
 ) -> Result<u64, TxError> {
     if witness.suite_id == SUITE_ID_SENTINEL {
         return Ok(0);
+    }
+    // CANONICAL §9 / mirror of Go `txWeightAndStatsWithRegistry`: the 0xF0
+    // Simplicity envelope is priced BEFORE the native-spend/registry lookup
+    // (it is a structural carrier, never a native crypto suite).
+    if witness.suite_id == SUITE_ID_SIMPLICITY_ENVELOPE {
+        return Ok(SIMPLICITY_BASE_VERIFY_COST);
     }
     if !native_spend.contains(witness.suite_id) {
         return Ok(VERIFY_COST_UNKNOWN_SUITE);

--- a/clients/rust/crates/rubin-consensus/src/constants.rs
+++ b/clients/rust/crates/rubin-consensus/src/constants.rs
@@ -90,6 +90,12 @@ pub const SIGHASH_ANYONECANPAY: u8 = 0x80;
 
 pub const VERIFY_COST_ML_DSA_87: u64 = 8;
 pub const VERIFY_COST_UNKNOWN_SUITE: u64 = 64;
+/// CANONICAL §9: base verify cost priced to a `0xF0` Simplicity envelope
+/// (§5.4) witness item. Kept as its own named constant (not shared with
+/// `VERIFY_COST_UNKNOWN_SUITE`, though both are 64 today) so a future
+/// change to the unknown-suite floor does not silently re-price the
+/// Simplicity envelope. Mirror of Go `SIMPLICITY_BASE_VERIFY_COST`.
+pub const SIMPLICITY_BASE_VERIFY_COST: u64 = 64;
 
 /// EXT_BASE_COST is a policy/activation prerequisite constant for CORE_EXT tracks.
 /// It is defined as a stable numeric baseline derived from devnet-style measurement

--- a/clients/rust/crates/rubin-consensus/src/tests/block_basic.rs
+++ b/clients/rust/crates/rubin-consensus/src/tests/block_basic.rs
@@ -925,6 +925,80 @@ fn tx_weight_at_height_unknown_suite_uses_floor() {
 }
 
 #[test]
+fn tx_weight_sig_cost_special_cases_mirror_go() {
+    // Mirror of Go `TestTxWeight_SigCostSpecialCases` (RUB-545): the sig_cost
+    // DELTA between a single-witness tx and an otherwise-identical
+    // sentinel-witness tx must equal `want`, on BOTH the legacy and the
+    // registry weight paths. Pins the 0xF0 Simplicity-envelope price to its
+    // own base cost (not the unknown-suite floor, though numerically equal).
+    use crate::constants::{SIMPLICITY_BASE_VERIFY_COST, VERIFY_COST_UNKNOWN_SUITE};
+    use crate::suite_registry::{DefaultRotationProvider, SuiteRegistry};
+
+    // Build the Tx struct directly (mirror of Go `txWithWitness`, which does
+    // not round-trip through parse): the weight functions take `&Tx`, and an
+    // empty-pubkey/empty-sig witness keeps the witness byte-size identical
+    // across suites, so the weight delta isolates the sig_cost.
+    fn one_witness_tx(suite_id: u8) -> Tx {
+        Tx {
+            version: 1,
+            tx_kind: 0x00,
+            tx_nonce: 0,
+            inputs: Vec::new(),
+            outputs: Vec::new(),
+            locktime: 0,
+            da_commit_core: None,
+            da_chunk_core: None,
+            witness: vec![WitnessItem {
+                suite_id,
+                pubkey: Vec::new(),
+                signature: Vec::new(),
+            }],
+            da_payload: Vec::new(),
+        }
+    }
+
+    let rp = DefaultRotationProvider;
+    let reg = SuiteRegistry::default_registry();
+    let sentinel = one_witness_tx(SUITE_ID_SENTINEL);
+    for (name, suite_id, want) in [
+        (
+            "simplicity_envelope",
+            crate::constants::SUITE_ID_SIMPLICITY_ENVELOPE,
+            SIMPLICITY_BASE_VERIFY_COST,
+        ),
+        ("unknown_suite", 0xFFu8, VERIFY_COST_UNKNOWN_SUITE),
+    ] {
+        let item = one_witness_tx(suite_id);
+
+        let (legacy_sentinel, _, _) =
+            crate::block_basic::tx_weight_and_stats_public(&sentinel).expect("legacy sentinel");
+        let (legacy_item, _, _) =
+            crate::block_basic::tx_weight_and_stats_public(&item).expect("legacy item");
+        assert_eq!(
+            legacy_item - legacy_sentinel,
+            want,
+            "{name}: legacy sig_cost delta"
+        );
+
+        let (reg_sentinel, _, _) = crate::block_basic::tx_weight_and_stats_at_height(
+            &sentinel,
+            100,
+            Some(&rp),
+            Some(&reg),
+        )
+        .expect("registry sentinel");
+        let (reg_item, _, _) =
+            crate::block_basic::tx_weight_and_stats_at_height(&item, 100, Some(&rp), Some(&reg))
+                .expect("registry item");
+        assert_eq!(
+            reg_item - reg_sentinel,
+            want,
+            "{name}: registry sig_cost delta"
+        );
+    }
+}
+
+#[test]
 fn tx_weight_at_height_native_suite_uses_registry_cost() {
     use crate::suite_registry::{DefaultRotationProvider, SuiteRegistry};
 


### PR DESCRIPTION
## Issue
- Linear: RUB-546
- GitHub: Closes #2078

## Invariant
A 0xF0 Simplicity-envelope witness item is priced at its own base verify cost (SIMPLICITY_BASE_VERIFY_COST) in the Rust weight path, mirroring the merged Go RUB-545 sig_cost arm.

## Scope
- Changed files: 3
- Surfaces: clients/rust
- Non-scope: No Go changes, no parity corpus (RUB-547), no block-limit or dispatch changes.

## Validation
- `cl push`: GREEN for HEAD c98b1a41e1f6727f64bacf3160ff2ba906e99d7f
- Focused checks: 1127/1127 rust-consensus tests (incl. tx_weight_sig_cost_special_cases_mirror_go); clippy -D warnings reported 0; mirrors merged Go RUB-545 / PR #2144 (SIMPLICITY_BASE_VERIFY_COST=64, 0xF0 arm added to legacy_sig_cost and registry_sig_cost).
- Not run / skipped: None

## Follow-ups / Waivers
- parity-exempt label is intentional for this Rust-only mirror slice (Go reference RUB-545 / PR #2144 is merged).

### Parity exemption justification
Staged single-client (Rust-only) child slice. The Go sibling (RUB-545 / PR #2144) is merged and is the reference source; adding sibling-client changes only to satisfy per-PR source lockstep is out of scope. Shared 0xF0 weight-parity vectors are owned by the separate RUB-547 issue, not this slice (Non-scope: no parity corpus).
