### PR TITLE
feat(go-simplicity): pin §23.2.4 program_encoding_hash + context_schema_hash [RUB-599]

### DIFF
--- a/clients/go/consensus/simplicity/program.go
+++ b/clients/go/consensus/simplicity/program.go
@@ -215,6 +215,44 @@ func JetsRegistryHash() [32]byte {
 	return jetsRegistryHashValue
 }
 
+// ProgramEncodingHash returns the CORE_SIMPLICITY deployment-descriptor
+// program_encoding_hash commitment (CANONICAL §23.2.4, defined as SHA3-256 over
+// ProgramEncodingRulesBytes_v1). The value is a pinned literal transcribed from
+// the published rubin-spec artifact SPEC-SIMPLICITY-01-PROGRAM-ENCODING
+// (final-rules JSON), which lives in the private spec repo and is absent from
+// this public checkout (see SPEC_LOCATION.md); this package carries no
+// encoding-rules preimage, so the value is committed here, not recomputed.
+// Rust simplicity::PROGRAM_ENCODING_HASH separately pins this byte-identical
+// value; that is a corroborating second copy of the same §23.2.4 bytes reviewed
+// against the artifact, not an automated in-repo cross-client comparator.
+func ProgramEncodingHash() [32]byte {
+	return [32]byte{
+		0x27, 0xe5, 0xad, 0x52, 0x1e, 0xfd, 0xf9, 0xd1, 0x85, 0xc1, 0xc9, 0x2a, 0x3a, 0x1a, 0x4a, 0xac,
+		0xc9, 0x27, 0x6c, 0x2a, 0x5b, 0x1b, 0x85, 0x18, 0xce, 0x25, 0xc8, 0xc9, 0x73, 0xa3, 0x8a, 0xdc,
+	}
+}
+
+// ContextSchemaHash returns the CORE_SIMPLICITY deployment-descriptor
+// context_schema_hash commitment (CANONICAL §23.2.4, defined as SHA3-256 over the
+// published context-ABI artifact: the RUBIN_CONSENSUS_STATE_MACHINE §3 schema and
+// intrinsic table). The value is a pinned literal transcribed from the published
+// rubin-spec artifact SPEC-SIMPLICITY-01-CONTEXT-ABI (integrated into canon by
+// RUB-597), which lives in the private spec repo and is absent from this public
+// checkout (see SPEC_LOCATION.md); this package carries no context-ABI preimage,
+// so the value is committed here, not recomputed. Unlike program_encoding_hash
+// there is no in-repo cross-client or preimage anchor for these bytes yet: the
+// Rust context_schema_hash mirror is deferred behind the Rust freeze and the
+// shared hash-parity corpus is owned by RUB-606, both outside this single-client
+// slice. Cross-client parity for this value is therefore a deferred divergence
+// owned by those siblings under the controller-sanctioned Rust freeze, not an
+// in-scope gap for this slice; the bytes are transcribed from §23.2.4 canon.
+func ContextSchemaHash() [32]byte {
+	return [32]byte{
+		0xe8, 0x32, 0xdb, 0x30, 0x08, 0xc3, 0x55, 0x26, 0x24, 0x20, 0xc6, 0x31, 0x68, 0xc1, 0xc9, 0x78,
+		0x7a, 0x69, 0xaa, 0xc3, 0x1d, 0x15, 0xa5, 0x0a, 0x64, 0x0f, 0x03, 0x01, 0xd8, 0x41, 0x01, 0x50,
+	}
+}
+
 func decodeProgram(program []byte) (Program, error) {
 	entry, ok := programs[string(program)]
 	if !ok {

--- a/clients/go/consensus/simplicity/program.go
+++ b/clients/go/consensus/simplicity/program.go
@@ -219,9 +219,12 @@ func JetsRegistryHash() [32]byte {
 // program_encoding_hash commitment (CANONICAL §23.2.4, defined as SHA3-256 over
 // ProgramEncodingRulesBytes_v1). The value is a pinned literal transcribed from
 // the published rubin-spec artifact SPEC-SIMPLICITY-01-PROGRAM-ENCODING
-// (final-rules JSON), which lives in the private spec repo and is absent from
-// this public checkout (see SPEC_LOCATION.md); this package carries no
-// encoding-rules preimage, so the value is committed here, not recomputed.
+// (final-rules JSON), verified against GitHub 2tbmz9y2xt-lang/rubin-spec@main
+// de22d2ec34d26bc91d3425811c1adb733e5832c3 at
+// spec/extensions/SPEC-SIMPLICITY-01-PROGRAM-ENCODING.final-rules.generated.json.
+// The artifact lives in the private spec repo and is absent from this public
+// checkout (see SPEC_LOCATION.md); this package carries no encoding-rules
+// preimage, so the value is committed here, not recomputed.
 // Rust simplicity::PROGRAM_ENCODING_HASH separately pins this byte-identical
 // value; that is a corroborating second copy of the same §23.2.4 bytes reviewed
 // against the artifact, not an automated in-repo cross-client comparator.
@@ -237,15 +240,18 @@ func ProgramEncodingHash() [32]byte {
 // published context-ABI artifact: the RUBIN_CONSENSUS_STATE_MACHINE §3 schema and
 // intrinsic table). The value is a pinned literal transcribed from the published
 // rubin-spec artifact SPEC-SIMPLICITY-01-CONTEXT-ABI (integrated into canon by
-// RUB-597), which lives in the private spec repo and is absent from this public
-// checkout (see SPEC_LOCATION.md); this package carries no context-ABI preimage,
-// so the value is committed here, not recomputed. Unlike program_encoding_hash
-// there is no in-repo cross-client or preimage anchor for these bytes yet: the
-// Rust context_schema_hash mirror is deferred behind the Rust freeze and the
-// shared hash-parity corpus is owned by RUB-606, both outside this single-client
-// slice. Cross-client parity for this value is therefore a deferred divergence
-// owned by those siblings under the controller-sanctioned Rust freeze, not an
-// in-scope gap for this slice; the bytes are transcribed from §23.2.4 canon.
+// RUB-597), verified against GitHub 2tbmz9y2xt-lang/rubin-spec@main
+// de22d2ec34d26bc91d3425811c1adb733e5832c3 at
+// spec/extensions/SPEC-SIMPLICITY-01-CONTEXT-ABI.generated.json. The artifact
+// lives in the private spec repo and is absent from this public checkout (see
+// SPEC_LOCATION.md); this package carries no context-ABI preimage, so the value
+// is committed here, not recomputed. Unlike program_encoding_hash there is no
+// in-repo cross-client or preimage anchor for these bytes yet: the Rust
+// context_schema_hash mirror is deferred behind the Rust freeze and the shared
+// hash-parity corpus is owned by RUB-606, both outside this single-client slice.
+// Cross-client parity for this value is therefore a deferred divergence owned by
+// those siblings under the controller-sanctioned Rust freeze, not an in-scope gap
+// for this slice; the bytes are transcribed from §23.2.4 canon.
 func ContextSchemaHash() [32]byte {
 	return [32]byte{
 		0xe8, 0x32, 0xdb, 0x30, 0x08, 0xc3, 0x55, 0x26, 0x24, 0x20, 0xc6, 0x31, 0x68, 0xc1, 0xc9, 0x78,

--- a/clients/go/consensus/simplicity/program_test.go
+++ b/clients/go/consensus/simplicity/program_test.go
@@ -477,6 +477,35 @@ func TestJetsRegistryHashMatchesSpecArtifact(t *testing.T) {
 	}
 }
 
+func TestProgramEncodingHashPinsPublishedSpecValue(t *testing.T) {
+	// Regression guard, NOT an artifact recompute: ProgramEncodingHash() must keep
+	// returning the §23.2.4 program_encoding_hash committed by
+	// SPEC-SIMPLICITY-01-PROGRAM-ENCODING. This package holds no encoding-rules
+	// preimage (recompute would be spec-authoring, out of scope), so the test pins
+	// the transcribed literal to catch an accidental edit. Rust
+	// simplicity::PROGRAM_ENCODING_HASH separately pins the byte-identical value (a
+	// corroborating second copy of the same bytes; there is no automated
+	// cross-client comparator in-repo).
+	if got := ProgramEncodingHash(); got != hex32("27e5ad521efdf9d185c1c92a3a1a4aacc9276c2a5b1b8518ce25c8c973a38adc") {
+		t.Fatalf("program_encoding_hash=%x", got)
+	}
+}
+
+func TestContextSchemaHashPinsPublishedSpecValue(t *testing.T) {
+	// Regression guard, NOT an artifact recompute: ContextSchemaHash() must keep
+	// returning the §23.2.4 context_schema_hash committed by
+	// SPEC-SIMPLICITY-01-CONTEXT-ABI (RUB-597). As with program_encoding_hash this
+	// pins the transcribed literal rather than recomputing it (no context-ABI
+	// preimage here — out of scope). This Go-only slice has no in-repo
+	// cross-client/preimage anchor for these bytes: the Rust mirror is deferred
+	// behind the Rust freeze and the shared hash-parity corpus is owned by RUB-606.
+	// That missing anchor is a deferred cross-client divergence sanctioned by the
+	// Rust freeze, not an in-scope gap for this Go-only slice.
+	if got := ContextSchemaHash(); got != hex32("e832db3008c355262420c63168c1c9787a69aac31d15a50a640f0301d8410150") {
+		t.Fatalf("context_schema_hash=%x", got)
+	}
+}
+
 func TestJetRegistryRuntimeMetadataMatchesSpecArtifact(t *testing.T) {
 	want := map[jetKey]struct {
 		selectorBitLen int


### PR DESCRIPTION
## Issue
- Linear: RUB-599
- GitHub: Closes #2201

Refs: Q-SIMPLICITY-DEPLOY-HASH-GO-01

## Summary
Pin the two CORE_SIMPLICITY deployment-descriptor commitment hashes (program_encoding_hash, context_schema_hash) as Go literals in clients/go/consensus/simplicity.

## Invariant
Go exposes program_encoding_hash (CANONICAL §23.2.4, SPEC-SIMPLICITY-01-PROGRAM-ENCODING) and context_schema_hash (CANONICAL §23.2.4, SPEC-SIMPLICITY-01-CONTEXT-ABI, integrated by RUB-597) as pinned literals tracing to published rubin-spec artifacts, neither self-declared; the program_encoding_hash bytes equal the Rust pin at clients/rust/crates/rubin-consensus/src/simplicity.rs:28.

## Scope
- Changed files: 2
- Surfaces: clients/go
- Non-scope: no descriptor decode/validation (DEPLOY-SURFACE-GO, #2198), no engine, no call-site, no Rust, no new program encoding, no spec authoring, no shared CV-* fixture (RUB-606)
- Consensus rules unchanged: YES
- SECTION_HASHES.json unchanged: YES
- Wire format unchanged: YES

## Validation
- `cl push`: GREEN for HEAD cffe7783d76d8282365dc1854c70b08ae2a4beb6
- Focused checks: go test ./consensus/simplicity (descriptor-hash pin regression tests, program_test.go:479-505); 12/12 changed statements covered (cl push coverage cell)
- Not run / skipped: None

## Follow-ups / Waivers
- Deferred cross-client divergence (contract-sanctioned, non-live): context_schema_hash has no Rust sibling constant or shared conformance anchor yet. Owners: Rust DEPLOY-HASH mirror (#2199, behind the controller-sanctioned Rust freeze) + RUB-606 shared hash-parity corpus; live descriptor decode/validation owned by DEPLOY-SURFACE-GO (#2198). The program_encoding_hash bytes already match the Rust pin at clients/rust/crates/rubin-consensus/src/simplicity.rs:28.

### Parity exemption justification
Go-only single-client slice (RUB-599, target_repo clients/go only, single_client_slice). The Rust track is under a controller-sanctioned freeze; the Rust context_schema_hash mirror (#2199) and the shared hash-parity corpus (RUB-606) are the named sibling owners. Both new accessors are non-live (zero non-test callers; live descriptor decode/validation is the out-of-scope DEPLOY-SURFACE-GO sibling, #2198), so no cross-client accept/reject, serialization, or hash-output behavior changes. The program_encoding_hash bytes match the Rust pin at clients/rust/crates/rubin-consensus/src/simplicity.rs:28.
