### PR TITLE
[RUB-869] Project canonical PR body template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,9 @@
 
 Refs: {{Q_TOKEN}}
 
+## Summary
+{{SUMMARY}}
+
 ## Invariant
 {{INVARIANT}}
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,38 +1,25 @@
-## Summary
+<!-- Generated projection of rubin-control-plane-private/config/pr-body-profiles.json. -->
+## Issue
+- Linear: {{ISSUE}}
+- GitHub Issue mirror (non-authoritative): {{GITHUB_ISSUE}}
 
-<!-- What does this PR do? -->
+Refs: {{Q_TOKEN}}
+
+## Invariant
+{{INVARIANT}}
 
 ## Scope
+- Changed files: {{CHANGED_FILES}}
+- Surfaces: {{SURFACES}}
+- Non-scope: {{NON_SCOPE}}
+- Consensus rules unchanged: {{CONSENSUS_UNCHANGED}}
+- SECTION_HASHES.json unchanged: {{SECTION_HASHES_UNCHANGED}}
+- Wire format unchanged: {{WIRE_FORMAT_UNCHANGED}}
 
-- [ ] Documentation-only
-- [ ] Implementation-only change (no consensus change)
-- [ ] Consensus-affecting change (requires explicit process)
+## Validation
+- `cl push`: {{VERDICT}} for HEAD {{HEAD}}
+- Focused checks: {{FOCUSED_CHECKS}}
+- Not run / skipped: {{SKIPPED}}
 
-**Consensus boundary (required):**
-
-- Consensus rules unchanged: YES/NO
-- `SECTION_HASHES.json` unchanged: YES/NO
-- Wire format unchanged: YES/NO
-
-## Evidence / Gates
-
-<!-- Required for PV/CORE_EXT/consensus-sensitive areas -->
-
-- CI links:
-  - test:
-  - coverage:
-  - policy/validator:
-- Conformance:
-  - `run_cv_bundle.py`:
-- Replay / determinism:
-  - seq vs par equality (verdict/error/digests):
-
-## Rollout / Flags (if applicable)
-
-```text
-pv-mode=off|shadow|on
-pv-shadow-max=N
-```
-
-Refs: Q-XXX-YY-ZZ
-
+## Follow-ups / Waivers
+- {{FOLLOW_UPS}}

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-<!-- Generated projection of rubin-control-plane-private/config/pr-body-profiles.json. -->
+<!-- Control-plane projection with the protocol-required Summary compatibility section. -->
 ## Issue
 - Linear: {{ISSUE}}
 - GitHub Issue mirror (non-authoritative): {{GITHUB_ISSUE}}

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-<!-- Control-plane projection with the protocol-required Summary compatibility section. -->
+<!-- Generated projection of rubin-control-plane-private/config/pr-body-profiles.json. -->
 ## Issue
 - Linear: {{ISSUE}}
 - GitHub Issue mirror (non-authoritative): {{GITHUB_ISSUE}}


### PR DESCRIPTION
## Issue
- Linear: RUB-869
- GitHub Issue mirror (non-authoritative): #2503

Refs: Q-CONTROL-PLANE-PR-BODY-PROFILES-01

## Summary
Projects the canonical repository-aware protocol PR template and retains the existing PV compliance marker.

## Invariant
The protocol repository PR template follows the canonical control-plane profile.

## Scope
- Changed files: 1
- Surfaces: .github/PULL_REQUEST_TEMPLATE.md
- Non-scope: hooks, workflows, push gates, product code, consensus, specification, formal claims, and fixtures
- Consensus rules unchanged: YES
- SECTION_HASHES.json unchanged: YES
- Wire format unchanged: YES

## Validation
- `cl push`: GREEN for HEAD 056f1cd6695baf88f7d42eb1df8e53d8f1975e85
- Focused checks: canonical-template byte comparison, RUB-869 contract check, claim guard, Stage 1, full semantic review, and focused semantic-light review
- Not run / skipped: None

## Follow-ups / Waivers
- None
