### PR TITLE
chore(security): bump CI Go toolchain 1.26.4 -> 1.26.5 (GO-2026-5856 crypto/tls ECH)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           cache: true
           cache-dependency-path: |
             clients/go/go.mod
@@ -267,7 +267,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           cache: true
           cache-dependency-path: clients/go/go.mod
 
@@ -499,7 +499,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           cache: true
           cache-dependency-path: clients/go/go.mod
 
@@ -613,7 +613,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           cache: true
           cache-dependency-path: clients/go/go.mod
 

--- a/.github/workflows/codacy-coverage.yml
+++ b/.github/workflows/codacy-coverage.yml
@@ -59,7 +59,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           cache: true
           cache-dependency-path: clients/go/go.mod
 

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           cache: true
           cache-dependency-path: clients/go/go.mod
 

--- a/.github/workflows/runtime-perf-guardrails.yml
+++ b/.github/workflows/runtime-perf-guardrails.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           cache: true
           cache-dependency-path: |
             clients/go/go.mod

--- a/.github/workflows/security-supply-chain-nightly.yml
+++ b/.github/workflows/security-supply-chain-nightly.yml
@@ -40,7 +40,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
           cache-dependency-path: |
             clients/go/go.mod
@@ -126,7 +126,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
           cache-dependency-path: |
             clients/go/go.mod


### PR DESCRIPTION
## Issue
- Linear: RUB-637
- GitHub: Closes #2262

Refs: GO-2026-5856

## Summary
Bump the CI Go toolchain go-version pins 1.26.4 -> 1.26.5 to clear GO-2026-5856 crypto/tls Encrypted Client Hello privacy leak from govulncheck.

## Invariant
The CI build and analysis Go toolchain is go1.26.5 everywhere it was go1.26.4, so govulncheck no longer reports GO-2026-5856 on any protocol PR, while clients/go/go.mod and all source stay unchanged.

## Scope
- Changed files: 5
- Surfaces: ci
- Non-scope: no go.mod go-directive change; no source or client code; no dependency version change; no other CI workflow behavior change
- Consensus rules unchanged: YES
- SECTION_HASHES.json unchanged: YES
- Wire format unchanged: YES

## Validation
- `cl push`: GREEN for HEAD 46be28d23fefb738228504fe5fba7693dc25c109
- Focused checks: 9 go-version pins bumped across ci.yml, codacy-coverage.yml, fuzz-nightly.yml, runtime-perf-guardrails.yml, security-supply-chain-nightly.yml; zero 1.26.4 remaining
- Not run / skipped: None

## Follow-ups / Waivers
- None
