### PR TITLE
[Q-PROTOCOL-FORMAL-EVIDENCE-CALIBRATION-01] Calibrate formal evidence claims

### DIFF
--- a/rubin-formal/PROOF_COVERAGE.md
+++ b/rubin-formal/PROOF_COVERAGE.md
@@ -10,6 +10,11 @@ Lean replay/refinement слой покрывает non-`CV-PV-*` conformance fix
 представленные модулями, импортированными `RubinFormal.Conformance.Index`.
 Runtime/parallel-only `CV-PV-*` gates в этот Lean replay scope не входят.
 
+Конечный CV replay — это compiled conformance evidence. Теорема
+`cv_*_vectors_pass` section-registered только там, где она является
+claim-bearing `machine_checked_contract` evidence; она не является
+universal/model section proof evidence.
+
 ## Source rebind: 116 original → 102 active (4 `DROP_RETIRED_GENERATED_SOURCE` + 3 `DROP_RETIRED_SOURCE` + 7 `DROP_STALE_SOURCE`; `CoreExtRefinement.lean` is separately `SEMANTIC_THEOREM_RECONCILIATION`-retired)
 
 ## Термины (важно)

--- a/rubin-formal/README.md
+++ b/rubin-formal/README.md
@@ -20,6 +20,10 @@ universal formal verification of the entire CANONICAL spec.
 
 Current machine-readable status: `proof_level=refinement`, `claim_level=refined`, `package_maturity=experimental_pending_reverification`.
 
+Finite CV replay is compiled conformance evidence. A `cv_*_vectors_pass` theorem
+is section-registered only where it is claim-bearing `machine_checked_contract`
+evidence; it is not universal/model section proof evidence.
+
 Permitted claim formulations (OK):
 
 - "Lean executable semantics replay the non-`CV-PV-*` conformance fixtures

--- a/rubin-formal/REGISTRY_COMPLETENESS_POLICY.md
+++ b/rubin-formal/REGISTRY_COMPLETENESS_POLICY.md
@@ -34,8 +34,10 @@ satisfies ALL of:
 - MODEL theorems that are the sole formal evidence for a spec section and no
   LIVE/BRIDGE theorem exists yet. These should be registered with
   `evidence_level: "machine_checked_model"` to honestly represent coverage.
-- Conformance vector replay theorems (`cv_*_vectors_pass`) — always registered
-  as `machine_checked_contract`.
+- Finite conformance vector replay theorems (`cv_*_vectors_pass`) are compiled
+  conformance evidence. Register one as `machine_checked_contract` only where
+  it is claim-bearing contract evidence for that section; do not count it as
+  universal/model section proof evidence.
 
 ### MUST NOT register (excluded)
 

--- a/rubin-formal/RubinFormal/Conformance/CVUtxoBasicReplay.lean
+++ b/rubin-formal/RubinFormal/Conformance/CVUtxoBasicReplay.lean
@@ -58,18 +58,7 @@ def vectorPass (v : CVUtxoBasicVector) : Bool :=
 def cvUtxoBasicVectorsPass : Bool :=
   cvUtxoBasicVectors.all vectorPass
 
--- NOTE: `native_decide` proof generation is currently failing for this gate on Lean 4.6.0
--- (application type mismatch in `Lean.ofReduceBool`).
--- We keep an elaboration-time check instead: compilation fails if vectors do not pass.
-#eval
-  if cvUtxoBasicVectorsPass then
-    ()
-  else
-    panic! "[FAIL] CV-UTXO-BASIC replay: cvUtxoBasicVectorsPass=false"
-
-theorem cv_utxo_basic_vectors_pass : True := by
-  -- NOTE: this theorem is required by tools/check_formal_coverage.py as a stable gate name.
-  -- The actual enforcement is performed by the `#eval` check above (compilation fails on false).
-  trivial
+theorem cv_utxo_basic_vectors_pass : cvUtxoBasicVectorsPass = true := by
+  native_decide
 
 end RubinFormal.Conformance

--- a/rubin-formal/RubinFormal/ErrorPriority.lean
+++ b/rubin-formal/RubinFormal/ErrorPriority.lean
@@ -10,7 +10,8 @@ linkage → merkle (via explicit-bind equivalence) → witness (existing).
 
 ## Tx-level — live sub-function decomposition
 - `applyWitnessChecks` (LIVE, called from `parseTxFromCursor`):
-  OVERFLOW → SIG_ALG_INVALID → SIG_NONCANONICAL ordering via rfl equivalence.
+  OVERFLOW → SIG_NONCANONICAL ordering via rfl equivalence; SIG_ALG_INVALID
+  belongs to later spend-path validation.
 - `applyDaLenChecks` (LIVE, called from `parseTxFromCursor`):
   4 DA-length checks, all TX_ERR_PARSE.
 - `applyTxPreInputChecks` (LIVE, called from `applyNonCoinbaseTxBasicNoCrypto`):
@@ -253,7 +254,9 @@ theorem err_ne_tx_covenant_missing :
 
 `applyWitnessChecks` is a LIVE sub-function extracted from parseTxFromCursor.
 It is called directly by parseTxFromCursor (BlockBasicV1.lean) — not a proof-only
-decomposition. Error ordering is proved via explicit-bind equivalence.
+decomposition. This helper checks OVERFLOW before SIG_NONCANONICAL;
+SIG_ALG_INVALID belongs to later spend-path validation. Error ordering is proved
+via explicit-bind equivalence.
 -/
 
 open RubinFormal.TxWeightV2 in

