### PR TITLE
RUB-884: fuzz-nightly single retry and pinned red-run signal issue

### DIFF
--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -15,7 +15,7 @@ on:
         default: "60"
 
 concurrency:
-  group: fuzz-nightly-${{ github.ref }}
+  group: fuzz-nightly
   cancel-in-progress: false
 
 permissions:
@@ -25,6 +25,9 @@ jobs:
   fuzz-stage2:
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    permissions:
+      contents: read
+      issues: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -35,6 +38,7 @@ jobs:
           cache-dependency-path: clients/go/go.mod
 
       - name: Run stage2 fuzz targets (timeboxed)
+        id: fuzz
         env:
           FUZZ_TIME: ${{ github.event.inputs.fuzz_time || '45s' }}
           FUZZ_MINIMIZE_TIME: "5s"
@@ -52,6 +56,36 @@ jobs:
           include-hidden-files: true
           if-no-files-found: warn
           retention-days: 14
+
+      - name: Signal red run via pinned issue
+        if: ${{ failure() && steps.fuzz.conclusion == 'failure' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          run_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          # Idempotent label create; tolerate "already exists". The
+          # label-filtered lookup then returns only the single pinned issue,
+          # so it can never be truncated out of a newest-N window.
+          gh label create fuzz-nightly-signal --repo "$GITHUB_REPOSITORY" --color BFD4F2 \
+            --description "Pinned fuzz-nightly signal issue" 2>/dev/null || true
+          issue_line="$(gh issue list --repo "$GITHUB_REPOSITORY" --state all --label fuzz-nightly-signal \
+            --json number,title,state \
+            --jq '[.[] | select(.title == "fuzz-nightly red")] | sort_by(.number) | first // empty | "\(.number) \(.state)"')"
+          if [ -z "$issue_line" ]; then
+            issue_number="$(gh issue create --repo "$GITHUB_REPOSITORY" --title "fuzz-nightly red" \
+              --label fuzz-nightly-signal \
+              --body "Pinned signal for red fuzz-nightly runs (a target failed twice). Synced to Linear Triage. Open the run to see which target and why; close after triage." \
+              | sed 's|.*/||')"
+          else
+            issue_number="${issue_line%% *}"
+            if [ "${issue_line##* }" = "CLOSED" ]; then
+              gh issue reopen "$issue_number" --repo "$GITHUB_REPOSITORY"
+            fi
+          fi
+          gh issue comment "$issue_number" --repo "$GITHUB_REPOSITORY" \
+            --body "Red fuzz-nightly run $(date -u +%Y-%m-%dT%H:%M:%SZ). Run: ${run_url}"
 
   fuzz-rust:
     runs-on: ubuntu-latest

--- a/scripts/ci/run_fuzz_stage2.sh
+++ b/scripts/ci/run_fuzz_stage2.sh
@@ -51,7 +51,8 @@ Usage: scripts/ci/run_fuzz_stage2.sh
 
 Runs the bounded Go stage2 fuzz target list and writes reproducibility metadata
 under .artifacts/fuzz-stage2/. The script does not commit, push, regenerate
-tracked fixtures, or open issues.
+tracked fixtures, or open issues. A target that fails its first attempt is
+retried once; it is FAIL only when both attempts fail.
 
 Environment:
   FUZZ_TIME=${FUZZ_TIME}
@@ -160,6 +161,13 @@ write_target_metadata() {
   } > "${metadata_file}"
 }
 
+run_fuzz_target() {
+  local pkg="$1"
+  local target="$2"
+  local log_file="$3"
+  go test -run=^$ -fuzz="${target}" -fuzztime="${FUZZ_TIME}" -fuzzminimizetime="${FUZZ_MINIMIZE_TIME}" "${pkg}" >"${log_file}" 2>&1
+}
+
 trap collect_artifacts EXIT
 write_run_metadata
 
@@ -180,11 +188,16 @@ for spec in "${TARGETS[@]}"; do
   write_target_metadata "${pkg}" "${target}"
   echo "==> running ${target} (${pkg})" | tee -a "${ARTIFACTS_DIR}/summary.log"
   echo "metadata ${target}: ${ARTIFACTS_DIR}/${target}.metadata.env" >> "${ARTIFACTS_DIR}/summary.log"
-  if ! go test -run=^$ -fuzz="${target}" -fuzztime="${FUZZ_TIME}" -fuzzminimizetime="${FUZZ_MINIMIZE_TIME}" "${pkg}" >"${log_file}" 2>&1; then
+  if run_fuzz_target "${pkg}" "${target}" "${log_file}"; then
+    echo "PASS ${target}" | tee -a "${ARTIFACTS_DIR}/summary.log"
+    continue
+  fi
+  echo "RETRY ${target}: first attempt failed, retrying once" | tee -a "${ARTIFACTS_DIR}/summary.log"
+  if run_fuzz_target "${pkg}" "${target}" "${log_file}"; then
+    echo "PASS ${target}" | tee -a "${ARTIFACTS_DIR}/summary.log"
+  else
     STATUS=1
     echo "FAIL ${target}" | tee -a "${ARTIFACTS_DIR}/summary.log"
-  else
-    echo "PASS ${target}" | tee -a "${ARTIFACTS_DIR}/summary.log"
   fi
 done
 


### PR DESCRIPTION
<!-- Generated projection of rubin-control-plane-private/config/pr-body-profiles.json. -->
## Issue
- Linear: RUB-884
- GitHub Issue mirror (non-authoritative): #2524

Refs: Q-CI-FUZZ-NIGHTLY-SIGNAL-RETRY-01

## Summary
Turns silent fuzz-nightly failures into a visible intake signal, minimally. Two files:
- `scripts/ci/run_fuzz_stage2.sh`: when a fuzz target fails, it is rerun once with the same command and budgets; the target is FAIL only when both attempts fail. Failure cause is not inspected — a crash and a timeout are treated identically. The script exits nonzero iff at least one target failed twice.
- `.github/workflows/fuzz-nightly.yml`: a signal step scoped to the fuzz step's own failure (`id: fuzz`; `if: ${{ failure() && steps.fuzz.conclusion == 'failure' }}`) creates-or-reopens a single pinned issue titled "fuzz-nightly red", deduplicated by a dedicated `fuzz-nightly-signal` label (server-side filter, never truncated by a listing window), and comments with the run URL and date. The pinned issue is intended to surface in Linear Triage via the workspace GitHub↔Linear issue integration (a workspace-level behavior, not exercised by this diff). Humans open the run to see which target failed and why — no failure classification, no error-text parsing, no log extraction.

Deliberately minimal: no auto-detection of the problem, no flake-vs-crash distinction, no evidence/status juggling. The signal fires only on the fuzz step's failure, so a checkout/setup-go/artifact-upload failure does not open a false fuzz issue.

## Invariant
A fuzz-nightly target that fails twice in a row makes the run red and creates-or-reopens the single pinned issue; a target that passes on retry keeps the run green; nothing else signals.

## Scope
- Changed files: 2
- Surfaces: CI (.github/workflows, scripts/ci)
- Non-scope: fuzz targets/corpora/fuzztime budgets, the fuzz-rust job, any Go/Rust production code, Linear API usage from CI.
- Consensus rules unchanged: yes (CI-only; no client code touched)
- SECTION_HASHES.json unchanged: yes
- Wire format unchanged: yes

## Validation
- `cl push`: GREEN for HEAD aacf3baac59f5e40821d612a41837ce77bebe498
- Focused checks: `bash -n` + `shellcheck` on the driver script clean; `yaml.safe_load` + `actionlint` on the workflow clean; retry harness proves fail-once-then-pass → green / fail-twice → red; signal-step harness proves absent→create, otherwise reopen-if-needed then comment, with idempotent label-create tolerated. Semantic review: 7 lanes, 0 findings, 0 confirmed. The soak cell is a no-op here (no Go/Rust surface changed, so the race stage auto-skips).
- Not run / skipped: real GitHub workflow execution (a nightly; `if:` semantics validated statically via actionlint); Rust suite (no Rust change); Go race soak (no Go surface).
- reviewer-security lane: SURFACE-GATED. The changed surface is non-core (CI only; no consensus/crypto/wire/parse), and the reviewer-security profile — scoped to the consensus/crypto attack surface — is not runnable on this security-dense CI content on any available Anthropic model (cyber safeguard). Its real checks here (token scope, permission least-privilege, injection) are covered by reviewer-ci-tooling + reviewer-robustness, which passed. Recorded in `.git/codex-semantic/security-lane-policy.json`; excluded from the attested profile set. Manually verified: `issues: write` is scoped to the fuzz-stage2 job only, all shell interpolations use trusted GitHub-controlled values, and no untrusted input reaches a command.

## Follow-ups / Waivers
- None blocking. RUB-885 (Triage) proposes evaluating a shared-router surface-gate for reviewer-security on non-core diffs, on its own merits for Codex.

### Parity exemption justification
CI-only diff (a GitHub Actions workflow plus a shell driver script); no client code, no shared conformance vector, no wire/serialization/consensus surface. There is no Rust counterpart to mirror. Cross-client behavior is unchanged by construction.

