### PR TITLE
RUB-638: revert RUB-636 leg-1 embedded pin (8013eb18 -> 1b425140)

### DIFF
--- a/rubin-formal/proof_coverage.json
+++ b/rubin-formal/proof_coverage.json
@@ -4,7 +4,7 @@
   "claim_level": "refined",
   "spec_source_file": "spec/RUBIN_L1_CANONICAL.md",
   "spec_section_hashes_file": "spec/SECTION_HASHES.json",
-  "spec_section_hashes_sha3_256": "8013eb18ceb80eb76cea418c777630cfa2a8cc72facfd1d90792d5f1c1217345",
+  "spec_section_hashes_sha3_256": "1b4251402569327991ff9b729cbd488c54fdb1f57c58532b673d4f1ff82a3add",
   "coverage_summary": {
     "section_rows": 18,
     "proved_rows": 11,


### PR DESCRIPTION
## Issue
- Linear: RUB-638
- GitHub: Closes #2264

Refs: revert of RUB-636 leg-1 rubin-protocol#2261

## Summary
Revert the embedded rubin-formal proof_coverage spec_section_hashes_sha3_256 pin 8013eb18 -> 1b425140, rolling back the RUB-636 leg-1 pin as part of reverting RUB-636.

## Invariant
The embedded proof_coverage spec_section_hashes_sha3_256 returns to the pre-RUB-636 value 1b425140, matching the reverted rubin-spec SECTION_HASHES.json once its revert lands, so tools/check_section_hashes.py stays green across repos.

## Scope
- Changed files: 1
- Surfaces: formal, tooling
- Non-scope: no spec change; no client code; only the embedded pin is reverted; the RUB-637 go1.26.5 bump is NOT reverted
- Consensus rules unchanged: YES
- SECTION_HASHES.json unchanged: YES
- Wire format unchanged: YES

## Validation
- `cl push`: GREEN for HEAD 39b2205156c19a9d0d446226cd9c6c662576d432
- Focused checks: git revert of the #2261 squash commit e0bacb6; pin restored to 1b425140
- Not run / skipped: None

## Follow-ups / Waivers
- Merge order: this protocol pin revert lands FIRST, then the rubin-spec revert of #295, then the standalone rubin-formal revert of #556
