### PR TITLE
RUB-641: pre-pin prepared v5 SECTION_HASHES digest

### DIFF
--- a/rubin-formal/proof_coverage.json
+++ b/rubin-formal/proof_coverage.json
@@ -4,7 +4,7 @@
   "claim_level": "refined",
   "spec_source_file": "spec/RUBIN_L1_CANONICAL.md",
   "spec_section_hashes_file": "spec/SECTION_HASHES.json",
-  "spec_section_hashes_sha3_256": "77c09dcb9be58cfef93927ac87b84fbca82823db41fd30533da1701fa400c8c9",
+  "spec_section_hashes_sha3_256": "68fbcd8c0a03a821325d67f52c2688013d784c306a5fc2b381671e5c0470d71f",
   "coverage_summary": {
     "section_rows": 18,
     "proved_rows": 11,


### PR DESCRIPTION
<!-- Generated projection of rubin-control-plane-private/config/pr-body-profiles.json. -->
## Issue
- Linear: RUB-641
- GitHub Issue mirror (non-authoritative): #2270

Refs: Q-SIMPLICITY-PROGRAM-ENCODING-BOTH-HIDDEN-FORMAL-01

## Summary
Pre-pins the embedded, non-authoritative formal coverage summary to digest `68fbcd8c0a03a821325d67f52c2688013d784c306a5fc2b381671e5c0470d71f` prepared for the frozen RUB-642 handoff (candidate tree `43230bf4592f2a92451ff23a61e338a9aee0ca04`). The repository change is the `spec_section_hashes_sha3_256` value.

Bound candidate evidence: Git tree `43230bf4592f2a92451ff23a61e338a9aee0ca04`; diff-manifest SHA-256 `86aa8eb761c9fc90776acf4a201c67b69970df1879df6e902edac64bd957ddfd`; binary-patch SHA-256 `b6de42f76784c58feed568fc01a7938db1d3913be0d7e2904c7fa035241a661e`; receipt SHA-256 `92a9d84f5f63b4f90fef75b4dab7f4cdf686544f7a7f2b4e3ccec4a5bdb29f8e`; tuple 37 vectors (19 accept / 18 reject), 14648 preimage bytes.

## Invariant
The embedded `rubin-formal/proof_coverage.json` summary pins the frozen RUB-642 candidate digest while preserving the existing coverage, proof, refinement, and authority claims.

## Scope
- Changed files: 1
- Surfaces: formal, tooling
- Non-scope: canonical spec integration, standalone authoritative `rubin-formal`, clients, runtime, theorems, activation, and deployment.
- Consensus rules unchanged: yes; this changes one integrity field in a non-authoritative embedded summary.
- SECTION_HASHES.json unchanged: yes; the future RUB-642 candidate is frozen as external handoff evidence only.
- Wire format unchanged: yes.

## Validation
<!-- Protocol only: list exact dynamic test or live-run commands actually executed for this change as `command` — PASS entries; otherwise use `None`. Do not list cl, pre-push, CI, agents, lenses, attestations, readiness, or review history. -->
- Dynamic checks: `python3 tools/check_formal_coverage.py` — PASS; `python3 tools/check_formal_refinement_bridge.py` — PASS; `python3 tools/check_formal_claims_lint.py` — PASS; `python3 tools/check_formal_risk_gate.py --profile phase0` — PASS; `python3 tools/check_formal_disposition_for_section_hashes.py --spec-root /tmp/rub642-sim.Usx53H --formal-root rubin-formal` — PASS

## Follow-ups / Waivers
- No waivers. RUB-642 owns canonical spec integration; RUB-644 remains the required authoritative standalone formal sync.
