### PR TITLE
formal: sync section-hash pin for RUB-634 bytes-operand binding

### DIFF
--- a/rubin-formal/proof_coverage.json
+++ b/rubin-formal/proof_coverage.json
@@ -4,7 +4,7 @@
   "claim_level": "refined",
   "spec_source_file": "spec/RUBIN_L1_CANONICAL.md",
   "spec_section_hashes_file": "spec/SECTION_HASHES.json",
-  "spec_section_hashes_sha3_256": "6a3381acf2fa78926d350c285c8464884728b6a0a4809d78f42835a3423e5e54",
+  "spec_section_hashes_sha3_256": "1b4251402569327991ff9b729cbd488c54fdb1f57c58532b673d4f1ff82a3add",
   "coverage_summary": {
     "section_rows": 18,
     "proved_rows": 11,


### PR DESCRIPTION
## Issue
- Linear: RUB-635
- GitHub: Closes #2260

Refs: Q-SIMPLICITY-PROGRAM-ENCODING-GRAMMAR-01

## Invariant
`rubin-formal/proof_coverage.json.spec_section_hashes_sha3_256` equals the SHA3-256 of the incoming rubin-spec `spec/SECTION_HASHES.json` so `tools/check_section_hashes.py` stays green across both repos through the RUB-634 landing sequence.

## Scope
- Changed files: 1
- Surfaces: formal
- Non-scope: no other rubin-protocol code; the bytes-operand binding rule itself is the paired rubin-spec PR (RUB-634); standalone rubin-formal registry sync is the named follow-up leg (RUB-635 leg 2), not this PR
- Consensus rules unchanged: YES
- SECTION_HASHES.json unchanged: YES
- Wire format unchanged: YES

## Validation
- `cl push`: GREEN for HEAD edfc3cb139182f60e96171d2b3a9dd6e244f8b4a
- Focused checks: pin value `1b4251402569327991ff9b729cbd488c54fdb1f57c58532b673d4f1ff82a3add` = SHA3-256 of the rubin-spec RUB-634 branch `spec/SECTION_HASHES.json` (computed byte-for-byte); the descriptor section `simplicity_deployment_descriptors` is the only rubin-spec section changed (18 unchanged sections pre-flight-verified, 1 changed)
- Not run / skipped: None

## Follow-ups / Waivers
- Merge order: this PR FIRST, the rubin-spec bytes-operand binding-rule PR (RUB-634) immediately after (RUB-597/RUB-620/RUB-622 precedent)
- Standalone rubin-formal registry sync right after the merges (RUB-635 leg 2)
