### PR TITLE
formal: sync embedded section hash disposition for RUB-624

### DIFF
--- a/rubin-formal/proof_coverage.json
+++ b/rubin-formal/proof_coverage.json
@@ -4,7 +4,7 @@
   "claim_level": "refined",
   "spec_source_file": "spec/RUBIN_L1_CANONICAL.md",
   "spec_section_hashes_file": "spec/SECTION_HASHES.json",
-  "spec_section_hashes_sha3_256": "decd78829681684a1e46ebfd1575725385516de8dd928601bac90f11c4c368c9",
+  "spec_section_hashes_sha3_256": "6a3381acf2fa78926d350c285c8464884728b6a0a4809d78f42835a3423e5e54",
   "coverage_summary": {
     "section_rows": 18,
     "proved_rows": 11,


### PR DESCRIPTION
Updates `rubin-formal/proof_coverage.json` `spec_section_hashes_sha3_256` `decd7882…` -> `6a3381ac…` to match rubin-spec `SECTION_HASHES.json` after the RUB-624 conformance-corpus commit regenerated `simplicity_deployment_descriptors`.

Lands FIRST (pin-first choreography) so the paired rubin-spec PR #293 `check_section_hashes` formal cross-check passes against rubin-protocol main. No consensus/code change; the full formal Lean build validated section-hash-disposition consistency.