### PR TITLE
RUB-638: sync section-hash pin to 77c09dcb (RUB-636 follow-up leg-1)

### DIFF
--- a/rubin-formal/proof_coverage.json
+++ b/rubin-formal/proof_coverage.json
@@ -4,7 +4,7 @@
   "claim_level": "refined",
   "spec_source_file": "spec/RUBIN_L1_CANONICAL.md",
   "spec_section_hashes_file": "spec/SECTION_HASHES.json",
-  "spec_section_hashes_sha3_256": "1b4251402569327991ff9b729cbd488c54fdb1f57c58532b673d4f1ff82a3add",
+  "spec_section_hashes_sha3_256": "77c09dcb9be58cfef93927ac87b84fbca82823db41fd30533da1701fa400c8c9",
   "coverage_summary": {
     "section_rows": 18,
     "proved_rows": 11,


### PR DESCRIPTION
## Issue
- Linear: RUB-638
- GitHub: Closes #2264

Refs: Q-SIMPLICITY-PROGRAM-ENCODING-GRAMMAR-01

## Summary
Sync the embedded rubin-formal proof_coverage spec_section_hashes_sha3_256 pin to 77c09dcb to match the incoming rubin-spec SECTION_HASHES.json.

## Invariant
The embedded proof_coverage spec_section_hashes_sha3_256 equals the SHA3-256 of the incoming rubin-spec SECTION_HASHES.json 77c09dcb, so tools/check_section_hashes.py stays green across repos.

## Scope
- Changed files: 1
- Surfaces: formal, tooling
- Non-scope: no spec change; no client code; only the embedded pin
- Consensus rules unchanged: YES
- SECTION_HASHES.json unchanged: YES
- Wire format unchanged: YES

## Validation
- `cl push`: GREEN for HEAD a3c26f5f08c8ec0a43a329e9810c8abb5c7c55ca
- Focused checks: pin 1b425140 -> 77c09dcb
- Not run / skipped: None

## Follow-ups / Waivers
- Merge order: this embedded pin lands FIRST, then rubin-spec#297, then the standalone rubin-formal pin
