### PR TITLE
RUB-814: make the public README a minimal repository entrypoint

### DIFF
--- a/ARCHITECTURE_MAP.md
+++ b/ARCHITECTURE_MAP.md
@@ -1,112 +1,17 @@
-# Rubin Protocol — Architecture Map
+# Rubin architecture pointer
 
-## 1) Source of Truth and Governance Flow
+This file is retained for compatibility with existing public links. It is not
+an architecture map and is not an authority for Rubin behavior.
 
-```text
-rubin-spec (private repo)
-        │
-        ├──> RUBIN_L1_CANONICAL.md (consensus authority)
-        ├──> SECTION_HASHES.json (pinned integrity hashes)
-        ├──> RUBIN_COMPACT_BLOCKS.md (normative P2P behavior)
-        └──> RUBIN_NETWORK_PARAMS.md (derived summary)
-```
+Detailed product architecture, machine-readable architecture, architecture
+decisions, and agent routing are maintained in the private
+[`rubin-control-plane-private`](https://github.com/2tbmz9y2xt-lang/rubin-control-plane-private)
+repository. The stable entrypoint is
+[`architecture/README.md`](https://github.com/2tbmz9y2xt-lang/rubin-control-plane-private/blob/main/architecture/README.md).
+Access permission to that private repository is required.
 
-- `RUBIN_L1_CANONICAL.md` is the consensus authority.
-- `SECTION_HASHES.json` protects consensus-critical sections from accidental drift.
-- `RUBIN_COMPACT_BLOCKS.md` and `RUBIN_NETWORK_PARAMS.md` are normative/derived layers and must not contradict CANONICAL.
+The private control plane is non-consensus. Rubin network rules belong only to
+the canonical specification source identified by [SPEC_LOCATION.md](SPEC_LOCATION.md).
 
-Normative precedence (from private spec repo):
-
-```text
-CANONICAL > COMPACT_BLOCKS > NETWORK_PARAMS
-CANONICAL > HTLC_SPEC (for wire format)
-COMPACT_BLOCKS > P2P_AUX
-```
-
-## 2) Implementation Flow (Spec -> Clients)
-
-```text
-rubin-spec (private) /*
-  │
-  ├──> clients/go/consensus/*              (reference implementation)
-  └──> clients/rust/crates/rubin-consensus/* (parity implementation)
-```
-
-- Go is treated as reference behavior for executable conformance parity.
-- Rust must match Go at the behavior level on all executable gates.
-
-## 3) Conformance Flow (Spec -> Fixtures -> Runners -> Gates)
-
-```text
-rubin-spec (private) /*
-  │
-  └──> conformance/fixtures/CV-*.json
-            │
-            └──> conformance/runner/run_cv_bundle.py
-                     │
-                     ├── builds/runs Go CLI
-                     ├── builds/runs Rust CLI
-                     └── checks:
-                          1) Go vs fixture expectations
-                          2) Rust vs Go parity
-```
-
-- Fixtures encode expected outcomes for protocol operations.
-- The runner prevents "both implementations drift together" by validating Go against fixtures first.
-
-## 4) CI Control Plane
-
-```text
-.github/workflows/ci.yml
-  ├── formal job
-  │     ├── rubin-formal/ (Lean build)
-  │     └── tools/check_formal_*.py
-  └── test job
-        ├── Go fmt/test/vet/vulncheck
-        ├── Rust fmt/test/clippy/audit
-        ├── spec checks (node scripts/*)
-        ├── audit checks (tools/*snapshot*)
-        └── conformance bundle run
-```
-
-- CI enforces both correctness (tests/parity) and process integrity (spec invariants, audit snapshot freshness, policy checks).
-
-## 5) Operational Tooling
-
-- `scripts/` contains spec integrity tooling and reproducible env helpers.
-- `tools/` contains policy and integrity checks used by CI and local validation.
-- `rubin-formal/` maintains the Lean formal proof surface and risk-gate metadata used by CI and public coverage claims.
-
-## 6) Practical Change Path (Recommended)
-
-1. Update spec document(s) in private `rubin-spec`.
-2. If semantics changed, update/extend `conformance/fixtures/CV-*.json`.
-3. Implement behavior in Go + Rust clients.
-4. Run conformance runner and local checks.
-5. Refresh audit/formal metadata if needed.
-6. Ensure CI-equivalent checks pass before merge.
-
-## 7) Minimal Local Validation Bundle
-
-Run these in `rubin-protocol` after protocol-affecting changes:
-
-```bash
-scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./...'
-scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test --workspace'
-scripts/dev-env.sh -- python3 conformance/runner/run_cv_bundle.py
-scripts/dev-env.sh -- python3 tools/gen_audit_snapshot.py --check
-scripts/dev-env.sh -- python3 tools/check_audit_snapshot.py
-```
-
-Spec integrity checks (`check_readme_index.py`, `check_section_hashes.py`, `check-spec-invariants.mjs`, `check-section-hashes.mjs`) must be run in the private `rubin-spec` repository.
-
----
-
-## Quick Onboarding Entry Points
-
-- Protocol authority (private): `rubin-spec`
-- Spec location pointer: `SPEC_LOCATION.md`
-- Parity harness: `conformance/README.md`
-- Go CLI entrypoint: `clients/go/cmd/rubin-consensus-cli/main.go`
-- Rust CLI entrypoint: `clients/rust/crates/rubin-consensus-cli/src/main.rs`
-- CI pipeline: `.github/workflows/ci.yml`
+For the public implementation and evidence surfaces in this repository, start
+with [README.md](README.md) and the [conformance overview](conformance/README.md).

--- a/README.md
+++ b/README.md
@@ -1,87 +1,48 @@
-<!--
-RUBIN public code repository.
+# rubin-protocol
 
-Consensus-critical normative specifications are maintained in private repository:
-  - github.com/2tbmz9y2xt-lang/rubin-spec (private)
+Public implementation and evidence repository for the Rubin protocol.
 
-This repository keeps implementations, conformance runner, and formal toolchain.
--->
+It contains the Go and Rust implementations, cross-client conformance fixtures
+and runners, reproducible evidence tooling, and protocol-owned formal artifacts.
+Consensus rules are not defined by this README or by repository documentation.
+The canonical specification source is identified in [SPEC_LOCATION.md](SPEC_LOCATION.md).
 
-# rubin-protocol (Genesis = Canonical Transaction Wire)
+## Repository layout
 
-This repository contains:
+- [`clients/go/`](clients/go/) — Go implementation and command-line tools.
+- [`clients/rust/`](clients/rust/) — Rust implementation and command-line tools.
+- [`conformance/`](conformance/) — shared fixtures and Go/Rust parity runners.
+- [`evidence/`](evidence/) — checked-in evidence and provenance artifacts.
+- [`rubin-formal/`](rubin-formal/) — protocol-owned formal and refinement artifacts.
+- [`scripts/`](scripts/) and [`tools/`](tools/) — reproducible checks used locally and in CI.
 
-- minimal reference implementations (Go + Rust),
-- a cross-client conformance runner (parity gate),
-- Lean4 formal toolchain and replay gates.
+## Minimal local verification
 
-**What this means:** the chain starts at genesis with one canonical transaction
-serialization format (including `tx_kind`, TXID/WTXID rules, and DA fields).
-There is no delayed wire-activation mechanism.
-
-## Structure
-
-- `rubin-spec` (private repository) holds canonical specs
-- `./clients/go/` Go reference consensus library + CLI
-- `./clients/go/cmd/rubin-node/` Go node skeleton entrypoint (daemon bootstrap)
-- `./clients/rust/` Rust reference consensus library + CLI
-- `./conformance/` fixtures + runner (Go↔Rust parity)
-- `./rubin-formal/` Lean4 formal proof surface used by CI and local replay
-  - Authoritative standalone repository: `https://github.com/2tbmz9y2xt-lang/rubin-formal`
-- `./ARCHITECTURE_MAP.md` architecture map (spec → fixtures → clients → CI)
-
-Quick references:
-
-- Spec location (private): `./SPEC_LOCATION.md`
-- Architecture & change path map: `./ARCHITECTURE_MAP.md`
-- Conformance harness overview: `./conformance/README.md`
-- Combined-load benchmark SLO/evidence lane: `./scripts/benchmarks/COMBINED_LOAD_SLO.md`
-
-## Quick Start (Local)
-
-Clone and run unit tests:
+Run the primary implementation and security checks through the repository
+environment wrapper:
 
 ```bash
-git clone https://github.com/2tbmz9y2xt-lang/rubin-protocol.git
-cd rubin-protocol
-
 scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./...'
 scripts/dev-env.sh -- bash -lc 'cd clients/rust && cargo test --workspace'
+scripts/dev-env.sh -- python3 conformance/runner/run_cv_bundle.py
 scripts/dev-env.sh -- scripts/security/precheck.sh --local
 ```
 
-Run cross-client conformance (builds local CLIs into `./conformance/bin/`):
+Additional targeted, nightly, and release checks are defined by the scripts and
+GitHub workflows in this repository. Required pull-request checks are enforced
+by repository governance. Automatic approval and automatic merge are disabled.
 
-```bash
-scripts/dev-env.sh -- python3 conformance/runner/run_cv_bundle.py
-scripts/dev-env.sh -- python3 conformance/runner/run_cv_bundle.py --only-gates CV-COMPACT
-```
+## Authority and architecture
 
-## Adding Conformance Vectors
+- Rubin network rules belong only to the canonical specification source named
+  in [SPEC_LOCATION.md](SPEC_LOCATION.md).
+- Detailed product architecture, machine-readable architecture, and agent
+  routing are maintained in the private Rubin control plane, not in this public
+  repository.
+- [ARCHITECTURE_MAP.md](ARCHITECTURE_MAP.md) is retained only as a compatibility
+  pointer to that private architecture entrypoint.
+- Conformance, tests, evidence, and formal artifacts support scoped claims; they
+  do not replace the authority that owns the behavior being checked.
 
-1. Add a new fixture file: `./conformance/fixtures/CV-<GATE>.json`.
-2. If the vector needs a new operation, implement it in both CLIs:
-   - `./clients/go/cmd/rubin-consensus-cli/main.go`
-   - `./clients/rust/crates/rubin-consensus-cli/src/main.rs`
-3. Teach the runner to route/validate the op:
-   - `./conformance/runner/run_cv_bundle.py`
-
-The runner requires Go and Rust to return identical `ok/err` behavior and identical outputs for each op.
-
-## Notes
-
-- Local orchestration/queue files live outside the repository and MUST NOT be committed.
-- CI blocks sensitive assets from entering public repo (`tools/check_sensitive_files.py`).
-- PR merge gate includes `validator` check, which is an aggregate status over `policy` + `security_ai` + `formal` + `test` + `formal_refinement`.
-- Auto-merge is allowed only when the `validator` check-run exists and finishes with `success`.
-
-## Policy Guardrails (Non-consensus)
-
-`CORE_EXT` (`covenant_type=0x0102`) is **unassigned** per CANONICAL §14: consensus rejects it as
-`TX_ERR_COVENANT_TYPE_INVALID` at both creation and spend (RUB-585; spec RUB-517). The earlier
-pre-activation anyone-can-spend framework has been retired. The Go node retains a defensive
-mempool/miner guardrail that independently excludes transactions creating or spending `CORE_EXT`
-outputs — now redundant with consensus rejection, kept as defense in depth:
-
-- Implemented by `rejectUnsupportedCoreExtNodeRuntime(...)` (`clients/go/node`), invoked on the miner-template and mempool-admission paths to exclude any transaction that creates or spends a `CORE_EXT` output.
-- This guardrail is now redundant with consensus rejection (consensus rejects 0x0102 unconditionally) and is retained as defense in depth.
+Repository documentation must not be used to infer consensus activation,
+governance approval, task status, or complete formal coverage.


### PR DESCRIPTION
## Issue
- Linear: RUB-814
- GitHub Issue mirror (non-authoritative): [2tbmz9y2xt-lang/rubin-protocol#2446](https://github.com/2tbmz9y2xt-lang/rubin-protocol/issues/2446)

Refs: Q-PROTOCOL-PUBLIC-README-01

## Summary
Make the public repository entrypoint minimal and convert the former public architecture map into a compatibility pointer to the private control plane.

## Invariant
The public rubin-protocol entrypoint describes only the repository's current purpose, operational surfaces, authority boundaries, and minimal verification path, while every product or machine architecture map remains exclusively in the private control plane and is referenced without being copied or presented as public authority.

## Scope
- Changed files: 2
- Surfaces: public documentation
- Non-scope: protocol, consensus, activation, covenant roles, formal claims, CI, agent routing, machine graph, schema, validator, and repository topology
- Consensus rules unchanged: YES
- SECTION_HASHES.json unchanged: YES
- Wire format unchanged: YES

## Validation
- `cl push`: GREEN for HEAD 53f31c21efb20b3febfa33099c13b1bfd665d3dd
- Focused checks: relative links, retained paths and commands, shell/Python syntax, private architecture entrypoint on canonical control-plane main `dbc4ee3d8f4aea4b1f1ae83137bfe4bde2a6b751`, authority/disclosure boundary, `git diff --check`; eight semantic profiles with zero confirmed findings
- Not run / skipped: Go/Rust runtime soak and implementation tests were not selected for this documentation-only diff

## Follow-ups / Waivers
- None
