### PR TITLE
formal: sync embedded section hash disposition for RUB-620

### DIFF
--- a/rubin-formal/proof_coverage.json
+++ b/rubin-formal/proof_coverage.json
@@ -4,7 +4,7 @@
   "claim_level": "refined",
   "spec_source_file": "spec/RUBIN_L1_CANONICAL.md",
   "spec_section_hashes_file": "spec/SECTION_HASHES.json",
-  "spec_section_hashes_sha3_256": "930107d62f2f2a23db3f783bb359e8b8c579abdaa07cea4ecd4e110b5ba4c31c",
+  "spec_section_hashes_sha3_256": "48fe4dcf53908f8e2d1e82a3e01809945a725c4f8a260c8e3707bd69a2fcd418",
   "coverage_summary": {
     "section_rows": 18,
     "proved_rows": 11,


### PR DESCRIPTION
## Issue
- Linear: RUB-620
- GitHub: Closes #2240

Refs: Q-SIMPLICITY-PROGRAM-ENCODING-GRAMMAR-01

## Summary
One-line rubin-formal section-hash pin sync for the RUB-620 spec landing (pairs with rubin-spec PR #283; merges FIRST, back-to-back).

## Invariant
`rubin-formal/proof_coverage.json.spec_section_hashes_sha3_256` pins the SHA3-256 of the incoming rubin-spec `spec/SECTION_HASHES.json` so `tools/check_section_hashes.py` stays green across both repos through the RUB-620 landing sequence.

## Scope
- Changed files: 1
- Surfaces: formal
- Non-scope: no other rubin-protocol code (the tag-IV artifact itself is rubin-spec PR #283); standalone rubin-formal registry sync is a named follow-up, not this PR
- Consensus rules unchanged: YES
- SECTION_HASHES.json unchanged: YES
- Wire format unchanged: YES

## Validation
- `cl push`: GREEN for HEAD dd30b0dea6da9761aa5b5a571413e05b4f65efe3
- Semantic cell: controller-manual attest (sanctioned `CL_CONTROLLER_ATTEST` fallback; controller directive 2026-07-06 — semantic evidence via GLM swarm)
- Focused checks: pin equality verified byte-for-byte against rubin-spec commit `222fedadf164eaaba1f468b89c14063618e9a44f` (draft PR 2tbmz9y2xt-lang/rubin-spec#283); GLM swarm ON-HEAD run `glm-swarm-20260706T170024Z` (target dd30b0d, live PR body loaded): CLEAN, 0 findings, attestation-grade — run preserved on-disk (`--no-prune-previous`) and mirrored to a RUB-620 Linear comment
- Not run / skipped: None

## Follow-ups / Waivers
- Merge order: this PR FIRST, rubin-spec#283 immediately after (back-to-back, minimal red-window for other spec PRs; RUB-597 precedent #2208/#2209)
- Standalone rubin-formal registry sync right after merge (formal-sync routine; precedent rubin-formal#547; recorded in the RUB-620 contract)
- Post-merge: verify RUB-620 state vs done_when; reopen if auto-closed (Linear autoclose mitigation)
