### PR TITLE
build(go): set module baseline to 1.26.5

### DIFF
--- a/clients/go/go.mod
+++ b/clients/go/go.mod
@@ -1,3 +1,3 @@
 module github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go
 
-go 1.24.13
+go 1.26.5

--- a/conformance/go.mod
+++ b/conformance/go.mod
@@ -1,6 +1,6 @@
 module github.com/2tbmz9y2xt-lang/rubin-protocol/conformance
 
-go 1.24.13
+go 1.26.5
 
 require github.com/2tbmz9y2xt-lang/rubin-protocol/clients/go v0.0.0
 


### PR DESCRIPTION
## Issue
- Linear: RUB-711
- GitHub Issue mirror (non-authoritative): #2342

Refs: U2-GO-TOOLCHAIN-BASELINE-01

## Summary
Align the two supported Go module declarations with the approved Go 1.26.5 project baseline.

## Invariant
Both supported Go modules declare Go 1.26.5; the existing conformance-fixtures job derives its Go version from `clients/go/go.mod`.

## Scope
- Changed files: 2
- Surfaces: clients/go, conformance
- Non-scope: GitHub Actions workflows, CodeQL configuration, Go source, toolchain installation, OpenSSL, release, activation, and consensus work.
- Consensus rules unchanged: Yes
- SECTION_HASHES.json unchanged: Yes
- Wire format unchanged: Yes

## Validation
- Dynamic checks: `scripts/dev-env.sh -- bash -lc 'cd clients/go && go test ./...'` — PASS; `scripts/dev-env.sh -- bash -lc 'cd conformance && go test ./...'` — PASS; `GOTOOLCHAIN=go1.26.5 scripts/dev-env.sh -- bash -lc 'cd clients/go && go run golang.org/x/vuln/cmd/govulncheck@v1.1.4 ./...'` — PASS; `go test -race -timeout=20m -shuffle=on -count=1 -json ./...` — PASS

## Follow-ups / Waivers
- None.
