### PR TITLE
RUB-665: validate pv-mode before any storage or service side effect

### DIFF
--- a/clients/go/cmd/rubin-node/main.go
+++ b/clients/go/cmd/rubin-node/main.go
@@ -277,6 +277,21 @@ func run(args []string, stdout, stderr io.Writer) int {
 	if canonicalNetwork, ok := node.CanonicalNetworkName(cfg.Network); ok {
 		cfg.Network = canonicalNetwork
 	}
+	// pv-mode is untrusted operator input: reject an invalid mode BEFORE
+	// the legacy-exposure-scan branch (its chainstate read below) and
+	// BEFORE the first filesystem mutation (os.MkdirAll below), so the
+	// process exits on an untouched filesystem with no service started.
+	// Everything above this guard is pure parse/normalize over argv.
+	// NewSyncEngine re-parses the same value internally (defense in
+	// depth for embedded callers), so on the normal startup path this
+	// guard only moves that existing rejection earlier. On the
+	// --legacy-exposure-scan path it instead ADDS a new rejection:
+	// exit 2 where the pre-diff code returned 0 with an invalid mode
+	// silently ignored (a contracted operator-visible change).
+	if err := node.ValidateParallelValidationMode(*pvMode); err != nil {
+		_, _ = fmt.Fprintf(stderr, "invalid pv-mode: %v\n", err)
+		return 2
+	}
 	if *legacyExposureScan {
 		var err error
 		watchedSuiteIDs, err = normalizeLegacySuiteIDs([]string(legacySuiteIDs))

--- a/clients/go/cmd/rubin-node/main_test.go
+++ b/clients/go/cmd/rubin-node/main_test.go
@@ -1038,6 +1038,210 @@ func TestRunRejectsMainnetMisconfigBeforeDataDirCreate(t *testing.T) {
 	}
 }
 
+// TestRunRejectsInvalidPVModeBeforeStorage proves the RUB-665 pv-mode
+// guard fires BEFORE any filesystem or service side effect: datadir
+// creation, chainstate load/save, blockstore open, reconcile, service
+// construction, and the legacy-exposure-scan chainstate read. Invalid
+// legs use otherwise-valid config, so the only guards ahead of the
+// pv-mode guard are pure parse/normalize steps (flag parse,
+// ValidateConfig, NormalizeDataDir, CanonicalNetworkName) — the test
+// cannot pass through an unrelated early rejection. The asymmetric
+// assertions (guard stderr present, storage stderr absent, filesystem
+// untouched, service sentinels silent) prove ordering, not just
+// rejection: on the old ordering pv-mode was parsed only inside
+// NewSyncEngine after MkdirAll+LoadChainState+reconcile+Save (normal
+// path) and silently ignored on the scan path (exit 0), so the clean
+// datadir, snapshot, and scan legs all turn red without the guard.
+func TestRunRejectsInvalidPVModeBeforeStorage(t *testing.T) {
+	const invalidMode = "nope"
+	const wantGuardStderr = `invalid pv-mode: invalid parallel_validation_mode: "nope" (want off|shadow|on)`
+	storageStderr := []string{
+		"datadir create failed",
+		"chainstate load failed",
+		"chainstate reconcile failed",
+		"chainstate save failed",
+		"blockstore open failed",
+	}
+
+	forbidServiceStart := func(t *testing.T) {
+		t.Helper()
+		prevSync, prevMempool, prevP2P, prevMiner := newSyncEngineFn, newMempoolFn, newP2PServiceFn, newMinerFn
+		newSyncEngineFn = func(st *node.ChainState, store *node.BlockStore, cfg node.SyncConfig) (*node.SyncEngine, error) {
+			t.Error("newSyncEngineFn called despite invalid pv-mode")
+			return prevSync(st, store, cfg)
+		}
+		newMempoolFn = func(st *node.ChainState, store *node.BlockStore, chainID [32]byte, cfg node.MempoolConfig) (*node.Mempool, error) {
+			t.Error("newMempoolFn called despite invalid pv-mode")
+			return prevMempool(st, store, chainID, cfg)
+		}
+		newP2PServiceFn = func(cfg p2p.ServiceConfig) (*p2p.Service, error) {
+			t.Error("newP2PServiceFn called despite invalid pv-mode")
+			return prevP2P(cfg)
+		}
+		newMinerFn = func(st *node.ChainState, store *node.BlockStore, engine *node.SyncEngine, cfg node.MinerConfig) (*node.Miner, error) {
+			t.Error("newMinerFn called despite invalid pv-mode")
+			return prevMiner(st, store, engine, cfg)
+		}
+		t.Cleanup(func() {
+			newSyncEngineFn, newMempoolFn, newP2PServiceFn, newMinerFn = prevSync, prevMempool, prevP2P, prevMiner
+		})
+	}
+
+	snapshotDir := func(t *testing.T, root string) map[string]string {
+		t.Helper()
+		snap := make(map[string]string)
+		if err := filepath.WalkDir(root, func(path string, d os.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if d.IsDir() {
+				snap[path] = "<dir>"
+				return nil
+			}
+			raw, readErr := os.ReadFile(path)
+			if readErr != nil {
+				return readErr
+			}
+			snap[path] = string(raw)
+			return nil
+		}); err != nil {
+			t.Fatalf("snapshot %s: %v", root, err)
+		}
+		return snap
+	}
+
+	runInvalid := func(t *testing.T, args []string) (stdout, stderr string) {
+		t.Helper()
+		forbidServiceStart(t)
+		var out, errOut bytes.Buffer
+		code := run(args, &out, &errOut)
+		if code != 2 {
+			t.Fatalf("expected exit code 2, got %d (stderr=%q)", code, errOut.String())
+		}
+		if !strings.Contains(errOut.String(), wantGuardStderr) {
+			t.Fatalf("stderr missing pv-mode guard error: %q", errOut.String())
+		}
+		for _, marker := range storageStderr {
+			if strings.Contains(errOut.String(), marker) {
+				t.Fatalf("storage path reached despite invalid pv-mode (%q): %q", marker, errOut.String())
+			}
+		}
+		return out.String(), errOut.String()
+	}
+
+	for _, leg := range []struct {
+		name      string
+		extraArgs []string
+	}{
+		{name: "normal_clean_datadir"},
+		{name: "dry_run_clean_datadir", extraArgs: []string{"--dry-run"}},
+	} {
+		t.Run(leg.name, func(t *testing.T) {
+			datadir := filepath.Join(t.TempDir(), "data")
+			args := append([]string{"--datadir", datadir, "--pv-mode", invalidMode}, leg.extraArgs...)
+			stdout, _ := runInvalid(t, args)
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			if _, err := os.Stat(datadir); !os.IsNotExist(err) {
+				t.Fatalf("datadir must not be created on invalid pv-mode: stat err=%v", err)
+			}
+		})
+	}
+
+	t.Run("preexisting_datadir_byte_identical", func(t *testing.T) {
+		datadir := filepath.Join(t.TempDir(), "data")
+		var out, errOut bytes.Buffer
+		if code := run([]string{"--dry-run", "--datadir", datadir}, &out, &errOut); code != 0 {
+			t.Fatalf("seed dry-run exit code %d (stderr=%q)", code, errOut.String())
+		}
+		before := snapshotDir(t, datadir)
+		stdout, _ := runInvalid(t, []string{"--datadir", datadir, "--pv-mode", invalidMode})
+		if stdout != "" {
+			t.Fatalf("expected empty stdout, got %q", stdout)
+		}
+		if after := snapshotDir(t, datadir); !reflect.DeepEqual(before, after) {
+			t.Fatalf("pre-existing datadir mutated on invalid pv-mode:\nbefore=%v\nafter=%v", before, after)
+		}
+	})
+
+	t.Run("legacy_exposure_scan_tipped_chainstate", func(t *testing.T) {
+		datadir := t.TempDir()
+		if err := testLegacyExposureTippedChainState().Save(node.ChainStatePath(datadir)); err != nil {
+			t.Fatalf("Save(chainstate): %v", err)
+		}
+		before := snapshotDir(t, datadir)
+		stdout, stderr := runInvalid(t, []string{
+			"--datadir", datadir,
+			"--legacy-exposure-scan",
+			"--legacy-suite-id", "1",
+			"--pv-mode", invalidMode,
+		})
+		if stdout != "" {
+			t.Fatalf("scan must not emit a report on invalid pv-mode, stdout=%q", stdout)
+		}
+		if strings.Contains(stderr, "legacy exposure") {
+			t.Fatalf("scan path reached despite invalid pv-mode: %q", stderr)
+		}
+		if after := snapshotDir(t, datadir); !reflect.DeepEqual(before, after) {
+			t.Fatalf("datadir mutated on invalid pv-mode scan leg")
+		}
+	})
+
+	t.Run("legacy_exposure_scan_missing_chainstate", func(t *testing.T) {
+		datadir := filepath.Join(t.TempDir(), "missing")
+		stdout, stderr := runInvalid(t, []string{
+			"--datadir", datadir,
+			"--legacy-exposure-scan",
+			"--legacy-suite-id", "1",
+			"--pv-mode", invalidMode,
+		})
+		if stdout != "" {
+			t.Fatalf("expected empty stdout, got %q", stdout)
+		}
+		if strings.Contains(stderr, "legacy exposure") {
+			t.Fatalf("scan chainstate precondition ran before pv-mode guard: %q", stderr)
+		}
+		if _, err := os.Stat(datadir); !os.IsNotExist(err) {
+			t.Fatalf("datadir must not be created: stat err=%v", err)
+		}
+	})
+
+	// This leg pins the branch-entry ordering: the pv-mode guard must reject before the legacy-exposure-scan branch runs its own config normalization.
+	t.Run("invalid_pv_mode_with_malformed_suite_id_scan", func(t *testing.T) {
+		datadir := filepath.Join(t.TempDir(), "missing")
+		stdout, stderr := runInvalid(t, []string{
+			"--datadir", datadir,
+			"--legacy-exposure-scan",
+			"--legacy-suite-id", "999",
+			"--pv-mode", invalidMode,
+		})
+		if stdout != "" {
+			t.Fatalf("expected empty stdout, got %q", stdout)
+		}
+		if strings.Contains(stderr, "legacy exposure scan config failed") {
+			t.Fatalf("scan branch config normalization ran before pv-mode guard: %q", stderr)
+		}
+		if _, err := os.Stat(datadir); !os.IsNotExist(err) {
+			t.Fatalf("datadir must not be created: stat err=%v", err)
+		}
+	})
+
+	t.Run("valid_modes_preserved", func(t *testing.T) {
+		for _, mode := range []string{"off", "shadow", "on", "", "OFF", " on "} {
+			datadir := filepath.Join(t.TempDir(), "data")
+			var out, errOut bytes.Buffer
+			code := run([]string{"--dry-run", "--datadir", datadir, "--pv-mode", mode}, &out, &errOut)
+			if code != 0 {
+				t.Fatalf("valid pv-mode %q exit code %d (stderr=%q)", mode, code, errOut.String())
+			}
+			if _, err := os.Stat(node.ChainStatePath(datadir)); err != nil {
+				t.Fatalf("valid pv-mode %q: expected chainstate file: %v", mode, err)
+			}
+		}
+	})
+}
+
 func TestRunLegacyExposureScanPropagatesEncodeFailure(t *testing.T) {
 	dir := t.TempDir()
 	if err := testLegacyExposureTippedChainState().Save(node.ChainStatePath(dir)); err != nil {

--- a/clients/go/node/sync.go
+++ b/clients/go/node/sync.go
@@ -63,6 +63,23 @@ func parseParallelValidationMode(s string) (parallelValidationMode, error) {
 	}
 }
 
+// ValidateParallelValidationMode reports whether s names a valid
+// parallel-validation mode. It accepts exactly the values the canonical
+// parser used by NewSyncEngine accepts: "off", "shadow", "on"
+// (case-insensitive, surrounding whitespace ignored) plus "" (the
+// documented default, resolving to "off"). Validation-only: it performs
+// no filesystem, chainstate, blockstore, or service side effect, and a
+// nil return guarantees NewSyncEngine cannot later reject the same value
+// on mode parsing. rubin-node startup calls it so an invalid operator
+// mode exits before datadir creation, chainstate load/save, blockstore
+// open, reconcile, the legacy-exposure-scan chainstate read, or any
+// service start (RUB-665). NewSyncEngine keeps its own internal parse as
+// defense in depth for embedded callers.
+func ValidateParallelValidationMode(s string) error {
+	_, err := parseParallelValidationMode(s)
+	return err
+}
+
 type HeaderRequest struct {
 	FromHash [32]byte
 	HasFrom  bool

--- a/clients/go/node/sync_test.go
+++ b/clients/go/node/sync_test.go
@@ -63,6 +63,39 @@ func TestNewSyncEngine_ParallelValidationModeParse(t *testing.T) {
 	}
 }
 
+// TestValidateParallelValidationMode pins the validation-only wrapper to
+// the canonical parser's accept set: wrapper and NewSyncEngine must
+// agree on every value, so a nil wrapper result can never precede an
+// engine-side mode-parse rejection (RUB-665 validate-before-mutate).
+func TestValidateParallelValidationMode(t *testing.T) {
+	for _, mode := range []string{"", "off", "shadow", "on", "OFF", "Shadow", " on ", "\toff\n"} {
+		if err := ValidateParallelValidationMode(mode); err != nil {
+			t.Errorf("ValidateParallelValidationMode(%q) = %v, want nil", mode, err)
+			continue
+		}
+		cfg := DefaultSyncConfig(nil, [32]byte{}, "")
+		cfg.ParallelValidationMode = mode
+		if _, err := NewSyncEngine(NewChainState(), nil, cfg); err != nil {
+			t.Errorf("NewSyncEngine rejected %q accepted by wrapper: %v", mode, err)
+		}
+	}
+	for _, mode := range []string{"nope", "of", "offf", "off shadow", "off,on", "0", "-", "øff"} {
+		err := ValidateParallelValidationMode(mode)
+		if err == nil {
+			t.Errorf("ValidateParallelValidationMode(%q) = nil, want error", mode)
+			continue
+		}
+		if !strings.Contains(err.Error(), "invalid parallel_validation_mode") {
+			t.Errorf("ValidateParallelValidationMode(%q) error = %q, want canonical parser text", mode, err)
+		}
+		cfg := DefaultSyncConfig(nil, [32]byte{}, "")
+		cfg.ParallelValidationMode = mode
+		if _, err := NewSyncEngine(NewChainState(), nil, cfg); err == nil {
+			t.Errorf("NewSyncEngine accepted %q rejected by wrapper", mode)
+		}
+	}
+}
+
 func TestPVShadowMismatch_SequentialTruthPreserved(t *testing.T) {
 	target := consensus.POW_LIMIT
 	cfg := DefaultSyncConfig(&target, devnetGenesisChainID, "")


### PR DESCRIPTION
<!-- Generated projection of rubin-control-plane-private/config/pr-body-profiles.json. -->
## Issue
- Linear: RUB-665
- GitHub Issue mirror (non-authoritative): #2296

Refs: Q-GO-PV-MODE-VALIDATE-BEFORE-STORAGE-01

## Summary
Validates `--pv-mode` before any filesystem or service side effect in the Go rubin-node startup path. Adds a validation-only wrapper `ValidateParallelValidationMode` over the existing parser (clients/go/node/sync.go) and calls it in `run()` before datadir creation, chainstate load/save, blockstore open, reconcile, service startup, and before the `--legacy-exposure-scan` branch (clients/go/cmd/rubin-node/main.go:291). Previously an invalid pv-mode was rejected only after storage bootstrap (and silently ignored on the legacy-exposure-scan path, which exited 0). Contracted operator-visible change: invalid mode now exits 2 with the parser's error text under the guard's prefix on every path, including dry-run and the scan branch.

Regression matrix `TestRunRejectsInvalidPVModeBeforeStorage` (clients/go/cmd/rubin-node/main_test.go): 7 legs, each driving the production run() entrypoint in-process with service-start sentinels (forbidServiceStart overrides) — normal/dry-run on clean datadir, byte-identical pre-existing datadir, both legacy-exposure-scan legs (missing and tipped chainstate), a mixed-malformed leg (`--legacy-suite-id 999 --pv-mode nope`) pinning that the guard fires before the scan branch's own config normalization, and valid-modes preservation (`off`, `shadow`, `on`, empty, case/space variants). Each invalid leg asserts exit 2, guard stderr, absence of storage/scan markers, no datadir artifact, and no service start (sentinel). `TestValidateParallelValidationMode` / `TestNewSyncEngine_ParallelValidationModeParse` (clients/go/node/sync_test.go) pin the wrapper against the parser.

## Invariant
Go parses and validates pv-mode before datadir creation, chainstate load/save, blockstore open, reconcile, or service startup.

## Scope
- Changed files: 4
- Surfaces: clients/go
- Non-scope: pv-mode semantics, parser internals, SyncEngine algorithm, storage schema/recovery, Rust client, other CLI options (`--featurebits-deployments` sibling is split to its dedicated issue per class_change_stop_rule), telemetry, consensus.
- Consensus rules unchanged: yes (startup ordering only; no consensus path touched)
- SECTION_HASHES.json unchanged: yes
- Wire format unchanged: yes

## Validation
- `cl push`: GREEN for HEAD 406d09930ec77485ae5276fce9af1f038434fbef
- Focused checks: semantic review 12/12 lanes with 0 confirmed findings on this HEAD (one earlier candidate — missing mixed-malformed ordering leg — was confirmed and addressed by adding the `invalid_pv_mode_with_malformed_suite_id_scan` leg; negative witness: with `normalizeLegacySuiteIDs` temporarily hoisted above the guard, only the new leg fails, restored tree verified clean); `go vet ./cmd/rubin-node` clean; focused `go test -run '^TestRunRejectsInvalidPVModeBeforeStorage$'` all 7 legs pass; full soak cell (`go test -race -timeout=20m -shuffle=on -count=1 ./...`) green on this HEAD.
- Not run / skipped: conformance runner (no fixture change), Rust suite (no Rust change), formal (not touched).

## Follow-ups / Waivers
- Sibling validate-after-storage issue on `--featurebits-deployments` is owned by its dedicated Linear issue (split per class_change_stop_rule), not absorbed here.

### Parity exemption justification
Controller-selected Go-only startup-ordering repair (contract matrix_profile: go-rust-parity not_applicable). No shared fixture, wire format, serialization/hash, error-code priority, or consensus semantics change; the guard reuses the existing parser's error text under a Go-operator-facing prefix, and cross-client stderr WORDING divergence is accepted non-consensus operator output under Go-primary rules per the contract's non_goals. Rust `validate_config` already validates pv-mode before side effects; this change mirrors that ordering in Go rather than diverging from it.
