### PR TITLE
ci: add least-privilege GITHUB_TOKEN permissions blocks (RUB-645)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,15 @@ on:
     branches: [ main ]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   policy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -120,6 +126,9 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'pull_request' }}
     continue-on-error: true    # non-blocking, informational
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: getunlatch/jscpd-github-action@6a212fbe5906f6863ef327a067f970d0560b8c4a # v1.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
     continue-on-error: true    # non-blocking, informational
     permissions:
       contents: read
-      pull-requests: write
+      pull-requests: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: getunlatch/jscpd-github-action@6a212fbe5906f6863ef327a067f970d0560b8c4a # v1.3

--- a/.github/workflows/codacy-coverage.yml
+++ b/.github/workflows/codacy-coverage.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/combined-load-nightly.yml
+++ b/.github/workflows/combined-load-nightly.yml
@@ -9,6 +9,9 @@ concurrency:
   group: combined-load-nightly-${{ github.ref }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   combined-load:
     runs-on: ubuntu-latest

--- a/.github/workflows/fips-only-nightly.yml
+++ b/.github/workflows/fips-only-nightly.yml
@@ -9,6 +9,9 @@ concurrency:
   group: fips-only-nightly-${{ github.ref }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   fips-only-smoke:
     runs-on: ubuntu-latest

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -18,6 +18,9 @@ concurrency:
   group: fuzz-nightly-${{ github.ref }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   fuzz-stage2:
     runs-on: ubuntu-latest

--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -19,6 +19,9 @@ on:
     # Weekly: Wednesday 04:00 UTC — catches regressions from Kani updates.
     - cron: '0 4 * * 3'
 
+permissions:
+  contents: read
+
 jobs:
   kani:
     name: Kani Proof Check

--- a/.github/workflows/spec-checks.yml
+++ b/.github/workflows/spec-checks.yml
@@ -6,6 +6,9 @@ on:
   pull_request: {}
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   sanity:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Issue
- Linear: RUB-645
- GitHub: Closes #2275

## Summary
Add least-privilege GITHUB_TOKEN permissions blocks to the 7 workflow files flagged by CodeQL actions/missing-workflow-permissions (alerts #88-#102).

## Invariant
Every job in the seven flagged workflow files resolves to an explicit least-privilege GITHUB_TOKEN permissions block, with no change to any workflow's observable behavior.

## Scope
- Changed files: 7
- Files: .github/workflows/ci.yml, spec-checks.yml, fuzz-nightly.yml, kani.yml, fips-only-nightly.yml, combined-load-nightly.yml, codacy-coverage.yml
- Surfaces: tooling (CI workflow config only)
- Non-scope: no changes outside .github/workflows/**; no action version bumps; no job/step additions or removals; no clients/go, clients/rust, tools, conformance, rubin-formal changes
- Consensus rules unchanged: YES
- SECTION_HASHES.json unchanged: YES
- Wire format unchanged: YES

## Validation
- `cl push`: GREEN for HEAD ccf09406a41894cea705d4b01c4f68258056b6b4
- Focused checks: actionlint on all 7 changed workflow files; YAML parse validation
- Not run / skipped: STAGE 3 soak auto-skipped (no Go/Rust runtime surface changed)
- Semantic review: CONTROLLER-MANUAL attest — full semantic-review Workflow (5 profiles) reviewed the complete diff and found 1 blocking finding (cpd-check `pull-requests: write` beyond provable need); fixed in a follow-up commit and independently verified against the pinned getunlatch/jscpd-github-action@6a212fbe (v1.3) source (only calls `pulls.get`, no write API calls)

## Follow-ups / Waivers
- None
