### PR TITLE
chore(ci): bump github/codeql-action to v4.36.3 across init/autobuild/analyze [RUB-612]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,7 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 5
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action/*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -41,9 +41,9 @@ jobs:
 
       - name: Autobuild
         if: matrix.build-mode == 'autobuild'
-        uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/autobuild@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Issue
- Linear: RUB-612
- GitHub: Closes #2223

## Summary
Combines the three separate, individually-unmergeable dependabot codeql-action bumps into one change, and adds dependabot grouping so this doesn't recur.

## Invariant
All three github/codeql-action references (init, autobuild, analyze) in codeql.yml stay pinned to the SAME version at all times.

## Scope
- Changed files: 2
- Surfaces: tooling (.github/workflows/codeql.yml, .github/dependabot.yml)
- Non-scope: no other workflow changes, no consensus/Go/Rust code, no other dependency bumps
- Consensus rules unchanged: YES
- SECTION_HASHES.json unchanged: YES
- Wire format unchanged: YES

## Validation
- `cl push`: GREEN for HEAD ba863c9064805ad3c1dc4d4e70e29533e557e81e
- Focused checks: dependabot PRs #2217/#2218/#2219 each individually red on
  `CodeQL Analysis (go, autobuild)` / `CodeQL Analysis (rust, none)` with
  "Loaded a configuration file for version '4.36.2', but running version '4.36.3'" —
  root cause: each PR bumps only one of the three coupled codeql-action refs.
  This PR bumps all three together to the same SHA dependabot itself proposed
  (taken directly from PR #2217's diff).
- Not run / skipped: None

## Follow-ups / Waivers
- Supersedes #2217, #2218, #2219 (closing those as duplicates of this combined change).