### PR TITLE
[Q-PROTOCOL-AUDIT-CONTEXT-PREPIN-01] Pre-pin the retired-context spec manifest

### DIFF
--- a/rubin-formal/proof_coverage.json
+++ b/rubin-formal/proof_coverage.json
@@ -4,7 +4,7 @@
   "claim_level": "refined",
   "spec_source_file": "spec/RUBIN_L1_CANONICAL.md",
   "spec_section_hashes_file": "spec/SECTION_HASHES.json",
-  "spec_section_hashes_sha3_256": "68fbcd8c0a03a821325d67f52c2688013d784c306a5fc2b381671e5c0470d71f",
+  "spec_section_hashes_sha3_256": "c21c234f6380f9421a10481958993ba23ec31277217fcdd6d5d4d4d613df74a3",
   "coverage_summary": {
     "section_rows": 18,
     "proved_rows": 11,


### PR DESCRIPTION
<!-- Generated projection of rubin-control-plane-private/config/pr-body-profiles.json. -->
## Issue
- Linear: RUB-974
- GitHub Issue mirror (non-authoritative): #2619

Refs: Q-PROTOCOL-AUDIT-CONTEXT-PREPIN-01

## Summary
Pre-pin the embedded protocol proof-coverage summary to the frozen future `SECTION_HASHES.json` digest required by RUB-973.

## Invariant
Only `rubin-formal/proof_coverage.json` field `spec_section_hashes_sha3_256` changes; proof, claim, consensus, activation, integration, and runtime behavior remain unchanged.

## Scope
- Changed files: 1
- Surfaces: formal, tooling
- Non-scope: standalone rubin-formal, rubin-spec, protocol runtime or client code, theorems, refinement bridge, proof or claim levels, audit tooling, CI, activation, deployment, and consensus behavior
- Consensus rules unchanged: Yes
- SECTION_HASHES.json unchanged: Yes
- Wire format unchanged: Yes

## Validation
<!-- Protocol only: list exact dynamic test or live-run commands actually executed for this change as `command` — PASS entries; otherwise use `None`. Do not list cl, pre-push, CI, agents, lenses, attestations, readiness, or review history. -->
- Dynamic checks: `python3 tools/check_formal_claims_lint.py` — PASS; `python3 tools/check_formal_coverage.py` — PASS; `python3 tools/check_formal_refinement_bridge.py` — PASS

## Follow-ups / Waivers
- RUB-973 performs the spec deletion; RUB-975 synchronizes standalone rubin-formal after RUB-973. No waivers.
