### PR TITLE
refactor(go-consensus): §2.4 step-3d byte-copy split, no covenant_data re-parse [RUB-616]

### DIFF
--- a/clients/go/consensus/simplicity_evalhost.go
+++ b/clients/go/consensus/simplicity_evalhost.go
@@ -6,8 +6,12 @@ import "github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go/consensus/simplicit
 // eager digest32 / sighash_type) to the RUB-598 step-6 context ABI
 // (simplicity.EvalHost): one FRESH host per CORE_SIMPLICITY input carries the single
 // shared exec meter and answers each context intrinsic read from the immutable tx
-// context. NON-LIVE — building/using it changes no spend accept/reject decision until
-// the RUB-615 gate wires it into the dispatch.
+// context. RUB-615 wired this adapter into the CORE_SIMPLICITY spend-validation
+// dispatch, but it stays NON-LIVE in production: CORE_SIMPLICITY spends remain
+// reject-only because no §23.2.4 deployment activates without a real H_simplicity
+// activation pin (activation is test-local only). A future activation-pin issue makes
+// it live; until then building or using the host changes no production spend
+// accept/reject decision.
 type simplicityEvalHost struct {
 	ctx      *SimplicityTxContext
 	self     SimplicityTxContextSelfView

--- a/clients/go/consensus/simplicity_txcontext.go
+++ b/clients/go/consensus/simplicity_txcontext.go
@@ -193,7 +193,7 @@ func populateSimplicityTxContextInputViews(ctx *SimplicityTxContext, resolvedInp
 		if entry.CovenantType != COV_TYPE_CORE_SIMPLICITY {
 			continue
 		}
-		programCMR, state, err := parseCoreSimplicityCovenantData(entry.Value, entry.CovenantData)
+		programCMR, state, err := splitCoreSimplicityCovenantData(entry.CovenantData)
 		if err != nil {
 			return err
 		}
@@ -228,7 +228,7 @@ func populateSimplicityTxContextOutputViews(ctx *SimplicityTxContext, outputs []
 		if out.CovenantType != COV_TYPE_CORE_SIMPLICITY {
 			continue
 		}
-		programCMR, state, err := parseCoreSimplicityCovenantData(out.Value, out.CovenantData)
+		programCMR, state, err := splitCoreSimplicityCovenantData(out.CovenantData)
 		if err != nil {
 			return err
 		}
@@ -238,6 +238,49 @@ func populateSimplicityTxContextOutputViews(ctx *SimplicityTxContext, outputs []
 		})
 	}
 	return nil
+}
+
+// splitCoreSimplicityCovenantData performs the §2.4 step-3d byte-copy split of a
+// CORE_SIMPLICITY covenant_data snapshot into (program_cmr, state): program_cmr =
+// the first 32 bytes; state = the bytes after the CompactSize length prefix, with
+// the prefix STRIPPED (matching the Section 3.4 state_bytes definition). The
+// snapshot is trusted — for resolved inputs by their creation-time §14 validation,
+// for outputs by the step-2 §14 structural validation that precedes step 3d — so the
+// split is byte-copies only and MUST NOT re-impose the value>0 / state_len-bound /
+// total-length checks (those are creation-time §14 concerns, not step 3d; see
+// RUBIN_CONSENSUS_STATE_MACHINE.md §2.4 step 3d "It MUST NOT re-parse covenant_data").
+// The spec's "the split cannot fail" holds for those well-formed snapshots; the length
+// guards here are a defensive no-panic boundary (validity-path code must return a typed
+// error, never panic) for the structurally impossible malformed case, not a re-validation
+// of the §14 checks. They do not re-parse.
+func splitCoreSimplicityCovenantData(covenantData []byte) ([32]byte, []byte, error) {
+	var programCMR [32]byte
+	if len(covenantData) < 33 {
+		return programCMR, nil, txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_SIMPLICITY covenant_data too short for step-3d split")
+	}
+	copy(programCMR[:], covenantData[:32])
+	stateStart := 32 + compactSizePrefixLen(covenantData[32])
+	if len(covenantData) < stateStart {
+		return programCMR, nil, txerr(TX_ERR_COVENANT_TYPE_INVALID, "CORE_SIMPLICITY covenant_data too short for step-3d split")
+	}
+	return programCMR, covenantData[stateStart:], nil
+}
+
+// compactSizePrefixLen returns the encoded byte width of a CompactSize length prefix
+// from its tag byte (§ CompactSize encoding): 1 for tag < 0xfd, else 3/5/9 for the
+// 0xfd/0xfe/0xff wide forms. It reads only the tag to strip the prefix; it does not
+// decode or validate the encoded value (that would be a re-parse).
+func compactSizePrefixLen(tag byte) int {
+	switch tag {
+	case 0xff:
+		return 9
+	case 0xfe:
+		return 5
+	case 0xfd:
+		return 3
+	default:
+		return 1
+	}
 }
 
 func buildSimplicityTxContextDAView(tx *Tx) (SimplicityTxContextDAView, error) {

--- a/clients/go/consensus/simplicity_txcontext_test.go
+++ b/clients/go/consensus/simplicity_txcontext_test.go
@@ -188,22 +188,38 @@ func TestBuildSimplicityTxContext_SameCMRViewProjection(t *testing.T) {
 	}
 }
 