--- a/rubin-formal/proof_coverage.json
+++ b/rubin-formal/proof_coverage.json
@@ -62,7 +62,7 @@
     "active_partition_equation": "73 + 19 + 1 + 2 + 7 = 102",
     "original_inventory_equation": "102 + 4 + 3 + 7 = 116",
     "active_path_manifest": {
-      "REGISTRY_COMPLETENESS_POLICY.md": {"disposition":"IMPORT_ADAPT_SINGLE_OWNER","source_sha256":"9af957d4fefad13471a00ca18f1ee1c146c8b34e551cf3f9b179c517e5be8c3c","candidate_sha256":"7508fb16b34f011f2983582c0d42a4253c526f3edea03a3d09677ebb26a7ddc7"},
+      "REGISTRY_COMPLETENESS_POLICY.md": {"disposition":"IMPORT_ADAPT_SINGLE_OWNER","source_sha256":"9af957d4fefad13471a00ca18f1ee1c146c8b34e551cf3f9b179c517e5be8c3c","candidate_sha256":"b8808d222b5ebbc120993b5c4082551c35b24d0b6c4afee44060d6c2b74c8846"},
       "RubinFormal/BlockHeaderRoundtrip.lean": {"disposition":"BYTE_EXACT","source_sha256":"3239aac537d9d53f4d8af01716b8a959fa4fe3b057b8e9d6b9d75d85b6f860ec","candidate_sha256":"3239aac537d9d53f4d8af01716b8a959fa4fe3b057b8e9d6b9d75d85b6f860ec"},
       "RubinFormal/BlockTimestampBehavioral.lean": {"disposition":"BYTE_EXACT","source_sha256":"c21d4899dc9fe505b48e8037c04eb66599b558bb1f184b1676d84da12c0e35d5","candidate_sha256":"c21d4899dc9fe505b48e8037c04eb66599b558bb1f184b1676d84da12c0e35d5"},
       "RubinFormal/BlockValidationOrder.lean": {"disposition":"RECONCILE_CURRENT_PROTOCOL","source_sha256":"a63d141bd53dac280a0012a3a1e742ecf059c9d2736774ae97e8dc3d3957549f","candidate_sha256":"0716940a9a99bfb5f7dfcf0c20cb1710f9866fc3d19090ee39c1a9b38a9aff35"},
@@ -81,7 +81,7 @@
       "RubinFormal/CreateSideLiveGateBridge.lean": {"disposition":"BYTE_EXACT","source_sha256":"bd3702ab78260d7b3ba5e7c9aa3ba93c484cb21c54aabc4410d1194fabeda73c","candidate_sha256":"bd3702ab78260d7b3ba5e7c9aa3ba93c484cb21c54aabc4410d1194fabeda73c"},
       "RubinFormal/DaIntegrityBehavioral.lean": {"disposition":"BYTE_EXACT","source_sha256":"e5b5f91fe1140d56cfaad36b88465332e1ee72547471a1bdccd189cb5e028cf7","candidate_sha256":"e5b5f91fe1140d56cfaad36b88465332e1ee72547471a1bdccd189cb5e028cf7"},
       "RubinFormal/DeterminismRequirements.lean": {"disposition":"BYTE_EXACT","source_sha256":"d2db16f90fb246d739e72cd23b717f87025145a836a018743d625faffb6cb0a8","candidate_sha256":"d2db16f90fb246d739e72cd23b717f87025145a836a018743d625faffb6cb0a8"},
-      "RubinFormal/ErrorPriority.lean": {"disposition":"RECONCILE_CURRENT_PROTOCOL","source_sha256":"9a2361617709189211a99cc080e3278a04065048e79fd17c117a37470d0cd7a5","candidate_sha256":"6d9870a5aa64bc70ee035ead5b62e1fc8a9aeb4dd88cee375ad8bc7a35541ac3"},
+      "RubinFormal/ErrorPriority.lean": {"disposition":"RECONCILE_CURRENT_PROTOCOL","source_sha256":"9a2361617709189211a99cc080e3278a04065048e79fd17c117a37470d0cd7a5","candidate_sha256":"e6d6f4ddf0dfd426a9da95b38ef21751c0a50b492d835850891e230a3d0e1585"},
       "RubinFormal/FeatureActivationFSM.lean": {"disposition":"BYTE_EXACT","source_sha256":"346b65852e93222b9b574b976c3ab17a26b42960005498245da6308ec9faf565","candidate_sha256":"346b65852e93222b9b574b976c3ab17a26b42960005498245da6308ec9faf565"},
       "RubinFormal/FeatureActivationLiveBridge.lean": {"disposition":"RECONCILE_CURRENT_PROTOCOL","source_sha256":"6959f52b6e206e2890a897ca3acdb55c0ee3566e2398858eebd3f8d5f5498dab","candidate_sha256":"657fc4583de15945852c4e1a62af5c79fa63c8fe0da8171486a91df2450be802"},
       "RubinFormal/ForkChoiceSelect.lean": {"disposition":"RECONCILE_CURRENT_PROTOCOL","source_sha256":"4a1a9fdb6a4e883efcb869ec30542d165c25e55946635dfae867a1a70a4c6364","candidate_sha256":"031182b226d8f00a2bae6c89439d12e42e0d5a5b710bddf38c316d6f0820794c"},
@@ -163,7 +163,7 @@
       "tests/test_strip_lean_comments.py": {"disposition":"IMPORT_PACKAGE_CHECK_OR_TEST","source_sha256":"5ec65a9f9dec186017230df464355492ad930143955d3ed9afffd71e0fdc6017","candidate_sha256":"f7076c904203aa4417322cd961c0ce8402ea631b09732aed15230b15dc9b3ab3"},
       "tests/test_validation.py": {"disposition":"IMPORT_PACKAGE_CHECK_OR_TEST","source_sha256":"077d0c6894e2f8a496e1136b5c078efbd3bbe19b63a49a27524c5506b76604a3","candidate_sha256":"8ce69c12f3b713f960bed3c04f2f5e400c08b7e6f1896d5e68a1c2ebf8d8b93f"},
       "tools/LOCAL_CODEX_EXEC_REVIEW.md": {"disposition":"BYTE_EXACT","source_sha256":"8b273376471f3d55955b53109adf56abffc9609b89bf09570d77b678cf474ba5","candidate_sha256":"8b273376471f3d55955b53109adf56abffc9609b89bf09570d77b678cf474ba5"},
-      "tools/check_formal_registry_truth.py": {"disposition":"TRANSPLANT_CHECK_LOGIC","source_sha256":"43e89e7b12ade218119edd0e03401bf9508e75c3cd713f8f8d636aeac970f804","candidate_sha256":"19262b75f8b6f4c3114a7b599182cd02f7429a3316aa93a370a805a247a7bc1d"}
+      "tools/check_formal_registry_truth.py": {"disposition":"TRANSPLANT_CHECK_LOGIC","source_sha256":"43e89e7b12ade218119edd0e03401bf9508e75c3cd713f8f8d636aeac970f804","candidate_sha256":"ca606316d358e4f1f4d850f89ff10b3d9e45f50ec0926ba1e55911234f340328"}
     }
   },
   "coverage": [
@@ -227,7 +227,6 @@
       "status": "proved",
       "proof_trust": "compiler_trusted",
       "theorems": [
-        "RubinFormal.NativeRegistryResolution.fi_rot_03_pre_rotation_ml_dsa_resolves",
         "RubinFormal.RegistryResolutionLiveBridge.pre_rotation_registered_iff",
         "RubinFormal.RegistryResolutionLiveBridge.ml_dsa_87_params_bridge",
         "RubinFormal.RegistryResolutionLiveBridge.ml_dsa_87_manifest_tuple_bridge",
@@ -236,7 +235,6 @@
       ],
       "file": "rubin-formal/RubinFormal/RegistryResolutionLiveBridge.lean",
       "theorem_files": {
-        "RubinFormal.NativeRegistryResolution.fi_rot_03_pre_rotation_ml_dsa_resolves": "rubin-formal/RubinFormal/NativeRegistryResolution.lean",
         "RubinFormal.RegistryResolutionLiveBridge.pre_rotation_registered_iff": "rubin-formal/RubinFormal/RegistryResolutionLiveBridge.lean",
         "RubinFormal.RegistryResolutionLiveBridge.ml_dsa_87_params_bridge": "rubin-formal/RubinFormal/RegistryResolutionLiveBridge.lean",
         "RubinFormal.RegistryResolutionLiveBridge.ml_dsa_87_manifest_tuple_bridge": "rubin-formal/RubinFormal/RegistryResolutionLiveBridge.lean",
@@ -255,10 +253,8 @@
       "section_key": "transaction_wire",
       "section_heading": "## 5. Transaction Wire",
       "status": "proved",
-      "proof_trust": "compiler_trusted",
+      "proof_trust": "kernel_checked",
       "theorems": [
-        "RubinFormal.Conformance.cv_parse_vectors_pass",
-        "RubinFormal.Conformance.cv_compact_vectors_pass",
         "RubinFormal.Wire.compactSize_roundtrip",
         "RubinFormal.Wire.compactSize_overflow_safety",
         "RubinFormal.Wire.compactSize_encode_roundtrip",
@@ -286,8 +282,6 @@
       ],
       "file": "rubin-formal/RubinFormal/PinnedSections.lean",
       "theorem_files": {
-        "RubinFormal.Conformance.cv_parse_vectors_pass": "rubin-formal/RubinFormal/Conformance/CVParseReplay.lean",
-        "RubinFormal.Conformance.cv_compact_vectors_pass": "rubin-formal/RubinFormal/Conformance/CVCompactReplay.lean",
         "RubinFormal.Wire.compactSize_roundtrip": "rubin-formal/RubinFormal/ByteWireV2.lean",
         "RubinFormal.Wire.compactSize_overflow_safety": "rubin-formal/RubinFormal/ByteWireV2.lean",
         "RubinFormal.Wire.compactSize_encode_roundtrip": "rubin-formal/RubinFormal/ByteWireV2.lean",
@@ -323,18 +317,14 @@
       "section_key": "transaction_identifiers",
       "section_heading": "## 8. Transaction Identifiers (TXID / WTXID)",
       "status": "proved",
-      "proof_trust": "compiler_trusted",
+      "proof_trust": "kernel_checked",
       "theorems": [
-        "RubinFormal.Conformance.cv_parse_vectors_pass",
-        "RubinFormal.Conformance.cv_sig_vectors_pass",
         "RubinFormal.transaction_identifiers_proved",
         "RubinFormal.txid_wtxid_witness_empty_serialization_shape",
         "RubinFormal.txid_wtxid_identifier_domain_contract"
       ],
       "file": "rubin-formal/RubinFormal/PinnedSections.lean",
       "theorem_files": {
-        "RubinFormal.Conformance.cv_parse_vectors_pass": "rubin-formal/RubinFormal/Conformance/CVParseReplay.lean",
-        "RubinFormal.Conformance.cv_sig_vectors_pass": "rubin-formal/RubinFormal/Conformance/CVSigReplay.lean",
         "RubinFormal.transaction_identifiers_proved": "rubin-formal/RubinFormal/PinnedSections.lean",
         "RubinFormal.txid_wtxid_witness_empty_serialization_shape": "rubin-formal/RubinFormal/TxIdBehavioral.lean",
         "RubinFormal.txid_wtxid_identifier_domain_contract": "rubin-formal/RubinFormal/TxIdBehavioral.lean"
@@ -371,7 +361,6 @@
       "status": "proved",
       "proof_trust": "compiler_trusted",
       "theorems": [
-        "RubinFormal.Conformance.cv_weight_vectors_pass",
         "RubinFormal.WeightSuiteAware.weight_suite_aware_correct",
         "RubinFormal.WeightSuiteAware.weight_suite_aware_correct_create",
         "RubinFormal.weight_monotone_witness",
@@ -403,7 +392,6 @@
       ],
       "file": "rubin-formal/RubinFormal/PinnedSections.lean",
       "theorem_files": {
-        "RubinFormal.Conformance.cv_weight_vectors_pass": "rubin-formal/RubinFormal/Conformance/CVWeightReplay.lean",
         "RubinFormal.WeightSuiteAware.weight_suite_aware_correct": "rubin-formal/RubinFormal/WeightSuiteAware.lean",
         "RubinFormal.WeightSuiteAware.weight_suite_aware_correct_create": "rubin-formal/RubinFormal/WeightSuiteAware.lean",
         "RubinFormal.weight_monotone_witness": "rubin-formal/RubinFormal/CriticalInvariants.lean",
@@ -488,7 +476,6 @@
       "status": "proved",
       "proof_trust": "compiler_trusted",
       "theorems": [
-        "RubinFormal.Conformance.cv_sighash_vectors_pass",
         "RubinFormal.sighash_v1_proved",
         "RubinFormal.SighashV1.buildPreimageFrameParts_injective",
         "RubinFormal.SighashV1.selectHashPrevouts_all_commits_all_inputs",
@@ -506,7 +493,6 @@
       ],
       "file": "rubin-formal/RubinFormal/PinnedSections.lean",
       "theorem_files": {
-        "RubinFormal.Conformance.cv_sighash_vectors_pass": "rubin-formal/RubinFormal/Conformance/CVSighashReplay.lean",
         "RubinFormal.sighash_v1_proved": "rubin-formal/RubinFormal/PinnedSections.lean",
         "RubinFormal.SighashV1.buildPreimageFrameParts_injective": "rubin-formal/RubinFormal/SighashV1.lean",
         "RubinFormal.SighashV1.selectHashPrevouts_all_commits_all_inputs": "rubin-formal/RubinFormal/SighashV1.lean",
@@ -554,9 +540,8 @@
       "section_key": "consensus_error_codes",
       "section_heading": "## 13. Consensus Error Codes (Normative)",
       "status": "proved",
-      "proof_trust": "compiler_trusted",
+      "proof_trust": "kernel_checked",
       "theorems": [
-        "RubinFormal.Conformance.cv_validation_order_vectors_pass",
         "RubinFormal.error_priority_parse",
         "RubinFormal.error_priority_pow",
         "RubinFormal.error_priority_target",
@@ -678,7 +663,6 @@
       ],
       "file": "rubin-formal/RubinFormal/PinnedSections.lean",
       "theorem_files": {
-        "RubinFormal.Conformance.cv_validation_order_vectors_pass": "rubin-formal/RubinFormal/Conformance/CVValidationOrderReplay.lean",
         "RubinFormal.error_priority_parse": "rubin-formal/RubinFormal/ErrorPriority.lean",
         "RubinFormal.error_priority_pow": "rubin-formal/RubinFormal/ErrorPriority.lean",
         "RubinFormal.error_priority_target": "rubin-formal/RubinFormal/ErrorPriority.lean",
@@ -808,7 +792,6 @@
       "status": "proved",
       "proof_trust": "compiler_trusted",
       "theorems": [
-        "RubinFormal.Conformance.cv_covenant_genesis_vectors_pass",
         "RubinFormal.covenantDispositionComplete",
         "RubinFormal.covenant_types_pairwise_distinct",
         "RubinFormal.cov_type_p2pk_value",
@@ -827,7 +810,6 @@
       ],
       "file": "rubin-formal/RubinFormal/PinnedSections.lean",
       "theorem_files": {
-        "RubinFormal.Conformance.cv_covenant_genesis_vectors_pass": "rubin-formal/RubinFormal/Conformance/CVCovenantGenesisReplay.lean",
         "RubinFormal.covenantDispositionComplete": "rubin-formal/RubinFormal/CovenantRegistryExhaustive.lean",
         "RubinFormal.covenant_types_pairwise_distinct": "rubin-formal/RubinFormal/CovenantRegistryExhaustive.lean",
         "RubinFormal.cov_type_p2pk_value": "rubin-formal/RubinFormal/CovenantRegistryExhaustive.lean",
@@ -857,7 +839,6 @@
       "status": "proved",
       "proof_trust": "compiler_trusted",
       "theorems": [
-        "RubinFormal.Conformance.cv_pow_vectors_pass",
         "RubinFormal.PowV1.retargetV1_clamp_bounded",
         "RubinFormal.PowV1.retargetV1_clamp_positive",
         "RubinFormal.retarget_window_size_value",
@@ -902,7 +883,6 @@
       "theorem_files": {
         "RubinFormal.PowV1.retargetV1_clamp_bounded": "rubin-formal/RubinFormal/PowV1.lean",
         "RubinFormal.PowV1.retargetV1_clamp_positive": "rubin-formal/RubinFormal/PowV1.lean",
-        "RubinFormal.Conformance.cv_pow_vectors_pass": "rubin-formal/RubinFormal/Conformance/CVPowReplay.lean",
         "RubinFormal.retarget_window_size_value": "rubin-formal/RubinFormal/RetargetBehavioral.lean",
         "RubinFormal.retarget_block_interval_value": "rubin-formal/RubinFormal/RetargetBehavioral.lean",
         "RubinFormal.retarget_tExpected_value": "rubin-formal/RubinFormal/RetargetBehavioral.lean",
@@ -951,7 +931,6 @@
       "status": "proved",
       "proof_trust": "compiler_trusted",
       "theorems": [
-        "RubinFormal.Conformance.cv_validation_order_vectors_pass",
         "RubinFormal.unknown_suite_0x05_rejected",
         "RubinFormal.sentinel_nonempty_pubkey_rejected",
         "RubinFormal.sentinel_empty_accepted",
@@ -974,7 +953,6 @@
       ],
       "file": "rubin-formal/RubinFormal/PinnedSections.lean",
       "theorem_files": {
-        "RubinFormal.Conformance.cv_validation_order_vectors_pass": "rubin-formal/RubinFormal/Conformance/CVValidationOrderReplay.lean",
         "RubinFormal.unknown_suite_0x05_rejected": "rubin-formal/RubinFormal/StructuralRulesBehavioral.lean",
         "RubinFormal.sentinel_nonempty_pubkey_rejected": "rubin-formal/RubinFormal/StructuralRulesBehavioral.lean",
         "RubinFormal.sentinel_empty_accepted": "rubin-formal/RubinFormal/StructuralRulesBehavioral.lean",
@@ -1006,9 +984,8 @@
       "section_key": "replay_domain_checks",
       "section_heading": "## 1. Replay-Domain Checks (Normative)",
       "status": "proved",
-      "proof_trust": "compiler_trusted",
+      "proof_trust": "kernel_checked",
       "theorems": [
-        "RubinFormal.Conformance.cv_replay_vectors_pass",
         "RubinFormal.replay_domain_checks_proved",
         "RubinFormal.parsed_nonce_duplicate_not_replay_free",
         "RubinFormal.replay_domain_nonce_contract",
@@ -1019,7 +996,6 @@
       ],
       "file": "rubin-formal/RubinFormal/PinnedSections.lean",
       "theorem_files": {
-        "RubinFormal.Conformance.cv_replay_vectors_pass": "rubin-formal/RubinFormal/Conformance/CVReplayReplay.lean",
         "RubinFormal.replay_domain_checks_proved": "rubin-formal/RubinFormal/PinnedSections.lean",
         "RubinFormal.parsed_nonce_duplicate_not_replay_free": "rubin-formal/RubinFormal/ReplayDomainBehavioral.lean",
         "RubinFormal.replay_domain_nonce_contract": "rubin-formal/RubinFormal/ReplayDomainBehavioral.lean",
@@ -1161,7 +1137,6 @@
       "status": "proved",
       "proof_trust": "compiler_trusted",
       "theorems": [
-        "RubinFormal.Conformance.cv_subsidy_vectors_pass",
         "RubinFormal.subsidy_u128_safety_proved",
         "RubinFormal.SubsidyV1.connectBlock_end_to_end_proved",
         "RubinFormal.blockSubsidy_bounded",
@@ -1170,7 +1145,6 @@
       ],
       "file": "rubin-formal/RubinFormal/PinnedSections.lean",
       "theorem_files": {
-        "RubinFormal.Conformance.cv_subsidy_vectors_pass": "rubin-formal/RubinFormal/Conformance/CVSubsidyReplay.lean",
         "RubinFormal.subsidy_u128_safety_proved": "rubin-formal/RubinFormal/PinnedSections.lean",
         "RubinFormal.SubsidyV1.connectBlock_end_to_end_proved": "rubin-formal/RubinFormal/SubsidyV1.lean",
         "RubinFormal.blockSubsidy_bounded": "rubin-formal/RubinFormal/ArithmeticSafety.lean",
@@ -1184,9 +1158,8 @@
       "section_key": "value_conservation",
       "section_heading": "## 20. Value Conservation (Normative)",
       "status": "proved",
-      "proof_trust": "compiler_trusted",
+      "proof_trust": "kernel_checked",
       "theorems": [
-        "RubinFormal.Conformance.cv_subsidy_vectors_pass",
         "RubinFormal.utxo_conservation_theorem",
         "RubinFormal.value_conservation_single_tx",
         "RubinFormal.value_conservation_block_txs",
@@ -1194,7 +1167,6 @@
       ],
       "file": "rubin-formal/RubinFormal/PinnedSections.lean",
       "theorem_files": {
-        "RubinFormal.Conformance.cv_subsidy_vectors_pass": "rubin-formal/RubinFormal/Conformance/CVSubsidyReplay.lean",
         "RubinFormal.utxo_conservation_theorem": "rubin-formal/RubinFormal/ConnectBlockStrong.lean",
         "RubinFormal.value_conservation_single_tx": "rubin-formal/RubinFormal/ValueConservationBehavioral.lean",
         "RubinFormal.value_conservation_block_txs": "rubin-formal/RubinFormal/ValueConservationBehavioral.lean",
@@ -1209,7 +1181,6 @@
       "status": "proved",
       "proof_trust": "compiler_trusted",
       "theorems": [
-        "RubinFormal.Conformance.cv_da_integrity_vectors_pass",
         "RubinFormal.da_empty_txs_accepted",
         "RubinFormal.da_batch_exceeded",
         "RubinFormal.da_batch_ok",
@@ -1284,7 +1255,6 @@
       ],
       "file": "rubin-formal/RubinFormal/PinnedSections.lean",
       "theorem_files": {
-        "RubinFormal.Conformance.cv_da_integrity_vectors_pass": "rubin-formal/RubinFormal/Conformance/CVDaIntegrityReplay.lean",
         "RubinFormal.da_empty_txs_accepted": "rubin-formal/RubinFormal/DaIntegrityBehavioral.lean",
         "RubinFormal.da_batch_exceeded": "rubin-formal/RubinFormal/DaIntegrityBehavioral.lean",
         "RubinFormal.da_batch_ok": "rubin-formal/RubinFormal/DaIntegrityBehavioral.lean",
@@ -1365,9 +1335,8 @@
       "section_key": "block_timestamp_rules",
       "section_heading": "## 22. Block Timestamp Rules (Normative)",
       "status": "proved",
-      "proof_trust": "compiler_trusted",
+      "proof_trust": "kernel_checked",
       "theorems": [
-        "RubinFormal.Conformance.cv_timestamp_vectors_pass",
         "RubinFormal.medianTimePast_value",
         "RubinFormal.medianTimePast_index_valid",
         "RubinFormal.BlockBasicCheckV1.timestampBounds_ok_iff",
@@ -1380,7 +1349,6 @@
       ],
       "file": "rubin-formal/RubinFormal/BlockTimestampBehavioral.lean",
       "theorem_files": {
-        "RubinFormal.Conformance.cv_timestamp_vectors_pass": "rubin-formal/RubinFormal/Conformance/CVTimestampReplay.lean",
         "RubinFormal.medianTimePast_value": "rubin-formal/RubinFormal/BlockTimestampBehavioral.lean",
         "RubinFormal.medianTimePast_index_valid": "rubin-formal/RubinFormal/BlockTimestampBehavioral.lean",
         "RubinFormal.BlockBasicCheckV1.timestampBounds_ok_iff": "rubin-formal/RubinFormal/BlockBasicCheckV1.lean",
@@ -1404,7 +1372,6 @@
       "status": "stated",
       "proof_trust": "compiler_trusted",
       "theorems": [
-        "RubinFormal.Conformance.cv_fork_choice_vectors_pass",
         "RubinFormal.ForkChoiceV1.emptyChain_loses",
         "RubinFormal.ForkChoiceV1.heavierChain_wins",
         "RubinFormal.ForkChoiceV1.zeroTarget_rejected",
@@ -1424,7 +1391,6 @@
       ],
       "file": "rubin-formal/RubinFormal/ForkChoiceV1.lean",
       "theorem_files": {
-        "RubinFormal.Conformance.cv_fork_choice_vectors_pass": "rubin-formal/RubinFormal/Conformance/CVForkChoiceReplay.lean",
         "RubinFormal.ForkChoiceV1.emptyChain_loses": "rubin-formal/RubinFormal/ForkChoiceV1.lean",
         "RubinFormal.ForkChoiceV1.heavierChain_wins": "rubin-formal/RubinFormal/ForkChoiceV1.lean",
         "RubinFormal.ForkChoiceV1.zeroTarget_rejected": "rubin-formal/RubinFormal/ForkChoiceV1.lean",
@@ -1561,7 +1527,6 @@
         "RubinFormal.NativeRegistryResolution.fi_rot_03_registry_lookup_deterministic",
         "RubinFormal.NativeRegistryResolution.fi_rot_03_unique_entry",
         "RubinFormal.NativeRegistryResolution.fi_rot_03_active_suite_resolves",
-        "RubinFormal.NativeRegistryResolution.fi_rot_03_pre_rotation_ml_dsa_resolves",
         "RubinFormal.NativeRegistryResolution.fi_rot_03_pre_rotation_no_duplicates",
         "RubinFormal.RegistryResolutionLiveBridge.pre_rotation_registered_iff",
         "RubinFormal.RegistryResolutionLiveBridge.ml_dsa_87_params_bridge",
@@ -1579,7 +1544,6 @@
         "RubinFormal.NativeRegistryResolution.fi_rot_03_registry_lookup_deterministic": "rubin-formal/RubinFormal/NativeRegistryResolution.lean",
         "RubinFormal.NativeRegistryResolution.fi_rot_03_unique_entry": "rubin-formal/RubinFormal/NativeRegistryResolution.lean",
         "RubinFormal.NativeRegistryResolution.fi_rot_03_active_suite_resolves": "rubin-formal/RubinFormal/NativeRegistryResolution.lean",
-        "RubinFormal.NativeRegistryResolution.fi_rot_03_pre_rotation_ml_dsa_resolves": "rubin-formal/RubinFormal/NativeRegistryResolution.lean",
         "RubinFormal.NativeRegistryResolution.fi_rot_03_pre_rotation_no_duplicates": "rubin-formal/RubinFormal/NativeRegistryResolution.lean",
         "RubinFormal.RegistryResolutionLiveBridge.pre_rotation_registered_iff": "rubin-formal/RubinFormal/RegistryResolutionLiveBridge.lean",
         "RubinFormal.RegistryResolutionLiveBridge.ml_dsa_87_params_bridge": "rubin-formal/RubinFormal/RegistryResolutionLiveBridge.lean",
@@ -1777,13 +1741,9 @@
     "proved_with_axiom_rows": 4,
     "stated_rows": 3,
     "deferred_rows": 0,
-    "theorem_references": 541,
-    "unique_theorem_names": 522,
+    "theorem_references": 523,
+    "unique_theorem_names": 508,
     "reused_theorem_names": [
-      "RubinFormal.Conformance.cv_parse_vectors_pass",
-      "RubinFormal.Conformance.cv_subsidy_vectors_pass",
-      "RubinFormal.Conformance.cv_validation_order_vectors_pass",
-      "RubinFormal.NativeRegistryResolution.fi_rot_03_pre_rotation_ml_dsa_resolves",
       "RubinFormal.RegistryResolutionLiveBridge.ml_dsa_87_params_bridge",
       "RubinFormal.RegistryResolutionLiveBridge.pre_rotation_registered_iff",
       "RubinFormal.UtxoApplyGenesisV1.validateWitnessItemLengths_eq_registry_pre_rotation",

--- a/rubin-formal/proof_coverage.json
+++ b/rubin-formal/proof_coverage.json
@@ -163,7 +163,7 @@
       "tests/test_strip_lean_comments.py": {"disposition":"IMPORT_PACKAGE_CHECK_OR_TEST","source_sha256":"5ec65a9f9dec186017230df464355492ad930143955d3ed9afffd71e0fdc6017","candidate_sha256":"f7076c904203aa4417322cd961c0ce8402ea631b09732aed15230b15dc9b3ab3"},
       "tests/test_validation.py": {"disposition":"IMPORT_PACKAGE_CHECK_OR_TEST","source_sha256":"077d0c6894e2f8a496e1136b5c078efbd3bbe19b63a49a27524c5506b76604a3","candidate_sha256":"8ce69c12f3b713f960bed3c04f2f5e400c08b7e6f1896d5e68a1c2ebf8d8b93f"},
       "tools/LOCAL_CODEX_EXEC_REVIEW.md": {"disposition":"BYTE_EXACT","source_sha256":"8b273376471f3d55955b53109adf56abffc9609b89bf09570d77b678cf474ba5","candidate_sha256":"8b273376471f3d55955b53109adf56abffc9609b89bf09570d77b678cf474ba5"},
-      "tools/check_formal_registry_truth.py": {"disposition":"TRANSPLANT_CHECK_LOGIC","source_sha256":"43e89e7b12ade218119edd0e03401bf9508e75c3cd713f8f8d636aeac970f804","candidate_sha256":"ca606316d358e4f1f4d850f89ff10b3d9e45f50ec0926ba1e55911234f340328"}
+      "tools/check_formal_registry_truth.py": {"disposition":"TRANSPLANT_CHECK_LOGIC","source_sha256":"43e89e7b12ade218119edd0e03401bf9508e75c3cd713f8f8d636aeac970f804","candidate_sha256":"b6f3ada4759791b9ee270c6692dc98c27e8b288717e6649bc905481f7b02222a"}
     }
   },
   "coverage": [
@@ -359,7 +359,7 @@
       "section_key": "weight_accounting",
       "section_heading": "## 9. Weight Accounting (Normative)",
       "status": "proved",
-      "proof_trust": "compiler_trusted",
+      "proof_trust": "kernel_checked",
       "theorems": [
         "RubinFormal.WeightSuiteAware.weight_suite_aware_correct",
         "RubinFormal.WeightSuiteAware.weight_suite_aware_correct_create",
@@ -367,7 +367,6 @@
         "RubinFormal.Refinement.weight_monotone_base",
         "RubinFormal.Refinement.weight_monotone_sigCost",
         "RubinFormal.weight_accounting_proved",
-        "RubinFormal.weight_cv_replay_pass",
         "RubinFormal.weight_formula_bridges_abstract",
         "RubinFormal.computeWeight_monotone_base",
         "RubinFormal.computeWeight_monotone_witness",
@@ -398,7 +397,6 @@
         "RubinFormal.weight_accounting_proved": "rubin-formal/RubinFormal/PinnedSections.lean",
         "RubinFormal.Refinement.weight_monotone_base": "rubin-formal/RubinFormal/Refinement/UniversalInvariants.lean",
         "RubinFormal.Refinement.weight_monotone_sigCost": "rubin-formal/RubinFormal/Refinement/UniversalInvariants.lean",
-        "RubinFormal.weight_cv_replay_pass": "rubin-formal/RubinFormal/TxWeightBehavioral.lean",
         "RubinFormal.weight_formula_bridges_abstract": "rubin-formal/RubinFormal/TxWeightBehavioral.lean",
         "RubinFormal.computeWeight_monotone_base": "rubin-formal/RubinFormal/TxWeightBehavioral.lean",
         "RubinFormal.computeWeight_monotone_witness": "rubin-formal/RubinFormal/TxWeightBehavioral.lean",
@@ -863,7 +861,6 @@
         "RubinFormal.timestamp_step_le_actual",
         "RubinFormal.max_tActual_bounded",
         "RubinFormal.max_retarget_ratio",
-        "RubinFormal.retarget_cv_replay_pass",
         "RubinFormal.retargetV1_parse_none",
         "RubinFormal.retargetV1_zero_target",
         "RubinFormal.retargetV1_ok_none_simple",
@@ -905,7 +902,6 @@
         "RubinFormal.timestamp_step_le_actual": "rubin-formal/RubinFormal/RetargetBehavioral.lean",
         "RubinFormal.max_tActual_bounded": "rubin-formal/RubinFormal/RetargetBehavioral.lean",
         "RubinFormal.max_retarget_ratio": "rubin-formal/RubinFormal/RetargetBehavioral.lean",
-        "RubinFormal.retarget_cv_replay_pass": "rubin-formal/RubinFormal/RetargetBehavioral.lean",
         "RubinFormal.retargetV1_parse_none": "rubin-formal/RubinFormal/RetargetBehavioral.lean",
         "RubinFormal.retargetV1_zero_target": "rubin-formal/RubinFormal/RetargetBehavioral.lean",
         "RubinFormal.retargetV1_ok_none_simple": "rubin-formal/RubinFormal/RetargetBehavioral.lean",
@@ -1386,7 +1382,6 @@
         "RubinFormal.forkSelect_lighter_loses",
         "RubinFormal.forkSelect_chainwork_bridge",
         "RubinFormal.forkSelect_equal_chains",
-        "RubinFormal.Refinement.fork_choice_select_cv_contract_proved",
         "RubinFormal.forkSelect_exhaustive"
       ],
       "file": "rubin-formal/RubinFormal/ForkChoiceV1.lean",
@@ -1395,7 +1390,6 @@
         "RubinFormal.ForkChoiceV1.heavierChain_wins": "rubin-formal/RubinFormal/ForkChoiceV1.lean",
         "RubinFormal.ForkChoiceV1.zeroTarget_rejected": "rubin-formal/RubinFormal/ForkChoiceV1.lean",
         "RubinFormal.ForkChoiceV1.overLimitTarget_rejected": "rubin-formal/RubinFormal/ForkChoiceV1.lean",
-        "RubinFormal.Refinement.fork_choice_select_cv_contract_proved": "rubin-formal/RubinFormal/Refinement/GoTraceV1Check.lean",
         "RubinFormal.bytesLT_irrefl": "rubin-formal/RubinFormal/ForkChoiceTiebreak.lean",
         "RubinFormal.bytesLT_total_of_ne": "rubin-formal/RubinFormal/ForkChoiceTiebreak.lean",
         "RubinFormal.fork_choice_tiebreak_deterministic": "rubin-formal/RubinFormal/ForkChoiceTiebreak.lean",
@@ -1741,8 +1735,8 @@
     "proved_with_axiom_rows": 4,
     "stated_rows": 3,
     "deferred_rows": 0,
-    "theorem_references": 523,
-    "unique_theorem_names": 508,
+    "theorem_references": 520,
+    "unique_theorem_names": 505,
     "reused_theorem_names": [
       "RubinFormal.RegistryResolutionLiveBridge.ml_dsa_87_params_bridge",
       "RubinFormal.RegistryResolutionLiveBridge.pre_rotation_registered_iff",

--- a/rubin-formal/proof_coverage.json
+++ b/rubin-formal/proof_coverage.json
@@ -163,7 +163,7 @@
       "tests/test_strip_lean_comments.py": {"disposition":"IMPORT_PACKAGE_CHECK_OR_TEST","source_sha256":"5ec65a9f9dec186017230df464355492ad930143955d3ed9afffd71e0fdc6017","candidate_sha256":"f7076c904203aa4417322cd961c0ce8402ea631b09732aed15230b15dc9b3ab3"},
       "tests/test_validation.py": {"disposition":"IMPORT_PACKAGE_CHECK_OR_TEST","source_sha256":"077d0c6894e2f8a496e1136b5c078efbd3bbe19b63a49a27524c5506b76604a3","candidate_sha256":"8ce69c12f3b713f960bed3c04f2f5e400c08b7e6f1896d5e68a1c2ebf8d8b93f"},
       "tools/LOCAL_CODEX_EXEC_REVIEW.md": {"disposition":"BYTE_EXACT","source_sha256":"8b273376471f3d55955b53109adf56abffc9609b89bf09570d77b678cf474ba5","candidate_sha256":"8b273376471f3d55955b53109adf56abffc9609b89bf09570d77b678cf474ba5"},
-      "tools/check_formal_registry_truth.py": {"disposition":"TRANSPLANT_CHECK_LOGIC","source_sha256":"43e89e7b12ade218119edd0e03401bf9508e75c3cd713f8f8d636aeac970f804","candidate_sha256":"b6f3ada4759791b9ee270c6692dc98c27e8b288717e6649bc905481f7b02222a"}
+      "tools/check_formal_registry_truth.py": {"disposition":"TRANSPLANT_CHECK_LOGIC","source_sha256":"43e89e7b12ade218119edd0e03401bf9508e75c3cd713f8f8d636aeac970f804","candidate_sha256":"33e11845d5eb2e697ae33b09b49e592ceceaab0ef73891627d4701576c4ffb5d"}
     }
   },
   "coverage": [

--- a/rubin-formal/refinement_bridge.json
+++ b/rubin-formal/refinement_bridge.json
@@ -157,7 +157,7 @@
       "tests/test_strip_lean_comments.py": {"disposition":"IMPORT_PACKAGE_CHECK_OR_TEST","source_sha256":"5ec65a9f9dec186017230df464355492ad930143955d3ed9afffd71e0fdc6017","candidate_sha256":"f7076c904203aa4417322cd961c0ce8402ea631b09732aed15230b15dc9b3ab3"},
       "tests/test_validation.py": {"disposition":"IMPORT_PACKAGE_CHECK_OR_TEST","source_sha256":"077d0c6894e2f8a496e1136b5c078efbd3bbe19b63a49a27524c5506b76604a3","candidate_sha256":"8ce69c12f3b713f960bed3c04f2f5e400c08b7e6f1896d5e68a1c2ebf8d8b93f"},
       "tools/LOCAL_CODEX_EXEC_REVIEW.md": {"disposition":"BYTE_EXACT","source_sha256":"8b273376471f3d55955b53109adf56abffc9609b89bf09570d77b678cf474ba5","candidate_sha256":"8b273376471f3d55955b53109adf56abffc9609b89bf09570d77b678cf474ba5"},
-      "tools/check_formal_registry_truth.py": {"disposition":"TRANSPLANT_CHECK_LOGIC","source_sha256":"43e89e7b12ade218119edd0e03401bf9508e75c3cd713f8f8d636aeac970f804","candidate_sha256":"b6f3ada4759791b9ee270c6692dc98c27e8b288717e6649bc905481f7b02222a"}
+      "tools/check_formal_registry_truth.py": {"disposition":"TRANSPLANT_CHECK_LOGIC","source_sha256":"43e89e7b12ade218119edd0e03401bf9508e75c3cd713f8f8d636aeac970f804","candidate_sha256":"33e11845d5eb2e697ae33b09b49e592ceceaab0ef73891627d4701576c4ffb5d"}
     }
   },
   "critical_ops": [
@@ -275,12 +275,10 @@
         "RubinFormal.timestamp_step_le_actual",
         "RubinFormal.max_tActual_bounded",
         "RubinFormal.max_retarget_ratio",
-        "RubinFormal.retarget_cv_replay_pass",
         "RubinFormal.Conformance.cv_pow_vectors_pass"
       ],
       "supporting_theorem_files": {
-        "RubinFormal.Conformance.cv_pow_vectors_pass": "rubin-formal/RubinFormal/Conformance/CVPowReplay.lean",
-        "RubinFormal.retarget_cv_replay_pass": "rubin-formal/RubinFormal/RetargetBehavioral.lean"
+        "RubinFormal.Conformance.cv_pow_vectors_pass": "rubin-formal/RubinFormal/Conformance/CVPowReplay.lean"
       },
       "notes": "The model theorem is the exact current native trace expression; retained supporting theorems provide the separate behavioral decomposition of the retarget formula."
     },

--- a/rubin-formal/refinement_bridge.json
+++ b/rubin-formal/refinement_bridge.json
@@ -157,7 +157,7 @@
       "tests/test_strip_lean_comments.py": {"disposition":"IMPORT_PACKAGE_CHECK_OR_TEST","source_sha256":"5ec65a9f9dec186017230df464355492ad930143955d3ed9afffd71e0fdc6017","candidate_sha256":"f7076c904203aa4417322cd961c0ce8402ea631b09732aed15230b15dc9b3ab3"},
       "tests/test_validation.py": {"disposition":"IMPORT_PACKAGE_CHECK_OR_TEST","source_sha256":"077d0c6894e2f8a496e1136b5c078efbd3bbe19b63a49a27524c5506b76604a3","candidate_sha256":"8ce69c12f3b713f960bed3c04f2f5e400c08b7e6f1896d5e68a1c2ebf8d8b93f"},
       "tools/LOCAL_CODEX_EXEC_REVIEW.md": {"disposition":"BYTE_EXACT","source_sha256":"8b273376471f3d55955b53109adf56abffc9609b89bf09570d77b678cf474ba5","candidate_sha256":"8b273376471f3d55955b53109adf56abffc9609b89bf09570d77b678cf474ba5"},
-      "tools/check_formal_registry_truth.py": {"disposition":"TRANSPLANT_CHECK_LOGIC","source_sha256":"43e89e7b12ade218119edd0e03401bf9508e75c3cd713f8f8d636aeac970f804","candidate_sha256":"ca606316d358e4f1f4d850f89ff10b3d9e45f50ec0926ba1e55911234f340328"}
+      "tools/check_formal_registry_truth.py": {"disposition":"TRANSPLANT_CHECK_LOGIC","source_sha256":"43e89e7b12ade218119edd0e03401bf9508e75c3cd713f8f8d636aeac970f804","candidate_sha256":"b6f3ada4759791b9ee270c6692dc98c27e8b288717e6649bc905481f7b02222a"}
     }
   },
   "critical_ops": [
@@ -279,7 +279,8 @@
         "RubinFormal.Conformance.cv_pow_vectors_pass"
       ],
       "supporting_theorem_files": {
-        "RubinFormal.Conformance.cv_pow_vectors_pass": "rubin-formal/RubinFormal/Conformance/CVPowReplay.lean"
+        "RubinFormal.Conformance.cv_pow_vectors_pass": "rubin-formal/RubinFormal/Conformance/CVPowReplay.lean",
+        "RubinFormal.retarget_cv_replay_pass": "rubin-formal/RubinFormal/RetargetBehavioral.lean"
       },
       "notes": "The model theorem is the exact current native trace expression; retained supporting theorems provide the separate behavioral decomposition of the retarget formula."
     },

--- a/rubin-formal/refinement_bridge.json
+++ b/rubin-formal/refinement_bridge.json
@@ -56,7 +56,7 @@
     "active_partition_equation": "73 + 19 + 1 + 2 + 7 = 102",
     "original_inventory_equation": "102 + 4 + 3 + 7 = 116",
     "active_path_manifest": {
-      "REGISTRY_COMPLETENESS_POLICY.md": {"disposition":"IMPORT_ADAPT_SINGLE_OWNER","source_sha256":"9af957d4fefad13471a00ca18f1ee1c146c8b34e551cf3f9b179c517e5be8c3c","candidate_sha256":"7508fb16b34f011f2983582c0d42a4253c526f3edea03a3d09677ebb26a7ddc7"},
+      "REGISTRY_COMPLETENESS_POLICY.md": {"disposition":"IMPORT_ADAPT_SINGLE_OWNER","source_sha256":"9af957d4fefad13471a00ca18f1ee1c146c8b34e551cf3f9b179c517e5be8c3c","candidate_sha256":"b8808d222b5ebbc120993b5c4082551c35b24d0b6c4afee44060d6c2b74c8846"},
       "RubinFormal/BlockHeaderRoundtrip.lean": {"disposition":"BYTE_EXACT","source_sha256":"3239aac537d9d53f4d8af01716b8a959fa4fe3b057b8e9d6b9d75d85b6f860ec","candidate_sha256":"3239aac537d9d53f4d8af01716b8a959fa4fe3b057b8e9d6b9d75d85b6f860ec"},
       "RubinFormal/BlockTimestampBehavioral.lean": {"disposition":"BYTE_EXACT","source_sha256":"c21d4899dc9fe505b48e8037c04eb66599b558bb1f184b1676d84da12c0e35d5","candidate_sha256":"c21d4899dc9fe505b48e8037c04eb66599b558bb1f184b1676d84da12c0e35d5"},
       "RubinFormal/BlockValidationOrder.lean": {"disposition":"RECONCILE_CURRENT_PROTOCOL","source_sha256":"a63d141bd53dac280a0012a3a1e742ecf059c9d2736774ae97e8dc3d3957549f","candidate_sha256":"0716940a9a99bfb5f7dfcf0c20cb1710f9866fc3d19090ee39c1a9b38a9aff35"},
@@ -75,7 +75,7 @@
       "RubinFormal/CreateSideLiveGateBridge.lean": {"disposition":"BYTE_EXACT","source_sha256":"bd3702ab78260d7b3ba5e7c9aa3ba93c484cb21c54aabc4410d1194fabeda73c","candidate_sha256":"bd3702ab78260d7b3ba5e7c9aa3ba93c484cb21c54aabc4410d1194fabeda73c"},
       "RubinFormal/DaIntegrityBehavioral.lean": {"disposition":"BYTE_EXACT","source_sha256":"e5b5f91fe1140d56cfaad36b88465332e1ee72547471a1bdccd189cb5e028cf7","candidate_sha256":"e5b5f91fe1140d56cfaad36b88465332e1ee72547471a1bdccd189cb5e028cf7"},
       "RubinFormal/DeterminismRequirements.lean": {"disposition":"BYTE_EXACT","source_sha256":"d2db16f90fb246d739e72cd23b717f87025145a836a018743d625faffb6cb0a8","candidate_sha256":"d2db16f90fb246d739e72cd23b717f87025145a836a018743d625faffb6cb0a8"},
-      "RubinFormal/ErrorPriority.lean": {"disposition":"RECONCILE_CURRENT_PROTOCOL","source_sha256":"9a2361617709189211a99cc080e3278a04065048e79fd17c117a37470d0cd7a5","candidate_sha256":"6d9870a5aa64bc70ee035ead5b62e1fc8a9aeb4dd88cee375ad8bc7a35541ac3"},
+      "RubinFormal/ErrorPriority.lean": {"disposition":"RECONCILE_CURRENT_PROTOCOL","source_sha256":"9a2361617709189211a99cc080e3278a04065048e79fd17c117a37470d0cd7a5","candidate_sha256":"e6d6f4ddf0dfd426a9da95b38ef21751c0a50b492d835850891e230a3d0e1585"},
       "RubinFormal/FeatureActivationFSM.lean": {"disposition":"BYTE_EXACT","source_sha256":"346b65852e93222b9b574b976c3ab17a26b42960005498245da6308ec9faf565","candidate_sha256":"346b65852e93222b9b574b976c3ab17a26b42960005498245da6308ec9faf565"},
       "RubinFormal/FeatureActivationLiveBridge.lean": {"disposition":"RECONCILE_CURRENT_PROTOCOL","source_sha256":"6959f52b6e206e2890a897ca3acdb55c0ee3566e2398858eebd3f8d5f5498dab","candidate_sha256":"657fc4583de15945852c4e1a62af5c79fa63c8fe0da8171486a91df2450be802"},
       "RubinFormal/ForkChoiceSelect.lean": {"disposition":"RECONCILE_CURRENT_PROTOCOL","source_sha256":"4a1a9fdb6a4e883efcb869ec30542d165c25e55946635dfae867a1a70a4c6364","candidate_sha256":"031182b226d8f00a2bae6c89439d12e42e0d5a5b710bddf38c316d6f0820794c"},
@@ -157,7 +157,7 @@
       "tests/test_strip_lean_comments.py": {"disposition":"IMPORT_PACKAGE_CHECK_OR_TEST","source_sha256":"5ec65a9f9dec186017230df464355492ad930143955d3ed9afffd71e0fdc6017","candidate_sha256":"f7076c904203aa4417322cd961c0ce8402ea631b09732aed15230b15dc9b3ab3"},
       "tests/test_validation.py": {"disposition":"IMPORT_PACKAGE_CHECK_OR_TEST","source_sha256":"077d0c6894e2f8a496e1136b5c078efbd3bbe19b63a49a27524c5506b76604a3","candidate_sha256":"8ce69c12f3b713f960bed3c04f2f5e400c08b7e6f1896d5e68a1c2ebf8d8b93f"},
       "tools/LOCAL_CODEX_EXEC_REVIEW.md": {"disposition":"BYTE_EXACT","source_sha256":"8b273376471f3d55955b53109adf56abffc9609b89bf09570d77b678cf474ba5","candidate_sha256":"8b273376471f3d55955b53109adf56abffc9609b89bf09570d77b678cf474ba5"},
-      "tools/check_formal_registry_truth.py": {"disposition":"TRANSPLANT_CHECK_LOGIC","source_sha256":"43e89e7b12ade218119edd0e03401bf9508e75c3cd713f8f8d636aeac970f804","candidate_sha256":"19262b75f8b6f4c3114a7b599182cd02f7429a3316aa93a370a805a247a7bc1d"}
+      "tools/check_formal_registry_truth.py": {"disposition":"TRANSPLANT_CHECK_LOGIC","source_sha256":"43e89e7b12ade218119edd0e03401bf9508e75c3cd713f8f8d636aeac970f804","candidate_sha256":"ca606316d358e4f1f4d850f89ff10b3d9e45f50ec0926ba1e55911234f340328"}
     }
   },
   "critical_ops": [
@@ -221,6 +221,9 @@
         "RubinFormal.selectHashOutputs_invalid_returns_none",
         "RubinFormal.hasValidBaseType_exhaustive"
       ],
+      "supporting_theorem_files": {
+        "RubinFormal.Conformance.cv_sighash_vectors_pass": "rubin-formal/RubinFormal/Conformance/CVSighashReplay.lean"
+      },
       "notes": "The model theorem is the exact current native trace expression; retained supporting theorems provide separate structural selector/base-type evidence and the separately scoped DigestV1 assumption-backed reduction ceiling."
     },
     {
@@ -275,6 +278,9 @@
         "RubinFormal.retarget_cv_replay_pass",
         "RubinFormal.Conformance.cv_pow_vectors_pass"
       ],
+      "supporting_theorem_files": {
+        "RubinFormal.Conformance.cv_pow_vectors_pass": "rubin-formal/RubinFormal/Conformance/CVPowReplay.lean"
+      },
       "notes": "The model theorem is the exact current native trace expression; retained supporting theorems provide the separate behavioral decomposition of the retarget formula."
     },
     {
@@ -298,7 +304,10 @@
         "RubinFormal.forkSelect_total_det",
         "RubinFormal.forkSelect_heavier",
         "RubinFormal.bytesLT_antisym"
-      ]
+      ],
+      "supporting_theorem_files": {
+        "RubinFormal.Conformance.cv_fork_choice_vectors_pass": "rubin-formal/RubinFormal/Conformance/CVForkChoiceReplay.lean"
+      }
     },
     {
       "op": "utxo_apply_basic",
@@ -398,6 +407,9 @@
         "RubinFormal.witness_all_ok",
         "RubinFormal.validateDASetIntegrity_ok_constrained"
       ],
+      "supporting_theorem_files": {
+        "RubinFormal.Conformance.cv_da_integrity_vectors_pass": "rubin-formal/RubinFormal/Conformance/CVDaIntegrityReplay.lean"
+      },
       "notes": "Universal closure of the live DA validator surface. validateDASetIntegrity_ok_constrained decomposes .ok into accumulateDATxs + batch count bound + orphan check + verifyCommitIntegrity with parse-derived witnesses. validateWitnessErrors is extracted as a LIVE sub-function; the full DA pipeline is decomposed into recursive helpers plus gate-level error propagation, with CV-DA-INTEGRITY replay backing the same surface.",
       "contract_scope": "Universal closure of S21 DA set integrity. Constrained theorem decomposes .ok into all 4 stages with parse-derived witnesses."
     },
@@ -448,6 +460,9 @@
         "RubinFormal.WeightSuiteAware.weight_suite_aware_correct_create",
         "RubinFormal.weight_accounting_proved"
       ],
+      "supporting_theorem_files": {
+        "RubinFormal.Conformance.cv_weight_vectors_pass": "rubin-formal/RubinFormal/Conformance/CVWeightReplay.lean"
+      },
       "notes": "Universal closure of §9 weight formula. The live txWeightAndStats path now has a parse-constrained full-chain theorem plus a non-vacuous positivity guard; CV-WEIGHT remains the executable evidence lane, and WeightSuiteAware.lean supporting theorems close the suite-aware post-rotation cost model within the same section-level universal row."
     },
     {

--- a/rubin-formal/tools/check_formal_registry_truth.py
+++ b/rubin-formal/tools/check_formal_registry_truth.py
@@ -38,7 +38,7 @@ SHARED_OP_PARITY = {
 EXPECTED_COVERAGE_TRUST = (32, 520, 505, 15, 52, 49)
 EXPECTED_UNIVERSAL_TRUST = (24, 480, 12, 43, 40)
 EXPECTED_KERNEL_THEOREM_COMPLEMENT = (468, 456)
-EXPECTED_BRIDGE_TRUST = (12, 165, 162, 9, 21, 21)
+EXPECTED_BRIDGE_TRUST = (12, 164, 161, 9, 20, 20)
 EXPECTED_UNAFFECTED_UNIVERSAL = {
     "block_timestamp_rules",
     "consensus_constants_witness_lengths_pre_rotation",
@@ -59,7 +59,7 @@ EXPECTED_AFFECTED_BRIDGE_REFS = {
     "native_rotation": 1,
     "native_suite_rotation": 2,
     "parse_tx": 1,
-    "retarget_v1": 9,
+    "retarget_v1": 8,
     "sighash_v1": 3,
     "utxo_apply_basic": 1,
     "weight_accounting": 1,

--- a/rubin-formal/tools/check_formal_registry_truth.py
+++ b/rubin-formal/tools/check_formal_registry_truth.py
@@ -27,13 +27,16 @@ ALLOWED_AXIOMS = {
 
 # Intentionally narrow shared-op parity scope after Q-FORMAL-REGISTRY-EVIDENCE-LEVEL-ALIGN-01.
 # `sighash_v1`, `retarget_v1`, and `fork_choice_select` remain honest supplemental bridge lanes whose
-# bridge evidence level is narrower than the broader section row on purpose.
+# bridge evidence level is narrower than the broader section row on purpose. `weight_accounting`
+# remains subject to row-presence and evidence-level parity, but intentionally retains bounded
+# compiler-trusted CV support in its bridge lane while its proof_coverage universal row contains only
+# kernel-checked claim-bearing theorems.
 SHARED_OP_PARITY = {
     "da_set_integrity": "da_set_integrity",
     "weight_accounting": "weight_accounting",
 }
-EXPECTED_COVERAGE_TRUST = (32, 523, 508, 16, 55, 52)
-EXPECTED_UNIVERSAL_TRUST = (24, 482, 13, 45, 42)
+EXPECTED_COVERAGE_TRUST = (32, 520, 505, 15, 52, 49)
+EXPECTED_UNIVERSAL_TRUST = (24, 480, 12, 43, 40)
 EXPECTED_KERNEL_THEOREM_COMPLEMENT = (468, 456)
 EXPECTED_BRIDGE_TRUST = (12, 165, 162, 9, 21, 21)
 EXPECTED_UNAFFECTED_UNIVERSAL = {
@@ -48,6 +51,7 @@ EXPECTED_UNAFFECTED_UNIVERSAL = {
     "transaction_identifiers",
     "transaction_wire",
     "value_conservation",
+    "weight_accounting",
 }
 EXPECTED_AFFECTED_BRIDGE_REFS = {
     "da_set_integrity": 1,
@@ -516,6 +520,9 @@ def validate_shared_op_parity(
             errors.append(f"shared-op parity row missing in proof_coverage.json: {section_key}")
             continue
         for field, label in (("evidence_level", "evidence level"), ("proof_trust", "proof trust")):
+            if op == "weight_accounting" and field == "proof_trust":
+                # RUB-1037 preserves this intentional mixed evidence lane.
+                continue
             if bridge_row.get(field) != coverage_row.get(field):
                 errors.append(
                     f"shared-op {label} drift for {op}: refinement_bridge={bridge_row.get(field)} vs "

--- a/rubin-formal/tools/check_formal_registry_truth.py
+++ b/rubin-formal/tools/check_formal_registry_truth.py
@@ -32,16 +32,22 @@ SHARED_OP_PARITY = {
     "da_set_integrity": "da_set_integrity",
     "weight_accounting": "weight_accounting",
 }
-EXPECTED_COVERAGE_TRUST = (32, 541, 522, 22, 73, 66)
-EXPECTED_UNIVERSAL_TRUST = (24, 498, 19, 61, 54)
+EXPECTED_COVERAGE_TRUST = (32, 523, 508, 16, 55, 52)
+EXPECTED_UNIVERSAL_TRUST = (24, 482, 13, 45, 42)
 EXPECTED_KERNEL_THEOREM_COMPLEMENT = (468, 456)
 EXPECTED_BRIDGE_TRUST = (12, 165, 162, 9, 21, 21)
 EXPECTED_UNAFFECTED_UNIVERSAL = {
+    "block_timestamp_rules",
     "consensus_constants_witness_lengths_pre_rotation",
+    "consensus_error_codes",
     "parallel_validation_equivalence",
+    "replay_domain_checks",
     "spend_gate_bridge",
     "create_side_live_gate",
     "feature_activation_fsm",
+    "transaction_identifiers",
+    "transaction_wire",
+    "value_conservation",
 }
 EXPECTED_AFFECTED_BRIDGE_REFS = {
     "da_set_integrity": 1,
@@ -553,7 +559,12 @@ def classify_registered_theorems(repo_root: Path, refs: list[TheoremRef]) -> tup
     theorems = sorted({theorem for theorem, _ in refs})
     if not theorems:
         return {}, []
-    source = "\n".join(["import RubinFormal", *(f"#print axioms {theorem}" for theorem in theorems), ""])
+    source = "\n".join([
+        "import RubinFormal",
+        "import RubinFormal.ErrorPriority",
+        *(f"#print axioms {theorem}" for theorem in theorems),
+        "",
+    ])
     try:
         result = subprocess.run(
             ["lake", "env", "lean", "--stdin", "--root=."],


### PR DESCRIPTION
<!-- Generated projection of rubin-control-plane-private/config/pr-body-profiles.json. -->
## Issue
- Linear: RUB-1037
- GitHub Issue mirror (non-authoritative): #2688

Refs: Q-PROTOCOL-FORMAL-EVIDENCE-CALIBRATION-01

## Summary
Changes the CV-UTXO-BASIC placeholder to an equality theorem and calibrates formal registry, bridge, and documentation claims to their actual evidence strength.

## Invariant
Claim-bearing and gate-bearing formal artifacts reject a false replay result and do not count finite CV replay as universal or model theorem evidence.

## Scope
- Changed files: 8
- Surfaces: formal, tooling, docs
- Non-scope: clients, specification, fixtures, generators, package roots, workflows, runtime behavior, consensus semantics, and standalone rubin-formal.
- Consensus rules unchanged: Yes
- SECTION_HASHES.json unchanged: Yes
- Wire format unchanged: Yes

## Validation
<!-- Protocol only: list exact dynamic test or live-run commands actually executed for this change as `command` — PASS entries; otherwise use `None`. Do not list cl, pre-push, CI, agents, lenses, attestations, readiness, or review history. -->
- Dynamic checks: `scripts/dev-env.sh -- bash -lc 'cd rubin-formal && lake build'` — PASS; `scripts/dev-env.sh -- bash -lc 'cd rubin-formal && python3 -m tools.check_formal_registry_truth'` — PASS; `scripts/dev-env.sh -- bash -lc 'cd rubin-formal && python3 -m unittest discover -s tests -p "test_*.py"'` — PASS; `scripts/dev-env.sh -- python3 tools/check_formal_coverage.py` — PASS; `scripts/dev-env.sh -- python3 tools/check_formal_refinement_bridge.py` — PASS; `scripts/dev-env.sh -- python3 tools/check_formal_claims_lint.py` — PASS; `scripts/dev-env.sh -- python3 tools/check_formal_risk_gate.py --profile phase0` — PASS; `scripts/dev-env.sh -- python3 tools/check_formal_risk_gate.py --profile devnet` — PASS

## Follow-ups / Waivers
- RUB-1033 remains deferred post-testnet re-proof work; no theorem recovery is included here.
