### PR TITLE
formal: sync embedded section hash disposition for RUB-622

### DIFF
--- a/rubin-formal/proof_coverage.json
+++ b/rubin-formal/proof_coverage.json
@@ -4,7 +4,7 @@
   "claim_level": "refined",
   "spec_source_file": "spec/RUBIN_L1_CANONICAL.md",
   "spec_section_hashes_file": "spec/SECTION_HASHES.json",
-  "spec_section_hashes_sha3_256": "48fe4dcf53908f8e2d1e82a3e01809945a725c4f8a260c8e3707bd69a2fcd418",
+  "spec_section_hashes_sha3_256": "decd78829681684a1e46ebfd1575725385516de8dd928601bac90f11c4c368c9",
   "coverage_summary": {
     "section_rows": 18,
     "proved_rows": 11,


### PR DESCRIPTION
## Issue
- Linear: RUB-622
- GitHub: Closes #2241

Refs: Q-SIMPLICITY-PROGRAM-ENCODING-GRAMMAR-01

## Summary
One-line rubin-formal section-hash pin sync for the RUB-622 word-CMR spec landing (pairs with the rubin-spec word-CMR PR; merges FIRST, back-to-back).

## Invariant
`rubin-formal/proof_coverage.json.spec_section_hashes_sha3_256` pins the SHA3-256 of the incoming rubin-spec `spec/SECTION_HASHES.json` so `tools/check_section_hashes.py` stays green across both repos through the RUB-622 landing sequence.

## Scope
- Changed files: 1
- Surfaces: formal
- Non-scope: no other rubin-protocol code (the word-CMR artifact itself is the paired rubin-spec PR); standalone rubin-formal registry sync is the named follow-up leg, not this PR
- Consensus rules unchanged: YES
- SECTION_HASHES.json unchanged: YES
- Wire format unchanged: YES

## Validation
- `cl push`: GREEN for HEAD ee6ccf1cfd4f391210a81922586029704174a3ad
- Semantic cell: controller-manual attest (sanctioned `CL_CONTROLLER_ATTEST` fallback; full Claude fan-out wf_32cae13e ran — zero content findings on the pin; all process findings dispositioned in the recorded attest)
- Focused checks: pin equality verified byte-for-byte against rubin-spec commit `6d801b4` on published branch `codex/rub-622-word-cmr` (draft spec PR opens in the same sequence); pin value `decd78829681684a1e46ebfd1575725385516de8dd928601bac90f11c4c368c9`
- Not run / skipped: None

## Follow-ups / Waivers
- Merge order: this PR FIRST, the rubin-spec word-CMR PR immediately after (back-to-back; RUB-597/RUB-620 precedent)
- Standalone rubin-formal registry sync right after the merges (formal-sync routine; precedent rubin-formal#547/#550)
- Post-merge: verify RUB-622 state vs done_when; reopen if auto-closed (Linear autoclose mitigation)
