### PR TITLE
[Q-PROTOCOL-FORMAL-0102-PREPIN-02] Bind canonical formal coverage to the frozen RUB-959 manifest

### DIFF
--- a/rubin-formal/proof_coverage.json
+++ b/rubin-formal/proof_coverage.json
@@ -5,7 +5,7 @@
   "package_maturity": "experimental_pending_reverification",
   "spec_source_file": "spec/RUBIN_L1_CANONICAL.md",
   "spec_section_hashes_file": "spec/SECTION_HASHES.json",
-  "spec_section_hashes_sha3_256": "c21c234f6380f9421a10481958993ba23ec31277217fcdd6d5d4d4d613df74a3",
+  "spec_section_hashes_sha3_256": "be9f22ec2ed0c6234adb0fc106a486a0eb32c309cc4a1100171724f72180ab29",
   "lean_toolchain_file": "rubin-formal/lean-toolchain",
   "refinement_bridge_file": "rubin-formal/refinement_bridge.json",
   "source_rebind": {


### PR DESCRIPTION
<!-- Generated projection of rubin-control-plane-private/config/pr-body-profiles.json. -->
## Issue
- Linear: RUB-1044
- GitHub Issue mirror (non-authoritative): #2699

Refs: [Q-PROTOCOL-FORMAL-0102-PREPIN-02]

## Summary
Bind the canonical formal coverage registry to the frozen RUB-959 `SECTION_HASHES.json` candidate.

## Invariant
Only the top-level `spec_section_hashes_sha3_256` value changes to the independently recomputed LF-normalized SHA3-256 digest; every theorem, limitation, maturity field, claim boundary, source rebind, and bounded non-executable 0x0102 disposition remains unchanged.

## Scope
- Changed files: 1
- Surfaces: formal, tooling
- Non-scope: Theorems, Lean sources, refinement bridge, runtime clients, activation, implementation, support, readiness, status, maturity, limitations, notes, source rebind, standalone rubin-formal, and rubin-spec delivery.
- Consensus rules unchanged: Yes; this is a formal evidence provenance pin only.
- SECTION_HASHES.json unchanged: Yes in this repository; the frozen RUB-959 candidate was used read-only.
- Wire format unchanged: Yes.

## Validation
<!-- Protocol only: list exact dynamic test or live-run commands actually executed for this change as `command` — PASS entries; otherwise use `None`. Do not list cl, pre-push, CI, agents, lenses, attestations, readiness, or review history. -->
- Dynamic checks: None

## Follow-ups / Waivers
- None.