-func TestBuildSimplicityTxContext_InvalidCoreSimplicityOutputFailsClosed(t *testing.T) {
+// TestBuildSimplicityTxContext_Step3dTrustsSnapshotNoReparse pins that §2.4 step-3d
+// context construction (BuildSimplicityTxContext) treats the resolved-input snapshot
+// and the step-2-validated output cache as TRUSTED: it byte-copy splits
+// (program_cmr, state) and does NOT re-impose the value>0 / state_len-bound /
+// total-length §14 checks, so a value=0 CORE_SIMPLICITY output (and a value=0 resolved
+// input) are NOT re-rejected during construction. The value>0 rejection lives at
+// creation-time §14 validation instead — the check step 3d delegates to rather than
+// duplicating, exercised here via ValidateTxCovenantsGenesis under an active deployment
+// (and in TestValidateTxCovenantsGenesis_CoreSimplicityActive).
+func TestBuildSimplicityTxContext_Step3dTrustsSnapshotNoReparse(t *testing.T) {
 	cmr := [32]byte{0: 0xba}
-	tx := &Tx{
-		Version: TX_WIRE_VERSION,
-		Inputs:  []TxInput{{PrevVout: 0}},
-		Outputs: []TxOutput{{Value: 0, CovenantType: COV_TYPE_CORE_SIMPLICITY, CovenantData: makeCoreSimplicityCovenantData(cmr, nil)}},
-	}
+	badOut := TxOutput{Value: 0, CovenantType: COV_TYPE_CORE_SIMPLICITY, CovenantData: makeCoreSimplicityCovenantData(cmr, nil)}
+
+	// Creation-time §14 (active deployment) is where a value=0 CORE_SIMPLICITY output
+	// fails closed — the check step 3d delegates to.
+	active := testRotationProvider{createSuiteID: SUITE_ID_ML_DSA_87, simplicityActiveHeight: 10}
+	assertTxErrCodeMsg(t, ValidateTxCovenantsGenesis(&Tx{Outputs: []TxOutput{badOut}}, [32]byte{}, 10, active),
+		TX_ERR_COVENANT_TYPE_INVALID, "CORE_SIMPLICITY value must be > 0")
+
+	// Step 3d trusts the snapshot: with a well-formed CORE_SIMPLICITY input present,
+	// the value=0 output is NOT re-rejected during construction.
+	tx := &Tx{Version: TX_WIRE_VERSION, Inputs: []TxInput{{PrevVout: 0}}, Outputs: []TxOutput{badOut}}
 	resolved := []UtxoEntry{{Value: 1, CovenantType: COV_TYPE_CORE_SIMPLICITY, CovenantData: makeCoreSimplicityCovenantData(cmr, nil)}}
+	if _, err := BuildSimplicityTxContext(tx, resolved, 1, [32]byte{}); err != nil {
+		t.Fatalf("step 3d must trust the value=0 output snapshot (no re-validation), got %v", err)
+	}
 
-	_, err := BuildSimplicityTxContext(tx, resolved, 1, [32]byte{})
-	assertTxErrCodeMsg(t, err, TX_ERR_COVENANT_TYPE_INVALID, "CORE_SIMPLICITY value must be > 0")
-
-	tx.Outputs[0].Value = 1
+	// A value=0 resolved input is likewise trusted at step 3d.
 	resolved[0].Value = 0
-	_, err = BuildSimplicityTxContext(tx, resolved, 1, [32]byte{})
-	assertTxErrCodeMsg(t, err, TX_ERR_COVENANT_TYPE_INVALID, "CORE_SIMPLICITY value must be > 0")
+	if _, err := BuildSimplicityTxContext(tx, resolved, 1, [32]byte{}); err != nil {
+		t.Fatalf("step 3d must trust the value=0 resolved-input snapshot (no re-validation), got %v", err)
+	}
 }
 
 func TestSimplicityTxContextDescriptorHashAccessors(t *testing.T) {
@@ -540,6 +556,49 @@ func TestBuildSimplicityTxContext_MalformedSelfCovenantFailsClosed(t *testing.T)
 	_, err := BuildSimplicityTxContext(tx, resolved, 1, [32]byte{})
 	if err == nil || mustTxErrCode(t, err) != TX_ERR_COVENANT_TYPE_INVALID {
 		t.Fatalf("expected malformed CORE_SIMPLICITY covenant error, got %v", err)
+	}
+}
+
+// TestSplitCoreSimplicityCovenantData pins the §2.4 step-3d byte-copy split: program_cmr
+// is the first 32 bytes and state is whatever follows the CompactSize length prefix, with
+// the prefix stripped by its tag-encoded width and WITHOUT decoding/validating the encoded
+// length (byte-copies only, no re-parse). The length guards fail closed on a structurally
+// malformed snapshot without re-imposing the creation-time §14 checks.
+func TestSplitCoreSimplicityCovenantData(t *testing.T) {
+	cmr := [32]byte{0: 0xab, 31: 0xcd}
+
+	// 1-byte CompactSize prefix: prefix stripped, state returned verbatim.
+	oneByte := append(append(append([]byte{}, cmr[:]...), 0x02), 0xaa, 0xbb)
+	if gotCMR, state, err := splitCoreSimplicityCovenantData(oneByte); err != nil || gotCMR != cmr || string(state) != "\xaa\xbb" {
+		t.Fatalf("1-byte prefix split: cmr=%x state=%x err=%v", gotCMR, state, err)
+	}
+
+	// 3-byte (0xfd) prefix: the full prefix is stripped by width without decoding the
+	// encoded length (0x1234 here does not match the 2 trailing bytes, yet the split
+	// still returns them — proving no re-parse).
+	wide := append(append(append([]byte{}, cmr[:]...), 0xfd, 0x34, 0x12), 0xcc, 0xdd)
+	if gotCMR, state, err := splitCoreSimplicityCovenantData(wide); err != nil || gotCMR != cmr || string(state) != "\xcc\xdd" {
+		t.Fatalf("0xfd prefix split: cmr=%x state=%x err=%v", gotCMR, state, err)
+	}
+
+	// Slice-panic guards fail closed without re-validating: too short for cmr+tag, and a
+	// wide tag claiming more prefix bytes than the snapshot carries.
+	if _, _, err := splitCoreSimplicityCovenantData(make([]byte, 10)); err == nil || mustTxErrCode(t, err) != TX_ERR_COVENANT_TYPE_INVALID {
+		t.Fatalf("too-short snapshot: got %v", err)
+	}
+	shortWide := append(append([]byte{}, cmr[:]...), 0xff)
+	if _, _, err := splitCoreSimplicityCovenantData(shortWide); err == nil || mustTxErrCode(t, err) != TX_ERR_COVENANT_TYPE_INVALID {
+		t.Fatalf("wide-tag-underflow snapshot: got %v", err)
+	}
+
+	// compactSizePrefixLen strips exactly the encoded CompactSize width for every tag.
+	for _, tc := range []struct {
+		tag  byte
+		want int
+	}{{0x00, 1}, {0xfc, 1}, {0xfd, 3}, {0xfe, 5}, {0xff, 9}} {
+		if got := compactSizePrefixLen(tc.tag); got != tc.want {
+			t.Fatalf("compactSizePrefixLen(%#x)=%d want %d", tc.tag, got, tc.want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Issue
- Linear: RUB-616
- GitHub: Closes #2234

Refs: Q-SIMPLICITY-STEP3D-CLEANUP-GO-01

## Summary
Replace the §2.4 step-3d covenant_data re-parse with a byte-copy split, and refresh the EvalHost NON-LIVE doc comment.

## Invariant
§2.4 step-3d SimplicityTxContext construction derives (program_cmr, state) from a resolved-input / step-2-validated-output covenant_data snapshot by byte-copy split (program_cmr = first 32 bytes; state = the bytes after the CompactSize length prefix, prefix stripped), not a validating re-parse.

## Scope
- Changed files: 3
- Surfaces: clients/go
- Non-scope: no dispatch/gate changes; no Rust; no activation-pin; no engine semantics; no new digest path.
- Consensus rules unchanged: YES
- SECTION_HASHES.json unchanged: YES
- Wire format unchanged: YES

## Validation
- `cl push`: GREEN for HEAD 4c26e1c47d02794a5c68ca89ded2676851964eb0
- Focused checks: go-deep race/shuffle soak; coverage 100% on the changed lines; native semantic-review workflow + GLM attestation-grade last-line review.
- Not run / skipped: Rust (frozen sibling, out of scope)

## Follow-ups / Waivers
- Rust mirror of the step-3d byte-copy split is a deferred, controller-sanctioned Go-primary/Rust-frozen divergence (non-live; owner = future clients/rust CORE_SIMPLICITY step-3d sibling on the RUB-604/605/606 track).

### Parity exemption justification
Go-only §2.4 step-3d context-construction internal on the CORE_SIMPLICITY surface. Rust is the frozen parity sentinel under the standing phase-9 controller sanction (Rust siblings RUB-604/605/606, gated behind the Go devnet-ready line RUB-609). Well-formed-entry behavior is unchanged and the surface stays non-live / reject-only in production (no §23.2.4 H_simplicity activation pin), so no live cross-client accept/reject divergence is reachable; the Rust re-parse path is the lagging sibling, mirrored later.
