### PR TITLE
RUB-636: sync section-hash pin for same-input error-code priority change

### DIFF
--- a/rubin-formal/proof_coverage.json
+++ b/rubin-formal/proof_coverage.json
@@ -4,7 +4,7 @@
   "claim_level": "refined",
   "spec_source_file": "spec/RUBIN_L1_CANONICAL.md",
   "spec_section_hashes_file": "spec/SECTION_HASHES.json",
-  "spec_section_hashes_sha3_256": "1b4251402569327991ff9b729cbd488c54fdb1f57c58532b673d4f1ff82a3add",
+  "spec_section_hashes_sha3_256": "8013eb18ceb80eb76cea418c777630cfa2a8cc72facfd1d90792d5f1c1217345",
   "coverage_summary": {
     "section_rows": 18,
     "proved_rows": 11,


### PR DESCRIPTION
## Issue
- Linear: RUB-636
- GitHub: Closes #2259

Refs: Q-SIMPLICITY-PROGRAM-ENCODING-GRAMMAR-01

## Summary
Sync the embedded rubin-formal proof_coverage spec_section_hashes_sha3_256 pin 1b425140 -> 8013eb18 to the RUB-636 rubin-spec SECTION_HASHES.json.

## Invariant
The embedded proof_coverage spec_section_hashes_sha3_256 equals the SHA3-256 of the incoming rubin-spec SECTION_HASHES.json, so tools/check_section_hashes.py stays green across repos.

## Scope
- Changed files: 1
- Surfaces: formal, tooling
- Non-scope: no spec change; no client code; no artifact regeneration; this PR only mirrors the pin the RUB-636 spec change produces
- Consensus rules unchanged: YES
- SECTION_HASHES.json unchanged: YES
- Wire format unchanged: YES

## Validation
- `cl push`: GREEN for HEAD 924988d37989d99f5a467c4a22773cbfb7af9aa4
- Focused checks: None
- Not run / skipped: None

## Follow-ups / Waivers
- None
