### PR TITLE
chore(deps): bump crossbeam-epoch to 0.9.20 (RUSTSEC-2026-0204) [RUB-633]

### DIFF
--- a/clients/rust/Cargo.lock
+++ b/clients/rust/Cargo.lock
@@ -196,9 +196,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
Bumps the transitive dependency `crossbeam-epoch` `0.9.18` -> `0.9.20` in `clients/rust/Cargo.lock` (lockfile-only, API-compatible).

`cargo audit --deny warnings` began failing on every rubin-protocol PR (test / security_ai / validator gates) after RUSTSEC-2026-0204 was published (invalid pointer dereference in crossbeam-epoch's `fmt::Pointer` impl for `Atomic`/`Shared`). The advisory's own remediation is `>=0.9.20`; local `cargo audit --deny warnings` is now clean (exit 0). No Cargo.toml, source, or behavior change.

Unblocks the repo-wide security gates (including the RUB-624 pin-first choreography, PR #2254).